### PR TITLE
[codex] Add task flow lifecycle hooks

### DIFF
--- a/docs/automation/hooks.md
+++ b/docs/automation/hooks.md
@@ -62,6 +62,10 @@ openclaw hooks info session-memory
 | `message:transcribed`    | After audio transcription completes                        |
 | `message:preprocessed`   | After media and link preprocessing completes or is skipped |
 | `message:sent`           | Outbound send attempted (`context.success` has the result) |
+| `task:flow:created`      | After a Task Flow record is persisted                      |
+| `task:flow:transition`   | After a Task Flow status changes                           |
+| `task:flow:deleted`      | After a Task Flow record is deleted                        |
+| `task`                   | Any Task Flow hook event                                   |
 
 ## Writing hooks
 
@@ -159,6 +163,15 @@ natural final answer and ask the agent for one more pass should use the typed
 plugin hook `before_agent_finalize` instead. See [Plugin hooks](/plugins/hooks).
 
 **Gateway lifecycle events**: `gateway:shutdown` includes `reason` and `restartExpectedMs` and fires when gateway shutdown begins. `gateway:pre-restart` includes the same context but only fires when shutdown is part of an expected restart and a finite `restartExpectedMs` value is supplied. During shutdown, each lifecycle hook wait is best-effort and bounded so shutdown continues if a handler stalls. The default wait budget is 5 seconds for `gateway:shutdown` and 10 seconds for `gateway:pre-restart`.
+
+**Task Flow events**: `task:flow:created`, `task:flow:transition`, and
+`task:flow:deleted` fire only after the Task Flow registry write succeeds.
+Their `context.flow` or `context.previous` value is a safe projection with
+`flowId`, `syncMode`, `ownerKey`, `status`, `goal`, `revision`, timestamps,
+and optional `currentStep`, `controllerId`, and `endedAt`. Transition events
+also include `previousStatus` and `durationMs`. Internal persistence fields
+such as `stateJson`, `waitJson`, `blockedTaskId`, `blockedSummary`, and
+`requesterOrigin` are not included.
 
 Use `gateway:pre-restart` for short restart notices while channels are still available:
 

--- a/scripts/plugin-sdk-surface-report.mjs
+++ b/scripts/plugin-sdk-surface-report.mjs
@@ -202,8 +202,8 @@ let publicDeprecatedExportsByEntrypointBudget;
 try {
   budgets = {
     publicEntrypoints: readBudgetEnv("OPENCLAW_PLUGIN_SDK_MAX_PUBLIC_ENTRYPOINTS", 324),
-    publicExports: readBudgetEnv("OPENCLAW_PLUGIN_SDK_MAX_PUBLIC_EXPORTS", 10429),
-    publicFunctionExports: readBudgetEnv("OPENCLAW_PLUGIN_SDK_MAX_PUBLIC_FUNCTION_EXPORTS", 5240),
+    publicExports: readBudgetEnv("OPENCLAW_PLUGIN_SDK_MAX_PUBLIC_EXPORTS", 10439),
+    publicFunctionExports: readBudgetEnv("OPENCLAW_PLUGIN_SDK_MAX_PUBLIC_FUNCTION_EXPORTS", 5243),
     publicDeprecatedExports: readBudgetEnv(
       "OPENCLAW_PLUGIN_SDK_MAX_PUBLIC_DEPRECATED_EXPORTS",
       3261,

--- a/src/hooks/internal-hook-types.ts
+++ b/src/hooks/internal-hook-types.ts
@@ -1,5 +1,11 @@
 // Internal hook types define runtime hook event families and payload contracts.
-export type InternalHookEventType = "command" | "session" | "agent" | "gateway" | "message";
+export type InternalHookEventType =
+  | "command"
+  | "session"
+  | "agent"
+  | "gateway"
+  | "message"
+  | "task";
 
 export interface InternalHookEvent {
   /** The type of event (command, session, agent, gateway, etc.) */

--- a/src/hooks/internal-hooks.ts
+++ b/src/hooks/internal-hooks.ts
@@ -13,6 +13,7 @@ import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { formatErrorMessage } from "../infra/errors.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
 import { resolveGlobalSingleton } from "../shared/global-singleton.js";
+import type { TaskFlowStatus, TaskFlowSyncMode } from "../tasks/task-flow-registry.types.js";
 import type {
   InternalHookEvent,
   InternalHookEventType,
@@ -174,6 +175,53 @@ export type SessionPatchHookEvent = InternalHookEvent & {
   type: "session";
   action: "patch";
   context: SessionPatchHookContext;
+};
+
+export type TaskFlowHookSnapshot = {
+  flowId: string;
+  syncMode: TaskFlowSyncMode;
+  ownerKey: string;
+  status: TaskFlowStatus;
+  goal: string;
+  revision: number;
+  createdAt: number;
+  updatedAt: number;
+  currentStep?: string;
+  controllerId?: string;
+  endedAt?: number;
+};
+
+export type TaskFlowCreatedHookContext = {
+  flow: TaskFlowHookSnapshot;
+};
+
+export type TaskFlowCreatedHookEvent = InternalHookEvent & {
+  type: "task";
+  action: "flow:created";
+  context: TaskFlowCreatedHookContext;
+};
+
+export type TaskFlowTransitionHookContext = {
+  flow: TaskFlowHookSnapshot;
+  previousStatus: TaskFlowStatus;
+  durationMs: number;
+};
+
+export type TaskFlowTransitionHookEvent = InternalHookEvent & {
+  type: "task";
+  action: "flow:transition";
+  context: TaskFlowTransitionHookContext;
+};
+
+export type TaskFlowDeletedHookContext = {
+  flowId: string;
+  previous: TaskFlowHookSnapshot;
+};
+
+export type TaskFlowDeletedHookEvent = InternalHookEvent & {
+  type: "task";
+  action: "flow:deleted";
+  context: TaskFlowDeletedHookContext;
 };
 
 /**
@@ -459,4 +507,38 @@ export function isSessionPatchEvent(event: InternalHookEvent): event is SessionP
     typeof context.sessionEntry === "object" &&
     context.sessionEntry !== null
   );
+}
+
+export function isTaskFlowCreatedEvent(
+  event: InternalHookEvent,
+): event is TaskFlowCreatedHookEvent {
+  if (!isHookEventTypeAndAction(event, "task", "flow:created")) {
+    return false;
+  }
+  const context = getHookContext<TaskFlowCreatedHookContext>(event);
+  return typeof context?.flow?.flowId === "string";
+}
+
+export function isTaskFlowTransitionEvent(
+  event: InternalHookEvent,
+): event is TaskFlowTransitionHookEvent {
+  if (!isHookEventTypeAndAction(event, "task", "flow:transition")) {
+    return false;
+  }
+  const context = getHookContext<TaskFlowTransitionHookContext>(event);
+  return (
+    typeof context?.flow?.flowId === "string" &&
+    typeof context.previousStatus === "string" &&
+    typeof context.durationMs === "number"
+  );
+}
+
+export function isTaskFlowDeletedEvent(
+  event: InternalHookEvent,
+): event is TaskFlowDeletedHookEvent {
+  if (!isHookEventTypeAndAction(event, "task", "flow:deleted")) {
+    return false;
+  }
+  const context = getHookContext<TaskFlowDeletedHookContext>(event);
+  return typeof context?.flowId === "string" && typeof context.previous?.flowId === "string";
 }

--- a/src/tasks/task-flow-registry.test.ts
+++ b/src/tasks/task-flow-registry.test.ts
@@ -1,5 +1,14 @@
 // Covers managed task-flow creation, lookup, ownership, and state transitions.
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  clearInternalHooks,
+  createInternalHookEvent,
+  isTaskFlowCreatedEvent,
+  isTaskFlowDeletedEvent,
+  isTaskFlowTransitionEvent,
+  registerInternalHook,
+  type InternalHookEvent,
+} from "../hooks/internal-hooks.js";
 import { withOpenClawTestState } from "../test-utils/openclaw-test-state.js";
 import {
   createFlowRecord as createFlowRecordOrNull,
@@ -68,6 +77,7 @@ describe("task-flow-registry", () => {
 
   afterEach(() => {
     vi.useRealTimers();
+    clearInternalHooks();
     resetTaskFlowRegistryForTests();
   });
 
@@ -239,7 +249,214 @@ describe("task-flow-registry", () => {
     expect(events[2]?.flowId).toBe(created.flowId);
   });
 
+  it("emits task-flow lifecycle hooks after successful persistence", async () => {
+    await withFlowRegistryTempDir(async () => {
+      const events: InternalHookEvent[] = [];
+      registerInternalHook("task", (event) => {
+        events.push(event);
+      });
+
+      const created = createManagedTaskFlow({
+        ownerKey: "agent:main:main",
+        controllerId: "tests/hooks",
+        goal: "Observe flow hooks",
+        currentStep: "created",
+        stateJson: { privateState: true },
+        waitJson: { privateWait: true },
+        blockedSummary: "private blocked details",
+      });
+      const resumed = resumeFlow({
+        flowId: created.flowId,
+        expectedRevision: created.revision,
+        status: "running",
+        currentStep: "running",
+      });
+      expect(resumed.applied).toBe(true);
+      expect(deleteTaskFlowRecordById(created.flowId)).toBe(true);
+
+      await vi.waitFor(() => expect(events).toHaveLength(3));
+
+      expect(events.map((event) => `${event.type}:${event.action}`)).toEqual([
+        "task:flow:created",
+        "task:flow:transition",
+        "task:flow:deleted",
+      ]);
+
+      const createdContext = events[0]?.context as {
+        flow?: Record<string, unknown>;
+      };
+      expect(createdContext.flow).toMatchObject({
+        flowId: created.flowId,
+        syncMode: "managed",
+        ownerKey: "agent:main:main",
+        status: "queued",
+        goal: "Observe flow hooks",
+        currentStep: "created",
+        controllerId: "tests/hooks",
+        revision: 0,
+        createdAt: created.createdAt,
+        updatedAt: created.updatedAt,
+      });
+      expect(createdContext.flow).not.toHaveProperty("stateJson");
+      expect(createdContext.flow).not.toHaveProperty("waitJson");
+      expect(createdContext.flow).not.toHaveProperty("blockedTaskId");
+      expect(createdContext.flow).not.toHaveProperty("blockedSummary");
+      expect(createdContext.flow).not.toHaveProperty("requesterOrigin");
+
+      const transitionContext = events[1]?.context as {
+        flow?: Record<string, unknown>;
+        previousStatus?: string;
+        durationMs?: number;
+      };
+      expect(transitionContext.previousStatus).toBe("queued");
+      expect(transitionContext.durationMs).toEqual(expect.any(Number));
+      expect(transitionContext.flow).toMatchObject({
+        flowId: created.flowId,
+        status: "running",
+        currentStep: "running",
+        revision: 1,
+      });
+      expect(transitionContext.flow).not.toHaveProperty("stateJson");
+      expect(transitionContext.flow).not.toHaveProperty("waitJson");
+
+      const deletedContext = events[2]?.context as {
+        flowId?: string;
+        previous?: Record<string, unknown>;
+      };
+      expect(deletedContext.flowId).toBe(created.flowId);
+      expect(deletedContext.previous).toMatchObject({
+        flowId: created.flowId,
+        status: "running",
+        revision: 1,
+      });
+      expect(deletedContext.previous).not.toHaveProperty("stateJson");
+      expect(deletedContext.previous).not.toHaveProperty("waitJson");
+      expect(deletedContext.previous).not.toHaveProperty("blockedSummary");
+    });
+  });
+
+  it("emits transition hooks only when flow status changes", async () => {
+    await withFlowRegistryTempDir(async () => {
+      const transitions: InternalHookEvent[] = [];
+      registerInternalHook("task:flow:transition", (event) => {
+        transitions.push(event);
+      });
+
+      const created = createManagedTaskFlow({
+        ownerKey: "agent:main:main",
+        controllerId: "tests/transition-hooks",
+        goal: "Status-only transitions",
+      });
+      const waiting = setFlowWaiting({
+        flowId: created.flowId,
+        expectedRevision: created.revision,
+        currentStep: "waiting",
+      });
+      expect(waiting.applied).toBe(true);
+      const stillWaiting = setFlowWaiting({
+        flowId: created.flowId,
+        expectedRevision: 1,
+        currentStep: "still waiting",
+      });
+      expect(stillWaiting.applied).toBe(true);
+
+      await vi.waitFor(() => expect(transitions).toHaveLength(1));
+      await new Promise<void>((resolve) => {
+        setTimeout(resolve, 25);
+      });
+
+      expect(transitions).toHaveLength(1);
+      expect(transitions[0]?.context).toMatchObject({
+        previousStatus: "queued",
+        flow: {
+          flowId: created.flowId,
+          status: "waiting",
+        },
+      });
+    });
+  });
+
+  it("does not let task-flow hook failures break registry writes", async () => {
+    await withFlowRegistryTempDir(async () => {
+      const successfulHandler = vi.fn();
+      registerInternalHook("task:flow:created", () => {
+        throw new Error("hook failed");
+      });
+      registerInternalHook("task:flow:created", successfulHandler);
+
+      const created = createManagedTaskFlow({
+        ownerKey: "agent:main:main",
+        controllerId: "tests/hook-failure",
+        goal: "Hook failure isolation",
+      });
+
+      await vi.waitFor(() => expect(successfulHandler).toHaveBeenCalledOnce());
+      expect(getTaskFlowById(created.flowId)?.flowId).toBe(created.flowId);
+    });
+  });
+
+  it("recognizes task-flow hook events with type guards", () => {
+    expect(
+      isTaskFlowCreatedEvent(
+        createInternalHookEvent("task", "flow:created", "agent:main:main", {
+          flow: {
+            flowId: "flow-1",
+            syncMode: "managed",
+            ownerKey: "agent:main:main",
+            status: "queued",
+            goal: "Test flow",
+            revision: 0,
+            createdAt: 10,
+            updatedAt: 10,
+          },
+        }),
+      ),
+    ).toBe(true);
+    expect(
+      isTaskFlowTransitionEvent(
+        createInternalHookEvent("task", "flow:transition", "agent:main:main", {
+          flow: {
+            flowId: "flow-1",
+            syncMode: "managed",
+            ownerKey: "agent:main:main",
+            status: "running",
+            goal: "Test flow",
+            revision: 1,
+            createdAt: 10,
+            updatedAt: 20,
+          },
+          previousStatus: "queued",
+          durationMs: 10,
+        }),
+      ),
+    ).toBe(true);
+    expect(
+      isTaskFlowDeletedEvent(
+        createInternalHookEvent("task", "flow:deleted", "agent:main:main", {
+          flowId: "flow-1",
+          previous: {
+            flowId: "flow-1",
+            syncMode: "managed",
+            ownerKey: "agent:main:main",
+            status: "running",
+            goal: "Test flow",
+            revision: 1,
+            createdAt: 10,
+            updatedAt: 20,
+          },
+        }),
+      ),
+    ).toBe(true);
+    expect(
+      isTaskFlowCreatedEvent(createInternalHookEvent("task", "flow:transition", "s1", {})),
+    ).toBe(false);
+  });
+
   it("does not throw or register memory when flow create persistence fails", () => {
+    const events: InternalHookEvent[] = [];
+    registerInternalHook("task", (event) => {
+      events.push(event);
+    });
     const upsertFlow = vi.fn((_flow: TaskFlowRecord) => {
       throw new Error("SQLITE_FULL: database or disk is full");
     });
@@ -263,9 +480,14 @@ describe("task-flow-registry", () => {
     const attempted = upsertFlow.mock.calls[0]?.[0];
     expect(attempted?.flowId).toEqual(expect.any(String));
     expect(getTaskFlowById(attempted?.flowId ?? "")).toBeUndefined();
+    expect(events).toHaveLength(0);
   });
 
   it("does not throw or mutate memory when flow update persistence fails", () => {
+    const events: InternalHookEvent[] = [];
+    registerInternalHook("task:flow:transition", (event) => {
+      events.push(event);
+    });
     let failUpsert = false;
     const upsertFlow = vi.fn(() => {
       if (failUpsert) {
@@ -307,9 +529,14 @@ describe("task-flow-registry", () => {
       revision: 0,
       status: "queued",
     });
+    expect(events).toHaveLength(0);
   });
 
   it("does not throw or delete memory when flow delete persistence fails", () => {
+    const events: InternalHookEvent[] = [];
+    registerInternalHook("task:flow:deleted", (event) => {
+      events.push(event);
+    });
     const deleteFlow = vi.fn(() => {
       throw new Error("SQLITE_BUSY: database is locked");
     });
@@ -333,6 +560,7 @@ describe("task-flow-registry", () => {
 
     expect(deleteFlow).toHaveBeenCalledWith(created.flowId);
     expect(getTaskFlowById(created.flowId)?.flowId).toBe(created.flowId);
+    expect(events).toHaveLength(0);
   });
 
   it("normalizes restored managed flows without a controller id", () => {

--- a/src/tasks/task-flow-registry.ts
+++ b/src/tasks/task-flow-registry.ts
@@ -1,6 +1,13 @@
 // Coordinates managed task-flow creation, updates, ownership, and snapshots.
 import crypto from "node:crypto";
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
+import { fireAndForgetHook } from "../hooks/fire-and-forget.js";
+import {
+  createInternalHookEvent,
+  hasInternalHookListeners,
+  triggerInternalHook,
+  type TaskFlowHookSnapshot,
+} from "../hooks/internal-hooks.js";
 import { formatErrorMessage } from "../infra/errors.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
 import {
@@ -165,6 +172,61 @@ function emitFlowRegistryObserverEvent(createEvent: () => TaskFlowRegistryObserv
   } catch {
     // Flow observers are best-effort only. They must not break registry writes.
   }
+}
+
+function flowRecordToHookSnapshot(flow: TaskFlowRecord): TaskFlowHookSnapshot {
+  return {
+    flowId: flow.flowId,
+    syncMode: flow.syncMode,
+    ownerKey: flow.ownerKey,
+    status: flow.status,
+    goal: flow.goal,
+    revision: flow.revision,
+    createdAt: flow.createdAt,
+    updatedAt: flow.updatedAt,
+    ...(flow.currentStep ? { currentStep: flow.currentStep } : {}),
+    ...(flow.controllerId ? { controllerId: flow.controllerId } : {}),
+    ...(flow.endedAt != null ? { endedAt: flow.endedAt } : {}),
+  };
+}
+
+function emitTaskFlowHook(
+  flow: TaskFlowRecord,
+  action: "flow:created" | "flow:transition" | "flow:deleted",
+  context: Record<string, unknown>,
+): void {
+  if (!hasInternalHookListeners("task", action)) {
+    return;
+  }
+  fireAndForgetHook(
+    triggerInternalHook(createInternalHookEvent("task", action, flow.ownerKey, context)),
+    `task:${action} hook`,
+    (message) => log.warn(message),
+  );
+}
+
+function emitTaskFlowUpsertHook(next: TaskFlowRecord, previous?: TaskFlowRecord): void {
+  if (!previous) {
+    emitTaskFlowHook(next, "flow:created", {
+      flow: flowRecordToHookSnapshot(next),
+    });
+    return;
+  }
+  if (previous.status === next.status) {
+    return;
+  }
+  emitTaskFlowHook(next, "flow:transition", {
+    flow: flowRecordToHookSnapshot(next),
+    previousStatus: previous.status,
+    durationMs: Math.max(0, next.updatedAt - next.createdAt),
+  });
+}
+
+function emitTaskFlowDeletedHook(flowId: string, previous: TaskFlowRecord): void {
+  emitTaskFlowHook(previous, "flow:deleted", {
+    flowId,
+    previous: flowRecordToHookSnapshot(previous),
+  });
 }
 
 function ensureNotifyPolicy(notifyPolicy?: TaskNotifyPolicy): TaskNotifyPolicy {
@@ -426,6 +488,7 @@ function writeFlowRecord(next: TaskFlowRecord, previous?: TaskFlowRecord): TaskF
     flow: cloneFlowRecord(next),
     ...(previous ? { previous: cloneFlowRecord(previous) } : {}),
   }));
+  emitTaskFlowUpsertHook(next, previous);
   return cloneFlowRecord(next);
 }
 
@@ -777,6 +840,7 @@ export function deleteTaskFlowRecordById(flowId: string): boolean {
     flowId,
     previous: cloneFlowRecord(current),
   }));
+  emitTaskFlowDeletedHook(flowId, current);
   return true;
 }
 


### PR DESCRIPTION
## What Problem This Solves

Plugins can create and manage Task Flow records through `api.runtime.tasks.managedFlows`, but they cannot observe Task Flow lifecycle changes through the hook system. This leaves plugin observability for flow creation, status transitions, and deletion tied to internal registry observers instead of a plugin-facing event surface.

This addresses the core hook-observability request in #87362.

## Why This Change Was Made

This is intentionally narrower than #87377 and the closed #75554:

- #87377 combines hooks with diagnostics events, OTel/Prometheus metrics, persisted tags, SQLite schema changes, plugin SDK tag input, and docs. Those extra surfaces raised privacy, schema, product, and proof concerns.
- #75554 added a plugin task-run lifecycle API (`create/progress/finalize`) plus persisted task identity semantics. That is a different SDK/product direction and was closed so it could be revisited separately.

This PR adds only the smallest core bridge: Task Flow registry mutations emit existing internal/plugin hook events after successful persistence.

## User Impact

Plugin authors can register hooks for:

- `task:flow:created`
- `task:flow:transition`
- `task:flow:deleted`
- `task` as a broad listener

The hook payload uses a safe projection instead of exposing the full persisted `TaskFlowRecord`. It includes stable lifecycle fields such as ids, owner, sync mode, status, goal, revision, timing, current step, and controller id. It deliberately excludes internal persistence fields such as `stateJson`, `waitJson`, `blockedTaskId`, `blockedSummary`, and `requesterOrigin`.

No tags, diagnostics bus events, exporters, metrics, migrations, SQLite schema changes, or task-run lifecycle APIs are added.

## Evidence

Focused tests:

```text
$ node scripts/run-vitest.mjs src/tasks/task-flow-registry.test.ts -- --reporter=verbose
Test Files  1 passed (1)
Tests  13 passed (13)
```

Formatting/lint/whitespace:

```text
$ pnpm exec oxfmt --check --threads=1 docs/automation/hooks.md src/hooks/internal-hook-types.ts src/hooks/internal-hooks.ts src/tasks/task-flow-registry.ts src/tasks/task-flow-registry.test.ts
All matched files use the correct format.

$ pnpm exec oxlint --deny-warnings src/hooks/internal-hook-types.ts src/hooks/internal-hooks.ts src/tasks/task-flow-registry.ts src/tasks/task-flow-registry.test.ts
# passed

$ git diff --check
# passed
```

Docs/type checks:

```text
$ pnpm docs:list
# passed

$ pnpm tsgo:core
# passed

$ pnpm tsgo:core:test
# passed
```

Autoreview:

```text
$ .agents/skills/autoreview/scripts/autoreview --mode local
autoreview clean: no accepted/actionable findings reported
```

Crabbox-backed runtime proof on the corrected branch:

```text
$ node scripts/crabbox-wrapper.mjs run --provider local-container --timing-json --script-stdin
provider=local-container lease=cbx_11636df24dce slug=harbor-prawn type=ubuntu_26.04 exit=0
```

The Crabbox script registered a real `task` hook listener, created a managed Task Flow through `createRuntimeTaskFlow().bindSession(...)`, transitioned it with the managed runtime, deleted it through the existing Task Flow runtime facade, and asserted that emitted hook contexts did not contain internal fields or private payload values.

Proof output summary:

```json
{
  "providerProof": "Crabbox local-container runtime script",
  "eventCount": 3,
  "actions": ["flow:created", "flow:transition", "flow:deleted"],
  "transition": {
    "previousStatus": "queued",
    "durationMsType": "number"
  },
  "deleted": {
    "flowIdMatches": true
  },
  "excludedFieldsChecked": [
    "stateJson",
    "waitJson",
    "blockedTaskId",
    "blockedSummary",
    "requesterOrigin"
  ]
}
```

Cloud Crabbox/Testbox note: Azure, AWS, and Blacksmith Testbox were attempted first but are not authenticated in this checkout. The successful proof above is still Crabbox-orchestrated on a synced Ubuntu container lease.
