### PR TITLE
fix(cron): engage model fallback on result-level embedded failures (#96525)

### DIFF
--- a/src/cron/isolated-agent/run-executor.ts
+++ b/src/cron/isolated-agent/run-executor.ts
@@ -2,6 +2,10 @@
 import { createHash } from "node:crypto";
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import type { BootstrapContextMode } from "../../agents/bootstrap-files.js";
+import {
+  classifyEmbeddedAgentRunResultForModelFallback,
+  mergeEmbeddedAgentRunResultForModelFallbackExhaustion,
+} from "../../agents/embedded-agent-runner/result-fallback-classifier.js";
 import type { FastModeAutoProgressState } from "../../agents/fast-mode.js";
 import { resolveCliRuntimeExecutionProvider } from "../../agents/model-runtime-aliases.js";
 import { wrapUntrustedPromptDataBlock } from "../../agents/sanitize-for-prompt.js";
@@ -307,6 +311,13 @@ export function createCronPromptExecutor(params: {
         });
       },
       fallbacksOverride: cronFallbacksOverride,
+      classifyResult: ({ provider, model, result }) =>
+        classifyEmbeddedAgentRunResultForModelFallback({
+          provider,
+          model,
+          result,
+        }),
+      mergeExhaustedResult: mergeEmbeddedAgentRunResultForModelFallbackExhaustion,
       run: async (providerOverride, modelOverride, runOptions) => {
         if (params.abortSignal?.aborted) {
           throw new Error(params.abortReason());

--- a/src/cron/isolated-agent/run.result-level-fallback.test.ts
+++ b/src/cron/isolated-agent/run.result-level-fallback.test.ts
@@ -1,0 +1,139 @@
+// Regression tests for cron isolated runs engaging model fallback on result-level failures (#96525).
+import { createContractRunResult } from "openclaw/plugin-sdk/agent-runtime-test-contracts";
+import { describe, expect, it } from "vitest";
+import { classifyEmbeddedAgentRunResultForModelFallback } from "../../agents/embedded-agent-runner/result-fallback-classifier.js";
+import { makeIsolatedAgentJobFixture, makeIsolatedAgentParamsFixture } from "./job-fixtures.js";
+import { setupRunCronIsolatedAgentTurnSuite } from "./run.suite-helpers.js";
+import {
+  loadRunCronIsolatedAgentTurn,
+  runEmbeddedAgentMock,
+  runWithModelFallbackMock,
+} from "./run.test-harness.js";
+
+const runCronIsolatedAgentTurn = await loadRunCronIsolatedAgentTurn();
+
+function requireModelFallbackRequest(): {
+  classifyResult?: (params: { provider: string; model: string; result: unknown }) => unknown;
+  mergeExhaustedResult?: unknown;
+  fallbacksOverride?: string[];
+  provider?: string;
+  model?: string;
+  run?: (
+    provider: string,
+    model: string,
+    options?: { isFinalFallbackAttempt?: boolean },
+  ) => Promise<unknown>;
+} {
+  const request = runWithModelFallbackMock.mock.calls[0]?.[0];
+  if (!request) {
+    throw new Error("Expected model fallback request");
+  }
+  return request;
+}
+
+describe("runCronIsolatedAgentTurn — result-level model fallback (#96525)", () => {
+  setupRunCronIsolatedAgentTurnSuite({ fast: true });
+
+  it("passes embedded result classifiers into runWithModelFallback", async () => {
+    runWithModelFallbackMock.mockImplementation(async ({ provider, model, run }) => ({
+      result: await run(provider, model),
+      provider,
+      model,
+      attempts: [],
+    }));
+
+    await runCronIsolatedAgentTurn(
+      makeIsolatedAgentParamsFixture({
+        job: makeIsolatedAgentJobFixture({
+          payload: {
+            kind: "agentTurn",
+            message: "test",
+            fallbacks: ["openai/gpt-5.4"],
+          },
+        }),
+      }),
+    );
+
+    const request = requireModelFallbackRequest();
+    expect(typeof request.classifyResult).toBe("function");
+    expect(typeof request.mergeExhaustedResult).toBe("function");
+  });
+
+  it("advances to configured fallback when the primary embedded run is reasoning-only", async () => {
+    const primary = createContractRunResult({
+      meta: {
+        durationMs: 1,
+        agentHarnessResultClassification: "reasoning-only",
+      },
+    });
+    const fallback = createContractRunResult({
+      payloads: [{ text: "cron fallback ok" }],
+      meta: { durationMs: 1, finalAssistantVisibleText: "cron fallback ok" },
+    });
+
+    runWithModelFallbackMock.mockImplementation(async (params) => {
+      const first = await params.run(params.provider, params.model);
+      const classification = await params.classifyResult?.({
+        provider: params.provider,
+        model: params.model,
+        result: first,
+      });
+      expect(classification).toMatchObject({
+        reason: "format",
+        code: "reasoning_only_result",
+      });
+
+      const [fallbackRef] = params.fallbacksOverride ?? [];
+      if (!fallbackRef || !classification) {
+        return { result: first, provider: params.provider, model: params.model, attempts: [] };
+      }
+      const slash = fallbackRef.indexOf("/");
+      const fallbackProvider = fallbackRef.slice(0, slash);
+      const fallbackModel = fallbackRef.slice(slash + 1);
+      const second = await params.run(fallbackProvider, fallbackModel, {
+        isFinalFallbackAttempt: true,
+      });
+      return {
+        result: second,
+        provider: fallbackProvider,
+        model: fallbackModel,
+        attempts: [
+          {
+            provider: params.provider,
+            model: params.model,
+            reason: classification.reason,
+            code: classification.code,
+          },
+        ],
+      };
+    });
+
+    runEmbeddedAgentMock.mockResolvedValueOnce(primary).mockResolvedValueOnce(fallback);
+
+    const result = await runCronIsolatedAgentTurn(
+      makeIsolatedAgentParamsFixture({
+        job: makeIsolatedAgentJobFixture({
+          payload: {
+            kind: "agentTurn",
+            message: "test",
+            fallbacks: ["openai/gpt-5.4"],
+          },
+        }),
+      }),
+    );
+
+    expect(result.status).toBe("ok");
+    expect(runEmbeddedAgentMock).toHaveBeenCalledTimes(2);
+    expect(runEmbeddedAgentMock.mock.calls[1]?.[0]).toMatchObject({
+      provider: "openai",
+      model: "gpt-5.4",
+    });
+    expect(
+      classifyEmbeddedAgentRunResultForModelFallback({
+        provider: "anthropic",
+        model: "claude-opus-4-6",
+        result: primary,
+      }),
+    ).toMatchObject({ code: "reasoning_only_result" });
+  });
+});


### PR DESCRIPTION
## Summary

- Wire `classifyResult` and `mergeExhaustedResult` into isolated cron `runWithModelFallback`, matching `agent-command` and `agent-runner-execution`.
- Result-level terminal outcomes (reasoning-only, empty, incomplete_turn, etc.) now advance the configured cron fallback chain instead of being treated as success.

Fixes #96525

## Why

`run-executor.ts` awaited `runWithModelFallback` without result classifiers. Thrown `FailoverError`s already engaged fallbacks via the catch path, but returned result-level failures silently dropped the answer and never tried the next model.

## Test plan

- [x] `pnpm exec vitest run src/cron/isolated-agent/run.result-level-fallback.test.ts` (2/2)
- [x] Regression asserts `classifyResult` / `mergeExhaustedResult` are passed through
- [x] Behavioral test: reasoning-only primary triggers embedded fallback attempt
