### PR TITLE
fix(android): return settings details to their originating tab on Back

### DIFF
--- a/apps/.i18n/native-source.json
+++ b/apps/.i18n/native-source.json
@@ -3475,7 +3475,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 440,
+      "line": 402,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Overview",
       "surface": "android",
@@ -3483,7 +3483,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 485,
+      "line": 447,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "No recent sessions",
       "surface": "android",
@@ -3491,7 +3491,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 487,
+      "line": 449,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Start Chat",
       "surface": "android",
@@ -3499,7 +3499,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 547,
+      "line": 509,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "OpenClaw",
       "surface": "android",
@@ -3507,7 +3507,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 555,
+      "line": 517,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Search",
       "surface": "android",
@@ -3515,7 +3515,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 607,
+      "line": 569,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "ACTIVE AGENT",
       "surface": "android",
@@ -3523,7 +3523,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 616,
+      "line": 578,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "View",
       "surface": "android",
@@ -3531,7 +3531,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 619,
+      "line": 581,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "$pendingRunCount active",
       "surface": "android",
@@ -3539,7 +3539,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 619,
+      "line": 581,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Idle",
       "surface": "android",
@@ -3547,7 +3547,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 619,
+      "line": 581,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Runs",
       "surface": "android",
@@ -3555,7 +3555,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 620,
+      "line": 582,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "$sessionCount recent",
       "surface": "android",
@@ -3563,7 +3563,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 620,
+      "line": 582,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Sessions",
       "surface": "android",
@@ -3571,7 +3571,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 621,
+      "line": 583,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Cron",
       "surface": "android",
@@ -3579,7 +3579,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 624,
+      "line": 586,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Chat",
       "surface": "android",
@@ -3587,7 +3587,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 628,
+      "line": 590,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Reconnect gateway",
       "surface": "android",
@@ -3595,7 +3595,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 773,
+      "line": 735,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Open ${card.title}",
       "surface": "android",
@@ -3603,7 +3603,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 841,
+      "line": 803,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Talk",
       "surface": "android",
@@ -3611,7 +3611,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 842,
+      "line": 804,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Open Talk",
       "surface": "android",
@@ -3619,7 +3619,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 844,
+      "line": 806,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Talk settings",
       "surface": "android",
@@ -3627,7 +3627,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 852,
+      "line": 814,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Recent Sessions",
       "surface": "android",
@@ -3635,7 +3635,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 862,
+      "line": 824,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "View all",
       "surface": "android",
@@ -3643,7 +3643,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 980,
+      "line": 942,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "$onlineNodes/$nodeCount",
       "surface": "android",
@@ -3651,7 +3651,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 980,
+      "line": 942,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "None",
       "surface": "android",
@@ -3659,7 +3659,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1012,
+      "line": 974,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Recent conversations",
       "surface": "android",
@@ -3667,7 +3667,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1063,
+      "line": 1025,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Working · $pendingRunCount active ${pluralize(\"run\", pendingRunCount)}",
       "surface": "android",
@@ -3675,7 +3675,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1184,
+      "line": 1146,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Needs attention",
       "surface": "android",
@@ -3683,7 +3683,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1323,
+      "line": 1285,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Open session",
       "surface": "android",
@@ -3691,15 +3691,15 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1437,
+      "line": 1397,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
-      "source": "Back to home",
+      "source": "Back",
       "surface": "android",
-      "id": "native.android.4daa24476dd0e5c7"
+      "id": "native.android.ede6f2717ca8e267"
     },
     {
       "kind": "ui-named-argument",
-      "line": 1440,
+      "line": 1400,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Settings",
       "surface": "android",
@@ -3707,7 +3707,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1443,
+      "line": 1403,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Search settings",
       "surface": "android",
@@ -3715,7 +3715,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1461,
+      "line": 1421,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "$readyProviderCount ready",
       "surface": "android",
@@ -3723,7 +3723,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1461,
+      "line": 1421,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Review readiness",
       "surface": "android",
@@ -3731,7 +3731,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1471,
+      "line": 1431,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Speaker muted",
       "surface": "android",
@@ -3739,7 +3739,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1471,
+      "line": 1431,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Speaker on",
       "surface": "android",
@@ -3747,7 +3747,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1473,
+      "line": 1433,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Off",
       "surface": "android",
@@ -3755,7 +3755,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1473,
+      "line": 1433,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Smart delivery",
       "surface": "android",
@@ -3763,7 +3763,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1474,
+      "line": 1434,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Camera enabled",
       "surface": "android",
@@ -3771,7 +3771,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1474,
+      "line": 1434,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Locked",
       "surface": "android",
@@ -3779,7 +3779,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1506,
+      "line": 1466,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "OpenClaw ${BuildConfig.VERSION_NAME} (${BuildConfig.VERSION_CODE})",
       "surface": "android",
@@ -3787,7 +3787,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1509,
+      "line": 1469,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "All systems operational",
       "surface": "android",
@@ -3795,7 +3795,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1509,
+      "line": 1469,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Gateway not connected",
       "surface": "android",
@@ -3803,7 +3803,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1541,
+      "line": 1501,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "No provider usage",
       "surface": "android",
@@ -3811,7 +3811,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1542,
+      "line": 1502,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "1 provider",
       "surface": "android",
@@ -3819,7 +3819,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1543,
+      "line": 1503,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "$count providers",
       "surface": "android",
@@ -3827,7 +3827,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1549,
+      "line": 1509,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "$ready/${skills.size} ready",
       "surface": "android",
@@ -3835,7 +3835,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1549,
+      "line": 1509,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "No skills",
       "surface": "android",
@@ -3843,7 +3843,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1725,
+      "line": 1685,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "OpenClaw mobile",
       "surface": "android",
@@ -3851,7 +3851,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1729,
+      "line": 1689,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Open profile",
       "surface": "android",
@@ -3859,7 +3859,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1791,
+      "line": 1751,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Open ${row.title}",
       "surface": "android",
@@ -3867,7 +3867,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1810,
+      "line": 1770,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Main session",
       "surface": "android",

--- a/apps/android/app/src/main/java/ai/openclaw/app/ui/ShellNavigation.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/ui/ShellNavigation.kt
@@ -1,0 +1,90 @@
+package ai.openclaw.app.ui
+
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.saveable.listSaver
+import androidx.compose.runtime.setValue
+
+/**
+ * Shell navigation state: the visible tab, the open settings route, and where Back
+ * returns after a cross-tab detail open. All tab/route transitions go through this
+ * class so Back semantics stay consistent across every entry point.
+ */
+internal class ShellNavigation(
+  activeTab: Tab = Tab.Overview,
+  settingsRoute: SettingsRoute = SettingsRoute.Home,
+  returnTab: Tab? = null,
+  settingsRouteFromHome: Boolean = false,
+) {
+  var activeTab by mutableStateOf(activeTab)
+    private set
+  var settingsRoute by mutableStateOf(settingsRoute)
+    private set
+
+  // Single-slot origin: Back from a cross-tab detail (settings route, Sessions,
+  // Providers) returns to the tab that opened it; deeper history intentionally
+  // collapses to Overview so the shell never accumulates a navigation stack.
+  private var returnTab by mutableStateOf(returnTab)
+
+  // Distinguishes a detail reached from the Settings Home list (Back unwinds to
+  // Home) from one opened cross-tab (Back leaves the Settings tab entirely).
+  private var settingsRouteFromHome by mutableStateOf(settingsRouteFromHome)
+
+  /** Tab-bar-style switch: Back from the selected tab returns to Overview. */
+  fun selectTab(tab: Tab) {
+    if (tab == Tab.Settings) settingsRoute = SettingsRoute.Home
+    settingsRouteFromHome = false
+    returnTab = null
+    activeTab = tab
+  }
+
+  /** Opens a settings route from another tab, remembering the origin for Back. */
+  fun openSettingsRoute(route: SettingsRoute) {
+    settingsRoute = route
+    settingsRouteFromHome = false
+    openDetailTab(Tab.Settings)
+  }
+
+  /** Opens a settings route from the Settings Home list; Back returns to Home. */
+  fun openSettingsRouteFromHome(route: SettingsRoute) {
+    settingsRoute = route
+    settingsRouteFromHome = true
+  }
+
+  /** Opens a detail tab (Sessions, Providers) from another tab, remembering the origin for Back. */
+  fun openDetailTab(tab: Tab) {
+    if (activeTab != tab) returnTab = activeTab
+    activeTab = tab
+  }
+
+  /** Unwinds one Back step: settings detail to Home or origin, otherwise tab to origin or Overview. */
+  fun back() {
+    if (activeTab == Tab.Settings && settingsRoute != SettingsRoute.Home) {
+      settingsRoute = SettingsRoute.Home
+      if (settingsRouteFromHome) {
+        settingsRouteFromHome = false
+        return
+      }
+    }
+    activeTab = returnTab ?: Tab.Overview
+    returnTab = null
+  }
+
+  companion object {
+    /** Persists shell navigation across process death for rememberSaveable. */
+    val Saver =
+      listSaver<ShellNavigation, String>(
+        save = { nav ->
+          listOf(nav.activeTab.name, nav.settingsRoute.name, nav.returnTab?.name.orEmpty(), nav.settingsRouteFromHome.toString())
+        },
+        restore = { saved ->
+          ShellNavigation(
+            activeTab = Tab.valueOf(saved[0]),
+            settingsRoute = SettingsRoute.valueOf(saved[1]),
+            returnTab = saved[2].takeIf { it.isNotEmpty() }?.let(Tab::valueOf),
+            settingsRouteFromHome = saved[3].toBoolean(),
+          )
+        },
+      )
+  }
+}

--- a/apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt
@@ -135,9 +135,7 @@ fun ShellScreen(
   val shellDark = appearanceThemeMode.isDark(systemDark = isSystemInDarkTheme())
   OpenClawSystemBarAppearance(lightAppearance = !shellDark)
   ClawDesignTheme(dark = shellDark) {
-    var activeTab by rememberSaveable { mutableStateOf(Tab.Overview) }
-    var settingsRoute by rememberSaveable { mutableStateOf(SettingsRoute.Home) }
-    var returnToOverviewFromSettings by rememberSaveable { mutableStateOf(false) }
+    val nav = rememberSaveable(saver = ShellNavigation.Saver) { ShellNavigation() }
     var commandOpen by rememberSaveable { mutableStateOf(false) }
     var voiceScreenWasActive by rememberSaveable { mutableStateOf(false) }
     val requestedHomeDestination by viewModel.requestedHomeDestination.collectAsState()
@@ -148,31 +146,28 @@ fun ShellScreen(
       val destination = requestedHomeDestination ?: return@LaunchedEffect
       // HomeDestination is a one-shot command from launch intents and settings
       // actions; consume it after translating to local shell state.
-      activeTab =
+      nav.selectTab(
         when (destination) {
           HomeDestination.Connect -> Tab.Overview
           HomeDestination.Chat -> Tab.Chat
           HomeDestination.Voice -> Tab.Voice
           HomeDestination.Screen -> Tab.Chat
           HomeDestination.Settings -> Tab.Settings
-        }
-      if (destination == HomeDestination.Settings) {
-        settingsRoute = SettingsRoute.Home
-        returnToOverviewFromSettings = false
-      }
+        },
+      )
       viewModel.clearRequestedHomeDestination()
     }
 
-    LaunchedEffect(activeTab, runtimeInitialized) {
-      val voiceScreenActive = activeTab == Tab.Voice
+    LaunchedEffect(nav.activeTab, runtimeInitialized) {
+      val voiceScreenActive = nav.activeTab == Tab.Voice
       if (voiceScreenActive || voiceScreenWasActive || runtimeInitialized) {
         viewModel.setVoiceScreenActive(voiceScreenActive)
       }
       voiceScreenWasActive = voiceScreenActive
     }
 
-    BackHandler(enabled = activeTab != Tab.Overview) {
-      activeTab = Tab.Overview
+    BackHandler(enabled = nav.activeTab != Tab.Overview) {
+      nav.back()
     }
 
     BackHandler(enabled = commandOpen) {
@@ -191,85 +186,54 @@ fun ShellScreen(
         if (showBottomNav) {
           ClawBottomNav(
             items = shellNavTabs.map { ClawNavItem(key = it.key, label = it.label, icon = it.icon) },
-            selectedKey = if (activeTab in shellNavTabs) activeTab.key else Tab.Overview.key,
+            selectedKey = if (nav.activeTab in shellNavTabs) nav.activeTab.key else Tab.Overview.key,
             onSelect = { key ->
-              val next = shellNavTabs.firstOrNull { it.key == key } ?: Tab.Overview
-              if (next == Tab.Settings) {
-                settingsRoute = SettingsRoute.Home
-                returnToOverviewFromSettings = false
-              }
-              activeTab = next
+              nav.selectTab(shellNavTabs.firstOrNull { it.key == key } ?: Tab.Overview)
             },
           )
         }
       },
     ) { shellPadding ->
       Box(modifier = Modifier.fillMaxSize().padding(shellPadding)) {
-        when (activeTab) {
+        when (nav.activeTab) {
           Tab.Overview ->
             OverviewScreen(
               viewModel = viewModel,
-              onSelectTab = { activeTab = it },
-              onOpenSettingsRoute = {
-                settingsRoute = it
-                returnToOverviewFromSettings = true
-                activeTab = Tab.Settings
-              },
+              onSelectTab = nav::selectTab,
+              onOpenSettingsRoute = nav::openSettingsRoute,
               onOpenCommand = { commandOpen = true },
             )
           Tab.Chat ->
             ChatShellScreen(
               viewModel = viewModel,
-              onVoice = { activeTab = Tab.Voice },
-              onOpenSessions = { activeTab = Tab.Sessions },
-              onOpenGatewaySettings = {
-                settingsRoute = SettingsRoute.Gateway
-                returnToOverviewFromSettings = false
-                activeTab = Tab.Settings
-              },
+              onVoice = { nav.selectTab(Tab.Voice) },
+              onOpenSessions = { nav.openDetailTab(Tab.Sessions) },
+              onOpenGatewaySettings = { nav.openSettingsRoute(SettingsRoute.Gateway) },
             )
           Tab.Voice ->
             VoiceShellScreen(
               viewModel = viewModel,
               onOpenCommand = { commandOpen = true },
-              onOpenGatewaySettings = {
-                settingsRoute = SettingsRoute.Gateway
-                returnToOverviewFromSettings = false
-                activeTab = Tab.Settings
-              },
-              onOpenVoiceSettings = {
-                settingsRoute = SettingsRoute.Voice
-                returnToOverviewFromSettings = false
-                activeTab = Tab.Settings
-              },
+              onOpenGatewaySettings = { nav.openSettingsRoute(SettingsRoute.Gateway) },
+              onOpenVoiceSettings = { nav.openSettingsRoute(SettingsRoute.Voice) },
             )
           Tab.ProvidersModels ->
             ProvidersModelsScreen(
               viewModel = viewModel,
-              onBack = { activeTab = Tab.Overview },
+              onBack = nav::back,
             )
           Tab.Sessions ->
             SessionsScreen(
               viewModel = viewModel,
               onOpenCommand = { commandOpen = true },
-              onOpenChat = { activeTab = Tab.Chat },
+              onOpenChat = { nav.selectTab(Tab.Chat) },
             )
           Tab.Settings ->
             SettingsShellScreen(
               viewModel = viewModel,
-              route = settingsRoute,
-              onRouteChange = {
-                settingsRoute = it
-                returnToOverviewFromSettings = false
-              },
-              onRouteBack = {
-                settingsRoute = SettingsRoute.Home
-                if (returnToOverviewFromSettings) {
-                  returnToOverviewFromSettings = false
-                  activeTab = Tab.Overview
-                }
-              },
-              onBackHome = { activeTab = Tab.Overview },
+              route = nav.settingsRoute,
+              onRouteChange = nav::openSettingsRouteFromHome,
+              onBack = nav::back,
               onOpenCommand = { commandOpen = true },
             )
         }
@@ -279,30 +243,28 @@ fun ShellScreen(
             viewModel = viewModel,
             onDismiss = { commandOpen = false },
             onOpenChat = {
-              activeTab = Tab.Chat
+              nav.selectTab(Tab.Chat)
               commandOpen = false
             },
             onOpenVoice = {
-              activeTab = Tab.Voice
+              nav.selectTab(Tab.Voice)
               commandOpen = false
             },
             onOpenSessions = {
-              activeTab = Tab.Sessions
+              nav.openDetailTab(Tab.Sessions)
               commandOpen = false
             },
             onOpenProviders = {
-              activeTab = Tab.ProvidersModels
+              nav.openDetailTab(Tab.ProvidersModels)
               commandOpen = false
             },
             onOpenSettings = {
-              settingsRoute = SettingsRoute.Home
-              returnToOverviewFromSettings = false
-              activeTab = Tab.Settings
+              nav.openSettingsRoute(SettingsRoute.Home)
               commandOpen = false
             },
             onOpenSession = { sessionKey ->
               viewModel.switchChatSession(sessionKey)
-              activeTab = Tab.Chat
+              nav.selectTab(Tab.Chat)
               commandOpen = false
             },
           )
@@ -1373,8 +1335,7 @@ private fun SettingsShellScreen(
   viewModel: MainViewModel,
   route: SettingsRoute,
   onRouteChange: (SettingsRoute) -> Unit,
-  onRouteBack: () -> Unit,
-  onBackHome: () -> Unit,
+  onBack: () -> Unit,
   onOpenCommand: () -> Unit,
 ) {
   val displayName by viewModel.displayName.collectAsState()
@@ -1412,12 +1373,11 @@ private fun SettingsShellScreen(
     }
   }
 
-  BackHandler(enabled = route != SettingsRoute.Home) {
-    onRouteBack()
-  }
-
+  // System Back for settings routes is owned by the shell-level BackHandler, which
+  // unwinds cross-tab opens to their originating tab via ShellNavigation. A local
+  // BackHandler here would shadow it and strand cross-tab opens on Settings Home.
   if (route != SettingsRoute.Home) {
-    SettingsDetailScreen(viewModel = viewModel, route = route, onBack = onRouteBack)
+    SettingsDetailScreen(viewModel = viewModel, route = route, onBack = onBack)
     return
   }
 
@@ -1434,8 +1394,8 @@ private fun SettingsShellScreen(
         ) {
           ClawPlainIconButton(
             icon = Icons.AutoMirrored.Filled.ArrowBack,
-            contentDescription = "Back to home",
-            onClick = onBackHome,
+            contentDescription = "Back",
+            onClick = onBack,
           )
           Text(text = "Settings", style = ClawTheme.type.display.copy(fontSize = 24.sp, lineHeight = 28.sp), color = ClawTheme.colors.text, modifier = Modifier.weight(1f))
           ClawPlainIconButton(

--- a/apps/android/app/src/test/java/ai/openclaw/app/ui/ShellScreenLogicTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/ui/ShellScreenLogicTest.kt
@@ -11,6 +11,7 @@ import ai.openclaw.app.GatewayPendingDeviceSummary
 import ai.openclaw.app.ui.design.ClawStatus
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Settings
+import androidx.compose.runtime.saveable.SaverScope
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
@@ -44,6 +45,98 @@ class ShellScreenLogicTest {
     assertTrue(AppearanceThemeMode.System.isDark(systemDark = true))
     assertTrue(AppearanceThemeMode.Dark.isDark(systemDark = false))
     assertFalse(AppearanceThemeMode.Light.isDark(systemDark = true))
+  }
+
+  @Test
+  fun settingsRouteOpenedCrossTabReturnsToOriginTab() {
+    val nav = ShellNavigation()
+    nav.selectTab(Tab.Voice)
+    nav.openSettingsRoute(SettingsRoute.Gateway)
+    assertEquals(Tab.Settings, nav.activeTab)
+    assertEquals(SettingsRoute.Gateway, nav.settingsRoute)
+
+    nav.back()
+    assertEquals(Tab.Voice, nav.activeTab)
+    assertEquals(SettingsRoute.Home, nav.settingsRoute)
+
+    nav.back()
+    assertEquals(Tab.Overview, nav.activeTab)
+  }
+
+  @Test
+  fun settingsRouteOpenedFromOverviewReturnsToOverview() {
+    val nav = ShellNavigation()
+    nav.openSettingsRoute(SettingsRoute.Approvals)
+    nav.back()
+    assertEquals(Tab.Overview, nav.activeTab)
+    assertEquals(SettingsRoute.Home, nav.settingsRoute)
+  }
+
+  @Test
+  fun tabBarSettingsSelectionOpensHomeAndBacksToOverview() {
+    val nav = ShellNavigation()
+    nav.selectTab(Tab.Voice)
+    nav.openSettingsRoute(SettingsRoute.Voice)
+    nav.selectTab(Tab.Settings)
+    assertEquals(SettingsRoute.Home, nav.settingsRoute)
+
+    nav.back()
+    assertEquals(Tab.Overview, nav.activeTab)
+  }
+
+  @Test
+  fun settingsDetailOpenedFromHomeUnwindsToHomeBeforeLeavingSettings() {
+    val nav = ShellNavigation()
+    nav.selectTab(Tab.Voice)
+    nav.openSettingsRoute(SettingsRoute.Home)
+    nav.openSettingsRouteFromHome(SettingsRoute.Gateway)
+
+    nav.back()
+    assertEquals(Tab.Settings, nav.activeTab)
+    assertEquals(SettingsRoute.Home, nav.settingsRoute)
+
+    nav.back()
+    assertEquals(Tab.Voice, nav.activeTab)
+  }
+
+  @Test
+  fun detailTabsReturnToTheTabThatOpenedThem() {
+    val nav = ShellNavigation()
+    nav.selectTab(Tab.Chat)
+    nav.openDetailTab(Tab.Sessions)
+    nav.back()
+    assertEquals(Tab.Chat, nav.activeTab)
+
+    nav.selectTab(Tab.Voice)
+    nav.openDetailTab(Tab.ProvidersModels)
+    nav.back()
+    assertEquals(Tab.Voice, nav.activeTab)
+  }
+
+  @Test
+  fun tabBarSelectionClearsCrossTabReturnOrigin() {
+    val nav = ShellNavigation()
+    nav.selectTab(Tab.Chat)
+    nav.openDetailTab(Tab.Sessions)
+    nav.selectTab(Tab.Voice)
+    nav.back()
+    assertEquals(Tab.Overview, nav.activeTab)
+  }
+
+  @Test
+  fun shellNavigationSaverRoundTripsCrossTabState() {
+    val nav = ShellNavigation()
+    nav.selectTab(Tab.Voice)
+    nav.openSettingsRoute(SettingsRoute.Gateway)
+
+    val saveAnything = SaverScope { true }
+    val saved = with(ShellNavigation.Saver) { saveAnything.save(nav) }!!
+    val restored = ShellNavigation.Saver.restore(saved)!!
+
+    assertEquals(Tab.Settings, restored.activeTab)
+    assertEquals(SettingsRoute.Gateway, restored.settingsRoute)
+    restored.back()
+    assertEquals(Tab.Voice, restored.activeTab)
   }
 
   @Test


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where Android users who open a settings detail from another tab would be returned to the wrong screen when pressing Back. Opening Gateway or Talk settings from the Voice tab landed on Settings Home (and then Overview) instead of back on Voice; settings, Sessions, and Providers opened from the command palette always returned to Overview regardless of where the palette was opened.

## Why This Change Was Made

The shell tracked the origin with a single hardcoded `returnToOverviewFromSettings` boolean, which could only express "return to Overview" and was written inconsistently across the Overview screen, Voice screen, attention panels, and command palette. This change replaces it with a small `ShellNavigation` state holder that remembers the originating tab for any cross-tab detail open and owns all tab/route transitions (`selectTab`, `openSettingsRoute`, `openSettingsRouteFromHome`, `openDetailTab`, `back`), so Back semantics are defined in one place. The origin is deliberately a single slot: chained cross-tab hops return one level and then collapse to Overview, so the shell never accumulates a navigation stack. `SettingsShellScreen`'s redundant inner `BackHandler` and its duplicate `onRouteBack`/`onBackHome` callbacks were removed; the shell-level handler owns system Back.

## User Impact

- Back from a settings detail opened from the Voice tab (Gateway or Talk settings) now returns to Voice.
- Settings, Sessions, and Providers opened from the command palette now return to the tab the palette was opened from.
- Sessions opened from Chat now returns to Chat.
- Unchanged: settings details opened from Overview still return to Overview, tab-bar selection of Settings still opens Settings Home with Back going to Overview, and details opened from the Settings Home list still unwind to Settings Home first.

## Evidence

Prepared on exact head `b50827c544c0429710cc1a5c8177cb43a04f0e46`.

Android 16 emulator flow: Voice -> Connect Gateway -> system Back.

| Before | After |
| --- | --- |
| Current `main` lands on Settings Home. ![Before: Back from Voice-opened Gateway lands on Settings Home](https://github.com/user-attachments/assets/b55559a8-1b31-49d3-a8b2-293c7e309045) | The PR returns to Voice. ![After: Back from Voice-opened Gateway returns to Voice](https://github.com/user-attachments/assets/898c6372-39ce-4a5e-9df1-b5c0758873ff) |

Commands run:

```text
ANDROID_HOME="$HOME/Library/Android/sdk" ANDROID_SDK_ROOT="$HOME/Library/Android/sdk" ./gradlew :app:testPlayDebugUnitTest --tests ai.openclaw.app.ui.ShellScreenLogicTest --tests ai.openclaw.app.ui.GatewayDiagnosticsTest --tests ai.openclaw.app.ui.chat.ChatErrorTextTest :app:ktlintCheck :app:assembleThirdPartyDebug
node --import tsx scripts/native-app-i18n.ts check
git diff --check origin/main...HEAD
.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main
```

Results: focused navigation and conflict-neighbor tests, ktlint, third-party debug assembly, native i18n validation, diff validation, fresh autoreview, and exact-head GitHub CI passed (48/48): https://github.com/openclaw/openclaw/actions/runs/28577161630.

Audit: every writer of shell tab/route state now routes through `ShellNavigation`; the rebase retained #94566's Chat -> Gateway recovery path. Focused tests cover Settings Home unwind, command-palette Sessions/Providers, tab-bar origin reset, and process-state restoration.

Known proof boundary: the emulator shows the Voice -> Gateway path; command-palette/detail-tab variants are covered by focused state tests rather than separate recordings.
