### PR TITLE
fix(diagnostics-otel): route shared OTLP endpoints per signal

### DIFF
--- a/extensions/diagnostics-otel/src/service.test.ts
+++ b/extensions/diagnostics-otel/src/service.test.ts
@@ -1490,6 +1490,24 @@ describe("diagnostics-otel service", () => {
     await service.stop?.(ctx);
   });
 
+  test("routes each signal from a shared signal-qualified endpoint", async () => {
+    const service = createDiagnosticsOtelService();
+    const ctx = createOtelContext("https://collector.example.com/otlp/v1/traces?timeout=30s", {
+      traces: true,
+      metrics: true,
+      logs: true,
+    });
+    await service.start(ctx);
+
+    const traceOptions = firstExporterOptions(traceExporterCtor);
+    const metricOptions = firstExporterOptions(metricExporterCtor);
+    const logOptions = firstExporterOptions(logExporterCtor);
+    expect(traceOptions.url).toBe("https://collector.example.com/otlp/v1/traces?timeout=30s");
+    expect(metricOptions.url).toBe("https://collector.example.com/otlp/v1/metrics?timeout=30s");
+    expect(logOptions.url).toBe("https://collector.example.com/otlp/v1/logs?timeout=30s");
+    await service.stop?.(ctx);
+  });
+
   test("inserts signal path before shared endpoint query params", async () => {
     const service = createDiagnosticsOtelService();
     const ctx = createTraceOnlyContext("https://collector.example.com/otlp?timeout=30s");

--- a/extensions/diagnostics-otel/src/service.ts
+++ b/extensions/diagnostics-otel/src/service.ts
@@ -169,8 +169,16 @@ function resolveOtelUrl(endpoint: string | undefined, path: string): string | un
     return undefined;
   }
   const endpointWithoutQueryOrFragment = endpoint.split(/[?#]/, 1)[0] ?? endpoint;
-  if (/\/v1\/(?:traces|metrics|logs)$/i.test(endpointWithoutQueryOrFragment)) {
-    return endpoint;
+  const signalPathMatch = /\/v1\/(?:traces|metrics|logs)$/iu.exec(endpointWithoutQueryOrFragment);
+  if (signalPathMatch) {
+    const configuredPath = signalPathMatch[0].slice(1);
+    if (configuredPath.toLowerCase() === path.toLowerCase()) {
+      return endpoint;
+    }
+    const signalPathStart = signalPathMatch.index;
+    const prefix = endpoint.slice(0, signalPathStart);
+    const suffix = endpoint.slice(endpointWithoutQueryOrFragment.length);
+    return `${prefix}/${path}${suffix}`;
   }
   if (/[?#]/u.test(endpoint)) {
     try {


### PR DESCRIPTION
Closes #98886

Related: #98899 is an existing draft from another fork. This PR keeps the fix to the runtime resolver/test surface only, preserves the existing same-signal endpoint behavior, and includes focused local proof for the regression.

## What Problem This Solves

Fixes an issue where users enabling diagnostics-otel metrics or logs with a shared OTLP endpoint that already ended in `/v1/traces` would send metrics and logs payloads to the traces endpoint.

## Why This Change Was Made

OpenClaw now treats a signal-qualified shared OTLP endpoint as the base endpoint plus a replaceable signal suffix: traces keep `/v1/traces`, metrics use `/v1/metrics`, and logs use `/v1/logs`, while query strings and fragments are preserved. Signal-specific endpoint config remains the explicit override path.

## User Impact

Operators can point `diagnostics.otel.endpoint` at a collector URL copied from a trace setup and still enable metrics or logs without misrouting those payloads to the trace receiver. Existing trace-only or same-signal endpoint behavior stays stable, including preserving the configured URL casing.

## Evidence

- Claim proved: a shared `.../v1/traces?timeout=30s` endpoint now constructs separate exporter URLs ending in `/v1/traces`, `/v1/metrics`, and `/v1/logs` for the three enabled OTLP signals.
- Commands / artifacts:
  - `node scripts/run-vitest.mjs run --config test/vitest/vitest.extension-misc.config.ts extensions/diagnostics-otel/src/service.test.ts --reporter=verbose --testNamePattern "routes each signal from a shared signal-qualified endpoint"`
  - `corepack pnpm exec oxfmt --check --threads=1 extensions/diagnostics-otel/src/service.ts extensions/diagnostics-otel/src/service.test.ts`
  - `git diff --check HEAD~1 HEAD`
  - `python .agents\skills\autoreview\scripts\autoreview --mode commit --commit HEAD`
- Observed result:
  - Focused Vitest passed: `1 passed | 95 skipped` in `extensions/diagnostics-otel/src/service.test.ts`.
  - Formatter check passed for both touched files.
  - `git diff --check HEAD~1 HEAD` passed with no whitespace errors.
  - Autoreview reported `clean: no accepted/actionable findings reported`; the helper printed a late Windows GBK decode exception after the clean verdict.
- Dependency/source contract checked:
  - Local `@opentelemetry/exporter-trace-otlp-http` README says shared `OTEL_EXPORTER_OTLP_ENDPOINT` automatically appends signal paths such as `/v1/traces` and `/v1/metrics`.
  - Local `@opentelemetry/exporter-metrics-otlp-proto` README says `/v1/metrics` is automatically appended to configured shared endpoint values.
  - Local `@opentelemetry/exporter-logs-otlp-http` README says `/v1/logs` is automatically appended to configured shared endpoint values.
- Not tested / proof gaps:
  - No live Langfuse or collector instance was run from this Windows worktree; validation is focused service startup/exporter URL proof plus local OpenTelemetry dependency documentation/source inspection.