### PR TITLE
fix(agents): Claude CLI is_error results no longer delivered as success on one-shot paths (#98896)

### DIFF
--- a/src/agents/cli-output.test.ts
+++ b/src/agents/cli-output.test.ts
@@ -752,6 +752,41 @@ describe("parseCliJsonl", () => {
 
     expect(result).toBe(message);
   });
+
+  it("classifies Claude is_error result envelopes as errorText instead of assistant text", () => {
+    const { message, apiError, jsonl } = createClaudeApiErrorFixture();
+    const backend = {
+      command: "claude",
+      output: "jsonl" as const,
+      sessionIdFields: ["session_id"],
+    };
+
+    expect(parseCliJsonl(jsonl, backend, "claude-cli")).toEqual({
+      text: "",
+      sessionId: "session-api-error",
+      usage: undefined,
+      errorText: message,
+    });
+
+    expect(
+      parseCliJson(
+        JSON.stringify({
+          type: "result",
+          subtype: "success",
+          is_error: true,
+          result: apiError,
+          session_id: "session-api-error",
+        }),
+        backend,
+        "claude-cli",
+      ),
+    ).toEqual({
+      text: "",
+      sessionId: "session-api-error",
+      usage: undefined,
+      errorText: message,
+    });
+  });
 });
 
 describe("createCliJsonlStreamingParser", () => {
@@ -931,6 +966,29 @@ describe("createCliJsonlStreamingParser", () => {
       sessionId: undefined,
       usage: undefined,
       errorText: "Gemini stream failed",
+    });
+  });
+
+  it("classifies Claude is_error result envelopes in streamed JSONL output", () => {
+    const { message, jsonl } = createClaudeApiErrorFixture();
+    const parser = createCliJsonlStreamingParser({
+      backend: {
+        command: "claude",
+        output: "jsonl",
+        sessionIdFields: ["session_id"],
+      },
+      providerId: "claude-cli",
+      onAssistantDelta: () => {},
+    });
+
+    parser.push(`${jsonl}\n`);
+    parser.finish();
+
+    expect(parser.getOutput()).toEqual({
+      text: "",
+      sessionId: "session-api-error",
+      usage: undefined,
+      errorText: message,
     });
   });
 

--- a/src/agents/cli-output.ts
+++ b/src/agents/cli-output.ts
@@ -374,10 +374,17 @@ export function parseCliJson(
   let sessionId: string | undefined;
   let usage: CliUsage | undefined;
   let text = "";
+  let errorText: string | undefined;
   let sawStructuredOutput = false;
   for (const parsed of parsedRecords) {
     sessionId = pickCliSessionId(parsed, backend) ?? sessionId;
     usage = readCliUsage(parsed) ?? usage;
+    const resultEnvelopeError = readClaudeCliResultEnvelopeError(parsed);
+    if (resultEnvelopeError) {
+      errorText = resultEnvelopeError;
+      sawStructuredOutput = true;
+      continue;
+    }
     const nextText =
       collectCliText(parsed.message) ||
       collectCliText(parsed.content) ||
@@ -402,6 +409,9 @@ export function parseCliJson(
   if (!text && !sawStructuredOutput) {
     return null;
   }
+  if (errorText) {
+    return { text: "", sessionId, usage, errorText };
+  }
   return { text, sessionId, usage };
 }
 
@@ -415,11 +425,19 @@ function parseClaudeCliJsonlResult(params: {
   if (!supportsCliJsonlToolEvents(params)) {
     return null;
   }
-  if (
-    typeof params.parsed.type === "string" &&
-    params.parsed.type === "result" &&
-    typeof params.parsed.result === "string"
-  ) {
+  if (typeof params.parsed.type === "string" && params.parsed.type === "result") {
+    const resultEnvelopeError = readClaudeCliResultEnvelopeError(params.parsed);
+    if (resultEnvelopeError) {
+      return {
+        text: "",
+        sessionId: params.sessionId,
+        usage: params.usage,
+        errorText: resultEnvelopeError,
+      };
+    }
+    if (typeof params.parsed.result !== "string") {
+      return null;
+    }
     const resultText = unwrapNestedCliResultText(params.parsed.result).trim();
     if (resultText) {
       return { text: resultText, sessionId: params.sessionId, usage: params.usage };
@@ -712,6 +730,14 @@ function dispatchGeminiCliStreamingToolEvent(params: {
 
 const GEMINI_CLI_ERROR_EVENT_FALLBACK = "Gemini CLI emitted an error event.";
 const GEMINI_CLI_RESULT_ERROR_FALLBACK = "Gemini CLI result status was error.";
+const CLAUDE_CLI_RESULT_ERROR_FALLBACK = "Claude CLI result status was error.";
+
+function readClaudeCliResultEnvelopeError(parsed: Record<string, unknown>): string | undefined {
+  if (parsed.type !== "result" || parsed.is_error !== true) {
+    return undefined;
+  }
+  return collectExplicitCliErrorText(parsed) || CLAUDE_CLI_RESULT_ERROR_FALLBACK;
+}
 
 function isFallbackGeminiCliStreamJsonError(errorText: string): boolean {
   return (

--- a/src/agents/cli-runner/execute.supervisor-capture.test.ts
+++ b/src/agents/cli-runner/execute.supervisor-capture.test.ts
@@ -12,6 +12,7 @@ import {
 import { onAgentEvent, resetAgentEventsForTest } from "../../infra/agent-events.js";
 import type { getProcessSupervisor } from "../../process/supervisor/index.js";
 import { createManagedRun, supervisorSpawnMock } from "../cli-runner.test-support.js";
+import { createClaudeApiErrorFixture } from "../test-helpers/claude-api-error-fixture.js";
 import { getCliMessagingDeliveryEvidence } from "./delivery-evidence.js";
 import { executePreparedCliRun } from "./execute.js";
 import type { PreparedCliRunContext } from "./types.js";
@@ -240,6 +241,37 @@ describe("executePreparedCliRun supervisor output capture", () => {
 
     expect(result.text).toBe("resumed answer");
     expect(result.sessionId).toBe("resume-jsonl-session");
+  });
+
+  it("fails one-shot Claude JSONL turns when the result envelope is is_error", async () => {
+    const { message, jsonl } = createClaudeApiErrorFixture();
+
+    supervisorSpawnMock.mockImplementationOnce(async (...args: unknown[]) => {
+      const input = args[0] as SupervisorSpawnInput;
+      input.onStdout?.(`${jsonl}\n`);
+      return createManagedRun({
+        reason: "exit",
+        exitCode: 0,
+        exitSignal: null,
+        durationMs: 50,
+        stdout: input.captureOutput === false ? "" : `${jsonl}\n`,
+        stderr: "",
+        timedOut: false,
+        noOutputTimedOut: false,
+      });
+    });
+
+    try {
+      await executePreparedCliRun(
+        buildPreparedCliRunContext({ output: "jsonl", provider: "claude-cli" }),
+      );
+    } catch (error) {
+      const failover = error as { message?: string; reason?: string };
+      expect(failover.message).toBe(message);
+      expect(failover.reason).toBe("billing");
+      return;
+    }
+    throw new Error("Expected Claude JSONL is_error turn to fail with failover");
   });
 
   it("classifies failed stdout from the retained parse buffer before the diagnostic tail", async () => {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users running Claude CLI through the one-shot (non-live-session) path would receive raw API error text as a normal assistant reply when Claude emitted a result envelope with `is_error: true`, instead of triggering model failover like the live-session path already does.

Related: #98896 (scoped to defect #1: `is_error` classification).

## Why This Change Was Made

`parseCliJson` and `parseClaudeCliJsonlResult` now classify `is_error` result envelopes into `errorText`, matching the live-session guard in `claude-live-session.ts`. `execute.ts` already throws `FailoverError` when `parsed.errorText` is set, so one-shot turns engage failover instead of persisting a bogus session binding.

Non-goals for this PR: raw NDJSON fallback and POSIX UTF-8 chunk decoding. Line-buffer cap is handled separately in #98935.

## User Impact

When Claude CLI returns a billing/rate-limit/API error inside an `is_error` result envelope on one-shot runs, users now get failover behavior instead of seeing the API error string as the assistant answer.

## Evidence

Local vitest (targeted):

```
pnpm exec vitest run src/agents/cli-output.test.ts src/agents/cli-runner/execute.supervisor-capture.test.ts -t "is_error|classifies Claude is_error"
# Test Files  3 passed (3)
# Tests  4 passed | 98 skipped (102)
```

Behavior covered:
- `parseCliJsonl` + `parseCliJson` return `{ errorText }` for `createClaudeApiErrorFixture()` instead of delivering API error as `text`
- streaming parser `getOutput()` surfaces the same `errorText`
- `executePreparedCliRun` one-shot JSONL path throws `FailoverError` with `reason: billing` instead of returning the error as assistant text
