### PR TITLE
fix(anthropic): restore Fable 5 Vertex simple completions

### DIFF
--- a/extensions/anthropic-vertex/stream-runtime.test.ts
+++ b/extensions/anthropic-vertex/stream-runtime.test.ts
@@ -177,6 +177,23 @@ describe("createAnthropicVertexStreamFn", () => {
     });
   });
 
+  it("restores the canonical API before calling the shared Anthropic transport", () => {
+    const { deps, streamAnthropicMock } = createStreamDeps();
+    const streamFn = createAnthropicVertexStreamFn("vertex-project", "us-east5", undefined, deps);
+    const model = {
+      ...makeModel({ id: "claude-fable-5", maxTokens: 128000 }),
+      api: "openclaw-anthropic-vertex-simple:default",
+    };
+
+    void streamFn(model as never, { messages: [] }, {});
+
+    expect(streamAnthropicCall(streamAnthropicMock)[0]).toMatchObject({
+      api: "anthropic-messages",
+      provider: "anthropic-vertex",
+      id: "claude-fable-5",
+    });
+  });
+
   it("defaults maxTokens to the model limit instead of the old 32000 cap", () => {
     const { deps, streamAnthropicMock } = createStreamDeps();
     const streamFn = createAnthropicVertexStreamFn("vertex-project", "us-east5", undefined, deps);

--- a/extensions/anthropic-vertex/stream-runtime.ts
+++ b/extensions/anthropic-vertex/stream-runtime.ts
@@ -135,8 +135,11 @@ export function createAnthropicVertexStreamFn(
   });
 
   return (model, context, options) => {
-    const transportModel = model as Model<"anthropic-messages"> & {
-      api: string;
+    // Simple completions use a synthetic registry API to select this plugin.
+    // The shared Anthropic transport must receive its canonical API or it recurses.
+    const transportModel = (
+      model.api === "anthropic-messages" ? model : { ...model, api: "anthropic-messages" as const }
+    ) as Model<"anthropic-messages"> & {
       baseUrl?: string;
       provider: string;
     };

--- a/extensions/matrix/src/matrix/monitor/inbound-dedupe.ts
+++ b/extensions/matrix/src/matrix/monitor/inbound-dedupe.ts
@@ -116,12 +116,21 @@ function pruneSeenEvents(params: {
   }
 }
 
-function createInboundDedupeStore(params: { env?: NodeJS.ProcessEnv; stateDir?: string }) {
-  return getMatrixRuntime().state.openKeyedStore<StoredMatrixInboundDedupeEntry>({
+export function openMatrixInboundDedupeStoreOptions(params: {
+  env?: NodeJS.ProcessEnv;
+  stateDir?: string;
+}) {
+  return {
     namespace: INBOUND_DEDUPE_NAMESPACE,
     maxEntries: DEFAULT_MAX_ENTRIES,
     env: resolveMatrixSqliteStateEnv(params),
-  });
+  };
+}
+
+function createInboundDedupeStore(params: { env?: NodeJS.ProcessEnv; stateDir?: string }) {
+  return getMatrixRuntime().state.openKeyedStore<StoredMatrixInboundDedupeEntry>(
+    openMatrixInboundDedupeStoreOptions(params),
+  );
 }
 
 function createInboundDedupeMigrationStore(params: { env?: NodeJS.ProcessEnv; stateDir?: string }) {

--- a/extensions/matrix/test-api.ts
+++ b/extensions/matrix/test-api.ts
@@ -5,6 +5,12 @@ export {
   openMatrixIdbSnapshotStoreOptions,
   openMatrixRecoveryKeyStoreOptions,
 } from "./src/matrix/crypto-state-store.js";
+export {
+  normalizeMatrixStorageMetadata,
+  openMatrixStorageMetaStoreOptions,
+} from "./src/matrix/client/storage.js";
+export type { MatrixStorageMetadata } from "./src/matrix/client/storage.js";
+export { openMatrixInboundDedupeStoreOptions } from "./src/matrix/monitor/inbound-dedupe.js";
 export type {
   EncryptedFile,
   MatrixDeviceVerificationStatus,

--- a/extensions/qa-matrix/src/runners/contract/scenario-runtime-e2ee-destructive.test.ts
+++ b/extensions/qa-matrix/src/runners/contract/scenario-runtime-e2ee-destructive.test.ts
@@ -1,0 +1,61 @@
+import { mkdtemp, rm } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import {
+  createPluginStateSyncKeyedStoreForTests,
+  resetPluginStateStoreForTests,
+} from "openclaw/plugin-sdk/plugin-state-test-runtime";
+import { afterEach, describe, expect, it } from "vitest";
+import { testing } from "./scenario-runtime-e2ee-destructive.js";
+
+const storageMetadataRuntime = {
+  normalizeMatrixStorageMetadata(value: unknown) {
+    if (!value || typeof value !== "object") {
+      return null;
+    }
+    const metadata = value as { deviceId?: unknown; userId?: unknown };
+    return {
+      ...(typeof metadata.deviceId === "string" ? { deviceId: metadata.deviceId } : {}),
+      ...(typeof metadata.userId === "string" ? { userId: metadata.userId } : {}),
+    };
+  },
+  openMatrixStorageMetaStoreOptions(storageRootDir: string) {
+    return {
+      namespace: "storage-meta",
+      maxEntries: 10,
+      env: { ...process.env, OPENCLAW_STATE_DIR: storageRootDir },
+    };
+  },
+};
+
+describe("Matrix destructive E2EE storage discovery", () => {
+  const tempDirs: string[] = [];
+
+  afterEach(async () => {
+    resetPluginStateStoreForTests();
+    await Promise.all(tempDirs.splice(0).map((dir) => rm(dir, { force: true, recursive: true })));
+  });
+
+  it("finds account metadata stored in account-local SQLite", async () => {
+    const stateDir = await mkdtemp(path.join(os.tmpdir(), "matrix-qa-storage-"));
+    tempDirs.push(stateDir);
+    const accountRoot = path.join(stateDir, "matrix", "accounts", "stored-key", "server", "token");
+    createPluginStateSyncKeyedStoreForTests(
+      "matrix",
+      storageMetadataRuntime.openMatrixStorageMetaStoreOptions(accountRoot),
+    ).register("current", {
+      deviceId: "DEVICE",
+      userId: "@owner:matrix-qa.test",
+    });
+    resetPluginStateStoreForTests();
+
+    await expect(
+      testing.findMatrixQaCliAccountRoot({
+        deviceId: "DEVICE",
+        runtime: { stateDir },
+        storageMetadataRuntime,
+        userId: "@owner:matrix-qa.test",
+      }),
+    ).resolves.toBe(accountRoot);
+  });
+});

--- a/extensions/qa-matrix/src/runners/contract/scenario-runtime-e2ee-destructive.ts
+++ b/extensions/qa-matrix/src/runners/contract/scenario-runtime-e2ee-destructive.ts
@@ -1,6 +1,6 @@
 // Qa Matrix plugin module implements scenario runtime e2ee destructive behavior.
 import { randomUUID } from "node:crypto";
-import { mkdir, readdir, readFile, rm, writeFile } from "node:fs/promises";
+import { access, mkdir, readdir, readFile, rm, writeFile } from "node:fs/promises";
 import path from "node:path";
 import { setTimeout as sleep } from "node:timers/promises";
 import type { OpenKeyedStoreOptions } from "openclaw/plugin-sdk/plugin-state-runtime";
@@ -46,6 +46,11 @@ import {
 import type { MatrixQaScenarioExecution } from "./scenario-types.js";
 
 type MatrixQaCliRuntime = Awaited<ReturnType<typeof createMatrixQaOpenClawCliRuntime>>;
+
+type MatrixQaStorageMetadataRuntime = Pick<
+  Awaited<ReturnType<typeof loadMatrixQaE2eeRuntime>>,
+  "normalizeMatrixStorageMetadata" | "openMatrixStorageMetaStoreOptions"
+>;
 
 type MatrixQaCliBackupStatus = {
   backup?: {
@@ -503,24 +508,59 @@ async function findFilesByName(params: { filename: string; rootDir: string }): P
 
 async function findMatrixQaCliAccountRoot(params: {
   deviceId: string;
-  runtime: MatrixQaCliRuntime;
+  runtime: Pick<MatrixQaCliRuntime, "stateDir">;
+  storageMetadataRuntime?: MatrixQaStorageMetadataRuntime;
   userId: string;
 }) {
-  const metadataPaths = await findFilesByName({
+  const storageMetadataRuntime = params.storageMetadataRuntime ?? (await loadMatrixQaE2eeRuntime());
+  const sqlitePaths = await findFilesByName({
+    filename: "openclaw.sqlite",
+    rootDir: params.runtime.stateDir,
+  });
+  const legacyMetadataPaths = await findFilesByName({
     filename: "storage-meta.json",
     rootDir: params.runtime.stateDir,
   });
-  for (const metadataPath of metadataPaths) {
+  // Current account metadata lives in account-local SQLite. Keep legacy JSON
+  // discovery for older tagged fixtures without making it the canonical path.
+  const accountRoots = new Set(
+    sqlitePaths
+      .filter((sqlitePath) => path.basename(path.dirname(sqlitePath)) === "state")
+      .map((sqlitePath) => path.dirname(path.dirname(sqlitePath))),
+  );
+  for (const metadataPath of legacyMetadataPaths) {
+    accountRoots.add(path.dirname(metadataPath));
+  }
+  for (const accountRoot of [...accountRoots].toSorted()) {
+    let metadata: { deviceId?: unknown; userId?: unknown } | null = null;
     try {
-      const metadata = JSON.parse(await readFile(metadataPath, "utf8")) as {
-        deviceId?: unknown;
-        userId?: unknown;
-      };
-      if (metadata.userId === params.userId && metadata.deviceId === params.deviceId) {
-        return path.dirname(metadataPath);
+      await access(path.join(accountRoot, "state", "openclaw.sqlite"));
+      try {
+        const store = createPluginStateSyncKeyedStoreForTests<unknown>(
+          "matrix",
+          storageMetadataRuntime.openMatrixStorageMetaStoreOptions(accountRoot),
+        );
+        metadata = storageMetadataRuntime.normalizeMatrixStorageMetadata(store.lookup("current"));
+      } finally {
+        resetPluginStateStoreForTests();
       }
     } catch {
-      continue;
+      // Fall through to the legacy sidecar for pre-SQLite fixtures.
+    }
+    if (!metadata) {
+      try {
+        metadata = JSON.parse(
+          await readFile(path.join(accountRoot, "storage-meta.json"), "utf8"),
+        ) as {
+          deviceId?: unknown;
+          userId?: unknown;
+        };
+      } catch {
+        continue;
+      }
+    }
+    if (metadata.userId === params.userId && metadata.deviceId === params.deviceId) {
+      return accountRoot;
     }
   }
   throw new Error(`Matrix CLI account storage root was not created for ${params.userId}`);
@@ -1685,3 +1725,7 @@ export async function runMatrixQaE2eeHistoryExistsBackupEmptyScenario(
     await cleanupMatrixQaTempDevices(setup.owner, [device.deviceId]);
   }
 }
+
+export const testing = {
+  findMatrixQaCliAccountRoot,
+};

--- a/extensions/qa-matrix/src/runners/contract/scenario-runtime-state-files.test.ts
+++ b/extensions/qa-matrix/src/runners/contract/scenario-runtime-state-files.test.ts
@@ -1,0 +1,69 @@
+import { createHash } from "node:crypto";
+import { mkdtemp, rm } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import {
+  createPluginStateSyncKeyedStoreForTests,
+  resetPluginStateStoreForTests,
+} from "openclaw/plugin-sdk/plugin-state-test-runtime";
+import { afterEach, describe, expect, it } from "vitest";
+import type { MatrixQaScenarioContext } from "./scenario-runtime-shared.js";
+import { waitForMatrixInboundDedupeEntry } from "./scenario-runtime-state-files.js";
+
+const dedupeStoreRuntime = {
+  openMatrixInboundDedupeStoreOptions(params: { stateDir?: string }) {
+    return {
+      namespace: "inbound-dedupe",
+      maxEntries: 20_000,
+      env: { ...process.env, OPENCLAW_STATE_DIR: params.stateDir },
+    };
+  },
+};
+
+function buildDedupeKey(params: { accountId: string; eventId: string; roomId: string }) {
+  return `${params.accountId}:${createHash("sha256")
+    .update(params.accountId)
+    .update("\0")
+    .update(params.roomId)
+    .update("\0")
+    .update(params.eventId)
+    .digest("hex")}`;
+}
+
+describe("Matrix QA persisted state probes", () => {
+  const tempDirs: string[] = [];
+
+  afterEach(async () => {
+    resetPluginStateStoreForTests();
+    await Promise.all(tempDirs.splice(0).map((dir) => rm(dir, { force: true, recursive: true })));
+  });
+
+  it("observes inbound dedupe entries through the canonical plugin-state store", async () => {
+    const stateDir = await mkdtemp(path.join(os.tmpdir(), "matrix-qa-dedupe-"));
+    tempDirs.push(stateDir);
+    const accountRoot = path.join(stateDir, "matrix", "accounts", "sut", "server", "token");
+    const accountId = "sut";
+    const eventId = "$event";
+    const roomId = "!room:matrix-qa.test";
+    const options = dedupeStoreRuntime.openMatrixInboundDedupeStoreOptions({
+      stateDir: accountRoot,
+    });
+    const runtimeAccountId = "runtime-default";
+    createPluginStateSyncKeyedStoreForTests("matrix", options).register(
+      buildDedupeKey({ accountId: runtimeAccountId, eventId, roomId }),
+      { eventId, roomId, ts: Date.now() },
+    );
+    resetPluginStateStoreForTests();
+
+    await expect(
+      waitForMatrixInboundDedupeEntry({
+        context: { sutAccountId: accountId } as MatrixQaScenarioContext,
+        dedupeStoreRuntime,
+        eventId,
+        roomId,
+        stateDir,
+        timeoutMs: 1_000,
+      }),
+    ).resolves.toBe(path.join(accountRoot, "state", "openclaw.sqlite"));
+  });
+});

--- a/extensions/qa-matrix/src/runners/contract/scenario-runtime-state-files.ts
+++ b/extensions/qa-matrix/src/runners/contract/scenario-runtime-state-files.ts
@@ -3,19 +3,27 @@ import { createHash, randomUUID } from "node:crypto";
 import fs from "node:fs/promises";
 import path from "node:path";
 import { setTimeout as sleep } from "node:timers/promises";
+import type { OpenKeyedStoreOptions } from "openclaw/plugin-sdk/plugin-state-runtime";
 import { isRecord } from "openclaw/plugin-sdk/string-coerce-runtime";
+import { loadMatrixQaE2eeRuntime } from "../../substrate/e2ee-client.js";
 import type { MatrixQaScenarioContext } from "./scenario-runtime-shared.js";
 
 const MATRIX_SYNC_STORE_FILENAME = "bot-storage.json";
 const MATRIX_INBOUND_DEDUPE_FILENAME = "inbound-dedupe.json";
 const MATRIX_PLUGIN_ID = "matrix";
 const MATRIX_SYNC_CACHE_NAMESPACE = "sync-cache";
-const MATRIX_INBOUND_DEDUPE_NAMESPACE = "inbound-dedupe";
 const MATRIX_STATE_POLL_INTERVAL_MS = 100;
 const MATRIX_SYNC_CACHE_MAX_ENTRIES = 20_000;
 const MATRIX_SYNC_CACHE_MAX_CHUNKS = Math.floor((MATRIX_SYNC_CACHE_MAX_ENTRIES - 1) / 2);
 // PluginState serializes this string inside a row object; 24KB leaves room for JSON escaping.
 const MATRIX_SYNC_CACHE_CHUNK_BYTES = 24_000;
+
+type MatrixQaInboundDedupeStoreRuntime = {
+  openMatrixInboundDedupeStoreOptions: (params: {
+    env?: NodeJS.ProcessEnv;
+    stateDir?: string;
+  }) => OpenKeyedStoreOptions;
+};
 
 type MatrixSyncStoreCursor = {
   cursor: string;
@@ -521,6 +529,7 @@ function buildMatrixInboundDedupePluginStateKey(params: {
 
 async function hasPersistedMatrixPluginStateDedupeEntry(params: {
   accountId: string;
+  dedupeStoreRuntime?: MatrixQaInboundDedupeStoreRuntime;
   eventId: string;
   roomId: string;
   stateDir: string;
@@ -530,65 +539,70 @@ async function hasPersistedMatrixPluginStateDedupeEntry(params: {
     eventId: params.eventId,
     roomId: params.roomId,
   });
+  const dedupeStoreRuntime = params.dedupeStoreRuntime ?? (await loadMatrixQaE2eeRuntime());
   const databasePaths = await findFilesByName({
     filename: "openclaw.sqlite",
     rootDir: params.stateDir,
-    maxDepth: 4,
+    maxDepth: 10,
   });
-  if (databasePaths.length === 0) {
-    databasePaths.push(path.join(params.stateDir, "state", "openclaw.sqlite"));
-  }
-  const now = Date.now();
-  const isExpectedValue = (raw: unknown) => {
-    if (typeof raw !== "string") {
-      return false;
-    }
-    try {
-      const parsed = JSON.parse(raw) as unknown;
-      return (
-        isRecord(parsed) && parsed.roomId === params.roomId && parsed.eventId === params.eventId
-      );
-    } catch {
-      return false;
-    }
-  };
+  let sqlite: typeof import("node:sqlite");
   try {
-    const sqlite = await import("node:sqlite");
-    for (const databasePath of databasePaths) {
-      try {
-        await fs.access(databasePath);
-        const db = new sqlite.DatabaseSync(databasePath, { readOnly: true });
-        try {
-          const rows = db
-            .prepare(
-              `SELECT entry_key AS entryKey, value_json AS valueJson
-                 FROM plugin_state_entries
-                WHERE plugin_id = ?
-                  AND namespace = ?
-                  AND (expires_at IS NULL OR expires_at > ?)`,
-            )
-            .all(MATRIX_PLUGIN_ID, MATRIX_INBOUND_DEDUPE_NAMESPACE, now) as Array<{
-            entryKey?: unknown;
-            valueJson?: unknown;
-          }>;
-          if (rows.some((row) => row.entryKey === entryKey || isExpectedValue(row.valueJson))) {
-            return databasePath;
-          }
-        } finally {
-          db.close();
-        }
-      } catch {
-        continue;
-      }
-    }
+    sqlite = await import("node:sqlite");
   } catch {
     return null;
+  }
+  for (const databasePath of databasePaths) {
+    try {
+      const storageRootDir = path.dirname(path.dirname(databasePath));
+      const options = dedupeStoreRuntime.openMatrixInboundDedupeStoreOptions({
+        stateDir: storageRootDir,
+      });
+      const stateRoot = options.env?.OPENCLAW_STATE_DIR?.trim();
+      if (
+        !stateRoot ||
+        path.resolve(stateRoot, "state", "openclaw.sqlite") !== path.resolve(databasePath)
+      ) {
+        continue;
+      }
+      const db = new sqlite.DatabaseSync(databasePath, { readOnly: true });
+      try {
+        const rows = db
+          .prepare(
+            `SELECT entry_key AS entryKey, value_json AS valueJson
+               FROM plugin_state_entries
+              WHERE plugin_id = ?
+                AND namespace = ?
+                AND (expires_at IS NULL OR expires_at > ?)`,
+          )
+          .all(MATRIX_PLUGIN_ID, options.namespace, Date.now()) as Array<{
+          entryKey?: unknown;
+          valueJson?: unknown;
+        }>;
+        const matched = rows.some((row) => {
+          if (row.entryKey === entryKey) {
+            return true;
+          }
+          const entry = parsePluginStateJson(row.valueJson);
+          return (
+            isRecord(entry) && entry.roomId === params.roomId && entry.eventId === params.eventId
+          );
+        });
+        if (matched) {
+          return databasePath;
+        }
+      } finally {
+        db.close();
+      }
+    } catch {
+      continue;
+    }
   }
   return null;
 }
 
 export async function waitForMatrixInboundDedupeEntry(params: {
   context: MatrixQaScenarioContext;
+  dedupeStoreRuntime?: MatrixQaInboundDedupeStoreRuntime;
   eventId: string;
   roomId: string;
   stateDir: string;
@@ -598,6 +612,7 @@ export async function waitForMatrixInboundDedupeEntry(params: {
   while (Date.now() - startedAt < params.timeoutMs) {
     const sqlitePath = await hasPersistedMatrixPluginStateDedupeEntry({
       accountId: params.context.sutAccountId ?? "sut",
+      ...(params.dedupeStoreRuntime ? { dedupeStoreRuntime: params.dedupeStoreRuntime } : {}),
       eventId: params.eventId,
       roomId: params.roomId,
       stateDir: params.stateDir,

--- a/extensions/qa-matrix/src/runners/contract/scenarios.test.ts
+++ b/extensions/qa-matrix/src/runners/contract/scenarios.test.ts
@@ -7,12 +7,17 @@ import { describe, expect, it, beforeEach, vi } from "vitest";
 const { createMatrixQaClient } = vi.hoisted(() => ({
   createMatrixQaClient: vi.fn(),
 }));
-const { createMatrixQaE2eeScenarioClient, runMatrixQaE2eeBootstrap, startMatrixQaFaultProxy } =
-  vi.hoisted(() => ({
-    createMatrixQaE2eeScenarioClient: vi.fn(),
-    runMatrixQaE2eeBootstrap: vi.fn(),
-    startMatrixQaFaultProxy: vi.fn(),
-  }));
+const {
+  createMatrixQaE2eeScenarioClient,
+  loadMatrixQaE2eeRuntime,
+  runMatrixQaE2eeBootstrap,
+  startMatrixQaFaultProxy,
+} = vi.hoisted(() => ({
+  createMatrixQaE2eeScenarioClient: vi.fn(),
+  loadMatrixQaE2eeRuntime: vi.fn(),
+  runMatrixQaE2eeBootstrap: vi.fn(),
+  startMatrixQaFaultProxy: vi.fn(),
+}));
 const {
   formatMatrixQaCliCommand,
   redactMatrixQaCliOutput,
@@ -32,6 +37,7 @@ vi.mock("../../substrate/client.js", () => ({
 }));
 vi.mock("../../substrate/e2ee-client.js", () => ({
   createMatrixQaE2eeScenarioClient,
+  loadMatrixQaE2eeRuntime,
   runMatrixQaE2eeBootstrap,
 }));
 vi.mock("../../substrate/fault-proxy.js", () => ({
@@ -364,6 +370,13 @@ describe("matrix live qa scenarios", () => {
   beforeEach(() => {
     createMatrixQaClient.mockReset();
     createMatrixQaE2eeScenarioClient.mockReset();
+    loadMatrixQaE2eeRuntime.mockReset().mockResolvedValue({
+      openMatrixInboundDedupeStoreOptions: ({ stateDir }: { stateDir?: string }) => ({
+        namespace: "inbound-dedupe",
+        maxEntries: 20_000,
+        env: { ...process.env, OPENCLAW_STATE_DIR: stateDir },
+      }),
+    });
     runMatrixQaE2eeBootstrap.mockReset();
     runMatrixQaOpenClawCli.mockReset();
     startMatrixQaOpenClawCli.mockReset();
@@ -2058,7 +2071,7 @@ describe("matrix live qa scenarios", () => {
             accountId: "runtime-default",
             eventId: "$first-trigger",
             roomId: staleSyncRoomId,
-            stateRoot,
+            stateRoot: accountDir,
           });
         }
         return {

--- a/packages/gateway-protocol/src/schema/cron.ts
+++ b/packages/gateway-protocol/src/schema/cron.ts
@@ -125,6 +125,7 @@ const CronFailoverReasonSchema = Type.Union([
   Type.Literal("billing"),
   Type.Literal("server_error"),
   Type.Literal("timeout"),
+  Type.Literal("context_overflow"),
   Type.Literal("model_not_found"),
   Type.Literal("session_expired"),
   Type.Literal("empty_response"),

--- a/src/agents/agent-bundle-mcp-runtime.test.ts
+++ b/src/agents/agent-bundle-mcp-runtime.test.ts
@@ -46,7 +46,10 @@ async function writeListToolsMcpServer(params: {
   inputSchema?: unknown;
   tools?: Array<{ name: string; description?: string; inputSchema?: unknown }>;
   capabilities?: Record<string, unknown>;
+  pidPath?: string;
   notifyListChangedOnInitialized?: boolean;
+  notifyListChangedAfterFirstList?: boolean;
+  exitOnListCall?: number;
   listToolsMethodNotFound?: boolean;
   callToolIsError?: boolean;
   callToolJsonRpcError?: boolean;
@@ -62,7 +65,10 @@ const delayMs = ${params.delayMs ?? 0};
 const initializeDelayMs = ${params.initializeDelayMs ?? 0};
 const hang = ${params.hang === true};
 const capabilities = ${JSON.stringify(params.capabilities ?? { tools: {} })};
+const pidPath = ${JSON.stringify(params.pidPath)};
 const notifyListChangedOnInitialized = ${params.notifyListChangedOnInitialized === true};
+const notifyListChangedAfterFirstList = ${params.notifyListChangedAfterFirstList === true};
+const exitOnListCall = ${params.exitOnListCall ?? 0};
 const listToolsMethodNotFound = ${params.listToolsMethodNotFound === true};
 const tools = ${JSON.stringify(
       params.tools ?? [
@@ -78,8 +84,12 @@ const callToolJsonRpcError = ${params.callToolJsonRpcError === true};
 const resourceListJsonRpcError = ${params.resourceListJsonRpcError === true};
 
 let buffer = "";
+let listCount = 0;
 let pendingTimer;
 let keepAlive;
+if (pidPath) {
+  await fs.writeFile(pidPath, String(process.pid), "utf8");
+}
 function log(line) {
   void fs.appendFile(logPath, line + "\\n", "utf8").catch(() => {});
 }
@@ -116,6 +126,11 @@ function handle(message) {
     return;
   }
   if (message.method === "tools/list") {
+    listCount += 1;
+    if (listCount === exitOnListCall) {
+      log("exit tools/list " + listCount);
+      process.exit(1);
+    }
     if (listToolsMethodNotFound) {
       log("reject tools/list method not found");
       send({
@@ -130,6 +145,7 @@ function handle(message) {
       keepAlive = setInterval(() => {}, 1000);
       return;
     }
+    const currentListCount = listCount;
     log("delay tools/list " + delayMs);
     pendingTimer = setTimeout(() => {
       send({
@@ -139,6 +155,10 @@ function handle(message) {
           tools,
         },
       });
+      if (notifyListChangedAfterFirstList && currentListCount === 1) {
+        log("notify tools/list_changed");
+        send({ jsonrpc: "2.0", method: "notifications/tools/list_changed" });
+      }
     }, delayMs);
   }
   if (message.method === "tools/call") {
@@ -245,6 +265,29 @@ async function waitForPredicate(
     });
   }
   throw new Error(`Timed out waiting for ${description}`);
+}
+
+async function waitForErrorMessage(
+  action: () => Promise<unknown>,
+  expectedText: string,
+  timeoutMs: number,
+): Promise<string> {
+  const deadline = Date.now() + timeoutMs;
+  let lastMessage = "";
+  while (Date.now() < deadline) {
+    try {
+      await action();
+    } catch (error) {
+      lastMessage = error instanceof Error ? error.message : String(error);
+      if (lastMessage.includes(expectedText)) {
+        return lastMessage;
+      }
+    }
+    await new Promise((resolve) => {
+      setTimeout(resolve, 10);
+    });
+  }
+  throw new Error(`Timed out waiting for ${expectedText}; saw ${JSON.stringify(lastMessage)}`);
 }
 
 function makeRuntime(
@@ -1030,6 +1073,92 @@ process.on("SIGINT", shutdown);`,
 
       const result = await runtime.callTool("volatile", "ok_tool", {});
       expect(result.content[0]).toEqual({ type: "text", text: "still connected" });
+    } finally {
+      await runtime.dispose();
+      await fs.rm(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it("fails fast with an attributable error after an MCP child process exits", async () => {
+    const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "bundle-mcp-child-exit-"));
+    const serverPath = path.join(tempDir, "server.mjs");
+    const logPath = path.join(tempDir, "server.log");
+    const pidPath = path.join(tempDir, "server.pid");
+    await writeListToolsMcpServer({ filePath: serverPath, logPath, pidPath });
+
+    const runtime = await getOrCreateSessionMcpRuntime({
+      sessionId: "session-child-exit",
+      sessionKey: "agent:test:session-child-exit",
+      workspaceDir: "/workspace",
+      cfg: {
+        mcp: {
+          servers: {
+            child: { command: process.execPath, args: [serverPath] },
+          },
+        },
+      },
+    });
+
+    try {
+      await expect(runtime.callTool("child", "slow_tool", {})).resolves.toMatchObject({
+        isError: false,
+      });
+      await waitForFileText(pidPath, "", LIST_TOOLS_SERVER_LOG_TIMEOUT_MS);
+      const pid = Number.parseInt((await fs.readFile(pidPath, "utf8")).trim(), 10);
+      process.kill(pid);
+
+      const message = await waitForErrorMessage(
+        () => runtime.callTool("child", "slow_tool", {}),
+        "is disconnected",
+        LIST_TOOLS_SERVER_LOG_TIMEOUT_MS,
+      );
+      expect(message).toBe('bundle-mcp server "child" is disconnected: mcp transport closed');
+    } finally {
+      await runtime.dispose();
+      await fs.rm(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it("retires a reused MCP session that exits during catalog refresh", async () => {
+    const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "bundle-mcp-refresh-exit-"));
+    const serverPath = path.join(tempDir, "server.mjs");
+    const logPath = path.join(tempDir, "server.log");
+    await writeListToolsMcpServer({
+      filePath: serverPath,
+      logPath,
+      capabilities: { tools: { listChanged: true } },
+      notifyListChangedAfterFirstList: true,
+      exitOnListCall: 2,
+    });
+
+    const runtime = await getOrCreateSessionMcpRuntime({
+      sessionId: "session-refresh-exit",
+      sessionKey: "agent:test:session-refresh-exit",
+      workspaceDir: "/workspace",
+      cfg: {
+        mcp: {
+          servers: {
+            child: { command: process.execPath, args: [serverPath] },
+          },
+        },
+      },
+    });
+
+    try {
+      expect((await runtime.getCatalog()).tools).toHaveLength(1);
+      await waitForFileText(logPath, "notify tools/list_changed", LIST_TOOLS_SERVER_LOG_TIMEOUT_MS);
+      await waitForPredicate(
+        () => runtime.peekCatalog() === null,
+        "list_changed to invalidate the catalog",
+        LIST_TOOLS_SERVER_LOG_TIMEOUT_MS,
+      );
+
+      const refreshedCatalog = await runtime.getCatalog();
+      expect(refreshedCatalog.tools).toEqual([]);
+      expect(refreshedCatalog.diagnostics?.[0]?.serverName).toBe("child");
+      await expect(runtime.callTool("child", "slow_tool", {})).rejects.toThrow(
+        'bundle-mcp server "child" is not connected',
+      );
     } finally {
       await runtime.dispose();
       await fs.rm(tempDir, { recursive: true, force: true });

--- a/src/agents/agent-bundle-mcp-runtime.ts
+++ b/src/agents/agent-bundle-mcp-runtime.ts
@@ -45,6 +45,7 @@ type BundleMcpSession = {
   requestTimeoutMs: number;
   supportsParallelToolCalls: boolean;
   connected: boolean;
+  disconnectReason?: string;
   retiring: boolean;
   catalogUseCount: number;
   sharedAcrossCatalogGenerations: boolean;
@@ -542,6 +543,17 @@ export function createSessionMcpRuntime(params: {
       throw createDisposedError(params.sessionId);
     }
   };
+  const requireConnectedSession = (serverName: string): BundleMcpSession => {
+    const session = sessions.get(serverName);
+    if (!session || !session.connected) {
+      throw new Error(
+        session?.disconnectReason
+          ? `bundle-mcp server "${serverName}" is disconnected: ${session.disconnectReason}`
+          : `bundle-mcp server "${serverName}" is not connected`,
+      );
+    }
+    return session;
+  };
   const ensureSessionConnected = async (
     session: BundleMcpSession,
     connectionTimeoutMs: number,
@@ -640,6 +652,18 @@ export function createSessionMcpRuntime(params: {
               failIfDisposed();
 
               let session = sessions.get(serverName);
+              while (
+                session &&
+                !session.retiring &&
+                !session.connected &&
+                !session.connectPromise
+              ) {
+                // A closed SDK client cannot reconnect cleanly on the same transport.
+                await retireSessionIfCurrent(serverName, session);
+                // Retirement yields while closing. Preserve any replacement that a
+                // newer catalog generation installed during that await.
+                session = sessions.get(serverName);
+              }
               if (session?.retiring) {
                 session = undefined;
               }
@@ -670,7 +694,7 @@ export function createSessionMcpRuntime(params: {
                     },
                   },
                 );
-                session = {
+                const createdSession: BundleMcpSession = {
                   serverName,
                   client,
                   transport: resolved.transport,
@@ -683,6 +707,14 @@ export function createSessionMcpRuntime(params: {
                   sharedAcrossCatalogGenerations: false,
                   detachStderr: resolved.detachStderr,
                 };
+                // The SDK exposes lifecycle hooks as callback properties. A close is
+                // terminal for this client/transport pair.
+                // oxlint-disable-next-line unicorn/prefer-add-event-listener -- MCP Client is not an EventTarget.
+                client.onclose = () => {
+                  createdSession.connected = false;
+                  createdSession.disconnectReason = "mcp transport closed";
+                };
+                session = createdSession;
                 sessions.set(serverName, session);
               }
 
@@ -693,11 +725,9 @@ export function createSessionMcpRuntime(params: {
                 session.sharedAcrossCatalogGenerations = true;
               }
               session.catalogUseCount += 1;
-              let connectedForCatalog = false;
               try {
                 failIfDisposed();
                 await ensureSessionConnected(session, resolved.connectionTimeoutMs);
-                connectedForCatalog = true;
                 failIfDisposed();
                 const capabilities = summarizeServerCapabilities(
                   session.client.getServerCapabilities(),
@@ -782,9 +812,9 @@ export function createSessionMcpRuntime(params: {
                 ];
                 const sharedWithNewerGeneration =
                   session.sharedAcrossCatalogGenerations || session.catalogUseCount > 1;
-                if (!connectedForCatalog && !session.connected) {
-                  // Timed-out connects can still leave the SDK client bound to a
-                  // transport. Delete before async close so future catalogs start fresh.
+                if (!session.connected) {
+                  // A close is terminal for every catalog generation sharing this
+                  // session. The identity guard preserves any newer replacement.
                   await retireSessionIfCurrent(serverName, session);
                 } else if (!reusedSession && !sharedWithNewerGeneration) {
                   // Catalog invalidation can overlap generations; an older failed
@@ -894,10 +924,7 @@ export function createSessionMcpRuntime(params: {
     async callTool(serverName, toolName, input) {
       failIfDisposed();
       await getCatalog();
-      const session = sessions.get(serverName);
-      if (!session) {
-        throw new Error(`bundle-mcp server "${serverName}" is not connected`);
-      }
+      const session = requireConnectedSession(serverName);
       return await runGuardedServerRequest(
         serverName,
         async () =>
@@ -914,10 +941,7 @@ export function createSessionMcpRuntime(params: {
     async listResources(serverName) {
       failIfDisposed();
       await getCatalog();
-      const session = sessions.get(serverName);
-      if (!session) {
-        throw new Error(`bundle-mcp server "${serverName}" is not connected`);
-      }
+      const session = requireConnectedSession(serverName);
       return await runGuardedServerRequest(serverName, async () =>
         listAllResources(session.client, session.requestTimeoutMs),
       );
@@ -925,10 +949,7 @@ export function createSessionMcpRuntime(params: {
     async readResource(serverName, uri) {
       failIfDisposed();
       await getCatalog();
-      const session = sessions.get(serverName);
-      if (!session) {
-        throw new Error(`bundle-mcp server "${serverName}" is not connected`);
-      }
+      const session = requireConnectedSession(serverName);
       return await runGuardedServerRequest(
         serverName,
         async () =>
@@ -938,10 +959,7 @@ export function createSessionMcpRuntime(params: {
     async listPrompts(serverName) {
       failIfDisposed();
       await getCatalog();
-      const session = sessions.get(serverName);
-      if (!session) {
-        throw new Error(`bundle-mcp server "${serverName}" is not connected`);
-      }
+      const session = requireConnectedSession(serverName);
       return await runGuardedServerRequest(serverName, async () =>
         listAllPrompts(session.client, session.requestTimeoutMs),
       );
@@ -949,10 +967,7 @@ export function createSessionMcpRuntime(params: {
     async getPrompt(serverName, name, args) {
       failIfDisposed();
       await getCatalog();
-      const session = sessions.get(serverName);
-      if (!session) {
-        throw new Error(`bundle-mcp server "${serverName}" is not connected`);
-      }
+      const session = requireConnectedSession(serverName);
       return await runGuardedServerRequest(
         serverName,
         async () =>

--- a/src/agents/cli-runner.reliability.test.ts
+++ b/src/agents/cli-runner.reliability.test.ts
@@ -3,6 +3,7 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
 import { getReplyPayloadMetadata } from "../auto-reply/reply-payload.js";
 import {
   testing as replyRunTesting,
@@ -24,6 +25,7 @@ import {
 } from "../gateway/mcp-http.loopback-runtime.js";
 import { getGlobalHookRunner } from "../plugins/hook-runner-global.js";
 import type { getProcessSupervisor } from "../process/supervisor/index.js";
+import type { RunExit } from "../process/supervisor/types.js";
 import {
   createUserTurnTranscriptRecorder,
   type UserTurnTranscriptRecorder,
@@ -37,6 +39,7 @@ import {
   requestHeartbeatMock,
   supervisorSpawnMock,
 } from "./cli-runner.test-support.js";
+import { resetClaudeLiveSessionsForTest } from "./cli-runner/claude-live-session.js";
 import { executePreparedCliRun } from "./cli-runner/execute.js";
 import {
   resolveCliNoOutputTimeoutMs,
@@ -62,6 +65,7 @@ vi.mock("../tts/tts.js", () => ({
 const mockGetGlobalHookRunner = vi.mocked(getGlobalHookRunner);
 const mockAutoCapture = vi.mocked(runSkillResearchAutoCapture);
 const hookRunnerGlobalStateKey = Symbol.for("openclaw.plugins.hook-runner-global-state");
+const autoCleanupTempDirs = useAutoCleanupTempDirTracker();
 let sessionFileEnvSnapshot: ReturnType<typeof captureEnv> | undefined;
 
 type HookRunnerGlobalStateForTest = {
@@ -304,6 +308,7 @@ describe("runCliAgent reliability", () => {
     vi.unstubAllEnvs();
     sessionFileEnvSnapshot?.restore();
     sessionFileEnvSnapshot = undefined;
+    resetClaudeLiveSessionsForTest();
   });
 
   it("fails with timeout when no-output watchdog trips", async () => {
@@ -656,6 +661,67 @@ describe("runCliAgent reliability", () => {
     expect(result.messagingToolSentTargets).toEqual([
       expect.objectContaining({ tool: "message", provider: "telegram", to: "chat123" }),
     ]);
+    expect(result.meta.executionTrace?.attempts?.[0]?.result).toBe("error");
+    expect(result.meta.agentMeta?.clearCliSessionBinding).toBe(true);
+    expect(supervisorSpawnMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not retry context overflow after a confirmed message send", async () => {
+    supervisorSpawnMock.mockClear();
+    supervisorSpawnMock.mockImplementationOnce(async (...args: unknown[]) => {
+      const input = args[0] as Parameters<ReturnType<typeof getProcessSupervisor>["spawn"]>[0];
+      const captureHandle = markMcpLoopbackToolCallStarted({
+        captureKey: input.env?.OPENCLAW_MCP_CLI_CAPTURE_KEY ?? "",
+        toolName: "message",
+        args: {
+          action: "send",
+          channel: "telegram",
+          target: "chat123",
+          message: "sent before overflow",
+        },
+      });
+      if (!captureHandle) {
+        throw new Error("Expected message delivery capture");
+      }
+      recordMcpLoopbackToolCallResult({
+        captureHandle,
+        toolName: "message",
+        args: {
+          action: "send",
+          channel: "telegram",
+          target: "chat123",
+          message: "sent before overflow",
+        },
+        result: { status: "sent" },
+        isError: false,
+      });
+      markMcpLoopbackToolCallFinished(captureHandle);
+      return createManagedRun({
+        reason: "exit",
+        exitCode: 1,
+        exitSignal: null,
+        durationMs: 150,
+        stdout: "",
+        stderr: "Prompt is too long",
+        timedOut: false,
+        noOutputTimedOut: false,
+      });
+    });
+    const context = buildPreparedContext({
+      sessionKey: "agent:main:delivered-overflow",
+      runId: "run-delivered-overflow",
+      cliSessionId: "stale-cli-session",
+      provider: "claude-cli",
+      model: "opus",
+      openClawHistoryPrompt: CLI_RESEED_PROMPT,
+    });
+    context.mcpDeliveryCapture = true;
+
+    const result = await runPreparedCliAgent(context);
+
+    expect(result.payloads).toBeUndefined();
+    expect(result.didSendViaMessagingTool).toBe(true);
+    expect(result.messagingToolSentTexts).toEqual(["sent before overflow"]);
     expect(result.meta.executionTrace?.attempts?.[0]?.result).toBe("error");
     expect(result.meta.agentMeta?.clearCliSessionBinding).toBe(true);
     expect(supervisorSpawnMock).toHaveBeenCalledTimes(1);
@@ -1390,6 +1456,211 @@ describe("runCliAgent reliability", () => {
     expect(clearBeforeRetry).not.toHaveBeenCalled();
   });
 
+  it("does not fresh retry context overflow when the run timeout budget is exhausted", async () => {
+    supervisorSpawnMock.mockClear();
+    const clearBeforeRetry = vi.fn(async () => true);
+    supervisorSpawnMock.mockResolvedValueOnce(
+      createManagedRun({
+        reason: "exit",
+        exitCode: 1,
+        exitSignal: null,
+        durationMs: 150,
+        stdout: "",
+        stderr: "Prompt is too long",
+        timedOut: false,
+        noOutputTimedOut: false,
+      }),
+    );
+    const context = buildPreparedContext({
+      sessionKey: "agent:main:expired-overflow-budget",
+      runId: "run-expired-overflow-budget",
+      cliSessionId: "stale-cli-session",
+      provider: "claude-cli",
+      model: "opus",
+      openClawHistoryPrompt: CLI_RESEED_PROMPT,
+    });
+    const expiredBudgetContext = {
+      ...context,
+      started: Date.now() - context.params.timeoutMs - 1,
+    };
+
+    await expect(
+      runPreparedCliAgent({
+        ...expiredBudgetContext,
+        params: {
+          ...expiredBudgetContext.params,
+          onBeforeFreshCliSessionRetry: clearBeforeRetry,
+        },
+      }),
+    ).rejects.toThrow("Prompt is too long");
+
+    expect(supervisorSpawnMock).toHaveBeenCalledTimes(1);
+    expect(clearBeforeRetry).not.toHaveBeenCalled();
+  });
+
+  it("keeps non-capture live-session artifacts through fresh recovery retry", async () => {
+    supervisorSpawnMock.mockClear();
+    const artifactDir = autoCleanupTempDirs.make("openclaw-live-retry-artifacts-");
+    const mcpConfigPath = path.join(artifactDir, "mcp.json");
+    const skillsDir = path.join(artifactDir, "skills-plugin");
+    fs.writeFileSync(mcpConfigPath, "{}\n", "utf-8");
+    fs.mkdirSync(skillsDir);
+
+    const resolveArg = (argv: string[] | undefined, flag: string) => {
+      const index = argv?.indexOf(flag) ?? -1;
+      if (index < 0) {
+        throw new Error(`expected ${flag}`);
+      }
+      const value = argv?.[index + 1];
+      if (!value) {
+        throw new Error(`expected value after ${flag}`);
+      }
+      return value;
+    };
+
+    let notifyFirstSpawn: (() => void) | undefined;
+    const firstSpawned = new Promise<void>((resolve) => {
+      notifyFirstSpawn = resolve;
+    });
+    let spawnCount = 0;
+    supervisorSpawnMock.mockImplementation(async (...args: unknown[]) => {
+      spawnCount += 1;
+      const input = args[0] as {
+        argv?: string[];
+        onStdout?: (chunk: string) => void;
+      };
+      expect(resolveArg(input.argv, "--mcp-config")).toBe(mcpConfigPath);
+      expect(resolveArg(input.argv, "--skills-plugin-dir")).toBe(skillsDir);
+      expect(fs.existsSync(mcpConfigPath)).toBe(true);
+      expect(fs.existsSync(skillsDir)).toBe(true);
+
+      if (spawnCount === 1) {
+        notifyFirstSpawn?.();
+        let resolveExit: ((value: RunExit) => void) | undefined;
+        const exited = new Promise<RunExit>((resolve) => {
+          resolveExit = resolve;
+        });
+        return {
+          runId: "live-retry-timeout",
+          pid: 3301,
+          startedAtMs: Date.now(),
+          stdin: {
+            write: vi.fn((dataValue: string, cb?: (err?: Error | null) => void) => cb?.()),
+            end: vi.fn(),
+          },
+          wait: vi.fn(() => exited),
+          cancel: vi.fn(() =>
+            resolveExit?.({
+              reason: "manual-cancel",
+              exitCode: null,
+              exitSignal: null,
+              durationMs: 1,
+              stdout: "",
+              stderr: "",
+              timedOut: false,
+              noOutputTimedOut: false,
+            }),
+          ),
+        };
+      }
+
+      const stdoutListener = input.onStdout;
+      return {
+        runId: "live-retry-fresh",
+        pid: 3302,
+        startedAtMs: Date.now(),
+        stdin: {
+          write: vi.fn((dataValue: string, cb?: (err?: Error | null) => void) => {
+            stdoutListener?.(
+              [
+                JSON.stringify({ type: "system", subtype: "init", session_id: "fresh-live" }),
+                JSON.stringify({ type: "result", session_id: "fresh-live", result: "fresh ok" }),
+              ].join("\n") + "\n",
+            );
+            cb?.();
+          }),
+          end: vi.fn(),
+        },
+        wait: vi.fn(() => new Promise(() => {})),
+        cancel: vi.fn(),
+      };
+    });
+
+    const liveBackend = {
+      command: "claude",
+      args: [
+        "-p",
+        "--output-format",
+        "stream-json",
+        "--mcp-config",
+        mcpConfigPath,
+        "--skills-plugin-dir",
+        skillsDir,
+      ],
+      resumeArgs: [
+        "-p",
+        "--resume",
+        "{sessionId}",
+        "--output-format",
+        "stream-json",
+        "--mcp-config",
+        mcpConfigPath,
+        "--skills-plugin-dir",
+        skillsDir,
+      ],
+      output: "jsonl" as const,
+      input: "stdin" as const,
+      modelArg: "--model",
+      sessionArg: "--session-id",
+      sessionMode: "always" as const,
+      liveSession: "claude-stdio" as const,
+      reliability: {
+        watchdog: {
+          resume: { noOutputTimeoutMs: 1_000, minMs: 1_000, maxMs: 1_000 },
+          fresh: { noOutputTimeoutMs: 1_000, minMs: 1_000, maxMs: 1_000 },
+        },
+      },
+      serialize: true,
+    };
+    const cleanup = vi.fn(async () => {
+      fs.rmSync(artifactDir, { recursive: true, force: true });
+    });
+    const clearBeforeRetry = vi.fn(async () => true);
+    const context = buildPreparedContext({
+      sessionKey: "agent:main:live-artifacts",
+      runId: "run-live-artifact-retry",
+      cliSessionId: "stale-live",
+      provider: "claude-cli",
+      model: "opus",
+      openClawHistoryPrompt: CLI_RESEED_PROMPT,
+    });
+    context.preparedBackend.backend = liveBackend;
+    context.preparedBackend.cleanup = cleanup;
+    context.backendResolved.config = liveBackend;
+
+    const resultPromise = runPreparedCliAgent({
+      ...context,
+      params: {
+        ...context.params,
+        timeoutMs: 5_000,
+        onBeforeFreshCliSessionRetry: clearBeforeRetry,
+      },
+    });
+    await firstSpawned;
+    const result = await resultPromise;
+
+    expect(result.payloads).toEqual([{ text: "fresh ok" }]);
+    expect(result.meta.finalPromptText).toContain("User: earlier context");
+    expect(supervisorSpawnMock).toHaveBeenCalledTimes(2);
+    expect(clearBeforeRetry).toHaveBeenCalledWith({
+      provider: "claude-cli",
+      reason: "timeout",
+      sessionId: "stale-live",
+    });
+    expect(cleanup).toHaveBeenCalledOnce();
+    expect(fs.existsSync(artifactDir)).toBe(false);
+  });
+
   it("does not fresh retry a no-output timeout after CLI diagnostic output", async () => {
     supervisorSpawnMock.mockClear();
     enqueueSystemEventMock.mockClear();
@@ -1468,7 +1739,7 @@ describe("runCliAgent reliability", () => {
     expect(clearBeforeRetry).not.toHaveBeenCalled();
   });
 
-  it.each(["timeout", "unknown"] as const)(
+  it.each(["timeout", "unknown", "context_overflow"] as const)(
     "retries a fresh CLI session after recoverable %s failover without a failed agent_end",
     async (reason) => {
       const hookRunner = {
@@ -1498,6 +1769,18 @@ describe("runCliAgent reliability", () => {
             stderr: "",
             timedOut: true,
             noOutputTimedOut: true,
+          });
+        }
+        if (spawnCount === 1 && reason === "context_overflow") {
+          return createManagedRun({
+            reason: "exit",
+            exitCode: 1,
+            exitSignal: null,
+            durationMs: 150,
+            stdout: "",
+            stderr: "Prompt is too long",
+            timedOut: false,
+            noOutputTimedOut: false,
           });
         }
         if (spawnCount === 1) {
@@ -1552,6 +1835,8 @@ describe("runCliAgent reliability", () => {
         });
 
         expect(result.payloads).toEqual([{ text: "hello from fresh cli" }]);
+        expect(result.meta.finalPromptText).toContain("User: earlier context");
+        expect(result.meta.finalPromptText).toContain("<next_user_message>");
         expect(supervisorSpawnMock).toHaveBeenCalledTimes(2);
         expect(events).toEqual(["spawn-1", `clear-${reason}`, "spawn-2"]);
         if (reason === "timeout") {

--- a/src/agents/cli-runner.spawn.test.ts
+++ b/src/agents/cli-runner.spawn.test.ts
@@ -1178,7 +1178,7 @@ describe("runCliAgent spawn path", () => {
     }
   });
 
-  it("defers prepared backend cleanup to the Claude live session lifecycle", async () => {
+  it("keeps non-capture live prepared backend cleanup with the whole-run owner", async () => {
     let stdoutListener: ((chunk: string) => void) | undefined;
     const stdin = {
       write: vi.fn((dataValue: string, cb?: (err?: Error | null) => void) => {
@@ -1225,11 +1225,13 @@ describe("runCliAgent spawn path", () => {
     const result = await executePreparedCliRun(context);
 
     expect(result.text).toBe("ok");
-    expect(context.preparedBackend.cleanup).toBeUndefined();
+    expect(context.preparedBackend.cleanup).toBe(preparedBackendCleanup);
     expect(preparedBackendCleanup).not.toHaveBeenCalled();
 
     resetClaudeLiveSessionsForTest();
-    await vi.waitFor(() => expect(preparedBackendCleanup).toHaveBeenCalledOnce());
+    expect(preparedBackendCleanup).not.toHaveBeenCalled();
+    await context.preparedBackend.cleanup?.();
+    expect(preparedBackendCleanup).toHaveBeenCalledOnce();
   });
 
   it("keeps captured live prepared backend cleanup with the whole-run owner", async () => {
@@ -3003,6 +3005,64 @@ ${JSON.stringify({
     );
   });
 
+  it("marks Claude live stderr context overflows as retryable", async () => {
+    let stdoutListener: ((chunk: string) => void) | undefined;
+    let resolveExit: ((exit: RunExit) => void) | undefined;
+    const exited = new Promise<RunExit>((resolve) => {
+      resolveExit = resolve;
+    });
+    const stdin = {
+      write: vi.fn((dataValue: string, cb?: (err?: Error | null) => void) => {
+        stdoutListener?.(
+          JSON.stringify({ type: "system", subtype: "init", session_id: "live-overflow" }) + "\n",
+        );
+        cb?.();
+        resolveExit?.({
+          reason: "exit",
+          exitCode: 1,
+          exitSignal: null,
+          durationMs: 1,
+          stdout: "",
+          stderr: "Prompt is too long",
+          timedOut: false,
+          noOutputTimedOut: false,
+        });
+      }),
+      end: vi.fn(),
+    };
+    supervisorSpawnMock.mockImplementationOnce(async (...args: unknown[]) => {
+      const input = (args[0] ?? {}) as { onStdout?: (chunk: string) => void };
+      stdoutListener = input.onStdout;
+      return {
+        runId: "live-overflow-run",
+        pid: 2345,
+        startedAtMs: Date.now(),
+        stdin,
+        wait: vi.fn(() => exited),
+        cancel: vi.fn(),
+      };
+    });
+
+    await expectRejectsWithFields(
+      executePreparedCliRun(
+        buildPreparedCliRunContext({
+          provider: "claude-cli",
+          model: "sonnet",
+          runId: "run-live-overflow",
+          backend: {
+            liveSession: "claude-stdio",
+          },
+        }),
+      ),
+      {
+        name: "FailoverError",
+        reason: "context_overflow",
+        code: "cli_context_overflow",
+        status: 413,
+      },
+    );
+  });
+
   it("fails when Claude exits before a live turn starts", async () => {
     supervisorSpawnMock.mockImplementationOnce(async () => ({
       runId: "live-run",
@@ -3137,6 +3197,77 @@ ${JSON.stringify({
 
     expect(second.text).toBe("second-ok");
     expect(supervisorSpawnMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("fails Claude live turns without unhandled rejection when stdin write is stuck", async () => {
+    vi.useFakeTimers();
+    const unhandledRejections: unknown[] = [];
+    const onUnhandledRejection = (reason: unknown) => {
+      unhandledRejections.push(reason);
+    };
+    process.on("unhandledRejection", onUnhandledRejection);
+    const cancel = vi.fn();
+    let pendingWriteCallback: ((err?: Error | null) => void) | undefined;
+    const stdin = {
+      write: vi.fn((dataValue: string, cb?: (err?: Error | null) => void) => {
+        pendingWriteCallback = cb;
+      }),
+      end: vi.fn(),
+    };
+    supervisorSpawnMock.mockImplementationOnce(async () => ({
+      runId: "live-run-stuck-stdin",
+      pid: 2345,
+      startedAtMs: Date.now(),
+      stdin,
+      wait: vi.fn(() => new Promise(() => {})),
+      cancel: vi.fn((reason: string) => {
+        cancel(reason);
+        pendingWriteCallback?.(new Error("stdin closed"));
+      }),
+    }));
+
+    try {
+      const context = buildPreparedCliRunContext({
+        provider: "claude-cli",
+        model: "sonnet",
+        runId: "run-live-stuck-stdin",
+        timeoutMs: 10_000,
+        backend: {
+          liveSession: "claude-stdio",
+        },
+      });
+      const run = runClaudeLiveSessionTurn({
+        context,
+        args: context.preparedBackend.backend.args ?? [],
+        env: {},
+        prompt: "stuck write",
+        useResume: false,
+        noOutputTimeoutMs: 1_000,
+        getProcessSupervisor: () => ({
+          spawn: (params: Parameters<SupervisorSpawnFn>[0]) =>
+            supervisorSpawnMock(params) as ReturnType<SupervisorSpawnFn>,
+          cancel: vi.fn(),
+          cancelScope: vi.fn(),
+          getRecord: vi.fn(),
+        }),
+        onAssistantDelta: () => {},
+        cleanup: async () => {},
+      });
+      const runExpectation = expectRejectsWithFields(run, {
+        name: "FailoverError",
+        message: "CLI produced no output for 1s and was terminated.",
+      });
+
+      await vi.advanceTimersByTimeAsync(1_000);
+
+      await runExpectation;
+      await Promise.resolve();
+      expect(unhandledRejections).toEqual([]);
+      expect(cancel).toHaveBeenCalledWith("manual-cancel");
+      expect(stdin.write).toHaveBeenCalledOnce();
+    } finally {
+      process.off("unhandledRejection", onUnhandledRejection);
+    }
   });
 
   it("restarts Claude live sessions when selected skills change", async () => {

--- a/src/agents/cli-runner.ts
+++ b/src/agents/cli-runner.ts
@@ -100,6 +100,8 @@ function shouldRetryFreshCliSessionAfterFailover(params: {
       return params.error.code === "cli_unknown_empty_failure";
     case "timeout":
       return params.error.code === "cli_no_output_timeout";
+    case "context_overflow":
+      return params.error.code === "cli_context_overflow";
     default:
       return false;
   }

--- a/src/agents/cli-runner/claude-live-session.ts
+++ b/src/agents/cli-runner/claude-live-session.ts
@@ -833,11 +833,13 @@ function createResultError(
   const result = typeof parsed.result === "string" ? parsed.result.trim() : "";
   const message = extractCliErrorMessage(raw) ?? (result || "Claude CLI failed.");
   const reason = classifyFailoverReason(message, { provider: session.providerId }) ?? "unknown";
+  const code = reason === "context_overflow" ? "cli_context_overflow" : undefined;
   return new FailoverError(message, {
     reason,
     provider: session.providerId,
     model: session.modelId,
     status: resolveFailoverStatus(reason),
+    code,
   });
 }
 
@@ -1012,6 +1014,7 @@ function handleClaudeExit(session: ClaudeLiveSession, exitCode: number | null): 
     return;
   }
   const reason = classifyFailoverReason(message, { provider: session.providerId }) ?? "unknown";
+  const code = reason === "context_overflow" ? "cli_context_overflow" : undefined;
   failTurn(
     session,
     new FailoverError(message, {
@@ -1019,6 +1022,7 @@ function handleClaudeExit(session: ClaudeLiveSession, exitCode: number | null): 
       provider: session.providerId,
       model: session.modelId,
       status: resolveFailoverStatus(reason),
+      code,
     }),
   );
 }
@@ -1376,6 +1380,9 @@ export async function runClaudeLiveSessionTurn(params: {
       reject,
     });
   });
+  // Timeout/abort can reject the turn while stdin is backpressured. Keep the
+  // rejection handled until the final await below rethrows the canonical result.
+  void outputPromise.catch(() => undefined);
   const abort = () => abortTurn(liveSession, createAbortError());
   let replyBackendCompleted = false;
   const replyBackendHandle: ReplyBackendHandle | undefined = params.context.params.replyOperation
@@ -1394,7 +1401,7 @@ export async function runClaudeLiveSessionTurn(params: {
       abort();
     } else {
       try {
-        await writeTurnInput(liveSession, params.prompt);
+        await Promise.race([writeTurnInput(liveSession, params.prompt), outputPromise]);
       } catch (error) {
         closeLiveSession(liveSession, "abort", error);
       }

--- a/src/agents/cli-runner/execute.ts
+++ b/src/agents/cli-runner/execute.ts
@@ -1026,14 +1026,7 @@ export async function executePreparedCliRun(
             model: context.modelId,
             backend: context.backendResolved.id,
           });
-          const liveSessionOwnsRunArtifacts = context.mcpDeliveryCapture !== true;
-          fallbackClaudeSkillsPluginCleanupOwned = liveSessionOwnsRunArtifacts;
-          const ownedPreparedBackendCleanup = liveSessionOwnsRunArtifacts
-            ? context.preparedBackend.cleanup
-            : undefined;
-          if (liveSessionOwnsRunArtifacts) {
-            context.preparedBackend.cleanup = undefined;
-          }
+          fallbackClaudeSkillsPluginCleanupOwned = fallbackClaudeSkillsPlugin !== undefined;
           const liveResult = await runClaudeLiveSessionTurn({
             context,
             args,
@@ -1050,15 +1043,9 @@ export async function executePreparedCliRun(
                 ? emitCliCommentaryText
                 : undefined,
             onMcpCaptureReady: beginGatewayCapture,
-            cleanup: liveSessionOwnsRunArtifacts
-              ? async () => {
-                  try {
-                    await fallbackClaudeSkillsPlugin?.cleanup();
-                  } finally {
-                    await ownedPreparedBackendCleanup?.();
-                  }
-                }
-              : async () => {},
+            cleanup: async () => {
+              await fallbackClaudeSkillsPlugin?.cleanup();
+            },
           });
           const rawText = liveResult.output.text;
           runOutput = {
@@ -1300,12 +1287,14 @@ export async function executePreparedCliRun(
             reason = reason ?? "unknown";
             const status = resolveFailoverStatus(reason);
             const retryCode =
-              reason === "unknown" &&
-              result.reason === "exit" &&
-              errorCandidates.length === 0 &&
-              !observedCliActivity
-                ? "cli_unknown_empty_failure"
-                : undefined;
+              reason === "context_overflow"
+                ? "cli_context_overflow"
+                : reason === "unknown" &&
+                    result.reason === "exit" &&
+                    errorCandidates.length === 0 &&
+                    !observedCliActivity
+                  ? "cli_unknown_empty_failure"
+                  : undefined;
             throw new FailoverError(err, {
               reason,
               provider: params.provider,

--- a/src/agents/cli-runner/session-history.test.ts
+++ b/src/agents/cli-runner/session-history.test.ts
@@ -75,11 +75,11 @@ function requireRecord(value: unknown, label: string): Record<string, unknown> {
   return value as Record<string, unknown>;
 }
 
-function expectMessageFields(value: unknown, expected: { role: string; content?: string }) {
+function expectMessageFields(value: unknown, expected: { role: string; content?: unknown }) {
   const message = requireRecord(value, "message");
   expect(message.role).toBe(expected.role);
   if ("content" in expected) {
-    expect(message.content).toBe(expected.content);
+    expect(message.content).toEqual(expected.content);
   }
 }
 
@@ -256,7 +256,10 @@ describe("loadCliSessionHistoryMessages", () => {
         });
         expect(history).toHaveLength(2);
         expectMessageFields(history[0], { role: "user", content: "active root" });
-        expectMessageFields(history[1], { role: "assistant", content: "active tail" });
+        expectMessageFields(history[1], {
+          role: "assistant",
+          content: [{ type: "text", text: "active tail" }],
+        });
       });
     } finally {
       fs.rmSync(stateDir, { recursive: true, force: true });
@@ -369,7 +372,10 @@ describe("loadCliSessionHistoryMessages", () => {
           content: "tail custom context",
         });
         expectBranchSummary(history[2], "tail branch context");
-        expectMessageFields(history[3], { role: "assistant", content: "tail answer" });
+        expectMessageFields(history[3], {
+          role: "assistant",
+          content: [{ type: "text", text: "tail answer" }],
+        });
       });
     } finally {
       fs.rmSync(stateDir, { recursive: true, force: true });

--- a/src/agents/custom-api-registry.test.ts
+++ b/src/agents/custom-api-registry.test.ts
@@ -12,6 +12,7 @@ import {
 } from "../llm/providers/register-builtins.js";
 import { createAssistantMessageEventStream } from "../llm/utils/event-stream.js";
 import { ensureCustomApiRegistered } from "./custom-api-registry.js";
+import { buildAssistantMessageWithZeroUsage } from "./stream-message-shared.js";
 
 function getRegisteredTestProvider() {
   const provider = getApiProvider("test-custom-api");
@@ -54,6 +55,50 @@ describe("ensureCustomApiRegistered", () => {
     expect(provider.stream(model as never, context as never, options as never)).toBe(stream);
     expect(provider.streamSimple(model as never, context as never, options as never)).toBe(stream);
     expect(streamFn).toHaveBeenCalledTimes(2);
+  });
+
+  it("adapts async stream factories to the synchronous provider contract", async () => {
+    const message = buildAssistantMessageWithZeroUsage({
+      model: { api: "test-custom-api", provider: "custom", id: "m" },
+      content: [{ type: "text", text: "done" }],
+      stopReason: "stop",
+    });
+    const streamFn = vi.fn(async () => {
+      await Promise.resolve();
+      const stream = createAssistantMessageEventStream();
+      stream.push({ type: "done", reason: "stop", message });
+      return stream;
+    });
+    ensureCustomApiRegistered("test-custom-api", streamFn);
+
+    const provider = getRegisteredTestProvider();
+    const stream = provider.stream(
+      { api: "test-custom-api", provider: "custom", id: "m" },
+      { messages: [] },
+      {},
+    );
+
+    expect(stream).not.toBeInstanceOf(Promise);
+    await expect(stream.result()).resolves.toBe(message);
+  });
+
+  it("converts async stream factory failures into terminal stream errors", async () => {
+    const streamFn = vi.fn(async () => {
+      throw new Error("factory failed");
+    });
+    ensureCustomApiRegistered("test-custom-api", streamFn);
+
+    const provider = getRegisteredTestProvider();
+    const stream = provider.stream(
+      { api: "test-custom-api", provider: "custom", id: "m" },
+      { messages: [] },
+      {},
+    );
+
+    await expect(stream.result()).resolves.toMatchObject({
+      stopReason: "error",
+      errorMessage: "factory failed",
+    });
   });
 
   it("keeps plugin api providers when refreshing built-ins", () => {

--- a/src/agents/custom-api-registry.test.ts
+++ b/src/agents/custom-api-registry.test.ts
@@ -73,7 +73,7 @@ describe("ensureCustomApiRegistered", () => {
 
     const provider = getRegisteredTestProvider();
     const stream = provider.stream(
-      { api: "test-custom-api", provider: "custom", id: "m" },
+      { api: "test-custom-api", provider: "custom", id: "m" } as never,
       { messages: [] },
       {},
     );
@@ -90,7 +90,7 @@ describe("ensureCustomApiRegistered", () => {
 
     const provider = getRegisteredTestProvider();
     const stream = provider.stream(
-      { api: "test-custom-api", provider: "custom", id: "m" },
+      { api: "test-custom-api", provider: "custom", id: "m" } as never,
       { messages: [] },
       {},
     );

--- a/src/agents/custom-api-registry.ts
+++ b/src/agents/custom-api-registry.ts
@@ -2,14 +2,48 @@
  * Registers caller-supplied custom API stream functions with the LLM registry.
  */
 import { getApiProvider, registerApiProvider } from "../llm/api-registry.js";
-import type { Api, StreamOptions } from "../llm/types.js";
+import type {
+  Api,
+  AssistantMessageEventStreamContract,
+  Model,
+  StreamOptions,
+} from "../llm/types.js";
+import { createAssistantMessageEventStream } from "../llm/utils/event-stream.js";
 import type { StreamFn } from "./runtime/index.js";
+import { buildStreamErrorAssistantMessage } from "./stream-message-shared.js";
 
 const CUSTOM_API_SOURCE_PREFIX = "openclaw-custom-api:";
 
 /** Returns the registry source id used for a custom API stream function. */
 function getCustomApiRegistrySourceId(api: Api): string {
   return `${CUSTOM_API_SOURCE_PREFIX}${api}`;
+}
+
+function adaptCustomStream(
+  model: Model,
+  stream: ReturnType<StreamFn>,
+): AssistantMessageEventStreamContract {
+  if (!(stream instanceof Promise)) {
+    return stream as AssistantMessageEventStreamContract;
+  }
+
+  const adapted = createAssistantMessageEventStream();
+  void (async () => {
+    try {
+      // Registry providers must return a stream immediately, while plugin
+      // hooks may resolve one lazily. Bridge that lifecycle at the boundary.
+      const resolved = await stream;
+      for await (const event of resolved) {
+        adapted.push(event);
+      }
+      adapted.end(await resolved.result());
+    } catch (error) {
+      const errorMessage = error instanceof Error ? error.message : String(error);
+      const message = buildStreamErrorAssistantMessage({ model, errorMessage });
+      adapted.push({ type: "error", reason: "error", error: message });
+    }
+  })();
+  return adapted;
 }
 
 /** Registers a custom API stream function when no provider already owns it. */
@@ -22,13 +56,9 @@ export function ensureCustomApiRegistered(api: Api, streamFn: StreamFn): boolean
     {
       api,
       stream: (model, context, options) =>
-        streamFn(model, context, options) as unknown as ReturnType<
-          NonNullable<ReturnType<typeof getApiProvider>>["stream"]
-        >,
+        adaptCustomStream(model, streamFn(model, context, options)),
       streamSimple: (model, context, options) =>
-        streamFn(model, context, options as StreamOptions) as unknown as ReturnType<
-          NonNullable<ReturnType<typeof getApiProvider>>["stream"]
-        >,
+        adaptCustomStream(model, streamFn(model, context, options as StreamOptions)),
     },
     getCustomApiRegistrySourceId(api),
   );

--- a/src/agents/embedded-agent-helpers.isbillingerrormessage.test.ts
+++ b/src/agents/embedded-agent-helpers.isbillingerrormessage.test.ts
@@ -611,6 +611,12 @@ describe("extractObservedOverflowTokenCount", () => {
   });
 });
 
+describe("classifyFailoverReason context overflow", () => {
+  it("maps prompt overflow to the closed failover reason", () => {
+    expect(classifyFailoverReason("Prompt is too long")).toBe("context_overflow");
+  });
+});
+
 describe("isTransientHttpError", () => {
   it("returns true for retryable 5xx status codes", () => {
     expect(isTransientHttpError("499 Client Closed Request")).toBe(true);
@@ -671,13 +677,13 @@ describe("classifyFailoverReasonFromHttpStatus", () => {
     ).toBe("rate_limit");
   });
 
-  it("does not force HTTP 400 context-overflow payloads into format", () => {
+  it("classifies HTTP 400 context-overflow payloads without using format", () => {
     expect(
       classifyFailoverReasonFromHttpStatus(
         400,
         "INVALID_ARGUMENT: input exceeds the maximum number of tokens",
       ),
-    ).toBeNull();
+    ).toBe("context_overflow");
   });
 
   it("lets OpenRouter billing-classified HTTP 401 responses bypass generic auth", () => {
@@ -803,12 +809,12 @@ describe("classifyFailoverReason HTTP 410 handling", () => {
     expect(classifyFailoverReason("HTTP 404: insufficient credits")).toBe("billing");
   });
 
-  it("does not map HTTP 404 plus context-overflow text to model_not_found", () => {
+  it("maps HTTP 404 plus context-overflow text to context_overflow", () => {
     expect(
       classifyFailoverReason(
         "HTTP 404: INVALID_ARGUMENT: input exceeds the maximum number of tokens",
       ),
-    ).toBeNull();
+    ).toBe("context_overflow");
   });
 
   it("keeps raw HTTP 400 wrappers aligned with structured provider classification", () => {
@@ -819,7 +825,7 @@ describe("classifyFailoverReason HTTP 410 handling", () => {
       classifyFailoverReason(
         "HTTP 400: INVALID_ARGUMENT: input exceeds the maximum number of tokens",
       ),
-    ).toBeNull();
+    ).toBe("context_overflow");
   });
 
   it("classifies OpenAI Responses unknown-no-details message distinctly", () => {

--- a/src/agents/embedded-agent-helpers/errors.ts
+++ b/src/agents/embedded-agent-helpers/errors.ts
@@ -731,7 +731,10 @@ function toReasonClassification(reason: FailoverReason): FailoverClassification 
 function failoverReasonFromClassification(
   classification: FailoverClassification | null,
 ): FailoverReason | null {
-  return classification?.kind === "reason" ? classification.reason : null;
+  if (!classification) {
+    return null;
+  }
+  return classification.kind === "reason" ? classification.reason : "context_overflow";
 }
 
 export function isTransientHttpError(raw: string): boolean {

--- a/src/agents/embedded-agent-helpers/types.ts
+++ b/src/agents/embedded-agent-helpers/types.ts
@@ -11,6 +11,7 @@ export type FailoverReason =
   | "billing"
   | "server_error"
   | "timeout"
+  | "context_overflow"
   | "model_not_found"
   | "session_expired"
   | "empty_response"

--- a/src/agents/embedded-agent-runner/run/auth-profile-failure-policy.ts
+++ b/src/agents/embedded-agent-runner/run/auth-profile-failure-policy.ts
@@ -34,6 +34,7 @@ export function resolveAuthProfileFailureReason(params: {
         (params.failoverReason === "rate_limit" && params.transientRateLimit === true))) ||
     params.failoverReason === "server_error" ||
     params.failoverReason === "empty_response" ||
+    params.failoverReason === "context_overflow" ||
     params.failoverReason === "format"
   ) {
     return null;

--- a/src/agents/embedded-agent-runner/transcript-file-state.test.ts
+++ b/src/agents/embedded-agent-runner/transcript-file-state.test.ts
@@ -192,7 +192,7 @@ describe("readTranscriptFileState", () => {
     expect(state.getEntries().map((entry) => entry.id)).toEqual(["user-1", "assistant-string"]);
     expect(state.buildSessionContext().messages).toMatchObject([
       { role: "user", content: "prompt" },
-      { role: "assistant", content: "legacy reply" },
+      { role: "assistant", content: [{ type: "text", text: "legacy reply" }] },
     ]);
   });
 
@@ -1185,7 +1185,7 @@ describe("readTranscriptFileState", () => {
 
     expect(state.buildSessionContext().messages).toMatchObject([
       { role: "user", content: "rewritten question" },
-      { role: "assistant", content: "answer" },
+      { role: "assistant", content: [{ type: "text", text: "answer" }] },
     ]);
   });
 

--- a/src/agents/failover-error.test.ts
+++ b/src/agents/failover-error.test.ts
@@ -607,13 +607,13 @@ describe("failover-error", () => {
     ).toBe("rate_limit");
   });
 
-  it("does not misclassify structured HTTP 400 context overflow payloads as format", () => {
+  it("classifies structured HTTP 400 context overflow payloads without using format", () => {
     expect(
       resolveFailoverReasonFromError({
         status: 400,
         message: "INVALID_ARGUMENT: input exceeds the maximum number of tokens",
       }),
-    ).toBeNull();
+    ).toBe("context_overflow");
   });
 
   it("keeps context overflow first-class in the shared signal classifier", () => {

--- a/src/agents/failover-error.ts
+++ b/src/agents/failover-error.ts
@@ -107,6 +107,8 @@ export function resolveFailoverStatus(reason: FailoverReason): number | undefine
       return 403;
     case "timeout":
       return 408;
+    case "context_overflow":
+      return 413;
     case "format":
       return 400;
     case "model_not_found":
@@ -461,7 +463,10 @@ export function isSignalTimeoutReason(reason: unknown): boolean {
 function failoverReasonFromClassification(
   classification: FailoverClassification | null,
 ): FailoverReason | null {
-  return classification?.kind === "reason" ? classification.reason : null;
+  if (!classification) {
+    return null;
+  }
+  return classification.kind === "reason" ? classification.reason : "context_overflow";
 }
 
 function normalizeErrorSignal(err: unknown, providerHint?: string): FailoverSignal {

--- a/src/agents/runtime-plan/types.ts
+++ b/src/agents/runtime-plan/types.ts
@@ -41,6 +41,7 @@ export type AgentRuntimeFailoverReason =
   | "billing"
   | "server_error"
   | "timeout"
+  | "context_overflow"
   | "model_not_found"
   | "session_expired"
   | "empty_response"

--- a/src/agents/sessions/session-manager.test.ts
+++ b/src/agents/sessions/session-manager.test.ts
@@ -58,6 +58,10 @@ describe("SessionManager.open", () => {
       timestamp: "2026-05-27T00:00:02.000Z",
       message: { role: "assistant", content: "important answer" },
     };
+    const normalizedAssistantEntry = {
+      ...assistantEntry,
+      message: { role: "assistant", content: [{ type: "text", text: "important answer" }] },
+    };
     const originalTranscript =
       [
         JSON.stringify(originalHeader).slice(0, 30),
@@ -71,8 +75,8 @@ describe("SessionManager.open", () => {
 
     const sessionManager = SessionManager.open(sessionFile, dir, "/tmp/task-repo");
 
-    expect(sessionManager.getEntries()).toEqual([userEntry, assistantEntry]);
-    expect(sessionManager.getChildren(userEntry.id)).toEqual([assistantEntry]);
+    expect(sessionManager.getEntries()).toEqual([userEntry, normalizedAssistantEntry]);
+    expect(sessionManager.getChildren(userEntry.id)).toEqual([normalizedAssistantEntry]);
     expect(await fs.readFile(sessionFile, "utf8")).toContain("important question");
     expect(await fs.readFile(sessionFile, "utf8")).toContain("important answer");
     await expect(fs.readFile(sessionFile, "utf8")).resolves.not.toBe(originalTranscript);
@@ -1432,6 +1436,10 @@ describe("SessionManager.open", () => {
       timestamp: "2026-06-04T00:00:01.000Z",
       message: { role: "assistant", content: "carried context" },
     };
+    const normalizedAssistantEntry = {
+      ...assistantEntry,
+      message: { role: "assistant", content: [{ type: "text", text: "carried context" }] },
+    };
     await fs.writeFile(
       sessionFile,
       [
@@ -1456,7 +1464,7 @@ describe("SessionManager.open", () => {
       .split("\n")
       .map((line) => JSON.parse(line) as unknown);
     expect(records).toContainEqual(metadata);
-    expect(sessionManager.getEntries()).toEqual([assistantEntry]);
+    expect(sessionManager.getEntries()).toEqual([normalizedAssistantEntry]);
   });
 
   it("bridges parent-linked opaque rows without exposing them as session entries", async () => {

--- a/src/agents/sessions/session-manager.tool-result-replay.test.ts
+++ b/src/agents/sessions/session-manager.tool-result-replay.test.ts
@@ -98,6 +98,52 @@ async function writeSessionWithToolResultContent(
   await fs.writeFile(sessionFile, `${entries.map((entry) => JSON.stringify(entry)).join("\n")}\n`);
 }
 
+async function writeSessionWithAssistantContent(
+  sessionFile: string,
+  content: unknown,
+): Promise<void> {
+  const entries = [
+    {
+      type: "session",
+      version: 3,
+      id: "string-assistant-session",
+      timestamp: "2026-07-01T00:00:00.000Z",
+      cwd: "/tmp/tool-result-replay",
+    },
+    {
+      type: "message",
+      id: "user-1",
+      parentId: null,
+      timestamp: "2026-07-01T00:00:01.000Z",
+      message: { role: "user", content: "say hello", timestamp: 1 },
+    },
+    {
+      type: "message",
+      id: "assistant-1",
+      parentId: "user-1",
+      timestamp: "2026-07-01T00:00:02.000Z",
+      message: {
+        role: "assistant",
+        provider: "anthropic",
+        api: "anthropic-messages",
+        model: "claude-sonnet-4-6",
+        stopReason: "stop",
+        timestamp: 2,
+        usage: {
+          input: 0,
+          output: 0,
+          cacheRead: 0,
+          cacheWrite: 0,
+          totalTokens: 0,
+          cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+        },
+        content,
+      },
+    },
+  ];
+  await fs.writeFile(sessionFile, `${entries.map((entry) => JSON.stringify(entry)).join("\n")}\n`);
+}
+
 describe("SessionManager tool-result replay", () => {
   afterEach(async () => {
     await Promise.all(
@@ -118,6 +164,43 @@ describe("SessionManager tool-result replay", () => {
     }
 
     expect(toolResult.content).toEqual([{ type: "text", text: "lookup result text" }]);
+  });
+
+  it("replays string assistant JSONL content as Anthropic assistant text", async () => {
+    const dir = await makeTempDir();
+    const sessionFile = path.join(dir, "session.jsonl");
+    await writeSessionWithAssistantContent(sessionFile, "assistant replay text");
+    const context = SessionManager.open(
+      sessionFile,
+      dir,
+      "/tmp/tool-result-replay",
+    ).buildSessionContext();
+    const assistant = context.messages.find((message) => message.role === "assistant");
+    if (!assistant || assistant.role !== "assistant") {
+      throw new Error("assistant message missing");
+    }
+    expect(assistant.content).toEqual([{ type: "text", text: "assistant replay text" }]);
+
+    let capturedPayload: unknown;
+    const stream = streamAnthropic(makeAnthropicModel(), toLlmContext(context), {
+      apiKey: "sk-ant-provider",
+      onPayload: (payload) => {
+        capturedPayload = payload;
+        throw new Error("stop before network");
+      },
+    });
+
+    await stream.result();
+
+    const payload = capturedPayload as {
+      messages: Array<{
+        role: string;
+        content: string | Array<{ type?: unknown; text?: unknown }>;
+      }>;
+    };
+    const assistantPayload = payload.messages.find((message) => message.role === "assistant");
+
+    expect(assistantPayload?.content).toEqual([{ type: "text", text: "assistant replay text" }]);
   });
 
   it("replays string tool-result JSONL content as Anthropic tool text", async () => {

--- a/src/agents/sessions/session-manager.ts
+++ b/src/agents/sessions/session-manager.ts
@@ -960,15 +960,15 @@ function normalizeLoadedFileEntry(entry: FileEntry): FileEntry {
   // Persisted JSONL is untrusted: shapes may predate the current Message type,
   // so normalize through a record view instead of the declared union.
   const message: Record<string, unknown> = entry.message;
-  if (message.role !== "toolResult") {
-    return entry;
-  }
-  // Replayed JSONL can carry string or single-record tool results while
-  // downstream providers require block arrays. Without this, strings replay as
-  // empty output and records hit non-array replay assumptions.
-  if (typeof message.content === "string") {
+  // Replayed JSONL can carry legacy string assistant/toolResult content while
+  // downstream providers require block arrays. Single-record tool results need
+  // the same ingress repair before replay reaches provider conversion.
+  if (
+    (message.role === "assistant" || message.role === "toolResult") &&
+    typeof message.content === "string"
+  ) {
     message.content = [{ type: "text", text: message.content }];
-  } else if (isJsonRecord(message.content)) {
+  } else if (message.role === "toolResult" && isJsonRecord(message.content)) {
     message.content = [message.content];
   }
   return entry;

--- a/src/auto-reply/reply/session-fork.runtime.test.ts
+++ b/src/auto-reply/reply/session-fork.runtime.test.ts
@@ -439,7 +439,7 @@ describe("forkSessionFromParentRuntime", () => {
     expect(records.at(-1)).toMatchObject({ type: "message", parentId: "plugin-metadata" });
     expect(records.at(-1)).not.toHaveProperty("appendMode");
     expect(reopened.buildSessionContext().messages).toMatchObject([
-      { role: "assistant", content: "active root" },
+      { role: "assistant", content: [{ type: "text", text: "active root" }] },
       { role: "user", content: "continued" },
     ]);
   });

--- a/src/auto-reply/reply/session-usage.ts
+++ b/src/auto-reply/reply/session-usage.ts
@@ -234,7 +234,7 @@ export async function persistSessionUsageUpdate(params: {
           ) {
             patch.totalTokensFresh = false;
           }
-          return preserveSessionModelState
+          return preserveUserFacingRunState
             ? patch
             : applyCliSessionIdToSessionPatch(params, entry, patch);
         },
@@ -285,7 +285,7 @@ export async function persistSessionUsageUpdate(params: {
             // zero persisted for the previously empty session.
             patch.totalTokensFresh = false;
           }
-          return preserveSessionModelState
+          return preserveUserFacingRunState
             ? patch
             : applyCliSessionIdToSessionPatch(params, entry, patch);
         },

--- a/src/auto-reply/reply/session.test.ts
+++ b/src/auto-reply/reply/session.test.ts
@@ -30,10 +30,10 @@ import {
 } from "../../test-utils/channel-plugins.js";
 import { withEnvAsync } from "../../test-utils/env.js";
 import { createSessionConversationTestRegistry } from "../../test-utils/session-conversation-registry.js";
+import { replyRunRegistry } from "./reply-run-registry.js";
 import { drainFormattedSystemEvents } from "./session-updates.js";
 import { persistSessionUsageUpdate } from "./session-usage.js";
 import { initSessionState } from "./session.js";
-import { replyRunRegistry } from "./reply-run-registry.js";
 
 const sessionForkMocks = vi.hoisted(() => ({
   forkSessionFromParent: vi.fn(),
@@ -4313,7 +4313,7 @@ describe("persistSessionUsageUpdate", () => {
     expect(stored[sessionKey].totalTokensFresh).toBe(true);
   });
 
-  it("accounts exhausted-run usage without committing its model", async () => {
+  it("accounts exhausted-run usage without committing its model and persists CLI binding", async () => {
     const storePath = await createStorePath("openclaw-usage-exhausted-");
     const sessionKey = "main";
     await seedSessionStore({
@@ -4357,12 +4357,12 @@ describe("persistSessionUsageUpdate", () => {
       totalTokens: 100,
       totalTokensFresh: true,
       cliSessionBindings: {
-        "claude-cli": { sessionId: "existing-cli-session" },
+        "claude-cli": { sessionId: "exhausted-cli-session" },
       },
       cliSessionIds: {
-        "claude-cli": "existing-cli-session",
+        "claude-cli": "exhausted-cli-session",
       },
-      claudeCliSessionId: "existing-cli-session",
+      claudeCliSessionId: "exhausted-cli-session",
     });
   });
 
@@ -4906,6 +4906,100 @@ describe("persistSessionUsageUpdate", () => {
     expect(stored[sessionKey].outputTokens).toBe(100);
     expect(stored[sessionKey].cacheRead).toBe(200);
     expect(stored[sessionKey].totalTokens).toBe(1_105);
+  });
+
+  it("persists heartbeat CLI binding while preserving displayed session model", async () => {
+    const storePath = await createStorePath("openclaw-usage-heartbeat-cli-binding-");
+    const sessionKey = "main";
+    await seedSessionStore({
+      storePath,
+      sessionKey,
+      entry: {
+        sessionId: "s1",
+        updatedAt: Date.now(),
+        modelProvider: "openai",
+        model: "gpt-5.4",
+        cliSessionBindings: {
+          "claude-cli": { sessionId: "old-heartbeat-cli-session" },
+        },
+        cliSessionIds: {
+          "claude-cli": "old-heartbeat-cli-session",
+        },
+        claudeCliSessionId: "old-heartbeat-cli-session",
+      },
+    });
+
+    await persistSessionUsageUpdate({
+      storePath,
+      sessionKey,
+      isHeartbeat: true,
+      usage: { input: 1_200, output: 100 },
+      usageIsContextSnapshot: true,
+      providerUsed: "claude-cli",
+      modelUsed: "claude-sonnet-4-6",
+      cliSessionBinding: {
+        sessionId: "new-heartbeat-cli-session",
+        authProfileId: "anthropic:heartbeat",
+      },
+      contextTokensUsed: 128_000,
+    });
+
+    const stored = JSON.parse(await fs.readFile(storePath, "utf-8"));
+    expect(stored[sessionKey].modelProvider).toBe("openai");
+    expect(stored[sessionKey].model).toBe("gpt-5.4");
+    expect(stored[sessionKey].cliSessionIds?.["claude-cli"]).toBe("new-heartbeat-cli-session");
+    expect(stored[sessionKey].cliSessionBindings?.["claude-cli"]).toEqual({
+      sessionId: "new-heartbeat-cli-session",
+      authProfileId: "anthropic:heartbeat",
+    });
+    expect(stored[sessionKey].claudeCliSessionId).toBe("new-heartbeat-cli-session");
+  });
+
+  it("honors heartbeat CLI binding clears while preserving displayed session model", async () => {
+    const storePath = await createStorePath("openclaw-usage-heartbeat-cli-clear-");
+    const sessionKey = "main";
+    await seedSessionStore({
+      storePath,
+      sessionKey,
+      entry: {
+        sessionId: "s1",
+        updatedAt: Date.now(),
+        modelProvider: "openai",
+        model: "gpt-5.4",
+        cliSessionIds: {
+          "claude-cli": "old-heartbeat-cli-session",
+          "codex-cli": "codex-cli-session",
+        },
+        cliSessionBindings: {
+          "claude-cli": { sessionId: "old-heartbeat-cli-session" },
+          "codex-cli": { sessionId: "codex-cli-session" },
+        },
+        claudeCliSessionId: "old-heartbeat-cli-session",
+      },
+    });
+
+    await persistSessionUsageUpdate({
+      storePath,
+      sessionKey,
+      isHeartbeat: true,
+      usage: { input: 1_200, output: 100 },
+      usageIsContextSnapshot: true,
+      providerUsed: "claude-cli",
+      modelUsed: "claude-sonnet-4-6",
+      clearCliSessionBinding: true,
+      contextTokensUsed: 128_000,
+    });
+
+    const stored = JSON.parse(await fs.readFile(storePath, "utf-8"));
+    expect(stored[sessionKey].modelProvider).toBe("openai");
+    expect(stored[sessionKey].model).toBe("gpt-5.4");
+    expect(stored[sessionKey].cliSessionIds?.["claude-cli"]).toBeUndefined();
+    expect(stored[sessionKey].cliSessionIds?.["codex-cli"]).toBe("codex-cli-session");
+    expect(stored[sessionKey].cliSessionBindings?.["claude-cli"]).toBeUndefined();
+    expect(stored[sessionKey].cliSessionBindings?.["codex-cli"]).toEqual({
+      sessionId: "codex-cli-session",
+    });
+    expect(stored[sessionKey].claudeCliSessionId).toBeUndefined();
   });
 
   it("preserves the displayed session model when an internal announce uses fallback", async () => {

--- a/src/cron/cron-protocol-conformance.test.ts
+++ b/src/cron/cron-protocol-conformance.test.ts
@@ -108,6 +108,7 @@ describe("cron protocol conformance", () => {
       "billing",
       "server_error",
       "timeout",
+      "context_overflow",
       "model_not_found",
       "session_expired",
       "empty_response",

--- a/src/cron/run-log.error-reason.test.ts
+++ b/src/cron/run-log.error-reason.test.ts
@@ -62,6 +62,7 @@ describe("cron run log errorReason", () => {
       "timeout",
       "model_not_found",
       "session_expired",
+      "context_overflow",
       "empty_response",
       "no_error_details",
       "unclassified",

--- a/src/cron/run-log/entry-codec.ts
+++ b/src/cron/run-log/entry-codec.ts
@@ -17,6 +17,7 @@ const CRON_FAILOVER_REASONS = new Set<FailoverReason>([
   "timeout",
   "model_not_found",
   "session_expired",
+  "context_overflow",
   "empty_response",
   "no_error_details",
   "unclassified",

--- a/src/gateway/openai-compat-errors.ts
+++ b/src/gateway/openai-compat-errors.ts
@@ -16,6 +16,7 @@ const ERROR_TYPE_BY_REASON: Partial<Record<FailoverReason, string>> = {
   auth: "authentication_error",
   auth_permanent: "permission_error",
   billing: "insufficient_quota",
+  context_overflow: "invalid_request_error",
   format: "invalid_request_error",
   model_not_found: "invalid_request_error",
   overloaded: "api_error",

--- a/src/gateway/session-compaction-checkpoints.test.ts
+++ b/src/gateway/session-compaction-checkpoints.test.ts
@@ -789,7 +789,7 @@ describe("session-compaction-checkpoints", () => {
     const messages = SessionManager.open(forked.sessionFile, dir).buildSessionContext().messages;
     expect(messages.map((message) => (message as { content?: unknown }).content)).toEqual([
       "legacy first",
-      "legacy second",
+      [{ type: "text", text: "legacy second" }],
     ]);
   });
 

--- a/src/gateway/session-utils.fs.test.ts
+++ b/src/gateway/session-utils.fs.test.ts
@@ -1788,7 +1788,7 @@ describe("readSessionMessages", () => {
       })),
     ).toEqual([
       { role: "user", text: "hello" },
-      { role: "assistant", text: "hi" },
+      { role: "assistant", text: [{ type: "text", text: "hi" }] },
       { role: "user", text: [{ type: "text", text: "Blocked by HITL test hook." }] },
     ]);
     expect(JSON.stringify(out)).not.toContain("[hitl:block] hello");

--- a/src/llm/providers/transform-messages.ts
+++ b/src/llm/providers/transform-messages.ts
@@ -117,13 +117,13 @@ export function transformMessages<TApi extends Api>(
           assistantMsg.api === model.api &&
           assistantMsg.model === model.id);
 
-      // Assistant content is typed as a block array, but transcript replay can
-      // hand us a raw string (JSONL passthrough). Normalize it to an equivalent
-      // single text block before transforming, matching the string->text block
-      // handling already used in anthropic-payload-policy.ts.
-      const contentBlocks = Array.isArray(assistantMsg.content)
-        ? assistantMsg.content
-        : [{ type: "text" as const, text: assistantMsg.content as unknown as string }];
+      // Public plugin-sdk/llm exports transformMessages; keep accepting legacy
+      // assistant strings from external provider adapters even though session
+      // JSONL replay normalizes them at ingest.
+      const contentBlocks =
+        typeof assistantMsg.content === "string"
+          ? [{ type: "text" as const, text: assistantMsg.content }]
+          : assistantMsg.content;
 
       const transformedContent = contentBlocks.flatMap((block) => {
         if (block.type === "thinking") {

--- a/src/scripts/test-projects.test.ts
+++ b/src/scripts/test-projects.test.ts
@@ -969,6 +969,7 @@ describe("test-projects args", () => {
           "src/agents/agent-bundle-mcp-runtime.test.ts",
           "src/agents/agent-tools-agent-config.exec.test.ts",
           "src/agents/bash-tools.exec-foreground-failures.test.ts",
+          "src/agents/cli-runner.reliability.test.ts",
           "src/agents/models-config.file-mode.test.ts",
           "src/agents/sandbox/ssh.test.ts",
         ],

--- a/test/scripts/lint-suppressions.test.ts
+++ b/test/scripts/lint-suppressions.test.ts
@@ -193,6 +193,7 @@ describe("production lint suppressions", () => {
         "extensions/feishu/src/bitable.ts|typescript/no-unnecessary-type-parameters|1",
         "extensions/matrix/src/onboarding.test-harness.ts|typescript/no-unnecessary-type-parameters|1",
         "extensions/slack/src/monitor/provider-support.ts|typescript/no-unnecessary-type-parameters|1",
+        "src/agents/agent-bundle-mcp-runtime.ts|unicorn/prefer-add-event-listener|1",
         "src/channels/plugins/channel-runtime-surface.types.ts|typescript/no-unnecessary-type-parameters|1",
         "src/channels/plugins/contracts/test-helpers.ts|typescript/no-unnecessary-type-parameters|1",
         "src/channels/plugins/types.plugin.ts|typescript/no-explicit-any|1",


### PR DESCRIPTION
Related: #91882

## What Problem This Solves

Fixes an issue where users running Claude Fable 5 through Anthropic Vertex simple-completion workflows would fail before the provider request. The lazy plugin stream factory returned a promise where the runtime requires an immediate event stream, and the selected synthetic API alias was then passed into the shared Anthropic transport instead of its canonical API.

## Why This Change Was Made

The custom API registry now adapts lazy stream factories once at its synchronous provider boundary while preserving synchronous streams unchanged and converting lazy failures into terminal stream errors. The Anthropic Vertex plugin restores `anthropic-messages` only after its synthetic simple-completion alias has selected the plugin, so the shared transport cannot recurse through or reject the internal alias.

## User Impact

Anthropic Vertex users can use Claude Fable 5 in simple-completion features such as generated conversation labels without an immediate stream-contract or missing-provider failure. Other custom provider streams keep their existing synchronous behavior.

## Evidence

- Before: a live `anthropic-vertex/claude-fable-5` simple-completion probe failed with `TypeError: s.result is not a function`.
- After: the same live path crossed both fixed boundaries and reached the Google Vertex API. The request then received HTTP 403 because the Vertex AI API is disabled in the available GCP project; no accessible project had Vertex AI enabled, so an authenticated successful model completion was not available for this run.
- Fable regression matrix: 26 test files, 858 tests, 6 Vitest shards, all passed.
- Custom registry and Vertex seam: 2 files, 31 tests, all passed.
- Anthropic Vertex plugin lane: 7 files, 49 tests, all passed.
- `pnpm build`: passed; 134.5 seconds.
- `pnpm check:test-types`: passed.
- Focused `oxfmt`, `oxlint`, and `git diff --check`: passed.
- Final branch-level Codex autoreview against current `origin/main`: no actionable findings; patch judged correct.
- Exact-head CI: [run 28569082966](https://github.com/openclaw/openclaw/actions/runs/28569082966), all relevant jobs passed.

AI-assisted: yes. The implementation, tests, failure reproduction, and live limitation were reviewed directly before submission.
