### PR TITLE
fix(agents): stop gateway crash from wedged claude-cli turns and persist heartbeat session bindings

### DIFF
--- a/src/agents/cli-runner.spawn.test.ts
+++ b/src/agents/cli-runner.spawn.test.ts
@@ -3139,6 +3139,77 @@ ${JSON.stringify({
     expect(supervisorSpawnMock).toHaveBeenCalledTimes(2);
   });
 
+  it("fails Claude live turns without unhandled rejection when stdin write is stuck", async () => {
+    vi.useFakeTimers();
+    const unhandledRejections: unknown[] = [];
+    const onUnhandledRejection = (reason: unknown) => {
+      unhandledRejections.push(reason);
+    };
+    process.on("unhandledRejection", onUnhandledRejection);
+    const cancel = vi.fn();
+    let pendingWriteCallback: ((err?: Error | null) => void) | undefined;
+    const stdin = {
+      write: vi.fn((dataValue: string, cb?: (err?: Error | null) => void) => {
+        pendingWriteCallback = cb;
+      }),
+      end: vi.fn(),
+    };
+    supervisorSpawnMock.mockImplementationOnce(async () => ({
+      runId: "live-run-stuck-stdin",
+      pid: 2345,
+      startedAtMs: Date.now(),
+      stdin,
+      wait: vi.fn(() => new Promise(() => {})),
+      cancel: vi.fn((reason: string) => {
+        cancel(reason);
+        pendingWriteCallback?.(new Error("stdin closed"));
+      }),
+    }));
+
+    try {
+      const context = buildPreparedCliRunContext({
+        provider: "claude-cli",
+        model: "sonnet",
+        runId: "run-live-stuck-stdin",
+        timeoutMs: 10_000,
+        backend: {
+          liveSession: "claude-stdio",
+        },
+      });
+      const run = runClaudeLiveSessionTurn({
+        context,
+        args: context.preparedBackend.backend.args ?? [],
+        env: {},
+        prompt: "stuck write",
+        useResume: false,
+        noOutputTimeoutMs: 1_000,
+        getProcessSupervisor: () => ({
+          spawn: (params: Parameters<SupervisorSpawnFn>[0]) =>
+            supervisorSpawnMock(params) as ReturnType<SupervisorSpawnFn>,
+          cancel: vi.fn(),
+          cancelScope: vi.fn(),
+          getRecord: vi.fn(),
+        }),
+        onAssistantDelta: () => {},
+        cleanup: async () => {},
+      });
+      const runExpectation = expectRejectsWithFields(run, {
+        name: "FailoverError",
+        message: "CLI produced no output for 1s and was terminated.",
+      });
+
+      await vi.advanceTimersByTimeAsync(1_000);
+
+      await runExpectation;
+      await Promise.resolve();
+      expect(unhandledRejections).toEqual([]);
+      expect(cancel).toHaveBeenCalledWith("manual-cancel");
+      expect(stdin.write).toHaveBeenCalledOnce();
+    } finally {
+      process.off("unhandledRejection", onUnhandledRejection);
+    }
+  });
+
   it("restarts Claude live sessions when selected skills change", async () => {
     const workspaceDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-live-skills-"));
     const weatherDir = path.join(workspaceDir, "skills", "weather");

--- a/src/agents/cli-runner/claude-live-session.ts
+++ b/src/agents/cli-runner/claude-live-session.ts
@@ -1376,6 +1376,9 @@ export async function runClaudeLiveSessionTurn(params: {
       reject,
     });
   });
+  // Timeout/abort can reject the turn while stdin is backpressured. Keep the
+  // rejection handled until the final await below rethrows the canonical result.
+  void outputPromise.catch(() => undefined);
   const abort = () => abortTurn(liveSession, createAbortError());
   let replyBackendCompleted = false;
   const replyBackendHandle: ReplyBackendHandle | undefined = params.context.params.replyOperation
@@ -1394,7 +1397,7 @@ export async function runClaudeLiveSessionTurn(params: {
       abort();
     } else {
       try {
-        await writeTurnInput(liveSession, params.prompt);
+        await Promise.race([writeTurnInput(liveSession, params.prompt), outputPromise]);
       } catch (error) {
         closeLiveSession(liveSession, "abort", error);
       }

--- a/src/auto-reply/reply/session-usage.ts
+++ b/src/auto-reply/reply/session-usage.ts
@@ -234,7 +234,7 @@ export async function persistSessionUsageUpdate(params: {
           ) {
             patch.totalTokensFresh = false;
           }
-          return preserveSessionModelState
+          return preserveUserFacingRunState
             ? patch
             : applyCliSessionIdToSessionPatch(params, entry, patch);
         },
@@ -285,7 +285,7 @@ export async function persistSessionUsageUpdate(params: {
             // zero persisted for the previously empty session.
             patch.totalTokensFresh = false;
           }
-          return preserveSessionModelState
+          return preserveUserFacingRunState
             ? patch
             : applyCliSessionIdToSessionPatch(params, entry, patch);
         },

--- a/src/auto-reply/reply/session.test.ts
+++ b/src/auto-reply/reply/session.test.ts
@@ -30,10 +30,10 @@ import {
 } from "../../test-utils/channel-plugins.js";
 import { withEnvAsync } from "../../test-utils/env.js";
 import { createSessionConversationTestRegistry } from "../../test-utils/session-conversation-registry.js";
+import { replyRunRegistry } from "./reply-run-registry.js";
 import { drainFormattedSystemEvents } from "./session-updates.js";
 import { persistSessionUsageUpdate } from "./session-usage.js";
 import { initSessionState } from "./session.js";
-import { replyRunRegistry } from "./reply-run-registry.js";
 
 const sessionForkMocks = vi.hoisted(() => ({
   forkSessionFromParent: vi.fn(),
@@ -4313,7 +4313,7 @@ describe("persistSessionUsageUpdate", () => {
     expect(stored[sessionKey].totalTokensFresh).toBe(true);
   });
 
-  it("accounts exhausted-run usage without committing its model", async () => {
+  it("accounts exhausted-run usage without committing its model and persists CLI binding", async () => {
     const storePath = await createStorePath("openclaw-usage-exhausted-");
     const sessionKey = "main";
     await seedSessionStore({
@@ -4357,12 +4357,12 @@ describe("persistSessionUsageUpdate", () => {
       totalTokens: 100,
       totalTokensFresh: true,
       cliSessionBindings: {
-        "claude-cli": { sessionId: "existing-cli-session" },
+        "claude-cli": { sessionId: "exhausted-cli-session" },
       },
       cliSessionIds: {
-        "claude-cli": "existing-cli-session",
+        "claude-cli": "exhausted-cli-session",
       },
-      claudeCliSessionId: "existing-cli-session",
+      claudeCliSessionId: "exhausted-cli-session",
     });
   });
 
@@ -4906,6 +4906,100 @@ describe("persistSessionUsageUpdate", () => {
     expect(stored[sessionKey].outputTokens).toBe(100);
     expect(stored[sessionKey].cacheRead).toBe(200);
     expect(stored[sessionKey].totalTokens).toBe(1_105);
+  });
+
+  it("persists heartbeat CLI binding while preserving displayed session model", async () => {
+    const storePath = await createStorePath("openclaw-usage-heartbeat-cli-binding-");
+    const sessionKey = "main";
+    await seedSessionStore({
+      storePath,
+      sessionKey,
+      entry: {
+        sessionId: "s1",
+        updatedAt: Date.now(),
+        modelProvider: "openai",
+        model: "gpt-5.4",
+        cliSessionBindings: {
+          "claude-cli": { sessionId: "old-heartbeat-cli-session" },
+        },
+        cliSessionIds: {
+          "claude-cli": "old-heartbeat-cli-session",
+        },
+        claudeCliSessionId: "old-heartbeat-cli-session",
+      },
+    });
+
+    await persistSessionUsageUpdate({
+      storePath,
+      sessionKey,
+      isHeartbeat: true,
+      usage: { input: 1_200, output: 100 },
+      usageIsContextSnapshot: true,
+      providerUsed: "claude-cli",
+      modelUsed: "claude-sonnet-4-6",
+      cliSessionBinding: {
+        sessionId: "new-heartbeat-cli-session",
+        authProfileId: "anthropic:heartbeat",
+      },
+      contextTokensUsed: 128_000,
+    });
+
+    const stored = JSON.parse(await fs.readFile(storePath, "utf-8"));
+    expect(stored[sessionKey].modelProvider).toBe("openai");
+    expect(stored[sessionKey].model).toBe("gpt-5.4");
+    expect(stored[sessionKey].cliSessionIds?.["claude-cli"]).toBe("new-heartbeat-cli-session");
+    expect(stored[sessionKey].cliSessionBindings?.["claude-cli"]).toEqual({
+      sessionId: "new-heartbeat-cli-session",
+      authProfileId: "anthropic:heartbeat",
+    });
+    expect(stored[sessionKey].claudeCliSessionId).toBe("new-heartbeat-cli-session");
+  });
+
+  it("honors heartbeat CLI binding clears while preserving displayed session model", async () => {
+    const storePath = await createStorePath("openclaw-usage-heartbeat-cli-clear-");
+    const sessionKey = "main";
+    await seedSessionStore({
+      storePath,
+      sessionKey,
+      entry: {
+        sessionId: "s1",
+        updatedAt: Date.now(),
+        modelProvider: "openai",
+        model: "gpt-5.4",
+        cliSessionIds: {
+          "claude-cli": "old-heartbeat-cli-session",
+          "codex-cli": "codex-cli-session",
+        },
+        cliSessionBindings: {
+          "claude-cli": { sessionId: "old-heartbeat-cli-session" },
+          "codex-cli": { sessionId: "codex-cli-session" },
+        },
+        claudeCliSessionId: "old-heartbeat-cli-session",
+      },
+    });
+
+    await persistSessionUsageUpdate({
+      storePath,
+      sessionKey,
+      isHeartbeat: true,
+      usage: { input: 1_200, output: 100 },
+      usageIsContextSnapshot: true,
+      providerUsed: "claude-cli",
+      modelUsed: "claude-sonnet-4-6",
+      clearCliSessionBinding: true,
+      contextTokensUsed: 128_000,
+    });
+
+    const stored = JSON.parse(await fs.readFile(storePath, "utf-8"));
+    expect(stored[sessionKey].modelProvider).toBe("openai");
+    expect(stored[sessionKey].model).toBe("gpt-5.4");
+    expect(stored[sessionKey].cliSessionIds?.["claude-cli"]).toBeUndefined();
+    expect(stored[sessionKey].cliSessionIds?.["codex-cli"]).toBe("codex-cli-session");
+    expect(stored[sessionKey].cliSessionBindings?.["claude-cli"]).toBeUndefined();
+    expect(stored[sessionKey].cliSessionBindings?.["codex-cli"]).toEqual({
+      sessionId: "codex-cli-session",
+    });
+    expect(stored[sessionKey].claudeCliSessionId).toBeUndefined();
   });
 
   it("preserves the displayed session model when an internal announce uses fallback", async () => {


### PR DESCRIPTION
Fixes #98894
Fixes #98895

## What Problem This Solves

Two P1 defects in the claude-cli backend found by a reliability audit:

1. **A wedged Claude CLI child could crash the entire gateway.** In the live session, the turn's `outputPromise` was created with no rejection handler attached until after `await writeTurnInput(...)`. If the child was alive but not reading stdin (hung startup, or a reseed history prompt larger than the 64 KiB pipe buffer), the stdin write callback never fired — and when the turn's no-output timer rejected the turn, the rejection had zero handlers. Node's `unhandledRejection` handler does not treat `FailoverError` as suppressible and calls `process.exit(1)`: one stuck CLI turn took down every agent and channel on the gateway.
2. **Heartbeat turns silently dropped claude-cli session-binding updates** (regression from 0314819f918, Jun 15). `persistSessionUsageUpdate` skipped `applyCliSessionIdToSessionPatch` for heartbeat and `preserveRuntimeModel` runs. Claude print-mode `--resume` mints a new session id every turn, so each heartbeat advanced the CLI conversation into a new session while the stored binding stayed on the old one — the next user turn resumed the pre-heartbeat session, silently losing everything the agent did during heartbeats and orphaning a forked session under `~/.claude/projects` per heartbeat.

## Why This Change Was Made

1. The rejection now always has a handler while the prompt write is in flight: a no-op catch sentinel is attached before the write, and the write is raced against the turn promise so a timeout/abort during a backpressured write settles the race instead of leaking; the canonical result still propagates through the final `await outputPromise`. A late rejection of the losing `writeTurnInput` promise is absorbed by the settled race.
2. The binding-persistence gate is restored to `preserveUserFacingRunState` (internal handoffs only), exactly the semantics f55e98671a0 established and 0eca3a92e3e intended: heartbeats keep preserving user-facing model-display state, but the CLI session binding (and binding clears) from the run persist again.

## User Impact

Gateways no longer hard-exit when a Claude CLI child wedges during turn startup — the turn fails through the normal failover path instead. Agents with heartbeats stop losing CLI-side conversation context after every heartbeat and stop accumulating orphaned forked sessions on disk.

## Evidence

- New regression test where mock stdin never invokes its write callback (the existing mocks call it synchronously, which is why this class was invisible): the no-output timer fires mid-write, the turn fails with the FailoverError, and a `process.on("unhandledRejection")` probe asserts nothing escapes.
- New tests proving a heartbeat run's `cliSessionBinding` is persisted, a heartbeat `clearCliSessionBinding` is honored, and model-display fields remain preserved.
- Validation: `node scripts/run-vitest.mjs src/agents/cli-runner.spawn.test.ts src/auto-reply/reply/session.test.ts` (187 tests pass), `pnpm tsgo` pass, `node scripts/run-oxlint.mjs` on touched files clean, repo autoreview (branch mode) clean.
