### PR TITLE
fix(agents): recover claude-cli context-overflow sessions and keep retry artifacts alive

### DIFF
--- a/packages/gateway-protocol/src/schema/cron.ts
+++ b/packages/gateway-protocol/src/schema/cron.ts
@@ -125,6 +125,7 @@ const CronFailoverReasonSchema = Type.Union([
   Type.Literal("billing"),
   Type.Literal("server_error"),
   Type.Literal("timeout"),
+  Type.Literal("context_overflow"),
   Type.Literal("model_not_found"),
   Type.Literal("session_expired"),
   Type.Literal("empty_response"),

--- a/src/agents/cli-runner.reliability.test.ts
+++ b/src/agents/cli-runner.reliability.test.ts
@@ -3,6 +3,7 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
 import { getReplyPayloadMetadata } from "../auto-reply/reply-payload.js";
 import {
   testing as replyRunTesting,
@@ -24,6 +25,7 @@ import {
 } from "../gateway/mcp-http.loopback-runtime.js";
 import { getGlobalHookRunner } from "../plugins/hook-runner-global.js";
 import type { getProcessSupervisor } from "../process/supervisor/index.js";
+import type { RunExit } from "../process/supervisor/types.js";
 import {
   createUserTurnTranscriptRecorder,
   type UserTurnTranscriptRecorder,
@@ -37,6 +39,7 @@ import {
   requestHeartbeatMock,
   supervisorSpawnMock,
 } from "./cli-runner.test-support.js";
+import { resetClaudeLiveSessionsForTest } from "./cli-runner/claude-live-session.js";
 import { executePreparedCliRun } from "./cli-runner/execute.js";
 import {
   resolveCliNoOutputTimeoutMs,
@@ -62,6 +65,7 @@ vi.mock("../tts/tts.js", () => ({
 const mockGetGlobalHookRunner = vi.mocked(getGlobalHookRunner);
 const mockAutoCapture = vi.mocked(runSkillResearchAutoCapture);
 const hookRunnerGlobalStateKey = Symbol.for("openclaw.plugins.hook-runner-global-state");
+const autoCleanupTempDirs = useAutoCleanupTempDirTracker();
 let sessionFileEnvSnapshot: ReturnType<typeof captureEnv> | undefined;
 
 type HookRunnerGlobalStateForTest = {
@@ -304,6 +308,7 @@ describe("runCliAgent reliability", () => {
     vi.unstubAllEnvs();
     sessionFileEnvSnapshot?.restore();
     sessionFileEnvSnapshot = undefined;
+    resetClaudeLiveSessionsForTest();
   });
 
   it("fails with timeout when no-output watchdog trips", async () => {
@@ -1491,6 +1496,169 @@ describe("runCliAgent reliability", () => {
 
     expect(supervisorSpawnMock).toHaveBeenCalledTimes(1);
     expect(clearBeforeRetry).not.toHaveBeenCalled();
+  });
+
+  it("keeps non-capture live-session artifacts through fresh recovery retry", async () => {
+    supervisorSpawnMock.mockClear();
+    const artifactDir = autoCleanupTempDirs.make("openclaw-live-retry-artifacts-");
+    const mcpConfigPath = path.join(artifactDir, "mcp.json");
+    const skillsDir = path.join(artifactDir, "skills-plugin");
+    fs.writeFileSync(mcpConfigPath, "{}\n", "utf-8");
+    fs.mkdirSync(skillsDir);
+
+    const resolveArg = (argv: string[] | undefined, flag: string) => {
+      const index = argv?.indexOf(flag) ?? -1;
+      if (index < 0) {
+        throw new Error(`expected ${flag}`);
+      }
+      const value = argv?.[index + 1];
+      if (!value) {
+        throw new Error(`expected value after ${flag}`);
+      }
+      return value;
+    };
+
+    let notifyFirstSpawn: (() => void) | undefined;
+    const firstSpawned = new Promise<void>((resolve) => {
+      notifyFirstSpawn = resolve;
+    });
+    let spawnCount = 0;
+    supervisorSpawnMock.mockImplementation(async (...args: unknown[]) => {
+      spawnCount += 1;
+      const input = args[0] as {
+        argv?: string[];
+        onStdout?: (chunk: string) => void;
+      };
+      expect(resolveArg(input.argv, "--mcp-config")).toBe(mcpConfigPath);
+      expect(resolveArg(input.argv, "--skills-plugin-dir")).toBe(skillsDir);
+      expect(fs.existsSync(mcpConfigPath)).toBe(true);
+      expect(fs.existsSync(skillsDir)).toBe(true);
+
+      if (spawnCount === 1) {
+        notifyFirstSpawn?.();
+        let resolveExit: ((value: RunExit) => void) | undefined;
+        const exited = new Promise<RunExit>((resolve) => {
+          resolveExit = resolve;
+        });
+        return {
+          runId: "live-retry-timeout",
+          pid: 3301,
+          startedAtMs: Date.now(),
+          stdin: {
+            write: vi.fn((dataValue: string, cb?: (err?: Error | null) => void) => cb?.()),
+            end: vi.fn(),
+          },
+          wait: vi.fn(() => exited),
+          cancel: vi.fn(() =>
+            resolveExit?.({
+              reason: "manual-cancel",
+              exitCode: null,
+              exitSignal: null,
+              durationMs: 1,
+              stdout: "",
+              stderr: "",
+              timedOut: false,
+              noOutputTimedOut: false,
+            }),
+          ),
+        };
+      }
+
+      const stdoutListener = input.onStdout;
+      return {
+        runId: "live-retry-fresh",
+        pid: 3302,
+        startedAtMs: Date.now(),
+        stdin: {
+          write: vi.fn((dataValue: string, cb?: (err?: Error | null) => void) => {
+            stdoutListener?.(
+              [
+                JSON.stringify({ type: "system", subtype: "init", session_id: "fresh-live" }),
+                JSON.stringify({ type: "result", session_id: "fresh-live", result: "fresh ok" }),
+              ].join("\n") + "\n",
+            );
+            cb?.();
+          }),
+          end: vi.fn(),
+        },
+        wait: vi.fn(() => new Promise(() => {})),
+        cancel: vi.fn(),
+      };
+    });
+
+    const liveBackend = {
+      command: "claude",
+      args: [
+        "-p",
+        "--output-format",
+        "stream-json",
+        "--mcp-config",
+        mcpConfigPath,
+        "--skills-plugin-dir",
+        skillsDir,
+      ],
+      resumeArgs: [
+        "-p",
+        "--resume",
+        "{sessionId}",
+        "--output-format",
+        "stream-json",
+        "--mcp-config",
+        mcpConfigPath,
+        "--skills-plugin-dir",
+        skillsDir,
+      ],
+      output: "jsonl" as const,
+      input: "stdin" as const,
+      modelArg: "--model",
+      sessionArg: "--session-id",
+      sessionMode: "always" as const,
+      liveSession: "claude-stdio" as const,
+      reliability: {
+        watchdog: {
+          resume: { noOutputTimeoutMs: 1_000, minMs: 1_000, maxMs: 1_000 },
+          fresh: { noOutputTimeoutMs: 1_000, minMs: 1_000, maxMs: 1_000 },
+        },
+      },
+      serialize: true,
+    };
+    const cleanup = vi.fn(async () => {
+      fs.rmSync(artifactDir, { recursive: true, force: true });
+    });
+    const clearBeforeRetry = vi.fn(async () => true);
+    const context = buildPreparedContext({
+      sessionKey: "agent:main:live-artifacts",
+      runId: "run-live-artifact-retry",
+      cliSessionId: "stale-live",
+      provider: "claude-cli",
+      model: "opus",
+      openClawHistoryPrompt: CLI_RESEED_PROMPT,
+    });
+    context.preparedBackend.backend = liveBackend;
+    context.preparedBackend.cleanup = cleanup;
+    context.backendResolved.config = liveBackend;
+
+    const resultPromise = runPreparedCliAgent({
+      ...context,
+      params: {
+        ...context.params,
+        timeoutMs: 5_000,
+        onBeforeFreshCliSessionRetry: clearBeforeRetry,
+      },
+    });
+    await firstSpawned;
+    const result = await resultPromise;
+
+    expect(result.payloads).toEqual([{ text: "fresh ok" }]);
+    expect(result.meta.finalPromptText).toContain("User: earlier context");
+    expect(supervisorSpawnMock).toHaveBeenCalledTimes(2);
+    expect(clearBeforeRetry).toHaveBeenCalledWith({
+      provider: "claude-cli",
+      reason: "timeout",
+      sessionId: "stale-live",
+    });
+    expect(cleanup).toHaveBeenCalledOnce();
+    expect(fs.existsSync(artifactDir)).toBe(false);
   });
 
   it("does not fresh retry a no-output timeout after CLI diagnostic output", async () => {

--- a/src/agents/cli-runner.reliability.test.ts
+++ b/src/agents/cli-runner.reliability.test.ts
@@ -661,6 +661,67 @@ describe("runCliAgent reliability", () => {
     expect(supervisorSpawnMock).toHaveBeenCalledTimes(1);
   });
 
+  it("does not retry context overflow after a confirmed message send", async () => {
+    supervisorSpawnMock.mockClear();
+    supervisorSpawnMock.mockImplementationOnce(async (...args: unknown[]) => {
+      const input = args[0] as Parameters<ReturnType<typeof getProcessSupervisor>["spawn"]>[0];
+      const captureHandle = markMcpLoopbackToolCallStarted({
+        captureKey: input.env?.OPENCLAW_MCP_CLI_CAPTURE_KEY ?? "",
+        toolName: "message",
+        args: {
+          action: "send",
+          channel: "telegram",
+          target: "chat123",
+          message: "sent before overflow",
+        },
+      });
+      if (!captureHandle) {
+        throw new Error("Expected message delivery capture");
+      }
+      recordMcpLoopbackToolCallResult({
+        captureHandle,
+        toolName: "message",
+        args: {
+          action: "send",
+          channel: "telegram",
+          target: "chat123",
+          message: "sent before overflow",
+        },
+        result: { status: "sent" },
+        isError: false,
+      });
+      markMcpLoopbackToolCallFinished(captureHandle);
+      return createManagedRun({
+        reason: "exit",
+        exitCode: 1,
+        exitSignal: null,
+        durationMs: 150,
+        stdout: "",
+        stderr: "Prompt is too long",
+        timedOut: false,
+        noOutputTimedOut: false,
+      });
+    });
+    const context = buildPreparedContext({
+      sessionKey: "agent:main:delivered-overflow",
+      runId: "run-delivered-overflow",
+      cliSessionId: "stale-cli-session",
+      provider: "claude-cli",
+      model: "opus",
+      openClawHistoryPrompt: CLI_RESEED_PROMPT,
+    });
+    context.mcpDeliveryCapture = true;
+
+    const result = await runPreparedCliAgent(context);
+
+    expect(result.payloads).toBeUndefined();
+    expect(result.didSendViaMessagingTool).toBe(true);
+    expect(result.messagingToolSentTexts).toEqual(["sent before overflow"]);
+    expect(result.meta.executionTrace?.attempts?.[0]?.result).toBe("error");
+    expect(result.meta.agentMeta?.clearCliSessionBinding).toBe(true);
+    expect(supervisorSpawnMock).toHaveBeenCalledTimes(1);
+  });
+
   it("preserves first-turn delivery through cleanup without binding the OpenClaw session id", async () => {
     supervisorSpawnMock.mockClear();
     supervisorSpawnMock.mockImplementationOnce(async (...args: unknown[]) => {
@@ -1390,6 +1451,48 @@ describe("runCliAgent reliability", () => {
     expect(clearBeforeRetry).not.toHaveBeenCalled();
   });
 
+  it("does not fresh retry context overflow when the run timeout budget is exhausted", async () => {
+    supervisorSpawnMock.mockClear();
+    const clearBeforeRetry = vi.fn(async () => true);
+    supervisorSpawnMock.mockResolvedValueOnce(
+      createManagedRun({
+        reason: "exit",
+        exitCode: 1,
+        exitSignal: null,
+        durationMs: 150,
+        stdout: "",
+        stderr: "Prompt is too long",
+        timedOut: false,
+        noOutputTimedOut: false,
+      }),
+    );
+    const context = buildPreparedContext({
+      sessionKey: "agent:main:expired-overflow-budget",
+      runId: "run-expired-overflow-budget",
+      cliSessionId: "stale-cli-session",
+      provider: "claude-cli",
+      model: "opus",
+      openClawHistoryPrompt: CLI_RESEED_PROMPT,
+    });
+    const expiredBudgetContext = {
+      ...context,
+      started: Date.now() - context.params.timeoutMs - 1,
+    };
+
+    await expect(
+      runPreparedCliAgent({
+        ...expiredBudgetContext,
+        params: {
+          ...expiredBudgetContext.params,
+          onBeforeFreshCliSessionRetry: clearBeforeRetry,
+        },
+      }),
+    ).rejects.toThrow("Prompt is too long");
+
+    expect(supervisorSpawnMock).toHaveBeenCalledTimes(1);
+    expect(clearBeforeRetry).not.toHaveBeenCalled();
+  });
+
   it("does not fresh retry a no-output timeout after CLI diagnostic output", async () => {
     supervisorSpawnMock.mockClear();
     enqueueSystemEventMock.mockClear();
@@ -1468,7 +1571,7 @@ describe("runCliAgent reliability", () => {
     expect(clearBeforeRetry).not.toHaveBeenCalled();
   });
 
-  it.each(["timeout", "unknown"] as const)(
+  it.each(["timeout", "unknown", "context_overflow"] as const)(
     "retries a fresh CLI session after recoverable %s failover without a failed agent_end",
     async (reason) => {
       const hookRunner = {
@@ -1498,6 +1601,18 @@ describe("runCliAgent reliability", () => {
             stderr: "",
             timedOut: true,
             noOutputTimedOut: true,
+          });
+        }
+        if (spawnCount === 1 && reason === "context_overflow") {
+          return createManagedRun({
+            reason: "exit",
+            exitCode: 1,
+            exitSignal: null,
+            durationMs: 150,
+            stdout: "",
+            stderr: "Prompt is too long",
+            timedOut: false,
+            noOutputTimedOut: false,
           });
         }
         if (spawnCount === 1) {
@@ -1552,6 +1667,8 @@ describe("runCliAgent reliability", () => {
         });
 
         expect(result.payloads).toEqual([{ text: "hello from fresh cli" }]);
+        expect(result.meta.finalPromptText).toContain("User: earlier context");
+        expect(result.meta.finalPromptText).toContain("<next_user_message>");
         expect(supervisorSpawnMock).toHaveBeenCalledTimes(2);
         expect(events).toEqual(["spawn-1", `clear-${reason}`, "spawn-2"]);
         if (reason === "timeout") {

--- a/src/agents/cli-runner.spawn.test.ts
+++ b/src/agents/cli-runner.spawn.test.ts
@@ -1178,7 +1178,7 @@ describe("runCliAgent spawn path", () => {
     }
   });
 
-  it("defers prepared backend cleanup to the Claude live session lifecycle", async () => {
+  it("keeps non-capture live prepared backend cleanup with the whole-run owner", async () => {
     let stdoutListener: ((chunk: string) => void) | undefined;
     const stdin = {
       write: vi.fn((dataValue: string, cb?: (err?: Error | null) => void) => {
@@ -1225,11 +1225,13 @@ describe("runCliAgent spawn path", () => {
     const result = await executePreparedCliRun(context);
 
     expect(result.text).toBe("ok");
-    expect(context.preparedBackend.cleanup).toBeUndefined();
+    expect(context.preparedBackend.cleanup).toBe(preparedBackendCleanup);
     expect(preparedBackendCleanup).not.toHaveBeenCalled();
 
     resetClaudeLiveSessionsForTest();
-    await vi.waitFor(() => expect(preparedBackendCleanup).toHaveBeenCalledOnce());
+    expect(preparedBackendCleanup).not.toHaveBeenCalled();
+    await context.preparedBackend.cleanup?.();
+    expect(preparedBackendCleanup).toHaveBeenCalledOnce();
   });
 
   it("keeps captured live prepared backend cleanup with the whole-run owner", async () => {

--- a/src/agents/cli-runner.spawn.test.ts
+++ b/src/agents/cli-runner.spawn.test.ts
@@ -3003,6 +3003,64 @@ ${JSON.stringify({
     );
   });
 
+  it("marks Claude live stderr context overflows as retryable", async () => {
+    let stdoutListener: ((chunk: string) => void) | undefined;
+    let resolveExit: ((exit: RunExit) => void) | undefined;
+    const exited = new Promise<RunExit>((resolve) => {
+      resolveExit = resolve;
+    });
+    const stdin = {
+      write: vi.fn((dataValue: string, cb?: (err?: Error | null) => void) => {
+        stdoutListener?.(
+          JSON.stringify({ type: "system", subtype: "init", session_id: "live-overflow" }) + "\n",
+        );
+        cb?.();
+        resolveExit?.({
+          reason: "exit",
+          exitCode: 1,
+          exitSignal: null,
+          durationMs: 1,
+          stdout: "",
+          stderr: "Prompt is too long",
+          timedOut: false,
+          noOutputTimedOut: false,
+        });
+      }),
+      end: vi.fn(),
+    };
+    supervisorSpawnMock.mockImplementationOnce(async (...args: unknown[]) => {
+      const input = (args[0] ?? {}) as { onStdout?: (chunk: string) => void };
+      stdoutListener = input.onStdout;
+      return {
+        runId: "live-overflow-run",
+        pid: 2345,
+        startedAtMs: Date.now(),
+        stdin,
+        wait: vi.fn(() => exited),
+        cancel: vi.fn(),
+      };
+    });
+
+    await expectRejectsWithFields(
+      executePreparedCliRun(
+        buildPreparedCliRunContext({
+          provider: "claude-cli",
+          model: "sonnet",
+          runId: "run-live-overflow",
+          backend: {
+            liveSession: "claude-stdio",
+          },
+        }),
+      ),
+      {
+        name: "FailoverError",
+        reason: "context_overflow",
+        code: "cli_context_overflow",
+        status: 413,
+      },
+    );
+  });
+
   it("fails when Claude exits before a live turn starts", async () => {
     supervisorSpawnMock.mockImplementationOnce(async () => ({
       runId: "live-run",

--- a/src/agents/cli-runner.ts
+++ b/src/agents/cli-runner.ts
@@ -100,6 +100,8 @@ function shouldRetryFreshCliSessionAfterFailover(params: {
       return params.error.code === "cli_unknown_empty_failure";
     case "timeout":
       return params.error.code === "cli_no_output_timeout";
+    case "context_overflow":
+      return params.error.code === "cli_context_overflow";
     default:
       return false;
   }

--- a/src/agents/cli-runner/claude-live-session.ts
+++ b/src/agents/cli-runner/claude-live-session.ts
@@ -833,11 +833,13 @@ function createResultError(
   const result = typeof parsed.result === "string" ? parsed.result.trim() : "";
   const message = extractCliErrorMessage(raw) ?? (result || "Claude CLI failed.");
   const reason = classifyFailoverReason(message, { provider: session.providerId }) ?? "unknown";
+  const code = reason === "context_overflow" ? "cli_context_overflow" : undefined;
   return new FailoverError(message, {
     reason,
     provider: session.providerId,
     model: session.modelId,
     status: resolveFailoverStatus(reason),
+    code,
   });
 }
 
@@ -1012,6 +1014,7 @@ function handleClaudeExit(session: ClaudeLiveSession, exitCode: number | null): 
     return;
   }
   const reason = classifyFailoverReason(message, { provider: session.providerId }) ?? "unknown";
+  const code = reason === "context_overflow" ? "cli_context_overflow" : undefined;
   failTurn(
     session,
     new FailoverError(message, {
@@ -1019,6 +1022,7 @@ function handleClaudeExit(session: ClaudeLiveSession, exitCode: number | null): 
       provider: session.providerId,
       model: session.modelId,
       status: resolveFailoverStatus(reason),
+      code,
     }),
   );
 }

--- a/src/agents/cli-runner/execute.ts
+++ b/src/agents/cli-runner/execute.ts
@@ -1026,14 +1026,7 @@ export async function executePreparedCliRun(
             model: context.modelId,
             backend: context.backendResolved.id,
           });
-          const liveSessionOwnsRunArtifacts = context.mcpDeliveryCapture !== true;
-          fallbackClaudeSkillsPluginCleanupOwned = liveSessionOwnsRunArtifacts;
-          const ownedPreparedBackendCleanup = liveSessionOwnsRunArtifacts
-            ? context.preparedBackend.cleanup
-            : undefined;
-          if (liveSessionOwnsRunArtifacts) {
-            context.preparedBackend.cleanup = undefined;
-          }
+          fallbackClaudeSkillsPluginCleanupOwned = fallbackClaudeSkillsPlugin !== undefined;
           const liveResult = await runClaudeLiveSessionTurn({
             context,
             args,
@@ -1050,15 +1043,9 @@ export async function executePreparedCliRun(
                 ? emitCliCommentaryText
                 : undefined,
             onMcpCaptureReady: beginGatewayCapture,
-            cleanup: liveSessionOwnsRunArtifacts
-              ? async () => {
-                  try {
-                    await fallbackClaudeSkillsPlugin?.cleanup();
-                  } finally {
-                    await ownedPreparedBackendCleanup?.();
-                  }
-                }
-              : async () => {},
+            cleanup: async () => {
+              await fallbackClaudeSkillsPlugin?.cleanup();
+            },
           });
           const rawText = liveResult.output.text;
           runOutput = {

--- a/src/agents/cli-runner/execute.ts
+++ b/src/agents/cli-runner/execute.ts
@@ -1300,12 +1300,14 @@ export async function executePreparedCliRun(
             reason = reason ?? "unknown";
             const status = resolveFailoverStatus(reason);
             const retryCode =
-              reason === "unknown" &&
-              result.reason === "exit" &&
-              errorCandidates.length === 0 &&
-              !observedCliActivity
-                ? "cli_unknown_empty_failure"
-                : undefined;
+              reason === "context_overflow"
+                ? "cli_context_overflow"
+                : reason === "unknown" &&
+                    result.reason === "exit" &&
+                    errorCandidates.length === 0 &&
+                    !observedCliActivity
+                  ? "cli_unknown_empty_failure"
+                  : undefined;
             throw new FailoverError(err, {
               reason,
               provider: params.provider,

--- a/src/agents/embedded-agent-helpers.isbillingerrormessage.test.ts
+++ b/src/agents/embedded-agent-helpers.isbillingerrormessage.test.ts
@@ -611,6 +611,12 @@ describe("extractObservedOverflowTokenCount", () => {
   });
 });
 
+describe("classifyFailoverReason context overflow", () => {
+  it("maps prompt overflow to the closed failover reason", () => {
+    expect(classifyFailoverReason("Prompt is too long")).toBe("context_overflow");
+  });
+});
+
 describe("isTransientHttpError", () => {
   it("returns true for retryable 5xx status codes", () => {
     expect(isTransientHttpError("499 Client Closed Request")).toBe(true);
@@ -671,13 +677,13 @@ describe("classifyFailoverReasonFromHttpStatus", () => {
     ).toBe("rate_limit");
   });
 
-  it("does not force HTTP 400 context-overflow payloads into format", () => {
+  it("classifies HTTP 400 context-overflow payloads without using format", () => {
     expect(
       classifyFailoverReasonFromHttpStatus(
         400,
         "INVALID_ARGUMENT: input exceeds the maximum number of tokens",
       ),
-    ).toBeNull();
+    ).toBe("context_overflow");
   });
 
   it("lets OpenRouter billing-classified HTTP 401 responses bypass generic auth", () => {
@@ -803,12 +809,12 @@ describe("classifyFailoverReason HTTP 410 handling", () => {
     expect(classifyFailoverReason("HTTP 404: insufficient credits")).toBe("billing");
   });
 
-  it("does not map HTTP 404 plus context-overflow text to model_not_found", () => {
+  it("maps HTTP 404 plus context-overflow text to context_overflow", () => {
     expect(
       classifyFailoverReason(
         "HTTP 404: INVALID_ARGUMENT: input exceeds the maximum number of tokens",
       ),
-    ).toBeNull();
+    ).toBe("context_overflow");
   });
 
   it("keeps raw HTTP 400 wrappers aligned with structured provider classification", () => {
@@ -819,7 +825,7 @@ describe("classifyFailoverReason HTTP 410 handling", () => {
       classifyFailoverReason(
         "HTTP 400: INVALID_ARGUMENT: input exceeds the maximum number of tokens",
       ),
-    ).toBeNull();
+    ).toBe("context_overflow");
   });
 
   it("classifies OpenAI Responses unknown-no-details message distinctly", () => {

--- a/src/agents/embedded-agent-helpers/errors.ts
+++ b/src/agents/embedded-agent-helpers/errors.ts
@@ -731,7 +731,10 @@ function toReasonClassification(reason: FailoverReason): FailoverClassification 
 function failoverReasonFromClassification(
   classification: FailoverClassification | null,
 ): FailoverReason | null {
-  return classification?.kind === "reason" ? classification.reason : null;
+  if (!classification) {
+    return null;
+  }
+  return classification.kind === "reason" ? classification.reason : "context_overflow";
 }
 
 export function isTransientHttpError(raw: string): boolean {

--- a/src/agents/embedded-agent-helpers/types.ts
+++ b/src/agents/embedded-agent-helpers/types.ts
@@ -11,6 +11,7 @@ export type FailoverReason =
   | "billing"
   | "server_error"
   | "timeout"
+  | "context_overflow"
   | "model_not_found"
   | "session_expired"
   | "empty_response"

--- a/src/agents/embedded-agent-runner/run/auth-profile-failure-policy.ts
+++ b/src/agents/embedded-agent-runner/run/auth-profile-failure-policy.ts
@@ -34,6 +34,7 @@ export function resolveAuthProfileFailureReason(params: {
         (params.failoverReason === "rate_limit" && params.transientRateLimit === true))) ||
     params.failoverReason === "server_error" ||
     params.failoverReason === "empty_response" ||
+    params.failoverReason === "context_overflow" ||
     params.failoverReason === "format"
   ) {
     return null;

--- a/src/agents/failover-error.test.ts
+++ b/src/agents/failover-error.test.ts
@@ -607,13 +607,13 @@ describe("failover-error", () => {
     ).toBe("rate_limit");
   });
 
-  it("does not misclassify structured HTTP 400 context overflow payloads as format", () => {
+  it("classifies structured HTTP 400 context overflow payloads without using format", () => {
     expect(
       resolveFailoverReasonFromError({
         status: 400,
         message: "INVALID_ARGUMENT: input exceeds the maximum number of tokens",
       }),
-    ).toBeNull();
+    ).toBe("context_overflow");
   });
 
   it("keeps context overflow first-class in the shared signal classifier", () => {

--- a/src/agents/failover-error.ts
+++ b/src/agents/failover-error.ts
@@ -107,6 +107,8 @@ export function resolveFailoverStatus(reason: FailoverReason): number | undefine
       return 403;
     case "timeout":
       return 408;
+    case "context_overflow":
+      return 413;
     case "format":
       return 400;
     case "model_not_found":
@@ -461,7 +463,10 @@ export function isSignalTimeoutReason(reason: unknown): boolean {
 function failoverReasonFromClassification(
   classification: FailoverClassification | null,
 ): FailoverReason | null {
-  return classification?.kind === "reason" ? classification.reason : null;
+  if (!classification) {
+    return null;
+  }
+  return classification.kind === "reason" ? classification.reason : "context_overflow";
 }
 
 function normalizeErrorSignal(err: unknown, providerHint?: string): FailoverSignal {

--- a/src/agents/runtime-plan/types.ts
+++ b/src/agents/runtime-plan/types.ts
@@ -41,6 +41,7 @@ export type AgentRuntimeFailoverReason =
   | "billing"
   | "server_error"
   | "timeout"
+  | "context_overflow"
   | "model_not_found"
   | "session_expired"
   | "empty_response"

--- a/src/cron/cron-protocol-conformance.test.ts
+++ b/src/cron/cron-protocol-conformance.test.ts
@@ -108,6 +108,7 @@ describe("cron protocol conformance", () => {
       "billing",
       "server_error",
       "timeout",
+      "context_overflow",
       "model_not_found",
       "session_expired",
       "empty_response",

--- a/src/cron/run-log.error-reason.test.ts
+++ b/src/cron/run-log.error-reason.test.ts
@@ -62,6 +62,7 @@ describe("cron run log errorReason", () => {
       "timeout",
       "model_not_found",
       "session_expired",
+      "context_overflow",
       "empty_response",
       "no_error_details",
       "unclassified",

--- a/src/cron/run-log/entry-codec.ts
+++ b/src/cron/run-log/entry-codec.ts
@@ -17,6 +17,7 @@ const CRON_FAILOVER_REASONS = new Set<FailoverReason>([
   "timeout",
   "model_not_found",
   "session_expired",
+  "context_overflow",
   "empty_response",
   "no_error_details",
   "unclassified",

--- a/src/gateway/openai-compat-errors.ts
+++ b/src/gateway/openai-compat-errors.ts
@@ -16,6 +16,7 @@ const ERROR_TYPE_BY_REASON: Partial<Record<FailoverReason, string>> = {
   auth: "authentication_error",
   auth_permanent: "permission_error",
   billing: "insufficient_quota",
+  context_overflow: "invalid_request_error",
   format: "invalid_request_error",
   model_not_found: "invalid_request_error",
   overloaded: "api_error",


### PR DESCRIPTION
Fixes #98897

## What Problem This Solves

Two claude-cli session-recovery defects found by a reliability audit:

1. **CLI context overflow permanently wedged the session.** "Prompt is too long" failures classified to a `context_overflow` classification that mapped to failover reason `unknown` with no retry code, so the existing fresh-session reseed machinery never fired and nothing on the main auto-reply path cleared the stale binding. Every subsequent turn resumed the same overflowing session and failed identically until a manual `/reset`. Since claude-cli sets `ownsNativeCompaction: true`, OpenClaw pre-turn compaction is a no-op for it — this path had no recovery at all. Same failure class as #97887.
2. **Live-session recovery retries ran against deleted run artifacts.** In non-capture mode (MCP loopback unavailable), artifact-cleanup ownership transferred into the live session; a retryable no-output timeout closed the session and deleted the temp `mcp.json` and skills-plugin dirs, then the fresh-session recovery retry re-ran on the same context whose argv still pointed at the deleted paths — the recovery spawn failed, defeating the retry.

## Why This Change Was Made

1. `context_overflow` is now a first-class failover reason across the closed reason unions (agent runtime, cron run-log, gateway protocol schema — additive enum extension, HTTP status 413, OpenAI-compat `invalid_request_error`). CLI context-overflow failures carry a `cli_context_overflow` retry code on both the live and one-shot paths, flow through `shouldRetryFreshCliSessionAfterFailover`, clear the stale binding, and take the existing fresh-session reseed retry so context is carried forward instead of dropped.
2. Run artifacts stay owned by the run (as capture mode already did): the ownership transfer into the live session is deleted, so a session close never deletes artifacts a pending retry still needs, and cleanup happens exactly once at run scope. The only spawn site builds sessions from the current turn's context, so no path respawns against another run's artifacts.

## User Impact

Long-running claude-cli sessions that hit a context overflow now recover automatically with a fresh reseeded session instead of failing every turn until a manual `/reset`. Recovery retries after no-output timeouts work in non-capture configurations instead of spawning against deleted config paths.

## Evidence

- New regression tests: context-overflow on a resumed turn clears the binding and retries with a reseed prompt (retry-budget and post-delivery guards still hold); non-capture live session + no-output timeout + fresh retry runs with existing artifact paths and cleans up exactly once.
- Validation: `node scripts/run-vitest.mjs` across cli-runner reliability/spawn/session, failover-error, cron run-log, and protocol conformance tests (400 tests pass); full remote `pnpm check:changed` green on Blacksmith Testbox `tbx_01kwgm9tmtgyw8rzwh48exqer7` (https://github.com/openclaw/openclaw/actions/runs/28567342178, exit 0); repo autoreview (branch mode) clean.
