### PR TITLE
fix(agents): cap one-shot Claude JSONL pending line buffer (#98896)

### DIFF
--- a/src/agents/cli-output.test.ts
+++ b/src/agents/cli-output.test.ts
@@ -6,6 +6,7 @@ import {
   parseCliJson,
   parseCliJsonl,
   supportsCliJsonlToolEvents,
+  CLAUDE_CLI_JSONL_LINE_EXCEEDED_ERROR,
   type CliToolResultDelta,
   type CliToolUseStartDelta,
 } from "./cli-output.js";
@@ -974,6 +975,28 @@ describe("createCliJsonlStreamingParser", () => {
         total: 1,
       },
       errorText: "Invalid stream payload",
+    });
+  });
+
+  it("caps pending JSONL line buffer to match Claude live session limits (#98896)", () => {
+    const parser = createCliJsonlStreamingParser({
+      backend: {
+        command: "claude",
+        output: "jsonl",
+        sessionIdFields: ["session_id"],
+      },
+      providerId: "claude-cli",
+      onAssistantDelta: () => {},
+      maxPendingLineChars: 1024,
+    });
+
+    parser.push("x".repeat(1025));
+
+    expect(parser.getOutput()).toEqual({
+      text: "",
+      sessionId: undefined,
+      usage: undefined,
+      errorText: CLAUDE_CLI_JSONL_LINE_EXCEEDED_ERROR,
     });
   });
 

--- a/src/agents/cli-output.ts
+++ b/src/agents/cli-output.ts
@@ -712,6 +712,8 @@ function dispatchGeminiCliStreamingToolEvent(params: {
 
 const GEMINI_CLI_ERROR_EVENT_FALLBACK = "Gemini CLI emitted an error event.";
 const GEMINI_CLI_RESULT_ERROR_FALLBACK = "Gemini CLI result status was error.";
+const CLAUDE_CLI_JSONL_MAX_PENDING_LINE_CHARS = 8 * 1024 * 1024;
+export const CLAUDE_CLI_JSONL_LINE_EXCEEDED_ERROR = "Claude CLI JSONL line exceeded output limit.";
 
 function isFallbackGeminiCliStreamJsonError(errorText: string): boolean {
   return (
@@ -747,6 +749,7 @@ export function createCliJsonlStreamingParser(params: {
   onToolUseStart?: (delta: CliToolUseStartDelta) => void;
   onToolResult?: (delta: CliToolResultDelta) => void;
   onCommentaryText?: (text: string) => void;
+  maxPendingLineChars?: number;
 }) {
   let lineBuffer = "";
   let assistantText = "";
@@ -760,6 +763,19 @@ export function createCliJsonlStreamingParser(params: {
   // always has a destination; a separate enable flag let it be dropped (#92092).
   const classifyClaudeCommentary =
     Boolean(params.onCommentaryText) && supportsCliJsonlToolEvents(params);
+  const maxPendingLineChars =
+    params.maxPendingLineChars ??
+    (supportsCliJsonlToolEvents(params) ? CLAUDE_CLI_JSONL_MAX_PENDING_LINE_CHARS : undefined);
+
+  const markLineBufferExceeded = () => {
+    output = {
+      text: "",
+      sessionId,
+      usage,
+      errorText: CLAUDE_CLI_JSONL_LINE_EXCEEDED_ERROR,
+    };
+    lineBuffer = "";
+  };
 
   const flushPendingClaudeAssistantText = () => {
     if (!pendingClaudeText) {
@@ -947,10 +963,14 @@ export function createCliJsonlStreamingParser(params: {
 
   return {
     push(chunk: string) {
-      if (!chunk) {
+      if (!chunk || output?.errorText) {
         return;
       }
       lineBuffer += chunk;
+      if (maxPendingLineChars !== undefined && lineBuffer.length > maxPendingLineChars) {
+        markLineBufferExceeded();
+        return;
+      }
       flushLines(false);
     },
     finish() {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where a babbling Claude CLI one-shot JSONL child could grow an unbounded `lineBuffer` while waiting for a newline, diverging from the live-session path that aborts at 8 MiB.

Related to #98896 (scoped to defect #3: pending line buffer cap).

## Why This Change Was Made

`createCliJsonlStreamingParser` now enforces the same 8 MiB pending-line ceiling as `claude-live-session.ts`. When exceeded, it surfaces `errorText` so `execute.ts` can fail the turn instead of allocating unbounded memory.

Non-goals: `is_error` classification (#98926), raw NDJSON fallback, POSIX UTF-8 chunk decoding.

## User Impact

One-shot Claude CLI turns with oversized JSONL lines fail fast with a clear output-limit error instead of risking multi-GB memory growth.

## Evidence

```
pnpm exec vitest run src/agents/cli-output.test.ts -t "caps pending JSONL"
# 1 passed
```

Test uses `maxPendingLineChars: 1024` override to assert `errorText` is set when a line grows past the cap without a newline.
