### PR TITLE
fix: Control row icons use inconsistent row styling (iOS)

### DIFF
--- a/apps/.i18n/native-source.json
+++ b/apps/.i18n/native-source.json
@@ -7779,7 +7779,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 56,
+      "line": 55,
       "path": "apps/ios/Sources/Design/RootTabsPhoneControlHub.swift",
       "source": "Gateway",
       "surface": "apple",
@@ -7787,7 +7787,7 @@
     },
     {
       "kind": "ui-modifier",
-      "line": 78,
+      "line": 77,
       "path": "apps/ios/Sources/Design/RootTabsPhoneControlHub.swift",
       "source": "Gateway \\(self.gatewayStateText), \\(self.sidebarActiveAgentTitle)",
       "surface": "apple",
@@ -7795,7 +7795,7 @@
     },
     {
       "kind": "ui-modifier",
-      "line": 79,
+      "line": 78,
       "path": "apps/ios/Sources/Design/RootTabsPhoneControlHub.swift",
       "source": "Opens Settings / Gateway",
       "surface": "apple",
@@ -7803,7 +7803,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 129,
+      "line": 125,
       "path": "apps/ios/Sources/Design/RootTabsPhoneControlHub.swift",
       "source": "Overview",
       "surface": "apple",
@@ -7811,7 +7811,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 151,
+      "line": 147,
       "path": "apps/ios/Sources/Design/RootTabsPhoneControlHub.swift",
       "source": "Instances",
       "surface": "apple",
@@ -7819,7 +7819,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 160,
+      "line": 156,
       "path": "apps/ios/Sources/Design/RootTabsPhoneControlHub.swift",
       "source": "Dreaming",
       "surface": "apple",
@@ -7827,7 +7827,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 165,
+      "line": 161,
       "path": "apps/ios/Sources/Design/RootTabsPhoneControlHub.swift",
       "source": "Usage",
       "surface": "apple",
@@ -7835,7 +7835,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 170,
+      "line": 166,
       "path": "apps/ios/Sources/Design/RootTabsPhoneControlHub.swift",
       "source": "Cron Jobs",
       "surface": "apple",
@@ -7843,7 +7843,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 225,
+      "line": 221,
       "path": "apps/ios/Sources/Design/RootTabsPhoneControlHub.swift",
       "source": "Online",
       "surface": "apple",
@@ -7851,7 +7851,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 226,
+      "line": 222,
       "path": "apps/ios/Sources/Design/RootTabsPhoneControlHub.swift",
       "source": "Connecting",
       "surface": "apple",
@@ -7859,7 +7859,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 227,
+      "line": 223,
       "path": "apps/ios/Sources/Design/RootTabsPhoneControlHub.swift",
       "source": "Attention",
       "surface": "apple",
@@ -7867,7 +7867,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 228,
+      "line": 224,
       "path": "apps/ios/Sources/Design/RootTabsPhoneControlHub.swift",
       "source": "Offline",
       "surface": "apple",

--- a/apps/ios/Sources/Design/RootTabsPhoneControlHub.swift
+++ b/apps/ios/Sources/Design/RootTabsPhoneControlHub.swift
@@ -48,10 +48,9 @@ struct RootTabsPhoneControlHub: View {
 
     private var gatewayRow: some View {
         HStack(spacing: 12) {
-            Image(systemName: "antenna.radiowaves.left.and.right")
-                .font(.body.weight(.semibold))
-                .foregroundStyle(self.gatewayStateColor)
-                .frame(width: 30, height: 30)
+            ProIconBadge(
+                systemName: "antenna.radiowaves.left.and.right",
+                color: self.gatewayStateColor)
             VStack(alignment: .leading, spacing: 2) {
                 Text("Gateway")
                     .font(.subheadline.weight(.semibold))
@@ -104,10 +103,7 @@ struct RootTabsPhoneControlHub: View {
 
     private func rowLabel(_ destination: RootTabs.SidebarDestination) -> some View {
         HStack(alignment: .center, spacing: 12) {
-            Image(systemName: destination.systemImage)
-                .font(.body.weight(.medium))
-                .foregroundStyle(.secondary)
-                .frame(width: 30, height: 30)
+            ProIconBadge(systemName: destination.systemImage, color: .secondary)
             Text(destination.title)
                 .font(.subheadline.weight(.semibold))
                 .foregroundStyle(.primary)


### PR DESCRIPTION
Closes #98916

## What Problem This Solves
The iOS phone Control tab used bare SF Symbol icons for list-row leading icons, while Settings list rows used rounded icon badges. This made similar row-list surfaces look inconsistent.

## Why This Change Was Made
Updated only the phone Control tab list-row leading icons to use the existing `ProIconBadge` style already used by Settings rows.

## User Impact
Control tab rows now visually match the row-list icon treatment used elsewhere in the app. Tab bar icons, chevrons, gateway status dot/text, Settings rows, detail screens, compact gateway pills, and shared badge styling are unchanged.

## Evidence
- `OpenClawLogicTests`: passed, 7 tests.
- Built and ran the iOS app on iPhone 17 Pro simulator.
- Ran `codex review --base origin/main`: no actionable regressions found.
- Visual comparison:

Control before:
<img width="368" height="800" alt="control-before" src="https://github.com/user-attachments/assets/ea74f223-28bf-4e7f-8fa1-24a4f49f02c8" />

Control after:
<img width="368" height="800" alt="control-after" src="https://github.com/user-attachments/assets/7cdadf9c-ecb0-4305-8fb1-c4332e4dff84" />

Settings:
<img width="368" height="800" alt="settings-after" src="https://github.com/user-attachments/assets/1b0bc1a6-3b5d-48f1-80b5-f45b8a34fbf7" />
