### PR TITLE
fix(browser): bound response text decoding

### DIFF
--- a/extensions/browser/src/browser/pw-tools-core.responses.ts
+++ b/extensions/browser/src/browser/pw-tools-core.responses.ts
@@ -29,6 +29,7 @@ export async function responseBodyViaPlaywright(opts: {
       ? Math.max(1, Math.min(5_000_000, Math.floor(opts.maxChars)))
       : 200_000;
   const timeout = normalizeTimeoutMs(opts.timeoutMs, 20_000);
+  const maxBytes = maxChars * 4;
 
   const page = await getPageForTargetId(opts);
   ensurePageState(page);
@@ -89,12 +90,14 @@ export async function responseBodyViaPlaywright(opts: {
   const headers = resp.headers?.();
 
   let bodyText = "";
+  let bodyByteLength = 0;
   try {
-    if (typeof resp.text === "function") {
-      bodyText = await resp.text();
-    } else if (typeof resp.body === "function") {
+    if (typeof resp.body === "function") {
       const buf = await resp.body();
-      bodyText = new TextDecoder("utf-8").decode(buf);
+      bodyByteLength = buf.byteLength;
+      // Playwright exposes only a full-body Buffer. Bound the second allocation
+      // while preserving the existing response-prefix contract.
+      bodyText = new TextDecoder("utf-8").decode(buf.subarray(0, maxBytes));
     }
   } catch (err) {
     throw new Error(`Failed to read response body for "${url}": ${String(err)}`, { cause: err });
@@ -106,6 +109,6 @@ export async function responseBodyViaPlaywright(opts: {
     status,
     headers,
     body: trimmed,
-    truncated: bodyText.length > maxChars ? true : undefined,
+    truncated: bodyByteLength > maxBytes || bodyText.length > maxChars ? true : undefined,
   };
 }

--- a/extensions/browser/src/browser/pw-tools-core.waits-next-download-saves-it.test.ts
+++ b/extensions/browser/src/browser/pw-tools-core.waits-next-download-saves-it.test.ts
@@ -503,11 +503,12 @@ describe("pw-tools-core", () => {
     const off = vi.fn();
     setPwToolsCoreCurrentPage({ on, off });
 
+    const bodyBytes = Buffer.from('{"ok":true,"value":123}');
     const resp = {
       url: () => "https://example.com/api/data",
       status: () => 200,
       headers: () => ({ "content-type": "application/json" }),
-      text: async () => '{"ok":true,"value":123}',
+      body: async () => bodyBytes,
     };
 
     const p = mod.responseBodyViaPlaywright({
@@ -529,5 +530,40 @@ describe("pw-tools-core", () => {
     expect(res.status).toBe(200);
     expect(res.body).toBe('{"ok":true');
     expect(res.truncated).toBe(true);
+  });
+
+  it("preserves the prefix while bounding decode for a large response", async () => {
+    let responseHandler: ((resp: unknown) => void) | undefined;
+    const on = vi.fn((event: string, handler: (resp: unknown) => void) => {
+      if (event === "response") {
+        responseHandler = handler;
+      }
+    });
+    const off = vi.fn();
+    setPwToolsCoreCurrentPage({ on, off });
+
+    const bodyBytes = Buffer.from("x".repeat(500_000));
+    const subarray = vi.spyOn(bodyBytes, "subarray");
+    const p = mod.responseBodyViaPlaywright({
+      cdpUrl: "http://127.0.0.1:18792",
+      targetId: "T1",
+      url: "**/large",
+      timeoutMs: 1000,
+      maxChars: 10,
+    });
+
+    await Promise.resolve();
+    if (!responseHandler) {
+      throw new Error("expected Playwright response handler");
+    }
+    responseHandler({
+      url: () => "https://example.com/large",
+      status: () => 200,
+      headers: () => ({ "content-type": "text/plain", "content-length": "500000" }),
+      body: async () => bodyBytes,
+    });
+
+    await expect(p).resolves.toMatchObject({ body: "x".repeat(10), truncated: true });
+    expect(subarray).toHaveBeenCalledWith(0, 40);
   });
 });


### PR DESCRIPTION
## What Problem This Solves

The Browser plugin's `responsebody` action used Playwright `Response.text()`. Playwright first obtains the complete response `Buffer` and then decodes the entire body into a JavaScript string, even though OpenClaw returns at most `maxChars`. Large responses therefore caused an avoidable second full-body allocation.

## Why This Change Was Made

The rewritten change keeps one passive Playwright response path and preserves the existing response prefix. It calls `Response.body()` once, decodes only `maxChars * 4` bytes (the maximum UTF-8 input needed for `maxChars` characters), then applies the existing character bound.

This is the strongest safe fix available through Playwright 1.60.0's public API: [`Response.body()` returns the complete Buffer and `Response.text()` calls it before decoding](https://github.com/microsoft/playwright/blob/v1.60.0/packages/playwright-core/src/client/network.ts#L727-L733). OpenClaw can avoid the second large string allocation, but cannot prevent Playwright's initial body buffering without an upstream streaming API.

The earlier content-length omission and CLI-message paths were removed. Known-large and chunked responses keep the same user-visible prefix instead of returning an empty body, and page delivery remains untouched.

## User Impact

- `responsebody` still returns the requested response prefix and `truncated: true` for oversized bodies.
- The page still receives the complete original response.
- OpenClaw no longer creates a full decoded string merely to return a bounded prefix.
- No config, auth, protocol, or browser-support changes.

## Evidence

Exact PR head: `781780e54dd183fa7d23ad1ceb141c197a80a52f`

- [Hosted CI run `28832020533`](https://github.com/openclaw/openclaw/actions/runs/28832020533): all selected checks passed; CodeQL completed neutral.
- Sanitized direct-AWS run `run_787bc7b5b70a` on fresh public-network lease `cbx_b5acd2f3429c` (`coral-prawn`, `c7a.8xlarge`): focused regression suite passed 12/12.
- The same exact-head run started a real Gateway and managed Chrome, returned `xxxxxxxxxx` with `truncated: true` from a 500,000-character response, and confirmed the page retained all 500,000 characters.
- The same run invoked an `openai/gpt-5.4` agent through the Gateway; the agent used the Browser tool against the live page and returned `RESPONSE_AGENT_OK`.
- Final-head autoreview against current `origin/main`: no actionable findings.

The live scenario serves a 500,000-character response, asserts that `responsebody --max-chars 10` returns `xxxxxxxxxx` with `truncated: true`, verifies the page received all 500,000 characters, then asks an `openai/gpt-5.4` agent through a real Gateway to open a second page with the Browser tool and return its marker.

## Scope and Limitations

This bounds OpenClaw's text decoding, not Playwright's initial response Buffer. No claim is made that the public Playwright API provides a fully streaming or constant-memory body read.
