### PR TITLE
fix(thread-ownership): bound 409 response read and preserve cancel semantics

### DIFF
--- a/extensions/thread-ownership/api.ts
+++ b/extensions/thread-ownership/api.ts
@@ -1,6 +1,7 @@
 // Thread Ownership API module exposes the plugin public contract.
 export type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 export { definePluginEntry, type OpenClawPluginApi } from "openclaw/plugin-sdk/plugin-entry";
+export { readProviderJsonResponse } from "openclaw/plugin-sdk/provider-http";
 export {
   fetchWithSsrFGuard,
   ssrfPolicyFromDangerouslyAllowPrivateNetwork,

--- a/extensions/thread-ownership/index.test.ts
+++ b/extensions/thread-ownership/index.test.ts
@@ -272,20 +272,39 @@ describe("thread-ownership plugin", () => {
       expect(infoMessage).toContain("cancelled send");
     });
 
-    it("cancels when the 409 conflict body is truncated or malformed", async () => {
-      // Simulates an over-cap or malformed 409 body: readResponseTextLimited
-      // stops at the cap, JSON.parse fails on the truncated text, but the 409
-      // status itself means another agent owns this thread — still cancel.
+    it("cancels when the forwarder conflict JSON is malformed", async () => {
+      vi.mocked(globalThis.fetch).mockResolvedValue(new Response("{", { status: 409 }));
+
+      const result = await sendSlackThreadMessage();
+
+      expect(result).toEqual({ cancel: true });
+      const warningMessage = requireFirstLogMessage(
+        api.logger.warn,
+        "ownership conflict warning log",
+      );
+      expect(warningMessage).toContain("conflict body unreadable");
+      expect(warningMessage).toContain("malformed JSON response");
+      const infoMessage = requireFirstLogMessage(api.logger.info, "ownership cancel info log");
+      expect(infoMessage).toContain("cancelled send");
+      expect(infoMessage).toContain("owned by unknown");
+    });
+
+    it("cancels when the forwarder conflict JSON exceeds the bounded read limit", async () => {
       vi.mocked(globalThis.fetch).mockResolvedValue(
-        new Response('{ "owner": "other-agent" ,', { status: 409 }),
+        new Response(JSON.stringify({ owner: "x".repeat(70 * 1024) }), { status: 409 }),
       );
 
       const result = await sendSlackThreadMessage();
 
       expect(result).toEqual({ cancel: true });
+      const warningMessage = requireFirstLogMessage(
+        api.logger.warn,
+        "ownership conflict warning log",
+      );
+      expect(warningMessage).toContain("conflict body unreadable");
+      expect(warningMessage).toContain("JSON response exceeds 65536 bytes");
       const infoMessage = requireFirstLogMessage(api.logger.info, "ownership cancel info log");
       expect(infoMessage).toContain("cancelled send");
-      // The owner field was unparseable, so the log falls back to "unknown".
       expect(infoMessage).toContain("owned by unknown");
     });
 

--- a/extensions/thread-ownership/index.test.ts
+++ b/extensions/thread-ownership/index.test.ts
@@ -272,6 +272,23 @@ describe("thread-ownership plugin", () => {
       expect(infoMessage).toContain("cancelled send");
     });
 
+    it("cancels when the 409 conflict body is truncated or malformed", async () => {
+      // Simulates an over-cap or malformed 409 body: readResponseTextLimited
+      // stops at the cap, JSON.parse fails on the truncated text, but the 409
+      // status itself means another agent owns this thread — still cancel.
+      vi.mocked(globalThis.fetch).mockResolvedValue(
+        new Response('{ "owner": "other-agent" ,', { status: 409 }),
+      );
+
+      const result = await sendSlackThreadMessage();
+
+      expect(result).toEqual({ cancel: true });
+      const infoMessage = requireFirstLogMessage(api.logger.info, "ownership cancel info log");
+      expect(infoMessage).toContain("cancelled send");
+      // The owner field was unparseable, so the log falls back to "unknown".
+      expect(infoMessage).toContain("owned by unknown");
+    });
+
     it("fails open on network error", async () => {
       vi.mocked(globalThis.fetch).mockRejectedValue(new Error("ECONNREFUSED"));
 

--- a/extensions/thread-ownership/index.ts
+++ b/extensions/thread-ownership/index.ts
@@ -1,5 +1,6 @@
 // Thread Ownership plugin entrypoint registers its OpenClaw integration.
 import { resolveLivePluginConfigObject } from "openclaw/plugin-sdk/plugin-config-runtime";
+import { readResponseTextLimited } from "openclaw/plugin-sdk/provider-http";
 import { normalizeOptionalString } from "openclaw/plugin-sdk/string-coerce-runtime";
 import { escapeRegExp } from "openclaw/plugin-sdk/text-utility-runtime";
 import {
@@ -9,6 +10,9 @@ import {
   type OpenClawConfig,
   type OpenClawPluginApi,
 } from "./api.js";
+
+/** Bound a forwarder 409 body; a compromised forwarder must not OOM the agent. */
+const THREAD_OWNERSHIP_CONFLICT_BODY_LIMIT_BYTES = 8 * 1024;
 
 type ThreadOwnershipConfig = {
   forwarderUrl?: string;
@@ -189,9 +193,18 @@ export default definePluginEntry({
             return undefined;
           }
           if (resp.status === 409) {
-            const body = (await resp.json()) as { owner?: string };
+            let owner: string | undefined;
+            try {
+              const body = JSON.parse(
+                await readResponseTextLimited(resp, THREAD_OWNERSHIP_CONFLICT_BODY_LIMIT_BYTES),
+              ) as { owner?: string };
+              owner = body.owner;
+            } catch {
+              // Truncated or malformed 409 body; the 409 status itself means
+              // another agent owns this thread — still cancel.
+            }
             api.logger.info?.(
-              `thread-ownership: cancelled send to ${channelId}:${threadTs} — owned by ${body.owner}`,
+              `thread-ownership: cancelled send to ${channelId}:${threadTs} — owned by ${owner ?? "unknown"}`,
             );
             return { cancel: true };
           }

--- a/extensions/thread-ownership/index.ts
+++ b/extensions/thread-ownership/index.ts
@@ -1,18 +1,17 @@
 // Thread Ownership plugin entrypoint registers its OpenClaw integration.
 import { resolveLivePluginConfigObject } from "openclaw/plugin-sdk/plugin-config-runtime";
-import { readResponseTextLimited } from "openclaw/plugin-sdk/provider-http";
 import { normalizeOptionalString } from "openclaw/plugin-sdk/string-coerce-runtime";
 import { escapeRegExp } from "openclaw/plugin-sdk/text-utility-runtime";
 import {
   definePluginEntry,
   fetchWithSsrFGuard,
+  readProviderJsonResponse,
   ssrfPolicyFromDangerouslyAllowPrivateNetwork,
   type OpenClawConfig,
   type OpenClawPluginApi,
 } from "./api.js";
 
-/** Bound a forwarder 409 body; a compromised forwarder must not OOM the agent. */
-const THREAD_OWNERSHIP_CONFLICT_BODY_LIMIT_BYTES = 8 * 1024;
+const THREAD_OWNERSHIP_CONFLICT_BODY_LIMIT_BYTES = 64 * 1024;
 
 type ThreadOwnershipConfig = {
   forwarderUrl?: string;
@@ -193,18 +192,24 @@ export default definePluginEntry({
             return undefined;
           }
           if (resp.status === 409) {
-            let owner: string | undefined;
+            let owner = "unknown";
             try {
-              const body = JSON.parse(
-                await readResponseTextLimited(resp, THREAD_OWNERSHIP_CONFLICT_BODY_LIMIT_BYTES),
-              ) as { owner?: string };
-              owner = body.owner;
-            } catch {
-              // Truncated or malformed 409 body; the 409 status itself means
-              // another agent owns this thread — still cancel.
+              const body = await readProviderJsonResponse<{ owner?: unknown }>(
+                resp,
+                "thread-ownership forwarder conflict",
+                { maxBytes: THREAD_OWNERSHIP_CONFLICT_BODY_LIMIT_BYTES },
+              );
+              if (typeof body.owner === "string" && body.owner) {
+                owner = body.owner;
+              }
+            } catch (error) {
+              // A 409 is authoritative even when its body is malformed or oversized.
+              api.logger.warn?.(
+                `thread-ownership: conflict body unreadable (${String(error)}), cancelling send`,
+              );
             }
             api.logger.info?.(
-              `thread-ownership: cancelled send to ${channelId}:${threadTs} — owned by ${owner ?? "unknown"}`,
+              `thread-ownership: cancelled send to ${channelId}:${threadTs} — owned by ${owner}`,
             );
             return { cancel: true };
           }


### PR DESCRIPTION
## What Problem This Solves

The thread-ownership plugin's 409 conflict path still used an unbounded `resp.json()`, inconsistent with the bounded readers shipped across the other channel/provider success paths (discord webhook, huggingface `/v1/models`, and others already use `readProviderJsonResponse` / `readResponseTextLimited`). A compromised or buggy forwarder returning a multi-GB 409 body would buffer the entire body before `JSON.parse` even runs, OOMing the agent.

> Scope note: an earlier version of this branch also bounded the discord webhook success read and the huggingface `/v1/models` read. Those two were superseded upstream by #98098 (`fix(providers): bound successful OAuth and webhook responses`) and #101079 (`fix(extensions/huggingface): bound model discovery JSON response read to prevent OOM`), which both use the shared `readProviderJsonResponse` helper. This branch was rebased onto current `main` and now carries only the thread-ownership fix, which is still open on `main` (unbounded `resp.json()`).

## Why This Change Was Made

Same partial-hardening pattern already shipped across comfy, anthropic-oauth, sms, matrix, telegram, and discord/api.ts. The thread-ownership 409 path was the remaining outlier: its success/409 body read was unbounded and reached `JSON.parse` over an internal forwarder whose response size is not guaranteed.

A 409 from the forwarder means another agent owns the thread — the send must be cancelled regardless of whether the body parses. The fix preserves that cancel semantics even when the body is truncated or malformed.

## User Impact

Well-formed 409 responses unchanged. A huge/non-JSON/truncated 409 body is capped (8 KiB) and the send is still cancelled (owner logged as `unknown`), instead of OOMing the agent or crashing the ownership check. The prior behavior on a truncated 409 body was an unhandled `SyntaxError` from `JSON.parse` that fell into the outer catch and allowed the send — this fix makes a malformed 409 cancel correctly.

## Real behavior proof

- **Behavior addressed:** Unbounded thread-ownership 409 body read; OOM risk + lost cancel semantics on a truncated/malformed 409.
- **Real environment tested:** Linux x86_64, Node v24.14.0, commit `47c03956dd` on branch `fix/unbounded-success-json-reads` (rebased onto current `main`).
- **Exact steps or command run after this patch:** `node --import tsx verify-thread-ownership-real.mjs` — stands up a REAL local HTTP server as the Slack forwarder and drives the REAL exported plugin entrypoint (`register` + the `message_sending` hook) from `extensions/thread-ownership/index.ts`. `globalThis.fetch` is NOT mocked: the production `fetchWithSsrFGuard` handles each request over a real socket (each case's local server confirms it served the 409). The SSRF guard is told to allow private-network access, exactly like prod.
- **Evidence after fix:** Terminal capture of `node` runtime verification (live stdout, copied verbatim — non-mocked, real forwarder + real plugin entrypoint):

  ```text
  Driving the real exported plugin entrypoint (register + message_sending hook).
  globalThis.fetch is NOT mocked; each case uses its own real local HTTP server.

  Case 1 (well-formed 409 body):
    [PASS]   local server served the 409
    [PASS]   cancel=true — result={"cancel":true}
    [PASS]   owner parsed as 'other-agent' — [info] thread-ownership: cancelled send to C100:111 — owned by other-agent

  Case 2 (malformed/truncated 409 body):
    [PASS]   local server served the 409
    [PASS]   cancel=true — result={"cancel":true}
    [PASS]   owner falls back to 'unknown' — [info] thread-ownership: cancelled send to C101:222 — owned by unknown

  Case 3 (oversized 409 body, 64 KiB vs 8 KiB cap):
    [PASS]   local server served the 409
    [PASS]   cancel=true — result={"cancel":true}
    [PASS]   owner falls back to 'unknown' (64 KiB body truncated at 8 KiB cap -> unparseable) — [info] thread-ownership: cancelled send to C102:333 — owned by unknown

  Verdict: all cases PASS — well-formed 409 cancels with parsed owner; malformed + oversized 409 still cancel (owner 'unknown') without crash or unbounded buffering.
  ```

- **Observed result after fix:** Against a real local forwarder, the real `message_sending` hook (driven through `register`) returns `{ cancel: true }` for all three 409 shapes. A well-formed 409 cancels with the parsed owner (`other-agent`); a malformed/truncated 409 and a 64 KiB oversized 409 both cancel with owner `unknown` — proving the body is capped (the oversized body is truncated at the 8 KiB cap, so `JSON.parse` fails and the 409 status alone drives cancellation) without unbounded buffering or a crash.
- **What was not tested:** A live multi-GB response from a production forwarder. The proof drives the real production entrypoint over a real socket; the oversized case uses a 64 KiB body (8x the cap) to exercise the truncation path deterministically.

## Tests and validation

```text
$ node scripts/run-vitest.mjs extensions/thread-ownership/index.test.ts   (22 passed)
```

## Risk checklist

- Cap size: thread-ownership 8 KiB (409 owner body is ~30 bytes).
- User-visible behavior: Yes (intended) — a malformed/truncated 409 body now cancels the send (owner `unknown`) instead of throwing into the outer catch and allowing it; well-formed 409 unchanged.
- Config/env/migration: No.
- Security: Yes (improvement) — bounds the 409 body read, mitigating OOM from a compromised/buggy forwarder.
- Plugins/providers/channels/SDK: Yes (bounded) — touches one extension; uses the shared `readResponseTextLimited` already used elsewhere.
- Highest-risk area: a legitimate 409 body exceeding 8 KiB would fail to parse and cancel with `owner=unknown` — but a 409 owner field is tiny in practice, and the cancel behavior is the correct 409 semantics, so this is strictly safer than the prior crash/allow.
- Mitigation: existing test suite passes (22 tests) + real local-forwarder runtime verification of well-formed / malformed / oversized 409 cancel semantics.

Closes: N/A (no existing issue)


---

## Exact-head refresh

Rebased onto `upstream/main` `07284af7489d2b7a1e0a69b738968b707e21f0fb`; current head is `afa0f8fe32f61e493ba96c48082579f7d6f15c76`.

The 409 path now uses the existing `readProviderJsonResponse` SDK contract with a 64 KiB cap rather than a local text-read/`JSON.parse` pair. A 409 remains authoritative: malformed or oversized response bodies log a bounded diagnostic and still return `{ cancel: true }`, while a valid owner remains visible.

### Node runtime evidence

Terminal capture of `node --import tsx /tmp/verify-thread-ownership-real.mjs` against the real exported plugin entrypoint, a real local forwarder, and unmocked `globalThis.fetch`:

```text
Case 1 (well-formed 409): local server served request; cancel=true; owner=other-agent PASS
Case 2 (malformed 409): local server served request; cancel=true; owner=unknown PASS
Case 3 (70 KiB 409 vs 64 KiB cap): local server served request; cancel=true; owner=unknown PASS
Verdict: all cases PASS
```

### Validation

```text
node scripts/run-vitest.mjs run extensions/thread-ownership/index.test.ts  # 23 passed
node scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.extensions.json <three changed files>  # 0 errors
node scripts/run-tsgo.mjs -p tsconfig.extensions.json --incremental --tsBuildInfoFile /tmp/openclaw-98941-extensions.tsbuildinfo  # exit 0
node scripts/run-tsgo.mjs -p test/tsconfig/tsconfig.extensions.test.json --incremental --tsBuildInfoFile /tmp/openclaw-98941-extension-tests.tsbuildinfo  # exit 0
node scripts/build-all.mjs  # exit 0
```

Direct dependency contract reviewed: `src/agents/provider-http-errors.ts:270` bounds `readProviderJsonResponse` with `readResponseWithLimit`, reports overflow with the supplied label, and normalizes malformed JSON. No config, migration, public SDK, or new dependency surface changed.
