### PR TITLE
fix(cron): restore persistent session targets

### DIFF
--- a/docs/automation/cron-jobs.md
+++ b/docs/automation/cron-jobs.md
@@ -87,16 +87,16 @@ This fires ~5–6 times per month instead of 0–1 times per month. OpenClaw use
 
 ## Execution styles
 
-| Style           | `--session` value   | Runs in                  | Best for                       |
-| --------------- | ------------------- | ------------------------ | ------------------------------ |
-| Main session    | `main`              | Dedicated cron wake lane | Reminders, system events       |
-| Isolated        | `isolated`          | Dedicated `cron:<jobId>` | Reports, background chores     |
-| Current session | `current`           | Detached cron run        | Context-aware recurring work   |
-| Custom session  | `session:custom-id` | Detached cron run        | Targeting a known chat/session |
+| Style           | `--session` value   | Runs in                  | Best for                        |
+| --------------- | ------------------- | ------------------------ | ------------------------------- |
+| Main session    | `main`              | Dedicated cron wake lane | Reminders, system events        |
+| Isolated        | `isolated`          | Dedicated `cron:<jobId>` | Reports, background chores      |
+| Current session | `current`           | Bound at creation time   | Context-aware recurring work    |
+| Custom session  | `session:custom-id` | Persistent named session | Workflows that build on history |
 
 <AccordionGroup>
   <Accordion title="Main session vs isolated vs custom">
-    **Main session** jobs enqueue a system event into a cron-owned run lane and optionally wake the heartbeat (`--wake now` or `--wake next-heartbeat`). They can use the target main session's last delivery context for replies, but they do not append routine cron turns to the human chat lane and do not extend daily/idle reset freshness for the target session. **Isolated** jobs run a dedicated agent turn with a fresh session. **Current** and **custom** session jobs (`current`, `session:xxx`) can use the selected chat/session for delivery context and safe preference seeding, but each run still executes in a detached cron session so scheduled work does not block or pollute the live conversation transcript.
+    **Main session** jobs enqueue a system event into a cron-owned run lane and optionally wake the heartbeat (`--wake now` or `--wake next-heartbeat`). They can use the target main session's last delivery context for replies, but they do not append routine cron turns to the human chat lane and do not extend daily/idle reset freshness for the target session. **Isolated** jobs run a dedicated agent turn with a fresh session. **Custom sessions** (`session:xxx`) persist context across runs, enabling workflows like daily standups that build on previous summaries.
 
     Main-session cron events are self-contained system-event reminders. They do
     not automatically include the default heartbeat prompt's "Read
@@ -105,8 +105,8 @@ This fires ~5–6 times per month instead of 0–1 times per month. OpenClaw use
     agent's own instructions.
 
   </Accordion>
-  <Accordion title="What 'fresh session' means for detached jobs">
-    For isolated, current-session, and custom-session jobs, "fresh session" means a new transcript/session id for each run. OpenClaw may carry safe preferences such as thinking/fast/verbose settings, labels, and explicit user-selected model/auth overrides. Detached runs do not inherit ambient conversation context from an older cron row: channel/group routing, send or queue policy, elevation, origin, or ACP runtime binding. Put durable recurring-work state in the prompt, workspace files, tools, or the system the job operates on rather than relying on a live chat transcript as cron memory.
+  <Accordion title="What 'fresh session' means for isolated jobs">
+    For isolated jobs, "fresh session" means a new transcript/session id for each run. OpenClaw may carry safe preferences such as thinking/fast/verbose settings, labels, and explicit user-selected model/auth overrides, but it does not inherit ambient conversation context from an older cron row: channel/group routing, send or queue policy, elevation, origin, or ACP runtime binding. Use `current` or `session:<id>` when a recurring job should deliberately build on the same conversation context.
   </Accordion>
   <Accordion title="Runtime cleanup">
     For isolated jobs, runtime teardown now includes best-effort browser cleanup for that cron session. Cleanup failures are ignored so the actual cron result still wins.

--- a/docs/automation/taskflow.md
+++ b/docs/automation/taskflow.md
@@ -25,7 +25,7 @@ Use Task Flow when work spans multiple sequential or branching steps and you nee
 For recurring workflows such as market intelligence briefings, treat the schedule, orchestration, and reliability checks as separate layers:
 
 1. Use [Scheduled Tasks](/automation/cron-jobs) for timing.
-2. Store prior context in the workflow's own files, database, or tool state.
+2. Use a persistent cron session when the workflow should build on prior context.
 3. Use [Lobster](/tools/lobster) for deterministic steps, approval gates, and resume tokens.
 4. Use Task Flow to track the multi-step run across child tasks, waits, retries, and gateway restarts.
 
@@ -43,7 +43,7 @@ openclaw cron add \
   --to "channel:C1234567890"
 ```
 
-Use `session:<id>` when the job should target a known chat/session for delivery context or safe preference seeding. Cron still executes each run in a detached session, so put previous run summaries and standing workflow state in explicit storage the job can read.
+Use `session:<id>` instead of `isolated` when the recurring workflow needs deliberate history, previous run summaries, or standing context. Use `isolated` when each run should start fresh and all required state is explicit in the workflow.
 
 Inside the workflow, put reliability checks before the LLM summary step:
 

--- a/src/cron/delivery-plan.ts
+++ b/src/cron/delivery-plan.ts
@@ -7,7 +7,6 @@ import {
 } from "@openclaw/normalization-core/string-coerce";
 import type { CronFailureDestinationConfig } from "../config/types.cron.js";
 import { resolveTargetPrefixedChannel } from "../infra/outbound/channel-target-prefix.js";
-import { isDetachedCronSessionTarget } from "./session-target.js";
 import type { CronDelivery, CronDeliveryMode, CronJob, CronMessageChannel } from "./types.js";
 
 /** Normalized routing plan for a cron job's primary delivery behavior. */
@@ -106,7 +105,10 @@ export function resolveCronDeliveryPlan(job: CronJob): CronDeliveryPlan {
 
   const isDetachedOutputJob =
     (job.payload.kind === "agentTurn" || job.payload.kind === "command") &&
-    isDetachedCronSessionTarget(job.sessionTarget);
+    typeof job.sessionTarget === "string" &&
+    (job.sessionTarget === "isolated" ||
+      job.sessionTarget === "current" ||
+      job.sessionTarget.startsWith("session:"));
   // Isolated/current/session output jobs default to announce delivery so their
   // result reaches the initiating session unless the job opts out.
   const resolvedMode = isDetachedOutputJob ? "announce" : "none";

--- a/src/cron/isolated-agent.session-identity.test.ts
+++ b/src/cron/isolated-agent.session-identity.test.ts
@@ -153,13 +153,12 @@ describe("runCronIsolatedAgentTurn session identity", () => {
     });
   });
 
-  it("persists rotated transcript identity for current-bound cron runs under the cron key", async () => {
+  it("persists rotated transcript identity for current-bound cron runs", async () => {
     await withTempHome(async (home) => {
       const deps = makeDeps();
       const boundSessionKey = "agent:main:telegram:direct:42";
       const originalSessionFile = path.join(home, "bound-session.jsonl");
       const rotatedSessionFile = path.join(home, "bound-session-rotated.jsonl");
-      await fs.writeFile(rotatedSessionFile, "", "utf-8");
       const storePath = await writeSessionStoreEntries(home, {
         [boundSessionKey]: {
           sessionId: "bound-session",
@@ -197,7 +196,6 @@ describe("runCronIsolatedAgentTurn session identity", () => {
         },
         { sessionContext: { sessionKey: boundSessionKey } },
       ) as CronJob;
-      const executionSessionKey = `agent:main:cron:${currentBoundJob.id}`;
 
       const res = await runCronIsolatedAgentTurn({
         cfg: makeCfg(home, storePath),
@@ -218,25 +216,19 @@ describe("runCronIsolatedAgentTurn session identity", () => {
       expect(finalPersist?.[0]).toBe(storePath);
       const persistedStore: Record<string, { [key: string]: unknown }> = {};
       (finalPersist![1] as (store: typeof persistedStore) => void)(persistedStore);
-      expect(persistedStore[executionSessionKey]).toEqual(
+      expect(persistedStore[boundSessionKey]).toEqual(
         expect.objectContaining({
           sessionId: "bound-session-rotated",
           sessionFile: rotatedSessionFile,
-          usageFamilyKey: executionSessionKey,
-          usageFamilySessionIds: expect.arrayContaining(["bound-session-rotated"]),
+          usageFamilyKey: boundSessionKey,
+          usageFamilySessionIds: ["bound-session", "bound-session-rotated"],
         }),
       );
 
-      await expect(readSessionEntry(storePath, executionSessionKey)).resolves.toEqual(
+      await expect(readSessionEntry(storePath, boundSessionKey)).resolves.toEqual(
         expect.objectContaining({
           sessionId: "bound-session-rotated",
           sessionFile: rotatedSessionFile,
-        }),
-      );
-      await expect(readSessionEntry(storePath, boundSessionKey)).resolves.toEqual(
-        expect.objectContaining({
-          sessionId: "bound-session",
-          sessionFile: originalSessionFile,
         }),
       );
     });

--- a/src/cron/isolated-agent/run-executor.ts
+++ b/src/cron/isolated-agent/run-executor.ts
@@ -1,4 +1,4 @@
-/** Executes detached cron prompts with model fallbacks and interim-ack retries. */
+/** Executes isolated cron prompts with model fallbacks and interim-ack retries. */
 import { createHash } from "node:crypto";
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import type { BootstrapContextMode } from "../../agents/bootstrap-files.js";
@@ -12,7 +12,6 @@ import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import type { SourceDeliveryPlan } from "../../infra/outbound/source-delivery-plan.js";
 import { createLazyImportLoader } from "../../shared/lazy-promise.js";
 import type { SkillSnapshot } from "../../skills/types.js";
-import { isDetachedCronSessionTarget } from "../session-target.js";
 import type { CronAgentExecutionPhaseUpdate, CronJob } from "../types.js";
 import {
   resolveCronChannelOutputPolicy,
@@ -67,19 +66,19 @@ const COMMAND_STYLE_CRON_PREFIX =
   /^(?:(?:[A-Z_][A-Z0-9_]*=\S+\s+)+)?(?:cd\s+\S+|(?:\.{1,2}|~)?\/\S+|[A-Za-z]:[\\/]\S+|(?:bash|bun|cargo|deno|docker|gh|git|go|make|node|npm|npx|pnpm|python|python3|ruby|sh|tsx|uv|zsh)\b)/u;
 const MAX_CRON_DELIVERY_TARGET_CONTEXT_CHARS = 1000;
 
-function resolveDetachedCronPromptCacheKey(params: {
+function resolveIsolatedCronPromptCacheKey(params: {
   job: CronJob;
   agentId: string;
   agentSessionKey: string;
   provider: string;
   model: string;
 }): string | undefined {
-  if (!isDetachedCronSessionTarget(params.job.sessionTarget)) {
+  if (params.job.sessionTarget !== "isolated") {
     return undefined;
   }
   const material = JSON.stringify({
     version: 1,
-    kind: "detached-cron",
+    kind: "isolated-cron",
     jobId: params.job.id,
     agentId: params.agentId,
     agentSessionKey: params.agentSessionKey,
@@ -87,7 +86,7 @@ function resolveDetachedCronPromptCacheKey(params: {
     model: params.model,
   });
   const digest = createHash("sha256").update(material).digest("hex").slice(0, 32);
-  // Detached cron rotates transcript/session ids per run; keep cache affinity
+  // Isolated cron rotates transcript/session ids per run; keep cache affinity
   // on stable job identity without sending raw local session labels upstream.
   return `openclaw-cron-${digest}`;
 }
@@ -333,7 +332,7 @@ export function createCronPromptExecutor(params: {
             agentId: params.agentId,
             trigger: "cron",
             jobId: params.job.id,
-            cleanupCliLiveSessionOnRunEnd: isDetachedCronSessionTarget(params.job.sessionTarget),
+            cleanupCliLiveSessionOnRunEnd: params.job.sessionTarget === "isolated",
             sessionFile,
             workspaceDir: params.workspaceDir,
             config: params.cfgWithAgentDefaults,
@@ -371,7 +370,7 @@ export function createCronPromptExecutor(params: {
           return result;
         }
         const { resolveFastModeState, runEmbeddedAgent } = await loadCronEmbeddedRuntime();
-        const promptCacheKey = resolveDetachedCronPromptCacheKey({
+        const promptCacheKey = resolveIsolatedCronPromptCacheKey({
           job: params.job,
           agentId: params.agentId,
           agentSessionKey: params.agentSessionKey,
@@ -392,7 +391,7 @@ export function createCronPromptExecutor(params: {
           agentId: params.agentId,
           trigger: "cron",
           jobId: params.job.id,
-          cleanupBundleMcpOnRunEnd: isDetachedCronSessionTarget(params.job.sessionTarget),
+          cleanupBundleMcpOnRunEnd: params.job.sessionTarget === "isolated",
           allowGatewaySubagentBinding: true,
           messageChannel,
           agentAccountId: params.resolvedDelivery.accountId,

--- a/src/cron/isolated-agent/run-session-state.test.ts
+++ b/src/cron/isolated-agent/run-session-state.test.ts
@@ -144,32 +144,26 @@ describe("createPersistCronSessionEntry", () => {
     });
   });
 
-  it("persists non-resumable cron state under the supplied execution session key", async () => {
+  it("persists explicit session-bound cron state under the requested session key", async () => {
     const cronSession = makeCronSession();
     const updateSessionStore = vi.fn(
       async (_storePath, update: (store: Record<string, SessionEntry>) => void) => {
         const store: Record<string, SessionEntry> = {};
         update(store);
-        expect(store["agent:main:cron:job"]).toEqual({
-          updatedAt: 1000,
-          systemSent: true,
-        });
+        expect(store["agent:main:session"]).toBe(cronSession.sessionEntry);
       },
     );
 
     const persist = createPersistCronSessionEntry({
       isFastTestEnv: false,
       cronSession,
-      agentSessionKey: "agent:main:cron:job",
+      agentSessionKey: "agent:main:session",
       updateSessionStore,
     });
 
     await persist();
 
-    expect(cronSession.store["agent:main:cron:job"]).toEqual({
-      updatedAt: 1000,
-      systemSent: true,
-    });
+    expect(cronSession.store["agent:main:session"]).toBe(cronSession.sessionEntry);
   });
 
   it("adopts rotated run transcript metadata before persisting session-bound cron state", async () => {

--- a/src/cron/isolated-agent/run.fast-mode.test.ts
+++ b/src/cron/isolated-agent/run.fast-mode.test.ts
@@ -128,22 +128,25 @@ async function runFastModeCase(params: {
     params.expectedCleanupBundleMcpOnRunEnd ?? true,
   );
   expect(embeddedRunParams.allowGatewaySubagentBinding).toBe(true);
-  const isDetached =
-    (params.sessionTarget ?? "isolated") === "isolated" ||
-    params.sessionTarget === "current" ||
-    params.sessionTarget?.startsWith("session:");
+  const isIsolated = (params.sessionTarget ?? "isolated") === "isolated";
   if (params.expectedRetiredSessionId) {
-    const retireParams = retireSessionMcpRuntimeMock.mock.calls[0]?.[0];
+    expect(retireSessionMcpRuntimeMock).toHaveBeenCalledOnce();
+    const [retireParams] = requireFirstMockCall(
+      retireSessionMcpRuntimeMock,
+      "retire session mcp runtime",
+    );
     expect(retireParams.sessionId).toBe(params.expectedRetiredSessionId);
     expect(retireParams.reason).toBe("cron-session-rollover");
+    return;
   }
-  if (isDetached) {
-    // disposeCronRunContext retires MCP for detached cron sessions.
-    expect(retireSessionMcpRuntimeMock).toHaveBeenCalledTimes(
-      params.expectedRetiredSessionId ? 2 : 1,
+  if (isIsolated) {
+    // disposeCronRunContext now retires MCP for isolated sessions
+    expect(retireSessionMcpRuntimeMock).toHaveBeenCalledOnce();
+    const [disposeRetireParams] = requireFirstMockCall(
+      retireSessionMcpRuntimeMock,
+      "dispose retire session mcp runtime",
     );
-    const disposeRetireParams = retireSessionMcpRuntimeMock.mock.calls.at(-1)?.[0];
-    expect(disposeRetireParams.reason).toBe("detached-cron-dispose");
+    expect(disposeRetireParams.reason).toBe("isolated-cron-dispose");
   } else {
     expect(retireSessionMcpRuntimeMock).not.toHaveBeenCalled();
   }
@@ -245,21 +248,23 @@ describe("runCronIsolatedAgentTurn — fast mode", () => {
     });
   });
 
-  it("cleans up bundled MCP runtime state for explicit session cron targets", async () => {
+  it("preserves bundled MCP runtime state for persistent cron session targets", async () => {
     await runFastModeCase({
       configFastMode: true,
       expectedFastMode: true,
-      message: "test explicit session cron target",
+      expectedCleanupBundleMcpOnRunEnd: false,
+      message: "test persistent cron session",
       sessionTarget: "session:agent:main:main:thread:9999",
     });
   });
 
-  it("cleans up bundled MCP runtime state when a detached cron session rolls over", async () => {
+  it("retires the previous bundled MCP runtime when a persistent cron session rolls over", async () => {
     await runFastModeCase({
       configFastMode: true,
       expectedFastMode: true,
+      expectedCleanupBundleMcpOnRunEnd: false,
       expectedRetiredSessionId: "stale-session-id",
-      message: "test detached cron session rollover",
+      message: "test persistent cron session rollover",
       previousSessionId: "stale-session-id",
       sessionId: "rotated-session-id",
       sessionTarget: "session:agent:main:main:thread:9999",

--- a/src/cron/isolated-agent/run.message-tool-policy.test.ts
+++ b/src/cron/isolated-agent/run.message-tool-policy.test.ts
@@ -996,12 +996,12 @@ describe("runCronIsolatedAgentTurn message tool policy", () => {
     expect(getAgentRunContext("test-session-id")).toBeUndefined();
   });
 
-  it("releases preexisting run context after detached current-session completion", async () => {
+  it("keeps shared cron run context references active after completion", async () => {
     const cronSession = makeCronSession({
       store: { "agent:default:cron:message-tool-policy": { retained: true } },
     });
     resolveCronSessionMock.mockReturnValue(cronSession);
-    const { getAgentRunContext, registerAgentRunContext } =
+    const { clearAgentRunContext, getAgentRunContext, registerAgentRunContext } =
       await import("../../infra/agent-events.js");
     registerAgentRunContext("test-session-id", {
       sessionKey: "agent:default:cron:message-tool-policy",
@@ -1015,8 +1015,11 @@ describe("runCronIsolatedAgentTurn message tool policy", () => {
       job: currentSessionJob as never,
     });
 
-    expect(getAgentRunContext("test-session-id")).toBeUndefined();
+    expect(getAgentRunContext("test-session-id")).toMatchObject({
+      sessionKey: "agent:default:cron:message-tool-policy",
+    });
     expect(cronSession.store).toBeUndefined();
+    clearAgentRunContext("test-session-id");
   });
 
   it("releases a shared cron run context created by this invocation", async () => {

--- a/src/cron/isolated-agent/run.session-key-isolation.test.ts
+++ b/src/cron/isolated-agent/run.session-key-isolation.test.ts
@@ -123,7 +123,7 @@ describe("runCronIsolatedAgentTurn isolated session identity", () => {
     expect(requests[0]?.promptCacheKey).toMatch(/^openclaw-cron-[a-f0-9]{32}$/u);
   });
 
-  it("uses a run-scoped execution key for explicit session-bound cron", async () => {
+  it("keeps explicit session-bound cron execution on the requested session key", async () => {
     resolveCronSessionMock.mockReturnValue(
       makeCronSession({
         sessionEntry: {
@@ -144,14 +144,7 @@ describe("runCronIsolatedAgentTurn isolated session identity", () => {
     );
 
     expect(result.status).toBe("ok");
-    expect(result.sessionKey).toBe("agent:default:cron:test-job:run:bound-run-1");
-    const sessionRequest = requireFirstMockArg(
-      resolveCronSessionMock,
-      "resolveCronSessionMock",
-    ) as { forceNew?: boolean; sessionKey?: string; sourceSessionKey?: string };
-    expect(sessionRequest.forceNew).toBe(true);
-    expect(sessionRequest.sessionKey).toBe("agent:default:cron:test-job");
-    expect(sessionRequest.sourceSessionKey).toBe("agent:default:project-alpha-monitor");
+    expect(result.sessionKey).toBe("agent:default:project-alpha-monitor");
     expect(runEmbeddedAgentMock).toHaveBeenCalledOnce();
     const runRequest = requireFirstMockArg(runEmbeddedAgentMock, "runEmbeddedAgentMock") as {
       sessionId?: string;
@@ -161,9 +154,8 @@ describe("runCronIsolatedAgentTurn isolated session identity", () => {
       bootstrapContextRunKind?: string;
     };
     expect(runRequest.sessionId).toBe("bound-run-1");
-    expect(runRequest.sessionKey).toBe("agent:default:cron:test-job:run:bound-run-1");
-    expect(runRequest.sessionKey).not.toBe("agent:default:project-alpha-monitor");
-    expect(runRequest.promptCacheKey).toMatch(/^openclaw-cron-[a-f0-9]{32}$/u);
+    expect(runRequest.sessionKey).toBe("agent:default:project-alpha-monitor");
+    expect(runRequest.promptCacheKey).toBeUndefined();
     expect(runRequest.bootstrapContextMode).toBeUndefined();
     expect(runRequest.bootstrapContextRunKind).toBe("cron");
   });

--- a/src/cron/isolated-agent/run.ts
+++ b/src/cron/isolated-agent/run.ts
@@ -38,7 +38,6 @@ import {
 import { createDiagnosticMessageLifecycle } from "../../logging/message-lifecycle.js";
 import { isCommandLaneTaskTimeoutError } from "../../process/command-queue.js";
 import { CommandLane } from "../../process/lanes.js";
-import { isCronSessionKey } from "../../sessions/session-key-utils.js";
 import { createLazyImportLoader } from "../../shared/lazy-promise.js";
 import { resolveNonNegativeNumber } from "../../shared/number-coercion.js";
 import { resolveCronSkillsSnapshot } from "../../skills/runtime/cron-snapshot.js";
@@ -56,7 +55,7 @@ import {
   toolsAllowRequestsWebSearch,
 } from "../run-diagnostics.js";
 import { resolveCronAbortReasonText } from "../service/execution-errors.js";
-import { isDetachedCronSessionTarget, resolveCronDeliverySessionKey } from "../session-target.js";
+import { resolveCronDeliverySessionKey } from "../session-target.js";
 import type {
   CronAgentExecutionPhaseUpdate,
   CronAgentExecutionStarted,
@@ -617,27 +616,12 @@ async function prepareCronRunContext(params: {
   };
 
   const baseSessionKey = (input.sessionKey?.trim() || `cron:${input.job.id}`).trim();
-  const usesDetachedRunSession = isDetachedCronSessionTarget(input.job.sessionTarget);
-  const baseSessionKeyIsCron =
-    baseSessionKey.startsWith("cron:") || isCronSessionKey(baseSessionKey);
-  const cronExecutionSessionKey =
-    usesDetachedRunSession && !baseSessionKeyIsCron ? `cron:${input.job.id}` : baseSessionKey;
   const agentSessionKey = resolveCronAgentSessionKey({
-    sessionKey: cronExecutionSessionKey,
-    agentId,
-    mainKey: input.cfg.session?.mainKey,
-    cfg: input.cfg,
-  });
-  const resolvedBaseSessionKey = resolveCronAgentSessionKey({
     sessionKey: baseSessionKey,
     agentId,
     mainKey: input.cfg.session?.mainKey,
     cfg: input.cfg,
   });
-  const sourceSessionKey =
-    usesDetachedRunSession && resolvedBaseSessionKey !== agentSessionKey
-      ? resolvedBaseSessionKey
-      : undefined;
   const payloadHookExternalContentSource =
     input.job.payload.kind === "agentTurn" ? input.job.payload.externalContentSource : undefined;
   const hookExternalContentSource =
@@ -664,17 +648,16 @@ async function prepareCronRunContext(params: {
   const cronSession = resolveCronSession({
     cfg: input.cfg,
     sessionKey: agentSessionKey,
-    sourceSessionKey,
     agentId,
     nowMs: now,
-    forceNew: usesDetachedRunSession,
+    forceNew: input.job.sessionTarget === "isolated",
   });
   const runSessionId = cronSession.sessionEntry.sessionId;
   const currentRunSessionId = () => cronSession.sessionEntry.sessionId ?? runSessionId;
   if (!cronSession.sessionEntry.sessionFile?.trim()) {
     cronSession.sessionEntry.sessionFile = resolveSessionTranscriptPath(runSessionId, agentId);
   }
-  const runSessionKey = usesDetachedRunSession
+  const runSessionKey = baseSessionKey.startsWith("cron:")
     ? `${agentSessionKey}:run:${runSessionId}`
     : agentSessionKey;
   const persistSessionEntry = createPersistCronSessionEntry({
@@ -691,7 +674,7 @@ async function prepareCronRunContext(params: {
     sessionId: currentRunSessionId(),
     sessionKey: runSessionKey,
   });
-  if (!cronSession.sessionEntry.label?.trim() && usesDetachedRunSession) {
+  if (!cronSession.sessionEntry.label?.trim() && baseSessionKey.startsWith("cron:")) {
     const labelSuffix =
       typeof input.job.name === "string" && input.job.name.trim()
         ? input.job.name.trim()
@@ -1402,7 +1385,7 @@ async function finalizeCronRun(params: {
 }
 
 /**
- * Release runtime references held by a completed detached cron run.
+ * Release runtime references held by a completed isolated cron run.
  *
  * After the final durable write and delivery complete, the cron session store
  * and run context are no longer needed in memory.  This shallow disposal prevents
@@ -1422,10 +1405,10 @@ async function disposeCronRunContext(params: {
   if (params.ownsRunContext) {
     await retireSessionMcpRuntime({
       sessionId: params.sessionId,
-      reason: "detached-cron-dispose",
+      reason: "isolated-cron-dispose",
       onError: (error, sid) => {
         logWarn(
-          `[cron] Failed to retire MCP runtime during detached cron dispose ${sid}: ${String(error)}`,
+          `[cron] Failed to retire MCP runtime during isolated cron dispose ${sid}: ${String(error)}`,
         );
       },
     }).catch(() => {});
@@ -1460,7 +1443,7 @@ export async function runCronIsolatedAgentTurn(params: {
   }
   // Capture the stable run id before execution can rotate its persisted session.
   const initialSessionId = prepared.context.cronSession.sessionEntry.sessionId;
-  const ownsRunContext = isDetachedCronSessionTarget(params.job.sessionTarget);
+  const ownsRunContext = params.job.sessionTarget === "isolated";
   let runContextOwnerToken: string | undefined;
   let runLifecycleGeneration = admittedLifecycleGeneration;
   const notifyExecutionStarted = (info?: { lifecycleGeneration?: string }) => {

--- a/src/cron/isolated-agent/session.test.ts
+++ b/src/cron/isolated-agent/session.test.ts
@@ -39,15 +39,13 @@ type MockSessionStoreEntry = Partial<SessionStoreEntry>;
 
 function resolveWithStoredEntry(params?: {
   sessionKey?: string;
-  sourceSessionKey?: string;
   entry?: MockSessionStoreEntry;
   forceNew?: boolean;
   fresh?: boolean;
 }) {
   const sessionKey = params?.sessionKey ?? "webhook:stable-key";
-  const sourceSessionKey = params?.sourceSessionKey;
   const store: SessionStore = params?.entry
-    ? ({ [sourceSessionKey ?? sessionKey]: params.entry as SessionStoreEntry } as SessionStore)
+    ? ({ [sessionKey]: params.entry as SessionStoreEntry } as SessionStore)
     : {};
   vi.mocked(loadSessionStore).mockReturnValue(store);
   vi.mocked(evaluateSessionFreshness).mockReturnValue({ fresh: params?.fresh ?? true });
@@ -55,7 +53,6 @@ function resolveWithStoredEntry(params?: {
   return resolveCronSession({
     cfg: {} as OpenClawConfig,
     sessionKey,
-    sourceSessionKey,
     agentId: "main",
     nowMs: NOW_MS,
     forceNew: params?.forceNew,
@@ -177,33 +174,6 @@ describe("resolveCronSession", () => {
       expect(result.sessionEntry.modelOverride).toBe("sonnet-4");
       expect(result.sessionEntry.providerOverride).toBe("anthropic");
       expect(clearBootstrapSnapshot).toHaveBeenCalledWith("webhook:stable-key");
-    });
-
-    it("seeds fresh cron run sessions from a source session without rolling that source", () => {
-      const result = resolveWithStoredEntry({
-        sessionKey: "agent:main:cron:daily-repost",
-        sourceSessionKey: "agent:main:telegram:direct:42",
-        entry: {
-          sessionId: "live-chat-session",
-          updatedAt: NOW_MS - 1000,
-          systemSent: true,
-          modelOverride: "sonnet-4",
-          providerOverride: "anthropic",
-          thinkingLevel: "high",
-          sendPolicy: "allow",
-        },
-        fresh: true,
-        forceNew: true,
-      });
-
-      expect(result.sessionEntry.sessionId).not.toBe("live-chat-session");
-      expect(result.isNewSession).toBe(true);
-      expect(result.previousSessionId).toBeUndefined();
-      expect(result.sessionEntry.modelOverride).toBe("sonnet-4");
-      expect(result.sessionEntry.providerOverride).toBe("anthropic");
-      expect(result.sessionEntry.thinkingLevel).toBe("high");
-      expect(result.sessionEntry.sendPolicy).toBeUndefined();
-      expect(clearBootstrapSnapshot).not.toHaveBeenCalled();
     });
 
     it("clears stale sessionFile when forceNew rolls to a fresh session", () => {

--- a/src/cron/isolated-agent/session.ts
+++ b/src/cron/isolated-agent/session.ts
@@ -110,7 +110,6 @@ function sanitizeFreshCronSessionEntry(
 export function resolveCronSession(params: {
   cfg: OpenClawConfig;
   sessionKey: string;
-  sourceSessionKey?: string;
   nowMs: number;
   agentId: string;
   forceNew?: boolean;
@@ -121,9 +120,7 @@ export function resolveCronSession(params: {
     agentId: params.agentId,
   });
   const store = params.store ?? loadSessionStore(storePath);
-  const sourceSessionKey = params.sourceSessionKey?.trim();
-  const sourceSessionDiffers = Boolean(sourceSessionKey && sourceSessionKey !== params.sessionKey);
-  const entry = store[sourceSessionKey || params.sessionKey];
+  const entry = store[params.sessionKey];
 
   let sessionId: string;
   let isNewSession: boolean;
@@ -165,7 +162,7 @@ export function resolveCronSession(params: {
     systemSent = false;
   }
 
-  const previousSessionId = isNewSession && !sourceSessionDiffers ? entry?.sessionId : undefined;
+  const previousSessionId = isNewSession ? entry?.sessionId : undefined;
   clearBootstrapSnapshotOnSessionRollover({
     sessionKey: params.sessionKey,
     previousSessionId,

--- a/src/cron/service/task-runs.ts
+++ b/src/cron/service/task-runs.ts
@@ -43,6 +43,15 @@ function resolveCronTaskChildSessionKey(params: {
   if (params.job.sessionTarget === "main") {
     return resolveMainSessionCronRunSessionKey(params.job, params.startedAt);
   }
+  const explicitSessionKey = params.job.sessionKey?.trim();
+  if (explicitSessionKey) {
+    // Explicit session bindings must win over generated cron session keys so
+    // task drill-down opens the same transcript the cron run actually used.
+    return explicitSessionKey;
+  }
+  if (params.job.sessionTarget !== "isolated") {
+    return undefined;
+  }
   return resolveCronAgentSessionKey({
     sessionKey: `cron:${params.job.id}`,
     agentId: params.job.agentId ?? params.state.deps.defaultAgentId ?? DEFAULT_AGENT_ID,

--- a/src/cron/session-target.test.ts
+++ b/src/cron/session-target.test.ts
@@ -1,7 +1,6 @@
 // Session target tests cover target resolution for cron-created sessions.
 import { describe, expect, it } from "vitest";
 import {
-  isDetachedCronSessionTarget,
   resolveCronCurrentSessionTarget,
   resolveCronDeliverySessionKey,
   resolveCronNotificationSessionKey,
@@ -28,17 +27,6 @@ describe("cron session target helpers", () => {
     expect(() => resolveCronSessionTargetSessionKey("session:bad\0id")).toThrow(
       "invalid cron sessionTarget session id",
     );
-  });
-
-  it.each(["isolated", "current", "session:agent:main:telegram:direct:123"] as const)(
-    "classifies %s as detached cron output",
-    (sessionTarget) => {
-      expect(isDetachedCronSessionTarget(sessionTarget)).toBe(true);
-    },
-  );
-
-  it("does not classify main as detached cron output", () => {
-    expect(isDetachedCronSessionTarget("main")).toBe(false);
   });
 
   it("resolves current targets to the creator session key", () => {

--- a/src/cron/session-target.ts
+++ b/src/cron/session-target.ts
@@ -18,7 +18,7 @@ export function assertSafeCronSessionTargetId(sessionId: string): string {
   return trimmed;
 }
 
-/** Extracts the session key from a `session:` cron target, if present. */
+/** Extracts the persistent session key from a `session:` cron target, if present. */
 export function resolveCronSessionTargetSessionKey(
   sessionTarget?: string | null,
 ): string | undefined {
@@ -26,15 +26,6 @@ export function resolveCronSessionTargetSessionKey(
     return undefined;
   }
   return assertSafeCronSessionTargetId(sessionTarget.slice(8));
-}
-
-/** Returns whether cron executes the job in a detached run session. */
-export function isDetachedCronSessionTarget(sessionTarget?: string | null): boolean {
-  return (
-    sessionTarget === "isolated" ||
-    sessionTarget === "current" ||
-    (typeof sessionTarget === "string" && sessionTarget.startsWith("session:"))
-  );
 }
 
 /** Resolves `current` at creation time so scheduled jobs do not depend on future active UI state. */
@@ -49,7 +40,7 @@ export function resolveCronCurrentSessionTarget(params: {
   return sessionKey ? `session:${assertSafeCronSessionTargetId(sessionKey)}` : "isolated";
 }
 
-/** Chooses the session key used for cron delivery, preferring explicit session targets. */
+/** Chooses the session key used for cron delivery, preferring explicit persistent targets. */
 export function resolveCronDeliverySessionKey(job: {
   sessionTarget?: string | null;
   sessionKey?: string | null;

--- a/src/gateway/server-cron.test.ts
+++ b/src/gateway/server-cron.test.ts
@@ -9,9 +9,7 @@ import { SsrFBlockedError } from "../infra/net/ssrf.js";
 
 type RunCronIsolatedAgentTurnMock = (params: {
   abortSignal?: AbortSignal;
-  onExecutionStarted?: (execution: { jobId: string; sessionKey?: string }) => void;
-  onExecutionPhase?: (execution: { jobId: string; sessionKey?: string }) => void;
-}) => Promise<{ status: "ok"; summary: string; sessionKey?: string }>;
+}) => Promise<{ status: "ok"; summary: string }>;
 
 const {
   enqueueSystemEventMock,
@@ -1456,17 +1454,12 @@ describe("buildGatewayCronService", () => {
         wakeMode: "next-heartbeat",
         payload: { kind: "agentTurn", message: "hello" },
       });
-      const runSessionKey = `agent:main:cron:${job.id}:run:run-1`;
-      runCronIsolatedAgentTurnMock.mockImplementationOnce(async ({ onExecutionStarted }) => {
-        onExecutionStarted?.({ jobId: job.id, sessionKey: runSessionKey });
-        return { status: "ok", summary: "ok", sessionKey: runSessionKey };
-      });
 
       await state.cron.run(job.id, "force");
 
       const options = expectIsolatedRunFields({ sessionKey });
       expect(requireRecord(options.job, "isolated job").id).toBe(job.id);
-      expectCleanupForSessionKeys([runSessionKey]);
+      expectCleanupForSessionKeys([sessionKey]);
     } finally {
       state.cron.stop();
     }

--- a/src/gateway/server-cron.ts
+++ b/src/gateway/server-cron.ts
@@ -473,38 +473,23 @@ export function buildGatewayCronService(params: {
     }) => {
       const { agentId, cfg: runtimeConfig } = resolveCronAgent(job.agentId);
       const sessionKey = resolveCronSessionTargetSessionKey(job.sessionTarget) ?? `cron:${job.id}`;
-      let cleanupSessionKey = sessionKey;
-      const trackCleanupSessionKey = (execution?: { sessionKey?: string }) => {
-        const nextSessionKey = execution?.sessionKey?.trim();
-        if (nextSessionKey) {
-          cleanupSessionKey = nextSessionKey;
-        }
-      };
       try {
-        const result = await runCronIsolatedAgentTurn({
+        return await runCronIsolatedAgentTurn({
           cfg: runtimeConfig,
           deps: params.deps,
           job,
           message,
           abortSignal,
-          onExecutionStarted: (execution) => {
-            trackCleanupSessionKey(execution);
-            onExecutionStarted?.(execution);
-          },
-          onExecutionPhase: (execution) => {
-            trackCleanupSessionKey(execution);
-            onExecutionPhase?.(execution);
-          },
+          onExecutionStarted,
+          onExecutionPhase,
           onLaneWait,
           agentId,
           sessionKey,
           lane: "cron",
         });
-        trackCleanupSessionKey(result);
-        return result;
       } finally {
         await cleanupBrowserSessionsForLifecycleEnd({
-          sessionKeys: [cleanupSessionKey],
+          sessionKeys: [sessionKey],
           onWarn: (msg) => cronLogger.warn({ jobId: job.id }, msg),
         });
       }


### PR DESCRIPTION
Related: https://github.com/openclaw/openclaw/issues/98121

Follow-up to [PR #98755](https://github.com/openclaw/openclaw/pull/98755). Pinned-base context: [PR #98812](https://github.com/openclaw/openclaw/pull/98812).

## What Problem This Solves

Fixes an issue where users scheduling cron work in `current` or `session:<id>` would unexpectedly lose persistent session history because every agent-turn cron target was changed to a detached fresh run. The merged change also caused deterministic session-state and shared run-context failures on exact-head CI.

## Why This Change Was Made

Cron jobs now follow the clarified product contract: a job normally runs in the session it was created from, while only an explicitly `isolated` job requests a detached fresh session. This restores the shipped canonical persistence path across target resolution, session identity, storage, prompt caching, run-context ownership, task drill-down, gateway wiring, tests, and docs, while retaining the independently valid stale childless-task cancellation from [PR #98755](https://github.com/openclaw/openclaw/pull/98755).

The approved patch originated as head `69cb904aaceeeb8be8448be7157b16e66e411123`, parent `27104c1afb13af39e675f637b5812b12a7088ba7`, tree `cdec0b484879ceba63e6542835587e9da60e9f55`. The single required main sync produced the textually equivalent head `f160075c36e8e1c925e1148236d50492486ecc11`, parented directly on main `2913d3aee90c79bc420129606b3912662359723d`, with tree `889530c73c8426dc61d9fd6bcb42e889718547e9`. A wrapper-created ancestry-only head `a5ddfe7eda69b77cc177f93aa923476f82a7230e` was replaced with `f160075c…` using an exact force-with-lease. The live PR remains 17 files, +90/-187, with stable patch ID `94180b4fcbf752cfa56db33df28bf4620ef633a2` and full-index diff SHA-256 `bf7396ac69911e288ba1e0fd3f20cfee1b19e44e3b35f855cf65bea0a0b751d9`.

## User Impact

Recurring cron workflows can again build on prior context in `current` and named `session:<id>` sessions. `isolated` jobs remain fresh and detached, and main-session cron behavior is unchanged.

## Evidence

- Exact regression files: 58/58 tests passed locally.
- Focused cron/task/gateway suite: 323/323 tests passed locally.
- Linux Node `v24.13.0` Testbox: 323/323 tests passed; wrapper exit `0`.
- Remote `check:changed`: both core typechecks, all core lint shards, import-cycle checks, and repository guards passed; wrapper exit `0`.
- Testbox proof: https://github.com/openclaw/openclaw/actions/runs/28557961455
- Pinned-base exact-head CI: 96 successes, nine intentional skips, five concurrency cancellations, zero failures: https://github.com/openclaw/openclaw/actions/runs/28557422336
- `oxfmt --check` passed for all 17 files; scoped Oxlint, `pnpm docs:list`, and `git diff --check` passed.
- Fresh `gpt-5.6-sol` xhigh autoreview reported zero findings with correctness confidence `0.97`.
- Correct synced head `f160075c36e8e1c925e1148236d50492486ecc11` has parent `2913d3aee90c79bc420129606b3912662359723d` and tree `889530c73c8426dc61d9fd6bcb42e889718547e9`; its patch ID and full-index diff digest exactly match the approved pre-sync patch.

Contributor credit: Ethan Sarif-Kattan (`@EthanSK`) supplied the original report and discussion in [issue #98121](https://github.com/openclaw/openclaw/issues/98121). Ayaan Zaidi (`@obviyus`) authored [PR #98755](https://github.com/openclaw/openclaw/pull/98755), including the stale childless-task cancellation retained here.

AI-assisted: yes, prepared and independently reviewed with Codex under Peter Steinberger's explicit product-contract and landing approval.
