### PR TITLE
fix(msteams): bound graph upload JSON reads

### DIFF
--- a/extensions/msteams/src/graph-upload.test.ts
+++ b/extensions/msteams/src/graph-upload.test.ts
@@ -32,6 +32,41 @@ function bodyOnlyErrorResponse(body: string, status = 500): Response {
   } as unknown as Response;
 }
 
+function oversizedJsonSuccessResponse(): {
+  response: Response;
+  getReadCount: () => number;
+  wasCanceled: () => boolean;
+} {
+  const chunkSize = 1024 * 1024;
+  const chunkCount = 20;
+  let readCount = 0;
+  let canceled = false;
+  const response = new Response(
+    new ReadableStream<Uint8Array>({
+      pull(controller) {
+        if (readCount >= chunkCount) {
+          controller.close();
+          return;
+        }
+        readCount += 1;
+        controller.enqueue(new Uint8Array(chunkSize));
+      },
+      cancel() {
+        canceled = true;
+      },
+    }),
+    { status: 200, headers: { "content-type": "application/json" } },
+  );
+  response.json = async () => {
+    throw new Error("unbounded response.json should not be called");
+  };
+  return {
+    response,
+    getReadCount: () => readCount,
+    wasCanceled: () => canceled,
+  };
+}
+
 describe("graph upload helpers", () => {
   const tokenProvider = {
     getAccessToken: vi.fn(async () => "graph-token"),
@@ -141,6 +176,26 @@ describe("graph upload helpers", () => {
     expect(message).toContain("SharePoint upload failed (413): upload-denied");
     expect(message).not.toContain("tail-marker");
     expect(message.length).toBeLessThan(700);
+  });
+
+  it("bounds successful SharePoint upload JSON bodies without using response.json()", async () => {
+    const streamed = oversizedJsonSuccessResponse();
+    const fetchFn = vi.fn(async () => streamed.response);
+
+    const error = await uploadToSharePoint({
+      buffer: Buffer.from("world"),
+      filename: "large.txt",
+      siteId: "site-123",
+      tokenProvider,
+      fetchFn: fetchFn as unknown as typeof fetch,
+    }).catch((caught: unknown) => caught);
+
+    expect(error).toBeInstanceOf(Error);
+    expect((error as Error).message).toBe(
+      "SharePoint upload failed: JSON response exceeds 16777216 bytes",
+    );
+    expect(streamed.wasCanceled()).toBe(true);
+    expect(streamed.getReadCount()).toBeLessThan(20);
   });
 });
 

--- a/extensions/msteams/src/graph-upload.ts
+++ b/extensions/msteams/src/graph-upload.ts
@@ -9,6 +9,7 @@
  * - Getting chat members for per-user sharing
  */
 
+import { readProviderJsonResponse } from "openclaw/plugin-sdk/provider-http";
 import type { MSTeamsAccessTokenProvider } from "./attachments/types.js";
 import { createMSTeamsHttpError } from "./http-error.js";
 import { buildUserAgent } from "./user-agent.js";
@@ -54,11 +55,11 @@ export async function uploadToOneDrive(params: {
     throw await createMSTeamsHttpError(res, "OneDrive upload failed");
   }
 
-  const data = (await res.json()) as {
+  const data = await readProviderJsonResponse<{
     id?: string;
     webUrl?: string;
     name?: string;
-  };
+  }>(res, "OneDrive upload failed");
 
   if (!data.id || !data.webUrl || !data.name) {
     throw new Error("OneDrive upload response missing required fields");
@@ -106,9 +107,9 @@ async function createSharingLink(params: {
     throw await createMSTeamsHttpError(res, "Create sharing link failed");
   }
 
-  const data = (await res.json()) as {
+  const data = await readProviderJsonResponse<{
     link?: { webUrl?: string };
-  };
+  }>(res, "Create sharing link failed");
 
   if (!data.link?.webUrl) {
     throw new Error("Create sharing link response missing webUrl");
@@ -200,11 +201,11 @@ export async function uploadToSharePoint(params: {
     throw await createMSTeamsHttpError(res, "SharePoint upload failed");
   }
 
-  const data = (await res.json()) as {
+  const data = await readProviderJsonResponse<{
     id?: string;
     webUrl?: string;
     name?: string;
-  };
+  }>(res, "SharePoint upload failed");
 
   if (!data.id || !data.webUrl || !data.name) {
     throw new Error("SharePoint upload response missing required fields");
@@ -260,11 +261,11 @@ export async function getDriveItemProperties(params: {
     throw await createMSTeamsHttpError(res, "Get driveItem properties failed");
   }
 
-  const data = (await res.json()) as {
+  const data = await readProviderJsonResponse<{
     eTag?: string;
     webDavUrl?: string;
     name?: string;
-  };
+  }>(res, "Get driveItem properties failed");
 
   if (!data.eTag || !data.webDavUrl || !data.name) {
     throw new Error("DriveItem response missing required properties (eTag, webDavUrl, or name)");
@@ -331,9 +332,9 @@ export async function resolveGraphChatId(params: {
     return null;
   }
 
-  const data = (await res.json()) as {
+  const data = await readProviderJsonResponse<{
     value?: Array<{ id?: string }>;
-  };
+  }>(res, "Resolve Graph chat failed");
 
   const chats = data.value ?? [];
 
@@ -371,12 +372,12 @@ async function getChatMembers(params: {
     throw await createMSTeamsHttpError(res, "Get chat members failed");
   }
 
-  const data = (await res.json()) as {
+  const data = await readProviderJsonResponse<{
     value?: Array<{
       userId?: string;
       displayName?: string;
     }>;
-  };
+  }>(res, "Get chat members failed");
 
   return (data.value ?? [])
     .map((m) => ({
@@ -435,9 +436,9 @@ async function createSharePointSharingLink(params: {
     throw await createMSTeamsHttpError(res, "Create SharePoint sharing link failed");
   }
 
-  const data = (await res.json()) as {
+  const data = await readProviderJsonResponse<{
     link?: { webUrl?: string };
-  };
+  }>(res, "Create SharePoint sharing link failed");
 
   if (!data.link?.webUrl) {
     throw new Error("Create SharePoint sharing link response missing webUrl");


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where MS Teams Graph upload and sharing helpers could buffer an unbounded successful JSON response when reading drive item, sharing link, or chat metadata.

## Why This Change Was Made

The Graph upload helpers now use the shared bounded provider JSON reader that other MS Teams Graph paths already use. Error responses were already bounded; this closes the matching successful-response path.

## User Impact

A faulty or hostile Graph-compatible endpoint cannot force OpenClaw to buffer an oversized success metadata response, while normal Graph metadata responses continue to parse normally.

## Evidence

- Red test before the fix: `node scripts/run-vitest.mjs extensions/msteams/src/graph-upload.test.ts -- --run` failed with `unbounded response.json should not be called`.
- `node scripts/run-vitest.mjs extensions/msteams/src/graph-upload.test.ts -- --run` -> 1 file / 12 tests passed.
- `node_modules/.bin/oxfmt --check extensions/msteams/src/graph-upload.ts extensions/msteams/src/graph-upload.test.ts` -> clean.
- `node scripts/run-oxlint.mjs extensions/msteams/src/graph-upload.ts extensions/msteams/src/graph-upload.test.ts` -> clean.
- `git diff --check` -> clean.

Loopback proof with a real `node:http` server streaming a 32 MiB successful Graph upload JSON response:

```text
error=SharePoint upload failed: JSON response exceeds 16777216 bytes
chunks_sent=18
total_chunks_available=32
response_closed=true
```

AI-assisted: built with Codex
