### PR TITLE
fix(google-meet): bound Meet API JSON response reads to prevent OOM

### DIFF
--- a/extensions/google-meet/src/meet.ts
+++ b/extensions/google-meet/src/meet.ts
@@ -1,5 +1,6 @@
 // Google Meet plugin module implements meet behavior.
 import { fetchWithSsrFGuard } from "openclaw/plugin-sdk/ssrf-runtime";
+import { readProviderJsonResponse } from "openclaw/plugin-sdk/provider-http";
 import { uniqueStrings } from "openclaw/plugin-sdk/string-coerce-runtime";
 import { exportGoogleDriveDocumentText, extractGoogleDriveDocumentId } from "./drive.js";
 import { googleApiError } from "./google-api-errors.js";
@@ -289,7 +290,7 @@ async function fetchGoogleMeetJson<T>(params: {
         scopes: [GOOGLE_MEET_MEDIA_SCOPE],
       });
     }
-    return (await response.json()) as T;
+    return await readProviderJsonResponse<T>(response, params.errorPrefix ?? "Google Meet API");
   } finally {
     await release();
   }
@@ -354,7 +355,7 @@ export async function fetchGoogleMeetSpace(params: {
         scopes: [GOOGLE_MEET_SPACE_SCOPE],
       });
     }
-    const payload = (await response.json()) as GoogleMeetSpace;
+    const payload = await readProviderJsonResponse<GoogleMeetSpace>(response, "Google Meet API");
     if (!payload.name?.trim()) {
       throw new Error("Google Meet spaces.get response was missing name");
     }
@@ -397,7 +398,7 @@ export async function createGoogleMeetSpace(params: {
             : [GOOGLE_MEET_SPACE_CREATED_SCOPE],
       });
     }
-    const payload = (await response.json()) as GoogleMeetSpace;
+    const payload = await readProviderJsonResponse<GoogleMeetSpace>(response, "Google Meet API");
     if (!payload.name?.trim()) {
       throw new Error("Google Meet spaces.create response was missing name");
     }


### PR DESCRIPTION
## What Problem This Solves

Google Meet API JSON responses are read with unbounded `response.json()` at 3 call sites in `extensions/google-meet/src/meet.ts`. A compromised, misconfigured, or SSRF-reachable Google API endpoint could return an arbitrarily large response body, causing OOM during Meet API operations.

All 3 calls go through `fetchWithSsrFGuard` which handles SSRF protection but does not limit response body size.

## Changes

- `extensions/google-meet/src/meet.ts`: replace 3 unbounded `response.json()` calls with the shared `readProviderJsonResponse` helper (16 MiB cap via `readResponseWithLimit`).

## Real behavior proof

- **Behavior addressed**: Unbounded Google Meet API JSON response reads can cause OOM.
- **Real environment tested**: Local `node:http` server on `127.0.0.1`, Node v24.
- **Evidence after fix**:

```
=== Google Meet: bound API JSON response ===

  Before (unbounded response.json()):
    20,971,520 bytes read in 172ms (all 20 MB buffered)

  After (readProviderJsonResponse with 16 MiB cap):
    threw: Google Meet: JSON response exceeds 16777216 bytes
    (stream cancelled at cap)

  Normal response (backward compatible):
    name=spaces/test (parsed correctly, unchanged)
```

## Evidence

```
--- Negative control: oversized Meet API response (20 MB) ---
  Before: unbounded response.json() → 20,971,520 bytes read
  After:  bounded → throws at 16,777,216 bytes cap → OOM prevented

--- Normal response (backward compatible) ---
  name=spaces/test (unchanged)
```

**What was not tested**: End-to-end with real Google Meet API (requires credentials). The `node:http` loopback proof covers transport and cancellation behavior.