### PR TITLE
fix: strict guarded fetch fails before managed proxy DNS

### DIFF
--- a/src/infra/net/configured-local-origin-bypass.ts
+++ b/src/infra/net/configured-local-origin-bypass.ts
@@ -60,6 +60,14 @@ function isPinnedLoopbackTarget(addresses: readonly string[]): boolean {
   return addresses.length > 0 && addresses.every((address) => isLoopbackIpAddress(address));
 }
 
+/** Return whether proving a configured local-origin bypass requires target DNS. */
+export function shouldResolveConfiguredLocalOriginManagedProxyBypass(params: {
+  url: URL;
+  managedProxyBypass: ConfiguredLocalOriginManagedProxyBypass | undefined;
+}): boolean {
+  return isExactConfiguredLocalOriginBypass(params);
+}
+
 /** Return whether a configured local provider origin may bypass the managed proxy. */
 export function shouldUseConfiguredLocalOriginManagedProxyBypass(params: {
   url: URL;

--- a/src/infra/net/fetch-guard.ssrf.test.ts
+++ b/src/infra/net/fetch-guard.ssrf.test.ts
@@ -257,6 +257,7 @@ describe("fetchWithSsrFGuard hardening", () => {
     });
 
     expect(fetchImpl).toHaveBeenCalledTimes(1);
+    expect(lookupFn).toHaveBeenCalledTimes(params.expectEnvProxy ? 0 : 1);
     if (params.expectEnvProxy) {
       expect(envHttpProxyAgentCtor).toHaveBeenCalledTimes(1);
       expect(envHttpProxyAgentCtor).toHaveBeenCalledWith({
@@ -1415,6 +1416,94 @@ describe("fetchWithSsrFGuard hardening", () => {
     });
   });
 
+  it("does not resolve target DNS before strict managed-proxy dispatch", async () => {
+    installManagedProxyRuntime();
+    const lookupFn: LookupFn = vi.fn(async (hostname: string) => {
+      throw new Error(`unexpected target DNS lookup for ${hostname}`);
+    }) as unknown as LookupFn;
+    const fetchImpl = vi.fn(async (_input: RequestInfo | URL, init?: RequestInit) => {
+      const requestInit = init as RequestInit & { dispatcher?: unknown };
+      expectDispatcherAttached(requestInit.dispatcher);
+      return okResponse();
+    });
+
+    const result = await fetchWithSsrFGuard({
+      url: "https://public.example/resource",
+      fetchImpl,
+      lookupFn,
+    });
+
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+    expect(lookupFn).not.toHaveBeenCalled();
+    expect(envHttpProxyAgentCtor).toHaveBeenCalledTimes(1);
+    await result.release();
+  });
+
+  it("falls back to strict DNS pinning when active managed proxy does not apply", async () => {
+    installManagedProxyRuntime();
+    vi.stubEnv("NO_PROXY", "public.example");
+    const lookupFn = createPublicLookup();
+    const fetchImpl = vi.fn(async (_input: RequestInfo | URL, init?: RequestInit) => {
+      const requestInit = init as RequestInit & { dispatcher?: unknown };
+      expectDispatcherAttached(requestInit.dispatcher);
+      expect(getDispatcherClassName(requestInit.dispatcher)).not.toBe("EnvHttpProxyAgent");
+      return okResponse();
+    });
+
+    const result = await fetchWithSsrFGuard({
+      url: "https://public.example/resource",
+      fetchImpl,
+      lookupFn,
+    });
+
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+    expect(lookupFn).toHaveBeenCalledWith("public.example", { all: true });
+    expect(envHttpProxyAgentCtor).not.toHaveBeenCalled();
+    expect(agentCtor).toHaveBeenCalledTimes(1);
+    await result.release();
+  });
+
+  it.each([
+    "http://127.0.0.1:8080/internal",
+    "http://metadata.google.internal/computeMetadata/v1/",
+  ])("blocks %s before strict managed-proxy dispatch", async (url) => {
+    installManagedProxyRuntime();
+    const lookupFn = vi.fn() as unknown as LookupFn;
+    const fetchImpl = vi.fn(async () => okResponse());
+
+    await expect(
+      fetchWithSsrFGuard({
+        url,
+        fetchImpl,
+        lookupFn,
+      }),
+    ).rejects.toThrow(/private|internal|blocked/i);
+
+    expect(lookupFn).not.toHaveBeenCalled();
+    expect(fetchImpl).not.toHaveBeenCalled();
+    expect(envHttpProxyAgentCtor).not.toHaveBeenCalled();
+  });
+
+  it("revalidates redirects before strict managed-proxy dispatch", async () => {
+    installManagedProxyRuntime();
+    const lookupFn = vi.fn() as unknown as LookupFn;
+    const fetchImpl = vi
+      .fn()
+      .mockResolvedValueOnce(redirectResponse("http://127.0.0.1:8080/internal"));
+
+    await expect(
+      fetchWithSsrFGuard({
+        url: "https://public.example/start",
+        fetchImpl,
+        lookupFn,
+      }),
+    ).rejects.toThrow(/private|internal|blocked/i);
+
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+    expect(lookupFn).not.toHaveBeenCalled();
+    expect(envHttpProxyAgentCtor).toHaveBeenCalledTimes(1);
+  });
+
   it.each([
     {
       name: "an exact configured local provider origin",
@@ -1646,6 +1735,28 @@ describe("fetchWithSsrFGuard hardening", () => {
       lookupFn: testCase.lookupFn(),
       expectedOrigin: testCase.expectedOrigin,
     });
+  });
+
+  it("honors proxy.loopbackMode=block for configured local origins before NO_PROXY fallback", async () => {
+    installManagedProxyRuntime("block");
+    vi.stubEnv("NO_PROXY", "127.0.0.1,localhost");
+    vi.stubEnv("no_proxy", "127.0.0.1,localhost");
+    const fetchImpl = vi.fn(async () => okResponse());
+
+    await expect(
+      fetchConfiguredLocalOriginWithSsrFGuard({
+        url: "http://127.0.0.1:11434/api/embed",
+        fetchImpl,
+        lookupFn: createLoopbackLookup(),
+        policy: { allowedOrigins: ["http://127.0.0.1:11434"] },
+        configuredLocalOriginBaseUrl: "http://127.0.0.1:11434",
+        auditContext: "ollama-memory-embedding",
+      }),
+    ).rejects.toThrow("blocked by proxy.loopbackMode");
+
+    expect(fetchImpl).not.toHaveBeenCalled();
+    expect(agentCtor).not.toHaveBeenCalled();
+    expect(envHttpProxyAgentCtor).not.toHaveBeenCalled();
   });
 
   it("routes through env proxy when trusted proxy mode is explicitly enabled", async () => {

--- a/src/infra/net/fetch-guard.ts
+++ b/src/infra/net/fetch-guard.ts
@@ -9,9 +9,10 @@ import {
 } from "../fetch-headers.js";
 import {
   shouldUseConfiguredLocalOriginManagedProxyBypass,
+  shouldResolveConfiguredLocalOriginManagedProxyBypass,
   type ConfiguredLocalOriginManagedProxyBypass,
 } from "./configured-local-origin-bypass.js";
-import { hasProxyEnvConfigured, shouldUseEnvHttpProxyForUrl } from "./proxy-env.js";
+import { shouldUseEnvHttpProxyForUrl } from "./proxy-env.js";
 import { retainSafeHeadersForCrossOriginRedirect as retainSafeRedirectHeaders } from "./redirect-headers.js";
 import {
   fetchWithRuntimeDispatcher,
@@ -502,8 +503,17 @@ async function fetchWithSsrFGuardInternal(
         usesTrustedExplicitProxyMode ? false : params.pinDns,
       );
       await assertExplicitProxyAllowed(dispatcherPolicy, params.lookupFn, params.policy);
+      const isStrictManagedProxyActive =
+        mode === GUARDED_FETCH_MODE.STRICT && isManagedProxyActive();
+      const shouldCheckManagedProxyBypass =
+        isStrictManagedProxyActive &&
+        shouldResolveConfiguredLocalOriginManagedProxyBypass({
+          url: parsedUrl,
+          managedProxyBypass: params.managedProxyBypass,
+        });
       const canUseManagedProxy =
-        mode === GUARDED_FETCH_MODE.STRICT && isManagedProxyActive() && hasProxyEnvConfigured();
+        isStrictManagedProxyActive &&
+        (shouldUseEnvHttpProxyForUrl(parsedUrl.toString()) || shouldCheckManagedProxyBypass);
       const canUseTrustedEnvProxy =
         (mode === GUARDED_FETCH_MODE.TRUSTED_ENV_PROXY ||
           (params.useEnvProxyForEligibleUrls === true && !canUseManagedProxy)) &&
@@ -518,26 +528,30 @@ async function fetchWithSsrFGuardInternal(
         params.pinDns !== false;
       const timeoutMs = resolveDispatcherTimeoutMs(params.timeoutMs);
 
-      // Trusted env-proxy and pinDns=false can skip local DNS pinning, so keep
-      // the pre-DNS hostname/IP policy checks from the pinned path.
-      if (canUseTrustedEnvProxy || params.pinDns === false) {
+      // Trusted env-proxy, managed proxy, and pinDns=false can skip local DNS
+      // pinning, so keep the pre-DNS hostname/IP policy checks from the pinned path.
+      if (canUseTrustedEnvProxy || canUseManagedProxy || params.pinDns === false) {
         assertHostnameAllowedWithPolicy(parsedUrl.hostname, policyForUrl);
       }
 
       if (canUseTrustedEnvProxy) {
         dispatcher = createHttp1EnvHttpProxyAgent(undefined, timeoutMs);
       } else if (canUseManagedProxy) {
-        const pinned = await resolvePinnedHostnameWithPolicy(parsedUrl.hostname, {
-          lookupFn: params.lookupFn,
-          policy: policyForUrl,
-        });
-        dispatcher = shouldUseConfiguredLocalOriginManagedProxyBypass({
-          url: parsedUrl,
-          managedProxyBypass: params.managedProxyBypass,
-          resolvedAddresses: pinned.addresses,
-        })
-          ? createPinnedDispatcher(pinned, dispatcherPolicy, policyForUrl, timeoutMs)
-          : createHttp1EnvHttpProxyAgent(undefined, timeoutMs);
+        if (shouldCheckManagedProxyBypass) {
+          const pinned = await resolvePinnedHostnameWithPolicy(parsedUrl.hostname, {
+            lookupFn: params.lookupFn,
+            policy: policyForUrl,
+          });
+          dispatcher = shouldUseConfiguredLocalOriginManagedProxyBypass({
+            url: parsedUrl,
+            managedProxyBypass: params.managedProxyBypass,
+            resolvedAddresses: pinned.addresses,
+          })
+            ? createPinnedDispatcher(pinned, dispatcherPolicy, policyForUrl, timeoutMs)
+            : createHttp1EnvHttpProxyAgent(undefined, timeoutMs);
+        } else {
+          dispatcher = createHttp1EnvHttpProxyAgent(undefined, timeoutMs);
+        }
       } else if (usesTrustedExplicitProxyMode) {
         // Explicit proxy targets are still checked against the caller's hostname
         // policy, but the proxy does the DNS resolution for the final target.


### PR DESCRIPTION
Closes #98925

## What Problem This Solves

Fixes an issue where users in managed proxy-only sandboxes could see strict/default guarded fetches fail before reaching the managed proxy when local DNS could not resolve, disagreed with, or rejected the target hostname.

Affected surfaces include guarded fetch callers that omit `mode` and therefore default to strict mode, such as channel/provider preflight and plugin HTTP paths described in #98925.

## Why This Change Was Made

When `OPENCLAW_PROXY_ACTIVE=1` and the HTTP(S) env proxy applies to the target URL, strict guarded fetch now keeps the pre-DNS hostname/IP-literal SSRF checks and dispatches through the managed env proxy without resolving the target locally. Direct strict mode and NO_PROXY targets still use DNS pinning, while exact configured local-origin bypass candidates still resolve/pin DNS so `proxy.loopbackMode` and loopback-only bypass policy remain enforced.

Provenance: current `origin/main` still called `resolvePinnedHostnameWithPolicy()` inside the strict managed-proxy branch before creating the env proxy dispatcher. The managed-proxy branch was introduced by #70044 and the configured-local-origin bypass path was later carried forward by #85707.

## User Impact

Operators can rely on the managed proxy as the resolver/enforcement boundary for strict/default guarded fetches in proxy-only deployments. Google Chat, Mattermost, managed provider preflight, media, and web-tool paths no longer need caller-specific `TRUSTED_ENV_PROXY` workarounds just to avoid local DNS in active managed-proxy mode.

Security boundary note: this does not make ordinary strict mode proxy-aware just because proxy env vars exist. The proxy skip is limited to the OpenClaw managed proxy lifecycle, still respects whether the HTTP(S) env proxy applies to the URL, still blocks private IP literals/blocked hostnames before fetch, and still revalidates redirects.

## Evidence

- `node scripts/run-vitest.mjs src/infra/net/fetch-guard.ssrf.test.ts src/infra/net/proxy-env.test.ts`
- `node scripts/run-oxlint.mjs src/infra/net/fetch-guard.ts src/infra/net/configured-local-origin-bypass.ts src/infra/net/fetch-guard.ssrf.test.ts`
- `pnpm exec oxfmt --check src/infra/net/fetch-guard.ts src/infra/net/configured-local-origin-bypass.ts src/infra/net/fetch-guard.ssrf.test.ts`
- `git diff --check`
- `codex review --base origin/main` initially found a `proxy.loopbackMode=block` + `NO_PROXY` regression; fixed with an extra regression test and reran `codex review --base origin/main`, which reported no actionable regressions.
- CI: `Real behavior proof`, `Security High (network-ssrf-boundary)`, `security-fast`, `check-lint`, `check-prod-types`, `check-test-types`, `check-guards`, and the compact/check shards passed on PR #98951. `Critical Quality (network-runtime-boundary)` intentionally fast-failed because added test lines mention `NO_PROXY`; its log says boundary-sensitive lines require full CodeQL review, and the relevant full security checks passed.

Managed proxy-only behavior proof from a local CONNECT proxy setup:

```json
{
  "proof": "strict managed-proxy guarded fetch skips local target DNS",
  "proxyUrl": "http://127.0.0.1:<ephemeral>",
  "managedFetch": {
    "status": 200,
    "body": "proxied-ok",
    "lookupCallsAfterManagedFetch": 0,
    "proxyEventsAfterManagedFetch": [
      {
        "type": "connect",
        "target": "proxy-only.example:80"
      },
      {
        "type": "tunnel-request",
        "requestLine": "GET /proxy-ok HTTP/1.1",
        "host": "host: proxy-only.example"
      }
    ]
  },
  "privateLiteral": {
    "blockedBeforeProxyDispatch": true,
    "proxyEventCountBefore": 2,
    "proxyEventCountAfter": 2
  },
  "redirectToPrivate": {
    "blockedAfterFirstProxyResponseBeforeSecondProxyDispatch": true,
    "proxyEventCountBefore": 2,
    "proxyEventCountAfter": 4,
    "redirectProxyEvents": [
      {
        "type": "connect",
        "target": "proxy-only.example:80"
      },
      {
        "type": "tunnel-request",
        "requestLine": "GET /redirect-to-private HTTP/1.1",
        "host": "host: proxy-only.example"
      }
    ]
  },
  "totalLookupCalls": 0
}
```

That proof used `OPENCLAW_PROXY_ACTIVE=1`, HTTP(S) proxy env vars pointing at a temporary local CONNECT proxy, an unresolvable target hostname (`proxy-only.example`), and a `lookupFn` that throws on any target DNS lookup. The successful 200 response and `lookupCallsAfterManagedFetch: 0` show strict managed-proxy dispatch reached the proxy without local target DNS. The private literal and redirect checks show those unsafe targets were rejected before proxy dispatch.

AI-assisted: yes, implemented with Codex; I understand the changed guarded-fetch/proxy path and verified the security-sensitive cases above.

## Additional Operator Proxy Policy Proof

To close the proxy-owned enforcement gap, I also ran a local operator-policy-equivalent CONNECT proxy proof. The proxy owns DNS for the target hostnames, maps test hostnames to public/private/link-local/loopback addresses, and rejects the CONNECT before opening a tunnel when the proxy-side resolved address is disallowed.

```json
{
  "proof": "operator proxy policy resolves target and blocks private/link-local/loopback destinations after proxy-side DNS",
  "proxyUrl": "http://127.0.0.1:<ephemeral>",
  "proxyPolicy": {
    "resolver": "proxy-owned static DNS map for proof",
    "denyAfterResolution": [
      "127.0.0.0/8",
      "10.0.0.0/8",
      "169.254.0.0/16"
    ],
    "allowPublicExampleAddress": "93.184.216.34"
  },
  "publicAllowed": {
    "url": "http://policy-public.example/proxy-ok",
    "ok": true,
    "status": 200,
    "body": "proxied-policy-ok",
    "events": [
      {
        "type": "connect",
        "targetHost": "policy-public.example",
        "targetPort": "80",
        "proxyResolvedAddress": "93.184.216.34",
        "decision": "allow",
        "reason": "public-address"
      },
      {
        "type": "tunnel-request",
        "requestLine": "GET /proxy-ok HTTP/1.1",
        "host": "host: policy-public.example",
        "targetHost": "policy-public.example",
        "proxyResolvedAddress": "93.184.216.34",
        "decision": "allow",
        "reason": "public-address"
      }
    ],
    "lookupCallsAfter": 0
  },
  "loopbackDenied": {
    "url": "http://policy-loopback.example/private",
    "ok": false,
    "errorName": "TypeError",
    "errorMessage": "fetch failed",
    "events": [
      {
        "type": "connect",
        "targetHost": "policy-loopback.example",
        "targetPort": "80",
        "proxyResolvedAddress": "127.0.0.1",
        "decision": "deny",
        "reason": "loopback"
      }
    ],
    "lookupCallsAfter": 0
  },
  "privateDenied": {
    "url": "http://policy-private.example/private",
    "ok": false,
    "errorName": "TypeError",
    "errorMessage": "fetch failed",
    "events": [
      {
        "type": "connect",
        "targetHost": "policy-private.example",
        "targetPort": "80",
        "proxyResolvedAddress": "10.0.0.5",
        "decision": "deny",
        "reason": "rfc1918-private"
      }
    ],
    "lookupCallsAfter": 0
  },
  "linkLocalDenied": {
    "url": "http://policy-linklocal.example/metadata",
    "ok": false,
    "errorName": "TypeError",
    "errorMessage": "fetch failed",
    "events": [
      {
        "type": "connect",
        "targetHost": "policy-linklocal.example",
        "targetPort": "80",
        "proxyResolvedAddress": "169.254.169.254",
        "decision": "deny",
        "reason": "link-local-metadata"
      }
    ],
    "lookupCallsAfter": 0
  },
  "totalLookupCalls": 0
}
```

This proof is intentionally policy-equivalent rather than tied to a specific production proxy vendor: it demonstrates the required deployment contract for the strict managed-proxy branch. The proxy, not local DNS pinning, owns target DNS; after proxy-side DNS resolution, the proxy blocks loopback, RFC1918 private, and link-local/metadata targets before creating the tunnel, while public destinations still work through the same managed-proxy path.