### PR TITLE
feat(runtime): report model fallback transitions

### DIFF
--- a/docs/gateway/opentelemetry.md
+++ b/docs/gateway/opentelemetry.md
@@ -216,7 +216,7 @@ on the public diagnostic event bus.
 - `openclaw.model_call.response_bytes` (histogram, UTF-8 byte size of streamed response chunk payloads; high-frequency text, thinking, and tool-call deltas count only incremental `delta` bytes; no raw response content)
 - `openclaw.model_call.time_to_first_byte_ms` (histogram, elapsed time before the first streamed response event)
 - `openclaw.model.failover` (counter, attrs: `openclaw.provider`, `openclaw.model`, `openclaw.failover.to_provider`, `openclaw.failover.to_model`, `openclaw.failover.reason`, `openclaw.failover.suspended`, `openclaw.lane`)
-- `openclaw.auth_profile.fallback` (counter, attrs: `openclaw.provider`, `openclaw.model`, `openclaw.auth_profile.from_hash`, `openclaw.auth_profile.to_hash`, `openclaw.auth_profile.reason`)
+- `openclaw.auth_profile.fallback` (counter, attrs: `openclaw.provider`, `openclaw.model`, `openclaw.auth_profile.reason`; profile hashes are exported on the corresponding span attributes)
 - `openclaw.skill.used` (counter, attrs: `openclaw.skill.name`, `openclaw.skill.source`, `openclaw.skill.activation`, optional `openclaw.agent`, optional `openclaw.toolName`)
 
 ### Message flow

--- a/docs/gateway/opentelemetry.md
+++ b/docs/gateway/opentelemetry.md
@@ -216,6 +216,7 @@ on the public diagnostic event bus.
 - `openclaw.model_call.response_bytes` (histogram, UTF-8 byte size of streamed response chunk payloads; high-frequency text, thinking, and tool-call deltas count only incremental `delta` bytes; no raw response content)
 - `openclaw.model_call.time_to_first_byte_ms` (histogram, elapsed time before the first streamed response event)
 - `openclaw.model.failover` (counter, attrs: `openclaw.provider`, `openclaw.model`, `openclaw.failover.to_provider`, `openclaw.failover.to_model`, `openclaw.failover.reason`, `openclaw.failover.suspended`, `openclaw.lane`)
+- `openclaw.auth_profile.fallback` (counter, attrs: `openclaw.provider`, `openclaw.model`, `openclaw.auth_profile.from_hash`, `openclaw.auth_profile.to_hash`, `openclaw.auth_profile.reason`)
 - `openclaw.skill.used` (counter, attrs: `openclaw.skill.name`, `openclaw.skill.source`, `openclaw.skill.activation`, optional `openclaw.agent`, optional `openclaw.toolName`)
 
 ### Message flow
@@ -383,6 +384,11 @@ to them directly without OTLP export.
   session ids. `usage` is provider/turn accounting for cost and telemetry;
   `context.used` is the current prompt/context snapshot and can be lower than
   provider `usage.total` when cached input or tool-loop calls are involved.
+- `model.failover` - model fallback transition emitted by the fallback owner
+  after the failed provider/model and selected next provider/model are both
+  known.
+- `auth_profile.fallback` - auth profile rotation emitted after the next
+  profile is selected. Profile identifiers are exported only as bounded hashes.
 
 **Message flow**
 

--- a/extensions/diagnostics-otel/src/service.ts
+++ b/extensions/diagnostics-otel/src/service.ts
@@ -133,6 +133,10 @@ type ModelCallLifecycleDiagnosticEvent = Extract<
   { type: "model.call.completed" | "model.call.error" }
 >;
 type ModelFailoverDiagnosticEvent = Extract<DiagnosticEventPayload, { type: "model.failover" }>;
+type AuthProfileFallbackDiagnosticEvent = Extract<
+  DiagnosticEventPayload,
+  { type: "auth_profile.fallback" }
+>;
 type HarnessRunDiagnosticEvent = Extract<
   DiagnosticEventPayload,
   { type: "harness.run.started" | "harness.run.completed" | "harness.run.error" }
@@ -1796,6 +1800,10 @@ export function createDiagnosticsOtelService(): OpenClawPluginService {
         unit: "1",
         description: "Model failovers by source, destination, lane, and reason",
       });
+      const authProfileFallbackCounter = meter.createCounter("openclaw.auth_profile.fallback", {
+        unit: "1",
+        description: "Auth profile fallbacks by provider, model, and reason",
+      });
       const toolExecutionDurationHistogram = meter.createHistogram(
         "openclaw.tool.execution.duration_ms",
         {
@@ -3201,6 +3209,40 @@ export function createDiagnosticsOtelService(): OpenClawPluginService {
         span.end(evt.ts);
       };
 
+      const recordAuthProfileFallback = (
+        evt: AuthProfileFallbackDiagnosticEvent,
+        metadata: DiagnosticEventMetadata,
+      ) => {
+        authProfileFallbackCounter.add(1, {
+          "openclaw.auth_profile.reason": lowCardinalityAttr(evt.reason, "unknown"),
+          "openclaw.model": lowCardinalityAttr(evt.model),
+          "openclaw.provider": lowCardinalityAttr(evt.provider),
+        });
+        if (!tracesEnabled) {
+          return;
+        }
+        const spanAttrs: Record<string, string | number | boolean> = {
+          "openclaw.auth_profile.reason": lowCardinalityAttr(evt.reason, "unknown"),
+        };
+        if (evt.provider) {
+          spanAttrs["openclaw.provider"] = evt.provider;
+        }
+        if (evt.model) {
+          spanAttrs["openclaw.model"] = evt.model;
+        }
+        if (evt.fromProfileIdHash) {
+          spanAttrs["openclaw.auth_profile.from_hash"] = evt.fromProfileIdHash;
+        }
+        if (evt.toProfileIdHash) {
+          spanAttrs["openclaw.auth_profile.to_hash"] = evt.toProfileIdHash;
+        }
+        const span = spanWithDuration("openclaw.auth_profile.fallback", spanAttrs, 0, {
+          parentContext: activeTrustedParentContext(evt, metadata),
+          endTimeMs: evt.ts,
+        });
+        span.end(evt.ts);
+      };
+
       const modelCallMetricAttrs = (evt: ModelCallLifecycleDiagnosticEvent) => ({
         "openclaw.provider": evt.provider,
         "openclaw.model": evt.model,
@@ -3851,6 +3893,9 @@ export function createDiagnosticsOtelService(): OpenClawPluginService {
               return;
             case "model.failover":
               recordModelFailover(evt, metadata);
+              return;
+            case "auth_profile.fallback":
+              recordAuthProfileFallback(evt, metadata);
           }
         } catch (err) {
           ctx.logger.error(

--- a/src/agents/embedded-agent-runner/run.ts
+++ b/src/agents/embedded-agent-runner/run.ts
@@ -3494,6 +3494,7 @@ async function runEmbeddedAgentInternal(
             maybeRetrySameModelRateLimit,
             maybeBackoffBeforeOverloadFailover,
             advanceAuthProfile: advanceAttemptAuthProfile,
+            getLastProfileId: () => lastProfileId,
           });
           overloadProfileRotations = assistantFailoverOutcome.overloadProfileRotations;
           if (assistantFailoverOutcome.action === "retry") {

--- a/src/agents/embedded-agent-runner/run.ts
+++ b/src/agents/embedded-agent-runner/run.ts
@@ -29,6 +29,7 @@ import {
   withAgentRunLifecycleGeneration,
 } from "../../infra/agent-events.js";
 import { sleepWithAbort } from "../../infra/backoff.js";
+import { emitTrustedDiagnosticEvent } from "../../infra/diagnostic-events.js";
 import { freezeDiagnosticTraceContext } from "../../infra/diagnostic-trace-context.js";
 import { formatErrorMessage, toErrorObject } from "../../infra/errors.js";
 import { redactIdentifier } from "../../logging/redact-identifier.js";
@@ -3210,6 +3211,19 @@ async function runEmbeddedAgentInternal(
               promptFailoverDecision.action === "rotate_profile" &&
               (await advanceAttemptAuthProfile())
             ) {
+              const nextPromptProfileId = lastProfileId;
+              emitTrustedDiagnosticEvent({
+                type: "auth_profile.fallback",
+                provider,
+                model: modelId,
+                fromProfileIdHash: failedPromptProfileId
+                  ? redactIdentifier(failedPromptProfileId)
+                  : undefined,
+                toProfileIdHash: nextPromptProfileId
+                  ? redactIdentifier(nextPromptProfileId)
+                  : undefined,
+                reason: promptProfileFailureReason ?? promptFailoverReason ?? "unknown",
+              });
               if (failedPromptProfileId && promptProfileFailureReason) {
                 void maybeMarkAuthProfileFailure({
                   profileId: failedPromptProfileId,

--- a/src/agents/embedded-agent-runner/run/assistant-failover.test.ts
+++ b/src/agents/embedded-agent-runner/run/assistant-failover.test.ts
@@ -1,5 +1,11 @@
 // Coverage for assistant failover decisions and auth-profile rotation.
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  onTrustedInternalDiagnosticEvent,
+  resetDiagnosticEventsForTest,
+  waitForDiagnosticEventsDrained,
+  type DiagnosticEventPayload,
+} from "../../../infra/diagnostic-events.js";
 import { formatBillingErrorMessage } from "../../embedded-agent-helpers.js";
 import { FailoverError } from "../../failover-error.js";
 import { handleAssistantFailover } from "./assistant-failover.js";
@@ -64,6 +70,11 @@ function expectThrownFailoverError(outcome: Outcome): FailoverError {
 }
 
 describe("handleAssistantFailover", () => {
+  afterEach(() => {
+    resetDiagnosticEventsForTest();
+    vi.restoreAllMocks();
+  });
+
   describe("rotate_profile branch", () => {
     it("rotates before waiting on auth profile failure marking", async () => {
       // Rotation is latency-sensitive; profile failure marking can persist in
@@ -107,6 +118,42 @@ describe("handleAssistantFailover", () => {
       await markSettled;
       await vi.waitFor(() => expect(events).toEqual(["advance", "mark-start", "mark-finish"]));
       expect(events).toEqual(["advance", "mark-start", "mark-finish"]);
+    });
+
+    it("emits hashed auth_profile.fallback diagnostics when profile rotation succeeds", async () => {
+      const events: DiagnosticEventPayload[] = [];
+      const stop = onTrustedInternalDiagnosticEvent((event) => {
+        events.push(event);
+      });
+
+      const outcome = await handleAssistantFailover(
+        makeParams({
+          initialDecision: { action: "rotate_profile", reason: "auth" },
+          failoverReason: "auth",
+          assistantProfileFailureReason: "auth",
+          lastProfileId: "openai:primary-secret-profile",
+          billingFailure: false,
+          authFailure: true,
+          advanceAuthProfile: vi.fn(async () => true),
+          getLastProfileId: () => "openai:fallback-secret-profile",
+        }),
+      );
+
+      await waitForDiagnosticEventsDrained();
+      stop();
+
+      expect(outcome.action).toBe("retry");
+      expect(events).toHaveLength(1);
+      expect(events[0]).toMatchObject({
+        type: "auth_profile.fallback",
+        provider: "Anthropic",
+        model: "claude-haiku-4-5-20251001",
+        reason: "auth",
+      });
+      expect(events[0]).toHaveProperty("fromProfileIdHash");
+      expect(events[0]).toHaveProperty("toProfileIdHash");
+      expect(JSON.stringify(events[0])).not.toContain("primary-secret-profile");
+      expect(JSON.stringify(events[0])).not.toContain("fallback-secret-profile");
     });
 
     it("retries the same model before spending a rate-limit profile rotation", async () => {

--- a/src/agents/embedded-agent-runner/run/assistant-failover.ts
+++ b/src/agents/embedded-agent-runner/run/assistant-failover.ts
@@ -3,6 +3,8 @@
  */
 import { sanitizeForLog } from "../../../../packages/terminal-core/src/ansi.js";
 import type { OpenClawConfig } from "../../../config/types.openclaw.js";
+import { emitAuthProfileFallbackEvent } from "../../../infra/diagnostic-events.js";
+import { redactIdentifier } from "../../../logging/redact-identifier.js";
 import type { AssistantMessage } from "../../../llm/types.js";
 import type { AuthProfileFailureReason } from "../../auth-profiles.js";
 import {
@@ -168,6 +170,7 @@ export async function handleAssistantFailover(params: {
   maybeRetrySameModelRateLimit: (retry?: ShortWindowRateLimitRetry) => Promise<boolean>;
   maybeBackoffBeforeOverloadFailover: (reason: FailoverReason | null) => Promise<void>;
   advanceAuthProfile: () => Promise<boolean>;
+  getLastProfileId?: () => string | undefined;
 }): Promise<AssistantFailoverOutcome> {
   let overloadProfileRotations = params.overloadProfileRotations;
   let decision = params.initialDecision;
@@ -280,6 +283,14 @@ export async function handleAssistantFailover(params: {
       // Marking the failed profile is non-blocking after rotation succeeds; the
       // retry can proceed with the next profile while the failure record settles.
       void markFailedProfilePromise;
+      const nextProfileId = params.getLastProfileId?.();
+      emitAuthProfileFallbackEvent({
+        provider: params.provider,
+        model: params.modelId,
+        fromProfileIdHash: failedProfileId ? redactIdentifier(failedProfileId) : undefined,
+        toProfileIdHash: nextProfileId ? redactIdentifier(nextProfileId) : undefined,
+        reason: failureReason ?? params.failoverReason ?? "unknown",
+      });
       params.logAssistantFailoverDecision("rotate_profile");
       await params.maybeBackoffBeforeOverloadFailover(params.failoverReason);
       return {

--- a/src/agents/embedded-agent-runner/run/assistant-failover.ts
+++ b/src/agents/embedded-agent-runner/run/assistant-failover.ts
@@ -3,9 +3,9 @@
  */
 import { sanitizeForLog } from "../../../../packages/terminal-core/src/ansi.js";
 import type { OpenClawConfig } from "../../../config/types.openclaw.js";
-import { emitAuthProfileFallbackEvent } from "../../../infra/diagnostic-events.js";
-import { redactIdentifier } from "../../../logging/redact-identifier.js";
+import { emitTrustedDiagnosticEvent } from "../../../infra/diagnostic-events.js";
 import type { AssistantMessage } from "../../../llm/types.js";
+import { redactIdentifier } from "../../../logging/redact-identifier.js";
 import type { AuthProfileFailureReason } from "../../auth-profiles.js";
 import {
   formatAssistantErrorText,
@@ -284,7 +284,8 @@ export async function handleAssistantFailover(params: {
       // retry can proceed with the next profile while the failure record settles.
       void markFailedProfilePromise;
       const nextProfileId = params.getLastProfileId?.();
-      emitAuthProfileFallbackEvent({
+      emitTrustedDiagnosticEvent({
+        type: "auth_profile.fallback",
         provider: params.provider,
         model: params.modelId,
         fromProfileIdHash: failedProfileId ? redactIdentifier(failedProfileId) : undefined,

--- a/src/agents/embedded-agent-runner/run/failover-observation.test.ts
+++ b/src/agents/embedded-agent-runner/run/failover-observation.test.ts
@@ -1,6 +1,12 @@
 // Failover observation tests pin the warning payloads emitted when embedded
 // runs decide whether to retry, rotate profiles, fall back, or surface errors.
 import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  onTrustedInternalDiagnosticEvent,
+  resetDiagnosticEventsForTest,
+  waitForDiagnosticEventsDrained,
+  type DiagnosticEventPayload,
+} from "../../../infra/diagnostic-events.js";
 import { log } from "../logger.js";
 import {
   createFailoverDecisionLogger,
@@ -86,6 +92,7 @@ describe("normalizeFailoverDecisionObservationBase", () => {
 
 describe("createFailoverDecisionLogger", () => {
   afterEach(() => {
+    resetDiagnosticEventsForTest();
     vi.restoreAllMocks();
   });
 
@@ -118,6 +125,52 @@ describe("createFailoverDecisionLogger", () => {
     expect(observation.model).toBe("gpt-5.4");
     expect(observation.consoleMessage).toContain("from=github-copilot/gpt-5.4-mini");
     expect(observation.consoleMessage).toContain("to=openai/gpt-5.4");
+  });
+
+  it("emits a trusted model.failover diagnostic only for fallback decisions", async () => {
+    const warnSpy = vi.spyOn(log, "warn").mockImplementation(() => {});
+    const events: DiagnosticEventPayload[] = [];
+    const stop = onTrustedInternalDiagnosticEvent((event) => {
+      events.push(event);
+    });
+    const logDecision = createFailoverDecisionLogger({
+      stage: "assistant",
+      runId: "run:failover",
+      rawError: "timeout",
+      failoverReason: "timeout",
+      profileFailureReason: "timeout",
+      provider: "openai",
+      model: "gpt-5.4",
+      sourceProvider: "github-copilot",
+      sourceModel: "gpt-5.4-mini",
+      profileId: "openai:p1",
+      fallbackConfigured: true,
+      timedOut: true,
+      aborted: false,
+    });
+
+    logDecision("surface_error");
+    await waitForDiagnosticEventsDrained();
+    expect(events).toEqual([]);
+
+    logDecision("fallback_model", { status: 408 });
+    await waitForDiagnosticEventsDrained();
+    stop();
+
+    expect(warnSpy).toHaveBeenCalledTimes(2);
+    expect(events).toHaveLength(1);
+    expect(events[0]).toMatchObject({
+      type: "model.failover",
+      fromProvider: "github-copilot",
+      fromModel: "gpt-5.4-mini",
+      toProvider: "openai",
+      toModel: "gpt-5.4",
+      reason: "timeout",
+      suspended: false,
+    });
+    expect(events[0]).not.toHaveProperty("sessionId");
+    expect(events[0]).not.toHaveProperty("sessionKey");
+    expect(events[0]).not.toHaveProperty("lane");
   });
 
   it("omits to model refs when the source matches the selected target", () => {

--- a/src/agents/embedded-agent-runner/run/failover-observation.test.ts
+++ b/src/agents/embedded-agent-runner/run/failover-observation.test.ts
@@ -1,12 +1,7 @@
 // Failover observation tests pin the warning payloads emitted when embedded
 // runs decide whether to retry, rotate profiles, fall back, or surface errors.
 import { afterEach, describe, expect, it, vi } from "vitest";
-import {
-  onTrustedInternalDiagnosticEvent,
-  resetDiagnosticEventsForTest,
-  waitForDiagnosticEventsDrained,
-  type DiagnosticEventPayload,
-} from "../../../infra/diagnostic-events.js";
+import { resetDiagnosticEventsForTest } from "../../../infra/diagnostic-events.js";
 import { log } from "../logger.js";
 import {
   createFailoverDecisionLogger,
@@ -127,12 +122,8 @@ describe("createFailoverDecisionLogger", () => {
     expect(observation.consoleMessage).toContain("to=openai/gpt-5.4");
   });
 
-  it("emits a trusted model.failover diagnostic only for fallback decisions", async () => {
+  it("logs fallback decisions without emitting model.failover diagnostics", async () => {
     const warnSpy = vi.spyOn(log, "warn").mockImplementation(() => {});
-    const events: DiagnosticEventPayload[] = [];
-    const stop = onTrustedInternalDiagnosticEvent((event) => {
-      events.push(event);
-    });
     const logDecision = createFailoverDecisionLogger({
       stage: "assistant",
       runId: "run:failover",
@@ -150,27 +141,10 @@ describe("createFailoverDecisionLogger", () => {
     });
 
     logDecision("surface_error");
-    await waitForDiagnosticEventsDrained();
-    expect(events).toEqual([]);
 
     logDecision("fallback_model", { status: 408 });
-    await waitForDiagnosticEventsDrained();
-    stop();
 
     expect(warnSpy).toHaveBeenCalledTimes(2);
-    expect(events).toHaveLength(1);
-    expect(events[0]).toMatchObject({
-      type: "model.failover",
-      fromProvider: "github-copilot",
-      fromModel: "gpt-5.4-mini",
-      toProvider: "openai",
-      toModel: "gpt-5.4",
-      reason: "timeout",
-      suspended: false,
-    });
-    expect(events[0]).not.toHaveProperty("sessionId");
-    expect(events[0]).not.toHaveProperty("sessionKey");
-    expect(events[0]).not.toHaveProperty("lane");
   });
 
   it("omits to model refs when the source matches the selected target", () => {
@@ -230,7 +204,8 @@ describe("createFailoverDecisionLogger", () => {
 
   it("omits raw HTML Cloudflare challenge bodies from consoleMessage for upstream_html 403", () => {
     const warnSpy = vi.spyOn(log, "warn").mockImplementation(() => {});
-    const cfChallengeHtml = "403 <!DOCTYPE html><html><head><title>403 Forbidden</title></head>" +
+    const cfChallengeHtml =
+      "403 <!DOCTYPE html><html><head><title>403 Forbidden</title></head>" +
       "<body>Enable JavaScript and cookies to continue." +
       "<p>Please stand by, while we are checking your browser...</p></body></html>";
     const logDecision = createFailoverDecisionLogger({

--- a/src/agents/embedded-agent-runner/run/failover-observation.ts
+++ b/src/agents/embedded-agent-runner/run/failover-observation.ts
@@ -2,6 +2,7 @@
  * Logs redacted failover decisions for embedded-agent attempts.
  */
 import { redactIdentifier } from "../../../logging/redact-identifier.js";
+import { emitFailoverEvent } from "../../../infra/diagnostic-events.js";
 import type { AuthProfileFailureReason } from "../../auth-profiles.js";
 import { sanitizeForConsole } from "../../console-sanitize.js";
 import {
@@ -104,5 +105,15 @@ export function createFailoverDecisionLogger(
         `reason=${reasonText} from=${safeSourceProvider}/${safeSourceModel}` +
         `${sourceChanged ? ` to=${safeProvider}/${safeModel}` : ""} profile=${profileText}${rawErrorConsoleSuffix}`,
     });
+    if (decision === "fallback_model") {
+      emitFailoverEvent({
+        fromProvider: normalizedBase.sourceProvider ?? normalizedBase.provider,
+        fromModel: normalizedBase.sourceModel ?? normalizedBase.model,
+        toProvider: normalizedBase.provider,
+        toModel: normalizedBase.model,
+        reason: normalizedBase.failoverReason ?? "unknown",
+        suspended: false,
+      });
+    }
   };
 }

--- a/src/agents/embedded-agent-runner/run/failover-observation.ts
+++ b/src/agents/embedded-agent-runner/run/failover-observation.ts
@@ -2,7 +2,6 @@
  * Logs redacted failover decisions for embedded-agent attempts.
  */
 import { redactIdentifier } from "../../../logging/redact-identifier.js";
-import { emitFailoverEvent } from "../../../infra/diagnostic-events.js";
 import type { AuthProfileFailureReason } from "../../auth-profiles.js";
 import { sanitizeForConsole } from "../../console-sanitize.js";
 import {
@@ -105,15 +104,5 @@ export function createFailoverDecisionLogger(
         `reason=${reasonText} from=${safeSourceProvider}/${safeSourceModel}` +
         `${sourceChanged ? ` to=${safeProvider}/${safeModel}` : ""} profile=${profileText}${rawErrorConsoleSuffix}`,
     });
-    if (decision === "fallback_model") {
-      emitFailoverEvent({
-        fromProvider: normalizedBase.sourceProvider ?? normalizedBase.provider,
-        fromModel: normalizedBase.sourceModel ?? normalizedBase.model,
-        toProvider: normalizedBase.provider,
-        toModel: normalizedBase.model,
-        reason: normalizedBase.failoverReason ?? "unknown",
-        suspended: false,
-      });
-    }
   };
 }

--- a/src/agents/model-fallback.test.ts
+++ b/src/agents/model-fallback.test.ts
@@ -3,6 +3,12 @@ import crypto from "node:crypto";
 import path from "node:path";
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../config/config.js";
+import {
+  onTrustedInternalDiagnosticEvent,
+  resetDiagnosticEventsForTest,
+  waitForDiagnosticEventsDrained,
+  type DiagnosticEventPayload,
+} from "../infra/diagnostic-events.js";
 import { resetLogger, setLoggerOverride } from "../logging/logger.js";
 import { createWarnLogCapture } from "../logging/test-helpers/warn-log-capture.js";
 import {
@@ -199,6 +205,7 @@ function resetModelFallbackTestState(): void {
   // Fallback state has process-level caches for skip markers, harnesses, auth,
   // and plugin normalization. Reset every surface between tests.
   resetFallbackSkipCacheForTest();
+  resetDiagnosticEventsForTest();
   clearAgentHarnesses();
   authRuntimeMock.clear();
   authRuntimeMock.runtime.ensureAuthProfileStore.mockClear();
@@ -1956,6 +1963,52 @@ describe("runWithModelFallback", () => {
       model: "gpt-4.1-mini",
       firstError: Object.assign(new Error("nope"), { status: 401 }),
     });
+  });
+
+  it("emits model.failover diagnostics from the fallback owner with the selected target", async () => {
+    const cfg = makeCfg();
+    const events: DiagnosticEventPayload[] = [];
+    const stop = onTrustedInternalDiagnosticEvent((event) => {
+      events.push(event);
+    });
+    const run = vi
+      .fn()
+      .mockRejectedValueOnce(
+        new FailoverError("primary timed out", {
+          reason: "timeout",
+          provider: "openai",
+          model: "gpt-4.1-mini",
+          sessionId: "session-1",
+          lane: "agent:default",
+        }),
+      )
+      .mockResolvedValueOnce("ok");
+
+    const result = await runWithModelFallback({
+      cfg,
+      provider: "openai",
+      model: "gpt-4.1-mini",
+      sessionId: "session-1",
+      lane: "agent:default",
+      run,
+    });
+    await waitForDiagnosticEventsDrained();
+    stop();
+
+    expect(result.result).toBe("ok");
+    expect(events).toContainEqual(
+      expect.objectContaining({
+        type: "model.failover",
+        sessionId: "session-1",
+        lane: "agent:default",
+        fromProvider: "openai",
+        fromModel: "gpt-4.1-mini",
+        toProvider: "anthropic",
+        toModel: "claude-haiku-3-5",
+        reason: "timeout",
+        suspended: false,
+      }),
+    );
   });
 
   it("puts configured fallbacks before the configured primary when an override model is requested", () => {

--- a/src/agents/model-fallback.ts
+++ b/src/agents/model-fallback.ts
@@ -1811,7 +1811,7 @@ async function runWithModelFallbackInternal<T>(
           fromModel: candidate.model,
           toProvider: nextCandidate.provider,
           toModel: nextCandidate.model,
-          reason: failure.reason,
+          reason: failure.reason ?? "unknown",
           suspended: normalized instanceof FailoverError ? Boolean(normalized.suspend) : false,
         });
       }

--- a/src/agents/model-fallback.ts
+++ b/src/agents/model-fallback.ts
@@ -1801,6 +1801,20 @@ async function runWithModelFallbackInternal<T>(
       }
 
       lastError = isKnownFailover ? normalized : err;
+      const nextCandidate = candidates[i + 1];
+      if (nextCandidate) {
+        const failure = describeFailoverError(normalized);
+        emitFailoverEvent({
+          sessionId: params.sessionId,
+          lane: params.lane,
+          fromProvider: candidate.provider,
+          fromModel: candidate.model,
+          toProvider: nextCandidate.provider,
+          toModel: nextCandidate.model,
+          reason: failure.reason,
+          suspended: normalized instanceof FailoverError ? Boolean(normalized.suspend) : false,
+        });
+      }
       await observeFailedCandidate({
         attempts,
         candidate,
@@ -1812,7 +1826,7 @@ async function runWithModelFallbackInternal<T>(
         requestedModel: params.model,
         attempt: i + 1,
         total: candidates.length,
-        nextCandidate: candidates[i + 1],
+        nextCandidate,
         isPrimary,
         requestedModelMatched: requestedModel,
         fallbackConfigured: hasFallbackCandidates,

--- a/src/infra/diagnostic-events.ts
+++ b/src/infra/diagnostic-events.ts
@@ -62,6 +62,15 @@ export type DiagnosticFailoverEvent = DiagnosticBaseEvent & {
   suspended?: boolean;
 };
 
+export type DiagnosticAuthProfileFallbackEvent = DiagnosticBaseEvent & {
+  type: "auth_profile.fallback";
+  provider?: string;
+  model?: string;
+  fromProfileIdHash?: string;
+  toProfileIdHash?: string;
+  reason: string;
+};
+
 export type DiagnosticSecurityEventActor = {
   kind: "operator" | "node" | "agent" | "plugin" | "channel_sender" | "system";
   idHash?: string;
@@ -743,6 +752,8 @@ export type DiagnosticAsyncQueueDroppedEvent = DiagnosticBaseEvent & {
 
 export type DiagnosticEventPayload =
   | DiagnosticUsageEvent
+  | DiagnosticFailoverEvent
+  | DiagnosticAuthProfileFallbackEvent
   | DiagnosticWebhookReceivedEvent
   | DiagnosticWebhookProcessedEvent
   | DiagnosticWebhookErrorEvent
@@ -1267,6 +1278,16 @@ export function emitTrustedSecurityEvent(event: DiagnosticSecurityEventInput) {
 export function emitFailoverEvent(event: Omit<DiagnosticFailoverEvent, "seq" | "ts" | "type">) {
   emitTrustedDiagnosticEvent({
     type: "model.failover",
+    ...event,
+  });
+}
+
+/** Emits a trusted auth-profile fallback diagnostic event. */
+export function emitAuthProfileFallbackEvent(
+  event: Omit<DiagnosticAuthProfileFallbackEvent, "seq" | "ts" | "type">,
+) {
+  emitTrustedDiagnosticEvent({
+    type: "auth_profile.fallback",
     ...event,
   });
 }

--- a/src/infra/diagnostic-events.ts
+++ b/src/infra/diagnostic-events.ts
@@ -62,7 +62,7 @@ export type DiagnosticFailoverEvent = DiagnosticBaseEvent & {
   suspended?: boolean;
 };
 
-export type DiagnosticAuthProfileFallbackEvent = DiagnosticBaseEvent & {
+type DiagnosticAuthProfileFallbackEvent = DiagnosticBaseEvent & {
   type: "auth_profile.fallback";
   provider?: string;
   model?: string;
@@ -1277,16 +1277,6 @@ export function emitTrustedSecurityEvent(event: DiagnosticSecurityEventInput) {
 export function emitFailoverEvent(event: Omit<DiagnosticFailoverEvent, "seq" | "ts" | "type">) {
   emitTrustedDiagnosticEvent({
     type: "model.failover",
-    ...event,
-  });
-}
-
-/** Emits a trusted auth-profile fallback diagnostic event. */
-export function emitAuthProfileFallbackEvent(
-  event: Omit<DiagnosticAuthProfileFallbackEvent, "seq" | "ts" | "type">,
-) {
-  emitTrustedDiagnosticEvent({
-    type: "auth_profile.fallback",
     ...event,
   });
 }

--- a/src/infra/diagnostic-events.ts
+++ b/src/infra/diagnostic-events.ts
@@ -803,8 +803,7 @@ export type DiagnosticEventPayload =
   | DiagnosticLogRecordEvent
   | DiagnosticSecurityEvent
   | DiagnosticTelemetryExporterEvent
-  | DiagnosticAsyncQueueDroppedEvent
-  | DiagnosticFailoverEvent;
+  | DiagnosticAsyncQueueDroppedEvent;
 
 type DiagnosticNonSecurityEventPayload = Exclude<DiagnosticEventPayload, DiagnosticSecurityEvent>;
 

--- a/src/logging/diagnostic-stability.ts
+++ b/src/logging/diagnostic-stability.ts
@@ -554,6 +554,13 @@ function sanitizeDiagnosticEvent(event: DiagnosticEventPayload): DiagnosticStabi
       record.model = event.fromModel;
       assignReasonCode(record, event.reason);
       break;
+    case "auth_profile.fallback":
+      record.provider = event.provider;
+      record.model = event.model;
+      record.source = event.fromProfileIdHash;
+      record.target = event.toProfileIdHash;
+      assignReasonCode(record, event.reason);
+      break;
   }
 
   return record;


### PR DESCRIPTION
## What Problem This Solves

OpenClaw can already move from a selected/default model route to a fallback model route or rotate auth profiles when a primary profile fails, but there was no optional runtime hook for operators to send a sanitized fallback-enter, fallback-cleared, or auth-profile-fallback event to their own alerting surface. That makes fallback state easy to miss even when the model call itself succeeds through a fallback.

This adds a disabled-by-default reporter that only sends when an endpoint and token are configured. It emits model fallback enter/clear and auth-profile fallback transitions, sanitizes bounded fields, supports token-file based configuration, surfaces non-2xx ingest failures, and suppresses duplicate direct model fallback alerts when the auto-reply path can emit the resolved active route.

## Evidence

Focused verification from the review worktree:

- node scripts/run-vitest.mjs run src/infra/fallback-alert-reporter.test.ts -t fallback: 9 passed
- node scripts/run-vitest.mjs run --config test/vitest/vitest.e2e.config.ts src/auto-reply/reply/agent-runner.runreplyagent.e2e.test.ts -t "announces fallback transitions and emits lifecycle events while verbose is off": 1 passed / 62 skipped
- pnpm dlx oxlint@1.67.0 --tsconfig config/tsconfig/oxlint.core.json <changed OpenClaw files>: passed after the curly/no-promise-executor-return cleanup
- git diff --check: clean

The reporter remains inert unless configured with both an ingest endpoint and token, so the default runtime behavior is unchanged.