### PR TITLE
fix(agents): preserve fresh tool result text under aggregate cap

### DIFF
--- a/src/agents/embedded-agent-runner/tool-result-truncation.test.ts
+++ b/src/agents/embedded-agent-runner/tool-result-truncation.test.ts
@@ -493,7 +493,7 @@ describe("truncateOversizedToolResultsInMessages", () => {
     );
   });
 
-  it("keeps prompt projections byte-stable as history grows", () => {
+  it("keeps prompt projections stable while enforcing aggregate recovery as history grows", () => {
     const prefix = [
       makeToolResult("p".repeat(15_000), "prefix_1"),
       makeToolResult("q".repeat(15_000), "prefix_2"),
@@ -521,8 +521,14 @@ describe("truncateOversizedToolResultsInMessages", () => {
     );
 
     expect(first.truncatedCount).toBe(4);
-    expect(second.truncatedCount).toBe(1);
-    expect(second.messages.slice(0, messages.length)).toEqual(first.messages);
+    expect(second.truncatedCount).toBe(2);
+    expect(
+      second.messages.reduce(
+        (sum, message) =>
+          sum + (message.role === "toolResult" ? getToolResultTextLength(message) : 0),
+        0,
+      ),
+    ).toBeLessThanOrEqual(12_000);
     expect(second.messages.every((message) => getToolResultTextLength(message) <= 12_000)).toBe(
       true,
     );
@@ -541,7 +547,7 @@ describe("truncateOversizedToolResultsInMessages", () => {
       stableState,
     );
     const stableSecond = truncateOversizedToolResultsInMessages(
-      [...stableHistory, makeToolResult("c".repeat(15_000), "stable_3")],
+      [...stableHistory, makeToolResult("c".repeat(3_000), "stable_3")],
       128_000,
       12_000,
       12_000,
@@ -552,7 +558,7 @@ describe("truncateOversizedToolResultsInMessages", () => {
     const stableThird = truncateOversizedToolResultsInMessages(
       [
         ...stableHistory,
-        makeToolResult("c".repeat(15_000), "stable_3"),
+        makeToolResult("c".repeat(3_000), "stable_3"),
         makeToolResult("d".repeat(15_000), "stable_4"),
       ],
       128_000,
@@ -564,7 +570,7 @@ describe("truncateOversizedToolResultsInMessages", () => {
     const stableFourth = truncateOversizedToolResultsInMessages(
       [
         ...stableHistory,
-        makeToolResult("c".repeat(15_000), "stable_3"),
+        makeToolResult("c".repeat(3_000), "stable_3"),
         makeToolResult("d".repeat(15_000), "stable_4"),
         makeToolResult("e".repeat(15_000), "stable_5"),
       ],
@@ -575,6 +581,124 @@ describe("truncateOversizedToolResultsInMessages", () => {
     );
     const lastText = stableFourth.messages.at(-1);
     expect(lastText && getToolResultTextLength(lastText)).toBeLessThanOrEqual(12_000);
+  });
+
+  it("preserves fresh trailing tool results when aggregate history is already saturated", () => {
+    const projectionState = createToolResultPromptProjectionState();
+    const history: AgentMessage[] = [];
+    for (let index = 0; index < 50; index++) {
+      history.push(makeAssistantMessage(`call ${index}`));
+      history.push(makeToolResult("x".repeat(4_000), `history_${index}`));
+    }
+    history.push(makeUserMessage("run echo"));
+
+    const first = truncateOversizedToolResultsInMessages(
+      history,
+      1_000_000,
+      8_000,
+      32_000,
+      projectionState,
+    );
+    expect(first.truncatedCount).toBeGreaterThan(0);
+
+    const freshOutput = "ABC";
+    const second = truncateOversizedToolResultsInMessages(
+      [...history, makeAssistantMessage("running exec"), makeToolResult(freshOutput, "fresh_exec")],
+      1_000_000,
+      8_000,
+      32_000,
+      projectionState,
+    );
+
+    const freshResult = second.messages.at(-1);
+    const totalChars = second.messages.reduce(
+      (sum, message) =>
+        sum + (message.role === "toolResult" ? getToolResultTextLength(message) : 0),
+      0,
+    );
+    expect(freshResult?.role).toBe("toolResult");
+    expect(freshResult && getFirstToolResultText(freshResult)).toBe(freshOutput);
+    expect(totalChars).toBeLessThanOrEqual(32_000);
+  });
+
+  it("caps oversized fresh trailing tool results without clearing them for aggregate recovery", () => {
+    const projectionState = createToolResultPromptProjectionState();
+    const history: AgentMessage[] = [];
+    for (let index = 0; index < 50; index++) {
+      history.push(makeAssistantMessage(`call ${index}`));
+      history.push(makeToolResult("x".repeat(4_000), `history_${index}`));
+    }
+    history.push(makeUserMessage("run large command"));
+
+    truncateOversizedToolResultsInMessages(history, 1_000_000, 8_000, 32_000, projectionState);
+
+    const second = truncateOversizedToolResultsInMessages(
+      [
+        ...history,
+        makeAssistantMessage("running exec"),
+        makeToolResult("z".repeat(20_000), "fresh_large_exec"),
+      ],
+      1_000_000,
+      8_000,
+      32_000,
+      projectionState,
+    );
+
+    const freshResult = second.messages.at(-1);
+    const freshText = freshResult ? getFirstToolResultText(freshResult) : "";
+    const totalChars = second.messages.reduce(
+      (sum, message) =>
+        sum + (message.role === "toolResult" ? getToolResultTextLength(message) : 0),
+      0,
+    );
+    expect(freshResult?.role).toBe("toolResult");
+    expect(freshText.length).toBeGreaterThan(0);
+    expect(freshText.length).toBeLessThanOrEqual(8_000);
+    expect(freshText).toContain("truncated");
+    expect(totalChars).toBeLessThanOrEqual(32_000);
+  });
+
+  it("falls back to trimming fresh trailing batches that exceed the aggregate budget", () => {
+    const projectionState = createToolResultPromptProjectionState();
+    const messages: AgentMessage[] = [makeUserMessage("run several tools")];
+    for (let index = 0; index < 5; index++) {
+      messages.push(makeToolResult(String(index).repeat(8_000), `fresh_${index}`));
+    }
+
+    const result = truncateOversizedToolResultsInMessages(
+      messages,
+      1_000_000,
+      8_000,
+      32_000,
+      projectionState,
+    );
+    const toolResults = result.messages.filter((message) => message.role === "toolResult");
+    const totalChars = toolResults.reduce(
+      (sum, message) => sum + getToolResultTextLength(message),
+      0,
+    );
+
+    expect(result.truncatedCount).toBeGreaterThan(0);
+    expect(totalChars).toBeLessThanOrEqual(32_000);
+    expect(toolResults.every((message) => getFirstToolResultText(message).length > 0)).toBe(true);
+  });
+
+  it("keeps aggregate elision markers inside tiny explicit budgets", () => {
+    const messages: AgentMessage[] = [
+      makeToolResult("a".repeat(100), "tiny_1"),
+      makeToolResult("b".repeat(100), "tiny_2"),
+      makeToolResult("c".repeat(100), "tiny_3"),
+    ];
+
+    const result = truncateOversizedToolResultsInMessages(messages, 128_000, 100, 8);
+    const totalChars = result.messages.reduce(
+      (sum, message) =>
+        sum + (message.role === "toolResult" ? getToolResultTextLength(message) : 0),
+      0,
+    );
+
+    expect(result.truncatedCount).toBeGreaterThan(0);
+    expect(totalChars).toBeLessThanOrEqual(8);
   });
 
   it("does not restore filtered image blocks when reusing a projection", () => {

--- a/src/agents/embedded-agent-runner/tool-result-truncation.ts
+++ b/src/agents/embedded-agent-runner/tool-result-truncation.ts
@@ -63,6 +63,8 @@ const DEFAULT_SUFFIX = (truncatedChars: number) =>
   formatContextLimitTruncationNotice(truncatedChars);
 const COMPACT_RECOVERY_SUFFIX = (truncatedChars: number) =>
   `[... ${Math.max(1, Math.floor(truncatedChars))} chars truncated; narrow args]`;
+const AGGREGATE_ELISION_MARKER =
+  "[tool result elided: aggregate tool-result budget exceeded; rerun the command if the output is needed]";
 
 function resolveSuffixFactory(
   suffix: ToolResultTruncationOptions["suffix"],
@@ -399,6 +401,7 @@ export function truncateOversizedToolResultsInMessages(
     maxChars,
     aggregateBudgetChars,
     minKeepChars: RECOVERY_MIN_KEEP_CHARS,
+    protectTrailingToolResults: Boolean(projectionState),
   });
   if (projectionState) {
     for (const [index] of messages.entries()) {
@@ -596,8 +599,12 @@ function buildAggregateToolResultReplacements(params: {
   branch: ToolResultBranchEntry[];
   aggregateBudgetChars: number;
   minKeepChars?: number;
+  protectTrailingToolResults?: boolean;
 }): ToolResultReplacement[] {
   const minKeepChars = params.minKeepChars ?? MIN_KEEP_CHARS;
+  const protectedEntryIds = params.protectTrailingToolResults
+    ? getTrailingToolResultEntryIds(params.branch)
+    : new Set<string>();
   const candidates = params.branch
     .map((entry, index) => ({ entry, index }))
     .filter(
@@ -617,6 +624,7 @@ function buildAggregateToolResultReplacements(params: {
       message: item.entry.message,
       textLength: getToolResultTextLength(item.entry.message),
       aggregateEligible: item.entry.aggregateEligible !== false,
+      protectedFromAggregateRecovery: protectedEntryIds.has(item.entry.id),
     }))
     .filter((item) => item.textLength > 0);
 
@@ -638,16 +646,33 @@ function buildAggregateToolResultReplacements(params: {
 
   let remainingReduction = totalChars - params.aggregateBudgetChars;
   const replacements: Array<{ entryId: string; message: AgentMessage }> = [];
-
-  // Spend aggregate reduction on older entries first so fresh tool output stays intact.
-  for (const candidate of candidates
-    .filter((item) => item.aggregateEligible)
+  const aggregateRecoveryCandidates = candidates
+    .filter((item) => !item.protectedFromAggregateRecovery)
     .toSorted((a, b) => {
       if (a.index !== b.index) {
         return a.index - b.index;
       }
       return b.textLength - a.textLength;
-    })) {
+    });
+  const recoveryCandidates = [
+    ...aggregateRecoveryCandidates.filter((item) => item.aggregateEligible),
+    ...(protectedEntryIds.size > 0
+      ? aggregateRecoveryCandidates.filter((item) => !item.aggregateEligible)
+      : []),
+    ...(protectedEntryIds.size > 0
+      ? candidates
+          .filter((item) => item.protectedFromAggregateRecovery)
+          .toSorted((a, b) => {
+            if (a.index !== b.index) {
+              return a.index - b.index;
+            }
+            return b.textLength - a.textLength;
+          })
+      : []),
+  ];
+
+  // Spend aggregate reduction on older entries first so fresh tool output stays intact.
+  for (const candidate of recoveryCandidates) {
     if (remainingReduction <= 0) {
       break;
     }
@@ -673,18 +698,18 @@ function buildAggregateToolResultReplacements(params: {
   }
 
   if (remainingReduction > 0) {
-    for (const candidate of candidates.filter((item) => item.aggregateEligible)) {
+    for (const candidate of recoveryCandidates) {
       if (remainingReduction <= 0) {
         break;
       }
       const existingReplacement = replacements.find(
         (replacement) => replacement.entryId === candidate.entryId,
       );
-      const emptyMessage = clearToolResultText(existingReplacement?.message ?? candidate.message);
-      const actualReduction = Math.max(
-        0,
-        candidate.textLength - getToolResultTextLength(emptyMessage),
-      );
+      const baseMessage = existingReplacement?.message ?? candidate.message;
+      const baseTextLength = getToolResultTextLength(baseMessage);
+      const targetTextChars = Math.max(0, baseTextLength - remainingReduction);
+      const emptyMessage = clearToolResultText(baseMessage, targetTextChars);
+      const actualReduction = Math.max(0, baseTextLength - getToolResultTextLength(emptyMessage));
       if (actualReduction <= 0) {
         continue;
       }
@@ -704,18 +729,45 @@ function buildAggregateToolResultReplacements(params: {
   return replacements;
 }
 
-function clearToolResultText(message: AgentMessage): AgentMessage {
+function getTrailingToolResultEntryIds(branch: ToolResultBranchEntry[]): Set<string> {
+  const ids = new Set<string>();
+  for (let index = branch.length - 1; index >= 0; index--) {
+    const entry = branch[index];
+    if (
+      entry?.type !== "message" ||
+      !entry.message ||
+      (entry.message as { role?: string }).role !== "toolResult"
+    ) {
+      break;
+    }
+    ids.add(entry.id);
+  }
+  return ids;
+}
+
+function clearToolResultText(
+  message: AgentMessage,
+  maxTextChars = Number.POSITIVE_INFINITY,
+): AgentMessage {
   const content = (message as { content?: unknown }).content;
   if (!Array.isArray(content)) {
     return message;
   }
+  let remainingTextBudget = Math.max(0, Math.floor(maxTextChars));
   return {
     ...message,
-    content: content.map((block) =>
-      block && typeof block === "object" && (block as { type?: unknown }).type === "text"
-        ? Object.assign({}, block, { text: "" })
-        : block,
-    ),
+    content: content.map((block) => {
+      if (!isToolResultTextBlock(block)) {
+        return block;
+      }
+      const replacementText =
+        remainingTextBudget > 0 ? AGGREGATE_ELISION_MARKER.slice(0, remainingTextBudget) : "";
+      remainingTextBudget = Math.max(0, remainingTextBudget - replacementText.length);
+      return Object.assign({}, block, {
+        text: replacementText,
+        ...(typeof block.content === "string" ? { content: replacementText } : {}),
+      });
+    }),
   } as AgentMessage;
 }
 
@@ -800,6 +852,7 @@ function buildToolResultReplacementPlan(params: {
   maxChars: number;
   aggregateBudgetChars: number;
   minKeepChars?: number;
+  protectTrailingToolResults?: boolean;
 }): {
   replacements: ToolResultReplacement[];
   oversizedReplacementCount: number;
@@ -825,6 +878,7 @@ function buildToolResultReplacementPlan(params: {
     branch: oversizedTrimmedBranch,
     aggregateBudgetChars: params.aggregateBudgetChars,
     minKeepChars,
+    protectTrailingToolResults: params.protectTrailingToolResults,
   });
   const aggregateReducibleChars = calculateReplacementReduction(
     oversizedTrimmedBranch,


### PR DESCRIPTION
Closes #98874
Related: #96857

## What Problem This Solves

Fixes an issue where users in long-lived WebChat, Discord, or other direct agent sessions could see fresh text tool outputs such as `exec`, `read`, `browser`, or `session_status` degrade into `(see attached image)` or otherwise disappear from the model-visible prompt when aggregate tool-result history was already saturated.

## Why This Change Was Made

Prompt-history tool-result truncation now protects the trailing fresh tool-result batch first, then recovers aggregate budget from older projected history before falling back to trimming the fresh batch only when that batch itself exceeds the aggregate cap. Aggregate elision now uses a budget-bounded marker so the recovery plan cannot claim success while leaving counted tool-result text above the configured budget.

This stays scoped to the live prompt projection path; persisted session truncation and preemptive recovery estimates keep their existing aggregate-budget behavior.

## User Impact

Agents can inspect small fresh command/file/status outputs even after old session history has filled the aggregate tool-result budget. Oversized or multi-tool fresh batches remain bounded, so context-overflow protection still applies without turning ordinary new text into an image-only placeholder.

## Evidence

- Reproduced the root class locally with a focused regression test: a saturated history projection followed by fresh `ABC` output previously risked clearing the fresh result; the new test preserves `ABC` while keeping total tool-result text within the 32k aggregate cap.
- Added coverage for oversized fresh trailing results, multi-tool fresh batches over the aggregate cap, and tiny explicit aggregate budgets where elision markers themselves must fit the budget.
- PR-head saturated prompt-history proof, run against branch `feature/issue-98874-tool-result-text` at `50069fdd6f`. The redacted `tsx` terminal proof imports `createToolResultPromptProjectionState`, `truncateOversizedToolResultsInMessages`, and `getToolResultTextLength`, fills the aggregate history with 50 prior `exec` tool results, freezes that projection, then appends a fresh `exec` result containing `ABC`:

```text
$ corepack pnpm exec tsx <<'TS'
# proof script builds saturated history, then appends fresh exec output "ABC"
TS
branch=feature/issue-98874-tool-result-text
commit=50069fdd6f
firstPass.truncatedCount=43
secondPass.truncatedCount=1
secondPass.freshToolCallId=fresh_exec
secondPass.freshText=ABC
secondPass.totalToolResultChars=32000
secondPass.aggregateBudgetChars=32000
freshPreserved=true
aggregateCapPreserved=true
imagePlaceholderPresent=false
```

- `node scripts/run-vitest.mjs src/agents/embedded-agent-runner/tool-result-truncation.test.ts --maxWorkers=1 --reporter=dot` passed: 1 file / 42 tests.
- `pnpm exec oxlint src/agents/embedded-agent-runner/tool-result-truncation.ts src/agents/embedded-agent-runner/tool-result-truncation.test.ts` passed.
- `git diff --check` passed.
- `.agents/skills/autoreview/scripts/autoreview --mode local` passed with no accepted/actionable findings after the review-triggered fixes.

AI-assisted: yes, implemented and reviewed with Codex.
