### PR TITLE
fix: collect all variadic --mcp-config values instead of only the first (fixes #98944)

### DIFF
--- a/src/agents/cli-runner/bundle-mcp-claude.ts
+++ b/src/agents/cli-runner/bundle-mcp-claude.ts
@@ -63,7 +63,7 @@ export function injectClaudeMcpConfigArgs(
     }
     if (arg === "--mcp-config") {
       // Variadic: skip all following non-flag values.
-      while (i + 1 < args.length && !(args?.[i + 1] ?? "").startsWith("-")) {
+      while (i + 1 < (args?.length ?? 0) && !(args?.[i + 1] ?? "").startsWith("-")) {
         i += 1;
       }
       continue;

--- a/src/agents/cli-runner/bundle-mcp-claude.ts
+++ b/src/agents/cli-runner/bundle-mcp-claude.ts
@@ -7,19 +7,47 @@ import { normalizeOptionalString } from "@openclaw/normalization-core/string-coe
 
 /** Find an existing Claude `--mcp-config` argument value. */
 export function findClaudeMcpConfigPath(args?: string[]): string | undefined {
+  return findAllClaudeMcpConfigPaths(args)[0];
+}
+
+/**
+ * Collect all Claude `--mcp-config` argument values.
+ *
+ * `--mcp-config` is variadic in Claude's own arg model (see
+ * `CLAUDE_SIDE_QUESTION_VARIADIC_VALUE_ARGS` in the anthropic extension):
+ * every non-dash token after `--mcp-config` until the next flag is a
+ * separate config file path.
+ */
+export function findAllClaudeMcpConfigPaths(args?: string[]): string[] {
+  const paths: string[] = [];
   if (!args?.length) {
-    return undefined;
+    return paths;
   }
   for (let i = 0; i < args.length; i += 1) {
     const arg = args[i] ?? "";
     if (arg === "--mcp-config") {
-      return normalizeOptionalString(args[i + 1]);
+      // Variadic: collect all following non-flag values.
+      while (
+        i + 1 < args.length &&
+        typeof args[i + 1] === "string" &&
+        !(args[i + 1] ?? "").startsWith("-")
+      ) {
+        i += 1;
+        const value = normalizeOptionalString(args[i]);
+        if (value) {
+          paths.push(value);
+        }
+      }
+      continue;
     }
     if (arg.startsWith("--mcp-config=")) {
-      return normalizeOptionalString(arg.slice("--mcp-config=".length));
+      const value = normalizeOptionalString(arg.slice("--mcp-config=".length));
+      if (value) {
+        paths.push(value);
+      }
     }
   }
-  return undefined;
+  return paths;
 }
 
 /** Return Claude args with OpenClaw's strict MCP config path injected. */
@@ -34,7 +62,10 @@ export function injectClaudeMcpConfigArgs(
       continue;
     }
     if (arg === "--mcp-config") {
-      i += 1;
+      // Variadic: skip all following non-flag values.
+      while (i + 1 < args.length && !(args?.[i + 1] ?? "").startsWith("-")) {
+        i += 1;
+      }
       continue;
     }
     if (arg.startsWith("--mcp-config=")) {

--- a/src/agents/cli-runner/bundle-mcp.test.ts
+++ b/src/agents/cli-runner/bundle-mcp.test.ts
@@ -263,4 +263,47 @@ describe("prepareCliBundleMcpConfig", () => {
 
     await prepared.cleanup?.();
   });
+
+  it("respects argv boundary: resumeArgs does not leak into fresh args", async () => {
+    const workspaceDir = await cliBundleMcpHarness.tempHarness.createTempDir(
+      "openclaw-cli-bundle-mcp-resume-boundary-",
+    );
+
+    // Write a user MCP config file for resume.
+    const resumeConfig = path.join(workspaceDir, "resume.json");
+    await fs.writeFile(
+      resumeConfig,
+      JSON.stringify({
+        mcpServers: { resumeServer: { command: "node", args: ["./resume.mjs"] } },
+      }),
+      "utf-8",
+    );
+
+    const prepared = await prepareCliBundleMcpConfig({
+      enabled: true,
+      mode: "claude-config-file",
+      backend: {
+        command: "node",
+        // resumeArgs contains --mcp-config, and args contains the fresh-run command
+        resumeArgs: ["./fake-claude.mjs", "--mcp-config", "resume.json"],
+        args: ["--another-flag", "some-value"],
+      },
+      workspaceDir,
+      config: { plugins: { enabled: false } },
+    });
+
+    // Only resume config should be merged; fresh args should not be consumed.
+    const generatedConfigPath = requireMcpConfigPath(prepared.backend.args);
+    const raw = JSON.parse(await fs.readFile(generatedConfigPath, "utf-8")) as {
+      mcpServers?: Record<string, unknown>;
+    };
+    expect(raw.mcpServers).toHaveProperty("resumeServer");
+    expect(raw.mcpServers).not.toHaveProperty("some-value");
+
+    // Fresh args should remain intact and not be stripped.
+    expect(prepared.backend.args).toContain("--another-flag");
+    expect(prepared.backend.args).toContain("some-value");
+
+    await prepared.cleanup?.();
+  });
 });

--- a/src/agents/cli-runner/bundle-mcp.test.ts
+++ b/src/agents/cli-runner/bundle-mcp.test.ts
@@ -214,4 +214,53 @@ describe("prepareCliBundleMcpConfig", () => {
     expect(prepared.backend.args).toEqual(["./fake-cli.mjs"]);
     expect(prepared.cleanup).toBeUndefined();
   });
+
+  it("merges all variadic --mcp-config files into the bundle overlay", async () => {
+    const workspaceDir = await cliBundleMcpHarness.tempHarness.createTempDir(
+      "openclaw-cli-bundle-mcp-variadic-",
+    );
+
+    // Write two separate user MCP config files.
+    const configA = path.join(workspaceDir, "a.json");
+    const configB = path.join(workspaceDir, "b.json");
+    await fs.writeFile(
+      configA,
+      JSON.stringify({
+        mcpServers: { serverA: { command: "node", args: ["./a.mjs"] } },
+      }),
+      "utf-8",
+    );
+    await fs.writeFile(
+      configB,
+      JSON.stringify({
+        mcpServers: { serverB: { command: "node", args: ["./b.mjs"] } },
+      }),
+      "utf-8",
+    );
+
+    const prepared = await prepareCliBundleMcpConfig({
+      enabled: true,
+      mode: "claude-config-file",
+      backend: {
+        command: "node",
+        args: ["./fake-claude.mjs", "--mcp-config", "a.json", "b.json"],
+      },
+      workspaceDir,
+      config: { plugins: { enabled: false } },
+    });
+
+    // Both user config servers should appear in the merged overlay.
+    const generatedConfigPath = requireMcpConfigPath(prepared.backend.args);
+    const raw = JSON.parse(await fs.readFile(generatedConfigPath, "utf-8")) as {
+      mcpServers?: Record<string, unknown>;
+    };
+    expect(raw.mcpServers).toHaveProperty("serverA");
+    expect(raw.mcpServers).toHaveProperty("serverB");
+
+    // The original --mcp-config args should be stripped (no bare "a.json"/"b.json").
+    expect(prepared.backend.args).not.toContain("a.json");
+    expect(prepared.backend.args).not.toContain("b.json");
+
+    await prepared.cleanup?.();
+  });
 });

--- a/src/agents/cli-runner/bundle-mcp.ts
+++ b/src/agents/cli-runner/bundle-mcp.ts
@@ -191,10 +191,13 @@ export async function prepareCliBundleMcpConfig(params: {
   const mode = resolveBundleMcpMode(params.mode);
   const existingMcpConfigPaths =
     mode === "claude-config-file"
-      ? findAllClaudeMcpConfigPaths([
-          ...(params.backend.resumeArgs ?? []),
-          ...(params.backend.args ?? []),
-        ])
+      ? findAllClaudeMcpConfigPaths(
+          // Prioritize resumeArgs if they exist (they replace args on resume),
+          // otherwise fall back to fresh args. Do not merge them.
+          params.backend.resumeArgs && params.backend.resumeArgs.length > 0
+            ? params.backend.resumeArgs
+            : (params.backend.args ?? []),
+        )
       : [];
   let mergedConfig: BundleMcpConfig = { mcpServers: {} };
 

--- a/src/agents/cli-runner/bundle-mcp.ts
+++ b/src/agents/cli-runner/bundle-mcp.ts
@@ -14,6 +14,7 @@ import type { CliBundleMcpMode } from "../../plugins/types.js";
 import { loadMergedBundleMcpConfig, toCliBundleMcpServerConfig } from "../bundle-mcp-config.js";
 import { isRecord } from "./bundle-mcp-adapter-shared.js";
 import {
+  findAllClaudeMcpConfigPaths,
   findClaudeMcpConfigPath,
   injectClaudeMcpConfigArgs,
   writeClaudeMcpCaptureConfig,
@@ -188,22 +189,24 @@ export async function prepareCliBundleMcpConfig(params: {
   }
 
   const mode = resolveBundleMcpMode(params.mode);
-  const existingMcpConfigPath =
+  const existingMcpConfigPaths =
     mode === "claude-config-file"
-      ? (findClaudeMcpConfigPath(params.backend.resumeArgs) ??
-        findClaudeMcpConfigPath(params.backend.args))
-      : undefined;
+      ? findAllClaudeMcpConfigPaths([
+          ...(params.backend.resumeArgs ?? []),
+          ...(params.backend.args ?? []),
+        ])
+      : [];
   let mergedConfig: BundleMcpConfig = { mcpServers: {} };
 
-  if (existingMcpConfigPath) {
-    // Merge any user-provided Claude MCP config first so bundle/plugin config can
+  for (const configPath of existingMcpConfigPaths) {
+    // Merge user-provided Claude MCP configs first so bundle/plugin config can
     // override intentionally managed server entries.
-    const resolvedExistingPath = path.isAbsolute(existingMcpConfigPath)
-      ? existingMcpConfigPath
-      : path.resolve(params.workspaceDir, existingMcpConfigPath);
+    const resolvedPath = path.isAbsolute(configPath)
+      ? configPath
+      : path.resolve(params.workspaceDir, configPath);
     mergedConfig = applyMergePatch(
       mergedConfig,
-      await readExternalMcpConfig(resolvedExistingPath),
+      await readExternalMcpConfig(resolvedPath),
     ) as BundleMcpConfig;
   }
 


### PR DESCRIPTION
## What Problem This Solves

`injectClaudeMcpConfigArgs` (`src/agents/cli-runner/bundle-mcp-claude.ts:26-47`) treats `--mcp-config` as taking exactly one value, but the repo's own Claude arg model treats it as variadic: `extensions/anthropic/cli-shared.ts:253-260` puts it in `CLAUDE_SIDE_QUESTION_VARIADIC_VALUE_ARGS` and skips all following non-dash values (`:290-297`). `findClaudeMcpConfigPath` (`bundle-mcp-claude.ts:9-23`) likewise returns only the first value, so only the first user config file is merged (`bundle-mcp.ts:191-208`).

A user configuring `cliBackends["claude-cli"].args: [..., "--mcp-config", "a.json", "b.json"]` gets: `--mcp-config a.json` stripped, `b.json` left behind as a bare positional (which Claude `-p` treats as the prompt or errors on), and `b.json`'s servers silently dropped from the merged strict config. Valid config produces a broken run.

## Why This Change Was Made

The fix aligns `--mcp-config` handling in the bundler with the variadic arg model already used by the anthropic extension's `stripClaudeSideQuestionConflictingArgs`. Four changes in two files:

1. **`findAllClaudeMcpConfigPaths`** (new helper in `bundle-mcp-claude.ts`): collects all `--mcp-config` values using the same variadic skip pattern — every non-dash token after `--mcp-config` until the next flag is a separate config file path.
2. **`injectClaudeMcpConfigArgs`** (`bundle-mcp-claude.ts`): updated to skip all following non-flag values after `--mcp-config` instead of only one.
3. **`prepareCliBundleMcpConfig`** (`bundle-mcp.ts`): reads and merges all user config files into the bundle overlay, not just the first.
4. **Argv boundary fix** (`bundle-mcp.ts`): `resumeArgs` and `args` are now scanned separately to prevent variadic scan from leaking across the resume boundary.

The existing `findClaudeMcpConfigPath` signature is preserved (delegates to `findAllClaudeMcpConfigPaths(args)[0]`) so callers that only need the first path are unaffected.

## User Impact

Users who pass multiple `--mcp-config` files to the Claude CLI backend will now have all their MCP servers correctly merged into the bundle overlay config, instead of only the first file being read and subsequent files leaking as bare positional args. Resume runs will also correctly respect the argv boundary and not consume fresh-run commands as config files.

## Evidence

- [x] AI-assisted (Hermes Agent)
- **Behavior addressed:** (1) The CLI runner bundler only reads the first `--mcp-config` file when multiple are provided. (2) When `resumeArgs` contains `--mcp-config`, the variadic scan incorrectly continued into `args`, treating the fresh-run command as a config file path.
- **Environment tested:** macOS 26.4.1, Node 22.22.3, OpenClaw commit `a2a68d154`
- **Steps run after the patch:** 
  1. Created two MCP config files (`a.json` and `b.json`) in a temporary workspace.
  2. Ran `prepareCliBundleMcpConfig` with variadic `--mcp-config a.json b.json` in args.
  3. Ran `prepareCliBundleMcpConfig` with `--mcp-config resume.json` in resumeArgs and fresh flags in args to test boundary.
  4. Executed the full test suite: `pnpm test src/agents/cli-runner/bundle-mcp.test.ts`
- **Evidence after fix:** All 8 verification cases pass including the new variadic case and the argv boundary regression test. The merged overlay config contains both servers from variadic config files. In the boundary test, only `resume.json` is merged while fresh args (`--another-flag`, `some-value`) remain untouched. Neither config path appears as a bare positional in the output args.
- **Observed result after fix:** Both user config files are read and merged into the bundle overlay. The `--mcp-config` flag correctly strips all variadic values. The argv boundary between `resumeArgs` and `args` is respected.
- **What was not tested:** Live Claude CLI invocation with multiple `--mcp-config` files (requires claude-cli binary not available in this environment). The verification exercises the same production code path (`prepareCliBundleMcpConfig` → `findAllClaudeMcpConfigPaths` → `readExternalMcpConfig` → `applyMergePatch`).

## Real behavior proof

- **Behavior addressed:** (1) The CLI runner bundler only reads the first `--mcp-config` file when multiple are provided. (2) When `resumeArgs` contains `--mcp-config`, the variadic scan incorrectly continued into `args`, treating the fresh-run command as a config file path.
- **Environment tested:** macOS 26.4.1, Node 22.22.3, OpenClaw commit `a2a68d154`
- **Steps run after the patch:** 
  1. Created two MCP config files (`a.json` and `b.json`) in a temporary workspace.
  2. Ran `prepareCliBundleMcpConfig` with variadic `--mcp-config a.json b.json` in args.
  3. Ran `prepareCliBundleMcpConfig` with `--mcp-config resume.json` in resumeArgs and fresh flags in args to test boundary.
  4. Executed the full test suite: `pnpm test src/agents/cli-runner/bundle-mcp.test.ts`
- **Evidence after fix:** All 8 verification cases pass including the new variadic case and the argv boundary regression test. The merged overlay config contains both servers from variadic config files. In the boundary test, only `resume.json` is merged while fresh args (`--another-flag`, `some-value`) remain untouched. Neither config path appears as a bare positional in the output args.
- **Observed result after fix:** Both user config files are read and merged into the bundle overlay. The `--mcp-config` flag correctly strips all variadic values. The argv boundary between `resumeArgs` and `args` is respected.
- **What was not tested:** Live Claude CLI invocation with multiple `--mcp-config` files (requires claude-cli binary not available in this environment). The verification exercises the same production code path (`prepareCliBundleMcpConfig` → `findAllClaudeMcpConfigPaths` → `readExternalMcpConfig` → `applyMergePatch`).

```
$ pnpm test src/agents/cli-runner/bundle-mcp.test.ts

 ✓  agents  src/agents/cli-runner/bundle-mcp.test.ts (8 tests) 71ms

 Test Files  1 passed (1)
      Tests  8 passed (8)
   Start at  17:13:58
   Duration  642ms
```
