### PR TITLE
fix(agents): collect variadic --mcp-config values in Claude CLI bundler

### DIFF
--- a/src/agents/cli-runner/bundle-mcp-claude.test.ts
+++ b/src/agents/cli-runner/bundle-mcp-claude.test.ts
@@ -1,0 +1,84 @@
+// Tests for Claude bundle-MCP arg helpers, focused on variadic --mcp-config.
+import { describe, expect, it } from "vitest";
+import { findClaudeMcpConfigPaths, injectClaudeMcpConfigArgs } from "./bundle-mcp-claude.js";
+
+describe("findClaudeMcpConfigPaths", () => {
+  it("returns empty array when args are absent", () => {
+    expect(findClaudeMcpConfigPaths(undefined)).toEqual([]);
+    expect(findClaudeMcpConfigPaths([])).toEqual([]);
+  });
+
+  it("collects a single --mcp-config value", () => {
+    expect(findClaudeMcpConfigPaths(["--mcp-config", "a.json"])).toEqual(["a.json"]);
+  });
+
+  it("collects every variadic value following --mcp-config", () => {
+    expect(findClaudeMcpConfigPaths(["--mcp-config", "a.json", "b.json"])).toEqual([
+      "a.json",
+      "b.json",
+    ]);
+  });
+
+  it("stops variadic collection at the next dash-prefixed arg", () => {
+    expect(
+      findClaudeMcpConfigPaths(["--mcp-config", "a.json", "b.json", "--strict-mcp-config"]),
+    ).toEqual(["a.json", "b.json"]);
+  });
+
+  it("collects --mcp-config=path form values", () => {
+    expect(findClaudeMcpConfigPaths(["--mcp-config=a.json"])).toEqual(["a.json"]);
+  });
+
+  it("combines variadic and equals-form values across multiple occurrences", () => {
+    expect(
+      findClaudeMcpConfigPaths(["--mcp-config", "a.json", "b.json", "--mcp-config=c.json"]),
+    ).toEqual(["a.json", "b.json", "c.json"]);
+  });
+});
+
+describe("injectClaudeMcpConfigArgs", () => {
+  it("appends strict + mcp-config when no user mcp-config is present", () => {
+    expect(injectClaudeMcpConfigArgs(["./fake-claude.mjs"], "openclaw.json")).toEqual([
+      "./fake-claude.mjs",
+      "--strict-mcp-config",
+      "--mcp-config",
+      "openclaw.json",
+    ]);
+  });
+
+  it("strips every variadic --mcp-config value so none leak as positional args", () => {
+    // --mcp-config is variadic: every following non-dash value is a config path.
+    // The variadic collection ends at the next dash-prefixed arg (or end of args),
+    // matching stripClaudeSideQuestionConflictingArgs.
+    const stripped = injectClaudeMcpConfigArgs(
+      ["./fake-claude.mjs", "--mcp-config", "a.json", "b.json"],
+      "openclaw.json",
+    );
+    expect(stripped).not.toContain("a.json");
+    expect(stripped).not.toContain("b.json");
+    expect(stripped).toEqual([
+      "./fake-claude.mjs",
+      "--strict-mcp-config",
+      "--mcp-config",
+      "openclaw.json",
+    ]);
+  });
+
+  it("strips --mcp-config=value form along with variadic neighbors", () => {
+    const stripped = injectClaudeMcpConfigArgs(
+      ["./fake-claude.mjs", "--mcp-config=a.json", "--mcp-config", "b.json"],
+      "openclaw.json",
+    );
+    expect(stripped).not.toContain("a.json");
+    expect(stripped).not.toContain("b.json");
+    expect(stripped).not.toContain("--mcp-config=a.json");
+  });
+
+  it("strips user-supplied --strict-mcp-config so OpenClaw's overlay is authoritative", () => {
+    const stripped = injectClaudeMcpConfigArgs(
+      ["--strict-mcp-config", "./fake-claude.mjs"],
+      "openclaw.json",
+    );
+    expect(stripped.filter((arg) => arg === "--strict-mcp-config")).toHaveLength(1);
+  });
+});

--- a/src/agents/cli-runner/bundle-mcp.user-config.test.ts
+++ b/src/agents/cli-runner/bundle-mcp.user-config.test.ts
@@ -263,4 +263,57 @@ describe("prepareCliBundleMcpConfig user mcp.servers", () => {
       await prepared.cleanup?.();
     });
   });
+
+  it("merges every variadic --mcp-config path and drops stray positional values", async () => {
+    // Regression for #98944: --mcp-config is variadic in the Claude arg model,
+    // so OpenClaw must collect every following non-dash value and merge each
+    // listed config file instead of leaving later values as bare positionals.
+    const workspaceDir = await cliBundleMcpHarness.tempHarness.createTempDir(
+      "openclaw-cli-bundle-mcp-variadic-",
+    );
+    const alphaPath = path.join(workspaceDir, "alpha.json");
+    const betaPath = path.join(workspaceDir, "beta.json");
+    await fs.writeFile(
+      alphaPath,
+      `${JSON.stringify({
+        mcpServers: {
+          alpha: { type: "sse", url: "https://alpha.example.invalid/mcp/sse" },
+        },
+      })}\n`,
+      "utf-8",
+    );
+    await fs.writeFile(
+      betaPath,
+      `${JSON.stringify({
+        mcpServers: {
+          beta: { type: "sse", url: "https://beta.example.invalid/mcp/sse" },
+        },
+      })}\n`,
+      "utf-8",
+    );
+
+    const prepared = await prepareCliBundleMcpConfig({
+      enabled: true,
+      mode: "claude-config-file",
+      backend: {
+        command: "node",
+        args: ["./fake-claude.mjs", "--mcp-config", alphaPath, betaPath],
+      },
+      workspaceDir,
+      config: { plugins: { enabled: false } },
+    });
+
+    // Neither user path should leak through as a bare positional arg.
+    expect(prepared.backend.args).not.toContain(alphaPath);
+    expect(prepared.backend.args).not.toContain(betaPath);
+
+    const generatedConfigPath = requireMcpConfigPath(prepared.backend.args);
+    const raw = JSON.parse(await fs.readFile(generatedConfigPath, "utf-8")) as {
+      mcpServers?: Record<string, { url?: string }>;
+    };
+    expect(raw.mcpServers?.alpha?.url).toBe("https://alpha.example.invalid/mcp/sse");
+    expect(raw.mcpServers?.beta?.url).toBe("https://beta.example.invalid/mcp/sse");
+
+    await prepared.cleanup?.();
+  });
 });


### PR DESCRIPTION
## What Problem This Solves

Closes #98944.

The Claude CLI bundler treated `--mcp-config` as a single-value flag, but the repo's own Claude arg model (`extensions/anthropic/cli-shared.ts:253-260`) treats it as **variadic** — every following non-dash token is another config path. As a result, `cliBackends["claude-cli"].args: [..., "--mcp-config", "a.json", "b.json"]` produced a broken run:

- `a.json` was stripped and merged into the strict overlay
- `b.json` was left behind as a bare positional arg (which Claude `-p` treats as the prompt or errors on)
- servers defined in `b.json` were silently dropped from the merged config

## Why This Change Was Made

`findClaudeMcpConfigPath` and `injectClaudeMcpConfigArgs` are the only places that mis-model the arg shape — every other Claude arg consumer in the repo follows the variadic contract. ClawSweeper's review of #98944 confirmed the requested fix is "a narrow Claude arg-shape helper that collects and strips all `--mcp-config` values, merge every referenced config in order for args and resume args, and cover the variadic case with focused bundle-MCP tests." This change does exactly that:

- Rename `findClaudeMcpConfigPath` → `findClaudeMcpConfigPaths` and have it return every variadic value, mirroring `stripClaudeSideQuestionConflictingArgs` in `extensions/anthropic/cli-shared.ts:290-297`.
- Update `injectClaudeMcpConfigArgs` to skip every non-dash value following `--mcp-config`, so none leak through as bare positionals.
- Iterate every collected path in `prepareCliBundleMcpConfig` so each user-listed config file is merged (in order) before the bundle/plugin overlay is applied.

## User Impact

Users who configure multiple MCP config files via `--mcp-config a.json b.json` (variadic form, supported by the Claude CLI) now get the behavior they expect: every file is merged into OpenClaw's strict overlay and no stray positional arg reaches the Claude process. Single-config setups are unchanged.

## Evidence

- Root cause: `bundle-mcp-claude.ts` (pre-fix) consumed only `args[i + 1]` after `--mcp-config`, leaving later values in place. `bundle-mcp.ts` then merged only that single path.
- Sibling contract: `extensions/anthropic/cli-shared.ts` puts `--mcp-config` in `CLAUDE_SIDE_QUESTION_VARIADIC_VALUE_ARGS` and strips all following non-dash values via a `while` loop.
- New focused unit tests in `bundle-mcp-claude.test.ts` (10 tests) cover: empty args, single value, variadic values, stop-at-dash, equals-form, combined forms, and the injection-side symmetry (variadic stripping, equals-form stripping, single-authoritative `--strict-mcp-config`).
- New integration test in `bundle-mcp.user-config.test.ts` ("merges every variadic --mcp-config path and drops stray positional values") writes two real config files, passes them via variadic `--mcp-config`, and asserts both servers land in the generated overlay while neither path leaks as a bare positional.
- Local validation: `vitest run src/agents/cli-runner/bundle-mcp-claude.test.ts src/agents/cli-runner/bundle-mcp.user-config.test.ts` → 4 files, 32 tests, all passing. `oxfmt --check` and `oxlint` clean on all changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
