### PR TITLE
fix(config): guard session transcript JSON.parse against malformed lines

### DIFF
--- a/src/config/sessions/transcript-parse.test.ts
+++ b/src/config/sessions/transcript-parse.test.ts
@@ -1,0 +1,65 @@
+// Tests cover session transcript JSON parse guard behavior.
+import { describe, expect, it } from "vitest";
+import { parseAssistantTranscriptText, parseRecentConversationText } from "./transcript.js";
+
+describe("parseAssistantTranscriptText", () => {
+  it("returns undefined on malformed JSON", () => {
+    expect(parseAssistantTranscriptText("NOT JSON {{{")).toBeUndefined();
+  });
+
+  it("returns undefined on empty string", () => {
+    expect(parseAssistantTranscriptText("")).toBeUndefined();
+  });
+
+  it("returns undefined for non-assistant role", () => {
+    const line = JSON.stringify({
+      id: "msg-1",
+      message: { role: "user", content: "hello" },
+    });
+    expect(parseAssistantTranscriptText(line)).toBeUndefined();
+  });
+
+  it("parses a valid assistant transcript line", () => {
+    const line = JSON.stringify({
+      id: "msg-1",
+      message: {
+        role: "assistant",
+        content: [{ type: "text", text: "Hello!" }],
+      },
+    });
+    const result = parseAssistantTranscriptText(line);
+    expect(result).toBeDefined();
+    expect(result?.id).toBe("msg-1");
+  });
+});
+
+describe("parseRecentConversationText", () => {
+  it("returns undefined on malformed JSON", () => {
+    expect(parseRecentConversationText("NOT JSON {{{")).toBeUndefined();
+  });
+
+  it("returns undefined on empty string", () => {
+    expect(parseRecentConversationText("")).toBeUndefined();
+  });
+
+  it("returns undefined for non-user/non-assistant role", () => {
+    const line = JSON.stringify({
+      id: "msg-1",
+      message: { role: "system", content: "system prompt" },
+    });
+    expect(parseRecentConversationText(line)).toBeUndefined();
+  });
+
+  it("parses a valid user conversation line", () => {
+    const line = JSON.stringify({
+      id: "msg-2",
+      message: {
+        role: "user",
+        content: [{ type: "text", text: "hi" }],
+      },
+    });
+    const result = parseRecentConversationText(line);
+    expect(result).toBeDefined();
+    expect(result?.id).toBe("msg-2");
+  });
+});

--- a/src/config/sessions/transcript.ts
+++ b/src/config/sessions/transcript.ts
@@ -101,14 +101,16 @@ export type TailAssistantTranscriptText = AssistantTranscriptText;
 
 export { resolveSessionTranscriptFile } from "./transcript-file-resolve.js";
 
-function parseAssistantTranscriptText(
+export function parseAssistantTranscriptText(
   line: string,
   options?: { excludeTranscriptOnlyOpenClawAssistant?: boolean },
 ): AssistantTranscriptText | undefined {
-  const parsed = JSON.parse(line) as {
-    id?: unknown;
-    message?: unknown;
-  };
+  let parsed: { id?: unknown; message?: unknown };
+  try {
+    parsed = JSON.parse(line) as { id?: unknown; message?: unknown };
+  } catch {
+    return undefined;
+  }
   const message = parsed.message as
     | { role?: unknown; timestamp?: unknown; provider?: unknown; model?: unknown }
     | undefined;
@@ -165,11 +167,15 @@ function normalizeRecentTranscriptLimit(limit: number | undefined): number {
   return Math.max(1, Math.floor(limit ?? 10));
 }
 
-function parseRecentConversationText(line: string): SessionRecentConversationText | undefined {
-  const parsed = JSON.parse(line) as {
-    id?: unknown;
-    message?: unknown;
-  };
+export function parseRecentConversationText(
+  line: string,
+): SessionRecentConversationText | undefined {
+  let parsed: { id?: unknown; message?: unknown };
+  try {
+    parsed = JSON.parse(line) as { id?: unknown; message?: unknown };
+  } catch {
+    return undefined;
+  }
   const message = parsed.message as
     | {
         role?: unknown;


### PR DESCRIPTION
## What Problem This Solves

`src/config/sessions/transcript.ts` has two functions that call bare `JSON.parse(line)` on session transcript file lines:
- `parseAssistantTranscriptText()` (line 108)
- `parseRecentConversationText()` (line 169)

Malformed or corrupted transcript files would throw raw `SyntaxError` instead of gracefully returning `undefined` (which is the existing behavior for other invalid cases like unknown roles).

## Changes

- `transcript.ts`: wrap both `JSON.parse(line)` calls in try/catch → return `undefined` on malformed JSON (consistent with existing fallback behavior)
- `transcript-parse.test.ts`: 8 colocated vitest tests covering malformed JSON, empty string, and valid parsing for both functions

## Evidence

### Vitest — colocated with source

```
pnpm exec vitest run src/config/sessions/transcript-parse.test.ts

 ✓ parseAssistantTranscriptText > returns undefined on malformed JSON
 ✓ parseAssistantTranscriptText > returns undefined on empty string
 ✓ parseAssistantTranscriptText > returns undefined for non-assistant role
 ✓ parseAssistantTranscriptText > parses a valid assistant transcript line
 ✓ parseRecentConversationText > returns undefined on malformed JSON
 ✓ parseRecentConversationText > returns undefined on empty string
 ✓ parseRecentConversationText > returns undefined for non-user/non-assistant role
 ✓ parseRecentConversationText > parses a valid user conversation line
```

Before: `JSON.parse("NOT JSON {{{")` → raw `SyntaxError` crashes transcript reader
After: `parseAssistantTranscriptText("NOT JSON {{{")` → `undefined` (graceful skip, consistent behavior)

### Call chain

`streamSessionTranscriptLinesReverse()` → reads session transcript file → for each line → `parseAssistantTranscriptText(line)` / `parseRecentConversationText(line)` → now tolerant of malformed JSON

Label: bugfix | merge-risk: 🟢 minimal | AI-assisted