### PR TITLE
[AI] test(tool-call-repair): add unit tests for grammar and payload modules

### DIFF
--- a/packages/tool-call-repair/src/grammar.test.ts
+++ b/packages/tool-call-repair/src/grammar.test.ts
@@ -404,7 +404,6 @@ describe("indexOfAsciiMarkerIgnoreCase", () => {
 });
 
 describe("findXmlishToolCallEnd", () => {
-  const functionOpen = "<function=get_weather>";
   const parameterBlock = '<parameter=location>{"city":"NYC"}</parameter>';
   const functionClose = "</function>";
 
@@ -414,9 +413,9 @@ describe("findXmlishToolCallEnd", () => {
     closeTag?: string;
   }): string {
     const fn = params?.functionName ?? "get_weather";
-    const params_ = params?.parameters ?? parameterBlock;
+    const p = params?.parameters ?? parameterBlock;
     const close = params?.closeTag ?? functionClose;
-    return `<function=${fn}>${params_}${close}`;
+    return `<function=${fn}>${p}${close}`;
   }
 
   it("finds end of XML-ish tool call", () => {

--- a/packages/tool-call-repair/src/grammar.test.ts
+++ b/packages/tool-call-repair/src/grammar.test.ts
@@ -1,0 +1,476 @@
+import { describe, expect, it } from "vitest";
+import {
+  consumeJsonToolClosingMarker,
+  consumeLineBreak,
+  END_TOOL_REQUEST,
+  findBracketedJsonPayloadStart,
+  findHarmonyJsonPayloadStart,
+  findJsonObjectEnd,
+  findXmlishToolCallEnd,
+  HARMONY_CALL_MARKER,
+  HARMONY_CHANNEL_MARKER,
+  HARMONY_MESSAGE_MARKER,
+  indexOfAsciiMarkerIgnoreCase,
+  isPlainTextToolNameChar,
+  isXmlishNameChar,
+  matchesLiteralPrefix,
+  skipHorizontalWhitespace,
+  skipSerializedToolCallTrailingLineBreak,
+  skipWhitespace,
+  startsWithAsciiMarkerIgnoreCase,
+} from "./grammar.js";
+
+describe("END_TOOL_REQUEST", () => {
+  it("equals [END_TOOL_REQUEST]", () => {
+    expect(END_TOOL_REQUEST).toBe("[END_TOOL_REQUEST]");
+  });
+});
+
+describe("HARMONY_CHANNEL_MARKER", () => {
+  it("equals <|channel|>", () => {
+    expect(HARMONY_CHANNEL_MARKER).toBe("<|channel|>");
+  });
+});
+
+describe("HARMONY_MESSAGE_MARKER", () => {
+  it("equals <|message|>", () => {
+    expect(HARMONY_MESSAGE_MARKER).toBe("<|message|>");
+  });
+});
+
+describe("HARMONY_CALL_MARKER", () => {
+  it("equals <|call|>", () => {
+    expect(HARMONY_CALL_MARKER).toBe("<|call|>");
+  });
+});
+
+describe("matchesLiteralPrefix", () => {
+  it("returns true when text equals literal", () => {
+    expect(matchesLiteralPrefix("hello", "hello")).toBe(true);
+  });
+
+  it("returns true when text is a prefix of literal", () => {
+    expect(matchesLiteralPrefix("hel", "hello")).toBe(true);
+  });
+
+  it("returns true when literal is a prefix of text", () => {
+    expect(matchesLiteralPrefix("hello world", "hello")).toBe(true);
+  });
+
+  it("returns false when text does not match", () => {
+    expect(matchesLiteralPrefix("xyz", "hello")).toBe(false);
+  });
+
+  it("handles single-character matching", () => {
+    expect(matchesLiteralPrefix("a", "a")).toBe(true);
+    expect(matchesLiteralPrefix("a", "b")).toBe(false);
+  });
+
+  it("handles empty text", () => {
+    expect(matchesLiteralPrefix("", "hello")).toBe(true);
+  });
+
+  it("handles empty literal", () => {
+    expect(matchesLiteralPrefix("hello", "")).toBe(true);
+  });
+});
+
+describe("isPlainTextToolNameChar", () => {
+  it("accepts letters, digits, underscore, hyphen", () => {
+    expect(isPlainTextToolNameChar("a")).toBe(true);
+    expect(isPlainTextToolNameChar("Z")).toBe(true);
+    expect(isPlainTextToolNameChar("9")).toBe(true);
+    expect(isPlainTextToolNameChar("_")).toBe(true);
+    expect(isPlainTextToolNameChar("-")).toBe(true);
+  });
+
+  it("rejects special characters and whitespace", () => {
+    expect(isPlainTextToolNameChar(".")).toBe(false);
+    expect(isPlainTextToolNameChar(":")).toBe(false);
+    expect(isPlainTextToolNameChar("@")).toBe(false);
+    expect(isPlainTextToolNameChar("/")).toBe(false);
+    expect(isPlainTextToolNameChar(" ")).toBe(false);
+    expect(isPlainTextToolNameChar("\n")).toBe(false);
+  });
+
+  it("returns false for undefined", () => {
+    expect(isPlainTextToolNameChar(undefined)).toBe(false);
+  });
+});
+
+describe("isXmlishNameChar", () => {
+  it("accepts letters, digits, underscore, hyphen, dot, colon", () => {
+    expect(isXmlishNameChar("a")).toBe(true);
+    expect(isXmlishNameChar("Z")).toBe(true);
+    expect(isXmlishNameChar("9")).toBe(true);
+    expect(isXmlishNameChar("_")).toBe(true);
+    expect(isXmlishNameChar("-")).toBe(true);
+    expect(isXmlishNameChar(".")).toBe(true);
+    expect(isXmlishNameChar(":")).toBe(true);
+  });
+
+  it("rejects at-sign and whitespace", () => {
+    expect(isXmlishNameChar("@")).toBe(false);
+    expect(isXmlishNameChar(" ")).toBe(false);
+  });
+
+  it("returns false for undefined", () => {
+    expect(isXmlishNameChar(undefined)).toBe(false);
+  });
+});
+
+describe("skipHorizontalWhitespace", () => {
+  it("skips spaces and tabs", () => {
+    expect(skipHorizontalWhitespace("  \tabc", 0)).toBe(3);
+  });
+
+  it("stops at newline", () => {
+    expect(skipHorizontalWhitespace(" \n x", 0)).toBe(1);
+  });
+
+  it("returns start when no whitespace", () => {
+    expect(skipHorizontalWhitespace("abc", 0)).toBe(0);
+  });
+
+  it("handles empty string", () => {
+    expect(skipHorizontalWhitespace("", 0)).toBe(0);
+  });
+
+  it("handles start past end", () => {
+    expect(skipHorizontalWhitespace("abc", 10)).toBe(10);
+  });
+});
+
+describe("skipWhitespace", () => {
+  it("skips all whitespace characters", () => {
+    expect(skipWhitespace(" \n\t\r x", 0)).toBe(5);
+  });
+
+  it("returns start when char is not whitespace", () => {
+    expect(skipWhitespace("abc", 0)).toBe(0);
+  });
+});
+
+describe("consumeLineBreak", () => {
+  it("consumes \\n", () => {
+    expect(consumeLineBreak("hello\nworld", 5)).toBe(6);
+  });
+
+  it("consumes \\r\\n", () => {
+    expect(consumeLineBreak("hello\r\nworld", 5)).toBe(7);
+  });
+
+  it("consumes standalone \\r", () => {
+    expect(consumeLineBreak("hello\rworld", 5)).toBe(6);
+  });
+
+  it("returns null when no line break", () => {
+    expect(consumeLineBreak("hello world", 5)).toBeNull();
+  });
+
+  it("returns null when start is past end", () => {
+    expect(consumeLineBreak("abc", 10)).toBeNull();
+  });
+
+  it("handles \\n at start", () => {
+    expect(consumeLineBreak("\nabc", 0)).toBe(1);
+  });
+});
+
+describe("findJsonObjectEnd", () => {
+  it("finds end of simple JSON object", () => {
+    expect(findJsonObjectEnd('{"a":1}', 0)).toBe(7);
+  });
+
+  // {"a":{"b":2}} -> chars: {"a":{"b":2}} = 13 chars (index 0-12, exclusive end 13)
+  it("finds end of nested JSON object", () => {
+    expect(findJsonObjectEnd('{"a":{"b":2}}', 0)).toBe(13);
+  });
+
+  // {"a":"\\u0041bc"} — JSON string with backslash-u0041 inside the string value.
+  // The parser does not interpret JSON escapes; it only tracks brace balance and string boundaries.
+  // \\ is escaped backslash in JSON, so the " after it closes the string, then bc"} ends the object.
+  it("handles JSON with escaped backslash inside string", () => {
+    expect(findJsonObjectEnd('{"a":"\\\\u0041bc"}', 0)).toBe(17);
+  });
+
+  it("handles backslash-escaped backslash inside strings", () => {
+    expect(findJsonObjectEnd('{"a":"\\\\"}', 0)).toBe(10);
+  });
+
+  it("handles empty object", () => {
+    expect(findJsonObjectEnd("{}", 0)).toBe(2);
+  });
+
+  it("returns null when object is not closed", () => {
+    expect(findJsonObjectEnd('{"a":1', 0)).toBeNull();
+  });
+
+  it("returns null when exceeds maxPayloadBytes", () => {
+    expect(findJsonObjectEnd('{"a":1}', 0, 3)).toBeNull();
+  });
+
+  it("honors maxPayloadBytes that is large enough", () => {
+    expect(findJsonObjectEnd('{"a":1}', 0, 10)).toBe(7);
+  });
+
+  it("starts from given offset", () => {
+    expect(findJsonObjectEnd('xx{"a":1}', 2)).toBe(9);
+  });
+});
+
+describe("skipSerializedToolCallTrailingLineBreak", () => {
+  it("skips trailing \\n", () => {
+    expect(skipSerializedToolCallTrailingLineBreak("abc\n", 3)).toBe(4);
+  });
+
+  it("returns cursor when no line break", () => {
+    expect(skipSerializedToolCallTrailingLineBreak("abc", 3)).toBe(3);
+  });
+});
+
+describe("consumeJsonToolClosingMarker", () => {
+  it("consumes END_TOOL_REQUEST", () => {
+    const result = consumeJsonToolClosingMarker(
+      `  ${END_TOOL_REQUEST}\n`,
+      0,
+    );
+    expect(result).toBe(2 + END_TOOL_REQUEST.length + 1);
+  });
+
+  it("consumes bracketed close [/name]", () => {
+    const result = consumeJsonToolClosingMarker("[/get_weather]\n", 0);
+    expect(result).toBe("[/get_weather]\n".length);
+  });
+
+  it("consumes harmony call marker", () => {
+    const result = consumeJsonToolClosingMarker("<|call|>\n", 0);
+    expect(result).toBe(`${HARMONY_CALL_MARKER}\n`.length);
+  });
+
+  it("returns cursor when no marker found", () => {
+    const result = consumeJsonToolClosingMarker("nothing here", 0);
+    expect(result).toBe(0);
+  });
+
+  it("skips leading whitespace before marker", () => {
+    const result = consumeJsonToolClosingMarker(`  ${END_TOOL_REQUEST}`, 0);
+    expect(result).toBe(2 + END_TOOL_REQUEST.length);
+  });
+});
+
+describe("findBracketedJsonPayloadStart", () => {
+  it("finds JSON start after [tool_name]", () => {
+    expect(findBracketedJsonPayloadStart("[get_weather]\n{")).toBe(
+      "[get_weather]\n".length,
+    );
+  });
+
+  it("returns null for non-bracket start", () => {
+    expect(findBracketedJsonPayloadStart("hello")).toBeNull();
+  });
+
+  it("returns null when missing closing bracket", () => {
+    expect(findBracketedJsonPayloadStart("[get_weather")).toBeNull();
+  });
+
+  it("returns null when JSON does not follow", () => {
+    expect(findBracketedJsonPayloadStart("[get_weather]\nnot json")).toBeNull();
+  });
+
+  it("handles trailing \r\n before JSON", () => {
+    expect(findBracketedJsonPayloadStart("[get_weather]\r\n{")).toBe(
+      "[get_weather]\r\n".length,
+    );
+  });
+
+  it("handles leading whitespace after bracket before JSON", () => {
+    expect(findBracketedJsonPayloadStart("[get_weather]  \n  {")).toBe(
+      "[get_weather]  \n  ".length,
+    );
+  });
+});
+
+describe("findHarmonyJsonPayloadStart", () => {
+  it("finds JSON after full harmony header", () => {
+    const header = `${HARMONY_CHANNEL_MARKER}commentary to=get_weather code`;
+    const result = findHarmonyJsonPayloadStart(`${header} {`);
+    expect(result).toBe(header.length + 1);
+  });
+
+  it("finds JSON without channel marker", () => {
+    const result = findHarmonyJsonPayloadStart("analysis to=search code {");
+    expect(result).toBe("analysis to=search code ".length);
+  });
+
+  it("finds JSON with optional message marker", () => {
+    const header = `final to=search code ${HARMONY_MESSAGE_MARKER}`;
+    const result = findHarmonyJsonPayloadStart(`${header} {`);
+    expect(result).toBe(header.length + 1);
+  });
+
+  it("returns null for unknown channel", () => {
+    expect(findHarmonyJsonPayloadStart("unknown to=foo code {")).toBeNull();
+  });
+
+  it("returns null when missing to=", () => {
+    expect(findHarmonyJsonPayloadStart("commentary foo code {")).toBeNull();
+  });
+
+  it("returns null when to= has no tool name", () => {
+    expect(
+      findHarmonyJsonPayloadStart("commentary to= code {"),
+    ).toBeNull();
+  });
+
+  it("returns null when missing code keyword", () => {
+    expect(
+      findHarmonyJsonPayloadStart("commentary to=get_weather foo {"),
+    ).toBeNull();
+  });
+
+  it("returns null when JSON does not follow", () => {
+    expect(
+      findHarmonyJsonPayloadStart("commentary to=get_weather code notjson"),
+    ).toBeNull();
+  });
+
+  it("handles channel commentary", () => {
+    const result = findHarmonyJsonPayloadStart(
+      `${HARMONY_CHANNEL_MARKER}commentary to=analyze code {`,
+    );
+    expect(result).not.toBeNull();
+  });
+
+  it("handles channel final", () => {
+    const result = findHarmonyJsonPayloadStart(
+      `${HARMONY_CHANNEL_MARKER}final to=summarize code {`,
+    );
+    expect(result).not.toBeNull();
+  });
+});
+
+describe("startsWithAsciiMarkerIgnoreCase", () => {
+  it("matches case-insensitively when marker is lowercase", () => {
+    expect(startsWithAsciiMarkerIgnoreCase("Hello World", 0, "hello")).toBe(true);
+    expect(startsWithAsciiMarkerIgnoreCase("HELLO World", 0, "hello")).toBe(true);
+  });
+
+  // The second argument is the *marker* — it is compared as-is against the lowercased text slice.
+  it("returns false when marker is uppercase and text does not match uppercase literal", () => {
+    expect(startsWithAsciiMarkerIgnoreCase("hello World", 0, "HELLO")).toBe(false);
+  });
+
+  it("returns false when no match", () => {
+    expect(startsWithAsciiMarkerIgnoreCase("xyz", 0, "abc")).toBe(false);
+  });
+
+  it("handles marker longer than remaining text", () => {
+    expect(startsWithAsciiMarkerIgnoreCase("ab", 0, "abc")).toBe(false);
+  });
+
+  it("respects the cursor offset", () => {
+    expect(
+      startsWithAsciiMarkerIgnoreCase("xx</function>", 2, "</function>"),
+    ).toBe(true);
+  });
+});
+
+describe("indexOfAsciiMarkerIgnoreCase", () => {
+  it("finds marker at the start", () => {
+    expect(indexOfAsciiMarkerIgnoreCase("</parameter>abc", "</parameter>", 0)).toBe(0);
+  });
+
+  it("finds marker case-insensitively", () => {
+    expect(indexOfAsciiMarkerIgnoreCase("xx</PARAMETER>", "</parameter>", 0)).toBe(2);
+  });
+
+  it("returns -1 when not found", () => {
+    expect(indexOfAsciiMarkerIgnoreCase("hello world", "</parameter>", 0)).toBe(-1);
+  });
+
+  it("returns -1 when marker is before the start offset", () => {
+    // < is at index 2; from offset 3 there is no <
+    expect(indexOfAsciiMarkerIgnoreCase("aa</parameter>bb", "</parameter>", 3)).toBe(-1);
+  });
+
+  it("finds marker at the end of text", () => {
+    expect(indexOfAsciiMarkerIgnoreCase("prefix</parameter>", "</parameter>", 0)).toBe(6);
+  });
+
+  it("handles empty text", () => {
+    expect(indexOfAsciiMarkerIgnoreCase("", "</parameter>", 0)).toBe(-1);
+  });
+});
+
+describe("findXmlishToolCallEnd", () => {
+  const functionOpen = "<function=get_weather>";
+  const parameterBlock = '<parameter=location>{"city":"NYC"}</parameter>';
+  const functionClose = "</function>";
+
+  function xmlBlock(params?: {
+    functionName?: string;
+    parameters?: string;
+    closeTag?: string;
+  }): string {
+    const fn = params?.functionName ?? "get_weather";
+    const params_ = params?.parameters ?? parameterBlock;
+    const close = params?.closeTag ?? functionClose;
+    return `<function=${fn}>${params_}${close}`;
+  }
+
+  it("finds end of XML-ish tool call", () => {
+    const text = xmlBlock();
+    expect(findXmlishToolCallEnd(text)).toBe(text.length);
+  });
+
+  it("finds end of bracketed tool call with parameters", () => {
+    const text = `[get_weather]\n${parameterBlock}${functionClose}`;
+    expect(findXmlishToolCallEnd(text)).toBe(text.length);
+  });
+
+  it("finds end of tool: prefixed bracketed call", () => {
+    const text = `[tool:get_weather]${parameterBlock}${functionClose}`;
+    expect(findXmlishToolCallEnd(text)).toBe(text.length);
+  });
+
+  it("returns null for plain text", () => {
+    expect(findXmlishToolCallEnd("hello world")).toBeNull();
+  });
+
+  it("returns null for function tag with no parameters", () => {
+    expect(findXmlishToolCallEnd("<function=foo>< /function>")).toBeNull();
+  });
+
+  it("returns null when parameter has no close", () => {
+    expect(
+      findXmlishToolCallEnd(
+        '<function=foo><parameter=bar>{"x":1}</parameter_not_close></function>',
+      ),
+    ).toBeNull();
+  });
+
+  it("handles multiple parameters", () => {
+    const p1 = '<parameter=a>{"a":1}</parameter>';
+    const p2 = '<parameter=b>{"b":2}</parameter>';
+    const text = `<function=foo>${p1}${p2}</function>`;
+    expect(findXmlishToolCallEnd(text)).toBe(text.length);
+  });
+
+  it("handles function close followed by more parameters (fallback)", () => {
+    const p1 = '<parameter=a>val</parameter>';
+    const text = `<function=foo>${p1}<parameter=b>val2</parameter>`;
+    expect(findXmlishToolCallEnd(text)).not.toBeNull();
+  });
+
+  it("is case-insensitive for <function=...>", () => {
+    const text = xmlBlock({ functionName: "GET_WEATHER" });
+    expect(findXmlishToolCallEnd(text)).toBe(text.length);
+  });
+
+  // The function includes skipSerializedToolCallTrailingLineBreak, so it consumes the trailing \n
+  it("handles trailing newline after function close", () => {
+    const text = `${xmlBlock()}\n`;
+    expect(findXmlishToolCallEnd(text)).toBe(text.length);
+  });
+});

--- a/packages/tool-call-repair/src/payload.test.ts
+++ b/packages/tool-call-repair/src/payload.test.ts
@@ -10,9 +10,10 @@ describe("parseStandalonePlainTextToolCallBlocks", () => {
       '[get_weather]\n{"city":"NYC"}\n[END_TOOL_REQUEST]',
     );
     expect(result).not.toBeNull();
-    expect(result).toHaveLength(1);
-    expect(result![0]!.name).toBe("get_weather");
-    expect(result![0]!.arguments).toEqual({ city: "NYC" });
+    const blocks = result!;
+    expect(blocks).toHaveLength(1);
+    expect(blocks[0]!.name).toBe("get_weather");
+    expect(blocks[0]!.arguments).toEqual({ city: "NYC" });
   });
 
   it("parses multiple bracket-style tool calls", () => {
@@ -20,9 +21,10 @@ describe("parseStandalonePlainTextToolCallBlocks", () => {
       '[get_weather]\n{"city":"NYC"}\n[END_TOOL_REQUEST]\n[search]\n{"q":"hello"}\n[/search]',
     );
     expect(result).not.toBeNull();
-    expect(result).toHaveLength(2);
-    expect(result![0]!.name).toBe("get_weather");
-    expect(result![1]!.name).toBe("search");
+    const blocks = result!;
+    expect(blocks).toHaveLength(2);
+    expect(blocks[0]!.name).toBe("get_weather");
+    expect(blocks[1]!.name).toBe("search");
   });
 
   it("parses tool: prefix bracket opening (no newline or closing marker required)", () => {
@@ -30,9 +32,10 @@ describe("parseStandalonePlainTextToolCallBlocks", () => {
       '[tool:get_weather]{"city":"NYC"}',
     );
     expect(result).not.toBeNull();
-    expect(result).toHaveLength(1);
-    expect(result![0]!.name).toBe("get_weather");
-    expect(result![0]!.arguments).toEqual({ city: "NYC" });
+    const blocks = result!;
+    expect(blocks).toHaveLength(1);
+    expect(blocks[0]!.name).toBe("get_weather");
+    expect(blocks[0]!.arguments).toEqual({ city: "NYC" });
   });
 
   it("parses harmony-style tool call with channel marker", () => {
@@ -40,8 +43,9 @@ describe("parseStandalonePlainTextToolCallBlocks", () => {
       '<|channel|>commentary to=get_weather code {"city":"NYC"}<|call|>',
     );
     expect(result).not.toBeNull();
-    expect(result).toHaveLength(1);
-    expect(result![0]!.name).toBe("get_weather");
+    const blocks = result!;
+    expect(blocks).toHaveLength(1);
+    expect(blocks[0]!.name).toBe("get_weather");
   });
 
   it("parses harmony-style tool call without channel marker", () => {
@@ -49,8 +53,9 @@ describe("parseStandalonePlainTextToolCallBlocks", () => {
       'analysis to=search code {"q":"test"}<|call|>',
     );
     expect(result).not.toBeNull();
-    expect(result).toHaveLength(1);
-    expect(result![0]!.name).toBe("search");
+    const blocks = result!;
+    expect(blocks).toHaveLength(1);
+    expect(blocks[0]!.name).toBe("search");
   });
 
   it("parses harmony-style with optional message marker", () => {
@@ -58,8 +63,9 @@ describe("parseStandalonePlainTextToolCallBlocks", () => {
       'final to=summarize code <|message|> {"text":"hello"}<|call|>',
     );
     expect(result).not.toBeNull();
-    expect(result).toHaveLength(1);
-    expect(result![0]!.name).toBe("summarize");
+    const blocks = result!;
+    expect(blocks).toHaveLength(1);
+    expect(blocks[0]!.name).toBe("summarize");
   });
 
   it("respects allowedToolNames filter", () => {
@@ -151,9 +157,10 @@ describe("parseStandalonePlainTextToolCallBlocks", () => {
       '[tool:search]{"q":"hello"}[tool:weather]{"city":"NYC"}',
     );
     expect(result).not.toBeNull();
-    expect(result).toHaveLength(2);
-    expect(result![0]!.name).toBe("search");
-    expect(result![1]!.name).toBe("weather");
+    const blocks = result!;
+    expect(blocks).toHaveLength(2);
+    expect(blocks[0]!.name).toBe("search");
+    expect(blocks[1]!.name).toBe("weather");
   });
 
   it("rejects bracket style missing newline before JSON", () => {
@@ -175,9 +182,10 @@ describe("parseStandalonePlainTextToolCallBlocks", () => {
     const text = '[get_weather]\n{"city":"NYC"}\n[END_TOOL_REQUEST]';
     const result = parseStandalonePlainTextToolCallBlocks(text);
     expect(result).not.toBeNull();
-    expect(result![0]!.start).toBe(0);
-    expect(result![0]!.end).toBe(text.length);
-    expect(result![0]!.raw).toBe(text);
+    const blocks = result!;
+    expect(blocks[0]!.start).toBe(0);
+    expect(blocks[0]!.end).toBe(text.length);
+    expect(blocks[0]!.raw).toBe(text);
   });
 });
 

--- a/packages/tool-call-repair/src/payload.test.ts
+++ b/packages/tool-call-repair/src/payload.test.ts
@@ -1,0 +1,228 @@
+import { describe, expect, it } from "vitest";
+import {
+  parseStandalonePlainTextToolCallBlocks,
+  stripPlainTextToolCallBlocks,
+} from "./payload.js";
+
+describe("parseStandalonePlainTextToolCallBlocks", () => {
+  it("parses a single bracket-style tool call", () => {
+    const result = parseStandalonePlainTextToolCallBlocks(
+      '[get_weather]\n{"city":"NYC"}\n[END_TOOL_REQUEST]',
+    );
+    expect(result).not.toBeNull();
+    expect(result).toHaveLength(1);
+    expect(result![0]!.name).toBe("get_weather");
+    expect(result![0]!.arguments).toEqual({ city: "NYC" });
+  });
+
+  it("parses multiple bracket-style tool calls", () => {
+    const result = parseStandalonePlainTextToolCallBlocks(
+      '[get_weather]\n{"city":"NYC"}\n[END_TOOL_REQUEST]\n[search]\n{"q":"hello"}\n[/search]',
+    );
+    expect(result).not.toBeNull();
+    expect(result).toHaveLength(2);
+    expect(result![0]!.name).toBe("get_weather");
+    expect(result![1]!.name).toBe("search");
+  });
+
+  it("parses tool: prefix bracket opening (no newline or closing marker required)", () => {
+    const result = parseStandalonePlainTextToolCallBlocks(
+      '[tool:get_weather]{"city":"NYC"}',
+    );
+    expect(result).not.toBeNull();
+    expect(result).toHaveLength(1);
+    expect(result![0]!.name).toBe("get_weather");
+    expect(result![0]!.arguments).toEqual({ city: "NYC" });
+  });
+
+  it("parses harmony-style tool call with channel marker", () => {
+    const result = parseStandalonePlainTextToolCallBlocks(
+      '<|channel|>commentary to=get_weather code {"city":"NYC"}<|call|>',
+    );
+    expect(result).not.toBeNull();
+    expect(result).toHaveLength(1);
+    expect(result![0]!.name).toBe("get_weather");
+  });
+
+  it("parses harmony-style tool call without channel marker", () => {
+    const result = parseStandalonePlainTextToolCallBlocks(
+      'analysis to=search code {"q":"test"}<|call|>',
+    );
+    expect(result).not.toBeNull();
+    expect(result).toHaveLength(1);
+    expect(result![0]!.name).toBe("search");
+  });
+
+  it("parses harmony-style with optional message marker", () => {
+    const result = parseStandalonePlainTextToolCallBlocks(
+      'final to=summarize code <|message|> {"text":"hello"}<|call|>',
+    );
+    expect(result).not.toBeNull();
+    expect(result).toHaveLength(1);
+    expect(result![0]!.name).toBe("summarize");
+  });
+
+  it("respects allowedToolNames filter", () => {
+    const result = parseStandalonePlainTextToolCallBlocks(
+      '[get_weather]\n{"city":"NYC"}\n[END_TOOL_REQUEST]',
+      { allowedToolNames: ["get_weather"] },
+    );
+    expect(result).not.toBeNull();
+    expect(result).toHaveLength(1);
+  });
+
+  it("rejects tool calls with names not in allowedToolNames", () => {
+    const result = parseStandalonePlainTextToolCallBlocks(
+      '[get_weather]\n{"city":"NYC"}\n[END_TOOL_REQUEST]',
+      { allowedToolNames: ["search"] },
+    );
+    expect(result).toBeNull();
+  });
+
+  it("rejects text that is not a tool call", () => {
+    const result = parseStandalonePlainTextToolCallBlocks("hello world");
+    expect(result).toBeNull();
+  });
+
+  it("returns null for empty input", () => {
+    const result = parseStandalonePlainTextToolCallBlocks("");
+    expect(result).toBeNull();
+  });
+
+  it("returns null for whitespace-only input", () => {
+    const result = parseStandalonePlainTextToolCallBlocks("  \n  ");
+    expect(result).toBeNull();
+  });
+
+  it("rejects input with mixed text and tool calls", () => {
+    const result = parseStandalonePlainTextToolCallBlocks(
+      'some text [get_weather]\n{"city":"NYC"}\n[END_TOOL_REQUEST]',
+    );
+    expect(result).toBeNull();
+  });
+
+  it("rejects tool call with invalid JSON", () => {
+    const result = parseStandalonePlainTextToolCallBlocks(
+      '[get_weather]\n{invalid}\n[END_TOOL_REQUEST]',
+    );
+    expect(result).toBeNull();
+  });
+
+  it("rejects tool call where JSON is an array", () => {
+    const result = parseStandalonePlainTextToolCallBlocks(
+      '[get_weather]\n[1,2,3]\n[END_TOOL_REQUEST]',
+    );
+    expect(result).toBeNull();
+  });
+
+  it("rejects tool call with missing closing marker for bracket style", () => {
+    const result = parseStandalonePlainTextToolCallBlocks(
+      '[get_weather]\n{"city":"NYC"}',
+    );
+    expect(result).toBeNull();
+  });
+
+  it("rejects tool call with mismatched closing marker", () => {
+    const result = parseStandalonePlainTextToolCallBlocks(
+      '[get_weather]\n{"city":"NYC"}\n[/wrong_name]',
+    );
+    expect(result).toBeNull();
+  });
+
+  it("honors maxPayloadBytes limit", () => {
+    const largePayload = `{"data":"${"x".repeat(100)}"}`;
+    const result = parseStandalonePlainTextToolCallBlocks(
+      `[get_weather]\n${largePayload}\n[END_TOOL_REQUEST]`,
+      { maxPayloadBytes: 10 },
+    );
+    expect(result).toBeNull();
+  });
+
+  it("handles tool: prefix with optional xmlish close (no close needed)", () => {
+    const result = parseStandalonePlainTextToolCallBlocks(
+      '[tool:get_weather]{"city":"NYC"}',
+    );
+    expect(result).not.toBeNull();
+    expect(result).toHaveLength(1);
+  });
+
+  it("handles consecutive tool: calls without closers", () => {
+    const result = parseStandalonePlainTextToolCallBlocks(
+      '[tool:search]{"q":"hello"}[tool:weather]{"city":"NYC"}',
+    );
+    expect(result).not.toBeNull();
+    expect(result).toHaveLength(2);
+    expect(result![0]!.name).toBe("search");
+    expect(result![1]!.name).toBe("weather");
+  });
+
+  it("rejects bracket style missing newline before JSON", () => {
+    const result = parseStandalonePlainTextToolCallBlocks(
+      '[get_weather]{"city":"NYC"}\n[END_TOOL_REQUEST]',
+    );
+    expect(result).toBeNull();
+  });
+
+  it("parses with \\r\\n line endings", () => {
+    const result = parseStandalonePlainTextToolCallBlocks(
+      '[get_weather]\r\n{"city":"NYC"}\r\n[END_TOOL_REQUEST]',
+    );
+    expect(result).not.toBeNull();
+    expect(result).toHaveLength(1);
+  });
+
+  it("records raw and offsets correctly", () => {
+    const text = '[get_weather]\n{"city":"NYC"}\n[END_TOOL_REQUEST]';
+    const result = parseStandalonePlainTextToolCallBlocks(text);
+    expect(result).not.toBeNull();
+    expect(result![0]!.start).toBe(0);
+    expect(result![0]!.end).toBe(text.length);
+    expect(result![0]!.raw).toBe(text);
+  });
+});
+
+describe("stripPlainTextToolCallBlocks", () => {
+  it("removes a bracket-style tool call from text", () => {
+    const result = stripPlainTextToolCallBlocks(
+      'some text\n[get_weather]\n{"city":"NYC"}\n[END_TOOL_REQUEST]\nmore text',
+    );
+    expect(result).toBe("some text\nmore text");
+  });
+
+  it("returns text unchanged when no tool call present", () => {
+    const result = stripPlainTextToolCallBlocks("hello world");
+    expect(result).toBe("hello world");
+  });
+
+  it("returns empty string for empty input", () => {
+    expect(stripPlainTextToolCallBlocks("")).toBe("");
+  });
+
+  it("removes tool call at the start of text", () => {
+    const result = stripPlainTextToolCallBlocks(
+      '[get_weather]\n{"city":"NYC"}\n[END_TOOL_REQUEST]\nremaining',
+    );
+    expect(result).toBe("remaining");
+  });
+
+  it("removes tool call at the end of text", () => {
+    const result = stripPlainTextToolCallBlocks(
+      'prefix\n[get_weather]\n{"city":"NYC"}\n[END_TOOL_REQUEST]',
+    );
+    expect(result).toBe("prefix\n");
+  });
+
+  it("removes multiple tool call blocks", () => {
+    const result = stripPlainTextToolCallBlocks(
+      'start\n[get_weather]\n{"city":"NYC"}\n[END_TOOL_REQUEST]\nmid\n[search]\n{"q":"x"}\n[/search]\nend',
+    );
+    expect(result).toBe("start\nmid\nend");
+  });
+
+  it("removes tool: prefix tool call at line start", () => {
+    const result = stripPlainTextToolCallBlocks(
+      'before\n[tool:get_weather]{"city":"NYC"}\nafter',
+    );
+    expect(result).toBe("before\nafter");
+  });
+});


### PR DESCRIPTION
## Summary

Add unit tests for the `packages/tool-call-repair/` module covering grammar parsing and payload parsing. The package currently has zero test coverage across all 5 source files. This PR adds comprehensive tests for the two foundational files (`grammar.ts` and `payload.ts`) that handle plain-text tool call format recognition, JSON boundary tracking, and tool call block stripping.

- Problem: `packages/tool-call-repair/` (2,299 lines of logic across 5 source files) had zero test coverage
- Solution: Add 112 unit tests across 2 new test files covering input boundaries, edge cases, and expected behavior for all grammar exports and all public payload exports
- What changed: 2 new test files only, zero source code changes
- What did NOT change: No production code, no behavior changes. The `promote.ts` and `stream-normalizer.ts` (main state machine) test coverage is deferred to follow-up

## Change Type

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [x] Chore/infra

## Scope

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [x] CI/CD / infra

## Motivation

`packages/tool-call-repair/` implements the runtime logic for detecting, parsing, and promoting plain-text tool calls emitted by models that do not support native tool calling. The package is consumed by `src/shared/`, `src/plugin-sdk/`, `src/infra/`, and `src/agents/` modules, making it a critical dependency. Despite 2,299 lines of parsing logic (state machine, grammar, JSON boundary tracking, promotion), it had zero unit tests. This PR adds coverage for the two pure-logic foundation files that all other modules depend on.

## Real behavior proof

- Behavior addressed: Adding test coverage for previously untested tool-call-repair package files
- Real environment tested: Linux, Node 24, branch `test/tool-call-repair-unit-tests`
- Exact steps or command run after this patch:
```ts
pnpm test packages/tool-call-repair/src/grammar.test.ts packages/tool-call-repair/src/payload.test.ts
```

- Evidence after fix:
```ts
Test Files 2 passed (2) 
     Tests 112 passed (112) 
Start at 14:48:17 
Duration 1.10s
```

- Observed result after fix:

1. `grammar.test.ts` — 83 tests passing, covering: all 4 grammar constants, `matchesLiteralPrefix` (exact/prefix/suffix/empty), `isPlainTextToolNameChar` / `isXmlishNameChar` character classification, `skipHorizontalWhitespace` / `skipWhitespace` (spaces/tabs/newlines), `consumeLineBreak` (Unix/Windows/standalone CR), `findJsonObjectEnd` (simple/nested/escaped strings/backslash/empty/unclosed/maxPayloadBytes/offset), `skipSerializedToolCallTrailingLineBreak`, `consumeJsonToolClosingMarker` (3 marker formats + leading whitespace), `findBracketedJsonPayloadStart` (bracket/JSON/missing close/no JSON/CRLF/whitespace), `findHarmonyJsonPayloadStart` (with/without channel marker/message marker/unknown channel/missing to=/no tool name/missing code/no JSON/commentary/final channels), `startsWithAsciiMarkerIgnoreCase` (case-insensitive/no match/too short/offset), `indexOfAsciiMarkerIgnoreCase` (start/offset/not found/available), `findXmlishToolCallEnd` (XML-ish/bracket/tool: prefix/plain text/no parameters/unclosed/multiple params/case-insensitive/trailing newline)

2. `payload.test.ts` — 29 tests passing, covering: `parseStandalonePlainTextToolCallBlocks` (single/multiple bracket, tool: prefix, harmony with/without channel marker, harmony with message marker, allowedToolNames filter/reject, mixed text rejection, invalid JSON, JSON array rejection, missing/mismatched closing markers, maxPayloadBytes, consecutive tool: calls, CRLF line endings, raw/offset tracking), `stripPlainTextToolCallBlocks` (bracket-style removal, unchanged text, empty input, start/end removal, multiple blocks, tool: prefix at line start)

- What was not tested: `promote.ts` and `stream-normalizer.ts` (main state machine) — deferred to follow-up PRs. `stream-normalizer.ts` requires AsyncIterable mocking for the core `normalizePlainTextToolCallStreamEvents` generator.

## User-visible / Behavior Changes

None

## Security Impact

- [x] New permissions/capabilities? No
- [x] Secrets/tokens handling changed? No
- [x] New/changed network calls? No
- [x] Command/tool execution surface changed? No
- [x] Data access scope changed? No

## Compatibility / Migration

- [x] Backward compatible? Yes
- [x] Config/env changes? No
- [x] Migration needed? No

## Best-fix Verdict

- **Best fix**: Yes — pure test addition is the correct approach; no behavior changes needed
- **Refactor needed**: No
- **Alternative considered**: Adding tests alongside a behavior change — rejected because these files are stable; tests add regression protection without risking new bugs

## AI Assistance 🤖

- **AI-assisted**: Yes
- **AI model**: deepseek-v4-flash
- **Human confirmed understanding of code changes**: Yes

## Risks and Mitigations

None — test-only change, zero production code modifications.  