### PR TITLE
test: migrate docs-path and system-prompt-params tests to shared temp-dir helpers

### DIFF
--- a/src/agents/docs-path.test.ts
+++ b/src/agents/docs-path.test.ts
@@ -1,17 +1,27 @@
 // Covers locating OpenClaw docs and source paths from package roots.
 import fs from "node:fs/promises";
-import os from "node:os";
 import path from "node:path";
-import { describe, expect, it } from "vitest";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { createSuiteTempRootTracker } from "../test-helpers/temp-dir.js";
 import { resolveOpenClawReferencePaths } from "./docs-path.js";
 
-async function makePackageRoot(prefix: string): Promise<string> {
+const suiteTempDirs = createSuiteTempRootTracker({ prefix: "openclaw-docs-path-" });
+
+async function makePackageRoot(): Promise<string> {
   // Tests create minimal package roots so path resolution is checked without
   // depending on this checkout's real docs or git state.
-  const root = await fs.mkdtemp(path.join(os.tmpdir(), prefix));
+  const root = await suiteTempDirs.make("package");
   await fs.writeFile(path.join(root, "package.json"), '{"name":"openclaw"}\n');
   return root;
 }
+
+beforeAll(async () => {
+  await suiteTempDirs.setup();
+});
+
+afterAll(async () => {
+  await suiteTempDirs.cleanup();
+});
 
 async function writeDocsJson(root: string): Promise<void> {
   await fs.mkdir(path.join(root, "docs"), { recursive: true });
@@ -20,7 +30,7 @@ async function writeDocsJson(root: string): Promise<void> {
 
 describe("resolveOpenClawDocsPath", () => {
   it("uses the workspace docs directory when it has canonical docs metadata", async () => {
-    const root = await makePackageRoot("openclaw-docs-workspace-");
+    const root = await makePackageRoot();
     await writeDocsJson(root);
 
     await expect(resolveOpenClawReferencePaths({ workspaceDir: root })).resolves.toMatchObject({
@@ -29,7 +39,7 @@ describe("resolveOpenClawDocsPath", () => {
   });
 
   it("finds bundled package docs from a nested package path", async () => {
-    const root = await makePackageRoot("openclaw-docs-package-");
+    const root = await makePackageRoot();
     await writeDocsJson(root);
     const nested = path.join(root, "dist", "agents");
     await fs.mkdir(nested, { recursive: true });
@@ -42,7 +52,7 @@ describe("resolveOpenClawDocsPath", () => {
   it("does not accept incomplete template-only docs directories", async () => {
     // Template folders alone are not published docs; docs.json is the canonical
     // marker that the path is usable for model reference context.
-    const root = await makePackageRoot("openclaw-docs-incomplete-");
+    const root = await makePackageRoot();
     await fs.mkdir(path.join(root, "docs", "reference", "templates"), { recursive: true });
 
     await expect(resolveOpenClawReferencePaths({ cwd: root })).resolves.toMatchObject({
@@ -53,7 +63,7 @@ describe("resolveOpenClawDocsPath", () => {
 
 describe("resolveOpenClawSourcePath", () => {
   it("returns the package root only for git checkouts", async () => {
-    const root = await makePackageRoot("openclaw-source-git-");
+    const root = await makePackageRoot();
     await fs.mkdir(path.join(root, ".git"));
 
     await expect(resolveOpenClawReferencePaths({ cwd: root })).resolves.toMatchObject({
@@ -63,7 +73,7 @@ describe("resolveOpenClawSourcePath", () => {
 
   it("omits source path for npm-style package installs", async () => {
     // npm installs may contain package files but not source checkout metadata.
-    const root = await makePackageRoot("openclaw-source-npm-");
+    const root = await makePackageRoot();
 
     await expect(resolveOpenClawReferencePaths({ cwd: root })).resolves.toMatchObject({
       sourcePath: null,
@@ -73,7 +83,7 @@ describe("resolveOpenClawSourcePath", () => {
 
 describe("resolveOpenClawReferencePaths", () => {
   it("returns docs and local source together for git checkouts", async () => {
-    const root = await makePackageRoot("openclaw-reference-git-");
+    const root = await makePackageRoot();
     await writeDocsJson(root);
     await fs.mkdir(path.join(root, ".git"));
 

--- a/src/agents/system-prompt-params.test.ts
+++ b/src/agents/system-prompt-params.test.ts
@@ -1,15 +1,25 @@
 // System prompt params tests cover runtime metadata assembly, especially repo
 // root discovery from workspace, cwd, and explicit config.
 import fs from "node:fs/promises";
-import os from "node:os";
 import path from "node:path";
-import { describe, expect, it } from "vitest";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import type { OpenClawConfig } from "../config/config.js";
+import { createSuiteTempRootTracker } from "../test-helpers/temp-dir.js";
 import { buildSystemPromptParams } from "./system-prompt-params.js";
 
-async function makeTempDir(label: string): Promise<string> {
-  return fs.mkdtemp(path.join(os.tmpdir(), `openclaw-${label}-`));
+const suiteTempDirs = createSuiteTempRootTracker({ prefix: "openclaw-system-prompt-" });
+
+async function makeTempDir(): Promise<string> {
+  return suiteTempDirs.make("temp");
 }
+
+beforeAll(async () => {
+  await suiteTempDirs.setup();
+});
+
+afterAll(async () => {
+  await suiteTempDirs.cleanup();
+});
 
 async function makeRepoRoot(root: string): Promise<void> {
   await fs.mkdir(path.join(root, ".git"), { recursive: true });
@@ -32,7 +42,7 @@ function buildParams(params: { config?: OpenClawConfig; workspaceDir?: string; c
 
 describe("buildSystemPromptParams", () => {
   it("detects repo root from workspaceDir", async () => {
-    const temp = await makeTempDir("workspace");
+    const temp = await makeTempDir();
     const repoRoot = path.join(temp, "repo");
     const workspaceDir = path.join(repoRoot, "nested", "workspace");
     await fs.mkdir(workspaceDir, { recursive: true });
@@ -44,7 +54,7 @@ describe("buildSystemPromptParams", () => {
   });
 
   it("falls back to cwd when workspaceDir has no repo", async () => {
-    const temp = await makeTempDir("cwd");
+    const temp = await makeTempDir();
     const repoRoot = path.join(temp, "repo");
     const workspaceDir = path.join(temp, "workspace");
     await fs.mkdir(workspaceDir, { recursive: true });
@@ -56,7 +66,7 @@ describe("buildSystemPromptParams", () => {
   });
 
   it("uses configured repoRoot when valid", async () => {
-    const temp = await makeTempDir("config");
+    const temp = await makeTempDir();
     const repoRoot = path.join(temp, "config-root");
     const workspaceDir = path.join(temp, "workspace");
     await fs.mkdir(repoRoot, { recursive: true });
@@ -79,7 +89,7 @@ describe("buildSystemPromptParams", () => {
   it("ignores invalid repoRoot config and auto-detects", async () => {
     // Invalid explicit roots must not poison runtime metadata; auto-detection
     // still finds the real repository root from the workspace path.
-    const temp = await makeTempDir("invalid");
+    const temp = await makeTempDir();
     const repoRoot = path.join(temp, "repo");
     const workspaceDir = path.join(repoRoot, "workspace");
     await fs.mkdir(workspaceDir, { recursive: true });
@@ -99,7 +109,7 @@ describe("buildSystemPromptParams", () => {
   });
 
   it("returns undefined when no repo is found", async () => {
-    const workspaceDir = await makeTempDir("norepo");
+    const workspaceDir = await makeTempDir();
 
     const { runtimeInfo } = buildParams({ workspaceDir });
 


### PR DESCRIPTION
## What Problem This Solves

Two `src/agents/` test files create temporary directories with raw `fs.mkdtemp` and never clean them up:

- `src/agents/docs-path.test.ts`: `makePackageRoot()` calls `fs.mkdtemp` for every test case (6 cases).
- `src/agents/system-prompt-params.test.ts`: `makeTempDir()` calls `fs.mkdtemp` for every test case (5 cases).

These leaks add `/tmp` pressure across repeated test runs.

## Why This Change Was Made

Migrates both files to the existing shared helper `createSuiteTempRootTracker` from `src/test-helpers/temp-dir.js`. The tracker creates one suite-level temp root in `beforeAll`, hands out isolated case subdirectories via `make()`, and removes the entire root in `afterAll`.

Changes per file:

- Replaced `fs.mkdtemp(...)` inside helpers with `suiteTempDirs.make(...)`.
- Added `createSuiteTempRootTracker` import and `beforeAll`/`afterAll` setup/cleanup hooks.
- Removed now-unused `os` imports.
- Kept all test bodies and assertions unchanged.

## User Impact

Test-only. Reduces dangling temp directories during agents test runs. No user-visible behavior change.

## Evidence

Unit tests:

```bash
node scripts/run-vitest.mjs src/agents/docs-path.test.ts src/agents/system-prompt-params.test.ts --run
```

Results:

```console
 Test Files  2 passed (2)
      Tests  12 passed (12)
```

Lint:

```bash
node scripts/run-oxlint.mjs src/agents/docs-path.test.ts src/agents/system-prompt-params.test.ts
```

→ exit 0

Typecheck:

```bash
pnpm tsgo:core:test
```

→ exit 0

Format:

```bash
pnpm format:check src/agents/docs-path.test.ts src/agents/system-prompt-params.test.ts
```

→ All matched files use the correct format.

## Real behavior proof

- **Behavior addressed**: two test files no longer leak temp directories created by `fs.mkdtemp`.
- **Real environment tested**: Linux x86_64, Node 22.19+, local source checkout.
- **Exact steps or command run after this patch**: see Evidence section above.
- **Evidence after fix**: 12 tests pass; lint, typecheck, and format pass; `createSuiteTempRootTracker` removes the suite temp root in `afterAll`.
- **Observed result after fix**: both test suites now use the shared tracker for temp directory lifecycle, matching the pattern used in xialonglee's merged temp-dir migration PRs.
- **What was not tested**: full CI suite (triggered on push to remote).

## AI-assisted

Implemented and verified with AI assistance; reviewed by a human before submission.
