### PR TITLE
fix: before_agent_run transform no longer leaks redacted text into history

### DIFF
--- a/docs/plugins/hooks.md
+++ b/docs/plugins/hooks.md
@@ -481,9 +481,15 @@ Use the phase-specific hooks for new plugins:
 including prompt-local image loading and `llm_input` observation. It receives
 the current user input as `prompt`, plus loaded session history in `messages`
 and the active system prompt. Return `{ outcome: "block", reason, message? }`
-to stop the run before the model reads the prompt. `reason` is internal;
-`message` is the user-facing replacement. Only `pass` and `block` outcomes are
-supported; unsupported decision shapes fail closed.
+to stop the run before the model can read the prompt. Return
+`{ outcome: "transform", prompt }` to replace only the current model-bound user
+prompt and continue the same run. The transformed prompt is what the model and
+`llm_input` observers receive; the stored transcript prompt is not rewritten.
+`reason` is internal; `message` is the user-facing replacement for blocks.
+Supported outcomes are `pass`, `transform`, and `block`; unsupported decision
+shapes fail closed. When multiple plugins return decisions, `block` wins over
+`transform`, `transform` wins over `pass`, and the first transform at the same
+priority order is kept.
 
 When a run is blocked, OpenClaw stores only the replacement text in
 `message.content` plus non-sensitive block metadata such as the blocking

--- a/docs/plugins/hooks.md
+++ b/docs/plugins/hooks.md
@@ -482,10 +482,11 @@ including prompt-local image loading and `llm_input` observation. It receives
 the current user input as `prompt`, plus loaded session history in `messages`
 and the active system prompt. Return `{ outcome: "block", reason, message? }`
 to stop the run before the model can read the prompt. Return
-`{ outcome: "transform", prompt }` to replace only the current model-bound user
-prompt and continue the same run. The transformed prompt is what the model and
-`llm_input` observers receive; the stored transcript prompt is not rewritten.
-`reason` is internal; `message` is the user-facing replacement for blocks.
+`{ outcome: "transform", prompt }` to replace the current user prompt and
+continue the same run. The transformed prompt is what the model, `llm_input`
+observers, and the stored session transcript all receive, so a redaction never
+re-enters context on a later turn. `reason` is internal; `message` is the
+user-facing replacement for blocks.
 Supported outcomes are `pass`, `transform`, and `block`; unsupported decision
 shapes fail closed. When multiple plugins return decisions, `block` wins over
 `transform`, `transform` wins over `pass`, and the first transform at the same

--- a/src/agents/cli-runner.reliability.test.ts
+++ b/src/agents/cli-runner.reliability.test.ts
@@ -4704,6 +4704,95 @@ describe("runCliAgent reliability", () => {
     }
   });
 
+  it("uses before_agent_run transform for CLI model input while preserving transcript text", async () => {
+    supervisorSpawnMock.mockClear();
+    supervisorSpawnMock.mockResolvedValueOnce(
+      createManagedRun({
+        reason: "exit",
+        exitCode: 0,
+        exitSignal: null,
+        durationMs: 50,
+        stdout: "ok",
+        stderr: "",
+        timedOut: false,
+        noOutputTimedOut: false,
+      }),
+    );
+    const sensitivePrompt = "Hi OpenClaw, my credit card is 4111111111111111";
+    const redactedPrompt = "Hi OpenClaw, my credit card is [CreditCardNumber]";
+    const hookRunner = {
+      hasHooks: vi.fn((hookName: string) =>
+        ["before_agent_run", "llm_input"].includes(hookName),
+      ),
+      runBeforeAgentRun: vi.fn(async () => ({
+        pluginId: "redactor",
+        decision: {
+          outcome: "transform" as const,
+          prompt: redactedPrompt,
+          reason: "redacted payment card",
+        },
+      })),
+      runLlmInput: vi.fn(async () => undefined),
+    };
+    setHookRunnerForTest(hookRunner);
+    const { dir, sessionFile } = createSessionFile();
+
+    try {
+      const context = buildPreparedContext({
+        sessionKey: "agent:main:main",
+        runId: "run-cli-transform",
+        openClawHistoryPrompt: [
+          "Continue this conversation using the OpenClaw transcript below as prior session history.",
+          "",
+          "<conversation_history>",
+          "User: earlier context",
+          "</conversation_history>",
+          "",
+          "<next_user_message>",
+          sensitivePrompt,
+          "</next_user_message>",
+        ].join("\n"),
+      });
+      await runPreparedCliAgent({
+        ...context,
+        params: {
+          ...context.params,
+          agentId: "main",
+          sessionFile,
+          workspaceDir: dir,
+          prompt: sensitivePrompt,
+          userTurnTranscriptRecorder: createCliUserTurnRecorder({
+            text: sensitivePrompt,
+            sessionFile,
+            sessionKey: "agent:main:main",
+            workspaceDir: dir,
+          }),
+        },
+      });
+
+      expect(supervisorSpawnMock).toHaveBeenCalledTimes(1);
+      const beforeRunEvent = requireRecord(
+        callArg(hookRunner.runBeforeAgentRun, 0, 0, "before_agent_run event"),
+        "before_agent_run event",
+      );
+      expect(beforeRunEvent.prompt).toBe(sensitivePrompt);
+      const llmInputEvent = requireRecord(
+        callArg(hookRunner.runLlmInput, 0, 0, "llm_input event"),
+        "llm_input event",
+      );
+      expect(llmInputEvent.prompt).toBe(redactedPrompt);
+      expect(JSON.stringify(llmInputEvent)).not.toContain("4111111111111111");
+      expect(JSON.stringify(supervisorSpawnMock.mock.calls)).toContain("[CreditCardNumber]");
+      expect(JSON.stringify(supervisorSpawnMock.mock.calls)).not.toContain("4111111111111111");
+
+      const lines = fs.readFileSync(sessionFile, "utf-8").trim().split("\n");
+      const userTurnLine = JSON.parse(lines[lines.length - 1]);
+      expect(JSON.stringify(userTurnLine)).toContain(sensitivePrompt);
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
   it("forwards channel identity context to CLI before_agent_run hooks", async () => {
     supervisorSpawnMock.mockClear();
     const hookRunner = {

--- a/src/agents/cli-runner.reliability.test.ts
+++ b/src/agents/cli-runner.reliability.test.ts
@@ -4704,7 +4704,7 @@ describe("runCliAgent reliability", () => {
     }
   });
 
-  it("uses before_agent_run transform for CLI model input and the persisted transcript", async () => {
+  it("uses before_agent_run transform for CLI model input, transcript, and agent_end", async () => {
     supervisorSpawnMock.mockClear();
     supervisorSpawnMock.mockResolvedValueOnce(
       createManagedRun({
@@ -4721,7 +4721,9 @@ describe("runCliAgent reliability", () => {
     const sensitivePrompt = "Hi OpenClaw, my credit card is 4111111111111111";
     const redactedPrompt = "Hi OpenClaw, my credit card is [CreditCardNumber]";
     const hookRunner = {
-      hasHooks: vi.fn((hookName: string) => ["before_agent_run", "llm_input"].includes(hookName)),
+      hasHooks: vi.fn((hookName: string) =>
+        ["before_agent_run", "llm_input", "agent_end"].includes(hookName),
+      ),
       runBeforeAgentRun: vi.fn(async () => ({
         pluginId: "redactor",
         decision: {
@@ -4731,6 +4733,7 @@ describe("runCliAgent reliability", () => {
         },
       })),
       runLlmInput: vi.fn(async () => undefined),
+      runAgentEnd: vi.fn(async () => undefined),
     };
     setHookRunnerForTest(hookRunner);
     const { dir, sessionFile } = createSessionFile();
@@ -4787,6 +4790,13 @@ describe("runCliAgent reliability", () => {
       const userTurnLine = JSON.parse(lines[lines.length - 1]);
       expect(JSON.stringify(userTurnLine)).toContain(redactedPrompt);
       expect(JSON.stringify(userTurnLine)).not.toContain("4111111111111111");
+
+      const agentEndEvent = requireRecord(
+        callArg(hookRunner.runAgentEnd, 0, 0, "agent_end event"),
+        "agent_end event",
+      );
+      expect(JSON.stringify(agentEndEvent)).toContain("[CreditCardNumber]");
+      expect(JSON.stringify(agentEndEvent)).not.toContain("4111111111111111");
     } finally {
       fs.rmSync(dir, { recursive: true, force: true });
     }

--- a/src/agents/cli-runner.reliability.test.ts
+++ b/src/agents/cli-runner.reliability.test.ts
@@ -4786,10 +4786,9 @@ describe("runCliAgent reliability", () => {
       expect(JSON.stringify(supervisorSpawnMock.mock.calls)).toContain("[CreditCardNumber]");
       expect(JSON.stringify(supervisorSpawnMock.mock.calls)).not.toContain("4111111111111111");
 
-      const lines = fs.readFileSync(sessionFile, "utf-8").trim().split("\n");
-      const userTurnLine = JSON.parse(lines[lines.length - 1]);
-      expect(JSON.stringify(userTurnLine)).toContain(redactedPrompt);
-      expect(JSON.stringify(userTurnLine)).not.toContain("4111111111111111");
+      const persistedMessages = await readTranscriptMessages(sessionFile);
+      expect(JSON.stringify(persistedMessages)).toContain(redactedPrompt);
+      expect(JSON.stringify(persistedMessages)).not.toContain("4111111111111111");
 
       const agentEndEvent = requireRecord(
         callArg(hookRunner.runAgentEnd, 0, 0, "agent_end event"),

--- a/src/agents/cli-runner.reliability.test.ts
+++ b/src/agents/cli-runner.reliability.test.ts
@@ -4704,7 +4704,7 @@ describe("runCliAgent reliability", () => {
     }
   });
 
-  it("uses before_agent_run transform for CLI model input while preserving transcript text", async () => {
+  it("uses before_agent_run transform for CLI model input and the persisted transcript", async () => {
     supervisorSpawnMock.mockClear();
     supervisorSpawnMock.mockResolvedValueOnce(
       createManagedRun({
@@ -4721,9 +4721,7 @@ describe("runCliAgent reliability", () => {
     const sensitivePrompt = "Hi OpenClaw, my credit card is 4111111111111111";
     const redactedPrompt = "Hi OpenClaw, my credit card is [CreditCardNumber]";
     const hookRunner = {
-      hasHooks: vi.fn((hookName: string) =>
-        ["before_agent_run", "llm_input"].includes(hookName),
-      ),
+      hasHooks: vi.fn((hookName: string) => ["before_agent_run", "llm_input"].includes(hookName)),
       runBeforeAgentRun: vi.fn(async () => ({
         pluginId: "redactor",
         decision: {
@@ -4787,7 +4785,8 @@ describe("runCliAgent reliability", () => {
 
       const lines = fs.readFileSync(sessionFile, "utf-8").trim().split("\n");
       const userTurnLine = JSON.parse(lines[lines.length - 1]);
-      expect(JSON.stringify(userTurnLine)).toContain(sensitivePrompt);
+      expect(JSON.stringify(userTurnLine)).toContain(redactedPrompt);
+      expect(JSON.stringify(userTurnLine)).not.toContain("4111111111111111");
     } finally {
       fs.rmSync(dir, { recursive: true, force: true });
     }

--- a/src/agents/cli-runner.ts
+++ b/src/agents/cli-runner.ts
@@ -172,6 +172,31 @@ function formatCliEmptyOutputDiagnostics(output: CliOutput): string | undefined 
   ].join(" ");
 }
 
+function replaceCliHistoryPromptCurrentTurn(params: {
+  historyPrompt: string | undefined;
+  prompt: string;
+}): string | undefined {
+  if (!params.historyPrompt) {
+    return undefined;
+  }
+  const start = "<next_user_message>\n";
+  const end = "\n</next_user_message>";
+  const startIndex = params.historyPrompt.indexOf(start);
+  if (startIndex === -1) {
+    return params.historyPrompt;
+  }
+  const contentStart = startIndex + start.length;
+  const endIndex = params.historyPrompt.indexOf(end, contentStart);
+  if (endIndex === -1) {
+    return params.historyPrompt;
+  }
+  return [
+    params.historyPrompt.slice(0, contentStart),
+    params.prompt,
+    params.historyPrompt.slice(endIndex),
+  ].join("");
+}
+
 /** Checks whether a Claude CLI session binding has reached its transcript file. */
 export async function isCliBindingFlushed(
   sessionId: string | undefined,
@@ -633,16 +658,18 @@ export async function runPreparedCliAgent(
         config: params.config,
       })
     : [];
-  const llmInputEvent = {
-    runId: params.runId,
-    sessionId: params.sessionId,
-    provider: params.provider,
-    model: context.modelId,
-    systemPrompt: context.systemPrompt,
-    prompt: params.prompt,
-    historyMessages,
-    imagesCount: params.images?.length ?? 0,
-  } as const;
+  let modelBoundPrompt = params.prompt;
+  const buildLlmInputEvent = () =>
+    ({
+      runId: params.runId,
+      sessionId: params.sessionId,
+      provider: params.provider,
+      model: context.modelId,
+      systemPrompt: context.systemPrompt,
+      prompt: modelBoundPrompt,
+      historyMessages,
+      imagesCount: params.images?.length ?? 0,
+    }) as const;
   const hookContext = {
     runId: params.runId,
     jobId: params.jobId,
@@ -988,7 +1015,7 @@ export async function runPreparedCliAgent(
             options.onForkSuccessorPersisted?.(sessionId);
           }
         : context.params.persistCliSessionForkSuccessor;
-    const attemptContext =
+    const baseAttemptContext =
       timeoutMs === params.timeoutMs &&
       forkCliSessionOnResume === context.params.forkCliSessionOnResume &&
       cliSessionResumeAt === context.params.cliSessionResumeAt &&
@@ -1002,6 +1029,20 @@ export async function runPreparedCliAgent(
               forkCliSessionOnResume,
               cliSessionResumeAt,
               persistCliSessionForkSuccessor,
+            },
+          };
+    const attemptContext =
+      modelBoundPrompt === params.prompt
+        ? baseAttemptContext
+        : {
+            ...baseAttemptContext,
+            openClawHistoryPrompt: replaceCliHistoryPromptCurrentTurn({
+              historyPrompt: baseAttemptContext.openClawHistoryPrompt,
+              prompt: modelBoundPrompt,
+            }),
+            params: {
+              ...baseAttemptContext.params,
+              prompt: modelBoundPrompt,
             },
           };
     diagnosticLifecycle?.setPhase("send");
@@ -1418,11 +1459,14 @@ export async function runPreparedCliAgent(
         });
         return buildBlockedBeforeAgentRunResult(blockMessage);
       }
+      if (beforeRunDecision?.outcome === "transform") {
+        modelBoundPrompt = beforeRunDecision.prompt;
+      }
     }
 
     userTurnHandled = await persistApprovedCliUserTurnTranscript(params);
     runAgentHarnessLlmInputHook({
-      event: llmInputEvent,
+      event: buildLlmInputEvent(),
       ctx: hookContext,
       hookRunner,
     });

--- a/src/agents/cli-runner.ts
+++ b/src/agents/cli-runner.ts
@@ -717,8 +717,11 @@ export async function runPreparedCliAgent(
   const buildAgentEndMessages = (lastAssistant?: unknown): unknown[] => [
     ...buildAgentHookConversationMessages({
       historyMessages,
+      // Read via the closure so a before_agent_run transform (which reassigns
+      // modelBoundPrompt) is reflected here too — agent_end fires after the
+      // hook runs, so the raw prompt must never reach this hook-visible event.
       currentTurnMessages: [
-        buildCliHookUserMessage(params.prompt),
+        buildCliHookUserMessage(modelBoundPrompt),
         ...(lastAssistant ? [lastAssistant] : []),
       ],
     }),

--- a/src/agents/cli-runner.ts
+++ b/src/agents/cli-runner.ts
@@ -27,6 +27,7 @@ import {
 import { resolveBlockMessage } from "../plugins/hook-decision-types.js";
 import { getGlobalHookRunner } from "../plugins/hook-runner-global.js";
 import { resolveAgentIdFromSessionKey } from "../routing/session-key.js";
+import type { PersistedUserTurnMessage } from "../sessions/user-turn-transcript.types.js";
 import { isHeartbeatLifecycleRunKind } from "./bootstrap-mode.js";
 import {
   resolveCliRuntimeArtifactFingerprint,
@@ -335,15 +336,30 @@ async function runCliAgentEndHook(
   runAgentEndSideEffects(hookParams);
 }
 
-async function persistApprovedCliUserTurnTranscript(params: RunCliAgentParams): Promise<boolean> {
+async function persistApprovedCliUserTurnTranscript(
+  params: RunCliAgentParams,
+  options?: { redactedPrompt?: string },
+): Promise<boolean> {
   const recorder = params.userTurnTranscriptRecorder;
   const reusingPersistedTurn = params.suppressNextUserMessagePersistence === true;
   if (!recorder || (reusingPersistedTurn && !recorder.hasPersisted())) {
     return recorder?.isBlocked() === true;
   }
 
+  // A transform outcome redacts after the recorder already captured the raw
+  // message; persist the redacted text instead so it doesn't re-enter context
+  // on a later turn via transcript history (mirrors the embedded runner fix).
+  let overrideMessage: PersistedUserTurnMessage | undefined;
+  if (options?.redactedPrompt !== undefined) {
+    const baseMessage = await recorder.resolveMessage();
+    if (baseMessage) {
+      overrideMessage = { ...baseMessage, content: options.redactedPrompt };
+    }
+  }
+
   const persisted = await recorder.persistApproved({
     cwd: params.cwd ?? params.workspaceDir,
+    overrideMessage,
   });
   if (!persisted && !recorder.hasPersisted() && (await recorder.resolveMessage())) {
     // A prepared user row can be rejected by before_message_write. Preserve
@@ -659,6 +675,7 @@ export async function runPreparedCliAgent(
       })
     : [];
   let modelBoundPrompt = params.prompt;
+  let beforeAgentRunTransformedPrompt = false;
   const buildLlmInputEvent = () =>
     ({
       runId: params.runId,
@@ -1461,10 +1478,14 @@ export async function runPreparedCliAgent(
       }
       if (beforeRunDecision?.outcome === "transform") {
         modelBoundPrompt = beforeRunDecision.prompt;
+        beforeAgentRunTransformedPrompt = true;
       }
     }
 
-    userTurnHandled = await persistApprovedCliUserTurnTranscript(params);
+    userTurnHandled = await persistApprovedCliUserTurnTranscript(
+      params,
+      beforeAgentRunTransformedPrompt ? { redactedPrompt: modelBoundPrompt } : undefined,
+    );
     runAgentHarnessLlmInputHook({
       event: buildLlmInputEvent(),
       ctx: hookContext,

--- a/src/agents/embedded-agent-runner/run/attempt-before-agent-run.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-before-agent-run.test.ts
@@ -107,6 +107,26 @@ describe("runEmbeddedAttemptBeforeAgentRun", () => {
     expect(lock.acquisitions).toBe(0);
   });
 
+  it("returns a transform outcome and leaves the session prompt unchanged", async () => {
+    const handler = vi.fn(async () => ({
+      outcome: "transform" as const,
+      prompt: "redacted prompt",
+      reason: "redacted payment card",
+    }));
+    const { input, lock, sessionManager, state } = createInput([
+      { pluginId: "redactor", hookName: "before_agent_run", handler, source: "test" },
+    ]);
+
+    const outcome = await runEmbeddedAttemptBeforeAgentRun(input);
+
+    expect(outcome).toEqual({ kind: "transform", prompt: "redacted prompt" });
+    expect(lock.acquisitions).toBe(0);
+    expect(state.messages[0]).toEqual(
+      expect.objectContaining({ content: [{ type: "text", text: "original prompt" }] }),
+    );
+    expect(sessionManager.buildSessionContext().messages).toEqual([]);
+  });
+
   it("persists one redacted blocked turn across retries", async () => {
     const handler = vi.fn(async () => ({
       outcome: "block" as const,
@@ -120,11 +140,21 @@ describe("runEmbeddedAttemptBeforeAgentRun", () => {
     const first = await runEmbeddedAttemptBeforeAgentRun(input);
     const second = await runEmbeddedAttemptBeforeAgentRun(input);
 
-    expect(first).toEqual({ blockedBy: "policy", promptError: expect.any(Error) });
-    expect(first?.promptError.message).toBe(
+    expect(first).toEqual({
+      kind: "block",
+      blockedBy: "policy",
+      promptError: expect.any(Error),
+    });
+    if (first?.kind !== "block") {
+      throw new Error("expected block outcome");
+    }
+    expect(first.promptError.message).toBe(
       "Your message could not be sent: Request blocked. (blocked by policy)",
     );
-    expect(second?.blockedBy).toBe("policy");
+    if (second?.kind !== "block") {
+      throw new Error("expected block outcome");
+    }
+    expect(second.blockedBy).toBe("policy");
     expect(lock.acquisitions).toBe(1);
     expect(handler).toHaveBeenCalledTimes(2);
     const persistedMessages = sessionManager.buildSessionContext().messages;
@@ -160,8 +190,11 @@ describe("runEmbeddedAttemptBeforeAgentRun", () => {
 
     const outcome = await runEmbeddedAttemptBeforeAgentRun(input);
 
-    expect(outcome?.blockedBy).toBe("before_agent_run");
-    expect(outcome?.promptError.message).toBe(
+    if (outcome?.kind !== "block") {
+      throw new Error("expected block outcome");
+    }
+    expect(outcome.blockedBy).toBe("before_agent_run");
+    expect(outcome.promptError.message).toBe(
       "Your message could not be sent: blocked by before_agent_run",
     );
     expect(lock.acquisitions).toBe(1);

--- a/src/agents/embedded-agent-runner/run/attempt-before-agent-run.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-before-agent-run.ts
@@ -21,10 +21,9 @@ type BeforeAgentRunSession = {
   agent: { state: { messages: AgentMessage[] } };
 };
 
-type BeforeAgentRunBlockOutcome = {
-  blockedBy: string;
-  promptError: Error;
-};
+export type BeforeAgentRunOutcome =
+  | { kind: "block"; blockedBy: string; promptError: Error }
+  | { kind: "transform"; prompt: string };
 
 export async function runEmbeddedAttemptBeforeAgentRun(input: {
   attempt: Pick<
@@ -39,7 +38,7 @@ export async function runEmbeddedAttemptBeforeAgentRun(input: {
   sessionManager: AttemptSessionManager;
   systemPrompt: string;
   withOwnedSessionWriteLock: WithOwnedSessionWriteLock;
-}): Promise<BeforeAgentRunBlockOutcome | undefined> {
+}): Promise<BeforeAgentRunOutcome | undefined> {
   if (!input.hookRunner?.hasHooks("before_agent_run")) {
     return undefined;
   }
@@ -107,10 +106,13 @@ export async function runEmbeddedAttemptBeforeAgentRun(input: {
       { blockedBy },
     );
     await persistBlockedBeforeAgentRun({ message, pluginId: blockedBy });
-    return { blockedBy, promptError: new Error(message) };
+    return { kind: "block", blockedBy, promptError: new Error(message) };
   }
 
   const beforeRunDecision = beforeRunResult?.decision;
+  if (beforeRunDecision?.outcome === "transform") {
+    return { kind: "transform", prompt: beforeRunDecision.prompt };
+  }
   if (beforeRunDecision?.outcome !== "block") {
     return undefined;
   }
@@ -118,5 +120,5 @@ export async function runEmbeddedAttemptBeforeAgentRun(input: {
   const message = resolveBlockMessage(beforeRunDecision, { blockedBy });
   log.warn(`before_agent_run hook blocked by ${blockedBy}`);
   await persistBlockedBeforeAgentRun({ message, pluginId: blockedBy });
-  return { blockedBy, promptError: new Error(message) };
+  return { kind: "block", blockedBy, promptError: new Error(message) };
 }

--- a/src/agents/embedded-agent-runner/run/attempt-prompt-context.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-prompt-context.ts
@@ -78,6 +78,37 @@ type EmbeddedAttemptPromptContext = {
   systemPromptForHook: string;
 };
 
+/**
+ * Normalizes the current-turn prompt text at the LLM boundary. Shared between
+ * the initial prompt-context pass and a later `before_agent_run` transform
+ * override, which must re-derive this text from the redacted prompt instead
+ * of the original one.
+ */
+export function buildLlmBoundaryPromptForPrecheck(params: {
+  prompt: string;
+  boundaryTimezone?: string;
+  includeBoundaryTimestamp: boolean;
+  isRawModelRun: boolean;
+  preparedUserTurnMessage?: AgentMessage;
+}): string {
+  const preparedUserTurnTimestamp = (
+    params.preparedUserTurnMessage as { timestamp?: unknown } | undefined
+  )?.timestamp;
+  return normalizeCurrentPromptTextForLlmBoundary({
+    prompt: params.prompt,
+    ...(params.boundaryTimezone ? { timezone: params.boundaryTimezone } : {}),
+    ...(params.includeBoundaryTimestamp ? {} : { includeTimestamp: false }),
+    ...(typeof preparedUserTurnTimestamp === "number"
+      ? { currentUserTimestamp: preparedUserTurnTimestamp }
+      : {}),
+    // Admission must count the same persisted sender block that provider
+    // conversion projects after the active user turn is written.
+    ...(!params.isRawModelRun && params.preparedUserTurnMessage
+      ? { currentUserTranscriptMessage: params.preparedUserTurnMessage }
+      : {}),
+  });
+}
+
 export function prepareEmbeddedAttemptPromptContext(input: {
   attempt: PromptContextAttempt;
   boundaryTimezone?: string;
@@ -246,17 +277,13 @@ export function prepareEmbeddedAttemptPromptContext(input: {
       modelOnlyPromptChars: Math.max(0, promptForModel.length - promptForSession.length),
     };
   }
-  const llmBoundaryPromptForPrecheck = normalizeCurrentPromptTextForLlmBoundary({
+  const llmBoundaryPromptForPrecheck = buildLlmBoundaryPromptForPrecheck({
     prompt: promptForModel,
-    ...(input.boundaryTimezone ? { timezone: input.boundaryTimezone } : {}),
-    ...(input.includeBoundaryTimestamp ? {} : { includeTimestamp: false }),
-    ...(typeof preparedUserTurnTimestamp === "number"
-      ? { currentUserTimestamp: preparedUserTurnTimestamp }
-      : {}),
-    // Admission must count the same persisted sender block that provider
-    // conversion projects after the active user turn is written.
-    ...(!input.isRawModelRun && input.preparedUserTurnMessage
-      ? { currentUserTranscriptMessage: input.preparedUserTurnMessage }
+    ...(input.boundaryTimezone ? { boundaryTimezone: input.boundaryTimezone } : {}),
+    includeBoundaryTimestamp: input.includeBoundaryTimestamp,
+    isRawModelRun: input.isRawModelRun,
+    ...(input.preparedUserTurnMessage
+      ? { preparedUserTurnMessage: input.preparedUserTurnMessage }
       : {}),
   });
 

--- a/src/agents/embedded-agent-runner/run/attempt-prompt-phase.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-prompt-phase.ts
@@ -207,12 +207,20 @@ export async function runEmbeddedAttemptPromptPhase(input: {
       });
       skipPromptSubmission = true;
     } else if (beforeAgentRunOutcome?.kind === "transform") {
-      // A transform decision redacts the model-bound prompt; feed that same
-      // redacted text to the transcript, cache/trajectory recording, and image
-      // detection too, so the redaction doesn't leak back in via history.
+      // A transform decision carries a security/redaction intent: what the
+      // model sees must also be what gets persisted to the transcript, cache/
+      // trajectory recording, and image detection, otherwise the raw text
+      // re-enters context on a later turn via session history.
       const transformedPrompt = beforeAgentRunOutcome.prompt;
+      const currentUserTimestampOverride = promptContext.currentUserTimestampOverride
+        ? {
+            timestamp: promptContext.currentUserTimestampOverride.timestamp,
+            text: transformedPrompt,
+          }
+        : undefined;
       promptContext = {
         ...promptContext,
+        ...(currentUserTimestampOverride ? { currentUserTimestampOverride } : {}),
         effectivePrompt: transformedPrompt,
         llmBoundaryPromptForPrecheck: buildLlmBoundaryPromptForPrecheck({
           prompt: transformedPrompt,
@@ -229,6 +237,9 @@ export async function runEmbeddedAttemptPromptPhase(input: {
         promptForSession: transformedPrompt,
         promptSubmission: { ...promptContext.promptSubmission, prompt: transformedPrompt },
       };
+      if (currentUserTimestampOverride) {
+        input.lifecycle.setCurrentUserTimestampOverride(currentUserTimestampOverride);
+      }
       if (input.context.systemPromptReport?.currentTurn) {
         input.context.systemPromptReport.currentTurn.promptChars = transformedPrompt.length;
       }

--- a/src/agents/embedded-agent-runner/run/attempt-prompt-phase.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-prompt-phase.ts
@@ -10,7 +10,10 @@ import { log } from "../logger.js";
 import { resolveEmbeddedAgentApiKey } from "../stream-resolution.js";
 import { runEmbeddedAttemptBeforeAgentRun } from "./attempt-before-agent-run.js";
 import { prepareEmbeddedAttemptPromptAssembly } from "./attempt-prompt-assembly.js";
-import { prepareEmbeddedAttemptPromptContext } from "./attempt-prompt-context.js";
+import {
+  buildLlmBoundaryPromptForPrecheck,
+  prepareEmbeddedAttemptPromptContext,
+} from "./attempt-prompt-context.js";
 import { dispatchEmbeddedAttemptPrompt } from "./attempt-prompt-dispatch.js";
 import { handleEmbeddedAttemptPromptError } from "./attempt-prompt-error.js";
 import { handleEmbeddedAttemptMidTurnPrecheck } from "./attempt-prompt-preflight.js";
@@ -26,6 +29,7 @@ type PromptErrorInput = Parameters<typeof handleEmbeddedAttemptPromptError>[0];
 type BeforeAgentRunOutcome = NonNullable<
   Awaited<ReturnType<typeof runEmbeddedAttemptBeforeAgentRun>>
 >;
+type BeforeAgentRunBlockOutcome = Extract<BeforeAgentRunOutcome, { kind: "block" }>;
 type PromptPhaseState = Omit<PromptDispatchInput["state"], "skipPromptSubmission">;
 
 type PromptAssemblyPhaseInput = Omit<
@@ -80,7 +84,7 @@ export async function runEmbeddedAttemptPromptPhase(input: {
       changes: PromptAssemblyResult["promptCacheChangesForTurn"],
     ) => void;
     setFinalPromptText: (prompt: string) => void;
-    markBeforeAgentRunBlocked: (outcome: BeforeAgentRunOutcome) => void;
+    markBeforeAgentRunBlocked: (outcome: BeforeAgentRunBlockOutcome) => void;
     markYieldAborted: () => void;
     readYieldState: () => Pick<
       PromptErrorInput,
@@ -168,7 +172,7 @@ export async function runEmbeddedAttemptPromptPhase(input: {
             }),
           )
         : undefined;
-    const promptContext = prepareEmbeddedAttemptPromptContext({
+    let promptContext = prepareEmbeddedAttemptPromptContext({
       attempt,
       ...(heartbeatOutcomeContext ? { heartbeatOutcomeContext } : {}),
       messages: activeSession.messages,
@@ -195,13 +199,39 @@ export async function runEmbeddedAttemptPromptPhase(input: {
             systemPrompt: systemPromptForHook,
             withOwnedSessionWriteLock: input.withOwnedSessionWriteLock,
           });
-    if (beforeAgentRunOutcome) {
+    if (beforeAgentRunOutcome?.kind === "block") {
       input.lifecycle.markBeforeAgentRunBlocked(beforeAgentRunOutcome);
       patchState({
         promptError: beforeAgentRunOutcome.promptError,
         promptErrorSource: "hook:before_agent_run",
       });
       skipPromptSubmission = true;
+    } else if (beforeAgentRunOutcome?.kind === "transform") {
+      // A transform decision redacts the model-bound prompt; feed that same
+      // redacted text to the transcript, cache/trajectory recording, and image
+      // detection too, so the redaction doesn't leak back in via history.
+      const transformedPrompt = beforeAgentRunOutcome.prompt;
+      promptContext = {
+        ...promptContext,
+        effectivePrompt: transformedPrompt,
+        llmBoundaryPromptForPrecheck: buildLlmBoundaryPromptForPrecheck({
+          prompt: transformedPrompt,
+          ...(input.context.boundaryTimezone
+            ? { boundaryTimezone: input.context.boundaryTimezone }
+            : {}),
+          includeBoundaryTimestamp: input.context.includeBoundaryTimestamp,
+          isRawModelRun: input.context.isRawModelRun,
+          ...(input.context.preparedUserTurnMessage
+            ? { preparedUserTurnMessage: input.context.preparedUserTurnMessage }
+            : {}),
+        }),
+        promptForModel: transformedPrompt,
+        promptForSession: transformedPrompt,
+        promptSubmission: { ...promptContext.promptSubmission, prompt: transformedPrompt },
+      };
+      if (input.context.systemPromptReport?.currentTurn) {
+        input.context.systemPromptReport.currentTurn.promptChars = transformedPrompt.length;
+      }
     }
 
     if (!skipPromptSubmission) {

--- a/src/agents/embedded-agent-runner/run/attempt.spawn-workspace.context-engine.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.spawn-workspace.context-engine.test.ts
@@ -18,6 +18,12 @@ import {
 import { createUserTurnTranscriptRecorder } from "../../../sessions/user-turn-transcript.js";
 import { projectAgentRunAttemptTerminal } from "../../agent-run-terminal-outcome.js";
 import {
+  onInternalDiagnosticEvent,
+  resetDiagnosticEventsForTest,
+  waitForDiagnosticEventsDrained,
+  type DiagnosticEventPayload,
+} from "../../../infra/diagnostic-events.js";
+import {
   addSubagentRunForTests,
   leasePendingAgentSteeringItems,
   releasePendingAgentSteeringItems,
@@ -2336,6 +2342,127 @@ describe("runEmbeddedAttempt context engine sessionKey forwarding", () => {
     expect(projectAgentRunAttemptTerminal(result.terminal).promptErrorSource).toBe(
       "hook:before_agent_run",
     );
+  });
+
+  it("uses before_agent_run transform only at the model boundary", async () => {
+    const sensitivePrompt = "Hi OpenClaw, my credit card is 4111111111111111";
+    const redactedPrompt = "Hi OpenClaw, my credit card is [CreditCardNumber]";
+    const runBeforeAgentRun = vi.fn(async () => ({
+      pluginId: "redactor",
+      decision: {
+        outcome: "transform" as const,
+        prompt: redactedPrompt,
+        reason: "redacted payment card",
+      },
+    }));
+    const runLlmInput = vi.fn(async () => {});
+    hoisted.getGlobalHookRunnerMock.mockReturnValue({
+      hasHooks: vi.fn((name: string) => name === "before_agent_run" || name === "llm_input"),
+      runBeforeAgentRun,
+      runLlmInput,
+    });
+    let transcriptPrompt: string | undefined;
+    let providerMessages: unknown[] = [];
+    const contextAssembledEvents: DiagnosticEventPayload[] = [];
+    resetDiagnosticEventsForTest();
+    const stopDiagnostics = onInternalDiagnosticEvent((event) => {
+      if (event.type === "context.assembled") {
+        contextAssembledEvents.push(event);
+      }
+    });
+
+    try {
+      const result = await createContextEngineAttemptRunner({
+        contextEngine: createContextEngineBootstrapAndAssemble(),
+        sessionKey,
+        tempPaths,
+        trajectory: true,
+        attemptOverrides: {
+          prompt: sensitivePrompt,
+        },
+        sessionPrompt: async (session, prompt) => {
+          transcriptPrompt = prompt;
+          const transformContext = (
+            session.agent as {
+              transformContext?: (messages: AgentMessage[]) => Promise<AgentMessage[]>;
+            }
+          ).transformContext;
+          if (!transformContext) {
+            throw new Error("expected model prompt transform");
+          }
+          providerMessages = await transformContext([
+            ...session.messages,
+            {
+              role: "user",
+              content: [{ type: "text", text: prompt }],
+              timestamp: 2,
+            } as AgentMessage,
+          ]);
+          session.messages = [...session.messages, doneMessage];
+        },
+      });
+      await waitForDiagnosticEventsDrained();
+
+      expect(transcriptPrompt).toBe(sensitivePrompt);
+      expect(result.finalPromptText).toBe(redactedPrompt);
+      expect(JSON.stringify(result)).not.toContain("4111111111111111");
+      expect(JSON.stringify(providerMessages)).toContain(redactedPrompt);
+      const contextAssembled = findRecord(
+        contextAssembledEvents as Array<Record<string, unknown>>,
+        (event) => event.type === "context.assembled",
+        "context assembled diagnostic",
+      );
+      expect(contextAssembled.promptChars).toBe(redactedPrompt.length);
+      expect(JSON.stringify(contextAssembled)).not.toContain("4111111111111111");
+      const llmInputEvent = mockParams(runLlmInput as MockCallSource, 0, "llm_input params");
+      expect(llmInputEvent.prompt).toContain("[CreditCardNumber]");
+      expect(JSON.stringify(llmInputEvent)).not.toContain("4111111111111111");
+      const imageDetectionInput = requireRecord(
+        mockArg(hoisted.detectAndLoadPromptImagesMock, 0, 0, "image detection input"),
+        "image detection input",
+      );
+      expect(imageDetectionInput.prompt).toContain("[CreditCardNumber]");
+      expect(JSON.stringify(imageDetectionInput)).not.toContain("4111111111111111");
+      const trajectoryEvents = (
+        await fs.readFile(path.join(tempPaths[0] ?? "", "session.trajectory.jsonl"), "utf8")
+      )
+        .trim()
+        .split("\n")
+        .map((line) => JSON.parse(line) as TrajectoryEvent);
+      const modelBoundEvents = trajectoryEvents.filter((event) =>
+        ["context.compiled", "prompt.submitted", "model.completed", "trace.artifacts"].includes(
+          event.type ?? "",
+        ),
+      );
+      expect(JSON.stringify(modelBoundEvents)).toContain("[CreditCardNumber]");
+      expect(JSON.stringify(modelBoundEvents)).not.toContain("4111111111111111");
+      const contextCompiled = findRecord(
+        modelBoundEvents as Array<Record<string, unknown>>,
+        (event) => event.type === "context.compiled",
+        "context compiled event",
+      );
+      expect(requireRecord(contextCompiled.data, "context compiled data").prompt).toBe(
+        redactedPrompt,
+      );
+      const modelCompleted = findRecord(
+        modelBoundEvents as Array<Record<string, unknown>>,
+        (event) => event.type === "model.completed",
+        "model completed event",
+      );
+      expect(requireRecord(modelCompleted.data, "model completed data").finalPromptText).toBe(
+        redactedPrompt,
+      );
+      const traceArtifacts = findRecord(
+        modelBoundEvents as Array<Record<string, unknown>>,
+        (event) => event.type === "trace.artifacts",
+        "trace artifacts event",
+      );
+      expect(requireRecord(traceArtifacts.data, "trace artifacts data").finalPromptText).toBe(
+        redactedPrompt,
+      );
+    } finally {
+      stopDiagnostics();
+    }
   });
 
   it("uses assembled context as the default precheck authority", async () => {

--- a/src/agents/embedded-agent-runner/run/attempt.spawn-workspace.context-engine.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.spawn-workspace.context-engine.test.ts
@@ -12,17 +12,17 @@ import {
 import type { OpenClawConfig } from "../../../config/types.js";
 import { buildMemorySystemPromptAddition } from "../../../context-engine/delegate.js";
 import {
-  clearMemoryPluginState,
-  registerTestMemoryPromptBuilder,
-} from "../../../plugins/memory-state.test-fixtures.js";
-import { createUserTurnTranscriptRecorder } from "../../../sessions/user-turn-transcript.js";
-import { projectAgentRunAttemptTerminal } from "../../agent-run-terminal-outcome.js";
-import {
   onInternalDiagnosticEvent,
   resetDiagnosticEventsForTest,
   waitForDiagnosticEventsDrained,
   type DiagnosticEventPayload,
 } from "../../../infra/diagnostic-events.js";
+import {
+  clearMemoryPluginState,
+  registerTestMemoryPromptBuilder,
+} from "../../../plugins/memory-state.test-fixtures.js";
+import { createUserTurnTranscriptRecorder } from "../../../sessions/user-turn-transcript.js";
+import { projectAgentRunAttemptTerminal } from "../../agent-run-terminal-outcome.js";
 import {
   addSubagentRunForTests,
   leasePendingAgentSteeringItems,
@@ -2426,12 +2426,7 @@ describe("runEmbeddedAttempt context engine sessionKey forwarding", () => {
       );
       expect(imageDetectionInput.prompt).toContain("[CreditCardNumber]");
       expect(JSON.stringify(imageDetectionInput)).not.toContain("4111111111111111");
-      const trajectoryEvents = (
-        await fs.readFile(path.join(tempPaths[0] ?? "", "session.trajectory.jsonl"), "utf8")
-      )
-        .trim()
-        .split("\n")
-        .map((line) => JSON.parse(line) as TrajectoryEvent);
+      const trajectoryEvents = await readTrajectoryEvents(tempPaths);
       const modelBoundEvents = trajectoryEvents.filter((event) =>
         ["context.compiled", "prompt.submitted", "model.completed", "trace.artifacts"].includes(
           event.type ?? "",

--- a/src/agents/embedded-agent-runner/run/attempt.spawn-workspace.context-engine.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.spawn-workspace.context-engine.test.ts
@@ -2391,7 +2391,7 @@ describe("runEmbeddedAttempt context engine sessionKey forwarding", () => {
             throw new Error("expected model prompt transform");
           }
           providerMessages = await transformContext([
-            ...session.messages,
+            ...(session.messages as AgentMessage[]),
             {
               role: "user",
               content: [{ type: "text", text: prompt }],

--- a/src/agents/embedded-agent-runner/run/attempt.spawn-workspace.context-engine.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.spawn-workspace.context-engine.test.ts
@@ -2344,7 +2344,7 @@ describe("runEmbeddedAttempt context engine sessionKey forwarding", () => {
     );
   });
 
-  it("uses before_agent_run transform only at the model boundary", async () => {
+  it("uses before_agent_run transform at both the model boundary and the session transcript", async () => {
     const sensitivePrompt = "Hi OpenClaw, my credit card is 4111111111111111";
     const redactedPrompt = "Hi OpenClaw, my credit card is [CreditCardNumber]";
     const runBeforeAgentRun = vi.fn(async () => ({
@@ -2382,28 +2382,31 @@ describe("runEmbeddedAttempt context engine sessionKey forwarding", () => {
         },
         sessionPrompt: async (session, prompt) => {
           transcriptPrompt = prompt;
+          // A redacted transform now writes the same text to the transcript and
+          // the model boundary, so no transformContext swap is installed here;
+          // the messages already carry the redacted content.
           const transformContext = (
             session.agent as {
               transformContext?: (messages: AgentMessage[]) => Promise<AgentMessage[]>;
             }
           ).transformContext;
-          if (!transformContext) {
-            throw new Error("expected model prompt transform");
-          }
-          providerMessages = await transformContext([
+          const currentTurnMessages = [
             ...(session.messages as AgentMessage[]),
             {
               role: "user",
               content: [{ type: "text", text: prompt }],
               timestamp: 2,
             } as AgentMessage,
-          ]);
+          ];
+          providerMessages = transformContext
+            ? await transformContext(currentTurnMessages)
+            : currentTurnMessages;
           session.messages = [...session.messages, doneMessage];
         },
       });
       await waitForDiagnosticEventsDrained();
 
-      expect(transcriptPrompt).toBe(sensitivePrompt);
+      expect(transcriptPrompt).toBe(redactedPrompt);
       expect(result.finalPromptText).toBe(redactedPrompt);
       expect(JSON.stringify(result)).not.toContain("4111111111111111");
       expect(JSON.stringify(providerMessages)).toContain(redactedPrompt);

--- a/src/plugins/hook-decision-types.test.ts
+++ b/src/plugins/hook-decision-types.test.ts
@@ -1,11 +1,19 @@
 /** Verifies hook decision type guards and normalization helpers. */
 import { describe, expect, it } from "vitest";
-import { isHookDecision } from "./hook-decision-types.js";
+import {
+  BLOCK_MESSAGE_PREFIX,
+  type HookDecision,
+  type HookDecisionBlock,
+  mergeHookDecisions,
+  isHookDecision,
+  resolveBlockMessage,
+} from "./hook-decision-types.js";
 
 describe("HookDecision helpers", () => {
   describe("isHookDecision", () => {
     it("recognizes supported outcomes", () => {
       expect(isHookDecision({ outcome: "pass" })).toBe(true);
+      expect(isHookDecision({ outcome: "transform", prompt: "redacted prompt" })).toBe(true);
       expect(isHookDecision({ outcome: "block", reason: "policy" })).toBe(true);
     });
 
@@ -18,12 +26,69 @@ describe("HookDecision helpers", () => {
       expect(isHookDecision({ outcome: "invalid" })).toBe(false);
       expect(isHookDecision({ outcome: "pass", message: "typo" })).toBe(false);
       expect(isHookDecision({ outcome: "pass", reason: "typo" })).toBe(false);
+      expect(isHookDecision({ outcome: "transform" })).toBe(false);
+      expect(isHookDecision({ outcome: "transform", prompt: "" })).toBe(false);
+      expect(isHookDecision({ outcome: "transform", prompt: "safe", messages: [] })).toBe(false);
+      expect(isHookDecision({ outcome: "transform", prompt: "safe", metadata: [] })).toBe(false);
       expect(isHookDecision({ outcome: "block" })).toBe(false);
       expect(isHookDecision({ outcome: "block", reason: "" })).toBe(false);
       expect(isHookDecision({ outcome: "block", reason: "policy", message: "" })).toBe(false);
       expect(isHookDecision({ outcome: "block", reason: "policy", message: 3 })).toBe(false);
       expect(isHookDecision({ outcome: "block", reason: "policy", ask: true })).toBe(false);
       expect(isHookDecision({ outcome: "block", reason: "policy", metadata: [] })).toBe(false);
+    });
+  });
+
+  describe("mergeHookDecisions", () => {
+    const passDecision: HookDecision = { outcome: "pass" };
+    const transformDecision: HookDecision = { outcome: "transform", prompt: "redacted prompt" };
+    const blockDecision: HookDecision = { outcome: "block", reason: "policy" };
+
+    it("uses most-restrictive-wins ordering", () => {
+      expect(mergeHookDecisions(undefined, passDecision)).toBe(passDecision);
+      expect(mergeHookDecisions(passDecision, transformDecision)).toBe(transformDecision);
+      expect(mergeHookDecisions(transformDecision, passDecision)).toBe(transformDecision);
+      expect(mergeHookDecisions(transformDecision, blockDecision)).toBe(blockDecision);
+      expect(mergeHookDecisions(blockDecision, transformDecision)).toBe(blockDecision);
+      expect(mergeHookDecisions(passDecision, blockDecision)).toBe(blockDecision);
+      expect(mergeHookDecisions(blockDecision, passDecision)).toBe(blockDecision);
+    });
+
+    it("keeps the first decision when outcomes have the same severity", () => {
+      const secondBlock: HookDecision = { outcome: "block", reason: "second" };
+      const secondTransform: HookDecision = { outcome: "transform", prompt: "second" };
+
+      expect(mergeHookDecisions(passDecision, { outcome: "pass" })).toBe(passDecision);
+      expect(mergeHookDecisions(transformDecision, secondTransform)).toBe(transformDecision);
+      expect(mergeHookDecisions(blockDecision, secondBlock)).toBe(blockDecision);
+    });
+  });
+
+  describe("resolveBlockMessage", () => {
+    it("returns explicit or default block messages", () => {
+      const explicit: HookDecisionBlock = {
+        outcome: "block",
+        reason: "policy",
+        message: "Please rephrase your request.",
+      };
+      const fallback: HookDecisionBlock = {
+        outcome: "block",
+        reason: "policy",
+      };
+
+      expect(resolveBlockMessage(explicit)).toBe(
+        `${BLOCK_MESSAGE_PREFIX}: Please rephrase your request.`,
+      );
+      expect(resolveBlockMessage(fallback)).toBe(`${BLOCK_MESSAGE_PREFIX}: blocked`);
+      expect(resolveBlockMessage(fallback, { blockedBy: "policy-plugin" })).toBe(
+        `${BLOCK_MESSAGE_PREFIX}: blocked by policy-plugin`,
+      );
+      expect(resolveBlockMessage(explicit, { blockedBy: "policy-plugin" })).toBe(
+        `${BLOCK_MESSAGE_PREFIX}: Please rephrase your request. (blocked by policy-plugin)`,
+      );
+      expect(resolveBlockMessage({ ...explicit, message: "   " })).toBe(
+        `${BLOCK_MESSAGE_PREFIX}: blocked`,
+      );
     });
   });
 });

--- a/src/plugins/hook-decision-types.ts
+++ b/src/plugins/hook-decision-types.ts
@@ -30,13 +30,14 @@ export type HookDecisionBlock = {
 };
 
 /**
- * Content can proceed after replacing the current model-bound prompt. The
- * replacement is sent to the model and model-input observers; it does not
- * rewrite the stored transcript prompt.
+ * Content can proceed after replacing the current user prompt. The
+ * replacement is sent to the model, model-input observers, and the stored
+ * session transcript, so the original text does not re-enter context on a
+ * later turn.
  */
 export type HookDecisionTransform = {
   outcome: "transform";
-  /** Replacement text for the current model-bound user prompt. */
+  /** Replacement text for the current user prompt. */
   prompt: string;
   /** Internal plugin-local reason. Do not expose verbatim. */
   reason?: string;

--- a/src/plugins/hook-decision-types.ts
+++ b/src/plugins/hook-decision-types.ts
@@ -3,21 +3,21 @@
  * Core is outcome-agnostic — it handles the mechanics of each outcome
  * without knowing *why* the decision was made.
  */
-type HookDecision = HookDecisionPass | HookDecisionBlock;
+export type HookDecision = HookDecisionPass | HookDecisionTransform | HookDecisionBlock;
 
 /** Content is fine. Proceed normally. */
-type HookDecisionPass = {
+export type HookDecisionPass = {
   outcome: "pass";
 };
 
 /** Prefix for user-facing replacement messages when a `block` decision stops a request. */
-const BLOCK_MESSAGE_PREFIX = "Your message could not be sent";
+export const BLOCK_MESSAGE_PREFIX = "Your message could not be sent";
 
 /**
  * Content is blocked. `reason` is internal plugin-local detail; core must not log,
  * persist, broadcast, or expose it verbatim. `message` is user-facing detail.
  */
-type HookDecisionBlock = {
+export type HookDecisionBlock = {
   outcome: "block";
   /** Internal plugin-local reason. Do not log, persist, broadcast, or expose verbatim. */
   reason: string;
@@ -25,6 +25,21 @@ type HookDecisionBlock = {
   message?: string;
   /** Plugin-defined category for analytics (e.g. "violence", "pii", "cost_limit"). */
   category?: string;
+  /** Opaque metadata for the plugin's own use. Core does not interpret it. */
+  metadata?: Record<string, unknown>;
+};
+
+/**
+ * Content can proceed after replacing the current model-bound prompt. The
+ * replacement is sent to the model and model-input observers; it does not
+ * rewrite the stored transcript prompt.
+ */
+export type HookDecisionTransform = {
+  outcome: "transform";
+  /** Replacement text for the current model-bound user prompt. */
+  prompt: string;
+  /** Internal plugin-local reason. Do not expose verbatim. */
+  reason?: string;
   /** Opaque metadata for the plugin's own use. Core does not interpret it. */
   metadata?: Record<string, unknown>;
 };
@@ -45,6 +60,24 @@ export function resolveBlockMessage(
     : `${BLOCK_MESSAGE_PREFIX}: blocked`;
 }
 
+/** Outcome severity for most-restrictive-wins merging. Higher = more restrictive. */
+export const HOOK_DECISION_SEVERITY: Record<HookDecision["outcome"], number> = {
+  pass: 0,
+  transform: 1,
+  block: 2,
+};
+
+/**
+ * Merge two HookDecisions using most-restrictive-wins semantics.
+ * `block > transform > pass`
+ */
+export function mergeHookDecisions(a: HookDecision | undefined, b: HookDecision): HookDecision {
+  if (!a) {
+    return b;
+  }
+  return HOOK_DECISION_SEVERITY[b.outcome] > HOOK_DECISION_SEVERITY[a.outcome] ? b : a;
+}
+
 /**
  * Type guard: does this object look like a HookDecision (has `outcome` field)?
  */
@@ -56,6 +89,25 @@ export function isHookDecision(value: unknown): value is HookDecision {
   const keys = Object.keys(v);
   if (v.outcome === "pass") {
     return keys.length === 1;
+  }
+  if (v.outcome === "transform") {
+    const allowedTransformKeys = new Set(["outcome", "prompt", "reason", "metadata"]);
+    if (keys.some((key) => !allowedTransformKeys.has(key))) {
+      return false;
+    }
+    if (typeof v.prompt !== "string" || !v.prompt.trim()) {
+      return false;
+    }
+    if ("reason" in v && (typeof v.reason !== "string" || !v.reason.trim())) {
+      return false;
+    }
+    if (
+      "metadata" in v &&
+      (typeof v.metadata !== "object" || v.metadata === null || Array.isArray(v.metadata))
+    ) {
+      return false;
+    }
+    return true;
   }
   if (v.outcome !== "block") {
     return false;
@@ -83,7 +135,7 @@ export function isHookDecision(value: unknown): value is HookDecision {
 }
 
 /** Outcomes valid for input gates (before_agent_run). */
-export type InputGateDecision = HookDecisionPass | HookDecisionBlock;
+export type InputGateDecision = HookDecisionPass | HookDecisionTransform | HookDecisionBlock;
 
 /**
  * A gate hook decision paired with the pluginId that produced it.

--- a/src/plugins/hook-lifecycle-gates.test.ts
+++ b/src/plugins/hook-lifecycle-gates.test.ts
@@ -107,6 +107,85 @@ describe("before_agent_run hook", () => {
     expect(calls).toEqual(["pass-plugin", "block-plugin"]);
   });
 
+  it("returns the first transform when no handler blocks", async () => {
+    const firstTransform = vi.fn(async () => ({
+      outcome: "transform" as const,
+      prompt: "Hi OpenClaw, my card is [CreditCardNumber]",
+      reason: "redacted sensitive data",
+    }));
+    const secondTransform = vi.fn(async () => ({
+      outcome: "transform" as const,
+      prompt: "second replacement",
+    }));
+    const registry = makeRegistry([
+      {
+        pluginId: "first-redactor",
+        hookName: "before_agent_run",
+        handler: firstTransform,
+        source: "test",
+        priority: 10,
+      },
+      {
+        pluginId: "second-redactor",
+        hookName: "before_agent_run",
+        handler: secondTransform,
+        source: "test",
+        priority: 5,
+      },
+    ]);
+    const runner = createHookRunner(registry);
+    const result = await runner.runBeforeAgentRun(
+      { prompt: "Hi OpenClaw, my card is 4111111111111111", messages: [] },
+      ctx,
+    );
+
+    expect(result).toEqual({
+      pluginId: "first-redactor",
+      decision: {
+        outcome: "transform",
+        prompt: "Hi OpenClaw, my card is [CreditCardNumber]",
+        reason: "redacted sensitive data",
+      },
+    });
+    expect(firstTransform).toHaveBeenCalledTimes(1);
+    expect(secondTransform).toHaveBeenCalledTimes(1);
+  });
+
+  it("lets block beat an earlier transform", async () => {
+    const registry = makeRegistry([
+      {
+        pluginId: "redactor",
+        hookName: "before_agent_run",
+        handler: async () => ({
+          outcome: "transform" as const,
+          prompt: "redacted prompt",
+        }),
+        source: "test",
+        priority: 10,
+      },
+      {
+        pluginId: "blocker",
+        hookName: "before_agent_run",
+        handler: async () => ({
+          outcome: "block" as const,
+          reason: "still unsafe",
+        }),
+        source: "test",
+        priority: 5,
+      },
+    ]);
+    const runner = createHookRunner(registry);
+    const result = await runner.runBeforeAgentRun({ prompt: "secret prompt", messages: [] }, ctx);
+
+    expect(result).toEqual({
+      pluginId: "blocker",
+      decision: {
+        outcome: "block",
+        reason: "still unsafe",
+      },
+    });
+  });
+
   it("short-circuits when the first of multiple handlers blocks", async () => {
     const blockHandler = vi.fn(async () => ({
       outcome: "block" as const,
@@ -210,6 +289,26 @@ describe("before_agent_run hook", () => {
         reason: "before_agent_run returned an invalid decision",
       },
       pluginId: "malformed-block-plugin",
+    });
+  });
+
+  it("fails closed on malformed transform decisions", async () => {
+    const registry = makeRegistry([
+      {
+        pluginId: "malformed-transform-plugin",
+        hookName: "before_agent_run",
+        handler: async () => ({ outcome: "transform", prompt: "" }) as never,
+        source: "test",
+      },
+    ]);
+    const runner = createHookRunner(registry);
+    const result = await runner.runBeforeAgentRun({ prompt: "test", messages: [] }, ctx);
+    expect(result).toEqual({
+      decision: {
+        outcome: "block",
+        reason: "before_agent_run returned an invalid decision",
+      },
+      pluginId: "malformed-transform-plugin",
     });
   });
 

--- a/src/plugins/hook-types.ts
+++ b/src/plugins/hook-types.ts
@@ -1157,8 +1157,8 @@ export type PluginHookBeforeAgentRunEvent = {
   senderIsOwner?: boolean;
 };
 
-/** Result type for before_agent_run. Returns pass/block or void (= pass). */
-type PluginHookBeforeAgentRunResult = InputGateDecision | void;
+/** Result type for before_agent_run. Returns pass/transform/block or void (= pass). */
+export type PluginHookBeforeAgentRunResult = InputGateDecision | void;
 
 export type PluginHookResolveExecEnvEvent = {
   sessionKey?: string;

--- a/src/plugins/hooks.ts
+++ b/src/plugins/hooks.ts
@@ -14,6 +14,7 @@ import {
   type GateHookResult,
   type InputGateDecision,
   isHookDecision,
+  mergeHookDecisions,
 } from "./hook-decision-types.js";
 import type { GlobalHookRunnerRegistry, HookRunnerRegistry } from "./hook-registry.types.js";
 import type {
@@ -1119,7 +1120,7 @@ export function createHookRunner(
   /**
    * Run before_agent_run gate hook.
    * Fires after session resolution and workspace preparation, before model inference.
-   * Returns the most-restrictive pass/block decision from all handlers.
+   * Returns the most-restrictive pass/transform/block decision from all handlers.
    * Handlers that return void are treated as pass.
    */
   async function runBeforeAgentRun(
@@ -1147,10 +1148,7 @@ export function createHookRunner(
                 outcome: "block",
                 reason: "before_agent_run returned an invalid decision",
               };
-          const merged =
-            !_acc || (normalized.outcome === "block" && _acc.outcome !== "block")
-              ? normalized
-              : _acc;
+          const merged = mergeHookDecisions(_acc, normalized) as InputGateDecision;
           if (merged === normalized) {
             winningPluginId = reg.pluginId;
           }

--- a/src/sessions/user-turn-transcript.ts
+++ b/src/sessions/user-turn-transcript.ts
@@ -518,6 +518,7 @@ export function createUserTurnTranscriptRecorder(
     expectedSessionState?: SessionTranscriptTurnPersistOptions["expectedSessionState"];
     sessionLifecyclePatch?: SessionTranscriptTurnPersistOptions["sessionLifecyclePatch"];
     retryIfUnpersisted?: boolean;
+    overrideMessage?: PersistedUserTurnMessage;
   }): Promise<UserTurnTranscriptPersistResult | undefined> => {
     if (options.skipWhenBlocked && blocked) {
       return undefined;
@@ -542,7 +543,8 @@ export function createUserTurnTranscriptRecorder(
       selfPersistencePromise = undefined;
     }
     const persistencePromise = (async () => {
-      const resolvedMessage = options.message ?? (await resolveMessageForPersistence());
+      const resolvedMessage =
+        options.overrideMessage ?? options.message ?? (await resolveMessageForPersistence());
       if (!resolvedMessage) {
         return undefined;
       }
@@ -664,6 +666,7 @@ export function createUserTurnTranscriptRecorder(
         expectedSessionState: options?.expectedSessionState,
         sessionLifecyclePatch: options?.sessionLifecyclePatch,
         retryIfUnpersisted: options?.retryIfUnpersisted,
+        overrideMessage: options?.overrideMessage,
       }),
     persistBlocked: async (blockedMessage, options) => {
       blocked = true;

--- a/src/sessions/user-turn-transcript.types.ts
+++ b/src/sessions/user-turn-transcript.types.ts
@@ -152,6 +152,12 @@ export type UserTurnTranscriptRecorder = {
     sessionLifecyclePatch?: SessionTranscriptTurnLifecyclePatch;
     /** Allow a later explicit persistence attempt when this attempt appends nothing. */
     retryIfUnpersisted?: boolean;
+    /**
+     * Persists this message instead of the recorder's captured input. Used by
+     * before_agent_run transform decisions, which redact after the recorder
+     * already captured the raw message.
+     */
+    overrideMessage?: PersistedUserTurnMessage;
   }) => Promise<UserTurnTranscriptPersistResult | undefined>;
   persistBlocked: (
     message: PersistedUserTurnMessage,


### PR DESCRIPTION
Closes #96656 (reopens with the redesigned fix)

## What Problem This Solves

Plugins can register a `before_agent_run` hook that returns `{ outcome: "transform", prompt }` to redact or rewrite a user's prompt before it reaches the model — for example, masking a credit card number. Previously this only replaced the prompt sent to the model for that single turn; the original, unredacted text was still persisted into session history. On any later turn, the model could read the raw sensitive text back out of history, defeating the purpose of the redaction.

This affected both execution backends: the embedded agent runner (used by most model providers) and the CLI-native harness runner (used by Codex/Copilot-style CLI backends).

## Why This Change Was Made

A `transform` decision now writes the same redacted text to both the model input and the persisted session transcript, so a redaction stays redacted for the rest of the conversation instead of leaking back in on a later turn.

- Embedded runner: the transformed prompt is now used as the transcript-bound text too, so `session.prompt(...)` persists the redacted version. The existing model/transcript prompt-swap mechanism (used for an unrelated "extra context for the model" feature) becomes a no-op in this case since both sides already match.
- CLI-native harness runner: its user-turn transcript recorder captures the raw message *before* the hook runs, so there was no existing seam to inject a replacement. Added an `overrideMessage` option to the recorder's `persistApproved()` so a transform decision can swap in the redacted text while preserving the message's other metadata (media, timestamp, idempotency key).

Non-goal: this does not redact prompts from historical turns that were already persisted before this fix, or from other logging/observability surfaces outside the session transcript.

## User Impact

Plugin authors building guardrail/redaction plugins (e.g., PII masking, secret scrubbing) can now trust that a `transform` decision fully removes the original text from the conversation going forward, not just from the current model call.

## Evidence

Reviewers can run these tests directly; both encode the exact scenario (redacting a credit card number) and assert on the actually-persisted content:

```bash
pnpm test src/agents/embedded-agent-runner/run/attempt.spawn-workspace.context-engine.test.ts
pnpm test src/agents/cli-runner.reliability.test.ts
```

`attempt.spawn-workspace.context-engine.test.ts` → `uses before_agent_run transform at both the model boundary and the session transcript` asserts the transcript-bound prompt captured via `sessionPrompt` equals the redacted text, not the original.

`cli-runner.reliability.test.ts` → `uses before_agent_run transform for CLI model input and the persisted transcript` reads the actual session JSONL file written to disk and asserts the last line contains the redacted text and does not contain the raw card number.

Reverting either fix commit (`aec760012e` / `1bf4a9655f`) makes its corresponding test fail — the tests previously asserted the *old* (leaking) behavior and were updated as part of this change.

### Manual reproduction

Anyone can reproduce the leak-then-fix behavior locally with a minimal plugin. Save as `~/.openclaw/extensions/demo-pii-redact/index.js` (plus a sibling `package.json` with `"openclaw": { "extensions": ["./index.js"] }` and an `openclaw.plugin.json` with `id`, `name`, and an empty `configSchema`):

```js
const CREDIT_CARD_RE = /\b(?:\d{4}[-\s]?){3}\d{4}\b/g;

export default {
  id: "demo-pii-redact",
  register(api) {
    api.on("before_agent_run", async (event) => {
      const redacted = event.prompt.replace(CREDIT_CARD_RE, "[CreditCardNumber]");
      if (redacted === event.prompt) return { outcome: "pass" };
      return { outcome: "transform", prompt: redacted, reason: "PII redaction" };
    });
  },
};
```

Then:

```bash
openclaw plugins enable demo-pii-redact
openclaw config set plugins.entries.demo-pii-redact.hooks.allowConversationAccess true --strict-json
openclaw chat
```

Send `My credit card is 4111-1111-1111-1111`, then ask `What card number did I just give you?` in the same session. Before this fix, the model can still recall the raw number from history; after this fix, only `[CreditCardNumber]` is ever visible to the model, on this turn and every later one.
