### PR TITLE
fix: emit plugin LLM usage diagnostics

### DIFF
--- a/docs/gateway/opentelemetry.md
+++ b/docs/gateway/opentelemetry.md
@@ -205,9 +205,9 @@ on the public diagnostic event bus.
 
 ### Model usage
 
-- `openclaw.tokens` (counter, attrs: `openclaw.token`, `openclaw.channel`, `openclaw.provider`, `openclaw.model`, `openclaw.agent`)
-- `openclaw.cost.usd` (counter, attrs: `openclaw.channel`, `openclaw.provider`, `openclaw.model`)
-- `openclaw.run.duration_ms` (histogram, attrs: `openclaw.channel`, `openclaw.provider`, `openclaw.model`)
+- `openclaw.tokens` (counter, attrs: `openclaw.token`, `openclaw.channel`, `openclaw.provider`, `openclaw.model`, `openclaw.agent`, `openclaw.plugin`)
+- `openclaw.cost.usd` (counter, attrs: `openclaw.channel`, `openclaw.provider`, `openclaw.model`, `openclaw.plugin`)
+- `openclaw.run.duration_ms` (histogram, attrs: `openclaw.channel`, `openclaw.provider`, `openclaw.model`, `openclaw.plugin`)
 - `openclaw.context.tokens` (histogram, attrs: `openclaw.context`, `openclaw.channel`, `openclaw.provider`, `openclaw.model`)
 - `gen_ai.client.token.usage` (histogram, GenAI semantic-conventions metric, attrs: `gen_ai.token.type` = `input`/`output`, `gen_ai.provider.name`, `gen_ai.operation.name`, `gen_ai.request.model`)
 - `gen_ai.client.operation.duration` (histogram, seconds, GenAI semantic-conventions metric, attrs: `gen_ai.provider.name`, `gen_ai.operation.name`, `gen_ai.request.model`, optional `error.type`)
@@ -328,7 +328,7 @@ Liveness warnings also emit:
 ## Exported spans
 
 - `openclaw.model.usage`
-  - `openclaw.channel`, `openclaw.provider`, `openclaw.model`
+  - `openclaw.channel`, `openclaw.provider`, `openclaw.model`, `openclaw.plugin`
   - `openclaw.tokens.*` (input/output/cache_read/cache_write/total)
   - `gen_ai.system` by default, or `gen_ai.provider.name` when the latest GenAI semantic conventions are opted in
   - `gen_ai.request.model`, `gen_ai.operation.name`, `gen_ai.usage.*`
@@ -380,7 +380,8 @@ to them directly without OTLP export.
 **Model usage**
 
 - `model.usage` - tokens, cost, duration, context, provider/model/channel,
-  session ids. `usage` is provider/turn accounting for cost and telemetry;
+  plugin id when emitted by plugin-owned runtime calls, and session ids.
+  `usage` is provider/turn accounting for cost and telemetry;
   `context.used` is the current prompt/context snapshot and can be lower than
   provider `usage.total` when cached input or tool-loop calls are involved.
 

--- a/extensions/diagnostics-otel/src/service.test.ts
+++ b/extensions/diagnostics-otel/src/service.test.ts
@@ -1939,6 +1939,7 @@ describe("diagnostics-otel service", () => {
       sessionKey: "session-key",
       channel: "webchat",
       agentId: "ops",
+      pluginId: "lossless-claw",
       provider: "openai",
       model: "gpt-5.4",
       usage: {
@@ -1963,6 +1964,7 @@ describe("diagnostics-otel service", () => {
     expect(tokens?.add).toHaveBeenCalledWith(12, {
       "openclaw.channel": "webchat",
       "openclaw.agent": "ops",
+      "openclaw.plugin": "lossless-claw",
       "openclaw.provider": "openai",
       "openclaw.model": "gpt-5.4",
       "openclaw.token": "input",
@@ -2001,6 +2003,7 @@ describe("diagnostics-otel service", () => {
     expect(telemetryState.counters.get("openclaw.tokens")?.add).toHaveBeenCalledWith(2, {
       "openclaw.channel": "unknown",
       "openclaw.agent": "unknown",
+      "openclaw.plugin": "none",
       "openclaw.provider": "openai",
       "openclaw.model": "gpt-5.4",
       "openclaw.token": "input",
@@ -2028,6 +2031,7 @@ describe("diagnostics-otel service", () => {
     expect(telemetryState.counters.get("openclaw.tokens")?.add).toHaveBeenCalledWith(2, {
       "openclaw.channel": "unknown",
       "openclaw.agent": "unknown",
+      "openclaw.plugin": "none",
       "openclaw.provider": "openai",
       "openclaw.model": "gpt-5.4",
       "openclaw.token": "input",
@@ -2119,6 +2123,7 @@ describe("diagnostics-otel service", () => {
       type: "model.usage",
       sessionKey: "session-key",
       sessionId: "session-id",
+      pluginId: "lossless-claw",
       provider: "anthropic",
       model: "anthropic/claude-sonnet-4.6",
       usage: {
@@ -2139,6 +2144,7 @@ describe("diagnostics-otel service", () => {
     expect(modelUsageOptions?.attributes?.["gen_ai.request.model"]).toBe(
       "anthropic/claude-sonnet-4.6",
     );
+    expect(modelUsageOptions?.attributes?.["openclaw.plugin"]).toBe("lossless-claw");
     expect(modelUsageOptions?.attributes?.["gen_ai.usage.input_tokens"]).toBe(150);
     expect(modelUsageOptions?.attributes?.["gen_ai.usage.output_tokens"]).toBe(40);
     expect(modelUsageOptions?.attributes?.["gen_ai.usage.cache_read.input_tokens"]).toBe(30);

--- a/extensions/diagnostics-otel/src/service.ts
+++ b/extensions/diagnostics-otel/src/service.ts
@@ -2400,6 +2400,7 @@ export function createDiagnosticsOtelService(): OpenClawPluginService {
         const attrs = {
           "openclaw.channel": evt.channel ?? "unknown",
           "openclaw.agent": lowCardinalityAttr(evt.agentId),
+          "openclaw.plugin": lowCardinalityAttr(evt.pluginId, "none"),
           "openclaw.provider": evt.provider ?? "unknown",
           "openclaw.model": evt.model ?? "unknown",
         };

--- a/extensions/diagnostics-prometheus/src/service.test.ts
+++ b/extensions/diagnostics-prometheus/src/service.test.ts
@@ -361,7 +361,7 @@ describe("diagnostics-prometheus service", () => {
     const rendered = testApi.renderPrometheusMetrics(store);
 
     expect(rendered).toContain(
-      'openclaw_model_tokens_total{agent="unknown",channel="unknown",model="gpt-5.4",provider="openai",token_type="input"} 12',
+      'openclaw_model_tokens_total{agent="unknown",channel="unknown",model="gpt-5.4",plugin="none",provider="openai",token_type="input"} 12',
     );
     expect(rendered).not.toContain("Agent:qa:otel-trace-smoke");
   });
@@ -700,6 +700,7 @@ describe("diagnostics-prometheus service", () => {
       {
         ...baseEvent(),
         type: "model.usage",
+        pluginId: "lossless-claw",
         provider: "openai",
         model: "gpt-5.4",
         usage: { input: 12, output: 3, total: 15 },
@@ -718,7 +719,7 @@ describe("diagnostics-prometheus service", () => {
       },
     ]);
     expect(exporter.render()).toContain(
-      'openclaw_model_tokens_total{agent="unknown",channel="unknown",model="gpt-5.4",provider="openai",token_type="input"} 12',
+      'openclaw_model_tokens_total{agent="unknown",channel="unknown",model="gpt-5.4",plugin="lossless-claw",provider="openai",token_type="input"} 12',
     );
 
     exporter.service.stop?.();

--- a/extensions/diagnostics-prometheus/src/service.ts
+++ b/extensions/diagnostics-prometheus/src/service.ts
@@ -498,6 +498,7 @@ function recordModelUsage(
     agent: lowCardinalityLabel(evt.agentId),
     channel: lowCardinalityLabel(evt.channel),
     model: lowCardinalityLabel(evt.model),
+    plugin: lowCardinalityLabel(evt.pluginId, "none"),
     provider: lowCardinalityLabel(evt.provider),
   };
   const usage = evt.usage;

--- a/src/infra/diagnostic-events.ts
+++ b/src/infra/diagnostic-events.ts
@@ -23,6 +23,7 @@ export type DiagnosticUsageEvent = DiagnosticBaseEvent & {
   sessionId?: string;
   channel?: string;
   agentId?: string;
+  pluginId?: string;
   provider?: string;
   model?: string;
   usage: {

--- a/src/plugins/runtime/runtime-llm.runtime.test.ts
+++ b/src/plugins/runtime/runtime-llm.runtime.test.ts
@@ -1,7 +1,12 @@
 // Runtime LLM tests cover plugin provider hooks inside the model runtime adapter.
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { resolveContextEngineCapabilities } from "../../agents/embedded-agent-runner/context-engine-capabilities.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
+import {
+  onInternalDiagnosticEvent,
+  resetDiagnosticEventsForTest,
+  type DiagnosticEventPayload,
+} from "../../infra/diagnostic-events.js";
 import { withPluginRuntimePluginIdScope } from "./gateway-request-scope.js";
 import { createRuntimeLlm } from "./runtime-llm.runtime.js";
 import type { RuntimeLogger } from "./types-core.js";
@@ -142,10 +147,16 @@ function primeCompletionMocks() {
 
 describe("runtime.llm.complete", () => {
   beforeEach(() => {
+    resetDiagnosticEventsForTest();
     hoisted.prepareSimpleCompletionModelForAgent.mockReset();
     hoisted.completeWithPreparedSimpleCompletionModel.mockReset();
     hoisted.resolveSimpleCompletionSelectionForAgent.mockReset();
     primeCompletionMocks();
+  });
+
+  afterEach(() => {
+    resetDiagnosticEventsForTest();
+    vi.restoreAllMocks();
   });
 
   it("binds context-engine completions to the active session agent", async () => {
@@ -456,6 +467,39 @@ describe("runtime.llm.complete", () => {
     });
   });
 
+  it("attributes context-engine usage diagnostics to the owning plugin policy", async () => {
+    const events: DiagnosticEventPayload[] = [];
+    const stop = onInternalDiagnosticEvent((event, metadata) => {
+      if (metadata.trusted && event.type === "model.usage") {
+        events.push(event);
+      }
+    });
+    const runtimeContext = resolveContextEngineCapabilities({
+      config: cfg,
+      sessionKey: "agent:main:session:abc",
+      contextEnginePluginId: "lossless-claw",
+      purpose: "context-engine.compaction",
+    });
+
+    try {
+      await runtimeContext.llm!.complete({
+        messages: [{ role: "user", content: "summarize" }],
+      });
+    } finally {
+      stop();
+    }
+
+    expect(events).toHaveLength(1);
+    expect(events[0]).toMatchObject({
+      type: "model.usage",
+      sessionKey: "agent:main:session:abc",
+      agentId: "main",
+      pluginId: "lossless-claw",
+      provider: "openai",
+      model: "gpt-5.5",
+    });
+  });
+
   it("allows the bound context-engine agent and denies cross-agent overrides", async () => {
     const runtimeContext = resolveContextEngineCapabilities({
       config: cfg,
@@ -639,6 +683,86 @@ describe("runtime.llm.complete", () => {
       caller: { kind: "plugin", id: "trusted-plugin" },
       purpose: "identity-test",
     });
+  });
+
+  it("emits model usage diagnostics for scoped plugin completions", async () => {
+    vi.spyOn(Date, "now")
+      .mockReturnValueOnce(900)
+      .mockReturnValueOnce(1_000)
+      .mockReturnValueOnce(1_250);
+    const events: DiagnosticEventPayload[] = [];
+    const stop = onInternalDiagnosticEvent((event, metadata) => {
+      if (metadata.trusted && event.type === "model.usage") {
+        events.push(event);
+      }
+    });
+    const llm = createRuntimeLlm({
+      getConfig: () => cfg,
+      authority: {
+        allowComplete: true,
+        sessionKey: "agent:main:session:abc",
+      },
+    });
+
+    try {
+      await withPluginRuntimePluginIdScope("trusted-plugin", () =>
+        llm.complete({
+          messages: [{ role: "user", content: "Ping" }],
+        }),
+      );
+    } finally {
+      stop();
+    }
+
+    expect(events).toHaveLength(1);
+    expect(events[0]).toMatchObject({
+      type: "model.usage",
+      sessionKey: "agent:main:session:abc",
+      agentId: "main",
+      pluginId: "trusted-plugin",
+      provider: "openai",
+      model: "gpt-5.5",
+      usage: {
+        input: 11,
+        output: 7,
+        cacheRead: 5,
+        cacheWrite: 2,
+        promptTokens: 18,
+        total: 25,
+      },
+      costUsd: 0.0042,
+      durationMs: 250,
+    });
+  });
+
+  it("honors disabled diagnostics config for plugin completion usage", async () => {
+    const events: DiagnosticEventPayload[] = [];
+    const stop = onInternalDiagnosticEvent((event, metadata) => {
+      if (metadata.trusted && event.type === "model.usage") {
+        events.push(event);
+      }
+    });
+    const llm = createRuntimeLlm({
+      getConfig: () => ({
+        ...cfg,
+        diagnostics: { enabled: false },
+      }),
+      authority: {
+        allowComplete: true,
+      },
+    });
+
+    try {
+      await withPluginRuntimePluginIdScope("trusted-plugin", () =>
+        llm.complete({
+          messages: [{ role: "user", content: "Ping" }],
+        }),
+      );
+    } finally {
+      stop();
+    }
+
+    expect(events).toHaveLength(0);
   });
 
   it("denies plugin model overrides by default", async () => {

--- a/src/plugins/runtime/runtime-llm.runtime.ts
+++ b/src/plugins/runtime/runtime-llm.runtime.ts
@@ -6,6 +6,7 @@ import { normalizeModelRef } from "../../agents/model-selection.js";
 import type { NormalizedUsage, UsageLike } from "../../agents/usage.js";
 import { normalizeUsage } from "../../agents/usage.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
+import { emitTrustedDiagnosticEvent, isDiagnosticsEnabled } from "../../infra/diagnostic-events.js";
 import type { Api, Message } from "../../llm/types.js";
 import { getChildLogger } from "../../logging.js";
 import { normalizeAgentId } from "../../routing/session-key.js";
@@ -215,6 +216,54 @@ function buildUsage(params: {
     ...(params.normalized?.total !== undefined ? { totalTokens: params.normalized.total } : {}),
     ...(costUsd !== undefined ? { costUsd } : {}),
   };
+}
+
+function hasDiagnosticUsage(usage: LlmCompleteUsage): boolean {
+  return Boolean(
+    usage.inputTokens ||
+    usage.outputTokens ||
+    usage.cacheReadTokens ||
+    usage.cacheWriteTokens ||
+    usage.totalTokens ||
+    usage.costUsd,
+  );
+}
+
+function emitLlmCompleteUsageDiagnostic(params: {
+  cfg: OpenClawConfig;
+  usage: LlmCompleteUsage;
+  sessionKey?: string;
+  agentId: string;
+  pluginId?: string;
+  provider: string;
+  model: string;
+  durationMs: number;
+}) {
+  if (!isDiagnosticsEnabled(params.cfg) || !hasDiagnosticUsage(params.usage)) {
+    return;
+  }
+  const promptTokens =
+    (params.usage.inputTokens ?? 0) +
+    (params.usage.cacheReadTokens ?? 0) +
+    (params.usage.cacheWriteTokens ?? 0);
+  emitTrustedDiagnosticEvent({
+    type: "model.usage",
+    ...(params.sessionKey ? { sessionKey: params.sessionKey } : {}),
+    agentId: params.agentId,
+    ...(params.pluginId ? { pluginId: params.pluginId } : {}),
+    provider: params.provider,
+    model: params.model,
+    usage: {
+      input: params.usage.inputTokens ?? 0,
+      output: params.usage.outputTokens ?? 0,
+      cacheRead: params.usage.cacheReadTokens ?? 0,
+      cacheWrite: params.usage.cacheWriteTokens ?? 0,
+      promptTokens,
+      total: params.usage.totalTokens ?? promptTokens + (params.usage.outputTokens ?? 0),
+    },
+    ...(params.usage.costUsd !== undefined ? { costUsd: params.usage.costUsd } : {}),
+    durationMs: params.durationMs,
+  });
 }
 
 function finiteOption(value: number | undefined): number | undefined {
@@ -441,6 +490,7 @@ export function createRuntimeLlm(options: CreateRuntimeLlmOptions = {}): PluginR
         }),
       };
 
+      const completionStartedAt = Date.now();
       const result = await completeWithPreparedSimpleCompletionModel({
         model: prepared.model,
         auth: prepared.auth,
@@ -474,6 +524,16 @@ export function createRuntimeLlm(options: CreateRuntimeLlmOptions = {}): PluginR
         provider: prepared.selection.provider,
         model: prepared.selection.modelId,
         usage,
+      });
+      emitLlmCompleteUsageDiagnostic({
+        cfg,
+        usage,
+        sessionKey: options.authority?.sessionKey,
+        agentId,
+        pluginId: pluginPolicyId,
+        provider: prepared.selection.provider,
+        model: prepared.selection.modelId,
+        durationMs: Date.now() - completionStartedAt,
       });
 
       return {


### PR DESCRIPTION
Closes #98968

## What Problem This Solves

Fixes an issue where plugin-owned LLM calls through `api.runtime.llm.complete` returned usage to the plugin but did not emit the `model.usage` diagnostic event used by the OpenTelemetry and Prometheus diagnostics exporters.

This left plugin-initiated model spend, such as context-engine or summarization plugins, out of token and cost telemetry even when diagnostics were enabled.

## Why This Change Was Made

The plugin runtime now emits a trusted `model.usage` event after successful `runtime.llm.complete` calls using the same normalized usage and cost data it already returns to the caller. The event includes a bounded `pluginId` attribution when the call is plugin-owned, and the OTel/Prometheus exporters carry that through as low-cardinality `openclaw.plugin` / `plugin` metadata.

Risk note: this changes diagnostics payload and metric label shape only; it does not change plugin result data or model selection, and the added exporter tests cover the new attribution plus the existing fallback label for non-plugin usage events.

## User Impact

Operators using diagnostics exporters can now see plugin-initiated LLM usage and cost in the same model usage telemetry as main agent turns. Existing non-plugin model usage continues to export with a `none` plugin label.

## Evidence

Source-level regression tests:

```text
node scripts/run-vitest.mjs src/plugins/runtime/runtime-llm.runtime.test.ts src/infra/diagnostic-events.test.ts extensions/diagnostics-otel/src/service.test.ts extensions/diagnostics-prometheus/src/service.test.ts
[test] passed 4 Vitest shards in 16.20s
```

Real DeepSeek runtime proof for `runtime.llm.complete` under a plugin scope:

```text
provider=deepseek model=deepseek-v4-pro status=200
completion.audit.caller={ kind: "plugin", id: "lossless-claw" }
completion.usage={ inputTokens: 17, outputTokens: 9, totalTokens: 26, costUsd: 0.0000609 }
diagnosticEvent={ type: "model.usage", pluginId: "lossless-claw", provider: "deepseek", model: "deepseek-v4-pro", usage.total: 26, durationMsType: "number" }
```

Real local agent round with DeepSeek:

```text
pnpm openclaw agent --local --agent main --model deepseek/deepseek-v4-pro --message "Reply exactly: OPENCLAW-98968-AGENT" --json --timeout 180
provider=deepseek model=deepseek-v4-pro status=200
finalAssistantVisibleText="OPENCLAW-98968-AGENT"
agentMeta.usage.total=24385
```

Other validation:

```text
pnpm docs:list
node scripts/format-docs.mjs --check docs/gateway/opentelemetry.md
node_modules/.bin/oxfmt --check --threads=1 <changed-ts-files>
node scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.core.json <changed-core-files>
node scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.extensions.json <changed-extension-files>
node scripts/run-tsgo.mjs -p tsconfig.core.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/core.tsbuildinfo
node scripts/run-tsgo.mjs -p test/tsconfig/tsconfig.core.test.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/core-test.tsbuildinfo
node scripts/run-tsgo.mjs -p tsconfig.extensions.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/extensions.tsbuildinfo
node scripts/run-tsgo.mjs -p test/tsconfig/tsconfig.extensions.test.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/extensions-test.tsbuildinfo
pnpm build
.agents/skills/autoreview/scripts/autoreview --mode local
```

Autoreview result:

```text
autoreview clean: no accepted/actionable findings reported
overall: patch is correct (0.72)
```

AI-assisted: AI-assisted implementation and review; proof run manually.
