### PR TITLE
test: migrate five test files to shared suite temp-dir helpers

### DIFF
--- a/src/agents/agent-model-discovery.test.ts
+++ b/src/agents/agent-model-discovery.test.ts
@@ -1,9 +1,23 @@
 /** Tests agent model discovery registry refresh and lookup cache behavior. */
 import fs from "node:fs";
-import os from "node:os";
 import path from "node:path";
-import { describe, expect, it } from "vitest";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { createSuiteTempRootTracker } from "../test-helpers/temp-dir.js";
 import { discoverAuthStorage, discoverModels } from "./agent-model-discovery.js";
+
+const suiteTempDirs = createSuiteTempRootTracker({ prefix: "openclaw-agent-models-" });
+
+async function makeTempDir(): Promise<string> {
+  return suiteTempDirs.make("temp");
+}
+
+beforeAll(async () => {
+  await suiteTempDirs.setup();
+});
+
+afterAll(async () => {
+  await suiteTempDirs.cleanup();
+});
 
 function writeModelsJson(agentDir: string, modelId: string): void {
   fs.writeFileSync(
@@ -22,8 +36,8 @@ function writeModelsJson(agentDir: string, modelId: string): void {
 }
 
 describe("discoverModels", () => {
-  it("clears cached find results when the agent model registry refreshes", () => {
-    const agentDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-agent-models-"));
+  it("clears cached find results when the agent model registry refreshes", async () => {
+    const agentDir = await makeTempDir();
     writeModelsJson(agentDir, "old-model");
     const authStorage = discoverAuthStorage(agentDir, { skipCredentials: true });
     const registry = discoverModels(authStorage, agentDir, { normalizeModels: false });

--- a/src/agents/models-config.providers.implicit.discovery-scope.test.ts
+++ b/src/agents/models-config.providers.implicit.discovery-scope.test.ts
@@ -1,11 +1,11 @@
 // Exercises startup provider discovery scoping without loading real plugin manifests.
-import { mkdtemp, writeFile } from "node:fs/promises";
-import os from "node:os";
+import { writeFile } from "node:fs/promises";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import type { PluginMetadataSnapshotOwnerMaps } from "../plugins/plugin-metadata-snapshot.js";
 import type { ProviderPlugin } from "../plugins/types.js";
+import { createSuiteTempRootTracker } from "../test-helpers/temp-dir.js";
 import { withEnvAsync } from "../test-utils/env.js";
 
 const mocks = vi.hoisted(() => ({
@@ -14,6 +14,20 @@ const mocks = vi.hoisted(() => ({
   runProviderStaticCatalog: vi.fn(),
 }));
 const BUNDLED_PLUGINS_DIR = fileURLToPath(new URL("../../extensions/", import.meta.url));
+
+const suiteTempDirs = createSuiteTempRootTracker({ prefix: "openclaw-discovery-scope-" });
+
+async function makeTempDir(): Promise<string> {
+  return suiteTempDirs.make("temp");
+}
+
+beforeAll(async () => {
+  await suiteTempDirs.setup();
+});
+
+afterAll(async () => {
+  await suiteTempDirs.cleanup();
+});
 
 vi.mock("../plugins/provider-discovery.js", () => ({
   resolveRuntimePluginDiscoveryProviders: mocks.resolveRuntimePluginDiscoveryProviders,
@@ -212,7 +226,7 @@ describe("resolveImplicitProviders startup discovery scope", () => {
   });
 
   it("fills missing static catalog apiKey from Google Vertex ADC auth evidence", async () => {
-    const tempDir = await mkdtemp(path.join(os.tmpdir(), "openclaw-google-vertex-adc-"));
+    const tempDir = await makeTempDir();
     const credentialsPath = path.join(tempDir, "application_default_credentials.json");
     await writeFile(credentialsPath, JSON.stringify({ type: "authorized_user" }));
     mocks.resolveRuntimePluginDiscoveryProviders.mockResolvedValue([

--- a/src/agents/models-config.providers.stepfun.test.ts
+++ b/src/agents/models-config.providers.stepfun.test.ts
@@ -1,9 +1,7 @@
 // Verifies StepFun standard and Step Plan catalog pairing across regions.
-import { mkdtempSync } from "node:fs";
-import { tmpdir } from "node:os";
-import { join } from "node:path";
-import { describe, expect, it } from "vitest";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import type { ModelDefinitionConfig, ModelProviderConfig } from "../config/types.models.js";
+import { createSuiteTempRootTracker } from "../test-helpers/temp-dir.js";
 import { upsertAuthProfile } from "./auth-profiles.js";
 import { installModelsConfigTestHooks } from "./models-config.e2e-harness.js";
 
@@ -15,6 +13,20 @@ const STEPFUN_PLAN_CN_BASE_URL = "https://api.stepfun.com/step_plan/v1";
 const STEPFUN_PLAN_INTL_BASE_URL = "https://api.stepfun.ai/step_plan/v1";
 
 installModelsConfigTestHooks();
+
+const suiteTempDirs = createSuiteTempRootTracker({ prefix: "openclaw-stepfun-" });
+
+async function makeAgentDir(): Promise<string> {
+  return suiteTempDirs.make("agent");
+}
+
+beforeAll(async () => {
+  await suiteTempDirs.setup();
+});
+
+afterAll(async () => {
+  await suiteTempDirs.cleanup();
+});
 
 type StepFunRegion = "cn" | "intl";
 type StepFunSurface = "standard" | "plan";
@@ -128,8 +140,8 @@ describe("StepFun provider catalog", () => {
     expect(planProvider.models?.map((model) => model.id)).toEqual(EXPECTED_PLAN_MODELS);
   });
 
-  it("falls back to global endpoints for untagged StepFun auth profiles", () => {
-    const agentDir = mkdtempSync(join(tmpdir(), "openclaw-test-"));
+  it("falls back to global endpoints for untagged StepFun auth profiles", async () => {
+    const agentDir = await makeAgentDir();
 
     upsertAuthProfile({
       profileId: "stepfun:default",
@@ -199,8 +211,8 @@ describe("StepFun provider catalog", () => {
     expect(providers["stepfun-plan"]?.baseUrl).toBe("https://api.stepfun.com/step_plan/v1");
   });
 
-  it("discovers both providers from shared regional auth profiles", () => {
-    const agentDir = mkdtempSync(join(tmpdir(), "openclaw-test-"));
+  it("discovers both providers from shared regional auth profiles", async () => {
+    const agentDir = await makeAgentDir();
 
     upsertAuthProfile({
       profileId: "stepfun:cn",

--- a/src/agents/sessions/session-migrate-id-dedup.test.ts
+++ b/src/agents/sessions/session-migrate-id-dedup.test.ts
@@ -1,7 +1,7 @@
-import { mkdtempSync, readFileSync, writeFileSync } from "node:fs";
-import { tmpdir } from "node:os";
+import { readFileSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
-import { describe, expect, it, vi } from "vitest";
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
+import { createSuiteTempRootTracker } from "../../test-helpers/temp-dir.js";
 
 const { uuidQueue } = vi.hoisted(() => ({ uuidQueue: [] as string[] }));
 
@@ -16,6 +16,20 @@ vi.mock("node:crypto", async (importOriginal) => {
 });
 
 const { SessionManager } = await import("./session-manager.js");
+
+const suiteTempDirs = createSuiteTempRootTracker({ prefix: "openclaw-session-migrate-" });
+
+async function makeTempDir(): Promise<string> {
+  return suiteTempDirs.make("temp");
+}
+
+beforeAll(async () => {
+  await suiteTempDirs.setup();
+});
+
+afterAll(async () => {
+  await suiteTempDirs.cleanup();
+});
 
 function writeV1File(dir: string): string {
   const file = join(dir, "2026-01-01T00-00-00-000Z_sess-v1.jsonl");
@@ -41,8 +55,8 @@ function writeV1File(dir: string): string {
 }
 
 describe("v1 session migration id assignment", () => {
-  it("keeps migrated entry ids unique even when the id generator first collides", () => {
-    const dir = mkdtempSync(join(tmpdir(), "oc-v1mig-"));
+  it("keeps migrated entry ids unique even when the id generator first collides", async () => {
+    const dir = await makeTempDir();
     const file = writeV1File(dir);
 
     uuidQueue.length = 0;
@@ -69,8 +83,8 @@ describe("v1 session migration id assignment", () => {
     expect(messages[1].parentId).not.toBe(messages[1].id);
   });
 
-  it("preserves compaction indexes across opaque rows", () => {
-    const dir = mkdtempSync(join(tmpdir(), "oc-v1mig-compaction-"));
+  it("preserves compaction indexes across opaque rows", async () => {
+    const dir = await makeTempDir();
     const file = join(dir, "session.jsonl");
     const keptMessage = {
       type: "message",

--- a/src/security/audit-config-include-perms.test.ts
+++ b/src/security/audit-config-include-perms.test.ts
@@ -1,14 +1,28 @@
 // Covers config include-file permission audit findings.
 import fs from "node:fs";
-import os from "node:os";
 import path from "node:path";
-import { describe, expect, it } from "vitest";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import type { ConfigFileSnapshot } from "../config/types.openclaw.js";
+import { createSuiteTempRootTracker } from "../test-helpers/temp-dir.js";
 import { collectIncludeFilePermFindings } from "./audit-extra.async.js";
+
+const suiteTempDirs = createSuiteTempRootTracker({ prefix: "openclaw-include-perms-" });
+
+async function makeTempDir(): Promise<string> {
+  return suiteTempDirs.make("temp");
+}
+
+beforeAll(async () => {
+  await suiteTempDirs.setup();
+});
+
+afterAll(async () => {
+  await suiteTempDirs.cleanup();
+});
 
 describe("security audit config include permissions", () => {
   it("flags group/world-readable config include files", async () => {
-    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-include-perms-"));
+    const tmp = await makeTempDir();
     const stateDir = path.join(tmp, "state");
     fs.mkdirSync(stateDir, { recursive: true, mode: 0o700 });
 


### PR DESCRIPTION
## What Problem This Solves

Five test files create temporary directories with raw `fs.mkdtemp` / `fs.mkdtempSync` and never clean them up:

- `src/agents/models-config.providers.stepfun.test.ts`: 2 cases call `mkdtempSync` for agent auth-profile directories.
- `src/agents/models-config.providers.implicit.discovery-scope.test.ts`: 1 case calls `mkdtemp` for Google Vertex ADC credentials.
- `src/agents/agent-model-discovery.test.ts`: 1 case calls `fs.mkdtempSync` for an agent model directory.
- `src/agents/sessions/session-migrate-id-dedup.test.ts`: 2 cases call `mkdtempSync` for v1 session migration directories.
- `src/security/audit-config-include-perms.test.ts`: 1 case calls `fs.mkdtempSync` for a config-include permission audit directory.

These leaks add `/tmp` pressure across repeated test runs.

## Why This Change Was Made

Migrates all five files to the existing shared helper `createSuiteTempRootTracker` from `src/test-helpers/temp-dir.js`. The tracker creates one suite-level temp root in `beforeAll`, hands out isolated case subdirectories via `make()`, and removes the entire root in `afterAll`.

Changes per file:

- Replaced `mkdtemp` / `mkdtempSync` calls with `suiteTempDirs.make(...)`.
- Added `createSuiteTempRootTracker` import and `beforeAll` / `afterAll` setup/cleanup hooks.
- Removed now-unused `os` imports (and `node:fs`/`node:path` imports where they became unused).
- Kept all test bodies and assertions unchanged.

## User Impact

Test-only. Reduces dangling temp directories during agents and security test runs. No user-visible behavior change.

## Evidence

Unit tests:

```bash
node scripts/run-vitest.mjs \
  src/agents/models-config.providers.stepfun.test.ts \
  src/agents/models-config.providers.implicit.discovery-scope.test.ts \
  src/agents/agent-model-discovery.test.ts \
  src/agents/sessions/session-migrate-id-dedup.test.ts \
  src/security/audit-config-include-perms.test.ts \
  --run
```

Results:

```console
 Test Files  5 passed (5)
      Tests  16 passed (16)
```

Lint:

```bash
node scripts/run-oxlint.mjs \
  src/agents/models-config.providers.stepfun.test.ts \
  src/agents/models-config.providers.implicit.discovery-scope.test.ts \
  src/agents/agent-model-discovery.test.ts \
  src/agents/sessions/session-migrate-id-dedup.test.ts \
  src/security/audit-config-include-perms.test.ts
```

→ exit 0

Typecheck:

```bash
pnpm tsgo:core:test
```

→ exit 0

Format:

```bash
pnpm format:check \
  src/agents/models-config.providers.stepfun.test.ts \
  src/agents/models-config.providers.implicit.discovery-scope.test.ts \
  src/agents/agent-model-discovery.test.ts \
  src/agents/sessions/session-migrate-id-dedup.test.ts \
  src/security/audit-config-include-perms.test.ts
```

→ All matched files use the correct format.

## Real behavior proof

- **Behavior addressed**: five test files no longer leak temp directories created by `fs.mkdtemp` / `fs.mkdtempSync`.
- **Real environment tested**: Linux x86_64, Node 22.19+, local source checkout.
- **Exact steps or command run after this patch**: see Evidence section above.
- **Evidence after fix**: 16 tests pass; lint, typecheck, and format pass; `createSuiteTempRootTracker` removes the suite temp root in `afterAll`.
- **Observed result after fix**: all five test suites now use the shared tracker for temp directory lifecycle, matching the pattern used in xialonglee's merged temp-dir migration PRs.
- **What was not tested**: full CI suite (triggered on push to remote).

## AI-assisted

Implemented and verified with AI assistance; reviewed by a human before submission.
