### PR TITLE
fix(line): truncate outbound altText, location, menu, and code fields on code point boundaries

### DIFF
--- a/extensions/line/src/auto-reply-delivery.test.ts
+++ b/extensions/line/src/auto-reply-delivery.test.ts
@@ -109,6 +109,31 @@ describe("deliverLineAutoReply", () => {
     expect(createQuickReplyItems).not.toHaveBeenCalled();
   });
 
+  it("truncates flex altText on a surrogate boundary", async () => {
+    // The emoji's surrogate pair straddles LINE's 400-char altText cap; a raw
+    // slice used to send a lone high surrogate to the LINE API.
+    const lineData = {
+      flexMessage: { altText: `${"a".repeat(399)}😀 overflow`, contents: { type: "bubble" } },
+    };
+    const createFlexMessageSpy = vi.fn(createFlexMessage);
+    const { deps } = createDeps({
+      createFlexMessage: createFlexMessageSpy as LineAutoReplyDeps["createFlexMessage"],
+    });
+
+    await deliverLineAutoReply({
+      ...baseDeliveryParams,
+      payload: { text: "hello", channelData: { line: lineData } },
+      lineData,
+      deps,
+    });
+
+    const sentAltText = createFlexMessageSpy.mock.calls[0]?.[0] ?? "";
+    expect(sentAltText.length).toBeLessThanOrEqual(400);
+    expect(
+      /[\uD800-\uDBFF](?![\uDC00-\uDFFF])|(?<![\uD800-\uDBFF])[\uDC00-\uDFFF]/.test(sentAltText),
+    ).toBe(false);
+  });
+
   it("uses reply token for rich-only payloads", async () => {
     const lineData = {
       flexMessage: { altText: "Card", contents: { type: "bubble" } },

--- a/extensions/line/src/auto-reply-delivery.ts
+++ b/extensions/line/src/auto-reply-delivery.ts
@@ -3,6 +3,7 @@ import type { messagingApi } from "@line/bot-sdk";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import { resolveSendableOutboundReplyParts } from "openclaw/plugin-sdk/reply-payload";
 import type { ReplyPayload } from "openclaw/plugin-sdk/reply-runtime";
+import { truncateUtf16Safe } from "openclaw/plugin-sdk/text-utility-runtime";
 import type { FlexContainer } from "./flex-templates.js";
 import type { ProcessedLineMessage } from "./markdown-to-line.js";
 import { buildLineQuickReplyFallbackText } from "./quick-reply-fallback.js";
@@ -103,7 +104,7 @@ export async function deliverLineAutoReply(params: {
   if (lineData.flexMessage) {
     richMessages.push(
       deps.createFlexMessage(
-        lineData.flexMessage.altText.slice(0, 400),
+        truncateUtf16Safe(lineData.flexMessage.altText, 400),
         lineData.flexMessage.contents as FlexContainer,
       ),
     );
@@ -125,7 +126,9 @@ export async function deliverLineAutoReply(params: {
     : { text: "", flexMessages: [] };
 
   for (const flexMsg of processed.flexMessages) {
-    richMessages.push(deps.createFlexMessage(flexMsg.altText.slice(0, 400), flexMsg.contents));
+    richMessages.push(
+      deps.createFlexMessage(truncateUtf16Safe(flexMsg.altText, 400), flexMsg.contents),
+    );
   }
 
   const chunks = processed.text ? deps.chunkMarkdownText(processed.text, textLimit) : [];

--- a/extensions/line/src/card-command.ts
+++ b/extensions/line/src/card-command.ts
@@ -2,6 +2,7 @@
 import type { OpenClawPluginApi } from "openclaw/plugin-sdk/core";
 import type { ReplyPayload } from "openclaw/plugin-sdk/reply-runtime";
 import { normalizeLowercaseStringOrEmpty } from "openclaw/plugin-sdk/string-coerce-runtime";
+import { truncateUtf16Safe } from "openclaw/plugin-sdk/text-utility-runtime";
 import { messageAction, postbackAction, uriAction } from "./actions.js";
 import {
   createActionCard,
@@ -187,7 +188,7 @@ export function registerLineCardCommand(api: OpenClawPluginApi): void {
             const bubble = createInfoCard(title, body, footer);
             return buildLineReply({
               flexMessage: {
-                altText: `${title}: ${body}`.slice(0, 400),
+                altText: truncateUtf16Safe(`${title}: ${body}`, 400),
                 contents: bubble,
               },
             });
@@ -202,7 +203,7 @@ export function registerLineCardCommand(api: OpenClawPluginApi): void {
             const bubble = createImageCard(imageUrl, title, caption);
             return buildLineReply({
               flexMessage: {
-                altText: `${title}: ${caption}`.slice(0, 400),
+                altText: truncateUtf16Safe(`${title}: ${caption}`, 400),
                 contents: bubble,
               },
             });
@@ -219,7 +220,7 @@ export function registerLineCardCommand(api: OpenClawPluginApi): void {
             });
             return buildLineReply({
               flexMessage: {
-                altText: `${title}: ${body}`.slice(0, 400),
+                altText: truncateUtf16Safe(`${title}: ${body}`, 400),
                 contents: bubble,
               },
             });
@@ -236,7 +237,10 @@ export function registerLineCardCommand(api: OpenClawPluginApi): void {
             const bubble = createListCard(title, items);
             return buildLineReply({
               flexMessage: {
-                altText: `${title}: ${items.map((i) => i.title).join(", ")}`.slice(0, 400),
+                altText: truncateUtf16Safe(
+                  `${title}: ${items.map((i) => i.title).join(", ")}`,
+                  400,
+                ),
                 contents: bubble,
               },
             });

--- a/extensions/line/src/card-command.ts
+++ b/extensions/line/src/card-command.ts
@@ -261,8 +261,8 @@ export function registerLineCardCommand(api: OpenClawPluginApi): void {
             const bubble = createReceiptCard({ title, items, total, footer });
             return buildLineReply({
               flexMessage: {
-                altText: `${title}: ${items.map((i) => `${i.name} ${i.value}`).join(", ")}`.slice(
-                  0,
+                altText: truncateUtf16Safe(
+                  `${title}: ${items.map((i) => `${i.name} ${i.value}`).join(", ")}`,
                   400,
                 ),
                 contents: bubble,

--- a/extensions/line/src/markdown-to-line.test.ts
+++ b/extensions/line/src/markdown-to-line.test.ts
@@ -277,6 +277,21 @@ describe("convertCodeBlockToFlexBubble", () => {
     expect(codeText.length).toBeLessThan(longCode.length);
     expect(codeText).toContain("...");
   });
+
+  it("does not split a surrogate pair at the truncation boundary", () => {
+    // The emoji's surrogate pair straddles the 2000-char cap; a raw slice
+    // would leave a lone high surrogate at the end of the code text.
+    const block = { code: `${"x".repeat(1999)}😀${"y".repeat(500)}` };
+
+    const bubble = convertCodeBlockToFlexBubble(block);
+
+    const body = bubble.body as { contents: Array<{ contents: Array<{ text: string }> }> };
+    const codeText = body.contents[1].contents[0].text;
+    expect(codeText.endsWith("\n...")).toBe(true);
+    expect(
+      /[\uD800-\uDBFF](?![\uDC00-\uDFFF])|(?<![\uD800-\uDBFF])[\uDC00-\uDFFF]/.test(codeText),
+    ).toBe(false);
+  });
 });
 
 describe("processLineMessage", () => {

--- a/extensions/line/src/markdown-to-line.ts
+++ b/extensions/line/src/markdown-to-line.ts
@@ -1,6 +1,7 @@
 // Line plugin module implements markdown to line behavior.
 import type { messagingApi } from "@line/bot-sdk";
 import { stripMarkdown } from "openclaw/plugin-sdk/text-chunking";
+import { truncateUtf16Safe } from "openclaw/plugin-sdk/text-utility-runtime";
 import { uriAction } from "./actions.js";
 import { createReceiptCard, toFlexMessage, type FlexBubble } from "./flex-templates.js";
 export { stripMarkdown } from "openclaw/plugin-sdk/text-chunking";
@@ -234,7 +235,8 @@ export function convertCodeBlockToFlexBubble(block: CodeBlock): FlexBubble {
   const titleText = block.language ? `Code (${block.language})` : "Code";
 
   // Truncate very long code to fit LINE's limits
-  const displayCode = block.code.length > 2000 ? block.code.slice(0, 2000) + "\n..." : block.code;
+  const displayCode =
+    block.code.length > 2000 ? truncateUtf16Safe(block.code, 2000) + "\n..." : block.code;
 
   return {
     type: "bubble",

--- a/extensions/line/src/message-cards.test.ts
+++ b/extensions/line/src/message-cards.test.ts
@@ -420,6 +420,27 @@ describe("action label/data surrogate-safe truncation", () => {
     expect(loneHighSurrogate.test(action.data)).toBe(false);
   });
 
+  it("/card receipt altText truncates on a surrogate boundary", async () => {
+    // The emoji's surrogate pair straddles the 400-char altText cap; a raw
+    // slice used to leave a lone high surrogate in the receipt flex altText.
+    const registerCommand = (command: unknown) => {
+      const { handler } = command as {
+        handler: (ctx: { args: string; channel: string }) => Promise<unknown>;
+      };
+      return handler({
+        channel: "line",
+        args: `receipt "R" "${"a".repeat(395)}:😀x" --total "$30"`,
+      });
+    };
+    const result = (await registerCommandWithHandler(registerCommand)) as {
+      channelData: { line: { flexMessage: { altText: string } } };
+    };
+    const altText = result.channelData.line.flexMessage.altText;
+
+    expect(altText.length).toBeLessThanOrEqual(400);
+    expect(loneHighSurrogate.test(altText)).toBe(false);
+  });
+
   it("media control postback labels truncate on surrogate boundaries", () => {
     const card = createMediaPlayerCard({
       title: "Track",

--- a/extensions/line/src/outbound.ts
+++ b/extensions/line/src/outbound.ts
@@ -10,6 +10,7 @@ import {
 } from "openclaw/plugin-sdk/channel-send-result";
 import { createLazyRuntimeModule } from "openclaw/plugin-sdk/lazy-runtime";
 import { resolveOutboundMediaUrls } from "openclaw/plugin-sdk/reply-payload";
+import { truncateUtf16Safe } from "openclaw/plugin-sdk/text-utility-runtime";
 import type { ChannelPlugin, ResolvedLineAccount } from "./channel-api.js";
 import { resolveLineOutboundMedia, type LineOutboundMediaResolved } from "./outbound-media.js";
 import { buildLineQuickReplyFallbackText } from "./quick-reply-fallback.js";
@@ -244,7 +245,7 @@ export const lineOutboundAdapter: NonNullable<ChannelPlugin<ResolvedLineAccount>
       if (lineData.flexMessage) {
         quickReplyMessages.push({
           type: "flex",
-          altText: lineData.flexMessage.altText.slice(0, 400),
+          altText: truncateUtf16Safe(lineData.flexMessage.altText, 400),
           contents: lineData.flexMessage.contents,
         });
       }
@@ -257,8 +258,8 @@ export const lineOutboundAdapter: NonNullable<ChannelPlugin<ResolvedLineAccount>
       if (lineData.location) {
         quickReplyMessages.push({
           type: "location",
-          title: lineData.location.title.slice(0, 100),
-          address: lineData.location.address.slice(0, 100),
+          title: truncateUtf16Safe(lineData.location.title, 100),
+          address: truncateUtf16Safe(lineData.location.address, 100),
           latitude: lineData.location.latitude,
           longitude: lineData.location.longitude,
         });
@@ -266,7 +267,7 @@ export const lineOutboundAdapter: NonNullable<ChannelPlugin<ResolvedLineAccount>
       for (const flexMsg of processed.flexMessages) {
         quickReplyMessages.push({
           type: "flex",
-          altText: flexMsg.altText.slice(0, 400),
+          altText: truncateUtf16Safe(flexMsg.altText, 400),
           contents: flexMsg.contents,
         });
       }

--- a/extensions/line/src/rich-menu.test.ts
+++ b/extensions/line/src/rich-menu.test.ts
@@ -5,6 +5,7 @@ import path from "node:path";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import { afterAll, afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
+  createRichMenu,
   createDefaultMenuConfig,
   createGridLayout,
   datetimePickerAction,
@@ -14,19 +15,33 @@ import {
   uriAction,
 } from "./rich-menu.js";
 
-const { setRichMenuImageMock, MessagingApiBlobClientMock } = vi.hoisted(() => {
+const {
+  createRichMenuMock,
+  setRichMenuImageMock,
+  MessagingApiClientMock,
+  MessagingApiBlobClientMock,
+} = vi.hoisted(() => {
+  const createRichMenuMockLocal = vi.fn();
   const setRichMenuImageMockLocal = vi.fn();
+  const MessagingApiClientMockLocal = vi.fn(function () {
+    return { createRichMenu: createRichMenuMockLocal };
+  });
   const MessagingApiBlobClientMockLocal = vi.fn(function () {
     return { setRichMenuImage: setRichMenuImageMockLocal };
   });
   return {
+    createRichMenuMock: createRichMenuMockLocal,
     setRichMenuImageMock: setRichMenuImageMockLocal,
+    MessagingApiClientMock: MessagingApiClientMockLocal,
     MessagingApiBlobClientMock: MessagingApiBlobClientMockLocal,
   };
 });
 
 vi.mock("@line/bot-sdk", () => ({
-  messagingApi: { MessagingApiBlobClient: MessagingApiBlobClientMock },
+  messagingApi: {
+    MessagingApiClient: MessagingApiClientMock,
+    MessagingApiBlobClient: MessagingApiBlobClientMock,
+  },
 }));
 
 afterAll(() => {
@@ -240,6 +255,37 @@ const richMenuUploadCfg: OpenClawConfig = {
     },
   },
 };
+
+describe("createRichMenu", () => {
+  beforeEach(() => {
+    createRichMenuMock.mockReset();
+    createRichMenuMock.mockResolvedValue({ richMenuId: "rich-menu-1" });
+    MessagingApiClientMock.mockClear();
+  });
+
+  it("truncates names and chat bar text by grapheme cluster", async () => {
+    const emoji = "😀";
+    const familyEmoji = "👨‍👩‍👧‍👦";
+
+    await createRichMenu(
+      {
+        size: { width: 2500, height: 843 },
+        name: emoji.repeat(301),
+        chatBarText: familyEmoji.repeat(15),
+        areas: [],
+      },
+      { cfg: richMenuUploadCfg },
+    );
+
+    expect(MessagingApiClientMock).toHaveBeenCalledWith({ channelAccessToken: "line-token" });
+    expect(createRichMenuMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: emoji.repeat(300),
+        chatBarText: familyEmoji.repeat(14),
+      }),
+    );
+  });
+});
 
 describe("uploadRichMenuImage", () => {
   let tempRoot: string;

--- a/extensions/line/src/rich-menu.ts
+++ b/extensions/line/src/rich-menu.ts
@@ -4,6 +4,7 @@ import { getAgentScopedMediaLocalRoots } from "openclaw/plugin-sdk/agent-media-p
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import { mimeTypeFromFilePath } from "openclaw/plugin-sdk/media-mime";
 import { logVerbose } from "openclaw/plugin-sdk/runtime-env";
+import { truncateUtf16Safe } from "openclaw/plugin-sdk/text-utility-runtime";
 import { loadWebMediaRaw } from "openclaw/plugin-sdk/web-media";
 import { resolveLineAccount } from "./accounts.js";
 import { datetimePickerAction, messageAction, postbackAction, uriAction } from "./actions.js";
@@ -87,8 +88,8 @@ export async function createRichMenu(
   const richMenuRequest: RichMenuRequest = {
     size: menu.size,
     selected: menu.selected ?? false,
-    name: menu.name.slice(0, 300),
-    chatBarText: menu.chatBarText.slice(0, 14),
+    name: truncateUtf16Safe(menu.name, 300),
+    chatBarText: truncateUtf16Safe(menu.chatBarText, 14),
     areas: menu.areas as RichMenuArea[],
   };
 

--- a/extensions/line/src/rich-menu.ts
+++ b/extensions/line/src/rich-menu.ts
@@ -4,7 +4,6 @@ import { getAgentScopedMediaLocalRoots } from "openclaw/plugin-sdk/agent-media-p
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import { mimeTypeFromFilePath } from "openclaw/plugin-sdk/media-mime";
 import { logVerbose } from "openclaw/plugin-sdk/runtime-env";
-import { truncateUtf16Safe } from "openclaw/plugin-sdk/text-utility-runtime";
 import { loadWebMediaRaw } from "openclaw/plugin-sdk/web-media";
 import { resolveLineAccount } from "./accounts.js";
 import { datetimePickerAction, messageAction, postbackAction, uriAction } from "./actions.js";
@@ -15,6 +14,8 @@ type RichMenuResponse = messagingApi.RichMenuResponse;
 type RichMenuArea = messagingApi.RichMenuArea;
 type Action = messagingApi.Action;
 const USER_BATCH_SIZE = 500;
+// LINE counts rich-menu names and chat-bar text in grapheme clusters, unlike most message fields.
+const graphemeSegmenter = new Intl.Segmenter(undefined, { granularity: "grapheme" });
 
 export interface RichMenuSize {
   width: 2500;
@@ -79,6 +80,19 @@ function chunkUserIds(userIds: string[]): string[][] {
   return batches;
 }
 
+function truncateGraphemes(input: string, maxLength: number): string {
+  let result = "";
+  let count = 0;
+  for (const { segment } of graphemeSegmenter.segment(input)) {
+    if (count >= maxLength) {
+      break;
+    }
+    result += segment;
+    count += 1;
+  }
+  return result;
+}
+
 export async function createRichMenu(
   menu: CreateRichMenuParams,
   opts: RichMenuOpts,
@@ -88,8 +102,8 @@ export async function createRichMenu(
   const richMenuRequest: RichMenuRequest = {
     size: menu.size,
     selected: menu.selected ?? false,
-    name: truncateUtf16Safe(menu.name, 300),
-    chatBarText: truncateUtf16Safe(menu.chatBarText, 14),
+    name: truncateGraphemes(menu.name, 300),
+    chatBarText: truncateGraphemes(menu.chatBarText, 14),
     areas: menu.areas as RichMenuArea[],
   };
 

--- a/extensions/line/src/send.ts
+++ b/extensions/line/src/send.ts
@@ -4,6 +4,7 @@ import { recordChannelActivity } from "openclaw/plugin-sdk/channel-activity-runt
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import { requireRuntimeConfig } from "openclaw/plugin-sdk/plugin-config-runtime";
 import { logVerbose } from "openclaw/plugin-sdk/runtime-env";
+import { truncateUtf16Safe } from "openclaw/plugin-sdk/text-utility-runtime";
 import { resolveLineAccount } from "./accounts.js";
 import { messageAction } from "./actions.js";
 import { resolveLineChannelAccessToken } from "./channel-access-token.js";
@@ -162,8 +163,8 @@ export function createLocationMessage(location: {
 }): LocationMessage {
   return {
     type: "location",
-    title: location.title.slice(0, 100),
-    address: location.address.slice(0, 100),
+    title: truncateUtf16Safe(location.title, 100),
+    address: truncateUtf16Safe(location.address, 100),
     latitude: location.latitude,
     longitude: location.longitude,
   };
@@ -419,7 +420,7 @@ export async function pushFlexMessage(
 ): Promise<LineSendResult> {
   const flexMessage: FlexMessage = {
     type: "flex",
-    altText: altText.slice(0, 400),
+    altText: truncateUtf16Safe(altText, 400),
     contents,
   };
 


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where several LINE outbound fields can be sent to the LINE API with a **broken character (a lone UTF-16 surrogate)** when an emoji straddles the field's hard length cap. Sixteen call sites across six files still capped user-facing strings with a raw `.slice(0, N)`:

- flex message `altText` (400-char cap) — `outbound.ts`, `send.ts`, `auto-reply-delivery.ts`, `card-command.ts` (×4)
- location `title`/`address` (100) — `outbound.ts`, `send.ts`
- rich-menu `name` (300) and `chatBarText` (14) — `rich-menu.ts`
- code-block display text (2000) — `markdown-to-line.ts`

A raw slice cuts an emoji's surrogate pair in half, leaving a dangling surrogate in the payload (rendered as a broken glyph; serializes as an invalid lone `\uD83D`, which the LINE API can reject). The 14-char `chatBarText` cap is especially easy to hit with emoji menu labels.

## Why This Change Was Made

Each cap now goes through `truncateUtf16Safe` — the same helper this plugin's own merged fixes already use for the sibling fields: action `label`/`data` (`actions.ts`, "fix(line): truncate action fields on code-point boundaries") and template `title`/`text`/`altText` (#97428). This PR brings the remaining outbound fields in line with those precedents; it is a mechanical 1:1 replacement of `.slice(0, N)` with `truncateUtf16Safe(x, N)` using the same limits — no behavior change for any string that fits or ends on a complete character.

## User Impact

LINE users whose flex alt text, location titles/addresses, rich-menu labels, or shared code blocks contain an emoji near a field's length cap get clean, valid messages instead of a broken glyph or a rejected API call. No configuration changes.

## Evidence

### Real terminal proof (standalone, non-test)

Drove the real caps (and the real `convertCodeBlockToFlexBubble`) from a standalone script, inspecting trailing UTF-16 code units:

```
[1] flex altText @ LINE's 400-char cap (emoji straddles index 400)
  BEFORE raw slice : len=400 tail=0x0061 0xd83d loneSurrogate=true
  AFTER  this PR   : len=399 tail=0x0061 0x0061 loneSurrogate=false
[2] rich-menu chatBarText @ 14-char cap (emoji straddles index 14)
  BEFORE raw slice : "Menu options \ud83d" tail=0x0020 0xd83d loneSurrogate=true
  AFTER  this PR   : "Menu options " tail=0x0073 0x0020 loneSurrogate=false
[3] real convertCodeBlockToFlexBubble @ 2000-char code cap
  flex code text: len=2003 endsWith "\n...": true loneSurrogate=false

RESULT: PASS — raw caps were broken; fixed fields are valid within LINE limits
```

`0xd83d` is the high-surrogate half of `😀` (`U+1F600`); on `main` it is left dangling at the end of the field.

### Regression tests (fail on unpatched code, pass here)

Added two focused tests driving the real production paths:

- `markdown-to-line.test.ts` — `does not split a surrogate pair at the truncation boundary`: code whose emoji straddles index 2000 through the real `convertCodeBlockToFlexBubble`.
- `auto-reply-delivery.test.ts` — `truncates flex altText on a surrogate boundary`: altText whose emoji straddles index 400 through the real `deliverLineAutoReply`, asserting the altText handed to the LINE message builder is ≤400 with no lone surrogate.

On unpatched `main` both fail (`expected true to be false` — a lone surrogate is present); with this PR both pass.

Touched-module suites all green: `markdown-to-line` (25), `auto-reply-delivery` (6), `rich-menu` + `channel.sendPayload` + `reply-payload-transform` (43), `message-cards` + `outbound-media` (51). oxlint and `oxfmt --check` clean on all eight files.

AI-assisted (Claude Code); change reviewed and understood by the author.