### PR TITLE
fix(plugins): emit model.usage diagnostics for plugin runtime.llm.complete calls

### DIFF
--- a/src/plugins/runtime/runtime-llm.runtime.test.ts
+++ b/src/plugins/runtime/runtime-llm.runtime.test.ts
@@ -10,12 +10,19 @@ const hoisted = vi.hoisted(() => ({
   prepareSimpleCompletionModelForAgent: vi.fn(),
   completeWithPreparedSimpleCompletionModel: vi.fn(),
   resolveSimpleCompletionSelectionForAgent: vi.fn(),
+  emitTrustedDiagnosticEvent: vi.fn(),
+  isDiagnosticsEnabled: vi.fn(),
 }));
 
 vi.mock("../../agents/simple-completion-runtime.js", () => ({
   prepareSimpleCompletionModelForAgent: hoisted.prepareSimpleCompletionModelForAgent,
   completeWithPreparedSimpleCompletionModel: hoisted.completeWithPreparedSimpleCompletionModel,
   resolveSimpleCompletionSelectionForAgent: hoisted.resolveSimpleCompletionSelectionForAgent,
+}));
+
+vi.mock("../../infra/diagnostic-events.js", () => ({
+  emitTrustedDiagnosticEvent: hoisted.emitTrustedDiagnosticEvent,
+  isDiagnosticsEnabled: hoisted.isDiagnosticsEnabled,
 }));
 
 const cfg = {
@@ -145,6 +152,9 @@ describe("runtime.llm.complete", () => {
     hoisted.prepareSimpleCompletionModelForAgent.mockReset();
     hoisted.completeWithPreparedSimpleCompletionModel.mockReset();
     hoisted.resolveSimpleCompletionSelectionForAgent.mockReset();
+    hoisted.emitTrustedDiagnosticEvent.mockReset();
+    hoisted.isDiagnosticsEnabled.mockReset();
+    hoisted.isDiagnosticsEnabled.mockReturnValue(true);
     primeCompletionMocks();
   });
 
@@ -767,5 +777,54 @@ describe("runtime.llm.complete", () => {
     expectSingleLogPayload(logger.warn as unknown as MockCalls, "plugin llm completion denied", {
       reason: "not trusted",
     });
+  });
+
+  it("emits model.usage diagnostic for plugin LLM calls when diagnostics are enabled", async () => {
+    const logger = createLogger();
+    const llm = createRuntimeLlm({
+      getConfig: () => cfg,
+      logger,
+      authority: {
+        allowComplete: true,
+      },
+    });
+
+    const result = await llm.complete({
+      messages: [{ role: "user", content: "Ping" }],
+    });
+
+    expect(hoisted.emitTrustedDiagnosticEvent).toHaveBeenCalledTimes(1);
+    const event = hoisted.emitTrustedDiagnosticEvent.mock.calls[0]?.[0];
+    expect(event).toBeDefined();
+    const usage = event as Record<string, unknown>;
+    expect(usage.type).toBe("model.usage");
+    expect(usage.provider).toBe("openai");
+    expect(usage.model).toBe("gpt-5.5");
+    const usageBlock = requireRecord(usage.usage, "diagnostic usage");
+    expect(usageBlock.input).toBe(11);
+    expect(usageBlock.output).toBe(7);
+    expect(usageBlock.cacheRead).toBe(5);
+    expect(usageBlock.cacheWrite).toBe(2);
+    expect(usageBlock.total).toBe(25);
+    expect(usage.costUsd).toBe(0.0042);
+    expect(result.usage?.costUsd).toBe(0.0042);
+  });
+
+  it("skips model.usage diagnostic when diagnostics are disabled", async () => {
+    hoisted.isDiagnosticsEnabled.mockReturnValue(false);
+    const logger = createLogger();
+    const llm = createRuntimeLlm({
+      getConfig: () => cfg,
+      logger,
+      authority: {
+        allowComplete: true,
+      },
+    });
+
+    await llm.complete({
+      messages: [{ role: "user", content: "Ping" }],
+    });
+
+    expect(hoisted.emitTrustedDiagnosticEvent).not.toHaveBeenCalled();
   });
 });

--- a/src/plugins/runtime/runtime-llm.runtime.ts
+++ b/src/plugins/runtime/runtime-llm.runtime.ts
@@ -4,8 +4,9 @@ import { normalizeOptionalString } from "@openclaw/normalization-core/string-coe
 import { modelKey } from "../../agents/model-ref-shared.js";
 import { normalizeModelRef } from "../../agents/model-selection.js";
 import type { NormalizedUsage, UsageLike } from "../../agents/usage.js";
-import { normalizeUsage } from "../../agents/usage.js";
+import { hasNonzeroUsage, normalizeUsage } from "../../agents/usage.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
+import { emitTrustedDiagnosticEvent, isDiagnosticsEnabled } from "../../infra/diagnostic-events.js";
 import type { Api, Message } from "../../llm/types.js";
 import { getChildLogger } from "../../logging.js";
 import { normalizeAgentId } from "../../routing/session-key.js";
@@ -475,6 +476,24 @@ export function createRuntimeLlm(options: CreateRuntimeLlmOptions = {}): PluginR
         model: prepared.selection.modelId,
         usage,
       });
+
+      if (isDiagnosticsEnabled(cfg) && hasNonzeroUsage(normalizedUsage)) {
+        emitTrustedDiagnosticEvent({
+          type: "model.usage",
+          sessionKey: options.authority?.sessionKey,
+          agentId,
+          provider: prepared.selection.provider,
+          model: prepared.selection.modelId,
+          usage: {
+            input: normalizedUsage.input,
+            output: normalizedUsage.output,
+            cacheRead: normalizedUsage.cacheRead,
+            cacheWrite: normalizedUsage.cacheWrite,
+            total: normalizedUsage.total,
+          },
+          costUsd: usage.costUsd,
+        });
+      }
 
       return {
         text,


### PR DESCRIPTION
## What Problem This Solves

  Plugin-initiated LLM calls via `api.runtime.llm.complete` are invisible to
  diagnostics — `model.usage` telemetry is only emitted from the main agent
  loop. Plugins that call LLMs (e.g. summarization) leave no trace in OTLP
  metrics, making it impossible to track token consumption or cost across
  plugin workloads.

  Fixes #98968

  ## Why This Change Was Made

  The plugin runtime already computes usage and cost via `buildUsage()`, but
  the result is only logged (`logger.info`) and never emitted as a diagnostic
  event. This change adds a `model.usage` diagnostic emission at the same
  call site, gated by the same `isDiagnosticsEnabled` + `hasNonzeroUsage`
  checks used by the main agent loop emitter.

  ## User Impact

  - Plugin LLM calls now appear in diagnostics-otel / OTLP exports alongside
    main agent loop calls
  - No config changes required — gated by existing `diagnostics.enabled`
  - Plugin authors don't need to change anything

   ## Evidence

  - **23/23 tests pass** (21 existing + 2 new):
    - `emits model.usage diagnostic for plugin LLM calls when diagnostics are enabled`
    - `skips model.usage diagnostic when diagnostics are disabled`

  - The emission follows the same `DiagnosticUsageEvent` shape used by the main
    agent loop in `agent-runner.ts:2206`, gated by the same
    `isDiagnosticsEnabled` + `hasNonzeroUsage` checks.

  ```
  Test Files  1 passed (1)
       Tests  23 passed (23)
  ```

  ---