### PR TITLE
docs(irc): document missing mentionPatterns config field

### DIFF
--- a/docs/channels/irc.md
+++ b/docs/channels/irc.md
@@ -58,6 +58,7 @@ Config keys:
 - Group sender allowlist (channel sender access): `channels.irc.groupAllowFrom`
 - Per-channel controls (channel + sender + mention rules): `channels.irc.groups["#channel"]`
 - `channels.irc.groupPolicy="open"` allows unconfigured channels (**still mention-gated by default**)
+- `channels.irc.mentionPatterns` — custom regex patterns the bot listens for in channel messages. When set, messages must match at least one pattern to trigger a reply (overrides the default nick-based mention matching). Accepts an array of regex strings. Useful for non-standard nick formats or keyword-based triggering.
 
 Allowlist entries should use stable sender identities (`nick!user@host`).
 Bare nick matching is mutable and only enabled when `channels.irc.dangerouslyAllowNameMatching: true`.


### PR DESCRIPTION
## What Problem This Solves

`extensions/irc/src/config-schema.ts` defines `mentionPatterns` (an array of custom regex strings) at the account level, but `docs/channels/irc.md` does not list it as a config key. Users configuring IRC cannot discover this field from the docs.

- Problem: The `mentionPatterns` field exists in the IRC config schema and types but is absent from the access-control config key reference
- Solution: Add a `mentionPatterns` entry to the config key list in the Access control section
- What changed: `docs/channels/irc.md` (+1 line — one config key bullet)
- What did NOT change: No code or behavior changes. Documentation only.

## Evidence

### Schema (`extensions/irc/src/config-schema.ts:66`)

```typescript
mentionPatterns: z.array(z.string()).optional(),
```

### Runtime type (`extensions/irc/src/types.ts:57`)

```typescript
mentionPatterns?: string[];
```

### Runtime consumer — mention resolution (`extensions/irc/src/inbound.ts:224`)

```typescript
const mentionRegexes = core.channel.mentions.buildMentionRegexes(config as OpenClawConfig);
```

The IRC inbound handler builds mention regexes from the full channel config, which includes `mentionPatterns`. When set, these custom patterns override the default nick-based mention matching.

### Runtime consumer — channel policy resolver (`src/channels/mention-pattern-policy.ts:58`)

```typescript
const policy = isRecord(channelConfig) ? channelConfig.mentionPatterns : undefined;
```

The core channel framework reads `mentionPatterns` from each channel's config to resolve mention-pattern policies.

## User Impact

Users can now discover the `mentionPatterns` config field from the IRC docs. This is particularly useful for IRC setups with non-standard nick formats or keyword-based triggering requirements.
