### PR TITLE
fix(cli): root --help showed stale command descriptions that contradicted command help and completion

### DIFF
--- a/docs/cli/agents.md
+++ b/docs/cli/agents.md
@@ -7,7 +7,7 @@ title: "Agents"
 
 # `openclaw agents`
 
-Manage isolated agents (workspaces + auth + routing).
+Manage isolated agents (workspaces, auth, routing).
 
 Related:
 

--- a/docs/cli/doctor.md
+++ b/docs/cli/doctor.md
@@ -8,7 +8,7 @@ title: "Doctor"
 
 # `openclaw doctor`
 
-Health checks + quick fixes for the gateway and channels.
+Diagnose and repair config, Gateway, plugin, and channel problems.
 
 Related:
 

--- a/docs/cli/logs.md
+++ b/docs/cli/logs.md
@@ -1,5 +1,5 @@
 ---
-summary: "CLI reference for `openclaw logs` (tail gateway logs via RPC)"
+summary: "CLI reference for `openclaw logs` (tail Gateway logs locally or via RPC)"
 read_when:
   - You need to tail Gateway logs remotely (without SSH)
   - You want JSON log lines for tooling
@@ -8,7 +8,8 @@ title: "Logs"
 
 # `openclaw logs`
 
-Tail Gateway file logs over RPC (works in remote mode).
+Tail Gateway logs locally or via RPC (works in remote mode, with local file and
+journal fallbacks when the loopback Gateway is unavailable).
 
 Related:
 

--- a/docs/cli/models.md
+++ b/docs/cli/models.md
@@ -8,7 +8,7 @@ title: "Models"
 
 # `openclaw models`
 
-Model discovery, scanning, and configuration (default model, fallbacks, auth profiles).
+List, scan, and set model providers (default model, fallbacks, auth profiles).
 
 Related:
 

--- a/src/cli/capability-cli.ts
+++ b/src/cli/capability-cli.ts
@@ -2159,7 +2159,7 @@ export function registerCapabilityCli(program: Command) {
   const capability = program
     .command("infer")
     .alias("capability")
-    .description("Run provider-backed inference commands through a stable CLI surface")
+    .description("Run provider-backed model, media, search, and embedding commands")
     .addHelpText(
       "after",
       () =>

--- a/src/cli/channels-cli.ts
+++ b/src/cli/channels-cli.ts
@@ -97,7 +97,7 @@ export async function registerChannelsCli(
   const channelNames = formatCliChannelOptions();
   const channels = program
     .command("channels")
-    .description("Manage connected chat channels and accounts")
+    .description("Add, remove, login, and inspect messaging channels")
     .addHelpText(
       "after",
       () =>

--- a/src/cli/cron-cli/register.ts
+++ b/src/cli/cron-cli/register.ts
@@ -14,7 +14,7 @@ import { registerCronSimpleCommands } from "./register.cron-simple.js";
 export function registerCronCli(program: Command) {
   const cron = program
     .command("cron")
-    .description("Manage cron jobs (via Gateway)")
+    .description("Schedule and inspect Gateway background jobs")
     .addHelpText(
       "after",
       () =>

--- a/src/cli/daemon-cli/register.ts
+++ b/src/cli/daemon-cli/register.ts
@@ -8,7 +8,7 @@ import { addGatewayServiceCommands } from "./register-service-commands.js";
 export function registerDaemonCli(program: Command) {
   const daemon = program
     .command("daemon")
-    .description("Manage the Gateway service (launchd/systemd/schtasks)")
+    .description("Manage the Gateway service (legacy alias)")
     .addHelpText(
       "after",
       () =>

--- a/src/cli/devices-cli.ts
+++ b/src/cli/devices-cli.ts
@@ -40,7 +40,7 @@ const devicesCallOpts = (cmd: Command, defaults?: { timeoutMs?: number }) =>
     .option("--json", "Output JSON", false);
 
 export function registerDevicesCli(program: Command) {
-  const devices = program.command("devices").description("Device pairing and auth tokens");
+  const devices = program.command("devices").description("Device pairing + token management");
 
   devicesCallOpts(
     devices

--- a/src/cli/gateway-cli/register.ts
+++ b/src/cli/gateway-cli/register.ts
@@ -501,7 +501,7 @@ export function registerGatewayCli(program: Command) {
   const gateway = addGatewayRunCommand(
     program
       .command("gateway")
-      .description("Run, inspect, and query the WebSocket Gateway")
+      .description("Run, inspect, and query the OpenClaw Gateway")
       .addHelpText(
         "after",
         () =>

--- a/src/cli/gateway-cli/register.ts
+++ b/src/cli/gateway-cli/register.ts
@@ -20,6 +20,7 @@ import { inheritOptionFromParent } from "../command-options.js";
 import { addGatewayServiceCommands } from "../daemon-cli/register-service-commands.js";
 import { parseGatewayPortOption } from "../gateway-port-option.js";
 import { formatHelpExamples } from "../help-format.js";
+import { subCliCommandDescription } from "../program/subcli-descriptors.js";
 import type { GatewayRpcOpts } from "./call.js";
 import type { GatewayDiscoverOpts } from "./discover.js";
 import { addGatewayRunCommand } from "./run-command.js";
@@ -501,7 +502,7 @@ export function registerGatewayCli(program: Command) {
   const gateway = addGatewayRunCommand(
     program
       .command("gateway")
-      .description("Run, inspect, and query the OpenClaw Gateway")
+      .description(subCliCommandDescription("gateway"))
       .addHelpText(
         "after",
         () =>

--- a/src/cli/logs-cli.ts
+++ b/src/cli/logs-cli.ts
@@ -532,7 +532,7 @@ async function emitGatewayError(
 export function registerLogsCli(program: Command) {
   const logs = program
     .command("logs")
-    .description("Tail gateway file logs via RPC")
+    .description("Tail Gateway logs locally or via RPC")
     .option("--limit <n>", "Max lines to return", "200")
     .option("--max-bytes <n>", "Max bytes to read", "250000")
     .option("--follow", "Follow log output", false)

--- a/src/cli/models-cli.ts
+++ b/src/cli/models-cli.ts
@@ -39,7 +39,7 @@ async function withModelsRuntime(
 export function registerModelsCli(program: Command) {
   const models = program
     .command("models")
-    .description("Model discovery, scanning, and configuration")
+    .description("List, scan, and set model providers")
     .option("--status-json", "Output JSON (alias for `models status --json`)", false)
     .option("--status-plain", "Plain output (alias for `models status --plain`)", false)
     .option("--agent <id>", "Agent id to inspect (overrides OPENCLAW_AGENT_DIR)")

--- a/src/cli/plugins-cli.ts
+++ b/src/cli/plugins-cli.ts
@@ -89,7 +89,7 @@ const loadPluginsAuthoringCommands = createModuleLoader(
 export function registerPluginsCli(program: Command) {
   const plugins = program
     .command("plugins")
-    .description("Manage OpenClaw plugins and extensions")
+    .description("Install, enable, disable, and inspect plugins")
     .addHelpText(
       "after",
       () =>

--- a/src/cli/program/core-command-descriptors.ts
+++ b/src/cli/program/core-command-descriptors.ts
@@ -13,12 +13,12 @@ const coreCliCommandCatalog = defineCommandDescriptorCatalog([
   },
   {
     name: "setup",
-    description: "Initialize local config and an agent workspace",
+    description: "Alias for openclaw onboard",
     hasSubcommands: false,
   },
   {
     name: "onboard",
-    description: "Interactive onboarding for gateway, workspace, and skills",
+    description: "Guided setup for auth, models, Gateway, workspace, channels, and skills",
     hasSubcommands: false,
   },
   {
@@ -29,7 +29,7 @@ const coreCliCommandCatalog = defineCommandDescriptorCatalog([
   {
     name: "config",
     description:
-      "Non-interactive config helpers (get/set/unset/file/validate). Default: starts guided setup.",
+      "Non-interactive config helpers (get/set/patch/unset/file/schema/validate). Run without subcommand for guided setup.",
     hasSubcommands: true,
   },
   {
@@ -64,12 +64,12 @@ const coreCliCommandCatalog = defineCommandDescriptorCatalog([
   },
   {
     name: "message",
-    description: "Send, read, and manage channel messages",
+    description: "Send, read, and manage messages and channel actions",
     hasSubcommands: true,
   },
   {
     name: "mcp",
-    description: "Manage OpenClaw MCP config and channel bridge",
+    description: "Manage OpenClaw mcp.servers config and channel bridge",
     hasSubcommands: true,
     parentDefaultHelp: true,
   },
@@ -80,7 +80,7 @@ const coreCliCommandCatalog = defineCommandDescriptorCatalog([
   },
   {
     name: "agent",
-    description: "Run one agent turn via the Gateway",
+    description: "Run an agent turn via the Gateway (use --local for embedded)",
     hasSubcommands: false,
   },
   {
@@ -90,7 +90,7 @@ const coreCliCommandCatalog = defineCommandDescriptorCatalog([
   },
   {
     name: "status",
-    description: "Show Gateway, channel, model, and recent-session status",
+    description: "Show channel health and recent session recipients",
     hasSubcommands: false,
   },
   {
@@ -110,7 +110,7 @@ const coreCliCommandCatalog = defineCommandDescriptorCatalog([
   },
   {
     name: "tasks",
-    description: "Inspect durable background tasks and flows",
+    description: "Inspect durable background tasks and TaskFlow state",
     hasSubcommands: true,
   },
 ] as const satisfies ReadonlyArray<CoreCliCommandDescriptor>);

--- a/src/cli/program/help.ts
+++ b/src/cli/program/help.ts
@@ -24,9 +24,9 @@ const ROOT_COMMANDS_HINT =
 
 const EXAMPLES = [
   ["openclaw onboard", "Run guided setup for a local Gateway, workspace, auth, and channels."],
-  ["openclaw setup", "Create the baseline config, workspace, and session folders."],
+  ["openclaw setup --baseline", "Create the baseline config, workspace, and session folders."],
   ["openclaw configure", "Change models, Gateway, channels, plugins, skills, and health checks."],
-  ["openclaw status", "Check Gateway, channel, model, and recent-session status."],
+  ["openclaw status", "Show channel health and recent session recipients."],
   ["openclaw doctor --fix", "Repair common config, service, plugin, and channel problems."],
   ["openclaw channels add", "Add or update a chat channel account with guided prompts."],
   ["openclaw channels status", "See connected messaging accounts and login state."],

--- a/src/cli/program/register.agent.ts
+++ b/src/cli/program/register.agent.ts
@@ -74,7 +74,7 @@ async function runAgentsCommandAction(
 export function registerAgentsCommands(program: Command): void {
   const agents = program
     .command("agents")
-    .description("Manage isolated agents (workspaces + auth + routing)")
+    .description("Manage isolated agents (workspaces, auth, routing)")
     .addHelpText(
       "after",
       () =>

--- a/src/cli/program/register.crestodian.ts
+++ b/src/cli/program/register.crestodian.ts
@@ -10,7 +10,7 @@ import { formatHelpExamples } from "../help-format.js";
 export function registerCrestodianCommand(program: Command) {
   program
     .command("crestodian")
-    .description("Open the ring-zero setup and repair helper")
+    .description("Open the interactive setup and repair assistant")
     .option("-m, --message <text>", "Run one Crestodian request")
     .option("--yes", "Approve persistent config writes for this request", false)
     .option("--json", "Output startup overview as JSON", false)

--- a/src/cli/program/register.maintenance.ts
+++ b/src/cli/program/register.maintenance.ts
@@ -9,7 +9,7 @@ import { runCommandWithRuntime } from "../cli-utils.js";
 export function registerMaintenanceCommands(program: Command) {
   program
     .command("doctor")
-    .description("Health checks + quick fixes for the gateway and channels")
+    .description("Diagnose and repair config, Gateway, plugin, and channel problems")
     .addHelpText(
       "after",
       () =>

--- a/src/cli/program/register.status-health-sessions.ts
+++ b/src/cli/program/register.status-health-sessions.ts
@@ -159,7 +159,7 @@ export function registerStatusHealthSessionsCommands(program: Command) {
 
   program
     .command("health")
-    .description("Fetch health from the running gateway")
+    .description("Fetch detailed health from the running Gateway")
     .option("--json", "Output JSON instead of text", false)
     .option("--timeout <ms>", "Connection timeout in milliseconds", "10000")
     .option("--verbose", "Verbose logging", false)

--- a/src/cli/program/register.subclis-core.ts
+++ b/src/cli/program/register.subclis-core.ts
@@ -22,6 +22,7 @@ import {
 import {
   getSubCliCommandsWithSubcommands,
   getSubCliEntries as getSubCliEntryDescriptors,
+  subCliCommandDescription,
   type SubCliDescriptor,
 } from "./subcli-descriptors.js";
 
@@ -58,7 +59,7 @@ async function registerGatewayRunOnly(program: Command): Promise<void> {
   const { addGatewayRunCommand } = await import("../gateway-cli/run-command.js");
   removeCommandByName(program, "gateway");
   const gateway = addGatewayRunCommand(
-    program.command("gateway").description("Run, inspect, and query the OpenClaw Gateway"),
+    program.command("gateway").description(subCliCommandDescription("gateway")),
   );
   addGatewayRunCommand(
     gateway.command("run").description("Run the WebSocket Gateway (foreground)"),

--- a/src/cli/program/register.subclis-core.ts
+++ b/src/cli/program/register.subclis-core.ts
@@ -58,7 +58,7 @@ async function registerGatewayRunOnly(program: Command): Promise<void> {
   const { addGatewayRunCommand } = await import("../gateway-cli/run-command.js");
   removeCommandByName(program, "gateway");
   const gateway = addGatewayRunCommand(
-    program.command("gateway").description("Run, inspect, and query the WebSocket Gateway"),
+    program.command("gateway").description("Run, inspect, and query the OpenClaw Gateway"),
   );
   addGatewayRunCommand(
     gateway.command("run").description("Run the WebSocket Gateway (foreground)"),

--- a/src/cli/program/root-command-descriptions.test.ts
+++ b/src/cli/program/root-command-descriptions.test.ts
@@ -1,0 +1,62 @@
+// Contract: root `--help` renders descriptions from the placeholder catalogs while
+// `<command> --help` and shell completion render the registered command. Both must
+// present the same text for every root command (https://github.com/openclaw/openclaw/issues/98978).
+import { Command } from "commander";
+import { describe, expect, it } from "vitest";
+import {
+  getCoreCliCommandDescriptors,
+  getCoreCliCommandNames,
+  registerCoreCliByName,
+} from "./command-registry-core.js";
+import { createProgramContext } from "./context.js";
+import { getSubCliEntries, registerSubCliByName } from "./register.subclis-core.js";
+
+// argv-rewrite aliases keep a catalog placeholder for root help but never register a
+// real command, so they have no registered description to compare.
+const ARGV_ALIAS_ONLY_COMMANDS = new Set(["capability", "terminal", "chat"]);
+
+describe("root command descriptions", () => {
+  it("keeps catalog placeholders and registered commands in sync", async () => {
+    const program = new Command().name("openclaw");
+    const ctx = createProgramContext();
+    // Mirror the `openclaw completion` eager registration path: neutral completion
+    // argv keeps command-path policies from narrowing or loading plugin commands.
+    const argv = ["node", "openclaw", "completion"];
+
+    for (const name of getCoreCliCommandNames()) {
+      await registerCoreCliByName(program, ctx, name, argv);
+    }
+    for (const entry of getSubCliEntries()) {
+      // `completion` registers itself outside the sub-CLI group entries.
+      if (entry.name === "completion") {
+        continue;
+      }
+      await registerSubCliByName(program, entry.name, argv, { purpose: "completion" });
+    }
+
+    const descriptors = [...getCoreCliCommandDescriptors(), ...getSubCliEntries()].filter(
+      (descriptor) => descriptor.name !== "completion",
+    );
+    const commandsByName = new Map(program.commands.map((command) => [command.name(), command]));
+
+    const missing: string[] = [];
+    const mismatches: string[] = [];
+    for (const descriptor of descriptors) {
+      const command = commandsByName.get(descriptor.name);
+      if (!command) {
+        if (!ARGV_ALIAS_ONLY_COMMANDS.has(descriptor.name)) {
+          missing.push(descriptor.name);
+        }
+        continue;
+      }
+      if (command.description() !== descriptor.description) {
+        mismatches.push(
+          `${descriptor.name}\n  catalog:    ${descriptor.description}\n  registered: ${command.description()}`,
+        );
+      }
+    }
+
+    expect(missing, "catalog entries with no registered command").toEqual([]);
+    expect(mismatches, "root help vs registered command description drift").toEqual([]);
+  });
+});

--- a/src/cli/program/root-command-descriptions.test.ts
+++ b/src/cli/program/root-command-descriptions.test.ts
@@ -2,7 +2,8 @@
 // `<command> --help` and shell completion render the registered command. Both must
 // present the same text for every root command (https://github.com/openclaw/openclaw/issues/98978).
 import { Command } from "commander";
-import { describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { registerCompletionCli } from "../completion-cli.js";
 import {
   getCoreCliCommandDescriptors,
   getCoreCliCommandNames,
@@ -11,11 +12,18 @@ import {
 import { createProgramContext } from "./context.js";
 import { getSubCliEntries, registerSubCliByName } from "./register.subclis-core.js";
 
-// argv-rewrite aliases keep a catalog placeholder for root help but never register a
-// real command, so they have no registered description to compare.
-const ARGV_ALIAS_ONLY_COMMANDS = new Set(["capability", "terminal", "chat"]);
-
 describe("root command descriptions", () => {
+  beforeEach(() => {
+    // Pin the private QA gate closed so the registered tree is deterministic
+    // regardless of the invoking shell (the qa registrar needs a built dist).
+    // beforeEach, not beforeAll: the shared test setup unstubs envs per test.
+    vi.stubEnv("OPENCLAW_ENABLE_PRIVATE_QA_CLI", "");
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
   it("keeps catalog placeholders and registered commands in sync", async () => {
     const program = new Command().name("openclaw");
     const ctx = createProgramContext();
@@ -23,28 +31,27 @@ describe("root command descriptions", () => {
     // argv keeps command-path policies from narrowing or loading plugin commands.
     const argv = ["node", "openclaw", "completion"];
 
+    registerCompletionCli(program);
     for (const name of getCoreCliCommandNames()) {
       await registerCoreCliByName(program, ctx, name, argv);
     }
     for (const entry of getSubCliEntries()) {
-      // `completion` registers itself outside the sub-CLI group entries.
-      if (entry.name === "completion") {
-        continue;
-      }
       await registerSubCliByName(program, entry.name, argv, { purpose: "completion" });
     }
 
-    const descriptors = [...getCoreCliCommandDescriptors(), ...getSubCliEntries()].filter(
-      (descriptor) => descriptor.name !== "completion",
-    );
+    const descriptors = [...getCoreCliCommandDescriptors(), ...getSubCliEntries()];
     const commandsByName = new Map(program.commands.map((command) => [command.name(), command]));
+    // capability/terminal/chat register as commander aliases of infer/tui. Their
+    // catalog rows intentionally describe the alias itself, so they are checked for
+    // existence as aliases instead of description equality.
+    const aliasNames = new Set(program.commands.flatMap((command) => command.aliases()));
 
     const missing: string[] = [];
     const mismatches: string[] = [];
     for (const descriptor of descriptors) {
       const command = commandsByName.get(descriptor.name);
       if (!command) {
-        if (!ARGV_ALIAS_ONLY_COMMANDS.has(descriptor.name)) {
+        if (!aliasNames.has(descriptor.name)) {
           missing.push(descriptor.name);
         }
         continue;
@@ -56,7 +63,7 @@ describe("root command descriptions", () => {
       }
     }
 
-    expect(missing, "catalog entries with no registered command").toEqual([]);
+    expect(missing, "catalog entries with no registered command or alias").toEqual([]);
     expect(mismatches, "root help vs registered command description drift").toEqual([]);
   });
 });

--- a/src/cli/program/subcli-descriptors.ts
+++ b/src/cli/program/subcli-descriptors.ts
@@ -7,7 +7,7 @@ import { isPrivateQaCliEnabled } from "./private-qa-cli.js";
 export type SubCliDescriptor = NamedCommandDescriptor;
 
 const subCliCommandCatalog = defineCommandDescriptorCatalog([
-  { name: "acp", description: "Run and manage ACP-backed coding agents", hasSubcommands: true },
+  { name: "acp", description: "Run an ACP bridge backed by the Gateway", hasSubcommands: true },
   {
     name: "gateway",
     description: "Run, inspect, and query the OpenClaw Gateway",
@@ -52,7 +52,7 @@ const subCliCommandCatalog = defineCommandDescriptorCatalog([
   },
   {
     name: "nodes",
-    description: "Pair nodes and run node-host commands through the Gateway",
+    description: "Manage gateway-owned nodes (pairing, status, invoke, and media)",
     hasSubcommands: true,
   },
   {
@@ -68,7 +68,7 @@ const subCliCommandCatalog = defineCommandDescriptorCatalog([
   },
   {
     name: "sandbox",
-    description: "Manage sandbox containers for agent isolation",
+    description: "Manage sandbox containers (Docker-based agent isolation)",
     hasSubcommands: true,
   },
   {
@@ -161,7 +161,7 @@ const subCliCommandCatalog = defineCommandDescriptorCatalog([
   },
   {
     name: "security",
-    description: "Security tools and local config audits",
+    description: "Audit local config and state for common security foot-guns",
     hasSubcommands: true,
   },
   {

--- a/src/cli/program/subcli-descriptors.ts
+++ b/src/cli/program/subcli-descriptors.ts
@@ -196,6 +196,17 @@ function filterPrivateQaItems<T>(
   return items.filter((item) => getName(item) !== "qa");
 }
 
+/** Canonical root description for one sub-CLI command; shared by fast-path registrations. */
+export function subCliCommandDescription(
+  name: (typeof subCliCommandCatalog.descriptors)[number]["name"],
+): string {
+  const descriptor = subCliCommandCatalog.descriptors.find((entry) => entry.name === name);
+  if (!descriptor) {
+    throw new Error(`Unknown sub-CLI command descriptor: ${name}`);
+  }
+  return descriptor.description;
+}
+
 /** Visible sub-CLI descriptors after private QA gating. */
 export const SUB_CLI_DESCRIPTORS = filterPrivateQaItems(
   subCliCommandCatalog.descriptors,

--- a/src/cli/qr-cli.ts
+++ b/src/cli/qr-cli.ts
@@ -94,7 +94,7 @@ function emitQrSecretResolveDiagnostics(diagnostics: string[], opts: QrCliOption
 export function registerQrCli(program: Command) {
   program
     .command("qr")
-    .description("Generate a mobile pairing QR code and setup code")
+    .description("Generate mobile pairing QR/setup code")
     .addHelpText(
       "after",
       () => `\n${theme.muted("Docs:")} ${formatDocsLink("/cli/qr", "docs.openclaw.ai/cli/qr")}\n`,

--- a/src/cli/run-main.ts
+++ b/src/cli/run-main.ts
@@ -36,7 +36,7 @@ import { hasJsonOutputFlag, withConsoleLogsRoutedToStderrForJson } from "./json-
 import { applyCliProfileEnv, parseCliProfileArgs } from "./profile.js";
 import { formatCliCommandSuggestions } from "./program/command-suggestions.js";
 import { getCoreCliCommandNames } from "./program/core-command-descriptors.js";
-import { getSubCliEntries } from "./program/subcli-descriptors.js";
+import { getSubCliEntries, subCliCommandDescription } from "./program/subcli-descriptors.js";
 import {
   resolvePrecomputedSubcommandHelpFastPath,
   resolveMissingPluginCommandMessage as resolveMissingPluginCommandMessageFromPolicy,
@@ -219,7 +219,7 @@ async function tryRunGatewayRunFastPath(
     });
   };
   const gateway = addGatewayRunCommand(
-    program.command("gateway").description("Run, inspect, and query the OpenClaw Gateway"),
+    program.command("gateway").description(subCliCommandDescription("gateway")),
     { beforeRun },
   );
   addGatewayRunCommand(

--- a/src/cli/run-main.ts
+++ b/src/cli/run-main.ts
@@ -219,7 +219,7 @@ async function tryRunGatewayRunFastPath(
     });
   };
   const gateway = addGatewayRunCommand(
-    program.command("gateway").description("Run, inspect, and query the WebSocket Gateway"),
+    program.command("gateway").description("Run, inspect, and query the OpenClaw Gateway"),
     { beforeRun },
   );
   addGatewayRunCommand(

--- a/src/cli/secrets-cli.ts
+++ b/src/cli/secrets-cli.ts
@@ -65,7 +65,7 @@ async function readPlanFile(pathname: string): Promise<SecretsApplyPlan> {
 export function registerSecretsCli(program: Command): void {
   const secrets = program
     .command("secrets")
-    .description("Secrets runtime controls")
+    .description("Audit, apply, and reload SecretRef-backed credentials")
     .addHelpText(
       "after",
       () =>

--- a/src/cli/skills-cli.ts
+++ b/src/cli/skills-cli.ts
@@ -309,7 +309,7 @@ async function readSkillProposalInput(options: {
 export function registerSkillsCli(program: Command) {
   const skills = program
     .command("skills")
-    .description("List and inspect available skills")
+    .description("List, inspect, and install agent skills")
     .option("--agent <id>", "Target agent workspace (defaults to cwd-inferred, then default agent)")
     .addHelpText(
       "after",

--- a/src/cli/system-cli.ts
+++ b/src/cli/system-cli.ts
@@ -50,7 +50,7 @@ async function runSystemGatewayCommand(
 export function registerSystemCli(program: Command) {
   const system = program
     .command("system")
-    .description("System tools (events, heartbeat, presence)")
+    .description("System events, heartbeat, and presence")
     .addHelpText(
       "after",
       () =>


### PR DESCRIPTION
Closes #98978

## What Problem This Solves

Fixes an issue where users reading `openclaw --help` would see command descriptions that contradict what `openclaw <command> --help` and shell completion show. 29 root commands were affected; the worst case is `config`, whose root-help line hid the real `patch` and `schema` subcommands (it advertised only `get/set/unset/file/validate`), so users could not discover `openclaw config patch` / `openclaw config schema` from the top-level help. Other rows described different behavior outright (`setup`, `daemon`, `acp`, `status`, `models`, `secrets`, `skills`).

## Why This Change Was Made

Root `--help` renders from static placeholder catalogs (`src/cli/program/core-command-descriptors.ts`, `subcli-descriptors.ts`, introduced in 9c89a74f84 for startup speed) while `<command> --help` and completion render the real registered command; the two copies drifted in both directions since 2026-03. This PR aligns all 29 pairs to one canonical text per command — taking whichever existing side is accurate today (verified against actual subcommands, e.g. `skills` does have `install`, `logs` does have a local fallback) — and adds a contract test (`src/cli/program/root-command-descriptions.test.ts`) that eagerly registers every cataloged command the same way `openclaw completion` does and fails on any future catalog/registration drift.

A review pass over the diff surfaced and fixed three adjacent instances of the same defect class: the root-help `Examples` block pinned the old `status` text and a behaviorally wrong `setup` example (plain `openclaw setup` runs the full wizard; the example now uses `setup --baseline`), and the `gateway` description existed in two additional fast-path registration sites (`run-main.ts`, `register.subclis-core.ts`) that no test executes — those now read the catalog via a shared `subCliCommandDescription()` accessor instead of keeping literals. Four docs pages quoting or paraphrasing old strings were aligned (`agents`, `doctor`, `models`, `logs`).

Non-goal: full single-sourcing of the remaining ~50 catalog/registrar description pairs (e.g. stamping catalog text onto commands after lazy-group registration in `register-command-groups.ts` and deleting all inline literals). That is a wider refactor of the registration mechanism; the contract test now pins the pairs together, and I am happy to do the consolidation as a follow-up if maintainers want it.

## User Impact

`openclaw --help`, `openclaw <command> --help`, and shell tab completion now show the same description for every root command, and `config patch` / `config schema` are discoverable from root help. No behavior, flags, config surface, or command routing changed — only user-visible description strings and docs.

## Evidence

Regression test fails without the fix (red run on unfixed tree listed all 29 drifted commands):

```text
❯ node scripts/run-vitest.mjs src/cli/program/root-command-descriptions.test.ts   # before fix
AssertionError: root help vs registered command description drift
  "config
  catalog:    Non-interactive config helpers (get/set/unset/file/validate). Default: starts guided setup.
  registered: Non-interactive config helpers (get/set/patch/unset/file/schema/validate). Run without subcommand for guided setup."
  ... (29 mismatches)
❯ node scripts/run-vitest.mjs src/cli/program/root-command-descriptions.test.ts   # after fix
Test Files  1 passed (1) / Tests  1 passed (1)
```

Before/after on the built CLI (macOS, Node 25.8, source checkout):

```console
# before (main)
$ openclaw --help | grep -A2 '  config'
  config *             Non-interactive config helpers
                       (get/set/unset/file/validate). Default: starts guided setup.
# after (this branch)
$ openclaw --help | grep -A2 '  config'
  config *             Non-interactive config helpers
                       (get/set/patch/unset/file/schema/validate). Run without
                       subcommand for guided setup.
```

Machine check across all three surfaces after the fix: regenerated `openclaw completion`, extracted every root entry description, compared against both catalogs — **0 drift** (was 29 on main).

Validation run locally:

- The contract test verifies alias-only catalog rows (`capability`, `terminal`, `chat`) by checking they exist as commander aliases (removing `.alias("capability")` from the infer registration now fails the test), covers the `completion` command itself, and pins the private-QA env gate closed so it is deterministic under shells exporting `OPENCLAW_ENABLE_PRIVATE_QA_CLI=1` (verified by running the battery with that variable set: all green).
- `node scripts/run-vitest.mjs` on the new contract test plus all 19 colocated tests of touched files: 501/502 pass. The single failure (`logs-cli.test.ts` "switches back to Gateway logs.tail after temporary journal fallback") is a pre-existing timezone-dependent assertion — it fails identically on pristine `main` with this branch's `logs-cli.ts` change stashed (expects `2026-05-29T20:00:00.000`, machine in UTC-6 renders `14:00:00.000-06:00`); unrelated to this diff, not touched per contributor guidelines.
- `oxfmt --check` clean on all touched files; `scripts/run-oxlint.mjs` clean.
- `pnpm tsgo:core` and `pnpm tsgo:core:test` green.
- `git diff --numstat`: prod (non-test, non-docs) diff is +47/−34 — the 29 string alignments net zero; the small growth is the shared `subCliCommandDescription()` accessor that deletes the two untestable gateway fast-path literals. Remaining new lines are the contract test.

AI-assisted: authored with Claude (Claude Code), per-change verification (drift table, provenance, subcommand accuracy checks, red/green test runs) executed and reviewed as described above.
