### PR TITLE
fix(plugins): emit usage diagnostics for runtime LLM completions

### DIFF
--- a/src/plugins/runtime/runtime-llm.runtime.test.ts
+++ b/src/plugins/runtime/runtime-llm.runtime.test.ts
@@ -2,6 +2,13 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { resolveContextEngineCapabilities } from "../../agents/embedded-agent-runner/context-engine-capabilities.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
+import {
+  onInternalDiagnosticEvent,
+  resetDiagnosticEventsForTest,
+  waitForDiagnosticEventsDrained,
+  type DiagnosticEventPayload,
+  type DiagnosticEventMetadata,
+} from "../../infra/diagnostic-events.js";
 import { withPluginRuntimePluginIdScope } from "./gateway-request-scope.js";
 import { createRuntimeLlm } from "./runtime-llm.runtime.js";
 import type { RuntimeLogger } from "./types-core.js";
@@ -142,6 +149,7 @@ function primeCompletionMocks() {
 
 describe("runtime.llm.complete", () => {
   beforeEach(() => {
+    resetDiagnosticEventsForTest();
     hoisted.prepareSimpleCompletionModelForAgent.mockReset();
     hoisted.completeWithPreparedSimpleCompletionModel.mockReset();
     hoisted.resolveSimpleCompletionSelectionForAgent.mockReset();
@@ -613,6 +621,79 @@ describe("runtime.llm.complete", () => {
       },
     );
     expectFields(requireRecord(logPayload.usage, "log usage"), { costUsd: 0.0042 });
+  });
+
+  it("emits model usage diagnostics for plugin runtime completions", async () => {
+    const events: Array<{ event: DiagnosticEventPayload; metadata: DiagnosticEventMetadata }> = [];
+    const unsubscribe = onInternalDiagnosticEvent((event, metadata) => {
+      events.push({ event, metadata });
+    });
+    const llm = createRuntimeLlm({
+      getConfig: () => cfg,
+      authority: {
+        allowComplete: true,
+        sessionKey: "agent:main:session:abc",
+      },
+    });
+
+    try {
+      await withPluginRuntimePluginIdScope("trusted-plugin", () =>
+        llm.complete({
+          messages: [{ role: "user", content: "Ping" }],
+        }),
+      );
+      await waitForDiagnosticEventsDrained();
+    } finally {
+      unsubscribe();
+    }
+
+    const usageEvent = events.find(({ event }) => event.type === "model.usage");
+    expect(usageEvent?.metadata.trusted).toBe(true);
+    expect(usageEvent?.event).toMatchObject({
+      type: "model.usage",
+      sessionKey: "agent:main:session:abc",
+      agentId: "main",
+      provider: "openai",
+      model: "gpt-5.5",
+      usage: {
+        input: 11,
+        output: 7,
+        cacheRead: 5,
+        cacheWrite: 2,
+        promptTokens: 18,
+        total: 25,
+      },
+      costUsd: 0.0042,
+    });
+  });
+
+  it("does not emit model usage diagnostics when diagnostics are disabled", async () => {
+    const events: DiagnosticEventPayload[] = [];
+    const unsubscribe = onInternalDiagnosticEvent((event) => {
+      events.push(event);
+    });
+    const llm = createRuntimeLlm({
+      getConfig: () => ({
+        ...cfg,
+        diagnostics: { enabled: false },
+      }),
+      authority: {
+        allowComplete: true,
+      },
+    });
+
+    try {
+      await withPluginRuntimePluginIdScope("trusted-plugin", () =>
+        llm.complete({
+          messages: [{ role: "user", content: "Ping" }],
+        }),
+      );
+      await waitForDiagnosticEventsDrained();
+    } finally {
+      unsubscribe();
+    }
+
+    expect(events.some((event) => event.type === "model.usage")).toBe(false);
   });
 
   it("uses scoped plugin identity and ignores caller-shaped spoofing input", async () => {

--- a/src/plugins/runtime/runtime-llm.runtime.ts
+++ b/src/plugins/runtime/runtime-llm.runtime.ts
@@ -4,8 +4,9 @@ import { normalizeOptionalString } from "@openclaw/normalization-core/string-coe
 import { modelKey } from "../../agents/model-ref-shared.js";
 import { normalizeModelRef } from "../../agents/model-selection.js";
 import type { NormalizedUsage, UsageLike } from "../../agents/usage.js";
-import { normalizeUsage } from "../../agents/usage.js";
+import { derivePromptTokens, normalizeUsage } from "../../agents/usage.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
+import { emitTrustedDiagnosticEvent, isDiagnosticsEnabled } from "../../infra/diagnostic-events.js";
 import type { Api, Message } from "../../llm/types.js";
 import { getChildLogger } from "../../logging.js";
 import { normalizeAgentId } from "../../routing/session-key.js";
@@ -215,6 +216,44 @@ function buildUsage(params: {
     ...(params.normalized?.total !== undefined ? { totalTokens: params.normalized.total } : {}),
     ...(costUsd !== undefined ? { costUsd } : {}),
   };
+}
+
+function emitPluginLlmUsageDiagnostic(params: {
+  cfg: OpenClawConfig;
+  usage: LlmCompleteUsage;
+  sessionKey?: string;
+  agentId: string;
+  provider: string;
+  model: string;
+}): void {
+  if (!isDiagnosticsEnabled(params.cfg)) {
+    return;
+  }
+  const promptTokens = derivePromptTokens({
+    input: params.usage.inputTokens,
+    cacheRead: params.usage.cacheReadTokens,
+    cacheWrite: params.usage.cacheWriteTokens,
+  });
+  emitTrustedDiagnosticEvent({
+    type: "model.usage",
+    ...(params.sessionKey ? { sessionKey: params.sessionKey } : {}),
+    agentId: params.agentId,
+    provider: params.provider,
+    model: params.model,
+    usage: {
+      ...(params.usage.inputTokens !== undefined ? { input: params.usage.inputTokens } : {}),
+      ...(params.usage.outputTokens !== undefined ? { output: params.usage.outputTokens } : {}),
+      ...(params.usage.cacheReadTokens !== undefined
+        ? { cacheRead: params.usage.cacheReadTokens }
+        : {}),
+      ...(params.usage.cacheWriteTokens !== undefined
+        ? { cacheWrite: params.usage.cacheWriteTokens }
+        : {}),
+      ...(promptTokens !== undefined ? { promptTokens } : {}),
+      ...(params.usage.totalTokens !== undefined ? { total: params.usage.totalTokens } : {}),
+    },
+    ...(params.usage.costUsd !== undefined ? { costUsd: params.usage.costUsd } : {}),
+  });
 }
 
 function finiteOption(value: number | undefined): number | undefined {
@@ -474,6 +513,14 @@ export function createRuntimeLlm(options: CreateRuntimeLlmOptions = {}): PluginR
         provider: prepared.selection.provider,
         model: prepared.selection.modelId,
         usage,
+      });
+      emitPluginLlmUsageDiagnostic({
+        cfg,
+        usage,
+        sessionKey: options.authority?.sessionKey,
+        agentId,
+        provider: prepared.selection.provider,
+        model: prepared.selection.modelId,
       });
 
       return {


### PR DESCRIPTION
Closes #98968

## What Problem This Solves

Fixes an issue where OpenClaw plugins using runtime.llm.complete would produce completion logs with usage and cost, but would not emit trusted model.usage diagnostics for diagnostics exporters and metrics consumers.

## Why This Change Was Made

The plugin runtime now emits a host-owned model.usage diagnostic after a successful runtime LLM completion, using the same normalized provider/model/usage/cost data already returned to the plugin and respecting the existing diagnostics.enabled gate. The change stays inside the plugin runtime LLM owner boundary and does not change the runtime.llm.complete response shape.

## User Impact

Operators using diagnostics exporters can now see plugin runtime LLM completions in the same model usage stream as agent, cron, and channel model calls. Disabled diagnostics remain quiet.

## Evidence

- Claim proved: plugin runtime LLM completions emit trusted model.usage diagnostics with provider, model, agent/session attribution, input/output/cache/prompt/total tokens, and cost; diagnostics.enabled=false suppresses the event.
- Commands / artifacts:
  - node scripts/run-vitest.mjs src/plugins/runtime/runtime-llm.runtime.test.ts -- --reporter=verbose -t "model usage diagnostics"
  - git diff --check
  - python .agents\skills\autoreview\scripts\autoreview --mode local
- Observed result:
  - Focused Vitest passed on head 2669f916792660a5e207b5f66d955f2deccf0094: 1 file, 2 tests passed, 21 skipped. The passing tests were "emits model usage diagnostics for plugin runtime completions" and "does not emit model usage diagnostics when diagnostics are disabled".
  - The positive test subscribes to onInternalDiagnosticEvent, calls runtime.llm.complete through withPluginRuntimePluginIdScope, waits for waitForDiagnosticEventsDrained, and asserts trusted metadata plus the exact model.usage payload: sessionKey agent:main:session:abc, agentId main, provider openai, model gpt-5.5, input 11, output 7, cacheRead 5, cacheWrite 2, promptTokens 18, total 25, costUsd 0.0042.
  - The disabled-diagnostics test uses cfg.diagnostics.enabled=false, calls runtime.llm.complete through the same plugin runtime path, drains diagnostic events, and asserts no model.usage event was emitted.
  - git diff --check passed.
  - Autoreview clean: no accepted/actionable findings reported.
- Not tested / proof gaps:
  - Did not run a live OTLP or Prometheus exporter. The focused test subscribes to the real internal diagnostic dispatcher and verifies the trusted event shape emitted by the plugin runtime LLM completion path directly.
