### PR TITLE
fix(codex): honor dynamic tool timeoutSeconds

### DIFF
--- a/extensions/codex/src/app-server/dynamic-tool-execution.test.ts
+++ b/extensions/codex/src/app-server/dynamic-tool-execution.test.ts
@@ -40,6 +40,35 @@ describe("dynamic tool execution helpers", () => {
     ).toBe(timeoutMs);
   });
 
+  it("uses per-call timeoutSeconds when timeoutMs is absent", () => {
+    expect(
+      resolveDynamicToolCallTimeoutMs({
+        call: {
+          threadId: "thread-1",
+          turnId: "turn-1",
+          callId: "call-seconds",
+          namespace: null,
+          tool: "session_status",
+          arguments: { sessionKey: "current", timeoutSeconds: 2 },
+        },
+        config: undefined,
+      }),
+    ).toBe(12_000);
+    expect(
+      resolveDynamicToolCallTimeoutMs({
+        call: {
+          threadId: "thread-1",
+          turnId: "turn-1",
+          callId: "call-prefers-ms",
+          namespace: null,
+          tool: "session_status",
+          arguments: { sessionKey: "current", timeoutMs: 1500, timeoutSeconds: 2 },
+        },
+        config: undefined,
+      }),
+    ).toBe(1500);
+  });
+
   it("ignores partial dynamic tool timeout strings", () => {
     expect(
       resolveDynamicToolCallTimeoutMs({
@@ -54,6 +83,24 @@ describe("dynamic tool execution helpers", () => {
         config: undefined,
       }),
     ).toBe(CODEX_DYNAMIC_TOOL_TIMEOUT_MS);
+  });
+
+  it("ignores invalid per-call timeoutSeconds values", () => {
+    for (const timeoutSeconds of [0, -1, "2" as never, Number.NaN]) {
+      expect(
+        resolveDynamicToolCallTimeoutMs({
+          call: {
+            threadId: "thread-1",
+            turnId: "turn-1",
+            callId: "call-invalid-seconds",
+            namespace: null,
+            tool: "session_status",
+            arguments: { sessionKey: "current", timeoutSeconds },
+          },
+          config: undefined,
+        }),
+      ).toBe(CODEX_DYNAMIC_TOOL_TIMEOUT_MS);
+    }
   });
 
   it("uses configured image generation timeouts for Codex dynamic tool calls", () => {
@@ -236,6 +283,75 @@ describe("dynamic tool execution helpers", () => {
         },
       },
       isError: true,
+    });
+  });
+
+  it("returns the existing failed response shape for timeoutSeconds deadlines", async () => {
+    vi.useFakeTimers();
+    const call = {
+      threadId: "thread-1",
+      turnId: "turn-1",
+      callId: "call-timeout-seconds",
+      namespace: null,
+      tool: "session_status",
+      arguments: { sessionKey: "current", timeoutSeconds: 1 },
+    };
+    const response = handleDynamicToolCallWithTimeout({
+      call,
+      toolBridge: {
+        handleToolCall: vi.fn(() => new Promise<never>(() => {})),
+      },
+      signal: new AbortController().signal,
+      timeoutMs: resolveDynamicToolCallTimeoutMs({ call, config: undefined }),
+    });
+
+    await vi.advanceTimersByTimeAsync(11_000);
+
+    await expect(response).resolves.toEqual({
+      success: false,
+      contentItems: [
+        {
+          type: "inputText",
+          text: "OpenClaw dynamic tool call timed out after 11000ms while running tool session_status.",
+        },
+      ],
+    });
+  });
+
+  it("lets tool-owned timeoutSeconds return before the wrapper grace expires", async () => {
+    vi.useFakeTimers();
+    const call = {
+      threadId: "thread-1",
+      turnId: "turn-1",
+      callId: "call-tool-seconds",
+      namespace: null,
+      tool: "sessions_send",
+      arguments: { sessionKey: "current", message: "ping", timeoutSeconds: 1 },
+    };
+    const response = handleDynamicToolCallWithTimeout({
+      call,
+      toolBridge: {
+        handleToolCall: vi.fn(
+          () =>
+            new Promise<CodexDynamicToolCallResponse>((resolve) => {
+              setTimeout(() => {
+                resolve({
+                  success: true,
+                  contentItems: [{ type: "inputText", text: "timeout: no reply" }],
+                });
+              }, 1_000);
+            }),
+        ),
+      },
+      signal: new AbortController().signal,
+      timeoutMs: resolveDynamicToolCallTimeoutMs({ call, config: undefined }),
+    });
+
+    await vi.advanceTimersByTimeAsync(1_000);
+
+    await expect(response).resolves.toEqual({
+      success: true,
+      contentItems: [{ type: "inputText", text: "timeout: no reply" }],
     });
   });
 

--- a/extensions/codex/src/app-server/dynamic-tool-execution.ts
+++ b/extensions/codex/src/app-server/dynamic-tool-execution.ts
@@ -10,7 +10,10 @@ import {
   hasPendingInternalDiagnosticEvent,
   type DiagnosticEventPayload,
 } from "openclaw/plugin-sdk/diagnostic-runtime";
-import { parseStrictNonNegativeInteger } from "openclaw/plugin-sdk/number-runtime";
+import {
+  addTimerTimeoutGraceMs,
+  parseStrictNonNegativeInteger,
+} from "openclaw/plugin-sdk/number-runtime";
 import type { CodexDynamicToolBridge } from "./dynamic-tools.js";
 import {
   isJsonObject,
@@ -23,6 +26,7 @@ import {
 export const CODEX_DYNAMIC_TOOL_TIMEOUT_MS = 90_000;
 /** Hard cap for per-call Codex dynamic tool timeout overrides. */
 export const CODEX_DYNAMIC_TOOL_MAX_TIMEOUT_MS = 600_000;
+const CODEX_DYNAMIC_TOOL_TIMEOUT_SECONDS_GRACE_MS = 10_000;
 const CODEX_DYNAMIC_IMAGE_GENERATION_TOOL_TIMEOUT_MS = 120_000;
 /** Timeout for image-understanding style dynamic tool calls. */
 export const CODEX_DYNAMIC_IMAGE_TOOL_TIMEOUT_MS = 60_000;
@@ -443,7 +447,14 @@ function readDynamicToolCallTimeoutMs(value: JsonValue | undefined): number | un
   if (!isJsonObject(value)) {
     return undefined;
   }
-  return readPositiveFiniteTimeoutMs(value.timeoutMs);
+  const timeoutMs = readPositiveFiniteTimeoutMs(value.timeoutMs);
+  if (timeoutMs !== undefined) {
+    return timeoutMs;
+  }
+  const timeoutSecondsMs = readTimeoutSecondsAsMs(value.timeoutSeconds);
+  return timeoutSecondsMs === undefined
+    ? undefined
+    : addTimerTimeoutGraceMs(timeoutSecondsMs, CODEX_DYNAMIC_TOOL_TIMEOUT_SECONDS_GRACE_MS);
 }
 
 function readConfiguredDynamicToolTimeoutMs(

--- a/extensions/codex/src/app-server/side-question.test.ts
+++ b/extensions/codex/src/app-server/side-question.test.ts
@@ -1886,6 +1886,33 @@ describe("runCodexAppServerSideQuestion", () => {
     expect(timeoutMs).toBe(90_000);
   });
 
+  it("uses per-call timeoutSeconds for generic side-thread dynamic tool calls", () => {
+    expect(
+      testing.resolveSideDynamicToolCallTimeoutMs({
+        call: {
+          threadId: "side-thread",
+          turnId: "turn-1",
+          callId: "tool-1",
+          tool: "session_status",
+          arguments: { sessionKey: "current", timeoutSeconds: 2 },
+        },
+        config: {} as never,
+      }),
+    ).toBe(12_000);
+    expect(
+      testing.resolveSideDynamicToolCallTimeoutMs({
+        call: {
+          threadId: "side-thread",
+          turnId: "turn-1",
+          callId: "tool-1",
+          tool: "session_status",
+          arguments: { sessionKey: "current", timeoutMs: 1_500, timeoutSeconds: 2 },
+        },
+        config: {} as never,
+      }),
+    ).toBe(1_500);
+  });
+
   it("cleans up notification handlers when side tool setup fails", async () => {
     const client = createFakeClient();
     createOpenClawCodingToolsMock.mockImplementation(() => {

--- a/extensions/codex/src/app-server/side-question.ts
+++ b/extensions/codex/src/app-server/side-question.ts
@@ -102,6 +102,7 @@ import {
 
 const CODEX_SIDE_DYNAMIC_TOOL_TIMEOUT_MS = 90_000;
 const CODEX_SIDE_DYNAMIC_TOOL_MAX_TIMEOUT_MS = 600_000;
+const CODEX_SIDE_DYNAMIC_TOOL_TIMEOUT_SECONDS_GRACE_MS = 10_000;
 const CODEX_SIDE_DYNAMIC_IMAGE_GENERATION_TOOL_TIMEOUT_MS = 120_000;
 const CODEX_SIDE_DYNAMIC_IMAGE_TOOL_TIMEOUT_MS = 60_000;
 const SIDE_QUESTION_COMPLETION_TIMEOUT_MS = 600_000;
@@ -898,7 +899,14 @@ function readSideDynamicToolCallTimeoutMs(value: JsonValue | undefined): number 
   if (!isJsonObject(value)) {
     return undefined;
   }
-  return readSidePositiveFiniteTimeoutMs(value.timeoutMs);
+  const timeoutMs = readSidePositiveFiniteTimeoutMs(value.timeoutMs);
+  if (timeoutMs !== undefined) {
+    return timeoutMs;
+  }
+  const timeoutSecondsMs = readSideTimeoutSecondsAsMs(value.timeoutSeconds);
+  return timeoutSecondsMs === undefined
+    ? undefined
+    : timeoutSecondsMs + CODEX_SIDE_DYNAMIC_TOOL_TIMEOUT_SECONDS_GRACE_MS;
 }
 
 function readSideImageGenerationModelTimeoutMs(


### PR DESCRIPTION
﻿Closes #98864

## What Problem This Solves

Fixes an issue where Codex dynamic tool calls that provided only timeoutSeconds could miss the intended seconds-form hard-call bound and fall back to the default dynamic tool watchdog.

## Why This Change Was Made

The Codex app-server dynamic tool timeout resolvers now preserve timeoutMs precedence and treat numeric timeoutSeconds as the seconds-form fallback when timeoutMs is absent. The fallback adds a small wrapper grace window so tools that already own timeoutSeconds, such as sessions_send, can return their structured timeout result before the outer app-server watchdog aborts the bridge.

## User Impact

Long-running or bounded Codex dynamic tools can use seconds-form timeout values without silently falling back to the default watchdog, including both the primary Codex dynamic-tool path and the side-question dynamic-tool path.

## Evidence

- Claim proved: timeoutMs still wins; timeoutSeconds-only calls now set a seconds-derived app-server watchdog; invalid timeoutSeconds values are ignored; the existing failed response shape is used when the wrapper watchdog expires; a tool-owned timeoutSeconds result can return before the wrapper grace expires; the side-question sibling dynamic-tool timeout reader now honors timeoutSeconds with the same precedence and grace behavior.
- Current head checked: 8d94a49ffad732fcd93cd42585d14c8393edfb75.
- Commands / artifacts:
  - node scripts/run-vitest.mjs extensions/codex/src/app-server/dynamic-tool-execution.test.ts -- --reporter=verbose -t "timeoutSeconds"
  - node scripts/run-vitest.mjs extensions/codex/src/app-server/side-question.test.ts -- --reporter=verbose -t "uses per-call timeoutSeconds for generic side-thread dynamic tool calls"
  - git diff --check
  - python .agents\skills\autoreview\scripts\autoreview --mode local
  - GitHub Real behavior proof check on current head: https://github.com/openclaw/openclaw/actions/runs/28581246921/job/84741801796
  - Dependency/source contract check: ../codex/codex-rs/app-server-protocol/src/protocol/v2/item.rs defines DynamicToolCallParams.arguments as JsonValue, so OpenClaw owns interpreting timeoutSeconds in the forwarded dynamic tool arguments.
- Observed result:
  - Primary dynamic-tool focused Vitest passed on current head: 1 file, 4 tests passed, 13 skipped. The passing tests covered timeoutSeconds fallback, invalid timeoutSeconds rejection, the 11000ms wrapper timeout response shape, and a sessions_send-style tool-owned timeoutSeconds result returning before wrapper grace.
  - Side-question focused Vitest passed on current head: 1 file, 1 test passed, 40 skipped. The test covered timeoutSeconds fallback and timeoutMs precedence in the side-thread dynamic-tool timeout reader.
  - git diff --check passed on current head.
  - GitHub Real behavior proof check passed on current head.
  - Autoreview clean: no accepted/actionable findings reported in the prior local review for this head.
- Proof boundary:
  - No credentialed live model turn was needed for this parser/wrapper fix. The current-head proof exercises the Codex app-server dynamic-tool timeout resolver/wrapper behavior and the side-question sibling resolver directly, and checks the upstream Codex protocol source that forwards dynamic-tool arguments as raw JSON.
