### PR TITLE
docs(irc): document markdown, streaming.chunkMode, and responsePrefix formatting

### DIFF
--- a/docs/channels/irc.md
+++ b/docs/channels/irc.md
@@ -146,6 +146,13 @@ Or to allow **all** IRC channels (no per-channel allowlist) and still reply with
 }
 ```
 
+## Message formatting
+
+- `channels.irc.markdown` — Markdown rendering options. Object with an optional `tables` key:
+  - `tables`: `"off"`, `"bullets"`, `"code"`, or `"block"` — controls how tables are rendered in IRC messages.
+- `channels.irc.streaming.chunkMode`: `"length"` (default) or `"newline"` — controls how long messages are split. `"length"` splits at a character limit; `"newline"` splits at paragraph boundaries.
+- `channels.irc.responsePrefix` — prepended to every outbound reply.
+
 ## Security note (recommended for public channels)
 
 If you allow `allowFrom: ["*"]` in a public channel, anyone can prompt the bot.

--- a/docs/docs_map.md
+++ b/docs/docs_map.md
@@ -501,6 +501,7 @@ Do not edit it by hand; run `pnpm docs:map:gen`.
   - H2: Access control
   - H3: Common gotcha: allowFrom is for DMs, not channels
   - H2: Reply triggering (mentions)
+  - H2: Message formatting
   - H2: Security note (recommended for public channels)
   - H3: Same tools for everyone in the channel
   - H3: Different tools per sender (owner gets more power)


### PR DESCRIPTION
## What Problem This Solves

`extensions/irc/src/config-schema.ts` includes `markdown` (MarkdownConfigSchema) and spreads `ReplyRuntimeConfigSchemaShape` which provides `streaming.chunkMode` and `responsePrefix`, but `docs/channels/irc.md` does not document these reply-formatting fields. Users configuring IRC cannot discover these formatting options from the docs.

- Problem: Three reply-formatting fields exist in the IRC config schema/types but are absent from the docs
- Solution: Add a "Message formatting" section documenting `markdown`, `streaming.chunkMode`, and `responsePrefix`
- What changed: `docs/channels/irc.md` (+7 lines — new H2 section), `docs/docs_map.md` (+1 line)
- What did NOT change: No code or behavior changes. Documentation only.

**Missing fields**:
1. **`markdown`** (MarkdownConfigSchema) — table rendering: `tables: "off" | "bullets" | "code" | "block"`
2. **`streaming.chunkMode`** (`"length"` (default) | `"newline"`) — message splitting strategy, inside the `streaming` delivery sub-object
3. **`responsePrefix`** (string) — prepended to every outbound reply

## Evidence

### Schema — `markdown` field (`extensions/irc/src/config-schema.ts:67`)

```typescript
markdown: MarkdownConfigSchema,
```

### Schema — `chunkMode` + `responsePrefix` via spread (`extensions/irc/src/config-schema.ts:68`)

```typescript
...ReplyRuntimeConfigSchemaShape,
```

### Core schema — `ReplyRuntimeConfigSchemaShape` (`src/config/zod-schema.core.ts:679-682`)

```typescript
chunkMode: z.enum(["length", "newline"]).optional(),
responsePrefix: z.string().optional(),
```

### Core schema — `MarkdownTableModeSchema` (`src/config/zod-schema.core.ts:696`)

```typescript
export const MarkdownTableModeSchema = z.enum(["off", "bullets", "code", "block"]);
```

### Runtime — `DEFAULT_CHUNK_MODE` (`src/auto-reply/chunk.ts:33`)

```typescript
const DEFAULT_CHUNK_MODE: ChunkMode = "length";
```

### Runtime consumption — IRC markdown table mode (`extensions/irc/src/send.ts:6`)

```typescript
import { resolveMarkdownTableMode } from "openclaw/plugin-sdk/markdown-table-runtime";
```

### Runtime consumption — chunkMode (`src/auto-reply/reply/block-streaming.ts:179`)

```typescript
const chunkMode = resolveChunkMode(cfg, providerKey, accountId);
// …
flushOnParagraph: chunkMode === "newline",
```

### Canonical user-facing config path (`src/config/zod-schema.core.ts:3471`)

```typescript
streaming: ChannelDeliveryStreamingConfigSchema,
```

`chunkMode` lives inside `ChannelDeliveryStreamingConfigSchema`, so the correct user-facing path is `channels.irc.streaming.chunkMode`.

## User Impact

Users can now discover three reply-formatting options from the IRC channel docs: Markdown table rendering (off/bullets/code/block), message chunking strategy (length/newline with length default), and reply prefix. All three were already functional — they were simply invisible to users who configure via docs.
