### PR TITLE
fix(media-understanding): suppress default English audio prompt for non-English transcription

### DIFF
--- a/src/media-understanding/resolve.test.ts
+++ b/src/media-understanding/resolve.test.ts
@@ -2,7 +2,12 @@
 import { MAX_TIMER_TIMEOUT_MS } from "@openclaw/normalization-core/number-coercion";
 import { describe, expect, it } from "vitest";
 import type { OpenClawConfig } from "../config/types.js";
-import { resolveMediaRuntimeTimeoutMs, resolveModelEntries, resolveTimeoutMs } from "./resolve.js";
+import {
+  resolveMediaRuntimeTimeoutMs,
+  resolveModelEntries,
+  resolvePrompt,
+  resolveTimeoutMs,
+} from "./resolve.js";
 import type { MediaUnderstandingCapability } from "./types.js";
 
 const providerRegistry = new Map<string, { capabilities: MediaUnderstandingCapability[] }>([
@@ -82,5 +87,41 @@ describe("resolveModelEntries", () => {
       providerRegistry,
     });
     expect(entries).toHaveLength(0);
+  });
+});
+
+describe("resolvePrompt", () => {
+  it("uses the default audio prompt when no prompt and no language are configured", () => {
+    expect(resolvePrompt("audio")).toBe("Transcribe the audio.");
+  });
+
+  it("uses an explicit audio prompt even when a non-English language is set", () => {
+    expect(resolvePrompt("audio", "Transcribe in Russian.", undefined, "ru")).toBe(
+      "Transcribe in Russian.",
+    );
+  });
+
+  it("suppresses the default audio prompt for a non-English language hint", () => {
+    // Groq Whisper treats `prompt` as a biasing hint; the English default
+    // can make it translate short non-English clips to English (#98970).
+    expect(resolvePrompt("audio", undefined, undefined, "ru")).toBe("");
+  });
+
+  it("keeps the default audio prompt for an English language hint", () => {
+    expect(resolvePrompt("audio", undefined, undefined, "en")).toBe("Transcribe the audio.");
+  });
+
+  it("keeps the default audio prompt for an English region tag (en-US)", () => {
+    expect(resolvePrompt("audio", undefined, undefined, "en-US")).toBe("Transcribe the audio.");
+  });
+
+  it("suppresses the default audio prompt for a region-qualified non-English hint (zh-CN)", () => {
+    expect(resolvePrompt("audio", undefined, undefined, "zh-CN")).toBe("");
+  });
+
+  it("appends length guidance for non-audio capabilities", () => {
+    expect(resolvePrompt("image", undefined, 500)).toBe(
+      "Describe the image. Respond in at most 500 characters.",
+    );
   });
 });

--- a/src/media-understanding/resolve.ts
+++ b/src/media-understanding/resolve.ts
@@ -50,12 +50,44 @@ export function resolvePrompt(
   capability: MediaUnderstandingCapability,
   prompt?: string,
   maxChars?: number,
+  language?: string,
 ): string {
-  const base = prompt?.trim() || DEFAULT_PROMPT[capability];
-  if (!maxChars || capability === "audio") {
+  // Audio providers (e.g. Groq Whisper) treat `prompt` as a biasing hint and
+  // may translate short non-English clips to English when the default English
+  // "Transcribe the audio." prompt is sent alongside a non-English `language`
+  // (#98970). When an explicit prompt is absent and a non-English language is
+  // configured, send no prompt so the provider honors the language hint.
+  const explicitPrompt = prompt?.trim();
+  if (capability === "audio") {
+    if (explicitPrompt) {
+      return explicitPrompt;
+    }
+    if (isNonEnglishLanguage(language)) {
+      return "";
+    }
+    return DEFAULT_PROMPT[capability];
+  }
+  const base = explicitPrompt || DEFAULT_PROMPT[capability];
+  if (!maxChars) {
     return base;
   }
   return `${base} Respond in at most ${maxChars} characters.`;
+}
+
+/** True when a transcription language hint is set and is not English. */
+function isNonEnglishLanguage(language: string | undefined): boolean {
+  const normalized = language?.trim().toLowerCase();
+  if (!normalized) {
+    return false;
+  }
+  // BCP-47 codes (`ru`, `zh-CN`, `en`) and the bare word `english`/`en`.
+  if (normalized === "en" || normalized === "eng" || normalized === "english") {
+    return false;
+  }
+  if (normalized.startsWith("en-") || normalized.startsWith("en_")) {
+    return false;
+  }
+  return true;
 }
 
 /** Resolves the effective max response characters for a model entry and capability. */

--- a/src/media-understanding/runner.auto-audio.test.ts
+++ b/src/media-understanding/runner.auto-audio.test.ts
@@ -400,6 +400,58 @@ describe("runCapability auto audio entries", () => {
     expect(seenPrompt).toBe("Focus on names");
   });
 
+  it("suppresses the default English audio prompt when a non-English language is configured", async () => {
+    let seenLanguage: string | undefined;
+    let seenPrompt: string | undefined;
+    const result = await runAutoAudioCase({
+      transcribeAudio: async (req) => {
+        seenLanguage = req.language;
+        seenPrompt = req.prompt;
+        return { text: "ok", model: req.model ?? "unknown" };
+      },
+      cfgExtra: {
+        tools: {
+          media: {
+            audio: {
+              enabled: true,
+              language: "ru",
+              models: [{ provider: "openai", model: "whisper-1" }],
+            },
+          },
+        },
+      } as Partial<OpenClawConfig>,
+    });
+
+    expect(requireCapabilityOutput(result, 0).text).toBe("ok");
+    expect(seenLanguage).toBe("ru");
+    // Groq Whisper treats `prompt` as a biasing hint; the English default
+    // can translate short non-English clips to English (#98970).
+    expect(seenPrompt).toBe("");
+  });
+
+  it("keeps the default English audio prompt when no language is configured", async () => {
+    let seenPrompt: string | undefined;
+    const result = await runAutoAudioCase({
+      transcribeAudio: async (req) => {
+        seenPrompt = req.prompt;
+        return { text: "ok", model: req.model ?? "unknown" };
+      },
+      cfgExtra: {
+        tools: {
+          media: {
+            audio: {
+              enabled: true,
+              models: [{ provider: "openai", model: "whisper-1" }],
+            },
+          },
+        },
+      } as Partial<OpenClawConfig>,
+    });
+
+    expect(requireCapabilityOutput(result, 0).text).toBe("ok");
+    expect(seenPrompt).toBe("Transcribe the audio.");
+  });
+
   it("uses mistral when only mistral key is configured", async () => {
     const isolatedAgentDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-audio-agent-"));
     let runResult: Awaited<ReturnType<typeof runCapability>> | undefined;

--- a/src/media-understanding/runner.entries.ts
+++ b/src/media-understanding/runner.entries.ts
@@ -7,12 +7,6 @@ import {
   normalizeNullableString,
 } from "@openclaw/normalization-core/string-coerce";
 import { normalizeStringEntries } from "@openclaw/normalization-core/string-normalization";
-import { MediaUnderstandingSkipError } from "../../packages/media-understanding-common/src/errors.js";
-import { extractGeminiResponse } from "../../packages/media-understanding-common/src/output-extract.js";
-import {
-  estimateBase64Size,
-  resolveVideoMaxBase64Bytes,
-} from "../../packages/media-understanding-common/src/video.js";
 import {
   collectProviderApiKeysForExecution,
   executeWithApiKeyRotation,
@@ -25,7 +19,6 @@ import {
 } from "../agents/provider-request-config.js";
 import type { MsgContext } from "../auto-reply/templating.js";
 import { applyTemplate } from "../auto-reply/templating.js";
-import { formatCliCommand } from "../cli/command-format.js";
 import type { ModelProviderConfig, OpenClawConfig } from "../config/types.js";
 import type {
   MediaUnderstandingConfig,
@@ -36,13 +29,14 @@ import { writeExternalFileWithinRoot } from "../infra/fs-safe.js";
 import { resolveProxyFetchFromEnv } from "../infra/net/proxy-fetch.js";
 import { resolvePreferredOpenClawTmpDir } from "../infra/tmp-openclaw-dir.js";
 import { runFfmpeg } from "../media/media-services.js";
-import {
-  getOfficialExternalPluginCatalogManifest,
-  listOfficialExternalProviderCatalogEntries,
-} from "../plugins/official-external-plugin-catalog.js";
-import { resolveOfficialExternalPluginRepairHint } from "../plugins/official-external-plugin-repair-hints.js";
 import { runExec } from "../process/exec.js";
 import { providerOperationRetryConfig } from "../provider-runtime/operation-retry.js";
+import { MediaUnderstandingSkipError } from "../../packages/media-understanding-common/src/errors.js";
+import { extractGeminiResponse } from "../../packages/media-understanding-common/src/output-extract.js";
+import {
+  estimateBase64Size,
+  resolveVideoMaxBase64Bytes,
+} from "../../packages/media-understanding-common/src/video.js";
 import { MediaAttachmentCache } from "./attachments.js";
 import {
   CLI_OUTPUT_MAX_BUFFER,
@@ -419,10 +413,17 @@ function resolveEntryRunOptions(params: {
       cfg.tools?.media?.[capability]?.timeoutSeconds,
     DEFAULT_TIMEOUT_SECONDS[capability],
   );
+  // Audio prompt resolution is language-aware: an explicit prompt wins, but
+  // when none is set and a non-English language is configured the default
+  // English prompt is suppressed so the provider honors the language hint
+  // (#98970).
+  const language =
+    entry.language ?? params.config?.language ?? cfg.tools?.media?.[capability]?.language;
   const prompt = resolvePrompt(
     capability,
     entry.prompt ?? params.config?.prompt ?? cfg.tools?.media?.[capability]?.prompt,
     maxChars,
+    language,
   );
   return { maxBytes, maxChars, timeoutMs, prompt };
 }
@@ -672,53 +673,6 @@ function assertMinAudioSize(params: { size: number; attachmentIndex: number }): 
   );
 }
 
-/**
- * Build an actionable hint suffix for "provider not available" errors.
- *
- * Restricts the hint to ids that are owned by the official external
- * provider catalog — NOT the combined channel/plugin catalog — so a media
- * provider id like `feishu` (an official channel, not a media provider)
- * never emits a misleading install hint from a media-provider error.
- *
- * Tier 1: provider id is owned by an official external provider entry that
- *   declares a `contracts.mediaUnderstandingProviders` block listing the
- *   id — emit the catalog-backed install + registry refresh + doctor fix
- *   commands.
- * Tier 2: empty string — keeps the legacy message verbatim for ids that
- *   are not in the provider catalog (channel ids, plugin ids, unknown
- *   ids, internal ids, etc.). Newly externalized media providers must
- *   register with the official external provider catalog to receive the
- *   actionable hint.
- */
-export function formatMissingProviderHint(providerId: string): string {
-  const trimmed = providerId.trim();
-  if (!trimmed) {
-    return "";
-  }
-  // Look up the id only in catalog entries that declare
-  // `contracts.mediaUnderstandingProviders`. This ensures the install hint
-  // only fires for provider packages that actually own the missing
-  // media-understanding capability. Providers that have a generic `providers[]`
-  // catalog entry but no media-understanding contract (e.g. Amazon Bedrock)
-  // will not emit misleading hints.
-  const providerEntry = listOfficialExternalProviderCatalogEntries().find((entry) => {
-    const manifest = getOfficialExternalPluginCatalogManifest(entry);
-    const mediaProviders = manifest?.contracts?.mediaUnderstandingProviders ?? [];
-    return mediaProviders.some((mediaId) => mediaId === trimmed);
-  });
-  if (!providerEntry) {
-    return "";
-  }
-  // `resolveOfficialExternalPluginRepairHint` is contract-agnostic but we
-  // already validated ownership via the provider-only catalog, so the
-  // returned hint is for the correct provider entry.
-  const catalogHint = resolveOfficialExternalPluginRepairHint(trimmed);
-  if (!catalogHint) {
-    return "";
-  }
-  return ` Install the official external plugin with: ${formatCliCommand(catalogHint.installCommand)}, then run ${formatCliCommand("openclaw plugins registry --refresh")} and stop and start the gateway service, or run ${formatCliCommand(catalogHint.doctorFixCommand)} to repair automatically.`;
-}
-
 /** Executes one provider-backed media-understanding entry for one attachment. */
 export async function runProviderEntry(params: {
   capability: MediaUnderstandingCapability;
@@ -794,9 +748,7 @@ export async function runProviderEntry(params: {
 
   const provider = getMediaUnderstandingProvider(providerId, params.providerRegistry);
   if (!provider) {
-    throw new Error(
-      `Media provider not available: ${providerId}${formatMissingProviderHint(providerId)}`,
-    );
+    throw new Error(`Media provider not available: ${providerId}`);
   }
 
   // Resolve proxy-aware fetch from env vars (HTTPS_PROXY, HTTP_PROXY, etc.)

--- a/src/media-understanding/runner.entries.ts
+++ b/src/media-understanding/runner.entries.ts
@@ -7,6 +7,12 @@ import {
   normalizeNullableString,
 } from "@openclaw/normalization-core/string-coerce";
 import { normalizeStringEntries } from "@openclaw/normalization-core/string-normalization";
+import { MediaUnderstandingSkipError } from "../../packages/media-understanding-common/src/errors.js";
+import { extractGeminiResponse } from "../../packages/media-understanding-common/src/output-extract.js";
+import {
+  estimateBase64Size,
+  resolveVideoMaxBase64Bytes,
+} from "../../packages/media-understanding-common/src/video.js";
 import {
   collectProviderApiKeysForExecution,
   executeWithApiKeyRotation,
@@ -19,6 +25,7 @@ import {
 } from "../agents/provider-request-config.js";
 import type { MsgContext } from "../auto-reply/templating.js";
 import { applyTemplate } from "../auto-reply/templating.js";
+import { formatCliCommand } from "../cli/command-format.js";
 import type { ModelProviderConfig, OpenClawConfig } from "../config/types.js";
 import type {
   MediaUnderstandingConfig,
@@ -29,14 +36,13 @@ import { writeExternalFileWithinRoot } from "../infra/fs-safe.js";
 import { resolveProxyFetchFromEnv } from "../infra/net/proxy-fetch.js";
 import { resolvePreferredOpenClawTmpDir } from "../infra/tmp-openclaw-dir.js";
 import { runFfmpeg } from "../media/media-services.js";
+import {
+  getOfficialExternalPluginCatalogManifest,
+  listOfficialExternalProviderCatalogEntries,
+} from "../plugins/official-external-plugin-catalog.js";
+import { resolveOfficialExternalPluginRepairHint } from "../plugins/official-external-plugin-repair-hints.js";
 import { runExec } from "../process/exec.js";
 import { providerOperationRetryConfig } from "../provider-runtime/operation-retry.js";
-import { MediaUnderstandingSkipError } from "../../packages/media-understanding-common/src/errors.js";
-import { extractGeminiResponse } from "../../packages/media-understanding-common/src/output-extract.js";
-import {
-  estimateBase64Size,
-  resolveVideoMaxBase64Bytes,
-} from "../../packages/media-understanding-common/src/video.js";
 import { MediaAttachmentCache } from "./attachments.js";
 import {
   CLI_OUTPUT_MAX_BUFFER,
@@ -673,6 +679,53 @@ function assertMinAudioSize(params: { size: number; attachmentIndex: number }): 
   );
 }
 
+/**
+ * Build an actionable hint suffix for "provider not available" errors.
+ *
+ * Restricts the hint to ids that are owned by the official external
+ * provider catalog - NOT the combined channel/plugin catalog - so a media
+ * provider id like `feishu` (an official channel, not a media provider)
+ * never emits a misleading install hint from a media-provider error.
+ *
+ * Tier 1: provider id is owned by an official external provider entry that
+ *   declares a `contracts.mediaUnderstandingProviders` block listing the
+ *   id - emit the catalog-backed install + registry refresh + doctor fix
+ *   commands.
+ * Tier 2: empty string - keeps the legacy message verbatim for ids that
+ *   are not in the provider catalog (channel ids, plugin ids, unknown
+ *   ids, internal ids, etc.). Newly externalized media providers must
+ *   register with the official external provider catalog to receive the
+ *   actionable hint.
+ */
+export function formatMissingProviderHint(providerId: string): string {
+  const trimmed = providerId.trim();
+  if (!trimmed) {
+    return "";
+  }
+  // Look up the id only in catalog entries that declare
+  // `contracts.mediaUnderstandingProviders`. This ensures the install hint
+  // only fires for provider packages that actually own the missing
+  // media-understanding capability. Providers that have a generic `providers[]`
+  // catalog entry but no media-understanding contract (e.g. Amazon Bedrock)
+  // will not emit misleading hints.
+  const providerEntry = listOfficialExternalProviderCatalogEntries().find((entry) => {
+    const manifest = getOfficialExternalPluginCatalogManifest(entry);
+    const mediaProviders = manifest?.contracts?.mediaUnderstandingProviders ?? [];
+    return mediaProviders.some((mediaId) => mediaId === trimmed);
+  });
+  if (!providerEntry) {
+    return "";
+  }
+  // `resolveOfficialExternalPluginRepairHint` is contract-agnostic but we
+  // already validated ownership via the provider-only catalog, so the
+  // returned hint is for the correct provider entry.
+  const catalogHint = resolveOfficialExternalPluginRepairHint(trimmed);
+  if (!catalogHint) {
+    return "";
+  }
+  return ` Install the official external plugin with: ${formatCliCommand(catalogHint.installCommand)}, then run ${formatCliCommand("openclaw plugins registry --refresh")} and stop and start the gateway service, or run ${formatCliCommand(catalogHint.doctorFixCommand)} to repair automatically.`;
+}
+
 /** Executes one provider-backed media-understanding entry for one attachment. */
 export async function runProviderEntry(params: {
   capability: MediaUnderstandingCapability;
@@ -748,7 +801,9 @@ export async function runProviderEntry(params: {
 
   const provider = getMediaUnderstandingProvider(providerId, params.providerRegistry);
   if (!provider) {
-    throw new Error(`Media provider not available: ${providerId}`);
+    throw new Error(
+      `Media provider not available: ${providerId}${formatMissingProviderHint(providerId)}`,
+    );
   }
 
   // Resolve proxy-aware fetch from env vars (HTTPS_PROXY, HTTP_PROXY, etc.)


### PR DESCRIPTION
## What Problem This Solves

Groq Whisper and OpenAI-compatible STT providers treat the audio transcription `prompt` field as a biasing hint, not an instruction. OpenClaw always sent the default English prompt `Transcribe the audio.` even when a non-English `language` hint was configured, which biased short non-English voice notes toward English translation despite the explicit language hint.

Reported in #98970: a short Russian Telegram voice note with `language=ru` returned the English translation `"Do it."` instead of the Russian transcript `делаете`. Direct Groq comparison on the same audio confirmed the cause:

```text
language=ru, no prompt      -> делаете
language=ru, English prompt -> Do it.
language=ru, Russian prompt -> Делайте.
```

## Why This Change Was Made

`resolvePrompt` (`src/media-understanding/resolve.ts`) applied the same default prompt logic to every capability. For audio, that meant the English `Transcribe the audio.` default was injected whenever no explicit `prompt` was configured, independent of the configured `language`.

The fix makes audio prompt resolution language-aware:

- An explicit `prompt` always wins.
- When no explicit prompt is set and a non-English language is configured, the default English prompt is suppressed to `""`.
- English hints (`en`, `en-US`, `english`, etc.) and the no-language case keep the existing default prompt.
- `resolveEntryRunOptions` threads the resolved language into `resolvePrompt`, using the same precedence that builds the provider request's `language` field.
- The existing missing-provider diagnostic path is preserved: `formatMissingProviderHint` remains exported and missing provider errors still include the install/registry/doctor hint for official external media providers.

## User Impact

- Non-English voice notes are transcribed in the requested language instead of being silently biased toward English translation when no custom audio prompt is set.
- Users who set a custom `tools.media.audio.prompt` see no change.
- English transcription is unchanged.
- Missing official media-provider diagnostics remain actionable.

## Real behavior proof

**Behavior addressed:** Non-English audio transcription requests with an explicit language hint omit the implicit English default prompt, while English and explicit-prompt cases keep the previous behavior.

**Environment tested:** Ubuntu Linux, Node 24.x, PR branch `fix/98970-non-english-audio-default-prompt`.

**Steps run after the patch:** Called the actual production functions from source with `node --import tsx`: `resolvePrompt`, `buildAudioTranscriptionFormData`, and `formatMissingProviderHint`.

**Evidence after fix:**

```bash
node --import tsx --no-warnings -e "
import { resolvePrompt } from './src/media-understanding/resolve.js';
import { buildAudioTranscriptionFormData } from './src/media-understanding/shared.js';
import { formatMissingProviderHint } from './src/media-understanding/runner.entries.js';

function summarizeForm(form) {
  const entries = [];
  for (const [name, value] of form.entries()) {
    entries.push({ name, kind: typeof value === 'string' ? 'field' : 'file', value: typeof value === 'string' ? value : '[binary]' });
  }
  return entries;
}

const nonEnglishPrompt = resolvePrompt('audio', undefined, undefined, 'ru');
const englishPrompt = resolvePrompt('audio', undefined, undefined, 'en-US');
const explicitPrompt = resolvePrompt('audio', 'Transcribe verbatim in Russian.', undefined, 'ru');
const nonEnglishForm = buildAudioTranscriptionFormData({
  buffer: Buffer.from([1, 2, 3, 4]),
  fileName: 'voice.ogg',
  mime: 'audio/ogg',
  fields: { model: 'whisper-large-v3-turbo', language: 'ru', prompt: nonEnglishPrompt },
});
const englishForm = buildAudioTranscriptionFormData({
  buffer: Buffer.from([1, 2, 3, 4]),
  fileName: 'voice.ogg',
  mime: 'audio/ogg',
  fields: { model: 'whisper-large-v3-turbo', language: 'en-US', prompt: englishPrompt },
});
console.log(JSON.stringify({
  promptResolution: {
    ruWithoutExplicitPrompt: nonEnglishPrompt,
    enUsWithoutExplicitPrompt: englishPrompt,
    ruWithExplicitPrompt: explicitPrompt,
  },
  multipartFields: {
    ruHasPromptField: summarizeForm(nonEnglishForm).some((entry) => entry.name === 'prompt'),
    ruFields: summarizeForm(nonEnglishForm),
    enUsHasPromptField: summarizeForm(englishForm).some((entry) => entry.name === 'prompt'),
    enUsFields: summarizeForm(englishForm),
  },
  missingProviderHint: {
    groqHasInstallHint: formatMissingProviderHint('groq').includes('openclaw plugins install @openclaw/groq-provider'),
    amazonBedrockHint: formatMissingProviderHint('amazon-bedrock'),
  },
}, null, 2));
"
```

Output:

```text
{
  "promptResolution": {
    "ruWithoutExplicitPrompt": "",
    "enUsWithoutExplicitPrompt": "Transcribe the audio.",
    "ruWithExplicitPrompt": "Transcribe verbatim in Russian."
  },
  "multipartFields": {
    "ruHasPromptField": false,
    "ruFields": [
      {
        "name": "file",
        "kind": "file",
        "value": "[binary]"
      },
      {
        "name": "model",
        "kind": "field",
        "value": "whisper-large-v3-turbo"
      },
      {
        "name": "language",
        "kind": "field",
        "value": "ru"
      }
    ],
    "enUsHasPromptField": true,
    "enUsFields": [
      {
        "name": "file",
        "kind": "file",
        "value": "[binary]"
      },
      {
        "name": "model",
        "kind": "field",
        "value": "whisper-large-v3-turbo"
      },
      {
        "name": "language",
        "kind": "field",
        "value": "en-US"
      },
      {
        "name": "prompt",
        "kind": "field",
        "value": "Transcribe the audio."
      }
    ]
  },
  "missingProviderHint": {
    "groqHasInstallHint": true,
    "amazonBedrockHint": ""
  }
}
```

**Observed result after the fix:** `language=ru` with no explicit prompt resolves to an empty prompt and the actual multipart request builder omits the `prompt` field. English audio still sends `Transcribe the audio.`, explicit Russian prompts still pass through, and the Groq missing-provider install hint is still available.

**Not tested:** A live Telegram/Groq transcription against the reporter's original voice note was not captured here; this environment has no Groq credentials or source audio sample. The requested Telegram desktop proof workflow also reported that the available runner could not drive this non-English voice-note transcription scenario.

## Evidence

```text
node scripts/run-vitest.mjs run src/media-understanding/resolve.test.ts src/media-understanding/runner.auto-audio.test.ts src/media-understanding/runner.entries.guards.test.ts src/media-understanding/openai-compatible-audio.test.ts
```

Result:

```text
[test] passed 2 Vitest shards in 54.19s
```

```text
pnpm check:test-types
```

Result: passed.

Additional production-function proof is included in `## Real behavior proof` above.

## Scope

- `src/media-understanding/resolve.ts`: `resolvePrompt` gains an optional `language` argument and audio-specific non-English suppression.
- `src/media-understanding/runner.entries.ts`: `resolveEntryRunOptions` passes the effective audio language into prompt resolution; the existing missing-provider hint/export is preserved.
- `src/media-understanding/resolve.test.ts`: regression coverage for default prompt, explicit prompt, non-English suppression, English retention, and non-audio length guidance.
- `src/media-understanding/runner.auto-audio.test.ts`: runner-level coverage that `language=ru` sends `prompt=""` while no-language audio keeps `Transcribe the audio.`.

No config/default surface is added or removed.

Closes #98970
