### PR TITLE
fix: report failed pr worktree cleanup

### DIFF
--- a/scripts/pr-lib/common.sh
+++ b/scripts/pr-lib/common.sh
@@ -198,9 +198,22 @@ worktree_path_for_branch() {
 
 worktree_is_registered() {
   local path="$1"
-  git worktree list --porcelain | awk -v target="$path" '
+  local normalized_path="$path"
+  case "$path" in
+    /*|[A-Za-z]:/*)
+      ;;
+    *)
+      local root
+      root=$(git rev-parse --path-format=absolute --show-toplevel 2>/dev/null || true)
+      if [ -n "$root" ]; then
+        normalized_path="$root/${path#./}"
+      fi
+      ;;
+  esac
+
+  git worktree list --porcelain | awk -v target="$path" -v normalized="$normalized_path" '
     /^worktree / {
-      if ($2 == target) {
+      if ($2 == target || $2 == normalized) {
         found=1
       }
     }
@@ -255,7 +268,10 @@ remove_worktree_if_present() {
   fi
 
   if worktree_is_registered "$path"; then
-    git worktree remove "$path" --force >/dev/null 2>&1 || true
+    if ! git worktree remove "$path" --force >/dev/null 2>&1; then
+      echo "Warning: failed to remove registered worktree $path"
+      return 1
+    fi
   fi
 
   if [ ! -e "$path" ]; then
@@ -264,24 +280,24 @@ remove_worktree_if_present() {
 
   if worktree_is_registered "$path"; then
     echo "Warning: failed to remove registered worktree $path"
-    return 0
+    return 1
   fi
 
   if ! is_repo_pr_worktree_dir "$path"; then
     echo "Warning: refusing to trash non-PR-worktree path $path"
-    return 0
+    return 1
   fi
 
   if command -v trash >/dev/null 2>&1; then
     trash "$path" >/dev/null 2>&1 || {
       echo "Warning: failed to trash orphaned worktree dir $path"
-      return 0
+      return 1
     }
     return 0
   fi
 
   echo "Warning: orphaned worktree dir remains and trash is unavailable: $path"
-  return 0
+  return 1
 }
 
 delete_local_branch_if_safe() {

--- a/scripts/pr-lib/merge.sh
+++ b/scripts/pr-lib/merge.sh
@@ -313,7 +313,7 @@ merge_run() {
   root=$(repo_root)
   cd "$root"
   delete_remote_pr_head_branch_after_merge
-  remove_worktree_if_present ".worktrees/pr-$pr"
+  remove_worktree_if_present ".worktrees/pr-$pr" || true
   delete_local_branch_if_safe "temp/pr-$pr"
   delete_local_branch_if_safe "pr-$pr"
   delete_local_branch_if_safe "pr-$pr-prep"

--- a/scripts/pr-lib/worktree.sh
+++ b/scripts/pr-lib/worktree.sh
@@ -145,11 +145,15 @@ gc_pr_worktrees() {
         if [ "$dry_run" = "true" ]; then
           echo "would remove $dir (PR #$pr state=$state)"
         else
-          remove_worktree_if_present "$dir"
-          delete_local_branch_if_safe "temp/pr-$pr"
-          delete_local_branch_if_safe "pr-$pr"
-          delete_local_branch_if_safe "pr-$pr-prep"
-          echo "removed $dir (PR #$pr state=$state)"
+          if remove_worktree_if_present "$dir"; then
+            delete_local_branch_if_safe "temp/pr-$pr"
+            delete_local_branch_if_safe "pr-$pr"
+            delete_local_branch_if_safe "pr-$pr-prep"
+            echo "removed $dir (PR #$pr state=$state)"
+          else
+            echo "skipped $dir (PR #$pr state=$state; removal failed)"
+            continue
+          fi
         fi
         removed=$((removed + 1))
         ;;

--- a/test/scripts/pr-wrappers.test.ts
+++ b/test/scripts/pr-wrappers.test.ts
@@ -41,6 +41,23 @@ describe("scripts/pr wrappers", () => {
     expect(script).not.toContain("Merged via rebase.");
   });
 
+  it("does not report failed PR worktree cleanup as removed", () => {
+    const common = readScript("scripts/pr-lib/common.sh");
+    const worktree = readScript("scripts/pr-lib/worktree.sh");
+    const merge = readScript("scripts/pr-lib/merge.sh");
+
+    expect(common).toContain("normalized_path=");
+    expect(common).toContain("git rev-parse --path-format=absolute --show-toplevel");
+    expect(common).toContain('normalized_path="$root/${path#./}"');
+    expect(common).toContain("$2 == target || $2 == normalized");
+    expect(common).toContain('if ! git worktree remove "$path" --force');
+    expect(common).toContain('echo "Warning: failed to remove registered worktree $path"');
+    expect(common).toContain("return 1");
+    expect(worktree).toContain('if remove_worktree_if_present "$dir"; then');
+    expect(worktree).toContain('echo "skipped $dir (PR #$pr state=$state; removal failed)"');
+    expect(merge).toContain('remove_worktree_if_present ".worktrees/pr-$pr" || true');
+  });
+
   it("keeps prepare wrapper modes delegated to the main PR helper", () => {
     const script = readScript("scripts/pr-prepare");
 


### PR DESCRIPTION
﻿Fixes #99011

## What Problem This Solves

`scripts/pr gc` could report a merged or closed PR worktree as `removed` even when cleanup did not remove it. The root cause was twofold:

- `remove_worktree_if_present` converted removal failures into success after `git worktree remove`, registered-worktree leftovers, refused non-PR paths, and failed orphan trashing.
- `gc_pr_worktrees` passed relative `.worktrees/pr-N` paths while `git worktree list --porcelain` reports absolute paths, so registered PR worktrees could be missed before the helper fell through to orphan handling.

That made local maintainer cleanup output unreliable and could leave worktree registrations/branches behind while the command claimed success.

## Why This Change Was Made

The cleanup helper now normalizes relative candidates to the current repo root before comparing against `git worktree list`, so `.worktrees/pr-N` matches the registered absolute worktree path. It returns non-zero when removal/refusal/trashing fails, and `gc_pr_worktrees` only deletes local PR branches and prints `removed` after the helper succeeds.

Post-merge cleanup remains best-effort by explicitly ignoring this helper's failure in `merge-run`; an already-completed merge should not fail only because local cleanup could not remove a worktree directory.

## User Impact

Maintainers running `scripts/pr gc` get truthful cleanup output: removed worktrees are reported as removed, failed removals are reported as skipped, and branch cleanup is not attempted after a failed worktree removal.

## Evidence

- `node scripts/run-vitest.mjs test/scripts/pr-wrappers.test.ts` -> 6 tests passed.
- `bash -n scripts/pr scripts/pr-lib/common.sh scripts/pr-lib/worktree.sh scripts/pr-lib/merge.sh` -> passed.
- `git diff --check` -> passed.
- Autoreview: branch mode vs `upstream/main` returned no findings; overall `patch is correct`.
- Real Windows Git Bash proof below ran against this PR head (`9e01d3127f`) using a temporary git repo. Case A uses real `git worktree add` plus `remove_worktree_if_present` to show relative `.worktrees/pr-1` registration is recognized and removed. Case B creates a real registered `.worktrees/pr-2`, then deterministically forces only `git worktree remove` to fail so `gc_pr_worktrees false` exercises the failed cleanup path without touching real OpenClaw worktrees.

```text
# OpenClaw PR #99012 real shell proof
repo_head=9e01d3127f
repo_branch=fix/pr-worktree-cleanup-failure
temp_repo=<tmp>
warning: in the working copy of 'README.md', LF will be replaced by CRLF the next time Git touches it

## Case A: relative registered worktree is recognized and removed
registered_relative_before=yes
remove_exit=0
dir_exists_after=no
registered_relative_after=no

## Case B: gc reports skipped when registered worktree removal fails
Warning: failed to remove registered worktree .worktrees/pr-2
skipped .worktrees/pr-2 (PR #2 state=MERGED; removal failed)
No merged/closed PR worktrees removed.
dir_exists_after_failed_gc=yes
branch_temp_pr2_exists=yes
```
