### PR TITLE
fix(agents): bound GitHub release JSON response reads to prevent OOM

### DIFF
--- a/src/agents/utils/tools-manager.test.ts
+++ b/src/agents/utils/tools-manager.test.ts
@@ -183,3 +183,25 @@ describe("getToolPath exit-status handling", () => {
     expect(getToolPath("fd")).toBe("fd");
   });
 });
+
+describe("ensureTool bounded release JSON", () => {
+  it("rejects oversized GitHub release responses", async () => {
+    const { ensureTool } = await import("./tools-manager.js");
+    const release = vi.fn(async () => {});
+    // 2 MiB body > 1 MiB cap
+    const bigBody = "x".repeat(2 * 1024 * 1024);
+    const response = new Response(bigBody, {
+      status: 200,
+      headers: { "content-type": "application/json" },
+    });
+    fetchWithSsrFGuardMock.mockResolvedValueOnce({
+      response,
+      release,
+      finalUrl: "https://api.github.com/repos/sharkdp/fd/releases/latest",
+    });
+
+    await expect(ensureTool("fd", true)).rejects.toThrow(
+      "GitHub release response too large",
+    );
+  });
+});

--- a/src/agents/utils/tools-manager.ts
+++ b/src/agents/utils/tools-manager.ts
@@ -20,6 +20,7 @@ import { Readable } from "node:stream";
 import { pipeline } from "node:stream/promises";
 import type { ReadableStream as NodeReadableStream } from "node:stream/web";
 import chalk from "chalk";
+import { readResponseWithLimit } from "@openclaw/media-core/read-response-with-limit";
 import { fetchWithSsrFGuard } from "../../infra/net/fetch-guard.js";
 import {
   getWindowsPowerShellExePath,
@@ -30,6 +31,7 @@ import { APP_NAME, getBinDir } from "../config.js";
 const TOOLS_DIR = getBinDir();
 const NETWORK_TIMEOUT_MS = 10_000;
 const DOWNLOAD_TIMEOUT_MS = 120_000;
+const TOOLS_RELEASE_JSON_MAX_BYTES = 1 * 1024 * 1024;
 
 async function cancelUnreadResponseBody(response: Response): Promise<void> {
   if (!response.bodyUsed) {
@@ -154,7 +156,13 @@ async function getLatestVersion(repo: string): Promise<string> {
       throw new Error(`GitHub API error: ${response.status}`);
     }
 
-    const data = (await response.json()) as { tag_name: string };
+    const body = await readResponseWithLimit(response, TOOLS_RELEASE_JSON_MAX_BYTES, {
+      onOverflow: ({ size, maxBytes }) =>
+        new Error(
+          `GitHub release response too large: ${size} bytes (limit: ${maxBytes} bytes)`,
+        ),
+    });
+    const data = JSON.parse(body.toString("utf8")) as { tag_name: string };
     return data.tag_name.replace(/^v/, "");
   } finally {
     await guarded.release();


### PR DESCRIPTION
## What Problem This Solves

`src/agents/utils/tools-manager.ts:157` calls bare `response.json()` in `getLatestVersion()` when fetching the latest GitHub release tag. A compromised or misconfigured GitHub API endpoint could return arbitrarily large JSON, causing OOM on the agent host.

This is the same D1 bounded-JSON pattern used in 40+ merged Alix-007 PRs.

## Changes

- `tools-manager.ts`: replace `response.json()` with `readResponseWithLimit` (1 MiB cap) + `JSON.parse`
- `tools-manager.test.ts`: 1 vitest test verifying oversized (2 MiB > 1 MiB cap) responses are rejected

## Pre-submit verification

- ✅ Non-auth module (`src/agents/utils/` — tool binary manager)
- ✅ Not fixed upstream (verified on latest origin/main, line still bare)
- ✅ Existing test file with working mocks for `fetchWithSsrFGuard`
- ✅ 1 MiB cap is generous (GitHub release API returns ~2 KB)

## Evidence

### Vitest

```
pnpm exec vitest run src/agents/utils/tools-manager.test.ts

 ✓ ensureTool bounded release JSON > rejects oversized GitHub release responses
 ... (all existing tests pass)
```

### Call chain

`ensureTool("fd")` → `downloadTool("fd")` → `getLatestVersion("sharkdp/fd")` → `fetchWithSsrFGuard(GitHub API)` → `readResponseWithLimit(response, 1 MiB)` → `JSON.parse()`

Label: security | merge-risk: 🟢 minimal | AI-assisted