### PR TITLE
docs(changelog): add missing PR #92654 (right-click Reply in Dashboard webchat)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ Docs: https://docs.openclaw.ai
 ### Changes
 
 - **Model and provider coverage:** add GPT-5.6 support, use Nemotron Super's 1M context window, and preserve explicit OpenRouter authentication headers. (#98333, #98726, #98187) Thanks @steipete-oai, @eleqtrizit, @sunlit-deng, and @laurencebrown.
-- **CLI and node workflows:** add `openclaw attach`, node context-path support, actionable device-approval recovery guidance, and clearer plugin install exit diagnostics. (#96454, #97679, #98115, #98146, #98497) Thanks @anagnorisis2peripeteia, @obviyus, @wm0018, @welfo-beo, @RomneyDa, @Sanjays2402, and @vincentkoc.
+- **CLI and node workflows:** add `openclaw attach`, node context-path support, right-click Reply in Dashboard webchat, actionable device-approval recovery guidance, and clearer plugin install exit diagnostics. (#96454, #97679, #98115, #98146, #98497, #92654) Thanks @anagnorisis2peripeteia, @obviyus, @wm0018, @welfo-beo, @RomneyDa, @Sanjays2402, @vincentkoc, and @programmingWTF.
 - **Cron and usage:** add exit-triggered schedules, detached session-targeted runs, an in-flight job doctor warning, and a built-in full usage footer. (#92037, #98755, #98620, #92657, #92877) Thanks @anagnorisis2peripeteia, @obviyus, @EthanSK, @masatohoshino, and @Marvinthebored.
 - **Native apps and localization:** modernize iOS presentation and Talk controls, add Gateway speech providers, improve QR onboarding and protocol recovery, localize core Apple and Android surfaces, and add Swedish mobile localization. (#98452, #98736, #98376, #98302, #98385, #97110, #97111, #97112, #97113, #98043) Thanks @Tony-ooo, @joelnishanth, @cursoragent, @joshavant, @vincentkoc, and @yeager.
 - **Messaging capabilities:** add native iMessage polls and Telegram Codex pairing and steering flows. (#98421, #98006, #98126) Thanks @omarshahine, @lobster, @100yenadmin, and @Kyzcreig.
@@ -229,6 +229,7 @@ This audited record covers the complete 66e676d29b92d040716376a75aca32bad655cfac
 - **PR #98701** fix: prevent agents-tools message test timeouts.
 - **PR #92657** feat(usage): ship built-in /usage full footer. Thanks @Marvinthebored.
 - **PR #92877** fix(usage): make built-in footer easier to wrap on Telegram. Thanks @Marvinthebored.
+- **PR #92654** feat(control-ui): add right-click Reply in Dashboard webchat. Thanks @programmingWTF and @vincentkoc.
 - **PR #98126** Restore Telegram /steer for active Codex runs. Related #81594. Thanks @100yenadmin and @Kyzcreig.
 - **PR #92037** feat(cron): on-exit schedule — wake on a watched command's exit. Thanks @anagnorisis2peripeteia.
 - **PR #98452** feat(ios): modernize the app with iOS 26 Liquid Glass.


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where PR #92654 (feat(control-ui): add right-click Reply in Dashboard webchat) was merged and included in the 2026.7.1 release but is not listed anywhere in CHANGELOG.md — neither in the grouped change summaries nor in the complete contribution record at the bottom.

## Why This Change Was Made

Adds the missing PR in two locations that follow the existing CHANGELOG conventions:

1. **Changes → CLI and node workflows** — added right-click Reply in Dashboard webchat alongside the other UI/workflow features in that group.
2. **Complete contribution record** — added the PR entry with attribution in the audited PR list.

Also credits @vincentkoc who contributed code to the original PR.

## User Impact

No user-facing impact beyond the CHANGELOG itself. Users and contributors browsing the release notes will now see the complete list of changes.

## Evidence

- Searched CHANGELOG.md for "92654": no results (confirmed the PR is absent).
- Original PR: https://github.com/openclaw/openclaw/pull/92654
- The PR is confirmed merged and included in the release.
- @vincentkoc's commits appear in the original PR commit log: `gh api repos/OpenClaw/OpenClaw/pulls/92654/commits --jq '.[].commit.author.name'` returns "Vincent Koc".