### PR TITLE
fix(cli): keep root help descriptions aligned with registered commands

### DIFF
--- a/src/cli/program/command-registry.test.ts
+++ b/src/cli/program/command-registry.test.ts
@@ -114,6 +114,16 @@ describe("command-registry", () => {
     expect(agentProgram.commands.map((command) => command.name())).toEqual(["agent"]);
   });
 
+  it("reconciles registered root command descriptions back to the descriptor catalog", async () => {
+    const program = createProgram();
+
+    expect(await registerCoreCliByName(program, testProgramContext, "doctor")).toBe(true);
+
+    expect(program.commands.find((command) => command.name() === "doctor")?.description()).toBe(
+      "Health checks + quick fixes for the gateway and channels",
+    );
+  });
+
   it("registerCoreCliByName returns false for unknown commands", async () => {
     const program = createProgram();
     const found = await registerCoreCliByName(program, testProgramContext, "nonexistent");

--- a/src/cli/program/core-command-descriptors.ts
+++ b/src/cli/program/core-command-descriptors.ts
@@ -8,17 +8,17 @@ export type CoreCliCommandDescriptor = NamedCommandDescriptor;
 const coreCliCommandCatalog = defineCommandDescriptorCatalog([
   {
     name: "crestodian",
-    description: "Open the interactive setup and repair assistant",
+    description: "Open the ring-zero setup and repair helper",
     hasSubcommands: false,
   },
   {
     name: "setup",
-    description: "Initialize local config and an agent workspace",
+    description: "Alias for openclaw onboard",
     hasSubcommands: false,
   },
   {
     name: "onboard",
-    description: "Interactive onboarding for gateway, workspace, and skills",
+    description: "Guided setup for auth, models, Gateway, workspace, channels, and skills",
     hasSubcommands: false,
   },
   {
@@ -29,7 +29,7 @@ const coreCliCommandCatalog = defineCommandDescriptorCatalog([
   {
     name: "config",
     description:
-      "Non-interactive config helpers (get/set/unset/file/validate). Default: starts guided setup.",
+      "Non-interactive config helpers (get/set/patch/unset/file/schema/validate). Run without subcommand for guided setup.",
     hasSubcommands: true,
   },
   {
@@ -44,7 +44,7 @@ const coreCliCommandCatalog = defineCommandDescriptorCatalog([
   },
   {
     name: "doctor",
-    description: "Diagnose and repair config, Gateway, plugin, and channel problems",
+    description: "Health checks + quick fixes for the gateway and channels",
     hasSubcommands: false,
   },
   {
@@ -64,12 +64,12 @@ const coreCliCommandCatalog = defineCommandDescriptorCatalog([
   },
   {
     name: "message",
-    description: "Send, read, and manage channel messages",
+    description: "Send, read, and manage messages and channel actions",
     hasSubcommands: true,
   },
   {
     name: "mcp",
-    description: "Manage OpenClaw MCP config and channel bridge",
+    description: "Manage OpenClaw mcp.servers config and channel bridge",
     hasSubcommands: true,
     parentDefaultHelp: true,
   },
@@ -80,22 +80,22 @@ const coreCliCommandCatalog = defineCommandDescriptorCatalog([
   },
   {
     name: "agent",
-    description: "Run one agent turn via the Gateway",
+    description: "Run an agent turn via the Gateway (use --local for embedded)",
     hasSubcommands: false,
   },
   {
     name: "agents",
-    description: "Manage isolated agents (workspaces, auth, routing)",
+    description: "Manage isolated agents (workspaces + auth + routing)",
     hasSubcommands: true,
   },
   {
     name: "status",
-    description: "Show Gateway, channel, model, and recent-session status",
+    description: "Show channel health and recent session recipients",
     hasSubcommands: false,
   },
   {
     name: "health",
-    description: "Fetch detailed health from the running Gateway",
+    description: "Fetch health from the running gateway",
     hasSubcommands: false,
   },
   {
@@ -110,7 +110,7 @@ const coreCliCommandCatalog = defineCommandDescriptorCatalog([
   },
   {
     name: "tasks",
-    description: "Inspect durable background tasks and flows",
+    description: "Inspect durable background tasks and TaskFlow state",
     hasSubcommands: true,
   },
 ] as const satisfies ReadonlyArray<CoreCliCommandDescriptor>);

--- a/src/cli/program/register-command-groups.ts
+++ b/src/cli/program/register-command-groups.ts
@@ -44,6 +44,15 @@ export function removeCommandGroupNames(program: Command, entry: CommandGroupEnt
   }
 }
 
+function syncCommandGroupPlaceholderDescriptions(program: Command, entry: CommandGroupEntry) {
+  for (const placeholder of entry.placeholders) {
+    const command = program.commands.find((candidate) => candidate.name() === placeholder.name);
+    if (command) {
+      command.description(placeholder.description);
+    }
+  }
+}
+
 /** Eagerly register one lazy command group by command name. */
 export async function registerCommandGroupByName(
   program: Command,
@@ -56,6 +65,7 @@ export async function registerCommandGroupByName(
   }
   removeCommandGroupNames(program, entry);
   await entry.register(program);
+  syncCommandGroupPlaceholderDescriptions(program, entry);
   return true;
 }
 
@@ -73,6 +83,7 @@ export function registerLazyCommandGroup(
     removeNames: uniqueStrings(getCommandGroupNames(entry)),
     register: async () => {
       await entry.register(program);
+      syncCommandGroupPlaceholderDescriptions(program, entry);
     },
   });
 }
@@ -89,7 +100,12 @@ export function registerCommandGroups(
 ) {
   if (params.eager) {
     for (const entry of entries) {
-      void entry.register(program);
+      const registration = entry.register(program);
+      if (registration && typeof (registration as PromiseLike<unknown>).then === "function") {
+        void registration.then(() => syncCommandGroupPlaceholderDescriptions(program, entry));
+        continue;
+      }
+      syncCommandGroupPlaceholderDescriptions(program, entry);
     }
     return;
   }

--- a/src/cli/program/register.subclis.test.ts
+++ b/src/cli/program/register.subclis.test.ts
@@ -206,6 +206,16 @@ describe("registerSubCliCommands", () => {
     expect(acpAction).toHaveBeenCalledTimes(1);
   });
 
+  it("reconciles registered sub-CLI descriptions back to the descriptor catalog", async () => {
+    const program = createRegisteredProgram(["node", "openclaw", "acp", "--help"], "openclaw");
+
+    await registerSubCliByName(program, "acp");
+
+    expect(program.commands.find((command) => command.name() === "acp")?.description()).toBe(
+      "Run an ACP bridge backed by the Gateway",
+    );
+  });
+
   it("registers only the gateway run surface for gateway startup", async () => {
     const argv = ["node", "openclaw", "gateway", "--force"];
     process.argv = argv;

--- a/src/cli/program/subcli-descriptors.ts
+++ b/src/cli/program/subcli-descriptors.ts
@@ -7,31 +7,31 @@ import { isPrivateQaCliEnabled } from "./private-qa-cli.js";
 export type SubCliDescriptor = NamedCommandDescriptor;
 
 const subCliCommandCatalog = defineCommandDescriptorCatalog([
-  { name: "acp", description: "Run and manage ACP-backed coding agents", hasSubcommands: true },
+  { name: "acp", description: "Run an ACP bridge backed by the Gateway", hasSubcommands: true },
   {
     name: "gateway",
-    description: "Run, inspect, and query the OpenClaw Gateway",
+    description: "Run, inspect, and query the WebSocket Gateway",
     hasSubcommands: true,
   },
   {
     name: "daemon",
-    description: "Manage the Gateway service (legacy alias)",
+    description: "Manage the Gateway service (launchd/systemd/schtasks)",
     hasSubcommands: true,
   },
-  { name: "logs", description: "Tail Gateway logs locally or via RPC", hasSubcommands: false },
+  { name: "logs", description: "Tail gateway file logs via RPC", hasSubcommands: false },
   {
     name: "system",
-    description: "System events, heartbeat, and presence",
+    description: "System tools (events, heartbeat, presence)",
     hasSubcommands: true,
   },
   {
     name: "models",
-    description: "List, scan, and set model providers",
+    description: "Model discovery, scanning, and configuration",
     hasSubcommands: true,
   },
   {
     name: "infer",
-    description: "Run provider-backed model, media, search, and embedding commands",
+    description: "Run provider-backed inference commands through a stable CLI surface",
     hasSubcommands: true,
   },
   {
@@ -52,12 +52,12 @@ const subCliCommandCatalog = defineCommandDescriptorCatalog([
   },
   {
     name: "nodes",
-    description: "Pair nodes and run node-host commands through the Gateway",
+    description: "Manage gateway-owned nodes (pairing, status, invoke, and media)",
     hasSubcommands: true,
   },
   {
     name: "devices",
-    description: "Device pairing + token management",
+    description: "Device pairing and auth tokens",
     hasSubcommands: true,
     parentDefaultHelp: true,
   },
@@ -68,7 +68,7 @@ const subCliCommandCatalog = defineCommandDescriptorCatalog([
   },
   {
     name: "sandbox",
-    description: "Manage sandbox containers for agent isolation",
+    description: "Manage sandbox containers (Docker-based agent isolation)",
     hasSubcommands: true,
   },
   {
@@ -88,7 +88,7 @@ const subCliCommandCatalog = defineCommandDescriptorCatalog([
   },
   {
     name: "cron",
-    description: "Schedule and inspect Gateway background jobs",
+    description: "Manage cron jobs (via Gateway)",
     hasSubcommands: true,
     parentDefaultHelp: true,
   },
@@ -124,7 +124,7 @@ const subCliCommandCatalog = defineCommandDescriptorCatalog([
   },
   {
     name: "qr",
-    description: "Generate mobile pairing QR/setup code",
+    description: "Generate a mobile pairing QR code and setup code",
     hasSubcommands: false,
   },
   {
@@ -139,13 +139,13 @@ const subCliCommandCatalog = defineCommandDescriptorCatalog([
   },
   {
     name: "plugins",
-    description: "Install, enable, disable, and inspect plugins",
+    description: "Manage OpenClaw plugins and extensions",
     hasSubcommands: true,
     parentDefaultHelp: true,
   },
   {
     name: "channels",
-    description: "Add, remove, login, and inspect messaging channels",
+    description: "Manage connected chat channels and accounts",
     hasSubcommands: true,
     parentDefaultHelp: true,
   },
@@ -156,17 +156,17 @@ const subCliCommandCatalog = defineCommandDescriptorCatalog([
   },
   {
     name: "security",
-    description: "Security tools and local config audits",
+    description: "Audit local config and state for common security foot-guns",
     hasSubcommands: true,
   },
   {
     name: "secrets",
-    description: "Audit, apply, and reload SecretRef-backed credentials",
+    description: "Secrets runtime controls",
     hasSubcommands: true,
   },
   {
     name: "skills",
-    description: "List, inspect, and install agent skills",
+    description: "List and inspect available skills",
     hasSubcommands: true,
   },
   {


### PR DESCRIPTION
Fixes #98978

## What Problem This Solves

`openclaw --help` renders root command descriptions from static descriptor catalogs, while `openclaw <command> --help` and shell completion use the live registered commands. Those two sources had drifted apart, which made root help disagree with command help and completion output.

The drift was not just wording churn. Some root descriptions were materially misleading, especially `config`, whose root help line hid shipped `patch` and `schema` subcommands.

## Why This Change Was Made

This change makes the descriptor catalogs the canonical source for top-level command descriptions and updates the catalog entries to match the current live command behavior.

It also synchronizes top-level command descriptions back onto the registered commands after lazy or eager command-group registration. That keeps these surfaces aligned:

- `openclaw --help`
- `openclaw <command> --help`
- shell completion

This keeps the startup-friendly placeholder catalogs while removing the long-term drift between placeholder metadata and live command registration.

## User Impact

CLI users now see the same top-level command descriptions across root help, command help, and completion.

This fixes misleading discovery text for commands like:

- `config`
- `setup`
- `onboard`
- `doctor`
- `status`
- `gateway`
- `daemon`
- `secrets`

In particular, root help now correctly advertises `config` as supporting `patch` and `schema`.

## Evidence

Targeted regression tests:

```bash
node scripts/run-vitest.mjs src/cli/program/command-registry.test.ts src/cli/program/register.subclis.test.ts
```

Diff sanity:

```bash
git diff --check
```

Local CLI proof after the patch:

```text
openclaw --help
config * Non-interactive config helpers
(get/set/patch/unset/file/schema/validate). Run without
subcommand for guided setup.
```

```text
openclaw config --help
Non-interactive config helpers (get/set/patch/unset/file/schema/validate). Run
without subcommand for guided setup.
```

What was verified locally:
- root help now shows the corrected `config` summary
- `openclaw config --help` shows the same top-level description
- regression tests cover the command-group registration path that now re-applies descriptor-catalog descriptions after lazy/eager registration

What was not fully captured as standalone terminal proof:
- a clean completion stdout snippet from the local Windows wrapper path, although completion uses the same eagerly registered top-level command tree that now receives the synchronized catalog descriptions