### PR TITLE
fix: avoid English audio prompt for non-English STT hints

### DIFF
--- a/src/media-understanding/openai-compatible-audio.test.ts
+++ b/src/media-understanding/openai-compatible-audio.test.ts
@@ -75,6 +75,29 @@ describe("transcribeOpenAiCompatibleAudio", () => {
     expect((file as File).name).toBe("voice-note.m4a");
   });
 
+  it("omits the optional prompt field while preserving language hints", async () => {
+    const { fetchFn, getRequest } = createRequestCaptureJsonFetch({ text: "ok" });
+
+    await transcribeOpenAiCompatibleAudio({
+      buffer: Buffer.from("audio"),
+      fileName: "note.ogg",
+      mime: "audio/ogg",
+      apiKey: "test-key",
+      timeoutMs: 1000,
+      fetchFn,
+      provider: "groq",
+      baseUrl: "https://api.groq.com/openai/v1",
+      defaultBaseUrl: "https://api.groq.com/openai/v1",
+      defaultModel: "whisper-large-v3-turbo",
+      language: "ru",
+    });
+
+    const form = getRequest().init?.body;
+    expect(form).toBeInstanceOf(FormData);
+    expect((form as FormData).get("language")).toBe("ru");
+    expect((form as FormData).get("prompt")).toBeNull();
+  });
+
   it("omits bearer auth for explicit no-auth requests", async () => {
     const { fetchFn, getRequest } = createRequestCaptureJsonFetch({ text: "ok" });
 

--- a/src/media-understanding/runner.auto-audio.test.ts
+++ b/src/media-understanding/runner.auto-audio.test.ts
@@ -452,11 +452,13 @@ describe("runCapability auto audio entries", () => {
       prompt: "Transcribe in Russian.",
       models: [{ provider: "openai", model: "whisper-1" }],
     });
-    await runCase({
-      enabled: true,
-      language: "en-US",
-      models: [{ provider: "openai", model: "whisper-1" }],
-    });
+    for (const language of ["en-US", "eng", "english"]) {
+      await runCase({
+        enabled: true,
+        language,
+        models: [{ provider: "openai", model: "whisper-1" }],
+      });
+    }
     await runCase({
       enabled: true,
       models: [{ provider: "openai", model: "whisper-1" }],
@@ -464,6 +466,8 @@ describe("runCapability auto audio entries", () => {
 
     expect(seenPrompts).toEqual([
       "Transcribe in Russian.",
+      "Transcribe the audio.",
+      "Transcribe the audio.",
       "Transcribe the audio.",
       "Transcribe the audio.",
     ]);

--- a/src/media-understanding/runner.auto-audio.test.ts
+++ b/src/media-understanding/runner.auto-audio.test.ts
@@ -5,6 +5,7 @@ import os from "node:os";
 import path from "node:path";
 import { describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../config/types.js";
+import type { MediaUnderstandingConfig } from "../config/types.tools.js";
 import { withEnvAsync } from "../test-utils/env.js";
 import { clearMediaUnderstandingBinaryCacheForTests, runCapability } from "./runner.js";
 import { withAudioFixture } from "./runner.test-utils.js";
@@ -398,6 +399,74 @@ describe("runCapability auto audio entries", () => {
     expect(requireCapabilityOutput(result, 0).text).toBe("ok");
     expect(seenLanguage).toBe("en");
     expect(seenPrompt).toBe("Focus on names");
+  });
+
+  it("omits the implicit English audio prompt when a non-English language is configured", async () => {
+    let seenLanguage: string | undefined;
+    let seenPrompt: string | undefined;
+    const result = await runAutoAudioCase({
+      transcribeAudio: async (req) => {
+        seenLanguage = req.language;
+        seenPrompt = req.prompt;
+        return { text: "ok", model: req.model ?? "unknown" };
+      },
+      cfgExtra: {
+        tools: {
+          media: {
+            audio: {
+              enabled: true,
+              language: "ru",
+              models: [{ provider: "openai", model: "whisper-1" }],
+            },
+          },
+        },
+      } as Partial<OpenClawConfig>,
+    });
+
+    expect(requireCapabilityOutput(result, 0).text).toBe("ok");
+    expect(seenLanguage).toBe("ru");
+    expect(seenPrompt).toBeUndefined();
+  });
+
+  it("keeps explicit and English-compatible audio prompts", async () => {
+    const seenPrompts: Array<string | undefined> = [];
+    const runCase = async (audio: MediaUnderstandingConfig) => {
+      await runAutoAudioCase({
+        transcribeAudio: async (req) => {
+          seenPrompts.push(req.prompt);
+          return { text: "ok", model: req.model ?? "unknown" };
+        },
+        cfgExtra: {
+          tools: {
+            media: {
+              audio,
+            },
+          },
+        } as Partial<OpenClawConfig>,
+      });
+    };
+
+    await runCase({
+      enabled: true,
+      language: "ru",
+      prompt: "Transcribe in Russian.",
+      models: [{ provider: "openai", model: "whisper-1" }],
+    });
+    await runCase({
+      enabled: true,
+      language: "en-US",
+      models: [{ provider: "openai", model: "whisper-1" }],
+    });
+    await runCase({
+      enabled: true,
+      models: [{ provider: "openai", model: "whisper-1" }],
+    });
+
+    expect(seenPrompts).toEqual([
+      "Transcribe in Russian.",
+      "Transcribe the audio.",
+      "Transcribe the audio.",
+    ]);
   });
 
   it("uses mistral when only mistral key is configured", async () => {

--- a/src/media-understanding/runner.entries.ts
+++ b/src/media-understanding/runner.entries.ts
@@ -397,7 +397,14 @@ function resolveEntryRunOptions(params: {
   entry: MediaUnderstandingModelConfig;
   cfg: OpenClawConfig;
   config?: MediaUnderstandingConfig;
-}): { maxBytes: number; maxChars?: number; timeoutMs: number; prompt: string } {
+}): {
+  maxBytes: number;
+  maxChars?: number;
+  timeoutMs: number;
+  prompt: string;
+  promptIsExplicit: boolean;
+  language?: string;
+} {
   const { capability, entry, cfg } = params;
   const maxBytes = resolveMaxBytes({ capability, entry, cfg, config: params.config });
   const maxChars = resolveMaxChars({ capability, entry, cfg, config: params.config });
@@ -407,12 +414,19 @@ function resolveEntryRunOptions(params: {
       cfg.tools?.media?.[capability]?.timeoutSeconds,
     DEFAULT_TIMEOUT_SECONDS[capability],
   );
-  const prompt = resolvePrompt(
-    capability,
-    entry.prompt ?? params.config?.prompt ?? cfg.tools?.media?.[capability]?.prompt,
+  const configuredPrompt =
+    entry.prompt ?? params.config?.prompt ?? cfg.tools?.media?.[capability]?.prompt;
+  const prompt = resolvePrompt(capability, configuredPrompt, maxChars);
+  const language =
+    entry.language ?? params.config?.language ?? cfg.tools?.media?.[capability]?.language;
+  return {
+    maxBytes,
     maxChars,
-  );
-  return { maxBytes, maxChars, timeoutMs, prompt };
+    timeoutMs,
+    prompt,
+    promptIsExplicit: Boolean(configuredPrompt?.trim()),
+    language,
+  };
 }
 
 function resolveMediaRequestOverrides(config: MediaUnderstandingConfig | undefined): {
@@ -427,6 +441,28 @@ function resolveMediaRequestOverrides(config: MediaUnderstandingConfig | undefin
     prompt: overrides["_requestPromptOverride"],
     language: overrides["_requestLanguageOverride"],
   };
+}
+
+function resolveAudioProviderPrompt(params: {
+  prompt: string;
+  promptIsExplicit: boolean;
+  language?: string;
+}): string | undefined {
+  const language = params.language?.trim().toLowerCase();
+  const isEnglish =
+    !language ||
+    language === "en" ||
+    language === "eng" ||
+    language === "english" ||
+    language.startsWith("en-") ||
+    language.startsWith("en_");
+  if (params.promptIsExplicit || isEnglish) {
+    return params.prompt;
+  }
+  // OpenAI-compatible transcription prompts guide style/context and should
+  // match the audio language; omit OpenClaw's English default for non-English
+  // language hints unless the user supplied an explicit prompt.
+  return undefined;
 }
 
 type ProviderExecutionAuth =
@@ -727,12 +763,13 @@ export async function runProviderEntry(params: {
   }
   const providerId = normalizeMediaProviderId(providerIdRaw);
   const requestProviderId = normalizeMediaExecutionProviderId(providerIdRaw);
-  const { maxBytes, maxChars, timeoutMs, prompt } = resolveEntryRunOptions({
-    capability,
-    entry,
-    cfg,
-    config: params.config,
-  });
+  const { maxBytes, maxChars, timeoutMs, prompt, promptIsExplicit, language } =
+    resolveEntryRunOptions({
+      capability,
+      entry,
+      cfg,
+      config: params.config,
+    });
 
   if (capability === "image") {
     if (!params.agentDir) {
@@ -803,6 +840,14 @@ export async function runProviderEntry(params: {
       timeoutMs,
     });
     assertMinAudioSize({ size: media.size, attachmentIndex: params.attachmentIndex });
+    const audioLanguage = requestOverrides.language ?? language;
+    const audioPrompt =
+      requestOverrides.prompt ??
+      resolveAudioProviderPrompt({
+        prompt,
+        promptIsExplicit,
+        language: audioLanguage,
+      });
     const { auth, baseUrl, headers, request } = await resolveProviderExecutionContext({
       capability,
       providerId,
@@ -841,12 +886,8 @@ export async function runProviderEntry(params: {
       headers,
       request,
       model,
-      language:
-        requestOverrides.language ??
-        entry.language ??
-        params.config?.language ??
-        cfg.tools?.media?.audio?.language,
-      prompt: requestOverrides.prompt ?? prompt,
+      language: audioLanguage,
+      prompt: audioPrompt,
       query: providerQuery,
       timeoutMs,
       fetchFn,

--- a/src/media-understanding/runner.entries.ts
+++ b/src/media-understanding/runner.entries.ts
@@ -402,8 +402,7 @@ function resolveEntryRunOptions(params: {
   maxChars?: number;
   timeoutMs: number;
   prompt: string;
-  promptIsExplicit: boolean;
-  language?: string;
+  hasConfiguredPrompt: boolean;
 } {
   const { capability, entry, cfg } = params;
   const maxBytes = resolveMaxBytes({ capability, entry, cfg, config: params.config });
@@ -417,15 +416,12 @@ function resolveEntryRunOptions(params: {
   const configuredPrompt =
     entry.prompt ?? params.config?.prompt ?? cfg.tools?.media?.[capability]?.prompt;
   const prompt = resolvePrompt(capability, configuredPrompt, maxChars);
-  const language =
-    entry.language ?? params.config?.language ?? cfg.tools?.media?.[capability]?.language;
   return {
     maxBytes,
     maxChars,
     timeoutMs,
     prompt,
-    promptIsExplicit: Boolean(configuredPrompt?.trim()),
-    language,
+    hasConfiguredPrompt: Boolean(configuredPrompt?.trim()),
   };
 }
 
@@ -445,7 +441,7 @@ function resolveMediaRequestOverrides(config: MediaUnderstandingConfig | undefin
 
 function resolveAudioProviderPrompt(params: {
   prompt: string;
-  promptIsExplicit: boolean;
+  hasConfiguredPrompt: boolean;
   language?: string;
 }): string | undefined {
   const language = params.language?.trim().toLowerCase();
@@ -456,7 +452,7 @@ function resolveAudioProviderPrompt(params: {
     language === "english" ||
     language.startsWith("en-") ||
     language.startsWith("en_");
-  if (params.promptIsExplicit || isEnglish) {
+  if (params.hasConfiguredPrompt || isEnglish) {
     return params.prompt;
   }
   // OpenAI-compatible transcription prompts guide style/context and should
@@ -763,13 +759,12 @@ export async function runProviderEntry(params: {
   }
   const providerId = normalizeMediaProviderId(providerIdRaw);
   const requestProviderId = normalizeMediaExecutionProviderId(providerIdRaw);
-  const { maxBytes, maxChars, timeoutMs, prompt, promptIsExplicit, language } =
-    resolveEntryRunOptions({
-      capability,
-      entry,
-      cfg,
-      config: params.config,
-    });
+  const { maxBytes, maxChars, timeoutMs, prompt, hasConfiguredPrompt } = resolveEntryRunOptions({
+    capability,
+    entry,
+    cfg,
+    config: params.config,
+  });
 
   if (capability === "image") {
     if (!params.agentDir) {
@@ -840,12 +835,16 @@ export async function runProviderEntry(params: {
       timeoutMs,
     });
     assertMinAudioSize({ size: media.size, attachmentIndex: params.attachmentIndex });
-    const audioLanguage = requestOverrides.language ?? language;
+    const audioLanguage =
+      requestOverrides.language ??
+      entry.language ??
+      params.config?.language ??
+      cfg.tools?.media?.audio?.language;
     const audioPrompt =
       requestOverrides.prompt ??
       resolveAudioProviderPrompt({
         prompt,
-        promptIsExplicit,
+        hasConfiguredPrompt,
         language: audioLanguage,
       });
     const { auth, baseUrl, headers, request } = await resolveProviderExecutionContext({


### PR DESCRIPTION
Closes #98970.

## What Problem This Solves

Fixes an issue where users transcribing short non-English audio with an explicit audio language hint, such as `language=ru`, could still receive an English translation when no custom audio prompt was configured. The affected workflow is provider-backed audio transcription through OpenAI-compatible STT providers such as Groq Whisper.

## Why This Change Was Made

OpenClaw previously resolved the built-in English audio prompt, `Transcribe the audio.`, before building provider transcription requests, so the provider could receive both a non-English language hint and an English prompt. This change keeps explicit prompts and English/default-language behavior intact, but omits only OpenClaw's implicit English audio prompt when the provider audio request has a non-English language hint.

The fix stays in shared media-understanding provider request construction instead of adding a Groq-only branch. The OpenAI-compatible adapter already omits undefined multipart fields, so when the runner leaves `prompt` unset the outgoing form keeps `language=ru` and has no `prompt` field.

## User Impact

Non-English voice notes are less likely to be silently translated into English when users already configured the audio language hint for transcription. Users who set an explicit audio prompt still get that exact prompt, and English or no-language transcription keeps the existing default prompt behavior.

## Evidence

Groq contract checked from current docs:

- [Groq Speech to Text](https://console.groq.com/docs/speech-to-text) separates `/audio/transcriptions` from `/audio/translations`; translations are the endpoint that translates audio to English.
- [Groq API reference](https://console.groq.com/docs/api-reference) documents transcription `language` as an optional ISO-639-1 input language hint and `prompt` as optional text that should match the audio language.

Focused behavior proof:

```text
node scripts/run-vitest.mjs src/media-understanding/runner.auto-audio.test.ts src/media-understanding/openai-compatible-audio.test.ts

Test Files  2 passed (2)
Tests       19 passed (19)
```

This covers the runner sending `language="ru"` with `prompt === undefined` for the implicit default case, preserving explicit prompts, keeping English/default behavior, and the OpenAI-compatible adapter preserving the `language` multipart field while omitting `prompt`.

Adjacent regression proof:

```text
node scripts/run-vitest.mjs src/media-understanding/runner.cli-audio.test.ts

Test Files  1 passed (1)
Tests       3 passed (3)
```

```text
node scripts/run-vitest.mjs src/media-understanding/runtime.test.ts

Test Files  1 passed (1)
Tests       21 passed (21)
```

Other local checks:

```text
git diff --check
# passed

.agents/skills/autoreview/scripts/autoreview --mode local
# autoreview clean: no accepted/actionable findings reported
```

GitHub PR checks on commit `6e92c810b927b929721829f7a5bc6976daabdaef`:

- `CI` run [28578566842](https://github.com/openclaw/openclaw/actions/runs/28578566842): success, 54/54 jobs completed, including `check-prod-types`, `check-test-types`, `check-lint`, `build-artifacts`, and Node test shards.
- `Real behavior proof` run [28578566983](https://github.com/openclaw/openclaw/actions/runs/28578566983): success.
- `CodeQL` run [28578566807](https://github.com/openclaw/openclaw/actions/runs/28578566807): success.
- `Dependency Guard` run [28578566896](https://github.com/openclaw/openclaw/actions/runs/28578566896): success.
- `Security Sensitive Guard` run [28578567000](https://github.com/openclaw/openclaw/actions/runs/28578567000): success.

`node scripts/check-changed.mjs` could not run locally before push because the available Crabbox binary is `0.18.0`, while OpenClaw's current Blacksmith Testbox wrapper requires Crabbox `>=0.22.0`. The PR CI above ran the changed check lanes successfully.

Not run: live Groq audio transcription, because this environment does not have `GROQ_API_KEY`. The request-shape regression is covered by the runner and adapter tests above.

AI-assisted: yes, implemented with Codex. A redacted local transcript was found but not included because transcript publication requires explicit approval.
