### PR TITLE
fix(media): suppress default audio prompt for non-English hints

### DIFF
--- a/src/media-understanding/openai-compatible-audio.test.ts
+++ b/src/media-understanding/openai-compatible-audio.test.ts
@@ -115,6 +115,27 @@ describe("transcribeOpenAiCompatibleAudio", () => {
     expect(headers.get("authorization")).toBe("Bearer typed-key");
   });
 
+  it("omits optional prompt fields from transcription multipart requests", async () => {
+    const { fetchFn, getRequest } = createRequestCaptureJsonFetch({ text: "ok" });
+
+    await transcribeOpenAiCompatibleAudio({
+      buffer: Buffer.from("audio"),
+      fileName: "note.mp3",
+      apiKey: "test-key",
+      language: "ru",
+      timeoutMs: 1000,
+      fetchFn,
+      provider: "openai",
+      defaultBaseUrl: "https://api.openai.com/v1",
+      defaultModel: "gpt-4o-transcribe",
+    });
+
+    const form = getRequest().init?.body;
+    expect(form).toBeInstanceOf(FormData);
+    expect((form as FormData).get("language")).toBe("ru");
+    expect((form as FormData).has("prompt")).toBe(false);
+  });
+
   it("wraps malformed transcription JSON with a stable provider error", async () => {
     const fetchFn = vi.fn<typeof fetch>().mockResolvedValueOnce(new Response("{ nope"));
 

--- a/src/media-understanding/resolve.test.ts
+++ b/src/media-understanding/resolve.test.ts
@@ -29,8 +29,8 @@ describe("media timeout resolution", () => {
 
 describe("resolvePrompt", () => {
   it("suppresses the implicit English audio prompt for explicit non-English languages", () => {
-    expect(resolvePrompt("audio", undefined, undefined, "ru")).toBe("");
-    expect(resolvePrompt("audio", undefined, undefined, "zh-CN")).toBe("");
+    expect(resolvePrompt("audio", undefined, undefined, "ru")).toBeUndefined();
+    expect(resolvePrompt("audio", undefined, undefined, "zh-CN")).toBeUndefined();
   });
 
   it("keeps explicit audio prompts and English defaults", () => {

--- a/src/media-understanding/resolve.test.ts
+++ b/src/media-understanding/resolve.test.ts
@@ -2,7 +2,12 @@
 import { MAX_TIMER_TIMEOUT_MS } from "@openclaw/normalization-core/number-coercion";
 import { describe, expect, it } from "vitest";
 import type { OpenClawConfig } from "../config/types.js";
-import { resolveMediaRuntimeTimeoutMs, resolveModelEntries, resolveTimeoutMs } from "./resolve.js";
+import {
+  resolveMediaRuntimeTimeoutMs,
+  resolveModelEntries,
+  resolvePrompt,
+  resolveTimeoutMs,
+} from "./resolve.js";
 import type { MediaUnderstandingCapability } from "./types.js";
 
 const providerRegistry = new Map<string, { capabilities: MediaUnderstandingCapability[] }>([
@@ -19,6 +24,27 @@ describe("media timeout resolution", () => {
   it("caps explicit runtime timeout milliseconds to timer-safe values", () => {
     expect(resolveMediaRuntimeTimeoutMs(Number.MAX_SAFE_INTEGER)).toBe(MAX_TIMER_TIMEOUT_MS);
     expect(resolveMediaRuntimeTimeoutMs(undefined)).toBe(30_000);
+  });
+});
+
+describe("resolvePrompt", () => {
+  it("suppresses the implicit English audio prompt for explicit non-English languages", () => {
+    expect(resolvePrompt("audio", undefined, undefined, "ru")).toBe("");
+    expect(resolvePrompt("audio", undefined, undefined, "zh-CN")).toBe("");
+  });
+
+  it("keeps explicit audio prompts and English defaults", () => {
+    expect(resolvePrompt("audio", "Transcribe verbatim.", undefined, "ru")).toBe(
+      "Transcribe verbatim.",
+    );
+    expect(resolvePrompt("audio", undefined, undefined, "en-US")).toBe("Transcribe the audio.");
+    expect(resolvePrompt("audio", undefined)).toBe("Transcribe the audio.");
+  });
+
+  it("keeps non-audio prompt length guidance unchanged", () => {
+    expect(resolvePrompt("image", undefined, 80, "ru")).toBe(
+      "Describe the image. Respond in at most 80 characters.",
+    );
   });
 });
 

--- a/src/media-understanding/resolve.ts
+++ b/src/media-understanding/resolve.ts
@@ -50,12 +50,29 @@ export function resolvePrompt(
   capability: MediaUnderstandingCapability,
   prompt?: string,
   maxChars?: number,
+  language?: string,
 ): string {
-  const base = prompt?.trim() || DEFAULT_PROMPT[capability];
+  const explicitPrompt = prompt?.trim();
+  const base =
+    explicitPrompt ||
+    (capability === "audio" && isNonEnglishLanguage(language) ? "" : DEFAULT_PROMPT[capability]);
   if (!maxChars || capability === "audio") {
     return base;
   }
   return `${base} Respond in at most ${maxChars} characters.`;
+}
+
+function isNonEnglishLanguage(language: string | undefined): boolean {
+  const normalized = language?.trim().toLowerCase().replaceAll("_", "-");
+  if (!normalized) {
+    return false;
+  }
+  return (
+    normalized !== "en" &&
+    normalized !== "eng" &&
+    normalized !== "english" &&
+    !normalized.startsWith("en-")
+  );
 }
 
 /** Resolves the effective max response characters for a model entry and capability. */

--- a/src/media-understanding/resolve.ts
+++ b/src/media-understanding/resolve.ts
@@ -51,13 +51,18 @@ export function resolvePrompt(
   prompt?: string,
   maxChars?: number,
   language?: string,
-): string {
+): string | undefined {
   const explicitPrompt = prompt?.trim();
   const base =
     explicitPrompt ||
-    (capability === "audio" && isNonEnglishLanguage(language) ? "" : DEFAULT_PROMPT[capability]);
+    (capability === "audio" && isNonEnglishLanguage(language)
+      ? undefined
+      : DEFAULT_PROMPT[capability]);
   if (!maxChars || capability === "audio") {
     return base;
+  }
+  if (!base) {
+    return undefined;
   }
   return `${base} Respond in at most ${maxChars} characters.`;
 }

--- a/src/media-understanding/runner.auto-audio.test.ts
+++ b/src/media-understanding/runner.auto-audio.test.ts
@@ -424,7 +424,7 @@ describe("runCapability auto audio entries", () => {
 
     expect(requireCapabilityOutput(result, 0).text).toBe("ok");
     expect(seenLanguage).toBe("ru");
-    expect(seenPrompt).toBe("");
+    expect(seenPrompt).toBeUndefined();
   });
 
   it("keeps the default audio prompt when no language hint is configured", async () => {

--- a/src/media-understanding/runner.auto-audio.test.ts
+++ b/src/media-understanding/runner.auto-audio.test.ts
@@ -400,6 +400,56 @@ describe("runCapability auto audio entries", () => {
     expect(seenPrompt).toBe("Focus on names");
   });
 
+  it("omits the implicit English prompt for non-English transcription hints", async () => {
+    let seenLanguage: string | undefined;
+    let seenPrompt: string | undefined;
+    const result = await runAutoAudioCase({
+      transcribeAudio: async (req) => {
+        seenLanguage = req.language;
+        seenPrompt = req.prompt;
+        return { text: "ok", model: req.model ?? "unknown" };
+      },
+      cfgExtra: {
+        tools: {
+          media: {
+            audio: {
+              enabled: true,
+              language: "ru",
+              models: [{ provider: "openai", model: "whisper-1" }],
+            },
+          },
+        },
+      } as Partial<OpenClawConfig>,
+    });
+
+    expect(requireCapabilityOutput(result, 0).text).toBe("ok");
+    expect(seenLanguage).toBe("ru");
+    expect(seenPrompt).toBe("");
+  });
+
+  it("keeps the default audio prompt when no language hint is configured", async () => {
+    let seenPrompt: string | undefined;
+    const result = await runAutoAudioCase({
+      transcribeAudio: async (req) => {
+        seenPrompt = req.prompt;
+        return { text: "ok", model: req.model ?? "unknown" };
+      },
+      cfgExtra: {
+        tools: {
+          media: {
+            audio: {
+              enabled: true,
+              models: [{ provider: "openai", model: "whisper-1" }],
+            },
+          },
+        },
+      } as Partial<OpenClawConfig>,
+    });
+
+    expect(requireCapabilityOutput(result, 0).text).toBe("ok");
+    expect(seenPrompt).toBe("Transcribe the audio.");
+  });
+
   it("uses mistral when only mistral key is configured", async () => {
     const isolatedAgentDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-audio-agent-"));
     let runResult: Awaited<ReturnType<typeof runCapability>> | undefined;

--- a/src/media-understanding/runner.entries.ts
+++ b/src/media-understanding/runner.entries.ts
@@ -409,7 +409,7 @@ function resolveEntryRunOptions(params: {
   entry: MediaUnderstandingModelConfig;
   cfg: OpenClawConfig;
   config?: MediaUnderstandingConfig;
-}): { maxBytes: number; maxChars?: number; timeoutMs: number; prompt: string } {
+}): { maxBytes: number; maxChars?: number; timeoutMs: number; prompt?: string } {
   const { capability, entry, cfg } = params;
   const requestOverrides = resolveMediaRequestOverrides(params.config);
   const maxBytes = resolveMaxBytes({ capability, entry, cfg, config: params.config });

--- a/src/media-understanding/runner.entries.ts
+++ b/src/media-understanding/runner.entries.ts
@@ -411,6 +411,7 @@ function resolveEntryRunOptions(params: {
   config?: MediaUnderstandingConfig;
 }): { maxBytes: number; maxChars?: number; timeoutMs: number; prompt: string } {
   const { capability, entry, cfg } = params;
+  const requestOverrides = resolveMediaRequestOverrides(params.config);
   const maxBytes = resolveMaxBytes({ capability, entry, cfg, config: params.config });
   const maxChars = resolveMaxChars({ capability, entry, cfg, config: params.config });
   const timeoutMs = resolveTimeoutMs(
@@ -421,8 +422,15 @@ function resolveEntryRunOptions(params: {
   );
   const prompt = resolvePrompt(
     capability,
-    entry.prompt ?? params.config?.prompt ?? cfg.tools?.media?.[capability]?.prompt,
+    requestOverrides.prompt ??
+      entry.prompt ??
+      params.config?.prompt ??
+      cfg.tools?.media?.[capability]?.prompt,
     maxChars,
+    requestOverrides.language ??
+      entry.language ??
+      params.config?.language ??
+      cfg.tools?.media?.[capability]?.language,
   );
   return { maxBytes, maxChars, timeoutMs, prompt };
 }


### PR DESCRIPTION
## What Problem This Solves

Fixes #98970.

OpenClaw currently resolves the built-in English audio prompt (`Transcribe the audio.`) even when audio transcription has an explicit non-English language hint. For OpenAI-compatible Whisper providers such as Groq, that prompt is a decoding bias hint, so short non-English clips can be translated into English despite `language=ru`.

This is an alternative/replacement for #99008. It keeps the same narrow prompt/language fix direction while preserving the existing missing-provider diagnostic path that #99008 currently regresses.

## Why This Change Was Made

The audio runner already resolves language from the request override, entry, capability config, and shared media config. The prompt resolver did not see that language, so an omitted user prompt always became the English default.

This change makes audio prompt resolution language-aware:

- Explicit prompts still win and are passed through unchanged.
- No language hint, English hints (`en`, `eng`, `english`, `en-*`, `en_*`), and non-audio capabilities keep existing behavior.
- Non-English audio hints with no explicit prompt now leave provider `prompt` unset.
- The OpenAI-compatible audio adapter omits unset optional prompt fields from the multipart request while still sending the explicit `language` hint.

The existing `formatMissingProviderHint` export and missing-provider error suffix are untouched.

## User Impact

Users who configure non-English audio transcription, such as `language=ru`, no longer get the default English prompt injected into provider requests. This lets Groq/OpenAI-compatible Whisper honor the language hint without the English prompt bias reported in #98970.

English transcription and explicit `tools.media.audio.prompt` configurations keep their previous behavior.

## Evidence

Tests run from `codex/98970-audio-prompt-language` on Windows, Node/Vitest from this checkout:

```powershell
$env:OPENCLAW_HEAVY_CHECK_LOCK_SCOPE='worktree'; node scripts/run-vitest.mjs src/media-understanding/openai-compatible-audio.test.ts --reporter=verbose
```

Result: passed 1 Vitest shard; `openai-compatible-audio.test.ts` 8/8. This includes adapter coverage proving `language=ru` is sent while the optional `prompt` multipart field is omitted when unset.

```powershell
$env:OPENCLAW_HEAVY_CHECK_LOCK_SCOPE='worktree'; node scripts/run-vitest.mjs src/media-understanding/resolve.test.ts src/media-understanding/runner.auto-audio.test.ts src/media-understanding/openai-compatible-audio.test.ts src/media-understanding/runner.entries.guards.test.ts src/media-understanding/runtime.test.ts --reporter=verbose
```

Result: passed 2 Vitest shards; 40/40 tests. This includes resolver coverage, runner-level request-shape coverage, OpenAI-compatible multipart coverage, runtime adjacency, and `runner.entries.guards.test.ts` proving the missing-provider hint path remains intact.

```shell
git diff --check
```

Result: clean.

```powershell
$env:OPENCLAW_HEAVY_CHECK_LOCK_SCOPE='worktree'; node scripts/run-tsgo.mjs -p test/tsconfig/tsconfig.core.test.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/core-test.tsbuildinfo
```

Result: exit code 0.

`pnpm check:test-types` was attempted earlier, but pnpm tried to run an install/dependency reconciliation and aborted with `ERR_PNPM_ABORTED_REMOVE_MODULES_DIR_NO_TTY` in this linked worktree. I ran the underlying core test tsgo command directly instead.

## Not Tested

- Live Groq or Telegram voice-note proof. This environment has no `GROQ_API_KEY`, `OPENCLAW_LIVE_GROQ_KEY`, or `OPENCLAW_LIVE_GROQ_KEYS`, so I could not run a real non-English audio transcription request. A Mantis Telegram Desktop proof run has been requested and is currently waiting on the shared Telegram proof account queue.