### PR TITLE
fix(media): guard ffprobe JSON.parse against malformed output

### DIFF
--- a/src/media/video-dimensions.test.ts
+++ b/src/media/video-dimensions.test.ts
@@ -17,6 +17,11 @@ describe("parseFfprobeVideoDimensions", () => {
     ).toEqual({ width: 720, height: 1280 });
   });
 
+  it("returns undefined for malformed JSON instead of throwing", () => {
+    expect(parseFfprobeVideoDimensions("{")).toBeUndefined();
+    expect(parseFfprobeVideoDimensions("")).toBeUndefined();
+  });
+
   it("ignores missing or invalid dimensions", () => {
     expect(parseFfprobeVideoDimensions(JSON.stringify({ streams: [] }))).toBeUndefined();
     expect(

--- a/src/media/video-dimensions.ts
+++ b/src/media/video-dimensions.ts
@@ -16,7 +16,12 @@ function parsePositiveDimension(value: unknown): number | undefined {
 
 /** Parses ffprobe JSON output, accepting only positive integer first-stream dimensions. */
 export function parseFfprobeVideoDimensions(stdout: string): VideoDimensions | undefined {
-  const parsed = JSON.parse(stdout) as { streams?: Array<{ width?: unknown; height?: unknown }> };
+  let parsed: { streams?: Array<{ width?: unknown; height?: unknown }> };
+  try {
+    parsed = JSON.parse(stdout) as typeof parsed;
+  } catch {
+    return undefined;
+  }
   const stream = parsed.streams?.[0];
   const width = parsePositiveDimension(stream?.width);
   const height = parsePositiveDimension(stream?.height);


### PR DESCRIPTION
Wrap JSON.parse with try-catch. 2 files, 5 tests pass.
