### PR TITLE
fix(qqbot): merge small markdown chunks into a single message bubble

### DIFF
--- a/extensions/qqbot/src/engine/messaging/markdown-table-chunking.ts
+++ b/extensions/qqbot/src/engine/messaging/markdown-table-chunking.ts
@@ -2,7 +2,7 @@
 
 export type QQBotBaseMarkdownChunker = (text: string, limit: number) => string[];
 
-const QQBOT_MARKDOWN_SAFE_CHUNK_BYTE_LIMIT = 3600;
+export const QQBOT_MARKDOWN_SAFE_CHUNK_BYTE_LIMIT = 3600;
 
 type TableHeader = {
   header: string;

--- a/extensions/qqbot/src/engine/messaging/outbound-deliver.test.ts
+++ b/extensions/qqbot/src/engine/messaging/outbound-deliver.test.ts
@@ -183,4 +183,40 @@ describe("sendTextOnlyReply chunk merging", () => {
     expect(sendTextMock).toHaveBeenCalledTimes(1);
     expect(sendTextMock.mock.calls[0]?.[1]).toBe("Just one chunk.");
   });
+
+  it("retries with original chunks when a merged chunk send fails", async () => {
+    // chunkText returns two small chunks that would normally merge.
+    // Make sendText fail on the first call (merged chunk), then succeed.
+    const chunk1 = "First paragraph.";
+    const chunk2 = "Second paragraph.";
+    sendTextMock
+      .mockRejectedValueOnce(new Error("QQ API reject"))
+      .mockResolvedValueOnce({ id: "fb-1", timestamp: "2026-07-01T00:00:00.000Z" })
+      .mockResolvedValueOnce({ id: "fb-2", timestamp: "2026-07-01T00:00:00.000Z" });
+
+    const deps = {
+      mediaSender: {} as Parameters<typeof sendTextOnlyReply>[5]["mediaSender"],
+      chunkText: (_text: string, _limit: number) => [chunk1, chunk2],
+    };
+
+    // Must not throw — fallback sends the original chunks individually.
+    await expect(
+      sendTextOnlyReply(
+        `${chunk1}\n\n${chunk2}`,
+        event,
+        actx,
+        sendWithRetry,
+        consumeQuoteRef,
+        deps,
+      ),
+    ).resolves.toBeUndefined();
+
+    // 3 calls total: 1 failed merged send + 2 fallback original chunks.
+    expect(sendTextMock).toHaveBeenCalledTimes(3);
+    // First attempt: the merged chunk.
+    expect(sendTextMock.mock.calls[0]?.[1]).toBe("First paragraph.\n\nSecond paragraph.");
+    // Fallback: original chunks sent individually in order.
+    expect(sendTextMock.mock.calls[1]?.[1]).toBe(chunk1);
+    expect(sendTextMock.mock.calls[2]?.[1]).toBe(chunk2);
+  });
 });

--- a/extensions/qqbot/src/engine/messaging/outbound-deliver.test.ts
+++ b/extensions/qqbot/src/engine/messaging/outbound-deliver.test.ts
@@ -96,16 +96,42 @@ describe("sendTextOnlyReply chunk merging", () => {
     // chunkText returns two chunks whose merged total exceeds 3600 bytes.
     // largeChunk at (limit - 50) bytes plus "\n\n" plus second chunk pushes over.
     const largeChunk = "A".repeat(QQBOT_MARKDOWN_SAFE_CHUNK_BYTE_LIMIT - 50);
+    const secondChunk = "Another paragraph that pushes the merge over the limit.";
     const deps = {
       mediaSender: {} as Parameters<typeof sendTextOnlyReply>[5]["mediaSender"],
-      chunkText: (_text: string, _limit: number) => [
-        largeChunk,
-        "Another paragraph that pushes the merge over the limit.",
-      ],
+      chunkText: (_text: string, _limit: number) => [largeChunk, secondChunk],
+    };
+
+    // Must not throw — overflow falls back to separate sends without errors.
+    await expect(
+      sendTextOnlyReply(
+        `${largeChunk}\n\n${secondChunk}`,
+        event,
+        actx,
+        sendWithRetry,
+        consumeQuoteRef,
+        deps,
+      ),
+    ).resolves.toBeUndefined();
+
+    // Two separate sendText calls because merging would exceed the byte limit.
+    expect(sendTextMock).toHaveBeenCalledTimes(2);
+    // Each original chunk is sent as-is.
+    expect(sendTextMock.mock.calls[0]?.[1]).toBe(largeChunk);
+    expect(sendTextMock.mock.calls[1]?.[1]).toBe(secondChunk);
+  });
+
+  it("merges chunks when total size is exactly at the safe byte limit", async () => {
+    // Two chunks whose merged size equals exactly 3600 bytes: still within <= limit.
+    const chunk1 = "A".repeat(2000);
+    const chunk2 = "B".repeat(QQBOT_MARKDOWN_SAFE_CHUNK_BYTE_LIMIT - 2000 - 2); // minus "\n\n"
+    const deps = {
+      mediaSender: {} as Parameters<typeof sendTextOnlyReply>[5]["mediaSender"],
+      chunkText: (_text: string, _limit: number) => [chunk1, chunk2],
     };
 
     await sendTextOnlyReply(
-      `${largeChunk}\n\nAnother paragraph that pushes the merge over the limit.`,
+      `${chunk1}\n\n${chunk2}`,
       event,
       actx,
       sendWithRetry,
@@ -113,8 +139,37 @@ describe("sendTextOnlyReply chunk merging", () => {
       deps,
     );
 
-    // Two separate sendText calls because merging would exceed the byte limit.
-    expect(sendTextMock).toHaveBeenCalledTimes(2);
+    // Merged into a single send because total === limit.
+    expect(sendTextMock).toHaveBeenCalledTimes(1);
+    expect(sendTextMock.mock.calls[0]?.[1]).toBe(`${chunk1}\n\n${chunk2}`);
+  });
+
+  it("falls back to separate sends for three or more chunks whose merged total overflows", async () => {
+    // Three chunks: first two are large, third pushes the merge well over 3600.
+    const chunk1 = "A".repeat(2000);
+    const chunk2 = "B".repeat(1500);
+    const chunk3 = "C".repeat(500);
+    const deps = {
+      mediaSender: {} as Parameters<typeof sendTextOnlyReply>[5]["mediaSender"],
+      chunkText: (_text: string, _limit: number) => [chunk1, chunk2, chunk3],
+    };
+
+    await expect(
+      sendTextOnlyReply(
+        `${chunk1}\n\n${chunk2}\n\n${chunk3}`,
+        event,
+        actx,
+        sendWithRetry,
+        consumeQuoteRef,
+        deps,
+      ),
+    ).resolves.toBeUndefined();
+
+    // All three chunks sent separately — no merge, no errors.
+    expect(sendTextMock).toHaveBeenCalledTimes(3);
+    expect(sendTextMock.mock.calls[0]?.[1]).toBe(chunk1);
+    expect(sendTextMock.mock.calls[1]?.[1]).toBe(chunk2);
+    expect(sendTextMock.mock.calls[2]?.[1]).toBe(chunk3);
   });
 
   it("passes through a single chunk unchanged", async () => {

--- a/extensions/qqbot/src/engine/messaging/outbound-deliver.test.ts
+++ b/extensions/qqbot/src/engine/messaging/outbound-deliver.test.ts
@@ -1,0 +1,131 @@
+// Tests cover chunk-merge behavior in outbound delivery.
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import type { GatewayAccount } from "../types.js";
+import { QQBOT_MARKDOWN_SAFE_CHUNK_BYTE_LIMIT } from "./markdown-table-chunking.js";
+import { sendTextOnlyReply } from "./outbound-deliver.js";
+
+// ─── Mocks ──────────────────────────────────────────────────────────────────
+
+const sendTextMock = vi.hoisted(() =>
+  vi.fn(async (..._params: unknown[]) => ({
+    id: "text-1",
+    timestamp: "2026-07-01T00:00:00.000Z",
+  })),
+);
+
+vi.mock("./sender.js", () => ({
+  accountToCreds: (account: GatewayAccount) => ({
+    appId: account.appId,
+    clientSecret: account.clientSecret,
+  }),
+  buildDeliveryTarget: (target: { type: string; senderId: string; groupOpenid?: string }) => ({
+    type: target.type === "group" ? "group" : "c2c",
+    id: target.type === "group" ? target.groupOpenid : target.senderId,
+  }),
+  initApiConfig: vi.fn(),
+  sendFileMessage: vi.fn(),
+  sendImage: vi.fn(),
+  sendText: sendTextMock,
+  sendVideoMessage: vi.fn(),
+  sendVoiceMessage: vi.fn(),
+  sendMedia: vi.fn(),
+  withTokenRetry: async (_creds: unknown, fn: () => Promise<unknown>) => await fn(),
+}));
+
+// ─── Fixtures ───────────────────────────────────────────────────────────────
+
+const account: GatewayAccount = {
+  accountId: "qq-main",
+  appId: "app",
+  clientSecret: "secret",
+  markdownSupport: false,
+  config: {},
+};
+
+const event = {
+  type: "c2c" as const,
+  senderId: "user-openid",
+  messageId: "msg-1",
+};
+
+const actx = {
+  account,
+  qualifiedTarget: "qqbot:c2c:user-openid",
+};
+
+const sendWithRetry: <T>(fn: (token: string) => Promise<T>) => Promise<T> = async (fn) =>
+  await fn("fake-token");
+
+function consumeQuoteRef(): string | undefined {
+  return undefined;
+}
+
+// ─── Tests ──────────────────────────────────────────────────────────────────
+
+describe("sendTextOnlyReply chunk merging", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("merges multiple chunks into a single send when merged size fits within the safe byte limit", async () => {
+    // chunkText returns two small chunks that easily fit within 3600 bytes.
+    const deps = {
+      mediaSender: {} as Parameters<typeof sendTextOnlyReply>[5]["mediaSender"],
+      chunkText: (_text: string, _limit: number) => [
+        "Short paragraph one.",
+        "Short paragraph two.",
+      ],
+    };
+
+    await sendTextOnlyReply(
+      "Short paragraph one.\n\nShort paragraph two.",
+      event,
+      actx,
+      sendWithRetry,
+      consumeQuoteRef,
+      deps,
+    );
+
+    // Only one sendText call because the two chunks were merged.
+    expect(sendTextMock).toHaveBeenCalledTimes(1);
+    const sentText = sendTextMock.mock.calls[0]?.[1] as string | undefined;
+    expect(sentText).toBe("Short paragraph one.\n\nShort paragraph two.");
+  });
+
+  it("keeps chunks separate when merged size exceeds the safe byte limit", async () => {
+    // chunkText returns two chunks whose merged total exceeds 3600 bytes.
+    // largeChunk at (limit - 50) bytes plus "\n\n" plus second chunk pushes over.
+    const largeChunk = "A".repeat(QQBOT_MARKDOWN_SAFE_CHUNK_BYTE_LIMIT - 50);
+    const deps = {
+      mediaSender: {} as Parameters<typeof sendTextOnlyReply>[5]["mediaSender"],
+      chunkText: (_text: string, _limit: number) => [
+        largeChunk,
+        "Another paragraph that pushes the merge over the limit.",
+      ],
+    };
+
+    await sendTextOnlyReply(
+      `${largeChunk}\n\nAnother paragraph that pushes the merge over the limit.`,
+      event,
+      actx,
+      sendWithRetry,
+      consumeQuoteRef,
+      deps,
+    );
+
+    // Two separate sendText calls because merging would exceed the byte limit.
+    expect(sendTextMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("passes through a single chunk unchanged", async () => {
+    const deps = {
+      mediaSender: {} as Parameters<typeof sendTextOnlyReply>[5]["mediaSender"],
+      chunkText: (_text: string, _limit: number) => ["Just one chunk."],
+    };
+
+    await sendTextOnlyReply("Just one chunk.", event, actx, sendWithRetry, consumeQuoteRef, deps);
+
+    expect(sendTextMock).toHaveBeenCalledTimes(1);
+    expect(sendTextMock.mock.calls[0]?.[1]).toBe("Just one chunk.");
+  });
+});

--- a/extensions/qqbot/src/engine/messaging/outbound-deliver.test.ts
+++ b/extensions/qqbot/src/engine/messaging/outbound-deliver.test.ts
@@ -1,6 +1,6 @@
 // Tests cover chunk-merge behavior in outbound delivery.
 import { describe, expect, it, vi, beforeEach } from "vitest";
-import type { GatewayAccount } from "../types.js";
+import { ApiError, type GatewayAccount } from "../types.js";
 import { QQBOT_MARKDOWN_SAFE_CHUNK_BYTE_LIMIT } from "./markdown-table-chunking.js";
 import { sendTextOnlyReply } from "./outbound-deliver.js";
 
@@ -184,13 +184,13 @@ describe("sendTextOnlyReply chunk merging", () => {
     expect(sendTextMock.mock.calls[0]?.[1]).toBe("Just one chunk.");
   });
 
-  it("retries with original chunks when a merged chunk send fails", async () => {
+  it("retries with original chunks when merged send fails with a deterministic 4xx rejection", async () => {
     // chunkText returns two small chunks that would normally merge.
-    // Make sendText fail on the first call (merged chunk), then succeed.
+    // Make sendText fail with a deterministic QQ rejection (ApiError, 4xx).
     const chunk1 = "First paragraph.";
     const chunk2 = "Second paragraph.";
     sendTextMock
-      .mockRejectedValueOnce(new Error("QQ API reject"))
+      .mockRejectedValueOnce(new ApiError("API Error", 400, "/v2/messages"))
       .mockResolvedValueOnce({ id: "fb-1", timestamp: "2026-07-01T00:00:00.000Z" })
       .mockResolvedValueOnce({ id: "fb-2", timestamp: "2026-07-01T00:00:00.000Z" });
 
@@ -218,5 +218,84 @@ describe("sendTextOnlyReply chunk merging", () => {
     // Fallback: original chunks sent individually in order.
     expect(sendTextMock.mock.calls[1]?.[1]).toBe(chunk1);
     expect(sendTextMock.mock.calls[2]?.[1]).toBe(chunk2);
+  });
+
+  it("does NOT retry original chunks when merged send fails with a timeout (httpStatus 0)", async () => {
+    // Timeout errors have httpStatus 0 — the merged POST may have been accepted.
+    const chunk1 = "A";
+    const chunk2 = "B";
+    sendTextMock.mockRejectedValueOnce(new ApiError("Request timeout", 0, "/v2/messages"));
+
+    const deps = {
+      mediaSender: {} as Parameters<typeof sendTextOnlyReply>[5]["mediaSender"],
+      chunkText: (_text: string, _limit: number) => [chunk1, chunk2],
+    };
+
+    await expect(
+      sendTextOnlyReply(
+        `${chunk1}\n\n${chunk2}`,
+        event,
+        actx,
+        sendWithRetry,
+        consumeQuoteRef,
+        deps,
+      ),
+    ).resolves.toBeUndefined();
+
+    // Only 1 call: the failed merged send. No fallback retries.
+    expect(sendTextMock).toHaveBeenCalledTimes(1);
+    expect(sendTextMock.mock.calls[0]?.[1]).toBe("A\n\nB");
+  });
+
+  it("does NOT retry original chunks when merged send fails with a 5xx server error", async () => {
+    // 5xx errors are ambiguous — the server may have processed the request.
+    const chunk1 = "A";
+    const chunk2 = "B";
+    sendTextMock.mockRejectedValueOnce(new ApiError("Server error", 502, "/v2/messages"));
+
+    const deps = {
+      mediaSender: {} as Parameters<typeof sendTextOnlyReply>[5]["mediaSender"],
+      chunkText: (_text: string, _limit: number) => [chunk1, chunk2],
+    };
+
+    await expect(
+      sendTextOnlyReply(
+        `${chunk1}\n\n${chunk2}`,
+        event,
+        actx,
+        sendWithRetry,
+        consumeQuoteRef,
+        deps,
+      ),
+    ).resolves.toBeUndefined();
+
+    // Only 1 call: the failed merged send. No fallback retries.
+    expect(sendTextMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("does NOT retry original chunks when merged send fails with a generic Error", async () => {
+    // Generic errors are not ApiError instances — unknown delivery state.
+    const chunk1 = "A";
+    const chunk2 = "B";
+    sendTextMock.mockRejectedValueOnce(new Error("Unexpected failure"));
+
+    const deps = {
+      mediaSender: {} as Parameters<typeof sendTextOnlyReply>[5]["mediaSender"],
+      chunkText: (_text: string, _limit: number) => [chunk1, chunk2],
+    };
+
+    await expect(
+      sendTextOnlyReply(
+        `${chunk1}\n\n${chunk2}`,
+        event,
+        actx,
+        sendWithRetry,
+        consumeQuoteRef,
+        deps,
+      ),
+    ).resolves.toBeUndefined();
+
+    // Only 1 call: the failed merged send. No fallback retries.
+    expect(sendTextMock).toHaveBeenCalledTimes(1);
   });
 });

--- a/extensions/qqbot/src/engine/messaging/outbound-deliver.ts
+++ b/extensions/qqbot/src/engine/messaging/outbound-deliver.ts
@@ -17,6 +17,7 @@ import {
 } from "../utils/string-normalize.js";
 import { filterInternalMarkers } from "../utils/text-parsing.js";
 import { decodeMediaPath } from "./decode-media-path.js";
+import { QQBOT_MARKDOWN_SAFE_CHUNK_BYTE_LIMIT } from "./markdown-table-chunking.js";
 import {
   sendText as senderSendText,
   sendMedia as senderSendMedia,
@@ -74,6 +75,26 @@ export interface DeliverDeps {
 
 /** Maximum text length for a single QQ Bot message. */
 export const TEXT_CHUNK_LIMIT = 5000;
+
+/**
+ * When chunker produces multiple chunks whose total merged size fits within the
+ * safe byte limit, merge them into a single chunk so the receiver sees one
+ * message bubble instead of N independent bubbles.
+ *
+ * Merged chunks are joined by a double-newline to preserve paragraph separation.
+ * If the merged result exceeds `byteLimit`, the original chunks are returned
+ * unchanged.
+ */
+function mergeChunksIfSafe(chunks: string[], byteLimit: number): string[] {
+  if (chunks.length <= 1) {
+    return chunks;
+  }
+  const merged = chunks.join("\n\n");
+  if (Buffer.byteLength(merged, "utf8") <= byteLimit) {
+    return [merged];
+  }
+  return chunks;
+}
 
 interface DeliverEventContext {
   type: "c2c" | "guild" | "dm" | "group";
@@ -198,7 +219,10 @@ async function sendTextChunks(
   deps: DeliverDeps,
 ): Promise<void> {
   const { account, log } = actx;
-  const chunks = deps.chunkText(text, TEXT_CHUNK_LIMIT);
+  const chunks = mergeChunksIfSafe(
+    deps.chunkText(text, TEXT_CHUNK_LIMIT),
+    QQBOT_MARKDOWN_SAFE_CHUNK_BYTE_LIMIT,
+  );
   await sendTextChunksWithRetry({
     account,
     event,
@@ -226,7 +250,10 @@ export async function sendTextOnlyReply(
     return;
   }
   const { account, log } = actx;
-  const chunks = deps.chunkText(safeText, TEXT_CHUNK_LIMIT);
+  const chunks = mergeChunksIfSafe(
+    deps.chunkText(safeText, TEXT_CHUNK_LIMIT),
+    QQBOT_MARKDOWN_SAFE_CHUNK_BYTE_LIMIT,
+  );
   await sendTextChunksWithRetry({
     account,
     event,
@@ -765,7 +792,10 @@ async function sendMarkdownReply(
 
   // Send markdown text.
   if (result.trim()) {
-    const mdChunks = deps.chunkText(result, TEXT_CHUNK_LIMIT);
+    const mdChunks = mergeChunksIfSafe(
+      deps.chunkText(result, TEXT_CHUNK_LIMIT),
+      QQBOT_MARKDOWN_SAFE_CHUNK_BYTE_LIMIT,
+    );
     await sendTextChunksWithRetry({
       account,
       event,
@@ -824,7 +854,10 @@ async function sendPlainTextReply(
     }
 
     if (result.trim()) {
-      const plainChunks = deps.chunkText(result, TEXT_CHUNK_LIMIT);
+      const plainChunks = mergeChunksIfSafe(
+        deps.chunkText(result, TEXT_CHUNK_LIMIT),
+        QQBOT_MARKDOWN_SAFE_CHUNK_BYTE_LIMIT,
+      );
       await sendTextChunksWithRetry({
         account,
         event,

--- a/extensions/qqbot/src/engine/messaging/outbound-deliver.ts
+++ b/extensions/qqbot/src/engine/messaging/outbound-deliver.ts
@@ -219,10 +219,8 @@ async function sendTextChunks(
   deps: DeliverDeps,
 ): Promise<void> {
   const { account, log } = actx;
-  const chunks = mergeChunksIfSafe(
-    deps.chunkText(text, TEXT_CHUNK_LIMIT),
-    QQBOT_MARKDOWN_SAFE_CHUNK_BYTE_LIMIT,
-  );
+  const rawChunks = deps.chunkText(text, TEXT_CHUNK_LIMIT);
+  const chunks = mergeChunksIfSafe(rawChunks, QQBOT_MARKDOWN_SAFE_CHUNK_BYTE_LIMIT);
   await sendTextChunksWithRetry({
     account,
     event,
@@ -231,6 +229,7 @@ async function sendTextChunks(
     consumeQuoteRef,
     allowDm: true,
     log,
+    fallbackChunks: chunks.length < rawChunks.length ? rawChunks : undefined,
     onSuccess: (chunk) =>
       `Sent text chunk (${chunk.length}/${text.length} chars): ${chunk.slice(0, 50)}...`,
     onError: (err) => `Failed to send text chunk: ${formatErrorMessage(err)}`,
@@ -250,10 +249,8 @@ export async function sendTextOnlyReply(
     return;
   }
   const { account, log } = actx;
-  const chunks = mergeChunksIfSafe(
-    deps.chunkText(safeText, TEXT_CHUNK_LIMIT),
-    QQBOT_MARKDOWN_SAFE_CHUNK_BYTE_LIMIT,
-  );
+  const rawChunks = deps.chunkText(safeText, TEXT_CHUNK_LIMIT);
+  const chunks = mergeChunksIfSafe(rawChunks, QQBOT_MARKDOWN_SAFE_CHUNK_BYTE_LIMIT);
   await sendTextChunksWithRetry({
     account,
     event,
@@ -263,6 +260,7 @@ export async function sendTextOnlyReply(
     allowDm: true,
     forcePlainText: true,
     log,
+    fallbackChunks: chunks.length < rawChunks.length ? rawChunks : undefined,
     onSuccess: (chunk) =>
       `Sent text-only chunk (${chunk.length}/${safeText.length} chars): ${chunk.slice(0, 50)}...`,
     onError: (err) => `Failed to send text-only chunk: ${formatErrorMessage(err)}`,
@@ -280,9 +278,25 @@ async function sendTextChunksWithRetry(params: {
   log?: DeliverAccountContext["log"];
   onSuccess: (chunk: string) => string;
   onError: (err: unknown) => string;
+  /**
+   * Original chunks before a merge-gate coalesced them.
+   * When a merged chunk fails, the sender retries with these original
+   * chunks individually so the reply is not lost entirely when QQ
+   * rejects a merged markdown shape.
+   */
+  fallbackChunks?: string[];
 }): Promise<void> {
-  const { account, event, chunks, sendWithRetry, consumeQuoteRef, allowDm, forcePlainText, log } =
-    params;
+  const {
+    account,
+    event,
+    chunks,
+    sendWithRetry,
+    consumeQuoteRef,
+    allowDm,
+    forcePlainText,
+    log,
+    fallbackChunks,
+  } = params;
   for (const chunk of chunks) {
     try {
       await sendWithRetry((token) =>
@@ -298,7 +312,33 @@ async function sendTextChunksWithRetry(params: {
       );
       log?.info(params.onSuccess(chunk));
     } catch (err) {
-      log?.error(params.onError(err));
+      // When a merged chunk fails, retry with the original split chunks
+      // so the reply is not lost entirely.
+      if (fallbackChunks?.length) {
+        log?.info(
+          `Merged chunk send failed; retrying with ${fallbackChunks.length} original chunk(s)`,
+        );
+        for (const fallbackChunk of fallbackChunks) {
+          try {
+            await sendWithRetry((token) =>
+              sendTextChunkToTarget({
+                account,
+                event,
+                token,
+                text: fallbackChunk,
+                consumeQuoteRef,
+                allowDm,
+                forcePlainText,
+              }),
+            );
+            log?.info(params.onSuccess(fallbackChunk));
+          } catch (fbErr) {
+            log?.error(params.onError(fbErr));
+          }
+        }
+      } else {
+        log?.error(params.onError(err));
+      }
     }
   }
 }
@@ -792,10 +832,8 @@ async function sendMarkdownReply(
 
   // Send markdown text.
   if (result.trim()) {
-    const mdChunks = mergeChunksIfSafe(
-      deps.chunkText(result, TEXT_CHUNK_LIMIT),
-      QQBOT_MARKDOWN_SAFE_CHUNK_BYTE_LIMIT,
-    );
+    const rawMdChunks = deps.chunkText(result, TEXT_CHUNK_LIMIT);
+    const mdChunks = mergeChunksIfSafe(rawMdChunks, QQBOT_MARKDOWN_SAFE_CHUNK_BYTE_LIMIT);
     await sendTextChunksWithRetry({
       account,
       event,
@@ -804,6 +842,7 @@ async function sendMarkdownReply(
       consumeQuoteRef,
       allowDm: true,
       log,
+      fallbackChunks: mdChunks.length < rawMdChunks.length ? rawMdChunks : undefined,
       onSuccess: (chunk) =>
         `Sent markdown chunk (${chunk.length}/${result.length} chars) with ${httpImageUrls.length} HTTP images (${event.type})`,
       onError: (err) => `Failed to send markdown message chunk: ${formatErrorMessage(err)}`,
@@ -854,10 +893,8 @@ async function sendPlainTextReply(
     }
 
     if (result.trim()) {
-      const plainChunks = mergeChunksIfSafe(
-        deps.chunkText(result, TEXT_CHUNK_LIMIT),
-        QQBOT_MARKDOWN_SAFE_CHUNK_BYTE_LIMIT,
-      );
+      const rawPlainChunks = deps.chunkText(result, TEXT_CHUNK_LIMIT);
+      const plainChunks = mergeChunksIfSafe(rawPlainChunks, QQBOT_MARKDOWN_SAFE_CHUNK_BYTE_LIMIT);
       await sendTextChunksWithRetry({
         account,
         event,
@@ -866,6 +903,7 @@ async function sendPlainTextReply(
         consumeQuoteRef,
         allowDm: false,
         log,
+        fallbackChunks: plainChunks.length < rawPlainChunks.length ? rawPlainChunks : undefined,
         onSuccess: (chunk) =>
           `Sent text chunk (${chunk.length}/${result.length} chars) (${event.type})`,
         onError: (err) => `Send failed: ${formatErrorMessage(err)}`,

--- a/extensions/qqbot/src/engine/messaging/outbound-deliver.ts
+++ b/extensions/qqbot/src/engine/messaging/outbound-deliver.ts
@@ -6,7 +6,7 @@
  * `DeliverDeps.mediaSender`.
  */
 
-import type { GatewayAccount } from "../types.js";
+import { ApiError, type GatewayAccount } from "../types.js";
 import { formatErrorMessage } from "../utils/format.js";
 import { getImageSize, formatQQBotMarkdownImage, hasQQBotImageSize } from "../utils/image-size.js";
 import { normalizeMediaTags } from "../utils/media-tags.js";
@@ -94,6 +94,19 @@ function mergeChunksIfSafe(chunks: string[], byteLimit: number): string[] {
     return [merged];
   }
   return chunks;
+}
+
+/**
+ * Returns `true` when the error proves QQ received and rejected the request.
+ *
+ * Only 4xx `ApiError` responses are treated as deterministic rejections.
+ * Timeout / network errors (`httpStatus === 0`), 5xx server errors, HTML
+ * gateway errors, and non-`ApiError` throwables are ambiguous — the merged
+ * POST may already have been accepted, so falling back to individual chunks
+ * risks double-delivery.
+ */
+function isDeterministicRejection(err: unknown): err is ApiError {
+  return err instanceof ApiError && err.httpStatus >= 400 && err.httpStatus < 500;
 }
 
 interface DeliverEventContext {
@@ -312,11 +325,14 @@ async function sendTextChunksWithRetry(params: {
       );
       log?.info(params.onSuccess(chunk));
     } catch (err) {
-      // When a merged chunk fails, retry with the original split chunks
-      // so the reply is not lost entirely.
-      if (fallbackChunks?.length) {
+      // When a merged chunk fails with a deterministic QQ rejection (4xx),
+      // retry with the original split chunks so the reply is not lost.
+      // Ambiguous failures (timeout, network error, 5xx, non-ApiError) are
+      // NOT retried because the merged POST may already have been accepted
+      // and falling back would risk double-delivery.
+      if (fallbackChunks?.length && isDeterministicRejection(err)) {
         log?.info(
-          `Merged chunk send failed; retrying with ${fallbackChunks.length} original chunk(s)`,
+          `Merged chunk rejected by QQ (HTTP ${err.httpStatus}); retrying with ${fallbackChunks.length} original chunk(s)`,
         );
         for (const fallbackChunk of fallbackChunks) {
           try {


### PR DESCRIPTION
## What Problem This Solves

When QQBot sends a long Markdown reply, the chunker splits the text at table/fence boundaries into multiple chunks, and each chunk is sent as an independent QQ API POST. This causes a single logical reply to appear as N separate message bubbles, fragmenting the user experience.

The invariant violated: one continuous Markdown reply should render as one message bubble, not multiple independent ones.

Fixes #95526

## Why This Change Was Made

The fix adds a pre-send merge step: after the chunker produces multiple chunks, `mergeChunksIfSafe` checks whether the total merged size fits within the QQ Markdown API safe byte limit (3600 bytes). If it does, the chunks are joined with `\n\n` and sent as a single message. If the merged result exceeds the limit, the original chunks are preserved and sent separately — exactly as before.

- Added `mergeChunksIfSafe(chunks, byteLimit)` — returns `[merged]` when `Buffer.byteLength(merged, "utf8")` ≤ byteLimit, otherwise returns chunks unchanged
- Wrapped chunker output at all 4 send call sites: `sendTextChunks`, `sendTextOnlyReply`, `sendMarkdownReply`, `sendPlainTextReply`
- Exported `QQBOT_MARKDOWN_SAFE_CHUNK_BYTE_LIMIT` (previously a module-private `const`) so the merge helper can reference it
- Added `fallbackChunks` to `sendTextChunksWithRetry` — when a merged chunk fails with a **deterministic QQ rejection** (ApiError with 4xx httpStatus), the original split chunks are retried individually so the reply is not lost. Ambiguous failures — timeouts (httpStatus 0), network errors, 5xx server errors, non-ApiError throwables — are **not** retried because the merged POST may already have been accepted and falling back would risk double-delivery
- Added `isDeterministicRejection(err)` guard — returns true only for `ApiError` with `httpStatus ≥ 400 && < 500`

This approach requires no changes to the chunker itself — only a single merge gate before dispatch — making it minimal and low-risk.

## User Impact

- **Affected**: all QQBot users receiving long Markdown replies (e.g. answers containing tables or code blocks)
- **Before**: one reply split into N bubbles, with each bubble potentially containing only a single sentence or table fragment
- **After**: when the merged text fits within the 3600-byte safe limit, it arrives as one complete bubble

## Evidence

- `pnpm test extensions/qqbot` — **599 tests passed** (70 files)
- `pnpm check:changed` — CI green, all checks passing
- Unit tests (9 tests):
  - Safe-size chunks → merged into single `sendText` call
  - Oversized chunks → fall back to separate sends, **no errors**, each chunk content validated
  - Exact limit boundary → merged (`=== 3600`, still within `≤`)
  - 3+ chunks overflow → all sent separately, no errors
  - Single chunk → passthrough unchanged
  - Merged chunk fails with 4xx ApiError → retries with original chunks individually
  - Merged chunk fails with timeout (httpStatus 0) → **no fallback** (ambiguous delivery)
  - Merged chunk fails with 5xx server error → **no fallback** (ambiguous delivery)
  - Merged chunk fails with generic Error → **no fallback** (unknown delivery state)

### Real behavior proof

Behavior addressed: QQBot chunk merge in real QQ C2C session — safe-size multi-chunk markdown merged into single bubble; oversized merged text falls back to separate sends without errors.

Real environment tested: Linux (TencentOS), Node 24.13.1, branch `fix/issue-95526-merge-qqbot-chunks`, commit `47d926471a`

Exact steps or command run after this patch:

```bash
node scripts/run-node.mjs --dev gateway
# Bot received C2C message, agent generated markdown table/code replies
```

Evidence after fix — chunk merge (gateway stderr):

```
[PROOF] mergeChunksIfSafe: merged 2 chunks → 1 chunk (830 bytes, limit 3600)
[PROOF] mergeChunksIfSafe: merged 4 chunks → 1 chunk (1215 bytes, limit 3600)
[PROOF] mergeChunksIfSafe: merged 3 chunks → 1 chunk (1648 bytes, limit 3600)
[PROOF] mergeChunksIfSafe: merged 5 chunks → 1 chunk (1746 bytes, limit 3600)
```

Evidence after fix — raw QQ API dispatch (one POST per merged reply, 200 OK, delivered message id):

```
[PROOF] QQ API POST → 200 OK | chunk=1/1 size=1230 msg_id=ROBOT1.0_FsLCv722wZ08iO0jNAHNsQTrtYZh8op6z8OLyuWY4Ax24ms0VPiB...
[PROOF] QQ API POST → 200 OK | chunk=1/1 size=1648 msg_id=ROBOT1.0_FsLCv722wZ08iO0jNAHNsRPWQTbmkceYEm3Ed6s-6OjVy7VwDfQvy8DT...
[PROOF] QQ API POST → 200 OK | chunk=1/1 size=1746 msg_id=ROBOT1.0_FsLCv722wZ08iO0jNAHNsapAemvGsHnC3eaQNiz.mLO47ybN.gB.Pac0...
[PROOF] QQ API POST → 200 OK | chunk=1/1 size=943 msg_id=ROBOT1.0_FsLCv722wZ08iO0jNAHNsYJ6KrRrRgL9zYDK0QLU5VsnuZSVd7TSP5WC...
[PROOF] QQ API POST → 200 OK | chunk=1/1 size=531 msg_id=ROBOT1.0_FsLCv722wZ08iO0jNAHNsapxTaGs1R1BXOq-gUB8rD968mVhMwZEaTanF...
```

Key observations from the raw API proof:
- **`chunk=1/1`** on every send — confirms mergeChunksIfSafe collapsed N chunks into exactly one API call each time
- **`200 OK`** — QQ Open Platform accepted and delivered each merged message
- **`msg_id=ROBOT1.0_...`** — each send returned a valid QQ message ID, confirming delivery

Overflow fallback also verified: when merged byte length exceeds the limit, original chunks are returned unchanged and sent separately — no errors, no dropped content.

Observed result after fix: Multi-chunk markdown replies within the 3600-byte safe limit are sent as one QQ API message → one bubble. Overflow falls back to separate sends without errors.

Screenshots:
<img width="432" height="761" alt="image" src="https://github.com/user-attachments/assets/68bb5ca6-cc58-4385-ad66-59dc1139f7f4" />
<img width="434" height="913" alt="image" src="https://github.com/user-attachments/assets/704e38d3-f17b-42dd-93df-f3cb8fcf5c09" />
<img width="430" height="874" alt="image" src="https://github.com/user-attachments/assets/d7050f40-5070-43a5-aca1-91a1f2553700" />

What was not tested: Overflow scenario triggering real QQ API with >3600 bytes (requires a very long agent reply to trigger naturally).

### Review revision (commit `b1c46d9`)

Addressed ClawSweeper [P1] review finding: gated fallback retries to deterministic 4xx QQ rejections only. Ambiguous failures (timeout, network error, 5xx, non-ApiError) no longer trigger fallback because the merged POST may already have been accepted — falling back would risk double-delivery.

- `node scripts/run-vitest.mjs extensions/qqbot/src/engine/messaging/outbound-deliver.test.ts` — 9 passed
- `node scripts/run-vitest.mjs extensions/qqbot/src/engine/messaging/markdown-table-chunking.test.ts` — 22 passed
- oxlint clean, oxfmt clean
