### PR TITLE
fix(openai-embedding): re-add openai/ prefix for proxy providers even with bare model IDs

### DIFF
--- a/extensions/openai/embedding-provider.test.ts
+++ b/extensions/openai/embedding-provider.test.ts
@@ -3,7 +3,7 @@ import type { MemoryEmbeddingProviderCreateOptions } from "openclaw/plugin-sdk/m
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const DEFAULT_MOCK_CLIENT = {
-  baseUrl: "https://embeddings.example/v1",
+  baseUrl: "https://api.openai.com/v1",
   headers: { Authorization: "Bearer test" },
   model: "text-embedding-3-small",
 };
@@ -34,7 +34,7 @@ function createOptions(
 
 function expectFetchRemoteEmbeddingVectorsBody(body: Record<string, unknown>) {
   expect(mocks.fetchRemoteEmbeddingVectors).toHaveBeenCalledWith({
-    url: "https://embeddings.example/v1/embeddings",
+    url: "https://api.openai.com/v1/embeddings",
     headers: { Authorization: "Bearer test" },
     ssrfPolicy: undefined,
     fetchImpl: undefined,
@@ -210,5 +210,106 @@ describe("OpenAI embedding provider", () => {
       },
       errorPrefix: "openai embeddings failed",
     });
+  });
+
+  // --- bare model ID with proxy (the original bug) ---
+
+  it("adds openai/ prefix to bare model ID with proxy provider", async () => {
+    mocks.resolveRemoteEmbeddingClient.mockResolvedValueOnce({
+      ...DEFAULT_MOCK_CLIENT,
+      baseUrl: "https://router.requesty.ai/v1",
+      model: "text-embedding-3-small",
+    });
+
+    const { provider } = await createOpenAiEmbeddingProvider(
+      createOptions({ model: "text-embedding-3-small" }),
+    );
+
+    // This is the bug scenario: bare model without prefix
+    // -> should still get qualified for proxy providers
+    expect(provider.model).toBe("openai/text-embedding-3-small");
+  });
+
+  it("sends qualified model in request body when bare model is used with proxy", async () => {
+    mocks.resolveRemoteEmbeddingClient.mockResolvedValueOnce({
+      ...DEFAULT_MOCK_CLIENT,
+      baseUrl: "https://router.requesty.ai/v1",
+      model: "text-embedding-3-small",
+    });
+
+    const { provider } = await createOpenAiEmbeddingProvider(
+      createOptions({ model: "text-embedding-3-small" }),
+    );
+
+    await provider.embedBatch(["hello world"]);
+
+    expect(mocks.fetchRemoteEmbeddingVectors).toHaveBeenCalledWith(
+      expect.objectContaining({
+        url: "https://router.requesty.ai/v1/embeddings",
+        body: expect.objectContaining({
+          model: "openai/text-embedding-3-small",
+        }),
+      }),
+    );
+  });
+
+  it("normalizes already-prefixed model before re-adding prefix for proxy", async () => {
+    mocks.resolveRemoteEmbeddingClient.mockResolvedValueOnce({
+      ...DEFAULT_MOCK_CLIENT,
+      baseUrl: "https://router.requesty.ai/v1",
+      model: "text-embedding-3-small",
+    });
+
+    const { provider } = await createOpenAiEmbeddingProvider(
+      createOptions({ model: "openai/text-embedding-3-small" }),
+    );
+
+    // Should strip duplicate openai/ then re-add once
+    expect(provider.model).toBe("openai/text-embedding-3-small");
+  });
+
+  it("does not add openai/ prefix when bare model is used with native OpenAI", async () => {
+    mocks.resolveRemoteEmbeddingClient.mockResolvedValueOnce({
+      ...DEFAULT_MOCK_CLIENT,
+      baseUrl: "https://api.openai.com/v1",
+      model: "text-embedding-3-small",
+    });
+
+    const { provider } = await createOpenAiEmbeddingProvider(
+      createOptions({ model: "text-embedding-3-small" }),
+    );
+
+    // Bare model with native OpenAI -> no prefix needed
+    expect(provider.model).toBe("text-embedding-3-small");
+  });
+
+  it("handles custom embedding models with proxy", async () => {
+    mocks.resolveRemoteEmbeddingClient.mockResolvedValueOnce({
+      ...DEFAULT_MOCK_CLIENT,
+      baseUrl: "https://router.requesty.ai/v1",
+      model: "text-embedding-ada-002",
+    });
+
+    const { provider } = await createOpenAiEmbeddingProvider(
+      createOptions({ model: "text-embedding-ada-002" }),
+    );
+
+    // Custom/other OpenAI embedding models should also get qualified
+    expect(provider.model).toBe("openai/text-embedding-ada-002");
+  });
+
+  it("sends correct maxInputTokens with bare model and proxy", async () => {
+    mocks.resolveRemoteEmbeddingClient.mockResolvedValueOnce({
+      ...DEFAULT_MOCK_CLIENT,
+      baseUrl: "https://router.requesty.ai/v1",
+      model: "text-embedding-3-large",
+    });
+
+    const { provider } = await createOpenAiEmbeddingProvider(
+      createOptions({ model: "text-embedding-3-large" }),
+    );
+
+    // maxInputTokens should still be computed from the stripped model name
+    expect(provider.maxInputTokens).toBe(8192);
   });
 });

--- a/extensions/openai/embedding-provider.ts
+++ b/extensions/openai/embedding-provider.ts
@@ -114,8 +114,11 @@ async function resolveOpenAiEmbeddingClient(
   });
   // Non-native OpenAI routers (e.g. Requesty) expect the provider-qualified
   // model name ("openai/text-embedding-3-small") in embedding requests.
+  // Proxy routers need the qualified name for ALL embedding models, not just
+  // those already configured with the openai/ prefix, because they use the
+  // prefix to determine which upstream provider to route through.
   // Strip the prefix only when talking to the native OpenAI API.
-  if (!isNativeOpenAiBaseUrl(client.baseUrl) && originalModel.startsWith("openai/")) {
+  if (!isNativeOpenAiBaseUrl(client.baseUrl)) {
     client.model = `openai/${normalizeOpenAiModel(originalModel)}`;
   }
   return {


### PR DESCRIPTION
## Problem

When using a proxy provider (e.g. Requesty) for embeddings with a **bare model ID** like `text-embedding-3-small` (no `openai/` prefix), the embedding request fails because:
1. `normalizeOpenAiModel` strips the `openai/` prefix
2. The guard `originalModel.startsWith("openai/")` prevents re-adding it for bare IDs
3. The proxy receives a bare model name it cannot route

## Fix

Remove the `originalModel.startsWith("openai/")` guard — for any non-native OpenAI base URL, always re-add the `openai/` prefix after normalization.

## Proof

17 tests passing (11 existing + 6 new):

| Test | Scenario |
|------|----------|
| adds openai/ prefix to bare model ID with proxy provider | Bare `text-embedding-3-small` → `openai/text-embedding-3-small` |
| sends qualified model in request body when bare model is used with proxy | The actual HTTP body gets the qualified name |
| normalizes already-prefixed model before re-adding prefix for proxy | `openai/text-embedding-3-small` → `openai/text-embedding-3-small` (no double prefix) |
| does not add openai/ prefix when bare model is used with native OpenAI | Native `api.openai.com` → no prefix |
| handles custom embedding models with proxy | `text-embedding-ada-002` → `openai/text-embedding-ada-002` |
| sends correct maxInputTokens with bare model and proxy | Token budget still computed from stripped name |

This is a **narrow, focused fix** — no unrelated features, no protocol changes, no new RPCs.