### PR TITLE
refactor: simplify nullish checks in CLI and config helpers

### DIFF
--- a/src/cli/gateway-port-option.ts
+++ b/src/cli/gateway-port-option.ts
@@ -4,7 +4,7 @@ import { parseStrictPositiveInteger } from "../infra/parse-finite-number.js";
 const MAX_TCP_PORT = 65_535;
 
 export function parseGatewayPortOption(raw: unknown, flagName = "--port"): number | undefined {
-  if (raw === undefined || raw === null) {
+  if (raw == null) {
     return undefined;
   }
 

--- a/src/cli/nodes-cli/register.status.ts
+++ b/src/cli/nodes-cli/register.status.ts
@@ -147,7 +147,7 @@ function formatPendingApprovalCommand(raw: unknown, opts: NodesRpcOpts): string 
 }
 
 function parseSinceMs(raw: unknown, label: string): number | undefined {
-  if (raw === undefined || raw === null) {
+  if (raw == null) {
     return undefined;
   }
   const value = normalizeOptionalString(raw) ?? (typeof raw === "number" ? String(raw) : null);

--- a/src/cli/parse-timeout.ts
+++ b/src/cli/parse-timeout.ts
@@ -3,7 +3,7 @@ import { parseStrictPositiveInteger } from "../infra/parse-finite-number.js";
 
 /** Parse a positive millisecond timeout, returning undefined for absent or invalid input. */
 export function parseTimeoutMs(raw: unknown): number | undefined {
-  if (raw === undefined || raw === null) {
+  if (raw == null) {
     return undefined;
   }
   let value = Number.NaN;
@@ -36,7 +36,7 @@ export function parseTimeoutMsWithFallback(
     invalidType?: "fallback" | "error";
   } = {},
 ): number {
-  if (raw === undefined || raw === null) {
+  if (raw == null) {
     return fallbackMs;
   }
 

--- a/src/cli/webhooks-cli.ts
+++ b/src/cli/webhooks-cli.ts
@@ -178,7 +178,7 @@ function gmailOptionsFromCommon(
 }
 
 function numberOption(value: unknown, label: string): number | undefined {
-  if (value === undefined || value === null) {
+  if (value == null) {
     return undefined;
   }
   const n = parseStrictPositiveInteger(value);
@@ -189,7 +189,7 @@ function numberOption(value: unknown, label: string): number | undefined {
 }
 
 function booleanOption(value: unknown): boolean | undefined {
-  if (value === undefined || value === null) {
+  if (value == null) {
     return undefined;
   }
   return Boolean(value);

--- a/src/infra/tcp-port.ts
+++ b/src/infra/tcp-port.ts
@@ -6,7 +6,7 @@ export const MAX_TCP_PORT = 65_535;
 
 /** Parse a positive TCP port or return null for absent/invalid input. */
 export function parseTcpPort(raw: unknown): number | null {
-  if (raw === undefined || raw === null) {
+  if (raw == null) {
     return null;
   }
   const parsed = parseStrictPositiveInteger(raw);

--- a/src/utils/reaction-level.ts
+++ b/src/utils/reaction-level.ts
@@ -22,7 +22,7 @@ const LEVELS = new Set<ReactionLevel>(["off", "ack", "minimal", "extensive"]);
 function parseLevel(
   value: unknown,
 ): { kind: "missing" } | { kind: "invalid" } | { kind: "ok"; value: ReactionLevel } {
-  if (value === undefined || value === null) {
+  if (value == null) {
     return { kind: "missing" };
   }
   if (typeof value !== "string") {

--- a/src/wizard/setup.plugin-config.ts
+++ b/src/wizard/setup.plugin-config.ts
@@ -68,7 +68,7 @@ function toPathSegments(fieldKey: string): string[] {
 }
 
 function formatCurrentValue(value: unknown): string {
-  if (value === undefined || value === null) {
+  if (value == null) {
     return "";
   }
   if (typeof value === "string") {
@@ -140,7 +140,7 @@ export function discoverUnconfiguredPlugins(params: {
     const existing = getExistingPluginConfig(params.config, plugin.id);
     return Object.keys(plugin.uiHints).some((key) => {
       const val = getPath(existing, toPathSegments(key));
-      return val === undefined || val === null || val === "";
+      return val == null || val === "";
     });
   });
 }


### PR DESCRIPTION
## What Problem This Solves

Reduces unnecessary verbosity in nullish checks across CLI argument parsers and config helpers. `x === undefined || x === null` is functionally identical to `x == null` but twice the length. The shorter form is the idiomatic JavaScript pattern for checking both null and undefined.

## Why This Change Was Made

These checks appear in CLI input parsing hot paths (`parseGatewayPortOption`, `parseTimeoutMs`, `parseTcpPort`, etc.) where brevity matters for readability. The codebase already uses `== null` in many places (e.g., `src/plugin-state/plugin-state-store.ts:81`, `src/infra/delivery-queue-sqlite.ts:72`), so this change improves consistency.

## User Impact

None. Zero behavioral change — the comparisons evaluate identically.

## Evidence

All affected test files pass:

```
$ pnpm test -- src/cli/gateway-port-option.test.ts
 Test Files  1 passed (1)
      Tests  6 passed (6)

$ pnpm test -- src/cli/parse-timeout.test.ts
 Test Files  1 passed (1)
      Tests  10 passed (10)

$ pnpm test -- src/cli/webhooks-cli.test.ts
 Test Files  1 passed (1)
      Tests  6 passed (6)

$ pnpm test -- src/infra/tcp-port.test.ts
 Test Files  1 passed (1)
      Tests  2 passed (2)

$ pnpm test -- src/utils/reaction-level.test.ts
 Test Files  1 passed (1)
      Tests  5 passed (5)

$ pnpm test -- src/wizard/setup.plugin-config.test.ts
 Test Files  1 passed (1)
      Tests  13 passed (13)
```