### PR TITLE
fix(macos): stop runtime config-health sidecar access

### DIFF
--- a/apps/macos/Sources/OpenClaw/OpenClawConfigFile.swift
+++ b/apps/macos/Sources/OpenClaw/OpenClawConfigFile.swift
@@ -5,8 +5,8 @@ import OpenClawProtocol
 enum OpenClawConfigFile {
     private static let logger = Logger(subsystem: "ai.openclaw", category: "config")
     private static let configAuditFileName = "config-audit.jsonl"
-    private static let configHealthFileName = "config-health.json"
     private static let fileLock = NSRecursiveLock()
+    private nonisolated(unsafe) static var configHealthState: [String: Any] = [:]
 
     private static func withFileLock<T>(_ body: () throws -> T) rethrows -> T {
         self.fileLock.lock()
@@ -477,39 +477,6 @@ enum OpenClawConfigFile {
             .appendingPathComponent(self.configAuditFileName, isDirectory: false)
     }
 
-    private static func configHealthStateURL() -> URL {
-        self.stateDirURL()
-            .appendingPathComponent("logs", isDirectory: true)
-            .appendingPathComponent(self.configHealthFileName, isDirectory: false)
-    }
-
-    private static func readConfigHealthState() -> [String: Any] {
-        let url = self.configHealthStateURL()
-        guard let data = try? Data(contentsOf: url),
-              let root = try? JSONSerialization.jsonObject(with: data) as? [String: Any]
-        else {
-            return [:]
-        }
-        return root
-    }
-
-    private static func writeConfigHealthState(_ root: [String: Any]) {
-        guard JSONSerialization.isValidJSONObject(root),
-              let data = try? JSONSerialization.data(withJSONObject: root, options: [.prettyPrinted, .sortedKeys])
-        else {
-            return
-        }
-        let url = self.configHealthStateURL()
-        do {
-            try FileManager().createDirectory(
-                at: url.deletingLastPathComponent(),
-                withIntermediateDirectories: true)
-            try data.write(to: url, options: [.atomic])
-        } catch {
-            // best-effort
-        }
-    }
-
     private static func configHealthEntry(state: [String: Any], configPath: String) -> [String: Any] {
         let entries = state["entries"] as? [String: Any]
         return entries?[configPath] as? [String: Any] ?? [:]
@@ -672,7 +639,7 @@ enum OpenClawConfigFile {
     private static func observeConfigRead(data: Data, root: [String: Any]?, configURL: URL, valid: Bool) {
         let observedAt = ISO8601DateFormatter().string(from: Date())
         let current = self.configFingerprint(data: data, root: root, configURL: configURL, observedAt: observedAt)
-        var state = self.readConfigHealthState()
+        var state = self.configHealthState
         let entry = self.configHealthEntry(state: state, configPath: configURL.path)
         let lastKnownGood = entry["lastKnownGood"] as? [String: Any]
         let suspicious = self.observeSuspiciousReasons(
@@ -688,7 +655,7 @@ enum OpenClawConfigFile {
             ]
             if !self.sameFingerprint(lastKnownGood, current) || entry["lastObservedSuspiciousSignature"] != nil {
                 state = self.setConfigHealthEntry(state: state, configPath: configURL.path, entry: nextEntry)
-                self.writeConfigHealthState(state)
+                self.configHealthState = state
             }
             return
         }
@@ -750,7 +717,7 @@ enum OpenClawConfigFile {
         var nextEntry = entry
         nextEntry["lastObservedSuspiciousSignature"] = signature
         state = self.setConfigHealthEntry(state: state, configPath: configURL.path, entry: nextEntry)
-        self.writeConfigHealthState(state)
+        self.configHealthState = state
     }
 
     private static func appendConfigWriteAudit(_ fields: [String: Any]) {

--- a/apps/macos/Tests/OpenClawIPCTests/OpenClawConfigFileTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/OpenClawConfigFileTests.swift
@@ -268,11 +268,64 @@ struct OpenClawConfigFileTests {
 
     @MainActor
     @Test
+    func `load dict ignores legacy config health sidecar`() async throws {
+        let stateDir = FileManager().temporaryDirectory
+            .appendingPathComponent("openclaw-state-\(UUID().uuidString)", isDirectory: true)
+        let configPath = stateDir.appendingPathComponent("openclaw.json")
+        let auditPath = stateDir.appendingPathComponent("logs/config-audit.jsonl")
+        let configHealthPath = stateDir.appendingPathComponent("logs/config-health.json")
+
+        defer { try? FileManager().removeItem(at: stateDir) }
+
+        try FileManager().createDirectory(
+            at: configHealthPath.deletingLastPathComponent(),
+            withIntermediateDirectories: true)
+        let legacyHealth = """
+        {
+          "entries": {
+            "\(configPath.path)": {
+              "lastKnownGood": {
+                "bytes": 4096,
+                "gatewayMode": "local",
+                "hasMeta": true
+              }
+            }
+          }
+        }
+        """
+        try legacyHealth.write(to: configHealthPath, atomically: true, encoding: .utf8)
+        let updateOnlyConfig = """
+        {
+          "update": {
+            "channel": "beta"
+          }
+        }
+        """
+        try updateOnlyConfig.write(to: configPath, atomically: true, encoding: .utf8)
+
+        try await TestIsolation.withEnvValues([
+            "OPENCLAW_STATE_DIR": stateDir.path,
+            "OPENCLAW_CONFIG_PATH": configPath.path,
+        ]) {
+            try OpenClawConfigFile.withTestingFileLock {
+                let loaded = OpenClawConfigFile.loadDict()
+                let update = loaded["update"] as? [String: Any]
+                #expect(update?["channel"] as? String == "beta")
+                #expect(!FileManager().fileExists(atPath: auditPath.path))
+                let persistedHealth = try String(contentsOf: configHealthPath, encoding: .utf8)
+                #expect(persistedHealth == legacyHealth)
+            }
+        }
+    }
+
+    @MainActor
+    @Test
     func `load dict audits suspicious out-of-band clobbers`() async throws {
         let stateDir = FileManager().temporaryDirectory
             .appendingPathComponent("openclaw-state-\(UUID().uuidString)", isDirectory: true)
         let configPath = stateDir.appendingPathComponent("openclaw.json")
         let auditPath = stateDir.appendingPathComponent("logs/config-audit.jsonl")
+        let configHealthPath = stateDir.appendingPathComponent("logs/config-health.json")
 
         defer { try? FileManager().removeItem(at: stateDir) }
 
@@ -293,6 +346,7 @@ struct OpenClawConfigFileTests {
                     ],
                 ])
                 _ = OpenClawConfigFile.loadDict()
+                #expect(!FileManager().fileExists(atPath: configHealthPath.path))
 
                 let clobbered = """
                 {
@@ -305,6 +359,7 @@ struct OpenClawConfigFileTests {
 
                 let loaded = OpenClawConfigFile.loadDict()
                 #expect((loaded["gateway"] as? [String: Any]) == nil)
+                #expect(!FileManager().fileExists(atPath: configHealthPath.path))
 
                 let rawAudit = try String(contentsOf: auditPath, encoding: .utf8)
                 let lines = rawAudit


### PR DESCRIPTION
Closes #98917
Supersedes #98928

## What Problem This Solves

Fixes an issue where users running the macOS app alongside the CLI/gateway would see recurring legacy state migration warnings because the app kept recreating `~/.openclaw/logs/config-health.json` after Node core moved config-health state to the shared SQLite `config_health_entries` table.

The existing #98928 PR stops the legacy writer, but keeps a runtime fallback reader for the retired sidecar. This PR supersedes it by removing both the steady-state read and write paths from the macOS runtime, matching the database-first contract that legacy JSON state is only a doctor/migration input.

## Why This Change Was Made

The macOS app now keeps its config observation baseline in process-local memory instead of reading or writing `logs/config-health.json`. That preserves in-session suspicious-read detection while letting `openclaw doctor --fix` own legacy JSON import/archive and preventing the app from recreating or depending on the retired sidecar.

Regression coverage now verifies both sides of the boundary: existing legacy sidecars are ignored by `loadDict()`, and normal plus suspicious config reads do not create `logs/config-health.json`.

## User Impact

Mac app users should no longer get repeated `[state-migrations]` config-health conflict warnings on every CLI command or gateway bootstrap. Once doctor archives an existing legacy sidecar, the macOS app will not recreate it.

The only behavior intentionally lost is cross-session macOS-only config health baseline persistence; canonical config health state belongs to Node core's shared SQLite store.

## Evidence

- `git diff --check origin/main...HEAD` passed.
- `node scripts/run-vitest.mjs src/infra/state-migrations.test.ts` passed: 1 file, 38 tests.
- GitHub CI passed `macos-swift` and `macos-node` on PR head `8cbc4e10d3b88bdd3f99f987c06d351e62a3c2d5`.
- `codex review --base origin/main` reported no actionable correctness findings.
- `rg -n "configHealthFileName|configHealthStateURL|readConfigHealthState|writeConfigHealthState|config-health\\.json" apps/macos/Sources/OpenClaw/OpenClawConfigFile.swift apps/macos/Tests/OpenClawIPCTests/OpenClawConfigFileTests.swift src/infra/state-migrations.ts` now finds the legacy path only in migration code and regression tests.
- macOS before/after source-runtime smoke: compiled a temporary Swift harness around the actual `OpenClawConfigFile.swift` implementation from `origin/main` and from PR head, using real macOS filesystem state under a temp `OPENCLAW_STATE_DIR`. The harness ran `saveDict()`, deleted `logs/config-health.json` if present, then ran `loadDict()` twice. This reproduces the old sidecar recreation loop and shows the PR stops it:

```text
RESULT variant=main afterSave=true afterDelete=false afterLoad1=true afterLoad2=true sidecarBytes=681
RESULT variant=pr-head afterSave=false afterDelete=false afterLoad1=false afterLoad2=false sidecarBytes=0
```

This is not a full GUI smoke, but it exercises the same macOS config file reader/writer path that the app calls (`OpenClawConfigFile.loadDict` / `observeConfigRead`) and proves the retired sidecar is no longer recreated after deletion.

- Attempted `swift test --filter OpenClawConfigFileTests` in `apps/macos`; it is blocked locally before the touched tests run because this machine only has Command Line Tools, not full Xcode. The compile failure is `ChatView+Previews.swift` failing to resolve `PreviewsMacros.SwiftUIView` for `#Preview`, and `xcodebuild -version` reports the active developer directory is `/Library/Developer/CommandLineTools`. GitHub's `macos-swift` CI lane does have the required Xcode environment and passed.

- [x] AI-assisted (Codex)

