### PR TITLE
fix(codex): keep mirrored tool results out of inline transcript updates

### DIFF
--- a/extensions/codex/src/app-server/transcript-mirror.test.ts
+++ b/extensions/codex/src/app-server/transcript-mirror.test.ts
@@ -749,6 +749,48 @@ describe("mirrorCodexAppServerTranscript", () => {
     });
   });
 
+  it("keeps failed bash tool output out of source-chat inline updates", async () => {
+    const target = await createSqliteMirrorTarget("openclaw-codex-mirror-bash-failure-");
+    const toolResultMessage = attachCodexMirrorIdentity(
+      castAgentMessage({
+        role: "toolResult",
+        toolCallId: "call-headless-check",
+        toolName: "bash",
+        isError: true,
+        content: [
+          {
+            type: "toolResult",
+            toolCallId: "call-headless-check",
+            toolName: "bash",
+            content:
+              "Bash failed: jq -e '.browser.headless == true' ~/.openclaw/openclaw.json && diff -u before after",
+          },
+        ],
+        timestamp: Date.now(),
+      }),
+      "turn-1:tool:call-headless-check:result",
+    ) as MirroredAgentMessage;
+
+    await mirrorCodexAppServerTranscript({
+      ...target,
+      messages: [toolResultMessage],
+      idempotencyScope: "codex-app-server:thread-1",
+    });
+
+    const raw = await readMirrorRaw(target);
+    expect(raw).toContain('"role":"toolResult"');
+    expect(raw).toContain("Bash failed: jq -e");
+
+    const updates = publishSessionTranscriptUpdateByIdentityMock.mock.calls.map(
+      ([update]) => update as Record<string, unknown> & { update?: Record<string, unknown> },
+    );
+    expect(updates).toHaveLength(1);
+    expect(updates[0]?.update?.message).toBeUndefined();
+    expect(updates[0]?.update?.messageId).toEqual(expect.any(String));
+    expect(updates[0]?.update?.messageSeq).toBe(1);
+    expect(JSON.stringify(updates)).not.toContain("Bash failed: jq -e");
+  });
+
   it("emits stable sequence numbers for multi-message mirror batches", async () => {
     const target = await createSqliteMirrorTarget("openclaw-codex-mirror-seq-");
 
@@ -763,9 +805,26 @@ describe("mirrorCodexAppServerTranscript", () => {
           "turn-1:prompt",
         ),
         attachCodexMirrorIdentity(
+          castAgentMessage({
+            role: "toolResult",
+            toolCallId: "call-headless-check",
+            toolName: "bash",
+            content: [
+              {
+                type: "toolResult",
+                toolCallId: "call-headless-check",
+                toolName: "bash",
+                content: "private tool output",
+              },
+            ],
+            timestamp: Date.now() + 1,
+          }),
+          "turn-1:tool:call-headless-check:result",
+        ),
+        attachCodexMirrorIdentity(
           makeAgentAssistantMessage({
             content: [{ type: "text", text: "second" }],
-            timestamp: Date.now() + 1,
+            timestamp: Date.now() + 2,
           }),
           "turn-1:assistant",
         ),
@@ -776,13 +835,14 @@ describe("mirrorCodexAppServerTranscript", () => {
     const updates = publishSessionTranscriptUpdateByIdentityMock.mock.calls.map(
       ([update]) => update as Record<string, unknown> & { update?: Record<string, unknown> },
     );
-    expect(updates.map((update) => update.update?.messageSeq)).toEqual([1, 2]);
+    expect(updates.map((update) => update.update?.messageSeq)).toEqual([1, 2, 3]);
     expect(
       updates.map((update) => {
         const message = update.update?.message as { role?: string } | undefined;
         return message?.role;
       }),
-    ).toEqual(["user", "assistant"]);
+    ).toEqual(["user", undefined, "assistant"]);
+    expect(JSON.stringify(updates)).not.toContain("private tool output");
   });
 
   it("keeps assistant ownership when live update publication fails", async () => {

--- a/extensions/codex/src/app-server/transcript-mirror.ts
+++ b/extensions/codex/src/app-server/transcript-mirror.ts
@@ -700,9 +700,7 @@ export async function mirrorCodexAppServerTranscript(params: {
         ...transcriptTarget,
         update: {
           ...(params.agentId ? { agentId: params.agentId } : {}),
-          message: update.message,
-          messageId: update.messageId,
-          messageSeq: update.messageSeq,
+          ...buildMirrorTranscriptPublishedUpdate(update),
           sessionKey: transcriptTarget.sessionKey,
         },
       });
@@ -716,6 +714,30 @@ export async function mirrorCodexAppServerTranscript(params: {
   }
 
   return { assistantMirrorIdentitiesOwned, userMessagesPresent };
+}
+
+function buildMirrorTranscriptPublishedUpdate(update: {
+  messageId: string;
+  message: AgentMessage;
+  messageSeq: number;
+}): {
+  message?: AgentMessage;
+  messageId: string;
+  messageSeq: number;
+} {
+  // Tool results belong in the durable transcript, but live inline updates
+  // are consumed by source-chat delivery paths and must contain only messages
+  // intended for the user. Preserve the sequence-only update so consumers can
+  // still observe that the transcript advanced without receiving tool output.
+  return {
+    ...(isInlineMirrorTranscriptUpdateMessage(update.message) ? { message: update.message } : {}),
+    messageId: update.messageId,
+    messageSeq: update.messageSeq,
+  };
+}
+
+function isInlineMirrorTranscriptUpdateMessage(message: AgentMessage): boolean {
+  return message.role === "user" || message.role === "assistant";
 }
 
 function resolveCodexMirrorTranscriptTarget(params: {


### PR DESCRIPTION
## What Problem This Solves

An internal Codex app-server tool result can be mirrored into an OpenClaw session transcript as a `toolResult` message. That durable record is useful for context, debugging, and replay, but the mirror path also published the same `toolResult` as an inline transcript-update `message`.

Live-update and source-chat delivery consumers treat inline transcript-update messages as displayable. A failed command result could therefore appear as a standalone source-chat message after an otherwise successful assistant response.

## Implementation

This change keeps `toolResult` records in the durable transcript while publishing them as sequence-only live updates:

- `user` and `assistant` records retain `update.message`;
- `toolResult` records retain `messageId` and `messageSeq`, but omit `update.message`;
- consumers can still observe transcript advancement and refresh durable state without receiving raw tool output as displayable content.

Focused regressions verify that a failed Bash result is persisted but not emitted inline, and that mixed user/tool-result/assistant batches preserve stable sequence numbers.

## Fresh Reimplementation

This refresh was not a mechanical rebase of the old implementation. The publication boundary and regressions were reimplemented from scratch on:

- current `main` at `ef13c2fe98fcca56da0948eabf1ac19128501a71`;
- installed `v2026.7.1-beta.5` at `b6387af` for runtime validation.

## Evidence

### Current main

- focused transcript-mirror suite: 26/26 passed;
- `pnpm tsgo:extensions`: passed;
- formatting, Oxlint, and `git diff --check`: passed;
- full `pnpm build`: passed;
- stale-head CI failures retested on current main: 7/7 and 139/139 passed.

### Installed beta.5

- focused transcript-mirror suite: 20/20 passed;
- beta.5 full build: passed;
- patched bundle loaded by the live gateway, which continued to report `OpenClaw 2026.7.1-beta.5 (b6387af)`.

### Live Matrix regression

The original user-visible failure was recreated against the live beta.5 gateway. The browser setting was first staged absent, then successfully restored to `browser.headless: true`. This exact verification command was invoked without accepting the expected `diff` exit code 1:

```sh
jq -e '.browser.headless == true' /Users/[REDACTED]/.openclaw/openclaw.json && diff -u <(jq '.browser' /Users/[REDACTED]/.openclaw/backups/pr99042-live-validation-20260712-062129/openclaw.json.headless-absent-test) <(jq '.browser' /Users/[REDACTED]/.openclaw/openclaw.json)
```

The trajectory recorded `status: failed`, `isError: true`, and exit code 1 while the intended headless configuration remained active. Matrix readback showed no standalone `Bash failed` or tool-result message.

Post-turn Matrix audit: **PASSED** at `2026-07-12T03:58Z`. The expected final reply was Matrix event `$oHhexSCRmWR1jlT4tKzUq8xYll1qqTrb0KQYYoKYRe8`; no standalone [REDACTED] message containing `Bash failed`, `toolResult`, or `tool result` appeared after the failed tool event. The trajectory still records `status: failed`, `isError: true`, and exit code 1, while `browser.headless` remains `true`.

## Risk

Low-to-medium. The change affects only the live publication shape of Codex app-server mirrored tool-result records. Durable transcript persistence, message sequencing, user/assistant publication, dedupe behavior, and explicit message-tool delivery remain unchanged.

## Non-Goals

- Do not remove tool results from session transcripts.
- Do not suppress user or assistant mirror updates.
- Do not change explicit delivery initiated through messaging tools.
