### PR TITLE
fix(discord): preserve text on oversized media replies

### DIFF
--- a/extensions/discord/src/outbound-adapter.test.ts
+++ b/extensions/discord/src/outbound-adapter.test.ts
@@ -466,6 +466,74 @@ describe("discordOutbound", () => {
     expect(mediaOptions.mediaUrl).toBe("/tmp/render.mp4");
   });
 
+  it("sends text fallback and reports partial failure when Discord rejects oversized media", async () => {
+    const tooLarge = Object.assign(new Error("Request entity too large"), { status: 413 });
+    hoisted.sendMessageDiscordMock
+      .mockRejectedValueOnce(tooLarge)
+      .mockResolvedValueOnce({ messageId: "fallback-text-1", channelId: "ch-1" });
+
+    await expect(
+      discordOutbound.sendMedia?.({
+        cfg: {},
+        to: "channel:123456",
+        text: "song ready",
+        mediaUrl: "media://local/song.mp3",
+        accountId: "default",
+        replyToId: "reply-1",
+      }),
+    ).rejects.toMatchObject({
+      name: "Error",
+      message: "Request entity too large",
+      sentBeforeError: true,
+      results: [{ channel: "discord", messageId: "fallback-text-1", channelId: "ch-1" }],
+    });
+
+    const mediaCall = mockCall(hoisted.sendMessageDiscordMock, "sendMessageDiscord", 0);
+    expect(mediaCall[0]).toBe("channel:123456");
+    expect(mediaCall[1]).toBe("song ready");
+    expect(mockObjectArg(hoisted.sendMessageDiscordMock, "sendMessageDiscord", 0, 2)).toMatchObject(
+      {
+        accountId: "default",
+        mediaUrl: "media://local/song.mp3",
+        replyTo: "reply-1",
+      },
+    );
+
+    const fallbackCall = mockCall(hoisted.sendMessageDiscordMock, "sendMessageDiscord", 1);
+    expect(fallbackCall[0]).toBe("channel:123456");
+    expect(fallbackCall[1]).toBe("song ready");
+    const fallbackOptions = mockObjectArg(
+      hoisted.sendMessageDiscordMock,
+      "sendMessageDiscord",
+      1,
+      2,
+    );
+    expect(fallbackOptions.accountId).toBe("default");
+    expect(fallbackOptions.replyTo).toBe("reply-1");
+    expect(fallbackOptions.mediaUrl).toBeUndefined();
+  });
+
+  it("does not send duplicate fallback text when the media error already has send evidence", async () => {
+    const tooLarge = Object.assign(new Error("Request entity too large"), {
+      status: 413,
+      sentBeforeError: true,
+      results: [{ channel: "discord", messageId: "starter-1", channelId: "thread-1" }],
+    });
+    hoisted.sendMessageDiscordMock.mockRejectedValueOnce(tooLarge);
+
+    await expect(
+      discordOutbound.sendMedia?.({
+        cfg: {},
+        to: "channel:forum-1",
+        text: "song ready",
+        mediaUrl: "media://local/song.mp3",
+        accountId: "default",
+      }),
+    ).rejects.toBe(tooLarge);
+
+    expect(hoisted.sendMessageDiscordMock).toHaveBeenCalledTimes(1);
+  });
+
   it("touches bound thread activity after shared outbound delivery succeeds", async () => {
     const touchThread = vi.fn();
     hoisted.getThreadBindingManagerMock.mockReturnValue({

--- a/extensions/discord/src/outbound-adapter.ts
+++ b/extensions/discord/src/outbound-adapter.ts
@@ -5,6 +5,7 @@ import {
   type ChannelOutboundAdapter,
   createAttachedChannelResultAdapter,
 } from "openclaw/plugin-sdk/channel-send-result";
+import type { OutboundDeliveryResult } from "openclaw/plugin-sdk/channel-send-result";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import {
   normalizeOptionalString,
@@ -28,6 +29,7 @@ import {
 } from "./outbound-send-context.js";
 
 export const DISCORD_TEXT_CHUNK_LIMIT = 2000;
+const DISCORD_REQUEST_ENTITY_TOO_LARGE_STATUS = 413;
 const DISCORD_INTERNAL_RUNTIME_SCAFFOLDING_BLOCK_RE =
   /<\s*(system-reminder|previous_response)\b[^>]*>[\s\S]*?<\s*\/\s*\1\s*>/gi;
 const DISCORD_INTERNAL_RUNTIME_SCAFFOLDING_SELF_CLOSING_RE =
@@ -40,6 +42,54 @@ function stripDiscordInternalRuntimeScaffolding(text: string): string {
     .replace(DISCORD_INTERNAL_RUNTIME_SCAFFOLDING_BLOCK_RE, "")
     .replace(DISCORD_INTERNAL_RUNTIME_SCAFFOLDING_SELF_CLOSING_RE, "")
     .replace(DISCORD_INTERNAL_RUNTIME_SCAFFOLDING_TAG_RE, "");
+}
+
+function getErrorStatus(error: unknown): number | undefined {
+  if (!error || typeof error !== "object") {
+    return undefined;
+  }
+  const candidate =
+    "status" in error && error.status !== undefined
+      ? error.status
+      : "statusCode" in error && error.statusCode !== undefined
+        ? error.statusCode
+        : undefined;
+  if (typeof candidate === "number" && Number.isFinite(candidate)) {
+    return candidate;
+  }
+  if (typeof candidate === "string" && /^\d+$/.test(candidate)) {
+    return Number(candidate);
+  }
+  return undefined;
+}
+
+function isDiscordRequestEntityTooLarge(error: unknown): boolean {
+  return getErrorStatus(error) === DISCORD_REQUEST_ENTITY_TOO_LARGE_STATUS;
+}
+
+function hasSentBeforeError(error: unknown): boolean {
+  return Boolean(
+    error &&
+    typeof error === "object" &&
+    (error as { sentBeforeError?: unknown }).sentBeforeError === true,
+  );
+}
+
+function createDiscordPartialDeliveryError(params: {
+  cause: unknown;
+  results: readonly OutboundDeliveryResult[];
+}): unknown {
+  if (params.cause && typeof params.cause === "object" && Object.isExtensible(params.cause)) {
+    return Object.assign(params.cause, {
+      results: [...params.results],
+      sentBeforeError: true,
+    });
+  }
+  return Object.assign(new Error("discord media delivery failed after text fallback"), {
+    cause: params.cause,
+    results: [...params.results],
+    sentBeforeError: true,
+  });
 }
 
 type DiscordThreadBindingsModule = typeof import("./monitor/thread-bindings.js");
@@ -277,23 +327,51 @@ export const discordOutbound: ChannelOutboundAdapter = {
             }),
         });
       }
-      return await withDiscordDeliveryRetry({
-        cfg,
-        accountId,
-        fn: async () =>
-          await send(target, text, {
-            verbose: false,
-            mediaUrl,
-            mediaAccess,
-            mediaLocalRoots,
-            mediaReadFile,
-            replyTo: replyToId ?? undefined,
-            accountId: accountId ?? undefined,
-            silent: silent ?? undefined,
-            cfg,
-            ...formattingOptions,
-          }),
-      });
+      try {
+        return await withDiscordDeliveryRetry({
+          cfg,
+          accountId,
+          fn: async () =>
+            await send(target, text, {
+              verbose: false,
+              mediaUrl,
+              mediaAccess,
+              mediaLocalRoots,
+              mediaReadFile,
+              replyTo: replyToId ?? undefined,
+              accountId: accountId ?? undefined,
+              silent: silent ?? undefined,
+              cfg,
+              ...formattingOptions,
+            }),
+        });
+      } catch (error) {
+        if (!text.trim() || hasSentBeforeError(error) || !isDiscordRequestEntityTooLarge(error)) {
+          throw error;
+        }
+        const fallbackResult = await withDiscordDeliveryRetry({
+          cfg,
+          accountId,
+          fn: async () =>
+            await send(target, text, {
+              verbose: false,
+              replyTo: replyToId ?? undefined,
+              accountId: accountId ?? undefined,
+              silent: silent ?? undefined,
+              cfg,
+              ...formattingOptions,
+            }),
+        });
+        throw createDiscordPartialDeliveryError({
+          cause: error,
+          results: [
+            {
+              channel: "discord",
+              ...fallbackResult,
+            },
+          ],
+        });
+      }
     },
     sendPoll: async ({ cfg, to, poll, accountId, threadId, silent }) =>
       await withDiscordDeliveryRetry({

--- a/extensions/discord/src/send.outbound.ts
+++ b/extensions/discord/src/send.outbound.ts
@@ -138,6 +138,29 @@ function toDiscordSendResult(
   return createDiscordSendResult(resultParams);
 }
 
+function createDiscordPartialSendError(params: {
+  error: unknown;
+  result: DiscordSendResult;
+}): unknown {
+  const partialResults = [
+    {
+      channel: "discord",
+      ...params.result,
+    },
+  ];
+  if (params.error && typeof params.error === "object" && Object.isExtensible(params.error)) {
+    return Object.assign(params.error, {
+      results: partialResults,
+      sentBeforeError: true,
+    });
+  }
+  return Object.assign(new Error("discord send failed after partial delivery"), {
+    cause: params.error,
+    results: partialResults,
+    sentBeforeError: true,
+  });
+}
+
 async function resolveDiscordSendTarget(
   to: string,
   opts: DiscordSendOpts,
@@ -294,12 +317,23 @@ export async function sendMessageDiscord(
         });
       }
     } catch (err) {
-      throw await buildDiscordSendError(err, {
+      const sendError = await buildDiscordSendError(err, {
         channelId: threadId,
         cfg,
         rest,
         token,
         hasMedia: Boolean(opts.mediaUrl),
+      });
+      throw createDiscordPartialSendError({
+        error: sendError,
+        result: toDiscordSendResult(
+          {
+            id: messageId,
+            channel_id: resultChannelId,
+          },
+          channelId,
+          { kind: "text", threadId },
+        ),
       });
     }
 

--- a/src/infra/outbound/deliver.test.ts
+++ b/src/infra/outbound/deliver.test.ts
@@ -2554,6 +2554,67 @@ describe("deliverOutboundPayloads", () => {
     expect(chunker).toHaveBeenNthCalledWith(1, text, 4000);
   });
 
+  it("merges adapter partial results with earlier delivered payloads", async () => {
+    const sendText = vi.fn().mockResolvedValue({
+      channel: "matrix",
+      messageId: "text-1",
+      roomId: "r1",
+    });
+    const mediaFailure = Object.assign(new Error("media too large"), {
+      results: [{ channel: "matrix", messageId: "fallback-1", roomId: "r1" }],
+      sentBeforeError: true,
+    });
+    const sendMedia = vi.fn().mockRejectedValue(mediaFailure);
+    setActivePluginRegistry(
+      createTestRegistry([
+        {
+          pluginId: "matrix",
+          source: "test",
+          plugin: createOutboundTestPlugin({
+            id: "matrix",
+            outbound: {
+              deliveryMode: "direct",
+              sendText,
+              sendMedia,
+            },
+          }),
+        },
+      ]),
+    );
+
+    await expect(
+      deliverOutboundPayloads({
+        cfg: {},
+        channel: "matrix",
+        to: "!room",
+        payloads: [
+          { text: "first" },
+          { text: "second", mediaUrl: "https://example.com/too-large.mp3" },
+        ],
+      }),
+    ).rejects.toMatchObject({
+      name: "OutboundDeliveryError",
+      sentBeforeError: true,
+      results: [
+        { channel: "matrix", messageId: "text-1", roomId: "r1" },
+        { channel: "matrix", messageId: "fallback-1", roomId: "r1" },
+      ],
+      payloadOutcomes: [
+        {
+          index: 0,
+          status: "sent",
+          results: [{ channel: "matrix", messageId: "text-1", roomId: "r1" }],
+        },
+        {
+          index: 1,
+          status: "failed",
+          sentBeforeError: true,
+          stage: "platform_send",
+        },
+      ],
+    });
+  });
+
   it("passes formatting overrides for pre-rendered chunker output", async () => {
     const chunker = vi.fn(() => ["<b>bold</b>"]);
     const sendText = vi.fn().mockImplementation(async ({ text }: { text: string }) => ({
@@ -2693,6 +2754,35 @@ describe("deliverOutboundPayloads", () => {
     expect(sendMatrix).toHaveBeenCalledTimes(2);
     expect(onError).toHaveBeenCalledTimes(1);
     expect(results).toEqual([{ channel: "matrix", messageId: "m2", roomId: "!room:example" }]);
+  });
+
+  it("preserves adapter partial results when bestEffort continues after a failure", async () => {
+    const partialFailure = Object.assign(new Error("media too large"), {
+      results: [{ channel: "matrix", messageId: "fallback-1", roomId: "!room:example" }],
+      sentBeforeError: true,
+    });
+    const sendMatrix = vi
+      .fn()
+      .mockRejectedValueOnce(partialFailure)
+      .mockResolvedValueOnce({ messageId: "m2", roomId: "!room:example" });
+    const onError = vi.fn();
+
+    const results = await deliverOutboundPayloads({
+      cfg: matrixChunkConfig,
+      channel: "matrix",
+      to: "!room:example",
+      payloads: [{ text: "caption", mediaUrl: "https://example.com/large.mp3" }, { text: "next" }],
+      deps: { matrix: sendMatrix },
+      bestEffort: true,
+      onError,
+    });
+
+    expect(sendMatrix).toHaveBeenCalledTimes(2);
+    expect(onError).toHaveBeenCalledTimes(1);
+    expect(results).toEqual([
+      { channel: "matrix", messageId: "fallback-1", roomId: "!room:example" },
+      { channel: "matrix", messageId: "m2", roomId: "!room:example" },
+    ]);
   });
 
   it("emits internal message:sent hook with success=true for chunked payload delivery", async () => {

--- a/src/infra/outbound/deliver.ts
+++ b/src/infra/outbound/deliver.ts
@@ -885,6 +885,28 @@ function filterIdentifiedDeliveryResults(
   return results.filter((result) => hasDeliveryResultIdentity(result));
 }
 
+function readPartialDeliveryResults(error: unknown): OutboundDeliveryResult[] {
+  if (!error || typeof error !== "object") {
+    return [];
+  }
+  const results = (error as { results?: unknown }).results;
+  if (!Array.isArray(results)) {
+    return [];
+  }
+  return filterIdentifiedDeliveryResults(results as OutboundDeliveryResult[]);
+}
+
+function mergeDeliveryResults(
+  first: readonly OutboundDeliveryResult[],
+  second: readonly OutboundDeliveryResult[],
+): OutboundDeliveryResult[] {
+  const merged: OutboundDeliveryResult[] = [];
+  for (const result of [...first, ...second]) {
+    pushIdentifiedDeliveryResult(merged, result);
+  }
+  return merged;
+}
+
 function normalizeDeliveryPin(payload: ReplyPayload): ReplyPayloadDeliveryPin | undefined {
   const pin = payload.delivery?.pin;
   if (pin === true) {
@@ -1218,12 +1240,22 @@ function toOutboundDeliveryError(params: {
   payloadOutcomes: readonly OutboundPayloadDeliveryOutcome[];
   stage: OutboundDeliveryFailureStage;
 }): OutboundDeliveryError {
+  const partialResults = readPartialDeliveryResults(params.error);
+  const mergedResults = mergeDeliveryResults(params.results, partialResults);
   if (params.error instanceof OutboundDeliveryError) {
-    return params.error;
+    return new OutboundDeliveryError(params.error.message, {
+      cause: (params.error as Error & { cause?: unknown }).cause ?? params.error,
+      results: mergedResults,
+      payloadOutcomes:
+        params.error.payloadOutcomes.length > 0
+          ? params.error.payloadOutcomes
+          : params.payloadOutcomes,
+      stage: params.error.stage,
+    });
   }
   return new OutboundDeliveryError(formatErrorMessage(params.error), {
     cause: params.error,
-    results: params.results,
+    results: mergedResults,
     payloadOutcomes: params.payloadOutcomes,
     stage: params.stage,
   });
@@ -1969,11 +2001,17 @@ async function deliverOutboundPayloadsCore(
         messageId: lastMessageId,
       });
     } catch (err) {
+      const partialResults = readPartialDeliveryResults(err);
+      if (params.bestEffort) {
+        for (const result of partialResults) {
+          pushIdentifiedDeliveryResult(results, result);
+        }
+      }
       recordPayloadOutcome({
         index: payloadIndex,
         status: "failed",
         error: err,
-        sentBeforeError: results.length > 0,
+        sentBeforeError: results.length > 0 || partialResults.length > 0,
         stage: "platform_send",
       });
       errorDeliveryDiagnostics(err);


### PR DESCRIPTION
## Summary
- Preserve Discord reply text when a media attachment is rejected with HTTP 413 by retrying the same reply as text-only.
- Carry the fallback send result on the thrown delivery error so durable delivery can record the partial send instead of losing the message evidence.
- Merge adapter-reported partial results in outbound delivery, including best-effort sends that continue after the failed payload.

## Change Type
- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security
- [ ] Chore

## Scope
- [ ] Gateway
- [ ] Skills
- [ ] Auth
- [ ] Memory
- [x] Integrations
- [ ] API
- [ ] UI/UX
- [ ] CI

## Real behavior proof

**Behavior addressed:** A Discord reply with text plus an oversized media attachment now sends the text fallback and exposes that sent message as partial delivery evidence when the media upload fails with HTTP 413.

**Environment tested:** Local Linux checkout on branch `fix/99021-discord-oversize-attachment`, Node via `node --import tsx`, targeted Vitest suites through `node scripts/run-vitest.mjs`.

**Steps run after the patch:** Called the actual Discord outbound adapter and outbound delivery core from source with `node --import tsx --no-warnings -e`, then ran the targeted Discord, outbound delivery, and durable message tests.

**Evidence after fix:**

```text
$ node --import tsx --no-warnings -e '... import { discordOutbound } from "./extensions/discord/src/outbound-adapter.js"; import { deliverOutboundPayloads } from "./src/infra/outbound/deliver.js"; ...'
discordProof {
  "calls": [
    {
      "to": "channel:123456",
      "text": "song ready",
      "hasMedia": true,
      "mediaUrl": "media://local/song.mp3",
      "replyTo": "reply-1"
    },
    {
      "to": "channel:123456",
      "text": "song ready",
      "hasMedia": false,
      "replyTo": "reply-1"
    }
  ],
  "errorName": "Error",
  "errorMessage": "Request entity too large",
  "sentBeforeError": true,
  "results": [
    {
      "channel": "discord",
      "messageId": "fallback-text-1",
      "channelId": "ch-1"
    }
  ]
}
bestEffortProof [
  {
    "channel": "proof",
    "messageId": "fallback-1",
    "roomId": "room-1"
  },
  {
    "channel": "proof",
    "messageId": "text-2",
    "roomId": "room-1"
  }
]
```

```text
$ node scripts/run-vitest.mjs run extensions/discord/src/outbound-adapter.test.ts
[test] starting test/vitest/vitest.extension-discord.config.ts
[test] passed 1 Vitest shard in 29.68s

$ node scripts/run-vitest.mjs run src/infra/outbound/deliver.test.ts
[test] starting test/vitest/vitest.infra.config.ts
[test] passed 1 Vitest shard in 16.92s

$ node scripts/run-vitest.mjs run src/channels/message/send.test.ts
[test] starting test/vitest/vitest.channels.config.ts
[test] passed 1 Vitest shard in 12.75s

$ git diff --check
```

**Observed result:** The production adapter first attempted the media reply, then retried the same text without media after the 413; the thrown error carried `sentBeforeError: true` plus the fallback Discord message result. The outbound delivery core also preserved adapter partial results when best-effort delivery continued to the next payload.

**Not tested:** A live Discord guild upload with real credentials and an actual over-limit attachment was not run; the proof exercises the production adapter and delivery functions with injected send dependencies to avoid external network side effects.

## Root Cause
- Discord rejected oversized media attachments before the reply text could be delivered, and the adapter did not retry the text-only portion.
- The outbound core already tracked prior successful payloads, but it did not read adapter-reported partial results from thrown errors in every path.

## Regression Test Plan
- `extensions/discord/src/outbound-adapter.test.ts` covers 413 media rejection, text-only fallback, and avoiding duplicate fallback when a lower Discord path already reports send evidence.
- `src/infra/outbound/deliver.test.ts` covers merging partial adapter results with earlier payloads and preserving those results in best-effort continuation.
- `src/channels/message/send.test.ts` verifies the durable message layer still maps partial outbound errors to `partial_failed` receipts.

## User-visible / Behavior Changes
When Discord rejects an oversized attachment, users still receive the reply text instead of losing the entire response. Delivery accounting records the text fallback as partial delivery evidence so retry/recovery paths do not treat it as a total no-send.

## Security Impact
- New permissions? No
- Secrets handling changed? No
- New network calls? No

Closes #99021
