### PR TITLE
fix(discord): degrade oversized attachment replies instead of dropping

### DIFF
--- a/extensions/discord/src/monitor/reply-delivery.test.ts
+++ b/extensions/discord/src/monitor/reply-delivery.test.ts
@@ -500,6 +500,64 @@ describe("deliverDiscordReply", () => {
     expect(params.mediaAccess).toEqual({ localRoots: ["/tmp/openclaw-media"] });
   });
 
+  it("falls back to text-only final delivery when Discord rejects oversized attachments", async () => {
+    sendDurableMessageBatchMock
+      .mockResolvedValueOnce({
+        status: "failed",
+        error: new Error("Request entity too large", {
+          cause: { status: 413, message: "Discord API failed (413): Request entity too large" },
+        }),
+      })
+      .mockResolvedValueOnce({
+        status: "sent",
+        results: [{ messageId: "msg-fallback", channelId: "channel-1" }],
+      });
+
+    await deliverDiscordReply({
+      replies: [{ text: "Here is the summary.", mediaUrl: "https://example.com/large.mp3" }],
+      target: "channel:101",
+      token: "token",
+      accountId: "default",
+      runtime,
+      cfg,
+      textLimit: 2000,
+      kind: "final",
+    });
+
+    expect(sendDurableMessageBatchMock).toHaveBeenCalledTimes(2);
+    const fallbackParams = (sendDurableMessageBatchMock.mock.calls[1]?.[0] ?? {}) as DeliverParams;
+    expect(fallbackParams.payloads).toEqual([
+      {
+        text: "Here is the summary.\n⚠️ Attachment omitted because it exceeds Discord upload limits.",
+        mediaUrl: undefined,
+        mediaUrls: undefined,
+        ttsSupplement: undefined,
+      },
+    ]);
+  });
+
+  it("does not text-fallback attachment failures for non-413 delivery errors", async () => {
+    sendDurableMessageBatchMock.mockResolvedValueOnce({
+      status: "failed",
+      error: new Error("Discord API failed (500): Internal Server Error"),
+    });
+
+    await expect(
+      deliverDiscordReply({
+        replies: [{ text: "This should fail.", mediaUrl: "https://example.com/large.mp3" }],
+        target: "channel:101",
+        token: "token",
+        accountId: "default",
+        runtime,
+        cfg,
+        textLimit: 2000,
+        kind: "final",
+      }),
+    ).rejects.toThrow("Internal Server Error");
+
+    expect(sendDurableMessageBatchMock).toHaveBeenCalledTimes(1);
+  });
+
   it("bridges Discord voice sends through the outbound dependency bag", async () => {
     await deliverDiscordReply({
       replies: [{ text: "voice", mediaUrl: "https://example.com/voice.ogg", audioAsVoice: true }],

--- a/extensions/discord/src/monitor/reply-delivery.test.ts
+++ b/extensions/discord/src/monitor/reply-delivery.test.ts
@@ -4,9 +4,18 @@ import type { RuntimeEnv } from "openclaw/plugin-sdk/runtime-env";
 import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import type { RequestClient } from "../internal/discord.js";
 
+type DurableBatchSendResult =
+  | { status: "sent"; results: Array<{ messageId: string; channelId: string }> }
+  | { status: "failed"; error: unknown }
+  | {
+      status: "partial_failed";
+      error: unknown;
+      results: Array<{ messageId: string; channelId: string }>;
+    };
+
 const sendDurableMessageBatchMock = vi.hoisted(() =>
-  vi.fn(async () => ({
-    status: "sent" as const,
+  vi.fn<() => Promise<DurableBatchSendResult>>(async () => ({
+    status: "sent",
     results: [{ messageId: "msg-1", channelId: "channel-1" }],
   })),
 );

--- a/extensions/discord/src/monitor/reply-delivery.ts
+++ b/extensions/discord/src/monitor/reply-delivery.ts
@@ -21,6 +21,72 @@ import type { RequestClient } from "../internal/discord.js";
 import { sendMessageDiscord, sendVoiceMessageDiscord } from "../send.js";
 import { sanitizeDiscordFrontChannelReplyPayloads } from "./reply-safety.js";
 
+const DISCORD_ATTACHMENT_TOO_LARGE_NOTICE =
+  "⚠️ Attachment omitted because it exceeds Discord upload limits.";
+
+function hasOversizedAttachmentError(error: unknown): boolean {
+  const seen = new Set<unknown>();
+  let current: unknown = error;
+  while (current && typeof current === "object" && !seen.has(current)) {
+    seen.add(current);
+    const record = current as { status?: unknown; message?: unknown; cause?: unknown };
+    if (record.status === 413) {
+      return true;
+    }
+    const message =
+      typeof record.message === "string"
+        ? record.message.toLowerCase()
+        : String(record).toLowerCase();
+    if (
+      message.includes("request entity too large") ||
+      (message.includes("payload") && message.includes("too large")) ||
+      (message.includes("attachment") && message.includes("too large")) ||
+      (message.includes("413") && message.includes("too large"))
+    ) {
+      return true;
+    }
+    current = record.cause;
+  }
+  return false;
+}
+
+function appendAttachmentTooLargeNotice(text: string): string {
+  if (text.includes(DISCORD_ATTACHMENT_TOO_LARGE_NOTICE)) {
+    return text;
+  }
+  return `${text}\n${DISCORD_ATTACHMENT_TOO_LARGE_NOTICE}`;
+}
+
+function stripMediaForOversizedAttachmentFallback(payloads: ReplyPayload[]): ReplyPayload[] {
+  const fallback: ReplyPayload[] = [];
+  let emittedStandaloneNotice = false;
+  for (const payload of payloads) {
+    const hasMedia = Boolean(
+      payload.mediaUrl?.trim() || payload.mediaUrls?.some((url) => url?.trim()),
+    );
+    if (!hasMedia) {
+      fallback.push(payload);
+      continue;
+    }
+    const text = payload.text?.trim();
+    if (text) {
+      fallback.push({
+        ...payload,
+        text: appendAttachmentTooLargeNotice(payload.text ?? ""),
+        mediaUrl: undefined,
+        mediaUrls: undefined,
+        ttsSupplement: undefined,
+      });
+      continue;
+    }
+    if (!emittedStandaloneNotice) {
+      fallback.push({ text: DISCORD_ATTACHMENT_TOO_LARGE_NOTICE, isError: true });
+      emittedStandaloneNotice = true;
+    }
+  }
+  return fallback;
+}
+
 export type DiscordThreadBindingLookupRecord = {
   accountId: string;
   channelId: string;
@@ -223,6 +289,44 @@ export async function deliverDiscordReply(params: {
     }),
   });
   if (send.status === "failed" || send.status === "partial_failed") {
+    const hasDeliveredResults = send.status === "partial_failed" && send.results.length > 0;
+    if (
+      params.kind === "final" &&
+      !hasDeliveredResults &&
+      hasOversizedAttachmentError(send.error)
+    ) {
+      const fallbackPayloads = stripMediaForOversizedAttachmentFallback(payloads);
+      if (fallbackPayloads.length > 0) {
+        const fallbackSend = await sendDurableMessageBatch({
+          cfg: params.cfg,
+          channel: "discord",
+          to: delivery.to,
+          accountId: params.accountId,
+          payloads: fallbackPayloads,
+          replyToId: normalizeOptionalString(params.replyToId),
+          replyToMode: delivery.replyToMode,
+          formatting: delivery.formatting,
+          threadId: delivery.threadId,
+          identity: delivery.identity,
+          deps: createDiscordDeliveryDeps({
+            cfg: params.cfg,
+            token: params.token,
+            rest: params.rest,
+          }),
+          mediaAccess: delivery.mediaAccess,
+          session: buildOutboundSessionContext({
+            cfg: params.cfg,
+            sessionKey: params.sessionKey,
+            agentId: delivery.agentId,
+            requesterAccountId: params.accountId,
+          }),
+        });
+        if (fallbackSend.status === "failed" || fallbackSend.status === "partial_failed") {
+          throw fallbackSend.error;
+        }
+        return;
+      }
+    }
     throw send.error;
   }
   const results = send.status === "sent" ? send.results : [];

--- a/extensions/discord/src/monitor/reply-delivery.ts
+++ b/extensions/discord/src/monitor/reply-delivery.ts
@@ -36,7 +36,9 @@ function hasOversizedAttachmentError(error: unknown): boolean {
     const message =
       typeof record.message === "string"
         ? record.message.toLowerCase()
-        : String(record).toLowerCase();
+        : current instanceof Error
+          ? current.message.toLowerCase()
+          : "";
     if (
       message.includes("request entity too large") ||
       (message.includes("payload") && message.includes("too large")) ||


### PR DESCRIPTION
## What Problem This Solves
When a Discord final reply includes an attachment above upload limits, Discord returns HTTP 413 and the whole outbound reply (including valid text) gets dropped. The user sees silence while dispatch can still appear completed.

## Summary
- detect attachment-too-large delivery failures (HTTP 413 / request entity too large)
- retry final delivery once with media stripped so text still reaches the channel
- append a clear attachment-limit notice to the delivered text; keep non-413 failures unchanged
- add focused regression tests for fallback and non-fallback error paths

## Evidence
- Repro class from issue #99021: oversized media triggers Request entity too large and no visible reply
- Validation: for 413 failures, final delivery now retries as text-only and includes Attachment omitted because it exceeds Discord upload limits.
- Non-regression: non-413 delivery failures still bubble as errors (no false-success fallback)
- Local test run:
  - [x] pnpm exec vitest run extensions/discord/src/monitor/reply-delivery.test.ts

Related: #99021
