### PR TITLE
fix(config): return empty string for undefined in safeStringify

### DIFF
--- a/src/config/allowed-values.test.ts
+++ b/src/config/allowed-values.test.ts
@@ -22,4 +22,13 @@ describe("summarizeAllowedValues", () => {
       values: [`${prefix}x`, `${prefix}y`],
     });
   });
+
+  it("returns empty label for undefined allowed value", () => {
+    const summary = summarizeAllowedValues([undefined]);
+    expect(summary).toStrictEqual({
+      formatted: "",
+      hiddenCount: 0,
+      values: [""],
+    });
+  });
 });

--- a/src/config/allowed-values.ts
+++ b/src/config/allowed-values.ts
@@ -18,6 +18,9 @@ function truncateHintText(text: string, limit: number): string {
 }
 
 function safeStringify(value: unknown): string {
+  if (value === undefined) {
+    return "";
+  }
   try {
     const serialized = JSON.stringify(value);
     if (serialized !== undefined) {
@@ -26,7 +29,9 @@ function safeStringify(value: unknown): string {
   } catch {
     // Fall back to string coercion when value is not JSON-serializable.
   }
-  return String(value);
+  // This is the deliberate last-resort renderer; the assertion opts into
+  // String() semantics for non-JSON values without changing runtime behavior.
+  return String(value as string | number | boolean | bigint | symbol | null);
 }
 
 function toAllowedValueLabel(value: unknown): string {


### PR DESCRIPTION
## What Problem This Solves

`safeStringify(undefined)` returned the literal string `"undefined"` because
`JSON.stringify(undefined)` returns `undefined`, causing the function to fall
through to `String(undefined)`.

That value is used by config and plugin-schema validation when rendering allowed
values, so an absent value could appear as the misleading text `undefined`
instead of an empty value.

## Why This Change Was Made

The shared `safeStringify` helper is the narrow owner boundary used by both
config validation and plugin schema validation. It now returns `""` immediately
for `undefined` while leaving the existing JSON and fallback stringification
paths unchanged for every other input. The fallback assertion documents the
intentional last-resort `String()` semantics and satisfies the type-aware lint
rule without changing runtime behavior.

A colocated regression test covers `summarizeAllowedValues([undefined])`.

## User Impact

Config validation and generated allowed-value hints render an undefined allowed
value as empty instead of displaying the literal text `undefined`.

## Evidence

- Current-main behavior and both callers were traced through
  `src/config/allowed-values.ts`, `src/config/validation.ts`, and
  `src/plugins/schema-validator.ts`.
- Fresh structured autoreview on final head
  `330fd1d951535b142d88ea85a265c5c27cc03a4b` returned no findings.
- Secretless GitHub-hosted Ubuntu proof passed on that exact head:
  type-aware oxlint reported 0 errors on both changed files, oxfmt passed, and
  `src/config/allowed-values.test.ts` passed 3/3 tests.
  https://github.com/vincentkoc/openclaw/actions/runs/28782771616
- A full Ubuntu lint attempt no longer reports an allowed-values error. Its only
  remaining failures are two unrelated pre-existing unused imports in
  `packages/gateway-protocol/src/index.ts`.

## Risk

Low. The production change is an early return plus a type-only assertion around
the existing fallback, with one focused regression test. No API, schema,
dependency, workflow, or configuration surface changes.
