### PR TITLE
fix(discord): fall back to text-only when media upload exceeds Discord size limit

### DIFF
--- a/extensions/discord/src/send.outbound.ts
+++ b/extensions/discord/src/send.outbound.ts
@@ -61,7 +61,7 @@ type DiscordSendOpts = {
 
 type DiscordClientRequest = ReturnType<typeof createDiscordClient>["request"];
 
-const DEFAULT_DISCORD_MEDIA_MAX_MB = 100;
+const DEFAULT_DISCORD_MEDIA_MAX_MB = 25;
 
 type DiscordChannelMessageResult = DiscordReceiptResultSource;
 

--- a/extensions/discord/src/send.sends-basic-channel-messages.test.ts
+++ b/extensions/discord/src/send.sends-basic-channel-messages.test.ts
@@ -590,7 +590,7 @@ describe("sendMessageDiscord", () => {
     expectRestRoute(postMock, 0, Routes.channelMessages("789"));
     expectBodyFileName(requireRestBody(postMock), "photo.jpg");
     expect(loadWebMedia).toHaveBeenCalledWith("file:///tmp/photo.jpg", {
-      maxBytes: 100 * 1024 * 1024,
+      maxBytes: 25 * 1024 * 1024,
     });
   });
 
@@ -712,6 +712,41 @@ describe("sendMessageDiscord", () => {
     });
     expectReplyReference(firstBody, "orig-123");
     expectReplyReference(secondBody, "orig-123");
+  });
+
+  it("falls back to text-only when Discord returns 413 for oversized media", async () => {
+    const { rest, postMock } = makeDiscordRest();
+    postMock
+      .mockRejectedValueOnce(Object.assign(new Error("Request entity too large"), { status: 413 }))
+      .mockResolvedValueOnce({ id: "msg", channel_id: "789" });
+
+    const res = await sendMessageDiscord("channel:789", "hello", {
+      rest,
+      token: "t",
+      cfg: DISCORD_TEST_CFG,
+      mediaUrl: "file:///tmp/large.bin",
+    });
+    expect(res.messageId).toBe("msg");
+    expect(postMock).toHaveBeenCalledTimes(2);
+    const fallbackBody = requireRestBody(postMock, 1);
+    expect(fallbackBody.content).toContain("hello");
+    expect(fallbackBody.content).toContain("exceeds Discord's upload size limit");
+    expect(fallbackBody).not.toHaveProperty("files");
+  });
+
+  it("re-throws non-413 media send errors without fallback", async () => {
+    const { rest, postMock } = makeDiscordRest();
+    postMock.mockRejectedValueOnce(Object.assign(new Error("Bad Request"), { status: 400 }));
+
+    await expect(
+      sendMessageDiscord("channel:789", "hello", {
+        rest,
+        token: "t",
+        cfg: DISCORD_TEST_CFG,
+        mediaUrl: "file:///tmp/large.bin",
+      }),
+    ).rejects.toThrow("Bad Request");
+    expect(postMock).toHaveBeenCalledTimes(1);
   });
 });
 

--- a/extensions/discord/src/send.shared.ts
+++ b/extensions/discord/src/send.shared.ts
@@ -420,10 +420,33 @@ async function sendDiscordMedia(
       },
     ],
   });
-  const res = (await request(
-    () => createChannelMessage<{ id: string; channel_id: string }>(rest, channelId, { body }),
-    "media",
-  )) as { id: string; channel_id: string };
+  let res: { id: string; channel_id: string };
+  try {
+    res = (await request(
+      () => createChannelMessage<{ id: string; channel_id: string }>(rest, channelId, { body }),
+      "media",
+    )) as { id: string; channel_id: string };
+  } catch (err) {
+    if (getDiscordErrorStatus(err) === 413) {
+      const sizeNote = "⚠️ Attachment could not be delivered — it exceeds Discord's upload size limit.";
+      const fallbackText = text ? `${text}\n\n${sizeNote}` : sizeNote;
+      return sendDiscordText(
+        rest,
+        channelId,
+        fallbackText,
+        replyTo,
+        request,
+        maxLinesPerMessage,
+        components,
+        embeds,
+        chunkMode,
+        silent,
+        suppressEmbeds,
+        maxChars,
+      );
+    }
+    throw err;
+  }
   await onResult?.(res, "media");
   const platformMessageIds = res.id ? [res.id] : [];
   for (const chunk of chunks.slice(1)) {


### PR DESCRIPTION
## What Problem This Solves

When an agent reply includes a media attachment larger than Discord's bot upload limit, the entire outbound reply (text AND attachment) is rejected by Discord with HTTP 413 and **silently lost**. The user sees the agent as simply not responding. Dispatch still reports `outcome=completed`, so monitoring doesn't catch it either.

Production evidence from issue #99021: a 10.7 MB MP3 attachment caused the same 413 failure twice, with the channel effectively wedged for that reply.

Fixes #99021

## Changes

**1. Lower `DEFAULT_DISCORD_MEDIA_MAX_MB` from 100 to 25** (`send.outbound.ts`)

Discord's base-tier upload cap is 25 MB. The previous 100 MB default meant files up to 100 MB passed OpenClaw's preflight check but Discord rejected them at upload. Users with boosted servers (50/100 MB limits) can still override via the existing `mediaMaxMb` config option.

**2. Add 413 text-only fallback in `sendDiscordMedia`** (`send.shared.ts`)

When Discord returns HTTP 413 for the multipart request (text + file), the catch block now:
- Detects the 413 via `getDiscordErrorStatus()` (existing utility in the same file)
- Falls back to `sendDiscordText()` with the full original text plus a note: *⚠️ Attachment could not be delivered — it exceeds Discord's upload size limit.*
- Non-413 errors are re-thrown unchanged

This is placed at the lowest layer — inside `sendDiscordMedia` — so it applies to all callers: outbound adapter, reply delivery, and direct sends.

## Evidence

**Test results:**
- 46/46 tests pass in `send.sends-basic-channel-messages.test.ts`
- 17/17 tests pass in `reply-delivery.test.ts`

```
node scripts/run-vitest.mjs extensions/discord/src/send.sends-basic-channel-messages.test.ts
✓ extension-discord extensions/discord/src/send.sends-basic-channel-messages.test.ts (46 tests) 2699ms
Test Files  1 passed (1)
     Tests  46 passed (46)
```

**New test: 413 fallback** — mocks Discord returning 413 on first call (media+text), verifies second call (text-only fallback) contains original text + warning note, no files attached.

**New test: non-413 re-throw** — mocks 400 error, verifies it's re-thrown without fallback attempt (only 1 API call).

**Behavior matrix:**

| Scenario | Before | After |
|---|---|---|
| 10.7 MB file, 10 MB server limit | Text + file silently lost | Text delivered with size-limit note |
| 15 MB file, 25 MB server limit | Text + file delivered | Text + file delivered (unchanged) |
| 30 MB file, 25 MB server limit | Text + file silently lost | Preflight rejects (clear error) |
| 5 MB file, any server | Text + file delivered | Text + file delivered (unchanged) |

🤖 *This PR was authored by an AI agent.*