### PR TITLE
fix(sessions): reply session init fails under rapid consecutive turns

### DIFF
--- a/src/auto-reply/reply/session-init-retry-budget.test.ts
+++ b/src/auto-reply/reply/session-init-retry-budget.test.ts
@@ -1,0 +1,105 @@
+// Exercises the real (non-mocked) session-accessor functions under an
+// induced revision-conflict burst, mirroring the retry loop in session.ts.
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  commitReplySessionInitialization,
+  loadReplySessionInitializationSnapshot,
+  upsertSessionEntry,
+} from "../../config/sessions/session-accessor.js";
+
+async function initSessionWithBudget(params: {
+  sessionKey: string;
+  storePath: string;
+  maxAttempts: number;
+  onSnapshot?: (attempt: number) => Promise<void> | void;
+}): Promise<{ attempts: number }> {
+  const { sessionKey, storePath, maxAttempts, onSnapshot } = params;
+  for (let attempt = 0; ; attempt += 1) {
+    const snapshot = loadReplySessionInitializationSnapshot({ sessionKey, storePath });
+    if (onSnapshot) {
+      await onSnapshot(attempt);
+    }
+    const committed = await commitReplySessionInitialization({
+      activeSessionKey: sessionKey,
+      agentId: "main",
+      expectedRevision: snapshot.revision,
+      sessionEntry: {
+        sessionId: `turn-${attempt}`,
+        updatedAt: Date.now(),
+      },
+      sessionKey,
+      storePath,
+    });
+    if (committed.ok) {
+      return { attempts: attempt + 1 };
+    }
+    if (attempt + 1 >= maxAttempts) {
+      throw new Error(`reply session initialization conflicted for ${sessionKey}`);
+    }
+  }
+}
+
+describe("reply session init retry budget under a revision-conflict burst", () => {
+  let tempDir: string;
+  let storePath: string;
+  const sessionKey = "agent:main:main";
+
+  beforeEach(() => {
+    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-retry-budget-"));
+    storePath = path.join(tempDir, "sessions.json");
+  });
+
+  afterEach(() => {
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  it("old budget (2 attempts) throws under a 3-writer burst", async () => {
+    await upsertSessionEntry({ sessionKey, storePath }, { sessionId: "seed", updatedAt: 1 });
+    let externalWriterCalls = 0;
+
+    await expect(
+      initSessionWithBudget({
+        sessionKey,
+        storePath,
+        maxAttempts: 2,
+        onSnapshot: async (attempt) => {
+          if (attempt < 3) {
+            externalWriterCalls += 1;
+            await upsertSessionEntry(
+              { sessionKey, storePath },
+              { sessionId: `external-writer-${attempt}`, updatedAt: 100 + attempt },
+            );
+          }
+        },
+      }),
+    ).rejects.toThrow(`reply session initialization conflicted for ${sessionKey}`);
+
+    expect(externalWriterCalls).toBe(2);
+  });
+
+  it("new budget (4 attempts) succeeds under the identical 3-writer burst", async () => {
+    await upsertSessionEntry({ sessionKey, storePath }, { sessionId: "seed", updatedAt: 1 });
+    let externalWriterCalls = 0;
+
+    const result = await initSessionWithBudget({
+      sessionKey,
+      storePath,
+      maxAttempts: 4,
+      onSnapshot: async (attempt) => {
+        if (attempt < 3) {
+          externalWriterCalls += 1;
+          await upsertSessionEntry(
+            { sessionKey, storePath },
+            { sessionId: `external-writer-${attempt}`, updatedAt: 100 + attempt },
+          );
+        }
+      },
+    });
+
+    expect(externalWriterCalls).toBe(3);
+    expect(result.attempts).toBe(4);
+  });
+});

--- a/src/auto-reply/reply/session-init-retry-budget.test.ts
+++ b/src/auto-reply/reply/session-init-retry-budget.test.ts
@@ -1,5 +1,3 @@
-// Exercises the real (non-mocked) session-accessor functions under an
-// induced revision-conflict burst, mirroring the retry loop in session.ts.
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";

--- a/src/auto-reply/reply/session.ts
+++ b/src/auto-reply/reply/session.ts
@@ -72,13 +72,13 @@ import { parseSoftResetCommand } from "./commands-reset-mode.js";
 import { resolveConversationBindingContextFromMessage } from "./conversation-binding-input.js";
 import { normalizeInboundTextNewlines } from "./inbound-text.js";
 import { stripMentions, stripStructuralPrefixes } from "./mentions.js";
+import { replyRunRegistry } from "./reply-run-registry.js";
 import { isResetAuthorizedForContext } from "./reset-authorization.js";
 import {
   maybeRetireLegacyMainDeliveryRoute,
   resolveLastChannelRaw,
   resolveLastToRaw,
 } from "./session-delivery.js";
-import { replyRunRegistry } from "./reply-run-registry.js";
 import {
   createReplySessionEntryHandle,
   type ReplySessionEntryHandle,
@@ -307,28 +307,32 @@ function resolveInitSessionStateAttemptContext(
   };
 }
 
+// A single retry was insufficient under bursts of rapid consecutive turns
+// on the same sessionKey. See the `!committed.ok` branch below.
+const MAX_SESSION_INIT_ATTEMPTS = 4;
+
 /** Initializes or reuses the reply session state for one inbound turn. */
 export async function initSessionState(params: InitSessionStateParams): Promise<SessionInitResult> {
-  return await initSessionStateAttempt(params, false);
+  return await initSessionStateAttempt(params, 0);
 }
 
 async function initSessionStateAttempt(
   params: InitSessionStateParams,
-  staleSnapshotRetried: boolean,
+  attempt: number,
 ): Promise<SessionInitResult> {
   const attemptContext = resolveInitSessionStateAttemptContext(params);
   // Guarded revision checks only serialize correctly when the snapshot and
   // commit share the same writer lane.
   return await runExclusiveSessionStoreWrite(
     attemptContext.storePath,
-    async () => await initSessionStateAttemptLocked(params, attemptContext, staleSnapshotRetried),
+    async () => await initSessionStateAttemptLocked(params, attemptContext, attempt),
   );
 }
 
 async function initSessionStateAttemptLocked(
   params: InitSessionStateParams,
   attemptContext: InitSessionStateAttemptContext,
-  staleSnapshotRetried: boolean,
+  attempt: number,
 ): Promise<SessionInitResult> {
   const { ctx, cfg, commandAuthorized } = params;
   const { agentId, conversationBindingContext, isSystemEvent, sessionCtxForState, storePath } =
@@ -930,8 +934,8 @@ async function initSessionStateAttemptLocked(
     storePath,
   });
   if (!committed.ok) {
-    if (!staleSnapshotRetried) {
-      return await initSessionStateAttemptLocked(params, attemptContext, true);
+    if (attempt + 1 < MAX_SESSION_INIT_ATTEMPTS) {
+      return await initSessionStateAttemptLocked(params, attemptContext, attempt + 1);
     }
     throw new Error(`reply session initialization conflicted for ${sessionKey}`);
   }

--- a/src/auto-reply/reply/session.ts
+++ b/src/auto-reply/reply/session.ts
@@ -307,8 +307,6 @@ function resolveInitSessionStateAttemptContext(
   };
 }
 
-// A single retry was insufficient under bursts of rapid consecutive turns
-// on the same sessionKey. See the `!committed.ok` branch below.
 const MAX_SESSION_INIT_ATTEMPTS = 4;
 
 /** Initializes or reuses the reply session state for one inbound turn. */


### PR DESCRIPTION
## What Problem This Solves

Rapid consecutive turns on the same reply session can hit `reply session initialization conflicted` when the session-store revision advances between snapshot and commit more than once. The previous code retried one stale snapshot, then surfaced the error to the user.

## Change

Replace the boolean stale-snapshot retry flag with a bounded attempt counter. The retry budget is now 4 total attempts.

The snapshot, commit, locking, and final failure behavior are unchanged. This only gives transient same-session revision conflicts a small bounded retry window.

## Evidence

Pre-fix TUI observation, redacted:

```text
session: agent:main:tui-b309...83a6
instagram.com curl: 301
rapid same-session follow-ups: polymarkets.com, this, hi please come alive
observed: Error: reply session initialization conflicted for agent:main:tui-b309...83a6
```

Post-fix runtime proof on this PR head:

```text
branch: fix/reply-session-init-retry-budget
head: 6d5cce63
cli: OpenClaw 2026.6.11 (6d5cce6)
proof session: agent:main:tui-a228...f259
command shape: three immediate same-session openclaw agent --session-key <proof-session> --message ... --json turns

status_a=0
status_b=0
status_c=0
turn_A status=ok text='OK A' sessionId=b917...208 model=openai/gpt-5.4
turn_B status=ok text='OK B' sessionId=b917...208 model=openai/gpt-5.4
turn_C status=ok text='OK C' sessionId=b917...208 model=openai/gpt-5.4
```

Target error check for the post-fix run:

```text
No `reply session initialization conflicted` error occurred during the post-fix proof run.
```

Added `src/auto-reply/reply/session-init-retry-budget.test.ts`. It uses the real file-backed `loadReplySessionInitializationSnapshot` and `commitReplySessionInitialization` functions and induces the same 3-writer revision-conflict burst against `agent:main:main`.

```text
old budget (2 attempts) throws under a 3-writer burst
new budget (4 attempts) succeeds under the identical 3-writer burst
```

Checked locally:

```text
npx vitest run src/auto-reply/reply/session-init-retry-budget.test.ts src/auto-reply/reply/session.test.ts extensions/telegram/src/polling-session.test.ts
Test Files  3 passed (3)
Tests       201 passed (201)

npx oxlint src/auto-reply/reply/session.ts src/auto-reply/reply/session-init-retry-budget.test.ts
npx oxfmt --check src/auto-reply/reply/session.ts src/auto-reply/reply/session-init-retry-budget.test.ts
```

`npx tsc --noEmit -p tsconfig.core.json` has no new errors. The existing `TS4058` in `src/secrets/config-io.ts` reproduces on `main`.

## Notes

This is a small mitigation for transient same-session write races. It does not replace the related root-cause work in #98416 or #98835.
