### PR TITLE
fix: Update Dark/Light mode UI control appearance

### DIFF
--- a/apps/.i18n/native-source.json
+++ b/apps/.i18n/native-source.json
@@ -8043,7 +8043,7 @@
     },
     {
       "kind": "ui-modifier",
-      "line": 116,
+      "line": 117,
       "path": "apps/ios/Sources/Design/SettingsProTab.swift",
       "source": "Settings",
       "surface": "apple",
@@ -8051,7 +8051,7 @@
     },
     {
       "kind": "ui-modifier",
-      "line": 213,
+      "line": 211,
       "path": "apps/ios/Sources/Design/SettingsProTab.swift",
       "source": "Scan QR Code",
       "surface": "apple",
@@ -8059,7 +8059,7 @@
     },
     {
       "kind": "ui-modifier",
-      "line": 227,
+      "line": 225,
       "path": "apps/ios/Sources/Design/SettingsProTab.swift",
       "source": "Reset Onboarding?",
       "surface": "apple",
@@ -8067,7 +8067,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 228,
+      "line": 226,
       "path": "apps/ios/Sources/Design/SettingsProTab.swift",
       "source": "Reset",
       "surface": "apple",
@@ -8075,7 +8075,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 231,
+      "line": 229,
       "path": "apps/ios/Sources/Design/SettingsProTab.swift",
       "source": "Cancel",
       "surface": "apple",
@@ -8083,7 +8083,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 233,
+      "line": 231,
       "path": "apps/ios/Sources/Design/SettingsProTab.swift",
       "source": "This disconnects, clears saved gateway credentials, and reopens onboarding.",
       "surface": "apple",
@@ -8091,7 +8091,7 @@
     },
     {
       "kind": "ui-modifier",
-      "line": 235,
+      "line": 233,
       "path": "apps/ios/Sources/Design/SettingsProTab.swift",
       "source": "QR Scanner Unavailable",
       "surface": "apple",
@@ -8099,7 +8099,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 241,
+      "line": 239,
       "path": "apps/ios/Sources/Design/SettingsProTab.swift",
       "source": "OK",
       "surface": "apple",
@@ -8107,7 +8107,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 286,
+      "line": 284,
       "path": "apps/ios/Sources/Design/SettingsProTab.swift",
       "source": "Enable OpenClaw Hosted Push Relay?",
       "surface": "apple",
@@ -8115,7 +8115,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 299,
+      "line": 297,
       "path": "apps/ios/Sources/Design/SettingsProTab.swift",
       "source": "Continue",
       "surface": "apple",
@@ -8123,7 +8123,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 302,
+      "line": 300,
       "path": "apps/ios/Sources/Design/SettingsProTab.swift",
       "source": "Not Now",
       "surface": "apple",
@@ -8371,23 +8371,23 @@
     },
     {
       "kind": "ui-call",
-      "line": 14,
+      "line": 34,
+      "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
+      "source": "Choose system, light, or dark appearance",
+      "surface": "apple",
+      "id": "native.apple.cfec8b4d042a8066"
+    },
+    {
+      "kind": "ui-call",
+      "line": 44,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Appearance",
       "surface": "apple",
       "id": "native.apple.747143c7ef879774"
     },
     {
-      "kind": "ui-modifier",
-      "line": 19,
-      "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
-      "source": "Choose system, light, or dark appearance",
-      "surface": "apple",
-      "id": "native.apple.80fade864c8ad242"
-    },
-    {
       "kind": "conditional-branch",
-      "line": 54,
+      "line": 95,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "1 agent",
       "surface": "apple",
@@ -8395,7 +8395,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 54,
+      "line": 95,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "\\(agentCount) agents",
       "surface": "apple",
@@ -8403,7 +8403,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 61,
+      "line": 102,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Reconnect",
       "surface": "apple",
@@ -8411,7 +8411,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 71,
+      "line": 112,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Diagnose",
       "surface": "apple",
@@ -8419,7 +8419,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 93,
+      "line": 134,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Permissions",
       "surface": "apple",
@@ -8427,7 +8427,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 98,
+      "line": 139,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Channels",
       "surface": "apple",
@@ -8435,7 +8435,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 110,
+      "line": 152,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Diagnostics",
       "surface": "apple",
@@ -8443,7 +8443,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 125,
+      "line": 167,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "About",
       "surface": "apple",
@@ -8451,7 +8451,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 205,
+      "line": 247,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Gateway",
       "surface": "apple",
@@ -8459,7 +8459,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 211,
+      "line": 253,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Address",
       "surface": "apple",
@@ -8467,7 +8467,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 213,
+      "line": 255,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Server",
       "surface": "apple",
@@ -8475,7 +8475,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 215,
+      "line": 257,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Discovered",
       "surface": "apple",
@@ -8483,7 +8483,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 219,
+      "line": 261,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Agents",
       "surface": "apple",
@@ -8491,7 +8491,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 240,
+      "line": 282,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Approvals",
       "surface": "apple",
@@ -8499,7 +8499,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 243,
+      "line": 285,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "No gateway actions are waiting for review.",
       "surface": "apple",
@@ -8507,7 +8507,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 243,
+      "line": 285,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Review the pending gateway action.",
       "surface": "apple",
@@ -8515,7 +8515,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 247,
+      "line": 289,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "1 waiting",
       "surface": "apple",
@@ -8523,7 +8523,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 265,
+      "line": 307,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Notifications are off",
       "surface": "apple",
@@ -8531,7 +8531,7 @@
     },
     {
       "kind": "ui-call-multiline",
-      "line": 267,
+      "line": 309,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Enable Notifications to receive approval notifications while OpenClaw is not open.",
       "surface": "apple",
@@ -8539,7 +8539,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 281,
+      "line": 323,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Open Notifications",
       "surface": "apple",
@@ -8547,7 +8547,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 315,
+      "line": 357,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Allow",
       "surface": "apple",
@@ -8555,7 +8555,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 335,
+      "line": 377,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Deny",
       "surface": "apple",
@@ -8563,7 +8563,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 347,
+      "line": 389,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "No approvals waiting",
       "surface": "apple",
@@ -8571,7 +8571,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 365,
+      "line": 407,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Camera",
       "surface": "apple",
@@ -8579,7 +8579,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 366,
+      "line": 408,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Allow the gateway to request photos or video while OpenClaw is foregrounded.",
       "surface": "apple",
@@ -8587,7 +8587,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 373,
+      "line": 415,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Keep Awake",
       "surface": "apple",
@@ -8595,7 +8595,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 374,
+      "line": 416,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Keep the screen awake while OpenClaw is open.",
       "surface": "apple",
@@ -8603,7 +8603,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 385,
+      "line": 427,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Voice & Talk",
       "surface": "apple",
@@ -8611,7 +8611,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 400,
+      "line": 442,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Health Check",
       "surface": "apple",
@@ -8619,7 +8619,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 401,
+      "line": 443,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Run app, permission, and gateway-adjacent checks without editing setup.",
       "surface": "apple",
@@ -8627,7 +8627,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 407,
+      "line": 449,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Run Diagnostics",
       "surface": "apple",
@@ -8635,7 +8635,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 422,
+      "line": 464,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Platform",
       "surface": "apple",
@@ -8643,7 +8643,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 424,
+      "line": 466,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "App",
       "surface": "apple",
@@ -8651,7 +8651,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 426,
+      "line": 468,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Model",
       "surface": "apple",
@@ -8659,7 +8659,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 437,
+      "line": 479,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Privacy",
       "surface": "apple",
@@ -8667,7 +8667,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 438,
+      "line": 480,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Control what device context OpenClaw can expose to the gateway.",
       "surface": "apple",
@@ -8675,7 +8675,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 444,
+      "line": 486,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Camera Access",
       "surface": "apple",
@@ -8683,7 +8683,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 445,
+      "line": 487,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Disable to block camera capture requests from the gateway.",
       "surface": "apple",
@@ -8691,7 +8691,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 452,
+      "line": 494,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Background Listening",
       "surface": "apple",
@@ -8699,7 +8699,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 453,
+      "line": 495,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Allow active Talk sessions to continue while the app is backgrounded.",
       "surface": "apple",
@@ -8707,7 +8707,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 464,
+      "line": 506,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Notifications",
       "surface": "apple",
@@ -8715,7 +8715,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 509,
+      "line": 551,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "OpenClaw app version",
       "surface": "apple",
@@ -8723,7 +8723,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 511,
+      "line": 553,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Device",
       "surface": "apple",
@@ -8731,7 +8731,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 513,
+      "line": 555,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "iOS",
       "surface": "apple",
@@ -8739,7 +8739,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 581,
+      "line": 623,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Controls whether location can be shared with gateway tools.",
       "surface": "apple",
@@ -8747,7 +8747,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 593,
+      "line": 635,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Location",
       "surface": "apple",
@@ -8755,7 +8755,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 594,
+      "line": 636,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Off",
       "surface": "apple",
@@ -8763,7 +8763,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 595,
+      "line": 637,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "While Using",
       "surface": "apple",
@@ -8771,7 +8771,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 596,
+      "line": 638,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Always",
       "surface": "apple",
@@ -8779,7 +8779,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 614,
+      "line": 656,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Default Agent",
       "surface": "apple",
@@ -8787,7 +8787,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 616,
+      "line": 658,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Agent",
       "surface": "apple",
@@ -8795,7 +8795,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 617,
+      "line": 659,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Default",
       "surface": "apple",
@@ -8803,7 +8803,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 625,
+      "line": 667,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Used for new Chat and Talk sessions.",
       "surface": "apple",
@@ -8811,7 +8811,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 636,
+      "line": 678,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Setup Code",
       "surface": "apple",
@@ -8819,7 +8819,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 638,
+      "line": 680,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Paste setup code",
       "surface": "apple",
@@ -8827,7 +8827,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 644,
+      "line": 686,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Scan QR",
       "surface": "apple",
@@ -8835,7 +8835,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 652,
+      "line": 694,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Connect",
       "surface": "apple",
@@ -8843,7 +8843,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 680,
+      "line": 722,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Discovered Gateways",
       "surface": "apple",
@@ -8851,7 +8851,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 683,
+      "line": 725,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "No gateways found yet. Use manual setup if Bonjour is blocked.",
       "surface": "apple",
@@ -8859,7 +8859,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 727,
+      "line": 769,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Use Manual Gateway",
       "surface": "apple",
@@ -8867,7 +8867,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 728,
+      "line": 770,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Host",
       "surface": "apple",
@@ -8875,7 +8875,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 732,
+      "line": 774,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Port",
       "surface": "apple",
@@ -8883,7 +8883,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 735,
+      "line": 777,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Use TLS",
       "surface": "apple",
@@ -8891,7 +8891,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 737,
+      "line": 779,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Connect Manual",
       "surface": "apple",
@@ -8899,7 +8899,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 754,
+      "line": 796,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Auto-connect on launch",
       "surface": "apple",
@@ -8907,7 +8907,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 755,
+      "line": 797,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Gateway Auth Token",
       "surface": "apple",
@@ -8915,7 +8915,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 759,
+      "line": 801,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Gateway Password",
       "surface": "apple",
@@ -8923,7 +8923,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 764,
+      "line": 806,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Reset Onboarding",
       "surface": "apple",
@@ -8931,7 +8931,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 777,
+      "line": 819,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Voice Wake",
       "surface": "apple",
@@ -8939,7 +8939,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 780,
+      "line": 822,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Talk Mode",
       "surface": "apple",
@@ -8947,7 +8947,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 788,
+      "line": 830,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Speech Language",
       "surface": "apple",
@@ -8955,7 +8955,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 794,
+      "line": 836,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Speakerphone",
       "surface": "apple",
@@ -8963,7 +8963,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 799,
+      "line": 841,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Wake Words",
       "surface": "apple",
@@ -8971,7 +8971,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 821,
+      "line": 863,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Provider",
       "surface": "apple",
@@ -8979,7 +8979,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 827,
+      "line": 869,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Realtime Voice",
       "surface": "apple",
@@ -8987,7 +8987,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 828,
+      "line": 870,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Gateway Default",
       "surface": "apple",
@@ -8995,7 +8995,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 834,
+      "line": 876,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Voice Mode",
       "surface": "apple",
@@ -9003,7 +9003,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 836,
+      "line": 878,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Active Voice",
       "surface": "apple",
@@ -9011,7 +9011,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 839,
+      "line": 881,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Last Voice Issue",
       "surface": "apple",
@@ -9019,7 +9019,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 842,
+      "line": 884,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Transport",
       "surface": "apple",
@@ -9027,7 +9027,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 844,
+      "line": 886,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "API Key",
       "surface": "apple",
@@ -9035,7 +9035,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 854,
+      "line": 896,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Show Talk Control",
       "surface": "apple",
@@ -9043,7 +9043,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 855,
+      "line": 897,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Default Share Instruction",
       "surface": "apple",
@@ -9051,7 +9051,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 862,
+      "line": 904,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Run Share Self-Test",
       "surface": "apple",
@@ -9059,7 +9059,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 883,
+      "line": 925,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Discovery Debug Logs",
       "surface": "apple",
@@ -9067,7 +9067,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 886,
+      "line": 928,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Debug Screen Status",
       "surface": "apple",
@@ -9075,7 +9075,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 890,
+      "line": 932,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Discovery Logs",
       "surface": "apple",
@@ -9083,7 +9083,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 900,
+      "line": 942,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Device Name",
       "surface": "apple",
@@ -9091,7 +9091,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 902,
+      "line": 944,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Instance ID",
       "surface": "apple",
@@ -9099,7 +9099,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 938,
+      "line": 980,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "On",
       "surface": "apple",

--- a/apps/ios/Sources/Design/SettingsProTab.swift
+++ b/apps/ios/Sources/Design/SettingsProTab.swift
@@ -58,6 +58,7 @@ struct SettingsProTab: View {
     @State var diagnosticsLastRunText = "Not run"
     @State var diagnosticsIssueCount: Int?
     @State var showTalkIssueDetails = false
+    @State var isShowingAppearanceDialog = false
     @State private var navigationPath: [SettingsRoute] = []
     let initialRoute: SettingsRoute?
     let directRoute: SettingsRoute?
@@ -120,9 +121,6 @@ struct SettingsProTab: View {
                 ToolbarItem(placement: .topBarLeading) {
                     OpenClawSidebarHeaderLeadingSlot(action: headerLeadingAction)
                 }
-            }
-            ToolbarItem(placement: .topBarTrailing) {
-                self.appearanceMenu
             }
         }
         .navigationDestination(for: SettingsRoute.self) { route in

--- a/apps/ios/Sources/Design/SettingsProTabSections.swift
+++ b/apps/ios/Sources/Design/SettingsProTabSections.swift
@@ -2,21 +2,62 @@ import OpenClawKit
 import SwiftUI
 
 extension SettingsProTab {
-    var appearanceMenu: some View {
-        Menu {
-            Picker("Appearance", selection: self.$appearancePreferenceRaw) {
-                ForEach(AppAppearancePreference.allCases) { preference in
+    var currentAppearancePreference: AppAppearancePreference {
+        AppAppearancePreference(rawValue: self.appearancePreferenceRaw) ?? .system
+    }
+
+    var appearanceRow: some View {
+        // Menu hides its source label while open on iPad; a dialog keeps the visible row stable.
+        Button {
+            self.isShowingAppearanceDialog = true
+        } label: {
+            self.appearanceRowLabel
+        }
+        .buttonStyle(.plain)
+        .accessibilityIdentifier("settings-appearance-row")
+        .accessibilityLabel("Appearance")
+        .accessibilityValue(self.currentAppearancePreference.label)
+        .accessibilityHint("Choose system, light, or dark appearance")
+        .confirmationDialog(
+            "Appearance",
+            isPresented: self.$isShowingAppearanceDialog,
+            titleVisibility: .visible)
+        {
+            ForEach(AppAppearancePreference.allCases) { preference in
+                Button {
+                    self.appearancePreferenceRaw = preference.rawValue
+                } label: {
                     Label(preference.label, systemImage: preference.systemImage)
-                        .tag(preference.rawValue)
                 }
             }
-        } label: {
-            Label("Appearance", systemImage: "ellipsis")
-                .labelStyle(.iconOnly)
+        } message: {
+            Text("Choose system, light, or dark appearance")
         }
-        .tint(.primary)
-        .accessibilityIdentifier("settings-appearance-menu")
-        .accessibilityHint("Choose system, light, or dark appearance")
+    }
+
+    var appearanceRowLabel: some View {
+        HStack(spacing: 12) {
+            ProIconBadge(
+                systemName: "circle.lefthalf.filled",
+                color: .secondary)
+
+            Text("Appearance")
+                .font(.subheadline.weight(.semibold))
+                .foregroundStyle(.primary)
+
+            Spacer(minLength: 8)
+
+            HStack(spacing: 5) {
+                Text(self.currentAppearancePreference.label)
+                    .font(.subheadline.weight(.semibold))
+                Image(systemName: "chevron.up.chevron.down")
+                    .font(.caption2.weight(.bold))
+            }
+            .foregroundStyle(OpenClawBrand.accent)
+        }
+        .padding(.vertical, 4)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .contentShape(Rectangle())
     }
 
     var gatewaySection: some View {
@@ -105,6 +146,7 @@ extension SettingsProTab {
         }
 
         Section("Device") {
+            self.appearanceRow
             self.settingsListRow(
                 icon: "stethoscope",
                 title: "Diagnostics",

--- a/apps/ios/Tests/RootTabsSourceGuardTests.swift
+++ b/apps/ios/Tests/RootTabsSourceGuardTests.swift
@@ -259,7 +259,7 @@ struct RootTabsSourceGuardTests {
         #expect(!settingsList.contains("ProCard("))
         #expect(settingsRow.contains("NavigationLink(value: route)"))
         #expect(!settingsRow.contains("chevron.right"))
-        #expect(settingsSource.contains("settings-appearance-menu"))
+        #expect(settingsSource.contains("settings-appearance-row"))
         #expect(!settingsSource.contains(".pickerStyle(.segmented)"))
         #expect(!overviewSource.contains("ProCapsule("))
         #expect(overviewSource.contains("value: self.gatewayConnectionText"))
@@ -294,6 +294,45 @@ struct RootTabsSourceGuardTests {
         #expect(diagnosticsDestination
             .contains("self.detailRow(\"Platform\", value: DeviceInfoHelper.platformStringForDisplay())"))
         #expect(diagnosticsDestination.contains("self.detailRow(\"Model\", value: DeviceInfoHelper.modelIdentifier())"))
+    }
+
+    @Test func settingsAppearanceSelectorLivesInDeviceRow() throws {
+        let settingsSource = try String(contentsOf: Self.settingsProTabSectionsSourceURL(), encoding: .utf8)
+        let settingsTabSource = try String(contentsOf: Self.settingsProTabSourceURL(), encoding: .utf8)
+        let settingsList = try Self.extract(
+            settingsSource,
+            from: "var settingsListSection: some View",
+            to: "func settingsListRow(")
+        let appearanceRowSource = try Self.extract(
+            settingsSource,
+            from: "var appearanceRow: some View",
+            to: "var appearanceRowLabel: some View")
+
+        #expect(settingsSource.contains("var appearanceRow: some View"))
+        #expect(settingsSource.contains("var appearanceRowLabel: some View"))
+        #expect(appearanceRowSource.contains("self.isShowingAppearanceDialog = true"))
+        #expect(appearanceRowSource.contains(".confirmationDialog("))
+        #expect(appearanceRowSource.contains("self.appearancePreferenceRaw = preference.rawValue"))
+        #expect(settingsSource.contains("AppAppearancePreference(rawValue: self.appearancePreferenceRaw) ?? .system"))
+        #expect(settingsSource.contains("systemName: \"circle.lefthalf.filled\""))
+        #expect(settingsSource.contains("chevron.up.chevron.down"))
+        #expect(settingsSource.contains("settings-appearance-row"))
+        #expect(settingsSource.contains(".accessibilityValue(self.currentAppearancePreference.label)"))
+        #expect(!appearanceRowSource.contains("Menu {"))
+        #expect(!appearanceRowSource.contains("Rectangle()"))
+        #expect(!settingsSource.contains("settings-appearance-menu"))
+        #expect(!settingsSource.contains("Label(\"Appearance\", systemImage: \"ellipsis\")"))
+
+        let deviceRange = try #require(settingsList.range(of: "Section(\"Device\") {"))
+        let appearanceRange = try #require(settingsList.range(of: "self.appearanceRow"))
+        let diagnosticsRange = try #require(settingsList.range(of: "title: \"Diagnostics\""))
+        #expect(deviceRange.lowerBound < appearanceRange.lowerBound)
+        #expect(appearanceRange.lowerBound < diagnosticsRange.lowerBound)
+
+        #expect(settingsTabSource.contains("ToolbarItem(placement: .topBarLeading)"))
+        #expect(settingsTabSource.contains("@State var isShowingAppearanceDialog = false"))
+        #expect(!settingsTabSource.contains("ToolbarItem(placement: .topBarTrailing)"))
+        #expect(!settingsTabSource.contains("self.appearanceMenu"))
     }
 
     @Test func `routed headers use shared adaptive layout`() throws {

--- a/apps/ios/Tests/RootTabsSourceGuardTests.swift
+++ b/apps/ios/Tests/RootTabsSourceGuardTests.swift
@@ -239,6 +239,10 @@ struct RootTabsSourceGuardTests {
             settingsSource,
             from: "func settingsListRow(",
             to: "func destination(for route:")
+        let appearanceRow = try Self.extract(
+            settingsSource,
+            from: "var appearanceRow: some View",
+            to: "var appearanceRowLabel: some View")
 
         #expect(gatewayStatus.contains("HStack(spacing: 6)"))
         #expect(!gatewayStatus.contains("ProCapsule("))
@@ -260,7 +264,7 @@ struct RootTabsSourceGuardTests {
         #expect(settingsRow.contains("NavigationLink(value: route)"))
         #expect(!settingsRow.contains("chevron.right"))
         #expect(settingsSource.contains("settings-appearance-row"))
-        #expect(!settingsSource.contains(".pickerStyle(.segmented)"))
+        #expect(!appearanceRow.contains(".pickerStyle(.segmented)"))
         #expect(!overviewSource.contains("ProCapsule("))
         #expect(overviewSource.contains("value: self.gatewayConnectionText"))
         #expect(overviewSource.contains("switch self.gatewayDisplayState"))
@@ -294,45 +298,6 @@ struct RootTabsSourceGuardTests {
         #expect(diagnosticsDestination
             .contains("self.detailRow(\"Platform\", value: DeviceInfoHelper.platformStringForDisplay())"))
         #expect(diagnosticsDestination.contains("self.detailRow(\"Model\", value: DeviceInfoHelper.modelIdentifier())"))
-    }
-
-    @Test func settingsAppearanceSelectorLivesInDeviceRow() throws {
-        let settingsSource = try String(contentsOf: Self.settingsProTabSectionsSourceURL(), encoding: .utf8)
-        let settingsTabSource = try String(contentsOf: Self.settingsProTabSourceURL(), encoding: .utf8)
-        let settingsList = try Self.extract(
-            settingsSource,
-            from: "var settingsListSection: some View",
-            to: "func settingsListRow(")
-        let appearanceRowSource = try Self.extract(
-            settingsSource,
-            from: "var appearanceRow: some View",
-            to: "var appearanceRowLabel: some View")
-
-        #expect(settingsSource.contains("var appearanceRow: some View"))
-        #expect(settingsSource.contains("var appearanceRowLabel: some View"))
-        #expect(appearanceRowSource.contains("self.isShowingAppearanceDialog = true"))
-        #expect(appearanceRowSource.contains(".confirmationDialog("))
-        #expect(appearanceRowSource.contains("self.appearancePreferenceRaw = preference.rawValue"))
-        #expect(settingsSource.contains("AppAppearancePreference(rawValue: self.appearancePreferenceRaw) ?? .system"))
-        #expect(settingsSource.contains("systemName: \"circle.lefthalf.filled\""))
-        #expect(settingsSource.contains("chevron.up.chevron.down"))
-        #expect(settingsSource.contains("settings-appearance-row"))
-        #expect(settingsSource.contains(".accessibilityValue(self.currentAppearancePreference.label)"))
-        #expect(!appearanceRowSource.contains("Menu {"))
-        #expect(!appearanceRowSource.contains("Rectangle()"))
-        #expect(!settingsSource.contains("settings-appearance-menu"))
-        #expect(!settingsSource.contains("Label(\"Appearance\", systemImage: \"ellipsis\")"))
-
-        let deviceRange = try #require(settingsList.range(of: "Section(\"Device\") {"))
-        let appearanceRange = try #require(settingsList.range(of: "self.appearanceRow"))
-        let diagnosticsRange = try #require(settingsList.range(of: "title: \"Diagnostics\""))
-        #expect(deviceRange.lowerBound < appearanceRange.lowerBound)
-        #expect(appearanceRange.lowerBound < diagnosticsRange.lowerBound)
-
-        #expect(settingsTabSource.contains("ToolbarItem(placement: .topBarLeading)"))
-        #expect(settingsTabSource.contains("@State var isShowingAppearanceDialog = false"))
-        #expect(!settingsTabSource.contains("ToolbarItem(placement: .topBarTrailing)"))
-        #expect(!settingsTabSource.contains("self.appearanceMenu"))
     }
 
     @Test func `routed headers use shared adaptive layout`() throws {

--- a/apps/ios/Tests/SwiftUIRenderSmokeTests.swift
+++ b/apps/ios/Tests/SwiftUIRenderSmokeTests.swift
@@ -4,7 +4,7 @@ import Testing
 import UIKit
 @testable import OpenClaw
 
-@Suite struct SwiftUIRenderSmokeTests {
+struct SwiftUIRenderSmokeTests {
     @MainActor private static func host(_ view: some View, size: CGSize? = nil) -> UIWindow {
         let frame = CGRect(origin: .zero, size: size ?? UIScreen.main.bounds.size)
         let window = UIWindow(frame: frame)
@@ -15,7 +15,7 @@ import UIKit
         return window
     }
 
-    @Test @MainActor func settingsProTabBuildsAViewHierarchy() {
+    @Test @MainActor func `settings pro tab builds A view hierarchy`() {
         let appModel = NodeAppModel()
         let gatewayController = GatewayConnectionController(appModel: appModel, startDiscovery: false)
 
@@ -27,7 +27,7 @@ import UIKit
         _ = Self.host(root)
     }
 
-    @Test @MainActor func settingsProTabBuildsInLightAndDarkMode() {
+    @Test @MainActor func `settings pro tab builds in light and dark mode`() {
         for scheme in [ColorScheme.light, ColorScheme.dark] {
             let appModel = NodeAppModel()
             let gatewayController = GatewayConnectionController(appModel: appModel, startDiscovery: false)
@@ -57,7 +57,7 @@ import UIKit
         }
     }
 
-    @Test @MainActor func settingsProTabAppearanceRowBuildsForAllPreferences() throws {
+    @Test @MainActor func `settings pro tab appearance row builds for all preferences`() throws {
         for preference in AppAppearancePreference.allCases {
             let suiteName = "OpenClawTests.appearance.\(preference.rawValue).\(UUID().uuidString)"
             let defaults = try #require(UserDefaults(suiteName: suiteName))
@@ -77,7 +77,7 @@ import UIKit
         }
     }
 
-    @Test @MainActor func hostedPushRelayDisclosureBuildsAViewHierarchy() {
+    @Test @MainActor func `hosted push relay disclosure builds A view hierarchy`() {
         for typeSize in [DynamicTypeSize.large, .accessibility5] {
             let root = HostedPushRelayDisclosureSheet(
                 message: "Enabling this sends delivery data through OpenClaw's hosted push relay.",
@@ -88,7 +88,7 @@ import UIKit
         }
     }
 
-    @Test @MainActor func rootTabsBuildsDeviceOrientationShellMatrix() {
+    @Test @MainActor func `root tabs builds device orientation shell matrix`() {
         for scenario in Self.rootTabsShellScenarios() {
             let appModel = NodeAppModel()
             let gatewayController = GatewayConnectionController(appModel: appModel, startDiscovery: false)
@@ -105,7 +105,7 @@ import UIKit
         }
     }
 
-    @Test @MainActor func rootTabsBuildGatewayStateViewHierarchies() {
+    @Test @MainActor func `root tabs build gateway state view hierarchies`() {
         for appModel in Self.rootTabsGatewayStateModels() {
             let gatewayController = GatewayConnectionController(appModel: appModel, startDiscovery: false)
 
@@ -118,7 +118,7 @@ import UIKit
         }
     }
 
-    @Test @MainActor func gatewayTrustPromptAlertPresentsWhenPromptAppearsAfterInitialRender() async {
+    @Test @MainActor func `gateway trust prompt alert presents when prompt appears after initial render`() async {
         let appModel = NodeAppModel()
         let gatewayController = Self.gatewayControllerWithCapturedTLSFingerprint(appModel: appModel)
         let root = Color.clear
@@ -132,7 +132,7 @@ import UIKit
         #expect(window.rootViewController?.presentedViewController is UIAlertController)
     }
 
-    @Test @MainActor func rootPromptAlertStackPresentsGatewayTrustPrompt() async {
+    @Test @MainActor func `root prompt alert stack presents gateway trust prompt`() async {
         let appModel = NodeAppModel()
         let gatewayController = Self.gatewayControllerWithCapturedTLSFingerprint(appModel: appModel)
         let root = Color.clear
@@ -148,7 +148,7 @@ import UIKit
         #expect(window.rootViewController?.presentedViewController is UIAlertController)
     }
 
-    @Test @MainActor func rootPromptAlertStackStillPresentsDeepLinkPrompt() async throws {
+    @Test @MainActor func `root prompt alert stack still presents deep link prompt`() async throws {
         let appModel = NodeAppModel()
         appModel._test_setGatewayConnected(true)
         let gatewayController = Self.gatewayControllerWithCapturedTLSFingerprint(appModel: appModel)
@@ -186,7 +186,7 @@ import UIKit
         await controller.connectManual(host: host, port: port, useTLS: true)
     }
 
-    @Test @MainActor func phoneControlHubBuildsGatewayStateViewHierarchies() {
+    @Test @MainActor func `phone control hub builds gateway state view hierarchies`() {
         for appModel in Self.rootTabsGatewayStateModels() {
             let root = RootTabsPhoneControlHub(
                 groups: RootTabs.phoneControlGroups,
@@ -198,7 +198,7 @@ import UIKit
         }
     }
 
-    @Test @MainActor func phoneControlHubBuildsLandscapeCompactState() {
+    @Test @MainActor func `phone control hub builds landscape compact state`() {
         let appModel = NodeAppModel()
         let root = RootTabsPhoneControlHub(
             groups: RootTabs.phoneControlGroups,
@@ -211,7 +211,7 @@ import UIKit
         _ = Self.host(root)
     }
 
-    @Test @MainActor func routedSidebarScreensBuildOfflineStates() {
+    @Test @MainActor func `routed sidebar screens build offline states`() {
         let appModel = NodeAppModel()
         let screens: [AnyView] = [
             AnyView(CommandCenterTab(openChat: {}, openSettings: {})),
@@ -234,7 +234,7 @@ import UIKit
         }
     }
 
-    @Test @MainActor func taskScreensBuildPhoneLandscapeCompactStates() {
+    @Test @MainActor func `task screens build phone landscape compact states`() {
         let appModel = NodeAppModel()
         let screens: [AnyView] = [
             AnyView(IPadWorkboardScreen(openChat: {}, openSettings: {})),
@@ -251,20 +251,20 @@ import UIKit
         }
     }
 
-    @Test @MainActor func voiceWakeWordsViewBuildsAViewHierarchy() {
+    @Test @MainActor func `voice wake words view builds A view hierarchy`() {
         let appModel = NodeAppModel()
         let root = NavigationStack { VoiceWakeWordsSettingsView() }
             .environment(appModel)
         _ = Self.host(root)
     }
 
-    @Test @MainActor func voiceWakeToastBuildsAViewHierarchy() {
+    @Test @MainActor func `voice wake toast builds A view hierarchy`() {
         let root = VoiceWakeToast(command: "openclaw: do something")
         _ = Self.host(root)
     }
 
     @MainActor private static func waitForPresentedAlert(in window: UIWindow) async {
-        for _ in 0 ..< 10 {
+        for _ in 0..<10 {
             if window.rootViewController?.presentedViewController != nil { return }
             await Task.yield()
             try? await Task.sleep(nanoseconds: 50_000_000)

--- a/apps/ios/Tests/SwiftUIRenderSmokeTests.swift
+++ b/apps/ios/Tests/SwiftUIRenderSmokeTests.swift
@@ -57,6 +57,26 @@ import UIKit
         }
     }
 
+    @Test @MainActor func settingsProTabAppearanceRowBuildsForAllPreferences() throws {
+        for preference in AppAppearancePreference.allCases {
+            let suiteName = "OpenClawTests.appearance.\(preference.rawValue).\(UUID().uuidString)"
+            let defaults = try #require(UserDefaults(suiteName: suiteName))
+            defer { defaults.removePersistentDomain(forName: suiteName) }
+            defaults.set(preference.rawValue, forKey: AppAppearancePreference.storageKey)
+
+            let appModel = NodeAppModel()
+            let gatewayController = GatewayConnectionController(appModel: appModel, startDiscovery: false)
+
+            let root = SettingsProTab()
+                .defaultAppStorage(defaults)
+                .environment(appModel)
+                .environment(appModel.voiceWake)
+                .environment(gatewayController)
+
+            _ = Self.host(root)
+        }
+    }
+
     @Test @MainActor func hostedPushRelayDisclosureBuildsAViewHierarchy() {
         for typeSize in [DynamicTypeSize.large, .accessibility5] {
             let root = HostedPushRelayDisclosureSheet(

--- a/apps/ios/UITests/OpenClawSnapshotUITests.swift
+++ b/apps/ios/UITests/OpenClawSnapshotUITests.swift
@@ -248,17 +248,18 @@ final class OpenClawSnapshotUITests: XCTestCase {
         XCTAssertNotEqual(speakerphone.value as? String, initialValue)
     }
 
-    func testAppearanceUsesToolbarMenu() throws {
+    func testAppearanceUsesSettingsRow() throws {
         try XCTSkipIf(UIDevice.current.userInterfaceIdiom != .phone, "Phone Settings proof only")
         self.launchApp(for: ScreenshotTarget(
             initialTab: "settings",
             initialDestination: "settings",
             name: "appearance-compact"))
 
-        let menu = try XCTUnwrap(app?.buttons["settings-appearance-menu"])
-        XCTAssertTrue(menu.waitForExistence(timeout: 8))
+        let row = try XCTUnwrap(self.app?.buttons["settings-appearance-row"])
+        XCTAssertTrue(row.waitForExistence(timeout: 8))
+        XCTAssertFalse(self.app?.buttons["settings-appearance-menu"].exists == true)
         XCTAssertFalse(self.app?.segmentedControls["settings-appearance-picker"].exists == true)
-        menu.tap()
+        row.tap()
         XCTAssertTrue(self.app?.buttons["System"].waitForExistence(timeout: 3) == true)
         XCTAssertTrue(self.app?.buttons["Light"].exists == true)
         XCTAssertTrue(self.app?.buttons["Dark"].exists == true)

--- a/apps/ios/UITests/OpenClawSnapshotUITests.swift
+++ b/apps/ios/UITests/OpenClawSnapshotUITests.swift
@@ -253,17 +253,31 @@ final class OpenClawSnapshotUITests: XCTestCase {
         self.launchApp(for: ScreenshotTarget(
             initialTab: "settings",
             initialDestination: "settings",
-            name: "appearance-compact"))
+            name: "appearance-compact"), appearance: nil)
 
         let row = try XCTUnwrap(self.app?.buttons["settings-appearance-row"])
         XCTAssertTrue(row.waitForExistence(timeout: 8))
         XCTAssertFalse(self.app?.buttons["settings-appearance-menu"].exists == true)
         XCTAssertFalse(self.app?.segmentedControls["settings-appearance-picker"].exists == true)
+
         row.tap()
         XCTAssertTrue(self.app?.buttons["System"].waitForExistence(timeout: 3) == true)
         XCTAssertTrue(self.app?.buttons["Light"].exists == true)
         XCTAssertTrue(self.app?.buttons["Dark"].exists == true)
-        self.attachScreenshot(named: "appearance-menu")
+        self.app?.buttons["System"].firstMatch.tap()
+        self.waitForValue("System", of: row)
+        self.attachScreenshot(named: "appearance-system")
+
+        row.tap()
+        XCTAssertTrue(self.app?.buttons["Dark"].waitForExistence(timeout: 3) == true)
+        self.app?.buttons["Dark"].firstMatch.tap()
+        self.waitForValue("Dark", of: row)
+        self.attachScreenshot(named: "appearance-dark")
+
+        row.tap()
+        XCTAssertTrue(self.app?.buttons["System"].waitForExistence(timeout: 3) == true)
+        self.app?.buttons["System"].firstMatch.tap()
+        self.waitForValue("System", of: row)
     }
 
     func testAgentUsesToolbarFilter() throws {
@@ -336,6 +350,13 @@ final class OpenClawSnapshotUITests: XCTestCase {
         self.app = app
 
         XCTAssertTrue(app.wait(for: .runningForeground, timeout: 8))
+    }
+
+    private func waitForValue(_ value: String, of element: XCUIElement) {
+        let expectation = XCTNSPredicateExpectation(
+            predicate: NSPredicate(format: "value == %@", value),
+            object: element)
+        XCTAssertEqual(XCTWaiter.wait(for: [expectation], timeout: 3), .completed)
     }
 
     private func launchPairedLiveGatewayApp(


### PR DESCRIPTION
Closes #98995

## What Problem This Solves

Fixes an issue where users opening iOS Settings would find the appearance selector hidden behind a top-right ellipsis toolbar button, making the control hard to discover and hiding the current selected mode until interaction.

On iPad, the toolbar button also appeared visually detached from the Settings content. During implementation, the row-based menu presentation exposed another iPad bug where tapping the Appearance row caused the row content to disappear while the options were open.

## Why This Change Was Made

The appearance selector now lives as a visible `Appearance` row inside the Settings `Device` section, showing the current value (`System`, `Light`, or `Dark`) without requiring a tap. The row opens the same appearance choices using the existing stored preference behavior, while removing the top-right ellipsis toolbar control.

## User Impact

Users can now discover and change appearance mode from a normal Settings row. The selected mode is visible at a glance, the iPad toolbar no longer shows a detached ellipsis control, and the Appearance row remains visible while choosing an option.

## Evidence

Focused verification:
- `xcodebuild test -project apps/ios/OpenClaw.xcodeproj -scheme OpenClawUITests -destination 'platform=iOS Simulator,name=iPhone 17 Pro' -only-testing:OpenClawUITests/OpenClawSnapshotUITests/testAppearanceUsesSettingsRow`
- `xcodebuild test -project apps/ios/OpenClaw.xcodeproj -scheme OpenClaw -destination 'platform=iOS Simulator,name=iPhone 17 Pro' -only-testing:OpenClawTests/SwiftUIRenderSmokeTests`
- `xcodebuild test -project apps/ios/OpenClaw.xcodeproj -scheme OpenClawLogicTests -destination 'platform=iOS Simulator,name=iPhone 17 Pro'`
- `git diff --check`
- `codex review --base origin/main`

### iPhone Settings

| Before | After |
| --- | --- |
| <img width="260" alt="iphone-settings-appearance-menu-before" src="https://github.com/user-attachments/assets/00525acb-4fb9-4113-953a-f9d47ef66160" /> | <img width="260" alt="iphone-settings-appearance-row-after" src="https://github.com/user-attachments/assets/0007aed9-6c86-4556-9e41-9bcccde34e4c" /> |

### iPhone Appearance Options

| Before | After |
| --- | --- |
| <img width="260" alt="iphone-settings-appearance-menu-before" src="https://github.com/user-attachments/assets/cf4267d1-c5a7-43a4-9e32-c096495cd268" /> | <img width="260" alt="iphone-settings-appearance-row-menu-after" src="https://github.com/user-attachments/assets/1b26f1c5-5f02-425c-af3a-34fdeaee3176" /> |

### iPad Settings

| Before | After |
| --- | --- |
| <img width="300" alt="ipad-settings-appearance-button-before" src="https://github.com/user-attachments/assets/09d728a0-66df-4396-aecb-6f29b5527239" /> | <img width="300" alt="ipad-settings-appearance-row-after" src="https://github.com/user-attachments/assets/3a560c52-6d77-4511-9623-1e9b41c0b390" /> |

### iPad Appearance Options

| Before | After |
| --- | --- |
| <img width="300" alt="ipad-settings-appearance-menu-before" src="https://github.com/user-attachments/assets/c731109a-c942-4d36-9c5c-c216135ad644" /> | <img width="300" alt="ipad-settings-appearance-row-menu-after-fixed" src="https://github.com/user-attachments/assets/263bb5cc-ad46-44b0-97e5-9211e35aee39" /> |

Notes:
- The broader `RootTabsSourceGuardTests` slice still has two unrelated existing failures outside this change.
- Screenshot files are local evidence only and are not committed.