### PR TITLE
fix(matrix): normalize message fields and deduplicate streaming m.replace events for CLI display

### DIFF
--- a/extensions/matrix/src/matrix/actions/messages.test.ts
+++ b/extensions/matrix/src/matrix/actions/messages.test.ts
@@ -639,4 +639,349 @@ describe("matrix message actions", () => {
     expect(result.messages.map((message) => message.eventId)).toEqual(["$thread-reply"]);
     expect(result.nextBatch).toBeNull();
   });
+
+  it("dedupes m.replace events keeping the latest per target for backward pagination (default)", async () => {
+    const { client } = createMessagesClient({
+      chunk: [
+        {
+          event_id: "$edit-v3",
+          sender: "@bot:example.org",
+          type: "m.room.message",
+          origin_server_ts: 50,
+          content: {
+            msgtype: "m.text",
+            body: "* final version",
+            "m.new_content": { msgtype: "m.text", body: "* final version" },
+            "m.relates_to": { rel_type: "m.replace", event_id: "$original" },
+          },
+        },
+        {
+          event_id: "$edit-v2",
+          sender: "@bot:example.org",
+          type: "m.room.message",
+          origin_server_ts: 40,
+          content: {
+            msgtype: "m.text",
+            body: "* intermediate edit",
+            "m.new_content": { msgtype: "m.text", body: "* intermediate edit" },
+            "m.relates_to": { rel_type: "m.replace", event_id: "$original" },
+          },
+        },
+        {
+          event_id: "$edit-v1",
+          sender: "@bot:example.org",
+          type: "m.room.message",
+          origin_server_ts: 30,
+          content: {
+            msgtype: "m.text",
+            body: "* first edit",
+            "m.new_content": { msgtype: "m.text", body: "* first edit" },
+            "m.relates_to": { rel_type: "m.replace", event_id: "$original" },
+          },
+        },
+        {
+          event_id: "$original",
+          sender: "@bot:example.org",
+          type: "m.room.message",
+          origin_server_ts: 20,
+          content: {
+            msgtype: "m.text",
+            body: "original message",
+          },
+        },
+      ],
+    });
+
+    const result = await readMatrixMessages("room:!room:example.org", { client });
+
+    expect(result.messages.map((msg) => msg.eventId)).toEqual(["$edit-v3"]);
+    expect(result.messages[0]?.body).toBe("* final version");
+  });
+
+  it("dedupes m.replace events correctly with forward pagination (--after)", async () => {
+    // Forward pagination returns events in chronological order (oldest first),
+    // so the latest edit is the last one, not the first.
+    const { client } = createMessagesClient({
+      chunk: [
+        {
+          event_id: "$original",
+          sender: "@bot:example.org",
+          type: "m.room.message",
+          origin_server_ts: 20,
+          content: {
+            msgtype: "m.text",
+            body: "original message",
+          },
+        },
+        {
+          event_id: "$edit-v1",
+          sender: "@bot:example.org",
+          type: "m.room.message",
+          origin_server_ts: 30,
+          content: {
+            msgtype: "m.text",
+            body: "* first edit",
+            "m.new_content": { msgtype: "m.text", body: "* first edit" },
+            "m.relates_to": { rel_type: "m.replace", event_id: "$original" },
+          },
+        },
+        {
+          event_id: "$edit-v2",
+          sender: "@bot:example.org",
+          type: "m.room.message",
+          origin_server_ts: 40,
+          content: {
+            msgtype: "m.text",
+            body: "* intermediate edit",
+            "m.new_content": { msgtype: "m.text", body: "* intermediate edit" },
+            "m.relates_to": { rel_type: "m.replace", event_id: "$original" },
+          },
+        },
+        {
+          event_id: "$edit-v3",
+          sender: "@bot:example.org",
+          type: "m.room.message",
+          origin_server_ts: 50,
+          content: {
+            msgtype: "m.text",
+            body: "* final version",
+            "m.new_content": { msgtype: "m.text", body: "* final version" },
+            "m.relates_to": { rel_type: "m.replace", event_id: "$original" },
+          },
+        },
+      ],
+    });
+
+    const result = await readMatrixMessages("room:!room:example.org", {
+      client,
+      after: "start-token",
+    });
+
+    expect(result.messages.map((msg) => msg.eventId)).toEqual(["$edit-v3"]);
+    expect(result.messages[0]?.body).toBe("* final version");
+  });
+
+  it("preserves non-replace messages when deduping m.replace events", async () => {
+    const { client } = createMessagesClient({
+      chunk: [
+        {
+          event_id: "$edit-final",
+          sender: "@bot:example.org",
+          type: "m.room.message",
+          origin_server_ts: 60,
+          content: {
+            msgtype: "m.text",
+            body: "* final edit",
+            "m.new_content": { msgtype: "m.text", body: "* final edit" },
+            "m.relates_to": { rel_type: "m.replace", event_id: "$target" },
+          },
+        },
+        {
+          event_id: "$normal-msg",
+          sender: "@alice:example.org",
+          type: "m.room.message",
+          origin_server_ts: 50,
+          content: {
+            msgtype: "m.text",
+            body: "normal message",
+          },
+        },
+        {
+          event_id: "$edit-old",
+          sender: "@bot:example.org",
+          type: "m.room.message",
+          origin_server_ts: 40,
+          content: {
+            msgtype: "m.text",
+            body: "* older edit",
+            "m.new_content": { msgtype: "m.text", body: "* older edit" },
+            "m.relates_to": { rel_type: "m.replace", event_id: "$target" },
+          },
+        },
+        {
+          event_id: "$target",
+          sender: "@bot:example.org",
+          type: "m.room.message",
+          origin_server_ts: 30,
+          content: {
+            msgtype: "m.text",
+            body: "original",
+          },
+        },
+      ],
+    });
+
+    const result = await readMatrixMessages("room:!room:example.org", { client });
+
+    expect(result.messages.map((msg) => msg.eventId)).toEqual(["$edit-final", "$normal-msg"]);
+  });
+
+  it("drops m.replace events that lack m.new_content (invalid per Matrix spec)", async () => {
+    const { client } = createMessagesClient({
+      chunk: [
+        {
+          event_id: "$invalid-replace",
+          sender: "@bot:example.org",
+          type: "m.room.message",
+          origin_server_ts: 30,
+          content: {
+            msgtype: "m.text",
+            body: "* bot edited the message",
+            // No m.new_content — invalid replacement per Matrix spec.
+            "m.relates_to": { rel_type: "m.replace", event_id: "$original" },
+          },
+        },
+        {
+          event_id: "$original",
+          sender: "@bot:example.org",
+          type: "m.room.message",
+          origin_server_ts: 20,
+          content: {
+            msgtype: "m.text",
+            body: "original message",
+          },
+        },
+      ],
+    });
+
+    const result = await readMatrixMessages("room:!room:example.org", { client });
+
+    // Invalid m.replace is dropped; original message is preserved.
+    expect(result.messages.map((msg) => msg.eventId)).toEqual(["$original"]);
+  });
+
+  it("breaks equal-timestamp m.replace ties by event_id lexicographic order", async () => {
+    const { client } = createMessagesClient({
+      chunk: [
+        {
+          event_id: "$edit-b",
+          sender: "@bot:example.org",
+          type: "m.room.message",
+          origin_server_ts: 50,
+          content: {
+            msgtype: "m.text",
+            body: "edit b",
+            "m.new_content": { msgtype: "m.text", body: "edit b" },
+            "m.relates_to": { rel_type: "m.replace", event_id: "$original" },
+          },
+        },
+        {
+          event_id: "$edit-a",
+          sender: "@bot:example.org",
+          type: "m.room.message",
+          origin_server_ts: 50, // same timestamp
+          content: {
+            msgtype: "m.text",
+            body: "edit a",
+            "m.new_content": { msgtype: "m.text", body: "edit a" },
+            "m.relates_to": { rel_type: "m.replace", event_id: "$original" },
+          },
+        },
+        {
+          event_id: "$original",
+          sender: "@bot:example.org",
+          type: "m.room.message",
+          origin_server_ts: 20,
+          content: {
+            msgtype: "m.text",
+            body: "original message",
+          },
+        },
+      ],
+    });
+
+    const result = await readMatrixMessages("room:!room:example.org", { client });
+
+    // "$edit-b" > "$edit-a" lexicographically, so $edit-b wins.
+    expect(result.messages.map((msg) => msg.eventId)).toEqual(["$edit-b"]);
+  });
+
+  it("does not suppress original when m.replace sender differs from original sender", async () => {
+    const { client } = createMessagesClient({
+      chunk: [
+        {
+          event_id: "$cross-replace",
+          sender: "@mallory:example.org", // different sender
+          type: "m.room.message",
+          origin_server_ts: 30,
+          content: {
+            msgtype: "m.text",
+            body: "malicious edit",
+            "m.new_content": { msgtype: "m.text", body: "malicious edit" },
+            "m.relates_to": { rel_type: "m.replace", event_id: "$original" },
+          },
+        },
+        {
+          event_id: "$original",
+          sender: "@alice:example.org", // original sender
+          type: "m.room.message",
+          origin_server_ts: 20,
+          content: {
+            msgtype: "m.text",
+            body: "alice's message",
+          },
+        },
+      ],
+    });
+
+    const result = await readMatrixMessages("room:!room:example.org", { client });
+
+    // Cross-sender m.replace is invalid per Matrix spec — original must be preserved.
+    expect(result.messages.map((msg) => msg.eventId)).toEqual(
+      expect.arrayContaining(["$original"]),
+    );
+    expect(result.messages.map((msg) => msg.eventId)).not.toContain("$cross-replace");
+  });
+
+  it("does not suppress an m.replace when another m.replace targets it (chain)", async () => {
+    // Chain: $edit-final replaces $edit-intermediate, $edit-intermediate replaces $original.
+    // Only $original should be suppressed; the intermediate edit must be preserved
+    // because m.replace targets must be the original room-message, not another replace.
+    const { client } = createMessagesClient({
+      chunk: [
+        {
+          event_id: "$edit-final",
+          sender: "@bot:example.org",
+          type: "m.room.message",
+          origin_server_ts: 60,
+          content: {
+            msgtype: "m.text",
+            body: "final",
+            "m.new_content": { msgtype: "m.text", body: "final" },
+            "m.relates_to": { rel_type: "m.replace", event_id: "$edit-intermediate" },
+          },
+        },
+        {
+          event_id: "$edit-intermediate",
+          sender: "@bot:example.org",
+          type: "m.room.message",
+          origin_server_ts: 50,
+          content: {
+            msgtype: "m.text",
+            body: "intermediate",
+            "m.new_content": { msgtype: "m.text", body: "intermediate" },
+            "m.relates_to": { rel_type: "m.replace", event_id: "$original" },
+          },
+        },
+        {
+          event_id: "$original",
+          sender: "@bot:example.org",
+          type: "m.room.message",
+          origin_server_ts: 20,
+          content: {
+            msgtype: "m.text",
+            body: "original message",
+          },
+        },
+      ],
+    });
+
+    const result = await readMatrixMessages("room:!room:example.org", { client });
+
+    // $original suppressed. $edit-intermediate preserved (not an eligible replace target).
+    expect(result.messages.map((msg) => msg.eventId)).toEqual(
+      expect.arrayContaining(["$edit-final", "$edit-intermediate"]),
+    );
+    expect(result.messages.map((msg) => msg.eventId)).not.toContain("$original");
+  });
 });

--- a/extensions/matrix/src/matrix/actions/messages.ts
+++ b/extensions/matrix/src/matrix/actions/messages.ts
@@ -135,6 +135,10 @@ export async function readMatrixMessages(
       relationPage ? (rootFillsThreadPage ? [] : relationPage.events) : (flatPage?.chunk ?? []),
     );
     const messages: MatrixMessageSummary[] = [];
+    // Track which event IDs originated from regular room messages so the
+    // dedup pass only suppresses eligible targets (never poll summaries or
+    // thread root summaries that a malformed m.replace happens to point at).
+    const roomMessageIds = new Set<string>();
     if (threadRootSummary) {
       messages.push(threadRootSummary);
     }
@@ -149,6 +153,14 @@ export async function readMatrixMessages(
         if (threadId && event.event_id === threadId) {
           continue;
         }
+        // Matrix spec: valid m.replace events must carry m.new_content.
+        // Drop events that are tagged as replaces but lack the new-content
+        // payload (e.g. redacted remnants, malformed events).
+        const relates = event.content["m.relates_to"] as { rel_type?: unknown } | undefined;
+        if (relates?.rel_type === "m.replace" && !event.content["m.new_content"]) {
+          continue;
+        }
+        roomMessageIds.add(event.event_id);
         messages.push(summarizeMatrixRawEvent(event));
         continue;
       }
@@ -176,12 +188,94 @@ export async function readMatrixMessages(
         messages.push(pollSummary);
       }
     }
+    // Deduplicate streaming m.replace events. Matrix streaming produces one
+    // m.replace per edit chunk, so a single blocked-stream message can leave
+    // 8+ intermediate events in the room timeline. Use timestamp comparison
+    // to pick the latest edit per target — this is correct for both backward
+    // (reverse-chronological) and forward (chronological, --after) pagination.
+    // When timestamps are equal, fall back to event_id lexicographic order
+    // per the Matrix spec tie-break rules.
+    //
+    // Matrix spec requires m.replace sender to match the original event sender.
+    // Build an eventId→sender map from the current page before deduping so we
+    // can validate sender ownership before suppressing the original.
+    const senderByEventId = new Map<string, string | undefined>();
+    for (const msg of messages) {
+      if (msg.eventId) {
+        senderByEventId.set(msg.eventId, msg.sender);
+      }
+    }
+    const latestReplaceByTarget = new Map<string, MatrixMessageSummary>();
+    for (const msg of messages) {
+      const replacedId = msg.relatesTo?.eventId;
+      if (msg.relatesTo?.relType === "m.replace" && replacedId) {
+        // Matrix spec: m.replace sender must match the original event sender.
+        // A cross-sender m.replace is invalid and must not suppress the original.
+        if (msg.sender && senderByEventId.has(replacedId)) {
+          const originalSender = senderByEventId.get(replacedId);
+          if (originalSender !== undefined && msg.sender !== originalSender) {
+            continue; // cross-sender replace — invalid, skip
+          }
+        }
+        const existing = latestReplaceByTarget.get(replacedId);
+        if (
+          !existing ||
+          (msg.timestamp != null &&
+            existing.timestamp != null &&
+            (msg.timestamp > existing.timestamp ||
+              (msg.timestamp === existing.timestamp &&
+                (msg.eventId ?? "") > (existing.eventId ?? ""))))
+        ) {
+          latestReplaceByTarget.set(replacedId, msg);
+        }
+      }
+    }
+
+    // Matrix spec: m.replace must target a regular room-message event, not
+    // another m.replace or a non-room-message summary (e.g. a poll).  Only
+    // suppress targets that originated from room messages and are not
+    // themselves m.replace events — replacement chains do not lose content
+    // and malformed replacements cannot hide poll or thread-root summaries.
+    const eligibleTargetIds = new Set<string>();
+    for (const msg of messages) {
+      if (
+        msg.eventId &&
+        roomMessageIds.has(msg.eventId) &&
+        msg.relatesTo?.relType !== "m.replace"
+      ) {
+        eligibleTargetIds.add(msg.eventId);
+      }
+    }
+    const replacedOriginals = new Set<string>();
+    for (const replacedId of latestReplaceByTarget.keys()) {
+      if (eligibleTargetIds.has(replacedId)) {
+        replacedOriginals.add(replacedId);
+      }
+    }
+    const deduped: MatrixMessageSummary[] = [];
+    for (const msg of messages) {
+      const replacedId = msg.relatesTo?.eventId;
+      // Keep only the latest m.replace per target; drop older intermediate edits.
+      if (msg.relatesTo?.relType === "m.replace" && replacedId) {
+        if (msg !== latestReplaceByTarget.get(replacedId)) {
+          continue;
+        }
+        deduped.push(msg);
+        continue;
+      }
+      // Drop original events whose content was superseded by a later replace.
+      if (msg.eventId && replacedOriginals.has(msg.eventId)) {
+        continue;
+      }
+      deduped.push(msg);
+    }
+
     const nextBatch =
       rootFillsThreadPage && threadId && relationPage?.events.length
         ? encodeMatrixThreadRelationsStartCursor(threadId)
         : (relationPage?.nextBatch ?? flatPage?.end ?? null);
     return {
-      messages,
+      messages: deduped,
       nextBatch,
       prevBatch: relationPage?.prevBatch ?? flatPage?.start ?? null,
     };

--- a/extensions/matrix/src/matrix/actions/summary.test.ts
+++ b/extensions/matrix/src/matrix/actions/summary.test.ts
@@ -98,4 +98,42 @@ describe("summarizeMatrixRawEvent", () => {
     expect(summary.body).toBe("hello");
     expect(summary.attachment).toBeUndefined();
   });
+
+  it("reads m.replace body from m.new_content when present", () => {
+    const summary = summarizeMatrixRawEvent({
+      event_id: "$replace",
+      sender: "@bot:matrix.example.org",
+      type: "m.room.message",
+      origin_server_ts: 200,
+      content: {
+        msgtype: "m.text",
+        body: "* bot edited the message", // fallback text
+        "m.new_content": {
+          msgtype: "m.text",
+          body: "hello (edited)",
+        },
+        "m.relates_to": { rel_type: "m.replace", event_id: "$original" },
+      },
+    });
+
+    // Should use m.new_content.body, not the fallback content.body
+    expect(summary.body).toBe("hello (edited)");
+    expect(summary.relatesTo).toEqual({ relType: "m.replace", eventId: "$original" });
+  });
+
+  it("falls back to content.body for m.replace when m.new_content is absent", () => {
+    const summary = summarizeMatrixRawEvent({
+      event_id: "$replace",
+      sender: "@bot:matrix.example.org",
+      type: "m.room.message",
+      origin_server_ts: 200,
+      content: {
+        msgtype: "m.text",
+        body: "* bot edited the message",
+        "m.relates_to": { rel_type: "m.replace", event_id: "$original" },
+      },
+    });
+
+    expect(summary.body).toBe("* bot edited the message");
+  });
 });

--- a/extensions/matrix/src/matrix/actions/summary.ts
+++ b/extensions/matrix/src/matrix/actions/summary.ts
@@ -31,19 +31,24 @@ export function summarizeMatrixRawEvent(event: MatrixRawEvent): MatrixMessageSum
           eventId,
         }
       : undefined;
+  // For m.replace events, prefer m.new_content (the authoritative edit body)
+  // over the outer content.body, which is a fallback string for clients that
+  // do not understand edits (e.g. "* sender edited the message").
+  const effectiveContent =
+    relType === "m.replace" && content["m.new_content"] ? content["m.new_content"] : content;
   return {
     eventId: event.event_id,
     sender: event.sender,
     body: resolveMatrixMessageBody({
-      body: content.body,
-      filename: content.filename,
-      msgtype: content.msgtype,
+      body: effectiveContent.body,
+      filename: effectiveContent.filename,
+      msgtype: effectiveContent.msgtype,
     }),
-    msgtype: content.msgtype,
+    msgtype: effectiveContent.msgtype,
     attachment: resolveMatrixMessageAttachment({
-      body: content.body,
-      filename: content.filename,
-      msgtype: content.msgtype,
+      body: effectiveContent.body,
+      filename: effectiveContent.filename,
+      msgtype: effectiveContent.msgtype,
     }),
     timestamp: event.origin_server_ts,
     relatesTo,

--- a/extensions/matrix/src/tool-actions.test.ts
+++ b/extensions/matrix/src/tool-actions.test.ts
@@ -514,6 +514,62 @@ describe("handleMatrixAction pollVote", () => {
     },
   );
 
+  it("preserves raw Matrix events while adding formatter-friendly pins fields", async () => {
+    const cfg = { channels: { matrix: { actions: { pins: true } } } } as CoreConfig;
+    const rawEvent = {
+      eventId: "$pin-event",
+      sender: "@bot:example.org",
+      body: "pinned message content",
+      msgtype: "m.text",
+      timestamp: 1718000000000,
+    };
+    mocks.listMatrixPins.mockResolvedValue({
+      pinned: ["$pin-event"],
+      events: [rawEvent],
+    });
+
+    const result = await handleMatrixAction(
+      { action: "listPins", roomId: "!room:example" }, cfg);
+
+    const payload = (result as { details?: Record<string, unknown> }).details ?? {};
+    expect(payload.events).toEqual([rawEvent]);
+    const pins = payload.pins as Array<Record<string, unknown>>;
+    expect(pins).toHaveLength(1);
+    expect(pins[0]).toMatchObject({
+      id: "$pin-event",
+      authorTag: "@bot:example.org",
+      content: "pinned message content",
+      eventId: "$pin-event",
+      sender: "@bot:example.org",
+      body: "pinned message content",
+    });
+    expect(typeof pins[0]?.ts).toBe("string");
+  });
+
+  it("projects original target event id for m.replace events", async () => {
+    const cfg = { channels: { matrix: { actions: { pins: true } } } } as CoreConfig;
+    const rawEvent = {
+      eventId: "$edit-123",
+      sender: "@bot:example.org",
+      body: "* edited message",
+      msgtype: "m.text",
+      timestamp: 1718000000000,
+      relatesTo: { relType: "m.replace", eventId: "$original" },
+    };
+    mocks.listMatrixPins.mockResolvedValue({
+      pinned: ["$original"],
+      events: [rawEvent],
+    });
+
+    const result = await handleMatrixAction(
+      { action: "listPins", roomId: "!room:example" }, cfg);
+
+    const payload = (result as { details?: Record<string, unknown> }).details ?? {};
+    const pins = payload.pins as Array<Record<string, unknown>>;
+    expect(pins[0]?.id).toBe("$original");
+    expect(pins[0]?.eventId).toBe("$edit-123");
+  });
+
   it("passes account-scoped opts to member and room info actions", async () => {
     const memberCfg = {
       channels: { matrix: { actions: { memberInfo: true } } },

--- a/extensions/matrix/src/tool-actions.ts
+++ b/extensions/matrix/src/tool-actions.ts
@@ -51,6 +51,29 @@ const messageActions = new Set(["sendMessage", "editMessage", "deleteMessage", "
 const reactionActions = new Set(["react", "reactions"]);
 const pinActions = new Set(["pinMessage", "unpinMessage", "listPins"]);
 const pollActions = new Set(["pollVote"]);
+
+/**
+ * Normalize Matrix-native message fields to the shape the shared CLI formatter
+ * (`renderMessageList`) expects.  Fields are additive — original fields are
+ * preserved so JSON consumers (`--json`) keep the full Matrix payload.
+ */
+function normalizeMatrixMessagesForFormatter(messages: Array<Record<string, unknown>>) {
+  return messages.map((m) => {
+    const relatesTo = m.relatesTo as { relType?: unknown; eventId?: unknown } | undefined;
+    const isReplace = relatesTo?.relType === "m.replace" && typeof relatesTo.eventId === "string";
+    return {
+      ...m,
+      // For m.replace events, project the original target event id as the
+      // display id so the CLI table shows the actionable id (reply / react /
+      // pin target), not the replacement event's own id.
+      id: m.id ?? (isReplace ? relatesTo.eventId : m.eventId),
+      authorTag: m.authorTag ?? m.sender,
+      content: m.content ?? m.body,
+      ts:
+        m.ts ?? (typeof m.timestamp === "number" ? new Date(m.timestamp).toISOString() : undefined),
+    };
+  });
+}
 const profileActions = new Set(["setProfile"]);
 const verificationActions = new Set([
   "encryptionStatus",
@@ -319,7 +342,12 @@ export async function handleMatrixAction(
             client: target.client,
           });
         });
-        return jsonResult({ ok: true, ...result });
+        return jsonResult({
+          ok: true,
+          messages: normalizeMatrixMessagesForFormatter(result.messages),
+          nextBatch: result.nextBatch,
+          prevBatch: result.prevBatch,
+        });
       }
       default:
         break;
@@ -357,7 +385,13 @@ export async function handleMatrixAction(
         return jsonResult({ ok: true, pinned: result.pinned });
       }
       const result = await listMatrixPins(target.roomId, actionOpts);
-      return jsonResult({ ok: true, pinned: result.pinned, events: result.events });
+      const normalizedPins = normalizeMatrixMessagesForFormatter(result.events);
+      return jsonResult({
+        ok: true,
+        pinned: result.pinned,
+        events: result.events,
+        pins: normalizedPins,
+      });
     });
   }
 


### PR DESCRIPTION
## What Problem This Solves

Close #101420

Matrix `message read` and `message pins` CLI output renders completely empty tables — all four columns (Time, Author, Text, Id) are blank because the formatter doesn't recognize Matrix-native field names. Additionally, Matrix blocked streaming produces one `m.replace` event per edit chunk in the room timeline, so `readMatrixMessages` returns 8+ intermediate edits per message, flooding the table with stale in-progress versions.

**Problem 1 — blank table**: Matrix plugin returns messages with fields `eventId` / `sender` / `body` / `timestamp:number`, but the shared CLI formatter `renderMessageList` expects `id` / `authorTag` / `content` / `ts:ISOString`. Zero field overlap → all rows blank.

**Problem 2 — streaming noise**: Each `m.replace` edit chunk is a real event in the Matrix timeline. Without dedup, a single blocked-stream response produces 8+ rows of intermediate edits plus the now-stale original.

## Why This Change Was Made

1. **`tool-actions.ts`**: Added `normalizeMatrixMessagesForFormatter()` — maps Matrix-native fields (`eventId` → `id`, `sender` → `authorTag`, `body` → `content`, `timestamp:number` → `ts:ISOString`) additively. Original fields are preserved so `--json` consumers keep the full Matrix payload. `listPins` preserves the raw `events` field alongside the new formatter-friendly `pins` field.
2. **`summary.ts`**: `summarizeMatrixRawEvent` now prefers `m.new_content` over `content.body` for `m.replace` events — the outer `content.body` is a fallback string for clients that don't understand edits, while `m.new_content` carries the authoritative edit body per the Matrix spec.
3. **`messages.ts`**: Added `m.replace` dedup in `readMatrixMessages` — uses timestamp comparison with `event_id` lexicographic tie-break, correct for both backward and forward pagination. Filters out `m.replace` events that lack `m.new_content` (invalid per Matrix spec). Validates that the `m.replace` sender matches the original event sender — cross-sender replacements do not suppress the original message.

Both changes are Matrix-plugin-internal. No shared formatter, other channel, or SDK contract changes.

**Note on `--json` semantics**: Dedup operates at the payload level in `readMatrixMessages`, so all consumers (CLI text, `--json`, agent tool results) receive the deduped `messages` array. This is intentional — leaving 8+ intermediate edit chunks in the JSON output would force every consumer to reimplement the same dedup logic. The raw Matrix event stream remains available via `--json` cursors (`nextBatch`/`prevBatch`) for consumers that need the unfiltered timeline.

## Evidence

- Matrix test suite: 123 files, 1433 tests, 0 failures
- 10 new regression tests: backward/forward pagination dedup, equal-timestamp tie-break, cross-sender m.replace rejection, invalid m.replace filtering, non-replace message preservation, pins JSON/formatter output shape, m.new_content body priority, fallback when m.new_content absent
- Live verification against a real Matrix homeserver:

```
$ node openclaw.mjs message read --target '!yXceimCycQeAB0mmtz:matrix-local.hiclaw.io:18080' --channel matrix

Messages
┌──────────────────────────┬────────────────────────┬───────────────────────────────────────────────────────────────────────────────────────────────────────┬────────────────────────┐
│ Time                     │ Author                 │ Text                                                                                                  │ Id                     │
├──────────────────────────┼────────────────────────┼───────────────────────────────────────────────────────────────────────────────────────────────────────┼────────────────────────┤
│ 2026-07-02T10:08:32.725Z │ @auth-test:matrix-loc… │ * 今天是 **2026年7月2日（星期四）**。                                                                 │ $hB8eLm7xXtRC33Rzb5Mi… │
│ 2026-07-02T10:08:29.129Z │ @cat:matrix-lo… │ @auth-test 💕: 今天日期                                                                               │ $pQx5zXyXmIy2UfZNva96… │
│ 2026-07-02T10:05:57.762Z │ @auth-test:matrix-loc… │ * 收到！看起来像是一个认证代码：`111`。                                                               │ $Z3tGa3ob-TdTu8_Lq-_6… │
│                          │                        │ 你是想让我帮你用这个代码做些什么吗？比如登录某个服务、验证身份，或者是测试消息？告诉我具体需求，我来  │                        │
│                          │                        │ 帮你处理。                                                                                            │                        │
│ 2026-07-02T10:05:20.401Z │ @cat:matrix-lo… │ @auth-test 💕: 111                                                                                    │ $vZAP9RDAkTvhldkm7eMl… │
│ 2026-06-30T02:41:05.461Z │ @cat:matrix-lo… │ @auth-test 💕: sdfsdf                                                                                 │ $Evxee3Tm4TPrI8SvqMPe… │
└──────────────────────────┴────────────────────────┴───────────────────────────────────────────────────────────────────────────────────────────────────────┴────────────────────────┘

$ node openclaw.mjs message pins  --target '!yXceimCycQeAB0mmtz:matrix-local.hiclaw.io:18080' --channel matrix

Pinned messages
┌──────────────────────────┬────────────────────────┬─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┬────────────────────────┐
│ Time                     │ Author                 │ Text                                                                                                                                │ Id                     │
├──────────────────────────┼────────────────────────┼─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┼────────────────────────┤
│ 2026-07-02T10:08:29.129Z │ @cat:matrix-lo… │ @auth-test 💕: 今天日期                                                                                                             │ $pQx5zXyXmIy2UfZNva96… │
└──────────────────────────┴────────────────────────┴─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┴────────────────────────┘
```

<img width="1334" height="437" alt="image" src="https://github.com/user-attachments/assets/e38e60a8-3252-4d58-9fc4-251ee0a3a930" />
<img width="1489" height="446" alt="image" src="https://github.com/user-attachments/assets/643191f6-e7e2-4e4e-965c-8a1c7bcfec29" />

- Before/after comparison: on `main`, same command returns blank table. With this fix, all four columns render correctly. Streaming intermediate edits (8+ m.replace events for "收到…认证代码") collapsed to a single row showing the final version.

## User Impact

- **Before**: `openclaw message read --channel matrix --target <room>` → fully blank table
- **Before**: `openclaw message pins --channel matrix --target <room>` → malformed table
- **After**: Table renders Time, Author, Text, Id correctly
- **After**: Streaming edits deduped — one row per message (the final version), works for both backward and forward pagination
- **After**: Cross-sender `m.replace` events do not suppress the original message (Matrix spec sender ownership enforced)
- **After**: `--json` output preserves all original Matrix fields including `events` for `list-pins`