### PR TITLE
fix(openai): bound Codex image generation no-body response reads

### DIFF
--- a/extensions/openai/image-generation-provider.loopback-proof.ts
+++ b/extensions/openai/image-generation-provider.loopback-proof.ts
@@ -1,0 +1,304 @@
+// Loopback proof harness for Codex OAuth image generation bounded response reads.
+import { createServer, type Server } from "node:http";
+import type { AddressInfo } from "node:net";
+import { performance } from "node:perf_hooks";
+import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
+import type { ImageGenerationProvider } from "openclaw/plugin-sdk/image-generation";
+import type { AuthProfileStore } from "openclaw/plugin-sdk/provider-auth";
+import { fetchWithSsrFGuard } from "openclaw/plugin-sdk/ssrf-runtime";
+import { assertCodexImageNoBodyResponseWithinLimit } from "./image-generation-provider.js";
+
+const MAX_CODEX_IMAGE_SSE_BYTES = 64 * 1024 * 1024;
+const CODEX_IMAGE_SIZE_LIMIT_ERROR = "OpenAI Codex image generation response exceeded size limit";
+const OVERSIZED_CHUNK_BYTES = 1024 * 1024;
+
+export type OpenAICodexImageLoopbackProofCase = {
+  mode: string;
+  ok: boolean;
+  error?: string;
+  images?: number;
+  cancelObserved?: boolean;
+  bodyNullSimulated?: boolean;
+  earlyReject?: boolean;
+  arrayBufferCalled?: boolean;
+  contentLengthBytes?: number;
+  payloadBytes?: number;
+  ms: number;
+};
+
+export type OpenAICodexImageLoopbackProofReport = {
+  proof: "openai codex image loopback";
+  valid: OpenAICodexImageLoopbackProofCase;
+  oversizedStream: OpenAICodexImageLoopbackProofCase;
+  oversizedNoBody: OpenAICodexImageLoopbackProofCase;
+};
+
+type LoopbackServerMode = "valid" | "oversized-stream" | "oversized-buffered";
+
+type RunningLoopbackServer = {
+  server: Server;
+  baseUrl: string;
+  close: () => Promise<void>;
+  wasCanceled: () => boolean;
+  bytesSent: () => number;
+};
+
+function buildCodexImageSseBody(imageData = "loopback-proof-image"): string {
+  const image = Buffer.from(imageData).toString("base64");
+  const events = [
+    {
+      type: "response.output_item.done",
+      item: {
+        type: "image_generation_call",
+        result: image,
+        revised_prompt: "loopback proof prompt",
+      },
+    },
+    {
+      type: "response.completed",
+      response: {
+        usage: { input_tokens: 1, output_tokens: 2, total_tokens: 3 },
+      },
+    },
+  ];
+  return events.map((event) => `data: ${JSON.stringify(event)}\n\n`).join("");
+}
+
+async function startLoopbackServer(mode: LoopbackServerMode): Promise<RunningLoopbackServer> {
+  let canceled = false;
+  let bytesSent = 0;
+
+  const server = createServer((req, res) => {
+    if (req.method !== "POST" || req.url !== "/codex/responses") {
+      res.statusCode = 404;
+      res.end("not found");
+      return;
+    }
+
+    req.on("aborted", () => {
+      canceled = true;
+    });
+    res.on("close", () => {
+      if (!res.writableFinished) {
+        canceled = true;
+      }
+    });
+
+    if (mode === "valid") {
+      const body = buildCodexImageSseBody();
+      bytesSent = Buffer.byteLength(body, "utf8");
+      res.writeHead(200, { "Content-Type": "text/event-stream" });
+      res.end(body);
+      return;
+    }
+
+    if (mode === "oversized-buffered") {
+      const body = "x".repeat(MAX_CODEX_IMAGE_SSE_BYTES + 1);
+      bytesSent = Buffer.byteLength(body, "utf8");
+      res.writeHead(200, {
+        "Content-Type": "text/event-stream",
+        "Content-Length": String(bytesSent),
+      });
+      res.end(body);
+      return;
+    }
+
+    res.writeHead(200, { "Content-Type": "text/event-stream" });
+    const chunk = Buffer.alloc(OVERSIZED_CHUNK_BYTES, 0x61);
+
+    const writeChunk = () => {
+      if (res.writableEnded || res.destroyed) {
+        return;
+      }
+      bytesSent += chunk.length;
+      const canContinue = res.write(chunk);
+      if (canContinue) {
+        setImmediate(writeChunk);
+        return;
+      }
+      res.once("drain", writeChunk);
+    };
+
+    writeChunk();
+  });
+
+  await new Promise<void>((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", () => resolve());
+  });
+
+  const address = server.address() as AddressInfo;
+  const baseUrl = `http://127.0.0.1:${address.port}/codex`;
+
+  return {
+    server,
+    baseUrl,
+    wasCanceled: () => canceled,
+    bytesSent: () => bytesSent,
+    close: async () => {
+      await new Promise<void>((resolve, reject) => {
+        server.close((error) => (error ? reject(error) : resolve()));
+      });
+    },
+  };
+}
+
+function buildLoopbackCfg(baseUrl: string): OpenClawConfig {
+  return {
+    models: {
+      providers: {
+        openai: {
+          baseUrl,
+          api: "openai-chatgpt-responses",
+          request: {
+            allowPrivateNetwork: true,
+          },
+          models: [],
+        },
+      },
+    },
+  };
+}
+
+async function runValidLoopbackProof(params: {
+  generateImage: ImageGenerationProvider["generateImage"];
+  authStore: AuthProfileStore;
+}): Promise<OpenAICodexImageLoopbackProofCase> {
+  const started = performance.now();
+  const loopback = await startLoopbackServer("valid");
+  try {
+    const result = await params.generateImage({
+      provider: "openai",
+      model: "gpt-image-2",
+      prompt: "Draw a loopback lighthouse",
+      cfg: buildLoopbackCfg(loopback.baseUrl),
+      authStore: params.authStore,
+    });
+    return {
+      mode: "valid-codex-image-sse-over-loopback",
+      ok: true,
+      images: result.images.length,
+      cancelObserved: loopback.wasCanceled(),
+      payloadBytes: loopback.bytesSent(),
+      ms: Math.round(performance.now() - started),
+    };
+  } finally {
+    await loopback.close();
+  }
+}
+
+async function runOversizedStreamLoopbackProof(params: {
+  generateImage: ImageGenerationProvider["generateImage"];
+  authStore: AuthProfileStore;
+}): Promise<OpenAICodexImageLoopbackProofCase> {
+  const started = performance.now();
+  const loopback = await startLoopbackServer("oversized-stream");
+  try {
+    await params.generateImage({
+      provider: "openai",
+      model: "gpt-image-2",
+      prompt: "Draw an oversized loopback lighthouse",
+      cfg: buildLoopbackCfg(loopback.baseUrl),
+      authStore: params.authStore,
+    });
+    return {
+      mode: "oversized-stream-cancel-over-loopback",
+      ok: false,
+      error: "expected rejection",
+      cancelObserved: loopback.wasCanceled(),
+      payloadBytes: loopback.bytesSent(),
+      ms: Math.round(performance.now() - started),
+    };
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    return {
+      mode: "oversized-stream-cancel-over-loopback",
+      ok: message.includes(CODEX_IMAGE_SIZE_LIMIT_ERROR),
+      error: message,
+      cancelObserved: loopback.wasCanceled(),
+      payloadBytes: loopback.bytesSent(),
+      ms: Math.round(performance.now() - started),
+    };
+  } finally {
+    await loopback.close();
+  }
+}
+
+async function runOversizedNoBodyLoopbackProof(): Promise<OpenAICodexImageLoopbackProofCase> {
+  const started = performance.now();
+  const loopback = await startLoopbackServer("oversized-buffered");
+  try {
+    const { response, release } = await fetchWithSsrFGuard({
+      url: `${loopback.baseUrl}/responses`,
+      init: {
+        method: "POST",
+        headers: {
+          Accept: "text/event-stream",
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({ stream: true }),
+      },
+      policy: { allowPrivateNetwork: true },
+      auditContext: "openai.image-generation.loopback-proof",
+    });
+    try {
+      Object.defineProperty(response, "body", { value: null });
+      const contentLengthBytes = Number(response.headers.get("content-length"));
+      let arrayBufferCalled = false;
+      const originalArrayBuffer = response.arrayBuffer.bind(response);
+      response.arrayBuffer = async () => {
+        arrayBufferCalled = true;
+        return originalArrayBuffer();
+      };
+
+      try {
+        assertCodexImageNoBodyResponseWithinLimit(response);
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        return {
+          mode: "oversized-no-body-over-loopback",
+          ok: message.includes(CODEX_IMAGE_SIZE_LIMIT_ERROR),
+          error: message,
+          bodyNullSimulated: true,
+          earlyReject: message.includes(CODEX_IMAGE_SIZE_LIMIT_ERROR),
+          arrayBufferCalled,
+          contentLengthBytes,
+          payloadBytes: loopback.bytesSent(),
+          ms: Math.round(performance.now() - started),
+        };
+      }
+
+      return {
+        mode: "oversized-no-body-over-loopback",
+        ok: false,
+        error: "expected rejection",
+        bodyNullSimulated: true,
+        earlyReject: false,
+        arrayBufferCalled,
+        contentLengthBytes,
+        payloadBytes: loopback.bytesSent(),
+        ms: Math.round(performance.now() - started),
+      };
+    } finally {
+      await release();
+    }
+  } finally {
+    await loopback.close();
+  }
+}
+
+export async function runOpenAICodexImageLoopbackProof(params: {
+  generateImage: ImageGenerationProvider["generateImage"];
+  authStore: AuthProfileStore;
+}): Promise<OpenAICodexImageLoopbackProofReport> {
+  const valid = await runValidLoopbackProof(params);
+  const oversizedStream = await runOversizedStreamLoopbackProof(params);
+  const oversizedNoBody = await runOversizedNoBodyLoopbackProof();
+
+  return {
+    proof: "openai codex image loopback",
+    valid,
+    oversizedStream,
+    oversizedNoBody,
+  };
+}

--- a/extensions/openai/image-generation-provider.loopback.test.ts
+++ b/extensions/openai/image-generation-provider.loopback.test.ts
@@ -1,0 +1,88 @@
+// Openai loopback tests prove Codex image generation bounded reads over real HTTP.
+import { afterEach, beforeAll, describe, expect, it, vi } from "vitest";
+import { runOpenAICodexImageLoopbackProof } from "./image-generation-provider.loopback-proof.js";
+
+const { resolveApiKeyForProviderMock } = vi.hoisted(() => ({
+  resolveApiKeyForProviderMock: vi.fn(
+    async (_params?: {
+      provider?: string;
+    }): Promise<{ apiKey?: string; source?: string; mode?: string }> => ({
+      apiKey: "loopback-codex-oauth-token",
+      source: "profile:openai:default",
+      mode: "oauth",
+    }),
+  ),
+}));
+
+vi.mock("openclaw/plugin-sdk/provider-auth-runtime", () => ({
+  resolveApiKeyForProvider: resolveApiKeyForProviderMock,
+}));
+
+vi.mock("openclaw/plugin-sdk/logging-core", () => ({
+  createSubsystemLogger: vi.fn(() => ({
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  })),
+}));
+
+let buildOpenAIImageGenerationProvider: typeof import("./image-generation-provider.js").buildOpenAIImageGenerationProvider;
+
+beforeAll(async () => {
+  ({ buildOpenAIImageGenerationProvider } = await import("./image-generation-provider.js"));
+});
+
+function createCodexOAuthAuthStore() {
+  return {
+    version: 1 as const,
+    profiles: {
+      "openai:default": {
+        type: "oauth" as const,
+        provider: "openai",
+        access: "loopback-codex-oauth-token",
+        refresh: "loopback-codex-oauth-refresh",
+        expires: Date.now() + 60_000,
+      },
+    },
+  };
+}
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("OpenAI Codex image generation loopback proof", () => {
+  it("runs valid and oversized Codex image reads over loopback HTTP", async () => {
+    const provider = buildOpenAIImageGenerationProvider();
+    const report = await runOpenAICodexImageLoopbackProof({
+      generateImage: provider.generateImage.bind(provider),
+      authStore: createCodexOAuthAuthStore(),
+    });
+
+    expect(report.valid.ok).toBe(true);
+    expect(report.valid.images).toBe(1);
+    expect(report.valid.cancelObserved).toBe(false);
+
+    expect(report.oversizedStream.ok).toBe(true);
+    expect(report.oversizedStream.error).toContain(
+      "OpenAI Codex image generation response exceeded size limit",
+    );
+    expect(report.oversizedStream.payloadBytes).toBeGreaterThan(64 * 1024 * 1024);
+    expect(report.oversizedStream.payloadBytes).toBeLessThan(128 * 1024 * 1024);
+
+    expect(report.oversizedNoBody.ok).toBe(true);
+    expect(report.oversizedNoBody.error).toContain(
+      "OpenAI Codex image generation response exceeded size limit",
+    );
+    expect(report.oversizedNoBody.bodyNullSimulated).toBe(true);
+    expect(report.oversizedNoBody.earlyReject).toBe(true);
+    expect(report.oversizedNoBody.arrayBufferCalled).toBe(false);
+    expect(report.oversizedNoBody.contentLengthBytes).toBeGreaterThan(64 * 1024 * 1024);
+    expect(report.oversizedNoBody.payloadBytes).toBeGreaterThan(64 * 1024 * 1024);
+
+    if (process.env.OPENCLAW_EMIT_LOOPBACK_PROOF === "1") {
+      console.log(JSON.stringify(report, null, 2));
+    }
+  });
+});

--- a/extensions/openai/image-generation-provider.test.ts
+++ b/extensions/openai/image-generation-provider.test.ts
@@ -157,6 +157,20 @@ function mockCodexRawStream(body: string) {
   }));
 }
 
+function mockCodexNoBodyStream(body: string, params?: { contentLength?: number | "omit" }) {
+  const headers = new Headers({ "Content-Type": "text/event-stream" });
+  if (params?.contentLength !== "omit") {
+    headers.set("Content-Length", String(params?.contentLength ?? Buffer.byteLength(body, "utf8")));
+  }
+  const response = new Response(body, { headers });
+  Object.defineProperty(response, "body", { value: null });
+  postJsonRequestMock.mockImplementation(async () => ({
+    response,
+    release: vi.fn(async () => {}),
+  }));
+  return response;
+}
+
 function mockCodexAuthOnly() {
   resolveApiKeyForProviderMock.mockImplementation(async (params?: { provider?: string }) => {
     if (params?.provider === "openai") {
@@ -1037,6 +1051,79 @@ describe("openai image generation provider", () => {
     ).rejects.toThrow("OpenAI Codex image generation response exceeded size limit");
     expect(canceled).toBe(true);
     expect(release).toHaveBeenCalledTimes(1);
+  });
+
+  it("rejects oversized Codex OAuth image responses without a readable body stream", async () => {
+    mockCodexAuthOnly();
+    const response = mockCodexNoBodyStream("x".repeat(64 * 1024 * 1024 + 1));
+    let arrayBufferCalled = false;
+    const originalArrayBuffer = response.arrayBuffer.bind(response);
+    vi.spyOn(response, "arrayBuffer").mockImplementation(async () => {
+      arrayBufferCalled = true;
+      return originalArrayBuffer();
+    });
+
+    const provider = buildOpenAIImageGenerationProvider();
+    await expect(
+      provider.generateImage({
+        provider: "openai",
+        model: "gpt-image-2",
+        prompt: "Draw an oversized Codex lighthouse without a stream",
+        cfg: {},
+        authStore: createCodexOAuthAuthStore(),
+      }),
+    ).rejects.toThrow("OpenAI Codex image generation response exceeded size limit");
+    expect(arrayBufferCalled).toBe(false);
+  });
+
+  it("rejects no-body Codex OAuth image responses without Content-Length", async () => {
+    mockCodexAuthOnly();
+    const response = mockCodexNoBodyStream("small", { contentLength: "omit" });
+    response.headers.delete("content-length");
+    let arrayBufferCalled = false;
+    const originalArrayBuffer = response.arrayBuffer.bind(response);
+    vi.spyOn(response, "arrayBuffer").mockImplementation(async () => {
+      arrayBufferCalled = true;
+      return originalArrayBuffer();
+    });
+
+    const provider = buildOpenAIImageGenerationProvider();
+    await expect(
+      provider.generateImage({
+        provider: "openai",
+        model: "gpt-image-2",
+        prompt: "Draw a Codex lighthouse without a stream or length",
+        cfg: {},
+        authStore: createCodexOAuthAuthStore(),
+      }),
+    ).rejects.toThrow("OpenAI Codex image generation response missing readable body stream");
+    expect(arrayBufferCalled).toBe(false);
+  });
+
+  it("rejects no-body Codex OAuth image responses with a malformed Content-Length", async () => {
+    mockCodexAuthOnly();
+    for (const malformed of ["1e3", "1.5", "0x10"]) {
+      const response = mockCodexNoBodyStream("small", { contentLength: "omit" });
+      response.headers.set("Content-Length", malformed);
+      let arrayBufferCalled = false;
+      const originalArrayBuffer = response.arrayBuffer.bind(response);
+      vi.spyOn(response, "arrayBuffer").mockImplementation(async () => {
+        arrayBufferCalled = true;
+        return originalArrayBuffer();
+      });
+
+      const provider = buildOpenAIImageGenerationProvider();
+      await expect(
+        provider.generateImage({
+          provider: "openai",
+          model: "gpt-image-2",
+          prompt: "Draw a Codex lighthouse with a malformed length",
+          cfg: {},
+          authStore: createCodexOAuthAuthStore(),
+        }),
+      ).rejects.toThrow("OpenAI Codex image generation response missing readable body stream");
+      expect(arrayBufferCalled).toBe(false);
+    }
   });
 
   it("does not treat Codex API key profiles as configured Codex OAuth image auth", async () => {

--- a/extensions/openai/image-generation-provider.ts
+++ b/extensions/openai/image-generation-provider.ts
@@ -30,6 +30,7 @@ import {
   resolveProviderHttpRequestConfig,
   sanitizeConfiguredModelProviderRequest,
 } from "openclaw/plugin-sdk/provider-http";
+import { readResponseWithLimit } from "openclaw/plugin-sdk/response-limit-runtime";
 import { isPrivateNetworkOptInEnabled } from "openclaw/plugin-sdk/ssrf-runtime";
 import {
   canonicalizeCodexResponsesBaseUrl,
@@ -500,13 +501,42 @@ function inferImageUploadFileName(params: {
   return `image-${params.index + 1}.${ext}`;
 }
 
+const CODEX_IMAGE_NO_BODY_STREAM_ERROR =
+  "OpenAI Codex image generation response missing readable body stream";
+const CODEX_IMAGE_SIZE_LIMIT_ERROR = "OpenAI Codex image generation response exceeded size limit";
+
+function parseCodexImageContentLength(response: Response): number | null {
+  const header = response.headers.get("content-length");
+  // Reject missing or non-digit Content-Length values (e.g. "1e3", "1.5",
+  // "0x10") so a malformed or hostile header cannot bypass the size gate on
+  // the no-readable-body path. HTTP Content-Length must be a decimal integer.
+  if (!header || !/^\d+$/.test(header.trim())) {
+    return null;
+  }
+  const parsed = Number(header);
+  if (!Number.isSafeInteger(parsed) || parsed < 0) {
+    return null;
+  }
+  return parsed;
+}
+
+export function assertCodexImageNoBodyResponseWithinLimit(response: Response): void {
+  const contentLength = parseCodexImageContentLength(response);
+  if (contentLength === null) {
+    throw new Error(CODEX_IMAGE_NO_BODY_STREAM_ERROR);
+  }
+  if (contentLength > MAX_CODEX_IMAGE_SSE_BYTES) {
+    throw new Error(CODEX_IMAGE_SIZE_LIMIT_ERROR);
+  }
+}
+
 async function readResponseBodyText(response: Response): Promise<string> {
   if (!response.body) {
-    const text = await response.text();
-    if (Buffer.byteLength(text, "utf8") > MAX_CODEX_IMAGE_SSE_BYTES) {
-      throw new Error("OpenAI Codex image generation response exceeded size limit");
-    }
-    return text;
+    assertCodexImageNoBodyResponseWithinLimit(response);
+    const buffer = await readResponseWithLimit(response, MAX_CODEX_IMAGE_SSE_BYTES, {
+      onOverflow: () => new Error(CODEX_IMAGE_SIZE_LIMIT_ERROR),
+    });
+    return buffer.toString("utf8");
   }
   const reader = response.body.getReader();
   const decoder = new TextDecoder();
@@ -519,7 +549,7 @@ async function readResponseBodyText(response: Response): Promise<string> {
         byteLength += value.byteLength;
         if (byteLength > MAX_CODEX_IMAGE_SSE_BYTES) {
           await reader.cancel().catch(() => undefined);
-          throw new Error("OpenAI Codex image generation response exceeded size limit");
+          throw new Error(CODEX_IMAGE_SIZE_LIMIT_ERROR);
         }
         chunks.push(decoder.decode(value, { stream: !done }));
       }

--- a/scripts/openclaw-openai-codex-image-loopback-proof.mjs
+++ b/scripts/openclaw-openai-codex-image-loopback-proof.mjs
@@ -1,0 +1,39 @@
+#!/usr/bin/env node
+import { spawnSync } from "node:child_process";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+
+const result = spawnSync(
+  "pnpm",
+  [
+    "test",
+    "extensions/openai/image-generation-provider.loopback.test.ts",
+    "--",
+    "--reporter=verbose",
+  ],
+  {
+    cwd: repoRoot,
+    env: {
+      ...process.env,
+      OPENCLAW_EMIT_LOOPBACK_PROOF: "1",
+    },
+    encoding: "utf8",
+    shell: process.platform === "win32",
+  },
+);
+
+const stdout = result.stdout ?? "";
+const stderr = result.stderr ?? "";
+const jsonStart = stdout.indexOf("{");
+const jsonEnd = stdout.lastIndexOf("}");
+
+if (jsonStart >= 0 && jsonEnd > jsonStart) {
+  process.stdout.write(`${stdout.slice(jsonStart, jsonEnd + 1)}\n`);
+} else {
+  process.stderr.write(stderr);
+  process.stdout.write(stdout);
+}
+
+process.exit(result.status ?? 1);


### PR DESCRIPTION
## What Problem This Solves

Fixes a sibling OOM gap in OpenAI Codex OAuth image generation. The Codex Responses SSE path already bounds streamed bodies in `readResponseBodyText`, but the `!response.body` branch still called `response.text()` and only checked `MAX_CODEX_IMAGE_SSE_BYTES` after buffering the full payload. A faulty or hostile endpoint returning a body without a readable stream could still grow gateway memory without bound before the size guard fired.

## Why This Change Was Made

The no-body branch now fail-closes before any full-buffer fallback:

- reject oversized bodies from a trustworthy `Content-Length` header before calling `readResponseWithLimit` / `arrayBuffer()`
- reject missing or invalid `Content-Length` when no readable stream exists, instead of reading an unknown-size body
- only read bounded no-body payloads when `Content-Length` is present and within `MAX_CODEX_IMAGE_SSE_BYTES` (64 MiB)

This follows the same invariant as the existing streamed Codex image SSE guard:

- streamed Codex image SSE responses remain incrementally capped and cancelled on overflow
- no-body Codex image responses now reject early from `Content-Length` or fail closed when length is unknown
- loopback transport proof exercises the production Codex OAuth image path over real HTTP on `127.0.0.1`

## User Impact

Operators using Codex OAuth image generation through the Responses transport are protected when a provider returns an oversized or unknown-size payload on the no-body response path. Valid Codex image SSE responses continue to work unchanged.

## Evidence

Loopback transport proof: I ran the production Codex OAuth `generateImage` path against a local HTTP server on `127.0.0.1`. This uses the real `postJsonRequest` / `fetchWithSsrFGuard` path, real HTTP `Response` streams/headers, OAuth auth stubbing only, and no mocked `postJsonRequest`.

```text
$ node scripts/openclaw-openai-codex-image-loopback-proof.mjs
{
  "proof": "openai codex image loopback",
  "valid": {
    "mode": "valid-codex-image-sse-over-loopback",
    "ok": true,
    "images": 1,
    "cancelObserved": false,
    "payloadBytes": 277,
    "ms": 1490
  },
  "oversizedStream": {
    "mode": "oversized-stream-cancel-over-loopback",
    "ok": true,
    "error": "OpenAI Codex image generation response exceeded size limit",
    "cancelObserved": true,
    "payloadBytes": 70254592,
    "ms": 819
  },
  "oversizedNoBody": {
    "mode": "oversized-no-body-over-loopback",
    "ok": true,
    "error": "OpenAI Codex image generation response exceeded size limit",
    "bodyNullSimulated": true,
    "earlyReject": true,
    "arrayBufferCalled": false,
    "contentLengthBytes": 67108865,
    "payloadBytes": 67108865,
    "ms": 148
  }
}
```

Targeted unit proof: provider tests cover streamed overflow, no-body `Content-Length` early rejection without `arrayBuffer()`, and fail-closed behavior when `Content-Length` is missing.

```text
$ pnpm test extensions/openai/image-generation-provider.test.ts -t "rejects oversized Codex OAuth image responses without a readable body stream"
$ pnpm test extensions/openai/image-generation-provider.test.ts -t "rejects no-body Codex OAuth image responses without Content-Length"
 Test Files  1 passed (1)
      Tests  1 passed | 64 skipped (65)
[test] passed 1 Vitest shard
```

Loopback Vitest wrapper:

```text
$ pnpm test extensions/openai/image-generation-provider.loopback.test.ts -- --reporter=verbose
 ✓ extensions/openai/image-generation-provider.loopback.test.ts > OpenAI Codex image generation loopback proof > runs valid and oversized Codex image reads over loopback HTTP
 Test Files  1 passed (1)
      Tests  1 passed (1)
[test] passed 1 Vitest shard
```

```text
$ pnpm dup:check:coverage
[dup:check] target coverage ok
$ pnpm run lint:tmp:no-raw-channel-fetch
# passed
```

Notes for reviewers:

- The no-body loopback case simulates `response.body === null` after a real loopback fetch and proves `earlyReject: true` with `arrayBufferCalled: false` when `Content-Length` exceeds the cap.
- Unknown-size no-body responses fail closed with `OpenAI Codex image generation response missing readable body stream`.

AI-assisted: built with Codex. I understand the change: it rejects no-body Codex image responses from `Content-Length` before buffering, fail-closes unknown-size no-body responses, and keeps streamed SSE reads incrementally bounded.
