### PR TITLE
fix(copilot): bound BYOK proxy request bodies

### DIFF
--- a/extensions/copilot/src/byok-proxy.test.ts
+++ b/extensions/copilot/src/byok-proxy.test.ts
@@ -414,6 +414,71 @@ describe("createCopilotByokProxy", () => {
     }
   });
 
+  it("stops collecting after chunked overflow while the sender remains open", async () => {
+    const proxy = await createCopilotByokProxy(
+      resolveCopilotProvider({
+        model: {
+          provider: "custom-proxy",
+          api: "openai-responses",
+          id: "proxy-model",
+          baseUrl: "https://proxy.example/v1",
+        },
+      }),
+    );
+    let request: ReturnType<typeof http.request> | undefined;
+
+    try {
+      const endpoint = new URL(`${proxy?.provider.provider?.baseUrl}/responses`);
+      const response = await new Promise<{ status: number; body: string }>((resolve, reject) => {
+        let settled = false;
+        const timer = setTimeout(() => {
+          request?.destroy();
+          reject(new Error("timed out waiting for trailing-input rejection"));
+        }, 2_000);
+        timer.unref();
+        request = http.request(
+          {
+            hostname: endpoint.hostname,
+            port: Number(endpoint.port),
+            path: endpoint.pathname,
+            method: "POST",
+            headers: {
+              "transfer-encoding": "chunked",
+              "content-type": "application/octet-stream",
+            },
+          },
+          (incoming) => {
+            let body = "";
+            incoming.setEncoding("utf8");
+            incoming.on("data", (chunk: string) => {
+              body += chunk;
+            });
+            incoming.once("end", () => {
+              settled = true;
+              clearTimeout(timer);
+              resolve({ status: incoming.statusCode ?? 0, body });
+            });
+          },
+        );
+        request.once("error", (error) => {
+          clearTimeout(timer);
+          if (!settled) {
+            reject(error);
+          }
+        });
+        request.write(Buffer.alloc(PROXY_MAX_REQUEST_BODY_BYTES, 0x41));
+        request.write("overflow");
+        // Keep the sender open: the proxy must stop collecting after the guard trips.
+      });
+
+      expect(response).toEqual({ status: 413, body: "Payload too large" });
+      expect(ssrfRuntimeMock.fetchWithSsrFGuard).not.toHaveBeenCalled();
+    } finally {
+      request?.destroy();
+      await proxy?.close();
+    }
+  });
+
   it("forwards a BYOK request containing two supported-size images", async () => {
     let forwardedBody: Buffer | undefined;
     ssrfRuntimeMock.fetchWithSsrFGuard.mockImplementation(

--- a/extensions/copilot/src/byok-proxy.test.ts
+++ b/extensions/copilot/src/byok-proxy.test.ts
@@ -10,6 +10,9 @@ const ssrfRuntimeMock = vi.hoisted(() => ({
   fetchWithSsrFGuard: vi.fn(),
 }));
 
+const PROXY_MAX_REQUEST_BODY_BYTES = 32 * 1024 * 1024;
+const SUPPORTED_IMAGE_BYTES = 6 * 1024 * 1024;
+
 vi.mock("openclaw/plugin-sdk/ssrf-runtime", async (importOriginal) => ({
   ...(await importOriginal<typeof import("openclaw/plugin-sdk/ssrf-runtime")>()),
   fetchWithSsrFGuard: ssrfRuntimeMock.fetchWithSsrFGuard,
@@ -330,7 +333,7 @@ describe("createCopilotByokProxy", () => {
             path: endpoint.pathname,
             method: "POST",
             headers: {
-              "content-length": String(16 * 1024 * 1024 + 1),
+              "content-length": String(PROXY_MAX_REQUEST_BODY_BYTES + 1),
             },
           },
           (incoming) => {
@@ -390,7 +393,7 @@ describe("createCopilotByokProxy", () => {
         body: new ReadableStream({
           start(controller) {
             const chunkSize = 1024 * 1024;
-            const totalBytes = 16 * 1024 * 1024 + 1;
+            const totalBytes = PROXY_MAX_REQUEST_BODY_BYTES + 1;
             let sent = 0;
             while (sent < totalBytes) {
               const size = Math.min(chunkSize, totalBytes - sent);
@@ -406,6 +409,73 @@ describe("createCopilotByokProxy", () => {
       expect(response.status).toBe(413);
       expect(await response.text()).toBe("Payload too large");
       expect(ssrfRuntimeMock.fetchWithSsrFGuard).not.toHaveBeenCalled();
+    } finally {
+      await proxy?.close();
+    }
+  });
+
+  it("forwards a BYOK request containing two supported-size images", async () => {
+    let forwardedBody: Buffer | undefined;
+    ssrfRuntimeMock.fetchWithSsrFGuard.mockImplementation(
+      async ({ init }: Parameters<typeof fetchWithSsrFGuard>[0]) => {
+        forwardedBody = Buffer.from(
+          await new Response(init?.body as BodyInit | null | undefined).arrayBuffer(),
+        );
+        return {
+          response: new Response(null, { status: 204 }),
+          release: vi.fn(async () => undefined),
+        };
+      },
+    );
+    const image = Buffer.alloc(SUPPORTED_IMAGE_BYTES).toString("base64");
+    const body = Buffer.from(
+      JSON.stringify({
+        model: "proxy-model",
+        input: [
+          { type: "input_image", image_url: `data:image/png;base64,${image}` },
+          { type: "input_image", image_url: `data:image/png;base64,${image}` },
+        ],
+      }),
+    );
+    expect(body.byteLength).toBeGreaterThan(16 * 1024 * 1024);
+    expect(body.byteLength).toBeLessThanOrEqual(PROXY_MAX_REQUEST_BODY_BYTES);
+    const proxy = await createCopilotByokProxy(
+      resolveCopilotProvider({
+        model: {
+          provider: "custom-proxy",
+          api: "openai-responses",
+          id: "proxy-model",
+          baseUrl: "https://proxy.example/v1",
+        },
+      }),
+    );
+
+    try {
+      const endpoint = new URL(`${proxy?.provider.provider?.baseUrl}/responses`);
+      const response = await new Promise<{ status: number }>((resolve, reject) => {
+        const request = http.request(
+          {
+            hostname: endpoint.hostname,
+            port: Number(endpoint.port),
+            path: endpoint.pathname,
+            method: "POST",
+            headers: {
+              "content-length": String(body.byteLength),
+              "content-type": "application/json",
+            },
+          },
+          (incoming) => {
+            incoming.resume();
+            incoming.once("end", () => resolve({ status: incoming.statusCode ?? 0 }));
+          },
+        );
+        request.once("error", reject);
+        request.end(body);
+      });
+
+      expect(response.status).toBe(204);
+      expect(forwardedBody).toHaveLength(body.byteLength);
+      expect(forwardedBody?.equals(body)).toBe(true);
     } finally {
       await proxy?.close();
     }

--- a/extensions/copilot/src/byok-proxy.test.ts
+++ b/extensions/copilot/src/byok-proxy.test.ts
@@ -307,6 +307,73 @@ describe("createCopilotByokProxy", () => {
       }
     },
   );
+  it("rejects oversized request bodies before forwarding upstream", async () => {
+    const resolvedProvider = resolveCopilotProvider({
+      model: {
+        provider: "custom-proxy",
+        api: "openai-responses",
+        id: "proxy-model",
+        baseUrl: "https://proxy.example/v1",
+      },
+    });
+    const proxy = await createCopilotByokProxy(resolvedProvider);
+
+    try {
+      const response = await fetch(`${proxy?.provider.provider?.baseUrl}/responses`, {
+        method: "POST",
+        body: "x".repeat(16 * 1024 * 1024 + 1),
+      });
+
+      expect(response.status).toBe(413);
+      expect(await response.text()).toBe("Payload too large");
+      expect(ssrfRuntimeMock.fetchWithSsrFGuard).not.toHaveBeenCalled();
+    } finally {
+      await proxy?.close();
+    }
+  });
+
+  it("returns 413 for chunked request bodies that overflow the streaming limit", async () => {
+    const resolvedProvider = resolveCopilotProvider({
+      model: {
+        provider: "custom-proxy",
+        api: "openai-responses",
+        id: "proxy-model",
+        baseUrl: "https://proxy.example/v1",
+      },
+    });
+    const proxy = await createCopilotByokProxy(resolvedProvider);
+
+    try {
+      // ReadableStream forces chunked transfer-encoding (no content-length),
+      // so the declared-length gate passes and the streaming reader catches
+      // the overflow mid-stream. The proxy must deliver a proper 413 response
+      // instead of tearing down the shared socket.
+      const response = await fetch(`${proxy?.provider.provider?.baseUrl}/responses`, {
+        method: "POST",
+        headers: { "content-type": "application/octet-stream" },
+        body: new ReadableStream({
+          start(controller) {
+            const chunkSize = 1024 * 1024;
+            const totalBytes = 16 * 1024 * 1024 + 1;
+            let sent = 0;
+            while (sent < totalBytes) {
+              const size = Math.min(chunkSize, totalBytes - sent);
+              controller.enqueue(new Uint8Array(size));
+              sent += size;
+            }
+            controller.close();
+          },
+        }),
+        duplex: "half",
+      } as RequestInit);
+
+      expect(response.status).toBe(413);
+      expect(await response.text()).toBe("Payload too large");
+      expect(ssrfRuntimeMock.fetchWithSsrFGuard).not.toHaveBeenCalled();
+    } finally {
+      await proxy?.close();
+    }
+  });
 
   it("accepts Azure SDK paths that are rebuilt from the proxy origin", async () => {
     ssrfRuntimeMock.fetchWithSsrFGuard.mockResolvedValue({

--- a/extensions/copilot/src/byok-proxy.test.ts
+++ b/extensions/copilot/src/byok-proxy.test.ts
@@ -1,4 +1,5 @@
 // Copilot BYOK proxy tests verify SDK-local transport is guarded outbound fetch.
+import http from "node:http";
 import { expectDefined } from "@openclaw/normalization-core";
 import type { fetchWithSsrFGuard } from "openclaw/plugin-sdk/ssrf-runtime";
 import { afterEach, describe, expect, it, vi } from "vitest";
@@ -307,7 +308,7 @@ describe("createCopilotByokProxy", () => {
       }
     },
   );
-  it("rejects oversized request bodies before forwarding upstream", async () => {
+  it("rejects a slow declared oversized body before waiting for the body stream", async () => {
     const resolvedProvider = resolveCopilotProvider({
       model: {
         provider: "custom-proxy",
@@ -319,13 +320,48 @@ describe("createCopilotByokProxy", () => {
     const proxy = await createCopilotByokProxy(resolvedProvider);
 
     try {
-      const response = await fetch(`${proxy?.provider.provider?.baseUrl}/responses`, {
-        method: "POST",
-        body: "x".repeat(16 * 1024 * 1024 + 1),
+      const endpoint = new URL(`${proxy?.provider.provider?.baseUrl}/responses`);
+      const response = await new Promise<{ status: number; body: string }>((resolve, reject) => {
+        let settled = false;
+        const request = http.request(
+          {
+            hostname: endpoint.hostname,
+            port: Number(endpoint.port),
+            path: endpoint.pathname,
+            method: "POST",
+            headers: {
+              "content-length": String(16 * 1024 * 1024 + 1),
+            },
+          },
+          (incoming) => {
+            let body = "";
+            incoming.setEncoding("utf8");
+            incoming.on("data", (chunk: string) => {
+              body += chunk;
+            });
+            incoming.on("end", () => {
+              settled = true;
+              clearTimeout(timer);
+              resolve({ status: incoming.statusCode ?? 0, body });
+            });
+          },
+        );
+        const timer = setTimeout(() => {
+          request.destroy();
+          reject(new Error("timed out waiting for declared-length rejection"));
+        }, 2_000);
+        timer.unref();
+        request.once("error", (error) => {
+          clearTimeout(timer);
+          if (!settled) {
+            reject(error);
+          }
+        });
+        request.write("x");
+        // Keep the request open: the guard must reject from Content-Length alone.
       });
 
-      expect(response.status).toBe(413);
-      expect(await response.text()).toBe("Payload too large");
+      expect(response).toEqual({ status: 413, body: "Payload too large" });
       expect(ssrfRuntimeMock.fetchWithSsrFGuard).not.toHaveBeenCalled();
     } finally {
       await proxy?.close();

--- a/extensions/copilot/src/byok-proxy.ts
+++ b/extensions/copilot/src/byok-proxy.ts
@@ -135,7 +135,7 @@ async function handleProxyRequest(
             : undefined,
         }),
         signal: upstreamAbort.signal,
-        ...(body ? { body: toFetchBody(body) } : {}),
+        ...(body ? { body } : {}),
       },
       auditContext: "copilot-byok-provider",
       requireHttps: true,
@@ -222,7 +222,7 @@ function isNonceProtectedProxyRequest(req: IncomingMessage, proxyPathPrefix: str
 async function readGuardedBody(
   req: IncomingMessage,
   res: ServerResponse,
-): Promise<Buffer | undefined> {
+): Promise<Buffer<ArrayBuffer> | undefined> {
   const guard = installRequestBodyLimitGuard(req, res, {
     maxBytes: PROXY_MAX_REQUEST_BODY_BYTES,
     timeoutMs: PROXY_REQUEST_BODY_TIMEOUT_MS,
@@ -234,7 +234,14 @@ async function readGuardedBody(
   try {
     const chunks: Buffer[] = [];
     for await (const chunk of req) {
+      if (guard.isTripped()) {
+        break;
+      }
       chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+      if (guard.isTripped()) {
+        chunks.pop();
+        break;
+      }
     }
     if (guard.isTripped()) {
       return undefined;
@@ -248,12 +255,6 @@ async function readGuardedBody(
   } finally {
     guard.dispose();
   }
-}
-
-function toFetchBody(body: Buffer): Uint8Array<ArrayBuffer> {
-  const copy = new Uint8Array(body.byteLength);
-  copy.set(body);
-  return copy;
 }
 
 function normalizeProxyRequestHeaders(headers: IncomingMessage["headers"]): Record<string, string> {

--- a/extensions/copilot/src/byok-proxy.ts
+++ b/extensions/copilot/src/byok-proxy.ts
@@ -9,7 +9,9 @@ import { installRequestBodyLimitGuard } from "openclaw/plugin-sdk/webhook-reques
 import type { ResolvedCopilotProvider } from "./provider-bridge.js";
 
 const LOOPBACK_HOST = "127.0.0.1";
-const PROXY_MAX_REQUEST_BODY_BYTES = 16 * 1024 * 1024;
+// Two supported 6 MiB images are about 16 MiB after base64 encoding; keep
+// room for the JSON request envelope while retaining a bounded proxy body.
+const PROXY_MAX_REQUEST_BODY_BYTES = 32 * 1024 * 1024;
 const PROXY_REQUEST_BODY_TIMEOUT_MS = 30_000;
 
 type CopilotByokProxyHandle = {
@@ -133,7 +135,7 @@ async function handleProxyRequest(
             : undefined,
         }),
         signal: upstreamAbort.signal,
-        ...(body ? { body } : {}),
+        ...(body ? { body: toFetchBody(body) } : {}),
       },
       auditContext: "copilot-byok-provider",
       requireHttps: true,

--- a/extensions/copilot/src/byok-proxy.ts
+++ b/extensions/copilot/src/byok-proxy.ts
@@ -5,7 +5,6 @@ import { Readable } from "node:stream";
 import { pipeline } from "node:stream/promises";
 import type { ReadableStream as NodeReadableStream } from "node:stream/web";
 import { fetchWithSsrFGuard } from "openclaw/plugin-sdk/ssrf-runtime";
-import { requestBodyErrorToText } from "openclaw/plugin-sdk/webhook-ingress";
 import { installRequestBodyLimitGuard } from "openclaw/plugin-sdk/webhook-request-guards";
 import type { ResolvedCopilotProvider } from "./provider-bridge.js";
 
@@ -119,12 +118,6 @@ async function handleProxyRequest(
       res.end("Not found");
       return;
     }
-    if (isProxyRequestBodyTooLarge(req)) {
-      res.writeHead(413);
-      res.end(requestBodyErrorToText("PAYLOAD_TOO_LARGE"));
-      req.resume();
-      return;
-    }
     const body =
       req.method === "GET" || req.method === "HEAD" ? undefined : await readGuardedBody(req, res);
     if (res.writableEnded) {
@@ -222,16 +215,6 @@ function isNonceProtectedProxyRequest(req: IncomingMessage, proxyPathPrefix: str
     incomingUrl.pathname === proxyPathPrefix ||
     incomingUrl.pathname.startsWith(`${proxyPathPrefix}/`)
   );
-}
-
-function isProxyRequestBodyTooLarge(req: IncomingMessage): boolean {
-  const header = req.headers["content-length"];
-  const raw = Array.isArray(header) ? header[0] : header;
-  if (typeof raw !== "string") {
-    return false;
-  }
-  const declaredLength = Number.parseInt(raw, 10);
-  return Number.isFinite(declaredLength) && declaredLength > PROXY_MAX_REQUEST_BODY_BYTES;
 }
 
 async function readGuardedBody(

--- a/extensions/copilot/src/byok-proxy.ts
+++ b/extensions/copilot/src/byok-proxy.ts
@@ -5,9 +5,13 @@ import { Readable } from "node:stream";
 import { pipeline } from "node:stream/promises";
 import type { ReadableStream as NodeReadableStream } from "node:stream/web";
 import { fetchWithSsrFGuard } from "openclaw/plugin-sdk/ssrf-runtime";
+import { requestBodyErrorToText } from "openclaw/plugin-sdk/webhook-ingress";
+import { installRequestBodyLimitGuard } from "openclaw/plugin-sdk/webhook-request-guards";
 import type { ResolvedCopilotProvider } from "./provider-bridge.js";
 
 const LOOPBACK_HOST = "127.0.0.1";
+const PROXY_MAX_REQUEST_BODY_BYTES = 16 * 1024 * 1024;
+const PROXY_REQUEST_BODY_TIMEOUT_MS = 30_000;
 
 type CopilotByokProxyHandle = {
   close: () => Promise<void>;
@@ -115,7 +119,17 @@ async function handleProxyRequest(
       res.end("Not found");
       return;
     }
-    const body = req.method === "GET" || req.method === "HEAD" ? undefined : await readBody(req);
+    if (isProxyRequestBodyTooLarge(req)) {
+      res.writeHead(413);
+      res.end(requestBodyErrorToText("PAYLOAD_TOO_LARGE"));
+      req.resume();
+      return;
+    }
+    const body =
+      req.method === "GET" || req.method === "HEAD" ? undefined : await readGuardedBody(req, res);
+    if (res.writableEnded) {
+      return;
+    }
     guarded = await fetchWithSsrFGuard({
       url: url.toString(),
       init: {
@@ -210,12 +224,51 @@ function isNonceProtectedProxyRequest(req: IncomingMessage, proxyPathPrefix: str
   );
 }
 
-async function readBody(req: IncomingMessage): Promise<Buffer<ArrayBuffer> | undefined> {
-  const chunks: Buffer[] = [];
-  for await (const chunk of req) {
-    chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+function isProxyRequestBodyTooLarge(req: IncomingMessage): boolean {
+  const header = req.headers["content-length"];
+  const raw = Array.isArray(header) ? header[0] : header;
+  if (typeof raw !== "string") {
+    return false;
   }
-  return chunks.length > 0 ? Buffer.concat(chunks) : undefined;
+  const declaredLength = Number.parseInt(raw, 10);
+  return Number.isFinite(declaredLength) && declaredLength > PROXY_MAX_REQUEST_BODY_BYTES;
+}
+
+async function readGuardedBody(
+  req: IncomingMessage,
+  res: ServerResponse,
+): Promise<Buffer | undefined> {
+  const guard = installRequestBodyLimitGuard(req, res, {
+    maxBytes: PROXY_MAX_REQUEST_BODY_BYTES,
+    timeoutMs: PROXY_REQUEST_BODY_TIMEOUT_MS,
+    responseFormat: "text",
+  });
+  if (guard.isTripped()) {
+    return undefined;
+  }
+  try {
+    const chunks: Buffer[] = [];
+    for await (const chunk of req) {
+      chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+    }
+    if (guard.isTripped()) {
+      return undefined;
+    }
+    return chunks.length > 0 ? Buffer.concat(chunks) : undefined;
+  } catch (error) {
+    if (guard.isTripped()) {
+      return undefined;
+    }
+    throw error;
+  } finally {
+    guard.dispose();
+  }
+}
+
+function toFetchBody(body: Buffer): Uint8Array<ArrayBuffer> {
+  const copy = new Uint8Array(body.byteLength);
+  copy.set(body);
+  return copy;
 }
 
 function normalizeProxyRequestHeaders(headers: IncomingMessage["headers"]): Record<string, string> {


### PR DESCRIPTION
## What Problem This Solves

Fixes a correctness and resource-lifetime defect in the Copilot BYOK proxy: every non-GET/HEAD request now uses one bounded request-body policy, while valid multi-image BYOK payloads remain supported.

## Why This Change Was Made

Every non-GET/HEAD BYOK request uses the existing `installRequestBodyLimitGuard` as its sole body-limit path. The aggregate cap is 32 MiB: two supported 6 MiB images are about 16 MiB after base64 encoding, leaving room for the JSON request envelope while keeping proxy buffering bounded. The shared guard rejects an oversized `Content-Length` before awaiting the body, owns the 30-second body timeout, and catches chunked overflow without forwarding data upstream. Once the guard trips, the collector stops immediately, and the bounded `Buffer<ArrayBuffer>` is passed directly to the guarded fetch without another request-body copy.

## User Impact

Normal BYOK requests, including two supported-size image inputs, keep their existing behavior. Declared-length and chunked requests above the 32 MiB aggregate cap receive the deterministic 413 response from the shared guard.

## Evidence

- Real call-chain loopback proof: `OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs run --config test/vitest/vitest.extensions.config.ts --maxWorkers=1 extensions/copilot/src/byok-proxy.test.ts -t 'declared|chunked|two supported-size images'` exercises the production `createCopilotByokProxy` entrypoint through its local HTTP server and shared guard. A 16,777,369-byte JSON request containing two 6 MiB image data URLs is above the previous 16 MiB bound and is forwarded byte-for-byte; declared-length and chunked `32 MiB + 1` controls return 413 without invoking guarded upstream fetch.
- Before-fix baseline: validation base `9fd5cba00f0e49e0eac65684b005c469573731af` retains the previous 16 MiB cap, so the same 16,777,369-byte multi-image request is outside the old bound. After-fix exact head: `c413876d043edddba3b08416f42188ab1fa66699` accepts it under the bounded 32 MiB policy.
- Targeted validation: changed-file format/lint, extension source and test type checks, plus the focused Copilot suite — 17 tests passed.
- Established contract: reuses the existing shared `installRequestBodyLimitGuard` and keeps the existing 30-second timeout and 413 response behavior.

```text
$ git rev-parse HEAD
c413876d043edddba3b08416f42188ab1fa66699
$ OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs run --config test/vitest/vitest.extensions.config.ts --maxWorkers=1 extensions/copilot/src/byok-proxy.test.ts -t 'declared|chunked|two supported-size images'
✓ rejects a slow declared oversized body before waiting for the body stream
✓ returns 413 for chunked request bodies that overflow the streaming limit
✓ stops collecting after chunked overflow while the sender remains open
✓ forwards a BYOK request containing two supported-size images

Test Files  1 passed (1)
Tests  4 passed | 13 skipped (17)
```

<details>
<summary>negative-control proof source</summary>

```ts
import http from "node:http";
import { execFileSync } from "node:child_process";
import { createCopilotByokProxy } from "./extensions/copilot/src/byok-proxy.js";
import { resolveCopilotProvider } from "./extensions/copilot/src/provider-bridge.js";

const PROXY_MAX_REQUEST_BODY_BYTES = 32 * 1024 * 1024;
const proxy = await createCopilotByokProxy(
  resolveCopilotProvider({
    model: {
      provider: "custom-proxy",
      api: "openai-responses",
      id: "proxy-model",
      baseUrl: "https://proxy.example/v1",
    },
  }),
);
if (!proxy) throw new Error("proxy creation failed");

try {
  const endpoint = new URL(`${proxy.provider.provider?.baseUrl}/responses`);
  const response = await new Promise<{ status: number; body: string }>((resolve, reject) => {
    let settled = false;
    let timer: ReturnType<typeof setTimeout> | undefined;
    const request = http.request(
      {
        hostname: endpoint.hostname,
        port: Number(endpoint.port),
        path: endpoint.pathname,
        method: "POST",
        headers: { "content-length": String(PROXY_MAX_REQUEST_BODY_BYTES + 1) },
      },
      (incoming) => {
        let body = "";
        incoming.setEncoding("utf8");
        incoming.on("data", (chunk: string) => {
          body += chunk;
        });
        incoming.on("end", () => {
          settled = true;
          if (timer) clearTimeout(timer);
          resolve({ status: incoming.statusCode ?? 0, body });
        });
      },
    );
    timer = setTimeout(() => {
      request.destroy();
      reject(new Error("timed out waiting for declared-length rejection"));
    }, 2_000);
    timer.unref();
    request.once("error", (error) => {
      if (timer) clearTimeout(timer);
      if (!settled) reject(error);
    });
    request.write("x");
    // Deliberately keep the request open: Content-Length alone must trip the guard.
  });

  console.log(JSON.stringify({
    head: execFileSync("git", ["rev-parse", "--short=12", "HEAD"], { encoding: "utf8" }).trim(),
    declaredOversize: response,
  }));
} finally {
  await proxy.close();
}
```

</details>

AI-assisted: built with Codex
