### PR TITLE
fix: strengthen macOS SQLite WAL checkpoint durability

### DIFF
--- a/src/infra/sqlite-wal.test.ts
+++ b/src/infra/sqlite-wal.test.ts
@@ -41,6 +41,7 @@ describe("sqlite WAL maintenance", () => {
 
   it("enables WAL mode and explicit autocheckpointing", () => {
     const db = createMockDb();
+    vi.spyOn(process, "platform", "get").mockReturnValue("linux");
 
     configureSqliteWalMaintenance(db, { checkpointIntervalMs: 0 });
 
@@ -51,10 +52,44 @@ describe("sqlite WAL maintenance", () => {
     );
   });
 
+  it("enables fullfsync barriers for WAL checkpoints on macOS", () => {
+    const db = createMockDb();
+    vi.spyOn(process, "platform", "get").mockReturnValue("darwin");
+
+    configureSqliteWalMaintenance(db, { checkpointIntervalMs: 0 });
+
+    expect(db["exec"]).toHaveBeenNthCalledWith(1, "PRAGMA journal_mode = WAL;");
+    expect(db["exec"]).toHaveBeenNthCalledWith(2, "PRAGMA checkpoint_fullfsync = 1;");
+    expect(db["exec"]).toHaveBeenNthCalledWith(
+      3,
+      `PRAGMA wal_autocheckpoint = ${DEFAULT_SQLITE_WAL_AUTOCHECKPOINT_PAGES};`,
+    );
+  });
+
+  it("continues WAL setup if macOS checkpoint fullfsync is unavailable", () => {
+    const db = createMockDb();
+    vi.spyOn(process, "platform", "get").mockReturnValue("darwin");
+    vi.mocked(db["exec"]).mockImplementation((sql) => {
+      if (sql.includes("checkpoint_fullfsync")) {
+        throw new Error("unsupported pragma");
+      }
+    });
+
+    configureSqliteWalMaintenance(db, { checkpointIntervalMs: 0 });
+
+    expect(db["exec"]).toHaveBeenNthCalledWith(1, "PRAGMA journal_mode = WAL;");
+    expect(db["exec"]).toHaveBeenNthCalledWith(2, "PRAGMA checkpoint_fullfsync = 1;");
+    expect(db["exec"]).toHaveBeenNthCalledWith(
+      3,
+      `PRAGMA wal_autocheckpoint = ${DEFAULT_SQLITE_WAL_AUTOCHECKPOINT_PAGES};`,
+    );
+  });
+
   it("uses rollback journaling for databases on NFS-backed volumes", () => {
     const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-sqlite-nfs-"));
     try {
       const db = createMockDb();
+      vi.spyOn(process, "platform", "get").mockReturnValue("linux");
       const statfs = vi.spyOn(fs, "statfsSync").mockReturnValue(statfsFixture(0x6969));
 
       const maintenance = configureSqliteWalMaintenance(db, {
@@ -81,6 +116,7 @@ describe("sqlite WAL maintenance", () => {
     const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-sqlite-network-"));
     try {
       const db = createMockDb();
+      vi.spyOn(process, "platform", "get").mockReturnValue("linux");
       vi.spyOn(fs, "statfsSync").mockReturnValue(statfsFixture(fsType));
 
       configureSqliteWalMaintenance(db, {
@@ -188,6 +224,7 @@ describe("sqlite WAL maintenance", () => {
     const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-sqlite-nfs-"));
     try {
       const db = createMockDb();
+      vi.spyOn(process, "platform", "get").mockReturnValue("linux");
       vi.spyOn(fs, "statfsSync").mockReturnValue(statfsFixture(0));
       vi.spyOn(fs, "readFileSync").mockReturnValue(
         `42 12 0:41 / ${tempDir} rw,relatime - nfs4 server:/share rw\n`,
@@ -208,6 +245,7 @@ describe("sqlite WAL maintenance", () => {
     const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-sqlite-sshfs-"));
     try {
       const db = createMockDb();
+      vi.spyOn(process, "platform", "get").mockReturnValue("linux");
       vi.spyOn(fs, "statfsSync").mockReturnValue(statfsFixture(0));
       vi.spyOn(fs, "readFileSync").mockReturnValue(
         `42 12 0:41 / ${tempDir} rw,relatime - fuse.sshfs user@host:/share rw\n`,
@@ -285,6 +323,7 @@ describe("sqlite WAL maintenance", () => {
     const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-sqlite-nfs-"));
     try {
       const db = createMockDb();
+      vi.spyOn(process, "platform", "get").mockReturnValue("linux");
       vi.spyOn(fs, "statfsSync").mockReturnValue(statfsFixture(0));
       vi.spyOn(fs, "readFileSync").mockImplementation(() => {
         throw new Error("no proc mountinfo");
@@ -308,6 +347,7 @@ describe("sqlite WAL maintenance", () => {
     const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-sqlite-smb-"));
     try {
       const db = createMockDb();
+      vi.spyOn(process, "platform", "get").mockReturnValue("darwin");
       vi.spyOn(fs, "statfsSync").mockReturnValue(statfsFixture(0));
       vi.spyOn(fs, "readFileSync").mockImplementation(() => {
         throw new Error("no proc mountinfo");
@@ -337,6 +377,7 @@ describe("sqlite WAL maintenance", () => {
     const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-sqlite-sshfs-macfuse-"));
     try {
       const db = createMockDb();
+      vi.spyOn(process, "platform", "get").mockReturnValue("darwin");
       vi.spyOn(fs, "statfsSync").mockReturnValue(statfsFixture(0));
       vi.spyOn(fs, "readFileSync").mockImplementation(() => {
         throw new Error("no proc mountinfo");
@@ -362,6 +403,7 @@ describe("sqlite WAL maintenance", () => {
     const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-sqlite-macfuse-"));
     try {
       const db = createMockDb();
+      vi.spyOn(process, "platform", "get").mockReturnValue("darwin");
       vi.spyOn(fs, "statfsSync").mockReturnValue(statfsFixture(0));
       vi.spyOn(fs, "readFileSync").mockImplementation(() => {
         throw new Error("no proc mountinfo");
@@ -385,6 +427,7 @@ describe("sqlite WAL maintenance", () => {
     const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-sqlite-nfs-"));
     try {
       const db = createMockDb();
+      vi.spyOn(process, "platform", "get").mockReturnValue("linux");
       vi.spyOn(fs, "statfsSync").mockReturnValue(statfsFixture(0));
       vi.spyOn(fs, "readFileSync").mockImplementation(() => {
         throw new Error("no proc mountinfo");
@@ -407,6 +450,7 @@ describe("sqlite WAL maintenance", () => {
   it("runs lightweight periodic PASSIVE checkpoints and TRUNCATE on close", () => {
     vi.useFakeTimers();
     const db = createMockDb();
+    vi.spyOn(process, "platform", "get").mockReturnValue("linux");
 
     const maintenance = configureSqliteWalMaintenance(db, { checkpointIntervalMs: 100 });
     expect(db["exec"]).toHaveBeenCalledTimes(2);
@@ -427,6 +471,7 @@ describe("sqlite WAL maintenance", () => {
     vi.useFakeTimers();
     const setIntervalSpy = vi.spyOn(globalThis, "setInterval");
     const db = createMockDb();
+    vi.spyOn(process, "platform", "get").mockReturnValue("linux");
 
     const maintenance = configureSqliteWalMaintenance(db, {
       checkpointIntervalMs: Number.MAX_SAFE_INTEGER,
@@ -439,6 +484,7 @@ describe("sqlite WAL maintenance", () => {
   it("honors explicit checkpoint mode overrides for periodic and close checkpoints", () => {
     vi.useFakeTimers();
     const db = createMockDb();
+    vi.spyOn(process, "platform", "get").mockReturnValue("linux");
 
     const maintenance = configureSqliteWalMaintenance(db, {
       checkpointIntervalMs: 100,
@@ -456,6 +502,7 @@ describe("sqlite WAL maintenance", () => {
     const db = createMockDb();
     const error = new Error("busy");
     const onCheckpointError = vi.fn();
+    vi.spyOn(process, "platform", "get").mockReturnValue("linux");
     vi.mocked(db["exec"]).mockImplementation((sql) => {
       if (sql.includes("wal_checkpoint")) {
         throw error;
@@ -473,6 +520,7 @@ describe("sqlite WAL maintenance", () => {
 
   it("configures connection pragmas before WAL maintenance", () => {
     const db = createMockDb();
+    vi.spyOn(process, "platform", "get").mockReturnValue("linux");
 
     configureSqliteConnectionPragmas(db, {
       busyTimeoutMs: 30_000,

--- a/src/infra/sqlite-wal.ts
+++ b/src/infra/sqlite-wal.ts
@@ -274,6 +274,19 @@ function requireRollbackJournalMode(db: DatabaseSync, options: SqliteWalMaintena
   }
 }
 
+function enableMacosCheckpointFullfsync(db: DatabaseSync): void {
+  if (process.platform !== "darwin") {
+    return;
+  }
+  try {
+    db.exec("PRAGMA checkpoint_fullfsync = 1;");
+  } catch {
+    // Older SQLite builds may ignore or reject platform-specific pragmas. WAL
+    // setup should still proceed because this is a durability upgrade, not a
+    // prerequisite for opening the store.
+  }
+}
+
 function refuseUnsupportedFilesystem(options: SqliteWalMaintenanceOptions): never {
   const label = options.databaseLabel ?? "sqlite database";
   const location = options.databasePath ? ` at ${options.databasePath}` : "";
@@ -312,6 +325,7 @@ export function configureSqliteWalMaintenance(
     };
   }
   db.exec("PRAGMA journal_mode = WAL;");
+  enableMacosCheckpointFullfsync(db);
   db.exec(`PRAGMA wal_autocheckpoint = ${autoCheckpointPages};`);
 
   const runCheckpoint = (mode: SqliteWalCheckpointMode): boolean => {


### PR DESCRIPTION
Closes #99066

## What Problem This Solves

Fixes an issue where macOS users could run OpenClaw SQLite WAL checkpoints without SQLite's macOS fullfsync checkpoint barrier enabled. The normal app behavior would not show an error, but recently checkpointed local state could be less durable than intended across abrupt power loss or OS crashes.

## Why This Change Was Made

This change enables `PRAGMA checkpoint_fullfsync = 1;` after WAL mode is turned on, only on macOS. The PRAGMA is treated as a best-effort durability upgrade: if a SQLite build rejects it, WAL setup continues with the existing autocheckpoint and rollback-on-unsupported-filesystem behavior.

## User Impact

Mac users get stronger SQLite WAL checkpoint durability without changing configuration. Linux and Windows behavior is unchanged, and older SQLite builds that do not support the PRAGMA continue to open and configure their stores normally.

## Evidence

Live macOS runtime proof from a real Node SQLite process on macOS 13.7.8, running this PR branch (`aa10f1dd2f58723d5c9769de52086115c1a308b9`):

```text
platform=darwin
macos=13.7.8
node=v22.22.0
branch=proof/sqlite-macos-checkpoint-fullfsync
head=aa10f1dd2f58723d5c9769de52086115c1a308b9
journal_mode=wal
checkpoint_fullfsync=1
wal_autocheckpoint=1000
maintenance_checkpoint=true
maintenance_close=true
(node:76412) ExperimentalWarning: SQLite is an experimental feature and might change at any time
```

The live probe created a temporary SQLite database, called `configureSqliteConnectionPragmas(db, { databasePath, checkpointIntervalMs: 0 })`, then queried:

```text
PRAGMA journal_mode;
PRAGMA checkpoint_fullfsync;
PRAGMA wal_autocheckpoint;
```

The observed `checkpoint_fullfsync=1` confirms the macOS PRAGMA is applied in a real SQLite process after WAL setup.

Additional validation:

- Source-level before condition: `configureSqliteWalMaintenance` enabled `journal_mode = WAL` and `wal_autocheckpoint`, but had no macOS branch for `checkpoint_fullfsync`.
- Added focused coverage that mocks `process.platform` to `darwin` and verifies WAL setup calls `PRAGMA checkpoint_fullfsync = 1;` immediately after enabling WAL mode.
- Added fallback coverage that makes the macOS `checkpoint_fullfsync` PRAGMA throw and verifies WAL setup continues to `wal_autocheckpoint`.
- Existing rollback/NFS/network-filesystem behavior remains pinned by the same `sqlite-wal.test.ts` suite with explicit non-macOS platform mocks where needed.
- `node scripts\run-vitest.mjs src/infra/sqlite-wal.test.ts` -> 1 file passed, 34 tests passed.
- `pnpm exec oxlint src/infra/sqlite-wal.ts src/infra/sqlite-wal.test.ts`
- `pnpm exec oxfmt --check src/infra/sqlite-wal.ts src/infra/sqlite-wal.test.ts`
- `git diff --check HEAD~1..HEAD`
- Repo-local autoreview: `python .agents\skills\autoreview\scripts\autoreview --mode commit --commit HEAD` -> `autoreview clean: no accepted/actionable findings reported`.
