### PR TITLE
fix(discord): only apply reply reference to first chunk in multi-chunk sends

### DIFF
--- a/extensions/discord/src/send.sends-basic-channel-messages.test.ts
+++ b/extensions/discord/src/send.sends-basic-channel-messages.test.ts
@@ -677,21 +677,21 @@ describe("sendMessageDiscord", () => {
     });
   });
 
-  it("preserves reply reference across all text chunks", async () => {
+  it("preserves reply reference only on the first text chunk", async () => {
     const { firstBody, secondBody } = await sendChunkedReplyAndCollectBodies({
       text: "a".repeat(2001),
     });
     expectReplyReference(firstBody, "orig-123");
-    expectReplyReference(secondBody, "orig-123");
+    expect(secondBody?.message_reference).toBeUndefined();
   });
 
-  it("preserves reply reference for follow-up text chunks after media caption split", async () => {
+  it("preserves reply reference only on media caption, not follow-up chunks", async () => {
     const { firstBody, secondBody } = await sendChunkedReplyAndCollectBodies({
       text: "a".repeat(2500),
       mediaUrl: "file:///tmp/photo.jpg",
     });
     expectReplyReference(firstBody, "orig-123");
-    expectReplyReference(secondBody, "orig-123");
+    expect(secondBody?.message_reference).toBeUndefined();
   });
 });
 

--- a/extensions/discord/src/send.shared.ts
+++ b/extensions/discord/src/send.shared.ts
@@ -328,7 +328,7 @@ async function sendDiscordText(
       components: chunkComponents,
       embeds: chunkEmbeds,
       flags,
-      replyTo,
+      replyTo: isFirst ? replyTo : undefined,
     });
     return (await request(
       () => createChannelMessage<{ id: string; channel_id: string }>(rest, channelId, { body }),
@@ -424,7 +424,7 @@ async function sendDiscordMedia(
       rest,
       channelId,
       chunk,
-      replyTo,
+      undefined,
       request,
       maxLinesPerMessage,
       undefined,


### PR DESCRIPTION
## What Problem This Solves

With `channels.discord.replyToMode: "first"`, one logical reply split into N physical Discord messages was sent with the `message_reference` on ALL N messages, not just the first. This causes reply-notification spam — the original message author receives N reply pings instead of one.

## Why This Change Was Made

The `sendDiscordText` function in `extensions/discord/src/send.shared.ts` passes `replyTo` unconditionally to `buildDiscordMessageRequest` for every chunk, regardless of whether it is the first message. The `isFirst` parameter already controls components and embeds but was not applied to the reply reference field.

The fix passes `replyTo` only when `isFirst` is true, ensuring only the leading chunk carries the native reply reference. The `sendDiscordMedia` follow-up text loop is also updated to skip the reply reference on trailing chunks.

## Changes

- **`extensions/discord/src/send.shared.ts`** — gate `replyTo` on `isFirst` in `sendChunk`, pass `undefined` for follow-up text chunks after media caption
- **`extensions/discord/src/send.sends-basic-channel-messages.test.ts`** — update two tests to verify reply reference is only on the first chunk, not follow-ups

## Evidence

### Test command
```
npx vitest run extensions/discord/src/send.sends-basic-channel-messages.test.ts extensions/discord/src/chunk.test.ts
```

### Test output
```
|extension-discord| ../../extensions/discord/src/send.sends-basic-channel-messages.test.ts (44 tests)
|extension-discord| ../../extensions/discord/src/chunk.test.ts (17 tests)
  ✓ preserves reply reference only on the first text chunk
  ✓ preserves reply reference only on media caption, not follow-up chunks

 Test Files  2 passed (2)
      Tests  61 passed (61)
```

### Behavior verification
- Before: N-chunk reply → N native reply pings on the original message (spam)
- After: N-chunk reply → 1 native reply ping on the first chunk only

## Related

Closes #99068

🤖 Generated with [Claude Code](https://claude.com/claude-code)
