### PR TITLE
test: migrate sandbox security and host-path tests to shared temp-dir helpers

### DIFF
--- a/src/agents/sandbox/host-paths.test.ts
+++ b/src/agents/sandbox/host-paths.test.ts
@@ -1,15 +1,29 @@
 // Sandbox host path tests cover cross-platform path normalization and symlink
 // resolution used before Docker bind mounts are constructed.
-import { mkdtempSync, mkdirSync, realpathSync, symlinkSync } from "node:fs";
-import { tmpdir } from "node:os";
+import { mkdirSync, realpathSync, symlinkSync } from "node:fs";
 import { join } from "node:path";
-import { describe, expect, it } from "vitest";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { createSuiteTempRootTracker } from "../../test-helpers/temp-dir.js";
 import {
   getSandboxHostPathPolicyKey,
   isSandboxHostPathAbsolute,
   normalizeSandboxHostPath,
   resolveSandboxHostPathViaExistingAncestor,
 } from "./host-paths.js";
+
+const suiteTempDirs = createSuiteTempRootTracker({ prefix: "openclaw-host-paths-" });
+
+async function makeTempDir(): Promise<string> {
+  return suiteTempDirs.make("case");
+}
+
+beforeAll(async () => {
+  await suiteTempDirs.setup();
+});
+
+afterAll(async () => {
+  await suiteTempDirs.cleanup();
+});
 
 describe("normalizeSandboxHostPath", () => {
   it("normalizes dot segments and strips trailing slash", () => {
@@ -61,14 +75,14 @@ describe("resolveSandboxHostPathViaExistingAncestor", () => {
     );
   });
 
-  it("resolves symlink parents when the final leaf does not exist", () => {
+  it("resolves symlink parents when the final leaf does not exist", async () => {
     // Mount checks need the real parent path even when Docker will create the
     // final missing leaf later.
     if (process.platform === "win32") {
       return;
     }
 
-    const root = mkdtempSync(join(tmpdir(), "openclaw-host-paths-"));
+    const root = await makeTempDir();
     const workspace = join(root, "workspace");
     const outside = join(root, "outside");
     mkdirSync(workspace, { recursive: true });

--- a/src/agents/sandbox/validate-sandbox-security.test.ts
+++ b/src/agents/sandbox/validate-sandbox-security.test.ts
@@ -1,9 +1,9 @@
 // Sandbox security validation tests cover bind, network, seccomp, and AppArmor
 // hardening rules before Docker runtimes are created.
-import { mkdirSync, mkdtempSync, symlinkSync } from "node:fs";
-import { tmpdir } from "node:os";
+import { mkdirSync, symlinkSync } from "node:fs";
 import { join } from "node:path";
-import { describe, expect, it } from "vitest";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { createSuiteTempRootTracker } from "../../test-helpers/temp-dir.js";
 import { withEnv } from "../../test-utils/env.js";
 import { resolveSandboxHostPathViaExistingAncestor } from "./host-paths.js";
 import {
@@ -14,6 +14,20 @@ import {
   validateApparmorProfile,
   validateSandboxSecurity,
 } from "./validate-sandbox-security.js";
+
+const suiteTempDirs = createSuiteTempRootTracker({ prefix: "openclaw-sandbox-" });
+
+async function makeTempDir(): Promise<string> {
+  return suiteTempDirs.make("case");
+}
+
+beforeAll(async () => {
+  await suiteTempDirs.setup();
+});
+
+afterAll(async () => {
+  await suiteTempDirs.cleanup();
+});
 
 function expectBindMountsToThrow(binds: string[], expected: RegExp, label: string) {
   expect(() => validateBindMounts(binds), label).toThrow(expected);
@@ -89,14 +103,14 @@ describe("getBlockedBindReason", () => {
     });
   });
 
-  it("blocks canonical OS-home aliases for credential paths", () => {
+  it("blocks canonical OS-home aliases for credential paths", async () => {
     // Credential blocking uses canonical home aliases so a symlinked HOME cannot
     // hide sensitive host paths.
     if (process.platform === "win32") {
       return;
     }
 
-    const dir = mkdtempSync(join(tmpdir(), "openclaw-home-"));
+    const dir = await makeTempDir();
     const realHome = join(dir, "real-home");
     const aliasHome = join(dir, "alias-home");
     mkdirSync(join(realHome, ".ssh"), { recursive: true });
@@ -109,8 +123,8 @@ describe("getBlockedBindReason", () => {
 });
 
 describe("validateBindMounts", () => {
-  it("allows legitimate project directory mounts", () => {
-    const projectRoot = mkdtempSync(join(tmpdir(), "openclaw-sbx-safe-"));
+  it("allows legitimate project directory mounts", async () => {
+    const projectRoot = await makeTempDir();
     expect(
       validateBindMounts([
         `${join(projectRoot, "source")}:/source:rw`,
@@ -229,12 +243,12 @@ describe("validateBindMounts", () => {
     ).toThrow(/outside allowed roots/);
   });
 
-  it("blocks credential binds through canonical home aliases", () => {
+  it("blocks credential binds through canonical home aliases", async () => {
     if (process.platform === "win32") {
       return;
     }
 
-    const dir = mkdtempSync(join(tmpdir(), "openclaw-home-"));
+    const dir = await makeTempDir();
     const realHome = join(dir, "real-home");
     const aliasHome = join(dir, "alias-home");
     mkdirSync(join(realHome, ".docker"), { recursive: true });
@@ -246,27 +260,27 @@ describe("validateBindMounts", () => {
     });
   });
 
-  it("blocks symlink escapes into blocked directories", () => {
+  it("blocks symlink escapes into blocked directories", async () => {
     if (process.platform === "win32") {
       // Symlink setup for blocked POSIX targets like /etc is POSIX-only.
       return;
     }
 
-    const dir = mkdtempSync(join(tmpdir(), "openclaw-sbx-"));
+    const dir = await makeTempDir();
     const link = join(dir, "etc-link");
     symlinkSync("/etc", link);
     const run = () => validateBindMounts([`${link}/passwd:/mnt/passwd:ro`]);
     expect(run).toThrow(/blocked path/);
   });
 
-  it("blocks symlink-parent escapes with non-existent leaf outside allowed roots", () => {
+  it("blocks symlink-parent escapes with non-existent leaf outside allowed roots", async () => {
     // Docker may create the final leaf; validate the existing ancestor so
     // symlink parents cannot escape an allowed root.
     if (process.platform === "win32") {
       // Windows symlink semantics differ; POSIX symlink escape coverage runs on POSIX hosts.
       return;
     }
-    const dir = mkdtempSync(join(tmpdir(), "openclaw-sbx-"));
+    const dir = await makeTempDir();
     const workspace = join(dir, "workspace");
     const outside = join(dir, "outside");
     mkdirSync(workspace, { recursive: true });
@@ -281,12 +295,12 @@ describe("validateBindMounts", () => {
     ).toThrow(/outside allowed roots/);
   });
 
-  it("blocks symlink-parent escapes into blocked paths when leaf does not exist", () => {
+  it("blocks symlink-parent escapes into blocked paths when leaf does not exist", async () => {
     if (process.platform === "win32") {
       // Symlink setup for blocked POSIX targets like /var/run is POSIX-only.
       return;
     }
-    const dir = mkdtempSync(join(tmpdir(), "openclaw-sbx-"));
+    const dir = await makeTempDir();
     const workspace = join(dir, "workspace");
     mkdirSync(workspace, { recursive: true });
     const link = join(workspace, "run-link");
@@ -306,9 +320,9 @@ describe("validateBindMounts", () => {
     }
   });
 
-  it("blocks bind sources outside allowed roots when allowlist is configured", () => {
-    const allowedRoot = mkdtempSync(join(tmpdir(), "openclaw-sbx-allowed-root-"));
-    const externalRoot = mkdtempSync(join(tmpdir(), "openclaw-sbx-external-"));
+  it("blocks bind sources outside allowed roots when allowlist is configured", async () => {
+    const allowedRoot = await makeTempDir();
+    const externalRoot = await makeTempDir();
     expect(() =>
       validateBindMounts([`${externalRoot}:/data:ro`], {
         allowedSourceRoots: [allowedRoot],
@@ -316,8 +330,8 @@ describe("validateBindMounts", () => {
     ).toThrow(/outside allowed roots/);
   });
 
-  it("allows bind sources in allowed roots when allowlist is configured", () => {
-    const projectRoot = mkdtempSync(join(tmpdir(), "openclaw-sbx-allowed-"));
+  it("allows bind sources in allowed roots when allowlist is configured", async () => {
+    const projectRoot = await makeTempDir();
     expect(
       validateBindMounts([`${join(projectRoot, "cache")}:/data:ro`], {
         allowedSourceRoots: [projectRoot],
@@ -325,9 +339,9 @@ describe("validateBindMounts", () => {
     ).toBeUndefined();
   });
 
-  it("allows bind sources outside allowed roots with explicit dangerous override", () => {
-    const allowedRoot = mkdtempSync(join(tmpdir(), "openclaw-sbx-allowed-root-"));
-    const externalRoot = mkdtempSync(join(tmpdir(), "openclaw-sbx-external-"));
+  it("allows bind sources outside allowed roots with explicit dangerous override", async () => {
+    const allowedRoot = await makeTempDir();
+    const externalRoot = await makeTempDir();
     expect(
       validateBindMounts([`${externalRoot}:/data:ro`], {
         allowedSourceRoots: [allowedRoot],
@@ -336,15 +350,15 @@ describe("validateBindMounts", () => {
     ).toBeUndefined();
   });
 
-  it("blocks reserved container target paths by default", () => {
-    const projectRoot = mkdtempSync(join(tmpdir(), "openclaw-sbx-reserved-default-"));
+  it("blocks reserved container target paths by default", async () => {
+    const projectRoot = await makeTempDir();
     expect(() =>
       validateBindMounts([`${projectRoot}:/workspace:rw`, `${projectRoot}:/agent/cache:rw`]),
     ).toThrow(/reserved container path/);
   });
 
-  it("allows reserved container target paths with explicit dangerous override", () => {
-    const projectRoot = mkdtempSync(join(tmpdir(), "openclaw-sbx-reserved-"));
+  it("allows reserved container target paths with explicit dangerous override", async () => {
+    const projectRoot = await makeTempDir();
     expect(
       validateBindMounts([`${projectRoot}:/workspace:rw`], {
         allowReservedContainerTargets: true,
@@ -433,8 +447,8 @@ describe("profile hardening", () => {
 });
 
 describe("validateSandboxSecurity", () => {
-  it("passes with safe config", () => {
-    const projectRoot = mkdtempSync(join(tmpdir(), "openclaw-sbx-safe-config-"));
+  it("passes with safe config", async () => {
+    const projectRoot = await makeTempDir();
     expect(
       validateSandboxSecurity({
         binds: [`${projectRoot}:/src:rw`],


### PR DESCRIPTION
## What Problem This Solves

Two sandbox test files create temp directories with raw `fs.mkdtempSync` and never clean them up:

- `src/agents/sandbox/validate-sandbox-security.test.ts`: 14 `mkdtempSync` calls across bind-mount, allowed-root, symlink-escape, and safe-config tests; none are removed.
- `src/agents/sandbox/host-paths.test.ts`: 1 `mkdtempSync` call in the symlink-parent resolution test; never removed.

These leaks add `/tmp` pressure during agent sandbox test runs.

## Why This Change Was Made

Migrates both files to the existing shared helper `createSuiteTempRootTracker` from `src/test-helpers/temp-dir.js`, which removes the suite temp root in `afterAll` even if individual assertions fail.

Changes per file:
- `validate-sandbox-security.test.ts`: replaced 14 `mkdtempSync(...)` calls with `await makeTempDir()`; made corresponding `it` callbacks async; added suite-level `beforeAll`/`afterAll` lifecycle.
- `host-paths.test.ts`: replaced the single `mkdtempSync(...)` call with `await makeTempDir()`; added matching suite lifecycle.

Removed now-unused `mkdtempSync` and `tmpdir` imports.

## User Impact

Test-only. Reduces dangling temp directories during sandbox security and host-path tests. No user-visible or production behavior change.

## Evidence

```bash
node scripts/run-vitest.mjs \
  src/agents/sandbox/validate-sandbox-security.test.ts \
  src/agents/sandbox/host-paths.test.ts \
  --run
```

Results:

```console
 Test Files  2 passed (2)
      Tests  42 passed (42)
```

Lint (modified files only):

```bash
node scripts/run-oxlint.mjs \
  src/agents/sandbox/validate-sandbox-security.test.ts \
  src/agents/sandbox/host-paths.test.ts
```

→ exit 0

Typecheck:

```bash
pnpm tsgo:core:test
```

→ exit 0

## Real behavior proof

- **Behavior addressed**: two sandbox test files no longer leak temp directories created by `mkdtempSync`.
- **Real environment tested**: Linux x86_64, Node 22.19+, local source checkout.
- **Exact steps or command run after this patch**: see Evidence section above.
- **Evidence after fix**: 42 tests pass; lint and typecheck pass; temp directories are removed by `createSuiteTempRootTracker` after the suite.
- **Observed result after fix**: the isolated `TMPDIR` contains no leftover directories matching `openclaw-sandbox-*`, `openclaw-host-paths-*`, or the old per-test prefixes (`openclaw-sbx-*`, `openclaw-home-*`).
- **What was not tested**: full CI suite (triggered on push to remote).

### Cleanup verification

```bash
tmp=$(mktemp -d)
TMPDIR="$tmp" node scripts/run-vitest.mjs \
  src/agents/sandbox/validate-sandbox-security.test.ts \
  src/agents/sandbox/host-paths.test.ts \
  --run

for p in openclaw-sandbox- openclaw-host-paths- openclaw-sbx- openclaw-home-; do
  ls -d "$tmp/${p}"* 2>/dev/null || echo "$p: none"
done
```

Results:

```console
 Test Files  2 passed (2)
      Tests  42 passed (42)

--- leftovers ---
openclaw-sandbox-: none
openclaw-host-paths-: none
openclaw-sbx-: none
openclaw-home-: none
```

The isolated `TMPDIR` contained no leftover directories matching any of the temp-root prefixes introduced or converted by this PR.

## AI-assisted

Implemented and verified with AI assistance; reviewed by a human before submission.
