### PR TITLE
fix(qqbot): bound gateway websocket payloads

### DIFF
--- a/extensions/qqbot/src/engine/gateway/ws-client.test.ts
+++ b/extensions/qqbot/src/engine/gateway/ws-client.test.ts
@@ -19,6 +19,7 @@ vi.mock("ws", () => ({
 
 type CreateQQWSClient = typeof import("./ws-client.js").createQQWSClient;
 let createQQWSClient: CreateQQWSClient;
+const qqbotGatewayPayloadLimitBytes = 16 * 1024 * 1024;
 let priorProxyEnv: Partial<Record<ProxyEnvKey, string | undefined>> = {};
 
 beforeAll(async () => {
@@ -78,6 +79,7 @@ describe("createQQWSClient", () => {
       {
         headers: { "User-Agent": "openclaw-qqbot-test" },
         handshakeTimeout: 30_000,
+        maxPayload: qqbotGatewayPayloadLimitBytes,
       },
     ]);
   });
@@ -98,6 +100,7 @@ describe("createQQWSClient", () => {
         agent: { proxied: true },
         headers: { "User-Agent": "openclaw-qqbot-test" },
         handshakeTimeout: 30_000,
+        maxPayload: qqbotGatewayPayloadLimitBytes,
       },
     ]);
   });
@@ -118,6 +121,7 @@ describe("createQQWSClient", () => {
         agent: { proxied: true },
         headers: { "User-Agent": "openclaw-qqbot-test" },
         handshakeTimeout: 30_000,
+        maxPayload: qqbotGatewayPayloadLimitBytes,
       },
     ]);
   });
@@ -138,6 +142,7 @@ describe("createQQWSClient", () => {
         agent: { proxied: true },
         headers: { "User-Agent": "openclaw-qqbot-test" },
         handshakeTimeout: 30_000,
+        maxPayload: qqbotGatewayPayloadLimitBytes,
       },
     ]);
   });

--- a/extensions/qqbot/src/engine/gateway/ws-client.ts
+++ b/extensions/qqbot/src/engine/gateway/ws-client.ts
@@ -7,6 +7,9 @@ import WebSocket from "ws";
 // precedent (Discord, Slack, Signal) so a half-open upgrade eventually closes,
 // releases GatewayConnection.isConnecting, and allows reconnects.
 const QQBOT_WEBSOCKET_HANDSHAKE_TIMEOUT_MS = 30_000;
+// Match the established Discord and Mattermost gateway ceiling: leave room for
+// multi-megabyte events while bounding ws's 100 MiB default before JSON parsing.
+const QQBOT_GATEWAY_PAYLOAD_LIMIT_BYTES = 16 * 1024 * 1024;
 
 interface QQWSClientOptions {
   gatewayUrl: string;
@@ -18,6 +21,7 @@ export async function createQQWSClient(options: QQWSClientOptions): Promise<WebS
   return new WebSocket(options.gatewayUrl, {
     headers: { "User-Agent": options.userAgent },
     handshakeTimeout: QQBOT_WEBSOCKET_HANDSHAKE_TIMEOUT_MS,
+    maxPayload: QQBOT_GATEWAY_PAYLOAD_LIMIT_BYTES,
     ...(wsAgent ? { agent: wsAgent } : {}),
   });
 }


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where QQBot gateway WebSocket connections inherited the `ws` client default 100 MiB inbound-message window.

## Why This Change Was Made

The QQBot client now uses the repository's established 16 MiB Discord/Mattermost gateway ceiling. QQ's gateway documentation defines JSON event envelopes but does not establish the earlier 1 MiB value, so the higher bounded ceiling avoids rejecting plausible multi-megabyte events while still failing closed well below the dependency default.

## User Impact

Operators get a bounded QQBot gateway resource policy without disconnecting on events between 1 MiB and 16 MiB.

## Evidence

- `pnpm exec tsx proof-live.ts` exercised production `createQQWSClient()` against a loopback WebSocket server: a 16,776,246-byte JSON event succeeded just below the 16 MiB boundary, and an over-boundary event was rejected by `ws` before application parsing.
- Negative control: the oversize path closed with server code `1009` and did not deliver a third message.
- `node scripts/run-vitest.mjs extensions/qqbot/src/engine/gateway/ws-client.test.ts`: 4 passed.

```text
$ pnpm exec tsx proof-live.ts
configured_max_payload_bytes=16777216
normal_frame_bytes=42
near_limit_frame_bytes=16776246
near_limit_event_received=true
client_error_message=Max payload size exceeded
client_error_code=WS_ERR_UNSUPPORTED_MESSAGE_LENGTH
server_close_code=1009
client_close_code=1006
messages_after_oversized=2
```

<details>
<summary>proof-live.ts</summary>

```ts
import { once } from "node:events";
import { WebSocket, WebSocketServer } from "ws";
import { createQQWSClient } from "./extensions/qqbot/src/engine/gateway/ws-client.ts";

const configuredMaxPayloadBytes = 16 * 1024 * 1024;
const server = new WebSocketServer({ host: "127.0.0.1", port: 0 });
await once(server, "listening");
const address = server.address();
if (typeof address === "string" || address === null) {
  throw new Error("unexpected websocket address");
}

const received: number[] = [];
server.on("connection", (socket) => {
  socket.send(JSON.stringify({ op: 0, t: "READY", s: 1, d: { ok: true } }));
  socket.send(
    JSON.stringify({
      op: 0,
      t: "MESSAGE_CREATE",
      s: 2,
      d: { content: "x".repeat(configuredMaxPayloadBytes - 1024) },
    }),
  );
  socket.send(
    JSON.stringify({
      op: 0,
      t: "MESSAGE_CREATE",
      s: 3,
      d: { content: "x".repeat(configuredMaxPayloadBytes) },
    }),
  );
});

const client = await createQQWSClient({
  gatewayUrl: `ws://127.0.0.1:${address.port}`,
  userAgent: "openclaw-qqbot-proof",
});
client.on("message", (data) => {
  received.push(Buffer.byteLength(data));
});
const [error] = (await once(client, "error")) as [Error & { code?: string }];
const [serverSocket] = [...server.clients];
const [serverCloseCode] = (await once(serverSocket, "close")) as [number];
const [clientCloseCode] = (await once(client, "close")) as [number];

console.log(`configured_max_payload_bytes=${configuredMaxPayloadBytes}`);
console.log(`normal_frame_bytes=${received[0]}`);
console.log(`near_limit_frame_bytes=${received[1]}`);
console.log(`near_limit_event_received=${received.length >= 2}`);
console.log(`client_error_message=${error.message}`);
console.log(`client_error_code=${error.code}`);
console.log(`server_close_code=${serverCloseCode}`);
console.log(`client_close_code=${clientCloseCode}`);
console.log(`messages_after_oversized=${received.length}`);

server.close();
```

</details>

AI-assisted: built with Codex
