### PR TITLE
fix: avoid model-not-found fallback on OpenRouter image-input 404s

### DIFF
--- a/src/agents/embedded-agent-helpers/errors.ts
+++ b/src/agents/embedded-agent-helpers/errors.ts
@@ -820,7 +820,8 @@ function classifyFailoverClassificationFromHttpStatus(
       messageReason === "session_expired" ||
       messageReason === "billing" ||
       messageReason === "auth_permanent" ||
-      messageReason === "auth"
+      messageReason === "auth" ||
+      messageReason === "format"
     ) {
       return messageClassification;
     }
@@ -998,6 +999,18 @@ function isClaudeCliLoggedOutError(raw: string, provider?: string): boolean {
   return /\bnot logged in\b\s*·\s*please run \/login\b/i.test(raw);
 }
 
+function isUnsupportedImageInputErrorMessage(raw: string | undefined): boolean {
+  const normalized = normalizeOptionalLowercaseString(raw);
+  if (!normalized) {
+    return false;
+  }
+  return (
+    /\bdoes not support image inputs?\b/.test(normalized) ||
+    /\bunsupported image input\b/.test(normalized) ||
+    (/\bno endpoints found\b/.test(normalized) && /\bsupport image input\b/.test(normalized))
+  );
+}
+
 function classifyFailoverClassificationFromMessage(
   raw: string,
   provider?: string,
@@ -1008,6 +1021,9 @@ function classifyFailoverClassificationFromMessage(
   }
   if (isImageSizeError(raw)) {
     return null;
+  }
+  if (isUnsupportedImageInputErrorMessage(raw)) {
+    return toReasonClassification("format");
   }
   if (isCliSessionExpiredErrorMessage(raw)) {
     return toReasonClassification("session_expired");

--- a/src/agents/failover-error.test.ts
+++ b/src/agents/failover-error.test.ts
@@ -375,6 +375,20 @@ describe("failover-error", () => {
     ).toBe("model_not_found");
   });
 
+  it("does not classify OpenRouter image-input no-endpoints 404s as model_not_found", () => {
+    expect(
+      resolveFailoverReasonFromError({
+        status: 404,
+        message: "No endpoints found that support image input",
+      }),
+    ).toBe("format");
+    expect(
+      resolveFailoverReasonFromError(
+        new Error("HTTP 404: No endpoints found that support image input"),
+      ),
+    ).toBe("format");
+  });
+
   it("classifies JSON-wrapped OpenRouter stealth-model 404s as model_not_found", () => {
     expect(
       resolveFailoverReasonFromError({

--- a/src/agents/live-model-errors.test.ts
+++ b/src/agents/live-model-errors.test.ts
@@ -76,6 +76,9 @@ describe("live model error helpers", () => {
       isModelNotFoundErrorMessage("This model is not supported when using tool calling."),
     ).toBe(false);
     expect(isModelNotFoundErrorMessage("This model does not support image inputs.")).toBe(false);
+    expect(
+      isModelNotFoundErrorMessage("HTTP 404: No endpoints found that support image input"),
+    ).toBe(false);
     expect(isModelNotFoundErrorMessage("Reasoning effort is not supported for this model.")).toBe(
       false,
     );

--- a/src/agents/openrouter-error-classification.integration.test.ts
+++ b/src/agents/openrouter-error-classification.integration.test.ts
@@ -1,0 +1,94 @@
+import { createServer } from "node:http";
+import type { AddressInfo } from "node:net";
+import type { Context, Model } from "@openclaw/ai";
+import { streamOpenAICompletions } from "@openclaw/ai/internal/openai";
+import { describe, expect, it } from "vitest";
+import { classifyAssistantFailoverReason } from "./embedded-agent-helpers/errors.js";
+
+const model = {
+  id: "example/model",
+  name: "OpenRouter mock",
+  api: "openai-completions",
+  provider: "openrouter",
+  baseUrl: "",
+  reasoning: false,
+  input: ["text", "image"],
+  cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+  contextWindow: 16_000,
+  maxTokens: 1_024,
+} satisfies Model<"openai-completions">;
+
+async function runAgainstOpenRouterError(params: {
+  message: string;
+  context: Context;
+}): Promise<{ reason: string | null; requestBody: string }> {
+  let requestBody = "";
+  const server = createServer((request, response) => {
+    request.setEncoding("utf8");
+    request.on("data", (chunk: string) => {
+      requestBody += chunk;
+    });
+    request.on("end", () => {
+      response.writeHead(404, { "content-type": "application/json" });
+      response.end(JSON.stringify({ error: { code: 404, message: params.message } }));
+    });
+  });
+
+  await new Promise<void>((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", resolve);
+  });
+  try {
+    const address = server.address() as AddressInfo;
+    const result = await streamOpenAICompletions(
+      { ...model, baseUrl: `http://127.0.0.1:${address.port}/api/v1` },
+      params.context,
+      { apiKey: ["test", "key"].join("-") },
+    ).result();
+    expect(result.stopReason).toBe("error");
+    expect(result.errorMessage).toContain(params.message);
+    return { reason: classifyAssistantFailoverReason(result), requestBody };
+  } finally {
+    await new Promise<void>((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+describe("OpenRouter runtime error classification", () => {
+  it("treats an image-capability 404 as a terminal format failure", async () => {
+    const result = await runAgainstOpenRouterError({
+      message: "No endpoints found that support image input",
+      context: {
+        messages: [
+          {
+            role: "user",
+            content: [
+              { type: "text", text: "describe this" },
+              { type: "image", mimeType: "image/png", data: "aW1n" },
+            ],
+            timestamp: 1,
+          },
+        ],
+      },
+    });
+
+    expect(result.reason).toBe("format");
+    expect(JSON.parse(result.requestBody)).toMatchObject({
+      messages: [
+        {
+          content: [{ type: "text", text: "describe this" }, { type: "image_url" }],
+        },
+      ],
+    });
+  });
+
+  it("keeps a genuine missing-model 404 eligible for model fallback", async () => {
+    const result = await runAgainstOpenRouterError({
+      message: "No endpoints found for missing/model.",
+      context: { messages: [{ role: "user", content: "hello", timestamp: 1 }] },
+    });
+
+    expect(result.reason).toBe("model_not_found");
+  });
+});


### PR DESCRIPTION
Closes #99078

## What Problem This Solves

Fixes an issue where users sending image input through OpenRouter could get missing-model fallback behavior when the route returned HTTP 404 with `No endpoints found that support image input`. The model exists; the selected endpoint cannot accept the image payload.

## Why This Change Was Made

Classify explicit image-capability rejection text as a deterministic format failure and preserve that classification across HTTP 404 handling. Genuine `No endpoints found for <model>` responses remain model-not-found failures and keep their existing fallback behavior.

## User Impact

OpenRouter image-capability rejections no longer masquerade as missing models. Operators get the correct terminal failure, while real missing-model failures still use configured model fallback.

## Evidence

An OpenRouter-compatible loopback server exercised the real `openai-completions` transport. The image case verified an `image_url` request reached the provider; the missing-model sibling used a text-only request:

```text
{"fixture":"image","classification":"format","providerObservedImage":true,"stopReason":"error"}
{"fixture":"missing","classification":"model_not_found","providerObservedImage":false,"stopReason":"error"}
```

Focused regression proof:

```text
node scripts/run-vitest.mjs src/agents/openrouter-error-classification.integration.test.ts src/agents/failover-error.test.ts src/agents/live-model-errors.test.ts

Test Files  3 passed (3)
Tests       104 passed (104)
```

Changed-surface Testbox gate: https://github.com/openclaw/openclaw/actions/runs/29578587555

No live OpenRouter credential was available. The loopback fixture returned the documented OpenRouter-compatible HTTP error envelope through the production transport and covered both required classification branches.
