### PR TITLE
feat(skills): add Atomic Mail agent-owned inbox skill

### DIFF
--- a/skills/atomicmail/SKILL.md
+++ b/skills/atomicmail/SKILL.md
@@ -1,0 +1,174 @@
+---
+name: atomicmail
+description: "Register and operate an autonomous agent-owned inbox over JMAP: send, receive, reply, and triage mail."
+homepage: https://atomicmail.ai
+metadata:
+  {
+    "openclaw":
+      {
+        "emoji": "📧",
+        "requires": { "bins": ["atomicmail"] },
+        "install":
+          [
+            {
+              "id": "npm",
+              "kind": "node",
+              "package": "@atomicmail/agent-skill-openclaw",
+              "bins": ["atomicmail"],
+              "label": "Install Atomic Mail AgentSkill (npm)",
+            },
+          ],
+      },
+  }
+---
+
+# Atomic Mail
+
+Atomic Mail exposes a programmable inbox over JMAP with proof-of-work signup and
+automatic JWT rotation — no operator mailbox or human verification required. Use
+this skill when the agent needs **its own** email address to send, receive,
+reply, and triage autonomously.
+
+The `atomicmail` CLI has three commands: `register`, `jmap_request`, and `help`.
+
+> For the **operator's** existing mailbox (Gmail, corporate IMAP/SMTP), use the
+> `himalaya` skill instead. Use `atomicmail` when the agent should own the inbox.
+
+## Prerequisites
+
+- Node.js 20+ on the host (`node --version`).
+- The `atomicmail` CLI on `PATH`. Don't guess install commands — install the
+  published package:
+
+```bash
+npm install -g @atomicmail/agent-skill-openclaw
+```
+
+Verify: `atomicmail --help` exits 0. Run `atomicmail <command> --help` for flags.
+
+## Call `help` early and often
+
+The CLI embeds its own docs, version-matched to the installed package. Prefer it
+over reconstructing JMAP grammar or preset shapes from memory:
+
+- `atomicmail help --topic overview` — at the start of a mail task
+- `atomicmail help --topic presets` — before custom `jmap_request` batches
+- `atomicmail help --topic jmap_cheatsheet` — placeholders, attachments, limits
+- `atomicmail help --topic cron` — right after `register` (hourly polling)
+- `atomicmail help --topic troubleshooting` — auth or missing-placeholder errors
+
+If installed behavior disagrees with docs elsewhere, trust `help` from the
+running package.
+
+## Defaults
+
+- auth endpoint: `https://auth.atomicmail.ai`
+- api endpoint: `https://api.atomicmail.ai`
+- credentials directory: `~/.atomicmail`
+
+## Workflow
+
+### 1. Register a new inbox
+
+```bash
+atomicmail register --username "alice"
+```
+
+Usernames are 5–21 characters (local part of your `@atomicmail.ai` address).
+Writes `credentials.json`, `session.jwt`, `capability.jwt` under `~/.atomicmail`
+(mode `0600`) and prints JSON including `inbox` and `accountId`.
+
+Existing API key (e.g. lost credentials file):
+
+```bash
+atomicmail register --api-key "..."
+```
+
+If credentials already exist for a different username, `register` fails by
+default to protect the old account. To add another inbox without replacing the
+current one, pass a separate `--credentials-dir`. Use `--forced` only when you
+intend to replace credentials in the same directory (back it up first).
+
+### 2. Arrange hourly inbox polling (after register)
+
+Registration only creates credentials. Inbound mail should be fetched and
+triaged about once per hour between interactive sessions.
+
+On OpenClaw, schedule an hourly **agent** turn (not a raw CLI call) with the
+built-in cron tool:
+
+```bash
+openclaw cron add \
+  --name "atomicmail-inbox" \
+  --cron "0 * * * *" \
+  --session isolated \
+  --announce \
+  --message "Use atomicmail jmap_request --ops-file list_inbox.json to fetch my inbox. Summarize new messages, highlight what needs a reply, and stay available — I may ask you to reply, forward, search, or dig into something important."
+```
+
+See `atomicmail help --topic cron` for other hosts and the full agent prompt.
+
+### 3. Send and read mail
+
+List inbox (preset):
+
+```bash
+atomicmail jmap_request --ops-file list_inbox.json
+```
+
+Send with vars:
+
+```bash
+atomicmail jmap_request \
+  --ops-file send_mail.json \
+  --vars '{"TO":"alice@example.com","SUBJECT":"Hello","BODY":"Hi there"}'
+```
+
+Inline JMAP:
+
+```bash
+atomicmail jmap_request \
+  --ops '[["Mailbox/get", {"accountId": "$ACCOUNT_ID"}, "m0"]]'
+```
+
+**Session placeholders** resolved automatically: `$ACCOUNT_ID`, `$INBOX`,
+`$INBOX_MAILBOX_ID`, `$UPLOAD_URL`, `$DOWNLOAD_URL`. Other placeholders such as
+`$TO` or `$SUBJECT` require `--vars` with a JSON object of strings.
+
+**Bundled presets** (shipped with the package, no local file creation required):
+
+- `list_inbox.json` — latest 50 (uses `$INBOX_MAILBOX_ID`); used for polling
+- `send_mail.json` — `$TO`, `$SUBJECT`, `$BODY`
+- `send_mail_attachment.json` — in-band base64 attachment
+- `send_mail_blob_attachment.json` — pair with repeatable `--attachment PATH` (RFC 8620 upload → `$ATTACHMENT_0_BLOB_ID`, …)
+- `reply.json` — `$MAIL_ID`, `$BODY`
+
+Attachment rules, limits, and the `Blob/upload` JSON shape:
+`atomicmail help --topic jmap_cheatsheet`.
+
+## Overriding defaults
+
+- Endpoints: `--auth-url` / `--api-url` or `ATOMIC_MAIL_AUTH_URL` / `ATOMIC_MAIL_API_URL`
+- Credentials path: `--credentials-dir` or `ATOMIC_MAIL_CREDENTIALS_DIR`
+- PoW salt: `--scrypt-salt` or `ATOMIC_MAIL_SCRYPT_SALT`
+
+## Pitfalls
+
+- **Never cron the raw CLI** — do not schedule `jmap_request` without a full
+  agent turn; you only get JSON and nothing prompts a reply.
+- **No cross-platform scheduling** — do not register in one runtime and schedule
+  the cron job on another.
+- **Operator mail → himalaya** — if the task is strictly the operator's
+  Gmail/IMAP, use the `himalaya` skill instead.
+- **Secrets** — `credentials.json` and the JWT files are bearer tokens (mode
+  `0600`); never log or commit them.
+- **Multi-account** — pass `--credentials-dir` only when operating multiple
+  inboxes; the default single-inbox flow needs no extra path.
+
+## Verification
+
+1. `atomicmail --help` exits 0 (CLI installed and on `PATH`).
+2. `atomicmail help --topic overview` exits 0.
+3. After `register`, JSON output includes `inbox` and `accountId`.
+4. `jmap_request --ops-file list_inbox.json` returns mailbox/email data without
+   auth errors.

--- a/skills/himalaya/SKILL.md
+++ b/skills/himalaya/SKILL.md
@@ -26,6 +26,10 @@ metadata:
 
 Use `himalaya` for IMAP/SMTP email from shell.
 
+For an **agent-owned** inbox (register a new `@atomicmail.ai` address over JMAP,
+with hourly triage), use the `atomicmail` skill instead. Use `himalaya` when the
+operator already has a personal mailbox (Gmail app password, corporate IMAP).
+
 ## References
 
 - `references/configuration.md`: account config, auth, backend setup.

--- a/src/skills/loading/bundled-frontmatter.test.ts
+++ b/src/skills/loading/bundled-frontmatter.test.ts
@@ -3,7 +3,7 @@ import fs from "node:fs/promises";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { describe, expect, it } from "vitest";
-import { parseFrontmatter } from "./frontmatter.js";
+import { parseFrontmatter, resolveOpenClawMetadata } from "./frontmatter.js";
 
 const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..", "..", "..");
 
@@ -23,5 +23,36 @@ describe("bundled taskflow skill frontmatter", () => {
       expect(frontmatter.description, relativePath).toBeTypeOf("string");
       expect(frontmatter.description?.trim(), relativePath).not.toBe("");
     }
+  });
+});
+
+describe("bundled atomicmail skill", () => {
+  const skillDir = path.join(repoRoot, "skills", "atomicmail");
+
+  it("has parseable frontmatter with the expected name", async () => {
+    const raw = await fs.readFile(path.join(skillDir, "SKILL.md"), "utf8");
+    const frontmatter = parseFrontmatter(raw);
+
+    expect(frontmatter.name).toBe("atomicmail");
+    expect(frontmatter.description?.trim()).not.toBe("");
+  });
+
+  it("declares the atomicmail bin requirement and npm install recipe", async () => {
+    const raw = await fs.readFile(path.join(skillDir, "SKILL.md"), "utf8");
+    const metadata = resolveOpenClawMetadata(parseFrontmatter(raw));
+
+    expect(metadata?.requires?.bins).toContain("atomicmail");
+
+    const nodeInstall = metadata?.install?.find((spec) => spec.kind === "node");
+    expect(nodeInstall).toBeDefined();
+    expect(nodeInstall?.package).toBe("@atomicmail/agent-skill-openclaw");
+    expect(nodeInstall?.bins).toContain("atomicmail");
+  });
+
+  it("stays a thin wrapper without vendored runtime files", async () => {
+    const entries = await fs.readdir(skillDir);
+    expect(entries).toContain("SKILL.md");
+    expect(entries).not.toContain("lib");
+    expect(entries).not.toContain("scripts");
   });
 });


### PR DESCRIPTION
Closes #99084

> AI-assisted PR (agent-authored). Author has reviewed and understands the change.

## What Problem This Solves

OpenClaw agents cannot own an email address. The bundled `himalaya` skill drives the **operator's** existing mailbox (Gmail/corporate IMAP/SMTP) and needs a human-provisioned account plus app password — so there is no bundled way for an agent to obtain its **own** address, receive unsolicited inbound mail, and reply under a persistent, publicly reachable identity. Providers that could fill this normally require human signup, email/CAPTCHA verification, and an API key, none of which an autonomous agent can complete on its own.

This adds a bundled `atomicmail` skill so an agent can register and operate its own `name@atomicmail.ai` inbox over JMAP — send, receive, reply, and triage — with no operator mailbox and no human verification. That unlocks agent-to-agent and agent-to-human workflows: support triage inboxes, agent orchestration, auditable/replayable comms, and stable public identities like `code-security-auditor@atomicmail.ai`.

## Why This Change Was Made

The skill is a **thin wrapper** over the published npm package [`@atomicmail/agent-skill-openclaw`](https://www.npmjs.com/package/@atomicmail/agent-skill-openclaw) (0 dependencies, MIT), following the existing `skills/1password` recipe: `requires.bins: ["atomicmail"]` plus a `node` install spec, with all runtime detail deferred to the CLI's built-in `help` topics instead of vendoring code. This keeps the review surface tiny and avoids the security-scanner concerns (`eval`, `process.env`+`fetch`) that vendoring the CLI would raise.

[Atomic Mail](https://atomicmail.ai) is a free service built on open JMAP standards (RFC 8620/8621); agents authenticate via a custom proof-of-work + reputation-enforced system, so no API key or secret provisioning is required. It complements rather than overlaps `himalaya` (operator's own mailbox), and a reciprocal cross-link is added in both directions. Non-goal: this does not manage the operator's personal mailbox.

## User Impact

- Operators/agents can give an agent its own autonomously-provisioned inbox and a stable, publicly reachable identity with zero manual mailbox setup and no API key.
- Discoverable out of the box as a default skill; `himalaya` now points here for the agent-owned case, and this skill points back to `himalaya` for operator mailboxes.
- No impact on existing skills or runtime paths; purely additive.

## Evidence

**Package install (same flow OpenClaw uses for `node`-kind skills — `npm install -g --ignore-scripts`):**

```
$ npm install -g --ignore-scripts @atomicmail/agent-skill-openclaw
install exit: 0
$ atomicmail --help
help exit: 0
Atomic Mail — AgentSkill
Usage:
  atomicmail <command> [options]
Commands:
  register       PoW signup or login with API key (writes credentials)
  jmap_request   Send a JMAP batch (inline --ops or --ops-file; optional --attachment)
  help           Full documentation [--topic TOPIC]
$ atomicmail help --topic overview
overview exit: 0
# Atomic Mail — Overview
```

**Focused test (repo runner):**

```
$ node scripts/run-vitest.mjs run src/skills/loading/bundled-frontmatter.test.ts
 Test Files  1 passed (1)
      Tests  4 passed (4)
```

The new assertions verify the install recipe (`requires.bins` contains `atomicmail`; `node` install of `@atomicmail/agent-skill-openclaw` with the `atomicmail` bin) and that the skill stays a thin wrapper (no vendored `lib/`/`scripts/`).

**Lint:** no linter errors on `skills/atomicmail/SKILL.md` or `src/skills/loading/bundled-frontmatter.test.ts`.

### Files
- `skills/atomicmail/SKILL.md` — new thin-wrapper skill (npm install recipe + OpenClaw cron guidance for hourly triage).
- `skills/himalaya/SKILL.md` — reciprocal cross-link (agent-owned vs operator mailbox).
- `src/skills/loading/bundled-frontmatter.test.ts` — install-recipe + thin-wrapper assertions.

`CHANGELOG.md` intentionally untouched (maintainers/ClawSweeper add entries on landing). *Allow edits by maintainers* is enabled.