### PR TITLE
feat(xai): add realtime voice provider

### DIFF
--- a/docs/providers/xai.md
+++ b/docs/providers/xai.md
@@ -127,26 +127,26 @@ The bundled plugin maps supported xAI APIs onto OpenClaw's shared provider and
 tool contracts. Capabilities that do not fit the shared contract are listed
 below or under known limits.
 
-| xAI capability             | OpenClaw surface                        | Status                                                        |
-| -------------------------- | --------------------------------------- | ------------------------------------------------------------- |
-| Chat / Responses           | `xai/<model>` model provider            | Yes                                                           |
-| Server-side web search     | `web_search` provider `grok`            | Yes                                                           |
-| Server-side X search       | `x_search` tool                         | Yes                                                           |
-| Server-side code execution | `code_execution` tool                   | Yes                                                           |
-| Images                     | `image_generate`                        | Yes                                                           |
-| Videos                     | `video_generate`                        | Classic full workflow; Video 1.5 image-to-video               |
-| Batch text-to-speech       | `messages.tts.provider: "xai"` / `tts`  | Yes                                                           |
-| Streaming TTS              | -                                       | Not implemented by the xAI provider yet                       |
-| Batch speech-to-text       | `tools.media.audio` media understanding | Yes                                                           |
-| Streaming speech-to-text   | Voice Call `streaming.provider: "xai"`  | Yes                                                           |
-| Realtime voice             | -                                       | Not exposed yet; needs a different session/WebSocket contract |
-| Files / batches            | Generic model API compatibility only    | Not a first-class OpenClaw tool                               |
+| xAI capability             | OpenClaw surface                        | Status                                                              |
+| -------------------------- | --------------------------------------- | ------------------------------------------------------------------- |
+| Chat / Responses           | `xai/<model>` model provider            | Yes                                                                 |
+| Server-side web search     | `web_search` provider `grok`            | Yes                                                                 |
+| Server-side X search       | `x_search` tool                         | Yes                                                                 |
+| Server-side code execution | `code_execution` tool                   | Yes                                                                 |
+| Images                     | `image_generate`                        | Yes                                                                 |
+| Videos                     | `video_generate`                        | Yes                                                                 |
+| Batch text-to-speech       | `messages.tts.provider: "xai"` / `tts`  | Yes                                                                 |
+| Streaming TTS              | -                                       | Not exposed; OpenClaw's TTS contract returns complete audio buffers |
+| Batch speech-to-text       | `tools.media.audio` media understanding | Yes                                                                 |
+| Streaming speech-to-text   | Voice Call `streaming.provider: "xai"`  | Yes                                                                 |
+| Realtime voice             | Talk `talk.realtime.provider: "xai"`    | Yes; gateway-relay for native Talk nodes                            |
+| Files / batches            | Generic model API compatibility only    | Not a first-class OpenClaw tool                                     |
 
 <Note>
 OpenClaw uses xAI's REST image/video/TTS/STT APIs for media generation and
 batch transcription, xAI's streaming STT WebSocket for live voice-call
-transcription, and the Responses API for chat, search, and code-execution
-tools.
+transcription, xAI's Grok Voice Agent WebSocket for Talk realtime sessions,
+and the Responses API for chat, search, and code-execution tools.
 </Note>
 
 ### Legacy fast-mode compatibility
@@ -438,6 +438,54 @@ stale context metadata on active 4.20 rows. It does not pin active 4.20
 
   </Accordion>
 
+  <Accordion title="Realtime voice (Talk)">
+    The bundled `xai` plugin registers Grok Voice Agent realtime sessions for
+    Talk mode through the shared `registerRealtimeVoiceProvider` contract.
+
+    - Endpoint: `wss://api.x.ai/v1/realtime?model=<voice-model>`
+    - Default model: `grok-voice-latest`
+    - Default voice: `eve`
+    - Transport: `gateway-relay` (iOS, Android, and Control UI relay paths)
+    - Audio: PCM16 24 kHz or G.711 µ-law 8 kHz
+    - Barge-in: `response.cancel` plus `conversation.item.truncate` for interrupted
+      assistant audio already sent to playback
+
+    Configure Talk on the Gateway:
+
+    ```json5
+    {
+      talk: {
+        realtime: {
+          provider: "xai",
+          mode: "realtime",
+          transport: "gateway-relay",
+          brain: "agent-consult",
+          providers: {
+            xai: {
+              model: "grok-voice-latest",
+              voice: "eve",
+            },
+          },
+        },
+      },
+      env: { XAI_API_KEY: "xai-..." },
+    }
+    ```
+
+    Provider-owned config also resolves from
+    `plugins.entries.voice-call.config.realtime.providers.xai` when Voice Call
+    or shared realtime selectors reuse the same provider map. Supported keys are
+    `apiKey`, `baseUrl`, `model`, `voice`, `vadThreshold`, `silenceDurationMs`,
+    `prefixPaddingMs`, `interruptResponseOnInputAudio`, and `reasoningEffort`.
+
+    <Note>
+    xAI OAuth or `XAI_API_KEY` can authenticate realtime voice. Browser-owned
+    WebRTC is not part of this provider surface yet; use gateway-relay Talk on
+    native nodes or the Control UI relay path.
+    </Note>
+
+  </Accordion>
+
   <Accordion title="x_search configuration">
     The bundled xAI plugin exposes `x_search` as an OpenClaw tool for
     searching X (formerly Twitter) content via Grok.
@@ -522,10 +570,10 @@ stale context metadata on active 4.20 rows. It does not pin active 4.20
       the client-side or custom tools used by OpenClaw's shared agent loop.
       See the
       [xAI multi-agent limitations](https://docs.x.ai/developers/model-capabilities/text/multi-agent#limitations).
-    - xAI Realtime voice is not registered as an OpenClaw provider yet. It
-      needs a different bidirectional voice session contract than batch STT
-      or streaming transcription.
-    - xAI image `quality`, image `mask`, and the native `auto` aspect ratio are
+    - xAI Realtime voice currently exposes gateway-relay Talk transport only.
+      Browser-owned provider WebSocket sessions are not wired in the Control UI
+      yet.
+    - xAI image `quality`, image `mask`, and extra native-only aspect ratios are
       not exposed until the shared `image_generate` tool has corresponding
       cross-provider controls.
   </Accordion>

--- a/docs/providers/xai.md
+++ b/docs/providers/xai.md
@@ -464,6 +464,8 @@ stale context metadata on active 4.20 rows. It does not pin active 4.20
             xai: {
               model: "grok-voice-latest",
               voice: "eve",
+              // Opt in only if provider-side session replay is acceptable.
+              sessionResumption: false,
             },
           },
         },
@@ -476,12 +478,21 @@ stale context metadata on active 4.20 rows. It does not pin active 4.20
     `plugins.entries.voice-call.config.realtime.providers.xai` when Voice Call
     or shared realtime selectors reuse the same provider map. Supported keys are
     `apiKey`, `baseUrl`, `model`, `voice`, `vadThreshold`, `silenceDurationMs`,
-    `prefixPaddingMs`, `interruptResponseOnInputAudio`, and `reasoningEffort`.
+    `prefixPaddingMs`, `interruptResponseOnInputAudio`, `reasoningEffort`, and
+    `sessionResumption`.
 
     <Note>
     xAI OAuth or `XAI_API_KEY` can authenticate realtime voice. Browser-owned
     WebRTC is not part of this provider surface yet; use gateway-relay Talk on
     native nodes or the Control UI relay path.
+    </Note>
+
+    <Note>
+    `sessionResumption` defaults to `false`. When set to `true`, OpenClaw asks
+    xAI to retain enough session state to resume the same conversation after a
+    reconnect and then reconnects with the returned conversation id. Leave it
+    disabled when provider-side replay/retention is not acceptable; interrupted
+    sockets then fail closed instead of silently starting a fresh conversation.
     </Note>
 
   </Accordion>

--- a/extensions/xai/index.test.ts
+++ b/extensions/xai/index.test.ts
@@ -623,6 +623,7 @@ describe("xai provider plugin", () => {
 
       expect(tool).toEqual(expected ? expect.objectContaining({ name: toolName }) : null);
     });
+  });
 
   it("declares setup auto-enable reasons for plugin-owned tool config", () => {
     const probe = registerXaiAutoEnableProbe();

--- a/extensions/xai/index.test.ts
+++ b/extensions/xai/index.test.ts
@@ -1,6 +1,7 @@
 // Xai tests cover index plugin behavior.
 import type { OpenClawPluginApi } from "openclaw/plugin-sdk/plugin-entry";
 import { createTestPluginApi } from "openclaw/plugin-sdk/plugin-test-api";
+import { createCapturedPluginRegistration } from "openclaw/plugin-sdk/plugin-test-runtime";
 import {
   registerProviderPlugin,
   registerSingleProviderPlugin,
@@ -494,6 +495,19 @@ describe("xai provider plugin", () => {
     expect(realtimeProvider.aliases).toContain("xai-realtime");
   });
 
+  it("registers xAI realtime voice for Talk gateway-relay", () => {
+    const captured = createCapturedPluginRegistration({
+      id: "xai",
+      name: "xAI Provider",
+      source: "test",
+    });
+    plugin.register(captured.api);
+    const realtimeVoiceProvider = requireEntry(captured.realtimeVoiceProviders, "xai");
+    expect(realtimeVoiceProvider.label).toBe("xAI Grok Voice");
+    expect(realtimeVoiceProvider.aliases).toContain("grok-voice");
+    expect(realtimeVoiceProvider.capabilities?.transports).toEqual(["gateway-relay"]);
+  });
+
   describe.each(["code_execution", "x_search"] as const)("%s exposure", (toolName) => {
     it.each([
       {
@@ -609,7 +623,6 @@ describe("xai provider plugin", () => {
 
       expect(tool).toEqual(expected ? expect.objectContaining({ name: toolName }) : null);
     });
-  });
 
   it("declares setup auto-enable reasons for plugin-owned tool config", () => {
     const probe = registerXaiAutoEnableProbe();

--- a/extensions/xai/index.ts
+++ b/extensions/xai/index.ts
@@ -25,6 +25,7 @@ import { isXaiProviderId } from "./provider-id.js";
 import { isModernXaiModel, resolveXaiForwardCompatModel } from "./provider-models.js";
 import { resolveThinkingProfile } from "./provider-policy-api.js";
 import { buildXaiRealtimeTranscriptionProvider } from "./realtime-transcription-provider.js";
+import { buildXaiRealtimeVoiceProvider } from "./realtime-voice-provider.js";
 import { buildXaiSpeechProvider } from "./speech-provider.js";
 import {
   readPluginCodeExecutionConfig,
@@ -283,6 +284,7 @@ export default defineSingleProviderPluginEntry({
     api.registerImageGenerationProvider(buildXaiImageGenerationProvider());
     api.registerSpeechProvider(buildXaiSpeechProvider());
     api.registerRealtimeTranscriptionProvider(buildXaiRealtimeTranscriptionProvider());
+    api.registerRealtimeVoiceProvider(buildXaiRealtimeVoiceProvider());
     api.registerTool((ctx) => createLazyCodeExecutionTool(ctx), { name: "code_execution" });
     api.registerTool((ctx) => createLazyXSearchTool(ctx), { name: "x_search" });
   },

--- a/extensions/xai/openclaw.plugin.json
+++ b/extensions/xai/openclaw.plugin.json
@@ -189,6 +189,7 @@
     "mediaUnderstandingProviders": ["xai"],
     "speechProviders": ["xai"],
     "realtimeTranscriptionProviders": ["xai"],
+    "realtimeVoiceProviders": ["xai"],
     "imageGenerationProviders": ["xai"],
     "tools": ["code_execution", "x_search"]
   },

--- a/extensions/xai/package.json
+++ b/extensions/xai/package.json
@@ -5,11 +5,11 @@
   "description": "OpenClaw xAI plugin",
   "type": "module",
   "dependencies": {
-    "typebox": "1.3.3"
+    "typebox": "1.3.3",
+    "ws": "8.21.0"
   },
   "devDependencies": {
-    "@openclaw/plugin-sdk": "workspace:*",
-    "ws": "8.21.0"
+    "@openclaw/plugin-sdk": "workspace:*"
   },
   "openclaw": {
     "extensions": [

--- a/extensions/xai/realtime-voice-provider.test.ts
+++ b/extensions/xai/realtime-voice-provider.test.ts
@@ -868,6 +868,73 @@ describe("buildXaiRealtimeVoiceProvider", () => {
     ]);
   });
 
+  it("preserves pending parallel tool calls across resumed reconnects", async () => {
+    vi.useFakeTimers();
+    vi.stubEnv("XAI_API_KEY", "xai-env"); // pragma: allowlist secret
+    const provider = buildXaiRealtimeVoiceProvider();
+    const bridge = provider.createBridge({
+      providerConfig: { apiKey: "xai-test" }, // pragma: allowlist secret
+      onAudio: vi.fn(),
+      onClearAudio: vi.fn(),
+      onToolCall: vi.fn(),
+    });
+
+    const connecting = bridge.connect();
+    await vi.waitFor(() => expect(FakeWebSocket.instances.length).toBe(1));
+    const firstSocket = FakeWebSocket.instances[0];
+    firstSocket.readyState = FakeWebSocket.OPEN;
+    firstSocket.emit("open");
+    firstSocket.emit(
+      "message",
+      Buffer.from(
+        JSON.stringify({ type: "conversation.created", conversation: { id: "conv_tools" } }),
+      ),
+    );
+    firstSocket.emit("message", Buffer.from(JSON.stringify({ type: "session.updated" })));
+    await connecting;
+
+    for (const callId of ["call_1", "call_2"]) {
+      firstSocket.emit(
+        "message",
+        Buffer.from(
+          JSON.stringify({
+            type: "response.function_call_arguments.done",
+            item_id: `item_${callId}`,
+            name: "openclaw_agent_consult",
+            call_id: callId,
+            arguments: JSON.stringify({ question: callId }),
+          }),
+        ),
+      );
+    }
+
+    firstSocket.close(1006, "connection lost");
+    await vi.advanceTimersByTimeAsync(1000);
+    await vi.waitFor(() => expect(FakeWebSocket.instances.length).toBe(2));
+    const secondSocket = FakeWebSocket.instances[1];
+    expect(String(secondSocket.args[0])).toContain("conversation_id=conv_tools");
+    secondSocket.readyState = FakeWebSocket.OPEN;
+    secondSocket.emit("open");
+    secondSocket.emit("message", Buffer.from(JSON.stringify({ type: "session.updated" })));
+
+    bridge.submitToolResult("call_1", { text: "first" });
+    expect(parseSent(secondSocket).filter((event) => event.type === "response.create")).toEqual([]);
+
+    bridge.submitToolResult("call_2", { text: "second" });
+    expect(parseSent(secondSocket).slice(-2)).toEqual([
+      {
+        type: "conversation.item.create",
+        item: {
+          type: "function_call_output",
+          call_id: "call_2",
+          output: JSON.stringify({ text: "second" }),
+        },
+      },
+      { type: "response.create" },
+    ]);
+    bridge.close();
+  });
+
   it("exhausts reconnect attempts when websocket opens without session setup", async () => {
     vi.useFakeTimers();
     vi.stubEnv("XAI_API_KEY", "xai-env"); // pragma: allowlist secret

--- a/extensions/xai/realtime-voice-provider.test.ts
+++ b/extensions/xai/realtime-voice-provider.test.ts
@@ -871,10 +871,10 @@ describe("buildXaiRealtimeVoiceProvider", () => {
       );
     }
 
-    bridge.submitToolResult("call_1", { text: "first" });
+    await bridge.submitToolResult("call_1", { text: "first" });
     expect(parseSent(socket).filter((event) => event.type === "response.create")).toEqual([]);
 
-    bridge.submitToolResult("call_2", { text: "second" });
+    await bridge.submitToolResult("call_2", { text: "second" });
     expect(parseSent(socket).slice(-2)).toEqual([
       {
         type: "conversation.item.create",
@@ -919,12 +919,12 @@ describe("buildXaiRealtimeVoiceProvider", () => {
       ),
     );
 
-    bridge.submitToolResult("call_1", { status: "working" }, { willContinue: true });
-    expect(
-      parseSent(socket).filter((event) => event.type === "conversation.item.create"),
-    ).toEqual([]);
+    await bridge.submitToolResult("call_1", { status: "working" }, { willContinue: true });
+    expect(parseSent(socket).filter((event) => event.type === "conversation.item.create")).toEqual(
+      [],
+    );
 
-    bridge.submitToolResult("call_1", { text: "final" });
+    await bridge.submitToolResult("call_1", { text: "final" });
     expect(parseSent(socket).slice(-2)).toEqual([
       {
         type: "conversation.item.create",
@@ -981,7 +981,7 @@ describe("buildXaiRealtimeVoiceProvider", () => {
       ),
     );
 
-    bridge.submitToolResult("call_1", { text: "final" });
+    await bridge.submitToolResult("call_1", { text: "final" });
     expect(parseSent(socket).filter((event) => event.type === "response.create")).toEqual([]);
 
     bridge.acknowledgeMark?.();
@@ -1037,10 +1037,10 @@ describe("buildXaiRealtimeVoiceProvider", () => {
     secondSocket.emit("open");
     secondSocket.emit("message", Buffer.from(JSON.stringify({ type: "session.updated" })));
 
-    bridge.submitToolResult("call_1", { text: "first" });
+    await bridge.submitToolResult("call_1", { text: "first" });
     expect(parseSent(secondSocket).filter((event) => event.type === "response.create")).toEqual([]);
 
-    bridge.submitToolResult("call_2", { text: "second" });
+    await bridge.submitToolResult("call_2", { text: "second" });
     expect(parseSent(secondSocket).slice(-2)).toEqual([
       {
         type: "conversation.item.create",
@@ -1103,9 +1103,10 @@ describe("buildXaiRealtimeVoiceProvider", () => {
     secondSocket.readyState = FakeWebSocket.OPEN;
     secondSocket.emit("open");
 
-    bridge.submitToolResult("call_1", { text: "first" });
-    expect(parseSent(secondSocket).filter((event) => event.type === "conversation.item.create"))
-      .toEqual([]);
+    await bridge.submitToolResult("call_1", { text: "first" });
+    expect(
+      parseSent(secondSocket).filter((event) => event.type === "conversation.item.create"),
+    ).toEqual([]);
 
     secondSocket.emit("message", Buffer.from(JSON.stringify({ type: "session.updated" })));
     expect(parseSent(secondSocket).filter((event) => event.type === "response.create")).toEqual([]);
@@ -1120,7 +1121,7 @@ describe("buildXaiRealtimeVoiceProvider", () => {
       },
     ]);
 
-    bridge.submitToolResult("call_2", { text: "second" });
+    await bridge.submitToolResult("call_2", { text: "second" });
     expect(parseSent(secondSocket).slice(-2)).toEqual([
       {
         type: "conversation.item.create",
@@ -1168,8 +1169,9 @@ describe("buildXaiRealtimeVoiceProvider", () => {
     secondSocket.emit("open");
 
     bridge.sendUserMessage?.("OpenClaw finished checking.");
-    expect(parseSent(secondSocket).filter((event) => event.type === "conversation.item.create"))
-      .toEqual([]);
+    expect(
+      parseSent(secondSocket).filter((event) => event.type === "conversation.item.create"),
+    ).toEqual([]);
 
     secondSocket.emit("message", Buffer.from(JSON.stringify({ type: "session.updated" })));
     expect(parseSent(secondSocket).slice(-2)).toEqual([

--- a/extensions/xai/realtime-voice-provider.test.ts
+++ b/extensions/xai/realtime-voice-provider.test.ts
@@ -210,6 +210,26 @@ describe("buildXaiRealtimeVoiceProvider", () => {
     });
   });
 
+  it("does not enable xAI session resumption by default", async () => {
+    vi.stubEnv("XAI_API_KEY", "xai-env"); // pragma: allowlist secret
+    const provider = buildXaiRealtimeVoiceProvider();
+    const bridge = provider.createBridge({
+      providerConfig: { apiKey: "xai-test" }, // pragma: allowlist secret
+      onAudio: vi.fn(),
+      onClearAudio: vi.fn(),
+    });
+
+    void bridge.connect();
+    await vi.waitFor(() => expect(FakeWebSocket.instances.length).toBe(1));
+    const socket = FakeWebSocket.instances[0];
+    socket.readyState = FakeWebSocket.OPEN;
+    socket.emit("open");
+    socket.emit("message", Buffer.from(JSON.stringify({ type: "session.updated" })));
+    bridge.close();
+
+    expect(requireSession(socket).resumption).toBeUndefined();
+  });
+
   it("sends nested xAI session.update audio formats for g711 bridges", async () => {
     vi.stubEnv("XAI_API_KEY", "xai-env"); // pragma: allowlist secret
     const provider = buildXaiRealtimeVoiceProvider();
@@ -873,7 +893,7 @@ describe("buildXaiRealtimeVoiceProvider", () => {
     vi.stubEnv("XAI_API_KEY", "xai-env"); // pragma: allowlist secret
     const provider = buildXaiRealtimeVoiceProvider();
     const bridge = provider.createBridge({
-      providerConfig: { apiKey: "xai-test" }, // pragma: allowlist secret
+      providerConfig: { apiKey: "xai-test", sessionResumption: true }, // pragma: allowlist secret
       onAudio: vi.fn(),
       onClearAudio: vi.fn(),
       onToolCall: vi.fn(),
@@ -935,6 +955,86 @@ describe("buildXaiRealtimeVoiceProvider", () => {
     bridge.close();
   });
 
+  it("queues tool results submitted while a resumed session is reconnecting", async () => {
+    vi.useFakeTimers();
+    vi.stubEnv("XAI_API_KEY", "xai-env"); // pragma: allowlist secret
+    const provider = buildXaiRealtimeVoiceProvider();
+    const bridge = provider.createBridge({
+      providerConfig: { apiKey: "xai-test", sessionResumption: true }, // pragma: allowlist secret
+      onAudio: vi.fn(),
+      onClearAudio: vi.fn(),
+      onToolCall: vi.fn(),
+    });
+
+    const connecting = bridge.connect();
+    await vi.waitFor(() => expect(FakeWebSocket.instances.length).toBe(1));
+    const firstSocket = FakeWebSocket.instances[0];
+    firstSocket.readyState = FakeWebSocket.OPEN;
+    firstSocket.emit("open");
+    firstSocket.emit(
+      "message",
+      Buffer.from(
+        JSON.stringify({ type: "conversation.created", conversation: { id: "conv_tool_queue" } }),
+      ),
+    );
+    firstSocket.emit("message", Buffer.from(JSON.stringify({ type: "session.updated" })));
+    await connecting;
+
+    for (const callId of ["call_1", "call_2"]) {
+      firstSocket.emit(
+        "message",
+        Buffer.from(
+          JSON.stringify({
+            type: "response.function_call_arguments.done",
+            item_id: `item_${callId}`,
+            name: "openclaw_agent_consult",
+            call_id: callId,
+            arguments: JSON.stringify({ question: callId }),
+          }),
+        ),
+      );
+    }
+
+    firstSocket.close(1006, "connection lost");
+    await vi.advanceTimersByTimeAsync(1000);
+    await vi.waitFor(() => expect(FakeWebSocket.instances.length).toBe(2));
+    const secondSocket = FakeWebSocket.instances[1];
+    expect(String(secondSocket.args[0])).toContain("conversation_id=conv_tool_queue");
+    secondSocket.readyState = FakeWebSocket.OPEN;
+    secondSocket.emit("open");
+
+    bridge.submitToolResult("call_1", { text: "first" });
+    expect(parseSent(secondSocket).filter((event) => event.type === "conversation.item.create"))
+      .toEqual([]);
+
+    secondSocket.emit("message", Buffer.from(JSON.stringify({ type: "session.updated" })));
+    expect(parseSent(secondSocket).filter((event) => event.type === "response.create")).toEqual([]);
+    expect(parseSent(secondSocket).slice(-1)).toEqual([
+      {
+        type: "conversation.item.create",
+        item: {
+          type: "function_call_output",
+          call_id: "call_1",
+          output: JSON.stringify({ text: "first" }),
+        },
+      },
+    ]);
+
+    bridge.submitToolResult("call_2", { text: "second" });
+    expect(parseSent(secondSocket).slice(-2)).toEqual([
+      {
+        type: "conversation.item.create",
+        item: {
+          type: "function_call_output",
+          call_id: "call_2",
+          output: JSON.stringify({ text: "second" }),
+        },
+      },
+      { type: "response.create" },
+    ]);
+    bridge.close();
+  });
+
   it("exhausts reconnect attempts when websocket opens without session setup", async () => {
     vi.useFakeTimers();
     vi.stubEnv("XAI_API_KEY", "xai-env"); // pragma: allowlist secret
@@ -942,7 +1042,7 @@ describe("buildXaiRealtimeVoiceProvider", () => {
     const onEvent = vi.fn();
     const onClose = vi.fn();
     const bridge = provider.createBridge({
-      providerConfig: { apiKey: "xai-test" }, // pragma: allowlist secret
+      providerConfig: { apiKey: "xai-test", sessionResumption: true }, // pragma: allowlist secret
       onAudio: vi.fn(),
       onClearAudio: vi.fn(),
       onEvent,
@@ -992,7 +1092,7 @@ describe("buildXaiRealtimeVoiceProvider", () => {
     const provider = buildXaiRealtimeVoiceProvider();
     const onReady = vi.fn();
     const bridge = provider.createBridge({
-      providerConfig: { apiKey: "xai-test" }, // pragma: allowlist secret
+      providerConfig: { apiKey: "xai-test", sessionResumption: true }, // pragma: allowlist secret
       onAudio: vi.fn(),
       onClearAudio: vi.fn(),
       onReady,
@@ -1030,7 +1130,7 @@ describe("buildXaiRealtimeVoiceProvider", () => {
     vi.stubEnv("XAI_API_KEY", "xai-env"); // pragma: allowlist secret
     const provider = buildXaiRealtimeVoiceProvider();
     const bridge = provider.createBridge({
-      providerConfig: { apiKey: "xai-test" }, // pragma: allowlist secret
+      providerConfig: { apiKey: "xai-test", sessionResumption: true }, // pragma: allowlist secret
       onAudio: vi.fn(),
       onClearAudio: vi.fn(),
     });
@@ -1068,7 +1168,7 @@ describe("buildXaiRealtimeVoiceProvider", () => {
     const onEvent = vi.fn();
     const onClose = vi.fn();
     const bridge = provider.createBridge({
-      providerConfig: { apiKey: "xai-test" }, // pragma: allowlist secret
+      providerConfig: { apiKey: "xai-test", sessionResumption: true }, // pragma: allowlist secret
       onAudio: vi.fn(),
       onClearAudio: vi.fn(),
       onEvent,
@@ -1091,6 +1191,47 @@ describe("buildXaiRealtimeVoiceProvider", () => {
       direction: "client",
       type: "session.reconnect.blocked",
       detail: "reason=websocket-close missingConversationId=true",
+    });
+    expect(onClose).toHaveBeenCalledWith("error");
+    bridge.close();
+  });
+
+  it("fails closed instead of reconnecting when xAI session resumption is disabled", async () => {
+    vi.useFakeTimers();
+    vi.stubEnv("XAI_API_KEY", "xai-env"); // pragma: allowlist secret
+    const provider = buildXaiRealtimeVoiceProvider();
+    const onEvent = vi.fn();
+    const onClose = vi.fn();
+    const bridge = provider.createBridge({
+      providerConfig: { apiKey: "xai-test" }, // pragma: allowlist secret
+      onAudio: vi.fn(),
+      onClearAudio: vi.fn(),
+      onEvent,
+      onClose,
+    });
+
+    const connecting = bridge.connect();
+    await vi.waitFor(() => expect(FakeWebSocket.instances.length).toBe(1));
+    const socket = FakeWebSocket.instances[0];
+    socket.readyState = FakeWebSocket.OPEN;
+    socket.emit("open");
+    socket.emit(
+      "message",
+      Buffer.from(
+        JSON.stringify({ type: "conversation.created", conversation: { id: "conv_default" } }),
+      ),
+    );
+    socket.emit("message", Buffer.from(JSON.stringify({ type: "session.updated" })));
+    await connecting;
+
+    socket.close(1006, "connection lost");
+    await vi.advanceTimersByTimeAsync(1000);
+
+    expect(FakeWebSocket.instances).toHaveLength(1);
+    expect(onEvent).toHaveBeenCalledWith({
+      direction: "client",
+      type: "session.reconnect.blocked",
+      detail: "reason=websocket-close sessionResumption=false",
     });
     expect(onClose).toHaveBeenCalledWith("error");
     bridge.close();

--- a/extensions/xai/realtime-voice-provider.test.ts
+++ b/extensions/xai/realtime-voice-provider.test.ts
@@ -145,7 +145,7 @@ describe("buildXaiRealtimeVoiceProvider", () => {
     });
   });
 
-  it("advertises continuing realtime tool results", () => {
+  it("does not advertise continuing realtime tool results", () => {
     const provider = buildXaiRealtimeVoiceProvider();
     const bridge = provider.createBridge({
       providerConfig: { apiKey: "xai-test" }, // pragma: allowlist secret
@@ -153,7 +153,7 @@ describe("buildXaiRealtimeVoiceProvider", () => {
       onClearAudio: vi.fn(),
     });
 
-    expect(bridge.supportsToolResultContinuation).toBe(true);
+    expect(bridge.supportsToolResultContinuation).toBe(false);
   });
 
   it("requires xAI credentials for native realtime websocket bridges", async () => {
@@ -888,6 +888,106 @@ describe("buildXaiRealtimeVoiceProvider", () => {
     ]);
   });
 
+  it("does not send unsupported interim willContinue tool results to xAI", async () => {
+    vi.stubEnv("XAI_API_KEY", "xai-env"); // pragma: allowlist secret
+    const provider = buildXaiRealtimeVoiceProvider();
+    const bridge = provider.createBridge({
+      providerConfig: { apiKey: "xai-test" }, // pragma: allowlist secret
+      onAudio: vi.fn(),
+      onClearAudio: vi.fn(),
+      onToolCall: vi.fn(),
+    });
+
+    const connecting = bridge.connect();
+    await vi.waitFor(() => expect(FakeWebSocket.instances.length).toBe(1));
+    const socket = FakeWebSocket.instances[0];
+    socket.readyState = FakeWebSocket.OPEN;
+    socket.emit("open");
+    socket.emit("message", Buffer.from(JSON.stringify({ type: "session.updated" })));
+    await connecting;
+
+    socket.emit(
+      "message",
+      Buffer.from(
+        JSON.stringify({
+          type: "response.function_call_arguments.done",
+          item_id: "item_call_1",
+          name: "openclaw_agent_consult",
+          call_id: "call_1",
+          arguments: JSON.stringify({ question: "call_1" }),
+        }),
+      ),
+    );
+
+    bridge.submitToolResult("call_1", { status: "working" }, { willContinue: true });
+    expect(
+      parseSent(socket).filter((event) => event.type === "conversation.item.create"),
+    ).toEqual([]);
+
+    bridge.submitToolResult("call_1", { text: "final" });
+    expect(parseSent(socket).slice(-2)).toEqual([
+      {
+        type: "conversation.item.create",
+        item: {
+          type: "function_call_output",
+          call_id: "call_1",
+          output: JSON.stringify({ text: "final" }),
+        },
+      },
+      { type: "response.create" },
+    ]);
+  });
+
+  it("defers response.create for tool results until queued playback marks drain", async () => {
+    vi.stubEnv("XAI_API_KEY", "xai-env"); // pragma: allowlist secret
+    const provider = buildXaiRealtimeVoiceProvider();
+    const bridge = provider.createBridge({
+      providerConfig: { apiKey: "xai-test" }, // pragma: allowlist secret
+      onAudio: vi.fn(),
+      onClearAudio: vi.fn(),
+      onToolCall: vi.fn(),
+    });
+
+    const connecting = bridge.connect();
+    await vi.waitFor(() => expect(FakeWebSocket.instances.length).toBe(1));
+    const socket = FakeWebSocket.instances[0];
+    socket.readyState = FakeWebSocket.OPEN;
+    socket.emit("open");
+    socket.emit("message", Buffer.from(JSON.stringify({ type: "session.updated" })));
+    await connecting;
+
+    socket.emit("message", Buffer.from(JSON.stringify({ type: "response.created" })));
+    socket.emit(
+      "message",
+      Buffer.from(
+        JSON.stringify({
+          type: "response.audio.delta",
+          item_id: "item_audio_1",
+          delta: Buffer.from("assistant audio").toString("base64"),
+        }),
+      ),
+    );
+    socket.emit("message", Buffer.from(JSON.stringify({ type: "response.done" })));
+    socket.emit(
+      "message",
+      Buffer.from(
+        JSON.stringify({
+          type: "response.function_call_arguments.done",
+          item_id: "item_call_1",
+          name: "openclaw_agent_consult",
+          call_id: "call_1",
+          arguments: JSON.stringify({ question: "call_1" }),
+        }),
+      ),
+    );
+
+    bridge.submitToolResult("call_1", { text: "final" });
+    expect(parseSent(socket).filter((event) => event.type === "response.create")).toEqual([]);
+
+    bridge.acknowledgeMark?.();
+    expect(parseSent(socket).slice(-1)).toEqual([{ type: "response.create" }]);
+  });
+
   it("preserves pending parallel tool calls across resumed reconnects", async () => {
     vi.useFakeTimers();
     vi.stubEnv("XAI_API_KEY", "xai-env"); // pragma: allowlist secret
@@ -1028,6 +1128,57 @@ describe("buildXaiRealtimeVoiceProvider", () => {
           type: "function_call_output",
           call_id: "call_2",
           output: JSON.stringify({ text: "second" }),
+        },
+      },
+      { type: "response.create" },
+    ]);
+    bridge.close();
+  });
+
+  it("queues text turns submitted while a resumed session is reconnecting", async () => {
+    vi.useFakeTimers();
+    vi.stubEnv("XAI_API_KEY", "xai-env"); // pragma: allowlist secret
+    const provider = buildXaiRealtimeVoiceProvider();
+    const bridge = provider.createBridge({
+      providerConfig: { apiKey: "xai-test", sessionResumption: true }, // pragma: allowlist secret
+      onAudio: vi.fn(),
+      onClearAudio: vi.fn(),
+    });
+
+    const connecting = bridge.connect();
+    await vi.waitFor(() => expect(FakeWebSocket.instances.length).toBe(1));
+    const firstSocket = FakeWebSocket.instances[0];
+    firstSocket.readyState = FakeWebSocket.OPEN;
+    firstSocket.emit("open");
+    firstSocket.emit(
+      "message",
+      Buffer.from(
+        JSON.stringify({ type: "conversation.created", conversation: { id: "conv_text_queue" } }),
+      ),
+    );
+    firstSocket.emit("message", Buffer.from(JSON.stringify({ type: "session.updated" })));
+    await connecting;
+
+    firstSocket.close(1006, "connection lost");
+    await vi.advanceTimersByTimeAsync(1000);
+    await vi.waitFor(() => expect(FakeWebSocket.instances.length).toBe(2));
+    const secondSocket = FakeWebSocket.instances[1];
+    expect(String(secondSocket.args[0])).toContain("conversation_id=conv_text_queue");
+    secondSocket.readyState = FakeWebSocket.OPEN;
+    secondSocket.emit("open");
+
+    bridge.sendUserMessage?.("OpenClaw finished checking.");
+    expect(parseSent(secondSocket).filter((event) => event.type === "conversation.item.create"))
+      .toEqual([]);
+
+    secondSocket.emit("message", Buffer.from(JSON.stringify({ type: "session.updated" })));
+    expect(parseSent(secondSocket).slice(-2)).toEqual([
+      {
+        type: "conversation.item.create",
+        item: {
+          type: "message",
+          role: "user",
+          content: [{ type: "input_text", text: "OpenClaw finished checking." }],
         },
       },
       { type: "response.create" },

--- a/extensions/xai/realtime-voice-provider.test.ts
+++ b/extensions/xai/realtime-voice-provider.test.ts
@@ -1,0 +1,1087 @@
+// Xai tests cover realtime voice provider plugin behavior.
+import { REALTIME_VOICE_AUDIO_FORMAT_PCM16_24KHZ } from "openclaw/plugin-sdk/realtime-voice";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { buildXaiRealtimeVoiceProvider } from "./realtime-voice-provider.js";
+
+const { FakeWebSocket, isProviderAuthProfileConfiguredMock, resolveApiKeyForProviderMock } =
+  vi.hoisted(() => {
+    type Listener = (...args: unknown[]) => void;
+
+    class MockWebSocket {
+      static readonly OPEN = 1;
+      static readonly CLOSED = 3;
+      static instances: MockWebSocket[] = [];
+
+      readonly listeners = new Map<string, Listener[]>();
+      readyState = 0;
+      sent: string[] = [];
+      closed = false;
+      terminated = false;
+      args: unknown[];
+
+      constructor(...args: unknown[]) {
+        this.args = args;
+        MockWebSocket.instances.push(this);
+      }
+
+      on(event: string, listener: Listener): this {
+        const listeners = this.listeners.get(event) ?? [];
+        listeners.push(listener);
+        this.listeners.set(event, listeners);
+        return this;
+      }
+
+      emit(event: string, ...args: unknown[]): void {
+        for (const listener of this.listeners.get(event) ?? []) {
+          listener(...args);
+        }
+      }
+
+      send(payload: string): void {
+        this.sent.push(payload);
+      }
+
+      close(code?: number, reason?: string): void {
+        this.closed = true;
+        this.readyState = MockWebSocket.CLOSED;
+        this.emit("close", code ?? 1000, Buffer.from(reason ?? ""));
+      }
+
+      terminate(): void {
+        this.terminated = true;
+        this.close(1006, "terminated");
+      }
+    }
+
+    return {
+      FakeWebSocket: MockWebSocket,
+      isProviderAuthProfileConfiguredMock: vi.fn(() => false),
+      resolveApiKeyForProviderMock: vi.fn(
+        async (): Promise<{ apiKey: string | undefined }> => ({ apiKey: undefined }),
+      ),
+    };
+  });
+
+vi.mock("ws", () => ({
+  default: FakeWebSocket,
+}));
+
+vi.mock("openclaw/plugin-sdk/provider-auth", () => ({
+  isProviderAuthProfileConfigured: isProviderAuthProfileConfiguredMock,
+}));
+
+vi.mock("openclaw/plugin-sdk/provider-auth-runtime", () => ({
+  resolveApiKeyForProvider: resolveApiKeyForProviderMock,
+}));
+
+type FakeWebSocketInstance = InstanceType<typeof FakeWebSocket>;
+type SentRealtimeEvent = {
+  type: string;
+  audio?: string;
+  session?: {
+    voice?: string;
+    model?: string;
+    turn_detection?: {
+      create_response?: boolean;
+      interrupt_response?: boolean;
+      threshold?: number;
+    };
+    audio?: {
+      input?: { format?: Record<string, unknown>; transcription?: Record<string, unknown> };
+      output?: { format?: Record<string, unknown> };
+    };
+    resumption?: {
+      enabled?: boolean;
+    };
+    tools?: unknown[];
+    tool_choice?: string;
+  };
+};
+
+function parseSent(socket: FakeWebSocketInstance): SentRealtimeEvent[] {
+  return socket.sent.map((payload: string) => JSON.parse(payload) as SentRealtimeEvent);
+}
+
+function requireSession(socket: FakeWebSocketInstance, index = 0): Record<string, unknown> {
+  const session = parseSent(socket)[index]?.session;
+  if (!session || typeof session !== "object") {
+    throw new Error("expected session.update payload");
+  }
+  return session as Record<string, unknown>;
+}
+
+describe("buildXaiRealtimeVoiceProvider", () => {
+  beforeEach(() => {
+    FakeWebSocket.instances = [];
+    isProviderAuthProfileConfiguredMock.mockReset();
+    isProviderAuthProfileConfiguredMock.mockReturnValue(false);
+    resolveApiKeyForProviderMock.mockReset();
+    resolveApiKeyForProviderMock.mockResolvedValue({ apiKey: undefined });
+    delete process.env.XAI_API_KEY;
+    vi.unstubAllEnvs();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.unstubAllEnvs();
+  });
+
+  it("declares realtime Talk capabilities for catalog selection", () => {
+    const provider = buildXaiRealtimeVoiceProvider();
+
+    expect(provider.defaultModel).toBe("grok-voice-latest");
+    expect(provider.capabilities).toEqual({
+      transports: ["gateway-relay"],
+      inputAudioFormats: [
+        { encoding: "g711_ulaw", sampleRateHz: 8000, channels: 1 },
+        { encoding: "pcm16", sampleRateHz: 24000, channels: 1 },
+      ],
+      outputAudioFormats: [
+        { encoding: "g711_ulaw", sampleRateHz: 8000, channels: 1 },
+        { encoding: "pcm16", sampleRateHz: 24000, channels: 1 },
+      ],
+      supportsBargeIn: true,
+      supportsToolCalls: true,
+    });
+  });
+
+  it("advertises continuing realtime tool results", () => {
+    const provider = buildXaiRealtimeVoiceProvider();
+    const bridge = provider.createBridge({
+      providerConfig: { apiKey: "xai-test" }, // pragma: allowlist secret
+      onAudio: vi.fn(),
+      onClearAudio: vi.fn(),
+    });
+
+    expect(bridge.supportsToolResultContinuation).toBe(true);
+  });
+
+  it("requires xAI credentials for native realtime websocket bridges", async () => {
+    const provider = buildXaiRealtimeVoiceProvider();
+    const bridge = provider.createBridge({
+      cfg: {} as never,
+      providerConfig: { model: "grok-voice-latest" },
+      onAudio: vi.fn(),
+      onClearAudio: vi.fn(),
+    });
+
+    await expect(bridge.connect()).rejects.toThrow("xAI credentials missing for realtime voice");
+    expect(FakeWebSocket.instances).toHaveLength(0);
+  });
+
+  it("uses XAI_API_KEY for default Grok realtime bridges", async () => {
+    vi.stubEnv("XAI_API_KEY", "xai-env"); // pragma: allowlist secret
+    const provider = buildXaiRealtimeVoiceProvider();
+    const bridge = provider.createBridge({
+      cfg: {} as never,
+      providerConfig: { model: "grok-voice-latest", voice: "ara" },
+      instructions: "Speak briefly.",
+      onAudio: vi.fn(),
+      onClearAudio: vi.fn(),
+    });
+
+    void bridge.connect();
+    await vi.waitFor(() => expect(FakeWebSocket.instances.length).toBe(1));
+    const socket = FakeWebSocket.instances[0];
+    socket.readyState = FakeWebSocket.OPEN;
+    socket.emit("open");
+    socket.emit("message", Buffer.from(JSON.stringify({ type: "session.updated" })));
+    bridge.close();
+
+    const url = socket.args[0] as string;
+    expect(url).toContain("wss://api.x.ai/v1/realtime?model=grok-voice-latest");
+    const options = socket?.args[1] as { headers?: Record<string, string> } | undefined;
+    expect(options?.headers?.Authorization).toBe("Bearer xai-env");
+    const session = requireSession(socket);
+    expect(session.voice).toBe("ara");
+    expect(session.turn_detection).toEqual(
+      expect.objectContaining({
+        create_response: true,
+        interrupt_response: true,
+        threshold: 0.85,
+      }),
+    );
+    expect(session.audio).toEqual({
+      input: {
+        format: { type: "audio/pcmu" },
+        transcription: { model: "grok-transcribe" },
+      },
+      output: { format: { type: "audio/pcmu" } },
+    });
+  });
+
+  it("sends nested xAI session.update audio formats for g711 bridges", async () => {
+    vi.stubEnv("XAI_API_KEY", "xai-env"); // pragma: allowlist secret
+    const provider = buildXaiRealtimeVoiceProvider();
+    const bridge = provider.createBridge({
+      providerConfig: { apiKey: "xai-test" }, // pragma: allowlist secret
+      audioFormat: { encoding: "g711_ulaw", sampleRateHz: 8000, channels: 1 },
+      onAudio: vi.fn(),
+      onClearAudio: vi.fn(),
+    });
+
+    void bridge.connect();
+    await vi.waitFor(() => expect(FakeWebSocket.instances.length).toBe(1));
+    const socket = FakeWebSocket.instances[0];
+    socket.readyState = FakeWebSocket.OPEN;
+    socket.emit("open");
+    socket.emit("message", Buffer.from(JSON.stringify({ type: "session.updated" })));
+    bridge.close();
+
+    const session = requireSession(socket);
+    expect(session.audio).toEqual({
+      input: {
+        format: { type: "audio/pcmu" },
+        transcription: { model: "grok-transcribe" },
+      },
+      output: { format: { type: "audio/pcmu" } },
+    });
+  });
+
+  it("only forwards xAI VAD thresholds accepted by the realtime API", async () => {
+    const provider = buildXaiRealtimeVoiceProvider();
+    const invalidThresholdBridge = provider.createBridge({
+      providerConfig: { apiKey: "xai-test", vadThreshold: 1 }, // pragma: allowlist secret
+      onAudio: vi.fn(),
+      onClearAudio: vi.fn(),
+    });
+
+    void invalidThresholdBridge.connect();
+    await vi.waitFor(() => expect(FakeWebSocket.instances.length).toBe(1));
+    const invalidThresholdSocket = FakeWebSocket.instances[0];
+    invalidThresholdSocket.readyState = FakeWebSocket.OPEN;
+    invalidThresholdSocket.emit("open");
+    invalidThresholdSocket.emit(
+      "message",
+      Buffer.from(JSON.stringify({ type: "session.updated" })),
+    );
+    invalidThresholdBridge.close();
+
+    expect(requireSession(invalidThresholdSocket).turn_detection).toEqual(
+      expect.objectContaining({ threshold: 0.85 }),
+    );
+
+    const validThresholdBridge = provider.createBridge({
+      providerConfig: { apiKey: "xai-test", vadThreshold: 0.9 }, // pragma: allowlist secret
+      onAudio: vi.fn(),
+      onClearAudio: vi.fn(),
+    });
+
+    void validThresholdBridge.connect();
+    await vi.waitFor(() => expect(FakeWebSocket.instances.length).toBe(2));
+    const validThresholdSocket = FakeWebSocket.instances[1];
+    validThresholdSocket.readyState = FakeWebSocket.OPEN;
+    validThresholdSocket.emit("open");
+    validThresholdSocket.emit("message", Buffer.from(JSON.stringify({ type: "session.updated" })));
+    validThresholdBridge.close();
+
+    expect(requireSession(validThresholdSocket).turn_detection).toEqual(
+      expect.objectContaining({ threshold: 0.9 }),
+    );
+  });
+
+  it("treats xAI input transcription updates as replacements until completed", async () => {
+    const provider = buildXaiRealtimeVoiceProvider();
+    const onTranscript = vi.fn();
+    const bridge = provider.createBridge({
+      providerConfig: { apiKey: "xai-test" }, // pragma: allowlist secret
+      onAudio: vi.fn(),
+      onClearAudio: vi.fn(),
+      onTranscript,
+    });
+
+    const connecting = bridge.connect();
+    await vi.waitFor(() => expect(FakeWebSocket.instances.length).toBe(1));
+    const socket = FakeWebSocket.instances[0];
+    socket.readyState = FakeWebSocket.OPEN;
+    socket.emit("open");
+    socket.emit("message", Buffer.from(JSON.stringify({ type: "session.updated" })));
+    await connecting;
+
+    socket.emit(
+      "message",
+      Buffer.from(
+        JSON.stringify({
+          type: "conversation.item.input_audio_transcription.updated",
+          item_id: "item_1",
+          transcript: "open",
+        }),
+      ),
+    );
+    socket.emit(
+      "message",
+      Buffer.from(
+        JSON.stringify({
+          type: "conversation.item.input_audio_transcription.updated",
+          item_id: "item_1",
+          transcript: "open claw",
+        }),
+      ),
+    );
+    socket.emit(
+      "message",
+      Buffer.from(
+        JSON.stringify({
+          type: "conversation.item.input_audio_transcription.completed",
+          item_id: "item_1",
+          transcript: "OpenClaw",
+        }),
+      ),
+    );
+    bridge.close();
+
+    expect(onTranscript).toHaveBeenCalledOnce();
+    expect(onTranscript).toHaveBeenCalledWith("user", "OpenClaw", true);
+  });
+
+  it("buffers assistant transcript deltas and finalizes them when done has no text", async () => {
+    const provider = buildXaiRealtimeVoiceProvider();
+    const onTranscript = vi.fn();
+    const bridge = provider.createBridge({
+      providerConfig: { apiKey: "xai-test" }, // pragma: allowlist secret
+      onAudio: vi.fn(),
+      onClearAudio: vi.fn(),
+      onTranscript,
+    });
+
+    const connecting = bridge.connect();
+    await vi.waitFor(() => expect(FakeWebSocket.instances.length).toBe(1));
+    const socket = FakeWebSocket.instances[0];
+    socket.readyState = FakeWebSocket.OPEN;
+    socket.emit("open");
+    socket.emit("message", Buffer.from(JSON.stringify({ type: "session.updated" })));
+    await connecting;
+
+    socket.emit("message", Buffer.from(JSON.stringify({ type: "response.created" })));
+    socket.emit(
+      "message",
+      Buffer.from(
+        JSON.stringify({
+          type: "response.output_audio_transcript.delta",
+          delta: "Hello ",
+        }),
+      ),
+    );
+    socket.emit(
+      "message",
+      Buffer.from(
+        JSON.stringify({
+          type: "response.output_audio_transcript.delta",
+          delta: "OpenClaw",
+        }),
+      ),
+    );
+    socket.emit(
+      "message",
+      Buffer.from(JSON.stringify({ type: "response.output_audio_transcript.done" })),
+    );
+    socket.emit("message", Buffer.from(JSON.stringify({ type: "response.done" })));
+    bridge.close();
+
+    expect(onTranscript).toHaveBeenNthCalledWith(1, "assistant", "Hello ", false);
+    expect(onTranscript).toHaveBeenNthCalledWith(2, "assistant", "OpenClaw", false);
+    expect(onTranscript).toHaveBeenNthCalledWith(3, "assistant", "Hello OpenClaw", true);
+    expect(onTranscript).toHaveBeenCalledTimes(3);
+  });
+
+  it("cancels active responses on server VAD speech_started without an audio item to truncate", async () => {
+    vi.stubEnv("XAI_API_KEY", "xai-env"); // pragma: allowlist secret
+    const provider = buildXaiRealtimeVoiceProvider();
+    const onClearAudio = vi.fn();
+    const bridge = provider.createBridge({
+      providerConfig: { apiKey: "xai-test" }, // pragma: allowlist secret
+      audioFormat: REALTIME_VOICE_AUDIO_FORMAT_PCM16_24KHZ,
+      onAudio: vi.fn(),
+      onClearAudio,
+    });
+
+    void bridge.connect();
+    await vi.waitFor(() => expect(FakeWebSocket.instances.length).toBe(1));
+    const socket = FakeWebSocket.instances[0];
+    socket.readyState = FakeWebSocket.OPEN;
+    socket.emit("open");
+    socket.emit("message", Buffer.from(JSON.stringify({ type: "session.updated" })));
+    socket.emit(
+      "message",
+      Buffer.from(
+        JSON.stringify({
+          type: "response.created",
+          response: { id: "resp_1" },
+        }),
+      ),
+    );
+    socket.emit(
+      "message",
+      Buffer.from(JSON.stringify({ type: "input_audio_buffer.speech_started" })),
+    );
+    bridge.close();
+
+    const sentTypes = parseSent(socket).map((event) => event.type);
+    expect(sentTypes).toContain("response.cancel");
+    expect(sentTypes).not.toContain("conversation.item.truncate");
+    expect(onClearAudio).toHaveBeenCalled();
+  });
+
+  it("cancels and truncates active response audio on barge-in", async () => {
+    vi.stubEnv("XAI_API_KEY", "xai-env"); // pragma: allowlist secret
+    const provider = buildXaiRealtimeVoiceProvider();
+    const onAudio = vi.fn();
+    const onClearAudio = vi.fn();
+    const bridge = provider.createBridge({
+      providerConfig: { apiKey: "xai-test" }, // pragma: allowlist secret
+      audioFormat: REALTIME_VOICE_AUDIO_FORMAT_PCM16_24KHZ,
+      onAudio,
+      onClearAudio,
+    });
+
+    void bridge.connect();
+    await vi.waitFor(() => expect(FakeWebSocket.instances.length).toBe(1));
+    const socket = FakeWebSocket.instances[0];
+    socket.readyState = FakeWebSocket.OPEN;
+    socket.emit("open");
+    socket.emit("message", Buffer.from(JSON.stringify({ type: "session.updated" })));
+    socket.emit(
+      "message",
+      Buffer.from(
+        JSON.stringify({
+          type: "response.created",
+          response: { id: "resp_1" },
+        }),
+      ),
+    );
+    bridge.setMediaTimestamp(1000);
+    socket.emit(
+      "message",
+      Buffer.from(
+        JSON.stringify({
+          type: "response.audio.delta",
+          item_id: "item_1",
+          delta: Buffer.from("assistant audio").toString("base64"),
+        }),
+      ),
+    );
+    bridge.setMediaTimestamp(1300);
+    bridge.handleBargeIn?.({ audioPlaybackActive: true });
+    bridge.close();
+
+    expect(onAudio).toHaveBeenCalledTimes(1);
+    expect(onClearAudio).toHaveBeenCalledTimes(1);
+    expect(parseSent(socket).slice(-2)).toEqual([
+      { type: "response.cancel" },
+      {
+        type: "conversation.item.truncate",
+        item_id: "item_1",
+        content_index: 0,
+        audio_end_ms: 300,
+      },
+    ]);
+  });
+
+  it("truncates server-VAD barge-in even when relay marks are already acknowledged", async () => {
+    vi.stubEnv("XAI_API_KEY", "xai-env"); // pragma: allowlist secret
+    const provider = buildXaiRealtimeVoiceProvider();
+    const bridge = provider.createBridge({
+      providerConfig: { apiKey: "xai-test" }, // pragma: allowlist secret
+      audioFormat: REALTIME_VOICE_AUDIO_FORMAT_PCM16_24KHZ,
+      onAudio: vi.fn(),
+      onClearAudio: vi.fn(),
+    });
+
+    void bridge.connect();
+    await vi.waitFor(() => expect(FakeWebSocket.instances.length).toBe(1));
+    const socket = FakeWebSocket.instances[0];
+    socket.readyState = FakeWebSocket.OPEN;
+    socket.emit("open");
+    socket.emit("message", Buffer.from(JSON.stringify({ type: "session.updated" })));
+    socket.emit(
+      "message",
+      Buffer.from(
+        JSON.stringify({
+          type: "response.created",
+          response: { id: "resp_1" },
+        }),
+      ),
+    );
+    bridge.setMediaTimestamp(1000);
+    socket.emit(
+      "message",
+      Buffer.from(
+        JSON.stringify({
+          type: "response.audio.delta",
+          item_id: "item_1",
+          delta: Buffer.from("assistant audio").toString("base64"),
+        }),
+      ),
+    );
+    bridge.acknowledgeMark?.();
+    bridge.setMediaTimestamp(1250);
+    socket.emit(
+      "message",
+      Buffer.from(JSON.stringify({ type: "input_audio_buffer.speech_started" })),
+    );
+    bridge.close();
+
+    expect(parseSent(socket).slice(-2)).toEqual([
+      { type: "response.cancel" },
+      {
+        type: "conversation.item.truncate",
+        item_id: "item_1",
+        content_index: 0,
+        audio_end_ms: 250,
+      },
+    ]);
+  });
+
+  it("does not truncate completed assistant audio on a later user turn", async () => {
+    vi.stubEnv("XAI_API_KEY", "xai-env"); // pragma: allowlist secret
+    const provider = buildXaiRealtimeVoiceProvider();
+    const onClearAudio = vi.fn();
+    const bridge = provider.createBridge({
+      providerConfig: { apiKey: "xai-test" }, // pragma: allowlist secret
+      audioFormat: REALTIME_VOICE_AUDIO_FORMAT_PCM16_24KHZ,
+      onAudio: vi.fn(),
+      onClearAudio,
+    });
+
+    void bridge.connect();
+    await vi.waitFor(() => expect(FakeWebSocket.instances.length).toBe(1));
+    const socket = FakeWebSocket.instances[0];
+    socket.readyState = FakeWebSocket.OPEN;
+    socket.emit("open");
+    socket.emit("message", Buffer.from(JSON.stringify({ type: "session.updated" })));
+    socket.emit(
+      "message",
+      Buffer.from(
+        JSON.stringify({
+          type: "response.created",
+          response: { id: "resp_1" },
+        }),
+      ),
+    );
+    bridge.setMediaTimestamp(1000);
+    socket.emit(
+      "message",
+      Buffer.from(
+        JSON.stringify({
+          type: "response.audio.delta",
+          item_id: "item_1",
+          delta: Buffer.from("assistant audio").toString("base64"),
+        }),
+      ),
+    );
+    bridge.acknowledgeMark?.();
+    socket.emit("message", Buffer.from(JSON.stringify({ type: "response.done" })));
+    bridge.setMediaTimestamp(2000);
+    socket.emit(
+      "message",
+      Buffer.from(JSON.stringify({ type: "input_audio_buffer.speech_started" })),
+    );
+    bridge.close();
+
+    const sentTypes = parseSent(socket).map((event) => event.type);
+    expect(sentTypes).not.toContain("response.cancel");
+    expect(sentTypes).not.toContain("conversation.item.truncate");
+    expect(onClearAudio).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps completed assistant item state so relay playback cancel can truncate it", async () => {
+    vi.stubEnv("XAI_API_KEY", "xai-env"); // pragma: allowlist secret
+    const provider = buildXaiRealtimeVoiceProvider();
+    const onClearAudio = vi.fn();
+    const bridge = provider.createBridge({
+      providerConfig: { apiKey: "xai-test" }, // pragma: allowlist secret
+      audioFormat: REALTIME_VOICE_AUDIO_FORMAT_PCM16_24KHZ,
+      onAudio: vi.fn(),
+      onClearAudio,
+    });
+
+    void bridge.connect();
+    await vi.waitFor(() => expect(FakeWebSocket.instances.length).toBe(1));
+    const socket = FakeWebSocket.instances[0];
+    socket.readyState = FakeWebSocket.OPEN;
+    socket.emit("open");
+    socket.emit("message", Buffer.from(JSON.stringify({ type: "session.updated" })));
+    socket.emit(
+      "message",
+      Buffer.from(
+        JSON.stringify({
+          type: "response.created",
+          response: { id: "resp_1" },
+        }),
+      ),
+    );
+    bridge.setMediaTimestamp(1000);
+    socket.emit(
+      "message",
+      Buffer.from(
+        JSON.stringify({
+          type: "response.audio.delta",
+          item_id: "item_1",
+          delta: Buffer.from("assistant audio").toString("base64"),
+        }),
+      ),
+    );
+    bridge.acknowledgeMark?.();
+    socket.emit("message", Buffer.from(JSON.stringify({ type: "response.done" })));
+    bridge.setMediaTimestamp(1300);
+    socket.emit(
+      "message",
+      Buffer.from(JSON.stringify({ type: "input_audio_buffer.speech_started" })),
+    );
+    bridge.handleBargeIn?.({ audioPlaybackActive: true });
+    bridge.close();
+
+    expect(onClearAudio).toHaveBeenCalledTimes(2);
+    expect(parseSent(socket).slice(-1)).toEqual([
+      {
+        type: "conversation.item.truncate",
+        item_id: "item_1",
+        content_index: 0,
+        audio_end_ms: 300,
+      },
+    ]);
+  });
+
+  it("does not truncate a previous assistant item when a new response is interrupted before audio", async () => {
+    vi.stubEnv("XAI_API_KEY", "xai-env"); // pragma: allowlist secret
+    const provider = buildXaiRealtimeVoiceProvider();
+    const bridge = provider.createBridge({
+      providerConfig: { apiKey: "xai-test" }, // pragma: allowlist secret
+      audioFormat: REALTIME_VOICE_AUDIO_FORMAT_PCM16_24KHZ,
+      onAudio: vi.fn(),
+      onClearAudio: vi.fn(),
+    });
+
+    void bridge.connect();
+    await vi.waitFor(() => expect(FakeWebSocket.instances.length).toBe(1));
+    const socket = FakeWebSocket.instances[0];
+    socket.readyState = FakeWebSocket.OPEN;
+    socket.emit("open");
+    socket.emit("message", Buffer.from(JSON.stringify({ type: "session.updated" })));
+    socket.emit(
+      "message",
+      Buffer.from(
+        JSON.stringify({
+          type: "response.created",
+          response: { id: "resp_1" },
+        }),
+      ),
+    );
+    bridge.setMediaTimestamp(1000);
+    socket.emit(
+      "message",
+      Buffer.from(
+        JSON.stringify({
+          type: "response.audio.delta",
+          item_id: "item_1",
+          delta: Buffer.from("assistant audio").toString("base64"),
+        }),
+      ),
+    );
+    bridge.acknowledgeMark?.();
+    socket.emit("message", Buffer.from(JSON.stringify({ type: "response.done" })));
+    socket.emit(
+      "message",
+      Buffer.from(
+        JSON.stringify({
+          type: "response.created",
+          response: { id: "resp_2" },
+        }),
+      ),
+    );
+    bridge.setMediaTimestamp(1500);
+    socket.emit(
+      "message",
+      Buffer.from(JSON.stringify({ type: "input_audio_buffer.speech_started" })),
+    );
+    bridge.close();
+
+    const sentTypes = parseSent(socket).map((event) => event.type);
+    expect(sentTypes).toContain("response.cancel");
+    expect(sentTypes).not.toContain("conversation.item.truncate");
+  });
+
+  it("emits tool calls from realtime conversation item done events", async () => {
+    vi.stubEnv("XAI_API_KEY", "xai-env"); // pragma: allowlist secret
+    const provider = buildXaiRealtimeVoiceProvider();
+    const onToolCall = vi.fn();
+    const onEvent = vi.fn();
+    const bridge = provider.createBridge({
+      providerConfig: { apiKey: "xai-test" }, // pragma: allowlist secret
+      onAudio: vi.fn(),
+      onClearAudio: vi.fn(),
+      onToolCall,
+      onEvent,
+    });
+
+    const connecting = bridge.connect();
+    await vi.waitFor(() => expect(FakeWebSocket.instances.length).toBe(1));
+    const socket = FakeWebSocket.instances[0];
+    socket.readyState = FakeWebSocket.OPEN;
+    socket.emit("open");
+    socket.emit("message", Buffer.from(JSON.stringify({ type: "session.updated" })));
+    await connecting;
+
+    socket.emit(
+      "message",
+      Buffer.from(
+        JSON.stringify({
+          type: "conversation.item.done",
+          item: {
+            id: "item_tool_1",
+            type: "function_call",
+            name: "openclaw_agent_consult",
+            call_id: "call_1",
+            arguments: JSON.stringify({ question: "delegate this" }),
+          },
+        }),
+      ),
+    );
+
+    expect(onToolCall).toHaveBeenCalledWith({
+      itemId: "item_tool_1",
+      callId: "call_1",
+      name: "openclaw_agent_consult",
+      args: { question: "delegate this" },
+    });
+    expect(onEvent).toHaveBeenCalledWith({
+      direction: "server",
+      type: "conversation.item.done",
+      detail: "function_call name=openclaw_agent_consult",
+    });
+  });
+
+  it("deduplicates tool calls reported by arguments done and item done events", async () => {
+    vi.stubEnv("XAI_API_KEY", "xai-env"); // pragma: allowlist secret
+    const provider = buildXaiRealtimeVoiceProvider();
+    const onToolCall = vi.fn();
+    const bridge = provider.createBridge({
+      providerConfig: { apiKey: "xai-test" }, // pragma: allowlist secret
+      onAudio: vi.fn(),
+      onClearAudio: vi.fn(),
+      onToolCall,
+    });
+
+    const connecting = bridge.connect();
+    await vi.waitFor(() => expect(FakeWebSocket.instances.length).toBe(1));
+    const socket = FakeWebSocket.instances[0];
+    socket.readyState = FakeWebSocket.OPEN;
+    socket.emit("open");
+    socket.emit("message", Buffer.from(JSON.stringify({ type: "session.updated" })));
+    await connecting;
+
+    socket.emit(
+      "message",
+      Buffer.from(
+        JSON.stringify({
+          type: "response.function_call_arguments.delta",
+          item_id: "item_tool_1",
+          name: "openclaw_agent_consult",
+          call_id: "call_1",
+          delta: JSON.stringify({ question: "delegate this" }),
+        }),
+      ),
+    );
+    socket.emit(
+      "message",
+      Buffer.from(
+        JSON.stringify({
+          type: "response.function_call_arguments.done",
+          item_id: "item_tool_1",
+          name: "openclaw_agent_consult",
+          call_id: "call_1",
+        }),
+      ),
+    );
+    socket.emit(
+      "message",
+      Buffer.from(
+        JSON.stringify({
+          type: "conversation.item.done",
+          item: {
+            id: "item_tool_1",
+            type: "function_call",
+            name: "openclaw_agent_consult",
+            call_id: "call_1",
+            arguments: JSON.stringify({ question: "delegate this" }),
+          },
+        }),
+      ),
+    );
+
+    expect(onToolCall).toHaveBeenCalledTimes(1);
+    expect(onToolCall).toHaveBeenCalledWith({
+      itemId: "item_tool_1",
+      callId: "call_1",
+      name: "openclaw_agent_consult",
+      args: { question: "delegate this" },
+    });
+  });
+
+  it("waits for all parallel tool results before sending response.create", async () => {
+    vi.stubEnv("XAI_API_KEY", "xai-env"); // pragma: allowlist secret
+    const provider = buildXaiRealtimeVoiceProvider();
+    const bridge = provider.createBridge({
+      providerConfig: { apiKey: "xai-test" }, // pragma: allowlist secret
+      onAudio: vi.fn(),
+      onClearAudio: vi.fn(),
+      onToolCall: vi.fn(),
+    });
+
+    const connecting = bridge.connect();
+    await vi.waitFor(() => expect(FakeWebSocket.instances.length).toBe(1));
+    const socket = FakeWebSocket.instances[0];
+    socket.readyState = FakeWebSocket.OPEN;
+    socket.emit("open");
+    socket.emit("message", Buffer.from(JSON.stringify({ type: "session.updated" })));
+    await connecting;
+
+    for (const callId of ["call_1", "call_2"]) {
+      socket.emit(
+        "message",
+        Buffer.from(
+          JSON.stringify({
+            type: "response.function_call_arguments.done",
+            item_id: `item_${callId}`,
+            name: "openclaw_agent_consult",
+            call_id: callId,
+            arguments: JSON.stringify({ question: callId }),
+          }),
+        ),
+      );
+    }
+
+    bridge.submitToolResult("call_1", { text: "first" });
+    expect(parseSent(socket).filter((event) => event.type === "response.create")).toEqual([]);
+
+    bridge.submitToolResult("call_2", { text: "second" });
+    expect(parseSent(socket).slice(-2)).toEqual([
+      {
+        type: "conversation.item.create",
+        item: {
+          type: "function_call_output",
+          call_id: "call_2",
+          output: JSON.stringify({ text: "second" }),
+        },
+      },
+      { type: "response.create" },
+    ]);
+  });
+
+  it("exhausts reconnect attempts when websocket opens without session setup", async () => {
+    vi.useFakeTimers();
+    vi.stubEnv("XAI_API_KEY", "xai-env"); // pragma: allowlist secret
+    const provider = buildXaiRealtimeVoiceProvider();
+    const onEvent = vi.fn();
+    const onClose = vi.fn();
+    const bridge = provider.createBridge({
+      providerConfig: { apiKey: "xai-test" }, // pragma: allowlist secret
+      onAudio: vi.fn(),
+      onClearAudio: vi.fn(),
+      onEvent,
+      onClose,
+    });
+
+    const connecting = bridge.connect();
+    await vi.waitFor(() => expect(FakeWebSocket.instances.length).toBe(1));
+    const firstSocket = FakeWebSocket.instances[0];
+    firstSocket.readyState = FakeWebSocket.OPEN;
+    firstSocket.emit("open");
+    firstSocket.emit(
+      "message",
+      Buffer.from(
+        JSON.stringify({ type: "conversation.created", conversation: { id: "conv_reconnect" } }),
+      ),
+    );
+    firstSocket.emit("message", Buffer.from(JSON.stringify({ type: "session.updated" })));
+    await connecting;
+
+    firstSocket.close(1006, "connection lost");
+
+    for (let attempt = 1; attempt <= 5; attempt += 1) {
+      const delayMs = 1000 * 2 ** (attempt - 1);
+      await vi.advanceTimersByTimeAsync(delayMs);
+      await vi.waitFor(() => expect(FakeWebSocket.instances.length).toBe(attempt + 1));
+      const socket = FakeWebSocket.instances[attempt];
+      socket.readyState = FakeWebSocket.OPEN;
+      socket.emit("open");
+      socket.close(1006, "session setup failed");
+    }
+
+    await vi.waitFor(() =>
+      expect(onEvent).toHaveBeenCalledWith({
+        direction: "client",
+        type: "session.reconnect.exhausted",
+        detail: "reason=websocket-close attempts=5",
+      }),
+    );
+    expect(onClose).toHaveBeenCalledWith("error");
+    bridge.close();
+  });
+
+  it("does not replay ready callbacks after reconnect", async () => {
+    vi.useFakeTimers();
+    vi.stubEnv("XAI_API_KEY", "xai-env"); // pragma: allowlist secret
+    const provider = buildXaiRealtimeVoiceProvider();
+    const onReady = vi.fn();
+    const bridge = provider.createBridge({
+      providerConfig: { apiKey: "xai-test" }, // pragma: allowlist secret
+      onAudio: vi.fn(),
+      onClearAudio: vi.fn(),
+      onReady,
+    });
+
+    const connecting = bridge.connect();
+    await vi.waitFor(() => expect(FakeWebSocket.instances.length).toBe(1));
+    const firstSocket = FakeWebSocket.instances[0];
+    firstSocket.readyState = FakeWebSocket.OPEN;
+    firstSocket.emit("open");
+    firstSocket.emit(
+      "message",
+      Buffer.from(
+        JSON.stringify({ type: "conversation.created", conversation: { id: "conv_ready" } }),
+      ),
+    );
+    firstSocket.emit("message", Buffer.from(JSON.stringify({ type: "session.updated" })));
+    await connecting;
+
+    firstSocket.close(1006, "connection lost");
+    await vi.advanceTimersByTimeAsync(1000);
+    await vi.waitFor(() => expect(FakeWebSocket.instances.length).toBe(2));
+    const secondSocket = FakeWebSocket.instances[1];
+    expect(String(secondSocket.args[0])).toContain("conversation_id=conv_ready");
+    secondSocket.readyState = FakeWebSocket.OPEN;
+    secondSocket.emit("open");
+    secondSocket.emit("message", Buffer.from(JSON.stringify({ type: "session.updated" })));
+    bridge.close();
+
+    expect(onReady).toHaveBeenCalledOnce();
+  });
+
+  it("enables xAI session resumption and reconnects with the created conversation id", async () => {
+    vi.useFakeTimers();
+    vi.stubEnv("XAI_API_KEY", "xai-env"); // pragma: allowlist secret
+    const provider = buildXaiRealtimeVoiceProvider();
+    const bridge = provider.createBridge({
+      providerConfig: { apiKey: "xai-test" }, // pragma: allowlist secret
+      onAudio: vi.fn(),
+      onClearAudio: vi.fn(),
+    });
+
+    const connecting = bridge.connect();
+    await vi.waitFor(() => expect(FakeWebSocket.instances.length).toBe(1));
+    const firstSocket = FakeWebSocket.instances[0];
+    firstSocket.readyState = FakeWebSocket.OPEN;
+    firstSocket.emit("open");
+    expect(requireSession(firstSocket).resumption).toEqual({ enabled: true });
+    firstSocket.emit(
+      "message",
+      Buffer.from(
+        JSON.stringify({ type: "conversation.created", conversation: { id: "conv_resume" } }),
+      ),
+    );
+    firstSocket.emit("message", Buffer.from(JSON.stringify({ type: "session.updated" })));
+    await connecting;
+
+    firstSocket.close(1006, "connection lost");
+    await vi.advanceTimersByTimeAsync(1000);
+    await vi.waitFor(() => expect(FakeWebSocket.instances.length).toBe(2));
+    const secondSocket = FakeWebSocket.instances[1];
+    expect(String(secondSocket.args[0])).toContain("conversation_id=conv_resume");
+    secondSocket.readyState = FakeWebSocket.OPEN;
+    secondSocket.emit("open");
+    expect(requireSession(secondSocket).resumption).toEqual({ enabled: true });
+    bridge.close();
+  });
+
+  it("fails closed instead of reconnecting without a conversation id", async () => {
+    vi.useFakeTimers();
+    vi.stubEnv("XAI_API_KEY", "xai-env"); // pragma: allowlist secret
+    const provider = buildXaiRealtimeVoiceProvider();
+    const onEvent = vi.fn();
+    const onClose = vi.fn();
+    const bridge = provider.createBridge({
+      providerConfig: { apiKey: "xai-test" }, // pragma: allowlist secret
+      onAudio: vi.fn(),
+      onClearAudio: vi.fn(),
+      onEvent,
+      onClose,
+    });
+
+    const connecting = bridge.connect();
+    await vi.waitFor(() => expect(FakeWebSocket.instances.length).toBe(1));
+    const socket = FakeWebSocket.instances[0];
+    socket.readyState = FakeWebSocket.OPEN;
+    socket.emit("open");
+    socket.emit("message", Buffer.from(JSON.stringify({ type: "session.updated" })));
+    await connecting;
+
+    socket.close(1006, "connection lost");
+    await vi.advanceTimersByTimeAsync(1000);
+
+    expect(FakeWebSocket.instances).toHaveLength(1);
+    expect(onEvent).toHaveBeenCalledWith({
+      direction: "client",
+      type: "session.reconnect.blocked",
+      detail: "reason=websocket-close missingConversationId=true",
+    });
+    expect(onClose).toHaveBeenCalledWith("error");
+    bridge.close();
+  });
+
+  it("does not retry after startup websocket errors", async () => {
+    vi.useFakeTimers();
+    vi.stubEnv("XAI_API_KEY", "xai-env"); // pragma: allowlist secret
+    const provider = buildXaiRealtimeVoiceProvider();
+    const onClose = vi.fn();
+    const bridge = provider.createBridge({
+      providerConfig: { apiKey: "xai-test" }, // pragma: allowlist secret
+      onAudio: vi.fn(),
+      onClearAudio: vi.fn(),
+      onClose,
+    });
+
+    const connecting = bridge.connect();
+    await vi.waitFor(() => expect(FakeWebSocket.instances.length).toBe(1));
+    const socket = FakeWebSocket.instances[0];
+    socket.readyState = FakeWebSocket.OPEN;
+    socket.emit("open");
+    socket.emit("error", new Error("bad auth"));
+
+    await expect(connecting).rejects.toThrow("bad auth");
+    await vi.advanceTimersByTimeAsync(1000);
+
+    expect(FakeWebSocket.instances).toHaveLength(1);
+    expect(onClose).not.toHaveBeenCalled();
+  });
+
+  it("forwards configured provider tools in session.update", async () => {
+    vi.stubEnv("XAI_API_KEY", "xai-env"); // pragma: allowlist secret
+    const provider = buildXaiRealtimeVoiceProvider();
+    const bridge = provider.createBridge({
+      providerConfig: { apiKey: "xai-test" }, // pragma: allowlist secret
+      tools: [
+        {
+          type: "function",
+          name: "openclaw_agent_consult",
+          description: "Consult OpenClaw",
+          parameters: { type: "object", properties: {} },
+        },
+      ],
+      onAudio: vi.fn(),
+      onClearAudio: vi.fn(),
+    });
+
+    void bridge.connect();
+    await vi.waitFor(() => expect(FakeWebSocket.instances.length).toBe(1));
+    const socket = FakeWebSocket.instances[0];
+    socket.readyState = FakeWebSocket.OPEN;
+    socket.emit("open");
+    socket.emit("message", Buffer.from(JSON.stringify({ type: "session.updated" })));
+    bridge.close();
+
+    const session = requireSession(socket);
+    expect(session.tools).toHaveLength(1);
+    expect(session.tool_choice).toBe("auto");
+  });
+});

--- a/extensions/xai/realtime-voice-provider.ts
+++ b/extensions/xai/realtime-voice-provider.ts
@@ -1,0 +1,1080 @@
+// Xai provider module implements Grok realtime voice bridge integration.
+import { randomUUID } from "node:crypto";
+import {
+  isProviderAuthProfileConfigured,
+  type OpenClawConfig,
+} from "openclaw/plugin-sdk/provider-auth";
+import { resolveApiKeyForProvider } from "openclaw/plugin-sdk/provider-auth-runtime";
+import {
+  captureWsEvent,
+  createDebugProxyWebSocketAgent,
+  resolveDebugProxySettings,
+} from "openclaw/plugin-sdk/proxy-capture";
+import type {
+  RealtimeVoiceAudioFormat,
+  RealtimeVoiceBargeInOptions,
+  RealtimeVoiceBridge,
+  RealtimeVoiceBridgeCreateRequest,
+  RealtimeVoiceProviderConfig,
+  RealtimeVoiceProviderPlugin,
+  RealtimeVoiceToolResultOptions,
+} from "openclaw/plugin-sdk/realtime-voice";
+import {
+  REALTIME_VOICE_AUDIO_FORMAT_G711_ULAW_8KHZ,
+  REALTIME_VOICE_AUDIO_FORMAT_PCM16_24KHZ,
+} from "openclaw/plugin-sdk/realtime-voice";
+import { normalizeResolvedSecretInputString } from "openclaw/plugin-sdk/secret-input";
+import {
+  asFiniteNumber,
+  normalizeOptionalString,
+  parseBooleanValue as readBoolean,
+} from "openclaw/plugin-sdk/string-coerce-runtime";
+import WebSocket from "ws";
+import { XAI_BASE_URL } from "./model-definitions.js";
+import { xaiUserAgentHeaderFor } from "./src/xai-user-agent.js";
+
+type XaiRealtimeVoice = "eve" | "ara" | "rex" | "sal" | "leo";
+
+type XaiRealtimeVoiceProviderConfig = {
+  apiKey?: string;
+  baseUrl?: string;
+  model?: string;
+  voice?: string;
+  vadThreshold?: number;
+  silenceDurationMs?: number;
+  prefixPaddingMs?: number;
+  interruptResponseOnInputAudio?: boolean;
+  reasoningEffort?: string;
+};
+
+type XaiRealtimeVoiceBridgeConfig = RealtimeVoiceBridgeCreateRequest & {
+  apiKey?: string;
+  baseUrl: string;
+  model?: string;
+  voice?: string;
+  vadThreshold?: number;
+  silenceDurationMs?: number;
+  prefixPaddingMs?: number;
+  interruptResponseOnInputAudio?: boolean;
+  reasoningEffort?: string;
+  resolveApiKey?: () => Promise<string>;
+};
+
+type RealtimeEvent = {
+  type: string;
+  delta?: string;
+  data?: string;
+  text?: string;
+  transcript?: string;
+  item_id?: string;
+  response_id?: string;
+  call_id?: string;
+  name?: string;
+  arguments?: string;
+  item?: {
+    id?: string;
+    type?: string;
+    name?: string;
+    call_id?: string;
+    arguments?: string;
+  };
+  response?: {
+    id?: string;
+    status?: string;
+    status_details?: unknown;
+  };
+  conversation?: {
+    id?: string;
+  };
+  error?: unknown;
+};
+
+type XaiRealtimeAudioFormatConfig =
+  | {
+      type: "audio/pcm";
+      rate: 24000;
+    }
+  | {
+      type: "audio/pcmu";
+    };
+
+type XaiRealtimeSessionUpdate = {
+  type: "session.update";
+  session: {
+    instructions?: string;
+    voice?: string;
+    output_modalities?: string[];
+    turn_detection?: {
+      type: "server_vad";
+      threshold?: number;
+      prefix_padding_ms?: number;
+      silence_duration_ms?: number;
+      create_response?: boolean;
+      interrupt_response?: boolean;
+    };
+    audio: {
+      input: {
+        format: XaiRealtimeAudioFormatConfig;
+        transcription: { model: string };
+      };
+      output: {
+        format: XaiRealtimeAudioFormatConfig;
+      };
+    };
+    reasoning?: { effort: string };
+    resumption?: {
+      enabled: boolean;
+    };
+    tools?: RealtimeVoiceBridgeCreateRequest["tools"];
+    tool_choice?: string;
+  };
+};
+
+const XAI_REALTIME_DEFAULT_MODEL = "grok-voice-latest";
+const XAI_REALTIME_CONNECT_TIMEOUT_MS = 10_000;
+const XAI_REALTIME_MAX_RECONNECT_ATTEMPTS = 5;
+const XAI_REALTIME_BASE_RECONNECT_DELAY_MS = 1000;
+const XAI_REALTIME_DEFAULT_VAD_THRESHOLD = 0.85;
+const XAI_REALTIME_DEFAULT_PREFIX_PADDING_MS = 333;
+const XAI_REALTIME_DEFAULT_SILENCE_DURATION_MS = 500;
+const XAI_REALTIME_INPUT_TRANSCRIPTION_MODEL = "grok-transcribe";
+const XAI_REALTIME_ACTIVE_RESPONSE_ERROR_PREFIX =
+  "Conversation already has an active response in progress:";
+const XAI_REALTIME_NO_ACTIVE_RESPONSE_CANCEL_ERROR =
+  "Cancellation failed: no active response found";
+const XAI_REALTIME_VOICES = [
+  "eve",
+  "ara",
+  "rex",
+  "sal",
+  "leo",
+] as const satisfies readonly XaiRealtimeVoice[];
+
+function readRecord(value: unknown): Record<string, unknown> | undefined {
+  return value && typeof value === "object" ? (value as Record<string, unknown>) : undefined;
+}
+
+function readNestedXaiConfig(rawConfig: RealtimeVoiceProviderConfig) {
+  const raw = readRecord(rawConfig);
+  const providers = readRecord(raw?.providers);
+  return readRecord(providers?.xai ?? raw?.xai ?? raw) ?? {};
+}
+
+function normalizeXaiRealtimeBaseUrl(value?: string): string {
+  return normalizeOptionalString(value ?? process.env.XAI_BASE_URL) ?? XAI_BASE_URL;
+}
+
+function normalizeXaiRealtimeVoice(value: unknown): string | undefined {
+  const normalized = normalizeOptionalString(value);
+  if (!normalized) {
+    return undefined;
+  }
+  const lower = normalized.toLowerCase();
+  return XAI_REALTIME_VOICES.includes(lower as XaiRealtimeVoice)
+    ? (lower as XaiRealtimeVoice)
+    : normalized;
+}
+
+function asXaiVadThreshold(value: unknown): number | undefined {
+  const number = asFiniteNumber(value);
+  return number !== undefined && number >= 0.1 && number <= 0.9 ? number : undefined;
+}
+
+function asNonNegativeInteger(value: unknown): number | undefined {
+  const number = asFiniteNumber(value);
+  return number !== undefined && Number.isSafeInteger(number) && number >= 0 ? number : undefined;
+}
+
+function normalizeProviderConfig(
+  config: RealtimeVoiceProviderConfig,
+): XaiRealtimeVoiceProviderConfig {
+  const raw = readNestedXaiConfig(config);
+  return {
+    apiKey: normalizeResolvedSecretInputString({
+      value: raw.apiKey,
+      path: "plugins.entries.voice-call.config.realtime.providers.xai.apiKey",
+    }),
+    baseUrl: normalizeOptionalString(raw.baseUrl),
+    model: normalizeOptionalString(raw.model),
+    voice: normalizeXaiRealtimeVoice(raw.speakerVoice ?? raw.voice),
+    vadThreshold: asXaiVadThreshold(raw.vadThreshold),
+    silenceDurationMs: asNonNegativeInteger(raw.silenceDurationMs),
+    prefixPaddingMs: asNonNegativeInteger(raw.prefixPaddingMs),
+    interruptResponseOnInputAudio: readBoolean(raw.interruptResponseOnInputAudio),
+    reasoningEffort: normalizeOptionalString(raw.reasoningEffort),
+  };
+}
+
+function readRealtimeErrorDetail(error: unknown): string {
+  if (typeof error === "string" && error) {
+    return error;
+  }
+  const record = readRecord(error);
+  const message = normalizeOptionalString(record?.message);
+  const code = normalizeOptionalString(record?.code);
+  return message ?? code ?? "xAI realtime voice error";
+}
+
+function base64ToBuffer(b64: string): Buffer {
+  return Buffer.from(b64, "base64");
+}
+
+function toXaiRealtimeWsUrl(baseUrl: string, model: string, conversationId?: string): string {
+  const url = new URL(normalizeXaiRealtimeBaseUrl(baseUrl));
+  url.protocol = url.protocol === "http:" ? "ws:" : "wss:";
+  url.pathname = `${url.pathname.replace(/\/+$/, "")}/realtime`;
+  url.searchParams.set("model", model);
+  if (conversationId) {
+    url.searchParams.set("conversation_id", conversationId);
+  }
+  return url.toString();
+}
+
+async function resolveXaiRealtimeApiKey(
+  configApiKey: string | undefined,
+  cfg: OpenClawConfig | undefined,
+): Promise<string> {
+  const direct =
+    normalizeOptionalString(configApiKey) ?? normalizeOptionalString(process.env.XAI_API_KEY);
+  if (direct) {
+    return direct;
+  }
+  const auth = await resolveApiKeyForProvider({ provider: "xai", cfg });
+  const oauthKey = normalizeOptionalString(auth?.apiKey);
+  if (oauthKey) {
+    return oauthKey;
+  }
+  throw new Error(
+    "xAI credentials missing for realtime voice. Sign in with `openclaw onboard --auth-choice xai-oauth`, run `openclaw onboard --auth-choice xai-api-key`, or set XAI_API_KEY.",
+  );
+}
+
+function hasXaiRealtimeApiKeyInput(
+  configApiKey: string | undefined,
+  cfg: OpenClawConfig | undefined,
+): boolean {
+  if (normalizeOptionalString(configApiKey) || normalizeOptionalString(process.env.XAI_API_KEY)) {
+    return true;
+  }
+  return isProviderAuthProfileConfigured({ provider: "xai", cfg });
+}
+
+class XaiRealtimeVoiceBridge implements RealtimeVoiceBridge {
+  private static readonly DEFAULT_MODEL = XAI_REALTIME_DEFAULT_MODEL;
+  readonly supportsToolResultContinuation = true;
+
+  private ws: WebSocket | null = null;
+  private connected = false;
+  private sessionConfigured = false;
+  private intentionallyClosed = false;
+  private reconnectAttempts = 0;
+  private pendingAudio: Buffer[] = [];
+  private markQueue: string[] = [];
+  private responseStartTimestamp: number | null = null;
+  private responseActive = false;
+  private responseCreateInFlight = false;
+  private responseCancelInFlight = false;
+  private responseCreatePending = false;
+  private continuingToolCallIds = new Set<string>();
+  private pendingToolCallIds = new Set<string>();
+  private latestMediaTimestamp = 0;
+  private lastAssistantItemId: string | null = null;
+  private assistantTranscriptBuffer = "";
+  private assistantTranscriptFinalized = false;
+  private inputTranscriptReplacements = new Map<string, string>();
+  private connectionUrl = "";
+  private toolCallBuffers = new Map<string, { name: string; callId: string; args: string }>();
+  private deliveredToolCallKeys = new Set<string>();
+  private readonly flowId = randomUUID();
+  private sessionReadyFired = false;
+  private conversationId: string | null = null;
+  private readonly audioFormat: RealtimeVoiceAudioFormat;
+
+  constructor(private readonly config: XaiRealtimeVoiceBridgeConfig) {
+    this.audioFormat = config.audioFormat ?? REALTIME_VOICE_AUDIO_FORMAT_G711_ULAW_8KHZ;
+  }
+
+  async connect(): Promise<void> {
+    this.intentionallyClosed = false;
+    this.reconnectAttempts = 0;
+    await this.doConnect();
+  }
+
+  sendAudio(audio: Buffer): void {
+    if (!this.connected || !this.sessionConfigured || this.ws?.readyState !== WebSocket.OPEN) {
+      if (this.pendingAudio.length < 320) {
+        this.pendingAudio.push(audio);
+      }
+      return;
+    }
+    this.sendEvent({
+      type: "input_audio_buffer.append",
+      audio: audio.toString("base64"),
+    });
+  }
+
+  setMediaTimestamp(ts: number): void {
+    this.latestMediaTimestamp = ts;
+  }
+
+  sendUserMessage(text: string): void {
+    this.sendEvent({
+      type: "conversation.item.create",
+      item: {
+        type: "message",
+        role: "user",
+        content: [{ type: "input_text", text }],
+      },
+    });
+    this.requestResponseCreate();
+  }
+
+  triggerGreeting(instructions?: string): void {
+    if (!this.isConnected() || !this.ws) {
+      return;
+    }
+    this.sendUserMessage(instructions ?? this.config.instructions ?? "Greet the user.");
+  }
+
+  submitToolResult(
+    callId: string,
+    result: unknown,
+    options?: RealtimeVoiceToolResultOptions,
+  ): void {
+    this.sendEvent({
+      type: "conversation.item.create",
+      item: {
+        type: "function_call_output",
+        call_id: callId,
+        output: JSON.stringify(result),
+      },
+    });
+    if (options?.willContinue === true) {
+      this.continuingToolCallIds.add(callId);
+      return;
+    }
+    this.continuingToolCallIds.delete(callId);
+    this.pendingToolCallIds.delete(callId);
+    if (options?.suppressResponse === true) {
+      return;
+    }
+    this.flushPendingResponseCreateAfterToolResults();
+  }
+
+  acknowledgeMark(): void {
+    if (this.markQueue.length === 0) {
+      return;
+    }
+    this.markQueue.shift();
+  }
+
+  close(): void {
+    this.intentionallyClosed = true;
+    this.connected = false;
+    this.sessionConfigured = false;
+    if (this.ws) {
+      this.ws.close(1000, "Bridge closed");
+      this.ws = null;
+    }
+  }
+
+  isConnected(): boolean {
+    return this.connected && this.sessionConfigured;
+  }
+
+  handleBargeIn(options?: RealtimeVoiceBargeInOptions): void {
+    const assistantItemId = this.lastAssistantItemId;
+    const responseStartTimestamp = this.responseStartTimestamp;
+    const outputInterruptible =
+      responseStartTimestamp !== null &&
+      (this.responseActive || this.markQueue.length > 0 || options?.audioPlaybackActive === true);
+    const shouldInterruptProvider = assistantItemId !== null && outputInterruptible;
+    const audioEndMs = shouldInterruptProvider
+      ? Math.max(
+          0,
+          responseStartTimestamp === null
+            ? this.latestMediaTimestamp
+            : this.latestMediaTimestamp - responseStartTimestamp,
+        )
+      : null;
+    if (this.responseActive && !this.responseCancelInFlight) {
+      this.sendEvent({ type: "response.cancel" }, "reason=barge-in");
+      this.responseCancelInFlight = true;
+    }
+    if (shouldInterruptProvider) {
+      this.sendEvent(
+        {
+          type: "conversation.item.truncate",
+          item_id: assistantItemId,
+          content_index: 0,
+          audio_end_ms: audioEndMs,
+        },
+        `reason=barge-in audioEndMs=${audioEndMs}`,
+      );
+      this.config.onClearAudio();
+      this.markQueue = [];
+      this.lastAssistantItemId = null;
+      this.responseStartTimestamp = null;
+      return;
+    }
+    this.config.onClearAudio();
+    this.markQueue = [];
+  }
+
+  private appendAssistantTranscriptDelta(delta: string): void {
+    if (this.assistantTranscriptFinalized) {
+      this.assistantTranscriptBuffer = "";
+      this.assistantTranscriptFinalized = false;
+    }
+    this.assistantTranscriptBuffer += delta;
+    this.config.onTranscript?.("assistant", delta, false);
+  }
+
+  private flushAssistantTranscript(finalTranscript?: string): void {
+    if (this.assistantTranscriptFinalized) {
+      return;
+    }
+    const transcript = finalTranscript || this.assistantTranscriptBuffer;
+    if (transcript) {
+      this.config.onTranscript?.("assistant", transcript, true);
+      this.assistantTranscriptFinalized = true;
+    }
+    this.assistantTranscriptBuffer = "";
+  }
+
+  private resetAssistantTranscript(): void {
+    this.assistantTranscriptBuffer = "";
+    this.assistantTranscriptFinalized = false;
+  }
+
+  private async doConnect(): Promise<void> {
+    const apiKey = this.config.resolveApiKey
+      ? await this.config.resolveApiKey()
+      : await resolveXaiRealtimeApiKey(this.config.apiKey, this.config.cfg);
+    const model = this.config.model ?? XaiRealtimeVoiceBridge.DEFAULT_MODEL;
+    const url = toXaiRealtimeWsUrl(this.config.baseUrl, model, this.conversationId ?? undefined);
+    const headers = {
+      Authorization: `Bearer ${apiKey}`,
+      ...xaiUserAgentHeaderFor(this.config.baseUrl),
+    };
+
+    await new Promise<void>((resolve, reject) => {
+      let settled = false;
+      let startupFailureClosing = false;
+      const settleResolve = () => {
+        if (settled) {
+          return;
+        }
+        settled = true;
+        clearTimeout(connectTimeout);
+        resolve();
+      };
+      const settleReject = (error: Error) => {
+        if (settled) {
+          return;
+        }
+        settled = true;
+        clearTimeout(connectTimeout);
+        reject(error);
+      };
+      const connectTimeout: ReturnType<typeof setTimeout> = setTimeout(() => {
+        if (!this.sessionConfigured && !this.intentionallyClosed) {
+          startupFailureClosing = true;
+          this.ws?.terminate();
+          settleReject(new Error("xAI realtime voice connection timeout"));
+        }
+      }, XAI_REALTIME_CONNECT_TIMEOUT_MS);
+
+      if (this.intentionallyClosed) {
+        settleResolve();
+        return;
+      }
+
+      this.connectionUrl = url;
+      const debugProxy = resolveDebugProxySettings();
+      const proxyAgent = createDebugProxyWebSocketAgent(debugProxy);
+      const ws = new WebSocket(url, {
+        headers,
+        ...(proxyAgent ? { agent: proxyAgent } : {}),
+      });
+      this.ws = ws;
+
+      const rejectStartup = (error: Error) => {
+        startupFailureClosing = true;
+        settleReject(error);
+        if (ws.readyState !== WebSocket.CLOSED) {
+          ws.close(1000, "startup failed");
+        }
+      };
+
+      ws.on("open", () => {
+        this.resetRealtimeSessionState();
+        this.connected = true;
+        this.sessionConfigured = false;
+        captureWsEvent({
+          url,
+          direction: "local",
+          kind: "ws-open",
+          flowId: this.flowId,
+          meta: {
+            provider: "xai",
+            capability: "realtime-voice",
+          },
+        });
+        this.sendSessionUpdate();
+      });
+
+      ws.on("message", (data: Buffer) => {
+        if (settled && !this.sessionConfigured) {
+          return;
+        }
+        captureWsEvent({
+          url,
+          direction: "inbound",
+          kind: "ws-frame",
+          flowId: this.flowId,
+          payload: data,
+          meta: {
+            provider: "xai",
+            capability: "realtime-voice",
+          },
+        });
+        try {
+          const event = JSON.parse(data.toString()) as RealtimeEvent;
+          if (event.type === "error" && !this.sessionConfigured) {
+            rejectStartup(new Error(readRealtimeErrorDetail(event.error)));
+            return;
+          }
+          this.handleEvent(event);
+          if (event.type === "session.updated") {
+            settleResolve();
+          }
+        } catch (error) {
+          console.error("[xai] realtime event parse failed:", error);
+        }
+      });
+
+      ws.on("error", (error) => {
+        captureWsEvent({
+          url,
+          direction: "local",
+          kind: "error",
+          flowId: this.flowId,
+          errorText: error instanceof Error ? error.message : String(error),
+          meta: {
+            provider: "xai",
+            capability: "realtime-voice",
+          },
+        });
+        if (!this.sessionConfigured) {
+          rejectStartup(error instanceof Error ? error : new Error(String(error)));
+          return;
+        }
+        this.config.onError?.(error instanceof Error ? error : new Error(String(error)));
+      });
+
+      ws.on("close", (code, reasonBuffer) => {
+        captureWsEvent({
+          url,
+          direction: "local",
+          kind: "ws-close",
+          flowId: this.flowId,
+          closeCode: typeof code === "number" ? code : undefined,
+          meta: {
+            provider: "xai",
+            capability: "realtime-voice",
+            reason:
+              Buffer.isBuffer(reasonBuffer) && reasonBuffer.length > 0
+                ? reasonBuffer.toString("utf8")
+                : undefined,
+          },
+        });
+        if (startupFailureClosing) {
+          if (this.ws === ws) {
+            this.connected = false;
+            this.sessionConfigured = false;
+          }
+          return;
+        }
+        const wasSessionConfigured = this.sessionConfigured;
+        this.connected = false;
+        this.sessionConfigured = false;
+        if (this.intentionallyClosed) {
+          settleResolve();
+          this.config.onClose?.("completed");
+          return;
+        }
+        if (!wasSessionConfigured && !settled) {
+          settleReject(new Error("xAI realtime voice connection closed before ready"));
+          return;
+        }
+        void this.attemptReconnect("websocket-close");
+      });
+    });
+  }
+
+  private async attemptReconnect(reason: string): Promise<void> {
+    if (this.intentionallyClosed) {
+      return;
+    }
+    if (!this.conversationId) {
+      this.config.onEvent?.({
+        direction: "client",
+        type: "session.reconnect.blocked",
+        detail: `reason=${reason} missingConversationId=true`,
+      });
+      this.config.onClose?.("error");
+      return;
+    }
+    if (this.reconnectAttempts >= XAI_REALTIME_MAX_RECONNECT_ATTEMPTS) {
+      this.config.onEvent?.({
+        direction: "client",
+        type: "session.reconnect.exhausted",
+        detail: `reason=${reason} attempts=${this.reconnectAttempts}`,
+      });
+      this.config.onClose?.("error");
+      return;
+    }
+    this.reconnectAttempts += 1;
+    const attempt = this.reconnectAttempts;
+    const delay = XAI_REALTIME_BASE_RECONNECT_DELAY_MS * 2 ** (attempt - 1);
+    this.config.onEvent?.({
+      direction: "client",
+      type: "session.reconnect.scheduled",
+      detail: `reason=${reason} attempt=${attempt} delayMs=${delay}`,
+    });
+    await new Promise((resolve) => {
+      setTimeout(resolve, delay);
+    });
+    if (this.intentionallyClosed) {
+      return;
+    }
+    try {
+      await this.doConnect();
+      this.config.onEvent?.({
+        direction: "client",
+        type: "session.reconnect.ready",
+        detail: `reason=${reason} attempt=${attempt}`,
+      });
+    } catch (error) {
+      this.config.onError?.(error instanceof Error ? error : new Error(String(error)));
+      await this.attemptReconnect(reason);
+    }
+  }
+
+  private sendSessionUpdate(): void {
+    this.sendEvent(this.buildSessionUpdate());
+  }
+
+  private buildSessionUpdate(): XaiRealtimeSessionUpdate {
+    const cfg = this.config;
+    const autoRespondToAudio = cfg.autoRespondToAudio ?? true;
+    const interruptResponseOnInputAudio = cfg.interruptResponseOnInputAudio ?? autoRespondToAudio;
+    const voice = cfg.voice ?? "eve";
+    return {
+      type: "session.update",
+      session: {
+        instructions: cfg.instructions,
+        voice,
+        output_modalities: ["audio"],
+        turn_detection: {
+          type: "server_vad",
+          threshold: cfg.vadThreshold ?? XAI_REALTIME_DEFAULT_VAD_THRESHOLD,
+          prefix_padding_ms: cfg.prefixPaddingMs ?? XAI_REALTIME_DEFAULT_PREFIX_PADDING_MS,
+          silence_duration_ms: cfg.silenceDurationMs ?? XAI_REALTIME_DEFAULT_SILENCE_DURATION_MS,
+          create_response: autoRespondToAudio,
+          interrupt_response: interruptResponseOnInputAudio,
+        },
+        audio: {
+          input: {
+            format: this.resolveRealtimeAudioFormat(),
+            transcription: { model: XAI_REALTIME_INPUT_TRANSCRIPTION_MODEL },
+          },
+          output: {
+            format: this.resolveRealtimeAudioFormat(),
+          },
+        },
+        resumption: { enabled: true },
+        ...(cfg.reasoningEffort ? { reasoning: { effort: cfg.reasoningEffort } } : {}),
+        ...(cfg.tools && cfg.tools.length > 0
+          ? {
+              tools: cfg.tools,
+              tool_choice: "auto",
+            }
+          : {}),
+      },
+    };
+  }
+
+  private resolveRealtimeAudioFormat(): XaiRealtimeAudioFormatConfig {
+    return this.audioFormat.encoding === "pcm16"
+      ? { type: "audio/pcm", rate: 24000 }
+      : { type: "audio/pcmu" };
+  }
+
+  private handleEvent(event: RealtimeEvent): void {
+    const emitServerEvent = () =>
+      this.config.onEvent?.({
+        direction: "server",
+        type: event.type,
+        detail: this.describeServerEvent(event),
+        ...(event.item_id ? { itemId: event.item_id } : {}),
+        ...((event.response_id ?? event.response?.id)
+          ? { responseId: event.response_id ?? event.response?.id }
+          : {}),
+      });
+    emitServerEvent();
+    switch (event.type) {
+      case "session.created":
+        return;
+
+      case "conversation.created": {
+        const conversationId = normalizeOptionalString(event.conversation?.id);
+        if (conversationId) {
+          this.conversationId = conversationId;
+        }
+        return;
+      }
+
+      case "session.updated":
+        this.sessionConfigured = true;
+        this.reconnectAttempts = 0;
+        for (const chunk of this.pendingAudio.splice(0)) {
+          this.sendAudio(chunk);
+        }
+        if (!this.sessionReadyFired) {
+          this.sessionReadyFired = true;
+          this.config.onReady?.();
+        }
+        return;
+
+      case "response.created":
+        this.responseActive = true;
+        this.responseCreateInFlight = false;
+        this.markQueue = [];
+        this.lastAssistantItemId = null;
+        this.responseStartTimestamp = null;
+        this.resetAssistantTranscript();
+        return;
+
+      case "conversation.output_audio.delta":
+      case "response.audio.delta":
+      case "response.output_audio.delta": {
+        const audioDelta = event.delta ?? event.data;
+        if (!audioDelta) {
+          return;
+        }
+        const audio = base64ToBuffer(audioDelta);
+        this.config.onAudio(audio);
+        if (event.item_id && event.item_id !== this.lastAssistantItemId) {
+          this.lastAssistantItemId = event.item_id;
+          this.responseStartTimestamp = this.latestMediaTimestamp;
+        } else if (this.responseStartTimestamp === null) {
+          this.responseStartTimestamp = this.latestMediaTimestamp;
+        }
+        this.responseActive = true;
+        this.sendMark();
+        return;
+      }
+
+      case "input_audio_buffer.speech_started":
+        if (this.config.interruptResponseOnInputAudio ?? this.config.autoRespondToAudio ?? true) {
+          this.handleBargeIn();
+        }
+        return;
+
+      case "conversation.output_transcript.delta":
+      case "response.output_text.delta":
+      case "response.audio_transcript.delta":
+      case "response.output_audio_transcript.delta":
+        if (event.delta) {
+          this.appendAssistantTranscriptDelta(event.delta);
+        }
+        return;
+
+      case "response.output_text.done":
+      case "response.audio_transcript.done":
+      case "response.output_audio_transcript.done":
+        this.flushAssistantTranscript(event.transcript ?? event.text);
+        return;
+
+      case "conversation.input_transcript.delta":
+      case "conversation.item.input_audio_transcription.delta":
+        if (event.delta) {
+          this.config.onTranscript?.("user", event.delta, false);
+        }
+        return;
+
+      case "conversation.item.input_audio_transcription.updated":
+        if (event.transcript) {
+          this.inputTranscriptReplacements.set(this.inputTranscriptKey(event), event.transcript);
+        }
+        return;
+
+      case "conversation.item.input_audio_transcription.completed":
+        {
+          const key = this.inputTranscriptKey(event);
+          const transcript = event.transcript ?? this.inputTranscriptReplacements.get(key);
+          this.inputTranscriptReplacements.delete(key);
+          if (transcript) {
+            this.config.onTranscript?.("user", transcript, true);
+          }
+        }
+        return;
+
+      case "response.cancelled":
+        this.resetAssistantTranscript();
+        this.responseActive = false;
+        this.responseCreateInFlight = false;
+        this.responseCancelInFlight = false;
+        this.flushPendingResponseCreate();
+        return;
+
+      case "response.done":
+        this.flushAssistantTranscript();
+        this.responseActive = false;
+        this.responseCreateInFlight = false;
+        this.responseCancelInFlight = false;
+        this.flushPendingResponseCreate();
+        return;
+
+      case "response.function_call_arguments.delta": {
+        const key = event.item_id ?? "unknown";
+        const existing = this.toolCallBuffers.get(key);
+        if (existing && event.delta) {
+          existing.args += event.delta;
+        } else if (event.item_id) {
+          this.toolCallBuffers.set(event.item_id, {
+            name: event.name ?? "",
+            callId: event.call_id ?? "",
+            args: event.delta ?? "",
+          });
+        }
+        return;
+      }
+
+      case "response.function_call_arguments.done": {
+        const key = event.item_id ?? "unknown";
+        const buffered = this.toolCallBuffers.get(key);
+        this.emitToolCallOnce({
+          itemId: event.item_id,
+          callId: buffered?.callId || event.call_id,
+          name: buffered?.name || event.name,
+          rawArgs: buffered?.args || event.arguments,
+        });
+        this.toolCallBuffers.delete(key);
+        return;
+      }
+
+      case "conversation.item.done": {
+        if (event.item?.type !== "function_call") {
+          return;
+        }
+        this.emitToolCallOnce({
+          itemId: event.item.id ?? event.item_id,
+          callId: event.item.call_id ?? event.call_id ?? event.item.id ?? event.item_id,
+          name: event.item.name ?? event.name,
+          rawArgs: event.item.arguments ?? event.arguments,
+        });
+        return;
+      }
+
+      case "error": {
+        const detail = readRealtimeErrorDetail(event.error);
+        if (detail.startsWith(XAI_REALTIME_ACTIVE_RESPONSE_ERROR_PREFIX)) {
+          this.responseActive = true;
+          this.responseCreateInFlight = false;
+          this.responseCreatePending = true;
+          return;
+        }
+        if (detail === XAI_REALTIME_NO_ACTIVE_RESPONSE_CANCEL_ERROR) {
+          this.responseActive = false;
+          this.responseCancelInFlight = false;
+          this.flushPendingResponseCreate();
+          return;
+        }
+        this.config.onError?.(new Error(detail));
+      }
+
+      default:
+    }
+  }
+
+  private emitToolCallOnce(fields: {
+    itemId?: string;
+    callId?: string;
+    name?: string;
+    rawArgs?: string;
+  }): void {
+    if (!this.config.onToolCall) {
+      return;
+    }
+    const itemId = fields.itemId || fields.callId || "unknown";
+    const callId = fields.callId || itemId;
+    const name = fields.name || "";
+    const dedupeKey = fields.itemId || fields.callId || `${name}:${fields.rawArgs ?? ""}`;
+    if (this.deliveredToolCallKeys.has(dedupeKey)) {
+      return;
+    }
+    this.deliveredToolCallKeys.add(dedupeKey);
+    this.pendingToolCallIds.add(callId);
+    let args: unknown = {};
+    try {
+      args = JSON.parse(fields.rawArgs || "{}");
+    } catch {}
+    this.config.onToolCall({
+      itemId,
+      callId,
+      name,
+      args,
+    });
+  }
+
+  private flushPendingResponseCreateAfterToolResults(): void {
+    if (this.pendingToolCallIds.size > 0 || this.continuingToolCallIds.size > 0) {
+      this.responseCreatePending = true;
+      return;
+    }
+    this.requestResponseCreate();
+  }
+
+  private requestResponseCreate(): void {
+    if (
+      this.responseActive ||
+      this.responseCreateInFlight ||
+      this.responseCancelInFlight ||
+      this.continuingToolCallIds.size > 0 ||
+      this.pendingToolCallIds.size > 0
+    ) {
+      this.responseCreatePending = true;
+      return;
+    }
+    this.responseCreatePending = false;
+    this.responseCreateInFlight = true;
+    this.sendEvent({ type: "response.create" });
+  }
+
+  private flushPendingResponseCreate(): void {
+    if (!this.responseCreatePending) {
+      return;
+    }
+    this.responseCreatePending = false;
+    this.requestResponseCreate();
+  }
+
+  private resetRealtimeSessionState(): void {
+    this.markQueue = [];
+    this.responseStartTimestamp = null;
+    this.responseActive = false;
+    this.responseCreateInFlight = false;
+    this.responseCancelInFlight = false;
+    this.responseCreatePending = false;
+    this.continuingToolCallIds.clear();
+    this.pendingToolCallIds.clear();
+    this.lastAssistantItemId = null;
+    this.inputTranscriptReplacements.clear();
+    this.toolCallBuffers.clear();
+    this.deliveredToolCallKeys.clear();
+  }
+
+  private inputTranscriptKey(event: RealtimeEvent): string {
+    return event.item_id ?? event.response_id ?? "default";
+  }
+
+  private sendMark(): void {
+    const markName = `audio-${Date.now()}`;
+    this.markQueue.push(markName);
+    this.config.onMark?.(markName);
+  }
+
+  private sendEvent(event: unknown, detail?: string): void {
+    if (this.ws?.readyState === WebSocket.OPEN) {
+      const type =
+        event && typeof event === "object" && typeof (event as { type?: unknown }).type === "string"
+          ? (event as { type: string }).type
+          : "unknown";
+      this.config.onEvent?.({ direction: "client", type, ...(detail ? { detail } : {}) });
+      const payload = JSON.stringify(event);
+      captureWsEvent({
+        url: this.connectionUrl,
+        direction: "outbound",
+        kind: "ws-frame",
+        flowId: this.flowId,
+        payload,
+        meta: {
+          provider: "xai",
+          capability: "realtime-voice",
+        },
+      });
+      this.ws.send(payload);
+    }
+  }
+
+  private describeServerEvent(event: RealtimeEvent): string | undefined {
+    if (event.type === "error") {
+      return readRealtimeErrorDetail(event.error);
+    }
+    if (event.type === "response.done") {
+      const status = event.response?.status;
+      const details =
+        event.response?.status_details === undefined
+          ? undefined
+          : JSON.stringify(event.response.status_details);
+      return (
+        [status ? `status=${status}` : undefined, details].filter(Boolean).join(" ") || undefined
+      );
+    }
+    if (event.type === "response.cancelled") {
+      return "cancelled";
+    }
+    if (event.type === "conversation.item.done" && event.item?.type) {
+      return [event.item.type, event.item.name ? `name=${event.item.name}` : undefined]
+        .filter(Boolean)
+        .join(" ");
+    }
+    return undefined;
+  }
+}
+
+export function buildXaiRealtimeVoiceProvider(): RealtimeVoiceProviderPlugin {
+  return {
+    id: "xai",
+    label: "xAI Grok Voice",
+    aliases: ["xai-realtime-voice", "grok-voice"],
+    defaultModel: XAI_REALTIME_DEFAULT_MODEL,
+    autoSelectOrder: 25,
+    capabilities: {
+      transports: ["gateway-relay"],
+      inputAudioFormats: [
+        REALTIME_VOICE_AUDIO_FORMAT_G711_ULAW_8KHZ,
+        REALTIME_VOICE_AUDIO_FORMAT_PCM16_24KHZ,
+      ],
+      outputAudioFormats: [
+        REALTIME_VOICE_AUDIO_FORMAT_G711_ULAW_8KHZ,
+        REALTIME_VOICE_AUDIO_FORMAT_PCM16_24KHZ,
+      ],
+      supportsBargeIn: true,
+      supportsToolCalls: true,
+    },
+    resolveConfig: ({ rawConfig }) => normalizeProviderConfig(rawConfig),
+    isConfigured: ({ providerConfig, cfg }) =>
+      hasXaiRealtimeApiKeyInput(normalizeProviderConfig(providerConfig).apiKey, cfg),
+    createBridge: (req) => {
+      const config = normalizeProviderConfig(req.providerConfig);
+      return new XaiRealtimeVoiceBridge({
+        ...req,
+        apiKey: config.apiKey,
+        baseUrl: normalizeXaiRealtimeBaseUrl(config.baseUrl),
+        model: config.model,
+        voice: config.voice,
+        vadThreshold: config.vadThreshold,
+        silenceDurationMs: config.silenceDurationMs,
+        prefixPaddingMs: config.prefixPaddingMs,
+        interruptResponseOnInputAudio:
+          req.interruptResponseOnInputAudio ?? config.interruptResponseOnInputAudio,
+        reasoningEffort: config.reasoningEffort,
+        resolveApiKey: () => resolveXaiRealtimeApiKey(config.apiKey, req.cfg),
+      });
+    },
+  };
+}

--- a/extensions/xai/realtime-voice-provider.ts
+++ b/extensions/xai/realtime-voice-provider.ts
@@ -508,7 +508,7 @@ class XaiRealtimeVoiceBridge implements RealtimeVoiceBridge {
       };
 
       ws.on("open", () => {
-        this.resetRealtimeSessionState();
+        this.resetRealtimeSessionState({ preserveToolCallState: this.conversationId !== null });
         this.connected = true;
         this.sessionConfigured = false;
         captureWsEvent({
@@ -962,19 +962,21 @@ class XaiRealtimeVoiceBridge implements RealtimeVoiceBridge {
     this.requestResponseCreate();
   }
 
-  private resetRealtimeSessionState(): void {
+  private resetRealtimeSessionState(options: { preserveToolCallState?: boolean } = {}): void {
     this.markQueue = [];
     this.responseStartTimestamp = null;
     this.responseActive = false;
     this.responseCreateInFlight = false;
     this.responseCancelInFlight = false;
     this.responseCreatePending = false;
-    this.continuingToolCallIds.clear();
-    this.pendingToolCallIds.clear();
     this.lastAssistantItemId = null;
     this.inputTranscriptReplacements.clear();
-    this.toolCallBuffers.clear();
-    this.deliveredToolCallKeys.clear();
+    if (!options.preserveToolCallState) {
+      this.continuingToolCallIds.clear();
+      this.pendingToolCallIds.clear();
+      this.toolCallBuffers.clear();
+      this.deliveredToolCallKeys.clear();
+    }
   }
 
   private inputTranscriptKey(event: RealtimeEvent): string {

--- a/extensions/xai/realtime-voice-provider.ts
+++ b/extensions/xai/realtime-voice-provider.ts
@@ -45,6 +45,7 @@ type XaiRealtimeVoiceProviderConfig = {
   prefixPaddingMs?: number;
   interruptResponseOnInputAudio?: boolean;
   reasoningEffort?: string;
+  sessionResumption?: boolean;
 };
 
 type XaiRealtimeVoiceBridgeConfig = RealtimeVoiceBridgeCreateRequest & {
@@ -57,6 +58,7 @@ type XaiRealtimeVoiceBridgeConfig = RealtimeVoiceBridgeCreateRequest & {
   prefixPaddingMs?: number;
   interruptResponseOnInputAudio?: boolean;
   reasoningEffort?: string;
+  sessionResumption?: boolean;
   resolveApiKey?: () => Promise<string>;
 };
 
@@ -134,6 +136,7 @@ const XAI_REALTIME_DEFAULT_MODEL = "grok-voice-latest";
 const XAI_REALTIME_CONNECT_TIMEOUT_MS = 10_000;
 const XAI_REALTIME_MAX_RECONNECT_ATTEMPTS = 5;
 const XAI_REALTIME_BASE_RECONNECT_DELAY_MS = 1000;
+const XAI_REALTIME_MAX_PENDING_TOOL_RESULTS = 128;
 const XAI_REALTIME_DEFAULT_VAD_THRESHOLD = 0.85;
 const XAI_REALTIME_DEFAULT_PREFIX_PADDING_MS = 333;
 const XAI_REALTIME_DEFAULT_SILENCE_DURATION_MS = 500;
@@ -202,6 +205,7 @@ function normalizeProviderConfig(
     prefixPaddingMs: asNonNegativeInteger(raw.prefixPaddingMs),
     interruptResponseOnInputAudio: readBoolean(raw.interruptResponseOnInputAudio),
     reasoningEffort: normalizeOptionalString(raw.reasoningEffort),
+    sessionResumption: readBoolean(raw.sessionResumption),
   };
 }
 
@@ -269,6 +273,11 @@ class XaiRealtimeVoiceBridge implements RealtimeVoiceBridge {
   private intentionallyClosed = false;
   private reconnectAttempts = 0;
   private pendingAudio: Buffer[] = [];
+  private pendingToolResults: Array<{
+    callId: string;
+    result: unknown;
+    options?: RealtimeVoiceToolResultOptions;
+  }> = [];
   private markQueue: string[] = [];
   private responseStartTimestamp: number | null = null;
   private responseActive = false;
@@ -337,6 +346,24 @@ class XaiRealtimeVoiceBridge implements RealtimeVoiceBridge {
   }
 
   submitToolResult(
+    callId: string,
+    result: unknown,
+    options?: RealtimeVoiceToolResultOptions,
+  ): void {
+    if (!this.canSubmitToolResult()) {
+      if (this.pendingToolResults.length < XAI_REALTIME_MAX_PENDING_TOOL_RESULTS) {
+        this.pendingToolResults.push({ callId, result, ...(options ? { options } : {}) });
+      } else {
+        this.config.onError?.(
+          new Error("xAI realtime voice pending tool result queue overflow during reconnect"),
+        );
+      }
+      return;
+    }
+    this.submitToolResultNow(callId, result, options);
+  }
+
+  private submitToolResultNow(
     callId: string,
     result: unknown,
     options?: RealtimeVoiceToolResultOptions,
@@ -452,7 +479,11 @@ class XaiRealtimeVoiceBridge implements RealtimeVoiceBridge {
       ? await this.config.resolveApiKey()
       : await resolveXaiRealtimeApiKey(this.config.apiKey, this.config.cfg);
     const model = this.config.model ?? XaiRealtimeVoiceBridge.DEFAULT_MODEL;
-    const url = toXaiRealtimeWsUrl(this.config.baseUrl, model, this.conversationId ?? undefined);
+    const url = toXaiRealtimeWsUrl(
+      this.config.baseUrl,
+      model,
+      this.config.sessionResumption === true ? this.conversationId ?? undefined : undefined,
+    );
     const headers = {
       Authorization: `Bearer ${apiKey}`,
       ...xaiUserAgentHeaderFor(this.config.baseUrl),
@@ -508,7 +539,10 @@ class XaiRealtimeVoiceBridge implements RealtimeVoiceBridge {
       };
 
       ws.on("open", () => {
-        this.resetRealtimeSessionState({ preserveToolCallState: this.conversationId !== null });
+        this.resetRealtimeSessionState({
+          preserveToolCallState:
+            this.config.sessionResumption === true && this.conversationId !== null,
+        });
         this.connected = true;
         this.sessionConfigured = false;
         captureWsEvent({
@@ -617,6 +651,15 @@ class XaiRealtimeVoiceBridge implements RealtimeVoiceBridge {
     if (this.intentionallyClosed) {
       return;
     }
+    if (this.config.sessionResumption !== true) {
+      this.config.onEvent?.({
+        direction: "client",
+        type: "session.reconnect.blocked",
+        detail: `reason=${reason} sessionResumption=false`,
+      });
+      this.config.onClose?.("error");
+      return;
+    }
     if (!this.conversationId) {
       this.config.onEvent?.({
         direction: "client",
@@ -694,7 +737,7 @@ class XaiRealtimeVoiceBridge implements RealtimeVoiceBridge {
             format: this.resolveRealtimeAudioFormat(),
           },
         },
-        resumption: { enabled: true },
+        ...(cfg.sessionResumption === true ? { resumption: { enabled: true } } : {}),
         ...(cfg.reasoningEffort ? { reasoning: { effort: cfg.reasoningEffort } } : {}),
         ...(cfg.tools && cfg.tools.length > 0
           ? {
@@ -741,6 +784,13 @@ class XaiRealtimeVoiceBridge implements RealtimeVoiceBridge {
         this.reconnectAttempts = 0;
         for (const chunk of this.pendingAudio.splice(0)) {
           this.sendAudio(chunk);
+        }
+        for (const pendingToolResult of this.pendingToolResults.splice(0)) {
+          this.submitToolResultNow(
+            pendingToolResult.callId,
+            pendingToolResult.result,
+            pendingToolResult.options,
+          );
         }
         if (!this.sessionReadyFired) {
           this.sessionReadyFired = true;
@@ -990,7 +1040,8 @@ class XaiRealtimeVoiceBridge implements RealtimeVoiceBridge {
   }
 
   private sendEvent(event: unknown, detail?: string): void {
-    if (this.ws?.readyState === WebSocket.OPEN) {
+    const ws = this.ws;
+    if (ws?.readyState === WebSocket.OPEN) {
       const type =
         event && typeof event === "object" && typeof (event as { type?: unknown }).type === "string"
           ? (event as { type: string }).type
@@ -1008,8 +1059,16 @@ class XaiRealtimeVoiceBridge implements RealtimeVoiceBridge {
           capability: "realtime-voice",
         },
       });
-      this.ws.send(payload);
+      ws.send(payload);
     }
+  }
+
+  private canSendEvent(): boolean {
+    return this.ws?.readyState === WebSocket.OPEN;
+  }
+
+  private canSubmitToolResult(): boolean {
+    return this.connected && this.sessionConfigured && this.canSendEvent();
   }
 
   private describeServerEvent(event: RealtimeEvent): string | undefined {
@@ -1075,6 +1134,7 @@ export function buildXaiRealtimeVoiceProvider(): RealtimeVoiceProviderPlugin {
         interruptResponseOnInputAudio:
           req.interruptResponseOnInputAudio ?? config.interruptResponseOnInputAudio,
         reasoningEffort: config.reasoningEffort,
+        sessionResumption: config.sessionResumption,
         resolveApiKey: () => resolveXaiRealtimeApiKey(config.apiKey, req.cfg),
       });
     },

--- a/extensions/xai/realtime-voice-provider.ts
+++ b/extensions/xai/realtime-voice-provider.ts
@@ -137,6 +137,7 @@ const XAI_REALTIME_CONNECT_TIMEOUT_MS = 10_000;
 const XAI_REALTIME_MAX_RECONNECT_ATTEMPTS = 5;
 const XAI_REALTIME_BASE_RECONNECT_DELAY_MS = 1000;
 const XAI_REALTIME_MAX_PENDING_TOOL_RESULTS = 128;
+const XAI_REALTIME_MAX_PENDING_USER_MESSAGES = 128;
 const XAI_REALTIME_DEFAULT_VAD_THRESHOLD = 0.85;
 const XAI_REALTIME_DEFAULT_PREFIX_PADDING_MS = 333;
 const XAI_REALTIME_DEFAULT_SILENCE_DURATION_MS = 500;
@@ -265,7 +266,7 @@ function hasXaiRealtimeApiKeyInput(
 
 class XaiRealtimeVoiceBridge implements RealtimeVoiceBridge {
   private static readonly DEFAULT_MODEL = XAI_REALTIME_DEFAULT_MODEL;
-  readonly supportsToolResultContinuation = true;
+  readonly supportsToolResultContinuation = false;
 
   private ws: WebSocket | null = null;
   private connected = false;
@@ -278,6 +279,7 @@ class XaiRealtimeVoiceBridge implements RealtimeVoiceBridge {
     result: unknown;
     options?: RealtimeVoiceToolResultOptions;
   }> = [];
+  private pendingUserMessages: string[] = [];
   private markQueue: string[] = [];
   private responseStartTimestamp: number | null = null;
   private responseActive = false;
@@ -327,6 +329,20 @@ class XaiRealtimeVoiceBridge implements RealtimeVoiceBridge {
   }
 
   sendUserMessage(text: string): void {
+    if (!this.canSubmitInput()) {
+      if (this.pendingUserMessages.length < XAI_REALTIME_MAX_PENDING_USER_MESSAGES) {
+        this.pendingUserMessages.push(text);
+      } else {
+        this.config.onError?.(
+          new Error("xAI realtime voice pending user message queue overflow during reconnect"),
+        );
+      }
+      return;
+    }
+    this.sendUserMessageNow(text);
+  }
+
+  private sendUserMessageNow(text: string): void {
     this.sendEvent({
       type: "conversation.item.create",
       item: {
@@ -368,6 +384,9 @@ class XaiRealtimeVoiceBridge implements RealtimeVoiceBridge {
     result: unknown,
     options?: RealtimeVoiceToolResultOptions,
   ): void {
+    if (options?.willContinue === true) {
+      return;
+    }
     this.sendEvent({
       type: "conversation.item.create",
       item: {
@@ -376,10 +395,6 @@ class XaiRealtimeVoiceBridge implements RealtimeVoiceBridge {
         output: JSON.stringify(result),
       },
     });
-    if (options?.willContinue === true) {
-      this.continuingToolCallIds.add(callId);
-      return;
-    }
     this.continuingToolCallIds.delete(callId);
     this.pendingToolCallIds.delete(callId);
     if (options?.suppressResponse === true) {
@@ -393,6 +408,9 @@ class XaiRealtimeVoiceBridge implements RealtimeVoiceBridge {
       return;
     }
     this.markQueue.shift();
+    if (this.markQueue.length === 0) {
+      this.flushPendingResponseCreate();
+    }
   }
 
   close(): void {
@@ -792,6 +810,9 @@ class XaiRealtimeVoiceBridge implements RealtimeVoiceBridge {
             pendingToolResult.options,
           );
         }
+        for (const pendingUserMessage of this.pendingUserMessages.splice(0)) {
+          this.sendUserMessageNow(pendingUserMessage);
+        }
         if (!this.sessionReadyFired) {
           this.sessionReadyFired = true;
           this.config.onReady?.();
@@ -993,6 +1014,7 @@ class XaiRealtimeVoiceBridge implements RealtimeVoiceBridge {
       this.responseActive ||
       this.responseCreateInFlight ||
       this.responseCancelInFlight ||
+      this.markQueue.length > 0 ||
       this.continuingToolCallIds.size > 0 ||
       this.pendingToolCallIds.size > 0
     ) {
@@ -1068,6 +1090,10 @@ class XaiRealtimeVoiceBridge implements RealtimeVoiceBridge {
   }
 
   private canSubmitToolResult(): boolean {
+    return this.connected && this.sessionConfigured && this.canSendEvent();
+  }
+
+  private canSubmitInput(): boolean {
     return this.connected && this.sessionConfigured && this.canSendEvent();
   }
 

--- a/extensions/xai/realtime-voice-provider.ts
+++ b/extensions/xai/realtime-voice-provider.ts
@@ -456,13 +456,13 @@ class XaiRealtimeVoiceBridge implements RealtimeVoiceBridge {
         },
         `reason=barge-in audioEndMs=${audioEndMs}`,
       );
-      this.config.onClearAudio();
+      this.config.onClearAudio("barge-in");
       this.markQueue = [];
       this.lastAssistantItemId = null;
       this.responseStartTimestamp = null;
       return;
     }
-    this.config.onClearAudio();
+    this.config.onClearAudio("barge-in");
     this.markQueue = [];
   }
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1813,13 +1813,13 @@ importers:
       typebox:
         specifier: 1.3.3
         version: 1.3.3
+      ws:
+        specifier: 8.21.0
+        version: 8.21.0
     devDependencies:
       '@openclaw/plugin-sdk':
         specifier: workspace:*
         version: link:../../packages/plugin-sdk
-      ws:
-        specifier: 8.21.0
-        version: 8.21.0
 
   extensions/xiaomi:
     devDependencies:

--- a/src/gateway/talk-realtime-relay.ts
+++ b/src/gateway/talk-realtime-relay.ts
@@ -25,6 +25,7 @@ import { recordTalkObservabilityEvent } from "../talk/observability.js";
 import {
   REALTIME_VOICE_AUDIO_FORMAT_PCM16_24KHZ,
   type RealtimeVoiceBrowserAudioContract,
+  type RealtimeVoiceAudioClearReason,
   type RealtimeVoiceProviderConfig,
   type RealtimeVoiceTool,
   type RealtimeVoiceToolResultOptions,
@@ -72,7 +73,7 @@ type TalkRealtimeRelayEventPayload =
       responseId?: string;
     }
   | { relaySessionId: string; type: "audioDone"; itemId?: string; responseId?: string }
-  | { relaySessionId: string; type: "clear" }
+  | { relaySessionId: string; type: "clear"; reason?: RealtimeVoiceAudioClearReason }
   | { relaySessionId: string; type: "mark"; markName: string }
   | {
       relaySessionId: string;
@@ -680,14 +681,14 @@ export function createTalkRealtimeRelaySession(
           },
         );
       },
-      clearAudio: () => {
+      clearAudio: (reason) => {
         const turnId = relayRef.current ? ensureRelayTurn(relayRef.current) : undefined;
         emit(
-          { relaySessionId, type: "clear" },
+          { relaySessionId, type: "clear", ...(reason ? { reason } : {}) },
           {
             type: "output.audio.done",
             turnId,
-            payload: { reason: "clear" },
+            payload: { reason: reason ?? "clear" },
             final: true,
           },
         );

--- a/ui/src/pages/chat/realtime-talk-gateway-relay.test.ts
+++ b/ui/src/pages/chat/realtime-talk-gateway-relay.test.ts
@@ -641,6 +641,113 @@ describe("GatewayRelayRealtimeTalkTransport", () => {
     transport.stop();
   });
 
+  it("releases delayed final tool results when playback is cleared normally", async () => {
+    vi.useFakeTimers();
+    const client = createClient();
+    vi.mocked(client["request"]).mockImplementation(async (method) => {
+      if (method === "talk.client.toolCall") {
+        return { runId: "run-1" };
+      }
+      return {};
+    });
+    const transport = new GatewayRelayRealtimeTalkTransport(createSession(), {
+      callbacks: {},
+      client,
+      sessionKey: "main",
+    });
+
+    await transport.start();
+    emitGatewayFrame({
+      event: "talk.event",
+      payload: {
+        relaySessionId: "relay-1",
+        type: "audio",
+        audioBase64: zeroPcmBase64(24000),
+      },
+    });
+    emitGatewayFrame({
+      event: "talk.event",
+      payload: {
+        relaySessionId: "relay-1",
+        type: "toolCall",
+        callId: "call-1",
+        name: REALTIME_VOICE_AGENT_CONSULT_TOOL_NAME,
+        args: { question: "status?" },
+      },
+    });
+    await vi.waitFor(() => expect(requestCallsFor(client, "talk.client.toolCall")).toHaveLength(1));
+    emitGatewayFrame({
+      event: "chat",
+      payload: { runId: "run-1", state: "final", message: { text: "ready" } },
+    });
+    await Promise.resolve();
+
+    emitGatewayFrame({
+      event: "talk.event",
+      payload: { relaySessionId: "relay-1", type: "clear" },
+    });
+
+    await vi.waitFor(() =>
+      expect(client["request"]).toHaveBeenCalledWith("talk.session.submitToolResult", {
+        sessionId: "relay-1",
+        callId: "call-1",
+        result: { result: "ready" },
+      }),
+    );
+    transport.stop();
+  });
+
+  it("drops delayed final tool results on provider barge-in clears", async () => {
+    vi.useFakeTimers();
+    const client = createClient();
+    vi.mocked(client["request"]).mockImplementation(async (method) => {
+      if (method === "talk.client.toolCall") {
+        return { runId: "run-1" };
+      }
+      return {};
+    });
+    const transport = new GatewayRelayRealtimeTalkTransport(createSession(), {
+      callbacks: {},
+      client,
+      sessionKey: "main",
+    });
+
+    await transport.start();
+    emitGatewayFrame({
+      event: "talk.event",
+      payload: {
+        relaySessionId: "relay-1",
+        type: "audio",
+        audioBase64: zeroPcmBase64(24000),
+      },
+    });
+    emitGatewayFrame({
+      event: "talk.event",
+      payload: {
+        relaySessionId: "relay-1",
+        type: "toolCall",
+        callId: "call-1",
+        name: REALTIME_VOICE_AGENT_CONSULT_TOOL_NAME,
+        args: { question: "status?" },
+      },
+    });
+    await vi.waitFor(() => expect(requestCallsFor(client, "talk.client.toolCall")).toHaveLength(1));
+    emitGatewayFrame({
+      event: "chat",
+      payload: { runId: "run-1", state: "final", message: { text: "ready" } },
+    });
+    await Promise.resolve();
+
+    emitGatewayFrame({
+      event: "talk.event",
+      payload: { relaySessionId: "relay-1", type: "clear", reason: "barge-in" },
+    });
+    await vi.advanceTimersByTimeAsync(2_000);
+
+    expect(requestCallsFor(client, "talk.session.submitToolResult")).toHaveLength(0);
+    transport.stop();
+  });
+
   it("does not start a forced consult when the working result is terminally cancelled", async () => {
     const client = createClient();
     vi.mocked(client["request"]).mockImplementation(async (method) => {

--- a/ui/src/pages/chat/realtime-talk-gateway-relay.test.ts
+++ b/ui/src/pages/chat/realtime-talk-gateway-relay.test.ts
@@ -114,6 +114,10 @@ function pumpMicrophone(samples: Float32Array): void {
   });
 }
 
+function zeroPcmBase64(sampleRate: number): string {
+  return "AAAA".repeat(sampleRate);
+}
+
 function requestCallsFor(
   client: RealtimeTalkTransportContext["client"],
   method: string,

--- a/ui/src/pages/chat/realtime-talk-gateway-relay.test.ts
+++ b/ui/src/pages/chat/realtime-talk-gateway-relay.test.ts
@@ -789,6 +789,69 @@ describe("GatewayRelayRealtimeTalkTransport", () => {
     transport.stop();
   });
 
+  it("drops delayed final tool results when barge-in cancels relay playback", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(0);
+    const client = createClient();
+    vi.mocked(client["request"]).mockImplementation(async (method) => {
+      if (method === "talk.client.toolCall") {
+        return { runId: "run-1" };
+      }
+      return {};
+    });
+    const transport = new GatewayRelayRealtimeTalkTransport(createSession(), {
+      callbacks: {},
+      client,
+      sessionKey: "main",
+    });
+    const speech = new Float32Array(4096).fill(0.25);
+
+    await transport.start();
+    emitGatewayFrame({
+      event: "talk.event",
+      payload: {
+        relaySessionId: "relay-1",
+        type: "audio",
+        audioBase64: zeroPcmBase64(24000),
+      },
+    });
+    emitGatewayFrame({
+      event: "talk.event",
+      payload: {
+        relaySessionId: "relay-1",
+        type: "toolCall",
+        callId: "call-1",
+        name: REALTIME_VOICE_AGENT_CONSULT_TOOL_NAME,
+        args: { question: "status?" },
+      },
+    });
+    await vi.waitFor(() => expect(requestCallsFor(client, "talk.client.toolCall")).toHaveLength(1));
+
+    emitGatewayFrame({
+      event: "chat",
+      payload: { runId: "run-1", state: "final", message: { text: "ready" } },
+    });
+    await Promise.resolve();
+    expect(requestCallsFor(client, "talk.session.submitToolResult")).toHaveLength(0);
+
+    pumpMicrophone(speech);
+    pumpMicrophone(speech);
+    pumpMicrophone(speech);
+    await vi.advanceTimersByTimeAsync(2000);
+
+    expect(requestCallsFor(client, "talk.session.cancelOutput")).toEqual([
+      [
+        "talk.session.cancelOutput",
+        {
+          sessionId: "relay-1",
+          reason: "barge-in",
+        },
+      ],
+    ]);
+    expect(requestCallsFor(client, "talk.session.submitToolResult")).toHaveLength(0);
+    transport.stop();
+  });
+
   it("treats server relay tool results as terminal for active consult calls", async () => {
     const client = createClient();
     vi.mocked(client["request"]).mockImplementation(async (method) => {

--- a/ui/src/pages/chat/realtime-talk-gateway-relay.ts
+++ b/ui/src/pages/chat/realtime-talk-gateway-relay.ts
@@ -45,6 +45,12 @@ type GatewayRelayEvent = {
   | { type?: "close"; reason?: string }
 );
 
+type DelayedToolResult = {
+  callId: string;
+  result: unknown;
+  options?: { suppressResponse?: boolean; willContinue?: boolean };
+  timer?: number;
+};
 const BARGE_IN_RMS_THRESHOLD = 0.02;
 const BARGE_IN_PEAK_THRESHOLD = 0.08;
 const BARGE_IN_CONSECUTIVE_SPEECH_FRAMES = 2;
@@ -404,7 +410,7 @@ export class GatewayRelayRealtimeTalkTransport implements RealtimeTalkTransport 
   }
 
   private flushDelayedToolResults(): void {
-    for (const pending of [...this.delayedToolResults]) {
+    for (const pending of this.delayedToolResults) {
       this.discardDelayedToolResult(pending);
       if (!this.closed) {
         void this.sendToolResultNow(pending.callId, pending.result, pending.options).catch(
@@ -417,7 +423,7 @@ export class GatewayRelayRealtimeTalkTransport implements RealtimeTalkTransport 
   }
 
   private discardDelayedToolResults(): void {
-    for (const pending of [...this.delayedToolResults]) {
+    for (const pending of this.delayedToolResults) {
       this.discardDelayedToolResult(pending);
     }
   }

--- a/ui/src/pages/chat/realtime-talk-gateway-relay.ts
+++ b/ui/src/pages/chat/realtime-talk-gateway-relay.ts
@@ -25,7 +25,7 @@ type GatewayRelayEvent = {
 } & (
   | { type?: "ready" }
   | { type?: "audio"; audioBase64?: string }
-  | { type?: "clear" }
+  | { type?: "clear"; reason?: "barge-in" }
   | { type?: "mark"; markName?: string }
   | {
       type?: "transcript";
@@ -62,6 +62,7 @@ export class GatewayRelayRealtimeTalkTransport implements RealtimeTalkTransport 
   private readonly consultAbortControllers = new Map<string, AbortController>();
   private readonly completedToolCalls = new Set<string>();
   private readonly submittingToolCalls = new Set<string>();
+  private readonly delayedToolResults = new Set<DelayedToolResult>();
   private cancelRequestedForPlayback = false;
   private speechFramesDuringPlayback = 0;
   private lastRelayError: string | undefined;
@@ -137,6 +138,7 @@ export class GatewayRelayRealtimeTalkTransport implements RealtimeTalkTransport 
     this.inputSource = null;
     this.inputMeter?.stop();
     this.inputMeter = null;
+    this.discardDelayedToolResults();
     this.abortConsults();
     this.media?.getTracks().forEach((track) => track.stop());
     this.media = null;
@@ -201,7 +203,12 @@ export class GatewayRelayRealtimeTalkTransport implements RealtimeTalkTransport 
         }
         return;
       case "clear":
-        this.stopOutput();
+        if (event.reason === "barge-in") {
+          this.discardDelayedToolResults();
+          this.stopOutput({ releaseDelayedToolResults: false });
+        } else {
+          this.stopOutput();
+        }
         if (event.talkEvent?.type === "turn.cancelled") {
           this.abortConsults();
         }
@@ -250,9 +257,12 @@ export class GatewayRelayRealtimeTalkTransport implements RealtimeTalkTransport 
     this.outputQueue.play(base64, this.outputContext, this.session.audio.outputSampleRateHz);
   }
 
-  private stopOutput(): void {
+  private stopOutput(options: { releaseDelayedToolResults?: boolean } = {}): void {
     this.outputQueue.stop(this.outputContext);
     this.speechFramesDuringPlayback = 0;
+    if (options.releaseDelayedToolResults ?? true) {
+      this.flushDelayedToolResults();
+    }
   }
 
   private scheduleMarkAck(): void {
@@ -329,6 +339,23 @@ export class GatewayRelayRealtimeTalkTransport implements RealtimeTalkTransport 
     result: unknown,
     options?: { suppressResponse?: boolean; willContinue?: boolean },
   ): Promise<void> {
+    if (this.closed || this.completedToolCalls.has(callId)) {
+      return;
+    }
+    const shouldAllowProviderResponse =
+      options?.suppressResponse !== true && options?.willContinue !== true;
+    if (shouldAllowProviderResponse && this.outputPlaybackDelayMs() > 0) {
+      this.scheduleDelayedToolResult({ callId, result, ...(options ? { options } : {}) });
+      return;
+    }
+    await this.sendToolResultNow(callId, result, options);
+  }
+
+  private async sendToolResultNow(
+    callId: string,
+    result: unknown,
+    options?: { suppressResponse?: boolean; willContinue?: boolean },
+  ): Promise<void> {
     if (this.completedToolCalls.has(callId)) {
       return;
     }
@@ -343,6 +370,64 @@ export class GatewayRelayRealtimeTalkTransport implements RealtimeTalkTransport 
     } finally {
       this.submittingToolCalls.delete(callId);
     }
+  }
+
+  private outputPlaybackDelayMs(): number {
+    if (!this.outputContext) {
+      return 0;
+    }
+    return Math.max(0, Math.ceil((this.outputQueue.queuedUntil - this.outputContext.currentTime) * 1000));
+  }
+
+  private scheduleDelayedToolResult(pending: DelayedToolResult): void {
+    this.delayedToolResults.add(pending);
+    this.rescheduleDelayedToolResult(pending);
+  }
+
+  private rescheduleDelayedToolResult(pending: DelayedToolResult): void {
+    if (this.closed) {
+      this.discardDelayedToolResult(pending);
+      return;
+    }
+    const playbackDelayMs = this.outputPlaybackDelayMs();
+    if (playbackDelayMs > 0) {
+      pending.timer = window.setTimeout(() => {
+        pending.timer = undefined;
+        this.rescheduleDelayedToolResult(pending);
+      }, playbackDelayMs);
+      return;
+    }
+    this.discardDelayedToolResult(pending);
+    void this.sendToolResultNow(pending.callId, pending.result, pending.options).catch((error: unknown) => {
+      this.reportToolResultSubmissionError(error);
+    });
+  }
+
+  private flushDelayedToolResults(): void {
+    for (const pending of [...this.delayedToolResults]) {
+      this.discardDelayedToolResult(pending);
+      if (!this.closed) {
+        void this.sendToolResultNow(pending.callId, pending.result, pending.options).catch(
+          (error: unknown) => {
+            this.reportToolResultSubmissionError(error);
+          },
+        );
+      }
+    }
+  }
+
+  private discardDelayedToolResults(): void {
+    for (const pending of [...this.delayedToolResults]) {
+      this.discardDelayedToolResult(pending);
+    }
+  }
+
+  private discardDelayedToolResult(pending: DelayedToolResult): void {
+    if (pending.timer !== undefined) {
+      window.clearTimeout(pending.timer);
+      pending.timer = undefined;
+    }
+    this.delayedToolResults.delete(pending);
   }
 
   private reportToolResultSubmissionError(error: unknown): void {
@@ -385,7 +470,8 @@ export class GatewayRelayRealtimeTalkTransport implements RealtimeTalkTransport 
       return;
     }
     this.cancelRequestedForPlayback = true;
-    this.stopOutput();
+    this.discardDelayedToolResults();
+    this.stopOutput({ releaseDelayedToolResults: false });
     void this.ctx.client.request("talk.session.cancelOutput", {
       sessionId: this.session.relaySessionId,
       reason: "barge-in",

--- a/ui/src/pages/chat/realtime-talk-gateway-relay.ts
+++ b/ui/src/pages/chat/realtime-talk-gateway-relay.ts
@@ -345,12 +345,12 @@ export class GatewayRelayRealtimeTalkTransport implements RealtimeTalkTransport 
     result: unknown,
     options?: { suppressResponse?: boolean; willContinue?: boolean },
   ): Promise<void> {
-    if (this.closed || this.completedToolCalls.has(callId)) {
+    if (this.completedToolCalls.has(callId)) {
       return;
     }
     const shouldAllowProviderResponse =
       options?.suppressResponse !== true && options?.willContinue !== true;
-    if (shouldAllowProviderResponse && this.outputPlaybackDelayMs() > 0) {
+    if (!this.closed && shouldAllowProviderResponse && this.outputPlaybackDelayMs() > 0) {
       this.scheduleDelayedToolResult({ callId, result, ...(options ? { options } : {}) });
       return;
     }
@@ -382,7 +382,10 @@ export class GatewayRelayRealtimeTalkTransport implements RealtimeTalkTransport 
     if (!this.outputContext) {
       return 0;
     }
-    return Math.max(0, Math.ceil((this.outputQueue.queuedUntil - this.outputContext.currentTime) * 1000));
+    return Math.max(
+      0,
+      Math.ceil((this.outputQueue.queuedUntil - this.outputContext.currentTime) * 1000),
+    );
   }
 
   private scheduleDelayedToolResult(pending: DelayedToolResult): void {
@@ -404,9 +407,11 @@ export class GatewayRelayRealtimeTalkTransport implements RealtimeTalkTransport 
       return;
     }
     this.discardDelayedToolResult(pending);
-    void this.sendToolResultNow(pending.callId, pending.result, pending.options).catch((error: unknown) => {
-      this.reportToolResultSubmissionError(error);
-    });
+    void this.sendToolResultNow(pending.callId, pending.result, pending.options).catch(
+      (error: unknown) => {
+        this.reportToolResultSubmissionError(error);
+      },
+    );
   }
 
   private flushDelayedToolResults(): void {

--- a/ui/src/pages/chat/realtime-talk.test.ts
+++ b/ui/src/pages/chat/realtime-talk.test.ts
@@ -157,6 +157,46 @@ describe("RealtimeTalkSession", () => {
     expect(webRtcCtor).not.toHaveBeenCalled();
   });
 
+  it("falls back to talk.session.create when gateway-relay is rejected by talk.client.create", async () => {
+    const request = vi
+      .fn()
+      .mockRejectedValueOnce(new Error("talk.client.create is client-owned; use talk.session.create"))
+      .mockResolvedValueOnce({
+        provider: "example",
+        transport: "gateway-relay",
+        relaySessionId: "relay-1",
+        audio: {
+          inputEncoding: "pcm16",
+          inputSampleRateHz: 24000,
+          outputEncoding: "pcm16",
+          outputSampleRateHz: 24000,
+        },
+      });
+    const session = new RealtimeTalkSession(
+      { request } as never,
+      "main",
+      {},
+      { provider: "xai", transport: "gateway-relay" },
+    );
+
+    await session.start();
+
+    expect(request).toHaveBeenNthCalledWith(1, "talk.client.create", {
+      sessionKey: "main",
+      provider: "xai",
+      transport: "gateway-relay",
+    });
+    expect(request).toHaveBeenNthCalledWith(2, "talk.session.create", {
+      sessionKey: "main",
+      provider: "xai",
+      transport: "gateway-relay",
+      mode: "realtime",
+      brain: "agent-consult",
+    });
+    expect(relayCtor).toHaveBeenCalledTimes(1);
+    expect(relayStart).toHaveBeenCalledTimes(1);
+  });
+
   it("starts the WebRTC transport for canonical WebRTC sessions", async () => {
     const request = vi.fn(async () => ({
       provider: "openai",

--- a/ui/src/pages/chat/realtime-talk.test.ts
+++ b/ui/src/pages/chat/realtime-talk.test.ts
@@ -160,7 +160,9 @@ describe("RealtimeTalkSession", () => {
   it("falls back to talk.session.create when gateway-relay is rejected by talk.client.create", async () => {
     const request = vi
       .fn()
-      .mockRejectedValueOnce(new Error("talk.client.create is client-owned; use talk.session.create"))
+      .mockRejectedValueOnce(
+        new Error("talk.client.create is client-owned; use talk.session.create"),
+      )
       .mockResolvedValueOnce({
         provider: "example",
         transport: "gateway-relay",


### PR DESCRIPTION
## What Problem This Solves

OpenClaw Talk already has a realtime provider contract and gateway-relay path, but the bundled xAI plugin did not expose Grok Voice Agent as a native realtime voice provider.

Without this, users who want xAI/Grok voice in OpenClaw either cannot use it through Talk or have to fall back to a lower-quality STT -> model -> TTS loop. That is especially limiting for long-running assistants where supplier choice and realtime voice cost matter.

Closes #99087.

## Why This Change Was Made

This adds one canonical bundled xAI realtime voice provider through the existing Talk `gateway-relay` contract instead of creating a separate voice stack.

The provider:

- connects to xAI realtime voice (`grok-voice-latest`) over WebSocket;
- registers through the existing `registerRealtimeVoiceProvider` seam;
- exposes the provider through the xAI plugin manifest;
- maps audio, transcript, tool-call, cancellation, reconnect, and close events into the existing Talk realtime bridge contract;
- keeps secrets out of docs and evidence.

The follow-up commits address the ClawSweeper/Codex review findings:

- interrupted assistant audio now sends `response.cancel` plus `conversation.item.truncate`;
- relay playback cancellation preserves the assistant item until truncation is possible;
- assistant transcript deltas are buffered so delta-only xAI completion still emits a final transcript;
- xAI `input_audio_transcription.updated` events are treated as cumulative replacements and emitted once on completion;
- provider-managed reconnects no longer replay initial `onReady`/greeting callbacks;
- startup WebSocket errors remain terminal instead of leaving background retry loops;
- reconnect continuity is now explicit opt-in through `sessionResumption`;
- default sessions do not send `session.resumption.enabled=true` and fail closed on disconnect instead of silently starting a fresh provider conversation.

Dependency note: `ws` is intentionally moved into the xAI runtime dependency set because the new provider imports it at runtime. The repository dependency guard correctly requires maintainer/security approval for the exact head SHA or a maintainer-owned regeneration path. This PR does not try to bypass that policy.

## User Impact

Users selecting xAI realtime Talk get native Grok voice replies through the existing OpenClaw Talk relay path rather than a synthetic STT/TTS loop.

Expected behavior:

- Talk can select `provider: "xai"` with `transport: "gateway-relay"`.
- Gateway-relay clients can stream mic audio and receive Grok voice audio.
- Barge-in cancels the active response and truncates only the currently interrupted assistant audio.
- Completed assistant audio and previous-turn assistant items are not truncated on later turns.
- Reconnect does not replay the initial greeting as a new user turn.
- Provider-side xAI session replay/resumption is disabled by default and only enabled when `sessionResumption: true` is configured.

This is intentionally scoped to the xAI realtime voice provider and Talk relay integration. It does not weaken gateway auth and does not include secrets or production token values.

## Evidence

Prior published validation head (superseded by the transcript checkpoint below):

```text
Base: origin/main @ 5f3629e944
Head: 60a8060608
```

Prior published proof retained for continuity:

```text
node scripts/run-vitest.mjs extensions/xai/realtime-voice-provider.test.ts
Result: passed, 1 file, 27 tests.

pnpm tsgo:prod
Result: passed.

pnpm check:test-types
Result: passed.

pnpm run test:extensions:package-boundary:compile
Result: passed, xai checked, extension package boundary check passed.

pnpm deps:shrinkwrap:check
Result: passed, all npm-shrinkwrap.json files current.

git diff --check origin/main...HEAD
Result: passed.

openclaw-autoreview --mode branch --base origin/main --engine codex --thinking high
Result: clean, no accepted/actionable findings. Overall: patch is correct (0.78).
```

Live Windows + WSL smoke proof already captured for the xAI gateway-relay voice path:

```text
Environment: Windows + WSL.
Direct xAI bridge: connected to grok-voice-latest, ready=true, received audio deltas.
Isolated Gateway smoke: ran on non-production port 18790 because daily Gateway used 18789.
Talk runtime: talkMode=realtime, talkTransport=gateway-relay, talkProvider=xai.
Observed log events: output.audio.done, transcript.done, turn.cancelled, tool.call, tool.result, session.closed.
Operator result: Grok realtime voice replied through OpenClaw Talk; after correcting local speaker feedback, voice interaction was fast and worked correctly.
```

Workflow note:

```text
For this branch I used the same review discipline we have been using on OpenClaw PRs: scoped local validation first, then openclaw-autoreview on the relevant diff/branch before publishing. Crabbox/Testbox remains the preferred broad proof surface for full CI-equivalent validation when available; it was not available in this local Windows pass, so the current-head proof above is focused local proof plus the existing live Windows+WSL smoke packet.
```

<!-- agent-transcript:start -->
## Agent Transcript

<details>
<summary>Sanitized worklog for PR #99088: xAI realtime voice provider</summary>

### Goal

Add xAI realtime voice through OpenClaw's existing realtime voice provider and gateway relay contracts, while preserving the expanded official xAI provider now present on upstream `main`.

### Continuity of work

This transcript is the latest checkpoint in a multi-day implementation and review effort, not a single-session change. Work on the PR was already active by July 3, 2026, when the branch had been rebased, provider tests were passing, and the external-contributor dependency gate was documented. Subsequent review rounds addressed barge-in truncation, assistant transcript buffering, reconnect behavior, delayed tool-result ownership, and relay cancellation. The July 10 pass rebased that accumulated work onto the official bundled xAI provider and re-proved the resulting integration.

### Decisions and implementation

- Verified that the official xAI provider still documents realtime voice as unavailable, so the PR remains a distinct feature rather than duplicate provider work.
- Rebased the scoped realtime voice commit stack onto current upstream `main`.
- Preserved current xAI model, media, transcription, OAuth, and provider documentation while adding only realtime voice registration and behavior.
- Kept the runtime WebSocket dependency owned by the xAI extension. This intentional dependency graph change remains subject to maintainer/security approval.
- Reconciled the gateway relay with current upstream barge-in semantics: provider-marked barge-in clears discard delayed tool results, while normal playback completion can still release them.
- Preserved cancellation delivery when an in-flight OpenClaw consult is aborted during relay shutdown.

### Failed-first proof and correction

- The first focused run failed because relay shutdown sent `chat.abort` and closed the session without submitting the synthetic cancellation result to the provider.
- The relay ownership path was corrected and the missing PCM test fixture was restored.
- The repeated focused suite passed: 107 tests across the xAI provider, registration, relay, and realtime talk files.
- `git diff --check` passed.
- Scoped Codex autoreview returned no accepted or actionable findings and classified the patch as correct with confidence 0.82.

### Remaining gate

- The public PR still points to the previous head and therefore has not run CI on the rebased commits.
- The public dependency guard remains expected until a maintainer/security reviewer authorizes the runtime dependency change.
- One public review thread remains open; the rebased local implementation contains the requested delayed-result barge-in correction, but the thread must not be resolved until the new head is pushed and checks are re-read.

No secrets, credentials, raw prompts, private paths, or raw tool output are included.

</details>
<!-- agent-transcript:end -->
