### PR TITLE
fix(message): thread --limit through to CLI formatter and surface provider pagination hints

### DIFF
--- a/src/commands/message-format.test.ts
+++ b/src/commands/message-format.test.ts
@@ -1,0 +1,191 @@
+// Tests for CLI message text formatting helpers (renderMessageList, formatMessageCliText).
+import { describe, expect, it } from "vitest";
+import { formatMessageCliText } from "./message-format.js";
+
+function readResultPayload(payload: unknown) {
+  return {
+    kind: "action" as const,
+    channel: "matrix" as const,
+    action: "read" as const,
+    handledBy: "plugin" as const,
+    payload,
+    dryRun: false,
+  };
+}
+
+function pinsResultPayload(payload: unknown) {
+  return {
+    kind: "action" as const,
+    channel: "matrix" as const,
+    action: "list-pins" as const,
+    handledBy: "plugin" as const,
+    payload,
+    dryRun: false,
+  };
+}
+
+function searchResultPayload(payload: unknown) {
+  return {
+    kind: "action" as const,
+    channel: "discord" as const,
+    action: "search" as const,
+    handledBy: "plugin" as const,
+    payload,
+    dryRun: false,
+  };
+}
+
+function msg(id: string, ts: string, authorTag: string, content: string) {
+  return { id, ts, authorTag, content };
+}
+
+function textJoined(lines: string[]): string {
+  return lines.join("\n");
+}
+
+describe("formatMessageCliText displayLimit", () => {
+  it("honors displayLimit for message read", () => {
+    const messages = Array.from({ length: 40 }, (_, i) =>
+      msg(`id-${i}`, `2026-01-01T00:00:0${i % 10}.000Z`, `user-${i}`, `text-${i}`),
+    );
+
+    const result = readResultPayload({ messages });
+    const out = textJoined(formatMessageCliText(result, { displayLimit: 15 }));
+
+    // Should include items within the limit
+    expect(out).toContain("text-0");
+    expect(out).toContain("text-14");
+    // Should NOT include items beyond the limit
+    expect(out).not.toContain("text-15");
+  });
+
+  it("honors displayLimit for list-pins", () => {
+    const pins = Array.from({ length: 40 }, (_, i) =>
+      msg(`pin-${i}`, `2026-01-01T00:00:0${i % 10}.000Z`, `user-${i}`, `pin-text-${i}`),
+    );
+
+    const result = pinsResultPayload({ pins });
+    const out = textJoined(formatMessageCliText(result, { displayLimit: 15 }));
+
+    expect(out).toContain("pin-text-0");
+    expect(out).toContain("pin-text-14");
+    expect(out).not.toContain("pin-text-15");
+  });
+
+  it("honors displayLimit for search", () => {
+    const messages = Array.from({ length: 40 }, (_, i) =>
+      msg(`id-${i}`, `2026-01-01T00:00:0${i % 10}.000Z`, `user-${i}`, `search-${i}`),
+    );
+    // Discord search returns messages as array-of-array
+    const wrapped = messages.map((m) => [m]);
+
+    const result = searchResultPayload({ results: { messages: wrapped } });
+    const out = textJoined(formatMessageCliText(result, { displayLimit: 15 }));
+
+    expect(out).toContain("search-0");
+    expect(out).toContain("search-14");
+    expect(out).not.toContain("search-15");
+  });
+
+  it("defaults to 25 when no displayLimit is provided", () => {
+    const messages = Array.from({ length: 50 }, (_, i) =>
+      msg(`id-${i}`, `2026-01-01T00:00:0${i % 10}.000Z`, `user-${i}`, `text-${i}`),
+    );
+
+    const result = readResultPayload({ messages });
+    const out = textJoined(formatMessageCliText(result));
+
+    expect(out).toContain("text-24");
+    expect(out).not.toContain("text-25");
+  });
+
+  it("renders all rows when total is below displayLimit", () => {
+    const messages = [
+      msg("id-1", "2026-01-01T00:00:00.000Z", "alice", "hello"),
+      msg("id-2", "2026-01-01T00:00:01.000Z", "bob", "world"),
+    ];
+
+    const result = readResultPayload({ messages });
+    const out = textJoined(formatMessageCliText(result, { displayLimit: 30 }));
+
+    expect(out).toContain("hello");
+    expect(out).toContain("world");
+  });
+});
+
+describe("renderPaginationHint", () => {
+  it("emits hint when payload has hasMore: true", () => {
+    const messages = [msg("id-1", "2026-01-01T00:00:00.000Z", "alice", "hello")];
+    const result = readResultPayload({ messages, hasMore: true });
+    const out = textJoined(formatMessageCliText(result, { displayLimit: 5 }));
+
+    expect(out).toContain("More results available");
+  });
+
+  it("emits hint when payload has nextBatch string", () => {
+    const messages = [msg("id-1", "2026-01-01T00:00:00.000Z", "alice", "hello")];
+    const result = readResultPayload({ messages, nextBatch: "token-123" });
+    const out = textJoined(formatMessageCliText(result, { displayLimit: 5 }));
+
+    expect(out).toContain("More results available");
+  });
+
+  it("emits hint when payload has @odata.nextLink string", () => {
+    const messages = [msg("id-1", "2026-01-01T00:00:00.000Z", "alice", "hello")];
+    const result = readResultPayload({
+      messages,
+      "@odata.nextLink": "https://graph.microsoft.com/v1.0/next",
+    });
+    const out = textJoined(formatMessageCliText(result, { displayLimit: 5 }));
+
+    expect(out).toContain("More results available");
+  });
+
+  it("emits hint when search results has hasMore without total_results", () => {
+    const messages = [msg("id-1", "2026-01-01T00:00:00.000Z", "alice", "hello")];
+    // hasMore: true inside results — Discord does not always include total_results.
+    const wrapped = messages.map((m) => [m]);
+    const result = searchResultPayload({
+      results: { messages: wrapped, hasMore: true },
+    });
+    const out = textJoined(formatMessageCliText(result, { displayLimit: 5 }));
+
+    expect(out).toContain("More results available");
+  });
+
+  it("emits hint when total_results exceeds returned count (Discord search)", () => {
+    const messages = [msg("id-1", "2026-01-01T00:00:00.000Z", "alice", "hello")];
+    // Discord search wraps messages and total_results inside a results object.
+    // total_results: 200 with 1 returned message → 199 more exist.
+    const wrapped = messages.map((m) => [m]);
+    const result = searchResultPayload({
+      results: { messages: wrapped, total_results: 200 },
+    });
+    const out = textJoined(formatMessageCliText(result, { displayLimit: 5 }));
+
+    expect(out).toContain("More results available");
+  });
+
+  it("does NOT emit hint when total_results equals returned count (completed search)", () => {
+    const messages = [
+      msg("id-1", "2026-01-01T00:00:00.000Z", "alice", "hello"),
+      msg("id-2", "2026-01-01T00:00:01.000Z", "bob", "world"),
+    ];
+    // total_results: 2 with 2 returned messages → search is complete.
+    const wrapped = messages.map((m) => [m]);
+    const result = searchResultPayload({
+      results: { messages: wrapped, total_results: 2 },
+    });
+    const out = textJoined(formatMessageCliText(result, { displayLimit: 5 }));
+
+    expect(out).not.toContain("More results available");
+  });
+
+  it("does NOT emit hint when no pagination signal is present", () => {
+    const messages = [msg("id-1", "2026-01-01T00:00:00.000Z", "alice", "hello")];
+    const result = readResultPayload({ messages });
+    const out = textJoined(formatMessageCliText(result, { displayLimit: 5 }));
+
+    expect(out).not.toContain("More results available");
+  });
+});

--- a/src/commands/message-format.ts
+++ b/src/commands/message-format.ts
@@ -36,6 +36,8 @@ function extractMessageId(payload: unknown): string | null {
 
 type FormatOpts = {
   width: number;
+  /** Max rows to render. Defaults to 25 when omitted. */
+  displayLimit?: number;
 };
 
 function renderObjectSummary(payload: unknown, opts: FormatOpts): string[] {
@@ -87,7 +89,8 @@ function renderObjectSummary(payload: unknown, opts: FormatOpts): string[] {
 }
 
 function renderMessageList(messages: unknown[], opts: FormatOpts, emptyLabel: string): string[] {
-  const rows = messages.slice(0, 25).map((m) => {
+  const cap = opts.displayLimit ?? 25;
+  const rows = messages.slice(0, cap).map((m) => {
     const msg = m as Record<string, unknown>;
     const id =
       (typeof msg.id === "string" && msg.id) ||
@@ -238,14 +241,45 @@ function renderReactions(payload: unknown, opts: FormatOpts): string[] | null {
   ];
 }
 
-export function formatMessageCliText(result: MessageActionRunResult): string[] {
+/**
+ * Emit a muted hint when the provider payload signals more results are available
+ * beyond the current page (e.g. hasMore, nextBatch, @odata.nextLink).
+ */
+function renderPaginationHint(payload: unknown, muted: (text: string) => string): string | null {
+  if (!payload || typeof payload !== "object") {
+    return null;
+  }
+  const obj = payload as Record<string, unknown>;
+  if (obj.hasMore === true) {
+    return muted(
+      "More results available. Use --limit to fetch more, or --json for the raw cursor.",
+    );
+  }
+  if (typeof obj.nextBatch === "string" && obj.nextBatch) {
+    return muted(
+      "More results available. Use --limit to fetch more, or --json for the raw cursor.",
+    );
+  }
+  if (typeof obj["@odata.nextLink"] === "string" && obj["@odata.nextLink"]) {
+    return muted(
+      "More results available. Use --limit to fetch more, or --json for the raw cursor.",
+    );
+  }
+  return null;
+}
+
+export function formatMessageCliText(
+  result: MessageActionRunResult,
+  opts?: { displayLimit?: number },
+): string[] {
   const rich = isRich();
   const ok = (text: string) => (rich ? theme.success(text) : text);
   const muted = (text: string) => (rich ? theme.muted(text) : text);
   const heading = (text: string) => (rich ? theme.heading(text) : text);
 
   const width = getTerminalTableWidth();
-  const opts: FormatOpts = { width };
+  const displayLimit = opts?.displayLimit;
+  const formatOpts: FormatOpts = { width, displayLimit };
 
   if (result.dryRun) {
     return [muted(`[dry-run] would run ${result.action} via ${result.channel}`)];
@@ -267,7 +301,7 @@ export function formatMessageCliText(result: MessageActionRunResult): string[] {
     return [
       headingLine,
       renderTable({
-        width: opts.width,
+        width: formatOpts.width,
         columns: [
           { key: "Channel", header: "Channel", minWidth: 10 },
           { key: "Target", header: "Target", minWidth: 12, flex: true },
@@ -352,7 +386,7 @@ export function formatMessageCliText(result: MessageActionRunResult): string[] {
     return lines;
   }
 
-  const reactionsTable = renderReactions(payload, opts);
+  const reactionsTable = renderReactions(payload, formatOpts);
   if (reactionsTable && result.action === "reactions") {
     lines.push(heading("Reactions"));
     lines.push(reactionsTable[0] ?? "");
@@ -360,19 +394,27 @@ export function formatMessageCliText(result: MessageActionRunResult): string[] {
   }
 
   if (result.action === "read") {
-    const messagesTable = renderMessagesFromPayload(payload, opts);
+    const messagesTable = renderMessagesFromPayload(payload, formatOpts);
     if (messagesTable) {
       lines.push(heading("Messages"));
       lines.push(messagesTable[0] ?? "");
+      const hint = renderPaginationHint(payload, muted);
+      if (hint) {
+        lines.push(hint);
+      }
       return lines;
     }
   }
 
   if (result.action === "list-pins") {
-    const pinsTable = renderPinsFromPayload(payload, opts);
+    const pinsTable = renderPinsFromPayload(payload, formatOpts);
     if (pinsTable) {
       lines.push(heading("Pinned messages"));
       lines.push(pinsTable[0] ?? "");
+      const hint = renderPaginationHint(payload, muted);
+      if (hint) {
+        lines.push(hint);
+      }
       return lines;
     }
   }
@@ -382,14 +424,36 @@ export function formatMessageCliText(result: MessageActionRunResult): string[] {
     const list = extractDiscordSearchResultsMessages(results);
     if (list) {
       lines.push(heading("Search results"));
-      lines.push(renderMessageList(list, opts, "No results.")[0] ?? "");
+      lines.push(renderMessageList(list, formatOpts, "No results.")[0] ?? "");
+      // Discord search nests cursor signals (hasMore, total_results) inside
+      // results rather than at the payload top level. Try payload first, then
+      // the nested results object, then a total_results-vs-count comparison
+      // so completed searches (total_results === returned) show no hint.
+      const hint =
+        renderPaginationHint(payload, muted) ??
+        renderPaginationHint(results, muted) ??
+        (() => {
+          if (!results || typeof results !== "object") {
+            return null;
+          }
+          const r = results as Record<string, unknown>;
+          if (typeof r.total_results === "number" && r.total_results > list.length) {
+            return muted(
+              "More results available. Use --limit to fetch more, or --json for the raw cursor.",
+            );
+          }
+          return null;
+        })();
+      if (hint) {
+        lines.push(hint);
+      }
       return lines;
     }
   }
 
   // Generic success + compact details table.
   lines.push(ok(`✅ ${result.action} via ${resolveChannelLabel(result.channel)}.`));
-  const summary = renderObjectSummary(payload, opts);
+  const summary = renderObjectSummary(payload, formatOpts);
   if (summary.length) {
     lines.push("");
     lines.push(...summary);

--- a/src/commands/message.ts
+++ b/src/commands/message.ts
@@ -15,6 +15,7 @@ import { formatCliCommand } from "../cli/command-format.js";
 import { getScopedChannelsCommandSecretTargets } from "../cli/command-secret-targets.js";
 import { resolveMessageSecretScope } from "../cli/message-secret-scope.js";
 import { createOutboundSendDeps, type CliDeps } from "../cli/outbound-send-deps.js";
+import { parsePositiveIntOrUndefined } from "../cli/program/helpers.js";
 import { withProgress } from "../cli/progress.js";
 import { getRuntimeConfig } from "../config/config.js";
 import type { OutboundSendDeps } from "../infra/outbound/deliver.js";
@@ -132,7 +133,8 @@ export async function messageCommand(
   }
 
   const { formatMessageCliText } = await import("./message-format.js");
-  for (const line of formatMessageCliText(result)) {
+  const displayLimit = parsePositiveIntOrUndefined(opts.limit);
+  for (const line of formatMessageCliText(result, { displayLimit })) {
     runtime.log(line);
   }
 }


### PR DESCRIPTION
## What Problem This Solves

Refs #71452

The CLI text renderer hard-coded `messages.slice(0, 25)`, so message reads and pin lists could display only 25 rows even when the provider returned more and the user requested a higher `--limit`.

This is a partial fix for #71452. It removes the formatter bottleneck and surfaces existing pagination metadata, but it does not add end-to-end provider pagination or cursor iteration. Discord search remains limited to one page of up to 25 results; broader pagination stays tracked in #71452.

## Why This Change Was Made

The change forwards the parsed CLI `--limit` into the shared message formatter while preserving the existing default of 25 rows. It also shows a hint when provider response metadata indicates that more results exist.

For Discord search, `total_results` can indicate that additional matches exist, but it is not a cursor and this PR does not implement Discord's offset-based pagination.

## User Impact

- `message read` and `message pins` can render more than 25 rows when the provider returns them and the user requests a higher limit.
- Existing provider pagination metadata is visible in text output instead of being silently discarded.
- Default text output remains capped at 25 rows when `--limit` is omitted.
- JSON output is unchanged.
- Multi-page iteration, including Discord search beyond its 25-result page, is not implemented by this PR.

## Evidence

- Added focused formatter coverage for read, pins, search, default limits, and pagination hints.
- Existing message command coverage remained green.
- PR-head CI completed successfully for `3364c11fd616e872c800a81ecac2802249dc4462`.
