### PR TITLE
fix: unblock replies after multi-agent room reset

### DIFF
--- a/src/auto-reply/reply/reply-run-registry.ts
+++ b/src/auto-reply/reply/reply-run-registry.ts
@@ -858,6 +858,18 @@ export function forceClearReplyRunBySessionId(sessionId: string, cause?: unknown
   return true;
 }
 
+export function forceClearReplyRunForResetBySessionId(sessionId: string, cause?: unknown): boolean {
+  const operation = resolveReplyRunForCurrentSessionId(sessionId);
+  if (!operation || operation.phase === "queued") {
+    return false;
+  }
+  operation.abortForRestart();
+  if (!resolveReplyRunForCurrentSessionId(sessionId)) {
+    return true;
+  }
+  return forceClearReplyRunBySessionId(sessionId, cause);
+}
+
 export function waitForReplyRunEndBySessionId(
   sessionId: string,
   timeoutMs: number,

--- a/src/auto-reply/reply/reply-run-registry.ts
+++ b/src/auto-reply/reply/reply-run-registry.ts
@@ -858,16 +858,17 @@ export function forceClearReplyRunBySessionId(sessionId: string, cause?: unknown
   return true;
 }
 
-export function forceClearReplyRunForResetBySessionId(sessionId: string, cause?: unknown): boolean {
+export function clearReplyRunForResetBySessionId(sessionId: string): void {
   const operation = resolveReplyRunForCurrentSessionId(sessionId);
   if (!operation || operation.phase === "queued") {
-    return false;
+    return;
   }
   operation.abortForRestart();
-  if (!resolveReplyRunForCurrentSessionId(sessionId)) {
-    return true;
+  // Backend cancellation may synchronously retire this operation and admit a
+  // replacement. Only clear the exact archived operation resolved above.
+  if (replyRunState.activeRunsByKey.get(operation.key) === operation) {
+    operation.complete();
   }
-  return forceClearReplyRunBySessionId(sessionId, cause);
 }
 
 export function waitForReplyRunEndBySessionId(

--- a/src/auto-reply/reply/session-reset-cleanup.test.ts
+++ b/src/auto-reply/reply/session-reset-cleanup.test.ts
@@ -1,13 +1,21 @@
 // Tests session reset cleanup for stale files and persisted state.
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   enqueueSystemEvent,
   peekSystemEvents,
   resetSystemEventsForTest,
 } from "../../infra/system-events.js";
+import { resetDiagnosticRunActivityForTest } from "../../logging/diagnostic-run-activity.js";
+import {
+  createReplyOperation,
+  replyRunRegistry,
+  testing as replyRunTesting,
+} from "./reply-run-registry.js";
 import { clearSessionResetRuntimeState } from "./session-reset-cleanup.js";
 
 afterEach(() => {
+  replyRunTesting.resetReplyRunRegistry();
+  resetDiagnosticRunActivityForTest();
   resetSystemEventsForTest();
 });
 
@@ -24,5 +32,66 @@ describe("clearSessionResetRuntimeState", () => {
     expect(peekSystemEvents("alpha")).toStrictEqual([]);
     expect(peekSystemEvents("beta")).toStrictEqual([]);
     expect(peekSystemEvents("gamma")).toEqual(["fresh gamma"]);
+  });
+
+  it("releases active reply work owned by the archived reset session id", () => {
+    const cancel = vi.fn();
+    const operation = createReplyOperation({
+      sessionKey: "agent:main:slack:room:1",
+      sessionId: "old-session",
+      resetTriggered: false,
+    });
+    operation.attachBackend({
+      kind: "embedded",
+      cancel,
+      isStreaming: () => false,
+    });
+    operation.setPhase("running");
+
+    const result = clearSessionResetRuntimeState(["agent:main:slack:room:1", "old-session"], {
+      activeReplySessionIds: ["old-session"],
+    });
+
+    expect(result.activeReplyRunsCleared).toBe(1);
+    expect(cancel).toHaveBeenCalledWith("restart");
+    expect(replyRunRegistry.isActive("agent:main:slack:room:1")).toBe(false);
+    const nextOperation = createReplyOperation({
+      sessionKey: "agent:main:slack:room:1",
+      sessionId: "new-session",
+      resetTriggered: false,
+    });
+    expect(nextOperation.sessionId).toBe("new-session");
+  });
+
+  it("does not clear a fresh active reply under the same key when only the archived id is reset", () => {
+    const operation = createReplyOperation({
+      sessionKey: "agent:main:slack:room:1",
+      sessionId: "new-session",
+      resetTriggered: false,
+    });
+    operation.setPhase("running");
+
+    const result = clearSessionResetRuntimeState(["agent:main:slack:room:1", "old-session"], {
+      activeReplySessionIds: ["old-session"],
+    });
+
+    expect(result.activeReplyRunsCleared).toBe(0);
+    expect(replyRunRegistry.get("agent:main:slack:room:1")).toBe(operation);
+  });
+
+  it("leaves queued reservations for the archived id so session init can rebind them", () => {
+    const operation = createReplyOperation({
+      sessionKey: "agent:main:slack:room:1",
+      sessionId: "old-session",
+      resetTriggered: false,
+    });
+
+    const result = clearSessionResetRuntimeState(["agent:main:slack:room:1", "old-session"], {
+      activeReplySessionIds: ["old-session"],
+    });
+
+    expect(result.activeReplyRunsCleared).toBe(0);
+    expect(operation.phase).toBe("queued");
+    expect(replyRunRegistry.get("agent:main:slack:room:1")).toBe(operation);
   });
 });

--- a/src/auto-reply/reply/session-reset-cleanup.test.ts
+++ b/src/auto-reply/reply/session-reset-cleanup.test.ts
@@ -48,11 +48,10 @@ describe("clearSessionResetRuntimeState", () => {
     });
     operation.setPhase("running");
 
-    const result = clearSessionResetRuntimeState(["agent:main:slack:room:1", "old-session"], {
-      activeReplySessionIds: ["old-session"],
+    clearSessionResetRuntimeState(["agent:main:slack:room:1", "old-session"], {
+      activeReplySessionId: "old-session",
     });
 
-    expect(result.activeReplyRunsCleared).toBe(1);
     expect(cancel).toHaveBeenCalledWith("restart");
     expect(replyRunRegistry.isActive("agent:main:slack:room:1")).toBe(false);
     const nextOperation = createReplyOperation({
@@ -71,12 +70,41 @@ describe("clearSessionResetRuntimeState", () => {
     });
     operation.setPhase("running");
 
-    const result = clearSessionResetRuntimeState(["agent:main:slack:room:1", "old-session"], {
-      activeReplySessionIds: ["old-session"],
+    clearSessionResetRuntimeState(["agent:main:slack:room:1", "old-session"], {
+      activeReplySessionId: "old-session",
     });
 
-    expect(result.activeReplyRunsCleared).toBe(0);
     expect(replyRunRegistry.get("agent:main:slack:room:1")).toBe(operation);
+  });
+
+  it("does not clear a replacement admitted while the archived run is cancelling", () => {
+    let replacement: ReturnType<typeof createReplyOperation> | undefined;
+    const operation = createReplyOperation({
+      sessionKey: "agent:main:slack:room:1",
+      sessionId: "old-session",
+      resetTriggered: false,
+    });
+    operation.attachBackend({
+      kind: "embedded",
+      cancel() {
+        operation.complete();
+        replacement = createReplyOperation({
+          sessionKey: "agent:main:slack:room:1",
+          sessionId: "old-session",
+          resetTriggered: false,
+        });
+        replacement.setPhase("running");
+      },
+      isStreaming: () => false,
+    });
+    operation.setPhase("running");
+
+    clearSessionResetRuntimeState(["agent:main:slack:room:1", "old-session"], {
+      activeReplySessionId: "old-session",
+    });
+
+    expect(replacement).toBeDefined();
+    expect(replyRunRegistry.get("agent:main:slack:room:1")).toBe(replacement);
   });
 
   it("leaves queued reservations for the archived id so session init can rebind them", () => {
@@ -86,11 +114,10 @@ describe("clearSessionResetRuntimeState", () => {
       resetTriggered: false,
     });
 
-    const result = clearSessionResetRuntimeState(["agent:main:slack:room:1", "old-session"], {
-      activeReplySessionIds: ["old-session"],
+    clearSessionResetRuntimeState(["agent:main:slack:room:1", "old-session"], {
+      activeReplySessionId: "old-session",
     });
 
-    expect(result.activeReplyRunsCleared).toBe(0);
     expect(operation.phase).toBe("queued");
     expect(replyRunRegistry.get("agent:main:slack:room:1")).toBe(operation);
   });

--- a/src/auto-reply/reply/session-reset-cleanup.ts
+++ b/src/auto-reply/reply/session-reset-cleanup.ts
@@ -1,41 +1,31 @@
 /** Clears reset-related queues and system events for session keys. */
 import { drainSystemEventEntries } from "../../infra/system-events.js";
 import { clearSessionQueues, type ClearSessionQueueResult } from "./queue/cleanup.js";
-import { forceClearReplyRunForResetBySessionId } from "./reply-run-registry.js";
+import { clearReplyRunForResetBySessionId } from "./reply-run-registry.js";
 
 /** Runtime cleanup result for reset-related queues and system events. */
 type ClearSessionResetRuntimeStateResult = ClearSessionQueueResult & {
   systemEventsCleared: number;
-  activeReplyRunsCleared: number;
 };
 
 /** Clears queued follow-ups and pending system events for reset session keys. */
 export function clearSessionResetRuntimeState(
   keys: Array<string | undefined>,
-  opts?: { activeReplySessionIds?: Array<string | undefined> },
+  opts?: { activeReplySessionId?: string },
 ): ClearSessionResetRuntimeStateResult {
   const cleared = clearSessionQueues(keys);
   let systemEventsCleared = 0;
-  let activeReplyRunsCleared = 0;
 
   for (const key of cleared.keys) {
     systemEventsCleared += drainSystemEventEntries(key).length;
   }
 
-  for (const sessionId of opts?.activeReplySessionIds ?? []) {
-    if (
-      forceClearReplyRunForResetBySessionId(
-        sessionId ?? "",
-        new Error("clearing active reply operation for reset session"),
-      )
-    ) {
-      activeReplyRunsCleared += 1;
-    }
+  if (opts?.activeReplySessionId) {
+    clearReplyRunForResetBySessionId(opts.activeReplySessionId);
   }
 
   return {
     ...cleared,
     systemEventsCleared,
-    activeReplyRunsCleared,
   };
 }

--- a/src/auto-reply/reply/session-reset-cleanup.ts
+++ b/src/auto-reply/reply/session-reset-cleanup.ts
@@ -1,25 +1,41 @@
 /** Clears reset-related queues and system events for session keys. */
 import { drainSystemEventEntries } from "../../infra/system-events.js";
 import { clearSessionQueues, type ClearSessionQueueResult } from "./queue/cleanup.js";
+import { forceClearReplyRunForResetBySessionId } from "./reply-run-registry.js";
 
 /** Runtime cleanup result for reset-related queues and system events. */
 type ClearSessionResetRuntimeStateResult = ClearSessionQueueResult & {
   systemEventsCleared: number;
+  activeReplyRunsCleared: number;
 };
 
 /** Clears queued follow-ups and pending system events for reset session keys. */
 export function clearSessionResetRuntimeState(
   keys: Array<string | undefined>,
+  opts?: { activeReplySessionIds?: Array<string | undefined> },
 ): ClearSessionResetRuntimeStateResult {
   const cleared = clearSessionQueues(keys);
   let systemEventsCleared = 0;
+  let activeReplyRunsCleared = 0;
 
   for (const key of cleared.keys) {
     systemEventsCleared += drainSystemEventEntries(key).length;
   }
 
+  for (const sessionId of opts?.activeReplySessionIds ?? []) {
+    if (
+      forceClearReplyRunForResetBySessionId(
+        sessionId ?? "",
+        new Error("clearing active reply operation for reset session"),
+      )
+    ) {
+      activeReplyRunsCleared += 1;
+    }
+  }
+
   return {
     ...cleared,
     systemEventsCleared,
+    activeReplyRunsCleared,
   };
 }

--- a/src/auto-reply/reply/session.ts
+++ b/src/auto-reply/reply/session.ts
@@ -684,7 +684,9 @@ async function initSessionStateAttemptLocked(
     previousSessionId: previousSessionEntry?.sessionId,
   });
   if (previousSessionEntry) {
-    clearSessionResetRuntimeState([sessionKey, previousSessionEntry.sessionId]);
+    clearSessionResetRuntimeState([sessionKey, previousSessionEntry.sessionId], {
+      activeReplySessionIds: [previousSessionEntry.sessionId],
+    });
   }
 
   const recoveredTerminalEntry =

--- a/src/auto-reply/reply/session.ts
+++ b/src/auto-reply/reply/session.ts
@@ -685,7 +685,7 @@ async function initSessionStateAttemptLocked(
   });
   if (previousSessionEntry) {
     clearSessionResetRuntimeState([sessionKey, previousSessionEntry.sessionId], {
-      activeReplySessionIds: [previousSessionEntry.sessionId],
+      activeReplySessionId: previousSessionEntry.sessionId,
     });
   }
 

--- a/src/gateway/session-reset-service.ts
+++ b/src/gateway/session-reset-service.ts
@@ -401,7 +401,9 @@ async function ensureSessionRuntimeCleanup(params: {
   if (params.sessionId) {
     queueKeys.add(params.sessionId);
   }
-  clearSessionResetRuntimeState([...queueKeys]);
+  clearSessionResetRuntimeState([...queueKeys], {
+    activeReplySessionIds: [params.sessionId],
+  });
   stopSubagentsForRequester({ cfg: params.cfg, requesterSessionKey: params.target.canonicalKey });
   if (!params.sessionId) {
     params.assertCurrent?.();

--- a/src/gateway/session-reset-service.ts
+++ b/src/gateway/session-reset-service.ts
@@ -402,7 +402,7 @@ async function ensureSessionRuntimeCleanup(params: {
     queueKeys.add(params.sessionId);
   }
   clearSessionResetRuntimeState([...queueKeys], {
-    activeReplySessionIds: [params.sessionId],
+    activeReplySessionId: params.sessionId,
   });
   stopSubagentsForRequester({ cfg: params.cfg, requesterSessionKey: params.target.canonicalKey });
   if (!params.sessionId) {


### PR DESCRIPTION
Closes #99082

## What Problem This Solves

Fixes an issue where users resetting a multi-agent room could have a stale visible reply operation from the archived session continue blocking the fresh session. In the reported Slack room flow, that made all but one agent wait for the stuck-session recovery window before the reset acknowledgement and queued replies could deliver.

## Why This Change Was Made

Reset cleanup now releases non-queued active reply work that is still owned by the archived session id, while leaving queued reservations alone so session initialization can rebind the current turn safely. This is intentionally scoped to the reset/session cleanup boundary and uses session-id ownership checks so a fresh active reply under the same session key is not cleared.

Risk note: the dangerous failure mode is dropping a valid in-flight fresh reply; the regression tests cover both the stale archived-id release and the fresh/queued reservation cases that must survive cleanup.

## User Impact

Multi-agent room resets should no longer leave fresh post-reset replies wedged behind stale active reply work from an archived session. Reset acknowledgements and later room messages can proceed once the old session is rotated instead of waiting for delayed stuck-session recovery.

## Evidence

- Source-level before/premise: current reset cleanup only cleared queues and system events; active reply operations remained keyed by session key and could still resolve by the archived session id.
- Focused regression proof: `node scripts/run-vitest.mjs src/auto-reply/reply/session-reset-cleanup.test.ts src/auto-reply/reply/reply-run-registry.test.ts src/auto-reply/reply/session.test.ts src/gateway/server.sessions.reset-cleanup.test.ts src/gateway/server-methods/agent.test.ts src/logging/diagnostic-stuck-session-recovery.runtime.test.ts` passed 3 Vitest shards, 544 tests.
- Type/format/lint: `node scripts/run-tsgo.mjs -p tsconfig.core.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/core.tsbuildinfo`, `node scripts/run-tsgo.mjs -p test/tsconfig/tsconfig.test.src.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/test-src.tsbuildinfo`, `node_modules/.bin/oxfmt --check --threads=1 ...`, and `node scripts/run-oxlint.mjs ...` all passed.
- Build: `pnpm build` passed.
- Real behavior proof: a local embedded agent turn using `deepseek/deepseek-v4-pro` returned `RESET_PROOF_OK` with `stopReason=stop` and `fallbackUsed=false`.
- Autoreview: `.agents/skills/autoreview/scripts/autoreview --mode local` passed with no accepted/actionable findings after one in-scope fix.

Live Slack multi-agent credentials were not available in this checkout, so I did not run the exact two-agent Slack room reproduction.

AI-assisted.
