### PR TITLE
fix: harden native i18n identifier filtering

### DIFF
--- a/scripts/native-app-i18n.ts
+++ b/scripts/native-app-i18n.ts
@@ -170,6 +170,42 @@ const EXCLUDED_FILE_RE = /(?:Tests?|UITests?|Previews?|Testing)\.(?:swift|kt|kts
 const BUILD_SETTING_RE = /\$\([A-Za-z0-9_.-]+\)/gu;
 const NATIVE_I18N_LOCALE_SET = new Set<string>(NATIVE_I18N_LOCALES);
 
+function isAsciiLowercaseLetter(character: string): boolean {
+  return character >= "a" && character <= "z";
+}
+
+function isAsciiUppercaseLetter(character: string): boolean {
+  return character >= "A" && character <= "Z";
+}
+
+function isAsciiAlphaNumeric(character: string): boolean {
+  return (
+    isAsciiLowercaseLetter(character) ||
+    isAsciiUppercaseLetter(character) ||
+    (character >= "0" && character <= "9")
+  );
+}
+
+export function isConditionalBranchIdentifier(source: string): boolean {
+  let index = 0;
+  while (index < source.length && isAsciiLowercaseLetter(source[index])) {
+    index += 1;
+  }
+
+  // Keep this scanner linear: PR-controlled native source passes through CI,
+  // so a backtracking regex here can become a cheap native-i18n DoS trigger.
+  if (index === 0 || index >= source.length || !isAsciiUppercaseLetter(source[index])) {
+    return false;
+  }
+
+  for (index += 1; index < source.length; index += 1) {
+    if (!isAsciiAlphaNumeric(source[index])) {
+      return false;
+    }
+  }
+  return true;
+}
+
 function isTranslatableCandidate(source: string, kind: string): boolean {
   if (BUILD_SETTING_RE.test(source)) {
     BUILD_SETTING_RE.lastIndex = 0;
@@ -180,7 +216,7 @@ function isTranslatableCandidate(source: string, kind: string): boolean {
   if (!isDirectUiText && (/^[a-z0-9_.:/$-]+$/u.test(source) || /^[A-Z0-9_.:/$-]+$/u.test(source))) {
     return false;
   }
-  if (kind === "conditional-branch" && /^[a-z]+(?:[A-Z][A-Za-z0-9]*)+$/u.test(source)) {
+  if (kind === "conditional-branch" && isConditionalBranchIdentifier(source)) {
     return false;
   }
   if (/[{}[\]]/u.test(source) && !/(?:\\\(|\$\{)/u.test(source)) {

--- a/test/scripts/native-app-i18n.test.ts
+++ b/test/scripts/native-app-i18n.test.ts
@@ -3,6 +3,7 @@ import path from "node:path";
 import { describe, expect, it } from "vitest";
 import {
   collectNativeI18nEntries,
+  isConditionalBranchIdentifier,
   NATIVE_I18N_LOCALES,
   parseNativeI18nCommand,
   syncNativeLocale,
@@ -11,6 +12,14 @@ import {
 import { cleanupTempDirs, makeTempDir } from "../helpers/temp-dir.js";
 
 describe("native app i18n inventory", () => {
+  it("detects conditional branch identifiers without regex backtracking", () => {
+    expect(isConditionalBranchIdentifier("isEnabled")).toBe(true);
+    expect(isConditionalBranchIdentifier("hasFA2Enabled")).toBe(true);
+    expect(isConditionalBranchIdentifier("abc123A")).toBe(false);
+    expect(isConditionalBranchIdentifier("already_lowercase")).toBe(false);
+    expect(isConditionalBranchIdentifier(`a${"A".repeat(4_096)}!`)).toBe(false);
+  });
+
   it("collects stable Android and Apple UI entries", async () => {
     const entries = await collectNativeI18nEntries();
     const surfaces = new Set(entries.map((entry) => entry.surface));


### PR DESCRIPTION
## What Problem This Solves

Resolves an edge case where native i18n inventory filtering needed more predictable handling for unusually shaped conditional-branch identifiers.

## Why This Change Was Made

The conditional-branch identifier check now uses a small linear ASCII scanner that preserves the existing filtering behavior without relying on a complex regular expression.

## User Impact

Maintainer tooling remains responsive and deterministic when scanning native app source text. There is no product UI behavior change.

AI-assisted: yes, implemented with Codex.

## Evidence

- `pnpm format:fix -- scripts/native-app-i18n.ts test/scripts/native-app-i18n.test.ts`
- `node scripts/run-vitest.mjs test/scripts/native-app-i18n.test.ts`
- `.agents/skills/autoreview/scripts/autoreview --mode local`
- Autoreview result: `autoreview clean: no accepted/actionable findings reported`
- `git diff --check`
