### PR TITLE
fix: harden qa lab report table rendering

### DIFF
--- a/extensions/qa-lab/src/confidence-report.test.ts
+++ b/extensions/qa-lab/src/confidence-report.test.ts
@@ -8,6 +8,7 @@ import {
   buildQaConfidenceSelfTestSummary,
   renderQaConfidenceMarkdownReport,
   writeQaConfidenceSelfTestArtifacts,
+  type QaConfidenceReport,
   type QaConfidenceManifest,
 } from "./confidence-report.js";
 
@@ -28,6 +29,33 @@ describe("qa confidence report", () => {
     await fs.writeFile(filePath, `${JSON.stringify(payload, null, 2)}\n`, "utf8");
     return filePath;
   }
+
+  it("escapes backslashes and pipes in markdown table cells", () => {
+    const report: QaConfidenceReport = {
+      generatedAt: "2026-05-12T00:00:00.000Z",
+      profile: "codex-100",
+      strictZeroUnknowns: false,
+      strictGlobalPass: false,
+      pass: false,
+      zeroUnknowns: false,
+      globalPass: false,
+      counts: { total: 1, passed: 0, failed: 1, blocked: 0, missing: 0, unknown: 0 },
+      failures: [],
+      lanes: [
+        {
+          id: String.raw`lane\|one`,
+          required: true,
+          status: "failed",
+          verdict: "qa-harness-bug",
+          details: String.raw`path\to\artifact | mismatch`,
+        },
+      ],
+    };
+
+    expect(renderQaConfidenceMarkdownReport(report)).toContain(
+      String.raw`| lane\\\|one | failed | qa-harness-bug |  |  | path\\to\\artifact \| mismatch |`,
+    );
+  });
 
   it("passes strict zero-unknowns when every lane passes or has an allowed blocked verdict", async () => {
     await writeJson("tool-defaults/qa-suite-summary.json", {

--- a/extensions/qa-lab/src/confidence-report.ts
+++ b/extensions/qa-lab/src/confidence-report.ts
@@ -13,6 +13,7 @@ import {
   type HarnessRuntimeParityCell,
   type RuntimeParitySystemPromptReport,
 } from "./harness-parity.js";
+import { escapeMarkdownTableCell } from "./markdown-report.js";
 import {
   runRuntimeParityScenario,
   type RuntimeParityCell,
@@ -389,8 +390,7 @@ function evaluateQaSuiteSummary(payload: unknown): QaConfidenceLaneEvaluation {
   const failedCount = readCount(counts?.failed);
   const explicitSkippedCount = readCount(counts?.skipped);
   if (totalCount !== undefined) {
-    const providedCountSum =
-      (passedCount ?? 0) + (failedCount ?? 0) + (explicitSkippedCount ?? 0);
+    const providedCountSum = (passedCount ?? 0) + (failedCount ?? 0) + (explicitSkippedCount ?? 0);
     if (totalCount < providedCountSum) {
       return {
         passed: false,
@@ -957,10 +957,6 @@ function formatVerdict(lane: QaConfidenceLaneResult): string {
   return lane.verdict ?? "unclassified";
 }
 
-function escapeTableCell(value: string): string {
-  return value.replace(/\|/gu, "\\|").replace(/\s+/gu, " ").trim();
-}
-
 export function renderQaConfidenceMarkdownReport(report: QaConfidenceReport): string {
   const lines = [
     `# OpenClaw QA Confidence Report - ${report.profile}`,
@@ -978,7 +974,7 @@ export function renderQaConfidenceMarkdownReport(report: QaConfidenceReport): st
   ];
   for (const lane of report.lanes) {
     lines.push(
-      `| ${escapeTableCell(lane.id)} | ${lane.status} | ${formatVerdict(lane)} | ${lane.productImpact ?? ""} | ${lane.qaImpact ?? ""} | ${escapeTableCell(lane.details)} |`,
+      `| ${escapeMarkdownTableCell(lane.id)} | ${lane.status} | ${formatVerdict(lane)} | ${lane.productImpact ?? ""} | ${lane.qaImpact ?? ""} | ${escapeMarkdownTableCell(lane.details)} |`,
     );
   }
   if (report.failures.length > 0) {
@@ -1287,7 +1283,7 @@ export function renderQaConfidenceSelfTestMarkdownReport(
   ];
   for (const canary of summary.canaries) {
     lines.push(
-      `| ${canary.id} | ${canary.category} | ${canary.detected ? "yes" : "no"} | ${canary.expectedVerdict} | ${escapeTableCell(canary.details)} |`,
+      `| ${canary.id} | ${canary.category} | ${canary.detected ? "yes" : "no"} | ${canary.expectedVerdict} | ${escapeMarkdownTableCell(canary.details)} |`,
     );
   }
   return `${lines.join("\n")}\n`;

--- a/extensions/qa-lab/src/markdown-report.ts
+++ b/extensions/qa-lab/src/markdown-report.ts
@@ -1,0 +1,5 @@
+// Qa Lab plugin module implements markdown report rendering helpers.
+
+export function escapeMarkdownTableCell(value: string): string {
+  return value.replace(/\\/gu, "\\\\").replace(/\|/gu, "\\|").replace(/\s+/gu, " ").trim();
+}

--- a/extensions/qa-lab/src/tool-coverage-report.test.ts
+++ b/extensions/qa-lab/src/tool-coverage-report.test.ts
@@ -97,7 +97,7 @@ describe("qa tool coverage report", () => {
   it("escapes freeform metadata in the markdown table", () => {
     const report = buildQaToolCoverageReport({
       scenarios: [
-        makeScenario("tool-read", "read|file", {
+        makeScenario("tool-read", String.raw`read\|file`, {
           toolCoverage: {
             bucket: "codex-native-workspace",
             expectedLayer: "codex-native-workspace",
@@ -116,7 +116,7 @@ describe("qa tool coverage report", () => {
 
     const markdown = renderQaToolCoverageMarkdownReport(report);
 
-    expect(markdown).toContain("read\\|file");
+    expect(markdown).toContain(String.raw`read\\\|file`);
     expect(markdown).toContain("P2 \\| default");
     expect(markdown).toContain("P1 \\| confidence");
     expect(markdown).toContain("fix \\| backfill");

--- a/extensions/qa-lab/src/tool-coverage-report.ts
+++ b/extensions/qa-lab/src/tool-coverage-report.ts
@@ -3,6 +3,7 @@ import {
   isRecord,
   normalizeOptionalString as readString,
 } from "openclaw/plugin-sdk/string-coerce-runtime";
+import { escapeMarkdownTableCell } from "./markdown-report.js";
 import {
   isRuntimeParityCellPassable,
   type RuntimeId,
@@ -339,7 +340,7 @@ export function renderQaToolCoverageMarkdownReport(report: QaToolCoverageReport)
       row.qaImpact ?? "",
       row.action ?? "",
       row.tracking ?? "",
-    ].map(escapeTableCell);
+    ].map(escapeMarkdownTableCell);
     lines.push(`| ${cells.join(" | ")} |`);
   }
 
@@ -356,8 +357,4 @@ export function renderQaToolCoverageMarkdownReport(report: QaToolCoverageReport)
   }
 
   return `${lines.join("\n").trimEnd()}\n`;
-}
-
-function escapeTableCell(value: string): string {
-  return value.replace(/\|/gu, "\\|").replace(/\s+/gu, " ").trim();
 }


### PR DESCRIPTION
## What Problem This Solves

Fixes an edge case where QA Lab Markdown reports could render freeform table-cell content ambiguously when values contained escaped separators or backslash-heavy text.

## Why This Change Was Made

QA Lab report rendering now uses one local Markdown table-cell escaping helper that handles backslashes before pipes and keeps the existing whitespace normalization behavior. The tool coverage and confidence reports share that helper for consistent output.

## User Impact

QA Lab report consumers get less ambiguous Markdown table output for paths, escaped separators, and other diagnostic text. There is no runtime product behavior change.

AI-assisted: yes, implemented with Codex.

## Evidence

- `pnpm format:fix -- extensions/qa-lab/src/markdown-report.ts extensions/qa-lab/src/tool-coverage-report.ts extensions/qa-lab/src/tool-coverage-report.test.ts extensions/qa-lab/src/confidence-report.ts extensions/qa-lab/src/confidence-report.test.ts`
- `node scripts/run-vitest.mjs extensions/qa-lab/src/tool-coverage-report.test.ts extensions/qa-lab/src/confidence-report.test.ts`
- `.agents/skills/autoreview/scripts/autoreview --mode local`
- Autoreview result: `autoreview clean: no accepted/actionable findings reported`
- `git diff --check`
