### PR TITLE
fix: harden npm packument package paths

### DIFF
--- a/scripts/transitive-manifest-risk-report.mjs
+++ b/scripts/transitive-manifest-risk-report.mjs
@@ -47,7 +47,8 @@ function isAllowedPinnedSpec(spec) {
 }
 
 function encodePackageName(name) {
-  return name.startsWith("@") ? name.replace("/", "%2f") : name;
+  const encoded = encodeURIComponent(name);
+  return encoded.startsWith("%40") ? `@${encoded.slice("%40".length)}` : encoded;
 }
 
 function resolveRegistryBaseUrl() {

--- a/test/scripts/transitive-manifest-risk-report.test.ts
+++ b/test/scripts/transitive-manifest-risk-report.test.ts
@@ -203,42 +203,54 @@ describe("transitive-manifest-risk-report", () => {
   it("fetches full npm packuments for the requested manifest version", async () => {
     const fetchCalls: Array<{ url: string; accept: string | null; signal: AbortSignal | null }> =
       [];
+    const fetchImpl = async (url: string | URL, init?: RequestInit) => {
+      fetchCalls.push({
+        url: String(url),
+        accept: new Headers(init?.headers).get("accept"),
+        signal: init?.signal instanceof AbortSignal ? init.signal : null,
+      });
+      return new Response(
+        JSON.stringify({
+          time: {
+            "1.0.0": "2026-05-12T00:00:00.000Z",
+          },
+          versions: {
+            "1.0.0": {
+              dependencies: {
+                exact: "1.2.3",
+              },
+              scripts: {
+                install: "node install.js",
+              },
+            },
+          },
+        }),
+        {
+          status: 200,
+        },
+      );
+    };
     const manifest = await fetchNpmManifest({
       packageName: "@scope/package",
       version: "1.0.0",
       registryBaseUrl: "https://registry.example.test",
-      fetchImpl: async (url, init) => {
-        fetchCalls.push({
-          url: String(url),
-          accept: new Headers(init?.headers).get("accept"),
-          signal: init?.signal instanceof AbortSignal ? init.signal : null,
-        });
-        return new Response(
-          JSON.stringify({
-            time: {
-              "1.0.0": "2026-05-12T00:00:00.000Z",
-            },
-            versions: {
-              "1.0.0": {
-                dependencies: {
-                  exact: "1.2.3",
-                },
-                scripts: {
-                  install: "node install.js",
-                },
-              },
-            },
-          }),
-          {
-            status: 200,
-          },
-        );
-      },
+      fetchImpl,
+    });
+    await fetchNpmManifest({
+      packageName: "@scope/package/extra",
+      version: "1.0.0",
+      registryBaseUrl: "https://registry.example.test",
+      fetchImpl,
     });
 
     expect(fetchCalls).toEqual([
       {
-        url: "https://registry.example.test/@scope%2fpackage",
+        url: "https://registry.example.test/@scope%2Fpackage",
+        accept: "application/json",
+        signal: expect.any(AbortSignal),
+      },
+      {
+        url: "https://registry.example.test/@scope%2Fpackage%2Fextra",
         accept: "application/json",
         signal: expect.any(AbortSignal),
       },


### PR DESCRIPTION
## What Problem This Solves

Fixes an edge case where the transitive manifest risk report could construct registry request paths inconsistently for unusual package names.

## Why This Change Was Made

The report script now percent-encodes package names and then restores only the conventional leading `@` for scoped package paths. This keeps package names from being interpreted as additional registry path structure.

## User Impact

Maintainers get more robust dependency risk report requests when auditing lockfile data. There is no product runtime behavior change.

AI-assisted: yes, implemented with Codex.

## Evidence

- `pnpm format:fix -- scripts/transitive-manifest-risk-report.mjs test/scripts/transitive-manifest-risk-report.test.ts`
- `node scripts/run-vitest.mjs test/scripts/transitive-manifest-risk-report.test.ts`
- `.agents/skills/autoreview/scripts/autoreview --mode local`
- Autoreview result: `autoreview clean: no accepted/actionable findings reported`
- `git diff --check`
