### PR TITLE
fix: harden e2e npm registry package paths

### DIFF
--- a/scripts/e2e/lib/plugins/npm-registry-server.mjs
+++ b/scripts/e2e/lib/plugins/npm-registry-server.mjs
@@ -14,13 +14,19 @@ if (!portFile || packageArgs.length === 0 || packageArgs.length % 3 !== 0) {
 }
 
 const packages = new Map();
+
+function encodePackagePathName(packageName) {
+  const encoded = encodeURIComponent(packageName);
+  return encoded.startsWith("%40") ? `@${encoded.slice("%40".length)}` : encoded;
+}
+
 for (let index = 0; index < packageArgs.length; index += 3) {
   const packageName = packageArgs[index];
   const version = packageArgs[index + 1];
   const tarballPath = packageArgs[index + 2];
   const archive = fs.readFileSync(tarballPath);
   const existing = packages.get(packageName) ?? {
-    encodedPackageName: encodeURIComponent(packageName).replace("%40", "@"),
+    encodedPackageName: encodePackagePathName(packageName),
     packageName,
     latestVersion: version,
     versions: new Map(),

--- a/test/scripts/plugins-assertions.test.ts
+++ b/test/scripts/plugins-assertions.test.ts
@@ -564,6 +564,9 @@ test -d "$OPENCLAW_PLUGINS_TMP_DIR"
         "@openclaw/demo-plugin-npm",
         "1.0.0",
         tarballPath,
+        "@openclaw/demo-plugin-npm/extra",
+        "1.0.0",
+        tarballPath,
       ],
       {
         cwd: process.cwd(),
@@ -591,6 +594,23 @@ test -d "$OPENCLAW_PLUGINS_TMP_DIR"
         name: "@openclaw/demo-plugin-npm",
         "dist-tags": { latest: "1.0.0" },
       });
+
+      const extra = await requestFixtureRegistry(port, "/@openclaw%2Fdemo-plugin-npm%2Fextra");
+      const extraMetadata = JSON.parse(extra.body) as {
+        versions: Record<string, { dist: { tarball: string } }>;
+      };
+      const extraTarballUrl = new URL(extraMetadata.versions["1.0.0"].dist.tarball);
+      const extraTarball = await requestFixtureRegistry(
+        port,
+        `${extraTarballUrl.pathname}${extraTarballUrl.search}`,
+      );
+
+      expect(extra.statusCode, stderr.text()).toBe(200);
+      expect(extraMetadata.versions["1.0.0"].dist.tarball).toContain(
+        "/@openclaw%2Fdemo-plugin-npm%2Fextra/-/",
+      );
+      expect(extraTarball.statusCode, stderr.text()).toBe(200);
+      expect(extraTarball.body).toBe("fixture package archive");
     } finally {
       if (child.exitCode === null) {
         child.kill();


### PR DESCRIPTION
## What Problem This Solves

Fixes an edge case where the plugin E2E npm registry fixture could render package metadata and tarball routes inconsistently for unusual package names.

## Why This Change Was Made

The fixture registry now percent-encodes package names and restores only the leading scoped-package `@`, matching the package path shape used by the report tooling. Regression coverage exercises metadata lookup and tarball download for the edge case.

## User Impact

Plugin E2E tests get a more faithful local npm registry fixture for scoped and unusual package names. There is no product runtime behavior change.

AI-assisted: yes, implemented with Codex.

## Evidence

- `pnpm format:fix -- scripts/e2e/lib/plugins/npm-registry-server.mjs test/scripts/plugins-assertions.test.ts`
- `node scripts/run-vitest.mjs test/scripts/plugins-assertions.test.ts`
- `.agents/skills/autoreview/scripts/autoreview --mode local`
- Autoreview result: `autoreview clean: no accepted/actionable findings reported`
- `git diff --check`
