### PR TITLE
fix: use boundary-aware home path replacement in chrome-mcp and session-memory

### DIFF
--- a/extensions/browser/src/browser/chrome-mcp.ts
+++ b/extensions/browser/src/browser/chrome-mcp.ts
@@ -496,10 +496,44 @@ function redactChromeMcpDiagnosticText(text: string): string {
   );
 }
 
+/** Replace home-path occurrences in diagnostic text without clipping sibling prefixes. */
+function replaceHomePathInText(text: string, homePath: string): string {
+  let output = "";
+  let cursor = 0;
+  while (cursor < text.length) {
+    const index = text.indexOf(homePath, cursor);
+    if (index < 0) {
+      return `${output}${text.slice(cursor)}`;
+    }
+    const before = text[index - 1];
+    const homeEnd = index + homePath.length;
+    const after = text[homeEnd];
+    // home-path match must start at a token boundary to avoid rewriting sibling
+    // paths that happen to share the home prefix (e.g. /home/user2 vs /home/user).
+    const startsToken = before === undefined || /[\s("'`:=[{,]/u.test(before);
+    let punctuationEnd = homeEnd;
+    while (punctuationEnd < text.length && /[)"'`:,;.\]}]/u.test(text[punctuationEnd])) {
+      punctuationEnd += 1;
+    }
+    const punctuationEndsToken =
+      punctuationEnd > homeEnd &&
+      (punctuationEnd === text.length || /\s/u.test(text[punctuationEnd]));
+    const endsTokenOrContinuesPath =
+      after === undefined || after === "/" || after === "\\" || punctuationEndsToken;
+    if (startsToken && endsTokenOrContinuesPath) {
+      output += `${text.slice(cursor, index)}~`;
+    } else {
+      output += text.slice(cursor, index + homePath.length);
+    }
+    cursor = index + homePath.length;
+  }
+  return output;
+}
+
 function redactChromeMcpDiagnosticTextWithLocalPaths(text: string): string {
   const homeDir = normalizeOptionalString(os.homedir());
   const homePath = homeDir ? path.resolve(homeDir) : undefined;
-  const withHomeRedacted = homePath ? text.split(homePath).join("~") : text;
+  const withHomeRedacted = homePath ? replaceHomePathInText(text, homePath) : text;
   return redactChromeMcpDiagnosticText(withHomeRedacted);
 }
 

--- a/src/cron/service/initial-delivery.ts
+++ b/src/cron/service/initial-delivery.ts
@@ -7,7 +7,9 @@ export function resolveInitialCronDelivery(input: CronJobCreate): CronDelivery |
     return input.delivery;
   }
   if (
-    input.sessionTarget === "isolated" &&
+    (input.sessionTarget === "isolated" ||
+      input.sessionTarget === "current" ||
+      (typeof input.sessionTarget === "string" && input.sessionTarget.startsWith("session:"))) &&
     (input.payload.kind === "agentTurn" || input.payload.kind === "command")
   ) {
     return { mode: "announce" };

--- a/src/hooks/bundled/session-memory/handler.ts
+++ b/src/hooks/bundled/session-memory/handler.ts
@@ -21,6 +21,7 @@ import {
   resolveAgentIdFromSessionKey,
   toAgentStoreSessionKey,
 } from "../../../routing/session-key.js";
+import { shortenHomePath } from "../../../utils.js";
 import { resolveHookConfig } from "../../config.js";
 import type { HookHandler } from "../../hooks.js";
 import { generateSlugViaLLM } from "../../llm-slug-generator.js";
@@ -249,7 +250,7 @@ async function saveSessionMemoryNow(event: Parameters<HookHandler>[0]): Promise<
     const memoryFilePath = path.join(memoryDir, filename);
     log.debug("Memory file path resolved", {
       filename,
-      path: memoryFilePath.replace(os.homedir(), "~"),
+      path: shortenHomePath(memoryFilePath),
     });
 
     const timeStr = localTimestamp.time;
@@ -282,7 +283,7 @@ async function saveSessionMemoryNow(event: Parameters<HookHandler>[0]): Promise<
     log.debug("Memory file written successfully");
 
     // Log completion (but don't send user-visible confirmation - it's internal housekeeping)
-    const relPath = memoryFilePath.replace(os.homedir(), "~");
+    const relPath = shortenHomePath(memoryFilePath);
     log.info(`Session context saved to ${relPath}`);
   } catch (err) {
     if (err instanceof Error) {


### PR DESCRIPTION
fix: use boundary-aware home path replacement in chrome-mcp and session-memory

- Replace text.split(homePath).join('~') in chrome-mcp.ts with
  replaceHomePathInText() that checks token boundaries, preventing
  sibling path corruption (e.g. /home/user2 -> ~2).
- Replace memoryFilePath.replace(os.homedir(), '~') in session-memory
  handler with the existing safe shortenHomePath() utility.
- Extend resolveInitialCronDelivery to also support 'current' and
  'session:' sessionTarget values, matching the behavior of all other
  cron delivery-plan/normalize/jobs code paths that already treat
  'isolated', 'current', and 'session:' as equivalent.

Real behavior proof:

1. chrome-mcp.ts split().join() sibling corruption:
   Input:  "Error in /home/user2/project: file not found at /home/user/config.json"
   OLD:    "Error in ~2/project: file not found at ~/config.json"  <- corrupted
   NEW:    "Error in /home/user2/project: file not found at ~/config.json"

2. session-memory/handler.ts replace() sibling corruption:
   Input:  "/home/user2/.openclaw/state/memory/test.md" (home=/home/user)
   OLD:    "~2/.openclaw/state/memory/test.md"  <- corrupted
   NEW:    "/home/user2/.openclaw/state/memory/test.md"  <- preserved

3. initial-delivery.ts sessionTarget gap:
   Input:  sessionTarget='current', payload.kind='agentTurn'
   OLD:    undefined  <- missing default announce delivery
   NEW:    {mode:'announce'}  <- matches delivery-plan.ts:106-114,
            normalize.ts:680-684, jobs.ts:288-298