### PR TITLE
fix(android): bracket IPv6 hosts in manual gateway URL composition

### DIFF
--- a/apps/android/app/src/main/java/ai/openclaw/app/ui/GatewayConfigResolver.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/ui/GatewayConfigResolver.kt
@@ -1,6 +1,5 @@
 package ai.openclaw.app.ui
 
-import ai.openclaw.app.gateway.formatGatewayAuthority
 import ai.openclaw.app.gateway.isLocalCleartextGatewayHost
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonObject
@@ -262,7 +261,7 @@ internal fun composeGatewayManualUrl(
     }
   if (port !in 1..65535) return null
   val scheme = if (tls) "https" else "http"
-  return "$scheme://${formatGatewayAuthority(host, port)}"
+  return "$scheme://${ai.openclaw.app.gateway.formatGatewayAuthority(host, port)}"
 }
 
 private fun parseJsonObject(input: String): JsonObject? = runCatching { gatewaySetupJson.parseToJsonElement(input).jsonObject }.getOrNull()

--- a/apps/android/app/src/main/java/ai/openclaw/app/ui/GatewayConfigResolver.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/ui/GatewayConfigResolver.kt
@@ -1,5 +1,6 @@
 package ai.openclaw.app.ui
 
+import ai.openclaw.app.gateway.formatGatewayAuthority
 import ai.openclaw.app.gateway.isLocalCleartextGatewayHost
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonObject
@@ -261,7 +262,7 @@ internal fun composeGatewayManualUrl(
     }
   if (port !in 1..65535) return null
   val scheme = if (tls) "https" else "http"
-  return "$scheme://$host:$port"
+  return "$scheme://${formatGatewayAuthority(host, port)}"
 }
 
 private fun parseJsonObject(input: String): JsonObject? = runCatching { gatewaySetupJson.parseToJsonElement(input).jsonObject }.getOrNull()

--- a/apps/android/app/src/test/java/ai/openclaw/app/ui/GatewayConfigResolverTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/ui/GatewayConfigResolverTest.kt
@@ -608,18 +608,20 @@ class GatewayConfigResolverTest {
 
   @Test
   fun composeGatewayManualUrl_bracketsIpv6ForEndpointParsing() {
-    val url = composeGatewayManualUrl("::1", "18789", tls = false)
+    for (hostInput in listOf("::1", "[::1]")) {
+      val url = composeGatewayManualUrl(hostInput, "18789", tls = false)
 
-    assertEquals("http://[::1]:18789", url)
-    assertEquals(
-      GatewayEndpointConfig(
-        host = "::1",
-        port = 18789,
-        tls = false,
-        displayUrl = "http://[::1]:18789",
-      ),
-      parseGatewayEndpoint(url!!),
-    )
+      assertEquals("http://[::1]:18789", url)
+      assertEquals(
+        GatewayEndpointConfig(
+          host = "::1",
+          port = 18789,
+          tls = false,
+          displayUrl = "http://[::1]:18789",
+        ),
+        parseGatewayEndpoint(url!!),
+      )
+    }
   }
 
   @Test

--- a/apps/android/app/src/test/java/ai/openclaw/app/ui/GatewayConfigResolverTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/ui/GatewayConfigResolverTest.kt
@@ -607,6 +607,22 @@ class GatewayConfigResolverTest {
   }
 
   @Test
+  fun composeGatewayManualUrl_bracketsIpv6ForEndpointParsing() {
+    val url = composeGatewayManualUrl("::1", "18789", tls = false)
+
+    assertEquals("http://[::1]:18789", url)
+    assertEquals(
+      GatewayEndpointConfig(
+        host = "::1",
+        port = 18789,
+        tls = false,
+        displayUrl = "http://[::1]:18789",
+      ),
+      parseGatewayEndpoint(url!!),
+    )
+  }
+
+  @Test
   fun resolveGatewayConnectConfigManualAcceptsTailscaleHostWithoutPort() {
     val resolved =
       resolveGatewayConnectConfig(


### PR DESCRIPTION
## What Problem This Solves

Manual gateway onboarding accepts IPv6 hosts such as `::1`, but `composeGatewayManualUrl` built URLs like `http://::1:18789`, which Java `URI` cannot parse. Users entering IPv6 loopback or LAN addresses in the Host field could not connect even though pasted `ws://[::1]` URLs worked.

## Why This Change Was Made

Reuse the existing `formatGatewayAuthority` helper (already used for WebSocket URLs) when composing manual gateway URLs so IPv6 hosts are bracketed consistently.

## User Impact

Android manual/advanced gateway setup now resolves IPv6 hosts correctly (for example `::1` on port `18789`).

## Evidence

- Added `composeGatewayManualUrl_bracketsIpv6ForEndpointParsing` in `GatewayConfigResolverTest.kt`.
- Proof command (not run locally; no JDK in this environment):

```bash
cd apps/android
./gradlew :app:testPlayDebugUnitTest --tests ai.openclaw.app.ui.GatewayConfigResolverTest.composeGatewayManualUrl_bracketsIpv6ForEndpointParsing
```