### PR TITLE
fix: session status card crashes when model identity has non-string model value

### DIFF
--- a/src/agents/tools/session-status-tool.ts
+++ b/src/agents/tools/session-status-tool.ts
@@ -783,7 +783,7 @@ export function createSessionStatusTool(opts?: {
         (resolved.entry.providerOverride?.trim() || resolved.entry.modelOverride?.trim()),
       );
       const runtimeProviderForCard = runtimeModelIdentity.provider?.trim();
-      const runtimeModelForCard = runtimeModelIdentity.model.trim();
+      const runtimeModelForCard = typeof runtimeModelIdentity.model === "string" ? runtimeModelIdentity.model.trim() : "";
       const defaultProviderForCard = hasExplicitModelOverride
         ? configured.provider
         : (runtimeProviderForCard ?? "");


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where the session status card can crash when the resolved model identity returns a non-string value for the `model` field. Calling `.trim()` on an undefined model value throws a TypeError, preventing the session status card from rendering.

## Why This Change Was Made

The `runtimeModelIdentity` object comes from either `resolveActiveStatusModelIdentity` or `resolveSessionModelIdentityRef`. While TypeScript types declare `model` as `string`, the runtime value can be `undefined` in certain code paths (e.g., when the session entry has no `model` field and fallback resolution does not produce a value). This is an existing type soundness gap. The fix adds a defensive runtime type guard before calling `.trim()`, matching the same defensive pattern used for `runtimeProviderForCard` (which already uses optional chaining for the `provider` field).

## User Impact

Users will no longer see session status card rendering failures when viewing sessions whose model identity lacks a string model field. The card gracefully falls back to an empty string for the model label, keeping the status display functional.

## Evidence

- TypeScript production types pass (`pnpm tsgo:prod`)
- Format check passes (`oxfmt --check`)
- Edge case guarded: `typeof === "string"` check prevents crash on non-string model values
- Test suite passes (`pnpm test:changed`)