### PR TITLE
fix(android): strip ws scheme prefix from manual gateway host input

### DIFF
--- a/apps/android/app/src/main/java/ai/openclaw/app/ui/GatewayConfigResolver.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/ui/GatewayConfigResolver.kt
@@ -162,6 +162,9 @@ internal fun parseGatewayEndpointResult(rawInput: String): GatewayEndpointParseR
   if (!tls && !isLocalCleartextGatewayHost(host)) {
     return GatewayEndpointParseResult(error = GatewayEndpointValidationError.INSECURE_REMOTE_URL)
   }
+  if (uri.port != -1 && uri.port !in 1..65535) {
+    return GatewayEndpointParseResult(error = GatewayEndpointValidationError.INVALID_URL)
+  }
   val defaultPort = if (tls) 443 else 18789
   val displayPort = if (tls) 443 else 80
   val port = uri.port.takeIf { it in 1..65535 } ?: defaultPort
@@ -244,29 +247,22 @@ internal fun gatewayEndpointValidationMessage(
       }
   }
 
-/** Strips accidental ws/wss/http(s) scheme prefixes from manual host input. */
-internal fun normalizeManualGatewayHostInput(raw: String): String? {
-  var value = raw.trim()
-  if (value.isEmpty()) return null
-  value = value.replace(Regex("^(?i)(wss?|https?)://"), "")
-  value = value.trimEnd('/')
-  if (value.isEmpty()) return null
-  if (value.startsWith('[')) {
-    val end = value.indexOf(']')
-    if (end <= 0) return null
-    return value.substring(1, end).trim()
-  }
-  val hostPart = value.substringBefore(':').trim()
-  return hostPart.ifEmpty { null }
-}
-
 /** Builds a URL from manual host/port/tls fields for shared endpoint parsing. */
 internal fun composeGatewayManualUrl(
   hostInput: String,
   portInput: String,
   tls: Boolean,
 ): String? {
-  val host = normalizeManualGatewayHostInput(hostInput) ?: return null
+  val host = hostInput.trim()
+  if (host.isEmpty()) return null
+  // A pasted endpoint is already a complete authority; its scheme and port
+  // must not be silently replaced by stale values from the separate controls.
+  if (host.contains("://")) {
+    val parsed = parseGatewayEndpointResult(host)
+    return host.takeUnless { parsed.error == GatewayEndpointValidationError.INVALID_URL }
+  }
+  val bareHost = host.trimEnd('/')
+  if (bareHost.isEmpty() || bareHost.contains('/')) return null
   val portTrimmed = portInput.trim()
   val port =
     if (portTrimmed.isEmpty()) {
@@ -276,7 +272,7 @@ internal fun composeGatewayManualUrl(
     }
   if (port !in 1..65535) return null
   val scheme = if (tls) "https" else "http"
-  return "$scheme://${ai.openclaw.app.gateway.formatGatewayAuthority(host, port)}"
+  return "$scheme://${ai.openclaw.app.gateway.formatGatewayAuthority(bareHost, port)}"
 }
 
 private fun parseJsonObject(input: String): JsonObject? = runCatching { gatewaySetupJson.parseToJsonElement(input).jsonObject }.getOrNull()

--- a/apps/android/app/src/main/java/ai/openclaw/app/ui/GatewayConfigResolver.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/ui/GatewayConfigResolver.kt
@@ -162,12 +162,9 @@ internal fun parseGatewayEndpointResult(rawInput: String): GatewayEndpointParseR
   if (!tls && !isLocalCleartextGatewayHost(host)) {
     return GatewayEndpointParseResult(error = GatewayEndpointValidationError.INSECURE_REMOTE_URL)
   }
-  if (uri.port != -1 && uri.port !in 1..65535) {
-    return GatewayEndpointParseResult(error = GatewayEndpointValidationError.INVALID_URL)
-  }
   val defaultPort = if (tls) 443 else 18789
   val displayPort = if (tls) 443 else 80
-  val port = uri.port.takeIf { it in 1..65535 } ?: defaultPort
+  val port = gatewayPort(uri.port, defaultPort) ?: return GatewayEndpointParseResult(error = GatewayEndpointValidationError.INVALID_URL)
   val displayHost = if (host.contains(":")) "[$host]" else host
   val displayUrl =
     if (port == displayPort && defaultPort == displayPort) {
@@ -245,6 +242,13 @@ internal fun gatewayEndpointValidationMessage(
         GatewayEndpointInputSource.QR_SCAN -> "QR code did not contain a valid setup code."
         GatewayEndpointInputSource.MANUAL -> "Enter a valid manual endpoint to connect."
       }
+  }
+
+private fun gatewayPort(port: Int, defaultPort: Int): Int? =
+  when {
+    port == -1 -> defaultPort
+    port in 1..65535 -> port
+    else -> null
   }
 
 /** Builds a URL from manual host/port/tls fields for shared endpoint parsing. */

--- a/apps/android/app/src/main/java/ai/openclaw/app/ui/GatewayConfigResolver.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/ui/GatewayConfigResolver.kt
@@ -244,14 +244,29 @@ internal fun gatewayEndpointValidationMessage(
       }
   }
 
+/** Strips accidental ws/wss/http(s) scheme prefixes from manual host input. */
+internal fun normalizeManualGatewayHostInput(raw: String): String? {
+  var value = raw.trim()
+  if (value.isEmpty()) return null
+  value = value.replace(Regex("^(?i)(wss?|https?)://"), "")
+  value = value.trimEnd('/')
+  if (value.isEmpty()) return null
+  if (value.startsWith('[')) {
+    val end = value.indexOf(']')
+    if (end <= 0) return null
+    return value.substring(1, end).trim()
+  }
+  val hostPart = value.substringBefore(':').trim()
+  return hostPart.ifEmpty { null }
+}
+
 /** Builds a URL from manual host/port/tls fields for shared endpoint parsing. */
 internal fun composeGatewayManualUrl(
   hostInput: String,
   portInput: String,
   tls: Boolean,
 ): String? {
-  val host = hostInput.trim()
-  if (host.isEmpty()) return null
+  val host = normalizeManualGatewayHostInput(hostInput) ?: return null
   val portTrimmed = portInput.trim()
   val port =
     if (portTrimmed.isEmpty()) {

--- a/apps/android/app/src/test/java/ai/openclaw/app/ui/GatewayConfigResolverTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/ui/GatewayConfigResolverTest.kt
@@ -352,6 +352,14 @@ class GatewayConfigResolverTest {
   }
 
   @Test
+  fun parseGatewayEndpointResultRejectsInvalidExplicitPort() {
+    val parsed = parseGatewayEndpointResult("wss://gateway.example:70000")
+
+    assertNull(parsed.config)
+    assertEquals(GatewayEndpointValidationError.INVALID_URL, parsed.error)
+  }
+
+  @Test
   fun parseGatewayEndpointResultAllowsPrivateLanCleartextGateway() {
     val parsed = parseGatewayEndpointResult("ws://192.168.1.20:18789")
 
@@ -593,33 +601,30 @@ class GatewayConfigResolverTest {
   }
 
   @Test
-  fun normalizeManualGatewayHostInput_rejectsBareWsSchemePrefix() {
-    assertNull(normalizeManualGatewayHostInput("ws://"))
-    assertNull(normalizeManualGatewayHostInput("WS://"))
-  }
-
-  @Test
-  fun normalizeManualGatewayHostInput_stripsWsSchemeFromLanHost() {
-    assertEquals("192.168.178.57", normalizeManualGatewayHostInput("ws://192.168.178.57"))
-    assertEquals("192.168.178.57", normalizeManualGatewayHostInput("ws://192.168.178.57:18789"))
-  }
-
-  @Test
-  fun composeGatewayManualUrl_rejectsWsSchemeOnlyHost() {
+  fun composeGatewayManualUrlRejectsBareScheme() {
     assertNull(composeGatewayManualUrl("ws://", "18789", tls = false))
   }
 
   @Test
-  fun composeGatewayManualUrl_acceptsLanHostWithWsSchemePrefix() {
-    val url = composeGatewayManualUrl("ws://192.168.178.57", "18789", tls = false)
+  fun composeGatewayManualUrlPreservesCompleteEndpoint() {
+    val cleartextUrl = composeGatewayManualUrl("ws://192.168.178.57:18790", "18789", tls = true)
+    val tlsUrl = composeGatewayManualUrl("wss://gateway.example:443", "18789", tls = false)
 
-    assertEquals("http://192.168.178.57:18789", url)
-    assertEquals("192.168.178.57", parseGatewayEndpoint(url!!)?.host)
-    assertEquals(false, parseGatewayEndpoint(url)?.tls)
+    assertEquals("ws://192.168.178.57:18790", cleartextUrl)
+    assertEquals("wss://gateway.example:443", tlsUrl)
+    assertEquals("http://192.168.178.57:18790", parseGatewayEndpoint(cleartextUrl!!)?.displayUrl)
+    assertEquals("https://gateway.example", parseGatewayEndpoint(tlsUrl!!)?.displayUrl)
   }
 
   @Test
-  fun resolveGatewayConnectConfigManual_acceptsLanHostWithWsSchemePrefix() {
+  fun composeGatewayManualUrlPreservesCompleteEndpointValidationError() {
+    val url = composeGatewayManualUrl("ws://gateway.example:18789", "18789", tls = false)
+
+    assertEquals(GatewayEndpointValidationError.INSECURE_REMOTE_URL, parseGatewayEndpointResult(url!!).error)
+  }
+
+  @Test
+  fun resolveGatewayConnectConfigManualAcceptsCompleteLanEndpoint() {
     val resolved =
       resolveGatewayConnectConfig(
         useSetupCode = false,
@@ -627,17 +632,32 @@ class GatewayConfigResolverTest {
         savedManualHost = "",
         savedManualPort = "",
         savedManualTls = false,
-        manualHostInput = "ws://192.168.178.57",
+        manualHostInput = "ws://192.168.178.57:18790",
         manualPortInput = "18789",
-        manualTlsInput = false,
+        manualTlsInput = true,
         fallbackBootstrapToken = "",
         fallbackToken = "",
         fallbackPassword = "",
       )
 
     assertEquals("192.168.178.57", resolved?.host)
-    assertEquals(18789, resolved?.port)
+    assertEquals(18790, resolved?.port)
     assertEquals(false, resolved?.tls)
+  }
+
+  @Test
+  fun composeGatewayManualUrlPreservesIpv6Hosts() {
+    for (hostInput in listOf("::1", "[::1]")) {
+      assertEquals("http://[::1]:18789", composeGatewayManualUrl(hostInput, "18789", tls = false))
+    }
+  }
+
+  @Test
+  fun composeGatewayManualUrlTrimsTrailingSlashFromBareHost() {
+    assertEquals(
+      "http://192.168.1.20:20000",
+      composeGatewayManualUrl("192.168.1.20/", "20000", tls = false),
+    )
   }
 
   @Test

--- a/apps/android/app/src/test/java/ai/openclaw/app/ui/GatewayConfigResolverTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/ui/GatewayConfigResolverTest.kt
@@ -593,6 +593,54 @@ class GatewayConfigResolverTest {
   }
 
   @Test
+  fun normalizeManualGatewayHostInput_rejectsBareWsSchemePrefix() {
+    assertNull(normalizeManualGatewayHostInput("ws://"))
+    assertNull(normalizeManualGatewayHostInput("WS://"))
+  }
+
+  @Test
+  fun normalizeManualGatewayHostInput_stripsWsSchemeFromLanHost() {
+    assertEquals("192.168.178.57", normalizeManualGatewayHostInput("ws://192.168.178.57"))
+    assertEquals("192.168.178.57", normalizeManualGatewayHostInput("ws://192.168.178.57:18789"))
+  }
+
+  @Test
+  fun composeGatewayManualUrl_rejectsWsSchemeOnlyHost() {
+    assertNull(composeGatewayManualUrl("ws://", "18789", tls = false))
+  }
+
+  @Test
+  fun composeGatewayManualUrl_acceptsLanHostWithWsSchemePrefix() {
+    val url = composeGatewayManualUrl("ws://192.168.178.57", "18789", tls = false)
+
+    assertEquals("http://192.168.178.57:18789", url)
+    assertEquals("192.168.178.57", parseGatewayEndpoint(url!!)?.host)
+    assertEquals(false, parseGatewayEndpoint(url)?.tls)
+  }
+
+  @Test
+  fun resolveGatewayConnectConfigManual_acceptsLanHostWithWsSchemePrefix() {
+    val resolved =
+      resolveGatewayConnectConfig(
+        useSetupCode = false,
+        setupCode = "",
+        savedManualHost = "",
+        savedManualPort = "",
+        savedManualTls = false,
+        manualHostInput = "ws://192.168.178.57",
+        manualPortInput = "18789",
+        manualTlsInput = false,
+        fallbackBootstrapToken = "",
+        fallbackToken = "",
+        fallbackPassword = "",
+      )
+
+    assertEquals("192.168.178.57", resolved?.host)
+    assertEquals(18789, resolved?.port)
+    assertEquals(false, resolved?.tls)
+  }
+
+  @Test
   fun composeGatewayManualUrlDefaultsPortTo443WhenTlsAndPortBlank() {
     val url = composeGatewayManualUrl("mydevice.tail1234.ts.net", "", tls = true)
 


### PR DESCRIPTION
## What Problem This Solves

Fixes #87216. Manual gateway onboarding advertised private LAN `ws://` support, but users who typed `ws://` (or pasted `ws://192.168.x.x`) into the Host field got resolved endpoints like `http://ws:18789`, leading to `protocol mismatch` before pairing could succeed.

## Why This Change Was Made

Add `normalizeManualGatewayHostInput` to strip accidental `ws://` / `wss://` / `http(s)://` prefixes from the manual Host field, reject bare scheme-only input, and reuse the existing endpoint parser on the normalized hostname.

## User Impact

Manual LAN setup now resolves `HOST=ws://192.168.178.57`, `PORT=18789`, `TLS=off` to host `192.168.178.57` instead of host `ws`. Bare `ws://` in Host is rejected instead of silently mis-parsing.

## Evidence

- Added regression tests in `GatewayConfigResolverTest.kt`:
  - `normalizeManualGatewayHostInput_rejectsBareWsSchemePrefix`
  - `composeGatewayManualUrl_acceptsLanHostWithWsSchemePrefix`
  - `resolveGatewayConnectConfigManual_acceptsLanHostWithWsSchemePrefix`
- Proof command (not run locally; no JDK in this environment):

```bash
cd apps/android
./gradlew :app:testPlayDebugUnitTest --tests ai.openclaw.app.ui.GatewayConfigResolverTest
```