### PR TITLE
fix(browser): use boundary-aware home path replacement in chrome-mcp diagnostics

### DIFF
--- a/extensions/browser/src/browser/chrome-mcp.ts
+++ b/extensions/browser/src/browser/chrome-mcp.ts
@@ -496,10 +496,44 @@ function redactChromeMcpDiagnosticText(text: string): string {
   );
 }
 
+/** Replace home-path occurrences in diagnostic text without clipping sibling prefixes. */
+function replaceHomePathInText(text: string, homePath: string): string {
+  let output = "";
+  let cursor = 0;
+  while (cursor < text.length) {
+    const index = text.indexOf(homePath, cursor);
+    if (index < 0) {
+      return `${output}${text.slice(cursor)}`;
+    }
+    const before = text[index - 1];
+    const homeEnd = index + homePath.length;
+    const after = text[homeEnd];
+    // home-path match must start at a token boundary to avoid rewriting sibling
+    // paths that happen to share the home prefix (e.g. /home/user2 vs /home/user).
+    const startsToken = before === undefined || /[\s("'`:=[{,]/u.test(before);
+    let punctuationEnd = homeEnd;
+    while (punctuationEnd < text.length && /[)"'`:,;.\]}]/u.test(text[punctuationEnd])) {
+      punctuationEnd += 1;
+    }
+    const punctuationEndsToken =
+      punctuationEnd > homeEnd &&
+      (punctuationEnd === text.length || /\s/u.test(text[punctuationEnd]));
+    const endsTokenOrContinuesPath =
+      after === undefined || after === "/" || after === "\\" || punctuationEndsToken;
+    if (startsToken && endsTokenOrContinuesPath) {
+      output += `${text.slice(cursor, index)}~`;
+    } else {
+      output += text.slice(cursor, index + homePath.length);
+    }
+    cursor = index + homePath.length;
+  }
+  return output;
+}
+
 function redactChromeMcpDiagnosticTextWithLocalPaths(text: string): string {
   const homeDir = normalizeOptionalString(os.homedir());
   const homePath = homeDir ? path.resolve(homeDir) : undefined;
-  const withHomeRedacted = homePath ? text.split(homePath).join("~") : text;
+  const withHomeRedacted = homePath ? replaceHomePathInText(text, homePath) : text;
   return redactChromeMcpDiagnosticText(withHomeRedacted);
 }
 


### PR DESCRIPTION
## What Problem This Solves

`redactChromeMcpDiagnosticTextWithLocalPaths` uses `text.split(homePath).join("~")` to redact home paths in Chrome MCP diagnostic output. This naive replacement corrupts sibling paths that share the home prefix. For example, with `HOME=/home/user`, the path `/home/user2/project/config.json` is corrupted to `~2/project/config.json`.

## Why This Change Was Made

The replacement `replaceHomePathInText()` function checks token boundaries before substituting, matching the same contract as the `shortenHomePath` utility in `src/utils.ts`. It verifies both the character before the match (must be a token boundary: whitespace, quotes, brackets, etc.) and the character after (must be a path separator, token boundary, or end-of-string) before replacing.

## Evidence

### Real behavior proof

With `HOME=/home/user`:

```
Input:  "Error in /home/user2/project: file not found at /home/user/config.json"
OLD:    "Error in ~2/project: file not found at ~/config.json"  ← corrupted
NEW:    "Error in /home/user2/project: file not found at ~/config.json"
```

### CI test results

All browser extension tests pass, including existing Chrome MCP diagnostic tests.

## Risk

Low. The new `replaceHomePathInText` function is scoped to Chrome MCP diagnostics only. It does not affect any other code path. Token-boundary checking prevents the sibling-path corruption while preserving correct home-path redaction.
