### PR TITLE
refactor: remove redundant type assertions and redundant UI esc label

### DIFF
--- a/src/cron/service/store.ts
+++ b/src/cron/service/store.ts
@@ -106,7 +106,7 @@ export async function ensureLoaded(
   const loaded = await loadCronJobsStoreWithConfigJobs(state.deps.storePath);
   // Persisted cron rows are validated lazily, so treat them as raw records at the
   // store boundary and only trust the CronJob shape after validation below.
-  const loadedJobs = (loaded.store.jobs ?? []) as unknown as Record<string, unknown>[];
+  const loadedJobs: Record<string, unknown>[] = loaded.store.jobs ?? [];
   const jobs: CronJob[] = [];
   const quarantinedConfigJobs: QuarantinedCronConfigJob[] = [...loaded.invalidConfigRows];
   for (const [index, raw] of loadedJobs.entries()) {
@@ -155,7 +155,7 @@ export async function ensureLoaded(
       continue;
     }
     // Validated above, so the raw record is now a trusted CronJob.
-    const hydrated = hydratedRaw as unknown as CronJob;
+    const hydrated = hydratedRaw as CronJob;
     jobs.push(hydrated);
     invalidateStaleNextRunOnScheduleChange({ previousJobsById, hydrated });
   }

--- a/src/cron/store/row-codec.ts
+++ b/src/cron/store/row-codec.ts
@@ -143,13 +143,13 @@ function bindCronJobRow(storeKey: string, job: CronJob, sortOrder: number): Cron
     job_json: JSON.stringify(stripJobRuntimeFields(job)),
     state_json: JSON.stringify(job.state ?? {}),
     runtime_updated_at_ms: job.updatedAtMs,
-    schedule_identity: tryCronScheduleIdentity(job as unknown as Record<string, unknown>) ?? null,
+    schedule_identity: tryCronScheduleIdentity(job as Record<string, unknown>) ?? null,
     sort_order: sortOrder,
   };
 }
 
 function normalizeCronJobForSqlite(job: CronStoreFile["jobs"][number]): CronJob | null {
-  const raw = structuredClone(job) as unknown as Record<string, unknown>;
+  const raw: Record<string, unknown> = structuredClone(job);
   const hadDeleteAfterRun = Object.hasOwn(raw, "deleteAfterRun");
   normalizeCronJobIdentityFields(raw);
   const normalized = normalizeCronJobInput(raw, { applyDefaults: true });
@@ -292,7 +292,7 @@ export function updateCronRuntimeRows(
           ...bindStateColumns(job.state ?? {}),
           state_json: JSON.stringify(job.state ?? {}),
           runtime_updated_at_ms: job.updatedAtMs,
-          schedule_identity: tryCronScheduleIdentity(job as unknown as Record<string, unknown>),
+          schedule_identity: tryCronScheduleIdentity(job as Record<string, unknown>),
         })
         .where("store_key", "=", storeKey)
         .where("job_id", "=", job.id),

--- a/ui/src/ui/components/file-preview-modal.ts
+++ b/ui/src/ui/components/file-preview-modal.ts
@@ -124,18 +124,10 @@ export class OpenClawFilePreviewModal extends LitElement {
       background: var(--bg-elevated);
     }
 
-    .esc,
     .kbd {
       font-family: var(--mono);
       border: 1px solid var(--border);
       color: var(--muted);
-    }
-
-    .esc {
-      font-size: 10px;
-      padding: 1px 5px;
-      border-radius: 3px;
-      background: var(--bg);
     }
 
     .body {
@@ -404,7 +396,7 @@ export class OpenClawFilePreviewModal extends LitElement {
             @input=${this.handleQueryInput}
             autofocus
           />
-          <span class="state">${fileCount} <span class="esc">esc</span></span>
+          <span class="state">${fileCount}</span>
         </header>
         <div class="body">
           <aside class="list">


### PR DESCRIPTION
Closes #99018, #99027

## What Problem This Solves

Two code quality issues:

1. **Redundant type assertions** (`#99018`): `src/cron/service/store.ts` and `src/cron/store/row-codec.ts` contain unnecessary `as unknown as` intermediate type assertions that reduce type safety by bypassing compiler checks.

2. **Redundant UI label** (`#99027`): In the Skill Workshop file preview modal, the header bar displays a redundant "esc" badge next to the file count, while the footer already has an "esc" label on the Close button.

## Why This Change Was Made

- For the type assertions: Since `CronJob extends object` and `object` is assignable to `Record<string, unknown>`, the intermediate `as unknown as` casts are unnecessary. Replaced with direct type annotations or simpler `as` assertions.
- For the UI: The "esc" badge in the header was placed inside the file-count display without a valid reason. Removed the redundant `<span>` and its CSS rules.

## User Impact

- No runtime impact (pure code quality improvements)
- Better type safety in cron subsystem
- Cleaner UI with no confusing duplicate keyboard shortcut hint

## Evidence

- TypeScript production types pass (`pnpm tsgo:prod`)
- Format check passes (`oxfmt --check`)
- No behavior changes