### PR TITLE
test(windows-encoding): add boundary tests for parseWindowsCodePage

### DIFF
--- a/src/infra/windows-encoding.test.ts
+++ b/src/infra/windows-encoding.test.ts
@@ -14,6 +14,34 @@ describe("windows output encoding", () => {
     expect(parseWindowsCodePage("no code page")).toBeNull();
   });
 
+  describe("parseWindowsCodePage", () => {
+    it("returns null for empty or whitespace-only input", () => {
+      expect(parseWindowsCodePage("")).toBeNull();
+      expect(parseWindowsCodePage("   ")).toBeNull();
+    });
+
+    it("rejects 1-2 digit numbers that are too short for a valid code page", () => {
+      expect(parseWindowsCodePage("Active code page: 0")).toBeNull();
+      expect(parseWindowsCodePage("Active code page: 12")).toBeNull();
+    });
+
+    it("accepts valid 3-5 digit code pages at the boundaries", () => {
+      expect(parseWindowsCodePage("Active code page: 437")).toBe(437);
+      expect(parseWindowsCodePage("Active code page: 54936")).toBe(54936);
+    });
+
+    it("extracts the first 3-5 digit number from multi-line text", () => {
+      expect(parseWindowsCodePage("line1\nActive code page: 936\nline3")).toBe(936);
+      expect(parseWindowsCodePage("error line\nActive code page: 1252\nsome error")).toBe(1252);
+    });
+
+    it("returns null when no 3-5 digit number is present", () => {
+      expect(parseWindowsCodePage("Active code page:")).toBeNull();
+      expect(parseWindowsCodePage("some text without numbers")).toBeNull();
+      expect(parseWindowsCodePage("1234567")).toBeNull(); // 6+ digits won't match
+    });
+  });
+
   it("decodes GBK output on Windows when UTF-8 is invalid and code page is known", () => {
     const raw = Buffer.from([0xb2, 0xe2, 0xca, 0xd4, 0xa1, 0xab, 0xa3, 0xbb]);
 


### PR DESCRIPTION
## What Problem This Solves

The `parseWindowsCodePage` helper in `src/infra/windows-encoding.ts` extracts Windows console code page numbers (3-5 digits) from localized `chcp` output. The existing test only covers two happy-path locales and one negative case. Edge cases around input boundaries — empty strings, too-short numbers, multi-line output — had no coverage.

## Why This Change Was Made

Adding focused boundary tests improves confidence that the helper correctly rejects invalid inputs before they reach downstream encoding resolution (`resolveWindowsConsoleEncoding`, `resolveWindowsSystemEncoding`).

## Changes

- **`src/infra/windows-encoding.test.ts`** — add `describe("parseWindowsCodePage")` with 5 focused test cases covering empty/whitespace input, 1-2 digit rejection, 3-5 digit boundary acceptance, multi-line extraction, and absence of valid code page digits

## Evidence

Reproducibility: not applicable. This PR adds direct coverage for existing utility behavior rather than reporting a user-visible runtime bug. Source inspection confirms the utility behavior the tests target.

Direct behavior probe (no mocks — real functions exercised directly):

```text
$ node --import tsx -e "import('./src/infra/windows-encoding.js').then((m) => { ... })"
[
  { "input": "Active code page: 936", "expected": 936, "result": 936 },
  { "input": "活动代码页: 65001", "expected": 65001, "result": 65001 },
  { "input": "no code page", "expected": null, "result": null },
  { "input": "(empty string)", "expected": null, "result": null },
  { "input": "   (whitespace)", "expected": null, "result": null },
  { "input": "Active code page: 0", "expected": null, "result": null },
  { "input": "Active code page: 12", "expected": null, "result": null },
  { "input": "Active code page: 437", "expected": 437, "result": 437 },
  { "input": "Active code page: 54936", "expected": 54936, "result": 54936 },
  { "input": "multi-line with code page", "expected": 936, "result": 936 },
  { "input": "1234567 (6+ digits)", "expected": null, "result": null },
  { "input": "some text without numbers", "expected": null, "result": null }
]

All assertions passed: true
```

## Related

N/A (self-contained test coverage improvement)

🤖 Generated with [Claude Code](https://claude.com/claude-code)