### PR TITLE
fix: deleting a session leaves its trajectory artifacts orphaned on disk

### DIFF
--- a/src/agents/agent-command.live-model-switch.test.ts
+++ b/src/agents/agent-command.live-model-switch.test.ts
@@ -3145,11 +3145,13 @@ describe("agentCommand – LiveSessionModelSwitchError retry", () => {
       sessionId: "session-1",
       sessionFile: "/tmp/openclaw-internal-model-run-success.jsonl",
       storePath: "/tmp/openclaw-internal-model-run-success.jsonl",
+      disposal: { mode: "delete" },
     });
     expect(state.removeSessionTrajectoryArtifactsMock).toHaveBeenCalledWith({
       sessionId: "rotated-model-run-session",
       sessionFile: "/tmp/openclaw-internal-rotated.jsonl",
       storePath: "/tmp/openclaw-internal-rotated.jsonl",
+      disposal: { mode: "delete" },
     });
     expect(state.removeInternalSessionEffectsTranscriptMock).toHaveBeenCalledWith(
       "/tmp/openclaw-internal-model-run-success.jsonl",

--- a/src/agents/agent-command.ts
+++ b/src/agents/agent-command.ts
@@ -2097,7 +2097,7 @@ async function agentCommandInternal(
       let liveSwitchRetries = 0;
       let autoFallbackPrimaryProbeInterruptedByLiveSwitch = false;
       const fastModeStartedAtMs = Date.now();
-      const fallbackTrajectoryRecorder = createTrajectoryRuntimeRecorder({
+      const fallbackTrajectoryRecorder = await createTrajectoryRuntimeRecorder({
         cfg,
         runId,
         sessionId,

--- a/src/agents/agent-command.ts
+++ b/src/agents/agent-command.ts
@@ -2759,6 +2759,11 @@ async function agentCommandInternal(
             sessionId: artifact.sessionId,
             sessionFile: artifact.sessionFile,
             storePath: artifact.sessionFile,
+            // A private internal-run scratch transcript, never archived (its
+            // own removeInternalSessionEffectsTranscript unlinks it outright
+            // for privacy/disk reasons below) — its trajectory pair must not
+            // outlive it as a lingering tombstone in an unswept directory.
+            disposal: { mode: "delete" },
           });
         } catch (error) {
           log.warn(

--- a/src/agents/embedded-agent-runner/run/attempt.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.ts
@@ -2403,7 +2403,7 @@ export async function runEmbeddedAttempt(
 
     let session: Awaited<ReturnType<typeof createAgentSession>>["session"] | undefined;
     let removeToolResultContextGuard: (() => void) | undefined;
-    let trajectoryRecorder: ReturnType<typeof createTrajectoryRuntimeRecorder> | null = null;
+    let trajectoryRecorder: Awaited<ReturnType<typeof createTrajectoryRuntimeRecorder>> = null;
     let trajectoryEndRecorded = false;
     let buildAbortSettlePromise: () => Promise<void> | null = () => null;
     let cleanupYieldAborted = false;
@@ -3067,7 +3067,7 @@ export async function runEmbeddedAttempt(
         modelApi: params.model.api,
         workspaceDir: params.workspaceDir,
       });
-      trajectoryRecorder = createTrajectoryRuntimeRecorder({
+      trajectoryRecorder = await createTrajectoryRuntimeRecorder({
         cfg: params.config,
         env: process.env,
         runId: params.runId,

--- a/src/auto-reply/reply/session.test.ts
+++ b/src/auto-reply/reply/session.test.ts
@@ -1192,6 +1192,102 @@ describe("initSessionState RawBody", () => {
     expect(peekSystemEvents(existingSessionId)).toStrictEqual([]);
   });
 
+  it("tombstones the previous session's trajectory pair on a typed /reset, entering through the real initSessionState command path", async () => {
+    // Reproduces a live production failure observed on v2026.6.10: a typed
+    // /reset in webchat tombstoned
+    // the transcript but left the trajectory pair bare, with zero
+    // trajectory/cleanup/error log lines. persistSessionResetLifecycle (the
+    // function the previous fix round patched) is only ever reached from
+    // agent-runner.ts's internal role-ordering-conflict self-heal — never
+    // from a user-typed command. Every typed /new and /reset, and every
+    // implicit daily/idle rollover, actually goes through initSessionState
+    // (this file) -> commitReplySessionInitialization
+    // (config/sessions/session-accessor.ts), which previously called
+    // archivePreviousSessionTranscript and nothing else: zero trajectory
+    // coupling. This test enters through initSessionState itself, the real
+    // command-level path a typed /reset takes, not the inner lifecycle
+    // function directly.
+    const root = await makeCaseDir("openclaw-typed-reset-trajectory-");
+    const storePath = path.join(root, "sessions.json");
+    const sessionKey = "agent:main:webchat:direct:uuid:typed-reset-trajectory";
+    const existingSessionId = "session-with-live-trajectory";
+    const previousTranscript = path.join(root, `${existingSessionId}.jsonl`);
+
+    await fs.writeFile(
+      previousTranscript,
+      `${JSON.stringify({ type: "session", id: existingSessionId })}\n`,
+      "utf-8",
+    );
+    await writeSessionStoreFast(storePath, {
+      [sessionKey]: {
+        sessionId: existingSessionId,
+        sessionFile: previousTranscript,
+        updatedAt: Date.now(),
+        systemSent: true,
+      },
+    });
+
+    const { resolveTrajectoryFilePath, resolveTrajectoryPointerFilePath } =
+      await import("../../trajectory/paths.js");
+    const { createTrajectoryRuntimeRecorder } = await import("../../trajectory/runtime.js");
+    const { clearTrajectoryWriterLifecycleRegistryForTest } =
+      await import("../../trajectory/writer-lifecycle.js");
+
+    const runtimeFile = resolveTrajectoryFilePath({
+      sessionFile: previousTranscript,
+      sessionId: existingSessionId,
+    });
+    const pointerPath = resolveTrajectoryPointerFilePath(previousTranscript);
+    const recorder = await createTrajectoryRuntimeRecorder({
+      sessionId: existingSessionId,
+      sessionFile: previousTranscript,
+    });
+    if (!recorder) {
+      throw new Error("expected trajectory runtime recorder");
+    }
+    recorder.recordEvent("prompt.submitted", { marker: "before-typed-reset" });
+    await recorder.flush();
+    await expect(fs.stat(runtimeFile)).resolves.toBeDefined();
+    await expect(fs.stat(pointerPath)).resolves.toBeDefined();
+
+    const cfg = {
+      session: {
+        store: storePath,
+        resetTriggers: ["/reset"],
+      },
+    } as OpenClawConfig;
+
+    try {
+      const result = await initSessionState({
+        ctx: {
+          RawBody: "/reset",
+          ChatType: "direct",
+          SessionKey: sessionKey,
+          Surface: "webchat",
+        },
+        cfg,
+        commandAuthorized: true,
+      });
+
+      expect(result.isNewSession).toBe(true);
+      expect(result.resetTriggered).toBe(true);
+      expect(result.sessionId).not.toBe(existingSessionId);
+
+      await expect(fs.stat(runtimeFile)).rejects.toThrow();
+      await expect(fs.stat(pointerPath)).rejects.toThrow();
+      const tombstones = (await fs.readdir(root)).filter((file) =>
+        file.startsWith(`${path.basename(runtimeFile)}.reset.`),
+      );
+      const pointerTombstones = (await fs.readdir(root)).filter((file) =>
+        file.startsWith(`${path.basename(pointerPath)}.reset.`),
+      );
+      expect(tombstones).toHaveLength(1);
+      expect(pointerTombstones).toHaveLength(1);
+    } finally {
+      clearTrajectoryWriterLifecycleRegistryForTest();
+    }
+  });
+
   it("preserves a user model override across an implicit daily stale rollover (#90119)", async () => {
     // Regression: a user-set /model override persisted on a session that then
     // goes stale at the daily reset boundary must survive the implicit

--- a/src/config/sessions/session-accessor.test.ts
+++ b/src/config/sessions/session-accessor.test.ts
@@ -56,6 +56,7 @@ import {
 } from "./session-accessor.js";
 import * as sessionStore from "./store.js";
 import { loadSessionStore, saveSessionStore, updateSessionStoreEntry } from "./store.js";
+import * as transcriptReplay from "./transcript-replay.js";
 import { withOwnedSessionTranscriptWrites } from "./transcript-write-context.js";
 import type { SessionEntry } from "./types.js";
 
@@ -2106,6 +2107,103 @@ describe("session accessor file-backed seam", () => {
       expect(lateLease.filePath).not.toBe(runtimeFile);
       expect(fs.existsSync(runtimeFile)).toBe(false);
     } finally {
+      clearTrajectoryWriterLifecycleRegistryForTest();
+    }
+  });
+
+  it("tombstones the previous session's trajectory pair even when a concurrent writer races the store swap with its own row for the same previous session id", async () => {
+    // Reproduces a live production failure observed on v2026.6.10: typed
+    // /reset tombstoned the transcript but left the trajectory pair bare,
+    // with no error in the gateway log, while a hook cascade (self-
+    // improvement, memory-reflection) ran normally in the same window. Root
+    // cause: persistSessionResetLifecycle computed its referenced-sessions
+    // guard via a SEPARATE, unlocked loadSessionStore call made well after
+    // the store swap's own exclusive lock had already released — a
+    // concurrent writer (e.g. a post-turn hook still persisting its own
+    // metadata under the pre-reset session identity) could land a store
+    // write in that window and make the previous session look "still
+    // referenced" when it was not at the moment of the swap, silently
+    // vetoing the tombstone. This simulates exactly that: a write lands
+    // during replayRecentUserAssistantMessages, the first await after the
+    // store swap.
+    const now = Date.now();
+    const sessionKey = "agent:main:main";
+    const previousTranscript = path.join(tempDir, "previous-race2-session.jsonl");
+    const nextTranscript = path.join(tempDir, "next-race2-session.jsonl");
+    const previousEntry: SessionEntry = {
+      sessionFile: previousTranscript,
+      sessionId: "previous-race2-session",
+      updatedAt: now,
+    };
+    const nextEntry: SessionEntry = {
+      sessionFile: nextTranscript,
+      sessionId: "next-race2-session",
+      updatedAt: now + 1,
+    };
+    fs.writeFileSync(
+      previousTranscript,
+      `${JSON.stringify({ type: "session", id: "previous-race2-session" })}\n`,
+      "utf-8",
+    );
+    await upsertSessionEntry({ sessionKey, storePath }, previousEntry);
+
+    const runtimeFile = resolveTrajectoryFilePath({
+      sessionFile: previousTranscript,
+      sessionId: previousEntry.sessionId,
+    });
+    const pointerPath = resolveTrajectoryPointerFilePath(previousTranscript);
+    const recorder = await createTrajectoryRuntimeRecorder({
+      sessionId: previousEntry.sessionId,
+      sessionFile: previousTranscript,
+    });
+    if (!recorder) {
+      throw new Error("expected trajectory runtime recorder");
+    }
+    recorder.recordEvent("prompt.submitted", { marker: "before-reset" });
+    await recorder.flush();
+    expect(fs.existsSync(runtimeFile)).toBe(true);
+
+    const realReplay = transcriptReplay.replayRecentUserAssistantMessages;
+    const replaySpy = vi
+      .spyOn(transcriptReplay, "replayRecentUserAssistantMessages")
+      .mockImplementationOnce(async (replayParams) => {
+        // Simulates a racing hook: it captured the pre-reset session
+        // identity before the swap landed, and only persists its own store
+        // row (under a DIFFERENT sessionKey, same old sessionId) after —
+        // right in the window this function's own store swap already
+        // released its lock but before this function decides whether the
+        // trajectory pair is still referenced.
+        await upsertSessionEntry(
+          { sessionKey: "agent:main:hook-race", storePath },
+          { sessionId: previousEntry.sessionId, updatedAt: Date.now() },
+        );
+        return await realReplay(replayParams);
+      });
+
+    try {
+      await persistSessionResetLifecycle({
+        agentId: "main",
+        cleanupPreviousTranscript: true,
+        nextEntry,
+        nextSessionFile: nextTranscript,
+        previousEntry,
+        previousSessionId: previousEntry.sessionId,
+        sessionKey,
+        storePath,
+      });
+
+      // The trajectory pair must still tombstone: at the instant of the
+      // store swap, previousSessionId was not referenced by anything else —
+      // the racing hook's write landing afterward must not retroactively
+      // veto that decision.
+      expect(fs.existsSync(runtimeFile)).toBe(false);
+      expect(fs.existsSync(pointerPath)).toBe(false);
+      const runtimeTombstones = fs
+        .readdirSync(tempDir)
+        .filter((file) => file.startsWith(`${path.basename(runtimeFile)}.reset.`));
+      expect(runtimeTombstones).toHaveLength(1);
+    } finally {
+      replaySpy.mockRestore();
       clearTrajectoryWriterLifecycleRegistryForTest();
     }
   });

--- a/src/config/sessions/session-accessor.test.ts
+++ b/src/config/sessions/session-accessor.test.ts
@@ -6,6 +6,15 @@ import { SessionManager } from "../../agents/sessions/session-manager.js";
 import type { MsgContext } from "../../auto-reply/templating.js";
 import { onSessionTranscriptUpdate } from "../../sessions/transcript-events.js";
 import { createCanonicalFixtureSkill } from "../../skills/test-support/test-helpers.js";
+import {
+  resolveTrajectoryFilePath,
+  resolveTrajectoryPointerFilePath,
+} from "../../trajectory/paths.js";
+import { createTrajectoryRuntimeRecorder } from "../../trajectory/runtime.js";
+import {
+  acquireTrajectoryWriterLease,
+  clearTrajectoryWriterLifecycleRegistryForTest,
+} from "../../trajectory/writer-lifecycle.js";
 import type { OpenClawConfig } from "../types.openclaw.js";
 import {
   applySessionEntryReplacements,
@@ -2013,6 +2022,92 @@ describe("session accessor file-backed seam", () => {
     );
     expect(fs.readFileSync(archivedPreviousTranscript, "utf-8")).toContain('"content":"hi"');
     expect(fs.readFileSync(nextTranscript, "utf-8")).toContain('"content":"hello"');
+  });
+
+  it("tombstones the previous session's trajectory pair during a runner-driven reset, and blocks a late straggler from resurrecting it", async () => {
+    // Reproduces the fleet divergence: the runner-driven reset (typed
+    // in-conversation /reset, agent-runner-session-reset.ts ->
+    // persistSessionResetLifecycle) used to persist its own store swap and
+    // transcript archive without ever routing through
+    // resetSessionEntryLifecycle in store.ts, so it never touched the
+    // previous session's trajectory pair at all — unlike the gateway RPC
+    // reset path (webchat "New chat" -> session-reset-service.ts ->
+    // resetSessionEntryLifecycle), which correctly tombstones it.
+    const now = Date.now();
+    const sessionKey = "agent:main:main";
+    const previousTranscript = path.join(tempDir, "previous-trajectory-session.jsonl");
+    const nextTranscript = path.join(tempDir, "next-trajectory-session.jsonl");
+    const previousEntry: SessionEntry = {
+      sessionFile: previousTranscript,
+      sessionId: "previous-trajectory-session",
+      updatedAt: now,
+    };
+    const nextEntry: SessionEntry = {
+      sessionFile: nextTranscript,
+      sessionId: "next-trajectory-session",
+      updatedAt: now + 1,
+    };
+    fs.writeFileSync(
+      previousTranscript,
+      `${JSON.stringify({ type: "session", id: "previous-trajectory-session" })}\n`,
+      "utf-8",
+    );
+    await upsertSessionEntry({ sessionKey, storePath }, previousEntry);
+
+    const runtimeFile = resolveTrajectoryFilePath({
+      sessionFile: previousTranscript,
+      sessionId: previousEntry.sessionId,
+    });
+    const pointerPath = resolveTrajectoryPointerFilePath(previousTranscript);
+    const recorderResult = createTrajectoryRuntimeRecorder({
+      sessionId: previousEntry.sessionId,
+      sessionFile: previousTranscript,
+    });
+    const recorder = await recorderResult;
+    if (!recorder) {
+      throw new Error("expected trajectory runtime recorder");
+    }
+    recorder.recordEvent("prompt.submitted", { marker: "before-reset" });
+    await recorder.flush();
+    expect(fs.existsSync(runtimeFile)).toBe(true);
+    expect(fs.existsSync(pointerPath)).toBe(true);
+
+    try {
+      await persistSessionResetLifecycle({
+        agentId: "main",
+        cleanupPreviousTranscript: true,
+        nextEntry,
+        nextSessionFile: nextTranscript,
+        previousEntry,
+        previousSessionId: previousEntry.sessionId,
+        sessionKey,
+        storePath,
+      });
+
+      expect(fs.existsSync(runtimeFile)).toBe(false);
+      expect(fs.existsSync(pointerPath)).toBe(false);
+      const runtimeTombstones = fs
+        .readdirSync(tempDir)
+        .filter((file) => file.startsWith(`${path.basename(runtimeFile)}.reset.`));
+      const pointerTombstones = fs
+        .readdirSync(tempDir)
+        .filter((file) => file.startsWith(`${path.basename(pointerPath)}.reset.`));
+      expect(runtimeTombstones).toHaveLength(1);
+      expect(pointerTombstones).toHaveLength(1);
+
+      // A late straggler write for the reset session (e.g. an async
+      // post-turn hook, such as a memory-reflection cascade, still finishing
+      // against the old identity) must not resurrect the tombstoned
+      // canonical path by freshly re-acquiring under the same session id.
+      const lateLease = await acquireTrajectoryWriterLease({
+        sessionId: previousEntry.sessionId,
+        candidatePath: runtimeFile,
+      });
+      expect(lateLease.filePath).not.toBe(runtimeFile);
+      expect(fs.existsSync(runtimeFile)).toBe(false);
+    } finally {
+      clearTrajectoryWriterLifecycleRegistryForTest();
+    }
   });
 
   it("appends transcript events through a session scope", async () => {

--- a/src/config/sessions/session-accessor.test.ts
+++ b/src/config/sessions/session-accessor.test.ts
@@ -2098,13 +2098,16 @@ describe("session accessor file-backed seam", () => {
 
       // A late straggler write for the reset session (e.g. an async
       // post-turn hook, such as a memory-reflection cascade, still finishing
-      // against the old identity) must not resurrect the tombstoned
-      // canonical path by freshly re-acquiring under the same session id.
+      // against the old identity) must not resurrect the tombstoned canonical
+      // path. Reset mints a new session id for the continuation, so a claim
+      // under the OLD id on its retired path is a straggler racing its own
+      // disposal — it is rejected outright, not disambiguated to a fresh
+      // sibling that would recreate a live pair for a session that is gone.
       const lateLease = await acquireTrajectoryWriterLease({
         sessionId: previousEntry.sessionId,
         candidatePath: runtimeFile,
       });
-      expect(lateLease.filePath).not.toBe(runtimeFile);
+      expect(lateLease.status).toBe("retired");
       expect(fs.existsSync(runtimeFile)).toBe(false);
     } finally {
       clearTrajectoryWriterLifecycleRegistryForTest();

--- a/src/config/sessions/session-accessor.ts
+++ b/src/config/sessions/session-accessor.ts
@@ -463,6 +463,10 @@ const loadSessionArchiveRuntime = createLazyRuntimeModule(
   () => import("../../gateway/session-archive.runtime.js"),
 );
 
+const loadTrajectoryCleanupRuntime = createLazyRuntimeModule(
+  () => import("../../trajectory/cleanup.js"),
+);
+
 // Fork-source reading parses legacy transcript versions through the agents
 // session-manager; load it lazily so accessor consumers do not pull that
 // runtime (and its module-init package metadata reads) at import time.
@@ -2230,14 +2234,50 @@ export async function persistSessionResetLifecycle(params: {
   });
 
   if (params.cleanupPreviousTranscript && params.previousSessionId) {
+    const previousSessionId = params.previousSessionId;
+    const previousEntryForArchive =
+      params.previousEntry.sessionId === previousSessionId
+        ? params.previousEntry
+        : { ...params.previousEntry, sessionId: previousSessionId };
+    // One instant for both the transcript's own reset-archive rename here and
+    // the trajectory tombstone below, so the pair carries the exact same
+    // ".reset.<timestamp>" suffix and stays visibly coupled — this runner-
+    // driven reset (typed in-conversation /reset) previously persisted its
+    // own store swap and transcript archive without ever routing through
+    // resetSessionEntryLifecycle in store.ts, so it never tombstoned the
+    // trajectory pair at all.
+    const nowMs = Date.now();
     await archivePreviousSessionTranscript({
       agentId: params.agentId ?? resolveAgentIdFromSessionKey(params.sessionKey),
-      previousEntry:
-        params.previousEntry.sessionId === params.previousSessionId
-          ? params.previousEntry
-          : { ...params.previousEntry, sessionId: params.previousSessionId },
+      previousEntry: previousEntryForArchive,
       storePath: params.storePath,
+      nowMs,
     });
+    const previousSessionFile = previousEntryForArchive.sessionFile;
+    if (!previousSessionFile || previousSessionFile !== params.nextSessionFile) {
+      // A fresh reset always mints a brand-new sessionId, so nextSessionFile
+      // is never the previous session's own transcript path here — this is
+      // always the "genuinely abandoned" case, never a reused-path handoff.
+      // Tombstone the previous session's trajectory pair unless another
+      // store row still references it (same referenced-sessions guard shape
+      // resetSessionEntryLifecycle and deleteSessionEntryLifecycle use).
+      const store = loadSessionStore(params.storePath, { skipCache: true, clone: false });
+      const referencedSessionIds = new Set(
+        Object.values(store)
+          .map((entry) => entry?.sessionId)
+          .filter((sessionId): sessionId is string => Boolean(sessionId)),
+      );
+      if (!referencedSessionIds.has(previousSessionId)) {
+        const { removeRemovedSessionTrajectoryArtifacts } = await loadTrajectoryCleanupRuntime();
+        await removeRemovedSessionTrajectoryArtifacts({
+          removedSessionFiles: [[previousSessionId, previousSessionFile]],
+          referencedSessionIds,
+          storePath: params.storePath,
+          restrictToStoreDir: true,
+          disposal: { mode: "tombstone", reason: "reset", nowMs },
+        });
+      }
+    }
   }
 
   if (persistError) {
@@ -3335,6 +3375,8 @@ async function archivePreviousSessionTranscript(params: {
   onArchiveError?: (error: unknown, sourcePath: string) => void;
   previousEntry?: SessionEntry;
   storePath: string;
+  /** Shared with a paired trajectory tombstone rename — see persistSessionResetLifecycle. */
+  nowMs?: number;
 }): Promise<SessionLifecycleTranscriptInfo> {
   if (!params.previousEntry?.sessionId) {
     return {};
@@ -3348,6 +3390,7 @@ async function archivePreviousSessionTranscript(params: {
     agentId: params.agentId,
     reason: "reset",
     onArchiveError: params.onArchiveError,
+    nowMs: params.nowMs,
   });
   return resolveStableSessionEndTranscript({
     sessionId: params.previousEntry.sessionId,

--- a/src/config/sessions/session-accessor.ts
+++ b/src/config/sessions/session-accessor.ts
@@ -2204,6 +2204,35 @@ export async function cleanupPluginHostSessionStore(
 }
 
 /**
+ * Tombstones an abandoned session's trajectory pair unless another store row
+ * still references its sessionId at swap time. Shared by
+ * persistSessionResetLifecycle (agent-runner self-heal restarts) and
+ * persistSessionRolloverLifecycle (the per-message /new, /reset, and
+ * daily/idle rollover path actually exercised by every inbound command) so
+ * both apply the same coupling resetSessionEntryLifecycle uses inline in
+ * store.ts, instead of a third divergent copy.
+ */
+async function tombstoneAbandonedSessionTrajectory(params: {
+  nowMs: number;
+  previousSessionFile: string | undefined;
+  previousSessionId: string;
+  referencedSessionIds: Set<string>;
+  storePath: string;
+}): Promise<void> {
+  if (params.referencedSessionIds.has(params.previousSessionId)) {
+    return;
+  }
+  const { removeRemovedSessionTrajectoryArtifacts } = await loadTrajectoryCleanupRuntime();
+  await removeRemovedSessionTrajectoryArtifacts({
+    removedSessionFiles: [[params.previousSessionId, params.previousSessionFile]],
+    referencedSessionIds: params.referencedSessionIds,
+    storePath: params.storePath,
+    restrictToStoreDir: true,
+    disposal: { mode: "tombstone", reason: "reset", nowMs: params.nowMs },
+  });
+}
+
+/**
  * Persists a runner-driven reset rotation together with transcript replay and
  * optional cleanup. File storage performs these steps sequentially; database
  * backends implement this operation as one lifecycle transaction.
@@ -2277,21 +2306,13 @@ export async function persistSessionResetLifecycle(params: {
       // A fresh reset always mints a brand-new sessionId, so nextSessionFile
       // is never the previous session's own transcript path here — this is
       // always the "genuinely abandoned" case, never a reused-path handoff.
-      // Tombstone the previous session's trajectory pair unless another
-      // store row already referenced it at swap time (same referenced-
-      // sessions guard shape resetSessionEntryLifecycle and
-      // deleteSessionEntryLifecycle use).
-      const referencedSessionIds = referencedSessionIdsAtSwap;
-      if (!referencedSessionIds.has(previousSessionId)) {
-        const { removeRemovedSessionTrajectoryArtifacts } = await loadTrajectoryCleanupRuntime();
-        await removeRemovedSessionTrajectoryArtifacts({
-          removedSessionFiles: [[previousSessionId, previousSessionFile]],
-          referencedSessionIds,
-          storePath: params.storePath,
-          restrictToStoreDir: true,
-          disposal: { mode: "tombstone", reason: "reset", nowMs },
-        });
-      }
+      await tombstoneAbandonedSessionTrajectory({
+        nowMs,
+        previousSessionFile,
+        previousSessionId,
+        referencedSessionIds: referencedSessionIdsAtSwap,
+        storePath: params.storePath,
+      });
     }
   }
 
@@ -2346,6 +2367,14 @@ export async function commitReplySessionInitialization(params: {
   snapshotEntry?: SessionEntry;
   storePath: string;
 }): Promise<ReplySessionInitializationCommitResult> {
+  // Captured inside the same locked mutator as the store swap (see
+  // persistSessionResetLifecycle's own comment for the race this avoids).
+  // This reply-session initialization — not persistSessionResetLifecycle — is
+  // the path every inbound /new, /reset, and implicit daily/idle rollover
+  // actually takes (initSessionState in auto-reply/reply/session.ts), so it
+  // needs the exact same referenced-sessions snapshot to safely tombstone the
+  // previous session's trajectory pair.
+  let referencedSessionIdsAtSwap = new Set<string>();
   const committed = await updateSessionStore(
     params.storePath,
     async (store): Promise<ReplySessionInitializationCommitResult> => {
@@ -2397,6 +2426,11 @@ export async function commitReplySessionInitialization(params: {
       if (params.retiredEntry) {
         store[params.retiredEntry.key] = params.retiredEntry.entry;
       }
+      referencedSessionIdsAtSwap = new Set(
+        Object.values(store)
+          .map((entry) => entry?.sessionId)
+          .filter((sessionId): sessionId is string => Boolean(sessionId)),
+      );
       return {
         ok: true,
         previousSessionTranscript: {},
@@ -2416,12 +2450,39 @@ export async function commitReplySessionInitialization(params: {
     return committed;
   }
 
+  // One instant for both the transcript's own reset-archive rename below and
+  // the trajectory tombstone further down, so the pair carries the exact
+  // same ".reset.<timestamp>" suffix and stays visibly coupled — matching
+  // resetSessionEntryLifecycle's own pairing in store.ts.
+  const nowMs = Date.now();
   const previousSessionTranscript = await archivePreviousSessionTranscript({
     agentId: params.agentId,
     onArchiveError: params.onArchiveError,
     previousEntry: params.previousEntry,
     storePath: params.storePath,
+    nowMs,
   });
+
+  const previousSessionId = params.previousEntry?.sessionId;
+  const previousSessionFile = params.previousEntry?.sessionFile;
+  if (
+    previousSessionId &&
+    // A reply-session reset/rollover always mints a brand-new sessionId with a
+    // freshly resolved transcript path (see initSessionState), so this is the
+    // "genuinely abandoned" case, never a reused-path handoff — but guard it
+    // explicitly against the actually-committed new entry anyway, mirroring
+    // resetSessionEntryLifecycle's own check.
+    (!previousSessionFile || previousSessionFile !== committed.sessionEntry.sessionFile)
+  ) {
+    await tombstoneAbandonedSessionTrajectory({
+      nowMs,
+      previousSessionFile,
+      previousSessionId,
+      referencedSessionIds: referencedSessionIdsAtSwap,
+      storePath: params.storePath,
+    });
+  }
+
   return {
     ...committed,
     previousSessionTranscript,

--- a/src/config/sessions/session-accessor.ts
+++ b/src/config/sessions/session-accessor.ts
@@ -2219,9 +2219,28 @@ export async function persistSessionResetLifecycle(params: {
   storePath: string;
 }): Promise<{ replayedMessages: number }> {
   let persistError: Error | undefined;
+  // Captured INSIDE the same locked turn as the store swap below (the
+  // mutator runs inside updateSessionStore's own runExclusiveSessionStoreWrite
+  // hold), not via a later, unlocked re-read. A concurrent writer — e.g. a
+  // still-finishing post-turn hook (self-improvement, memory-reflection)
+  // that captured the pre-reset session identity before this swap landed —
+  // can freely acquire the store lock and persist its own row referencing
+  // the previous sessionId in the window between this function's own swap
+  // and a later read, making the previous session look "still referenced"
+  // when it genuinely was not at reset time. Snapshotting here, matching
+  // resetSessionEntryLifecycle's own pattern in store.ts (which computes
+  // this from the same locked store object it just mutated), closes that
+  // race: the fleet-observed silent skip on every typed /reset whose hook
+  // cascade raced this exact window.
+  let referencedSessionIdsAtSwap = new Set<string>();
   try {
     await updateSessionStore(params.storePath, (store) => {
       store[params.sessionKey] = params.nextEntry;
+      referencedSessionIdsAtSwap = new Set(
+        Object.values(store)
+          .map((entry) => entry?.sessionId)
+          .filter((sessionId): sessionId is string => Boolean(sessionId)),
+      );
     });
   } catch (err) {
     persistError = err instanceof Error ? err : new Error(String(err));
@@ -2259,14 +2278,10 @@ export async function persistSessionResetLifecycle(params: {
       // is never the previous session's own transcript path here — this is
       // always the "genuinely abandoned" case, never a reused-path handoff.
       // Tombstone the previous session's trajectory pair unless another
-      // store row still references it (same referenced-sessions guard shape
-      // resetSessionEntryLifecycle and deleteSessionEntryLifecycle use).
-      const store = loadSessionStore(params.storePath, { skipCache: true, clone: false });
-      const referencedSessionIds = new Set(
-        Object.values(store)
-          .map((entry) => entry?.sessionId)
-          .filter((sessionId): sessionId is string => Boolean(sessionId)),
-      );
+      // store row already referenced it at swap time (same referenced-
+      // sessions guard shape resetSessionEntryLifecycle and
+      // deleteSessionEntryLifecycle use).
+      const referencedSessionIds = referencedSessionIdsAtSwap;
       if (!referencedSessionIds.has(previousSessionId)) {
         const { removeRemovedSessionTrajectoryArtifacts } = await loadTrajectoryCleanupRuntime();
         await removeRemovedSessionTrajectoryArtifacts({

--- a/src/config/sessions/store-maintenance-operations.ts
+++ b/src/config/sessions/store-maintenance-operations.ts
@@ -52,6 +52,9 @@ type RemovedSessionArtifactCleanup = {
   }) => Promise<Set<string>>;
   cleanupArchivedSessionTranscripts: (params: {
     directories: string[];
+    // The session store dir; entries outside it (an OPENCLAW_TRAJECTORY_DIR
+    // override) require trajectory-ownership proof before the sweep deletes them.
+    storeDir: string;
     rules: Array<{ reason: "deleted" | "reset"; olderThanMs: number }>;
   }) => Promise<void>;
 };
@@ -187,15 +190,17 @@ async function cleanupRemovedSessionArtifacts(params: {
   ) {
     return;
   }
+  const storeDir = path.dirname(path.resolve(params.operation.storePath));
   const targetDirs =
     archivedDirs.size > 0 || trajectoryTombstoneDirs.size > 0
       ? [...new Set([...archivedDirs, ...trajectoryTombstoneDirs])]
-      : [path.dirname(path.resolve(params.operation.storePath))];
+      : [storeDir];
   // Both retention reasons ride one cleanup call so each save enumerates the
   // sessions dir at most once; reset retention defaults on, so a listing per
   // reason would scan twice per save.
   await params.operation.artifacts.cleanupArchivedSessionTranscripts({
     directories: targetDirs,
+    storeDir,
     rules:
       params.maintenance.resetArchiveRetentionMs != null
         ? [

--- a/src/config/sessions/store-maintenance-operations.ts
+++ b/src/config/sessions/store-maintenance-operations.ts
@@ -41,13 +41,15 @@ type RemovedSessionArtifactCleanup = {
     restrictToStoreDir: true;
     nowMs: number;
   }) => Promise<Set<string>>;
+  // Returns the directories tombstones actually landed in, so the retention
+  // sweep below reaches an OPENCLAW_TRAJECTORY_DIR override too.
   removeRemovedSessionTrajectoryArtifacts: (params: {
     removedSessionFiles: RemovedSessionFiles;
     referencedSessionIds: ReadonlySet<string>;
     storePath: string;
     restrictToStoreDir: true;
     disposal: { mode: "tombstone"; reason: "deleted"; nowMs: number };
-  }) => Promise<void>;
+  }) => Promise<Set<string>>;
   cleanupArchivedSessionTranscripts: (params: {
     directories: string[];
     rules: Array<{ reason: "deleted" | "reset"; olderThanMs: number }>;
@@ -167,21 +169,27 @@ async function cleanupRemovedSessionArtifacts(params: {
     restrictToStoreDir: true,
     nowMs,
   });
+  let trajectoryTombstoneDirs: Set<string> = new Set();
   if (params.removedSessionFiles.size > 0) {
-    await params.operation.artifacts.removeRemovedSessionTrajectoryArtifacts({
-      removedSessionFiles: params.removedSessionFiles,
-      referencedSessionIds: params.referencedSessionIds,
-      storePath: params.operation.storePath,
-      restrictToStoreDir: true,
-      disposal: { mode: "tombstone", reason: "deleted", nowMs },
-    });
+    trajectoryTombstoneDirs =
+      await params.operation.artifacts.removeRemovedSessionTrajectoryArtifacts({
+        removedSessionFiles: params.removedSessionFiles,
+        referencedSessionIds: params.referencedSessionIds,
+        storePath: params.operation.storePath,
+        restrictToStoreDir: true,
+        disposal: { mode: "tombstone", reason: "deleted", nowMs },
+      });
   }
-  if (archivedDirs.size === 0 && params.maintenance.resetArchiveRetentionMs == null) {
+  if (
+    archivedDirs.size === 0 &&
+    trajectoryTombstoneDirs.size === 0 &&
+    params.maintenance.resetArchiveRetentionMs == null
+  ) {
     return;
   }
   const targetDirs =
-    archivedDirs.size > 0
-      ? [...archivedDirs]
+    archivedDirs.size > 0 || trajectoryTombstoneDirs.size > 0
+      ? [...new Set([...archivedDirs, ...trajectoryTombstoneDirs])]
       : [path.dirname(path.resolve(params.operation.storePath))];
   // Both retention reasons ride one cleanup call so each save enumerates the
   // sessions dir at most once; reset retention defaults on, so a listing per

--- a/src/config/sessions/store-maintenance-operations.ts
+++ b/src/config/sessions/store-maintenance-operations.ts
@@ -39,12 +39,14 @@ type RemovedSessionArtifactCleanup = {
     storePath: string;
     reason: "deleted";
     restrictToStoreDir: true;
+    nowMs: number;
   }) => Promise<Set<string>>;
   removeRemovedSessionTrajectoryArtifacts: (params: {
     removedSessionFiles: RemovedSessionFiles;
     referencedSessionIds: ReadonlySet<string>;
     storePath: string;
     restrictToStoreDir: true;
+    disposal: { mode: "tombstone"; reason: "deleted"; nowMs: number };
   }) => Promise<void>;
   cleanupArchivedSessionTranscripts: (params: {
     directories: string[];
@@ -152,12 +154,18 @@ async function cleanupRemovedSessionArtifacts(params: {
   // SQLite should commit entry-retention rows before this named artifact cleanup.
   // The cleanup needs the final referenced-session set so shared transcripts and
   // trajectory sidecars survive until the last referring row is gone.
+  //
+  // One instant for both archive calls below, so a session's transcript and
+  // trajectory tombstones from this maintenance pass carry the exact same
+  // ".deleted.<timestamp>" suffix and stay visibly coupled.
+  const nowMs = Date.now();
   const archivedDirs = await params.operation.artifacts.archiveRemovedSessionTranscripts({
     removedSessionFiles: params.removedSessionFiles,
     referencedSessionIds: params.referencedSessionIds,
     storePath: params.operation.storePath,
     reason: "deleted",
     restrictToStoreDir: true,
+    nowMs,
   });
   if (params.removedSessionFiles.size > 0) {
     await params.operation.artifacts.removeRemovedSessionTrajectoryArtifacts({
@@ -165,6 +173,7 @@ async function cleanupRemovedSessionArtifacts(params: {
       referencedSessionIds: params.referencedSessionIds,
       storePath: params.operation.storePath,
       restrictToStoreDir: true,
+      disposal: { mode: "tombstone", reason: "deleted", nowMs },
     });
   }
   if (archivedDirs.size === 0 && params.maintenance.resetArchiveRetentionMs == null) {

--- a/src/config/sessions/store.pruning.test.ts
+++ b/src/config/sessions/store.pruning.test.ts
@@ -260,6 +260,7 @@ describe("applyFileBackedSessionStoreMaintenance", () => {
       ],
     ]);
     let sweptDirectories: string[] | undefined;
+    let sweptStoreDir: string | undefined;
 
     await applyFileBackedSessionStoreMaintenance({
       storePath: "/tmp/openclaw-sessions/sessions.json",
@@ -280,6 +281,7 @@ describe("applyFileBackedSessionStoreMaintenance", () => {
           new Set(["/tmp/openclaw-sessions", "/mnt/external-trajectory-dir"]),
         cleanupArchivedSessionTranscripts: async (params) => {
           sweptDirectories = params.directories;
+          sweptStoreDir = params.storeDir;
         },
       },
     });
@@ -288,6 +290,9 @@ describe("applyFileBackedSessionStoreMaintenance", () => {
       expect.arrayContaining(["/tmp/openclaw-sessions", "/mnt/external-trajectory-dir"]),
     );
     expect(sweptDirectories).toHaveLength(2);
+    // The store dir is threaded through so the sweep can require ownership proof
+    // before deleting suffix look-alikes in the external trajectory dir.
+    expect(sweptStoreDir).toBe("/tmp/openclaw-sessions");
   });
 
   it("forced cleanup prunes stale model-run probes before the cap evicts real sessions", async () => {

--- a/src/config/sessions/store.pruning.test.ts
+++ b/src/config/sessions/store.pruning.test.ts
@@ -248,6 +248,48 @@ describe("applyFileBackedSessionStoreMaintenance", () => {
     expect(trajectoryCleanupReferencedIds).toEqual(new Set(["shared-session", "active-session"]));
   });
 
+  it("folds an external trajectory tombstone directory into the retention sweep's targets", async () => {
+    // A configured OPENCLAW_TRAJECTORY_DIR tombstones outside the sessions
+    // dir archiveRemovedSessionTranscripts already reports — the sweep must
+    // still reach it, or those tombstones never age out.
+    const now = Date.now();
+    const store = makeStore([
+      [
+        "stale",
+        { sessionId: "stale-session", sessionFile: "stale.jsonl", updatedAt: now - 30 * DAY_MS },
+      ],
+    ]);
+    let sweptDirectories: string[] | undefined;
+
+    await applyFileBackedSessionStoreMaintenance({
+      storePath: "/tmp/openclaw-sessions/sessions.json",
+      store,
+      maintenanceConfig: {
+        mode: "enforce",
+        pruneAfterMs: 7 * DAY_MS,
+        maxEntries: 500,
+        modelRunPruneAfterMs: DAY_MS,
+        resetArchiveRetentionMs: null,
+        maxDiskBytes: null,
+        highWaterBytes: null,
+      },
+      log: { warn: () => {}, info: () => {} },
+      artifacts: {
+        archiveRemovedSessionTranscripts: async () => new Set(["/tmp/openclaw-sessions"]),
+        removeRemovedSessionTrajectoryArtifacts: async () =>
+          new Set(["/tmp/openclaw-sessions", "/mnt/external-trajectory-dir"]),
+        cleanupArchivedSessionTranscripts: async (params) => {
+          sweptDirectories = params.directories;
+        },
+      },
+    });
+
+    expect(sweptDirectories).toEqual(
+      expect.arrayContaining(["/tmp/openclaw-sessions", "/mnt/external-trajectory-dir"]),
+    );
+    expect(sweptDirectories).toHaveLength(2);
+  });
+
   it("forced cleanup prunes stale model-run probes before the cap evicts real sessions", async () => {
     const now = Date.now();
     const staleProbe = "agent:main:explicit:model-run-123e4567-e89b-12d3-a456-426614174099";

--- a/src/config/sessions/store.pruning.test.ts
+++ b/src/config/sessions/store.pruning.test.ts
@@ -47,7 +47,7 @@ function makeStore(entries: Array<[string, SessionEntry]>): Record<string, Sessi
 function createMaintenanceArtifacts() {
   return {
     archiveRemovedSessionTranscripts: async () => new Set<string>(),
-    removeRemovedSessionTrajectoryArtifacts: async () => {},
+    removeRemovedSessionTrajectoryArtifacts: async () => new Set<string>(),
     cleanupArchivedSessionTranscripts: async () => {},
   };
 }
@@ -225,6 +225,7 @@ describe("applyFileBackedSessionStoreMaintenance", () => {
         },
         removeRemovedSessionTrajectoryArtifacts: async (params) => {
           trajectoryCleanupReferencedIds = new Set(params.referencedSessionIds);
+          return new Set<string>();
         },
         cleanupArchivedSessionTranscripts: async () => {},
       },
@@ -281,7 +282,7 @@ describe("applyFileBackedSessionStoreMaintenance", () => {
       log: { warn: () => {}, info: () => {} },
       artifacts: {
         archiveRemovedSessionTranscripts: async () => new Set(),
-        removeRemovedSessionTrajectoryArtifacts: async () => {},
+        removeRemovedSessionTrajectoryArtifacts: async () => new Set(),
         cleanupArchivedSessionTranscripts: async () => {},
       },
     });

--- a/src/config/sessions/store.session-lifecycle-mutation.test.ts
+++ b/src/config/sessions/store.session-lifecycle-mutation.test.ts
@@ -366,7 +366,7 @@ describe("session store lifecycle mutations", () => {
       { skipMaintenance: true },
     );
 
-    const recorder = createTrajectoryRuntimeRecorder({
+    const recorder = await createTrajectoryRuntimeRecorder({
       sessionId,
       sessionFile: transcriptPath,
     });
@@ -412,7 +412,7 @@ describe("session store lifecycle mutations", () => {
       { skipMaintenance: true },
     );
 
-    const recorder = createTrajectoryRuntimeRecorder({
+    const recorder = await createTrajectoryRuntimeRecorder({
       sessionId,
       sessionFile: transcriptPath,
     });
@@ -480,12 +480,12 @@ describe("session store lifecycle mutations", () => {
     );
 
     const env = { OPENCLAW_TRAJECTORY_DIR: trajectoryDir };
-    const recorderA = createTrajectoryRuntimeRecorder({
+    const recorderA = await createTrajectoryRuntimeRecorder({
       env,
       sessionId: sessionAId,
       sessionFile: transcriptPathA,
     });
-    const recorderB = createTrajectoryRuntimeRecorder({
+    const recorderB = await createTrajectoryRuntimeRecorder({
       env,
       sessionId: sessionBId,
       sessionFile: transcriptPathB,

--- a/src/config/sessions/store.session-lifecycle-mutation.test.ts
+++ b/src/config/sessions/store.session-lifecycle-mutation.test.ts
@@ -256,4 +256,85 @@ describe("session store lifecycle mutations", () => {
     expect(result.deleted).toBe(true);
     expect(loadSessionStore(storePath, { skipCache: true })[sessionKey]).toBeUndefined();
   });
+
+  it("removes the deleted session's trajectory artifacts alongside the transcript", async () => {
+    const transcriptPath = path.join(tempDir, "delete-session.jsonl");
+    const runtimePath = path.join(tempDir, "delete-session.trajectory.jsonl");
+    const pointerPath = path.join(tempDir, "delete-session.trajectory-path.json");
+    const now = Date.now();
+    fs.writeFileSync(transcriptPath, '{"type":"session","id":"delete-session"}\n', "utf-8");
+    fs.writeFileSync(runtimePath, '{"type":"session","sessionId":"delete-session"}\n', "utf-8");
+    fs.writeFileSync(
+      pointerPath,
+      JSON.stringify({ sessionId: "delete-session", runtimeFile: runtimePath }),
+      "utf-8",
+    );
+    await saveSessionStore(
+      storePath,
+      {
+        "agent:main:delete": {
+          sessionFile: transcriptPath,
+          sessionId: "delete-session",
+          updatedAt: now,
+        },
+      },
+      { skipMaintenance: true },
+    );
+
+    const result = await deleteSessionEntryLifecycle({
+      archiveTranscript: true,
+      storePath,
+      target: {
+        canonicalKey: "agent:main:delete",
+        storeKeys: ["agent:main:delete"],
+      },
+    });
+
+    expect(result.deleted).toBe(true);
+    expect(fs.existsSync(runtimePath)).toBe(false);
+    expect(fs.existsSync(pointerPath)).toBe(false);
+  });
+
+  it("keeps trajectory artifacts while another entry still references the session", async () => {
+    const transcriptPath = path.join(tempDir, "shared-session.jsonl");
+    const runtimePath = path.join(tempDir, "shared-session.trajectory.jsonl");
+    const pointerPath = path.join(tempDir, "shared-session.trajectory-path.json");
+    const now = Date.now();
+    fs.writeFileSync(transcriptPath, '{"type":"session","id":"shared-session"}\n', "utf-8");
+    fs.writeFileSync(runtimePath, '{"type":"session","sessionId":"shared-session"}\n', "utf-8");
+    fs.writeFileSync(
+      pointerPath,
+      JSON.stringify({ sessionId: "shared-session", runtimeFile: runtimePath }),
+      "utf-8",
+    );
+    await saveSessionStore(
+      storePath,
+      {
+        "agent:main:delete": {
+          sessionFile: transcriptPath,
+          sessionId: "shared-session",
+          updatedAt: now - 1,
+        },
+        "agent:main:mirror": {
+          sessionFile: transcriptPath,
+          sessionId: "shared-session",
+          updatedAt: now,
+        },
+      },
+      { skipMaintenance: true },
+    );
+
+    const result = await deleteSessionEntryLifecycle({
+      archiveTranscript: true,
+      storePath,
+      target: {
+        canonicalKey: "agent:main:delete",
+        storeKeys: ["agent:main:delete"],
+      },
+    });
+
+    expect(result.deleted).toBe(true);
+    expect(fs.existsSync(runtimePath)).toBe(true);
+    expect(fs.existsSync(pointerPath)).toBe(true);
+  });
 });

--- a/src/config/sessions/store.session-lifecycle-mutation.test.ts
+++ b/src/config/sessions/store.session-lifecycle-mutation.test.ts
@@ -3,6 +3,16 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  resolveTrajectoryFilePath,
+  resolveTrajectoryPointerFilePath,
+} from "../../trajectory/paths.js";
+import { createTrajectoryRuntimeRecorder } from "../../trajectory/runtime.js";
+import {
+  canonicalizeTrajectoryPath,
+  clearTrajectoryWriterLifecycleRegistryForTest,
+  withTrajectoryPathLock,
+} from "../../trajectory/writer-lifecycle.js";
 import { deleteSessionEntryLifecycle, resetSessionEntryLifecycle } from "./session-accessor.js";
 import { clearSessionStoreCacheForTest, loadSessionStore, saveSessionStore } from "./store.js";
 import type { SessionEntry } from "./types.js";
@@ -18,6 +28,7 @@ describe("session store lifecycle mutations", () => {
 
   afterEach(() => {
     clearSessionStoreCacheForTest();
+    clearTrajectoryWriterLifecycleRegistryForTest();
     fs.rmSync(tempDir, { recursive: true, force: true });
   });
 
@@ -336,5 +347,167 @@ describe("session store lifecycle mutations", () => {
     expect(result.deleted).toBe(true);
     expect(fs.existsSync(runtimePath)).toBe(true);
     expect(fs.existsSync(pointerPath)).toBe(true);
+  });
+
+  it("rejects a trajectory flush issued after the session has already been deleted", async () => {
+    const sessionId = "post-delete-session";
+    const transcriptPath = path.join(tempDir, "post-delete-session.jsonl");
+    const now = Date.now();
+    fs.writeFileSync(transcriptPath, `{"type":"session","id":"${sessionId}"}\n`, "utf-8");
+    await saveSessionStore(
+      storePath,
+      {
+        "agent:main:post-delete": {
+          sessionFile: transcriptPath,
+          sessionId,
+          updatedAt: now,
+        },
+      },
+      { skipMaintenance: true },
+    );
+
+    const recorder = createTrajectoryRuntimeRecorder({
+      sessionId,
+      sessionFile: transcriptPath,
+    });
+    if (!recorder) {
+      throw new Error("expected trajectory runtime recorder");
+    }
+    recorder.recordEvent("prompt.submitted", { marker: "should-not-land" });
+
+    const deleteResult = await deleteSessionEntryLifecycle({
+      archiveTranscript: true,
+      storePath,
+      target: {
+        canonicalKey: "agent:main:post-delete",
+        storeKeys: ["agent:main:post-delete"],
+      },
+    });
+    expect(deleteResult.deleted).toBe(true);
+
+    // Models the abandoned cleanup-timeout flush landing after run teardown
+    // (and therefore delete) already proceeded.
+    await recorder.flush();
+
+    const runtimeFile = resolveTrajectoryFilePath({ sessionFile: transcriptPath, sessionId });
+    const pointerPath = resolveTrajectoryPointerFilePath(transcriptPath);
+    expect(fs.existsSync(runtimeFile)).toBe(false);
+    expect(fs.existsSync(pointerPath)).toBe(false);
+  });
+
+  it("closes the race between an in-flight trajectory flush and a concurrent session delete", async () => {
+    const sessionId = "race-session";
+    const transcriptPath = path.join(tempDir, "race-session.jsonl");
+    const now = Date.now();
+    fs.writeFileSync(transcriptPath, `{"type":"session","id":"${sessionId}"}\n`, "utf-8");
+    await saveSessionStore(
+      storePath,
+      {
+        "agent:main:race": {
+          sessionFile: transcriptPath,
+          sessionId,
+          updatedAt: now,
+        },
+      },
+      { skipMaintenance: true },
+    );
+
+    const recorder = createTrajectoryRuntimeRecorder({
+      sessionId,
+      sessionFile: transcriptPath,
+    });
+    if (!recorder) {
+      throw new Error("expected trajectory runtime recorder");
+    }
+    recorder.recordEvent("prompt.submitted", { marker: "abandoned-flush" });
+
+    const canonicalPath = canonicalizeTrajectoryPath(
+      resolveTrajectoryFilePath({ sessionFile: transcriptPath, sessionId }),
+    );
+
+    // Hold the per-path lock to put flush() and delete() in the same queued
+    // race an abandoned cleanup-timeout flush would create against a
+    // concurrent sessions.delete — regardless of which one is admitted to
+    // the lock first, the outcome must be deterministic (F1).
+    let releaseHeldTurn: () => void = () => {};
+    const heldTurnGate = new Promise<void>((resolve) => {
+      releaseHeldTurn = resolve;
+    });
+    const heldTurn = withTrajectoryPathLock(canonicalPath, async () => {
+      await heldTurnGate;
+    });
+
+    const flushPromise = recorder.flush();
+    const deletePromise = deleteSessionEntryLifecycle({
+      archiveTranscript: true,
+      storePath,
+      target: {
+        canonicalKey: "agent:main:race",
+        storeKeys: ["agent:main:race"],
+      },
+    });
+
+    releaseHeldTurn();
+    await heldTurn;
+    const [, deleteResult] = await Promise.all([flushPromise, deletePromise]);
+
+    expect(deleteResult.deleted).toBe(true);
+    const runtimeFile = resolveTrajectoryFilePath({ sessionFile: transcriptPath, sessionId });
+    const pointerPath = resolveTrajectoryPointerFilePath(transcriptPath);
+    expect(fs.existsSync(runtimeFile)).toBe(false);
+    expect(fs.existsSync(pointerPath)).toBe(false);
+  });
+
+  it("does not delete a colliding sibling session's trajectory file", async () => {
+    const trajectoryDir = path.join(tempDir, "traces");
+    // Colliding under safeTrajectorySessionFileName's sanitizer (":" -> "_")
+    // while both remain valid persisted session store ids (isSafeSessionId
+    // allows ":" but not "*").
+    const sessionAId = "abc:def";
+    const sessionBId = "abc_def";
+    const transcriptPathA = path.join(tempDir, "session-a.jsonl");
+    const transcriptPathB = path.join(tempDir, "session-b.jsonl");
+    const now = Date.now();
+    fs.writeFileSync(transcriptPathA, `{"type":"session","id":"${sessionAId}"}\n`, "utf-8");
+    fs.writeFileSync(transcriptPathB, `{"type":"session","id":"${sessionBId}"}\n`, "utf-8");
+    await saveSessionStore(
+      storePath,
+      {
+        "agent:main:a": { sessionFile: transcriptPathA, sessionId: sessionAId, updatedAt: now },
+        "agent:main:b": { sessionFile: transcriptPathB, sessionId: sessionBId, updatedAt: now },
+      },
+      { skipMaintenance: true },
+    );
+
+    const env = { OPENCLAW_TRAJECTORY_DIR: trajectoryDir };
+    const recorderA = createTrajectoryRuntimeRecorder({
+      env,
+      sessionId: sessionAId,
+      sessionFile: transcriptPathA,
+    });
+    const recorderB = createTrajectoryRuntimeRecorder({
+      env,
+      sessionId: sessionBId,
+      sessionFile: transcriptPathB,
+    });
+    if (!recorderA || !recorderB) {
+      throw new Error("expected trajectory runtime recorders");
+    }
+    expect(recorderA.filePath).not.toBe(recorderB.filePath);
+    recorderA.recordEvent("prompt.submitted", { marker: "owner-a" });
+    recorderB.recordEvent("prompt.submitted", { marker: "owner-b" });
+    await recorderA.flush();
+    await recorderB.flush();
+
+    const result = await deleteSessionEntryLifecycle({
+      archiveTranscript: true,
+      storePath,
+      target: { canonicalKey: "agent:main:a", storeKeys: ["agent:main:a"] },
+    });
+
+    expect(result.deleted).toBe(true);
+    expect(fs.existsSync(recorderA.filePath)).toBe(false);
+    expect(fs.existsSync(recorderB.filePath)).toBe(true);
+    expect(fs.readFileSync(recorderB.filePath, "utf8")).toContain("owner-b");
   });
 });

--- a/src/config/sessions/store.ts
+++ b/src/config/sessions/store.ts
@@ -1478,6 +1478,23 @@ async function deleteSessionEntryLifecycleInternal(
           reason: "deleted",
         })
       : [];
+    if (params.archiveTranscript && deletedSessionId) {
+      // Trajectory artifacts pair with the live transcript: reclaim them only
+      // when the transcript is archived away, and never while another store
+      // entry still references the same session.
+      const referencedSessionIds = new Set(
+        Object.values(store)
+          .map((entry) => entry?.sessionId)
+          .filter((sessionId): sessionId is string => Boolean(sessionId)),
+      );
+      const { removeRemovedSessionTrajectoryArtifacts } = await loadTrajectoryCleanupRuntime();
+      await removeRemovedSessionTrajectoryArtifacts({
+        removedSessionFiles: [[deletedSessionId, deletedSessionFile]],
+        referencedSessionIds,
+        storePath: params.storePath,
+        restrictToStoreDir: true,
+      });
+    }
     const result: DeleteSessionEntryLifecycleResult = {
       archivedTranscripts,
       deleted: true,

--- a/src/config/sessions/store.ts
+++ b/src/config/sessions/store.ts
@@ -851,6 +851,8 @@ async function archiveLifecycleSessionTranscripts(params: {
   sessionFile?: string;
   agentId?: string;
   reason: "reset" | "deleted";
+  /** Shared with the paired trajectory tombstone rename — see callers. */
+  nowMs?: number;
 }): Promise<SessionLifecycleArchivedTranscript[]> {
   if (!params.sessionId) {
     return [];
@@ -862,6 +864,7 @@ async function archiveLifecycleSessionTranscripts(params: {
     sessionFile: params.sessionFile,
     agentId: params.agentId,
     reason: params.reason,
+    nowMs: params.nowMs,
   });
 }
 
@@ -944,6 +947,8 @@ function lifecycleTranscriptIsReclaimable(params: {
 function archiveExactLifecycleTranscriptPath(params: {
   sessionsDir: string;
   transcriptPath: string;
+  /** Shared with the paired trajectory tombstone rename — see callers. */
+  nowMs?: number;
 }): number {
   const resolvedSessionsDir = normalizePathForLifecycleComparison(params.sessionsDir);
   const resolvedTranscriptPath = normalizePathForLifecycleComparison(params.transcriptPath);
@@ -951,7 +956,7 @@ function archiveExactLifecycleTranscriptPath(params: {
   if (!relative || relative.startsWith("..") || path.isAbsolute(relative)) {
     return 0;
   }
-  const archivedPath = `${resolvedTranscriptPath}.deleted.${formatSessionArchiveTimestamp()}`;
+  const archivedPath = `${resolvedTranscriptPath}.deleted.${formatSessionArchiveTimestamp(params.nowMs)}`;
   try {
     fs.renameSync(resolvedTranscriptPath, archivedPath);
     emitSessionTranscriptUpdate({ sessionFile: archivedPath });
@@ -1372,12 +1377,17 @@ export async function resetSessionEntryLifecycle(params: {
       });
     }
     await params.afterEntryMutation?.(mutation);
+    // One instant for both the transcript's own reset-archive rename below and
+    // the abandoned-path trajectory tombstone further down, so the pair carries
+    // the exact same ".reset.<timestamp>" suffix and stays visibly coupled.
+    const nowMs = Date.now();
     const archivedTranscripts = await archiveLifecycleSessionTranscripts({
       sessionId: previousSessionId,
       storePath: params.storePath,
       sessionFile: previousSessionFile,
       agentId: params.agentId,
       reason: "reset",
+      nowMs,
     });
     if (reusesTranscriptPath) {
       ensureLifecycleTranscriptHeader({
@@ -1395,7 +1405,8 @@ export async function resetSessionEntryLifecycle(params: {
       }
     } else if (previousSessionId) {
       // The previous path is genuinely abandoned (different transcript path):
-      // retire it exactly like a delete, unless another row still points at it.
+      // tombstone it exactly like a delete (reason "reset", same nowMs as the
+      // transcript archive above), unless another row still points at it.
       const referencedSessionIds = new Set(
         Object.values(store)
           .map((entry) => entry?.sessionId)
@@ -1408,6 +1419,7 @@ export async function resetSessionEntryLifecycle(params: {
           referencedSessionIds,
           storePath: params.storePath,
           restrictToStoreDir: true,
+          disposal: { mode: "tombstone", reason: "reset", nowMs },
         });
       }
     }
@@ -1495,6 +1507,10 @@ async function deleteSessionEntryLifecycleInternal(
           }
         : undefined,
     );
+    // One instant for both the transcript's own deleted-archive rename below
+    // and the trajectory tombstone further down, so the pair carries the
+    // exact same ".deleted.<timestamp>" suffix and stays visibly coupled.
+    const nowMs = Date.now();
     const archivedTranscripts = params.archiveTranscript
       ? await archiveLifecycleSessionTranscripts({
           sessionId: deletedSessionId,
@@ -1502,6 +1518,7 @@ async function deleteSessionEntryLifecycleInternal(
           sessionFile: deletedSessionFile,
           agentId: params.agentId,
           reason: "deleted",
+          nowMs,
         })
       : [];
     if (params.archiveTranscript && deletedSessionId) {
@@ -1519,6 +1536,7 @@ async function deleteSessionEntryLifecycleInternal(
         referencedSessionIds,
         storePath: params.storePath,
         restrictToStoreDir: true,
+        disposal: { mode: "tombstone", reason: "deleted", nowMs },
       });
     }
     const result: DeleteSessionEntryLifecycleResult = {
@@ -1925,6 +1943,7 @@ export async function cleanupSessionLifecycleArtifacts(
       archivedTranscriptArtifacts += archiveExactLifecycleTranscriptPath({
         sessionsDir,
         transcriptPath,
+        nowMs,
       });
     }
     const { removeRemovedSessionTrajectoryArtifacts } = await loadTrajectoryCleanupRuntime();
@@ -1933,6 +1952,7 @@ export async function cleanupSessionLifecycleArtifacts(
       referencedSessionIds,
       storePath,
       restrictToStoreDir: true,
+      disposal: { mode: "tombstone", reason: "deleted", nowMs },
     });
     replaceSessionEntries(mutableStore, store);
     await saveSessionStoreUnlocked(storePath, mutableStore, { skipMaintenance: true });
@@ -1973,6 +1993,8 @@ export async function archiveRemovedSessionTranscripts(params: {
   storePath: string;
   reason: "deleted" | "reset";
   restrictToStoreDir?: boolean;
+  /** Shared with the paired trajectory tombstone batch rename — see callers. */
+  nowMs?: number;
 }): Promise<Set<string>> {
   const { archiveSessionTranscripts } = await loadSessionArchiveRuntime();
   const archivedDirs = new Set<string>();
@@ -1986,6 +2008,7 @@ export async function archiveRemovedSessionTranscripts(params: {
       sessionFile,
       reason: params.reason,
       restrictToStoreDir: params.restrictToStoreDir,
+      nowMs: params.nowMs,
     });
     for (const archivedPath of archived) {
       archivedDirs.add(path.dirname(archivedPath));

--- a/src/config/sessions/store.ts
+++ b/src/config/sessions/store.ts
@@ -997,7 +997,11 @@ async function saveSessionStoreUnlocked(
         archiveRemovedSessionTranscripts,
         removeRemovedSessionTrajectoryArtifacts: async (params) => {
           const { removeRemovedSessionTrajectoryArtifacts } = await loadTrajectoryCleanupRuntime();
-          await removeRemovedSessionTrajectoryArtifacts(params);
+          const removed = await removeRemovedSessionTrajectoryArtifacts(params);
+          // Surface the directories tombstones actually landed in (an
+          // OPENCLAW_TRAJECTORY_DIR override lands outside the sessions dir)
+          // so the retention sweep below can reach them too.
+          return new Set(removed.map((artifact) => path.dirname(artifact.path)));
         },
         cleanupArchivedSessionTranscripts: async (params) => {
           const { cleanupArchivedSessionTranscripts } = await loadSessionArchiveRuntime();

--- a/src/config/sessions/store.ts
+++ b/src/config/sessions/store.ts
@@ -1384,6 +1384,32 @@ export async function resetSessionEntryLifecycle(params: {
         sessionFile: nextSessionFile,
         sessionId: nextEntry.sessionId,
       });
+      if (previousSessionId && previousSessionId !== nextEntry.sessionId) {
+        const { reassignSessionTrajectoryPathOwner } = await loadTrajectoryCleanupRuntime();
+        reassignSessionTrajectoryPathOwner({
+          previousSessionId,
+          previousSessionFile,
+          nextSessionId: nextEntry.sessionId,
+          nextSessionFile,
+        });
+      }
+    } else if (previousSessionId) {
+      // The previous path is genuinely abandoned (different transcript path):
+      // retire it exactly like a delete, unless another row still points at it.
+      const referencedSessionIds = new Set(
+        Object.values(store)
+          .map((entry) => entry?.sessionId)
+          .filter((sessionId): sessionId is string => Boolean(sessionId)),
+      );
+      if (!referencedSessionIds.has(previousSessionId)) {
+        const { removeRemovedSessionTrajectoryArtifacts } = await loadTrajectoryCleanupRuntime();
+        await removeRemovedSessionTrajectoryArtifacts({
+          removedSessionFiles: [[previousSessionId, previousSessionFile]],
+          referencedSessionIds,
+          storePath: params.storePath,
+          restrictToStoreDir: true,
+        });
+      }
     }
     const result: ResetSessionEntryLifecycleResult = {
       ...mutation,

--- a/src/config/sessions/store.ts
+++ b/src/config/sessions/store.ts
@@ -1386,7 +1386,7 @@ export async function resetSessionEntryLifecycle(params: {
       });
       if (previousSessionId && previousSessionId !== nextEntry.sessionId) {
         const { reassignSessionTrajectoryPathOwner } = await loadTrajectoryCleanupRuntime();
-        reassignSessionTrajectoryPathOwner({
+        await reassignSessionTrajectoryPathOwner({
           previousSessionId,
           previousSessionFile,
           nextSessionId: nextEntry.sessionId,

--- a/src/gateway/session-transcript-files.fs.archive-cleanup.test.ts
+++ b/src/gateway/session-transcript-files.fs.archive-cleanup.test.ts
@@ -86,6 +86,40 @@ describe("cleanupArchivedSessionTranscripts", () => {
     expect(await remaining()).toEqual([`a.jsonl.reset.${OLD_STAMP}`]);
   });
 
+  it("ages out trajectory tombstones under the same rules and directory listing as transcript tombstones", async () => {
+    // The trajectory pair is renamed beside its transcript on reset/delete
+    // (trajectory/cleanup.ts), so its tombstones share this exact suffix
+    // contract and reuse this same sweep with no trajectory-specific code.
+    await seed([
+      `session-a.jsonl.deleted.${OLD_STAMP}`,
+      `session-a.trajectory.jsonl.deleted.${OLD_STAMP}`,
+      `session-a.trajectory-path.json.deleted.${OLD_STAMP}`,
+      `session-b.jsonl.reset.${FRESH_STAMP}`,
+      `session-b.trajectory.jsonl.reset.${FRESH_STAMP}`,
+      `session-b.trajectory-path.json.reset.${FRESH_STAMP}`,
+    ]);
+    const readdirSpy = vi.spyOn(fsPromises, "readdir");
+
+    const result = await cleanupArchivedSessionTranscripts({
+      directories: [dir],
+      rules: [
+        { reason: "deleted", olderThanMs: 30 * DAY_MS },
+        { reason: "reset", olderThanMs: 30 * DAY_MS },
+      ],
+      nowMs: NOW_MS,
+    });
+
+    expect(readdirSpy).toHaveBeenCalledTimes(1);
+    expect(result).toEqual({ removed: 3, scanned: 6 });
+    expect(await remaining()).toEqual(
+      [
+        `session-b.jsonl.reset.${FRESH_STAMP}`,
+        `session-b.trajectory.jsonl.reset.${FRESH_STAMP}`,
+        `session-b.trajectory-path.json.reset.${FRESH_STAMP}`,
+      ].toSorted(),
+    );
+  });
+
   it("drops invalid rules and never lists when none remain", async () => {
     const readdirSpy = vi.spyOn(fsPromises, "readdir");
 

--- a/src/gateway/session-transcript-files.fs.archive-cleanup.test.ts
+++ b/src/gateway/session-transcript-files.fs.archive-cleanup.test.ts
@@ -1,6 +1,7 @@
 // Gateway tests cover archived-transcript retention cleanup: every retention
 // rule shares one directory listing per cleanup call. Store maintenance runs
 // this on each save, so per-rule listings would multiply READDIR load.
+import fs from "node:fs";
 import fsPromises from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
@@ -134,5 +135,155 @@ describe("cleanupArchivedSessionTranscripts", () => {
 
     expect(result).toEqual({ removed: 0, scanned: 0 });
     expect(readdirSpy).not.toHaveBeenCalled();
+  });
+});
+
+describe("cleanupArchivedSessionTranscripts external-directory ownership guard", () => {
+  let storeDir = "";
+  let externalDir = "";
+
+  beforeEach(async () => {
+    storeDir = await fsPromises.mkdtemp(path.join(os.tmpdir(), "openclaw-store-"));
+    externalDir = await fsPromises.mkdtemp(path.join(os.tmpdir(), "openclaw-ext-traj-"));
+  });
+
+  afterEach(async () => {
+    vi.restoreAllMocks();
+    await fsPromises.rm(storeDir, { recursive: true, force: true });
+    await fsPromises.rm(externalDir, { recursive: true, force: true });
+  });
+
+  const RULES = [
+    { reason: "deleted" as const, olderThanMs: 30 * DAY_MS },
+    { reason: "reset" as const, olderThanMs: 30 * DAY_MS },
+  ];
+
+  // Matches what the trajectory recorder writes as a runtime sidecar's first
+  // JSONL line (src/trajectory/runtime.ts).
+  function runtimeSidecar(sessionId: string): string {
+    const header = JSON.stringify({
+      traceSchema: "openclaw-trajectory",
+      schemaVersion: 1,
+      traceId: "trace-1",
+      source: "runtime",
+      type: "session",
+      sessionId,
+    });
+    return `${header}\n${JSON.stringify({ seq: 2, type: "note" })}\n`;
+  }
+
+  // Matches the pretty-printed pointer body the recorder writes.
+  function pointerBody(sessionId: string): string {
+    return `${JSON.stringify(
+      {
+        traceSchema: "openclaw-trajectory-pointer",
+        schemaVersion: 1,
+        sessionId,
+        runtimeFile: `/elsewhere/${sessionId}.trajectory.jsonl`,
+      },
+      null,
+      2,
+    )}\n`;
+  }
+
+  it("in an external dir, reaps a genuine aged trajectory tombstone but keeps a foreign suffix look-alike", async () => {
+    // Store dir owns a plain transcript tombstone (no header) — aged by suffix.
+    await fsPromises.writeFile(path.join(storeDir, `session-a.jsonl.deleted.${OLD_STAMP}`), "");
+    // External (operator-owned) dir: an unrelated rotated log that merely matches
+    // the archive suffix must survive; our own aged tombstone beside it must go.
+    await fsPromises.writeFile(
+      path.join(externalDir, `notes.jsonl.reset.${OLD_STAMP}`),
+      "some other tool's rotated log\n",
+    );
+    await fsPromises.writeFile(
+      path.join(externalDir, `session-b.trajectory.jsonl.deleted.${OLD_STAMP}`),
+      runtimeSidecar("session-b"),
+    );
+
+    const result = await cleanupArchivedSessionTranscripts({
+      directories: [storeDir, externalDir],
+      storeDir,
+      rules: RULES,
+      nowMs: NOW_MS,
+    });
+
+    expect(await fsPromises.readdir(storeDir)).toEqual([]);
+    expect(await fsPromises.readdir(externalDir)).toEqual([`notes.jsonl.reset.${OLD_STAMP}`]);
+    expect(result.removed).toBe(2);
+  });
+
+  it("keeps a foreign pointer-shaped tombstone with invalid JSON in an external dir", async () => {
+    await fsPromises.writeFile(
+      path.join(externalDir, `foreign.trajectory-path.json.deleted.${OLD_STAMP}`),
+      "not-json {{{ nope\n",
+    );
+    // A genuine aged pointer beside it is still reaped.
+    await fsPromises.writeFile(
+      path.join(externalDir, `session-c.trajectory-path.json.deleted.${OLD_STAMP}`),
+      pointerBody("session-c"),
+    );
+
+    const result = await cleanupArchivedSessionTranscripts({
+      directories: [externalDir],
+      storeDir,
+      rules: RULES,
+      nowMs: NOW_MS,
+    });
+
+    expect(await fsPromises.readdir(externalDir)).toEqual([
+      `foreign.trajectory-path.json.deleted.${OLD_STAMP}`,
+    ]);
+    expect(result.removed).toBe(1);
+  });
+
+  it("still ages in-store-dir tombstones by suffix alone, with no header requirement", async () => {
+    // Regression guard on the hot common path: files inside the store dir are
+    // ours by construction, so empty/headerless tombstones must still age out
+    // even when a storeDir is supplied (no per-file header read there).
+    await fsPromises.writeFile(path.join(storeDir, `session-d.jsonl.deleted.${OLD_STAMP}`), "");
+    await fsPromises.writeFile(
+      path.join(storeDir, `session-d.trajectory.jsonl.deleted.${OLD_STAMP}`),
+      "",
+    );
+    await fsPromises.writeFile(
+      path.join(storeDir, `session-d.trajectory-path.json.deleted.${OLD_STAMP}`),
+      "",
+    );
+
+    const result = await cleanupArchivedSessionTranscripts({
+      directories: [storeDir],
+      storeDir,
+      rules: RULES,
+      nowMs: NOW_MS,
+    });
+
+    expect(await fsPromises.readdir(storeDir)).toEqual([]);
+    expect(result.removed).toBe(3);
+  });
+
+  it("keeps an oversized/garbage external tombstone using only a bounded prefix read", async () => {
+    const blobName = `blob.jsonl.reset.${OLD_STAMP}`;
+    // 256 KiB of non-JSON, single line: a genuine trajectory header would sit on
+    // the first line, so this must be kept — and only a bounded prefix may be
+    // read, never the whole blob.
+    await fsPromises.writeFile(path.join(externalDir, blobName), "x".repeat(256 * 1024));
+    const readSyncSpy = vi.spyOn(fs, "readSync");
+
+    const result = await cleanupArchivedSessionTranscripts({
+      directories: [externalDir],
+      storeDir,
+      rules: RULES,
+      nowMs: NOW_MS,
+    });
+
+    expect(await fsPromises.readdir(externalDir)).toEqual([blobName]);
+    expect(result.removed).toBe(0);
+    // Proof of bounded read: every read targets a capped buffer, so no more than
+    // that many bytes of the 256 KiB blob are ever loaded.
+    expect(readSyncSpy).toHaveBeenCalled();
+    for (const call of readSyncSpy.mock.calls) {
+      const buffer = call[1] as ArrayBufferView;
+      expect(buffer.byteLength).toBeLessThanOrEqual(64 * 1024);
+    }
   });
 });

--- a/src/gateway/session-transcript-files.fs.ts
+++ b/src/gateway/session-transcript-files.fs.ts
@@ -354,8 +354,12 @@ export async function resolveSessionTranscriptResetArchiveCandidatesAsync(
   return uniqueStrings(archives.map((archive) => archive.archivePath));
 }
 
-export function archiveFileOnDisk(filePath: string, reason: ArchiveFileReason): string {
-  const ts = formatSessionArchiveTimestamp();
+export function archiveFileOnDisk(
+  filePath: string,
+  reason: ArchiveFileReason,
+  nowMs?: number,
+): string {
+  const ts = formatSessionArchiveTimestamp(nowMs);
   const archived = `${filePath}.${reason}.${ts}`;
   fs.renameSync(filePath, archived);
   clearSessionTranscriptResetArchiveDiscoveryCache();
@@ -384,6 +388,10 @@ export function archiveSessionTranscripts(opts: {
    */
   restrictToStoreDir?: boolean;
   onArchiveError?: (err: unknown, sourcePath: string) => void;
+  /** Explicit archive instant. Lets a caller pair this rename with another
+   * artifact's rename (e.g. a trajectory tombstone) under the exact same
+   * timestamp string instead of each independently calling Date.now(). */
+  nowMs?: number;
 }): string[] {
   return archiveSessionTranscriptsDetailed(opts).map((entry) => entry.archivedPath);
 }
@@ -404,6 +412,8 @@ export function archiveSessionTranscriptsDetailed(opts: {
    * caller decides whether to log, warn-deliver, or escalate.
    */
   onArchiveError?: (err: unknown, sourcePath: string) => void;
+  /** Explicit archive instant — see archiveSessionTranscripts. */
+  nowMs?: number;
 }): ArchivedSessionTranscript[] {
   const archived: ArchivedSessionTranscript[] = [];
   const storeDir =
@@ -429,7 +439,7 @@ export function archiveSessionTranscriptsDetailed(opts: {
     try {
       archived.push({
         sourcePath: candidatePath,
-        archivedPath: archiveFileOnDisk(candidatePath, opts.reason),
+        archivedPath: archiveFileOnDisk(candidatePath, opts.reason, opts.nowMs),
       });
     } catch (err) {
       opts.onArchiveError?.(err, candidatePath);
@@ -485,6 +495,13 @@ export type SessionArchiveCleanupRule = {
 // Store maintenance runs this on every session-store save. All retention rules
 // share one directory listing: a listing per reason would multiply READDIR
 // load on the per-save hot path, which is expensive on networked filesystems.
+//
+// The `.{reason}.{timestamp}` suffix match below is filename-agnostic, so
+// trajectory tombstones (`X.trajectory.jsonl.reset.<ts>`,
+// `X.trajectory-path.json.deleted.<ts>`) age out under the exact same rules
+// and cadence as transcript tombstones for free, as long as they land in one
+// of `directories` — which they do by default, since the trajectory pair is
+// renamed beside its transcript (see trajectory/cleanup.ts).
 export async function cleanupArchivedSessionTranscripts(opts: {
   directories: string[];
   rules: SessionArchiveCleanupRule[];

--- a/src/gateway/session-transcript-files.fs.ts
+++ b/src/gateway/session-transcript-files.fs.ts
@@ -3,6 +3,7 @@
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
+import { isRecord } from "@openclaw/normalization-core/record-coerce";
 import { uniqueStrings } from "@openclaw/normalization-core/string-normalization";
 import {
   formatSessionArchiveTimestamp,
@@ -16,6 +17,7 @@ import {
   resolveSessionTranscriptPathInDir,
 } from "../config/sessions/paths.js";
 import { resolveRequiredHomeDir } from "../infra/home-dir.js";
+import { isPathInside } from "../infra/path-guards.js";
 import { emitSessionTranscriptUpdate } from "../sessions/transcript-events.js";
 
 type ArchiveFileReason = SessionArchiveReason;
@@ -492,6 +494,76 @@ export type SessionArchiveCleanupRule = {
   olderThanMs: number;
 };
 
+// A genuine trajectory header would sit within the first line (runtime) or the
+// whole small body (pointer), so this bounded prefix is enough to identify one
+// without ever loading a huge/binary look-alike into memory. Matches the 64 KiB
+// bound trajectory/cleanup.ts already uses for the same ownership question.
+const TRAJECTORY_ARCHIVE_OWNERSHIP_PROOF_MAX_BYTES = 64 * 1024;
+
+function jsonRecordTraceSchemaEquals(text: string, expected: string): boolean {
+  try {
+    const parsed: unknown = JSON.parse(text);
+    return isRecord(parsed) && parsed.traceSchema === expected;
+  } catch {
+    return false;
+  }
+}
+
+// Ownership proof for deleting a suffix-matched archive that resolves OUTSIDE
+// the session store dir. The retention sweep follows trajectory tombstones into
+// an OPENCLAW_TRAJECTORY_DIR override (store-maintenance-operations.ts), and that
+// directory is the operator's: a pre-existing foreign file whose name merely
+// matches `.{reason}.{timestamp}` must never be reaped by suffix alone. Require
+// the trajectory header the recorder wrote (src/trajectory/runtime.ts) — the
+// runtime sidecar's first JSONL line, or the pointer's whole body. Reads at most
+// a bounded prefix and fails closed (kept) on anything unreadable, foreign, or
+// empty, so we never delete what we cannot prove is ours.
+function archivedFileIsOwnedTrajectoryArtifact(filePath: string): boolean {
+  let fd: number | null = null;
+  let prefix: string;
+  try {
+    const lst = fs.lstatSync(filePath);
+    if (!lst.isFile() || lst.isSymbolicLink()) {
+      return false;
+    }
+    fd = fs.openSync(filePath, "r");
+    const buffer = Buffer.alloc(TRAJECTORY_ARCHIVE_OWNERSHIP_PROOF_MAX_BYTES);
+    const bytesRead = fs.readSync(fd, buffer, 0, buffer.length, 0);
+    if (bytesRead <= 0) {
+      return false;
+    }
+    prefix = buffer.subarray(0, bytesRead).toString("utf8");
+  } catch {
+    return false;
+  } finally {
+    if (fd !== null) {
+      try {
+        fs.closeSync(fd);
+      } catch {
+        // Best-effort close of the read-only probe handle.
+      }
+    }
+  }
+  for (const line of prefix.split(/\r?\n/u)) {
+    const trimmed = line.trim();
+    if (!trimmed) {
+      continue;
+    }
+    // Only the first non-empty line can be the runtime sidecar header; if it is
+    // not, the file may still be a pointer, whose (pretty-printed) body is one
+    // JSON object spanning the whole bounded prefix.
+    return (
+      jsonRecordTraceSchemaEquals(trimmed, "openclaw-trajectory") ||
+      jsonRecordTraceSchemaEquals(prefix, "openclaw-trajectory-pointer")
+    );
+  }
+  return false;
+}
+
+function directoryIsWithinStoreDir(canonicalDir: string, canonicalStoreDir: string): boolean {
+  return canonicalDir === canonicalStoreDir || isPathInside(canonicalStoreDir, canonicalDir);
+}
+
 // Store maintenance runs this on every session-store save. All retention rules
 // share one directory listing: a listing per reason would multiply READDIR
 // load on the per-save hot path, which is expensive on networked filesystems.
@@ -501,11 +573,14 @@ export type SessionArchiveCleanupRule = {
 // `X.trajectory-path.json.deleted.<ts>`) age out under the exact same rules
 // and cadence as transcript tombstones for free, as long as they land in one
 // of `directories` — which they do by default, since the trajectory pair is
-// renamed beside its transcript (see trajectory/cleanup.ts).
+// renamed beside its transcript (see trajectory/cleanup.ts). A tombstone that
+// landed OUTSIDE the store dir (an OPENCLAW_TRAJECTORY_DIR override) ages by the
+// same rules but only after trajectory-ownership proof — see the storeDir guard.
 export async function cleanupArchivedSessionTranscripts(opts: {
   directories: string[];
   rules: SessionArchiveCleanupRule[];
   nowMs?: number;
+  storeDir?: string;
 }): Promise<{ removed: number; scanned: number }> {
   const rules = opts.rules.filter(
     (rule) => Number.isFinite(rule.olderThanMs) && rule.olderThanMs >= 0,
@@ -515,10 +590,20 @@ export async function cleanupArchivedSessionTranscripts(opts: {
   }
   const now = opts.nowMs ?? Date.now();
   const directories = uniqueStrings(opts.directories.map((dir) => path.resolve(dir)));
+  // The store dir is ours: suffix aging is safe for everything in it, so the hot
+  // common path takes no per-file header read. A directory outside it belongs to
+  // the operator (an OPENCLAW_TRAJECTORY_DIR override the tombstone sweep followed
+  // into), where only files carrying our trajectory header may be deleted.
+  // storeDir omitted = callers that only ever pass store-owned dirs → unchanged
+  // suffix aging everywhere.
+  const canonicalStoreDir = opts.storeDir ? canonicalizePathForComparison(opts.storeDir) : null;
   let removed = 0;
   let scanned = 0;
 
   for (const dir of directories) {
+    const externalDir =
+      canonicalStoreDir != null &&
+      !directoryIsWithinStoreDir(canonicalizePathForComparison(dir), canonicalStoreDir);
     const entries = await fs.promises.readdir(dir).catch(() => []);
     for (const entry of entries) {
       for (const rule of rules) {
@@ -530,7 +615,12 @@ export async function cleanupArchivedSessionTranscripts(opts: {
         if (now - timestamp > rule.olderThanMs) {
           const fullPath = path.join(dir, entry);
           const stat = await fs.promises.stat(fullPath).catch(() => null);
-          if (stat?.isFile()) {
+          // Outside the store dir, prove the aged file is ours before unlinking
+          // — never reap an operator's suffix look-alike by name alone.
+          const mayRemove =
+            stat?.isFile() === true &&
+            (!externalDir || archivedFileIsOwnedTrajectoryArtifact(fullPath));
+          if (mayRemove) {
             await fs.promises.rm(fullPath).catch(() => undefined);
             removed += 1;
           }

--- a/src/trajectory/cleanup.test.ts
+++ b/src/trajectory/cleanup.test.ts
@@ -58,8 +58,30 @@ async function expectPathMissing(targetPath: string): Promise<void> {
   expect((statError as NodeJS.ErrnoException | undefined)?.code).toBe("ENOENT");
 }
 
+async function findTombstone(
+  originalPath: string,
+  reason: "reset" | "deleted",
+): Promise<string | undefined> {
+  const dir = path.dirname(originalPath);
+  const prefix = `${path.basename(originalPath)}.${reason}.`;
+  const entries = await fs.readdir(dir).catch(() => []);
+  const match = entries.find((name) => name.startsWith(prefix));
+  return match ? path.join(dir, match) : undefined;
+}
+
+/** Asserts originalPath is gone and a matching tombstone now exists; returns its path. */
+async function expectTombstoned(
+  originalPath: string,
+  reason: "reset" | "deleted",
+): Promise<string> {
+  await expectPathMissing(originalPath);
+  const tombstone = await findTombstone(originalPath, reason);
+  expect(tombstone).toBeDefined();
+  return tombstone as string;
+}
+
 describe("trajectory cleanup", () => {
-  it("removes adjacent trajectory sidecars for a deleted session", async () => {
+  it("tombstones adjacent trajectory sidecars into .deleted.<timestamp> for a deleted session", async () => {
     await withTempDir({ prefix: "openclaw-trajectory-cleanup-" }, async (dir) => {
       const sessionId = "session-1";
       const storePath = path.join(dir, "sessions.json");
@@ -74,11 +96,15 @@ describe("trajectory cleanup", () => {
         sessionFile,
         storePath,
         restrictToStoreDir: true,
+        disposal: { mode: "tombstone", reason: "deleted" },
       });
 
       expect(removed.map((entry) => entry.kind).toSorted()).toEqual(["pointer", "runtime"]);
-      await expectPathMissing(runtimeFile);
-      await expectPathMissing(pointerPath);
+      const runtimeTombstone = await expectTombstoned(runtimeFile, "deleted");
+      const pointerTombstone = await expectTombstoned(pointerPath, "deleted");
+      expect(removed.map((entry) => entry.path).toSorted()).toEqual(
+        [runtimeTombstone, pointerTombstone].toSorted(),
+      );
     });
   });
 
@@ -97,6 +123,7 @@ describe("trajectory cleanup", () => {
         referencedSessionIds: new Set([sessionId]),
         storePath,
         restrictToStoreDir: true,
+        disposal: { mode: "tombstone", reason: "deleted" },
       });
 
       expect(removed).toStrictEqual([]);
@@ -126,10 +153,11 @@ describe("trajectory cleanup", () => {
         sessionFile,
         storePath,
         restrictToStoreDir: true,
+        disposal: { mode: "tombstone", reason: "deleted" },
       });
 
-      await expectPathMissing(safeExternalRuntime);
-      await expectPathMissing(pointerPath);
+      await expectTombstoned(safeExternalRuntime, "deleted");
+      await expectTombstoned(pointerPath, "deleted");
 
       await fs.writeFile(pointerPath, pointerFile(sessionId, unsafeExternalRuntime), "utf8");
       await removeSessionTrajectoryArtifacts({
@@ -137,6 +165,7 @@ describe("trajectory cleanup", () => {
         sessionFile,
         storePath,
         restrictToStoreDir: true,
+        disposal: { mode: "tombstone", reason: "deleted" },
       });
 
       expect((await fs.stat(unsafeExternalRuntime)).isFile()).toBe(true);
@@ -162,15 +191,16 @@ describe("trajectory cleanup", () => {
         sessionFile,
         storePath,
         restrictToStoreDir: true,
+        disposal: { mode: "tombstone", reason: "deleted" },
       });
 
-      expect(removed).toEqual([{ kind: "pointer", path: pointerPath }]);
+      const pointerTombstone = await expectTombstoned(pointerPath, "deleted");
+      expect(removed).toEqual([{ kind: "pointer", path: pointerTombstone }]);
       expect((await fs.stat(unrelatedTranscript)).isFile()).toBe(true);
-      await expectPathMissing(pointerPath);
     });
   });
 
-  it("continues best-effort cleanup when one artifact cannot be unlinked", async () => {
+  it("continues best-effort cleanup when one artifact cannot be archived", async () => {
     await withTempDir({ prefix: "openclaw-trajectory-cleanup-" }, async (dir) => {
       const sessionId = "session-4";
       const storePath = path.join(dir, "sessions.json");
@@ -179,8 +209,8 @@ describe("trajectory cleanup", () => {
       const pointerPath = resolveTrajectoryPointerFilePath(sessionFile);
       await fs.writeFile(runtimeFile, runtimeEvent(sessionId), "utf8");
       await fs.writeFile(pointerPath, pointerFile(sessionId, runtimeFile), "utf8");
-      const removeFailure = Object.assign(new Error("busy"), { code: "EBUSY" });
-      const rmSpy = vi.spyOn(nodeFs.promises, "rm").mockRejectedValueOnce(removeFailure);
+      const archiveFailure = Object.assign(new Error("busy"), { code: "EBUSY" });
+      const renameSpy = vi.spyOn(nodeFs.promises, "rename").mockRejectedValueOnce(archiveFailure);
 
       try {
         const removed = await removeSessionTrajectoryArtifacts({
@@ -188,18 +218,21 @@ describe("trajectory cleanup", () => {
           sessionFile,
           storePath,
           restrictToStoreDir: true,
+          disposal: { mode: "tombstone", reason: "deleted" },
         });
 
-        expect(removed).toEqual([{ kind: "pointer", path: pointerPath }]);
+        const pointerTombstone = await expectTombstoned(pointerPath, "deleted");
+        expect(removed).toEqual([{ kind: "pointer", path: pointerTombstone }]);
+        // The runtime rename was the one made to fail — it stays exactly where
+        // it was, not tombstoned, matching the best-effort contract.
         expect((await fs.stat(runtimeFile)).isFile()).toBe(true);
-        await expectPathMissing(pointerPath);
       } finally {
-        rmSpy.mockRestore();
+        renameSpy.mockRestore();
       }
     });
   });
 
-  it("retires the canonical path before unlinking the runtime file", async () => {
+  it("retires the canonical path before archiving the runtime file", async () => {
     await withTempDir({ prefix: "openclaw-trajectory-cleanup-" }, async (dir) => {
       const sessionId = "session-5";
       const storePath = path.join(dir, "sessions.json");
@@ -220,6 +253,7 @@ describe("trajectory cleanup", () => {
         sessionFile,
         storePath,
         restrictToStoreDir: true,
+        disposal: { mode: "tombstone", reason: "deleted" },
       });
 
       const afterRemoval = await withTrajectoryPathLock(canonicalPath, (ctx) => ctx);
@@ -261,9 +295,10 @@ describe("trajectory cleanup", () => {
         sessionFile: sessionFileA,
         storePath,
         restrictToStoreDir: true,
+        disposal: { mode: "tombstone", reason: "deleted" },
       });
 
-      await expectPathMissing(leaseA.filePath);
+      await expectTombstoned(leaseA.filePath, "deleted");
       expect((await fs.stat(leaseB.filePath)).isFile()).toBe(true);
     });
   });
@@ -306,15 +341,16 @@ describe("trajectory cleanup", () => {
         sessionFile: sessionFileB,
         storePath,
         restrictToStoreDir: true,
+        disposal: { mode: "tombstone", reason: "deleted" },
       });
 
-      await expectPathMissing(leaseB.filePath);
-      await expectPathMissing(pointerPathB);
+      await expectTombstoned(leaseB.filePath, "deleted");
+      await expectTombstoned(pointerPathB, "deleted");
       expect((await fs.stat(leaseA.filePath)).isFile()).toBe(true);
     });
   });
 
-  it("does not admit a writer claim while a delete's unlink is still in flight", async () => {
+  it("does not admit a writer claim while a delete's archive-rename is still in flight", async () => {
     await withTempDir({ prefix: "openclaw-trajectory-cleanup-" }, async (dir) => {
       const sessionId = "session-7";
       const storePath = path.join(dir, "sessions.json");
@@ -325,18 +361,18 @@ describe("trajectory cleanup", () => {
       await fs.writeFile(pointerPath, pointerFile(sessionId, runtimeFile), "utf8");
 
       const order: string[] = [];
-      const originalRm = nodeFs.promises.rm.bind(nodeFs.promises);
-      let releaseUnlink: () => void = () => {};
-      const unlinkGate = new Promise<void>((resolve) => {
-        releaseUnlink = resolve;
+      const originalRename = nodeFs.promises.rename.bind(nodeFs.promises);
+      let releaseArchive: () => void = () => {};
+      const archiveGate = new Promise<void>((resolve) => {
+        releaseArchive = resolve;
       });
-      const rmSpy = vi
-        .spyOn(nodeFs.promises, "rm")
-        .mockImplementation(async (target: nodeFs.PathLike, options?: nodeFs.RmOptions) => {
-          order.push("unlink-start");
-          await unlinkGate;
-          const result = await originalRm(target, options);
-          order.push("unlink-done");
+      const renameSpy = vi
+        .spyOn(nodeFs.promises, "rename")
+        .mockImplementation(async (src: nodeFs.PathLike, dest: nodeFs.PathLike) => {
+          order.push("archive-start");
+          await archiveGate;
+          const result = await originalRename(src, dest);
+          order.push("archive-done");
           return result;
         });
 
@@ -346,14 +382,15 @@ describe("trajectory cleanup", () => {
           sessionFile,
           storePath,
           restrictToStoreDir: true,
+          disposal: { mode: "tombstone", reason: "deleted" },
         });
 
         // Let the delete turn's synchronous claim+retire run and reach the
-        // paused unlink before attempting a concurrent claim.
+        // paused archive rename before attempting a concurrent claim.
         await new Promise<void>((resolve) => {
           setImmediate(() => resolve());
         });
-        expect(order).toEqual(["unlink-start"]);
+        expect(order).toEqual(["archive-start"]);
 
         const acquirePromise = acquireTrajectoryWriterLease({
           sessionId,
@@ -364,28 +401,29 @@ describe("trajectory cleanup", () => {
         });
 
         // The claim must queue behind the per-path lock, not run concurrently
-        // with the paused unlink (P1-A) — give it every chance to (wrongly)
-        // resolve early before asserting it hasn't.
+        // with the paused archive rename (P1-A) — give it every chance to
+        // (wrongly) resolve early before asserting it hasn't.
         await new Promise<void>((resolve) => {
           setImmediate(() => resolve());
         });
-        expect(order).toEqual(["unlink-start"]);
+        expect(order).toEqual(["archive-start"]);
 
-        releaseUnlink();
+        releaseArchive();
         const [, lease] = await Promise.all([deletePromise, acquirePromise]);
 
-        expect(order.indexOf("unlink-done")).toBeLessThan(order.indexOf("acquire-done"));
+        expect(order.indexOf("archive-done")).toBeLessThan(order.indexOf("acquire-done"));
         expect(lease.filePath).toBe(runtimeFile);
-        // The claim was only admitted after delete's unlink fully committed,
-        // so it cannot have reactivated or recreated the deleted artifact.
-        await expectPathMissing(runtimeFile);
+        // The claim was only admitted after delete's archive rename fully
+        // committed, so it cannot have reactivated or recreated the tombstoned
+        // artifact — the original path is free and a fresh tombstone exists.
+        await expectTombstoned(runtimeFile, "deleted");
       } finally {
-        rmSpy.mockRestore();
+        renameSpy.mockRestore();
       }
     });
   });
 
-  it("keeps a queued re-acquisition's fresh runtime and pointer intact against a racing delete's pointer removal", async () => {
+  it("keeps a queued re-acquisition's fresh runtime and pointer intact against a racing delete's pointer archive", async () => {
     await withTempDir({ prefix: "openclaw-trajectory-cleanup-" }, async (dir) => {
       const sessionId = "session-8";
       const storePath = path.join(dir, "sessions.json");
@@ -396,22 +434,22 @@ describe("trajectory cleanup", () => {
       await fs.writeFile(pointerPath, pointerFile(sessionId, runtimeFile), "utf8");
 
       const order: string[] = [];
-      const originalRm = nodeFs.promises.rm.bind(nodeFs.promises);
-      let releasePointerRemoval: () => void = () => {};
-      const pointerRemovalGate = new Promise<void>((resolve) => {
-        releasePointerRemoval = resolve;
+      const originalRename = nodeFs.promises.rename.bind(nodeFs.promises);
+      let releasePointerArchive: () => void = () => {};
+      const pointerArchiveGate = new Promise<void>((resolve) => {
+        releasePointerArchive = resolve;
       });
-      const rmSpy = vi
-        .spyOn(nodeFs.promises, "rm")
-        .mockImplementation(async (target: nodeFs.PathLike, options?: nodeFs.RmOptions) => {
-          const isPointerTarget = String(target) === pointerPath;
+      const renameSpy = vi
+        .spyOn(nodeFs.promises, "rename")
+        .mockImplementation(async (src: nodeFs.PathLike, dest: nodeFs.PathLike) => {
+          const isPointerTarget = String(src) === pointerPath;
           if (isPointerTarget) {
-            order.push("pointer-unlink-start");
-            await pointerRemovalGate;
+            order.push("pointer-archive-start");
+            await pointerArchiveGate;
           }
-          const result = await originalRm(target, options);
+          const result = await originalRename(src, dest);
           if (isPointerTarget) {
-            order.push("pointer-unlink-done");
+            order.push("pointer-archive-done");
           }
           return result;
         });
@@ -422,29 +460,30 @@ describe("trajectory cleanup", () => {
           sessionFile,
           storePath,
           restrictToStoreDir: true,
+          disposal: { mode: "tombstone", reason: "deleted" },
         });
 
-        // Let delete's locked turn remove the runtime file and reach the
-        // paused pointer removal — still inside the SAME turn once fixed —
+        // Let delete's locked turn archive the runtime file and reach the
+        // paused pointer archive — still inside the SAME turn once fixed —
         // before attempting a concurrent re-acquisition for the same
         // session (ordering (B) from the round-4 finding). The runtime
-        // file's own (unpaused) removal is real disk I/O, so poll rather
+        // file's own (unpaused) rename is real disk I/O, so poll rather
         // than assume a fixed number of ticks.
         for (let attempt = 0; attempt < 50 && order.length === 0; attempt += 1) {
           await new Promise<void>((resolve) => {
             setImmediate(() => resolve());
           });
         }
-        expect(order).toEqual(["pointer-unlink-start"]);
+        expect(order).toEqual(["pointer-archive-start"]);
 
         const recorderPromise = createTrajectoryRuntimeRecorder({ sessionId, sessionFile });
 
         await new Promise<void>((resolve) => {
           setImmediate(() => resolve());
         });
-        expect(order).toEqual(["pointer-unlink-start"]);
+        expect(order).toEqual(["pointer-archive-start"]);
 
-        releasePointerRemoval();
+        releasePointerArchive();
         const [, recorder] = await Promise.all([deletePromise, recorderPromise]);
         if (!recorder) {
           throw new Error("expected trajectory runtime recorder");
@@ -452,6 +491,16 @@ describe("trajectory cleanup", () => {
         recorder.recordEvent("prompt.submitted", { marker: "post-race-owner" });
         await recorder.flush();
 
+        // Delete's OWN pair tombstoned (the runtime rename already completed
+        // unpaused, before this test even started polling for pointer-archive-start).
+        await findTombstone(runtimeFile, "deleted").then((tombstone) =>
+          expect(tombstone).toBeDefined(),
+        );
+        await findTombstone(pointerPath, "deleted").then((tombstone) =>
+          expect(tombstone).toBeDefined(),
+        );
+
+        // The NEW owner's fresh pair is live at the original (now-vacant) paths.
         const pointerContent = JSON.parse(nodeFs.readFileSync(pointerPath, "utf8")) as {
           runtimeFile?: string;
         };
@@ -459,7 +508,7 @@ describe("trajectory cleanup", () => {
         expect(nodeFs.existsSync(recorder.filePath)).toBe(true);
         expect(nodeFs.readFileSync(recorder.filePath, "utf8")).toContain("post-race-owner");
       } finally {
-        rmSpy.mockRestore();
+        renameSpy.mockRestore();
       }
     });
   });

--- a/src/trajectory/cleanup.test.ts
+++ b/src/trajectory/cleanup.test.ts
@@ -200,9 +200,9 @@ describe("trajectory cleanup", () => {
       await fs.writeFile(pointerPath, pointerFile(sessionId, runtimeFile), "utf8");
 
       const canonicalPath = canonicalizeTrajectoryPath(runtimeFile);
-      const generationBefore = await withTrajectoryPathLock(
+      const incarnationBefore = await withTrajectoryPathLock(
         canonicalPath,
-        (ctx) => ctx.currentGeneration,
+        (ctx) => ctx.currentIncarnation,
       );
 
       await removeSessionTrajectoryArtifacts({
@@ -214,7 +214,7 @@ describe("trajectory cleanup", () => {
 
       const afterRemoval = await withTrajectoryPathLock(canonicalPath, (ctx) => ctx);
       expect(afterRemoval.retired).toBe(true);
-      expect(afterRemoval.currentGeneration).toBeGreaterThan(generationBefore);
+      expect(afterRemoval.currentIncarnation).toBeGreaterThan(incarnationBefore);
     });
   });
 
@@ -228,11 +228,11 @@ describe("trajectory cleanup", () => {
       const sessionFileB = path.join(dir, "session-b.jsonl");
       const env = { OPENCLAW_TRAJECTORY_DIR: trajectoryDir };
 
-      const leaseA = acquireTrajectoryWriterLease({
+      const leaseA = await acquireTrajectoryWriterLease({
         sessionId: sessionAId,
         candidatePath: resolveTrajectoryFilePath({ env, sessionId: sessionAId }),
       });
-      const leaseB = acquireTrajectoryWriterLease({
+      const leaseB = await acquireTrajectoryWriterLease({
         sessionId: sessionBId,
         candidatePath: resolveTrajectoryFilePath({ env, sessionId: sessionBId }),
       });
@@ -255,6 +255,73 @@ describe("trajectory cleanup", () => {
 
       await expectPathMissing(leaseA.filePath);
       expect((await fs.stat(leaseB.filePath)).isFile()).toBe(true);
+    });
+  });
+
+  it("does not admit a writer claim while a delete's unlink is still in flight", async () => {
+    await withTempDir({ prefix: "openclaw-trajectory-cleanup-" }, async (dir) => {
+      const sessionId = "session-7";
+      const storePath = path.join(dir, "sessions.json");
+      const sessionFile = path.join(dir, `${sessionId}.jsonl`);
+      const runtimeFile = resolveTrajectoryFilePath({ env: {}, sessionFile, sessionId });
+      const pointerPath = resolveTrajectoryPointerFilePath(sessionFile);
+      await fs.writeFile(runtimeFile, runtimeEvent(sessionId), "utf8");
+      await fs.writeFile(pointerPath, pointerFile(sessionId, runtimeFile), "utf8");
+
+      const order: string[] = [];
+      const originalRm = nodeFs.promises.rm.bind(nodeFs.promises);
+      let releaseUnlink: () => void = () => {};
+      const unlinkGate = new Promise<void>((resolve) => {
+        releaseUnlink = resolve;
+      });
+      const rmSpy = vi
+        .spyOn(nodeFs.promises, "rm")
+        .mockImplementation(async (target: nodeFs.PathLike, options?: nodeFs.RmOptions) => {
+          order.push("unlink-start");
+          await unlinkGate;
+          const result = await originalRm(target, options);
+          order.push("unlink-done");
+          return result;
+        });
+
+      try {
+        const deletePromise = removeSessionTrajectoryArtifacts({
+          sessionId,
+          sessionFile,
+          storePath,
+          restrictToStoreDir: true,
+        });
+
+        // Let the delete turn's synchronous claim+retire run and reach the
+        // paused unlink before attempting a concurrent claim.
+        await new Promise((resolve) => setImmediate(resolve));
+        expect(order).toEqual(["unlink-start"]);
+
+        const acquirePromise = acquireTrajectoryWriterLease({
+          sessionId,
+          candidatePath: runtimeFile,
+        }).then((lease) => {
+          order.push("acquire-done");
+          return lease;
+        });
+
+        // The claim must queue behind the per-path lock, not run concurrently
+        // with the paused unlink (P1-A) — give it every chance to (wrongly)
+        // resolve early before asserting it hasn't.
+        await new Promise((resolve) => setImmediate(resolve));
+        expect(order).toEqual(["unlink-start"]);
+
+        releaseUnlink();
+        const [, lease] = await Promise.all([deletePromise, acquirePromise]);
+
+        expect(order.indexOf("unlink-done")).toBeLessThan(order.indexOf("acquire-done"));
+        expect(lease.filePath).toBe(runtimeFile);
+        // The claim was only admitted after delete's unlink fully committed,
+        // so it cannot have reactivated or recreated the deleted artifact.
+        await expectPathMissing(runtimeFile);
+      } finally {
+        rmSpy.mockRestore();
+      }
     });
   });
 });

--- a/src/trajectory/cleanup.test.ts
+++ b/src/trajectory/cleanup.test.ts
@@ -252,7 +252,7 @@ describe("trajectory cleanup", () => {
     });
   });
 
-  it("continues best-effort cleanup when one artifact cannot be archived", async () => {
+  it("commits the runtime archive even when the pointer archive fails best-effort", async () => {
     await withTempDir({ prefix: "openclaw-trajectory-cleanup-" }, async (dir) => {
       const sessionId = "session-4";
       const storePath = path.join(dir, "sessions.json");
@@ -261,8 +261,19 @@ describe("trajectory cleanup", () => {
       const pointerPath = resolveTrajectoryPointerFilePath(sessionFile);
       await fs.writeFile(runtimeFile, runtimeEvent(sessionId), "utf8");
       await fs.writeFile(pointerPath, pointerFile(sessionId, runtimeFile), "utf8");
-      const archiveFailure = Object.assign(new Error("busy"), { code: "EBUSY" });
-      const renameSpy = vi.spyOn(nodeFs.promises, "rename").mockRejectedValueOnce(archiveFailure);
+
+      // Fail ONLY the pointer's archive rename. The runtime archive (the
+      // disposal commit point) still succeeds, so the pointer is the sole
+      // best-effort casualty — the runtime is not held hostage to it.
+      const originalRename = nodeFs.promises.rename.bind(nodeFs.promises);
+      const renameSpy = vi
+        .spyOn(nodeFs.promises, "rename")
+        .mockImplementation(async (src: nodeFs.PathLike, dest: nodeFs.PathLike) => {
+          if (String(src) === pointerPath) {
+            throw Object.assign(new Error("busy"), { code: "EBUSY" });
+          }
+          return originalRename(src, dest);
+        });
 
       try {
         const removed = await removeSessionTrajectoryArtifacts({
@@ -273,11 +284,88 @@ describe("trajectory cleanup", () => {
           disposal: { mode: "tombstone", reason: "deleted" },
         });
 
-        const pointerTombstone = await expectTombstoned(pointerPath, "deleted");
-        expect(removed).toEqual([{ kind: "pointer", path: pointerTombstone }]);
-        // The runtime rename was the one made to fail — it stays exactly where
+        const runtimeTombstone = await expectTombstoned(runtimeFile, "deleted");
+        expect(removed).toEqual([{ kind: "runtime", path: runtimeTombstone }]);
+        // The pointer rename was the one made to fail — it stays exactly where
         // it was, not tombstoned, matching the best-effort contract.
+        expect((await fs.stat(pointerPath)).isFile()).toBe(true);
+      } finally {
+        renameSpy.mockRestore();
+      }
+    });
+  });
+
+  it("leaves the trajectory pair fully live when the runtime archive fails, then disposes on retry", async () => {
+    await withTempDir({ prefix: "openclaw-trajectory-cleanup-" }, async (dir) => {
+      const sessionId = "session-9";
+      const storePath = path.join(dir, "sessions.json");
+      const sessionFile = path.join(dir, `${sessionId}.jsonl`);
+      const runtimeFile = resolveTrajectoryFilePath({ env: {}, sessionFile, sessionId });
+      const pointerPath = resolveTrajectoryPointerFilePath(sessionFile);
+      await fs.writeFile(runtimeFile, runtimeEvent(sessionId), "utf8");
+      await fs.writeFile(pointerPath, pointerFile(sessionId, runtimeFile), "utf8");
+
+      // A live writer owns the canonical path. Its lease incarnation must
+      // survive a failed disposal unchanged so it can still flush afterwards —
+      // the rollback restores the prior entry verbatim, it does not re-claim.
+      const canonicalPath = canonicalizeTrajectoryPath(runtimeFile);
+      const lease = await acquireTrajectoryWriterLease({ sessionId, candidatePath: runtimeFile });
+      const liveIncarnation = lease.incarnation;
+
+      // Fail ONLY the runtime file's archive rename (the commit point);
+      // everything else, including the retry below, renames normally.
+      const originalRename = nodeFs.promises.rename.bind(nodeFs.promises);
+      let failRuntimeRename = true;
+      const renameSpy = vi
+        .spyOn(nodeFs.promises, "rename")
+        .mockImplementation(async (src: nodeFs.PathLike, dest: nodeFs.PathLike) => {
+          if (failRuntimeRename && String(src) === runtimeFile) {
+            throw Object.assign(new Error("busy"), { code: "EBUSY" });
+          }
+          return originalRename(src, dest);
+        });
+
+      try {
+        const removedOnFailure = await removeSessionTrajectoryArtifacts({
+          sessionId,
+          sessionFile,
+          storePath,
+          restrictToStoreDir: true,
+          disposal: { mode: "tombstone", reason: "deleted" },
+        });
+
+        // Nothing disposed, nothing thrown: both artifacts stay at their live
+        // paths with no tombstone, and the registry entry stays live and owned
+        // at its ORIGINAL incarnation (a verbatim rollback, not a fresh claim),
+        // so the live writer's lease still validates and the pair is retryable.
+        expect(removedOnFailure).toEqual([]);
         expect((await fs.stat(runtimeFile)).isFile()).toBe(true);
+        expect((await fs.stat(pointerPath)).isFile()).toBe(true);
+        expect(await findTombstone(runtimeFile, "deleted")).toBeUndefined();
+        expect(await findTombstone(pointerPath, "deleted")).toBeUndefined();
+        const afterFailure = await withTrajectoryPathLock(canonicalPath, (ctx) => ctx);
+        expect(afterFailure.retired).toBe(false);
+        expect(afterFailure.currentIncarnation).toBe(liveIncarnation);
+
+        // Retry once the rename recovers: the pair now tombstones normally.
+        failRuntimeRename = false;
+        const removedOnRetry = await removeSessionTrajectoryArtifacts({
+          sessionId,
+          sessionFile,
+          storePath,
+          restrictToStoreDir: true,
+          disposal: { mode: "tombstone", reason: "deleted" },
+        });
+
+        const runtimeTombstone = await expectTombstoned(runtimeFile, "deleted");
+        const pointerTombstone = await expectTombstoned(pointerPath, "deleted");
+        expect(removedOnRetry.map((entry) => entry.kind).toSorted()).toEqual([
+          "pointer",
+          "runtime",
+        ]);
+        expect(removedOnRetry.map((entry) => entry.path).toSorted()).toEqual(
+          [runtimeTombstone, pointerTombstone].toSorted(),
+        );
       } finally {
         renameSpy.mockRestore();
       }

--- a/src/trajectory/cleanup.test.ts
+++ b/src/trajectory/cleanup.test.ts
@@ -294,7 +294,9 @@ describe("trajectory cleanup", () => {
 
         // Let the delete turn's synchronous claim+retire run and reach the
         // paused unlink before attempting a concurrent claim.
-        await new Promise((resolve) => setImmediate(resolve));
+        await new Promise<void>((resolve) => {
+          setImmediate(() => resolve());
+        });
         expect(order).toEqual(["unlink-start"]);
 
         const acquirePromise = acquireTrajectoryWriterLease({
@@ -308,7 +310,9 @@ describe("trajectory cleanup", () => {
         // The claim must queue behind the per-path lock, not run concurrently
         // with the paused unlink (P1-A) — give it every chance to (wrongly)
         // resolve early before asserting it hasn't.
-        await new Promise((resolve) => setImmediate(resolve));
+        await new Promise<void>((resolve) => {
+          setImmediate(() => resolve());
+        });
         expect(order).toEqual(["unlink-start"]);
 
         releaseUnlink();

--- a/src/trajectory/cleanup.test.ts
+++ b/src/trajectory/cleanup.test.ts
@@ -8,6 +8,11 @@ import {
   removeSessionTrajectoryArtifacts,
 } from "./cleanup.js";
 import { resolveTrajectoryFilePath, resolveTrajectoryPointerFilePath } from "./paths.js";
+import {
+  acquireTrajectoryWriterLease,
+  canonicalizeTrajectoryPath,
+  withTrajectoryPathLock,
+} from "./writer-lifecycle.js";
 
 function runtimeEvent(sessionId: string): string {
   return `${JSON.stringify({
@@ -124,6 +129,131 @@ describe("trajectory cleanup", () => {
       });
 
       expect((await fs.stat(unsafeExternalRuntime)).isFile()).toBe(true);
+    });
+  });
+
+  it("does not trust an unrelated pointer target merely because it is in the sessions dir", async () => {
+    await withTempDir({ prefix: "openclaw-trajectory-cleanup-" }, async (dir) => {
+      const sessionId = "session-3";
+      const storePath = path.join(dir, "sessions.json");
+      const sessionFile = path.join(dir, "custom-transcript.jsonl");
+      const unrelatedTranscript = path.join(dir, `${sessionId}.jsonl`);
+      const pointerPath = resolveTrajectoryPointerFilePath(sessionFile);
+      await fs.writeFile(
+        unrelatedTranscript,
+        `${JSON.stringify({ type: "session", id: "unrelated-session" })}\n`,
+        "utf8",
+      );
+      await fs.writeFile(pointerPath, pointerFile(sessionId, unrelatedTranscript), "utf8");
+
+      const removed = await removeSessionTrajectoryArtifacts({
+        sessionId,
+        sessionFile,
+        storePath,
+        restrictToStoreDir: true,
+      });
+
+      expect(removed).toEqual([{ kind: "pointer", path: pointerPath }]);
+      expect((await fs.stat(unrelatedTranscript)).isFile()).toBe(true);
+      await expectPathMissing(pointerPath);
+    });
+  });
+
+  it("continues best-effort cleanup when one artifact cannot be unlinked", async () => {
+    await withTempDir({ prefix: "openclaw-trajectory-cleanup-" }, async (dir) => {
+      const sessionId = "session-4";
+      const storePath = path.join(dir, "sessions.json");
+      const sessionFile = path.join(dir, `${sessionId}.jsonl`);
+      const runtimeFile = resolveTrajectoryFilePath({ env: {}, sessionFile, sessionId });
+      const pointerPath = resolveTrajectoryPointerFilePath(sessionFile);
+      await fs.writeFile(runtimeFile, runtimeEvent(sessionId), "utf8");
+      await fs.writeFile(pointerPath, pointerFile(sessionId, runtimeFile), "utf8");
+      const removeFailure = Object.assign(new Error("busy"), { code: "EBUSY" });
+      const rmSpy = vi.spyOn(nodeFs.promises, "rm").mockRejectedValueOnce(removeFailure);
+
+      try {
+        const removed = await removeSessionTrajectoryArtifacts({
+          sessionId,
+          sessionFile,
+          storePath,
+          restrictToStoreDir: true,
+        });
+
+        expect(removed).toEqual([{ kind: "pointer", path: pointerPath }]);
+        expect((await fs.stat(runtimeFile)).isFile()).toBe(true);
+        await expectPathMissing(pointerPath);
+      } finally {
+        rmSpy.mockRestore();
+      }
+    });
+  });
+
+  it("retires the canonical path before unlinking the runtime file", async () => {
+    await withTempDir({ prefix: "openclaw-trajectory-cleanup-" }, async (dir) => {
+      const sessionId = "session-5";
+      const storePath = path.join(dir, "sessions.json");
+      const sessionFile = path.join(dir, `${sessionId}.jsonl`);
+      const runtimeFile = resolveTrajectoryFilePath({ env: {}, sessionFile, sessionId });
+      const pointerPath = resolveTrajectoryPointerFilePath(sessionFile);
+      await fs.writeFile(runtimeFile, runtimeEvent(sessionId), "utf8");
+      await fs.writeFile(pointerPath, pointerFile(sessionId, runtimeFile), "utf8");
+
+      const canonicalPath = canonicalizeTrajectoryPath(runtimeFile);
+      const generationBefore = await withTrajectoryPathLock(
+        canonicalPath,
+        (ctx) => ctx.currentGeneration,
+      );
+
+      await removeSessionTrajectoryArtifacts({
+        sessionId,
+        sessionFile,
+        storePath,
+        restrictToStoreDir: true,
+      });
+
+      const afterRemoval = await withTrajectoryPathLock(canonicalPath, (ctx) => ctx);
+      expect(afterRemoval.retired).toBe(true);
+      expect(afterRemoval.currentGeneration).toBeGreaterThan(generationBefore);
+    });
+  });
+
+  it("does not cross-delete a colliding sibling session's disambiguated file", async () => {
+    await withTempDir({ prefix: "openclaw-trajectory-cleanup-" }, async (dir) => {
+      const storePath = path.join(dir, "sessions.json");
+      const trajectoryDir = path.join(dir, "traces");
+      const sessionAId = "abc*def";
+      const sessionBId = "abc_def";
+      const sessionFileA = path.join(dir, "session-a.jsonl");
+      const sessionFileB = path.join(dir, "session-b.jsonl");
+      const env = { OPENCLAW_TRAJECTORY_DIR: trajectoryDir };
+
+      const leaseA = acquireTrajectoryWriterLease({
+        sessionId: sessionAId,
+        candidatePath: resolveTrajectoryFilePath({ env, sessionId: sessionAId }),
+      });
+      const leaseB = acquireTrajectoryWriterLease({
+        sessionId: sessionBId,
+        candidatePath: resolveTrajectoryFilePath({ env, sessionId: sessionBId }),
+      });
+      expect(leaseA.filePath).not.toBe(leaseB.filePath);
+
+      await fs.mkdir(trajectoryDir, { recursive: true });
+      await fs.writeFile(leaseA.filePath, runtimeEvent(sessionAId), "utf8");
+      await fs.writeFile(leaseB.filePath, runtimeEvent(sessionBId), "utf8");
+      const pointerPathA = resolveTrajectoryPointerFilePath(sessionFileA);
+      const pointerPathB = resolveTrajectoryPointerFilePath(sessionFileB);
+      await fs.writeFile(pointerPathA, pointerFile(sessionAId, leaseA.filePath), "utf8");
+      await fs.writeFile(pointerPathB, pointerFile(sessionBId, leaseB.filePath), "utf8");
+
+      await removeSessionTrajectoryArtifacts({
+        sessionId: sessionAId,
+        sessionFile: sessionFileA,
+        storePath,
+        restrictToStoreDir: true,
+      });
+
+      await expectPathMissing(leaseA.filePath);
+      expect((await fs.stat(leaseB.filePath)).isFile()).toBe(true);
     });
   });
 });

--- a/src/trajectory/cleanup.test.ts
+++ b/src/trajectory/cleanup.test.ts
@@ -158,6 +158,13 @@ describe("trajectory cleanup", () => {
 
       await expectTombstoned(safeExternalRuntime, "deleted");
       await expectTombstoned(pointerPath, "deleted");
+      // The first disposal above left a retired (but still sessionId-owned)
+      // registry entry for safeExternalRuntime's now-vacant canonical path —
+      // findTrajectoryPathOwnedBySession does not distinguish retired from
+      // live. Clear it so the second scenario below genuinely exercises "no
+      // registry owner at all", matching a real maintenance sweep running
+      // long after any writer process for this session exited.
+      clearTrajectoryWriterLifecycleRegistryForTest();
 
       await fs.writeFile(pointerPath, pointerFile(sessionId, unsafeExternalRuntime), "utf8");
       await removeSessionTrajectoryArtifacts({
@@ -169,6 +176,51 @@ describe("trajectory cleanup", () => {
       });
 
       expect((await fs.stat(unsafeExternalRuntime)).isFile()).toBe(true);
+      // Round 5 P1: an unprovable external target must not cost the pointer
+      // either — disposing it here would orphan unsafeExternalRuntime with
+      // no discovery path left, even though the runtime itself was (rightly)
+      // left untouched above.
+      expect((await fs.stat(pointerPath)).isFile()).toBe(true);
+    });
+  });
+
+  it("tombstones a proven external trajectory pair together, in its own directory, with no live registry owner", async () => {
+    // Reproduces the maintenance-driven shape of the round-5 P1 finding: the
+    // writer process is long gone (no acquireTrajectoryWriterLease call in
+    // this test at all, so the registry has no owner record), and only the
+    // persisted pointer + external runtime file on disk remain — exactly
+    // what a per-save maintenance sweep discovers well after a session goes
+    // idle under a configured OPENCLAW_TRAJECTORY_DIR.
+    await withTempDir({ prefix: "openclaw-trajectory-cleanup-" }, async (dir) => {
+      const sessionId = "session-11";
+      const sessionsDir = path.join(dir, "sessions");
+      const storePath = path.join(sessionsDir, "sessions.json");
+      const sessionFile = path.join(sessionsDir, `${sessionId}.jsonl`);
+      const externalDir = path.join(dir, "external");
+      await fs.mkdir(sessionsDir);
+      await fs.mkdir(externalDir);
+      const externalRuntime = path.join(externalDir, `${sessionId}.jsonl`);
+      await fs.writeFile(externalRuntime, runtimeEvent(sessionId), "utf8");
+      const pointerPath = resolveTrajectoryPointerFilePath(sessionFile);
+      await fs.writeFile(pointerPath, pointerFile(sessionId, externalRuntime), "utf8");
+
+      const removed = await removeSessionTrajectoryArtifacts({
+        sessionId,
+        sessionFile,
+        storePath,
+        restrictToStoreDir: true,
+        disposal: { mode: "tombstone", reason: "deleted" },
+      });
+
+      const runtimeTombstone = await expectTombstoned(externalRuntime, "deleted");
+      const pointerTombstone = await expectTombstoned(pointerPath, "deleted");
+      // The pair stays coupled in the EXTERNAL directory, not the co-located
+      // (nonexistent) default candidate's — this is what closes the P1 gap.
+      expect(path.dirname(runtimeTombstone)).toBe(externalDir);
+      expect(removed.map((entry) => entry.kind).toSorted()).toEqual(["pointer", "runtime"]);
+      expect(removed.map((entry) => entry.path).toSorted()).toEqual(
+        [runtimeTombstone, pointerTombstone].toSorted(),
+      );
     });
   });
 

--- a/src/trajectory/cleanup.test.ts
+++ b/src/trajectory/cleanup.test.ts
@@ -9,6 +9,7 @@ import {
   removeSessionTrajectoryArtifacts,
 } from "./cleanup.js";
 import { resolveTrajectoryFilePath, resolveTrajectoryPointerFilePath } from "./paths.js";
+import { createTrajectoryRuntimeRecorder } from "./runtime.js";
 import {
   acquireTrajectoryWriterLease,
   canonicalizeTrajectoryPath,
@@ -378,6 +379,85 @@ describe("trajectory cleanup", () => {
         // The claim was only admitted after delete's unlink fully committed,
         // so it cannot have reactivated or recreated the deleted artifact.
         await expectPathMissing(runtimeFile);
+      } finally {
+        rmSpy.mockRestore();
+      }
+    });
+  });
+
+  it("keeps a queued re-acquisition's fresh runtime and pointer intact against a racing delete's pointer removal", async () => {
+    await withTempDir({ prefix: "openclaw-trajectory-cleanup-" }, async (dir) => {
+      const sessionId = "session-8";
+      const storePath = path.join(dir, "sessions.json");
+      const sessionFile = path.join(dir, `${sessionId}.jsonl`);
+      const runtimeFile = resolveTrajectoryFilePath({ env: {}, sessionFile, sessionId });
+      const pointerPath = resolveTrajectoryPointerFilePath(sessionFile);
+      await fs.writeFile(runtimeFile, runtimeEvent(sessionId), "utf8");
+      await fs.writeFile(pointerPath, pointerFile(sessionId, runtimeFile), "utf8");
+
+      const order: string[] = [];
+      const originalRm = nodeFs.promises.rm.bind(nodeFs.promises);
+      let releasePointerRemoval: () => void = () => {};
+      const pointerRemovalGate = new Promise<void>((resolve) => {
+        releasePointerRemoval = resolve;
+      });
+      const rmSpy = vi
+        .spyOn(nodeFs.promises, "rm")
+        .mockImplementation(async (target: nodeFs.PathLike, options?: nodeFs.RmOptions) => {
+          const isPointerTarget = String(target) === pointerPath;
+          if (isPointerTarget) {
+            order.push("pointer-unlink-start");
+            await pointerRemovalGate;
+          }
+          const result = await originalRm(target, options);
+          if (isPointerTarget) {
+            order.push("pointer-unlink-done");
+          }
+          return result;
+        });
+
+      try {
+        const deletePromise = removeSessionTrajectoryArtifacts({
+          sessionId,
+          sessionFile,
+          storePath,
+          restrictToStoreDir: true,
+        });
+
+        // Let delete's locked turn remove the runtime file and reach the
+        // paused pointer removal — still inside the SAME turn once fixed —
+        // before attempting a concurrent re-acquisition for the same
+        // session (ordering (B) from the round-4 finding). The runtime
+        // file's own (unpaused) removal is real disk I/O, so poll rather
+        // than assume a fixed number of ticks.
+        for (let attempt = 0; attempt < 50 && order.length === 0; attempt += 1) {
+          await new Promise<void>((resolve) => {
+            setImmediate(() => resolve());
+          });
+        }
+        expect(order).toEqual(["pointer-unlink-start"]);
+
+        const recorderPromise = createTrajectoryRuntimeRecorder({ sessionId, sessionFile });
+
+        await new Promise<void>((resolve) => {
+          setImmediate(() => resolve());
+        });
+        expect(order).toEqual(["pointer-unlink-start"]);
+
+        releasePointerRemoval();
+        const [, recorder] = await Promise.all([deletePromise, recorderPromise]);
+        if (!recorder) {
+          throw new Error("expected trajectory runtime recorder");
+        }
+        recorder.recordEvent("prompt.submitted", { marker: "post-race-owner" });
+        await recorder.flush();
+
+        const pointerContent = JSON.parse(nodeFs.readFileSync(pointerPath, "utf8")) as {
+          runtimeFile?: string;
+        };
+        expect(pointerContent.runtimeFile).toBe(recorder.filePath);
+        expect(nodeFs.existsSync(recorder.filePath)).toBe(true);
+        expect(nodeFs.readFileSync(recorder.filePath, "utf8")).toContain("post-race-owner");
       } finally {
         rmSpy.mockRestore();
       }

--- a/src/trajectory/cleanup.test.ts
+++ b/src/trajectory/cleanup.test.ts
@@ -2,7 +2,7 @@
 import nodeFs from "node:fs";
 import fs from "node:fs/promises";
 import path from "node:path";
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { withTempDir } from "../test-helpers/temp-dir.js";
 import {
   removeRemovedSessionTrajectoryArtifacts,
@@ -12,8 +12,17 @@ import { resolveTrajectoryFilePath, resolveTrajectoryPointerFilePath } from "./p
 import {
   acquireTrajectoryWriterLease,
   canonicalizeTrajectoryPath,
+  clearTrajectoryWriterLifecycleRegistryForTest,
   withTrajectoryPathLock,
 } from "./writer-lifecycle.js";
+
+afterEach(() => {
+  // findTrajectoryPathOwnedBySession scans the whole registry by sessionId;
+  // several tests below reuse the same literal sessionId strings ("abc*def"
+  // etc.) across cases, so leaked entries from an earlier test can otherwise
+  // shadow the current test's own owner record.
+  clearTrajectoryWriterLifecycleRegistryForTest();
+});
 
 function runtimeEvent(sessionId: string): string {
   return `${JSON.stringify({
@@ -255,6 +264,52 @@ describe("trajectory cleanup", () => {
 
       await expectPathMissing(leaseA.filePath);
       expect((await fs.stat(leaseB.filePath)).isFile()).toBe(true);
+    });
+  });
+
+  it("removes the disambiguated owner's own runtime and pointer on its own delete", async () => {
+    await withTempDir({ prefix: "openclaw-trajectory-cleanup-" }, async (dir) => {
+      const storePath = path.join(dir, "sessions.json");
+      const trajectoryDir = path.join(dir, "traces");
+      const sessionAId = "abc*def";
+      const sessionBId = "abc_def";
+      const sessionFileA = path.join(dir, "session-a.jsonl");
+      const sessionFileB = path.join(dir, "session-b.jsonl");
+      const env = { OPENCLAW_TRAJECTORY_DIR: trajectoryDir };
+
+      const leaseA = await acquireTrajectoryWriterLease({
+        sessionId: sessionAId,
+        candidatePath: resolveTrajectoryFilePath({ env, sessionId: sessionAId }),
+      });
+      const leaseB = await acquireTrajectoryWriterLease({
+        sessionId: sessionBId,
+        candidatePath: resolveTrajectoryFilePath({ env, sessionId: sessionBId }),
+      });
+      expect(leaseA.filePath).not.toBe(leaseB.filePath);
+
+      await fs.mkdir(trajectoryDir, { recursive: true });
+      await fs.writeFile(leaseA.filePath, runtimeEvent(sessionAId), "utf8");
+      await fs.writeFile(leaseB.filePath, runtimeEvent(sessionBId), "utf8");
+      const pointerPathA = resolveTrajectoryPointerFilePath(sessionFileA);
+      const pointerPathB = resolveTrajectoryPointerFilePath(sessionFileB);
+      await fs.writeFile(pointerPathA, pointerFile(sessionAId, leaseA.filePath), "utf8");
+      await fs.writeFile(pointerPathB, pointerFile(sessionBId, leaseB.filePath), "utf8");
+
+      // Delete the DISAMBIGUATED owner (B) this time — the reverse of the
+      // sibling test above. B's own runtime file lives at a hash-suffixed
+      // path its own default-derivation never produces, so cleanup must
+      // resolve it via the registry's owner record, not by re-deriving B's
+      // (wrong) default candidate.
+      await removeSessionTrajectoryArtifacts({
+        sessionId: sessionBId,
+        sessionFile: sessionFileB,
+        storePath,
+        restrictToStoreDir: true,
+      });
+
+      await expectPathMissing(leaseB.filePath);
+      await expectPathMissing(pointerPathB);
+      expect((await fs.stat(leaseA.filePath)).isFile()).toBe(true);
     });
   });
 

--- a/src/trajectory/cleanup.test.ts
+++ b/src/trajectory/cleanup.test.ts
@@ -14,6 +14,7 @@ import {
   acquireTrajectoryWriterLease,
   canonicalizeTrajectoryPath,
   clearTrajectoryWriterLifecycleRegistryForTest,
+  getTrajectoryPathRegistryEntryForTest,
   withTrajectoryPathLock,
 } from "./writer-lifecycle.js";
 
@@ -310,6 +311,9 @@ describe("trajectory cleanup", () => {
       // the rollback restores the prior entry verbatim, it does not re-claim.
       const canonicalPath = canonicalizeTrajectoryPath(runtimeFile);
       const lease = await acquireTrajectoryWriterLease({ sessionId, candidatePath: runtimeFile });
+      if (lease.status !== "acquired") {
+        throw new Error("expected a fresh live claim to be acquired");
+      }
       const liveIncarnation = lease.incarnation;
 
       // Fail ONLY the runtime file's archive rename (the commit point);
@@ -420,6 +424,9 @@ describe("trajectory cleanup", () => {
         sessionId: sessionBId,
         candidatePath: resolveTrajectoryFilePath({ env, sessionId: sessionBId }),
       });
+      if (leaseA.status !== "acquired" || leaseB.status !== "acquired") {
+        throw new Error("expected both sibling claims to be acquired");
+      }
       expect(leaseA.filePath).not.toBe(leaseB.filePath);
 
       await fs.mkdir(trajectoryDir, { recursive: true });
@@ -461,6 +468,9 @@ describe("trajectory cleanup", () => {
         sessionId: sessionBId,
         candidatePath: resolveTrajectoryFilePath({ env, sessionId: sessionBId }),
       });
+      if (leaseA.status !== "acquired" || leaseB.status !== "acquired") {
+        throw new Error("expected both sibling claims to be acquired");
+      }
       expect(leaseA.filePath).not.toBe(leaseB.filePath);
 
       await fs.mkdir(trajectoryDir, { recursive: true });
@@ -553,13 +563,12 @@ describe("trajectory cleanup", () => {
 
         expect(order.indexOf("archive-done")).toBeLessThan(order.indexOf("acquire-done"));
         // The claim was only admitted after delete's archive rename fully
-        // committed and observed the path retired — it disambiguates to a
-        // fresh sibling path rather than reclaiming the tombstoned canonical
-        // one (same-owner reclaim of a *retired* path is never admitted at
-        // the original path: retired is set exclusively by disposal, so this
-        // claim is indistinguishable at the registry from a late straggler
-        // write racing that exact disposal, not a legitimate continuation).
-        expect(lease.filePath).not.toBe(runtimeFile);
+        // committed and observed the path retired. A same-owner claim on a
+        // *retired* path is a late straggler racing its own session's disposal
+        // (retired is set exclusively by disposal), so it is rejected outright —
+        // it does NOT disambiguate to a fresh sibling, which would resurrect the
+        // deleted session as a live artifact pair after its deletion.
+        expect(lease.status).toBe("retired");
         await expectTombstoned(runtimeFile, "deleted");
       } finally {
         renameSpy.mockRestore();
@@ -567,7 +576,7 @@ describe("trajectory cleanup", () => {
     });
   });
 
-  it("keeps a queued re-acquisition's fresh runtime and pointer intact against a racing delete's pointer archive", async () => {
+  it("rejects a queued same-owner re-acquisition after a racing delete retires the path", async () => {
     await withTempDir({ prefix: "openclaw-trajectory-cleanup-" }, async (dir) => {
       const sessionId = "session-8";
       const storePath = path.join(dir, "sessions.json");
@@ -576,6 +585,10 @@ describe("trajectory cleanup", () => {
       const pointerPath = resolveTrajectoryPointerFilePath(sessionFile);
       await fs.writeFile(runtimeFile, runtimeEvent(sessionId), "utf8");
       await fs.writeFile(pointerPath, pointerFile(sessionId, runtimeFile), "utf8");
+      // Snapshot the canonical key while the file still exists (realpath
+      // resolves); once the delete tombstones it, the lookup below falls back to
+      // path.resolve, which would diverge on a symlinked tmp root.
+      const canonicalPath = canonicalizeTrajectoryPath(runtimeFile);
 
       const order: string[] = [];
       const originalRename = nodeFs.promises.rename.bind(nodeFs.promises);
@@ -634,11 +647,13 @@ describe("trajectory cleanup", () => {
 
         releasePointerArchive();
         const [, recorder] = await Promise.all([deletePromise, recorderPromise]);
-        if (!recorder) {
-          throw new Error("expected trajectory runtime recorder");
-        }
-        recorder.recordEvent("prompt.submitted", { marker: "post-race-owner" });
-        await recorder.flush();
+
+        // The re-acquisition is for the SAME session the delete just retired, so
+        // it is a straggler racing its own deletion: createTrajectoryRuntimeRecorder
+        // returns null and mints nothing. Publishing a fresh pair here (the old
+        // behavior) would leave a live, bare artifact pair after the session was
+        // deleted — the orphan this lifecycle exists to prevent.
+        expect(recorder).toBeNull();
 
         // Delete's OWN pair tombstoned (the runtime rename already completed
         // unpaused, before this test even started polling for pointer-archive-start).
@@ -649,16 +664,69 @@ describe("trajectory cleanup", () => {
           expect(tombstone).toBeDefined(),
         );
 
-        // The NEW owner's fresh pair is live at the original (now-vacant) paths.
-        const pointerContent = JSON.parse(nodeFs.readFileSync(pointerPath, "utf8")) as {
-          runtimeFile?: string;
-        };
-        expect(pointerContent.runtimeFile).toBe(recorder.filePath);
-        expect(nodeFs.existsSync(recorder.filePath)).toBe(true);
-        expect(nodeFs.readFileSync(recorder.filePath, "utf8")).toContain("post-race-owner");
+        // No fresh pair was minted: neither the runtime path nor its pointer has
+        // a live file (only their tombstones), and the rejected claim left the
+        // registry entry retired and still owned by the deleted session.
+        expect(nodeFs.existsSync(runtimeFile)).toBe(false);
+        expect(nodeFs.existsSync(pointerPath)).toBe(false);
+        const entry = getTrajectoryPathRegistryEntryForTest(canonicalPath);
+        expect(entry?.retired).toBe(true);
+        expect(entry?.ownerSessionId).toBe(sessionId);
       } finally {
         renameSpy.mockRestore();
       }
+    });
+  });
+
+  it("disables a straggler recorder acquiring its own path after the session was deleted", async () => {
+    await withTempDir({ prefix: "openclaw-trajectory-cleanup-" }, async (dir) => {
+      // realpath the tmp root so the post-tombstone canonicalization (which falls
+      // back to path.resolve once the file is gone) matches the retire-time key
+      // on a symlinked tmp root (e.g. macOS /var -> /private/var).
+      const cdir = await fs.realpath(dir);
+      const sessionId = "session-late-delete";
+      const storePath = path.join(cdir, "sessions.json");
+      const sessionFile = path.join(cdir, `${sessionId}.jsonl`);
+      const runtimeFile = resolveTrajectoryFilePath({ env: {}, sessionFile, sessionId });
+      const pointerPath = resolveTrajectoryPointerFilePath(sessionFile);
+      await fs.writeFile(runtimeFile, runtimeEvent(sessionId), "utf8");
+      await fs.writeFile(pointerPath, pointerFile(sessionId, runtimeFile), "utf8");
+      const canonicalPath = canonicalizeTrajectoryPath(runtimeFile);
+
+      // Delete tombstones the pair and retires the canonical path.
+      await removeSessionTrajectoryArtifacts({
+        sessionId,
+        sessionFile,
+        storePath,
+        restrictToStoreDir: true,
+        disposal: { mode: "tombstone", reason: "deleted" },
+      });
+      await expectTombstoned(runtimeFile, "deleted");
+      await expectTombstoned(pointerPath, "deleted");
+      const retired = getTrajectoryPathRegistryEntryForTest(canonicalPath);
+      expect(retired?.retired).toBe(true);
+      const retiredIncarnation = retired?.incarnation;
+
+      // A late straggler for the SAME session (e.g. an async post-turn hook that
+      // captured the pre-delete identity) opens a recorder against its own, now
+      // tombstoned, path. OPENCLAW_TRAJECTORY=1 forces capture on so a null
+      // recorder can only mean the retired-path rejection, never a disabled env.
+      const recorder = await createTrajectoryRuntimeRecorder({
+        sessionId,
+        sessionFile,
+        env: { OPENCLAW_TRAJECTORY: "1" },
+      });
+      expect(recorder).toBeNull();
+
+      // Nothing minted: no republished pointer, no runtime file, no sibling.
+      expect(nodeFs.existsSync(runtimeFile)).toBe(false);
+      expect(nodeFs.existsSync(pointerPath)).toBe(false);
+      // The rejected claim never touched the registry: same retired entry, same
+      // incarnation, same owner (no fresh claim, no disambiguated reclaim).
+      const afterReject = getTrajectoryPathRegistryEntryForTest(canonicalPath);
+      expect(afterReject?.retired).toBe(true);
+      expect(afterReject?.incarnation).toBe(retiredIncarnation);
+      expect(afterReject?.ownerSessionId).toBe(sessionId);
     });
   });
 });

--- a/src/trajectory/cleanup.test.ts
+++ b/src/trajectory/cleanup.test.ts
@@ -583,12 +583,22 @@ describe("trajectory cleanup", () => {
       const pointerArchiveGate = new Promise<void>((resolve) => {
         releasePointerArchive = resolve;
       });
+      // Resolves the instant delete's turn reaches the paused pointer archive —
+      // the exact event the assertion below waits for. The runtime file's own
+      // rename ahead of it is real disk I/O of unbounded duration, so a fixed
+      // event-loop-tick budget (the previous wait) could expire before this
+      // point under CI load and wrongly observe order === [] (the reported flake).
+      let signalPointerArchiveStarted: () => void = () => {};
+      const pointerArchiveStarted = new Promise<void>((resolve) => {
+        signalPointerArchiveStarted = resolve;
+      });
       const renameSpy = vi
         .spyOn(nodeFs.promises, "rename")
         .mockImplementation(async (src: nodeFs.PathLike, dest: nodeFs.PathLike) => {
           const isPointerTarget = String(src) === pointerPath;
           if (isPointerTarget) {
             order.push("pointer-archive-start");
+            signalPointerArchiveStarted();
             await pointerArchiveGate;
           }
           const result = await originalRename(src, dest);
@@ -607,17 +617,12 @@ describe("trajectory cleanup", () => {
           disposal: { mode: "tombstone", reason: "deleted" },
         });
 
-        // Let delete's locked turn archive the runtime file and reach the
-        // paused pointer archive — still inside the SAME turn once fixed —
-        // before attempting a concurrent re-acquisition for the same
-        // session (ordering (B) from the round-4 finding). The runtime
-        // file's own (unpaused) rename is real disk I/O, so poll rather
-        // than assume a fixed number of ticks.
-        for (let attempt = 0; attempt < 50 && order.length === 0; attempt += 1) {
-          await new Promise<void>((resolve) => {
-            setImmediate(() => resolve());
-          });
-        }
+        // Wait for delete's locked turn to actually reach the paused pointer
+        // archive (ordering (B) from the round-4 finding) before attempting a
+        // concurrent re-acquisition for the same session. Awaiting the mock's
+        // own start signal is deterministic regardless of how long the runtime
+        // file's (unpaused, real-I/O) rename ahead of it takes.
+        await pointerArchiveStarted;
         expect(order).toEqual(["pointer-archive-start"]);
 
         const recorderPromise = createTrajectoryRuntimeRecorder({ sessionId, sessionFile });

--- a/src/trajectory/cleanup.test.ts
+++ b/src/trajectory/cleanup.test.ts
@@ -1,7 +1,8 @@
 // Trajectory cleanup tests cover retention pruning of trajectory artifacts.
+import nodeFs from "node:fs";
 import fs from "node:fs/promises";
 import path from "node:path";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { withTempDir } from "../test-helpers/temp-dir.js";
 import {
   removeRemovedSessionTrajectoryArtifacts,

--- a/src/trajectory/cleanup.test.ts
+++ b/src/trajectory/cleanup.test.ts
@@ -412,10 +412,14 @@ describe("trajectory cleanup", () => {
         const [, lease] = await Promise.all([deletePromise, acquirePromise]);
 
         expect(order.indexOf("archive-done")).toBeLessThan(order.indexOf("acquire-done"));
-        expect(lease.filePath).toBe(runtimeFile);
         // The claim was only admitted after delete's archive rename fully
-        // committed, so it cannot have reactivated or recreated the tombstoned
-        // artifact — the original path is free and a fresh tombstone exists.
+        // committed and observed the path retired — it disambiguates to a
+        // fresh sibling path rather than reclaiming the tombstoned canonical
+        // one (same-owner reclaim of a *retired* path is never admitted at
+        // the original path: retired is set exclusively by disposal, so this
+        // claim is indistinguishable at the registry from a late straggler
+        // write racing that exact disposal, not a legitimate continuation).
+        expect(lease.filePath).not.toBe(runtimeFile);
         await expectTombstoned(runtimeFile, "deleted");
       } finally {
         renameSpy.mockRestore();

--- a/src/trajectory/cleanup.ts
+++ b/src/trajectory/cleanup.ts
@@ -259,15 +259,61 @@ export async function removeSessionTrajectoryArtifacts(params: {
   if (registryOwnedPath) {
     runtimeCandidates.add(registryOwnedPath);
   }
-  const canRemovePointer = !restrictToStoreDir || isPathWithinDir(storeDir, pointerPath);
   // The runtime file and its pointer are one incarnation-owned artifact pair:
   // whichever canonical path this session actually owns is where BOTH must
   // retire/archive in the SAME locked turn, so a racing acquisition on that
   // exact path can never observe a half-tombstoned pair — a fresh pointer
   // published after this turn releases, or this turn's archive clobbering a
   // pointer a racing claim just published (round 4 P1).
-  const primaryCanonicalPath =
-    registryOwnedPath ?? canonicalizePathForComparison(defaultRuntimePath);
+  //
+  // Preference order for which canonical path is "primary" (couples the
+  // pointer's disposal to its turn): registry ownership (strongest,
+  // in-process-trusted) > a pointer-declared target OUTSIDE the store dir
+  // (an OPENCLAW_TRAJECTORY_DIR override) whose ownership independently
+  // validates via mayRemoveRuntimeTarget > the co-located default candidate,
+  // which is what most sessions (no override configured) actually use.
+  // Blindly defaulting to the co-located candidate when the pointer names a
+  // *different*, unvalidated external target would dispose the pointer on
+  // an unrelated (often nonexistent) file's turn, orphaning the real
+  // external runtime with no discovery pointer left to find it by (round 5
+  // P1) — so an unvalidated external target instead leaves the pointer
+  // alone entirely: an orphaned runtime WITH a pointer beats one with none.
+  // A pointer-declared target that merely differs from the default but is
+  // STILL inside the store dir (a stale/forged pointer, not an
+  // OPENCLAW_TRAJECTORY_DIR override) is not "external" — it keeps the
+  // existing fallback behavior below, where the pointer itself is still
+  // reachable and safe to dispose regardless of the runtime target's proof.
+  const canonicalDefaultPath = canonicalizePathForComparison(defaultRuntimePath);
+  const externalPointerTarget =
+    pointer?.runtimeFile &&
+    canonicalizePathForComparison(pointer.runtimeFile) !== canonicalDefaultPath &&
+    !isPathWithinDir(storeDir, pointer.runtimeFile)
+      ? pointer.runtimeFile
+      : undefined;
+  let primaryCanonicalPath: string;
+  let canRemovePointer: boolean;
+  if (registryOwnedPath) {
+    primaryCanonicalPath = registryOwnedPath;
+    canRemovePointer = !restrictToStoreDir || isPathWithinDir(storeDir, pointerPath);
+  } else if (
+    externalPointerTarget &&
+    mayRemoveRuntimeTarget({
+      defaultRuntimePath,
+      filePath: externalPointerTarget,
+      sessionId: params.sessionId,
+      storeDir,
+      restrictToStoreDir,
+    })
+  ) {
+    primaryCanonicalPath = canonicalizePathForComparison(externalPointerTarget);
+    canRemovePointer = true;
+  } else if (externalPointerTarget) {
+    primaryCanonicalPath = canonicalDefaultPath;
+    canRemovePointer = false;
+  } else {
+    primaryCanonicalPath = canonicalDefaultPath;
+    canRemovePointer = !restrictToStoreDir || isPathWithinDir(storeDir, pointerPath);
+  }
   let pointerHandledInPrimaryTurn = false;
 
   for (const runtimePath of runtimeCandidates) {

--- a/src/trajectory/cleanup.ts
+++ b/src/trajectory/cleanup.ts
@@ -1,7 +1,13 @@
-// Trajectory cleanup helpers remove old trajectory files by retention policy.
+// Trajectory cleanup helpers retire old trajectory files. A session's own
+// trajectory pair is tombstoned by renaming it into a reset/deleted suffix —
+// the same archive contract session transcripts use — so a later retention
+// sweep (cleanupArchivedSessionTranscripts) reaps it; see
+// TrajectoryArtifactDisposal for the narrow exception (private scratch
+// artifacts that are unlinked outright).
 import fs from "node:fs";
 import path from "node:path";
 import { isRecord } from "@openclaw/normalization-core/record-coerce";
+import { formatSessionArchiveTimestamp } from "../config/sessions/artifacts.js";
 import { resolveSessionFilePath } from "../config/sessions/paths.js";
 import { isPathInside } from "../infra/path-guards.js";
 import {
@@ -20,8 +26,24 @@ import {
 
 type RemovedTrajectoryArtifact = {
   kind: "pointer" | "runtime";
+  // The archived (tombstoned) path, not the original — see archiveRegularFile.
   path: string;
 };
+
+export type TrajectoryTombstoneReason = "reset" | "deleted";
+
+// How a caller wants a trajectory artifact taken off its live canonical path.
+// "tombstone" renames it beside its (also-renamed) transcript, matching the
+// reset/deleted archive contract session transcripts use, for a session's own
+// user-visible trajectory pair (RESET, DELETE, and maintenance's removed-row
+// sweep). "delete" unlinks it outright, for artifact classes that are never
+// archived to begin with — the private/ephemeral internal-agent-run scratch
+// trajectory (agent-command.ts), whose own transcript is likewise unlinked
+// rather than archived for privacy/disk reasons; tombstoning only that half of
+// the pair would leak scratch data into a directory no retention sweep visits.
+export type TrajectoryArtifactDisposal =
+  | { mode: "tombstone"; reason: TrajectoryTombstoneReason; nowMs?: number }
+  | { mode: "delete" };
 
 type TrajectoryPointer = {
   runtimeFile: string;
@@ -123,21 +145,45 @@ function runtimeFileStartsWithSessionEvent(filePath: string, sessionId: string):
   }
 }
 
-async function removeRegularFile(
+function tombstoneSuffix(reason: TrajectoryTombstoneReason, nowMs?: number): string {
+  return `.${reason}.${formatSessionArchiveTimestamp(nowMs)}`;
+}
+
+async function disposeRegularFile(
   filePath: string,
+  disposal: TrajectoryArtifactDisposal,
   kind: RemovedTrajectoryArtifact["kind"],
 ): Promise<RemovedTrajectoryArtifact | null> {
   if (!isRegularNonSymlinkFile(filePath)) {
     return null;
   }
+  if (disposal.mode === "delete") {
+    try {
+      await fs.promises.rm(filePath, { force: true });
+    } catch {
+      // Best-effort: a transiently busy/locked artifact should not block
+      // removal of the remaining candidates (runtime file vs. pointer).
+      return null;
+    }
+    return { kind, path: path.resolve(filePath) };
+  }
+  const suffix = tombstoneSuffix(disposal.reason, disposal.nowMs);
+  const archivedPath = `${filePath}${suffix}`;
+  // suffix always carries a non-empty `.{reason}.{timestamp}` marker (see
+  // tombstoneSuffix), so this can only fire on a caller bug — guard so a
+  // blank suffix can never "archive" a live canonical path onto itself and
+  // desync the registry from what is actually on disk.
+  if (archivedPath === filePath) {
+    throw new Error(`trajectory tombstone suffix produced no rename for ${filePath}`);
+  }
   try {
-    await fs.promises.rm(filePath, { force: true });
+    await fs.promises.rename(filePath, archivedPath);
   } catch {
     // Best-effort: a transiently busy/locked artifact should not block
-    // removal of the remaining candidates (runtime file vs. pointer).
+    // archiving of the remaining candidates (runtime file vs. pointer).
     return null;
   }
-  return { kind, path: path.resolve(filePath) };
+  return { kind, path: archivedPath };
 }
 
 function resolveRemovedSessionFile(params: {
@@ -183,6 +229,7 @@ export async function removeSessionTrajectoryArtifacts(params: {
   sessionFile?: string;
   storePath: string;
   restrictToStoreDir?: boolean;
+  disposal: TrajectoryArtifactDisposal;
 }): Promise<RemovedTrajectoryArtifact[]> {
   const sessionFile = resolveRemovedSessionFile(params);
   if (!sessionFile) {
@@ -215,9 +262,9 @@ export async function removeSessionTrajectoryArtifacts(params: {
   const canRemovePointer = !restrictToStoreDir || isPathWithinDir(storeDir, pointerPath);
   // The runtime file and its pointer are one incarnation-owned artifact pair:
   // whichever canonical path this session actually owns is where BOTH must
-  // retire/remove in the SAME locked turn, so a racing acquisition on that
-  // exact path can never observe a half-deleted pair — a fresh pointer
-  // published after this turn releases, or this turn's removal clobbering a
+  // retire/archive in the SAME locked turn, so a racing acquisition on that
+  // exact path can never observe a half-tombstoned pair — a fresh pointer
+  // published after this turn releases, or this turn's archive clobbering a
   // pointer a racing claim just published (round 4 P1).
   const primaryCanonicalPath =
     registryOwnedPath ?? canonicalizePathForComparison(defaultRuntimePath);
@@ -250,18 +297,19 @@ export async function removeSessionTrajectoryArtifacts(params: {
       if (!mayTrajectoryPathBeRemovedBySession(canonicalRuntimePath, params.sessionId)) {
         return { runtime: null, pointer: null };
       }
-      // Retire before unlinking, in the same locked turn: a writer's flush
-      // turn queued behind this one must observe "retired" and no-op instead
-      // of recreating the file we are about to remove (F1/F2/F5). Acquisition
-      // shares this same lock (writer-lifecycle.ts), so no concurrent claim
-      // can slip in between the retire and the unlink either (P1-A).
+      // Retire before archiving (renaming into a tombstone), in the same
+      // locked turn: a writer's flush turn queued behind this one must
+      // observe "retired" and no-op instead of recreating the file we are
+      // about to archive away (F1/F2/F5). Acquisition shares this same lock
+      // (writer-lifecycle.ts), so no concurrent claim can slip in between the
+      // retire and the rename either (P1-A).
       claimTrajectoryPathIncarnation(canonicalRuntimePath, {
         ownerSessionId: params.sessionId,
         retired: true,
       });
-      const runtime = await removeRegularFile(runtimePath, "runtime");
+      const runtime = await disposeRegularFile(runtimePath, params.disposal, "runtime");
       const pointerRemoved = removePointerHere
-        ? await removeRegularFile(pointerPath, "pointer")
+        ? await disposeRegularFile(pointerPath, params.disposal, "pointer")
         : null;
       return { runtime, pointer: pointerRemoved };
     });
@@ -274,12 +322,12 @@ export async function removeSessionTrajectoryArtifacts(params: {
   }
 
   // Fallback: none of the runtime candidates landed on primaryCanonicalPath's
-  // own locked turn (e.g. mayRemoveRuntimeTarget rejected it) — still remove
+  // own locked turn (e.g. mayRemoveRuntimeTarget rejected it) — still archive
   // the pointer, locked on the same canonical path a racing claim would use,
   // rather than the old fully-unlocked step this replaces.
   if (canRemovePointer && !pointerHandledInPrimaryTurn) {
     const deletedPointer = await withTrajectoryPathLock(primaryCanonicalPath, () =>
-      removeRegularFile(pointerPath, "pointer"),
+      disposeRegularFile(pointerPath, params.disposal, "pointer"),
     );
     if (deletedPointer) {
       removed.push(deletedPointer);
@@ -327,6 +375,7 @@ export async function removeRemovedSessionTrajectoryArtifacts(params: {
   referencedSessionIds: ReadonlySet<string>;
   storePath: string;
   restrictToStoreDir?: boolean;
+  disposal: TrajectoryArtifactDisposal;
 }): Promise<RemovedTrajectoryArtifact[]> {
   const removed: RemovedTrajectoryArtifact[] = [];
   for (const [sessionId, sessionFile] of params.removedSessionFiles) {
@@ -339,6 +388,7 @@ export async function removeRemovedSessionTrajectoryArtifacts(params: {
         sessionFile,
         storePath: params.storePath,
         restrictToStoreDir: params.restrictToStoreDir,
+        disposal: params.disposal,
       })),
     );
   }

--- a/src/trajectory/cleanup.ts
+++ b/src/trajectory/cleanup.ts
@@ -12,6 +12,8 @@ import {
 import {
   canonicalizeTrajectoryPath as canonicalizePathForComparison,
   claimTrajectoryPathIncarnation,
+  findTrajectoryPathOwnedBySession,
+  mayTrajectoryPathBeRemovedBySession,
   reassignTrajectoryPathOwner,
   withTrajectoryPathLock,
 } from "./writer-lifecycle.js";
@@ -200,9 +202,22 @@ export async function removeSessionTrajectoryArtifacts(params: {
   if (pointer?.runtimeFile) {
     runtimeCandidates.add(pointer.runtimeFile);
   }
+  // The one shared, authoritative derivation for a collision-disambiguated
+  // path: ask the registry what canonicalPath this exact sessionId owns,
+  // rather than re-deriving the (wrong, un-suffixed) default candidate. Ownership
+  // records are in-process-trusted, unlike a persisted pointer file, so this
+  // candidate skips the basename/content heuristic below and is validated by
+  // owner match alone, inside the lock.
+  const registryOwnedPath = findTrajectoryPathOwnedBySession(params.sessionId);
+  if (registryOwnedPath) {
+    runtimeCandidates.add(registryOwnedPath);
+  }
 
   for (const runtimePath of runtimeCandidates) {
+    const canonicalRuntimePath = canonicalizePathForComparison(runtimePath);
+    const isRegistryOwnedCandidate = canonicalRuntimePath === registryOwnedPath;
     if (
+      !isRegistryOwnedCandidate &&
       !mayRemoveRuntimeTarget({
         defaultRuntimePath,
         filePath: runtimePath,
@@ -213,8 +228,14 @@ export async function removeSessionTrajectoryArtifacts(params: {
     ) {
       continue;
     }
-    const canonicalRuntimePath = canonicalizePathForComparison(runtimePath);
     const deleted = await withTrajectoryPathLock(canonicalRuntimePath, async () => {
+      // Validate ownership from the registry's own record, not just the
+      // pre-lock heuristic above: a concurrent reassignment could have moved
+      // this canonical path to a different owner between that check and
+      // lock admission, and no cross-session delete may ever go through.
+      if (!mayTrajectoryPathBeRemovedBySession(canonicalRuntimePath, params.sessionId)) {
+        return null;
+      }
       // Retire before unlinking, in the same locked turn: a writer's flush
       // turn queued behind this one must observe "retired" and no-op instead
       // of recreating the file we are about to remove (F1/F2/F5). Acquisition

--- a/src/trajectory/cleanup.ts
+++ b/src/trajectory/cleanup.ts
@@ -17,10 +17,10 @@ import {
 } from "./paths.js";
 import {
   canonicalizeTrajectoryPath as canonicalizePathForComparison,
-  claimTrajectoryPathIncarnation,
   findTrajectoryPathOwnedBySession,
   mayTrajectoryPathBeRemovedBySession,
   reassignTrajectoryPathOwner,
+  retireTrajectoryPathForDisposal,
   withTrajectoryPathLock,
 } from "./writer-lifecycle.js";
 
@@ -149,13 +149,23 @@ function tombstoneSuffix(reason: TrajectoryTombstoneReason, nowMs?: number): str
   return `.${reason}.${formatSessionArchiveTimestamp(nowMs)}`;
 }
 
+// "absent" (nothing on the live path) is deliberately distinct from "failed"
+// (the artifact is there but its rename/unlink threw): the disposal commit
+// ordering in removeSessionTrajectoryArtifacts keys retirement + pointer
+// disposal off "failed" alone, since a runtime that was never there strands
+// nothing, whereas one whose move failed is still live and must not be orphaned.
+type TrajectoryDisposalOutcome =
+  | { status: "absent" }
+  | { status: "failed" }
+  | { status: "disposed"; artifact: RemovedTrajectoryArtifact };
+
 async function disposeRegularFile(
   filePath: string,
   disposal: TrajectoryArtifactDisposal,
   kind: RemovedTrajectoryArtifact["kind"],
-): Promise<RemovedTrajectoryArtifact | null> {
+): Promise<TrajectoryDisposalOutcome> {
   if (!isRegularNonSymlinkFile(filePath)) {
-    return null;
+    return { status: "absent" };
   }
   if (disposal.mode === "delete") {
     try {
@@ -163,9 +173,9 @@ async function disposeRegularFile(
     } catch {
       // Best-effort: a transiently busy/locked artifact should not block
       // removal of the remaining candidates (runtime file vs. pointer).
-      return null;
+      return { status: "failed" };
     }
-    return { kind, path: path.resolve(filePath) };
+    return { status: "disposed", artifact: { kind, path: path.resolve(filePath) } };
   }
   const suffix = tombstoneSuffix(disposal.reason, disposal.nowMs);
   const archivedPath = `${filePath}${suffix}`;
@@ -181,9 +191,9 @@ async function disposeRegularFile(
   } catch {
     // Best-effort: a transiently busy/locked artifact should not block
     // archiving of the remaining candidates (runtime file vs. pointer).
-    return null;
+    return { status: "failed" };
   }
-  return { kind, path: archivedPath };
+  return { status: "disposed", artifact: { kind, path: archivedPath } };
 }
 
 function resolveRemovedSessionFile(params: {
@@ -349,15 +359,31 @@ export async function removeSessionTrajectoryArtifacts(params: {
       // about to archive away (F1/F2/F5). Acquisition shares this same lock
       // (writer-lifecycle.ts), so no concurrent claim can slip in between the
       // retire and the rename either (P1-A).
-      claimTrajectoryPathIncarnation(canonicalRuntimePath, {
-        ownerSessionId: params.sessionId,
-        retired: true,
-      });
+      const disposalTurn = retireTrajectoryPathForDisposal(canonicalRuntimePath, params.sessionId);
       const runtime = await disposeRegularFile(runtimePath, params.disposal, "runtime");
+      if (runtime.status === "failed") {
+        // The runtime rename is the disposal's commit point. It did not move
+        // (transient busy/locked rename), so roll the retirement back to fully
+        // live and leave the pointer untouched: a still-live, still-owned path
+        // whose discovery pointer is intact is retried cleanly by a later
+        // delete/reset/maintenance pass, whereas retiring ownership and
+        // disposing the pointer now would strand the live runtime file as a
+        // harder-to-find orphan than the one this cleanup exists to prevent
+        // (round 6 P1).
+        disposalTurn.rollback();
+        return { runtime: null, pointer: null };
+      }
+      // Runtime committed (archived) or was verifiably absent — a runtime that
+      // never existed strands nothing, so disposing its pointer stays valid.
+      // Either way the canonical path is clear; retire the pointer in this same
+      // turn so the pair stays coupled (round 4/5 P1).
       const pointerRemoved = removePointerHere
         ? await disposeRegularFile(pointerPath, params.disposal, "pointer")
         : null;
-      return { runtime, pointer: pointerRemoved };
+      return {
+        runtime: runtime.status === "disposed" ? runtime.artifact : null,
+        pointer: pointerRemoved?.status === "disposed" ? pointerRemoved.artifact : null,
+      };
     });
     if (result.runtime) {
       removed.push(result.runtime);
@@ -375,8 +401,8 @@ export async function removeSessionTrajectoryArtifacts(params: {
     const deletedPointer = await withTrajectoryPathLock(primaryCanonicalPath, () =>
       disposeRegularFile(pointerPath, params.disposal, "pointer"),
     );
-    if (deletedPointer) {
-      removed.push(deletedPointer);
+    if (deletedPointer.status === "disposed") {
+      removed.push(deletedPointer.artifact);
     }
   }
 

--- a/src/trajectory/cleanup.ts
+++ b/src/trajectory/cleanup.ts
@@ -212,6 +212,16 @@ export async function removeSessionTrajectoryArtifacts(params: {
   if (registryOwnedPath) {
     runtimeCandidates.add(registryOwnedPath);
   }
+  const canRemovePointer = !restrictToStoreDir || isPathWithinDir(storeDir, pointerPath);
+  // The runtime file and its pointer are one incarnation-owned artifact pair:
+  // whichever canonical path this session actually owns is where BOTH must
+  // retire/remove in the SAME locked turn, so a racing acquisition on that
+  // exact path can never observe a half-deleted pair — a fresh pointer
+  // published after this turn releases, or this turn's removal clobbering a
+  // pointer a racing claim just published (round 4 P1).
+  const primaryCanonicalPath =
+    registryOwnedPath ?? canonicalizePathForComparison(defaultRuntimePath);
+  let pointerHandledInPrimaryTurn = false;
 
   for (const runtimePath of runtimeCandidates) {
     const canonicalRuntimePath = canonicalizePathForComparison(runtimePath);
@@ -228,13 +238,17 @@ export async function removeSessionTrajectoryArtifacts(params: {
     ) {
       continue;
     }
-    const deleted = await withTrajectoryPathLock(canonicalRuntimePath, async () => {
+    const removePointerHere = canRemovePointer && canonicalRuntimePath === primaryCanonicalPath;
+    if (removePointerHere) {
+      pointerHandledInPrimaryTurn = true;
+    }
+    const result = await withTrajectoryPathLock(canonicalRuntimePath, async () => {
       // Validate ownership from the registry's own record, not just the
       // pre-lock heuristic above: a concurrent reassignment could have moved
       // this canonical path to a different owner between that check and
       // lock admission, and no cross-session delete may ever go through.
       if (!mayTrajectoryPathBeRemovedBySession(canonicalRuntimePath, params.sessionId)) {
-        return null;
+        return { runtime: null, pointer: null };
       }
       // Retire before unlinking, in the same locked turn: a writer's flush
       // turn queued behind this one must observe "retired" and no-op instead
@@ -245,15 +259,28 @@ export async function removeSessionTrajectoryArtifacts(params: {
         ownerSessionId: params.sessionId,
         retired: true,
       });
-      return await removeRegularFile(runtimePath, "runtime");
+      const runtime = await removeRegularFile(runtimePath, "runtime");
+      const pointerRemoved = removePointerHere
+        ? await removeRegularFile(pointerPath, "pointer")
+        : null;
+      return { runtime, pointer: pointerRemoved };
     });
-    if (deleted) {
-      removed.push(deleted);
+    if (result.runtime) {
+      removed.push(result.runtime);
+    }
+    if (result.pointer) {
+      removed.push(result.pointer);
     }
   }
 
-  if (!restrictToStoreDir || isPathWithinDir(storeDir, pointerPath)) {
-    const deletedPointer = await removeRegularFile(pointerPath, "pointer");
+  // Fallback: none of the runtime candidates landed on primaryCanonicalPath's
+  // own locked turn (e.g. mayRemoveRuntimeTarget rejected it) — still remove
+  // the pointer, locked on the same canonical path a racing claim would use,
+  // rather than the old fully-unlocked step this replaces.
+  if (canRemovePointer && !pointerHandledInPrimaryTurn) {
+    const deletedPointer = await withTrajectoryPathLock(primaryCanonicalPath, () =>
+      removeRegularFile(pointerPath, "pointer"),
+    );
     if (deletedPointer) {
       removed.push(deletedPointer);
     }

--- a/src/trajectory/cleanup.ts
+++ b/src/trajectory/cleanup.ts
@@ -9,6 +9,12 @@ import {
   resolveTrajectoryPointerFilePath,
   safeTrajectorySessionFileName,
 } from "./paths.js";
+import {
+  bumpTrajectoryPathGeneration,
+  canonicalizeTrajectoryPath as canonicalizePathForComparison,
+  reassignTrajectoryPathOwner,
+  withTrajectoryPathLock,
+} from "./writer-lifecycle.js";
 
 type RemovedTrajectoryArtifact = {
   kind: "pointer" | "runtime";
@@ -18,15 +24,6 @@ type RemovedTrajectoryArtifact = {
 type TrajectoryPointer = {
   runtimeFile: string;
 };
-
-function canonicalizePathForComparison(filePath: string): string {
-  const resolved = path.resolve(filePath);
-  try {
-    return fs.realpathSync(resolved);
-  } catch {
-    return resolved;
-  }
-}
 
 function isPathWithinDir(parentDir: string, filePath: string): boolean {
   const resolvedParent = canonicalizePathForComparison(parentDir);
@@ -131,7 +128,13 @@ async function removeRegularFile(
   if (!isRegularNonSymlinkFile(filePath)) {
     return null;
   }
-  await fs.promises.rm(filePath, { force: true });
+  try {
+    await fs.promises.rm(filePath, { force: true });
+  } catch {
+    // Best-effort: a transiently busy/locked artifact should not block
+    // removal of the remaining candidates (runtime file vs. pointer).
+    return null;
+  }
   return { kind, path: path.resolve(filePath) };
 }
 
@@ -163,9 +166,9 @@ function mayRemoveRuntimeTarget(params: {
   if (canonicalizePathForComparison(params.defaultRuntimePath) === resolved) {
     return !params.restrictToStoreDir || withinStoreDir;
   }
-  if (params.restrictToStoreDir && withinStoreDir) {
-    return true;
-  }
+  // A pointer-declared path that merely sits inside the store dir is not proof
+  // it belongs to this session (a stale/forged pointer can name any sibling
+  // file there) — still require the basename+content match below.
   const expectedName = `${safeTrajectorySessionFileName(params.sessionId)}.jsonl`;
   if (path.basename(resolved) !== expectedName) {
     return false;
@@ -210,7 +213,17 @@ export async function removeSessionTrajectoryArtifacts(params: {
     ) {
       continue;
     }
-    const deleted = await removeRegularFile(runtimePath, "runtime");
+    const canonicalRuntimePath = canonicalizePathForComparison(runtimePath);
+    const deleted = await withTrajectoryPathLock(canonicalRuntimePath, async () => {
+      // Retire before unlinking, in the same locked turn: a writer's flush
+      // turn queued behind this one must observe "retired" and no-op instead
+      // of recreating the file we are about to remove (F1/F2/F5).
+      bumpTrajectoryPathGeneration(canonicalRuntimePath, {
+        retire: true,
+        ownerSessionId: params.sessionId,
+      });
+      return await removeRegularFile(runtimePath, "runtime");
+    });
     if (deleted) {
       removed.push(deleted);
     }
@@ -224,6 +237,39 @@ export async function removeSessionTrajectoryArtifacts(params: {
   }
 
   return removed;
+}
+
+/**
+ * Reassigns a reused trajectory path's registry ownership from the previous
+ * session id to the next one, without a generation bump: the file and any
+ * in-flight writer for it remain valid, only the logical owner changes
+ * (resetSessionEntryLifecycle's "reused transcript path" case, §3.6).
+ */
+export function reassignSessionTrajectoryPathOwner(params: {
+  previousSessionId: string;
+  previousSessionFile?: string;
+  nextSessionId: string;
+  nextSessionFile: string;
+}): void {
+  const previousCandidatePath = resolveTrajectoryFilePath({
+    sessionFile: params.previousSessionFile,
+    sessionId: params.previousSessionId,
+  });
+  const nextCandidatePath = resolveTrajectoryFilePath({
+    sessionFile: params.nextSessionFile,
+    sessionId: params.nextSessionId,
+  });
+  const previousCanonicalPath = canonicalizePathForComparison(previousCandidatePath);
+  if (previousCanonicalPath !== canonicalizePathForComparison(nextCandidatePath)) {
+    // Different canonical paths (e.g. an OPENCLAW_TRAJECTORY_DIR override
+    // keyed by sessionId): nothing to reassign, the next session's own
+    // recorder creation claims its path fresh.
+    return;
+  }
+  reassignTrajectoryPathOwner(previousCanonicalPath, {
+    from: params.previousSessionId,
+    to: params.nextSessionId,
+  });
 }
 
 export async function removeRemovedSessionTrajectoryArtifacts(params: {

--- a/src/trajectory/cleanup.ts
+++ b/src/trajectory/cleanup.ts
@@ -10,8 +10,8 @@ import {
   safeTrajectorySessionFileName,
 } from "./paths.js";
 import {
-  bumpTrajectoryPathGeneration,
   canonicalizeTrajectoryPath as canonicalizePathForComparison,
+  claimTrajectoryPathIncarnation,
   reassignTrajectoryPathOwner,
   withTrajectoryPathLock,
 } from "./writer-lifecycle.js";
@@ -217,10 +217,12 @@ export async function removeSessionTrajectoryArtifacts(params: {
     const deleted = await withTrajectoryPathLock(canonicalRuntimePath, async () => {
       // Retire before unlinking, in the same locked turn: a writer's flush
       // turn queued behind this one must observe "retired" and no-op instead
-      // of recreating the file we are about to remove (F1/F2/F5).
-      bumpTrajectoryPathGeneration(canonicalRuntimePath, {
-        retire: true,
+      // of recreating the file we are about to remove (F1/F2/F5). Acquisition
+      // shares this same lock (writer-lifecycle.ts), so no concurrent claim
+      // can slip in between the retire and the unlink either (P1-A).
+      claimTrajectoryPathIncarnation(canonicalRuntimePath, {
         ownerSessionId: params.sessionId,
+        retired: true,
       });
       return await removeRegularFile(runtimePath, "runtime");
     });
@@ -245,12 +247,12 @@ export async function removeSessionTrajectoryArtifacts(params: {
  * in-flight writer for it remain valid, only the logical owner changes
  * (resetSessionEntryLifecycle's "reused transcript path" case, §3.6).
  */
-export function reassignSessionTrajectoryPathOwner(params: {
+export async function reassignSessionTrajectoryPathOwner(params: {
   previousSessionId: string;
   previousSessionFile?: string;
   nextSessionId: string;
   nextSessionFile: string;
-}): void {
+}): Promise<void> {
   const previousCandidatePath = resolveTrajectoryFilePath({
     sessionFile: params.previousSessionFile,
     sessionId: params.previousSessionId,
@@ -266,7 +268,7 @@ export function reassignSessionTrajectoryPathOwner(params: {
     // recorder creation claims its path fresh.
     return;
   }
-  reassignTrajectoryPathOwner(previousCanonicalPath, {
+  await reassignTrajectoryPathOwner(previousCanonicalPath, {
     from: params.previousSessionId,
     to: params.nextSessionId,
   });

--- a/src/trajectory/runtime.test.ts
+++ b/src/trajectory/runtime.test.ts
@@ -52,6 +52,15 @@ async function expectTrajectoryRuntimeRecorder(
   return recorder;
 }
 
+/** Asserts originalPath is gone and a matching tombstone now exists. */
+function expectTombstoned(originalPath: string, reason: "reset" | "deleted"): void {
+  expect(fs.existsSync(originalPath)).toBe(false);
+  const dir = path.dirname(originalPath);
+  const prefix = `${path.basename(originalPath)}.${reason}.`;
+  const entries = fs.existsSync(dir) ? fs.readdirSync(dir) : [];
+  expect(entries.some((name) => name.startsWith(prefix))).toBe(true);
+}
+
 describe("trajectory runtime", () => {
   it("resolves a session-adjacent trajectory file by default", () => {
     expect(
@@ -630,6 +639,7 @@ describe("trajectory runtime", () => {
         sessionFile,
         storePath,
         restrictToStoreDir: true,
+        disposal: { mode: "tombstone", reason: "deleted" },
       });
 
       releaseContinuation();
@@ -638,7 +648,9 @@ describe("trajectory runtime", () => {
       await new Promise<void>((resolve) => {
         setImmediate(() => resolve());
       });
-      expect(fs.existsSync(pointerPath)).toBe(false);
+      // The stale claim's publish must never recreate the pointer at its
+      // original path — the path stays free, tombstoned by the delete above.
+      expectTombstoned(pointerPath, "deleted");
     } finally {
       acquireSpy.mockRestore();
     }

--- a/src/trajectory/runtime.test.ts
+++ b/src/trajectory/runtime.test.ts
@@ -513,12 +513,14 @@ describe("trajectory runtime", () => {
       maxRuntimeFileBytes: 2_400,
     });
     await expectTrajectoryRuntimeRecorder(recorderA);
-    const incarnationAfterA = (
-      await acquireTrajectoryWriterLease({
-        sessionId: "reuse-session",
-        candidatePath: runtimeFile,
-      })
-    ).incarnation;
+    const leaseAfterA = await acquireTrajectoryWriterLease({
+      sessionId: "reuse-session",
+      candidatePath: runtimeFile,
+    });
+    if (leaseAfterA.status !== "acquired") {
+      throw new Error("expected reconnecting owner to reuse its acquired lease");
+    }
+    const incarnationAfterA = leaseAfterA.incarnation;
 
     for (let index = 0; index < 100; index += 1) {
       await expectTrajectoryRuntimeRecorder(
@@ -536,12 +538,14 @@ describe("trajectory runtime", () => {
       maxRuntimeFileBytes: 2_400,
     });
     const runtimeRecorderB = await expectTrajectoryRuntimeRecorder(recorderB);
-    const incarnationAfterB = (
-      await acquireTrajectoryWriterLease({
-        sessionId: "reuse-session",
-        candidatePath: runtimeFile,
-      })
-    ).incarnation;
+    const leaseAfterB = await acquireTrajectoryWriterLease({
+      sessionId: "reuse-session",
+      candidatePath: runtimeFile,
+    });
+    if (leaseAfterB.status !== "acquired") {
+      throw new Error("expected reconnecting owner to reuse its acquired lease");
+    }
+    const incarnationAfterB = leaseAfterB.incarnation;
 
     // Eviction+recreation for the *same* still-live session must not spuriously
     // claim a fresh incarnation — it is the same owner reconnecting, not a new epoch.
@@ -591,6 +595,9 @@ describe("trajectory runtime", () => {
       sessionId: "post-reap-owner",
       candidatePath: runtimeFile,
     });
+    if (freshLease.status !== "acquired") {
+      throw new Error("expected a fresh claim on the reaped path to be acquired");
+    }
     expect(freshLease.filePath).toBe(runtimeFile);
 
     await runtimeRecorder.flush();

--- a/src/trajectory/runtime.test.ts
+++ b/src/trajectory/runtime.test.ts
@@ -10,6 +10,13 @@ import {
   resolveTrajectoryPointerOpenFlags,
 } from "./paths.js";
 import { createTrajectoryRuntimeRecorder, toTrajectoryToolDefinitions } from "./runtime.js";
+import {
+  acquireTrajectoryWriterLease,
+  bumpTrajectoryPathGeneration,
+  canonicalizeTrajectoryPath,
+  clearTrajectoryWriterLifecycleRegistryForTest,
+  withTrajectoryPathLock,
+} from "./writer-lifecycle.js";
 
 type TrajectoryRuntimeRecorder = NonNullable<ReturnType<typeof createTrajectoryRuntimeRecorder>>;
 
@@ -23,6 +30,7 @@ function makeTempDir(): string {
 
 afterEach(() => {
   vi.useRealTimers();
+  clearTrajectoryWriterLifecycleRegistryForTest();
   for (const dir of tempDirs.splice(0)) {
     fs.rmSync(dir, { recursive: true, force: true });
   }
@@ -409,6 +417,189 @@ describe("trajectory runtime", () => {
     expect(raw).toContain("old-recorder");
     expect(raw).toContain("new-recorder");
     expect(raw.indexOf("old-recorder")).toBeLessThan(raw.indexOf("new-recorder"));
+  });
+
+  it("rejects a late flush after its canonical path has been retired", async () => {
+    const tmpDir = makeTempDir();
+    const sessionFile = path.join(tmpDir, "session.jsonl");
+    const recorder = createTrajectoryRuntimeRecorder({
+      sessionId: "session-1",
+      sessionFile,
+      maxRuntimeFileBytes: 2_400,
+    });
+    const runtimeRecorder = expectTrajectoryRuntimeRecorder(recorder);
+    runtimeRecorder.recordEvent("prompt.submitted", { marker: "should-not-land" });
+
+    const runtimeFile = resolveTrajectoryFilePath({ sessionFile, sessionId: "session-1" });
+    const canonicalPath = canonicalizeTrajectoryPath(runtimeFile);
+    await withTrajectoryPathLock(canonicalPath, () => {
+      bumpTrajectoryPathGeneration(canonicalPath, {
+        retire: true,
+        ownerSessionId: "session-1",
+      });
+    });
+
+    await runtimeRecorder.flush();
+
+    expect(fs.existsSync(runtimeFile)).toBe(false);
+  });
+
+  it("keeps a writer evicted from the process cache invalidated once its path is retired", async () => {
+    const tmpDir = makeTempDir();
+    const sessionFile = path.join(tmpDir, "session-evict.jsonl");
+    const recorder = createTrajectoryRuntimeRecorder({
+      sessionId: "evict-session",
+      sessionFile,
+      maxRuntimeFileBytes: 2_400,
+    });
+    const runtimeRecorder = expectTrajectoryRuntimeRecorder(recorder);
+    runtimeRecorder.recordEvent("prompt.submitted", { marker: "first" });
+    await runtimeRecorder.flush();
+
+    // Drive MAX_TRAJECTORY_WRITERS eviction so the writers-map entry for
+    // "evict-session" is dropped, while this test keeps its own direct
+    // reference to the writer exactly as an abandoned closure would.
+    for (let index = 0; index < 100; index += 1) {
+      expectTrajectoryRuntimeRecorder(
+        createTrajectoryRuntimeRecorder({
+          sessionId: `evict-filler-${index}`,
+          sessionFile: path.join(tmpDir, `evict-filler-${index}.jsonl`),
+          maxRuntimeFileBytes: 2_400,
+        }),
+      );
+    }
+
+    const runtimeFile = resolveTrajectoryFilePath({ sessionFile, sessionId: "evict-session" });
+    const canonicalPath = canonicalizeTrajectoryPath(runtimeFile);
+    await withTrajectoryPathLock(canonicalPath, () => {
+      bumpTrajectoryPathGeneration(canonicalPath, {
+        retire: true,
+        ownerSessionId: "evict-session",
+      });
+      // Mirror what a real sessions.delete does inside the same locked turn:
+      // retire the generation, then remove the artifact it protects.
+      fs.rmSync(runtimeFile, { force: true });
+    });
+
+    runtimeRecorder.recordEvent("prompt.submitted", { marker: "late-after-eviction" });
+    await runtimeRecorder.flush();
+
+    expect(fs.existsSync(runtimeFile)).toBe(false);
+  });
+
+  it("reuses the same lease generation when a live writer is evicted and recreated", async () => {
+    const tmpDir = makeTempDir();
+    const sessionFile = path.join(tmpDir, "session-reuse.jsonl");
+    const runtimeFile = resolveTrajectoryFilePath({ sessionFile, sessionId: "reuse-session" });
+
+    const recorderA = createTrajectoryRuntimeRecorder({
+      sessionId: "reuse-session",
+      sessionFile,
+      maxRuntimeFileBytes: 2_400,
+    });
+    expectTrajectoryRuntimeRecorder(recorderA);
+    const generationAfterA = acquireTrajectoryWriterLease({
+      sessionId: "reuse-session",
+      candidatePath: runtimeFile,
+    }).generation;
+
+    for (let index = 0; index < 100; index += 1) {
+      expectTrajectoryRuntimeRecorder(
+        createTrajectoryRuntimeRecorder({
+          sessionId: `reuse-filler-${index}`,
+          sessionFile: path.join(tmpDir, `reuse-filler-${index}.jsonl`),
+          maxRuntimeFileBytes: 2_400,
+        }),
+      );
+    }
+
+    const recorderB = createTrajectoryRuntimeRecorder({
+      sessionId: "reuse-session",
+      sessionFile,
+      maxRuntimeFileBytes: 2_400,
+    });
+    const runtimeRecorderB = expectTrajectoryRuntimeRecorder(recorderB);
+    const generationAfterB = acquireTrajectoryWriterLease({
+      sessionId: "reuse-session",
+      candidatePath: runtimeFile,
+    }).generation;
+
+    // Eviction+recreation for the *same* still-live session must not spuriously
+    // bump the generation — it is the same owner reconnecting, not a new epoch.
+    expect(generationAfterB).toBe(generationAfterA);
+
+    runtimeRecorderB.recordEvent("prompt.submitted", { marker: "reused-writer" });
+    await runtimeRecorderB.flush();
+    expect(fs.readFileSync(runtimeFile, "utf8")).toContain("reused-writer");
+  });
+
+  it("keeps colliding sanitized session ids in separate files under an override directory", async () => {
+    const tmpDir = makeTempDir();
+    const trajectoryDir = path.join(tmpDir, "traces");
+    const env = { OPENCLAW_TRAJECTORY_DIR: trajectoryDir };
+    const runtimeRecorder1 = expectTrajectoryRuntimeRecorder(
+      createTrajectoryRuntimeRecorder({
+        env,
+        sessionId: "abc*def",
+        maxRuntimeFileBytes: 2_400,
+      }),
+    );
+    const runtimeRecorder2 = expectTrajectoryRuntimeRecorder(
+      createTrajectoryRuntimeRecorder({
+        env,
+        sessionId: "abc_def",
+        maxRuntimeFileBytes: 2_400,
+      }),
+    );
+
+    expect(runtimeRecorder1.filePath).not.toBe(runtimeRecorder2.filePath);
+
+    runtimeRecorder1.recordEvent("prompt.submitted", { marker: "owner-1" });
+    runtimeRecorder2.recordEvent("prompt.submitted", { marker: "owner-2" });
+    await runtimeRecorder1.flush();
+    await runtimeRecorder2.flush();
+
+    const raw1 = fs.readFileSync(runtimeRecorder1.filePath, "utf8");
+    const raw2 = fs.readFileSync(runtimeRecorder2.filePath, "utf8");
+    expect(raw1).toContain("owner-1");
+    expect(raw1).not.toContain("owner-2");
+    expect(raw2).toContain("owner-2");
+    expect(raw2).not.toContain("owner-1");
+  });
+
+  it("keeps colliding sanitized session ids in separate files under the no-sessionFile cwd fallback", async () => {
+    const tmpDir = makeTempDir();
+    const cwdSpy = vi.spyOn(process, "cwd").mockReturnValue(tmpDir);
+    try {
+      const runtimeRecorder1 = expectTrajectoryRuntimeRecorder(
+        createTrajectoryRuntimeRecorder({
+          sessionId: "abc*def",
+          maxRuntimeFileBytes: 2_400,
+        }),
+      );
+      const runtimeRecorder2 = expectTrajectoryRuntimeRecorder(
+        createTrajectoryRuntimeRecorder({
+          sessionId: "abc_def",
+          maxRuntimeFileBytes: 2_400,
+        }),
+      );
+
+      expect(runtimeRecorder1.filePath).not.toBe(runtimeRecorder2.filePath);
+
+      runtimeRecorder1.recordEvent("prompt.submitted", { marker: "owner-1" });
+      runtimeRecorder2.recordEvent("prompt.submitted", { marker: "owner-2" });
+      await runtimeRecorder1.flush();
+      await runtimeRecorder2.flush();
+
+      const raw1 = fs.readFileSync(runtimeRecorder1.filePath, "utf8");
+      const raw2 = fs.readFileSync(runtimeRecorder2.filePath, "utf8");
+      expect(raw1).toContain("owner-1");
+      expect(raw1).not.toContain("owner-2");
+      expect(raw2).toContain("owner-2");
+      expect(raw2).not.toContain("owner-1");
+    } finally {
+      cwdSpy.mockRestore();
+    }
   });
 
   it.runIf(process.platform !== "win32")(

--- a/src/trajectory/runtime.test.ts
+++ b/src/trajectory/runtime.test.ts
@@ -12,13 +12,16 @@ import {
 import { createTrajectoryRuntimeRecorder, toTrajectoryToolDefinitions } from "./runtime.js";
 import {
   acquireTrajectoryWriterLease,
-  bumpTrajectoryPathGeneration,
   canonicalizeTrajectoryPath,
+  claimTrajectoryPathIncarnation,
   clearTrajectoryWriterLifecycleRegistryForTest,
+  reapRetiredTrajectoryPathEntries,
   withTrajectoryPathLock,
 } from "./writer-lifecycle.js";
 
-type TrajectoryRuntimeRecorder = NonNullable<ReturnType<typeof createTrajectoryRuntimeRecorder>>;
+type TrajectoryRuntimeRecorder = NonNullable<
+  Awaited<ReturnType<typeof createTrajectoryRuntimeRecorder>>
+>;
 
 const tempDirs: string[] = [];
 
@@ -36,9 +39,10 @@ afterEach(() => {
   }
 });
 
-function expectTrajectoryRuntimeRecorder(
-  recorder: ReturnType<typeof createTrajectoryRuntimeRecorder>,
-): TrajectoryRuntimeRecorder {
+async function expectTrajectoryRuntimeRecorder(
+  recorderPromise: ReturnType<typeof createTrajectoryRuntimeRecorder>,
+): Promise<TrajectoryRuntimeRecorder> {
+  const recorder = await recorderPromise;
   if (recorder === null) {
     throw new Error("Expected trajectory runtime recorder");
   }
@@ -65,7 +69,7 @@ describe("trajectory runtime", () => {
     ).toBe(path.join(path.resolve("/tmp/traces"), "___evil_session.jsonl"));
   });
 
-  it("records sanitized runtime events by default", () => {
+  it("records sanitized runtime events by default", async () => {
     const writes: string[] = [];
     const recorder = createTrajectoryRuntimeRecorder({
       sessionId: "session-1",
@@ -84,7 +88,7 @@ describe("trajectory runtime", () => {
       },
     });
 
-    const runtimeRecorder = expectTrajectoryRuntimeRecorder(recorder);
+    const runtimeRecorder = await expectTrajectoryRuntimeRecorder(recorder);
     runtimeRecorder.recordEvent("context.compiled", {
       systemPrompt: "system prompt",
       headers: [{ name: "Authorization", value: "Bearer sk-test-secret-token" }],
@@ -113,7 +117,7 @@ describe("trajectory runtime", () => {
     expect(JSON.stringify(parsed.data)).not.toContain("abcd-efgh-ijkl-mnop");
   });
 
-  it("bounds large runtime event fields before serialization", () => {
+  it("bounds large runtime event fields before serialization", async () => {
     const writes: string[] = [];
     const recorder = createTrajectoryRuntimeRecorder({
       sessionId: "session-1",
@@ -127,7 +131,7 @@ describe("trajectory runtime", () => {
       },
     });
 
-    const runtimeRecorder = expectTrajectoryRuntimeRecorder(recorder);
+    const runtimeRecorder = await expectTrajectoryRuntimeRecorder(recorder);
     runtimeRecorder.recordEvent("context.compiled", {
       prompt: "x".repeat(TRAJECTORY_RUNTIME_EVENT_MAX_BYTES + 1),
     });
@@ -141,7 +145,7 @@ describe("trajectory runtime", () => {
     );
   });
 
-  it("preserves usage when truncating oversized runtime events", () => {
+  it("preserves usage when truncating oversized runtime events", async () => {
     const writes: string[] = [];
     const usage = {
       input: 384_954,
@@ -163,7 +167,7 @@ describe("trajectory runtime", () => {
       },
     });
 
-    const runtimeRecorder = expectTrajectoryRuntimeRecorder(recorder);
+    const runtimeRecorder = await expectTrajectoryRuntimeRecorder(recorder);
     runtimeRecorder.recordEvent("model.completed", {
       usage,
       promptCache,
@@ -189,7 +193,7 @@ describe("trajectory runtime", () => {
     );
   });
 
-  it("drops oversized preserved fields when needed to keep runtime events bounded", () => {
+  it("drops oversized preserved fields when needed to keep runtime events bounded", async () => {
     const writes: string[] = [];
     const oversizedUsage = Object.fromEntries(
       Array.from({ length: 64 }, (_value, index) => [`field-${index}`, "x".repeat(5_000)]),
@@ -207,7 +211,7 @@ describe("trajectory runtime", () => {
       },
     });
 
-    const runtimeRecorder = expectTrajectoryRuntimeRecorder(recorder);
+    const runtimeRecorder = await expectTrajectoryRuntimeRecorder(recorder);
     runtimeRecorder.recordEvent("model.completed", {
       usage: oversizedUsage,
       promptCache,
@@ -230,7 +234,7 @@ describe("trajectory runtime", () => {
     );
   });
 
-  it("preserves usage on non-final oversized runtime completions", () => {
+  it("preserves usage on non-final oversized runtime completions", async () => {
     const writes: string[] = [];
     const firstUsage = {
       input: 384_954,
@@ -252,7 +256,7 @@ describe("trajectory runtime", () => {
       },
     });
 
-    const runtimeRecorder = expectTrajectoryRuntimeRecorder(recorder);
+    const runtimeRecorder = await expectTrajectoryRuntimeRecorder(recorder);
     runtimeRecorder.recordEvent("model.completed", {
       usage: firstUsage,
       promptCache: { readTokens: 333_824 },
@@ -281,7 +285,7 @@ describe("trajectory runtime", () => {
     expect(second.data.truncated).toBeUndefined();
   });
 
-  it("redacts secrets before preserving usage in truncated runtime events", () => {
+  it("redacts secrets before preserving usage in truncated runtime events", async () => {
     const writes: string[] = [];
     const recorder = createTrajectoryRuntimeRecorder({
       sessionId: "session-1",
@@ -295,7 +299,7 @@ describe("trajectory runtime", () => {
       },
     });
 
-    const runtimeRecorder = expectTrajectoryRuntimeRecorder(recorder);
+    const runtimeRecorder = await expectTrajectoryRuntimeRecorder(recorder);
     runtimeRecorder.recordEvent("model.completed", {
       usage: {
         total: 1,
@@ -329,7 +333,7 @@ describe("trajectory runtime", () => {
       maxRuntimeFileBytes,
     });
 
-    const firstRuntimeRecorder = expectTrajectoryRuntimeRecorder(firstRecorder);
+    const firstRuntimeRecorder = await expectTrajectoryRuntimeRecorder(firstRecorder);
     for (const marker of ["old-1", "old-2", "old-3"]) {
       firstRuntimeRecorder.recordEvent("prompt.submitted", {
         marker,
@@ -343,7 +347,7 @@ describe("trajectory runtime", () => {
       sessionFile,
       maxRuntimeFileBytes,
     });
-    const secondRuntimeRecorder = expectTrajectoryRuntimeRecorder(secondRecorder);
+    const secondRuntimeRecorder = await expectTrajectoryRuntimeRecorder(secondRecorder);
     for (const marker of ["new-1", "new-2", "new-3"]) {
       secondRuntimeRecorder.recordEvent("prompt.submitted", {
         marker,
@@ -371,7 +375,7 @@ describe("trajectory runtime", () => {
         maxRuntimeFileBytes: 1_600,
       });
 
-      const runtimeRecorder = expectTrajectoryRuntimeRecorder(recorder);
+      const runtimeRecorder = await expectTrajectoryRuntimeRecorder(recorder);
       runtimeRecorder.recordEvent("prompt.submitted", {
         prompt: "hello",
       });
@@ -390,7 +394,7 @@ describe("trajectory runtime", () => {
       maxRuntimeFileBytes: 2_400,
     });
 
-    const staleRuntimeRecorder = expectTrajectoryRuntimeRecorder(staleRecorder);
+    const staleRuntimeRecorder = await expectTrajectoryRuntimeRecorder(staleRecorder);
     vi.useFakeTimers();
     vi.setSystemTime(new Date("2026-01-01T00:00:00.000Z"));
     staleRuntimeRecorder.recordEvent("prompt.submitted", {
@@ -403,7 +407,7 @@ describe("trajectory runtime", () => {
       sessionFile,
       maxRuntimeFileBytes: 2_400,
     });
-    const newerRuntimeRecorder = expectTrajectoryRuntimeRecorder(newerRecorder);
+    const newerRuntimeRecorder = await expectTrajectoryRuntimeRecorder(newerRecorder);
     newerRuntimeRecorder.recordEvent("prompt.submitted", {
       marker: "new-recorder",
       prompt: "y".repeat(260),
@@ -427,14 +431,14 @@ describe("trajectory runtime", () => {
       sessionFile,
       maxRuntimeFileBytes: 2_400,
     });
-    const runtimeRecorder = expectTrajectoryRuntimeRecorder(recorder);
+    const runtimeRecorder = await expectTrajectoryRuntimeRecorder(recorder);
     runtimeRecorder.recordEvent("prompt.submitted", { marker: "should-not-land" });
 
     const runtimeFile = resolveTrajectoryFilePath({ sessionFile, sessionId: "session-1" });
     const canonicalPath = canonicalizeTrajectoryPath(runtimeFile);
     await withTrajectoryPathLock(canonicalPath, () => {
-      bumpTrajectoryPathGeneration(canonicalPath, {
-        retire: true,
+      claimTrajectoryPathIncarnation(canonicalPath, {
+        retired: true,
         ownerSessionId: "session-1",
       });
     });
@@ -452,7 +456,7 @@ describe("trajectory runtime", () => {
       sessionFile,
       maxRuntimeFileBytes: 2_400,
     });
-    const runtimeRecorder = expectTrajectoryRuntimeRecorder(recorder);
+    const runtimeRecorder = await expectTrajectoryRuntimeRecorder(recorder);
     runtimeRecorder.recordEvent("prompt.submitted", { marker: "first" });
     await runtimeRecorder.flush();
 
@@ -460,7 +464,7 @@ describe("trajectory runtime", () => {
     // "evict-session" is dropped, while this test keeps its own direct
     // reference to the writer exactly as an abandoned closure would.
     for (let index = 0; index < 100; index += 1) {
-      expectTrajectoryRuntimeRecorder(
+      await expectTrajectoryRuntimeRecorder(
         createTrajectoryRuntimeRecorder({
           sessionId: `evict-filler-${index}`,
           sessionFile: path.join(tmpDir, `evict-filler-${index}.jsonl`),
@@ -472,8 +476,8 @@ describe("trajectory runtime", () => {
     const runtimeFile = resolveTrajectoryFilePath({ sessionFile, sessionId: "evict-session" });
     const canonicalPath = canonicalizeTrajectoryPath(runtimeFile);
     await withTrajectoryPathLock(canonicalPath, () => {
-      bumpTrajectoryPathGeneration(canonicalPath, {
-        retire: true,
+      claimTrajectoryPathIncarnation(canonicalPath, {
+        retired: true,
         ownerSessionId: "evict-session",
       });
       // Mirror what a real sessions.delete does inside the same locked turn:
@@ -487,7 +491,7 @@ describe("trajectory runtime", () => {
     expect(fs.existsSync(runtimeFile)).toBe(false);
   });
 
-  it("reuses the same lease generation when a live writer is evicted and recreated", async () => {
+  it("reuses the same lease incarnation when a live writer is evicted and recreated", async () => {
     const tmpDir = makeTempDir();
     const sessionFile = path.join(tmpDir, "session-reuse.jsonl");
     const runtimeFile = resolveTrajectoryFilePath({ sessionFile, sessionId: "reuse-session" });
@@ -497,14 +501,16 @@ describe("trajectory runtime", () => {
       sessionFile,
       maxRuntimeFileBytes: 2_400,
     });
-    expectTrajectoryRuntimeRecorder(recorderA);
-    const generationAfterA = acquireTrajectoryWriterLease({
-      sessionId: "reuse-session",
-      candidatePath: runtimeFile,
-    }).generation;
+    await expectTrajectoryRuntimeRecorder(recorderA);
+    const incarnationAfterA = (
+      await acquireTrajectoryWriterLease({
+        sessionId: "reuse-session",
+        candidatePath: runtimeFile,
+      })
+    ).incarnation;
 
     for (let index = 0; index < 100; index += 1) {
-      expectTrajectoryRuntimeRecorder(
+      await expectTrajectoryRuntimeRecorder(
         createTrajectoryRuntimeRecorder({
           sessionId: `reuse-filler-${index}`,
           sessionFile: path.join(tmpDir, `reuse-filler-${index}.jsonl`),
@@ -518,33 +524,81 @@ describe("trajectory runtime", () => {
       sessionFile,
       maxRuntimeFileBytes: 2_400,
     });
-    const runtimeRecorderB = expectTrajectoryRuntimeRecorder(recorderB);
-    const generationAfterB = acquireTrajectoryWriterLease({
-      sessionId: "reuse-session",
-      candidatePath: runtimeFile,
-    }).generation;
+    const runtimeRecorderB = await expectTrajectoryRuntimeRecorder(recorderB);
+    const incarnationAfterB = (
+      await acquireTrajectoryWriterLease({
+        sessionId: "reuse-session",
+        candidatePath: runtimeFile,
+      })
+    ).incarnation;
 
     // Eviction+recreation for the *same* still-live session must not spuriously
-    // bump the generation — it is the same owner reconnecting, not a new epoch.
-    expect(generationAfterB).toBe(generationAfterA);
+    // claim a fresh incarnation — it is the same owner reconnecting, not a new epoch.
+    expect(incarnationAfterB).toBe(incarnationAfterA);
 
     runtimeRecorderB.recordEvent("prompt.submitted", { marker: "reused-writer" });
     await runtimeRecorderB.flush();
     expect(fs.readFileSync(runtimeFile, "utf8")).toContain("reused-writer");
   });
 
+  it("keeps a writer held past its retirement's tombstone reap invalidated against a fresh claim", async () => {
+    const tmpDir = makeTempDir();
+    const sessionFile = path.join(tmpDir, "session-reap.jsonl");
+    const runtimeFile = resolveTrajectoryFilePath({ sessionFile, sessionId: "reap-session" });
+    const canonicalPath = canonicalizeTrajectoryPath(runtimeFile);
+
+    const recorder = createTrajectoryRuntimeRecorder({
+      sessionId: "reap-session",
+      sessionFile,
+      maxRuntimeFileBytes: 2_400,
+    });
+    const runtimeRecorder = await expectTrajectoryRuntimeRecorder(recorder);
+    runtimeRecorder.recordEvent("prompt.submitted", { marker: "stale-before-reap" });
+
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-01-01T00:00:00.000Z"));
+    // Retire exactly like a delete would, then remove the file it protected.
+    await withTrajectoryPathLock(canonicalPath, () => {
+      claimTrajectoryPathIncarnation(canonicalPath, {
+        retired: true,
+        ownerSessionId: "reap-session",
+      });
+    });
+    fs.rmSync(runtimeFile, { force: true });
+
+    // Past the 5-minute retired grace period: the registry entry reaps,
+    // losing all local memory of this path's prior incarnation.
+    vi.setSystemTime(new Date("2026-01-01T00:06:00.000Z"));
+    reapRetiredTrajectoryPathEntries();
+    vi.useRealTimers();
+
+    // A fresh, unrelated claim on the same (now-reaped) canonical path must
+    // land on a process-unique incarnation the pre-reap stale writer can
+    // never match, even though the per-path registry has no memory of it
+    // and would otherwise restart local numbering from scratch (P1-B).
+    const freshLease = await acquireTrajectoryWriterLease({
+      sessionId: "post-reap-owner",
+      candidatePath: runtimeFile,
+    });
+    expect(freshLease.filePath).toBe(runtimeFile);
+
+    await runtimeRecorder.flush();
+
+    expect(fs.existsSync(runtimeFile)).toBe(false);
+  });
+
   it("keeps colliding sanitized session ids in separate files under an override directory", async () => {
     const tmpDir = makeTempDir();
     const trajectoryDir = path.join(tmpDir, "traces");
     const env = { OPENCLAW_TRAJECTORY_DIR: trajectoryDir };
-    const runtimeRecorder1 = expectTrajectoryRuntimeRecorder(
+    const runtimeRecorder1 = await expectTrajectoryRuntimeRecorder(
       createTrajectoryRuntimeRecorder({
         env,
         sessionId: "abc*def",
         maxRuntimeFileBytes: 2_400,
       }),
     );
-    const runtimeRecorder2 = expectTrajectoryRuntimeRecorder(
+    const runtimeRecorder2 = await expectTrajectoryRuntimeRecorder(
       createTrajectoryRuntimeRecorder({
         env,
         sessionId: "abc_def",
@@ -571,13 +625,13 @@ describe("trajectory runtime", () => {
     const tmpDir = makeTempDir();
     const cwdSpy = vi.spyOn(process, "cwd").mockReturnValue(tmpDir);
     try {
-      const runtimeRecorder1 = expectTrajectoryRuntimeRecorder(
+      const runtimeRecorder1 = await expectTrajectoryRuntimeRecorder(
         createTrajectoryRuntimeRecorder({
           sessionId: "abc*def",
           maxRuntimeFileBytes: 2_400,
         }),
       );
-      const runtimeRecorder2 = expectTrajectoryRuntimeRecorder(
+      const runtimeRecorder2 = await expectTrajectoryRuntimeRecorder(
         createTrajectoryRuntimeRecorder({
           sessionId: "abc_def",
           maxRuntimeFileBytes: 2_400,
@@ -616,7 +670,7 @@ describe("trajectory runtime", () => {
         maxRuntimeFileBytes: 2_400,
       });
 
-      const runtimeRecorder = expectTrajectoryRuntimeRecorder(recorder);
+      const runtimeRecorder = await expectTrajectoryRuntimeRecorder(recorder);
       runtimeRecorder.recordEvent("prompt.submitted", {
         prompt: "hello",
       });
@@ -626,7 +680,7 @@ describe("trajectory runtime", () => {
     },
   );
 
-  it("describes queued writer state for cleanup timeout logs", () => {
+  it("describes queued writer state for cleanup timeout logs", async () => {
     const recorder = createTrajectoryRuntimeRecorder({
       sessionId: "session-1",
       sessionFile: "/tmp/session.jsonl",
@@ -646,14 +700,14 @@ describe("trajectory runtime", () => {
       },
     });
 
-    const runtimeRecorder = expectTrajectoryRuntimeRecorder(recorder);
+    const runtimeRecorder = await expectTrajectoryRuntimeRecorder(recorder);
 
     expect(runtimeRecorder.describeFlushState()).toBe(
       "pendingWrites=2 queuedBytes=256 activeOperation=file-append yieldBeforeWrite=true activeWriteBytes=128 maxQueuedBytes=1024 maxFileBytes=1024",
     );
   });
 
-  it("writes a session-adjacent pointer when using an override directory", () => {
+  it("writes a session-adjacent pointer when using an override directory", async () => {
     const tmpDir = makeTempDir();
     const sessionFile = path.join(tmpDir, "session.jsonl");
     const trajectoryDir = path.join(tmpDir, "traces");
@@ -668,7 +722,7 @@ describe("trajectory runtime", () => {
       },
     });
 
-    expectTrajectoryRuntimeRecorder(recorder);
+    await expectTrajectoryRuntimeRecorder(recorder);
     const pointer = JSON.parse(
       fs.readFileSync(resolveTrajectoryPointerFilePath(sessionFile), "utf8"),
     ) as { runtimeFile?: string };
@@ -685,8 +739,8 @@ describe("trajectory runtime", () => {
     ).toBe(0x07);
   });
 
-  it("does not record runtime events when explicitly disabled", () => {
-    const recorder = createTrajectoryRuntimeRecorder({
+  it("does not record runtime events when explicitly disabled", async () => {
+    const recorder = await createTrajectoryRuntimeRecorder({
       env: {
         OPENCLAW_TRAJECTORY: "0",
       },

--- a/src/trajectory/runtime.test.ts
+++ b/src/trajectory/runtime.test.ts
@@ -3,6 +3,7 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { removeSessionTrajectoryArtifacts } from "./cleanup.js";
 import {
   TRAJECTORY_RUNTIME_EVENT_MAX_BYTES,
   resolveTrajectoryFilePath,
@@ -10,6 +11,7 @@ import {
   resolveTrajectoryPointerOpenFlags,
 } from "./paths.js";
 import { createTrajectoryRuntimeRecorder, toTrajectoryToolDefinitions } from "./runtime.js";
+import * as writerLifecycle from "./writer-lifecycle.js";
 import {
   acquireTrajectoryWriterLease,
   canonicalizeTrajectoryPath,
@@ -585,6 +587,61 @@ describe("trajectory runtime", () => {
     await runtimeRecorder.flush();
 
     expect(fs.existsSync(runtimeFile)).toBe(false);
+  });
+
+  it("does not leave an orphaned pointer when a claim's publish would land after a concurrent delete retires the path", async () => {
+    const tmpDir = makeTempDir();
+    const sessionId = "race-a-session";
+    const sessionFile = path.join(tmpDir, "session.jsonl");
+    const storePath = path.join(tmpDir, "sessions.json");
+    const pointerPath = resolveTrajectoryPointerFilePath(sessionFile);
+
+    // Wraps the real acquireTrajectoryWriterLease so this test controls
+    // exactly when createTrajectoryRuntimeRecorder's continuation resumes
+    // after the claim (and, once fixed, its bundled publish) settle — the
+    // window the round-4 finding is about. Old code's onClaimed never fires
+    // (the parameter did not exist yet), so old code's publish still runs in
+    // that continuation, unguarded, after this artificial pause.
+    const realAcquire = writerLifecycle.acquireTrajectoryWriterLease;
+    let releaseContinuation: () => void = () => {};
+    const continuationGate = new Promise<void>((resolve) => {
+      releaseContinuation = resolve;
+    });
+    const acquireSpy = vi
+      .spyOn(writerLifecycle, "acquireTrajectoryWriterLease")
+      .mockImplementation(async (params) => {
+        const lease = await realAcquire(params);
+        await continuationGate;
+        return lease;
+      });
+
+    try {
+      const recorderPromise = createTrajectoryRuntimeRecorder({ sessionId, sessionFile });
+
+      // Let the real claim (and, with the fix, its bundled publish) settle
+      // before the artificial pause; only createTrajectoryRuntimeRecorder's
+      // resumption is held back from here.
+      await new Promise<void>((resolve) => {
+        setImmediate(() => resolve());
+      });
+
+      await removeSessionTrajectoryArtifacts({
+        sessionId,
+        sessionFile,
+        storePath,
+        restrictToStoreDir: true,
+      });
+
+      releaseContinuation();
+      await recorderPromise;
+
+      await new Promise<void>((resolve) => {
+        setImmediate(() => resolve());
+      });
+      expect(fs.existsSync(pointerPath)).toBe(false);
+    } finally {
+      acquireSpy.mockRestore();
+    }
   });
 
   it("keeps colliding sanitized session ids in separate files under an override directory", async () => {

--- a/src/trajectory/runtime.ts
+++ b/src/trajectory/runtime.ts
@@ -66,8 +66,8 @@ type TrajectoryRuntimeWriterDiagnostics = Omit<QueuedFileWriterDiagnostics, "act
 type TrajectoryRuntimeWriter = Omit<QueuedFileWriter, "describeQueue"> & {
   describeQueue?: () => TrajectoryRuntimeWriterDiagnostics;
   nextSourceSeq?: () => number;
-  /** Immutable generation captured at construction; absent for test-injected writers. */
-  leaseGeneration?: number;
+  /** Immutable incarnation captured at construction; absent for test-injected writers. */
+  leaseIncarnation?: number;
 };
 
 function writeTrajectoryPointerBestEffort(params: {
@@ -395,7 +395,7 @@ async function replaceTrajectoryWindow(params: {
 function createTrajectoryWindowWriter(
   filePath: string,
   maxFileBytes: number,
-  leaseGeneration: number,
+  leaseIncarnation: number,
 ): TrajectoryRuntimeWriter {
   let pendingLines: string[] = [];
   let queuedBytes = 0;
@@ -407,7 +407,7 @@ function createTrajectoryWindowWriter(
 
   return {
     filePath,
-    leaseGeneration,
+    leaseIncarnation,
     write: (line) => {
       const lineBytes = Buffer.byteLength(line, "utf8");
       if (lineBytes > maxFileBytes) {
@@ -430,11 +430,13 @@ function createTrajectoryWindowWriter(
       queue = queue
         .then(async () => {
           activeOperation = "file-replace";
-          await withTrajectoryPathLock(canonicalPath, async ({ currentGeneration, retired }) => {
-            if (retired || currentGeneration !== leaseGeneration) {
-              // Stale generation: the path was retired or reclaimed by a newer
-              // owner since this writer's lease was issued. Drop the write
-              // silently rather than resurrecting a deleted artifact (F1/F2/F5).
+          await withTrajectoryPathLock(canonicalPath, async ({ currentIncarnation, retired }) => {
+            if (retired || currentIncarnation !== leaseIncarnation) {
+              // Stale incarnation: the path was retired or reclaimed by a
+              // newer owner since this writer's lease was issued. Drop the
+              // write silently rather than resurrecting a deleted artifact
+              // (F1/F2/F5), and rather than trusting a restartable per-path
+              // counter that a reaped-then-reclaimed path could reuse (P1-B).
               return;
             }
             await replaceTrajectoryWindow({ filePath, maxFileBytes, appendedLines });
@@ -465,14 +467,14 @@ function createTrajectoryWindowWriter(
 function getTrajectoryWindowWriter(
   filePath: string,
   maxFileBytes: number,
-  leaseGeneration: number,
+  leaseIncarnation: number,
 ): TrajectoryRuntimeWriter {
   const existing = writers.get(filePath);
-  if (existing && existing.leaseGeneration === leaseGeneration) {
+  if (existing && existing.leaseIncarnation === leaseIncarnation) {
     return existing;
   }
   trimTrajectoryWriterCache();
-  const writer = createTrajectoryWindowWriter(filePath, maxFileBytes, leaseGeneration);
+  const writer = createTrajectoryWindowWriter(filePath, maxFileBytes, leaseIncarnation);
   writers.set(filePath, writer);
   return writer;
 }
@@ -497,9 +499,9 @@ export function toTrajectoryToolDefinitions(
     .toSorted((left, right) => left.name.localeCompare(right.name));
 }
 
-export function createTrajectoryRuntimeRecorder(
+export async function createTrajectoryRuntimeRecorder(
   params: TrajectoryRuntimeInit,
-): TrajectoryRuntimeRecorder | null {
+): Promise<TrajectoryRuntimeRecorder | null> {
   const env = params.env ?? process.env;
   // Trajectory capture is now default-on. The env var remains as an explicit
   // override so operators can still disable recording with OPENCLAW_TRAJECTORY=0.
@@ -513,7 +515,7 @@ export function createTrajectoryRuntimeRecorder(
     sessionFile: params.sessionFile,
     sessionId: params.sessionId,
   });
-  const lease = acquireTrajectoryWriterLease({
+  const lease = await acquireTrajectoryWriterLease({
     sessionId: params.sessionId,
     candidatePath,
   });
@@ -523,7 +525,7 @@ export function createTrajectoryRuntimeRecorder(
     Math.floor(params.maxRuntimeFileBytes ?? TRAJECTORY_RUNTIME_CAPTURE_MAX_BYTES),
   );
   const writer =
-    params.writer ?? getTrajectoryWindowWriter(filePath, maxRuntimeFileBytes, lease.generation);
+    params.writer ?? getTrajectoryWindowWriter(filePath, maxRuntimeFileBytes, lease.incarnation);
   writeTrajectoryPointerBestEffort({
     filePath,
     sessionFile: params.sessionFile,

--- a/src/trajectory/runtime.ts
+++ b/src/trajectory/runtime.ts
@@ -518,6 +518,15 @@ export async function createTrajectoryRuntimeRecorder(
   const lease = await acquireTrajectoryWriterLease({
     sessionId: params.sessionId,
     candidatePath,
+    // Publish inside the same locked turn the claim happens in, not after
+    // acquireTrajectoryWriterLease returns — see its own comment (round 4 P1).
+    onClaimed: ({ filePath: claimedFilePath }) => {
+      writeTrajectoryPointerBestEffort({
+        filePath: claimedFilePath,
+        sessionFile: params.sessionFile,
+        sessionId: params.sessionId,
+      });
+    },
   });
   const filePath = lease.filePath;
   const maxRuntimeFileBytes = Math.max(
@@ -526,11 +535,6 @@ export async function createTrajectoryRuntimeRecorder(
   );
   const writer =
     params.writer ?? getTrajectoryWindowWriter(filePath, maxRuntimeFileBytes, lease.incarnation);
-  writeTrajectoryPointerBestEffort({
-    filePath,
-    sessionFile: params.sessionFile,
-    sessionId: params.sessionId,
-  });
   let seq = 0;
   const traceId = params.sessionId;
 

--- a/src/trajectory/runtime.ts
+++ b/src/trajectory/runtime.ts
@@ -1,7 +1,6 @@
 // Trajectory runtime records runtime events into trajectory log files.
 import fs from "node:fs";
 import path from "node:path";
-import { KeyedAsyncQueue } from "openclaw/plugin-sdk/keyed-async-queue";
 import { sanitizeDiagnosticPayload } from "../agents/payload-redaction.js";
 import type {
   QueuedFileWriter,
@@ -22,6 +21,12 @@ import {
   resolveTrajectoryPointerOpenFlags,
 } from "./paths.js";
 import type { TrajectoryEvent, TrajectoryToolDefinition } from "./types.js";
+import {
+  acquireTrajectoryWriterLease,
+  canonicalizeTrajectoryPath,
+  reapRetiredTrajectoryPathEntries,
+  withTrajectoryPathLock,
+} from "./writer-lifecycle.js";
 
 type TrajectoryRuntimeInit = {
   cfg?: OpenClawConfig;
@@ -47,7 +52,6 @@ type TrajectoryRuntimeRecorder = {
 };
 
 const writers = new Map<string, TrajectoryRuntimeWriter>();
-const windowFlushes = new KeyedAsyncQueue();
 const MAX_TRAJECTORY_WRITERS = 100;
 const TRAJECTORY_RUNTIME_DATA_STRING_MAX_CHARS = 32_768;
 const TRAJECTORY_RUNTIME_DATA_ARRAY_MAX_ITEMS = 64;
@@ -62,6 +66,8 @@ type TrajectoryRuntimeWriterDiagnostics = Omit<QueuedFileWriterDiagnostics, "act
 type TrajectoryRuntimeWriter = Omit<QueuedFileWriter, "describeQueue"> & {
   describeQueue?: () => TrajectoryRuntimeWriterDiagnostics;
   nextSourceSeq?: () => number;
+  /** Immutable generation captured at construction; absent for test-injected writers. */
+  leaseGeneration?: number;
 };
 
 function writeTrajectoryPointerBestEffort(params: {
@@ -113,6 +119,7 @@ function writeTrajectoryPointerBestEffort(params: {
 }
 
 function trimTrajectoryWriterCache(): void {
+  reapRetiredTrajectoryPathEntries();
   while (writers.size >= MAX_TRAJECTORY_WRITERS) {
     const oldestKey = writers.keys().next().value;
     if (!oldestKey) {
@@ -385,19 +392,10 @@ async function replaceTrajectoryWindow(params: {
   });
 }
 
-async function queueTrajectoryWindowFlush(params: {
-  filePath: string;
-  maxFileBytes: number;
-  appendedLines: string[];
-}): Promise<void> {
-  await windowFlushes.enqueue(params.filePath, async () => {
-    await replaceTrajectoryWindow(params);
-  });
-}
-
 function createTrajectoryWindowWriter(
   filePath: string,
   maxFileBytes: number,
+  leaseGeneration: number,
 ): TrajectoryRuntimeWriter {
   let pendingLines: string[] = [];
   let queuedBytes = 0;
@@ -405,9 +403,11 @@ function createTrajectoryWindowWriter(
   let activeOperation: TrajectoryRuntimeWriterDiagnostics["activeOperation"] = "idle";
   let queue: Promise<unknown> = Promise.resolve();
   let sourceSeq = readMaxTrajectorySourceSeq(filePath);
+  const canonicalPath = canonicalizeTrajectoryPath(filePath);
 
   return {
     filePath,
+    leaseGeneration,
     write: (line) => {
       const lineBytes = Buffer.byteLength(line, "utf8");
       if (lineBytes > maxFileBytes) {
@@ -430,10 +430,14 @@ function createTrajectoryWindowWriter(
       queue = queue
         .then(async () => {
           activeOperation = "file-replace";
-          await queueTrajectoryWindowFlush({
-            filePath,
-            maxFileBytes,
-            appendedLines,
+          await withTrajectoryPathLock(canonicalPath, async ({ currentGeneration, retired }) => {
+            if (retired || currentGeneration !== leaseGeneration) {
+              // Stale generation: the path was retired or reclaimed by a newer
+              // owner since this writer's lease was issued. Drop the write
+              // silently rather than resurrecting a deleted artifact (F1/F2/F5).
+              return;
+            }
+            await replaceTrajectoryWindow({ filePath, maxFileBytes, appendedLines });
           });
         })
         .catch(() => undefined)
@@ -461,13 +465,14 @@ function createTrajectoryWindowWriter(
 function getTrajectoryWindowWriter(
   filePath: string,
   maxFileBytes: number,
+  leaseGeneration: number,
 ): TrajectoryRuntimeWriter {
   const existing = writers.get(filePath);
-  if (existing) {
+  if (existing && existing.leaseGeneration === leaseGeneration) {
     return existing;
   }
   trimTrajectoryWriterCache();
-  const writer = createTrajectoryWindowWriter(filePath, maxFileBytes);
+  const writer = createTrajectoryWindowWriter(filePath, maxFileBytes, leaseGeneration);
   writers.set(filePath, writer);
   return writer;
 }
@@ -503,16 +508,22 @@ export function createTrajectoryRuntimeRecorder(
     return null;
   }
 
-  const filePath = resolveTrajectoryFilePath({
+  const candidatePath = resolveTrajectoryFilePath({
     env,
     sessionFile: params.sessionFile,
     sessionId: params.sessionId,
   });
+  const lease = acquireTrajectoryWriterLease({
+    sessionId: params.sessionId,
+    candidatePath,
+  });
+  const filePath = lease.filePath;
   const maxRuntimeFileBytes = Math.max(
     1,
     Math.floor(params.maxRuntimeFileBytes ?? TRAJECTORY_RUNTIME_CAPTURE_MAX_BYTES),
   );
-  const writer = params.writer ?? getTrajectoryWindowWriter(filePath, maxRuntimeFileBytes);
+  const writer =
+    params.writer ?? getTrajectoryWindowWriter(filePath, maxRuntimeFileBytes, lease.generation);
   writeTrajectoryPointerBestEffort({
     filePath,
     sessionFile: params.sessionFile,

--- a/src/trajectory/runtime.ts
+++ b/src/trajectory/runtime.ts
@@ -528,6 +528,13 @@ export async function createTrajectoryRuntimeRecorder(
       });
     },
   });
+  if (lease.status === "retired") {
+    // The path was tombstoned by a reset/delete disposal for this same session:
+    // this recorder belongs to a late straggler racing that disposal. Disabling
+    // it (no writer, no runtime file) is what keeps the deletion final — see the
+    // retired branch in acquireTrajectoryWriterLease.
+    return null;
+  }
   const filePath = lease.filePath;
   const maxRuntimeFileBytes = Math.max(
     1,

--- a/src/trajectory/writer-lifecycle.ts
+++ b/src/trajectory/writer-lifecycle.ts
@@ -199,6 +199,41 @@ export function reapRetiredTrajectoryPathEntries(): void {
   }
 }
 
+/**
+ * Reverse lookup: the canonical path currently on file for sessionId, if any.
+ * This is the ONE shared derivation collision-aware callers (cleanup.ts) must
+ * use to find the exact path a disambiguated owner holds, instead of
+ * re-deriving the (wrong, un-suffixed) default candidate path — the previous
+ * shape left a disambiguated owner's own runtime file unreachable by its own
+ * delete, orphaning it right back through the collision branch it exists to
+ * guard.
+ */
+export function findTrajectoryPathOwnedBySession(sessionId: string): string | undefined {
+  for (const [canonicalPath, entry] of registry) {
+    if (entry.ownerSessionId === sessionId) {
+      return canonicalPath;
+    }
+  }
+  return undefined;
+}
+
+/**
+ * The same-turn ownership check collision-aware removal validates inside
+ * withTrajectoryPathLock before claiming+removing: true when canonicalPath's
+ * registry entry is absent (no in-process memory, e.g. the writer lived in a
+ * prior process run — the pre-existing candidate-matching heuristics in
+ * cleanup.ts remain the authority for that case) or is owned by sessionId.
+ * False when a DIFFERENT session's owner record is on file, which must block
+ * removal so no cross-session delete becomes possible.
+ */
+export function mayTrajectoryPathBeRemovedBySession(
+  canonicalPath: string,
+  sessionId: string,
+): boolean {
+  const entry = registry.get(canonicalPath);
+  return !entry || entry.ownerSessionId === sessionId;
+}
+
 /** Test-only: does not reset nextIncarnation — see its module-level comment. */
 export function clearTrajectoryWriterLifecycleRegistryForTest(): void {
   registry.clear();

--- a/src/trajectory/writer-lifecycle.ts
+++ b/src/trajectory/writer-lifecycle.ts
@@ -97,8 +97,8 @@ export function claimTrajectoryPathIncarnation(
  * a sanitized-name collision against a different live/retired owner. Runs entirely
  * inside withTrajectoryPathLock so a claim can never interleave with a concurrent
  * delete/retire turn for the same canonical path (P1-A) — including the awaited
- * unlink inside that turn, since the whole turn (bump + unlink) shares one lock
- * admission and this claim queues behind it rather than racing it.
+ * archive rename inside that turn, since the whole turn (bump + rename) shares
+ * one lock admission and this claim queues behind it rather than racing it.
  *
  * onClaimed, when provided, runs INSIDE the same locked turn immediately after a
  * successful (non-collision) claim — before the lock releases. The runtime file

--- a/src/trajectory/writer-lifecycle.ts
+++ b/src/trajectory/writer-lifecycle.ts
@@ -99,36 +99,48 @@ export function claimTrajectoryPathIncarnation(
  * delete/retire turn for the same canonical path (P1-A) — including the awaited
  * unlink inside that turn, since the whole turn (bump + unlink) shares one lock
  * admission and this claim queues behind it rather than racing it.
+ *
+ * onClaimed, when provided, runs INSIDE the same locked turn immediately after a
+ * successful (non-collision) claim — before the lock releases. The runtime file
+ * and its discovery pointer are one incarnation-owned artifact pair; publishing
+ * the pointer here (rather than after acquireTrajectoryWriterLease returns) closes
+ * the window where a concurrent delete could retire the path between the claim
+ * and the publish, which would otherwise either leave a pointer-only orphan (the
+ * publish lands after delete already ran) or let delete's own pointer removal
+ * clobber a freshly published pointer for a still-live claim (round 4 P1).
  */
 export async function acquireTrajectoryWriterLease(params: {
   sessionId: string;
   candidatePath: string;
+  onClaimed?: (claim: { filePath: string; incarnation: number }) => void;
 }): Promise<{ filePath: string; incarnation: number }> {
   let candidatePath = params.candidatePath;
   for (;;) {
     const canonicalPath = canonicalizeTrajectoryPath(candidatePath);
     const claim = await withTrajectoryPathLock(canonicalPath, () => {
       const existing = registry.get(canonicalPath);
+      const claimed = (incarnation: number) => {
+        params.onClaimed?.({ filePath: candidatePath, incarnation });
+        return { collision: false as const, incarnation };
+      };
       if (!existing) {
-        return {
-          collision: false as const,
-          incarnation: claimTrajectoryPathIncarnation(canonicalPath, {
+        return claimed(
+          claimTrajectoryPathIncarnation(canonicalPath, {
             ownerSessionId: params.sessionId,
             retired: false,
           }),
-        };
+        );
       }
       if (existing.ownerSessionId === params.sessionId) {
         if (!existing.retired) {
-          return { collision: false as const, incarnation: existing.incarnation };
+          return claimed(existing.incarnation);
         }
-        return {
-          collision: false as const,
-          incarnation: claimTrajectoryPathIncarnation(canonicalPath, {
+        return claimed(
+          claimTrajectoryPathIncarnation(canonicalPath, {
             ownerSessionId: params.sessionId,
             retired: false,
           }),
-        };
+        );
       }
       // Different owner already holds this canonical path: disambiguate rather
       // than share a file between two unrelated sessions (F4/F6).

--- a/src/trajectory/writer-lifecycle.ts
+++ b/src/trajectory/writer-lifecycle.ts
@@ -131,19 +131,22 @@ export async function acquireTrajectoryWriterLease(params: {
           }),
         );
       }
-      if (existing.ownerSessionId === params.sessionId) {
-        if (!existing.retired) {
-          return claimed(existing.incarnation);
-        }
-        return claimed(
-          claimTrajectoryPathIncarnation(canonicalPath, {
-            ownerSessionId: params.sessionId,
-            retired: false,
-          }),
-        );
+      if (existing.ownerSessionId === params.sessionId && !existing.retired) {
+        // Same live owner reconnecting (process restart, or a fresh writer
+        // object requested after writers-Map eviction while the session is
+        // still active) — reuse the existing incarnation unchanged.
+        return claimed(existing.incarnation);
       }
-      // Different owner already holds this canonical path: disambiguate rather
-      // than share a file between two unrelated sessions (F4/F6).
+      // Either a different owner already holds this canonical path (F4/F6),
+      // or this owner's own path was already retired by an explicit
+      // reset/delete disposal. retired is set exclusively by that disposal
+      // (cleanup.ts), so a same-owner claim reaching here is never a
+      // legitimate new session reusing an old id (session ids are random
+      // UUIDs) — it is a late straggler write racing the disposal (e.g. an
+      // async post-turn hook still finishing against the session that was
+      // just reset/deleted). Disambiguating it to a fresh sibling path,
+      // exactly like a cross-owner collision, keeps the tombstoned canonical
+      // path permanently dead instead of letting the straggler resurrect it.
       return { collision: true as const };
     });
     if (!claim.collision) {

--- a/src/trajectory/writer-lifecycle.ts
+++ b/src/trajectory/writer-lifecycle.ts
@@ -1,7 +1,8 @@
-// Trajectory writer lifecycle owns per-canonical-path generation/ownership so
-// flush/rename (runtime.ts) and delete/retire (cleanup.ts) serialize through
-// one registry instead of three uncoordinated primitives (writers-map
-// eviction, the old windowFlushes queue, and delete's raw fs.rm).
+// Trajectory writer lifecycle owns per-canonical-path incarnation/ownership so
+// acquisition (runtime.ts), flush/rename (runtime.ts), and delete/retire
+// (cleanup.ts) all serialize through one registry and one lock instead of
+// racing through independent primitives (writers-map eviction, the old
+// windowFlushes queue, and delete's raw fs.rm).
 import { createHash } from "node:crypto";
 import fs from "node:fs";
 import path from "node:path";
@@ -9,7 +10,11 @@ import { KeyedAsyncQueue } from "openclaw/plugin-sdk/keyed-async-queue";
 import { createSubsystemLogger } from "../logging/subsystem.js";
 
 type TrajectoryPathEntry = {
-  generation: number;
+  // Process-unique, monotonically increasing, never reused — including across
+  // a reap of this same canonical path. A per-path counter that restarts at 1
+  // after reap would let a long-held stale writer from a fully retired-and-
+  // reaped epoch validate against a brand new owner's claim (P1-B).
+  incarnation: number;
   ownerSessionId: string;
   retired: boolean;
   retiredAtMs?: number;
@@ -21,6 +26,10 @@ const TRAJECTORY_REGISTRY_MAX_ENTRIES = 10_000;
 const log = createSubsystemLogger("trajectory/writer-lifecycle");
 const registry = new Map<string, TrajectoryPathEntry>();
 const pathQueue = new KeyedAsyncQueue();
+
+// Never reset (including by the test-clear helper below): its only job is to
+// guarantee no two claims, for any path, at any time, ever collide.
+let nextIncarnation = 1;
 
 /** Canonical registry key: resolved + best-effort realpath'd, shared with cleanup.ts. */
 export function canonicalizeTrajectoryPath(filePath: string): string {
@@ -40,58 +49,19 @@ function disambiguateTrajectoryCandidatePath(candidatePath: string, sessionId: s
 }
 
 /**
- * Resolves a candidate path to its registered filePath/generation, disambiguating a
- * sanitized-name collision against a different live/retired owner. Synchronous and
- * non-yielding by design: a claim can never interleave with a concurrent retirement
- * of the same path, since neither touches the registry across an `await` boundary.
- */
-export function acquireTrajectoryWriterLease(params: {
-  sessionId: string;
-  candidatePath: string;
-}): { filePath: string; generation: number } {
-  let candidatePath = params.candidatePath;
-  for (;;) {
-    const canonicalPath = canonicalizeTrajectoryPath(candidatePath);
-    const existing = registry.get(canonicalPath);
-    if (!existing) {
-      registry.set(canonicalPath, {
-        generation: 1,
-        ownerSessionId: params.sessionId,
-        retired: false,
-      });
-      return { filePath: candidatePath, generation: 1 };
-    }
-    if (existing.ownerSessionId === params.sessionId) {
-      if (!existing.retired) {
-        return { filePath: candidatePath, generation: existing.generation };
-      }
-      const generation = existing.generation + 1;
-      registry.set(canonicalPath, {
-        generation,
-        ownerSessionId: params.sessionId,
-        retired: false,
-      });
-      return { filePath: candidatePath, generation };
-    }
-    // Different owner already holds this canonical path: disambiguate rather
-    // than share a file between two unrelated sessions (F4/F6).
-    candidatePath = disambiguateTrajectoryCandidatePath(candidatePath, params.sessionId);
-  }
-}
-
-/**
- * THE serialized boundary for a trajectory path. Both the flush/rename path and the
- * delete/retire path go through this, so a stale-generation write can never land
- * after a retirement decided in an earlier turn for the same canonical path.
+ * THE serialized boundary for a trajectory path. Acquisition, reassignment,
+ * flush/rename, and delete/retire all go through this, so none of them can
+ * observe or mutate a canonical path's registry entry while another turn for
+ * the same path is in flight (P1-A).
  */
 export async function withTrajectoryPathLock<T>(
   canonicalPath: string,
-  fn: (ctx: { currentGeneration: number; retired: boolean }) => Promise<T> | T,
+  fn: (ctx: { currentIncarnation: number; retired: boolean }) => Promise<T> | T,
 ): Promise<T> {
   return await pathQueue.enqueue(canonicalPath, async () => {
     const entry = registry.get(canonicalPath);
     return await fn({
-      currentGeneration: entry?.generation ?? 0,
+      currentIncarnation: entry?.incarnation ?? 0,
       retired: entry?.retired ?? false,
     });
   });
@@ -99,41 +69,96 @@ export async function withTrajectoryPathLock<T>(
 
 /**
  * Must only be called from inside a withTrajectoryPathLock(canonicalPath, ...) turn.
- * ownerSessionId defaults to the existing entry's owner so a retire call that races
- * ahead of any writer created in this process (e.g. deleting a session whose
- * trajectory writer lived in a prior process run) still records who owned the path,
- * which is required for that owner's later resurrection to reuse the path instead of
+ * Claims a fresh, process-unique incarnation for canonicalPath. ownerSessionId
+ * defaults to the existing entry's owner so a retire call that races ahead of
+ * any writer created in this process (e.g. deleting a session whose trajectory
+ * writer lived in a prior process run) still records who owned the path, which
+ * is required for that owner's later resurrection to reuse the path instead of
  * hitting the collision-disambiguation branch.
  */
-export function bumpTrajectoryPathGeneration(
+export function claimTrajectoryPathIncarnation(
   canonicalPath: string,
-  opts: { retire: boolean; ownerSessionId?: string },
+  params: { ownerSessionId?: string; retired: boolean },
 ): number {
   const existing = registry.get(canonicalPath);
-  const generation = (existing?.generation ?? 0) + 1;
+  const incarnation = nextIncarnation;
+  nextIncarnation += 1;
   registry.set(canonicalPath, {
-    generation,
-    ownerSessionId: opts.ownerSessionId ?? existing?.ownerSessionId ?? "",
-    retired: opts.retire,
-    retiredAtMs: opts.retire ? Date.now() : undefined,
+    incarnation,
+    ownerSessionId: params.ownerSessionId ?? existing?.ownerSessionId ?? "",
+    retired: params.retired,
+    retiredAtMs: params.retired ? Date.now() : undefined,
   });
-  return generation;
+  return incarnation;
 }
 
 /**
- * Reassigns a still-live (non-retired) path to a new owner without a generation bump,
- * for the resetSessionEntryLifecycle "reused transcript path" case: the file and any
- * in-flight writer for it remain valid, only the logical owner changes (§3.6).
+ * Resolves a candidate path to its registered filePath/incarnation, disambiguating
+ * a sanitized-name collision against a different live/retired owner. Runs entirely
+ * inside withTrajectoryPathLock so a claim can never interleave with a concurrent
+ * delete/retire turn for the same canonical path (P1-A) — including the awaited
+ * unlink inside that turn, since the whole turn (bump + unlink) shares one lock
+ * admission and this claim queues behind it rather than racing it.
  */
-export function reassignTrajectoryPathOwner(
+export async function acquireTrajectoryWriterLease(params: {
+  sessionId: string;
+  candidatePath: string;
+}): Promise<{ filePath: string; incarnation: number }> {
+  let candidatePath = params.candidatePath;
+  for (;;) {
+    const canonicalPath = canonicalizeTrajectoryPath(candidatePath);
+    const claim = await withTrajectoryPathLock(canonicalPath, () => {
+      const existing = registry.get(canonicalPath);
+      if (!existing) {
+        return {
+          collision: false as const,
+          incarnation: claimTrajectoryPathIncarnation(canonicalPath, {
+            ownerSessionId: params.sessionId,
+            retired: false,
+          }),
+        };
+      }
+      if (existing.ownerSessionId === params.sessionId) {
+        if (!existing.retired) {
+          return { collision: false as const, incarnation: existing.incarnation };
+        }
+        return {
+          collision: false as const,
+          incarnation: claimTrajectoryPathIncarnation(canonicalPath, {
+            ownerSessionId: params.sessionId,
+            retired: false,
+          }),
+        };
+      }
+      // Different owner already holds this canonical path: disambiguate rather
+      // than share a file between two unrelated sessions (F4/F6).
+      return { collision: true as const };
+    });
+    if (!claim.collision) {
+      return { filePath: candidatePath, incarnation: claim.incarnation };
+    }
+    candidatePath = disambiguateTrajectoryCandidatePath(candidatePath, params.sessionId);
+  }
+}
+
+/**
+ * Reassigns a still-live (non-retired) path to a new owner without a fresh
+ * incarnation claim, for the resetSessionEntryLifecycle "reused transcript path"
+ * case: the file and any in-flight writer for it remain valid, only the logical
+ * owner changes (§3.6). Runs inside withTrajectoryPathLock for the same reason
+ * acquisition does (P1-A).
+ */
+export async function reassignTrajectoryPathOwner(
   canonicalPath: string,
   params: { from: string; to: string },
-): void {
-  const existing = registry.get(canonicalPath);
-  if (!existing || existing.retired || existing.ownerSessionId !== params.from) {
-    return;
-  }
-  registry.set(canonicalPath, { ...existing, ownerSessionId: params.to });
+): Promise<void> {
+  await withTrajectoryPathLock(canonicalPath, () => {
+    const existing = registry.get(canonicalPath);
+    if (!existing || existing.retired || existing.ownerSessionId !== params.from) {
+      return;
+    }
+    registry.set(canonicalPath, { ...existing, ownerSessionId: params.to });
+  });
 }
 
 /**
@@ -141,6 +166,10 @@ export function reassignTrajectoryPathOwner(
  * above the cleanup-step flush timeout) so a late-arriving stale flush still finds a
  * "retired" entry rather than an absent one that would be wrongly treated as fresh.
  * Piggybacks on trimTrajectoryWriterCache's call site instead of a timer/interval.
+ * Reaping only ever removes the registry *entry* — it never touches or resets
+ * nextIncarnation, which is what keeps a stale writer from before the reap unable
+ * to match whatever fresh incarnation a later claim on the same path receives
+ * (P1-B).
  */
 export function reapRetiredTrajectoryPathEntries(): void {
   const nowMs = Date.now();
@@ -170,6 +199,7 @@ export function reapRetiredTrajectoryPathEntries(): void {
   }
 }
 
+/** Test-only: does not reset nextIncarnation — see its module-level comment. */
 export function clearTrajectoryWriterLifecycleRegistryForTest(): void {
   registry.clear();
 }

--- a/src/trajectory/writer-lifecycle.ts
+++ b/src/trajectory/writer-lifecycle.ts
@@ -124,64 +124,88 @@ export function retireTrajectoryPathForDisposal(
 }
 
 /**
- * Resolves a candidate path to its registered filePath/incarnation, disambiguating
- * a sanitized-name collision against a different live/retired owner. Runs entirely
- * inside withTrajectoryPathLock so a claim can never interleave with a concurrent
+ * The lease a writer holds over a canonical trajectory path. "retired" carries no
+ * path: it is a closed signal that the claim was rejected because the path is
+ * tombstoned and the caller must NOT create any artifact (see the retired branch
+ * in acquireTrajectoryWriterLease).
+ */
+export type TrajectoryWriterLeaseResult =
+  | { status: "acquired"; filePath: string; incarnation: number }
+  | { status: "retired" };
+
+/**
+ * Resolves a candidate path to a lease. Three outcomes: a fresh/live-reconnect
+ * claim ("acquired"); a same-owner claim on a RETIRED path, which is rejected
+ * outright ("retired", see below); or a different-owner sanitized-name collision,
+ * which disambiguates to a hash-suffixed sibling and retries. Runs entirely inside
+ * withTrajectoryPathLock so a claim can never interleave with a concurrent
  * delete/retire turn for the same canonical path (P1-A) — including the awaited
  * archive rename inside that turn, since the whole turn (bump + rename) shares
  * one lock admission and this claim queues behind it rather than racing it.
  *
- * onClaimed, when provided, runs INSIDE the same locked turn immediately after a
- * successful (non-collision) claim — before the lock releases. The runtime file
- * and its discovery pointer are one incarnation-owned artifact pair; publishing
- * the pointer here (rather than after acquireTrajectoryWriterLease returns) closes
- * the window where a concurrent delete could retire the path between the claim
- * and the publish, which would otherwise either leave a pointer-only orphan (the
- * publish lands after delete already ran) or let delete's own pointer removal
- * clobber a freshly published pointer for a still-live claim (round 4 P1).
+ * onClaimed, when provided, runs INSIDE the same locked turn immediately after an
+ * "acquired" claim — before the lock releases, and never for a rejected retired
+ * claim. The runtime file and its discovery pointer are one incarnation-owned
+ * artifact pair; publishing the pointer here (rather than after
+ * acquireTrajectoryWriterLease returns) closes the window where a concurrent
+ * delete could retire the path between the claim and the publish, which would
+ * otherwise either leave a pointer-only orphan (the publish lands after delete
+ * already ran) or let delete's own pointer removal clobber a freshly published
+ * pointer for a still-live claim (round 4 P1).
  */
 export async function acquireTrajectoryWriterLease(params: {
   sessionId: string;
   candidatePath: string;
   onClaimed?: (claim: { filePath: string; incarnation: number }) => void;
-}): Promise<{ filePath: string; incarnation: number }> {
+}): Promise<TrajectoryWriterLeaseResult> {
   let candidatePath = params.candidatePath;
   for (;;) {
     const canonicalPath = canonicalizeTrajectoryPath(candidatePath);
-    const claim = await withTrajectoryPathLock(canonicalPath, () => {
+    const outcome = await withTrajectoryPathLock(canonicalPath, () => {
       const existing = registry.get(canonicalPath);
-      const claimed = (incarnation: number) => {
+      const acquired = (incarnation: number) => {
         params.onClaimed?.({ filePath: candidatePath, incarnation });
-        return { collision: false as const, incarnation };
+        return { kind: "acquired" as const, incarnation };
       };
       if (!existing) {
-        return claimed(
+        return acquired(
           claimTrajectoryPathIncarnation(canonicalPath, {
             ownerSessionId: params.sessionId,
             retired: false,
           }),
         );
       }
-      if (existing.ownerSessionId === params.sessionId && !existing.retired) {
-        // Same live owner reconnecting (process restart, or a fresh writer
-        // object requested after writers-Map eviction while the session is
-        // still active) — reuse the existing incarnation unchanged.
-        return claimed(existing.incarnation);
+      if (existing.ownerSessionId === params.sessionId) {
+        if (!existing.retired) {
+          // Same live owner reconnecting (process restart, or a fresh writer
+          // object requested after writers-Map eviction while the session is
+          // still active) — reuse the existing incarnation unchanged.
+          return acquired(existing.incarnation);
+        }
+        // Same owner, but the path was already RETIRED by an explicit
+        // reset/delete disposal (retired is set exclusively there, cleanup.ts).
+        // Every reset mints a NEW session id for the continuation while the old
+        // id's path is tombstoned, so a same-owner claim on a retired path is
+        // never a legitimate continuation — it is a late straggler (async
+        // post-turn hook, or an in-flight run reaching recorder creation) racing
+        // the disposal of the very session it belongs to. Reject it: creating a
+        // fresh disambiguated pair here would resurrect a deleted session as a
+        // live, bare artifact pair AFTER its deletion. No pointer, no runtime
+        // file, no registry mutation — the tombstoned path stays dead.
+        log.debug(
+          `rejected straggler trajectory claim on retired path ${canonicalPath} (session ${params.sessionId})`,
+        );
+        return { kind: "retired" as const };
       }
-      // Either a different owner already holds this canonical path (F4/F6),
-      // or this owner's own path was already retired by an explicit
-      // reset/delete disposal. retired is set exclusively by that disposal
-      // (cleanup.ts), so a same-owner claim reaching here is never a
-      // legitimate new session reusing an old id (session ids are random
-      // UUIDs) — it is a late straggler write racing the disposal (e.g. an
-      // async post-turn hook still finishing against the session that was
-      // just reset/deleted). Disambiguating it to a fresh sibling path,
-      // exactly like a cross-owner collision, keeps the tombstoned canonical
-      // path permanently dead instead of letting the straggler resurrect it.
-      return { collision: true as const };
+      // A DIFFERENT owner holds this canonical path (sanitized-name collision,
+      // F4/F6): disambiguate to a hash-suffixed sibling and retry.
+      return { kind: "collision" as const };
     });
-    if (!claim.collision) {
-      return { filePath: candidatePath, incarnation: claim.incarnation };
+    if (outcome.kind === "acquired") {
+      return { status: "acquired", filePath: candidatePath, incarnation: outcome.incarnation };
+    }
+    if (outcome.kind === "retired") {
+      return { status: "retired" };
     }
     candidatePath = disambiguateTrajectoryCandidatePath(candidatePath, params.sessionId);
   }

--- a/src/trajectory/writer-lifecycle.ts
+++ b/src/trajectory/writer-lifecycle.ts
@@ -1,0 +1,181 @@
+// Trajectory writer lifecycle owns per-canonical-path generation/ownership so
+// flush/rename (runtime.ts) and delete/retire (cleanup.ts) serialize through
+// one registry instead of three uncoordinated primitives (writers-map
+// eviction, the old windowFlushes queue, and delete's raw fs.rm).
+import { createHash } from "node:crypto";
+import fs from "node:fs";
+import path from "node:path";
+import { KeyedAsyncQueue } from "openclaw/plugin-sdk/keyed-async-queue";
+import { createSubsystemLogger } from "../logging/subsystem.js";
+
+type TrajectoryPathEntry = {
+  generation: number;
+  ownerSessionId: string;
+  retired: boolean;
+  retiredAtMs?: number;
+};
+
+const TRAJECTORY_REGISTRY_RETIRED_GRACE_MS = 5 * 60 * 1000;
+const TRAJECTORY_REGISTRY_MAX_ENTRIES = 10_000;
+
+const log = createSubsystemLogger("trajectory/writer-lifecycle");
+const registry = new Map<string, TrajectoryPathEntry>();
+const pathQueue = new KeyedAsyncQueue();
+
+/** Canonical registry key: resolved + best-effort realpath'd, shared with cleanup.ts. */
+export function canonicalizeTrajectoryPath(filePath: string): string {
+  const resolved = path.resolve(filePath);
+  try {
+    return fs.realpathSync(resolved);
+  } catch {
+    return resolved;
+  }
+}
+
+function disambiguateTrajectoryCandidatePath(candidatePath: string, sessionId: string): string {
+  const suffix = createHash("sha256").update(sessionId).digest("hex").slice(0, 8);
+  return candidatePath.endsWith(".jsonl")
+    ? `${candidatePath.slice(0, -".jsonl".length)}-${suffix}.jsonl`
+    : `${candidatePath}-${suffix}.jsonl`;
+}
+
+/**
+ * Resolves a candidate path to its registered filePath/generation, disambiguating a
+ * sanitized-name collision against a different live/retired owner. Synchronous and
+ * non-yielding by design: a claim can never interleave with a concurrent retirement
+ * of the same path, since neither touches the registry across an `await` boundary.
+ */
+export function acquireTrajectoryWriterLease(params: {
+  sessionId: string;
+  candidatePath: string;
+}): { filePath: string; generation: number } {
+  let candidatePath = params.candidatePath;
+  for (;;) {
+    const canonicalPath = canonicalizeTrajectoryPath(candidatePath);
+    const existing = registry.get(canonicalPath);
+    if (!existing) {
+      registry.set(canonicalPath, {
+        generation: 1,
+        ownerSessionId: params.sessionId,
+        retired: false,
+      });
+      return { filePath: candidatePath, generation: 1 };
+    }
+    if (existing.ownerSessionId === params.sessionId) {
+      if (!existing.retired) {
+        return { filePath: candidatePath, generation: existing.generation };
+      }
+      const generation = existing.generation + 1;
+      registry.set(canonicalPath, {
+        generation,
+        ownerSessionId: params.sessionId,
+        retired: false,
+      });
+      return { filePath: candidatePath, generation };
+    }
+    // Different owner already holds this canonical path: disambiguate rather
+    // than share a file between two unrelated sessions (F4/F6).
+    candidatePath = disambiguateTrajectoryCandidatePath(candidatePath, params.sessionId);
+  }
+}
+
+/**
+ * THE serialized boundary for a trajectory path. Both the flush/rename path and the
+ * delete/retire path go through this, so a stale-generation write can never land
+ * after a retirement decided in an earlier turn for the same canonical path.
+ */
+export async function withTrajectoryPathLock<T>(
+  canonicalPath: string,
+  fn: (ctx: { currentGeneration: number; retired: boolean }) => Promise<T> | T,
+): Promise<T> {
+  return await pathQueue.enqueue(canonicalPath, async () => {
+    const entry = registry.get(canonicalPath);
+    return await fn({
+      currentGeneration: entry?.generation ?? 0,
+      retired: entry?.retired ?? false,
+    });
+  });
+}
+
+/**
+ * Must only be called from inside a withTrajectoryPathLock(canonicalPath, ...) turn.
+ * ownerSessionId defaults to the existing entry's owner so a retire call that races
+ * ahead of any writer created in this process (e.g. deleting a session whose
+ * trajectory writer lived in a prior process run) still records who owned the path,
+ * which is required for that owner's later resurrection to reuse the path instead of
+ * hitting the collision-disambiguation branch.
+ */
+export function bumpTrajectoryPathGeneration(
+  canonicalPath: string,
+  opts: { retire: boolean; ownerSessionId?: string },
+): number {
+  const existing = registry.get(canonicalPath);
+  const generation = (existing?.generation ?? 0) + 1;
+  registry.set(canonicalPath, {
+    generation,
+    ownerSessionId: opts.ownerSessionId ?? existing?.ownerSessionId ?? "",
+    retired: opts.retire,
+    retiredAtMs: opts.retire ? Date.now() : undefined,
+  });
+  return generation;
+}
+
+/**
+ * Reassigns a still-live (non-retired) path to a new owner without a generation bump,
+ * for the resetSessionEntryLifecycle "reused transcript path" case: the file and any
+ * in-flight writer for it remain valid, only the logical owner changes (§3.6).
+ */
+export function reassignTrajectoryPathOwner(
+  canonicalPath: string,
+  params: { from: string; to: string },
+): void {
+  const existing = registry.get(canonicalPath);
+  if (!existing || existing.retired || existing.ownerSessionId !== params.from) {
+    return;
+  }
+  registry.set(canonicalPath, { ...existing, ownerSessionId: params.to });
+}
+
+/**
+ * Opportunistic/lazy reap: retired entries must survive a grace period (comfortably
+ * above the cleanup-step flush timeout) so a late-arriving stale flush still finds a
+ * "retired" entry rather than an absent one that would be wrongly treated as fresh.
+ * Piggybacks on trimTrajectoryWriterCache's call site instead of a timer/interval.
+ */
+export function reapRetiredTrajectoryPathEntries(): void {
+  const nowMs = Date.now();
+  for (const [canonicalPath, entry] of registry) {
+    if (
+      entry.retired &&
+      entry.retiredAtMs !== undefined &&
+      nowMs - entry.retiredAtMs > TRAJECTORY_REGISTRY_RETIRED_GRACE_MS
+    ) {
+      registry.delete(canonicalPath);
+    }
+  }
+  if (registry.size <= TRAJECTORY_REGISTRY_MAX_ENTRIES) {
+    return;
+  }
+  const retiredByAge = [...registry.entries()]
+    .filter(([, entry]) => entry.retired)
+    .toSorted((left, right) => (left[1].retiredAtMs ?? 0) - (right[1].retiredAtMs ?? 0));
+  for (const [canonicalPath, entry] of retiredByAge) {
+    if (registry.size <= TRAJECTORY_REGISTRY_MAX_ENTRIES) {
+      break;
+    }
+    log.warn(
+      `trajectory writer registry backstop evicted a retired path before its grace period: ${canonicalPath} (retired ${Math.round((nowMs - (entry.retiredAtMs ?? nowMs)) / 1000)}s ago)`,
+    );
+    registry.delete(canonicalPath);
+  }
+}
+
+export function clearTrajectoryWriterLifecycleRegistryForTest(): void {
+  registry.clear();
+}
+
+export function getTrajectoryPathRegistryEntryForTest(
+  canonicalPath: string,
+): Readonly<TrajectoryPathEntry> | undefined {
+  return registry.get(canonicalPath);
+}

--- a/src/trajectory/writer-lifecycle.ts
+++ b/src/trajectory/writer-lifecycle.ts
@@ -93,6 +93,37 @@ export function claimTrajectoryPathIncarnation(
 }
 
 /**
+ * Retires canonicalPath for a disposal turn and returns a rollback that
+ * restores the pre-retire entry VERBATIM. The retire must precede the runtime
+ * archive rename so a flush turn queued behind this disposal observes "retired"
+ * and no-ops instead of recreating the file being archived away (F1/F2/F5).
+ * When that rename fails the disposal never committed: rollback re-installs the
+ * exact prior entry (same incarnation and owner, not a fresh incarnation, which
+ * would strand a still-live writer whose lease matches the old incarnation) so
+ * the path stays fully live and a later disposal pass retries it cleanly.
+ * Must only be called from inside a withTrajectoryPathLock(canonicalPath, ...) turn.
+ */
+export function retireTrajectoryPathForDisposal(
+  canonicalPath: string,
+  ownerSessionId: string,
+): { rollback: () => void } {
+  // Snapshot the exact prior entry object. claimTrajectoryPathIncarnation
+  // replaces the map value with a fresh object rather than mutating this one,
+  // so restoring it on failure is a true rollback to the pre-retire state.
+  const previous = registry.get(canonicalPath);
+  claimTrajectoryPathIncarnation(canonicalPath, { ownerSessionId, retired: true });
+  return {
+    rollback: () => {
+      if (previous) {
+        registry.set(canonicalPath, previous);
+      } else {
+        registry.delete(canonicalPath);
+      }
+    },
+  };
+}
+
+/**
  * Resolves a candidate path to its registered filePath/incarnation, disambiguating
  * a sanitized-name collision against a different live/retired owner. Runs entirely
  * inside withTrajectoryPathLock so a claim can never interleave with a concurrent


### PR DESCRIPTION
Closes [#89200](https://github.com/openclaw/openclaw/issues/89200)

> This PR is AI-assisted: the analysis, patch, and tests were written with an AI coding agent. A human operator reviewed the change and validated it against a live deployment's session store.

## What Problem This Solves

Session trajectory artifacts (`.trajectory.jsonl` + `.trajectory-path.json`) were handled inconsistently, and destructively, across the session lifecycle:

1. **Delete** (dashboard / `sessions.delete` RPC) archived the transcript but left the trajectory pair orphaned on disk forever (the original [#89200](https://github.com/openclaw/openclaw/issues/89200) defect).
2. **Reset paths** either deleted the trajectory outright (destroying the forensic tool-call record, flagged as a P1 by the automated review on this PR) or left it at its live name to be misclassified later.
3. The **typed `/new` and `/reset`** commands (and the implicit daily/idle rollover) went through a code path with no trajectory handling at all, so fixes applied to the other reset doors never reached the path users actually type.

## What This Change Does

One consistent model: **trajectory artifacts shadow their transcript**. Whenever a session's transcript is archived with a `.reset.<ts>` or `.deleted.<ts>` suffix, the trajectory runtime file and pointer are renamed with the byte-identical suffix in the same operation (shared `nowMs`), never unlinked:

- A `TrajectoryArtifactDisposal` union threads the disposal mode through the cleanup helpers: `{ mode: "tombstone", reason, nowMs }` for user-visible lifecycle events, with rename-in-place semantics under the same `withTrajectoryPathLock` retire turn.
- All three lifecycle doors are coupled: `deleteSessionEntryLifecycle` (delete), `resetSessionEntryLifecycle` (dashboard New Session button), and the typed-command rollover path `initSessionState` → `commitReplySessionInitialization`, plus the internal self-heal path `persistSessionResetLifecycle`.
- The referenced-sessions guard snapshot is taken **inside the locked store mutator** (`referencedSessionIdsAtSwap`), closing a race where an unlocked re-read after two await points could see a concurrent writer's row and silently skip the tombstone.
- **External trajectory directories** (`OPENCLAW_TRAJECTORY_DIR`): the pair is tombstoned in place only under proven ownership (registry-owned, or the session's own pointer file names the target); unproven files in an operator-configured directory are left untouched. The retention sweep follows tombstone directories, so aging works there too.
- **No new retention code.** Tombstoned trajectories reuse the existing `.reset.<ts>` / `.deleted.<ts>` suffix conventions and age out with the existing archived-transcript sweep.

## Why rename instead of delete on reset

No merged commit or confirmed-maintainer comment currently states reset-vs-trajectory policy explicitly, but the record strongly and repeatedly converges on one answer: reset must preserve trajectory records via rename/archive, never delete them outright. This is proposed directly in [#90707](https://github.com/openclaw/openclaw/issues/90707) (with a concrete forensics-loss incident as motivation), implemented the same way in the still-open [#94593](https://github.com/openclaw/openclaw/pull/94593) (after two prior closed-unmerged attempts at the identical shape, [#93319](https://github.com/openclaw/openclaw/pull/93319) and [#94895](https://github.com/openclaw/openclaw/pull/94895)), echoed by the broader "never `rm` a session file, only move/rename" position in [#56609](https://github.com/openclaw/openclaw/issues/56609), and most directly, flagged as a P1 blocker on this very branch by the automated reviewer, which asked explicitly to "preserve or archive pre-reset trajectories instead of deleting them." This PR's tombstone-rename on the runner-driven `/reset` path is our attempt to satisfy that converging intent without waiting on #94593 to land, since the two changes touch adjacent but distinct code paths (delete-lifecycle cleanup vs. the shared reset-archive helper) and reconciling them is better done as a maintainer-guided follow-up than by blocking this fix on an unrelated open PR.

## Evidence

Test gates on the final head: trajectory cleanup 13/13 (including the runtime-rename-failure regression and both retired-claim rejection regressions), gateway archive-cleanup 27/27 (external-dir ownership guard), session-accessor + store.pruning 108, session 143/143, typecheck (`tsgo:core` + `tsgo:core:test`), oxlint/oxfmt, all green. Every fix commit is red-proven against its pre-fix code.

## Exact-head live behavior proof

- **Head:** `cf2e5359e4026710ac36e83eb14ac0195af57213` (branch `fix/session-delete-trajectory-orphan`), confirmed both via `git rev-parse HEAD` and the built CLI's own `openclaw --version` output (`OpenClaw 2026.7.2 (cf2e535)`). This head adds two commits atop the previously-proven `992958805d336da12b6b1e5535fbc2192c148983`: `eeec4f5c55d` ("fix(trajectory): reject same-owner claims on a retired path instead of disambiguating") and `cf2e5359e40` ("test(trajectory): cover retired-path late-claim rejection") — writer-lifecycle/runtime tightening only; the reset/delete lifecycle behavior proven below is unchanged.
- **Build:** `pnpm install --frozen-lockfile` (already current) + `pnpm build` (`scripts/build-all.mjs`, ~266s, all phases green).
- **Environment:** isolated scratch state dir (`OPENCLAW_STATE_DIR=~/oc-proof-home/.openclaw`, `HOME=~/oc-proof-home`), gateway built from this head, running on loopback port `28789` (never the live fleet's `18789`). Re-onboarded non-interactively (the prior scratch home had aged out of `/tmp` between runs) with the model provider `baseUrl` pointed at a dead local port (`http://127.0.0.1:1/v1`) so every model call fails fast on connection refusal — irrelevant to the proof, since session lifecycle (rollover/delete tombstoning) happens at inbound dispatch before any model reply.

**Inbound surface note (unchanged from prior runs):** the real inbound door for `chat.send` is the same RPC the webchat/dashboard client uses. The built-in `openclaw gateway call` CLI tool auto-resolves *least-privilege* scopes per method, which for `chat.send` does not include `operator.admin` — so a plain `gateway call chat.send "/reset"` gets silently accepted into history as **plain text**, never triggering the reset door. This is deliberate authorization behavior (`isResetAuthorizedForContext`), not a bug. To reproduce the trusted dashboard/operator path faithfully, `chat.send`/`sessions.delete` were called via `callGateway(...)` with an explicit `scopes: ["operator.admin"]`, matching what an authenticated control-ui session is granted.

---

### Scenario A — typed `/reset` (rollover door)

Inbound surface: `chat.send` RPC (admin-scoped), literal text `/reset` sent as a normal chat message (not the `sessions.reset` RPC directly).

**Before** (`agents/main/sessions/`):
```
-rw-rw-r-- 1 user user  1641 Jul 12 00:54 bd7bdcfe-86cb-…-7e45.jsonl
-rw------- 1 user user 77777 Jul 12 00:54 bd7bdcfe-86cb-…-7e45.trajectory.jsonl
-rw------- 1 user user   252 Jul 12 00:54 bd7bdcfe-86cb-…-7e45.trajectory-path.json
```

**After** `/reset`:
```
-rw-rw-r-- 1 user user  1641 Jul 12 00:54 bd7bdcfe-86cb-…-7e45.jsonl.reset.2026-07-11T21-54-53.103Z
-rw------- 1 user user 77777 Jul 12 00:54 bd7bdcfe-86cb-…-7e45.trajectory.jsonl.reset.2026-07-11T21-54-53.103Z
-rw------- 1 user user   252 Jul 12 00:54 bd7bdcfe-86cb-…-7e45.trajectory-path.json.reset.2026-07-11T21-54-53.103Z
-rw------- 1 user user   976 Jul 12 00:54 8394dfd1-8d1a-…-e8cf.jsonl   ← fresh session
```
All three tombstoned with the **identical** `.reset.2026-07-11T21-54-53.103Z` suffix; fresh session created. **PASS.**

---

### Scenario B — deletion (delete door)

Inbound surface: `sessions.delete` RPC (admin-scoped) — the same RPC the dashboard's delete action calls — on a freshly seeded non-main session `proof-b3`.

**Before:**
```
-rw-rw-r-- 1 user user  1383 Jul 12 00:55 7d7afdd1-e5a8-…-8b016.jsonl
-rw------- 1 user user 77611 Jul 12 00:55 7d7afdd1-e5a8-…-8b016.trajectory.jsonl
-rw------- 1 user user   252 Jul 12 00:55 7d7afdd1-e5a8-…-8b016.trajectory-path.json
```

**After** `sessions.delete({key:"proof-b3"})` → `{"ok":true,"deleted":true}`:
```
-rw-rw-r-- 1 user user  1383 Jul 12 00:55 7d7afdd1-e5a8-…-8b016.jsonl.deleted.2026-07-11T21-55-33.255Z
-rw------- 1 user user 77611 Jul 12 00:55 7d7afdd1-e5a8-…-8b016.trajectory.jsonl.deleted.2026-07-11T21-55-33.255Z
-rw------- 1 user user   252 Jul 12 00:55 7d7afdd1-e5a8-…-8b016.trajectory-path.json.deleted.2026-07-11T21-55-33.255Z
```
Registry key `agent:main:proof-b3` absent from `sessions.json` after delete. All three tombstoned with the identical `.deleted.<timestamp>` suffix — no orphaned trajectory. **PASS.**

---

### Scenario C — configured external trajectory directory

Gateway restarted with `OPENCLAW_TRAJECTORY_DIR=~/oc-proof-trajectories` (a second scratch dir, separate from the sessions dir). Seeded session `proof-c3`, confirmed placement, then sent `/reset` (admin-scoped `chat.send`).

**Seed placement** — sessions dir holds only the session file + pointer (no local `.trajectory.jsonl`); the trajectory itself lives in the external dir, and the pointer references it:
```
agents/main/sessions/b883e5e3-52e8-…-8e66f.jsonl
agents/main/sessions/b883e5e3-52e8-…-8e66f.trajectory-path.json  → runtimeFile: "~/oc-proof-trajectories/b883e5e3-52e8-…-8e66f.jsonl"
oc-proof-trajectories/b883e5e3-52e8-…-8e66f.jsonl
```

**Before `/reset`:**
```
sessions/:              b883e5e3-….jsonl, b883e5e3-….trajectory-path.json
oc-proof-trajectories/: b883e5e3-….jsonl
```

**After `/reset`:**
```
sessions/:              b883e5e3-….jsonl.reset.2026-07-11T21-56-43.689Z
                         b883e5e3-….trajectory-path.json.reset.2026-07-11T21-56-43.689Z
oc-proof-trajectories/:  b883e5e3-….jsonl.reset.2026-07-11T21-56-43.689Z
```
Session + pointer tombstoned in the sessions dir, and the trajectory renamed **in place** inside the external directory — all three sharing the identical `.reset.2026-07-11T21-56-43.689Z` timestamp. No orphaned file left behind in either directory. **PASS.**

---

### Failure-path proof (deterministic regressions at this head)

Both suites re-run at head `cf2e535`, verbose reporter, on the built/checked-out worktree (no scratch gateway involved). `cleanup.test.ts` grew from 12 to 13 tests: the two race tests that previously asserted same-owner-retired *disambiguation* were reworked to assert outright *rejection* instead.

**1. Runtime-rename failure is retryable, not data-losing, and retired-path late-claims are rejected** — `src/trajectory/cleanup.test.ts`:
```
node scripts/run-vitest.mjs run --config test/vitest/vitest.unit-fast.config.ts src/trajectory/cleanup.test.ts --reporter=verbose

 ✓ |unit-fast| src/trajectory/cleanup.test.ts > trajectory cleanup > commits the runtime archive even when the pointer archive fails best-effort 4ms
 ✓ |unit-fast| src/trajectory/cleanup.test.ts > trajectory cleanup > leaves the trajectory pair fully live when the runtime archive fails, then disposes on retry 5ms
 ✓ |unit-fast| src/trajectory/cleanup.test.ts > trajectory cleanup > retires the canonical path before archiving the runtime file 2ms
 ✓ |unit-fast| src/trajectory/cleanup.test.ts > trajectory cleanup > does not admit a writer claim while a delete's archive-rename is still in flight 5ms
 ✓ |unit-fast| src/trajectory/cleanup.test.ts > trajectory cleanup > rejects a queued same-owner re-acquisition after a racing delete retires the path 4ms
 ✓ |unit-fast| src/trajectory/cleanup.test.ts > trajectory cleanup > disables a straggler recorder acquiring its own path after the session was deleted 3ms

 Test Files  1 passed (1)
      Tests  13 passed (13)
```
Proves two things: (1) when the runtime-file rename (the actual disposal commit point) fails, the session+pointer pair is left **fully live** rather than half-tombstoned — no orphan from a partial failure — and a retry disposes it once the failure clears; (2) a same-owner claim that races a delete onto an already-retired path is now **rejected outright** (lease resolves `status: "retired"`, recorder `null`, no fresh pointer/runtime file minted) instead of the old behavior of disambiguating into a second file — closing the exact race the retired-path guard targets.

**2. External-dir ownership guard: ownership proven before reaping** — `src/gateway/session-transcript-files.fs.archive-cleanup.test.ts` (unchanged from the prior head; re-run for completeness):
```
node scripts/run-vitest.mjs run --config test/vitest/vitest.config.ts src/gateway/session-transcript-files.fs.archive-cleanup.test.ts --reporter=verbose

 ✓ |gateway-core| ... external-directory ownership guard > in an external dir, reaps a genuine aged trajectory tombstone but keeps a foreign suffix look-alike 5ms
 ✓ |gateway-core| ... external-directory ownership guard > keeps a foreign pointer-shaped tombstone with invalid JSON in an external dir 2ms
 ✓ |gateway-core| ... external-directory ownership guard > still ages in-store-dir tombstones by suffix alone, with no header requirement 2ms
 ✓ |gateway-core| ... external-directory ownership guard > keeps an oversized/garbage external tombstone using only a bounded prefix read 3ms
 (same 4 cases repeat green under the gateway-server and gateway-client projects)

 Test Files  3 passed (3)
      Tests  27 passed (27)
```
Proves: the retention sweep only reaps a tombstone in an externally-configured trajectory directory when it can prove ownership (a genuine, aged, well-formed pointer-shaped header) — a same-suffix file dropped there by something else survives untouched, while in-store-dir tombstones keep the cheaper suffix-only aging rule since there's no cross-owner ambiguity there.

---

### Isolation proof

- Live gateway `ActiveEnterTimestamp` unchanged across the whole window: `Sat 2026-07-11 20:26:28 +03` (captured before and after this refresh run too).
- Live gateway still solely bound to `127.0.0.1:18789` / `[::1]:18789`; scratch gateway only ever bound `28789`, confirmed freed after teardown.
- Scratch gateway PID confirmed gone after `kill`; scratch dirs (`~/oc-proof-home`, `~/oc-proof-trajectories`) left on disk for inspection, nothing else touched or removed.

## Scope notes

- `applySessionEntryLifecycleMutation` (the batched background-maintenance mutation used by the session reaper, cleanup service, and heartbeat runner) is deliberately not touched: its removed-session cleanup already routes through the trajectory-coupled maintenance helpers, and unreferenced pairs are reclaimed by the age-based prune, which is the correct model for background reaping (no user action to timestamp-couple to).
- [#94593](https://github.com/openclaw/openclaw/pull/94593) partially overlaps on intent (reset-time preservation) but implements it in the shared reset-archive helper; this PR covers the delete lifecycle and the typed-command rollover door. If #94593 lands first we are happy to rebase and drop any overlap, and vice versa.

## User Impact

Deleting or resetting a session, from any surface, now leaves a complete archived trio with one shared timestamp instead of orphaned or destroyed trajectory files. Post-incident forensics of tool calls survives resets. Existing retention behavior and bounds are unchanged.
