### PR TITLE
fix(msteams): bound Bot Framework attachmentInfo JSON response reads

### DIFF
--- a/extensions/msteams/src/attachments/bot-framework.test.ts
+++ b/extensions/msteams/src/attachments/bot-framework.test.ts
@@ -534,39 +534,40 @@ describe("downloadMSTeamsBotFrameworkAttachment", () => {
       const jsonSpy = vi.spyOn(Response.prototype, "json").mockImplementation(async () => {
         throw new Error("raw response.json() should not be used");
       });
-      const fetchFn = createMockFetch([
-        {
-          match: /\/v3\/attachments\/att-1$/,
-          response: new Response(stream, {
-            status: 200,
-            headers: { "content-type": "application/json" },
-          }),
-        },
-      ]);
-
-      const warn = vi.fn();
-      const media = await downloadMSTeamsBotFrameworkAttachment({
-        serviceUrl: "https://smba.trafficmanager.net/amer",
-        attachmentId: "att-1",
-        tokenProvider: buildTokenProvider(),
-        maxBytes: 10_000_000,
-        fetchFn,
-        fetchFnSupportsDispatcher: true,
-        resolveFn: resolvePublicHost,
-        logger: { warn },
+      const fetchFn: typeof fetch = vi.fn(async () => {
+        return new Response(stream, {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        });
       });
 
-      expect(media).toBeUndefined();
-      expect(jsonSpy).not.toHaveBeenCalled();
-      // Enforced well before the 64 MiB test ceiling; an unbounded reader would keep pulling.
-      expect(state.enqueued).toBeLessThan(32);
-      expect(warn).toHaveBeenCalledWith(
-        "msteams botFramework attachmentInfo parse failed",
-        expect.objectContaining({
-          error: expect.stringMatching(/JSON response exceeds 16777216 bytes/),
-        }),
-      );
-      jsonSpy.mockRestore();
+      try {
+        const warn = vi.fn();
+        const media = await downloadMSTeamsBotFrameworkAttachment({
+          serviceUrl: "https://smba.trafficmanager.net/amer",
+          attachmentId: "att-1",
+          tokenProvider: buildTokenProvider(),
+          maxBytes: 10_000_000,
+          fetchFn,
+          fetchFnSupportsDispatcher: true,
+          resolveFn: resolvePublicHost,
+          logger: { warn },
+        });
+
+        expect(media).toBeUndefined();
+        expect(jsonSpy).not.toHaveBeenCalled();
+        // Enforced well before the 64 MiB test ceiling; an unbounded reader would keep pulling.
+        expect(state.enqueued).toBeLessThan(32);
+        expect(state.canceled).toBe(true);
+        expect(warn).toHaveBeenCalledWith(
+          "msteams botFramework attachmentInfo parse failed",
+          expect.objectContaining({
+            error: expect.stringMatching(/JSON response exceeds 16777216 bytes/),
+          }),
+        );
+      } finally {
+        jsonSpy.mockRestore();
+      }
     });
   });
 });

--- a/extensions/msteams/src/attachments/bot-framework.test.ts
+++ b/extensions/msteams/src/attachments/bot-framework.test.ts
@@ -514,6 +514,60 @@ describe("downloadMSTeamsBotFrameworkAttachment", () => {
         { status: 500 },
       ]);
     });
+
+    it("bounds an unbounded attachmentInfo JSON body and cancels the stream", async () => {
+      const state = { canceled: false, enqueued: 0 };
+      const chunkBytes = 1024 * 1024;
+      const stream = new ReadableStream<Uint8Array>({
+        pull(controller) {
+          if (state.enqueued >= 64) {
+            controller.close();
+            return;
+          }
+          state.enqueued += 1;
+          controller.enqueue(new Uint8Array(chunkBytes).fill(0x61));
+        },
+        cancel() {
+          state.canceled = true;
+        },
+      });
+      const jsonSpy = vi.spyOn(Response.prototype, "json").mockImplementation(async () => {
+        throw new Error("raw response.json() should not be used");
+      });
+      const fetchFn = createMockFetch([
+        {
+          match: /\/v3\/attachments\/att-1$/,
+          response: new Response(stream, {
+            status: 200,
+            headers: { "content-type": "application/json" },
+          }),
+        },
+      ]);
+
+      const warn = vi.fn();
+      const media = await downloadMSTeamsBotFrameworkAttachment({
+        serviceUrl: "https://smba.trafficmanager.net/amer",
+        attachmentId: "att-1",
+        tokenProvider: buildTokenProvider(),
+        maxBytes: 10_000_000,
+        fetchFn,
+        fetchFnSupportsDispatcher: true,
+        resolveFn: resolvePublicHost,
+        logger: { warn },
+      });
+
+      expect(media).toBeUndefined();
+      expect(jsonSpy).not.toHaveBeenCalled();
+      // Enforced well before the 64 MiB test ceiling; an unbounded reader would keep pulling.
+      expect(state.enqueued).toBeLessThan(32);
+      expect(warn).toHaveBeenCalledWith(
+        "msteams botFramework attachmentInfo parse failed",
+        expect.objectContaining({
+          error: expect.stringMatching(/JSON response exceeds 16777216 bytes/),
+        }),
+      );
+      jsonSpy.mockRestore();
+    });
   });
 });
 

--- a/extensions/msteams/src/attachments/bot-framework.ts
+++ b/extensions/msteams/src/attachments/bot-framework.ts
@@ -1,5 +1,6 @@
 // Msteams plugin module implements bot framework behavior.
 import { parseMediaContentLength } from "openclaw/plugin-sdk/media-runtime";
+import { readProviderJsonResponse } from "openclaw/plugin-sdk/provider-http";
 import { getMSTeamsRuntime } from "../runtime.js";
 import { ensureUserAgentHeader } from "../user-agent.js";
 import {
@@ -112,7 +113,10 @@ async function fetchBotFrameworkAttachmentInfo(params: {
     return undefined;
   }
   try {
-    return (await response.json()) as BotFrameworkAttachmentInfo;
+    return await readProviderJsonResponse<BotFrameworkAttachmentInfo>(
+      response,
+      "msteams botFramework attachmentInfo",
+    );
   } catch (err) {
     params.logger?.warn?.("msteams botFramework attachmentInfo parse failed", {
       error: err instanceof Error ? err.message : String(err),


### PR DESCRIPTION
## What Problem This Solves

Bot Framework personal-chat attachment downloads call `/v3/attachments/{id}` and previously parsed the metadata with unbounded `response.json()`. A hostile or misbehaving endpoint could stream an arbitrarily large JSON body and OOM the gateway process before the attachment view download even starts.

Related open bounded-read work covers MS Teams Graph collection (#98833), Graph upload (#97784), and SSO (#97781), but not the Bot Framework `attachmentInfo` path in `bot-framework.ts`.

Note: Inworld TTS/voices bounded reads are already on `main` (#95416, #98660), so this PR targets the remaining MS Teams gap instead.

## Why This Change Was Made

Route the Bot Framework attachment metadata success path through the shared `readProviderJsonResponse` helper (16 MiB cap, stream cancel on overflow), matching sibling MS Teams Graph/OAuth bounded JSON reads.

The 16 MiB fail-closed cap is intentional: successful Bot Framework metadata responses larger than the shared provider JSON cap now fail as invalid attachment metadata instead of being buffered without a limit. That can reject unusual oversized metadata, but keeps the gateway from accepting unbounded JSON on this shipped attachment path.

## User Impact

No config or API changes. Personal DM / Bot Framework attachment downloads fail closed with a logged warning when attachment metadata JSON exceeds the cap, instead of buffering the full body.

## Evidence

### Maintainer verification

Exact head `660df2c24db7abd5d4fb541eb5f9f90f302eed6d` was tested in a fresh,
sanitized direct AWS Crabbox with public networking, no Tailscale, no instance
profile, isolated HOME, and the trusted untrusted-PR bootstrap.

- Focused run [`run_d895c9a9e528`](https://crabbox.openclaw.ai/portal/runs/run_d895c9a9e528): 21/21 Bot Framework attachment tests passed.
- Loopback API run [`run_1f4883b97ce5`](https://crabbox.openclaw.ai/portal/runs/run_1f4883b97ce5): normal metadata and view each completed once; oversized metadata was rejected, the server stream closed after 20 one-MiB writes, and the exact 16 MiB warning was emitted.
- Fresh exact-head Codex autoreview found no accepted or actionable findings.
- Exact-head GitHub CI [`28811868628`](https://github.com/openclaw/openclaw/actions/runs/28811868628): success.

### Contributor verification

Branch `fix/msteams-bound-bot-framework-attachmentinfo-json-reads`.

```bash
node scripts/run-vitest.mjs extensions/msteams/src/attachments/bot-framework.test.ts
```

Result: 21/21 tests passed. The oversized regression test now returns a fresh streaming `Response`, asserts `response.json()` is not used, verifies the bounded reader stops before the 64 MiB test ceiling, and asserts the original stream was canceled.

```bash
pnpm format:check -- extensions/msteams/src/attachments/bot-framework.test.ts
```

Result: all matched files use the correct format.

Loopback Bot Framework-style proof:

```bash
node --import tsx --input-type=module -
```

The proof script started a local HTTP server with Bot Framework-style routes, invoked `downloadMSTeamsBotFrameworkAttachment` through the production MS Teams attachment path, mapped the Bot Framework URL to the loopback server via the injected fetch implementation, and exercised both normal metadata and oversized metadata responses.

Output:

```json
{
  "ok": true,
  "normalMetadataHits": 1,
  "normalViewHits": 1,
  "oversizedRejected": true,
  "oversizedMetadataHits": 1,
  "oversizedChunksWritten": 19,
  "oversizedClosed": true,
  "warning": {
    "message": "msteams botFramework attachmentInfo parse failed",
    "meta": {
      "error": "msteams botFramework attachmentInfo: JSON response exceeds 16777216 bytes"
    }
  }
}
```

Changed files:
- `extensions/msteams/src/attachments/bot-framework.ts` — `readProviderJsonResponse` for attachmentInfo
- `extensions/msteams/src/attachments/bot-framework.test.ts` — bounded-read regression test with fresh streaming response cancellation proof

Fix, regression, and original loopback proof by @ly85206559; final exact-head
AWS/CI verification by @steipete.
