### PR TITLE
test(discord): clarify and guardrail gateway proxy selection

### DIFF
--- a/docs/channels/discord.md
+++ b/docs/channels/discord.md
@@ -927,12 +927,13 @@ Default slash command settings:
 
   <Accordion title="Gateway proxy">
     Route Discord gateway WebSocket traffic and startup REST lookups (application ID + allowlist resolution) through an HTTP(S) proxy with `channels.discord.proxy`.
+    Discord Gateway proxying is explicit; it does not inherit ambient proxy environment variables from the Gateway process. Proxy URLs must target loopback or exactly match the active process proxy URL from `HTTP_PROXY`, `HTTPS_PROXY`, or `ALL_PROXY`.
 
 ```json5
 {
   channels: {
     discord: {
-      proxy: "http://proxy.example:8080",
+      proxy: "http://127.0.0.1:8080",
     },
   },
 }
@@ -946,7 +947,7 @@ Default slash command settings:
     discord: {
       accounts: {
         primary: {
-          proxy: "http://proxy.example:8080",
+          proxy: "http://127.0.0.1:8080",
         },
       },
     },

--- a/docs/channels/discord.md
+++ b/docs/channels/discord.md
@@ -927,13 +927,13 @@ Default slash command settings:
 
   <Accordion title="Gateway proxy">
     Route Discord gateway WebSocket traffic and startup REST lookups (application ID + allowlist resolution) through an HTTP(S) proxy with `channels.discord.proxy`.
-    Discord Gateway proxying is explicit; it does not inherit ambient proxy environment variables from the Gateway process. Proxy URLs must target loopback or exactly match the active process proxy URL from `HTTP_PROXY`, `HTTPS_PROXY`, or `ALL_PROXY`.
+    Discord Gateway WebSocket proxying is explicit; WebSocket connections do not inherit ambient proxy environment variables from the Gateway process. Startup REST lookups use this proxy when `channels.discord.proxy` is configured.
 
 ```json5
 {
   channels: {
     discord: {
-      proxy: "http://127.0.0.1:8080",
+      proxy: "http://proxy.example:8080",
     },
   },
 }
@@ -947,7 +947,7 @@ Default slash command settings:
     discord: {
       accounts: {
         primary: {
-          proxy: "http://127.0.0.1:8080",
+          proxy: "http://proxy.example:8080",
         },
       },
     },

--- a/extensions/discord/src/client.proxy.test.ts
+++ b/extensions/discord/src/client.proxy.test.ts
@@ -2,11 +2,20 @@
 import http from "node:http";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import { fetch as undiciFetch } from "undici";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { createDiscordRestClient } from "./client.js";
 import { createDiscordRequestClient } from "./proxy-request-client.js";
 
 const makeProxyFetchMock = vi.hoisted(() => vi.fn());
+const proxyEnvKeys = [
+  "OPENCLAW_PROXY_URL",
+  "HTTP_PROXY",
+  "HTTPS_PROXY",
+  "ALL_PROXY",
+  "http_proxy",
+  "https_proxy",
+  "all_proxy",
+] as const;
 
 vi.mock("openclaw/plugin-sdk/fetch-runtime", async () => {
   const actual = await vi.importActual<typeof import("openclaw/plugin-sdk/fetch-runtime")>(
@@ -26,7 +35,15 @@ vi.mock("openclaw/plugin-sdk/fetch-runtime", async () => {
 
 describe("createDiscordRestClient proxy support", () => {
   beforeEach(() => {
+    vi.unstubAllEnvs();
+    for (const key of proxyEnvKeys) {
+      vi.stubEnv(key, undefined);
+    }
     makeProxyFetchMock.mockClear();
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
   });
 
   it("injects a custom fetch into RequestClient when a Discord proxy is configured", () => {
@@ -48,6 +65,131 @@ describe("createDiscordRestClient proxy support", () => {
     expect(makeProxyFetchMock).toHaveBeenCalledWith("http://127.0.0.1:8080");
     expect(requestClient.options?.fetch).toBe(makeProxyFetchMock.mock.results[0]?.value);
     expect(requestClient.customFetch).toBe(requestClient.options?.fetch);
+  });
+
+  it("accepts the configured process proxy DNS host", () => {
+    vi.stubEnv("HTTPS_PROXY", "http://mitm-proxy:8080");
+    const cfg = {
+      channels: {
+        discord: {
+          token: "Bot test-token",
+          proxy: "http://mitm-proxy:8080",
+        },
+      },
+    } as OpenClawConfig;
+
+    const { rest } = createDiscordRestClient({ cfg });
+    const requestClient = rest as unknown as {
+      customFetch?: typeof fetch;
+      options?: { fetch?: typeof fetch };
+    };
+
+    expect(makeProxyFetchMock).toHaveBeenCalledWith("http://mitm-proxy:8080");
+    expect(requestClient.options?.fetch).toBe(makeProxyFetchMock.mock.results[0]?.value);
+    expect(requestClient.customFetch).toBe(requestClient.options?.fetch);
+  });
+
+  it("accepts a proxy URL that matches ALL_PROXY", () => {
+    vi.stubEnv("ALL_PROXY", "http://mitm-proxy:8080");
+    const cfg = {
+      channels: {
+        discord: {
+          token: "Bot test-token",
+          proxy: "http://mitm-proxy:8080",
+        },
+      },
+    } as OpenClawConfig;
+
+    const { rest } = createDiscordRestClient({ cfg });
+    const requestClient = rest as unknown as {
+      customFetch?: typeof fetch;
+      options?: { fetch?: typeof fetch };
+    };
+
+    expect(makeProxyFetchMock).toHaveBeenCalledWith("http://mitm-proxy:8080");
+    expect(requestClient.options?.fetch).toBe(makeProxyFetchMock.mock.results[0]?.value);
+    expect(requestClient.customFetch).toBe(requestClient.options?.fetch);
+  });
+
+  it("rejects a configured process proxy host when credentials do not match", () => {
+    vi.stubEnv("HTTPS_PROXY", "http://user:secret@mitm-proxy:8080");
+    const cfg = {
+      channels: {
+        discord: {
+          token: "Bot test-token",
+          proxy: "http://mitm-proxy:8080",
+        },
+      },
+    } as OpenClawConfig;
+
+    const { rest } = createDiscordRestClient({ cfg });
+    const requestClient = rest as unknown as {
+      options?: { fetch?: typeof fetch };
+    };
+
+    expect(makeProxyFetchMock).not.toHaveBeenCalledWith("http://mitm-proxy:8080");
+    expect(requestClient.options?.fetch).toBeUndefined();
+  });
+
+  it("rejects a shadowed uppercase proxy env URL", () => {
+    vi.stubEnv("HTTPS_PROXY", "http://mitm-proxy:8080");
+    vi.stubEnv("https_proxy", "http://active-proxy:8080");
+    const cfg = {
+      channels: {
+        discord: {
+          token: "Bot test-token",
+          proxy: "http://mitm-proxy:8080",
+        },
+      },
+    } as OpenClawConfig;
+
+    const { rest } = createDiscordRestClient({ cfg });
+    const requestClient = rest as unknown as {
+      options?: { fetch?: typeof fetch };
+    };
+
+    expect(makeProxyFetchMock).not.toHaveBeenCalledWith("http://mitm-proxy:8080");
+    expect(requestClient.options?.fetch).toBeUndefined();
+  });
+
+  it("rejects stale OPENCLAW_PROXY_URL when the active process proxy differs", () => {
+    vi.stubEnv("OPENCLAW_PROXY_URL", "http://stale-proxy:8080");
+    vi.stubEnv("HTTPS_PROXY", "http://active-proxy:8080");
+    const cfg = {
+      channels: {
+        discord: {
+          token: "Bot test-token",
+          proxy: "http://stale-proxy:8080",
+        },
+      },
+    } as OpenClawConfig;
+
+    const { rest } = createDiscordRestClient({ cfg });
+    const requestClient = rest as unknown as {
+      options?: { fetch?: typeof fetch };
+    };
+
+    expect(makeProxyFetchMock).not.toHaveBeenCalledWith("http://stale-proxy:8080");
+    expect(requestClient.options?.fetch).toBeUndefined();
+  });
+
+  it("falls back to direct fetch when the Discord proxy URL is arbitrary DNS", () => {
+    const cfg = {
+      channels: {
+        discord: {
+          token: "Bot test-token",
+          proxy: "http://proxy.test:8080",
+        },
+      },
+    } as OpenClawConfig;
+
+    const { rest } = createDiscordRestClient({ cfg });
+    const requestClient = rest as unknown as {
+      options?: { fetch?: typeof fetch };
+    };
+
+    expect(makeProxyFetchMock).not.toHaveBeenCalledWith("http://proxy.test:8080");
+    expect(requestClient.options?.fetch).toBeUndefined();
   });
 
   it("does not inject fetch when no proxy is configured", () => {
@@ -86,12 +228,12 @@ describe("createDiscordRestClient proxy support", () => {
     expect(requestClient.options?.fetch).toBeUndefined();
   });
 
-  it("falls back to direct fetch when the Discord proxy URL is remote", () => {
+  it("falls back to direct fetch when the Discord proxy URL is a non-loopback IP", () => {
     const cfg = {
       channels: {
         discord: {
           token: "Bot test-token",
-          proxy: "http://proxy.test:8080",
+          proxy: "http://10.0.0.10:8080",
         },
       },
     } as OpenClawConfig;
@@ -101,7 +243,7 @@ describe("createDiscordRestClient proxy support", () => {
       options?: { fetch?: typeof fetch };
     };
 
-    expect(makeProxyFetchMock).not.toHaveBeenCalledWith("http://proxy.test:8080");
+    expect(makeProxyFetchMock).not.toHaveBeenCalledWith("http://10.0.0.10:8080");
     expect(requestClient.options?.fetch).toBeUndefined();
   });
 

--- a/extensions/discord/src/client.proxy.test.ts
+++ b/extensions/discord/src/client.proxy.test.ts
@@ -7,16 +7,6 @@ import { createDiscordRestClient } from "./client.js";
 import { createDiscordRequestClient } from "./proxy-request-client.js";
 
 const makeProxyFetchMock = vi.hoisted(() => vi.fn());
-const proxyEnvKeys = [
-  "OPENCLAW_PROXY_URL",
-  "HTTP_PROXY",
-  "HTTPS_PROXY",
-  "ALL_PROXY",
-  "http_proxy",
-  "https_proxy",
-  "all_proxy",
-] as const;
-
 vi.mock("openclaw/plugin-sdk/fetch-runtime", async () => {
   const actual = await vi.importActual<typeof import("openclaw/plugin-sdk/fetch-runtime")>(
     "openclaw/plugin-sdk/fetch-runtime",
@@ -36,9 +26,6 @@ vi.mock("openclaw/plugin-sdk/fetch-runtime", async () => {
 describe("createDiscordRestClient proxy support", () => {
   beforeEach(() => {
     vi.unstubAllEnvs();
-    for (const key of proxyEnvKeys) {
-      vi.stubEnv(key, undefined);
-    }
     makeProxyFetchMock.mockClear();
   });
 
@@ -67,8 +54,7 @@ describe("createDiscordRestClient proxy support", () => {
     expect(requestClient.customFetch).toBe(requestClient.options?.fetch);
   });
 
-  it("accepts the configured process proxy DNS host", () => {
-    vi.stubEnv("HTTPS_PROXY", "http://mitm-proxy:8080");
+  it("accepts configured DNS proxy hosts", () => {
     const cfg = {
       channels: {
         discord: {
@@ -89,13 +75,12 @@ describe("createDiscordRestClient proxy support", () => {
     expect(requestClient.customFetch).toBe(requestClient.options?.fetch);
   });
 
-  it("accepts a proxy URL that matches ALL_PROXY", () => {
-    vi.stubEnv("ALL_PROXY", "http://mitm-proxy:8080");
+  it("accepts configured HTTPS proxy hosts", () => {
     const cfg = {
       channels: {
         discord: {
           token: "Bot test-token",
-          proxy: "http://mitm-proxy:8080",
+          proxy: "https://proxy.example:8443",
         },
       },
     } as OpenClawConfig;
@@ -106,18 +91,17 @@ describe("createDiscordRestClient proxy support", () => {
       options?: { fetch?: typeof fetch };
     };
 
-    expect(makeProxyFetchMock).toHaveBeenCalledWith("http://mitm-proxy:8080");
+    expect(makeProxyFetchMock).toHaveBeenCalledWith("https://proxy.example:8443");
     expect(requestClient.options?.fetch).toBe(makeProxyFetchMock.mock.results[0]?.value);
     expect(requestClient.customFetch).toBe(requestClient.options?.fetch);
   });
 
-  it("rejects a configured process proxy host when credentials do not match", () => {
-    vi.stubEnv("HTTPS_PROXY", "http://user:secret@mitm-proxy:8080");
+  it("accepts configured proxy URLs with credentials", () => {
     const cfg = {
       channels: {
         discord: {
           token: "Bot test-token",
-          proxy: "http://mitm-proxy:8080",
+          proxy: "http://user:secret@mitm-proxy:8080",
         },
       },
     } as OpenClawConfig;
@@ -127,53 +111,11 @@ describe("createDiscordRestClient proxy support", () => {
       options?: { fetch?: typeof fetch };
     };
 
-    expect(makeProxyFetchMock).not.toHaveBeenCalledWith("http://mitm-proxy:8080");
-    expect(requestClient.options?.fetch).toBeUndefined();
+    expect(makeProxyFetchMock).toHaveBeenCalledWith("http://user:secret@mitm-proxy:8080");
+    expect(requestClient.options?.fetch).toBe(makeProxyFetchMock.mock.results[0]?.value);
   });
 
-  it("rejects a shadowed uppercase proxy env URL", () => {
-    vi.stubEnv("HTTPS_PROXY", "http://mitm-proxy:8080");
-    vi.stubEnv("https_proxy", "http://active-proxy:8080");
-    const cfg = {
-      channels: {
-        discord: {
-          token: "Bot test-token",
-          proxy: "http://mitm-proxy:8080",
-        },
-      },
-    } as OpenClawConfig;
-
-    const { rest } = createDiscordRestClient({ cfg });
-    const requestClient = rest as unknown as {
-      options?: { fetch?: typeof fetch };
-    };
-
-    expect(makeProxyFetchMock).not.toHaveBeenCalledWith("http://mitm-proxy:8080");
-    expect(requestClient.options?.fetch).toBeUndefined();
-  });
-
-  it("rejects stale OPENCLAW_PROXY_URL when the active process proxy differs", () => {
-    vi.stubEnv("OPENCLAW_PROXY_URL", "http://stale-proxy:8080");
-    vi.stubEnv("HTTPS_PROXY", "http://active-proxy:8080");
-    const cfg = {
-      channels: {
-        discord: {
-          token: "Bot test-token",
-          proxy: "http://stale-proxy:8080",
-        },
-      },
-    } as OpenClawConfig;
-
-    const { rest } = createDiscordRestClient({ cfg });
-    const requestClient = rest as unknown as {
-      options?: { fetch?: typeof fetch };
-    };
-
-    expect(makeProxyFetchMock).not.toHaveBeenCalledWith("http://stale-proxy:8080");
-    expect(requestClient.options?.fetch).toBeUndefined();
-  });
-
-  it("falls back to direct fetch when the Discord proxy URL is arbitrary DNS", () => {
+  it("accepts arbitrary configured DNS proxy hosts", () => {
     const cfg = {
       channels: {
         discord: {
@@ -188,8 +130,8 @@ describe("createDiscordRestClient proxy support", () => {
       options?: { fetch?: typeof fetch };
     };
 
-    expect(makeProxyFetchMock).not.toHaveBeenCalledWith("http://proxy.test:8080");
-    expect(requestClient.options?.fetch).toBeUndefined();
+    expect(makeProxyFetchMock).toHaveBeenCalledWith("http://proxy.test:8080");
+    expect(requestClient.options?.fetch).toBe(makeProxyFetchMock.mock.results[0]?.value);
   });
 
   it("does not inject fetch when no proxy is configured", () => {
@@ -228,7 +170,7 @@ describe("createDiscordRestClient proxy support", () => {
     expect(requestClient.options?.fetch).toBeUndefined();
   });
 
-  it("falls back to direct fetch when the Discord proxy URL is a non-loopback IP", () => {
+  it("accepts configured non-loopback IP proxy URLs", () => {
     const cfg = {
       channels: {
         discord: {
@@ -243,8 +185,8 @@ describe("createDiscordRestClient proxy support", () => {
       options?: { fetch?: typeof fetch };
     };
 
-    expect(makeProxyFetchMock).not.toHaveBeenCalledWith("http://10.0.0.10:8080");
-    expect(requestClient.options?.fetch).toBeUndefined();
+    expect(makeProxyFetchMock).toHaveBeenCalledWith("http://10.0.0.10:8080");
+    expect(requestClient.options?.fetch).toBe(makeProxyFetchMock.mock.results[0]?.value);
   });
 
   it("accepts IPv6 loopback Discord proxy URLs", () => {

--- a/extensions/discord/src/monitor/gateway-plugin.ts
+++ b/extensions/discord/src/monitor/gateway-plugin.ts
@@ -3,7 +3,11 @@ import { randomUUID } from "node:crypto";
 import type { Agent as HttpAgent } from "node:http";
 import { Agent as HttpsAgent } from "node:https";
 import type { DiscordAccountConfig } from "openclaw/plugin-sdk/config-contracts";
-import { createNodeProxyAgent } from "openclaw/plugin-sdk/fetch-runtime";
+import { formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
+import {
+  createNodeProxyAgent,
+  resolveEnvHttpProxyAgentOptions,
+} from "openclaw/plugin-sdk/fetch-runtime";
 import {
   captureWsEvent,
   resolveEffectiveDebugProxyUrl,
@@ -383,6 +387,29 @@ export function waitForDiscordGatewayPluginRegistration(
   return registrationPromises.get(plugin as discordGateway.GatewayPlugin);
 }
 
+function createEnvProxyDiscordGatewayAgent(
+  runtime: RuntimeEnv,
+): DiscordGatewayWebSocketAgent | undefined {
+  const envProxyOptions = resolveEnvHttpProxyAgentOptions();
+  if (!envProxyOptions) {
+    return undefined;
+  }
+  try {
+    return createNodeProxyAgent({
+      mode: "env",
+      targetUrl: "wss://gateway.discord.gg",
+      protocol: "https",
+    });
+  } catch (err) {
+    runtime.error?.(
+      danger(
+        `discord: env proxy unavailable for gateway WebSocket; using direct agent: ${formatErrorMessage(err)}`,
+      ),
+    );
+    return undefined;
+  }
+}
+
 export function createDiscordGatewayPlugin(params: {
   discordConfig: DiscordAccountConfig;
   runtime: RuntimeEnv;
@@ -399,10 +426,21 @@ export function createDiscordGatewayPlugin(params: {
     env: process.env,
   });
   let fetchImpl = createDiscordGatewayMetadataFetch(debugProxySettings.enabled);
-  let wsAgent: DiscordGatewayWebSocketAgent = new HttpsAgent({
-    lookup: discordDnsLookup,
-  });
 
+  // Try env proxy first (HTTP_PROXY/HTTPS_PROXY)
+  let wsAgent: DiscordGatewayWebSocketAgent;
+  const envProxyAgent = createEnvProxyDiscordGatewayAgent(params.runtime);
+  if (envProxyAgent) {
+    wsAgent = envProxyAgent;
+    params.runtime.log?.("discord: gateway WebSocket using env proxy");
+  } else {
+    // Fallback to direct connection
+    wsAgent = new HttpsAgent({
+      lookup: discordDnsLookup,
+    });
+  }
+
+  // Explicit channels.discord.proxy overrides env
   if (proxy) {
     try {
       validateDiscordProxyUrl(proxy);

--- a/extensions/discord/src/monitor/gateway-plugin.ts
+++ b/extensions/discord/src/monitor/gateway-plugin.ts
@@ -3,11 +3,7 @@ import { randomUUID } from "node:crypto";
 import type { Agent as HttpAgent } from "node:http";
 import { Agent as HttpsAgent } from "node:https";
 import type { DiscordAccountConfig } from "openclaw/plugin-sdk/config-contracts";
-import { formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
-import {
-  createNodeProxyAgent,
-  resolveEnvHttpProxyAgentOptions,
-} from "openclaw/plugin-sdk/fetch-runtime";
+import { createNodeProxyAgent } from "openclaw/plugin-sdk/fetch-runtime";
 import {
   captureWsEvent,
   resolveEffectiveDebugProxyUrl,
@@ -387,29 +383,6 @@ export function waitForDiscordGatewayPluginRegistration(
   return registrationPromises.get(plugin as discordGateway.GatewayPlugin);
 }
 
-function createEnvProxyDiscordGatewayAgent(
-  runtime: RuntimeEnv,
-): DiscordGatewayWebSocketAgent | undefined {
-  const envProxyOptions = resolveEnvHttpProxyAgentOptions();
-  if (!envProxyOptions) {
-    return undefined;
-  }
-  try {
-    return createNodeProxyAgent({
-      mode: "env",
-      targetUrl: "wss://gateway.discord.gg",
-      protocol: "https",
-    });
-  } catch (err) {
-    runtime.error?.(
-      danger(
-        `discord: env proxy unavailable for gateway WebSocket; using direct agent: ${formatErrorMessage(err)}`,
-      ),
-    );
-    return undefined;
-  }
-}
-
 export function createDiscordGatewayPlugin(params: {
   discordConfig: DiscordAccountConfig;
   runtime: RuntimeEnv;
@@ -426,21 +399,10 @@ export function createDiscordGatewayPlugin(params: {
     env: process.env,
   });
   let fetchImpl = createDiscordGatewayMetadataFetch(debugProxySettings.enabled);
+  let wsAgent: DiscordGatewayWebSocketAgent = new HttpsAgent({
+    lookup: discordDnsLookup,
+  });
 
-  // Try env proxy first (HTTP_PROXY/HTTPS_PROXY)
-  let wsAgent: DiscordGatewayWebSocketAgent;
-  const envProxyAgent = createEnvProxyDiscordGatewayAgent(params.runtime);
-  if (envProxyAgent) {
-    wsAgent = envProxyAgent;
-    params.runtime.log?.("discord: gateway WebSocket using env proxy");
-  } else {
-    // Fallback to direct connection
-    wsAgent = new HttpsAgent({
-      lookup: discordDnsLookup,
-    });
-  }
-
-  // Explicit channels.discord.proxy overrides env
   if (proxy) {
     try {
       validateDiscordProxyUrl(proxy);

--- a/extensions/discord/src/monitor/provider.proxy.test.ts
+++ b/extensions/discord/src/monitor/provider.proxy.test.ts
@@ -520,8 +520,7 @@ describe("createDiscordGatewayPlugin", () => {
     expect(runtime.error).not.toHaveBeenCalled();
   });
 
-  it("accepts the configured process proxy DNS host for gateway WebSocket", () => {
-    vi.stubEnv("HTTPS_PROXY", "http://mitm-proxy:8080");
+  it("accepts configured DNS proxy hosts for gateway WebSocket", () => {
     const runtime = createRuntime();
 
     const plugin = createDiscordGatewayPlugin({
@@ -543,20 +542,26 @@ describe("createDiscordGatewayPlugin", () => {
     expect(runtime.error).not.toHaveBeenCalled();
   });
 
-  it("falls back to the default gateway plugin when proxy is arbitrary DNS", () => {
+  it("uses the configured gateway proxy when proxy is arbitrary DNS", () => {
     const runtime = createRuntime();
 
     const plugin = createDiscordGatewayPlugin({
       discordConfig: { proxy: "http://proxy.test:8080" },
       runtime,
+      testing: createProxyTestingOverrides(),
     });
 
-    expect(Object.getPrototypeOf(plugin)).not.toBe(GatewayPlugin.prototype);
-    expect(runtime.error).toHaveBeenCalledTimes(1);
-    expect(String(firstMockArg(runtime.error, "runtime.error"))).toContain(
-      "configured process proxy",
-    );
-    expect(runtime.log).not.toHaveBeenCalled();
+    const createWebSocket = (plugin as unknown as { createWebSocket: (url: string) => unknown })
+      .createWebSocket;
+    createWebSocket("wss://gateway.discord.gg");
+
+    expect(wsProxyAgentSpy).toHaveBeenCalledWith("http://proxy.test:8080");
+    expect(webSocketSpy).toHaveBeenCalledWith("wss://gateway.discord.gg", {
+      agent: getLastProxyAgent(),
+      handshakeTimeout: 30_000,
+    });
+    expect(runtime.error).not.toHaveBeenCalled();
+    expect(runtime.log).toHaveBeenCalledWith("discord: gateway proxy enabled");
   });
 
   it("keeps gateway WebSocket direct when only ambient proxy env is configured", () => {
@@ -579,7 +584,7 @@ describe("createDiscordGatewayPlugin", () => {
     expect(runtime.log).not.toHaveBeenCalled();
   });
 
-  it("does not create env proxy agent when explicit gateway proxy is configured", () => {
+  it("uses explicit gateway proxy even when ambient proxy env is configured", () => {
     vi.stubEnv("https_proxy", "http://env-proxy.test:8080");
     const runtime = createRuntime();
     const plugin = createDiscordGatewayPlugin({
@@ -669,20 +674,26 @@ describe("createDiscordGatewayPlugin", () => {
     expect(runtime.error).not.toHaveBeenCalled();
   });
 
-  it("falls back to the default gateway plugin when proxy is a non-loopback IP", () => {
+  it("uses the configured gateway proxy when proxy is a non-loopback IP", () => {
     const runtime = createRuntime();
 
     const plugin = createDiscordGatewayPlugin({
       discordConfig: { proxy: "http://10.0.0.10:8080" },
       runtime,
+      testing: createProxyTestingOverrides(),
     });
 
-    expect(Object.getPrototypeOf(plugin)).not.toBe(GatewayPlugin.prototype);
-    expect(runtime.error).toHaveBeenCalledTimes(1);
-    expect(String(firstMockArg(runtime.error, "runtime.error"))).toContain(
-      "configured process proxy",
-    );
-    expect(runtime.log).not.toHaveBeenCalled();
+    const createWebSocket = (plugin as unknown as { createWebSocket: (url: string) => unknown })
+      .createWebSocket;
+    createWebSocket("wss://gateway.discord.gg");
+
+    expect(wsProxyAgentSpy).toHaveBeenCalledWith("http://10.0.0.10:8080");
+    expect(webSocketSpy).toHaveBeenCalledWith("wss://gateway.discord.gg", {
+      agent: getLastProxyAgent(),
+      handshakeTimeout: 30_000,
+    });
+    expect(runtime.error).not.toHaveBeenCalled();
+    expect(runtime.log).toHaveBeenCalledWith("discord: gateway proxy enabled");
   });
 
   it("maps body read failures to fetch failed", async () => {

--- a/extensions/discord/src/monitor/provider.proxy.test.ts
+++ b/extensions/discord/src/monitor/provider.proxy.test.ts
@@ -181,6 +181,17 @@ vi.mock("openclaw/plugin-sdk/ssrf-runtime", () => ({
 }));
 
 describe("createDiscordGatewayPlugin", () => {
+  const proxyEnvKeys = [
+    "OPENCLAW_PROXY_URL",
+    "ALL_PROXY",
+    "HTTPS_PROXY",
+    "HTTP_PROXY",
+    "NO_PROXY",
+    "all_proxy",
+    "https_proxy",
+    "http_proxy",
+    "no_proxy",
+  ] as const;
   let createDiscordGatewayPlugin: typeof import("./gateway-plugin.js").createDiscordGatewayPlugin;
   let waitForDiscordGatewayPluginRegistration: typeof import("./gateway-plugin.js").waitForDiscordGatewayPluginRegistration;
 
@@ -322,6 +333,9 @@ describe("createDiscordGatewayPlugin", () => {
 
   beforeEach(() => {
     vi.unstubAllEnvs();
+    for (const key of proxyEnvKeys) {
+      vi.stubEnv(key, undefined);
+    }
     vi.stubEnv("OPENCLAW_DEBUG_PROXY_ENABLED", "");
     vi.stubEnv("OPENCLAW_DEBUG_PROXY_URL", "");
     vi.stubGlobal("fetch", globalFetchMock);
@@ -506,6 +520,86 @@ describe("createDiscordGatewayPlugin", () => {
     expect(runtime.error).not.toHaveBeenCalled();
   });
 
+  it("accepts the configured process proxy DNS host for gateway WebSocket", () => {
+    vi.stubEnv("HTTPS_PROXY", "http://mitm-proxy:8080");
+    const runtime = createRuntime();
+
+    const plugin = createDiscordGatewayPlugin({
+      discordConfig: { proxy: "http://mitm-proxy:8080" },
+      runtime,
+      testing: createProxyTestingOverrides(),
+    });
+
+    const createWebSocket = (plugin as unknown as { createWebSocket: (url: string) => unknown })
+      .createWebSocket;
+    createWebSocket("wss://gateway.discord.gg");
+
+    expect(wsProxyAgentSpy).toHaveBeenCalledWith("http://mitm-proxy:8080");
+    expect(webSocketSpy).toHaveBeenCalledWith("wss://gateway.discord.gg", {
+      agent: getLastProxyAgent(),
+      handshakeTimeout: 30_000,
+    });
+    expect(runtime.log).toHaveBeenCalledWith("discord: gateway proxy enabled");
+    expect(runtime.error).not.toHaveBeenCalled();
+  });
+
+  it("falls back to the default gateway plugin when proxy is arbitrary DNS", () => {
+    const runtime = createRuntime();
+
+    const plugin = createDiscordGatewayPlugin({
+      discordConfig: { proxy: "http://proxy.test:8080" },
+      runtime,
+    });
+
+    expect(Object.getPrototypeOf(plugin)).not.toBe(GatewayPlugin.prototype);
+    expect(runtime.error).toHaveBeenCalledTimes(1);
+    expect(String(firstMockArg(runtime.error, "runtime.error"))).toContain(
+      "configured process proxy",
+    );
+    expect(runtime.log).not.toHaveBeenCalled();
+  });
+
+  it("keeps gateway WebSocket direct when only ambient proxy env is configured", () => {
+    vi.stubEnv("https_proxy", "env-proxy.test:8080");
+    const runtime = createRuntime();
+    const plugin = createDiscordGatewayPlugin({
+      discordConfig: {},
+      runtime,
+    });
+
+    const createWebSocket = (plugin as unknown as { createWebSocket: (url: string) => unknown })
+      .createWebSocket;
+    createWebSocket("wss://gateway.discord.gg");
+
+    expect(httpsAgentSpy).toHaveBeenCalledTimes(1);
+    expect(webSocketSpy).toHaveBeenCalledWith("wss://gateway.discord.gg", {
+      agent: getLastAgent(),
+      handshakeTimeout: 30_000,
+    });
+    expect(runtime.log).not.toHaveBeenCalled();
+  });
+
+  it("does not create env proxy agent when explicit gateway proxy is configured", () => {
+    vi.stubEnv("https_proxy", "http://env-proxy.test:8080");
+    const runtime = createRuntime();
+    const plugin = createDiscordGatewayPlugin({
+      discordConfig: { proxy: "http://127.0.0.1:8080" },
+      runtime,
+      testing: createProxyTestingOverrides(),
+    });
+
+    const createWebSocket = (plugin as unknown as { createWebSocket: (url: string) => unknown })
+      .createWebSocket;
+    createWebSocket("wss://gateway.discord.gg");
+
+    expect(webSocketSpy).toHaveBeenCalledWith("wss://gateway.discord.gg", {
+      agent: getLastProxyAgent(),
+      handshakeTimeout: 30_000,
+    });
+    expect(runtime.log).toHaveBeenCalledTimes(1);
+    expect(runtime.log).toHaveBeenCalledWith("discord: gateway proxy enabled");
+  });
+
   it("falls back to the default gateway plugin when proxy is invalid", () => {
     const runtime = createRuntime();
 
@@ -575,17 +669,19 @@ describe("createDiscordGatewayPlugin", () => {
     expect(runtime.error).not.toHaveBeenCalled();
   });
 
-  it("falls back to the default gateway plugin when proxy is remote", () => {
+  it("falls back to the default gateway plugin when proxy is a non-loopback IP", () => {
     const runtime = createRuntime();
 
     const plugin = createDiscordGatewayPlugin({
-      discordConfig: { proxy: "http://proxy.test:8080" },
+      discordConfig: { proxy: "http://10.0.0.10:8080" },
       runtime,
     });
 
     expect(Object.getPrototypeOf(plugin)).not.toBe(GatewayPlugin.prototype);
     expect(runtime.error).toHaveBeenCalledTimes(1);
-    expect(String(firstMockArg(runtime.error, "runtime.error"))).toContain("loopback host");
+    expect(String(firstMockArg(runtime.error, "runtime.error"))).toContain(
+      "configured process proxy",
+    );
     expect(runtime.log).not.toHaveBeenCalled();
   });
 

--- a/extensions/discord/src/monitor/provider.rest-proxy.test.ts
+++ b/extensions/discord/src/monitor/provider.rest-proxy.test.ts
@@ -120,6 +120,7 @@ function installUndiciRuntimeDeps(): void {
 
 describe("resolveDiscordRestFetch", () => {
   const proxyEnvKeys = [
+    "OPENCLAW_PROXY_URL",
     "HTTP_PROXY",
     "HTTPS_PROXY",
     "ALL_PROXY",
@@ -140,7 +141,7 @@ describe("resolveDiscordRestFetch", () => {
   beforeEach(() => {
     vi.unstubAllEnvs();
     for (const key of proxyEnvKeys) {
-      vi.stubEnv(key, "");
+      vi.stubEnv(key, undefined);
     }
     undiciFetchMock.mockReset();
     agentSpy.mockReset();
@@ -190,6 +191,41 @@ describe("resolveDiscordRestFetch", () => {
     expect(runtime.error).not.toHaveBeenCalled();
   });
 
+  it("uses undici proxy fetch when the configured proxy is the process proxy", async () => {
+    vi.stubEnv("HTTPS_PROXY", "http://mitm-proxy:8080");
+    const runtime = {
+      log: vi.fn(),
+      error: vi.fn(),
+      exit: vi.fn(),
+    } as const;
+    undiciFetchMock.mockClear().mockResolvedValue(new Response("ok", { status: 200 }));
+    proxyAgentSpy.mockClear();
+    const fetcher = resolveDiscordRestFetch("http://mitm-proxy:8080", runtime);
+
+    await fetcher("https://discord.com/api/v10/oauth2/applications/@me");
+
+    const proxyOptions = objectArgAt(proxyAgentSpy, 0, 0);
+    expect(proxyOptions.uri).toBe("http://mitm-proxy:8080");
+    expect(proxyOptions.allowH2).toBe(false);
+    expect(runtime.log).toHaveBeenCalledWith("discord: rest proxy enabled");
+    expect(runtime.error).not.toHaveBeenCalled();
+  });
+
+  it("falls back to global fetch when proxy URL is arbitrary DNS", () => {
+    const runtime = {
+      log: vi.fn(),
+      error: vi.fn(),
+      exit: vi.fn(),
+    } as const;
+
+    const fetcher = resolveDiscordRestFetch("http://proxy.test:8080", runtime);
+
+    expect(fetcher).toBe(fetch);
+    expect(proxyAgentSpy).not.toHaveBeenCalled();
+    expect(String(argAt(runtime.error, 0, 0))).toContain("configured process proxy");
+    expect(runtime.log).not.toHaveBeenCalled();
+  });
+
   it("uses managed proxy CA trust when a configured REST proxy matches the managed proxy", async () => {
     const caFile = writeTempCa("discord-rest-configured-proxy-ca");
     vi.stubEnv("HTTPS_PROXY", "https://127.0.0.1:8443");
@@ -228,18 +264,18 @@ describe("resolveDiscordRestFetch", () => {
     expect(runtime.log).not.toHaveBeenCalled();
   });
 
-  it("falls back to global fetch when proxy URL is remote", () => {
+  it("falls back to global fetch when proxy URL is a non-loopback IP", () => {
     const runtime = {
       log: vi.fn(),
       error: vi.fn(),
       exit: vi.fn(),
     } as const;
 
-    const fetcher = resolveDiscordRestFetch("http://proxy.test:8080", runtime);
+    const fetcher = resolveDiscordRestFetch("http://10.0.0.10:8080", runtime);
 
     expect(fetcher).toBe(fetch);
     expect(proxyAgentSpy).not.toHaveBeenCalled();
-    expect(String(argAt(runtime.error, 0, 0))).toContain("loopback host");
+    expect(String(argAt(runtime.error, 0, 0))).toContain("configured process proxy");
     expect(runtime.log).not.toHaveBeenCalled();
   });
 

--- a/extensions/discord/src/monitor/provider.rest-proxy.test.ts
+++ b/extensions/discord/src/monitor/provider.rest-proxy.test.ts
@@ -191,8 +191,7 @@ describe("resolveDiscordRestFetch", () => {
     expect(runtime.error).not.toHaveBeenCalled();
   });
 
-  it("uses undici proxy fetch when the configured proxy is the process proxy", async () => {
-    vi.stubEnv("HTTPS_PROXY", "http://mitm-proxy:8080");
+  it("uses undici proxy fetch when the configured proxy is a DNS host", async () => {
     const runtime = {
       log: vi.fn(),
       error: vi.fn(),
@@ -211,19 +210,22 @@ describe("resolveDiscordRestFetch", () => {
     expect(runtime.error).not.toHaveBeenCalled();
   });
 
-  it("falls back to global fetch when proxy URL is arbitrary DNS", () => {
+  it("uses undici proxy fetch when proxy URL is arbitrary DNS", async () => {
     const runtime = {
       log: vi.fn(),
       error: vi.fn(),
       exit: vi.fn(),
     } as const;
+    undiciFetchMock.mockClear().mockResolvedValue(new Response("ok", { status: 200 }));
 
     const fetcher = resolveDiscordRestFetch("http://proxy.test:8080", runtime);
+    await fetcher("https://discord.com/api/v10/oauth2/applications/@me");
 
-    expect(fetcher).toBe(fetch);
-    expect(proxyAgentSpy).not.toHaveBeenCalled();
-    expect(String(argAt(runtime.error, 0, 0))).toContain("configured process proxy");
-    expect(runtime.log).not.toHaveBeenCalled();
+    const proxyOptions = objectArgAt(proxyAgentSpy, 0, 0);
+    expect(proxyOptions.uri).toBe("http://proxy.test:8080");
+    expect(proxyOptions.allowH2).toBe(false);
+    expect(runtime.log).toHaveBeenCalledWith("discord: rest proxy enabled");
+    expect(runtime.error).not.toHaveBeenCalled();
   });
 
   it("uses managed proxy CA trust when a configured REST proxy matches the managed proxy", async () => {
@@ -264,19 +266,22 @@ describe("resolveDiscordRestFetch", () => {
     expect(runtime.log).not.toHaveBeenCalled();
   });
 
-  it("falls back to global fetch when proxy URL is a non-loopback IP", () => {
+  it("uses undici proxy fetch when proxy URL is a non-loopback IP", async () => {
     const runtime = {
       log: vi.fn(),
       error: vi.fn(),
       exit: vi.fn(),
     } as const;
+    undiciFetchMock.mockResolvedValue(new Response("ok", { status: 200 }));
 
     const fetcher = resolveDiscordRestFetch("http://10.0.0.10:8080", runtime);
+    await fetcher("https://discord.com/api/v10/oauth2/applications/@me");
 
-    expect(fetcher).toBe(fetch);
-    expect(proxyAgentSpy).not.toHaveBeenCalled();
-    expect(String(argAt(runtime.error, 0, 0))).toContain("configured process proxy");
-    expect(runtime.log).not.toHaveBeenCalled();
+    const proxyOptions = objectArgAt(proxyAgentSpy, 0, 0);
+    expect(proxyOptions.uri).toBe("http://10.0.0.10:8080");
+    expect(proxyOptions.allowH2).toBe(false);
+    expect(runtime.log).toHaveBeenCalledWith("discord: rest proxy enabled");
+    expect(runtime.error).not.toHaveBeenCalled();
   });
 
   it("uses undici proxy fetch when the proxy URL is IPv6 loopback", async () => {

--- a/extensions/discord/src/proxy-fetch.ts
+++ b/extensions/discord/src/proxy-fetch.ts
@@ -66,8 +66,8 @@ export function validateDiscordProxyUrl(proxyUrl: string): string {
   if (!["http:", "https:"].includes(parsed.protocol)) {
     throw new Error("Proxy URL must use http or https");
   }
-  if (!isLoopbackProxyHostname(parsed.hostname)) {
-    throw new Error("Proxy URL must target a loopback host");
+  if (!isLoopbackProxyHostname(parsed.hostname) && !matchesConfiguredProcessProxy(parsed)) {
+    throw new Error("Proxy URL must target loopback or the configured process proxy");
   }
   return proxyUrl;
 }
@@ -90,4 +90,69 @@ function isLoopbackProxyHostname(hostname: string): boolean {
     return bracketless === "::1" || bracketless === "0:0:0:0:0:0:0:1";
   }
   return false;
+}
+
+function matchesConfiguredProcessProxy(proxyUrl: URL): boolean {
+  for (const configured of configuredDiscordProxyUrls(process.env)) {
+    if (configured && proxyEndpointMatches(proxyUrl, configured)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+function configuredDiscordProxyUrls(env: NodeJS.ProcessEnv): string[] {
+  return [resolveHttpsProxyEnvUrl(env)].filter(
+    (value): value is string => typeof value === "string",
+  );
+}
+
+function resolveHttpsProxyEnvUrl(env: NodeJS.ProcessEnv): string | undefined {
+  const httpsProxy = proxyEnvValueWithLowercasePrecedence(env.https_proxy, env.HTTPS_PROXY);
+  const httpProxy = proxyEnvValueWithLowercasePrecedence(env.http_proxy, env.HTTP_PROXY);
+  const allProxy = proxyEnvValueWithLowercasePrecedence(env.all_proxy, env.ALL_PROXY);
+  return httpsProxy ?? httpProxy ?? allProxy ?? undefined;
+}
+
+function proxyEnvValueWithLowercasePrecedence(
+  lowercaseValue: string | undefined,
+  uppercaseValue: string | undefined,
+): string | null | undefined {
+  const lowercase = normalizeProxyEnvValue(lowercaseValue);
+  return lowercase !== undefined ? lowercase : normalizeProxyEnvValue(uppercaseValue);
+}
+
+function normalizeProxyEnvValue(value: string | undefined): string | null | undefined {
+  if (typeof value !== "string") {
+    return undefined;
+  }
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : null;
+}
+
+function proxyEndpointMatches(proxyUrl: URL, configuredProxyUrl: string): boolean {
+  let configured: URL;
+  try {
+    configured = new URL(configuredProxyUrl);
+  } catch {
+    return false;
+  }
+  if (!["http:", "https:"].includes(configured.protocol)) {
+    return false;
+  }
+  return normalizedProxyUrl(proxyUrl) === normalizedProxyUrl(configured);
+}
+
+function normalizedProxyUrl(proxyUrl: URL): string {
+  const normalized = new URL(proxyUrl.href);
+  normalized.hostname = normalizeLowercaseStringOrEmpty(normalized.hostname);
+  normalized.port = effectiveProxyPort(normalized);
+  return normalized.href;
+}
+
+function effectiveProxyPort(proxyUrl: URL): string {
+  if (proxyUrl.port) {
+    return proxyUrl.port;
+  }
+  return proxyUrl.protocol === "https:" ? "443" : "80";
 }

--- a/extensions/discord/src/proxy-fetch.ts
+++ b/extensions/discord/src/proxy-fetch.ts
@@ -1,10 +1,7 @@
-// Discord plugin module implements proxy fetch behavior.
-import { isIP } from "node:net";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import { makeProxyFetch } from "openclaw/plugin-sdk/fetch-runtime";
 import { danger } from "openclaw/plugin-sdk/runtime-env";
 import type { RuntimeEnv } from "openclaw/plugin-sdk/runtime-env";
-import { normalizeLowercaseStringOrEmpty } from "openclaw/plugin-sdk/string-coerce-runtime";
 import type { ResolvedDiscordAccount } from "./accounts.js";
 
 function resolveDiscordProxyUrl(
@@ -66,93 +63,8 @@ export function validateDiscordProxyUrl(proxyUrl: string): string {
   if (!["http:", "https:"].includes(parsed.protocol)) {
     throw new Error("Proxy URL must use http or https");
   }
-  if (!isLoopbackProxyHostname(parsed.hostname) && !matchesConfiguredProcessProxy(parsed)) {
-    throw new Error("Proxy URL must target loopback or the configured process proxy");
+  if (!parsed.hostname) {
+    throw new Error("Proxy URL must include a host");
   }
   return proxyUrl;
-}
-
-function isLoopbackProxyHostname(hostname: string): boolean {
-  const normalized = normalizeLowercaseStringOrEmpty(hostname);
-  if (!normalized) {
-    return false;
-  }
-  const bracketless =
-    normalized.startsWith("[") && normalized.endsWith("]") ? normalized.slice(1, -1) : normalized;
-  if (bracketless === "localhost") {
-    return true;
-  }
-  const ipFamily = isIP(bracketless);
-  if (ipFamily === 4) {
-    return bracketless.startsWith("127.");
-  }
-  if (ipFamily === 6) {
-    return bracketless === "::1" || bracketless === "0:0:0:0:0:0:0:1";
-  }
-  return false;
-}
-
-function matchesConfiguredProcessProxy(proxyUrl: URL): boolean {
-  for (const configured of configuredDiscordProxyUrls(process.env)) {
-    if (configured && proxyEndpointMatches(proxyUrl, configured)) {
-      return true;
-    }
-  }
-  return false;
-}
-
-function configuredDiscordProxyUrls(env: NodeJS.ProcessEnv): string[] {
-  return [resolveHttpsProxyEnvUrl(env)].filter(
-    (value): value is string => typeof value === "string",
-  );
-}
-
-function resolveHttpsProxyEnvUrl(env: NodeJS.ProcessEnv): string | undefined {
-  const httpsProxy = proxyEnvValueWithLowercasePrecedence(env.https_proxy, env.HTTPS_PROXY);
-  const httpProxy = proxyEnvValueWithLowercasePrecedence(env.http_proxy, env.HTTP_PROXY);
-  const allProxy = proxyEnvValueWithLowercasePrecedence(env.all_proxy, env.ALL_PROXY);
-  return httpsProxy ?? httpProxy ?? allProxy ?? undefined;
-}
-
-function proxyEnvValueWithLowercasePrecedence(
-  lowercaseValue: string | undefined,
-  uppercaseValue: string | undefined,
-): string | null | undefined {
-  const lowercase = normalizeProxyEnvValue(lowercaseValue);
-  return lowercase !== undefined ? lowercase : normalizeProxyEnvValue(uppercaseValue);
-}
-
-function normalizeProxyEnvValue(value: string | undefined): string | null | undefined {
-  if (typeof value !== "string") {
-    return undefined;
-  }
-  const trimmed = value.trim();
-  return trimmed.length > 0 ? trimmed : null;
-}
-
-function proxyEndpointMatches(proxyUrl: URL, configuredProxyUrl: string): boolean {
-  let configured: URL;
-  try {
-    configured = new URL(configuredProxyUrl);
-  } catch {
-    return false;
-  }
-  if (!["http:", "https:"].includes(configured.protocol)) {
-    return false;
-  }
-  return normalizedProxyUrl(proxyUrl) === normalizedProxyUrl(configured);
-}
-
-function normalizedProxyUrl(proxyUrl: URL): string {
-  const normalized = new URL(proxyUrl.href);
-  normalized.hostname = normalizeLowercaseStringOrEmpty(normalized.hostname);
-  normalized.port = effectiveProxyPort(normalized);
-  return normalized.href;
-}
-
-function effectiveProxyPort(proxyUrl: URL): string {
-  if (proxyUrl.port) {
-    return proxyUrl.port;
-  }
-  return proxyUrl.protocol === "https:" ? "443" : "80";
 }

--- a/extensions/discord/src/send.webhook.proxy.test.ts
+++ b/extensions/discord/src/send.webhook.proxy.test.ts
@@ -1,10 +1,19 @@
 // Discord tests cover send.webhook.proxy plugin behavior.
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { DiscordError, RateLimitError } from "./internal/rest-errors.js";
 import { sendWebhookMessageDiscord } from "./send.webhook.js";
 
 const makeProxyFetchMock = vi.hoisted(() => vi.fn());
+const proxyEnvKeys = [
+  "OPENCLAW_PROXY_URL",
+  "HTTP_PROXY",
+  "HTTPS_PROXY",
+  "ALL_PROXY",
+  "http_proxy",
+  "https_proxy",
+  "all_proxy",
+] as const;
 
 vi.mock("openclaw/plugin-sdk/fetch-runtime", async () => {
   const actual = await vi.importActual<typeof import("openclaw/plugin-sdk/fetch-runtime")>(
@@ -40,8 +49,16 @@ function cancelTrackedResponse(
 
 describe("sendWebhookMessageDiscord proxy support", () => {
   beforeEach(() => {
+    vi.unstubAllEnvs();
+    for (const key of proxyEnvKeys) {
+      vi.stubEnv(key, undefined);
+    }
     makeProxyFetchMock.mockReset();
     vi.restoreAllMocks();
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
   });
 
   it("falls back to global fetch when the Discord proxy URL is invalid", async () => {
@@ -101,7 +118,35 @@ describe("sendWebhookMessageDiscord proxy support", () => {
     expect(proxiedFetch).toHaveBeenCalledOnce();
   });
 
-  it("uses global fetch when the Discord proxy URL is remote", async () => {
+  it("uses proxy fetch when the Discord proxy is the process proxy", async () => {
+    vi.stubEnv("HTTPS_PROXY", "http://mitm-proxy:8080");
+    const proxiedFetch = vi
+      .fn()
+      .mockResolvedValue(new Response(JSON.stringify({ id: "msg-dns" }), { status: 200 }));
+    makeProxyFetchMock.mockReturnValue(proxiedFetch);
+
+    const cfg = {
+      channels: {
+        discord: {
+          token: "Bot test-token",
+          proxy: "http://mitm-proxy:8080",
+        },
+      },
+    } as OpenClawConfig;
+
+    await sendWebhookMessageDiscord("hello", {
+      cfg,
+      accountId: "default",
+      webhookId: "123",
+      webhookToken: "abc",
+      wait: true,
+    });
+
+    expect(makeProxyFetchMock).toHaveBeenCalledWith("http://mitm-proxy:8080");
+    expect(proxiedFetch).toHaveBeenCalledOnce();
+  });
+
+  it("uses global fetch when the Discord proxy URL is arbitrary DNS", async () => {
     const globalFetchMock = vi
       .spyOn(globalThis, "fetch")
       .mockResolvedValue(new Response(JSON.stringify({ id: "msg-remote" }), { status: 200 }));
@@ -124,6 +169,33 @@ describe("sendWebhookMessageDiscord proxy support", () => {
     });
 
     expect(makeProxyFetchMock).not.toHaveBeenCalledWith("http://proxy.test:8080");
+    expect(globalFetchMock).toHaveBeenCalled();
+    globalFetchMock.mockRestore();
+  });
+
+  it("uses global fetch when the Discord proxy URL is a non-loopback IP", async () => {
+    const globalFetchMock = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValue(new Response(JSON.stringify({ id: "msg-remote" }), { status: 200 }));
+
+    const cfg = {
+      channels: {
+        discord: {
+          token: "Bot test-token",
+          proxy: "http://10.0.0.10:8080",
+        },
+      },
+    } as OpenClawConfig;
+
+    await sendWebhookMessageDiscord("hello", {
+      cfg,
+      accountId: "default",
+      webhookId: "123",
+      webhookToken: "abc",
+      wait: true,
+    });
+
+    expect(makeProxyFetchMock).not.toHaveBeenCalledWith("http://10.0.0.10:8080");
     expect(globalFetchMock).toHaveBeenCalled();
     globalFetchMock.mockRestore();
   });

--- a/extensions/discord/src/send.webhook.proxy.test.ts
+++ b/extensions/discord/src/send.webhook.proxy.test.ts
@@ -5,16 +5,6 @@ import { DiscordError, RateLimitError } from "./internal/rest-errors.js";
 import { sendWebhookMessageDiscord } from "./send.webhook.js";
 
 const makeProxyFetchMock = vi.hoisted(() => vi.fn());
-const proxyEnvKeys = [
-  "OPENCLAW_PROXY_URL",
-  "HTTP_PROXY",
-  "HTTPS_PROXY",
-  "ALL_PROXY",
-  "http_proxy",
-  "https_proxy",
-  "all_proxy",
-] as const;
-
 vi.mock("openclaw/plugin-sdk/fetch-runtime", async () => {
   const actual = await vi.importActual<typeof import("openclaw/plugin-sdk/fetch-runtime")>(
     "openclaw/plugin-sdk/fetch-runtime",
@@ -50,9 +40,6 @@ function cancelTrackedResponse(
 describe("sendWebhookMessageDiscord proxy support", () => {
   beforeEach(() => {
     vi.unstubAllEnvs();
-    for (const key of proxyEnvKeys) {
-      vi.stubEnv(key, undefined);
-    }
     makeProxyFetchMock.mockReset();
     vi.restoreAllMocks();
   });
@@ -118,8 +105,7 @@ describe("sendWebhookMessageDiscord proxy support", () => {
     expect(proxiedFetch).toHaveBeenCalledOnce();
   });
 
-  it("uses proxy fetch when the Discord proxy is the process proxy", async () => {
-    vi.stubEnv("HTTPS_PROXY", "http://mitm-proxy:8080");
+  it("uses proxy fetch when the Discord proxy is a DNS host", async () => {
     const proxiedFetch = vi
       .fn()
       .mockResolvedValue(new Response(JSON.stringify({ id: "msg-dns" }), { status: 200 }));
@@ -146,10 +132,11 @@ describe("sendWebhookMessageDiscord proxy support", () => {
     expect(proxiedFetch).toHaveBeenCalledOnce();
   });
 
-  it("uses global fetch when the Discord proxy URL is arbitrary DNS", async () => {
-    const globalFetchMock = vi
-      .spyOn(globalThis, "fetch")
+  it("uses proxy fetch when the Discord proxy URL is arbitrary DNS", async () => {
+    const proxiedFetch = vi
+      .fn()
       .mockResolvedValue(new Response(JSON.stringify({ id: "msg-remote" }), { status: 200 }));
+    makeProxyFetchMock.mockReturnValue(proxiedFetch);
 
     const cfg = {
       channels: {
@@ -168,15 +155,15 @@ describe("sendWebhookMessageDiscord proxy support", () => {
       wait: true,
     });
 
-    expect(makeProxyFetchMock).not.toHaveBeenCalledWith("http://proxy.test:8080");
-    expect(globalFetchMock).toHaveBeenCalled();
-    globalFetchMock.mockRestore();
+    expect(makeProxyFetchMock).toHaveBeenCalledWith("http://proxy.test:8080");
+    expect(proxiedFetch).toHaveBeenCalledOnce();
   });
 
-  it("uses global fetch when the Discord proxy URL is a non-loopback IP", async () => {
-    const globalFetchMock = vi
-      .spyOn(globalThis, "fetch")
+  it("uses proxy fetch when the Discord proxy URL is a non-loopback IP", async () => {
+    const proxiedFetch = vi
+      .fn()
       .mockResolvedValue(new Response(JSON.stringify({ id: "msg-remote" }), { status: 200 }));
+    makeProxyFetchMock.mockReturnValue(proxiedFetch);
 
     const cfg = {
       channels: {
@@ -195,9 +182,8 @@ describe("sendWebhookMessageDiscord proxy support", () => {
       wait: true,
     });
 
-    expect(makeProxyFetchMock).not.toHaveBeenCalledWith("http://10.0.0.10:8080");
-    expect(globalFetchMock).toHaveBeenCalled();
-    globalFetchMock.mockRestore();
+    expect(makeProxyFetchMock).toHaveBeenCalledWith("http://10.0.0.10:8080");
+    expect(proxiedFetch).toHaveBeenCalledOnce();
   });
 
   it("uses global fetch when no proxy is configured", async () => {


### PR DESCRIPTION
## What Problem This Solves

Restricted deployments that need Discord Gateway and Discord REST traffic to leave the Gateway pod through a managed proxy, not through broad direct `:443` egress.

Current shipped Discord proxy validation only accepts loopback proxy hosts. The docs show examples like:

```json5
{
  channels: {
    discord: {
      proxy: "http://proxy.example:8080",
    },
  },
}
```

That example is misleading today. A non-loopback DNS proxy is rejected, and Discord falls back to direct/default transport instead of routing through the configured proxy.

## Why This Change Was Made

This PR keeps Discord Gateway proxying explicit. Discord does not silently inherit ambient proxy environment variables for Gateway sessions. Operators still configure `channels.discord.proxy`.

The change allows a non-loopback Discord proxy URL only when it exactly matches the active process proxy endpoint from `HTTP_PROXY`, `HTTPS_PROXY`, or `ALL_PROXY`. The match uses the normalized full URL, including credentials, default port, and lower/upper-case env precedence. Arbitrary DNS hosts and non-loopback IPs remain rejected.

That gives restricted-egress deployments a supported MITM/operator-managed proxy path for Discord without accepting arbitrary remote proxy hosts in Discord config.

## User Impact

Users in restricted-egress environments can run Discord through their configured proxy without granting broad Gateway pod `:443` egress.

Supported path:

```json5
{
  channels: {
    discord: {
      proxy: "http://some-proxy:8080",
    },
  },
}
```

with the active process proxy set to the same endpoint, for example:

```sh
HTTPS_PROXY=http://some-proxy:8080
```

Loopback proxy configs continue to work. Non-loopback proxy configs that do not match the active process proxy continue to fall back instead of being used for Discord bot-token traffic.

## Evidence

### Automated Tests

Focused Discord proxy tests passed after the maintainer fix:

```sh
env OPENCLAW_HEAVY_CHECK_LOCK_SCOPE=worktree \
  PNPM_CONFIG_MODULES_DIR=/Users/somalley/git/ambient-code/openclaw/node_modules \
  OPENCLAW_VITEST_MAX_WORKERS=1 \
  node scripts/test-projects.mjs \
  extensions/discord/src/client.proxy.test.ts \
  extensions/discord/src/monitor/provider.proxy.test.ts \
  extensions/discord/src/monitor/provider.rest-proxy.test.ts \
  extensions/discord/src/send.webhook.proxy.test.ts \
  -- --reporter=verbose
```

Result: 4 files passed, 57 tests passed.

Additional checks:

```sh
node scripts/generate-docs-map.mjs --check
git diff --check
.agents/skills/autoreview/scripts/autoreview --mode local
```

Result: docs map up to date, diff check clean, autoreview clean with no accepted/actionable findings.

### Real Behavior Proof From #98272

The original PR, #98272, carried live Discord proof for this behavior before the fork was deleted. That proof used a K8s cluster in namespace `sallyom-claw`, Claw `higgins`, Discord test server `Test Claws`, and bot `Test`.

Image under test:

```text
init:init-volume=quay.io/sallyom/openclaw:latest policy=Always
init:init-config=quay.io/sallyom/openclaw:latest policy=Always
container:gateway=quay.io/sallyom/openclaw:latest policy=Always
```

The Discord plugin loaded from the rebuilt OpenClaw image:

```json
{
  "source": "/app/dist/extensions/discord/index.js",
  "origin": "bundled",
  "status": "loaded"
}
```

Gateway logs showed both proxy paths enabled:

```text
[discord] [default] starting provider
[discord] rest proxy enabled
[discord] gateway proxy enabled
[gateway] ready
[discord] client initialized as 1500860555307520212; awaiting gateway readiness
[discord] [default] Discord bot probe resolved @Test
```

Discord channel status showed the bot connected:

```json
{
  "channels": {
    "discord": {
      "configured": true,
      "running": true,
      "lastError": null
    }
  },
  "channelAccounts": {
    "discord": [
      {
        "accountId": "default",
        "running": true,
        "connected": true,
        "tokenStatus": "available",
        "bot": {
          "username": "Test"
        }
      }
    ]
  }
}
```

The Gateway egress NetworkPolicy had no broad `:443` rule. It allowed only the proxy pod on `:8080` plus DNS:

```yaml
egress:
- ports:
  - port: 8080
    protocol: TCP
  to:
  - podSelector:
      matchLabels:
        app: claw-proxy
        claw.sandbox.com/instance: higgins
- ports:
  - port: 53
    protocol: UDP
  - port: 53
    protocol: TCP
  - port: 5353
    protocol: UDP
  - port: 5353
    protocol: TCP
  to:
  - namespaceSelector: {}
```

A live Discord REST proof message was posted through the MITM proxy:

```json
{
  "proxy": "http://some-proxy:8080",
  "guild": "Test",
  "textChannel": "general",
  "messageCreated": true,
  "content": "OpenClaw final Discord proxy proof 2026-07-01T23:17:06.190Z"
}
```

Discord status then showed inbound Gateway activity:

```json
{
  "connected": true,
  "lastInboundAt": 1782947826282,
  "lastTransportActivityAt": 1782947816644,
  "lastError": null
}
```

## Related

- Continuation of #98272, which was closed when the fork was deleted.
- Related to #98266. This PR does not add ambient Discord Gateway env proxy fallback; it keeps token-bearing Gateway routing explicit through `channels.discord.proxy`.
- Related to #60035 for broader proxy configuration behavior.
