### PR TITLE
fix: first visible turn after reset waits out the stuck-session abort window

### DIFF
--- a/src/auto-reply/reply/dispatch-from-config.stale-recovery.test.ts
+++ b/src/auto-reply/reply/dispatch-from-config.stale-recovery.test.ts
@@ -9,6 +9,7 @@ import {
   noAbortResult,
   resetPluginTtsAndThreadMocks,
   runtimePluginMocks,
+  sessionStoreMocks,
 } from "./dispatch-from-config.shared.test-harness.js";
 import { buildTestCtx } from "./test-ctx.js";
 
@@ -50,6 +51,97 @@ describe("dispatchReplyFromConfig stale visible admission recovery", () => {
     vi.useRealTimers();
     replyRunTesting.resetReplyRunRegistry();
     resetInboundDedupe();
+    sessionStoreMocks.currentEntry = undefined;
+  });
+
+  it("clears a leftover reply operation from a rotated session without waiting for recovery", async () => {
+    const sessionKey = "agent:main:telegram:direct:rotated-session-leftover";
+    const staleOperation = createReplyOperation({
+      sessionKey,
+      sessionId: "archived-session",
+      resetTriggered: false,
+    });
+    staleOperation.setPhase("running");
+    sessionStoreMocks.currentEntry = { sessionId: "rotated-session", updatedAt: Date.now() };
+    const dispatcher = createDispatcher();
+    const replyResolver = vi.fn(async () => ({ text: "post-reset reply" }) satisfies ReplyPayload);
+
+    const result = await dispatchReplyFromConfig({
+      ctx: buildTestCtx({
+        Provider: "telegram",
+        Surface: "telegram",
+        OriginatingChannel: "telegram",
+        OriginatingTo: "user:1",
+        ChatType: "direct",
+        SessionKey: sessionKey,
+        MessageThreadId: "501.000",
+        BodyForAgent: "first post-reset turn",
+      }),
+      cfg: emptyConfig,
+      dispatcher,
+      replyResolver,
+    });
+
+    expect(result).toMatchObject({
+      queuedFinal: true,
+      counts: { tool: 0, block: 0, final: 0 },
+    });
+    expect(replyResolver).toHaveBeenCalledTimes(1);
+    expect(dispatcher.sendFinalReply).toHaveBeenCalledTimes(1);
+    expect(staleOperation.result).toMatchObject({
+      kind: "failed",
+      code: "run_failed",
+    });
+    expect(diagnosticMocks.requestStuckDiagnosticSessionRecovery).not.toHaveBeenCalled();
+  });
+
+  it("does not clear an active reply operation whose session id matches the store entry", async () => {
+    vi.useFakeTimers();
+    const sessionKey = "agent:main:telegram:direct:current-session-active";
+    const activeOperation = createReplyOperation({
+      sessionKey,
+      sessionId: "active-session",
+      resetTriggered: false,
+    });
+    activeOperation.setPhase("running");
+    sessionStoreMocks.currentEntry = { sessionId: "active-session", updatedAt: Date.now() };
+    const dispatcher = createDispatcher();
+    const replyResolver = vi.fn(async () => ({ text: "telegram reply" }) satisfies ReplyPayload);
+
+    const resultPromise = dispatchReplyFromConfig({
+      ctx: buildTestCtx({
+        Provider: "telegram",
+        Surface: "telegram",
+        OriginatingChannel: "telegram",
+        OriginatingTo: "user:1",
+        ChatType: "direct",
+        SessionKey: sessionKey,
+        MessageThreadId: "501.000",
+        BodyForAgent: "second telegram direct turn",
+      }),
+      cfg: {
+        diagnostics: {
+          stuckSessionWarnMs: 1_000,
+          stuckSessionAbortMs: 1_000,
+        },
+      } as OpenClawConfig,
+      dispatcher,
+      replyResolver,
+    });
+
+    await vi.advanceTimersByTimeAsync(1_000);
+    expect(activeOperation.result).toBeNull();
+    expect(replyResolver).not.toHaveBeenCalled();
+    activeOperation.complete();
+    await vi.advanceTimersByTimeAsync(1_000);
+    const result = await resultPromise;
+
+    expect(result).toMatchObject({
+      queuedFinal: true,
+      counts: { tool: 0, block: 0, final: 0 },
+    });
+    expect(replyResolver).toHaveBeenCalledTimes(1);
+    expect(activeOperation.result).toMatchObject({ kind: "completed" });
   });
 
   it("recovers stale visible reply work and retries dispatch admission", async () => {

--- a/src/auto-reply/reply/dispatch-from-config.stale-recovery.test.ts
+++ b/src/auto-reply/reply/dispatch-from-config.stale-recovery.test.ts
@@ -95,6 +95,61 @@ describe("dispatchReplyFromConfig stale visible admission recovery", () => {
     expect(diagnosticMocks.requestStuckDiagnosticSessionRecovery).not.toHaveBeenCalled();
   });
 
+  it("does not clear a queued pre-dispatch reservation whose turn already committed a new session id", async () => {
+    vi.useFakeTimers();
+    const sessionKey = "agent:main:telegram:direct:queued-pre-dispatch-rotation";
+    const queuedOperation = createReplyOperation({
+      sessionKey,
+      sessionId: "archived-session",
+      resetTriggered: false,
+    });
+    // Left in the default "queued" phase: get-reply-run.ts only relabels this
+    // reservation to the session id its own turn committed once it reaches
+    // updateSessionId, so a store mismatch here does not mean it is stale.
+    sessionStoreMocks.currentEntry = { sessionId: "rotated-session", updatedAt: Date.now() };
+    const dispatcher = createDispatcher();
+    const replyResolver = vi.fn(async () => ({ text: "post-reset reply" }) satisfies ReplyPayload);
+
+    const resultPromise = dispatchReplyFromConfig({
+      ctx: buildTestCtx({
+        Provider: "telegram",
+        Surface: "telegram",
+        OriginatingChannel: "telegram",
+        OriginatingTo: "user:1",
+        ChatType: "direct",
+        SessionKey: sessionKey,
+        MessageThreadId: "501.000",
+        BodyForAgent: "first post-reset turn",
+      }),
+      cfg: {
+        diagnostics: {
+          stuckSessionWarnMs: 1_000,
+          stuckSessionAbortMs: 1_000,
+        },
+      } as OpenClawConfig,
+      dispatcher,
+      replyResolver,
+    });
+
+    await vi.advanceTimersByTimeAsync(1_000);
+    expect(queuedOperation.result).toBeNull();
+    expect(replyResolver).not.toHaveBeenCalled();
+
+    // Mirrors get-reply-run.ts reaching updateSessionId for its own queued
+    // reservation before finishing, exactly like the real continuation path.
+    queuedOperation.updateSessionId("rotated-session");
+    queuedOperation.complete();
+    await vi.advanceTimersByTimeAsync(1_000);
+    const result = await resultPromise;
+
+    expect(result).toMatchObject({
+      queuedFinal: true,
+      counts: { tool: 0, block: 0, final: 0 },
+    });
+    expect(replyResolver).toHaveBeenCalledTimes(1);
+    expect(dispatcher.sendFinalReply).toHaveBeenCalledTimes(1);
+  });
+
   it("does not clear an active reply operation whose session id matches the store entry", async () => {
     vi.useFakeTimers();
     const sessionKey = "agent:main:telegram:direct:current-session-active";

--- a/src/auto-reply/reply/dispatch-from-config.ts
+++ b/src/auto-reply/reply/dispatch-from-config.ts
@@ -1496,21 +1496,32 @@ export async function dispatchReplyFromConfig(
     // operation registered under the archived sessionId keeps the slot latched.
     // Without this check the first post-reset visible turn (including the reset
     // acknowledgement) waits out the full stuck-session abort window before the
-    // recovery one-shot reclaims the slot. An operation whose sessionId no
-    // longer matches the freshly-resolved store entry is provably superseded;
-    // a legitimately concurrent fresh operation carries the current sessionId
-    // and is never touched, and terminal-recovery operations stay protected
-    // exactly as in the terminal-session force-clear below.
+    // recovery one-shot reclaims the slot. Guards, in order: terminal-recovery
+    // operations stay protected exactly as in the terminal-session force-clear
+    // below; both the dispatch-start snapshot AND a fresh store lookup must
+    // disagree with the operation's sessionId, so a mid-run rotation that has
+    // committed the store but not yet relabeled its own operation is never
+    // treated as stale; and terminal snapshots are excluded entirely because
+    // terminal-session recovery admits a fresh operation with a NEW sessionId
+    // before the store entry rotates (#86827), which the id comparison alone
+    // cannot distinguish from a leftover.
     if (phase === "dispatch" && replyTurnKind === "visible") {
       const activeBeforeAdmission = replyRunRegistry.get(dispatchOperationSessionKey);
-      if (activeBeforeAdmission && !activeBeforeAdmission.terminalRecovery) {
-        const currentSessionId = resolveSessionStoreLookup(
+      const snapshotSessionId = sessionStoreEntry.entry?.sessionId;
+      if (
+        activeBeforeAdmission &&
+        !activeBeforeAdmission.terminalRecovery &&
+        snapshotSessionId &&
+        snapshotSessionId !== activeBeforeAdmission.sessionId
+      ) {
+        const currentEntry = resolveSessionStoreLookup(
           { ...ctx, SessionKey: dispatchOperationSessionKey },
           cfg,
-        ).entry?.sessionId;
+        ).entry;
         if (
-          currentSessionId &&
-          activeBeforeAdmission.sessionId !== currentSessionId &&
+          currentEntry?.sessionId &&
+          currentEntry.sessionId !== activeBeforeAdmission.sessionId &&
+          !isRecoverableTerminalSessionStatus(currentEntry.status) &&
           forceClearReplyRunBySessionId(
             activeBeforeAdmission.sessionId,
             new Error("clearing stale reply operation from a rotated session"),

--- a/src/auto-reply/reply/dispatch-from-config.ts
+++ b/src/auto-reply/reply/dispatch-from-config.ts
@@ -1491,6 +1491,37 @@ export async function dispatchReplyFromConfig(
         queueDepth: 1,
         staleActiveProgressAbortMs: visibleReplyRecoveryWaitMs,
       });
+    // A committed session reset/rotation replaces the store entry's sessionId,
+    // but the reply registry is keyed by the stable session key, so a leftover
+    // operation registered under the archived sessionId keeps the slot latched.
+    // Without this check the first post-reset visible turn (including the reset
+    // acknowledgement) waits out the full stuck-session abort window before the
+    // recovery one-shot reclaims the slot. An operation whose sessionId no
+    // longer matches the freshly-resolved store entry is provably superseded;
+    // a legitimately concurrent fresh operation carries the current sessionId
+    // and is never touched, and terminal-recovery operations stay protected
+    // exactly as in the terminal-session force-clear below.
+    if (phase === "dispatch" && replyTurnKind === "visible") {
+      const activeBeforeAdmission = replyRunRegistry.get(dispatchOperationSessionKey);
+      if (activeBeforeAdmission && !activeBeforeAdmission.terminalRecovery) {
+        const currentSessionId = resolveSessionStoreLookup(
+          { ...ctx, SessionKey: dispatchOperationSessionKey },
+          cfg,
+        ).entry?.sessionId;
+        if (
+          currentSessionId &&
+          activeBeforeAdmission.sessionId !== currentSessionId &&
+          forceClearReplyRunBySessionId(
+            activeBeforeAdmission.sessionId,
+            new Error("clearing stale reply operation from a rotated session"),
+          )
+        ) {
+          logVerbose(
+            `dispatch-from-config: cleared stale reply operation from rotated session for ${dispatchOperationSessionKey}`,
+          );
+        }
+      }
+    }
     let admission = await admitReplyTurn({
       sessionKey: dispatchOperationSessionKey,
       sessionId: operationSessionId,

--- a/src/auto-reply/reply/dispatch-from-config.ts
+++ b/src/auto-reply/reply/dispatch-from-config.ts
@@ -1498,19 +1498,23 @@ export async function dispatchReplyFromConfig(
     // acknowledgement) waits out the full stuck-session abort window before the
     // recovery one-shot reclaims the slot. Guards, in order: terminal-recovery
     // operations stay protected exactly as in the terminal-session force-clear
-    // below; both the dispatch-start snapshot AND a fresh store lookup must
-    // disagree with the operation's sessionId, so a mid-run rotation that has
-    // committed the store but not yet relabeled its own operation is never
-    // treated as stale; and terminal snapshots are excluded entirely because
-    // terminal-session recovery admits a fresh operation with a NEW sessionId
-    // before the store entry rotates (#86827), which the id comparison alone
-    // cannot distinguish from a leftover.
+    // below; a still-queued reservation is skipped because get-reply-run.ts only
+    // relabels it to its own turn's committed sessionId once dispatch reaches
+    // updateSessionId, so a queued op's sessionId legitimately lags there; both
+    // the dispatch-start snapshot AND a fresh store lookup must disagree with
+    // the operation's sessionId, so a mid-run rotation that has committed the
+    // store but not yet relabeled its own operation is never treated as stale;
+    // and terminal snapshots are excluded entirely because terminal-session
+    // recovery admits a fresh operation with a NEW sessionId before the store
+    // entry rotates (#86827), which the id comparison alone cannot distinguish
+    // from a leftover.
     if (phase === "dispatch" && replyTurnKind === "visible") {
       const activeBeforeAdmission = replyRunRegistry.get(dispatchOperationSessionKey);
       const snapshotSessionId = sessionStoreEntry.entry?.sessionId;
       if (
         activeBeforeAdmission &&
         !activeBeforeAdmission.terminalRecovery &&
+        activeBeforeAdmission.phase !== "queued" &&
         snapshotSessionId &&
         snapshotSessionId !== activeBeforeAdmission.sessionId
       ) {


### PR DESCRIPTION
Closes #99082

> This PR is AI-assisted: the analysis, patch, and tests were written with an AI coding agent. A human operator reviewed the change and traced the incident on a live deployment.

## What Problem This Solves

Fixes an issue where the first visible turn after a session reset waits out the full stuck-session abort window (default 360s) before it can be delivered. A committed reset rotates the store entry's sessionId, but the visible-reply registry is keyed by the stable session key, so a leftover operation registered under the archived sessionId keeps the reply slot latched. In multi-agent rooms this reliably wedges every agent except the first one to finish resetting: their "Session reset." acknowledgements and all queued inbounds wait ~6 minutes for the stuck-session recovery one-shot, and with stuck-session recovery disabled the wait is unbounded. Full traced incident (two rooms, ack latencies 9m48s and 11m46s, recovery reclaiming the stale work at exactly the abort threshold) is in #99082.

## Why This Change Was Made

Before visible dispatch admission, the dispatcher now force-clears an active reply operation that is provably superseded by a committed rotation. The guards, in order: terminal-recovery operations keep their existing protection; both the dispatch-start store snapshot AND a fresh store lookup must disagree with the operation's sessionId, so a mid-run rotation that has committed the store but not yet relabeled its own operation is never treated as stale; and terminal-status snapshots are excluded entirely, because terminal-session recovery admits a fresh operation with a new sessionId before the store entry rotates (#86827) and an id comparison alone cannot distinguish that from a leftover. The existing terminal-session force-clear block is untouched and continues to own the terminal case. Boundary: a turn that is already blocked inside the admission wait when the rotation commits still waits its configured timeout; every subsequent visible turn clears the leftover immediately, which removes the user-visible wedge.

## User Impact

/reset in a multi-agent room now acknowledges promptly on every agent instead of wedging all but one for ~6 minutes, and queued messages behind the reset no longer pile up. Deployments with stuck-session recovery disabled gain a bound they previously lacked. No configuration change; single-agent resets, terminal-session recovery, and normal busy handling behave exactly as before.

## Evidence

- `node scripts/run-vitest.mjs run --config test/vitest/vitest.auto-reply-reply.config.ts src/auto-reply/reply/dispatch-from-config.test.ts src/auto-reply/reply/dispatch-from-config.stale-recovery.test.ts src/auto-reply/reply/reply-run-registry.test.ts src/auto-reply/reply/reply-turn-admission.test.ts src/auto-reply/reply/session-reset-cleanup.test.ts` passes 275/275, including 2 new tests (a leftover operation from a rotated session is cleared without invoking stuck-session recovery; an active operation whose sessionId matches the store entry is never touched) and the existing terminal-snapshot invariant test "does not force-clear an active operation whose session id differs from the terminal snapshot", which caught an over-broad first revision of this check in CI and now passes with the terminal-snapshot exclusion.
- Red proof: with the source change stashed, the new rotated-session test does not merely fail, it hangs in the visible-admission wait until the test runner's no-output watchdog kills the process group, reproducing the reported wedge in miniature; with the change applied it completes immediately.
- Live incident motivating the fix: on a 2026.6.10 multi-agent gateway, /reset in two rooms wedged one agent per room for 9m48s and 11m46s with `stalled session ... recovery=none` warnings every 30s and `stuck session recovery reclaiming stale active reply work` firing at exactly the 360s threshold under the archived session id (logs and timeline in #99082).
- Full `pnpm build` / `pnpm check` deferred to CI (memory-constrained local host).
