### PR TITLE
fix: system events render twice per turn when hooks add prompt context

### DIFF
--- a/src/agents/embedded-agent-runner/run/runtime-context-prompt.test.ts
+++ b/src/agents/embedded-agent-runner/run/runtime-context-prompt.test.ts
@@ -99,6 +99,29 @@ describe("runtime context prompt submission", () => {
     });
   });
 
+  it("does not repeat derived hidden context in the model prompt", () => {
+    // A before_prompt_build hook contributes model-only context, so the model
+    // prompt arrives separately and still embeds the drained system-event
+    // block; the block must render only once, via the hidden runtime context.
+    expect(
+      resolveRuntimeContextPromptParts({
+        effectivePrompt: ["System: [12:00] Model switched.", "", "visible ask"].join("\n"),
+        transcriptPrompt: "visible ask",
+        modelPrompt: [
+          "System: [12:00] Model switched.",
+          "",
+          "visible ask",
+          "",
+          "memory hook append",
+        ].join("\n"),
+      }),
+    ).toEqual({
+      prompt: "visible ask",
+      modelPrompt: "visible ask\n\nmemory hook append",
+      runtimeContext: "System: [12:00] Model switched.",
+    });
+  });
+
   it("does not extract no-transcript delimiter text", () => {
     const effectivePrompt = [
       "visible ask",

--- a/src/agents/embedded-agent-runner/run/runtime-context-prompt.ts
+++ b/src/agents/embedded-agent-runner/run/runtime-context-prompt.ts
@@ -134,10 +134,20 @@ export function resolveRuntimeContextPromptParts(params: {
         };
   }
 
+  // A hook-provided model prompt still embeds the block this split just
+  // derived as hidden runtime context (for example a drained system-event
+  // block prepended into the reply body), so the model would see it twice:
+  // once inline and once via the runtime-context message. Strip the derived
+  // remainder back out of the visible model prompt; when it is not a literal
+  // substring (inline-marker prompts), leave the model prompt untouched.
+  const visibleModelPromptText =
+    runtimeContext && modelPrompt
+      ? (removeLastPromptOccurrence(modelPromptText, runtimeContext) ?? modelPromptText)
+      : modelPromptText;
   return {
     prompt,
-    ...(modelPromptText.trim() && modelPromptText !== prompt
-      ? { modelPrompt: modelPromptText }
+    ...(visibleModelPromptText.trim() && visibleModelPromptText !== prompt
+      ? { modelPrompt: visibleModelPromptText }
       : {}),
     ...(runtimeContext ? { runtimeContext } : {}),
   };


### PR DESCRIPTION
Closes #95323

> This PR is AI-assisted: the analysis, patch, and test were written with an AI coding agent. A human operator reviewed the change; the report's payload evidence came from a live deployment.

## What Problem This Solves

Fixes an issue where the one drained inbound system event is rendered twice in a single turn's model payload: once standalone before the raw user message and once inside the hidden "OpenClaw runtime context ..." message. On current main this happens whenever a `before_prompt_build` hook contributes prepend/append context (memory-injection plugins do this on essentially every turn), on any channel that enqueues inbound system events (Slack in the original report; Telegram shows zero because it enqueues none). The duplicated block is per-turn prompt noise the model has to read twice.

## Why This Change Was Made

The reply pipeline prepends drained system events into the model-visible bodies while keeping the transcript body clean, and `resolveRuntimeContextPromptParts` derives that same block as hidden runtime context. The plain path already renders once because the visible prompt falls back to the transcript text. The hook path threads a separate model prompt that still embeds the event block, producing the double render. The fix strips the derived hidden-context remainder back out of the visible model prompt at the split, restoring the invariant that the model-visible prompt never repeats the hidden runtime context. When the remainder is not a literal substring of the model prompt (inline-marker prompts), the model prompt is left untouched, so existing marker semantics are preserved.

## User Impact

Turns with pending system events (model switches, queue notices, and similar) and prompt-building hooks now deliver the event block once, via the runtime-context message, instead of twice. Transcript persistence and user-visible text are unchanged; channels without inbound system events are unaffected.

## Evidence

- `node scripts/run-vitest.mjs run --config test/vitest/vitest.unit-fast.config.ts src/agents/embedded-agent-runner/run/runtime-context-prompt.test.ts` passes 18/18, including a new regression test: a hook-supplied model prompt embedding the drained event block comes back without it while the block remains in `runtimeContext`.
- Red/green: with the source change stashed, exactly the new test fails (17/18); restoring the change returns 18/18. The existing inline-marker tests ("keeps prompt-local additions in the model prompt", "keeps hidden runtime context separate from prompt-local additions") pass unchanged, covering the not-a-substring fallback.
- Mechanism chain on current main: events drained and prepended in `src/auto-reply/reply/get-reply-run.ts` (drained blocks into `systemEventBlocks`) and `src/auto-reply/reply/prompt-prelude.ts` (prepended into `prefixedCommandBody`/`queuedBody`, not the transcript body); hook context makes `attempt.ts` pass a distinct `modelPrompt` into the split, which then returns both the event-bearing model prompt and the same block as `runtimeContext`, rendered again via `buildRuntimeContextCustomMessage`.
- Live payloads motivating the report showed the same drained event with the same timestamp both standalone before the raw message and inside the runtime-context wrapper (details in #95323).
- Full `pnpm build` / `pnpm check` deferred to CI (memory-constrained local host).
