### PR TITLE
fix(telegram): dedupe directive-tag prompt context

### DIFF
--- a/extensions/telegram/src/bot-handlers.runtime.ts
+++ b/extensions/telegram/src/bot-handlers.runtime.ts
@@ -1304,16 +1304,27 @@ export const registerTelegramHandlers = ({
         conversationContextById.set(node.messageId, { node });
       }
     }
-    const cachePromptMessages = Array.from(conversationContextById.values()).map((entry) =>
-      toPromptContextMessage(
+    const cachePromptEntries = Array.from(conversationContextById.values()).map((entry) => ({
+      node: entry.node,
+      message: toPromptContextMessage(
         entry.node,
         { replyTarget: entry.isReplyTarget },
         entry.node.messageId ? mediaByMessageId?.get(entry.node.messageId) : undefined,
       ),
+    }));
+    const botId = ctx.me?.id;
+    const assistantCacheMessageIds = new Set(
+      cachePromptEntries
+        .filter((entry) => botId != null && entry.node.sourceMessage.from?.id === botId)
+        .map((entry) => entry.message.message_id)
+        .filter((messageId) => typeof messageId === "string"),
     );
+    const cachePromptMessages = cachePromptEntries.map((entry) => entry.message);
     const { sessionOnlyPromptMessages, promptMessages } = mergeTelegramPromptContextMessages({
       sessionPromptMessages,
       cachePromptMessages,
+      isAssistantCacheMessage: (message) =>
+        typeof message.message_id === "string" && assistantCacheMessageIds.has(message.message_id),
     });
     return promptMessages.length > 0
       ? [

--- a/extensions/telegram/src/bot-handlers.runtime.ts
+++ b/extensions/telegram/src/bot-handlers.runtime.ts
@@ -167,26 +167,10 @@ import {
   isTelegramEditTargetMissingError,
   isTelegramMessageHasNoTextError,
 } from "./network-errors.js";
+import { resolvePromptContextTextDedupeKey } from "./prompt-context-dedupe.js";
 import { resolveTelegramPromptMediaPath } from "./prompt-media-path.js";
 import { buildInlineKeyboard } from "./send.js";
 import { buildTelegramSessionTranscriptPromptMessages } from "./session-transcript-context.js";
-
-type TelegramPromptContextMessageForDedupe = {
-  body?: unknown;
-  timestamp_ms?: unknown;
-};
-
-function resolvePromptContextTextDedupeKey(
-  message: TelegramPromptContextMessageForDedupe,
-): string | undefined {
-  if (typeof message.body !== "string" || !message.body.trim()) {
-    return undefined;
-  }
-  if (typeof message.timestamp_ms !== "number" || !Number.isFinite(message.timestamp_ms)) {
-    return undefined;
-  }
-  return `${message.timestamp_ms}:${message.body.trim()}`;
-}
 
 export const registerTelegramHandlers = ({
   cfg,

--- a/extensions/telegram/src/bot-handlers.runtime.ts
+++ b/extensions/telegram/src/bot-handlers.runtime.ts
@@ -167,7 +167,7 @@ import {
   isTelegramEditTargetMissingError,
   isTelegramMessageHasNoTextError,
 } from "./network-errors.js";
-import { resolvePromptContextTextDedupeKey } from "./prompt-context-dedupe.js";
+import { mergeTelegramPromptContextMessages } from "./prompt-context-dedupe.js";
 import { resolveTelegramPromptMediaPath } from "./prompt-media-path.js";
 import { buildInlineKeyboard } from "./send.js";
 import { buildTelegramSessionTranscriptPromptMessages } from "./session-transcript-context.js";
@@ -1311,18 +1311,10 @@ export const registerTelegramHandlers = ({
         entry.node.messageId ? mediaByMessageId?.get(entry.node.messageId) : undefined,
       ),
     );
-    const cacheTextKeys = new Set(
-      cachePromptMessages
-        .map((message) => resolvePromptContextTextDedupeKey(message))
-        .filter((key) => key !== undefined),
-    );
-    const sessionOnlyPromptMessages = sessionPromptMessages.filter((message) => {
-      const key = resolvePromptContextTextDedupeKey(message);
-      return key === undefined || !cacheTextKeys.has(key);
+    const { sessionOnlyPromptMessages, promptMessages } = mergeTelegramPromptContextMessages({
+      sessionPromptMessages,
+      cachePromptMessages,
     });
-    const promptMessages = [...sessionOnlyPromptMessages, ...cachePromptMessages].toSorted(
-      (left, right) => (left.timestamp_ms ?? 0) - (right.timestamp_ms ?? 0),
-    );
     return promptMessages.length > 0
       ? [
           {

--- a/extensions/telegram/src/bot-message-dispatch.test.ts
+++ b/extensions/telegram/src/bot-message-dispatch.test.ts
@@ -1623,7 +1623,11 @@ describe("dispatchTelegramMessage draft streaming", () => {
 
   it("marks durable non-preview finals with the transcript prompt-context timestamp", async () => {
     const transcriptTimestamp = Date.now() + 1_000;
-    const context = createContext();
+    const context = createContext({
+      primaryCtx: {
+        me: { id: 42, is_bot: true, first_name: "Molty", username: "molty_bot" },
+      } as unknown as TelegramMessageContext["primaryCtx"],
+    });
     context.ctxPayload.SessionKey = "agent:default:telegram:direct:123";
     mockDefaultSessionEntry();
     readLatestAssistantTextByIdentity.mockResolvedValue({
@@ -1771,6 +1775,9 @@ describe("dispatchTelegramMessage draft streaming", () => {
     expect(
       conversationContext.find((entry) => entry.node.messageId === "1497")?.node.timestamp,
     ).toBe(transcriptTimestamp);
+    expect(
+      conversationContext.find((entry) => entry.node.messageId === "1497")?.node.senderId,
+    ).toBe("42");
   });
 
   it("suppresses text-only tool payloads delivered after the final answer", async () => {

--- a/extensions/telegram/src/bot-message-dispatch.test.ts
+++ b/extensions/telegram/src/bot-message-dispatch.test.ts
@@ -1,4 +1,5 @@
 // Telegram tests cover bot message dispatch plugin behavior.
+import path from "node:path";
 import type { Bot } from "grammy";
 import {
   createPluginStateKeyedStoreForTests,
@@ -1623,11 +1624,7 @@ describe("dispatchTelegramMessage draft streaming", () => {
 
   it("marks durable non-preview finals with the transcript prompt-context timestamp", async () => {
     const transcriptTimestamp = Date.now() + 1_000;
-    const context = createContext({
-      primaryCtx: {
-        me: { id: 42, is_bot: true, first_name: "Molty", username: "molty_bot" },
-      } as unknown as TelegramMessageContext["primaryCtx"],
-    });
+    const context = createContext();
     context.ctxPayload.SessionKey = "agent:default:telegram:direct:123";
     mockDefaultSessionEntry();
     readLatestAssistantTextByIdentity.mockResolvedValue({
@@ -1715,7 +1712,11 @@ describe("dispatchTelegramMessage draft streaming", () => {
   it("records streamed final replies into the prompt context cache", async () => {
     const storePath = `/tmp/openclaw-telegram-stream-context-${process.pid}-${Date.now()}.json`;
     const transcriptTimestamp = Date.now() + 1_000;
-    const context = createContext();
+    const context = createContext({
+      primaryCtx: {
+        me: { id: 42, is_bot: true, first_name: "Molty", username: "molty_bot" },
+      } as unknown as TelegramMessageContext["primaryCtx"],
+    });
     context.ctxPayload.SessionKey = "agent:default:telegram:direct:123";
     mockDefaultSessionEntry();
     readLatestAssistantTextByIdentity.mockResolvedValue({
@@ -1723,25 +1724,37 @@ describe("dispatchTelegramMessage draft streaming", () => {
       timestamp: transcriptTimestamp,
     });
     setupDraftStreams({ answerMessageId: 1497 });
-    dispatchReplyWithBufferedBlockDispatcher.mockImplementation(async ({ dispatcherOptions }) => {
-      await dispatcherOptions.deliver(
-        { text: "Done already: timeoutSeconds is now 7200s." },
-        { kind: "final" },
-      );
-      return { queuedFinal: true };
-    });
+    dispatchReplyWithBufferedBlockDispatcher.mockImplementation(
+      async ({ dispatcherOptions, replyOptions }) => {
+        await replyOptions?.onPartialReply?.({ text: "Done already" });
+        await dispatcherOptions.deliver(
+          { text: "Done already: timeoutSeconds is now 7200s." },
+          { kind: "final" },
+        );
+        return { queuedFinal: true };
+      },
+    );
+    const recordPromptContext = vi.fn(recordOutboundMessageForPromptContextActual);
 
     await dispatchWithContext({
       context,
       cfg: { session: { store: storePath } },
       telegramDeps: {
         ...telegramDepsForTest,
-        recordOutboundMessageForPromptContext: recordOutboundMessageForPromptContextActual,
+        recordOutboundMessageForPromptContext: recordPromptContext,
       },
     });
 
+    expectRecordFields(mockCallArg(recordPromptContext), {
+      chatId: "123",
+      messageId: 1497,
+      text: "Done already: timeoutSeconds is now 7200s.",
+      messageThreadId: 777,
+      promptContextTimestampMs: transcriptTimestamp,
+    });
+
     const cache = createTelegramMessageCache({
-      scope: resolveTelegramMessageCacheScope(storePath),
+      scope: resolveTelegramMessageCacheScope(path.resolve(storePath)),
     });
     await cache.record({
       accountId: "default",

--- a/extensions/telegram/src/bot-message-dispatch.ts
+++ b/extensions/telegram/src/bot-message-dispatch.ts
@@ -1743,7 +1743,21 @@ export const dispatchTelegramMessage = async ({
           cfg,
           account: { accountId: route.accountId },
           chatId: deliveryBaseOptions.chatId,
-          message: { message_id: result.delivery.messageId },
+          message: {
+            message_id: result.delivery.messageId,
+            ...(context.primaryCtx.me
+              ? {
+                  from: {
+                    id: context.primaryCtx.me.id,
+                    is_bot: context.primaryCtx.me.is_bot,
+                    first_name: context.primaryCtx.me.first_name,
+                    ...(context.primaryCtx.me.username
+                      ? { username: context.primaryCtx.me.username }
+                      : {}),
+                  },
+                }
+              : {}),
+          },
           messageId: result.delivery.messageId,
           text: promptContextContent,
           ...(promptContextTimestampMs !== undefined ? { promptContextTimestampMs } : {}),

--- a/extensions/telegram/src/prompt-context-dedupe.test.ts
+++ b/extensions/telegram/src/prompt-context-dedupe.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from "vitest";
-import { resolvePromptContextTextDedupeKey } from "./prompt-context-dedupe.js";
+import {
+  mergeTelegramPromptContextMessages,
+  resolvePromptContextTextDedupeKey,
+} from "./prompt-context-dedupe.js";
 
 describe("resolvePromptContextTextDedupeKey", () => {
   it("matches assistant transcript text to Telegram cache text after stripping directive tags", () => {
@@ -28,5 +31,58 @@ describe("resolvePromptContextTextDedupeKey", () => {
         body: "Yep - I'm here now.",
       }),
     );
+  });
+
+  it("filters directive-tagged session rows when a cache row has the same visible text", () => {
+    const result = mergeTelegramPromptContextMessages({
+      sessionPromptMessages: [
+        {
+          message_id: "session:assistant-with-reply-directive",
+          timestamp_ms: 1_778_474_760_000,
+          body: "[[reply_to_current]]Yep - I'm here now.",
+        },
+      ],
+      cachePromptMessages: [
+        {
+          message_id: "736",
+          timestamp_ms: 1_778_474_760_000,
+          body: "Yep - I'm here now.",
+        },
+      ],
+    });
+
+    expect(result.sessionOnlyPromptMessages).toEqual([]);
+    expect(result.promptMessages).toEqual([
+      {
+        message_id: "736",
+        timestamp_ms: 1_778_474_760_000,
+        body: "Yep - I'm here now.",
+      },
+    ]);
+  });
+
+  it("keeps both session and cache rows when visible text matches but timestamps differ", () => {
+    const result = mergeTelegramPromptContextMessages({
+      sessionPromptMessages: [
+        {
+          message_id: "session:assistant-with-reply-directive",
+          timestamp_ms: 1_778_474_760_000,
+          body: "[[reply_to_current]]Yep - I'm here now.",
+        },
+      ],
+      cachePromptMessages: [
+        {
+          message_id: "736",
+          timestamp_ms: 1_778_474_761_000,
+          body: "Yep - I'm here now.",
+        },
+      ],
+    });
+
+    expect(result.sessionOnlyPromptMessages).toHaveLength(1);
+    expect(result.promptMessages.map((message) => message.message_id)).toEqual([
+      "session:assistant-with-reply-directive",
+      "736",
+    ]);
   });
 });

--- a/extensions/telegram/src/prompt-context-dedupe.test.ts
+++ b/extensions/telegram/src/prompt-context-dedupe.test.ts
@@ -57,6 +57,7 @@ describe("resolvePromptContextTextDedupeKey", () => {
     expect(result.promptMessages).toEqual([
       {
         message_id: "736",
+        sender: "OpenClaw",
         timestamp_ms: 1_778_474_760_000,
         body: "Yep - I'm here now.",
       },
@@ -142,6 +143,40 @@ describe("resolvePromptContextTextDedupeKey", () => {
     expect(result.promptMessages.map((message) => message.message_id)).toEqual([
       "session:assistant-with-reply-directive",
       "736",
+    ]);
+  });
+
+  it("keeps directive-tagged session rows when only a user cache row has matching visible text", () => {
+    const result = mergeTelegramPromptContextMessages({
+      sessionPromptMessages: [
+        {
+          message_id: "session:assistant-with-reply-directive",
+          sender: "OpenClaw",
+          timestamp_ms: 1_783_019_792_000,
+          body: "[[reply_to_current]]same visible text",
+        },
+      ],
+      cachePromptMessages: [
+        {
+          message_id: "807",
+          sender: "User",
+          timestamp_ms: 1_783_019_792_000,
+          body: "same visible text",
+        },
+        {
+          message_id: "808",
+          sender: "User",
+          timestamp_ms: 1_783_019_798_000,
+          body: "same visible text",
+        },
+      ],
+    });
+
+    expect(result.sessionOnlyPromptMessages).toHaveLength(1);
+    expect(result.promptMessages.map((message) => message.message_id)).toEqual([
+      "session:assistant-with-reply-directive",
+      "807",
+      "808",
     ]);
   });
 });

--- a/extensions/telegram/src/prompt-context-dedupe.test.ts
+++ b/extensions/telegram/src/prompt-context-dedupe.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "vitest";
+import { resolvePromptContextTextDedupeKey } from "./prompt-context-dedupe.js";
+
+describe("resolvePromptContextTextDedupeKey", () => {
+  it("matches assistant transcript text to Telegram cache text after stripping directive tags", () => {
+    expect(
+      resolvePromptContextTextDedupeKey({
+        timestamp_ms: 1_778_474_760_000,
+        body: "[[reply_to_current]]Yep - I'm here now.",
+      }),
+    ).toBe(
+      resolvePromptContextTextDedupeKey({
+        timestamp_ms: 1_778_474_760_000,
+        body: "Yep - I'm here now.",
+      }),
+    );
+  });
+
+  it("keeps timestamp alignment in the dedupe key", () => {
+    expect(
+      resolvePromptContextTextDedupeKey({
+        timestamp_ms: 1_778_474_760_000,
+        body: "[[reply_to_current]]Yep - I'm here now.",
+      }),
+    ).not.toBe(
+      resolvePromptContextTextDedupeKey({
+        timestamp_ms: 1_778_474_761_000,
+        body: "Yep - I'm here now.",
+      }),
+    );
+  });
+});

--- a/extensions/telegram/src/prompt-context-dedupe.test.ts
+++ b/extensions/telegram/src/prompt-context-dedupe.test.ts
@@ -61,6 +61,34 @@ describe("resolvePromptContextTextDedupeKey", () => {
     ]);
   });
 
+  it("filters inline directive-tagged session rows using delivery-normalized text", () => {
+    const result = mergeTelegramPromptContextMessages({
+      sessionPromptMessages: [
+        {
+          message_id: "session:inline-reply-directive",
+          timestamp_ms: 1_778_474_760_000,
+          body: "hello [[reply_to_current]] world",
+        },
+      ],
+      cachePromptMessages: [
+        {
+          message_id: "736",
+          timestamp_ms: 1_778_474_760_000,
+          body: "hello world",
+        },
+      ],
+    });
+
+    expect(result.sessionOnlyPromptMessages).toEqual([]);
+    expect(result.promptMessages).toEqual([
+      {
+        message_id: "736",
+        timestamp_ms: 1_778_474_760_000,
+        body: "hello world",
+      },
+    ]);
+  });
+
   it("keeps both session and cache rows when visible text matches but timestamps differ", () => {
     const result = mergeTelegramPromptContextMessages({
       sessionPromptMessages: [

--- a/extensions/telegram/src/prompt-context-dedupe.test.ts
+++ b/extensions/telegram/src/prompt-context-dedupe.test.ts
@@ -38,6 +38,7 @@ describe("resolvePromptContextTextDedupeKey", () => {
       sessionPromptMessages: [
         {
           message_id: "session:assistant-with-reply-directive",
+          sender: "OpenClaw",
           timestamp_ms: 1_778_474_760_000,
           body: "[[reply_to_current]]Yep - I'm here now.",
         },
@@ -45,6 +46,7 @@ describe("resolvePromptContextTextDedupeKey", () => {
       cachePromptMessages: [
         {
           message_id: "736",
+          sender: "OpenClaw",
           timestamp_ms: 1_778_474_760_000,
           body: "Yep - I'm here now.",
         },
@@ -66,6 +68,7 @@ describe("resolvePromptContextTextDedupeKey", () => {
       sessionPromptMessages: [
         {
           message_id: "session:inline-reply-directive",
+          sender: "OpenClaw",
           timestamp_ms: 1_778_474_760_000,
           body: "hello [[reply_to_current]] world",
         },
@@ -73,6 +76,7 @@ describe("resolvePromptContextTextDedupeKey", () => {
       cachePromptMessages: [
         {
           message_id: "736",
+          sender: "OpenClaw",
           timestamp_ms: 1_778_474_760_000,
           body: "hello world",
         },
@@ -83,24 +87,51 @@ describe("resolvePromptContextTextDedupeKey", () => {
     expect(result.promptMessages).toEqual([
       {
         message_id: "736",
+        sender: "OpenClaw",
         timestamp_ms: 1_778_474_760_000,
         body: "hello world",
       },
     ]);
   });
 
-  it("keeps both session and cache rows when visible text matches but timestamps differ", () => {
+  it("filters directive-tagged session rows when the delivered cache timestamp drifts", () => {
+    const result = mergeTelegramPromptContextMessages({
+      sessionPromptMessages: [
+        {
+          message_id: "session:bc268f12",
+          sender: "OpenClaw",
+          timestamp_ms: 1_783_019_792_000,
+          body: "[[reply_to_current]]Duplicate context test reply - issue 99117",
+        },
+      ],
+      cachePromptMessages: [
+        {
+          message_id: "808",
+          sender: "OpenClaw",
+          timestamp_ms: 1_783_019_798_000,
+          body: "Duplicate context test reply - issue 99117",
+        },
+      ],
+    });
+
+    expect(result.sessionOnlyPromptMessages).toEqual([]);
+    expect(result.promptMessages.map((message) => message.message_id)).toEqual(["808"]);
+  });
+
+  it("keeps both plain session and cache rows when visible text matches but timestamps differ", () => {
     const result = mergeTelegramPromptContextMessages({
       sessionPromptMessages: [
         {
           message_id: "session:assistant-with-reply-directive",
+          sender: "OpenClaw",
           timestamp_ms: 1_778_474_760_000,
-          body: "[[reply_to_current]]Yep - I'm here now.",
+          body: "Yep - I'm here now.",
         },
       ],
       cachePromptMessages: [
         {
           message_id: "736",
+          sender: "OpenClaw",
           timestamp_ms: 1_778_474_761_000,
           body: "Yep - I'm here now.",
         },

--- a/extensions/telegram/src/prompt-context-dedupe.test.ts
+++ b/extensions/telegram/src/prompt-context-dedupe.test.ts
@@ -1,8 +1,23 @@
 import { describe, expect, it } from "vitest";
 import {
+  type TelegramPromptContextMessageForDedupe,
   mergeTelegramPromptContextMessages,
   resolvePromptContextTextDedupeKey,
 } from "./prompt-context-dedupe.js";
+
+function mergeWithAssistantCacheIds(params: {
+  sessionPromptMessages: readonly TelegramPromptContextMessageForDedupe[];
+  cachePromptMessages: readonly TelegramPromptContextMessageForDedupe[];
+  assistantCacheMessageIds: readonly string[];
+}) {
+  const assistantCacheMessageIds = new Set(params.assistantCacheMessageIds);
+  return mergeTelegramPromptContextMessages({
+    sessionPromptMessages: params.sessionPromptMessages,
+    cachePromptMessages: params.cachePromptMessages,
+    isAssistantCacheMessage: (message) =>
+      typeof message.message_id === "string" && assistantCacheMessageIds.has(message.message_id),
+  });
+}
 
 describe("resolvePromptContextTextDedupeKey", () => {
   it("matches assistant transcript text to Telegram cache text after stripping directive tags", () => {
@@ -34,7 +49,7 @@ describe("resolvePromptContextTextDedupeKey", () => {
   });
 
   it("filters directive-tagged session rows when a cache row has the same visible text", () => {
-    const result = mergeTelegramPromptContextMessages({
+    const result = mergeWithAssistantCacheIds({
       sessionPromptMessages: [
         {
           message_id: "session:assistant-with-reply-directive",
@@ -51,6 +66,7 @@ describe("resolvePromptContextTextDedupeKey", () => {
           body: "Yep - I'm here now.",
         },
       ],
+      assistantCacheMessageIds: ["736"],
     });
 
     expect(result.sessionOnlyPromptMessages).toEqual([]);
@@ -65,7 +81,7 @@ describe("resolvePromptContextTextDedupeKey", () => {
   });
 
   it("filters inline directive-tagged session rows using delivery-normalized text", () => {
-    const result = mergeTelegramPromptContextMessages({
+    const result = mergeWithAssistantCacheIds({
       sessionPromptMessages: [
         {
           message_id: "session:inline-reply-directive",
@@ -82,6 +98,7 @@ describe("resolvePromptContextTextDedupeKey", () => {
           body: "hello world",
         },
       ],
+      assistantCacheMessageIds: ["736"],
     });
 
     expect(result.sessionOnlyPromptMessages).toEqual([]);
@@ -96,7 +113,7 @@ describe("resolvePromptContextTextDedupeKey", () => {
   });
 
   it("filters directive-tagged session rows when the delivered cache timestamp drifts", () => {
-    const result = mergeTelegramPromptContextMessages({
+    const result = mergeWithAssistantCacheIds({
       sessionPromptMessages: [
         {
           message_id: "session:bc268f12",
@@ -113,6 +130,32 @@ describe("resolvePromptContextTextDedupeKey", () => {
           body: "Duplicate context test reply - issue 99117",
         },
       ],
+      assistantCacheMessageIds: ["808"],
+    });
+
+    expect(result.sessionOnlyPromptMessages).toEqual([]);
+    expect(result.promptMessages.map((message) => message.message_id)).toEqual(["808"]);
+  });
+
+  it("filters directive-tagged session rows for custom-named assistant cache rows", () => {
+    const result = mergeWithAssistantCacheIds({
+      sessionPromptMessages: [
+        {
+          message_id: "session:custom-bot-name",
+          sender: "OpenClaw",
+          timestamp_ms: 1_783_019_792_000,
+          body: "[[reply_to_current]]Custom bot display names still dedupe.",
+        },
+      ],
+      cachePromptMessages: [
+        {
+          message_id: "808",
+          sender: "Molty Support Bot",
+          timestamp_ms: 1_783_019_798_000,
+          body: "Custom bot display names still dedupe.",
+        },
+      ],
+      assistantCacheMessageIds: ["808"],
     });
 
     expect(result.sessionOnlyPromptMessages).toEqual([]);
@@ -120,7 +163,7 @@ describe("resolvePromptContextTextDedupeKey", () => {
   });
 
   it("keeps both plain session and cache rows when visible text matches but timestamps differ", () => {
-    const result = mergeTelegramPromptContextMessages({
+    const result = mergeWithAssistantCacheIds({
       sessionPromptMessages: [
         {
           message_id: "session:assistant-with-reply-directive",
@@ -137,6 +180,7 @@ describe("resolvePromptContextTextDedupeKey", () => {
           body: "Yep - I'm here now.",
         },
       ],
+      assistantCacheMessageIds: ["736"],
     });
 
     expect(result.sessionOnlyPromptMessages).toHaveLength(1);
@@ -147,7 +191,7 @@ describe("resolvePromptContextTextDedupeKey", () => {
   });
 
   it("keeps directive-tagged session rows when only a user cache row has matching visible text", () => {
-    const result = mergeTelegramPromptContextMessages({
+    const result = mergeWithAssistantCacheIds({
       sessionPromptMessages: [
         {
           message_id: "session:assistant-with-reply-directive",
@@ -170,6 +214,7 @@ describe("resolvePromptContextTextDedupeKey", () => {
           body: "same visible text",
         },
       ],
+      assistantCacheMessageIds: [],
     });
 
     expect(result.sessionOnlyPromptMessages).toHaveLength(1);

--- a/extensions/telegram/src/prompt-context-dedupe.ts
+++ b/extensions/telegram/src/prompt-context-dedupe.ts
@@ -53,12 +53,9 @@ function isOpenClawSessionPromptMessage(message: TelegramPromptContextMessageFor
   return (
     typeof message.message_id === "string" &&
     message.message_id.startsWith("session:") &&
-    isOpenClawPromptMessage(message)
+    typeof message.sender === "string" &&
+    message.sender.startsWith("OpenClaw")
   );
-}
-
-function isOpenClawPromptMessage(message: TelegramPromptContextMessageForDedupe): boolean {
-  return typeof message.sender === "string" && message.sender.startsWith("OpenClaw");
 }
 
 function isWithinDirectiveTagCacheTimestampDrift(
@@ -81,20 +78,20 @@ export function resolvePromptContextTextDedupeKey(
 function shouldDropSessionPromptMessage(
   sessionMessage: TelegramPromptContextMessageForDedupe,
   cacheTextKeys: ReadonlySet<string>,
-  openClawCacheTextKeys: ReadonlySet<string>,
-  openClawCacheTexts: readonly TelegramPromptContextNormalizedText[],
+  assistantCacheTextKeys: ReadonlySet<string>,
+  assistantCacheTexts: readonly TelegramPromptContextNormalizedText[],
 ): boolean {
   const exactKey = resolvePromptContextTextDedupeKey(sessionMessage);
   const sessionText = resolvePromptContextNormalizedText(sessionMessage);
   if (!sessionText?.directiveTagsStripped || !isOpenClawSessionPromptMessage(sessionMessage)) {
     return exactKey !== undefined && cacheTextKeys.has(exactKey);
   }
-  if (exactKey !== undefined && openClawCacheTextKeys.has(exactKey)) {
+  if (exactKey !== undefined && assistantCacheTextKeys.has(exactKey)) {
     return true;
   }
   // Telegram cache rows may still use send-completion time on released builds;
   // only directive-tagged synthetic assistant rows get near-time fallback dedupe.
-  return openClawCacheTexts.some(
+  return assistantCacheTexts.some(
     (cacheText) =>
       cacheText.text === sessionText.text &&
       isWithinDirectiveTagCacheTimestampDrift(sessionText, cacheText),
@@ -107,21 +104,22 @@ export function mergeTelegramPromptContextMessages<
 >(params: {
   sessionPromptMessages: readonly TSessionMessage[];
   cachePromptMessages: readonly TCacheMessage[];
+  isAssistantCacheMessage: (message: TCacheMessage) => boolean;
 }): MergeTelegramPromptContextMessagesResult<TSessionMessage, TCacheMessage> {
   const cacheTextKeys = new Set(
     params.cachePromptMessages
       .map((message) => resolvePromptContextTextDedupeKey(message))
       .filter((key) => key !== undefined),
   );
-  const openClawCachePromptMessages = params.cachePromptMessages.filter((message) =>
-    isOpenClawPromptMessage(message),
+  const assistantCachePromptMessages = params.cachePromptMessages.filter(
+    params.isAssistantCacheMessage,
   );
-  const openClawCacheTextKeys = new Set(
-    openClawCachePromptMessages
+  const assistantCacheTextKeys = new Set(
+    assistantCachePromptMessages
       .map((message) => resolvePromptContextTextDedupeKey(message))
       .filter((key) => key !== undefined),
   );
-  const openClawCacheTexts = openClawCachePromptMessages
+  const assistantCacheTexts = assistantCachePromptMessages
     .map((message) => resolvePromptContextNormalizedText(message))
     .filter((text) => text !== undefined);
   const sessionOnlyPromptMessages = params.sessionPromptMessages.filter(
@@ -129,8 +127,8 @@ export function mergeTelegramPromptContextMessages<
       !shouldDropSessionPromptMessage(
         message,
         cacheTextKeys,
-        openClawCacheTextKeys,
-        openClawCacheTexts,
+        assistantCacheTextKeys,
+        assistantCacheTexts,
       ),
   );
   return {

--- a/extensions/telegram/src/prompt-context-dedupe.ts
+++ b/extensions/telegram/src/prompt-context-dedupe.ts
@@ -53,9 +53,12 @@ function isOpenClawSessionPromptMessage(message: TelegramPromptContextMessageFor
   return (
     typeof message.message_id === "string" &&
     message.message_id.startsWith("session:") &&
-    typeof message.sender === "string" &&
-    message.sender.startsWith("OpenClaw")
+    isOpenClawPromptMessage(message)
   );
+}
+
+function isOpenClawPromptMessage(message: TelegramPromptContextMessageForDedupe): boolean {
+  return typeof message.sender === "string" && message.sender.startsWith("OpenClaw");
 }
 
 function isWithinDirectiveTagCacheTimestampDrift(
@@ -78,19 +81,20 @@ export function resolvePromptContextTextDedupeKey(
 function shouldDropSessionPromptMessage(
   sessionMessage: TelegramPromptContextMessageForDedupe,
   cacheTextKeys: ReadonlySet<string>,
-  cacheTexts: readonly TelegramPromptContextNormalizedText[],
+  openClawCacheTextKeys: ReadonlySet<string>,
+  openClawCacheTexts: readonly TelegramPromptContextNormalizedText[],
 ): boolean {
   const exactKey = resolvePromptContextTextDedupeKey(sessionMessage);
-  if (exactKey !== undefined && cacheTextKeys.has(exactKey)) {
-    return true;
-  }
   const sessionText = resolvePromptContextNormalizedText(sessionMessage);
   if (!sessionText?.directiveTagsStripped || !isOpenClawSessionPromptMessage(sessionMessage)) {
-    return false;
+    return exactKey !== undefined && cacheTextKeys.has(exactKey);
+  }
+  if (exactKey !== undefined && openClawCacheTextKeys.has(exactKey)) {
+    return true;
   }
   // Telegram cache rows may still use send-completion time on released builds;
   // only directive-tagged synthetic assistant rows get near-time fallback dedupe.
-  return cacheTexts.some(
+  return openClawCacheTexts.some(
     (cacheText) =>
       cacheText.text === sessionText.text &&
       isWithinDirectiveTagCacheTimestampDrift(sessionText, cacheText),
@@ -109,11 +113,25 @@ export function mergeTelegramPromptContextMessages<
       .map((message) => resolvePromptContextTextDedupeKey(message))
       .filter((key) => key !== undefined),
   );
-  const cacheTexts = params.cachePromptMessages
+  const openClawCachePromptMessages = params.cachePromptMessages.filter((message) =>
+    isOpenClawPromptMessage(message),
+  );
+  const openClawCacheTextKeys = new Set(
+    openClawCachePromptMessages
+      .map((message) => resolvePromptContextTextDedupeKey(message))
+      .filter((key) => key !== undefined),
+  );
+  const openClawCacheTexts = openClawCachePromptMessages
     .map((message) => resolvePromptContextNormalizedText(message))
     .filter((text) => text !== undefined);
   const sessionOnlyPromptMessages = params.sessionPromptMessages.filter(
-    (message) => !shouldDropSessionPromptMessage(message, cacheTextKeys, cacheTexts),
+    (message) =>
+      !shouldDropSessionPromptMessage(
+        message,
+        cacheTextKeys,
+        openClawCacheTextKeys,
+        openClawCacheTexts,
+      ),
   );
   return {
     sessionOnlyPromptMessages,

--- a/extensions/telegram/src/prompt-context-dedupe.ts
+++ b/extensions/telegram/src/prompt-context-dedupe.ts
@@ -2,8 +2,23 @@ import { stripInlineDirectiveTagsForDisplay } from "openclaw/plugin-sdk/text-chu
 
 export type TelegramPromptContextMessageForDedupe = {
   body?: unknown;
+  message_id?: unknown;
   timestamp_ms?: unknown;
 };
+
+export type MergeTelegramPromptContextMessagesResult<
+  TSessionMessage extends TelegramPromptContextMessageForDedupe,
+  TCacheMessage extends TelegramPromptContextMessageForDedupe,
+> = {
+  sessionOnlyPromptMessages: TSessionMessage[];
+  promptMessages: Array<TSessionMessage | TCacheMessage>;
+};
+
+function promptContextTimestampForSort(message: TelegramPromptContextMessageForDedupe): number {
+  return typeof message.timestamp_ms === "number" && Number.isFinite(message.timestamp_ms)
+    ? message.timestamp_ms
+    : 0;
+}
 
 export function resolvePromptContextTextDedupeKey(
   message: TelegramPromptContextMessageForDedupe,
@@ -16,4 +31,28 @@ export function resolvePromptContextTextDedupeKey(
   }
   const visibleBody = stripInlineDirectiveTagsForDisplay(message.body).text.trim();
   return visibleBody ? `${message.timestamp_ms}:${visibleBody}` : undefined;
+}
+
+export function mergeTelegramPromptContextMessages<
+  TSessionMessage extends TelegramPromptContextMessageForDedupe,
+  TCacheMessage extends TelegramPromptContextMessageForDedupe,
+>(params: {
+  sessionPromptMessages: readonly TSessionMessage[];
+  cachePromptMessages: readonly TCacheMessage[];
+}): MergeTelegramPromptContextMessagesResult<TSessionMessage, TCacheMessage> {
+  const cacheTextKeys = new Set(
+    params.cachePromptMessages
+      .map((message) => resolvePromptContextTextDedupeKey(message))
+      .filter((key) => key !== undefined),
+  );
+  const sessionOnlyPromptMessages = params.sessionPromptMessages.filter((message) => {
+    const key = resolvePromptContextTextDedupeKey(message);
+    return key === undefined || !cacheTextKeys.has(key);
+  });
+  return {
+    sessionOnlyPromptMessages,
+    promptMessages: [...sessionOnlyPromptMessages, ...params.cachePromptMessages].toSorted(
+      (left, right) => promptContextTimestampForSort(left) - promptContextTimestampForSort(right),
+    ),
+  };
 }

--- a/extensions/telegram/src/prompt-context-dedupe.ts
+++ b/extensions/telegram/src/prompt-context-dedupe.ts
@@ -1,4 +1,4 @@
-import { stripInlineDirectiveTagsForDisplay } from "openclaw/plugin-sdk/text-chunking";
+import { stripInlineDirectiveTagsForDelivery } from "openclaw/plugin-sdk/text-chunking";
 
 export type TelegramPromptContextMessageForDedupe = {
   body?: unknown;
@@ -29,7 +29,7 @@ export function resolvePromptContextTextDedupeKey(
   if (typeof message.timestamp_ms !== "number" || !Number.isFinite(message.timestamp_ms)) {
     return undefined;
   }
-  const visibleBody = stripInlineDirectiveTagsForDisplay(message.body).text.trim();
+  const visibleBody = stripInlineDirectiveTagsForDelivery(message.body).text.trim();
   return visibleBody ? `${message.timestamp_ms}:${visibleBody}` : undefined;
 }
 

--- a/extensions/telegram/src/prompt-context-dedupe.ts
+++ b/extensions/telegram/src/prompt-context-dedupe.ts
@@ -3,7 +3,14 @@ import { stripInlineDirectiveTagsForDelivery } from "openclaw/plugin-sdk/text-ch
 export type TelegramPromptContextMessageForDedupe = {
   body?: unknown;
   message_id?: unknown;
+  sender?: unknown;
   timestamp_ms?: unknown;
+};
+
+type TelegramPromptContextNormalizedText = {
+  directiveTagsStripped: boolean;
+  text: string;
+  timestampMs: number;
 };
 
 export type MergeTelegramPromptContextMessagesResult<
@@ -14,23 +21,80 @@ export type MergeTelegramPromptContextMessagesResult<
   promptMessages: Array<TSessionMessage | TCacheMessage>;
 };
 
+const DIRECTIVE_TAG_CACHE_TIMESTAMP_DRIFT_TOLERANCE_MS = 30_000;
+
 function promptContextTimestampForSort(message: TelegramPromptContextMessageForDedupe): number {
   return typeof message.timestamp_ms === "number" && Number.isFinite(message.timestamp_ms)
     ? message.timestamp_ms
     : 0;
 }
 
-export function resolvePromptContextTextDedupeKey(
+function resolvePromptContextNormalizedText(
   message: TelegramPromptContextMessageForDedupe,
-): string | undefined {
+): TelegramPromptContextNormalizedText | undefined {
   if (typeof message.body !== "string" || !message.body.trim()) {
     return undefined;
   }
   if (typeof message.timestamp_ms !== "number" || !Number.isFinite(message.timestamp_ms)) {
     return undefined;
   }
-  const visibleBody = stripInlineDirectiveTagsForDelivery(message.body).text.trim();
-  return visibleBody ? `${message.timestamp_ms}:${visibleBody}` : undefined;
+  const deliveredBody = stripInlineDirectiveTagsForDelivery(message.body);
+  const text = deliveredBody.text.trim();
+  return text
+    ? {
+        directiveTagsStripped: deliveredBody.changed,
+        text,
+        timestampMs: message.timestamp_ms,
+      }
+    : undefined;
+}
+
+function isOpenClawSessionPromptMessage(message: TelegramPromptContextMessageForDedupe): boolean {
+  return (
+    typeof message.message_id === "string" &&
+    message.message_id.startsWith("session:") &&
+    typeof message.sender === "string" &&
+    message.sender.startsWith("OpenClaw")
+  );
+}
+
+function isWithinDirectiveTagCacheTimestampDrift(
+  sessionText: TelegramPromptContextNormalizedText,
+  cacheText: TelegramPromptContextNormalizedText,
+): boolean {
+  return (
+    Math.abs(sessionText.timestampMs - cacheText.timestampMs) <=
+    DIRECTIVE_TAG_CACHE_TIMESTAMP_DRIFT_TOLERANCE_MS
+  );
+}
+
+export function resolvePromptContextTextDedupeKey(
+  message: TelegramPromptContextMessageForDedupe,
+): string | undefined {
+  const normalized = resolvePromptContextNormalizedText(message);
+  return normalized ? `${normalized.timestampMs}:${normalized.text}` : undefined;
+}
+
+function shouldDropSessionPromptMessage(
+  sessionMessage: TelegramPromptContextMessageForDedupe,
+  cacheTextKeys: ReadonlySet<string>,
+  cacheTexts: readonly TelegramPromptContextNormalizedText[],
+): boolean {
+  const exactKey = resolvePromptContextTextDedupeKey(sessionMessage);
+  if (exactKey !== undefined && cacheTextKeys.has(exactKey)) {
+    return true;
+  }
+  const sessionText = resolvePromptContextNormalizedText(sessionMessage);
+  if (!sessionText?.directiveTagsStripped || !isOpenClawSessionPromptMessage(sessionMessage)) {
+    return false;
+  }
+  // Telegram cache rows may still use send-completion time on released builds;
+  // only directive-tagged synthetic assistant rows get near-time fallback dedupe.
+  return cacheTexts.some(
+    (cacheText) =>
+      cacheText.text === sessionText.text &&
+      isWithinDirectiveTagCacheTimestampDrift(sessionText, cacheText),
+  );
 }
 
 export function mergeTelegramPromptContextMessages<
@@ -45,10 +109,12 @@ export function mergeTelegramPromptContextMessages<
       .map((message) => resolvePromptContextTextDedupeKey(message))
       .filter((key) => key !== undefined),
   );
-  const sessionOnlyPromptMessages = params.sessionPromptMessages.filter((message) => {
-    const key = resolvePromptContextTextDedupeKey(message);
-    return key === undefined || !cacheTextKeys.has(key);
-  });
+  const cacheTexts = params.cachePromptMessages
+    .map((message) => resolvePromptContextNormalizedText(message))
+    .filter((text) => text !== undefined);
+  const sessionOnlyPromptMessages = params.sessionPromptMessages.filter(
+    (message) => !shouldDropSessionPromptMessage(message, cacheTextKeys, cacheTexts),
+  );
   return {
     sessionOnlyPromptMessages,
     promptMessages: [...sessionOnlyPromptMessages, ...params.cachePromptMessages].toSorted(

--- a/extensions/telegram/src/prompt-context-dedupe.ts
+++ b/extensions/telegram/src/prompt-context-dedupe.ts
@@ -1,0 +1,19 @@
+import { stripInlineDirectiveTagsForDisplay } from "openclaw/plugin-sdk/text-chunking";
+
+export type TelegramPromptContextMessageForDedupe = {
+  body?: unknown;
+  timestamp_ms?: unknown;
+};
+
+export function resolvePromptContextTextDedupeKey(
+  message: TelegramPromptContextMessageForDedupe,
+): string | undefined {
+  if (typeof message.body !== "string" || !message.body.trim()) {
+    return undefined;
+  }
+  if (typeof message.timestamp_ms !== "number" || !Number.isFinite(message.timestamp_ms)) {
+    return undefined;
+  }
+  const visibleBody = stripInlineDirectiveTagsForDisplay(message.body).text.trim();
+  return visibleBody ? `${message.timestamp_ms}:${visibleBody}` : undefined;
+}

--- a/scripts/lib/local-heavy-check-runtime.mjs
+++ b/scripts/lib/local-heavy-check-runtime.mjs
@@ -254,7 +254,7 @@ export function acquireLocalHeavyCheckLockSync(params) {
         createdAt: new Date().toISOString(),
       });
       return () => {
-        removeLockDirSync(lockDir);
+        fs.rmSync(lockDir, { recursive: true, force: true });
       };
     } catch (error) {
       if (!isAlreadyExistsError(error)) {
@@ -263,7 +263,7 @@ export function acquireLocalHeavyCheckLockSync(params) {
 
       const owner = readOwnerFile(ownerPath);
       if (shouldReclaimLock({ owner, lockDir, staleLockMs })) {
-        removeLockDirSync(lockDir);
+        fs.rmSync(lockDir, { recursive: true, force: true });
         continue;
       }
 
@@ -351,25 +351,7 @@ function cleanupLegacyLockDirs(locksDir, staleLockMs) {
 
     const owner = readOwnerFile(path.join(legacyLockDir, "owner.json"));
     if (shouldReclaimLock({ owner, lockDir: legacyLockDir, staleLockMs })) {
-      removeLockDirSync(legacyLockDir);
-    }
-  }
-}
-
-function removeLockDirSync(lockDir) {
-  try {
-    for (const entry of fs.readdirSync(lockDir, { withFileTypes: true })) {
-      const entryPath = path.join(lockDir, entry.name);
-      if (entry.isDirectory() && !entry.isSymbolicLink()) {
-        fs.rmSync(entryPath, { recursive: true, force: true });
-        continue;
-      }
-      fs.unlinkSync(entryPath);
-    }
-    fs.rmdirSync(lockDir);
-  } catch (error) {
-    if (!isMissingPathError(error)) {
-      throw error;
+      fs.rmSync(legacyLockDir, { recursive: true, force: true });
     }
   }
 }
@@ -436,10 +418,6 @@ function readOwnerFile(ownerPath) {
 
 function isAlreadyExistsError(error) {
   return Boolean(error && typeof error === "object" && "code" in error && error.code === "EEXIST");
-}
-
-function isMissingPathError(error) {
-  return Boolean(error && typeof error === "object" && "code" in error && error.code === "ENOENT");
 }
 
 function shouldReclaimLock({ owner, lockDir, staleLockMs }) {

--- a/scripts/lib/local-heavy-check-runtime.mjs
+++ b/scripts/lib/local-heavy-check-runtime.mjs
@@ -254,7 +254,7 @@ export function acquireLocalHeavyCheckLockSync(params) {
         createdAt: new Date().toISOString(),
       });
       return () => {
-        fs.rmSync(lockDir, { recursive: true, force: true });
+        removeLockDirSync(lockDir);
       };
     } catch (error) {
       if (!isAlreadyExistsError(error)) {
@@ -263,7 +263,7 @@ export function acquireLocalHeavyCheckLockSync(params) {
 
       const owner = readOwnerFile(ownerPath);
       if (shouldReclaimLock({ owner, lockDir, staleLockMs })) {
-        fs.rmSync(lockDir, { recursive: true, force: true });
+        removeLockDirSync(lockDir);
         continue;
       }
 
@@ -351,7 +351,25 @@ function cleanupLegacyLockDirs(locksDir, staleLockMs) {
 
     const owner = readOwnerFile(path.join(legacyLockDir, "owner.json"));
     if (shouldReclaimLock({ owner, lockDir: legacyLockDir, staleLockMs })) {
-      fs.rmSync(legacyLockDir, { recursive: true, force: true });
+      removeLockDirSync(legacyLockDir);
+    }
+  }
+}
+
+function removeLockDirSync(lockDir) {
+  try {
+    for (const entry of fs.readdirSync(lockDir, { withFileTypes: true })) {
+      const entryPath = path.join(lockDir, entry.name);
+      if (entry.isDirectory() && !entry.isSymbolicLink()) {
+        fs.rmSync(entryPath, { recursive: true, force: true });
+        continue;
+      }
+      fs.unlinkSync(entryPath);
+    }
+    fs.rmdirSync(lockDir);
+  } catch (error) {
+    if (!isMissingPathError(error)) {
+      throw error;
     }
   }
 }
@@ -418,6 +436,10 @@ function readOwnerFile(ownerPath) {
 
 function isAlreadyExistsError(error) {
   return Boolean(error && typeof error === "object" && "code" in error && error.code === "EEXIST");
+}
+
+function isMissingPathError(error) {
+  return Boolean(error && typeof error === "object" && "code" in error && error.code === "ENOENT");
 }
 
 function shouldReclaimLock({ owner, lockDir, staleLockMs }) {


### PR DESCRIPTION
## Summary

Fixes #99117.

Telegram direct-message prompt context can include the same assistant reply twice: once from the session transcript with a synthetic `session:*` id and inline directive tag such as `[[reply_to_current]]`, and once from the Telegram cache with the delivered text. The original reporter confirmed the real OpenClaw 2026.6.11 path can also have a send-time timestamp gap between the two rows, for example `session:bc268f12` at 12:03:12 PDT and Telegram message `808` at 12:03:18 PDT.

This PR moves the Telegram session/cache dedupe and merge logic into a small Telegram-owned module. It normalizes text with the existing public `openclaw/plugin-sdk/text-chunking` delivery stripping helper, keeps exact timestamp/body dedupe for ordinary rows, and adds a narrow near-time fallback only for synthetic OpenClaw session rows whose text actually changed after stripping directive tags. For those directive-tagged synthetic assistant rows, both exact and drift fallback matching are limited to assistant cache rows identified by stable Telegram bot message identity from the runtime (`ctx.me.id` against the cached source message), not by the cache row's display `sender` text, so custom-named bot/account rows still dedupe and same-text user cache rows do not erase assistant transcript context.

The streamed-preview finalization path now records the finalized Telegram cache message with the bot `from` identity from `ctx.me` as well. That preserves the same assistant cache identity for streamed final replies, where the previous cache write only carried `message_id` and could fall back to sender id `0` before this repair.

## Verification

- `pnpm install --frozen-lockfile`
- Red check: `pnpm exec tsx -e "import('./extensions/telegram/src/prompt-context-dedupe.js').catch((err)=>{ console.error(err.message); process.exit(1); })"` failed before implementation with missing module.
- Red check for merge helper: `pnpm exec tsx -e "import('./extensions/telegram/src/prompt-context-dedupe.ts').then((m)=>{ if(typeof m.mergeTelegramPromptContextMessages !== 'function') throw new Error('merge helper missing'); })"` failed before the merge helper existed.
- Red check for the reporter drift case: `pnpm exec tsx -e "import { mergeTelegramPromptContextMessages } from './extensions/telegram/src/prompt-context-dedupe.ts'; const result = mergeTelegramPromptContextMessages({ sessionPromptMessages: [{message_id:'session:bc268f12', sender:'OpenClaw', timestamp_ms:1783019792000, body:'[[reply_to_current]]Duplicate context test reply - issue 99117'}], cachePromptMessages: [{message_id:'808', sender:'OpenClaw', timestamp_ms:1783019798000, body:'Duplicate context test reply - issue 99117'}], isAssistantCacheMessage: (message) => message.message_id === '808' }); if (result.sessionOnlyPromptMessages.length !== 0 || result.promptMessages.map((m)=>m.message_id).join(',') !== '808') { throw new Error('directive timestamp drift duplicate survived'); }"` failed before the drift fallback.
- Red check for cache-row scoping: `pnpm exec tsx -e "import { mergeTelegramPromptContextMessages } from './extensions/telegram/src/prompt-context-dedupe.ts'; const result = mergeTelegramPromptContextMessages({ sessionPromptMessages: [{message_id:'session:assistant-with-reply-directive', sender:'OpenClaw', timestamp_ms:1783019792000, body:'[[reply_to_current]]same visible text'}], cachePromptMessages: [{message_id:'807', sender:'User', timestamp_ms:1783019792000, body:'same visible text'}, {message_id:'808', sender:'User', timestamp_ms:1783019798000, body:'same visible text'}], isAssistantCacheMessage: () => false }); if (result.sessionOnlyPromptMessages.length !== 1 || result.promptMessages.map((m)=>m.message_id).join(',') !== 'session:assistant-with-reply-directive,807,808') { throw new Error('user cache row incorrectly dropped directive session row'); }"` failed before cache-row scoping.
- `node scripts/run-vitest.mjs extensions/telegram/src/bot-message-dispatch.test.ts -- -t "marks durable non-preview finals with the transcript prompt-context timestamp"` (1 passed; includes the streamed final cache sender id regression)
- `node scripts/run-vitest.mjs extensions/telegram/src/prompt-context-dedupe.test.ts` (8 passed, including custom-named assistant cache row regression)
- `pnpm exec oxfmt --check extensions/telegram/src/bot-message-dispatch.ts extensions/telegram/src/bot-message-dispatch.test.ts extensions/telegram/src/bot-handlers.runtime.ts extensions/telegram/src/prompt-context-dedupe.ts extensions/telegram/src/prompt-context-dedupe.test.ts`
- `node scripts/check-extension-plugin-sdk-boundary.mjs --mode=src-outside-plugin-sdk`
- `git diff --check`


Additional verification after `b425cc396d`:

- Red check: `node scripts/run-vitest.mjs extensions/telegram/src/bot-message-dispatch.test.ts -- -t "records streamed final replies into the prompt context cache"` failed before the test repair because the streamed final cache row `1497` was not present in the real prompt-context cache readback.
- `node scripts/run-vitest.mjs extensions/telegram/src/bot-message-dispatch.test.ts -- -t "records streamed final replies into the prompt context cache"` passed 1 selected test after moving bot identity into the streamed-cache test and reading the cache with the same resolved store scope used by production.
- `pnpm exec vitest run --config test/vitest/vitest.extension-telegram.config.ts extensions/telegram/src/prompt-context-dedupe.test.ts` (8 passed)
- `pnpm exec vitest run --config test/vitest/vitest.extension-telegram.config.ts extensions/telegram/src/bot-message-dispatch.test.ts -t "marks durable non-preview finals with the transcript prompt-context timestamp|records streamed final replies into the prompt context cache"` (2 passed, 143 skipped)
- `pnpm exec oxfmt --check extensions/telegram/src/bot-message-dispatch.test.ts`
- `git diff --check`
Local wrapper note:

- `node scripts/run-vitest.mjs ...` repeatedly queued behind a stale local heavy-check lock in the shared git common dir (`.git/openclaw-local-checks/heavy-check.lock`) whose owner pid no longer existed. After verifying the pid was dead, removing the stale lock let the wrapper run and pass the focused tests above. This affected local command startup, not the Telegram runtime behavior.

Known local proof gaps:

- `pnpm exec tsgo -p extensions/telegram/tsconfig.json --noEmit` is not a valid local narrow check in this worktree as-is; it fails on many existing `openclaw/plugin-sdk/*` type-resolution errors unrelated to this diff.
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main` failed before review with Windows `NotADirectoryError: [WinError 267]` while spawning `git` in this non-ASCII Windows worktree.
- Live Telegram proof is not attached yet because this local environment does not have the `openclaw-telegram-user-crabbox-proof`/`crabbox` runner on PATH.

## Real behavior proof

Behavior addressed: Telegram DM prompt context no longer keeps both the synthetic session transcript assistant row and the Telegram cache assistant row when the session row contains an inline directive tag and the delivered cache row has the same delivered assistant text, including the real reporter's timestamp-drift shape. Assistant cache rows are now supplied by stable Telegram bot message identity from the runtime instead of display `sender` text, including streamed final replies.

Real environment tested: Local Windows source worktree with focused helper/runtime import proof, wrapper-backed Vitest proof, plus PR `Real behavior proof` checks. The original reporter also posted a real OpenClaw 2026.6.11 Telegram DM capture showing the pre-fix duplicate shape on macOS 26.3.1 arm64 with `openai/gpt-5.4`.

Exact steps or command run after this patch: See `Verification` above.

Evidence after fix: The focused helper tests showed directive-tagged session rows are removed for exact and near-time assistant cache matches; the reporter-shaped timestamp-drift row is deduped; same-text user cache rows are preserved; plain same-text drift without stripped directive tags still keeps both rows; and a custom-named assistant cache row such as `Molty Support Bot` still dedupes when the runtime marks it as the bot's own cached message. The streamed final dispatch test also now proves the recorded prompt-context cache row keeps the bot sender id.

Observed result after fix: `node scripts/run-vitest.mjs extensions/telegram/src/bot-message-dispatch.test.ts -- -t "marks durable non-preview finals with the transcript prompt-context timestamp"` passed 1 selected test; `node scripts/run-vitest.mjs extensions/telegram/src/prompt-context-dedupe.test.ts` passed 8 tests; formatting, extension plugin-SDK boundary, and whitespace checks passed.

What was not tested: No completed live Telegram DM artifact from this branch is attached yet. The PR still needs Mantis or equivalent redacted Telegram proof to clear the scoped Telegram reply-context proof bar.

