### PR TITLE
fix #97625: Qwen3:14b compaction fails with Already compacted

### DIFF
--- a/src/agents/command/cli-compaction.test.ts
+++ b/src/agents/command/cli-compaction.test.ts
@@ -273,6 +273,74 @@ describe("runCliTurnCompactionLifecycle", () => {
     );
   });
 
+  it("treats already-compacted CLI transcript compaction as a no-op", async () => {
+    const sessionKey = "agent:main:qwen-already-compacted";
+    const sessionId = "session-qwen-already-compacted";
+    const sessionFile = path.join(tmpDir, "session-qwen-already-compacted.jsonl");
+    const storePath = path.join(tmpDir, "sessions-qwen-already-compacted.json");
+    await writeSessionFile({ sessionFile, sessionId });
+
+    const sessionEntry: SessionEntry = {
+      sessionId,
+      updatedAt: Date.now(),
+      sessionFile,
+      contextTokens: 1_000,
+      totalTokens: 950,
+      totalTokensFresh: true,
+    };
+    const sessionStore: Record<string, SessionEntry> = { [sessionKey]: sessionEntry };
+    await fs.writeFile(storePath, JSON.stringify(sessionStore, null, 2), "utf-8");
+
+    const compactCalls: Array<Parameters<ContextEngine["compact"]>[0]> = [];
+    const maintenance = vi.fn(async () => ({ changed: false, bytesFreed: 0, rewrittenEntries: 0 }));
+    const recordCliCompactionInStore = vi.fn();
+    setCliCompactionTestDeps({
+      resolveContextEngine: async () => ({
+        ...buildContextEngine({ compactCalls }),
+        async compact(compactParams) {
+          compactCalls.push(compactParams);
+          throw new Error("Already compacted");
+        },
+      }),
+      createPreparedEmbeddedAgentSettingsManager: async () => ({
+        getCompactionReserveTokens: () => 200,
+        getCompactionKeepRecentTokens: () => 0,
+        applyOverrides: () => {},
+      }),
+      shouldPreemptivelyCompactBeforePrompt: () => ({
+        route: "fits",
+        shouldCompact: false,
+        estimatedPromptTokens: 600,
+        promptBudgetBeforeReserve: 800,
+        overflowTokens: 0,
+        toolResultReducibleChars: 0,
+        effectiveReserveTokens: 200,
+      }),
+      resolveLiveToolResultMaxChars: () => 20_000,
+      runContextEngineMaintenance: maintenance,
+      recordCliCompactionInStore,
+    });
+
+    const updatedEntry = await runCliTurnCompactionLifecycle({
+      cfg: {} as OpenClawConfig,
+      sessionId,
+      sessionKey,
+      sessionEntry,
+      sessionStore,
+      storePath,
+      sessionAgentId: "main",
+      workspaceDir: tmpDir,
+      agentDir: tmpDir,
+      provider: "ollama",
+      model: "qwen3:14b",
+    });
+
+    expect(compactCalls).toHaveLength(1);
+    expect(maintenance).not.toHaveBeenCalled();
+    expect(recordCliCompactionInStore).not.toHaveBeenCalled();
+    expect(updatedEntry).toBe(sessionEntry);
+  });
+
   it("routes OpenAI Codex harness CLI compaction through native harness compaction", async () => {
     const sessionKey = "agent:main:codex";
     const sessionId = "session-codex";

--- a/src/agents/command/cli-compaction.ts
+++ b/src/agents/command/cli-compaction.ts
@@ -200,8 +200,9 @@ function isUnsupportedNativeHarnessCompaction(
   return result?.ok === false && result.failure?.reason === "unsupported_harness_compaction";
 }
 
-function isBelowCompactionTargetReason(reason: string | undefined): boolean {
-  return classifyCompactionReason(reason) === "below_threshold";
+function isBenignCliCompactionNoopReason(reason: string | undefined): boolean {
+  const classification = classifyCompactionReason(reason);
+  return classification === "below_threshold" || classification === "already_compacted_recently";
 }
 
 function isIntentionalNativeAutoCompactionSkip(
@@ -317,18 +318,23 @@ async function compactCliTranscript(params: {
       resolveCompactionTimeoutMs(params.cfg),
     );
   } catch (error) {
-    log.warn(
-      `CLI transcript compaction failed for ${params.provider}/${params.model}: ${error instanceof Error ? error.message : String(error)}`,
-    );
+    const reason = error instanceof Error ? error.message : String(error);
+    if (isBenignCliCompactionNoopReason(reason)) {
+      log.info(
+        `CLI transcript compaction skipped for ${params.provider}/${params.model}: ${reason}`,
+      );
+      return { compacted: false };
+    }
+    log.warn(`CLI transcript compaction failed for ${params.provider}/${params.model}: ${reason}`);
     return {
       compacted: false,
-      failureReason: error instanceof Error ? error.message : String(error),
+      failureReason: reason,
     };
   }
 
   if (!compactResult.compacted) {
     const reason = compactResult.reason ?? "nothing to compact";
-    if (isBelowCompactionTargetReason(reason)) {
+    if (isBenignCliCompactionNoopReason(reason)) {
       log.info(
         `CLI transcript compaction skipped for ${params.provider}/${params.model}: ${reason}`,
       );
@@ -466,7 +472,7 @@ async function compactNativeHarnessCliTranscript(params: {
 
   if (!result?.compacted) {
     const reason = result?.reason ?? "nothing to compact";
-    if (isBelowCompactionTargetReason(reason)) {
+    if (isBenignCliCompactionNoopReason(reason)) {
       log.info(
         `CLI native harness compaction skipped for ${params.provider}/${params.model}: ${reason}`,
       );


### PR DESCRIPTION
Closes #97625

## Summary

- Treat `Already compacted` / `already_compacted` CLI turn compaction outcomes as safe no-ops instead of fatal pre-turn failures.
- Apply the same benign no-op classification to the context-engine throw path and non-compacting result path.
- Add regression coverage for the reported `ollama/qwen3:14b` failure message.

## What Problem This Solves

Users running local Ollama-backed CLI sessions can hit a fatal turn abort after the runtime has already compacted the transcript. In the reported Qwen3:14b workflow, this surfaced as `CLI transcript compaction failed for ollama/qwen3:14b: Already compacted` before the MCP tool result could reach the user, while another Ollama model completed the same flow.

## Why This Change Was Made

OpenClaw already classifies `Already compacted` as `already_compacted_recently`, and adjacent manual `/compact` plus memory-flush preflight paths already treat that class as a skipped compaction. The CLI turn compaction lifecycle only skipped `below_threshold`, so the same harmless already-compacted state became a fatal `failureReason` for CLI-backed turns.

## User Impact

A CLI-backed agent turn can now continue when the selected context engine reports that the transcript was already compacted. Real compaction failures still fail closed, so timeouts, guard failures, provider errors, and unclassified compaction errors remain visible instead of being hidden.

## Why it matters / User impact

The failure happens on the path that decides whether a user turn may proceed after transcript persistence. When it fails closed on a harmless already-compacted transcript, the user loses the expected assistant/tool response even though the transcript source of truth is already in a compacted state. This is especially visible for small-context local models such as `ollama/qwen3:14b`, where compaction can happen before the MCP tool workflow completes.

## Maintainer-ready checklist

- **Why it matters / User impact:** The failure happens on the path that decides whether a user turn may proceed after transcript persistence. When it fails closed on a harmless already-compacted transcript, the user loses the expected assistant/tool response even though the transcript source of truth is already in a compacted state.
- **What did NOT change:** This patch only changes CLI compaction no-op classification. It does not change MCP execution, Ollama routing, model catalog/config behavior, prompt assembly, transcript rewriting, context-engine plugin registration, or the lazy compaction-count reconcile persistence path.
- **Architecture / source-of-truth check:** The model-consumed source-of-truth is the active session transcript plus the context-engine compaction result for that transcript. `Already compacted` means the compact boundary found the current branch already ends at a compaction state, so the correct lifecycle contract is to skip without mutating transcript contents, session state, or compaction counters.
- **Scenario locked in:** A CLI-backed session above its prompt-reserve budget selects `ollama/qwen3:14b`, reaches context-engine compaction, and receives `Already compacted`; the lifecycle must return the existing session entry instead of throwing `CLI transcript compaction failed`.
- **Why this is the smallest reliable guardrail:** The regression checks exactly the decision boundary that failed, verifies the compact boundary is reached once, and verifies no maintenance or compaction-count write happens for the no-op. That prevents both the reported abort and an over-broad false success.

## Scope boundary

This patch is limited to the CLI turn compaction lifecycle in `src/agents/command/cli-compaction.ts` and its regression coverage. It does not change MCP execution, Ollama routing, model catalog/config behavior, prompt assembly, transcript rewriting, context-engine plugin registration, or the lazy compaction-count reconcile persistence path.

## Source-of-truth / architecture boundary

The model-consumed source of truth is the active session transcript and the context-engine compaction result for that transcript. `Already compacted` means the compact boundary found the current branch already ends at a compaction state, so there is no additional transcript rewrite to perform. The fix changes only the decision that maps that known terminal no-op reason into turn control flow; it does not mutate transcript contents, session store entries, or compaction counters for the no-op path.

## Related PR scan

The issue evidence scan found no related open PRs for the public-contract search terms or direct issue linkage. The `config.plugins.slots.contextEngine` reference appears only in the local proof command to select a registered context-engine slot; this patch does not add or modify any public config/schema/API/protocol surface.

## Root Cause

- **Root cause:** `compactCliTranscript` converted every thrown context-engine compact error into `failureReason`, and `runCliTurnCompactionLifecycle` throws on that `failureReason`. Although `classifyCompactionReason()` already maps `Already compacted` to `already_compacted_recently`, the CLI lifecycle only treated `below_threshold` as a non-fatal no-op.
- **Why this is root-cause fix:** The patch classifies the thrown or returned compaction reason before deciding whether to fail the turn. Only the already-known benign no-op class is added to the CLI skip path, matching adjacent compaction preflight semantics without adding provider-specific Qwen/Ollama handling.
- **Not changed:** The lazy compaction-count reconcile path is not changed. A focused handler test passed locally and did not reproduce the reported `reconcile is not a function` warning, which also appeared in the reporter's successful Llama3.1 run and was not the fatal abort path.

## Real behavior proof

- **Behavior or issue addressed:** CLI turn compaction should not abort a turn when the context-engine compact boundary reports `Already compacted` for `ollama/qwen3:14b`.
- **Real environment tested:** Linux source checkout running the actual `runCliTurnCompactionLifecycle` production path with a registered public context-engine slot selected through `config.plugins.slots.contextEngine`. The slot's compact boundary throws the reporter's exact `Already compacted` message for `ollama/qwen3:14b`; no direct helper call bypasses the lifecycle.
- **Exact steps or command run after this patch:**

```shell
pnpm --dir /media/vdb/code/ai/aispace/openclaw-worktrees/issue-97625 exec node --import tsx -e "import fs from 'node:fs/promises'; import os from 'node:os'; import path from 'node:path'; import { CURRENT_SESSION_VERSION } from 'openclaw/plugin-sdk/agent-sessions'; import { registerContextEngine } from './src/context-engine/registry.ts'; import { runCliTurnCompactionLifecycle } from './src/agents/command/cli-compaction.ts'; const dir = await fs.mkdtemp(path.join(os.tmpdir(), 'oc-97625-slot-proof-')); try { const engineId = 'already-compacted-proof'; const compactCalls = []; registerContextEngine(engineId, () => ({ info: { id: engineId, name: 'Already Compacted Proof Engine' }, async ingest() { return { ingested: false }; }, async assemble(params) { return { messages: params.messages, estimatedTokens: 0 }; }, async compact(params) { compactCalls.push({ force: params.force, currentTokenCount: params.currentTokenCount, compactionTarget: params.compactionTarget }); throw new Error('Already compacted'); } })); const sessionKey = 'agent:main:qwen-proof'; const sessionId = 'session-qwen-proof'; const sessionFile = path.join(dir, 'session.jsonl'); const storePath = path.join(dir, 'sessions.json'); await fs.writeFile(sessionFile, [JSON.stringify({ type: 'session', version: CURRENT_SESSION_VERSION, id: sessionId, timestamp: new Date(0).toISOString(), cwd: dir }), JSON.stringify({ type: 'message', message: { role: 'user', content: 'old ask', timestamp: 1 } }), JSON.stringify({ type: 'message', message: { role: 'assistant', content: [{ type: 'text', text: 'old answer' }], timestamp: 2 } }), ''].join('\n'), 'utf-8'); const sessionEntry = { sessionId, updatedAt: Date.now(), sessionFile, contextTokens: 1000, totalTokens: 950, totalTokensFresh: true }; const sessionStore = { [sessionKey]: sessionEntry }; await fs.writeFile(storePath, JSON.stringify(sessionStore, null, 2), 'utf-8'); const updatedEntry = await runCliTurnCompactionLifecycle({ cfg: { plugins: { slots: { contextEngine: engineId } } }, sessionId, sessionKey, sessionEntry, sessionStore, storePath, sessionAgentId: 'main', workspaceDir: dir, agentDir: dir, provider: 'ollama', model: 'qwen3:14b' }); console.log(JSON.stringify({ completedWithoutThrow: true, sameEntryReturned: updatedEntry === sessionEntry, compactCalls, persistedCompactionCount: sessionStore[sessionKey]?.compactionCount ?? null }, null, 2)); } finally { await fs.rm(dir, { recursive: true, force: true }); }"
```

- **Evidence after fix:**

```text
[context-engine] Context engine "already-compacted-proof" owner=public-sdk failed during compact: Already compacted; quarantining it for this process and falling back to default engine "legacy".
[agents/cli-compaction] CLI transcript compaction skipped for ollama/qwen3:14b: Already compacted
{
  "completedWithoutThrow": true,
  "sameEntryReturned": true,
  "compactCalls": [
    {
      "force": true,
      "currentTokenCount": 950,
      "compactionTarget": "budget"
    }
  ],
  "persistedCompactionCount": null
}
```

- **Observed result after fix:** The CLI turn compaction lifecycle reaches the configured context-engine compact boundary, receives the exact `Already compacted` failure text, logs it as skipped for `ollama/qwen3:14b`, and returns the existing session entry without throwing or recording a new compaction.
- **What was not tested:** I did not run a live Ollama `qwen3:14b` model, the reporter's Python MCP stdio server, or the exact `jarvis__expand` tool workflow in this environment. The reported late reconcile `TypeError` was checked through `src/agents/embedded-agent-subscribe.handlers.compaction.test.ts` but was not reproduced locally, so this patch does not change the lazy reconcile import/persistence path.

## Regression Test Plan

- **Target test file:** `src/agents/command/cli-compaction.test.ts`
- **Regression scenario:** A CLI-backed session is above its prompt-reserve budget, selects `ollama/qwen3:14b`, reaches context-engine compaction, and receives the reported `Already compacted` reason. Before this patch, the lifecycle threw `CLI transcript compaction failed for ollama/qwen3:14b: Already compacted`; after this patch, it returns the existing session entry as a no-op.
- **Test guardrail rationale:** The regression asserts that the compact boundary is reached exactly once, maintenance is not invoked, and no compaction record is written. That guards against both the reported fatal abort and an over-broad fix that would incorrectly count a no-op as a successful new compaction.

```shell
pnpm --dir /media/vdb/code/ai/aispace/openclaw-worktrees/issue-97625 test src/agents/command/cli-compaction.test.ts
```

```text
Test Files  1 passed (1)
Tests  20 passed (20)
```

```shell
pnpm --dir /media/vdb/code/ai/aispace/openclaw-worktrees/issue-97625 test src/agents/embedded-agent-subscribe.handlers.compaction.test.ts
```

```text
Test Files  1 passed (1)
Tests  11 passed (11)
```

```shell
pnpm --dir /media/vdb/code/ai/aispace/openclaw-worktrees/issue-97625 run format:check -- src/agents/command/cli-compaction.ts src/agents/command/cli-compaction.test.ts
```

```text
All matched files use the correct format.
```

```shell
pnpm --dir /media/vdb/code/ai/aispace/openclaw-worktrees/issue-97625 run tsgo:test:src
```

```text
PASS, exit code 0.
```

## Merge risk

- **Risk labels considered:** `impact:session-state`, `impact:message-loss`, `impact:auth-provider`, `merge-risk:agent-runtime`, `merge-risk:session-state`.
- **Risk explanation:** The change affects whether a CLI compaction failure aborts a user turn. Over-broad skipping could hide real compaction failures and allow a too-large prompt to continue.
- **Why acceptable:** The skip is limited to shared classifier output for `below_threshold` and `already_compacted_recently`. Existing timeout/provider/guard/unknown failures still produce `failureReason`, and the regression asserts that no maintenance or compaction-count write is performed for the already-compacted no-op.

## Patch quality notes

- **Fix classification:** Root-cause CLI compaction lifecycle fix with focused regression coverage.
- **Maintainer-ready confidence:** High for the source-level CLI compaction lifecycle and the exact fatal reason mapping; live Ollama/Qwen3 MCP validation remains the proof gap.
- **Patch quality notes:** The patch changes only the compaction reason classification boundary and one focused test file. It does not add model-specific handling, config knobs, or unrelated compaction policy changes.
