### PR TITLE
fix: prevent Voice Wake crash after Talk audio capture

### DIFF
--- a/apps/.i18n/native-source.json
+++ b/apps/.i18n/native-source.json
@@ -11490,6 +11490,22 @@
       "id": "native.apple.d2db26b3bb266491"
     },
     {
+      "kind": "conditional-branch",
+      "line": 255,
+      "path": "apps/ios/Sources/Voice/VoiceWakeManager.swift",
+      "source": "Off",
+      "surface": "apple",
+      "id": "native.apple.b6bc54876f20104f"
+    },
+    {
+      "kind": "conditional-branch",
+      "line": 255,
+      "path": "apps/ios/Sources/Voice/VoiceWakeManager.swift",
+      "source": "Paused",
+      "surface": "apple",
+      "id": "native.apple.5590d661cdc81fbf"
+    },
+    {
       "kind": "ui-named-argument",
       "line": 96,
       "path": "apps/ios/WatchApp/Sources/WatchInboxView.swift",

--- a/apps/.i18n/native-source.json
+++ b/apps/.i18n/native-source.json
@@ -8203,7 +8203,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 610,
+      "line": 613,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "Configured",
       "surface": "apple",
@@ -8211,7 +8211,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 610,
+      "line": 613,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "Not configured",
       "surface": "apple",
@@ -8219,7 +8219,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 675,
+      "line": 678,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "Connect to the gateway.",
       "surface": "apple",
@@ -8227,7 +8227,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 675,
+      "line": 678,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "Gateway requests will appear here.",
       "surface": "apple",
@@ -8235,7 +8235,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 730,
+      "line": 733,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "High",
       "surface": "apple",
@@ -8243,7 +8243,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 730,
+      "line": 733,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "Resolving",
       "surface": "apple",
@@ -8251,7 +8251,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 735,
+      "line": 738,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "One-time approval",
       "surface": "apple",
@@ -8259,7 +8259,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 735,
+      "line": 738,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "Permission can be saved",
       "surface": "apple",
@@ -8267,7 +8267,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 737,
+      "line": 740,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "Medium",
       "surface": "apple",
@@ -8275,7 +8275,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 737,
+      "line": 740,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "Review",
       "surface": "apple",
@@ -8283,7 +8283,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 762,
+      "line": 765,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "\\(diagnosticsIssueCount)",
       "surface": "apple",
@@ -8291,7 +8291,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 772,
+      "line": 775,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "Location \\(self.locationLabel)",
       "surface": "apple",
@@ -8299,7 +8299,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 772,
+      "line": 775,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "Location off",
       "surface": "apple",
@@ -8307,7 +8307,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 777,
+      "line": 780,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "Off",
       "surface": "apple",
@@ -8315,7 +8315,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 778,
+      "line": 781,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "While Using",
       "surface": "apple",
@@ -8323,7 +8323,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 779,
+      "line": 782,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "Always",
       "surface": "apple",
@@ -8331,7 +8331,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 793,
+      "line": 796,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "Checking iOS notification permission.",
       "surface": "apple",
@@ -8339,7 +8339,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 795,
+      "line": 798,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "OpenClaw can show approval prompts and event alerts when the app is not active.",
       "surface": "apple",
@@ -8347,7 +8347,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 797,
+      "line": 800,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "Notifications have been denied. Enable them in iOS Settings.",
       "surface": "apple",
@@ -8355,7 +8355,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 799,
+      "line": 802,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "Enable notifications to receive approval prompts and event alerts outside the app.",
       "surface": "apple",
@@ -8363,7 +8363,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 801,
+      "line": 804,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "OpenClaw cannot determine the current notification permission state.",
       "surface": "apple",
@@ -11491,7 +11491,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 255,
+      "line": 260,
       "path": "apps/ios/Sources/Voice/VoiceWakeManager.swift",
       "source": "Off",
       "surface": "apple",
@@ -11499,7 +11499,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 255,
+      "line": 260,
       "path": "apps/ios/Sources/Voice/VoiceWakeManager.swift",
       "source": "Paused",
       "surface": "apple",

--- a/apps/ios/Sources/Design/SettingsProTabActions.swift
+++ b/apps/ios/Sources/Design/SettingsProTabActions.swift
@@ -80,6 +80,9 @@ extension SettingsProTab {
                     detail: self.appModel.voiceWake.statusText,
                     value: self.voiceWakeEnabled ? "on" : "off",
                     color: self.voiceWakeEnabled ? OpenClawBrand.ok : .secondary)
+                    .accessibilityElement(children: .combine)
+                    .accessibilityIdentifier("diagnostics-voice-wake-status")
+                    .accessibilityValue(self.appModel.voiceWake.statusText)
             }
         }
         .padding(.horizontal, OpenClawProMetric.pagePadding)

--- a/apps/ios/Sources/Voice/VoiceWakeManager.swift
+++ b/apps/ios/Sources/Voice/VoiceWakeManager.swift
@@ -38,6 +38,17 @@ private final class AudioBufferQueue: @unchecked Sendable {
     }
 }
 
+private enum VoiceWakeAudioError: LocalizedError {
+    case invalidInputFormat
+
+    var errorDescription: String? {
+        switch self {
+        case .invalidInputFormat:
+            "Microphone input format unavailable"
+        }
+    }
+}
+
 extension AVAudioPCMBuffer {
     fileprivate func deepCopy() -> AVAudioPCMBuffer? {
         let format = self.format
@@ -93,11 +104,15 @@ final class VoiceWakeManager: NSObject {
     private var recognitionTask: SFSpeechRecognitionTask?
     private var tapQueue: AudioBufferQueue?
     private var tapDrainTask: Task<Void, Never>?
+    private var scheduledStartTask: Task<Void, Never>?
+    private var isStarting: Bool = false
 
     private var lastDispatched: String?
     private var onCommand: (@Sendable (String) async -> Void)?
     private var userDefaultsObserver: NSObjectProtocol?
     private var suppressedByTalk: Bool = false
+
+    private static let externalAudioResumeDelayNs: UInt64 = 350_000_000
 
     override init() {
         super.init()
@@ -137,7 +152,7 @@ final class VoiceWakeManager: NSObject {
     func setEnabled(_ enabled: Bool) {
         self.isEnabled = enabled
         if enabled {
-            Task { await self.start() }
+            self.scheduleStart()
         } else {
             self.stop()
         }
@@ -146,20 +161,45 @@ final class VoiceWakeManager: NSObject {
     func setSuppressedByTalk(_ suppressed: Bool) {
         self.suppressedByTalk = suppressed
         if suppressed {
+            self.cancelScheduledStart()
             _ = self.suspendForExternalAudioCapture()
             if self.isEnabled {
                 self.statusText = "Paused"
             }
-        } else {
-            if self.isEnabled {
-                Task { await self.start() }
-            }
+        } else if self.isEnabled {
+            self.scheduleStart()
         }
+    }
+
+    private func scheduleStart(after delayNs: UInt64 = 0) {
+        guard self.isEnabled else { return }
+
+        self.scheduledStartTask?.cancel()
+        self.scheduledStartTask = Task { [weak self] in
+            if delayNs > 0 {
+                try? await Task.sleep(nanoseconds: delayNs)
+            }
+            guard !Task.isCancelled else { return }
+            await MainActor.run {
+                self?.scheduledStartTask = nil
+            }
+            await self?.start()
+        }
+    }
+
+    private func cancelScheduledStart() {
+        self.scheduledStartTask?.cancel()
+        self.scheduledStartTask = nil
     }
 
     func start() async {
         guard self.isEnabled else { return }
         if self.isListening { return }
+        if self.isStarting { return }
+
+        self.isStarting = true
+        defer { self.isStarting = false }
+
         guard !self.suppressedByTalk else {
             self.isListening = false
             self.statusText = "Paused"
@@ -201,6 +241,12 @@ final class VoiceWakeManager: NSObject {
             return
         }
 
+        guard self.isEnabled, !self.suppressedByTalk else {
+            self.isListening = false
+            self.statusText = self.suppressedByTalk ? "Paused" : "Off"
+            return
+        }
+
         do {
             try Self.configureAudioSession()
             try self.startRecognition()
@@ -216,13 +262,16 @@ final class VoiceWakeManager: NSObject {
         self.isEnabled = false
         self.isListening = false
         self.statusText = "Off"
+        self.cancelScheduledStart()
         self.tearDownRecognitionPipeline()
     }
 
     /// Temporarily releases the microphone so other subsystems (e.g. camera video capture) can record audio.
-    /// Returns `true` when listening was active and was suspended.
+    /// Returns `true` when listening or a pending restart was active and was suspended.
     func suspendForExternalAudioCapture() -> Bool {
-        guard self.isEnabled, self.isListening else { return false }
+        let hadPendingStart = self.scheduledStartTask != nil
+        self.cancelScheduledStart()
+        guard self.isEnabled, self.isListening || hadPendingStart else { return false }
 
         self.isListening = false
         self.statusText = "Paused"
@@ -232,10 +281,12 @@ final class VoiceWakeManager: NSObject {
 
     func resumeAfterExternalAudioCapture(wasSuspended: Bool) {
         guard wasSuspended else { return }
-        Task { await self.start() }
+        self.scheduleStart(after: Self.externalAudioResumeDelayNs)
     }
 
     private func startRecognition() throws {
+        guard self.isEnabled, !self.suppressedByTalk else { return }
+
         self.recognitionTask?.cancel()
         self.recognitionTask = nil
         self.tapDrainTask?.cancel()
@@ -251,6 +302,9 @@ final class VoiceWakeManager: NSObject {
         inputNode.removeTap(onBus: 0)
 
         let recordingFormat = inputNode.outputFormat(forBus: 0)
+        guard recordingFormat.sampleRate > 0, recordingFormat.channelCount > 0 else {
+            throw VoiceWakeAudioError.invalidInputFormat
+        }
 
         let queue = AudioBufferQueue()
         self.tapQueue = queue
@@ -317,13 +371,7 @@ final class VoiceWakeManager: NSObject {
             self.statusText = "Recognizer error: \(errorText)"
             self.isListening = false
 
-            let shouldRestart = self.isEnabled
-            if shouldRestart {
-                Task {
-                    try? await Task.sleep(nanoseconds: 700_000_000)
-                    await self.start()
-                }
-            }
+            self.scheduleStart(after: 700_000_000)
             return
         }
 
@@ -343,10 +391,7 @@ final class VoiceWakeManager: NSObject {
     }
 
     private func startIfEnabled() async {
-        let shouldRestart = self.isEnabled
-        if shouldRestart {
-            await self.start()
-        }
+        self.scheduleStart()
     }
 
     private func extractCommand(from transcript: String, segments: [WakeWordSegment]) -> String? {

--- a/apps/ios/Sources/Voice/VoiceWakeManager.swift
+++ b/apps/ios/Sources/Voice/VoiceWakeManager.swift
@@ -113,9 +113,16 @@ final class VoiceWakeManager: NSObject {
     private var userDefaultsObserver: NSObjectProtocol?
     private var suppressedByTalk: Bool = false
 
-    private static let externalAudioResumeDelayNs: UInt64 = 350_000_000
+    private let externalAudioResumeDelayNs: UInt64
+    private let recognitionErrorRestartDelayNs: UInt64
 
-    override init() {
+    override convenience init() {
+        self.init(externalAudioResumeDelayNs: 350_000_000, recognitionErrorRestartDelayNs: 700_000_000)
+    }
+
+    private init(externalAudioResumeDelayNs: UInt64, recognitionErrorRestartDelayNs: UInt64) {
+        self.externalAudioResumeDelayNs = externalAudioResumeDelayNs
+        self.recognitionErrorRestartDelayNs = recognitionErrorRestartDelayNs
         super.init()
         self.triggerWords = VoiceWakePreferences.loadTriggerWords()
         self.userDefaultsObserver = NotificationCenter.default.addObserver(
@@ -184,9 +191,7 @@ final class VoiceWakeManager: NSObject {
                 try? await Task.sleep(nanoseconds: delayNs)
             }
             guard !Task.isCancelled else { return }
-            await MainActor.run {
-                self?.scheduledStartTask = nil
-            }
+            self?.scheduledStartTask = nil
             await self?.start()
         }
     }
@@ -293,7 +298,7 @@ final class VoiceWakeManager: NSObject {
     func resumeAfterExternalAudioCapture(wasSuspended: Bool) {
         guard wasSuspended else { return }
         self.isSuspendedForExternalAudio = false
-        self.scheduleStart(after: Self.externalAudioResumeDelayNs)
+        self.scheduleStart(after: self.externalAudioResumeDelayNs)
     }
 
     private func startRecognition() throws {
@@ -383,7 +388,7 @@ final class VoiceWakeManager: NSObject {
             self.statusText = "Recognizer error: \(errorText)"
             self.isListening = false
 
-            self.scheduleStart(after: 700_000_000)
+            self.scheduleStart(after: self.recognitionErrorRestartDelayNs)
             return
         }
 
@@ -526,12 +531,21 @@ final class VoiceWakeManager: NSObject {
 
 #if DEBUG
 extension VoiceWakeManager {
+    static func _test_withoutRestartDelays() -> VoiceWakeManager {
+        VoiceWakeManager(externalAudioResumeDelayNs: 0, recognitionErrorRestartDelayNs: 0)
+    }
+
     func _test_handleRecognitionCallback(transcript: String?, segments: [WakeWordSegment], errorText: String?) {
         self.handleRecognitionCallback(transcript: transcript, segments: segments, errorText: errorText)
     }
 
     func _test_setStartInFlight(_ isStarting: Bool) {
         self.isStarting = isStarting
+    }
+
+    func _test_waitForScheduledStart() async {
+        let task = self.scheduledStartTask
+        await task?.value
     }
 }
 #endif

--- a/apps/ios/Sources/Voice/VoiceWakeManager.swift
+++ b/apps/ios/Sources/Voice/VoiceWakeManager.swift
@@ -268,6 +268,7 @@ final class VoiceWakeManager: NSObject {
             self.statusText = "Listening"
         } catch {
             self.isListening = false
+            self.tearDownRecognitionPipeline()
             self.statusText = "Start failed: \(error.localizedDescription)"
         }
     }
@@ -363,8 +364,9 @@ final class VoiceWakeManager: NSObject {
 
         if self.audioEngine.isRunning {
             self.audioEngine.stop()
-            self.audioEngine.inputNode.removeTap(onBus: 0)
         }
+        // A tap can be installed before AVAudioEngine.start() throws.
+        self.audioEngine.inputNode.removeTap(onBus: 0)
 
         try? AVAudioSession.sharedInstance().setActive(false, options: .notifyOthersOnDeactivation)
     }

--- a/apps/ios/Sources/Voice/VoiceWakeManager.swift
+++ b/apps/ios/Sources/Voice/VoiceWakeManager.swift
@@ -106,6 +106,7 @@ final class VoiceWakeManager: NSObject {
     private var tapDrainTask: Task<Void, Never>?
     private var scheduledStartTask: Task<Void, Never>?
     private var isStarting: Bool = false
+    private var isSuspendedForExternalAudio: Bool = false
 
     private var lastDispatched: String?
     private var onCommand: (@Sendable (String) async -> Void)?
@@ -162,7 +163,10 @@ final class VoiceWakeManager: NSObject {
         self.suppressedByTalk = suppressed
         if suppressed {
             self.cancelScheduledStart()
-            _ = self.suspendForExternalAudioCapture()
+            if self.isListening {
+                self.isListening = false
+                self.tearDownRecognitionPipeline()
+            }
             if self.isEnabled {
                 self.statusText = "Paused"
             }
@@ -196,6 +200,11 @@ final class VoiceWakeManager: NSObject {
         guard self.isEnabled else { return }
         if self.isListening { return }
         if self.isStarting { return }
+        guard !self.isSuspendedForExternalAudio else {
+            self.isListening = false
+            self.statusText = "Paused"
+            return
+        }
 
         self.isStarting = true
         defer { self.isStarting = false }
@@ -241,9 +250,9 @@ final class VoiceWakeManager: NSObject {
             return
         }
 
-        guard self.isEnabled, !self.suppressedByTalk else {
+        guard self.isEnabled, !self.suppressedByTalk, !self.isSuspendedForExternalAudio else {
             self.isListening = false
-            self.statusText = self.suppressedByTalk ? "Paused" : "Off"
+            self.statusText = self.isEnabled ? "Paused" : "Off"
             return
         }
 
@@ -262,17 +271,19 @@ final class VoiceWakeManager: NSObject {
         self.isEnabled = false
         self.isListening = false
         self.statusText = "Off"
+        self.isSuspendedForExternalAudio = false
         self.cancelScheduledStart()
         self.tearDownRecognitionPipeline()
     }
 
     /// Temporarily releases the microphone so other subsystems (e.g. camera video capture) can record audio.
-    /// Returns `true` when listening or a pending restart was active and was suspended.
+    /// Returns `true` when listening, starting, or a pending restart was active and was suspended.
     func suspendForExternalAudioCapture() -> Bool {
         let hadPendingStart = self.scheduledStartTask != nil
         self.cancelScheduledStart()
-        guard self.isEnabled, self.isListening || hadPendingStart else { return false }
+        guard self.isEnabled, self.isListening || self.isStarting || hadPendingStart else { return false }
 
+        self.isSuspendedForExternalAudio = true
         self.isListening = false
         self.statusText = "Paused"
         self.tearDownRecognitionPipeline()
@@ -281,11 +292,12 @@ final class VoiceWakeManager: NSObject {
 
     func resumeAfterExternalAudioCapture(wasSuspended: Bool) {
         guard wasSuspended else { return }
+        self.isSuspendedForExternalAudio = false
         self.scheduleStart(after: Self.externalAudioResumeDelayNs)
     }
 
     private func startRecognition() throws {
-        guard self.isEnabled, !self.suppressedByTalk else { return }
+        guard self.isEnabled, !self.suppressedByTalk, !self.isSuspendedForExternalAudio else { return }
 
         self.recognitionTask?.cancel()
         self.recognitionTask = nil
@@ -516,6 +528,10 @@ final class VoiceWakeManager: NSObject {
 extension VoiceWakeManager {
     func _test_handleRecognitionCallback(transcript: String?, segments: [WakeWordSegment], errorText: String?) {
         self.handleRecognitionCallback(transcript: transcript, segments: segments, errorText: errorText)
+    }
+
+    func _test_setStartInFlight(_ isStarting: Bool) {
+        self.isStarting = isStarting
     }
 }
 #endif

--- a/apps/ios/Tests/VoiceWakeManagerStateTests.swift
+++ b/apps/ios/Tests/VoiceWakeManagerStateTests.swift
@@ -4,8 +4,8 @@ import Testing
 @testable import OpenClaw
 
 @Suite(.serialized) struct VoiceWakeManagerStateTests {
-    @Test @MainActor func suspendAndResumeCycleUpdatesState() async {
-        let manager = VoiceWakeManager()
+    @Test @MainActor func `suspend and resume cycle updates state`() async {
+        let manager = VoiceWakeManager._test_withoutRestartDelays()
         manager.isEnabled = true
         manager.isListening = true
         manager.statusText = "Listening"
@@ -16,12 +16,12 @@ import Testing
         #expect(manager.statusText == "Paused")
 
         manager.resumeAfterExternalAudioCapture(wasSuspended: true)
-        try? await Task.sleep(nanoseconds: 900_000_000)
-        #expect(manager.statusText.contains("Voice Wake") == true)
+        await manager._test_waitForScheduledStart()
+        #expect(manager.statusText == "Voice Wake isn’t supported on Simulator")
     }
 
-    @Test @MainActor func handleRecognitionCallbackRestartsOnError() async {
-        let manager = VoiceWakeManager()
+    @Test @MainActor func `handle recognition callback restarts on error`() async {
+        let manager = VoiceWakeManager._test_withoutRestartDelays()
         manager.isEnabled = true
         manager.isListening = true
 
@@ -29,18 +29,20 @@ import Testing
         #expect(manager.statusText.contains("Recognizer error") == true)
         #expect(manager.isListening == false)
 
-        try? await Task.sleep(nanoseconds: 900_000_000)
-        #expect(manager.statusText.contains("Voice Wake") == true)
+        await manager._test_waitForScheduledStart()
+        #expect(manager.statusText == "Voice Wake isn’t supported on Simulator")
     }
 
-    @Test @MainActor func handleRecognitionCallbackDispatchesCommand() async {
+    @Test @MainActor func `handle recognition callback dispatches command`() async throws {
         let manager = VoiceWakeManager()
         manager.triggerWords = ["openclaw"]
         manager.isEnabled = true
 
         actor CaptureBox {
             var value: String?
-            func set(_ next: String) { self.value = next }
+            func set(_ next: String) {
+                self.value = next
+            }
         }
         let capture = CaptureBox()
         manager.configure { cmd in
@@ -48,8 +50,8 @@ import Testing
         }
 
         let transcript = "openclaw hello"
-        let triggerRange = transcript.range(of: "openclaw")!
-        let helloRange = transcript.range(of: "hello")!
+        let triggerRange = try #require(transcript.range(of: "openclaw"))
+        let helloRange = try #require(transcript.range(of: "hello"))
         let segments = [
             WakeWordSegment(text: "openclaw", start: 0.0, duration: 0.2, range: triggerRange),
             WakeWordSegment(text: "hello", start: 0.8, duration: 0.2, range: helloRange),

--- a/apps/ios/Tests/VoiceWakeManagerSuppressionTests.swift
+++ b/apps/ios/Tests/VoiceWakeManagerSuppressionTests.swift
@@ -33,4 +33,40 @@ struct VoiceWakeManagerSuppressionTests {
         #expect(manager.statusText.contains("Voice Wake") == true)
         #expect(manager.isListening == false)
     }
+
+    @Test
+    @MainActor func `external audio resumes in flight Voice Wake start`() async {
+        let manager = VoiceWakeManager()
+        manager.isEnabled = true
+        manager._test_setStartInFlight(true)
+
+        let suspended = manager.suspendForExternalAudioCapture()
+        #expect(suspended == true)
+        #expect(manager.statusText == "Paused")
+
+        manager._test_setStartInFlight(false)
+        manager.resumeAfterExternalAudioCapture(wasSuspended: suspended)
+
+        try? await Task.sleep(nanoseconds: 900_000_000)
+        #expect(manager.statusText.contains("Voice Wake") == true)
+        #expect(manager.isListening == false)
+    }
+
+    @Test
+    @MainActor func `Talk suppression toggle does not leave Voice Wake externally suspended`() async {
+        let manager = VoiceWakeManager()
+        manager.isEnabled = true
+        manager.isListening = true
+
+        manager.setSuppressedByTalk(true)
+        let suspended = manager.suspendForExternalAudioCapture()
+        #expect(suspended == false)
+
+        manager.setSuppressedByTalk(false)
+        manager.resumeAfterExternalAudioCapture(wasSuspended: suspended)
+
+        try? await Task.sleep(nanoseconds: 500_000_000)
+        #expect(manager.statusText.contains("Voice Wake") == true)
+        #expect(manager.isListening == false)
+    }
 }

--- a/apps/ios/Tests/VoiceWakeManagerSuppressionTests.swift
+++ b/apps/ios/Tests/VoiceWakeManagerSuppressionTests.swift
@@ -1,0 +1,36 @@
+import Foundation
+import Testing
+@testable import OpenClaw
+
+@Suite("Voice Wake manager suppression")
+struct VoiceWakeManagerSuppressionTests {
+    @Test
+    @MainActor func `clearing Talk suppression restarts after pending start was canceled`() async {
+        let manager = VoiceWakeManager()
+        manager.isEnabled = true
+        manager.statusText = "Paused"
+
+        manager.setSuppressedByTalk(true)
+        manager.setSuppressedByTalk(false)
+
+        try? await Task.sleep(nanoseconds: 500_000_000)
+        #expect(manager.statusText.contains("Voice Wake") == true)
+        #expect(manager.isListening == false)
+    }
+
+    @Test
+    @MainActor func `external audio resumes pending Voice Wake restart`() async {
+        let manager = VoiceWakeManager()
+        manager.isEnabled = true
+        manager.resumeAfterExternalAudioCapture(wasSuspended: true)
+
+        let suspended = manager.suspendForExternalAudioCapture()
+        #expect(suspended == true)
+
+        manager.resumeAfterExternalAudioCapture(wasSuspended: suspended)
+
+        try? await Task.sleep(nanoseconds: 900_000_000)
+        #expect(manager.statusText.contains("Voice Wake") == true)
+        #expect(manager.isListening == false)
+    }
+}

--- a/apps/ios/Tests/VoiceWakeManagerSuppressionTests.swift
+++ b/apps/ios/Tests/VoiceWakeManagerSuppressionTests.swift
@@ -2,25 +2,25 @@ import Foundation
 import Testing
 @testable import OpenClaw
 
-@Suite("Voice Wake manager suppression")
+@Suite("Voice Wake manager suppression", .serialized)
 struct VoiceWakeManagerSuppressionTests {
     @Test
     @MainActor func `clearing Talk suppression restarts after pending start was canceled`() async {
-        let manager = VoiceWakeManager()
+        let manager = VoiceWakeManager._test_withoutRestartDelays()
         manager.isEnabled = true
         manager.statusText = "Paused"
 
         manager.setSuppressedByTalk(true)
         manager.setSuppressedByTalk(false)
 
-        try? await Task.sleep(nanoseconds: 500_000_000)
-        #expect(manager.statusText.contains("Voice Wake") == true)
+        await manager._test_waitForScheduledStart()
+        #expect(manager.statusText == "Voice Wake isn’t supported on Simulator")
         #expect(manager.isListening == false)
     }
 
     @Test
     @MainActor func `external audio resumes pending Voice Wake restart`() async {
-        let manager = VoiceWakeManager()
+        let manager = VoiceWakeManager._test_withoutRestartDelays()
         manager.isEnabled = true
         manager.resumeAfterExternalAudioCapture(wasSuspended: true)
 
@@ -29,14 +29,14 @@ struct VoiceWakeManagerSuppressionTests {
 
         manager.resumeAfterExternalAudioCapture(wasSuspended: suspended)
 
-        try? await Task.sleep(nanoseconds: 900_000_000)
-        #expect(manager.statusText.contains("Voice Wake") == true)
+        await manager._test_waitForScheduledStart()
+        #expect(manager.statusText == "Voice Wake isn’t supported on Simulator")
         #expect(manager.isListening == false)
     }
 
     @Test
     @MainActor func `external audio resumes in flight Voice Wake start`() async {
-        let manager = VoiceWakeManager()
+        let manager = VoiceWakeManager._test_withoutRestartDelays()
         manager.isEnabled = true
         manager._test_setStartInFlight(true)
 
@@ -47,14 +47,14 @@ struct VoiceWakeManagerSuppressionTests {
         manager._test_setStartInFlight(false)
         manager.resumeAfterExternalAudioCapture(wasSuspended: suspended)
 
-        try? await Task.sleep(nanoseconds: 900_000_000)
-        #expect(manager.statusText.contains("Voice Wake") == true)
+        await manager._test_waitForScheduledStart()
+        #expect(manager.statusText == "Voice Wake isn’t supported on Simulator")
         #expect(manager.isListening == false)
     }
 
     @Test
     @MainActor func `Talk suppression toggle does not leave Voice Wake externally suspended`() async {
-        let manager = VoiceWakeManager()
+        let manager = VoiceWakeManager._test_withoutRestartDelays()
         manager.isEnabled = true
         manager.isListening = true
 
@@ -65,8 +65,8 @@ struct VoiceWakeManagerSuppressionTests {
         manager.setSuppressedByTalk(false)
         manager.resumeAfterExternalAudioCapture(wasSuspended: suspended)
 
-        try? await Task.sleep(nanoseconds: 500_000_000)
-        #expect(manager.statusText.contains("Voice Wake") == true)
+        await manager._test_waitForScheduledStart()
+        #expect(manager.statusText == "Voice Wake isn’t supported on Simulator")
         #expect(manager.isListening == false)
     }
 }

--- a/apps/ios/UITests/OpenClawSnapshotUITests.swift
+++ b/apps/ios/UITests/OpenClawSnapshotUITests.swift
@@ -141,7 +141,9 @@ final class OpenClawSnapshotUITests: XCTestCase {
             self.app?.descendants(matching: .any)["diagnostics-voice-wake-status"])
         XCTAssertTrue(voiceWakeStatus.waitForExistence(timeout: 5))
         let resumed = expectation(
-            for: NSPredicate(format: "value != 'Paused' AND value != 'Off'"),
+            for: NSPredicate(
+                format: "value == %@",
+                "Voice Wake isn’t supported on Simulator"),
             evaluatedWith: voiceWakeStatus)
         wait(for: [resumed], timeout: 5)
 

--- a/apps/ios/UITests/OpenClawSnapshotUITests.swift
+++ b/apps/ios/UITests/OpenClawSnapshotUITests.swift
@@ -92,6 +92,67 @@ final class OpenClawSnapshotUITests: XCTestCase {
         XCTAssertTrue(self.app?.tabBars.buttons["Talk"].isSelected == true)
     }
 
+    func testVoiceWakeResumesAfterTalkModeToggle() throws {
+        try XCTSkipIf(UIDevice.current.userInterfaceIdiom != .phone, "Phone Settings proof only")
+        self.addUIInterruptionMonitor(withDescription: "Microphone and speech permissions") { alert in
+            guard alert.buttons["Allow"].exists else { return false }
+            alert.buttons["Allow"].tap()
+            return true
+        }
+        self.launchApp(for: ScreenshotTarget(
+            initialTab: "settings",
+            initialDestination: "settings",
+            name: "voice-wake-talk-lifecycle"))
+
+        let voiceSettings = try XCTUnwrap(
+            self.app?.buttons.containing(.staticText, identifier: "Voice & Talk").firstMatch)
+        XCTAssertTrue(voiceSettings.waitForExistence(timeout: 8))
+        voiceSettings.tap()
+
+        let voiceWake = try XCTUnwrap(self.app?.switches["Voice Wake"])
+        let talkMode = try XCTUnwrap(self.app?.switches["Talk Mode"])
+        XCTAssertTrue(voiceWake.waitForExistence(timeout: 5))
+        XCTAssertTrue(talkMode.exists)
+
+        if talkMode.value as? String == "1" {
+            talkMode.tap()
+        }
+        if voiceWake.value as? String == "1" {
+            voiceWake.tap()
+        }
+
+        voiceWake.tap()
+        XCTAssertEqual(voiceWake.value as? String, "1")
+        talkMode.tap()
+        XCTAssertEqual(talkMode.value as? String, "1")
+        talkMode.tap()
+        XCTAssertEqual(talkMode.value as? String, "0")
+        XCTAssertEqual(voiceWake.value as? String, "1")
+        XCTAssertEqual(self.app?.state, .runningForeground)
+        self.attachScreenshot(named: "voice-wake-after-talk-resume")
+
+        let voiceNavigationBar = try XCTUnwrap(self.app?.navigationBars["Voice & Talk"])
+        voiceNavigationBar.buttons["BackButton"].tap()
+        let diagnostics = try XCTUnwrap(
+            self.app?.buttons.containing(.staticText, identifier: "Diagnostics").firstMatch)
+        XCTAssertTrue(diagnostics.waitForExistence(timeout: 5))
+        diagnostics.tap()
+        let voiceWakeStatus = try XCTUnwrap(
+            self.app?.descendants(matching: .any)["diagnostics-voice-wake-status"])
+        XCTAssertTrue(voiceWakeStatus.waitForExistence(timeout: 5))
+        let resumed = expectation(
+            for: NSPredicate(format: "value != 'Paused' AND value != 'Off'"),
+            evaluatedWith: voiceWakeStatus)
+        wait(for: [resumed], timeout: 5)
+
+        let diagnosticsNavigationBar = try XCTUnwrap(self.app?.navigationBars["Diagnostics"])
+        diagnosticsNavigationBar.buttons["BackButton"].tap()
+        voiceSettings.tap()
+        XCTAssertTrue(voiceWake.waitForExistence(timeout: 5))
+        voiceWake.tap()
+        XCTAssertEqual(voiceWake.value as? String, "0")
+    }
+
     func testChatComposerStartsCompactAndGrowsWithDraft() throws {
         try XCTSkipIf(UIDevice.current.userInterfaceIdiom != .phone, "Phone composer proof only")
         self.launchApp(for: ScreenshotTarget(
@@ -126,7 +187,8 @@ final class OpenClawSnapshotUITests: XCTestCase {
 
         textField.tap()
         textField.typeText(
-            "Draft a polished launch note that covers the new design, validation, rollout plan, and follow-up details for the team.")
+            "Draft a polished launch note that covers the new design, validation, rollout plan, " +
+                "and follow-up details for the team.")
         let composerGrew = expectation(
             for: NSPredicate { _, _ in textField.frame.height >= compactHeight + 12 },
             evaluatedWith: textField)


### PR DESCRIPTION
Related: #99093

## What Problem This Solves

Fixes an issue where iOS users with Voice Wake enabled could hit a foreground crash after using Talk or other microphone capture, including screen recording with microphone enabled. The observed crashes abort while Voice Wake is reinstalling its microphone tap after another audio path releases capture.

## Why This Change Was Made

Voice Wake restarts now go through one scheduled-start path that cancels stale pending starts, prevents overlapping `start()` attempts, and debounces restarts after external audio capture. External-capture suspension now covers listening, queued, and already in-flight starts so push-to-talk, camera/audio capture, backgrounding, and Talk teardown cannot leave a start racing toward `installTap`.

Talk suppression tears down Voice Wake without marking it as externally suspended, so the existing Talk enable/disable caller sequence can restart Voice Wake normally when Talk is disabled. The manager also rechecks suppression/enabled/external-suspension state before rebuilding the AVAudioEngine pipeline and rejects invalid microphone input formats before installing a tap.

This is intentionally limited to the Voice Wake restart/audio-tap lifecycle; it does not change Talk routing, push, share extension, widget, or watch behavior.

## User Impact

Voice Wake should resume more reliably after Talk, push-to-talk, camera/audio capture, foregrounding, and screen-recording-adjacent audio-session changes instead of racing into a duplicate or invalid mic tap install.

## Evidence

- Physical iPhone crash evidence in #99093: three fresh `EXC_CRASH` / `SIGABRT` reports all point to `VoiceWakeManager.startRecognition()` calling `AVAudioNode.installTap(...)` from Voice Wake restart paths.
- Before-fix crash video is attached on #99093: https://github.com/openclaw/openclaw/issues/99093#issuecomment-4867070232
- Physical iPhone patched-app smoke: 69.48s recording with Voice Wake/Talk active, screen-recording/control-center interaction, repeated Talk activations, and wake-word setting changes completed without crash.
  - Video: https://raw.githubusercontent.com/PollyBot13/openclaw/proof/pr-99093-ios-voicewake-crash/proof/pr-99137/ios-voicewake-talk-stability-after-fix-20260702T1705.mp4
  - Contact sheet: https://raw.githubusercontent.com/PollyBot13/openclaw/proof/pr-99093-ios-voicewake-crash/proof/pr-99137/ios-voicewake-talk-stability-after-fix-20260702T1705-contact-sheet.jpg
  - README: https://raw.githubusercontent.com/PollyBot13/openclaw/proof/pr-99093-ios-voicewake-crash/proof/pr-99137/README.md
  - Video SHA-256: `5bd27b91599f3ec0c2af293159332fa9c8f7ee146907a09847ad8cf5a19d2f9e`; contact sheet SHA-256: `2aff73e9004a3f05d4820b494467452adf4ca1df5cb7a3a4cdd41e2befed4793`.
- `swiftformat --lint --config config/swiftformat apps/ios/Sources/Voice/VoiceWakeManager.swift apps/ios/Tests/VoiceWakeManagerSuppressionTests.swift`
- `swiftlint lint --config config/swiftlint.yml --strict -- apps/ios/Sources/Voice/VoiceWakeManager.swift apps/ios/Tests/VoiceWakeManagerSuppressionTests.swift`
- `git diff --check`
- `pnpm native:i18n:sync && pnpm native:i18n:check`
- `xcodebuild test -project apps/ios/OpenClaw.xcodeproj -scheme OpenClaw -destination 'platform=iOS Simulator,name=iPhone 17,OS=26.5' -only-testing:OpenClawTests/VoiceWakeManagerStateTests -only-testing:OpenClawTests/VoiceWakeManagerSuppressionTests` (7 tests in 2 suites; build graph included share extension, live activity widget, and watch app targets)
- Local Codex review found the same in-flight-start gap that ClawSweeper flagged; fixed here with coverage for pending starts, in-flight starts, and the Talk suppression toggle path. Final local Codex review found no discrete introduced correctness issues in the changed scheduling/suspension logic or adjacent tests.

AI-assisted: yes (Codex)
