### PR TITLE
fix(auto-reply): suppress room-event notice leaks

### DIFF
--- a/src/auto-reply/reply/dispatch-from-config.test.ts
+++ b/src/auto-reply/reply/dispatch-from-config.test.ts
@@ -9904,6 +9904,44 @@ describe("sendPolicy deny — suppress delivery, not processing (#53328)", () =>
     expect(dispatcher.sendFinalReply).not.toHaveBeenCalled();
   });
 
+  it("suppresses fast auto progress for room-event message-tool-only turns", async () => {
+    setNoAbort();
+    sessionStoreMocks.currentEntry = {
+      sessionId: "s1",
+      updatedAt: 0,
+      sendPolicy: "allow",
+    };
+    const dispatcher = createDispatcher();
+    const replyResolver = vi.fn(async (_ctx: MsgContext, opts?: GetReplyOptions) => {
+      await opts?.onToolResult?.({
+        text: "💨Fast: auto-off(75s>=60s)",
+        channelData: { openclawProgressKind: "fast-mode-auto" },
+      });
+      return { text: "NO_REPLY" } satisfies ReplyPayload;
+    });
+    const ctx = buildTestCtx({
+      SessionKey: "test:session",
+      ChatType: "channel",
+      InboundEventKind: "room_event",
+    });
+
+    const result = await dispatchReplyFromConfig({
+      ctx,
+      cfg: emptyConfig,
+      dispatcher,
+      replyResolver,
+      replyOptions: {
+        sourceReplyDeliveryMode: "message_tool_only",
+        suppressDefaultToolProgressMessages: true,
+      },
+    });
+
+    expect(result.queuedFinal).toBe(false);
+    expect(result.sourceReplyDeliveryMode).toBe("message_tool_only");
+    expect(dispatcher.sendToolResult).not.toHaveBeenCalled();
+    expect(dispatcher.sendFinalReply).not.toHaveBeenCalled();
+  });
+
   it("suppresses fast auto progress when sendPolicy is deny", async () => {
     setNoAbort();
     sessionStoreMocks.currentEntry = {

--- a/src/auto-reply/reply/dispatch-from-config.ts
+++ b/src/auto-reply/reply/dispatch-from-config.ts
@@ -2383,6 +2383,11 @@ export async function dispatchReplyFromConfig(
       ctx.InboundEventKind !== "room_event" &&
       !sendPolicyDenied &&
       params.replyOptions?.forceToolResultProgress === true;
+    const shouldDeliverFastModeAutoProgressDespiteSourceSuppression = () =>
+      suppressAutomaticSourceDelivery &&
+      sourceReplyDeliveryMode === "message_tool_only" &&
+      ctx.InboundEventKind !== "room_event" &&
+      !sendPolicyDenied;
     let finalReplyDeliveryStarted = false;
     const hasExecApprovalPayload = (payload: ReplyPayload) => {
       const execApproval =
@@ -3074,8 +3079,7 @@ export async function dispatchReplyFromConfig(
             suppressTyping: typing.suppressTyping,
             onPartialReply: wrapProgressCallback(params.replyOptions?.onPartialReply),
             onReasoningStream: wrapProgressCallback(params.replyOptions?.onReasoningStream),
-            streamReasoningInNonStreamModes:
-              params.replyOptions?.streamReasoningInNonStreamModes,
+            streamReasoningInNonStreamModes: params.replyOptions?.streamReasoningInNonStreamModes,
             onReasoningEnd: wrapProgressCallback(params.replyOptions?.onReasoningEnd),
             onAssistantMessageStart: wrapProgressCallback(
               params.replyOptions?.onAssistantMessageStart,
@@ -3140,6 +3144,9 @@ export async function dispatchReplyFromConfig(
                   return;
                 }
                 const isFastModeAutoProgress = isFastModeAutoProgressPayload(payload);
+                const isFastModeAutoProgressDelivery =
+                  isFastModeAutoProgress &&
+                  shouldDeliverFastModeAutoProgressDespiteSourceSuppression();
                 const isForcedToolProgress =
                   shouldDeliverForcedToolProgressDespiteSourceSuppression();
                 const progressCallbackForwarded = shouldForwardToolResultProgressCallback(
@@ -3164,7 +3171,7 @@ export async function dispatchReplyFromConfig(
                 }
                 if (
                   shouldSuppressProgressDelivery() &&
-                  !isFastModeAutoProgress &&
+                  !isFastModeAutoProgressDelivery &&
                   !isForcedToolProgress
                 ) {
                   return;

--- a/src/auto-reply/reply/followup-runner.test.ts
+++ b/src/auto-reply/reply/followup-runner.test.ts
@@ -843,6 +843,40 @@ describe("createFollowupRunner reply-lane admission", () => {
     );
   });
 
+  it("suppresses preflight compaction failure notices for queued room events", async () => {
+    runPreflightCompactionIfNeededMock.mockRejectedValueOnce(
+      new Error("Preflight compaction required but failed: auth profile mismatch"),
+    );
+    const runner = createFollowupRunner({
+      typing: createMockTypingController(),
+      typingMode: "instant",
+      sessionKey: "main",
+      defaultModel: "anthropic/claude",
+    });
+
+    await runner(
+      createQueuedRun({
+        currentInboundEventKind: "room_event",
+        originatingChannel: "discord",
+        originatingTo: "channel:C1",
+        originatingAccountId: "acct-1",
+        originatingThreadId: "thread-1",
+        originatingChatType: "group",
+        run: {
+          messageProvider: "discord",
+          provider: "anthropic",
+          model: "claude",
+          verboseLevel: "off",
+          sessionKey: "main",
+          sourceReplyDeliveryMode: "message_tool_only",
+        },
+      }),
+    );
+
+    expect(runEmbeddedAgentMock).not.toHaveBeenCalled();
+    expect(routeReplyMock).not.toHaveBeenCalled();
+  });
+
   it("preserves non-compaction preflight failures for queued followup runs", async () => {
     runPreflightCompactionIfNeededMock.mockRejectedValueOnce(new Error("session load failed"));
     const runner = createFollowupRunner({
@@ -1424,6 +1458,7 @@ describe("createFollowupRunner runtime config", () => {
       }),
     );
 
+    expect(runCliAgentMock).toHaveBeenCalledOnce();
     expect(routeReplyMock).toHaveBeenCalledWith(
       expect.objectContaining({
         payload: { text: "persisted CLI followup" },
@@ -2351,6 +2386,179 @@ describe("createFollowupRunner progress forwarding", () => {
         payload: expect.objectContaining({ text: "🛠️ Exec: echo queued-progress" }),
       }),
     );
+  });
+
+  it("keeps queued room-event verbose tool summaries suppressed", async () => {
+    const queued = createQueuedRun({
+      currentInboundEventKind: "room_event",
+      originatingChannel: "discord",
+      originatingTo: "channel:C1",
+      originatingAccountId: "acct-1",
+      originatingThreadId: "thread-1",
+      run: {
+        messageProvider: "discord",
+        sourceReplyDeliveryMode: "message_tool_only",
+        verboseLevel: "on",
+      },
+    });
+
+    runEmbeddedAgentMock.mockImplementationOnce(
+      async (args: {
+        onToolResult?: (payload: { text: string }) => Promise<void>;
+        shouldEmitToolResult?: () => boolean;
+      }) => {
+        expect(args.shouldEmitToolResult?.()).toBe(true);
+        await args.onToolResult?.({ text: "🛠️ Exec: echo ambient-progress" });
+        return { payloads: [], meta: { agentMeta: {} } };
+      },
+    );
+
+    const runner = createFollowupRunner({
+      typing: createMockTypingController(),
+      typingMode: "instant",
+      defaultModel: "claude",
+    });
+
+    await runner(queued);
+
+    expect(routeReplyMock).not.toHaveBeenCalled();
+  });
+
+  it("delivers queued fast auto progress for non-room-event message-tool-only turns", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(1_000);
+    const realAgentEvents = await vi.importActual<typeof import("../../infra/agent-events.js")>(
+      "../../infra/agent-events.js",
+    );
+    const runtimeConfig: OpenClawConfig = {
+      agents: {
+        defaults: {
+          cliBackends: {
+            "claude-cli": { command: "claude" },
+          },
+          models: {
+            "anthropic/claude-opus-4-7": { agentRuntime: { id: "claude-cli" } },
+          },
+        },
+      },
+    };
+    runCliAgentMock.mockImplementationOnce((params: { runId?: string }) => {
+      realAgentEvents.emitAgentEvent({
+        runId: params.runId ?? "run-fast-followup",
+        stream: "tool",
+        data: { phase: "start", name: "bash", toolCallId: "call-1" },
+      });
+      vi.setSystemTime(7_100);
+      realAgentEvents.emitAgentEvent({
+        runId: params.runId ?? "run-fast-followup",
+        stream: "tool",
+        data: { phase: "result", name: "bash", toolCallId: "call-1" },
+      });
+      return { payloads: [], meta: { agentMeta: {} } };
+    });
+    const runner = createFollowupRunner({
+      typing: createMockTypingController(),
+      typingMode: "instant",
+      defaultModel: "anthropic/claude-opus-4-7",
+    });
+
+    await runner(
+      createQueuedRun({
+        currentInboundEventKind: "user_request",
+        originatingChannel: "discord",
+        originatingTo: "channel:C1",
+        originatingAccountId: "acct-1",
+        originatingThreadId: "thread-1",
+        run: {
+          config: runtimeConfig,
+          messageProvider: "discord",
+          provider: "anthropic",
+          model: "claude-opus-4-7",
+          sourceReplyDeliveryMode: "message_tool_only",
+          fastMode: "auto",
+          fastModeOverride: true,
+          fastModeAutoOnSeconds: 5,
+          fastModeAutoOnSecondsOverride: true,
+        },
+      }),
+    );
+
+    expect(routeReplyMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        channel: "discord",
+        to: "channel:C1",
+        accountId: "acct-1",
+        threadId: "thread-1",
+        mirror: false,
+        replyKind: "tool",
+        payload: expect.objectContaining({
+          text: "💨Fast: auto-off(6s>=5s)",
+          channelData: { openclawProgressKind: "fast-mode-auto" },
+        }),
+      }),
+    );
+  });
+
+  it("suppresses queued fast auto progress for room-event message-tool-only turns", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(1_000);
+    const realAgentEvents = await vi.importActual<typeof import("../../infra/agent-events.js")>(
+      "../../infra/agent-events.js",
+    );
+    const runtimeConfig: OpenClawConfig = {
+      agents: {
+        defaults: {
+          cliBackends: {
+            "claude-cli": { command: "claude" },
+          },
+          models: {
+            "anthropic/claude-opus-4-7": { agentRuntime: { id: "claude-cli" } },
+          },
+        },
+      },
+    };
+    runCliAgentMock.mockImplementationOnce((params: { runId?: string }) => {
+      realAgentEvents.emitAgentEvent({
+        runId: params.runId ?? "run-fast-followup",
+        stream: "tool",
+        data: { phase: "start", name: "bash", toolCallId: "call-1" },
+      });
+      vi.setSystemTime(7_100);
+      realAgentEvents.emitAgentEvent({
+        runId: params.runId ?? "run-fast-followup",
+        stream: "tool",
+        data: { phase: "result", name: "bash", toolCallId: "call-1" },
+      });
+      return { payloads: [], meta: { agentMeta: {} } };
+    });
+    const runner = createFollowupRunner({
+      typing: createMockTypingController(),
+      typingMode: "instant",
+      defaultModel: "anthropic/claude-opus-4-7",
+    });
+
+    await runner(
+      createQueuedRun({
+        currentInboundEventKind: "room_event",
+        originatingChannel: "discord",
+        originatingTo: "channel:C1",
+        originatingAccountId: "acct-1",
+        originatingThreadId: "thread-1",
+        run: {
+          config: runtimeConfig,
+          messageProvider: "discord",
+          provider: "anthropic",
+          model: "claude-opus-4-7",
+          sourceReplyDeliveryMode: "message_tool_only",
+          fastMode: "auto",
+          fastModeOverride: true,
+          fastModeAutoOnSeconds: 5,
+          fastModeAutoOnSecondsOverride: true,
+        },
+      }),
+    );
+
+    expect(routeReplyMock).not.toHaveBeenCalled();
   });
 
   it("drains fire-and-forget queued tool progress before final delivery", async () => {
@@ -4091,6 +4299,24 @@ describe("createFollowupRunner messaging delivery and dedupe", () => {
     expectNoBlockReplyText(onBlockReply, "second payload");
   });
 
+  it("suppresses cross-channel route-failure notices for room events", async () => {
+    routeReplyMock.mockResolvedValue({
+      ok: false,
+      error: "forced route failure",
+    });
+    const queued = baseQueuedRun("webchat");
+    queued.currentInboundEventKind = "room_event";
+    queued.originatingChannel = "discord";
+    queued.originatingTo = "channel:C1";
+    const { onBlockReply } = await runMessagingCase({
+      agentResult: { payloads: [{ text: "hello world!" }, { text: "second payload" }] },
+      queued,
+    });
+
+    expect(routeReplyMock).toHaveBeenCalledTimes(2);
+    expect(onBlockReply).not.toHaveBeenCalled();
+  });
+
   it("does not emit cross-channel route-failure notice when a later payload routes", async () => {
     routeReplyMock
       .mockResolvedValueOnce({
@@ -4431,6 +4657,47 @@ describe("createFollowupRunner messaging delivery and dedupe", () => {
       replyToCurrent: true,
       isCompactionNotice: true,
     });
+  });
+
+  it("suppresses queued compaction notices for room events", async () => {
+    runPreflightCompactionIfNeededMock.mockImplementationOnce(
+      async (params: {
+        onCompactionNotice?: (phase: "start" | "end") => Promise<void> | void;
+        sessionEntry?: SessionEntry;
+      }) => {
+        await params.onCompactionNotice?.("start");
+        await params.onCompactionNotice?.("end");
+        return params.sessionEntry;
+      },
+    );
+    runEmbeddedAgentMock.mockResolvedValueOnce({
+      payloads: [],
+      meta: {},
+    });
+    const runner = createFollowupRunner({
+      typing: createMockTypingController(),
+      typingMode: "instant",
+      defaultModel: "openai/gpt-5.5",
+    });
+
+    await runner(
+      createQueuedRun({
+        currentInboundEventKind: "room_event",
+        originatingChannel: "discord",
+        originatingTo: "channel:C1",
+        messageId: "current-msg-1",
+        run: {
+          config: {
+            channels: { discord: { replyToMode: "all" } },
+            agents: { defaults: { compaction: { notifyUser: true } } },
+          },
+          messageProvider: "discord",
+          sourceReplyDeliveryMode: "message_tool_only",
+        },
+      }),
+    );
+
+    expect(routeReplyMock).not.toHaveBeenCalled();
   });
 
   it("routes queued compaction hook messages alongside notifyUser notices (#90185)", async () => {

--- a/src/auto-reply/reply/followup-runner.ts
+++ b/src/auto-reply/reply/followup-runner.ts
@@ -482,6 +482,10 @@ export function createFollowupRunner(params: {
       !routedAnyCrossChannelPayloadToOrigin &&
       opts?.onBlockReply
     ) {
+      if (queued.currentInboundEventKind === "room_event") {
+        logVerbose("followup queue: cross-channel failure notice suppressed for room_event");
+        return;
+      }
       await sendDispatcherPayload({
         text:
           "Follow-up completed, but OpenClaw could not deliver it to the originating " +
@@ -560,6 +564,7 @@ export function createFollowupRunner(params: {
         shouldEmitVerboseProgress() && !shouldSuppressDefaultToolProgressMessages();
       const shouldEmitToolOutputProgress = () =>
         resolveCurrentVerboseLevel() === "full" && !shouldSuppressDefaultToolProgressMessages();
+      const isRoomEventFollowup = () => queued.currentInboundEventKind === "room_event";
       let observedVisibleToolErrorProgress = false;
       const markVisibleToolErrorProgress = () => {
         if (resolveCurrentVerboseLevel() === "on" && shouldEmitToolResultProgress()) {
@@ -653,6 +658,10 @@ export function createFollowupRunner(params: {
           modelId: fallbackModel,
         },
       ) => {
+        if (isRoomEventFollowup()) {
+          logVerbose("followup queue: compaction notice suppressed for room_event");
+          return;
+        }
         const noticePayloads = resolveFollowupDeliveryPayloads({
           cfg: runtimeConfig,
           payloads: [payload],
@@ -719,6 +728,12 @@ export function createFollowupRunner(params: {
           includeDetails: run.verboseLevel === "on" || run.verboseLevel === "full",
         });
         if (preflightCompactionFailureText) {
+          if (isRoomEventFollowup()) {
+            logVerbose(
+              "followup queue: preflight compaction failure notice suppressed for room_event",
+            );
+            return;
+          }
           await sendFollowupPayloads(
             [
               markReplyPayloadForSourceSuppressionDelivery({
@@ -932,6 +947,11 @@ export function createFollowupRunner(params: {
             // summary tracker so both runners deliver identical durable summaries.
             const deliverFollowupToolSummary = (payload: ReplyPayload) =>
               enqueueProgressDelivery(async () => {
+                // room_event turns are ambient; only an explicit message tool call
+                // may post back into the source chat.
+                if (isRoomEventFollowup()) {
+                  return;
+                }
                 if (
                   run.sourceReplyDeliveryMode === "message_tool_only" &&
                   !shouldEmitToolResultProgress()
@@ -1013,6 +1033,11 @@ export function createFollowupRunner(params: {
                       : undefined,
                   onFastModeAutoProgress: async (payload) => {
                     await enqueueProgressDelivery(async () => {
+                      // Mirrors direct dispatch progress suppression: ambient
+                      // room events never get automatic fast-mode notices.
+                      if (isRoomEventFollowup()) {
+                        return;
+                      }
                       await sendFollowupPayloads(
                         [payload],
                         effectiveQueued,

--- a/src/auto-reply/reply/queue.collect.test.ts
+++ b/src/auto-reply/reply/queue.collect.test.ts
@@ -2768,7 +2768,7 @@ describe("followup queue collect routing", () => {
 
     expect(calls).toHaveLength(2);
     expect(calls[0]?.prompt).toContain("[Queue overflow] Dropped 1 message due to cap.");
-    expect(calls[0]?.currentInboundEventKind).toBeUndefined();
+    expect(calls[0]?.currentInboundEventKind).toBe("room_event");
     expect(calls[0]?.currentInboundContext).toBeUndefined();
     expect(calls[0]?.abortSignal).toBeUndefined();
     expect(calls[1]?.prompt).toBe("live ambient");
@@ -2778,6 +2778,50 @@ describe("followup queue collect routing", () => {
     expect(calls[1]?.abortSignal).toBe(controller.signal);
     expect(calls[1]?.queuedLifecycle?.onComplete).toBe(onComplete);
     expect(calls[1]?.deliveryCorrelations?.[0]?.begin).toBe(begin);
+  });
+
+  it("keeps mixed overflow summaries as normal followups", async () => {
+    const key = `test-overflow-summary-mixed-kind-${Date.now()}`;
+    const calls: FollowupRun[] = [];
+    const done = createDeferred<void>();
+    const runFollowup = async (run: FollowupRun) => {
+      calls.push(run);
+      if (calls.length >= 2) {
+        done.resolve();
+      }
+    };
+    const settings: QueueSettings = {
+      mode: "followup",
+      debounceMs: 0,
+      cap: 1,
+      dropPolicy: "summarize",
+    };
+
+    enqueueFollowupRun(
+      key,
+      {
+        ...createRun({ prompt: "dropped ambient" }),
+        currentInboundEventKind: "room_event",
+      },
+      settings,
+    );
+    enqueueFollowupRun(
+      key,
+      {
+        ...createRun({ prompt: "dropped request" }),
+        currentInboundEventKind: "user_request",
+      },
+      settings,
+    );
+    enqueueFollowupRun(key, createRun({ prompt: "live followup" }), settings);
+
+    scheduleFollowupDrain(key, runFollowup);
+    await done.promise;
+
+    expect(calls).toHaveLength(2);
+    expect(calls[0]?.prompt).toContain("[Queue overflow] Dropped 2 messages due to cap.");
+    expect(calls[0]?.currentInboundEventKind).toBeUndefined();
+    expect(calls[1]?.prompt).toBe("live followup");
   });
 
   it("keeps summarized room-event lifecycle until the overflow summary drains", async () => {
@@ -2820,7 +2864,7 @@ describe("followup queue collect routing", () => {
 
     expect(calls).toHaveLength(2);
     expect(calls[0]?.prompt).toContain("[Queue overflow] Dropped 1 message due to cap.");
-    expect(calls[0]?.currentInboundEventKind).toBeUndefined();
+    expect(calls[0]?.currentInboundEventKind).toBe("room_event");
     expect(calls[0]?.currentInboundContext).toBeUndefined();
     expect(calls[0]?.abortSignal).toBeUndefined();
     expect(calls[1]?.prompt).toBe("live followup");
@@ -2872,6 +2916,9 @@ describe("followup queue collect routing", () => {
 
     expect(onComplete).toHaveBeenCalledTimes(1);
     expect(getExistingFollowupQueue(key)?.summarySources).toHaveLength(1);
+    expect(getExistingFollowupQueue(key)?.summarySources[0]?.currentInboundEventKind).toBe(
+      "room_event",
+    );
     expect(getExistingFollowupQueue(key)?.summarySources[0]?.queuedLifecycle).toBeUndefined();
     expect(getExistingFollowupQueue(key)?.summarySources[0]?.currentInboundContext).toBeUndefined();
 
@@ -2881,6 +2928,7 @@ describe("followup queue collect routing", () => {
     expect(calls).toHaveLength(2);
     expect(calls[1]?.prompt).toContain("[Queue overflow] Dropped 1 message due to cap.");
     expect(calls[1]?.prompt).toContain("- dropped ambient");
+    expect(calls[1]?.currentInboundEventKind).toBe("room_event");
     expect(onComplete).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/auto-reply/reply/queue/drain.ts
+++ b/src/auto-reply/reply/queue/drain.ts
@@ -314,6 +314,7 @@ type FollowupQueueSummaryState = {
     count: number;
     source: FollowupRun;
     sourceRefs: WeakSet<FollowupRun>;
+    allRoomEvents: boolean;
   }>;
   evictedSummaryCount: number;
 };
@@ -513,12 +514,23 @@ export function createOverflowSummaryRetrySource(source: FollowupRun): FollowupR
     originatingReplyToId: source.originatingReplyToId,
     originatingReplyToMode: source.originatingReplyToMode,
     originatingChatType: source.originatingChatType,
+    ...(source.currentInboundEventKind === "room_event"
+      ? { currentInboundEventKind: "room_event" }
+      : {}),
     run: source.run,
   };
 }
 
+function resolveOverflowSummaryInboundEventKind(sources: FollowupRun[]): "room_event" | undefined {
+  return sources.length > 0 &&
+    sources.every((source) => source.currentInboundEventKind === "room_event")
+    ? "room_event"
+    : undefined;
+}
+
 async function runSyntheticOverflowSummary(params: {
   source: FollowupRun;
+  sources: FollowupRun[];
   prompt: string;
   runFollowup: (run: FollowupRun) => Promise<void>;
 }): Promise<void> {
@@ -579,6 +591,7 @@ async function runSyntheticOverflowSummary(params: {
     beforeMessageWrite: runAgentHarnessBeforeMessageWriteHook,
     errorContext: "followup overflow summary transcript",
   });
+  const currentInboundEventKind = resolveOverflowSummaryInboundEventKind(params.sources);
   await params.runFollowup({
     prompt: params.prompt,
     transcriptPrompt: params.prompt,
@@ -587,6 +600,7 @@ async function runSyntheticOverflowSummary(params: {
     run: params.source.run,
     enqueuedAt: Date.now(),
     ...resolveOriginRoutingMetadata([params.source]),
+    ...(currentInboundEventKind ? { currentInboundEventKind } : {}),
   });
 }
 
@@ -629,6 +643,7 @@ async function drainElidedOverflowSummary(params: {
     async () => {
       await runSyntheticOverflowSummary({
         source,
+        sources: entry.allRoomEvents ? [entry.source, ...retainedSources] : [],
         prompt,
         runFollowup: params.runFollowup,
       });
@@ -678,6 +693,7 @@ async function drainOverflowSummaryGroup(params: {
   await runQueueSummaryDelivery(params.queue, delivery, async () => {
     await runSyntheticOverflowSummary({
       source,
+      sources: delivery.sources,
       prompt: delivery.prompt,
       runFollowup: params.runFollowup,
     });

--- a/src/auto-reply/reply/queue/enqueue.ts
+++ b/src/auto-reply/reply/queue/enqueue.ts
@@ -145,6 +145,8 @@ export function enqueueFollowupRun(
           lastElision.count += 1;
           lastElision.source = createOverflowSummaryRetrySource(item);
           lastElision.sourceRefs.add(item);
+          lastElision.allRoomEvents =
+            lastElision.allRoomEvents && item.currentInboundEventKind === "room_event";
         } else {
           if (queue.summaryElisions.length >= queue.cap) {
             const evicted = queue.summaryElisions.shift();
@@ -158,6 +160,7 @@ export function enqueueFollowupRun(
             count: 1,
             source: createOverflowSummaryRetrySource(item),
             sourceRefs: new WeakSet([item]),
+            allRoomEvents: item.currentInboundEventKind === "room_event",
           });
         }
         completeFollowupRunLifecycle(item);

--- a/src/auto-reply/reply/queue/state.test.ts
+++ b/src/auto-reply/reply/queue/state.test.ts
@@ -53,6 +53,7 @@ describe("refreshQueuedFollowupSession", () => {
         run: makeRun(),
       },
       sourceRefs: new WeakSet(),
+      allRoomEvents: false,
     });
 
     refreshQueuedFollowupSession({
@@ -136,6 +137,7 @@ describe("getFollowupQueue", () => {
           run: makeRun(),
         },
         sourceRefs: new WeakSet(),
+        allRoomEvents: false,
       });
     }
     queue.evictedSummaryCount = 5;

--- a/src/auto-reply/reply/queue/state.ts
+++ b/src/auto-reply/reply/queue/state.ts
@@ -26,6 +26,7 @@ export type FollowupQueueState = {
     count: number;
     source: FollowupRun;
     sourceRefs: WeakSet<FollowupRun>;
+    allRoomEvents: boolean;
   }>;
   evictedSummaryCount: number;
   lastRun?: FollowupRun["run"];


### PR DESCRIPTION
Part of #99142

## What Problem This Solves

`room_event` (ambient) turns have a strict contract: nothing reaches the source chat unless the agent explicitly calls `message(action=send)`. Five paths violate it, so ambient groups receive unprompted bot output that no instruction can prevent: fast-mode auto notices ("💨Fast: auto-off(...)") bypass suppression on both the direct dispatch path and queued followups; verbose 🛠️ tool summaries deliver from queued room-event followups (while the direct path correctly suppresses them); followup-path compaction/preflight-failure/cross-channel-error notices deliver to the group; and queue-overflow summaries strip the `room_event` kind, turning a burst of ambient chatter into a normal turn with `forceMessageTool` — a direct invitation to respond to messages nobody addressed to the bot.

## Why This Change Was Made

Each fix mirrors the existing correct gate rather than inventing new policy: the fast-mode dispatch bypass now requires `ctx.InboundEventKind !== "room_event"` exactly like the sibling verbose/forced bypasses; the followup paths gate on the queued run's `currentInboundEventKind` with logging consistent with the direct path's suppressed-notice logs; overflow summaries carry `currentInboundEventKind: "room_event"` only when every summarized item was a room event (mixed batches keep current behavior), tracked via an `allRoomEvents` flag on elision entries so the retry source preserves the kind.

## User Impact

Ambient-mode group chats no longer receive fast-mode status lines, tool summaries, compaction warnings, or overflow-triggered replies the agent never chose to send. Non-room-event behavior is unchanged, including the existing "delivers fast auto progress in message-tool-only mode" contract.

## Evidence

- Per-fix regression tests in `dispatch-from-config.test.ts`, `followup-runner.test.ts`, and `queue.collect.test.ts`: room_event variant suppressed, non-room-event variant unchanged; the overflow test's pinned `undefined` kind updated to the new all-room-events contract.
- `node scripts/run-vitest.mjs` over the three touched test files: 382 tests; both tsgo lanes; oxlint clean; repo autoreview clean; combined-tree validation with the two sibling PRs (both tsgo lanes + 16 test files + Linux Testbox gates).
