### PR TITLE
fix(android): preserve split SMS permission grants

### DIFF
--- a/apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt
@@ -1440,10 +1440,10 @@ private fun rememberPermissionState(
         }
       motionGranted = permissions[Manifest.permission.ACTIVITY_RECOGNITION] ?: motionGranted
       smsGranted =
-        mergedSmsPermissionGrantState(
+        mergedRequiredPermissionGrantState(
           permissions = permissions,
-          currentSendSmsGranted = hasPermission(context, Manifest.permission.SEND_SMS),
-          currentReadSmsGranted = hasPermission(context, Manifest.permission.READ_SMS),
+          requiredPermissions = listOf(Manifest.permission.SEND_SMS, Manifest.permission.READ_SMS),
+          currentlyGranted = { permission -> hasPermission(context, permission) },
         )
       callLogGranted = permissions[Manifest.permission.READ_CALL_LOG] ?: callLogGranted
     }
@@ -1515,14 +1515,12 @@ private fun rememberPermissionState(
   )
 }
 
-/** RequestMultiplePermissions only reports launched permissions, so omitted SMS entries fall back per permission. */
-internal fun mergedSmsPermissionGrantState(
+/** RequestMultiplePermissions only reports launched permissions, so omitted entries use current system state. */
+internal fun mergedRequiredPermissionGrantState(
   permissions: Map<String, Boolean>,
-  currentSendSmsGranted: Boolean,
-  currentReadSmsGranted: Boolean,
-): Boolean =
-  (permissions[Manifest.permission.SEND_SMS] ?: currentSendSmsGranted) &&
-    (permissions[Manifest.permission.READ_SMS] ?: currentReadSmsGranted)
+  requiredPermissions: List<String>,
+  currentlyGranted: (String) -> Boolean,
+): Boolean = requiredPermissions.all { permission -> permissions[permission] ?: currentlyGranted(permission) }
 
 private fun hasPermission(
   context: Context,

--- a/apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt
@@ -1440,8 +1440,11 @@ private fun rememberPermissionState(
         }
       motionGranted = permissions[Manifest.permission.ACTIVITY_RECOGNITION] ?: motionGranted
       smsGranted =
-        (permissions[Manifest.permission.SEND_SMS] ?: smsGranted) &&
-        (permissions[Manifest.permission.READ_SMS] ?: smsGranted)
+        mergedSmsPermissionGrantState(
+          permissions = permissions,
+          currentSendSmsGranted = hasPermission(context, Manifest.permission.SEND_SMS),
+          currentReadSmsGranted = hasPermission(context, Manifest.permission.READ_SMS),
+        )
       callLogGranted = permissions[Manifest.permission.READ_CALL_LOG] ?: callLogGranted
     }
 
@@ -1511,6 +1514,15 @@ private fun rememberPermissionState(
     },
   )
 }
+
+/** RequestMultiplePermissions only reports launched permissions, so omitted SMS entries fall back per permission. */
+internal fun mergedSmsPermissionGrantState(
+  permissions: Map<String, Boolean>,
+  currentSendSmsGranted: Boolean,
+  currentReadSmsGranted: Boolean,
+): Boolean =
+  (permissions[Manifest.permission.SEND_SMS] ?: currentSendSmsGranted) &&
+    (permissions[Manifest.permission.READ_SMS] ?: currentReadSmsGranted)
 
 private fun hasPermission(
   context: Context,

--- a/apps/android/app/src/test/java/ai/openclaw/app/ui/OnboardingFlowLogicTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/ui/OnboardingFlowLogicTest.kt
@@ -1,8 +1,8 @@
 package ai.openclaw.app.ui
 
-import android.Manifest
 import ai.openclaw.app.GatewayConnectionProblem
 import ai.openclaw.app.GatewayNodeApprovalState
+import android.Manifest
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.runTest
@@ -62,21 +62,30 @@ class OnboardingFlowLogicTest {
 
   @Test
   fun splitSmsPermissionCallbacksMergePerPermissionGrantState() {
+    val requiredPermissions = listOf(Manifest.permission.SEND_SMS, Manifest.permission.READ_SMS)
     val afterSendOnly =
-      mergedSmsPermissionGrantState(
+      mergedRequiredPermissionGrantState(
         permissions = mapOf(Manifest.permission.SEND_SMS to true),
-        currentSendSmsGranted = false,
-        currentReadSmsGranted = false,
+        requiredPermissions = requiredPermissions,
+        currentlyGranted = { false },
       )
     assertFalse(afterSendOnly)
 
     val afterReadOnly =
-      mergedSmsPermissionGrantState(
+      mergedRequiredPermissionGrantState(
         permissions = mapOf(Manifest.permission.READ_SMS to true),
-        currentSendSmsGranted = true,
-        currentReadSmsGranted = false,
+        requiredPermissions = requiredPermissions,
+        currentlyGranted = { permission -> permission == Manifest.permission.SEND_SMS },
       )
     assertTrue(afterReadOnly)
+
+    val deniedRead =
+      mergedRequiredPermissionGrantState(
+        permissions = mapOf(Manifest.permission.READ_SMS to false),
+        requiredPermissions = requiredPermissions,
+        currentlyGranted = { true },
+      )
+    assertFalse(deniedRead)
   }
 
   @Test

--- a/apps/android/app/src/test/java/ai/openclaw/app/ui/OnboardingFlowLogicTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/ui/OnboardingFlowLogicTest.kt
@@ -1,5 +1,6 @@
 package ai.openclaw.app.ui
 
+import android.Manifest
 import ai.openclaw.app.GatewayConnectionProblem
 import ai.openclaw.app.GatewayNodeApprovalState
 import kotlinx.coroutines.CompletableDeferred
@@ -57,6 +58,25 @@ class OnboardingFlowLogicTest {
   @Test
   fun allowsFinishWhenSuccessfulLegacyNodeListOmitsApprovalState() {
     assertTrue(canFinishOnboarding(isConnected = true, isNodeConnected = true, nodeCapabilityApprovalState = GatewayNodeApprovalState.Unsupported))
+  }
+
+  @Test
+  fun splitSmsPermissionCallbacksMergePerPermissionGrantState() {
+    val afterSendOnly =
+      mergedSmsPermissionGrantState(
+        permissions = mapOf(Manifest.permission.SEND_SMS to true),
+        currentSendSmsGranted = false,
+        currentReadSmsGranted = false,
+      )
+    assertFalse(afterSendOnly)
+
+    val afterReadOnly =
+      mergedSmsPermissionGrantState(
+        permissions = mapOf(Manifest.permission.READ_SMS to true),
+        currentSendSmsGranted = true,
+        currentReadSmsGranted = false,
+      )
+    assertTrue(afterReadOnly)
   }
 
   @Test


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where Android third-party onboarding could keep showing SMS as unauthorized when users granted `SEND_SMS` and `READ_SMS` in separate permission prompts.

## Why This Change Was Made

`ActivityResultContracts.RequestMultiplePermissions` only reports the permissions included in the current launch result. The onboarding callback previously used the aggregate `smsGranted` value as the fallback for each SMS permission, so a callback that only included `READ_SMS` could discard the already-granted `SEND_SMS` state. This change merges SMS callback results against the current per-permission grant state instead.

## User Impact

Users who grant SMS permissions incrementally can complete the third-party onboarding SMS row once both SMS permissions are actually granted. Denied permissions still keep the row unauthorized until the missing permission is granted.

## Evidence

- Dependency contract checked: `androidx.activity:activity` 1.13.0 `RequestMultiplePermissions` maps results from the launched permission list.
- `cd apps/android && ./gradlew :app:testThirdPartyDebugUnitTest --tests ai.openclaw.app.ui.OnboardingFlowLogicTest`
- `cd apps/android && ./gradlew :app:testPlayDebugUnitTest --tests ai.openclaw.app.ui.OnboardingFlowLogicTest`
- `git diff --check`
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base upstream/main --prompt "Scope: Android onboarding SMS permission state merge after rebase to current upstream/main. Review only the one-commit diff for split SEND_SMS/READ_SMS permission callback regressions."`

AI-assisted: yes.