### PR TITLE
fix(telegram): dedupe directive-tag prompt context

### DIFF
--- a/extensions/telegram/src/bot-handlers.runtime.ts
+++ b/extensions/telegram/src/bot-handlers.runtime.ts
@@ -167,26 +167,10 @@ import {
   isTelegramEditTargetMissingError,
   isTelegramMessageHasNoTextError,
 } from "./network-errors.js";
+import { resolvePromptContextTextDedupeKey } from "./prompt-context-dedupe.js";
 import { resolveTelegramPromptMediaPath } from "./prompt-media-path.js";
 import { buildInlineKeyboard } from "./send.js";
 import { buildTelegramSessionTranscriptPromptMessages } from "./session-transcript-context.js";
-
-type TelegramPromptContextMessageForDedupe = {
-  body?: unknown;
-  timestamp_ms?: unknown;
-};
-
-function resolvePromptContextTextDedupeKey(
-  message: TelegramPromptContextMessageForDedupe,
-): string | undefined {
-  if (typeof message.body !== "string" || !message.body.trim()) {
-    return undefined;
-  }
-  if (typeof message.timestamp_ms !== "number" || !Number.isFinite(message.timestamp_ms)) {
-    return undefined;
-  }
-  return `${message.timestamp_ms}:${message.body.trim()}`;
-}
 
 export const registerTelegramHandlers = ({
   cfg,

--- a/extensions/telegram/src/bot-message-dispatch.test.ts
+++ b/extensions/telegram/src/bot-message-dispatch.test.ts
@@ -1653,6 +1653,39 @@ describe("dispatchTelegramMessage draft streaming", () => {
     expect(deliverReplies).not.toHaveBeenCalled();
   });
 
+  it("marks directive-tagged durable finals with the transcript prompt-context timestamp", async () => {
+    const transcriptTimestamp = Date.now() + 1_000;
+    const rawFinalText = "[[reply_to_current]]Final answer";
+    const context = createContext();
+    context.ctxPayload.SessionKey = "agent:default:telegram:direct:123";
+    mockDefaultSessionEntry();
+    readLatestAssistantTextByIdentity.mockResolvedValue({
+      text: rawFinalText,
+      timestamp: transcriptTimestamp,
+    });
+    deliverInboundReplyWithMessageSendContext.mockResolvedValue({
+      status: "handled_visible",
+      delivery: {
+        messageIds: ["2001"],
+        visibleReplySent: true,
+      },
+    });
+    dispatchReplyWithBufferedBlockDispatcher.mockImplementation(async ({ dispatcherOptions }) => {
+      await dispatcherOptions.deliver({ text: rawFinalText }, { kind: "final" });
+      return { queuedFinal: true };
+    });
+
+    await dispatchWithContext({ context, streamMode: "off" });
+
+    const outbound = expectRecordFields(mockCallArg(deliverInboundReplyWithMessageSendContext), {
+      payload: expect.objectContaining({ text: "Final answer" }),
+    });
+    expectRecordFields(expectRecordFields(outbound.payload, {}).channelData, {
+      telegram: { promptContextTimestampMs: transcriptTimestamp },
+    });
+    expect(deliverReplies).not.toHaveBeenCalled();
+  });
+
   it("keeps the Telegram edit cap for non-block previews regardless of chunk config", async () => {
     const draftStream = createDraftStream();
     createTelegramDraftStream.mockReturnValue(draftStream);

--- a/extensions/telegram/src/bot-message-dispatch.ts
+++ b/extensions/telegram/src/bot-message-dispatch.ts
@@ -57,6 +57,7 @@ import {
   appendAssistantMirrorMessageByIdentity,
   readLatestAssistantTextByIdentity,
 } from "openclaw/plugin-sdk/session-transcript-runtime";
+import { stripInlineDirectiveTagsForDelivery } from "openclaw/plugin-sdk/text-chunking";
 import { resolveTelegramConfigReasoningDefault } from "./agent-config.js";
 import { withTelegramApiErrorLogging } from "./api-logging.js";
 import type { TelegramBotDeps } from "./bot-deps.js";
@@ -1499,9 +1500,14 @@ export const dispatchTelegramMessage = async ({
   };
   const resolveCurrentTurnTranscriptFinalText = async (): Promise<string | undefined> =>
     (await resolveCurrentTurnTranscriptFinal())?.text;
+  const normalizePromptContextTimestampText = (text: string): string =>
+    stripInlineDirectiveTagsForDelivery(text).text.trim();
   const resolvePromptContextTimestampMs = async (text: string): Promise<number | undefined> => {
     const final = await resolveCurrentTurnTranscriptFinal();
-    if (final?.text.trim() !== text.trim()) {
+    if (
+      !final ||
+      normalizePromptContextTimestampText(final.text) !== normalizePromptContextTimestampText(text)
+    ) {
       return undefined;
     }
     return final.timestamp;

--- a/extensions/telegram/src/prompt-context-dedupe.test.ts
+++ b/extensions/telegram/src/prompt-context-dedupe.test.ts
@@ -16,6 +16,20 @@ describe("resolvePromptContextTextDedupeKey", () => {
     );
   });
 
+  it("matches inline directive text to Telegram delivery-normalized cache text", () => {
+    expect(
+      resolvePromptContextTextDedupeKey({
+        timestamp_ms: 1_778_474_760_000,
+        body: "hello [[reply_to_current]] world",
+      }),
+    ).toBe(
+      resolvePromptContextTextDedupeKey({
+        timestamp_ms: 1_778_474_760_000,
+        body: "hello world",
+      }),
+    );
+  });
+
   it("keeps timestamp alignment in the dedupe key", () => {
     expect(
       resolvePromptContextTextDedupeKey({

--- a/extensions/telegram/src/prompt-context-dedupe.test.ts
+++ b/extensions/telegram/src/prompt-context-dedupe.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "vitest";
+import { resolvePromptContextTextDedupeKey } from "./prompt-context-dedupe.js";
+
+describe("resolvePromptContextTextDedupeKey", () => {
+  it("matches assistant transcript text to Telegram cache text after stripping directive tags", () => {
+    expect(
+      resolvePromptContextTextDedupeKey({
+        timestamp_ms: 1_778_474_760_000,
+        body: "[[reply_to_current]]Yep - I'm here now.",
+      }),
+    ).toBe(
+      resolvePromptContextTextDedupeKey({
+        timestamp_ms: 1_778_474_760_000,
+        body: "Yep - I'm here now.",
+      }),
+    );
+  });
+
+  it("keeps timestamp alignment in the dedupe key", () => {
+    expect(
+      resolvePromptContextTextDedupeKey({
+        timestamp_ms: 1_778_474_760_000,
+        body: "[[reply_to_current]]Yep - I'm here now.",
+      }),
+    ).not.toBe(
+      resolvePromptContextTextDedupeKey({
+        timestamp_ms: 1_778_474_761_000,
+        body: "Yep - I'm here now.",
+      }),
+    );
+  });
+});

--- a/extensions/telegram/src/prompt-context-dedupe.ts
+++ b/extensions/telegram/src/prompt-context-dedupe.ts
@@ -1,4 +1,4 @@
-import { stripInlineDirectiveTagsForDisplay } from "openclaw/plugin-sdk/text-chunking";
+import { stripInlineDirectiveTagsForDelivery } from "openclaw/plugin-sdk/text-chunking";
 
 export type TelegramPromptContextMessageForDedupe = {
   body?: unknown;
@@ -14,6 +14,6 @@ export function resolvePromptContextTextDedupeKey(
   if (typeof message.timestamp_ms !== "number" || !Number.isFinite(message.timestamp_ms)) {
     return undefined;
   }
-  const visibleBody = stripInlineDirectiveTagsForDisplay(message.body).text.trim();
+  const visibleBody = stripInlineDirectiveTagsForDelivery(message.body).text.trim();
   return visibleBody ? `${message.timestamp_ms}:${visibleBody}` : undefined;
 }

--- a/extensions/telegram/src/prompt-context-dedupe.ts
+++ b/extensions/telegram/src/prompt-context-dedupe.ts
@@ -1,0 +1,19 @@
+import { stripInlineDirectiveTagsForDisplay } from "openclaw/plugin-sdk/text-chunking";
+
+export type TelegramPromptContextMessageForDedupe = {
+  body?: unknown;
+  timestamp_ms?: unknown;
+};
+
+export function resolvePromptContextTextDedupeKey(
+  message: TelegramPromptContextMessageForDedupe,
+): string | undefined {
+  if (typeof message.body !== "string" || !message.body.trim()) {
+    return undefined;
+  }
+  if (typeof message.timestamp_ms !== "number" || !Number.isFinite(message.timestamp_ms)) {
+    return undefined;
+  }
+  const visibleBody = stripInlineDirectiveTagsForDisplay(message.body).text.trim();
+  return visibleBody ? `${message.timestamp_ms}:${visibleBody}` : undefined;
+}


### PR DESCRIPTION
Closes #99117

## What Problem This Solves

Fixes an issue where Telegram direct-chat follow-up turns could include the same assistant reply twice in model-visible conversation context when the session transcript copy still had an inline directive tag such as `[[reply_to_current]]` and the Telegram cache copy had only the displayed reply text.

## Why This Change Was Made

Telegram already dedupes session transcript prompt rows against Telegram cache rows by timestamp and body, but exact body matching misses display-only directive tag differences. This change moves the keying logic into a Telegram-owned helper and strips inline directive tags through the existing public plugin SDK display helper before building the timestamp/body key, while keeping the timestamp in the key so the timestamp-alignment behavior from #98769 stays intact.

## User Impact

Telegram DM users should see cleaner follow-up context: a prior assistant reply that was delivered once is represented once in the next prompt context, instead of appearing as both a synthetic session row and a Telegram cache row.

## Evidence

Post-rebase local proof from `codex/99117-telegram-context-dedupe-proof` at commit `38606236cd8`:

- `node scripts/run-vitest.mjs extensions/telegram/src/prompt-context-dedupe.test.ts -- --reporter=verbose`
  - Passed: 1 file, 2 tests.
- `node scripts/run-vitest.mjs extensions/telegram/src/session-transcript-context.test.ts extensions/telegram/src/bot-message-context.prompt-context.test.ts extensions/telegram/src/bot-message-dispatch.test.ts -- --reporter=verbose`
  - Passed: 3 files, 150 tests.
- `node scripts/run-vitest.mjs extensions/telegram/src/bot.test.ts -- --reporter=verbose -t "direct Telegram media context|direct transcript context|conversation prompt context"`
  - Passed: 1 file, 3 focused tests; 81 skipped by filter.
- `pnpm exec oxfmt --check extensions/telegram/src/bot-handlers.runtime.ts extensions/telegram/src/prompt-context-dedupe.ts extensions/telegram/src/prompt-context-dedupe.test.ts`
  - Passed.
- `node scripts/check-extension-plugin-sdk-boundary.mjs --mode=src-outside-plugin-sdk`
  - Passed.
- `git diff --check origin/main...HEAD`
  - Passed.

Proof gaps:

- Live Telegram Desktop proof was not run from this machine; the local real-user proof path requires repo/Convex credentials that are not present here.
- One Codex autoreview round was attempted as required for draft PR work, but it did not produce review findings because the local autoreview helper could not spawn the configured Homebrew Codex reviewer binary: `ENOENT` under `/opt/homebrew/lib/node_modules/@openai/codex/.../codex`.
