### PR TITLE
fix(config): use Object.hasOwn instead of in operator in restoreOriginalValueOrThrow

### DIFF
--- a/src/config/redact-snapshot.restore.test.ts
+++ b/src/config/redact-snapshot.restore.test.ts
@@ -100,6 +100,16 @@ describe("restoreRedactedValues", () => {
     expect(restoreRedactedValues_orig(incoming, original).ok).toBe(false);
   });
 
+  it.each(["toString", "constructor", "valueOf", "hasOwnProperty"])(
+    "rejects inherited %s values when the original key is missing",
+    (key) => {
+      const hints = { [key]: { sensitive: true } };
+      const result = restoreRedactedValues_orig({ [key]: REDACTED_SENTINEL }, {}, hints);
+
+      expect(result.ok).toBe(false);
+    },
+  );
+
   it("rejects invalid restore inputs", () => {
     const invalidInputs = [null, undefined, "token-value"] as const;
     for (const input of invalidInputs) {

--- a/src/config/redact-snapshot.test.ts
+++ b/src/config/redact-snapshot.test.ts
@@ -3,7 +3,11 @@ import JSON5 from "json5";
 import { describe, expect, it } from "vitest";
 import { redactSnapshotTestHints as mainSchemaHints } from "../../test/helpers/config/redact-snapshot-test-hints.js";
 import { materializeRuntimeConfig } from "./materialize.js";
-import { REDACTED_SENTINEL, redactConfigSnapshot } from "./redact-snapshot.js";
+import {
+  REDACTED_SENTINEL,
+  redactConfigSnapshot,
+  restoreRedactedValues as restoreRedactedRaw,
+} from "./redact-snapshot.js";
 import {
   makeSnapshot,
   restoreRedactedValues,
@@ -1377,5 +1381,16 @@ describe("redactConfigSnapshot", () => {
       "https://alice:secret@chrome.prod.example.com",
     );
     expect(restored.browser.profiles.local.cdpUrl).toBe("ws://localhost:9222");
+  });
+
+  it("rejects prototype-named missing keys instead of returning functions", () => {
+    const PROTOTYPE_KEYS = ["toString", "constructor", "valueOf", "hasOwnProperty"];
+    for (const key of PROTOTYPE_KEYS) {
+      const redacted = { [key]: REDACTED_SENTINEL };
+      const original = {};
+      const hints = { [key]: { sensitive: true, label: "test" } };
+      const result = restoreRedactedRaw(redacted, original, hints);
+      expect(result.ok).toBe(false);
+    }
   });
 });

--- a/src/config/redact-snapshot.test.ts
+++ b/src/config/redact-snapshot.test.ts
@@ -3,11 +3,7 @@ import JSON5 from "json5";
 import { describe, expect, it } from "vitest";
 import { redactSnapshotTestHints as mainSchemaHints } from "../../test/helpers/config/redact-snapshot-test-hints.js";
 import { materializeRuntimeConfig } from "./materialize.js";
-import {
-  REDACTED_SENTINEL,
-  redactConfigSnapshot,
-  restoreRedactedValues as restoreRedactedRaw,
-} from "./redact-snapshot.js";
+import { REDACTED_SENTINEL, redactConfigSnapshot } from "./redact-snapshot.js";
 import {
   makeSnapshot,
   restoreRedactedValues,
@@ -1381,16 +1377,5 @@ describe("redactConfigSnapshot", () => {
       "https://alice:secret@chrome.prod.example.com",
     );
     expect(restored.browser.profiles.local.cdpUrl).toBe("ws://localhost:9222");
-  });
-
-  it("rejects prototype-named missing keys instead of returning functions", () => {
-    const PROTOTYPE_KEYS = ["toString", "constructor", "valueOf", "hasOwnProperty"];
-    for (const key of PROTOTYPE_KEYS) {
-      const redacted = { [key]: REDACTED_SENTINEL };
-      const original = {};
-      const hints = { [key]: { sensitive: true, label: "test" } };
-      const result = restoreRedactedRaw(redacted, original, hints);
-      expect(result.ok).toBe(false);
-    }
   });
 });

--- a/src/config/redact-snapshot.ts
+++ b/src/config/redact-snapshot.ts
@@ -538,7 +538,7 @@ function restoreOriginalValueOrThrow(params: {
   path: string;
   original: Record<string, unknown>;
 }): unknown {
-  if (params.key in params.original) {
+  if (Object.hasOwn(params.original, params.key)) {
     return params.original[params.key];
   }
   if (!suppressRestoreWarnings) {


### PR DESCRIPTION
## Summary
Use `Object.hasOwn()` instead of the `in` operator in `restoreOriginalValueOrThrow()` to prevent prototype chain pollution when restoring redacted config values.

## What Problem This Solves
When a config key named after an `Object.prototype` property (e.g., `toString`) is redacted and needs restoration, `restoreOriginalValueOrThrow` uses `key in original` to check if the original value exists. On a plain object without that key, `"toString" in original` returns `true` (matching `Object.prototype.toString`), causing the function to return a **native function** instead of the expected config value.

**Code evidence**: In `src/config/redact-snapshot.ts:541`, `if (params.key in params.original)` traverses the prototype chain. `params.original` is a `Record<string, unknown>` plain object, and `params.key` comes from redacted config paths.

## Root Cause
- The `in` operator checks the entire prototype chain, not just own properties
- `Object.hasOwn()` (ES2022+) correctly checks only own properties
- This is the third fix in the series (after #99129 and #99148)

## Why This Fix
- **Minimal**: 1-line change
- **Consistent**: same `Object.hasOwn` pattern as #99129 and #99148
- **Correct**: prevents prototype functions from being returned as config values

## Evidence
- **Before**: `restoreRedactedValues({toString: REDACTED}, {}, hints)` returns ok=true with a **function** value
- **After**: correctly returns ok=false with a proper error

## Real Behavior Proof

### Before (on main)
```bash
$ node --import tsx proof.mjs
FAIL: restoreRedactedValues returned ok=true
  restored value type: function
  got FUNCTION from prototype
PASS: normal key restoration still works
SOME FAILED
```

### After (with fix)
```bash
$ node --import tsx proof.mjs
PASS: restoreRedactedValues correctly rejected missing toString key
  error: Sentinel value "__OPENCLAW_REDACTED__" in key toString is not valid as real data
PASS: normal key restoration still works
ALL PASS
```

## Tests and Validation
- Regression test added to existing `src/config/redact-snapshot.test.ts` covering 4 prototype keys
- Normal key restoration: unaffected
- Diff: 1 line changed in source + regression test
