### PR TITLE
fix: clean up Android camera clips on cancellation

### DIFF
--- a/apps/android/app/src/main/java/ai/openclaw/app/node/CameraCaptureManager.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/node/CameraCaptureManager.kt
@@ -21,7 +21,6 @@ import androidx.camera.video.FileOutputOptions
 import androidx.camera.video.Quality
 import androidx.camera.video.QualitySelector
 import androidx.camera.video.Recorder
-import androidx.camera.video.Recording
 import androidx.camera.video.VideoCapture
 import androidx.camera.video.VideoRecordEvent
 import androidx.core.content.ContextCompat
@@ -44,23 +43,51 @@ import kotlin.math.roundToInt
 /**
  * CameraX-backed capture service used by gateway camera commands.
  */
-internal fun cleanupCameraClipSession(
-  recordingStopNeeded: Boolean,
-  stopRecording: () -> Unit,
-  cameraBound: Boolean,
-  unbindCamera: () -> Unit,
-  temporaryFile: File?,
-  callerOwnsFile: Boolean,
-  deleteTemporaryFile: (File) -> Unit,
-) {
-  if (recordingStopNeeded) {
-    runCatching { stopRecording() }
+internal class CameraClipSession(
+  private val unbind: () -> Unit,
+  private val deleteTemporaryFile: (File) -> Unit,
+) : AutoCloseable {
+  private var recording: AutoCloseable? = null
+  private var temporaryFile: File? = null
+  private var closed = false
+
+  fun ownRecording(recording: AutoCloseable) {
+    check(!closed) { "camera clip session is closed" }
+    this.recording = recording
   }
-  if (cameraBound) {
-    runCatching { unbindCamera() }
+
+  fun ownFile(file: File): File {
+    check(!closed) { "camera clip session is closed" }
+    check(temporaryFile == null) { "camera clip session already owns a file" }
+    temporaryFile = file
+    return file
   }
-  if (!callerOwnsFile && temporaryFile != null) {
-    runCatching { deleteTemporaryFile(temporaryFile) }
+
+  fun transferFile(): File {
+    check(!closed) { "camera clip session is closed" }
+    return checkNotNull(temporaryFile) { "camera clip session has no file" }
+      .also { temporaryFile = null }
+  }
+
+  override fun close() {
+    if (closed) return
+    closed = true
+
+    var failure: Throwable? = null
+
+    fun cleanup(action: () -> Unit) {
+      try {
+        action()
+      } catch (err: Throwable) {
+        failure?.addSuppressed(err) ?: run { failure = err }
+      }
+    }
+
+    // Keep teardown symmetric across bind, warmup, recording, finalize, and success exits.
+    cleanup { recording?.close() }
+    cleanup(unbind)
+    temporaryFile?.let { file -> cleanup { deleteTemporaryFile(file) } }
+    failure?.let { throw it }
   }
 }
 
@@ -255,40 +282,38 @@ class CameraCaptureManager(
         androidx.camera.core.Preview
           .Builder()
           .build()
-      // Provide a dummy SurfaceTexture so the preview pipeline activates
-      val surfaceTexture = android.graphics.SurfaceTexture(0)
-      surfaceTexture.setDefaultBufferSize(640, 480)
+      // Allocate the dummy preview surface only after CameraX requests it; its result owns release.
       preview.setSurfaceProvider { request ->
+        val surfaceTexture = android.graphics.SurfaceTexture(0)
+        surfaceTexture.setDefaultBufferSize(640, 480)
         val surface = android.view.Surface(surfaceTexture)
-        request.provideSurface(surface, context.mainExecutor()) { result ->
+        request.provideSurface(surface, context.mainExecutor()) {
           surface.release()
           surfaceTexture.release()
         }
       }
 
       provider.unbindAll()
-      var cameraBound = false
-      var recording: Recording? = null
-      var recordingStopRequested = false
-      var file: File? = null
-      var callerOwnsFile = false
-      try {
+      CameraClipSession(
+        unbind = { provider.unbind(preview, videoCapture) },
+        deleteTemporaryFile = { file ->
+          check(!file.exists() || file.delete()) { "failed to delete temporary camera clip" }
+        },
+      ).use { session ->
         android.util.Log.w("CameraCaptureManager", "clip: binding preview + videoCapture to lifecycle")
         val camera = provider.bindToLifecycle(owner, selector, preview, videoCapture)
-        cameraBound = true
         android.util.Log.w("CameraCaptureManager", "clip: bound, cameraInfo=${camera.cameraInfo}")
 
         // Give camera pipeline time to initialize before recording
         android.util.Log.w("CameraCaptureManager", "clip: warming up camera 1.5s...")
         kotlinx.coroutines.delay(1_500)
 
-        val clipFile = File.createTempFile("openclaw-clip-", ".mp4", context.cacheDir)
-        file = clipFile
+        val clipFile = session.ownFile(File.createTempFile("openclaw-clip-", ".mp4", context.cacheDir))
         val outputOptions = FileOutputOptions.Builder(clipFile).build()
 
         val finalized = kotlinx.coroutines.CompletableDeferred<VideoRecordEvent.Finalize>()
         android.util.Log.w("CameraCaptureManager", "clip: starting recording to ${clipFile.absolutePath}")
-        recording =
+        val recording =
           videoCapture.output
             .prepareRecording(context, outputOptions)
             .apply {
@@ -306,22 +331,18 @@ class CameraCaptureManager(
                 finalized.complete(event)
               }
             }
+        session.ownRecording(recording)
 
         android.util.Log.w("CameraCaptureManager", "clip: recording started, delaying ${durationMs}ms")
-        try {
-          kotlinx.coroutines.delay(durationMs.toLong())
-        } finally {
-          android.util.Log.w("CameraCaptureManager", "clip: stopping recording")
-          recording.stop()
-          recordingStopRequested = true
-        }
+        kotlinx.coroutines.delay(durationMs.toLong())
+        android.util.Log.w("CameraCaptureManager", "clip: stopping recording")
+        recording.close()
 
         val finalizeEvent =
           try {
             withTimeout(15_000) { finalized.await() }
           } catch (err: kotlinx.coroutines.TimeoutCancellationException) {
             android.util.Log.e("CameraCaptureManager", "clip: finalize timed out", err)
-            withContext(Dispatchers.IO) { clipFile.delete() }
             throw IllegalStateException("UNAVAILABLE: camera clip finalize timed out")
           }
         if (finalizeEvent.hasError()) {
@@ -333,24 +354,16 @@ class CameraCaptureManager(
           // Check file size for debugging
           val fileSize = withContext(Dispatchers.IO) { if (clipFile.exists()) clipFile.length() else -1 }
           android.util.Log.e("CameraCaptureManager", "clip: file exists=${clipFile.exists()} size=$fileSize")
-          withContext(Dispatchers.IO) { clipFile.delete() }
           throw IllegalStateException("UNAVAILABLE: camera clip failed (error=${finalizeEvent.error})")
         }
 
         val fileSize = withContext(Dispatchers.IO) { clipFile.length() }
         android.util.Log.w("CameraCaptureManager", "clip: SUCCESS file size=$fileSize")
 
-        callerOwnsFile = true
-        FilePayload(file = clipFile, durationMs = durationMs.toLong(), hasAudio = includeAudio)
-      } finally {
-        cleanupCameraClipSession(
-          recordingStopNeeded = recording != null && !recordingStopRequested,
-          stopRecording = { recording?.stop() },
-          cameraBound = cameraBound,
-          unbindCamera = { provider.unbindAll() },
-          temporaryFile = file,
-          callerOwnsFile = callerOwnsFile,
-          deleteTemporaryFile = { it.delete() },
+        FilePayload(
+          file = session.transferFile(),
+          durationMs = durationMs.toLong(),
+          hasAudio = includeAudio,
         )
       }
     }

--- a/apps/android/app/src/main/java/ai/openclaw/app/node/CameraCaptureManager.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/node/CameraCaptureManager.kt
@@ -44,6 +44,26 @@ import kotlin.math.roundToInt
 /**
  * CameraX-backed capture service used by gateway camera commands.
  */
+internal fun cleanupCameraClipSession(
+  recordingStopNeeded: Boolean,
+  stopRecording: () -> Unit,
+  cameraBound: Boolean,
+  unbindCamera: () -> Unit,
+  temporaryFile: File?,
+  callerOwnsFile: Boolean,
+  deleteTemporaryFile: (File) -> Unit,
+) {
+  if (recordingStopNeeded) {
+    runCatching { stopRecording() }
+  }
+  if (cameraBound) {
+    runCatching { unbindCamera() }
+  }
+  if (!callerOwnsFile && temporaryFile != null) {
+    runCatching { deleteTemporaryFile(temporaryFile) }
+  }
+}
+
 class CameraCaptureManager(
   private val context: Context,
 ) {
@@ -247,75 +267,92 @@ class CameraCaptureManager(
       }
 
       provider.unbindAll()
-      android.util.Log.w("CameraCaptureManager", "clip: binding preview + videoCapture to lifecycle")
-      val camera = provider.bindToLifecycle(owner, selector, preview, videoCapture)
-      android.util.Log.w("CameraCaptureManager", "clip: bound, cameraInfo=${camera.cameraInfo}")
-
-      // Give camera pipeline time to initialize before recording
-      android.util.Log.w("CameraCaptureManager", "clip: warming up camera 1.5s...")
-      kotlinx.coroutines.delay(1_500)
-
-      val file = File.createTempFile("openclaw-clip-", ".mp4", context.cacheDir)
-      val outputOptions = FileOutputOptions.Builder(file).build()
-
-      val finalized = kotlinx.coroutines.CompletableDeferred<VideoRecordEvent.Finalize>()
-      android.util.Log.w("CameraCaptureManager", "clip: starting recording to ${file.absolutePath}")
-      val recording: Recording =
-        videoCapture.output
-          .prepareRecording(context, outputOptions)
-          .apply {
-            if (includeAudio) withAudioEnabled()
-          }.start(context.mainExecutor()) { event ->
-            android.util.Log.w("CameraCaptureManager", "clip: event ${event.javaClass.simpleName}")
-            if (event is VideoRecordEvent.Status) {
-              android.util.Log.w("CameraCaptureManager", "clip: recording status update")
-            }
-            if (event is VideoRecordEvent.Finalize) {
-              android.util.Log.w(
-                "CameraCaptureManager",
-                "clip: finalize hasError=${event.hasError()} error=${event.error} cause=${event.cause}",
-              )
-              finalized.complete(event)
-            }
-          }
-
-      android.util.Log.w("CameraCaptureManager", "clip: recording started, delaying ${durationMs}ms")
+      var cameraBound = false
+      var recording: Recording? = null
+      var recordingStopRequested = false
+      var file: File? = null
+      var callerOwnsFile = false
       try {
-        kotlinx.coroutines.delay(durationMs.toLong())
-      } finally {
-        android.util.Log.w("CameraCaptureManager", "clip: stopping recording")
-        recording.stop()
-      }
+        android.util.Log.w("CameraCaptureManager", "clip: binding preview + videoCapture to lifecycle")
+        val camera = provider.bindToLifecycle(owner, selector, preview, videoCapture)
+        cameraBound = true
+        android.util.Log.w("CameraCaptureManager", "clip: bound, cameraInfo=${camera.cameraInfo}")
 
-      val finalizeEvent =
+        // Give camera pipeline time to initialize before recording
+        android.util.Log.w("CameraCaptureManager", "clip: warming up camera 1.5s...")
+        kotlinx.coroutines.delay(1_500)
+
+        val clipFile = File.createTempFile("openclaw-clip-", ".mp4", context.cacheDir)
+        file = clipFile
+        val outputOptions = FileOutputOptions.Builder(clipFile).build()
+
+        val finalized = kotlinx.coroutines.CompletableDeferred<VideoRecordEvent.Finalize>()
+        android.util.Log.w("CameraCaptureManager", "clip: starting recording to ${clipFile.absolutePath}")
+        recording =
+          videoCapture.output
+            .prepareRecording(context, outputOptions)
+            .apply {
+              if (includeAudio) withAudioEnabled()
+            }.start(context.mainExecutor()) { event ->
+              android.util.Log.w("CameraCaptureManager", "clip: event ${event.javaClass.simpleName}")
+              if (event is VideoRecordEvent.Status) {
+                android.util.Log.w("CameraCaptureManager", "clip: recording status update")
+              }
+              if (event is VideoRecordEvent.Finalize) {
+                android.util.Log.w(
+                  "CameraCaptureManager",
+                  "clip: finalize hasError=${event.hasError()} error=${event.error} cause=${event.cause}",
+                )
+                finalized.complete(event)
+              }
+            }
+
+        android.util.Log.w("CameraCaptureManager", "clip: recording started, delaying ${durationMs}ms")
         try {
-          withTimeout(15_000) { finalized.await() }
-        } catch (err: Throwable) {
-          android.util.Log.e("CameraCaptureManager", "clip: finalize timed out", err)
-          withContext(Dispatchers.IO) { file.delete() }
-          provider.unbindAll()
-          throw IllegalStateException("UNAVAILABLE: camera clip finalize timed out")
+          kotlinx.coroutines.delay(durationMs.toLong())
+        } finally {
+          android.util.Log.w("CameraCaptureManager", "clip: stopping recording")
+          recording.stop()
+          recordingStopRequested = true
         }
-      if (finalizeEvent.hasError()) {
-        android.util.Log.e(
-          "CameraCaptureManager",
-          "clip: FAILED error=${finalizeEvent.error}, cause=${finalizeEvent.cause}",
-          finalizeEvent.cause,
+
+        val finalizeEvent =
+          try {
+            withTimeout(15_000) { finalized.await() }
+          } catch (err: kotlinx.coroutines.TimeoutCancellationException) {
+            android.util.Log.e("CameraCaptureManager", "clip: finalize timed out", err)
+            withContext(Dispatchers.IO) { clipFile.delete() }
+            throw IllegalStateException("UNAVAILABLE: camera clip finalize timed out")
+          }
+        if (finalizeEvent.hasError()) {
+          android.util.Log.e(
+            "CameraCaptureManager",
+            "clip: FAILED error=${finalizeEvent.error}, cause=${finalizeEvent.cause}",
+            finalizeEvent.cause,
+          )
+          // Check file size for debugging
+          val fileSize = withContext(Dispatchers.IO) { if (clipFile.exists()) clipFile.length() else -1 }
+          android.util.Log.e("CameraCaptureManager", "clip: file exists=${clipFile.exists()} size=$fileSize")
+          withContext(Dispatchers.IO) { clipFile.delete() }
+          throw IllegalStateException("UNAVAILABLE: camera clip failed (error=${finalizeEvent.error})")
+        }
+
+        val fileSize = withContext(Dispatchers.IO) { clipFile.length() }
+        android.util.Log.w("CameraCaptureManager", "clip: SUCCESS file size=$fileSize")
+
+        callerOwnsFile = true
+        FilePayload(file = clipFile, durationMs = durationMs.toLong(), hasAudio = includeAudio)
+      } finally {
+        cleanupCameraClipSession(
+          recordingStopNeeded = recording != null && !recordingStopRequested,
+          stopRecording = { recording?.stop() },
+          cameraBound = cameraBound,
+          unbindCamera = { provider.unbindAll() },
+          temporaryFile = file,
+          callerOwnsFile = callerOwnsFile,
+          deleteTemporaryFile = { it.delete() },
         )
-        // Check file size for debugging
-        val fileSize = withContext(Dispatchers.IO) { if (file.exists()) file.length() else -1 }
-        android.util.Log.e("CameraCaptureManager", "clip: file exists=${file.exists()} size=$fileSize")
-        withContext(Dispatchers.IO) { file.delete() }
-        provider.unbindAll()
-        throw IllegalStateException("UNAVAILABLE: camera clip failed (error=${finalizeEvent.error})")
       }
-
-      val fileSize = withContext(Dispatchers.IO) { file.length() }
-      android.util.Log.w("CameraCaptureManager", "clip: SUCCESS file size=$fileSize")
-
-      provider.unbindAll()
-
-      FilePayload(file = file, durationMs = durationMs.toLong(), hasAudio = includeAudio)
     }
 
   private fun rotateBitmapByExif(

--- a/apps/android/app/src/test/java/ai/openclaw/app/node/CameraHandlerTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/node/CameraHandlerTest.kt
@@ -2,8 +2,10 @@ package ai.openclaw.app.node
 
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
+import org.junit.Assert.assertSame
 import org.junit.Assert.assertTrue
 import org.junit.Test
+import java.io.File
 
 class CameraHandlerTest {
   @Test
@@ -21,5 +23,56 @@ class CameraHandlerTest {
   @Test
   fun cameraClipMaxRawBytes_matchesExpectedBudget() {
     assertEquals(18L * 1024L * 1024L, CAMERA_CLIP_MAX_RAW_BYTES)
+  }
+
+  @Test
+  fun cleanupCameraClipSession_stopsRecordingUnbindsCameraAndDeletesOwnedFile() {
+    val tempFile = File.createTempFile("openclaw-clip-test-", ".mp4")
+    var stopped = false
+    var unbound = false
+    var deletedFile: File? = null
+
+    cleanupCameraClipSession(
+      recordingStopNeeded = true,
+      stopRecording = { stopped = true },
+      cameraBound = true,
+      unbindCamera = { unbound = true },
+      temporaryFile = tempFile,
+      callerOwnsFile = false,
+      deleteTemporaryFile = {
+        deletedFile = it
+        it.delete()
+      },
+    )
+
+    assertTrue(stopped)
+    assertTrue(unbound)
+    assertSame(tempFile, deletedFile)
+    assertFalse(tempFile.exists())
+  }
+
+  @Test
+  fun cleanupCameraClipSession_keepsFileReturnedToCallerAndSkipsAlreadyStoppedRecording() {
+    val tempFile = File.createTempFile("openclaw-clip-test-", ".mp4")
+    try {
+      var stopped = false
+      var unbound = false
+
+      cleanupCameraClipSession(
+        recordingStopNeeded = false,
+        stopRecording = { stopped = true },
+        cameraBound = true,
+        unbindCamera = { unbound = true },
+        temporaryFile = tempFile,
+        callerOwnsFile = true,
+        deleteTemporaryFile = { it.delete() },
+      )
+
+      assertFalse(stopped)
+      assertTrue(unbound)
+      assertTrue(tempFile.exists())
+    } finally {
+      tempFile.delete()
+    }
   }
 }

--- a/apps/android/app/src/test/java/ai/openclaw/app/node/CameraHandlerTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/node/CameraHandlerTest.kt
@@ -26,50 +26,57 @@ class CameraHandlerTest {
   }
 
   @Test
-  fun cleanupCameraClipSession_stopsRecordingUnbindsCameraAndDeletesOwnedFile() {
+  fun cameraClipSession_closesRecordingUnbindsAndDeletesOwnedFile() {
     val tempFile = File.createTempFile("openclaw-clip-test-", ".mp4")
-    var stopped = false
-    var unbound = false
-    var deletedFile: File? = null
+    val cleanup = mutableListOf<String>()
+    val session =
+      CameraClipSession(
+        unbind = { cleanup += "unbind" },
+        deleteTemporaryFile = { file ->
+          cleanup += "file"
+          assertSame(tempFile, file)
+          file.delete()
+        },
+      )
+    session.ownRecording(AutoCloseable { cleanup += "recording" })
+    session.ownFile(tempFile)
 
-    cleanupCameraClipSession(
-      recordingStopNeeded = true,
-      stopRecording = { stopped = true },
-      cameraBound = true,
-      unbindCamera = { unbound = true },
-      temporaryFile = tempFile,
-      callerOwnsFile = false,
-      deleteTemporaryFile = {
-        deletedFile = it
-        it.delete()
-      },
-    )
+    session.close()
+    session.close()
 
-    assertTrue(stopped)
-    assertTrue(unbound)
-    assertSame(tempFile, deletedFile)
+    assertEquals(listOf("recording", "unbind", "file"), cleanup)
     assertFalse(tempFile.exists())
   }
 
   @Test
-  fun cleanupCameraClipSession_keepsFileReturnedToCallerAndSkipsAlreadyStoppedRecording() {
+  fun cameraClipSession_unbindsBeforeRecordingStarts() {
+    val cleanup = mutableListOf<String>()
+
+    CameraClipSession(
+      unbind = { cleanup += "unbind" },
+      deleteTemporaryFile = { cleanup += "file" },
+    ).close()
+
+    assertEquals(listOf("unbind"), cleanup)
+  }
+
+  @Test
+  fun cameraClipSession_keepsFileTransferredToCaller() {
     val tempFile = File.createTempFile("openclaw-clip-test-", ".mp4")
     try {
-      var stopped = false
-      var unbound = false
+      val cleanup = mutableListOf<String>()
+      val session =
+        CameraClipSession(
+          unbind = { cleanup += "unbind" },
+          deleteTemporaryFile = { cleanup += "file" },
+        )
+      session.ownRecording(AutoCloseable { cleanup += "recording" })
+      session.ownFile(tempFile)
 
-      cleanupCameraClipSession(
-        recordingStopNeeded = false,
-        stopRecording = { stopped = true },
-        cameraBound = true,
-        unbindCamera = { unbound = true },
-        temporaryFile = tempFile,
-        callerOwnsFile = true,
-        deleteTemporaryFile = { it.delete() },
-      )
+      assertSame(tempFile, session.transferFile())
+      session.close()
 
-      assertFalse(stopped)
-      assertTrue(unbound)
+      assertEquals(listOf("recording", "unbind"), cleanup)
       assertTrue(tempFile.exists())
     } finally {
       tempFile.delete()


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where Android users running `camera.clip` could leave CameraX video use cases bound when the clip coroutine was cancelled or failed after binding the preview/video pipeline.

The affected workflow is remote camera video capture through the Android node app. A cancellation during warmup, recording delay, or finalization could skip the later success/error `unbindAll()` calls, leaving the camera session/resources active until another camera operation or lifecycle transition cleaned them up.

## Why This Change Was Made

The clip capture path now tracks the bound CameraX session, active `Recording`, and temporary MP4 ownership in one cleanup scope. A single `finally` path stops any still-active recording, unbinds the CameraX use cases, and deletes manager-owned temporary files while preserving successful clip files for `CameraHandler` to encode and delete.

The finalize wait now distinguishes the 15 second finalize timeout from coroutine cancellation, so cancellation can propagate while still running the same cleanup path.

## User Impact

Android camera clip requests no longer risk leaving the camera pipeline bound after interrupted or failed captures. Follow-up camera commands have a cleaner starting state, and cancelled/failed clips are less likely to leave temporary cache files behind.

## Evidence

- `cd apps/android && ./gradlew :app:testThirdPartyDebugUnitTest --tests ai.openclaw.app.node.CameraHandlerTest`
- `cd apps/android && ./gradlew :app:testPlayDebugUnitTest --tests ai.openclaw.app.node.CameraHandlerTest`
- `git diff --check`
- `.agents/skills/autoreview/scripts/autoreview --mode local` -> clean, no accepted/actionable findings

AI-assisted: yes.
