### PR TITLE
fix: stop iOS screen recording after cancellation

### DIFF
--- a/apps/ios/Sources/Screen/ScreenRecordService.swift
+++ b/apps/ios/Sources/Screen/ScreenRecordService.swift
@@ -3,6 +3,9 @@ import OpenClawKit
 import ReplayKit
 
 final class ScreenRecordService: @unchecked Sendable {
+    typealias CaptureHandler = @Sendable (CMSampleBuffer, RPSampleBufferType, Error?) -> Void
+    typealias CaptureCompletion = @Sendable (Error?) -> Void
+
     private struct UncheckedSendableBox<T>: @unchecked Sendable {
         let value: T
     }
@@ -22,6 +25,41 @@ final class ScreenRecordService: @unchecked Sendable {
             defer { lock.unlock() }
             return body(self)
         }
+    }
+
+    private let startReplayKitCaptureAction: @Sendable (
+        Bool,
+        @escaping CaptureHandler,
+        @escaping CaptureCompletion)
+        -> Void
+    private let stopReplayKitCaptureAction: @Sendable (@escaping CaptureCompletion) -> Void
+    private let sleepNanoseconds: @Sendable (UInt64) async throws -> Void
+
+    init(
+        startReplayKitCaptureAction: @escaping @Sendable (
+            Bool,
+            @escaping CaptureHandler,
+            @escaping CaptureCompletion)
+            -> Void = { includeAudio, handler, completion in
+                Task { @MainActor in
+                    startReplayKitCapture(
+                        includeAudio: includeAudio,
+                        handler: handler,
+                        completion: completion)
+                }
+            },
+        stopReplayKitCaptureAction: @escaping @Sendable (@escaping CaptureCompletion) -> Void = { completion in
+            Task { @MainActor in
+                stopReplayKitCapture(completion)
+            }
+        },
+        sleepNanoseconds: @escaping @Sendable (UInt64) async throws -> Void = { nanoseconds in
+            try await Task.sleep(nanoseconds: nanoseconds)
+        })
+    {
+        self.startReplayKitCaptureAction = startReplayKitCaptureAction
+        self.stopReplayKitCaptureAction = stopReplayKitCaptureAction
+        self.sleepNanoseconds = sleepNanoseconds
     }
 
     enum ScreenRecordError: LocalizedError {
@@ -59,10 +97,19 @@ final class ScreenRecordService: @unchecked Sendable {
         let recordQueue = DispatchQueue(label: "ai.openclawfoundation.app.screenrecord")
 
         try await self.startCapture(state: state, config: config, recordQueue: recordQueue)
-        try await Task.sleep(nanoseconds: UInt64(config.durationMs) * 1_000_000)
-        try await self.stopCapture()
-        try self.finalizeCapture(state: state)
-        try await self.finishWriting(state: state)
+        var captureActive = true
+        do {
+            try await self.sleepNanoseconds(UInt64(config.durationMs) * 1_000_000)
+            try await self.stopCapture()
+            captureActive = false
+            try self.finalizeCapture(state: state)
+            try await self.finishWriting(state: state)
+        } catch {
+            if captureActive {
+                try? await self.stopCapture()
+            }
+            throw error
+        }
 
         return config.outURL.path
     }
@@ -123,12 +170,10 @@ final class ScreenRecordService: @unchecked Sendable {
                 if let error { cont.resume(throwing: error) } else { cont.resume() }
             }
 
-            Task { @MainActor in
-                startReplayKitCapture(
-                    includeAudio: config.includeAudio,
-                    handler: handler,
-                    completion: completion)
-            }
+            self.startReplayKitCaptureAction(
+                config.includeAudio,
+                handler,
+                completion)
         }
     }
 
@@ -277,8 +322,8 @@ final class ScreenRecordService: @unchecked Sendable {
 
     private func stopCapture() async throws {
         let stopError = await withCheckedContinuation { cont in
-            Task { @MainActor in
-                stopReplayKitCapture { error in cont.resume(returning: error) }
+            self.stopReplayKitCaptureAction { error in
+                cont.resume(returning: error)
             }
         }
         if let stopError { throw stopError }

--- a/apps/ios/Sources/Screen/ScreenRecordService.swift
+++ b/apps/ios/Sources/Screen/ScreenRecordService.swift
@@ -33,7 +33,6 @@ final class ScreenRecordService: @unchecked Sendable {
         @escaping CaptureCompletion)
         -> Void
     private let stopReplayKitCaptureAction: @Sendable (@escaping CaptureCompletion) -> Void
-    private let sleepNanoseconds: @Sendable (UInt64) async throws -> Void
 
     init(
         startReplayKitCaptureAction: @escaping @Sendable (
@@ -52,14 +51,10 @@ final class ScreenRecordService: @unchecked Sendable {
             Task { @MainActor in
                 stopReplayKitCapture(completion)
             }
-        },
-        sleepNanoseconds: @escaping @Sendable (UInt64) async throws -> Void = { nanoseconds in
-            try await Task.sleep(nanoseconds: nanoseconds)
         })
     {
         self.startReplayKitCaptureAction = startReplayKitCaptureAction
         self.stopReplayKitCaptureAction = stopReplayKitCaptureAction
-        self.sleepNanoseconds = sleepNanoseconds
     }
 
     enum ScreenRecordError: LocalizedError {
@@ -97,19 +92,15 @@ final class ScreenRecordService: @unchecked Sendable {
         let recordQueue = DispatchQueue(label: "ai.openclawfoundation.app.screenrecord")
 
         try await self.startCapture(state: state, config: config, recordQueue: recordQueue)
-        var captureActive = true
         do {
-            try await self.sleepNanoseconds(UInt64(config.durationMs) * 1_000_000)
-            try await self.stopCapture()
-            captureActive = false
-            try self.finalizeCapture(state: state)
-            try await self.finishWriting(state: state)
+            try await Task.sleep(nanoseconds: UInt64(config.durationMs) * 1_000_000)
         } catch {
-            if captureActive {
-                try? await self.stopCapture()
-            }
+            try? await self.stopCapture()
             throw error
         }
+        try await self.stopCapture()
+        try self.finalizeCapture(state: state)
+        try await self.finishWriting(state: state)
 
         return config.outURL.path
     }

--- a/apps/ios/Tests/ScreenRecordServiceTests.swift
+++ b/apps/ios/Tests/ScreenRecordServiceTests.swift
@@ -18,10 +18,16 @@ private final class ScreenRecordServiceProbe: @unchecked Sendable {
         self.stopCount += 1
         self.lock.unlock()
     }
+
+    func counts() -> (start: Int, stop: Int) {
+        self.lock.lock()
+        defer { self.lock.unlock() }
+        return (self.startCount, self.stopCount)
+    }
 }
 
 @Suite(.serialized) struct ScreenRecordServiceTests {
-    @Test func clampDefaultsAndBounds() {
+    @Test func `clamp defaults and bounds`() {
         #expect(ScreenRecordService._test_clampDurationMs(nil) == 10000)
         #expect(ScreenRecordService._test_clampDurationMs(0) == 250)
         #expect(ScreenRecordService._test_clampDurationMs(60001) == 60000)
@@ -32,7 +38,7 @@ private final class ScreenRecordServiceProbe: @unchecked Sendable {
         #expect(ScreenRecordService._test_clampFps(.infinity) == 10)
     }
 
-    @Test @MainActor func recordRejectsInvalidScreenIndex() async {
+    @Test @MainActor func `record rejects invalid screen index`() async {
         let recorder = ScreenRecordService()
         do {
             _ = try await recorder.record(
@@ -49,28 +55,36 @@ private final class ScreenRecordServiceProbe: @unchecked Sendable {
         }
     }
 
-    @Test func recordStopsCaptureWhenSleepIsCancelled() async {
+    @Test func `record stops capture when sleep is cancelled`() async {
         let probe = ScreenRecordServiceProbe()
+        let started = AsyncStream<Void>.makeStream()
         let recorder = ScreenRecordService(
             startReplayKitCaptureAction: { _, _, completion in
                 probe.recordStart()
+                started.continuation.yield()
+                started.continuation.finish()
                 completion(nil)
             },
             stopReplayKitCaptureAction: { completion in
                 probe.recordStop()
                 completion(nil)
-            },
-            sleepNanoseconds: { _ in
-                throw CancellationError()
             })
 
-        do {
-            _ = try await recorder.record(
+        let recordingTask = Task {
+            try await recorder.record(
                 screenIndex: nil,
-                durationMs: 250,
+                durationMs: 60000,
                 fps: 5,
                 includeAudio: false,
                 outPath: nil)
+        }
+        for await _ in started.stream {
+            break
+        }
+        recordingTask.cancel()
+
+        do {
+            _ = try await recordingTask.value
             Issue.record("Expected cancellation to throw")
         } catch is CancellationError {
             // Expected; cleanup should stop ReplayKit before preserving cancellation.
@@ -78,7 +92,8 @@ private final class ScreenRecordServiceProbe: @unchecked Sendable {
             Issue.record("Unexpected error type: \(error)")
         }
 
-        #expect(probe.startCount == 1)
-        #expect(probe.stopCount == 1)
+        let counts = probe.counts()
+        #expect(counts.start == 1)
+        #expect(counts.stop == 1)
     }
 }

--- a/apps/ios/Tests/ScreenRecordServiceTests.swift
+++ b/apps/ios/Tests/ScreenRecordServiceTests.swift
@@ -1,5 +1,24 @@
+import Foundation
 import Testing
 @testable import OpenClaw
+
+private final class ScreenRecordServiceProbe: @unchecked Sendable {
+    private let lock = NSLock()
+    private(set) var startCount = 0
+    private(set) var stopCount = 0
+
+    func recordStart() {
+        self.lock.lock()
+        self.startCount += 1
+        self.lock.unlock()
+    }
+
+    func recordStop() {
+        self.lock.lock()
+        self.stopCount += 1
+        self.lock.unlock()
+    }
+}
 
 @Suite(.serialized) struct ScreenRecordServiceTests {
     @Test func clampDefaultsAndBounds() {
@@ -28,5 +47,38 @@ import Testing
         } catch {
             Issue.record("Unexpected error type: \(error)")
         }
+    }
+
+    @Test func recordStopsCaptureWhenSleepIsCancelled() async {
+        let probe = ScreenRecordServiceProbe()
+        let recorder = ScreenRecordService(
+            startReplayKitCaptureAction: { _, _, completion in
+                probe.recordStart()
+                completion(nil)
+            },
+            stopReplayKitCaptureAction: { completion in
+                probe.recordStop()
+                completion(nil)
+            },
+            sleepNanoseconds: { _ in
+                throw CancellationError()
+            })
+
+        do {
+            _ = try await recorder.record(
+                screenIndex: nil,
+                durationMs: 250,
+                fps: 5,
+                includeAudio: false,
+                outPath: nil)
+            Issue.record("Expected cancellation to throw")
+        } catch is CancellationError {
+            // Expected; cleanup should stop ReplayKit before preserving cancellation.
+        } catch {
+            Issue.record("Unexpected error type: \(error)")
+        }
+
+        #expect(probe.startCount == 1)
+        #expect(probe.stopCount == 1)
     }
 }


### PR DESCRIPTION
## What Problem This Solves

The iOS app's `screen.record` tool could leave ReplayKit capture running if the recording task was cancelled or if the delay before stopping the capture failed.

The previous flow started capture, slept for the requested duration, then stopped capture. If cancellation happened during that sleep, control left `record(...)` before `stopCapture()` ran, so ReplayKit could keep capturing after the tool call had already failed.

AI-assisted: yes.

## Why This Change Was Made

This change wraps the active ReplayKit window in cleanup logic. Once capture starts, any error before the normal stop/finalize path now attempts to stop ReplayKit before rethrowing the original error.

I also added narrow injected closures for ReplayKit start/stop and sleep so the cancellation path can be tested without needing a real screen capture session in unit tests. The production defaults still call ReplayKit on the main actor and still use `Task.sleep` for the requested duration.

## User Impact

Users who cancel or interrupt an iOS `screen.record` call should no longer risk leaving the system screen recorder active behind the failed tool call. The success path is unchanged: recording still starts, waits for the requested duration, stops capture, finalizes samples, and writes the video.

## Evidence

- `swiftc -parse apps/ios/Sources/Screen/ScreenRecordService.swift`
- `swiftc -parse apps/ios/Tests/ScreenRecordServiceTests.swift`
- `git diff --check`
- `.agents/skills/autoreview/scripts/autoreview --mode local`
  - Result: `autoreview clean: no accepted/actionable findings reported`

Not run locally: full iOS XCTest via `xcodebuild`. This machine currently only has Command Line Tools selected and no full Xcode/iOS SDK is installed, so `xcodebuild -list -project apps/ios/OpenClaw.xcodeproj` cannot initialize the iOS project locally.
