### PR TITLE
fix: local workflow check rejects tabs

### DIFF
--- a/scripts/check-workflows.mjs
+++ b/scripts/check-workflows.mjs
@@ -3,7 +3,7 @@
 // Uses installed tools when present, otherwise falls back to pinned hooks where
 // possible, then runs repo-specific workflow guards.
 import { spawnSync } from "node:child_process";
-import { mkdtempSync, readdirSync, rmSync } from "node:fs";
+import { mkdtempSync, readFileSync, readdirSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
@@ -93,6 +93,19 @@ function workflowFiles() {
     .map((file) => join(WORKFLOW_DIR, file));
 }
 
+function failOnWorkflowTabs(workflows) {
+  const bad = workflows.filter((file) => readFileSync(file).includes("\t"));
+  if (bad.length === 0) {
+    return;
+  }
+
+  console.error("Tabs found in workflow file(s):");
+  for (const file of bad) {
+    console.error(`- ${file}`);
+  }
+  process.exit(1);
+}
+
 function runPreCommitHook(hook, files) {
   const hookArgs = ["run", "--config", ".pre-commit-config.yaml", hook, "--files", ...files];
   if (commandExists("pre-commit")) {
@@ -114,6 +127,8 @@ function runPreCommitHook(hook, files) {
 }
 
 const workflows = workflowFiles();
+
+failOnWorkflowTabs(workflows);
 
 if (commandExists("actionlint")) {
   run("actionlint", workflows);

--- a/test/scripts/check-workflows.test.ts
+++ b/test/scripts/check-workflows.test.ts
@@ -27,6 +27,31 @@ describe("check-workflows", () => {
     expect(result.stderr).toContain("install actionlint, Go");
   });
 
+  it("fails before external linters when workflow files contain tabs", () => {
+    const tempDir = makeTempDir(tempDirs, "check-workflows-");
+    const binDir = path.join(tempDir, "bin");
+    const workflowDir = path.join(tempDir, ".github", "workflows");
+    mkdirSync(binDir, { recursive: true });
+    mkdirSync(workflowDir, { recursive: true });
+    writeFileSync(path.join(workflowDir, "bad.yml"), "name:\tbad\n");
+    for (const command of ["actionlint", "node", "pre-commit", "python3"]) {
+      writeFileSync(path.join(binDir, command), "#!/bin/sh\nexit 0\n", { mode: 0o755 });
+    }
+
+    const result = spawnSync(process.execPath, [scriptPath], {
+      cwd: tempDir,
+      encoding: "utf8",
+      env: {
+        ...process.env,
+        PATH: binDir,
+      },
+    });
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain("Tabs found in workflow file(s):");
+    expect(result.stderr).toContain(".github/workflows/bad.yml");
+  });
+
   it("uses the pinned go fallback and audits all workflows with zizmor", () => {
     const tempDir = makeTempDir(tempDirs, "check-workflows-");
     const binDir = path.join(tempDir, "bin");


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where developers running `pnpm check:workflows` locally could pass workflow sanity even though the Workflow Sanity CI tab guard would fail on `.github/workflows/*.yml` or `.yaml` files containing tab characters.

## Why This Change Was Made

The local workflow checker now runs the same tab guard before invoking external linters, so tabbed workflow files fail fast with the same actionable diagnostic. The guard reuses the workflow file list already passed to actionlint and zizmor, keeping the check scoped to workflow YAML files.

## User Impact

Developers get the CI failure locally before pushing, which avoids a workflow-sanity round trip for tabbed workflow files. There is no runtime or product behavior change.

## Evidence

- Before: running the upstream `scripts/check-workflows.mjs` against a temp workflow containing `name:\tbad` with fake passing child tools exited `0`.
- After: running this branch against the same temp workflow exits `1` and prints `Tabs found in workflow file(s):` with `.github/workflows/bad.yml`.
- Smoke: current repository workflows pass the new guard with fake child tools standing in for actionlint, zizmor, and the trailing repo checks.
- `node --check scripts/check-workflows.mjs`
- `git diff --check`

Focused Vitest was not run locally because this sparse checkout had no `node_modules`; an external dependency hydration attempt under `/Volumes/STOREJET/2/Dependencies` hit the remaining SSD space limit. The committed test covers the new guard in `test/scripts/check-workflows.test.ts`.
