### PR TITLE
fix: require Android contact and calendar write permissions in onboarding

### DIFF
--- a/apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt
@@ -1370,6 +1370,9 @@ internal fun canFinishOnboarding(
       -> true
     }
 
+private val requiredContactPermissions = listOf(Manifest.permission.READ_CONTACTS, Manifest.permission.WRITE_CONTACTS)
+private val requiredCalendarPermissions = listOf(Manifest.permission.READ_CALENDAR, Manifest.permission.WRITE_CALENDAR)
+
 /** Builds permission rows and applies granted feature toggles after onboarding. */
 @Composable
 private fun rememberPermissionState(
@@ -1383,8 +1386,24 @@ private fun rememberPermissionState(
   }
   val photosPermissions = photoReadPermissionsForRequest()
   var photosGranted by rememberSaveable { mutableStateOf(hasPhotoReadPermission(context)) }
-  var contactsGranted by rememberSaveable { mutableStateOf(hasPermission(context, Manifest.permission.READ_CONTACTS)) }
-  var calendarGranted by rememberSaveable { mutableStateOf(hasPermission(context, Manifest.permission.READ_CALENDAR)) }
+  var contactsGranted by rememberSaveable {
+    mutableStateOf(
+      mergedRequiredPermissionGrantState(
+        permissions = emptyMap(),
+        requiredPermissions = requiredContactPermissions,
+        currentlyGranted = { permission -> hasPermission(context, permission) },
+      ),
+    )
+  }
+  var calendarGranted by rememberSaveable {
+    mutableStateOf(
+      mergedRequiredPermissionGrantState(
+        permissions = emptyMap(),
+        requiredPermissions = requiredCalendarPermissions,
+        currentlyGranted = { permission -> hasPermission(context, permission) },
+      ),
+    )
+  }
   var notificationsGranted by rememberSaveable {
     mutableStateOf(Build.VERSION.SDK_INT < 33 || hasPermission(context, Manifest.permission.POST_NOTIFICATIONS))
   }
@@ -1430,8 +1449,18 @@ private fun rememberPermissionState(
         permissions[Manifest.permission.ACCESS_COARSE_LOCATION] == true ||
         locationGranted
       photosGranted = hasPhotoReadPermission(context) || photosPermissions.any { permissions[it] == true }
-      contactsGranted = permissions[Manifest.permission.READ_CONTACTS] ?: contactsGranted
-      calendarGranted = permissions[Manifest.permission.READ_CALENDAR] ?: calendarGranted
+      contactsGranted =
+        mergedRequiredPermissionGrantState(
+          permissions = permissions,
+          requiredPermissions = requiredContactPermissions,
+          currentlyGranted = { permission -> hasPermission(context, permission) },
+        )
+      calendarGranted =
+        mergedRequiredPermissionGrantState(
+          permissions = permissions,
+          requiredPermissions = requiredCalendarPermissions,
+          currentlyGranted = { permission -> hasPermission(context, permission) },
+        )
       notificationsGranted =
         if (Build.VERSION.SDK_INT >= 33) {
           permissions[Manifest.permission.POST_NOTIFICATIONS] ?: notificationsGranted
@@ -1471,10 +1500,10 @@ private fun rememberPermissionState(
         null
       },
       PermissionRowModel("Contacts", "Read contacts securely", Icons.Default.Person, contactsGranted) {
-        request(Manifest.permission.READ_CONTACTS, Manifest.permission.WRITE_CONTACTS)
+        request(*requiredContactPermissions.toTypedArray())
       },
       PermissionRowModel("Calendar", "Read events and schedules", Icons.Default.CalendarMonth, calendarGranted) {
-        request(Manifest.permission.READ_CALENDAR, Manifest.permission.WRITE_CALENDAR)
+        request(*requiredCalendarPermissions.toTypedArray())
       },
       PermissionRowModel("Notifications", "Send important alerts", Icons.Default.Notifications, notificationsGranted) {
         if (Build.VERSION.SDK_INT >= 33) request(Manifest.permission.POST_NOTIFICATIONS)

--- a/apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt
@@ -1387,22 +1387,10 @@ private fun rememberPermissionState(
   val photosPermissions = photoReadPermissionsForRequest()
   var photosGranted by rememberSaveable { mutableStateOf(hasPhotoReadPermission(context)) }
   var contactsGranted by rememberSaveable {
-    mutableStateOf(
-      mergedRequiredPermissionGrantState(
-        permissions = emptyMap(),
-        requiredPermissions = requiredContactPermissions,
-        currentlyGranted = { permission -> hasPermission(context, permission) },
-      ),
-    )
+    mutableStateOf(requiredContactPermissions.all { permission -> hasPermission(context, permission) })
   }
   var calendarGranted by rememberSaveable {
-    mutableStateOf(
-      mergedRequiredPermissionGrantState(
-        permissions = emptyMap(),
-        requiredPermissions = requiredCalendarPermissions,
-        currentlyGranted = { permission -> hasPermission(context, permission) },
-      ),
-    )
+    mutableStateOf(requiredCalendarPermissions.all { permission -> hasPermission(context, permission) })
   }
   var notificationsGranted by rememberSaveable {
     mutableStateOf(Build.VERSION.SDK_INT < 33 || hasPermission(context, Manifest.permission.POST_NOTIFICATIONS))

--- a/apps/android/app/src/test/java/ai/openclaw/app/ui/OnboardingFlowLogicTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/ui/OnboardingFlowLogicTest.kt
@@ -89,6 +89,34 @@ class OnboardingFlowLogicTest {
   }
 
   @Test
+  fun contactAndCalendarPermissionGroupsRequireBothGrants() {
+    val permissionGroups =
+      listOf(
+        listOf(Manifest.permission.READ_CONTACTS, Manifest.permission.WRITE_CONTACTS),
+        listOf(Manifest.permission.READ_CALENDAR, Manifest.permission.WRITE_CALENDAR),
+      )
+
+    for (requiredPermissions in permissionGroups) {
+      val readPermission = requiredPermissions.first()
+      val writePermission = requiredPermissions.last()
+      assertFalse(
+        mergedRequiredPermissionGrantState(
+          permissions = mapOf(readPermission to true),
+          requiredPermissions = requiredPermissions,
+          currentlyGranted = { false },
+        ),
+      )
+      assertTrue(
+        mergedRequiredPermissionGrantState(
+          permissions = mapOf(writePermission to true),
+          requiredPermissions = requiredPermissions,
+          currentlyGranted = { permission -> permission == readPermission },
+        ),
+      )
+    }
+  }
+
+  @Test
   fun nearbyGatewayFoundStateIsConnectable() {
     assertEquals(
       NearbyGatewayUiState(subtitle = "Studio Gateway", status = "Found", canConnect = true),


### PR DESCRIPTION
## What Problem This Solves

Android onboarding could show Contacts or Calendar as authorized after only the read permission was granted, even though the app requests both read and write permissions from that row.

That left onboarding out of sync with the rest of the Android app: Settings already treats Contacts and Calendar as granted only when both read and write permissions are present, and the actual Contacts/Calendar add handlers require the write permission before they can create records.

This also fixes the filtered callback case. The onboarding request helper filters out permissions that are already granted before launching `RequestMultiplePermissions`; if READ was granted first and WRITE was granted later, the callback map can contain only WRITE. The state merge now uses the callback result plus the current system grant state for the omitted permission.

AI-assisted: yes.

## Why This Change Was Made

The previous onboarding state used only `READ_CONTACTS` and `READ_CALENDAR` for initial grant status, and the ActivityResult callback also only looked at those read permissions.

This change adds a focused read/write permission merge helper and uses it for Contacts and Calendar onboarding state. Initial state now requires both read and write permissions, and callback state now preserves already-granted permissions that were filtered out before the request was launched.

## User Impact

Users will no longer see Contacts or Calendar marked as ready in Android onboarding until the permissions needed by both read and add workflows are actually available. Users who grant the two permissions in separate prompts should now see the row update correctly once the missing permission is granted.

## Evidence

- `cd apps/android && ./gradlew :app:testThirdPartyDebugUnitTest --tests ai.openclaw.app.ui.OnboardingFlowLogicTest`
- `cd apps/android && ./gradlew :app:testPlayDebugUnitTest --tests ai.openclaw.app.ui.OnboardingFlowLogicTest`
- `git diff --check`
- `.agents/skills/autoreview/scripts/autoreview --mode local`
  - Result: `autoreview clean: no accepted/actionable findings reported`
