### PR TITLE
fix(agents): claude-cli lifecycle cleanup — loopback fail-loud, exit-0 failover, bounded reseed, image sweep, one prepare cleanup owner

### DIFF
--- a/src/agents/cli-runner.helpers.test.ts
+++ b/src/agents/cli-runner.helpers.test.ts
@@ -287,6 +287,42 @@ describe("writeCliImages", () => {
     }
   });
 
+  it("sweeps stale workspace-scoped CLI image files", async () => {
+    const workspaceDir = await fs.mkdtemp(
+      path.join(resolvePreferredOpenClawTmpDir(), "openclaw-cli-write-sweep-"),
+    );
+    const imageRoot = path.join(workspaceDir, ".openclaw-cli-images");
+    const stalePath = path.join(imageRoot, "stale.png");
+    const freshPath = path.join(imageRoot, "fresh.png");
+    const image: ImageContent = {
+      type: "image",
+      data: "bmV3LWltYWdl",
+      mimeType: "image/png",
+    };
+
+    await fs.mkdir(imageRoot, { recursive: true });
+    await fs.writeFile(stalePath, "stale");
+    await fs.writeFile(freshPath, "fresh");
+    const staleTime = new Date(Date.now() - 8 * 24 * 60 * 60 * 1_000);
+    await fs.utimes(stalePath, staleTime, staleTime);
+
+    const written = await writeCliImages({
+      backend: { command: "gemini", imagePathScope: "workspace" },
+      workspaceDir,
+      images: [image],
+    });
+
+    try {
+      await expect(fs.access(stalePath)).rejects.toMatchObject({ code: "ENOENT" });
+      await expect(fs.readFile(freshPath, "utf-8")).resolves.toBe("fresh");
+      await expect(fs.readFile(written.paths[0])).resolves.toEqual(
+        Buffer.from(image.data, "base64"),
+      );
+    } finally {
+      await fs.rm(workspaceDir, { recursive: true, force: true });
+    }
+  });
+
   it("hydrates prompt media refs into codex image args through the helper seams", async () => {
     const tempDir = await fs.mkdtemp(
       path.join(resolvePreferredOpenClawTmpDir(), "openclaw-cli-prompt-image-"),

--- a/src/agents/cli-runner.spawn.test.ts
+++ b/src/agents/cli-runner.spawn.test.ts
@@ -3080,6 +3080,104 @@ ${JSON.stringify({
     );
   });
 
+  it("marks quiet Claude live exit-zero turns as retryable empty responses", async () => {
+    let resolveExit: ((exit: RunExit) => void) | undefined;
+    const exited = new Promise<RunExit>((resolve) => {
+      resolveExit = resolve;
+    });
+    const stdin = {
+      write: vi.fn((_dataValue: string, cb?: (err?: Error | null) => void) => {
+        cb?.();
+        resolveExit?.({
+          reason: "exit",
+          exitCode: 0,
+          exitSignal: null,
+          durationMs: 1,
+          stdout: "",
+          stderr: "",
+          timedOut: false,
+          noOutputTimedOut: false,
+        });
+      }),
+      end: vi.fn(),
+    };
+    supervisorSpawnMock.mockImplementationOnce(async () => ({
+      runId: "live-empty-run",
+      pid: 2345,
+      startedAtMs: Date.now(),
+      stdin,
+      wait: vi.fn(() => exited),
+      cancel: vi.fn(),
+    }));
+
+    await expectRejectsWithFields(
+      executePreparedCliRun(
+        buildPreparedCliRunContext({
+          provider: "claude-cli",
+          model: "sonnet",
+          runId: "run-live-empty",
+          backend: {
+            liveSession: "claude-stdio",
+          },
+        }),
+      ),
+      {
+        name: "FailoverError",
+        reason: "empty_response",
+        code: "cli_unknown_empty_failure",
+      },
+    );
+  });
+
+  it("preserves Claude live stderr classification on exit-zero failures", async () => {
+    let resolveExit: ((exit: RunExit) => void) | undefined;
+    const exited = new Promise<RunExit>((resolve) => {
+      resolveExit = resolve;
+    });
+    const stdin = {
+      write: vi.fn((_dataValue: string, cb?: (err?: Error | null) => void) => {
+        cb?.();
+        resolveExit?.({
+          reason: "exit",
+          exitCode: 0,
+          exitSignal: null,
+          durationMs: 1,
+          stdout: "",
+          stderr: "Prompt is too long",
+          timedOut: false,
+          noOutputTimedOut: false,
+        });
+      }),
+      end: vi.fn(),
+    };
+    supervisorSpawnMock.mockImplementationOnce(async () => ({
+      runId: "live-exit-zero-overflow-run",
+      pid: 2345,
+      startedAtMs: Date.now(),
+      stdin,
+      wait: vi.fn(() => exited),
+      cancel: vi.fn(),
+    }));
+
+    await expectRejectsWithFields(
+      executePreparedCliRun(
+        buildPreparedCliRunContext({
+          provider: "claude-cli",
+          model: "sonnet",
+          runId: "run-live-exit-zero-overflow",
+          backend: {
+            liveSession: "claude-stdio",
+          },
+        }),
+      ),
+      {
+        name: "FailoverError",
+        reason: "context_overflow",
+        code: "cli_context_overflow",
+      },
+    );
+  });
+
   it("fails when Claude exits before a live turn starts", async () => {
     supervisorSpawnMock.mockImplementationOnce(async () => ({
       runId: "live-run",

--- a/src/agents/cli-runner.ts
+++ b/src/agents/cli-runner.ts
@@ -98,6 +98,8 @@ function shouldRetryFreshCliSessionAfterFailover(params: {
       return true;
     case "unknown":
       return params.error.code === "cli_unknown_empty_failure";
+    case "empty_response":
+      return params.error.code === "cli_unknown_empty_failure";
     case "timeout":
       return params.error.code === "cli_no_output_timeout";
     case "context_overflow":

--- a/src/agents/cli-runner/claude-live-session.ts
+++ b/src/agents/cli-runner/claude-live-session.ts
@@ -58,6 +58,7 @@ type ClaudeLiveTurn = {
   timeoutTimer: NodeJS.Timeout | null;
   activeToolTimer: NodeJS.Timeout | null;
   activeTools: Map<string, ClaudeLiveActiveTool>;
+  observedStdout: boolean;
   streamingParser: ReturnType<typeof createCliJsonlStreamingParser>;
   execPermission: ClaudeLiveExecPermission;
   resolve: (output: CliOutput) => void;
@@ -73,8 +74,6 @@ type ClaudeLiveSession = {
   stderr: string;
   stdoutBuffer: string;
   currentTurn: ClaudeLiveTurn | null;
-  drainTimer: NodeJS.Timeout | null;
-  drainingAbortedTurn: boolean;
   idleTimer: NodeJS.Timeout | null;
   cleanup: () => Promise<void>;
   cleanupPromise: Promise<void> | null;
@@ -375,13 +374,6 @@ function clearTurnTimers(turn: ClaudeLiveTurn): void {
   }
 }
 
-function clearDrainTimer(session: ClaudeLiveSession): void {
-  if (session.drainTimer) {
-    clearTimeout(session.drainTimer);
-    session.drainTimer = null;
-  }
-}
-
 function finishTurn(session: ClaudeLiveSession, output: CliOutput): void {
   const turn = session.currentTurn;
   if (!turn) {
@@ -447,7 +439,6 @@ function closeLiveSession(
     clearTimeout(session.idleTimer);
     session.idleTimer = null;
   }
-  clearDrainTimer(session);
   if (liveSessions.get(session.key) === session) {
     liveSessions.delete(session.key);
   }
@@ -854,20 +845,10 @@ function handleClaudeLiveLine(session: ClaudeLiveSession, line: string): void {
     return;
   }
   const parsed = parseClaudeLiveJsonLine(session, trimmed);
-  if (!parsed) {
-    return;
+  if (turn) {
+    turn.observedStdout = true;
   }
-  if (session.drainingAbortedTurn) {
-    if (parsed.type === "result") {
-      const turnToClear = session.currentTurn;
-      if (turnToClear) {
-        clearTurnTimers(turnToClear);
-        session.currentTurn = null;
-      }
-      session.drainingAbortedTurn = false;
-      clearDrainTimer(session);
-      scheduleIdleClose(session);
-    }
+  if (!parsed) {
     return;
   }
   if (!turn) {
@@ -940,7 +921,6 @@ function handleClaudeExit(session: ClaudeLiveSession, exitCode: number | null): 
     clearTimeout(session.idleTimer);
     session.idleTimer = null;
   }
-  clearDrainTimer(session);
   if (liveSessions.get(session.key) === session) {
     liveSessions.delete(session.key);
   }
@@ -965,8 +945,22 @@ function handleClaudeExit(session: ClaudeLiveSession, exitCode: number | null): 
   const fallbackMessage =
     exitCode === 0 ? "Claude CLI exited before completing the turn." : "Claude CLI failed.";
   const message = extractCliErrorMessage(stderr) ?? (stderr || fallbackMessage);
-  if (exitCode === 0) {
-    failTurn(session, new Error(message));
+  if (exitCode === 0 && !stderr) {
+    const turn = session.currentTurn;
+    const retryCode =
+      turn && !turn.observedStdout && turn.rawLines.length === 0
+        ? "cli_unknown_empty_failure"
+        : undefined;
+    failTurn(
+      session,
+      new FailoverError(message, {
+        reason: "empty_response",
+        provider: session.providerId,
+        model: session.modelId,
+        status: resolveFailoverStatus("empty_response"),
+        code: retryCode,
+      }),
+    );
     return;
   }
   const reason = classifyFailoverReason(message, { provider: session.providerId }) ?? "unknown";
@@ -1076,8 +1070,6 @@ async function createClaudeLiveSession(params: {
     stderr: "",
     stdoutBuffer: "",
     currentTurn: null,
-    drainTimer: null,
-    drainingAbortedTurn: false,
     idleTimer: null,
     cleanup: async () => {
       await mcpCaptureAttempt.cleanup?.();
@@ -1129,6 +1121,7 @@ function createTurn(params: {
     timeoutTimer: null,
     activeToolTimer: null,
     activeTools: new Map(),
+    observedStdout: false,
     streamingParser: createCliJsonlStreamingParser({
       backend: params.context.preparedBackend.backend,
       providerId: params.context.backendResolved.id,
@@ -1167,7 +1160,7 @@ function createTurn(params: {
 
 function closeOldestIdleSession(): boolean {
   for (const session of liveSessions.values()) {
-    if (!session.currentTurn && !session.drainingAbortedTurn) {
+    if (!session.currentTurn) {
       closeLiveSession(session, "idle");
       return true;
     }
@@ -1312,7 +1305,7 @@ export async function runClaudeLiveSessionTurn(params: {
     await cleanup();
     throw new Error("Claude CLI live session closed before handling the turn");
   }
-  if (session.currentTurn || session.drainingAbortedTurn) {
+  if (session.currentTurn) {
     throw new Error("Claude CLI live session is already handling a turn");
   }
   const liveSession = session;

--- a/src/agents/cli-runner/helpers.ts
+++ b/src/agents/cli-runner/helpers.ts
@@ -36,6 +36,7 @@ import { buildConfiguredAgentSystemPrompt } from "../system-prompt-config.js";
 import { buildSystemPromptParams } from "../system-prompt-params.js";
 import type { SilentReplyPromptMode } from "../system-prompt.types.js";
 import { sanitizeImageBlocks } from "../tool-images.js";
+import { cliBackendLog } from "./log.js";
 import { formatTomlConfigOverride } from "./toml-inline.js";
 /** Re-export CLI reliability helpers used by older runner call sites. */
 export {
@@ -45,6 +46,8 @@ export {
 } from "./reliability.js";
 
 const CLI_RUN_QUEUE = new KeyedAsyncQueue();
+const CLI_IMAGE_SWEEP_TTL_MS = 7 * 24 * 60 * 60 * 1_000;
+const sweptCliImageRoots = new Set<string>();
 
 function isClaudeCliProvider(providerId: string): boolean {
   return normalizeOptionalLowercaseString(providerId) === "claude-cli";
@@ -295,6 +298,53 @@ function resolveCliImageRoot(params: { backend: CliBackendConfig; workspaceDir: 
   return path.join(resolvePreferredOpenClawTmpDir(), "openclaw-cli-images");
 }
 
+function isFileNotFoundError(error: unknown): boolean {
+  return Boolean(
+    error &&
+    typeof error === "object" &&
+    "code" in error &&
+    (error as { code?: unknown }).code === "ENOENT",
+  );
+}
+
+async function sweepCliImageRoot(imageRoot: string): Promise<void> {
+  if (sweptCliImageRoots.has(imageRoot)) {
+    return;
+  }
+  sweptCliImageRoots.add(imageRoot);
+  try {
+    const cutoffMs = Date.now() - CLI_IMAGE_SWEEP_TTL_MS;
+    const entries = await fs.readdir(imageRoot, { withFileTypes: true });
+    for (const entry of entries) {
+      if (!entry.isFile()) {
+        continue;
+      }
+      const entryPath = path.join(imageRoot, entry.name);
+      const stat = await fs.stat(entryPath).catch((error: unknown) => {
+        if (isFileNotFoundError(error)) {
+          return undefined;
+        }
+        throw error;
+      });
+      if (!stat) {
+        continue;
+      }
+      if (stat.mtimeMs >= cutoffMs) {
+        continue;
+      }
+      try {
+        await fs.rm(entryPath, { force: true });
+      } catch (error) {
+        if (!isFileNotFoundError(error)) {
+          throw error;
+        }
+      }
+    }
+  } catch (error) {
+    cliBackendLog.debug(`cli image cache sweep failed: ${String(error)}`);
+  }
+}
+
 function appendImagePathsToPrompt(prompt: string, paths: string[], prefix = ""): string {
   if (!paths.length) {
     return prompt;
@@ -353,6 +403,7 @@ export async function writeCliImages(params: {
     workspaceDir: params.workspaceDir,
   });
   await fs.mkdir(imageRoot, { recursive: true, mode: 0o700 });
+  await sweepCliImageRoot(imageRoot);
   const store = privateFileStore(imageRoot);
   const paths: string[] = [];
   for (const image of params.images) {

--- a/src/agents/cli-runner/prepare.test.ts
+++ b/src/agents/cli-runner/prepare.test.ts
@@ -24,6 +24,7 @@ import {
 import { captureEnv, setTestEnvValue } from "../../test-utils/env.js";
 import { resolveApiKeyForProfile as resolveApiKeyForProfileImpl } from "../auth-profiles/oauth.js";
 import { saveAuthProfileStore } from "../auth-profiles/store.js";
+import { resetCliAuthEpochTestDeps, setCliAuthEpochTestDeps } from "../cli-auth-epoch.js";
 import { testing as cliBackendsTesting } from "../cli-backends.js";
 import { hashCliSessionText } from "../cli-session.js";
 import { resetContextWindowCacheForTest } from "../context.js";
@@ -279,6 +280,7 @@ describe("shouldSkipLocalCliCredentialEpoch", () => {
 
   afterEach(() => {
     cliBackendsTesting.resetDepsForTest();
+    resetCliAuthEpochTestDeps();
     getRuntimeConfigMock.mockReset();
     mockGetGlobalHookRunner.mockReset();
     mockBuildActiveImageGenerationTaskPromptContextForSession.mockReset();
@@ -956,6 +958,121 @@ describe("shouldSkipLocalCliCredentialEpoch", () => {
       expect(generatedSystemSettingsPath).toBeTruthy();
       expect(fs.existsSync(generatedSystemSettingsPath ?? "")).toBe(false);
     } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("cleans prepared execution resources when auth epoch resolution fails", async () => {
+    const { dir, sessionFile } = createSessionFile();
+    const preparedExecutionCleanup = vi.fn(async () => undefined);
+    const prepareExecution = vi.fn(async () => ({ cleanup: preparedExecutionCleanup }));
+    setCliAuthEpochTestDeps({
+      loadAuthProfileStoreForRuntime: () => {
+        throw new Error("auth epoch read failed");
+      },
+    });
+    cliBackendsTesting.setDepsForTest({
+      resolvePluginSetupCliBackend: () => undefined,
+      resolveRuntimeCliBackends: () => [
+        {
+          id: "test-cli",
+          pluginId: "test",
+          bundleMcp: false,
+          authEpochMode: "profile-only",
+          prepareExecution,
+          config: {
+            command: "test-cli",
+            args: ["--print"],
+            systemPromptArg: "--system-prompt",
+            systemPromptWhen: "first",
+            output: "text",
+            input: "arg",
+            sessionMode: "existing",
+          },
+        },
+      ],
+    });
+
+    try {
+      await expect(
+        prepareCliRunContext({
+          sessionId: "session-test",
+          sessionKey: "agent:main:main",
+          sessionFile,
+          workspaceDir: dir,
+          prompt: "latest ask",
+          provider: "test-cli",
+          model: "test-model",
+          timeoutMs: 1_000,
+          runId: "run-test-prepare-execution-cleanup-on-auth-epoch-failure",
+          authProfileId: "test-cli:profile",
+          config: {},
+        }),
+      ).rejects.toThrow("auth epoch read failed");
+
+      expect(prepareExecution).toHaveBeenCalledOnce();
+      expect(preparedExecutionCleanup).toHaveBeenCalledOnce();
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("cleans prepared MCP and skills plugin dirs when mid-prepare reference lookup fails", async () => {
+    const { dir, sessionFile } = createSessionFile();
+    const tempEnvSnapshot = captureEnv(["TMPDIR", "TMP", "TEMP"]);
+    const tempRoot = path.join(dir, "tmp");
+    const skillsPluginDir = path.join(dir, "claude-skills-plugin");
+    const skillsCleanup = vi.fn(async () => {
+      fs.rmSync(skillsPluginDir, { recursive: true, force: true });
+    });
+    fs.mkdirSync(tempRoot, { recursive: true });
+    fs.mkdirSync(skillsPluginDir, { recursive: true });
+    setTestEnvValue("TMPDIR", tempRoot);
+    setTestEnvValue("TMP", tempRoot);
+    setTestEnvValue("TEMP", tempRoot);
+    const getActiveMcpLoopbackRuntime = vi.fn(() => ({
+      port: 31783,
+      ownerToken: "loopback-owner-token",
+      nonOwnerToken: "loopback-non-owner-token",
+    }));
+    setCliRunnerPrepareTestDeps({
+      getActiveMcpLoopbackRuntime,
+      ensureMcpLoopbackServer: vi.fn(createTestMcpLoopbackServer),
+      createMcpLoopbackServerConfig: vi.fn(createTestMcpLoopbackServerConfig),
+      resolveMcpLoopbackBearerToken: vi.fn(() => "loopback-token"),
+      resolveMcpLoopbackScopedTools: vi.fn(() => ({ agentId: "main", tools: [] })),
+      prepareClaudeCliSkillsPlugin: vi.fn(async () => ({
+        args: ["--plugin-dir", skillsPluginDir],
+        cleanup: skillsCleanup,
+      })),
+      resolveOpenClawReferencePaths: vi.fn(async () => {
+        throw new Error("reference path lookup failed");
+      }),
+    });
+
+    try {
+      await expect(
+        prepareCliRunContext({
+          sessionId: "session-test",
+          sessionKey: "agent:main:main",
+          sessionFile,
+          workspaceDir: dir,
+          prompt: "latest ask",
+          provider: "test-cli",
+          model: "test-model",
+          timeoutMs: 1_000,
+          runId: "run-test-mid-prepare-cleanup",
+          config: createCliBackendConfig({ bundleMcp: true }),
+        }),
+      ).rejects.toThrow("reference path lookup failed");
+
+      expect(skillsCleanup).toHaveBeenCalledOnce();
+      expect(fs.existsSync(skillsPluginDir)).toBe(false);
+      expect(
+        fs.readdirSync(tempRoot).filter((entry) => entry.startsWith("openclaw-cli-mcp-")),
+      ).toEqual([]);
+    } finally {
+      tempEnvSnapshot.restore();
       fs.rmSync(dir, { recursive: true, force: true });
     }
   });
@@ -2162,7 +2279,7 @@ describe("shouldSkipLocalCliCredentialEpoch", () => {
     }
   });
 
-  it("does not advertise loopback prompt tools when the runtime is unavailable", async () => {
+  it("fails bundled MCP preparation when the loopback runtime is unavailable", async () => {
     const { dir, sessionFile } = createSessionFile();
     try {
       registerMemoryPromptSection(({ availableTools }) =>
@@ -2213,29 +2330,25 @@ describe("shouldSkipLocalCliCredentialEpoch", () => {
           },
         ],
       });
-      const context = await prepareCliRunContext({
-        sessionId: "session-test",
-        sessionKey: "agent:main:test",
-        sessionFile,
-        workspaceDir: dir,
-        prompt: "latest ask",
-        provider: "native-cli",
-        model: "test-model",
-        timeoutMs: 1_000,
-        runId: "run-test-loopback-prompt-tools-fallback",
-        config: createCliBackendConfig({ bundleMcp: true }),
-      });
+      await expect(
+        prepareCliRunContext({
+          sessionId: "session-test",
+          sessionKey: "agent:main:test",
+          sessionFile,
+          workspaceDir: dir,
+          prompt: "latest ask",
+          provider: "native-cli",
+          model: "test-model",
+          timeoutMs: 1_000,
+          runId: "run-test-loopback-prompt-tools-fallback",
+          config: createCliBackendConfig({ bundleMcp: true }),
+        }),
+      ).rejects.toThrow(/loopback unavailable/);
 
       expect(ensureMcpLoopbackServer).toHaveBeenCalledTimes(1);
-      expect(getActiveMcpLoopbackRuntime).toHaveBeenCalledTimes(2);
+      expect(getActiveMcpLoopbackRuntime).toHaveBeenCalledTimes(1);
       expect(createMcpLoopbackServerConfig).not.toHaveBeenCalled();
       expect(resolveMcpLoopbackScopedTools).not.toHaveBeenCalled();
-      expect(context.systemPrompt).not.toContain("## Memory Recall");
-      expect(context.systemPrompt).not.toMatch(/^- memory_search\b/m);
-      expect(context.systemPromptReport.tools.entries).toEqual([]);
-      expect(context.promptToolNamesHash).toBeUndefined();
-      expect(context.preparedBackend.env).toBeUndefined();
-      expect(context.mcpDeliveryCapture).toBeUndefined();
     } finally {
       fs.rmSync(dir, { recursive: true, force: true });
     }

--- a/src/agents/cli-runner/prepare.ts
+++ b/src/agents/cli-runner/prepare.ts
@@ -432,57 +432,69 @@ export async function prepareCliRunContext(
     try {
       await prepareDeps.ensureMcpLoopbackServer();
     } catch (error) {
-      cliBackendLog.warn(`mcp loopback server failed to start: ${String(error)}`);
+      throw new Error(
+        `Bundled MCP is enabled, but the OpenClaw MCP loopback server failed to start: ${String(error)}`,
+        { cause: error },
+      );
     }
     mcpLoopbackRuntime = prepareDeps.getActiveMcpLoopbackRuntime();
   }
+  if (bundleMcpEnabled && !mcpLoopbackRuntime) {
+    throw new Error(
+      "Bundled MCP is enabled, but the OpenClaw MCP loopback server did not publish a runtime after startup.",
+    );
+  }
   const mcpDeliveryCaptureEnabled = bundleMcpEnabled && Boolean(mcpLoopbackRuntime);
-  const preparedBackend = await prepareCliBundleMcpConfig({
-    enabled: bundleMcpEnabled,
-    mode: backendResolved.bundleMcpMode,
-    backend: backendResolved.config,
-    workspaceDir,
-    config: params.config,
-    additionalConfig: mcpLoopbackRuntime
-      ? prepareDeps.createMcpLoopbackServerConfig(mcpLoopbackRuntime.port)
-      : undefined,
-    env: mcpLoopbackRuntime
-      ? {
-          OPENCLAW_MCP_TOKEN: prepareDeps.resolveMcpLoopbackBearerToken(
-            mcpLoopbackRuntime,
-            params.senderIsOwner === true,
-          ),
-          OPENCLAW_MCP_AGENT_ID: sessionAgentId ?? "",
-          OPENCLAW_MCP_ACCOUNT_ID: params.agentAccountId ?? "",
-          OPENCLAW_MCP_SESSION_KEY: params.sessionKey ?? "",
-          OPENCLAW_MCP_SESSION_ID: params.sessionId,
-          OPENCLAW_MCP_MESSAGE_CHANNEL: params.messageChannel ?? params.messageProvider ?? "",
-          OPENCLAW_MCP_CURRENT_CHANNEL_ID: params.currentChannelId ?? "",
-          OPENCLAW_MCP_CURRENT_THREAD_TS: params.currentThreadTs ?? "",
-          OPENCLAW_MCP_CURRENT_MESSAGE_ID:
-            params.currentMessageId != null ? String(params.currentMessageId) : "",
-          OPENCLAW_MCP_CURRENT_INBOUND_AUDIO: params.currentInboundAudio === true ? "true" : "",
-          OPENCLAW_MCP_INBOUND_EVENT_KIND: params.currentInboundEventKind ?? "",
-          OPENCLAW_MCP_SOURCE_REPLY_DELIVERY_MODE: params.sourceReplyDeliveryMode ?? "",
-          OPENCLAW_MCP_REQUIRE_EXPLICIT_MESSAGE_TARGET: requireExplicitMessageTarget ? "true" : "",
-          OPENCLAW_MCP_CLI_CAPTURE_KEY: "",
-        }
-      : undefined,
-    warn: (message) => cliBackendLog.warn(message),
-  });
-  const prepareExecutionContext = {
-    config: params.config,
-    workspaceDir,
-    agentDir,
-    provider: params.provider,
-    modelId,
-    authProfileId: effectiveAuthProfileId,
-    executionMode,
-    env: preparedBackend.env,
-  } as Parameters<NonNullable<typeof backendResolved.prepareExecution>>[0];
+  let cleanupPreparedResources: (() => Promise<void>) | undefined;
   let preparedExecution: Awaited<ReturnType<NonNullable<typeof backendResolved.prepareExecution>>> =
     undefined;
   try {
+    const preparedBackend = await prepareCliBundleMcpConfig({
+      enabled: bundleMcpEnabled,
+      mode: backendResolved.bundleMcpMode,
+      backend: backendResolved.config,
+      workspaceDir,
+      config: params.config,
+      additionalConfig: mcpLoopbackRuntime
+        ? prepareDeps.createMcpLoopbackServerConfig(mcpLoopbackRuntime.port)
+        : undefined,
+      env: mcpLoopbackRuntime
+        ? {
+            OPENCLAW_MCP_TOKEN: prepareDeps.resolveMcpLoopbackBearerToken(
+              mcpLoopbackRuntime,
+              params.senderIsOwner === true,
+            ),
+            OPENCLAW_MCP_AGENT_ID: sessionAgentId ?? "",
+            OPENCLAW_MCP_ACCOUNT_ID: params.agentAccountId ?? "",
+            OPENCLAW_MCP_SESSION_KEY: params.sessionKey ?? "",
+            OPENCLAW_MCP_SESSION_ID: params.sessionId,
+            OPENCLAW_MCP_MESSAGE_CHANNEL: params.messageChannel ?? params.messageProvider ?? "",
+            OPENCLAW_MCP_CURRENT_CHANNEL_ID: params.currentChannelId ?? "",
+            OPENCLAW_MCP_CURRENT_THREAD_TS: params.currentThreadTs ?? "",
+            OPENCLAW_MCP_CURRENT_MESSAGE_ID:
+              params.currentMessageId != null ? String(params.currentMessageId) : "",
+            OPENCLAW_MCP_CURRENT_INBOUND_AUDIO: params.currentInboundAudio === true ? "true" : "",
+            OPENCLAW_MCP_INBOUND_EVENT_KIND: params.currentInboundEventKind ?? "",
+            OPENCLAW_MCP_SOURCE_REPLY_DELIVERY_MODE: params.sourceReplyDeliveryMode ?? "",
+            OPENCLAW_MCP_REQUIRE_EXPLICIT_MESSAGE_TARGET: requireExplicitMessageTarget
+              ? "true"
+              : "",
+            OPENCLAW_MCP_CLI_CAPTURE_KEY: "",
+          }
+        : undefined,
+      warn: (message) => cliBackendLog.warn(message),
+    });
+    cleanupPreparedResources = preparedBackend.cleanup;
+    const prepareExecutionContext = {
+      config: params.config,
+      workspaceDir,
+      agentDir,
+      provider: params.provider,
+      modelId,
+      authProfileId: effectiveAuthProfileId,
+      executionMode,
+      env: preparedBackend.env,
+    } as Parameters<NonNullable<typeof backendResolved.prepareExecution>>[0];
     preparedExecution = await backendResolved.prepareExecution?.(
       (backendResolved.id === "google-gemini-cli"
         ? {
@@ -496,417 +508,412 @@ export async function prepareCliRunContext(
         authCredential?: AuthProfileCredential;
       },
     );
-  } catch (err) {
-    try {
-      await preparedBackend.cleanup?.();
-    } catch (cleanupErr) {
-      cliBackendLog.warn(`cli backend cleanup after prepare failure failed: ${String(cleanupErr)}`);
-    }
-    throw err;
-  }
-  const skipLocalCredentialEpoch = shouldSkipLocalCliCredentialEpoch({
-    authEpochMode: backendResolved.authEpochMode,
-    authProfileId: effectiveAuthProfileId,
-    authCredential,
-    preparedExecution,
-  });
-  const authEpoch = await resolveCliAuthEpoch({
-    provider: params.provider,
-    agentDir,
-    authProfileId: effectiveAuthProfileId,
-    skipLocalCredential: skipLocalCredentialEpoch,
-  });
-  const preparedBackendEnv =
-    preparedExecution?.env && Object.keys(preparedExecution.env).length > 0
-      ? { ...preparedBackend.env, ...preparedExecution.env }
-      : preparedBackend.env;
-  const preparedBackendCleanup =
-    preparedBackend.cleanup || preparedExecution?.cleanup
-      ? async () => {
-          try {
-            await preparedExecution?.cleanup?.();
-          } finally {
-            await preparedBackend.cleanup?.();
+    const preparedBackendCleanup =
+      preparedBackend.cleanup || preparedExecution?.cleanup
+        ? async () => {
+            try {
+              await preparedExecution?.cleanup?.();
+            } finally {
+              await preparedBackend.cleanup?.();
+            }
           }
-        }
-      : undefined;
-  const preparedBackendBeforeExecution =
-    preparedBackend.beforeExecution || preparedExecution?.beforeExecution
-      ? async () => {
-          await preparedBackend.beforeExecution?.();
-          await preparedExecution?.beforeExecution?.();
-        }
-      : undefined;
-  const claudeSkillsPlugin = isSideQuestion
-    ? { args: [], cleanup: async () => {} }
-    : await prepareDeps.prepareClaudeCliSkillsPlugin({
-        backendId: backendResolved.id,
-        skillsSnapshot: params.skillsSnapshot,
-      });
-  const preparedCleanup =
-    preparedBackendCleanup || claudeSkillsPlugin.args.length > 0
-      ? async () => {
-          try {
-            await claudeSkillsPlugin.cleanup();
-          } finally {
-            await preparedBackendCleanup?.();
+        : undefined;
+    cleanupPreparedResources = preparedBackendCleanup;
+    const skipLocalCredentialEpoch = shouldSkipLocalCliCredentialEpoch({
+      authEpochMode: backendResolved.authEpochMode,
+      authProfileId: effectiveAuthProfileId,
+      authCredential,
+      preparedExecution,
+    });
+    const authEpoch = await resolveCliAuthEpoch({
+      provider: params.provider,
+      agentDir,
+      authProfileId: effectiveAuthProfileId,
+      skipLocalCredential: skipLocalCredentialEpoch,
+    });
+    const preparedBackendEnv =
+      preparedExecution?.env && Object.keys(preparedExecution.env).length > 0
+        ? { ...preparedBackend.env, ...preparedExecution.env }
+        : preparedBackend.env;
+    const preparedBackendBeforeExecution =
+      preparedBackend.beforeExecution || preparedExecution?.beforeExecution
+        ? async () => {
+            await preparedBackend.beforeExecution?.();
+            await preparedExecution?.beforeExecution?.();
           }
-        }
-      : undefined;
-  const preparedBackendClearEnv = [
-    ...(preparedBackend.backend.clearEnv ?? []),
-    ...(preparedExecution?.clearEnv ?? []),
-  ];
-  const sideQuestionBackend = (() => {
-    const { liveSession: _liveSession, ...backend } = preparedBackend.backend;
-    return {
-      ...backend,
-      sessionMode: "none" as const,
-    };
-  })();
-  const preparedBackendFinal = {
-    ...preparedBackend,
-    backend: {
-      ...(isSideQuestion ? sideQuestionBackend : preparedBackend.backend),
-      ...(preparedBackendClearEnv.length > 0
-        ? { clearEnv: uniqueStrings(preparedBackendClearEnv) }
+        : undefined;
+    const claudeSkillsPlugin = isSideQuestion
+      ? { args: [], cleanup: async () => {} }
+      : await prepareDeps.prepareClaudeCliSkillsPlugin({
+          backendId: backendResolved.id,
+          skillsSnapshot: params.skillsSnapshot,
+        });
+    const preparedCleanup =
+      preparedBackendCleanup || claudeSkillsPlugin.args.length > 0
+        ? async () => {
+            try {
+              await claudeSkillsPlugin.cleanup();
+            } finally {
+              await preparedBackendCleanup?.();
+            }
+          }
+        : undefined;
+    cleanupPreparedResources = preparedCleanup ?? preparedBackendCleanup;
+    const preparedBackendClearEnv = [
+      ...(preparedBackend.backend.clearEnv ?? []),
+      ...(preparedExecution?.clearEnv ?? []),
+    ];
+    const sideQuestionBackend = (() => {
+      const { liveSession: _liveSession, ...backend } = preparedBackend.backend;
+      return {
+        ...backend,
+        sessionMode: "none" as const,
+      };
+    })();
+    const preparedBackendFinal = {
+      ...preparedBackend,
+      backend: {
+        ...(isSideQuestion ? sideQuestionBackend : preparedBackend.backend),
+        ...(preparedBackendClearEnv.length > 0
+          ? { clearEnv: uniqueStrings(preparedBackendClearEnv) }
+          : {}),
+      },
+      ...(preparedBackendEnv ? { env: preparedBackendEnv } : {}),
+      ...(preparedBackendBeforeExecution
+        ? { beforeExecution: preparedBackendBeforeExecution }
         : {}),
-    },
-    ...(preparedBackendEnv ? { env: preparedBackendEnv } : {}),
-    ...(preparedBackendBeforeExecution ? { beforeExecution: preparedBackendBeforeExecution } : {}),
-    ...(preparedCleanup ? { cleanup: preparedCleanup } : {}),
-  };
-  const promptTools =
-    bundleMcpEnabled && mcpLoopbackRuntime
-      ? prepareDeps.resolveMcpLoopbackScopedTools({
-          cfg: params.config ?? getRuntimeConfig(),
-          sessionKey: params.sessionKey ?? "",
-          messageProvider: params.messageChannel ?? params.messageProvider,
-          currentChannelId: params.currentChannelId,
-          currentThreadTs: params.currentThreadTs,
-          currentMessageId: params.currentMessageId,
-          currentInboundAudio: params.currentInboundAudio,
+      ...(preparedCleanup ? { cleanup: preparedCleanup } : {}),
+    };
+    const promptTools =
+      bundleMcpEnabled && mcpLoopbackRuntime
+        ? prepareDeps.resolveMcpLoopbackScopedTools({
+            cfg: params.config ?? getRuntimeConfig(),
+            sessionKey: params.sessionKey ?? "",
+            messageProvider: params.messageChannel ?? params.messageProvider,
+            currentChannelId: params.currentChannelId,
+            currentThreadTs: params.currentThreadTs,
+            currentMessageId: params.currentMessageId,
+            currentInboundAudio: params.currentInboundAudio,
+            accountId: params.agentAccountId,
+            inboundEventKind: params.currentInboundEventKind,
+            sourceReplyDeliveryMode: params.sourceReplyDeliveryMode,
+            requireExplicitMessageTarget,
+            senderIsOwner: params.senderIsOwner,
+          }).tools
+        : [];
+    const promptToolNamesHash =
+      bundleMcpEnabled && mcpLoopbackRuntime
+        ? hashCliSessionText(JSON.stringify(promptTools.map((tool) => tool.name).toSorted()))
+        : undefined;
+    const reusableCliSessionCandidate: CliReusableSession = isSideQuestion
+      ? {}
+      : params.cliSessionBinding
+        ? resolveCliSessionReuse({
+            binding: params.cliSessionBinding,
+            authProfileId: effectiveAuthProfileId,
+            authEpoch,
+            authEpochVersion: CLI_AUTH_EPOCH_VERSION,
+            extraSystemPromptHash,
+            messageToolPolicyHash,
+            promptToolNamesHash,
+            cwdHash,
+            mcpConfigHash: preparedBackendFinal.mcpConfigHash,
+            mcpResumeHash: preparedBackendFinal.mcpResumeHash,
+          })
+        : params.cliSessionId
+          ? { sessionId: params.cliSessionId }
+          : {};
+    const candidateClaudeCliSessionId = reusableCliSessionCandidate.sessionId?.trim() || undefined;
+    const hasClaudeCliCandidate =
+      candidateClaudeCliSessionId !== undefined && isClaudeCliProvider(params.provider);
+    const claudeCliTranscriptMissing =
+      hasClaudeCliCandidate &&
+      !(await prepareDeps.claudeCliSessionTranscriptHasContent({
+        sessionId: candidateClaudeCliSessionId,
+        workspaceDir: cwd,
+      }));
+    const claudeCliTranscriptOrphanedToolUse =
+      hasClaudeCliCandidate &&
+      !claudeCliTranscriptMissing &&
+      (await prepareDeps.claudeCliSessionTranscriptHasOrphanedToolUse({
+        sessionId: candidateClaudeCliSessionId,
+        workspaceDir: cwd,
+      }));
+    const claudeCliInvalidatedReason: CliReusableSession["invalidatedReason"] | undefined =
+      claudeCliTranscriptMissing
+        ? "missing-transcript"
+        : claudeCliTranscriptOrphanedToolUse
+          ? "orphaned-tool-use"
+          : undefined;
+    const reusableCliSession: CliReusableSession = claudeCliInvalidatedReason
+      ? { invalidatedReason: claudeCliInvalidatedReason }
+      : reusableCliSessionCandidate;
+    if (reusableCliSession.invalidatedReason) {
+      cliBackendLog.info(
+        `cli session reset: provider=${params.provider} reason=${reusableCliSession.invalidatedReason}`,
+      );
+    }
+    let openClawHistoryMessages: unknown[] | undefined;
+    const loadOpenClawHistoryMessages = async () => {
+      openClawHistoryMessages ??= await loadCliSessionHistoryMessages({
+        sessionId: params.sessionId,
+        sessionFile: params.sessionFile,
+        sessionKey: params.sessionKey,
+        agentId: params.agentId,
+        config: params.config,
+      });
+      return openClawHistoryMessages;
+    };
+    const heartbeatPrompt =
+      isSideQuestion || params.bootstrapContextRunKind === "commitment-only"
+        ? undefined
+        : resolveHeartbeatPromptForSystemPrompt({
+            config: params.config,
+            agentId: sessionAgentId,
+            defaultAgentId,
+          });
+    const openClawReferences = isSideQuestion
+      ? { docsPath: null, sourcePath: null }
+      : await prepareDeps.resolveOpenClawReferencePaths({
+          workspaceDir,
+          argv1: process.argv[1],
+          cwd,
+          moduleUrl: import.meta.url,
+        });
+    const systemPromptSkillsPrompt =
+      isSideQuestion || claudeSkillsPlugin.args.length > 0
+        ? ""
+        : await resolveCliSkillsPrompt({
+            skillsSnapshot: params.skillsSnapshot,
+            workspaceDir,
+            config: params.config,
+            agentId: sessionAgentId,
+            sessionKey: params.sessionKey?.trim() || params.sessionId,
+          });
+    const runtimeChannel = isSideQuestion
+      ? undefined
+      : normalizeMessageChannel(params.messageChannel ?? params.messageProvider);
+    const runtimeCapabilities = isSideQuestion
+      ? undefined
+      : collectRuntimeChannelCapabilities({
+          cfg: params.config,
+          channel: runtimeChannel,
           accountId: params.agentAccountId,
-          inboundEventKind: params.currentInboundEventKind,
+        });
+    const builtSystemPrompt = isSideQuestion
+      ? extraSystemPrompt
+      : buildCliAgentSystemPrompt({
+          workspaceDir,
+          cwd,
+          config: params.config,
+          defaultThinkLevel: params.thinkLevel,
+          extraSystemPrompt,
           sourceReplyDeliveryMode: params.sourceReplyDeliveryMode,
           requireExplicitMessageTarget,
-          senderIsOwner: params.senderIsOwner,
-        }).tools
-      : [];
-  const promptToolNamesHash =
-    bundleMcpEnabled && mcpLoopbackRuntime
-      ? hashCliSessionText(JSON.stringify(promptTools.map((tool) => tool.name).toSorted()))
-      : undefined;
-  const reusableCliSessionCandidate: CliReusableSession = isSideQuestion
-    ? {}
-    : params.cliSessionBinding
-      ? resolveCliSessionReuse({
-          binding: params.cliSessionBinding,
-          authProfileId: effectiveAuthProfileId,
-          authEpoch,
-          authEpochVersion: CLI_AUTH_EPOCH_VERSION,
-          extraSystemPromptHash,
-          messageToolPolicyHash,
-          promptToolNamesHash,
-          cwdHash,
-          mcpConfigHash: preparedBackendFinal.mcpConfigHash,
-          mcpResumeHash: preparedBackendFinal.mcpResumeHash,
-        })
-      : params.cliSessionId
-        ? { sessionId: params.cliSessionId }
-        : {};
-  const candidateClaudeCliSessionId = reusableCliSessionCandidate.sessionId?.trim() || undefined;
-  const hasClaudeCliCandidate =
-    candidateClaudeCliSessionId !== undefined && isClaudeCliProvider(params.provider);
-  const claudeCliTranscriptMissing =
-    hasClaudeCliCandidate &&
-    !(await prepareDeps.claudeCliSessionTranscriptHasContent({
-      sessionId: candidateClaudeCliSessionId,
-      workspaceDir: cwd,
-    }));
-  const claudeCliTranscriptOrphanedToolUse =
-    hasClaudeCliCandidate &&
-    !claudeCliTranscriptMissing &&
-    (await prepareDeps.claudeCliSessionTranscriptHasOrphanedToolUse({
-      sessionId: candidateClaudeCliSessionId,
-      workspaceDir: cwd,
-    }));
-  const claudeCliInvalidatedReason: CliReusableSession["invalidatedReason"] | undefined =
-    claudeCliTranscriptMissing
-      ? "missing-transcript"
-      : claudeCliTranscriptOrphanedToolUse
-        ? "orphaned-tool-use"
-        : undefined;
-  const reusableCliSession: CliReusableSession = claudeCliInvalidatedReason
-    ? { invalidatedReason: claudeCliInvalidatedReason }
-    : reusableCliSessionCandidate;
-  if (reusableCliSession.invalidatedReason) {
-    cliBackendLog.info(
-      `cli session reset: provider=${params.provider} reason=${reusableCliSession.invalidatedReason}`,
-    );
-  }
-  let openClawHistoryMessages: unknown[] | undefined;
-  const loadOpenClawHistoryMessages = async () => {
-    openClawHistoryMessages ??= await loadCliSessionHistoryMessages({
-      sessionId: params.sessionId,
-      sessionFile: params.sessionFile,
-      sessionKey: params.sessionKey,
-      agentId: params.agentId,
-      config: params.config,
-    });
-    return openClawHistoryMessages;
-  };
-  const heartbeatPrompt =
-    isSideQuestion || params.bootstrapContextRunKind === "commitment-only"
-      ? undefined
-      : resolveHeartbeatPromptForSystemPrompt({
-          config: params.config,
-          agentId: sessionAgentId,
-          defaultAgentId,
-        });
-  const openClawReferences = isSideQuestion
-    ? { docsPath: null, sourcePath: null }
-    : await prepareDeps.resolveOpenClawReferencePaths({
-        workspaceDir,
-        argv1: process.argv[1],
-        cwd,
-        moduleUrl: import.meta.url,
-      });
-  const systemPromptSkillsPrompt =
-    isSideQuestion || claudeSkillsPlugin.args.length > 0
-      ? ""
-      : await resolveCliSkillsPrompt({
-          skillsSnapshot: params.skillsSnapshot,
-          workspaceDir,
-          config: params.config,
-          agentId: sessionAgentId,
-          sessionKey: params.sessionKey?.trim() || params.sessionId,
-        });
-  const runtimeChannel = isSideQuestion
-    ? undefined
-    : normalizeMessageChannel(params.messageChannel ?? params.messageProvider);
-  const runtimeCapabilities = isSideQuestion
-    ? undefined
-    : collectRuntimeChannelCapabilities({
-        cfg: params.config,
-        channel: runtimeChannel,
-        accountId: params.agentAccountId,
-      });
-  const builtSystemPrompt = isSideQuestion
-    ? extraSystemPrompt
-    : buildCliAgentSystemPrompt({
-        workspaceDir,
-        cwd,
-        config: params.config,
-        defaultThinkLevel: params.thinkLevel,
-        extraSystemPrompt,
-        sourceReplyDeliveryMode: params.sourceReplyDeliveryMode,
-        requireExplicitMessageTarget,
-        silentReplyPromptMode: params.silentReplyPromptMode,
-        runtimeChannel,
-        runtimeChatType: params.sessionEntry?.chatType,
-        runtimeCapabilities,
-        ownerNumbers: params.ownerNumbers,
-        heartbeatPrompt,
-        docsPath: openClawReferences.docsPath ?? undefined,
-        sourcePath: openClawReferences.sourcePath ?? undefined,
-        skillsPrompt: systemPromptSkillsPrompt,
-        tools: promptTools,
-        contextFiles,
-        modelDisplay,
-        agentId: sessionAgentId,
-        sessionKey: params.sessionKey,
-        sessionId: params.sessionId,
-      });
-  const transformedSystemPrompt = !isSideQuestion
-    ? (backendResolved.transformSystemPrompt?.({
-        config: params.config,
-        workspaceDir,
-        provider: params.provider,
-        modelId,
-        modelDisplay,
-        agentId: sessionAgentId,
-        systemPrompt: builtSystemPrompt,
-      }) ?? builtSystemPrompt)
-    : builtSystemPrompt;
-  let systemPrompt = transformedSystemPrompt;
-  let preparedPrompt = params.prompt;
-  if (!isSideQuestion) {
-    const hookRunner = getGlobalHookRunner();
-    try {
-      const hookResult = await resolvePromptBuildHookResult({
-        config: params.config ?? getRuntimeConfig(),
-        prompt: params.prompt,
-        messages: await loadOpenClawHistoryMessages(),
-        hookCtx: {
-          runId: params.runId,
+          silentReplyPromptMode: params.silentReplyPromptMode,
+          runtimeChannel,
+          runtimeChatType: params.sessionEntry?.chatType,
+          runtimeCapabilities,
+          ownerNumbers: params.ownerNumbers,
+          heartbeatPrompt,
+          docsPath: openClawReferences.docsPath ?? undefined,
+          sourcePath: openClawReferences.sourcePath ?? undefined,
+          skillsPrompt: systemPromptSkillsPrompt,
+          tools: promptTools,
+          contextFiles,
+          modelDisplay,
           agentId: sessionAgentId,
           sessionKey: params.sessionKey,
           sessionId: params.sessionId,
+        });
+    const transformedSystemPrompt = !isSideQuestion
+      ? (backendResolved.transformSystemPrompt?.({
+          config: params.config,
           workspaceDir,
-          modelProviderId: params.provider,
+          provider: params.provider,
           modelId,
-          trigger: params.trigger,
-          ...buildAgentHookContextChannelFields(params),
-        },
-        hookRunner,
-        bootstrapContextRunKind: params.bootstrapContextRunKind,
-      });
-      if (hookResult.prependContext) {
-        preparedPrompt = `${hookResult.prependContext}\n\n${preparedPrompt}`;
-      }
-      if (hookResult.appendContext) {
-        preparedPrompt = `${preparedPrompt}\n\n${hookResult.appendContext}`;
-      }
-      const hookSystemPrompt = hookResult.systemPrompt?.trim();
-      if (hookSystemPrompt) {
-        systemPrompt = hookSystemPrompt;
-      }
-      systemPrompt =
-        composeSystemPromptWithHookContext({
-          baseSystemPrompt: systemPrompt,
-          prependSystemContext: hookResult.prependSystemContext,
-          appendSystemContext: hookResult.appendSystemContext,
-        }) ?? systemPrompt;
-      const mediaTaskSystemPromptAddition = resolveAttemptMediaTaskSystemPromptAddition({
-        sessionKey: params.sessionKey,
-        trigger: params.trigger,
-      });
-      if (mediaTaskSystemPromptAddition) {
-        systemPrompt = prependSystemPromptAddition({
-          systemPrompt: ensureSystemPromptCacheBoundary(systemPrompt),
-          systemPromptAddition: mediaTaskSystemPromptAddition,
+          modelDisplay,
+          agentId: sessionAgentId,
+          systemPrompt: builtSystemPrompt,
+        }) ?? builtSystemPrompt)
+      : builtSystemPrompt;
+    let systemPrompt = transformedSystemPrompt;
+    let preparedPrompt = params.prompt;
+    if (!isSideQuestion) {
+      const hookRunner = getGlobalHookRunner();
+      try {
+        const hookResult = await resolvePromptBuildHookResult({
+          config: params.config ?? getRuntimeConfig(),
+          prompt: params.prompt,
+          messages: await loadOpenClawHistoryMessages(),
+          hookCtx: {
+            runId: params.runId,
+            agentId: sessionAgentId,
+            sessionKey: params.sessionKey,
+            sessionId: params.sessionId,
+            workspaceDir,
+            modelProviderId: params.provider,
+            modelId,
+            trigger: params.trigger,
+            ...buildAgentHookContextChannelFields(params),
+          },
+          hookRunner,
+          bootstrapContextRunKind: params.bootstrapContextRunKind,
         });
-      }
-    } catch (error) {
-      cliBackendLog.warn(`cli prompt-build hook preparation failed: ${String(error)}`);
-    }
-  }
-  let historyPromptCurrentTurn = preparedPrompt;
-  if (!isSideQuestion) {
-    const fullCurrentInboundPrompt = buildCurrentInboundPrompt({
-      context: params.currentInboundContext,
-      prompt: preparedPrompt,
-    });
-    const runCurrentInboundPrompt = buildCurrentInboundPrompt({
-      context: params.currentInboundContext,
-      prompt: preparedPrompt,
-      preferResumableText:
-        params.currentInboundEventKind === "room_event" && Boolean(reusableCliSession.sessionId),
-    });
-    historyPromptCurrentTurn = annotateInterSessionPromptText(
-      fullCurrentInboundPrompt,
-      params.inputProvenance,
-    );
-    preparedPrompt = annotateInterSessionPromptText(
-      runCurrentInboundPrompt,
-      params.inputProvenance,
-    );
-  }
-  const allowRawTranscriptReseed =
-    backendResolved.config.reseedFromRawTranscriptWhenUncompacted === true;
-  const rawTranscriptReseedReason = reusableCliSession.sessionId
-    ? "session-expired"
-    : reusableCliSession.invalidatedReason;
-  const shouldPrepareOpenClawHistoryPrompt =
-    !isSideQuestion && (!reusableCliSession.sessionId || allowRawTranscriptReseed);
-  const openClawHistoryPrompt = shouldPrepareOpenClawHistoryPrompt
-    ? buildCliSessionHistoryPrompt({
-        messages: await loadCliSessionReseedMessages({
-          sessionId: params.sessionId,
-          sessionFile: params.sessionFile,
+        if (hookResult.prependContext) {
+          preparedPrompt = `${hookResult.prependContext}\n\n${preparedPrompt}`;
+        }
+        if (hookResult.appendContext) {
+          preparedPrompt = `${preparedPrompt}\n\n${hookResult.appendContext}`;
+        }
+        const hookSystemPrompt = hookResult.systemPrompt?.trim();
+        if (hookSystemPrompt) {
+          systemPrompt = hookSystemPrompt;
+        }
+        systemPrompt =
+          composeSystemPromptWithHookContext({
+            baseSystemPrompt: systemPrompt,
+            prependSystemContext: hookResult.prependSystemContext,
+            appendSystemContext: hookResult.appendSystemContext,
+          }) ?? systemPrompt;
+        const mediaTaskSystemPromptAddition = resolveAttemptMediaTaskSystemPromptAddition({
           sessionKey: params.sessionKey,
-          agentId: params.agentId,
-          config: params.config,
-          allowRawTranscriptReseed,
-          rawTranscriptReseedReason,
-        }),
-        prompt: historyPromptCurrentTurn,
-        maxHistoryChars: autoReseedHistoryChars,
-      })
-    : undefined;
-  const systemPromptWithReplacements = applyPluginTextReplacements(
-    systemPrompt,
-    backendResolved.textTransforms?.input,
-  );
-  // Ensure the cache boundary before appending the model identity so the identity lands in the
-  // dynamic suffix, not the cached prefix, for marker-free hook overrides — otherwise an idle
-  // turn's prefix (O + identity) diverges from an active media turn's prefix (O) and breaks
-  // prompt caching. Skip empty prompts and turns with no identity line, which need no boundary.
-  systemPrompt = isSideQuestion
-    ? systemPromptWithReplacements
-    : appendModelIdentitySystemPrompt({
-        systemPrompt:
-          buildModelIdentityPromptLine(modelDisplay) &&
-          systemPromptWithReplacements.trim().length > 0
-            ? ensureSystemPromptCacheBoundary(systemPromptWithReplacements)
-            : systemPromptWithReplacements,
-        model: modelDisplay,
+          trigger: params.trigger,
+        });
+        if (mediaTaskSystemPromptAddition) {
+          systemPrompt = prependSystemPromptAddition({
+            systemPrompt: ensureSystemPromptCacheBoundary(systemPrompt),
+            systemPromptAddition: mediaTaskSystemPromptAddition,
+          });
+        }
+      } catch (error) {
+        cliBackendLog.warn(`cli prompt-build hook preparation failed: ${String(error)}`);
+      }
+    }
+    let historyPromptCurrentTurn = preparedPrompt;
+    if (!isSideQuestion) {
+      const fullCurrentInboundPrompt = buildCurrentInboundPrompt({
+        context: params.currentInboundContext,
+        prompt: preparedPrompt,
       });
-  const systemPromptReport = buildSystemPromptReport({
-    source: "run",
-    generatedAt: Date.now(),
-    sessionId: params.sessionId,
-    sessionKey: params.sessionKey,
-    provider: params.provider,
-    model: modelId,
-    workspaceDir,
-    bootstrapMaxChars,
-    bootstrapTotalMaxChars,
-    bootstrapTruncation: buildBootstrapTruncationReportMeta({
-      analysis: bootstrapAnalysis,
-      warningMode: bootstrapPromptWarningMode,
-      warning: bootstrapPromptWarning,
-    }),
-    sandbox: { mode: "off", sandboxed: false },
-    systemPrompt,
-    bootstrapFiles,
-    injectedFiles: contextFiles,
-    skillsPrompt: systemPromptSkillsPrompt,
-    tools: promptTools,
-    currentTurn: {
-      ...(params.currentInboundEventKind ? { kind: params.currentInboundEventKind } : {}),
-      promptChars: preparedPrompt.length,
-      runtimeContextChars: 0,
-    },
-  });
-  const contextEngineConfig = params.config ?? getRuntimeConfig();
-  if (isSideQuestion) {
-    const preparedParams: RunCliAgentParams = {
-      ...params,
-      config: contextEngineConfig,
-      prompt: preparedPrompt,
-      ...(requireExplicitMessageTarget ? { requireExplicitMessageTarget: true } : {}),
-    };
-
-    return {
-      params: preparedParams,
-      effectiveAuthProfileId,
-      started,
-      workspaceDir,
-      cwd,
-      backendResolved,
-      preparedBackend: preparedBackendFinal,
-      reusableCliSession,
-      hadSessionFile: false,
-      contextEngineConfig,
-      modelId,
-      normalizedModel,
-      contextWindowInfo,
+      const runCurrentInboundPrompt = buildCurrentInboundPrompt({
+        context: params.currentInboundContext,
+        prompt: preparedPrompt,
+        preferResumableText:
+          params.currentInboundEventKind === "room_event" && Boolean(reusableCliSession.sessionId),
+      });
+      historyPromptCurrentTurn = annotateInterSessionPromptText(
+        fullCurrentInboundPrompt,
+        params.inputProvenance,
+      );
+      preparedPrompt = annotateInterSessionPromptText(
+        runCurrentInboundPrompt,
+        params.inputProvenance,
+      );
+    }
+    const allowRawTranscriptReseed =
+      backendResolved.config.reseedFromRawTranscriptWhenUncompacted === true;
+    const rawTranscriptReseedReason = reusableCliSession.sessionId
+      ? "session-expired"
+      : reusableCliSession.invalidatedReason;
+    const shouldPrepareOpenClawHistoryPrompt =
+      !isSideQuestion && (!reusableCliSession.sessionId || allowRawTranscriptReseed);
+    const openClawHistoryPrompt = shouldPrepareOpenClawHistoryPrompt
+      ? buildCliSessionHistoryPrompt({
+          messages: await loadCliSessionReseedMessages({
+            sessionId: params.sessionId,
+            sessionFile: params.sessionFile,
+            sessionKey: params.sessionKey,
+            agentId: params.agentId,
+            config: params.config,
+            allowRawTranscriptReseed,
+            rawTranscriptReseedReason,
+          }),
+          prompt: historyPromptCurrentTurn,
+          maxHistoryChars: autoReseedHistoryChars,
+        })
+      : undefined;
+    const systemPromptWithReplacements = applyPluginTextReplacements(
       systemPrompt,
-      systemPromptReport,
-      claudeSkillsPluginArgs: claudeSkillsPlugin.args,
-      bootstrapPromptWarningLines: bootstrapPromptWarning.lines,
-      authEpoch,
-      authEpochVersion: CLI_AUTH_EPOCH_VERSION,
-      extraSystemPromptHash,
-      messageToolPolicyHash,
-      promptToolNamesHash,
-      cwdHash,
-      ...(mcpDeliveryCaptureEnabled ? { mcpDeliveryCapture: true } : {}),
-    };
-  }
-  try {
+      backendResolved.textTransforms?.input,
+    );
+    // Ensure the cache boundary before appending the model identity so the identity lands in the
+    // dynamic suffix, not the cached prefix, for marker-free hook overrides — otherwise an idle
+    // turn's prefix (O + identity) diverges from an active media turn's prefix (O) and breaks
+    // prompt caching. Skip empty prompts and turns with no identity line, which need no boundary.
+    systemPrompt = isSideQuestion
+      ? systemPromptWithReplacements
+      : appendModelIdentitySystemPrompt({
+          systemPrompt:
+            buildModelIdentityPromptLine(modelDisplay) &&
+            systemPromptWithReplacements.trim().length > 0
+              ? ensureSystemPromptCacheBoundary(systemPromptWithReplacements)
+              : systemPromptWithReplacements,
+          model: modelDisplay,
+        });
+    const systemPromptReport = buildSystemPromptReport({
+      source: "run",
+      generatedAt: Date.now(),
+      sessionId: params.sessionId,
+      sessionKey: params.sessionKey,
+      provider: params.provider,
+      model: modelId,
+      workspaceDir,
+      bootstrapMaxChars,
+      bootstrapTotalMaxChars,
+      bootstrapTruncation: buildBootstrapTruncationReportMeta({
+        analysis: bootstrapAnalysis,
+        warningMode: bootstrapPromptWarningMode,
+        warning: bootstrapPromptWarning,
+      }),
+      sandbox: { mode: "off", sandboxed: false },
+      systemPrompt,
+      bootstrapFiles,
+      injectedFiles: contextFiles,
+      skillsPrompt: systemPromptSkillsPrompt,
+      tools: promptTools,
+      currentTurn: {
+        ...(params.currentInboundEventKind ? { kind: params.currentInboundEventKind } : {}),
+        promptChars: preparedPrompt.length,
+        runtimeContextChars: 0,
+      },
+    });
+    const contextEngineConfig = params.config ?? getRuntimeConfig();
+    if (isSideQuestion) {
+      const preparedParams: RunCliAgentParams = {
+        ...params,
+        config: contextEngineConfig,
+        prompt: preparedPrompt,
+        ...(requireExplicitMessageTarget ? { requireExplicitMessageTarget: true } : {}),
+      };
+
+      return {
+        params: preparedParams,
+        effectiveAuthProfileId,
+        started,
+        workspaceDir,
+        cwd,
+        backendResolved,
+        preparedBackend: preparedBackendFinal,
+        reusableCliSession,
+        hadSessionFile: false,
+        contextEngineConfig,
+        modelId,
+        normalizedModel,
+        contextWindowInfo,
+        systemPrompt,
+        systemPromptReport,
+        claudeSkillsPluginArgs: claudeSkillsPlugin.args,
+        bootstrapPromptWarningLines: bootstrapPromptWarning.lines,
+        authEpoch,
+        authEpochVersion: CLI_AUTH_EPOCH_VERSION,
+        extraSystemPromptHash,
+        messageToolPolicyHash,
+        promptToolNamesHash,
+        cwdHash,
+        ...(mcpDeliveryCaptureEnabled ? { mcpDeliveryCapture: true } : {}),
+      };
+    }
     ensureContextEnginesInitialized();
     const { sessionAgentId: contextEngineSessionAgentId } = resolveSessionAgentIds({
       sessionKey: params.sessionKey,
@@ -977,7 +984,7 @@ export async function prepareCliRunContext(
     };
   } catch (err) {
     try {
-      await preparedBackendFinal.cleanup?.();
+      await cleanupPreparedResources?.();
     } catch (cleanupErr) {
       cliBackendLog.warn(`cli backend cleanup after prepare failure failed: ${String(cleanupErr)}`);
     }

--- a/src/agents/cli-runner/session-history.test.ts
+++ b/src/agents/cli-runner/session-history.test.ts
@@ -3,8 +3,9 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { CURRENT_SESSION_VERSION } from "openclaw/plugin-sdk/agent-sessions";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { withEnvAsync } from "../../test-utils/env.js";
+import { cliBackendLog } from "./log.js";
 import {
   buildCliSessionHistoryPrompt,
   hasCliSessionTranscript,
@@ -420,7 +421,7 @@ describe("loadCliSessionHistoryMessages", () => {
     }
   });
 
-  it("drops oversized transcript files instead of loading them into hook payloads", async () => {
+  it("loads a bounded tail from oversized transcript files", async () => {
     const stateDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-cli-state-"));
     const sessionFile = path.join(
       stateDir,
@@ -429,21 +430,173 @@ describe("loadCliSessionHistoryMessages", () => {
       "sessions",
       "session-oversized.jsonl",
     );
+    const warnSpy = vi.spyOn(cliBackendLog, "warn").mockImplementation(() => undefined);
     fs.mkdirSync(path.dirname(sessionFile), { recursive: true });
-    fs.writeFileSync(sessionFile, "x".repeat(MAX_CLI_SESSION_HISTORY_FILE_BYTES + 1), "utf-8");
+    fs.writeFileSync(
+      sessionFile,
+      [
+        JSON.stringify({
+          type: "session",
+          version: CURRENT_SESSION_VERSION,
+          id: "session-oversized",
+          timestamp: new Date(0).toISOString(),
+          cwd: stateDir,
+        }),
+        JSON.stringify({
+          type: "message",
+          id: "old",
+          parentId: null,
+          timestamp: new Date(1).toISOString(),
+          message: {
+            role: "user",
+            content: "x".repeat(MAX_CLI_SESSION_HISTORY_FILE_BYTES),
+            timestamp: 1,
+          },
+        }),
+        JSON.stringify({
+          type: "message",
+          id: "tail",
+          parentId: "old",
+          timestamp: new Date(2).toISOString(),
+          message: { role: "user", content: "tail history", timestamp: 2 },
+        }),
+      ].join("\n") + "\n",
+      "utf-8",
+    );
 
     try {
       await withCliSessionState(stateDir, async () => {
-        expect(
-          await loadCliSessionHistoryMessages({
-            sessionId: "session-oversized",
+        const history = await loadCliSessionHistoryMessages({
+          sessionId: "session-oversized",
+          sessionFile,
+          sessionKey: "agent:main:main",
+          agentId: "main",
+        });
+        expect(history).toHaveLength(1);
+        expectMessageFields(history[0], { role: "user", content: "tail history" });
+        expect(warnSpy).toHaveBeenCalledWith(
+          expect.stringContaining("cli session history truncated to last"),
+        );
+      });
+    } finally {
+      warnSpy.mockRestore();
+      fs.rmSync(stateDir, { recursive: true, force: true });
+    }
+  });
+
+  it("skips oversized transcript tails when branch controls were dropped", async () => {
+    const stateDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-cli-state-"));
+    const sessionFile = path.join(
+      stateDir,
+      "agents",
+      "main",
+      "sessions",
+      "session-oversized-branch.jsonl",
+    );
+    const warnSpy = vi.spyOn(cliBackendLog, "warn").mockImplementation(() => undefined);
+    fs.mkdirSync(path.dirname(sessionFile), { recursive: true });
+    fs.writeFileSync(
+      sessionFile,
+      [
+        JSON.stringify({
+          type: "session",
+          version: CURRENT_SESSION_VERSION,
+          id: "session-oversized-branch",
+          timestamp: new Date(0).toISOString(),
+          cwd: stateDir,
+        }),
+        JSON.stringify({
+          type: "message",
+          id: "root",
+          parentId: null,
+          timestamp: new Date(1).toISOString(),
+          message: { role: "user", content: "root", timestamp: 1 },
+        }),
+        JSON.stringify({
+          type: "leaf",
+          id: "active-leaf",
+          parentId: "side-entry",
+          timestamp: new Date(2).toISOString(),
+          targetId: "root",
+        }),
+        JSON.stringify({
+          type: "message",
+          id: "filler",
+          parentId: "root",
+          timestamp: new Date(3).toISOString(),
+          message: {
+            role: "assistant",
+            content: "x".repeat(MAX_CLI_SESSION_HISTORY_FILE_BYTES),
+            timestamp: 3,
+          },
+        }),
+        JSON.stringify({
+          type: "message",
+          id: "side-entry",
+          parentId: "root",
+          timestamp: new Date(4).toISOString(),
+          message: { role: "assistant", content: "side history", timestamp: 4 },
+        }),
+        JSON.stringify({
+          type: "message",
+          id: "active-tail",
+          parentId: "root",
+          timestamp: new Date(5).toISOString(),
+          message: { role: "assistant", content: "active history", timestamp: 5 },
+        }),
+      ].join("\n") + "\n",
+      "utf-8",
+    );
+
+    try {
+      await withCliSessionState(stateDir, async () => {
+        await expect(
+          loadCliSessionHistoryMessages({
+            sessionId: "session-oversized-branch",
             sessionFile,
             sessionKey: "agent:main:main",
             agentId: "main",
           }),
-        ).toStrictEqual([]);
+        ).resolves.toStrictEqual([]);
+        expect(warnSpy).toHaveBeenCalledWith(
+          expect.stringContaining("cli session history truncated tail skipped"),
+        );
       });
     } finally {
+      warnSpy.mockRestore();
+      fs.rmSync(stateDir, { recursive: true, force: true });
+    }
+  });
+
+  it("warns when transcript parsing fails", async () => {
+    const stateDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-cli-state-"));
+    const sessionFile = path.join(
+      stateDir,
+      "agents",
+      "main",
+      "sessions",
+      "session-invalid-jsonl.jsonl",
+    );
+    const warnSpy = vi.spyOn(cliBackendLog, "warn").mockImplementation(() => undefined);
+    fs.mkdirSync(path.dirname(sessionFile), { recursive: true });
+    fs.writeFileSync(sessionFile, "{not-json}\n", "utf-8");
+
+    try {
+      await withCliSessionState(stateDir, async () => {
+        await expect(
+          loadCliSessionHistoryMessages({
+            sessionId: "session-invalid-jsonl",
+            sessionFile,
+            sessionKey: "agent:main:main",
+            agentId: "main",
+          }),
+        ).resolves.toStrictEqual([]);
+        expect(warnSpy).toHaveBeenCalledWith(
+          expect.stringContaining("cli session history parse failed:"),
+        );
+      });
+    } finally {
+      warnSpy.mockRestore();
       fs.rmSync(stateDir, { recursive: true, force: true });
     }
   });

--- a/src/agents/cli-runner/session-history.ts
+++ b/src/agents/cli-runner/session-history.ts
@@ -8,8 +8,12 @@ import {
   resolveSessionFilePath,
   resolveSessionFilePathOptions,
 } from "../../config/sessions/paths.js";
-import { selectSessionTranscriptLeafControlledPath } from "../../config/sessions/transcript-tree.js";
+import {
+  scanSessionTranscriptTree,
+  selectSessionTranscriptLeafControlledPath,
+} from "../../config/sessions/transcript-tree.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
+import { formatErrorMessage } from "../../infra/errors.js";
 import { isPathInside } from "../../infra/path-guards.js";
 import { resolveSessionAgentIds } from "../agent-scope.js";
 import {
@@ -18,6 +22,7 @@ import {
 } from "../harness/hook-history.js";
 import type { AgentMessage } from "../runtime/index.js";
 import { migrateSessionEntries, parseSessionEntries } from "../sessions/session-manager.js";
+import { cliBackendLog } from "./log.js";
 
 /** Maximum transcript size read for CLI session history. */
 export const MAX_CLI_SESSION_HISTORY_FILE_BYTES = 5 * 1024 * 1024;
@@ -29,6 +34,7 @@ export const MAX_CLI_SESSION_RESEED_HISTORY_CHARS = 12 * 1024;
 export const MAX_AUTO_CLI_SESSION_RESEED_HISTORY_CHARS = 256 * 1024;
 const CLI_SESSION_RESEED_HISTORY_CONTEXT_SHARE = 0.08;
 const CHARS_PER_TOKEN_ESTIMATE = 4;
+const CLI_SESSION_HISTORY_HEADER_READ_BYTES = 64 * 1024;
 
 type HistoryMessage = {
   role?: unknown;
@@ -275,6 +281,109 @@ async function safeRealpath(filePath: string): Promise<string | undefined> {
   }
 }
 
+function isFileNotFoundError(error: unknown): boolean {
+  return Boolean(
+    error &&
+    typeof error === "object" &&
+    "code" in error &&
+    (error as { code?: unknown }).code === "ENOENT",
+  );
+}
+
+async function readCliSessionHeaderLine(filePath: string): Promise<string | undefined> {
+  const handle = await fsp.open(filePath, "r");
+  try {
+    const buffer = Buffer.alloc(CLI_SESSION_HISTORY_HEADER_READ_BYTES);
+    const { bytesRead } = await handle.read(buffer, 0, buffer.length, 0);
+    const firstChunk = buffer.subarray(0, bytesRead).toString("utf-8");
+    const lineEnd = firstChunk.indexOf("\n");
+    if (lineEnd < 0) {
+      return undefined;
+    }
+    const line = firstChunk.slice(0, lineEnd);
+    const parsed = JSON.parse(line) as { type?: unknown };
+    return parsed.type === "session" ? line : undefined;
+  } catch {
+    return undefined;
+  } finally {
+    await handle.close();
+  }
+}
+
+async function readBoundedCliSessionTranscript(
+  filePath: string,
+  fileSize: number,
+): Promise<{ content: string; truncated: boolean }> {
+  if (fileSize <= MAX_CLI_SESSION_HISTORY_FILE_BYTES) {
+    return { content: await fsp.readFile(filePath, "utf-8"), truncated: false };
+  }
+
+  cliBackendLog.warn(
+    `cli session history truncated to last ${MAX_CLI_SESSION_HISTORY_FILE_BYTES} bytes: ${filePath}`,
+  );
+  const handle = await fsp.open(filePath, "r");
+  try {
+    const buffer = Buffer.alloc(MAX_CLI_SESSION_HISTORY_FILE_BYTES);
+    await handle.read(buffer, 0, buffer.length, fileSize - buffer.length);
+    const tail = buffer.toString("utf-8");
+    const firstLineEnd = tail.indexOf("\n");
+    const completeTail = firstLineEnd >= 0 ? tail.slice(firstLineEnd + 1) : "";
+    const headerLine = await readCliSessionHeaderLine(filePath);
+    return {
+      content: headerLine ? `${headerLine}\n${completeTail}` : completeTail,
+      truncated: true,
+    };
+  } finally {
+    await handle.close();
+  }
+}
+
+function isSafeTruncatedCliSessionTail(entries: readonly unknown[]): boolean {
+  const tree = scanSessionTranscriptTree(entries);
+  if (tree.hasLeafControl) {
+    return !tree.hasInvalidLeafControl;
+  }
+  const childParentIds = new Set<string>();
+  let truncatedRootParentId: string | undefined;
+  for (const node of tree.nodes) {
+    if (node.appendMode === "side") {
+      return false;
+    }
+    if (node.parentId === null) {
+      continue;
+    }
+    if (!tree.byId.has(node.parentId)) {
+      if (truncatedRootParentId !== undefined || childParentIds.size > 0) {
+        return false;
+      }
+      truncatedRootParentId = node.parentId;
+      continue;
+    }
+    if (childParentIds.has(node.parentId)) {
+      return false;
+    }
+    childParentIds.add(node.parentId);
+  }
+  return true;
+}
+
+function parseCliSessionEntries(
+  content: string,
+): ReturnType<typeof parseSessionEntries> | undefined {
+  for (const line of content.trim().split("\n")) {
+    if (!line.trim()) {
+      continue;
+    }
+    try {
+      JSON.parse(line);
+    } catch (error) {
+      cliBackendLog.warn(`cli session history parse failed: ${formatErrorMessage(error)}`);
+      return undefined;
+    }
+  }
+  return parseSessionEntries(content);
+}
+
 function resolveSafeCliSessionFile(params: {
   sessionId: string;
   sessionFile: string;
@@ -325,14 +434,27 @@ async function loadCliSessionEntries(params: {
       return [];
     }
     const stat = await fsp.stat(realSessionFile);
-    if (!stat.isFile() || stat.size > MAX_CLI_SESSION_HISTORY_FILE_BYTES) {
+    if (!stat.isFile()) {
       return [];
     }
-    const entries = parseSessionEntries(await fsp.readFile(realSessionFile, "utf-8"));
+    const transcript = await readBoundedCliSessionTranscript(realSessionFile, stat.size);
+    const entries = parseCliSessionEntries(transcript.content);
+    if (!entries) {
+      return [];
+    }
     migrateSessionEntries(entries);
     const sessionEntries = entries.filter((entry) => entry.type !== "session");
+    if (transcript.truncated && !isSafeTruncatedCliSessionTail(sessionEntries)) {
+      cliBackendLog.warn(
+        `cli session history truncated tail skipped because branch controls are incomplete: ${realSessionFile}`,
+      );
+      return [];
+    }
     return selectSessionTranscriptLeafControlledPath(sessionEntries) ?? sessionEntries;
-  } catch {
+  } catch (error) {
+    if (!isFileNotFoundError(error)) {
+      cliBackendLog.warn(`cli session history load failed: ${formatErrorMessage(error)}`);
+    }
     return [];
   }
 }
@@ -361,7 +483,7 @@ export async function hasCliSessionTranscript(params: {
       return false;
     }
     const stat = await fsp.stat(realSessionFile);
-    return stat.isFile() && stat.size <= MAX_CLI_SESSION_HISTORY_FILE_BYTES;
+    return stat.isFile();
   } catch {
     return false;
   }


### PR DESCRIPTION
Fixes #98946

## What Problem This Solves

Six lifecycle/cleanup defects in the claude-cli backend from the reliability audit — the tail of the same audit that produced #98933, #98934, #98942, and #98983:

1. A loopback MCP server startup failure was warn-and-continue: runs proceeded with bundled MCP enabled but no `openclaw` server, so agents ran whole turns with no messaging/gateway tools, and in `message_tool_only` delivery the visible reply was silently lost.
2. ~30 lines of dead "drain aborted turn" state in the live session (`drainingAbortedTurn`/`drainTimer`) — never activated since their introducing commit.
3. A live Claude process exiting 0 mid-turn produced a plain `Error`, bypassing failover entirely, while the identical one-shot outcome rotated the fallback chain via `FailoverError("empty_response")`.
4. Transcripts over 5MB silently disabled all reseed history (`return []`, parse errors swallowed) — and since claude-cli owns native compaction, long sessions can cross 5MB, after which any binding invalidation reseeded with zero context, unlogged.
5. CLI prompt image files were written content-addressed with a deliberate no-op cleanup, but no sweeper existed anywhere — unbounded disk growth per distinct inbound image.
6. Temp MCP-config and skills-plugin dirs leaked whenever preparation threw between backend prep and the two guarded regions (auth-epoch read, transcript probes, reference-path/sandbox/reseed stages were all unguarded).

## Why This Change Was Made

Bundled-MCP runs now fail loudly at prepare when the loopback server cannot start or publishes no runtime (no legitimate loopback-less bundleMcp mode exists — side questions and `disableTools` already skip bundled MCP). The dead drain machinery is deleted outright. Quiet exit-0/no-result live turns classify as `FailoverError("empty_response")`, attaching the `cli_unknown_empty_failure` retry code only when the turn observed no stdout activity — mirroring the one-shot path's gates rather than inventing looser ones. Oversized transcripts reseed from a bounded 5MB tail (first partial JSONL line dropped, session header preserved) and warn once on truncation or malformed lines. `writeCliImages` opportunistically sweeps files older than 7 days once per root per process (ENOENT-tolerant, debug-only on errors; the content-addressed path-stability contract is preserved — expired files are simply rewritten if needed again). Prepare cleanup now has a single try/catch owner covering every prepared resource from creation until ownership passes to the returned context, absorbing the two previous partial guards; the `beforeExecution` staging thunk from #98983 threads through the restructure unchanged. Fixes 2 and 6 together are LOC-negative in source (+456/−458).

## User Impact

Loopback failures surface as actionable errors instead of silently tool-less agents and lost replies. Mid-turn clean exits now take model fallback and recovery retries. Long-running sessions keep (bounded) reseed context instead of silently losing all of it past 5MB. Image-heavy deployments stop growing disk without bound, and failed preparations stop leaking temp directories.

## Evidence

- New/extended tests: loopback failure fails prepare; exit-0 classification with and without observed stdout; bounded-tail reseed including header preservation and malformed-line warning; image sweep TTL behavior; mid-prepare throw cleans the MCP temp dir and skills-plugin dir.
- Rebase proof over #98983: `git diff origin/main` is empty for that PR's landed test files (`bundle-mcp.test.ts`, `execute.supervisor-capture.test.ts`, `extensions/google/setup-api.test.ts`); `prepare.test.ts` differs only by this PR's own additive prepare-path tests.
- Validation on the rebased branch: `node scripts/run-vitest.mjs` across prepare, spawn, session-history, helpers, reliability, execute supervisor-capture, bundle-mcp, and google setup-api suites (284 tests pass); extension-boundary import gate plus the boundary/tooling Vitest pair (94 tests) — the gates that caught #98983's first push; full remote `pnpm check:changed` green pre-rebase on Blacksmith Testbox `tbx_01kwgv54a1ak84zjy04pmesg8t` (https://github.com/openclaw/openclaw/actions/runs/28572651592, exit 0); repo autoreview (branch mode vs origin/main) clean.
