### PR TITLE
fix: prevent encoded plugin prefix sibling matches

### DIFF
--- a/src/gateway/security-path.test.ts
+++ b/src/gateway/security-path.test.ts
@@ -90,6 +90,8 @@ describe("security-path protected-prefix matching", () => {
   it("does not protect unrelated paths", () => {
     expect(isProtectedPluginRoutePath("/plugin/public")).toBe(false);
     expect(isProtectedPluginRoutePath("/api/channels-public")).toBe(false);
+    expect(isProtectedPluginRoutePath("/api/channels%2dpublic")).toBe(false);
+    expect(isProtectedPluginRoutePath("/api/channels%252dpublic")).toBe(false);
     expect(isProtectedPluginRoutePath("/api/foo/..%2fchannels-public")).toBe(false);
     expect(isProtectedPluginRoutePath("/api/channel")).toBe(false);
   });

--- a/src/gateway/security-path.ts
+++ b/src/gateway/security-path.ts
@@ -101,12 +101,12 @@ export function canonicalizePathVariant(pathname: string): string {
 }
 
 function prefixMatch(pathname: string, prefix: string): boolean {
-  return (
-    pathname === prefix ||
-    pathname.startsWith(`${prefix}/`) ||
-    // Fail closed when malformed %-encoding follows the protected prefix.
-    pathname.startsWith(`${prefix}%`)
-  );
+  return pathname === prefix || pathname.startsWith(`${prefix}/`);
+}
+
+function prefixMatchMalformedRawPath(pathname: string, prefix: string): boolean {
+  // Fail closed when malformed %-encoding follows the protected prefix.
+  return prefixMatch(pathname, prefix) || pathname.startsWith(`${prefix}%`);
 }
 
 export function canonicalizePathForSecurity(pathname: string): SecurityPathCanonicalization {
@@ -152,7 +152,9 @@ export function isPathProtectedByPrefixes(pathname: string, prefixes: readonly s
   if (!canonical.malformedEncoding) {
     return false;
   }
-  return normalizedPrefixes.some((prefix) => prefixMatch(canonical.rawNormalizedPath, prefix));
+  return normalizedPrefixes.some((prefix) =>
+    prefixMatchMalformedRawPath(canonical.rawNormalizedPath, prefix),
+  );
 }
 
 export const PROTECTED_PLUGIN_ROUTE_PREFIXES = ["/api/channels"] as const;

--- a/src/gateway/server/plugins-http.test.ts
+++ b/src/gateway/server/plugins-http.test.ts
@@ -503,6 +503,27 @@ describe("plugin HTTP route auth checks", () => {
     expect(isRegisteredPluginHttpRoutePath(registry, "/api/%2564emo")).toBe(true);
   });
 
+  it("does not match percent-encoded prefix siblings", async () => {
+    const routeHandler = vi.fn(async (_req, res: ServerResponse) => {
+      res.statusCode = 200;
+    });
+    const registry = createTestRegistry({
+      httpRoutes: [createRoute({ path: "/googlechat", match: "prefix", handler: routeHandler })],
+    });
+
+    expect(isRegisteredPluginHttpRoutePath(registry, "/googlechat%2dpublic")).toBe(false);
+
+    const handler = createGatewayPluginRequestHandler({
+      registry,
+      log: createPluginLog(),
+    });
+    const { res } = makeMockHttpResponse();
+    const handled = await handler({ url: "/googlechat%2dpublic" } as IncomingMessage, res);
+
+    expect(handled).toBe(false);
+    expect(routeHandler).not.toHaveBeenCalled();
+  });
+
   it("enforces auth for protected and gateway-auth routes", () => {
     const registry = createTestRegistry({
       httpRoutes: [

--- a/src/gateway/server/plugins-http/path-context.ts
+++ b/src/gateway/server/plugins-http/path-context.ts
@@ -27,9 +27,11 @@ function normalizeProtectedPrefix(prefix: string): string {
 
 /** Matches a normalized path against an exact protected prefix boundary. */
 export function prefixMatchPath(pathname: string, prefix: string): boolean {
-  return (
-    pathname === prefix || pathname.startsWith(`${prefix}/`) || pathname.startsWith(`${prefix}%`)
-  );
+  return pathname === prefix || pathname.startsWith(`${prefix}/`);
+}
+
+function prefixMatchMalformedRawPath(pathname: string, prefix: string): boolean {
+  return prefixMatchPath(pathname, prefix) || pathname.startsWith(`${prefix}%`);
 }
 
 const NORMALIZED_PROTECTED_PLUGIN_ROUTE_PREFIXES =
@@ -50,7 +52,7 @@ export function isProtectedPluginRoutePathFromContext(context: PluginRoutePathCo
     return false;
   }
   return NORMALIZED_PROTECTED_PLUGIN_ROUTE_PREFIXES.some((prefix) =>
-    prefixMatchPath(context.rawNormalizedPath, prefix),
+    prefixMatchMalformedRawPath(context.rawNormalizedPath, prefix),
   );
 }
 


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where plugin HTTP prefix routes could match a percent-encoded sibling path when the encoded character was not a path separator. For example, a prefix route registered at `/googlechat` could incorrectly claim `/googlechat%2dpublic`, even though that canonicalizes to `/googlechat-public` rather than a child route.

## Why This Change Was Made

Normal prefix matching now requires an exact match or a slash boundary. The existing percent-boundary fail-closed behavior is kept only for malformed raw protected paths, so invalid encodings such as `/api/channels%zz` still require gateway auth while valid encoded sibling names do not get treated as protected child paths.

## User Impact

Plugin authors and gateway operators get stricter route isolation: one plugin prefix can no longer claim a sibling route just because the sibling name uses percent encoding. Malformed protected paths still fail closed for auth.

## Evidence

- Before: the existing prefix helper returned `true` for `/googlechat%2dpublic` under `/googlechat` and `/api/channels%2dpublic` under `/api/channels`.
- After: a direct boundary check returns `false` for those valid encoded sibling paths and `true` for malformed raw `/api/channels%zz` fail-closed handling.
- `node --check src/gateway/security-path.ts`
- `node --check src/gateway/server/plugins-http/path-context.ts`
- `node --check src/gateway/security-path.test.ts`
- `node --check src/gateway/server/plugins-http.test.ts`
- `git diff --check`

Focused source-backed behavior proof, run locally against the touched TypeScript source files with a temporary Node loader for `.ts` source imports and the tiny normalization helper:

```text
$ node --experimental-strip-types --experimental-loader /private/tmp/openclaw-loader-XXXXXX.mjs /private/tmp/openclaw-proof-XXXXXX.mts
plugin exact prefix: true (expected true)
plugin encoded sibling: false (expected false)
protected child: true (expected true)
protected encoded sibling: false (expected false)
protected malformed raw: true (expected true)
encoded sibling canonical path: /api/channels-public
encoded sibling protected from context: false (expected false)
malformed raw path marked malformed: true
malformed raw protected from context: true (expected true)
```

Focused Vitest was not run locally because this sparse checkout has no `node_modules`; `node scripts/check-changed.mjs --dry-run ...` failed on missing package `yaml`, and an external dependency hydration attempt under `/Volumes/STOREJET/2/Dependencies` hit the remaining SSD space limit. The PR adds focused regression coverage in `src/gateway/server/plugins-http.test.ts` and `src/gateway/security-path.test.ts`.
