### PR TITLE
Preserve Codex output after missing turn completion

### DIFF
--- a/src/agents/embedded-agent-runner/run.codex-app-server-recovery.test.ts
+++ b/src/agents/embedded-agent-runner/run.codex-app-server-recovery.test.ts
@@ -244,6 +244,46 @@ describe("runEmbeddedAgent Codex app-server recovery", () => {
     expect(mockedMarkAuthProfileFailure).not.toHaveBeenCalled();
   });
 
+  it("delivers safe assistant text after a missing turn/completed timeout", async () => {
+    const assistantText = "The direct answer survived the missing terminal event.";
+    mockedRunEmbeddedAttempt.mockResolvedValueOnce(
+      codexTurnCompletionIdleTimeoutAttempt({
+        assistantTexts: [assistantText],
+        lastAssistant: {
+          role: "assistant",
+          content: [{ type: "text", text: assistantText }],
+          stopReason: "error",
+        } as EmbeddedRunAttemptResult["lastAssistant"],
+        codexAppServerFailure: {
+          kind: "turn_completion_idle_timeout",
+          turnWatchTimeoutKind: "completion",
+          transport: "stdio",
+          threadId: "thread-1",
+          turnId: "turn-1",
+          replaySafe: false,
+          replayBlockedReason: "assistant_output",
+        },
+      }),
+    );
+
+    const result = await runEmbeddedAgent({
+      ...overflowBaseRunParams,
+      provider: "codex",
+      model: "gpt-5.5",
+      runId: "run-codex-turn-completion-idle-timeout-assistant-output",
+    });
+
+    expect(result.payloads?.[0]).toMatchObject({
+      text: assistantText,
+    });
+    expect(result.payloads?.[0]?.isError).not.toBe(true);
+    expect(result.payloads?.some((payload) => payload.text === CODEX_MISSING_TERMINAL_MESSAGE)).toBe(
+      false,
+    );
+    expect(mockedRunEmbeddedAttempt).toHaveBeenCalledTimes(1);
+    expect(mockedMarkAuthProfileFailure).not.toHaveBeenCalled();
+  });
+
   it("surfaces non-stdio turn/completed idle timeouts instead of throwing", async () => {
     mockedRunEmbeddedAttempt.mockResolvedValueOnce(
       codexTurnCompletionIdleTimeoutAttempt({

--- a/src/agents/embedded-agent-runner/run.ts
+++ b/src/agents/embedded-agent-runner/run.ts
@@ -3639,10 +3639,30 @@ async function runEmbeddedAgentInternal(
           const finalAssistantStopReason = (sessionLastAssistant?.stopReason ?? "")
             .trim()
             .toLowerCase();
+          const promptTimeoutAssistantTextCandidate =
+            (finalAssistantVisibleText ?? finalAssistantRawText)?.trim() ||
+            (attempt.assistantTexts ?? []).join("\n\n").trim();
+          const promptTimeoutHadUnsafeActivity =
+            Boolean(
+              attempt.clientToolCalls ||
+                attempt.yieldDetected ||
+                attempt.didSendViaMessagingTool ||
+                attempt.didDeliverSourceReplyViaMessageTool ||
+                attempt.didSendDeterministicApprovalPrompt ||
+                attempt.lastToolError ||
+                attempt.replayMetadata.hadPotentialSideEffects,
+            ) || (attempt.toolMetas?.length ?? 0) > 0;
+          const canRecoverCodexCompletionTimeoutAssistantText =
+            timedOutDuringPrompt &&
+            shouldSurfaceCodexCompletionTimeout &&
+            attempt.codexAppServerFailure?.replayBlockedReason === "assistant_output" &&
+            !promptTimeoutHadUnsafeActivity &&
+            promptTimeoutAssistantTextCandidate.length > 0;
           const recoveredFinalAssistantTextAfterPromptTimeout =
             timedOutDuringPrompt &&
-            ["completed", "end_turn", "stop"].includes(finalAssistantStopReason)
-              ? (finalAssistantVisibleText ?? finalAssistantRawText)?.trim()
+            (["completed", "end_turn", "stop"].includes(finalAssistantStopReason) ||
+              canRecoverCodexCompletionTimeoutAssistantText)
+              ? promptTimeoutAssistantTextCandidate
               : undefined;
           const payloadAlreadyContainsRecoveredFinalAssistant =
             recoveredFinalAssistantTextAfterPromptTimeout
@@ -3668,6 +3688,7 @@ async function runEmbeddedAgentInternal(
           const hasPartialAssistantTextAfterPromptTimeout =
             timedOutDuringPrompt &&
             (attempt.assistantTexts ?? []).some((text) => text.trim().length > 0) &&
+            !recoveredFinalAssistantTextAfterPromptTimeout &&
             !attempt.clientToolCalls &&
             !attempt.yieldDetected &&
             !attempt.didSendViaMessagingTool &&


### PR DESCRIPTION
## What Problem This Solves

Addresses the #88312 / #87744 Codex app-server `turn/completed` timeout family for the safest message-loss case: OpenClaw has already captured assistant text, but Codex never delivers the terminal `turn/completed` notification.

Before this change, a `turn_completion_idle_timeout` with assistant text but no tool/messaging side effects could still return only the generic missing-terminal warning. The captured assistant text was treated as partial and suppressed, so users saw message loss even though OpenClaw had the response.

## Scope / Non-goals

This is a recovery/guardrail PR, not a root-cause fix for the missing `turn/completed` event.

It does not make Codex app-server reliably emit `turn/completed`, identify where the terminal notification is dropped, repair the app-server notification dispatcher, or prove the underlying #88312 / #87744 timeout family is solved. Those issues should remain open unless a separate fix proves the terminal event is consistently delivered.

This PR only reduces user-visible damage when OpenClaw already captured safe assistant text and the turn has no unsafe activity or side effects.

## Why This Change Was Made

The upstream Codex app-server contract still says `turn/completed` is the authoritative terminal turn event:

- `codex-rs/app-server/README.md:1353` says each turn begins with `turn/started` and ends with `turn/completed`.
- `codex-rs/app-server/README.md:1356` defines the terminal `turn/completed` payload/status shape.
- `sdk/python/docs/faq.md:105` states a turn is complete only when `turn/completed` arrives.
- `codex-rs/app-server/src/bespoke_event_handling.rs:185` handles `EventMsg::TurnComplete` as terminal app-server work.
- `codex-rs/app-server/src/bespoke_event_handling.rs:1348` and `:1368` build and send `TurnCompletedNotification`.

So OpenClaw should keep detecting the missing terminal event. But if the missing-event timeout is already non-replayable only because assistant output escaped, and there was no tool activity, messaging delivery, yield, deterministic approval, or recorded side effect, the assistant text is the best available user-facing result. This change preserves that text instead of replacing it with the generic warning.

## User Impact

For safe no-side-effect Codex turns, users should receive the assistant answer even if the app-server terminal notification is lost. Riskier turns still fail closed: tool activity, side effects, message-tool delivery, yield, approval prompts, and other unsafe states keep the existing timeout/error behavior and do not get replayed through model fallback.

## Evidence

- Added a regression test covering a `turn_completion_idle_timeout` with `replayBlockedReason: assistant_output` and no unsafe activity; the expected user payload is the captured assistant answer, not the missing-terminal warning.
- Kept existing timeout tests and fallback blocking behavior intact.
- Ran `git diff --check`: passed.
- Did not run Vitest for this branch locally because the Windows dependency install was removed during cleanup after earlier test-environment issues. VPS smoke/test execution is pending authenticated SSH access, so this is intentionally opened as a draft PR.
