### PR TITLE
fix(qa-channel): bound QA bus JSON response reads

### DIFF
--- a/extensions/qa-channel/src/bus-client.test.ts
+++ b/extensions/qa-channel/src/bus-client.test.ts
@@ -1,7 +1,9 @@
 // Qa Channel tests cover bus client plugin behavior.
-import { createServer } from "node:http";
+import { createServer, type Server } from "node:http";
 import { afterEach, describe, expect, it } from "vitest";
 import { buildQaTarget, getQaBusState, parseQaTarget, pollQaBus } from "./bus-client.js";
+
+const OVERSIZED_RESPONSE_BYTES = 18 * 1024 * 1024;
 
 async function startJsonServer(
   handler: (req: { url?: string | undefined }) => { statusCode?: number; body: string },
@@ -32,6 +34,83 @@ async function startJsonServer(
       });
     },
   };
+}
+
+async function listenLoopbackServer(server: Server): Promise<number> {
+  await new Promise<void>((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", () => {
+      server.off("error", reject);
+      resolve();
+    });
+  });
+  const address = server.address();
+  if (!address || typeof address === "string") {
+    throw new Error("test server failed to bind");
+  }
+  return address.port;
+}
+
+function createOversizedJsonServer(pathname: string): { server: Server; closed: Promise<number> } {
+  let resolveClosed: (sentBytes: number) => void = () => {};
+  const closed = new Promise<number>((resolve) => {
+    resolveClosed = resolve;
+  });
+  const server = createServer((req, res) => {
+    if (req.url !== pathname) {
+      res.writeHead(404, { "content-type": "application/json; charset=utf-8" });
+      res.end(JSON.stringify({ error: `unexpected path: ${req.url}` }));
+      return;
+    }
+    let sentBytes = 0;
+    let stopped = false;
+    let prefixSent = false;
+    const prefixChunk = Buffer.from('{"payload":"');
+    const bodyChunk = Buffer.alloc(64 * 1024, 0x61);
+    const suffixChunk = Buffer.from('"}');
+    const writeBuffer = (buffer: Buffer) => {
+      sentBytes += buffer.length;
+      if (!res.write(buffer)) {
+        res.once("drain", writeChunks);
+        return false;
+      }
+      return true;
+    };
+    const writeChunks = () => {
+      if (!prefixSent) {
+        prefixSent = true;
+        if (!writeBuffer(prefixChunk)) {
+          return;
+        }
+      }
+      while (true) {
+        if (stopped) {
+          return;
+        }
+        if (sentBytes + bodyChunk.length + suffixChunk.length >= OVERSIZED_RESPONSE_BYTES) {
+          break;
+        }
+        if (!writeBuffer(bodyChunk)) {
+          return;
+        }
+      }
+      if (!stopped) {
+        sentBytes += suffixChunk.length;
+        res.end(suffixChunk);
+      }
+    };
+    res.writeHead(200, { "content-type": "application/json; charset=utf-8", connection: "close" });
+    res.on("close", () => {
+      stopped = true;
+      resolveClosed(sentBytes);
+    });
+    req.on("aborted", () => {
+      stopped = true;
+      res.destroy();
+    });
+    writeChunks();
+  });
+  return { server, closed };
 }
 
 async function withTimeout<T>(promise: Promise<T>, timeoutMs: number, message: string): Promise<T> {
@@ -83,7 +162,29 @@ describe("qa-bus client", () => {
         cursor: 0,
         timeoutMs: 0,
       }),
-    ).rejects.toThrow(SyntaxError);
+    ).rejects.toThrow("qa-bus /v1/poll: malformed JSON response");
+  });
+
+  it("bounds oversized poll responses and closes the stream early", async () => {
+    const oversized = createOversizedJsonServer("/v1/poll");
+    const port = await listenLoopbackServer(oversized.server);
+    stops.push(async () => {
+      oversized.server.closeAllConnections?.();
+      await new Promise<void>((resolve, reject) => {
+        oversized.server.close((error) => (error ? reject(error) : resolve()));
+      });
+    });
+
+    await expect(
+      pollQaBus({
+        baseUrl: `http://127.0.0.1:${port}`,
+        accountId: "acct-a",
+        cursor: 0,
+        timeoutMs: 0,
+      }),
+    ).rejects.toThrow("qa-bus /v1/poll: JSON response exceeds 16777216 bytes");
+    const sentBytes = await oversized.closed;
+    expect(sentBytes).toBeLessThan(OVERSIZED_RESPONSE_BYTES);
   });
 
   it("rejects immediately when a poll request is aborted", async () => {
@@ -150,5 +251,20 @@ describe("qa-bus client", () => {
       messages: [],
       events: [],
     });
+  });
+
+  it("bounds oversized qa-bus state responses", async () => {
+    const oversized = createOversizedJsonServer("/v1/state");
+    const port = await listenLoopbackServer(oversized.server);
+    stops.push(async () => {
+      oversized.server.closeAllConnections?.();
+      await new Promise<void>((resolve, reject) => {
+        oversized.server.close((error) => (error ? reject(error) : resolve()));
+      });
+    });
+
+    await expect(getQaBusState(`http://127.0.0.1:${port}`)).rejects.toThrow(
+      "qa-channel.bus-state: JSON response exceeds 16777216 bytes",
+    );
   });
 });

--- a/extensions/qa-channel/src/bus-client.ts
+++ b/extensions/qa-channel/src/bus-client.ts
@@ -1,6 +1,8 @@
 // Qa Channel plugin module implements bus client behavior.
 import http from "node:http";
 import https from "node:https";
+import { readProviderJsonResponse } from "openclaw/plugin-sdk/provider-http";
+import { readByteStreamWithLimit } from "openclaw/plugin-sdk/response-limit-runtime";
 import { fetchWithSsrFGuard } from "openclaw/plugin-sdk/ssrf-runtime";
 import type {
   QaBusInboundMessageInput,
@@ -35,10 +37,30 @@ export type {
 } from "./protocol.js";
 
 type JsonResult<T> = Promise<T>;
+const QA_BUS_JSON_RESPONSE_MAX_BYTES = 16 * 1024 * 1024;
 
 function buildQaBusUrl(baseUrl: string, path: string): URL {
   const normalizedBaseUrl = baseUrl.endsWith("/") ? baseUrl : `${baseUrl}/`;
   return new URL(path.replace(/^\/+/, ""), normalizedBaseUrl);
+}
+
+async function readQaBusNodeJsonResponse<T>(
+  response: http.IncomingMessage,
+  label: string,
+): Promise<T> {
+  const bytes = await readByteStreamWithLimit(response, {
+    maxBytes: QA_BUS_JSON_RESPONSE_MAX_BYTES,
+    onOverflow: ({ maxBytes }) => new Error(`${label}: JSON response exceeds ${maxBytes} bytes`),
+  });
+  const text = bytes.toString("utf8");
+  if (!text) {
+    return {} as T;
+  }
+  try {
+    return JSON.parse(text) as T;
+  } catch (cause) {
+    throw new Error(`${label}: malformed JSON response`, { cause });
+  }
 }
 
 async function postJson<T>(
@@ -70,27 +92,23 @@ async function postJson<T>(
         },
       },
       (response) => {
-        const chunks: Buffer[] = [];
-        response.on("data", (chunk) => {
-          chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
-        });
-        response.on("end", () => {
-          const text = Buffer.concat(chunks).toString("utf8");
-          let parsed: T | { error?: string };
-          try {
-            parsed = text ? (JSON.parse(text) as T | { error?: string }) : ({} as T);
-          } catch (error) {
+        const label = `qa-bus ${path}`;
+        void readQaBusNodeJsonResponse<T | { error?: string }>(response, label).then(
+          (parsed) => {
+            if ((response.statusCode ?? 500) < 200 || (response.statusCode ?? 500) >= 300) {
+              const error =
+                typeof parsed === "object" && parsed && "error" in parsed
+                  ? parsed.error
+                  : undefined;
+              reject(new Error(error || `qa-bus request failed: ${response.statusCode ?? 500}`));
+              return;
+            }
+            resolve(parsed as T);
+          },
+          (error: unknown) => {
             reject(toLintErrorObject(error, "Non-Error rejection"));
-            return;
-          }
-          if ((response.statusCode ?? 500) < 200 || (response.statusCode ?? 500) >= 300) {
-            const error =
-              typeof parsed === "object" && parsed && "error" in parsed ? parsed.error : undefined;
-            reject(new Error(error || `qa-bus request failed: ${response.statusCode ?? 500}`));
-            return;
-          }
-          resolve(parsed as T);
-        });
+          },
+        );
         response.on("error", reject);
       },
     );
@@ -291,7 +309,7 @@ export async function getQaBusState(baseUrl: string): Promise<QaBusStateSnapshot
     if (!response.ok) {
       throw new Error(`qa-bus request failed: ${response.status}`);
     }
-    return (await response.json()) as QaBusStateSnapshot;
+    return await readProviderJsonResponse<QaBusStateSnapshot>(response, "qa-channel.bus-state");
   } finally {
     await release();
   }


### PR DESCRIPTION
## What Problem This Solves

`extensions/qa-channel/src/bus-client.ts` used unbounded JSON reads on the QA bus
HTTP success paths:

- `postJson` (used by `pollQaBus` and other bus calls) buffered the full
  `node:http` response body into memory before `JSON.parse`.
- `getQaBusState` used unbounded `await response.json()` on the fetch success path.

A misbehaving or hostile QA bus endpoint (or accidental huge payload) could stream
oversized JSON and trigger unbounded allocation during QA channel polling and state
inspection.

This change caps both paths at 16 MiB with labeled errors such as
`qa-bus /v1/poll: JSON response exceeds 16777216 bytes` and
`qa-channel.bus-state: JSON response exceeds 16777216 bytes`.

This aligns QA Channel's bus client with the broader OpenClaw response-limit
campaign that already bounded sibling provider, channel, and QA Lab surfaces.

## Changes

* `extensions/qa-channel/src/bus-client.ts`:
  - adds `readQaBusNodeJsonResponse` using `readByteStreamWithLimit` for
    `node:http` POST responses (`pollQaBus`, etc.)
  - replaces unbounded `response.json()` in `getQaBusState` with
    `readProviderJsonResponse(response, "qa-channel.bus-state")`
  - normalizes malformed JSON errors to `"qa-bus <path>: malformed JSON response"`

* `extensions/qa-channel/src/bus-client.test.ts`:
  - adds regression tests for oversized `/v1/poll` and `/v1/state` responses
  - updates malformed JSON assertion to match the new labeled error

* `scripts/proof-qa-channel-bus-bound.mjs`:
  - path-level proof over `node:http` streaming poll bodies and fetch state reads

## Real behavior proof

**Behavior addressed:** Oversized QA bus JSON success bodies fail closed instead of
unbounded heap growth on poll and state reads.

**Real environment tested:** Node v22.22.0, macOS 15.3.1, `node:http` streaming
server on `127.0.0.1`, built helpers from `dist/plugin-sdk/provider-http.js` and
`dist/plugin-sdk/response-limit-runtime.js`.

**Exact steps:**
1. Stream an ~18 MiB JSON envelope from a local HTTP server (no `Content-Length`).
2. Drive `readByteStreamWithLimit` on a `node:http` poll response → assert labeled cap.
3. Drive `readProviderJsonResponse` on a fetch state response → assert labeled cap.
4. Verify a normal state snapshot still parses.
5. Run qa-channel vitest regression tests for poll/state bounds.

**Observed result:**
- Poll path: `qa-bus /v1/poll: JSON response exceeds 16777216 bytes`
- State path: `qa-channel.bus-state: JSON response exceeds 16777216 bytes`
- Normal state snapshot parses with `accounts` and `threads` arrays intact
- Vitest: 6 passed (6)
- `ALL PROOF ASSERTIONS PASSED`

**What was not tested:** live QA bus server integration against a running OpenClaw gateway.

## Evidence

```
=== QA Channel bus bound proof (path-level) ===
--- Case 1: node:http poll path rejects oversized streamed body ---
  ok: readByteStreamWithLimit rejects oversized poll stream
  ok: poll label present (got: qa-bus /v1/poll: JSON response exceeds 16777216 bytes)

--- Case 2: fetch state path rejects oversized streamed body ---
  ok: readProviderJsonResponse rejects oversized state stream
  ok: state label present (got: qa-channel.bus-state: JSON response exceeds 16777216 bytes)

--- Case 3: normal state snapshot still parses ---
  ok: state snapshot parses
  ok: threads array intact

--- Case 4: qa-channel bus-client regression tests ---
  Tests  6 passed (6)
  ok: vitest qa-channel bus bound regression tests passed

ALL PROOF ASSERTIONS PASSED
```

```
OPENCLAW_VITEST_MAX_WORKERS=1 pnpm test extensions/qa-channel/src/bus-client.test.ts
# Tests  6 passed (6)
```

New bound regression tests (2 added):
- `bounds oversized poll responses and closes the stream early` ✓
- `bounds oversized qa-bus state responses` ✓
