### PR TITLE
fix(edit): show candidate lines on oldText mismatch

### DIFF
--- a/src/agents/sessions/tools/edit.test.ts
+++ b/src/agents/sessions/tools/edit.test.ts
@@ -46,6 +46,42 @@ describe("edit tool", () => {
     ).rejects.toThrow(/Current file contents:\nactual current content/);
   });
 
+  it("adds nearest candidate lines and indentation hints to mismatch errors", async () => {
+    const filePath = await createTempFile("function demo() {\n    return value;\n}\n");
+    const tool = createEditTool(tmpDir);
+
+    await expect(
+      tool.execute(
+        "call-1",
+        {
+          path: filePath,
+          edits: [{ oldText: "      return value;", newText: "      return nextValue;" }],
+        },
+        undefined,
+      ),
+    ).rejects.toThrow(
+      /Nearest candidate lines:[\s\S]*line 2:[\s\S]*candidate: " {4}return value;"[\s\S]*indent differs: oldText has 6 leading spaces, candidate has 4/,
+    );
+  });
+
+  it("adds backslash hints to mismatch errors", async () => {
+    const filePath = await createTempFile(String.raw`const word = /\btest\b/u;` + "\n");
+    const tool = createEditTool(tmpDir);
+
+    await expect(
+      tool.execute(
+        "call-1",
+        {
+          path: filePath,
+          edits: [{ oldText: String.raw`const word = /\\btest\\b/u;`, newText: "changed" }],
+        },
+        undefined,
+      ),
+    ).rejects.toThrow(
+      /diff: {6} {17}\^{16}[\s\S]*hint: {6}backslashes differ: oldText has 4, candidate has 2/,
+    );
+  });
+
   it("recovers success after a post-write throw when the edit already applied", async () => {
     // Some backends throw after flushing content; a readback match is the
     // contract that lets the tool report success without duplicating edits.

--- a/src/agents/sessions/tools/edit.ts
+++ b/src/agents/sessions/tools/edit.ts
@@ -78,6 +78,8 @@ type LegacyEditToolInput = Record<string, unknown> & {
 
 const EDIT_MISMATCH_MESSAGE = "Could not find the exact text in";
 const EDIT_MISMATCH_HINT_LIMIT = 800;
+const EDIT_MISMATCH_CANDIDATE_LIMIT = 3;
+const EDIT_MISMATCH_CANDIDATE_LINE_LIMIT = 160;
 
 /**
  * Pluggable operations for the edit tool.
@@ -173,14 +175,150 @@ function didEditLikelyApply(params: {
   );
 }
 
-function appendMismatchHint(error: Error, currentContent: string): Error {
+function countLeadingSpaces(value: string): number {
+  const match = /^ */.exec(value);
+  return match?.[0].length ?? 0;
+}
+
+function countBackslashes(value: string): number {
+  let count = 0;
+  for (const char of value) {
+    if (char === "\\") {
+      count++;
+    }
+  }
+  return count;
+}
+
+function shortenDiagnosticLine(value: string): string {
+  return value.length <= EDIT_MISMATCH_CANDIDATE_LINE_LIMIT
+    ? value
+    : `${value.slice(0, EDIT_MISMATCH_CANDIDATE_LINE_LIMIT)}...`;
+}
+
+function formatDiagnosticLine(value: string): string {
+  return JSON.stringify(shortenDiagnosticLine(value));
+}
+
+function buildDifferenceMarker(expected: string, candidate: string): string {
+  const expectedLine = formatDiagnosticLine(expected);
+  const candidateLine = formatDiagnosticLine(candidate);
+  const maxLength = Math.max(expectedLine.length, candidateLine.length);
+  let marker = "";
+  for (let i = 0; i < maxLength; i++) {
+    marker += expectedLine[i] === candidateLine[i] ? " " : "^";
+  }
+  return marker.trimEnd() || "^";
+}
+
+function scoreCandidateLine(expected: string, candidate: string): number {
+  const expectedTrimmed = expected.trim();
+  const candidateTrimmed = candidate.trim();
+  if (!expectedTrimmed || !candidateTrimmed) {
+    return 0;
+  }
+
+  let commonPrefix = 0;
+  while (
+    commonPrefix < expectedTrimmed.length &&
+    commonPrefix < candidateTrimmed.length &&
+    expectedTrimmed[commonPrefix] === candidateTrimmed[commonPrefix]
+  ) {
+    commonPrefix++;
+  }
+
+  const candidateChars = new Map<string, number>();
+  for (const char of candidateTrimmed) {
+    candidateChars.set(char, (candidateChars.get(char) ?? 0) + 1);
+  }
+
+  let sharedChars = 0;
+  for (const char of expectedTrimmed) {
+    const count = candidateChars.get(char) ?? 0;
+    if (count > 0) {
+      sharedChars++;
+      candidateChars.set(char, count - 1);
+    }
+  }
+
+  const maxLength = Math.max(expectedTrimmed.length, candidateTrimmed.length);
+  return (sharedChars + commonPrefix * 2) / maxLength;
+}
+
+function buildCandidateHint(expected: string, candidate: string): string | undefined {
+  const hints: string[] = [];
+  const expectedIndent = countLeadingSpaces(expected);
+  const candidateIndent = countLeadingSpaces(candidate);
+  if (expectedIndent !== candidateIndent) {
+    hints.push(
+      `indent differs: oldText has ${expectedIndent} leading spaces, candidate has ${candidateIndent}`,
+    );
+  }
+
+  const expectedBackslashes = countBackslashes(expected);
+  const candidateBackslashes = countBackslashes(candidate);
+  if (expectedBackslashes !== candidateBackslashes) {
+    hints.push(
+      `backslashes differ: oldText has ${expectedBackslashes}, candidate has ${candidateBackslashes}`,
+    );
+  }
+
+  if (expected.trim() === candidate.trim() && expected !== candidate) {
+    hints.push("only surrounding whitespace differs");
+  }
+
+  return hints.length > 0 ? hints.join("; ") : undefined;
+}
+
+function buildMismatchCandidateLines(currentContent: string, edits: Edit[]): string {
+  const expectedLine = edits
+    .flatMap((edit) => normalizeToLF(edit.oldText).split("\n"))
+    .find((line) => line.trim().length > 0);
+  if (!expectedLine) {
+    return "";
+  }
+
+  const candidates = normalizeToLF(currentContent)
+    .split("\n")
+    .map((line, index) => ({
+      line,
+      lineNumber: index + 1,
+      score: scoreCandidateLine(expectedLine, line),
+    }))
+    .filter((candidate) => candidate.score > 0)
+    .toSorted((a, b) => b.score - a.score)
+    .slice(0, EDIT_MISMATCH_CANDIDATE_LIMIT);
+
+  if (candidates.length === 0) {
+    return "";
+  }
+
+  const lines = ["Nearest candidate lines:"];
+  for (const candidate of candidates) {
+    lines.push(`- line ${candidate.lineNumber}:`);
+    lines.push(`  oldText:   ${formatDiagnosticLine(expectedLine)}`);
+    lines.push(`  candidate: ${formatDiagnosticLine(candidate.line)}`);
+    lines.push(`  diff:      ${buildDifferenceMarker(expectedLine, candidate.line)}`);
+    const hint = buildCandidateHint(expectedLine, candidate.line);
+    if (hint) {
+      lines.push(`  hint:      ${hint}`);
+    }
+  }
+  return lines.join("\n");
+}
+
+function appendMismatchHint(error: Error, currentContent: string, edits: Edit[]): Error {
   const snippet =
     currentContent.length <= EDIT_MISMATCH_HINT_LIMIT
       ? currentContent
       : `${currentContent.slice(0, EDIT_MISMATCH_HINT_LIMIT)}\n... (truncated)`;
-  const enhanced = new Error(`${error.message}\nCurrent file contents:\n${snippet}`, {
-    cause: error,
-  });
+  const candidates = buildMismatchCandidateLines(currentContent, edits);
+  const enhanced = new Error(
+    `${error.message}${candidates ? `\n${candidates}` : ""}\nCurrent file contents:\n${snippet}`,
+    {
+      cause: error,
+    },
+  );
   enhanced.stack = error.stack;
   return enhanced;
 }
@@ -490,7 +628,7 @@ export function createEditToolDefinition(
             };
           }
           if (normalizedError.message.includes(EDIT_MISMATCH_MESSAGE)) {
-            throw appendMismatchHint(normalizedError, currentContent);
+            throw appendMismatchHint(normalizedError, currentContent, originalEdits);
           }
           // Terminal no-op: the edit matched but produced identical content.
           if (normalizedError instanceof EditNoChangeError) {


### PR DESCRIPTION
Closes #97032

## What Problem This Solves

When the edit tool cannot find an exact oldText match, it currently reports the generic exact-match error plus a capped current-file snippet. That still leaves the caller guessing whether the failure came from indentation, escaping, or a nearby line mismatch.

## Why This Change Was Made

This keeps edit matching semantics unchanged and only improves the mismatch diagnostic. On an exact-match miss, the edit tool now appends up to three nearest candidate lines with line numbers, the requested oldText line, the candidate line, a small caret marker, and targeted hints for common causes such as leading-space differences and backslash escaping differences. The existing capped current-file-content hint remains in place.

The diagnostic is intentionally bounded: at most three candidates and 160 characters per displayed line, so the error does not dump substantially more file content than the existing current-file snippet path.

## User Impact

Failed edit calls become actionable: callers can see the likely nearby line and whether whitespace or escaping is the mismatch, without changing the exact replacement behavior.

## Evidence

Real edit-tool output proof after the escaped-marker fix:

```text
Could not find the exact text in /var/folders/.../openclaw-99170-proof-u6furG/demo.ts. The old text must match exactly including all whitespace and newlines.
Nearest candidate lines:
- line 1:
  oldText:   "const word = /\\\\btest\\\\b/u;"
  candidate: "const word = /\\btest\\b/u;"
  diff:                       ^^^^^^^^^^^^^^^^
  hint:      backslashes differ: oldText has 4, candidate has 2
Current file contents:
const word = /\btest\b/u;
```

Validation run locally after the marker alignment update:

- `node scripts/run-vitest.mjs src/agents/sessions/tools/edit.test.ts --reporter=verbose` passed: 21 tests.
- `node scripts/run-oxlint.mjs src/agents/sessions/tools/edit.ts src/agents/sessions/tools/edit.test.ts` passed.
- `node_modules/.bin/oxfmt --check --threads=1 src/agents/sessions/tools/edit.ts src/agents/sessions/tools/edit.test.ts` passed.
- `git diff --check` passed.
- Proof command: `node_modules/.bin/tsx /tmp/openclaw-99170-edit-proof.ts` produced the redacted edit-tool output above.

AI-assisted: yes; implementation and validation were run locally.
