### PR TITLE
fix(control-ui): retry bundle fetch and improve restart diagnosis (#99092)

### DIFF
--- a/ui/index.html
+++ b/ui/index.html
@@ -174,6 +174,13 @@
         outline-offset: 3px;
       }
 
+      .mount-fallback__retry-status {
+        margin: 12px 0 0;
+        color: #9fb0bd;
+        font-size: 0.85rem;
+        line-height: 1.4;
+      }
+
       html[data-theme-mode="light"] body.openclaw-mount-fallback-active {
         color: #151b21;
         background: #f5f7fa;
@@ -194,6 +201,10 @@
       html[data-theme-mode="light"] .mount-fallback__panel a {
         color: #0369a1;
       }
+
+      html[data-theme-mode="light"] .mount-fallback__retry-status {
+        color: #6b7785;
+      }
     </style>
   </head>
   <body>
@@ -209,12 +220,12 @@
       <div class="mount-fallback__panel" tabindex="-1">
         <p class="mount-fallback__eyebrow">OpenClaw Control UI</p>
         <h1 id="openclaw-mount-fallback-title">Control UI did not start</h1>
-        <p>
+        <p id="openclaw-mount-fallback-reason">
           The browser loaded the static page, but the app bundle did not register the
           <code>openclaw-app</code> web component. A browser extension or early content script may
           be blocking module execution.
         </p>
-        <ul>
+        <ul id="openclaw-mount-fallback-steps">
           <li>Try again in a clean browser profile or private window.</li>
           <li>Disable extensions that run on all pages, then reload this dashboard.</li>
           <li>
@@ -239,6 +250,7 @@
             Keep waiting
           </button>
         </div>
+        <p id="openclaw-mount-retry-status" class="mount-fallback__retry-status" hidden></p>
       </div>
     </section>
     <script>
@@ -251,9 +263,18 @@
         var panel = fallback.querySelector(".mount-fallback__panel");
         var retry = document.getElementById("openclaw-mount-retry");
         var wait = document.getElementById("openclaw-mount-wait");
+        var retryStatus = document.getElementById("openclaw-mount-retry-status");
+        var titleEl = document.getElementById("openclaw-mount-fallback-title");
+        var reasonEl = document.getElementById("openclaw-mount-fallback-reason");
+        var stepsEl = document.getElementById("openclaw-mount-fallback-steps");
         var rawDelay = Number(fallback.getAttribute("data-openclaw-mount-timeout-ms"));
         var delay = Number.isFinite(rawDelay) && rawDelay > 0 ? rawDelay : 12000;
         var timer;
+        var retryCount = 0;
+        var maxRetries = 5;
+        var backoffSchedule = [2000, 4000, 8000, 16000, 32000];
+        var retrying = false;
+        var probeResult = null; // null = not probed, "reachable", "unreachable"
 
         function appMounted() {
           try {
@@ -284,11 +305,148 @@
               panel.focus();
             }
           }
+          // Probe gateway reachability to distinguish restart from extension blocking
+          probeGateway();
+        }
+
+        function probeGateway() {
+          if (probeResult !== null) return; // already probed
+          try {
+            fetch(window.location.href, {
+              method: "GET",
+              cache: "no-store",
+              headers: { "X-OpenClaw-Probe": "1" },
+            }).then(
+              function (res) {
+                probeResult = res && res.ok ? "reachable" : "unreachable";
+                updateFallbackMessage();
+              },
+              function () {
+                probeResult = "unreachable";
+                updateFallbackMessage();
+              },
+            );
+          } catch (e) {
+            probeResult = "unreachable";
+            updateFallbackMessage();
+          }
+        }
+
+        function updateFallbackMessage() {
+          if (probeResult === null || !titleEl || !reasonEl || !stepsEl) return;
+          if (probeResult === "unreachable") {
+            titleEl.textContent = "Control UI is starting up";
+            reasonEl.textContent =
+              "The gateway is restarting or temporarily unavailable. The app bundle will be retried automatically — please wait.";
+            stepsEl.innerHTML =
+              '<li>The gateway may take a few seconds to come back online.</li>' +
+              '<li>If this persists after 30 seconds, try reloading the page.</li>' +
+              '<li>See <a href="https://docs.openclaw.ai/web/control-ui#blank-control-ui-page" target="_blank" rel="noopener noreferrer">Control UI troubleshooting</a>.</li>';
+          } else {
+            titleEl.textContent = "Control UI did not start";
+            reasonEl.textContent =
+              "The browser loaded the static page, but the app bundle did not register the " +
+              "openclaw-app web component. A browser extension or early content script may " +
+              "be blocking module execution.";
+            stepsEl.innerHTML =
+              '<li>Try again in a clean browser profile or private window.</li>' +
+              '<li>Disable extensions that run on all pages, then reload this dashboard.</li>' +
+              '<li>See <a href="https://docs.openclaw.ai/web/control-ui#blank-control-ui-page" target="_blank" rel="noopener noreferrer">Control UI troubleshooting</a>.</li>';
+          }
         }
 
         function armFallbackTimer() {
           window.clearTimeout(timer);
           timer = window.setTimeout(showFallback, delay);
+        }
+
+        function fetchAppBundle() {
+          try {
+            return fetch("/src/main.ts", { cache: "no-store" }).then(
+              function (res) {
+                return res && res.ok;
+              },
+              function () {
+                return false;
+              },
+            );
+          } catch (e) {
+            return Promise.resolve(false);
+          }
+        }
+
+        function showRetryStatus(message) {
+          if (!retryStatus) return;
+          retryStatus.textContent = message;
+          retryStatus.hidden = false;
+        }
+
+        function hideRetryStatus() {
+          if (!retryStatus) return;
+          retryStatus.hidden = true;
+          retryStatus.textContent = "";
+        }
+
+        function performRetry() {
+          if (retrying || appMounted()) return;
+          if (retryCount >= maxRetries) {
+            showRetryStatus(
+              "Automatic retry limit reached. Use \u201cTry again\u201d to reload the page.",
+            );
+            return;
+          }
+          retrying = true;
+          var attempt = retryCount + 1;
+          var backoff = backoffSchedule[retryCount] || 32000;
+          showRetryStatus("Retrying (attempt " + attempt + " of " + maxRetries + ")\u2026");
+          fetchAppBundle().then(function (ok) {
+            retrying = false;
+            retryCount++;
+            if (ok && appMounted()) {
+              hideRetryStatus();
+              hideFallback();
+              return;
+            }
+            if (ok && !appMounted()) {
+              // Bundle is fetchable but component hasn\u2019t registered yet \u2014 give it more time
+              showRetryStatus(
+                "Bundle fetched; waiting for app to initialize\u2026",
+              );
+              timer = window.setTimeout(performRetry, backoff);
+              return;
+            }
+            // Fetch failed \u2014 gateway likely still restarting
+            if (retryCount >= maxRetries) {
+              showRetryStatus(
+                "Automatic retry limit reached. Use \u201cTry again\u201d to reload the page.",
+              );
+            } else {
+              showRetryStatus(
+                "Gateway still unavailable. Next retry in " + Math.round(backoff / 1000) + "s\u2026",
+              );
+              timer = window.setTimeout(performRetry, backoff);
+            }
+          });
+        }
+
+        function startRetrySequence() {
+          hideFallback();
+          hideRetryStatus();
+          retryCount = 0;
+          retrying = false;
+          window.clearTimeout(timer);
+          // Reset probe so we re-check gateway status on the next fallback
+          probeResult = null;
+          performRetry();
+          // Arm a safety timer in case retries don\u2019t trigger fallback show
+          timer = window.setTimeout(function () {
+            if (!appMounted()) {
+              showFallback();
+              if (retryCount < maxRetries && !retrying) {
+                performRetry();
+              }
+            }
+          }, delay);
         }
 
         armFallbackTimer();
@@ -298,6 +456,7 @@
             function () {
               window.clearTimeout(timer);
               hideFallback();
+              hideRetryStatus();
             },
             function () {},
           );
@@ -310,8 +469,7 @@
         }
         if (wait) {
           wait.addEventListener("click", function () {
-            hideFallback();
-            armFallbackTimer();
+            startRetrySequence();
           });
         }
       })();

--- a/ui/src/ui/mount-fallback.test.ts
+++ b/ui/src/ui/mount-fallback.test.ts
@@ -1,7 +1,7 @@
 // Control UI tests cover mount fallback behavior.
 import { readFile } from "node:fs/promises";
 import path from "node:path";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
 const indexHtmlPath = path.resolve(
   process.cwd(),
@@ -60,6 +60,93 @@ function requireElementById<T extends HTMLElement>(
   return element;
 }
 
+/**
+ * Installs a fetch mock on the given window. The iframe contentWindow does not
+ * have its own `Response` constructor in jsdom, so we use the parent window's
+ * `Response` to build the return value. The mock is defined as an own property
+ * on the frameWindow so the eval'd inline script sees it.
+ */
+function installFetchMock(
+  window: TestWindow,
+  handler: (
+    url: string,
+    init?: RequestInit,
+  ) => Promise<{ ok: boolean; status: number; body?: string }>,
+): { mock: ReturnType<typeof vi.fn>; restore: () => void } {
+  const mock = vi.fn(async (input: URL | RequestInfo, init?: RequestInit) => {
+    const url = typeof input === "string" ? input : (input as URL).toString();
+    const result = await handler(url, init);
+    // Use the parent (test) Response — the iframe lacks its own in jsdom
+    return new Response(result.body ?? "", {
+      status: result.status,
+      headers: { "Content-Type": "text/html" },
+    });
+  });
+  Object.defineProperty(window, "fetch", {
+    value: mock,
+    writable: true,
+    configurable: true,
+  });
+  return {
+    mock,
+    restore: () => {
+      try {
+        delete (window as Record<string, unknown>).fetch;
+      } catch {
+        // ignore
+      }
+    },
+  };
+}
+
+/**
+ * Installs a fetch mock that rejects all requests (simulates gateway down).
+ */
+function installFailingFetchMock(window: TestWindow): {
+  mock: ReturnType<typeof vi.fn>;
+  restore: () => void;
+} {
+  const mock = vi.fn(async (input: URL | RequestInfo) => {
+    const url = typeof input === "string" ? input : (input as URL).toString();
+    throw new Error(`NetworkError: ${url} unreachable`);
+  });
+  Object.defineProperty(window, "fetch", {
+    value: mock,
+    writable: true,
+    configurable: true,
+  });
+  return {
+    mock,
+    restore: () => {
+      try {
+        delete (window as Record<string, unknown>).fetch;
+      } catch {
+        // ignore
+      }
+    },
+  };
+}
+
+/**
+ * Installs a fetch mock that returns reachable (200) for the gateway probe URL
+ * and the provided result for the bundle URL.
+ */
+function installMixedFetchMock(
+  window: TestWindow,
+  bundleOk: boolean,
+): { mock: ReturnType<typeof vi.fn>; restore: () => void } {
+  const probeUrl = window.location.href;
+  return installFetchMock(window, async (url) => {
+    if (url === probeUrl) {
+      return { ok: true, status: 200, body: "ok" };
+    }
+    if (url === "/src/main.ts") {
+      return { ok: bundleOk, status: bundleOk ? 200 : 500, body: bundleOk ? "export {}" : "" };
+    }
+    return { ok: false, status: 404, body: "" };
+  });
+}
+
 describe("Control UI mount fallback", () => {
   afterEach(() => {
     document.body.innerHTML = "";
@@ -68,6 +155,8 @@ describe("Control UI mount fallback", () => {
   it("shows the static troubleshooting panel when the app element is never registered", async () => {
     const frameWindow = createIsolatedWindow();
     expect(frameWindow.customElements.get("openclaw-app")).toBeUndefined();
+    // Install a reachable fetch mock so the probe keeps the default "did not start" message
+    const { restore } = installMixedFetchMock(frameWindow, true);
     installFallbackShell(frameWindow, await readIndexHtmlWithDelay(1));
     await waitForWindowTimeout(frameWindow, 10);
 
@@ -78,6 +167,8 @@ describe("Control UI mount fallback", () => {
     );
     expect(fallback.hidden).toBe(false);
     expect([...frameWindow.document.body.classList]).toEqual(["openclaw-mount-fallback-active"]);
+    // Wait for the probe to settle so the message updates
+    await waitForWindowTimeout(frameWindow, 10);
     expect(fallback.querySelector("h1")?.textContent?.trim()).toBe("Control UI did not start");
     expect(fallback.querySelector("a")?.textContent?.trim()).toBe("Control UI troubleshooting");
     expect(frameWindow.document.activeElement).toBeInstanceOf(frameWindow.HTMLElement);
@@ -96,10 +187,13 @@ describe("Control UI mount fallback", () => {
 
     await waitForWindowTimeout(frameWindow, 10);
     expect(fallback.hidden).toBe(false);
+
+    restore();
   });
 
   it("keeps the fallback hidden when the app element registers before the timeout", async () => {
     const frameWindow = createIsolatedWindow();
+    const { restore } = installMixedFetchMock(frameWindow, true);
     installFallbackShell(frameWindow, await readIndexHtmlWithDelay(25));
     if (!frameWindow.customElements.get("openclaw-app")) {
       frameWindow.customElements.define("openclaw-app", class extends frameWindow.HTMLElement {});
@@ -114,5 +208,145 @@ describe("Control UI mount fallback", () => {
     );
     expect(fallback.hidden).toBe(true);
     expect([...frameWindow.document.body.classList]).toEqual([]);
+
+    restore();
+  });
+
+  it("re-fetches the bundle when 'Keep waiting' is clicked", async () => {
+    const frameWindow = createIsolatedWindow();
+    const { mock: fetchMock, restore } = installMixedFetchMock(frameWindow, true);
+
+    installFallbackShell(frameWindow, await readIndexHtmlWithDelay(1));
+    await waitForWindowTimeout(frameWindow, 10);
+
+    const fallback = requireElementById(
+      frameWindow,
+      "openclaw-mount-fallback",
+      frameWindow.HTMLElement,
+    );
+    expect(fallback.hidden).toBe(false);
+
+    const waitButton = requireElementById(
+      frameWindow,
+      "openclaw-mount-wait",
+      frameWindow.HTMLButtonElement,
+    );
+    const retryStatus = requireElementById(
+      frameWindow,
+      "openclaw-mount-retry-status",
+      frameWindow.HTMLParagraphElement,
+    );
+
+    // Click "Keep waiting" — should start retry sequence
+    waitButton.click();
+    expect(fallback.hidden).toBe(true);
+    expect(retryStatus.hidden).toBe(false);
+    expect(retryStatus.textContent).toContain("Retrying");
+
+    // Wait for the fetch to be called
+    await waitForWindowTimeout(frameWindow, 10);
+
+    // fetch should have been called for the bundle retry
+    const fetchUrls = fetchMock.mock.calls.map((c) => {
+      const input = c[0];
+      return typeof input === "string" ? input : (input as URL).toString();
+    });
+    expect(fetchUrls.some((url) => url === "/src/main.ts")).toBe(true);
+
+    restore();
+  });
+
+  it("shows gateway restarting message when probe detects unreachable gateway", async () => {
+    const frameWindow = createIsolatedWindow();
+    const { restore } = installFailingFetchMock(frameWindow);
+
+    installFallbackShell(frameWindow, await readIndexHtmlWithDelay(1));
+    // Wait for fallback to show and probe to settle
+    await waitForWindowTimeout(frameWindow, 50);
+
+    const fallback = requireElementById(
+      frameWindow,
+      "openclaw-mount-fallback",
+      frameWindow.HTMLElement,
+    );
+    expect(fallback.hidden).toBe(false);
+
+    const titleEl = requireElementById(
+      frameWindow,
+      "openclaw-mount-fallback-title",
+      frameWindow.HTMLElement,
+    );
+
+    // After the probe rejects, the title should say "starting up"
+    await waitForWindowTimeout(frameWindow, 10);
+    expect(titleEl.textContent).toBe("Control UI is starting up");
+
+    restore();
+  });
+
+  it("shows extension blocking message when probe detects reachable gateway", async () => {
+    const frameWindow = createIsolatedWindow();
+    const { restore } = installMixedFetchMock(frameWindow, true);
+
+    installFallbackShell(frameWindow, await readIndexHtmlWithDelay(1));
+    await waitForWindowTimeout(frameWindow, 50);
+
+    const fallback = requireElementById(
+      frameWindow,
+      "openclaw-mount-fallback",
+      frameWindow.HTMLElement,
+    );
+    expect(fallback.hidden).toBe(false);
+
+    const titleEl = requireElementById(
+      frameWindow,
+      "openclaw-mount-fallback-title",
+      frameWindow.HTMLElement,
+    );
+
+    // After the probe resolves as reachable, the title should say "did not start"
+    await waitForWindowTimeout(frameWindow, 10);
+    expect(titleEl.textContent).toBe("Control UI did not start");
+
+    restore();
+  });
+
+  it("attempts bundle fetch at least once during retry sequence", async () => {
+    const frameWindow = createIsolatedWindow();
+    const { mock: fetchMock, restore } = installFailingFetchMock(frameWindow);
+
+    installFallbackShell(frameWindow, await readIndexHtmlWithDelay(1));
+    await waitForWindowTimeout(frameWindow, 10);
+
+    const waitButton = requireElementById(
+      frameWindow,
+      "openclaw-mount-wait",
+      frameWindow.HTMLButtonElement,
+    );
+    const retryStatus = requireElementById(
+      frameWindow,
+      "openclaw-mount-retry-status",
+      frameWindow.HTMLParagraphElement,
+    );
+
+    // Click "Keep waiting" to start retry sequence
+    waitButton.click();
+    expect(retryStatus.hidden).toBe(false);
+
+    // Wait for the first fetch attempt to settle
+    await waitForWindowTimeout(frameWindow, 10);
+
+    // The bundle fetch should have been attempted at least once
+    const bundleFetchCalls = fetchMock.mock.calls.filter((c) => {
+      const input = c[0];
+      const url = typeof input === "string" ? input : (input as URL).toString();
+      return url === "/src/main.ts";
+    });
+    expect(bundleFetchCalls.length).toBeGreaterThanOrEqual(1);
+
+    // Retry status should show some message (either retrying or backoff)
+    expect(retryStatus.textContent).toBeTruthy();
+
+    restore();
   });
 });


### PR DESCRIPTION
## Summary

When the gateway restarts, the Control UI's JS bundle fails to load. The "Keep waiting" button only re-armed a 12s timer without retrying the fetch. The error message blamed browser extensions instead of "gateway is restarting." Only a full page reload could fix it.

## Changes

### `ui/index.html` — inline fallback script
1. **Gateway reachability probe**: On fallback show, fetches `window.location.href` to distinguish "gateway restarting" from "module blocked by extension"
2. **"Keep waiting" now retries**: Re-fetches the JS bundle (`/src/main.ts`) with exponential backoff — 5 retries at 2s, 4s, 8s, 16s, 32s — instead of just re-arming the timer
3. **Branched error message**: 
   - Gateway unreachable → "Control UI is starting up" with restart guidance
   - Gateway reachable → original "Control UI did not start" with extension guidance
4. **Retry status indicator**: Shows "Retrying (attempt N of 5)…" / "Gateway still unavailable. Next retry in Xs…" below the action buttons
5. **"Try again"** (full page reload) preserved as manual escape hatch

### `ui/src/ui/mount-fallback.test.ts`
- Original test updated to install fetch mock for probe compatibility
- New: verifies bundle is re-fetched when "Keep waiting" is clicked
- New: verifies "starting up" message when gateway probe is unreachable
- New: verifies "did not start" message when gateway is reachable
- New: verifies at least one bundle fetch attempt during retry sequence

## Test
```
node scripts/run-vitest.mjs ui/src/ui/mount-fallback.test.ts
```
All 6 tests pass.

Fixes #99092