### PR TITLE
fix(gateway): prevent RangeError on large clipboard screenshot attachments (#99163)

### DIFF
--- a/packages/media-core/src/base64.test.ts
+++ b/packages/media-core/src/base64.test.ts
@@ -2,6 +2,20 @@
 import { describe, expect, it } from "vitest";
 import { canonicalizeBase64, estimateBase64DecodedBytes } from "./base64.js";
 
+/**
+ * Generates a large valid base64 string (~2.7M chars) simulating a ~2MB PNG
+ * clipboard screenshot. The raw bytes are a valid PNG header followed by
+ * filler so sniffers still recognise it as image/png.
+ */
+function largePngBase64(sizeBytes = 2_000_000): string {
+  const buffer = Buffer.alloc(sizeBytes);
+  // PNG magic bytes
+  buffer.set([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a], 0);
+  // IHDR chunk marker (minimal)
+  buffer.write("IHDR", 12, "ascii");
+  return buffer.toString("base64");
+}
+
 describe("base64 helpers", () => {
   function expectBase64HelperCase<T>(actual: T, expected: T) {
     expect(actual).toBe(expected);
@@ -40,5 +54,32 @@ describe("base64 helpers", () => {
     },
   ] as const)("$name", ({ actual, expected }) => {
     expectBase64HelperCase(actual, expected);
+  });
+
+  it("canonicalizeBase64 does not overflow the call stack on ~2MB PNG payloads", () => {
+    // Regression: character-by-character string concatenation (`cleaned += ch`)
+    // produced a deeply nested V8 cons-string that overflowed the stack when
+    // flattened. A ~2MB screenshot encodes to ~2.7M base64 chars.
+    const large = largePngBase64(2_000_000);
+    expect(large.length).toBeGreaterThan(2_600_000);
+
+    const result = canonicalizeBase64(large);
+    expect(result).toBeDefined();
+    // The result must be a flat string — .slice() and Buffer.from() must not
+    // throw RangeError.
+    expect(() => result!.slice(0, 256)).not.toThrow();
+    expect(() => Buffer.from(result!.slice(0, 256), "base64")).not.toThrow();
+    // Correctness: canonical output should equal the input (no whitespace to strip).
+    expect(result).toBe(large);
+  });
+
+  it("canonicalizeBase64 handles large payloads with whitespace without stack overflow", () => {
+    const large = largePngBase64(2_000_000);
+    // Insert whitespace every 4096 chars to exercise the whitespace-stripping path.
+    const withWhitespace = large.replace(/(.{4096})/g, "$1\n");
+    const result = canonicalizeBase64(withWhitespace);
+    expect(result).toBeDefined();
+    expect(() => result!.slice(0, 256)).not.toThrow();
+    expect(result).toBe(large);
   });
 });

--- a/packages/media-core/src/base64.ts
+++ b/packages/media-core/src/base64.ts
@@ -50,9 +50,17 @@ function isBase64DataChar(code: number): boolean {
 /**
  * Normalizes and validates a base64 string, returning canonical no-whitespace
  * base64 only when the input has valid alphabet, padding, and length.
+ *
+ * Implementation note: we accumulate characters into an array and join once
+ * at the end instead of using `cleaned += base64[i]` in a loop. Repeated
+ * string concatenation creates a deeply nested V8 cons-string tree; for
+ * large payloads (~2.7M chars from a 2MB clipboard PNG) V8 overflows the
+ * call stack when it later tries to flatten the tree (e.g. during `.slice()`
+ * or `Buffer.from(..., "base64")`). Array join produces a flat string in O(n)
+ * without deep recursion.
  */
 export function canonicalizeBase64(base64: string): string | undefined {
-  let cleaned = "";
+  const parts: string[] = [];
   let padding = 0;
   let sawPadding = false;
   for (let i = 0; i < base64.length; i += 1) {
@@ -66,17 +74,18 @@ export function canonicalizeBase64(base64: string): string | undefined {
         return undefined;
       }
       sawPadding = true;
-      cleaned += "=";
+      parts.push("=");
       continue;
     }
     if (sawPadding || !isBase64DataChar(code)) {
       return undefined;
     }
-    cleaned += base64[i];
+    parts.push(base64[i]);
   }
-  if (!cleaned) {
+  if (parts.length === 0) {
     return undefined;
   }
+  let cleaned = parts.join("");
   const remainder = cleaned.length % 4;
   if (remainder !== 0) {
     if (sawPadding || remainder === 1) {

--- a/src/gateway/chat-attachments.test.ts
+++ b/src/gateway/chat-attachments.test.ts
@@ -523,3 +523,30 @@ describe("attachment validation", () => {
     }
   });
 });
+
+describe("parseMessageWithAttachments large payload regression (issue #99163)", () => {
+  it("processes ~2MB PNG screenshot without RangeError", async () => {
+    // Regression: a ~2MB clipboard PNG encodes to ~2.7M base64 chars.
+    // canonicalizeBase64 used char-by-char concatenation creating a deep V8
+    // cons-string that overflowed the stack on flatten. The full
+    // parseMessageWithAttachments pipeline (sniff → size check → offload)
+    // must complete without RangeError.
+    const pngBytes = Buffer.alloc(2_000_000);
+    pngBytes.set([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a], 0);
+    pngBytes.write("IHDR", 12, "ascii");
+    const base64 = pngBytes.toString("base64");
+    expect(base64.length).toBeGreaterThan(2_600_000);
+
+    const parsed = await parseMessageWithAttachments(
+      "see this screenshot",
+      [{ type: "image", mimeType: "image/png", fileName: "screenshot.png", content: base64 }],
+      { log: { warn: () => {} } },
+    );
+
+    // 2MB exceeds OFFLOAD_THRESHOLD_BYTES (2_000_000) so it should offload.
+    expect(parsed.offloadedRefs).toHaveLength(1);
+    expect(parsed.offloadedRefs[0]?.mimeType).toBe("image/png");
+    expect(parsed.images).toHaveLength(0);
+    expect(saveMediaBufferMock).toHaveBeenCalledOnce();
+  });
+});


### PR DESCRIPTION
## Summary

Pasting a ~2MB PNG screenshot into the Control UI webchat triggered `RangeError: Maximum call stack size exceeded` server-side in the `chat.send` attachment parse/stage pipeline. Smaller images (~200KB) worked fine.

## Root Cause

`canonicalizeBase64` in `packages/media-core/src/base64.ts` built its output string using character-by-character concatenation (`cleaned += base64[i]`) in a loop. For large base64 payloads (~2.7M chars from a ~2MB clipboard PNG), this created a deeply nested V8 cons-string tree. When any downstream operation triggered V8 string flattening — e.g. `.slice()` or `Buffer.from(..., "base64")` in `sniffMimeFromBase64` — V8 recursed into the cons-string tree and overflowed the call stack.

The call chain is:
```
chat.send handler
  → parseMessageWithAttachments
    → sniffMimeFromBase64
      → canonicalizeBase64  ← creates deep cons-string tree
      → canonicalBase64.slice(0, sliceLen)  ← V8 flattens tree → RangeError
```

## Fix

Replace character-by-character string concatenation with array accumulation + single `join("")` at the end. This produces a flat string in O(n) without deep V8 recursion.

**Before:**
```ts
let cleaned = "";
for (...) {
  cleaned += base64[i];  // creates deep cons-string tree
}
```

**After:**
```ts
const parts: string[] = [];
for (...) {
  parts.push(base64[i]);
}
let cleaned = parts.join("");  // flat string, no deep recursion
```

## Tests

- **`packages/media-core/src/base64.test.ts`**: Added regression test verifying `canonicalizeBase64` handles ~2MB PNG payloads (~2.7M base64 chars) without `RangeError` on `.slice()` or `Buffer.from()`. Also tests large payloads with embedded whitespace.
- **`src/gateway/chat-attachments.test.ts`**: Added end-to-end regression test verifying `parseMessageWithAttachments` processes a ~2MB PNG screenshot attachment without `RangeError`, confirming the full attachment pipeline (sniff → size check → offload) works.

## Affected Paths

`canonicalizeBase64` is also called from:
- `src/media/input-files.ts` — inbound file attachment handling
- `src/infra/outbound/message-action-params.ts` — outbound message params
- `src/image-generation/image-assets.ts` — generated image assets
- `src/agents/tool-images.ts` — agent tool image handling
- `packages/media-core/src/inline-image-data-url.ts` — inline image data URL sanitization

All of these paths benefit from the fix.

Closes #99163