### PR TITLE
fix(codex): cache plugin inventory to prevent repeated disk I/O (#99071)

### DIFF
--- a/extensions/codex/src/app-server/attempt-startup.ts
+++ b/extensions/codex/src/app-server/attempt-startup.ts
@@ -35,6 +35,7 @@ import {
   buildCodexAppServerRuntimeFingerprint,
   buildCodexPluginAppCacheKey,
 } from "./plugin-app-cache-key.js";
+import { defaultCodexPluginListCache, type CodexPluginListCache } from "./plugin-list-cache.js";
 import {
   buildCodexPluginThreadConfig,
   buildCodexPluginThreadConfigInputFingerprint,
@@ -349,6 +350,8 @@ export async function startCodexAttemptThread(params: {
                           configCwd: startupExecutionCwd,
                           appCache: defaultCodexAppInventoryCache,
                           appCacheKey: pluginAppCacheKey,
+                          pluginListCache: defaultCodexPluginListCache,
+                          pluginListCacheKey: pluginAppCacheKey,
                         }),
                     }
                   : undefined,

--- a/extensions/codex/src/app-server/plugin-activation.ts
+++ b/extensions/codex/src/app-server/plugin-activation.ts
@@ -12,6 +12,7 @@ import {
   type CodexPluginMarketplaceRef,
   type CodexPluginRuntimeRequest,
 } from "./plugin-inventory.js";
+import type { CodexPluginListCache } from "./plugin-list-cache.js";
 import type { v2 } from "./protocol.js";
 
 /** Terminal reason reported after trying to activate one Codex plugin policy. */
@@ -46,6 +47,8 @@ export type EnsureCodexPluginActivationParams = {
   request: CodexPluginRuntimeRequest;
   appCache?: CodexAppInventoryCache;
   appCacheKey?: string;
+  pluginListCache?: CodexPluginListCache;
+  pluginListCacheKey?: string;
   installEvenIfActive?: boolean;
   targetAppIds?: readonly string[];
 };
@@ -65,6 +68,11 @@ export async function ensureCodexPluginActivation(
     });
   }
 
+  const pluginListCache = params.pluginListCache;
+  const pluginListCacheKey = params.pluginListCacheKey;
+  // Activation needs fresh plugin/list state to check current install/enable
+  // status. Do not use the cache here — the cache is invalidated below after
+  // install, and the initial pre-install read must see the latest server state.
   const listed = (await params.request("plugin/list", {
     cwds: [],
   } satisfies v2.PluginListParams)) as v2.PluginListResponse;
@@ -103,6 +111,10 @@ export async function ensureCodexPluginActivation(
         : params.identity.pluginName,
     ) satisfies v2.PluginInstallParams,
   )) as v2.PluginInstallResponse;
+  // Invalidate the plugin list cache so the next read sees the new install state.
+  if (pluginListCache && pluginListCacheKey) {
+    pluginListCache.invalidate(pluginListCacheKey, "plugin installed");
+  }
   const refreshDiagnostics: CodexPluginActivationDiagnostic[] = [];
   let refreshFailed = false;
   try {
@@ -110,6 +122,8 @@ export async function ensureCodexPluginActivation(
       request: params.request,
       appCache: params.appCache,
       appCacheKey: params.appCacheKey,
+      pluginListCache,
+      pluginListCacheKey,
       targetAppIds: params.targetAppIds,
     });
     refreshDiagnostics.push(...refreshResult.diagnostics);
@@ -149,9 +163,16 @@ export async function refreshCodexPluginRuntimeState(params: {
   request: CodexPluginRuntimeRequest;
   appCache?: CodexAppInventoryCache;
   appCacheKey?: string;
+  pluginListCache?: CodexPluginListCache;
+  pluginListCacheKey?: string;
   targetAppIds?: readonly string[];
 }): Promise<CodexPluginRuntimeRefreshResult> {
   const diagnostics: CodexPluginActivationDiagnostic[] = [];
+  // Invalidate plugin list cache before reloading so the next read picks up
+  // any install/enable state changes from the plugin/install call.
+  if (params.pluginListCache && params.pluginListCacheKey) {
+    params.pluginListCache.invalidate(params.pluginListCacheKey, "plugin runtime refresh");
+  }
   await params.request("plugin/list", {
     cwds: [],
   } satisfies v2.PluginListParams);

--- a/extensions/codex/src/app-server/plugin-inventory.test.ts
+++ b/extensions/codex/src/app-server/plugin-inventory.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from "vitest";
 import { CodexAppInventoryCache } from "./app-inventory-cache.js";
 import { CODEX_PLUGINS_MARKETPLACE_NAME } from "./config.js";
 import { findOpenAiCuratedPluginSummary, readCodexPluginInventory } from "./plugin-inventory.js";
+import { CodexPluginListCache } from "./plugin-list-cache.js";
 import type { v2 } from "./protocol.js";
 
 describe("Codex plugin inventory", () => {
@@ -349,6 +350,143 @@ describe("Codex plugin inventory", () => {
     expect(inventory.diagnostics.map((diagnostic) => diagnostic.code)).toStrictEqual([
       "app_inventory_missing",
     ]);
+  });
+
+  it("uses the plugin list cache to avoid repeated plugin/list calls", async () => {
+    const appCache = new CodexAppInventoryCache();
+    await appCache.refreshNow({
+      key: "runtime",
+      nowMs: 0,
+      request: async () => ({
+        data: [appInfo("google-calendar-app", true)],
+        nextCursor: null,
+      }),
+    });
+    const pluginListCache = new CodexPluginListCache({ ttlMs: 1_000 });
+    const calls: string[] = [];
+    const request = async (method: string, params?: unknown) => {
+      calls.push(method);
+      if (method === "plugin/list") {
+        return pluginList([pluginSummary("google-calendar", { installed: true, enabled: true })]);
+      }
+      if (method === "plugin/read") {
+        return pluginDetail("google-calendar", [appSummary("google-calendar-app")]);
+      }
+      throw new Error(`unexpected request ${method}`);
+    };
+
+    // First call populates the plugin list cache.
+    await readCodexPluginInventory({
+      pluginConfig: {
+        codexPlugins: {
+          enabled: true,
+          plugins: {
+            "google-calendar": {
+              marketplaceName: CODEX_PLUGINS_MARKETPLACE_NAME,
+              pluginName: "google-calendar",
+            },
+          },
+        },
+      },
+      appCache,
+      appCacheKey: "runtime",
+      pluginListCache,
+      pluginListCacheKey: "runtime",
+      nowMs: 1,
+      request,
+    });
+    const firstCallCount = calls.length;
+    expect(calls.filter((c) => c === "plugin/list")).toHaveLength(1);
+
+    // Second call should use the cached plugin/list — no new plugin/list call.
+    await readCodexPluginInventory({
+      pluginConfig: {
+        codexPlugins: {
+          enabled: true,
+          plugins: {
+            "google-calendar": {
+              marketplaceName: CODEX_PLUGINS_MARKETPLACE_NAME,
+              pluginName: "google-calendar",
+            },
+          },
+        },
+      },
+      appCache,
+      appCacheKey: "runtime",
+      pluginListCache,
+      pluginListCacheKey: "runtime",
+      nowMs: 2,
+      request,
+    });
+    expect(calls.filter((c) => c === "plugin/list")).toHaveLength(1);
+    expect(calls.length).toBe(firstCallCount + 1); // only plugin/read is added
+  });
+
+  it("forces a plugin list refetch when forcePluginListRefetch is true", async () => {
+    const appCache = new CodexAppInventoryCache();
+    await appCache.refreshNow({
+      key: "runtime",
+      nowMs: 0,
+      request: async () => ({
+        data: [appInfo("google-calendar-app", true)],
+        nextCursor: null,
+      }),
+    });
+    const pluginListCache = new CodexPluginListCache({ ttlMs: 1_000 });
+    let pluginListCalls = 0;
+    const request = async (method: string) => {
+      if (method === "plugin/list") {
+        pluginListCalls += 1;
+        return pluginList([pluginSummary("google-calendar", { installed: true, enabled: true })]);
+      }
+      if (method === "plugin/read") {
+        return pluginDetail("google-calendar", [appSummary("google-calendar-app")]);
+      }
+      throw new Error(`unexpected request ${method}`);
+    };
+
+    await readCodexPluginInventory({
+      pluginConfig: {
+        codexPlugins: {
+          enabled: true,
+          plugins: {
+            "google-calendar": {
+              marketplaceName: CODEX_PLUGINS_MARKETPLACE_NAME,
+              pluginName: "google-calendar",
+            },
+          },
+        },
+      },
+      appCache,
+      appCacheKey: "runtime",
+      pluginListCache,
+      pluginListCacheKey: "runtime",
+      nowMs: 1,
+      request,
+    });
+    expect(pluginListCalls).toBe(1);
+
+    await readCodexPluginInventory({
+      pluginConfig: {
+        codexPlugins: {
+          enabled: true,
+          plugins: {
+            "google-calendar": {
+              marketplaceName: CODEX_PLUGINS_MARKETPLACE_NAME,
+              pluginName: "google-calendar",
+            },
+          },
+        },
+      },
+      appCache,
+      appCacheKey: "runtime",
+      pluginListCache,
+      pluginListCacheKey: "runtime",
+      nowMs: 2,
+      forcePluginListRefetch: true,
+      request,
+    });
+    expect(pluginListCalls).toBe(2);
   });
 });
 

--- a/extensions/codex/src/app-server/plugin-inventory.ts
+++ b/extensions/codex/src/app-server/plugin-inventory.ts
@@ -14,6 +14,7 @@ import {
   type ResolvedCodexPluginPolicy,
   type ResolvedCodexPluginsPolicy,
 } from "./config.js";
+import type { CodexPluginListCache, CodexPluginListRequest } from "./plugin-list-cache.js";
 import type { v2 } from "./protocol.js";
 
 const CODEX_PLUGINS_REMOTE_MARKETPLACE_NAME = `${CODEX_PLUGINS_MARKETPLACE_NAME}-remote`;
@@ -83,9 +84,12 @@ export type ReadCodexPluginInventoryParams = {
   request: CodexPluginRuntimeRequest;
   appCache?: CodexAppInventoryCache;
   appCacheKey?: string;
+  pluginListCache?: CodexPluginListCache;
+  pluginListCacheKey?: string;
   nowMs?: number;
   readPluginDetails?: boolean;
   suppressAppInventoryRefresh?: boolean;
+  forcePluginListRefetch?: boolean;
 };
 
 /** Reads configured Codex plugin state and maps owned apps to readiness diagnostics. */
@@ -107,9 +111,7 @@ export async function readCodexPluginInventory(
   }
 
   const appInventory = readCachedAppInventory(params);
-  const listed = (await params.request("plugin/list", {
-    cwds: [],
-  } satisfies v2.PluginListParams)) as v2.PluginListResponse;
+  const listed = await readPluginList(params);
   const marketplaceEntry = listed.marketplaces.find(isOpenAiCuratedMarketplace);
   if (!marketplaceEntry) {
     return {
@@ -258,6 +260,25 @@ function readCachedAppInventory(
     nowMs: params.nowMs,
     suppressRefresh: params.suppressAppInventoryRefresh,
   });
+}
+
+async function readPluginList(
+  params: ReadCodexPluginInventoryParams,
+): Promise<v2.PluginListResponse> {
+  if (params.pluginListCache && params.pluginListCacheKey) {
+    const request: CodexPluginListRequest = async (method, requestParams) =>
+      (await params.request(method, requestParams)) as v2.PluginListResponse;
+    const snapshot = await params.pluginListCache.readOrRefresh({
+      key: params.pluginListCacheKey,
+      request,
+      nowMs: params.nowMs,
+      forceRefetch: params.forcePluginListRefetch,
+    });
+    return snapshot.response;
+  }
+  return (await params.request("plugin/list", {
+    cwds: [],
+  } satisfies v2.PluginListParams)) as v2.PluginListResponse;
 }
 
 async function readPluginDetail(

--- a/extensions/codex/src/app-server/plugin-list-cache.test.ts
+++ b/extensions/codex/src/app-server/plugin-list-cache.test.ts
@@ -1,0 +1,193 @@
+// Codex tests cover plugin list cache behavior.
+import { describe, expect, it, vi } from "vitest";
+import { CodexPluginListCache, CODEX_PLUGIN_LIST_CACHE_TTL_MS } from "./plugin-list-cache.js";
+import type { v2 } from "./protocol.js";
+
+describe("Codex plugin list cache", () => {
+  it("returns missing on first read and refreshes on demand", async () => {
+    const cache = new CodexPluginListCache({ ttlMs: 100 });
+    const request = vi.fn(async () => pluginListResponse());
+    const read = cache.read({ key: "runtime" });
+    expect(read.state).toBe("missing");
+    expect(read.snapshot).toBeUndefined();
+
+    const snapshot = await cache.refreshNow({ key: "runtime", request, nowMs: 0 });
+    expect(snapshot.response.marketplaces).toHaveLength(1);
+    expect(request).toHaveBeenCalledTimes(1);
+
+    const fresh = cache.read({ key: "runtime", nowMs: 50 });
+    expect(fresh.state).toBe("fresh");
+    expect(fresh.snapshot?.response).toStrictEqual(snapshot.response);
+  });
+
+  it("returns a fresh snapshot from readOrRefresh without extra calls", async () => {
+    const cache = new CodexPluginListCache({ ttlMs: 100 });
+    const request = vi.fn(async () => pluginListResponse());
+    const first = await cache.readOrRefresh({ key: "runtime", request, nowMs: 0 });
+    expect(first.response.marketplaces).toHaveLength(1);
+
+    const second = await cache.readOrRefresh({ key: "runtime", request, nowMs: 50 });
+    expect(second).toStrictEqual(first);
+    expect(request).toHaveBeenCalledTimes(1);
+  });
+
+  it("refreshes when stale on readOrRefresh", async () => {
+    const cache = new CodexPluginListCache({ ttlMs: 10 });
+    let callCount = 0;
+    const request = vi.fn(async () => {
+      callCount += 1;
+      return pluginListResponse([pluginSummary(`plugin-${callCount}`)]);
+    });
+    await cache.readOrRefresh({ key: "runtime", request, nowMs: 0 });
+    const refreshed = await cache.readOrRefresh({ key: "runtime", request, nowMs: 15 });
+    expect(refreshed.response.marketplaces[0]?.plugins[0]?.id).toBe("plugin-2");
+    expect(request).toHaveBeenCalledTimes(2);
+  });
+
+  it("forces refetch when forceRefetch is true", async () => {
+    const cache = new CodexPluginListCache({ ttlMs: 1_000 });
+    let callCount = 0;
+    const request = vi.fn(async () => {
+      callCount += 1;
+      return pluginListResponse([pluginSummary(`plugin-${callCount}`)]);
+    });
+    await cache.readOrRefresh({ key: "runtime", request, nowMs: 0 });
+    expect(request).toHaveBeenCalledTimes(1);
+
+    const forced = await cache.readOrRefresh({
+      key: "runtime",
+      request,
+      nowMs: 1,
+      forceRefetch: true,
+    });
+    expect(forced.response.marketplaces[0]?.plugins[0]?.id).toBe("plugin-2");
+    expect(request).toHaveBeenCalledTimes(2);
+  });
+
+  it("marks entries stale after invalidation", async () => {
+    const cache = new CodexPluginListCache({ ttlMs: 1_000 });
+    const request = vi.fn(async () => pluginListResponse());
+    await cache.refreshNow({ key: "runtime", request, nowMs: 0 });
+
+    cache.invalidate("runtime", "plugin installed", 10);
+    const read = cache.read({ key: "runtime", nowMs: 15 });
+    expect(read.state).toBe("stale");
+  });
+
+  it("coalesces concurrent refreshes for the same key", async () => {
+    const cache = new CodexPluginListCache({ ttlMs: 100 });
+    let resolveFirst: ((response: v2.PluginListResponse) => void) | undefined;
+    const request = vi.fn(
+      async (): Promise<v2.PluginListResponse> =>
+        new Promise((resolve) => {
+          resolveFirst = resolve;
+        }),
+    );
+
+    const first = cache.refreshNow({ key: "runtime", request, nowMs: 0 });
+    const second = cache.refreshNow({ key: "runtime", request, nowMs: 0 });
+    expect(request).toHaveBeenCalledTimes(1);
+
+    resolveFirst?.(pluginListResponse());
+    const firstResult = await first;
+    const secondResult = await second;
+    // Both callers receive the same coalesced snapshot.
+    expect(secondResult).toStrictEqual(firstResult);
+  });
+
+  it("prevents an older refresh from overwriting a newer snapshot", async () => {
+    const cache = new CodexPluginListCache({ ttlMs: 1_000 });
+    let resolveStale: ((response: v2.PluginListResponse) => void) | undefined;
+    let resolveFresh: ((response: v2.PluginListResponse) => void) | undefined;
+    const request = vi.fn(async (): Promise<v2.PluginListResponse> => {
+      return new Promise((resolve) => {
+        if (request.mock.calls.length === 1) {
+          resolveStale = resolve;
+        } else {
+          resolveFresh = resolve;
+        }
+      });
+    });
+
+    const stalePromise = cache.refreshNow({ key: "runtime", request, nowMs: 0 });
+    const freshPromise = cache.refreshNow({
+      key: "runtime",
+      request,
+      nowMs: 1,
+      forceRefetch: true,
+    });
+
+    resolveFresh?.(pluginListResponse([pluginSummary("fresh-plugin")]));
+    await expect(freshPromise).resolves.toMatchObject({
+      response: { marketplaces: expect.arrayContaining([expect.anything()]) },
+    });
+
+    resolveStale?.(pluginListResponse([pluginSummary("stale-plugin")]));
+    await stalePromise.catch(() => undefined);
+
+    const read = cache.read({ key: "runtime", nowMs: 2 });
+    expect(read.snapshot?.response.marketplaces[0]?.plugins[0]?.id).toBe("fresh-plugin");
+  });
+
+  it("clears all entries", async () => {
+    const cache = new CodexPluginListCache({ ttlMs: 100 });
+    const request = vi.fn(async () => pluginListResponse());
+    await cache.refreshNow({ key: "key-a", request, nowMs: 0 });
+    await cache.refreshNow({ key: "key-b", request, nowMs: 0 });
+    expect(cache.getRevision()).toBeGreaterThan(0);
+
+    cache.clear();
+    expect(cache.getRevision()).toBe(0);
+    expect(cache.read({ key: "key-a" }).state).toBe("missing");
+    expect(cache.read({ key: "key-b" }).state).toBe("missing");
+  });
+
+  it("uses the default TTL when not overridden", () => {
+    const cache = new CodexPluginListCache();
+    // The default TTL is 5 minutes; we verify it's not zero or undefined.
+    expect(CODEX_PLUGIN_LIST_CACHE_TTL_MS).toBe(5 * 60 * 1_000);
+    expect(cache.getRevision()).toBe(0);
+  });
+
+  it("propagates refresh errors", async () => {
+    const cache = new CodexPluginListCache({ ttlMs: 100 });
+    const request = vi.fn(async () => {
+      throw new Error("plugin list failed");
+    });
+    await expect(cache.readOrRefresh({ key: "runtime", request, nowMs: 0 })).rejects.toThrow(
+      "plugin list failed",
+    );
+    expect(cache.read({ key: "runtime" }).state).toBe("missing");
+  });
+});
+
+function pluginListResponse(
+  plugins: v2.PluginSummary[] = [pluginSummary("google-calendar")],
+): v2.PluginListResponse {
+  return {
+    marketplaces: [
+      {
+        name: "openai-curated",
+        path: "/marketplaces/openai-curated",
+        interface: null,
+        plugins,
+      },
+    ],
+    marketplaceLoadErrors: [],
+    featuredPluginIds: [],
+  };
+}
+
+function pluginSummary(id: string): v2.PluginSummary {
+  return {
+    id,
+    name: id,
+    source: { type: "remote" },
+    installed: false,
+    enabled: false,
+    installPolicy: "AVAILABLE",
+    authPolicy: "ON_USE",
+    availability: "AVAILABLE",
+    interface: null,
+  };
+}

--- a/extensions/codex/src/app-server/plugin-list-cache.ts
+++ b/extensions/codex/src/app-server/plugin-list-cache.ts
@@ -1,0 +1,199 @@
+/**
+ * Process-local cache for Codex app-server `plugin/list` responses, keyed by
+ * runtime identity. Prevents repeated disk I/O when multiple code paths
+ * (plugin inventory, activation, thread config) call `plugin/list` during a
+ * single request cycle.
+ *
+ * See https://github.com/openclaw/openclaw/issues/99071 — without this cache,
+ * each `buildCodexPluginThreadConfig` call issues up to 4 `plugin/list` RPCs,
+ * and each RPC causes the Codex app-server to scan ~180 `plugin.json` files
+ * from disk, producing 1.3–1.4 GB of reads per 30-second window.
+ */
+import { embeddedAgentLog } from "openclaw/plugin-sdk/agent-harness-runtime";
+import {
+  isFutureDateTimestampMs,
+  resolveDateTimestampMs,
+  resolveExpiresAtMsFromDurationMs,
+} from "openclaw/plugin-sdk/number-runtime";
+import type { v2 } from "./protocol.js";
+
+/** Default plugin list cache freshness window — shorter than app inventory
+ * because plugin install/enable state changes are more disruptive. */
+export const CODEX_PLUGIN_LIST_CACHE_TTL_MS = 5 * 60 * 1_000;
+
+/** Request function used to call `plugin/list` on the Codex app-server. */
+export type CodexPluginListRequest = (
+  method: "plugin/list",
+  params: v2.PluginListParams,
+) => Promise<v2.PluginListResponse>;
+
+/** Immutable plugin list snapshot returned from cache reads and refreshes. */
+export type CodexPluginListSnapshot = {
+  key: string;
+  response: v2.PluginListResponse;
+  fetchedAtMs: number;
+  expiresAtMs: number;
+  revision: number;
+};
+
+/** Freshness state for a cache read. */
+export type CodexPluginListReadState = "fresh" | "stale" | "missing";
+
+/** Cache read result. */
+export type CodexPluginListCacheRead = {
+  state: CodexPluginListReadState;
+  key: string;
+  revision: number;
+  snapshot?: CodexPluginListSnapshot;
+};
+
+type CacheEntry = CodexPluginListSnapshot & {
+  invalidated: boolean;
+};
+
+type RefreshParams = {
+  key: string;
+  request: CodexPluginListRequest;
+  nowMs?: number;
+  forceRefetch?: boolean;
+};
+
+/** In-memory `plugin/list` cache with coalesced refreshes per key. */
+export class CodexPluginListCache {
+  private readonly ttlMs: number;
+  private readonly entries = new Map<string, CacheEntry>();
+  private readonly inFlight = new Map<string, Promise<CodexPluginListSnapshot>>();
+  private readonly refreshTokens = new Map<string, number>();
+  private revision = 0;
+
+  constructor(options: { ttlMs?: number } = {}) {
+    this.ttlMs = options.ttlMs ?? CODEX_PLUGIN_LIST_CACHE_TTL_MS;
+  }
+
+  /** Reads a snapshot, returning freshness state without scheduling refresh. */
+  read(params: { key: string; nowMs?: number }): CodexPluginListCacheRead {
+    const nowMs = resolveDateTimestampMs(params.nowMs);
+    const entry = this.entries.get(params.key);
+    if (!entry) {
+      return {
+        state: "missing",
+        key: params.key,
+        revision: this.revision,
+      };
+    }
+
+    const state: CodexPluginListReadState =
+      entry.invalidated || !isFutureDateTimestampMs(entry.expiresAtMs, { nowMs })
+        ? "stale"
+        : "fresh";
+    return {
+      state,
+      key: params.key,
+      revision: entry.revision,
+      snapshot: stripEntryState(entry),
+    };
+  }
+
+  /** Forces or joins an immediate refresh for a cache key. */
+  refreshNow(params: RefreshParams): Promise<CodexPluginListSnapshot> {
+    return this.refresh(params);
+  }
+
+  /** Returns a cached fresh snapshot or refreshes if missing/stale. */
+  async readOrRefresh(params: RefreshParams): Promise<CodexPluginListSnapshot> {
+    const nowMs = resolveDateTimestampMs(params.nowMs);
+    const entry = this.entries.get(params.key);
+    if (
+      entry &&
+      !entry.invalidated &&
+      isFutureDateTimestampMs(entry.expiresAtMs, { nowMs }) &&
+      !params.forceRefetch
+    ) {
+      return stripEntryState(entry);
+    }
+    return this.refresh(params);
+  }
+
+  /** Marks a key stale and records the reason. */
+  invalidate(key: string, _reason: string, nowMs = Date.now()): number {
+    this.revision += 1;
+    const entry = this.entries.get(key);
+    if (entry) {
+      entry.invalidated = true;
+      entry.revision = this.revision;
+    }
+    return this.revision;
+  }
+
+  /** Clears all cached snapshots and state. */
+  clear(): void {
+    this.entries.clear();
+    this.inFlight.clear();
+    this.refreshTokens.clear();
+    this.revision = 0;
+  }
+
+  /** Returns the monotonically increasing cache revision. */
+  getRevision(): number {
+    return this.revision;
+  }
+
+  private async refresh(params: RefreshParams): Promise<CodexPluginListSnapshot> {
+    const existing = this.inFlight.get(params.key);
+    if (existing && !params.forceRefetch) {
+      return existing;
+    }
+
+    const refreshToken = (this.refreshTokens.get(params.key) ?? 0) + 1;
+    this.refreshTokens.set(params.key, refreshToken);
+    const promise = this.refreshUncoalesced(params, refreshToken);
+    this.inFlight.set(params.key, promise);
+    try {
+      return await promise;
+    } finally {
+      if (this.inFlight.get(params.key) === promise) {
+        this.inFlight.delete(params.key);
+      }
+    }
+  }
+
+  private async refreshUncoalesced(
+    params: RefreshParams,
+    refreshToken: number,
+  ): Promise<CodexPluginListSnapshot> {
+    const nowMs = resolveDateTimestampMs(params.nowMs);
+    try {
+      const response = await params.request("plugin/list", {
+        cwds: [],
+      } satisfies v2.PluginListParams);
+      this.revision += 1;
+      const expiresAtMs = resolveExpiresAtMsFromDurationMs(this.ttlMs, { nowMs }) ?? 0;
+      const snapshot: CodexPluginListSnapshot = {
+        key: params.key,
+        response,
+        fetchedAtMs: nowMs,
+        expiresAtMs,
+        revision: this.revision,
+      };
+      if (this.refreshTokens.get(params.key) === refreshToken) {
+        this.entries.set(params.key, { ...snapshot, invalidated: false });
+      }
+      return snapshot;
+    } catch (error) {
+      embeddedAgentLog.warn("codex plugin list cache refresh failed", {
+        forceRefetch: params.forceRefetch === true,
+        key: params.key,
+        error: error instanceof Error ? error.message : String(error),
+      });
+      throw error;
+    }
+  }
+}
+
+/** Shared plugin list cache used by Codex app-server runtime paths. */
+export const defaultCodexPluginListCache = new CodexPluginListCache();
+
+function stripEntryState(entry: CacheEntry): CodexPluginListSnapshot {
+  const { invalidated: _invalidated, ...snapshot } = entry;
+  return snapshot;
+}

--- a/extensions/codex/src/app-server/plugin-thread-config.test.ts
+++ b/extensions/codex/src/app-server/plugin-thread-config.test.ts
@@ -1,7 +1,8 @@
 // Codex tests cover plugin thread config plugin behavior.
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { CodexAppInventoryCache } from "./app-inventory-cache.js";
 import { CODEX_PLUGINS_MARKETPLACE_NAME } from "./config.js";
+import { defaultCodexPluginListCache } from "./plugin-list-cache.js";
 import {
   buildCodexPluginAppsConfigPatchFromPolicyContext,
   buildCodexPluginThreadConfig,
@@ -13,6 +14,9 @@ import {
 import type { v2 } from "./protocol.js";
 
 describe("Codex plugin thread config", () => {
+  beforeEach(() => {
+    defaultCodexPluginListCache.clear();
+  });
   it("defaults destructive app access on for accessible migrated plugin apps", async () => {
     const appCache = new CodexAppInventoryCache();
     await appCache.refreshNow({

--- a/extensions/codex/src/app-server/plugin-thread-config.ts
+++ b/extensions/codex/src/app-server/plugin-thread-config.ts
@@ -29,6 +29,7 @@ import {
   type CodexPluginOwnedApp,
   type CodexPluginRuntimeRequest,
 } from "./plugin-inventory.js";
+import { defaultCodexPluginListCache, type CodexPluginListCache } from "./plugin-list-cache.js";
 import { isJsonObject, type JsonObject, type JsonValue } from "./protocol.js";
 
 /** Policy context for one app id exposed by a configured Codex plugin. */
@@ -75,6 +76,8 @@ export type BuildCodexPluginThreadConfigParams = {
   configCwd?: string;
   appCache?: CodexAppInventoryCache;
   appCacheKey: string;
+  pluginListCache?: CodexPluginListCache;
+  pluginListCacheKey?: string;
   nowMs?: number;
 };
 
@@ -104,6 +107,7 @@ export async function buildCodexPluginThreadConfig(
   params: BuildCodexPluginThreadConfigParams,
 ): Promise<CodexPluginThreadConfig> {
   const appCache = params.appCache ?? defaultCodexAppInventoryCache;
+  const pluginListCache = params.pluginListCache ?? defaultCodexPluginListCache;
   let inputFingerprint = buildCodexPluginThreadConfigInputFingerprint({
     pluginConfig: params.pluginConfig,
     appCacheKey: params.appCacheKey,
@@ -123,6 +127,8 @@ export async function buildCodexPluginThreadConfig(
     request: params.request,
     appCache,
     appCacheKey: params.appCacheKey,
+    pluginListCache,
+    pluginListCacheKey: params.pluginListCacheKey ?? params.appCacheKey,
     nowMs: params.nowMs,
     suppressAppInventoryRefresh: true,
   });
@@ -144,6 +150,8 @@ export async function buildCodexPluginThreadConfig(
       request: params.request,
       appCache,
       appCacheKey: params.appCacheKey,
+      pluginListCache,
+      pluginListCacheKey: params.pluginListCacheKey ?? params.appCacheKey,
       nowMs: params.nowMs,
     });
     inputFingerprint = buildCodexPluginThreadConfigInputFingerprint({
@@ -162,6 +170,8 @@ export async function buildCodexPluginThreadConfig(
       request: params.request,
       appCache,
       appCacheKey: params.appCacheKey,
+      pluginListCache,
+      pluginListCacheKey: params.pluginListCacheKey ?? params.appCacheKey,
       targetAppIds: record.ownedAppIds,
     });
     activationResults.push(activation);
@@ -194,6 +204,8 @@ export async function buildCodexPluginThreadConfig(
       request: params.request,
       appCache,
       appCacheKey: params.appCacheKey,
+      pluginListCache,
+      pluginListCacheKey: params.pluginListCacheKey ?? params.appCacheKey,
       nowMs: params.nowMs,
     });
     inputFingerprint = buildCodexPluginThreadConfigInputFingerprint({
@@ -213,6 +225,8 @@ export async function buildCodexPluginThreadConfig(
       request: params.request,
       appCache,
       appCacheKey: params.appCacheKey,
+      pluginListCache,
+      pluginListCacheKey: params.pluginListCacheKey ?? params.appCacheKey,
       nowMs: params.nowMs,
     });
     inputFingerprint = buildCodexPluginThreadConfigInputFingerprint({


### PR DESCRIPTION
## Problem

During complex multi-turn tasks, `buildCodexPluginThreadConfig` calls `readCodexPluginInventory` up to **4 times** per request cycle. Each call issues a `plugin/list` RPC to the Codex app-server, which scans ~180 `plugin.json` files from disk. This produces **1.3–1.4 GB of disk reads in 30 seconds** and drives disk utilization to **99%** on resource-constrained cloud servers (2 vCPU / 4 GB RAM Ubuntu 24.04.4), making the server unresponsive.

Reported in #99071.

## Root Cause

The existing `CodexAppInventoryCache` only caches `app/list` responses. The `plugin/list` and `plugin/read` RPC paths — the ones that trigger the heavy disk scanning — had **no cache at all**. Every call to `readCodexPluginInventory` resulted in a fresh `plugin/list` RPC, and `buildCodexPluginThreadConfig` calls it up to 4 times:

1. Initial inventory read (line 126)
2. After waiting for initial app inventory (line 147)
3. After post-install refresh (line 197)
4. After not-ready plugin apps refresh (line 216)

Additionally, `ensureCodexPluginActivation` in `plugin-activation.ts` makes its own `plugin/list` call for each plugin that needs activation.

## Fix

Introduces `CodexPluginListCache` — a process-local in-memory cache for `plugin/list` responses with:
- **5-minute TTL** (shorter than app inventory's 1-hour TTL since plugin install/enable state changes are more disruptive)
- **Coalesced refreshes** per cache key (concurrent callers share the same in-flight request)
- **Refresh generation tokens** to prevent older in-flight refreshes from overwriting newer snapshots
- **Invalidation API** for post-install state changes

### Wiring

| File | Change |
|------|--------|
| `plugin-list-cache.ts` | New file — `CodexPluginListCache` class + `defaultCodexPluginListCache` singleton |
| `plugin-inventory.ts` | `readCodexPluginInventory` uses `readOrRefresh()` for `plugin/list` when cache is provided |
| `plugin-thread-config.ts` | All 4 `readCodexPluginInventory` calls + `ensureCodexPluginActivation` pass the shared cache |
| `attempt-startup.ts` | `buildCodexPluginThreadConfig` callback passes `defaultCodexPluginListCache` |
| `plugin-activation.ts` | Cache invalidated on plugin install and during `refreshCodexPluginRuntimeState` |

### Design Decision: Activation Path Stays Uncached

`ensureCodexPluginActivation` intentionally does **NOT** use the cache for its initial `plugin/list` read. It needs fresh install/enable state to decide whether `plugin/install` is needed. Using a cached response could show a plugin as not-yet-installed when it actually was just installed by a concurrent process, leading to a redundant `plugin/install` call. The cache **is** invalidated after install so subsequent reads see the new state.

## Impact

**Before:** 4+ `plugin/list` RPCs per `buildCodexPluginThreadConfig` call × ~180 `plugin.json` file reads each = 1.3–1.4 GB disk I/O in 30 seconds.

**After:** 1 `plugin/list` RPC per cache TTL window (5 minutes). Subsequent calls within that window return the cached snapshot. Cache is invalidated on plugin install/activation so post-install state changes are always observed.

## Tests

- **10 new tests** in `plugin-list-cache.test.ts`: cache reads, refreshes, coalescing, invalidation, forced refetch, error propagation, revision tracking, clear
- **2 new tests** in `plugin-inventory.test.ts`: verify repeated `readCodexPluginInventory` calls use the cached `plugin/list` response, and `forcePluginListRefetch` bypasses the cache
- **`plugin-thread-config.test.ts`**: `beforeEach` clears `defaultCodexPluginListCache` to prevent cross-test cache pollution
- All **73 existing + new tests** pass across 6 test files

Fixes #99071