### PR TITLE
docs: add scoped iOS TCA agent rules

### DIFF
--- a/apps/ios/AGENTS.md
+++ b/apps/ios/AGENTS.md
@@ -1,6 +1,6 @@
-# iOS Release Agent Policy
+# iOS Agent Policy
 
-Root rules still apply. This file adds the iOS release guardrails.
+Scope: `apps/ios/**`. Root `AGENTS.md` still applies.
 
 ## App Store Releases
 
@@ -10,3 +10,41 @@ Root rules still apply. This file adds the iOS release guardrails.
 - After a failed `pnpm ios:release:upload`, do not continue with `pnpm ios:release:archive`, `asc builds upload`, `asc release stage`, `asc publish appstore`, `asc review submit`, direct Fastlane lanes, or any manual App Store Connect mutation command.
 - Do not submit an iOS App Store version for App Review. App Review submission stays manual unless the user explicitly asks to submit a specific already-prepared version after the failed state has been reported.
 - `pnpm ios:release:archive` is for local archive validation only. It is not a fallback release path after screenshot, metadata, or upload-lane failure.
+
+## TCA Direction
+
+- TCA is the app-logic migration target for the iOS app.
+- New app logic belongs in `@Reducer` features. Keep SwiftUI views rendering state and sending actions.
+- Feature state uses `@ObservableState` and conforms to `Equatable` and `Sendable`.
+- SwiftUI views hold `StoreOf<Feature>` directly. Do not add `WithViewStore` or `ViewStore`.
+- Async work goes through small `@Dependency` clients and returns `Effect.run`.
+- Long-lived effects need explicit cancellation IDs and owner-scoped cancellation.
+- After the helper exists under `apps/ios/Sources/Support/TCA/`, non-root reducers use `.autoLogActions()`.
+
+## Incremental Layout
+
+- Migrate incrementally. Do not reshuffle stable code only to match the target folders.
+- Intended folders:
+  - `apps/ios/Sources/App/` for app composition and root reducer wiring.
+  - `apps/ios/Sources/Features/` for reducer-owned feature logic.
+  - `apps/ios/Sources/Dependencies/` for dependency clients and live/test values.
+  - `apps/ios/Sources/Domain/` for value models and domain types.
+  - `apps/ios/Sources/Support/TCA/` for TCA support helpers.
+
+## Tests
+
+- New reducer tests use Swift Testing plus `TestStore`.
+- Existing UI tests may remain XCTest in `apps/ios/UITests/`.
+- Override dependencies in reducer tests; do not depend on live gateway, network, timers, or device services.
+
+## Project
+
+- iOS project membership and config are owned by `apps/ios/project.yml`.
+- Regenerate with `cd apps/ios && xcodegen generate` after project membership or config changes.
+- Do not hand-edit generated Xcode project membership.
+
+## Validation
+
+- Docs/governance-only changes: `git diff --check`.
+- If touching reducer code, add or update scoped Swift Testing `TestStore` proof.
+- If touching project membership/config, regenerate from `apps/ios/project.yml` and verify the generated project diff.


### PR DESCRIPTION
Related: Loop task TCA-0 (OpenClaw iOS TCA Migration)

AI-assisted: yes. A local transcript candidate was found, but no transcript logs are included because explicit approval was not provided.

## What Problem This Solves

OpenClaw iOS did not have scoped agent guidance for the TCA migration, so future iOS changes could drift on reducer style, view observation, dependency ownership, test expectations, or XcodeGen project ownership.

## Why This Change Was Made

Extends `apps/ios/AGENTS.md` from iOS release-only guardrails into the scoped iOS policy for incremental TCA migration, while preserving the existing App Store release rules. The guide documents the intended TCA direction, target folders, reducer/test expectations, and `apps/ios/project.yml` ownership without adding the TCA package or code scaffolding. The existing `apps/ios/CLAUDE.md -> AGENTS.md` symlink is retained from current `main`.

## User Impact

No runtime behavior changes. Contributors and agents working under `apps/ios/**` now get concise migration rules before making iOS app-logic changes.

## Evidence

- Read repo guidance and scoped inputs: `AGENTS.md`, `CONTRIBUTING.md`, `.github/pull_request_template.md`, `.github/CODEOWNERS`, issue templates, `apps/ios/project.yml`, and `apps/ios/README.md`.
- Verified current iOS layout before writing the rules.
- Rebasing proof: resolved the current `main` `apps/ios/AGENTS.md` add/add conflict by preserving release guardrails and appending TCA policy.
- `git diff --check`
- `git diff --check upstream/main...HEAD`
