### PR TITLE
fix #98866: Embedded local agent runs should serialize globally across session keys when sharing one app-server

### DIFF
--- a/src/tui/embedded-backend.test.ts
+++ b/src/tui/embedded-backend.test.ts
@@ -114,7 +114,8 @@ vi.mock("../agents/agent-scope.js", () => ({
     agents?: { list?: Array<{ id?: string; default?: boolean }> };
   }) =>
     cfg?.agents?.list?.find((agent) => agent.default)?.id ?? cfg?.agents?.list?.[0]?.id ?? "main",
-  resolveSessionAgentId: () => "main",
+  resolveSessionAgentId: (params?: { sessionKey?: string; agentId?: string }) =>
+    params?.agentId ?? /^agent:([^:]+):/.exec(params?.sessionKey ?? "")?.[1] ?? "main",
 }));
 
 vi.mock("../agents/runtime-plugins.js", () => ({
@@ -1054,7 +1055,7 @@ describe("EmbeddedTuiBackend", () => {
     });
   });
 
-  it("queues different-session sends behind active local runs", async () => {
+  it("queues same-agent different-session sends behind active local runs", async () => {
     const { EmbeddedTuiBackend } = await import("./embedded-backend.js");
     const first = deferred<{
       payloads: Array<{ text: string }>;
@@ -1077,7 +1078,7 @@ describe("EmbeddedTuiBackend", () => {
     });
 
     await backend.sendChat({
-      sessionKey: "agent:research:main",
+      sessionKey: "agent:main:research",
       message: "second",
       runId: "run-local-second",
     });
@@ -1338,7 +1339,7 @@ describe("EmbeddedTuiBackend", () => {
     await flushMicrotasks();
   });
 
-  it("queues selected-agent global sends behind active local runs", async () => {
+  it("does not queue selected-agent global sends for different agents", async () => {
     const { EmbeddedTuiBackend } = await import("./embedded-backend.js");
     const first = deferred<{
       payloads: Array<{ text: string }>;
@@ -1367,13 +1368,9 @@ describe("EmbeddedTuiBackend", () => {
       runId: "run-local-work-global",
     });
 
-    expect(agentCommandFromIngressMock).toHaveBeenCalledTimes(1);
+    expect(agentCommandFromIngressMock).toHaveBeenCalledTimes(2);
 
     first.resolve({ payloads: [{ text: "main done" }], meta: {} });
-    await vi.waitFor(() => {
-      expect(agentCommandFromIngressMock).toHaveBeenCalledTimes(2);
-    });
-
     second.resolve({ payloads: [{ text: "work done" }], meta: {} });
     await flushMicrotasks();
   });
@@ -1414,13 +1411,9 @@ describe("EmbeddedTuiBackend", () => {
     });
 
     expect(firstAbortListener).not.toHaveBeenCalled();
-    expect(agentCommandFromIngressMock).toHaveBeenCalledTimes(1);
+    expect(agentCommandFromIngressMock).toHaveBeenCalledTimes(2);
 
     first.resolve({ payloads: [{ text: "main done" }], meta: {} });
-    await vi.waitFor(() => {
-      expect(agentCommandFromIngressMock).toHaveBeenCalledTimes(2);
-    });
-
     stop.resolve({ payloads: [{ text: "work stop" }], meta: {} });
     await flushMicrotasks();
   });

--- a/src/tui/embedded-backend.test.ts
+++ b/src/tui/embedded-backend.test.ts
@@ -1054,6 +1054,94 @@ describe("EmbeddedTuiBackend", () => {
     });
   });
 
+  it("queues different-session sends behind active local runs", async () => {
+    const { EmbeddedTuiBackend } = await import("./embedded-backend.js");
+    const first = deferred<{
+      payloads: Array<{ text: string }>;
+      meta: Record<string, unknown>;
+    }>();
+    const second = deferred<{
+      payloads: Array<{ text: string }>;
+      meta: Record<string, unknown>;
+    }>();
+    agentCommandFromIngressMock
+      .mockReturnValueOnce(first.promise)
+      .mockReturnValueOnce(second.promise);
+
+    const backend = new EmbeddedTuiBackend();
+    backend.start();
+    await backend.sendChat({
+      sessionKey: "agent:main:main",
+      message: "first",
+      runId: "run-local-first",
+    });
+
+    await backend.sendChat({
+      sessionKey: "agent:research:main",
+      message: "second",
+      runId: "run-local-second",
+    });
+    await flushMicrotasks();
+
+    expect(agentCommandFromIngressMock).toHaveBeenCalledTimes(1);
+
+    first.resolve({ payloads: [{ text: "first done" }], meta: {} });
+    await vi.waitFor(() => {
+      expect(agentCommandFromIngressMock).toHaveBeenCalledTimes(2);
+    });
+
+    second.resolve({ payloads: [{ text: "second done" }], meta: {} });
+    await flushMicrotasks();
+  });
+
+  it("does not queue local /btw runs behind active local runs", async () => {
+    const { EmbeddedTuiBackend } = await import("./embedded-backend.js");
+    const first = deferred<{
+      payloads: Array<{ text: string }>;
+      meta: Record<string, unknown>;
+    }>();
+    agentCommandFromIngressMock.mockReturnValueOnce(first.promise);
+    runBtwSideQuestionMock.mockResolvedValueOnce({ text: "side result" });
+    loadSessionEntryMock.mockImplementation((sessionKey: string) => ({
+      cfg: {},
+      canonicalKey: sessionKey,
+      storePath: "/tmp/openclaw-sessions.json",
+      store: {
+        [sessionKey]: {
+          sessionId: `session-${sessionKey}`,
+          updatedAt: Date.now(),
+        },
+      },
+      entry: {
+        sessionId: `session-${sessionKey}`,
+        updatedAt: Date.now(),
+      },
+    }));
+
+    const backend = new EmbeddedTuiBackend();
+    backend.start();
+    await backend.sendChat({
+      sessionKey: "agent:main:main",
+      message: "first",
+      runId: "run-local-first",
+    });
+
+    await backend.sendChat({
+      sessionKey: "agent:research:main",
+      message: "/btw can this run now?",
+      runId: "run-local-btw",
+    });
+    await flushMicrotasks();
+
+    expect(agentCommandFromIngressMock).toHaveBeenCalledTimes(1);
+    await vi.waitFor(() => {
+      expect(runBtwSideQuestionMock).toHaveBeenCalledTimes(1);
+    });
+
+    first.resolve({ payloads: [{ text: "first done" }], meta: {} });
+    await flushMicrotasks();
+  });
+
   it("does not queue stop commands behind active local runs", async () => {
     const { EmbeddedTuiBackend } = await import("./embedded-backend.js");
     const first = deferred<{
@@ -1250,7 +1338,7 @@ describe("EmbeddedTuiBackend", () => {
     await flushMicrotasks();
   });
 
-  it("runs selected-agent global sends independently across agents", async () => {
+  it("queues selected-agent global sends behind active local runs", async () => {
     const { EmbeddedTuiBackend } = await import("./embedded-backend.js");
     const first = deferred<{
       payloads: Array<{ text: string }>;
@@ -1279,9 +1367,13 @@ describe("EmbeddedTuiBackend", () => {
       runId: "run-local-work-global",
     });
 
-    expect(agentCommandFromIngressMock).toHaveBeenCalledTimes(2);
+    expect(agentCommandFromIngressMock).toHaveBeenCalledTimes(1);
 
     first.resolve({ payloads: [{ text: "main done" }], meta: {} });
+    await vi.waitFor(() => {
+      expect(agentCommandFromIngressMock).toHaveBeenCalledTimes(2);
+    });
+
     second.resolve({ payloads: [{ text: "work done" }], meta: {} });
     await flushMicrotasks();
   });
@@ -1322,9 +1414,13 @@ describe("EmbeddedTuiBackend", () => {
     });
 
     expect(firstAbortListener).not.toHaveBeenCalled();
-    expect(agentCommandFromIngressMock).toHaveBeenCalledTimes(2);
+    expect(agentCommandFromIngressMock).toHaveBeenCalledTimes(1);
 
     first.resolve({ payloads: [{ text: "main done" }], meta: {} });
+    await vi.waitFor(() => {
+      expect(agentCommandFromIngressMock).toHaveBeenCalledTimes(2);
+    });
+
     stop.resolve({ payloads: [{ text: "work stop" }], meta: {} });
     await flushMicrotasks();
   });

--- a/src/tui/embedded-backend.test.ts
+++ b/src/tui/embedded-backend.test.ts
@@ -1369,6 +1369,11 @@ describe("EmbeddedTuiBackend", () => {
     });
 
     expect(agentCommandFromIngressMock).toHaveBeenCalledTimes(2);
+    const firstIngressOpts = agentCommandFromIngressMock.mock.calls[0]?.[0] as { lane?: string };
+    const secondIngressOpts = agentCommandFromIngressMock.mock.calls[1]?.[0] as { lane?: string };
+    expect(firstIngressOpts.lane).toMatch(/^embedded-local:/u);
+    expect(secondIngressOpts.lane).toMatch(/^embedded-local:/u);
+    expect(secondIngressOpts.lane).not.toBe(firstIngressOpts.lane);
 
     first.resolve({ payloads: [{ text: "main done" }], meta: {} });
     second.resolve({ payloads: [{ text: "work done" }], meta: {} });

--- a/src/tui/embedded-backend.ts
+++ b/src/tui/embedded-backend.ts
@@ -85,6 +85,7 @@ import type {
 type LocalRunState = {
   sessionKey: string;
   agentId?: string;
+  localBackendKey: string;
   controller: AbortController;
   buffer: string;
   lastBroadcastText?: string;
@@ -382,9 +383,19 @@ export class EmbeddedTuiBackend implements TuiBackend {
       sessionKey: opts.sessionKey,
       agentId: opts.agentId,
     };
+    const cfg = getRuntimeConfig();
+    const localBackendKey = resolveAgentWorkspaceDir(
+      cfg,
+      resolveSessionAgentId({
+        sessionKey: opts.sessionKey,
+        config: cfg,
+        agentId: opts.agentId,
+      }),
+    );
     const abortableSessionRun = this.hasAbortableSessionRun(runScope);
     const stopCommand = abortableSessionRun && isChatStopCommandText(opts.message);
-    const queuedAfter = question || stopCommand ? undefined : this.findQueuedLocalRunPromise();
+    const queuedAfter =
+      question || stopCommand ? undefined : this.findQueuedLocalRunPromise(localBackendKey);
     if (stopCommand) {
       this.abortSessionRuns(runScope);
       return { runId };
@@ -394,6 +405,7 @@ export class EmbeddedTuiBackend implements TuiBackend {
     this.runs.set(runId, {
       sessionKey: opts.sessionKey,
       agentId: opts.agentId,
+      localBackendKey,
       controller,
       buffer: "",
       isBtw: Boolean(question),
@@ -788,10 +800,10 @@ export class EmbeddedTuiBackend implements TuiBackend {
     }
   }
 
-  private findQueuedLocalRunPromise(): QueuedSessionRun | undefined {
+  private findQueuedLocalRunPromise(localBackendKey: string): QueuedSessionRun | undefined {
     let queuedAfter: QueuedSessionRun | undefined;
     for (const [runId, run] of this.runs) {
-      if (!run.isBtw) {
+      if (!run.isBtw && run.localBackendKey === localBackendKey) {
         const promise = this.runPromises.get(runId);
         if (promise) {
           queuedAfter = { run, promise };

--- a/src/tui/embedded-backend.ts
+++ b/src/tui/embedded-backend.ts
@@ -1,5 +1,5 @@
 // Implements the embedded backend used by local TUI sessions.
-import { randomUUID } from "node:crypto";
+import { createHash, randomUUID } from "node:crypto";
 import type { SessionsPatchResult } from "../../packages/gateway-protocol/src/index.js";
 import { agentCommandFromIngress } from "../agents/agent-command.js";
 import {
@@ -198,6 +198,11 @@ function timeoutSecondsFromMs(timeoutMs?: number): string | undefined {
     return undefined;
   }
   return String(Math.max(0, Math.ceil(timeoutMs / 1000)));
+}
+
+function resolveEmbeddedLocalLane(localBackendKey: string): string {
+  const digest = createHash("sha256").update(localBackendKey).digest("hex").slice(0, 16);
+  return `embedded-local:${digest}`;
 }
 
 function resolveDeltaPayload(text: string, previousText: string | undefined) {
@@ -1146,6 +1151,9 @@ export class EmbeddedTuiBackend implements TuiBackend {
         return;
       }
       const loadOptions = params.agentId ? { agentId: params.agentId } : undefined;
+      const localBackendLane = activeRun
+        ? resolveEmbeddedLocalLane(activeRun.localBackendKey)
+        : undefined;
       const { canonicalKey, entry } = loadSessionEntry(params.sessionKey, loadOptions);
       const result = await agentCommandFromIngress(
         {
@@ -1159,6 +1167,7 @@ export class EmbeddedTuiBackend implements TuiBackend {
           ...(entry?.sessionId ? { sessionId: entry.sessionId } : {}),
           thinking: params.thinking,
           deliver: params.deliver,
+          ...(localBackendLane ? { lane: localBackendLane } : {}),
           channel: INTERNAL_MESSAGE_CHANNEL,
           runContext: {
             messageChannel: INTERNAL_MESSAGE_CHANNEL,

--- a/src/tui/embedded-backend.ts
+++ b/src/tui/embedded-backend.ts
@@ -384,8 +384,7 @@ export class EmbeddedTuiBackend implements TuiBackend {
     };
     const abortableSessionRun = this.hasAbortableSessionRun(runScope);
     const stopCommand = abortableSessionRun && isChatStopCommandText(opts.message);
-    const queuedAfter =
-      question || stopCommand ? undefined : this.findQueuedSessionRunPromise(runScope);
+    const queuedAfter = question || stopCommand ? undefined : this.findQueuedLocalRunPromise();
     if (stopCommand) {
       this.abortSessionRuns(runScope);
       return { runId };
@@ -789,13 +788,10 @@ export class EmbeddedTuiBackend implements TuiBackend {
     }
   }
 
-  private findQueuedSessionRunPromise(params: {
-    sessionKey: string;
-    agentId?: string;
-  }): QueuedSessionRun | undefined {
+  private findQueuedLocalRunPromise(): QueuedSessionRun | undefined {
     let queuedAfter: QueuedSessionRun | undefined;
     for (const [runId, run] of this.runs) {
-      if (this.isSameRunScope(run, params) && !run.isBtw) {
+      if (!run.isBtw) {
         const promise = this.runPromises.get(runId);
         if (promise) {
           queuedAfter = { run, promise };


### PR DESCRIPTION
## Summary

- Fixes #98866.
- Scope embedded local non-BTW queueing to the resolved local backend identity instead of the whole `EmbeddedTuiBackend` instance.
- Pass that resolved backend identity into the embedded command lane as `embedded-local:<hash>`, so downstream process-level queueing uses the same boundary instead of the shared `main` lane.
- Same resolved backend workspace still serializes before entering agent execution; different selected-agent `global` sends no longer block each other when they resolve to different agent workspaces.
- `/btw` side questions and scoped stop/abort behavior remain outside the non-BTW queue path.
- **Why it matters / User impact:** Users keep protection against concurrent local turns that share one backend workspace, without unrelated selected agents waiting on each other.
- **Scope boundary:** The change is limited to the in-memory embedded local scheduler identity and the lane passed to existing embedded agent ingress. No provider routing, protocol, schema, config, app-server launch, session persistence, or lockfile behavior changed.

## What Problem This Solves

The original issue was that different local session keys could enter the embedded local agent path concurrently even when they shared one app-server lifecycle. The previous PR revision fixed that by making every non-BTW local send wait behind every active non-BTW local run, but that queue boundary was too broad for selected-agent `global` sends: separate selected agents resolve to separate local backend workspaces, so unrelated prompts could wait behind a run that does not share their backend identity.

A live app-server/provider proof then exposed one more boundary: even after the local `EmbeddedTuiBackend` queue predicate was scoped correctly, the downstream embedded runner still defaulted its process-level global lane to `main` unless a lane was provided. This kept different selected agents serialized by the shared process lane. This patch now uses the same resolved local backend identity for both boundaries: the local queue predicate and the downstream embedded command lane.

## User Impact

Before the fix, selected-agent users could see an unrelated prompt wait because another selected agent had an active local run. After the fix, only prompts that share the same resolved local backend workspace wait behind each other. Same-agent multi-session usage remains serialized, which preserves the safety goal from #98866.

## Origin / follow-up

N/A — independent root cause for #98866 plus review follow-up on PR #99179.

## Competition / linked PR analysis

- **Linked PR(s):** None found for #98866 in this PR diagnosis.
- **Gap in linked PR(s):** N/A.
- **Related open PR scan:** The existing PR diagnostic found no linked competing PR for #98866. This patch is an update to the existing PR head, not a replacement PR.
- **Why this patch is better/canonical:** The fix is at `EmbeddedTuiBackend.sendChat()` and `EmbeddedTuiBackend.runTurn()`, before downstream agent ingress starts a local turn. That is the narrowest source-of-truth point that can decide whether a run shares backend identity with an active run and which process lane should own that backend.
- **Local real behavior proof advantage:** The regression exercises the real `EmbeddedTuiBackend` queue decision and verifies both shared-backend waiting and non-shared selected-agent independence.
- **Live real behavior proof advantage:** The live proof drives the embedded TUI backend through real Codex app-server/provider execution and shows the same two queue invariants with actual lifecycle/tool/assistant events.

## Real behavior proof

- **Behavior or issue addressed:** Non-BTW embedded local sends now queue only behind active non-BTW runs with the same resolved local backend identity. Same resolved agent workspace plus different session keys waits; different selected-agent `global` sends resolve to different backend lanes and do not wait on each other.
- **Real environment tested:** Linux host, local OpenClaw worktree, real `EmbeddedTuiBackend.sendChat()` calls, live Codex app-server processes, and live `codex/gpt-5.5` provider turns via the OpenAI-compatible Codex path using redacted Claude Code base URL/auth source names.
- **Exact steps or command run after this patch:**

```bash
source /media/vdb/code/ai/aispace/openclaw-pr-99179-evidence/context.env
OPENCLAW_PR99179_LIVE_MODEL="codex/gpt-5.5" \
OPENCLAW_PR99179_PROOF_COMMIT="$(git -C "$TASK_WORKTREE" rev-parse HEAD)+pending-diff" \
pnpm --dir "$TASK_WORKTREE" exec tsx "$EVIDENCE_DIR/embedded-backend-live-queue-proof.mts"
```

- **Evidence after fix:**

```text
PR #99179 live embedded backend queue proof
model: codex/gpt-5.5

[254590ms] same-workspace.second-sent-while-first-active {"firstStarted":true,"firstTerminalAtSend":null}
[298155ms] agent.event {"runId":"pr99179-same-first-40625efc","stream":"lifecycle","sessionKey":"agent:dev:queue-a-40625efc","data":{"phase":"finishing"}}
[299835ms] agent.event {"runId":"pr99179-same-second-40625efc","stream":"codex_app_server.lifecycle","sessionKey":"agent:dev:queue-b-40625efc","data":{"phase":"startup"}}
[304830ms] same-workspace.result {"firstRunId":"pr99179-same-first-40625efc","secondRunId":"pr99179-same-second-40625efc","firstTerminalElapsedMs":298155,"secondFirstAgentEventElapsedMs":299835,"passed":true}

[306592ms] different-agent.second-sent-while-first-active {"firstStarted":true,"firstTerminalAtSend":null}
[307980ms] agent.event {"runId":"pr99179-diff-second-40625efc","stream":"codex_app_server.lifecycle","sessionKey":"agent:work:global","data":{"phase":"startup"}}
[347155ms] agent.event {"runId":"pr99179-diff-first-40625efc","stream":"lifecycle","sessionKey":"agent:dev:global","data":{"phase":"finishing"}}
[347300ms] different-agent.result {"firstRunId":"pr99179-diff-first-40625efc","secondRunId":"pr99179-diff-second-40625efc","firstTerminalElapsedMs":347155,"firstTerminalBeforeSecondFirstEventElapsedMs":null,"secondFirstAgentEventElapsedMs":307980,"passed":true}
[347300ms] proof.result {"sameWorkspaceQueued":{"firstRunId":"pr99179-same-first-40625efc","secondRunId":"pr99179-same-second-40625efc","firstTerminalElapsedMs":298155,"secondFirstAgentEventElapsedMs":299835,"passed":true},"differentSelectedAgentsIndependent":{"firstRunId":"pr99179-diff-first-40625efc","secondRunId":"pr99179-diff-second-40625efc","firstTerminalElapsedMs":347155,"firstTerminalBeforeSecondFirstEventElapsedMs":null,"secondFirstAgentEventElapsedMs":307980,"passed":true},"passed":true}

JSON summary:
{
  "sameWorkspaceQueued": {
    "firstRunId": "pr99179-same-first-40625efc",
    "secondRunId": "pr99179-same-second-40625efc",
    "firstTerminalElapsedMs": 298155,
    "secondFirstAgentEventElapsedMs": 299835,
    "passed": true
  },
  "differentSelectedAgentsIndependent": {
    "firstRunId": "pr99179-diff-first-40625efc",
    "secondRunId": "pr99179-diff-second-40625efc",
    "firstTerminalElapsedMs": 347155,
    "firstTerminalBeforeSecondFirstEventElapsedMs": null,
    "secondFirstAgentEventElapsedMs": 307980,
    "passed": true
  },
  "passed": true
}
```

- **Observed result after fix:** The live proof passes both invariants. In the same-workspace scenario, the second run's first app-server lifecycle event occurs after the first run reaches a terminal lifecycle phase (`299835ms` after `298155ms`). In the different selected-agent scenario, the `work` selected-agent run reaches app-server startup at `307980ms` while the `dev` selected-agent run is still active and does not finish until `347155ms`, proving the selected-agent runs no longer share a false-blocking global lane.
- **What was not tested:** This proof does not change or retest persisted session schema, public API compatibility, gateway wire protocol, browser UI, or multi-host deployment behavior. Those areas are out of scope for this in-memory embedded local scheduler/lane boundary change.
- **Fix classification:** Root cause fix.

## Review findings addressed

- **RF-001 / RF-002 / RF-004 / RF-005:** Live embedded app-server/provider proof is now supplied. The proof drives real `EmbeddedTuiBackend.sendChat()` calls through live Codex app-server/provider turns and records lifecycle/tool/assistant timing for shared-backend serialization and selected-agent independence.
- **RF-003:** Fixed. Different selected-agent `global` sends now resolve different local backend workspace identities and receive different `embedded-local:<hash>` process lanes instead of falling back to the shared `main` lane.
- **RF-006:** Fixed. Queueing is scoped to the shared resolved backend identity via `resolveSessionAgentId()` plus `resolveAgentWorkspaceDir()`, and the downstream embedded command lane uses the same identity boundary.

## Regression Test Plan

- **Target test file:** `src/tui/embedded-backend.test.ts`.
- **Scenario locked in:** Start one local non-BTW run, then send another run across the same resolved agent workspace with a different session key; the second run stays queued until the first settles. Start two selected-agent `global` runs with different `agentId` values; both reach agent ingress without waiting and receive different embedded local process lanes.
- **Why this is the smallest reliable guardrail:** The bug is the queue predicate and lane identity before local agent execution, so the focused regression test locks the source-of-truth decision without adding provider flakiness to the unit suite.
- Existing `/btw`, stop/abort, maintenance, and queued-timeout coverage remains green.
- `pnpm tsgo:test:src` passes on the current HEAD.

## Risk / Compatibility

- **Risk labels considered:** session-state, availability, compatibility, security-boundary.
- **Risk explanation:** The queue boundary changes from backend-global to per resolved backend workspace, and the downstream embedded command lane now uses the same resolved backend identity. This reduces unnecessary waiting for unrelated selected agents while preserving serialization for runs that share a backend workspace.
- **Why acceptable:** The diff is limited to the local run state key, queue predicate, and existing lane option passed into embedded agent ingress. It does not change public API, persisted session schema, gateway protocol, provider selection, model routing, app-server launch code, `/btw`, or scoped stop/abort matching.
- **Public contract / compatibility:** No public API, config, schema, protocol, wire format, default, migration, or persisted data contract is changed. `EmbeddedTuiBackend.sendChat()` remains the same internal TUI backend method; only its private queue/lane identity changes.

## Merge risk

- **Risk labels considered:** session-state, availability, compatibility, security-boundary.
- **Risk explanation:** Queueing is still conservative for shared backend workspaces and narrower for non-shared selected-agent workspaces.
- **Why acceptable:** If two sends resolve to the same agent workspace they still serialize; if they resolve to different workspaces they no longer create false waiting. Stop/abort scope checks remain separate and unchanged.

## What was not changed

- **What did NOT change:** Public API, gateway protocol, config schema, persisted session format, provider routing, model execution, app-server launch, auth behavior, and lockfile contents are unchanged.
- App-server launch, lease, and shutdown code are unchanged.
- No lockfiles, generated assets, docs, or unrelated cleanup were changed.

## Root Cause

- **Root cause:** The source invariant was missing at two queue boundaries. The local queue predicate keyed waiting on any active non-BTW local run instead of the resolved agent workspace that owns the local backend state. After that was scoped, the downstream embedded runner still defaulted to the shared process lane `main` because `agentCommandFromIngress()` was not given a backend-specific lane.
- **Why this is root-cause fix:** The fix uses the same source-of-truth resolver boundary before `agentCommandFromIngress()` — `resolveSessionAgentId()` plus `resolveAgentWorkspaceDir()` — for both the in-memory local queue predicate and the embedded process lane. The scheduler state invariant now matches backend ownership rather than masking the symptom downstream.
- **Architecture / source-of-truth check:** `EmbeddedTuiBackend.sendChat()` owns local run creation and queue selection before `runTurn()` reaches `agentCommandFromIngress()`. `EmbeddedTuiBackend.runTurn()` is the handoff point to the embedded runner, so it is also the source-of-truth point for passing the resolved backend lane into the downstream process queue.
- **Architecture boundary:** The patch changes only the in-memory TUI local run scheduler and lane metadata passed into existing embedded command execution. It does not post-process transcripts, change model input, alter gateway protocol, or change app-server lifecycle ownership.
- **Maintainer-ready confidence:** High. The code path has focused regression coverage, the diff is limited, and the live app-server/provider proof now demonstrates both required queue invariants.
- **Patch quality notes:** This is not a fallback or mitigation. It removes the over-broad backend-global queue predicate and replaces it with the resolved backend workspace invariant used by local execution, then passes that same invariant into the downstream process lane. The diff is two source files, with one production change and focused regression coverage.

## Additional verification

```text
Evidence files:
- /media/vdb/code/ai/aispace/openclaw-pr-99179-evidence/embedded-backend-live-queue-proof.txt
- /media/vdb/code/ai/aispace/openclaw-pr-99179-evidence/embedded-backend-live-queue-proof.json
- /media/vdb/code/ai/aispace/openclaw-pr-99179-evidence/embedded-backend-live-queue-proof-summary.md
- /media/vdb/code/ai/aispace/openclaw-pr-99179-evidence/embedded-backend-vitest-head.txt
- /media/vdb/code/ai/aispace/openclaw-pr-99179-evidence/tsgo-test-src-head.txt
```
