### PR TITLE
fix(mcp): reject tools/call requests with non-object arguments

### DIFF
--- a/src/gateway/mcp-http.handlers.ts
+++ b/src/gateway/mcp-http.handlers.ts
@@ -2,6 +2,7 @@
 // Implements initialize, tools/list, tools/call, and notification handling.
 import crypto from "node:crypto";
 import { ContentBlockSchema, type ContentBlock } from "@modelcontextprotocol/sdk/types.js";
+import { isRecord } from "@openclaw/normalization-core/record-coerce";
 import { runBeforeToolCallHook, type HookContext } from "../agents/agent-tools.before-tool-call.js";
 import {
   formatToolExecutionErrorMessage,
@@ -99,7 +100,11 @@ export async function handleMcpJsonRpc(params: {
       return jsonRpcResult(id, { tools: params.toolSchema });
     case "tools/call": {
       const toolName = typeof methodParams?.name === "string" ? methodParams.name.trim() : "";
-      const toolArgs = (methodParams?.arguments ?? {}) as Record<string, unknown>;
+      const rawToolArgs = methodParams?.arguments;
+      if (rawToolArgs !== undefined && !isRecord(rawToolArgs)) {
+        return jsonRpcError(id, -32602, "Invalid params: tools/call arguments must be an object");
+      }
+      const toolArgs = rawToolArgs ?? {};
       if (!toolName) {
         return jsonRpcResult(id, {
           content: [{ type: "text", text: "Tool not available: unknown" }],

--- a/src/gateway/mcp-http.test.ts
+++ b/src/gateway/mcp-http.test.ts
@@ -1153,19 +1153,86 @@ describe("mcp loopback server", () => {
   });
 
   it("executes tools for loopback callers", async () => {
-    const cronExecute = vi.fn(async () => ({
+    const cronExecute = vi.fn<MockGatewayTool["execute"]>(async () => ({
       content: [{ type: "text", text: "CRON_EXECUTED" }],
     }));
+    const args = { action: "status" };
     mockScopedTools([makeMessageTool(), makeCronTool({ execute: cronExecute })]);
     const { runtime } = await startLoopbackServerForTest();
 
     const payload = await callMainSessionTool({
       token: runtime?.ownerToken,
       name: "cron",
+      args,
     });
 
     expect(cronExecute).toHaveBeenCalledTimes(1);
+    expect(getBeforeToolCallHookInput(0).params).toEqual(args);
+    expect(cronExecute.mock.calls[0]?.[1]).toEqual(args);
     expectMcpResultText(payload, "CRON_EXECUTED");
+  });
+
+  it.each([
+    ["null", null],
+    ["array", []],
+    ["string", "bad"],
+  ])("rejects %s tool call arguments before hooks or execution", async (_label, badArguments) => {
+    const execute = vi.fn<MockGatewayTool["execute"]>(async () => ({
+      content: [{ type: "text", text: "EXECUTED" }],
+    }));
+    mockScopedTools([makeMessageTool({ execute })]);
+    const { runtime, port } = await startLoopbackServerForTest();
+
+    const response = await sendRaw({
+      port,
+      token: runtime.ownerToken,
+      headers: jsonHeaders(),
+      body: JSON.stringify({
+        jsonrpc: "2.0",
+        id: 1,
+        method: "tools/call",
+        params: { name: "message", arguments: badArguments },
+      }),
+    });
+
+    expect(response.status).toBe(200);
+    expect(await readMcpPayload(response)).toEqual({
+      jsonrpc: "2.0",
+      id: 1,
+      error: {
+        code: -32602,
+        message: "Invalid params: tools/call arguments must be an object",
+      },
+    });
+    expect(runBeforeToolCallHookMock).not.toHaveBeenCalled();
+    expect(execute).not.toHaveBeenCalled();
+  });
+
+  it("keeps omitted tool call arguments as an empty object", async () => {
+    const execute = vi.fn<MockGatewayTool["execute"]>(async () => ({
+      content: [{ type: "text", text: "EXECUTED" }],
+    }));
+    mockScopedTools([makeMessageTool({ execute })]);
+    const { runtime, port } = await startLoopbackServerForTest();
+
+    const response = await sendRaw({
+      port,
+      token: runtime.ownerToken,
+      headers: jsonHeaders(),
+      body: JSON.stringify({
+        jsonrpc: "2.0",
+        id: 1,
+        method: "tools/call",
+        params: { name: "message" },
+      }),
+    });
+
+    expect(response.status).toBe(200);
+    expectMcpResultText(await readMcpPayload(response), "EXECUTED");
+    expect(runBeforeToolCallHookMock).toHaveBeenCalledTimes(1);
+    expect(getBeforeToolCallHookInput(0).params).toEqual({});
+    expect(execute).toHaveBeenCalledTimes(1);
+    expect(execute.mock.calls[0]?.[1]).toEqual({});
   });
 
   it("preserves valid MCP content blocks returned by loopback tools", async () => {


### PR DESCRIPTION
## What Problem This Solves

The raw Gateway MCP loopback handler accepted any JSON value in `tools/call.params.arguments` and cast it to an object record. Malformed `null`, array, or primitive arguments could therefore reach before-tool hooks and tool implementations even though MCP defines this field as an optional object map.

## Why This Change Was Made

The loopback handler now rejects a present non-object `arguments` value with JSON-RPC `-32602` before hooks, capture preparation, or tool execution. Omitted arguments still become `{}`, and valid object arguments pass through unchanged.

This is deliberately limited to the raw loopback HTTP boundary. The sibling stdio MCP server already registers `CallToolRequestSchema` from the SDK and receives the same validation there. Applying full per-tool schema validation or parsing every loopback request through the SDK would broaden behavior beyond this malformed envelope.

## User Impact

Valid MCP clients are unchanged. Clients sending malformed primitive, `null`, or array tool arguments now receive `Invalid params: tools/call arguments must be an object` instead of passing the wrong runtime shape into OpenClaw tools.

## Evidence

- Direct dependency inspection: the pinned `@modelcontextprotocol/sdk` 1.29.0 defines `CallToolRequestParamsSchema.arguments` as `z.record(z.string(), z.unknown()).optional()` in `dist/esm/types.js`; `src/mcp/tools-stdio-server.ts` uses that request schema.
- Sanitized AWS Crabbox baseline run `run_2be60da5f513` combined the regression test with current-main `src/gateway/mcp-http.handlers.ts` and reproduced the malformed-arguments failure.
- Sanitized AWS Crabbox run `run_6273eafe9b17`, provider `aws`, lease `cbx_e322edfdf5fc`: `pnpm test src/gateway/mcp-http.test.ts` passed 272/272 tests across four Gateway projects before the test-only mock typing correction.
- Exact final-head GitHub Actions workflow `28858393759` passed on `705e63af0e793e46db0467031e1f405db93568a9`, including `check-test-types` and every selected test shard. A repeat sanitized AWS attempt (`run_1fa1a1d425db`) could not install dependencies because AWS fell the requested beast lease back to a `t3.small` and the install was OOM-killed.
- The focused HTTP tests prove `null`, array, and string inputs return `-32602` with zero hook/tool calls; omitted arguments reach both as `{}`; the existing object execution test now verifies a non-empty argument object reaches the hook and executor unchanged.
- The branch was rebuilt from current `main` as one commit, preserving contributor credit with `Co-authored-by: VectorPeak`.
- `git diff --check` passed.
- Final structured autoreview on exact head `705e63af0e793e46db0467031e1f405db93568a9` was clean with 0.92 confidence.
