### PR TITLE
fix(browser): accept tab aliases in action target ids

### DIFF
--- a/extensions/browser/src/browser/routes/agent.act.ts
+++ b/extensions/browser/src/browser/routes/agent.act.ts
@@ -27,6 +27,7 @@ import {
 } from "../navigation-guard.js";
 import { getBrowserProfileCapabilities } from "../profile-capabilities.js";
 import type { BrowserRouteContext } from "../server-context.js";
+import { resolveTargetIdFromTabs } from "../target-id.js";
 import { matchBrowserUrlPattern } from "../url-pattern.js";
 import { registerBrowserAgentActDownloadRoutes } from "./agent.act.download.js";
 import {
@@ -35,7 +36,7 @@ import {
   jsonActError,
 } from "./agent.act.errors.js";
 import { registerBrowserAgentActHookRoutes } from "./agent.act.hooks.js";
-import { normalizeActRequest, validateBatchTargetIds } from "./agent.act.normalize.js";
+import { normalizeActRequest } from "./agent.act.normalize.js";
 import { type ActKind, isActKind } from "./agent.act.shared.js";
 import {
   readBody,
@@ -357,6 +358,66 @@ function getExistingSessionUnsupportedMessage(action: BrowserActRequest): string
   throw new Error("Unsupported browser act kind");
 }
 
+type TargetComparableTab = {
+  targetId: string;
+  suggestedTargetId?: string;
+  tabId?: string;
+  label?: string;
+};
+
+function actionContainsTargetId(action: BrowserActRequest): boolean {
+  if (action.targetId) {
+    return true;
+  }
+  return action.kind === "batch" && action.actions.some(actionContainsTargetId);
+}
+
+function actionTargetIdMatchesTab(params: {
+  requestedTargetId: string;
+  selectedTargetId: string;
+  tabs: TargetComparableTab[];
+}): boolean {
+  if (params.requestedTargetId === params.selectedTargetId) {
+    return true;
+  }
+  const resolved = resolveTargetIdFromTabs(params.requestedTargetId, params.tabs);
+  return resolved.ok && resolved.targetId === params.selectedTargetId;
+}
+
+function normalizeActionTargetIdsForSelectedTab(params: {
+  action: BrowserActRequest;
+  selectedTargetId: string;
+  tabs: TargetComparableTab[];
+  mismatchMessage: string;
+}): string | null {
+  if (params.action.targetId) {
+    if (
+      !actionTargetIdMatchesTab({
+        requestedTargetId: params.action.targetId,
+        selectedTargetId: params.selectedTargetId,
+        tabs: params.tabs,
+      })
+    ) {
+      return params.mismatchMessage;
+    }
+    params.action.targetId = params.selectedTargetId;
+  }
+  if (params.action.kind === "batch") {
+    for (const nestedAction of params.action.actions) {
+      const nestedError = normalizeActionTargetIdsForSelectedTab({
+        action: nestedAction,
+        selectedTargetId: params.selectedTargetId,
+        tabs: params.tabs,
+        mismatchMessage: "batched action targetId must match request targetId",
+      });
+      if (nestedError) {
+        return nestedError;
+      }
+    }
+  }
+  return null;
+}
+
 /** Register browser action endpoints, including hook and download subroutes. */
 export function registerBrowserAgentActRoutes(
   app: BrowserRouteRegistrar,
@@ -412,6 +473,9 @@ export function registerBrowserAgentActRoutes(
           const hasNavigationResultPolicy = Boolean(
             withBrowserNavigationPolicy(ssrfPolicy).ssrfPolicy,
           );
+          const targetComparableTabs = actionContainsTargetId(action)
+            ? await profileCtx.listTabs().catch(() => [] as TargetComparableTab[])
+            : [];
           const jsonOk = async (
             extra?: Record<string, unknown>,
             options?: { resolveCurrentTarget?: boolean },
@@ -441,13 +505,14 @@ export function registerBrowserAgentActRoutes(
               ...extra,
             });
           };
-          if (action.targetId && action.targetId !== tab.targetId) {
-            return jsonActError(
-              res,
-              403,
-              ACT_ERROR_CODES.targetIdMismatch,
-              "action targetId must match request targetId",
-            );
+          const targetIdError = normalizeActionTargetIdsForSelectedTab({
+            action,
+            selectedTargetId: tab.targetId,
+            tabs: targetComparableTabs,
+            mismatchMessage: "action targetId must match request targetId",
+          });
+          if (targetIdError) {
+            return jsonActError(res, 403, ACT_ERROR_CODES.targetIdMismatch, targetIdError);
           }
           const profileName = profileCtx.profile.name;
           if (isExistingSession) {
@@ -660,12 +725,6 @@ export function registerBrowserAgentActRoutes(
           const pw = await requirePwAi(res, `act:${kind}`);
           if (!pw) {
             return;
-          }
-          if (action.kind === "batch") {
-            const targetIdError = validateBatchTargetIds(action.actions, tab.targetId);
-            if (targetIdError) {
-              return jsonActError(res, 403, ACT_ERROR_CODES.targetIdMismatch, targetIdError);
-            }
           }
           const result = await pw.executeActViaPlaywright({
             cdpUrl,

--- a/extensions/browser/src/browser/server.agent-contract-core.test.ts
+++ b/extensions/browser/src/browser/server.agent-contract-core.test.ts
@@ -197,6 +197,46 @@ describe("browser control server", () => {
   );
 
   it(
+    "accepts tabId aliases for top-level action targetId",
+    async () => {
+      const base = await startServerAndBase();
+      const response = await postJson<{ ok: boolean; targetId?: string }>(`${base}/act`, {
+        kind: "click",
+        ref: "5",
+        targetId: "t1",
+      });
+
+      expect(response.ok).toBe(true);
+      expect(response.targetId).toBe("abcd1234");
+      const actCall = mockFirstArg(pwMocks.executeActViaPlaywright, 0, "act");
+      expectRecordFields(actCall, { targetId: "abcd1234" });
+      expectRecordFields(actCall.action, { targetId: "abcd1234" });
+    },
+    slowTimeoutMs,
+  );
+
+  it(
+    "accepts tabId aliases for batched action targetIds",
+    async () => {
+      const base = await startServerAndBase();
+      const response = await postJson<{ ok: boolean; targetId?: string }>(`${base}/act`, {
+        kind: "batch",
+        targetId: "t1",
+        actions: [{ kind: "click", ref: "5", targetId: "t1" }],
+      });
+
+      expect(response.ok).toBe(true);
+      expect(response.targetId).toBe("abcd1234");
+      const actCall = mockFirstArg(pwMocks.executeActViaPlaywright, 0, "act");
+      expectRecordFields(actCall, { targetId: "abcd1234" });
+      expectRecordFields(actCall.action, { targetId: "abcd1234" });
+      const action = actCall.action as { actions?: Array<Record<string, unknown>> };
+      expectRecordFields(action.actions?.[0], { targetId: "abcd1234" });
+    },
+    slowTimeoutMs,
+  );
+
+  it(
     "returns the replacement targetId after an action-triggered target swap",
     async () => {
       const base = await startServerAndBase();


### PR DESCRIPTION
## Summary
- resolve friendly browser tab refs like `t1` before validating top-level and nested action `targetId` fields
- normalize accepted action target ids to the raw CDP target id before Playwright dispatch
- keep true cross-tab mismatches rejected, including inside batch actions

## Verification
- `node scripts/run-vitest.mjs extensions/browser/src/browser/server.agent-contract-core.test.ts`

## Real behavior proof
The browser `/tabs` response tells agents to use friendly refs such as `t1`, but `/act` previously compared nested action `targetId` values directly with the raw CDP target id. That made valid requests like `targetId: "t1"` fail with `ACT_TARGET_ID_MISMATCH` before dispatch. The new tests cover accepted friendly refs at the top level and inside batch actions, while existing mismatch tests continue to reject real cross-tab drift.
