### PR TITLE
fix: use fallback for structured invalid request errors

### DIFF
--- a/src/agents/embedded-agent-helpers.formatassistanterrortext.test.ts
+++ b/src/agents/embedded-agent-helpers.formatassistanterrortext.test.ts
@@ -151,6 +151,27 @@ describe("formatAssistantErrorText", () => {
       "LLM request failed: provider rejected the request schema or tool payload.",
     );
   });
+  it("keeps internal detail and user-facing redaction in sync for #99174 fallback bodies", () => {
+    // Structured invalid_request bodies now classify as "format" so the fallback
+    // chain advances (#99174). Two independent call sites decide error copy —
+    // isSchemaErrorMessage (internal formatter) and the invalid_request re-check in
+    // formatUserFacingAssistantErrorText — and must stay in sync: internal keeps
+    // provider detail for logs, user-facing collapses to the generic schema copy.
+    const msg = makeAssistantError(
+      '{"type":"error","error":{"type":"invalid_request_error","message":"messages.27.content.1: `thinking` blocks cannot be modified"}}',
+    );
+    const internal = formatAssistantErrorText(msg);
+    // Internal formatter keeps the provider detail (via either the "LLM request
+    // rejected:" or "LLM error ..." path depending on key order), never the
+    // generic schema copy.
+    expect(internal).toContain("messages.27.content.1: `thinking` blocks cannot be modified");
+    expect(internal).not.toBe(
+      "LLM request failed: provider rejected the request schema or tool payload.",
+    );
+    expect(formatUserFacingAssistantErrorText(msg)).toBe(
+      "LLM request failed: provider rejected the request schema or tool payload.",
+    );
+  });
   it("sanitizes Codex error-prefixed JSON payloads", () => {
     const msg = makeAssistantError(
       'Codex error: {"type":"error","error":{"message":"Something exploded","type":"server_error"},"sequence_number":2}',

--- a/src/agents/embedded-agent-helpers/errors.ts
+++ b/src/agents/embedded-agent-helpers/errors.ts
@@ -597,7 +597,17 @@ function isSandboxBlockedErrorMessage(raw: string): boolean {
 }
 
 function isSchemaErrorMessage(raw: string): boolean {
-  if (!raw || isReplayInvalidErrorMessage(raw) || isContextOverflowError(raw)) {
+  // Structured invalid_request bodies classify as "format" so the model fallback
+  // chain advances (#99174), but they must NOT collapse the internal/log formatter
+  // to the generic schema copy — that formatter keeps provider detail for logs while
+  // only the user-facing formatter redacts. Genuine schema/tool-payload rejections
+  // still reach the generic copy via matchesFormatErrorPattern below.
+  if (
+    !raw ||
+    isReplayInvalidErrorMessage(raw) ||
+    isContextOverflowError(raw) ||
+    isStructuredInvalidRequestError(raw)
+  ) {
     return false;
   }
   return classifyFailoverReason(raw) === "format" || matchesFormatErrorPattern(raw);
@@ -1111,6 +1121,9 @@ function classifyFailoverClassificationFromMessage(
   }
   if (isJsonApiInternalServerError(raw)) {
     return toReasonClassification("timeout");
+  }
+  if (isStructuredInvalidRequestError(raw)) {
+    return toReasonClassification("format");
   }
   if (isCloudCodeAssistFormatError(raw)) {
     return toReasonClassification("format");
@@ -1764,6 +1777,11 @@ export function isImageSizeError(errorMessage?: string): boolean {
     return false;
   }
   return Boolean(parseImageSizeError(errorMessage));
+}
+
+function isStructuredInvalidRequestError(raw: string): boolean {
+  const type = normalizeOptionalLowercaseString(parseApiErrorInfo(raw)?.type);
+  return Boolean(type && type.includes("invalid_request"));
 }
 
 export function isCloudCodeAssistFormatError(raw: string): boolean {

--- a/src/agents/embedded-agent-helpers/failover-matches.test.ts
+++ b/src/agents/embedded-agent-helpers/failover-matches.test.ts
@@ -1,6 +1,12 @@
 // Covers provider-specific failover matcher regressions.
 import { describe, expect, it } from "vitest";
-import { classifyFailoverReason, classifyFailoverReasonFromHttpStatus } from "./errors.js";
+import { makeAssistantMessageFixture } from "../test-helpers/assistant-message-fixtures.js";
+import {
+  classifyAssistantFailoverReason,
+  classifyFailoverReason,
+  classifyFailoverReasonFromHttpStatus,
+  isFailoverAssistantError,
+} from "./errors.js";
 import {
   isAuthErrorMessage,
   isBillingErrorMessage,
@@ -177,6 +183,40 @@ describe("server error status classification", () => {
 
   it("does not classify prefixed plain internal server error status prose", () => {
     expect(isServerErrorMessage("Proxy notice: Status: Internal Server Error")).toBe(false);
+  });
+});
+
+describe("structured invalid request classification (#99174)", () => {
+  it("classifies unprefixed invalid_request_error JSON as format", () => {
+    const raw =
+      '{"type":"error","error":{"type":"invalid_request_error","message":"messages.27.content.1: `thinking` or `redacted_thinking` blocks in the latest assistant message cannot be modified."}}';
+
+    expect(classifyFailoverReason(raw)).toBe("format");
+  });
+
+  it("classifies assistant invalid_request_error stops as failover format", () => {
+    // The runner's empty-error-retry gate keys on classifyAssistantFailoverReason
+    // returning non-null; prove the assistant-stage entry point (not just the raw
+    // string classifier) advances the fallback chain for this exact body.
+    const raw =
+      '{"type":"error","error":{"type":"invalid_request_error","message":"messages.27.content.1: `thinking` or `redacted_thinking` blocks in the latest assistant message cannot be modified."}}';
+    const msg = makeAssistantMessageFixture({ errorMessage: raw });
+
+    expect(classifyAssistantFailoverReason(msg)).toBe("format");
+    expect(isFailoverAssistantError(msg)).toBe(true);
+  });
+
+  it("preserves more specific invalid request classifications", () => {
+    expect(
+      classifyFailoverReason(
+        '{"type":"error","error":{"type":"invalid_request_error","message":"prompt is too long: 277403 tokens > 200000 maximum"}}',
+      ),
+    ).toBe("context_overflow");
+    expect(
+      classifyFailoverReason(
+        '{"error":{"message":"Invalid API key provided.","type":"invalid_request_error","code":"invalid_api_key"}}',
+      ),
+    ).toBe("auth");
   });
 });
 

--- a/src/agents/embedded-agent-runner/result-fallback-classifier.test.ts
+++ b/src/agents/embedded-agent-runner/result-fallback-classifier.test.ts
@@ -106,6 +106,34 @@ describe("classifyEmbeddedAgentRunResultForModelFallback", () => {
     });
   });
 
+  it("classifies structured provider invalid_request_error payloads as format fallback", () => {
+    const rawError =
+      '{"type":"error","error":{"type":"invalid_request_error","message":"messages.27.content.1: `thinking` or `redacted_thinking` blocks in the latest assistant message cannot be modified."}}';
+
+    const result = classifyEmbeddedAgentRunResultForModelFallback({
+      provider: "anthropic-compatible",
+      model: "primary-model",
+      result: {
+        payloads: [
+          {
+            isError: true,
+            text: rawError,
+          },
+        ],
+        meta: {
+          durationMs: 42,
+        },
+      },
+    });
+
+    expect(result).toEqual({
+      message: `anthropic-compatible/primary-model ended with a provider error: ${rawError}`,
+      reason: "format",
+      code: "embedded_error_payload",
+      rawError,
+    });
+  });
+
   it("classifies generic external runner failure text as fallback-worthy", () => {
     const result = classifyEmbeddedAgentRunResultForModelFallback({
       provider: "claude-cli",

--- a/src/agents/embedded-agent-runner/result-fallback-classifier.ts
+++ b/src/agents/embedded-agent-runner/result-fallback-classifier.ts
@@ -15,7 +15,7 @@ import type { EmbeddedAgentRunResult } from "./types.js";
 
 type ProviderErrorPayloadFailoverReason = Extract<
   FailoverReason,
-  "auth" | "auth_permanent" | "billing" | "rate_limit" | "server_error" | "overloaded"
+  "auth" | "auth_permanent" | "billing" | "format" | "rate_limit" | "server_error" | "overloaded"
 >;
 
 /**
@@ -163,6 +163,7 @@ function classifyProviderErrorPayloadReason(
     case "auth":
     case "auth_permanent":
     case "billing":
+    case "format":
     case "rate_limit":
     case "server_error":
     case "overloaded":

--- a/src/agents/model-fallback.test.ts
+++ b/src/agents/model-fallback.test.ts
@@ -1704,6 +1704,62 @@ describe("runWithModelFallback", () => {
     });
   });
 
+  it("continues fallback after embedded structured invalid_request_error payloads (#99174)", async () => {
+    const cfg = makeCfg({
+      agents: {
+        defaults: {
+          model: {
+            primary: "anthropic/primary-model",
+            fallbacks: ["openai/gpt-5.5"],
+          },
+        },
+      },
+    });
+    // Unprefixed Anthropic-shaped 400 body: no leading HTTP status, structured
+    // invalid_request_error. Before #99174 this classified as null → same-model
+    // empty-error replay instead of advancing to the configured fallback.
+    const rawError =
+      '{"type":"error","error":{"type":"invalid_request_error","message":"messages.27.content.1: `thinking` or `redacted_thinking` blocks in the latest assistant message cannot be modified."}}';
+    const run = vi
+      .fn()
+      .mockResolvedValueOnce({
+        payloads: [{ text: rawError, isError: true }],
+        meta: { durationMs: 1 },
+      } satisfies EmbeddedAgentRunResult)
+      .mockResolvedValueOnce({
+        payloads: [{ text: "fallback ok" }],
+        meta: { durationMs: 1 },
+      } satisfies EmbeddedAgentRunResult);
+
+    const result = await runWithModelFallback<EmbeddedAgentRunResult>({
+      cfg,
+      provider: "anthropic",
+      model: "primary-model",
+      run,
+      classifyResult: ({ provider, model, result: resultLocal }) =>
+        classifyEmbeddedAgentRunResultForModelFallback({
+          provider,
+          model,
+          result: resultLocal,
+        }),
+    });
+
+    expect(result.result.payloads).toEqual([{ text: "fallback ok" }]);
+    expect(run).toHaveBeenCalledTimes(2);
+    expect(requireMockCall(run, 1, "fallback run")).toEqual([
+      "openai",
+      "gpt-5.5",
+      { isFinalFallbackAttempt: true },
+    ]);
+    expect(result.attempts[0]).toMatchObject({
+      provider: "anthropic",
+      model: "primary-model",
+      reason: "format",
+      code: "embedded_error_payload",
+      error: rawError,
+    });
+  });
+
   it("surfaces classified terminal results when no fallback remains", async () => {
     const cfg = makeCfg({
       agents: {


### PR DESCRIPTION
Closes #99174

AI-assisted: yes (Codex implementation; Claude review + regression fix).

## What Problem This Solves

Anthropic-compatible providers can return a structured `invalid_request_error` as a raw
JSON body with no leading HTTP status. The failover classifier only inferred status from a
leading `"400 "` prefix and had no rule for these bodies, so classification returned `null`:
the run was treated as an unclassified silent error, the same model was retried via
`[empty-error-retry]` (replaying the rejected transcript, guaranteed to fail again), and the
configured `agents.defaults.model.fallbacks` chain was never consulted — surfacing a terminal
error even when a healthy fallback model was available.

## Why This Change Was Made

Two coordinated gaps had to close for the fallback chain to advance:
1. **Classification** — `classifyFailoverClassificationFromMessage` now recognizes structured
   `invalid_request` payloads as the existing `format` reason, placed *after* the more specific
   model-not-found / context-overflow / billing / rate-limit / overloaded / server-error / auth
   checks so those still win ("prompt is too long" stays `context_overflow`, "Invalid API key"
   stays `auth`).
2. **Embedded result payload** — the embedded-runner error-payload classifier now allows
   `format` through, so a terminal error *payload* (not just a thrown failover signal) also
   advances the chain.

Reusing the already-integration-tested `format` reason keeps this on the shared classifier path
with no new failover machinery. One subtle coupling: `format` is also read by
`isSchemaErrorMessage`, which feeds the internal/log error formatter. Classifying these bodies
as `format` is excluded from `isSchemaErrorMessage` only, so the internal formatter keeps
provider detail for logs while the user-facing formatter's independent redaction is unchanged.

## User Impact

- **With a fallback model configured:** structured provider request-format rejections now
  advance to the configured fallback instead of losing the turn after a same-model retry.
- **Intentional behavior change:** genuinely user/config-caused `invalid_request_error`
  responses (e.g. a malformed tool param) will now *also* fail over to the next model rather
  than erroring in place. With no fallbacks configured, behavior is unchanged.
- Error-log detail for these bodies is preserved; user-facing copy is unchanged (still redacted).

## Evidence

Source-level red→green plus a real-runtime CLI proof (below).

- **Fallback chain actually advances** (the issue's core claim) — new test in
  `src/agents/model-fallback.test.ts`: an embedded `invalid_request_error` payload drives
  `runWithModelFallback` from `anthropic/primary-model` to the configured `openai/gpt-5.5`
  fallback (`reason: "format"`, `code: "embedded_error_payload"`), `run` called twice.
- **Assistant-stage + raw classification** — `failover-matches.test.ts`: `classifyFailoverReason`
  / `classifyAssistantFailoverReason` / `isFailoverAssistantError` all return `format` for the
  unprefixed body; precedence cases (`context_overflow`, `auth`) preserved.
- **Regression guard** — `embedded-agent-helpers.formatassistanterrortext.test.ts`: internal
  formatter keeps provider detail, user-facing formatter stays redacted (pins the two call
  sites in sync).
- Full affected surface green (395 tests) via `node scripts/run-vitest.mjs` over
  `failover-matches`, `result-fallback-classifier`, `model-fallback`, `formatassistanterrortext`,
  `isbillingerrormessage`, `embedded-agent-error-observation`.
- `oxfmt --check` clean; `git diff --check` clean. Rebased on latest `origin/main`.

### Real-runtime proof (local CLI, no cloud creds)

Drove the actual `openclaw agent --local` embedded runner against a localhost mock
provider (`api: openai-completions`, isolated `OPENCLAW_HOME`) — primary `model-a`
returns the exact structured `invalid_request_error` HTTP 400, fallback `model-b`
returns success. Config: `agents.defaults.model = { primary: mockp/model-a,
fallbacks: [mockp/model-b] }`. `OPENCLAW_LOG_LEVEL=debug`, reproduced identically
across runs. Mock request order: **model-a → model-a → model-b**.

- Primary 400: `[model-fetch] response ... model=model-a status=400 ... contentType=application/json`
  then `embedded run agent end: isError=true model=model-a ... rawError=400 messages.27.content.1: <thinking blocks cannot be modified>`
- **Fallback advances (the fix):** `failover decision: ... reason=format from=mockp/model-a`
  → `model fallback decision: decision=candidate_failed requested=mockp/model-a reason=format next=mockp/model-b`
- No same-model empty-error replay: `[empty-error-retry]` (marker at `run.ts:3413`) count = **0**
  (the pre-existing one-time thinking-stream recovery retry accounts for the 2nd model-a call, not the old 3× loop).
- Fallback success: `decision=candidate_succeeded ... candidate=mockp/model-b`
  → `model=model-b status=200` → `finalAssistantVisibleText: "fallback-ok-…-reply from model-b"`

On `main` these bodies classify null (unclassified → empty-error path, no fallback);
`reason=format` is this PR's behavior. Harness is reproducible; no live provider creds used.
