### PR TITLE
fix(reply): use document cap for local media attachments

### DIFF
--- a/src/auto-reply/reply/agent-runner.final-media-runreplyagent.test.ts
+++ b/src/auto-reply/reply/agent-runner.final-media-runreplyagent.test.ts
@@ -224,7 +224,7 @@ describe("runReplyAgent final MEDIA replies", () => {
     expect(runAgentTurnWithFallbackMock).toHaveBeenCalledOnce();
     expect(resolveOutboundAttachmentFromUrlMock).toHaveBeenCalledWith(
       path.join("/tmp/workspace", "out", "generated.png"),
-      5 * 1024 * 1024,
+      100 * 1024 * 1024,
       { mediaAccess: expect.objectContaining({ workspaceDir: "/tmp/workspace" }) },
     );
   });

--- a/src/auto-reply/reply/reply-media-paths.test.ts
+++ b/src/auto-reply/reply/reply-media-paths.test.ts
@@ -25,6 +25,8 @@ vi.mock("../../media/read-capability.js", () => ({
 
 import { createReplyMediaPathNormalizer } from "./reply-media-paths.js";
 
+const DEFAULT_DOCUMENT_BYTES = 100 * 1024 * 1024;
+
 type NormalizedReply = {
   mediaUrl?: string;
   mediaUrls?: string[];
@@ -109,7 +111,7 @@ describe("createReplyMediaPathNormalizer", () => {
     const options = expectOutboundAttachmentCall(
       0,
       path.join("/tmp/agent-workspace", "out", "photo.png"),
-      5 * 1024 * 1024,
+      DEFAULT_DOCUMENT_BYTES,
     );
     const mediaAccess = requireRecord(options.mediaAccess, "media access");
     expect(mediaAccess.workspaceDir).toBe("/tmp/agent-workspace");
@@ -170,12 +172,12 @@ describe("createReplyMediaPathNormalizer", () => {
     expectOutboundAttachmentCall(
       0,
       path.join("/tmp/sandboxes/session-1", "out", "photo.png"),
-      5 * 1024 * 1024,
+      DEFAULT_DOCUMENT_BYTES,
     );
     expectOutboundAttachmentCall(
       1,
       path.join("/tmp/sandboxes/session-1", "screens", "final.png"),
-      5 * 1024 * 1024,
+      DEFAULT_DOCUMENT_BYTES,
     );
   });
 
@@ -200,7 +202,7 @@ describe("createReplyMediaPathNormalizer", () => {
     expectOutboundAttachmentCall(
       0,
       path.join("/tmp/sandboxes/session-1", "out", "photo.png"),
-      5 * 1024 * 1024,
+      DEFAULT_DOCUMENT_BYTES,
     );
     expect(result.text).toBe("⚠️ Media failed.");
   });
@@ -277,7 +279,7 @@ describe("createReplyMediaPathNormalizer", () => {
     expectMedia(result, "/tmp/outbound-media/screenshot.png", [
       "/tmp/outbound-media/screenshot.png",
     ]);
-    expectOutboundAttachmentCall(0, absolutePath, 5 * 1024 * 1024);
+    expectOutboundAttachmentCall(0, absolutePath, DEFAULT_DOCUMENT_BYTES);
   });
 
   it("stages absolute workspace media paths so the PR scenario now works", async () => {

--- a/src/auto-reply/reply/reply-media-paths.test.ts
+++ b/src/auto-reply/reply/reply-media-paths.test.ts
@@ -25,6 +25,7 @@ vi.mock("../../media/read-capability.js", () => ({
 
 import { createReplyMediaPathNormalizer } from "./reply-media-paths.js";
 
+const DEFAULT_MEDIA_BYTES = 5 * 1024 * 1024;
 const DEFAULT_DOCUMENT_BYTES = 100 * 1024 * 1024;
 
 type NormalizedReply = {
@@ -111,7 +112,7 @@ describe("createReplyMediaPathNormalizer", () => {
     const options = expectOutboundAttachmentCall(
       0,
       path.join("/tmp/agent-workspace", "out", "photo.png"),
-      DEFAULT_DOCUMENT_BYTES,
+      DEFAULT_MEDIA_BYTES,
     );
     const mediaAccess = requireRecord(options.mediaAccess, "media access");
     expect(mediaAccess.workspaceDir).toBe("/tmp/agent-workspace");
@@ -172,12 +173,12 @@ describe("createReplyMediaPathNormalizer", () => {
     expectOutboundAttachmentCall(
       0,
       path.join("/tmp/sandboxes/session-1", "out", "photo.png"),
-      DEFAULT_DOCUMENT_BYTES,
+      DEFAULT_MEDIA_BYTES,
     );
     expectOutboundAttachmentCall(
       1,
       path.join("/tmp/sandboxes/session-1", "screens", "final.png"),
-      DEFAULT_DOCUMENT_BYTES,
+      DEFAULT_MEDIA_BYTES,
     );
   });
 
@@ -202,7 +203,7 @@ describe("createReplyMediaPathNormalizer", () => {
     expectOutboundAttachmentCall(
       0,
       path.join("/tmp/sandboxes/session-1", "out", "photo.png"),
-      DEFAULT_DOCUMENT_BYTES,
+      DEFAULT_MEDIA_BYTES,
     );
     expect(result.text).toBe("⚠️ Media failed.");
   });
@@ -279,6 +280,22 @@ describe("createReplyMediaPathNormalizer", () => {
     expectMedia(result, "/tmp/outbound-media/screenshot.png", [
       "/tmp/outbound-media/screenshot.png",
     ]);
+    expectOutboundAttachmentCall(0, absolutePath, DEFAULT_MEDIA_BYTES);
+  });
+
+  it("uses the Telegram document cap for unconfigured Telegram reply attachments", async () => {
+    const absolutePath = "/Users/peter/.openclaw/workspace/exports/deck.pptx";
+    const normalize = createReplyMediaPathNormalizer({
+      cfg: {},
+      sessionKey: "session-key",
+      workspaceDir: "/Users/peter/.openclaw/workspace",
+      messageProvider: "telegram",
+    });
+
+    await normalize({
+      mediaUrls: [absolutePath],
+    });
+
     expectOutboundAttachmentCall(0, absolutePath, DEFAULT_DOCUMENT_BYTES);
   });
 
@@ -296,6 +313,22 @@ describe("createReplyMediaPathNormalizer", () => {
 
     expectMedia(result, "/tmp/outbound-media/chart.png", ["/tmp/outbound-media/chart.png"]);
     expectOutboundAttachmentCall(0, absolutePath, 8 * 1024 * 1024);
+  });
+
+  it("keeps unconfigured non-Telegram reply attachments on the media-store cap", async () => {
+    const absolutePath = "/Users/peter/.openclaw/workspace/exports/deck.pptx";
+    const normalize = createReplyMediaPathNormalizer({
+      cfg: {},
+      sessionKey: "session-key",
+      workspaceDir: "/Users/peter/.openclaw/workspace",
+      messageProvider: "whatsapp",
+    });
+
+    await normalize({
+      mediaUrls: [absolutePath],
+    });
+
+    expectOutboundAttachmentCall(0, absolutePath, DEFAULT_MEDIA_BYTES);
   });
 
   it("prefers channel account media limits when staging reply attachments", async () => {

--- a/src/auto-reply/reply/reply-media-paths.ts
+++ b/src/auto-reply/reply/reply-media-paths.ts
@@ -16,6 +16,7 @@ import { logVerbose } from "../../globals.js";
 import { resolveChannelAccountMediaMaxMb } from "../../media/configured-max-bytes.js";
 import { resolveOutboundAttachmentFromUrl } from "../../media/outbound-attachment.js";
 import { resolveAgentScopedOutboundMediaAccess } from "../../media/read-capability.js";
+import { MEDIA_MAX_BYTES } from "../../media/store.js";
 import { appendReplyMediaFailureWarning, copyReplyPayloadMetadata } from "../reply-payload.js";
 import type { ReplyPayload } from "../types.js";
 
@@ -49,9 +50,12 @@ function resolveReplyMediaMaxBytes(params: {
 }): number {
   const limitMb =
     resolveChannelAccountMediaMaxMb(params) ?? params.cfg.agents?.defaults?.mediaMaxMb;
-  return typeof limitMb === "number" && Number.isFinite(limitMb) && limitMb > 0
-    ? Math.floor(limitMb * 1024 * 1024)
-    : maxBytesForKind("document");
+  if (typeof limitMb === "number" && Number.isFinite(limitMb) && limitMb > 0) {
+    return Math.floor(limitMb * 1024 * 1024);
+  }
+  return params.channel?.trim().toLowerCase() === "telegram"
+    ? maxBytesForKind("document")
+    : MEDIA_MAX_BYTES;
 }
 
 export function createReplyMediaPathNormalizer(params: {

--- a/src/auto-reply/reply/reply-media-paths.ts
+++ b/src/auto-reply/reply/reply-media-paths.ts
@@ -1,5 +1,6 @@
 // Resolves media paths from reply payloads into runtime attachment metadata.
 import path from "node:path";
+import { maxBytesForKind } from "@openclaw/media-core/constants";
 import { isPassThroughRemoteMediaSource } from "@openclaw/media-core/media-source-url";
 import { resolveSendableOutboundReplyParts } from "openclaw/plugin-sdk/reply-payload";
 import { resolveSessionAgentId } from "../../agents/agent-scope.js";
@@ -15,7 +16,6 @@ import { logVerbose } from "../../globals.js";
 import { resolveChannelAccountMediaMaxMb } from "../../media/configured-max-bytes.js";
 import { resolveOutboundAttachmentFromUrl } from "../../media/outbound-attachment.js";
 import { resolveAgentScopedOutboundMediaAccess } from "../../media/read-capability.js";
-import { MEDIA_MAX_BYTES } from "../../media/store.js";
 import { appendReplyMediaFailureWarning, copyReplyPayloadMetadata } from "../reply-payload.js";
 import type { ReplyPayload } from "../types.js";
 
@@ -51,7 +51,7 @@ function resolveReplyMediaMaxBytes(params: {
     resolveChannelAccountMediaMaxMb(params) ?? params.cfg.agents?.defaults?.mediaMaxMb;
   return typeof limitMb === "number" && Number.isFinite(limitMb) && limitMb > 0
     ? Math.floor(limitMb * 1024 * 1024)
-    : MEDIA_MAX_BYTES;
+    : maxBytesForKind("document");
 }
 
 export function createReplyMediaPathNormalizer(params: {


### PR DESCRIPTION
## What Problem This Solves

Refs #40880 for the Telegram outbound reply-media path.

Telegram can send generated local documents larger than 5 MiB, but final-reply media staging was dropping an unconfigured 23,456,667 byte PPTX before it reached Telegram `sendDocument`. Direct Telegram `sendDocument` for the same file succeeded, so the failing boundary was local reply-media staging rather than the Telegram adapter or the PPTX MIME type.

## Summary

Local final-reply attachments sent back to Telegram now use the document media cap when no explicit `mediaMaxMb` is configured.

## Change

- Preserve explicit channel/account/default `mediaMaxMb` overrides.
- Use the 100 MiB document cap only for unconfigured Telegram reply-media staging.
- Keep unconfigured non-Telegram reply-media staging on the existing 5 MiB media-store cap.
- Add focused tests for the Telegram default cap and the non-Telegram fallback.

## Evidence

Real failure observed on a Telegram reply with:

- `MEDIA:./tmp/izen_shooting/Annual_CIS_Conference_2026_RU.pptx`
- `application/vnd.openxmlformats-officedocument.presentationml.presentation`
- `23,456,667` bytes

Focused validation after this patch:

```text
node scripts/run-vitest.mjs src/auto-reply/reply/reply-media-paths.test.ts src/auto-reply/reply/agent-runner.final-media-runreplyagent.test.ts
# 2 files passed, 26 tests passed
```

Live Telegram smoke proof from a real OpenClaw Telegram reply:

![Redacted Telegram screenshot showing an 8.0 MB PPTX delivered without Media failed](https://raw.githubusercontent.com/dankarization/openclaw/pr-99189-proof-assets/proofs/pr-99189/telegram-pptx-8mb-proof-redacted.jpg)

- File shown by Telegram: `test_local_reply_media_8mb_...pptx`
- Telegram UI size/type: `8.0 MB PPTX`
- Result: the document is visible in Telegram without `Media failed`

Telegram limit note: the cloud Bot API upload limit is 50 MB for documents, while a self-hosted local Bot API server supports uploads up to 2000 MB. This proof intentionally stays inside the normal cloud `sendDocument` envelope while crossing the old 5 MiB reply-media staging cap.
