### PR TITLE
fix: keep load-path plugins after managed plugin installs

### DIFF
--- a/src/config/config.plugin-validation.test.ts
+++ b/src/config/config.plugin-validation.test.ts
@@ -1,10 +1,13 @@
 // Covers plugin config validation and manifest-backed constraints.
+import crypto from "node:crypto";
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
+import { resolveInstalledPluginIndexPolicyHash } from "../plugins/installed-plugin-index-policy.js";
 import { clearLoadInstalledPluginIndexInstallRecordsCache } from "../plugins/installed-plugin-index-records.js";
 import { writePersistedInstalledPluginIndex } from "../plugins/installed-plugin-index-store.js";
+import { clearPluginMetadataLifecycleCaches } from "../plugins/plugin-metadata-lifecycle.js";
 import { validateConfigObjectWithPlugins } from "./validation.js";
 
 vi.unmock("../version.js");
@@ -116,6 +119,13 @@ function expectNoPath(
   pathValue: string,
 ) {
   expect(entries?.some((entry) => entry.path === pathValue)).toBe(false);
+}
+
+async function sha256File(filePath: string): Promise<string> {
+  return crypto
+    .createHash("sha256")
+    .update(await fs.readFile(filePath))
+    .digest("hex");
 }
 
 describe("config plugin validation", () => {
@@ -1300,6 +1310,97 @@ describe("config plugin validation", () => {
         { stateDir },
       );
       clearLoadInstalledPluginIndexInstallRecordsCache();
+    }
+  });
+
+  it("keeps load-path plugins valid when a persisted installed index has managed plugins", async () => {
+    const stateDir = path.join(suiteHome, ".openclaw");
+    const managedPluginDir = path.join(stateDir, "npm", "projects", "openclaw-llama-cpp-provider");
+    const loadPathRoot = path.join(suiteHome, "workspace", "plugins");
+    const workspacePluginDir = path.join(loadPathRoot, "local-tools");
+    await writePluginFixture({
+      dir: managedPluginDir,
+      id: "llama-cpp",
+      schema: { type: "object" },
+    });
+    await writePluginFixture({
+      dir: workspacePluginDir,
+      id: "local-tools",
+      schema: { type: "object" },
+    });
+    const config = {
+      agents: { list: [{ id: "openclaw" }] },
+      plugins: {
+        enabled: true,
+        load: { paths: [loadPathRoot] },
+        entries: {
+          "llama-cpp": { enabled: true },
+          "local-tools": { enabled: true },
+        },
+        allow: ["llama-cpp", "local-tools"],
+      },
+    };
+    const managedManifestPath = path.join(managedPluginDir, "openclaw.plugin.json");
+    clearLoadInstalledPluginIndexInstallRecordsCache();
+    clearPluginMetadataLifecycleCaches();
+    await writePersistedInstalledPluginIndex(
+      {
+        version: 1,
+        hostContractVersion: "test",
+        compatRegistryVersion: "test",
+        migrationVersion: 1,
+        policyHash: resolveInstalledPluginIndexPolicyHash(config),
+        generatedAtMs: 1,
+        installRecords: {},
+        plugins: [
+          {
+            pluginId: "llama-cpp",
+            manifestPath: managedManifestPath,
+            manifestHash: await sha256File(managedManifestPath),
+            source: path.join(managedPluginDir, "index.js"),
+            rootDir: managedPluginDir,
+            origin: "global",
+            enabled: true,
+            startup: {
+              sidecar: false,
+              memory: false,
+              deferConfiguredChannelFullLoadUntilAfterListen: false,
+              agentHarnesses: [],
+            },
+            compat: [],
+          },
+        ],
+        diagnostics: [],
+      },
+      { stateDir },
+    );
+    clearPluginMetadataLifecycleCaches();
+    try {
+      const res = validateInSuite(config);
+
+      expect(res.ok).toBe(true);
+      if (!res.ok) {
+        return;
+      }
+      expectNoPath(res.warnings, "plugins.entries.local-tools");
+      expectNoPath(res.warnings, "plugins.allow");
+    } finally {
+      await writePersistedInstalledPluginIndex(
+        {
+          version: 1,
+          hostContractVersion: "test",
+          compatRegistryVersion: "test",
+          migrationVersion: 1,
+          policyHash: resolveInstalledPluginIndexPolicyHash({}),
+          generatedAtMs: 2,
+          installRecords: {},
+          plugins: [],
+          diagnostics: [],
+        },
+        { stateDir },
+      );
+      clearLoadInstalledPluginIndexInstallRecordsCache();
+      clearPluginMetadataLifecycleCaches();
     }
   });
 

--- a/src/plugins/discovery.ts
+++ b/src/plugins/discovery.ts
@@ -1429,6 +1429,105 @@ function discoverFromPath(params: {
   }
 }
 
+function discoverConfiguredOpenClawPluginCandidates(params: {
+  workspaceDir?: string;
+  workspaceRoot?: string;
+  roots: ReturnType<typeof resolvePluginSourceRoots>;
+  extraPaths?: string[];
+  ownershipUid?: number | null;
+  env: NodeJS.ProcessEnv;
+  realpathCache: Map<string, string>;
+  packageManifestCache: Map<string, PackageManifest | null>;
+}): PluginDiscoveryResult {
+  const result = createDiscoveryResult();
+  const seen = new Set<string>();
+  const extra = params.extraPaths ?? [];
+  for (const extraPath of extra) {
+    if (typeof extraPath !== "string") {
+      continue;
+    }
+    const trimmed = extraPath.trim();
+    if (!trimmed) {
+      continue;
+    }
+    const bundledAlias = resolvePackagedBundledLoadPathAlias({
+      bundledRoot: params.roots.stock,
+      loadPath: resolveUserPath(trimmed, params.env),
+    });
+    if (bundledAlias) {
+      result.diagnostics.push({
+        level: "warn",
+        source: trimmed,
+        message: `ignored plugins.load.paths entry that points at OpenClaw's ${bundledAlias.kind} bundled plugin directory; remove this redundant path or run openclaw doctor --fix`,
+      });
+      continue;
+    }
+    discoverFromPath({
+      rawPath: trimmed,
+      origin: "config",
+      ownershipUid: params.ownershipUid,
+      workspaceDir: params.workspaceDir,
+      env: params.env,
+      candidates: result.candidates,
+      diagnostics: result.diagnostics,
+      seen,
+      realpathCache: params.realpathCache,
+      packageManifestCache: params.packageManifestCache,
+    });
+  }
+  const workspaceMatchesBundledRoot = resolvesToSameDirectory(
+    params.workspaceRoot,
+    params.roots.stock,
+    params.realpathCache,
+  );
+  if (params.roots.workspace && params.workspaceRoot && !workspaceMatchesBundledRoot) {
+    // Keep workspace auto-discovery constrained to the OpenClaw extensions root.
+    // Recursively scanning the full workspace treats arbitrary project folders as
+    // plugin candidates and causes noisy "plugin manifest not found" validation failures.
+    discoverInDirectory({
+      dir: params.roots.workspace,
+      origin: "workspace",
+      env: params.env,
+      ownershipUid: params.ownershipUid,
+      workspaceDir: params.workspaceRoot,
+      candidates: result.candidates,
+      diagnostics: result.diagnostics,
+      seen,
+      realpathCache: params.realpathCache,
+      packageManifestCache: params.packageManifestCache,
+    });
+  }
+  return result;
+}
+
+export function discoverConfiguredOpenClawPlugins(params: {
+  workspaceDir?: string;
+  extraPaths?: string[];
+  ownershipUid?: number | null;
+  env?: NodeJS.ProcessEnv;
+}): PluginDiscoveryResult {
+  const env = params.env ?? process.env;
+  const workspaceDir = normalizeOptionalString(params.workspaceDir);
+  const workspaceRoot = workspaceDir ? resolveUserPath(workspaceDir, env) : undefined;
+  const roots = resolvePluginSourceRoots({ workspaceDir: workspaceRoot, env });
+  const result = tracePluginLifecyclePhase(
+    "discovery scan",
+    () =>
+      discoverConfiguredOpenClawPluginCandidates({
+        workspaceDir,
+        workspaceRoot,
+        roots,
+        extraPaths: params.extraPaths,
+        ownershipUid: params.ownershipUid,
+        env,
+        realpathCache: new Map<string, string>(),
+        packageManifestCache: new Map<string, PackageManifest | null>(),
+      }),
+    { scope: "scoped", extraPathCount: params.extraPaths?.length ?? 0 },
+  );
+  return result;
+}
+
 export function discoverOpenClawPlugins(params: {
   workspaceDir?: string;
   extraPaths?: string[];
@@ -1444,67 +1543,17 @@ export function discoverOpenClawPlugins(params: {
   const packageManifestCache = new Map<string, PackageManifest | null>();
   const scopedResult = tracePluginLifecyclePhase(
     "discovery scan",
-    () => {
-      const result = createDiscoveryResult();
-      const seen = new Set<string>();
-      const extra = params.extraPaths ?? [];
-      for (const extraPath of extra) {
-        if (typeof extraPath !== "string") {
-          continue;
-        }
-        const trimmed = extraPath.trim();
-        if (!trimmed) {
-          continue;
-        }
-        const bundledAlias = resolvePackagedBundledLoadPathAlias({
-          bundledRoot: roots.stock,
-          loadPath: resolveUserPath(trimmed, env),
-        });
-        if (bundledAlias) {
-          result.diagnostics.push({
-            level: "warn",
-            source: trimmed,
-            message: `ignored plugins.load.paths entry that points at OpenClaw's ${bundledAlias.kind} bundled plugin directory; remove this redundant path or run openclaw doctor --fix`,
-          });
-          continue;
-        }
-        discoverFromPath({
-          rawPath: trimmed,
-          origin: "config",
-          ownershipUid: params.ownershipUid,
-          workspaceDir,
-          env,
-          candidates: result.candidates,
-          diagnostics: result.diagnostics,
-          seen,
-          realpathCache,
-          packageManifestCache,
-        });
-      }
-      const workspaceMatchesBundledRoot = resolvesToSameDirectory(
+    () =>
+      discoverConfiguredOpenClawPluginCandidates({
+        workspaceDir,
         workspaceRoot,
-        roots.stock,
+        roots,
+        extraPaths: params.extraPaths,
+        ownershipUid: params.ownershipUid,
+        env,
         realpathCache,
-      );
-      if (roots.workspace && workspaceRoot && !workspaceMatchesBundledRoot) {
-        // Keep workspace auto-discovery constrained to the OpenClaw extensions root.
-        // Recursively scanning the full workspace treats arbitrary project folders as
-        // plugin candidates and causes noisy "plugin manifest not found" validation failures.
-        discoverInDirectory({
-          dir: roots.workspace,
-          origin: "workspace",
-          env,
-          ownershipUid: params.ownershipUid,
-          workspaceDir: workspaceRoot,
-          candidates: result.candidates,
-          diagnostics: result.diagnostics,
-          seen,
-          realpathCache,
-          packageManifestCache,
-        });
-      }
-      return result;
-    },
+        packageManifestCache,
+      }),
     { scope: "scoped", extraPathCount: params.extraPaths?.length ?? 0 },
   );
   const sharedResult = tracePluginLifecyclePhase(

--- a/src/plugins/manifest-registry-installed.test.ts
+++ b/src/plugins/manifest-registry-installed.test.ts
@@ -449,6 +449,42 @@ describe("loadPluginManifestRegistryForInstalledIndex", () => {
     });
   });
 
+  it("includes configured load-path plugins missing from the installed index", () => {
+    const installedRoot = makeTempDir();
+    const loadPathRoot = makeTempDir();
+    const workspacePluginRoot = path.join(loadPathRoot, "workspace-local");
+    fs.mkdirSync(workspacePluginRoot);
+    writePlugin(installedRoot, "installed", "installed-");
+    writePlugin(workspacePluginRoot, "workspace-local", "workspace-");
+
+    const registry = loadPluginManifestRegistryForInstalledIndex({
+      index: createIndex(installedRoot),
+      config: {
+        plugins: {
+          load: { paths: [loadPathRoot] },
+          entries: { "workspace-local": { enabled: true } },
+          allow: ["workspace-local"],
+        },
+      },
+      env: {
+        OPENCLAW_VERSION: "2026.4.25",
+        VITEST: "true",
+      },
+      includeDisabled: true,
+    });
+
+    expect(registry.diagnostics).toStrictEqual([]);
+    expect(registry.plugins.map((plugin) => plugin.id)).toEqual(["installed", "workspace-local"]);
+    expect(registry.plugins.find((plugin) => plugin.id === "workspace-local")?.origin).toBe(
+      "config",
+    );
+    expect(
+      registry.plugins.find((plugin) => plugin.id === "workspace-local")?.modelSupport,
+    ).toEqual({
+      modelPrefixes: ["workspace-"],
+    });
+  });
+
   it("reconstructs bundle candidates with their bundle manifest format", () => {
     const rootDir = makeTempDir();
     fs.mkdirSync(path.join(rootDir, ".claude-plugin"), { recursive: true });

--- a/src/plugins/manifest-registry-installed.ts
+++ b/src/plugins/manifest-registry-installed.ts
@@ -6,7 +6,8 @@ import { normalizeOptionalString } from "@openclaw/normalization-core/string-coe
 import { normalizeOptionalTrimmedStringList } from "@openclaw/normalization-core/string-normalization";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { tryReadJsonSync } from "../infra/json-files.js";
-import type { PluginCandidate } from "./discovery.js";
+import { normalizePluginsConfig } from "./config-state.js";
+import { discoverConfiguredOpenClawPlugins, type PluginCandidate } from "./discovery.js";
 import { hashJson } from "./installed-plugin-index-hash.js";
 import type { InstalledPluginFileSignature } from "./installed-plugin-index-hash.js";
 import type { InstalledPluginIndex, InstalledPluginIndexRecord } from "./installed-plugin-index.js";
@@ -594,6 +595,34 @@ function toPluginCandidate(
   };
 }
 
+function appendConfiguredPluginCandidates(params: {
+  candidates: PluginCandidate[];
+  diagnostics: PluginManifestRegistry["diagnostics"];
+  config?: OpenClawConfig;
+  workspaceDir?: string;
+  env: NodeJS.ProcessEnv;
+  pluginIdSet: ReadonlySet<string> | null;
+}): void {
+  const loadPaths = normalizePluginsConfig(params.config?.plugins).loadPaths;
+  if (loadPaths.length === 0 && !params.workspaceDir) {
+    return;
+  }
+  const configuredDiscovery = discoverConfiguredOpenClawPlugins({
+    workspaceDir: params.workspaceDir,
+    extraPaths: loadPaths,
+    env: params.env,
+  });
+  const candidates = params.pluginIdSet
+    ? configuredDiscovery.candidates.filter((candidate) =>
+        params.pluginIdSet?.has(candidate.idHint),
+      )
+    : configuredDiscovery.candidates;
+  params.candidates.push(...candidates);
+  if (candidates.length > 0 || !params.pluginIdSet) {
+    params.diagnostics.push(...configuredDiscovery.diagnostics);
+  }
+}
+
 export function loadPluginManifestRegistryForInstalledIndex(params: {
   index: InstalledPluginIndex;
   config?: OpenClawConfig;
@@ -622,6 +651,14 @@ export function loadPluginManifestRegistryForInstalledIndex(params: {
         .filter((plugin) => params.includeDisabled || plugin.enabled)
         .filter((plugin) => !pluginIdSet || pluginIdSet.has(plugin.pluginId))
         .map((plugin) => toPluginCandidate(plugin, realpathCache));
+      appendConfiguredPluginCandidates({
+        candidates,
+        diagnostics,
+        config: params.config,
+        workspaceDir: params.workspaceDir,
+        env,
+        pluginIdSet,
+      });
       return loadPluginManifestRegistry({
         config: params.config,
         workspaceDir: params.workspaceDir,


### PR DESCRIPTION
Fixes #99185

AI-assisted: yes (Codex).

## What Problem This Solves

Fixes an issue where users with workspace plugins configured through `plugins.load.paths` would see those plugins dropped as stale after installing and enabling a managed npm plugin.

With a persisted installed-plugin index present, config validation could rebuild manifest metadata only from the installed index rows. That left load-path workspace plugins out of `knownIds`, producing warnings such as `plugin not found: <id> (stale config entry ignored; remove it from plugins config)` even though the configured plugin files still existed on disk.

## Why This Change Was Made

The installed-index manifest reconstruction path now includes the same configured-scope discovery candidates used by normal plugin discovery. This keeps explicit `plugins.load.paths` and workspace-scoped plugins visible while preserving the persisted-index fast path for installed/shared plugin metadata.

This does not change shared/global root scanning for the installed-index fast path, and scoped metadata requests still filter configured candidates to the requested plugin ids.

Duplicate-work check: exact PR searches for #99185 found no active fix PR. Related PR #96080 handles configured plugins under the global extensions root for #96046, and PR #89882 handles recovered install records for #89606; neither covers the `plugins.load.paths` workspace-plugin path reported here.

## User Impact

Operators can install and enable managed npm plugins without causing existing load-path workspace plugins to disappear from gateway startup or CLI validation. Existing workspace plugin entries and allowlist entries remain valid when their manifests are still present.

## Evidence

Focused proof run on this branch:

```text
node scripts/run-vitest.mjs src/plugins/manifest-registry-installed.test.ts
# 1 file passed, 18 tests passed

node scripts/run-vitest.mjs src/plugins/plugin-metadata-snapshot.memo.test.ts
# 1 file passed, 33 tests passed

node scripts/run-vitest.mjs src/config/config.plugin-validation.test.ts
# 1 file passed, 59 tests passed

node scripts/run-vitest.mjs src/plugins/discovery.test.ts
# 1 file passed, 76 tests passed

node node_modules/oxfmt/bin/oxfmt --check src/plugins/discovery.ts src/plugins/manifest-registry-installed.ts src/plugins/manifest-registry-installed.test.ts src/config/config.plugin-validation.test.ts
# passed

git diff --check
# passed
```

Autoreview note: attempted `.agents/skills/autoreview/scripts/autoreview --mode local`, but this environment's approval policy rejected the external Codex review-engine run because it would export the local patch. Keeping this PR draft so maintainers can run or trigger the normal review path.
