### PR TITLE
fix(agents): stop a single reused-CLI-session death from cascading to "All models failed"

### DIFF
--- a/src/agents/agent-command.ts
+++ b/src/agents/agent-command.ts
@@ -1887,20 +1887,34 @@ async function agentCommandInternal(
               autoFallbackPrimaryProbe &&
               providerOverride === autoFallbackPrimaryProbe.provider &&
               modelOverride === autoFallbackPrimaryProbe.model;
+            const isFallbackRetry = fallbackAttemptIndex > 0;
+            fallbackAttemptIndex += 1;
+            // SCRUM-3256: on a fallback retry, a prior candidate may have cleared a
+            // poisoned CLI session in the shared sessionStore (reused-session turn
+            // death -- see attempt-execution.ts's "CLI session cleared after failed
+            // reused turn"). sessionEntryForAttempt is a snapshot captured once
+            // before this fallback loop began, so it still carries the dead
+            // binding; without this re-read, the next candidate resumes the
+            // already-cleared session and fails near-instantly, cascading a single
+            // transient death into "All models failed" across every remaining
+            // model. Re-read the live store entry for fallback retries only --
+            // the primary attempt (isFallbackRetry === false) is unaffected.
+            const liveSessionEntry =
+              isFallbackRetry && sessionStore
+                ? (sessionStore[sessionKey ?? sessionId] ?? sessionEntryForAttempt)
+                : sessionEntryForAttempt;
             const attemptSessionEntry =
               autoFallbackPrimaryProbe &&
               providerOverride === autoFallbackPrimaryProbe.fallbackProvider &&
               !isAutoFallbackPrimaryProbeCandidate
                 ? sessionEntry
-                : sessionEntryForAttempt;
+                : liveSessionEntry;
             if (isAutoFallbackPrimaryProbeCandidate) {
               markAutoFallbackPrimaryProbe({
                 probe: autoFallbackPrimaryProbe,
                 sessionKey,
               });
             }
-            const isFallbackRetry = fallbackAttemptIndex > 0;
-            fallbackAttemptIndex += 1;
             opts.onActiveModelSelected?.({
               provider: providerOverride,
               model: modelOverride,

--- a/src/agents/command/attempt-execution.cli.test.ts
+++ b/src/agents/command/attempt-execution.cli.test.ts
@@ -448,7 +448,13 @@ describe("CLI attempt execution", () => {
     expect(persisted[sessionKey]?.claudeCliSessionId).toBeUndefined();
   });
 
-  it("clears reused Claude CLI session IDs after AbortError without retrying", async () => {
+  it("clears reused Claude CLI session IDs after AbortError, then retries once with a fresh session (SCRUM-3256)", async () => {
+    // SCRUM-3256: a ~600s CLI turn-timeout raises AbortError on a reused session.
+    // Clearing the poisoned binding without retrying used to surface the error
+    // straight to the caller -- in a model-fallback dispatch, the *next*
+    // candidate would then resume the same now-cleared/dead session and fail
+    // near-instantly too, cascading into "All models failed". The outer catch
+    // now retries once in-process with a brand-new session before giving up.
     const sessionKey = "agent:main:direct:cli-abort";
     const cliSessionId = "abort-poisoned-session";
     await writeClaudeCliAssistantTranscript(cliSessionId);
@@ -457,19 +463,24 @@ describe("CLI attempt execution", () => {
     await fs.writeFile(storePath, JSON.stringify(sessionStore, null, 2), "utf-8");
     const abortError = Object.assign(new Error("aborted"), { name: "AbortError" });
     runCliAgentMock.mockRejectedValueOnce(abortError);
+    runCliAgentMock.mockResolvedValueOnce(makeCliResult("hello after abort retry"));
 
-    await expect(
-      runClaudeCliAttempt({
-        sessionKey,
-        sessionEntry,
-        sessionStore,
-        body: "resume after abort",
-        runId: "run-cli-abort",
-      }),
-    ).rejects.toMatchObject({ name: "AbortError" });
+    await runClaudeCliAttempt({
+      sessionKey,
+      sessionEntry,
+      sessionStore,
+      body: "resume after abort",
+      runId: "run-cli-abort",
+    });
 
-    expect(runCliAgentMock).toHaveBeenCalledTimes(1);
+    expect(runCliAgentMock).toHaveBeenCalledTimes(2);
     expect(firstRunCliAgentArg().cliSessionId).toBe(cliSessionId);
+    // The retry must not resume the dead session -- it starts fresh.
+    const secondCallArg = requireRecord(
+      runCliAgentMock.mock.calls[1]?.[0],
+      "second run CLI agent argument",
+    );
+    expect(secondCallArg.cliSessionId).toBeUndefined();
     expect(sessionStore[sessionKey]?.cliSessionBindings?.["claude-cli"]).toBeUndefined();
     expect(sessionStore[sessionKey]?.cliSessionIds?.["claude-cli"]).toBeUndefined();
     expect(sessionStore[sessionKey]?.claudeCliSessionId).toBeUndefined();
@@ -481,6 +492,44 @@ describe("CLI attempt execution", () => {
     expect(persisted[sessionKey]?.cliSessionBindings?.["claude-cli"]).toBeUndefined();
     expect(persisted[sessionKey]?.cliSessionIds?.["claude-cli"]).toBeUndefined();
     expect(persisted[sessionKey]?.claudeCliSessionId).toBeUndefined();
+  });
+
+  it("clears reused Claude CLI session IDs after an unknown-reason FailoverError, then retries once with a fresh session (SCRUM-3256)", async () => {
+    // SCRUM-3256: reason=unknown is explicitly outside cli-runner.ts's narrow
+    // internal shouldRetryFreshCliSessionAfterFailover allowlist (it only
+    // retries unknown when error.code === "cli_unknown_empty_failure"), so this
+    // is the exact class of failure the RCA found falling through to "All
+    // models failed" with no recovery. The outer-catch retry closes that gap.
+    const sessionKey = "agent:main:direct:cli-unknown";
+    const cliSessionId = "unknown-poisoned-session";
+    await writeClaudeCliAssistantTranscript(cliSessionId);
+    const sessionEntry = makeClaudeCliSessionEntry("session-cli-unknown", cliSessionId);
+    const sessionStore: Record<string, SessionEntry> = { [sessionKey]: sessionEntry };
+    await fs.writeFile(storePath, JSON.stringify(sessionStore, null, 2), "utf-8");
+    runCliAgentMock.mockRejectedValueOnce(
+      new FailoverError("unknown failure", {
+        reason: "unknown",
+        provider: "claude-cli",
+        model: "opus",
+      }),
+    );
+    runCliAgentMock.mockResolvedValueOnce(makeCliResult("hello after unknown-reason retry"));
+
+    await runClaudeCliAttempt({
+      sessionKey,
+      sessionEntry,
+      sessionStore,
+      body: "resume after unknown failure",
+      runId: "run-cli-unknown",
+    });
+
+    expect(runCliAgentMock).toHaveBeenCalledTimes(2);
+    const secondCallArg = requireRecord(
+      runCliAgentMock.mock.calls[1]?.[0],
+      "second run CLI agent argument",
+    );
+    expect(secondCallArg.cliSessionId).toBeUndefined();
+    expect(sessionStore[sessionKey]?.cliSessionBindings?.["claude-cli"]).toBeUndefined();
   });
 
   it("clears reused Claude CLI session IDs before a fresh retry after timeout failover", async () => {

--- a/src/agents/command/attempt-execution.ts
+++ b/src/agents/command/attempt-execution.ts
@@ -69,6 +69,30 @@ function shouldClearReusedCliSessionAfterError(err: unknown): boolean {
   return err instanceof FailoverError;
 }
 
+// SCRUM-3256: narrower than shouldClearReusedCliSessionAfterError -- clearing a
+// dead session from the store is always safe, but retrying immediately is only
+// worthwhile when the failure looks like reused-session poisoning or a transient
+// hiccup (timeout, unknown, session_expired, empty_response). auth/billing/
+// rate_limit failures will fail again identically on an instant retry, so those
+// stay single-attempt (matches the existing "without retrying" test contracts).
+function shouldRetryFreshCliSessionAfterClear(err: unknown): boolean {
+  if (readErrorName(err) === "AbortError") {
+    return true;
+  }
+  if (err instanceof FailoverError) {
+    switch (err.reason) {
+      case "timeout":
+      case "unknown":
+      case "session_expired":
+      case "empty_response":
+        return true;
+      default:
+        return false;
+    }
+  }
+  return false;
+}
+
 function resolveClearedCliSessionReason(err: unknown): string {
   if (err instanceof FailoverError) {
     return err.reason;
@@ -97,9 +121,7 @@ const ACP_TRANSCRIPT_USAGE = {
 const GOOGLE_GEMINI_CLI_PROVIDER_ID = "google-gemini-cli";
 const GOOGLE_PROVIDER_ID = "google";
 
-function shouldSuppressEmbeddedLiveStreamOutput(params: {
-  opts: AgentCommandOpts;
-}): boolean {
+function shouldSuppressEmbeddedLiveStreamOutput(params: { opts: AgentCommandOpts }): boolean {
   return params.opts.sessionEffects === "internal" && params.opts.deliver !== true;
 }
 
@@ -753,6 +775,25 @@ export function runAgentAttempt(params: {
               provider: cliExecutionProvider,
               ...mutableCliSessionStore,
             })) ?? params.sessionEntry;
+
+          // SCRUM-3256: the reused session that just died is now cleared from the
+          // store, but nothing else in this call recovers from it. Callers that
+          // rely on in-process model fallback (agent-command.ts's
+          // runWithModelFallback) can still hand the *next* candidate a stale
+          // snapshot that carries the dead binding, cascading one transient
+          // reused-session death into "All models failed" across every remaining
+          // fallback model -- and single-candidate sessions have no fallback
+          // candidate to recover on at all. Retry once, in-process, with a brand
+          // new session (no resumeSession id) before giving up, so a single
+          // transient death self-heals here instead of depending on an outer
+          // fallback candidate or a cron-level retry. Bounded to one retry: if
+          // the fresh-session attempt also fails, that error propagates normally.
+          if (!params.opts.abortSignal?.aborted && shouldRetryFreshCliSessionAfterClear(err)) {
+            log.warn(
+              `cli session retry starting fresh session: provider=${sanitizeForLog(cliExecutionProvider)} sessionKey=${mutableCliSessionStore.sessionKey} reason=prior-attempt-cleared`,
+            );
+            return await runCliWithSession(undefined, undefined);
+          }
         }
         throw err;
       }


### PR DESCRIPTION
## What Problem This Solves

A single transient failure on a reused Claude CLI session can cascade into a full `All models failed (2)` dispatch failure, even though the underlying failure is transient and normally self-heals on the *next* dispatch (fresh session).

Two compounding defects:

1. **`src/agents/agent-command.ts`** — the model-fallback `run` closure captures the session entry (`sessionEntryForAttempt`) once, before the fallback candidate loop starts, and reuses that same snapshot for every candidate. When candidate N's reused CLI session dies and gets cleared from the shared session store (`clearCliSessionInStore`), candidate N+1 never sees that clear — it's handed the same pre-loop snapshot, still carrying the dead session binding. It resumes the already-dead session and fails near-instantly (observed 127–450ms in production, vs. seconds-to-minutes for a real turn), exhausting all fallback candidates.

2. **`src/agents/command/attempt-execution.ts`** — the outer catch around a CLI attempt already clears a poisoned reused session from the store on a qualifying failure (`shouldClearReusedCliSessionAfterError`), but never retries — it just rethrows. For single-candidate sessions (no fallback list configured) this means a purely transient failure has *no* recovery path at all.

### Evidence

Production gateway journal (7 days): 4 concrete `All models failed` incidents matching this exact pattern — e.g. a `claude-sonnet-4-6` fallback candidate dispatched with `resumeSession=<id>` identical to the just-cleared primary candidate's session, dying in 127ms. The existing pattern of "the *next* dispatch (fresh session) succeeds" is what makes this diagnosable — a fresh store read/session always recovers, but nothing re-reads the store or retries fresh *within* the same dispatch.

## Fix

- **`agent-command.ts`**: on a fallback retry (`isFallbackRetry === true`), re-read the live `sessionStore` entry (already updated by a prior candidate's clear) instead of the stale pre-loop snapshot. The primary attempt is untouched — this only changes behavior when a fallback candidate is about to run.
- **`attempt-execution.ts`**: after clearing a reused-and-dead CLI session, retry once in-process with a brand-new session (no `resumeSession` id) before rethrowing. Scoped via a new `shouldRetryFreshCliSessionAfterClear` predicate to failure reasons that indicate transient/reused-session poisoning (`timeout`, `unknown`, `session_expired`, `empty_response`, `AbortError`) — `auth`/`billing`/`rate_limit` failures are deliberately excluded since an instant retry would just fail identically and burn an extra attempt for nothing.

Both fixes are narrowly scoped (guarded by `isFallbackRetry` / the new reason allowlist) and additive — the happy path (primary attempt succeeds, or a genuinely non-recoverable failure) is unchanged.

## Tests

- Updated `attempt-execution.cli.test.ts`'s AbortError case: it previously asserted the failure propagated "without retrying" — that was the bug being fixed, so it now asserts the outer-catch retry recovers the turn with a fresh session.
- Added a case for `FailoverError` with `reason: "unknown"`, which is explicitly *outside* `cli-runner.ts`'s existing internal `shouldRetryFreshCliSessionAfterFailover` allowlist (it only retries `unknown` when `error.code === "cli_unknown_empty_failure"`) — this was the most common real-world trigger in the production journal, and previously had zero recovery path.
- The existing `auth`/`billing`/`rate_limit` "without retrying" parametrized tests are untouched and still pass — confirms the new retry gate correctly excludes those reasons.
- `pnpm tsgo:core` and `pnpm tsgo:core:test` pass (typecheck).
- `node scripts/run-oxlint.mjs` clean on all three changed files.
- Full suite for the affected files: `attempt-execution.cli.test.ts` (50 tests), `attempt-execution.test.ts`, `attempt-execution.error-propagation.test.ts`, `attempt-execution.shared.test.ts`, `model-fallback.test.ts`, `model-fallback.probe.test.ts` — 178 tests total, all passing.

## Context

Root-caused and tracked internally as SCRUM-3256. A cron-layer retry mitigation is already in place upstream of this and stays as defense-in-depth for the dispatch paths it covers (cron/sweep). This PR is the durable, in-process fix that covers *every* dispatch path (n8n webhook, manual `openclaw agent`, all crons) permanently, without needing any local runtime restart or config change.
