### PR TITLE
fix(agents): preserve operator.write scope for in-process subagent spawns

### DIFF
--- a/src/agents/subagent-spawn.test.ts
+++ b/src/agents/subagent-spawn.test.ts
@@ -346,6 +346,7 @@ describe("spawnSubagentDirect seam flow", () => {
         sessionKey: result.childSessionKey,
       }),
       expect.objectContaining({
+        forceSyntheticClient: true,
         timeoutMs: expect.any(Number),
       }),
     );

--- a/src/agents/subagent-spawn.ts
+++ b/src/agents/subagent-spawn.ts
@@ -241,9 +241,12 @@ async function callSubagentGateway(
   // scope-upgrade handshake that headless gateway-client connections cannot
   // complete interactively, causing close(1008) "pairing required" (#59428).
   //
+  // In-process dispatch always uses a synthetic operator client so that scope
+  // resolution does not depend on the calling channel plugin's client scopes.
   // Only admin-requiring calls are pinned to ADMIN_SCOPE; other methods (e.g.
-  // "agent" -> write) keep their least-privilege scope. The params-aware
-  // resolver keeps spawn-metadata sessions.patch calls on the admin tier.
+  // "agent" -> write) keep the synthetic client's least-privilege default.
+  // The params-aware resolver keeps spawn-metadata sessions.patch calls on the
+  // admin tier.
   const leastPrivilegeScopes = resolveLeastPrivilegeOperatorScopesForMethod(
     params.method,
     params.params,
@@ -267,7 +270,7 @@ async function callSubagentGateway(
       request.params as Record<string, unknown>,
       {
         expectFinal: request.expectFinal,
-        ...(scopes != null ? { forceSyntheticClient: true } : {}),
+        forceSyntheticClient: true,
         ...(typeof request.timeoutMs === "number" ? { timeoutMs: request.timeoutMs } : {}),
         ...(scopes != null ? { syntheticScopes: scopes } : {}),
       },


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where `sessions_spawn` fails with `missing scope: operator.write` when triggered from a channel plugin (e.g. Google Chat) using token auth. This is a regression introduced by commit `58bab0c2761` which added in-process dispatch optimization to `callSubagentGateway`.

Before the optimization, all `callSubagentGateway` calls went through the WebSocket connection path where `callGatewayLeastPrivilege` correctly resolves `operator.write` scope for the `agent` method. After the optimization, when `hasInProcessGatewayContext()` is true (the common case for channel-triggered sessions), the dispatch uses `dispatchGatewayMethodInProcess` which inherits the outer request scope's client. Channel plugin clients may not carry `operator.write`, causing the gateway method authorizer to reject the dispatch.

## Why This Change Was Made

Always set `forceSyntheticClient: true` when dispatching in process from `callSubagentGateway`, so that non-admin methods like `agent` use the synthetic operator client (defaults to `WRITE_SCOPE`) instead of inheriting the calling channel plugin client's scopes. Admin-only methods (e.g. `sessions.delete`) continue to pass explicit `syntheticScopes: [ADMIN_SCOPE]`.

## User Impact

Users deploying OpenClaw with token auth and triggering subagent spawns from channel plugins (Google Chat, WhatsApp, Telegram, etc.) will no longer see `missing scope: operator.write` errors. Multi-agent delegation works correctly again.

## Evidence

Tests pass locally:
```
✓ src/agents/subagent-spawn.test.ts (25 tests) 
✓ src/agents/tools/sessions-spawn-tool.test.ts (53 tests)
```

The in-process dispatch test now verifies `forceSyntheticClient: true` for non-admin "agent" dispatches, and admin-scoped cleanup test continues to verify `forceSyntheticClient: true, syntheticScopes: ["operator.admin"]` for admin methods.

## Real behavior proof

Behavior or issue addressed: After the fix, sessions_spawn triggered from a channel plugin (e.g. Google Chat) via token auth no longer fails with "missing scope: operator.write". The in-process dispatch for "agent" method uses the synthetic operator client with WRITE_SCOPE instead of inheriting the channel plugin client's scopes.
Real environment tested: Repository `openclaw/openclaw`, branch `fix/token-auth-operator-write-98614`, commit `4a43bcec234`, using the project's test runner from a git worktree on latest main (826c84ea194).
Exact steps or command run after this patch:
```shell
npx vitest run src/agents/subagent-spawn.test.ts --config test/vitest/vitest.agents.config.ts --reporter=verbose
```
Evidence after fix: Terminal output from the verification:
```
✓ agents src/agents/subagent-spawn.test.ts > spawnSubagentDirect seam flow > dispatches spawned agent runs in process when a gateway context is available 16ms
✓ agents src/agents/subagent-spawn.test.ts > spawnSubagentDirect seam flow > keeps admin-scoped cleanup on in-process spawn failure 9ms
...all 25 tests passed
```
Observed result after fix: The in-process dispatch test confirms forceSyntheticClient: true is set for the "agent" method (which requires operator.write), ensuring the synthetic client with [WRITE_SCOPE] is used. Admin-scoped cleanup test still passes with correct admin-tier scope override.
What was not tested: End-to-end Google Chat channel trigger with token auth — requires a live Google Chat deployment. The fix is verified at the unit level through the in-process dispatch mock assertions.

Closes #98614