### PR TITLE
fix: require Android contact and calendar write permissions

### DIFF
--- a/apps/.i18n/native-source.json
+++ b/apps/.i18n/native-source.json
@@ -11291,7 +11291,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 209,
+      "line": 210,
       "path": "apps/ios/Sources/Voice/TalkModeGatewayConfig.swift",
       "source": "Gateway Default",
       "surface": "apple",
@@ -11299,7 +11299,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 211,
+      "line": 212,
       "path": "apps/ios/Sources/Voice/TalkModeGatewayConfig.swift",
       "source": "ElevenLabs",
       "surface": "apple",
@@ -11307,7 +11307,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 213,
+      "line": 214,
       "path": "apps/ios/Sources/Voice/TalkModeGatewayConfig.swift",
       "source": "Realtime-2 (OpenAI)",
       "surface": "apple",
@@ -11315,55 +11315,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 825,
-      "path": "apps/ios/Sources/Voice/TalkModeManager.swift",
-      "source": "Listening",
-      "surface": "apple",
-      "id": "native.apple.794c5c98f3a4238d"
-    },
-    {
-      "kind": "conditional-branch",
-      "line": 825,
-      "path": "apps/ios/Sources/Voice/TalkModeManager.swift",
-      "source": "Speech error: \\(msg)",
-      "surface": "apple",
-      "id": "native.apple.0b35fc3b0b221098"
-    },
-    {
-      "kind": "conditional-branch",
-      "line": 1026,
-      "path": "apps/ios/Sources/Voice/TalkModeManager.swift",
-      "source": "Aborted",
-      "surface": "apple",
-      "id": "native.apple.96c7457cafa7dd47"
-    },
-    {
-      "kind": "conditional-branch",
-      "line": 1026,
-      "path": "apps/ios/Sources/Voice/TalkModeManager.swift",
-      "source": "Chat error",
-      "surface": "apple",
-      "id": "native.apple.7c027ae095940485"
-    },
-    {
-      "kind": "conditional-branch",
-      "line": 2853,
-      "path": "apps/ios/Sources/Voice/TalkModeManager.swift",
-      "source": "Native",
-      "surface": "apple",
-      "id": "native.apple.c48dc51b49089432"
-    },
-    {
-      "kind": "conditional-branch",
-      "line": 2853,
-      "path": "apps/ios/Sources/Voice/TalkModeManager.swift",
-      "source": "Native WebRTC",
-      "surface": "apple",
-      "id": "native.apple.b0eb8a8cad908166"
-    },
-    {
-      "kind": "conditional-branch",
-      "line": 3172,
+      "line": 284,
       "path": "apps/ios/Sources/Voice/TalkModeManager.swift",
       "source": "Offline",
       "surface": "apple",
@@ -11371,11 +11323,59 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 3172,
+      "line": 284,
       "path": "apps/ios/Sources/Voice/TalkModeManager.swift",
       "source": "Ready",
       "surface": "apple",
       "id": "native.apple.5839cdb826c12c71"
+    },
+    {
+      "kind": "conditional-branch",
+      "line": 957,
+      "path": "apps/ios/Sources/Voice/TalkModeManager.swift",
+      "source": "Listening",
+      "surface": "apple",
+      "id": "native.apple.794c5c98f3a4238d"
+    },
+    {
+      "kind": "conditional-branch",
+      "line": 957,
+      "path": "apps/ios/Sources/Voice/TalkModeManager.swift",
+      "source": "Speech error: \\(msg)",
+      "surface": "apple",
+      "id": "native.apple.0b35fc3b0b221098"
+    },
+    {
+      "kind": "conditional-branch",
+      "line": 1158,
+      "path": "apps/ios/Sources/Voice/TalkModeManager.swift",
+      "source": "Aborted",
+      "surface": "apple",
+      "id": "native.apple.96c7457cafa7dd47"
+    },
+    {
+      "kind": "conditional-branch",
+      "line": 1158,
+      "path": "apps/ios/Sources/Voice/TalkModeManager.swift",
+      "source": "Chat error",
+      "surface": "apple",
+      "id": "native.apple.7c027ae095940485"
+    },
+    {
+      "kind": "conditional-branch",
+      "line": 2988,
+      "path": "apps/ios/Sources/Voice/TalkModeManager.swift",
+      "source": "Native",
+      "surface": "apple",
+      "id": "native.apple.c48dc51b49089432"
+    },
+    {
+      "kind": "conditional-branch",
+      "line": 2988,
+      "path": "apps/ios/Sources/Voice/TalkModeManager.swift",
+      "source": "Native WebRTC",
+      "surface": "apple",
+      "id": "native.apple.b0eb8a8cad908166"
     },
     {
       "kind": "ui-call",
@@ -11475,7 +11475,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 479,
+      "line": 508,
       "path": "apps/ios/Sources/Voice/TalkRealtimeWebRTCSession.swift",
       "source": "Asking OpenClaw",
       "surface": "apple",
@@ -11483,7 +11483,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 479,
+      "line": 508,
       "path": "apps/ios/Sources/Voice/TalkRealtimeWebRTCSession.swift",
       "source": "Updating OpenClaw",
       "surface": "apple",

--- a/apps/.i18n/native/ar.json
+++ b/apps/.i18n/native/ar.json
@@ -7074,6 +7074,16 @@
       "translated": "Realtime-2 (OpenAI)"
     },
     {
+      "id": "native.apple.c09f4e3bbef8177a",
+      "source": "Offline",
+      "translated": "غير متصل"
+    },
+    {
+      "id": "native.apple.5839cdb826c12c71",
+      "source": "Ready",
+      "translated": "جاهز"
+    },
+    {
       "id": "native.apple.794c5c98f3a4238d",
       "source": "Listening",
       "translated": "جارٍ الاستماع"
@@ -7102,16 +7112,6 @@
       "id": "native.apple.b0eb8a8cad908166",
       "source": "Native WebRTC",
       "translated": "WebRTC الأصلي"
-    },
-    {
-      "id": "native.apple.c09f4e3bbef8177a",
-      "source": "Offline",
-      "translated": "غير متصل"
-    },
-    {
-      "id": "native.apple.5839cdb826c12c71",
-      "source": "Ready",
-      "translated": "جاهز"
     },
     {
       "id": "native.apple.0189269b6a863dc2",

--- a/apps/.i18n/native/de.json
+++ b/apps/.i18n/native/de.json
@@ -7074,6 +7074,16 @@
       "translated": "Realtime-2 (OpenAI)"
     },
     {
+      "id": "native.apple.c09f4e3bbef8177a",
+      "source": "Offline",
+      "translated": "Offline"
+    },
+    {
+      "id": "native.apple.5839cdb826c12c71",
+      "source": "Ready",
+      "translated": "Bereit"
+    },
+    {
       "id": "native.apple.794c5c98f3a4238d",
       "source": "Listening",
       "translated": "Hört zu"
@@ -7102,16 +7112,6 @@
       "id": "native.apple.b0eb8a8cad908166",
       "source": "Native WebRTC",
       "translated": "Natives WebRTC"
-    },
-    {
-      "id": "native.apple.c09f4e3bbef8177a",
-      "source": "Offline",
-      "translated": "Offline"
-    },
-    {
-      "id": "native.apple.5839cdb826c12c71",
-      "source": "Ready",
-      "translated": "Bereit"
     },
     {
       "id": "native.apple.0189269b6a863dc2",

--- a/apps/.i18n/native/es.json
+++ b/apps/.i18n/native/es.json
@@ -7074,6 +7074,16 @@
       "translated": "Realtime-2 (OpenAI)"
     },
     {
+      "id": "native.apple.c09f4e3bbef8177a",
+      "source": "Offline",
+      "translated": "Sin conexión"
+    },
+    {
+      "id": "native.apple.5839cdb826c12c71",
+      "source": "Ready",
+      "translated": "Listo"
+    },
+    {
       "id": "native.apple.794c5c98f3a4238d",
       "source": "Listening",
       "translated": "Escuchando"
@@ -7102,16 +7112,6 @@
       "id": "native.apple.b0eb8a8cad908166",
       "source": "Native WebRTC",
       "translated": "WebRTC nativo"
-    },
-    {
-      "id": "native.apple.c09f4e3bbef8177a",
-      "source": "Offline",
-      "translated": "Sin conexión"
-    },
-    {
-      "id": "native.apple.5839cdb826c12c71",
-      "source": "Ready",
-      "translated": "Listo"
     },
     {
       "id": "native.apple.0189269b6a863dc2",

--- a/apps/.i18n/native/fa.json
+++ b/apps/.i18n/native/fa.json
@@ -7074,6 +7074,16 @@
       "translated": "Realtime-2 (OpenAI)"
     },
     {
+      "id": "native.apple.c09f4e3bbef8177a",
+      "source": "Offline",
+      "translated": "آفلاین"
+    },
+    {
+      "id": "native.apple.5839cdb826c12c71",
+      "source": "Ready",
+      "translated": "آماده"
+    },
+    {
       "id": "native.apple.794c5c98f3a4238d",
       "source": "Listening",
       "translated": "در حال گوش دادن"
@@ -7102,16 +7112,6 @@
       "id": "native.apple.b0eb8a8cad908166",
       "source": "Native WebRTC",
       "translated": "WebRTC بومی"
-    },
-    {
-      "id": "native.apple.c09f4e3bbef8177a",
-      "source": "Offline",
-      "translated": "آفلاین"
-    },
-    {
-      "id": "native.apple.5839cdb826c12c71",
-      "source": "Ready",
-      "translated": "آماده"
     },
     {
       "id": "native.apple.0189269b6a863dc2",

--- a/apps/.i18n/native/fr.json
+++ b/apps/.i18n/native/fr.json
@@ -7074,6 +7074,16 @@
       "translated": "Realtime-2 (OpenAI)"
     },
     {
+      "id": "native.apple.c09f4e3bbef8177a",
+      "source": "Offline",
+      "translated": "Hors ligne"
+    },
+    {
+      "id": "native.apple.5839cdb826c12c71",
+      "source": "Ready",
+      "translated": "Prêt"
+    },
+    {
       "id": "native.apple.794c5c98f3a4238d",
       "source": "Listening",
       "translated": "Écoute"
@@ -7102,16 +7112,6 @@
       "id": "native.apple.b0eb8a8cad908166",
       "source": "Native WebRTC",
       "translated": "WebRTC natif"
-    },
-    {
-      "id": "native.apple.c09f4e3bbef8177a",
-      "source": "Offline",
-      "translated": "Hors ligne"
-    },
-    {
-      "id": "native.apple.5839cdb826c12c71",
-      "source": "Ready",
-      "translated": "Prêt"
     },
     {
       "id": "native.apple.0189269b6a863dc2",

--- a/apps/.i18n/native/hi.json
+++ b/apps/.i18n/native/hi.json
@@ -7074,6 +7074,16 @@
       "translated": "Realtime-2 (OpenAI)"
     },
     {
+      "id": "native.apple.c09f4e3bbef8177a",
+      "source": "Offline",
+      "translated": "ऑफ़लाइन"
+    },
+    {
+      "id": "native.apple.5839cdb826c12c71",
+      "source": "Ready",
+      "translated": "तैयार"
+    },
+    {
       "id": "native.apple.794c5c98f3a4238d",
       "source": "Listening",
       "translated": "सुन रहा है"
@@ -7102,16 +7112,6 @@
       "id": "native.apple.b0eb8a8cad908166",
       "source": "Native WebRTC",
       "translated": "Native WebRTC"
-    },
-    {
-      "id": "native.apple.c09f4e3bbef8177a",
-      "source": "Offline",
-      "translated": "ऑफ़लाइन"
-    },
-    {
-      "id": "native.apple.5839cdb826c12c71",
-      "source": "Ready",
-      "translated": "तैयार"
     },
     {
       "id": "native.apple.0189269b6a863dc2",

--- a/apps/.i18n/native/id.json
+++ b/apps/.i18n/native/id.json
@@ -7074,6 +7074,16 @@
       "translated": "Realtime-2 (OpenAI)"
     },
     {
+      "id": "native.apple.c09f4e3bbef8177a",
+      "source": "Offline",
+      "translated": "Offline"
+    },
+    {
+      "id": "native.apple.5839cdb826c12c71",
+      "source": "Ready",
+      "translated": "Siap"
+    },
+    {
       "id": "native.apple.794c5c98f3a4238d",
       "source": "Listening",
       "translated": "Mendengarkan"
@@ -7102,16 +7112,6 @@
       "id": "native.apple.b0eb8a8cad908166",
       "source": "Native WebRTC",
       "translated": "WebRTC Native"
-    },
-    {
-      "id": "native.apple.c09f4e3bbef8177a",
-      "source": "Offline",
-      "translated": "Offline"
-    },
-    {
-      "id": "native.apple.5839cdb826c12c71",
-      "source": "Ready",
-      "translated": "Siap"
     },
     {
       "id": "native.apple.0189269b6a863dc2",

--- a/apps/.i18n/native/it.json
+++ b/apps/.i18n/native/it.json
@@ -7074,6 +7074,16 @@
       "translated": "Realtime-2 (OpenAI)"
     },
     {
+      "id": "native.apple.c09f4e3bbef8177a",
+      "source": "Offline",
+      "translated": "Offline"
+    },
+    {
+      "id": "native.apple.5839cdb826c12c71",
+      "source": "Ready",
+      "translated": "Pronto"
+    },
+    {
       "id": "native.apple.794c5c98f3a4238d",
       "source": "Listening",
       "translated": "In ascolto"
@@ -7102,16 +7112,6 @@
       "id": "native.apple.b0eb8a8cad908166",
       "source": "Native WebRTC",
       "translated": "WebRTC nativo"
-    },
-    {
-      "id": "native.apple.c09f4e3bbef8177a",
-      "source": "Offline",
-      "translated": "Offline"
-    },
-    {
-      "id": "native.apple.5839cdb826c12c71",
-      "source": "Ready",
-      "translated": "Pronto"
     },
     {
       "id": "native.apple.0189269b6a863dc2",

--- a/apps/.i18n/native/ko.json
+++ b/apps/.i18n/native/ko.json
@@ -7074,6 +7074,16 @@
       "translated": "Realtime-2 (OpenAI)"
     },
     {
+      "id": "native.apple.c09f4e3bbef8177a",
+      "source": "Offline",
+      "translated": "오프라인"
+    },
+    {
+      "id": "native.apple.5839cdb826c12c71",
+      "source": "Ready",
+      "translated": "준비됨"
+    },
+    {
       "id": "native.apple.794c5c98f3a4238d",
       "source": "Listening",
       "translated": "듣는 중"
@@ -7102,16 +7112,6 @@
       "id": "native.apple.b0eb8a8cad908166",
       "source": "Native WebRTC",
       "translated": "네이티브 WebRTC"
-    },
-    {
-      "id": "native.apple.c09f4e3bbef8177a",
-      "source": "Offline",
-      "translated": "오프라인"
-    },
-    {
-      "id": "native.apple.5839cdb826c12c71",
-      "source": "Ready",
-      "translated": "준비됨"
     },
     {
       "id": "native.apple.0189269b6a863dc2",

--- a/apps/.i18n/native/nl.json
+++ b/apps/.i18n/native/nl.json
@@ -7074,6 +7074,16 @@
       "translated": "Realtime-2 (OpenAI)"
     },
     {
+      "id": "native.apple.c09f4e3bbef8177a",
+      "source": "Offline",
+      "translated": "Offline"
+    },
+    {
+      "id": "native.apple.5839cdb826c12c71",
+      "source": "Ready",
+      "translated": "Klaar"
+    },
+    {
       "id": "native.apple.794c5c98f3a4238d",
       "source": "Listening",
       "translated": "Luistert"
@@ -7102,16 +7112,6 @@
       "id": "native.apple.b0eb8a8cad908166",
       "source": "Native WebRTC",
       "translated": "Native WebRTC"
-    },
-    {
-      "id": "native.apple.c09f4e3bbef8177a",
-      "source": "Offline",
-      "translated": "Offline"
-    },
-    {
-      "id": "native.apple.5839cdb826c12c71",
-      "source": "Ready",
-      "translated": "Klaar"
     },
     {
       "id": "native.apple.0189269b6a863dc2",

--- a/apps/.i18n/native/pl.json
+++ b/apps/.i18n/native/pl.json
@@ -7074,6 +7074,16 @@
       "translated": "Realtime-2 (OpenAI)"
     },
     {
+      "id": "native.apple.c09f4e3bbef8177a",
+      "source": "Offline",
+      "translated": "Offline"
+    },
+    {
+      "id": "native.apple.5839cdb826c12c71",
+      "source": "Ready",
+      "translated": "Gotowe"
+    },
+    {
       "id": "native.apple.794c5c98f3a4238d",
       "source": "Listening",
       "translated": "Nasłuchiwanie"
@@ -7102,16 +7112,6 @@
       "id": "native.apple.b0eb8a8cad908166",
       "source": "Native WebRTC",
       "translated": "Natywny WebRTC"
-    },
-    {
-      "id": "native.apple.c09f4e3bbef8177a",
-      "source": "Offline",
-      "translated": "Offline"
-    },
-    {
-      "id": "native.apple.5839cdb826c12c71",
-      "source": "Ready",
-      "translated": "Gotowe"
     },
     {
       "id": "native.apple.0189269b6a863dc2",

--- a/apps/.i18n/native/pt-BR.json
+++ b/apps/.i18n/native/pt-BR.json
@@ -7074,6 +7074,16 @@
       "translated": "Realtime-2 (OpenAI)"
     },
     {
+      "id": "native.apple.c09f4e3bbef8177a",
+      "source": "Offline",
+      "translated": "Offline"
+    },
+    {
+      "id": "native.apple.5839cdb826c12c71",
+      "source": "Ready",
+      "translated": "Pronto"
+    },
+    {
       "id": "native.apple.794c5c98f3a4238d",
       "source": "Listening",
       "translated": "Ouvindo"
@@ -7102,16 +7112,6 @@
       "id": "native.apple.b0eb8a8cad908166",
       "source": "Native WebRTC",
       "translated": "WebRTC nativo"
-    },
-    {
-      "id": "native.apple.c09f4e3bbef8177a",
-      "source": "Offline",
-      "translated": "Offline"
-    },
-    {
-      "id": "native.apple.5839cdb826c12c71",
-      "source": "Ready",
-      "translated": "Pronto"
     },
     {
       "id": "native.apple.0189269b6a863dc2",

--- a/apps/.i18n/native/ru.json
+++ b/apps/.i18n/native/ru.json
@@ -7074,6 +7074,16 @@
       "translated": "Realtime-2 (OpenAI)"
     },
     {
+      "id": "native.apple.c09f4e3bbef8177a",
+      "source": "Offline",
+      "translated": "Офлайн"
+    },
+    {
+      "id": "native.apple.5839cdb826c12c71",
+      "source": "Ready",
+      "translated": "Готово"
+    },
+    {
       "id": "native.apple.794c5c98f3a4238d",
       "source": "Listening",
       "translated": "Прослушивание"
@@ -7102,16 +7112,6 @@
       "id": "native.apple.b0eb8a8cad908166",
       "source": "Native WebRTC",
       "translated": "Нативный WebRTC"
-    },
-    {
-      "id": "native.apple.c09f4e3bbef8177a",
-      "source": "Offline",
-      "translated": "Офлайн"
-    },
-    {
-      "id": "native.apple.5839cdb826c12c71",
-      "source": "Ready",
-      "translated": "Готово"
     },
     {
       "id": "native.apple.0189269b6a863dc2",

--- a/apps/.i18n/native/sv.json
+++ b/apps/.i18n/native/sv.json
@@ -7074,6 +7074,16 @@
       "translated": "Realtime-2 (OpenAI)"
     },
     {
+      "id": "native.apple.c09f4e3bbef8177a",
+      "source": "Offline",
+      "translated": "Offline"
+    },
+    {
+      "id": "native.apple.5839cdb826c12c71",
+      "source": "Ready",
+      "translated": "Klar"
+    },
+    {
       "id": "native.apple.794c5c98f3a4238d",
       "source": "Listening",
       "translated": "Lyssnar"
@@ -7102,16 +7112,6 @@
       "id": "native.apple.b0eb8a8cad908166",
       "source": "Native WebRTC",
       "translated": "Inbyggd WebRTC"
-    },
-    {
-      "id": "native.apple.c09f4e3bbef8177a",
-      "source": "Offline",
-      "translated": "Offline"
-    },
-    {
-      "id": "native.apple.5839cdb826c12c71",
-      "source": "Ready",
-      "translated": "Klar"
     },
     {
       "id": "native.apple.0189269b6a863dc2",

--- a/apps/.i18n/native/th.json
+++ b/apps/.i18n/native/th.json
@@ -7074,6 +7074,16 @@
       "translated": "Realtime-2 (OpenAI)"
     },
     {
+      "id": "native.apple.c09f4e3bbef8177a",
+      "source": "Offline",
+      "translated": "ออฟไลน์"
+    },
+    {
+      "id": "native.apple.5839cdb826c12c71",
+      "source": "Ready",
+      "translated": "พร้อม"
+    },
+    {
       "id": "native.apple.794c5c98f3a4238d",
       "source": "Listening",
       "translated": "กำลังฟัง"
@@ -7102,16 +7112,6 @@
       "id": "native.apple.b0eb8a8cad908166",
       "source": "Native WebRTC",
       "translated": "WebRTC แบบเนทีฟ"
-    },
-    {
-      "id": "native.apple.c09f4e3bbef8177a",
-      "source": "Offline",
-      "translated": "ออฟไลน์"
-    },
-    {
-      "id": "native.apple.5839cdb826c12c71",
-      "source": "Ready",
-      "translated": "พร้อม"
     },
     {
       "id": "native.apple.0189269b6a863dc2",

--- a/apps/.i18n/native/tr.json
+++ b/apps/.i18n/native/tr.json
@@ -7074,6 +7074,16 @@
       "translated": "Realtime-2 (OpenAI)"
     },
     {
+      "id": "native.apple.c09f4e3bbef8177a",
+      "source": "Offline",
+      "translated": "Çevrimdışı"
+    },
+    {
+      "id": "native.apple.5839cdb826c12c71",
+      "source": "Ready",
+      "translated": "Hazır"
+    },
+    {
       "id": "native.apple.794c5c98f3a4238d",
       "source": "Listening",
       "translated": "Dinleniyor"
@@ -7102,16 +7112,6 @@
       "id": "native.apple.b0eb8a8cad908166",
       "source": "Native WebRTC",
       "translated": "Yerel WebRTC"
-    },
-    {
-      "id": "native.apple.c09f4e3bbef8177a",
-      "source": "Offline",
-      "translated": "Çevrimdışı"
-    },
-    {
-      "id": "native.apple.5839cdb826c12c71",
-      "source": "Ready",
-      "translated": "Hazır"
     },
     {
       "id": "native.apple.0189269b6a863dc2",

--- a/apps/.i18n/native/uk.json
+++ b/apps/.i18n/native/uk.json
@@ -7074,6 +7074,16 @@
       "translated": "Realtime-2 (OpenAI)"
     },
     {
+      "id": "native.apple.c09f4e3bbef8177a",
+      "source": "Offline",
+      "translated": "Офлайн"
+    },
+    {
+      "id": "native.apple.5839cdb826c12c71",
+      "source": "Ready",
+      "translated": "Готово"
+    },
+    {
       "id": "native.apple.794c5c98f3a4238d",
       "source": "Listening",
       "translated": "Слухання"
@@ -7102,16 +7112,6 @@
       "id": "native.apple.b0eb8a8cad908166",
       "source": "Native WebRTC",
       "translated": "Нативний WebRTC"
-    },
-    {
-      "id": "native.apple.c09f4e3bbef8177a",
-      "source": "Offline",
-      "translated": "Офлайн"
-    },
-    {
-      "id": "native.apple.5839cdb826c12c71",
-      "source": "Ready",
-      "translated": "Готово"
     },
     {
       "id": "native.apple.0189269b6a863dc2",

--- a/apps/.i18n/native/vi.json
+++ b/apps/.i18n/native/vi.json
@@ -7074,6 +7074,16 @@
       "translated": "Realtime-2 (OpenAI)"
     },
     {
+      "id": "native.apple.c09f4e3bbef8177a",
+      "source": "Offline",
+      "translated": "Ngoại tuyến"
+    },
+    {
+      "id": "native.apple.5839cdb826c12c71",
+      "source": "Ready",
+      "translated": "Sẵn sàng"
+    },
+    {
       "id": "native.apple.794c5c98f3a4238d",
       "source": "Listening",
       "translated": "Đang nghe"
@@ -7102,16 +7112,6 @@
       "id": "native.apple.b0eb8a8cad908166",
       "source": "Native WebRTC",
       "translated": "WebRTC gốc"
-    },
-    {
-      "id": "native.apple.c09f4e3bbef8177a",
-      "source": "Offline",
-      "translated": "Ngoại tuyến"
-    },
-    {
-      "id": "native.apple.5839cdb826c12c71",
-      "source": "Ready",
-      "translated": "Sẵn sàng"
     },
     {
       "id": "native.apple.0189269b6a863dc2",

--- a/apps/.i18n/native/zh-CN.json
+++ b/apps/.i18n/native/zh-CN.json
@@ -7074,6 +7074,16 @@
       "translated": "Realtime-2 (OpenAI)"
     },
     {
+      "id": "native.apple.c09f4e3bbef8177a",
+      "source": "Offline",
+      "translated": "离线"
+    },
+    {
+      "id": "native.apple.5839cdb826c12c71",
+      "source": "Ready",
+      "translated": "就绪"
+    },
+    {
       "id": "native.apple.794c5c98f3a4238d",
       "source": "Listening",
       "translated": "正在聆听"
@@ -7102,16 +7112,6 @@
       "id": "native.apple.b0eb8a8cad908166",
       "source": "Native WebRTC",
       "translated": "原生 WebRTC"
-    },
-    {
-      "id": "native.apple.c09f4e3bbef8177a",
-      "source": "Offline",
-      "translated": "离线"
-    },
-    {
-      "id": "native.apple.5839cdb826c12c71",
-      "source": "Ready",
-      "translated": "就绪"
     },
     {
       "id": "native.apple.0189269b6a863dc2",

--- a/apps/.i18n/native/zh-TW.json
+++ b/apps/.i18n/native/zh-TW.json
@@ -7074,6 +7074,16 @@
       "translated": "Realtime-2 (OpenAI)"
     },
     {
+      "id": "native.apple.c09f4e3bbef8177a",
+      "source": "Offline",
+      "translated": "離線"
+    },
+    {
+      "id": "native.apple.5839cdb826c12c71",
+      "source": "Ready",
+      "translated": "就緒"
+    },
+    {
       "id": "native.apple.794c5c98f3a4238d",
       "source": "Listening",
       "translated": "正在聆聽"
@@ -7102,16 +7112,6 @@
       "id": "native.apple.b0eb8a8cad908166",
       "source": "Native WebRTC",
       "translated": "原生 WebRTC"
-    },
-    {
-      "id": "native.apple.c09f4e3bbef8177a",
-      "source": "Offline",
-      "translated": "離線"
-    },
-    {
-      "id": "native.apple.5839cdb826c12c71",
-      "source": "Ready",
-      "translated": "就緒"
     },
     {
       "id": "native.apple.0189269b6a863dc2",

--- a/apps/android/app/src/main/java/ai/openclaw/app/node/DeviceHandler.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/node/DeviceHandler.kt
@@ -426,14 +426,18 @@ class DeviceHandler private constructor(
           put(
             "contacts",
             permissionStateJson(
-              granted = hasPermission(Manifest.permission.READ_CONTACTS),
+              granted =
+                hasPermission(Manifest.permission.READ_CONTACTS) &&
+                  hasPermission(Manifest.permission.WRITE_CONTACTS),
               promptableWhenDenied = true,
             ),
           )
           put(
             "calendar",
             permissionStateJson(
-              granted = hasPermission(Manifest.permission.READ_CALENDAR),
+              granted =
+                hasPermission(Manifest.permission.READ_CALENDAR) &&
+                  hasPermission(Manifest.permission.WRITE_CALENDAR),
               promptableWhenDenied = true,
             ),
           )

--- a/apps/android/app/src/test/java/ai/openclaw/app/node/DeviceHandlerTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/node/DeviceHandlerTest.kt
@@ -1,5 +1,7 @@
 package ai.openclaw.app.node
 
+import android.Manifest
+import android.app.Application
 import android.content.Context
 import android.content.pm.ApplicationInfo
 import kotlinx.serialization.json.Json
@@ -15,6 +17,7 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
 import org.robolectric.RuntimeEnvironment
+import org.robolectric.Shadows.shadowOf
 
 @RunWith(RobolectricTestRunner::class)
 class DeviceHandlerTest {
@@ -275,6 +278,34 @@ class DeviceHandlerTest {
   }
 
   @Test
+  fun handleDevicePermissions_requiresContactsReadAndWritePermissions() {
+    val app = appContext()
+    shadowOf(app).grantPermissions(Manifest.permission.READ_CONTACTS)
+    shadowOf(app).denyPermissions(Manifest.permission.WRITE_CONTACTS)
+
+    val readOnly = DeviceHandler(app).handleDevicePermissions(null)
+    assertEquals("denied", permissionStatus(readOnly.payloadJson, "contacts"))
+
+    shadowOf(app).grantPermissions(Manifest.permission.WRITE_CONTACTS)
+    val readWrite = DeviceHandler(app).handleDevicePermissions(null)
+    assertEquals("granted", permissionStatus(readWrite.payloadJson, "contacts"))
+  }
+
+  @Test
+  fun handleDevicePermissions_requiresCalendarReadAndWritePermissions() {
+    val app = appContext()
+    shadowOf(app).grantPermissions(Manifest.permission.READ_CALENDAR)
+    shadowOf(app).denyPermissions(Manifest.permission.WRITE_CALENDAR)
+
+    val readOnly = DeviceHandler(app).handleDevicePermissions(null)
+    assertEquals("denied", permissionStatus(readOnly.payloadJson, "calendar"))
+
+    shadowOf(app).grantPermissions(Manifest.permission.WRITE_CALENDAR)
+    val readWrite = DeviceHandler(app).handleDevicePermissions(null)
+    assertEquals("granted", permissionStatus(readWrite.payloadJson, "calendar"))
+  }
+
+  @Test
   fun handleDeviceHealth_returnsExpectedShape() {
     val handler = DeviceHandler(appContext())
 
@@ -423,12 +454,25 @@ class DeviceHandlerTest {
     assertTrue(isSystemDeviceApp(appInfo))
   }
 
-  private fun appContext(): Context = RuntimeEnvironment.getApplication()
+  private fun appContext(): Application = RuntimeEnvironment.getApplication()
 
   private fun parsePayload(payloadJson: String?): JsonObject {
     val jsonString = payloadJson ?: error("expected payload")
     return Json.parseToJsonElement(jsonString).jsonObject
   }
+
+  private fun permissionStatus(
+    payloadJson: String?,
+    key: String,
+  ): String =
+    parsePayload(payloadJson)
+      .getValue("permissions")
+      .jsonObject
+      .getValue(key)
+      .jsonObject
+      .getValue("status")
+      .jsonPrimitive
+      .content
 }
 
 private class FakeDeviceAppSource(

--- a/apps/android/app/src/test/java/ai/openclaw/app/node/DeviceHandlerTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/node/DeviceHandlerTest.kt
@@ -2,7 +2,6 @@ package ai.openclaw.app.node
 
 import android.Manifest
 import android.app.Application
-import android.content.Context
 import android.content.pm.ApplicationInfo
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonObject
@@ -278,31 +277,28 @@ class DeviceHandlerTest {
   }
 
   @Test
-  fun handleDevicePermissions_requiresContactsReadAndWritePermissions() {
+  fun handleDevicePermissions_requiresReadAndWritePermissionPairs() {
     val app = appContext()
-    shadowOf(app).grantPermissions(Manifest.permission.READ_CONTACTS)
-    shadowOf(app).denyPermissions(Manifest.permission.WRITE_CONTACTS)
+    val handler = DeviceHandler(app)
+    val permissionPairs =
+      listOf(
+        Triple("contacts", Manifest.permission.READ_CONTACTS, Manifest.permission.WRITE_CONTACTS),
+        Triple("calendar", Manifest.permission.READ_CALENDAR, Manifest.permission.WRITE_CALENDAR),
+      )
 
-    val readOnly = DeviceHandler(app).handleDevicePermissions(null)
-    assertEquals("denied", permissionStatus(readOnly.payloadJson, "contacts"))
+    for ((key, readPermission, writePermission) in permissionPairs) {
+      shadowOf(app).denyPermissions(readPermission, writePermission)
 
-    shadowOf(app).grantPermissions(Manifest.permission.WRITE_CONTACTS)
-    val readWrite = DeviceHandler(app).handleDevicePermissions(null)
-    assertEquals("granted", permissionStatus(readWrite.payloadJson, "contacts"))
-  }
+      shadowOf(app).grantPermissions(readPermission)
+      assertEquals("$key read-only", "denied", permissionStatus(handler.handleDevicePermissions(null).payloadJson, key))
 
-  @Test
-  fun handleDevicePermissions_requiresCalendarReadAndWritePermissions() {
-    val app = appContext()
-    shadowOf(app).grantPermissions(Manifest.permission.READ_CALENDAR)
-    shadowOf(app).denyPermissions(Manifest.permission.WRITE_CALENDAR)
+      shadowOf(app).denyPermissions(readPermission)
+      shadowOf(app).grantPermissions(writePermission)
+      assertEquals("$key write-only", "denied", permissionStatus(handler.handleDevicePermissions(null).payloadJson, key))
 
-    val readOnly = DeviceHandler(app).handleDevicePermissions(null)
-    assertEquals("denied", permissionStatus(readOnly.payloadJson, "calendar"))
-
-    shadowOf(app).grantPermissions(Manifest.permission.WRITE_CALENDAR)
-    val readWrite = DeviceHandler(app).handleDevicePermissions(null)
-    assertEquals("granted", permissionStatus(readWrite.payloadJson, "calendar"))
+      shadowOf(app).grantPermissions(readPermission)
+      assertEquals("$key read-write", "granted", permissionStatus(handler.handleDevicePermissions(null).payloadJson, key))
+    }
   }
 
   @Test

--- a/apps/ios/Sources/Voice/TalkDefaults.swift
+++ b/apps/ios/Sources/Voice/TalkDefaults.swift
@@ -1,3 +1,4 @@
+import AVFoundation
 import Foundation
 
 enum TalkDefaults {
@@ -10,5 +11,24 @@ enum TalkDefaults {
             return self.speakerphoneEnabledByDefault
         }
         return defaults.bool(forKey: self.speakerphoneEnabledKey)
+    }
+}
+
+enum TalkAudioRoute {
+    static func categoryOptions(speakerphoneEnabled: Bool) -> AVAudioSession.CategoryOptions {
+        var options: AVAudioSession.CategoryOptions = [.allowBluetoothHFP, .allowBluetoothA2DP, .allowAirPlay]
+        if speakerphoneEnabled {
+            options.insert(.defaultToSpeaker)
+        }
+        return options
+    }
+
+    static func shouldForceSpeaker(
+        preferenceEnabled: Bool,
+        outputPortTypes: [AVAudioSession.Port]) -> Bool
+    {
+        guard preferenceEnabled else { return false }
+        guard !outputPortTypes.isEmpty else { return false }
+        return outputPortTypes.allSatisfy { $0 == .builtInReceiver || $0 == .builtInSpeaker }
     }
 }

--- a/apps/ios/Sources/Voice/TalkModeGatewayConfig.swift
+++ b/apps/ios/Sources/Voice/TalkModeGatewayConfig.swift
@@ -3,6 +3,7 @@ import OpenClawKit
 
 enum TalkModeExecutionMode: Equatable {
     case native
+    case realtimeWebRTC
     case realtimeRelay
 }
 
@@ -224,10 +225,11 @@ enum TalkModeProviderSelection: String, CaseIterable, Identifiable {
 enum TalkModeRuntimeRoute: Equatable {
     case localElevenLabs
     case gatewayTalkSpeak
+    case realtimeWebRTC
     case realtimeRelay
 
     var usesRealtime: Bool {
-        self == .realtimeRelay
+        self == .realtimeRelay || self == .realtimeWebRTC
     }
 
     var usesGatewayTalkSpeak: Bool {
@@ -263,7 +265,9 @@ enum TalkModeRoutingResolver {
         case .gatewayDefault:
             // Only an explicit realtime config selects the realtime transport. Other Gateway
             // speech providers stay native and synthesize through talk.speak.
-            if parsed.executionMode == .realtimeRelay {
+            if parsed.executionMode == .realtimeWebRTC {
+                route = .realtimeWebRTC
+            } else if parsed.executionMode == .realtimeRelay {
                 route = .realtimeRelay
             } else if Self.normalized(activeProvider) == Self.normalized(defaultProvider) {
                 // Preserve the shipped local ElevenLabs path, including its streaming playback.
@@ -276,17 +280,30 @@ enum TalkModeRoutingResolver {
             route = .localElevenLabs
         case .openAIRealtime:
             activeProvider = "openai"
-            realtimeProvider = realtimeProvider ?? "openai"
-            realtimeModelId = realtimeModelId ?? defaultRealtimeModelId
-            route = .realtimeRelay
+            realtimeProvider = "openai"
+            realtimeModelId = defaultRealtimeModelId
+            // Provider selection can replace provider details, but an explicit Gateway-owned
+            // realtime route must remain on the Gateway (for example, Azure-backed OpenAI).
+            route = parsed.openAIRequiresGatewayRealtimeTransport ? .realtimeRelay : .realtimeWebRTC
         }
 
         return TalkModeResolvedRouting(
             activeProvider: activeProvider,
-            executionMode: route.usesRealtime ? .realtimeRelay : .native,
+            executionMode: Self.executionMode(for: route),
             realtimeProvider: realtimeProvider,
             realtimeModelId: realtimeModelId,
             route: route)
+    }
+
+    private static func executionMode(for route: TalkModeRuntimeRoute) -> TalkModeExecutionMode {
+        switch route {
+        case .localElevenLabs, .gatewayTalkSpeak:
+            .native
+        case .realtimeWebRTC:
+            .realtimeWebRTC
+        case .realtimeRelay:
+            .realtimeRelay
+        }
     }
 
     private static func normalized(_ value: String) -> String {
@@ -325,6 +342,8 @@ struct TalkModeGatewayConfigState {
     let normalizedPayload: Bool
     let missingResolvedPayload: Bool
     let executionMode: TalkModeExecutionMode
+    let requiresGatewayRealtimeTransport: Bool
+    let openAIRequiresGatewayRealtimeTransport: Bool
     let defaultVoiceId: String?
     let voiceAliases: [String: String]
     let configuredModelId: String?
@@ -384,7 +403,19 @@ enum TalkModeGatewayConfigParser {
         let realtimeModelId = realtimeModel ?? defaultRealtimeModelIdFallback
         let realtimeVoiceId = Self.firstString(realtime, keys: ["voice"])
             ?? Self.firstString(realtimeProviderConfig, keys: ["voice"])
-        let executionMode = Self.resolvedExecutionMode(realtime)
+        let realtimeTransport = Self.firstString(realtime, keys: ["transport"])?.lowercased()
+        let requiresGatewayRealtimeTransport = realtimeTransport == "gateway-relay"
+            || realtimeTransport == "provider-websocket"
+            || Self.usesAzureOpenAI(provider: realtimeProvider, config: realtimeProviderConfig)
+        let openAIProviderConfig = Self.realtimeProviderConfig(
+            providers: realtimeProviders,
+            provider: "openai")
+        let openAIRequiresGatewayRealtimeTransport = realtimeTransport == "gateway-relay"
+            || realtimeTransport == "provider-websocket"
+            || Self.usesAzureOpenAI(provider: "openai", config: openAIProviderConfig)
+        let executionMode = Self.resolvedExecutionMode(
+            realtime,
+            requiresGatewayRealtimeTransport: requiresGatewayRealtimeTransport)
         let rawConfigApiKey = activeConfig?["apiKey"]?.stringValue?.trimmingCharacters(in: .whitespacesAndNewlines)
         let interruptOnSpeech = talk?["interruptOnSpeech"]?.boolValue
         let silenceTimeoutMs = TalkConfigParsing.resolvedSilenceTimeoutMs(
@@ -397,6 +428,8 @@ enum TalkModeGatewayConfigParser {
             normalizedPayload: selection?.normalizedPayload == true,
             missingResolvedPayload: talk != nil && selection == nil,
             executionMode: executionMode,
+            requiresGatewayRealtimeTransport: requiresGatewayRealtimeTransport,
+            openAIRequiresGatewayRealtimeTransport: openAIRequiresGatewayRealtimeTransport,
             defaultVoiceId: defaultVoiceId,
             voiceAliases: voiceAliases,
             configuredModelId: model,
@@ -422,21 +455,52 @@ enum TalkModeGatewayConfigParser {
         return nil
     }
 
-    private static func resolvedExecutionMode(_ realtime: [String: AnyCodable]?) -> TalkModeExecutionMode {
+    private static func resolvedExecutionMode(
+        _ realtime: [String: AnyCodable]?,
+        requiresGatewayRealtimeTransport: Bool) -> TalkModeExecutionMode
+    {
         guard let realtime else { return .native }
         let mode = Self.firstString(realtime, keys: ["mode"])?.lowercased()
         let transport = Self.firstString(realtime, keys: ["transport"])?.lowercased()
+        let provider = Self.firstString(realtime, keys: ["provider"])?.lowercased()
+            ?? Self.singleRealtimeProviderId(realtime["providers"]?.dictionaryValue)?.lowercased()
         let brain = Self.firstString(realtime, keys: ["brain"])?.lowercased()
         guard mode == "realtime" else {
-            return .native
-        }
-        if transport == "managed-room" {
             return .native
         }
         if brain != nil, brain != "agent-consult" {
             return .native
         }
-        return .realtimeRelay
+        if requiresGatewayRealtimeTransport {
+            return .realtimeRelay
+        }
+        switch transport {
+        case "managed-room":
+            return .native
+        case "gateway-relay":
+            return .realtimeRelay
+        case "provider-websocket":
+            return .realtimeRelay
+        case "webrtc":
+            if provider != "openai" {
+                return .realtimeRelay
+            }
+        case nil:
+            if provider != "openai" {
+                return .realtimeRelay
+            }
+        default:
+            return .realtimeRelay
+        }
+        return .realtimeWebRTC
+    }
+
+    private static func usesAzureOpenAI(
+        provider: String?,
+        config: [String: AnyCodable]?) -> Bool
+    {
+        guard provider?.caseInsensitiveCompare("openai") == .orderedSame else { return false }
+        return self.firstString(config, keys: ["azureEndpoint", "azureDeployment"]) != nil
     }
 
     private static func singleRealtimeProviderId(_ providers: [String: AnyCodable]?) -> String? {
@@ -451,7 +515,13 @@ enum TalkModeGatewayConfigParser {
     {
         guard let providers else { return nil }
         if let provider {
-            return providers[provider]?.dictionaryValue
+            if let exact = providers[provider]?.dictionaryValue {
+                return exact
+            }
+            return providers.first { key, _ in
+                key.trimmingCharacters(in: .whitespacesAndNewlines)
+                    .caseInsensitiveCompare(provider) == .orderedSame
+            }?.value.dictionaryValue
         }
         if providers.count == 1 {
             return providers.values.first?.dictionaryValue

--- a/apps/ios/Sources/Voice/TalkModeManager.swift
+++ b/apps/ios/Sources/Voice/TalkModeManager.swift
@@ -82,6 +82,9 @@ final class TalkModeManager: NSObject {
         case ignored
     }
 
+    private static let realtimeStableSessionSeconds: TimeInterval = 30
+    private static let realtimeRestartDelaysNanoseconds: [UInt64] = [500_000_000, 2_000_000_000]
+
     private var isStarting = false
     private var startAttemptID = 0
     private var captureMode: CaptureMode = .idle
@@ -103,6 +106,10 @@ final class TalkModeManager: NSObject {
     private var recognitionTask: SFSpeechRecognitionTask?
     private var silenceTask: Task<Void, Never>?
     private var realtimeSession: TalkRealtimeWebRTCSession?
+    private var realtimeSessionReadyAt: Date?
+    private var rapidRealtimeRestartCount = 0
+    private var bypassRealtimeOnNextStart = false
+    private var realtimeRestartGeneration = 0
     private var realtimeRelaySession: RealtimeTalkRelaySession?
     private var realtimeRelayStartInFlight = false
     private var prefetchedRealtimeSession: TalkRealtimeClientSession?
@@ -184,6 +191,121 @@ final class TalkModeManager: NSObject {
         max(0, Int((self.nowSeconds() - start) * 1000))
     }
 
+    private static func shouldRestartRealtimeSession(
+        isEnabled: Bool,
+        gatewayConnected: Bool,
+        captureIsContinuous: Bool) -> Bool
+    {
+        isEnabled && gatewayConnected && captureIsContinuous
+    }
+
+    private static func realtimeRestartAttempt(
+        previousRapidRestarts: Int,
+        activeDuration: TimeInterval) -> Int
+    {
+        activeDuration >= self.realtimeStableSessionSeconds ? 1 : previousRapidRestarts + 1
+    }
+
+    private static func realtimeRestartDelayNanoseconds(attempt: Int) -> UInt64? {
+        guard attempt > 0, attempt <= self.realtimeRestartDelaysNanoseconds.count else { return nil }
+        return self.realtimeRestartDelaysNanoseconds[attempt - 1]
+    }
+
+    private func resetRealtimeRestartState() {
+        self.realtimeRestartGeneration += 1
+        self.realtimeSessionReadyAt = nil
+        self.rapidRealtimeRestartCount = 0
+        self.bypassRealtimeOnNextStart = false
+    }
+
+    private func markRealtimeSessionReady() {
+        self.isListening = true
+        if self.captureMode != .pushToTalk {
+            self.captureMode = .continuous
+        }
+        if self.realtimeSessionReadyAt == nil {
+            self.realtimeSessionReadyAt = Date()
+        }
+        self.markRealtimeActive()
+    }
+
+    private func scheduleRealtimeRestart(after delayNanoseconds: UInt64?, generation: Int) {
+        Task { [weak self] in
+            if let delayNanoseconds {
+                do {
+                    try await Task.sleep(nanoseconds: delayNanoseconds)
+                } catch {
+                    return
+                }
+            }
+            // A ready/close pair can arrive before the current start() unwinds. Wait for that
+            // attempt instead of letting its isStarting guard consume the only recovery task.
+            while self?.isStarting == true {
+                do {
+                    try await Task.sleep(nanoseconds: 50_000_000)
+                } catch {
+                    return
+                }
+                guard let self,
+                      self.realtimeRestartGeneration == generation,
+                      Self.shouldRestartRealtimeSession(
+                          isEnabled: self.isEnabled,
+                          gatewayConnected: self.gatewayConnected,
+                          captureIsContinuous: self.captureMode == .continuous)
+                else { return }
+            }
+            guard let self,
+                  self.realtimeRestartGeneration == generation,
+                  Self.shouldRestartRealtimeSession(
+                      isEnabled: self.isEnabled,
+                      gatewayConnected: self.gatewayConnected,
+                      captureIsContinuous: self.captureMode == .continuous)
+            else { return }
+            await self.start()
+        }
+    }
+
+    private func handleRealtimeSessionFinish() {
+        // Provider sessions expire or disconnect while continuous Talk remains enabled. Explicit
+        // stop/background paths clear one of these guards before closing either session type.
+        let shouldRestart = Self.shouldRestartRealtimeSession(
+            isEnabled: self.isEnabled,
+            gatewayConnected: self.gatewayConnected,
+            captureIsContinuous: self.captureMode == .continuous)
+        let activeDuration = self.realtimeSessionReadyAt.map { Date().timeIntervalSince($0) } ?? 0
+        self.realtimeSessionReadyAt = nil
+        self.isListening = false
+        self.isSpeaking = false
+        self.isUserSpeechDetected = false
+        self.gatewayTalkActiveModeTitle = "Not active"
+        self.gatewayTalkActiveModeSubtitle = nil
+        guard shouldRestart else {
+            if self.isEnabled {
+                self.statusText = self.gatewayConnected ? "Ready" : "Offline"
+            }
+            return
+        }
+
+        self.realtimeRestartGeneration += 1
+        let restartGeneration = self.realtimeRestartGeneration
+        let attempt = Self.realtimeRestartAttempt(
+            previousRapidRestarts: self.rapidRealtimeRestartCount,
+            activeDuration: activeDuration)
+        self.rapidRealtimeRestartCount = attempt
+        guard let delay = Self.realtimeRestartDelayNanoseconds(attempt: attempt) else {
+            let issue = self.realtimeIssue(
+                message: "Realtime disconnected repeatedly.",
+                phase: "reconnect")
+            self.pendingRealtimeIssue = issue
+            self.gatewayTalkLastIssueText = issue.diagnosticSummary
+            self.bypassRealtimeOnNextStart = true
+            self.scheduleRealtimeRestart(after: nil, generation: restartGeneration)
+            return
+        }
+        self.statusText = "Reconnecting"
+        self.scheduleRealtimeRestart(after: delay, generation: restartGeneration)
+    }
+
     init(
         allowSimulatorCapture: Bool = false,
         gatewaySpeechSynthesizer: (any TalkGatewaySpeechSynthesizing)? = nil)
@@ -206,6 +328,7 @@ final class TalkModeManager: NSObject {
                 Task { await self.start() }
             }
         } else {
+            self.resetRealtimeRestartState()
             self.stopRealtimeSession()
             self.gatewayTalkActiveModeTitle = "Not active"
             self.gatewayTalkActiveModeSubtitle = nil
@@ -283,7 +406,9 @@ final class TalkModeManager: NSObject {
     func applyAudioRoutePreferenceChanged() {
         guard self.isEnabled || self.isListening || self.isSpeaking else { return }
         do {
-            if self.realtimeRelaySession != nil {
+            if let realtimeSession {
+                try realtimeSession.applyAudioRoutePreferenceChanged()
+            } else if self.realtimeRelaySession != nil {
                 try Self.configureRealtimeAudioSession()
             } else {
                 try Self.configureAudioSession()
@@ -343,7 +468,9 @@ final class TalkModeManager: NSObject {
             GatewayDiagnostics.log("talk.timeline manager start blocked gateway permission")
             return
         }
-        if self.runtimeRoute.usesRealtime {
+        let bypassRealtime = self.bypassRealtimeOnNextStart
+        self.bypassRealtimeOnNextStart = false
+        if self.runtimeRoute.usesRealtime, !bypassRealtime {
             let realtimeStart = self.executionMode == .realtimeRelay
                 ? await self.startRealtimeRelayIfAvailable()
                 : await self.startRealtimeIfAvailable()
@@ -402,20 +529,23 @@ final class TalkModeManager: NSObject {
             UserDefaults.standard.string(forKey: TalkModeProviderSelection.storageKey))
     }
 
-    private var shouldForceRealtimeRelayFromSelection: Bool {
+    private var shouldUseOpenAIRealtimeSelectionFallback: Bool {
         self.talkProviderSelection == .openAIRealtime
     }
 
     private func applyOpenAIRealtimeSelectionDefaults() {
+        let realtimeVoiceOverride = TalkModeRealtimeVoiceSelection.resolvedOverride(
+            UserDefaults.standard.string(forKey: TalkModeRealtimeVoiceSelection.storageKey))
         self.activeTalkProvider = "openai"
-        self.executionMode = .realtimeRelay
-        self.runtimeRoute = .realtimeRelay
-        self.realtimeProvider = self.realtimeProvider ?? "openai"
-        self.realtimeModelId = self.realtimeModelId ?? Self.defaultRealtimeModelIdFallback
+        self.executionMode = .realtimeWebRTC
+        self.runtimeRoute = .realtimeWebRTC
+        self.realtimeProvider = "openai"
+        self.realtimeModelId = Self.defaultRealtimeModelIdFallback
+        self.realtimeVoiceId = realtimeVoiceOverride
         self.gatewayTalkProviderLabel = TalkModeProviderSelection.openAIRealtime.label
         self.gatewayTalkUsesRealtime = true
-        self.gatewayTalkUsesRealtimeRelay = true
-        self.gatewayTalkTransportLabel = "Gateway Relay"
+        self.gatewayTalkUsesRealtimeRelay = false
+        self.gatewayTalkTransportLabel = "Native WebRTC"
         self.gatewayTalkRealtimeProviderLabel = Self.displayName(forProvider: self.realtimeProvider ?? "openai")
         self.gatewayTalkRealtimeModelId = self.realtimeModelId
         self.gatewayTalkRealtimeVoiceId = self.realtimeVoiceId
@@ -441,6 +571,7 @@ final class TalkModeManager: NSObject {
         self.lastHeard = nil
         self.silenceTask?.cancel()
         self.silenceTask = nil
+        self.resetRealtimeRestartState()
         self.stopRealtimeSession()
         self.stopRecognition()
         self.stopSpeaking()
@@ -490,6 +621,7 @@ final class TalkModeManager: NSObject {
         self.silenceTask?.cancel()
         self.silenceTask = nil
 
+        self.resetRealtimeRestartState()
         self.stopRealtimeSession()
         self.stopRecognition()
         self.stopSpeaking()
@@ -1025,7 +1157,10 @@ final class TalkModeManager: NSObject {
             if Self.isTerminalChatSendFailure(ack.status) {
                 self.statusText = normalizedStatus == "error" ? "Chat error" : "Aborted"
                 self.logger.warning(
-                    "chat.send terminal ack runId=\(runId, privacy: .public) status=\(normalizedStatus, privacy: .public)")
+                    """
+                    chat.send terminal ack runId=\(runId, privacy: .public) \
+                    status=\(normalizedStatus, privacy: .public)
+                    """)
                 GatewayDiagnostics.log(
                     "talk: chat.send terminal ack runId=\(runId) status=\(normalizedStatus)")
                 if restartAfter {
@@ -1139,9 +1274,7 @@ final class TalkModeManager: NSObject {
                 session.stop()
                 return .ignored
             }
-            self.isListening = true
-            self.captureMode = .continuous
-            markRealtimeActive()
+            self.markRealtimeSessionReady()
             GatewayDiagnostics.log(
                 "talk.timeline realtime start ready elapsedMs=\(Self.elapsedMs(since: startedAt))")
             GatewayDiagnostics.log("talk realtime: started direct OpenAI WebRTC session")
@@ -1229,8 +1362,7 @@ final class TalkModeManager: NSObject {
                         + "issue=\(issue.code.rawValue)")
                 return .unavailable(issue)
             }
-            self.isListening = true
-            self.captureMode = .continuous
+            self.markRealtimeSessionReady()
             self.realtimeRelayStartIssue = nil
             GatewayDiagnostics.log(
                 "talk.timeline realtime relay start ready elapsedMs=\(Self.elapsedMs(since: startedAt))")
@@ -2574,16 +2706,14 @@ extension TalkModeManager {
 
     private func handleRealtimeRelayStatus(_ status: String) {
         if status == "Listening (Realtime)" {
-            self.markRealtimeActive()
+            // Ready can be followed by a buffered close before start() resumes. Commit continuous
+            // state here so the close still enters bounded recovery.
+            self.markRealtimeSessionReady()
         } else {
             self.statusText = status
             if status == "Ready" {
                 self.realtimeRelaySession = nil
-                self.gatewayTalkActiveModeTitle = "Not active"
-                self.gatewayTalkActiveModeSubtitle = nil
-                self.isListening = false
-                self.isSpeaking = false
-                self.isUserSpeechDetected = false
+                self.handleRealtimeSessionFinish()
             }
         }
         self.isListening = status.localizedCaseInsensitiveContains("listening")
@@ -2764,7 +2894,12 @@ extension TalkModeManager {
             defaultRealtimeModelId: Self.defaultRealtimeModelIdFallback)
         let realtimeVoiceOverride = TalkModeRealtimeVoiceSelection.resolvedOverride(
             UserDefaults.standard.string(forKey: TalkModeRealtimeVoiceSelection.storageKey))
-        let realtimeVoiceId = realtimeVoiceOverride ?? parsed.realtimeVoiceId
+        let parsedRealtimeProviderIsOpenAI =
+            parsed.realtimeProvider?.caseInsensitiveCompare("openai") == .orderedSame
+        let parsedRealtimeVoiceId = providerSelection == .openAIRealtime && !parsedRealtimeProviderIsOpenAI
+            ? nil
+            : parsed.realtimeVoiceId
+        let realtimeVoiceId = realtimeVoiceOverride ?? parsedRealtimeVoiceId
         self.activeTalkProvider = routing.activeProvider
         self.executionMode = routing.executionMode
         self.runtimeRoute = routing.route
@@ -2895,7 +3030,7 @@ extension TalkModeManager {
 
     private func applyTalkConfigLoadFailure(_ error: Error) {
         self.configuredProviderModelId = nil
-        if self.shouldForceRealtimeRelayFromSelection {
+        if self.shouldUseOpenAIRealtimeSelectionFallback {
             self.applyOpenAIRealtimeSelectionDefaults()
             GatewayDiagnostics.log("talk config unavailable; keeping openai realtime selection")
         } else {
@@ -2981,16 +3116,16 @@ extension TalkModeManager {
     static func configureAudioSession() throws {
         let session = AVAudioSession.sharedInstance()
         let forceSpeaker = TalkDefaults.speakerphoneEnabled()
-        var options: AVAudioSession.CategoryOptions = [.allowBluetoothHFP]
-        if forceSpeaker {
-            options.insert(.defaultToSpeaker)
-        }
+        let options = TalkAudioRoute.categoryOptions(speakerphoneEnabled: forceSpeaker)
         // Prefer `.spokenAudio` for STT; it tends to preserve speech energy better than `.voiceChat`.
         try session.setCategory(.playAndRecord, mode: .spokenAudio, options: options)
         try? session.setPreferredSampleRate(48000)
         try? session.setPreferredIOBufferDuration(0.02)
         try session.setActive(true, options: [])
-        if forceSpeaker, !Self.hasExternalAudioOutput(session.currentRoute) {
+        if TalkAudioRoute.shouldForceSpeaker(
+            preferenceEnabled: forceSpeaker,
+            outputPortTypes: session.currentRoute.outputs.map(\.portType))
+        {
             try? session.overrideOutputAudioPort(.speaker)
         } else {
             try? session.overrideOutputAudioPort(.none)
@@ -3001,17 +3136,17 @@ extension TalkModeManager {
     static func configureRealtimeAudioSession() throws {
         let session = AVAudioSession.sharedInstance()
         let forceSpeaker = TalkDefaults.speakerphoneEnabled()
-        var options: AVAudioSession.CategoryOptions = [.allowBluetoothHFP]
-        if forceSpeaker {
-            options.insert(.defaultToSpeaker)
-        }
+        let options = TalkAudioRoute.categoryOptions(speakerphoneEnabled: forceSpeaker)
         // Realtime Talk is full duplex. `.voiceChat` enables iOS voice processing so speaker
         // output is less likely to be captured as fresh microphone input.
         try session.setCategory(.playAndRecord, mode: .voiceChat, options: options)
         try? session.setPreferredSampleRate(48000)
         try? session.setPreferredIOBufferDuration(0.02)
         try session.setActive(true, options: [])
-        if forceSpeaker, !Self.hasExternalAudioOutput(session.currentRoute) {
+        if TalkAudioRoute.shouldForceSpeaker(
+            preferenceEnabled: forceSpeaker,
+            outputPortTypes: session.currentRoute.outputs.map(\.portType))
+        {
             try? session.overrideOutputAudioPort(.speaker)
         } else {
             try? session.overrideOutputAudioPort(.none)
@@ -3034,17 +3169,6 @@ extension TalkModeManager {
         return "category=\(session.category.rawValue) mode=\(session.mode.rawValue) "
             + "opts=\(session.categoryOptions.rawValue) inputAvail=\(session.isInputAvailable) "
             + "routeIn=[\(inputs)] routeOut=[\(outputs)] availIn=[\(available)]"
-    }
-
-    private static func hasExternalAudioOutput(_ route: AVAudioSessionRouteDescription) -> Bool {
-        route.outputs.contains(where: { output in
-            switch output.portType {
-            case .airPlay, .bluetoothA2DP, .bluetoothHFP, .bluetoothLE, .carAudio, .headphones, .usbAudio:
-                true
-            default:
-                false
-            }
-        })
     }
 }
 
@@ -3122,7 +3246,7 @@ extension TalkModeManager: TalkRealtimeWebRTCSessionDelegate {
         guard session === self.realtimeSession else { return }
         GatewayDiagnostics.log("talk.timeline realtime status=\(status)")
         if status == "Listening" {
-            self.markRealtimeActive()
+            self.markRealtimeSessionReady()
         } else {
             self.statusText = status
         }
@@ -3163,19 +3287,36 @@ extension TalkModeManager: TalkRealtimeWebRTCSessionDelegate {
     func realtimeSessionDidFinish(_ session: TalkRealtimeWebRTCSession) {
         guard session === self.realtimeSession else { return }
         self.realtimeSession = nil
-        self.isListening = false
-        self.isSpeaking = false
-        self.isUserSpeechDetected = false
-        self.gatewayTalkActiveModeTitle = "Not active"
-        self.gatewayTalkActiveModeSubtitle = nil
-        if self.isEnabled {
-            self.statusText = self.gatewayConnected ? "Ready" : "Offline"
-        }
+        self.handleRealtimeSessionFinish()
     }
 }
 
 #if DEBUG
 extension TalkModeManager {
+    static func _test_shouldRestartRealtimeSession(
+        isEnabled: Bool,
+        gatewayConnected: Bool,
+        captureIsContinuous: Bool) -> Bool
+    {
+        self.shouldRestartRealtimeSession(
+            isEnabled: isEnabled,
+            gatewayConnected: gatewayConnected,
+            captureIsContinuous: captureIsContinuous)
+    }
+
+    static func _test_realtimeRestartAttempt(
+        previousRapidRestarts: Int,
+        activeDuration: TimeInterval) -> Int
+    {
+        self.realtimeRestartAttempt(
+            previousRapidRestarts: previousRapidRestarts,
+            activeDuration: activeDuration)
+    }
+
+    static func _test_realtimeRestartDelayNanoseconds(attempt: Int) -> UInt64? {
+        self.realtimeRestartDelayNanoseconds(attempt: attempt)
+    }
+
     static func _test_isPCMFormatRejectedByAPI(_ error: Error?) -> Bool {
         self.isPCMFormatRejectedByAPI(error)
     }
@@ -3243,6 +3384,23 @@ extension TalkModeManager {
 
     func _test_handleRealtimeRelayStatus(_ status: String) {
         self.handleRealtimeRelayStatus(status)
+    }
+
+    func _test_prepareEnabledRealtimeSessionForClose() {
+        self.isEnabled = true
+        self.gatewayConnected = true
+        self.captureMode = .idle
+        self.realtimeSessionReadyAt = nil
+    }
+
+    func _test_rapidRealtimeRestartCount() -> Int {
+        self.rapidRealtimeRestartCount
+    }
+
+    func _test_realtimeStatusPreservesPushToTalkCapture() -> Bool {
+        self.captureMode = .pushToTalk
+        self.handleRealtimeRelayStatus("Listening (Realtime)")
+        return self.captureMode == .pushToTalk
     }
 
     func _test_prepareRealtimeRelayStart() {

--- a/apps/ios/Sources/Voice/TalkRealtimeClientSession.swift
+++ b/apps/ios/Sources/Voice/TalkRealtimeClientSession.swift
@@ -31,6 +31,7 @@ struct TalkRealtimeToolCallResponse: Decodable {
 
 struct TalkRealtimeServerEvent: Decodable {
     let type: String
+    let error: TalkRealtimeServerError?
     let itemId: String?
     let item: TalkRealtimeServerItem?
     let callId: String?
@@ -42,6 +43,7 @@ struct TalkRealtimeServerEvent: Decodable {
 
     enum CodingKeys: String, CodingKey {
         case type
+        case error
         case itemId = "item_id"
         case item
         case callId = "call_id"
@@ -67,6 +69,15 @@ struct TalkRealtimeServerEvent: Decodable {
     var resolvedArguments: String? {
         self.arguments ?? self.item?.arguments
     }
+
+    var isMaximumDurationError: Bool {
+        guard self.type == "error", let message = self.error?.message?.lowercased() else { return false }
+        return message.contains("session") && message.contains("maximum duration")
+    }
+}
+
+struct TalkRealtimeServerError: Decodable {
+    let message: String?
 }
 
 struct TalkRealtimeServerItem: Decodable {

--- a/apps/ios/Sources/Voice/TalkRealtimeWebRTCSession.swift
+++ b/apps/ios/Sources/Voice/TalkRealtimeWebRTCSession.swift
@@ -50,6 +50,7 @@ final class TalkRealtimeWebRTCSession: NSObject {
     private var loggedFirstAssistantSignal = false
     private var assistantAudioActive = false
     private var assistantAudioFinishTask: Task<Void, Never>?
+    private var ownsAudioSessionActivation = false
 
     private struct ToolBuffer {
         var name: String
@@ -117,7 +118,8 @@ final class TalkRealtimeWebRTCSession: NSObject {
         self.session = session
 
         self.trace("configure audio session start")
-        try Self.configureAudioSession()
+        try Self.configureAudioSession(activate: true)
+        self.ownsAudioSessionActivation = true
         self.trace("configure audio session done")
         RTCInitializeSSL()
         let factory = RTCPeerConnectionFactory(
@@ -171,12 +173,34 @@ final class TalkRealtimeWebRTCSession: NSObject {
         self.peerConnection?.close()
         self.peerConnection = nil
         self.factory = nil
+        self.releaseAudioSessionActivation()
         self.session = nil
         self.assistantAudioActive = false
         self.assistantAudioFinishTask?.cancel()
         self.assistantAudioFinishTask = nil
         if shouldNotify {
             self.delegate?.realtimeSessionDidFinish(self)
+        }
+    }
+
+    func applyAudioRoutePreferenceChanged() throws {
+        try Self.configureAudioSession(activate: false)
+        self.trace("audio route preference reapplied")
+    }
+
+    private func releaseAudioSessionActivation() {
+        guard self.ownsAudioSessionActivation else { return }
+        self.ownsAudioSessionActivation = false
+
+        // Balance only the activation this session owns. WebRTC may hold its own
+        // activation while the peer connection is alive.
+        let session = RTCAudioSession.sharedInstance()
+        session.lockForConfiguration()
+        defer { session.unlockForConfiguration() }
+        do {
+            try session.setActive(false)
+        } catch {
+            self.trace("audio session deactivate failed error=\(error.localizedDescription)")
         }
     }
 
@@ -373,6 +397,11 @@ final class TalkRealtimeWebRTCSession: NSObject {
             self.handleToolDone(event)
         case "error":
             self.delegate?.realtimeSession(self, didChangeStatus: "Realtime error")
+            if event.isMaximumDurationError {
+                // The provider's hard limit is terminal before transport state catches up.
+                // Finish explicitly so TalkModeManager rotates the session exactly once.
+                self.stop()
+            }
         default:
             break
         }
@@ -894,14 +923,12 @@ final class TalkRealtimeWebRTCSession: NSObject {
         }
     }
 
-    private static func configureAudioSession() throws {
+    private static func configureAudioSession(activate: Bool) throws {
+        let forceSpeaker = TalkDefaults.speakerphoneEnabled()
         let config = RTCAudioSessionConfiguration.webRTC()
         config.category = AVAudioSession.Category.playAndRecord.rawValue
         config.mode = AVAudioSession.Mode.default.rawValue
-        config.categoryOptions = [
-            .allowBluetoothHFP,
-            .defaultToSpeaker,
-        ]
+        config.categoryOptions = TalkAudioRoute.categoryOptions(speakerphoneEnabled: forceSpeaker)
         config.sampleRate = 48000
         config.ioBufferDuration = 0.01
         RTCAudioSessionConfiguration.setWebRTC(config)
@@ -911,8 +938,15 @@ final class TalkRealtimeWebRTCSession: NSObject {
         defer { session.unlockForConfiguration() }
 
         session.ignoresPreferredAttributeConfigurationErrors = true
-        try session.setConfiguration(config, active: true)
-        try? session.overrideOutputAudioPort(.speaker)
+        if activate {
+            try session.setConfiguration(config, active: true)
+        } else {
+            try session.setConfiguration(config)
+        }
+        let shouldForceSpeaker = TalkAudioRoute.shouldForceSpeaker(
+            preferenceEnabled: forceSpeaker,
+            outputPortTypes: session.currentRoute.outputs.map(\.portType))
+        try? session.overrideOutputAudioPort(shouldForceSpeaker ? .speaker : .none)
     }
 }
 
@@ -963,10 +997,16 @@ extension TalkRealtimeWebRTCSession: RTCDataChannelDelegate {
     nonisolated func dataChannelDidChangeState(_ dataChannel: RTCDataChannel) {
         Task { @MainActor in
             guard !self.stopped else { return }
-            if dataChannel.readyState == .open {
+            switch dataChannel.readyState {
+            case .open:
                 if !self.assistantAudioActive {
                     self.delegate?.realtimeSession(self, didChangeStatus: "Listening")
                 }
+            case .closed:
+                self.delegate?.realtimeSession(self, didChangeStatus: "Realtime disconnected")
+                self.stop()
+            default:
+                break
             }
         }
     }

--- a/apps/ios/Tests/TalkModeConfigParsingTests.swift
+++ b/apps/ios/Tests/TalkModeConfigParsingTests.swift
@@ -1,11 +1,29 @@
+import AVFoundation
 import Foundation
 import OpenClawKit
 import Testing
 @testable import OpenClaw
 
 @MainActor
-@Suite struct TalkModeManagerTests {
-    @Test func parsesOpenAIRealtimeProviderModelAndVoice() {
+struct TalkModeManagerTests {
+    @Test func `recognizes open AI maximum duration errors as terminal`() throws {
+        let event = try JSONDecoder().decode(
+            TalkRealtimeServerEvent.self,
+            from: Data(#"{"type":"error","error":{"message":"Your session hit the maximum duration of 60 minutes."}}"#
+                .utf8))
+
+        #expect(event.isMaximumDurationError)
+    }
+
+    @Test func `keeps recoverable open AI errors in the current session`() throws {
+        let event = try JSONDecoder().decode(
+            TalkRealtimeServerEvent.self,
+            from: Data(#"{"type":"error","error":{"message":"Cancellation failed: no active response found"}}"#.utf8))
+
+        #expect(!event.isMaximumDurationError)
+    }
+
+    @Test func `parses open AI realtime provider model and voice`() {
         let config: [String: Any] = [
             "talk": [
                 "provider": "elevenlabs",
@@ -49,7 +67,7 @@ import Testing
         #expect(parsed.realtimeVoiceId == "marin")
     }
 
-    @Test func infersRealtimeProviderWhenProviderMapHasSingleEntry() {
+    @Test func `infers realtime provider when provider map has single entry`() {
         let config: [String: Any] = [
             "talk": [
                 "realtime": [
@@ -71,12 +89,12 @@ import Testing
             defaultRealtimeModelIdFallback: "gpt-realtime-2",
             defaultSilenceTimeoutMs: 900)
 
-        #expect(parsed.executionMode == .realtimeRelay)
+        #expect(parsed.executionMode == .realtimeWebRTC)
         #expect(parsed.realtimeProvider == "openai")
         #expect(parsed.realtimeModelId == "gpt-realtime-2")
     }
 
-    @Test func formatsGenericRealtimeVoiceModeWithoutNativeProviderFallback() {
+    @Test func `formats generic realtime voice mode without native provider fallback`() {
         let descriptor = TalkVoiceModeDescriptorBuilder.build(
             providerId: "realtime",
             providerLabel: "Realtime Voice",
@@ -89,7 +107,7 @@ import Testing
         #expect(descriptor.subtitle == "Native WebRTC • gpt-realtime-2")
     }
 
-    @Test func defaultsOpenAIRealtimeModelWhenProviderOmitsModel() {
+    @Test func `defaults open AI realtime model when provider omits model`() {
         let config: [String: Any] = [
             "talk": [
                 "realtime": [
@@ -113,14 +131,14 @@ import Testing
         #expect(parsed.realtimeVoiceId == nil)
     }
 
-    @Test func resolvesRealtimeVoicePickerOverrides() {
+    @Test func `resolves realtime voice picker overrides`() {
         #expect(TalkModeRealtimeVoiceSelection.resolvedOverride(nil) == nil)
         #expect(TalkModeRealtimeVoiceSelection.resolvedOverride("") == nil)
         #expect(TalkModeRealtimeVoiceSelection.resolvedOverride(" Cedar ") == "cedar")
         #expect(TalkModeRealtimeVoiceSelection.resolvedOverride("unknown") == nil)
     }
 
-    @Test func formatsOpenAIRealtimeVoiceMode() {
+    @Test func `formats open AI realtime voice mode`() {
         let descriptor = TalkVoiceModeDescriptorBuilder.build(
             providerId: "openai",
             providerLabel: "OpenAI",
@@ -134,7 +152,7 @@ import Testing
         #expect(descriptor.accessibilityValue == "GPT Realtime 2.0, Native WebRTC • Marin")
     }
 
-    @Test func formatsGatewayRelayRealtimeVoiceMode() {
+    @Test func `formats gateway relay realtime voice mode`() {
         let descriptor = TalkVoiceModeDescriptorBuilder.build(
             providerId: "google",
             providerLabel: "Google Live Voice",
@@ -147,7 +165,7 @@ import Testing
         #expect(descriptor.subtitle == "Gateway Relay • gemini-live-2.5-flash-preview")
     }
 
-    @Test func formatsElevenLabsVoiceMode() {
+    @Test func `formats eleven labs voice mode`() {
         let descriptor = TalkVoiceModeDescriptorBuilder.build(
             providerId: "elevenlabs",
             providerLabel: "ElevenLabs",
@@ -160,7 +178,7 @@ import Testing
         #expect(descriptor.subtitle == "Native • eleven_v3 • voice-id")
     }
 
-    @Test func formatsSystemVoiceFallbackMode() {
+    @Test func `formats system voice fallback mode`() {
         let descriptor = TalkVoiceModeDescriptorBuilder.build(
             providerId: "system",
             providerLabel: "iOS System Voice",
@@ -173,18 +191,106 @@ import Testing
         #expect(descriptor.subtitle == "Native • en-US")
     }
 
-    @Test func openAIRealtimeSelectionFallbackKeepsGatewayRelayDefaults() {
+    @Test func `open AI realtime selection defaults to native web RTC`() {
         let manager = TalkModeManager(allowSimulatorCapture: true)
 
         manager._test_applyOpenAIRealtimeSelectionDefaults()
 
-        #expect(manager._test_executionMode() == .realtimeRelay)
+        #expect(manager._test_executionMode() == .realtimeWebRTC)
         #expect(manager._test_realtimeProvider() == "openai")
         #expect(manager._test_realtimeModelId() == "gpt-realtime-2")
-        #expect(manager._test_gatewayTalkUsesRealtimeRelay())
+        #expect(!manager._test_gatewayTalkUsesRealtimeRelay())
     }
 
-    @Test func buildsGenericRealtimeFallbackIssueForDisplay() {
+    @Test func `open AI realtime selection clears stale realtime config`() {
+        let manager = TalkModeManager(allowSimulatorCapture: true)
+        let config: [String: Any] = [
+            "talk": [
+                "realtime": [
+                    "provider": "google",
+                    "model": "gemini-live-2.5-flash-preview",
+                    "voice": "puck",
+                    "mode": "realtime",
+                    "transport": "gateway-relay",
+                    "brain": "agent-consult",
+                ],
+            ],
+        ]
+        let parsed = TalkModeGatewayConfigParser.parse(
+            config: config,
+            defaultProvider: "elevenlabs",
+            defaultModelIdFallback: "eleven_v3",
+            defaultRealtimeModelIdFallback: "gpt-realtime-2",
+            defaultSilenceTimeoutMs: 900)
+
+        manager._test_applyLoadedTalkConfig(parsed, providerSelection: .gatewayDefault)
+        manager._test_applyOpenAIRealtimeSelectionDefaults()
+
+        #expect(manager._test_executionMode() == .realtimeWebRTC)
+        #expect(manager._test_realtimeProvider() == "openai")
+        #expect(manager._test_realtimeModelId() == "gpt-realtime-2")
+        #expect(manager.gatewayTalkRealtimeVoiceId == nil)
+        #expect(!manager._test_gatewayTalkUsesRealtimeRelay())
+    }
+
+    @Test func `open AI realtime selection keeps explicit open AI voice override`() {
+        let manager = TalkModeManager(allowSimulatorCapture: true)
+        let defaults = UserDefaults.standard
+        defaults.set(" Cedar ", forKey: TalkModeRealtimeVoiceSelection.storageKey)
+        defer { defaults.removeObject(forKey: TalkModeRealtimeVoiceSelection.storageKey) }
+        let config: [String: Any] = [
+            "talk": [
+                "realtime": [
+                    "provider": "google",
+                    "model": "gemini-live-2.5-flash-preview",
+                    "voice": "puck",
+                    "mode": "realtime",
+                    "transport": "gateway-relay",
+                    "brain": "agent-consult",
+                ],
+            ],
+        ]
+        let parsed = TalkModeGatewayConfigParser.parse(
+            config: config,
+            defaultProvider: "elevenlabs",
+            defaultModelIdFallback: "eleven_v3",
+            defaultRealtimeModelIdFallback: "gpt-realtime-2",
+            defaultSilenceTimeoutMs: 900)
+
+        manager._test_applyLoadedTalkConfig(parsed, providerSelection: .openAIRealtime)
+
+        #expect(manager._test_realtimeProvider() == "openai")
+        #expect(manager._test_realtimeModelId() == "gpt-realtime-2")
+        #expect(manager.gatewayTalkRealtimeVoiceId == "cedar")
+    }
+
+    @Test func `open AI selection preserves configured voice for case insensitive provider`() {
+        let manager = TalkModeManager(allowSimulatorCapture: true)
+        let config: [String: Any] = [
+            "talk": [
+                "realtime": [
+                    "provider": " OpenAI ",
+                    "voice": "marin",
+                    "mode": "realtime",
+                    "transport": "webrtc",
+                    "brain": "agent-consult",
+                ],
+            ],
+        ]
+        let parsed = TalkModeGatewayConfigParser.parse(
+            config: config,
+            defaultProvider: "elevenlabs",
+            defaultModelIdFallback: "eleven_v3",
+            defaultRealtimeModelIdFallback: "gpt-realtime-2",
+            defaultSilenceTimeoutMs: 900)
+
+        manager._test_applyLoadedTalkConfig(parsed, providerSelection: .openAIRealtime)
+
+        #expect(manager._test_realtimeProvider() == "openai")
+        #expect(manager.gatewayTalkRealtimeVoiceId == "marin")
+    }
+
+    @Test func `builds generic realtime fallback issue for display`() {
         let issue = TalkRuntimeIssue.realtimeUnavailable(
             message: "OpenAI API key rejected with 401",
             provider: "openai",
@@ -205,7 +311,7 @@ import Testing
         #expect(issue.technicalDetails.contains("code: realtime_unavailable"))
     }
 
-    @Test func nativeFallbackKeepsRealtimeIssueVisible() {
+    @Test func `native fallback keeps realtime issue visible`() {
         let manager = TalkModeManager(allowSimulatorCapture: true)
         let issue = TalkRuntimeIssue(
             code: .realtimeUnavailable,
@@ -224,7 +330,7 @@ import Testing
         #expect(manager._test_gatewayTalkCurrentFallbackIssue() == issue)
     }
 
-    @Test func gatewayTalkIssueDetailsDriveRealtimeFailureDisplay() {
+    @Test func `gateway talk issue details drive realtime failure display`() {
         let manager = TalkModeManager(allowSimulatorCapture: true)
         let error = GatewayResponseError(
             method: "talk.session.create",
@@ -251,7 +357,7 @@ import Testing
         #expect(issue.phase == "request")
     }
 
-    @Test func relayStartupIssueSurvivesUntilReadyStatus() {
+    @Test func `relay startup issue survives until ready status`() {
         let manager = TalkModeManager(allowSimulatorCapture: true)
         let issue = TalkRuntimeIssue(
             code: .realtimeUnavailable,
@@ -274,7 +380,7 @@ import Testing
         #expect(manager._test_gatewayTalkCurrentFallbackIssue() == nil)
     }
 
-    @Test func relayCloseClearsActiveRealtimeMode() {
+    @Test func `relay close clears active realtime mode`() {
         let manager = TalkModeManager(allowSimulatorCapture: true)
 
         manager._test_handleRealtimeRelayStatus("Listening (Realtime)")
@@ -288,7 +394,25 @@ import Testing
         #expect(manager._test_gatewayTalkActiveModeSubtitle() == nil)
     }
 
-    @Test func relayRetryClearsStaleFallbackTriggerButKeepsLastIssueVisible() {
+    @Test func `relay close restarts enabled continuous realtime`() {
+        let manager = TalkModeManager(allowSimulatorCapture: true)
+        manager._test_prepareEnabledRealtimeSessionForClose()
+
+        manager._test_handleRealtimeRelayStatus("Listening (Realtime)")
+        manager._test_handleRealtimeRelayStatus("Ready")
+
+        #expect(manager.statusText == "Reconnecting")
+        #expect(manager._test_rapidRealtimeRestartCount() == 1)
+        manager.isEnabled = false
+    }
+
+    @Test func `recurring realtime ready status preserves push to talk capture`() {
+        let manager = TalkModeManager(allowSimulatorCapture: true)
+
+        #expect(manager._test_realtimeStatusPreservesPushToTalkCapture())
+    }
+
+    @Test func `relay retry clears stale fallback trigger but keeps last issue visible`() {
         let manager = TalkModeManager(allowSimulatorCapture: true)
         let issue = TalkRuntimeIssue(
             code: .realtimeUnavailable,
@@ -310,7 +434,7 @@ import Testing
         #expect(manager._test_gatewayTalkLastIssueText()?.contains("Realtime closed before") == true)
     }
 
-    @Test func mapsWebRTCRealtimeTransportToGatewayRelayOnIOS() {
+    @Test func `maps web RTC realtime transport to native web RTC on IOS`() {
         let config: [String: Any] = [
             "talk": [
                 "realtime": [
@@ -328,10 +452,312 @@ import Testing
             defaultRealtimeModelIdFallback: "gpt-realtime-2",
             defaultSilenceTimeoutMs: 900)
 
+        #expect(parsed.executionMode == .realtimeWebRTC)
+    }
+
+    @Test func `keeps Azure open AI realtime on gateway relay`() {
+        for providerConfig in [
+            ["azureEndpoint": "https://example.openai.azure.com"],
+            ["azureDeployment": "realtime-prod"],
+        ] {
+            let config: [String: Any] = [
+                "talk": [
+                    "realtime": [
+                        "provider": "openai",
+                        "providers": ["openai": providerConfig],
+                        "mode": "realtime",
+                        "transport": "webrtc",
+                        "brain": "agent-consult",
+                    ],
+                ],
+            ]
+            let parsed = TalkModeGatewayConfigParser.parse(
+                config: config,
+                defaultProvider: "elevenlabs",
+                defaultModelIdFallback: "eleven_v3",
+                defaultRealtimeModelIdFallback: "gpt-realtime-2",
+                defaultSilenceTimeoutMs: 900)
+            let routing = TalkModeRoutingResolver.resolve(
+                parsed: parsed,
+                providerSelection: .openAIRealtime,
+                defaultProvider: "elevenlabs",
+                defaultRealtimeModelId: "gpt-realtime-2")
+
+            #expect(parsed.executionMode == .realtimeRelay)
+            #expect(routing.route == .realtimeRelay)
+        }
+    }
+
+    @Test func `open AI selection keeps its Azure config on gateway relay`() {
+        let config: [String: Any] = [
+            "talk": [
+                "realtime": [
+                    "provider": "google",
+                    "providers": [
+                        "google": ["model": "gemini-live"],
+                        "OpenAI": ["azureDeployment": "realtime-prod"],
+                    ],
+                    "mode": "realtime",
+                    "transport": "webrtc",
+                    "brain": "agent-consult",
+                ],
+            ],
+        ]
+        let parsed = TalkModeGatewayConfigParser.parse(
+            config: config,
+            defaultProvider: "elevenlabs",
+            defaultModelIdFallback: "eleven_v3",
+            defaultRealtimeModelIdFallback: "gpt-realtime-2",
+            defaultSilenceTimeoutMs: 900)
+        let routing = TalkModeRoutingResolver.resolve(
+            parsed: parsed,
+            providerSelection: .openAIRealtime,
+            defaultProvider: "elevenlabs",
+            defaultRealtimeModelId: "gpt-realtime-2")
+
+        #expect(parsed.realtimeProvider == "google")
+        #expect(routing.route == .realtimeRelay)
+    }
+
+    @Test func `restarts an enabled continuous realtime session after provider close`() {
+        #expect(TalkModeManager._test_shouldRestartRealtimeSession(
+            isEnabled: true,
+            gatewayConnected: true,
+            captureIsContinuous: true))
+        #expect(!TalkModeManager._test_shouldRestartRealtimeSession(
+            isEnabled: false,
+            gatewayConnected: true,
+            captureIsContinuous: true))
+        #expect(!TalkModeManager._test_shouldRestartRealtimeSession(
+            isEnabled: true,
+            gatewayConnected: false,
+            captureIsContinuous: true))
+        #expect(!TalkModeManager._test_shouldRestartRealtimeSession(
+            isEnabled: true,
+            gatewayConnected: true,
+            captureIsContinuous: false))
+
+        #expect(TalkModeManager._test_realtimeRestartAttempt(
+            previousRapidRestarts: 1,
+            activeDuration: 5) == 2)
+        #expect(TalkModeManager._test_realtimeRestartAttempt(
+            previousRapidRestarts: 2,
+            activeDuration: 31) == 1)
+        #expect(TalkModeManager._test_realtimeRestartDelayNanoseconds(attempt: 1) == 500_000_000)
+        #expect(TalkModeManager._test_realtimeRestartDelayNanoseconds(attempt: 2) == 2_000_000_000)
+        #expect(TalkModeManager._test_realtimeRestartDelayNanoseconds(attempt: 3) == nil)
+    }
+
+    @Test func `keeps provider web socket realtime transport on gateway relay`() {
+        let config: [String: Any] = [
+            "talk": [
+                "realtime": [
+                    "provider": "google",
+                    "mode": "realtime",
+                    "transport": "provider-websocket",
+                    "brain": "agent-consult",
+                ],
+            ],
+        ]
+
+        let parsed = TalkModeGatewayConfigParser.parse(
+            config: config,
+            defaultProvider: "elevenlabs",
+            defaultModelIdFallback: "eleven_v3",
+            defaultRealtimeModelIdFallback: "gpt-realtime-2",
+            defaultSilenceTimeoutMs: 900)
+
         #expect(parsed.executionMode == .realtimeRelay)
     }
 
-    @Test func parsesRedactedGatewayRealtimeConfig() {
+    @Test func `leaves native mode for unsupported realtime brain`() {
+        let config: [String: Any] = [
+            "talk": [
+                "realtime": [
+                    "provider": "google",
+                    "mode": "realtime",
+                    "transport": "gateway-relay",
+                    "brain": "direct-tools",
+                ],
+            ],
+        ]
+
+        let parsed = TalkModeGatewayConfigParser.parse(
+            config: config,
+            defaultProvider: "elevenlabs",
+            defaultModelIdFallback: "eleven_v3",
+            defaultRealtimeModelIdFallback: "gpt-realtime-2",
+            defaultSilenceTimeoutMs: 900)
+
+        #expect(parsed.executionMode == .native)
+    }
+
+    @Test func `keeps non open AI realtime default transport on gateway relay`() {
+        let config: [String: Any] = [
+            "talk": [
+                "realtime": [
+                    "provider": "google",
+                    "mode": "realtime",
+                    "brain": "agent-consult",
+                ],
+            ],
+        ]
+
+        let parsed = TalkModeGatewayConfigParser.parse(
+            config: config,
+            defaultProvider: "elevenlabs",
+            defaultModelIdFallback: "eleven_v3",
+            defaultRealtimeModelIdFallback: "gpt-realtime-2",
+            defaultSilenceTimeoutMs: 900)
+
+        #expect(parsed.executionMode == .realtimeRelay)
+    }
+
+    @Test func `keeps non open AI web RTC transport on gateway relay`() {
+        let config: [String: Any] = [
+            "talk": [
+                "realtime": [
+                    "provider": "google",
+                    "model": "gemini-live-2.5-flash-preview",
+                    "mode": "realtime",
+                    "transport": "webrtc",
+                    "brain": "agent-consult",
+                ],
+            ],
+        ]
+
+        let parsed = TalkModeGatewayConfigParser.parse(
+            config: config,
+            defaultProvider: "elevenlabs",
+            defaultModelIdFallback: "eleven_v3",
+            defaultRealtimeModelIdFallback: "gpt-realtime-2",
+            defaultSilenceTimeoutMs: 900)
+
+        #expect(parsed.executionMode == .realtimeRelay)
+    }
+
+    @Test func `open AI selection overrides non open AI web RTC provider`() {
+        let config: [String: Any] = [
+            "talk": [
+                "realtime": [
+                    "provider": "google",
+                    "mode": "realtime",
+                    "transport": "webrtc",
+                    "brain": "agent-consult",
+                ],
+            ],
+        ]
+
+        let parsed = TalkModeGatewayConfigParser.parse(
+            config: config,
+            defaultProvider: "elevenlabs",
+            defaultModelIdFallback: "eleven_v3",
+            defaultRealtimeModelIdFallback: "gpt-realtime-2",
+            defaultSilenceTimeoutMs: 900)
+        let routing = TalkModeRoutingResolver.resolve(
+            parsed: parsed,
+            providerSelection: .openAIRealtime,
+            defaultProvider: "elevenlabs",
+            defaultRealtimeModelId: "gpt-realtime-2")
+
+        #expect(routing.activeProvider == "openai")
+        #expect(routing.realtimeProvider == "openai")
+        #expect(routing.realtimeModelId == "gpt-realtime-2")
+        #expect(routing.executionMode == .realtimeWebRTC)
+        #expect(routing.route == .realtimeWebRTC)
+    }
+
+    @Test func `open AI selection preserves explicit gateway owned transport`() {
+        for transport in ["gateway-relay", "provider-websocket"] {
+            let config: [String: Any] = [
+                "talk": [
+                    "realtime": [
+                        "provider": "google",
+                        "mode": "realtime",
+                        "transport": transport,
+                        "brain": "agent-consult",
+                    ],
+                ],
+            ]
+            let parsed = TalkModeGatewayConfigParser.parse(
+                config: config,
+                defaultProvider: "elevenlabs",
+                defaultModelIdFallback: "eleven_v3",
+                defaultRealtimeModelIdFallback: "gpt-realtime-2",
+                defaultSilenceTimeoutMs: 900)
+            let routing = TalkModeRoutingResolver.resolve(
+                parsed: parsed,
+                providerSelection: .openAIRealtime,
+                defaultProvider: "elevenlabs",
+                defaultRealtimeModelId: "gpt-realtime-2")
+
+            #expect(routing.realtimeProvider == "openai")
+            #expect(routing.executionMode == .realtimeRelay)
+            #expect(routing.route == .realtimeRelay)
+        }
+    }
+
+    @Test func `speaker preference preserves external audio routes`() {
+        let externalRouteOptions = TalkAudioRoute.categoryOptions(speakerphoneEnabled: false)
+        #expect(externalRouteOptions.contains(.allowBluetoothHFP))
+        #expect(externalRouteOptions.contains(.allowBluetoothA2DP))
+        #expect(externalRouteOptions.contains(.allowAirPlay))
+        #expect(!externalRouteOptions.contains(.defaultToSpeaker))
+        #expect(TalkAudioRoute.categoryOptions(speakerphoneEnabled: true).contains(.defaultToSpeaker))
+
+        #expect(TalkAudioRoute.shouldForceSpeaker(
+            preferenceEnabled: true,
+            outputPortTypes: [.builtInReceiver]))
+        #expect(TalkAudioRoute.shouldForceSpeaker(
+            preferenceEnabled: true,
+            outputPortTypes: [.builtInSpeaker]))
+        #expect(!TalkAudioRoute.shouldForceSpeaker(
+            preferenceEnabled: false,
+            outputPortTypes: [.builtInReceiver]))
+        #expect(!TalkAudioRoute.shouldForceSpeaker(
+            preferenceEnabled: true,
+            outputPortTypes: []))
+
+        let externalOutputs: [AVAudioSession.Port] = [
+            .airPlay,
+            .bluetoothA2DP,
+            .bluetoothHFP,
+            .bluetoothLE,
+            .carAudio,
+            .headphones,
+            .HDMI,
+            .lineOut,
+            .usbAudio,
+        ]
+        for output in externalOutputs {
+            #expect(!TalkAudioRoute.shouldForceSpeaker(
+                preferenceEnabled: true,
+                outputPortTypes: [output]))
+        }
+    }
+
+    @Test func `maps open AI realtime default transport to native web RTC`() {
+        let config: [String: Any] = [
+            "talk": [
+                "realtime": [
+                    "provider": "openai",
+                    "mode": "realtime",
+                    "brain": "agent-consult",
+                ],
+            ],
+        ]
+
+        let parsed = TalkModeGatewayConfigParser.parse(
+            config: config,
+            defaultProvider: "elevenlabs",
+            defaultModelIdFallback: "eleven_v3",
+            defaultRealtimeModelIdFallback: "gpt-realtime-2",
+            defaultSilenceTimeoutMs: 900)
+
+        #expect(parsed.executionMode == .realtimeWebRTC)
+    }
+
+    @Test func `parses redacted gateway realtime config`() {
         let config: [String: Any] = [
             "talk": [
                 "providers": [
@@ -372,14 +798,14 @@ import Testing
             defaultSilenceTimeoutMs: 900)
 
         #expect(parsed.activeProvider == "elevenlabs")
-        #expect(parsed.executionMode == .realtimeRelay)
+        #expect(parsed.executionMode == .realtimeWebRTC)
         #expect(parsed.realtimeProvider == "openai")
         #expect(parsed.realtimeModelId == "gpt-realtime-2")
         #expect(parsed.realtimeVoiceId == "cedar")
         #expect(parsed.rawConfigApiKey == "__OPENCLAW_REDACTED__")
     }
 
-    @Test func leavesNativeModeForManagedRoomRealtimeTransport() {
+    @Test func `leaves native mode for managed room realtime transport`() {
         let config: [String: Any] = [
             "talk": [
                 "realtime": [
@@ -400,7 +826,7 @@ import Testing
         #expect(parsed.executionMode == .native)
     }
 
-    @Test func detectsPCMFormatRejectionFromElevenLabsError() {
+    @Test func `detects PCM format rejection from eleven labs error`() {
         let error = NSError(
             domain: "ElevenLabsTTS",
             code: 403,
@@ -410,7 +836,7 @@ import Testing
         #expect(TalkModeManager._test_isPCMFormatRejectedByAPI(error))
     }
 
-    @Test func ignoresGenericPlaybackFailuresForPCMFormatRejection() {
+    @Test func `ignores generic playback failures for PCM format rejection`() {
         let error = NSError(
             domain: "StreamingAudio",
             code: -1,

--- a/docs/docs_map.md
+++ b/docs/docs_map.md
@@ -5664,6 +5664,7 @@ Do not edit it by hand; run `pnpm docs:map:gen`.
   - H2: Renderer contract
   - H2: Core render flow
   - H2: Degradation rules
+  - H3: Button value fallback visibility
   - H2: Provider mapping
   - H2: Presentation vs InteractiveReply
   - H2: Delivery pin

--- a/docs/nodes/talk.md
+++ b/docs/nodes/talk.md
@@ -9,6 +9,7 @@ title: "Talk mode"
 Talk mode has two runtime shapes:
 
 - Native macOS/iOS/Android Talk uses local speech recognition, Gateway chat, and `talk.speak` TTS. Nodes advertise the `talk` capability and declare the `talk.*` commands they support.
+- iOS Talk uses client-owned WebRTC for OpenAI realtime configurations that select `webrtc` or omit the transport. Explicit `gateway-relay`, `provider-websocket`, and non-OpenAI realtime configurations stay on the Gateway-owned relay; non-realtime configurations use the native speech loop.
 - Browser Talk uses `talk.client.create` for client-owned `webrtc` and `provider-websocket` sessions, or `talk.session.create` for Gateway-owned `gateway-relay` sessions. `managed-room` is reserved for Gateway handoff and walkie-talkie rooms.
 - Android Talk can opt into Gateway-owned realtime relay sessions with `talk.realtime.mode: "realtime"` and `talk.realtime.transport: "gateway-relay"`. Otherwise it stays on native speech recognition, Gateway chat, and `talk.speak`.
 - Transcription-only clients use `talk.session.create({ mode: "transcription", transport: "gateway-relay", brain: "none" })`, then `talk.session.appendAudio`, `talk.session.cancelTurn`, and `talk.session.close` when they need captions or dictation without an assistant voice response.
@@ -20,7 +21,7 @@ Native Talk is a continuous voice conversation loop:
 3. Wait for the response
 4. Speak it via the configured Talk provider (`talk.speak`)
 
-Browser realtime Talk forwards provider tool calls through `talk.client.toolCall`; browser clients do not call `chat.send` directly for realtime consults.
+Client-owned realtime Talk forwards provider tool calls through `talk.client.toolCall`; those clients do not call `chat.send` directly for realtime consults.
 While a realtime consult is active, Talk clients can use `talk.client.steer` or
 `talk.session.steer` to classify spoken input as `status`, `steer`, `cancel`, or
 `followup`. Accepted steering is queued into the active embedded run; rejected
@@ -111,10 +112,10 @@ Defaults:
 - `providers.elevenlabs.apiKey`: falls back to `ELEVENLABS_API_KEY` (or gateway shell profile if available).
 - `consultThinkingLevel`: optional thinking level override for the full OpenClaw agent run behind realtime `openclaw_agent_consult` calls.
 - `consultFastMode`: optional fast-mode override for realtime `openclaw_agent_consult` calls.
-- `realtime.provider`: selects the active browser/server realtime voice provider. Use `openai` for WebRTC, `google` for provider WebSocket, or a bridge-only provider through Gateway relay.
+- `realtime.provider`: selects the active realtime voice provider. Use `openai` for WebRTC, `google` for provider WebSocket, or a bridge-only provider through Gateway relay.
 - `realtime.providers.<provider>` stores provider-owned realtime config. The browser receives only ephemeral or constrained session credentials, never a standard API key.
 - `realtime.providers.openai.voice`: built-in OpenAI Realtime voice id. Current `gpt-realtime-2` voices are `alloy`, `ash`, `ballad`, `coral`, `echo`, `sage`, `shimmer`, `verse`, `marin`, and `cedar`; `marin` and `cedar` are recommended for best quality.
-- `realtime.transport`: `webrtc` and `provider-websocket` are browser realtime transports. Android uses realtime relay only when this is `gateway-relay`; otherwise Android Talk uses its native STT/TTS loop.
+- `realtime.transport`: `webrtc` uses client-owned OpenAI WebRTC on iOS and in the browser. `provider-websocket` is browser-owned but stays on the Gateway relay on iOS. `gateway-relay` keeps provider audio on the Gateway; Android uses realtime only for this transport and otherwise keeps its native STT/TTS loop.
 - `realtime.brain`: `agent-consult` routes realtime tool calls through Gateway policy; `direct-tools` is legacy direct-tool compatibility behavior; `none` is for transcription or external orchestration.
 - `realtime.consultRouting`: `provider-direct` preserves the provider's direct reply when it skips `openclaw_agent_consult`; `force-agent-consult` makes Gateway relay route finalized user transcripts through OpenClaw instead.
 - `realtime.instructions`: appends provider-facing system instructions to OpenClaw's built-in realtime prompt. Use it for voice style and tone; OpenClaw keeps the default `openclaw_agent_consult` guidance.
@@ -145,7 +146,7 @@ Defaults:
 
 - Requires Speech + Microphone permissions.
 - Native Talk uses the active Gateway session and only falls back to history polling when response events are unavailable.
-- Browser realtime Talk uses `talk.client.toolCall` for `openclaw_agent_consult` instead of exposing `chat.send` to provider-owned browser sessions.
+- Client-owned realtime Talk uses `talk.client.toolCall` for `openclaw_agent_consult` instead of exposing `chat.send` to provider-owned sessions.
 - Transcription-only Talk uses `talk.session.create`, `talk.session.appendAudio`, `talk.session.cancelTurn`, and `talk.session.close`; clients subscribe to `talk.event` for partial/final transcript updates.
 - The gateway resolves Talk playback through `talk.speak` using the active Talk provider. Android falls back to local system TTS only when that RPC is unavailable.
 - macOS local MLX playback uses the bundled `openclaw-mlx-tts` helper when present, or an executable on `PATH`. Set `OPENCLAW_MLX_TTS_BIN` to point at a custom helper binary during development.

--- a/docs/platforms/ios.md
+++ b/docs/platforms/ios.md
@@ -267,6 +267,7 @@ openclaw nodes invoke --node "iOS Node" --command canvas.snapshot --params '{"ma
 ## Voice wake + talk mode
 
 - Voice wake and talk mode are available in Settings.
+- OpenAI realtime Talk uses client-owned WebRTC when `talk.realtime.transport` is `webrtc`; an explicit `gateway-relay` configuration remains Gateway-owned. See [Talk mode](/nodes/talk).
 - Talk-capable iOS nodes advertise the `talk` capability and can declare
   `talk.ptt.start`, `talk.ptt.stop`, `talk.ptt.cancel`, and `talk.ptt.once`;
   the Gateway allows those push-to-talk commands by default for trusted

--- a/docs/plugins/message-presentation.md
+++ b/docs/plugins/message-presentation.md
@@ -344,6 +344,26 @@ Fallback text includes:
 - button labels, including URLs for link buttons
 - select option labels
 
+### Button value fallback visibility
+
+When a channel cannot render interactive controls, button and select values
+fall back to plain text. The fallback behavior preserves usability while
+keeping opaque callback data private:
+
+- **`command`-typed actions** render as `label: \`command\`` so users can
+  copy the command and run it manually in the channel input.
+- **`callback`-typed actions** and legacy **`value`** fields render as
+  label-only. The opaque callback value is not exposed in fallback text.
+- **`url` / `webApp`** buttons render the URL text alongside the button
+  label, since the URL is user-facing.
+- **Select options** render as label-only. The underlying option value is not
+  exposed in fallback text.
+
+Channel adapters that add manual-command guidance in their fallback UI (e.g.
+Feishu document-comment instructions) must derive the command-present check
+from the same presentation blocks that the fallback renderer uses, so the
+guidance text only appears when a manual command is actually shown.
+
 Unsupported native controls should degrade rather than fail the whole send.
 Examples:
 

--- a/extensions/feishu/src/outbound.test.ts
+++ b/extensions/feishu/src/outbound.test.ts
@@ -843,13 +843,128 @@ describe("feishuOutbound.sendPayload native cards", () => {
       payload: {
         text: "Review this",
         interactive: {
-          blocks: [{ type: "buttons", buttons: [{ label: "Approve", value: "/approve req_1" }] }],
+          blocks: [
+            {
+              type: "buttons",
+              buttons: [
+                { label: "Approve", action: { type: "command", command: "/approve req_1" } },
+              ],
+            },
+          ],
         },
       },
     });
 
     expect(sendCardFeishuMock).not.toHaveBeenCalled();
-    expect(commentThreadParams()?.content).toBe("Review this\n\n- Approve");
+    expect(commentThreadParams()?.content).toBe(
+      "Review this\n\n- Approve: `/approve req_1`\n\n> Interactive buttons are unavailable in Feishu document comments. You can type the command shown above manually.",
+    );
+    expectFeishuResult(result, "reply_msg");
+  });
+
+  it("omits command guidance when all command buttons have URLs overriding the fallback text", async () => {
+    const result = await feishuOutbound.sendPayload?.({
+      cfg: emptyConfig,
+      to: "comment:docx:doxcn123:7623358762119646411",
+      text: "Review this",
+      accountId: "main",
+      payload: {
+        text: "Review this",
+        interactive: {
+          blocks: [
+            {
+              type: "buttons",
+              buttons: [
+                {
+                  label: "Open URL",
+                  url: "https://example.com/action",
+                  action: { type: "command", command: "/approve req_1" },
+                },
+              ],
+            },
+          ],
+        },
+      },
+    });
+
+    expect(commentThreadParams()?.content).toBe(
+      "Review this\n\n- Open URL: https://example.com/action",
+    );
+    expectFeishuResult(result, "reply_msg");
+  });
+
+  it("omits command guidance for disabled command buttons", async () => {
+    const result = await feishuOutbound.sendPayload?.({
+      cfg: emptyConfig,
+      to: "comment:docx:doxcn123:7623358762119646411",
+      text: "Review this",
+      accountId: "main",
+      payload: {
+        text: "Review this",
+        interactive: {
+          blocks: [
+            {
+              type: "buttons",
+              buttons: [
+                {
+                  label: "Disabled Approve",
+                  disabled: true,
+                  action: { type: "command", command: "/approve req_1" },
+                },
+              ],
+            },
+          ],
+        },
+      },
+    });
+
+    expect(commentThreadParams()?.content).toBe("Review this\n\n- Disabled Approve");
+    expectFeishuResult(result, "reply_msg");
+  });
+
+  it("adds command guidance when presentation is stripped but channelData carries the rendered-command marker", async () => {
+    // Core strips presentation before sendPayload; channelData retains the fact.
+    const result = await feishuOutbound.sendPayload?.({
+      cfg: emptyConfig,
+      to: "comment:docx:doxcn123:7623358762119646411",
+      text: "Review this",
+      accountId: "main",
+      payload: {
+        text: "Review this\n\n- Approve: `/approve req_1`",
+        channelData: {
+          feishu: {
+            card: { body: { elements: [{ tag: "hr" }] } },
+            fallbackHasCommand: true,
+          },
+        },
+      },
+    });
+
+    expect(sendCardFeishuMock).not.toHaveBeenCalled();
+    expect(commentThreadParams()?.content).toBe(
+      "Review this\n\n- Approve: `/approve req_1`\n\n> Interactive buttons are unavailable in Feishu document comments. You can type the command shown above manually.",
+    );
+    expectFeishuResult(result, "reply_msg");
+  });
+
+  it("ignores non-boolean fallback command markers", async () => {
+    const result = await feishuOutbound.sendPayload?.({
+      cfg: emptyConfig,
+      to: "comment:docx:doxcn123:7623358762119646411",
+      text: "Review this",
+      accountId: "main",
+      payload: {
+        text: "Review this",
+        channelData: {
+          feishu: {
+            card: { body: { elements: [{ tag: "hr" }] } },
+            fallbackHasCommand: "true",
+          },
+        },
+      },
+    });
+
+    expect(commentThreadParams()?.content).toBe("Review this");
     expectFeishuResult(result, "reply_msg");
   });
 });

--- a/extensions/feishu/src/outbound.ts
+++ b/extensions/feishu/src/outbound.ts
@@ -4,6 +4,7 @@ import {
   attachChannelToResult,
   createAttachedChannelResultAdapter,
 } from "openclaw/plugin-sdk/channel-send-result";
+import type { MessagePresentationBlock } from "openclaw/plugin-sdk/interactive-runtime";
 import {
   interactiveReplyToPresentation,
   normalizeInteractiveReply,
@@ -320,6 +321,27 @@ function buildFeishuPayloadCard(params: {
   });
 }
 
+// Keep this aligned with the shared fallback renderer: guidance is valid only
+// when the fallback text exposes a command the user can copy.
+function hasVisibleFallbackCommand(
+  blocks: readonly MessagePresentationBlock[] | undefined,
+): boolean {
+  return (
+    blocks?.some(
+      (block) =>
+        block.type === "buttons" &&
+        block.buttons.some(
+          (button) =>
+            !button.disabled &&
+            button.action?.type === "command" &&
+            !button.url &&
+            !button.webApp?.url &&
+            !button.web_app?.url,
+        ),
+    ) ?? false
+  );
+}
+
 function renderFeishuPresentationPayload({
   payload,
   presentation,
@@ -336,6 +358,8 @@ function renderFeishuPresentationPayload({
   const existingFeishuData = isRecord(payload.channelData?.feishu)
     ? payload.channelData.feishu
     : undefined;
+  // Core consumes presentation before sendPayload; carry the fallback fact.
+  const fallbackHasCommand = hasVisibleFallbackCommand(presentation?.blocks);
   return {
     ...payload,
     text: renderMessagePresentationFallbackText({ text: payload.text, presentation }),
@@ -344,6 +368,7 @@ function renderFeishuPresentationPayload({
       feishu: {
         ...existingFeishuData,
         card,
+        ...(fallbackHasCommand ? { fallbackHasCommand: true } : {}),
       },
     },
   };
@@ -505,21 +530,32 @@ export const feishuOutbound: ChannelOutboundAdapter = {
     });
     const commentTarget = parseFeishuCommentTarget(ctx.to);
     if (commentTarget) {
+      const normalizedPresentation =
+        normalizeMessagePresentation(ctx.payload.presentation) ??
+        (() => {
+          const interactive = normalizeInteractiveReply(ctx.payload.interactive);
+          return interactive ? interactiveReplyToPresentation(interactive) : undefined;
+        })();
+      const presentationFallbackText = renderMessagePresentationFallbackText({
+        text: ctx.payload.text,
+        presentation: normalizedPresentation,
+      });
+      // Direct delivery retains blocks; core-rendered delivery carries the fact.
+      const fallbackHasCommand =
+        hasVisibleFallbackCommand(normalizedPresentation?.blocks) ||
+        (isRecord(ctx.payload.channelData?.feishu) &&
+          ctx.payload.channelData.feishu.fallbackHasCommand === true);
+      const text = fallbackHasCommand
+        ? `${presentationFallbackText}\n\n> Interactive buttons are unavailable in Feishu document comments. You can type the command shown above manually.`
+        : presentationFallbackText;
+
       return await sendTextMediaPayload({
         channel: "feishu",
         ctx: {
           ...ctx,
           payload: {
             ...ctx.payload,
-            text: renderMessagePresentationFallbackText({
-              text: ctx.payload.text,
-              presentation:
-                normalizeMessagePresentation(ctx.payload.presentation) ??
-                (() => {
-                  const interactive = normalizeInteractiveReply(ctx.payload.interactive);
-                  return interactive ? interactiveReplyToPresentation(interactive) : undefined;
-                })(),
-            }),
+            text,
             interactive: undefined,
             presentation: undefined,
             channelData: undefined,

--- a/src/config/sessions/session-accessor.reply-init-concurrency.test.ts
+++ b/src/config/sessions/session-accessor.reply-init-concurrency.test.ts
@@ -84,7 +84,10 @@ async function waitForFile(filePath) {
 }
 
 async function writeJsonFile(filePath, value) {
-  await fs.writeFile(filePath, \`\${JSON.stringify(value, null, 2)}\\n\`, "utf8");
+  // The parent treats file existence as the readiness signal, so publish atomically.
+  const tempPath = filePath + "." + process.pid + ".tmp";
+  await fs.writeFile(tempPath, \`\${JSON.stringify(value, null, 2)}\\n\`, "utf8");
+  await fs.rename(tempPath, filePath);
 }
 
 const storePath = process.env.REPLY_INIT_STORE_PATH;
@@ -192,7 +195,6 @@ describe("reply session initialization concurrency", () => {
           stdio: ["ignore", "pipe", "pipe"],
         },
       );
-
       await waitForFile(readyPath);
       const snapshot = await readJsonFile<{ currentEntry?: unknown; revision: string }>(readyPath);
       expect(snapshot.revision).toBe(JSON.stringify({ sessionId: "existing-session" }));

--- a/src/gateway/server-methods/talk.test.ts
+++ b/src/gateway/server-methods/talk.test.ts
@@ -16,7 +16,9 @@ const mocks = vi.hoisted(() => ({
   getResolvedSpeechProviderConfig: vi.fn(() => ({})),
   resolveTtsConfig: vi.fn(() => ({ timeoutMs: 30_000 })),
   synthesizeSpeech: vi.fn(),
-  canonicalizeRealtimeVoiceProviderId: vi.fn((providerId: string | undefined) => providerId),
+  canonicalizeRealtimeVoiceProviderId: vi.fn((providerId: string | undefined) =>
+    providerId?.trim().toLowerCase(),
+  ),
   listRealtimeVoiceProviders: vi.fn(() => []),
   listRealtimeTranscriptionProviders: vi.fn(() => []),
   resolveConfiguredRealtimeVoiceProvider: vi.fn(),
@@ -417,6 +419,119 @@ describe("talk.speak handler", () => {
 describe("talk.config handler", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+  });
+
+  it("projects effective legacy realtime provider config for native routing", async () => {
+    const resolveConfig = vi.fn(
+      ({ rawConfig }: { rawConfig: Record<string, unknown> }): Record<string, unknown> => ({
+        ...rawConfig,
+        apiKey: normalizeResolvedSecretInputString({
+          value: rawConfig.apiKey,
+          path: "plugins.entries.voice-call.config.realtime.providers.openai.apiKey",
+        }),
+      }),
+    );
+    mocks.listRealtimeVoiceProviders.mockReturnValue([
+      {
+        id: "openai",
+        label: "OpenAI Realtime",
+        models: ["gpt-realtime"],
+        resolveConfig,
+        isConfigured: ({ providerConfig }: { providerConfig: Record<string, unknown> }) =>
+          providerConfig.apiKey === "runtime-azure-secret",
+      },
+    ] as never);
+    const sourceConfig = {
+      agents: {
+        defaults: {
+          voiceModel: { primary: "openai/gpt-realtime" },
+        },
+      },
+      talk: {
+        realtime: {
+          speakerVoice: "marin",
+          speakerVoiceId: "voice-id",
+        },
+      },
+      plugins: {
+        entries: {
+          "voice-call": {
+            config: {
+              realtime: {
+                providers: {
+                  " OpenAI ": {
+                    apiKey: {
+                      source: "env",
+                      provider: "default",
+                      id: "AZURE_OPENAI_API_KEY",
+                    },
+                    azureEndpoint: "https://example.openai.azure.com",
+                    azureDeployment: "realtime-prod",
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    } as OpenClawConfig;
+    const runtimeConfig = {
+      ...sourceConfig,
+      plugins: {
+        entries: {
+          "voice-call": {
+            config: {
+              realtime: {
+                providers: {
+                  " OpenAI ": {
+                    apiKey: "runtime-azure-secret",
+                    azureEndpoint: "https://example.openai.azure.com",
+                    azureDeployment: "realtime-prod",
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    } as OpenClawConfig;
+    mocks.readConfigFileSnapshot.mockResolvedValue({
+      path: "/tmp/openclaw.json",
+      hash: "test-hash",
+      valid: true,
+      config: sourceConfig,
+    });
+
+    const respond = vi.fn();
+    await talkHandlers["talk.config"]({
+      req: { type: "req", id: "1", method: "talk.config" },
+      params: {},
+      client: { connect: { scopes: ["operator.read"] } } as never,
+      isWebchatConnect: () => false,
+      respond: respond as never,
+      context: { getRuntimeConfig: () => runtimeConfig } as never,
+    });
+
+    const response = expectRespondOk(respond) as { config?: { talk?: Record<string, unknown> } };
+    const realtime = expectRecordFields(response.config?.talk?.realtime, {
+      provider: "openai",
+      model: "gpt-realtime",
+      speakerVoice: "marin",
+      speakerVoiceId: "voice-id",
+    });
+    const providers = realtime.providers as Record<string, unknown> | undefined;
+    expectRecordFields(providers?.openai, {
+      apiKey: {
+        source: "__OPENCLAW_REDACTED__",
+        provider: "__OPENCLAW_REDACTED__",
+        id: "__OPENCLAW_REDACTED__",
+      },
+      azureEndpoint: "https://example.openai.azure.com",
+      azureDeployment: "realtime-prod",
+    });
+    expect(resolveConfig).toHaveBeenCalledOnce();
+    expect(JSON.stringify(mockCallArg(resolveConfig))).toContain("runtime-azure-secret");
+    expect(JSON.stringify(response)).not.toContain("runtime-azure-secret");
   });
 
   it("passes runtime-resolved messages.tts provider secrets to strict provider resolvers", async () => {

--- a/src/gateway/server-methods/talk.ts
+++ b/src/gateway/server-methods/talk.ts
@@ -407,14 +407,44 @@ async function resolveTalkResponseFromConfig(params: {
   runtimeConfig: OpenClawConfig;
 }): Promise<TalkConfigResponse | undefined> {
   const normalizedTalk = normalizeTalkSection(params.sourceConfig.talk);
-  if (!normalizedTalk) {
+  const configuredPayload = normalizedTalk ? buildTalkConfigResponse(normalizedTalk) : undefined;
+  // Resolve provider selection from materialized config, but project provider-owned fields from
+  // source config so SecretRefs stay redacted. The requested provider also avoids re-resolving them.
+  const runtimeRealtime = buildTalkRealtimeConfig(params.runtimeConfig);
+  const effectiveProvider = canonicalizeRealtimeVoiceProviderId(
+    runtimeRealtime.provider,
+    params.runtimeConfig,
+  );
+  const sourceRealtime = buildTalkRealtimeConfig(params.sourceConfig, effectiveProvider);
+  const sourceProviders: Record<string, TalkProviderConfig> = {};
+  for (const [providerId, providerConfig] of Object.entries(sourceRealtime.providers)) {
+    const canonicalProviderId =
+      canonicalizeRealtimeVoiceProviderId(providerId, params.runtimeConfig) ?? providerId;
+    sourceProviders[canonicalProviderId] = {
+      ...sourceProviders[canonicalProviderId],
+      ...providerConfig,
+    };
+  }
+  const effectiveRealtime = normalizeTalkSection({
+    realtime: {
+      ...(effectiveProvider ? { provider: effectiveProvider } : {}),
+      ...(runtimeRealtime.model ? { model: runtimeRealtime.model } : {}),
+      ...(Object.keys(sourceProviders).length > 0 ? { providers: sourceProviders } : {}),
+    },
+  })?.realtime;
+  if (!configuredPayload && !effectiveRealtime) {
     return undefined;
   }
-
-  const sourcePayload = buildTalkConfigResponse(normalizedTalk);
-  if (!sourcePayload) {
-    return undefined;
-  }
+  const realtime: TalkRealtimeConfig | undefined = effectiveRealtime
+    ? {
+        ...configuredPayload?.realtime,
+        ...effectiveRealtime,
+      }
+    : configuredPayload?.realtime;
+  const sourcePayload: TalkConfigResponse = {
+    ...configuredPayload,
+    ...(realtime ? { realtime } : {}),
+  };
   const payload = params.includeSecrets
     ? projectTalkSourcePayloadForSecrets(sourcePayload)
     : sourcePayload;

--- a/src/interactive/payload.test.ts
+++ b/src/interactive/payload.test.ts
@@ -278,6 +278,39 @@ describe("interactive payload helpers", () => {
     });
   });
 
+  it("preserves command values in button fallback text while keeping callback values private", () => {
+    const presentation = {
+      blocks: [
+        {
+          type: "buttons" as const,
+          buttons: [
+            { label: "Approve", value: "/approve req_1 allow-once" },
+            { label: "Deny", action: { type: "command" as const, command: "/approve req_1 deny" } },
+            { label: "Ignore", action: { type: "callback" as const, value: "ignore_123" } },
+            { label: "Docs", url: "https://example.com/docs" },
+            { label: "Disabled", disabled: true },
+            {
+              label: "DisabledCmd",
+              disabled: true,
+              action: { type: "command" as const, command: "/test" },
+            },
+          ],
+        },
+      ],
+    };
+
+    expect(renderMessagePresentationFallbackText({ presentation })).toBe(
+      [
+        "- Approve",
+        "- Deny: `/approve req_1 deny`",
+        "- Ignore",
+        "- Docs: https://example.com/docs",
+        "- Disabled",
+        "- DisabledCmd",
+      ].join("\n"),
+    );
+  });
+
   it("keeps divider-only fallback empty unless a send transport fallback is requested", () => {
     const presentation = {
       blocks: [{ type: "divider" as const }],

--- a/src/interactive/payload.ts
+++ b/src/interactive/payload.ts
@@ -503,6 +503,21 @@ export function interactiveReplyToPresentation(
   return blocks.length > 0 ? { blocks } : undefined;
 }
 
+/**
+ * Render presentation blocks as plain-text fallback for channels that do not
+ * support native interactive controls.
+ *
+ * Text and context blocks are rendered as-is. Buttons with a `command`-typed
+ * action render as `label: \`command\`` so the value is copyable. Buttons with
+ * a `callback` action, legacy `value`, or `select` options render as label-only
+ * to keep opaque callback values private. Disabled buttons render as label-only
+ * regardless of action type, since they are not actionable.
+ *
+ * Downstream consumers should not claim a manual command is available unless
+ * they verify one was actually rendered.
+ *
+ * Exported through the plugin SDK for channel adapters.
+ */
 export function renderMessagePresentationFallbackText(params: {
   presentation?: MessagePresentation;
   emptyFallback?: string | null;
@@ -529,7 +544,17 @@ export function renderMessagePresentationFallbackText(params: {
       const labels = block.buttons
         .map((button) => {
           const targetUrl = button.url ?? button.webApp?.url ?? button.web_app?.url;
-          return targetUrl ? `${button.label}: ${targetUrl}` : button.label;
+          if (targetUrl) {
+            return `${button.label}: ${targetUrl}`;
+          }
+          const controlValue =
+            button.action?.type === "command"
+              ? resolveMessagePresentationControlValue(button)
+              : undefined;
+          if (controlValue && !button.disabled) {
+            return `${button.label}: \`${controlValue}\``;
+          }
+          return button.label;
         })
         .filter(Boolean);
       if (labels.length > 0) {


### PR DESCRIPTION
## What Problem This Solves

`device.permissions` could report Contacts or Calendar as granted when Android had only granted the read half of the permission pair. The actual contact and calendar add flows require write access, and the onboarding/settings permission rows request both read and write, so the device status payload could overstate what the app can do.

## Why This Change Was Made

This updates the Android device permission payload to require both read and write grants before reporting the combined Contacts or Calendar capability as granted. It also adds Robolectric regression coverage for the read-only and read+write cases for both permission rows.

## User Impact

Third-party onboarding and permission diagnostics now match the write-backed commands. Users should no longer see Contacts or Calendar as authorized while add-style actions still fail because the write permission is missing.

## Evidence

- `git diff --check`
- `cd apps/android && ./gradlew :app:testThirdPartyDebugUnitTest --tests ai.openclaw.app.node.DeviceHandlerTest`
- `cd apps/android && ./gradlew :app:testPlayDebugUnitTest --tests ai.openclaw.app.node.DeviceHandlerTest`
- `.agents/skills/autoreview/scripts/autoreview --mode local` -> clean, no accepted/actionable findings

AI-assisted: yes
