### PR TITLE
fix #99174: classify structured invalid request failover

### DIFF
--- a/src/agents/embedded-agent-helpers.isbillingerrormessage.test.ts
+++ b/src/agents/embedded-agent-helpers.isbillingerrormessage.test.ts
@@ -1289,6 +1289,11 @@ describe("classifyFailoverReason provider messages", () => {
     expect(classifyFailoverReason("string should match pattern")).toBe("format");
     expect(
       classifyFailoverReason(
+        '{"type":"error","error":{"type":"invalid_request_error","message":"messages.27.content.1: thinking or redacted_thinking blocks in the latest assistant message cannot be modified."}}',
+      ),
+    ).toBe("format");
+    expect(
+      classifyFailoverReason(
         "This model does not support assistant message prefill. The conversation must end with a user message.",
       ),
     ).toBe("format");
@@ -1302,6 +1307,21 @@ describe("classifyFailoverReason provider messages", () => {
         "messages.84.content.1.image.source.base64.data: At least one of the image dimensions exceed max allowed size for many-image requests: 2000 pixels",
       ),
     ).toBeNull();
+    expect(
+      classifyFailoverReason(
+        '{"type":"error","error":{"type":"invalid_request_error","message":"Request size exceeds model context window"}}',
+      ),
+    ).toBe("context_overflow");
+    expect(
+      classifyFailoverReason(
+        '{"type":"error","error":{"type":"invalid_request_error","message":"invalid api key"}}',
+      ),
+    ).toBe("auth");
+    expect(
+      classifyFailoverReason(
+        '{"type":"error","error":{"type":"invalid_request_error","message":"Your account has insufficient quota balance to run this request."}}',
+      ),
+    ).toBe("billing");
     expect(classifyFailoverReason("image exceeds 5 MB maximum")).toBeNull();
   });
   it("classifies OpenAI usage limit errors as rate_limit", () => {

--- a/src/agents/embedded-agent-helpers/errors.ts
+++ b/src/agents/embedded-agent-helpers/errors.ts
@@ -595,7 +595,12 @@ function isSandboxBlockedErrorMessage(raw: string): boolean {
 }
 
 function isSchemaErrorMessage(raw: string): boolean {
-  if (!raw || isReplayInvalidErrorMessage(raw) || isContextOverflowError(raw)) {
+  if (
+    !raw ||
+    isReplayInvalidErrorMessage(raw) ||
+    isContextOverflowError(raw) ||
+    isStructuredInvalidRequestApiError(raw)
+  ) {
     return false;
   }
   return classifyFailoverReason(raw) === "format" || matchesFormatErrorPattern(raw);
@@ -1024,6 +1029,11 @@ function isExactUnknownNoDetailsError(raw: string): boolean {
   );
 }
 
+function isStructuredInvalidRequestApiError(raw: string): boolean {
+  const type = normalizeOptionalLowercaseString(parseApiErrorInfo(raw)?.type);
+  return Boolean(type && type.includes("invalid_request"));
+}
+
 function classifyFailoverClassificationFromMessage(
   raw: string,
   provider?: string,
@@ -1111,6 +1121,9 @@ function classifyFailoverClassificationFromMessage(
     return toReasonClassification("timeout");
   }
   if (isCloudCodeAssistFormatError(raw)) {
+    return toReasonClassification("format");
+  }
+  if (isStructuredInvalidRequestApiError(raw)) {
     return toReasonClassification("format");
   }
   if (isExactUnknownNoDetailsError(raw)) {
@@ -1765,7 +1778,10 @@ export function isImageSizeError(errorMessage?: string): boolean {
 }
 
 export function isCloudCodeAssistFormatError(raw: string): boolean {
-  return !isImageDimensionErrorMessage(raw) && matchesFormatErrorPattern(raw);
+  return (
+    !isImageDimensionErrorMessage(raw) &&
+    (matchesFormatErrorPattern(raw) || isStructuredInvalidRequestApiError(raw))
+  );
 }
 
 export function isAuthAssistantError(msg: AssistantMessage | undefined): boolean {

--- a/src/agents/embedded-agent-runner/run/assistant-failover.test.ts
+++ b/src/agents/embedded-agent-runner/run/assistant-failover.test.ts
@@ -707,6 +707,28 @@ describe("handleAssistantFailover", () => {
       expect(logDecision).toHaveBeenCalledWith("fallback_model", { status: 408 });
     });
 
+    it("throws format FailoverError for structured invalid-request fallback handoff", async () => {
+      const logDecision = vi.fn();
+      const outcome = await handleAssistantFailover(
+        makeParams({
+          initialDecision: { action: "fallback_model", reason: "format" },
+          fallbackConfigured: true,
+          failoverReason: "format",
+          billingFailure: false,
+          cloudCodeAssistFormatError: true,
+          lastAssistant: {
+            errorMessage: `{"type":"error","error":{"type":"invalid_request_error","message":"messages.27.content.1: thinking or redacted_thinking blocks in the latest assistant message cannot be modified."}}`,
+          } as Params["lastAssistant"],
+          logAssistantFailoverDecision: logDecision,
+        }),
+      );
+
+      const err = expectThrownFailoverError(outcome);
+      expect(err.reason).toBe("format");
+      expect(err.status).toBe(400);
+      expect(logDecision).toHaveBeenCalledWith("fallback_model", { status: 400 });
+    });
+
     it("still throws a FailoverError after the surface_error refactor", async () => {
       const logDecision = vi.fn();
       const outcome = await handleAssistantFailover(

--- a/src/agents/embedded-agent-runner/run/failover-policy.test.ts
+++ b/src/agents/embedded-agent-runner/run/failover-policy.test.ts
@@ -195,6 +195,49 @@ describe("resolveRunFailoverDecision", () => {
     });
   });
 
+  it("falls back for explicitly retryable assistant format failures after rotation is exhausted", () => {
+    const assistantError = {
+      role: "assistant" as const,
+      api: "openai-completions" as const,
+      provider: "Anthropic",
+      model: "claude-haiku-4-5-20251001",
+      usage: {
+        input: 0,
+        output: 0,
+        cacheRead: 0,
+        cacheWrite: 0,
+        totalTokens: 0,
+        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+      },
+      stopReason: "error" as const,
+      errorMessage: `{"type":"error","error":{"type":"invalid_request_error","message":"messages.27.content.1: thinking or redacted_thinking blocks in the latest assistant message cannot be modified."}}`,
+      content: [],
+      timestamp: 0,
+    };
+    const failoverReason = classifyAssistantFailoverReason(assistantError);
+
+    expect(failoverReason).toBe("format");
+    expect(
+      resolveRunFailoverDecision({
+        stage: "assistant",
+        allowFormatRetry: true,
+        aborted: false,
+        externalAbort: false,
+        fallbackConfigured: true,
+        failoverFailure: failoverReason !== null,
+        failoverReason,
+        timedOut: false,
+        idleTimedOut: false,
+        timedOutDuringCompaction: false,
+        timedOutDuringToolExecution: false,
+        profileRotated: true,
+      }),
+    ).toEqual({
+      action: "fallback_model",
+      reason: "format",
+    });
+  });
+
   it("falls back after assistant rotation is exhausted", () => {
     expect(
       resolveRunFailoverDecision({


### PR DESCRIPTION
## What Problem This Solves

Anthropic-compatible providers can return unprefixed JSON 400 bodies like `{"type":"error","error":{"type":"invalid_request_error",...}}`. The failover classifier previously relied on a leading HTTP status or other message patterns, so these schema rejection bodies classified as `null` and the configured fallback chain was skipped.

## Summary

- classify structured API error payloads with `invalid_request*` types as format failover errors when no leading HTTP status is present
- treat those structured provider format rejections as replayable so profile rotation can exhaust and the configured model fallback chain can advance
- preserve higher-priority context overflow/auth/billing classifications for the same payload shape
- keep internal assistant error formatting detailed while user-facing text remains generic/safe

Fixes #99174.

## Evidence

Runtime fallback proof added in this PR:

- `src/agents/embedded-agent-runner/run/failover-policy.test.ts`: structured `invalid_request_error` assistant payload classifies as `format` and resolves to `{ action: "fallback_model", reason: "format" }` after profile rotation is exhausted.
- `src/agents/embedded-agent-runner/run/assistant-failover.test.ts`: the assistant failover handler throws a `FailoverError` with `reason: "format"`, `status: 400`, and logs `fallback_model` for the same structured payload.

Validation run locally after the fallback proof update:

- `node scripts/run-vitest.mjs src/agents/embedded-agent-helpers.isbillingerrormessage.test.ts src/agents/embedded-agent-runner/run/failover-policy.test.ts src/agents/embedded-agent-runner/run/assistant-failover.test.ts --reporter=verbose` — passed 2 shards, 210 tests (183 + 27)
- `OPENCLAW_OXLINT_SKIP_PREPARE=1 node scripts/run-oxlint.mjs src/agents/embedded-agent-helpers/errors.ts src/agents/embedded-agent-runner/run/failover-policy.test.ts src/agents/embedded-agent-runner/run/assistant-failover.test.ts` — passed
- `node_modules/.bin/oxfmt --check --threads=1 src/agents/embedded-agent-helpers/errors.ts src/agents/embedded-agent-runner/run/failover-policy.test.ts src/agents/embedded-agent-runner/run/assistant-failover.test.ts` — passed
- `node scripts/run-tsgo.mjs -p test/tsconfig/tsconfig.core.test.non-agents.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/core-test-non-agents.tsbuildinfo` — passed
- `git diff --check` — passed

Note: the normal oxlint wrapper was previously attempted, but its package-boundary artifact preparation timed out locally while generating plugin-sdk boundary root shims. The targeted oxlint invocation above skips that preparation step and validates the changed files directly.
