### PR TITLE
test: cover Android discovery and foreground startup gates

### DIFF
--- a/apps/.i18n/native-source.json
+++ b/apps/.i18n/native-source.json
@@ -11,7 +11,7 @@
     },
     {
       "kind": "ui-state-text",
-      "line": 99,
+      "line": 104,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/MainViewModel.kt",
       "source": "Searching…",
       "surface": "android",
@@ -19,7 +19,7 @@
     },
     {
       "kind": "ui-state-text",
-      "line": 184,
+      "line": 189,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/MainViewModel.kt",
       "source": "Mic off",
       "surface": "android",
@@ -27,7 +27,7 @@
     },
     {
       "kind": "ui-state-text",
-      "line": 194,
+      "line": 199,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/MainViewModel.kt",
       "source": "Off",
       "surface": "android",
@@ -251,7 +251,7 @@
     },
     {
       "kind": "ui-state-text",
-      "line": 76,
+      "line": 96,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/gateway/GatewayDiscovery.kt",
       "source": "Searching…",
       "surface": "android",

--- a/apps/android/app/src/main/java/ai/openclaw/app/MainViewModel.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/MainViewModel.kt
@@ -26,6 +26,11 @@ import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 
+internal fun shouldStartRuntimeOnForeground(
+  foreground: Boolean,
+  onboardingCompleted: Boolean,
+): Boolean = foreground && onboardingCompleted
+
 /**
  * UI-facing bridge that exposes NodeRuntime and preference state as Compose-friendly StateFlows.
  */
@@ -237,7 +242,12 @@ class MainViewModel(
    */
   fun setForeground(value: Boolean) {
     foreground = value
-    if (value && prefs.onboardingCompleted.value) {
+    if (
+      shouldStartRuntimeOnForeground(
+        foreground = value,
+        onboardingCompleted = prefs.onboardingCompleted.value,
+      )
+    ) {
       queueRuntimeStartup()
     }
     runtimeRef.value?.setForeground(value)

--- a/apps/android/app/src/main/java/ai/openclaw/app/gateway/GatewayDiscovery.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/gateway/GatewayDiscovery.kt
@@ -52,6 +52,26 @@ import kotlin.coroutines.resumeWithException
 @Suppress("DEPRECATION")
 private fun createDnsResolver(): DnsResolver = DnsResolver.getInstance()
 
+internal fun gatewayDiscoveryStatusText(
+  localCount: Int,
+  wideAreaRcode: Int?,
+  wideAreaCount: Int,
+): String {
+  val wide =
+    when (wideAreaRcode) {
+      null -> "Wide: ?"
+      Rcode.NOERROR -> "Wide: $wideAreaCount"
+      Rcode.NXDOMAIN -> "Wide: NXDOMAIN"
+      else -> "Wide: ${Rcode.string(wideAreaRcode)}"
+    }
+
+  return when {
+    localCount == 0 && wideAreaRcode == null -> "Searching for gateways…"
+    localCount == 0 -> wide
+    else -> "Local: $localCount • $wide"
+  }
+}
+
 /**
  * Watches local DNS-SD and optional wide-area DNS-SD for reachable OpenClaw gateways.
  */
@@ -300,23 +320,11 @@ class GatewayDiscovery(
   }
 
   private fun buildStatusText(): String {
-    val localCount = localById.size
-    val wideRcode = lastWideAreaRcode
-    val wideCount = lastWideAreaCount
-
-    val wide =
-      when (wideRcode) {
-        null -> "Wide: ?"
-        Rcode.NOERROR -> "Wide: $wideCount"
-        Rcode.NXDOMAIN -> "Wide: NXDOMAIN"
-        else -> "Wide: ${Rcode.string(wideRcode)}"
-      }
-
-    return when {
-      localCount == 0 && wideRcode == null -> "Searching for gateways…"
-      localCount == 0 -> "$wide"
-      else -> "Local: $localCount • $wide"
-    }
+    return gatewayDiscoveryStatusText(
+      localCount = localById.size,
+      wideAreaRcode = lastWideAreaRcode,
+      wideAreaCount = lastWideAreaCount,
+    )
   }
 
   private fun stableId(

--- a/apps/android/app/src/test/java/ai/openclaw/app/MainViewModelTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/MainViewModelTest.kt
@@ -1,0 +1,62 @@
+package ai.openclaw.app
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.RuntimeEnvironment
+import org.robolectric.annotation.Config
+
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [34])
+class MainViewModelTest {
+  @Test
+  fun setForegroundDoesNotStartRuntimeBeforeOnboardingCompletes() {
+    val app = appContext()
+    app.prefs.setOnboardingCompleted(false)
+    val viewModel = MainViewModel(app)
+
+    viewModel.setForeground(true)
+
+    assertFalse(viewModel.runtimeInitialized.value)
+    assertNull(app.peekRuntime())
+  }
+
+  @Test
+  fun setForegroundDoesNotStartRuntimeWhileActivityIsStopped() {
+    val app = appContext()
+    app.prefs.setOnboardingCompleted(true)
+    val viewModel = MainViewModel(app)
+
+    viewModel.setForeground(false)
+
+    assertFalse(viewModel.runtimeInitialized.value)
+    assertNull(app.peekRuntime())
+  }
+
+  @Test
+  fun foregroundStartupRequiresForegroundAndCompletedOnboarding() {
+    assertFalse(
+      shouldStartRuntimeOnForeground(
+        foreground = false,
+        onboardingCompleted = true,
+      ),
+    )
+    assertFalse(
+      shouldStartRuntimeOnForeground(
+        foreground = true,
+        onboardingCompleted = false,
+      ),
+    )
+    assertTrue(
+      shouldStartRuntimeOnForeground(
+        foreground = true,
+        onboardingCompleted = true,
+      ),
+    )
+  }
+
+  private fun appContext(): NodeApp = RuntimeEnvironment.getApplication() as NodeApp
+}

--- a/apps/android/app/src/test/java/ai/openclaw/app/gateway/GatewayDiscoveryTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/gateway/GatewayDiscoveryTest.kt
@@ -1,0 +1,68 @@
+package ai.openclaw.app.gateway
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import org.xbill.DNS.Rcode
+
+class GatewayDiscoveryTest {
+  @Test
+  fun statusTextFormatsLocalAndWideAreaDiscoveryStates() {
+    val cases =
+      listOf(
+        StatusCase(
+          localCount = 0,
+          wideAreaRcode = null,
+          wideAreaCount = 0,
+          expected = "Searching for gateways…",
+        ),
+        StatusCase(
+          localCount = 0,
+          wideAreaRcode = Rcode.NOERROR,
+          wideAreaCount = 2,
+          expected = "Wide: 2",
+        ),
+        StatusCase(
+          localCount = 1,
+          wideAreaRcode = Rcode.NOERROR,
+          wideAreaCount = 2,
+          expected = "Local: 1 • Wide: 2",
+        ),
+        StatusCase(
+          localCount = 1,
+          wideAreaRcode = null,
+          wideAreaCount = 0,
+          expected = "Local: 1 • Wide: ?",
+        ),
+        StatusCase(
+          localCount = 0,
+          wideAreaRcode = Rcode.NXDOMAIN,
+          wideAreaCount = 0,
+          expected = "Wide: NXDOMAIN",
+        ),
+        StatusCase(
+          localCount = 2,
+          wideAreaRcode = Rcode.SERVFAIL,
+          wideAreaCount = 0,
+          expected = "Local: 2 • Wide: SERVFAIL",
+        ),
+      )
+
+    for (case in cases) {
+      assertEquals(
+        case.expected,
+        gatewayDiscoveryStatusText(
+          localCount = case.localCount,
+          wideAreaRcode = case.wideAreaRcode,
+          wideAreaCount = case.wideAreaCount,
+        ),
+      )
+    }
+  }
+}
+
+private data class StatusCase(
+  val localCount: Int,
+  val wideAreaRcode: Int?,
+  val wideAreaCount: Int,
+  val expected: String,
+)


### PR DESCRIPTION
## What Problem This Solves

Android gateway discovery and runtime startup had sparse focused unit coverage. `GatewayDiscovery` formatted user-visible local/wide-area discovery status from private instance state, and `MainViewModel.setForeground` is the gate that MainActivity drives from foreground/background lifecycle events before runtime startup.

## Why This Change Was Made

This extracts the existing discovery status formatting and foreground startup predicate into package-internal pure helpers, then adds focused tests around the urgent states:

- `GatewayDiscoveryTest` covers searching, local-only, wide-area success, NXDOMAIN, and SERVFAIL status text.
- `MainViewModelTest` covers the startup predicate and verifies `setForeground` does not create the runtime before onboarding completes or while the Activity is stopped.
- `apps/.i18n/native-source.json` is synchronized so the native i18n inventory gate matches the moved Android string sources.

This keeps the Android tests stable and narrow while avoiding a heavier Compose Activity or Android NSD harness in this PR. The branch is rebased on the upstream reply-init fixture stabilization from #99212 instead of carrying a duplicate core-test patch.

## User Impact

Future Android changes are less likely to regress the connect UI's discovery diagnostics or accidentally start the node runtime before onboarding/foreground conditions are met.

## Evidence

Local focused proof, rerun July 3, 2026 on branch head `c605dc776640`:

```text
$ git diff --check upstream/main...HEAD
git diff --check upstream/main...HEAD exit=0

$ node --import tsx scripts/native-app-i18n.ts check
native-app-i18n: entries=2359 changed=false

$ cd apps/android && ./gradlew :app:testThirdPartyDebugUnitTest --tests ai.openclaw.app.gateway.GatewayDiscoveryTest --tests ai.openclaw.app.MainViewModelTest --console=plain --no-daemon -Dorg.gradle.java.home=$JAVA_HOME
> Task :app:testThirdPartyDebugUnitTest
BUILD SUCCESSFUL in 11s
30 actionable tasks: 6 executed, 24 up-to-date

$ cd apps/android && ./gradlew :app:testPlayDebugUnitTest --tests ai.openclaw.app.gateway.GatewayDiscoveryTest --tests ai.openclaw.app.MainViewModelTest --console=plain --no-daemon -Dorg.gradle.java.home=$JAVA_HOME
> Task :app:testPlayDebugUnitTest
BUILD SUCCESSFUL in 11s
30 actionable tasks: 6 executed, 24 up-to-date
```

Live CI proof for this head:

- `gh pr checks 99206`: 62 pass, 19 skipping, 0 fail, 0 pending.
- `android-test-third-party`: pass, https://github.com/openclaw/openclaw/actions/runs/28616797157/job/84862625794
- `android-test-play`: pass, https://github.com/openclaw/openclaw/actions/runs/28616797157/job/84862625793
- `android-build-play`: pass, https://github.com/openclaw/openclaw/actions/runs/28616797157/job/84862625792
- `native-i18n`: pass, https://github.com/openclaw/openclaw/actions/runs/28616797157/job/84862625727
- `QA Smoke CI`: pass, https://github.com/openclaw/openclaw/actions/runs/28616797157/job/84862625735
- `checks-node-compact-small-whole-2`: pass, https://github.com/openclaw/openclaw/actions/runs/28616797157/job/84862626083

Code-path proof:

- `MainActivity` still drives the foreground path through `MainViewModel.setForeground` from `onStart`, `onStop`, and ViewModel activation; the tests cover the extracted foreground-start predicate used by that path.
- `GatewayDiscovery.buildStatusText()` now delegates to `gatewayDiscoveryStatusText`, and the tests cover searching, local-only, wide-area success, NXDOMAIN, and SERVFAIL status rendering.
- `.agents/skills/autoreview/scripts/autoreview --mode local` was clean with no accepted/actionable findings before push.

AI-assisted: yes
