### PR TITLE
Expose legacy cron store doctor lint findings

### DIFF
--- a/scripts/check-kysely-guardrails.mjs
+++ b/scripts/check-kysely-guardrails.mjs
@@ -49,6 +49,7 @@ const rawSqliteAllowPathGroups = {
   "agent auth profile read-only bootstrap": ["src/agents/auth-profiles/sqlite.ts"],
   "read-only SQLite status probes": ["src/commands/status.scan.shared.ts"],
   "doctor legacy state migration": [
+    "src/commands/doctor/cron/migration-ledger.ts",
     "src/infra/state-migrations.ts",
     "src/infra/state-migrations.debug-proxy.ts",
   ],

--- a/src/commands/doctor/cron/index.test.ts
+++ b/src/commands/doctor/cron/index.test.ts
@@ -14,6 +14,7 @@ import {
   saveCronStore,
 } from "../../../cron/store.js";
 import { runOpenClawStateWriteTransaction } from "../../../state/openclaw-state-db.js";
+import { resolveOpenClawStateSqlitePath } from "../../../state/openclaw-state-db.paths.js";
 import { withRestoredMocks } from "../../../test-utils/vitest-spies.js";
 import {
   collectLegacyCronStoreHealthFindings,
@@ -39,6 +40,7 @@ async function makeTempStorePath() {
 }
 
 afterEach(async () => {
+  vi.unstubAllEnvs();
   noteMock.mockClear();
   if (tempRoot) {
     await fs.rm(tempRoot, { recursive: true, force: true });
@@ -301,6 +303,37 @@ describe("collectLegacyCronStoreHealthFindings", () => {
 });
 
 describe("collectLegacyCronStoreRepairEffects", () => {
+  it("does not create the shared state database while previewing legacy cron state", async () => {
+    const storePath = await makeTempStorePath();
+    const stateDir = path.join(path.dirname(storePath), "state-root");
+    vi.stubEnv("OPENCLAW_STATE_DIR", stateDir);
+    const stateDbPath = resolveOpenClawStateSqlitePath({ OPENCLAW_STATE_DIR: stateDir });
+    await writeLegacyCronArrayStore(storePath, [createLegacyCronJob()]);
+
+    await expect(
+      collectLegacyCronStoreHealthFindings({ cfg: createCronConfig(storePath) }),
+    ).resolves.toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          checkId: "core/doctor/legacy-cron-store",
+          requirement: "legacy-cron-store",
+        }),
+      ]),
+    );
+    await expect(
+      collectLegacyCronStoreRepairEffects({ cfg: createCronConfig(storePath) }),
+    ).resolves.toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          action: "would-migrate-legacy-cron-store",
+          target: storePath,
+        }),
+      ]),
+    );
+
+    expect(fsSync.existsSync(stateDbPath)).toBe(false);
+  });
+
   it("previews legacy cron store repair effects without mutating files", async () => {
     const storePath = await makeTempStorePath();
     await writeLegacyCronArrayStore(storePath, [

--- a/src/commands/doctor/cron/index.test.ts
+++ b/src/commands/doctor/cron/index.test.ts
@@ -17,6 +17,7 @@ import { runOpenClawStateWriteTransaction } from "../../../state/openclaw-state-
 import { withRestoredMocks } from "../../../test-utils/vitest-spies.js";
 import {
   collectLegacyCronStoreHealthFindings,
+  collectLegacyCronStoreRepairEffects,
   collectLegacyWhatsAppCrontabHealthWarning,
   maybeRepairLegacyCronStore,
   noteLegacyWhatsAppCrontabHealthCheck,
@@ -295,6 +296,115 @@ describe("collectLegacyCronStoreHealthFindings", () => {
 
     await expect(
       collectLegacyCronStoreHealthFindings({ cfg: createCronConfig(storePath) }),
+    ).resolves.toEqual([]);
+  });
+});
+
+describe("collectLegacyCronStoreRepairEffects", () => {
+  it("previews legacy cron store repair effects without mutating files", async () => {
+    const storePath = await makeTempStorePath();
+    await writeLegacyCronArrayStore(storePath, [
+      createLegacyCronJob({
+        jobId: "legacy-notify",
+        payload: {
+          kind: "systemEvent",
+          text: "Morning brief",
+        },
+      }),
+    ]);
+    const runLogPath = path.join(path.dirname(storePath), "runs", "legacy-notify.jsonl");
+    await fs.mkdir(path.dirname(runLogPath), { recursive: true });
+    await fs.writeFile(runLogPath, "", "utf-8");
+
+    const effects = await collectLegacyCronStoreRepairEffects({
+      cfg: createCronConfig(storePath),
+    });
+
+    expect(effects).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          kind: "state",
+          action: "would-migrate-legacy-cron-store",
+          target: storePath,
+          dryRunSafe: false,
+        }),
+        expect.objectContaining({
+          kind: "state",
+          action: "would-import-legacy-cron-run-logs",
+          target: path.join(path.dirname(storePath), "runs"),
+          dryRunSafe: false,
+        }),
+        expect.objectContaining({
+          kind: "state",
+          action: "would-normalize-cron-store",
+          target: storePath,
+          dryRunSafe: false,
+        }),
+        expect.objectContaining({
+          kind: "state",
+          action: "would-migrate-legacy-cron-notify-fallback",
+          target: storePath,
+          dryRunSafe: false,
+        }),
+      ]),
+    );
+    await expect(fs.readFile(storePath, "utf-8")).resolves.toContain("legacy-notify");
+    await expect(fs.stat(runLogPath)).resolves.toBeDefined();
+  });
+
+  it("previews quarantine and dreaming payload rewrite effects", async () => {
+    const storePath = await makeTempStorePath();
+    await writeCronStore(storePath, [
+      { id: "invalid-cron", name: "Invalid cron", payload: { kind: "systemEvent" } },
+      {
+        id: "memory-dreaming",
+        name: "Memory Dreaming Promotion",
+        description:
+          "[managed-by=memory-core.short-term-promotion] Promote weighted short-term recalls.",
+        enabled: true,
+        createdAtMs: Date.parse("2026-04-01T00:00:00.000Z"),
+        updatedAtMs: Date.parse("2026-04-01T00:00:00.000Z"),
+        schedule: { kind: "cron", expr: "0 3 * * *", tz: "UTC" },
+        sessionTarget: "main",
+        wakeMode: "now",
+        payload: {
+          kind: "systemEvent",
+          text: "__openclaw_memory_core_short_term_promotion_dream__",
+        },
+        state: {},
+      },
+    ]);
+
+    const effects = await collectLegacyCronStoreRepairEffects({
+      cfg: createCronConfig(storePath),
+    });
+
+    expect(effects).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          action: "would-quarantine-invalid-cron-jobs",
+          target: resolveCronQuarantinePath(storePath),
+        }),
+        expect.objectContaining({
+          action: "would-normalize-cron-store",
+          target: storePath,
+        }),
+        expect.objectContaining({
+          action: "would-rewrite-legacy-dreaming-cron-payload",
+          target: storePath,
+        }),
+      ]),
+    );
+    await expect(fs.readFile(storePath, "utf-8")).resolves.toContain("invalid-cron");
+    await expect(fs.readFile(storePath, "utf-8")).resolves.toContain("memory-dreaming");
+  });
+
+  it("returns no repair effects for an already-normalized empty cron store", async () => {
+    const storePath = await makeTempStorePath();
+    await writeCurrentCronStore(storePath, []);
+
+    await expect(
+      collectLegacyCronStoreRepairEffects({ cfg: createCronConfig(storePath) }),
     ).resolves.toEqual([]);
   });
 });

--- a/src/commands/doctor/cron/index.test.ts
+++ b/src/commands/doctor/cron/index.test.ts
@@ -16,6 +16,7 @@ import {
 import { runOpenClawStateWriteTransaction } from "../../../state/openclaw-state-db.js";
 import { withRestoredMocks } from "../../../test-utils/vitest-spies.js";
 import {
+  collectLegacyCronStoreHealthFindings,
   collectLegacyWhatsAppCrontabHealthWarning,
   maybeRepairLegacyCronStore,
   noteLegacyWhatsAppCrontabHealthCheck,
@@ -208,6 +209,95 @@ function mockExdevRename(filePath: string) {
     return await realRename(oldPath, newPath);
   });
 }
+
+describe("collectLegacyCronStoreHealthFindings", () => {
+  it("reports legacy cron store, run-log, and payload findings without mutating files", async () => {
+    const storePath = await makeTempStorePath();
+    await writeLegacyCronArrayStore(storePath, [
+      createLegacyCronJob({
+        jobId: "legacy-notify",
+        payload: {
+          kind: "systemEvent",
+          text: "Morning brief",
+        },
+      }),
+    ]);
+    const runLogPath = path.join(path.dirname(storePath), "runs", "legacy-notify.jsonl");
+    await fs.mkdir(path.dirname(runLogPath), { recursive: true });
+    await fs.writeFile(runLogPath, "", "utf-8");
+
+    const findings = await collectLegacyCronStoreHealthFindings({
+      cfg: createCronConfig(storePath),
+    });
+
+    expect(findings).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          checkId: "core/doctor/legacy-cron-store",
+          severity: "warning",
+          path: storePath,
+          requirement: "legacy-cron-store",
+        }),
+        expect.objectContaining({
+          checkId: "core/doctor/legacy-cron-store",
+          severity: "warning",
+          path: storePath,
+          requirement: "legacy-notify-fallback",
+        }),
+      ]),
+    );
+    expect(findings.some((finding) => finding.requirement === "legacy-cron-run-logs")).toBe(true);
+    await expect(fs.readFile(storePath, "utf-8")).resolves.toContain("legacy-notify");
+    await expect(fs.stat(runLogPath)).resolves.toBeDefined();
+  });
+
+  it("reports quarantined cron rows while leaving the active store untouched", async () => {
+    const storePath = await makeTempStorePath();
+    await writeCurrentCronStore(storePath, []);
+    await fs.mkdir(path.dirname(resolveCronQuarantinePath(storePath)), { recursive: true });
+    await fs.writeFile(
+      resolveCronQuarantinePath(storePath),
+      JSON.stringify(
+        {
+          version: 1,
+          jobs: [
+            {
+              quarantinedAtMs: Date.parse("2026-05-29T09:00:00.000Z"),
+              sourceIndex: 1,
+              reason: "missing-schedule",
+              job: { id: "bad-cron", name: "Bad cron" },
+            },
+          ],
+        },
+        null,
+        2,
+      ),
+      "utf-8",
+    );
+
+    const findings = await collectLegacyCronStoreHealthFindings({
+      cfg: createCronConfig(storePath),
+    });
+
+    expect(findings).toEqual([
+      expect.objectContaining({
+        checkId: "core/doctor/legacy-cron-store",
+        path: resolveCronQuarantinePath(storePath),
+        requirement: "quarantined-cron-rows",
+      }),
+    ]);
+    await expect(readPersistedJobs(storePath)).resolves.toEqual([]);
+  });
+
+  it("returns no findings for an already-normalized empty cron store", async () => {
+    const storePath = await makeTempStorePath();
+    await writeCurrentCronStore(storePath, []);
+
+    await expect(
+      collectLegacyCronStoreHealthFindings({ cfg: createCronConfig(storePath) }),
+    ).resolves.toEqual([]);
+  });
+});
 
 describe("maybeRepairLegacyCronStore", () => {
   it("reports quarantined cron rows even when the active store is already sanitized", async () => {
@@ -555,7 +645,9 @@ describe("maybeRepairLegacyCronStore", () => {
       await expect(fs.stat(storePath)).rejects.toMatchObject({ code: "ENOENT" });
       await expect(fs.readFile(archivePath, "utf-8")).resolves.toContain("legacy-job");
       const archiveStat = await fs.stat(archivePath);
-      expect(archiveStat.mode & 0o777).toBe(0o640);
+      if (process.platform !== "win32") {
+        expect(archiveStat.mode & 0o777).toBe(0o640);
+      }
       expect(archiveStat.mtimeMs).toBe(sourceMtime.getTime());
       expectNoteContaining("Cron store migrated to SQLite", "Doctor changes");
       expectNoNoteContaining("could not archive the legacy cron file", "Doctor warnings");

--- a/src/commands/doctor/cron/index.test.ts
+++ b/src/commands/doctor/cron/index.test.ts
@@ -14,11 +14,9 @@ import {
   saveCronStore,
 } from "../../../cron/store.js";
 import { runOpenClawStateWriteTransaction } from "../../../state/openclaw-state-db.js";
-import { resolveOpenClawStateSqlitePath } from "../../../state/openclaw-state-db.paths.js";
 import { withRestoredMocks } from "../../../test-utils/vitest-spies.js";
 import {
   collectLegacyCronStoreHealthFindings,
-  collectLegacyCronStoreRepairEffects,
   collectLegacyWhatsAppCrontabHealthWarning,
   maybeRepairLegacyCronStore,
   noteLegacyWhatsAppCrontabHealthCheck,
@@ -298,146 +296,6 @@ describe("collectLegacyCronStoreHealthFindings", () => {
 
     await expect(
       collectLegacyCronStoreHealthFindings({ cfg: createCronConfig(storePath) }),
-    ).resolves.toEqual([]);
-  });
-});
-
-describe("collectLegacyCronStoreRepairEffects", () => {
-  it("does not create the shared state database while previewing legacy cron state", async () => {
-    const storePath = await makeTempStorePath();
-    const stateDir = path.join(path.dirname(storePath), "state-root");
-    vi.stubEnv("OPENCLAW_STATE_DIR", stateDir);
-    const stateDbPath = resolveOpenClawStateSqlitePath({ OPENCLAW_STATE_DIR: stateDir });
-    await writeLegacyCronArrayStore(storePath, [createLegacyCronJob()]);
-
-    await expect(
-      collectLegacyCronStoreHealthFindings({ cfg: createCronConfig(storePath) }),
-    ).resolves.toEqual(
-      expect.arrayContaining([
-        expect.objectContaining({
-          checkId: "core/doctor/legacy-cron-store",
-          requirement: "legacy-cron-store",
-        }),
-      ]),
-    );
-    await expect(
-      collectLegacyCronStoreRepairEffects({ cfg: createCronConfig(storePath) }),
-    ).resolves.toEqual(
-      expect.arrayContaining([
-        expect.objectContaining({
-          action: "would-migrate-legacy-cron-store",
-          target: storePath,
-        }),
-      ]),
-    );
-
-    expect(fsSync.existsSync(stateDbPath)).toBe(false);
-  });
-
-  it("previews legacy cron store repair effects without mutating files", async () => {
-    const storePath = await makeTempStorePath();
-    await writeLegacyCronArrayStore(storePath, [
-      createLegacyCronJob({
-        jobId: "legacy-notify",
-        payload: {
-          kind: "systemEvent",
-          text: "Morning brief",
-        },
-      }),
-    ]);
-    const runLogPath = path.join(path.dirname(storePath), "runs", "legacy-notify.jsonl");
-    await fs.mkdir(path.dirname(runLogPath), { recursive: true });
-    await fs.writeFile(runLogPath, "", "utf-8");
-
-    const effects = await collectLegacyCronStoreRepairEffects({
-      cfg: createCronConfig(storePath),
-    });
-
-    expect(effects).toEqual(
-      expect.arrayContaining([
-        expect.objectContaining({
-          kind: "state",
-          action: "would-migrate-legacy-cron-store",
-          target: storePath,
-          dryRunSafe: false,
-        }),
-        expect.objectContaining({
-          kind: "state",
-          action: "would-import-legacy-cron-run-logs",
-          target: path.join(path.dirname(storePath), "runs"),
-          dryRunSafe: false,
-        }),
-        expect.objectContaining({
-          kind: "state",
-          action: "would-normalize-cron-store",
-          target: storePath,
-          dryRunSafe: false,
-        }),
-        expect.objectContaining({
-          kind: "state",
-          action: "would-migrate-legacy-cron-notify-fallback",
-          target: storePath,
-          dryRunSafe: false,
-        }),
-      ]),
-    );
-    await expect(fs.readFile(storePath, "utf-8")).resolves.toContain("legacy-notify");
-    await expect(fs.stat(runLogPath)).resolves.toBeDefined();
-  });
-
-  it("previews quarantine and dreaming payload rewrite effects", async () => {
-    const storePath = await makeTempStorePath();
-    await writeCronStore(storePath, [
-      { id: "invalid-cron", name: "Invalid cron", payload: { kind: "systemEvent" } },
-      {
-        id: "memory-dreaming",
-        name: "Memory Dreaming Promotion",
-        description:
-          "[managed-by=memory-core.short-term-promotion] Promote weighted short-term recalls.",
-        enabled: true,
-        createdAtMs: Date.parse("2026-04-01T00:00:00.000Z"),
-        updatedAtMs: Date.parse("2026-04-01T00:00:00.000Z"),
-        schedule: { kind: "cron", expr: "0 3 * * *", tz: "UTC" },
-        sessionTarget: "main",
-        wakeMode: "now",
-        payload: {
-          kind: "systemEvent",
-          text: "__openclaw_memory_core_short_term_promotion_dream__",
-        },
-        state: {},
-      },
-    ]);
-
-    const effects = await collectLegacyCronStoreRepairEffects({
-      cfg: createCronConfig(storePath),
-    });
-
-    expect(effects).toEqual(
-      expect.arrayContaining([
-        expect.objectContaining({
-          action: "would-quarantine-invalid-cron-jobs",
-          target: resolveCronQuarantinePath(storePath),
-        }),
-        expect.objectContaining({
-          action: "would-normalize-cron-store",
-          target: storePath,
-        }),
-        expect.objectContaining({
-          action: "would-rewrite-legacy-dreaming-cron-payload",
-          target: storePath,
-        }),
-      ]),
-    );
-    await expect(fs.readFile(storePath, "utf-8")).resolves.toContain("invalid-cron");
-    await expect(fs.readFile(storePath, "utf-8")).resolves.toContain("memory-dreaming");
-  });
-
-  it("returns no repair effects for an already-normalized empty cron store", async () => {
-    const storePath = await makeTempStorePath();
-    await writeCurrentCronStore(storePath, []);
-
-    await expect(
-      collectLegacyCronStoreRepairEffects({ cfg: createCronConfig(storePath) }),
     ).resolves.toEqual([]);
   });
 });

--- a/src/commands/doctor/cron/index.ts
+++ b/src/commands/doctor/cron/index.ts
@@ -13,6 +13,7 @@ import {
   saveCronJobsStoreWithMetadata,
 } from "../../../cron/store.js";
 import type { CronJob } from "../../../cron/types.js";
+import type { HealthFinding } from "../../../flows/health-checks.js";
 import { shortenHomePath } from "../../../utils.js";
 import type { DoctorPrompter, DoctorOptions } from "../../doctor-prompter.js";
 import {
@@ -98,6 +99,26 @@ export type LegacyCronRepairResult = {
   changes: string[];
   warnings: string[];
 };
+
+const LEGACY_CRON_STORE_CHECK_ID = "core/doctor/legacy-cron-store";
+
+function legacyCronStoreFinding(params: {
+  readonly message: string;
+  readonly path: string;
+  readonly requirement: string;
+  readonly fixHint?: string;
+}): HealthFinding {
+  return {
+    checkId: LEGACY_CRON_STORE_CHECK_ID,
+    severity: "warning",
+    message: params.message,
+    path: params.path,
+    requirement: params.requirement,
+    fixHint:
+      params.fixHint ??
+      `Run ${formatCliCommand("openclaw doctor --fix")} to normalize legacy cron storage.`,
+  };
+}
 
 async function loadLegacyCronRepairState(params: {
   cfg: OpenClawConfig;
@@ -281,6 +302,137 @@ async function applyLegacyCronStoreRepair(params: {
   }
 
   return { changes, warnings };
+}
+
+export async function collectLegacyCronStoreHealthFindings(params: {
+  cfg: OpenClawConfig;
+}): Promise<readonly HealthFinding[]> {
+  let state: LegacyCronRepairState | null;
+  try {
+    state = await loadLegacyCronRepairState({ cfg: params.cfg });
+  } catch (err) {
+    const storePath = resolveCronJobsStorePath(params.cfg.cron?.store);
+    return [
+      legacyCronStoreFinding({
+        message: `Unable to read cron job store at ${shortenHomePath(storePath)}.`,
+        path: storePath,
+        requirement: "cron-store-readable",
+        fixHint: [
+          `Fix the file's permissions or contents and re-run ${formatCliCommand("openclaw doctor")}.`,
+          "Later health checks will continue.",
+          `Details: ${errorMessage(err)}`,
+        ].join(" "),
+      }),
+    ];
+  }
+  if (!state) {
+    return [];
+  }
+
+  const findings: HealthFinding[] = [];
+  const {
+    storePath,
+    quarantinePath,
+    legacyStoreDetected,
+    legacyRunLogDetected,
+    legacyImportCount,
+    sqliteProjectionBackfillCount,
+    rawJobs,
+  } = state;
+
+  try {
+    const quarantine = await loadCronQuarantineFile(quarantinePath);
+    if (quarantine.jobs.length > 0) {
+      findings.push(
+        legacyCronStoreFinding({
+          message: `${pluralize(quarantine.jobs.length, "quarantined cron job row")} found at ${shortenHomePath(quarantinePath)}.`,
+          path: quarantinePath,
+          requirement: "quarantined-cron-rows",
+          fixHint: `Review or repair the quarantined rows manually before copying any job back into ${shortenHomePath(storePath)}.`,
+        }),
+      );
+    }
+  } catch (err) {
+    findings.push(
+      legacyCronStoreFinding({
+        message: `Unable to read quarantined cron rows at ${shortenHomePath(quarantinePath)}.`,
+        path: quarantinePath,
+        requirement: "cron-quarantine-readable",
+        fixHint: `Fix the quarantine file's permissions or contents. Details: ${errorMessage(err)}`,
+      }),
+    );
+  }
+
+  if (legacyStoreDetected) {
+    findings.push(
+      legacyCronStoreFinding({
+        message:
+          legacyImportCount > 0
+            ? `${pluralize(legacyImportCount, "legacy JSON cron job")} will be imported into SQLite.`
+            : `Legacy JSON cron store was found at ${shortenHomePath(storePath)}.`,
+        path: storePath,
+        requirement: "legacy-cron-store",
+      }),
+    );
+  }
+  if (legacyRunLogDetected) {
+    findings.push(
+      legacyCronStoreFinding({
+        message: `Legacy JSON cron run logs will be imported into SQLite for ${shortenHomePath(storePath)}.`,
+        path: storePath,
+        requirement: "legacy-cron-run-logs",
+      }),
+    );
+  }
+
+  if (rawJobs.length === 0) {
+    return findings;
+  }
+
+  const normalized = normalizeStoredCronJobs(rawJobs);
+  for (const line of formatLegacyIssuePreview(normalized.issues)) {
+    findings.push(
+      legacyCronStoreFinding({
+        message: line.replace(/^- /u, ""),
+        path: storePath,
+        requirement: "legacy-cron-store-shape",
+      }),
+    );
+  }
+
+  if (sqliteProjectionBackfillCount > 0) {
+    findings.push(
+      legacyCronStoreFinding({
+        message: `${pluralize(sqliteProjectionBackfillCount, "SQLite cron row")} will be backfilled from stored config JSON into split columns.`,
+        path: storePath,
+        requirement: "sqlite-projection-backfill",
+      }),
+    );
+  }
+
+  const notifyCount = rawJobs.filter((job) => job.notify === true).length;
+  if (notifyCount > 0) {
+    findings.push(
+      legacyCronStoreFinding({
+        message: `${pluralize(notifyCount, "job")} still uses legacy notify webhook fallback.`,
+        path: storePath,
+        requirement: "legacy-notify-fallback",
+      }),
+    );
+  }
+
+  const dreamingStaleCount = countStaleDreamingJobs(rawJobs);
+  if (dreamingStaleCount > 0) {
+    findings.push(
+      legacyCronStoreFinding({
+        message: `${pluralize(dreamingStaleCount, "managed dreaming job")} still has the legacy heartbeat-coupled shape.`,
+        path: storePath,
+        requirement: "legacy-dreaming-payload",
+      }),
+    );
+  }
+
+  return findings;
 }
 
 export async function repairLegacyCronStoreWithoutPrompt(params: {

--- a/src/commands/doctor/cron/index.ts
+++ b/src/commands/doctor/cron/index.ts
@@ -1,4 +1,5 @@
 // Doctor cron repair orchestration for legacy stores, run logs, payloads, and warnings.
+import path from "node:path";
 import { normalizeOptionalString } from "../../../../packages/normalization-core/src/string-coerce.js";
 import { note } from "../../../../packages/terminal-core/src/note.js";
 import { formatCliCommand } from "../../../cli/command-format.js";
@@ -13,7 +14,7 @@ import {
   saveCronJobsStoreWithMetadata,
 } from "../../../cron/store.js";
 import type { CronJob } from "../../../cron/types.js";
-import type { HealthFinding } from "../../../flows/health-checks.js";
+import type { HealthFinding, HealthRepairEffect } from "../../../flows/health-checks.js";
 import { shortenHomePath } from "../../../utils.js";
 import type { DoctorPrompter, DoctorOptions } from "../../doctor-prompter.js";
 import {
@@ -118,6 +119,10 @@ function legacyCronStoreFinding(params: {
       params.fixHint ??
       `Run ${formatCliCommand("openclaw doctor --fix")} to normalize legacy cron storage.`,
   };
+}
+
+function cloneCronJobRecords(jobs: Array<Record<string, unknown>>): Array<Record<string, unknown>> {
+  return structuredClone(jobs);
 }
 
 async function loadLegacyCronRepairState(params: {
@@ -433,6 +438,97 @@ export async function collectLegacyCronStoreHealthFindings(params: {
   }
 
   return findings;
+}
+
+export async function collectLegacyCronStoreRepairEffects(params: {
+  cfg: OpenClawConfig;
+}): Promise<readonly HealthRepairEffect[]> {
+  let state: LegacyCronRepairState | null;
+  try {
+    state = await loadLegacyCronRepairState({ cfg: params.cfg });
+  } catch {
+    return [];
+  }
+  if (!state) {
+    return [];
+  }
+
+  const effects: HealthRepairEffect[] = [];
+  if (state.legacyStoreDetected) {
+    effects.push({
+      kind: "state",
+      action: state.legacyMigrationAlreadyImported
+        ? "would-archive-legacy-cron-store"
+        : "would-migrate-legacy-cron-store",
+      target: state.storePath,
+      dryRunSafe: false,
+    });
+  }
+  if (state.legacyRunLogDetected) {
+    effects.push({
+      kind: "state",
+      action: "would-import-legacy-cron-run-logs",
+      target: path.join(path.dirname(state.storePath), "runs"),
+      dryRunSafe: false,
+    });
+  }
+  if (state.rawJobs.length === 0) {
+    return effects;
+  }
+
+  const normalizedPreviewJobs = cloneCronJobRecords(state.rawJobs);
+  const normalized = normalizeStoredCronJobs(normalizedPreviewJobs);
+  if (normalized.removedJobs.length > 0) {
+    effects.push({
+      kind: "state",
+      action: "would-quarantine-invalid-cron-jobs",
+      target: state.quarantinePath,
+      dryRunSafe: false,
+    });
+  }
+  if (normalized.mutated) {
+    effects.push({
+      kind: "state",
+      action: "would-normalize-cron-store",
+      target: state.storePath,
+      dryRunSafe: false,
+    });
+  }
+  if (state.sqliteProjectionBackfillCount > 0) {
+    effects.push({
+      kind: "state",
+      action: "would-backfill-cron-sqlite-projection",
+      target: state.storePath,
+      dryRunSafe: false,
+    });
+  }
+
+  const notifyPreviewJobs = cloneCronJobRecords(state.rawJobs);
+  const notifyMigration = migrateLegacyNotifyFallback({
+    jobs: notifyPreviewJobs,
+    legacyWebhook: normalizeOptionalString(params.cfg.cron?.webhook),
+  });
+  if (notifyMigration.changed) {
+    effects.push({
+      kind: "state",
+      action: "would-migrate-legacy-cron-notify-fallback",
+      target: state.storePath,
+      dryRunSafe: false,
+    });
+  }
+
+  const dreamingPreviewJobs = cloneCronJobRecords(state.rawJobs);
+  const dreamingMigration = migrateLegacyDreamingPayloadShape(dreamingPreviewJobs);
+  if (dreamingMigration.changed) {
+    effects.push({
+      kind: "state",
+      action: "would-rewrite-legacy-dreaming-cron-payload",
+      target: state.storePath,
+      dryRunSafe: false,
+    });
+  }
+
+  return effects;
 }
 
 export async function repairLegacyCronStoreWithoutPrompt(params: {

--- a/src/commands/doctor/cron/index.ts
+++ b/src/commands/doctor/cron/index.ts
@@ -1,5 +1,4 @@
 // Doctor cron repair orchestration for legacy stores, run logs, payloads, and warnings.
-import path from "node:path";
 import { normalizeOptionalString } from "../../../../packages/normalization-core/src/string-coerce.js";
 import { note } from "../../../../packages/terminal-core/src/note.js";
 import { formatCliCommand } from "../../../cli/command-format.js";
@@ -15,7 +14,7 @@ import {
   saveCronJobsStoreWithMetadata,
 } from "../../../cron/store.js";
 import type { CronJob } from "../../../cron/types.js";
-import type { HealthFinding, HealthRepairEffect } from "../../../flows/health-checks.js";
+import type { HealthFinding } from "../../../flows/health-checks.js";
 import { shortenHomePath } from "../../../utils.js";
 import type { DoctorPrompter, DoctorOptions } from "../../doctor-prompter.js";
 import {
@@ -121,10 +120,6 @@ function legacyCronStoreFinding(params: {
       params.fixHint ??
       `Run ${formatCliCommand("openclaw doctor --fix")} to normalize legacy cron storage.`,
   };
-}
-
-function cloneCronJobRecords(jobs: Array<Record<string, unknown>>): Array<Record<string, unknown>> {
-  return structuredClone(jobs);
 }
 
 async function loadLegacyCronRepairState(params: {
@@ -445,97 +440,6 @@ export async function collectLegacyCronStoreHealthFindings(params: {
   }
 
   return findings;
-}
-
-export async function collectLegacyCronStoreRepairEffects(params: {
-  cfg: OpenClawConfig;
-}): Promise<readonly HealthRepairEffect[]> {
-  let state: LegacyCronRepairState | null;
-  try {
-    state = await loadLegacyCronRepairState({ cfg: params.cfg, readOnly: true });
-  } catch {
-    return [];
-  }
-  if (!state) {
-    return [];
-  }
-
-  const effects: HealthRepairEffect[] = [];
-  if (state.legacyStoreDetected) {
-    effects.push({
-      kind: "state",
-      action: state.legacyMigrationAlreadyImported
-        ? "would-archive-legacy-cron-store"
-        : "would-migrate-legacy-cron-store",
-      target: state.storePath,
-      dryRunSafe: false,
-    });
-  }
-  if (state.legacyRunLogDetected) {
-    effects.push({
-      kind: "state",
-      action: "would-import-legacy-cron-run-logs",
-      target: path.join(path.dirname(state.storePath), "runs"),
-      dryRunSafe: false,
-    });
-  }
-  if (state.rawJobs.length === 0) {
-    return effects;
-  }
-
-  const normalizedPreviewJobs = cloneCronJobRecords(state.rawJobs);
-  const normalized = normalizeStoredCronJobs(normalizedPreviewJobs);
-  if (normalized.removedJobs.length > 0) {
-    effects.push({
-      kind: "state",
-      action: "would-quarantine-invalid-cron-jobs",
-      target: state.quarantinePath,
-      dryRunSafe: false,
-    });
-  }
-  if (normalized.mutated) {
-    effects.push({
-      kind: "state",
-      action: "would-normalize-cron-store",
-      target: state.storePath,
-      dryRunSafe: false,
-    });
-  }
-  if (state.sqliteProjectionBackfillCount > 0) {
-    effects.push({
-      kind: "state",
-      action: "would-backfill-cron-sqlite-projection",
-      target: state.storePath,
-      dryRunSafe: false,
-    });
-  }
-
-  const notifyPreviewJobs = cloneCronJobRecords(state.rawJobs);
-  const notifyMigration = migrateLegacyNotifyFallback({
-    jobs: notifyPreviewJobs,
-    legacyWebhook: normalizeOptionalString(params.cfg.cron?.webhook),
-  });
-  if (notifyMigration.changed) {
-    effects.push({
-      kind: "state",
-      action: "would-migrate-legacy-cron-notify-fallback",
-      target: state.storePath,
-      dryRunSafe: false,
-    });
-  }
-
-  const dreamingPreviewJobs = cloneCronJobRecords(state.rawJobs);
-  const dreamingMigration = migrateLegacyDreamingPayloadShape(dreamingPreviewJobs);
-  if (dreamingMigration.changed) {
-    effects.push({
-      kind: "state",
-      action: "would-rewrite-legacy-dreaming-cron-payload",
-      target: state.storePath,
-      dryRunSafe: false,
-    });
-  }
-
-  return effects;
 }
 
 export async function repairLegacyCronStoreWithoutPrompt(params: {

--- a/src/commands/doctor/cron/index.ts
+++ b/src/commands/doctor/cron/index.ts
@@ -7,6 +7,7 @@ import type { OpenClawConfig } from "../../../config/types.openclaw.js";
 import {
   loadCronQuarantineFile,
   loadCronJobsStoreWithConfigJobs,
+  loadCronJobsStoreWithConfigJobsReadOnly,
   resolveCronQuarantinePath,
   resolveCronJobsStorePath,
   saveCronQuarantineFile,
@@ -36,6 +37,7 @@ import {
 import {
   acquireLegacyCronMigrationReceipt,
   hasLegacyCronMigrationReceipt,
+  hasLegacyCronMigrationReceiptReadOnly,
   markLegacyCronMigrationSourceRemoved,
 } from "./migration-ledger.js";
 import {
@@ -128,6 +130,7 @@ function cloneCronJobRecords(jobs: Array<Record<string, unknown>>): Array<Record
 async function loadLegacyCronRepairState(params: {
   cfg: OpenClawConfig;
   onlyIfLegacyDetected?: boolean;
+  readOnly?: boolean;
 }): Promise<LegacyCronRepairState | null> {
   const storePath = resolveCronJobsStorePath(params.cfg.cron?.store);
   const quarantinePath = resolveCronQuarantinePath(storePath);
@@ -137,7 +140,9 @@ async function loadLegacyCronRepairState(params: {
     return null;
   }
 
-  const loaded = await loadCronJobsStoreWithConfigJobs(storePath);
+  const loaded = params.readOnly
+    ? await loadCronJobsStoreWithConfigJobsReadOnly(storePath)
+    : await loadCronJobsStoreWithConfigJobs(storePath);
   const currentJobs =
     loaded.configJobs.length > 0
       ? loaded.configJobs.map((job, index) =>
@@ -164,7 +169,9 @@ async function loadLegacyCronRepairState(params: {
     const loadedLegacy = await loadLegacyCronStoreForMigration(storePath);
     legacyMigrationSource = loadedLegacy.migrationSource;
     legacyMigrationAlreadyImported = legacyMigrationSource
-      ? hasLegacyCronMigrationReceipt(legacyMigrationSource)
+      ? params.readOnly
+        ? hasLegacyCronMigrationReceiptReadOnly(legacyMigrationSource)
+        : hasLegacyCronMigrationReceipt(legacyMigrationSource)
       : false;
     if (!legacyMigrationAlreadyImported) {
       const merged = mergeLegacyCronJobs({
@@ -314,7 +321,7 @@ export async function collectLegacyCronStoreHealthFindings(params: {
 }): Promise<readonly HealthFinding[]> {
   let state: LegacyCronRepairState | null;
   try {
-    state = await loadLegacyCronRepairState({ cfg: params.cfg });
+    state = await loadLegacyCronRepairState({ cfg: params.cfg, readOnly: true });
   } catch (err) {
     const storePath = resolveCronJobsStorePath(params.cfg.cron?.store);
     return [
@@ -445,7 +452,7 @@ export async function collectLegacyCronStoreRepairEffects(params: {
 }): Promise<readonly HealthRepairEffect[]> {
   let state: LegacyCronRepairState | null;
   try {
-    state = await loadLegacyCronRepairState({ cfg: params.cfg });
+    state = await loadLegacyCronRepairState({ cfg: params.cfg, readOnly: true });
   } catch {
     return [];
   }

--- a/src/commands/doctor/cron/migration-ledger.ts
+++ b/src/commands/doctor/cron/migration-ledger.ts
@@ -1,15 +1,18 @@
 // Durable receipts make legacy cron migration retries independent of mutable runtime rows.
+import fs from "node:fs";
 import type { DatabaseSync } from "node:sqlite";
 import {
   executeSqliteQuerySync,
   executeSqliteQueryTakeFirstSync,
   getNodeSqliteKysely,
 } from "../../../infra/kysely-sync.js";
+import { requireNodeSqlite } from "../../../infra/node-sqlite.js";
 import type { DB as OpenClawStateDatabase } from "../../../state/openclaw-state-db.generated.js";
 import {
   openOpenClawStateDatabase,
   runOpenClawStateWriteTransaction,
 } from "../../../state/openclaw-state-db.js";
+import { resolveOpenClawStateSqlitePath } from "../../../state/openclaw-state-db.paths.js";
 import type { LegacyCronMigrationSource } from "./legacy-store-migration.js";
 
 type CronMigrationDatabase = Pick<OpenClawStateDatabase, "migration_runs" | "migration_sources">;
@@ -34,6 +37,31 @@ function hasLegacyCronMigrationReceiptInDatabase(
 
 export function hasLegacyCronMigrationReceipt(source: LegacyCronMigrationSource): boolean {
   return hasLegacyCronMigrationReceiptInDatabase(openOpenClawStateDatabase().db, source);
+}
+
+function tableExists(db: DatabaseSync, tableName: string): boolean {
+  return (
+    db
+      .prepare("SELECT 1 AS ok FROM sqlite_master WHERE type = 'table' AND name = ?")
+      .get(tableName) !== undefined
+  );
+}
+
+export function hasLegacyCronMigrationReceiptReadOnly(source: LegacyCronMigrationSource): boolean {
+  const statePath = resolveOpenClawStateSqlitePath(process.env);
+  if (!fs.existsSync(statePath)) {
+    return false;
+  }
+  const sqlite = requireNodeSqlite();
+  const db = new sqlite.DatabaseSync(statePath, { readOnly: true });
+  try {
+    if (!tableExists(db, "migration_sources")) {
+      return false;
+    }
+    return hasLegacyCronMigrationReceiptInDatabase(db, source);
+  } finally {
+    db.close();
+  }
 }
 
 export function acquireLegacyCronMigrationReceipt(

--- a/src/cron/store.ts
+++ b/src/cron/store.ts
@@ -5,11 +5,13 @@ import type { DatabaseSync } from "node:sqlite";
 import { isRecord } from "@openclaw/normalization-core/record-coerce";
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import { expandHomePrefix } from "../infra/home-dir.js";
+import { requireNodeSqlite } from "../infra/node-sqlite.js";
 import { replaceFileAtomic } from "../infra/replace-file.js";
 import {
   openOpenClawStateDatabase,
   runOpenClawStateWriteTransaction,
 } from "../state/openclaw-state-db.js";
+import { resolveOpenClawStateSqlitePath } from "../state/openclaw-state-db.paths.js";
 import { resolveConfigDir } from "../utils.js";
 import { parseJsonWithJson5Fallback } from "../utils/parse-json-compat.js";
 import { cronStoreKey } from "./store/key.js";
@@ -77,6 +79,50 @@ export async function loadCronJobsStoreWithConfigJobs(storePath: string): Promis
     configJobRuntimeEntries: [],
     invalidConfigRows: [],
   };
+}
+
+function emptyLoadedCronStore(): LoadedCronStore {
+  return {
+    store: { version: 1, jobs: [] },
+    configJobs: [],
+    configJobIndexes: [],
+    configJobRuntimeEntries: [],
+    invalidConfigRows: [],
+  };
+}
+
+function tableExists(db: DatabaseSync, tableName: string): boolean {
+  return (
+    db
+      .prepare("SELECT 1 AS ok FROM sqlite_master WHERE type = 'table' AND name = ?")
+      .get(tableName) !== undefined
+  );
+}
+
+/** Loads cron jobs from an existing SQLite store without creating or migrating state. */
+export async function loadCronJobsStoreWithConfigJobsReadOnly(
+  storePath: string,
+): Promise<LoadedCronStore> {
+  const statePath = resolveOpenClawStateSqlitePath(process.env);
+  if (!fs.existsSync(statePath)) {
+    return emptyLoadedCronStore();
+  }
+  const resolvedStorePath = path.resolve(storePath);
+  const storeKey = cronStoreKey(resolvedStorePath);
+  const sqlite = requireNodeSqlite();
+  const db = new sqlite.DatabaseSync(statePath, { readOnly: true });
+  try {
+    if (!tableExists(db, "cron_jobs")) {
+      return emptyLoadedCronStore();
+    }
+    const rows = loadCronRows(db, storeKey);
+    if (rows.length > 0) {
+      return loadedCronStoreFromRows(rows);
+    }
+    return emptyLoadedCronStore();
+  } finally {
+    db.close();
+  }
 }
 
 /** Loads only the persisted cron job store payload. */

--- a/src/flows/doctor-core-checks.ts
+++ b/src/flows/doctor-core-checks.ts
@@ -678,7 +678,7 @@ const legacyWhatsAppCrontabCheck: HealthCheck = {
   },
 };
 
-const legacyCronStoreCheck: HealthCheck = {
+const legacyCronStoreCheck: SplitHealthCheckInput = {
   id: "core/doctor/legacy-cron-store",
   kind: "core",
   description: "Legacy cron store, run-log, and payload state is normalized.",
@@ -688,20 +688,6 @@ const legacyCronStoreCheck: HealthCheck = {
     const { collectLegacyCronStoreHealthFindings } =
       await import("../commands/doctor/cron/index.js");
     return collectLegacyCronStoreHealthFindings({ cfg: ctx.cfg });
-  },
-  async repair(ctx) {
-    const { collectLegacyCronStoreRepairEffects } =
-      await import("../commands/doctor/cron/index.js");
-    const effects = await collectLegacyCronStoreRepairEffects({ cfg: ctx.cfg });
-    if (ctx.dryRun === true) {
-      return { status: "repaired", changes: [], effects };
-    }
-    return {
-      status: "skipped",
-      reason: "legacy doctor cron contribution owns real cron store repair",
-      changes: [],
-      effects,
-    };
   },
 };
 

--- a/src/flows/doctor-core-checks.ts
+++ b/src/flows/doctor-core-checks.ts
@@ -689,6 +689,20 @@ const legacyCronStoreCheck: HealthCheck = {
       await import("../commands/doctor/cron/index.js");
     return collectLegacyCronStoreHealthFindings({ cfg: ctx.cfg });
   },
+  async repair(ctx) {
+    const { collectLegacyCronStoreRepairEffects } =
+      await import("../commands/doctor/cron/index.js");
+    const effects = await collectLegacyCronStoreRepairEffects({ cfg: ctx.cfg });
+    if (ctx.dryRun === true) {
+      return { status: "repaired", changes: [], effects };
+    }
+    return {
+      status: "skipped",
+      reason: "legacy doctor cron contribution owns real cron store repair",
+      changes: [],
+      effects,
+    };
+  },
 };
 
 const codexSessionRoutesCheck: HealthCheck = {

--- a/src/flows/doctor-core-checks.ts
+++ b/src/flows/doctor-core-checks.ts
@@ -678,6 +678,19 @@ const legacyWhatsAppCrontabCheck: HealthCheck = {
   },
 };
 
+const legacyCronStoreCheck: HealthCheck = {
+  id: "core/doctor/legacy-cron-store",
+  kind: "core",
+  description: "Legacy cron store, run-log, and payload state is normalized.",
+  source: "doctor",
+  defaultEnabled: false,
+  async detect(ctx) {
+    const { collectLegacyCronStoreHealthFindings } =
+      await import("../commands/doctor/cron/index.js");
+    return collectLegacyCronStoreHealthFindings({ cfg: ctx.cfg });
+  },
+};
+
 const codexSessionRoutesCheck: HealthCheck = {
   id: CODEX_SESSION_ROUTES_CHECK_ID,
   kind: "core",
@@ -1066,6 +1079,7 @@ function createConvertedWorkflowChecks(
     gatewayAuthCheck,
     legacyStateCheck,
     legacyWhatsAppCrontabCheck,
+    legacyCronStoreCheck,
     codexSessionRoutesCheck,
     sessionLocksCheck,
     shellCompletionCheck,

--- a/src/flows/doctor-health-contributions.test.ts
+++ b/src/flows/doctor-health-contributions.test.ts
@@ -104,8 +104,7 @@ const mocks = vi.hoisted(() => ({
   collectWhatsappResponsivenessHealthFindings: vi.fn((): readonly HealthFinding[] => []),
   noteWhatsappResponsivenessHealth: vi.fn().mockResolvedValue(undefined),
   collectDevicePairingHealthFindings: vi.fn(async () => []),
-  collectLegacyCronStoreHealthFindings: vi.fn(async () => []),
-  collectLegacyCronStoreRepairEffects: vi.fn(async () => []),
+  collectLegacyCronStoreHealthFindings: vi.fn(async (): Promise<readonly HealthFinding[]> => []),
   collectLegacyWhatsAppCrontabHealthWarning: vi.fn(async () => undefined),
   maybeRepairLegacyCronStore: vi.fn().mockResolvedValue(undefined),
   noteLegacyWhatsAppCrontabHealthCheck: vi.fn().mockResolvedValue(undefined),
@@ -359,7 +358,6 @@ vi.mock("../commands/doctor-device-pairing.js", () => ({
 
 vi.mock("../commands/doctor/cron/index.js", () => ({
   collectLegacyCronStoreHealthFindings: mocks.collectLegacyCronStoreHealthFindings,
-  collectLegacyCronStoreRepairEffects: mocks.collectLegacyCronStoreRepairEffects,
   collectLegacyWhatsAppCrontabHealthWarning: mocks.collectLegacyWhatsAppCrontabHealthWarning,
   maybeRepairLegacyCronStore: mocks.maybeRepairLegacyCronStore,
   noteLegacyWhatsAppCrontabHealthCheck: mocks.noteLegacyWhatsAppCrontabHealthCheck,
@@ -574,8 +572,6 @@ describe("doctor health contributions", () => {
     mocks.collectDevicePairingHealthFindings.mockResolvedValue([]);
     mocks.collectLegacyCronStoreHealthFindings.mockReset();
     mocks.collectLegacyCronStoreHealthFindings.mockResolvedValue([]);
-    mocks.collectLegacyCronStoreRepairEffects.mockReset();
-    mocks.collectLegacyCronStoreRepairEffects.mockResolvedValue([]);
     mocks.collectLegacyWhatsAppCrontabHealthWarning.mockReset();
     mocks.collectLegacyWhatsAppCrontabHealthWarning.mockResolvedValue(undefined);
     mocks.maybeRepairLegacyCronStore.mockReset();
@@ -1928,48 +1924,6 @@ describe("doctor health contributions", () => {
       findings: [expect.objectContaining({ checkId: "core/doctor/legacy-cron-store" })],
     });
     expect(mocks.collectLegacyCronStoreHealthFindings).toHaveBeenCalledWith({ cfg: ctx.cfg });
-  });
-
-  it("previews legacy cron store repair effects without taking over real repair", async () => {
-    const contributionChecks = await resolveDoctorContributionHealthChecks();
-    const cronStoreCheck = contributionChecks.find(
-      (check) => check.id === "core/doctor/legacy-cron-store",
-    );
-    expect(cronStoreCheck?.repair).toBeDefined();
-    mocks.collectLegacyCronStoreRepairEffects.mockResolvedValue([
-      {
-        kind: "state",
-        action: "would-migrate-legacy-cron-store",
-        target: "/tmp/openclaw-cron/jobs.json",
-        dryRunSafe: false,
-      },
-    ]);
-    const ctx = {
-      cfg: { cron: { store: "/tmp/openclaw-cron/jobs.json" } },
-      mode: "fix",
-      dryRun: true,
-      runtime: { log: vi.fn(), error: vi.fn(), exit: vi.fn() },
-    } as const;
-
-    await expect(cronStoreCheck!.repair!(ctx, [])).resolves.toEqual({
-      status: "repaired",
-      changes: [],
-      effects: [
-        {
-          kind: "state",
-          action: "would-migrate-legacy-cron-store",
-          target: "/tmp/openclaw-cron/jobs.json",
-          dryRunSafe: false,
-        },
-      ],
-    });
-    await expect(cronStoreCheck!.repair!({ ...ctx, dryRun: false }, [])).resolves.toMatchObject({
-      status: "skipped",
-      reason: "legacy doctor cron contribution owns real cron store repair",
-      changes: [],
-      effects: [expect.objectContaining({ action: "would-migrate-legacy-cron-store" })],
-    });
-    expect(mocks.collectLegacyCronStoreRepairEffects).toHaveBeenCalledWith({ cfg: ctx.cfg });
   });
 
   it("keeps channel plugin blockers opt-in for default lint selection", async () => {

--- a/src/flows/doctor-health-contributions.test.ts
+++ b/src/flows/doctor-health-contributions.test.ts
@@ -105,6 +105,7 @@ const mocks = vi.hoisted(() => ({
   noteWhatsappResponsivenessHealth: vi.fn().mockResolvedValue(undefined),
   collectDevicePairingHealthFindings: vi.fn(async () => []),
   collectLegacyCronStoreHealthFindings: vi.fn(async () => []),
+  collectLegacyCronStoreRepairEffects: vi.fn(async () => []),
   collectLegacyWhatsAppCrontabHealthWarning: vi.fn(async () => undefined),
   maybeRepairLegacyCronStore: vi.fn().mockResolvedValue(undefined),
   noteLegacyWhatsAppCrontabHealthCheck: vi.fn().mockResolvedValue(undefined),
@@ -358,6 +359,7 @@ vi.mock("../commands/doctor-device-pairing.js", () => ({
 
 vi.mock("../commands/doctor/cron/index.js", () => ({
   collectLegacyCronStoreHealthFindings: mocks.collectLegacyCronStoreHealthFindings,
+  collectLegacyCronStoreRepairEffects: mocks.collectLegacyCronStoreRepairEffects,
   collectLegacyWhatsAppCrontabHealthWarning: mocks.collectLegacyWhatsAppCrontabHealthWarning,
   maybeRepairLegacyCronStore: mocks.maybeRepairLegacyCronStore,
   noteLegacyWhatsAppCrontabHealthCheck: mocks.noteLegacyWhatsAppCrontabHealthCheck,
@@ -572,6 +574,8 @@ describe("doctor health contributions", () => {
     mocks.collectDevicePairingHealthFindings.mockResolvedValue([]);
     mocks.collectLegacyCronStoreHealthFindings.mockReset();
     mocks.collectLegacyCronStoreHealthFindings.mockResolvedValue([]);
+    mocks.collectLegacyCronStoreRepairEffects.mockReset();
+    mocks.collectLegacyCronStoreRepairEffects.mockResolvedValue([]);
     mocks.collectLegacyWhatsAppCrontabHealthWarning.mockReset();
     mocks.collectLegacyWhatsAppCrontabHealthWarning.mockResolvedValue(undefined);
     mocks.maybeRepairLegacyCronStore.mockReset();
@@ -1924,6 +1928,48 @@ describe("doctor health contributions", () => {
       findings: [expect.objectContaining({ checkId: "core/doctor/legacy-cron-store" })],
     });
     expect(mocks.collectLegacyCronStoreHealthFindings).toHaveBeenCalledWith({ cfg: ctx.cfg });
+  });
+
+  it("previews legacy cron store repair effects without taking over real repair", async () => {
+    const contributionChecks = await resolveDoctorContributionHealthChecks();
+    const cronStoreCheck = contributionChecks.find(
+      (check) => check.id === "core/doctor/legacy-cron-store",
+    );
+    expect(cronStoreCheck?.repair).toBeDefined();
+    mocks.collectLegacyCronStoreRepairEffects.mockResolvedValue([
+      {
+        kind: "state",
+        action: "would-migrate-legacy-cron-store",
+        target: "/tmp/openclaw-cron/jobs.json",
+        dryRunSafe: false,
+      },
+    ]);
+    const ctx = {
+      cfg: { cron: { store: "/tmp/openclaw-cron/jobs.json" } },
+      mode: "fix",
+      dryRun: true,
+      runtime: { log: vi.fn(), error: vi.fn(), exit: vi.fn() },
+    } as const;
+
+    await expect(cronStoreCheck!.repair!(ctx, [])).resolves.toEqual({
+      status: "repaired",
+      changes: [],
+      effects: [
+        {
+          kind: "state",
+          action: "would-migrate-legacy-cron-store",
+          target: "/tmp/openclaw-cron/jobs.json",
+          dryRunSafe: false,
+        },
+      ],
+    });
+    await expect(cronStoreCheck!.repair!({ ...ctx, dryRun: false }, [])).resolves.toMatchObject({
+      status: "skipped",
+      reason: "legacy doctor cron contribution owns real cron store repair",
+      changes: [],
+      effects: [expect.objectContaining({ action: "would-migrate-legacy-cron-store" })],
+    });
+    expect(mocks.collectLegacyCronStoreRepairEffects).toHaveBeenCalledWith({ cfg: ctx.cfg });
   });
 
   it("keeps channel plugin blockers opt-in for default lint selection", async () => {

--- a/src/flows/doctor-health-contributions.test.ts
+++ b/src/flows/doctor-health-contributions.test.ts
@@ -104,6 +104,10 @@ const mocks = vi.hoisted(() => ({
   collectWhatsappResponsivenessHealthFindings: vi.fn((): readonly HealthFinding[] => []),
   noteWhatsappResponsivenessHealth: vi.fn().mockResolvedValue(undefined),
   collectDevicePairingHealthFindings: vi.fn(async () => []),
+  collectLegacyCronStoreHealthFindings: vi.fn(async () => []),
+  collectLegacyWhatsAppCrontabHealthWarning: vi.fn(async () => undefined),
+  maybeRepairLegacyCronStore: vi.fn().mockResolvedValue(undefined),
+  noteLegacyWhatsAppCrontabHealthCheck: vi.fn().mockResolvedValue(undefined),
   scanConfiguredChannelPluginBlockers: vi.fn(
     (): Array<{ channelId: string; pluginId: string; reason: string }> => [],
   ),
@@ -352,6 +356,13 @@ vi.mock("../commands/doctor-device-pairing.js", () => ({
   noteDevicePairingHealth: vi.fn().mockResolvedValue(undefined),
 }));
 
+vi.mock("../commands/doctor/cron/index.js", () => ({
+  collectLegacyCronStoreHealthFindings: mocks.collectLegacyCronStoreHealthFindings,
+  collectLegacyWhatsAppCrontabHealthWarning: mocks.collectLegacyWhatsAppCrontabHealthWarning,
+  maybeRepairLegacyCronStore: mocks.maybeRepairLegacyCronStore,
+  noteLegacyWhatsAppCrontabHealthCheck: mocks.noteLegacyWhatsAppCrontabHealthCheck,
+}));
+
 vi.mock("../commands/doctor/shared/channel-plugin-blockers.js", () => ({
   scanConfiguredChannelPluginBlockers: mocks.scanConfiguredChannelPluginBlockers,
   channelPluginBlockerHitToHealthFinding: mocks.channelPluginBlockerHitToHealthFinding,
@@ -559,6 +570,14 @@ describe("doctor health contributions", () => {
     mocks.noteWhatsappResponsivenessHealth.mockResolvedValue(undefined);
     mocks.collectDevicePairingHealthFindings.mockReset();
     mocks.collectDevicePairingHealthFindings.mockResolvedValue([]);
+    mocks.collectLegacyCronStoreHealthFindings.mockReset();
+    mocks.collectLegacyCronStoreHealthFindings.mockResolvedValue([]);
+    mocks.collectLegacyWhatsAppCrontabHealthWarning.mockReset();
+    mocks.collectLegacyWhatsAppCrontabHealthWarning.mockResolvedValue(undefined);
+    mocks.maybeRepairLegacyCronStore.mockReset();
+    mocks.maybeRepairLegacyCronStore.mockResolvedValue(undefined);
+    mocks.noteLegacyWhatsAppCrontabHealthCheck.mockReset();
+    mocks.noteLegacyWhatsAppCrontabHealthCheck.mockResolvedValue(undefined);
     mocks.scanConfiguredChannelPluginBlockers.mockReset();
     mocks.scanConfiguredChannelPluginBlockers.mockReturnValue([]);
     mocks.channelPluginBlockerHitToHealthFinding.mockClear();
@@ -1859,6 +1878,52 @@ describe("doctor health contributions", () => {
       cfg: ctx.cfg,
       healthOk: false,
     });
+  });
+
+  it("keeps legacy cron store opt-in for default lint selection", async () => {
+    const contribution = requireDoctorContribution("doctor:legacy-cron");
+    expect(contribution.healthCheckIds).toEqual([
+      "core/doctor/legacy-whatsapp-crontab",
+      "core/doctor/legacy-cron-store",
+    ]);
+
+    const contributionChecks = await resolveDoctorContributionHealthChecks();
+    const cronStoreCheck = contributionChecks.find(
+      (check) => check.id === "core/doctor/legacy-cron-store",
+    );
+    expect(cronStoreCheck).toMatchObject({ defaultEnabled: false });
+    expect(cronStoreCheck).toBeDefined();
+
+    const ctx = {
+      cfg: { cron: { store: "/tmp/openclaw-cron/jobs.json" } },
+      mode: "lint",
+      runtime: { log: vi.fn(), error: vi.fn(), exit: vi.fn() },
+    } as const;
+    const checks = [cronStoreCheck!];
+
+    await expect(runDoctorLintChecks(ctx, { checks })).resolves.toMatchObject({
+      checksRun: 0,
+      checksSkipped: 1,
+    });
+    expect(mocks.collectLegacyCronStoreHealthFindings).not.toHaveBeenCalled();
+
+    mocks.collectLegacyCronStoreHealthFindings.mockResolvedValueOnce([
+      {
+        checkId: "core/doctor/legacy-cron-store",
+        severity: "warning",
+        message: "Legacy JSON cron store was found.",
+        path: "/tmp/openclaw-cron/jobs.json",
+        requirement: "legacy-cron-store",
+      },
+    ]);
+    await expect(
+      runDoctorLintChecks(ctx, { checks, onlyIds: ["core/doctor/legacy-cron-store"] }),
+    ).resolves.toMatchObject({
+      checksRun: 1,
+      checksSkipped: 0,
+      findings: [expect.objectContaining({ checkId: "core/doctor/legacy-cron-store" })],
+    });
+    expect(mocks.collectLegacyCronStoreHealthFindings).toHaveBeenCalledWith({ cfg: ctx.cfg });
   });
 
   it("keeps channel plugin blockers opt-in for default lint selection", async () => {

--- a/src/flows/doctor-health-contributions.ts
+++ b/src/flows/doctor-health-contributions.ts
@@ -1733,7 +1733,7 @@ export function resolveDoctorHealthContributions(): DoctorHealthContribution[] {
     createDoctorHealthContribution({
       id: "doctor:legacy-cron",
       label: "Legacy cron",
-      healthCheckIds: ["core/doctor/legacy-whatsapp-crontab"],
+      healthCheckIds: ["core/doctor/legacy-whatsapp-crontab", "core/doctor/legacy-cron-store"],
       run: runLegacyCronHealth,
     }),
     createDoctorHealthContribution({


### PR DESCRIPTION
## Summary
- expose default-disabled `core/doctor/legacy-cron-store` findings for legacy cron stores, legacy run logs, quarantined rows, SQLite projection backfills, legacy notify fallback, and stale dreaming payload shape
- use read-only state inspection paths for selected lint
- keep all real cron mutation in the existing legacy cron `doctor --fix` contribution; this PR is lint-only and does not add a structured repair/dry-run hook

## Contract / compatibility
- No public SDK, plugin, config, or CLI contract changes.
- Default `doctor --lint` is unchanged; `--only core/doctor/legacy-cron-store` and `--all` can select it.
- Selected lint must not create or rewrite user cron state.

## Validation on `9ca7491f8c`
- `node scripts/run-vitest.mjs src/commands/doctor/cron/index.test.ts src/flows/doctor-health-contributions.test.ts` (119 tests)
- changed-file `oxfmt --check`
- changed-file `oxlint --tsconfig config/tsconfig/oxlint.core.json`
- `pnpm check:architecture`
- `node scripts/plugin-sdk-surface-report.mjs --check`
- `git diff --check`

## Type-check note
- Hosted `check-test-types` on `56a56afdc5` failed on an untyped test mock; fixed on `9ca7491f8c` by typing `collectLegacyCronStoreHealthFindings` as `Promise<readonly HealthFinding[]>`.
- Local Windows `pnpm check:test-types` / `pnpm tsgo:core:test` timed out without diagnostics after the fix; hosted CI is the authoritative type-check proof for the refreshed head.

## Real behavior proof on `56a56afdc5` (source behavior unchanged on `9ca7491f8c`)
- Ran source CLI with isolated `OPENCLAW_CONFIG_PATH` and `OPENCLAW_STATE_DIR` against a temp legacy cron JSON array store:
  `node scripts/run-node.mjs doctor --lint --json --only core/doctor/legacy-cron-store`
- Result: exit code 1, `checksRun: 1`, `checksSkipped: 44`, four `core/doctor/legacy-cron-store` warning findings for the temp legacy store.
- Read-only proof: `<state>/openclaw-state.sqlite` was not created and `<state>/identity/device.json` was not created.

## Notes
The earlier structured dry-run preview text was removed after Omar's review because the core check repair hook was not reachable from a supported Doctor CLI path. Real mutation remains in the legacy cron `doctor --fix` path.