### PR TITLE
fix(ci): session concurrency test flakes during child handshake

### DIFF
--- a/src/config/sessions/session-accessor.reply-init-concurrency.test.ts
+++ b/src/config/sessions/session-accessor.reply-init-concurrency.test.ts
@@ -84,7 +84,10 @@ async function waitForFile(filePath) {
 }
 
 async function writeJsonFile(filePath, value) {
-  await fs.writeFile(filePath, \`\${JSON.stringify(value, null, 2)}\\n\`, "utf8");
+  // The parent treats file existence as the readiness signal, so publish atomically.
+  const tempPath = filePath + "." + process.pid + ".tmp";
+  await fs.writeFile(tempPath, \`\${JSON.stringify(value, null, 2)}\\n\`, "utf8");
+  await fs.rename(tempPath, filePath);
 }
 
 const storePath = process.env.REPLY_INIT_STORE_PATH;
@@ -192,7 +195,6 @@ describe("reply session initialization concurrency", () => {
           stdio: ["ignore", "pipe", "pipe"],
         },
       );
-
       await waitForFile(readyPath);
       const snapshot = await readJsonFile<{ currentEntry?: unknown; revision: string }>(readyPath);
       expect(snapshot.revision).toBe(JSON.stringify({ sessionId: "existing-session" }));


### PR DESCRIPTION
## What Problem This Solves

Resolves a CI problem where the reply-session initialization concurrency test could read its child-process JSON readiness marker while that file was only partially written. The same `Unexpected end of JSON input` failure reproduced across unrelated PRs #95973 and #94385.

## Why This Change Was Made

The child now writes each JSON marker to a same-directory temporary path and atomically renames it into place. File existence therefore remains the synchronization signal, but readers can only observe a complete JSON document; product session behavior is unchanged.

## User Impact

No product behavior change. Maintainers get a deterministic concurrency test instead of unrelated PRs failing on a marker-file race.

## Evidence

- Blacksmith Testbox: focused Linux/Node 24 proof passed, 1/1 test: https://github.com/openclaw/openclaw/actions/runs/28615586571
- Before: `src/config/sessions/session-accessor.reply-init-concurrency.test.ts` failed with `Unexpected end of JSON input` in #95973 CI attempts 1-3 and #94385 CI attempt 1.
- Fresh local autoreview: clean, 0.88 confidence.
- `git diff --check` passed.
