### PR TITLE
test: cover Android voice wake gateway sync

### DIFF
--- a/apps/android/app/src/main/java/ai/openclaw/app/node/GatewayEventHandler.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/node/GatewayEventHandler.kt
@@ -12,13 +12,27 @@ import kotlinx.serialization.json.JsonArray
 /**
  * Handles gateway-originated events that need to update local Android preferences.
  */
-class GatewayEventHandler(
+class GatewayEventHandler internal constructor(
   private val scope: CoroutineScope,
   private val prefs: SecurePrefs,
   private val json: Json,
-  private val operatorSession: GatewaySession,
+  private val requestSender: GatewayRequestSender,
   private val isConnected: () -> Boolean,
 ) {
+  constructor(
+    scope: CoroutineScope,
+    prefs: SecurePrefs,
+    json: Json,
+    operatorSession: GatewaySession,
+    isConnected: () -> Boolean,
+  ) : this(
+    scope = scope,
+    prefs = prefs,
+    json = json,
+    requestSender = GatewaySessionRequestSender(operatorSession),
+    isConnected = isConnected,
+  )
+
   private var suppressWakeWordsSync = false
   private var wakeWordsSyncJob: Job? = null
 
@@ -42,7 +56,7 @@ class GatewayEventHandler(
         val jsonList = snapshot.joinToString(separator = ",") { it.toJsonString() }
         val params = """{"triggers":[$jsonList]}"""
         try {
-          operatorSession.request("voicewake.set", params)
+          requestSender.request("voicewake.set", params)
         } catch (_: Throwable) {
           // ignore
         }
@@ -53,7 +67,7 @@ class GatewayEventHandler(
   suspend fun refreshWakeWordsFromGateway() {
     if (!isConnected()) return
     try {
-      val res = operatorSession.request("voicewake.get", "{}")
+      val res = requestSender.request("voicewake.get", "{}")
       val payload = json.parseToJsonElement(res).asObjectOrNull() ?: return
       val array = payload["triggers"] as? JsonArray ?: return
       val triggers = array.mapNotNull { it.asStringOrNull() }
@@ -75,4 +89,20 @@ class GatewayEventHandler(
       // ignore
     }
   }
+}
+
+internal fun interface GatewayRequestSender {
+  suspend fun request(
+    method: String,
+    paramsJson: String?,
+  ): String
+}
+
+private class GatewaySessionRequestSender(
+  private val session: GatewaySession,
+) : GatewayRequestSender {
+  override suspend fun request(
+    method: String,
+    paramsJson: String?,
+  ): String = session.request(method, paramsJson)
 }

--- a/apps/android/app/src/test/java/ai/openclaw/app/node/GatewayEventHandlerTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/node/GatewayEventHandlerTest.kt
@@ -1,0 +1,149 @@
+package ai.openclaw.app.node
+
+import android.content.Context
+import ai.openclaw.app.SecurePrefs
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.advanceTimeBy
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.jsonArray
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.RuntimeEnvironment
+import org.robolectric.annotation.Config
+import kotlin.coroutines.EmptyCoroutineContext
+
+@OptIn(ExperimentalCoroutinesApi::class)
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [34])
+class GatewayEventHandlerTest {
+  @Test
+  fun scheduleWakeWordsSyncIfNeeded_debouncesLatestLocalWakeWords() =
+    runTest {
+      val sender = FakeGatewayRequestSender()
+      val prefs = securePrefs()
+      val handler = eventHandler(scope = this, prefs = prefs, sender = sender)
+
+      prefs.setWakeWords(listOf("first"))
+      handler.scheduleWakeWordsSyncIfNeeded()
+      advanceTimeBy(649)
+
+      prefs.setWakeWords(listOf("second", "third"))
+      handler.scheduleWakeWordsSyncIfNeeded()
+      advanceTimeBy(650)
+      advanceUntilIdle()
+
+      assertEquals(1, sender.requests.size)
+      assertEquals("voicewake.set", sender.requests.single().method)
+      assertEquals(listOf("second", "third"), triggersFromParams(sender.requests.single().paramsJson))
+    }
+
+  @Test
+  fun scheduleWakeWordsSyncIfNeeded_skipsWhenDisconnected() =
+    runTest {
+      val sender = FakeGatewayRequestSender()
+      val prefs = securePrefs()
+      val handler = eventHandler(scope = this, prefs = prefs, sender = sender, connected = false)
+
+      prefs.setWakeWords(listOf("offline"))
+      handler.scheduleWakeWordsSyncIfNeeded()
+      advanceTimeBy(650)
+      advanceUntilIdle()
+
+      assertEquals(emptyList<GatewayRequest>(), sender.requests)
+    }
+
+  @Test
+  fun refreshWakeWordsFromGateway_appliesGatewayTriggers() =
+    runTest {
+      val sender =
+        FakeGatewayRequestSender(responseJson = """{"triggers":[" molty ","openclaw",""]}""")
+      val prefs = securePrefs()
+      val handler = eventHandler(prefs = prefs, sender = sender)
+
+      handler.refreshWakeWordsFromGateway()
+
+      assertEquals(listOf("molty", "openclaw"), prefs.wakeWords.value)
+      assertEquals(listOf(GatewayRequest("voicewake.get", "{}")), sender.requests)
+    }
+
+  @Test
+  fun refreshWakeWordsFromGateway_preservesWakeWordsOnMalformedResponse() =
+    runTest {
+      val sender = FakeGatewayRequestSender(responseJson = """{"triggers":"not-an-array"}""")
+      val prefs = securePrefs()
+      prefs.setWakeWords(listOf("existing"))
+      val handler = eventHandler(prefs = prefs, sender = sender)
+
+      handler.refreshWakeWordsFromGateway()
+
+      assertEquals(listOf("existing"), prefs.wakeWords.value)
+    }
+
+  @Test
+  fun handleVoiceWakeChangedEvent_appliesGatewayTriggersAndIgnoresMalformedPayloads() {
+    val prefs = securePrefs()
+    val handler = eventHandler(prefs = prefs, sender = FakeGatewayRequestSender())
+
+    handler.handleVoiceWakeChangedEvent("""{"triggers":[" gateway ","wake"]}""")
+    handler.handleVoiceWakeChangedEvent("""{"triggers":42}""")
+    handler.handleVoiceWakeChangedEvent("{")
+
+    assertEquals(listOf("gateway", "wake"), prefs.wakeWords.value)
+  }
+
+  private fun eventHandler(
+    scope: CoroutineScope = CoroutineScope(EmptyCoroutineContext),
+    prefs: SecurePrefs,
+    sender: GatewayRequestSender,
+    connected: Boolean = true,
+  ): GatewayEventHandler =
+    GatewayEventHandler(
+      scope = scope,
+      prefs = prefs,
+      json = Json,
+      requestSender = sender,
+      isConnected = { connected },
+    )
+
+  private fun securePrefs(): SecurePrefs {
+    val context = RuntimeEnvironment.getApplication()
+    context.getSharedPreferences("openclaw.node", Context.MODE_PRIVATE).edit().clear().commit()
+    return SecurePrefs(context)
+  }
+
+  private fun triggersFromParams(paramsJson: String?): List<String> {
+    requireNotNull(paramsJson)
+    return Json
+      .parseToJsonElement(paramsJson)
+      .jsonObject["triggers"]
+      ?.jsonArray
+      ?.map { it.jsonPrimitive.content }
+      .orEmpty()
+  }
+}
+
+private data class GatewayRequest(
+  val method: String,
+  val paramsJson: String?,
+)
+
+private class FakeGatewayRequestSender(
+  private val responseJson: String = "{}",
+) : GatewayRequestSender {
+  val requests = mutableListOf<GatewayRequest>()
+
+  override suspend fun request(
+    method: String,
+    paramsJson: String?,
+  ): String {
+    requests += GatewayRequest(method, paramsJson)
+    return responseJson
+  }
+}


### PR DESCRIPTION
## What Problem This Solves

Android voice wake gateway synchronization had no focused unit coverage around the `GatewayEventHandler` paths that bridge local wake-word preferences with gateway `voicewake.*` requests and events.

## Why This Change Was Made

This adds a narrow request-sender seam while preserving the existing `GatewaySession` constructor path, then covers the urgent behavior directly:

- local wake-word edits debounce to one latest `voicewake.set` request
- disconnected state skips outbound sync
- `voicewake.get` refresh applies gateway triggers into `SecurePrefs`
- malformed refresh responses preserve existing wake words
- `voicewake.changed` events apply valid triggers and ignore malformed payloads

The production request path still delegates to `GatewaySession.request`; the seam only lets tests drive the request boundary without opening a real gateway connection.

## User Impact

Future Android voice wake changes are less likely to regress settings synchronization or spam stale wake-word updates back to the gateway if this helper remains part of the near-term Android path.

## Evidence

Local focused proof, rerun July 3, 2026 on branch head `a9964d605496`:

```text
$ git diff --check upstream/main...HEAD
git diff --check upstream/main...HEAD exit=0

$ cd apps/android && ./gradlew :app:testThirdPartyDebugUnitTest --tests ai.openclaw.app.node.GatewayEventHandlerTest --console=plain --no-daemon -Dorg.gradle.java.home=$JAVA_HOME
> Task :app:testThirdPartyDebugUnitTest
BUILD SUCCESSFUL in 10s
30 actionable tasks: 5 executed, 25 up-to-date

$ cd apps/android && ./gradlew :app:testPlayDebugUnitTest --tests ai.openclaw.app.node.GatewayEventHandlerTest --console=plain --no-daemon -Dorg.gradle.java.home=$JAVA_HOME
> Task :app:testPlayDebugUnitTest
BUILD SUCCESSFUL in 10s
30 actionable tasks: 5 executed, 25 up-to-date
```

Live CI proof for this head:

- `gh pr checks 99214`: 19 pass, 22 skipping, 0 fail, 0 pending.
- `android-test-third-party`: pass, https://github.com/openclaw/openclaw/actions/runs/28616049878/job/84860112283
- `android-test-play`: pass, https://github.com/openclaw/openclaw/actions/runs/28616049878/job/84860112312
- `android-build-play`: pass, https://github.com/openclaw/openclaw/actions/runs/28616049878/job/84860112317
- `native-i18n`: pass, https://github.com/openclaw/openclaw/actions/runs/28616049878/job/84860112160

Code-path and scope proof:

- `GatewayEventHandler` still owns the `voicewake.set`, `voicewake.get`, and `voicewake.changed` logic under test.
- `SecurePrefs.setWakeWords` / `loadWakeWords` remain the preference boundary exercised by the handler tests.
- Source search found only the handler and tests using `GatewayEventHandler` in the Android app, so this PR does not claim a live app caller is already wired. It is coverage for preserving or intentionally deciding the helper contract; maintainers can still choose to pair it with a later wire-up/removal decision.
- `.agents/skills/autoreview/scripts/autoreview --mode local` was clean with no accepted/actionable findings before push.

AI-assisted: yes
