### PR TITLE
test: cover Android main activity lifecycle gates

### DIFF
--- a/apps/.i18n/native-source.json
+++ b/apps/.i18n/native-source.json
@@ -3,7 +3,7 @@
   "entries": [
     {
       "kind": "ui-named-argument",
-      "line": 203,
+      "line": 250,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/MainActivity.kt",
       "source": "OPENCLAW",
       "surface": "android",

--- a/apps/android/app/src/main/java/ai/openclaw/app/MainActivity.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/MainActivity.kt
@@ -43,15 +43,14 @@ class MainActivity : ComponentActivity() {
   private val viewModel: MainViewModel by viewModels()
   private lateinit var permissionRequester: PermissionRequester
   private var initializedViewModel: MainViewModel? = null
-  private var didAttachRuntimeUi = false
-  private var didStartNodeService = false
   private var didStartViewModelCollectors = false
   private var foreground = false
-  private var pendingIntent: Intent? = null
+  private val pendingIntentRouter = MainActivityPendingIntentRouter()
+  private val runtimeUiStarter = MainActivityRuntimeUiStarter()
 
   override fun onCreate(savedInstanceState: Bundle?) {
     super.onCreate(savedInstanceState)
-    pendingIntent = intent
+    pendingIntentRouter.setInitialIntent(intent)
     WindowCompat.setDecorFitsSystemWindows(window, false)
     permissionRequester = PermissionRequester(this)
     if (BuildConfig.DEBUG) {
@@ -119,8 +118,9 @@ class MainActivity : ComponentActivity() {
   override fun onNewIntent(intent: android.content.Intent) {
     super.onNewIntent(intent)
     setIntent(intent)
-    pendingIntent = intent
-    initializedViewModel?.let { handleAssistantIntent(viewModel = it, intent = intent) }
+    pendingIntentRouter.onNewIntent(intent) { routedIntent ->
+      initializedViewModel?.let { handleAssistantIntent(viewModel = it, intent = routedIntent) }
+    }
   }
 
   /**
@@ -131,9 +131,8 @@ class MainActivity : ComponentActivity() {
     initializedViewModel = readyViewModel
     readyViewModel.setForeground(foreground)
     startViewModelCollectors(readyViewModel)
-    pendingIntent?.let { initialIntent ->
+    pendingIntentRouter.activate { initialIntent ->
       handleAssistantIntent(viewModel = readyViewModel, intent = initialIntent)
-      pendingIntent = null
     }
   }
 
@@ -159,14 +158,16 @@ class MainActivity : ComponentActivity() {
     lifecycleScope.launch {
       repeatOnLifecycle(Lifecycle.State.STARTED) {
         readyViewModel.runtimeInitialized.collect { ready ->
-          if (!ready || didAttachRuntimeUi) return@collect
-          // Runtime UI helpers need an Activity owner, so attach once after NodeRuntime is ready.
-          readyViewModel.attachRuntimeUi(owner = this@MainActivity, permissionRequester = permissionRequester)
-          didAttachRuntimeUi = true
-          if (!didStartNodeService) {
-            NodeForegroundService.start(this@MainActivity)
-            didStartNodeService = true
-          }
+          runtimeUiStarter.onRuntimeInitialized(
+            ready = ready,
+            attachRuntimeUi = {
+              // Runtime UI helpers need an Activity owner, so attach once after NodeRuntime is ready.
+              readyViewModel.attachRuntimeUi(owner = this@MainActivity, permissionRequester = permissionRequester)
+            },
+            startNodeService = {
+              NodeForegroundService.start(this@MainActivity)
+            },
+          )
         }
       }
     }
@@ -185,6 +186,52 @@ class MainActivity : ComponentActivity() {
     }
     val request = parseAssistantLaunchIntent(intent) ?: return
     viewModel.handleAssistantLaunch(request)
+  }
+}
+
+internal class MainActivityPendingIntentRouter {
+  private var activated = false
+  private var pendingIntent: Intent? = null
+
+  fun setInitialIntent(intent: Intent?) {
+    if (!activated) {
+      pendingIntent = intent
+    }
+  }
+
+  fun onNewIntent(
+    intent: Intent,
+    routeIntent: (Intent) -> Unit,
+  ) {
+    if (activated) {
+      routeIntent(intent)
+      return
+    }
+    pendingIntent = intent
+  }
+
+  fun activate(routeIntent: (Intent) -> Unit): Boolean {
+    if (activated) return false
+    activated = true
+    val intent = pendingIntent ?: return true
+    pendingIntent = null
+    routeIntent(intent)
+    return true
+  }
+}
+
+internal class MainActivityRuntimeUiStarter {
+  private var didAttachRuntimeUi = false
+
+  fun onRuntimeInitialized(
+    ready: Boolean,
+    attachRuntimeUi: () -> Unit,
+    startNodeService: () -> Unit,
+  ) {
+    if (!ready || didAttachRuntimeUi) return
+    attachRuntimeUi()
+    didAttachRuntimeUi = true
+    startNodeService()
   }
 }
 

--- a/apps/android/app/src/test/java/ai/openclaw/app/MainActivityLifecycleTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/MainActivityLifecycleTest.kt
@@ -1,0 +1,75 @@
+package ai.openclaw.app
+
+import android.content.Intent
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [34])
+class MainActivityLifecycleTest {
+  @Test
+  fun pendingIntentRouter_defersInitialIntentUntilActivationAndConsumesOnce() {
+    val router = MainActivityPendingIntentRouter()
+    val routedActions = mutableListOf<String?>()
+
+    router.setInitialIntent(Intent("ai.openclaw.FIRST"))
+
+    assertTrue(router.activate { intent -> routedActions += intent.action })
+    assertFalse(router.activate { intent -> routedActions += intent.action })
+
+    assertEquals(listOf("ai.openclaw.FIRST"), routedActions)
+  }
+
+  @Test
+  fun pendingIntentRouter_routesLatestIntentReceivedBeforeActivation() {
+    val router = MainActivityPendingIntentRouter()
+    val routedActions = mutableListOf<String?>()
+
+    router.setInitialIntent(Intent("ai.openclaw.FIRST"))
+    router.onNewIntent(Intent("ai.openclaw.SECOND")) { intent -> routedActions += intent.action }
+
+    assertTrue(router.activate { intent -> routedActions += intent.action })
+
+    assertEquals(listOf("ai.openclaw.SECOND"), routedActions)
+  }
+
+  @Test
+  fun pendingIntentRouter_routesNewIntentImmediatelyAfterActivation() {
+    val router = MainActivityPendingIntentRouter()
+    val routedActions = mutableListOf<String?>()
+
+    assertTrue(router.activate { intent -> routedActions += intent.action })
+    router.onNewIntent(Intent("ai.openclaw.NEXT")) { intent -> routedActions += intent.action }
+
+    assertEquals(listOf("ai.openclaw.NEXT"), routedActions)
+  }
+
+  @Test
+  fun runtimeUiStarter_attachesRuntimeUiAndStartsServiceOnceWhenReady() {
+    val starter = MainActivityRuntimeUiStarter()
+    val calls = mutableListOf<String>()
+
+    starter.onRuntimeInitialized(
+      ready = false,
+      attachRuntimeUi = { calls += "attach" },
+      startNodeService = { calls += "service" },
+    )
+    starter.onRuntimeInitialized(
+      ready = true,
+      attachRuntimeUi = { calls += "attach" },
+      startNodeService = { calls += "service" },
+    )
+    starter.onRuntimeInitialized(
+      ready = true,
+      attachRuntimeUi = { calls += "attach-again" },
+      startNodeService = { calls += "service-again" },
+    )
+
+    assertEquals(listOf("attach", "service"), calls)
+  }
+}


### PR DESCRIPTION
## What Problem This Solves

Android `MainActivity` lifecycle wiring had little focused coverage around the gates that defer initial intents until ViewModel activation, route new intents after activation, and attach runtime UI/service side effects only once after runtime startup.

## Why This Change Was Made

This extracts the lifecycle decisions into small package-internal helpers and covers the urgent behavior without launching the full Compose Activity:

- initial intents are deferred until activation and consumed once
- newer intents received before activation replace the stale pending intent
- intents received after activation route immediately
- runtime UI attachment and foreground service start only once when runtime initialization becomes ready
- the native i18n inventory is synchronized after moving the `OPENCLAW` source line

The Activity still owns the actual ViewModel, Compose, runtime UI, and service calls; the helpers only make the existing gating rules directly testable. The branch is rebased on the upstream reply-init fixture stabilization from #99212 instead of carrying a duplicate core-test patch.

## User Impact

Future Android startup changes are less likely to drop assistant launch intents, replay stale intents, or duplicate runtime UI/service startup work around Activity lifecycle transitions.

## Evidence

Local focused proof, rerun July 3, 2026 on branch head `d4f14df17fc9`:

```text
$ git diff --check upstream/main...HEAD
git diff --check upstream/main...HEAD exit=0

$ node --import tsx scripts/native-app-i18n.ts check
native-app-i18n: entries=2359 changed=false

$ cd apps/android && ./gradlew :app:testThirdPartyDebugUnitTest --tests ai.openclaw.app.MainActivityLifecycleTest --console=plain --no-daemon -Dorg.gradle.java.home=$JAVA_HOME
> Task :app:testThirdPartyDebugUnitTest
BUILD SUCCESSFUL in 11s
30 actionable tasks: 6 executed, 24 up-to-date

$ cd apps/android && ./gradlew :app:testPlayDebugUnitTest --tests ai.openclaw.app.MainActivityLifecycleTest --console=plain --no-daemon -Dorg.gradle.java.home=$JAVA_HOME
> Task :app:testPlayDebugUnitTest
BUILD SUCCESSFUL in 11s
30 actionable tasks: 6 executed, 24 up-to-date
```

Live CI proof for this head:

- `gh pr checks 99215`: 60 pass, 19 skipping, 0 fail, 0 pending.
- `android-test-third-party`: pass, https://github.com/openclaw/openclaw/actions/runs/28616860288/job/84862810264
- `android-test-play`: pass, https://github.com/openclaw/openclaw/actions/runs/28616860288/job/84862810282
- `android-build-play`: pass, https://github.com/openclaw/openclaw/actions/runs/28616860288/job/84862810248
- `native-i18n`: pass, https://github.com/openclaw/openclaw/actions/runs/28616860288/job/84862809929
- `QA Smoke CI`: pass, https://github.com/openclaw/openclaw/actions/runs/28616860288/job/84862809976
- `checks-node-compact-small-whole-2`: pass, https://github.com/openclaw/openclaw/actions/runs/28616860288/job/84862810558

Code-path proof:

- `MainActivity.onCreate` stores the initial intent, `activateViewModel` consumes it after ViewModel activation, and `onNewIntent` routes later intents through `MainActivityPendingIntentRouter`.
- The runtime-start side effects are now gated by `MainActivityRuntimeUiStarter`, which is driven from the existing `runtimeInitialized` collector.
- `MainActivityLifecycleTest` covers deferred initial intent routing, replacement of stale pre-activation intents, immediate post-activation routing, and one-time runtime UI/service startup.
- `.agents/skills/autoreview/scripts/autoreview --mode local` was clean with no accepted/actionable findings before push.

AI-assisted: yes
