### PR TITLE
feat(plugins): expose read-only model.usage stream to plugin services

### DIFF
--- a/src/plugins/services.test.ts
+++ b/src/plugins/services.test.ts
@@ -420,4 +420,19 @@ describe("startPluginServices", () => {
 
     expect(spoofedContexts[0]?.internalDiagnostics).toBeUndefined();
   });
+
+  it("exposes a read-only modelUsage stream to every plugin service", async () => {
+    // A non-exporter, untrusted (workspace-origin) plugin gets no internalDiagnostics
+    // grant, yet still receives the public read-only model.usage cost stream — so
+    // cost-accounting plugins like tokenomics work without the exporter-only grant.
+    const contexts: OpenClawPluginServiceContext[] = [];
+    const service = createTrackingService("tokenomics", { contexts });
+    await startPluginServices({
+      registry: createRegistry([service], "tokenomics", "workspace"),
+      config: createServiceConfig(),
+    });
+
+    expect(contexts[0]?.internalDiagnostics).toBeUndefined();
+    expect(contexts[0]?.modelUsage?.onEvent).toBeTypeOf("function");
+  });
 });

--- a/src/plugins/services.ts
+++ b/src/plugins/services.ts
@@ -57,6 +57,19 @@ function createServiceContext(params: {
           },
         }
       : {}),
+    // Public, read-only cost/usage stream for every plugin service. Wraps the
+    // internal diagnostic subscription but forwards only `model.usage` events and
+    // drops metadata + privateData, so cost-accounting plugins (e.g. tokenomics)
+    // work without the exporter-only `internalDiagnostics` grant above — no
+    // bundled-only backdoor, no prompt/response content, no `emit`.
+    modelUsage: {
+      onEvent: (listener) =>
+        onTrustedInternalDiagnosticEvent((event) => {
+          if (event.type === "model.usage") {
+            listener(event);
+          }
+        }),
+    },
   };
 }
 

--- a/src/plugins/types.ts
+++ b/src/plugins/types.ts
@@ -33,6 +33,7 @@ import type {
   DiagnosticEventInput,
   DiagnosticEventMetadata,
   DiagnosticEventPayload,
+  DiagnosticUsageEvent,
 } from "../infra/diagnostic-events.js";
 import type { ProviderUsageSnapshot } from "../infra/provider-usage.types.js";
 import type { ModelRegistry } from "../llm/model-registry.js";
@@ -2354,6 +2355,15 @@ export type OpenClawPluginServiceContext = {
         privateData: DiagnosticEventPrivateData,
       ) => void,
     ) => () => void;
+  };
+  // Read-only stream of public `model.usage` cost/usage events (provider, model,
+  // token counts, costUsd, durationMs — no prompt/response content, no `emit`).
+  // Available to every plugin service so cost-accounting plugins (e.g. tokenomics)
+  // work without the exporter-only `internalDiagnostics` grant above, which also
+  // exposes private data + arbitrary emit and stays restricted to trusted bundled
+  // diagnostics exporters.
+  modelUsage?: {
+    onEvent: (listener: (event: DiagnosticUsageEvent) => void) => () => void;
   };
 };
 


### PR DESCRIPTION
## What Problem This Solves

External plugins that consume model-usage diagnostics can't record anything. On `2026.7.1-beta.1`, installing the tokenomics ClawHub plugin (`@perlowja/tokenomics`) loads cleanly but logs at startup:

```
[plugins] tokenomics: no model-usage capability (ctx.modelUsage or internalDiagnostics) available; spend will not be recorded
```

In `src/plugins/services.ts`, `createServiceContext` grants `internalDiagnostics` only to the `diagnostics-otel` / `diagnostics-prometheus` bundled/official exporters, and there is no `ctx.modelUsage`. So any third-party plugin that needs `model.usage` events — cost/FinOps trackers, custom exporters — silently records nothing, even when the operator trusts it via `plugins.allow`. That's a bundled-only capability external plugins can't reach, which the plugin-boundary guide says we shouldn't ship.

## Why This Change Was Made

`model.usage` (`DiagnosticUsageEvent`) is public cost/usage metadata — provider, model, token counts, `costUsd`, `durationMs` — with no prompt/response content (that lives in `privateData`). Exposing a **read-only** slice to plugin services is safe and is the seam the boundary guide asks for, whereas the full `internalDiagnostics` (arbitrary `emit` + `privateData` + all event types) legitimately stays exporter-gated.

This adds `ctx.modelUsage.onEvent(listener)` to `OpenClawPluginServiceContext`, populated for every plugin service. It wraps the internal diagnostic subscription but forwards **only** `model.usage` events and drops `metadata` + `privateData` — no `emit`, no content, no bundled-only backdoor.

## User Impact

Cost-accounting plugins work again: the tokenomics plugin (and any `model.usage` consumer) records spend and serves its report. No behavior change for existing bundled diagnostics exporters — they still receive the full `internalDiagnostics`. Additive, opt-in field on the plugin service context; no config, no migration.

## Evidence

- Repro on `2026.7.1-beta.1`: `openclaw plugins install clawhub:@perlowja/tokenomics` → gateway logs the "no model-usage capability … spend will not be recorded" error; **persists with `plugins.allow: ["tokenomics"]`** (not a trust-config issue).
- Root cause: the plugin checks `ctx.modelUsage` then `ctx.internalDiagnostics?.onEvent`, gets neither; the grant is `isDiagnosticsExporter && (origin === "bundled" || trustedOfficialInstall)`.
- `pnpm test src/plugins/services.test.ts` → **8 passed** (adds a test: an untrusted workspace-origin plugin gets `modelUsage.onEvent` but not `internalDiagnostics`).
- `pnpm tsgo:core` clean; `oxfmt --check` clean on the 3 touched files.

---
Enables `@perlowja/tokenomics` (submitted in #97149). cc @jacobtomlinson @RomneyDa — flagging for design input on the seam: a read-only `ctx.modelUsage` (this PR) vs. broadening the `internalDiagnostics` grant.
