### PR TITLE
fix(ios): onboarding Retry Connection does nothing after editing gateway details

### DIFF
--- a/apps/ios/Sources/Onboarding/OnboardingWizardView.swift
+++ b/apps/ios/Sources/Onboarding/OnboardingWizardView.swift
@@ -1034,7 +1034,25 @@ extension OnboardingWizardView {
             self.statusLine = "Retrying last connection…"
         }
         defer { self.connectingGatewayID = nil }
-        await self.gatewayController.connectLastKnown()
+
+        switch GatewaySettingsStore.loadLastGatewayConnection() {
+        case .some(.discovered):
+            await self.gatewayController.connectLastKnown()
+        case .some(.manual), .none:
+            // connectLastKnown() replays the persisted endpoint and credentials,
+            // so token/host/port edits made on this screen would be ignored and
+            // a missing stored connection would silently do nothing. Manual
+            // retries must dial the current form input instead.
+            let host = self.manualHost.trimmingCharacters(in: .whitespacesAndNewlines)
+            if !host.isEmpty, self.manualPort > 0, self.manualPort <= 65535 {
+                await self.connectManual()
+                return
+            }
+            if !silent {
+                self.connectMessage = nil
+                self.statusLine = "No connection to retry. Check the gateway host and port."
+            }
+        }
     }
 
     private func gatewayProblemPrimaryActionTitle(_ problem: GatewayConnectionProblem) -> String? {

--- a/apps/ios/Sources/Onboarding/OnboardingWizardView.swift
+++ b/apps/ios/Sources/Onboarding/OnboardingWizardView.swift
@@ -1014,6 +1014,10 @@ extension OnboardingWizardView {
         self.connectMessage = "Connecting to \(host)…"
         self.statusLine = "Connecting to \(host):\(self.manualPort)…"
         defer { self.connectingGatewayID = nil }
+        await self.connectCurrentManualGateway(host: host, forceReconnect: false)
+    }
+
+    private func connectCurrentManualGateway(host: String, forceReconnect: Bool) async {
         let authOverride = GatewayConnectionController.ManualAuthOverride.currentManualInput(
             token: self.gatewayToken,
             pendingOverride: self.pendingManualAuthOverride,
@@ -1023,7 +1027,8 @@ extension OnboardingWizardView {
             host: host,
             port: self.manualPort,
             useTLS: self.manualTLS,
-            authOverride: authOverride)
+            authOverride: authOverride,
+            forceReconnect: forceReconnect)
     }
 
     private func retryLastAttempt(silent: Bool = false) async {
@@ -1045,7 +1050,7 @@ extension OnboardingWizardView {
             // retries must dial the current form input instead.
             let host = self.manualHost.trimmingCharacters(in: .whitespacesAndNewlines)
             if !host.isEmpty, self.manualPort > 0, self.manualPort <= 65535 {
-                await self.connectManual()
+                await self.connectCurrentManualGateway(host: host, forceReconnect: true)
                 return
             }
             if !silent {

--- a/apps/ios/UITests/OpenClawSnapshotUITests.swift
+++ b/apps/ios/UITests/OpenClawSnapshotUITests.swift
@@ -392,6 +392,51 @@ final class OpenClawSnapshotUITests: XCTestCase {
         XCTAssertEqual(controlApp.state, .runningForeground)
     }
 
+    func testManualAuthRetryUsesEditedToken() throws {
+        try XCTSkipUnless(
+            ProcessInfo.processInfo.environment["OPENCLAW_IOS_RETRY_E2E"] == "1",
+            "Set OPENCLAW_IOS_RETRY_E2E=1 with a local token-auth Gateway on port 18920")
+        let token = try XCTUnwrap(ProcessInfo.processInfo.environment["OPENCLAW_IOS_RETRY_TOKEN"])
+
+        let app = XCUIApplication()
+        addUIInterruptionMonitor(withDescription: "Local network access") { alert in
+            guard alert.buttons["Allow"].exists else { return false }
+            alert.buttons["Allow"].tap()
+            return true
+        }
+        app.launchArguments += ["--openclaw-reset-onboarding"]
+        app.launch()
+        self.app = app
+
+        XCTAssertTrue(app.buttons["Continue"].waitForExistence(timeout: 8))
+        app.buttons["Continue"].tap()
+        app.tap()
+        XCTAssertTrue(app.buttons["Set Up Manually"].waitForExistence(timeout: 8))
+        app.buttons["Set Up Manually"].tap()
+        let developerMode = app.buttons["Developer mode"]
+        if developerMode.value as? String != "On" {
+            developerMode.tap()
+        }
+        app.buttons.matching(NSPredicate(format: "label BEGINSWITH %@", "Same Machine (Dev)")).firstMatch.tap()
+        app.buttons["Continue"].tap()
+
+        let port = app.textFields["Port"]
+        XCTAssertTrue(port.waitForExistence(timeout: 5))
+        port.tap()
+        port.typeText(String(repeating: XCUIKeyboardKey.delete.rawValue, count: 5) + "18920")
+        app.buttons["Connect"].tap()
+
+        let tokenField = app.secureTextFields["Gateway Auth Token"]
+        XCTAssertTrue(tokenField.waitForExistence(timeout: 20))
+        tokenField.tap()
+        tokenField.typeText(token)
+        app.buttons["Done"].tap()
+        app.buttons["Retry Connection"].tap()
+
+        XCTAssertTrue(app.staticTexts["Connected"].waitForExistence(timeout: 30))
+        self.attachScreenshot(named: "manual-auth-retry-connected")
+    }
+
     private func launchApp(for target: ScreenshotTarget, appearance: String? = "dark") {
         self.app?.terminate()
 


### PR DESCRIPTION
Closes #99219

## What Problem This Solves

Fixes an issue where users on the iOS onboarding Authentication step (Step 3 of 4) who tap **Retry Connection** after editing the gateway auth token — or after fixing host/port/TLS on the previous screen — get no connection attempt at all: no error, no traffic toward the gateway, a seemingly dead button. When a stale last-connection record exists, Retry redials that stale endpoint instead of what is currently on screen. Either way, onboarding dead-ends and the only (undiscoverable) workaround is navigating back and tapping Connect.

## Why This Change Was Made

`retryLastAttempt()` delegated unconditionally to `connectLastKnown()`, which silently returns when `GatewaySettingsStore.loadLastGatewayConnection()` is empty and otherwise replays the persisted endpoint/credentials, ignoring current form input. The fix branches on the stored connection kind: for `.manual` or no stored record, Retry now dials the current form input via the same `connectManual()` path the Connect button uses (which includes the token/password fields); for `.discovered` gateways the existing `connectLastKnown()` behavior is preserved so Bonjour/tailnet flows are unaffected. If there is nothing to retry at all, the status line now says so instead of staying silent.

## User Impact

Users who mistype or paste a token, or correct host/port after a failed attempt, can now recover with Retry Connection directly instead of getting stuck on a button that does nothing. No behavior change for discovered-gateway reconnects.

## Evidence

Reproduced against a source-built dev gateway (`pnpm gateway:dev`, token auth, `ws://127.0.0.1:19001`), iPhone 17 Pro simulator (iOS 26.5), Xcode 26.6.

**Before** — token pasted in the field, Retry tapped repeatedly for ~5 minutes: the gateway websocket log records **zero** incoming connections between the initial empty-token failure and a later manual Connect:

```
22:13:49.809 [ws] unauthorized ... role=node auth=none reason=token_missing   <- initial Connect with empty token (expected)
22:14:20.085 [ws] unauthorized ... role=node auth=none reason=token_missing   <- app auto-retry (expected)
   ... Retry Connection tapped repeatedly ~22:14-22:19: no [ws] entries from the app at all ...
```

**After (this branch)** — identical scenario; Retry Connection immediately dials with the pasted token and pairing proceeds:

```
22:52:08.536 [ws] unauthorized ... role=node auth=none reason=token_missing   <- initial Connect with empty token (expected)
22:52:13.797 [gateway] device pairing auto-approved device=7e68c923... role=operator   <- Retry tapped ~5s later, token now sent
```

Also verified that the fixed build still completes the normal onboarding path end to end (`openclaw --profile dev nodes status` → `Known: 2 · Paired: 2 · Connected: 2` with this device connected), and `xcodebuild ... -scheme OpenClaw` succeeds (build phases include swiftformat/swiftlint).
