### PR TITLE
feat(sessions): add session.allowMainDelete to permit main-session deletion

### DIFF
--- a/src/config/schema.help.quality.test.ts
+++ b/src/config/schema.help.quality.test.ts
@@ -163,6 +163,7 @@ const TARGET_KEYS = [
   "session.typingIntervalSeconds",
   "session.typingMode",
   "session.mainKey",
+  "session.allowMainDelete",
   "session.sendPolicy",
   "session.sendPolicy.default",
   "session.sendPolicy.rules",

--- a/src/config/schema.help.ts
+++ b/src/config/schema.help.ts
@@ -1650,6 +1650,8 @@ export const FIELD_HELP: Record<string, string> = {
     'Controls typing behavior timing: "never", "instant", "thinking", or "message" based emission points. Keep conservative modes in high-volume channels to avoid unnecessary typing noise.',
   "session.mainKey":
     'Overrides the canonical main session key used for continuity when dmScope or routing logic points to "main". Use a stable value only if you intentionally need custom session anchoring.',
+  "session.allowMainDelete":
+    "Allows sessions.delete to remove the main session entry instead of rejecting it (default: false). The gateway recreates the main session on the next inbound event, so enable this only for deliberate cleanup flows.",
   "session.sendPolicy":
     "Controls cross-session send permissions using allow/deny rules evaluated against channel, chatType, and key prefixes. Use this to fence where session tools can deliver messages in complex environments.",
   "session.sendPolicy.default":

--- a/src/config/schema.labels.ts
+++ b/src/config/schema.labels.ts
@@ -831,6 +831,7 @@ export const FIELD_LABELS: Record<string, string> = {
   "session.typingIntervalSeconds": "Session Typing Interval (seconds)",
   "session.typingMode": "Session Typing Mode",
   "session.mainKey": "Session Main Key",
+  "session.allowMainDelete": "Allow Main Session Delete",
   "session.sendPolicy": "Session Send Policy",
   "session.sendPolicy.default": "Session Send Policy Default Action",
   "session.sendPolicy.rules": "Session Send Policy Rules",

--- a/src/config/types.base.ts
+++ b/src/config/types.base.ts
@@ -225,6 +225,12 @@ export type SessionConfig = {
   typingIntervalSeconds?: number;
   typingMode?: TypingMode;
   mainKey?: string;
+  /**
+   * Allow deleting the main session via sessions.delete (default: false).
+   * The gateway recreates the main session on the next inbound event, so
+   * deleting only clears its stored entry and archives the transcript.
+   */
+  allowMainDelete?: boolean;
   sendPolicy?: SessionSendPolicyConfig;
   /** Session transcript write-lock acquisition policy. */
   writeLock?: SessionWriteLockConfig;

--- a/src/config/zod-schema.session.ts
+++ b/src/config/zod-schema.session.ts
@@ -56,6 +56,7 @@ export const SessionSchema = z
     typingIntervalSeconds: z.number().int().positive().optional(),
     typingMode: TypingModeSchema.optional(),
     mainKey: z.string().optional(),
+    allowMainDelete: z.boolean().optional(),
     sendPolicy: SessionSendPolicySchema.optional(),
     writeLock: z
       .object({

--- a/src/gateway/server-methods/sessions.ts
+++ b/src/gateway/server-methods/sessions.ts
@@ -2231,11 +2231,15 @@ export const sessionsHandlers: GatewayRequestHandlers = {
       target.canonicalKey === "global" &&
       requestedAgentId !== undefined &&
       requestedAgentId !== resolveDefaultAgentId(cfg);
-    if (target.canonicalKey === mainKey && !isSelectedNonDefaultGlobal) {
+    const allowMainDelete = cfg.session?.allowMainDelete === true;
+    if (target.canonicalKey === mainKey && !isSelectedNonDefaultGlobal && !allowMainDelete) {
       respond(
         false,
         undefined,
-        errorShape(ErrorCodes.INVALID_REQUEST, `Cannot delete the main session (${mainKey}).`),
+        errorShape(
+          ErrorCodes.INVALID_REQUEST,
+          `Cannot delete the main session (${mainKey}). Set session.allowMainDelete to permit this.`,
+        ),
       );
       return;
     }

--- a/src/gateway/server.sessions.delete-lifecycle.test.ts
+++ b/src/gateway/server.sessions.delete-lifecycle.test.ts
@@ -8,7 +8,7 @@ import {
   writeAcpSessionMetaForMigration,
 } from "../acp/runtime/session-meta.js";
 import { closeOpenClawStateDatabaseForTest } from "../state/openclaw-state-db.js";
-import { embeddedRunMock, rpcReq, writeSessionStore } from "./test-helpers.js";
+import { embeddedRunMock, rpcReq, testState, writeSessionStore } from "./test-helpers.js";
 import {
   setupGatewaySessionsTestHarness,
   sessionLifecycleHookMocks,
@@ -132,6 +132,24 @@ test("sessions.delete rejects main and aborts active runs", async () => {
     targetSessionKey: "agent:main:discord:group:dev",
     reason: "session-delete",
   });
+});
+
+test("sessions.delete removes main when session.allowMainDelete is enabled", async () => {
+  const { dir } = await createSessionStoreDir();
+  await writeSingleLineSession(dir, "sess-main", "hello");
+
+  await writeSessionStore({
+    entries: {
+      main: sessionStoreEntry("sess-main"),
+    },
+  });
+
+  testState.sessionConfig = { allowMainDelete: true };
+  try {
+    await expectSessionDeleteSucceeds({ key: "main" });
+  } finally {
+    testState.sessionConfig = undefined;
+  }
 });
 
 test("sessions.delete limits plugin-runtime cleanup to sessions owned by that plugin", async () => {


### PR DESCRIPTION
## What

Adds a new opt-in config flag `session.allowMainDelete` (default: `false`). When enabled, the `sessions.delete` RPC may delete the main session, which is currently blocked by a hard-coded guard.

## Why

The main-session delete guard in `sessions.delete` is unconditional (except for non-default global agents). Users who intentionally want to reset/delete their main session — e.g. for lifecycle automation or self-hosted setups — have no supported way to do so. This makes the guard configurable while keeping the safe default: behavior is unchanged unless the flag is explicitly set.

## Changes

- Guard in `src/gateway/server-methods/sessions.ts` now checks `session.allowMainDelete`; the error message mentions the flag so users can discover it
- Zod schema, TypeScript type (with doc comment), config label and help text in `src/config/…`
- New test: main-session delete succeeds with the flag enabled (existing test still covers the default-deny path)

## Verification

- `tsgo` typecheck clean
- Config schema tests 23/23, delete-lifecycle tests 24/24 (incl. new one)
- `oxlint` clean, base-config-schema generator re-run

🤖 Generated with [Claude Code](https://claude.com/claude-code)