### PR TITLE
prompt-prelude: prefer message tool before MEDIA fallback

### DIFF
--- a/src/auto-reply/reply/prompt-prelude.test.ts
+++ b/src/auto-reply/reply/prompt-prelude.test.ts
@@ -200,6 +200,30 @@ describe("buildReplyPromptEnvelope", () => {
     expect(envelope.transcriptCommandBody).toContain("https://example.com/photo.jpg");
   });
 
+  it("pushes media replies toward the message tool first", () => {
+    const sessionCtx = finalizeInboundContext({
+      Body: "",
+      BodyStripped: "",
+      Provider: "telegram",
+      ChatType: "direct",
+      MediaPaths: ["/tmp/openclaw-photo.jpg"],
+    });
+
+    const envelope = buildReplyPromptEnvelope({
+      ctx: sessionCtx,
+      sessionCtx,
+      baseBody: "",
+      hasUserBody: true,
+      inboundUserContext: "",
+      isBareSessionReset: false,
+      startupAction: "new",
+    });
+
+    expect(envelope.prefixedCommandBody).toContain("use the message tool when it is available");
+    expect(envelope.prefixedCommandBody).toContain("one rich message");
+    expect(envelope.prefixedCommandBody).toContain("Only fall back to inline MEDIA:");
+  });
+
   it("keeps soft reset user notes visible without leaking startup context into transcripts", () => {
     const sessionCtx = finalizeInboundContext({
       Body: "",

--- a/src/auto-reply/reply/prompt-prelude.ts
+++ b/src/auto-reply/reply/prompt-prelude.ts
@@ -10,7 +10,7 @@ import type { MsgContext, TemplateContext } from "../templating.js";
 import { appendUntrustedContext } from "./untrusted-context.js";
 
 const REPLY_MEDIA_HINT =
-  "To send an image back, use the message tool with structured media fields such as media, mediaUrl, path, or filePath. Keep caption in the text body.";
+  "To send an image back, use the message tool when it is available so the caption and image ship as one rich message. Pass the image via media/path/filePath and keep the caption in the text body. Only fall back to inline MEDIA:https://example.com/image.jpg or a safe relative path like MEDIA:./image.jpg when the message tool is unavailable. Absolute and ~ paths only work when they stay inside your allowed file-read boundary; host file:// URLs are blocked.";
 const ROOM_EVENT_PROMPT = "[OpenClaw room event]";
 const ROOM_EVENT_SOURCE_REPLY_DELIVERY_MODE = "message_tool_only";
 const RESUMABLE_ROOM_CONTEXT_OMITTED_PREFIXES = [


### PR DESCRIPTION
## Summary

Prefer structured rich-message image delivery before legacy inline `MEDIA:` fallback in reply prompt guidance.

## Problem

When image replies are possible through both a structured message tool and the legacy final-reply `MEDIA:` path, the current prompt hint does not strongly bias the model toward the richer path. In practice this can lead to brittle attachment delivery, split caption/image UX, or fallback behavior being chosen too early.

## Changes

- update reply prompt guidance to prefer the message tool first when it is available
- clarify that caption and image should be sent as one rich message
- keep inline `MEDIA:` as fallback only when no structured send path exists
- add a regression test covering Telegram direct sessions with inbound media context

## Test

- `node scripts/test-projects.mjs src/auto-reply/reply/prompt-prelude.test.ts`
