### PR TITLE
fix: ignore test-only network CI guard lines

### DIFF
--- a/.github/workflows/codeql-critical-quality.yml
+++ b/.github/workflows/codeql-critical-quality.yml
@@ -446,6 +446,7 @@ jobs:
           gh api --paginate "repos/${REPOSITORY}/pulls/${PR_NUMBER}/files" --jq '
             .[]
             | select(.filename | test("^(src/cli/gateway-cli/run-loop\\.ts|src/infra/(gateway-lock|jsonl-socket|push-apns-http2|ssh-tunnel)\\.ts|src/infra/net/|src/proxy-capture/|extensions/codex-supervisor/src/json-rpc-client\\.ts|extensions/irc/src/|extensions/qa-lab/src/|packages/net-policy/src/)"))
+            | select(.filename | test("(^|/)[^/]+\\.(?:e2e\\.)?test\\.tsx?$") | not)
             | .filename as $file
             | (.patch // "")
             | split("\n")[]

--- a/test/scripts/ci-workflow-guards.test.ts
+++ b/test/scripts/ci-workflow-guards.test.ts
@@ -968,6 +968,9 @@ describe("ci workflow guards", () => {
     expect(networkConfig).toContain("\n  - src/infra/net\n");
     expect(networkConfig).toContain("\n  - packages/net-policy/src\n");
     expect(workflow).toContain("Fast PR network boundary diff scan");
+    expect(workflow).toContain(
+      '| select(.filename | test("(^|/)[^/]+\\\\.(?:e2e\\\\.)?test\\\\.tsx?$") | not)',
+    );
     expect(workflow).toContain("Network runtime boundary-sensitive added lines");
     expect(workflow).toContain("if: ${{ github.event_name != 'pull_request' }}");
   });


### PR DESCRIPTION
Related: #98951

## What Problem This Solves

Resolves a problem where the network runtime critical-quality PR scan fails on test-only `NO_PROXY` assertions under `src/infra/net/**`, even when the production network runtime path is unchanged.

## Why This Change Was Made

The fast PR scan should continue to require review for sensitive production network-runtime additions, but test files should be allowed to name proxy environment variables when they are proving the intended boundary behavior. This keeps the guard focused on runtime changes without making SSRF/proxy tests obscure their assertions.

AI-assisted: yes.

## User Impact

No direct user-visible behavior changes. Maintainers can land network-boundary regression tests without tripping the production-sensitive-line guard solely because the test names or stubs `NO_PROXY`.

## Evidence

- `pnpm test test/scripts/ci-workflow-guards.test.ts`
- `pnpm exec oxfmt --check test/scripts/ci-workflow-guards.test.ts`
- `pnpm exec actionlint .github/workflows/codeql-critical-quality.yml`
- `git diff --check`
