### PR TITLE
Expose channel preview warning doctor findings

### DIFF
--- a/src/commands/doctor/shared/preview-warnings.ts
+++ b/src/commands/doctor/shared/preview-warnings.ts
@@ -675,7 +675,7 @@ export type DoctorPreviewNotes = {
   warningNotes: string[];
 };
 
-async function resolveDoctorChannelPreviewConfig(params: {
+export async function resolveDoctorChannelPreviewConfig(params: {
   cfg: OpenClawConfig;
   env: NodeJS.ProcessEnv;
   allowExec?: boolean;

--- a/src/flows/doctor-health-contributions.test.ts
+++ b/src/flows/doctor-health-contributions.test.ts
@@ -122,6 +122,9 @@ const mocks = vi.hoisted(() => ({
     }),
   ),
   collectStalePluginRuntimeSymlinkHealthFindings: vi.fn(async () => [] as unknown[]),
+  collectStartupChannelMaintenanceHealthFindings: vi.fn(
+    async (): Promise<readonly HealthFinding[]> => [],
+  ),
   applyWizardMetadata: vi.fn((cfg: unknown) => cfg),
   logConfigUpdated: vi.fn(),
   isRecord: vi.fn(
@@ -367,6 +370,15 @@ vi.mock("../commands/doctor/shared/channel-plugin-blockers.js", () => ({
   scanConfiguredChannelPluginBlockers: mocks.scanConfiguredChannelPluginBlockers,
   channelPluginBlockerHitToHealthFinding: mocks.channelPluginBlockerHitToHealthFinding,
 }));
+
+vi.mock("./doctor-startup-channel-maintenance.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./doctor-startup-channel-maintenance.js")>();
+  return {
+    ...actual,
+    collectStartupChannelMaintenanceHealthFindings:
+      mocks.collectStartupChannelMaintenanceHealthFindings,
+  };
+});
 
 vi.mock("../commands/onboard-helpers.js", () => ({
   applyWizardMetadata: mocks.applyWizardMetadata,
@@ -1399,6 +1411,7 @@ describe("doctor health contributions", () => {
     expect(contributionIds).toContain("core/doctor/whatsapp-responsiveness");
     expect(contributionIds).toContain("core/doctor/device-pairing");
     expect(contributionIds).toContain("core/doctor/channel-plugin-blockers");
+    expect(contributionIds).toContain("core/doctor/startup-channel-maintenance");
     expect(contributionIds).toContain("core/doctor/tool-result-cap");
     expect(contributionChecks.map((check) => check.id)).toEqual(contributionIds);
   });
@@ -1964,6 +1977,56 @@ describe("doctor health contributions", () => {
       ],
     });
     expect(mocks.scanConfiguredChannelPluginBlockers).toHaveBeenCalledWith(ctx.cfg, process.env);
+  });
+
+  it("keeps startup channel maintenance opt-in for default lint selection", async () => {
+    const contribution = requireDoctorContribution("doctor:startup-channel-maintenance");
+    expect(contribution.healthCheckIds).toEqual([
+      "core/doctor/channel-plugin-blockers",
+      "core/doctor/startup-channel-maintenance",
+    ]);
+    const startupCheck = contribution.healthChecks.find(
+      (check) => check.id === "core/doctor/startup-channel-maintenance",
+    ) as HealthCheck | undefined;
+    expect(startupCheck).toMatchObject({ defaultEnabled: false });
+    expect(startupCheck).toBeDefined();
+    mocks.collectStartupChannelMaintenanceHealthFindings.mockResolvedValue([
+      {
+        checkId: "core/doctor/startup-channel-maintenance",
+        severity: "warning",
+        message: "channels.matrix needs startup maintenance",
+        path: "channels.matrix",
+      },
+    ]);
+
+    const ctx = {
+      cfg: { channels: { matrix: { enabled: true } } },
+      mode: "lint",
+      runtime: { log: vi.fn(), error: vi.fn(), exit: vi.fn() },
+    } as const;
+    const checks = [startupCheck!];
+
+    await expect(runDoctorLintChecks(ctx, { checks })).resolves.toMatchObject({
+      checksRun: 0,
+      checksSkipped: 1,
+    });
+    expect(mocks.collectStartupChannelMaintenanceHealthFindings).not.toHaveBeenCalled();
+
+    await expect(
+      runDoctorLintChecks(ctx, { checks, onlyIds: ["core/doctor/startup-channel-maintenance"] }),
+    ).resolves.toMatchObject({
+      checksRun: 1,
+      checksSkipped: 0,
+      findings: [
+        expect.objectContaining({
+          checkId: "core/doctor/startup-channel-maintenance",
+          path: "channels.matrix",
+        }),
+      ],
+    });
+    expect(mocks.collectStartupChannelMaintenanceHealthFindings).toHaveBeenCalledWith({
+      cfg: ctx.cfg,
+    });
   });
 
   it("uses legacy run when a contribution also declares structured health", async () => {

--- a/src/flows/doctor-health-contributions.test.ts
+++ b/src/flows/doctor-health-contributions.test.ts
@@ -122,7 +122,7 @@ const mocks = vi.hoisted(() => ({
     }),
   ),
   collectStalePluginRuntimeSymlinkHealthFindings: vi.fn(async () => [] as unknown[]),
-  collectStartupChannelMaintenanceHealthFindings: vi.fn(
+  collectChannelPreviewWarningHealthFindings: vi.fn(
     async (): Promise<readonly HealthFinding[]> => [],
   ),
   applyWizardMetadata: vi.fn((cfg: unknown) => cfg),
@@ -375,8 +375,7 @@ vi.mock("./doctor-startup-channel-maintenance.js", async (importOriginal) => {
   const actual = await importOriginal<typeof import("./doctor-startup-channel-maintenance.js")>();
   return {
     ...actual,
-    collectStartupChannelMaintenanceHealthFindings:
-      mocks.collectStartupChannelMaintenanceHealthFindings,
+    collectChannelPreviewWarningHealthFindings: mocks.collectChannelPreviewWarningHealthFindings,
   };
 });
 
@@ -595,6 +594,8 @@ describe("doctor health contributions", () => {
     mocks.channelPluginBlockerHitToHealthFinding.mockClear();
     mocks.collectStalePluginRuntimeSymlinkHealthFindings.mockReset();
     mocks.collectStalePluginRuntimeSymlinkHealthFindings.mockResolvedValue([]);
+    mocks.collectChannelPreviewWarningHealthFindings.mockReset();
+    mocks.collectChannelPreviewWarningHealthFindings.mockResolvedValue([]);
   });
 
   afterEach(() => {
@@ -1411,7 +1412,7 @@ describe("doctor health contributions", () => {
     expect(contributionIds).toContain("core/doctor/whatsapp-responsiveness");
     expect(contributionIds).toContain("core/doctor/device-pairing");
     expect(contributionIds).toContain("core/doctor/channel-plugin-blockers");
-    expect(contributionIds).toContain("core/doctor/startup-channel-maintenance");
+    expect(contributionIds).toContain("core/doctor/channel-preview-warnings");
     expect(contributionIds).toContain("core/doctor/tool-result-cap");
     expect(contributionChecks.map((check) => check.id)).toEqual(contributionIds);
   });
@@ -1979,22 +1980,22 @@ describe("doctor health contributions", () => {
     expect(mocks.scanConfiguredChannelPluginBlockers).toHaveBeenCalledWith(ctx.cfg, process.env);
   });
 
-  it("keeps startup channel maintenance opt-in for default lint selection", async () => {
+  it("keeps channel preview warnings opt-in for default lint selection", async () => {
     const contribution = requireDoctorContribution("doctor:startup-channel-maintenance");
     expect(contribution.healthCheckIds).toEqual([
       "core/doctor/channel-plugin-blockers",
-      "core/doctor/startup-channel-maintenance",
+      "core/doctor/channel-preview-warnings",
     ]);
-    const startupCheck = contribution.healthChecks.find(
-      (check) => check.id === "core/doctor/startup-channel-maintenance",
+    const previewWarningsCheck = contribution.healthChecks.find(
+      (check) => check.id === "core/doctor/channel-preview-warnings",
     ) as HealthCheck | undefined;
-    expect(startupCheck).toMatchObject({ defaultEnabled: false });
-    expect(startupCheck).toBeDefined();
-    mocks.collectStartupChannelMaintenanceHealthFindings.mockResolvedValue([
+    expect(previewWarningsCheck).toMatchObject({ defaultEnabled: false });
+    expect(previewWarningsCheck).toBeDefined();
+    mocks.collectChannelPreviewWarningHealthFindings.mockResolvedValue([
       {
-        checkId: "core/doctor/startup-channel-maintenance",
+        checkId: "core/doctor/channel-preview-warnings",
         severity: "warning",
-        message: "channels.matrix needs startup maintenance",
+        message: "channels.matrix has a preview warning",
         path: "channels.matrix",
       },
     ]);
@@ -2004,28 +2005,50 @@ describe("doctor health contributions", () => {
       mode: "lint",
       runtime: { log: vi.fn(), error: vi.fn(), exit: vi.fn() },
     } as const;
-    const checks = [startupCheck!];
+    const checks = [previewWarningsCheck!];
 
     await expect(runDoctorLintChecks(ctx, { checks })).resolves.toMatchObject({
       checksRun: 0,
       checksSkipped: 1,
     });
-    expect(mocks.collectStartupChannelMaintenanceHealthFindings).not.toHaveBeenCalled();
+    expect(mocks.collectChannelPreviewWarningHealthFindings).not.toHaveBeenCalled();
 
     await expect(
-      runDoctorLintChecks(ctx, { checks, onlyIds: ["core/doctor/startup-channel-maintenance"] }),
+      runDoctorLintChecks(ctx, { checks, onlyIds: ["core/doctor/channel-preview-warnings"] }),
     ).resolves.toMatchObject({
       checksRun: 1,
       checksSkipped: 0,
       findings: [
         expect.objectContaining({
-          checkId: "core/doctor/startup-channel-maintenance",
+          checkId: "core/doctor/channel-preview-warnings",
           path: "channels.matrix",
         }),
       ],
     });
-    expect(mocks.collectStartupChannelMaintenanceHealthFindings).toHaveBeenCalledWith({
+    expect(mocks.collectChannelPreviewWarningHealthFindings).toHaveBeenCalledWith({
       cfg: ctx.cfg,
+      allowExec: false,
+    });
+  });
+
+  it("forwards allow-exec secret refs into channel preview warnings", async () => {
+    const contribution = requireDoctorContribution("doctor:startup-channel-maintenance");
+    const previewWarningsCheck = contribution.healthChecks.find(
+      (check) => check.id === "core/doctor/channel-preview-warnings",
+    ) as HealthCheck | undefined;
+    expect(previewWarningsCheck).toBeDefined();
+    const ctx = {
+      cfg: { channels: { matrix: { enabled: true } } },
+      mode: "lint",
+      runtime: { log: vi.fn(), error: vi.fn(), exit: vi.fn() },
+      allowExecSecretRefs: true,
+    } as const;
+
+    await previewWarningsCheck!.detect(ctx);
+
+    expect(mocks.collectChannelPreviewWarningHealthFindings).toHaveBeenCalledWith({
+      cfg: ctx.cfg,
+      allowExec: true,
     });
   });
 

--- a/src/flows/doctor-health-contributions.ts
+++ b/src/flows/doctor-health-contributions.ts
@@ -1784,18 +1784,34 @@ export function resolveDoctorHealthContributions(): DoctorHealthContribution[] {
     createDoctorHealthContribution({
       id: "doctor:startup-channel-maintenance",
       label: "Startup channel maintenance",
-      healthChecks: {
-        id: "core/doctor/channel-plugin-blockers",
-        description: "Configured channels must have loadable backing channel plugins.",
-        defaultEnabled: false,
-        async detect(ctx) {
-          const { channelPluginBlockerHitToHealthFinding, scanConfiguredChannelPluginBlockers } =
-            await import("../commands/doctor/shared/channel-plugin-blockers.js");
-          return scanConfiguredChannelPluginBlockers(ctx.cfg, process.env).map(
-            channelPluginBlockerHitToHealthFinding,
-          );
+      healthCheckIds: [
+        "core/doctor/channel-plugin-blockers",
+        "core/doctor/startup-channel-maintenance",
+      ],
+      healthChecks: [
+        {
+          id: "core/doctor/channel-plugin-blockers",
+          description: "Configured channels must have loadable backing channel plugins.",
+          defaultEnabled: false,
+          async detect(ctx) {
+            const { channelPluginBlockerHitToHealthFinding, scanConfiguredChannelPluginBlockers } =
+              await import("../commands/doctor/shared/channel-plugin-blockers.js");
+            return scanConfiguredChannelPluginBlockers(ctx.cfg, process.env).map(
+              channelPluginBlockerHitToHealthFinding,
+            );
+          },
         },
-      },
+        {
+          id: "core/doctor/startup-channel-maintenance",
+          description: "Channel startup maintenance warnings are captured as structured findings.",
+          defaultEnabled: false,
+          async detect(ctx) {
+            const { collectStartupChannelMaintenanceHealthFindings } =
+              await import("./doctor-startup-channel-maintenance.js");
+            return collectStartupChannelMaintenanceHealthFindings({ cfg: ctx.cfg });
+          },
+        },
+      ],
       run: runStartupChannelMaintenanceHealth,
     }),
     createDoctorHealthContribution({

--- a/src/flows/doctor-health-contributions.ts
+++ b/src/flows/doctor-health-contributions.ts
@@ -1786,7 +1786,7 @@ export function resolveDoctorHealthContributions(): DoctorHealthContribution[] {
       label: "Startup channel maintenance",
       healthCheckIds: [
         "core/doctor/channel-plugin-blockers",
-        "core/doctor/startup-channel-maintenance",
+        "core/doctor/channel-preview-warnings",
       ],
       healthChecks: [
         {
@@ -1802,13 +1802,16 @@ export function resolveDoctorHealthContributions(): DoctorHealthContribution[] {
           },
         },
         {
-          id: "core/doctor/startup-channel-maintenance",
-          description: "Channel startup maintenance warnings are captured as structured findings.",
+          id: "core/doctor/channel-preview-warnings",
+          description: "Channel doctor preview warnings are captured as structured findings.",
           defaultEnabled: false,
           async detect(ctx) {
-            const { collectStartupChannelMaintenanceHealthFindings } =
+            const { collectChannelPreviewWarningHealthFindings } =
               await import("./doctor-startup-channel-maintenance.js");
-            return collectStartupChannelMaintenanceHealthFindings({ cfg: ctx.cfg });
+            return collectChannelPreviewWarningHealthFindings({
+              cfg: ctx.cfg,
+              allowExec: ctx.allowExecSecretRefs === true,
+            });
           },
         },
       ],

--- a/src/flows/doctor-startup-channel-maintenance.test.ts
+++ b/src/flows/doctor-startup-channel-maintenance.test.ts
@@ -1,12 +1,20 @@
-// Doctor startup maintenance tests cover channel startup maintenance checks.
+// Doctor startup maintenance tests cover channel preview warnings and startup repair flow.
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
-  collectStartupChannelMaintenanceHealthFindings,
+  collectChannelPreviewWarningHealthFindings,
   maybeRunDoctorStartupChannelMaintenance,
 } from "./doctor-startup-channel-maintenance.js";
 
 const mocks = vi.hoisted(() => ({
+  resolveDoctorChannelPreviewConfig: vi.fn(async (params: { cfg: unknown }) => ({
+    cfg: params.cfg,
+    diagnostics: [],
+  })),
   collectChannelDoctorPreviewWarnings: vi.fn(async (): Promise<string[]> => []),
+}));
+
+vi.mock("../commands/doctor/shared/preview-warnings.js", () => ({
+  resolveDoctorChannelPreviewConfig: mocks.resolveDoctorChannelPreviewConfig,
 }));
 
 vi.mock("../commands/doctor/shared/channel-doctor.js", () => ({
@@ -15,6 +23,10 @@ vi.mock("../commands/doctor/shared/channel-doctor.js", () => ({
 
 describe("doctor startup channel maintenance", () => {
   beforeEach(() => {
+    mocks.resolveDoctorChannelPreviewConfig.mockReset().mockImplementation(async (params) => ({
+      cfg: params.cfg,
+      diagnostics: [],
+    }));
     mocks.collectChannelDoctorPreviewWarnings.mockReset().mockResolvedValue([]);
   });
 
@@ -31,22 +43,28 @@ describe("doctor startup channel maintenance", () => {
     ]);
 
     await expect(
-      collectStartupChannelMaintenanceHealthFindings({
+      collectChannelPreviewWarningHealthFindings({
         cfg,
         doctorFixCommand: "openclaw doctor --fix --dry-run",
         env: { OPENCLAW_TEST: "1" },
+        allowExec: true,
       }),
     ).resolves.toEqual([
       {
-        checkId: "core/doctor/startup-channel-maintenance",
+        checkId: "core/doctor/channel-preview-warnings",
         severity: "warning",
         message: "channels.matrix: stale config needs startup maintenance.",
         path: "channels.matrix",
-        requirement: "Configured channels should not require startup maintenance before use.",
+        requirement: "Configured channels should not emit doctor preview warnings.",
         fixHint:
-          "Run `openclaw doctor --fix --dry-run` to apply safe channel maintenance repairs, or update the affected channel config manually.",
+          "Run `openclaw doctor --fix --dry-run` if the channel warning recommends repair, or update the affected channel config manually.",
       },
     ]);
+    expect(mocks.resolveDoctorChannelPreviewConfig).toHaveBeenCalledWith({
+      cfg,
+      env: { OPENCLAW_TEST: "1" },
+      allowExec: true,
+    });
     expect(mocks.collectChannelDoctorPreviewWarnings).toHaveBeenCalledWith({
       cfg,
       doctorFixCommand: "openclaw doctor --fix --dry-run",

--- a/src/flows/doctor-startup-channel-maintenance.test.ts
+++ b/src/flows/doctor-startup-channel-maintenance.test.ts
@@ -1,8 +1,59 @@
 // Doctor startup maintenance tests cover channel startup maintenance checks.
-import { describe, expect, it } from "vitest";
-import { maybeRunDoctorStartupChannelMaintenance } from "./doctor-startup-channel-maintenance.js";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  collectStartupChannelMaintenanceHealthFindings,
+  maybeRunDoctorStartupChannelMaintenance,
+} from "./doctor-startup-channel-maintenance.js";
+
+const mocks = vi.hoisted(() => ({
+  collectChannelDoctorPreviewWarnings: vi.fn(async (): Promise<string[]> => []),
+}));
+
+vi.mock("../commands/doctor/shared/channel-doctor.js", () => ({
+  collectChannelDoctorPreviewWarnings: mocks.collectChannelDoctorPreviewWarnings,
+}));
 
 describe("doctor startup channel maintenance", () => {
+  beforeEach(() => {
+    mocks.collectChannelDoctorPreviewWarnings.mockReset().mockResolvedValue([]);
+  });
+
+  it("maps channel doctor preview warnings to structured findings", async () => {
+    const cfg = {
+      channels: {
+        matrix: {
+          enabled: true,
+        },
+      },
+    };
+    mocks.collectChannelDoctorPreviewWarnings.mockResolvedValue([
+      "- channels.matrix: stale config needs startup maintenance.",
+    ]);
+
+    await expect(
+      collectStartupChannelMaintenanceHealthFindings({
+        cfg,
+        doctorFixCommand: "openclaw doctor --fix --dry-run",
+        env: { OPENCLAW_TEST: "1" },
+      }),
+    ).resolves.toEqual([
+      {
+        checkId: "core/doctor/startup-channel-maintenance",
+        severity: "warning",
+        message: "channels.matrix: stale config needs startup maintenance.",
+        path: "channels.matrix",
+        requirement: "Configured channels should not require startup maintenance before use.",
+        fixHint:
+          "Run `openclaw doctor --fix --dry-run` to apply safe channel maintenance repairs, or update the affected channel config manually.",
+      },
+    ]);
+    expect(mocks.collectChannelDoctorPreviewWarnings).toHaveBeenCalledWith({
+      cfg,
+      doctorFixCommand: "openclaw doctor --fix --dry-run",
+      env: { OPENCLAW_TEST: "1" },
+    });
+  });
+
   it("runs Matrix startup migration during repair flows", async () => {
     const cfg = {
       channels: {

--- a/src/flows/doctor-startup-channel-maintenance.ts
+++ b/src/flows/doctor-startup-channel-maintenance.ts
@@ -1,6 +1,9 @@
 // Doctor startup channel maintenance runs channel plugin startup repairs.
 import { runChannelPluginStartupMaintenance } from "../channels/plugins/lifecycle-startup.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
+import type { HealthFinding } from "./health-checks.js";
+
+const STARTUP_CHANNEL_MAINTENANCE_CHECK_ID = "core/doctor/startup-channel-maintenance";
 
 // Doctor wrapper for plugin startup maintenance repairs.
 type DoctorStartupMaintenanceRuntime = {
@@ -9,6 +12,51 @@ type DoctorStartupMaintenanceRuntime = {
 };
 
 type ChannelPluginStartupMaintenanceRunner = typeof runChannelPluginStartupMaintenance;
+
+function normalizeWarningMessage(warning: string): string {
+  return warning.replace(/^-\s*/, "").trim();
+}
+
+function warningPath(warning: string): string | undefined {
+  return warning.match(/^\s*-?\s*(channels\.[^\s:]+)/)?.[1];
+}
+
+/** Collect read-only startup-channel maintenance findings from channel doctor preview warnings. */
+export async function collectStartupChannelMaintenanceHealthFindings(params: {
+  cfg: OpenClawConfig;
+  doctorFixCommand?: string;
+  env?: NodeJS.ProcessEnv;
+}): Promise<readonly HealthFinding[]> {
+  const { collectChannelDoctorPreviewWarnings } =
+    await import("../commands/doctor/shared/channel-doctor.js");
+  const doctorFixCommand = params.doctorFixCommand ?? "openclaw doctor --fix";
+  const warnings = await collectChannelDoctorPreviewWarnings({
+    cfg: params.cfg,
+    doctorFixCommand,
+    env: params.env ?? process.env,
+  });
+  return warnings.map((warning): HealthFinding => {
+    const path = warningPath(warning);
+    const baseFinding = {
+      checkId: STARTUP_CHANNEL_MAINTENANCE_CHECK_ID,
+      severity: "warning",
+      message: normalizeWarningMessage(warning),
+      requirement: "Configured channels should not require startup maintenance before use.",
+      fixHint: `Run \`${doctorFixCommand}\` to apply safe channel maintenance repairs, or update the affected channel config manually.`,
+    } satisfies HealthFinding;
+    if (path) {
+      return {
+        checkId: baseFinding.checkId,
+        severity: baseFinding.severity,
+        message: baseFinding.message,
+        path,
+        requirement: baseFinding.requirement,
+        fixHint: baseFinding.fixHint,
+      };
+    }
+    return baseFinding;
+  });
+}
 
 /** Runs channel plugin startup maintenance when doctor fix mode explicitly permits repairs. */
 export async function maybeRunDoctorStartupChannelMaintenance(params: {

--- a/src/flows/doctor-startup-channel-maintenance.ts
+++ b/src/flows/doctor-startup-channel-maintenance.ts
@@ -1,9 +1,10 @@
 // Doctor startup channel maintenance runs channel plugin startup repairs.
 import { runChannelPluginStartupMaintenance } from "../channels/plugins/lifecycle-startup.js";
+import { resolveDoctorChannelPreviewConfig } from "../commands/doctor/shared/preview-warnings.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import type { HealthFinding } from "./health-checks.js";
 
-const STARTUP_CHANNEL_MAINTENANCE_CHECK_ID = "core/doctor/startup-channel-maintenance";
+const CHANNEL_PREVIEW_WARNINGS_CHECK_ID = "core/doctor/channel-preview-warnings";
 
 // Doctor wrapper for plugin startup maintenance repairs.
 type DoctorStartupMaintenanceRuntime = {
@@ -21,28 +22,34 @@ function warningPath(warning: string): string | undefined {
   return warning.match(/^\s*-?\s*(channels\.[^\s:]+)/)?.[1];
 }
 
-/** Collect read-only startup-channel maintenance findings from channel doctor preview warnings. */
-export async function collectStartupChannelMaintenanceHealthFindings(params: {
+/** Collect read-only channel doctor preview warnings as structured findings. */
+export async function collectChannelPreviewWarningHealthFindings(params: {
   cfg: OpenClawConfig;
   doctorFixCommand?: string;
   env?: NodeJS.ProcessEnv;
+  allowExec?: boolean;
 }): Promise<readonly HealthFinding[]> {
   const { collectChannelDoctorPreviewWarnings } =
     await import("../commands/doctor/shared/channel-doctor.js");
   const doctorFixCommand = params.doctorFixCommand ?? "openclaw doctor --fix";
-  const warnings = await collectChannelDoctorPreviewWarnings({
+  const previewConfig = await resolveDoctorChannelPreviewConfig({
     cfg: params.cfg,
+    env: params.env ?? process.env,
+    allowExec: params.allowExec,
+  });
+  const warnings = await collectChannelDoctorPreviewWarnings({
+    cfg: previewConfig.cfg,
     doctorFixCommand,
     env: params.env ?? process.env,
   });
   return warnings.map((warning): HealthFinding => {
     const path = warningPath(warning);
     const baseFinding = {
-      checkId: STARTUP_CHANNEL_MAINTENANCE_CHECK_ID,
+      checkId: CHANNEL_PREVIEW_WARNINGS_CHECK_ID,
       severity: "warning",
       message: normalizeWarningMessage(warning),
-      requirement: "Configured channels should not require startup maintenance before use.",
-      fixHint: `Run \`${doctorFixCommand}\` to apply safe channel maintenance repairs, or update the affected channel config manually.`,
+      requirement: "Configured channels should not emit doctor preview warnings.",
+      fixHint: `Run \`${doctorFixCommand}\` if the channel warning recommends repair, or update the affected channel config manually.`,
     } satisfies HealthFinding;
     if (path) {
       return {


### PR DESCRIPTION
## Summary
- add default-disabled `core/doctor/channel-preview-warnings` structured findings under the existing startup-channel-maintenance Doctor contribution
- map read-only generic channel doctor preview warnings into stable health findings with `channels.*` paths
- resolve configured channel SecretRefs through the existing doctor preview helper and forward `--allow-exec` parity into the new lint check
- keep startup maintenance mutation in the existing repair-only `doctor --fix` path; this lint check does not claim startup-maintenance ownership for every channel warning

## Public surface
- No public SDK/plugin/config contract changes.
- Default `doctor --lint` is unchanged; this check runs with `--only core/doctor/channel-preview-warnings` or `--all`.

## PR surface
- 5 files changed, +244/-15 from `main` after the rebase and SecretRef parity fix.

## Validation
- `node scripts/run-vitest.mjs src/flows/doctor-startup-channel-maintenance.test.ts src/flows/doctor-health-contributions.test.ts src/commands/doctor/shared/preview-warnings.test.ts` (114 passed)
- direct changed-file `oxfmt` check on the touched files
- direct changed-file `oxlint` check on the touched files
- `node scripts/plugin-sdk-surface-report.mjs --check`
- `git diff --check`

## Real behavior proof
Behavior or issue addressed:
`core/doctor/channel-preview-warnings` surfaces channel preview warnings as structured doctor lint findings without changing the default `doctor --lint` selection.

Real environment tested:
Local Windows PowerShell checkout of `openclaw/openclaw`, using the source entrypoint through `tsx` against a throwaway config under `%TEMP%`.

Exact steps or command run after this patch:
```powershell
node --import tsx .\src\entry.ts doctor --lint --json --only core/doctor/channel-preview-warnings
```

Evidence after fix:
`{"ok":false,"checksRun":1,"checksSkipped":45,"findings":[{"checkId":"core/doctor/channel-preview-warnings","severity":"warning","path":"channels.discord"}]}`

Observed result after fix:
The targeted lint run returned the new structured warning finding for the Discord channel preview path.

What was not tested:
No packaged `dist/` CLI build was run in this session; the proof used the source entrypoint with a throwaway config. Default-lint exclusion is supported by unit tests and the existing selection contract.
