### PR TITLE
fix(ios): return chat to originating control detail

### DIFF
--- a/apps/.i18n/native-source.json
+++ b/apps/.i18n/native-source.json
@@ -7763,7 +7763,7 @@
     },
     {
       "kind": "ui-modifier",
-      "line": 38,
+      "line": 41,
       "path": "apps/ios/Sources/Design/RootTabsPhoneControlHub.swift",
       "source": "Control",
       "surface": "apple",
@@ -7771,7 +7771,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 55,
+      "line": 62,
       "path": "apps/ios/Sources/Design/RootTabsPhoneControlHub.swift",
       "source": "Gateway",
       "surface": "apple",
@@ -7779,7 +7779,7 @@
     },
     {
       "kind": "ui-modifier",
-      "line": 77,
+      "line": 84,
       "path": "apps/ios/Sources/Design/RootTabsPhoneControlHub.swift",
       "source": "Gateway \\(self.gatewayStateText), \\(self.sidebarActiveAgentTitle)",
       "surface": "apple",
@@ -7787,7 +7787,7 @@
     },
     {
       "kind": "ui-modifier",
-      "line": 78,
+      "line": 85,
       "path": "apps/ios/Sources/Design/RootTabsPhoneControlHub.swift",
       "source": "Opens Settings / Gateway",
       "surface": "apple",
@@ -7795,7 +7795,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 125,
+      "line": 132,
       "path": "apps/ios/Sources/Design/RootTabsPhoneControlHub.swift",
       "source": "Overview",
       "surface": "apple",
@@ -7803,7 +7803,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 147,
+      "line": 154,
       "path": "apps/ios/Sources/Design/RootTabsPhoneControlHub.swift",
       "source": "Instances",
       "surface": "apple",
@@ -7811,7 +7811,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 156,
+      "line": 163,
       "path": "apps/ios/Sources/Design/RootTabsPhoneControlHub.swift",
       "source": "Dreaming",
       "surface": "apple",
@@ -7819,7 +7819,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 161,
+      "line": 168,
       "path": "apps/ios/Sources/Design/RootTabsPhoneControlHub.swift",
       "source": "Usage",
       "surface": "apple",
@@ -7827,7 +7827,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 166,
+      "line": 173,
       "path": "apps/ios/Sources/Design/RootTabsPhoneControlHub.swift",
       "source": "Cron Jobs",
       "surface": "apple",
@@ -7835,7 +7835,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 221,
+      "line": 243,
       "path": "apps/ios/Sources/Design/RootTabsPhoneControlHub.swift",
       "source": "Online",
       "surface": "apple",
@@ -7843,7 +7843,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 222,
+      "line": 244,
       "path": "apps/ios/Sources/Design/RootTabsPhoneControlHub.swift",
       "source": "Connecting",
       "surface": "apple",
@@ -7851,7 +7851,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 223,
+      "line": 245,
       "path": "apps/ios/Sources/Design/RootTabsPhoneControlHub.swift",
       "source": "Attention",
       "surface": "apple",
@@ -7859,7 +7859,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 224,
+      "line": 246,
       "path": "apps/ios/Sources/Design/RootTabsPhoneControlHub.swift",
       "source": "Offline",
       "surface": "apple",
@@ -10755,7 +10755,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 177,
+      "line": 180,
       "path": "apps/ios/Sources/RootTabs.swift",
       "source": "Talk",
       "surface": "apple",
@@ -10763,7 +10763,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 187,
+      "line": 192,
       "path": "apps/ios/Sources/RootTabs.swift",
       "source": "Control",
       "surface": "apple",
@@ -10771,7 +10771,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 196,
+      "line": 201,
       "path": "apps/ios/Sources/RootTabs.swift",
       "source": "Agent",
       "surface": "apple",
@@ -10779,7 +10779,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 203,
+      "line": 208,
       "path": "apps/ios/Sources/RootTabs.swift",
       "source": "Settings",
       "surface": "apple",
@@ -10787,7 +10787,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 302,
+      "line": 307,
       "path": "apps/ios/Sources/RootTabs.swift",
       "source": "OpenClaw",
       "surface": "apple",
@@ -10795,7 +10795,7 @@
     },
     {
       "kind": "ui-modifier",
-      "line": 331,
+      "line": 336,
       "path": "apps/ios/Sources/RootTabs.swift",
       "source": "OpenClaw \\(self.sidebarGatewayStatusTitle)",
       "surface": "apple",
@@ -10803,7 +10803,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 336,
+      "line": 341,
       "path": "apps/ios/Sources/RootTabs.swift",
       "source": "Online",
       "surface": "apple",
@@ -10811,7 +10811,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 338,
+      "line": 343,
       "path": "apps/ios/Sources/RootTabs.swift",
       "source": "Connecting",
       "surface": "apple",
@@ -10819,7 +10819,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 340,
+      "line": 345,
       "path": "apps/ios/Sources/RootTabs.swift",
       "source": "Needs attention",
       "surface": "apple",
@@ -10827,7 +10827,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 342,
+      "line": 347,
       "path": "apps/ios/Sources/RootTabs.swift",
       "source": "Offline",
       "surface": "apple",
@@ -10835,7 +10835,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 420,
+      "line": 425,
       "path": "apps/ios/Sources/RootTabs.swift",
       "source": "Chat",
       "surface": "apple",
@@ -10843,7 +10843,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 433,
+      "line": 438,
       "path": "apps/ios/Sources/RootTabs.swift",
       "source": "Overview",
       "surface": "apple",
@@ -10851,7 +10851,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 457,
+      "line": 462,
       "path": "apps/ios/Sources/RootTabs.swift",
       "source": "Agents",
       "surface": "apple",
@@ -10859,7 +10859,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 464,
+      "line": 469,
       "path": "apps/ios/Sources/RootTabs.swift",
       "source": "Instances",
       "surface": "apple",
@@ -10867,7 +10867,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 475,
+      "line": 480,
       "path": "apps/ios/Sources/RootTabs.swift",
       "source": "Dreaming",
       "surface": "apple",
@@ -10875,7 +10875,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 482,
+      "line": 487,
       "path": "apps/ios/Sources/RootTabs.swift",
       "source": "Usage",
       "surface": "apple",
@@ -10883,7 +10883,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 489,
+      "line": 494,
       "path": "apps/ios/Sources/RootTabs.swift",
       "source": "Cron Jobs",
       "surface": "apple",
@@ -10891,7 +10891,7 @@
     },
     {
       "kind": "ui-modifier",
-      "line": 594,
+      "line": 616,
       "path": "apps/ios/Sources/RootTabs.swift",
       "source": "Hide Sidebar",
       "surface": "apple",
@@ -10899,7 +10899,7 @@
     },
     {
       "kind": "ui-modifier",
-      "line": 721,
+      "line": 743,
       "path": "apps/ios/Sources/RootTabs.swift",
       "source": "Close canvas",
       "surface": "apple",
@@ -10907,7 +10907,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 975,
+      "line": 997,
       "path": "apps/ios/Sources/RootTabs.swift",
       "source": "Gateway needs attention",
       "surface": "apple",
@@ -10915,7 +10915,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 975,
+      "line": 997,
       "path": "apps/ios/Sources/RootTabs.swift",
       "source": "OpenClaw iOS",
       "surface": "apple",
@@ -10923,7 +10923,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1011,
+      "line": 1033,
       "path": "apps/ios/Sources/RootTabs.swift",
       "source": "Available",
       "surface": "apple",
@@ -10931,7 +10931,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1011,
+      "line": 1033,
       "path": "apps/ios/Sources/RootTabs.swift",
       "source": "Gateway default",
       "surface": "apple",
@@ -10939,7 +10939,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 47,
+      "line": 62,
       "path": "apps/ios/Sources/RootTabsNavigation.swift",
       "source": "Chat",
       "surface": "apple",
@@ -10947,7 +10947,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 48,
+      "line": 63,
       "path": "apps/ios/Sources/RootTabsNavigation.swift",
       "source": "Talk",
       "surface": "apple",
@@ -10955,7 +10955,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 49,
+      "line": 64,
       "path": "apps/ios/Sources/RootTabsNavigation.swift",
       "source": "Overview",
       "surface": "apple",
@@ -10963,7 +10963,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 50,
+      "line": 65,
       "path": "apps/ios/Sources/RootTabsNavigation.swift",
       "source": "Activity",
       "surface": "apple",
@@ -10971,7 +10971,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 51,
+      "line": 66,
       "path": "apps/ios/Sources/RootTabsNavigation.swift",
       "source": "Agents",
       "surface": "apple",
@@ -10979,7 +10979,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 52,
+      "line": 67,
       "path": "apps/ios/Sources/RootTabsNavigation.swift",
       "source": "Workboard",
       "surface": "apple",
@@ -10987,7 +10987,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 53,
+      "line": 68,
       "path": "apps/ios/Sources/RootTabsNavigation.swift",
       "source": "Skill Workshop",
       "surface": "apple",
@@ -10995,7 +10995,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 54,
+      "line": 69,
       "path": "apps/ios/Sources/RootTabsNavigation.swift",
       "source": "Instances",
       "surface": "apple",
@@ -11003,7 +11003,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 55,
+      "line": 70,
       "path": "apps/ios/Sources/RootTabsNavigation.swift",
       "source": "Sessions",
       "surface": "apple",
@@ -11011,7 +11011,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 56,
+      "line": 71,
       "path": "apps/ios/Sources/RootTabsNavigation.swift",
       "source": "Dreaming",
       "surface": "apple",
@@ -11019,7 +11019,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 57,
+      "line": 72,
       "path": "apps/ios/Sources/RootTabsNavigation.swift",
       "source": "Usage",
       "surface": "apple",
@@ -11027,7 +11027,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 58,
+      "line": 73,
       "path": "apps/ios/Sources/RootTabsNavigation.swift",
       "source": "Cron Jobs",
       "surface": "apple",
@@ -11035,7 +11035,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 59,
+      "line": 74,
       "path": "apps/ios/Sources/RootTabsNavigation.swift",
       "source": "Docs",
       "surface": "apple",
@@ -11043,7 +11043,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 60,
+      "line": 75,
       "path": "apps/ios/Sources/RootTabsNavigation.swift",
       "source": "Settings",
       "surface": "apple",
@@ -11051,7 +11051,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 61,
+      "line": 76,
       "path": "apps/ios/Sources/RootTabsNavigation.swift",
       "source": "Settings / Gateway",
       "surface": "apple",
@@ -11059,7 +11059,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 67,
+      "line": 82,
       "path": "apps/ios/Sources/RootTabsNavigation.swift",
       "source": "Connection",
       "surface": "apple",

--- a/apps/.i18n/native-source.json
+++ b/apps/.i18n/native-source.json
@@ -7475,7 +7475,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 924,
+      "line": 927,
       "path": "apps/ios/Sources/Design/IPadWorkboardScreen.swift",
       "source": "No \\(IPadWorkboardDefaults.label(for: self.status).lowercased()) cards",
       "surface": "apple",
@@ -7483,7 +7483,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 925,
+      "line": 928,
       "path": "apps/ios/Sources/Design/IPadWorkboardScreen.swift",
       "source": "Cards moved into this lane appear here.",
       "surface": "apple",
@@ -7491,7 +7491,7 @@
     },
     {
       "kind": "ui-modifier",
-      "line": 1104,
+      "line": 1107,
       "path": "apps/ios/Sources/Design/IPadWorkboardScreen.swift",
       "source": "Card Actions",
       "surface": "apple",
@@ -7499,7 +7499,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1115,
+      "line": 1118,
       "path": "apps/ios/Sources/Design/IPadWorkboardScreen.swift",
       "source": "Open",
       "surface": "apple",
@@ -7507,7 +7507,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1136,
+      "line": 1139,
       "path": "apps/ios/Sources/Design/IPadWorkboardScreen.swift",
       "source": "Inspect",
       "surface": "apple",
@@ -7515,7 +7515,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1138,
+      "line": 1141,
       "path": "apps/ios/Sources/Design/IPadWorkboardScreen.swift",
       "source": "Move to \\(IPadWorkboardDefaults.label(for: status))",
       "surface": "apple",
@@ -7523,7 +7523,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1182,
+      "line": 1185,
       "path": "apps/ios/Sources/Design/IPadWorkboardScreen.swift",
       "source": "Default agent",
       "surface": "apple",
@@ -7531,7 +7531,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1200,
+      "line": 1203,
       "path": "apps/ios/Sources/Design/IPadWorkboardScreen.swift",
       "source": "Card",
       "surface": "apple",
@@ -7539,7 +7539,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1201,
+      "line": 1204,
       "path": "apps/ios/Sources/Design/IPadWorkboardScreen.swift",
       "source": "Title",
       "surface": "apple",
@@ -7547,7 +7547,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1202,
+      "line": 1205,
       "path": "apps/ios/Sources/Design/IPadWorkboardScreen.swift",
       "source": "Status",
       "surface": "apple",
@@ -7555,7 +7555,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1208,
+      "line": 1211,
       "path": "apps/ios/Sources/Design/IPadWorkboardScreen.swift",
       "source": "Actions",
       "surface": "apple",
@@ -7563,7 +7563,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1210,
+      "line": 1213,
       "path": "apps/ios/Sources/Design/IPadWorkboardScreen.swift",
       "source": "Open Session",
       "surface": "apple",
@@ -7571,7 +7571,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1212,
+      "line": 1215,
       "path": "apps/ios/Sources/Design/IPadWorkboardScreen.swift",
       "source": "Move",
       "surface": "apple",
@@ -7579,7 +7579,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1220,
+      "line": 1223,
       "path": "apps/ios/Sources/Design/IPadWorkboardScreen.swift",
       "source": "Archive",
       "surface": "apple",
@@ -7587,7 +7587,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1220,
+      "line": 1223,
       "path": "apps/ios/Sources/Design/IPadWorkboardScreen.swift",
       "source": "Unarchive",
       "surface": "apple",
@@ -7595,7 +7595,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1228,
+      "line": 1231,
       "path": "apps/ios/Sources/Design/IPadWorkboardScreen.swift",
       "source": "Done",
       "surface": "apple",
@@ -10755,7 +10755,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 180,
+      "line": 181,
       "path": "apps/ios/Sources/RootTabs.swift",
       "source": "Talk",
       "surface": "apple",
@@ -10763,7 +10763,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 192,
+      "line": 193,
       "path": "apps/ios/Sources/RootTabs.swift",
       "source": "Control",
       "surface": "apple",
@@ -10771,7 +10771,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 201,
+      "line": 202,
       "path": "apps/ios/Sources/RootTabs.swift",
       "source": "Agent",
       "surface": "apple",
@@ -10779,7 +10779,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 208,
+      "line": 209,
       "path": "apps/ios/Sources/RootTabs.swift",
       "source": "Settings",
       "surface": "apple",
@@ -10787,7 +10787,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 307,
+      "line": 308,
       "path": "apps/ios/Sources/RootTabs.swift",
       "source": "OpenClaw",
       "surface": "apple",
@@ -10795,7 +10795,7 @@
     },
     {
       "kind": "ui-modifier",
-      "line": 336,
+      "line": 337,
       "path": "apps/ios/Sources/RootTabs.swift",
       "source": "OpenClaw \\(self.sidebarGatewayStatusTitle)",
       "surface": "apple",
@@ -10803,7 +10803,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 341,
+      "line": 342,
       "path": "apps/ios/Sources/RootTabs.swift",
       "source": "Online",
       "surface": "apple",
@@ -10811,7 +10811,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 343,
+      "line": 344,
       "path": "apps/ios/Sources/RootTabs.swift",
       "source": "Connecting",
       "surface": "apple",
@@ -10819,7 +10819,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 345,
+      "line": 346,
       "path": "apps/ios/Sources/RootTabs.swift",
       "source": "Needs attention",
       "surface": "apple",
@@ -10827,7 +10827,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 347,
+      "line": 348,
       "path": "apps/ios/Sources/RootTabs.swift",
       "source": "Offline",
       "surface": "apple",
@@ -10835,7 +10835,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 425,
+      "line": 426,
       "path": "apps/ios/Sources/RootTabs.swift",
       "source": "Chat",
       "surface": "apple",
@@ -10843,7 +10843,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 438,
+      "line": 439,
       "path": "apps/ios/Sources/RootTabs.swift",
       "source": "Overview",
       "surface": "apple",
@@ -10851,7 +10851,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 462,
+      "line": 463,
       "path": "apps/ios/Sources/RootTabs.swift",
       "source": "Agents",
       "surface": "apple",
@@ -10859,7 +10859,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 469,
+      "line": 470,
       "path": "apps/ios/Sources/RootTabs.swift",
       "source": "Instances",
       "surface": "apple",
@@ -10867,7 +10867,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 480,
+      "line": 481,
       "path": "apps/ios/Sources/RootTabs.swift",
       "source": "Dreaming",
       "surface": "apple",
@@ -10875,7 +10875,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 487,
+      "line": 488,
       "path": "apps/ios/Sources/RootTabs.swift",
       "source": "Usage",
       "surface": "apple",
@@ -10883,7 +10883,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 494,
+      "line": 495,
       "path": "apps/ios/Sources/RootTabs.swift",
       "source": "Cron Jobs",
       "surface": "apple",
@@ -10891,7 +10891,7 @@
     },
     {
       "kind": "ui-modifier",
-      "line": 616,
+      "line": 617,
       "path": "apps/ios/Sources/RootTabs.swift",
       "source": "Hide Sidebar",
       "surface": "apple",
@@ -10899,7 +10899,7 @@
     },
     {
       "kind": "ui-modifier",
-      "line": 743,
+      "line": 744,
       "path": "apps/ios/Sources/RootTabs.swift",
       "source": "Close canvas",
       "surface": "apple",
@@ -10907,7 +10907,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 997,
+      "line": 998,
       "path": "apps/ios/Sources/RootTabs.swift",
       "source": "Gateway needs attention",
       "surface": "apple",
@@ -10915,7 +10915,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 997,
+      "line": 998,
       "path": "apps/ios/Sources/RootTabs.swift",
       "source": "OpenClaw iOS",
       "surface": "apple",
@@ -10923,7 +10923,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1033,
+      "line": 1034,
       "path": "apps/ios/Sources/RootTabs.swift",
       "source": "Available",
       "surface": "apple",
@@ -10931,7 +10931,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1033,
+      "line": 1034,
       "path": "apps/ios/Sources/RootTabs.swift",
       "source": "Gateway default",
       "surface": "apple",

--- a/apps/ios/Sources/Design/IPadWorkboardScreen.swift
+++ b/apps/ios/Sources/Design/IPadWorkboardScreen.swift
@@ -788,6 +788,9 @@ struct IPadWorkboardScreen: View {
 
     private func open(_ card: IPadWorkboardCard) {
         guard let sessionKey = normalized(card.sessionKey) else { return }
+        // Card details are a sheet. Dismiss it before changing tabs or the requested
+        // Chat session and contextual return action remain obscured by the old card.
+        self.presentedSheet = nil
         self.appModel.openChat(sessionKey: sessionKey)
         self.openChat()
     }

--- a/apps/ios/Sources/Design/RootTabsPhoneControlHub.swift
+++ b/apps/ios/Sources/Design/RootTabsPhoneControlHub.swift
@@ -5,10 +5,13 @@ struct RootTabsPhoneControlHub: View {
     @Environment(NodeAppModel.self) private var appModel
     @State private var navigationPath: [RootTabs.SidebarDestination] = []
     @State private var didApplyInitialDestination = false
+    @State private var handledNavigationRequestID = 0
 
     let groups: [RootTabs.SidebarGroup]
     let initialDestination: RootTabs.SidebarDestination?
+    let navigationRequest: RootTabs.PhoneControlNavigationRequest?
     let openRootDestination: (RootTabs.SidebarDestination) -> Void
+    let openChatFromControlDetail: (RootTabs.SidebarDestination) -> Void
 
     var body: some View {
         NavigationStack(path: self.$navigationPath) {
@@ -42,6 +45,10 @@ struct RootTabsPhoneControlHub: View {
             }
             .onAppear {
                 self.applyInitialDestinationIfNeeded()
+                self.applyNavigationRequestIfNeeded()
+            }
+            .onChange(of: self.navigationRequest) { _, _ in
+                self.applyNavigationRequestIfNeeded()
             }
         }
     }
@@ -124,18 +131,18 @@ struct RootTabsPhoneControlHub: View {
                 usesNativeNavigationChrome: true,
                 headerTitle: "Overview",
                 showsHeaderMark: false,
-                openChat: { self.openPhoneRootDestination(.chat) },
+                openChat: { self.openChatFromControlDetail(.overview) },
                 openSettings: { self.openGatewayDetail() },
                 openSessions: { self.navigationPath.append(.sessions) })
         case .activity:
             IPadActivityScreen(
                 usesNativeNavigationChrome: true,
-                openChat: { self.openPhoneRootDestination(.chat) },
+                openChat: { self.openChatFromControlDetail(.activity) },
                 openSettings: { self.openGatewayDetail() })
         case .workboard:
             IPadWorkboardScreen(
                 usesNativeNavigationChrome: true,
-                openChat: { self.openPhoneRootDestination(.chat) },
+                openChat: { self.openChatFromControlDetail(.workboard) },
                 openSettings: { self.openGatewayDetail() })
         case .skillWorkshop:
             IPadSkillWorkshopScreen(
@@ -149,7 +156,7 @@ struct RootTabsPhoneControlHub: View {
         case .sessions:
             CommandSessionsScreen(
                 usesNativeNavigationChrome: true,
-                openChat: { self.openPhoneRootDestination(.chat) })
+                openChat: { self.openChatFromControlDetail(.sessions) })
         case .dreaming:
             AgentProTab(
                 directRoute: .dreaming,
@@ -201,10 +208,25 @@ struct RootTabsPhoneControlHub: View {
         guard !self.didApplyInitialDestination else { return }
         self.didApplyInitialDestination = true
         guard let initialDestination, initialDestination != .overview else { return }
-        if self.opensRootTab(initialDestination) {
-            self.openPhoneRootDestination(initialDestination)
+        self.applyDestination(initialDestination)
+    }
+
+    private func applyNavigationRequestIfNeeded() {
+        guard let navigationRequest, navigationRequest.id != self.handledNavigationRequestID else { return }
+        self.handledNavigationRequestID = navigationRequest.id
+        switch navigationRequest.target {
+        case .root:
+            self.navigationPath.removeAll()
+        case let .detail(destination):
+            self.applyDestination(destination)
+        }
+    }
+
+    private func applyDestination(_ destination: RootTabs.SidebarDestination) {
+        if self.opensRootTab(destination) {
+            self.openPhoneRootDestination(destination)
         } else {
-            self.navigationPath = [initialDestination]
+            self.navigationPath = [destination]
         }
     }
 
@@ -300,7 +322,9 @@ extension RootTabsPhoneControlHub {
         RootTabsPhoneControlHub(
             groups: RootTabs.phoneControlGroups,
             initialDestination: nil,
-            openRootDestination: { _ in })
+            navigationRequest: nil,
+            openRootDestination: { _ in },
+            openChatFromControlDetail: { _ in })
             .environment(appModel)
     }
 }

--- a/apps/ios/Sources/RootTabs.swift
+++ b/apps/ios/Sources/RootTabs.swift
@@ -26,6 +26,8 @@ struct RootTabs: View {
     @State private var selectedSidebarDestination: SidebarDestination = Self.initialSidebarDestination
     @State private var selectedSettingsRoute: SettingsRoute? = Self.initialSidebarDestination.settingsRoute
     @State private var selectedSettingsRouteRequestID: Int = 0
+    @State private var phoneControlNavigationRequest: PhoneControlNavigationRequest?
+    @State private var phoneChatReturn: PhoneChatReturn?
     // Embedded Settings rows push onto the sidebar stack; clear it before
     // changing sidebar roots so stale settings detail screens cannot survive.
     @State private var sidebarNavigationPath: [SettingsRoute] = []
@@ -158,9 +160,10 @@ struct RootTabs: View {
     }
 
     private var phoneTabContent: some View {
-        TabView(selection: self.$selectedTab) {
+        TabView(selection: self.phoneTabSelection) {
             PhoneTabSettingsHost { openSettingsRoute in
                 ChatProTab(
+                    headerLeadingAction: self.phoneChatReturnAction,
                     ownsNavigationStack: false,
                     openSettings: { openSettingsRoute(.gateway) })
             }
@@ -183,7 +186,9 @@ struct RootTabs: View {
             RootTabsPhoneControlHub(
                 groups: Self.phoneControlGroups,
                 initialDestination: Self.requestedInitialSidebarDestination,
-                openRootDestination: { self.selectSidebarDestination($0) })
+                navigationRequest: self.phoneControlNavigationRequest,
+                openRootDestination: { self.selectSidebarDestination($0) },
+                openChatFromControlDetail: { self.openChatFromControlDetail($0) })
                 .tabItem { Label("Control", systemImage: "square.grid.2x2") }
                 .badge(self.appModel.pendingExecApprovalPrompt == nil ? 0 : 1)
                 .tag(AppTab.control)
@@ -580,6 +585,23 @@ struct RootTabs: View {
             action: { self.showSidebar() })
     }
 
+    private var phoneChatReturnAction: OpenClawSidebarHeaderAction? {
+        guard !self.usesSidebarTabs, let phoneChatReturn else { return nil }
+        return OpenClawSidebarHeaderAction(
+            systemName: "chevron.left",
+            accessibilityLabel: "Back to \(phoneChatReturn.destination.title)",
+            accessibilityIdentifier: "OpenClawChatBackToControlDetailButton",
+            action: { self.openPhoneControlDetail(phoneChatReturn.destination) })
+    }
+
+    /// TabView writes through this binding; internal routing writes selectedTab directly.
+    /// That distinction keeps only a user-selected Control tab responsible for resetting its child stack.
+    private var phoneTabSelection: Binding<AppTab> {
+        Binding(
+            get: { self.selectedTab },
+            set: { self.handlePhoneTabSelection($0) })
+    }
+
     private var sidebarHideButton: some View {
         Button {
             self.hideSidebar()
@@ -835,8 +857,8 @@ struct RootTabs: View {
                 guard !newValue else { return }
                 self.maybeRequestLocalNetworkAccess(reason: "onboarding_dismissed")
             }
-            .onChange(of: self.appModel.openChatRequestID) { _, _ in
-                self.selectSidebarDestination(.chat)
+            .onChange(of: self.appModel.openChatRequestID) { _, newValue in
+                self.handleOpenChatRequest(newValue)
             }
             .onChange(of: self.appModel.gatewaySetupRequestID) { _, _ in
                 self.maybeOpenSettingsForGatewaySetup()
@@ -1026,7 +1048,13 @@ struct RootTabs: View {
 }
 
 extension RootTabs {
-    private func selectSidebarDestination(_ destination: SidebarDestination) {
+    private func selectSidebarDestination(
+        _ destination: SidebarDestination,
+        preservingChatReturn: Bool = false)
+    {
+        if destination != .chat || !preservingChatReturn {
+            self.phoneChatReturn = nil
+        }
         self.sidebarNavigationPath.removeAll()
         if destination.settingsRoute != .notifications {
             self.suppressedExecApprovalPromptIDForNotificationSettings = nil
@@ -1034,13 +1062,61 @@ extension RootTabs {
         self.selectedSidebarDestination = destination
         self.selectedSettingsRoute = destination.settingsRoute
         self.selectedTab = destination.appTab
+        self.requestPhoneControlDestinationIfNeeded(destination)
         guard self.usesSidebarTabs, self.shouldCollapseSidebarAfterSelection else { return }
         withAnimation(.easeInOut(duration: 0.22)) {
             self.setSidebarVisible(false)
         }
     }
 
+    private func openChatFromControlDetail(_ returnDestination: SidebarDestination) {
+        // Detail screens focus a session before invoking this route callback. Remember that
+        // synchronous request so its later observation cannot erase the contextual return.
+        self.phoneChatReturn = PhoneChatReturn(
+            destination: returnDestination,
+            openChatRequestID: self.appModel.openChatRequestID)
+        self.selectSidebarDestination(.chat, preservingChatReturn: true)
+    }
+
+    private func handleOpenChatRequest(_ requestID: Int) {
+        guard requestID != self.phoneChatReturn?.openChatRequestID else { return }
+        self.selectSidebarDestination(.chat)
+    }
+
+    private func openPhoneControlDetail(_ destination: SidebarDestination) {
+        self.selectSidebarDestination(destination)
+        if destination == .overview {
+            self.requestPhoneControlDestinationIfNeeded(destination, force: true)
+        }
+    }
+
+    private func handlePhoneTabSelection(_ selectedTab: AppTab) {
+        if selectedTab != .chat {
+            self.phoneChatReturn = nil
+        }
+        if selectedTab == .control {
+            self.requestPhoneControlNavigation(.root)
+        }
+        self.selectedTab = selectedTab
+    }
+
+    private func requestPhoneControlDestinationIfNeeded(
+        _ destination: SidebarDestination,
+        force: Bool = false)
+    {
+        guard !self.usesSidebarTabs else { return }
+        guard destination.appTab == .control else { return }
+        guard force || destination != .overview else { return }
+        self.requestPhoneControlNavigation(.detail(destination))
+    }
+
+    private func requestPhoneControlNavigation(_ target: PhoneControlNavigationRequest.Target) {
+        let requestID = (self.phoneControlNavigationRequest?.id ?? 0) &+ 1
+        self.phoneControlNavigationRequest = PhoneControlNavigationRequest(id: requestID, target: target)
+    }
+
     private func selectSettingsRoute(_ route: SettingsRoute) {
+        self.phoneChatReturn = nil
         self.sidebarNavigationPath.removeAll()
         if route != .notifications {
             self.suppressedExecApprovalPromptIDForNotificationSettings = nil

--- a/apps/ios/Sources/RootTabs.swift
+++ b/apps/ios/Sources/RootTabs.swift
@@ -28,6 +28,7 @@ struct RootTabs: View {
     @State private var selectedSettingsRouteRequestID: Int = 0
     @State private var phoneControlNavigationRequest: PhoneControlNavigationRequest?
     @State private var phoneChatReturn: PhoneChatReturn?
+    @State private var phoneChatSettingsResetRequestID: Int = 0
     // Embedded Settings rows push onto the sidebar stack; clear it before
     // changing sidebar roots so stale settings detail screens cannot survive.
     @State private var sidebarNavigationPath: [SettingsRoute] = []
@@ -161,7 +162,7 @@ struct RootTabs: View {
 
     private var phoneTabContent: some View {
         TabView(selection: self.phoneTabSelection) {
-            PhoneTabSettingsHost { openSettingsRoute in
+            PhoneTabSettingsHost(resetRequestID: self.phoneChatSettingsResetRequestID) { openSettingsRoute in
                 ChatProTab(
                     headerLeadingAction: self.phoneChatReturnAction,
                     ownsNavigationStack: false,
@@ -1075,6 +1076,9 @@ extension RootTabs {
         self.phoneChatReturn = PhoneChatReturn(
             destination: returnDestination,
             openChatRequestID: self.appModel.openChatRequestID)
+        // Chat owns an embedded Settings stack. Pop it before routing so the requested
+        // session and contextual return action cannot remain hidden behind Settings.
+        self.phoneChatSettingsResetRequestID &+= 1
         self.selectSidebarDestination(.chat, preservingChatReturn: true)
     }
 
@@ -1339,9 +1343,14 @@ extension RootTabs {
 /// (deep links, onboarding, problem banner) jump to the canonical Settings tab.
 private struct PhoneTabSettingsHost<Content: View>: View {
     @State private var settingsPath: [SettingsRoute] = []
+    private let resetRequestID: Int
     private let content: (_ openSettingsRoute: @escaping (SettingsRoute) -> Void) -> Content
 
-    init(@ViewBuilder content: @escaping (_ openSettingsRoute: @escaping (SettingsRoute) -> Void) -> Content) {
+    init(
+        resetRequestID: Int = 0,
+        @ViewBuilder content: @escaping (_ openSettingsRoute: @escaping (SettingsRoute) -> Void) -> Content)
+    {
+        self.resetRequestID = resetRequestID
         self.content = content
     }
 
@@ -1353,6 +1362,9 @@ private struct PhoneTabSettingsHost<Content: View>: View {
             .navigationDestination(for: SettingsRoute.self) { route in
                 SettingsProTab(directRoute: route)
             }
+        }
+        .onChange(of: self.resetRequestID) { _, _ in
+            self.settingsPath.removeAll()
         }
     }
 }

--- a/apps/ios/Sources/RootTabsNavigation.swift
+++ b/apps/ios/Sources/RootTabsNavigation.swift
@@ -3,6 +3,21 @@ import Foundation
 import SwiftUI
 
 extension RootTabs {
+    struct PhoneChatReturn: Equatable {
+        let destination: SidebarDestination
+        let openChatRequestID: Int
+    }
+
+    struct PhoneControlNavigationRequest: Equatable {
+        enum Target: Equatable {
+            case root
+            case detail(SidebarDestination)
+        }
+
+        let id: Int
+        let target: Target
+    }
+
     private static var sidebarPersistentWidthThreshold: CGFloat {
         980
     }

--- a/apps/ios/Tests/RootTabsSidebarRegressionTests.swift
+++ b/apps/ios/Tests/RootTabsSidebarRegressionTests.swift
@@ -70,7 +70,7 @@ import Testing
             to: "private var usesSidebarTabs: Bool")
         let selection = try Self.extract(
             source,
-            from: "private func selectSidebarDestination(_ destination: SidebarDestination)",
+            from: "private func selectSidebarDestination(",
             to: "private func showSidebar()")
         let resetRange = try #require(selection.range(of: "self.sidebarNavigationPath.removeAll()"))
         let destinationRange = try #require(selection.range(of: "self.selectedSidebarDestination = destination"))

--- a/apps/ios/Tests/RootTabsSourceGuardTests.swift
+++ b/apps/ios/Tests/RootTabsSourceGuardTests.swift
@@ -84,7 +84,7 @@ struct RootTabsSourceGuardTests {
         #expect(talkRange.lowerBound < controlRange.lowerBound)
         #expect(controlRange.lowerBound < agentRange.lowerBound)
         #expect(agentRange.lowerBound < settingsRange.lowerBound)
-        #expect(phoneTabContent.matches(of: /PhoneTabSettingsHost \{/).count == 3)
+        #expect(phoneTabContent.matches(of: /PhoneTabSettingsHost(?:\([^\n]+\))? \{/).count == 3)
     }
 
     @Test func `sidebar keeps navigation model destination only`() throws {
@@ -422,6 +422,20 @@ struct RootTabsSourceGuardTests {
         #expect(!source.contains("supportsGatewayContract"))
         #expect(!source.contains("Compact mobile queue control"))
         #expect(!source.contains("Multi-column queue control"))
+    }
+
+    @Test func `workboard dismisses card sheet before opening chat`() throws {
+        let source = try String(contentsOf: Self.iPadWorkboardScreenSourceURL(), encoding: .utf8)
+        let openFunction = try Self.extract(
+            source,
+            from: "private func open(_ card: IPadWorkboardCard)",
+            to: "private func replace(_ card: IPadWorkboardCard)")
+        let dismiss = try #require(openFunction.range(of: "self.presentedSheet = nil"))
+        let focus = try #require(openFunction.range(of: "self.appModel.openChat(sessionKey: sessionKey)"))
+        let route = try #require(openFunction.range(of: "self.openChat()"))
+
+        #expect(dismiss.lowerBound < focus.lowerBound)
+        #expect(focus.lowerBound < route.lowerBound)
     }
 
     @Test func `workboard create action surfaces unavailable reasons`() throws {
@@ -863,12 +877,10 @@ struct RootTabsSourceGuardTests {
     @Test func `native chat uses gateway transport`() throws {
         let chatSource = try String(contentsOf: Self.chatProTabSourceURL(), encoding: .utf8)
         let channelsSource = try String(contentsOf: Self.channelsSourceURL(), encoding: .utf8)
-        let settingsSectionsSource = try String(contentsOf: Self.settingsProTabSectionsSourceURL(), encoding: .utf8)
         let appModelSource = try String(contentsOf: Self.nodeAppModelSourceURL(), encoding: .utf8)
 
         #expect(chatSource.matches(of: /self\.appModel\.makeChatTransport\(\)/).count == 2)
         #expect(appModelSource.contains("return IOSGatewayChatTransport(gateway: self.operatorSession)"))
-        #expect(settingsSectionsSource.contains("Connected services and message routing"))
         #expect(channelsSource.contains("\"clickclack\": SettingsChannelFallbackMetadata"))
         #expect(channelsSource.contains("label: \"ClickClack\""))
         #expect(channelsSource.contains("Self-hosted chat bot routing."))

--- a/apps/ios/Tests/SwiftUIRenderSmokeTests.swift
+++ b/apps/ios/Tests/SwiftUIRenderSmokeTests.swift
@@ -191,7 +191,9 @@ struct SwiftUIRenderSmokeTests {
             let root = RootTabsPhoneControlHub(
                 groups: RootTabs.phoneControlGroups,
                 initialDestination: nil,
-                openRootDestination: { _ in })
+                navigationRequest: nil,
+                openRootDestination: { _ in },
+                openChatFromControlDetail: { _ in })
                 .environment(appModel)
 
             _ = Self.host(root)
@@ -203,7 +205,9 @@ struct SwiftUIRenderSmokeTests {
         let root = RootTabsPhoneControlHub(
             groups: RootTabs.phoneControlGroups,
             initialDestination: nil,
-            openRootDestination: { _ in })
+            navigationRequest: nil,
+            openRootDestination: { _ in },
+            openChatFromControlDetail: { _ in })
             .environment(appModel)
             .environment(\.horizontalSizeClass, .regular)
             .environment(\.verticalSizeClass, .compact)

--- a/apps/ios/UITests/OpenClawSnapshotUITests.swift
+++ b/apps/ios/UITests/OpenClawSnapshotUITests.swift
@@ -289,6 +289,20 @@ final class OpenClawSnapshotUITests: XCTestCase {
 
         let chatTab = try XCTUnwrap(self.app?.tabBars.buttons["Chat"])
         let controlTab = try XCTUnwrap(self.app?.tabBars.buttons["Control"])
+
+        // Retain an embedded Chat Settings route, then prove contextual routing pops it.
+        chatTab.tap()
+        let gatewaySettings = try XCTUnwrap(self.app?.buttons["chat-gateway-status"])
+        XCTAssertTrue(gatewaySettings.waitForExistence(timeout: 5))
+        gatewaySettings.tap()
+        XCTAssertTrue(self.app?.navigationBars["Gateway"].waitForExistence(timeout: 5) == true)
+
+        controlTab.tap()
+        XCTAssertTrue(self.app?.navigationBars["Control"].waitForExistence(timeout: 8) == true)
+        let activity = try XCTUnwrap(self.app?.buttons["Activity"])
+        XCTAssertTrue(activity.waitForExistence(timeout: 5))
+        activity.tap()
+
         let recentActivity = try XCTUnwrap(self.app?.staticTexts["Recent activity"])
         XCTAssertTrue(recentActivity.waitForExistence(timeout: 8))
         self.attachScreenshot(named: "control-activity-before-chat")

--- a/apps/ios/UITests/OpenClawSnapshotUITests.swift
+++ b/apps/ios/UITests/OpenClawSnapshotUITests.swift
@@ -280,6 +280,55 @@ final class OpenClawSnapshotUITests: XCTestCase {
         self.waitForValue("System", of: row)
     }
 
+    func testChatReturnsToOriginatingControlDetail() throws {
+        try XCTSkipIf(UIDevice.current.userInterfaceIdiom != .phone, "Phone Control proof only")
+        self.launchApp(for: ScreenshotTarget(
+            initialTab: "control",
+            initialDestination: "activity",
+            name: "control-chat-return"))
+
+        let chatTab = try XCTUnwrap(self.app?.tabBars.buttons["Chat"])
+        let controlTab = try XCTUnwrap(self.app?.tabBars.buttons["Control"])
+        let recentActivity = try XCTUnwrap(self.app?.staticTexts["Recent activity"])
+        XCTAssertTrue(recentActivity.waitForExistence(timeout: 8))
+        self.attachScreenshot(named: "control-activity-before-chat")
+
+        let activityChat = try self.controlDetailChatButton(above: chatTab)
+        activityChat.tap()
+        XCTAssertTrue(chatTab.isSelected)
+
+        let returnButton = try XCTUnwrap(self.app?.buttons["OpenClawChatBackToControlDetailButton"])
+        XCTAssertTrue(returnButton.waitForExistence(timeout: 5))
+        XCTAssertEqual(returnButton.label, "Back to Activity")
+        self.attachScreenshot(named: "chat-return-to-activity")
+
+        returnButton.tap()
+        XCTAssertTrue(recentActivity.waitForExistence(timeout: 8))
+        XCTAssertTrue(controlTab.isSelected)
+        self.attachScreenshot(named: "control-activity-after-chat")
+
+        try self.controlDetailChatButton(above: chatTab).tap()
+        XCTAssertTrue(chatTab.isSelected)
+        controlTab.tap()
+        XCTAssertTrue(self.app?.navigationBars["Control"].waitForExistence(timeout: 8) == true)
+        let overview = try XCTUnwrap(self.app?.buttons["Overview"])
+        XCTAssertTrue(overview.exists)
+        self.attachScreenshot(named: "control-tab-returns-to-root")
+
+        overview.tap()
+        XCTAssertTrue(self.app?.staticTexts["Agent session"].waitForExistence(timeout: 8) == true)
+        let agentSession = try XCTUnwrap(
+            self.app?.buttons.containing(.staticText, identifier: "Molty").firstMatch)
+        XCTAssertTrue(agentSession.waitForExistence(timeout: 8))
+        agentSession.tap()
+
+        XCTAssertTrue(returnButton.waitForExistence(timeout: 8))
+        XCTAssertEqual(returnButton.label, "Back to Overview")
+        self.attachScreenshot(named: "chat-session-return-to-overview")
+        returnButton.tap()
+        XCTAssertTrue(self.app?.navigationBars["Overview"].waitForExistence(timeout: 8) == true)
+    }
+
     func testAgentUsesToolbarFilter() throws {
         try XCTSkipIf(UIDevice.current.userInterfaceIdiom != .phone, "Phone Agent proof only")
         self.launchApp(for: ScreenshotTarget(
@@ -357,6 +406,11 @@ final class OpenClawSnapshotUITests: XCTestCase {
             predicate: NSPredicate(format: "value == %@", value),
             object: element)
         XCTAssertEqual(XCTWaiter.wait(for: [expectation], timeout: 3), .completed)
+    }
+
+    private func controlDetailChatButton(above chatTab: XCUIElement) throws -> XCUIElement {
+        let buttons = try XCTUnwrap(self.app?.buttons.matching(NSPredicate(format: "label == 'Chat'")))
+        return try XCTUnwrap(buttons.allElementsBoundByIndex.first { $0.frame.maxY < chatTab.frame.minY })
     }
 
     private func launchPairedLiveGatewayApp(


### PR DESCRIPTION
## What Problem This Solves

Repairs and supersedes #98023. On iPhone, opening Chat from a Control detail could leave no visible route back to the originating Overview, Activity, Workboard, or Sessions screen. The contributor branch could not be updated because maintainer edits are disabled.

## Why This Change Was Made

The phone shell now carries two closed navigation values: a typed Control navigation request and a contextual Chat return that records both the source detail and the exact global Chat request it already handled. This keeps internal detail-return routing distinct from direct bottom-tab selection, prevents the later global request observation from erasing the contextual back action, and removes the original parallel nullable destination/request/reset-suppression state.

The maintainer rewrite also clears stale return state on programmatic Settings routing, resets Chat's retained embedded Settings stack before contextual routing, and dismisses a Workboard card sheet before switching tabs. A direct Control-tab tap always resets the child stack to the Control hub; the Chat header action returns to the exact source detail.

Contributor credit is preserved in the maintainer commit via `Co-authored-by: Colin <colin@solvely.net>`.

## User Impact

On iPhone, users can open Chat from Overview, Activity, Workboard, or Sessions and use a visible `Back to …` action to return to that detail. Tapping the bottom Control tab instead returns to the main Control hub. iPad/sidebar behavior is unchanged.

## Evidence

- Before/after proof from the contributor: [hosted bundle](https://github.com/Solvely-Colin/pr-proof-assets/tree/main/openclaw/pr-98023), [corrected flow GIF](https://raw.githubusercontent.com/Solvely-Colin/pr-proof-assets/main/openclaw/pr-98023/control-tab-root-chat-back.gif), and [contact sheet](https://raw.githubusercontent.com/Solvely-Colin/pr-proof-assets/main/openclaw/pr-98023/control-tab-root-chat-back-contact.png).
- Exact head `e42dc9728a3d19fa7907bfaf9af0483c987d630c`: iPhone 17 Pro / iOS 26.5 simulator UI E2E passed in 25.459s. It first retained Chat's Gateway Settings route, then proved Activity → Chat → `Back to Activity` → Activity; direct Control tab → hub; and Overview agent-session row → Chat through the real `NodeAppModel.openChat` request path → `Back to Overview` → Overview.
- Exact-head `RootTabsSourceGuardTests` passed 35/35, including Workboard card-sheet dismissal ordering. Earlier focused presentation/sidebar/render coverage passed 65/65.
- Native i18n is synchronized; `git diff --check` passes; [hosted CI run 28624771490](https://github.com/openclaw/openclaw/actions/runs/28624771490) passed for the exact head, including `ios-build`, `macos-swift`, lint, guards, and all required shards.
- Fresh Codex autoreview found and drove fixes for the duplicate production Chat request, stale programmatic Settings return, retained Chat Settings stack, and Workboard sheet, then passed on the exact head with no accepted/actionable findings.

No changelog entry: release generation owns `CHANGELOG.md`.
