### PR TITLE
[codex] Support Slack assistant suggested prompts

### DIFF
--- a/docs/channels/slack.md
+++ b/docs/channels/slack.md
@@ -922,15 +922,36 @@ Slack actions are controlled by `channels.slack.actions.*`.
 
 Available action groups in current Slack tooling:
 
-| Group      | Default |
-| ---------- | ------- |
-| messages   | enabled |
-| reactions  | enabled |
-| pins       | enabled |
-| memberInfo | enabled |
-| emojiList  | enabled |
+| Group            | Default |
+| ---------------- | ------- |
+| messages         | enabled |
+| reactions        | enabled |
+| pins             | enabled |
+| memberInfo       | enabled |
+| emojiList        | enabled |
+| assistantPrompts | enabled |
 
-Current Slack message actions include `send`, `upload-file`, `download-file`, `read`, `edit`, `delete`, `pin`, `unpin`, `list-pins`, `member-info`, and `emoji-list`. `download-file` accepts Slack file IDs shown in inbound file placeholders and returns image previews for images or local file metadata for other file types.
+Current Slack message actions include `send`, `upload-file`, `download-file`, `read`, `edit`, `delete`, `pin`, `unpin`, `list-pins`, `member-info`, `emoji-list`, and `set-suggested-prompts`. `download-file` accepts Slack file IDs shown in inbound file placeholders and returns image previews for images or local file metadata for other file types. `set-suggested-prompts` calls Slack's assistant suggested prompt API for an assistant thread and accepts `channelId` or `to`, `threadTs` or `threadId`/`replyTo`, optional `title`, and up to four `{ title, message }` prompts.
+
+Slack assistant threads get built-in suggested prompts when a thread starts. Override them with `channels.slack.assistantPrompts`:
+
+```json
+{
+  "channels": {
+    "slack": {
+      "assistantPrompts": {
+        "title": "What can I help with?",
+        "prompts": [
+          { "title": "Check status", "message": "What's the current status?" },
+          { "title": "Show diff", "message": "Show me the latest diff." }
+        ]
+      }
+    }
+  }
+}
+```
+
+Set `channels.slack.assistantPrompts` to `false` to suppress the built-in suggestions.
 
 ## Access control and routing
 
@@ -1462,7 +1483,7 @@ Primary reference: [Configuration reference - Slack](/gateway/config-channels#sl
 - threading/history: `replyToMode`, `replyToModeByChatType`, `thread.*`, `historyLimit`, `dmHistoryLimit`, `dms.*.historyLimit`
 - delivery: `textChunkLimit`, `chunkMode`, `mediaMaxMb`, `streaming`, `streaming.nativeTransport`, `streaming.preview.toolProgress`
 - unfurls: `unfurlLinks` (default: `false`), `unfurlMedia` for `chat.postMessage` link/media preview control; set `unfurlLinks: true` to opt back into link previews
-- ops/features: `configWrites`, `commands.native`, `slashCommand.*`, `actions.*`, `userToken`, `userTokenReadOnly`
+- ops/features: `configWrites`, `commands.native`, `slashCommand.*`, `actions.*`, `assistantPrompts`, `userToken`, `userTokenReadOnly`
 
 </Accordion>
 

--- a/extensions/slack/src/action-runtime.test.ts
+++ b/extensions/slack/src/action-runtime.test.ts
@@ -18,6 +18,10 @@ const readSlackMessages = vi.fn(async (..._args: unknown[]) => ({}));
 const removeOwnSlackReactions = vi.fn(async (..._args: unknown[]) => ["thumbsup"]);
 const removeSlackReaction = vi.fn(async (..._args: unknown[]) => ({}));
 const sendSlackMessage = vi.fn(async (..._args: unknown[]) => ({ channelId: "C123" }));
+const setSlackAssistantSuggestedPrompts = vi.fn(async (..._args: unknown[]) => ({
+  ok: true,
+  prompts: [{ title: "Review", message: "Review the current plan." }],
+}));
 const unpinSlackMessage = vi.fn(async (..._args: unknown[]) => ({}));
 
 describe("handleSlackAction", () => {
@@ -216,6 +220,7 @@ describe("handleSlackAction", () => {
       removeOwnSlackReactions,
       removeSlackReaction,
       sendSlackMessage,
+      setSlackAssistantSuggestedPrompts,
       unpinSlackMessage,
     });
   });
@@ -1227,5 +1232,50 @@ describe("handleSlackAction", () => {
       handleSlackAction({ action: "emojiList", limit: 2.5 }, slackConfig()),
     ).rejects.toThrow("limit must be a positive integer.");
     expect(listSlackEmojis).not.toHaveBeenCalled();
+  });
+
+  it("sets Slack assistant suggested prompts", async () => {
+    const cfg = slackConfig();
+    const result = await handleSlackAction(
+      {
+        action: "setSuggestedPrompts",
+        channelId: "C123",
+        threadTs: "1777423717.666499",
+        title: "Next",
+        prompts: [{ title: "Review", message: "Review the current plan." }],
+      },
+      cfg,
+    );
+
+    expect(setSlackAssistantSuggestedPrompts).toHaveBeenCalledWith(
+      "C123",
+      "1777423717.666499",
+      {
+        title: "Next",
+        prompts: [{ title: "Review", message: "Review the current plan." }],
+      },
+      {
+        cfg,
+      },
+    );
+    expect(requireDetails(result)).toEqual({
+      ok: true,
+      prompts: [{ title: "Review", message: "Review the current plan." }],
+    });
+  });
+
+  it("respects assistant prompt action gating", async () => {
+    await expect(
+      handleSlackAction(
+        {
+          action: "setSuggestedPrompts",
+          channelId: "C123",
+          threadTs: "1777423717.666499",
+          prompts: [{ title: "Review", message: "Review the current plan." }],
+        },
+        slackConfig({ actions: { assistantPrompts: false } }),
+      ),
+    ).rejects.toThrow("Slack assistant prompts are disabled.");
+    expect(setSlackAssistantSuggestedPrompts).not.toHaveBeenCalled();
   });
 });

--- a/extensions/slack/src/action-runtime.ts
+++ b/extensions/slack/src/action-runtime.ts
@@ -30,6 +30,7 @@ const messagingActions = new Set([
 
 const reactionsActions = new Set(["react", "reactions"]);
 const pinActions = new Set(["pinMessage", "unpinMessage", "listPins"]);
+const assistantPromptActions = new Set(["setSuggestedPrompts"]);
 
 type SlackActionsRuntimeModule = typeof import("./actions.runtime.js");
 type SlackAccountsRuntimeModule = typeof import("./accounts.runtime.js");
@@ -72,6 +73,7 @@ export const slackActionRuntime = {
   removeOwnSlackReactions: createLazySlackAction("removeOwnSlackReactions"),
   removeSlackReaction: createLazySlackAction("removeSlackReaction"),
   sendSlackMessage: createLazySlackAction("sendSlackMessage"),
+  setSlackAssistantSuggestedPrompts: createLazySlackAction("setSlackAssistantSuggestedPrompts"),
   unpinSlackMessage: createLazySlackAction("unpinSlackMessage"),
 };
 
@@ -576,6 +578,24 @@ export async function handleSlackAction(
       }
     }
     return jsonResult({ ok: true, emojis: result });
+  }
+
+  if (assistantPromptActions.has(action)) {
+    if (!isActionEnabled("assistantPrompts")) {
+      throw new Error("Slack assistant prompts are disabled.");
+    }
+    const channelId = resolveChannelId();
+    const threadTs = readStringParam(params, "threadTs", { required: true });
+    const result = await slackActionRuntime.setSlackAssistantSuggestedPrompts(
+      channelId,
+      threadTs,
+      {
+        title: readStringParam(params, "title"),
+        prompts: params.prompts,
+      },
+      writeOpts,
+    );
+    return jsonResult(result);
   }
 
   throw new Error(`Unknown action: ${action}`);

--- a/extensions/slack/src/actions.runtime.ts
+++ b/extensions/slack/src/actions.runtime.ts
@@ -13,5 +13,6 @@ export {
   removeOwnSlackReactions,
   removeSlackReaction,
   sendSlackMessage,
+  setSlackAssistantSuggestedPrompts,
   unpinSlackMessage,
 } from "./actions.js";

--- a/extensions/slack/src/actions.ts
+++ b/extensions/slack/src/actions.ts
@@ -5,6 +5,10 @@ import { requireRuntimeConfig } from "openclaw/plugin-sdk/plugin-config-runtime"
 import { logVerbose } from "openclaw/plugin-sdk/runtime-env";
 import { z } from "zod";
 import { resolveSlackAccount } from "./accounts.js";
+import {
+  normalizeSlackAssistantSuggestedPrompts,
+  type SlackAssistantSuggestedPrompt,
+} from "./assistant-prompts.js";
 import { validateSlackBlocksArray } from "./blocks-input.js";
 import { createSlackWebClient, getSlackWriteClient } from "./client.js";
 import { buildSlackEditTextPayload } from "./edit-text.js";
@@ -390,6 +394,29 @@ export async function listSlackPins(
   const client = await getClient(opts);
   const result = await client.pins.list({ channel: channelId });
   return (result.items ?? []) as SlackPin[];
+}
+
+export async function setSlackAssistantSuggestedPrompts(
+  channelId: string,
+  threadTs: string,
+  params: {
+    title?: string;
+    prompts: unknown;
+  },
+  opts: SlackActionClientOpts = {},
+): Promise<{ ok: true; prompts: SlackAssistantSuggestedPrompt[] }> {
+  const prompts = normalizeSlackAssistantSuggestedPrompts(params.prompts);
+  if (prompts.length === 0) {
+    throw new Error("Slack suggested prompts require at least one prompt with title and message.");
+  }
+  const client = await getClient(opts, "write");
+  await client.assistant.threads.setSuggestedPrompts({
+    channel_id: channelId,
+    thread_ts: threadTs,
+    ...(params.title?.trim() ? { title: params.title.trim() } : {}),
+    prompts,
+  });
+  return { ok: true, prompts };
 }
 
 type SlackFileInfoSummary = {

--- a/extensions/slack/src/assistant-prompts.ts
+++ b/extensions/slack/src/assistant-prompts.ts
@@ -1,0 +1,71 @@
+// Slack plugin module owns assistant suggested prompt normalization.
+
+export type SlackAssistantSuggestedPrompt = {
+  title: string;
+  message: string;
+};
+
+export type SlackAssistantPromptsConfig =
+  | false
+  | {
+      title?: string;
+      prompts: SlackAssistantSuggestedPrompt[];
+    };
+
+export const DEFAULT_ASSISTANT_PROMPTS_TITLE = "Try asking";
+
+export const DEFAULT_ASSISTANT_PROMPTS: SlackAssistantSuggestedPrompt[] = [
+  { title: "What can you do?", message: "What can you help me with?" },
+  { title: "Summarize this channel", message: "Summarize the recent activity in this channel." },
+  { title: "Draft a reply", message: "Help me draft a reply." },
+];
+
+function normalizePrompt(value: unknown): SlackAssistantSuggestedPrompt | undefined {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return undefined;
+  }
+  const record = value as Record<string, unknown>;
+  const title = typeof record.title === "string" ? record.title.trim() : "";
+  const message = typeof record.message === "string" ? record.message.trim() : "";
+  return title && message ? { title, message } : undefined;
+}
+
+export function normalizeSlackAssistantSuggestedPrompts(
+  value: unknown,
+): SlackAssistantSuggestedPrompt[] {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+  return value
+    .flatMap((entry) => {
+      const prompt = normalizePrompt(entry);
+      return prompt ? [prompt] : [];
+    })
+    .slice(0, 4);
+}
+
+export function resolveSlackAssistantPromptsConfig(
+  config: SlackAssistantPromptsConfig | undefined,
+):
+  | {
+      title?: string;
+      prompts: SlackAssistantSuggestedPrompt[];
+    }
+  | undefined {
+  if (config === false) {
+    return undefined;
+  }
+  const source = config ?? {
+    title: DEFAULT_ASSISTANT_PROMPTS_TITLE,
+    prompts: DEFAULT_ASSISTANT_PROMPTS,
+  };
+  const prompts = normalizeSlackAssistantSuggestedPrompts(source.prompts);
+  if (prompts.length === 0) {
+    return undefined;
+  }
+  const title = source.title?.trim();
+  return {
+    ...(title ? { title } : {}),
+    prompts,
+  };
+}

--- a/extensions/slack/src/config-schema.test.ts
+++ b/extensions/slack/src/config-schema.test.ts
@@ -109,6 +109,56 @@ describe("slack config schema", () => {
     });
   });
 
+  it("accepts assistant suggested prompt config", () => {
+    expectSlackConfigValid({
+      assistantPrompts: {
+        title: "What next?",
+        prompts: [
+          { title: "Status", message: "What's the current status?" },
+          { title: "Diff", message: "Show me the diff." },
+        ],
+      },
+      accounts: {
+        ops: {
+          assistantPrompts: false,
+        },
+      },
+    });
+  });
+
+  it("rejects invalid assistant suggested prompt config", () => {
+    expectSlackConfigIssue(
+      {
+        assistantPrompts: {
+          prompts: [],
+        },
+      },
+      "assistantPrompts.prompts",
+    );
+    expectSlackConfigIssue(
+      {
+        assistantPrompts: {
+          prompts: [
+            { title: "One", message: "1" },
+            { title: "Two", message: "2" },
+            { title: "Three", message: "3" },
+            { title: "Four", message: "4" },
+            { title: "Five", message: "5" },
+          ],
+        },
+      },
+      "assistantPrompts.prompts",
+    );
+    expectSlackConfigIssue(
+      {
+        assistantPrompts: {
+          prompts: [{ title: "Missing message" }],
+        },
+      },
+      "assistantPrompts",
+    );
+  });
+
   it("accepts Socket Mode ping/pong transport tuning", () => {
     expectSlackConfigValid({
       mode: "socket",

--- a/extensions/slack/src/config-ui-hints.ts
+++ b/extensions/slack/src/config-ui-hints.ts
@@ -166,6 +166,14 @@ export const slackChannelConfigUiHints = {
     label: "Slack Native Streaming",
     help: "Enable native Slack text streaming (chat.startStream/chat.appendStream/chat.stopStream) when channels.slack.streaming.mode is partial (default: true). Native streaming and Slack assistant thread status require a reply thread target; top-level DMs can still use draft post-and-edit preview streaming.",
   },
+  assistantPrompts: {
+    label: "Slack Assistant Prompts",
+    help: "Configure static Slack assistant suggested prompts for new assistant threads, or set false to suppress the built-in suggestions.",
+  },
+  "actions.assistantPrompts": {
+    label: "Slack Assistant Prompt Actions",
+    help: "Allow agents to update Slack assistant suggested prompts dynamically through the message tool.",
+  },
   "streaming.preview.toolProgress": {
     label: "Slack Draft Tool Progress",
     help: "Show tool/progress activity in the live draft preview message (default: true). Set false to hide interim tool updates while the draft preview stays active.",

--- a/extensions/slack/src/message-action-dispatch.test.ts
+++ b/extensions/slack/src/message-action-dispatch.test.ts
@@ -254,6 +254,36 @@ describe("handleSlackMessageAction", () => {
     expectNoForwardedToolContext(invoke);
   });
 
+  it("maps suggested prompt updates to the Slack action runtime", async () => {
+    const invoke = createInvokeSpy();
+    const cfg = slackConfig();
+
+    await handleSlackMessageAction({
+      providerId: "slack",
+      ctx: {
+        action: "set-suggested-prompts",
+        cfg,
+        params: {
+          to: "C123",
+          threadId: "1777423717.666499",
+          title: "Next",
+          prompts: [{ title: "Review", message: "Review the current plan." }],
+        },
+      } as never,
+      invoke: invoke as never,
+    });
+
+    expect(firstAction(invoke)).toEqual({
+      action: "setSuggestedPrompts",
+      channelId: "C123",
+      threadTs: "1777423717.666499",
+      title: "Next",
+      prompts: [{ title: "Review", message: "Review the current plan." }],
+      accountId: undefined,
+    });
+    expectForwardedCfg(invoke, cfg);
+  });
+
   it("maps upload-file to the internal uploadFile action", async () => {
     const invoke = createInvokeSpy();
     const cfg = slackConfig();

--- a/extensions/slack/src/message-action-dispatch.ts
+++ b/extensions/slack/src/message-action-dispatch.ts
@@ -227,6 +227,25 @@ export async function handleSlackMessageAction(params: {
     return await invoke({ action: "emojiList", limit, accountId }, cfg);
   }
 
+  if (action === "set-suggested-prompts") {
+    const channelId = resolveChannelId();
+    const threadTs =
+      readStringParam(actionParams, "threadTs") ??
+      readStringParam(actionParams, "threadId") ??
+      readStringParam(actionParams, "replyTo", { required: true });
+    return await invoke(
+      {
+        action: "setSuggestedPrompts",
+        channelId,
+        threadTs,
+        title: readStringParam(actionParams, "title"),
+        prompts: actionParams.prompts,
+        accountId,
+      },
+      cfg,
+    );
+  }
+
   if (action === "download-file") {
     const fileIdParam = readStringParam(actionParams, "fileId");
     const messageIdParam =

--- a/extensions/slack/src/message-actions.ts
+++ b/extensions/slack/src/message-actions.ts
@@ -52,6 +52,9 @@ export function listSlackMessageActions(
   if (isActionEnabled("emojiList")) {
     actions.add("emoji-list");
   }
+  if (isActionEnabled("assistantPrompts")) {
+    actions.add("set-suggested-prompts");
+  }
   return Array.from(actions);
 }
 

--- a/extensions/slack/src/message-tool-api.ts
+++ b/extensions/slack/src/message-tool-api.ts
@@ -59,6 +59,36 @@ function createSlackTopLevelActionSchema(): Record<string, TSchema> {
   };
 }
 
+function createSlackSuggestedPromptsActionSchema(): Record<string, TSchema> {
+  return {
+    threadTs: Type.Optional(
+      Type.String({
+        description:
+          'Slack assistant thread timestamp. Required for action="set-suggested-prompts"; threadId or replyTo are accepted aliases.',
+      }),
+    ),
+    title: Type.Optional(
+      Type.String({
+        description:
+          'Optional Slack title shown above the suggested prompt list for action="set-suggested-prompts".',
+      }),
+    ),
+    prompts: Type.Optional(
+      Type.Array(
+        Type.Object({
+          title: Type.String(),
+          message: Type.String(),
+        }),
+        {
+          maxItems: 4,
+          description:
+            'Up to four Slack assistant suggested prompts for action="set-suggested-prompts". Each prompt needs title and message.',
+        },
+      ),
+    ),
+  };
+}
+
 export function describeSlackMessageTool({
   cfg,
   accountId,
@@ -90,6 +120,12 @@ export function describeSlackMessageTool({
     schema.push({
       properties: createSlackTopLevelActionSchema(),
       actions: ["upload-file"],
+    });
+  }
+  if (actions.includes("set-suggested-prompts")) {
+    schema.push({
+      properties: createSlackSuggestedPromptsActionSchema(),
+      actions: ["set-suggested-prompts"],
     });
   }
   const messageIdActions: ChannelMessageActionName[] = [];

--- a/extensions/slack/src/message-tools.test.ts
+++ b/extensions/slack/src/message-tools.test.ts
@@ -61,6 +61,7 @@ describe("Slack message tools", () => {
       "list-pins",
       "member-info",
       "emoji-list",
+      "set-suggested-prompts",
     ]);
     expect(discovery.capabilities).toEqual(["presentation"]);
     expect(Array.isArray(discovery.schema)).toBe(true);
@@ -115,7 +116,23 @@ describe("Slack message tools", () => {
       "list-pins",
       "member-info",
       "emoji-list",
+      "set-suggested-prompts",
     ]);
+  });
+
+  it("honors assistant prompt action gates", () => {
+    const cfg = {
+      channels: {
+        slack: {
+          botToken: "xoxb-test",
+          actions: {
+            assistantPrompts: false,
+          },
+        },
+      },
+    } as OpenClawConfig;
+
+    expect(listSlackMessageActions(cfg)).not.toContain("set-suggested-prompts");
   });
 
   it("honors the selected Slack account during discovery", () => {
@@ -129,6 +146,7 @@ describe("Slack message tools", () => {
             pins: false,
             memberInfo: false,
             emojiList: false,
+            assistantPrompts: false,
           },
           accounts: {
             default: {
@@ -139,6 +157,7 @@ describe("Slack message tools", () => {
                 pins: false,
                 memberInfo: false,
                 emojiList: false,
+                assistantPrompts: false,
               },
             },
             work: {
@@ -149,6 +168,7 @@ describe("Slack message tools", () => {
                 pins: false,
                 memberInfo: false,
                 emojiList: false,
+                assistantPrompts: false,
               },
             },
           },
@@ -248,6 +268,22 @@ describe("Slack message tools", () => {
     expect(property.description).toContain("threadId: null");
   });
 
+  it("describes Slack suggested prompt action params", () => {
+    const discovery = describeSlackMessageTool({
+      cfg: {
+        channels: {
+          slack: {
+            botToken: "xoxb-test",
+          },
+        },
+      },
+    });
+    const { schema } = requireSchemaProperty(discovery, "prompts");
+
+    expect(schema.actions).toEqual(["set-suggested-prompts"]);
+    expect(Object.keys(schema.properties).toSorted()).toEqual(["prompts", "threadTs", "title"]);
+  });
+
   it("omits Slack file and message id schemas when those actions are disabled", () => {
     const discovery = describeSlackMessageTool({
       cfg: {
@@ -260,6 +296,7 @@ describe("Slack message tools", () => {
               pins: false,
               memberInfo: false,
               emojiList: false,
+              assistantPrompts: false,
             },
           },
         },

--- a/extensions/slack/src/monitor/context.ts
+++ b/extensions/slack/src/monitor/context.ts
@@ -21,6 +21,7 @@ import {
   normalizeLowercaseStringOrEmpty,
   normalizeOptionalString,
 } from "openclaw/plugin-sdk/string-coerce-runtime";
+import type { SlackAssistantSuggestedPrompt } from "../assistant-prompts.js";
 import { formatSlackError } from "../errors.js";
 import type { SlackMessageEvent } from "../types.js";
 import { normalizeAllowList, normalizeAllowListLower, normalizeSlackSlug } from "./allow-list.js";
@@ -31,11 +32,6 @@ import { resolveSessionKey } from "./config.runtime.js";
 import { isSlackChannelAllowedByPolicy } from "./policy.js";
 
 export { normalizeSlackChannelType, resolveSlackChatType } from "./channel-type.js";
-
-export type SlackAssistantSuggestedPrompt = {
-  title: string;
-  message: string;
-};
 
 export type SlackAssistantThreadContext = {
   assistantChannelId: string;

--- a/extensions/slack/src/monitor/events/assistant.test.ts
+++ b/extensions/slack/src/monitor/events/assistant.test.ts
@@ -11,6 +11,7 @@ function createHarness(overrides?: {
   existingContext?: ReturnType<SlackMonitorContext["getSlackAssistantThreadContext"]>;
   replies?: ReturnType<typeof vi.fn>;
   update?: ReturnType<typeof vi.fn>;
+  slackConfig?: Record<string, unknown>;
 }) {
   const handlers: Record<string, Handler> = {};
   const getSlackAssistantThreadContext = vi.fn(() => overrides?.existingContext);
@@ -29,6 +30,15 @@ function createHarness(overrides?: {
         handlers[name] = handler;
       },
     } as unknown as App,
+    cfg: {
+      channels: {
+        slack: {
+          botToken: "xoxb-test",
+          ...overrides?.slackConfig,
+        },
+      },
+    },
+    accountId: "default",
     runtime: { error: vi.fn() },
     botToken: "xoxb-test",
     botUserId: "B1",
@@ -116,6 +126,47 @@ describe("registerSlackAssistantEvents", () => {
         { title: "Draft a reply", message: "Help me draft a reply." },
       ],
     });
+  });
+
+  it("sets configured assistant thread prompts", async () => {
+    const harness = createHarness({
+      slackConfig: {
+        assistantPrompts: {
+          title: "Next steps",
+          prompts: [
+            { title: "Ship it", message: "Prepare the release summary." },
+            { title: "Review risk", message: "List the remaining merge risks." },
+          ],
+        },
+      },
+    });
+
+    await harness.handlers.assistant_thread_started?.({
+      event: makeThreadEvent("assistant_thread_started"),
+      body: {},
+    });
+
+    expect(harness.setSlackAssistantSuggestedPrompts).toHaveBeenCalledWith({
+      channelId: "D123",
+      threadTs: "1729999327.187299",
+      title: "Next steps",
+      prompts: [
+        { title: "Ship it", message: "Prepare the release summary." },
+        { title: "Review risk", message: "List the remaining merge risks." },
+      ],
+    });
+  });
+
+  it("allows configured assistant thread prompts to be disabled", async () => {
+    const harness = createHarness({ slackConfig: { assistantPrompts: false } });
+
+    await harness.handlers.assistant_thread_started?.({
+      event: makeThreadEvent("assistant_thread_started"),
+      body: {},
+    });
+
+    expect(harness.saveSlackAssistantThreadContext).toHaveBeenCalledTimes(1);
+    expect(harness.setSlackAssistantSuggestedPrompts).not.toHaveBeenCalled();
   });
 
   it("updates assistant thread context without resetting prompts", async () => {

--- a/extensions/slack/src/monitor/events/assistant.ts
+++ b/extensions/slack/src/monitor/events/assistant.ts
@@ -2,12 +2,10 @@
 import type { Block, KnownBlock } from "@slack/web-api";
 import { formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
 import { danger, logVerbose } from "openclaw/plugin-sdk/runtime-env";
+import { resolveSlackAccount } from "../../accounts.js";
+import { resolveSlackAssistantPromptsConfig } from "../../assistant-prompts.js";
 import { buildSlackAssistantThreadMetadata } from "../context.js";
-import type {
-  SlackMonitorContext,
-  SlackAssistantSuggestedPrompt,
-  SlackAssistantThreadContext,
-} from "../context.js";
+import type { SlackMonitorContext, SlackAssistantThreadContext } from "../context.js";
 
 type SlackAssistantThreadPayload = {
   user_id?: string;
@@ -48,12 +46,6 @@ type SlackAssistantEventRegistrar = {
     handler: SlackAssistantEventHandler<SlackAssistantThreadContextChangedEvent>,
   ): void;
 };
-
-const DEFAULT_ASSISTANT_PROMPTS: SlackAssistantSuggestedPrompt[] = [
-  { title: "What can you do?", message: "What can you help me with?" },
-  { title: "Summarize this channel", message: "Summarize the recent activity in this channel." },
-  { title: "Draft a reply", message: "Help me draft a reply." },
-];
 
 function normalizeAssistantThread(
   event: SlackAssistantThreadStartedEvent | SlackAssistantThreadContextChangedEvent,
@@ -163,12 +155,16 @@ export function registerSlackAssistantEvents(params: {
         return;
       }
       ctx.saveSlackAssistantThreadContext(assistantThread);
-      await ctx.setSlackAssistantSuggestedPrompts({
-        channelId: assistantThread.assistantChannelId,
-        threadTs: assistantThread.threadTs,
-        title: "Try asking",
-        prompts: DEFAULT_ASSISTANT_PROMPTS,
-      });
+      const assistantPrompts = resolveSlackAssistantPromptsConfig(
+        resolveSlackAccount({ cfg: ctx.cfg, accountId: ctx.accountId }).config.assistantPrompts,
+      );
+      if (assistantPrompts) {
+        await ctx.setSlackAssistantSuggestedPrompts({
+          channelId: assistantThread.assistantChannelId,
+          threadTs: assistantThread.threadTs,
+          ...assistantPrompts,
+        });
+      }
     } catch (err) {
       ctx.runtime.error?.(
         danger(`slack assistant_thread_started handler failed: ${formatErrorMessage(err)}`),

--- a/src/channels/plugins/message-action-names.ts
+++ b/src/channels/plugins/message-action-names.ts
@@ -59,6 +59,7 @@ export const CHANNEL_MESSAGE_ACTION_NAMES = [
   "set-profile",
   "download-file",
   "upload-file",
+  "set-suggested-prompts",
 ] as const;
 
 /**

--- a/src/config/schema.help.ts
+++ b/src/config/schema.help.ts
@@ -917,6 +917,10 @@ export const FIELD_HELP: Record<string, string> = {
   "tools.message.broadcast.enabled": "Enable broadcast action (default: true).",
   "tools.message.actions.allow":
     "Global message action allowlist for the message tool. Use only when the whole runtime should expose and accept a reduced action set; prefer per-agent allowlists for public or sandboxed agents.",
+  "channels.slack.assistantPrompts":
+    "Static Slack assistant suggested prompts shown when a Slack assistant thread starts. Set false to suppress the built-in defaults, or provide a title plus up to four {title,message} prompts.",
+  "channels.slack.actions.assistantPrompts":
+    "Expose the Slack-only message action for updating assistant suggested prompts dynamically. Disable when agents should not change Slack assistant prompt suggestions.",
   "tools.web.search.enabled":
     "Enable managed web_search and optional Codex-native search for eligible models.",
   "tools.web.search.provider":

--- a/src/config/types.slack.ts
+++ b/src/config/types.slack.ts
@@ -101,7 +101,22 @@ export type SlackActionConfig = {
   memberInfo?: boolean;
   channelInfo?: boolean;
   emojiList?: boolean;
+  assistantPrompts?: boolean;
 };
+
+export type SlackAssistantPromptConfig = {
+  title: string;
+  message: string;
+};
+
+export type SlackAssistantPromptsConfig =
+  | false
+  | {
+      /** Optional Slack title shown above the suggested prompt list. */
+      title?: string;
+      /** Up to four Slack assistant suggested prompts. */
+      prompts: SlackAssistantPromptConfig[];
+    };
 
 export type SlackSlashCommandConfig = {
   /** Enable handling for the configured slash command (default: false). */
@@ -229,6 +244,8 @@ export type SlackAccountConfig = {
   /** Thread session behavior. */
   thread?: SlackThreadConfig;
   actions?: SlackActionConfig;
+  /** Static Slack assistant thread suggested prompts. Set false to suppress defaults. */
+  assistantPrompts?: SlackAssistantPromptsConfig;
   slashCommand?: SlackSlashCommandConfig;
   /**
    * Canonical DM policy key. Doctor migrates legacy channels.slack.dm.policy here.

--- a/src/config/zod-schema.providers-core.ts
+++ b/src/config/zod-schema.providers-core.ts
@@ -964,6 +964,23 @@ export const SlackRelaySchema = z
   })
   .strict();
 
+const SlackAssistantPromptSchema = z
+  .object({
+    title: z.string().min(1),
+    message: z.string().min(1),
+  })
+  .strict();
+
+const SlackAssistantPromptsSchema = z.union([
+  z.literal(false),
+  z
+    .object({
+      title: z.string().optional(),
+      prompts: z.array(SlackAssistantPromptSchema).min(1).max(4),
+    })
+    .strict(),
+]);
+
 export const SlackAccountSchema = z
   .object({
     name: z.string().optional(),
@@ -1021,9 +1038,11 @@ export const SlackAccountSchema = z
         memberInfo: z.boolean().optional(),
         channelInfo: z.boolean().optional(),
         emojiList: z.boolean().optional(),
+        assistantPrompts: z.boolean().optional(),
       })
       .strict()
       .optional(),
+    assistantPrompts: SlackAssistantPromptsSchema.optional(),
     slashCommand: z
       .object({
         enabled: z.boolean().optional(),

--- a/src/infra/outbound/message-action-spec.test.ts
+++ b/src/infra/outbound/message-action-spec.test.ts
@@ -12,6 +12,7 @@ vi.mock("../../channels/plugins/bootstrap-registry.js", async () => ({
 describe("actionRequiresTarget", () => {
   it.each([
     ["send", true],
+    ["set-suggested-prompts", true],
     ["channel-info", true],
     ["broadcast", false],
     ["search", false],
@@ -23,6 +24,11 @@ describe("actionRequiresTarget", () => {
 describe("actionHasTarget", () => {
   it.each([
     { action: "send", params: { to: "  channel:C1  " }, expected: true },
+    {
+      action: "set-suggested-prompts",
+      params: { to: "  C123  ", threadTs: "1777423717.666499" },
+      expected: true,
+    },
     { action: "channel-info", params: { channelId: "  C123  " }, expected: true },
     { action: "send", params: { to: "   ", channelId: "" }, expected: false },
     {

--- a/src/infra/outbound/message-action-spec.ts
+++ b/src/infra/outbound/message-action-spec.ts
@@ -75,6 +75,7 @@ export const MESSAGE_ACTION_TARGET_MODE: Record<ChannelMessageActionName, Messag
     "set-presence": "none",
     "download-file": "none",
     "upload-file": "to",
+    "set-suggested-prompts": "to",
   };
 
 type ActionTargetAliasSpec = {

--- a/src/plugin-sdk/config-contracts.ts
+++ b/src/plugin-sdk/config-contracts.ts
@@ -39,6 +39,7 @@ export type {
   ResolvedTtsPersona,
   SignalReactionNotificationMode,
   SlackAccountConfig,
+  SlackAssistantPromptsConfig,
   SlackChannelConfig,
   SlackReactionNotificationMode,
   SlackSlashCommandConfig,


### PR DESCRIPTION
## Summary
- add static Slack assistant suggested prompts via `channels.slack.assistantPrompts`, including `false` to suppress defaults
- add dynamic `set-suggested-prompts` message action gated by Slack assistant prompt actions
- wire runtime dispatch to Slack `assistant.threads.setSuggestedPrompts` and document/test the flow

## Verification
- `node scripts/run-vitest.mjs extensions/slack/src/config-schema.test.ts extensions/slack/src/monitor/events/assistant.test.ts extensions/slack/src/message-tools.test.ts extensions/slack/src/message-action-dispatch.test.ts extensions/slack/src/action-runtime.test.ts` passed
- `node scripts/run-vitest.mjs src/infra/outbound/message-action-spec.test.ts` passed
- `git diff --check origin/main...HEAD` passed

Remote changed-gate was not run locally because provider auth was unavailable in the OCA environment; CI should cover it on this PR.