### PR TITLE
Keep workspace suggestions opt-in for doctor lint

### DIFF
--- a/src/flows/doctor-core-checks.ts
+++ b/src/flows/doctor-core-checks.ts
@@ -1050,7 +1050,9 @@ const uiProtocolFreshnessCheck: HealthCheck = {
   },
 };
 
-function createWorkspaceSuggestionsCheck(deps: CoreHealthCheckDeps): HealthCheck {
+function createWorkspaceSuggestionsCheck(
+  deps: CoreHealthCheckDeps,
+): HealthCheck & { readonly defaultEnabled: false } {
   return {
     id: "core/doctor/workspace-suggestions",
     kind: "core",

--- a/src/flows/doctor-core-checks.ts
+++ b/src/flows/doctor-core-checks.ts
@@ -1056,6 +1056,7 @@ function createWorkspaceSuggestionsCheck(deps: CoreHealthCheckDeps): HealthCheck
     kind: "core",
     description:
       "Workspace backup and memory-system suggestions are captured as structured findings.",
+    defaultEnabled: false,
     source: "doctor",
     async detect(ctx) {
       const workspaceDir = resolveAgentWorkspaceDir(ctx.cfg, resolveDefaultAgentId(ctx.cfg));

--- a/src/flows/doctor-health-contributions.test.ts
+++ b/src/flows/doctor-health-contributions.test.ts
@@ -98,6 +98,8 @@ const mocks = vi.hoisted(() => ({
   gatherDaemonStatus: vi.fn(),
   noteWorkspaceStatus: vi.fn(),
   collectWorkspaceStatusHealthFindings: vi.fn().mockResolvedValue([]),
+  collectWorkspaceBackupTip: vi.fn((): string | undefined => undefined),
+  shouldSuggestMemorySystem: vi.fn(async () => false),
   collectDiskSpaceHealthFindings: vi.fn((): readonly HealthFinding[] => []),
   collectHeartbeatTemplateHealthFindings: vi.fn(async () => [] as unknown[]),
   maybeRepairHeartbeatTemplate: vi.fn().mockResolvedValue(undefined),
@@ -337,6 +339,16 @@ vi.mock("../cli/daemon-cli/status.gather.js", () => ({
 vi.mock("../commands/doctor-workspace-status.js", () => ({
   noteWorkspaceStatus: mocks.noteWorkspaceStatus,
   collectWorkspaceStatusHealthFindings: mocks.collectWorkspaceStatusHealthFindings,
+}));
+
+vi.mock("../commands/doctor-state-integrity.js", () => ({
+  collectWorkspaceBackupTip: mocks.collectWorkspaceBackupTip,
+  noteWorkspaceBackupTip: vi.fn(),
+}));
+
+vi.mock("../commands/doctor-workspace.js", () => ({
+  MEMORY_SYSTEM_PROMPT: "Enable memory system for better recall.",
+  shouldSuggestMemorySystem: mocks.shouldSuggestMemorySystem,
 }));
 
 vi.mock("../commands/doctor-disk-space.js", () => ({
@@ -1700,6 +1712,46 @@ describe("doctor health contributions", () => {
     });
 
     expect(findings).toEqual([]);
+  });
+
+  it("keeps workspace suggestions opt-in for default lint selection", async () => {
+    const contributionChecks = await resolveDoctorContributionHealthChecks();
+    const workspaceSuggestionsCheck = contributionChecks.find(
+      (check) => check.id === "core/doctor/workspace-suggestions",
+    );
+    expect(workspaceSuggestionsCheck).toMatchObject({ defaultEnabled: false });
+    expect(workspaceSuggestionsCheck).toBeDefined();
+    mocks.collectWorkspaceBackupTip.mockReturnValueOnce(
+      "Back up your workspace before major repair work.",
+    );
+
+    const ctx = {
+      cfg: {},
+      mode: "lint",
+      runtime: { log: vi.fn(), error: vi.fn(), exit: vi.fn() },
+    } as const;
+    const checks = [workspaceSuggestionsCheck!];
+
+    await expect(runDoctorLintChecks(ctx, { checks })).resolves.toMatchObject({
+      checksRun: 0,
+      checksSkipped: 1,
+    });
+    expect(mocks.collectWorkspaceBackupTip).not.toHaveBeenCalled();
+
+    await expect(
+      runDoctorLintChecks(ctx, { checks, onlyIds: ["core/doctor/workspace-suggestions"] }),
+    ).resolves.toMatchObject({
+      checksRun: 1,
+      checksSkipped: 0,
+      findings: [
+        expect.objectContaining({
+          checkId: "core/doctor/workspace-suggestions",
+          severity: "info",
+          message: "Back up your workspace before major repair work.",
+        }),
+      ],
+    });
+    expect(mocks.collectWorkspaceBackupTip).toHaveBeenCalledWith("/tmp/openclaw-workspace");
   });
 
   it("keeps disk space opt-in for default lint selection", async () => {


### PR DESCRIPTION
## Summary
- mark `core/doctor/workspace-suggestions` default-disabled so default `doctor --lint` stays focused on actionable config/runtime problems
- keep the advisory workspace backup and memory-system suggestions available through `--only core/doctor/workspace-suggestions` or `--all`
- add selection coverage proving default lint skips the advisory check while explicit selection still reports info findings

## Public surface
- No public SDK/plugin/config contract changes.
- Default `doctor --lint` changes only by omitting this advisory `info` check; `--all` and `--only` still include it.

## PR surface
- 2 files changed, +53/-0 from `main`.

## Validation
- `node scripts/run-vitest.mjs src/flows/doctor-health-contributions.test.ts src/flows/doctor-core-checks.test.ts` (78 tests)
- `pnpm exec oxfmt --check src/flows/doctor-core-checks.ts src/flows/doctor-health-contributions.ts src/flows/doctor-health-contributions.test.ts`
- `pnpm exec oxlint src/flows/doctor-core-checks.ts src/flows/doctor-health-contributions.ts src/flows/doctor-health-contributions.test.ts`
- `node scripts/plugin-sdk-surface-report.mjs --check`
- `git diff --check`

## Real behavior proof
- GitHub Actions `Real behavior proof` passed on the updated head `13f50ef9b73061f23b12992cb18ce9775b9e8d10`:
  https://github.com/openclaw/openclaw/actions/runs/28692008105/job/85094905334
- This is a type-only fix; runtime selection behavior is unchanged from the proof already covered by the passing check.