### PR TITLE
Keep legacy WhatsApp crontab lint opt-in

### DIFF
--- a/src/flows/doctor-core-checks.ts
+++ b/src/flows/doctor-core-checks.ts
@@ -656,11 +656,12 @@ const openAIOAuthTlsCheck: HealthCheck = {
   },
 };
 
-const legacyWhatsAppCrontabCheck: HealthCheck = {
+const legacyWhatsAppCrontabCheck: HealthCheck & { readonly defaultEnabled: false } = {
   id: "core/doctor/legacy-whatsapp-crontab",
   kind: "core",
   description: "Legacy WhatsApp crontab health entries are detected as structured findings.",
   source: "doctor",
+  defaultEnabled: false,
   async detect() {
     const { collectLegacyWhatsAppCrontabHealthWarning } =
       await import("../commands/doctor/cron/index.js");

--- a/src/flows/doctor-health-contributions.test.ts
+++ b/src/flows/doctor-health-contributions.test.ts
@@ -107,7 +107,9 @@ const mocks = vi.hoisted(() => ({
   noteWhatsappResponsivenessHealth: vi.fn().mockResolvedValue(undefined),
   collectDevicePairingHealthFindings: vi.fn(async () => []),
   collectLegacyCronStoreHealthFindings: vi.fn(async (): Promise<readonly HealthFinding[]> => []),
-  collectLegacyWhatsAppCrontabHealthWarning: vi.fn(async () => undefined),
+  collectLegacyWhatsAppCrontabHealthWarning: vi.fn(
+    async (): Promise<string | undefined> => undefined,
+  ),
   maybeRepairLegacyCronStore: vi.fn().mockResolvedValue(undefined),
   noteLegacyWhatsAppCrontabHealthCheck: vi.fn().mockResolvedValue(undefined),
   scanConfiguredChannelPluginBlockers: vi.fn(
@@ -1990,6 +1992,46 @@ describe("doctor health contributions", () => {
       findings: [expect.objectContaining({ checkId: "core/doctor/legacy-cron-store" })],
     });
     expect(mocks.collectLegacyCronStoreHealthFindings).toHaveBeenCalledWith({ cfg: ctx.cfg });
+  });
+
+  it("keeps legacy WhatsApp crontab opt-in for default lint selection", async () => {
+    const contributionChecks = await resolveDoctorContributionHealthChecks();
+    const crontabCheck = contributionChecks.find(
+      (check) => check.id === "core/doctor/legacy-whatsapp-crontab",
+    );
+    expect(crontabCheck).toMatchObject({ defaultEnabled: false });
+    expect(crontabCheck).toBeDefined();
+
+    const ctx = {
+      cfg: {},
+      mode: "lint",
+      runtime: { log: vi.fn(), error: vi.fn(), exit: vi.fn() },
+    } as const;
+    const checks = [crontabCheck!];
+
+    await expect(runDoctorLintChecks(ctx, { checks })).resolves.toMatchObject({
+      checksRun: 0,
+      checksSkipped: 1,
+    });
+    expect(mocks.collectLegacyWhatsAppCrontabHealthWarning).not.toHaveBeenCalled();
+
+    mocks.collectLegacyWhatsAppCrontabHealthWarning.mockResolvedValueOnce(
+      "Legacy WhatsApp crontab health check detected.\nRemove the stale crontab entry.",
+    );
+
+    await expect(
+      runDoctorLintChecks(ctx, { checks, onlyIds: ["core/doctor/legacy-whatsapp-crontab"] }),
+    ).resolves.toMatchObject({
+      checksRun: 1,
+      checksSkipped: 0,
+      findings: [
+        expect.objectContaining({
+          checkId: "core/doctor/legacy-whatsapp-crontab",
+          severity: "warning",
+        }),
+      ],
+    });
+    expect(mocks.collectLegacyWhatsAppCrontabHealthWarning).toHaveBeenCalledTimes(1);
   });
 
   it("keeps channel plugin blockers opt-in for default lint selection", async () => {


### PR DESCRIPTION
## Summary
- mark `core/doctor/legacy-whatsapp-crontab` default-disabled so default `doctor --lint` does not invoke the shell-backed `crontab -l` probe
- preserve explicit selection through `--only core/doctor/legacy-whatsapp-crontab` and `--all`
- keep the ordered Doctor legacy-cron contribution wired through the existing `healthCheckIds` mapping instead of duplicating core checks inline

## Public surface
- No public SDK/plugin/config contract changes.
- Default `doctor --lint` changes only by skipping this live crontab probe; `--all` and `--only` still include it.
- Real repair/reporting behavior for the legacy WhatsApp crontab path remains owned by the existing Doctor implementation.

## PR surface
- 2 files changed, +45/-2 after removing the duplicate inline contribution checks and preserving the existing core check mapping.

## Real behavior proof

Behavior or issue addressed:
Default `doctor --lint` leaves the legacy WhatsApp crontab probe opt-in, while explicit `--only core/doctor/legacy-whatsapp-crontab` still runs the detector and reports the warning.

Real environment tested:
WSL Ubuntu source checkout at head `8964ccb23931a3c0d8e09122f4dff6cfbbd960b4`; built OpenClaw doctor lint CLI module from this checkout; isolated `OPENCLAW_STATE_DIR`; PATH-scoped temporary `crontab` shim returning a redacted legacy `~/.openclaw/bin/ensure-whatsapp.sh` entry. The real system crontab was not modified.

Exact steps or command run after this patch:
1. `pnpm build`
2. `OPENCLAW_STATE_DIR=<tmp> PATH=<tmp>:$PATH runDoctorLintCli({json:true})`
3. `OPENCLAW_STATE_DIR=<tmp> PATH=<tmp>:$PATH runDoctorLintCli({json:true, onlyIds:["core/doctor/legacy-whatsapp-crontab"]})`

Evidence after fix:
```json
{
  "defaultRun": {
    "exitCode": 1,
    "checksRun": 23,
    "checksSkipped": 23,
    "findingCount": 31,
    "crontabShimCalls": "<none>",
    "hasLegacyWhatsAppCrontabFinding": false
  },
  "explicitOnlyRun": {
    "exitCode": 1,
    "checksRun": 1,
    "checksSkipped": 45,
    "findingCount": 1,
    "crontabShimCalls": "called: -l",
    "legacyWhatsAppCrontabFindings": [
      {
        "checkId": "core/doctor/legacy-whatsapp-crontab",
        "severity": "warning",
        "message": "Legacy WhatsApp crontab health check detected.",
        "fixHint": "`~/.openclaw/bin/ensure-whatsapp.sh` is not maintained by current OpenClaw and can misreport `Gateway inactive` from cron when the systemd user bus environment is missing.\nRemove the stale crontab entry with crontab -e; use openclaw channels status --probe, openclaw doctor, and openclaw gateway status for current health checks.\nMatched 1 entry."
      }
    ]
  }
}
```

Observed result after fix:
Default lint did not call `crontab -l` and did not include `core/doctor/legacy-whatsapp-crontab`. Explicit `--only core/doctor/legacy-whatsapp-crontab` called `crontab -l` once and emitted the structured warning finding.

What was not tested:
A real user crontab was not edited; the crontab content was supplied by a PATH-scoped shim to avoid mutating host cron state. Full `openclaw.mjs doctor --lint` proof with a PATH shim was not used because the entrypoint startup path can respawn/normalize process env; the tested command module is the same doctor lint implementation invoked by that entrypoint after option parsing.

## Validation
- `pnpm exec vitest run src/flows/doctor-health-contributions.test.ts --maxWorkers 1 --no-fileParallelism`
- `pnpm exec oxfmt --check src/flows/doctor-health-contributions.ts src/flows/doctor-core-checks.ts src/flows/doctor-health-contributions.test.ts`
- `pnpm exec oxlint src/flows/doctor-health-contributions.ts src/flows/doctor-core-checks.ts src/flows/doctor-health-contributions.test.ts`
- `git diff --check`
- `pnpm build`

## Not tested / baseline gaps
- Full `pnpm exec tsgo --noEmit --project tsconfig.json --pretty false` previously failed outside this PR in `src/config/io.ts` / `src/secrets/config-io.ts` around `configWritePostCommitRollback` exported type naming. This PR does not touch those files.


