### PR TITLE
fix(gateway,approvals): crash-safe hook agent dispatch + realpath-aware allowlist add

### DIFF
--- a/docs/cli/approvals.md
+++ b/docs/cli/approvals.md
@@ -160,6 +160,16 @@ openclaw approvals allowlist add --agent "*" "/usr/bin/uname"
 openclaw approvals allowlist remove "~/Projects/**/bin/rg"
 ```
 
+Path entries match the executable **realpath** (symlink retargeting must not keep
+approvals). When you add a literal path that is a symlink on the local host — for
+example `/opt/homebrew/bin/rg`, which Homebrew symlinks into `Cellar/` — the CLI
+stores the resolved realpath and says so. Glob patterns and bare command names are
+stored as typed. For `--gateway` and `--node` targets the CLI cannot inspect the
+target filesystem, so add the realpath yourself if the path is a symlink there.
+`allowlist remove` accepts the stored pattern or a symlink path, resolved at remove
+time — if the symlink was retargeted since you added it (for example by a package
+upgrade), remove the old realpath shown by `openclaw approvals get` instead.
+
 ## Common options
 
 `get`, `set`, and `allowlist add|remove` all support:

--- a/src/cli/exec-approvals-cli.test.ts
+++ b/src/cli/exec-approvals-cli.test.ts
@@ -1,4 +1,7 @@
 // Exec approvals CLI tests cover approval command registration and output handling.
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
 import { Readable } from "node:stream";
 import { Command } from "commander";
 import { beforeEach, describe, expect, it, vi } from "vitest";
@@ -560,6 +563,81 @@ describe("exec approvals CLI", () => {
       agents: undefined,
     });
     expect(runtimeErrors).toHaveLength(0);
+  });
+
+  it.runIf(process.platform !== "win32")(
+    "stores the executable realpath when allowlisting a symlink path",
+    async () => {
+      const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-approvals-cli-"));
+      try {
+        const realBinary = path.join(tempDir, "cellar-rg");
+        fs.writeFileSync(realBinary, "#!/bin/sh\n", { mode: 0o755 });
+        const symlinkPath = path.join(tempDir, "rg");
+        fs.symlinkSync(realBinary, symlinkPath);
+        const realPath = fs.realpathSync(realBinary);
+
+        const saveExecApprovals = vi.mocked(execApprovals.saveExecApprovals);
+        saveExecApprovals.mockClear();
+
+        await runApprovalsCommand(["approvals", "allowlist", "add", symlinkPath]);
+
+        const saved = requireRecord(firstMockArg(saveExecApprovals), "saved approvals");
+        const agent = requireRecord(requireRecord(saved.agents, "agents")["*"], "wildcard agent");
+        const allowlist = requireArray(agent.allowlist, "allowlist");
+        expectFields(allowlist[0], "allowlist entry", { pattern: realPath });
+        expect(
+          defaultRuntime.log.mock.calls.some((call) =>
+            String(call[0]).includes(`storing the realpath`),
+          ),
+        ).toBe(true);
+
+        // Removing by the symlink path the operator typed removes the realpath entry.
+        localSnapshot.file = {
+          version: 1,
+          agents: { "*": { allowlist: [{ pattern: realPath, lastUsedAt: Date.now() }] } },
+        };
+        saveExecApprovals.mockClear();
+        await runApprovalsCommand(["approvals", "allowlist", "remove", symlinkPath]);
+        const savedAfterRemove = requireRecord(
+          firstMockArg(saveExecApprovals),
+          "saved approvals after remove",
+        );
+        expectFields(savedAfterRemove, "saved approvals after remove", {
+          version: 1,
+          agents: undefined,
+        });
+        expect(runtimeErrors).toHaveLength(0);
+      } finally {
+        fs.rmSync(tempDir, { recursive: true, force: true });
+      }
+    },
+  );
+
+  it("keeps node-target allowlist patterns unresolved and prints a realpath hint", async () => {
+    await runApprovalsCommand([
+      "approvals",
+      "allowlist",
+      "add",
+      "--node",
+      "macbook",
+      "/opt/homebrew/bin/rg",
+    ]);
+
+    const setCall = callGatewayFromCli.mock.calls.find(
+      (call) => call[0] === "exec.approvals.node.set",
+    );
+    if (!setCall) {
+      throw new Error("Expected exec.approvals.node.set call");
+    }
+    const file = requireRecord(requireRecord(setCall[2], "set params").file, "approvals file");
+    const agent = requireRecord(requireRecord(file.agents, "agents")["*"], "wildcard agent");
+    const allowlist = requireArray(agent.allowlist, "allowlist");
+    expectFields(allowlist[0], "allowlist entry", { pattern: "/opt/homebrew/bin/rg" });
+    expect(
+      defaultRuntime.log.mock.calls.some((call) =>
+        String(call[0]).includes("match the executable realpath"),
+      ),
+    ).toBe(true);
   });
 
   it("bounds approvals JSON read from stdin", async () => {

--- a/src/cli/exec-approvals-cli.ts
+++ b/src/cli/exec-approvals-cli.ts
@@ -9,6 +9,7 @@ import { getTerminalTableWidth, renderTable } from "../../packages/terminal-core
 import { isRich, theme } from "../../packages/terminal-core/src/theme.js";
 import { readBestEffortConfig, type OpenClawConfig } from "../config/config.js";
 import { formatErrorMessage } from "../infra/errors.js";
+import { normalizeExecAllowlistPatternForAdd } from "../infra/exec-allowlist-pattern.js";
 import {
   collectExecPolicyScopeSnapshots,
   type ExecPolicyScopeSnapshot,
@@ -394,6 +395,14 @@ function normalizeAllowlistEntry(entry: { pattern?: string } | null): string | n
   return pattern ? pattern : null;
 }
 
+function resolveAllowlistMutationPattern(params: { trimmedPattern: string; source: string }) {
+  // Gateway and node targets can live on another host; resolving the local
+  // realpath there would store a wrong-host path, so only local writes translate.
+  return normalizeExecAllowlistPatternForAdd(params.trimmedPattern, {
+    resolveLocalRealpath: params.source === "local",
+  });
+}
+
 function ensureAgent(file: ExecApprovalsFile, agentKey: string): ExecApprovalsAgent {
   const agents = file.agents ?? {};
   const entry = agents[agentKey] ?? {};
@@ -590,12 +599,23 @@ export function registerExecApprovalsCli(program: Command) {
     allowlist,
     name: "add",
     description: "Add a glob pattern to an allowlist",
-    mutate: ({ trimmedPattern, file, agent, agentKey, allowlistEntries }) => {
-      if (allowlistEntries.some((entry) => normalizeAllowlistEntry(entry) === trimmedPattern)) {
+    mutate: ({ trimmedPattern, source, file, agent, agentKey, allowlistEntries }) => {
+      const normalized = resolveAllowlistMutationPattern({ trimmedPattern, source });
+      const pattern = normalized.pattern;
+      if (normalized.kind === "resolved-symlink") {
+        defaultRuntime.log(
+          `Resolved ${trimmedPattern} to executable realpath ${pattern}; storing the realpath so the entry matches at exec time.`,
+        );
+      } else if (normalized.kind === "unverified-path") {
+        defaultRuntime.log(
+          `Note: path allowlist entries match the executable realpath. If ${pattern} is a symlink on the target host, add its realpath instead.`,
+        );
+      }
+      if (allowlistEntries.some((entry) => normalizeAllowlistEntry(entry) === pattern)) {
         defaultRuntime.log("Already allowlisted.");
         return false;
       }
-      allowlistEntries.push({ pattern: trimmedPattern, lastUsedAt: Date.now() });
+      allowlistEntries.push({ pattern, lastUsedAt: Date.now() });
       agent.allowlist = allowlistEntries;
       file.agents = { ...file.agents, [agentKey]: agent };
       return true;
@@ -606,10 +626,19 @@ export function registerExecApprovalsCli(program: Command) {
     allowlist,
     name: "remove",
     description: "Remove a glob pattern from an allowlist",
-    mutate: ({ trimmedPattern, file, agent, agentKey, allowlistEntries }) => {
-      const nextEntries = allowlistEntries.filter(
+    mutate: ({ trimmedPattern, source, file, agent, agentKey, allowlistEntries }) => {
+      // Prefer the exact typed pattern; fall back to its current realpath so a
+      // symlink path still removes the stored realpath entry. Skips the
+      // filesystem call entirely when the typed pattern matches directly.
+      let nextEntries = allowlistEntries.filter(
         (entry) => normalizeAllowlistEntry(entry) !== trimmedPattern,
       );
+      if (nextEntries.length === allowlistEntries.length) {
+        const normalized = resolveAllowlistMutationPattern({ trimmedPattern, source });
+        nextEntries = allowlistEntries.filter(
+          (entry) => normalizeAllowlistEntry(entry) !== normalized.pattern,
+        );
+      }
       if (nextEntries.length === allowlistEntries.length) {
         defaultRuntime.log("Pattern not found.");
         return false;

--- a/src/cron/service/agent-watchdog.ts
+++ b/src/cron/service/agent-watchdog.ts
@@ -50,6 +50,7 @@ export type CronAgentWatchdog = {
   start: () => void;
   noteLaneWait: () => void;
   noteLaneAdmitted: () => void;
+  noteLaneState: (info?: { waiting?: boolean }) => void;
   noteRunnerStarted: (info?: CronAgentExecutionStarted) => void;
   notePhase: (info: CronAgentExecutionPhaseUpdate) => void;
   activeExecution: () => CronAgentExecutionStarted | undefined;
@@ -157,6 +158,11 @@ export function createCronAgentWatchdog(params: {
         observedLaneWait = false;
       }
     },
+    noteLaneState: (info?: { waiting?: boolean }) => {
+      if (state === "waiting_for_runner") {
+        observedLaneWait = info?.waiting !== false;
+      }
+    },
     noteRunnerStarted: (info?: CronAgentExecutionStarted) => {
       if (state === "disposed" || state === "timed_out") {
         return;
@@ -185,6 +191,56 @@ export function createCronAgentWatchdog(params: {
       clearSetupTimeout();
       clearPreExecutionTimeout();
     },
+  };
+}
+
+/** Race marker resolved by a timeout guard when the watchdog fires. */
+export const CRON_AGENT_TIMEOUT_MARKER: unique symbol = Symbol("cron-agent-timeout");
+
+/** Abort-on-timeout guard around one isolated agent run, shared by cron timer and hook dispatch. */
+export type CronAgentTimeoutGuard = {
+  abortController: AbortController;
+  watchdog: CronAgentWatchdog;
+  timeoutPromise: Promise<typeof CRON_AGENT_TIMEOUT_MARKER>;
+  timeoutReason: () => string | undefined;
+  dispose: () => void;
+};
+
+/**
+ * Couples a watchdog to an AbortController and a raceable timeout promise.
+ * The timeout error keeps the `TimeoutError` name because downstream abort
+ * classification distinguishes timeouts from operator cancels by it.
+ */
+export function createCronAgentTimeoutGuard(params: {
+  jobTimeoutMs: number;
+  deferUntilRunner: boolean;
+  abortController?: AbortController;
+}): CronAgentTimeoutGuard {
+  const abortController = params.abortController ?? new AbortController();
+  let timeoutReason: string | undefined;
+  let resolveTimeout: ((value: typeof CRON_AGENT_TIMEOUT_MARKER) => void) | undefined;
+  const timeoutPromise = new Promise<typeof CRON_AGENT_TIMEOUT_MARKER>((resolve) => {
+    resolveTimeout = resolve;
+  });
+  const watchdog = createCronAgentWatchdog({
+    deferUntilRunner: params.deferUntilRunner,
+    jobTimeoutMs: params.jobTimeoutMs,
+    triggerTimeout: (reason) => {
+      timeoutReason = reason;
+      if (!abortController.signal.aborted) {
+        const timeoutError = new Error(reason);
+        timeoutError.name = "TimeoutError";
+        abortController.abort(timeoutError);
+      }
+      resolveTimeout?.(CRON_AGENT_TIMEOUT_MARKER);
+    },
+  });
+  return {
+    abortController,
+    watchdog,
+    timeoutPromise,
+    timeoutReason: () => timeoutReason,
+    dispose: watchdog.dispose,
   };
 }
 

--- a/src/cron/service/task-runs.ts
+++ b/src/cron/service/task-runs.ts
@@ -58,45 +58,109 @@ function resolveCronTaskChildSessionKey(params: {
   });
 }
 
-/** Creates a best-effort detached task ledger row for a cron run. */
-export function tryCreateCronTaskRun(params: {
-  state: CronServiceState;
+type CronTaskRunWarn = (meta: Record<string, unknown>, message: string) => void;
+
+/**
+ * Best-effort detached ledger row for one cron-shaped agent run.
+ *
+ * Shared by scheduled cron jobs and gateway hook dispatches. The registry's
+ * cron-runtime contract requires `sourceId` to be a job id currently marked
+ * via `markCronJobActive`; rows without an active marker are swept to "lost"
+ * by task maintenance after the reconcile grace.
+ */
+export function tryCreateCronRunLedgerRow(params: {
+  warn: CronTaskRunWarn;
   job: CronJob;
+  runId: string;
+  childSessionKey: string | undefined;
+  label: string;
+  progressSummary: string;
   startedAt: number;
 }): string | undefined {
-  const runId = createCronExecutionId(params.job.id, params.startedAt);
   try {
     const task = createRunningTaskRun({
       runtime: "cron",
       sourceId: params.job.id,
       ownerKey: "",
       scopeKind: "system",
-      childSessionKey: resolveCronTaskChildSessionKey(params),
+      childSessionKey: params.childSessionKey,
       agentId: params.job.agentId,
-      runId,
-      label: params.job.name,
+      runId: params.runId,
+      label: params.label,
       task: params.job.name || params.job.id,
       deliveryStatus: "not_applicable",
       notifyPolicy: "silent",
       startedAt: params.startedAt,
       lastEventAt: params.startedAt,
-      progressSummary: CRON_TASK_RUNNING_PROGRESS_SUMMARY,
+      progressSummary: params.progressSummary,
     });
     if (!task) {
-      params.state.deps.log.warn(
-        { jobId: params.job.id },
-        "cron: task ledger record was not persisted",
-      );
+      params.warn({ jobId: params.job.id }, "cron: task ledger record was not persisted");
       return undefined;
     }
-    return runId;
+    return params.runId;
   } catch (error) {
-    params.state.deps.log.warn(
-      { jobId: params.job.id, error },
-      "cron: failed to create task ledger record",
-    );
+    params.warn({ jobId: params.job.id, error }, "cron: failed to create task ledger record");
     return undefined;
   }
+}
+
+/** Completes or fails a cron-shaped detached ledger row when one exists. */
+export function tryFinishCronRunLedgerRow(params: {
+  warn: CronTaskRunWarn;
+  taskRunId: string | undefined;
+  status: CronRunStatus;
+  failStatus?: "failed" | "timed_out" | "cancelled";
+  error?: string;
+  summary?: string;
+  endedAt: number;
+}): void {
+  if (!params.taskRunId) {
+    return;
+  }
+  try {
+    if (params.status === "ok" || params.status === "skipped") {
+      completeTaskRunByRunId({
+        runId: params.taskRunId,
+        runtime: "cron",
+        endedAt: params.endedAt,
+        lastEventAt: params.endedAt,
+        terminalSummary: params.summary ?? undefined,
+      });
+      return;
+    }
+    failTaskRunByRunId({
+      runId: params.taskRunId,
+      runtime: "cron",
+      status: params.failStatus ?? "failed",
+      endedAt: params.endedAt,
+      lastEventAt: params.endedAt,
+      error: params.error,
+      terminalSummary: params.summary ?? undefined,
+    });
+  } catch (error) {
+    params.warn(
+      { runId: params.taskRunId, jobStatus: params.status, error },
+      "cron: failed to update task ledger record",
+    );
+  }
+}
+
+/** Creates a best-effort detached task ledger row for a cron run. */
+export function tryCreateCronTaskRun(params: {
+  state: CronServiceState;
+  job: CronJob;
+  startedAt: number;
+}): string | undefined {
+  return tryCreateCronRunLedgerRow({
+    warn: (meta, message) => params.state.deps.log.warn(meta, message),
+    job: params.job,
+    runId: createCronExecutionId(params.job.id, params.startedAt),
+    childSessionKey: resolveCronTaskChildSessionKey(params),
+    label: params.job.name,
+    progressSummary: CRON_TASK_RUNNING_PROGRESS_SUMMARY,
+    startedAt: params.startedAt,
+  });
 }
 
 /** Completes or fails the detached task ledger row for a cron run when one exists. */
@@ -110,34 +174,15 @@ export function tryFinishCronTaskRun(
     summary?: string;
   },
 ): void {
-  if (!result.taskRunId) {
-    return;
-  }
-  try {
-    if (result.status === "ok" || result.status === "skipped") {
-      completeTaskRunByRunId({
-        runId: result.taskRunId,
-        runtime: "cron",
-        endedAt: result.endedAt,
-        lastEventAt: result.endedAt,
-        terminalSummary: result.summary ?? undefined,
-      });
-      return;
-    }
-    failTaskRunByRunId({
-      runId: result.taskRunId,
-      runtime: "cron",
-      status:
-        normalizeCronRunErrorText(result.error) === timeoutErrorMessage() ? "timed_out" : "failed",
-      endedAt: result.endedAt,
-      lastEventAt: result.endedAt,
-      error: result.status === "error" ? normalizeCronRunErrorText(result.error) : undefined,
-      terminalSummary: result.summary ?? undefined,
-    });
-  } catch (error) {
-    state.deps.log.warn(
-      { runId: result.taskRunId, jobStatus: result.status, error },
-      "cron: failed to update task ledger record",
-    );
-  }
+  const errorText = result.status === "error" ? normalizeCronRunErrorText(result.error) : undefined;
+  tryFinishCronRunLedgerRow({
+    warn: (meta, message) => state.deps.log.warn(meta, message),
+    taskRunId: result.taskRunId,
+    status: result.status,
+    failStatus:
+      normalizeCronRunErrorText(result.error) === timeoutErrorMessage() ? "timed_out" : "failed",
+    error: errorText,
+    summary: result.summary,
+    endedAt: result.endedAt,
+  });
 }

--- a/src/cron/service/timer.ts
+++ b/src/cron/service/timer.ts
@@ -48,8 +48,9 @@ import type {
 } from "../types.js";
 import {
   cleanupTimedOutCronAgentRun,
-  createCronAgentWatchdog,
+  createCronAgentTimeoutGuard,
   CRON_AGENT_SETUP_WATCHDOG_MS,
+  CRON_AGENT_TIMEOUT_MARKER,
 } from "./agent-watchdog.js";
 import {
   abortErrorMessage,
@@ -252,42 +253,20 @@ export async function executeJobCoreWithTimeout(
       return createOperatorCancellationOutcome(activeExecution);
     }
 
-    let timeoutReason: string | undefined;
-    const timeoutMarker = Symbol("cron-timeout");
-    let resolveTimeout: ((value: typeof timeoutMarker) => void) | undefined;
-    const timeoutPromise = new Promise<typeof timeoutMarker>((resolve) => {
-      resolveTimeout = resolve;
-    });
-
     // Detached agent runs report setup phases separately; defer the wall-clock
     // timeout until the runner starts so cold setup gets a clearer failure reason.
     const deferTimeoutUntilExecutionStart =
       job.sessionTarget !== "main" && job.payload.kind === "agentTurn";
-    const triggerTimeout = (reason: string) => {
-      timeoutReason = reason;
-      if (!runAbortController.signal.aborted) {
-        const timeoutError = new Error(reason);
-        timeoutError.name = "TimeoutError";
-        runAbortController.abort(timeoutError);
-      }
-      resolveTimeout?.(timeoutMarker);
-    };
-    const watchdog = createCronAgentWatchdog({
-      deferUntilRunner: deferTimeoutUntilExecutionStart,
+    const guard = createCronAgentTimeoutGuard({
       jobTimeoutMs,
-      triggerTimeout,
+      deferUntilRunner: deferTimeoutUntilExecutionStart,
+      abortController: runAbortController,
     });
-    const noteLaneState = (info?: { waiting?: boolean }) => {
-      if (info?.waiting === false) {
-        watchdog.noteLaneAdmitted();
-        return;
-      }
-      watchdog.noteLaneWait();
-    };
+    const { watchdog } = guard;
     const corePromise = executeJobCore(state, job, runAbortController.signal, {
       onExecutionStarted: deferTimeoutUntilExecutionStart ? watchdog.noteRunnerStarted : undefined,
       onExecutionPhase: deferTimeoutUntilExecutionStart ? watchdog.notePhase : undefined,
-      onLaneWait: deferTimeoutUntilExecutionStart ? noteLaneState : undefined,
+      onLaneWait: deferTimeoutUntilExecutionStart ? watchdog.noteLaneState : undefined,
     });
     trackActiveCronTaskRunSettlement(corePromise);
     watchdog.start();
@@ -300,18 +279,22 @@ export async function executeJobCoreWithTimeout(
       }
     });
     try {
-      const first = await Promise.race([corePromise, timeoutPromise, operatorCancellationPromise]);
+      const first = await Promise.race([
+        corePromise,
+        guard.timeoutPromise,
+        operatorCancellationPromise,
+      ]);
       if (first === operatorCancellationMarker) {
         startActiveCronTaskRunSettlementGrace();
         return createOperatorCancellationOutcome(watchdog.activeExecution());
       }
-      if (first !== timeoutMarker) {
+      if (first !== CRON_AGENT_TIMEOUT_MARKER) {
         return first;
       }
       startActiveCronTaskRunSettlementGrace();
       const activeExecution = watchdog.activeExecution();
       await cleanupTimedOutCronAgentRun(state, job, jobTimeoutMs, activeExecution);
-      const error = timeoutReason ?? timeoutErrorMessage(activeExecution);
+      const error = guard.timeoutReason() ?? timeoutErrorMessage(activeExecution);
       const observedLaneWait = watchdog.observedLaneWait();
       const isolatedAgentSetupTimeout =
         job.sessionTarget === "isolated" && isSetupTimeoutErrorText(error) && !observedLaneWait
@@ -331,7 +314,7 @@ export async function executeJobCoreWithTimeout(
         ...(isolatedAgentSetupTimeout ? { isolatedAgentSetupTimeout } : {}),
       };
     } finally {
-      watchdog.dispose();
+      guard.dispose();
     }
   } finally {
     releaseCronTaskRun?.();

--- a/src/gateway/server-cron.ts
+++ b/src/gateway/server-cron.ts
@@ -1,8 +1,6 @@
 // Gateway cron runtime service runs scheduled agent turns, heartbeat wakeups,
 // plugin hooks, notifications, and cron lifecycle cleanup.
-import { retireSessionMcpRuntime } from "../agents/agent-bundle-mcp-tools.js";
 import { resolveDefaultAgentId } from "../agents/agent-scope.js";
-import { abortAndDrainEmbeddedAgentRun } from "../agents/embedded-agent.js";
 import { isSilentReplyText, SILENT_REPLY_TOKEN } from "../auto-reply/tokens.js";
 import { cleanupBrowserSessionsForLifecycleEnd } from "../browser-lifecycle-cleanup.js";
 import type { CliDeps } from "../cli/deps.types.js";
@@ -61,6 +59,7 @@ import {
   dispatchGatewayCronFinishedNotifications,
   sendGatewayCronFailureAlert,
 } from "./server-cron-notifications.js";
+import { cleanupTimedOutIsolatedAgentRun } from "./timed-out-agent-run-cleanup.js";
 
 export type GatewayCronState = {
   cron: CronServiceContract;
@@ -596,37 +595,12 @@ export function buildGatewayCronService(params: {
       }
     },
     cleanupTimedOutAgentRun: async ({ job, execution }) => {
-      if (!execution?.sessionId) {
-        return;
-      }
-      const result = await abortAndDrainEmbeddedAgentRun({
-        sessionId: execution.sessionId,
-        sessionKey: execution.sessionKey,
-        settleMs: 15_000,
-        forceClear: true,
+      await cleanupTimedOutIsolatedAgentRun({
+        execution,
         reason: "cron_timeout",
+        retireReason: "cron-timeout-cleanup",
+        warn: (meta, message) => cronLogger.warn({ jobId: job.id, ...meta }, `cron: ${message}`),
       });
-      cronLogger.warn(
-        {
-          jobId: job.id,
-          sessionId: execution.sessionId,
-          sessionKey: execution.sessionKey,
-          aborted: result.aborted,
-          drained: result.drained,
-          forceCleared: result.forceCleared,
-        },
-        "cron: cleaned up timed-out agent run",
-      );
-      await retireSessionMcpRuntime({
-        sessionId: execution.sessionId,
-        reason: "cron-timeout-cleanup",
-        onError: (error, sid) => {
-          cronLogger.warn(
-            { jobId: job.id, sessionId: sid },
-            `cron: failed to retire MCP runtime for timed-out session: ${String(error)}`,
-          );
-        },
-      }).catch(() => {});
     },
     onIsolatedAgentSetupTimeout: ({ job, error, timeoutMs }) => {
       cronLogger.warn(

--- a/src/gateway/server/hooks.agent-dispatch-watchdog.test.ts
+++ b/src/gateway/server/hooks.agent-dispatch-watchdog.test.ts
@@ -1,0 +1,295 @@
+/**
+ * Hook agent dispatch crash-safety tests: task-ledger persistence, watchdog
+ * timeout for wedged runs, operator cancel, and dispatch isolation so one
+ * dead run cannot silently swallow later dispatches.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const enqueueSystemEventMock = vi.fn();
+const requestHeartbeatMock = vi.fn();
+const runCronIsolatedAgentTurnMock = vi.fn();
+const resolveMainSessionKeyMock = vi.fn(() => "main-session");
+const loadConfigMock = vi.fn(() => ({}));
+const createRunningTaskRunMock = vi.fn(() => ({ runId: "task" }));
+const completeTaskRunByRunIdMock = vi.fn();
+const failTaskRunByRunIdMock = vi.fn();
+const cleanupTimedOutIsolatedAgentRunMock = vi.fn(async () => {});
+
+vi.mock("../../infra/system-events.js", () => ({
+  enqueueSystemEvent: enqueueSystemEventMock,
+}));
+vi.mock("../../infra/heartbeat-wake.js", () => ({
+  requestHeartbeat: requestHeartbeatMock,
+}));
+vi.mock("../../cron/isolated-agent.js", () => ({
+  runCronIsolatedAgentTurn: runCronIsolatedAgentTurnMock,
+}));
+vi.mock("../../config/sessions.js", () => ({
+  resolveMainSessionKeyFromConfig: resolveMainSessionKeyMock,
+  resolveMainSessionKey: vi.fn(() => "agent:main:main"),
+  resolveAgentMainSessionKey: vi.fn(
+    (params: { agentId: string }) => `agent:${params.agentId}:main`,
+  ),
+}));
+vi.mock("../../config/io.js", () => ({
+  getRuntimeConfig: loadConfigMock,
+}));
+vi.mock("../../tasks/detached-task-runtime.js", () => ({
+  createRunningTaskRun: createRunningTaskRunMock,
+  completeTaskRunByRunId: completeTaskRunByRunIdMock,
+  failTaskRunByRunId: failTaskRunByRunIdMock,
+}));
+vi.mock("../timed-out-agent-run-cleanup.js", () => ({
+  cleanupTimedOutIsolatedAgentRun: cleanupTimedOutIsolatedAgentRunMock,
+}));
+
+let capturedDispatchAgentHook: ((...args: unknown[]) => unknown) | undefined;
+
+vi.mock("./hooks-request-handler.js", () => ({
+  createHooksRequestHandler: vi.fn((opts: Record<string, unknown>) => {
+    capturedDispatchAgentHook = opts.dispatchAgentHook as typeof capturedDispatchAgentHook;
+    return vi.fn();
+  }),
+}));
+
+const { createGatewayHooksRequestHandler } = await import("./hooks.js");
+const { CRON_AGENT_SETUP_WATCHDOG_MS } = await import("../../cron/service/agent-watchdog.js");
+const { isCronJobActive } = await import("../../cron/active-jobs.js");
+const { cancelActiveCronTaskRun, resetActiveCronTaskRunsForTests } =
+  await import("../../tasks/cron-task-cancel.js");
+
+const logHooksInfoMock = vi.fn();
+const logHooksWarnMock = vi.fn();
+
+function buildMinimalParams() {
+  return {
+    deps: {} as never,
+    getHooksConfig: () => null,
+    getClientIpConfig: () => ({ trustedProxies: undefined, allowRealIpFallback: false }),
+    bindHost: "127.0.0.1",
+    port: 18789,
+    logHooks: {
+      warn: logHooksWarnMock,
+      debug: vi.fn(),
+      info: logHooksInfoMock,
+      error: vi.fn(),
+    } as never,
+  };
+}
+
+function buildAgentPayload(name: string, sessionKey = "session-1") {
+  return {
+    message: "test message",
+    name,
+    agentId: undefined,
+    idempotencyKey: undefined,
+    wakeMode: "now" as const,
+    sessionKey,
+    sourcePath: "/hooks/agent",
+    deliver: false,
+    channel: "last" as const,
+    to: undefined,
+    model: undefined,
+    thinking: undefined,
+    timeoutSeconds: undefined,
+    allowUnsafeExternalContent: undefined,
+    externalContentSource: undefined,
+  };
+}
+
+function dispatchAgentHook(payload: unknown): string {
+  if (!capturedDispatchAgentHook) {
+    throw new Error("dispatchAgentHook missing");
+  }
+  return capturedDispatchAgentHook(payload) as string;
+}
+
+function dispatchedJobId(callIndex = 0): string {
+  const call = runCronIsolatedAgentTurnMock.mock.calls[callIndex]?.[0] as
+    | { job: { id: string } }
+    | undefined;
+  if (!call) {
+    throw new Error(`missing runCronIsolatedAgentTurn call ${callIndex}`);
+  }
+  return call.job.id;
+}
+
+describe("dispatchAgentHook crash safety", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    resetActiveCronTaskRunsForTests();
+    capturedDispatchAgentHook = undefined;
+    createGatewayHooksRequestHandler(buildMinimalParams());
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it("persists a ledger row for accepted dispatches and completes it on success", async () => {
+    runCronIsolatedAgentTurnMock.mockResolvedValueOnce({
+      status: "ok",
+      summary: "done",
+      delivered: false,
+    });
+
+    const runId = dispatchAgentHook(buildAgentPayload("Reindex"));
+
+    await vi.waitFor(() => expect(completeTaskRunByRunIdMock).toHaveBeenCalledTimes(1));
+    // The registry's cron contract requires sourceId to be the active job id.
+    expect(createRunningTaskRunMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        runtime: "cron",
+        runId,
+        label: "Hook: Reindex",
+        sourceId: dispatchedJobId(),
+      }),
+    );
+    expect(completeTaskRunByRunIdMock).toHaveBeenCalledWith(
+      expect.objectContaining({ runId, runtime: "cron", terminalSummary: "done" }),
+    );
+    expect(failTaskRunByRunIdMock).not.toHaveBeenCalled();
+    expect(isCronJobActive(dispatchedJobId())).toBe(false);
+  });
+
+  it("completes the ledger row for skipped runs like the cron ledger does", async () => {
+    runCronIsolatedAgentTurnMock.mockResolvedValueOnce({
+      status: "skipped",
+      summary: "no eligible model",
+      delivered: false,
+    });
+
+    const runId = dispatchAgentHook(buildAgentPayload("Reindex"));
+
+    await vi.waitFor(() => expect(completeTaskRunByRunIdMock).toHaveBeenCalledTimes(1));
+    expect(completeTaskRunByRunIdMock).toHaveBeenCalledWith(expect.objectContaining({ runId }));
+    expect(failTaskRunByRunIdMock).not.toHaveBeenCalled();
+  });
+
+  it("fails the ledger row when the run returns an error status", async () => {
+    runCronIsolatedAgentTurnMock.mockResolvedValueOnce({
+      status: "error",
+      summary: "boom",
+      delivered: false,
+    });
+
+    const runId = dispatchAgentHook(buildAgentPayload("Reindex"));
+
+    await vi.waitFor(() => expect(failTaskRunByRunIdMock).toHaveBeenCalledTimes(1));
+    expect(failTaskRunByRunIdMock).toHaveBeenCalledWith(
+      expect.objectContaining({ runId, status: "failed", error: "boom" }),
+    );
+  });
+
+  it("fails the ledger row when the run rejects", async () => {
+    runCronIsolatedAgentTurnMock.mockRejectedValueOnce(new Error("agent exploded"));
+
+    const runId = dispatchAgentHook(buildAgentPayload("Reindex"));
+
+    await vi.waitFor(() => expect(failTaskRunByRunIdMock).toHaveBeenCalledTimes(1));
+    expect(failTaskRunByRunIdMock).toHaveBeenCalledWith(
+      expect.objectContaining({ runId, status: "failed", error: "Error: agent exploded" }),
+    );
+  });
+
+  it("times out a wedged run, cleans it up, and keeps later dispatches executing", async () => {
+    vi.useFakeTimers();
+    // A run wedged before the runner starts: promise never settles, no phases.
+    let sawAbort = false;
+    runCronIsolatedAgentTurnMock.mockImplementationOnce(
+      (params: { abortSignal?: AbortSignal }) =>
+        new Promise(() => {
+          params.abortSignal?.addEventListener("abort", () => {
+            sawAbort = true;
+          });
+        }),
+    );
+
+    const wedgedRunId = dispatchAgentHook(buildAgentPayload("Wedged"));
+    await vi.advanceTimersByTimeAsync(0);
+    expect(runCronIsolatedAgentTurnMock).toHaveBeenCalledTimes(1);
+    expect(isCronJobActive(dispatchedJobId())).toBe(true);
+
+    await vi.advanceTimersByTimeAsync(CRON_AGENT_SETUP_WATCHDOG_MS + 1_000);
+
+    expect(sawAbort).toBe(true);
+    expect(cleanupTimedOutIsolatedAgentRunMock).toHaveBeenCalledTimes(1);
+    expect(failTaskRunByRunIdMock).toHaveBeenCalledWith(
+      expect.objectContaining({ runId: wedgedRunId, status: "timed_out" }),
+    );
+    expect(
+      enqueueSystemEventMock.mock.calls.some(([message]) =>
+        String(message).startsWith("Hook Wedged (timeout):"),
+      ),
+    ).toBe(true);
+    expect(requestHeartbeatMock).toHaveBeenCalledWith(
+      expect.objectContaining({ source: "hook", intent: "immediate" }),
+    );
+    expect(isCronJobActive(dispatchedJobId())).toBe(false);
+
+    // The dead run must not swallow subsequent dispatches (live wedge repro:
+    // gateway kept acking hook posts for hours without executing them).
+    runCronIsolatedAgentTurnMock.mockResolvedValueOnce({
+      status: "ok",
+      summary: "done",
+      delivered: false,
+    });
+    const nextRunId = dispatchAgentHook(buildAgentPayload("Next"));
+    await vi.advanceTimersByTimeAsync(0);
+    expect(runCronIsolatedAgentTurnMock).toHaveBeenCalledTimes(2);
+    await vi.advanceTimersByTimeAsync(0);
+    expect(completeTaskRunByRunIdMock).toHaveBeenCalledWith(
+      expect.objectContaining({ runId: nextRunId }),
+    );
+  });
+
+  it("reports operator cancel quietly instead of as a hook failure", async () => {
+    runCronIsolatedAgentTurnMock.mockImplementationOnce(() => new Promise(() => {}));
+
+    const runId = dispatchAgentHook(buildAgentPayload("Cancelled"));
+    await vi.waitFor(() => expect(runCronIsolatedAgentTurnMock).toHaveBeenCalledTimes(1));
+
+    expect(cancelActiveCronTaskRun({ runId, reason: "Cancelled by operator." })).toBe(true);
+
+    await vi.waitFor(() =>
+      expect(failTaskRunByRunIdMock).toHaveBeenCalledWith(
+        expect.objectContaining({ runId, status: "cancelled" }),
+      ),
+    );
+    expect(enqueueSystemEventMock).not.toHaveBeenCalled();
+    expect(requestHeartbeatMock).not.toHaveBeenCalled();
+    expect(
+      logHooksInfoMock.mock.calls.some(([message]) => message === "hook agent run cancelled"),
+    ).toBe(true);
+  });
+
+  it("runs concurrent dispatches as independent isolated jobs", async () => {
+    const resolvers: Array<(value: unknown) => void> = [];
+    runCronIsolatedAgentTurnMock.mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          resolvers.push(resolve);
+        }),
+    );
+
+    const firstRunId = dispatchAgentHook(buildAgentPayload("First", "hook:one"));
+    const secondRunId = dispatchAgentHook(buildAgentPayload("Second", "hook:two"));
+    await vi.waitFor(() => expect(runCronIsolatedAgentTurnMock).toHaveBeenCalledTimes(2));
+
+    expect(firstRunId).not.toBe(secondRunId);
+    const [firstCall, secondCall] = runCronIsolatedAgentTurnMock.mock.calls as Array<
+      [{ job: { id: string; sessionTarget: string }; sessionKey: string }]
+    >;
+    expect(firstCall[0].job.sessionTarget).toBe("isolated");
+    expect(secondCall[0].job.sessionTarget).toBe("isolated");
+    expect(firstCall[0].job.id).not.toBe(secondCall[0].job.id);
+    expect(firstCall[0].sessionKey).not.toBe(secondCall[0].sessionKey);
+
+    for (const resolve of resolvers) {
+      resolve({ status: "ok", summary: "done", delivered: false });
+    }
+    await vi.waitFor(() => expect(completeTaskRunByRunIdMock).toHaveBeenCalledTimes(2));
+    runCronIsolatedAgentTurnMock.mockReset();
+  });
+});

--- a/src/gateway/server/hooks.agent-trust.test.ts
+++ b/src/gateway/server/hooks.agent-trust.test.ts
@@ -33,6 +33,18 @@ vi.mock("../../config/sessions.js", () => ({
 vi.mock("../../config/io.js", () => ({
   getRuntimeConfig: loadConfigMock,
 }));
+// Keep the trust tests hermetic: ledger writes are covered by the
+// hooks.agent-dispatch-watchdog suite.
+vi.mock("../../tasks/detached-task-runtime.js", () => ({
+  createRunningTaskRun: vi.fn(() => ({ runId: "task" })),
+  completeTaskRunByRunId: vi.fn(),
+  failTaskRunByRunId: vi.fn(),
+}));
+// The timeout-cleanup helper statically imports the embedded agent runtime;
+// mock it so trust tests stay import-light.
+vi.mock("../timed-out-agent-run-cleanup.js", () => ({
+  cleanupTimedOutIsolatedAgentRun: vi.fn(async () => {}),
+}));
 
 let capturedDispatchAgentHook: ((...args: unknown[]) => unknown) | undefined;
 

--- a/src/gateway/server/hooks.ts
+++ b/src/gateway/server/hooks.ts
@@ -5,6 +5,7 @@ import {
   resolveTimestampMsToIsoString,
 } from "@openclaw/normalization-core/number-coercion";
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
+import { resolveDefaultAgentId } from "../../agents/agent-scope.js";
 import { sanitizeInboundSystemTags } from "../../auto-reply/reply/inbound-text.js";
 import type { CliDeps } from "../../cli/deps.types.js";
 import { getRuntimeConfig } from "../../config/io.js";
@@ -14,12 +15,32 @@ import {
   resolveMainSessionKeyFromConfig,
 } from "../../config/sessions.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
+import { markCronJobActive, clearCronJobActive } from "../../cron/active-jobs.js";
 import type { RunCronAgentTurnResult } from "../../cron/isolated-agent/run.types.js";
+import { resolveCronAgentSessionKey } from "../../cron/isolated-agent/session-key.js";
+import {
+  createCronAgentTimeoutGuard,
+  CRON_AGENT_TIMEOUT_MARKER,
+  type CronAgentTimeoutGuard,
+} from "../../cron/service/agent-watchdog.js";
+import {
+  tryCreateCronRunLedgerRow,
+  tryFinishCronRunLedgerRow,
+} from "../../cron/service/task-runs.js";
+import { resolveCronJobTimeoutMs } from "../../cron/service/timeout-policy.js";
 import type { CronJob } from "../../cron/types.js";
 import { requestHeartbeat } from "../../infra/heartbeat-wake.js";
 import { enqueueSystemEvent } from "../../infra/system-events.js";
 import type { createSubsystemLogger } from "../../logging/subsystem.js";
+import { normalizeAgentId } from "../../routing/session-key.js";
+import { createLazyImportLoader } from "../../shared/lazy-promise.js";
+import {
+  registerActiveCronTaskRun,
+  startActiveCronTaskRunSettlementGrace,
+  trackActiveCronTaskRunSettlement,
+} from "../../tasks/cron-task-cancel.js";
 import type { HookAgentDispatchPayload, HooksConfigResolved } from "../hooks.js";
+import { cleanupTimedOutIsolatedAgentRun } from "../timed-out-agent-run-cleanup.js";
 import { createHooksRequestHandler, type HookClientIpConfig } from "./hooks-request-handler.js";
 
 /**
@@ -29,6 +50,12 @@ import { createHooksRequestHandler, type HookClientIpConfig } from "./hooks-requ
  * sanitize external input before it reaches logs or system-event text.
  */
 type SubsystemLogger = ReturnType<typeof createSubsystemLogger>;
+
+const isolatedAgentRuntimeLoader = createLazyImportLoader(
+  () => import("../../cron/isolated-agent.js"),
+);
+
+const HOOK_CANCEL_MARKER: unique symbol = Symbol("hook-agent-cancelled");
 
 function resolveHookEventSessionKey(params: { cfg: OpenClawConfig; agentId?: string }): string {
   return params.agentId
@@ -57,6 +84,26 @@ function resolveHookRunSummary(result: RunCronAgentTurnResult): string {
     normalizeOptionalString(result.error) ||
     result.status
   );
+}
+
+/** Session key the run will actually use, so ledger drill-down opens the real transcript. */
+function resolveHookTaskChildSessionKey(params: {
+  cfg: OpenClawConfig;
+  sessionKey: string;
+  agentId: string | undefined;
+}): string {
+  // Mirror the run's own agent/mainKey resolution (run.ts prepare path); a
+  // plain DEFAULT_AGENT_ID fallback would orphan drill-down when the config
+  // names a different default agent or a non-"main" mainKey alias (#29683).
+  const agentId = params.agentId
+    ? normalizeAgentId(params.agentId)
+    : resolveDefaultAgentId(params.cfg);
+  return resolveCronAgentSessionKey({
+    sessionKey: params.sessionKey,
+    agentId,
+    mainKey: params.cfg.session?.mainKey,
+    cfg: params.cfg,
+  });
 }
 
 function sanitizeHookConsoleValue(value: string | undefined): string | undefined {
@@ -101,6 +148,8 @@ export function createGatewayHooksRequestHandler(params: {
   logHooks: SubsystemLogger;
 }) {
   const { deps, getHooksConfig, getClientIpConfig, bindHost, port, logHooks } = params;
+  const ledgerWarn = (meta: Record<string, unknown>, message: string) =>
+    logHooks.warn(message, meta);
 
   const dispatchWakeHook = (value: { text: string; mode: "now" | "next-heartbeat" }) => {
     const sessionKey = resolveMainSessionKeyFromConfig();
@@ -148,25 +197,166 @@ export function createGatewayHooksRequestHandler(params: {
       state: { nextRunAtMs: nowMs },
     };
 
-    let hookEventSessionKey: string | undefined;
     void (async () => {
+      // Yield first: the ledger insert below is a synchronous state-DB write
+      // and must not delay the HTTP ack this dispatch already returned for.
+      await Promise.resolve();
+      const startedAt = Date.now();
+      let hookEventSessionKey: string | undefined;
+      const announce = (text: string, heartbeatReason: string | undefined) => {
+        enqueueSystemEvent(text, {
+          sessionKey: hookEventSessionKey ?? resolveMainSessionKeyFromConfig(),
+        });
+        if (heartbeatReason && value.wakeMode === "now") {
+          requestHeartbeat({ source: "hook", intent: "immediate", reason: heartbeatReason });
+        }
+      };
+      let activeJobMarker: ReturnType<typeof markCronJobActive> = undefined;
+      let taskRunId: string | undefined;
+      const finishLedger = (outcome: {
+        status: "ok" | "skipped" | "error";
+        failStatus?: "failed" | "timed_out" | "cancelled";
+        error?: string;
+        summary?: string;
+      }) =>
+        tryFinishCronRunLedgerRow({
+          warn: ledgerWarn,
+          taskRunId,
+          status: outcome.status,
+          failStatus: outcome.failStatus,
+          error: outcome.error,
+          summary: outcome.summary,
+          endedAt: Date.now(),
+        });
+      let guard: CronAgentTimeoutGuard | undefined;
+      let releaseTaskRun: (() => void) | undefined;
+      let cancelReason: string | undefined;
+      const logLateSettlement = (runPromise: Promise<RunCronAgentTurnResult>, after: string) => {
+        void runPromise.then(
+          (lateResult) => {
+            logHooks.warn(`hook agent run settled after ${after}`, {
+              runId,
+              name: safeName,
+              status: lateResult.status,
+            });
+          },
+          (lateErr: unknown) => {
+            logHooks.warn(`hook agent run rejected after ${after}`, {
+              runId,
+              name: safeName,
+              error: String(lateErr),
+            });
+          },
+        );
+      };
       try {
         // Agent hooks run after the HTTP response path has returned, so failure
         // handling must record a system event instead of throwing to the caller.
         const cfg = getRuntimeConfig();
-        hookEventSessionKey = resolveHookEventSessionKey({
-          cfg,
-          agentId: value.agentId,
-        });
-        const { runCronIsolatedAgentTurn } = await import("../../cron/isolated-agent.js");
-        const result = await runCronIsolatedAgentTurn({
-          cfg,
-          deps,
+        hookEventSessionKey = resolveHookEventSessionKey({ cfg, agentId: value.agentId });
+        // Registry maintenance treats a cron-runtime ledger row as live only
+        // while its sourceId is an active job marker; without it a hook run
+        // longer than the reconcile grace is flipped to "lost" mid-run.
+        activeJobMarker = markCronJobActive(jobId);
+        taskRunId = tryCreateCronRunLedgerRow({
+          warn: ledgerWarn,
           job,
-          message: value.message,
-          sessionKey,
-          lane: "cron",
+          runId,
+          childSessionKey: resolveHookTaskChildSessionKey({
+            cfg,
+            sessionKey,
+            agentId: value.agentId,
+          }),
+          label: `Hook: ${safeName}`,
+          progressSummary: "Running hook agent turn.",
+          startedAt,
         });
+        const jobTimeoutMs = resolveCronJobTimeoutMs(job);
+        guard =
+          jobTimeoutMs !== undefined
+            ? createCronAgentTimeoutGuard({ jobTimeoutMs, deferUntilRunner: true })
+            : undefined;
+        const runAbortController = guard?.abortController ?? new AbortController();
+        let resolveCancelled: ((value: typeof HOOK_CANCEL_MARKER) => void) | undefined;
+        const cancelledPromise = new Promise<typeof HOOK_CANCEL_MARKER>((resolve) => {
+          resolveCancelled = resolve;
+        });
+        releaseTaskRun = registerActiveCronTaskRun({
+          runId,
+          controller: runAbortController,
+          onCancel: (reason) => {
+            cancelReason = reason;
+            resolveCancelled?.(HOOK_CANCEL_MARKER);
+          },
+        });
+        // The module load stays inside the guarded core so a hung import is
+        // still covered by the setup watchdog instead of silently vanishing.
+        const corePromise = (async () => {
+          const { runCronIsolatedAgentTurn } = await isolatedAgentRuntimeLoader.load();
+          return await runCronIsolatedAgentTurn({
+            cfg,
+            deps,
+            job,
+            message: value.message,
+            sessionKey,
+            lane: "cron",
+            abortSignal: runAbortController.signal,
+            onExecutionStarted: guard?.watchdog.noteRunnerStarted,
+            onExecutionPhase: guard?.watchdog.notePhase,
+            onLaneWait: guard?.watchdog.noteLaneState,
+          });
+        })();
+        trackActiveCronTaskRunSettlement(corePromise);
+        guard?.watchdog.start();
+        const raced = await Promise.race([
+          corePromise,
+          cancelledPromise,
+          ...(guard ? [guard.timeoutPromise] : []),
+        ]);
+        if (raced === HOOK_CANCEL_MARKER) {
+          // Operator cancel / gateway drain: cancelActiveCronTaskRun already
+          // starts settlement grace and the registry row is marked terminal by
+          // the cancel path, so report quietly instead of as a hook failure.
+          logLateSettlement(corePromise, "cancel");
+          logHooks.info("hook agent run cancelled", {
+            runId,
+            jobId,
+            name: safeName,
+            reason: cancelReason,
+          });
+          finishLedger({
+            status: "error",
+            failStatus: "cancelled",
+            error: cancelReason ?? "Cancelled.",
+          });
+          return;
+        }
+        if (raced === CRON_AGENT_TIMEOUT_MARKER) {
+          const error =
+            guard?.timeoutReason() ?? `hook agent run timed out after ${jobTimeoutMs}ms`;
+          startActiveCronTaskRunSettlementGrace();
+          logLateSettlement(corePromise, "timeout");
+          await cleanupTimedOutIsolatedAgentRun({
+            execution: guard?.watchdog.activeExecution(),
+            reason: "hook_timeout",
+            retireReason: "hook-timeout-cleanup",
+            warn: ledgerWarn,
+          });
+          logHooks.warn("hook agent run timed out", {
+            sourcePath: value.sourcePath,
+            name: safeName,
+            runId,
+            jobId,
+            agentId: value.agentId,
+            sessionKey,
+            timeoutMs: jobTimeoutMs,
+            consoleMessage: `hook agent run timed out name=${sanitizeHookConsoleValue(safeName) ?? "unknown"} timeoutMs=${jobTimeoutMs}`,
+          });
+          announce(`Hook ${safeName} (timeout): ${error}`, `hook:${jobId}:timeout`);
+          finishLedger({ status: "error", failStatus: "timed_out", error });
+          return;
+        }
+        const result = raced;
         const summary = resolveHookRunSummary(result);
         const prefix =
           result.status === "ok" ? `Hook ${safeName}` : `Hook ${safeName} (${result.status})`;
@@ -190,13 +380,7 @@ export function createGatewayHooksRequestHandler(params: {
           });
         }
         if (shouldAnnounce) {
-          const eventSessionKey = hookEventSessionKey ?? resolveMainSessionKeyFromConfig();
-          enqueueSystemEvent(`${prefix}: ${summary}`.trim(), {
-            sessionKey: eventSessionKey,
-          });
-          if (value.wakeMode === "now") {
-            requestHeartbeat({ source: "hook", intent: "immediate", reason: `hook:${jobId}` });
-          }
+          announce(`${prefix}: ${summary}`.trim(), `hook:${jobId}`);
         } else if (result.status === "ok" && !value.deliver) {
           logHooks.info("hook agent run completed without announcement", {
             sourcePath: value.sourcePath,
@@ -208,20 +392,35 @@ export function createGatewayHooksRequestHandler(params: {
             completedAt: new Date().toISOString(),
           });
         }
-      } catch (err) {
-        logHooks.warn(`hook agent failed: ${String(err)}`);
-        enqueueSystemEvent(`Hook ${safeName} (error): ${String(err)}`, {
-          sessionKey: hookEventSessionKey ?? resolveMainSessionKeyFromConfig(),
+        finishLedger({
+          status: result.status === "skipped" ? "skipped" : result.status === "ok" ? "ok" : "error",
+          error: result.status === "ok" || result.status === "skipped" ? undefined : summary,
+          summary,
         });
-        if (value.wakeMode === "now") {
-          requestHeartbeat({
-            source: "hook",
-            intent: "immediate",
-            reason: `hook:${jobId}:error`,
+      } catch (err) {
+        if (cancelReason !== undefined) {
+          logHooks.info("hook agent run cancelled", {
+            runId,
+            jobId,
+            name: safeName,
+            reason: cancelReason,
           });
+          finishLedger({ status: "error", failStatus: "cancelled", error: cancelReason });
+          return;
         }
+        logHooks.warn(`hook agent failed: ${String(err)}`);
+        announce(`Hook ${safeName} (error): ${String(err)}`, `hook:${jobId}:error`);
+        finishLedger({ status: "error", error: String(err) });
+      } finally {
+        guard?.dispose();
+        releaseTaskRun?.();
+        clearCronJobActive(jobId, activeJobMarker);
       }
-    })();
+    })().catch((err: unknown) => {
+      // Last-resort guard: pre-run setup (config read, session-key resolution)
+      // threw outside the announce path; a dropped dispatch must stay loggable.
+      logHooks.warn(`hook agent dispatch failed: ${String(err)}`);
+    });
 
     return runId;
   };

--- a/src/gateway/timed-out-agent-run-cleanup.ts
+++ b/src/gateway/timed-out-agent-run-cleanup.ts
@@ -1,0 +1,83 @@
+// Force-clears a timed-out isolated agent run so an abort-ignoring turn cannot
+// keep its embedded session, lane slot, and MCP runtime alive until restart.
+import { retireSessionMcpRuntime } from "../agents/agent-bundle-mcp-tools.js";
+import { abortAndDrainEmbeddedAgentRun } from "../agents/embedded-agent.js";
+import type { CronAgentExecutionStarted } from "../cron/types.js";
+
+// Stuck cleanup must not wedge the caller's timeout path; the drain's own
+// settleMs bounds the abort wait, this bounds everything else (MCP retire).
+const CLEANUP_SETTLE_GUARD_MS = 20_000;
+
+async function drainAndRetireTimedOutRun(params: {
+  execution: CronAgentExecutionStarted & { sessionId: string };
+  reason: string;
+  retireReason: string;
+  warn: (meta: Record<string, unknown>, message: string) => void;
+}): Promise<void> {
+  const { execution } = params;
+  try {
+    const result = await abortAndDrainEmbeddedAgentRun({
+      sessionId: execution.sessionId,
+      sessionKey: execution.sessionKey,
+      settleMs: 15_000,
+      forceClear: true,
+      reason: params.reason,
+    });
+    params.warn(
+      {
+        sessionId: execution.sessionId,
+        sessionKey: execution.sessionKey,
+        aborted: result.aborted,
+        drained: result.drained,
+        forceCleared: result.forceCleared,
+      },
+      "cleaned up timed-out agent run",
+    );
+  } catch (err) {
+    params.warn(
+      { sessionId: execution.sessionId, error: String(err) },
+      "timed-out agent run cleanup failed",
+    );
+    return;
+  }
+  await retireSessionMcpRuntime({
+    sessionId: execution.sessionId,
+    reason: params.retireReason,
+    onError: (error, sid) => {
+      params.warn(
+        { sessionId: sid },
+        `failed to retire MCP runtime for timed-out session: ${String(error)}`,
+      );
+    },
+  }).catch(() => {});
+}
+
+export async function cleanupTimedOutIsolatedAgentRun(params: {
+  execution: CronAgentExecutionStarted | undefined;
+  reason: string;
+  retireReason: string;
+  warn: (meta: Record<string, unknown>, message: string) => void;
+}): Promise<void> {
+  const { execution } = params;
+  if (!execution?.sessionId) {
+    return;
+  }
+  let settleTimer: NodeJS.Timeout | undefined;
+  const settleGuard = new Promise<void>((resolve) => {
+    settleTimer = setTimeout(resolve, CLEANUP_SETTLE_GUARD_MS);
+    settleTimer.unref?.();
+  });
+  try {
+    await Promise.race([
+      drainAndRetireTimedOutRun({
+        ...params,
+        execution: { ...execution, sessionId: execution.sessionId },
+      }),
+      settleGuard,
+    ]);
+  } finally {
+    if (settleTimer) {
+      clearTimeout(settleTimer);
+    }
+  }
+}

--- a/src/infra/exec-allowlist-pattern.test.ts
+++ b/src/infra/exec-allowlist-pattern.test.ts
@@ -1,8 +1,13 @@
 // Verifies exec approval allowlist pattern parsing and matching.
+import fs from "node:fs";
+import os from "node:os";
 import path from "node:path";
-import { describe, expect, it } from "vitest";
+import { afterAll, describe, expect, it } from "vitest";
 import { withEnv } from "../test-utils/env.js";
-import { matchesExecAllowlistPattern } from "./exec-allowlist-pattern.js";
+import {
+  matchesExecAllowlistPattern,
+  normalizeExecAllowlistPatternForAdd,
+} from "./exec-allowlist-pattern.js";
 
 describe("matchesExecAllowlistPattern", () => {
   it.each([
@@ -101,6 +106,76 @@ describe("matchesExecAllowlistPattern", () => {
         false,
       );
       expect(matchesExecAllowlistPattern("C:/Tools/**", "C:/Tools/bin/../runner.exe")).toBe(true);
+    },
+  );
+});
+
+describe("normalizeExecAllowlistPatternForAdd", () => {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-allowlist-add-"));
+  afterAll(() => {
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  it("keeps bare command names and glob patterns unchanged", () => {
+    expect(normalizeExecAllowlistPatternForAdd("rg")).toEqual({
+      kind: "unchanged",
+      pattern: "rg",
+    });
+    expect(normalizeExecAllowlistPatternForAdd("/opt/homebrew/bin/*")).toEqual({
+      kind: "unchanged",
+      pattern: "/opt/homebrew/bin/*",
+    });
+    expect(normalizeExecAllowlistPatternForAdd("~/Projects/**/bin/rg")).toEqual({
+      kind: "unchanged",
+      pattern: "~/Projects/**/bin/rg",
+    });
+  });
+
+  it("reports literal paths that do not resolve locally as unverified", () => {
+    const missing = path.join(tempDir, "does-not-exist", "tool");
+    expect(normalizeExecAllowlistPatternForAdd(missing)).toEqual({
+      kind: "unverified-path",
+      pattern: missing,
+    });
+  });
+
+  it.runIf(process.platform !== "win32")(
+    "resolves symlinked binaries to their realpath so the entry matches at exec time",
+    () => {
+      const cellarDir = fs.mkdtempSync(path.join(tempDir, "cellar-"));
+      const binDir = fs.mkdtempSync(path.join(tempDir, "bin-"));
+      const realBinary = path.join(cellarDir, "rg");
+      fs.writeFileSync(realBinary, "#!/bin/sh\n", { mode: 0o755 });
+      const symlinkPath = path.join(binDir, "rg");
+      fs.symlinkSync(realBinary, symlinkPath);
+
+      const normalized = normalizeExecAllowlistPatternForAdd(symlinkPath);
+      expect(normalized).toEqual({
+        kind: "resolved-symlink",
+        pattern: fs.realpathSync(realBinary),
+      });
+      // The stored pattern must match the trust realpath the allowlist uses.
+      expect(matchesExecAllowlistPattern(normalized.pattern, fs.realpathSync(realBinary))).toBe(
+        true,
+      );
+      // Remote-target writes must not translate against the local filesystem.
+      expect(
+        normalizeExecAllowlistPatternForAdd(symlinkPath, { resolveLocalRealpath: false }),
+      ).toEqual({ kind: "unverified-path", pattern: symlinkPath });
+    },
+  );
+
+  it.runIf(process.platform !== "win32")(
+    "keeps regular file paths unchanged when the realpath already matches",
+    () => {
+      const plainDir = fs.mkdtempSync(path.join(tempDir, "plain-"));
+      const realDir = fs.realpathSync(plainDir);
+      const binary = path.join(realDir, "tool");
+      fs.writeFileSync(binary, "#!/bin/sh\n", { mode: 0o755 });
+      expect(normalizeExecAllowlistPatternForAdd(binary)).toEqual({
+        kind: "unchanged",
+        pattern: binary,
+      });
     },
   );
 });

--- a/src/infra/exec-allowlist-pattern.ts
+++ b/src/infra/exec-allowlist-pattern.ts
@@ -89,6 +89,48 @@ function compileGlobRegex(pattern: string): RegExp {
   return compiled;
 }
 
+/** Add-time normalization outcome for an operator-supplied allowlist pattern. */
+export type ExecAllowlistAddPatternNormalization =
+  | { kind: "unchanged"; pattern: string }
+  | { kind: "resolved-symlink"; pattern: string }
+  | { kind: "unverified-path"; pattern: string };
+
+function isLiteralPathAllowlistPattern(pattern: string): boolean {
+  const isPathShaped = pattern.includes("/") || pattern.includes("\\") || pattern.startsWith("~");
+  // Globs are operator-authored match structure; only literal paths resolve.
+  return Boolean(pattern) && isPathShaped && !/[*?]/.test(pattern);
+}
+
+/**
+ * Normalizes a literal path pattern to the executable realpath before storing.
+ * Path-shaped entries match only the resolved realpath (symlink retargeting
+ * must not keep approvals), so storing a symlink path (e.g. /opt/homebrew/bin/rg)
+ * would create an entry that never matches. Pass `resolveLocalRealpath: false`
+ * when the entry targets another host's filesystem; literal paths then report
+ * "unverified-path" so callers hint instead of translating against the wrong disk.
+ */
+export function normalizeExecAllowlistPatternForAdd(
+  rawPattern: string,
+  opts?: { resolveLocalRealpath?: boolean },
+): ExecAllowlistAddPatternNormalization {
+  const trimmed = rawPattern.trim();
+  if (!isLiteralPathAllowlistPattern(trimmed)) {
+    return { kind: "unchanged", pattern: trimmed };
+  }
+  if (opts?.resolveLocalRealpath === false) {
+    return { kind: "unverified-path", pattern: trimmed };
+  }
+  const expanded = trimmed.startsWith("~") ? expandHomePrefix(trimmed) : trimmed;
+  const realPath = tryRealpath(expanded);
+  if (!realPath) {
+    return { kind: "unverified-path", pattern: trimmed };
+  }
+  if (normalizeMatchTarget(realPath) === normalizeMatchTarget(expanded)) {
+    return { kind: "unchanged", pattern: trimmed };
+  }
+  return { kind: "resolved-symlink", pattern: realPath };
+}
+
 export function matchesExecAllowlistPattern(pattern: string, target: string): boolean {
   const trimmed = pattern.trim();
   if (!trimmed) {


### PR DESCRIPTION
## Summary

Two production bugs observed on a live single-user deployment (macOS gateway, v2026.6.11), reproduced live and fixed against current `main`:

**1. Hook agent dispatch was fire-and-forget; wedged runs silently swallowed later dispatches** (`src/gateway/server/hooks.ts`). `dispatchAgentHook` ran `runCronIsolatedAgentTurn` inside a bare `void (async () => ...)()` with no watchdog, no abort signal, and no run record. Live impact: after a run died mid-lock, the gateway kept 200-acking `POST /hooks/<mapping>` for 3+ hours while executing nothing, with no log line or run-history evidence; only a restart cleared it. Dispatches now get:

- a detached task-ledger row in the state DB under the acked `runId` (hook runs appear in run history; `sourceId` is bound to an active-job marker so registry maintenance does not flip long runs to `lost` mid-run)
- the same watchdog stack scheduled cron uses (setup / pre-execution / wall-clock, honoring the payload's `timeoutSeconds`), armed before the lazy runtime import so a hung import cannot escape it
- abort + force-cleanup on timeout (settle-guarded embedded-run drain + MCP retire), settlement grace, a `Hook <name> (timeout)` system event, and a `timed_out` ledger row
- operator-cancel / gateway-drain registration, with cancels reported quietly instead of as hook failures

The timeout/abort race and ledger machinery moved to shared cron-service owners instead of being copied: `createCronAgentTimeoutGuard` + `watchdog.noteLaneState` in `agent-watchdog.ts` (timer.ts migrated onto them), shared `tryCreate/tryFinishCronRunLedgerRow` in `task-runs.ts`, and a shared `cleanupTimedOutIsolatedAgentRun` used by both the cron timer and hooks.

**2. `openclaw approvals allowlist add` on a symlink path stored a permanently dead entry** (`src/cli/exec-approvals-cli.ts`, `src/infra/exec-allowlist-pattern.ts`). Path-shaped allowlist entries match only the executable realpath (the deliberate symlink-retargeting defense from #45595), but `allowlist add` stored the operator-typed path verbatim — so approving the path every shell shows (`/opt/homebrew/bin/rg`, a Homebrew symlink into `Cellar/`) produced an entry that never matched, and with exec `ask: "off"` the denial was silent. Live impact: `mcporter` and `python3.12` approvals dead for weeks across three agents. The matching invariant is untouched; instead `add` resolves literal local paths to their realpath at add time and says so. Glob patterns and bare command names are stored as typed; `--gateway`/`--node` targets are never translated against the local filesystem (wrong-host hazard) and print a realpath hint; `remove` accepts the typed symlink path by resolving it when no exact entry matches. Docs updated in `docs/cli/approvals.md`.

Known follow-up (not in this PR): the gateway RPC (`exec.approvals.set`) and Control-UI approvals writers still store symlink paths verbatim; the durable owner for the normalization is the host-side write path.

Related context: the third live failure from the same incident (`EmbeddedAttemptSessionTakeoverError` wedging the session write lock) is already fixed on `main` by #93740 and #96100; this PR's dispatch watchdog closes the remaining "acked but never executed, invisibly" half of that failure mode.

## Verification

- `pnpm test src/gateway/server/hooks.agent-dispatch-watchdog.test.ts src/gateway/server/hooks.agent-trust.test.ts src/gateway/server.hooks.test.ts` — 112 passed
- `pnpm test src/cron/service` (incl. `timer.regression.test.ts`, 66 tests) — 152 passed
- `pnpm test src/infra/exec-allowlist-pattern.test.ts src/cli/exec-approvals-cli.test.ts src/infra/exec-allowlist-matching.test.ts` — all passed (symlink fixture uses a real temp-dir symlink)
- `pnpm tsgo` clean; `pnpm build` green with no `INEFFECTIVE_DYNAMIC_IMPORT`; oxfmt/oxlint clean on touched files
- Two autoreview rounds (8-angle finder pass + adversarial verify, then a second-round regression verify of the refactor); all accepted findings fixed before commit

## Real behavior proof

Behavior addressed: Hook dispatches vanishing silently after a wedged run, and `approvals allowlist add` on symlink paths creating entries that never match at exec time.
Real environment tested: macOS (Darwin 25.5.0) source checkout, Node 22; live failure originally reproduced on a production single-user gateway running v2026.6.11.
Exact steps or command run after this patch: `pnpm test src/gateway/server/hooks.agent-dispatch-watchdog.test.ts src/cli/exec-approvals-cli.test.ts src/infra/exec-allowlist-pattern.test.ts src/cron/service && pnpm build && pnpm tsgo`
Evidence after fix: Dispatch-layer regression proves a wedged run is aborted at the setup watchdog, announced, marked `timed_out` in the ledger, force-cleaned, and cannot block subsequent dispatches; CLI test proves a real temp-dir symlink is stored as its realpath and that the realpath matches the allowlist trust path.
Observed result after fix: All suites green (112 gateway hook tests, 152 cron service tests, 32 approvals/allowlist tests); full build and typecheck green.
What was not tested: No live end-to-end `POST /hooks/<mapping>` against a running production gateway after the patch; the wedge repro is mock-shaped at the dispatch boundary. Gateway/Control-UI approvals writers are intentionally out of scope (follow-up noted above).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
