### PR TITLE
fix: wake top-level sessions after subagent drain

### DIFF
--- a/src/agents/subagent-announce.format.e2e.test.ts
+++ b/src/agents/subagent-announce.format.e2e.test.ts
@@ -546,6 +546,23 @@ describe("subagent announce formatting", () => {
     expect(call?.params?.internalEvents?.[0]?.taskLabel).toBe("do thing");
   });
 
+  it("nudges top-level requesters to synthesize after all child runs settled", async () => {
+    await runSubagentAnnounceFlow({
+      childSessionKey: "agent:main:subagent:test",
+      childRunId: "run-all-settled",
+      requesterSessionKey: "agent:main:main",
+      requesterDisplayKey: "main",
+      allRequesterChildrenSettled: true,
+      ...defaultOutcomeAnnounce,
+    });
+
+    const call = getAgentCall() as { params?: { message?: string } };
+    const msg = call?.params?.message as string;
+    expect(msg).toContain("All spawned subtasks for this requester have now completed.");
+    expect(msg).toContain("synthesize the final answer or next action");
+    expect(msg).not.toContain("A completed subagent task is ready for parent review.");
+  });
+
   it("includes success status when outcome is ok", async () => {
     // Use waitForCompletion: false so it uses the provided outcome instead of calling agent.wait
     await runSubagentAnnounceFlow({
@@ -2957,6 +2974,13 @@ describe("subagent announce formatting", () => {
     expect(call?.params?.channel).toBe("whatsapp");
     expect(call?.params?.to).toBe("+1555");
     expect(call?.params?.accountId).toBe("acct-main");
+    expect(subagentRegistryMock.countPendingDescendantRunsExcludingRun).toHaveBeenCalledWith(
+      "agent:main:main",
+      "run-leaf",
+    );
+    const message = typeof call?.params?.message === "string" ? call.params.message : "";
+    expect(message).toContain("All spawned subtasks for this requester have now completed.");
+    expect(message).toContain("synthesize the final answer or next action");
   });
 
   it("keeps announce retryable when missing requester subagent session has no fallback requester", async () => {

--- a/src/agents/subagent-announce.ts
+++ b/src/agents/subagent-announce.ts
@@ -89,9 +89,13 @@ function buildAnnounceReplyInstruction(params: {
   requesterIsSubagent: boolean;
   announceType: SubagentAnnounceType;
   expectsCompletionMessage?: boolean;
+  allRequesterChildrenSettled?: boolean;
 }): string {
   if (params.requesterIsSubagent) {
     return `Convert this completion into a concise internal orchestration update for your parent agent in your own words. Keep this internal context private (don't mention system/log/stats/session details or announce type). If this result is duplicate or no update is needed, reply ONLY: ${SILENT_REPLY_TOKEN}.`;
+  }
+  if (params.allRequesterChildrenSettled) {
+    return `All spawned subtasks for this requester have now completed. Review the delivered completion results and synthesize the final answer or next action. Keep this internal context private (don't mention system/log/stats/session details or announce type). Reply ONLY: ${SILENT_REPLY_TOKEN} only when the final answer or next action is already visible to the user in this same turn.`;
   }
   if (params.expectsCompletionMessage) {
     return `A completed ${params.announceType} is ready for parent review. Review/verify the result above before deciding whether the original task is done. If additional action is required, continue the task or record a follow-up; otherwise send a truthful user-facing update. Keep this internal context private (don't mention system/log/stats/session details or announce type). Reply ONLY: ${SILENT_REPLY_TOKEN} only when this exact result is already visible to the user in this same turn.`;
@@ -258,6 +262,7 @@ export async function runSubagentAnnounceFlow(params: {
   expectsCompletionMessage?: boolean;
   spawnMode?: SpawnSubagentMode;
   wakeOnDescendantSettle?: boolean;
+  allRequesterChildrenSettled?: boolean;
   signal?: AbortSignal;
   bestEffortDeliver?: boolean;
   onDeliveryResult?: (delivery: SubagentAnnounceDeliveryResult) => void;
@@ -498,6 +503,7 @@ export async function runSubagentAnnounceFlow(params: {
     const findings = childCompletionFindings || reply || "(no output)";
 
     let requesterIsSubagent = requesterIsInternalSession();
+    let didFallbackRequester = false;
     if (requesterIsSubagent) {
       const {
         isSubagentSessionRunActive,
@@ -518,6 +524,7 @@ export async function runSubagentAnnounceFlow(params: {
             return false;
           }
           targetRequesterSessionKey = fallback.requesterSessionKey;
+          didFallbackRequester = true;
           targetRequesterOrigin =
             normalizeDeliveryContext(fallback.requesterOrigin) ?? targetRequesterOrigin;
           requesterDepth = getSubagentDepthFromSessionStore(targetRequesterSessionKey);
@@ -526,10 +533,23 @@ export async function runSubagentAnnounceFlow(params: {
       }
     }
 
+    let allRequesterChildrenSettled = params.allRequesterChildrenSettled === true;
+    if (didFallbackRequester && !requesterIsSubagent && subagentRegistryRuntime) {
+      allRequesterChildrenSettled ||=
+        Math.max(
+          0,
+          subagentRegistryRuntime.countPendingDescendantRunsExcludingRun(
+            targetRequesterSessionKey,
+            params.childRunId,
+          ),
+        ) === 0;
+    }
+
     const replyInstruction = buildAnnounceReplyInstruction({
       requesterIsSubagent,
       announceType,
       expectsCompletionMessage,
+      allRequesterChildrenSettled,
     });
     const statsLine = await buildCompactAnnounceStatsLine({
       sessionKey: params.childSessionKey,

--- a/src/agents/subagent-registry-lifecycle.ts
+++ b/src/agents/subagent-registry-lifecycle.ts
@@ -9,6 +9,7 @@ import type { cleanupBrowserSessionsForLifecycleEnd } from "../browser-lifecycle
 import type { callGateway as defaultCallGateway } from "../gateway/call.js";
 import { formatErrorMessage, readErrorName } from "../infra/errors.js";
 import { defaultRuntime } from "../runtime.js";
+import { isCronSessionKey, isSubagentSessionKey } from "../sessions/session-key-utils.js";
 import { emitSessionLifecycleEvent } from "../sessions/session-lifecycle-events.js";
 import { extractTextFromChatContent } from "../shared/chat-content.js";
 import { createLazyImportLoader } from "../shared/lazy-promise.js";
@@ -57,6 +58,10 @@ import {
   resolveAnnounceRetryDelayMs,
   safeRemoveAttachmentsDir,
 } from "./subagent-registry-helpers.js";
+import {
+  countPendingDescendantRunsFromRuns,
+  listRunsForRequesterFromRuns,
+} from "./subagent-registry-queries.js";
 import type { PendingFinalDeliveryPayload, SubagentRunRecord } from "./subagent-registry.types.js";
 import { resolveSubagentRunDeadlineMs } from "./subagent-run-timeout.js";
 import { deleteSubagentSessionForCleanup } from "./subagent-session-cleanup.js";
@@ -517,12 +522,48 @@ export function createSubagentRegistryLifecycleController(params: {
     }
   };
 
+  const countActiveRequesterChildRuns = (
+    requesterSessionKey: string,
+    excludeRunId?: string,
+  ): number => {
+    const latestByChildSessionKey = new Map<string, SubagentRunRecord>();
+    for (const entry of listRunsForRequesterFromRuns(params.runs, requesterSessionKey)) {
+      if (entry.runId === excludeRunId) {
+        continue;
+      }
+      const existing = latestByChildSessionKey.get(entry.childSessionKey);
+      if (!existing || entry.createdAt > existing.createdAt) {
+        latestByChildSessionKey.set(entry.childSessionKey, entry);
+      }
+    }
+    let count = 0;
+    for (const entry of latestByChildSessionKey.values()) {
+      if (typeof entry.endedAt !== "number" || typeof entry.cleanupCompletedAt !== "number") {
+        count += 1;
+        continue;
+      }
+      if (countPendingDescendantRunsFromRuns(params.runs, entry.childSessionKey) > 0) {
+        count += 1;
+      }
+    }
+    return count;
+  };
+
+  const areRequesterChildrenSettled = (
+    requesterSessionKey: string,
+    excludeRunId?: string,
+  ): boolean =>
+    !isSubagentSessionKey(requesterSessionKey) &&
+    !isCronSessionKey(requesterSessionKey) &&
+    countActiveRequesterChildRuns(requesterSessionKey, excludeRunId) === 0;
+
   const loadPendingFinalDeliveryPayload = (
     entry: SubagentRunRecord,
   ): PendingFinalDeliveryPayload => {
+    const requesterSessionKey =
+      entry.delivery?.payload?.requesterSessionKey ?? entry.requesterSessionKey;
     return {
-      requesterSessionKey:
-        entry.delivery?.payload?.requesterSessionKey ?? entry.requesterSessionKey,
+      requesterSessionKey,
       requesterOrigin: entry.delivery?.payload?.requesterOrigin ?? entry.requesterOrigin,
       requesterDisplayKey:
         entry.delivery?.payload?.requesterDisplayKey ?? entry.requesterDisplayKey,
@@ -1016,6 +1057,10 @@ export function createSubagentRegistryLifecycleController(params: {
     }
     const pendingPayload = loadPendingFinalDeliveryPayload(entry);
     const requesterOrigin = normalizeDeliveryContext(pendingPayload.requesterOrigin);
+    const allRequesterChildrenSettled = areRequesterChildrenSettled(
+      pendingPayload.requesterSessionKey,
+      pendingPayload.childRunId,
+    );
     let latestDeliveryError = getDeliveryLastError(entry);
     const finalizeAnnounceCleanup = async (didAnnounce: boolean) => {
       const shouldCreditPriorDelivery =
@@ -1061,6 +1106,7 @@ export function createSubagentRegistryLifecycleController(params: {
         spawnMode: pendingPayload.spawnMode,
         expectsCompletionMessage: pendingPayload.expectsCompletionMessage,
         wakeOnDescendantSettle: pendingPayload.wakeOnDescendantSettle === true,
+        allRequesterChildrenSettled,
         onDeliveryResult: (delivery) => {
           recordAnnounceDeliveryResult(entry, delivery);
           if (delivery.delivered) {

--- a/src/agents/subagent-registry.test.ts
+++ b/src/agents/subagent-registry.test.ts
@@ -930,6 +930,11 @@ describe("subagent registry seam flow", () => {
         },
         "refreshed pending delivery outcome",
       );
+      expectRecordFields(
+        announceParams,
+        { allRequesterChildrenSettled: true },
+        "refreshed pending delivery announce",
+      );
     });
   });
 
@@ -3425,6 +3430,150 @@ describe("subagent registry seam flow", () => {
         wakeOnDescendantSettle: true,
       },
       "yielded parent wake announce params",
+    );
+  });
+
+  it("marks final top-level requester child completion when all direct children settled", async () => {
+    mocks.loadSessionStore.mockReturnValue({
+      "agent:main:subagent:done": {
+        sessionId: "sess-done",
+        updatedAt: 1,
+      },
+      "agent:main:subagent:last": {
+        sessionId: "sess-last",
+        updatedAt: 1,
+      },
+    });
+
+    mod.addSubagentRunForTests({
+      runId: "run-already-done",
+      childSessionKey: "agent:main:subagent:done",
+      requesterSessionKey: "agent:main:main",
+      requesterDisplayKey: "main",
+      task: "already completed sibling",
+      cleanup: "keep",
+      createdAt: Date.parse("2026-06-26T02:17:00Z"),
+      startedAt: Date.parse("2026-06-26T02:18:00Z"),
+      endedAt: Date.parse("2026-06-26T02:19:00Z"),
+      outcome: { status: "ok" },
+      cleanupHandled: true,
+      cleanupCompletedAt: Date.parse("2026-06-26T02:20:00Z"),
+    });
+
+    mod.registerSubagentRun({
+      runId: "run-last-child",
+      childSessionKey: "agent:main:subagent:last",
+      requesterSessionKey: "agent:main:main",
+      requesterDisplayKey: "main",
+      task: "last direct child completes",
+      cleanup: "keep",
+    });
+
+    await waitForFast(() => {
+      expect(mocks.runSubagentAnnounceFlow).toHaveBeenCalledTimes(1);
+    });
+    expectRecordFields(
+      getMockCallArg(mocks.runSubagentAnnounceFlow, 0, 0, "last child announce params"),
+      {
+        childRunId: "run-last-child",
+        allRequesterChildrenSettled: true,
+      },
+      "last child announce params",
+    );
+  });
+
+  it("does not mark top-level requester completion while proxy-owned children remain active", async () => {
+    mocks.loadSessionStore.mockReturnValue({
+      "agent:main:subagent:proxy-active": {
+        sessionId: "sess-proxy-active",
+        updatedAt: 1,
+      },
+      "agent:main:subagent:last": {
+        sessionId: "sess-last",
+        updatedAt: 1,
+      },
+    });
+
+    mod.addSubagentRunForTests({
+      runId: "run-proxy-active",
+      childSessionKey: "agent:main:subagent:proxy-active",
+      controllerSessionKey: "agent:main:subagent:proxy-owner",
+      requesterSessionKey: "agent:main:main",
+      requesterDisplayKey: "main",
+      task: "proxy-owned sibling still running",
+      cleanup: "keep",
+      createdAt: Date.parse("2026-06-26T02:17:00Z"),
+      startedAt: Date.parse("2026-06-26T02:18:00Z"),
+    });
+
+    mod.registerSubagentRun({
+      runId: "run-last-child-with-proxy-sibling",
+      childSessionKey: "agent:main:subagent:last",
+      requesterSessionKey: "agent:main:main",
+      requesterDisplayKey: "main",
+      task: "last non-proxy child completes",
+      cleanup: "keep",
+    });
+
+    await waitForFast(() => {
+      expect(mocks.runSubagentAnnounceFlow).toHaveBeenCalledTimes(1);
+    });
+    expectRecordFields(
+      getMockCallArg(mocks.runSubagentAnnounceFlow, 0, 0, "proxy sibling announce params"),
+      {
+        childRunId: "run-last-child-with-proxy-sibling",
+        allRequesterChildrenSettled: false,
+      },
+      "proxy sibling announce params",
+    );
+  });
+
+  it("does not mark top-level requester completion while child cleanup is still pending", async () => {
+    mocks.loadSessionStore.mockReturnValue({
+      "agent:main:subagent:cleanup-pending": {
+        sessionId: "sess-cleanup-pending",
+        updatedAt: 1,
+      },
+      "agent:main:subagent:last": {
+        sessionId: "sess-last",
+        updatedAt: 1,
+      },
+    });
+
+    mod.addSubagentRunForTests({
+      runId: "run-cleanup-pending",
+      childSessionKey: "agent:main:subagent:cleanup-pending",
+      requesterSessionKey: "agent:main:main",
+      requesterDisplayKey: "main",
+      task: "sibling cleanup still pending",
+      cleanup: "keep",
+      createdAt: Date.parse("2026-06-26T02:17:00Z"),
+      startedAt: Date.parse("2026-06-26T02:18:00Z"),
+      endedAt: Date.parse("2026-06-26T02:19:00Z"),
+      cleanupHandled: true,
+      cleanupCompletedAt: undefined,
+      outcome: { status: "ok" },
+    });
+
+    mod.registerSubagentRun({
+      runId: "run-last-child-with-cleanup-pending",
+      childSessionKey: "agent:main:subagent:last",
+      requesterSessionKey: "agent:main:main",
+      requesterDisplayKey: "main",
+      task: "last child completes while cleanup is pending",
+      cleanup: "keep",
+    });
+
+    await waitForFast(() => {
+      expect(mocks.runSubagentAnnounceFlow).toHaveBeenCalledTimes(1);
+    });
+    expectRecordFields(
+      getMockCallArg(mocks.runSubagentAnnounceFlow, 0, 0, "cleanup pending announce params"),
+      {
+        childRunId: "run-last-child-with-cleanup-pending",
+        allRequesterChildrenSettled: false,
+      },
+      "cleanup pending announce params",
     );
   });
 


### PR DESCRIPTION
## What Problem This Solves

Fixes #99060.

When a top-level requester spawned subagents and then yielded for their completion, the final child completion could still be announced with ordinary single-child review guidance. In webchat/session-yield flows this can leave the requester replying `NO_REPLY` after all child work has drained, instead of synthesizing the final user-visible answer or next action.

## Why This Change Was Made

This wires a narrow requester-drain signal through the subagent registry and announce paths:

- The registry computes whether the top-level requester has remaining active, pending-descendant, or cleanup-pending child work.
- The current completion is excluded from its own remaining-child count, while other cleanup-pending siblings still block the final-drain signal.
- Proxied subagent spawns are counted by requester ownership, not controller ownership.
- Pending delivery retries derive the prompt hint at dispatch time instead of persisting a stale payload flag.
- Missing-requester fallback recomputes the final-target settled state after rerouting to the parent requester.
- Nested subagent requesters keep the internal orchestration prompt; only top-level requester delivery gets the final synthesis nudge.

## User Impact

Top-level sessions, including webchat requester sessions, now get a final synthesis prompt once spawned subagent work has genuinely drained. This prevents the deadlock pattern where completion context arrives but the orchestrator stays silent with `NO_REPLY`.

## Before-Fix Proof

Issue/behavior evidence:

- #99060 reported a webchat orchestrator session deadlock where subagent completion events could trigger premature `NO_REPLY`.
- ClawSweeper labeled the issue `clawsweeper:needs-live-repro`, `impact:session-state`, `impact:message-loss`, and `issue-rating: 🐚 platinum hermit`.
- Code inspection showed the top-level requester announce path lacked an all-descendants/all-direct-children-drained backstop comparable to the yielded subagent wake path.

Local red regression proof during TDD:

- Added a registry seam regression for a top-level requester where one sibling was already completed and the final direct child completed.
- Before the production change, that test failed because the announce params did not include the final-drain signal:

```text
last child announce params.allRequesterChildrenSettled: expected undefined to deeply equal true
```

Evidence boundary:

- I did not run a separate pre-fix QA-suite baseline on `origin/main`; the before-fix proof is the issue report, ClawSweeper analysis, source inspection, and the red regression test above.

## After-Fix Real Behavior Proof

Ran the repo-backed fanout QA scenario that exercises a real local QA gateway child, qa-channel transport, mock-openai provider, two sequential subagent spawns, and the final parent synthesis reply after both children completed:

```bash
NO_PROXY=127.0.0.1,localhost,::1 no_proxy=127.0.0.1,localhost,::1 OPENCLAW_QA_SUITE_PROGRESS=1 pnpm openclaw qa suite --provider-mode mock-openai --scenario subagent-fanout-synthesis --concurrency 1 --output-dir .artifacts/qa-e2e/99060-fanout-synthesis-proof
```

Result:

```text
Passed: 1
Failed: 0
Scenario: Subagent fanout synthesis
Step: spawns sequential workers and folds both results back into the parent reply
Details:
subagent-1: ok
subagent-2: ok
```

Artifacts:

- `.artifacts/qa-e2e/99060-fanout-synthesis-proof/qa-suite-report.md`
- `.artifacts/qa-e2e/99060-fanout-synthesis-proof/qa-evidence.json`
- `.artifacts/qa-e2e/99060-fanout-synthesis-proof/qa-suite-summary.json`

This is the proof ClawSweeper asked for: two sibling subagents complete, then the parent produces the synthesized final reply.

## Additional Verification

```bash
node scripts/run-vitest.mjs src/agents/subagent-registry.test.ts src/agents/subagent-announce.format.e2e.test.ts src/agents/embedded-agent-runner/sessions-yield.orchestration.test.ts
git diff --check
./agents/skills/autoreview/scripts/autoreview --mode local
```

Results:

- Focused Vitest shards passed.
- `git diff --check` passed.
- Autoreview completed cleanly with no accepted/actionable findings.
