### PR TITLE
fix(android): use Bluetooth microphones for voice capture

### DIFF
--- a/apps/.i18n/native-source.json
+++ b/apps/.i18n/native-source.json
@@ -4891,7 +4891,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 224,
+      "line": 221,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/voice/MicCaptureManager.kt",
       "source": "Speaking · waiting for reply",
       "surface": "android",
@@ -4899,7 +4899,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 224,
+      "line": 221,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/voice/MicCaptureManager.kt",
       "source": "Speaking…",
       "surface": "android",
@@ -4907,7 +4907,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 418,
+      "line": 415,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/voice/MicCaptureManager.kt",
       "source": "Mic off",
       "surface": "android",
@@ -4915,7 +4915,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 418,
+      "line": 415,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/voice/MicCaptureManager.kt",
       "source": "Mic off · sending…",
       "surface": "android",
@@ -4923,7 +4923,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 484,
+      "line": 481,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/voice/MicCaptureManager.kt",
       "source": "Listening · sending queued voice",
       "surface": "android",
@@ -4931,7 +4931,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 484,
+      "line": 481,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/voice/MicCaptureManager.kt",
       "source": "Sending queued voice",
       "surface": "android",
@@ -4939,7 +4939,7 @@
     },
     {
       "kind": "ui-state-text",
-      "line": 132,
+      "line": 130,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/voice/TalkModeManager.kt",
       "source": "Off",
       "surface": "android",
@@ -4947,7 +4947,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 342,
+      "line": 340,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/voice/TalkModeManager.kt",
       "source": "Listening",
       "surface": "android",
@@ -4955,7 +4955,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 342,
+      "line": 340,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/voice/TalkModeManager.kt",
       "source": "Ready",
       "surface": "android",
@@ -4963,7 +4963,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1629,
+      "line": 1600,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/voice/TalkModeManager.kt",
       "source": "Aborted",
       "surface": "android",
@@ -4971,7 +4971,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1629,
+      "line": 1600,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/voice/TalkModeManager.kt",
       "source": "Chat error",
       "surface": "android",

--- a/apps/android/app/src/main/java/ai/openclaw/app/voice/AndroidAudioInputSession.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/voice/AndroidAudioInputSession.kt
@@ -1,0 +1,262 @@
+package ai.openclaw.app.voice
+
+import android.annotation.SuppressLint
+import android.content.Context
+import android.media.AudioDeviceCallback
+import android.media.AudioDeviceInfo
+import android.media.AudioFormat
+import android.media.AudioManager
+import android.media.AudioRecord
+import android.media.MediaRecorder
+import android.os.Build
+import android.os.Handler
+import android.os.Looper
+import android.util.Log
+
+/** Owns one recorder and its Bluetooth route for the full capture lifecycle. */
+internal class AndroidAudioInputSession private constructor(
+  private val audioManager: AudioManager,
+  private val audioRecord: AudioRecord,
+) : AutoCloseable {
+  companion object {
+    private const val tag = "AudioInput"
+
+    @SuppressLint("MissingPermission")
+    fun open(
+      context: Context,
+      sampleRateHz: Int,
+      frameBytes: Int,
+    ): AndroidAudioInputSession {
+      val minBuffer =
+        AudioRecord.getMinBufferSize(
+          sampleRateHz,
+          AudioFormat.CHANNEL_IN_MONO,
+          AudioFormat.ENCODING_PCM_16BIT,
+        )
+      if (minBuffer <= 0) {
+        throw IllegalStateException("AudioRecord buffer unavailable")
+      }
+      val audioRecord =
+        AudioRecord
+          .Builder()
+          .setAudioSource(MediaRecorder.AudioSource.VOICE_RECOGNITION)
+          .setAudioFormat(
+            AudioFormat
+              .Builder()
+              .setEncoding(AudioFormat.ENCODING_PCM_16BIT)
+              .setSampleRate(sampleRateHz)
+              .setChannelMask(AudioFormat.CHANNEL_IN_MONO)
+              .build(),
+          ).setBufferSizeInBytes(maxOf(minBuffer, frameBytes * 4))
+          .build()
+      val audioManager = context.getSystemService(Context.AUDIO_SERVICE) as AudioManager
+      return AndroidAudioInputSession(audioManager, audioRecord).also { session ->
+        try {
+          session.openRoute()
+        } catch (err: RuntimeException) {
+          session.close()
+          throw err
+        }
+      }
+    }
+  }
+
+  private val lock = Any()
+  private val communicationRouteOwner = bluetoothCommunicationRoute.newOwner()
+  private val callbackHandler = Handler(Looper.getMainLooper())
+  private var closed = false
+  private var callbackRegistered = false
+  private var requestedInput: AudioDeviceInfo? = null
+  private var requestedCommunicationDevice: AudioDeviceInfo? = null
+  private var selectedInput: AudioDeviceInfo? = null
+
+  private val deviceCallback =
+    object : AudioDeviceCallback() {
+      override fun onAudioDevicesAdded(addedDevices: Array<out AudioDeviceInfo>) {
+        refreshRouteSafely()
+      }
+
+      override fun onAudioDevicesRemoved(removedDevices: Array<out AudioDeviceInfo>) {
+        refreshRouteSafely()
+      }
+    }
+  internal val preferredInputType: Int?
+    get() = synchronized(lock) { selectedInput?.type }
+
+  internal val requestedInputType: Int?
+    get() = synchronized(lock) { requestedInput?.type }
+
+  fun startRecording() {
+    audioRecord.startRecording()
+    Log.d(tag, "capture started preferred=${preferredInputType ?: "default"} routed=${audioRecord.routedDevice?.type ?: "pending"}")
+  }
+
+  fun read(
+    buffer: ByteArray,
+    offset: Int,
+    size: Int,
+  ): Int = audioRecord.read(buffer, offset, size)
+
+  private fun openRoute() {
+    audioManager.registerAudioDeviceCallback(deviceCallback, callbackHandler)
+    synchronized(lock) { callbackRegistered = true }
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+      bluetoothCommunicationRoute.begin(communicationRouteOwner)
+    }
+    refreshRouteSafely()
+  }
+
+  private fun refreshRouteSafely() {
+    try {
+      refreshRoute()
+    } catch (err: RuntimeException) {
+      // Routing is a preference; default capture remains better than losing the voice session.
+      Log.w(tag, "Bluetooth route update failed: ${err.message ?: err::class.simpleName}")
+    }
+  }
+
+  private fun refreshRoute() {
+    synchronized(lock) {
+      if (closed) return
+      val inputs = audioManager.getDevices(AudioManager.GET_DEVICES_INPUTS).toList()
+      val communicationDevice =
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+          selectBluetoothDevice(audioManager.availableCommunicationDevices, requestedCommunicationDevice)
+        } else {
+          null
+        }
+      val communicationSelected =
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+          bluetoothCommunicationRoute.update(audioManager, communicationRouteOwner, communicationDevice)
+        } else {
+          false
+        }
+      requestedCommunicationDevice = communicationDevice.takeIf { communicationSelected }
+      val input = selectBluetoothInput(inputs, requestedInput, requestedCommunicationDevice)
+      if (!sameDevice(requestedInput, input) || !sameDevice(selectedInput, input)) {
+        requestedInput = input
+        if (audioRecord.setPreferredDevice(input)) {
+          selectedInput = input
+          Log.d(tag, "preferred input changed type=${input?.type ?: "default"}")
+        } else {
+          selectedInput = null
+          Log.w(tag, "preferred input rejected type=${input?.type ?: "default"}")
+        }
+      }
+    }
+  }
+
+  override fun close() {
+    synchronized(lock) {
+      if (closed) return
+      closed = true
+      if (callbackRegistered) {
+        runCatching { audioManager.unregisterAudioDeviceCallback(deviceCallback) }
+        callbackRegistered = false
+      }
+      runCatching { audioRecord.setPreferredDevice(null) }
+      requestedInput = null
+      selectedInput = null
+      if (audioRecord.recordingState == AudioRecord.RECORDSTATE_RECORDING) {
+        runCatching { audioRecord.stop() }
+      }
+      runCatching { audioRecord.release() }
+      if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+        bluetoothCommunicationRoute.close(audioManager, communicationRouteOwner)
+      }
+      requestedCommunicationDevice = null
+    }
+  }
+}
+
+/** Serializes Android's process-wide communication route across overlapping capture cleanup. */
+private class BluetoothCommunicationRoute {
+  private var nextOwner = 0L
+  private var latestOwner = 0L
+  private var activeOwner: Long? = null
+
+  @Synchronized
+  fun newOwner(): Long = ++nextOwner
+
+  @Synchronized
+  fun begin(owner: Long) {
+    if (owner > latestOwner) latestOwner = owner
+  }
+
+  @Synchronized
+  fun update(
+    audioManager: AudioManager,
+    owner: Long,
+    device: AudioDeviceInfo?,
+  ): Boolean {
+    if (owner < latestOwner) return false
+    latestOwner = owner
+    if (device == null) {
+      if (activeOwner != null) audioManager.clearCommunicationDevice()
+      activeOwner = null
+      return false
+    }
+    if (!audioManager.setCommunicationDevice(device)) {
+      if (activeOwner != null) audioManager.clearCommunicationDevice()
+      activeOwner = null
+      return false
+    }
+    activeOwner = owner
+    return true
+  }
+
+  @Synchronized
+  fun close(
+    audioManager: AudioManager,
+    owner: Long,
+  ) {
+    if (activeOwner != owner || owner < latestOwner) return
+    audioManager.clearCommunicationDevice()
+    activeOwner = null
+  }
+}
+
+private val bluetoothCommunicationRoute = BluetoothCommunicationRoute()
+
+private fun selectBluetoothDevice(
+  devices: List<AudioDeviceInfo>,
+  current: AudioDeviceInfo? = null,
+): AudioDeviceInfo? {
+  current
+    ?.takeIf { candidate ->
+      bluetoothPriority(candidate.type) != null && devices.any { sameDevice(it, candidate) }
+    }?.let { return it }
+  return devices
+    .asSequence()
+    .mapNotNull { device -> bluetoothPriority(device.type)?.let { priority -> priority to device } }
+    .minWithOrNull(compareBy<Pair<Int, AudioDeviceInfo>> { it.first }.thenBy { it.second.id })
+    ?.second
+}
+
+private fun selectBluetoothInput(
+  devices: List<AudioDeviceInfo>,
+  current: AudioDeviceInfo?,
+  communicationDevice: AudioDeviceInfo?,
+): AudioDeviceInfo? {
+  if (communicationDevice == null) return selectBluetoothDevice(devices, current)
+  val candidates = devices.filter { it.type == communicationDevice.type }
+  current?.takeIf { candidate -> candidates.any { sameDevice(it, candidate) } }?.let { return it }
+  val address = communicationDevice.address.trim()
+  if (address.isNotEmpty()) {
+    candidates.firstOrNull { it.address == address }?.let { return it }
+  }
+  // setCommunicationDevice chooses the matching source; only override it when unambiguous.
+  return candidates.singleOrNull()
+}
+
+private fun bluetoothPriority(type: Int): Int? =
+  when (type) {
+    AudioDeviceInfo.TYPE_BLE_HEADSET -> 0
+    AudioDeviceInfo.TYPE_BLUETOOTH_SCO -> 1
+    else -> null
+  }
+
+private fun sameDevice(
+  left: AudioDeviceInfo?,
+  right: AudioDeviceInfo?,
+): Boolean = left?.id == right?.id && left?.type == right?.type

--- a/apps/android/app/src/main/java/ai/openclaw/app/voice/MicCaptureManager.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/voice/MicCaptureManager.kt
@@ -5,9 +5,6 @@ import android.Manifest
 import android.annotation.SuppressLint
 import android.content.Context
 import android.content.pm.PackageManager
-import android.media.AudioFormat
-import android.media.AudioRecord
-import android.media.MediaRecorder
 import android.util.Log
 import androidx.core.content.ContextCompat
 import kotlinx.coroutines.CancellationException
@@ -650,35 +647,14 @@ internal class MicCaptureManager(
       }
     transcriptionCaptureJob =
       scope.launch(Dispatchers.IO) {
-        var audioRecord: AudioRecord? = null
+        var audioInput: AndroidAudioInputSession? = null
         try {
           val frameBytes = transcriptionSampleRateHz * 2 * transcriptionAudioFrameMs / 1000
-          val minBuffer =
-            AudioRecord.getMinBufferSize(
-              transcriptionSampleRateHz,
-              AudioFormat.CHANNEL_IN_MONO,
-              AudioFormat.ENCODING_PCM_16BIT,
-            )
-          if (minBuffer <= 0) {
-            throw IllegalStateException("AudioRecord buffer unavailable")
-          }
-          audioRecord =
-            AudioRecord
-              .Builder()
-              .setAudioSource(MediaRecorder.AudioSource.VOICE_RECOGNITION)
-              .setAudioFormat(
-                AudioFormat
-                  .Builder()
-                  .setEncoding(AudioFormat.ENCODING_PCM_16BIT)
-                  .setSampleRate(transcriptionSampleRateHz)
-                  .setChannelMask(AudioFormat.CHANNEL_IN_MONO)
-                  .build(),
-              ).setBufferSizeInBytes(maxOf(minBuffer, frameBytes * 4))
-              .build()
+          audioInput = AndroidAudioInputSession.open(context, transcriptionSampleRateHz, frameBytes)
           val buffer = ByteArray(frameBytes)
-          audioRecord.startRecording()
+          audioInput.startRecording()
           while (coroutineContext.isActive && _micEnabled.value && transcriptionSessionId == sessionId) {
-            val read = audioRecord.read(buffer, 0, buffer.size)
+            val read = audioInput.read(buffer, 0, buffer.size)
             if (read <= 0) continue
             _inputLevel.value = pcm16Level(buffer, read)
             audioFrames.trySend(buffer.copyOf(read))
@@ -688,13 +664,7 @@ internal class MicCaptureManager(
           failTranscription(sessionId, err.message ?: err::class.simpleName ?: "capture failed")
         } finally {
           audioFrames.close()
-          audioRecord?.let { record ->
-            try {
-              record.stop()
-            } catch (_: Throwable) {
-            }
-            record.release()
-          }
+          audioInput?.close()
         }
       }
   }

--- a/apps/android/app/src/main/java/ai/openclaw/app/voice/TalkModeManager.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/voice/TalkModeManager.kt
@@ -13,9 +13,7 @@ import android.media.AudioAttributes
 import android.media.AudioFocusRequest
 import android.media.AudioFormat
 import android.media.AudioManager
-import android.media.AudioRecord
 import android.media.AudioTrack
-import android.media.MediaRecorder
 import android.os.Bundle
 import android.os.Handler
 import android.os.Looper
@@ -736,35 +734,14 @@ class TalkModeManager internal constructor(
       }
     realtimeCaptureJob =
       scope.launch(Dispatchers.IO) {
-        var audioRecord: AudioRecord? = null
+        var audioInput: AndroidAudioInputSession? = null
         try {
           val frameBytes = realtimeSampleRateHz * 2 * realtimeAudioFrameMs / 1000
-          val minBuffer =
-            AudioRecord.getMinBufferSize(
-              realtimeSampleRateHz,
-              AudioFormat.CHANNEL_IN_MONO,
-              AudioFormat.ENCODING_PCM_16BIT,
-            )
-          if (minBuffer <= 0) {
-            throw IllegalStateException("AudioRecord buffer unavailable")
-          }
-          audioRecord =
-            AudioRecord
-              .Builder()
-              .setAudioSource(MediaRecorder.AudioSource.VOICE_RECOGNITION)
-              .setAudioFormat(
-                AudioFormat
-                  .Builder()
-                  .setEncoding(AudioFormat.ENCODING_PCM_16BIT)
-                  .setSampleRate(realtimeSampleRateHz)
-                  .setChannelMask(AudioFormat.CHANNEL_IN_MONO)
-                  .build(),
-              ).setBufferSizeInBytes(maxOf(minBuffer, frameBytes * 4))
-              .build()
+          audioInput = AndroidAudioInputSession.open(context, realtimeSampleRateHz, frameBytes)
           val buffer = ByteArray(frameBytes)
-          audioRecord.startRecording()
+          audioInput.startRecording()
           while (coroutineContext.isActive && _isEnabled.value && realtimeSessionId == sessionId) {
-            val read = audioRecord.read(buffer, 0, buffer.size)
+            val read = audioInput.read(buffer, 0, buffer.size)
             if (read <= 0) continue
             if (!shouldAppendRealtimeCapturedFrame(read)) continue
             audioFrames.trySend(buffer.copyOf(read))
@@ -775,13 +752,7 @@ class TalkModeManager internal constructor(
           failRealtimeRelay(sessionId, err.message ?: err::class.simpleName ?: "capture failed")
         } finally {
           audioFrames.close()
-          audioRecord?.let { record ->
-            try {
-              record.stop()
-            } catch (_: Throwable) {
-            }
-            record.release()
-          }
+          audioInput?.close()
         }
       }
   }

--- a/apps/android/app/src/test/java/ai/openclaw/app/voice/AndroidAudioInputSessionTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/voice/AndroidAudioInputSessionTest.kt
@@ -1,0 +1,121 @@
+package ai.openclaw.app.voice
+
+import android.Manifest
+import android.content.Context
+import android.media.AudioDeviceInfo
+import android.media.AudioManager
+import android.os.Looper
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.RuntimeEnvironment
+import org.robolectric.Shadows.shadowOf
+import org.robolectric.annotation.Config
+import org.robolectric.shadows.AudioDeviceInfoBuilder
+import org.robolectric.shadows.ShadowAudioManager
+import org.robolectric.util.ReflectionHelpers
+
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [34])
+class AndroidAudioInputSessionTest {
+  private val context = RuntimeEnvironment.getApplication()
+  private val audioManager = context.getSystemService(Context.AUDIO_SERVICE) as AudioManager
+  private val shadowAudioManager: ShadowAudioManager = shadowOf(audioManager)
+  private var nextDeviceId = 1
+
+  @Before
+  fun setUp() {
+    shadowOf(context).grantPermissions(Manifest.permission.RECORD_AUDIO)
+  }
+
+  @After
+  fun tearDown() {
+    shadowAudioManager.setInputDevices(emptyList())
+    shadowAudioManager.setAvailableCommunicationDevices(emptyList())
+    audioManager.clearCommunicationDevice()
+  }
+
+  @Test
+  fun prefersBleHeadsetInputAndCommunicationRoute() {
+    val sco = audioDevice(AudioDeviceInfo.TYPE_BLUETOOTH_SCO)
+    val ble = audioDevice(AudioDeviceInfo.TYPE_BLE_HEADSET)
+    val scoOutput = audioDevice(AudioDeviceInfo.TYPE_BLUETOOTH_SCO)
+    val bleOutput = audioDevice(AudioDeviceInfo.TYPE_BLE_HEADSET)
+    shadowAudioManager.setInputDevices(listOf(sco, ble))
+    shadowAudioManager.setAvailableCommunicationDevices(listOf(scoOutput, bleOutput))
+
+    val session = AndroidAudioInputSession.open(context, sampleRateHz = 24_000, frameBytes = 4_800)
+
+    assertEquals(AudioDeviceInfo.TYPE_BLE_HEADSET, session.requestedInputType)
+    assertEquals(AudioDeviceInfo.TYPE_BLE_HEADSET, audioManager.communicationDevice?.type)
+    session.close()
+  }
+
+  @Test
+  fun removalFallsBackToClassicBluetoothInput() {
+    val sco = audioDevice(AudioDeviceInfo.TYPE_BLUETOOTH_SCO)
+    val ble = audioDevice(AudioDeviceInfo.TYPE_BLE_HEADSET)
+    val scoOutput = audioDevice(AudioDeviceInfo.TYPE_BLUETOOTH_SCO)
+    val bleOutput = audioDevice(AudioDeviceInfo.TYPE_BLE_HEADSET)
+    shadowAudioManager.setInputDevices(listOf(sco, ble))
+    shadowAudioManager.setAvailableCommunicationDevices(listOf(scoOutput, bleOutput))
+    val session = AndroidAudioInputSession.open(context, sampleRateHz = 24_000, frameBytes = 4_800)
+
+    shadowAudioManager.setAvailableCommunicationDevices(listOf(scoOutput))
+    shadowAudioManager.removeInputDevice(ble, true)
+    shadowOf(Looper.getMainLooper()).idle()
+
+    assertEquals(AudioDeviceInfo.TYPE_BLUETOOTH_SCO, session.requestedInputType)
+    assertEquals(AudioDeviceInfo.TYPE_BLUETOOTH_SCO, audioManager.communicationDevice?.type)
+    session.close()
+  }
+
+  @Test
+  fun closeRestoresDefaultInputAndUnregistersDeviceCallback() {
+    val ble = audioDevice(AudioDeviceInfo.TYPE_BLE_HEADSET)
+    val bleOutput = audioDevice(AudioDeviceInfo.TYPE_BLE_HEADSET)
+    shadowAudioManager.setInputDevices(listOf(ble))
+    shadowAudioManager.setAvailableCommunicationDevices(listOf(bleOutput))
+    val session = AndroidAudioInputSession.open(context, sampleRateHz = 8_000, frameBytes = 1_600)
+
+    session.close()
+
+    assertNull(session.requestedInputType)
+    assertNull(audioManager.communicationDevice)
+    shadowAudioManager.addInputDevice(audioDevice(AudioDeviceInfo.TYPE_BLE_HEADSET), true)
+    shadowOf(Looper.getMainLooper()).idle()
+    assertNull(session.requestedInputType)
+  }
+
+  @Test
+  fun delayedOldCloseDoesNotClearNewerCommunicationRoute() {
+    val ble = audioDevice(AudioDeviceInfo.TYPE_BLE_HEADSET)
+    val bleOutput = audioDevice(AudioDeviceInfo.TYPE_BLE_HEADSET)
+    shadowAudioManager.setInputDevices(listOf(ble))
+    shadowAudioManager.setAvailableCommunicationDevices(listOf(bleOutput))
+    val oldSession = AndroidAudioInputSession.open(context, sampleRateHz = 24_000, frameBytes = 4_800)
+    val newSession = AndroidAudioInputSession.open(context, sampleRateHz = 24_000, frameBytes = 4_800)
+
+    oldSession.close()
+
+    assertEquals(AudioDeviceInfo.TYPE_BLE_HEADSET, audioManager.communicationDevice?.type)
+    newSession.close()
+    assertNull(audioManager.communicationDevice)
+  }
+
+  private fun audioDevice(type: Int): AudioDeviceInfo {
+    val device =
+      AudioDeviceInfoBuilder
+        .newBuilder()
+        .setType(type)
+        .build()
+    val port = ReflectionHelpers.getField<Any>(device, "mPort")
+    val handle = ReflectionHelpers.getField<Any>(port, "mHandle")
+    ReflectionHelpers.setField(handle, "mId", nextDeviceId++)
+    return device
+  }
+}

--- a/docs/nodes/talk.md
+++ b/docs/nodes/talk.md
@@ -139,6 +139,7 @@ Defaults:
 
 - Voice tab toggle: **Talk**
 - Manual **Mic** and **Talk** are mutually exclusive runtime capture modes.
+- Manual Mic and realtime Talk prefer a connected Bluetooth Classic or BLE headset microphone. If it disconnects, the app requests another headset input or lets Android use the default microphone; stopping capture restores the default microphone preference.
 - Manual Mic stops when the app leaves the foreground or the user leaves the Voice tab.
 - Talk Mode keeps running until toggled off or the Android node disconnects, and uses Android's microphone foreground-service type while active.
 


### PR DESCRIPTION
Fixes #96241

## What Problem This Solves

Fixes an issue where Android users with a connected Bluetooth headset could hear OpenClaw through the headset while Talk or Dictation still captured the phone microphone.

## Why This Change Was Made

Both Android voice paths now share one capture-lifecycle owner. On Android 12 and newer it establishes the process communication route, while each `AudioRecord` also requests the matching Bluetooth Classic or BLE input; device callbacks re-evaluate the route after connect/disconnect, and generation ownership prevents delayed cleanup from clearing a newer voice session. Older Android versions keep the per-recorder preferred-input path.

This follows Android's documented [BLE recording flow](https://developer.android.com/develop/connectivity/bluetooth/ble-audio/audio-recording) and [communication-device contract](https://developer.android.com/reference/android/media/AudioManager#setCommunicationDevice(android.media.AudioDeviceInfo)).

## User Impact

Manual Dictation and realtime Talk prefer a connected Bluetooth headset microphone, fall back when it disconnects, and restore default routing when capture ends.

## Evidence

- Play and third-party focused suites passed for `AndroidAudioInputSessionTest`, `TalkModeManagerTest`, and `MicCaptureManagerTest`; Android `ktlintCheck` and native i18n inventory checks passed.
- Exact-head Testbox `tbx_01kwjk00ysksteeqwbb34hd3x7` passed `pnpm check:changed`: https://github.com/openclaw/openclaw/actions/runs/28628336528
- The exact `25d8690944` Play debug APK installed on an API 36.1 emulator.
- A real-Gateway Dictation run connected successfully, created a transcription session, started `VOICE_RECOGNITION` capture, and logged `AudioInput: capture started preferred=default routed=15`. The configured OpenAI OAuth refresh then failed, so this proves the real capture lifecycle but not speech-provider completion.
- Route tests cover BLE preference over Classic, BLE removal fallback to Classic, default restoration/callback cleanup, and delayed-old-session cleanup not clearing a newer route.
- Fresh Codex autoreview: no accepted/actionable findings.
- Hardware boundary: no physical Android Bluetooth Classic or BLE headset target was available in the authorized local/remote device inventory. Emulator/default-mic lifecycle proof is complete; physical headset route proof remains unavailable.
- No before/after screenshots: this changes audio routing and has no visual UI delta.
