### PR TITLE
test(qa): cover Crabline Matrix sends

### DIFF
--- a/extensions/qa-lab/src/crabline-transport.test.ts
+++ b/extensions/qa-lab/src/crabline-transport.test.ts
@@ -561,6 +561,62 @@ describe("crabline transport", () => {
     });
   });
 
+  it("normalizes native Matrix room message sends into outbound state", async () => {
+    await withTempDir("qa-crabline-transport-", async (outputDir) => {
+      const transport = await createQaCrablineTransportAdapter({
+        outputDir,
+        selection: createSelection("matrix"),
+        state: createQaBusState(),
+      });
+
+      try {
+        const roomId = "!qa:matrix.test";
+        await transport.state.addInboundMessage({
+          conversation: { id: roomId, kind: "group" },
+          senderId: "@alice:matrix.test",
+          senderName: "Alice",
+          text: "Matrix baseline marker check.",
+        });
+        const delivery = transport.buildAgentDelivery({ target: `group:${roomId}` });
+        const providerRoomId = delivery.to.replace(/^room:/u, "");
+        const manifest = JSON.parse(
+          await fs.readFile(path.join(outputDir, OPENCLAW_CRABLINE_MANIFEST_PATH), "utf8"),
+        ) as {
+          accessToken: string;
+          endpoints: { clientApiRoot: string };
+        };
+        const { response, release } = await fetchWithSsrFGuard({
+          url: `${manifest.endpoints.clientApiRoot}/rooms/${encodeURIComponent(providerRoomId)}/send/m.room.message/qa-matrix-send`,
+          init: {
+            body: JSON.stringify({ body: "assistant via fake matrix", msgtype: "m.text" }),
+            headers: {
+              authorization: `Bearer ${manifest.accessToken}`,
+              "content-type": "application/json",
+            },
+            method: "PUT",
+          },
+          policy: { allowPrivateNetwork: true },
+          auditContext: "qa-lab-crabline-matrix-transport-test",
+        });
+        await release();
+        expect(response.ok).toBe(true);
+
+        await expect(
+          transport.waitForOutbound({
+            conversation: { id: roomId, kind: "group" },
+            textIncludes: "assistant via fake matrix",
+            timeoutMs: 1_000,
+          }),
+        ).resolves.toMatchObject({
+          conversation: { id: roomId, kind: "group" },
+          text: "assistant via fake matrix",
+        });
+      } finally {
+        await transport.cleanup?.();
+      }
+    });
+  });
+
   it("injects inbound messages through Crabline and mirrors Telegram sends into normalized state", async () => {
     await withTempDir("qa-crabline-transport-", async (outputDir) => {
       const transport = await createQaCrablineTransportAdapter({

--- a/extensions/qa-lab/src/crabline-transport.test.ts
+++ b/extensions/qa-lab/src/crabline-transport.test.ts
@@ -348,6 +348,58 @@ describe("crabline transport", () => {
     });
   });
 
+  it("normalizes native Signal JSON-RPC sends into outbound state", async () => {
+    await withTempDir("qa-crabline-transport-", async (outputDir) => {
+      const transport = await createQaCrablineTransportAdapter({
+        outputDir,
+        selection: createSelection("signal"),
+        state: createQaBusState(),
+      });
+
+      try {
+        const delivery = transport.buildAgentDelivery({ target: "dm:alice" });
+        const manifest = JSON.parse(
+          await fs.readFile(path.join(outputDir, OPENCLAW_CRABLINE_MANIFEST_PATH), "utf8"),
+        ) as {
+          endpoints: { rpcUrl: string };
+        };
+        const { response, release } = await fetchWithSsrFGuard({
+          url: manifest.endpoints.rpcUrl,
+          init: {
+            body: JSON.stringify({
+              id: "qa-signal-send",
+              jsonrpc: "2.0",
+              method: "send",
+              params: {
+                message: "assistant via fake signal",
+                recipient: [delivery.to],
+              },
+            }),
+            headers: { "content-type": "application/json" },
+            method: "POST",
+          },
+          policy: { allowPrivateNetwork: true },
+          auditContext: "qa-lab-crabline-signal-transport-test",
+        });
+        await release();
+        expect(response.ok).toBe(true);
+
+        await expect(
+          transport.waitForOutbound({
+            conversation: { id: "alice", kind: "direct" },
+            textIncludes: "assistant via fake signal",
+            timeoutMs: 1_000,
+          }),
+        ).resolves.toMatchObject({
+          conversation: { id: "alice", kind: "direct" },
+          text: "assistant via fake signal",
+        });
+      } finally {
+        await transport.cleanup?.();
+      }
+    });
+  });
+
   it("binds Mattermost config and normalizes transport targets", async () => {
     await withTempDir("qa-crabline-transport-", async (outputDir) => {
       const transport = await createQaCrablineTransportAdapter({

--- a/extensions/qa-lab/src/crabline-transport.test.ts
+++ b/extensions/qa-lab/src/crabline-transport.test.ts
@@ -450,6 +450,63 @@ describe("crabline transport", () => {
     });
   });
 
+  it("normalizes native Mattermost post creation into outbound state", async () => {
+    await withTempDir("qa-crabline-transport-", async (outputDir) => {
+      const transport = await createQaCrablineTransportAdapter({
+        outputDir,
+        selection: createSelection("mattermost"),
+        state: createQaBusState(),
+      });
+
+      try {
+        await transport.state.addInboundMessage({
+          conversation: { id: "qa-channel", kind: "group" },
+          senderId: "alice",
+          senderName: "Alice",
+          text: "Mattermost baseline marker check.",
+        });
+        const delivery = transport.buildAgentDelivery({ target: "group:qa-channel" });
+        const manifest = JSON.parse(
+          await fs.readFile(path.join(outputDir, OPENCLAW_CRABLINE_MANIFEST_PATH), "utf8"),
+        ) as {
+          botToken: string;
+          endpoints: { apiRoot: string };
+        };
+        const { response, release } = await fetchWithSsrFGuard({
+          url: `${manifest.endpoints.apiRoot}/posts`,
+          init: {
+            body: JSON.stringify({
+              channel_id: delivery.to.replace(/^channel:/u, ""),
+              message: "assistant via fake mattermost",
+            }),
+            headers: {
+              authorization: `Bearer ${manifest.botToken}`,
+              "content-type": "application/json",
+            },
+            method: "POST",
+          },
+          policy: { allowPrivateNetwork: true },
+          auditContext: "qa-lab-crabline-mattermost-transport-test",
+        });
+        await release();
+        expect(response.ok).toBe(true);
+
+        await expect(
+          transport.waitForOutbound({
+            conversation: { id: "qa-channel", kind: "group" },
+            textIncludes: "assistant via fake mattermost",
+            timeoutMs: 1_000,
+          }),
+        ).resolves.toMatchObject({
+          conversation: { id: "qa-channel", kind: "group" },
+          text: "assistant via fake mattermost",
+        });
+      } finally {
+        await transport.cleanup?.();
+      }
+    });
+  });
+
   it("binds Matrix config and normalizes transport targets", async () => {
     await withTempDir("qa-crabline-transport-", async (outputDir) => {
       const transport = await createQaCrablineTransportAdapter({


### PR DESCRIPTION
## Summary

- establish a Matrix reply-flow target mapping through inbound delivery
- send through Crabline's Matrix-compatible room-message endpoint
- verify the recorded event is normalized into the original QA room conversation

## Stack

- stacked on #99264
- Signal native outbound coverage is in #99262
- shared binding coverage is in #98779

## Tests

- `node scripts/run-vitest.mjs extensions/qa-lab/src/crabline-transport.test.ts`
- `pnpm format:check extensions/qa-lab/src/crabline-transport.test.ts`
- `git diff --check`
- `.agents/skills/autoreview/scripts/autoreview --mode local --stream-engine-output` (clean, no actionable findings)
