### PR TITLE
Surface config hot-reload watcher status in health

### DIFF
--- a/src/commands/health.snapshot.test.ts
+++ b/src/commands/health.snapshot.test.ts
@@ -585,6 +585,28 @@ describe("getHealthSnapshot", () => {
     }
   });
 
+  it("omits configReload when no config reloader status is supplied", async () => {
+    testConfig = { session: { store: "/tmp/x" } };
+    testStore = {};
+
+    const snap = await getHealthSnapshot({ timeoutMs: 10, probe: false });
+
+    expect(snap.configReload).toBeUndefined();
+  });
+
+  it("surfaces a disabled config hot-reload watcher in the health snapshot", async () => {
+    testConfig = { session: { store: "/tmp/x" } };
+    testStore = {};
+
+    const snap = await getHealthSnapshot({
+      timeoutMs: 10,
+      probe: false,
+      configReloadHotReloadStatus: "disabled",
+    });
+
+    expect(snap.configReload).toEqual({ hotReloadStatus: "disabled" });
+  });
+
   it("skips telegram probe when not configured", async () => {
     testConfig = { session: { store: "/tmp/x" } };
     testStore = {

--- a/src/commands/health.test.ts
+++ b/src/commands/health.test.ts
@@ -9,6 +9,7 @@ import {
 import { formatHealthCheckFailure } from "./health-format.js";
 import type { HealthSummary } from "./health.js";
 import {
+  formatConfigReloadHealthLine,
   formatContextEngineHealthLine,
   formatDeliveryQueueHealthLine,
   formatHealthChannelLines,
@@ -203,6 +204,51 @@ describe("healthCommand", () => {
     expect(output).toContain(
       "Delivery queue: warning (dead-lettered entries — outbound: 2; oldest 2h ago)",
     );
+  });
+
+  it("surfaces a disabled config hot-reload watcher in JSON output", async () => {
+    const snapshot = createHealthSummary({
+      channels: {},
+      channelOrder: [],
+      channelLabels: {},
+    });
+    snapshot.configReload = { hotReloadStatus: "disabled" };
+    callGatewayMock.mockResolvedValueOnce(snapshot);
+
+    await healthCommand({ json: true, timeoutMs: 5000, config: {} }, runtime as never);
+
+    const parsed = JSON.parse(requireFirstRuntimeLog()) as HealthSummary;
+    expect(parsed.configReload).toEqual({ hotReloadStatus: "disabled" });
+  });
+
+  it("prints the config hot-reload disabled line in text output", async () => {
+    const snapshot = createHealthSummary({
+      channels: {},
+      channelOrder: [],
+      channelLabels: {},
+    });
+    snapshot.configReload = { hotReloadStatus: "disabled" };
+    callGatewayMock.mockResolvedValueOnce(snapshot);
+
+    await healthCommand({ json: false, timeoutMs: 5000, config: {} }, runtime as never);
+
+    const output = stripAnsi(runtime.log.mock.calls.map((c) => String(c[0])).join("\n"));
+    expect(output).toContain("Config hot reload: disabled");
+  });
+
+  it("omits the config hot-reload line in text output when the reloader is active", async () => {
+    const snapshot = createHealthSummary({
+      channels: {},
+      channelOrder: [],
+      channelLabels: {},
+    });
+    snapshot.configReload = { hotReloadStatus: "active" };
+    callGatewayMock.mockResolvedValueOnce(snapshot);
+
+    await healthCommand({ json: false, timeoutMs: 5000, config: {} }, runtime as never);
+
+    const output = stripAnsi(runtime.log.mock.calls.map((c) => String(c[0])).join("\n"));
+    expect(output).not.toContain("Config hot reload");
   });
 
   it("prints the rich text summary and verbose gateway details", async () => {
@@ -534,6 +580,42 @@ describe("formatDeliveryQueueHealthLine", () => {
     });
 
     expect(formatDeliveryQueueHealthLine(summary)).toBeNull();
+  });
+});
+
+describe("formatConfigReloadHealthLine", () => {
+  it("reports a disabled config hot-reload watcher", () => {
+    const summary = createHealthSummary({
+      channels: {},
+      channelOrder: [],
+      channelLabels: {},
+    });
+    summary.configReload = { hotReloadStatus: "disabled" };
+
+    expect(formatConfigReloadHealthLine(summary)).toBe(
+      "Config hot reload: disabled (watcher retries exhausted; restart the gateway to restore it)",
+    );
+  });
+
+  it("stays silent while the config hot-reload watcher is active", () => {
+    const summary = createHealthSummary({
+      channels: {},
+      channelOrder: [],
+      channelLabels: {},
+    });
+    summary.configReload = { hotReloadStatus: "active" };
+
+    expect(formatConfigReloadHealthLine(summary)).toBeNull();
+  });
+
+  it("stays silent when no config reloader is running", () => {
+    const summary = createHealthSummary({
+      channels: {},
+      channelOrder: [],
+      channelLabels: {},
+    });
+
+    expect(formatConfigReloadHealthLine(summary)).toBeNull();
   });
 });
 

--- a/src/commands/health.ts
+++ b/src/commands/health.ts
@@ -31,7 +31,7 @@ import {
   DEFAULT_CHANNEL_STALE_EVENT_THRESHOLD_MS,
   evaluateChannelHealth,
 } from "../gateway/channel-health-policy.js";
-import type { GatewayHotReloadStatus } from "../gateway/config-reload.js";
+import type { GatewayHotReloadStatus } from "../gateway/config-reload-status.types.js";
 import { isGatewaySecretRefUnavailableError } from "../gateway/credentials.js";
 import { getGatewayModelPricingHealth } from "../gateway/model-pricing-cache-state.js";
 import { isGatewayModelPricingEnabled } from "../gateway/model-pricing-config.js";

--- a/src/commands/health.ts
+++ b/src/commands/health.ts
@@ -31,6 +31,7 @@ import {
   DEFAULT_CHANNEL_STALE_EVENT_THRESHOLD_MS,
   evaluateChannelHealth,
 } from "../gateway/channel-health-policy.js";
+import type { GatewayHotReloadStatus } from "../gateway/config-reload.js";
 import { isGatewaySecretRefUnavailableError } from "../gateway/credentials.js";
 import { getGatewayModelPricingHealth } from "../gateway/model-pricing-cache-state.js";
 import { isGatewayModelPricingEnabled } from "../gateway/model-pricing-config.js";
@@ -285,6 +286,14 @@ export function formatDeliveryQueueHealthLine(
   return `Delivery queue: warning (dead-lettered entries — ${counts}${oldestNote})`;
 }
 
+/** Formats config hot-reload watcher degradation for text health output. */
+export function formatConfigReloadHealthLine(summary: HealthSummary): string | null {
+  if (summary.configReload?.hotReloadStatus !== "disabled") {
+    return null;
+  }
+  return "Config hot reload: disabled (watcher retries exhausted; restart the gateway to restore it)";
+}
+
 const resolveHeartbeatSummary = (cfg: OpenClawConfig, agentId: string) =>
   resolveHeartbeatSummaryForAgent(cfg, agentId);
 
@@ -504,6 +513,7 @@ export async function getHealthSnapshot(params?: {
   includeSensitive?: boolean;
   runtimeSnapshot?: ChannelRuntimeSnapshot;
   eventLoop?: HealthSummary["eventLoop"];
+  configReloadHotReloadStatus?: GatewayHotReloadStatus;
 }): Promise<HealthSummary> {
   const timeoutMs = params?.timeoutMs;
   const cfg = await readRuntimeHealthConfig();
@@ -710,6 +720,9 @@ export async function getHealthSnapshot(params?: {
     ...(pluginHealth ? { plugins: pluginHealth } : {}),
     ...(contextEngineHealth ? { contextEngines: contextEngineHealth } : {}),
     ...(deliveryQueueHealth ? { deliveryQueues: deliveryQueueHealth } : {}),
+    ...(params?.configReloadHotReloadStatus
+      ? { configReload: { hotReloadStatus: params.configReloadHotReloadStatus } }
+      : {}),
     modelPricing: getGatewayModelPricingHealth({ enabled: isGatewayModelPricingEnabled(cfg) }),
     channels,
     channelOrder,
@@ -948,6 +961,10 @@ export async function healthCommand(
     const deliveryQueueLine = formatDeliveryQueueHealthLine(summary);
     if (deliveryQueueLine) {
       runtime.log(styleHealthChannelLine(deliveryQueueLine, rich));
+    }
+    const configReloadLine = formatConfigReloadHealthLine(summary);
+    if (configReloadLine) {
+      runtime.log(styleHealthChannelLine(configReloadLine, rich));
     }
     for (const plugin of displayPlugins) {
       const channelSummary = summary.channels?.[plugin.id];

--- a/src/commands/health.types.ts
+++ b/src/commands/health.types.ts
@@ -70,7 +70,7 @@ type ModelPricingHealthSummary =
 
 /** Config hot-reload watcher status, present only when a reloader is running. */
 export type ConfigReloadHealthSummary = {
-  hotReloadStatus: import("../gateway/config-reload.js").GatewayHotReloadStatus;
+  hotReloadStatus: import("../gateway/config-reload-status.types.js").GatewayHotReloadStatus;
 };
 
 /** Full gateway health payload consumed by `openclaw health`. */

--- a/src/commands/health.types.ts
+++ b/src/commands/health.types.ts
@@ -68,6 +68,11 @@ export type DeliveryQueueHealthSummary = {
 type ModelPricingHealthSummary =
   import("../gateway/model-pricing-cache-state.js").GatewayModelPricingHealth;
 
+/** Config hot-reload watcher status, present only when a reloader is running. */
+export type ConfigReloadHealthSummary = {
+  hotReloadStatus: import("../gateway/config-reload.js").GatewayHotReloadStatus;
+};
+
 /** Full gateway health payload consumed by `openclaw health`. */
 export type HealthSummary = {
   ok: true;
@@ -78,6 +83,7 @@ export type HealthSummary = {
   contextEngines?: ContextEngineHealthSummary;
   deliveryQueues?: DeliveryQueueHealthSummary;
   modelPricing?: ModelPricingHealthSummary;
+  configReload?: ConfigReloadHealthSummary;
   channels: Record<string, ChannelHealthSummary>;
   channelOrder: string[];
   channelLabels: Record<string, string>;

--- a/src/gateway/config-reload-status.types.ts
+++ b/src/gateway/config-reload-status.types.ts
@@ -1,0 +1,9 @@
+// Leaf contract for the config hot-reload watcher's terminal status.
+// Kept separate from config-reload.ts so callers that only need the status
+// shape (health summaries, request context, runtime handles) do not pull in
+// the full config-reload implementation.
+
+// Hot-reload stays "active" while a watcher is live. It flips to "disabled" only
+// after watcher re-creation fails past the retry budget, so operators/callers
+// can detect silent degradation instead of assuming reloads still fire.
+export type GatewayHotReloadStatus = "active" | "disabled";

--- a/src/gateway/config-reload.ts
+++ b/src/gateway/config-reload.ts
@@ -20,6 +20,7 @@ import {
   type GatewayReloadPlan,
 } from "./config-reload-plan.js";
 import { resolveGatewayReloadSettings } from "./config-reload-settings.js";
+import type { GatewayHotReloadStatus } from "./config-reload-status.types.js";
 
 export {
   buildGatewayReloadPlan,
@@ -89,11 +90,6 @@ function isNoopReloadPlan(plan: GatewayReloadPlan): boolean {
     plan.restartChannels.size === 0
   );
 }
-
-// Hot-reload stays "active" while a watcher is live. It flips to "disabled" only
-// after watcher re-creation fails past the retry budget, so operators/callers
-// can detect silent degradation instead of assuming reloads still fire.
-export type GatewayHotReloadStatus = "active" | "disabled";
 
 type GatewayConfigReloader = {
   stop: () => Promise<void>;

--- a/src/gateway/server-methods/health.ts
+++ b/src/gateway/server-methods/health.ts
@@ -6,7 +6,7 @@ import { buildDeliveryQueueHealthSummary } from "../../commands/health.js";
 import type { ChannelHealthSummary, HealthSummary } from "../../commands/health.types.js";
 import { getStatusSummary } from "../../commands/status.js";
 import { listContextEngineQuarantines } from "../../context-engine/registry.js";
-import type { GatewayHotReloadStatus } from "../config-reload.js";
+import type { GatewayHotReloadStatus } from "../config-reload-status.types.js";
 import { getGatewayModelPricingHealth } from "../model-pricing-cache-state.js";
 import type { ChannelRuntimeSnapshot } from "../server-channel-runtime.types.js";
 import { HEALTH_REFRESH_INTERVAL_MS } from "../server-constants.js";

--- a/src/gateway/server-methods/health.ts
+++ b/src/gateway/server-methods/health.ts
@@ -6,6 +6,7 @@ import { buildDeliveryQueueHealthSummary } from "../../commands/health.js";
 import type { ChannelHealthSummary, HealthSummary } from "../../commands/health.types.js";
 import { getStatusSummary } from "../../commands/status.js";
 import { listContextEngineQuarantines } from "../../context-engine/registry.js";
+import type { GatewayHotReloadStatus } from "../config-reload.js";
 import { getGatewayModelPricingHealth } from "../model-pricing-cache-state.js";
 import type { ChannelRuntimeSnapshot } from "../server-channel-runtime.types.js";
 import { HEALTH_REFRESH_INTERVAL_MS } from "../server-constants.js";
@@ -92,6 +93,7 @@ function cachedHealthDiffersFromRuntime(
 function mergeCachedHealthRuntimeState(params: {
   cached: HealthSummary;
   eventLoop?: HealthSummary["eventLoop"];
+  configReloadHotReloadStatus?: GatewayHotReloadStatus;
 }): HealthSummary {
   const {
     contextEngines: _cachedContextEngines,
@@ -122,6 +124,9 @@ function mergeCachedHealthRuntimeState(params: {
       ? { contextEngines: { quarantined: quarantinedContextEngines } }
       : {}),
     ...(deliveryQueues ? { deliveryQueues } : {}),
+    ...(params.configReloadHotReloadStatus
+      ? { configReload: { hotReloadStatus: params.configReloadHotReloadStatus } }
+      : {}),
     modelPricing: getGatewayModelPricingHealth({
       enabled: params.cached.modelPricing?.state !== "disabled",
     }),
@@ -159,6 +164,7 @@ export const healthHandlers: GatewayRequestHandlers = {
         mergeCachedHealthRuntimeState({
           cached,
           eventLoop: context.getEventLoopHealth?.(),
+          configReloadHotReloadStatus: context.getConfigReloaderHotReloadStatus?.(),
         }),
         undefined,
         { cached: true },

--- a/src/gateway/server-methods/server-methods.test.ts
+++ b/src/gateway/server-methods/server-methods.test.ts
@@ -4962,6 +4962,87 @@ describe("gateway healthHandlers.health cache freshness", () => {
     }
   });
 
+  it("merges a live disabled config hot-reload status into cached health responses", async () => {
+    const cached = {
+      ok: true,
+      ts: Date.now(),
+      durationMs: 1,
+      channels: {},
+      channelOrder: [],
+      channelLabels: {},
+      heartbeatSeconds: 0,
+      defaultAgentId: "main",
+      agents: [],
+      sessions: { path: "/tmp/sessions.json", count: 0, recent: [] },
+      configReload: { hotReloadStatus: "active" },
+    };
+    const respond = vi.fn();
+    const refreshHealthSnapshot = vi.fn().mockResolvedValue(cached);
+    const getConfigReloaderHotReloadStatus = vi.fn(() => "disabled" as const);
+
+    await healthHandlers.health({
+      req: {} as never,
+      params: {} as never,
+      respond: respond as never,
+      context: {
+        getHealthCache: () => cached,
+        refreshHealthSnapshot,
+        getRuntimeSnapshot: () => ({ channels: {}, channelAccounts: {} }),
+        getConfigReloaderHotReloadStatus,
+        logHealth: { error: vi.fn() },
+      } as never,
+      client: { connect: { role: "operator", scopes: ["operator.read"] } } as never,
+      isWebchatConnect: () => false,
+    });
+
+    const payload = mockCallArg(respond, 0, 1) as
+      | { configReload?: { hotReloadStatus?: string } }
+      | undefined;
+    // The cache-hit merge must reflect the live "disabled" flip immediately,
+    // not the stale "active" value from the cached snapshot — otherwise
+    // operators wait up to HEALTH_REFRESH_INTERVAL_MS to see a watcher that
+    // has already permanently given up.
+    expect(payload?.configReload?.hotReloadStatus).toBe("disabled");
+    expect(mockCallArg(respond, 0, 3)).toEqual({ cached: true });
+  });
+
+  it("preserves the cached config hot-reload status when no live accessor is available", async () => {
+    const cached = {
+      ok: true,
+      ts: Date.now(),
+      durationMs: 1,
+      channels: {},
+      channelOrder: [],
+      channelLabels: {},
+      heartbeatSeconds: 0,
+      defaultAgentId: "main",
+      agents: [],
+      sessions: { path: "/tmp/sessions.json", count: 0, recent: [] },
+      configReload: { hotReloadStatus: "disabled" },
+    };
+    const respond = vi.fn();
+    const refreshHealthSnapshot = vi.fn().mockResolvedValue(cached);
+
+    await healthHandlers.health({
+      req: {} as never,
+      params: {} as never,
+      respond: respond as never,
+      context: {
+        getHealthCache: () => cached,
+        refreshHealthSnapshot,
+        getRuntimeSnapshot: () => ({ channels: {}, channelAccounts: {} }),
+        logHealth: { error: vi.fn() },
+      } as never,
+      client: { connect: { role: "operator", scopes: ["operator.read"] } } as never,
+      isWebchatConnect: () => false,
+    });
+
+    const payload = mockCallArg(respond, 0, 1) as
+      | { configReload?: { hotReloadStatus?: string } }
+      | undefined;
+    expect(payload?.configReload?.hotReloadStatus).toBe("disabled");
+  });
+
   it("refreshes cached health when a runtime account is missing from the cached account summary", async () => {
     const cached = {
       ok: true,

--- a/src/gateway/server-methods/shared-types.ts
+++ b/src/gateway/server-methods/shared-types.ts
@@ -15,6 +15,7 @@ import type { createSubsystemLogger } from "../../logging/subsystem.js";
 import type { WizardSession } from "../../wizard/session.js";
 import type { AgentRuntimeIdentity } from "../agent-runtime-identity-token.js";
 import type { ChatAbortControllerEntry } from "../chat-abort.js";
+import type { GatewayHotReloadStatus } from "../config-reload.js";
 import type { ExecApprovalManager, ExecApprovalRecord } from "../exec-approval-manager.js";
 import type { GatewayMethodRegistryView } from "../methods/descriptor.js";
 import type { NodeRegistry } from "../node-registry.js";
@@ -140,6 +141,7 @@ export type GatewayRequestContext = {
   purgeWizardSession: (id: string) => void;
   getRuntimeSnapshot: () => ChannelRuntimeSnapshot;
   getEventLoopHealth?: () => GatewayEventLoopHealth | undefined;
+  getConfigReloaderHotReloadStatus?: () => GatewayHotReloadStatus | undefined;
   startChannel: (
     channel: import("../../channels/plugins/types.public.js").ChannelId,
     accountId?: string,

--- a/src/gateway/server-methods/shared-types.ts
+++ b/src/gateway/server-methods/shared-types.ts
@@ -15,7 +15,7 @@ import type { createSubsystemLogger } from "../../logging/subsystem.js";
 import type { WizardSession } from "../../wizard/session.js";
 import type { AgentRuntimeIdentity } from "../agent-runtime-identity-token.js";
 import type { ChatAbortControllerEntry } from "../chat-abort.js";
-import type { GatewayHotReloadStatus } from "../config-reload.js";
+import type { GatewayHotReloadStatus } from "../config-reload-status.types.js";
 import type { ExecApprovalManager, ExecApprovalRecord } from "../exec-approval-manager.js";
 import type { GatewayMethodRegistryView } from "../methods/descriptor.js";
 import type { NodeRegistry } from "../node-registry.js";

--- a/src/gateway/server-reload-handlers.hot-reload-status.test.ts
+++ b/src/gateway/server-reload-handlers.hot-reload-status.test.ts
@@ -1,0 +1,91 @@
+/**
+ * Proves `startManagedGatewayConfigReloader` forwards the underlying watcher's
+ * live `hotReloadStatus()` accessor on its returned handle instead of only
+ * `stop`. Before this test, the returned handle dropped the accessor, so
+ * `openclaw health` had no live signal to surface even though the watcher
+ * itself already tracked "active"/"disabled" correctly.
+ */
+import { describe, expect, it, vi } from "vitest";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
+import type { GatewayPluginReloadResult } from "./server-reload-handlers.js";
+import { startManagedGatewayConfigReloader } from "./server-reload-handlers.js";
+
+const hoisted = vi.hoisted(() => ({
+  hotReloadStatus: { current: "active" as "active" | "disabled" },
+  stop: vi.fn(async () => {}),
+}));
+
+vi.mock("./config-reload.js", async () => {
+  const actual = await vi.importActual<typeof import("./config-reload.js")>("./config-reload.js");
+  return {
+    ...actual,
+    startGatewayConfigReloader: vi.fn(() => ({
+      stop: hoisted.stop,
+      hotReloadStatus: () => hoisted.hotReloadStatus.current,
+    })),
+  };
+});
+
+describe("startManagedGatewayConfigReloader hotReloadStatus plumbing", () => {
+  it("forwards the live watcher accessor instead of dropping it", async () => {
+    const initialConfig = { session: { store: "/tmp/sessions.json" } } as OpenClawConfig;
+    const reloader = startManagedGatewayConfigReloader({
+      minimalTestGateway: false,
+      initialConfig,
+      initialCompareConfig: initialConfig,
+      initialInternalWriteHash: null,
+      watchPath: "/tmp/openclaw.json",
+      readSnapshot: vi.fn() as never,
+      promoteSnapshot: vi.fn(async () => true) as never,
+      subscribeToWrites: vi.fn(() => () => {}) as never,
+      deps: {} as never,
+      broadcast: vi.fn(),
+      getState: () => ({
+        hooksConfig: {} as never,
+        hookClientIpConfig: {} as never,
+        heartbeatRunner: { stop: vi.fn(), updateConfig: vi.fn() } as never,
+        cronState: {
+          cron: { start: vi.fn(async () => {}), stop: vi.fn() },
+          storePath: "/tmp/cron.json",
+          cronEnabled: false,
+        } as never,
+        channelHealthMonitor: null,
+      }),
+      setState: vi.fn(),
+      startChannel: vi.fn(async () => {}),
+      stopChannel: vi.fn(async () => {}),
+      reloadPlugins: vi.fn(
+        async (): Promise<GatewayPluginReloadResult> => ({
+          restartChannels: new Set(),
+          activeChannels: new Set(),
+        }),
+      ),
+      logHooks: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+      logChannels: { info: vi.fn(), error: vi.fn() },
+      logCron: { error: vi.fn() },
+      logReload: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+      channelManager: {} as never,
+      activateRuntimeSecrets: vi.fn(async (config: OpenClawConfig) => ({
+        sourceConfig: config,
+        config,
+        authStores: [],
+        warnings: [],
+        webTools: {},
+      })) as never,
+      resolveSharedGatewaySessionGenerationForConfig: () => undefined,
+      sharedGatewaySessionGenerationState: { current: undefined, required: null },
+      clients: [],
+    });
+
+    expect(reloader.hotReloadStatus).toBeTypeOf("function");
+    expect(reloader.hotReloadStatus?.()).toBe("active");
+
+    // Flip the underlying watcher's live state without recreating the managed
+    // handle — a copied/snapshotted value would stay stuck on "active".
+    hoisted.hotReloadStatus.current = "disabled";
+    expect(reloader.hotReloadStatus?.()).toBe("disabled");
+
+    await reloader.stop();
+    expect(hoisted.stop).toHaveBeenCalledOnce();
+  });
+});

--- a/src/gateway/server-reload-handlers.hot-reload-status.test.ts
+++ b/src/gateway/server-reload-handlers.hot-reload-status.test.ts
@@ -74,6 +74,8 @@ describe("startManagedGatewayConfigReloader hotReloadStatus plumbing", () => {
       })) as never,
       resolveSharedGatewaySessionGenerationForConfig: () => undefined,
       sharedGatewaySessionGenerationState: { current: undefined, required: null },
+      reconcileTerminalSessions: vi.fn(),
+      commitTerminalConfig: vi.fn(),
       clients: [],
     });
 

--- a/src/gateway/server-reload-handlers.ts
+++ b/src/gateway/server-reload-handlers.ts
@@ -44,6 +44,7 @@ import { resolveHooksConfig } from "./hooks.js";
 import { buildGatewayCronService, type GatewayCronState } from "./server-cron.js";
 import { applyGatewayLaneConcurrency } from "./server-lanes.js";
 import { markGatewayModelCatalogStaleForReload } from "./server-model-catalog.js";
+import type { GatewayConfigReloaderHandle } from "./server-runtime-handles.js";
 import {
   type GatewayChannelManager,
   startGatewayChannelHealthMonitor,
@@ -735,7 +736,9 @@ export function createGatewayReloadHandlers(params: GatewayReloadHandlerParams) 
   return { applyHotReload, requestGatewayRestart };
 }
 
-export function startManagedGatewayConfigReloader(params: ManagedGatewayConfigReloaderParams) {
+export function startManagedGatewayConfigReloader(
+  params: ManagedGatewayConfigReloaderParams,
+): GatewayConfigReloaderHandle {
   if (params.minimalTestGateway) {
     return { stop: async () => {} };
   }
@@ -901,5 +904,6 @@ export function startManagedGatewayConfigReloader(params: ManagedGatewayConfigRe
       abortActiveGmailRestart();
       await configReloader.stop();
     },
+    hotReloadStatus: configReloader.hotReloadStatus,
   };
 }

--- a/src/gateway/server-request-context.test.ts
+++ b/src/gateway/server-request-context.test.ts
@@ -11,12 +11,13 @@ import {
 function makeContextParams(
   overrides: Partial<GatewayRequestContextParams> = {},
 ): GatewayRequestContextParams {
-  const runtimeState: Pick<GatewayServerLiveState, "cronState"> = {
+  const runtimeState: Pick<GatewayServerLiveState, "cronState" | "configReloader"> = {
     cronState: {
       cron: { start: vi.fn(), stop: vi.fn() } as never,
       storePath: "/tmp/cron",
       cronEnabled: true,
     },
+    configReloader: { stop: vi.fn(async () => {}) },
   };
   return {
     deps: {} as never,
@@ -88,12 +89,13 @@ describe("createGatewayRequestContext", () => {
   it("reads cron state live from runtime state", () => {
     const cronA = { start: vi.fn(), stop: vi.fn() } as never;
     const cronB = { start: vi.fn(), stop: vi.fn() } as never;
-    const runtimeState: Pick<GatewayServerLiveState, "cronState"> = {
+    const runtimeState: Pick<GatewayServerLiveState, "cronState" | "configReloader"> = {
       cronState: {
         cron: cronA,
         storePath: "/tmp/cron-a",
         cronEnabled: true,
       },
+      configReloader: { stop: vi.fn(async () => {}) },
     };
 
     const context = createGatewayRequestContext(makeContextParams({ runtimeState }));
@@ -109,6 +111,33 @@ describe("createGatewayRequestContext", () => {
 
     expect(context.cron).toBe(cronB);
     expect(context.cronStorePath).toBe("/tmp/cron-b");
+  });
+
+  it("reads config hot-reload status live from runtime state", () => {
+    const runtimeState: Pick<GatewayServerLiveState, "cronState" | "configReloader"> = {
+      cronState: {
+        cron: { start: vi.fn(), stop: vi.fn() } as never,
+        storePath: "/tmp/cron",
+        cronEnabled: true,
+      },
+      configReloader: { stop: vi.fn(async () => {}) },
+    };
+
+    const context = createGatewayRequestContext(makeContextParams({ runtimeState }));
+
+    expect(context.getConfigReloaderHotReloadStatus?.()).toBeUndefined();
+
+    runtimeState.configReloader = {
+      stop: vi.fn(async () => {}),
+      hotReloadStatus: () => "active",
+    };
+    expect(context.getConfigReloaderHotReloadStatus?.()).toBe("active");
+
+    runtimeState.configReloader = {
+      stop: vi.fn(async () => {}),
+      hotReloadStatus: () => "disabled",
+    };
+    expect(context.getConfigReloaderHotReloadStatus?.()).toBe("disabled");
   });
 
   it("invalidateClientsForDevice sets the flag on matching clients without closing the socket", () => {

--- a/src/gateway/server-request-context.ts
+++ b/src/gateway/server-request-context.ts
@@ -14,7 +14,7 @@ type GatewayRequestContextClient = GatewayClient & {
 
 export type GatewayRequestContextParams = {
   deps: GatewayRequestContext["deps"];
-  runtimeState: Pick<GatewayServerLiveState, "cronState">;
+  runtimeState: Pick<GatewayServerLiveState, "cronState" | "configReloader">;
   getRuntimeConfig: GatewayRequestContext["getRuntimeConfig"];
   resolveTerminalLaunchPolicy: GatewayRequestContext["resolveTerminalLaunchPolicy"];
   isTerminalEnabled: GatewayRequestContext["isTerminalEnabled"];
@@ -212,6 +212,7 @@ export function createGatewayRequestContext(
     purgeWizardSession: params.purgeWizardSession,
     getRuntimeSnapshot: params.getRuntimeSnapshot,
     getEventLoopHealth: params.getEventLoopHealth,
+    getConfigReloaderHotReloadStatus: () => params.runtimeState.configReloader.hotReloadStatus?.(),
     startChannel: params.startChannel,
     stopChannel: params.stopChannel,
     markChannelLoggedOut: params.markChannelLoggedOut,

--- a/src/gateway/server-runtime-handles.ts
+++ b/src/gateway/server-runtime-handles.ts
@@ -3,7 +3,7 @@
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import type { HeartbeatRunner } from "../infra/heartbeat-runner.js";
 import type { ChannelHealthMonitor } from "./channel-health-monitor.js";
-import type { GatewayHotReloadStatus } from "./config-reload.js";
+import type { GatewayHotReloadStatus } from "./config-reload-status.types.js";
 import type { GatewayPostReadySidecarHandle } from "./server-startup-post-attach.js";
 
 // Mutable server handles track timers, sidecars, subscriptions, and service

--- a/src/gateway/server-runtime-handles.ts
+++ b/src/gateway/server-runtime-handles.ts
@@ -3,12 +3,17 @@
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import type { HeartbeatRunner } from "../infra/heartbeat-runner.js";
 import type { ChannelHealthMonitor } from "./channel-health-monitor.js";
+import type { GatewayHotReloadStatus } from "./config-reload.js";
 import type { GatewayPostReadySidecarHandle } from "./server-startup-post-attach.js";
 
 // Mutable server handles track timers, sidecars, subscriptions, and service
 // cleanup hooks that shutdown/reload code must stop exactly once.
-type GatewayConfigReloaderHandle = {
+// `hotReloadStatus` is omitted (not defaulted to "active") when no real
+// watcher is running, so health can distinguish "no reloader" from "reloader
+// active" instead of guessing.
+export type GatewayConfigReloaderHandle = {
   stop: () => Promise<void>;
+  hotReloadStatus?: () => GatewayHotReloadStatus;
 };
 
 /** Mutable handles owned by a running gateway server process. */

--- a/src/gateway/server.impl.ts
+++ b/src/gateway/server.impl.ts
@@ -1027,6 +1027,7 @@ export async function startGatewayServer(
       ...optsResult,
       getRuntimeSnapshot,
       getEventLoopHealth: readinessEventLoopHealth.snapshot,
+      getConfigReloaderHotReloadStatus: () => runtimeState?.configReloader.hotReloadStatus?.(),
     });
   const stopRegisteredPostReadySidecars = async () => {
     const postReadySidecars = runtimeState.postReadySidecars;

--- a/src/gateway/server/health-state.test.ts
+++ b/src/gateway/server/health-state.test.ts
@@ -18,6 +18,7 @@ function healthSnapshotCallArg(index = 0) {
         includeSensitive?: boolean;
         probe?: boolean;
         runtimeSnapshot?: unknown;
+        configReloadHotReloadStatus?: unknown;
       }
     | undefined;
 }
@@ -101,6 +102,25 @@ describe("refreshGatewayHealthSnapshot", () => {
     expect(getHealthSnapshotMock).toHaveBeenCalledTimes(2);
     expect(healthSnapshotCallArg()?.eventLoop).toBe(eventLoop);
     expect(Object.hasOwn(healthSnapshotCallArg(1) ?? {}, "eventLoop")).toBe(false);
+  });
+
+  it("passes the config reloader hot-reload status only when the hook returns one", async () => {
+    const healthState = await loadHealthState();
+
+    await healthState.refreshGatewayHealthSnapshot({
+      probe: false,
+      getConfigReloaderHotReloadStatus: () => "disabled",
+    });
+    await healthState.refreshGatewayHealthSnapshot({
+      probe: true,
+      getConfigReloaderHotReloadStatus: () => undefined,
+    });
+
+    expect(getHealthSnapshotMock).toHaveBeenCalledTimes(2);
+    expect(healthSnapshotCallArg()?.configReloadHotReloadStatus).toBe("disabled");
+    expect(Object.hasOwn(healthSnapshotCallArg(1) ?? {}, "configReloadHotReloadStatus")).toBe(
+      false,
+    );
   });
 
   it("captures runtime snapshots for completed refreshes and guards snapshot failures", async () => {

--- a/src/gateway/server/health-state.ts
+++ b/src/gateway/server/health-state.ts
@@ -9,6 +9,7 @@ import { listSystemPresence } from "../../infra/system-presence.js";
 import { getUpdateAvailable } from "../../infra/update-startup.js";
 import { normalizeMainKey } from "../../routing/session-key.js";
 import { resolveGatewayAuth } from "../auth.js";
+import type { GatewayHotReloadStatus } from "../config-reload.js";
 import type { ChannelRuntimeSnapshot } from "../server-channel-runtime.types.js";
 import type { GatewayEventLoopHealth } from "./event-loop-health.js";
 
@@ -79,6 +80,7 @@ export async function refreshGatewayHealthSnapshot(opts?: {
   includeSensitive?: boolean;
   getRuntimeSnapshot?: () => ChannelRuntimeSnapshot;
   getEventLoopHealth?: () => GatewayEventLoopHealth | undefined;
+  getConfigReloaderHotReloadStatus?: () => GatewayHotReloadStatus | undefined;
 }) {
   const includeSensitive = opts?.includeSensitive === true;
   let refresh = includeSensitive ? sensitiveHealthRefresh : healthRefresh;
@@ -91,11 +93,13 @@ export async function refreshGatewayHealthSnapshot(opts?: {
         runtimeSnapshot = undefined;
       }
       const eventLoop = opts?.getEventLoopHealth?.();
+      const configReloadHotReloadStatus = opts?.getConfigReloaderHotReloadStatus?.();
       const snap = await getHealthSnapshot({
         probe: opts?.probe,
         includeSensitive,
         runtimeSnapshot,
         ...(eventLoop ? { eventLoop } : {}),
+        ...(configReloadHotReloadStatus ? { configReloadHotReloadStatus } : {}),
       });
       if (!includeSensitive) {
         healthCache = snap;

--- a/src/gateway/server/health-state.ts
+++ b/src/gateway/server/health-state.ts
@@ -9,7 +9,7 @@ import { listSystemPresence } from "../../infra/system-presence.js";
 import { getUpdateAvailable } from "../../infra/update-startup.js";
 import { normalizeMainKey } from "../../routing/session-key.js";
 import { resolveGatewayAuth } from "../auth.js";
-import type { GatewayHotReloadStatus } from "../config-reload.js";
+import type { GatewayHotReloadStatus } from "../config-reload-status.types.js";
 import type { ChannelRuntimeSnapshot } from "../server-channel-runtime.types.js";
 import type { GatewayEventLoopHealth } from "./event-loop-health.js";
 


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where operators running a managed gateway would keep working
with a silently disabled config hot-reload watcher. #92027 and #92852
(both merged) taught the watcher to retry past transient native/polling
errors and record a terminal `"disabled"` status once retries are
exhausted, but that status was discarded at the managed-reloader boundary
and never reached `openclaw health`. An operator editing `openclaw.json`
and expecting a hot reload would see nothing happen, with no way to tell
"the gateway ignored this edit" apart from "the edit produced a no-op
reload plan."

## Why This Change Was Made

The watcher already computes the right terminal state; this change is pure
plumbing to surface it, not new reload policy.

**Changed surface:**
- `src/gateway/server-runtime-handles.ts` / `src/gateway/server-reload-handlers.ts`
  — `GatewayConfigReloaderHandle` gains an optional `hotReloadStatus()`
  accessor alongside `stop()`; `startManagedGatewayConfigReloader` returns
  the watcher's real accessor instead of a handle that only exposes `stop`.
- `src/commands/health.types.ts` / `src/commands/health.ts` — new optional
  `HealthSummary.configReload.hotReloadStatus` field + a text-output line
  that only prints on `"disabled"`.
- `src/gateway/server.impl.ts` / `src/gateway/server/health-state.ts` /
  `src/gateway/server-methods/shared-types.ts` /
  `src/gateway/server-request-context.ts` / `src/gateway/server-methods/health.ts`
  — thread the live accessor through both the full-refresh path and the
  cache-hit merge path (one new `GatewayRequestContext` getter, wired at the
  single `createGatewayRequestContext` call site).

Each layer above exists because the health RPC has two independent response
paths (full refresh vs. cache-hit merge), and both already carry other live
runtime facts (`eventLoop`, `modelPricing`, `contextEngines`) the same way —
this change reuses that existing plumbing pattern rather than adding a new
one. No generic "conditions" abstraction was introduced because there is
exactly one signal to surface today; a future second signal would be the
trigger to generalize.

`configReload.hotReloadStatus` follows the existing `modelPricing`/
`contextEngines` sibling pattern: the JSON field is present whenever a real
reloader is running (`"active"` or `"disabled"`), and omitted only when
there is no reloader at all (`minimalTestGateway`, pre-startup inert state).
Text output additionally suppresses the `"active"` case and only prints a
line on `"disabled"`, matching how `formatModelPricingHealthLine` and
`formatContextEngineHealthLine` stay silent on the healthy/ok case.

Non-goals: no new persisted state (the field is derived, not stored), no
doctor repair (this surfaces existing in-memory watcher state, not a
migratable config shape), no generic "conditions" enum (see above), no
change to reload/retry policy.

## User Impact

Operators can now run `openclaw health` (text or `--json`) and see `Config
hot reload: disabled (watcher retries exhausted; restart the gateway to
restore it)` when the gateway's config watcher has permanently given up,
instead of silently continuing to run on stale config with no visible
signal. The status is fresh on every call, including cache-hit responses,
so it's visible immediately rather than after a cache refresh delay.
`--json` includes `configReload.hotReloadStatus` whenever a reloader is
running, whether `"active"` or `"disabled"`; text output only prints a line
for the `"disabled"` case, so the common healthy case stays quiet. The
field is omitted entirely only when no reloader exists at all (e.g.
minimal/test gateways).

## Evidence

**Production-path health capture**:
- Booted a real gateway on this branch (isolated `OPENCLAW_STATE_DIR`/
  `OPENCLAW_CONFIG_PATH`/port, `gateway.auth.mode=none`, channels/providers
  skipped so no real credentials were needed) and ran `openclaw health
  --json`; the response included `"configReload":{"hotReloadStatus":"active"}`.
  This validates the `"active"` plumbing end to end through the real
  production chain (real `startGatewayConfigReloader` →
  `runtimeState.configReloader` → `GatewayRequestContext` →
  `healthHandlers.health` → JSON output), not just a mocked/unit-test path.
- This capture does **not** by itself validate the `"disabled"` path in a
  running production gateway — that terminal transition is covered
  separately by `src/gateway/config-reload.test.ts`'s existing real-watcher
  retry/polling exhaustion test (cited below), not a live capture. Forcing
  real chokidar/inotify exhaustion in a production-path capture would be
  flaky and wasn't attempted.

**Existing signal proof (unchanged, cited not duplicated):**
`src/gateway/config-reload.test.ts:1675` — `"degrades to polling then
disables after both native and polling retries are exhausted"` — already
proves `hotReloadStatus()` flips `"active"` → `"disabled"` after native +
polling retries are exhausted (introduced by #92027/#92852).

**New plumbing proof** (`src/gateway/server-reload-handlers.hot-reload-status.test.ts`):
mocks `startGatewayConfigReloader` to return a controllable live accessor,
then proves `startManagedGatewayConfigReloader(...).hotReloadStatus` is a
function that reflects a live mutation of the underlying watcher's status
(`"active"` → `"disabled"`) without recreating the managed handle — this is
exactly the regression a copied/snapshotted value would fail.

**New health summary proof** (`src/commands/health.snapshot.test.ts`):
- `"omits configReload when no config reloader status is supplied"`
- `"surfaces a disabled config hot-reload watcher in the health snapshot"`

**New health-state passthrough proof** (`src/gateway/server/health-state.test.ts`):
- `"passes the config reloader hot-reload status only when the hook returns one"`
  (mirrors the existing `getEventLoopHealth` passthrough test)

**New cache-hit freshness proof** (`src/gateway/server-methods/server-methods.test.ts`,
`describe("gateway healthHandlers.health cache freshness")`):
- `"merges a live disabled config hot-reload status into cached health responses"`
  — cached snapshot says `"active"`, live accessor says `"disabled"`; the
  cache-hit response (`{ cached: true }`) reflects `"disabled"` immediately
- `"preserves the cached config hot-reload status when no live accessor is
  available"` — no getter on context → last cached value survives unchanged

**New live request-context read proof** (`src/gateway/server-request-context.test.ts`):
- `"reads config hot-reload status live from runtime state"` — proves
  `context.getConfigReloaderHotReloadStatus()` reflects live mutation of
  `runtimeState.configReloader` at the single wiring site, mirroring the
  existing live `cron` / `cronStorePath` request-context read tests.

**New CLI output proof** (`src/commands/health.test.ts`):
- `formatConfigReloadHealthLine` unit tests: disabled → line text, active →
  `null`, absent → `null`
- `"surfaces a disabled config hot-reload watcher in JSON output"`
- `"prints the config hot-reload disabled line in text output"`
- `"omits the config hot-reload line in text output when the reloader is active"`

**Validation run (worktree `repo/worktrees/config-hot-reload-health-status`,
`node scripts/run-vitest.mjs`, rebased onto upstream/main
`dad7768da8500d1c785ef33e19aabee9d01081bd`):**
- `src/gateway/config-reload.test.ts` — 304/304 passed
- `src/gateway/server-reload-handlers.test.ts` +
  `src/gateway/server-reload-handlers.hot-reload-status.test.ts` +
  `src/gateway/server-request-context.test.ts` +
  `src/gateway/server-methods/server-methods.test.ts` +
  `src/gateway/server/health-state.test.ts` (gateway config project,
  15 files) — 553/553 passed
- `src/commands/health.test.ts` + `src/commands/health.snapshot.test.ts` —
  35/35 passed
- `pnpm exec oxfmt --check` on all touched files — clean
- `node scripts/run-oxlint.mjs` on all touched files — clean
- `node scripts/run-tsgo.mjs -p tsconfig.core.json` (prod typecheck) — clean
- `node scripts/run-tsgo.mjs -p test/tsconfig/tsconfig.core.test.json` (test
  typecheck) — clean
- `node --import tsx scripts/check-import-cycles.ts` — 0 runtime value cycles

No live/E2E proof was added beyond the production-path capture above: this
is plumbing of an already-tested terminal state through existing accessor
boundaries, not new watcher/chokidar behavior, so no OS-specific or
timing-sensitive CI test was introduced per repo guidance against flaky
watcher tests in CI.

**Precheck note**
- `ocw review precheck config-hot-reload-health-status` reached the broad
  `gateway-server` Vitest lane but failed in pre-existing shared-lane tests
  unrelated to this branch.
- Minimal reproducer with zero files from this branch:
  `node scripts/run-vitest.mjs run --config test/vitest/vitest.gateway-server.config.ts src/gateway/server.health.test.ts src/gateway/server-startup-log.test.ts`
  reproduces the same `server-startup-log.test.ts` warning failures.
- The reproducer files and root-cause helper are byte-identical to
  `upstream/main`; this branch does not touch them.
- Root cause: `src/gateway/test-helpers.mocks.ts` mutates
  `process.env.OPENCLAW_SKIP_CHANNELS = "1"` at module top level without
  cleanup, then leaks across the non-isolated gateway-server project
  depending on file order.
- This branch's own focused tests, typecheck, lint, import-cycle checks,
  and production-path health capture all passed.
