### PR TITLE
fix(zalo): match native bot identity fields

### DIFF
--- a/extensions/zalo/src/api.test.ts
+++ b/extensions/zalo/src/api.test.ts
@@ -76,6 +76,28 @@ describe("Zalo API request methods", () => {
     });
   });
 
+  it("accepts the native Zalo getMe identity fields", async () => {
+    const fetcher: ZaloFetch = vi.fn(async () =>
+      Response.json({
+        ok: true,
+        result: {
+          account_name: "bot.example",
+          account_type: "BASIC",
+          can_join_groups: false,
+          id: "1459232241454765289",
+        },
+      }),
+    );
+
+    await expect(getMe("test-token", undefined, fetcher)).resolves.toMatchObject({
+      result: {
+        account_name: "bot.example",
+        account_type: "BASIC",
+        can_join_groups: false,
+      },
+    });
+  });
+
   it("uses POST for getWebhookInfo", async () => {
     await expectPostJsonRequest(getWebhookInfo);
   });

--- a/extensions/zalo/src/api.ts
+++ b/extensions/zalo/src/api.ts
@@ -21,8 +21,9 @@ export type ZaloApiResponse<T = unknown> = {
 
 export type ZaloBotInfo = {
   id: string;
-  name: string;
-  avatar?: string;
+  account_name: string;
+  account_type: string;
+  can_join_groups: boolean;
 };
 
 export type ZaloMessage = {

--- a/extensions/zalo/src/channel.runtime.ts
+++ b/extensions/zalo/src/channel.runtime.ts
@@ -54,7 +54,7 @@ export async function startZaloGatewayAccount(
   const fetcher = resolveZaloProxyFetch(account.config.proxy);
   try {
     const probe = await probeZalo(token, 2500, fetcher);
-    const name = probe.ok ? probe.bot?.name?.trim() : null;
+    const name = probe.ok ? probe.bot?.account_name?.trim() : null;
     if (name) {
       zaloBotLabel = ` (${name})`;
     }


### PR DESCRIPTION
## Summary

- align `ZaloBotInfo` with the official Zalo Bot Platform `getMe` response
- use `account_name` for the gateway startup label
- cover the documented `id`, `account_name`, `account_type`, and `can_join_groups` fields

Official contract: https://bot.zapps.me/docs/apis/getMe/

## Stack

- #98768 will be restacked on this PR and retain the alternate API-root work

## Tests

- `node scripts/run-vitest.mjs extensions/zalo/src/api.test.ts`
- `pnpm format:check extensions/zalo/src/api.ts extensions/zalo/src/api.test.ts extensions/zalo/src/channel.runtime.ts`
- `git diff --check`
- `.agents/skills/autoreview/scripts/autoreview --mode branch --stream-engine-output` (clean, no actionable findings)
