### PR TITLE
fix(memory-wiki): source imports crash on unreadable pages

### DIFF
--- a/extensions/memory-wiki/src/ingest.ts
+++ b/extensions/memory-wiki/src/ingest.ts
@@ -40,12 +40,28 @@ function assertUtf8Text(buffer: Buffer, sourcePath: string): string {
   return buffer.toString("utf8");
 }
 
+function isEmptyExistingSourcePage(error: unknown): boolean {
+  return (
+    !!error &&
+    typeof error === "object" &&
+    ((error as NodeJS.ErrnoException).code === "ENOENT" ||
+      (error as NodeJS.ErrnoException).code === "EISDIR")
+  );
+}
+
 async function readExistingSourcePage(pagePath: string): Promise<string> {
-  try {
-    return await fs.readFile(pagePath, "utf8");
-  } catch {
-    return await fs.readFile(pagePath, "utf8");
+  let readError: unknown;
+  for (let attempt = 0; attempt < 2; attempt += 1) {
+    try {
+      return await fs.readFile(pagePath, "utf8");
+    } catch (error) {
+      readError = error;
+    }
   }
+  if (isEmptyExistingSourcePage(readError)) {
+    return "";
+  }
+  throw readError;
 }
 
 export async function ingestMemoryWikiSource(params: {

--- a/extensions/memory-wiki/src/source-page-shared.ts
+++ b/extensions/memory-wiki/src/source-page-shared.ts
@@ -13,15 +13,23 @@ import { writeGuardedVaultPage } from "./vault-page-write.js";
 type ImportedSourceState = Parameters<typeof shouldSkipImportedSourceWrite>[0]["state"];
 type VaultRoot = Awaited<ReturnType<typeof fsRoot>>;
 
+function isUnreadableImportedSourcePage(error: unknown): boolean {
+  return error instanceof FsSafeError && (error.code === "not-file" || error.code === "hardlink");
+}
+
 async function readExistingImportedSourcePage(vault: VaultRoot, pagePath: string): Promise<string> {
-  try {
-    return await vault.readText(pagePath);
-  } catch (error) {
-    if (error instanceof FsSafeError && (error.code === "not-file" || error.code === "hardlink")) {
-      return "";
+  let readError: unknown;
+  for (let attempt = 0; attempt < 2; attempt += 1) {
+    try {
+      return await vault.readText(pagePath);
+    } catch (error) {
+      readError = error;
     }
-    return await vault.readText(pagePath);
   }
+  if (isUnreadableImportedSourcePage(readError)) {
+    return "";
+  }
+  throw readError;
 }
 
 export async function writeImportedSourcePage(params: {

--- a/extensions/memory-wiki/src/wiki-notes-read-retry.test.ts
+++ b/extensions/memory-wiki/src/wiki-notes-read-retry.test.ts
@@ -238,6 +238,130 @@ describe("memory-wiki existing-page read retry", () => {
     }
   });
 
+  it("leaves imported source pages unchanged after a persistent existing-page read failure", async () => {
+    const suiteRoot = await fs.mkdtemp(path.join(os.tmpdir(), "memory-wiki-source-page-"));
+    const sourcePath = path.join(suiteRoot, "imported-persistent.txt");
+    const pagePath = "sources/imported-persistent.md";
+    const absPage = path.join(suiteRoot, pagePath);
+    const state: Parameters<typeof writeImportedSourcePage>[0]["state"] = {
+      entries: {},
+      version: 1,
+    };
+
+    try {
+      await fs.writeFile(sourcePath, "first body", "utf8");
+      await writeImportedSourcePage({
+        vaultRoot: suiteRoot,
+        syncKey: "bridge:imported-persistent",
+        sourcePath,
+        sourceUpdatedAtMs: Date.UTC(2026, 4, 1),
+        sourceSize: 10,
+        renderFingerprint: "fp-1",
+        pagePath,
+        group: "bridge",
+        state,
+        buildRendered: buildSourcePage,
+      });
+      const before = await fs.readFile(absPage, "utf8");
+
+      securityRuntimeMock.failReadTextAlwaysFor = pagePath;
+
+      await fs.writeFile(sourcePath, "second body changed", "utf8");
+      await expect(
+        writeImportedSourcePage({
+          vaultRoot: suiteRoot,
+          syncKey: "bridge:imported-persistent",
+          sourcePath,
+          sourceUpdatedAtMs: Date.UTC(2026, 4, 2),
+          sourceSize: 19,
+          renderFingerprint: "fp-2",
+          pagePath,
+          group: "bridge",
+          state,
+          buildRendered: buildSourcePage,
+        }),
+      ).rejects.toThrow("persistent existing-page read failure");
+
+      expect(securityRuntimeMock.readTextFailureInjected).toBe(true);
+      await expect(fs.readFile(absPage, "utf8")).resolves.toBe(before);
+    } finally {
+      await fs.rm(suiteRoot, { recursive: true, force: true });
+    }
+  });
+
+  it("updates ingested source pages when the existing page stays missing across retry", async () => {
+    const rootDir = await createTempDir("memory-wiki-reingest-persistent-read-");
+    const inputPath = path.join(rootDir, "roadmap.txt");
+    const { config } = await createVault({ rootDir: path.join(rootDir, "vault") });
+
+    await fs.writeFile(inputPath, "v1 content\n", "utf8");
+    await ingestMemoryWikiSource({
+      config,
+      inputPath,
+      nowMs: Date.UTC(2026, 3, 5, 12, 0, 0),
+    });
+
+    const pagePath = path.join(config.vault.path, "sources", "roadmap.md");
+    await fs.writeFile(inputPath, "v2 content updated\n", "utf8");
+    const originalReadFile = fs.readFile.bind(fs);
+    let remainingExistingPageReadFailures = 2;
+    vi.spyOn(fs, "readFile").mockImplementation(
+      async (...args: Parameters<typeof fs.readFile>): ReturnType<typeof fs.readFile> => {
+        if (remainingExistingPageReadFailures > 0 && args[0] === pagePath && args[1] === "utf8") {
+          remainingExistingPageReadFailures -= 1;
+          throw Object.assign(new Error("page disappeared"), { code: "ENOENT" });
+        }
+        return originalReadFile(...args);
+      },
+    );
+
+    const result = await ingestMemoryWikiSource({
+      config,
+      inputPath,
+      nowMs: Date.UTC(2026, 3, 6, 12, 0, 0),
+    });
+
+    expect(result.created).toBe(false);
+    expect(remainingExistingPageReadFailures).toBe(0);
+    await expect(originalReadFile(pagePath, "utf8")).resolves.toContain("v2 content updated");
+  });
+
+  it("leaves ingested source pages unchanged after a persistent existing-page read failure", async () => {
+    const rootDir = await createTempDir("memory-wiki-reingest-persistent-read-");
+    const inputPath = path.join(rootDir, "roadmap.txt");
+    const { config } = await createVault({ rootDir: path.join(rootDir, "vault") });
+
+    await fs.writeFile(inputPath, "v1 content\n", "utf8");
+    await ingestMemoryWikiSource({
+      config,
+      inputPath,
+      nowMs: Date.UTC(2026, 3, 5, 12, 0, 0),
+    });
+
+    const pagePath = path.join(config.vault.path, "sources", "roadmap.md");
+    const before = await fs.readFile(pagePath, "utf8");
+    await fs.writeFile(inputPath, "v2 content updated\n", "utf8");
+    const originalReadFile = fs.readFile.bind(fs);
+    vi.spyOn(fs, "readFile").mockImplementation(
+      async (...args: Parameters<typeof fs.readFile>): ReturnType<typeof fs.readFile> => {
+        if (args[0] === pagePath && args[1] === "utf8") {
+          throw Object.assign(new Error("resource busy"), { code: "EBUSY" });
+        }
+        return originalReadFile(...args);
+      },
+    );
+
+    await expect(
+      ingestMemoryWikiSource({
+        config,
+        inputPath,
+        nowMs: Date.UTC(2026, 3, 6, 12, 0, 0),
+      }),
+    ).rejects.toMatchObject({ code: "EBUSY" });
+
+    await expect(originalReadFile(pagePath, "utf8")).resolves.toBe(before);
+  });
+
   it("preserves synthesis notes and frontmatter after a transient existing-page read failure", async () => {
     const { rootDir, config } = await createVault({ prefix: "memory-wiki-apply-read-retry-" });
 


### PR DESCRIPTION
Related: #98360

## What Problem This Solves

Fixes an issue where users syncing memory-wiki source pages could hit crashes when an existing source page could not be read on the retry path.

## Why This Change Was Made

The source-page readers now keep the one-shot retry for transient page replacement races, but only treat true empty/no-content cases as blank pages. Persistent read failures fail closed so existing human notes and page edits are not silently overwritten.

## User Impact

Memory-wiki bridge and local source imports can recover from missing or non-file page collisions without regressing the note-preservation behavior added for transient read races.

## Evidence

- `node scripts/run-vitest.mjs extensions/memory-wiki/src/wiki-notes-read-retry.test.ts extensions/memory-wiki/src/source-page-shared.test.ts extensions/memory-wiki/src/ingest.test.ts extensions/memory-wiki/src/bridge.test.ts --reporter=verbose`
  - 4 files passed
  - 25 tests passed
- `.agents/skills/autoreview/scripts/autoreview --mode local`
  - clean: no accepted/actionable findings
