### PR TITLE
fix(mcp): bound HTTP response body reads at 16 MiB

### DIFF
--- a/src/agents/mcp-http-fetch.test.ts
+++ b/src/agents/mcp-http-fetch.test.ts
@@ -245,4 +245,69 @@ describe("MCP HTTP fetch helpers", () => {
     expect(error.message).toContain("bad redirect");
     expect(error.message).not.toContain("[object Response]");
   });
+
+  it("rejects body-less responses whose Content-Length exceeds the 16 MiB cap", async () => {
+    testGlobal[TEST_UNDICI_RUNTIME_DEPS_KEY] = {
+      Agent: TestAgent,
+      EnvHttpProxyAgent: TestEnvHttpProxyAgent,
+      ProxyAgent: TestProxyAgent,
+      fetch: async () =>
+        new Response(null, {
+          status: 200,
+          headers: { "content-length": String(17 * 1024 * 1024) },
+        }),
+    };
+    const fetch = buildMcpHttpFetch({ resourceUrl: "https://mcp.example.com/mcp" });
+
+    await expect(fetch("https://mcp.example.com/mcp")).rejects.toThrow(
+      "exceeds 16777216 byte limit",
+    );
+  });
+
+  it("rejects body-less responses whose actual text exceeds the 16 MiB cap", async () => {
+    class OversizedTextResponse {
+      status = 200;
+      statusText = "OK";
+      headers = new Headers();
+      body = null;
+      async text() {
+        return "x".repeat(17 * 1024 * 1024);
+      }
+    }
+    testGlobal[TEST_UNDICI_RUNTIME_DEPS_KEY] = {
+      Agent: TestAgent,
+      EnvHttpProxyAgent: TestEnvHttpProxyAgent,
+      ProxyAgent: TestProxyAgent,
+      fetch: async () => new OversizedTextResponse() as unknown as Response,
+    };
+    const fetch = buildMcpHttpFetch({ resourceUrl: "https://mcp.example.com/mcp" });
+
+    await expect(fetch("https://mcp.example.com/mcp")).rejects.toThrow(
+      "exceeds 16777216 byte limit",
+    );
+  });
+
+  it("accepts body-less responses within the 16 MiB cap", async () => {
+    class WithinLimitResponse {
+      status = 200;
+      statusText = "OK";
+      headers = new Headers({ "content-type": "application/json" });
+      body = null;
+      async text() {
+        return JSON.stringify({ ok: true });
+      }
+    }
+    testGlobal[TEST_UNDICI_RUNTIME_DEPS_KEY] = {
+      Agent: TestAgent,
+      EnvHttpProxyAgent: TestEnvHttpProxyAgent,
+      ProxyAgent: TestProxyAgent,
+      fetch: async () => new WithinLimitResponse() as unknown as Response,
+    };
+    const fetch = buildMcpHttpFetch({ resourceUrl: "https://mcp.example.com/mcp" });
+
+    const response = await fetch("https://mcp.example.com/mcp");
+    expect(response.status).toBe(200);
+    const text = await response.text();
+    expect(text).toBe('{"ok":true}');
+  });
 });

--- a/src/agents/mcp-http-fetch.ts
+++ b/src/agents/mcp-http-fetch.ts
@@ -25,6 +25,8 @@ const fetchWithUndiciGuard = async (
 ): Promise<Response> => await fetchWithUndici(input instanceof Request ? input.url : input, init);
 
 const MCP_HTTP_MAX_REDIRECTS = 20;
+/** Safety cap for MCP HTTP response body reads (16 MiB). */
+const MCP_HTTP_MAX_RESPONSE_BYTES = 16 * 1024 * 1024;
 const managedMcpResponseCleanupRegistry = new FinalizationRegistry<{
   finalize: () => Promise<void>;
 }>((held) => {
@@ -66,7 +68,21 @@ async function ensureGlobalFetchResponse(response: Response): Promise<Response> 
     return new Response(null, init);
   }
   if (typeof response.text === "function") {
+    const contentLength = response.headers.get("content-length");
+    if (contentLength != null) {
+      const length = Number(contentLength);
+      if (!Number.isFinite(length) || length > MCP_HTTP_MAX_RESPONSE_BYTES) {
+        throw new Error(
+          `Response body size (${contentLength} bytes) exceeds ${MCP_HTTP_MAX_RESPONSE_BYTES} byte limit`,
+        );
+      }
+    }
     const text = await response.text();
+    if (text.length > MCP_HTTP_MAX_RESPONSE_BYTES) {
+      throw new Error(
+        `Response body size (${text.length} chars) exceeds ${MCP_HTTP_MAX_RESPONSE_BYTES} byte limit`,
+      );
+    }
     return new Response(text, init);
   }
   return new Response(null, init);


### PR DESCRIPTION
## What Problem This Solves
Fixes an issue where MCP HTTP responses with large bodies (e.g. from a misconfigured or malicious MCP server) could exhaust process memory. The `ensureGlobalFetchResponse` function read `response.text()` without any size check, so a response body of hundreds of megabytes would be buffered entirely in memory — risking OOM.

## Why This Change Was Made
A single chokepoint fix at `ensureGlobalFetchResponse` — both callers in `buildManagedMcpResponse` pass through this function. The fix adds a two-layer guard:

1. **Content-Length pre-check** — rejects before `response.text()` is called when the header is present and oversized.
2. **Post-read length guard** — catches oversized bodies that arrive without a Content-Length header.

Cap is 16 MiB, matching the existing SSH sandbox output bound.

## User Impact
MCP server responses larger than 16 MiB are now rejected with a clear error message instead of silently consuming unbounded memory until the process crashes.

## Real behavior proof

**Behavior addressed:** `ensureGlobalFetchResponse` rejects oversized body-less responses via `buildMcpHttpFetch`.

**Real environment tested:** Linux x64, Node 22.22.0, openclaw main branch.

**Evidence after fix:**
```
[case 1] Content-Length pre-check rejects before reading body
  ok: rejects when Content-Length header exceeds cap
  ok: error message includes byte limit (16777216)
  ok: error message includes offending size
[case 2] Post-read check catches oversized body without Content-Length
  ok: rejects when actual text length exceeds cap
  ok: error message includes byte limit (16777216)
  ok: error message includes offending char count
  info: bodyLength=16777217 chars, cap=16777216 chars, elapsed=1 ms
[case 3] Within-limit response passes through unchanged
  ok: returns status 200
  ok: returns JSON body intact
[case 4] Body at exactly the cap (boundary) is accepted
  ok: accepts response at exact cap (Content-Length)

=== Summary ===
cap: 16777216 bytes (~16 MiB)
ALL PROOF ASSERTIONS: 9 passed, 0 failed
```

**Negative control (pre-fix behavior reproduced):**
```
[case 1] Content-Length pre-check rejects before reading body
  FAIL: rejects when Content-Length header exceeds cap
  FAIL: error message includes byte limit (16777216)
  FAIL: error message includes offending size
[case 2] Post-read check catches oversized body without Content-Length
  FAIL: rejects when actual text length exceeds cap
  FAIL: error message includes byte limit (16777216)
  FAIL: error message includes offending char count
  info: bodyLength=16777217 chars, cap=16777216 chars, elapsed=22 ms
[case 3] Within-limit response passes through unchanged
  ok: returns status 200
  ok: returns JSON body intact
[case 4] Body at exactly the cap (boundary) is accepted
  ok: accepts response at exact cap (Content-Length)

ALL PROOF ASSERTIONS: 3 passed, 6 failed
exit=1
```

Without the fix, oversized responses pass through silently (no rejection, potential OOM). With the fix, they are caught and rejected.

**What was not tested:** Real undici HTTP server round-trip (mock fetch used; the bounds guards operate on the Response object post-fetch, independent of transport).

## Evidence
**Vitest:** 13/13 passed (10 existing + 3 new bound tests)
```
$ node scripts/run-vitest.mjs src/agents/mcp-http-fetch.test.ts --run
Test Files  1 passed (1)
     Tests  13 passed (13)
```

**New tests:**
- `rejects body-less responses whose Content-Length exceeds the 16 MiB cap`
- `rejects body-less responses whose actual text exceeds the 16 MiB cap`
- `accepts body-less responses within the 16 MiB cap`