### PR TITLE
feat(ios): add licenses settings screen

### DIFF
--- a/apps/.i18n/native-source.json
+++ b/apps/.i18n/native-source.json
@@ -8219,7 +8219,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 613,
+      "line": 614,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "Configured",
       "surface": "apple",
@@ -8227,7 +8227,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 613,
+      "line": 614,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "Not configured",
       "surface": "apple",
@@ -8235,7 +8235,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 678,
+      "line": 679,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "Connect to the gateway.",
       "surface": "apple",
@@ -8243,7 +8243,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 678,
+      "line": 679,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "Gateway requests will appear here.",
       "surface": "apple",
@@ -8251,7 +8251,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 733,
+      "line": 734,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "High",
       "surface": "apple",
@@ -8259,7 +8259,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 733,
+      "line": 734,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "Resolving",
       "surface": "apple",
@@ -8267,7 +8267,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 738,
+      "line": 739,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "One-time approval",
       "surface": "apple",
@@ -8275,7 +8275,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 738,
+      "line": 739,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "Permission can be saved",
       "surface": "apple",
@@ -8283,7 +8283,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 740,
+      "line": 741,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "Medium",
       "surface": "apple",
@@ -8291,7 +8291,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 740,
+      "line": 741,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "Review",
       "surface": "apple",
@@ -8299,7 +8299,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 765,
+      "line": 766,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "\\(diagnosticsIssueCount)",
       "surface": "apple",
@@ -8307,7 +8307,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 775,
+      "line": 776,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "Location \\(self.locationLabel)",
       "surface": "apple",
@@ -8315,7 +8315,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 775,
+      "line": 776,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "Location off",
       "surface": "apple",
@@ -8323,7 +8323,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 780,
+      "line": 781,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "Off",
       "surface": "apple",
@@ -8331,7 +8331,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 781,
+      "line": 782,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "While Using",
       "surface": "apple",
@@ -8339,7 +8339,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 782,
+      "line": 783,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "Always",
       "surface": "apple",
@@ -8347,7 +8347,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 796,
+      "line": 797,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "Checking iOS notification permission.",
       "surface": "apple",
@@ -8355,7 +8355,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 798,
+      "line": 799,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "OpenClaw can show approval prompts and event alerts when the app is not active.",
       "surface": "apple",
@@ -8363,7 +8363,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 800,
+      "line": 801,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "Notifications have been denied. Enable them in iOS Settings.",
       "surface": "apple",
@@ -8371,7 +8371,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 802,
+      "line": 803,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "Enable notifications to receive approval prompts and event alerts outside the app.",
       "surface": "apple",
@@ -8379,7 +8379,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 804,
+      "line": 805,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "OpenClaw cannot determine the current notification permission state.",
       "surface": "apple",
@@ -8467,7 +8467,15 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 247,
+      "line": 174,
+      "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
+      "source": "Licenses",
+      "surface": "apple",
+      "id": "native.apple.529c06f7f7f6e428"
+    },
+    {
+      "kind": "ui-named-argument",
+      "line": 257,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Gateway",
       "surface": "apple",
@@ -8475,7 +8483,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 253,
+      "line": 263,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Address",
       "surface": "apple",
@@ -8483,7 +8491,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 255,
+      "line": 265,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Server",
       "surface": "apple",
@@ -8491,7 +8499,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 257,
+      "line": 267,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Discovered",
       "surface": "apple",
@@ -8499,7 +8507,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 261,
+      "line": 271,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Agents",
       "surface": "apple",
@@ -8507,7 +8515,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 282,
+      "line": 292,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Approvals",
       "surface": "apple",
@@ -8515,7 +8523,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 285,
+      "line": 295,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "No gateway actions are waiting for review.",
       "surface": "apple",
@@ -8523,7 +8531,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 285,
+      "line": 295,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Review the pending gateway action.",
       "surface": "apple",
@@ -8531,7 +8539,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 289,
+      "line": 299,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "1 waiting",
       "surface": "apple",
@@ -8539,7 +8547,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 307,
+      "line": 317,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Notifications are off",
       "surface": "apple",
@@ -8547,7 +8555,7 @@
     },
     {
       "kind": "ui-call-multiline",
-      "line": 309,
+      "line": 319,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Enable Notifications to receive approval notifications while OpenClaw is not open.",
       "surface": "apple",
@@ -8555,7 +8563,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 323,
+      "line": 333,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Open Notifications",
       "surface": "apple",
@@ -8563,7 +8571,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 357,
+      "line": 367,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Allow",
       "surface": "apple",
@@ -8571,7 +8579,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 377,
+      "line": 387,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Deny",
       "surface": "apple",
@@ -8579,7 +8587,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 389,
+      "line": 399,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "No approvals waiting",
       "surface": "apple",
@@ -8587,7 +8595,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 407,
+      "line": 417,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Camera",
       "surface": "apple",
@@ -8595,7 +8603,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 408,
+      "line": 418,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Allow the gateway to request photos or video while OpenClaw is foregrounded.",
       "surface": "apple",
@@ -8603,7 +8611,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 415,
+      "line": 425,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Keep Awake",
       "surface": "apple",
@@ -8611,7 +8619,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 416,
+      "line": 426,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Keep the screen awake while OpenClaw is open.",
       "surface": "apple",
@@ -8619,7 +8627,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 427,
+      "line": 437,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Voice & Talk",
       "surface": "apple",
@@ -8627,7 +8635,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 442,
+      "line": 452,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Health Check",
       "surface": "apple",
@@ -8635,7 +8643,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 443,
+      "line": 453,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Run app, permission, and gateway-adjacent checks without editing setup.",
       "surface": "apple",
@@ -8643,7 +8651,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 449,
+      "line": 459,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Run Diagnostics",
       "surface": "apple",
@@ -8651,7 +8659,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 464,
+      "line": 474,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Platform",
       "surface": "apple",
@@ -8659,7 +8667,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 466,
+      "line": 476,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "App",
       "surface": "apple",
@@ -8667,7 +8675,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 468,
+      "line": 478,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Model",
       "surface": "apple",
@@ -8675,7 +8683,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 479,
+      "line": 489,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Privacy",
       "surface": "apple",
@@ -8683,7 +8691,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 480,
+      "line": 490,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Control what device context OpenClaw can expose to the gateway.",
       "surface": "apple",
@@ -8691,7 +8699,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 486,
+      "line": 496,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Camera Access",
       "surface": "apple",
@@ -8699,7 +8707,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 487,
+      "line": 497,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Disable to block camera capture requests from the gateway.",
       "surface": "apple",
@@ -8707,7 +8715,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 494,
+      "line": 504,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Background Listening",
       "surface": "apple",
@@ -8715,7 +8723,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 495,
+      "line": 505,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Allow active Talk sessions to continue while the app is backgrounded.",
       "surface": "apple",
@@ -8723,7 +8731,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 506,
+      "line": 516,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Notifications",
       "surface": "apple",
@@ -8731,7 +8739,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 551,
+      "line": 561,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "OpenClaw app version",
       "surface": "apple",
@@ -8739,7 +8747,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 553,
+      "line": 563,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Device",
       "surface": "apple",
@@ -8747,7 +8755,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 555,
+      "line": 565,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "iOS",
       "surface": "apple",
@@ -8755,7 +8763,31 @@
     },
     {
       "kind": "ui-call",
-      "line": 623,
+      "line": 578,
+      "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
+      "source": "No licenses bundled",
+      "surface": "apple",
+      "id": "native.apple.5abfcc15e933c483"
+    },
+    {
+      "kind": "ui-call",
+      "line": 580,
+      "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
+      "source": "License files are not available in this build.",
+      "surface": "apple",
+      "id": "native.apple.af22fba4150f2c1d"
+    },
+    {
+      "kind": "ui-call",
+      "line": 591,
+      "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
+      "source": "OpenClaw appreciates its partners in the open-source community.",
+      "surface": "apple",
+      "id": "native.apple.a82dc4a746268028"
+    },
+    {
+      "kind": "ui-call",
+      "line": 696,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Controls whether location can be shared with gateway tools.",
       "surface": "apple",
@@ -8763,7 +8795,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 635,
+      "line": 708,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Location",
       "surface": "apple",
@@ -8771,7 +8803,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 636,
+      "line": 709,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Off",
       "surface": "apple",
@@ -8779,7 +8811,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 637,
+      "line": 710,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "While Using",
       "surface": "apple",
@@ -8787,7 +8819,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 638,
+      "line": 711,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Always",
       "surface": "apple",
@@ -8795,7 +8827,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 656,
+      "line": 729,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Default Agent",
       "surface": "apple",
@@ -8803,7 +8835,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 658,
+      "line": 731,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Agent",
       "surface": "apple",
@@ -8811,7 +8843,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 659,
+      "line": 732,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Default",
       "surface": "apple",
@@ -8819,7 +8851,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 667,
+      "line": 740,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Used for new Chat and Talk sessions.",
       "surface": "apple",
@@ -8827,7 +8859,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 678,
+      "line": 751,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Setup Code",
       "surface": "apple",
@@ -8835,7 +8867,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 680,
+      "line": 753,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Paste setup code",
       "surface": "apple",
@@ -8843,7 +8875,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 686,
+      "line": 759,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Scan QR",
       "surface": "apple",
@@ -8851,7 +8883,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 694,
+      "line": 767,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Connect",
       "surface": "apple",
@@ -8859,7 +8891,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 722,
+      "line": 795,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Discovered Gateways",
       "surface": "apple",
@@ -8867,7 +8899,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 725,
+      "line": 798,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "No gateways found yet. Use manual setup if Bonjour is blocked.",
       "surface": "apple",
@@ -8875,7 +8907,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 769,
+      "line": 842,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Use Manual Gateway",
       "surface": "apple",
@@ -8883,7 +8915,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 770,
+      "line": 843,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Host",
       "surface": "apple",
@@ -8891,7 +8923,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 774,
+      "line": 847,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Port",
       "surface": "apple",
@@ -8899,7 +8931,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 777,
+      "line": 850,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Use TLS",
       "surface": "apple",
@@ -8907,7 +8939,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 779,
+      "line": 852,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Connect Manual",
       "surface": "apple",
@@ -8915,7 +8947,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 796,
+      "line": 869,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Auto-connect on launch",
       "surface": "apple",
@@ -8923,7 +8955,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 797,
+      "line": 870,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Gateway Auth Token",
       "surface": "apple",
@@ -8931,7 +8963,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 801,
+      "line": 874,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Gateway Password",
       "surface": "apple",
@@ -8939,7 +8971,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 806,
+      "line": 879,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Reset Onboarding",
       "surface": "apple",
@@ -8947,7 +8979,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 819,
+      "line": 892,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Voice Wake",
       "surface": "apple",
@@ -8955,7 +8987,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 822,
+      "line": 895,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Talk Mode",
       "surface": "apple",
@@ -8963,7 +8995,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 830,
+      "line": 903,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Speech Language",
       "surface": "apple",
@@ -8971,7 +9003,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 836,
+      "line": 909,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Speakerphone",
       "surface": "apple",
@@ -8979,7 +9011,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 841,
+      "line": 914,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Wake Words",
       "surface": "apple",
@@ -8987,7 +9019,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 863,
+      "line": 936,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Provider",
       "surface": "apple",
@@ -8995,7 +9027,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 869,
+      "line": 942,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Realtime Voice",
       "surface": "apple",
@@ -9003,7 +9035,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 870,
+      "line": 943,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Gateway Default",
       "surface": "apple",
@@ -9011,7 +9043,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 876,
+      "line": 949,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Voice Mode",
       "surface": "apple",
@@ -9019,7 +9051,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 878,
+      "line": 951,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Active Voice",
       "surface": "apple",
@@ -9027,7 +9059,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 881,
+      "line": 954,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Last Voice Issue",
       "surface": "apple",
@@ -9035,7 +9067,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 884,
+      "line": 957,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Transport",
       "surface": "apple",
@@ -9043,7 +9075,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 886,
+      "line": 959,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "API Key",
       "surface": "apple",
@@ -9051,7 +9083,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 896,
+      "line": 969,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Show Talk Control",
       "surface": "apple",
@@ -9059,7 +9091,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 897,
+      "line": 970,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Default Share Instruction",
       "surface": "apple",
@@ -9067,7 +9099,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 904,
+      "line": 977,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Run Share Self-Test",
       "surface": "apple",
@@ -9075,7 +9107,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 925,
+      "line": 998,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Discovery Debug Logs",
       "surface": "apple",
@@ -9083,7 +9115,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 928,
+      "line": 1001,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Debug Screen Status",
       "surface": "apple",
@@ -9091,7 +9123,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 932,
+      "line": 1005,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Discovery Logs",
       "surface": "apple",
@@ -9099,7 +9131,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 942,
+      "line": 1015,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Device Name",
       "surface": "apple",
@@ -9107,7 +9139,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 944,
+      "line": 1017,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Instance ID",
       "surface": "apple",
@@ -9115,7 +9147,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 980,
+      "line": 1053,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "On",
       "surface": "apple",
@@ -9123,7 +9155,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 92,
+      "line": 93,
       "path": "apps/ios/Sources/Design/SettingsProTabSupport.swift",
       "source": "Enabled",
       "surface": "apple",
@@ -9131,7 +9163,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 93,
+      "line": 94,
       "path": "apps/ios/Sources/Design/SettingsProTabSupport.swift",
       "source": "Denied",
       "surface": "apple",
@@ -9139,7 +9171,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 94,
+      "line": 95,
       "path": "apps/ios/Sources/Design/SettingsProTabSupport.swift",
       "source": "Not Enabled",
       "surface": "apple",
@@ -9147,7 +9179,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 95,
+      "line": 96,
       "path": "apps/ios/Sources/Design/SettingsProTabSupport.swift",
       "source": "Unknown",
       "surface": "apple",
@@ -9155,7 +9187,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 101,
+      "line": 102,
       "path": "apps/ios/Sources/Design/SettingsProTabSupport.swift",
       "source": "Enable Notifications",
       "surface": "apple",
@@ -9163,7 +9195,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 103,
+      "line": 104,
       "path": "apps/ios/Sources/Design/SettingsProTabSupport.swift",
       "source": "Checking",
       "surface": "apple",
@@ -9171,7 +9203,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 105,
+      "line": 106,
       "path": "apps/ios/Sources/Design/SettingsProTabSupport.swift",
       "source": "Manage in iOS Settings",
       "surface": "apple",
@@ -9179,7 +9211,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 107,
+      "line": 108,
       "path": "apps/ios/Sources/Design/SettingsProTabSupport.swift",
       "source": "Open iOS Settings",
       "surface": "apple",
@@ -9187,7 +9219,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 249,
+      "line": 250,
       "path": "apps/ios/Sources/Design/SettingsProTabSupport.swift",
       "source": "Connected",
       "surface": "apple",
@@ -9195,7 +9227,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 251,
+      "line": 252,
       "path": "apps/ios/Sources/Design/SettingsProTabSupport.swift",
       "source": "Gateway online",
       "surface": "apple",
@@ -9203,7 +9235,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 252,
+      "line": 253,
       "path": "apps/ios/Sources/Design/SettingsProTabSupport.swift",
       "source": "Connected to openclaw-gateway.tailnet.ts.net.",
       "surface": "apple",
@@ -9211,7 +9243,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 262,
+      "line": 263,
       "path": "apps/ios/Sources/Design/SettingsProTabSupport.swift",
       "source": "Loading",
       "surface": "apple",
@@ -9219,7 +9251,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 264,
+      "line": 265,
       "path": "apps/ios/Sources/Design/SettingsProTabSupport.swift",
       "source": "Checking gateway",
       "surface": "apple",
@@ -9227,7 +9259,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 265,
+      "line": 266,
       "path": "apps/ios/Sources/Design/SettingsProTabSupport.swift",
       "source": "Refreshing connection, discovery, and device trust state.",
       "surface": "apple",
@@ -9235,7 +9267,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 271,
+      "line": 272,
       "path": "apps/ios/Sources/Design/SettingsProTabSupport.swift",
       "source": "Empty",
       "surface": "apple",
@@ -9243,7 +9275,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 273,
+      "line": 274,
       "path": "apps/ios/Sources/Design/SettingsProTabSupport.swift",
       "source": "No gateway configured",
       "surface": "apple",
@@ -9251,7 +9283,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 274,
+      "line": 275,
       "path": "apps/ios/Sources/Design/SettingsProTabSupport.swift",
       "source": "Scan a setup QR code, paste a setup code, or choose a discovered gateway.",
       "surface": "apple",
@@ -9259,7 +9291,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 280,
+      "line": 281,
       "path": "apps/ios/Sources/Design/SettingsProTabSupport.swift",
       "source": "Error",
       "surface": "apple",
@@ -9267,7 +9299,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 282,
+      "line": 283,
       "path": "apps/ios/Sources/Design/SettingsProTabSupport.swift",
       "source": "Tailscale warning",
       "surface": "apple",
@@ -9275,7 +9307,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 283,
+      "line": 284,
       "path": "apps/ios/Sources/Design/SettingsProTabSupport.swift",
       "source": "Tailscale is off on this device. Turn it on, then try again.",
       "surface": "apple",
@@ -9283,7 +9315,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 332,
+      "line": 333,
       "path": "apps/ios/Sources/Design/SettingsProTabSupport.swift",
       "source": "Address",
       "surface": "apple",
@@ -9291,7 +9323,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 334,
+      "line": 335,
       "path": "apps/ios/Sources/Design/SettingsProTabSupport.swift",
       "source": "Server",
       "surface": "apple",
@@ -9299,7 +9331,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 336,
+      "line": 337,
       "path": "apps/ios/Sources/Design/SettingsProTabSupport.swift",
       "source": "Discovered",
       "surface": "apple",
@@ -9307,7 +9339,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 338,
+      "line": 339,
       "path": "apps/ios/Sources/Design/SettingsProTabSupport.swift",
       "source": "Default Agent",
       "surface": "apple",
@@ -9315,7 +9347,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 360,
+      "line": 361,
       "path": "apps/ios/Sources/Design/SettingsProTabSupport.swift",
       "source": "Reconnect",
       "surface": "apple",
@@ -9323,7 +9355,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 361,
+      "line": 362,
       "path": "apps/ios/Sources/Design/SettingsProTabSupport.swift",
       "source": "Diagnose",
       "surface": "apple",
@@ -9331,7 +9363,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 370,
+      "line": 371,
       "path": "apps/ios/Sources/Design/SettingsProTabSupport.swift",
       "source": "Scan QR",
       "surface": "apple",
@@ -9339,7 +9371,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 371,
+      "line": 372,
       "path": "apps/ios/Sources/Design/SettingsProTabSupport.swift",
       "source": "Connect",
       "surface": "apple",
@@ -9347,7 +9379,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 373,
+      "line": 374,
       "path": "apps/ios/Sources/Design/SettingsProTabSupport.swift",
       "source": "Discovered gateways and manual setup live here when the gateway has not connected yet.",
       "surface": "apple",

--- a/apps/ios/AGENTS.md
+++ b/apps/ios/AGENTS.md
@@ -2,6 +2,20 @@
 
 Root rules still apply. This file adds the iOS release guardrails.
 
+## Licenses Screen
+
+- Maintain the Settings-tab Licenses screen when iOS app dependencies change.
+- Bundled license files live in `apps/ios/Resources/Licenses/`.
+- License files must be UTF-8 `.txt` files. Do not add Markdown, HTML, RTF, or generated plist license content.
+- The Licenses screen discovers bundled `.txt` files at runtime through `LicenseDocumentLoader`; do not hardcode individual license rows in Swift.
+- License rows are ordered alphabetically in code by derived display title. Do not use numeric filename prefixes for ordering.
+- Filenames should be plain dependency names, for example `WebRTC.txt`; the filename is used only to derive the row title and must not be shown as a row subtitle.
+- Do not add OpenClaw, OpenClaw Foundation, or other first-party/self-owned license entries. The screen is for third-party/open-source dependency acknowledgements.
+- When adding, removing, or upgrading iOS dependencies, audit whether `apps/ios/Resources/Licenses/` needs updates. Exclude dependencies owned by OpenClaw Foundation from the published license list.
+- Keep license detail bodies rendered as verbatim monospace text.
+- Keep the Settings Licenses row at the bottom Settings section with no section title unless product direction changes.
+- When changing license loading or presentation, update `apps/ios/Tests/LicenseDocumentLoaderTests.swift` and `apps/ios/Tests/SwiftUIRenderSmokeTests.swift`, then run focused iOS tests.
+
 ## App Store Releases
 
 - Agent-driven App Store uploads must use only `pnpm ios:release:upload`.

--- a/apps/ios/Resources/Licenses/ElevenLabsKit.txt
+++ b/apps/ios/Resources/Licenses/ElevenLabsKit.txt
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Peter Steinberger
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/apps/ios/Resources/Licenses/WebRTC.txt
+++ b/apps/ios/Resources/Licenses/WebRTC.txt
@@ -1,0 +1,58 @@
+BSD 3-Clause License
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+   contributors may be used to endorse or promote products derived from
+   this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+
+
+Google WebRTC
+Copyright (c) 2011, The WebRTC project authors. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+  * Redistributions of source code must retain the above copyright
+    notice, this list of conditions and the following disclaimer.
+
+  * Redistributions in binary form must reproduce the above copyright
+    notice, this list of conditions and the following disclaimer in
+    the documentation and/or other materials provided with the
+    distribution.
+
+  * Neither the name of Google nor the names of its contributors may
+    be used to endorse or promote products derived from this software
+    without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/apps/ios/Sources/Design/LicenseDocuments.swift
+++ b/apps/ios/Sources/Design/LicenseDocuments.swift
@@ -1,0 +1,89 @@
+import Foundation
+import SwiftUI
+
+struct LicenseDocument: Identifiable {
+    let id: String
+    let title: String
+    let filename: String
+    let body: String
+}
+
+enum LicenseDocumentLoader {
+    static let directoryName = "Licenses"
+
+    static func bundledDocuments(bundle: Bundle = .main) -> [LicenseDocument] {
+        guard let resourceURL = bundle.resourceURL else { return [] }
+        return self.documents(in: resourceURL.appendingPathComponent(self.directoryName, isDirectory: true))
+    }
+
+    static func documents(in directoryURL: URL) -> [LicenseDocument] {
+        let fileManager = FileManager.default
+        guard let urls = try? fileManager.contentsOfDirectory(
+            at: directoryURL,
+            includingPropertiesForKeys: [.isRegularFileKey],
+            options: [.skipsHiddenFiles])
+        else {
+            return []
+        }
+
+        return urls.compactMap(self.document(from:)).sorted { lhs, rhs in
+            let titleComparison = lhs.title.localizedCaseInsensitiveCompare(rhs.title)
+            if titleComparison == .orderedSame {
+                return lhs.filename.localizedCaseInsensitiveCompare(rhs.filename) == .orderedAscending
+            }
+            return titleComparison == .orderedAscending
+        }
+    }
+
+    static func title(from filename: String) -> String {
+        let name = URL(fileURLWithPath: filename).deletingPathExtension().lastPathComponent
+        let title = name
+            .replacingOccurrences(of: "-", with: " ")
+            .replacingOccurrences(of: "_", with: " ")
+            .split(whereSeparator: \.isWhitespace)
+            .joined(separator: " ")
+        return title.isEmpty ? filename : title
+    }
+
+    private static func document(from url: URL) -> LicenseDocument? {
+        let filename = url.lastPathComponent
+        guard !filename.hasPrefix("."),
+              url.pathExtension.lowercased() == "txt"
+        else {
+            return nil
+        }
+
+        let values = try? url.resourceValues(forKeys: [.isRegularFileKey])
+        guard values?.isRegularFile == true else { return nil }
+        guard let body = try? String(contentsOf: url, encoding: .utf8),
+              !body.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+        else {
+            return nil
+        }
+
+        return LicenseDocument(
+            id: filename,
+            title: self.title(from: filename),
+            filename: filename,
+            body: body)
+    }
+}
+
+struct LicenseDocumentDetailView: View {
+    let document: LicenseDocument
+
+    var body: some View {
+        ScrollView {
+            Text(verbatim: self.document.body)
+                .font(.system(.footnote, design: .monospaced))
+                .foregroundStyle(.primary)
+                .textSelection(.enabled)
+                .accessibilityIdentifier("licenses-detail-text")
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .padding(OpenClawProMetric.pagePadding)
+        }
+        .background(OpenClawProBackground())
+        .navigationTitle(self.document.title)
+        .navigationBarTitleDisplayMode(.inline)
+    }
+}

--- a/apps/ios/Sources/Design/SettingsProTabActions.swift
+++ b/apps/ios/Sources/Design/SettingsProTabActions.swift
@@ -484,6 +484,7 @@ extension SettingsProTab {
         case .diagnostics: "Diagnostics"
         case .privacy: "Privacy"
         case .notifications: "Notifications"
+        case .licenses: "Licenses"
         case .about: "About"
         }
     }

--- a/apps/ios/Sources/Design/SettingsProTabSections.swift
+++ b/apps/ios/Sources/Design/SettingsProTabSections.swift
@@ -167,6 +167,14 @@ extension SettingsProTab {
                 title: "About",
                 route: .about)
         }
+
+        Section {
+            self.settingsListRow(
+                icon: "doc.text",
+                title: "Licenses",
+                route: .licenses)
+                .accessibilityIdentifier("settings-licenses-row")
+        }
     }
 
     func settingsListRow(
@@ -221,6 +229,8 @@ extension SettingsProTab {
                         self.privacyDestination
                     case .notifications:
                         self.notificationsDestination
+                    case .licenses:
+                        self.licensesDestination
                     case .about:
                         self.aboutDestination
                     }
@@ -555,6 +565,69 @@ extension SettingsProTab {
                 self.detailRow("iOS", value: DeviceInfoHelper.iOSVersionStringForDisplay())
             }
         }
+    }
+
+    var licensesDestination: some View {
+        let documents = LicenseDocumentLoader.bundledDocuments()
+        return VStack(alignment: .leading, spacing: 14) {
+            if documents.isEmpty {
+                ProCard(radius: SettingsLayout.cardRadius) {
+                    HStack(spacing: 12) {
+                        ProIconBadge(systemName: "doc.text", color: .secondary)
+                        VStack(alignment: .leading, spacing: 3) {
+                            Text("No licenses bundled")
+                                .font(.subheadline.weight(.semibold))
+                            Text("License files are not available in this build.")
+                                .font(.caption)
+                                .foregroundStyle(.secondary)
+                                .lineLimit(2)
+                        }
+                    }
+                }
+                .padding(.horizontal, OpenClawProMetric.pagePadding)
+            } else {
+                let lastDocumentID = documents.last?.id
+
+                Text("OpenClaw appreciates its partners in the open-source community.")
+                    .font(.footnote)
+                    .foregroundStyle(.secondary)
+                    .multilineTextAlignment(.center)
+                    .fixedSize(horizontal: false, vertical: true)
+                    .frame(maxWidth: .infinity)
+                    .padding(.horizontal, OpenClawProMetric.pagePadding)
+
+                self.detailListCard {
+                    ForEach(documents) { document in
+                        NavigationLink {
+                            LicenseDocumentDetailView(document: document)
+                        } label: {
+                            self.licenseDocumentRow(document)
+                        }
+                        .buttonStyle(.plain)
+
+                        if document.id != lastDocumentID {
+                            Divider().padding(.leading, 60)
+                        }
+                    }
+                }
+                .accessibilityIdentifier("settings-licenses-list")
+            }
+        }
+    }
+
+    func licenseDocumentRow(_ document: LicenseDocument) -> some View {
+        HStack(spacing: 12) {
+            ProIconBadge(systemName: "doc.text", color: .secondary)
+            Text(document.title)
+                .font(.subheadline.weight(.semibold))
+                .foregroundStyle(.primary)
+            Spacer(minLength: 8)
+            Image(systemName: "chevron.right")
+                .font(.caption.weight(.semibold))
+                .foregroundStyle(.tertiary)
+        }
+        .padding(.horizontal, 14)
+        .frame(minHeight: SettingsLayout.rowHeight)
     }
 
     func gatewayActionButton(

--- a/apps/ios/Sources/Design/SettingsProTabSupport.swift
+++ b/apps/ios/Sources/Design/SettingsProTabSupport.swift
@@ -12,6 +12,7 @@ enum SettingsRoute: Hashable {
     case diagnostics
     case privacy
     case notifications
+    case licenses
     case about
 }
 

--- a/apps/ios/Tests/LicenseDocumentLoaderTests.swift
+++ b/apps/ios/Tests/LicenseDocumentLoaderTests.swift
@@ -1,0 +1,46 @@
+import Foundation
+import Testing
+@testable import OpenClaw
+
+struct LicenseDocumentLoaderTests {
+    @Test func `loads only utf8 text licenses sorted alphabetically by title`() throws {
+        let directory = try Self.makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        try "Gamma License".write(
+            to: directory.appendingPathComponent("Gamma.txt"),
+            atomically: true,
+            encoding: .utf8)
+        try "Alpha License".write(
+            to: directory.appendingPathComponent("Alpha.txt"),
+            atomically: true,
+            encoding: .utf8)
+        try "Ignored".write(
+            to: directory.appendingPathComponent("Beta.md"),
+            atomically: true,
+            encoding: .utf8)
+        try "Hidden".write(
+            to: directory.appendingPathComponent(".Hidden.txt"),
+            atomically: true,
+            encoding: .utf8)
+
+        let documents = LicenseDocumentLoader.documents(in: directory)
+
+        #expect(documents.map(\.filename) == ["Alpha.txt", "Gamma.txt"])
+        #expect(documents.map(\.title) == ["Alpha", "Gamma"])
+        #expect(documents.map(\.body) == ["Alpha License", "Gamma License"])
+    }
+
+    @Test func `derives readable titles from license filenames`() {
+        #expect(LicenseDocumentLoader.title(from: "WebRTC.txt") == "WebRTC")
+        #expect(LicenseDocumentLoader.title(from: "openclaw_plugin_sdk.txt") == "openclaw plugin sdk")
+        #expect(LicenseDocumentLoader.title(from: "010-WebRTC.txt") == "010 WebRTC")
+    }
+
+    private static func makeTemporaryDirectory() throws -> URL {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("OpenClawLicenseDocumentLoaderTests-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        return directory
+    }
+}

--- a/apps/ios/Tests/SwiftUIRenderSmokeTests.swift
+++ b/apps/ios/Tests/SwiftUIRenderSmokeTests.swift
@@ -57,6 +57,24 @@ struct SwiftUIRenderSmokeTests {
         }
     }
 
+    @Test @MainActor func `settings Licenses destination builds in light and dark mode`() {
+        var windows: [UIWindow] = []
+        defer { windows.forEach { $0.isHidden = true } }
+
+        for scheme in [ColorScheme.light, ColorScheme.dark] {
+            let appModel = NodeAppModel()
+            let gatewayController = GatewayConnectionController(appModel: appModel, startDiscovery: false)
+
+            let root = SettingsProTab(directRoute: .licenses)
+                .environment(appModel)
+                .environment(appModel.voiceWake)
+                .environment(gatewayController)
+                .preferredColorScheme(scheme)
+
+            windows.append(Self.host(root, size: CGSize(width: 393, height: 852)))
+        }
+    }
+
     @Test @MainActor func `settings pro tab appearance row builds for all preferences`() throws {
         for preference in AppAppearancePreference.allCases {
             let suiteName = "OpenClawTests.appearance.\(preference.rawValue).\(UUID().uuidString)"

--- a/apps/ios/project.yml
+++ b/apps/ios/project.yml
@@ -60,6 +60,9 @@ targets:
       Release: Signing.xcconfig
     sources:
       - path: Sources
+      - path: Resources/Licenses
+        type: folder
+        buildPhase: resources
     resources:
       - path: Resources/Localizable.xcstrings
     dependencies:


### PR DESCRIPTION
## What Problem This Solves

Adds a Settings-tab Licenses screen so iOS users can view bundled third-party license acknowledgements in the app.

## Why This Change Was Made

The screen loads UTF-8 `.txt` license files from `apps/ios/Resources/Licenses/`, orders them alphabetically by display title, and renders each license body as verbatim monospace text. The published list excludes OpenClaw/OpenClaw Foundation-owned entries and the iOS AGENTS guidance now documents how agents should maintain the screen.

## User Impact

iOS users can open Settings > Licenses to inspect third-party license text for bundled dependencies. Maintainers can add or remove license entries by updating `.txt` files in the license resource folder rather than editing row source code.

## Evidence

- `pnpm docs:list`
- `git diff --check -- apps/ios/AGENTS.md`
- `xcodebuild test -project apps/ios/OpenClaw.xcodeproj -scheme OpenClaw -destination 'id=CC67DD42-8B9E-43A8-B10E-532238BD283E' -configuration Debug -only-testing:OpenClawTests/LicenseDocumentLoaderTests -only-testing:OpenClawTests/SwiftUIRenderSmokeTests`
- `maestro test --udid CC67DD42-8B9E-43A8-B10E-532238BD283E --no-ansi --debug-output .artifacts/ios-licenses-e2e/maestro-third-party-only-debug .artifacts/ios-licenses-e2e/licenses-no-subtitles.yaml`
- `.agents/skills/autoreview/scripts/autoreview --mode commit --commit HEAD`

Local screenshot artifact for maintainer inspection: `.artifacts/ios-licenses-e2e/09-licenses-list-third-party-only.png`.
