### PR TITLE
fix(mcp): bound body-less MCP HTTP text responses at 1 MiB

### DIFF
--- a/src/agents/mcp-http-fetch.test.ts
+++ b/src/agents/mcp-http-fetch.test.ts
@@ -213,16 +213,20 @@ describe("MCP HTTP fetch helpers", () => {
   });
 
   it("returns fetch responses compatible with MCP SDK OAuth error parsing", async () => {
+    const body = '{"error":"invalid_client_metadata","error_description":"bad redirect"}';
     class ForeignResponse {
       status = 400;
       statusText = "Bad Request";
-      headers = new Headers({ "content-type": "application/json" });
+      headers = new Headers({
+        "content-length": String(Buffer.byteLength(body, "utf8")),
+        "content-type": "application/json",
+      });
       body = null;
       get ok() {
         return false;
       }
       async text() {
-        return '{"error":"invalid_client_metadata","error_description":"bad redirect"}';
+        return body;
       }
     }
 
@@ -244,5 +248,120 @@ describe("MCP HTTP fetch helpers", () => {
     const error = await parseErrorResponse(response);
     expect(error.message).toContain("bad redirect");
     expect(error.message).not.toContain("[object Response]");
+  });
+
+  it("drops body-less text when Content-Length exceeds the 1 MiB cap", async () => {
+    const text = vi.fn(async () => "x".repeat(1024 * 1024 + 1));
+    class OversizedResponse {
+      status = 400;
+      statusText = "Bad Request";
+      headers = new Headers({
+        "content-length": String(1024 * 1024 + 1),
+        "content-type": "application/json",
+      });
+      body = null;
+      get ok() {
+        return false;
+      }
+      text = text;
+    }
+    testGlobal[TEST_UNDICI_RUNTIME_DEPS_KEY] = {
+      Agent: TestAgent,
+      EnvHttpProxyAgent: TestEnvHttpProxyAgent,
+      ProxyAgent: TestProxyAgent,
+      fetch: async () => new OversizedResponse() as unknown as Response,
+    };
+    const fetch = buildMcpHttpFetch({ resourceUrl: "https://mcp.example.com/mcp" });
+
+    const response = await fetch("https://mcp.example.com/mcp");
+    expect(response).toBeInstanceOf(Response);
+    expect(response.body).toBeNull();
+    expect(text).not.toHaveBeenCalled();
+  });
+
+  it("drops body-less text when Content-Length is missing", async () => {
+    const text = vi.fn(async () => '{"error":"too large"}');
+    class NoLengthResponse {
+      status = 400;
+      statusText = "Bad Request";
+      headers = new Headers({ "content-type": "application/json" });
+      body = null;
+      get ok() {
+        return false;
+      }
+      text = text;
+    }
+    testGlobal[TEST_UNDICI_RUNTIME_DEPS_KEY] = {
+      Agent: TestAgent,
+      EnvHttpProxyAgent: TestEnvHttpProxyAgent,
+      ProxyAgent: TestProxyAgent,
+      fetch: async () => new NoLengthResponse() as unknown as Response,
+    };
+    const fetch = buildMcpHttpFetch({ resourceUrl: "https://mcp.example.com/mcp" });
+
+    const response = await fetch("https://mcp.example.com/mcp");
+    expect(response).toBeInstanceOf(Response);
+    expect(response.body).toBeNull();
+    expect(text).not.toHaveBeenCalled();
+  });
+
+  it.each(["abc", "1e3", "0x40"])(
+    "drops body-less text when Content-Length is malformed (%s)",
+    async (contentLength) => {
+      const text = vi.fn(async () => '{"error":"too large"}');
+      class MalformedLengthResponse {
+        status = 400;
+        statusText = "Bad Request";
+        headers = new Headers({
+          "content-length": contentLength,
+          "content-type": "application/json",
+        });
+        body = null;
+        get ok() {
+          return false;
+        }
+        text = text;
+      }
+      testGlobal[TEST_UNDICI_RUNTIME_DEPS_KEY] = {
+        Agent: TestAgent,
+        EnvHttpProxyAgent: TestEnvHttpProxyAgent,
+        ProxyAgent: TestProxyAgent,
+        fetch: async () => new MalformedLengthResponse() as unknown as Response,
+      };
+      const fetch = buildMcpHttpFetch({ resourceUrl: "https://mcp.example.com/mcp" });
+
+      const response = await fetch("https://mcp.example.com/mcp");
+      expect(response).toBeInstanceOf(Response);
+      expect(response.body).toBeNull();
+      expect(text).not.toHaveBeenCalled();
+    },
+  );
+
+  it("accepts body-less responses with valid Content-Length within the 1 MiB cap", async () => {
+    const body = JSON.stringify({ ok: true });
+    class WithinLimitResponse {
+      status = 200;
+      statusText = "OK";
+      headers = new Headers({
+        "content-length": String(Buffer.byteLength(body, "utf8")),
+        "content-type": "application/json",
+      });
+      body = null;
+      async text() {
+        return body;
+      }
+    }
+    testGlobal[TEST_UNDICI_RUNTIME_DEPS_KEY] = {
+      Agent: TestAgent,
+      EnvHttpProxyAgent: TestEnvHttpProxyAgent,
+      ProxyAgent: TestProxyAgent,
+      fetch: async () => new WithinLimitResponse() as unknown as Response,
+    };
+    const fetch = buildMcpHttpFetch({ resourceUrl: "https://mcp.example.com/mcp" });
+
+    const response = await fetch("https://mcp.example.com/mcp");
+    expect(response.status).toBe(200);
+    const text = await response.text();
+    expect(text).toBe('{"ok":true}');
   });
 });

--- a/src/agents/mcp-http-fetch.ts
+++ b/src/agents/mcp-http-fetch.ts
@@ -25,6 +25,8 @@ const fetchWithUndiciGuard = async (
 ): Promise<Response> => await fetchWithUndici(input instanceof Request ? input.url : input, init);
 
 const MCP_HTTP_MAX_REDIRECTS = 20;
+/** Safety cap for MCP HTTP response body reads (1 MiB). */
+const MCP_HTTP_MAX_RESPONSE_BYTES = 1 * 1024 * 1024;
 const managedMcpResponseCleanupRegistry = new FinalizationRegistry<{
   finalize: () => Promise<void>;
 }>((held) => {
@@ -66,7 +68,23 @@ async function ensureGlobalFetchResponse(response: Response): Promise<Response> 
     return new Response(null, init);
   }
   if (typeof response.text === "function") {
+    const contentLength = response.headers.get("content-length");
+    // Reject without reading when the declared size is missing, malformed,
+    // or exceeds the cap. A missing Content-Length on a body-less response
+    // means we cannot verify the size before calling text(), so we skip the
+    // read to avoid unbounded allocation on untrusted input.
+    if (contentLength == null || !/^\d+$/.test(contentLength)) {
+      return new Response(null, init);
+    }
+    const length = Number(contentLength);
+    if (!Number.isFinite(length) || length > MCP_HTTP_MAX_RESPONSE_BYTES) {
+      return new Response(null, init);
+    }
     const text = await response.text();
+    // Guard against declared Content-Length that understates the actual body.
+    if (Buffer.byteLength(text, "utf8") > MCP_HTTP_MAX_RESPONSE_BYTES) {
+      return new Response(null, init);
+    }
     return new Response(text, init);
   }
   return new Response(null, init);


### PR DESCRIPTION
## What Problem This Solves
Fixes an issue where body-less MCP HTTP responses (e.g. OAuth error ForeignResponse objects from the MCP SDK, or responses whose body was consumed) could exhaust process memory. The `ensureGlobalFetchResponse` function called `response.text()` without verifying the declared Content-Length, allowing an oversized body-less response to allocate unbounded memory.

## Why This Change Was Made
Single-chokepoint fix at `ensureGlobalFetchResponse` — both callers in `buildManagedMcpResponse` converge through this function. The change makes the body-less path fail-safe:

- **Content-Length present and valid (decimal integer, <= 1 MiB)** → `text()` is called, response body preserved.
- **Content-Length missing, malformed (non-decimal), or oversized** → `text()` is **never called**, returning a null-body Response. No allocation, no OOM.
- **Post-read guard** → even when Content-Length is valid, byte length is verified after `text()` to catch lying headers.
- **Streaming responses (body != null) are untouched** — they already avoid buffering.

Cap is **1 MiB**, matching the merged `CONVEX_BROKER_RESPONSE_MAX_BYTES` precedent in #98619. Content-Length validation uses `/^\d+$/` to reject scientific-notation (`1e3`) and hex (`0x40`) values that `Number()` would accept but are invalid per RFC 7230.

## User Impact
MCP servers returning oversized or unverifiable body-less responses now receive a null-body Response instead of causing the gateway process to allocate unbounded memory. Legitimate MCP OAuth error responses (which declare a valid Content-Length) are unaffected.

## Real behavior proof

**Behavior addressed:** `buildMcpHttpFetch` (production entry point) → `ensureGlobalFetchResponse` rejects/drops body-less text reads when Content-Length is missing, malformed, or oversized. `text()` is never called in those cases, preventing the unbounded allocation.

**Real environment tested:** Linux x64, Node 22.22.0, standalone `.mts` script driving the real `buildMcpHttpFetch` production function.

**Evidence after fix:**
```
[case 1] body-less response with valid Content-Length — text preserved
  ok: returns status 400
  ok: body is readable
  ok: text content preserved
[case 2] oversized Content-Length (1048577 bytes) → null body, text() skipped
  ok: returns a Response (does not throw)
  ok: body is null (text dropped)
  ok: text() was NOT called
  info: text() called 0 times (expected 0)
[case 3] missing Content-Length → null body, text() skipped
  ok: returns a Response (does not throw)
  ok: body is null (text skipped)
  ok: text() was NOT called
  info: text() called 0 times (expected 0)
[case 4] malformed Content-Length ("abc") → null body, text() skipped
  ok: returns a Response (does not throw)
  ok: body is null (text skipped)
  ok: text() was NOT called
  info: text() called 0 times (expected 0)
[case 5] Content-Length exactly at cap (1048576 bytes) → accepted
  ok: returns a Response
  ok: body is readable
  ok: text() was called
  info: text() called 1 times, body byteLength=1048576
[case 6] 204 No Content response passes through unchanged
  ok: returns status 204
  ok: body is null
[case 7] streaming response (body != null) passes through untouched
  ok: returns status 200
  ok: body is readable
  ok: text content preserved

=== Summary ===
cap: 1048576 bytes (~1 MiB)
ALL PROOF ASSERTIONS: 20 passed, 0 failed
```

**Negative control (pre-fix main code, same script):**
```
[case 2] oversized Content-Length (1048577 bytes) → null body, text() skipped
  FAIL: body is null (text dropped)
  FAIL: text() was NOT called
  info: text() called 1 times (expected 0)
[case 3] missing Content-Length → null body, text() skipped
  FAIL: body is null (text skipped)
  FAIL: text() was NOT called
  info: text() called 1 times (expected 0)
[case 4] malformed Content-Length ("abc") → null body, text() skipped
  FAIL: body is null (text skipped)
  FAIL: text() was NOT called
  info: text() called 1 times (expected 0)

ALL PROOF ASSERTIONS: 14 passed, 6 failed
exit=1
```

Without the fix, `text()` is called unconditionally on oversized/missing/malformed Content-Length responses (6 FAIL, exit=1). With the fix, text() is never called in those cases and the response is dropped safely.

**What was not tested:** Full undici network round-trip (mock fetch used; the bounds guards operate on the Response object post-fetch, independent of transport). Streaming response path is verified untouched.

## Evidence
**Vitest:** 16/16 passed (10 existing + 6 new)
```
$ node scripts/run-vitest.mjs src/agents/mcp-http-fetch.test.ts --run
Test Files  1 passed (1)
     Tests  16 passed (16)
```

**New tests:**
- `drops body-less text when Content-Length exceeds the 1 MiB cap` — verifies `text()` not called
- `drops body-less text when Content-Length is missing` — verifies `text()` not called
- `drops body-less text when Content-Length is malformed (abc/1e3/0x40)` — parameterized, verifies `text()` not called
- `accepts body-less responses with valid Content-Length within the 1 MiB cap` — verifies normal path works
- Updated existing ForeignResponse OAuth test to include Content-Length header