### PR TITLE
test(regexp): add unit tests for escapeRegExp

### DIFF
--- a/src/shared/regexp.test.ts
+++ b/src/shared/regexp.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "vitest";
+import { escapeRegExp } from "./regexp.js";
+
+describe("escapeRegExp", () => {
+  it("returns the original string when no regex special characters are present", () => {
+    expect(escapeRegExp("hello")).toBe("hello");
+    expect(escapeRegExp("hello world 123")).toBe("hello world 123");
+  });
+
+  it("escapes individual regex special characters", () => {
+    expect(escapeRegExp(".")).toBe("\\.");
+    expect(escapeRegExp("*")).toBe("\\*");
+    expect(escapeRegExp("+")).toBe("\\+");
+    expect(escapeRegExp("?")).toBe("\\?");
+    expect(escapeRegExp("^")).toBe("\\^");
+    expect(escapeRegExp("$")).toBe("\\$");
+    expect(escapeRegExp("{")).toBe("\\{");
+    expect(escapeRegExp("}")).toBe("\\}");
+    expect(escapeRegExp("(")).toBe("\\(");
+    expect(escapeRegExp(")")).toBe("\\)");
+    expect(escapeRegExp("[")).toBe("\\[");
+    expect(escapeRegExp("]")).toBe("\\]");
+    expect(escapeRegExp("|")).toBe("\\|");
+    expect(escapeRegExp("\\")).toBe("\\\\");
+  });
+
+  it("escapes combinations of special characters", () => {
+    expect(escapeRegExp("[test].*")).toBe("\\[test\\]\\.\\*");
+    expect(escapeRegExp("a+b?c")).toBe("a\\+b\\?c");
+    expect(escapeRegExp("${value}")).toBe("\\$\\{value\\}");
+  });
+
+  it("returns an empty string unchanged", () => {
+    expect(escapeRegExp("")).toBe("");
+  });
+
+  it("handles strings that are already partially escaped", () => {
+    expect(escapeRegExp("\\.")).toBe("\\\\\\.");
+    expect(escapeRegExp("\\[test\\]")).toBe("\\\\\\[test\\\\\\]");
+  });
+
+  it("escapes special characters embedded in longer text", () => {
+    expect(escapeRegExp("price: $19.99 + tax?")).toBe("price: \\$19\\.99 \\+ tax\\?");
+  });
+});


### PR DESCRIPTION
## What Problem This Solves

The `escapeRegExp` helper in `src/shared/regexp.ts` escapes special characters so they can be embedded literally inside a RegExp pattern. Despite being a shared utility with zero dependencies, this module had no unit tests.

## Why This Change Was Made

Add unit tests for the `escapeRegExp` function covering:
- No-op on regular text without special characters
- Individual escaping of all 14 regex special characters (`. * + ? ^ $ { } ( ) [ ] | \`)
- Combined special character sequences
- Empty string handling
- Already-escaped inputs (double-escaping)
- Embedded special characters in longer strings

## Changes

- **`src/shared/regexp.test.ts`** — new test file with 6 focused test cases

## Evidence

Reproducibility: not applicable. This PR adds direct coverage for existing utility behavior. Source inspection confirms the utility behavior the tests target.

Direct behavior probe (no mocks — real functions exercised directly):

```text
$ node --import tsx _probe_escape_regexp.mjs
  "hello" → "hello"
  "." → "\."
  "*" → "\*"
  "+" → "\+"
  "?" → "\?"
  "^" → "\^"
  "$" → "\$"
  "(" → "\("
  ")" → "\)"
  "[" → "\["
  "]" → "\]"
  "|" → "\|"
  "\" → "\\"
  "[test].*" → "\[test\]\.\*"
  "${value}" → "\$\{value\}"
  "(empty)" → ""
  "price: $19.99 + tax?" → "price: \$19\.99 \+ tax\?"
```

## Related

N/A (self-contained test coverage improvement)

🤖 Generated with [Claude Code](https://claude.com/claude-code)