### PR TITLE
refactor(shared): consolidate gateway and stateful runtime lazy loaders

### DIFF
--- a/src/acp/translator.ts
+++ b/src/acp/translator.ts
@@ -47,6 +47,7 @@ import {
   resolveFixedWindowRateLimitInteger,
   type FixedWindowRateLimiter,
 } from "../infra/fixed-window-rate-limit.js";
+import { createLazyRuntimeModule } from "../shared/lazy-runtime.js";
 import { shortenHomePath } from "../utils.js";
 import {
   createInMemoryAcpEventLedger,
@@ -127,18 +128,16 @@ function isTerminalChatSendAckSuccess(status: unknown): boolean {
   return normalizedChatSendAckStatus(status) === "ok";
 }
 
-let acpCommandsModulePromise: Promise<typeof import("./commands.js")> | undefined;
-let acpSdkModulePromise: Promise<typeof import("@agentclientprotocol/sdk")> | undefined;
+const loadAcpCommandsModule = createLazyRuntimeModule(() => import("./commands.js"));
+const loadAcpSdkModule = createLazyRuntimeModule(() => import("@agentclientprotocol/sdk"));
 
 async function getAvailableCommandsForAcp() {
-  acpCommandsModulePromise ??= import("./commands.js");
-  const { getAvailableCommands } = await acpCommandsModulePromise;
+  const { getAvailableCommands } = await loadAcpCommandsModule();
   return getAvailableCommands();
 }
 
 async function getAcpProtocolVersion() {
-  acpSdkModulePromise ??= import("@agentclientprotocol/sdk");
-  const { PROTOCOL_VERSION } = await acpSdkModulePromise;
+  const { PROTOCOL_VERSION } = await loadAcpSdkModule();
   return PROTOCOL_VERSION;
 }
 

--- a/src/channels/plugins/setup-wizard-helpers.ts
+++ b/src/channels/plugins/setup-wizard-helpers.ts
@@ -13,6 +13,7 @@ import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import type { SecretInput } from "../../config/types.secrets.js";
 import { resolveSecretInputModeForEnvSelection } from "../../plugins/provider-auth-mode.js";
 import { DEFAULT_ACCOUNT_ID, normalizeAccountId } from "../../routing/session-key.js";
+import { createLazyRuntimeModule } from "../../shared/lazy-runtime.js";
 import type { WizardPrompter } from "../../wizard/prompts.js";
 import { resolveChannelDmAllowFrom, resolveChannelDmPolicy } from "./dm-access.js";
 import {
@@ -28,14 +29,9 @@ import type {
   PromptAccountIdParams,
 } from "./setup-wizard-types.js";
 
-let providerAuthInputPromise:
-  | Promise<Pick<typeof import("../../plugins/provider-auth-ref.js"), "promptSecretRefForSetup">>
-  | undefined;
-
-function loadProviderAuthInput() {
-  providerAuthInputPromise ??= import("../../plugins/provider-auth-ref.js");
-  return providerAuthInputPromise;
-}
+const loadProviderAuthInput = createLazyRuntimeModule(
+  () => import("../../plugins/provider-auth-ref.js"),
+);
 
 function asRecord(value: unknown): Record<string, unknown> | undefined {
   return value != null && typeof value === "object" && !Array.isArray(value)

--- a/src/channels/plugins/stateful-target-builtins.ts
+++ b/src/channels/plugins/stateful-target-builtins.ts
@@ -1,3 +1,4 @@
+import { createLazyRuntimeModule } from "../../shared/lazy-runtime.js";
 /**
  * Built-in stateful binding target registration.
  *
@@ -5,15 +6,11 @@
  */
 import { registerStatefulBindingTargetDriver } from "./stateful-target-drivers.js";
 
-type AcpStatefulTargetDriverModule = typeof import("./acp-stateful-target-driver.js");
-
 let builtinsRegisteredPromise: Promise<void> | null = null;
-let acpDriverModulePromise: Promise<AcpStatefulTargetDriverModule> | undefined;
 
-function loadAcpStatefulTargetDriverModule(): Promise<AcpStatefulTargetDriverModule> {
-  acpDriverModulePromise ??= import("./acp-stateful-target-driver.js");
-  return acpDriverModulePromise;
-}
+const loadAcpStatefulTargetDriverModule = createLazyRuntimeModule(
+  () => import("./acp-stateful-target-driver.js"),
+);
 
 export function isStatefulTargetBuiltinDriverId(id: string): boolean {
   return id.trim() === "acp";

--- a/src/channels/session-meta.ts
+++ b/src/channels/session-meta.ts
@@ -1,16 +1,12 @@
 // Best-effort inbound session metadata recorder for channel plugin command handlers.
 import type { MsgContext } from "../auto-reply/templating.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { createLazyRuntimeModule } from "../shared/lazy-runtime.js";
 
-let inboundSessionRuntimePromise: Promise<
-  typeof import("../config/sessions/inbound.runtime.js")
-> | null = null;
-
-function loadInboundSessionRuntime() {
-  // Keep the session writer out of channel startup paths that only need SDK types.
-  inboundSessionRuntimePromise ??= import("../config/sessions/inbound.runtime.js");
-  return inboundSessionRuntimePromise;
-}
+// Keep the session writer out of channel startup paths that only need SDK types.
+const loadInboundSessionRuntime = createLazyRuntimeModule(
+  () => import("../config/sessions/inbound.runtime.js"),
+);
 
 /**
  * Best-effort inbound session metadata recorder for channel plugin command handlers.

--- a/src/channels/session.ts
+++ b/src/channels/session.ts
@@ -3,18 +3,15 @@ import { normalizeLowercaseStringOrEmpty } from "@openclaw/normalization-core/st
 import type { MsgContext } from "../auto-reply/templating.js";
 import type { GroupKeyResolution } from "../config/sessions/types.js";
 import { normalizeSessionKeyPreservingOpaquePeerIds } from "../sessions/session-key-utils.js";
+import { createLazyRuntimeModule } from "../shared/lazy-runtime.js";
 import type { InboundLastRouteUpdate } from "./session.types.js";
+
 export type { InboundLastRouteUpdate, RecordInboundSession } from "./session.types.js";
 
-let inboundSessionRuntimePromise: Promise<
-  typeof import("../config/sessions/inbound.runtime.js")
-> | null = null;
-
-function loadInboundSessionRuntime() {
-  // Keep session persistence lazy so channel SDK type paths do not load disk writers.
-  inboundSessionRuntimePromise ??= import("../config/sessions/inbound.runtime.js");
-  return inboundSessionRuntimePromise;
-}
+// Keep session persistence lazy so channel SDK type paths do not load disk writers.
+const loadInboundSessionRuntime = createLazyRuntimeModule(
+  () => import("../config/sessions/inbound.runtime.js"),
+);
 
 function shouldSkipPinnedMainDmRouteUpdate(
   pin: InboundLastRouteUpdate["mainDmOwnerPin"] | undefined,

--- a/src/context-engine/delegate.ts
+++ b/src/context-engine/delegate.ts
@@ -1,22 +1,13 @@
 // Context-engine delegates bridge custom engines to built-in compaction and memory prompt paths.
-import type { CompactEmbeddedAgentSessionDirect } from "../agents/embedded-agent-runner/compact.runtime.types.js";
 import { normalizeStructuredPromptSection } from "../agents/prompt-cache-stability.js";
 import type { MemoryCitationsMode } from "../config/types.memory.js";
 import { buildMemoryPromptSection } from "../plugins/memory-state.js";
+import { createLazyRuntimeModule } from "../shared/lazy-runtime.js";
 import type { ContextEngine, CompactResult, ContextEngineRuntimeContext } from "./types.js";
 
-type CompactRuntimeModule = {
-  compactEmbeddedAgentSessionDirect: CompactEmbeddedAgentSessionDirect;
-};
-
-let compactRuntimePromise: Promise<CompactRuntimeModule> | null = null;
-
-function loadCompactRuntime(): Promise<CompactRuntimeModule> {
-  // Use a literal specifier so the bundler rewrites the runtime chunk path
-  // instead of resolving a source-tree path at runtime.
-  compactRuntimePromise ??= import("../agents/embedded-agent-runner/compact.runtime.js");
-  return compactRuntimePromise;
-}
+const loadCompactRuntime = createLazyRuntimeModule(
+  () => import("../agents/embedded-agent-runner/compact.runtime.js"),
+);
 
 /**
  * Delegate a context-engine compaction request to OpenClaw's built-in runtime compaction path.

--- a/src/gateway/server-aux-handlers.ts
+++ b/src/gateway/server-aux-handlers.ts
@@ -12,6 +12,7 @@ import {
   getActiveSecretsRuntimeSnapshot,
   type PreparedSecretsRuntimeSnapshot,
 } from "../secrets/runtime-state.js";
+import { createLazyPromise } from "../shared/lazy-runtime.js";
 import { diffConfigPaths } from "./config-diff.js";
 import {
   buildGatewayReloadPlan,
@@ -76,25 +77,27 @@ export function createGatewayAuxHandlers(params: {
   const execApprovalManager = new ExecApprovalManager();
   const execApprovalForwarder = createExecApprovalForwarder();
   const execApprovalIosPushDelivery = createExecApprovalIosPushDelivery({ log: params.log });
-  let execApprovalHandlersPromise: Promise<GatewayRequestHandlers> | null = null;
-  const loadExecApprovalHandlers = () =>
-    (execApprovalHandlersPromise ??= import("./server-methods/exec-approval.js").then(
-      ({ createExecApprovalHandlers }) =>
+  const loadExecApprovalHandlers = createLazyPromise(
+    () =>
+      import("./server-methods/exec-approval.js").then(({ createExecApprovalHandlers }) =>
         createExecApprovalHandlers(execApprovalManager, {
           forwarder: execApprovalForwarder,
           iosPushDelivery: execApprovalIosPushDelivery,
         }),
-    ));
+      ),
+    { cacheRejections: true },
+  );
   const buildReloadPlan = params.buildReloadPlan ?? buildGatewayReloadPlan;
   const pluginApprovalManager = new ExecApprovalManager<PluginApprovalRequestPayload>();
-  let pluginApprovalHandlersPromise: Promise<GatewayRequestHandlers> | null = null;
-  const loadPluginApprovalHandlers = () =>
-    (pluginApprovalHandlersPromise ??= import("./server-methods/plugin-approval.js").then(
-      ({ createPluginApprovalHandlers }) =>
+  const loadPluginApprovalHandlers = createLazyPromise(
+    () =>
+      import("./server-methods/plugin-approval.js").then(({ createPluginApprovalHandlers }) =>
         createPluginApprovalHandlers(pluginApprovalManager, {
           forwarder: execApprovalForwarder,
         }),
-    ));
+      ),
+    { cacheRejections: true },
+  );
   // Serialize the entire `secrets.reload` path (activation + channel restart)
   // so concurrent callers cannot overlap the stop/start loop and so the
   // "before" snapshot used for the reload-plan diff is always the snapshot
@@ -116,10 +119,9 @@ export function createGatewayAuxHandlers(params: {
     reloadInFlight = run;
     return run;
   };
-  let secretsHandlersPromise: Promise<GatewayRequestHandlers> | null = null;
-  const loadSecretsHandlers = () =>
-    (secretsHandlersPromise ??= import("./server-methods/secrets.js").then(
-      ({ createSecretsHandlers }) =>
+  const loadSecretsHandlers = createLazyPromise(
+    () =>
+      import("./server-methods/secrets.js").then(({ createSecretsHandlers }) =>
         createSecretsHandlers({
           reloadSecrets: () =>
             runExclusiveReload(async () => {
@@ -262,7 +264,9 @@ export function createGatewayAuxHandlers(params: {
             return { assignments, diagnostics, inactiveRefPaths };
           },
         }),
-    ));
+      ),
+    { cacheRejections: true },
+  );
 
   return {
     execApprovalManager,

--- a/src/gateway/server-cron-lazy.ts
+++ b/src/gateway/server-cron-lazy.ts
@@ -4,6 +4,7 @@ import type { CliDeps } from "../cli/deps.types.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import type { CronServiceContract } from "../cron/service-contract.js";
 import { resolveCronJobsStorePath } from "../cron/store.js";
+import { createLazyPromiseLoader } from "../shared/lazy-runtime.js";
 import type { GatewayCronState } from "./server-cron.js";
 
 type LazyGatewayCronParams = {
@@ -22,8 +23,18 @@ export function createLazyGatewayCronState(params: LazyGatewayCronParams): Gatew
   const storePath = resolveCronJobsStorePath(params.cfg.cron?.store);
   const cronEnabled = process.env.OPENCLAW_SKIP_CRON !== "1" && params.cfg.cron?.enabled !== false;
   let loaded: LoadedGatewayCronState | null = null;
-  let loading: Promise<LoadedGatewayCronState> | null = null;
   let stopped = false;
+  const cronStateLoader = createLazyPromiseLoader(
+    () =>
+      import("./server-cron.js").then(({ buildGatewayCronService }) => {
+        loaded = {
+          state: buildGatewayCronService(params),
+          started: false,
+        };
+        return loaded;
+      }),
+    { cacheRejections: true },
+  );
 
   const load = async (): Promise<LoadedGatewayCronState> => {
     if (loaded) {
@@ -31,14 +42,7 @@ export function createLazyGatewayCronState(params: LazyGatewayCronParams): Gatew
     }
     // Share the same import promise across concurrent API calls so only one
     // scheduler instance is built for a Gateway process.
-    loading ??= import("./server-cron.js").then(({ buildGatewayCronService }) => {
-      loaded = {
-        state: buildGatewayCronService(params),
-        started: false,
-      };
-      return loaded;
-    });
-    return await loading;
+    return await cronStateLoader.load();
   };
 
   const cron: CronServiceContract = {
@@ -74,6 +78,7 @@ export function createLazyGatewayCronState(params: LazyGatewayCronParams): Gatew
         loaded.state.stopExitWatchers?.();
         return;
       }
+      const loading = cronStateLoader.peek();
       if (loading) {
         // Stop may happen while the dynamic import is still in flight; attach a
         // cleanup continuation instead of forcing cron to load synchronously.

--- a/src/gateway/server-http.ts
+++ b/src/gateway/server-http.ts
@@ -16,6 +16,7 @@ import {
   createDiagnosticTraceContext,
   runWithDiagnosticTraceContext,
 } from "../infra/diagnostic-trace-context.js";
+import { createLazyRuntimeModule } from "../shared/lazy-runtime.js";
 import { resolveAssistantIdentity } from "./assistant-identity.js";
 import type { AuthRateLimiter } from "./auth-rate-limit.js";
 import {
@@ -69,92 +70,41 @@ type ResolvePluginNodeCapabilityRoute = (
   pathContext: PluginRoutePathContext,
 ) => PluginNodeCapabilitySurface | undefined;
 
-let identityAvatarModulePromise: Promise<typeof import("../agents/identity-avatar.js")> | undefined;
-let controlUiModulePromise: Promise<typeof import("./control-ui.js")> | undefined;
-let embeddingsHttpModulePromise: Promise<typeof import("./embeddings-http.js")> | undefined;
-let managedImageAttachmentsModulePromise:
-  | Promise<typeof import("./managed-image-attachments.js")>
-  | undefined;
-let modelsHttpModulePromise: Promise<typeof import("./models-http.js")> | undefined;
-let openAiHttpModulePromise: Promise<typeof import("./openai-http.js")> | undefined;
-let openResponsesHttpModulePromise: Promise<typeof import("./openresponses-http.js")> | undefined;
-let sessionHistoryHttpModulePromise:
-  | Promise<typeof import("./sessions-history-http.js")>
-  | undefined;
-let sessionKillHttpModulePromise: Promise<typeof import("./session-kill-http.js")> | undefined;
-let toolsInvokeHttpModulePromise: Promise<typeof import("./tools-invoke-http.js")> | undefined;
-let pluginNodeCapabilityAuthModulePromise:
-  | Promise<typeof import("./server/plugin-node-capability-auth.js")>
-  | undefined;
-let httpAuthUtilsModulePromise: Promise<typeof import("./http-auth-utils.js")> | undefined;
-let pluginRouteRuntimeScopesModulePromise:
-  | Promise<typeof import("./server/plugin-route-runtime-scopes.js")>
-  | undefined;
+const getIdentityAvatarModule = createLazyRuntimeModule(
+  () => import("../agents/identity-avatar.js"),
+);
 
-function getIdentityAvatarModule() {
-  identityAvatarModulePromise ??= import("../agents/identity-avatar.js");
-  return identityAvatarModulePromise;
-}
+const getControlUiModule = createLazyRuntimeModule(() => import("./control-ui.js"));
 
-function getControlUiModule() {
-  controlUiModulePromise ??= import("./control-ui.js");
-  return controlUiModulePromise;
-}
+const getEmbeddingsHttpModule = createLazyRuntimeModule(() => import("./embeddings-http.js"));
 
-function getEmbeddingsHttpModule() {
-  embeddingsHttpModulePromise ??= import("./embeddings-http.js");
-  return embeddingsHttpModulePromise;
-}
+const getManagedImageAttachmentsModule = createLazyRuntimeModule(
+  () => import("./managed-image-attachments.js"),
+);
 
-function getManagedImageAttachmentsModule() {
-  managedImageAttachmentsModulePromise ??= import("./managed-image-attachments.js");
-  return managedImageAttachmentsModulePromise;
-}
+const getModelsHttpModule = createLazyRuntimeModule(() => import("./models-http.js"));
 
-function getModelsHttpModule() {
-  modelsHttpModulePromise ??= import("./models-http.js");
-  return modelsHttpModulePromise;
-}
+const getOpenAiHttpModule = createLazyRuntimeModule(() => import("./openai-http.js"));
 
-function getOpenAiHttpModule() {
-  openAiHttpModulePromise ??= import("./openai-http.js");
-  return openAiHttpModulePromise;
-}
+const getOpenResponsesHttpModule = createLazyRuntimeModule(() => import("./openresponses-http.js"));
 
-function getOpenResponsesHttpModule() {
-  openResponsesHttpModulePromise ??= import("./openresponses-http.js");
-  return openResponsesHttpModulePromise;
-}
+const getSessionHistoryHttpModule = createLazyRuntimeModule(
+  () => import("./sessions-history-http.js"),
+);
 
-function getSessionHistoryHttpModule() {
-  sessionHistoryHttpModulePromise ??= import("./sessions-history-http.js");
-  return sessionHistoryHttpModulePromise;
-}
+const getSessionKillHttpModule = createLazyRuntimeModule(() => import("./session-kill-http.js"));
 
-function getSessionKillHttpModule() {
-  sessionKillHttpModulePromise ??= import("./session-kill-http.js");
-  return sessionKillHttpModulePromise;
-}
+const getToolsInvokeHttpModule = createLazyRuntimeModule(() => import("./tools-invoke-http.js"));
 
-function getToolsInvokeHttpModule() {
-  toolsInvokeHttpModulePromise ??= import("./tools-invoke-http.js");
-  return toolsInvokeHttpModulePromise;
-}
+const getPluginNodeCapabilityAuthModule = createLazyRuntimeModule(
+  () => import("./server/plugin-node-capability-auth.js"),
+);
 
-function getPluginNodeCapabilityAuthModule() {
-  pluginNodeCapabilityAuthModulePromise ??= import("./server/plugin-node-capability-auth.js");
-  return pluginNodeCapabilityAuthModulePromise;
-}
+const getHttpAuthUtilsModule = createLazyRuntimeModule(() => import("./http-auth-utils.js"));
 
-function getHttpAuthUtilsModule() {
-  httpAuthUtilsModulePromise ??= import("./http-auth-utils.js");
-  return httpAuthUtilsModulePromise;
-}
-
-function getPluginRouteRuntimeScopesModule() {
-  pluginRouteRuntimeScopesModulePromise ??= import("./server/plugin-route-runtime-scopes.js");
-  return pluginRouteRuntimeScopesModulePromise;
-}
+const getPluginRouteRuntimeScopesModule = createLazyRuntimeModule(
+  () => import("./server/plugin-route-runtime-scopes.js"),
+);
 
 const GATEWAY_PROBE_STATUS_BY_PATH = new Map<string, "live" | "ready">([
   ["/health", "live"],

--- a/src/gateway/server-methods/sessions.ts
+++ b/src/gateway/server-methods/sessions.ts
@@ -82,6 +82,7 @@ import {
   resolveAgentIdFromSessionKey,
   toAgentStoreSessionKey,
 } from "../../routing/session-key.js";
+import { createLazyRuntimeModule } from "../../shared/lazy-runtime.js";
 import { ADMIN_SCOPE } from "../operator-scopes.js";
 import { resolveSessionKeyForRun } from "../server-session-key.js";
 import {
@@ -199,14 +200,7 @@ function inheritSessionRuntimeSelection(
   };
 }
 
-type SessionsRuntimeModule = typeof import("./sessions.runtime.js");
-
-let sessionsRuntimeModulePromise: Promise<SessionsRuntimeModule> | undefined;
-
-function loadSessionsRuntimeModule(): Promise<SessionsRuntimeModule> {
-  sessionsRuntimeModulePromise ??= import("./sessions.runtime.js");
-  return sessionsRuntimeModulePromise;
-}
+const loadSessionsRuntimeModule = createLazyRuntimeModule(() => import("./sessions.runtime.js"));
 
 function requireSessionKey(key: unknown, respond: RespondFn): string | null {
   const raw =

--- a/src/gateway/server-runtime-subscriptions.ts
+++ b/src/gateway/server-runtime-subscriptions.ts
@@ -3,6 +3,7 @@ import { clearAgentRunContext, onAgentEvent } from "../infra/agent-events.js";
 import { onHeartbeatEvent } from "../infra/heartbeat-events.js";
 import { onSessionLifecycleEvent } from "../sessions/session-lifecycle-events.js";
 import { onInternalSessionTranscriptUpdate } from "../sessions/transcript-events.js";
+import { createLazyPromise } from "../shared/lazy-runtime.js";
 import type { ChatAbortControllerEntry, RestartRecoveryCandidate } from "./chat-abort.js";
 import type {
   ChatRunState,
@@ -29,122 +30,116 @@ export function startGatewayEventSubscriptions(params: {
   chatAbortControllers: Map<string, ChatAbortControllerEntry>;
   restartRecoveryCandidates: Map<string, RestartRecoveryCandidate>;
 }) {
-  let agentEventHandlerPromise: Promise<
-    ReturnType<typeof import("./server-chat.js").createAgentEventHandler>
-  > | null = null;
-  const getAgentEventHandler = () => {
-    // Lazy-load heavy chat modules only after the first agent event reaches the gateway.
-    agentEventHandlerPromise ??= Promise.all([
-      import("./server-chat.js"),
-      import("./server-session-key.js"),
-    ]).then(([{ createAgentEventHandler }, { resolveSessionKeyForRun }]) =>
-      createAgentEventHandler({
-        broadcast: params.broadcast,
-        broadcastToConnIds: params.broadcastToConnIds,
-        nodeSendToSession: params.nodeSendToSession,
-        agentRunSeq: params.agentRunSeq,
-        chatRunState: params.chatRunState,
-        resolveSessionKeyForRun,
-        clearAgentRunContext,
-        toolEventRecipients: params.toolEventRecipients,
-        sessionEventSubscribers: params.sessionEventSubscribers,
-        sessionMessageSubscribers: params.sessionMessageSubscribers,
-        clearTrackedActiveRun: ({ runId, clientRunId }) => {
-          const candidateRunIds = runId === clientRunId ? [runId] : [runId, clientRunId];
-          for (const candidateRunId of candidateRunIds) {
-            const entry = params.chatAbortControllers.get(candidateRunId);
-            // Chat abort entries can hold the requested key while chat run
-            // state holds the canonical key; the run ids are the scoped match.
-            if (entry) {
-              entry.projectSessionActive = false;
-              entry.projectSessionTerminalPending = false;
-              entry.projectSessionTerminalPersisted = false;
-              queueMicrotask(() => {
-                const current = params.chatAbortControllers.get(candidateRunId);
-                if (
-                  current === entry &&
-                  entry.registrationCleanupRequested === true &&
-                  !entry.projectSessionTerminalPersistence
-                ) {
-                  params.chatAbortControllers.delete(candidateRunId);
-                }
-              });
-            }
-          }
-        },
-        markTrackedRunTerminalPersisted: ({ runId, clientRunId }) => {
-          const candidateRunIds = runId === clientRunId ? [runId] : [runId, clientRunId];
-          for (const candidateRunId of candidateRunIds) {
-            params.restartRecoveryCandidates.delete(candidateRunId);
-            const entry = params.chatAbortControllers.get(candidateRunId);
-            if (entry) {
-              entry.projectSessionTerminalPending = false;
-              entry.projectSessionTerminalPersisted = true;
-              entry.projectSessionTerminalPersistence = undefined;
-            }
-          }
-        },
-        trackTrackedRunTerminalPersistence: ({
-          runId,
-          clientRunId,
-          sessionId: terminalSessionId,
-          observedAt,
-          persistence,
-        }) => {
-          const candidateRunIds = runId === clientRunId ? [runId] : [runId, clientRunId];
-          for (const candidateRunId of candidateRunIds) {
-            const entry = params.chatAbortControllers.get(candidateRunId);
-            if (entry) {
-              entry.projectSessionTerminalPending = false;
-              entry.projectSessionTerminalPersistence = persistence;
-              if (entry.registrationCleanupRequested === true) {
-                void persistence
-                  .catch(() => undefined)
-                  .then(() => {
-                    if (params.chatAbortControllers.get(candidateRunId) === entry) {
+  const getAgentEventHandler = createLazyPromise(
+    () => {
+      // Lazy-load heavy chat modules only after the first agent event reaches the gateway.
+      return Promise.all([import("./server-chat.js"), import("./server-session-key.js")]).then(
+        ([{ createAgentEventHandler }, { resolveSessionKeyForRun }]) =>
+          createAgentEventHandler({
+            broadcast: params.broadcast,
+            broadcastToConnIds: params.broadcastToConnIds,
+            nodeSendToSession: params.nodeSendToSession,
+            agentRunSeq: params.agentRunSeq,
+            chatRunState: params.chatRunState,
+            resolveSessionKeyForRun,
+            clearAgentRunContext,
+            toolEventRecipients: params.toolEventRecipients,
+            sessionEventSubscribers: params.sessionEventSubscribers,
+            sessionMessageSubscribers: params.sessionMessageSubscribers,
+            clearTrackedActiveRun: ({ runId, clientRunId }) => {
+              const candidateRunIds = runId === clientRunId ? [runId] : [runId, clientRunId];
+              for (const candidateRunId of candidateRunIds) {
+                const entry = params.chatAbortControllers.get(candidateRunId);
+                // Chat abort entries can hold the requested key while chat run
+                // state holds the canonical key; the run ids are the scoped match.
+                if (entry) {
+                  entry.projectSessionActive = false;
+                  entry.projectSessionTerminalPending = false;
+                  entry.projectSessionTerminalPersisted = false;
+                  queueMicrotask(() => {
+                    const current = params.chatAbortControllers.get(candidateRunId);
+                    if (
+                      current === entry &&
+                      entry.registrationCleanupRequested === true &&
+                      !entry.projectSessionTerminalPersistence
+                    ) {
                       params.chatAbortControllers.delete(candidateRunId);
                     }
                   });
+                }
               }
-              const lifecycleGeneration = entry.lifecycleGeneration?.trim();
-              const sessionKey = entry.sessionKey.trim();
-              const sessionId = terminalSessionId?.trim() || entry.sessionId.trim();
-              if (
-                entry.controlUiVisible !== false &&
-                lifecycleGeneration &&
-                sessionKey &&
-                sessionId
-              ) {
-                void persistence.catch(() => {
-                  params.restartRecoveryCandidates.set(candidateRunId, {
-                    runId: candidateRunId,
-                    lifecycleGeneration,
-                    sessionKey,
-                    sessionId,
-                    observedAt,
-                  });
-                });
+            },
+            markTrackedRunTerminalPersisted: ({ runId, clientRunId }) => {
+              const candidateRunIds = runId === clientRunId ? [runId] : [runId, clientRunId];
+              for (const candidateRunId of candidateRunIds) {
+                params.restartRecoveryCandidates.delete(candidateRunId);
+                const entry = params.chatAbortControllers.get(candidateRunId);
+                if (entry) {
+                  entry.projectSessionTerminalPending = false;
+                  entry.projectSessionTerminalPersisted = true;
+                  entry.projectSessionTerminalPersistence = undefined;
+                }
               }
-            }
-          }
-        },
-        isChatSendRunActive: (runId) => {
-          const entry = params.chatAbortControllers.get(runId);
-          return entry !== undefined && entry.kind !== "agent";
-        },
-        resolveActiveLifecycleGenerationForRun: (runId) =>
-          params.chatAbortControllers.get(runId)?.lifecycleGeneration,
-      }),
-    );
-    return agentEventHandlerPromise;
-  };
+            },
+            trackTrackedRunTerminalPersistence: ({
+              runId,
+              clientRunId,
+              sessionId: terminalSessionId,
+              observedAt,
+              persistence,
+            }) => {
+              const candidateRunIds = runId === clientRunId ? [runId] : [runId, clientRunId];
+              for (const candidateRunId of candidateRunIds) {
+                const entry = params.chatAbortControllers.get(candidateRunId);
+                if (entry) {
+                  entry.projectSessionTerminalPending = false;
+                  entry.projectSessionTerminalPersistence = persistence;
+                  if (entry.registrationCleanupRequested === true) {
+                    void persistence
+                      .catch(() => undefined)
+                      .then(() => {
+                        if (params.chatAbortControllers.get(candidateRunId) === entry) {
+                          params.chatAbortControllers.delete(candidateRunId);
+                        }
+                      });
+                  }
+                  const lifecycleGeneration = entry.lifecycleGeneration?.trim();
+                  const sessionKey = entry.sessionKey.trim();
+                  const sessionId = terminalSessionId?.trim() || entry.sessionId.trim();
+                  if (
+                    entry.controlUiVisible !== false &&
+                    lifecycleGeneration &&
+                    sessionKey &&
+                    sessionId
+                  ) {
+                    void persistence.catch(() => {
+                      params.restartRecoveryCandidates.set(candidateRunId, {
+                        runId: candidateRunId,
+                        lifecycleGeneration,
+                        sessionKey,
+                        sessionId,
+                        observedAt,
+                      });
+                    });
+                  }
+                }
+              }
+            },
+            isChatSendRunActive: (runId) => {
+              const entry = params.chatAbortControllers.get(runId);
+              return entry !== undefined && entry.kind !== "agent";
+            },
+            resolveActiveLifecycleGenerationForRun: (runId) =>
+              params.chatAbortControllers.get(runId)?.lifecycleGeneration,
+          }),
+      );
+    },
+    { cacheRejections: true },
+  );
 
-  let sessionEventsModulePromise: Promise<typeof import("./server-session-events.js")> | null =
-    null;
-  const getSessionEventsModule = () => {
-    sessionEventsModulePromise ??= import("./server-session-events.js");
-    return sessionEventsModulePromise;
-  };
+  const getSessionEventsModule = createLazyPromise(() => import("./server-session-events.js"), {
+    cacheRejections: true,
+  });
 
   let transcriptUpdateHandlerPromise: Promise<
     ReturnType<typeof import("./server-session-events.js").createTranscriptUpdateBroadcastHandler>

--- a/src/gateway/server-startup-config.ts
+++ b/src/gateway/server-startup-config.ts
@@ -34,6 +34,7 @@ import {
   getLiveSecretsRuntimeAuthStores,
   setPreparedSecretsRuntimeSnapshotRefreshContext,
 } from "../secrets/runtime-state.js";
+import { createLazyPromise } from "../shared/lazy-runtime.js";
 import { resolveGatewayAuth } from "./auth.js";
 import { assertGatewayAuthNotKnownWeak } from "./known-weak-gateway-secrets.js";
 import {
@@ -183,19 +184,14 @@ export function createRuntimeSecretsActivator(params: {
 }): ActivateRuntimeSecrets {
   let secretsDegraded = false;
   let secretsActivationTail: Promise<void> = Promise.resolve();
-  let secretsRuntimePromise: Promise<typeof import("../secrets/runtime.js")> | null = null;
-  let authProfilesPromise: Promise<typeof import("../agents/auth-profiles.js")> | null = null;
+  const loadSecretsRuntime = createLazyPromise(() => import("../secrets/runtime.js"), {
+    cacheRejections: true,
+  });
+  const loadAuthProfiles = createLazyPromise(() => import("../agents/auth-profiles.js"), {
+    cacheRejections: true,
+  });
   const startupManifestRegistry =
     params.manifestRegistry ?? params.pluginMetadataSnapshot?.manifestRegistry;
-  const loadSecretsRuntime = () => {
-    secretsRuntimePromise ??= import("../secrets/runtime.js");
-    return secretsRuntimePromise;
-  };
-  const loadAuthProfiles = () => {
-    authProfilesPromise ??= import("../agents/auth-profiles.js");
-    return authProfilesPromise;
-  };
-
   const runWithSecretsActivationLock = async <T>(operation: () => Promise<T>): Promise<T> => {
     // Secret refresh mutates process-wide active snapshot state, so activation
     // requests are serialized even when reload and startup probes overlap.

--- a/src/gateway/server-startup-post-attach.ts
+++ b/src/gateway/server-startup-post-attach.ts
@@ -16,6 +16,7 @@ import type { loadOpenClawPlugins } from "../plugins/loader.js";
 import { getPluginModuleLoaderStats } from "../plugins/plugin-module-loader-cache.js";
 import type { PluginRegistry } from "../plugins/registry.js";
 import type { PluginServicesHandle } from "../plugins/services.js";
+import { createLazyRuntimeModule } from "../shared/lazy-runtime.js";
 import {
   GATEWAY_EVENT_UPDATE_AVAILABLE,
   type GatewayUpdateAvailableEventPayload,
@@ -50,42 +51,21 @@ type GatewayMemoryStartupPolicy =
   | { mode: "immediate" }
   | { mode: "idle"; delayMs: number };
 
-let mainSessionRestartRecoveryModulePromise: Promise<
-  typeof import("../agents/main-session-restart-recovery.js")
-> | null = null;
-let agentDefaultsModulePromise: Promise<typeof import("../agents/defaults.js")> | null = null;
-let agentModelSelectionModulePromise: Promise<
-  typeof import("../agents/model-selection.js")
-> | null = null;
-let internalHooksModulePromise: Promise<typeof import("../hooks/internal-hooks.js")> | null = null;
-let gatewayRestartSentinelModulePromise: Promise<
-  typeof import("./server-restart-sentinel.js")
-> | null = null;
+const loadMainSessionRestartRecoveryModule = createLazyRuntimeModule(
+  () => import("../agents/main-session-restart-recovery.js"),
+);
 
-const loadMainSessionRestartRecoveryModule = async () => {
-  mainSessionRestartRecoveryModulePromise ??= import("../agents/main-session-restart-recovery.js");
-  return await mainSessionRestartRecoveryModulePromise;
-};
+const loadAgentDefaultsModule = createLazyRuntimeModule(() => import("../agents/defaults.js"));
 
-const loadAgentDefaultsModule = async () => {
-  agentDefaultsModulePromise ??= import("../agents/defaults.js");
-  return await agentDefaultsModulePromise;
-};
+const loadAgentModelSelectionModule = createLazyRuntimeModule(
+  () => import("../agents/model-selection.js"),
+);
 
-const loadAgentModelSelectionModule = async () => {
-  agentModelSelectionModulePromise ??= import("../agents/model-selection.js");
-  return await agentModelSelectionModulePromise;
-};
+const loadInternalHooksModule = createLazyRuntimeModule(() => import("../hooks/internal-hooks.js"));
 
-const loadInternalHooksModule = async () => {
-  internalHooksModulePromise ??= import("../hooks/internal-hooks.js");
-  return await internalHooksModulePromise;
-};
-
-const loadGatewayRestartSentinelModule = async () => {
-  gatewayRestartSentinelModulePromise ??= import("./server-restart-sentinel.js");
-  return await gatewayRestartSentinelModulePromise;
-};
+const loadGatewayRestartSentinelModule = createLazyRuntimeModule(
+  () => import("./server-restart-sentinel.js"),
+);
 
 export type GatewayPostReadySidecarHandle = {
   stop: () => Awaitable<void>;

--- a/src/gateway/server.impl.ts
+++ b/src/gateway/server.impl.ts
@@ -54,13 +54,14 @@ import {
   pinActivePluginHttpRouteRegistry,
   pinActivePluginSessionExtensionRegistry,
 } from "../plugins/runtime.js";
-import type { PluginRuntime } from "../plugins/runtime/types.js";
 import { getTotalQueueSize, isGatewayDraining } from "../process/command-queue.js";
 import type { RuntimeEnv } from "../runtime.js";
 import {
   clearSecretsRuntimeSnapshot,
   getActiveSecretsRuntimeConfigSnapshot,
 } from "../secrets/runtime-state.js";
+import { createLazyRuntimeModule } from "../shared/lazy-runtime.js";
+import { createLazyPromise } from "../shared/lazy-runtime.js";
 import { createAuthRateLimiter, type AuthRateLimiter } from "./auth-rate-limit.js";
 import { resolveGatewayAuth } from "./auth.js";
 import type { RestartRecoveryCandidate } from "./chat-abort.js";
@@ -123,13 +124,9 @@ import { maybeSeedControlUiAllowedOriginsAtStartup } from "./startup-control-ui-
 
 type LoadGatewayModelCatalog = typeof import("./server-model-catalog.js").loadGatewayModelCatalog;
 
-let gatewayModelCatalogModulePromise: Promise<typeof import("./server-model-catalog.js")> | null =
-  null;
-
-const loadGatewayModelCatalogModule = async () => {
-  gatewayModelCatalogModulePromise ??= import("./server-model-catalog.js");
-  return await gatewayModelCatalogModulePromise;
-};
+const loadGatewayModelCatalogModule = createLazyRuntimeModule(
+  () => import("./server-model-catalog.js"),
+);
 
 export async function resetModelCatalogCacheForTest(): Promise<void> {
   const { resetModelCatalogCacheForTest: resetModelCatalogCacheForTestLocal } =
@@ -151,23 +148,13 @@ type GatewayStartupChannelPlugin = {
   };
 };
 
-let gatewayStartupEarlyModulePromise: Promise<typeof import("./server-startup-early.js")> | null =
-  null;
-let gatewayStartupPostAttachModulePromise: Promise<
-  typeof import("./server-startup-post-attach.js")
-> | null = null;
+const loadGatewayStartupEarlyModule = createLazyRuntimeModule(
+  () => import("./server-startup-early.js"),
+);
 
-function loadGatewayStartupEarlyModule(): Promise<typeof import("./server-startup-early.js")> {
-  gatewayStartupEarlyModulePromise ??= import("./server-startup-early.js");
-  return gatewayStartupEarlyModulePromise;
-}
-
-function loadGatewayStartupPostAttachModule(): Promise<
-  typeof import("./server-startup-post-attach.js")
-> {
-  gatewayStartupPostAttachModulePromise ??= import("./server-startup-post-attach.js");
-  return gatewayStartupPostAttachModulePromise;
-}
+const loadGatewayStartupPostAttachModule = createLazyRuntimeModule(
+  () => import("./server-startup-post-attach.js"),
+);
 
 function listGatewayStartupChannelPlugins(): GatewayStartupChannelPlugin[] {
   return listLoadedChannelPlugins() as GatewayStartupChannelPlugin[];
@@ -187,40 +174,27 @@ const logDiscovery = log.child("discovery");
 const logTailscale = log.child("tailscale");
 const logChannels = log.child("channels");
 
-let cachedChannelRuntimePromise: Promise<PluginRuntime["channel"]> | null = null;
-
-function getChannelRuntime() {
-  cachedChannelRuntimePromise ??= import("../plugins/runtime/runtime-channel.js").then(
-    ({ createRuntimeChannel }) => createRuntimeChannel(),
-  );
-  return cachedChannelRuntimePromise;
-}
+const getChannelRuntime = createLazyRuntimeModule(() =>
+  import("../plugins/runtime/runtime-channel.js").then(({ createRuntimeChannel }) =>
+    createRuntimeChannel(),
+  ),
+);
 
 async function closeMcpLoopbackServerOnDemand(): Promise<void> {
   const { closeMcpLoopbackServer } = await import("./mcp-http.js");
   await closeMcpLoopbackServer();
 }
 
-let gatewayCloseModulePromise: Promise<typeof import("./server-close.runtime.js")> | null = null;
-
-function loadGatewayCloseModule(): Promise<typeof import("./server-close.runtime.js")> {
-  gatewayCloseModulePromise ??= import("./server-close.runtime.js");
-  return gatewayCloseModulePromise;
-}
+const loadGatewayCloseModule = createLazyRuntimeModule(() => import("./server-close.runtime.js"));
 
 const loadGatewayModelCatalog: LoadGatewayModelCatalog = async (...args) => {
   const mod = await loadGatewayModelCatalogModule();
   return mod.loadGatewayModelCatalog(...args);
 };
 
-let gatewayPluginBootstrapModulePromise: Promise<
-  typeof import("./server-plugin-bootstrap.js")
-> | null = null;
-
-const loadGatewayPluginBootstrapModule = async () => {
-  gatewayPluginBootstrapModulePromise ??= import("./server-plugin-bootstrap.js");
-  return await gatewayPluginBootstrapModulePromise;
-};
+const loadGatewayPluginBootstrapModule = createLazyRuntimeModule(
+  () => import("./server-plugin-bootstrap.js"),
+);
 
 const logHealth = log.child("health");
 const logCron = log.child("cron");
@@ -596,12 +570,9 @@ export async function startGatewayServer(
   }
   const startupTrace = createGatewayStartupTrace();
   const startupConfigModulePromise = import("./server-startup-config.js");
-  let startupPluginsModulePromise: Promise<typeof import("./server-startup-plugins.js")> | null =
-    null;
-  const loadStartupPluginsModule = () => {
-    startupPluginsModulePromise ??= import("./server-startup-plugins.js");
-    return startupPluginsModulePromise;
-  };
+  const loadStartupPluginsModule = createLazyPromise(() => import("./server-startup-plugins.js"), {
+    cacheRejections: true,
+  });
   const { loadGatewayStartupConfigSnapshot } = await startupConfigModulePromise;
 
   const startupConfigLoad = await startupTrace.measure("config.snapshot", () =>
@@ -1589,13 +1560,10 @@ export async function startGatewayServer(
     const sessionDeliveryRecoveryMaxEnqueuedAt = Date.now();
     let postAttachRuntimeReturned = false;
     let scheduledServicesActivated = false;
-    let scheduledServicesModulePromise: Promise<
-      typeof import("./server-runtime-services.js")
-    > | null = null;
-    const loadScheduledServicesModule = () => {
-      scheduledServicesModulePromise ??= import("./server-runtime-services.js");
-      return scheduledServicesModulePromise;
-    };
+    const loadScheduledServicesModule = createLazyPromise(
+      () => import("./server-runtime-services.js"),
+      { cacheRejections: true },
+    );
     const activateScheduledServicesWhenReady = () => {
       if (
         closePreludeStarted ||

--- a/src/gateway/test-helpers.server.ts
+++ b/src/gateway/test-helpers.server.ts
@@ -36,6 +36,7 @@ import {
   parseAgentSessionKey,
   toAgentStoreSessionKey,
 } from "../routing/session-key.js";
+import { createLazyRuntimeModule } from "../shared/lazy-runtime.js";
 import { resetTaskRegistryForTests } from "../tasks/runtime-internal.js";
 import { resetTaskFlowRegistryForTests } from "../tasks/task-flow-runtime-internal.js";
 import { captureEnv } from "../test-utils/env.js";
@@ -59,14 +60,7 @@ import {
   testTailnetIPv4,
 } from "./test-helpers.runtime-state.js";
 
-// Import lazily after test env/home setup so config/session paths resolve to test dirs.
-// Keep one cached module per worker for speed.
-let serverModulePromise: Promise<typeof import("./server.js")> | undefined;
-
-async function getServerModule() {
-  serverModulePromise ??= import("./server.js");
-  return await serverModulePromise;
-}
+const getServerModule = createLazyRuntimeModule(() => import("./server.js"));
 
 const GATEWAY_TEST_ENV_KEYS = [
   "HOME",

--- a/src/gateway/test/server-sessions.test-helpers.ts
+++ b/src/gateway/test/server-sessions.test-helpers.ts
@@ -10,6 +10,7 @@ import { afterAll, beforeAll, beforeEach, expect, vi } from "vitest";
 import type { SessionEntry } from "../../config/sessions.js";
 import type { InternalHookEvent } from "../../hooks/internal-hooks.js";
 import { resetSystemEventsForTest } from "../../infra/system-events.js";
+import { createLazyRuntimeModule } from "../../shared/lazy-runtime.js";
 import { startGatewayServerHarness, type GatewayServerHarness } from "../server.e2e-ws-harness.js";
 import {
   connectOk,
@@ -21,20 +22,13 @@ import {
   writeSessionStore,
 } from "../test-helpers.js";
 
-let sessionManagerModulePromise:
-  | Promise<typeof import("../../agents/sessions/index.js")>
-  | undefined;
-let gatewayConfigModulePromise: Promise<typeof import("../../config/config.js")> | undefined;
+export const getSessionManagerModule = createLazyRuntimeModule(
+  () => import("../../agents/sessions/index.js"),
+);
 
-export async function getSessionManagerModule() {
-  sessionManagerModulePromise ??= import("../../agents/sessions/index.js");
-  return await sessionManagerModulePromise;
-}
-
-export async function getGatewayConfigModule() {
-  gatewayConfigModulePromise ??= import("../../config/config.js");
-  return await gatewayConfigModulePromise;
-}
+export const getGatewayConfigModule = createLazyRuntimeModule(
+  () => import("../../config/config.js"),
+);
 
 export async function getSessionsHandlers() {
   return (await import("../server-methods/sessions.js")).sessionsHandlers;

--- a/src/node-host/plugin-node-host.ts
+++ b/src/node-host/plugin-node-host.ts
@@ -1,21 +1,16 @@
-/** Plugin node-host bridge for loading plugin registry commands and dispatching node capabilities. */
-import type { OpenClawConfig } from "../config/types.openclaw.js";
-import { getActivePluginRegistry } from "../plugins/runtime.js";
-
 /**
  * Plugin node-host command registry bridge.
  *
  * Node hosts load the active plugin registry, expose registered capabilities
  * and commands, and dispatch incoming node-host commands by exact command id.
  */
-let pluginRegistryLoaderModulePromise:
-  | Promise<typeof import("../plugins/runtime/runtime-registry-loader.js")>
-  | undefined;
+import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { getActivePluginRegistry } from "../plugins/runtime.js";
+import { createLazyRuntimeModule } from "../shared/lazy-runtime.js";
 
-async function loadPluginRegistryLoaderModule() {
-  pluginRegistryLoaderModulePromise ??= import("../plugins/runtime/runtime-registry-loader.js");
-  return await pluginRegistryLoaderModulePromise;
-}
+const loadPluginRegistryLoaderModule = createLazyRuntimeModule(
+  () => import("../plugins/runtime/runtime-registry-loader.js"),
+);
 
 /** Ensure plugin registry data is loaded before node-host command dispatch. */
 export async function ensureNodeHostPluginRegistry(params: {

--- a/src/plugin-sdk/acp-runtime-backend.ts
+++ b/src/plugin-sdk/acp-runtime-backend.ts
@@ -6,6 +6,7 @@ import type {
   PluginHookReplyDispatchEvent,
   PluginHookReplyDispatchResult,
 } from "../plugins/types.js";
+import { createLazyRuntimeModule } from "../shared/lazy-runtime.js";
 
 export { AcpRuntimeError, isAcpRuntimeError } from "../acp/runtime/errors.js";
 export type { AcpRuntimeErrorCode } from "../acp/runtime/errors.js";
@@ -31,16 +32,11 @@ export type {
   AcpSessionUpdateTag,
 } from "@openclaw/acp-core/runtime/types";
 
-let dispatchAcpRuntimePromise: Promise<
-  typeof import("../auto-reply/reply/dispatch-acp.runtime.js")
-> | null = null;
-
-function loadDispatchAcpRuntime() {
-  // ACP dispatch pulls in session/media/manager code; cache the dynamic import so
-  // startup-loaded plugin surfaces stay light and concurrent hooks share one load.
-  dispatchAcpRuntimePromise ??= import("../auto-reply/reply/dispatch-acp.runtime.js");
-  return dispatchAcpRuntimePromise;
-}
+// ACP dispatch pulls in session/media/manager code; keep it lazy so
+// startup-loaded plugin surfaces stay light and concurrent hooks share one load.
+const loadDispatchAcpRuntime = createLazyRuntimeModule(
+  () => import("../auto-reply/reply/dispatch-acp.runtime.js"),
+);
 
 /**
  * Dispatch a plugin reply hook through ACP when the event targets an ACP-bound session.

--- a/src/plugin-sdk/channel-outbound.ts
+++ b/src/plugin-sdk/channel-outbound.ts
@@ -4,17 +4,14 @@ import type {
   DurableMessageSendContext,
   DurableMessageSendContextParams,
 } from "../channels/message/runtime.js";
+import { createLazyRuntimeModule } from "../shared/lazy-runtime.js";
+
 type ChannelInboundKernelModule = typeof import("../channels/turn/kernel.js");
-type ChannelMessageRuntimeModule = typeof import("../channels/message/runtime.js");
-
-let channelMessageRuntimeModulePromise: Promise<ChannelMessageRuntimeModule> | null = null;
-
-const loadChannelMessageRuntimeModule = async () => {
-  // Share one lazy import across SDK helper calls so plugin barrels do not eagerly pull
-  // message runtime internals into registration/discovery-only paths.
-  channelMessageRuntimeModulePromise ??= import("../channels/message/runtime.js");
-  return await channelMessageRuntimeModulePromise;
-};
+// Share one lazy import across SDK helper calls so plugin barrels do not eagerly pull
+// message runtime internals into registration/discovery-only paths.
+const loadChannelMessageRuntimeModule = createLazyRuntimeModule(
+  () => import("../channels/message/runtime.js"),
+);
 
 export type {
   DurableInboundReplyDeliveryOptions,

--- a/src/plugin-sdk/delivery-queue-runtime.ts
+++ b/src/plugin-sdk/delivery-queue-runtime.ts
@@ -3,8 +3,8 @@ import {
   drainPendingDeliveries as coreDrainPendingDeliveries,
   type DeliverFn,
 } from "../infra/outbound/delivery-queue.js";
+import { createLazyRuntimeModule } from "../shared/lazy-runtime.js";
 
-type OutboundDeliverRuntimeModule = typeof import("../infra/outbound/deliver-runtime.js");
 type DrainPendingDeliveriesOptions = Omit<
   Parameters<typeof coreDrainPendingDeliveries>[0],
   "deliver"
@@ -13,12 +13,9 @@ type DrainPendingDeliveriesOptions = Omit<
   deliver?: DeliverFn;
 };
 
-let outboundDeliverRuntimePromise: Promise<OutboundDeliverRuntimeModule> | null = null;
-
-async function loadOutboundDeliverRuntime(): Promise<OutboundDeliverRuntimeModule> {
-  outboundDeliverRuntimePromise ??= import("../infra/outbound/deliver-runtime.js");
-  return await outboundDeliverRuntimePromise;
-}
+const loadOutboundDeliverRuntime = createLazyRuntimeModule(
+  () => import("../infra/outbound/deliver-runtime.js"),
+);
 
 /**
  * Drain queued outbound payloads after a channel reconnect or transport recovery.

--- a/src/plugin-sdk/image-generation-core.ts
+++ b/src/plugin-sdk/image-generation-core.ts
@@ -1,3 +1,4 @@
+import { createLazyRuntimeModule } from "../shared/lazy-runtime.js";
 // Shared image-generation implementation helpers for bundled and third-party plugins.
 
 export type { AuthProfileStore } from "../agents/auth-profiles/types.js";
@@ -39,14 +40,9 @@ export const OPENAI_DEFAULT_IMAGE_MODEL = "gpt-image-2";
 type ImageGenerationCoreAuthRuntimeModule =
   typeof import("./image-generation-core.auth.runtime.js");
 
-let imageGenerationCoreAuthRuntimePromise:
-  | Promise<ImageGenerationCoreAuthRuntimeModule>
-  | undefined;
-
-async function loadImageGenerationCoreAuthRuntime(): Promise<ImageGenerationCoreAuthRuntimeModule> {
-  imageGenerationCoreAuthRuntimePromise ??= import("./image-generation-core.auth.runtime.js");
-  return imageGenerationCoreAuthRuntimePromise;
-}
+const loadImageGenerationCoreAuthRuntime = createLazyRuntimeModule(
+  () => import("./image-generation-core.auth.runtime.js"),
+);
 
 /** Resolve image-generation provider API keys through the lazy auth runtime helper. */
 export async function resolveApiKeyForProvider(

--- a/src/plugin-sdk/reply-dispatch-runtime.ts
+++ b/src/plugin-sdk/reply-dispatch-runtime.ts
@@ -1,3 +1,4 @@
+import { createLazyPromise } from "../shared/lazy-runtime.js";
 /**
  * Runtime SDK subpath for lazy reply dispatch and inbound-context helpers.
  */
@@ -16,15 +17,10 @@ export type {
 } from "../auto-reply/reply/provider-dispatcher.types.js";
 export type { ReplyPayload } from "./reply-payload.js";
 
-let providerDispatcherRuntimeModulePromise: Promise<
-  typeof import("../auto-reply/reply/provider-dispatcher.runtime.js")
-> | null = null;
-
-const loadProviderDispatcherRuntimeModule = async () => {
-  providerDispatcherRuntimeModulePromise ??=
-    import("../auto-reply/reply/provider-dispatcher.runtime.js");
-  return await providerDispatcherRuntimeModulePromise;
-};
+const loadProviderDispatcherRuntimeModule = createLazyPromise(
+  () => import("../auto-reply/reply/provider-dispatcher.runtime.js"),
+  { cacheRejections: true },
+);
 
 /** Dispatches a reply with buffered block support after lazy-loading the runtime dispatcher. */
 export const dispatchReplyWithBufferedBlockDispatcher: DispatchReplyWithBufferedBlockDispatcher =

--- a/src/tasks/task-registry.ts
+++ b/src/tasks/task-registry.ts
@@ -15,6 +15,7 @@ import { requestHeartbeat } from "../infra/heartbeat-wake.js";
 import { enqueueSystemEvent } from "../infra/system-events.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
 import { normalizeAgentId, parseAgentSessionKey } from "../routing/session-key.js";
+import { createLazyPromiseLoader } from "../shared/lazy-runtime.js";
 import { normalizeDeliveryContext } from "../utils/delivery-context.shared.js";
 import { isDeliverableMessageChannel } from "../utils/message-channel.js";
 import { cancelActiveCronTaskRun } from "./cron-task-cancel.js";
@@ -91,9 +92,24 @@ type TaskRegistryGlobalWithRuntimeOverrides = typeof globalThis & {
   [TASK_REGISTRY_DELIVERY_RUNTIME_OVERRIDE_KEY]?: TaskRegistryDeliveryRuntime | null;
   [TASK_REGISTRY_CONTROL_RUNTIME_OVERRIDE_KEY]?: TaskRegistryControlRuntime | null;
 };
-let deliveryRuntimePromise: Promise<typeof import("./task-registry-delivery-runtime.js")> | null =
-  null;
-let controlRuntimePromise: Promise<TaskRegistryControlRuntime> | null = null;
+const deliveryRuntimeLoader = createLazyPromiseLoader(
+  () => import("./task-registry-delivery-runtime.js"),
+  { cacheRejections: true },
+);
+const controlRuntimeLoader = createLazyPromiseLoader(
+  () =>
+    Promise.resolve().then(() => {
+      for (const candidate of TASK_REGISTRY_CONTROL_RUNTIME_CANDIDATES) {
+        try {
+          return require(candidate) as TaskRegistryControlRuntime;
+        } catch {
+          // Try runtime/source candidates in order.
+        }
+      }
+      throw new Error("Failed to load task registry control runtime.");
+    }),
+  { cacheRejections: true },
+);
 
 type TaskDeliveryOwner = {
   sessionKey?: string;
@@ -567,8 +583,7 @@ function loadTaskRegistryDeliveryRuntime() {
   if (deliveryRuntimeOverride) {
     return Promise.resolve(deliveryRuntimeOverride);
   }
-  deliveryRuntimePromise ??= import("./task-registry-delivery-runtime.js");
-  return deliveryRuntimePromise;
+  return deliveryRuntimeLoader.load();
 }
 
 function loadTaskRegistryControlRuntime() {
@@ -580,17 +595,7 @@ function loadTaskRegistryControlRuntime() {
   }
   // Registry reads happen far more often than task cancellation, so keep the ACP/subagent
   // control graph off the default import path until a cancellation flow actually needs it.
-  controlRuntimePromise ??= Promise.resolve().then(() => {
-    for (const candidate of TASK_REGISTRY_CONTROL_RUNTIME_CANDIDATES) {
-      try {
-        return require(candidate) as TaskRegistryControlRuntime;
-      } catch {
-        // Try runtime/source candidates in order.
-      }
-    }
-    throw new Error("Failed to load task registry control runtime.");
-  });
-  return controlRuntimePromise;
+  return controlRuntimeLoader.load();
 }
 
 function addRunIdIndex(taskId: string, runId?: string) {
@@ -2403,8 +2408,8 @@ export function resetTaskRegistryForTests(opts?: { persist?: boolean }) {
     listenerStop = null;
   }
   listenerStarted = false;
-  deliveryRuntimePromise = null;
-  controlRuntimePromise = null;
+  deliveryRuntimeLoader.clear();
+  controlRuntimeLoader.clear();
   if (opts?.persist !== false) {
     persistTaskRegistry();
   }
@@ -2417,26 +2422,26 @@ export function resetTaskRegistryDeliveryRuntimeForTests() {
   (globalThis as TaskRegistryGlobalWithRuntimeOverrides)[
     TASK_REGISTRY_DELIVERY_RUNTIME_OVERRIDE_KEY
   ] = null;
-  deliveryRuntimePromise = null;
+  deliveryRuntimeLoader.clear();
 }
 
 export function setTaskRegistryDeliveryRuntimeForTests(runtime: TaskRegistryDeliveryRuntime): void {
   (globalThis as TaskRegistryGlobalWithRuntimeOverrides)[
     TASK_REGISTRY_DELIVERY_RUNTIME_OVERRIDE_KEY
   ] = runtime;
-  deliveryRuntimePromise = null;
+  deliveryRuntimeLoader.clear();
 }
 
 export function resetTaskRegistryControlRuntimeForTests() {
   (globalThis as TaskRegistryGlobalWithRuntimeOverrides)[
     TASK_REGISTRY_CONTROL_RUNTIME_OVERRIDE_KEY
   ] = null;
-  controlRuntimePromise = null;
+  controlRuntimeLoader.clear();
 }
 
 export function setTaskRegistryControlRuntimeForTests(runtime: TaskRegistryControlRuntime): void {
   (globalThis as TaskRegistryGlobalWithRuntimeOverrides)[
     TASK_REGISTRY_CONTROL_RUNTIME_OVERRIDE_KEY
   ] = runtime;
-  controlRuntimePromise = null;
+  controlRuntimeLoader.clear();
 }


### PR DESCRIPTION
Related: #98748

## What Problem This Solves

OpenClaw still has duplicated promise memoizers around lazy dynamic imports in core Gateway and stateful runtime paths. Those local cache owners repeat lifecycle logic, make rejection behavior easier to drift, and increase the cost of maintaining import boundaries.

This is PR 3 of 6 in the lazy-runtime utility consolidation series.

Completed dependency batches:
- [#99261](https://github.com/openclaw/openclaw/pull/99261) — shared lazy runtime loader foundation.
- [#99278](https://github.com/openclaw/openclaw/pull/99278) — core leaf lazy loader consolidation.

Remaining batches:
- Batch 4 — Discord, Slack, and Telegram lazy loaders.
- Batch 5 — remaining channel and plugin lazy loaders.
- Batch 6 — residual repository sweep and consolidation cleanup.

## Why This Change Was Made

This migrates the core Gateway, session/stateful, task registry, node-host, ACP, channel, and narrow Plugin SDK runtime loaders to the shared lazy-runtime owner. It preserves sticky rejection caching, explicit clear/peek test and lifecycle behavior, startup ordering, and existing dynamic import boundaries without adding SDK exports or compatibility paths.

## User Impact

No intended user-visible behavior change. Maintainers get one canonical lazy-loader implementation with less duplicated production code and consistent cache semantics across these runtime paths.

## Evidence

- Existing focused proof: 547 tests across ACP, channels, agents, Gateway, SDK, node-host, and tasks.
- Existing focused static proof: core production typecheck, oxlint, and oxfmt passed.
- Fresh rebased build: Blacksmith Testbox-through-Crabbox `tbx_01kwjsgnpa39k6r314s21jc6nc`, Actions run https://github.com/openclaw/openclaw/actions/runs/28632429729, `pnpm build` passed.
- Fresh rebased import graph: `node scripts/check-import-cycles.ts` reported `0 runtime value cycle(s)`.
- Fresh autoreview before commit: no accepted/actionable findings, confidence 0.94.
- Scope: 23 owned files, 306 insertions and 468 deletions; no changelog entry.
