### PR TITLE
fix(shared/text): strip standalone <parameter> tool-call wrappers in assistant visible text

### DIFF
--- a/src/shared/text/assistant-visible-text.test.ts
+++ b/src/shared/text/assistant-visible-text.test.ts
@@ -614,6 +614,17 @@ describe("stripToolCallXmlTags", () => {
     );
   });
 
+  it("strips standalone <parameter> wrappers outside a <function> block (#98557)", () => {
+    expect(
+      stripToolCallXmlTags('prefix\n<parameter name="assumptions">\nvalue\n</parameter>\nsuffix'),
+    ).toBe("prefix\n\nsuffix");
+  });
+
+  it("preserves inline <parameter> examples in prose", () => {
+    const input = 'prefix <parameter name="x">value</parameter> suffix';
+    expect(stripToolCallXmlTags(input)).toBe(input);
+  });
+
   it("strips function_response adjacent to an opt-in stripped function_calls block", () => {
     const input = [
       '<function_calls><invoke name="exec">internal</invoke></function_calls><function_response>',
@@ -829,6 +840,29 @@ describe("sanitizeAssistantVisibleText", () => {
     ].join("\n");
 
     expect(sanitizeAssistantVisibleText(input)).toBe("Visible answer");
+  });
+
+  it("strips standalone <parameter> wrappers that leak into rich message content (#98557)", () => {
+    const input = [
+      "Here are the results.",
+      "",
+      '<parameter name="assumptions">',
+      "• 7-day window",
+      "• Direct employer filter",
+      "</parameter>",
+      "",
+      "Let me know if you need more.",
+    ].join("\n");
+
+    expect(sanitizeAssistantVisibleText(input)).toBe(
+      ["Here are the results.", "", "", "", "Let me know if you need more."].join("\n"),
+    );
+  });
+
+  it("preserves inline <parameter> examples in prose", () => {
+    const input = 'Use <parameter name="x">value</parameter> in docs.';
+
+    expect(sanitizeAssistantVisibleText(input)).toBe(input);
   });
 
   it("preserves prose examples of plural function-call XML on the delivery path", () => {

--- a/src/shared/text/assistant-visible-text.ts
+++ b/src/shared/text/assistant-visible-text.ts
@@ -41,6 +41,7 @@ const TOOL_CALL_TAG_NAMES = new Set([
   "tool_calls",
   "antml:invoke",
   "antml:parameter",
+  "parameter",
 ]);
 const TOOL_CALL_JSON_PAYLOAD_START_RE =
   /^(?:\s+[A-Za-z_:][-A-Za-z0-9_:.]*\s*=\s*(?:"[^"]*"|'[^']*'|[^\s"'=<>`]+))*\s*(?:\r?\n\s*)?[[{]/;
@@ -181,6 +182,24 @@ function isLikelyStandaloneFunctionToolCall(
   }
 
   return idx < 0 || text[idx] === "\n" || text[idx] === "\r" || /[.!?:]/.test(text[idx]);
+}
+
+function isLikelyStandaloneParameterWrapper(
+  text: string,
+  tagStart: number,
+  tag: ParsedToolCallTag,
+): boolean {
+  if (tag.tagName !== "parameter" || tag.isClose || tag.isSelfClosing || tag.isTruncated) {
+    return false;
+  }
+
+  if (findMatchingToolCallCloseIndex(text, tag.end, tag.tagName) === -1) {
+    return false;
+  }
+
+  return (
+    isStandaloneOpeningTagLine(text, tagStart, tag) || isOpeningTagFollowedByLineBreak(text, tag)
+  );
 }
 
 function isStandaloneOpeningTagLine(
@@ -433,9 +452,12 @@ export function stripToolCallXmlTags(
           (functionResponseCloseStart !== -1 &&
             isVisibleLineStart(result) &&
             isOpeningTagFollowedByLineBreak(text, tag)));
+      const shouldStripStandaloneParameter = isLikelyStandaloneParameterWrapper(text, idx, tag);
       if (
         !tag.isClose &&
-        ((payloadKind && shouldStripStandaloneFunction) || shouldStripStandaloneResult)
+        ((payloadKind && shouldStripStandaloneFunction) ||
+          shouldStripStandaloneResult ||
+          shouldStripStandaloneParameter)
       ) {
         inToolCallBlock = true;
         toolCallBlockContentStart = tag.end;


### PR DESCRIPTION
## What Problem This Solves

Fixes #98557. When `channels.telegram.richMessages: true` is enabled, model-generated standalone `<parameter name="...">...</parameter>` XML wrappers inside rich content were not stripped by the assistant-visible-text sanitizer. Full `<function>...</function>` blocks were already removed, but the standalone parameter wrapper leaked through and was rendered as visible markup to the user.

## Why This Change Was Made

`stripToolCallXmlTags` only entered a tool-call block when the payload looked like JSON or nested XML (e.g., `<function>` / `<tool_call>`). A bare `<parameter>` wrapper was parsed as a known tag but then preserved, so its XML tags stayed in the delivered message. This change adds a narrow heuristic to treat a standalone `<parameter>` wrapper as a tool-call-shaped block when it starts a line or is immediately followed by a line break, matching the shape seen in the reported bug.

## User Impact

Telegram rich messages (and any other delivery path using `sanitizeAssistantVisibleText`) no longer expose raw `<parameter>` XML tags generated by the model; the content between the tags is removed along with the wrapper, keeping the visible message clean.

## Evidence

- Added unit tests in `src/shared/text/assistant-visible-text.test.ts` that reproduce the standalone `<parameter>` leak and verify it is stripped, while inline prose examples are preserved.
- Ran the affected test file: `node scripts/run-vitest.mjs run src/shared/text/assistant-visible-text.test.ts` → 113 passed.
- Ran related text sanitizer tests: `node scripts/run-vitest.mjs run src/shared/text/assistant-visible-text.test.ts src/shared/text/tool-call-shaped-text.test.ts` → 118 passed.
- Formatted and linted the changed files with `oxfmt` and `oxlint`; 0 warnings/errors.

Fixes #98557