### PR TITLE
refactor(shared): consolidate Discord Slack and Telegram lazy loaders

### DIFF
--- a/extensions/discord/src/channel-actions.ts
+++ b/extensions/discord/src/channel-actions.ts
@@ -6,6 +6,7 @@ import type {
   ChannelMessageToolDiscovery,
 } from "openclaw/plugin-sdk/channel-contract";
 import type { DiscordActionConfig, OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
+import { createLazyRuntimeModule } from "openclaw/plugin-sdk/lazy-runtime";
 import { normalizeOptionalString } from "openclaw/plugin-sdk/string-coerce-runtime";
 import { extractToolSend } from "openclaw/plugin-sdk/tool-send";
 import { inspectDiscordAccount } from "./account-inspect.js";
@@ -28,14 +29,9 @@ function resolveDiscordActionExecutionMode({ action }: { action: ChannelMessageA
   return localExecutionActions.has(action) ? "local" : "gateway";
 }
 
-let discordChannelActionsRuntimePromise:
-  | Promise<typeof import("./channel-actions.runtime.js")>
-  | undefined;
-
-async function loadDiscordChannelActionsRuntime() {
-  discordChannelActionsRuntimePromise ??= import("./channel-actions.runtime.js");
-  return await discordChannelActionsRuntimePromise;
-}
+const loadDiscordChannelActionsRuntime = createLazyRuntimeModule(
+  () => import("./channel-actions.runtime.js"),
+);
 
 function listDiscoverableDiscordAccounts(cfg: OpenClawConfig) {
   return listDiscordAccountIds(cfg)

--- a/extensions/discord/src/channel.loaders.ts
+++ b/extensions/discord/src/channel.loaders.ts
@@ -1,14 +1,6 @@
 // Discord plugin module implements channel.loaders behavior.
 import { createLazyRuntimeModule } from "openclaw/plugin-sdk/lazy-runtime";
 
-let discordProviderRuntimePromise:
-  | Promise<typeof import("./monitor/provider.runtime.js")>
-  | undefined;
-let discordProbeRuntimePromise: Promise<typeof import("./probe.runtime.js")> | undefined;
-let discordAuditModulePromise: Promise<typeof import("./audit.js")> | undefined;
-let discordSendModulePromise: Promise<typeof import("./send.js")> | undefined;
-let discordDirectoryLiveModulePromise: Promise<typeof import("./directory-live.js")> | undefined;
-
 export const loadDiscordDirectoryConfigModule = createLazyRuntimeModule(
   () => import("./directory-config.js"),
 );
@@ -25,27 +17,16 @@ export const loadDiscordTargetResolverModule = createLazyRuntimeModule(
   () => import("./target-resolver.js"),
 );
 
-export async function loadDiscordProviderRuntime() {
-  discordProviderRuntimePromise ??= import("./monitor/provider.runtime.js");
-  return await discordProviderRuntimePromise;
-}
+export const loadDiscordProviderRuntime = createLazyRuntimeModule(
+  () => import("./monitor/provider.runtime.js"),
+);
 
-export async function loadDiscordProbeRuntime() {
-  discordProbeRuntimePromise ??= import("./probe.runtime.js");
-  return await discordProbeRuntimePromise;
-}
+export const loadDiscordProbeRuntime = createLazyRuntimeModule(() => import("./probe.runtime.js"));
 
-export async function loadDiscordAuditModule() {
-  discordAuditModulePromise ??= import("./audit.js");
-  return await discordAuditModulePromise;
-}
+export const loadDiscordAuditModule = createLazyRuntimeModule(() => import("./audit.js"));
 
-export async function loadDiscordSendModule() {
-  discordSendModulePromise ??= import("./send.js");
-  return await discordSendModulePromise;
-}
+export const loadDiscordSendModule = createLazyRuntimeModule(() => import("./send.js"));
 
-export async function loadDiscordDirectoryLiveModule() {
-  discordDirectoryLiveModulePromise ??= import("./directory-live.js");
-  return await discordDirectoryLiveModulePromise;
-}
+export const loadDiscordDirectoryLiveModule = createLazyRuntimeModule(
+  () => import("./directory-live.js"),
+);

--- a/extensions/discord/src/monitor/agent-components.dispatch.ts
+++ b/extensions/discord/src/monitor/agent-components.dispatch.ts
@@ -6,6 +6,7 @@ import {
   runChannelInboundEvent,
 } from "openclaw/plugin-sdk/channel-inbound";
 import { isDangerousNameMatchingEnabled } from "openclaw/plugin-sdk/dangerous-name-runtime";
+import { createLazyRuntimeModule } from "openclaw/plugin-sdk/lazy-runtime";
 import { logError } from "openclaw/plugin-sdk/logging-core";
 import { resolveMarkdownTableMode } from "openclaw/plugin-sdk/markdown-table-runtime";
 import { getAgentScopedMediaLocalRoots } from "openclaw/plugin-sdk/media-runtime";
@@ -36,18 +37,11 @@ import {
 import { buildDirectLabel, buildGuildLabel } from "./reply-context.js";
 import { deliverDiscordReply } from "./reply-delivery.js";
 
-let conversationRuntimePromise: Promise<typeof import("./agent-components.runtime.js")> | undefined;
-let typingRuntimePromise: Promise<typeof import("./typing.js")> | undefined;
+const loadConversationRuntime = createLazyRuntimeModule(
+  () => import("./agent-components.runtime.js"),
+);
 
-async function loadConversationRuntime() {
-  conversationRuntimePromise ??= import("./agent-components.runtime.js");
-  return await conversationRuntimePromise;
-}
-
-async function loadTypingRuntime() {
-  typingRuntimePromise ??= import("./typing.js");
-  return await typingRuntimePromise;
-}
+const loadTypingRuntime = createLazyRuntimeModule(() => import("./typing.js"));
 
 function buildDiscordComponentConversationLabel(params: {
   interactionCtx: ComponentInteractionContext;

--- a/extensions/discord/src/monitor/agent-components.handlers.ts
+++ b/extensions/discord/src/monitor/agent-components.handlers.ts
@@ -1,3 +1,4 @@
+import { createLazyRuntimeModule } from "openclaw/plugin-sdk/lazy-runtime";
 // Discord plugin module implements agent components.handlers behavior.
 import { logError } from "openclaw/plugin-sdk/logging-core";
 import {
@@ -18,12 +19,7 @@ import { dispatchDiscordComponentEvent } from "./agent-components.dispatch.js";
 import { dispatchPluginDiscordInteractiveEvent } from "./agent-components.plugin-interactive.js";
 import type { DiscordComponentControlHandlers } from "./agent-components.wildcard-controls.js";
 
-let componentsRuntimePromise: Promise<typeof import("../components.js")> | undefined;
-
-async function loadComponentsRuntime() {
-  componentsRuntimePromise ??= import("../components.js");
-  return await componentsRuntimePromise;
-}
+const loadComponentsRuntime = createLazyRuntimeModule(() => import("../components.js"));
 
 async function handleDiscordComponentEvent(params: {
   ctx: AgentComponentContext;

--- a/extensions/discord/src/monitor/agent-components.plugin-interactive.ts
+++ b/extensions/discord/src/monitor/agent-components.plugin-interactive.ts
@@ -1,5 +1,6 @@
 // Discord plugin module implements agent components.plugin interactive behavior.
 import { ChannelType } from "discord-api-types/v10";
+import { createLazyRuntimeModule } from "openclaw/plugin-sdk/lazy-runtime";
 import { logError } from "openclaw/plugin-sdk/logging-core";
 import {
   dispatchDiscordPluginInteractiveHandler,
@@ -15,12 +16,9 @@ import {
   type DiscordChannelContext,
 } from "./agent-components-helpers.js";
 
-let conversationRuntimePromise: Promise<typeof import("./agent-components.runtime.js")> | undefined;
-
-async function loadConversationRuntime() {
-  conversationRuntimePromise ??= import("./agent-components.runtime.js");
-  return await conversationRuntimePromise;
-}
+const loadConversationRuntime = createLazyRuntimeModule(
+  () => import("./agent-components.runtime.js"),
+);
 
 export async function dispatchPluginDiscordInteractiveEvent(params: {
   ctx: AgentComponentContext;

--- a/extensions/discord/src/monitor/message-handler.dm-preflight.ts
+++ b/extensions/discord/src/monitor/message-handler.dm-preflight.ts
@@ -1,3 +1,4 @@
+import { createLazyRuntimeModule } from "openclaw/plugin-sdk/lazy-runtime";
 // Discord plugin module implements message handlerm preflight behavior.
 import { logVerbose } from "openclaw/plugin-sdk/runtime-env";
 import { resolveDiscordConversationIdentity } from "../conversation-identity.js";
@@ -10,20 +11,11 @@ import type {
   DiscordSenderIdentity,
 } from "./message-handler.preflight.types.js";
 
-let conversationRuntimePromise:
-  | Promise<typeof import("openclaw/plugin-sdk/conversation-binding-runtime")>
-  | undefined;
-let discordSendRuntimePromise: Promise<typeof import("../send.js")> | undefined;
+const loadConversationRuntime = createLazyRuntimeModule(
+  () => import("openclaw/plugin-sdk/conversation-binding-runtime"),
+);
 
-async function loadConversationRuntime() {
-  conversationRuntimePromise ??= import("openclaw/plugin-sdk/conversation-binding-runtime");
-  return await conversationRuntimePromise;
-}
-
-async function loadDiscordSendRuntime() {
-  discordSendRuntimePromise ??= import("../send.js");
-  return await discordSendRuntimePromise;
-}
+const loadDiscordSendRuntime = createLazyRuntimeModule(() => import("../send.js"));
 
 function resolveDiscordDmPairingSenderId(sender: DiscordSenderIdentity): string {
   return sender.isPluralKit ? `pk:${sender.id}` : sender.id;

--- a/extensions/discord/src/monitor/message-handler.preflight-runtime.ts
+++ b/extensions/discord/src/monitor/message-handler.preflight-runtime.ts
@@ -1,28 +1,14 @@
-// Discord plugin module implements message handler.preflight runtime behavior.
-let pluralkitRuntimePromise: Promise<typeof import("../pluralkit.js")> | undefined;
-let preflightAudioRuntimePromise: Promise<typeof import("./preflight-audio.js")> | undefined;
-let systemEventsRuntimePromise: Promise<typeof import("./system-events.js")> | undefined;
-let discordThreadingRuntimePromise: Promise<typeof import("./threading.js")> | undefined;
+import { createLazyRuntimeModule } from "openclaw/plugin-sdk/lazy-runtime";
 
-export async function loadPluralKitRuntime() {
-  pluralkitRuntimePromise ??= import("../pluralkit.js");
-  return await pluralkitRuntimePromise;
-}
+export const loadPluralKitRuntime = createLazyRuntimeModule(() => import("../pluralkit.js"));
 
-export async function loadPreflightAudioRuntime() {
-  preflightAudioRuntimePromise ??= import("./preflight-audio.js");
-  return await preflightAudioRuntimePromise;
-}
+export const loadPreflightAudioRuntime = createLazyRuntimeModule(
+  () => import("./preflight-audio.js"),
+);
 
-export async function loadSystemEventsRuntime() {
-  systemEventsRuntimePromise ??= import("./system-events.js");
-  return await systemEventsRuntimePromise;
-}
+export const loadSystemEventsRuntime = createLazyRuntimeModule(() => import("./system-events.js"));
 
-export async function loadDiscordThreadingRuntime() {
-  discordThreadingRuntimePromise ??= import("./threading.js");
-  return await discordThreadingRuntimePromise;
-}
+export const loadDiscordThreadingRuntime = createLazyRuntimeModule(() => import("./threading.js"));
 
 export function isPreflightAborted(abortSignal?: AbortSignal): boolean {
   return Boolean(abortSignal?.aborted);

--- a/extensions/discord/src/monitor/message-handler.process.ts
+++ b/extensions/discord/src/monitor/message-handler.process.ts
@@ -26,6 +26,7 @@ import {
   resolveTranscriptBackedChannelFinalText,
 } from "openclaw/plugin-sdk/channel-outbound";
 import { recordInboundSession } from "openclaw/plugin-sdk/conversation-runtime";
+import { createLazyRuntimeModule } from "openclaw/plugin-sdk/lazy-runtime";
 import { resolveMarkdownTableMode } from "openclaw/plugin-sdk/markdown-table-runtime";
 import { getAgentScopedMediaLocalRoots } from "openclaw/plugin-sdk/media-runtime";
 import { resolveChunkMode } from "openclaw/plugin-sdk/reply-chunking";
@@ -76,12 +77,7 @@ function sleep(ms: number): Promise<void> {
   });
 }
 
-let replyRuntimePromise: Promise<typeof import("openclaw/plugin-sdk/reply-runtime")> | undefined;
-
-async function loadReplyRuntime() {
-  replyRuntimePromise ??= import("openclaw/plugin-sdk/reply-runtime");
-  return await replyRuntimePromise;
-}
+const loadReplyRuntime = createLazyRuntimeModule(() => import("openclaw/plugin-sdk/reply-runtime"));
 
 function isProcessAborted(abortSignal?: AbortSignal): boolean {
   return Boolean(abortSignal?.aborted);

--- a/extensions/discord/src/monitor/message-handler.routing-preflight.ts
+++ b/extensions/discord/src/monitor/message-handler.routing-preflight.ts
@@ -1,3 +1,4 @@
+import { createLazyRuntimeModule } from "openclaw/plugin-sdk/lazy-runtime";
 // Discord plugin module implements message handler.routing preflight behavior.
 import { logVerbose } from "openclaw/plugin-sdk/runtime-env";
 import { resolveDiscordConversationIdentity } from "../conversation-identity.js";
@@ -10,14 +11,9 @@ import {
   shouldIgnoreStaleDiscordRouteBinding,
 } from "./route-resolution.js";
 
-let conversationRuntimePromise:
-  | Promise<typeof import("openclaw/plugin-sdk/conversation-binding-runtime")>
-  | undefined;
-
-async function loadConversationRuntime() {
-  conversationRuntimePromise ??= import("openclaw/plugin-sdk/conversation-binding-runtime");
-  return await conversationRuntimePromise;
-}
+const loadConversationRuntime = createLazyRuntimeModule(
+  () => import("openclaw/plugin-sdk/conversation-binding-runtime"),
+);
 
 export async function resolveDiscordPreflightRoute(params: {
   preflight: DiscordMessagePreflightParams;

--- a/extensions/discord/src/monitor/message-handler.ts
+++ b/extensions/discord/src/monitor/message-handler.ts
@@ -3,6 +3,7 @@ import {
   createChannelInboundDebouncer,
   shouldDebounceTextInbound,
 } from "openclaw/plugin-sdk/channel-inbound";
+import { createLazyRuntimeModule } from "openclaw/plugin-sdk/lazy-runtime";
 import { finiteSecondsToTimerSafeMilliseconds } from "openclaw/plugin-sdk/number-runtime";
 import { danger, logVerbose } from "openclaw/plugin-sdk/runtime-env";
 import { resolveOpenProviderRuntimeGroupPolicy } from "openclaw/plugin-sdk/runtime-group-policy";
@@ -61,14 +62,9 @@ type PrestartedTypingFeedbackEntry = {
   feedback: DiscordReplyTypingFeedback;
 };
 
-let messagePreflightRuntimePromise:
-  | Promise<typeof import("./message-handler.preflight.js")>
-  | undefined;
-
-async function loadMessagePreflightRuntime() {
-  messagePreflightRuntimePromise ??= import("./message-handler.preflight.js");
-  return await messagePreflightRuntimePromise;
-}
+const loadMessagePreflightRuntime = createLazyRuntimeModule(
+  () => import("./message-handler.preflight.js"),
+);
 
 export type DiscordMessageHandlerWithLifecycle = DiscordMessageHandler & {
   deactivate: () => void;

--- a/extensions/discord/src/monitor/message-run-queue.ts
+++ b/extensions/discord/src/monitor/message-run-queue.ts
@@ -1,5 +1,6 @@
 // Discord plugin module implements message run queue behavior.
 import { createChannelRunQueue } from "openclaw/plugin-sdk/channel-outbound";
+import { createLazyRuntimeModule } from "openclaw/plugin-sdk/lazy-runtime";
 import type { ClaimableDedupe } from "openclaw/plugin-sdk/persistent-dedupe";
 import { danger } from "openclaw/plugin-sdk/runtime-env";
 import {
@@ -34,14 +35,9 @@ export type DiscordMessageRunQueueTestingHooks = {
 
 type SkippedQueuedMessageCleanup = () => void;
 
-let messageProcessRuntimePromise:
-  | Promise<typeof import("./message-handler.process.js")>
-  | undefined;
-
-async function loadMessageProcessRuntime() {
-  messageProcessRuntimePromise ??= import("./message-handler.process.js");
-  return await messageProcessRuntimePromise;
-}
+const loadMessageProcessRuntime = createLazyRuntimeModule(
+  () => import("./message-handler.process.js"),
+);
 
 async function processDiscordQueuedMessage(params: {
   job: DiscordInboundJob;

--- a/extensions/discord/src/monitor/model-picker.state.ts
+++ b/extensions/discord/src/monitor/model-picker.state.ts
@@ -1,5 +1,6 @@
 // Discord plugin module implements model picker.state behavior.
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
+import { createLazyRuntimeModule } from "openclaw/plugin-sdk/lazy-runtime";
 import type { ModelsProviderData } from "openclaw/plugin-sdk/models-provider-runtime";
 import { parseStrictInteger, parseStrictPositiveInteger } from "openclaw/plugin-sdk/number-runtime";
 import { normalizeProviderId } from "openclaw/plugin-sdk/provider-model-shared";
@@ -105,14 +106,9 @@ export type DiscordModelPickerModelPage = DiscordModelPickerPage<string> & {
   provider: string;
 };
 
-let modelsProviderRuntimePromise:
-  | Promise<typeof import("openclaw/plugin-sdk/models-provider-runtime")>
-  | undefined;
-
-async function loadModelsProviderRuntime() {
-  modelsProviderRuntimePromise ??= import("openclaw/plugin-sdk/models-provider-runtime");
-  return await modelsProviderRuntimePromise;
-}
+const loadModelsProviderRuntime = createLazyRuntimeModule(
+  () => import("openclaw/plugin-sdk/models-provider-runtime"),
+);
 
 function encodeCustomIdValue(value: string): string {
   return encodeURIComponent(value);

--- a/extensions/discord/src/monitor/preflight-audio.ts
+++ b/extensions/discord/src/monitor/preflight-audio.ts
@@ -1,17 +1,13 @@
 // Discord plugin module implements preflight audio behavior.
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
+import { createLazyRuntimeModule } from "openclaw/plugin-sdk/lazy-runtime";
 import { getFileExtension } from "openclaw/plugin-sdk/media-mime";
 import { logVerbose } from "openclaw/plugin-sdk/runtime-env";
 import { normalizeOptionalString } from "openclaw/plugin-sdk/string-coerce-runtime";
 
-type DiscordPreflightAudioRuntime = typeof import("./preflight-audio.runtime.js");
-
-let discordPreflightAudioRuntimePromise: Promise<DiscordPreflightAudioRuntime> | undefined;
-
-function loadDiscordPreflightAudioRuntime(): Promise<DiscordPreflightAudioRuntime> {
-  discordPreflightAudioRuntimePromise ??= import("./preflight-audio.runtime.js");
-  return discordPreflightAudioRuntimePromise;
-}
+const loadDiscordPreflightAudioRuntime = createLazyRuntimeModule(
+  () => import("./preflight-audio.runtime.js"),
+);
 
 type DiscordAudioAttachment = {
   content_type?: string;

--- a/extensions/discord/src/outbound-adapter.ts
+++ b/extensions/discord/src/outbound-adapter.ts
@@ -6,6 +6,7 @@ import {
   createAttachedChannelResultAdapter,
 } from "openclaw/plugin-sdk/channel-send-result";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
+import { createLazyRuntimeModule } from "openclaw/plugin-sdk/lazy-runtime";
 import {
   normalizeOptionalString,
   normalizeOptionalStringifiedId,
@@ -42,14 +43,9 @@ function stripDiscordInternalRuntimeScaffolding(text: string): string {
     .replace(DISCORD_INTERNAL_RUNTIME_SCAFFOLDING_TAG_RE, "");
 }
 
-type DiscordThreadBindingsModule = typeof import("./monitor/thread-bindings.js");
-
-let discordThreadBindingsPromise: Promise<DiscordThreadBindingsModule> | undefined;
-
-function loadDiscordThreadBindings(): Promise<DiscordThreadBindingsModule> {
-  discordThreadBindingsPromise ??= import("./monitor/thread-bindings.js");
-  return discordThreadBindingsPromise;
-}
+const loadDiscordThreadBindings = createLazyRuntimeModule(
+  () => import("./monitor/thread-bindings.js"),
+);
 
 function resolveDiscordWebhookIdentity(params: {
   identity?: OutboundIdentity;

--- a/extensions/discord/src/outbound-components.ts
+++ b/extensions/discord/src/outbound-components.ts
@@ -1,29 +1,30 @@
 // Discord plugin module implements outbound components behavior.
 import type { ChannelOutboundAdapter } from "openclaw/plugin-sdk/channel-send-result";
+import {
+  createLazyRuntimeModule,
+  createLazyRuntimeNamedExport,
+} from "openclaw/plugin-sdk/lazy-runtime";
 import { readDiscordComponentSpec, type DiscordComponentMessageSpec } from "./components.js";
 
 type DiscordComponentSendFn = typeof import("./send.components.js").sendDiscordComponentMessage;
-type DiscordSharedInteractiveModule = typeof import("./shared-interactive.js");
 type OutboundPayload = Parameters<NonNullable<ChannelOutboundAdapter["sendPayload"]>>[0]["payload"];
 
-let discordComponentSendPromise: Promise<DiscordComponentSendFn> | undefined;
-let discordSharedInteractivePromise: Promise<DiscordSharedInteractiveModule> | undefined;
+const loadDiscordComponentSend = createLazyRuntimeNamedExport(
+  () => import("./send.components.js"),
+  "sendDiscordComponentMessage",
+);
 
 export async function sendDiscordComponentMessageLazy(
   ...args: Parameters<DiscordComponentSendFn>
 ): ReturnType<DiscordComponentSendFn> {
-  discordComponentSendPromise ??= import("./send.components.js").then(
-    (module) => module.sendDiscordComponentMessage,
-  );
   return await (
-    await discordComponentSendPromise
+    await loadDiscordComponentSend()
   )(...args);
 }
 
-function loadDiscordSharedInteractive(): Promise<DiscordSharedInteractiveModule> {
-  discordSharedInteractivePromise ??= import("./shared-interactive.js");
-  return discordSharedInteractivePromise;
-}
+const loadDiscordSharedInteractive = createLazyRuntimeModule(
+  () => import("./shared-interactive.js"),
+);
 
 function addPayloadTextFallback(
   spec: DiscordComponentMessageSpec,

--- a/extensions/discord/src/outbound-send-context.ts
+++ b/extensions/discord/src/outbound-send-context.ts
@@ -5,6 +5,7 @@ import {
   type OutboundSendDeps,
 } from "openclaw/plugin-sdk/channel-outbound";
 import type { OpenClawConfig, ReplyToMode } from "openclaw/plugin-sdk/config-contracts";
+import { createLazyRuntimeModule } from "openclaw/plugin-sdk/lazy-runtime";
 import { normalizeOptionalStringifiedId } from "openclaw/plugin-sdk/string-coerce-runtime";
 import { withDiscordDeliveryRetry } from "./delivery-retry.js";
 
@@ -19,12 +20,7 @@ type DiscordFormattingOptions = {
   chunkMode?: NonNullable<Parameters<DiscordSendFn>[2]>["chunkMode"];
 };
 
-let discordSendRuntimePromise: Promise<DiscordSendRuntime> | undefined;
-
-export async function loadDiscordSendRuntime(): Promise<DiscordSendRuntime> {
-  discordSendRuntimePromise ??= import("./send.js");
-  return await discordSendRuntimePromise;
-}
+export const loadDiscordSendRuntime = createLazyRuntimeModule(() => import("./send.js"));
 
 export function resolveDiscordOutboundTarget(params: {
   to: string;

--- a/extensions/discord/src/security.ts
+++ b/extensions/discord/src/security.ts
@@ -1,6 +1,7 @@
 // Discord plugin module implements security behavior.
 import { createScopedDmSecurityResolver } from "openclaw/plugin-sdk/channel-config-helpers";
 import { createOpenProviderConfiguredRouteWarningCollector } from "openclaw/plugin-sdk/channel-policy";
+import { createLazyRuntimeModule } from "openclaw/plugin-sdk/lazy-runtime";
 import {
   resolveDiscordAccountAllowFrom,
   resolveDiscordAccountDmPolicy,
@@ -44,14 +45,9 @@ const collectDiscordSecurityWarnings =
     },
   });
 
-let discordSecurityAuditModulePromise:
-  | Promise<typeof import("./security-audit.runtime.js")>
-  | undefined;
-
-async function loadDiscordSecurityAuditModule() {
-  discordSecurityAuditModulePromise ??= import("./security-audit.runtime.js");
-  return await discordSecurityAuditModulePromise;
-}
+const loadDiscordSecurityAuditModule = createLazyRuntimeModule(
+  () => import("./security-audit.runtime.js"),
+);
 
 export const discordSecurityAdapter = {
   resolveDmPolicy: resolveDiscordDmPolicy,

--- a/extensions/discord/src/shared.ts
+++ b/extensions/discord/src/shared.ts
@@ -5,6 +5,7 @@ import { formatAllowFromLowercase } from "openclaw/plugin-sdk/allow-from";
 import { adaptScopedAccountAccessor } from "openclaw/plugin-sdk/channel-config-helpers";
 import { createScopedChannelConfigAdapter } from "openclaw/plugin-sdk/channel-config-helpers";
 import type { ChannelDoctorAdapter } from "openclaw/plugin-sdk/channel-contract";
+import { createLazyRuntimeModule } from "openclaw/plugin-sdk/lazy-runtime";
 import { inspectDiscordAccount } from "./account-inspect.js";
 import {
   isDiscordAccountEnabledForRuntime,
@@ -37,19 +38,12 @@ import { discordSecurityAdapter } from "./security.js";
 import { deriveLegacySessionChatType } from "./session-contract.js";
 
 const DISCORD_CHANNEL = "discord" as const;
-
-type DiscordDoctorModule = typeof import("./doctor.js");
 type DiscordConfigAccessorAccount = {
   allowFrom: string[] | undefined;
   defaultTo: string | undefined;
 };
 
-let discordDoctorModulePromise: Promise<DiscordDoctorModule> | undefined;
-
-async function loadDiscordDoctorModule(): Promise<DiscordDoctorModule> {
-  discordDoctorModulePromise ??= import("./doctor.js");
-  return await discordDoctorModulePromise;
-}
+const loadDiscordDoctorModule = createLazyRuntimeModule(() => import("./doctor.js"));
 
 const discordDoctor: ChannelDoctorAdapter = {
   dmAllowFromMode: "topOnly",

--- a/extensions/discord/subagent-hooks-api.ts
+++ b/extensions/discord/subagent-hooks-api.ts
@@ -1,14 +1,10 @@
 // Discord API module exposes the plugin public contract.
 import type { OpenClawPluginApi } from "openclaw/plugin-sdk/channel-entry-contract";
+import { createLazyRuntimeModule } from "openclaw/plugin-sdk/lazy-runtime";
 
-type DiscordSubagentHooksModule = typeof import("./src/subagent-hooks.js");
-
-let discordSubagentHooksPromise: Promise<DiscordSubagentHooksModule> | null = null;
-
-function loadDiscordSubagentHooksModule() {
-  discordSubagentHooksPromise ??= import("./src/subagent-hooks.js");
-  return discordSubagentHooksPromise;
-}
+const loadDiscordSubagentHooksModule = createLazyRuntimeModule(
+  () => import("./src/subagent-hooks.js"),
+);
 
 // Subagent hooks live behind a dedicated barrel so the bundled entry can
 // register one stable hook wiring path while keeping the handler module lazy.

--- a/extensions/slack/src/action-runtime.ts
+++ b/extensions/slack/src/action-runtime.ts
@@ -1,6 +1,7 @@
 // Slack plugin module implements action runtime behavior.
 import type { AgentToolResult } from "openclaw/plugin-sdk/agent-core";
 import { readBooleanParam } from "openclaw/plugin-sdk/boolean-param";
+import { createLazyRuntimeModule } from "openclaw/plugin-sdk/lazy-runtime";
 import { isSingleUseReplyToMode } from "openclaw/plugin-sdk/reply-reference";
 import { resolveOpenProviderRuntimeGroupPolicy } from "openclaw/plugin-sdk/runtime-group-policy";
 import type { ResolvedSlackAccount } from "./accounts.js";
@@ -32,20 +33,10 @@ const reactionsActions = new Set(["react", "reactions"]);
 const pinActions = new Set(["pinMessage", "unpinMessage", "listPins"]);
 
 type SlackActionsRuntimeModule = typeof import("./actions.runtime.js");
-type SlackAccountsRuntimeModule = typeof import("./accounts.runtime.js");
 
-let slackActionsRuntimePromise: Promise<SlackActionsRuntimeModule> | undefined;
-let slackAccountsRuntimePromise: Promise<SlackAccountsRuntimeModule> | undefined;
+const loadSlackActionsRuntime = createLazyRuntimeModule(() => import("./actions.runtime.js"));
 
-function loadSlackActionsRuntime(): Promise<SlackActionsRuntimeModule> {
-  slackActionsRuntimePromise ??= import("./actions.runtime.js");
-  return slackActionsRuntimePromise;
-}
-
-function loadSlackAccountsRuntime(): Promise<SlackAccountsRuntimeModule> {
-  slackAccountsRuntimePromise ??= import("./accounts.runtime.js");
-  return slackAccountsRuntimePromise;
-}
+const loadSlackAccountsRuntime = createLazyRuntimeModule(() => import("./accounts.runtime.js"));
 
 function createLazySlackAction<K extends keyof SlackActionsRuntimeModule>(
   key: K,

--- a/extensions/slack/src/channel-actions.ts
+++ b/extensions/slack/src/channel-actions.ts
@@ -1,6 +1,7 @@
 // Slack plugin module implements channel actions behavior.
 import type { AgentToolResult } from "openclaw/plugin-sdk/agent-core";
 import type { ChannelMessageActionAdapter } from "openclaw/plugin-sdk/channel-contract";
+import { createLazyRuntimeModule } from "openclaw/plugin-sdk/lazy-runtime";
 import type { SlackActionContext } from "./action-runtime.js";
 import { handleSlackMessageAction } from "./message-action-dispatch.js";
 import { extractSlackToolSend } from "./message-actions.js";
@@ -13,8 +14,6 @@ type SlackActionInvoke = (
   toolContext: unknown,
 ) => Promise<AgentToolResult<unknown>>;
 
-let slackActionRuntimePromise: Promise<typeof import("./action-runtime.runtime.js")> | undefined;
-
 const SLACK_TOOL_DELIVERY_ACTIONS = new Set([
   "deleteMessage",
   "editMessage",
@@ -25,10 +24,7 @@ const SLACK_TOOL_DELIVERY_ACTIONS = new Set([
   "uploadFile",
 ]);
 
-async function loadSlackActionRuntime() {
-  slackActionRuntimePromise ??= import("./action-runtime.runtime.js");
-  return await slackActionRuntimePromise;
-}
+const loadSlackActionRuntime = createLazyRuntimeModule(() => import("./action-runtime.runtime.js"));
 
 function resolveSlackActionContext(params: {
   toolContext: unknown;

--- a/extensions/slack/src/channel.ts
+++ b/extensions/slack/src/channel.ts
@@ -175,12 +175,6 @@ function getTokenForOperation(
 
 type SlackSendFn = typeof import("./send.runtime.js").sendMessageSlack;
 
-let slackActionRuntimePromise: Promise<typeof import("./action-runtime.runtime.js")> | undefined;
-let slackSendRuntimePromise: Promise<typeof import("./send.runtime.js")> | undefined;
-let slackProbeModulePromise: Promise<typeof import("./probe.js")> | undefined;
-let slackMonitorModulePromise: Promise<typeof import("./monitor.js")> | undefined;
-let slackDirectoryLiveModulePromise: Promise<typeof import("./directory-live.js")> | undefined;
-
 const loadSlackDirectoryConfigModule = createLazyRuntimeModule(
   () => import("./directory-config.js"),
 );
@@ -189,30 +183,15 @@ const loadSlackResolveChannelsModule = createLazyRuntimeModule(
 );
 const loadSlackResolveUsersModule = createLazyRuntimeModule(() => import("./resolve-users.js"));
 
-async function loadSlackActionRuntime() {
-  slackActionRuntimePromise ??= import("./action-runtime.runtime.js");
-  return await slackActionRuntimePromise;
-}
+const loadSlackActionRuntime = createLazyRuntimeModule(() => import("./action-runtime.runtime.js"));
 
-async function loadSlackSendRuntime() {
-  slackSendRuntimePromise ??= import("./send.runtime.js");
-  return await slackSendRuntimePromise;
-}
+const loadSlackSendRuntime = createLazyRuntimeModule(() => import("./send.runtime.js"));
 
-async function loadSlackProbeModule() {
-  slackProbeModulePromise ??= import("./probe.js");
-  return await slackProbeModulePromise;
-}
+const loadSlackProbeModule = createLazyRuntimeModule(() => import("./probe.js"));
 
-async function loadSlackMonitorModule() {
-  slackMonitorModulePromise ??= import("./monitor.js");
-  return await slackMonitorModulePromise;
-}
+const loadSlackMonitorModule = createLazyRuntimeModule(() => import("./monitor.js"));
 
-async function loadSlackDirectoryLiveModule() {
-  slackDirectoryLiveModulePromise ??= import("./directory-live.js");
-  return await slackDirectoryLiveModulePromise;
-}
+const loadSlackDirectoryLiveModule = createLazyRuntimeModule(() => import("./directory-live.js"));
 
 async function resolveSlackSendContext(params: {
   cfg: Parameters<typeof resolveSlackAccount>[0]["cfg"];

--- a/extensions/slack/src/monitor/message-handler.ts
+++ b/extensions/slack/src/monitor/message-handler.ts
@@ -4,6 +4,7 @@ import {
   shouldDebounceTextInbound,
 } from "openclaw/plugin-sdk/channel-inbound";
 import { formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
+import { createLazyRuntimeModule } from "openclaw/plugin-sdk/lazy-runtime";
 import {
   asDateTimestampMs,
   resolveExpiresAtMsFromDurationMs,
@@ -23,14 +24,9 @@ import {
 } from "./message-handler/debounce-key.js";
 import { createSlackThreadTsResolver } from "./thread-resolution.js";
 
-type SlackMessagePipeline = typeof import("./message-handler/pipeline.runtime.js");
-
-let slackMessagePipelinePromise: Promise<SlackMessagePipeline> | undefined;
-
-function loadSlackMessagePipeline(): Promise<SlackMessagePipeline> {
-  slackMessagePipelinePromise ??= import("./message-handler/pipeline.runtime.js");
-  return slackMessagePipelinePromise;
-}
+const loadSlackMessagePipeline = createLazyRuntimeModule(
+  () => import("./message-handler/pipeline.runtime.js"),
+);
 
 export type SlackMessageHandler = (
   message: SlackMessageEvent,

--- a/extensions/slack/src/monitor/message-handler/prepare-content.ts
+++ b/extensions/slack/src/monitor/message-handler/prepare-content.ts
@@ -1,6 +1,7 @@
 // Slack plugin module implements prepare content behavior.
 import type { WebClient as SlackWebClient } from "@slack/web-api";
 import { runTasksWithConcurrency } from "openclaw/plugin-sdk/concurrency-runtime";
+import { createLazyRuntimeModule } from "openclaw/plugin-sdk/lazy-runtime";
 import { logVerbose } from "openclaw/plugin-sdk/runtime-env";
 import {
   normalizeOptionalString,
@@ -50,13 +51,7 @@ type SlackBlocksText = {
   hasRichText: boolean;
 };
 
-type SlackMediaModule = typeof import("../media.js");
-let slackMediaModulePromise: Promise<SlackMediaModule> | undefined;
-
-function loadSlackMediaModule(): Promise<SlackMediaModule> {
-  slackMediaModulePromise ??= import("../media.js");
-  return slackMediaModulePromise;
-}
+const loadSlackMediaModule = createLazyRuntimeModule(() => import("../media.js"));
 
 function collectUniqueSlackMentionIds(texts: Array<string | undefined>): string[] {
   const seen = new Set<string>();

--- a/extensions/slack/src/monitor/message-handler/prepare-thread-context.ts
+++ b/extensions/slack/src/monitor/message-handler/prepare-thread-context.ts
@@ -2,6 +2,7 @@
 import { formatInboundEnvelope } from "openclaw/plugin-sdk/channel-inbound";
 import { runTasksWithConcurrency } from "openclaw/plugin-sdk/concurrency-runtime";
 import type { ContextVisibilityMode, OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
+import { createLazyRuntimeModule } from "openclaw/plugin-sdk/lazy-runtime";
 import { logVerbose } from "openclaw/plugin-sdk/runtime-env";
 import {
   filterSupplementalContextItems,
@@ -24,13 +25,7 @@ import {
 } from "./prepare-thread-context-root.js";
 import { resolveSlackTimestampMs } from "./timestamp.js";
 
-type SlackMediaModule = typeof import("../media.js");
-let slackMediaModulePromise: Promise<SlackMediaModule> | undefined;
-
-function loadSlackMediaModule(): Promise<SlackMediaModule> {
-  slackMediaModulePromise ??= import("../media.js");
-  return slackMediaModulePromise;
-}
+const loadSlackMediaModule = createLazyRuntimeModule(() => import("../media.js"));
 
 type SlackThreadContextData = {
   threadStarterBody: string | undefined;

--- a/extensions/slack/src/monitor/provider.ts
+++ b/extensions/slack/src/monitor/provider.ts
@@ -10,6 +10,7 @@ import {
 import { CHANNEL_APPROVAL_NATIVE_RUNTIME_CONTEXT_CAPABILITY } from "openclaw/plugin-sdk/approval-handler-adapter-runtime";
 import { registerChannelRuntimeContext } from "openclaw/plugin-sdk/channel-runtime-context";
 import type { SessionScope } from "openclaw/plugin-sdk/config-contracts";
+import { createLazyRuntimeModule } from "openclaw/plugin-sdk/lazy-runtime";
 import { resolveTextChunkLimit } from "openclaw/plugin-sdk/reply-chunking";
 import { DEFAULT_GROUP_HISTORY_LIMIT } from "openclaw/plugin-sdk/reply-history";
 import { normalizeMainKey } from "openclaw/plugin-sdk/routing";
@@ -75,8 +76,6 @@ import { registerSlackMonitorSlashCommands } from "./slash.js";
 import type { MonitorSlackOpts } from "./types.js";
 
 let slackBoltInterop: SlackBoltResolvedExports | undefined;
-type SlackRelaySourceModule = typeof import("./relay-source.js");
-let slackRelaySourcePromise: Promise<SlackRelaySourceModule> | undefined;
 
 async function getSlackBoltInterop(): Promise<SlackBoltResolvedExports> {
   if (!slackBoltInterop) {
@@ -89,10 +88,7 @@ async function getSlackBoltInterop(): Promise<SlackBoltResolvedExports> {
   return slackBoltInterop;
 }
 
-function loadSlackRelaySource(): Promise<SlackRelaySourceModule> {
-  slackRelaySourcePromise ??= import("./relay-source.js");
-  return slackRelaySourcePromise;
-}
+const loadSlackRelaySource = createLazyRuntimeModule(() => import("./relay-source.js"));
 
 const SLACK_WEBHOOK_MAX_BODY_BYTES = 1024 * 1024;
 const SLACK_WEBHOOK_BODY_TIMEOUT_MS = 30_000;

--- a/extensions/slack/src/monitor/slash.ts
+++ b/extensions/slack/src/monitor/slash.ts
@@ -12,6 +12,7 @@ import {
   resolveNativeCommandSessionTargets,
 } from "openclaw/plugin-sdk/command-auth-native";
 import { formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
+import { createLazyRuntimeModule } from "openclaw/plugin-sdk/lazy-runtime";
 import {
   resolveNativeCommandsEnabled,
   resolveNativeSkillsEnabled,
@@ -67,36 +68,22 @@ const SLACK_COMMAND_ARG_CONFIRM_TEXT_MAX = 300;
 const SLACK_HEADER_TEXT_MAX = 150;
 const SLACK_COMMAND_ARG_CHROME_BLOCKS = 3;
 const SLACK_COMMAND_ARG_ACTION_BLOCKS_MAX = SLACK_MAX_BLOCKS - SLACK_COMMAND_ARG_CHROME_BLOCKS;
-let slashCommandsRuntimePromise: Promise<typeof import("./slash-commands.runtime.js")> | null =
-  null;
-let slashDispatchRuntimePromise: Promise<typeof import("./slash-dispatch.runtime.js")> | null =
-  null;
-let slackPluginCommandsRuntimePromise: Promise<
-  typeof import("./slash-plugin-commands.runtime.js")
-> | null = null;
-let slashSkillCommandsRuntimePromise: Promise<
-  typeof import("./slash-skill-commands.runtime.js")
-> | null = null;
 
-function loadSlashCommandsRuntime() {
-  slashCommandsRuntimePromise ??= import("./slash-commands.runtime.js");
-  return slashCommandsRuntimePromise;
-}
+const loadSlashCommandsRuntime = createLazyRuntimeModule(
+  () => import("./slash-commands.runtime.js"),
+);
 
-function loadSlashDispatchRuntime() {
-  slashDispatchRuntimePromise ??= import("./slash-dispatch.runtime.js");
-  return slashDispatchRuntimePromise;
-}
+const loadSlashDispatchRuntime = createLazyRuntimeModule(
+  () => import("./slash-dispatch.runtime.js"),
+);
 
-function loadSlackPluginCommandsRuntime() {
-  slackPluginCommandsRuntimePromise ??= import("./slash-plugin-commands.runtime.js");
-  return slackPluginCommandsRuntimePromise;
-}
+const loadSlackPluginCommandsRuntime = createLazyRuntimeModule(
+  () => import("./slash-plugin-commands.runtime.js"),
+);
 
-function loadSlashSkillCommandsRuntime() {
-  slashSkillCommandsRuntimePromise ??= import("./slash-skill-commands.runtime.js");
-  return slashSkillCommandsRuntimePromise;
-}
+const loadSlashSkillCommandsRuntime = createLazyRuntimeModule(
+  () => import("./slash-skill-commands.runtime.js"),
+);
 
 function resolveSlackCommandMenuModelContext(params: {
   cfg: SlackMonitorContext["cfg"];

--- a/extensions/slack/src/outbound-adapter.ts
+++ b/extensions/slack/src/outbound-adapter.ts
@@ -11,6 +11,7 @@ import {
   type InteractiveReply,
   type MessagePresentation,
 } from "openclaw/plugin-sdk/interactive-runtime";
+import { createLazyRuntimeModule } from "openclaw/plugin-sdk/lazy-runtime";
 import {
   resolvePayloadMediaUrls,
   sendPayloadMediaSequenceAndFinalize,
@@ -32,12 +33,7 @@ import { resolveSlackThreadTsValue } from "./thread-ts.js";
 const SLACK_MAX_BLOCKS = 50;
 type SlackSendFn = typeof import("./send.runtime.js").sendMessageSlack;
 
-let slackSendRuntimePromise: Promise<typeof import("./send.runtime.js")> | undefined;
-
-async function loadSlackSendRuntime() {
-  slackSendRuntimePromise ??= import("./send.runtime.js");
-  return await slackSendRuntimePromise;
-}
+const loadSlackSendRuntime = createLazyRuntimeModule(() => import("./send.runtime.js"));
 
 function resolveRenderedInteractiveBlocks(
   interactive?: InteractiveReply,

--- a/extensions/telegram/src/audit.ts
+++ b/extensions/telegram/src/audit.ts
@@ -1,6 +1,8 @@
 // Telegram plugin module implements audit behavior.
 import type { TelegramGroupConfig } from "openclaw/plugin-sdk/config-contracts";
+import { createLazyRuntimeModule } from "openclaw/plugin-sdk/lazy-runtime";
 import { normalizeOptionalString } from "openclaw/plugin-sdk/string-coerce-runtime";
+
 export type {
   AuditTelegramGroupMembershipParams,
   TelegramGroupMembershipAudit,
@@ -52,13 +54,9 @@ export function collectTelegramUnmentionedGroupIds(
   return { groupIds, unresolvedGroups, hasWildcardUnmentionedGroups };
 }
 
-let auditMembershipRuntimePromise: Promise<typeof import("./audit-membership-runtime.js")> | null =
-  null;
-
-function loadAuditMembershipRuntime() {
-  auditMembershipRuntimePromise ??= import("./audit-membership-runtime.js");
-  return auditMembershipRuntimePromise;
-}
+const loadAuditMembershipRuntime = createLazyRuntimeModule(
+  () => import("./audit-membership-runtime.js"),
+);
 
 export async function auditTelegramGroupMembership(
   params: AuditTelegramGroupMembershipParams,

--- a/extensions/telegram/src/bot-message-context.body.ts
+++ b/extensions/telegram/src/bot-message-context.body.ts
@@ -24,6 +24,7 @@ import {
   toInternalMessageReceivedContext,
   triggerInternalHook,
 } from "openclaw/plugin-sdk/hook-runtime";
+import { createLazyRuntimeModule } from "openclaw/plugin-sdk/lazy-runtime";
 import type { HistoryEntry } from "openclaw/plugin-sdk/reply-history";
 import type { MsgContext } from "openclaw/plugin-sdk/reply-runtime";
 import { logVerbose } from "openclaw/plugin-sdk/runtime-env";
@@ -51,25 +52,17 @@ import type { TelegramContext } from "./bot/types.js";
 import { isTelegramForumServiceMessage } from "./forum-service-message.js";
 import { recordTelegramGroupHistoryEntry } from "./group-history-window.js";
 import { resolveTelegramCommandIngressAuthorization } from "./ingress.js";
-
-type StickerVisionRuntime = typeof import("./sticker-vision.runtime.js");
-type MediaUnderstandingRuntime = typeof import("./media-understanding.runtime.js");
 type TelegramMentionFacts = NonNullable<
   NonNullable<BuildChannelInboundEventContextParams["access"]>["mentions"]
 >;
 
-let stickerVisionRuntimePromise: Promise<StickerVisionRuntime> | undefined;
-let mediaUnderstandingRuntimePromise: Promise<MediaUnderstandingRuntime> | undefined;
+const loadStickerVisionRuntime = createLazyRuntimeModule(
+  () => import("./sticker-vision.runtime.js"),
+);
 
-function loadStickerVisionRuntime(): Promise<StickerVisionRuntime> {
-  stickerVisionRuntimePromise ??= import("./sticker-vision.runtime.js");
-  return stickerVisionRuntimePromise;
-}
-
-function loadMediaUnderstandingRuntime(): Promise<MediaUnderstandingRuntime> {
-  mediaUnderstandingRuntimePromise ??= import("./media-understanding.runtime.js");
-  return mediaUnderstandingRuntimePromise;
-}
+const loadMediaUnderstandingRuntime = createLazyRuntimeModule(
+  () => import("./media-understanding.runtime.js"),
+);
 
 export type TelegramInboundBodyResult = {
   bodyText: string;

--- a/extensions/telegram/src/bot-message-context.test-harness.ts
+++ b/extensions/telegram/src/bot-message-context.test-harness.ts
@@ -1,6 +1,7 @@
 // Telegram plugin module implements bot message context harness behavior.
 import { createHash } from "node:crypto";
 import { buildChannelInboundEventContext } from "openclaw/plugin-sdk/channel-inbound";
+import { createLazyRuntimeModule } from "openclaw/plugin-sdk/lazy-runtime";
 import type { BuildTelegramMessageContextParams, TelegramMediaRef } from "./bot-message-context.js";
 import { setTelegramTopicNameStoreFactoryForTest } from "./topic-name-cache.js";
 
@@ -153,7 +154,6 @@ export async function buildTelegramMessageContextForTest(
 let buildTelegramMessageContextLoader:
   | typeof import("./bot-message-context.js").buildTelegramMessageContext
   | undefined;
-let vitestModuleLoader: Promise<typeof import("vitest")> | undefined;
 let messageContextMocksInstalled = false;
 
 async function loadBuildTelegramMessageContext() {
@@ -165,10 +165,7 @@ async function loadBuildTelegramMessageContext() {
   return buildTelegramMessageContextLoader;
 }
 
-async function loadVitestModule() {
-  vitestModuleLoader ??= import("vitest");
-  return await vitestModuleLoader;
-}
+const loadVitestModule = createLazyRuntimeModule(() => import("vitest"));
 
 async function installMessageContextTestMocks() {
   installTelegramTopicNameStoreForTest();

--- a/extensions/telegram/src/bot-message-context.ts
+++ b/extensions/telegram/src/bot-message-context.ts
@@ -9,6 +9,7 @@ import type {
   TelegramDirectConfig,
   TelegramGroupConfig,
 } from "openclaw/plugin-sdk/config-contracts";
+import { createLazyRuntimeModule } from "openclaw/plugin-sdk/lazy-runtime";
 import { deriveLastRoutePolicy } from "openclaw/plugin-sdk/routing";
 import { normalizeAccountId, resolveThreadSessionKeys } from "openclaw/plugin-sdk/routing";
 import { logVerbose } from "openclaw/plugin-sdk/runtime-env";
@@ -60,14 +61,9 @@ export type {
   TelegramMediaRef,
 } from "./bot-message-context.types.js";
 
-type TelegramMessageContextRuntime = typeof import("./bot-message-context.runtime.js");
-
-let telegramMessageContextRuntimePromise: Promise<TelegramMessageContextRuntime> | undefined;
-
-async function loadTelegramMessageContextRuntime() {
-  telegramMessageContextRuntimePromise ??= import("./bot-message-context.runtime.js");
-  return await telegramMessageContextRuntimePromise;
-}
+const loadTelegramMessageContextRuntime = createLazyRuntimeModule(
+  () => import("./bot-message-context.runtime.js"),
+);
 
 type TelegramMessageContextPayload = Awaited<ReturnType<typeof buildTelegramInboundContextPayload>>;
 type TelegramReactionApi = (

--- a/extensions/telegram/src/bot-native-commands.ts
+++ b/extensions/telegram/src/bot-native-commands.ts
@@ -31,6 +31,7 @@ import type {
   TelegramGroupConfig,
   TelegramTopicConfig,
 } from "openclaw/plugin-sdk/config-contracts";
+import { createLazyRuntimeModule } from "openclaw/plugin-sdk/lazy-runtime";
 import { resolveMarkdownTableMode } from "openclaw/plugin-sdk/markdown-table-runtime";
 import { codexChannelLoginRuntime } from "openclaw/plugin-sdk/provider-auth-login-flow-runtime";
 import { resolveSendableOutboundReplyParts } from "openclaw/plugin-sdk/reply-payload";
@@ -106,6 +107,7 @@ import { buildInlineKeyboard } from "./inline-keyboard.js";
 import { buildTelegramNativeCommandCallbackData } from "./native-command-callback-data.js";
 import { recordSentMessage } from "./sent-message-cache.js";
 import { getTopicName, resolveTopicNameCacheScope } from "./topic-name-cache.js";
+
 export {
   buildTelegramNativeCommandCallbackData,
   parseTelegramNativeCommandCallbackData,
@@ -198,24 +200,13 @@ function buildTelegramCommandMenuModelContext(params: {
   };
 }
 
-let telegramNativeCommandDeliveryRuntimePromise:
-  | Promise<typeof import("./bot-native-commands.delivery.runtime.js")>
-  | undefined;
+const loadTelegramNativeCommandDeliveryRuntime = createLazyRuntimeModule(
+  () => import("./bot-native-commands.delivery.runtime.js"),
+);
 
-async function loadTelegramNativeCommandDeliveryRuntime() {
-  telegramNativeCommandDeliveryRuntimePromise ??=
-    import("./bot-native-commands.delivery.runtime.js");
-  return await telegramNativeCommandDeliveryRuntimePromise;
-}
-
-let telegramNativeCommandRuntimePromise:
-  | Promise<typeof import("./bot-native-commands.runtime.js")>
-  | undefined;
-
-async function loadTelegramNativeCommandRuntime() {
-  telegramNativeCommandRuntimePromise ??= import("./bot-native-commands.runtime.js");
-  return await telegramNativeCommandRuntimePromise;
-}
+const loadTelegramNativeCommandRuntime = createLazyRuntimeModule(
+  () => import("./bot-native-commands.runtime.js"),
+);
 
 type TelegramNativeCommandRuntime = Awaited<ReturnType<typeof loadTelegramNativeCommandRuntime>>;
 

--- a/extensions/telegram/src/channel-actions.ts
+++ b/extensions/telegram/src/channel-actions.ts
@@ -11,6 +11,7 @@ import type {
   ChannelMessageToolSchemaContribution,
 } from "openclaw/plugin-sdk/channel-contract";
 import type { TelegramActionConfig } from "openclaw/plugin-sdk/config-contracts";
+import { createLazyRuntimeModule } from "openclaw/plugin-sdk/lazy-runtime";
 import { readStringValue } from "openclaw/plugin-sdk/string-coerce-runtime";
 import { extractToolSend } from "openclaw/plugin-sdk/tool-send";
 import { inspectTelegramAccount } from "./account-inspect.js";
@@ -22,12 +23,7 @@ import {
 import { isTelegramInlineButtonsEnabled } from "./inline-buttons.js";
 import { createTelegramPollExtraToolSchemas } from "./message-tool-schema.js";
 
-let telegramActionRuntimePromise: Promise<typeof import("./action-runtime.js")> | null = null;
-
-async function loadTelegramActionRuntime() {
-  telegramActionRuntimePromise ??= import("./action-runtime.js");
-  return await telegramActionRuntimePromise;
-}
+const loadTelegramActionRuntime = createLazyRuntimeModule(() => import("./action-runtime.js"));
 
 export const telegramMessageActionRuntime = {
   handleTelegramAction: async (

--- a/extensions/telegram/src/channel.ts
+++ b/extensions/telegram/src/channel.ts
@@ -27,6 +27,7 @@ import {
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import { createChannelDirectoryAdapter } from "openclaw/plugin-sdk/directory-runtime";
 import { formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
+import { createLazyRuntimeModule } from "openclaw/plugin-sdk/lazy-runtime";
 import type { RoutePeer } from "openclaw/plugin-sdk/routing";
 import {
   createComputedAccountStatusAdapter,
@@ -76,6 +77,7 @@ import { resolveTelegramReactionLevel } from "./reaction-level.js";
 import { resolveTelegramStartupProbeTimeoutMs } from "./request-timeouts.js";
 import { getTelegramRuntime } from "./runtime.js";
 import { telegramSecurityAdapter } from "./security.js";
+import { loadTelegramSendModule } from "./send-runtime.js";
 import {
   resolveTelegramSessionConversation,
   resolveTelegramSessionTarget,
@@ -92,7 +94,6 @@ import { withTelegramStartupProbeSlot } from "./startup-probe-limiter.js";
 import { detectTelegramLegacyStateMigrations } from "./state-migrations.js";
 import { collectTelegramStatusIssues } from "./status-issues.js";
 import { parseTelegramTarget } from "./targets.js";
-import { loadTelegramSendModule } from "./send-runtime.js";
 import {
   createTelegramThreadBindingManager,
   setTelegramThreadBindingIdleTimeoutBySessionKey,
@@ -103,14 +104,10 @@ import { resolveTelegramToken } from "./token.js";
 import { parseTelegramTopicConversation } from "./topic-conversation.js";
 
 type TelegramSendFn = typeof import("./send.js").sendMessageTelegram;
-type TelegramUpdateOffsetRuntime = typeof import("../update-offset-runtime-api.js");
 
-let telegramUpdateOffsetRuntimePromise: Promise<TelegramUpdateOffsetRuntime> | undefined;
-
-async function loadTelegramUpdateOffsetRuntime() {
-  telegramUpdateOffsetRuntimePromise ??= import("../update-offset-runtime-api.js");
-  return await telegramUpdateOffsetRuntimePromise;
-}
+const loadTelegramUpdateOffsetRuntime = createLazyRuntimeModule(
+  () => import("../update-offset-runtime-api.js"),
+);
 
 function resolveTelegramProbe() {
   return (

--- a/extensions/telegram/src/monitor.ts
+++ b/extensions/telegram/src/monitor.ts
@@ -3,6 +3,7 @@ import type { RunOptions } from "@grammyjs/runner";
 import { CHANNEL_APPROVAL_NATIVE_RUNTIME_CONTEXT_CAPABILITY } from "openclaw/plugin-sdk/approval-handler-adapter-runtime";
 import { registerChannelRuntimeContext } from "openclaw/plugin-sdk/channel-runtime-context";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
+import { createLazyRuntimeModule } from "openclaw/plugin-sdk/lazy-runtime";
 import { resolveAgentMaxConcurrent } from "openclaw/plugin-sdk/model-session-runtime";
 import { getRuntimeConfig } from "openclaw/plugin-sdk/runtime-config-snapshot";
 import {
@@ -90,23 +91,13 @@ type TelegramPollingSessionInstance = InstanceType<
   TelegramMonitorPollingRuntime["TelegramPollingSession"]
 >;
 
-let telegramMonitorPollingRuntimePromise:
-  | Promise<typeof import("./monitor-polling.runtime.js")>
-  | undefined;
+const loadTelegramMonitorPollingRuntime = createLazyRuntimeModule(
+  () => import("./monitor-polling.runtime.js"),
+);
 
-async function loadTelegramMonitorPollingRuntime() {
-  telegramMonitorPollingRuntimePromise ??= import("./monitor-polling.runtime.js");
-  return await telegramMonitorPollingRuntimePromise;
-}
-
-let telegramMonitorWebhookRuntimePromise:
-  | Promise<typeof import("./monitor-webhook.runtime.js")>
-  | undefined;
-
-async function loadTelegramMonitorWebhookRuntime() {
-  telegramMonitorWebhookRuntimePromise ??= import("./monitor-webhook.runtime.js");
-  return await telegramMonitorWebhookRuntimePromise;
-}
+const loadTelegramMonitorWebhookRuntime = createLazyRuntimeModule(
+  () => import("./monitor-webhook.runtime.js"),
+);
 
 export async function monitorTelegramProvider(opts: MonitorTelegramOpts = {}) {
   const logInfo = (line: string) => (opts.runtime?.log ?? console.log)(line);

--- a/extensions/telegram/src/send-runtime.ts
+++ b/extensions/telegram/src/send-runtime.ts
@@ -1,9 +1,5 @@
+import { createLazyRuntimeModule } from "openclaw/plugin-sdk/lazy-runtime";
 // Telegram plugin module owns the lazy send runtime import.
 export type TelegramSendModule = typeof import("./send.js");
 
-let telegramSendModulePromise: Promise<TelegramSendModule> | undefined;
-
-export async function loadTelegramSendModule(): Promise<TelegramSendModule> {
-  telegramSendModulePromise ??= import("./send.js");
-  return await telegramSendModulePromise;
-}
+export const loadTelegramSendModule = createLazyRuntimeModule(() => import("./send.js"));


### PR DESCRIPTION
Related: #98748

## What Problem This Solves

OpenClaw still has duplicated hand-written lazy dynamic-import memoizers across the Discord, Slack, and Telegram plugins. Keeping those loaders separate makes their caching and rejection behavior easier to drift and harder to audit consistently.

## Why This Change Was Made

This is PR 4 of 6 in the lazy-runtime utility consolidation series. It replaces the owned Discord, Slack, and Telegram module memoizers with the shared lazy-runtime helpers while preserving transport startup and teardown, approval and model-picker resets, cached rejection behavior, and the existing hot-entrypoint import boundaries.

Series progress:

- PR 1: [#99261](https://github.com/openclaw/openclaw/pull/99261) established the shared lazy-runtime loader foundation.
- PR 2: [#99278](https://github.com/openclaw/openclaw/pull/99278) consolidated core leaf lazy loaders.
- PR 3: the preceding gateway batch.
- PR 4: this Discord, Slack, and Telegram batch.
- PR 5: remaining channel and plugin lazy loaders.
- PR 6: final residual loader cleanup and series-wide audit.

## User Impact

There is no intended user-visible behavior change. Developers get one shared implementation for cached lazy module loading across these three plugins, reducing duplicate code and future semantic drift.

## Evidence

- Discord focused tests: 10 files, 313 tests passed.
- Slack focused tests: 8 files, 195 tests passed.
- Telegram focused tests: 10 files, 311 tests passed.
- Blacksmith Testbox through Crabbox `tbx_01kwjsbw294jxsfnyzfv6rz4qk`: scoped `oxfmt`, extension `oxlint`, `tsgo:extensions`, `tsgo:extensions:test`, full build, and import-cycle check passed.
- Import audit found no remaining hand-written module promise memoizers and no runtime static-plus-dynamic import overlap in the owned paths.
- Startup topology did not change, so an isolated memory profile was not warranted.
- Fresh Codex autoreview completed cleanly with no accepted or actionable findings.
