### PR TITLE
fix(doctor): catch EACCES on shell completion install so optional step does not fail doctor --fix

### DIFF
--- a/src/commands/doctor-completion.test.ts
+++ b/src/commands/doctor-completion.test.ts
@@ -2,7 +2,7 @@
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { captureEnv, setTestEnvValue } from "../test-utils/env.js";
 import {
   checkShellCompletionStatus,
@@ -10,6 +10,15 @@ import {
   shellCompletionStatusToRepairEffects,
   type ShellCompletionStatus,
 } from "./doctor-completion.js";
+
+const installCompletionMock = vi.hoisted(() => vi.fn());
+vi.mock("../cli/completion-runtime.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../cli/completion-runtime.js")>();
+  return {
+    ...actual,
+    installCompletion: installCompletionMock,
+  };
+});
 
 const originalEnv = captureEnv(["HOME", "OPENCLAW_STATE_DIR", "SHELL"]);
 const tempDirs: string[] = [];
@@ -100,5 +109,26 @@ describe("shell completion health mapping", () => {
 
     expect(shellCompletionStatusToHealthFindings(current)).toEqual([]);
     expect(shellCompletionStatusToRepairEffects(current)).toEqual([]);
+  });
+});
+
+describe("doctorShellCompletion EACCES handling", () => {
+  it("logs a friendly message and does not throw when installCompletion fails with EACCES", async () => {
+    installCompletionMock.mockRejectedValueOnce(
+      Object.assign(new Error("EACCES: permission denied, open '/sandbox/.bashrc'"), {
+        code: "EACCES",
+      }),
+    );
+
+    const { doctorShellCompletion } = await import("./doctor-completion.js");
+
+    // Should not throw — the catch block logs the error and returns gracefully
+    await expect(
+      doctorShellCompletion(
+        { log: vi.fn(), error: vi.fn(), exit: vi.fn() } as never,
+        { confirm: vi.fn() } as never,
+        { nonInteractive: true },
+      ),
+    ).resolves.toBeUndefined();
   });
 });

--- a/src/commands/doctor-completion.ts
+++ b/src/commands/doctor-completion.ts
@@ -195,8 +195,16 @@ export async function doctorShellCompletion(
       }
     }
 
-    await installCompletion(status.shell, true, cliName);
-    note(formatCompletionReloadNote(status.shell, "upgraded"), "Shell completion");
+    try {
+      await installCompletion(status.shell, true, cliName);
+      note(formatCompletionReloadNote(status.shell, "upgraded"), "Shell completion");
+    } catch {
+      note(
+        `Failed to install shell completion: ${status.shell} profile is not writable. ` +
+          `Run \`${cliName} completion --install\` manually after fixing permissions.`,
+        "Shell completion",
+      );
+    }
     return;
   }
 
@@ -237,8 +245,16 @@ export async function doctorShellCompletion(
         return;
       }
 
-      await installCompletion(status.shell, true, cliName);
-      note(formatCompletionReloadNote(status.shell, "installed"), "Shell completion");
+      try {
+        await installCompletion(status.shell, true, cliName);
+        note(formatCompletionReloadNote(status.shell, "installed"), "Shell completion");
+      } catch {
+        note(
+          `Failed to install shell completion: ${status.shell} profile is not writable. ` +
+            `Run \`${cliName} completion --install\` manually after fixing permissions.`,
+          "Shell completion",
+        );
+      }
     }
   }
 }


### PR DESCRIPTION
## What Problem This Solves

`openclaw doctor --fix` exits with code 1 when shell completion install fails on a read-only shell profile (EACCES). Shell completion setup is an optional step — a non-writable profile should not block the rest of the doctor run.

Observed error:
```
Error: Failed to install completion: EACCES: permission denied, open '/sandbox/.bashrc'
```

## Why This Change Was Made

Wrap both `installCompletion` call sites in `doctorShellCompletion` in try-catch blocks. On EACCES (or any install failure), log a friendly message telling the user to run completion install manually after fixing permissions, then continue instead of crashing.

## Changes

- `src/commands/doctor-completion.ts`: Wrap two `installCompletion` calls in try-catch (+20/-4)
- `src/commands/doctor-completion.test.ts`: Add regression test for EACCES handling (+31/-1)

## Real behavior proof

**Behavior addressed:** doctor --fix no longer exits 1 when shell completion install fails on read-only profile.
**Environment tested:** Node 22.x on Linux
**Steps run after the patch:** Ran focused unit test and compilation check
**Evidence after fix:**

Test output (5/5 passed):

```
 ✓ shell completion health mapping > checks an explicit shell instead of the detected environment shell
 ✓ shell completion health mapping > reports slow dynamic shell completion with dry-run effects
 ✓ shell completion health mapping > reports missing completion cache with a dry-run cache effect
 ✓ shell completion health mapping > keeps healthy shell completion quiet
 ✓ doctorShellCompletion EACCES handling > logs a friendly message and does not throw when installCompletion fails with EACCES

 Test Files  1 passed (1)
      Tests  5 passed (5)
```

**Observed result:** All 5 tests pass. The new EACCES test mocks installCompletion to reject with EACCES and verifies doctorShellCompletion resolves gracefully instead of throwing.
**Not tested:** Live EACCES scenario with read-only ~/.bashrc on a real system.

Fixes #99237
