### PR TITLE
fix(feishu): catch unhandled promise rejection in streaming card flush timer

### DIFF
--- a/extensions/feishu/src/streaming-card.test.ts
+++ b/extensions/feishu/src/streaming-card.test.ts
@@ -187,6 +187,37 @@ describe("FeishuStreamingSession", () => {
     });
   });
 
+  it("handles a rejected scheduled flush update", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(1_500);
+    const updateBodies: string[] = [];
+    mockFetches(updateBodies);
+    const log = vi.fn();
+    const session = new FeishuStreamingSession(
+      {} as never,
+      { appId: "app_rejected_pending_flush", appSecret: "secret" },
+      log,
+    );
+    setStreamingSessionInternals(session, {
+      state: {
+        cardId: "card_rejected_flush",
+        messageId: "om_rejected_flush",
+        sequence: 1,
+        currentText: "hello",
+        sentText: "hello",
+        hasNote: false,
+      },
+      lastUpdateTime: 1_500,
+    });
+
+    await session.update("hello small");
+    vi.spyOn(session, "update").mockRejectedValueOnce(new Error("flush exploded"));
+    await vi.advanceTimersByTimeAsync(160);
+
+    expect(log).toHaveBeenCalledWith("Scheduled flush update failed: Error: flush exploded");
+    expect(updateBodies).toHaveLength(0);
+  });
+
   it("pushes natural-boundary updates immediately inside the throttle window", async () => {
     vi.useFakeTimers();
     vi.setSystemTime(2_000);

--- a/extensions/feishu/src/streaming-card.ts
+++ b/extensions/feishu/src/streaming-card.ts
@@ -452,7 +452,9 @@ export class FeishuStreamingSession {
       if (!pending || this.closed) {
         return;
       }
-      void this.update(pending);
+      void this.update(pending).catch((e: unknown) =>
+        this.log?.(`Scheduled flush update failed: ${String(e)}`),
+      );
     }, delayMs);
   }
 

--- a/extensions/feishu/src/streaming-card.ts
+++ b/extensions/feishu/src/streaming-card.ts
@@ -452,8 +452,8 @@ export class FeishuStreamingSession {
       if (!pending || this.closed) {
         return;
       }
-      void this.update(pending).catch((e: unknown) =>
-        this.log?.(`Scheduled flush update failed: ${String(e)}`),
+      void this.update(pending).catch((error: unknown) =>
+        this.log?.(`Scheduled flush update failed: ${String(error)}`),
       );
     }, delayMs);
   }


### PR DESCRIPTION
## What Problem This Solves

The scheduled flush update in FeishuStreamingSession called `this.update(pending)` without catching potential rejections, which could cause unhandled promise rejections when card content updates fail due to transient network errors.

## Why This Change Was Made

Add a `.catch()` with diagnostic logging to the scheduled flush timer's `update()` call so transient card update failures are visible without causing unhandled promise rejections.

## User Impact

Scheduled streaming-card updates that fail transiently will log a diagnostic instead of producing an unhandled promise rejection.

## Evidence

### Focused runtime test

A dedicated runtime test verifies that the `.catch()` handler on the flush timer's `update()` call prevents unhandled rejections:

- `.catch()` present in flush timer source: true
- `UnhandledRejection` events: 0 (should be 0)
- streaming-card fix verified

### Full test suite (44/44 passed)

```
 Test Files  1 passed (1)
 Tests       44 passed (44)
```

### Format / Lint / Whitespace

- oxfmt: All matched files use the correct format.
- oxlint: exit=0
- git diff --check: exit=0

### Source change

```typescript
// Before:
void this.update(pending);

// After:
void this.update(pending).catch((e: unknown) =>
  this.log?.(`Scheduled flush update failed: ${String(e)}`),
);
```

### Diff summary

```
 extensions/feishu/src/streaming-card.ts | 4 +++-
 1 file changed, 3 insertions(+), 1 deletion(-)
```

AI-assisted: Codex reviewed and implemented.