### PR TITLE
test(qa): cover Crabline Zalo transport

### DIFF
--- a/extensions/qa-lab/package.json
+++ b/extensions/qa-lab/package.json
@@ -16,7 +16,7 @@
     "@openclaw/plugin-sdk": "workspace:*",
     "@openclaw/slack": "workspace:*",
     "@openclaw/whatsapp": "workspace:*",
-    "@openclaw/crabline": "0.1.7",
+    "@openclaw/crabline": "0.1.8",
     "openclaw": "workspace:*"
   },
   "peerDependencies": {

--- a/extensions/qa-lab/src/crabline-transport.test.ts
+++ b/extensions/qa-lab/src/crabline-transport.test.ts
@@ -617,6 +617,85 @@ describe("crabline transport", () => {
     });
   });
 
+  it("configures Zalo and normalizes native message sends", async () => {
+    await withTempDir("qa-crabline-transport-", async (outputDir) => {
+      const transport = await createQaCrablineTransportAdapter({
+        outputDir,
+        selection: createSelection("zalo"),
+        state: createQaBusState(),
+      });
+
+      try {
+        expect(transport.requiredPluginIds).toEqual(["zalo"]);
+        expect(transport.createGatewayConfig({ baseUrl: "http://127.0.0.1:1" })).toMatchObject({
+          channels: {
+            zalo: {
+              allowFrom: ["*"],
+              botToken: "crabline-zalo-bot-token",
+              dmPolicy: "open",
+              enabled: true,
+              groupAllowFrom: ["*"],
+              groupPolicy: "open",
+            },
+          },
+        });
+        expect(transport.createRuntimeEnvPatch?.()).toMatchObject({
+          ZALO_API_URL: expect.stringMatching(/^http:\/\/127\.0\.0\.1:\d+$/u),
+          ZALO_BOT_TOKEN: "crabline-zalo-bot-token",
+        });
+
+        await transport.state.addInboundMessage({
+          conversation: { id: "qa-group", kind: "group" },
+          senderId: "alice",
+          senderName: "Alice",
+          text: "Zalo baseline marker check.",
+        });
+        const delivery = transport.buildAgentDelivery({ target: "group:qa-group" });
+        expect(delivery).toEqual({
+          channel: "zalo",
+          replyChannel: "zalo",
+          replyTo: "qa-group",
+          to: "qa-group",
+        });
+
+        const manifest = JSON.parse(
+          await fs.readFile(path.join(outputDir, OPENCLAW_CRABLINE_MANIFEST_PATH), "utf8"),
+        ) as {
+          botToken: string;
+          endpoints: { apiRoot: string };
+        };
+        const { response, release } = await fetchWithSsrFGuard({
+          url: `${manifest.endpoints.apiRoot}/bot${manifest.botToken}/sendMessage`,
+          init: {
+            body: JSON.stringify({
+              chat_id: delivery.to,
+              text: "assistant via fake zalo",
+            }),
+            headers: { "content-type": "application/json" },
+            method: "POST",
+          },
+          policy: { allowPrivateNetwork: true },
+          auditContext: "qa-lab-crabline-zalo-transport-test",
+        });
+        await release();
+        expect(response.ok).toBe(true);
+
+        await expect(
+          transport.waitForOutbound({
+            conversation: { id: "qa-group", kind: "group" },
+            textIncludes: "assistant via fake zalo",
+            timeoutMs: 1_000,
+          }),
+        ).resolves.toMatchObject({
+          conversation: { id: "qa-group", kind: "group" },
+          text: "assistant via fake zalo",
+        });
+      } finally {
+        await transport.cleanup?.();
+      }
+    });
+  });
+
   it("injects inbound messages through Crabline and mirrors Telegram sends into normalized state", async () => {
     await withTempDir("qa-crabline-transport-", async (outputDir) => {
       const transport = await createQaCrablineTransportAdapter({

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1350,8 +1350,8 @@ importers:
         version: 4.4.3
     devDependencies:
       '@openclaw/crabline':
-        specifier: 0.1.7
-        version: 0.1.7
+        specifier: 0.1.8
+        version: 0.1.8
       '@openclaw/discord':
         specifier: workspace:*
         version: link:../discord
@@ -3165,8 +3165,8 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@openclaw/crabline@0.1.7':
-    resolution: {integrity: sha512-FwKY45UJ4nlKA3wMEGb9KSxNvJgI4gzaLttr4wxARpurQArzVyf5z3IjWzN7b9sra0oNQTk2Y8ugdOtJqSjI4g==}
+  '@openclaw/crabline@0.1.8':
+    resolution: {integrity: sha512-a6r4vkPEsDaMdznLVcxiVdKA3oI3k2IUU0sJjCd699pFWR401qfvvQMbgFOb403eA7/vaRkpN0E9tBbFycl6Ug==}
     engines: {node: '>=22'}
     hasBin: true
 
@@ -9198,7 +9198,7 @@ snapshots:
   '@openai/codex@0.142.4-win32-x64':
     optional: true
 
-  '@openclaw/crabline@0.1.7':
+  '@openclaw/crabline@0.1.8':
     dependencies:
       commander: 15.0.0
       curve25519-js: 0.0.4

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -7,7 +7,7 @@ packages:
 minimumReleaseAge: 2880
 
 minimumReleaseAgeExclude:
-  - "@openclaw/crabline@0.1.7"
+  - "@openclaw/crabline@0.1.8"
   - "@openclaw/fs-safe@0.3.0"
   - "@openclaw/proxyline@0.3.3"
   - "acpx"


### PR DESCRIPTION
## Summary

- upgrade QA Lab to `@openclaw/crabline@0.1.8`
- move the exact minimum-release-age exception from 0.1.7 to 0.1.8
- verify Zalo gateway config, trusted runtime environment, native target mapping, and admin inbound delivery
- send through Crabline's Zalo-compatible `sendMessage` endpoint and assert recorder-backed QA outbound normalization

No additional QA runtime or Zalo channel wiring is required: the existing generic Crabline transport consumes the released Zalo bridge.

## Stack

- stacked on #98768, which adds the guarded `ZALO_API_URL` endpoint seam

## Tests

- `pnpm install --frozen-lockfile`
- `node scripts/run-vitest.mjs extensions/qa-lab/src/crabline-transport.test.ts` (14 tests passed)
- `pnpm format:check extensions/qa-lab/src/crabline-transport.test.ts extensions/qa-lab/package.json pnpm-workspace.yaml`
- `git diff --check`
- `.agents/skills/autoreview/scripts/autoreview --mode local --stream-engine-output` (clean, no actionable findings)
