### PR TITLE
fix: surface terminal agent run failures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ Docs: https://docs.openclaw.ai
 ### Fixes
 
 - **iOS QR gateway handoff:** stop VisionKit before delivering scanned setup codes, and keep deferred auth, approval, Watch, and foreground-node work bound to its originating gateway across reconnects. (#99572) Thanks @PollyBot13.
+- **Agent terminal failures:** surface a safe interactive reply when an agent run ends without visible output, while preserving completed message-tool delivery and heartbeat-specific guidance. (#99304) Thanks @moeedahmed.
 - **iOS Voice Wake cleanup:** avoid initializing the microphone audio pipeline while disabling inactive Voice Wake, preventing simulator launch aborts and unnecessary audio setup.
 - **Cron duration validation:** reject positive durations that truncate below one millisecond instead of silently scheduling a zero-duration interval. (#100311) Thanks @qingminglong.
 - **Skill workshop proposals:** preserve the terminal newline in generated proposal Markdown while still rejecting blank raw content. (#100293) Thanks @anyech.

--- a/src/auto-reply/reply/agent-runner-execution.test.ts
+++ b/src/auto-reply/reply/agent-runner-execution.test.ts
@@ -2073,6 +2073,7 @@ describe("runAgentTurnWithFallback", () => {
       fallbackExhausted: true,
       fallbackProvider: probe.provider,
       fallbackModel: probe.model,
+      runResult: exhaustedResult,
     });
     expect(activeSessionStore[sessionKey]).toMatchObject({
       providerOverride: probe.fallbackProvider,
@@ -2140,7 +2141,7 @@ describe("runAgentTurnWithFallback", () => {
       }),
     );
 
-    expect(result.kind).toBe("success");
+    expect(result).toMatchObject({ kind: "success", runResult: terminalErrorResult });
     expect(retainFailureUntilCompleteMock).toHaveBeenCalledTimes(1);
     expect(failMock).toHaveBeenCalledWith("run_failed", expect.any(Error));
     const lifecycleEvents = emitAgentEvent.mock.calls
@@ -2165,6 +2166,66 @@ describe("runAgentTurnWithFallback", () => {
       ),
     ).toBe(false);
     expect(JSON.stringify(lifecycleEvents)).not.toContain("raw provider detail");
+  });
+
+  it.each([
+    {
+      label: "exhausted",
+      outcome: "exhausted" as const,
+      attempts: [{ error: "missing tool result" }],
+      isHeartbeat: false,
+      expectedText: GENERIC_RUN_FAILURE_TEXT,
+    },
+    {
+      label: "completed",
+      outcome: "completed" as const,
+      attempts: [],
+      isHeartbeat: false,
+      expectedText: GENERIC_RUN_FAILURE_TEXT,
+    },
+    {
+      label: "heartbeat",
+      outcome: "completed" as const,
+      attempts: [],
+      isHeartbeat: true,
+      expectedText: HEARTBEAT_EXTERNAL_RUN_FAILURE_TEXT,
+    },
+  ])("surfaces an empty $label terminal result through the normal reply path", async (testCase) => {
+    state.runEmbeddedAgentMock.mockResolvedValueOnce({
+      payloads: [],
+      meta: {
+        error: {
+          kind: "tool_result_mismatch",
+          message: "Agent run reached a terminal error before reply delivery.",
+        },
+      },
+    });
+    state.runWithModelFallbackMock.mockImplementationOnce(async (params: FallbackRunnerParams) => ({
+      outcome: testCase.outcome,
+      result: await params.run("anthropic", "claude"),
+      provider: "anthropic",
+      model: "claude",
+      attempts: testCase.attempts,
+    }));
+    const { replyOperation, failMock } = createMockReplyOperation();
+
+    const runAgentTurnWithFallback = await getRunAgentTurnWithFallback();
+    const result = await runAgentTurnWithFallback({
+      ...createMinimalRunAgentTurnParams({ replyOperation }),
+      isHeartbeat: testCase.isHeartbeat,
+    });
+
+    expect(result).toMatchObject({
+      kind: "success",
+      terminalFailurePayload: {
+        text: testCase.expectedText,
+        isError: true,
+      },
+      runResult: {
+        payloads: [],
+      },
+    });
+    expect(failMock).toHaveBeenCalledWith("run_failed", expect.any(Error));
   });
 
   it("reports exhausted CLI results without a success lifecycle terminal", async () => {

--- a/src/auto-reply/reply/agent-runner-execution.ts
+++ b/src/auto-reply/reply/agent-runner-execution.ts
@@ -427,6 +427,8 @@ export type AgentRunLoopResult =
       directlySentBlockKeys?: Set<string>;
       /** Payloads successfully sent directly during tool flush. */
       directlySentBlockPayloads?: ReplyPayload[];
+      /** Prepared terminal failure, appended only after delivery evidence settles. */
+      terminalFailurePayload?: ReplyPayload;
     }
   | { kind: "final"; payload: ReplyPayload };
 
@@ -1839,6 +1841,7 @@ async function runAgentTurnWithFallbackInternal(
   let attemptedRuntimeModel = fallbackModel;
   let fallbackAttempts: RuntimeFallbackAttempt[] = [];
   let fallbackExhausted = false;
+  let terminalRunFailed = false;
   let pendingLifecycleTerminal:
     | {
         provider: string;
@@ -3165,6 +3168,7 @@ async function runAgentTurnWithFallbackInternal(
         const exhaustionError = new Error(
           terminalErrorMessage ?? "All model fallback candidates failed",
         );
+        terminalRunFailed = true;
         emitSettledLifecycleError(exhaustionError, {
           ...terminalMetadata,
           fallbackExhaustedFailure: true,
@@ -3173,6 +3177,7 @@ async function runAgentTurnWithFallbackInternal(
         params.replyOperation?.fail("run_failed", exhaustionError);
       } else if (deferredLifecycleError || embeddedError) {
         const terminalError = new Error(terminalErrorMessage ?? "Agent run failed");
+        terminalRunFailed = true;
         emitSettledLifecycleError(terminalError, terminalMetadata);
         params.replyOperation?.retainFailureUntilComplete();
         params.replyOperation?.fail("run_failed", terminalError);
@@ -3524,6 +3529,22 @@ async function runAgentTurnWithFallbackInternal(
       }
     }
   }
+  const terminalFailurePayload =
+    terminalRunFailed &&
+    !runResult?.payloads?.some(
+      (p) => !p.isReasoning && hasOutboundReplyContent(p, { trimText: true }),
+    )
+      ? markAgentRunFailureReplyPayload({
+          text: resolveExternalRunFailureTextForConversation({
+            text: params.isHeartbeat
+              ? HEARTBEAT_EXTERNAL_RUN_FAILURE_TEXT
+              : GENERIC_EXTERNAL_RUN_FAILURE_TEXT,
+            sessionCtx: params.sessionCtx,
+            isGenericRunnerFailure: true,
+            cfg: params.followupRun.run.config,
+          }),
+        })
+      : undefined;
 
   return {
     kind: "success",
@@ -3539,6 +3560,7 @@ async function runAgentTurnWithFallbackInternal(
     directlySentBlockPayloads: directlySentBlockPayloads.filter(
       (payload): payload is ReplyPayload => payload !== undefined,
     ),
+    ...(terminalFailurePayload ? { terminalFailurePayload } : {}),
   };
 }
 

--- a/src/auto-reply/reply/agent-runner-execution.ts
+++ b/src/auto-reply/reply/agent-runner-execution.ts
@@ -3529,22 +3529,18 @@ async function runAgentTurnWithFallbackInternal(
       }
     }
   }
-  const terminalFailurePayload =
-    terminalRunFailed &&
-    !runResult?.payloads?.some(
-      (p) => !p.isReasoning && hasOutboundReplyContent(p, { trimText: true }),
-    )
-      ? markAgentRunFailureReplyPayload({
-          text: resolveExternalRunFailureTextForConversation({
-            text: params.isHeartbeat
-              ? HEARTBEAT_EXTERNAL_RUN_FAILURE_TEXT
-              : GENERIC_EXTERNAL_RUN_FAILURE_TEXT,
-            sessionCtx: params.sessionCtx,
-            isGenericRunnerFailure: true,
-            cfg: params.followupRun.run.config,
-          }),
-        })
-      : undefined;
+  const terminalFailurePayload = terminalRunFailed
+    ? markAgentRunFailureReplyPayload({
+        text: resolveExternalRunFailureTextForConversation({
+          text: params.isHeartbeat
+            ? HEARTBEAT_EXTERNAL_RUN_FAILURE_TEXT
+            : GENERIC_EXTERNAL_RUN_FAILURE_TEXT,
+          sessionCtx: params.sessionCtx,
+          isGenericRunnerFailure: true,
+          cfg: params.followupRun.run.config,
+        }),
+      })
+    : undefined;
 
   return {
     kind: "success",

--- a/src/auto-reply/reply/agent-runner-payloads.test.ts
+++ b/src/auto-reply/reply/agent-runner-payloads.test.ts
@@ -13,6 +13,7 @@ import {
 } from "../reply-payload.js";
 import { buildReplyPayloads } from "./agent-runner-payloads.js";
 import { createBlockReplyPipeline } from "./block-reply-pipeline.js";
+import { createReplyToModeFilterForChannel } from "./reply-threading.js";
 
 const baseParams = {
   isHeartbeat: false,
@@ -134,6 +135,28 @@ describe("buildReplyPayloads media filter integration", () => {
         },
       ]),
     );
+  });
+
+  it("shares first-reply threading across staged payload builds", async () => {
+    const applyReplyToMode = createReplyToModeFilterForChannel("first", "whatsapp");
+    const sharedParams = {
+      ...baseParams,
+      replyToMode: "first" as const,
+      replyToChannel: "whatsapp" as const,
+      currentMessageId: "msg",
+      applyReplyToMode,
+    };
+    const first = await buildReplyPayloads({
+      ...sharedParams,
+      payloads: [{ text: "internal commentary", isCommentary: true }],
+    });
+    const fallback = await buildReplyPayloads({
+      ...sharedParams,
+      payloads: [{ text: "run failed", isError: true }],
+    });
+
+    expect(first.replyPayloads[0]?.replyToId).toBe("msg");
+    expect(fallback.replyPayloads[0]?.replyToId).toBeUndefined();
   });
 
   it("records the reply policy used by dedupe and final delivery", async () => {
@@ -627,6 +650,36 @@ describe("buildReplyPayloads media filter integration", () => {
     });
 
     expect(replyPayloads.map((payload) => payload.text)).toEqual(["intro", "result"]);
+  });
+
+  it("dedupes against final routes when first-reply state is shared", async () => {
+    const applyReplyToMode = createReplyToModeFilterForChannel("first", "slack");
+    const { replyPayloads } = await buildReplyPayloads({
+      ...baseParams,
+      config: {},
+      payloads: [{ text: "intro" }, { text: "result" }],
+      replyToMode: "first",
+      replyToChannel: "slack",
+      currentMessageId: "111.000",
+      applyReplyToMode,
+      messageProvider: "slack",
+      originatingTo: "channel:C1",
+      messagingToolSentTexts: ["result"],
+      messagingToolSentTargets: [
+        {
+          tool: "slack",
+          provider: "slack",
+          to: "channel:C1",
+          threadId: "111.000",
+          text: "result",
+        },
+      ],
+    });
+
+    expect(replyPayloads.map((payload) => [payload.text, payload.replyToId])).toEqual([
+      ["intro", "111.000"],
+      ["result", undefined],
+    ]);
   });
 
   it("does not treat a Discord native reply id as a thread route", async () => {

--- a/src/auto-reply/reply/agent-runner-payloads.ts
+++ b/src/auto-reply/reply/agent-runner-payloads.ts
@@ -28,7 +28,11 @@ import {
   resolveOriginMessageTo,
 } from "./origin-routing.js";
 import { normalizeReplyPayloadDirectives } from "./reply-delivery.js";
-import { applyReplyThreading, isRenderablePayload } from "./reply-payloads-base.js";
+import {
+  applyReplyThreading,
+  isRenderablePayload,
+  resolveReplyThreadingPayloads,
+} from "./reply-payloads-base.js";
 import { createReplyDeliveryContext } from "./reply-threading.js";
 
 const replyPayloadsDedupeRuntimeLoader = createLazyImportLoader(
@@ -179,6 +183,7 @@ export async function buildReplyPayloads(params: {
   replyToChannel?: OriginatingChannelType;
   currentMessageId?: string;
   replyThreading?: ReplyThreadingPolicy;
+  applyReplyToMode?: (payload: ReplyPayload) => ReplyPayload;
   messageProvider?: string;
   messagingToolSentTexts?: string[];
   messagingToolSentMediaUrls?: string[];
@@ -236,8 +241,11 @@ export async function buildReplyPayloads(params: {
         ...(accountId ? { accountId } : {}),
       }
     : undefined;
+  const resolveThreading = params.applyReplyToMode
+    ? resolveReplyThreadingPayloads
+    : applyReplyThreading;
   const replyTaggedPayloadCandidates = await Promise.all(
-    applyReplyThreading({
+    resolveThreading({
       payloads: sanitizedPayloads,
       replyToMode: params.replyToMode,
       replyToChannel: params.replyToChannel,
@@ -281,6 +289,9 @@ export async function buildReplyPayloads(params: {
   } else {
     silentFilteredPayloads.push(...replyTaggedPayloads);
   }
+  const threadedPayloads = params.applyReplyToMode
+    ? silentFilteredPayloads.map(params.applyReplyToMode)
+    : silentFilteredPayloads;
 
   // Drop final payloads only when block streaming succeeded end-to-end.
   // If streaming aborted (e.g., timeout), fall back to final payloads.
@@ -295,14 +306,14 @@ export async function buildReplyPayloads(params: {
     (params.messagingToolSentMediaUrls?.length ?? 0) > 0 ||
     messagingToolSentTargets.length > 0;
   const sentMediaUrlFallback = params.messagingToolSentMediaUrls ?? [];
-  let dedupedPayloads = silentFilteredPayloads;
+  let dedupedPayloads = threadedPayloads;
   if (shouldCheckMessagingToolDedupe) {
     const dedupeRuntime = await loadReplyPayloadsDedupeRuntime();
     const originatingTo = resolveOriginMessageTo({
       originatingTo: params.originatingTo,
     });
     dedupedPayloads = [];
-    for (const payload of silentFilteredPayloads) {
+    for (const payload of threadedPayloads) {
       const payloadMetadata = getReplyPayloadMetadata(payload);
       // Source mirrors exist because an internal sink send must reach the UI and
       // transcript; that send is not outbound evidence for dropping the mirror.

--- a/src/auto-reply/reply/agent-runner.runreplyagent.e2e.test.ts
+++ b/src/auto-reply/reply/agent-runner.runreplyagent.e2e.test.ts
@@ -12,6 +12,7 @@ import {
 } from "../../infra/heartbeat-run-scope.js";
 import type { TemplateContext } from "../templating.js";
 import type { GetReplyOptions } from "../types.js";
+import { GENERIC_EXTERNAL_RUN_FAILURE_TEXT } from "./agent-runner-failure-copy.js";
 import {
   enqueueFollowupRun,
   refreshQueuedFollowupSession,
@@ -1357,6 +1358,76 @@ describe("runReplyAgent typing (heartbeat)", () => {
     } finally {
       await rm(root, { recursive: true, force: true });
     }
+  });
+
+  it("drains pending tool delivery before returning an empty terminal-run failure", async () => {
+    let markToolResultStarted = () => {};
+    const toolResultStarted = new Promise<void>((resolve) => {
+      markToolResultStarted = resolve;
+    });
+    let releaseToolResult = () => {};
+    const toolResultReleased = new Promise<void>((resolve) => {
+      releaseToolResult = resolve;
+    });
+    let toolResultDelivered = false;
+    state.runEmbeddedAgentMock.mockImplementationOnce(async (params: AgentRunParams) => {
+      void params.onToolResult?.({ text: "late tool result" });
+      return {
+        payloads: [],
+        meta: {
+          error: {
+            kind: "tool_result_mismatch",
+            message: "Agent run reached a terminal error before reply delivery.",
+          },
+        },
+      };
+    });
+    const { run } = createMinimalRun({
+      opts: {
+        onToolResult: async () => {
+          markToolResultStarted();
+          await toolResultReleased;
+          toolResultDelivered = true;
+        },
+      },
+    });
+
+    const pendingResult = run();
+    await toolResultStarted;
+    expect(toolResultDelivered).toBe(false);
+    releaseToolResult();
+    const result = await pendingResult;
+    const payload = Array.isArray(result) ? result[0] : result;
+
+    expect(toolResultDelivered).toBe(true);
+    expect(payload).toMatchObject({
+      text: GENERIC_EXTERNAL_RUN_FAILURE_TEXT,
+      isError: true,
+    });
+  });
+
+  it.each([
+    { label: "message-tool", delivery: { didSendViaMessagingTool: true } },
+    {
+      label: "source-reply",
+      delivery: { didDeliverSourceReplyViaMessageTool: true },
+    },
+  ])("does not duplicate an empty terminal failure after $label delivery", async ({ delivery }) => {
+    state.runEmbeddedAgentMock.mockResolvedValueOnce({
+      payloads: [],
+      meta: {
+        error: {
+          kind: "tool_result_mismatch",
+          message: "Agent run reached a terminal error after delivery.",
+        },
+      },
+      ...delivery,
+    });
+
+    const { run } = createMinimalRun();
+    const result = await run();
+
+    expect(result).toBeUndefined();
   });
 
   it("does not persist active fallback state for internal subagent announce fallback", async () => {

--- a/src/auto-reply/reply/agent-runner.runreplyagent.e2e.test.ts
+++ b/src/auto-reply/reply/agent-runner.runreplyagent.e2e.test.ts
@@ -12,7 +12,10 @@ import {
 } from "../../infra/heartbeat-run-scope.js";
 import type { TemplateContext } from "../templating.js";
 import type { GetReplyOptions } from "../types.js";
-import { GENERIC_EXTERNAL_RUN_FAILURE_TEXT } from "./agent-runner-failure-copy.js";
+import {
+  GENERIC_EXTERNAL_RUN_FAILURE_TEXT,
+  HEARTBEAT_EXTERNAL_RUN_FAILURE_TEXT,
+} from "./agent-runner-failure-copy.js";
 import {
   enqueueFollowupRun,
   refreshQueuedFollowupSession,
@@ -1404,6 +1407,62 @@ describe("runReplyAgent typing (heartbeat)", () => {
       text: GENERIC_EXTERNAL_RUN_FAILURE_TEXT,
       isError: true,
     });
+  });
+
+  it.each([
+    {
+      label: "silent token",
+      payload: { text: "NO_REPLY" },
+      opts: undefined,
+      expectedText: GENERIC_EXTERNAL_RUN_FAILURE_TEXT,
+    },
+    {
+      label: "heartbeat acknowledgement",
+      payload: { text: "HEARTBEAT_OK" },
+      opts: { isHeartbeat: true as const },
+      expectedText: HEARTBEAT_EXTERNAL_RUN_FAILURE_TEXT,
+    },
+    {
+      label: "reasoning-only output",
+      payload: { text: "internal reasoning", isReasoning: true },
+      opts: undefined,
+      expectedText: GENERIC_EXTERNAL_RUN_FAILURE_TEXT,
+    },
+    {
+      label: "commentary-only output",
+      payload: { text: "internal commentary", isCommentary: true },
+      opts: undefined,
+      expectedText: GENERIC_EXTERNAL_RUN_FAILURE_TEXT,
+    },
+    {
+      label: "directive-only output",
+      payload: { text: "[[reply_to_current]]" },
+      opts: undefined,
+      expectedText: GENERIC_EXTERNAL_RUN_FAILURE_TEXT,
+    },
+  ])("replaces filtered $label after a terminal failure", async (testCase) => {
+    state.runEmbeddedAgentMock.mockResolvedValueOnce({
+      payloads: [testCase.payload],
+      meta: {
+        error: {
+          kind: "tool_result_mismatch",
+          message: "Agent run reached a terminal error before visible reply delivery.",
+        },
+      },
+    });
+    const { run } = createMinimalRun({
+      opts: testCase.opts,
+      runOverrides: {
+        config: { channels: { whatsapp: { replyToMode: "first" } } },
+      },
+    });
+
+    const result = await run();
+    const payloads = Array.isArray(result) ? result : [result];
+    const failure = payloads.find((payload) => payload?.isError === true);
+
+    expect(failure?.text).toBe(testCase.expectedText);
+    expect(failure?.replyToId).toBe("msg");
   });
 
   it.each([

--- a/src/auto-reply/reply/agent-runner.ts
+++ b/src/auto-reply/reply/agent-runner.ts
@@ -2111,6 +2111,24 @@ export async function runReplyAgent(params: {
     }
 
     const currentMessageId = sessionCtx.MessageSidFull ?? sessionCtx.MessageSid;
+    // A terminal fallback is built separately after normal payload filtering.
+    // Share this state across deliverable lanes so replyToMode=first still threads
+    // at most one visible payload without hidden reasoning/commentary consuming it.
+    const applyDeliveredReplyToMode = createReplyToModeFilterForChannel(
+      replyToMode,
+      replyToChannel,
+    );
+    const applyFinalReplyToMode = (payload: ReplyPayload) => {
+      const isDisabledReasoningLane =
+        payload.isReasoning === true && opts?.reasoningPayloadsEnabled !== true;
+      const isDisabledCommentaryLane =
+        payload.isCommentary === true && opts?.commentaryPayloadsEnabled !== true;
+      const isFilteredPayload =
+        normalizeReplyPayload(payload, { applyChannelTransforms: false }) === null;
+      return isDisabledReasoningLane || isDisabledCommentaryLane || isFilteredPayload
+        ? payload
+        : applyDeliveredReplyToMode(payload);
+    };
     const buildFinalPayloads = (payloads: ReplyPayload[]) =>
       buildReplyPayloads({
         config: cfg,
@@ -2126,6 +2144,7 @@ export async function runReplyAgent(params: {
         replyToChannel,
         currentMessageId,
         replyThreading: replyThreadingOverride ?? sessionCtx.ReplyThreading,
+        applyReplyToMode: applyFinalReplyToMode,
         messageProvider: followupRun.run.messageProvider,
         messagingToolSentTexts: runResult.messagingToolSentTexts,
         messagingToolSentMediaUrls: runResult.messagingToolSentMediaUrls,

--- a/src/auto-reply/reply/agent-runner.ts
+++ b/src/auto-reply/reply/agent-runner.ts
@@ -1774,6 +1774,7 @@ export async function runReplyAgent(params: {
       fallbackAttempts,
       directlySentBlockKeys,
       directlySentBlockPayloads,
+      terminalFailurePayload,
     } = runOutcome;
     const { autoCompactionCount } = runOutcome;
     let { didLogHeartbeatStrip } = runOutcome;
@@ -1991,6 +1992,13 @@ export async function runReplyAgent(params: {
     const committedMessagingToolSourceReplyDelivery =
       runResult.didDeliverSourceReplyViaMessageTool === true ||
       hasVisibleAgentPayload({ payloads: runResult.messagingToolSourceReplyPayloads });
+    if (
+      terminalFailurePayload &&
+      !successfulSideEffectDelivery &&
+      !committedMessagingToolSourceReplyDelivery
+    ) {
+      payloadArray.push(terminalFailurePayload);
+    }
     if (
       opts?.sourceReplyDeliveryMode === "message_tool_only" &&
       committedMessagingToolSourceReplyDelivery

--- a/src/auto-reply/reply/agent-runner.ts
+++ b/src/auto-reply/reply/agent-runner.ts
@@ -96,6 +96,7 @@ import {
 import { resolveEffectiveReplyRoute } from "./effective-reply-route.js";
 import { createFollowupRunner } from "./followup-runner.js";
 import { REPLY_RUN_STILL_SHUTTING_DOWN_TEXT } from "./get-reply-run-queue.js";
+import { normalizeReplyPayload } from "./normalize-reply.js";
 import { resolveOriginMessageProvider, resolveOriginMessageTo } from "./origin-routing.js";
 import { sanitizePendingFinalDeliveryText } from "./pending-final-delivery.js";
 import { drainPendingToolTasks } from "./pending-tool-task-drain.js";
@@ -1992,13 +1993,11 @@ export async function runReplyAgent(params: {
     const committedMessagingToolSourceReplyDelivery =
       runResult.didDeliverSourceReplyViaMessageTool === true ||
       hasVisibleAgentPayload({ payloads: runResult.messagingToolSourceReplyPayloads });
-    if (
+    const shouldDeliverTerminalFailure = Boolean(
       terminalFailurePayload &&
       !successfulSideEffectDelivery &&
-      !committedMessagingToolSourceReplyDelivery
-    ) {
-      payloadArray.push(terminalFailurePayload);
-    }
+      !committedMessagingToolSourceReplyDelivery,
+    );
     if (
       opts?.sourceReplyDeliveryMode === "message_tool_only" &&
       committedMessagingToolSourceReplyDelivery
@@ -2099,7 +2098,11 @@ export async function runReplyAgent(params: {
     // Drain any late tool/block deliveries before deciding there's "nothing to send".
     // Otherwise, a late typing trigger (e.g. from a tool callback) can outlive the run and
     // keep the typing indicator stuck.
-    if (payloadArray.length === 0 && fallbackNoticePayloads.length === 0) {
+    if (
+      payloadArray.length === 0 &&
+      fallbackNoticePayloads.length === 0 &&
+      !shouldDeliverTerminalFailure
+    ) {
       const silentFallbackFailurePayload = await returnSilentFallbackFailureIfNeeded();
       if (silentFallbackFailurePayload) {
         return silentFallbackFailurePayload;
@@ -2108,39 +2111,54 @@ export async function runReplyAgent(params: {
     }
 
     const currentMessageId = sessionCtx.MessageSidFull ?? sessionCtx.MessageSid;
-    const payloadResult = await buildReplyPayloads({
-      config: cfg,
-      payloads:
-        fallbackNoticePayloads.length > 0
-          ? [...fallbackNoticePayloads, ...payloadArray]
-          : payloadArray,
-      isHeartbeat,
-      didLogHeartbeatStrip,
-      silentExpected: followupRun.run.silentExpected,
-      blockStreamingEnabled,
-      blockReplyPipeline,
-      directlySentBlockKeys,
-      directlySentBlockPayloads,
-      replyToMode,
-      replyToChannel,
-      currentMessageId,
-      replyThreading: replyThreadingOverride ?? sessionCtx.ReplyThreading,
-      messageProvider: followupRun.run.messageProvider,
-      messagingToolSentTexts: runResult.messagingToolSentTexts,
-      messagingToolSentMediaUrls: runResult.messagingToolSentMediaUrls,
-      messagingToolSentTargets: runResult.messagingToolSentTargets,
-      originatingChannel: sessionCtx.OriginatingChannel,
-      originatingChatType: sessionCtx.ChatType,
-      originatingTo: resolveOriginMessageTo({
-        originatingTo: sessionCtx.OriginatingTo,
-        to: sessionCtx.To,
-      }),
-      originatingThreadId: replyRouteThreadId,
-      accountId: sessionCtx.AccountId,
-      normalizeMediaPaths: replyMediaContext.normalizePayload,
-    });
-    const { replyPayloads } = payloadResult;
+    const buildFinalPayloads = (payloads: ReplyPayload[]) =>
+      buildReplyPayloads({
+        config: cfg,
+        payloads,
+        isHeartbeat,
+        didLogHeartbeatStrip,
+        silentExpected: followupRun.run.silentExpected,
+        blockStreamingEnabled,
+        blockReplyPipeline,
+        directlySentBlockKeys,
+        directlySentBlockPayloads,
+        replyToMode,
+        replyToChannel,
+        currentMessageId,
+        replyThreading: replyThreadingOverride ?? sessionCtx.ReplyThreading,
+        messageProvider: followupRun.run.messageProvider,
+        messagingToolSentTexts: runResult.messagingToolSentTexts,
+        messagingToolSentMediaUrls: runResult.messagingToolSentMediaUrls,
+        messagingToolSentTargets: runResult.messagingToolSentTargets,
+        originatingChannel: sessionCtx.OriginatingChannel,
+        originatingChatType: sessionCtx.ChatType,
+        originatingTo: resolveOriginMessageTo({
+          originatingTo: sessionCtx.OriginatingTo,
+          to: sessionCtx.To,
+        }),
+        originatingThreadId: replyRouteThreadId,
+        accountId: sessionCtx.AccountId,
+        normalizeMediaPaths: replyMediaContext.normalizePayload,
+      });
+    const payloadCandidates =
+      fallbackNoticePayloads.length > 0
+        ? [...fallbackNoticePayloads, ...payloadArray]
+        : payloadArray;
+    const payloadResult = await buildFinalPayloads(payloadCandidates);
+    let { replyPayloads } = payloadResult;
     didLogHeartbeatStrip = payloadResult.didLogHeartbeatStrip;
+    const hasTerminalReplyPayload = replyPayloads.some(
+      (payload) =>
+        !payload.isReasoning &&
+        !payload.isCommentary &&
+        !isReplyPayloadStatusNotice(payload) &&
+        normalizeReplyPayload(payload, { applyChannelTransforms: false }) !== null,
+    );
+    if (shouldDeliverTerminalFailure && !hasTerminalReplyPayload && terminalFailurePayload) {
+      const terminalPayloadResult = await buildFinalPayloads([terminalFailurePayload]);
+      replyPayloads = [...replyPayloads, ...terminalPayloadResult.replyPayloads];
+      didLogHeartbeatStrip = terminalPayloadResult.didLogHeartbeatStrip;
+    }
 
     const hasReplyPayloadBeyondFallbackNotice = replyPayloads.some(
       (payload) => !isReplyPayloadStatusNotice(payload),

--- a/src/auto-reply/reply/reply-payloads-base.ts
+++ b/src/auto-reply/reply/reply-payloads-base.ts
@@ -98,16 +98,17 @@ export function shouldSuppressReasoningPayload(payload: ReplyPayload): boolean {
   return payload.isReasoning === true;
 }
 
-/** Applies threading policy and filters empty payloads before channel delivery. */
-export function applyReplyThreading(params: {
+type ReplyThreadingParams = {
   payloads: ReplyPayload[];
   replyToMode: ReplyToMode;
   replyToChannel?: OriginatingChannelType;
   currentMessageId?: string;
   replyThreading?: ReplyThreadingPolicy;
-}): ReplyPayload[] {
-  const { payloads, replyToMode, replyToChannel, currentMessageId, replyThreading } = params;
-  const applyReplyToMode = createReplyToModeFilterForChannel(replyToMode, replyToChannel);
+};
+
+/** Resolves reply targets and filters empty payloads before channel delivery. */
+export function resolveReplyThreadingPayloads(params: ReplyThreadingParams): ReplyPayload[] {
+  const { payloads, replyToMode, currentMessageId, replyThreading } = params;
   const implicitReplyToId = normalizeOptionalString(currentMessageId);
   return payloads
     .map((payload) =>
@@ -119,6 +120,14 @@ export function applyReplyThreading(params: {
         replyThreading,
       }),
     )
-    .filter(isRenderablePayload)
-    .map(applyReplyToMode);
+    .filter(isRenderablePayload);
+}
+
+/** Applies threading policy and filters empty payloads before channel delivery. */
+export function applyReplyThreading(params: ReplyThreadingParams): ReplyPayload[] {
+  const applyReplyToMode = createReplyToModeFilterForChannel(
+    params.replyToMode,
+    params.replyToChannel,
+  );
+  return resolveReplyThreadingPayloads(params).map(applyReplyToMode);
 }


### PR DESCRIPTION
## What Problem This Solves

An embedded agent can reach a terminal failure while returning no visible payload. The reply operation records the failure, but the normal chat path previously had nothing to send, so an interactive request could appear to be ignored.

## Why This Change Was Made

The contributor patch correctly identified the missing presentation, but its early `kind: "final"` returns bypassed pending tool/block drains, reply normalization, dedupe, session bookkeeping, and usage/model metadata.

This rewrite carries a prepared terminal-failure payload through the existing success-shaped run result. The outer reply owner waits for pending delivery, evaluates the canonical side-effect and source-delivery evidence, then appends the failure only when nothing was already delivered. Existing visible errors, message-tool/source replies, block streams, cron/approval side effects, non-direct silent policy, and heartbeat-specific copy remain authoritative.

## User Impact

Interactive terminal run failures now produce one safe visible failure instead of silence. A reply already delivered through another supported path is not duplicated, and heartbeat failures retain heartbeat-specific guidance.

Release note context: Fix interactive requests appearing to be ignored when an agent run ends in a terminal failure without a visible payload.

## Evidence

- Testbox `tbx_01kwsmzw7a12qk14aezg1w0wbr` on the final rebased head:
  - 229 focused execution tests passed.
  - 67 payload normalization/threading tests passed.
  - 71 full `runReplyAgent` E2E tests passed.
  - Exact eight-file `check:changed` core/coreTests/docs gate passed, including core/test typechecks, lint, import-cycle and repository guards.
- E2E regression proof holds a pending tool-result delivery open, confirms the reply does not finish early, releases it, and then observes exactly one marked generic failure.
- Negative E2E coverage proves both message-tool and source-reply delivery suppress the duplicate.
- Reply-threading coverage proves filtered payloads cannot consume `replyToMode: first`, enabled display lanes share the slot, and message-tool dedupe sees the final routed target.
- Unit coverage includes exhausted, completed, and heartbeat terminal results plus preservation of existing visible terminal payloads.
- Fresh post-rebase full-branch autoreview: no accepted/actionable findings (confidence 0.91).
- Source-blind behavior validation on Testbox `tbx_01kwsnw1132ts7a0v3sg6sg3tm` passed all 5 clauses:
  - 295/295 focused unit/E2E tests passed.
  - Real local/Gateway TUI PTY lane passed 7/7, including validation failures, fresh sessions, followup queueing, cancellation, and recovery.
  - Actions run: https://github.com/openclaw/openclaw/actions/runs/28749300454

No config, protocol, dependency, or storage surface changes.

Co-authored with and preserves credit for @moeedahmed's original report and patch direction.
