### PR TITLE
feat(auto-reply): persist ambient room events as transcript rows

### DIFF
--- a/extensions/telegram/src/bot-deps.ts
+++ b/extensions/telegram/src/bot-deps.ts
@@ -19,6 +19,8 @@ import {
   getSessionEntry,
   listSessionEntries,
   readSessionUpdatedAt,
+  readAmbientTranscriptWatermark,
+  resolveAmbientTranscriptWatermarkKey,
   resolveStorePath,
 } from "openclaw/plugin-sdk/session-store-runtime";
 import { loadSessionStore } from "openclaw/plugin-sdk/session-store-runtime";
@@ -40,6 +42,8 @@ export type TelegramBotDeps = {
   listSessionEntries?: typeof listSessionEntries;
   loadSessionStore?: typeof loadSessionStore;
   readSessionUpdatedAt?: typeof readSessionUpdatedAt;
+  readAmbientTranscriptWatermark?: typeof readAmbientTranscriptWatermark;
+  resolveAmbientTranscriptWatermarkKey?: typeof resolveAmbientTranscriptWatermarkKey;
   recordInboundSession?: typeof recordInboundSession;
   recordChannelActivity?: typeof recordChannelActivity;
   resolveInboundLastRouteSessionKey?: typeof resolveInboundLastRouteSessionKey;
@@ -85,6 +89,12 @@ export const defaultTelegramBotDeps: TelegramBotDeps = {
   },
   get readSessionUpdatedAt() {
     return readSessionUpdatedAt;
+  },
+  get readAmbientTranscriptWatermark() {
+    return readAmbientTranscriptWatermark;
+  },
+  get resolveAmbientTranscriptWatermarkKey() {
+    return resolveAmbientTranscriptWatermarkKey;
   },
   get recordInboundSession() {
     return recordInboundSession;

--- a/extensions/telegram/src/bot-handlers.runtime.ts
+++ b/extensions/telegram/src/bot-handlers.runtime.ts
@@ -43,6 +43,8 @@ import {
   getSessionEntry,
   listSessionEntries,
   patchSessionEntry,
+  readAmbientTranscriptWatermark,
+  resolveAmbientTranscriptWatermarkKey,
 } from "openclaw/plugin-sdk/session-store-runtime";
 import { normalizeStringEntries } from "openclaw/plugin-sdk/string-coerce-runtime";
 import { expandTelegramAllowFromWithAccessGroups } from "./access-groups.js";
@@ -77,6 +79,7 @@ import type {
   TelegramMessageContextOptions,
   TelegramPromptContextEntry,
 } from "./bot-message-context.types.js";
+import type { TelegramAmbientTranscriptWatermark } from "./bot-message-context.types.js";
 import { parseTelegramNativeCommandCallbackData } from "./bot-native-commands.js";
 import type { RegisterTelegramHandlerParams } from "./bot-native-commands.js";
 import {
@@ -93,6 +96,7 @@ import {
 } from "./bot-updates.js";
 import { resolveMedia } from "./bot/delivery.resolve-media.js";
 import {
+  buildSenderName,
   getTelegramTextParts,
   hasBotMention,
   buildTelegramThreadParams,
@@ -106,6 +110,7 @@ import {
   resolveTelegramThreadSpec,
   loadTelegramPairingStoreIfNeeded,
   resolveTelegramBotHasTopicsEnabled,
+  resolveTelegramMediaPlaceholder,
   TelegramPairingStoreReadError,
   shouldUseTelegramDmThreadSession,
   withResolvedTelegramForumFlag,
@@ -130,6 +135,7 @@ import {
   evaluateTelegramGroupPolicyAccess,
 } from "./group-access.js";
 import { resolveTelegramScopedGroupConfig } from "./group-config-helpers.js";
+import { isTelegramHistoryEntryAfterAmbientWatermark } from "./group-history-window.js";
 import { migrateTelegramGroupConfig } from "./group-migration.js";
 import {
   resolveTelegramCommandIngressAuthorization,
@@ -265,6 +271,7 @@ export const registerTelegramHandlers = ({
     threadId?: number;
     messages: Array<{ msg: Message; ctx: TelegramContext; receivedAtMs: number }>;
     promptContextMinTimestampMs?: number;
+    promptContextAmbientWatermark?: TelegramAmbientTranscriptWatermark;
     dispatchDedupeKeys: string[];
     spooledReplayParticipants: TelegramSpooledReplayDeferredParticipant[];
     timer: ReturnType<typeof setTimeout>;
@@ -300,6 +307,7 @@ export const registerTelegramHandlers = ({
     botUsername?: string;
     threadId?: number;
     promptContextMinTimestampMs?: number;
+    promptContextAmbientWatermark?: TelegramAmbientTranscriptWatermark;
     dispatchDedupeKeys: string[];
     spooledReplayParticipant?: TelegramSpooledReplayDeferredParticipant;
   };
@@ -326,9 +334,18 @@ export const registerTelegramHandlers = ({
     typeof timestampMs === "number" && Number.isFinite(timestampMs) ? timestampMs : undefined;
   const promptContextBoundaryOptions = (
     timestampMs?: number,
-  ): Pick<TelegramMessageContextOptions, "promptContextMinTimestampMs"> => {
+    ambientWatermark?: TelegramAmbientTranscriptWatermark,
+  ): Pick<
+    TelegramMessageContextOptions,
+    "promptContextMinTimestampMs" | "promptContextAmbientWatermark"
+  > => {
     const promptContextMinTimestampMs = normalizePromptContextMinTimestampMs(timestampMs);
-    return promptContextMinTimestampMs === undefined ? {} : { promptContextMinTimestampMs };
+    return {
+      ...(promptContextMinTimestampMs === undefined ? {} : { promptContextMinTimestampMs }),
+      ...(ambientWatermark === undefined
+        ? {}
+        : { promptContextAmbientWatermark: ambientWatermark }),
+    };
   };
   const latestPromptContextMinTimestampMs = (
     ...timestamps: Array<number | undefined>
@@ -342,6 +359,11 @@ export const registerTelegramHandlers = ({
       latest = latest === undefined ? normalized : Math.max(latest, normalized);
     }
     return latest;
+  };
+  const latestPromptContextAmbientWatermark = (
+    ...watermarks: Array<TelegramAmbientTranscriptWatermark | undefined>
+  ): TelegramAmbientTranscriptWatermark | undefined => {
+    return watermarks.findLast((watermark) => watermark !== undefined);
   };
   const mergeDispatchDedupeKeys = (...groups: Array<readonly string[] | undefined>) => [
     ...new Set(normalizeStringEntries(groups.flatMap((group) => group ?? []))),
@@ -434,6 +456,23 @@ export const registerTelegramHandlers = ({
     ctx: Pick<TelegramContext, "me" | "getFile">,
     message: Message,
   ): TelegramContext => ({ message, me: ctx.me, getFile: ctx.getFile.bind(ctx) });
+
+  const formatTelegramAmbientTranscriptLine = (msg: Message): string => {
+    const text = getTelegramTextParts(msg).text.trim();
+    const body =
+      text || resolveTelegramMediaPlaceholder(msg) || "[User sent media without caption]";
+    const messageId = msg.message_id ? `#${msg.message_id}` : undefined;
+    const sender = buildSenderName(msg);
+    const prefix = [messageId, sender].filter(Boolean).join(" ");
+    return prefix ? `${prefix}: ${body}` : body;
+  };
+
+  const formatTelegramAmbientTranscriptBody = (
+    messages: readonly Message[],
+  ): string | undefined => {
+    const lines = messages.map(formatTelegramAmbientTranscriptLine);
+    return lines.length > 0 ? lines.join("\n") : undefined;
+  };
 
   const MULTI_SELECT_PREFIX = "OC_MULTI|";
   const MULTI_SELECT_TOGGLE_PREFIX = `${MULTI_SELECT_PREFIX}toggle|`;
@@ -589,7 +628,10 @@ export const registerTelegramHandlers = ({
             options: {
               receivedAtMs: last.receivedAtMs,
               ingressBuffer: "inbound-debounce",
-              ...promptContextBoundaryOptions(last.promptContextMinTimestampMs),
+              ...promptContextBoundaryOptions(
+                last.promptContextMinTimestampMs,
+                last.promptContextAmbientWatermark,
+              ),
               ...spooledReplayOptions(spooledReplayParticipants),
             },
             dispatchDedupeKeys: last.dispatchDedupeKeys,
@@ -610,6 +652,9 @@ export const registerTelegramHandlers = ({
         const promptContextMinTimestampMs = latestPromptContextMinTimestampMs(
           ...entries.map((entry) => entry.promptContextMinTimestampMs),
         );
+        const promptContextAmbientWatermark = latestPromptContextAmbientWatermark(
+          ...entries.map((entry) => entry.promptContextAmbientWatermark),
+        );
         const baseCtx = first.ctx;
         const syntheticMessage = buildSyntheticTextMessage({
           base: first.msg,
@@ -625,9 +670,15 @@ export const registerTelegramHandlers = ({
           storeAllowFrom: first.storeAllowFrom,
           options: {
             ...(messageIdOverride ? { messageIdOverride } : {}),
+            ambientTranscriptBody: formatTelegramAmbientTranscriptBody(
+              entries.map((entry) => entry.msg),
+            ),
             receivedAtMs: first.receivedAtMs,
             ingressBuffer: "inbound-debounce",
-            ...promptContextBoundaryOptions(promptContextMinTimestampMs),
+            ...promptContextBoundaryOptions(
+              promptContextMinTimestampMs,
+              promptContextAmbientWatermark,
+            ),
             ...spooledReplayOptions(spooledReplayParticipants),
           },
           dispatchDedupeKeys: mergeDispatchDedupeKeys(
@@ -784,6 +835,31 @@ export const registerTelegramHandlers = ({
       storePath,
       model: typeof modelCfg === "string" ? modelCfg : modelCfg?.primary,
     };
+  };
+
+  const resolvePromptContextAmbientWatermark = (params: {
+    chatId: number | string;
+    isGroup: boolean;
+    resolvedThreadId?: number;
+    sessionKey: string;
+    storePath: string;
+  }): TelegramAmbientTranscriptWatermark | undefined => {
+    if (!params.isGroup) {
+      return undefined;
+    }
+    const key = (
+      telegramDeps.resolveAmbientTranscriptWatermarkKey ?? resolveAmbientTranscriptWatermarkKey
+    )({
+      channel: "telegram",
+      accountId,
+      conversationId: String(params.chatId),
+      ...(params.resolvedThreadId !== undefined ? { threadId: params.resolvedThreadId } : {}),
+    });
+    return (telegramDeps.readAmbientTranscriptWatermark ?? readAmbientTranscriptWatermark)({
+      storePath: params.storePath,
+      sessionKey: params.sessionKey,
+      key,
+    });
   };
 
   const mediaMayNeedDownloadForMentionDetection = (msg: Message): boolean => {
@@ -1016,7 +1092,10 @@ export const registerTelegramHandlers = ({
         promptContextMessageSelection,
         storeAllowFrom: entry.storeAllowFrom,
         options: {
-          ...promptContextBoundaryOptions(entry.promptContextMinTimestampMs),
+          ...promptContextBoundaryOptions(
+            entry.promptContextMinTimestampMs,
+            entry.promptContextAmbientWatermark,
+          ),
           ...spooledReplayOptions(entry.spooledReplayParticipants),
         },
         dispatchDedupeKeys: entry.dispatchDedupeKeys,
@@ -1068,9 +1147,15 @@ export const registerTelegramHandlers = ({
         storeAllowFrom,
         options: {
           messageIdOverride: String(last.msg.message_id),
+          ambientTranscriptBody: formatTelegramAmbientTranscriptBody(
+            entry.messages.map((message) => message.msg),
+          ),
           receivedAtMs: first.receivedAtMs,
           ingressBuffer: "text-fragment",
-          ...promptContextBoundaryOptions(entry.promptContextMinTimestampMs),
+          ...promptContextBoundaryOptions(
+            entry.promptContextMinTimestampMs,
+            entry.promptContextAmbientWatermark,
+          ),
           ...spooledReplayOptions(entry.spooledReplayParticipants),
         },
         dispatchDedupeKeys: entry.dispatchDedupeKeys,
@@ -1240,6 +1325,21 @@ export const registerTelegramHandlers = ({
             replyTargetWindowSize: 2,
             ...(options?.promptContextMinTimestampMs !== undefined
               ? { minTimestampMs: options.promptContextMinTimestampMs }
+              : {}),
+            ...(isGroup && options?.promptContextAmbientWatermark !== undefined
+              ? {
+                  includeNode: (
+                    node: TelegramCachedMessageNode,
+                    flags?: { replyTarget?: boolean },
+                  ) =>
+                    // Explicit reply targets stay visible so the current turn is not shown
+                    // as a reply to invisible transcript-owned text.
+                    flags?.replyTarget === true ||
+                    isTelegramHistoryEntryAfterAmbientWatermark(
+                      node,
+                      options.promptContextAmbientWatermark,
+                    ),
+                }
               : {}),
           });
     const conversationContextById = new Map(
@@ -1968,6 +2068,7 @@ export const registerTelegramHandlers = ({
     sendOversizeWarning: boolean;
     oversizeLogMessage: string;
     promptContextMinTimestampMs?: number;
+    promptContextAmbientWatermark?: TelegramAmbientTranscriptWatermark;
     dispatchDedupeKeys: string[];
   }) => {
     const {
@@ -1988,6 +2089,7 @@ export const registerTelegramHandlers = ({
       sendOversizeWarning,
       oversizeLogMessage,
       promptContextMinTimestampMs,
+      promptContextAmbientWatermark,
       dispatchDedupeKeys,
     } = params;
 
@@ -2064,6 +2166,10 @@ export const registerTelegramHandlers = ({
               existing.promptContextMinTimestampMs,
               promptContextMinTimestampMs,
             );
+            existing.promptContextAmbientWatermark = latestPromptContextAmbientWatermark(
+              existing.promptContextAmbientWatermark,
+              promptContextAmbientWatermark,
+            );
             existing.dispatchDedupeKeys = mergeDispatchDedupeKeys(
               existing.dispatchDedupeKeys,
               dispatchDedupeKeys,
@@ -2089,7 +2195,10 @@ export const registerTelegramHandlers = ({
           messages: [{ msg, ctx, receivedAtMs: nowMs }],
           dispatchDedupeKeys,
           spooledReplayParticipants: spooledReplayParticipant ? [spooledReplayParticipant] : [],
-          ...promptContextBoundaryOptions(promptContextMinTimestampMs),
+          ...promptContextBoundaryOptions(
+            promptContextMinTimestampMs,
+            promptContextAmbientWatermark,
+          ),
           timer: setTimeout(() => {}, TELEGRAM_TEXT_FRAGMENT_MAX_GAP_MS),
         };
         textFragmentBuffer.set(key, entry);
@@ -2128,6 +2237,10 @@ export const registerTelegramHandlers = ({
           existing.promptContextMinTimestampMs,
           promptContextMinTimestampMs,
         );
+        existing.promptContextAmbientWatermark = latestPromptContextAmbientWatermark(
+          existing.promptContextAmbientWatermark,
+          promptContextAmbientWatermark,
+        );
         existing.dispatchDedupeKeys = mergeDispatchDedupeKeys(
           existing.dispatchDedupeKeys,
           dispatchDedupeKeys,
@@ -2156,7 +2269,10 @@ export const registerTelegramHandlers = ({
           topicConfig,
           dispatchDedupeKeys,
           spooledReplayParticipants: spooledReplayParticipant ? [spooledReplayParticipant] : [],
-          ...promptContextBoundaryOptions(promptContextMinTimestampMs),
+          ...promptContextBoundaryOptions(
+            promptContextMinTimestampMs,
+            promptContextAmbientWatermark,
+          ),
           timer: setTimeout(() => {
             mediaGroupBuffer.delete(mediaGroupKey);
             void queueBufferedProcessing(mediaGroupProcessingByKey, mediaGroupKey, async () => {
@@ -2290,7 +2406,7 @@ export const registerTelegramHandlers = ({
       debounceKey: isAbortControlMessage ? null : debounceKey,
       debounceLane,
       botUsername,
-      ...promptContextBoundaryOptions(promptContextMinTimestampMs),
+      ...promptContextBoundaryOptions(promptContextMinTimestampMs, promptContextAmbientWatermark),
       dispatchDedupeKeys,
     };
     if (
@@ -3305,18 +3421,26 @@ export const registerTelegramHandlers = ({
         effectiveGroupAllow,
       } = gate.context;
 
+      const sessionState = resolveTelegramSessionState({
+        chatId: event.chatId,
+        isGroup: event.isGroup,
+        isForum: event.isForum,
+        messageThreadId: event.messageThreadId,
+        resolvedThreadId,
+        botHasTopicsEnabled: resolveTelegramBotHasTopicsEnabled(event.ctx.me),
+        senderId: event.senderId,
+        runtimeCfg: cfg,
+      });
       const promptContextMinTimestampMs = normalizePromptContextMinTimestampMs(
-        resolveTelegramSessionState({
-          chatId: event.chatId,
-          isGroup: event.isGroup,
-          isForum: event.isForum,
-          messageThreadId: event.messageThreadId,
-          resolvedThreadId,
-          botHasTopicsEnabled: resolveTelegramBotHasTopicsEnabled(event.ctx.me),
-          senderId: event.senderId,
-          runtimeCfg: cfg,
-        }).sessionEntry?.sessionStartedAt,
+        sessionState.sessionEntry?.sessionStartedAt,
       );
+      const promptContextAmbientWatermark = resolvePromptContextAmbientWatermark({
+        chatId: event.chatId,
+        isGroup: event.isGroup,
+        resolvedThreadId,
+        sessionKey: sessionState.sessionKey,
+        storePath: sessionState.storePath,
+      });
 
       const dispatchDedupe = await claimMessageDispatchDedupe(event.msg);
       if (!dispatchDedupe.process) {
@@ -3342,7 +3466,7 @@ export const registerTelegramHandlers = ({
         sendOversizeWarning: event.sendOversizeWarning,
         oversizeLogMessage: event.oversizeLogMessage,
         dispatchDedupeKeys,
-        ...promptContextBoundaryOptions(promptContextMinTimestampMs),
+        ...promptContextBoundaryOptions(promptContextMinTimestampMs, promptContextAmbientWatermark),
       });
     } catch (err) {
       releaseDispatchDedupeKeys(dispatchDedupeKeys, err);

--- a/extensions/telegram/src/bot-message-context.prompt-context.test.ts
+++ b/extensions/telegram/src/bot-message-context.prompt-context.test.ts
@@ -1,6 +1,28 @@
 import { describe, expect, it } from "vitest";
+import { buildInboundUserContextPrefix } from "../../../src/auto-reply/reply/inbound-meta.js";
+import { buildReplyPromptEnvelopeBase } from "../../../src/auto-reply/reply/prompt-prelude.js";
 import { buildTelegramMessageContextForTest } from "./bot-message-context.test-harness.js";
 import type { TelegramPromptContextEntry } from "./bot-message-context.types.js";
+
+type RoomEventPromptContext = Parameters<typeof buildInboundUserContextPrefix>[0] &
+  Parameters<typeof buildReplyPromptEnvelopeBase>[0]["ctx"];
+
+function renderRoomEventPromptText(ctx: RoomEventPromptContext): string {
+  const inboundUserContext = buildInboundUserContextPrefix(ctx);
+  return (
+    buildReplyPromptEnvelopeBase({
+      ctx,
+      sessionCtx: ctx,
+      baseBody: ctx.BodyForAgent ?? ctx.Body ?? ctx.RawBody ?? "",
+      hasUserBody: true,
+      inboundUserContext,
+      isBareSessionReset: false,
+      startupAction: "new",
+      inboundEventKind: "room_event",
+      sourceReplyDeliveryMode: "message_tool_only",
+    }).currentInboundContext?.text ?? ""
+  );
+}
 
 const telegramChatWindowContext: TelegramPromptContextEntry = {
   label: "Conversation context",
@@ -139,5 +161,126 @@ describe("buildTelegramMessageContext prompt context", () => {
         }),
       }),
     ]);
+  });
+
+  it("excludes ambient transcript rows from the group history window", async () => {
+    const ctx = await buildTelegramMessageContextForTest({
+      message: {
+        message_id: 13,
+        chat: { id: -1001234567890, type: "supergroup", title: "Forum" },
+        from: { id: 1234, first_name: "Pat" },
+        text: "@bot what happened?",
+        entities: [{ type: "mention", offset: 0, length: 4 }],
+      },
+      historyLimit: 10,
+      groupHistories: new Map([
+        [
+          "-1001234567890",
+          [
+            {
+              messageId: "10",
+              sender: "Sam",
+              timestamp: 1_700_000_000_000,
+              body: "persisted ambient one",
+            },
+            {
+              messageId: "11",
+              sender: "Lee",
+              timestamp: 1_700_000_001_000,
+              body: "persisted ambient two",
+            },
+            {
+              messageId: "12",
+              sender: "Mira",
+              timestamp: 1_700_000_002_000,
+              body: "unpersisted gap",
+            },
+          ],
+        ],
+      ]),
+      sessionRuntime: {
+        readAmbientTranscriptWatermark: ({ key }) =>
+          key === '["telegram","default","-1001234567890",""]'
+            ? {
+                messageId: "11",
+                timestampMs: 1_700_000_001_000,
+                updatedAt: 1_700_000_003_000,
+              }
+            : undefined,
+      },
+    });
+
+    expect(ctx?.ctxPayload.UntrustedStructuredContext).toEqual([
+      expect.objectContaining({
+        type: "chat_window",
+        payload: expect.objectContaining({
+          messages: [
+            expect.objectContaining({
+              message_id: "12",
+              body: "unpersisted gap",
+            }),
+          ],
+        }),
+      }),
+    ]);
+    expect(JSON.stringify(ctx?.ctxPayload.UntrustedStructuredContext)).not.toContain(
+      "persisted ambient",
+    );
+  });
+
+  it("omits transcript-owned ambient rows from steady-state room-event prompt text", async () => {
+    const ctx = await buildTelegramMessageContextForTest({
+      message: {
+        message_id: 12,
+        chat: { id: -1001234567890, type: "supergroup", title: "Forum" },
+        from: { id: 1234, first_name: "Pat" },
+        text: "current ambient",
+        date: 1_700_000_002,
+      },
+      cfg: {
+        messages: { groupChat: { unmentionedInbound: "room_event", mentionPatterns: [] } },
+        channels: { telegram: { dmPolicy: "open", allowFrom: ["*"] } },
+      },
+      historyLimit: 10,
+      groupHistories: new Map([
+        [
+          "-1001234567890",
+          [
+            {
+              messageId: "10",
+              sender: "Sam",
+              timestamp: 1_700_000_000_000,
+              body: "persisted ambient one",
+            },
+            {
+              messageId: "11",
+              sender: "Lee",
+              timestamp: 1_700_000_001_000,
+              body: "persisted ambient two",
+            },
+          ],
+        ],
+      ]),
+      sessionRuntime: {
+        readAmbientTranscriptWatermark: ({ key }) =>
+          key === '["telegram","default","-1001234567890",""]'
+            ? {
+                messageId: "11",
+                timestampMs: 1_700_000_001_000,
+                updatedAt: 1_700_000_003_000,
+              }
+            : undefined,
+      },
+    });
+
+    if (!ctx) {
+      throw new Error("Expected room-event context");
+    }
+    const promptText = renderRoomEventPromptText(ctx.ctxPayload as RoomEventPromptContext);
+    expect(promptText).toContain("[OpenClaw room event]");
+    expect(promptText).toContain("Current event:\n#12 Pat: current ambient");
+    expect(promptText).not.toContain("persisted ambient");
+    expect(promptText).not.toContain("Chat history since last reply");
+    expect(ctx.ctxPayload.InboundHistory).toBeUndefined();
   });
 });

--- a/extensions/telegram/src/bot-message-context.session.runtime.ts
+++ b/extensions/telegram/src/bot-message-context.session.runtime.ts
@@ -1,6 +1,11 @@
 // Telegram plugin module implements bot message context.session behavior.
 export { buildChannelInboundEventContext } from "openclaw/plugin-sdk/channel-inbound";
-export { readSessionUpdatedAt, resolveStorePath } from "openclaw/plugin-sdk/session-store-runtime";
+export {
+  readAmbientTranscriptWatermark,
+  readSessionUpdatedAt,
+  resolveAmbientTranscriptWatermarkKey,
+  resolveStorePath,
+} from "openclaw/plugin-sdk/session-store-runtime";
 export { recordInboundSession } from "openclaw/plugin-sdk/conversation-runtime";
 export { resolveInboundLastRouteSessionKey } from "openclaw/plugin-sdk/routing";
 export { resolvePinnedMainDmOwnerFromAllowlist } from "openclaw/plugin-sdk/security-runtime";

--- a/extensions/telegram/src/bot-message-context.session.ts
+++ b/extensions/telegram/src/bot-message-context.session.ts
@@ -20,7 +20,7 @@ import type {
 } from "openclaw/plugin-sdk/config-contracts";
 import { resolveChannelContextVisibilityMode } from "openclaw/plugin-sdk/context-visibility-runtime";
 import { timestampMsToIsoString } from "openclaw/plugin-sdk/number-runtime";
-import { createChannelHistoryWindow, type HistoryEntry } from "openclaw/plugin-sdk/reply-history";
+import type { HistoryEntry } from "openclaw/plugin-sdk/reply-history";
 import type { ResolvedAgentRoute } from "openclaw/plugin-sdk/routing";
 import { logVerbose, shouldLogVerbose } from "openclaw/plugin-sdk/runtime-env";
 import { evaluateSupplementalContextVisibility } from "openclaw/plugin-sdk/security-runtime";
@@ -52,6 +52,7 @@ import {
 import type { TelegramContext } from "./bot/types.js";
 import { resolveTelegramGroupPromptSettings } from "./group-config-helpers.js";
 import {
+  isTelegramHistoryEntryAfterAmbientWatermark,
   isTelegramChatWindowPromptContext,
   mergeTelegramGroupHistoryPromptContext,
   recordTelegramGroupHistoryEntry,
@@ -76,8 +77,10 @@ type TelegramMessageContextSessionRuntime =
 
 const sessionRuntimeMethods = [
   "buildChannelInboundEventContext",
+  "readAmbientTranscriptWatermark",
   "readSessionUpdatedAt",
   "recordInboundSession",
+  "resolveAmbientTranscriptWatermarkKey",
   "resolveInboundLastRouteSessionKey",
   "resolvePinnedMainDmOwnerFromAllowlist",
   "resolveStorePath",
@@ -377,6 +380,22 @@ export async function buildTelegramInboundContextPayload(params: {
     storePath,
     sessionKey: route.sessionKey,
   });
+  const ambientTranscriptWatermarkKey =
+    isGroup && historyKey
+      ? sessionRuntime.resolveAmbientTranscriptWatermarkKey({
+          channel: "telegram",
+          accountId: route.accountId,
+          conversationId: String(chatId),
+          ...(resolvedThreadId !== undefined ? { threadId: resolvedThreadId } : {}),
+        })
+      : undefined;
+  const ambientTranscriptWatermark = ambientTranscriptWatermarkKey
+    ? sessionRuntime.readAmbientTranscriptWatermark({
+        storePath,
+        sessionKey: route.sessionKey,
+        key: ambientTranscriptWatermarkKey,
+      })
+    : undefined;
   const shouldSuppressPersistedDmChatWindowContext =
     !isGroup &&
     previousTimestamp !== undefined &&
@@ -402,7 +421,6 @@ export async function buildTelegramInboundContextPayload(params: {
     previousTimestamp,
     envelope: envelopeOptions,
   });
-  const channelHistory = createChannelHistoryWindow({ historyMap: groupHistories });
   const hasGroupHistoryContext = isGroup;
   const commandBody = normalizeCommandBody(rawBody, {
     botUsername: normalizeOptionalLowercaseString(primaryCtx.me?.username),
@@ -429,7 +447,11 @@ export async function buildTelegramInboundContextPayload(params: {
   let watermarkedGroupHistoryEntries: HistoryEntry[] | undefined;
   let groupHistoryPromptEntries: HistoryEntry[] = [];
   if (hasGroupHistoryContext && historyKey && historyLimit > 0) {
-    const fullGroupHistoryEntries = (groupHistories.get(historyKey) ?? []).slice(-historyLimit);
+    const fullGroupHistoryEntries = (groupHistories.get(historyKey) ?? [])
+      .filter((entry) =>
+        isTelegramHistoryEntryAfterAmbientWatermark(entry, ambientTranscriptWatermark),
+      )
+      .slice(-historyLimit);
     watermarkedGroupHistoryEntries =
       selectTelegramGroupHistoryAfterLastSelf(fullGroupHistoryEntries).slice(-historyLimit);
     groupHistoryPromptEntries =
@@ -469,14 +491,9 @@ export async function buildTelegramInboundContextPayload(params: {
   const locationContext = locationData ? toLocationContext(locationData) : undefined;
   const inboundHistory =
     hasGroupHistoryContext && historyKey && historyLimit > 0
-      ? inboundEventKind === "room_event"
-        ? channelHistory.buildInboundHistory({
-            historyKey,
-            limit: historyLimit,
-          })
-        : watermarkedGroupHistoryEntries && watermarkedGroupHistoryEntries.length > 0
-          ? watermarkedGroupHistoryEntries
-          : undefined
+      ? groupHistoryPromptEntries.length > 0
+        ? groupHistoryPromptEntries
+        : undefined
       : undefined;
   const ctxPayload = await sessionRuntime.buildChannelInboundEventContext({
     channel: "telegram",
@@ -566,6 +583,18 @@ export async function buildTelegramInboundContextPayload(params: {
     contextVisibility: contextVisibilityMode,
     extra: {
       BotUsername: primaryCtx.me?.username ?? undefined,
+      AmbientTranscriptWatermarkKey: ambientTranscriptWatermarkKey,
+      AmbientTranscriptBody: options?.ambientTranscriptBody,
+      AmbientTranscriptMessageId: ambientTranscriptWatermarkKey
+        ? (options?.messageIdOverride ?? String(msg.message_id))
+        : undefined,
+      AmbientTranscriptTimestampMs: ambientTranscriptWatermarkKey
+        ? msg.date
+          ? msg.date * 1000
+          : undefined
+        : undefined,
+      AmbientTranscriptPreviousMessageId: ambientTranscriptWatermark?.messageId,
+      AmbientTranscriptPreviousTimestampMs: ambientTranscriptWatermark?.timestampMs,
       GroupSubject: isGroup ? (msg.chat.title ?? undefined) : undefined,
       ReplyChain: visibleReplyChain.length > 0 ? visibleReplyChain : undefined,
       ReplyToIsExternal: visibleReplyTarget?.source === "external_reply" ? true : undefined,

--- a/extensions/telegram/src/bot-message-context.test-harness.ts
+++ b/extensions/telegram/src/bot-message-context.test-harness.ts
@@ -56,8 +56,16 @@ function createTelegramMessageContextSessionRuntimeForTest(
 ): TelegramTestSessionRuntime {
   return {
     buildChannelInboundEventContext,
+    readAmbientTranscriptWatermark: () => undefined,
     readSessionUpdatedAt: () => undefined,
     recordInboundSession: async () => undefined,
+    resolveAmbientTranscriptWatermarkKey: ({ channel, accountId, conversationId, threadId }) =>
+      JSON.stringify([
+        channel,
+        accountId ?? "",
+        conversationId,
+        threadId === undefined ? "" : String(threadId),
+      ]),
     resolveInboundLastRouteSessionKey: ({ route, sessionKey }) =>
       route.lastRoutePolicy === "main" ? route.mainSessionKey : sessionKey,
     resolvePinnedMainDmOwnerFromAllowlist: () => null,

--- a/extensions/telegram/src/bot-message-context.types.ts
+++ b/extensions/telegram/src/bot-message-context.types.ts
@@ -26,12 +26,19 @@ export type TelegramMessageContextOptions = {
   receivedAtMs?: number;
   ingressBuffer?: "inbound-debounce" | "text-fragment";
   promptContextMinTimestampMs?: number;
+  promptContextAmbientWatermark?: TelegramAmbientTranscriptWatermark;
+  ambientTranscriptBody?: string;
   spooledReplay?: boolean;
 };
 
 export type TelegramPromptContextEntry = NonNullable<
   MsgContext["UntrustedStructuredContext"]
 >[number];
+
+export type TelegramAmbientTranscriptWatermark = {
+  messageId: string;
+  timestampMs?: number;
+};
 
 export type TelegramLogger = {
   info: (obj: Record<string, unknown>, msg: string) => void;
@@ -70,6 +77,8 @@ export type TelegramMessageContextSessionRuntimeOverrides = Partial<
     | "buildChannelInboundEventContext"
     | "readSessionUpdatedAt"
     | "recordInboundSession"
+    | "readAmbientTranscriptWatermark"
+    | "resolveAmbientTranscriptWatermarkKey"
     | "resolveInboundLastRouteSessionKey"
     | "resolvePinnedMainDmOwnerFromAllowlist"
     | "resolveStorePath"

--- a/extensions/telegram/src/bot-message-dispatch.test.ts
+++ b/extensions/telegram/src/bot-message-dispatch.test.ts
@@ -7,6 +7,8 @@ import {
 } from "openclaw/plugin-sdk/plugin-state-test-runtime";
 import { setReplyPayloadMetadata } from "openclaw/plugin-sdk/reply-payload-testing";
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { buildInboundUserContextPrefix } from "../../../src/auto-reply/reply/inbound-meta.js";
+import { buildReplyPromptEnvelopeBase } from "../../../src/auto-reply/reply/prompt-prelude.js";
 import { resolveAutoTopicLabelConfig as resolveAutoTopicLabelConfigRuntime } from "./auto-topic-label-config.js";
 import type { TelegramBotDeps } from "./bot-deps.js";
 import {
@@ -26,6 +28,8 @@ import type { TelegramRuntime } from "./runtime.types.js";
 type DispatchReplyWithBufferedBlockDispatcherArgs = Parameters<
   TelegramBotDeps["dispatchReplyWithBufferedBlockDispatcher"]
 >[0];
+type RoomEventPromptContext = Parameters<typeof buildInboundUserContextPrefix>[0] &
+  Parameters<typeof buildReplyPromptEnvelopeBase>[0]["ctx"];
 
 const createTelegramDraftStream = vi.hoisted(() => vi.fn());
 const dispatchReplyWithBufferedBlockDispatcher = vi.hoisted(() =>
@@ -421,6 +425,23 @@ describe("dispatchTelegramMessage draft streaming", () => {
     expect(calls.length).toBeGreaterThan(0);
     const preview = calls[calls.length - 1][0] as { text?: string };
     expect(preview.text).toBe(barText);
+  }
+
+  function renderRoomEventPromptText(ctx: RoomEventPromptContext): string {
+    const inboundUserContext = buildInboundUserContextPrefix(ctx);
+    return (
+      buildReplyPromptEnvelopeBase({
+        ctx,
+        sessionCtx: ctx,
+        baseBody: ctx.BodyForAgent ?? ctx.Body ?? ctx.RawBody ?? "",
+        hasUserBody: true,
+        inboundUserContext,
+        isBareSessionReset: false,
+        startupAction: "new",
+        inboundEventKind: "room_event",
+        sourceReplyDeliveryMode: "message_tool_only",
+      }).currentInboundContext?.text ?? ""
+    );
   }
 
   function createContext(overrides?: Partial<TelegramMessageContext>): TelegramMessageContext {
@@ -1186,6 +1207,80 @@ describe("dispatchTelegramMessage draft streaming", () => {
       expect.objectContaining({ body: "recovered topic context" }),
       expect.objectContaining({ body: "ambient leak", messageId: "27787" }),
     ]);
+  });
+
+  it("omits transcript-owned ambient rows from recovered room-event prompt text", async () => {
+    const oldHistoryKey = "-1003774691294:topic:1";
+    const recoveredHistoryKey = "-1003774691294:topic:3731";
+    const groupHistories = new Map([
+      [
+        oldHistoryKey,
+        [{ sender: "Cara", body: "ambient current", timestamp: 3, messageId: "27787" }],
+      ],
+      [
+        recoveredHistoryKey,
+        [
+          {
+            sender: "Alice",
+            body: "persisted recovered ambient one",
+            timestamp: 1,
+            messageId: "199",
+          },
+          {
+            sender: "Bob",
+            body: "persisted recovered ambient two",
+            timestamp: 2,
+            messageId: "200",
+          },
+        ],
+      ],
+    ]);
+    dispatchReplyWithBufferedBlockDispatcher.mockResolvedValue({
+      queuedFinal: false,
+      counts: { block: 0, final: 0, tool: 0 },
+      sourceReplyDeliveryMode: "message_tool_only",
+    });
+
+    await dispatchWithContext({
+      context: createContext({
+        ctxPayload: {
+          InboundEventKind: "room_event",
+          BodyForAgent: "ambient current",
+          ChatType: "group",
+          From: "telegram:group:-1003774691294:topic:1",
+          MessageSid: "27787",
+          MessageThreadId: 1,
+          RawBody: "ambient current",
+          SenderName: "Cara",
+          SessionKey: "agent:main:telegram:group:-1003774691294:topic:3731",
+          TransportThreadId: 1,
+          AmbientTranscriptPreviousMessageId: "200",
+          AmbientTranscriptPreviousTimestampMs: 2,
+        } as TelegramMessageContext["ctxPayload"],
+        msg: {
+          chat: { id: -1003774691294, type: "supergroup" },
+          message_id: 27787,
+        } as TelegramMessageContext["msg"],
+        chatId: -1003774691294,
+        isGroup: true,
+        threadSpec: { id: 1, scope: "forum" },
+        historyKey: oldHistoryKey,
+        historyLimit: 10,
+        groupHistories,
+      }),
+      replyToMode: "off",
+      streamMode: "off",
+    });
+
+    const dispatchParams = mockCallArg(
+      dispatchReplyWithBufferedBlockDispatcher,
+    ) as DispatchReplyWithBufferedBlockDispatcherArgs;
+    const promptText = renderRoomEventPromptText(dispatchParams.ctx as RoomEventPromptContext);
+    expect(promptText).toContain("[OpenClaw room event]");
+    expect(promptText).toContain("Current event:\n#27787 Cara: ambient current");
+    expect(promptText).not.toContain("persisted recovered ambient");
+    expect(promptText).not.toContain("Chat history since last reply");
+    expect(dispatchParams.ctx.InboundHistory).toBeUndefined();
   });
 
   it("moves recovered user-request history out of the original topic", async () => {
@@ -3446,14 +3541,12 @@ describe("dispatchTelegramMessage draft streaming", () => {
       .mockImplementationOnce(() => answerDraftStream)
       .mockImplementationOnce(() => reasoningDraftStream);
     // Only the cosmetic bar send throws; the real final "Done" still delivers.
-    deliverReplies.mockImplementation(
-      async (params: { replies?: Array<{ text?: string }> }) => {
-        if (params.replies?.some((reply) => reply.text?.includes("⏱️"))) {
-          throw new Error("Too Many Requests: retry after 5");
-        }
-        return { delivered: true };
-      },
-    );
+    deliverReplies.mockImplementation(async (params: { replies?: Array<{ text?: string }> }) => {
+      if (params.replies?.some((reply) => reply.text?.includes("⏱️"))) {
+        throw new Error("Too Many Requests: retry after 5");
+      }
+      return { delivered: true };
+    });
     dispatchReplyWithBufferedBlockDispatcher.mockImplementation(
       async ({ dispatcherOptions, replyOptions }) => {
         await replyOptions?.onToolStart?.({ name: "exec", phase: "start" });
@@ -4580,9 +4673,7 @@ describe("dispatchTelegramMessage draft streaming", () => {
 
     await dispatchWithContext({ context: createReasoningStreamContext() });
 
-    expect(reasoningDraftStream.update).toHaveBeenLastCalledWith(
-      "🧠 _Reading_\n\n_Checking_",
-    );
+    expect(reasoningDraftStream.update).toHaveBeenLastCalledWith("🧠 _Reading_\n\n_Checking_");
     const updates = reasoningDraftStream.update.mock.calls.map((call) => call[0]);
     expect(updates.join("\n")).not.toContain("CheckingReading");
   });

--- a/extensions/telegram/src/bot-message-dispatch.ts
+++ b/extensions/telegram/src/bot-message-dispatch.ts
@@ -104,6 +104,7 @@ import {
 import { shouldSuppressLocalTelegramExecApprovalPrompt } from "./exec-approvals.js";
 import { renderTelegramHtmlText } from "./format.js";
 import {
+  isTelegramHistoryEntryAfterAmbientWatermark,
   mergeTelegramGroupHistoryPromptContext,
   retainTelegramGroupHistoryPromptContext,
   selectTelegramGroupHistoryAfterLastSelf,
@@ -599,6 +600,8 @@ function migrateRecoveredTelegramGroupHistory(params: {
   ) {
     return;
   }
+  // Topic recovery mutates the raw in-memory buffer before any prompt is built;
+  // prompt readers apply the ambient transcript watermark after recovery.
   const originalEntries = params.context.groupHistories.get(originalHistoryKey);
   if (!originalEntries?.length) {
     return;
@@ -658,35 +661,43 @@ function resolveDispatchTelegramContext(params: {
     : params.context.historyKey;
   const recoveredHistoryEntries =
     recoveredHistoryKey && params.context.historyLimit > 0
-      ? (params.context.groupHistories.get(recoveredHistoryKey) ?? []).slice(
-          -params.context.historyLimit,
-        )
+      ? (params.context.groupHistories.get(recoveredHistoryKey) ?? [])
+          .filter((entry) =>
+            isTelegramHistoryEntryAfterAmbientWatermark(
+              entry,
+              params.context.ctxPayload.AmbientTranscriptPreviousMessageId
+                ? {
+                    messageId: params.context.ctxPayload.AmbientTranscriptPreviousMessageId,
+                    ...(params.context.ctxPayload.AmbientTranscriptPreviousTimestampMs !== undefined
+                      ? {
+                          timestampMs:
+                            params.context.ctxPayload.AmbientTranscriptPreviousTimestampMs,
+                        }
+                      : {}),
+                  }
+                : undefined,
+            ),
+          )
+          .slice(-params.context.historyLimit)
       : [];
   const recoveredWatermarkedHistoryEntries = selectTelegramGroupHistoryAfterLastSelf(
     recoveredHistoryEntries,
   ).slice(-params.context.historyLimit);
-  const recoveredInboundHistory =
-    params.context.isGroup && recoveredHistoryKey && params.context.historyLimit > 0
-      ? params.context.ctxPayload.InboundEventKind === "room_event"
-        ? createChannelHistoryWindow({
-            historyMap: params.context.groupHistories,
-          }).buildInboundHistory({
-            historyKey: recoveredHistoryKey,
-            limit: params.context.historyLimit,
-          })
-        : recoveredWatermarkedHistoryEntries.length > 0
-          ? recoveredWatermarkedHistoryEntries
-          : undefined
-      : params.context.ctxPayload.InboundHistory;
-  const recoveredBodyForAgent = extractCurrentTelegramBody(
-    params.context.ctxPayload.BodyForAgent ?? params.context.ctxPayload.Body,
-  );
   const recoveredPromptHistoryEntries =
     params.context.isGroup && recoveredHistoryKey && params.context.historyLimit > 0
       ? params.context.ctxPayload.InboundEventKind === "room_event"
         ? recoveredHistoryEntries
         : recoveredWatermarkedHistoryEntries
       : [];
+  const recoveredInboundHistory =
+    params.context.isGroup && recoveredHistoryKey && params.context.historyLimit > 0
+      ? recoveredPromptHistoryEntries.length > 0
+        ? recoveredPromptHistoryEntries
+        : undefined
+      : params.context.ctxPayload.InboundHistory;
+  const recoveredBodyForAgent = extractCurrentTelegramBody(
+    params.context.ctxPayload.BodyForAgent ?? params.context.ctxPayload.Body,
+  );
   const recoveredPromptContextBase = retainTelegramGroupHistoryPromptContext({
     promptContext: params.context.ctxPayload.UntrustedStructuredContext ?? [],
     entries: recoveredPromptHistoryEntries,

--- a/extensions/telegram/src/bot-message.ts
+++ b/extensions/telegram/src/bot-message.ts
@@ -89,8 +89,14 @@ export const createTelegramMessageProcessor = (deps: TelegramMessageProcessorDep
     ...(telegramDeps.readSessionUpdatedAt
       ? { readSessionUpdatedAt: telegramDeps.readSessionUpdatedAt }
       : {}),
+    ...(telegramDeps.readAmbientTranscriptWatermark
+      ? { readAmbientTranscriptWatermark: telegramDeps.readAmbientTranscriptWatermark }
+      : {}),
     ...(telegramDeps.recordInboundSession
       ? { recordInboundSession: telegramDeps.recordInboundSession }
+      : {}),
+    ...(telegramDeps.resolveAmbientTranscriptWatermarkKey
+      ? { resolveAmbientTranscriptWatermarkKey: telegramDeps.resolveAmbientTranscriptWatermarkKey }
       : {}),
     ...(telegramDeps.resolveInboundLastRouteSessionKey
       ? { resolveInboundLastRouteSessionKey: telegramDeps.resolveInboundLastRouteSessionKey }

--- a/extensions/telegram/src/bot-updates.ts
+++ b/extensions/telegram/src/bot-updates.ts
@@ -1,6 +1,7 @@
 // Telegram plugin module implements bot updates behavior.
 import type { Message } from "grammy/types";
 import { createDedupeCache } from "openclaw/plugin-sdk/dedupe-runtime";
+import type { TelegramAmbientTranscriptWatermark } from "./bot-message-context.types.js";
 import type { TelegramContext } from "./bot/types.js";
 
 const MEDIA_GROUP_TIMEOUT_MS = 500;
@@ -13,6 +14,7 @@ export type MediaGroupEntry = {
     ctx: TelegramContext;
   }>;
   promptContextMinTimestampMs?: number;
+  promptContextAmbientWatermark?: TelegramAmbientTranscriptWatermark;
   timer: ReturnType<typeof setTimeout>;
 };
 

--- a/extensions/telegram/src/bot.test.ts
+++ b/extensions/telegram/src/bot.test.ts
@@ -2082,6 +2082,109 @@ describe("createTelegramBot", () => {
     ]);
   });
 
+  it("excludes ambient transcript rows from live group conversation context", async () => {
+    onSpy.mockClear();
+    replySpy.mockClear();
+
+    loadConfig.mockReturnValue({
+      agents: {
+        defaults: {
+          envelopeTimezone: "utc",
+        },
+      },
+      channels: {
+        telegram: {
+          groupPolicy: "allowlist",
+          groupAllowFrom: ["111", "222", "333", "444"],
+          groups: { "*": { requireMention: true } },
+        },
+      },
+    });
+
+    const previousReadAmbient = telegramBotDepsForTest.readAmbientTranscriptWatermark;
+    const previousResolveAmbientKey = telegramBotDepsForTest.resolveAmbientTranscriptWatermarkKey;
+    telegramBotDepsForTest.resolveAmbientTranscriptWatermarkKey = vi.fn(
+      () => "telegram:default:42",
+    );
+    telegramBotDepsForTest.readAmbientTranscriptWatermark = vi.fn(() => ({
+      messageId: "502",
+      timestampMs: 1_736_380_860_000,
+      updatedAt: 1_736_380_900_000,
+    }));
+
+    try {
+      createTelegramBot({ token: "tok" });
+      const handler = getOnHandler("message") as (ctx: Record<string, unknown>) => Promise<void>;
+      const baseCtx = {
+        me: { id: 999, username: "openclaw_bot" },
+        getFile: async () => ({ download: async () => new Uint8Array() }),
+      };
+
+      for (const message of [
+        {
+          chat: { id: 42, type: "group", title: "Ops" },
+          text: "persisted ambient one",
+          date: 1_736_380_800,
+          message_id: 501,
+          from: { id: 111, is_bot: false, first_name: "Requester" },
+        },
+        {
+          chat: { id: 42, type: "group", title: "Ops" },
+          text: "persisted ambient two",
+          date: 1_736_380_860,
+          message_id: 502,
+          from: { id: 222, is_bot: false, first_name: "Operator" },
+        },
+        {
+          chat: { id: 42, type: "group", title: "Ops" },
+          text: "unpersisted gap",
+          date: 1_736_380_920,
+          message_id: 503,
+          from: { id: 333, is_bot: false, first_name: "Mira" },
+        },
+      ]) {
+        await handler({ ...baseCtx, message });
+      }
+
+      expect(replySpy).not.toHaveBeenCalled();
+
+      await handler({
+        ...baseCtx,
+        message: {
+          chat: { id: 42, type: "group", title: "Ops" },
+          text: "@openclaw_bot what changed?",
+          date: 1_736_380_980,
+          message_id: 504,
+          from: { id: 444, is_bot: false, first_name: "Pat" },
+          entities: [{ type: "mention", offset: 0, length: 13 }],
+        },
+      });
+
+      expect(replySpy).toHaveBeenCalledTimes(1);
+      const payload = mockMsgContextArg(
+        replySpy as unknown as MockCallSource,
+        0,
+        0,
+        "replySpy call",
+      );
+      const [conversationContext] = requireArray(
+        payload.UntrustedStructuredContext,
+        "structured context",
+      );
+      const contextPayload = requireRecord(
+        requireRecord(conversationContext, "conversation context").payload,
+        "conversation context payload",
+      );
+      const messages = requireArray(contextPayload.messages, "conversation context messages").map(
+        (message, index) => requireRecord(message, `conversation context message ${index + 1}`),
+      );
+      expect(messages.map((message) => message.body)).toEqual(["unpersisted gap"]);
+    } finally {
+      telegramBotDepsForTest.readAmbientTranscriptWatermark = previousReadAmbient;
+      telegramBotDepsForTest.resolveAmbientTranscriptWatermarkKey = previousResolveAmbientKey;
+    }
+  });
+
   it("honors historyLimit zero for group chat-window context", async () => {
     onSpy.mockClear();
     replySpy.mockClear();

--- a/extensions/telegram/src/group-history-window.ts
+++ b/extensions/telegram/src/group-history-window.ts
@@ -1,6 +1,9 @@
 // Telegram plugin module implements group history window behavior.
 import { createChannelHistoryWindow, type HistoryEntry } from "openclaw/plugin-sdk/reply-history";
-import type { TelegramPromptContextEntry } from "./bot-message-context.types.js";
+import type {
+  TelegramAmbientTranscriptWatermark,
+  TelegramPromptContextEntry,
+} from "./bot-message-context.types.js";
 
 const TELEGRAM_GROUP_HISTORY_SELF_SUFFIX = " (you)";
 
@@ -33,6 +36,42 @@ function telegramHistoryEntryKey(entry: HistoryEntry): string | undefined {
     return `text:${entry.timestamp}:${entry.body.trim()}`;
   }
   return undefined;
+}
+
+function numericMessageId(value: string | undefined): number | undefined {
+  if (!value?.trim()) {
+    return undefined;
+  }
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : undefined;
+}
+
+export function isTelegramHistoryEntryAfterAmbientWatermark(
+  entry: Pick<HistoryEntry, "messageId" | "timestamp">,
+  watermark: TelegramAmbientTranscriptWatermark | undefined,
+): boolean {
+  if (!watermark) {
+    return true;
+  }
+  // Exclusive boundary: entries at or before this point are transcript-owned.
+  if (entry.timestamp !== undefined && watermark.timestampMs !== undefined) {
+    if (entry.timestamp !== watermark.timestampMs) {
+      return entry.timestamp > watermark.timestampMs;
+    }
+    const entryMessageId = numericMessageId(entry.messageId);
+    const watermarkMessageId = numericMessageId(watermark.messageId);
+    return (
+      entryMessageId !== undefined &&
+      watermarkMessageId !== undefined &&
+      entryMessageId > watermarkMessageId
+    );
+  }
+  const entryMessageId = numericMessageId(entry.messageId);
+  const watermarkMessageId = numericMessageId(watermark.messageId);
+  if (entryMessageId !== undefined && watermarkMessageId !== undefined) {
+    return entryMessageId > watermarkMessageId;
+  }
+  return entry.messageId !== watermark.messageId;
 }
 
 function telegramChatWindowPayload(

--- a/extensions/telegram/src/message-cache.test.ts
+++ b/extensions/telegram/src/message-cache.test.ts
@@ -2,6 +2,7 @@
 import { rm, writeFile } from "node:fs/promises";
 import type { Message } from "grammy/types";
 import { describe, expect, it } from "vitest";
+import { isTelegramHistoryEntryAfterAmbientWatermark } from "./group-history-window.js";
 import {
   buildTelegramConversationContext,
   buildTelegramReplyChain,
@@ -804,6 +805,72 @@ describe("telegram message cache", () => {
     });
 
     expect(context.map((entry) => entry.node.messageId)).toEqual(["601"]);
+  });
+
+  it("filters ambient transcript rows from cache-derived group context", async () => {
+    const cache = createTelegramMessageCache();
+    const chat = { id: 7, type: "group", title: "Ops" } as const;
+    const timestampMs = 1_700_000_000_000;
+    for (const msg of [
+      {
+        chat,
+        message_id: 10,
+        date: timestampMs / 1000,
+        text: "persisted ambient one",
+        from: { id: 101, is_bot: false, first_name: "Sam" },
+      },
+      {
+        chat,
+        message_id: 11,
+        date: (timestampMs + 1000) / 1000,
+        text: "persisted ambient two",
+        from: { id: 102, is_bot: false, first_name: "Lee" },
+      },
+      {
+        chat,
+        message_id: 12,
+        date: (timestampMs + 2000) / 1000,
+        text: "unpersisted gap",
+        from: { id: 103, is_bot: false, first_name: "Mira" },
+        reply_to_message: {
+          chat,
+          message_id: 11,
+          date: (timestampMs + 1000) / 1000,
+          text: "persisted ambient two",
+          from: { id: 102, is_bot: false, first_name: "Lee" },
+        } as Message["reply_to_message"],
+      },
+      {
+        chat,
+        message_id: 13,
+        date: (timestampMs + 3000) / 1000,
+        text: "@openclaw_bot what happened?",
+        from: { id: 104, is_bot: false, first_name: "Pat" },
+      },
+    ] satisfies Message[]) {
+      await cache.record({ accountId: "default", chatId: 7, msg });
+    }
+
+    const context = await buildTelegramConversationContext({
+      cache,
+      accountId: "default",
+      chatId: 7,
+      messageId: "13",
+      replyChainNodes: [],
+      recentLimit: 10,
+      replyTargetWindowSize: 1,
+      includeNode: (node, flags) =>
+        flags?.replyTarget === true ||
+        isTelegramHistoryEntryAfterAmbientWatermark(node, {
+          messageId: "11",
+          timestampMs: timestampMs + 1000,
+        }),
+    });
+
+    expect(context.map((entry) => entry.node.messageId)).toEqual(["11", "12"]);
+    expect(context.find((entry) => entry.node.messageId === "11")?.isReplyTarget).toBe(true);
+    expect(context.map((entry) => entry.node.body)).not.toContain("persisted ambient one");
+    expect(context.map((entry) => entry.node.body)).toContain("unpersisted gap");
   });
 
   it("does not select messages before the latest session reset command", async () => {

--- a/extensions/telegram/src/message-cache.ts
+++ b/extensions/telegram/src/message-cache.ts
@@ -904,7 +904,7 @@ export async function buildTelegramConversationContext(params: {
   recentLimit: number;
   replyTargetWindowSize: number;
   minTimestampMs?: number;
-  includeNode?: (node: TelegramCachedMessageNode) => boolean;
+  includeNode?: (node: TelegramCachedMessageNode, flags?: { replyTarget?: boolean }) => boolean;
 }): Promise<TelegramConversationContextNode[]> {
   const selected = new Map<string, TelegramConversationContextNode>();
   const replyTargetIds = new Set<string>();
@@ -920,7 +920,7 @@ export async function buildTelegramConversationContext(params: {
     if (!isAtOrAfterSessionBoundaryTimestamp(node, sessionBoundaryTimestamp)) {
       return false;
     }
-    if (params.includeNode && !params.includeNode(node)) {
+    if (params.includeNode && !params.includeNode(node, flags)) {
       return false;
     }
     const existing = selected.get(node.messageId);

--- a/src/agents/cli-runner/session-history.test.ts
+++ b/src/agents/cli-runner/session-history.test.ts
@@ -699,6 +699,35 @@ describe("loadCliSessionReseedMessages", () => {
     }
   });
 
+  it("raw-reseeds consecutive ambient user rows", async () => {
+    const stateDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-cli-state-"));
+    const sessionFile = createSessionTranscript({
+      rootDir: stateDir,
+      sessionId: "session-consecutive-ambient",
+      messages: ["#10 Sam: first ambient", "#11 Lee: second ambient", "#12 Pat: @bot what now?"],
+    });
+
+    try {
+      await withCliSessionState(stateDir, async () => {
+        const reseed = await loadCliSessionReseedMessages({
+          sessionId: "session-consecutive-ambient",
+          sessionFile,
+          sessionKey: "agent:main:main",
+          agentId: "main",
+          allowRawTranscriptReseed: true,
+          rawTranscriptReseedReason: "missing-transcript",
+        });
+
+        expect(reseed).toHaveLength(3);
+        expectMessageFields(reseed[0], { role: "user", content: "#10 Sam: first ambient" });
+        expectMessageFields(reseed[1], { role: "user", content: "#11 Lee: second ambient" });
+        expectMessageFields(reseed[2], { role: "user", content: "#12 Pat: @bot what now?" });
+      });
+    } finally {
+      fs.rmSync(stateDir, { recursive: true, force: true });
+    }
+  });
+
   it("does not raw-reseed auth-boundary invalidations even when opted in", async () => {
     const stateDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-cli-state-"));
     const sessionFile = createSessionTranscript({

--- a/src/agents/embedded-agent-runner/replay-history.test.ts
+++ b/src/agents/embedded-agent-runner/replay-history.test.ts
@@ -95,6 +95,15 @@ describe("normalizeAssistantReplayContent", () => {
     expect(out).toEqual([messages[0], messages[2]]);
   });
 
+  it("preserves consecutive ambient user rows", () => {
+    const messages = [
+      userMessage("#10 Sam: first ambient"),
+      userMessage("#11 Lee: second ambient"),
+      userMessage("#12 Pat: @bot what now?"),
+    ];
+    expect(normalizeAssistantReplayContent(messages)).toBe(messages);
+  });
+
   it("removes blank user text blocks while preserving non-text content", () => {
     const imageBlock = { type: "image", data: "AA==", mimeType: "image/png" };
     const messages = [

--- a/src/auto-reply/reply/get-reply-run.media-only.test.ts
+++ b/src/auto-reply/reply/get-reply-run.media-only.test.ts
@@ -37,6 +37,11 @@ vi.mock("../../config/sessions/paths.js", () => ({
 
 const storeRuntimeLoads = vi.hoisted(() => vi.fn());
 const updateSessionStore = vi.hoisted(() => vi.fn());
+const updateAmbientTranscriptWatermarkMock = vi.hoisted(() => vi.fn().mockResolvedValue(null));
+
+vi.mock("../../config/sessions/ambient-transcript-watermark.js", () => ({
+  updateAmbientTranscriptWatermark: updateAmbientTranscriptWatermarkMock,
+}));
 
 vi.mock("../../config/sessions/store.runtime.js", () => {
   storeRuntimeLoads();
@@ -296,6 +301,7 @@ describe("runPreparedReply media-only handling", () => {
   beforeEach(async () => {
     storeRuntimeLoads.mockClear();
     updateSessionStore.mockReset();
+    updateAmbientTranscriptWatermarkMock.mockClear();
     vi.clearAllMocks();
     replyRunTesting.resetReplyRunRegistry();
   });
@@ -2014,19 +2020,42 @@ describe("runPreparedReply media-only handling", () => {
           MediaType: "audio/ogg",
           MessageSid: "35676",
           SenderName: "Keśava",
+          AmbientTranscriptWatermarkKey: '["telegram","","-100123",""]',
+          AmbientTranscriptMessageId: "35676",
+          AmbientTranscriptTimestampMs: 1_710_000_000_000,
         },
+        storePath: "/tmp/openclaw-session-store.json",
       }),
     );
 
     const call = requireLastRunReplyAgentCall();
     expect(call?.commandBody).toBe("[OpenClaw room event]");
-    expect(call?.transcriptCommandBody).toBe("");
+    expect(call?.transcriptCommandBody).toBe("#35676 Keśava: No wtf");
     expect(call?.followupRun.prompt).toBe("[OpenClaw room event]");
-    expect(call?.followupRun.transcriptPrompt).toBe("");
+    expect(call?.followupRun.transcriptPrompt).toBe("#35676 Keśava: No wtf");
     expect(call?.followupRun.currentInboundEventKind).toBe("room_event");
     expect(call?.followupRun.currentInboundAudio).toBe(true);
     expect(call?.followupRun.run.sourceReplyDeliveryMode).toBe("message_tool_only");
-    expect(call?.followupRun.run.suppressNextUserMessagePersistence).toBe(true);
+    expect(call?.followupRun.run.suppressNextUserMessagePersistence).toBeUndefined();
+    expect(call?.followupRun.run.suppressTranscriptOnlyAssistantPersistence).toBe(true);
+    expect(call?.followupRun.userTurnTranscriptRecorder?.message).toEqual({
+      role: "user",
+      content: "#35676 Keśava: No wtf",
+      timestamp: expect.any(Number),
+      __openclaw: { senderIsOwner: false },
+    });
+    call?.followupRun.userTurnTranscriptRecorder?.markRuntimePersisted({
+      role: "user",
+      content: "#35676 Keśava: No wtf",
+      timestamp: 1_710_000_000_000,
+    });
+    expect(updateAmbientTranscriptWatermarkMock).toHaveBeenCalledWith({
+      storePath: "/tmp/openclaw-session-store.json",
+      sessionKey: "session-key",
+      key: '["telegram","","-100123",""]',
+      messageId: "35676",
+      timestampMs: 1_710_000_000_000,
+    });
     expect(call?.followupRun.currentInboundContext?.text).toContain(
       "#35675 obviyus ->#35674: Are you fr fr",
     );

--- a/src/auto-reply/reply/get-reply-run.ts
+++ b/src/auto-reply/reply/get-reply-run.ts
@@ -20,6 +20,7 @@ import { listOpenAIAuthProfileProvidersForAgentRuntime } from "../../agents/open
 import { resolveIngressWorkspaceOverrideForSpawnedRun } from "../../agents/spawned-context.js";
 import type { SilentReplyPromptMode } from "../../agents/system-prompt.types.js";
 import { normalizeChatType } from "../../channels/chat-type.js";
+import { updateAmbientTranscriptWatermark } from "../../config/sessions/ambient-transcript-watermark.js";
 import { resolveGroupSessionKey } from "../../config/sessions/group.js";
 import {
   resolveSessionFilePath,
@@ -170,6 +171,27 @@ function normalizeMessageTimestampMs(value: unknown): number | undefined {
   const timestampMs =
     timestamp < EPOCH_MILLISECONDS_THRESHOLD ? Math.trunc(timestamp * 1000) : timestamp;
   return asDateTimestampMs(timestampMs);
+}
+
+async function updateRoomEventAmbientTranscriptWatermark(params: {
+  sessionCtx: TemplateContext;
+  storePath?: string;
+  sessionKey?: string;
+}): Promise<void> {
+  const key = normalizeOptionalString(params.sessionCtx.AmbientTranscriptWatermarkKey);
+  const messageId = normalizeOptionalString(params.sessionCtx.AmbientTranscriptMessageId);
+  if (!params.storePath || !params.sessionKey || !key || !messageId) {
+    return;
+  }
+  // Advance only after the transcript row exists; Telegram windows exclude
+  // everything at or before this durable boundary on later turns.
+  await updateAmbientTranscriptWatermark({
+    storePath: params.storePath,
+    sessionKey: params.sessionKey,
+    key,
+    messageId,
+    timestampMs: params.sessionCtx.AmbientTranscriptTimestampMs,
+  });
 }
 
 function isSlackDirectRoutedThreadTurn(ctx: MsgContext): boolean {
@@ -1282,6 +1304,14 @@ export async function runPreparedReply(
           }),
           errorContext: "reply user turn transcript",
           beforeMessageWrite: runAgentHarnessBeforeMessageWriteHook,
+          onMessagePersisted: isRoomEvent
+            ? async () =>
+                await updateRoomEventAmbientTranscriptWatermark({
+                  sessionCtx,
+                  storePath,
+                  sessionKey: sessionKey ?? preparedSessionState.sessionId,
+                })
+            : undefined,
         })
       : undefined);
   const replyRoute = resolveEffectiveReplyRoute({
@@ -1424,7 +1454,6 @@ export async function runPreparedReply(
       extraSystemPromptStatic: extraSystemPromptStaticParts.join("\n\n"),
       skipProviderRuntimeHints: useFastReplyRuntime,
       allowEmptyAssistantReplyAsSilent,
-      suppressNextUserMessagePersistence: isRoomEvent,
       suppressTranscriptOnlyAssistantPersistence: isRoomEvent,
       ...(!useFastReplyRuntime &&
       isReasoningTagProvider(provider, {

--- a/src/auto-reply/reply/prompt-prelude.test.ts
+++ b/src/auto-reply/reply/prompt-prelude.test.ts
@@ -92,7 +92,7 @@ describe("buildReplyPromptEnvelope", () => {
 
     expect(envelope.prefixedCommandBody).toBe("[OpenClaw room event]");
     expect(envelope.queuedBody).toBe("[OpenClaw room event]");
-    expect(envelope.transcriptCommandBody).toBe("");
+    expect(envelope.transcriptCommandBody).toBe("#35676 Keśava: No wtf");
     expect(envelope.currentInboundContext?.text).toBe(
       [
         "[OpenClaw room event]",
@@ -129,6 +129,36 @@ describe("buildReplyPromptEnvelope", () => {
     );
     expect(envelope.currentInboundContext?.resumableText).not.toContain(
       "Conversation context (untrusted, chronological, selected for current message):",
+    );
+  });
+
+  it("uses attributed coalesced room-event lines for current event and transcript", () => {
+    const ambientTranscriptBody = ["#35676 Keśava: No wtf", "#35677 Ayaan: fr"].join("\n");
+    const sessionCtx = finalizeInboundContext({
+      Body: "No wtf\nfr",
+      BodyStripped: "No wtf\nfr",
+      Provider: "telegram",
+      ChatType: "group",
+      InboundEventKind: "room_event",
+      MessageSid: "35677",
+      SenderName: "Ayaan",
+      AmbientTranscriptBody: ambientTranscriptBody,
+    });
+
+    const envelope = buildReplyPromptEnvelope({
+      ctx: sessionCtx,
+      sessionCtx,
+      baseBody: "No wtf\nfr",
+      hasUserBody: true,
+      inboundUserContext: "Conversation context:",
+      isBareSessionReset: false,
+      startupAction: "new",
+      inboundEventKind: "room_event",
+    });
+
+    expect(envelope.transcriptCommandBody).toBe(ambientTranscriptBody);
+    expect(envelope.currentInboundContext?.text).toContain(
+      `Current event:\n${ambientTranscriptBody}`,
     );
   });
 

--- a/src/auto-reply/reply/prompt-prelude.ts
+++ b/src/auto-reply/reply/prompt-prelude.ts
@@ -56,12 +56,12 @@ export function buildReplyPromptBodies(params: {
     ? [mediaNote, mediaReplyHint, prefixedBody].filter(Boolean).join("\n").trim()
     : prefixedBody;
   const transcriptBody = params.transcriptBody ?? params.effectiveBaseBody;
-  const includeMediaOnlyTranscript = mediaNote && params.inboundEventKind !== "room_event";
+  const includeMediaTranscript = mediaNote && params.inboundEventKind !== "room_event";
   const transcriptCommandBodyRaw = transcriptBody
-    ? mediaNote
+    ? includeMediaTranscript
       ? [mediaNote, transcriptBody].filter(Boolean).join("\n").trim()
       : transcriptBody
-    : includeMediaOnlyTranscript
+    : includeMediaTranscript
       ? mediaNote
       : "";
   return {
@@ -139,8 +139,16 @@ function resolveRoomEventBody(params: ReplyPromptEnvelopeBaseParams): string {
   );
 }
 
+function resolveRoomEventTranscriptBody(params: ReplyPromptEnvelopeBaseParams): string {
+  return (
+    normalizeOptionalString(params.sessionCtx.AmbientTranscriptBody) ??
+    normalizeOptionalString(params.ctx.AmbientTranscriptBody) ??
+    formatRoomEventLine(params.sessionCtx, resolveRoomEventBody(params))
+  );
+}
+
 function buildRoomEventContext(params: ReplyPromptEnvelopeBaseParams, roomContext: string): string {
-  const roomEventBody = resolveRoomEventBody(params);
+  const roomEventBody = resolveRoomEventTranscriptBody(params);
   const roomContextBlock = roomContext.trim() ? `Room context:\n${roomContext.trim()}` : "";
   const deliveryDirective =
     params.sourceReplyDeliveryMode === "message_tool_only"
@@ -150,7 +158,7 @@ function buildRoomEventContext(params: ReplyPromptEnvelopeBaseParams, roomContex
     "[OpenClaw room event]",
     "inbound_event_kind: room_event",
     roomContextBlock,
-    `Current event:\n${formatRoomEventLine(params.sessionCtx, roomEventBody)}`,
+    `Current event:\n${roomEventBody}`,
     deliveryDirective,
   ]
     .filter(Boolean)
@@ -196,12 +204,14 @@ export function buildReplyPromptEnvelopeBase(
     : params.hasUserBody
       ? resetModelBody
       : "[User sent media without caption]";
+  // Room-event transcript rows are plain chat lines; replay treats them as
+  // conversation, while the OpenClaw marker remains current-turn context only.
   const transcriptBody = params.isHeartbeat
     ? HEARTBEAT_TRANSCRIPT_PROMPT
     : params.isBareSessionReset
       ? softResetTail || `[OpenClaw session ${params.startupAction}]`
       : isRoomEvent
-        ? ""
+        ? resolveRoomEventTranscriptBody(params)
         : params.hasUserBody
           ? params.baseBody
           : "[User sent media without caption]";

--- a/src/auto-reply/reply/strip-inbound-meta.test.ts
+++ b/src/auto-reply/reply/strip-inbound-meta.test.ts
@@ -58,6 +58,11 @@ describe("stripInboundMetadata", () => {
     expect(stripInboundMetadata(text)).toBe(text);
   });
 
+  it("preserves bare ambient envelope rows", () => {
+    const text = "#35676 Keśava: No wtf";
+    expect(stripInboundMetadata(text)).toBe(text);
+  });
+
   it("fast-path: returns empty string unchanged", () => {
     expect(stripInboundMetadata("")).toBe("");
   });

--- a/src/auto-reply/templating.ts
+++ b/src/auto-reply/templating.ts
@@ -135,6 +135,12 @@ export type MsgContext = {
   MessageSids?: string[];
   MessageSidFirst?: string;
   MessageSidLast?: string;
+  AmbientTranscriptWatermarkKey?: string;
+  AmbientTranscriptBody?: string;
+  AmbientTranscriptMessageId?: string;
+  AmbientTranscriptTimestampMs?: number;
+  AmbientTranscriptPreviousMessageId?: string;
+  AmbientTranscriptPreviousTimestampMs?: number;
   /** Per-turn reply-threading overrides. */
   ReplyThreading?: ReplyThreadingPolicy;
   ReplyToId?: string;

--- a/src/config/sessions/ambient-transcript-watermark.ts
+++ b/src/config/sessions/ambient-transcript-watermark.ts
@@ -1,0 +1,99 @@
+import { updateSessionEntry } from "./session-accessor.js";
+import type { AmbientTranscriptWatermark, SessionEntry } from "./types.js";
+
+export type AmbientTranscriptWatermarkScope = {
+  channel: string;
+  accountId?: string;
+  conversationId: string;
+  threadId?: string | number;
+};
+
+export function resolveAmbientTranscriptWatermarkKey(
+  scope: AmbientTranscriptWatermarkScope,
+): string {
+  return JSON.stringify([
+    scope.channel,
+    scope.accountId ?? "",
+    scope.conversationId,
+    scope.threadId === undefined ? "" : String(scope.threadId),
+  ]);
+}
+
+function numericMessageId(value: string): number | undefined {
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : undefined;
+}
+
+function isAmbientTranscriptWatermarkAfter(
+  next: Pick<AmbientTranscriptWatermark, "messageId" | "timestampMs">,
+  current: AmbientTranscriptWatermark | undefined,
+): boolean {
+  if (!current) {
+    return true;
+  }
+  if (next.timestampMs !== undefined && current.timestampMs !== undefined) {
+    if (next.timestampMs !== current.timestampMs) {
+      return next.timestampMs > current.timestampMs;
+    }
+    const nextMessageId = numericMessageId(next.messageId);
+    const currentMessageId = numericMessageId(current.messageId);
+    return (
+      nextMessageId !== undefined &&
+      currentMessageId !== undefined &&
+      nextMessageId > currentMessageId
+    );
+  }
+  const nextMessageId = numericMessageId(next.messageId);
+  const currentMessageId = numericMessageId(current.messageId);
+  if (nextMessageId !== undefined && currentMessageId !== undefined) {
+    return nextMessageId > currentMessageId;
+  }
+  return next.messageId !== current.messageId;
+}
+
+export function readAmbientTranscriptWatermark(
+  entry: Pick<SessionEntry, "ambientTranscriptWatermarks"> | undefined,
+  key: string,
+): AmbientTranscriptWatermark | undefined {
+  return entry?.ambientTranscriptWatermarks?.[key];
+}
+
+export async function updateAmbientTranscriptWatermark(params: {
+  storePath: string;
+  sessionKey: string;
+  key: string;
+  messageId: string;
+  timestampMs?: number;
+}): Promise<SessionEntry | null> {
+  return await updateSessionEntry(
+    {
+      storePath: params.storePath,
+      sessionKey: params.sessionKey,
+    },
+    (entry) => {
+      const current = readAmbientTranscriptWatermark(entry, params.key);
+      if (
+        !isAmbientTranscriptWatermarkAfter(
+          { messageId: params.messageId, timestampMs: params.timestampMs },
+          current,
+        )
+      ) {
+        return null;
+      }
+      return {
+        ambientTranscriptWatermarks: {
+          ...entry.ambientTranscriptWatermarks,
+          [params.key]: {
+            messageId: params.messageId,
+            ...(params.timestampMs !== undefined ? { timestampMs: params.timestampMs } : {}),
+            updatedAt: Date.now(),
+          },
+        },
+      };
+    },
+    {
+      skipMaintenance: true,
+      takeCacheOwnership: true,
+    },
+  );
+}

--- a/src/config/sessions/types.ts
+++ b/src/config/sessions/types.ts
@@ -7,10 +7,7 @@ import type {
   SessionAcpIdentityState,
   SessionAcpMeta,
 } from "@openclaw/acp-core/types";
-import {
-  normalizeOptionalString,
-  type FastMode,
-} from "@openclaw/normalization-core/string-coerce";
+import { normalizeOptionalString, type FastMode } from "@openclaw/normalization-core/string-coerce";
 import type { ChatType } from "../../channels/chat-type.js";
 import type { ChannelId } from "../../channels/plugins/channel-id.types.js";
 import type { ChannelRouteRef } from "../../plugin-sdk/channel-route.js";
@@ -113,6 +110,12 @@ export type SessionContextBudgetStatus = {
   messageCount: number;
   unwindowedMessageCount: number;
   sessionId?: string;
+};
+
+export type AmbientTranscriptWatermark = {
+  messageId: string;
+  timestampMs?: number;
+  updatedAt: number;
 };
 
 export type SessionPluginDebugEntry = {
@@ -408,6 +411,8 @@ export type SessionEntry = {
   origin?: SessionOrigin;
   route?: ChannelRouteRef;
   deliveryContext?: DeliveryContext;
+  /** Last ambient room message durably appended to this transcript, keyed by channel scope. */
+  ambientTranscriptWatermarks?: Record<string, AmbientTranscriptWatermark>;
   lastChannel?: SessionChannelId;
   lastTo?: string;
   lastAccountId?: string;

--- a/src/plugin-sdk/session-store-runtime.ts
+++ b/src/plugin-sdk/session-store-runtime.ts
@@ -1,5 +1,11 @@
 // Narrow session-store helpers for channel hot paths.
 
+import {
+  readAmbientTranscriptWatermark as readAmbientTranscriptWatermarkFromEntry,
+  resolveAmbientTranscriptWatermarkKey,
+  updateAmbientTranscriptWatermark,
+  type AmbientTranscriptWatermarkScope,
+} from "../config/sessions/ambient-transcript-watermark.js";
 import { resolveStorePath as resolveSessionStorePath } from "../config/sessions/paths.js";
 import {
   cleanupSessionLifecycleArtifacts as cleanupAccessorSessionLifecycleArtifacts,
@@ -14,7 +20,7 @@ import {
 import { loadSessionStore as loadSessionStoreImpl } from "../config/sessions/store-load.js";
 import { normalizeResolvedMaintenanceConfigInput } from "../config/sessions/store-maintenance.js";
 import type { ResolvedSessionMaintenanceConfigInput } from "../config/sessions/store.js";
-import type { SessionEntry } from "../config/sessions/types.js";
+import type { AmbientTranscriptWatermark, SessionEntry } from "../config/sessions/types.js";
 
 type SessionStoreReadParams = {
   agentId?: string;
@@ -50,6 +56,10 @@ type PatchSessionEntryParams = SessionStoreReadParams & {
 };
 
 type ReadSessionUpdatedAtParams = SessionStoreReadParams;
+
+type ReadAmbientTranscriptWatermarkParams = SessionStoreReadParams & {
+  key: string;
+};
 
 type UpdateSessionStoreEntryParams = {
   storePath: string;
@@ -141,6 +151,15 @@ export async function patchSessionEntry(
 /** Reads the last activity timestamp for one session entry. */
 export function readSessionUpdatedAt(params: ReadSessionUpdatedAtParams): number | undefined {
   return readAccessorSessionUpdatedAt(toSessionAccessScope(params));
+}
+
+export { resolveAmbientTranscriptWatermarkKey, updateAmbientTranscriptWatermark };
+export type { AmbientTranscriptWatermarkScope };
+
+export function readAmbientTranscriptWatermark(
+  params: ReadAmbientTranscriptWatermarkParams,
+): AmbientTranscriptWatermark | undefined {
+  return readAmbientTranscriptWatermarkFromEntry(getSessionEntry(params), params.key);
 }
 
 /** Updates an existing session entry by store path and session key. */

--- a/src/plugins/session-entry-slot-keys.ts
+++ b/src/plugins/session-entry-slot-keys.ts
@@ -32,6 +32,7 @@ const SESSION_ENTRY_RESERVED_SLOT_KEY_LIST = [
   "restartRecoveryRuns",
   "goal",
   "sessionStartedAt",
+  "ambientTranscriptWatermarks",
   "lastInteractionAt",
   "startedAt",
   "endedAt",

--- a/src/sessions/user-turn-transcript.test.ts
+++ b/src/sessions/user-turn-transcript.test.ts
@@ -502,6 +502,45 @@ describe("user turn transcript persistence", () => {
       ]);
     });
 
+    it("notifies once after fallback user-turn persistence", async () => {
+      const dir = createTempDir("openclaw-user-turn-recorder-notify-");
+      const transcriptPath = path.join(dir, "session.jsonl");
+      const persistedMessages: unknown[] = [];
+      const recorder = createUserTurnTranscriptRecorder({
+        input: {
+          text: "#35676 Keśava: No wtf",
+          timestamp: 123,
+          idempotencyKey: "chat-run-ambient:user",
+        },
+        target: {
+          transcriptPath,
+          sessionId: "session-1",
+          sessionKey: "main",
+          cwd: dir,
+        },
+        updateMode: "none",
+        onMessagePersisted: (message) => {
+          persistedMessages.push(message);
+        },
+      });
+
+      await recorder.persistFallback();
+      await recorder.persistFallback();
+
+      expect(persistedMessages).toEqual([
+        expect.objectContaining({
+          role: "user",
+          content: "#35676 Keśava: No wtf",
+        }),
+      ]);
+      expect(readTranscriptMessages(transcriptPath)).toEqual([
+        expect.objectContaining({
+          role: "user",
+          content: "#35676 Keśava: No wtf",
+        }),
+      ]);
+    });
+
     it("resolves media lazily at persistence time", async () => {
       const dir = createTempDir("openclaw-user-turn-recorder-lazy-media-");
       const transcriptPath = path.join(dir, "session.jsonl");

--- a/src/sessions/user-turn-transcript.ts
+++ b/src/sessions/user-turn-transcript.ts
@@ -72,6 +72,7 @@ type CreateUserTurnTranscriptRecorderParams = {
   beforeMessageWrite?: UserTurnBeforeMessageWrite;
   errorContext?: string;
   onPersistenceError?: (error: unknown) => void;
+  onMessagePersisted?: (message: PersistedUserTurnMessage) => void | Promise<void>;
 };
 
 type ResolvePersistedUserTurnTextOptions = {
@@ -496,6 +497,7 @@ export function createUserTurnTranscriptRecorder(
   let runtimePersistencePromise: Promise<void> | undefined;
   let selfPersistencePromise: Promise<UserTurnTranscriptPersistResult | undefined> | undefined;
   let resolvedMessagePromise: Promise<PersistedUserTurnMessage | undefined> | undefined;
+  let persistedMessageNotified = false;
 
   const handlePersistenceError = (error: unknown) => {
     if (params.onPersistenceError) {
@@ -535,6 +537,21 @@ export function createUserTurnTranscriptRecorder(
       })();
     }
     return await resolvedMessagePromise;
+  };
+
+  const notifyMessagePersisted = (persistedMessage?: PersistedUserTurnMessage) => {
+    const notificationMessage = persistedMessage ?? persistedResult?.message ?? message;
+    if (!notificationMessage || persistedMessageNotified || !params.onMessagePersisted) {
+      return;
+    }
+    persistedMessageNotified = true;
+    try {
+      void Promise.resolve(params.onMessagePersisted(notificationMessage)).catch(
+        handlePersistenceError,
+      );
+    } catch (error) {
+      handlePersistenceError(error);
+    }
   };
 
   const waitForRuntimePersistence = async () => {
@@ -600,6 +617,7 @@ export function createUserTurnTranscriptRecorder(
       if (result) {
         persisted = true;
         persistedResult = result;
+        notifyMessagePersisted(result.message);
       }
       return result;
     })();
@@ -625,6 +643,7 @@ export function createUserTurnTranscriptRecorder(
           message: persistedMessage,
         };
       }
+      notifyMessagePersisted(persistedMessage);
     },
     markBlocked: () => {
       blocked = true;


### PR DESCRIPTION
## What Problem This Solves

Fixes #99257. In ambient group mode (`room_event` turns) the agent evaluates every unmentioned message but is forced to forget it: `get-reply-run.ts` suppressed all room-event persistence, so group knowledge lived only in the bounded per-turn chat window (default 50 messages, rebuilt every turn in the uncached prompt tail). Messages older than the window were permanently invisible, compaction could not preserve ambient chat (nothing was persisted to summarize), and every turn re-paid the full window in fresh tokens.

## Why This Change Was Made

The session transcript becomes the durable group chat log:

- **Bare attributed rows**: each observed room event persists exactly one user-role transcript row in the same `#id sender: body` shape as the Current event display line (byte-identical). No metadata prefix, no window snapshot, no assistant row when the turn stays silent. Coalesced room events persist one row with each observed message as its own attributed line.
- **Watermark dedupe (the core invariant)**: a per-chat ambient watermark (`SessionEntry.ambientTranscriptWatermarks`, core-owned in `src/config/sessions/ambient-transcript-watermark.ts`) advances only after the row durably persists (`onMessagePersisted` hook on the user-turn transcript recorder), monotonically (timestamp-first, message-id tiebreak). Every prompt-facing consumer of the raw group history — the group-history entries, the cache-derived chat window (`includeNode` hook), room-event `InboundHistory` (no raw fallback; `undefined` when empty), and the recovered-thread paths — excludes everything at or before the watermark, so the per-turn window shrinks to the un-persisted gap (normally empty; covers races, coalesced bursts, and pre-feature history). The one intentional exemption is explicit reply targets (a quoted message stays visible even if transcript-owned, so the model never sees a reply to invisible text). All 14 raw-window consumer sites were enumerated as filtered-or-exempt during review.
- **Cutover, no knob**: this is ambient mode's behavior; mention-only mode is untouched (the persist hook is wired only for room events). The room-event user-suppression special-casing is deleted rather than branched around; silent turns still suppress transcript-only assistant rows.
- **Channel-agnostic seam**: core owns the watermark; the channel reads it via the documented `plugin-sdk/session-store-runtime` barrel (narrow channel hot-path helpers).

Net effect: append-only rows mean each group message costs its tokens once and is prompt-cache-hit on every later turn; compaction natively summarizes old ambient chat, so the agent retains the gist of messages far beyond any window.

## User Impact

Ambient-mode deployments get durable full-chat awareness: the agent remembers group conversation across turns, restarts, and compaction, with strictly better cache economics than widening `historyLimit`. Reply gating is unchanged — the default-silent room-event contract (#99144) and the single-canonical-history payload shape (#99256) are preserved and test-pinned.

## Evidence

- Row shape, silent-turn assistant suppression, and watermark advance pinned in `src/auto-reply/reply/get-reply-run.media-only.test.ts`; dedupe boundary (persisted rows absent from the window, only the gap remains) in `extensions/telegram/src/bot-message-context.prompt-context.test.ts`.
- Two review rounds (fresh branch autoreview) each caught a raw-window consumer bypassing the watermark — the live cache-derived group path and room-event `InboundHistory` + recovered threads. Each fix carries a regression test confirmed to fail without it (assertions on the final assembled prompt text, so future fallback paths also fail).
- Consecutive user rows proven through embedded replay (`src/agents/embedded-agent-runner/replay-history.test.ts`), CLI session reseed (`src/agents/cli-runner/session-history.test.ts`), and `strip-inbound-meta` pass-through.
- `node scripts/run-vitest.mjs` across all touched test files plus the affected-format sweep; `pnpm tsgo`, `pnpm check:test-types`, scoped oxlint on every touched file, `pnpm prompt:snapshots:check` — all green.
- `node scripts/run-vitest.mjs test/extension-test-boundary.test.ts src/scripts/test-projects.test.ts` — green.
- Blacksmith Testbox `check:changed` green on the final HEAD (exit 0) and on the two prior review-round HEADs.
- Review posture: two fresh autoreview rounds each surfaced a watermark-bypass leak (fixed above, fail-confirmed regressions). A third full pass was skipped by maintainer decision after the reviewer process hung; the closing delta (`InboundHistory` + recovered-thread filtering) was instead manually verified against the enumeration.
