### PR TITLE
fix(memory-wiki): avoid implicit error coercion

### DIFF
--- a/extensions/memory-wiki/src/ingest.ts
+++ b/extensions/memory-wiki/src/ingest.ts
@@ -42,8 +42,8 @@ function assertUtf8Text(buffer: Buffer, sourcePath: string): string {
 
 function isEmptyExistingSourcePage(error: unknown): boolean {
   return (
-    !!error &&
     typeof error === "object" &&
+    error !== null &&
     ((error as NodeJS.ErrnoException).code === "ENOENT" ||
       (error as NodeJS.ErrnoException).code === "EISDIR")
   );


### PR DESCRIPTION
fixes broken ci lint on main

## What Problem This Solves

The extension lint gate fails on `extensions/memory-wiki/src/ingest.ts` because the existing-source error predicate uses implicit boolean coercion. Since extension lint runs across the full bundled plugin surface, the failure blocks otherwise unrelated pull requests.

## Why This Change Was Made

Replaces `!!error` with an explicit non-null object guard. This satisfies `no-implicit-coercion` while preserving the predicate's existing `ENOENT` and `EISDIR` behavior.

## User Impact

No user-visible behavior change. Pull requests can pass the bundled extension lint gates again.

## Evidence

- Exact oxlint check passed for `extensions/memory-wiki/src/ingest.ts`.
- Formatting check passed for the changed file.
- `node scripts/run-vitest.mjs extensions/memory-wiki/src/wiki-notes-read-retry.test.ts --reporter=verbose` — 1 file, 9 tests passed.
- Fresh Codex autoreview completed with no accepted/actionable findings and 0.99 confidence.
- Scope: 1 file changed, 1 insertion, 1 deletion.
