### PR TITLE
fix: keep Discord reply references on the first chunk

### DIFF
--- a/extensions/discord/src/send.sends-basic-channel-messages.test.ts
+++ b/extensions/discord/src/send.sends-basic-channel-messages.test.ts
@@ -677,21 +677,21 @@ describe("sendMessageDiscord", () => {
     });
   });
 
-  it("preserves reply reference across all text chunks", async () => {
+  it("keeps reply reference only on the first text chunk", async () => {
     const { firstBody, secondBody } = await sendChunkedReplyAndCollectBodies({
       text: "a".repeat(2001),
     });
     expectReplyReference(firstBody, "orig-123");
-    expectReplyReference(secondBody, "orig-123");
+    expect(secondBody.message_reference).toBeUndefined();
   });
 
-  it("preserves reply reference for follow-up text chunks after media caption split", async () => {
+  it("keeps reply reference off follow-up text chunks after media caption split", async () => {
     const { firstBody, secondBody } = await sendChunkedReplyAndCollectBodies({
       text: "a".repeat(2500),
       mediaUrl: "file:///tmp/photo.jpg",
     });
     expectReplyReference(firstBody, "orig-123");
-    expectReplyReference(secondBody, "orig-123");
+    expect(secondBody.message_reference).toBeUndefined();
   });
 });
 

--- a/extensions/discord/src/send.shared.ts
+++ b/extensions/discord/src/send.shared.ts
@@ -328,7 +328,7 @@ async function sendDiscordText(
       components: chunkComponents,
       embeds: chunkEmbeds,
       flags,
-      replyTo,
+      replyTo: isFirst ? replyTo : undefined,
     });
     return (await request(
       () => createChannelMessage<{ id: string; channel_id: string }>(rest, channelId, { body }),
@@ -424,7 +424,7 @@ async function sendDiscordMedia(
       rest,
       channelId,
       chunk,
-      replyTo,
+      undefined,
       request,
       maxLinesPerMessage,
       undefined,


### PR DESCRIPTION
## Summary
- only attach Discord `message_reference` to the first physical text chunk of a logical reply
- avoid reusing the native reply reference on follow-up text chunks after media captions split
- update Discord send tests to cover the single-reply notification behavior

## Testing
- pnpm vitest run extensions/discord/src/send.sends-basic-channel-messages.test.ts extensions/discord/src/outbound-adapter.test.ts

Closes #99068