### PR TITLE
fix: soften doctor shell completion install failures

### DIFF
--- a/src/commands/doctor-completion.test.ts
+++ b/src/commands/doctor-completion.test.ts
@@ -131,12 +131,20 @@ describe("shell completion health mapping", () => {
     await fs.chmod(profilePath, 0o444);
 
     const prompter = {
-      shouldRepair: true,
       confirm: vi.fn(async () => true),
       confirmAutoFix: vi.fn(async () => true),
       confirmAggressiveAutoFix: vi.fn(async () => true),
       confirmRuntimeRepair: vi.fn(async () => true),
-      resolveServiceRepairMode: vi.fn(() => ({ shouldRepair: true })),
+      select: vi.fn(async (_params, fallback) => fallback),
+      shouldRepair: true,
+      shouldForce: false,
+      repairMode: {
+        shouldRepair: true,
+        shouldForce: false,
+        nonInteractive: false,
+        canPrompt: true,
+        updateInProgress: false,
+      },
     };
 
     await expect(doctorShellCompletion({} as never, prompter)).resolves.toBeUndefined();

--- a/src/commands/doctor-completion.test.ts
+++ b/src/commands/doctor-completion.test.ts
@@ -2,14 +2,26 @@
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { resolveCliName } from "../cli/cli-name.js";
 import { captureEnv, setTestEnvValue } from "../test-utils/env.js";
 import {
   checkShellCompletionStatus,
+  doctorShellCompletion,
   shellCompletionStatusToHealthFindings,
   shellCompletionStatusToRepairEffects,
   type ShellCompletionStatus,
 } from "./doctor-completion.js";
+
+vi.mock("../../packages/terminal-core/src/note.js", () => ({
+  note: vi.fn(),
+}));
+
+vi.mock("node:child_process", () => ({
+  spawnSync: vi.fn(() => ({ status: 0 })),
+}));
+
+import { note } from "../../packages/terminal-core/src/note.js";
 
 const originalEnv = captureEnv(["HOME", "OPENCLAW_STATE_DIR", "SHELL"]);
 const tempDirs: string[] = [];
@@ -100,5 +112,37 @@ describe("shell completion health mapping", () => {
 
     expect(shellCompletionStatusToHealthFindings(current)).toEqual([]);
     expect(shellCompletionStatusToRepairEffects(current)).toEqual([]);
+  });
+
+  it("downgrades profile write permission failures to a note during doctor --fix", async () => {
+    const homeDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-completion-home-"));
+    const stateDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-completion-state-"));
+    tempDirs.push(homeDir, stateDir);
+    setTestEnvValue("HOME", homeDir);
+    setTestEnvValue("OPENCLAW_STATE_DIR", stateDir);
+    setTestEnvValue("SHELL", "/bin/bash");
+
+    const cachePath = path.join(stateDir, "completions", `${resolveCliName()}.bash`);
+    await fs.mkdir(path.dirname(cachePath), { recursive: true });
+    await fs.writeFile(cachePath, "# bash completion\n", "utf-8");
+
+    const profilePath = path.join(homeDir, ".bashrc");
+    await fs.writeFile(profilePath, "# test profile\n", "utf-8");
+    await fs.chmod(profilePath, 0o444);
+
+    const prompter = {
+      shouldRepair: true,
+      confirm: vi.fn(async () => true),
+      confirmAutoFix: vi.fn(async () => true),
+      confirmAggressiveAutoFix: vi.fn(async () => true),
+      confirmRuntimeRepair: vi.fn(async () => true),
+      resolveServiceRepairMode: vi.fn(() => ({ shouldRepair: true })),
+    };
+
+    await expect(doctorShellCompletion({} as never, prompter)).resolves.toBeUndefined();
+    expect(note).toHaveBeenCalledWith(
+      expect.stringContaining("Shell completion not installed: ~/.bashrc is not writable."),
+      "Shell completion",
+    );
   });
 });

--- a/src/commands/doctor-completion.ts
+++ b/src/commands/doctor-completion.ts
@@ -163,6 +163,37 @@ export type DoctorCompletionOptions = {
   nonInteractive?: boolean;
 };
 
+function stripCompletionInstallPrefix(message: string): string {
+  return message.replace(/^Failed to install completion:\s*/i, "").trim();
+}
+
+function formatOptionalCompletionFailureNote(
+  shell: CompletionShell,
+  cliName: string,
+  error: unknown,
+): string {
+  const rawMessage = error instanceof Error ? error.message : String(error);
+  const detail = stripCompletionInstallPrefix(rawMessage);
+  const profilePath = resolveCompletionReloadPath(shell);
+  if (/\b(?:EACCES|EPERM|EROFS)\b|permission denied|read-only/i.test(detail)) {
+    return `Shell completion not installed: ${profilePath} is not writable. Run \`${cliName} completion --install --shell ${shell}\` after making the profile writable.`;
+  }
+  return `Shell completion not installed: ${detail}. Run \`${cliName} completion --install --shell ${shell}\` manually if you want shell completion.`;
+}
+
+async function installOptionalShellCompletion(
+  shell: CompletionShell,
+  cliName: string,
+): Promise<boolean> {
+  try {
+    await installCompletion(shell, true, cliName);
+    return true;
+  } catch (error) {
+    note(formatOptionalCompletionFailureNote(shell, cliName, error), "Shell completion");
+    return false;
+  }
+}
+
 /**
  * Repairs shell completion setup when doctor runs interactively.
  *
@@ -195,7 +226,10 @@ export async function doctorShellCompletion(
       }
     }
 
-    await installCompletion(status.shell, true, cliName);
+    const installed = await installOptionalShellCompletion(status.shell, cliName);
+    if (!installed) {
+      return;
+    }
     note(formatCompletionReloadNote(status.shell, "upgraded"), "Shell completion");
     return;
   }
@@ -237,7 +271,10 @@ export async function doctorShellCompletion(
         return;
       }
 
-      await installCompletion(status.shell, true, cliName);
+      const installed = await installOptionalShellCompletion(status.shell, cliName);
+      if (!installed) {
+        return;
+      }
       note(formatCompletionReloadNote(status.shell, "installed"), "Shell completion");
     }
   }


### PR DESCRIPTION
## Summary
- downgrade shell completion install failures during `doctor --fix` into a non-blocking note
- keep successful install/upgrade notes unchanged
- add coverage for read-only `~/.bashrc` so doctor does not fail the whole run

## Testing
- pnpm vitest run src/commands/doctor-completion.test.ts src/cli/completion-runtime.test.ts

Closes #99237