### PR TITLE
improve(mattermost): restart only the changed account on config reload

### DIFF
--- a/docs/docs_map.md
+++ b/docs/docs_map.md
@@ -7397,6 +7397,7 @@ Do not edit it by hand; run `pnpm docs:map:gen`.
   - H3: Narrower approval runtime subpaths
   - H3: Setup subpaths
   - H3: Other narrow channel subpaths
+  - H2: Account-scoped config reloads
   - H2: Inbound mention policy
   - H2: Walkthrough
   - H2: File structure

--- a/docs/docs_map.md
+++ b/docs/docs_map.md
@@ -7385,6 +7385,7 @@ Do not edit it by hand; run `pnpm docs:map:gen`.
   - H2: Message adapter
   - H3: Inbound ingress (experimental)
   - H3: Durable ingress and replay dedupe
+  - H4: Account-scoped restart contract
   - H3: Typing indicators
   - H3: Media source params
   - H3: Native payload shaping
@@ -7397,7 +7398,6 @@ Do not edit it by hand; run `pnpm docs:map:gen`.
   - H3: Narrower approval runtime subpaths
   - H3: Setup subpaths
   - H3: Other narrow channel subpaths
-  - H2: Account-scoped config reloads
   - H2: Inbound mention policy
   - H2: Walkthrough
   - H2: File structure

--- a/docs/plugins/sdk-channel-plugins.md
+++ b/docs/plugins/sdk-channel-plugins.md
@@ -116,6 +116,32 @@ guard when adopting the drain and size `completedTtlMs`/`completedMaxEntries`
 to cover the old guard window instead. Non-dedupe protections (age fences,
 outbound echo caches) are unrelated to this rule and stay.
 
+#### Account-scoped restart contract
+
+Channel config changes restart the whole channel by default. A multi-account
+channel may set `reload.accountScopedRestart: true` only when configuration
+resolution reads channel-wide shared fields plus the selected account, never a
+sibling account, and the Gateway can stop and start one `(channel, accountId)`
+runtime without replacing sibling runtimes.
+
+The scoped path applies only to changes under
+`channels.<channel>.accounts.<non-default-id>.*`. Changes to shared channel
+fields, `accounts.default`, removed or unresolvable accounts, and mixed changes
+that can affect inheritance are promoted to a whole-channel restart. Plugins
+that do not opt in always use the whole-channel path.
+
+For channels using the durable ingress drain, the account monitor's stop path
+must first settle all accepted transport admissions, then dispose and await its
+drain. Starting the account opens the same account-keyed queue, whose initial
+drain recovers undispatched durable rows. Do not add a second reload-specific
+replay pass; queue recovery is the canonical restart path.
+
+Treat this flag as a capability claim, not a performance preference. Contract
+tests should prove that adding and editing one named account leaves a sibling's
+resolved config unchanged, stopping one account settles only that account's
+monitor and drain, and a fresh monitor recovers that account's rows exactly
+once. If any guarantee cannot be proved, omit the flag.
+
 ### Typing indicators
 
 If your channel supports typing indicators outside inbound replies, expose
@@ -447,28 +473,6 @@ approvals and the plugin just exposes outbound/auth capabilities. Native
 approval channels such as Matrix, Slack, Telegram, and custom chat transports
 should use the shared native helpers instead of rolling their own approval
 lifecycle.
-
-## Account-scoped config reloads
-
-Channel config changes restart the whole channel by default. A multi-account
-channel may set `reload.accountScopedRestart: true` only when both of these
-contracts hold:
-
-- Resolving, routing, or authenticating one named account never reads mutable
-  state from a sibling named account.
-- The gateway runtime can stop and start one account by `accountId` without
-  interrupting or replacing sibling runtimes.
-
-The scoped path applies only to changes under
-`channels.<channel>.accounts.<non-default-id>.*`. Changes to shared channel
-fields, the `default` account, removed or unresolvable accounts, and any mixed
-change that can affect inheritance are promoted to a whole-channel restart.
-Plugins that do not opt in always use the whole-channel path.
-
-Treat this flag as a capability claim, not a performance preference. Contract
-tests should prove that adding and editing one named account leaves a sibling's
-resolved config unchanged, and that hot reload stops and starts only the named
-runtime. If either guarantee cannot be proved, omit the flag.
 
 ## Inbound mention policy
 

--- a/docs/plugins/sdk-channel-plugins.md
+++ b/docs/plugins/sdk-channel-plugins.md
@@ -448,6 +448,28 @@ approval channels such as Matrix, Slack, Telegram, and custom chat transports
 should use the shared native helpers instead of rolling their own approval
 lifecycle.
 
+## Account-scoped config reloads
+
+Channel config changes restart the whole channel by default. A multi-account
+channel may set `reload.accountScopedRestart: true` only when both of these
+contracts hold:
+
+- Resolving, routing, or authenticating one named account never reads mutable
+  state from a sibling named account.
+- The gateway runtime can stop and start one account by `accountId` without
+  interrupting or replacing sibling runtimes.
+
+The scoped path applies only to changes under
+`channels.<channel>.accounts.<non-default-id>.*`. Changes to shared channel
+fields, the `default` account, removed or unresolvable accounts, and any mixed
+change that can affect inheritance are promoted to a whole-channel restart.
+Plugins that do not opt in always use the whole-channel path.
+
+Treat this flag as a capability claim, not a performance preference. Contract
+tests should prove that adding and editing one named account leaves a sibling's
+resolved config unchanged, and that hot reload stops and starts only the named
+runtime. If either guarantee cannot be proved, omit the flag.
+
 ## Inbound mention policy
 
 Keep inbound mention handling split in two layers:

--- a/extensions/mattermost/src/channel.setup.ts
+++ b/extensions/mattermost/src/channel.setup.ts
@@ -24,7 +24,7 @@ export const mattermostSetupPlugin: ChannelPlugin<ResolvedMattermostAccount> = {
     media: true,
     nativeCommands: true,
   },
-  reload: { configPrefixes: ["channels.mattermost"] },
+  reload: { configPrefixes: ["channels.mattermost"], accountScopedRestart: true },
   configSchema: MattermostChannelConfigSchema,
   config: {
     ...mattermostConfigAdapter,

--- a/extensions/mattermost/src/channel.setup.ts
+++ b/extensions/mattermost/src/channel.setup.ts
@@ -24,7 +24,14 @@ export const mattermostSetupPlugin: ChannelPlugin<ResolvedMattermostAccount> = {
     media: true,
     nativeCommands: true,
   },
-  reload: { configPrefixes: ["channels.mattermost"], accountScopedRestart: true },
+  reload: {
+    configPrefixes: ["channels.mattermost"],
+    /**
+     * accounts.default is promoted; named resolution merges only channel-wide fields
+     * plus the selected account. Runtime monitor, debounce, and ingress use accountId.
+     */
+    accountScopedRestart: true,
+  },
   configSchema: MattermostChannelConfigSchema,
   config: {
     ...mattermostConfigAdapter,

--- a/extensions/mattermost/src/channel.test.ts
+++ b/extensions/mattermost/src/channel.test.ts
@@ -169,6 +169,60 @@ describe("mattermostPlugin", () => {
     expect(mattermostPlugin.reload).toMatchObject({ accountScopedRestart: true });
   });
 
+  it("keeps sibling resolution stable across named-account additions and edits", () => {
+    const before: OpenClawConfig = {
+      channels: {
+        mattermost: {
+          replyToMode: "first",
+          accounts: {
+            beta: {
+              baseUrl: "https://beta.example.com",
+              chatmode: "onmessage",
+            },
+          },
+        },
+      },
+    };
+    const afterAdd: OpenClawConfig = {
+      channels: {
+        mattermost: {
+          replyToMode: "first",
+          accounts: {
+            alpha: {
+              baseUrl: "https://alpha.example.com",
+              chatmode: "oncall",
+            },
+            beta: {
+              baseUrl: "https://beta.example.com",
+              chatmode: "onmessage",
+            },
+          },
+        },
+      },
+    };
+    const afterEdit: OpenClawConfig = {
+      channels: {
+        mattermost: {
+          replyToMode: "first",
+          accounts: {
+            alpha: {
+              baseUrl: "https://alpha-new.example.com",
+              chatmode: "onchar",
+            },
+            beta: {
+              baseUrl: "https://beta.example.com",
+              chatmode: "onmessage",
+            },
+          },
+        },
+      },
+    };
+
+    const expectedBeta = mattermostPlugin.config.resolveAccount(before, "beta");
+    expect(mattermostPlugin.config.resolveAccount(afterAdd, "beta")).toEqual(expectedBeta);
+    expect(mattermostPlugin.config.resolveAccount(afterEdit, "beta")).toEqual(expectedBeta);
+  });
+
   describe("messaging", () => {
     it("keeps @username targets", () => {
       const normalize = requireMattermostNormalizeTarget();

--- a/extensions/mattermost/src/channel.test.ts
+++ b/extensions/mattermost/src/channel.test.ts
@@ -165,6 +165,10 @@ describe("mattermostPlugin", () => {
     });
   });
 
+  it("opts into account-scoped config restarts", () => {
+    expect(mattermostPlugin.reload).toMatchObject({ accountScopedRestart: true });
+  });
+
   describe("messaging", () => {
     it("keeps @username targets", () => {
       const normalize = requireMattermostNormalizeTarget();

--- a/extensions/mattermost/src/channel.ts
+++ b/extensions/mattermost/src/channel.ts
@@ -798,7 +798,14 @@ export const mattermostPlugin: ChannelPlugin<ResolvedMattermostAccount> = create
     streaming: {
       blockStreamingCoalesceDefaults: { minChars: 1500, idleMs: 1000 },
     },
-    reload: { configPrefixes: ["channels.mattermost"], accountScopedRestart: true },
+    reload: {
+      configPrefixes: ["channels.mattermost"],
+      /**
+       * accounts.default is promoted; named resolution merges only channel-wide fields
+       * plus the selected account. Monitor debounce and durable ingress use accountId.
+       */
+      accountScopedRestart: true,
+    },
     configSchema: MattermostChannelConfigSchema,
     config: {
       ...mattermostConfigAdapter,

--- a/extensions/mattermost/src/channel.ts
+++ b/extensions/mattermost/src/channel.ts
@@ -798,7 +798,7 @@ export const mattermostPlugin: ChannelPlugin<ResolvedMattermostAccount> = create
     streaming: {
       blockStreamingCoalesceDefaults: { minChars: 1500, idleMs: 1000 },
     },
-    reload: { configPrefixes: ["channels.mattermost"] },
+    reload: { configPrefixes: ["channels.mattermost"], accountScopedRestart: true },
     configSchema: MattermostChannelConfigSchema,
     config: {
       ...mattermostConfigAdapter,

--- a/extensions/mattermost/src/mattermost/monitor-ingress.test.ts
+++ b/extensions/mattermost/src/mattermost/monitor-ingress.test.ts
@@ -38,9 +38,13 @@ function postedEvent(params?: {
   });
 }
 
-function startMonitor(queue: MattermostIngressQueue, dispatch: MattermostIngressDispatch) {
+function startMonitor(
+  queue: MattermostIngressQueue,
+  dispatch: MattermostIngressDispatch,
+  accountId = "default",
+) {
   return createMattermostIngressMonitor({
-    accountId: "default",
+    accountId,
     queue,
     dispatch,
     runtime: { error: vi.fn(), log: vi.fn() },
@@ -49,20 +53,35 @@ function startMonitor(queue: MattermostIngressQueue, dispatch: MattermostIngress
   });
 }
 
-async function withQueue<T>(fn: (queue: MattermostIngressQueue) => Promise<T>): Promise<T> {
-  const created = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-mattermost-ingress-"));
-  const stateDir = await fs.realpath(created);
-  const queue = createChannelIngressQueueForTests<MattermostIngressPayload>({
+function createQueue(stateDir: string, accountId: string): MattermostIngressQueue {
+  return createChannelIngressQueueForTests<MattermostIngressPayload>({
     channelId: "mattermost",
-    accountId: "default",
+    accountId,
     stateDir,
   });
+}
+
+async function withStateDir<T>(fn: (stateDir: string) => Promise<T>): Promise<T> {
+  const created = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-mattermost-ingress-"));
+  const stateDir = await fs.realpath(created);
   try {
-    return await fn(queue);
+    return await fn(stateDir);
   } finally {
     closeOpenClawStateDatabaseForTest();
     await fs.rm(stateDir, { recursive: true, force: true });
   }
+}
+
+async function withQueue<T>(fn: (queue: MattermostIngressQueue) => Promise<T>): Promise<T> {
+  return await withStateDir(async (stateDir) => await fn(createQueue(stateDir, "default")));
+}
+
+function createDeferred(): { promise: Promise<void>; resolve: () => void } {
+  let resolvePromise = () => {};
+  const promise = new Promise<void>((resolve) => {
+    resolvePromise = resolve;
+  });
+  return { promise, resolve: resolvePromise };
 }
 
 function testLifecycle() {
@@ -127,6 +146,88 @@ describe("Mattermost durable ingress", () => {
         expect(recoveredDispatch).toHaveBeenCalledTimes(1);
       } finally {
         await recovered.stop();
+      }
+    });
+  });
+
+  it("settles only the restarted account and recovers its durable row exactly once", async () => {
+    await withStateDir(async (stateDir) => {
+      const queueA = createQueue(stateDir, "account-a");
+      const queueB = createQueue(stateDir, "account-b");
+      const dispatchA = vi.fn<MattermostIngressDispatch>(async (_post, _payload, lifecycle) => {
+        lifecycle.onDeferred();
+        return { kind: "deferred" } as const;
+      });
+      const dispatchBBeforeRestart = vi.fn<MattermostIngressDispatch>(async () => undefined);
+      const monitorA = startMonitor(queueA, dispatchA, "account-a");
+      const monitorBBeforeRestart = startMonitor(queueB, dispatchBBeforeRestart, "account-b");
+      const admissionStored = createDeferred();
+      const releaseAdmission = createDeferred();
+      const enqueueB = queueB.enqueue.bind(queueB);
+      queueB.enqueue = async (...args) => {
+        const result = await enqueueB(...args);
+        admissionStored.resolve();
+        await releaseAdmission.promise;
+        return result;
+      };
+      let admittingB: Promise<void> | undefined;
+      let stoppingB: Promise<void> | undefined;
+
+      try {
+        await Promise.all([monitorA.waitForIdle(), monitorBBeforeRestart.waitForIdle()]);
+        await monitorA.receive(postedEvent({ postId: "post-account-a" }));
+        await monitorA.waitForIdle();
+        const claimsABefore = await queueA.listClaims();
+        expect(claimsABefore).toHaveLength(1);
+        expect(dispatchA).toHaveBeenCalledTimes(1);
+
+        admittingB = monitorBBeforeRestart.receive(postedEvent({ postId: "post-account-b" }));
+        await admissionStored.promise;
+        let stopSettled = false;
+        stoppingB = monitorBBeforeRestart.stop().then(() => {
+          stopSettled = true;
+        });
+        await Promise.resolve();
+
+        // stop() must wait for the serialized append admission. Account A's
+        // drain claim and debounce handoff stay owned by its live monitor.
+        expect(stopSettled).toBe(false);
+        expect(await queueA.listClaims()).toEqual(claimsABefore);
+        expect(dispatchA).toHaveBeenCalledTimes(1);
+
+        releaseAdmission.resolve();
+        await Promise.all([admittingB, stoppingB]);
+        expect(dispatchBBeforeRestart).not.toHaveBeenCalled();
+        expect(await queueB.listPending({ limit: "all" })).toEqual([
+          expect.objectContaining({ id: "post-account-b" }),
+        ]);
+        expect(await queueA.listClaims()).toEqual(claimsABefore);
+
+        const dispatchBAfterRestart = vi.fn<MattermostIngressDispatch>(
+          async (_post, _payload, lifecycle) => {
+            await lifecycle.onAdopted();
+          },
+        );
+        const monitorBAfterRestart = startMonitor(queueB, dispatchBAfterRestart, "account-b");
+        try {
+          await monitorBAfterRestart.waitForIdle();
+          expect(dispatchBAfterRestart).toHaveBeenCalledTimes(1);
+          expect(dispatchBAfterRestart.mock.calls[0]?.[0].id).toBe("post-account-b");
+
+          await monitorBAfterRestart.receive(postedEvent({ postId: "post-account-b" }));
+          await monitorBAfterRestart.waitForIdle();
+          expect(dispatchBAfterRestart).toHaveBeenCalledTimes(1);
+          expect(await queueA.listClaims()).toEqual(claimsABefore);
+          expect(dispatchA).toHaveBeenCalledTimes(1);
+        } finally {
+          await monitorBAfterRestart.stop();
+        }
+      } finally {
+        releaseAdmission.resolve();
+        await Promise.allSettled(
+          [admittingB, stoppingB].filter((task): task is Promise<void> => task !== undefined),
+        );
+        await Promise.allSettled([monitorA.stop(), monitorBBeforeRestart.stop()]);
       }
     });
   });

--- a/src/channels/plugins/types.plugin.ts
+++ b/src/channels/plugins/types.plugin.ts
@@ -65,7 +65,11 @@ export type ChannelPlugin<ResolvedAccount = any, Probe = unknown, Audit = unknow
       debounceMs?: number;
     };
   };
-  reload?: { configPrefixes: string[]; noopPrefixes?: string[] };
+  reload?: {
+    configPrefixes: string[];
+    noopPrefixes?: string[];
+    accountScopedRestart?: boolean;
+  };
   setupWizard?: ChannelPluginSetupWizard;
   config: ChannelConfigAdapter<ResolvedAccount>;
   configSchema?: ChannelConfigSchema;

--- a/src/channels/plugins/types.plugin.ts
+++ b/src/channels/plugins/types.plugin.ts
@@ -70,8 +70,9 @@ export type ChannelPlugin<ResolvedAccount = any, Probe = unknown, Audit = unknow
     noopPrefixes?: string[];
     /**
      * Opt into restarting only the changed non-default named account.
-     * Set only when sibling account resolution and runtime lifecycle are isolated;
-     * default, shared, removed, or unresolved account changes still restart the channel.
+     * Set only when sibling account resolution and lifecycle state are isolated and
+     * account stop fully settles owned work. Shared, default, removed, or unresolved
+     * account changes still restart the whole channel.
      */
     accountScopedRestart?: boolean;
   };

--- a/src/channels/plugins/types.plugin.ts
+++ b/src/channels/plugins/types.plugin.ts
@@ -68,6 +68,11 @@ export type ChannelPlugin<ResolvedAccount = any, Probe = unknown, Audit = unknow
   reload?: {
     configPrefixes: string[];
     noopPrefixes?: string[];
+    /**
+     * Opt into restarting only the changed non-default named account.
+     * Set only when sibling account resolution and runtime lifecycle are isolated;
+     * default, shared, removed, or unresolved account changes still restart the channel.
+     */
     accountScopedRestart?: boolean;
   };
   setupWizard?: ChannelPluginSetupWizard;

--- a/src/cli/config-cli.ts
+++ b/src/cli/config-cli.ts
@@ -1051,7 +1051,7 @@ function configApplyHintForPaths(paths: string[], afterConfig: OpenClawConfig): 
   if (paths.some(isPluginEntryConfigPath)) {
     return RESTART_HINT;
   }
-  const plan = buildGatewayReloadPlan(paths);
+  const plan = buildGatewayReloadPlan(paths, { candidateConfig: afterConfig });
   if (plan.restartGateway) {
     return RESTART_HINT;
   }

--- a/src/gateway/config-reload-plan.ts
+++ b/src/gateway/config-reload-plan.ts
@@ -47,6 +47,7 @@ type ReloadAction =
   | "restart-health-monitor"
   | "reload-plugins"
   | "dispose-mcp-runtimes"
+  | `restart-channel-account:${ChannelId}`
   | `restart-channel:${ChannelId}`;
 
 type GatewayReloadPlanOptions = {
@@ -182,13 +183,16 @@ function listReloadRules(): ReloadRule[] {
     return cachedReloadRules;
   }
   // Channel docking: plugins contribute hot reload/no-op prefixes here.
-  const channelReloadRules: ReloadRule[] = listChannelPlugins().flatMap((plugin) =>
-    (plugin.reload?.configPrefixes ?? [])
+  const channelReloadRules: ReloadRule[] = listChannelPlugins().flatMap((plugin) => {
+    const restartAction = plugin.reload?.accountScopedRestart
+      ? (`restart-channel-account:${plugin.id}` as ReloadAction)
+      : (`restart-channel:${plugin.id}` as ReloadAction);
+    return (plugin.reload?.configPrefixes ?? [])
       .map(
         (prefix): ReloadRule => ({
           prefix,
           kind: "hot",
-          actions: [`restart-channel:${plugin.id}` as ReloadAction],
+          actions: [restartAction],
         }),
       )
       .concat(
@@ -198,8 +202,8 @@ function listReloadRules(): ReloadRule[] {
             kind: "none",
           }),
         ),
-      ),
-  );
+      );
+  });
   const channelPluginStateRules: ReloadRule[] = listChannelPlugins().flatMap((plugin) => [
     {
       prefix: `plugins.entries.${plugin.id}`,
@@ -387,8 +391,8 @@ export function buildGatewayReloadPlan(
   };
 
   const applyAction = (action: ReloadAction, originatingPath: string) => {
-    if (action.startsWith("restart-channel:")) {
-      const channel = action.slice("restart-channel:".length) as ChannelId;
+    if (action.startsWith("restart-channel-account:")) {
+      const channel = action.slice("restart-channel-account:".length) as ChannelId;
       const accountId = extractAccountIdFromPath(channel, originatingPath);
       if (accountId !== null) {
         let set = restartChannelAccounts.get(channel);
@@ -399,6 +403,11 @@ export function buildGatewayReloadPlan(
         set.add(accountId);
         return;
       }
+      plan.restartChannels.add(channel);
+      return;
+    }
+    if (action.startsWith("restart-channel:")) {
+      const channel = action.slice("restart-channel:".length) as ChannelId;
       plan.restartChannels.add(channel);
       return;
     }

--- a/src/gateway/config-reload-plan.ts
+++ b/src/gateway/config-reload-plan.ts
@@ -6,6 +6,7 @@ import {
   getActivePluginHttpRouteRegistry,
   getActivePluginHttpRouteRegistryVersion,
 } from "../plugins/runtime.js";
+import { DEFAULT_ACCOUNT_ID } from "../routing/account-id.js";
 import { isPlainObject } from "../utils.js";
 
 export type ChannelKind = ChannelId;
@@ -23,6 +24,8 @@ export type GatewayReloadPlan = {
   reloadPlugins: boolean;
   restartChannels: Set<ChannelKind>;
   disposeMcpRuntimes: boolean;
+  /** Account targets; absent means no targeted restarts for hand-built plans. */
+  restartChannelAccounts?: Map<ChannelKind, Set<string>>;
   noopPaths: string[];
 };
 
@@ -338,12 +341,34 @@ export function listPluginInstallWholeRecordPaths(
   );
 }
 
+function extractAccountIdFromPath(channel: ChannelId, path: string): string | null {
+  const prefix = `channels.${channel}.accounts.`;
+  if (!path.startsWith(prefix)) {
+    return null;
+  }
+  const rest = path.slice(prefix.length);
+  if (rest.length === 0) {
+    return null;
+  }
+  const dotIdx = rest.indexOf(".");
+  const id = dotIdx === -1 ? rest : rest.slice(0, dotIdx);
+  if (id.length === 0) {
+    return null;
+  }
+  // Default config is the inheritance base, so it can change every account.
+  if (id === DEFAULT_ACCOUNT_ID) {
+    return null;
+  }
+  return id;
+}
+
 export function buildGatewayReloadPlan(
   changedPaths: string[],
   options: GatewayReloadPlanOptions = {},
 ): GatewayReloadPlan {
   const noopPaths = new Set(options.noopPaths);
   const forceChangedPaths = new Set(options.forceChangedPaths);
+  const restartChannelAccounts = new Map<ChannelKind, Set<string>>();
   const plan: GatewayReloadPlan = {
     changedPaths,
     restartGateway: false,
@@ -357,12 +382,23 @@ export function buildGatewayReloadPlan(
     reloadPlugins: false,
     restartChannels: new Set(),
     disposeMcpRuntimes: false,
+    restartChannelAccounts,
     noopPaths: [],
   };
 
-  const applyAction = (action: ReloadAction) => {
+  const applyAction = (action: ReloadAction, originatingPath: string) => {
     if (action.startsWith("restart-channel:")) {
       const channel = action.slice("restart-channel:".length) as ChannelId;
+      const accountId = extractAccountIdFromPath(channel, originatingPath);
+      if (accountId !== null) {
+        let set = restartChannelAccounts.get(channel);
+        if (!set) {
+          set = new Set<string>();
+          restartChannelAccounts.set(channel, set);
+        }
+        set.add(accountId);
+        return;
+      }
       plan.restartChannels.add(channel);
       return;
     }
@@ -418,8 +454,13 @@ export function buildGatewayReloadPlan(
     }
     plan.hotReasons.push(path);
     for (const action of rule.actions ?? []) {
-      applyAction(action);
+      applyAction(action, path);
     }
+  }
+
+  // A wholesale restart covers its account targets and must run only once.
+  for (const channel of plan.restartChannels) {
+    restartChannelAccounts.delete(channel);
   }
 
   if (plan.restartGmailWatcher) {

--- a/src/gateway/config-reload-plan.ts
+++ b/src/gateway/config-reload-plan.ts
@@ -1,6 +1,11 @@
 // Gateway config reload planner.
 // Maps changed config paths to hot-reload actions, no-ops, or full restarts.
-import { type ChannelId, listChannelPlugins } from "../channels/plugins/index.js";
+import {
+  type ChannelId,
+  type ChannelPlugin,
+  listChannelPlugins,
+} from "../channels/plugins/index.js";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
 import {
   getActivePluginChannelRegistryVersion,
   getActivePluginHttpRouteRegistry,
@@ -33,6 +38,7 @@ type ReloadRule = {
   prefix: string;
   kind: "restart" | "hot" | "none";
   actions?: ReloadAction[];
+  accountScopedPlugin?: ChannelPlugin;
 };
 
 type ConfigReloadMetadata = {
@@ -53,6 +59,8 @@ type ReloadAction =
 type GatewayReloadPlanOptions = {
   noopPaths?: Iterable<string>;
   forceChangedPaths?: Iterable<string>;
+  /** Candidate config used to reject removed, unknown, or unresolvable account targets. */
+  candidateConfig?: OpenClawConfig;
 };
 
 const PLUGIN_INSTALL_TIMESTAMP_KEYS = ["installedAt", "resolvedAt"] as const;
@@ -188,13 +196,17 @@ function listReloadRules(): ReloadRule[] {
       ? (`restart-channel-account:${plugin.id}` as ReloadAction)
       : (`restart-channel:${plugin.id}` as ReloadAction);
     return (plugin.reload?.configPrefixes ?? [])
-      .map(
-        (prefix): ReloadRule => ({
+      .map((prefix): ReloadRule => {
+        const rule: ReloadRule = {
           prefix,
           kind: "hot",
           actions: [restartAction],
-        }),
-      )
+        };
+        if (plugin.reload?.accountScopedRestart) {
+          rule.accountScopedPlugin = plugin;
+        }
+        return rule;
+      })
       .concat(
         (plugin.reload?.noopPrefixes ?? []).map(
           (prefix): ReloadRule => ({
@@ -366,6 +378,25 @@ function extractAccountIdFromPath(channel: ChannelId, path: string): string | nu
   return id;
 }
 
+function isResolvableChannelAccount(params: {
+  plugin: ChannelPlugin | undefined;
+  accountId: string;
+  config: OpenClawConfig;
+}): boolean {
+  if (!params.plugin) {
+    return false;
+  }
+  try {
+    if (!params.plugin.config.listAccountIds(params.config).includes(params.accountId)) {
+      return false;
+    }
+    params.plugin.config.resolveAccount(params.config, params.accountId);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
 export function buildGatewayReloadPlan(
   changedPaths: string[],
   options: GatewayReloadPlanOptions = {},
@@ -390,11 +421,26 @@ export function buildGatewayReloadPlan(
     noopPaths: [],
   };
 
-  const applyAction = (action: ReloadAction, originatingPath: string) => {
+  const applyAction = (
+    action: ReloadAction,
+    originatingPath: string,
+    accountScopedPlugin?: ChannelPlugin,
+  ) => {
     if (action.startsWith("restart-channel-account:")) {
       const channel = action.slice("restart-channel-account:".length) as ChannelId;
       const accountId = extractAccountIdFromPath(channel, originatingPath);
       if (accountId !== null) {
+        if (
+          options.candidateConfig &&
+          !isResolvableChannelAccount({
+            plugin: accountScopedPlugin,
+            accountId,
+            config: options.candidateConfig,
+          })
+        ) {
+          plan.restartChannels.add(channel);
+          return;
+        }
         let set = restartChannelAccounts.get(channel);
         if (!set) {
           set = new Set<string>();
@@ -463,7 +509,7 @@ export function buildGatewayReloadPlan(
     }
     plan.hotReasons.push(path);
     for (const action of rule.actions ?? []) {
-      applyAction(action, path);
+      applyAction(action, path, rule.accountScopedPlugin);
     }
   }
 

--- a/src/gateway/config-reload-recovery.ts
+++ b/src/gateway/config-reload-recovery.ts
@@ -24,6 +24,7 @@ export function reloadPlanNeedsRecovery(plan: GatewayReloadPlan): boolean {
     plan.restartGmailWatcher ||
     plan.reloadPlugins ||
     plan.restartChannels.size > 0 ||
+    (plan.restartChannelAccounts?.size ?? 0) > 0 ||
     shouldRefreshContextWindowCache(plan)
   );
 }

--- a/src/gateway/config-reload.test.ts
+++ b/src/gateway/config-reload.test.ts
@@ -29,7 +29,11 @@ import {
 } from "../skills/runtime/refresh-state.js";
 import { createTestRegistry } from "../test-utils/channel-plugins.js";
 import { diffConfigPaths, diffGatewayReloadPaths } from "./config-diff.js";
-import { buildGatewayReloadPlan, resolveConfigReloadMetadata } from "./config-reload-plan.js";
+import {
+  buildGatewayReloadPlan,
+  type ChannelKind,
+  resolveConfigReloadMetadata,
+} from "./config-reload-plan.js";
 import { resolveGatewayReloadSettings } from "./config-reload-settings.js";
 import {
   type GatewayConfigReloadTransactionOwnership,
@@ -191,7 +195,7 @@ describe("buildGatewayReloadPlan", () => {
     },
     capabilities: { chatTypes: ["direct"] },
     config: {
-      listAccountIds: () => [],
+      listAccountIds: (cfg) => Object.keys(cfg.channels?.mattermost?.accounts ?? {}),
       resolveAccount: () => ({}),
     },
     reload: { configPrefixes: ["channels.mattermost"], accountScopedRestart: true },
@@ -391,34 +395,73 @@ describe("buildGatewayReloadPlan", () => {
     expect(plan.restartChannels).toEqual(new Set(["telegram"]));
   });
 
-  it("targets only changed non-default channel accounts", () => {
-    const plan = buildGatewayReloadPlan([
-      "channels.mattermost.accounts.alpha.enabled",
-      "channels.mattermost.accounts.beta.commands",
-    ]);
+  const mattermostAccountConfig = {
+    channels: {
+      mattermost: {
+        accounts: {
+          alpha: { enabled: true },
+          beta: { enabled: true },
+        },
+      },
+    },
+  } as OpenClawConfig;
 
-    expect(plan.restartChannels).toEqual(new Set());
-    expect(plan.restartChannelAccounts).toEqual(
-      new Map([["mattermost", new Set(["alpha", "beta"])]]),
-    );
-  });
+  it.each([
+    {
+      label: "targets changed named accounts",
+      paths: [
+        "channels.mattermost.accounts.alpha.enabled",
+        "channels.mattermost.accounts.beta.commands",
+      ],
+      expectedChannels: new Set<ChannelKind>(),
+      expectedAccounts: new Map<ChannelKind, Set<string>>([
+        ["mattermost", new Set(["alpha", "beta"])],
+      ]),
+    },
+    {
+      label: "promotes accounts.default changes",
+      paths: ["channels.mattermost.accounts.default.commands"],
+      expectedChannels: new Set<ChannelKind>(["mattermost"]),
+      expectedAccounts: new Map<ChannelKind, Set<string>>(),
+    },
+    {
+      label: "promotes channel-global changes",
+      paths: ["channels.mattermost.botToken"],
+      expectedChannels: new Set<ChannelKind>(["mattermost"]),
+      expectedAccounts: new Map<ChannelKind, Set<string>>(),
+    },
+    {
+      label: "promotes unlisted account changes",
+      paths: ["channels.mattermost.accounts.removed.enabled"],
+      expectedChannels: new Set<ChannelKind>(["mattermost"]),
+      expectedAccounts: new Map<ChannelKind, Set<string>>(),
+    },
+    {
+      label: "lets an unlisted account replace earlier scoped targets",
+      paths: [
+        "channels.mattermost.accounts.alpha.enabled",
+        "channels.mattermost.accounts.removed.enabled",
+      ],
+      expectedChannels: new Set<ChannelKind>(["mattermost"]),
+      expectedAccounts: new Map<ChannelKind, Set<string>>(),
+    },
+    {
+      label: "lets a mixed global change replace scoped targets",
+      paths: ["channels.mattermost.accounts.alpha.enabled", "channels.mattermost.botToken"],
+      expectedChannels: new Set<ChannelKind>(["mattermost"]),
+      expectedAccounts: new Map<ChannelKind, Set<string>>(),
+    },
+    {
+      label: "keeps non-opted-in channels wholesale",
+      paths: ["channels.telegram.accounts.alpha.enabled"],
+      expectedChannels: new Set<ChannelKind>(["telegram"]),
+      expectedAccounts: new Map<ChannelKind, Set<string>>(),
+    },
+  ])("$label", ({ paths, expectedChannels, expectedAccounts }) => {
+    const plan = buildGatewayReloadPlan(paths, { candidateConfig: mattermostAccountConfig });
 
-  it("keeps non-isolated channel account changes on the wholesale path", () => {
-    const plan = buildGatewayReloadPlan(["channels.telegram.accounts.alpha.enabled"]);
-
-    expect(plan.restartChannels).toEqual(new Set(["telegram"]));
-    expect(plan.restartChannelAccounts).toEqual(new Map());
-  });
-
-  it("keeps default account and channel-wide changes on the wholesale path", () => {
-    const plan = buildGatewayReloadPlan([
-      "channels.mattermost.accounts.alpha.enabled",
-      "channels.mattermost.accounts.default.commands",
-      "channels.mattermost.botToken",
-    ]);
-
-    expect(plan.restartChannels).toEqual(new Set(["mattermost"]));
-    expect(plan.restartChannelAccounts).toEqual(new Map());
+    expect(plan.restartChannels).toEqual(expectedChannels);
+    expect(plan.restartChannelAccounts).toEqual(expectedAccounts);
   });
 
   it("restarts every channel whose config prefix matches", () => {

--- a/src/gateway/config-reload.test.ts
+++ b/src/gateway/config-reload.test.ts
@@ -14,6 +14,7 @@ import type { PluginInstallRecord } from "../config/types.plugins.js";
 import {
   pinActivePluginChannelRegistry,
   pinActivePluginHttpRouteRegistry,
+  releasePinnedPluginChannelRegistry,
   resetPluginRuntimeStateForTest,
   setActivePluginRegistry,
 } from "../plugins/runtime.js";
@@ -371,6 +372,29 @@ describe("buildGatewayReloadPlan", () => {
     const plan = buildGatewayReloadPlan(["channels.telegram.botToken"]);
     expect(plan.restartGateway).toBe(false);
     expect(plan.restartChannels).toEqual(new Set(["telegram"]));
+  });
+
+  it("targets only changed non-default channel accounts", () => {
+    const plan = buildGatewayReloadPlan([
+      "channels.telegram.accounts.alpha.enabled",
+      "channels.telegram.accounts.beta.commands",
+    ]);
+
+    expect(plan.restartChannels).toEqual(new Set());
+    expect(plan.restartChannelAccounts).toEqual(
+      new Map([["telegram", new Set(["alpha", "beta"])]]),
+    );
+  });
+
+  it("keeps default account and channel-wide changes on the wholesale path", () => {
+    const plan = buildGatewayReloadPlan([
+      "channels.telegram.accounts.alpha.enabled",
+      "channels.telegram.accounts.default.commands",
+      "channels.telegram.botToken",
+    ]);
+
+    expect(plan.restartChannels).toEqual(new Set(["telegram"]));
+    expect(plan.restartChannelAccounts).toEqual(new Map());
   });
 
   it("restarts every channel whose config prefix matches", () => {
@@ -1659,6 +1683,53 @@ describe("startGatewayConfigReloader", () => {
       harness.onConfigApplied.mock.invocationCallOrder[0] ?? Number.POSITIVE_INFINITY,
     );
     await harness.reloader.stop();
+  });
+
+  it("runs account-scoped channel changes through hot reload", async () => {
+    const channelRegistry = createTestRegistry([
+      {
+        pluginId: "telegram",
+        plugin: {
+          id: "telegram",
+          meta: {
+            id: "telegram",
+            label: "Telegram",
+            selectionLabel: "Telegram",
+            docsPath: "/channels/telegram",
+            blurb: "test",
+          },
+          capabilities: { chatTypes: ["direct"] },
+          config: { listAccountIds: () => ["default", "alpha"], resolveAccount: () => ({}) },
+          reload: { configPrefixes: ["channels.telegram"] },
+        } satisfies ChannelPlugin,
+        source: "test",
+      },
+    ]);
+    const initialConfig = {
+      gateway: { reload: { debounceMs: 0 } },
+      channels: { telegram: { accounts: { alpha: { enabled: false } } } },
+    } as OpenClawConfig;
+    const nextConfig = {
+      gateway: { reload: { debounceMs: 0 } },
+      channels: { telegram: { accounts: { alpha: { enabled: true } } } },
+    } as OpenClawConfig;
+    const harness = createReloaderHarness(
+      vi.fn(async () => makeSnapshot({ config: nextConfig, hash: "account-reload" })),
+      { initialConfig },
+    );
+
+    pinActivePluginChannelRegistry(channelRegistry);
+    try {
+      harness.watcher.emit("change");
+      await vi.runAllTimersAsync();
+
+      const [plan] = getOnlyHotReloadCall(harness);
+      expect(plan.restartChannelAccounts).toEqual(new Map([["telegram", new Set(["alpha"])]]));
+      expect(harness.onNoopConfigCommit).not.toHaveBeenCalled();
+    } finally {
+      releasePinnedPluginChannelRegistry(channelRegistry);
+      await harness.reloader.stop();
+    }
   });
 
   it("plans one immutable runtime override snapshot per candidate", async () => {

--- a/src/gateway/config-reload.test.ts
+++ b/src/gateway/config-reload.test.ts
@@ -180,9 +180,26 @@ describe("buildGatewayReloadPlan", () => {
       noopPrefixes: ["channels.whatsapp"],
     },
   };
+  const mattermostPlugin: ChannelPlugin = {
+    id: "mattermost",
+    meta: {
+      id: "mattermost",
+      label: "Mattermost",
+      selectionLabel: "Mattermost",
+      docsPath: "/channels/mattermost",
+      blurb: "test",
+    },
+    capabilities: { chatTypes: ["direct"] },
+    config: {
+      listAccountIds: () => [],
+      resolveAccount: () => ({}),
+    },
+    reload: { configPrefixes: ["channels.mattermost"], accountScopedRestart: true },
+  };
   const registry = createTestRegistry([
     { pluginId: "telegram", plugin: telegramPlugin, source: "test" },
     { pluginId: "whatsapp", plugin: whatsappPlugin, source: "test" },
+    { pluginId: "mattermost", plugin: mattermostPlugin, source: "test" },
   ]);
   registry.reloads = [
     {
@@ -376,24 +393,31 @@ describe("buildGatewayReloadPlan", () => {
 
   it("targets only changed non-default channel accounts", () => {
     const plan = buildGatewayReloadPlan([
-      "channels.telegram.accounts.alpha.enabled",
-      "channels.telegram.accounts.beta.commands",
+      "channels.mattermost.accounts.alpha.enabled",
+      "channels.mattermost.accounts.beta.commands",
     ]);
 
     expect(plan.restartChannels).toEqual(new Set());
     expect(plan.restartChannelAccounts).toEqual(
-      new Map([["telegram", new Set(["alpha", "beta"])]]),
+      new Map([["mattermost", new Set(["alpha", "beta"])]]),
     );
+  });
+
+  it("keeps non-isolated channel account changes on the wholesale path", () => {
+    const plan = buildGatewayReloadPlan(["channels.telegram.accounts.alpha.enabled"]);
+
+    expect(plan.restartChannels).toEqual(new Set(["telegram"]));
+    expect(plan.restartChannelAccounts).toEqual(new Map());
   });
 
   it("keeps default account and channel-wide changes on the wholesale path", () => {
     const plan = buildGatewayReloadPlan([
-      "channels.telegram.accounts.alpha.enabled",
-      "channels.telegram.accounts.default.commands",
-      "channels.telegram.botToken",
+      "channels.mattermost.accounts.alpha.enabled",
+      "channels.mattermost.accounts.default.commands",
+      "channels.mattermost.botToken",
     ]);
 
-    expect(plan.restartChannels).toEqual(new Set(["telegram"]));
+    expect(plan.restartChannels).toEqual(new Set(["mattermost"]));
     expect(plan.restartChannelAccounts).toEqual(new Map());
   });
 
@@ -1688,30 +1712,30 @@ describe("startGatewayConfigReloader", () => {
   it("runs account-scoped channel changes through hot reload", async () => {
     const channelRegistry = createTestRegistry([
       {
-        pluginId: "telegram",
+        pluginId: "mattermost",
         plugin: {
-          id: "telegram",
+          id: "mattermost",
           meta: {
-            id: "telegram",
-            label: "Telegram",
-            selectionLabel: "Telegram",
-            docsPath: "/channels/telegram",
+            id: "mattermost",
+            label: "Mattermost",
+            selectionLabel: "Mattermost",
+            docsPath: "/channels/mattermost",
             blurb: "test",
           },
           capabilities: { chatTypes: ["direct"] },
           config: { listAccountIds: () => ["default", "alpha"], resolveAccount: () => ({}) },
-          reload: { configPrefixes: ["channels.telegram"] },
+          reload: { configPrefixes: ["channels.mattermost"], accountScopedRestart: true },
         } satisfies ChannelPlugin,
         source: "test",
       },
     ]);
     const initialConfig = {
       gateway: { reload: { debounceMs: 0 } },
-      channels: { telegram: { accounts: { alpha: { enabled: false } } } },
+      channels: { mattermost: { accounts: { alpha: { enabled: false } } } },
     } as OpenClawConfig;
     const nextConfig = {
       gateway: { reload: { debounceMs: 0 } },
-      channels: { telegram: { accounts: { alpha: { enabled: true } } } },
+      channels: { mattermost: { accounts: { alpha: { enabled: true } } } },
     } as OpenClawConfig;
     const harness = createReloaderHarness(
       vi.fn(async () => makeSnapshot({ config: nextConfig, hash: "account-reload" })),
@@ -1724,7 +1748,7 @@ describe("startGatewayConfigReloader", () => {
       await vi.runAllTimersAsync();
 
       const [plan] = getOnlyHotReloadCall(harness);
-      expect(plan.restartChannelAccounts).toEqual(new Map([["telegram", new Set(["alpha"])]]));
+      expect(plan.restartChannelAccounts).toEqual(new Map([["mattermost", new Set(["alpha"])]]));
       expect(harness.onNoopConfigCommit).not.toHaveBeenCalled();
     } finally {
       releasePinnedPluginChannelRegistry(channelRegistry);

--- a/src/gateway/config-reload.ts
+++ b/src/gateway/config-reload.ts
@@ -531,6 +531,7 @@ export function startGatewayConfigReloader(opts: {
     const plan = buildGatewayReloadPlan(changedPaths, {
       noopPaths: pluginInstallTimestampNoopPaths,
       forceChangedPaths: pluginInstallWholeRecordPaths,
+      candidateConfig: nextConfig,
     });
     if (nextSettings.mode === "off") {
       opts.log.info("config reload disabled (gateway.reload.mode=off)");

--- a/src/gateway/config-reload.ts
+++ b/src/gateway/config-reload.ts
@@ -82,7 +82,8 @@ function isNoopReloadPlan(plan: GatewayReloadPlan): boolean {
     !plan.restartHealthMonitor &&
     !plan.reloadPlugins &&
     !plan.disposeMcpRuntimes &&
-    plan.restartChannels.size === 0
+    plan.restartChannels.size === 0 &&
+    (plan.restartChannelAccounts?.size ?? 0) === 0
   );
 }
 

--- a/src/gateway/server-aux-handlers.test.ts
+++ b/src/gateway/server-aux-handlers.test.ts
@@ -47,6 +47,7 @@ function createReloadPlan(overrides?: Partial<GatewayReloadPlan>): GatewayReload
     restartHealthMonitor: overrides?.restartHealthMonitor ?? false,
     reloadPlugins: overrides?.reloadPlugins ?? false,
     restartChannels: overrides?.restartChannels ?? new Set(),
+    restartChannelAccounts: overrides?.restartChannelAccounts,
     disposeMcpRuntimes: overrides?.disposeMcpRuntimes ?? false,
     noopPaths: overrides?.noopPaths ?? [],
   };
@@ -301,6 +302,34 @@ describe("gateway aux handlers", () => {
     expect(
       startChannel.mock.calls.map(([ch]) => ch).toSorted((a, b) => a.localeCompare(b)),
     ).toEqual(["slack", "zalo"]);
+    expect(respond).toHaveBeenCalledWith(true, { ok: true, warningCount: 0 });
+  });
+
+  it("restarts the whole channel when a secret change is scoped to one account", async () => {
+    // secrets.reload has no per-account restart path — account-scoped plan
+    // entries must still produce a channel restart so rotated credentials
+    // are applied.
+    const buildReloadPlan = () =>
+      createReloadPlan({
+        restartChannels: new Set(),
+        restartChannelAccounts: new Map([["slack", new Set(["ops"])]]),
+      });
+    activateSnapshot(slackConfig("old-slack-secret"));
+    const prepared = createSnapshot(slackConfig("new-slack-secret"));
+    const activateRuntimeSecrets = vi.fn().mockImplementation(async () => {
+      activateSecretsRuntimeSnapshot(prepared);
+      return prepared;
+    });
+    const { reload, respond, startChannel, stopChannel } =
+      createSecretsReloadHarnessWithChannelMocks({
+        activateRuntimeSecrets,
+        buildReloadPlan,
+      });
+
+    await reload();
+
+    expect(stopChannel.mock.calls.map(([ch]) => ch)).toEqual(["slack"]);
+    expect(startChannel.mock.calls.map(([ch]) => ch)).toEqual(["slack"]);
     expect(respond).toHaveBeenCalledWith(true, { ok: true, warningCount: 0 });
   });
 

--- a/src/gateway/server-aux-handlers.test.ts
+++ b/src/gateway/server-aux-handlers.test.ts
@@ -316,10 +316,7 @@ describe("gateway aux handlers", () => {
       });
     activateSnapshot(slackConfig("old-slack-secret"));
     const prepared = createSnapshot(slackConfig("new-slack-secret"));
-    const activateRuntimeSecrets = vi.fn().mockImplementation(async () => {
-      activateSecretsRuntimeSnapshot(prepared);
-      return prepared;
-    });
+    const activateRuntimeSecrets = vi.fn().mockResolvedValue(prepared);
     const { reload, respond, startChannel, stopChannel } =
       createSecretsReloadHarnessWithChannelMocks({
         activateRuntimeSecrets,

--- a/src/gateway/server-aux-handlers.ts
+++ b/src/gateway/server-aux-handlers.ts
@@ -361,8 +361,15 @@ export function createGatewayAuxHandlers(params: {
                     expectedGeneration: nextSharedGatewaySessionGeneration,
                   });
                 }
-                if (plan.restartChannels.size > 0) {
-                  const restartChannels = [...plan.restartChannels];
+                // Account-scoped changes restart their whole channel here:
+                // secrets.reload has no per-account restart path, and a missed
+                // restart would leave rotated credentials unapplied.
+                const channelsToRestart = new Set<ChannelKind>([
+                  ...plan.restartChannels,
+                  ...(plan.restartChannelAccounts?.keys() ?? []),
+                ]);
+                if (channelsToRestart.size > 0) {
+                  const restartChannels = [...channelsToRestart];
                   if (
                     isTruthyEnvValue(process.env.OPENCLAW_SKIP_CHANNELS) ||
                     isTruthyEnvValue(process.env.OPENCLAW_SKIP_PROVIDERS)

--- a/src/gateway/server-methods/config-write-flow.ts
+++ b/src/gateway/server-methods/config-write-flow.ts
@@ -141,7 +141,8 @@ function isNoopConfigReloadPlan(plan: ReturnType<typeof buildGatewayReloadPlan>)
     !plan.restartHealthMonitor &&
     !plan.reloadPlugins &&
     !plan.disposeMcpRuntimes &&
-    plan.restartChannels.size === 0
+    plan.restartChannels.size === 0 &&
+    (plan.restartChannelAccounts?.size ?? 0) === 0
   );
 }
 
@@ -150,7 +151,7 @@ function resolveConfigRestartRequirement(params: {
   nextConfig: OpenClawConfig;
 }): { requiresRestart: boolean; scheduleDirectRestart: boolean } {
   const reloadSettings = resolveGatewayReloadSettings(params.nextConfig);
-  const plan = buildGatewayReloadPlan(params.changedPaths);
+  const plan = buildGatewayReloadPlan(params.changedPaths, { candidateConfig: params.nextConfig });
   if (isNoopConfigReloadPlan(plan)) {
     return { requiresRestart: false, scheduleDirectRestart: false };
   }

--- a/src/gateway/server-reload-handlers.test.ts
+++ b/src/gateway/server-reload-handlers.test.ts
@@ -3130,14 +3130,17 @@ describe("gateway channel hot reload handlers", () => {
     };
   }
 
-  async function withDiscordAccounts(accountIds: string[], run: () => Promise<void>) {
+  async function withDiscordAccountResolver(
+    listAccountIds: () => string[],
+    run: () => Promise<void>,
+  ) {
     const registry = createTestRegistry([
       {
         pluginId: "discord",
         plugin: {
           ...createChannelTestPluginBase({
             id: "discord",
-            config: { listAccountIds: () => accountIds },
+            config: { listAccountIds },
           }),
         },
         source: "test",
@@ -3149,6 +3152,10 @@ describe("gateway channel hot reload handlers", () => {
     } finally {
       releasePinnedPluginChannelRegistry(registry);
     }
+  }
+
+  async function withDiscordAccounts(accountIds: string[], run: () => Promise<void>) {
+    await withDiscordAccountResolver(() => accountIds, run);
   }
 
   it("restarts only the changed account", async () => {
@@ -3234,6 +3241,101 @@ describe("gateway channel hot reload handlers", () => {
     });
 
     expect(events).toEqual(["stop:discord:undefined", "start:discord:undefined"]);
+  });
+
+  it("requests recovery when account enumeration fails after config commit", async () => {
+    const channels = {
+      stop: vi.fn(async () => {}),
+      start: vi.fn(async () => {}),
+    };
+    const requestRecoveryRestart = vi.fn(() => ({ status: "emitted" as const }));
+    const { applyHotReload } = createReloadHandlersForTest(
+      undefined,
+      channels,
+      undefined,
+      undefined,
+      requestRecoveryRestart,
+    );
+
+    await withChannelReloadsEnabled(async () => {
+      await withDiscordAccountResolver(
+        () => {
+          throw new Error("account enumeration failed");
+        },
+        async () => {
+          await applyHotReload(createAccountReloadPlan(["alpha"]), {});
+        },
+      );
+    });
+
+    expect(channels.stop).not.toHaveBeenCalled();
+    expect(channels.start).not.toHaveBeenCalled();
+    expect(requestRecoveryRestart).toHaveBeenCalledOnce();
+  });
+
+  it("skips per-account restarts for channels already queued for wholesale restart", async () => {
+    const events: string[] = [];
+    const channels = {
+      stop: vi.fn(async (channel: ChannelKind, accountId?: string) => {
+        events.push(`stop:${channel}:${accountId}`);
+      }),
+      start: vi.fn(async (channel: ChannelKind, accountId?: string) => {
+        events.push(`start:${channel}:${accountId}`);
+      }),
+    };
+    const { applyHotReload } = createReloadHandlersForTest(undefined, channels);
+
+    await withChannelReloadsEnabled(async () => {
+      await withDiscordAccounts(["default", "alpha"], async () => {
+        await applyHotReload(
+          createAccountReloadPlan(["alpha"], { restartChannels: new Set(["discord"]) }),
+          {},
+        );
+      });
+    });
+
+    expect(events).toEqual(["stop:discord:undefined", "start:discord:undefined"]);
+  });
+
+  it("aggregates targeted and wholesale stop failures into one suppressed recovery request", async () => {
+    const events: string[] = [];
+    const channels = {
+      stop: vi.fn(async (channel: ChannelKind, accountId?: string) => {
+        events.push(`stop:${channel}:${accountId}`);
+        throw new Error("stop failed");
+      }),
+      start: vi.fn(async (channel: ChannelKind, accountId?: string) => {
+        events.push(`start:${channel}:${accountId}`);
+      }),
+    };
+    const requestRecoveryRestart = vi.fn(() => ({ status: "emitted" as const }));
+    const { applyHotReload } = createReloadHandlersForTest(
+      undefined,
+      channels,
+      undefined,
+      undefined,
+      requestRecoveryRestart,
+      {
+        getChannelAutostartSuppression: () => ({
+          reason: "crash-loop-breaker",
+          message: "safe mode",
+        }),
+      },
+    );
+
+    await withChannelReloadsEnabled(async () => {
+      await withDiscordAccounts(["default", "alpha"], async () => {
+        await applyHotReload(
+          createAccountReloadPlan(["alpha"], {
+            restartChannels: new Set<ChannelKind>(["telegram"]),
+          }),
+          {},
+        );
+      });
+    });
+
+    expect(events).toEqual(["stop:discord:alpha", "stop:telegram:undefined"]);
+    expect(requestRecoveryRestart).toHaveBeenCalledOnce();
   });
 
   it("stops account targets without restarting them while autostart is suppressed", async () => {

--- a/src/gateway/server-reload-handlers.test.ts
+++ b/src/gateway/server-reload-handlers.test.ts
@@ -332,12 +332,15 @@ function createDeferredVoid() {
 function createReloadHandlersForTest(
   logReload = { info: vi.fn(), warn: vi.fn() },
   channels?: {
-    start: (channel: ChannelKind) => Promise<void>;
-    stop: (channel: ChannelKind) => Promise<void>;
+    start: ReloadHandlerParams["startChannel"];
+    stop: ReloadHandlerParams["stopChannel"];
   },
   reloadPlugins?: Parameters<typeof createGatewayReloadHandlers>[0]["reloadPlugins"],
   stopPostReadySidecars = vi.fn(),
   recovery: boolean | NonNullable<ReloadHandlerParams["requestRecoveryRestart"]> = true,
+  options?: {
+    getChannelAutostartSuppression?: ReloadHandlerParams["getChannelAutostartSuppression"];
+  },
 ) {
   const cron = { start: vi.fn(async () => {}), stop: vi.fn() };
   const stopExitWatchers = vi.fn();
@@ -369,6 +372,7 @@ function createReloadHandlersForTest(
     setState,
     startChannel: channels?.start ?? vi.fn(async () => {}),
     stopChannel: channels?.stop ?? vi.fn(async () => {}),
+    getChannelAutostartSuppression: options?.getChannelAutostartSuppression,
     stopPostReadySidecars,
     reloadPlugins:
       reloadPlugins ??
@@ -3113,6 +3117,206 @@ describe("gateway channel hot reload handlers", () => {
       }
     }
   }
+
+  function createAccountReloadPlan(
+    accountIds: string[],
+    overrides: Partial<GatewayReloadPlan> = {},
+  ): GatewayReloadPlan {
+    return {
+      ...createChannelReloadPlan([]),
+      changedPaths: accountIds.map((accountId) => `channels.discord.accounts.${accountId}`),
+      restartChannelAccounts: new Map([["discord", new Set(accountIds)]]),
+      ...overrides,
+    };
+  }
+
+  async function withDiscordAccounts(accountIds: string[], run: () => Promise<void>) {
+    const registry = createTestRegistry([
+      {
+        pluginId: "discord",
+        plugin: {
+          ...createChannelTestPluginBase({
+            id: "discord",
+            config: { listAccountIds: () => accountIds },
+          }),
+        },
+        source: "test",
+      },
+    ]);
+    pinActivePluginChannelRegistry(registry);
+    try {
+      await run();
+    } finally {
+      releasePinnedPluginChannelRegistry(registry);
+    }
+  }
+
+  it("restarts only the changed account", async () => {
+    const events: string[] = [];
+    const channels = {
+      stop: vi.fn(async (channel: ChannelKind, accountId?: string) => {
+        events.push(`stop:${channel}:${accountId}`);
+      }),
+      start: vi.fn(async (channel: ChannelKind, accountId?: string) => {
+        events.push(`start:${channel}:${accountId}`);
+      }),
+    };
+    const { applyHotReload } = createReloadHandlersForTest(undefined, channels);
+
+    await withChannelReloadsEnabled(async () => {
+      await withDiscordAccounts(["default", "alpha", "beta"], async () => {
+        await applyHotReload(createAccountReloadPlan(["alpha"]), {});
+      });
+    });
+
+    expect(events).toEqual(["stop:discord:alpha", "start:discord:alpha"]);
+  });
+
+  it("continues targeted restarts after an account failure", async () => {
+    const events: string[] = [];
+    const channels = {
+      stop: vi.fn(async (channel: ChannelKind, accountId?: string) => {
+        events.push(`stop:${channel}:${accountId}`);
+        if (accountId === "alpha") {
+          throw new Error("stop failed");
+        }
+      }),
+      start: vi.fn(async (channel: ChannelKind, accountId?: string) => {
+        events.push(`start:${channel}:${accountId}`);
+      }),
+    };
+    const requestRecoveryRestart = vi.fn(() => ({ status: "emitted" as const }));
+    const { applyHotReload } = createReloadHandlersForTest(
+      undefined,
+      channels,
+      undefined,
+      undefined,
+      requestRecoveryRestart,
+    );
+
+    await withChannelReloadsEnabled(async () => {
+      await withDiscordAccounts(["default", "alpha", "beta"], async () => {
+        await applyHotReload(createAccountReloadPlan(["alpha", "beta"]), {});
+      });
+    });
+
+    expect(events).toEqual(["stop:discord:alpha", "stop:discord:beta", "start:discord:beta"]);
+    expect(requestRecoveryRestart).toHaveBeenCalledOnce();
+  });
+
+  it("promotes unlisted accounts to a wholesale restart", async () => {
+    const events: string[] = [];
+    const channels = {
+      stop: vi.fn(async (channel: ChannelKind, accountId?: string) => {
+        events.push(`stop:${channel}:${accountId}`);
+      }),
+      start: vi.fn(async (channel: ChannelKind, accountId?: string) => {
+        events.push(`start:${channel}:${accountId}`);
+      }),
+    };
+    const { applyHotReload } = createReloadHandlersForTest(undefined, channels);
+
+    await withChannelReloadsEnabled(async () => {
+      await withDiscordAccounts(["default", "alpha"], async () => {
+        await applyHotReload(createAccountReloadPlan(["removed-account"]), {});
+      });
+    });
+
+    expect(events).toEqual(["stop:discord:undefined", "start:discord:undefined"]);
+  });
+
+  it("stops account targets without restarting them while autostart is suppressed", async () => {
+    const events: string[] = [];
+    const channels = {
+      stop: vi.fn(async (channel: ChannelKind, accountId?: string) => {
+        events.push(`stop:${channel}:${accountId}`);
+      }),
+      start: vi.fn(async (channel: ChannelKind, accountId?: string) => {
+        events.push(`start:${channel}:${accountId}`);
+      }),
+    };
+    const { applyHotReload } = createReloadHandlersForTest(
+      undefined,
+      channels,
+      undefined,
+      undefined,
+      true,
+      {
+        getChannelAutostartSuppression: () => ({
+          reason: "crash-loop-breaker",
+          message: "safe mode",
+        }),
+      },
+    );
+
+    await withChannelReloadsEnabled(async () => {
+      await withDiscordAccounts(["default", "alpha"], async () => {
+        await applyHotReload(createAccountReloadPlan(["alpha"]), {});
+      });
+    });
+
+    expect(events).toEqual(["stop:discord:alpha"]);
+  });
+
+  it("defers account restarts when a plugin reload did not stop a channel", async () => {
+    const events: string[] = [];
+    const channels = {
+      stop: vi.fn(async (channel: ChannelKind, accountId?: string) => {
+        events.push(`stop:${channel}:${accountId}`);
+      }),
+      start: vi.fn(async (channel: ChannelKind, accountId?: string) => {
+        events.push(`start:${channel}:${accountId}`);
+      }),
+    };
+    const reloadPlugins = vi.fn(
+      async (): Promise<GatewayPluginReloadResult> => ({
+        restartChannels: new Set(),
+        activeChannels: new Set(["discord"]),
+      }),
+    );
+    const logReload = { info: vi.fn(), warn: vi.fn() };
+    const { applyHotReload } = createReloadHandlersForTest(logReload, channels, reloadPlugins);
+    hoisted.activeEmbeddedRunCount.value = 1;
+    vi.useFakeTimers();
+    let reload: Promise<void> | undefined;
+
+    try {
+      await withChannelReloadsEnabled(async () => {
+        await withDiscordAccounts(["default", "alpha"], async () => {
+          reload = applyHotReload(createAccountReloadPlan(["alpha"], { reloadPlugins: true }), {});
+          await vi.advanceTimersByTimeAsync(0);
+          expect(events).toEqual([]);
+          expect(logReload.warn).toHaveBeenCalledWith(expect.stringContaining("(discord)"));
+
+          hoisted.activeEmbeddedRunCount.value = 0;
+          await vi.advanceTimersByTimeAsync(500);
+          await reload;
+        });
+      });
+    } finally {
+      hoisted.activeEmbeddedRunCount.value = 0;
+      await vi.advanceTimersByTimeAsync(500).catch(() => {});
+      vi.useRealTimers();
+      await reload?.catch(() => {});
+    }
+
+    expect(events).toEqual(["stop:discord:alpha", "start:discord:alpha"]);
+    expect(reloadPlugins).toHaveBeenCalledOnce();
+  });
+
+  it("requires a recovery owner for targeted account reloads", async () => {
+    const { applyHotReload } = createReloadHandlersForTest(
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      false,
+    );
+
+    await expect(applyHotReload(createAccountReloadPlan(["alpha"]), {})).rejects.toThrow(
+      "config reload requires a managed gateway restart owner for irreversible hot reload",
+    );
+  });
 
   it("refuses channel restarts while crash-loop safe mode suppresses autostart", async () => {
     const logChannels = { info: vi.fn(), error: vi.fn() };

--- a/src/gateway/server-reload-handlers.test.ts
+++ b/src/gateway/server-reload-handlers.test.ts
@@ -3407,7 +3407,7 @@ describe("gateway channel hot reload handlers", () => {
     expect(events).toEqual(["stop:discord:alpha"]);
   });
 
-  it("defers account restarts when a plugin reload did not stop a channel", async () => {
+  it("re-drains account work admitted after plugin reload leaves the channel running", async () => {
     const events: string[] = [];
     const channels = {
       stop: vi.fn(async (channel: ChannelKind, accountId?: string) => {
@@ -3417,15 +3417,16 @@ describe("gateway channel hot reload handlers", () => {
         events.push(`start:${channel}:${accountId}`);
       }),
     };
-    const reloadPlugins = vi.fn(
-      async (): Promise<GatewayPluginReloadResult> => ({
+    const reloadPlugins = vi.fn(async (params): Promise<GatewayPluginReloadResult> => {
+      await params.beforeReplace(new Set());
+      hoisted.activeEmbeddedRunCount.value = 1;
+      return {
         restartChannels: new Set(),
         activeChannels: new Set(["discord"]),
-      }),
-    );
+      };
+    });
     const logReload = { info: vi.fn(), warn: vi.fn() };
     const { applyHotReload } = createReloadHandlersForTest(logReload, channels, reloadPlugins);
-    hoisted.activeEmbeddedRunCount.value = 1;
     vi.useFakeTimers();
     let reload: Promise<void> | undefined;
 

--- a/src/gateway/server-reload-handlers.test.ts
+++ b/src/gateway/server-reload-handlers.test.ts
@@ -3164,9 +3164,11 @@ describe("gateway channel hot reload handlers", () => {
   it("restarts only the changed account", async () => {
     const events: string[] = [];
     const startRootCounts: number[] = [];
+    const accountStopSettled = createDeferredVoid();
     const channels = {
       stop: vi.fn(async (channel: ChannelKind, accountId?: string) => {
         events.push(`stop:${channel}:${accountId}`);
+        await accountStopSettled.promise;
       }),
       start: vi.fn(async (channel: ChannelKind, accountId?: string) => {
         events.push(`start:${channel}:${accountId}`);
@@ -3176,21 +3178,31 @@ describe("gateway channel hot reload handlers", () => {
     const { applyHotReload } = createReloadHandlersForTest(undefined, channels);
     const root = tryBeginGatewayRootWorkAdmission();
     expect(root).not.toBeNull();
+    let reload: Promise<void> | undefined;
 
     try {
       await root?.run(async () => {
         await withChannelReloadsEnabled(async () => {
           await withDiscordAccounts(["default", "alpha", "beta"], async () => {
-            await applyHotReload(createAccountReloadPlan(["alpha"]), {});
+            reload = applyHotReload(createAccountReloadPlan(["alpha"]), {});
+            await waitForFast(() => expect(events).toEqual(["stop:discord:alpha"]));
+            expect(channels.start).not.toHaveBeenCalled();
+
+            accountStopSettled.resolve();
+            await reload;
           });
         });
       });
     } finally {
+      accountStopSettled.resolve();
+      await reload?.catch(() => {});
       root?.release();
     }
 
     expect(events).toEqual(["stop:discord:alpha", "start:discord:alpha"]);
     expect(startRootCounts).toEqual([1]);
+    expect(channels.stop).toHaveBeenCalledOnce();
+    expect(channels.start).toHaveBeenCalledOnce();
   });
 
   it("continues targeted restarts after an account failure", async () => {
@@ -3407,7 +3419,7 @@ describe("gateway channel hot reload handlers", () => {
     expect(events).toEqual(["stop:discord:alpha"]);
   });
 
-  it("re-drains account work admitted after plugin reload leaves the channel running", async () => {
+  it("rechecks agent work admitted after plugin reload leaves the channel running", async () => {
     const events: string[] = [];
     const channels = {
       stop: vi.fn(async (channel: ChannelKind, accountId?: string) => {

--- a/src/gateway/server-reload-handlers.test.ts
+++ b/src/gateway/server-reload-handlers.test.ts
@@ -365,6 +365,7 @@ function createReloadHandlersForTest(
   });
   const cronReconciliation = createTestCronReconciliation();
   const logCron = { error: vi.fn() };
+  const logChannels = { info: vi.fn(), error: vi.fn() };
   const handlers = createGatewayReloadHandlers({
     deps: {} as never,
     broadcast: vi.fn(),
@@ -383,7 +384,7 @@ function createReloadHandlersForTest(
         }),
       ),
     logHooks: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
-    logChannels: { info: vi.fn(), error: vi.fn() },
+    logChannels,
     logCron,
     logReload,
     cronReconciliation,
@@ -401,6 +402,7 @@ function createReloadHandlersForTest(
     cron,
     cronReconciliation,
     heartbeatRunner,
+    logChannels,
     logCron,
     setState,
     stopExitWatchers,
@@ -3133,6 +3135,7 @@ describe("gateway channel hot reload handlers", () => {
   async function withDiscordAccountResolver(
     listAccountIds: () => string[],
     run: () => Promise<void>,
+    resolveAccount: (cfg: OpenClawConfig, accountId?: string | null) => unknown = () => ({}),
   ) {
     const registry = createTestRegistry([
       {
@@ -3140,7 +3143,7 @@ describe("gateway channel hot reload handlers", () => {
         plugin: {
           ...createChannelTestPluginBase({
             id: "discord",
-            config: { listAccountIds },
+            config: { listAccountIds, resolveAccount },
           }),
         },
         source: "test",
@@ -3241,6 +3244,39 @@ describe("gateway channel hot reload handlers", () => {
     });
 
     expect(events).toEqual(["stop:discord:undefined", "start:discord:undefined"]);
+  });
+
+  it("promotes unresolvable accounts to a wholesale restart before stopping any account", async () => {
+    const events: string[] = [];
+    const channels = {
+      stop: vi.fn(async (channel: ChannelKind, accountId?: string) => {
+        events.push(`stop:${channel}:${accountId}`);
+      }),
+      start: vi.fn(async (channel: ChannelKind, accountId?: string) => {
+        events.push(`start:${channel}:${accountId}`);
+      }),
+    };
+    const { applyHotReload, logChannels } = createReloadHandlersForTest(undefined, channels);
+
+    await withChannelReloadsEnabled(async () => {
+      await withDiscordAccountResolver(
+        () => ["default", "alpha", "beta"],
+        async () => {
+          await applyHotReload(createAccountReloadPlan(["alpha", "beta"]), {});
+        },
+        (_cfg, accountId) => {
+          if (accountId === "beta") {
+            throw new Error("account resolution failed");
+          }
+          return {};
+        },
+      );
+    });
+
+    expect(events).toEqual(["stop:discord:undefined", "start:discord:undefined"]);
+    expect(logChannels.info).toHaveBeenCalledWith(
+      "promoting discord account reload to whole-channel restart after account resolution failed: account resolution failed",
+    );
   });
 
   it("requests recovery when account enumeration fails after config commit", async () => {

--- a/src/gateway/server-reload-handlers.test.ts
+++ b/src/gateway/server-reload-handlers.test.ts
@@ -3153,23 +3153,34 @@ describe("gateway channel hot reload handlers", () => {
 
   it("restarts only the changed account", async () => {
     const events: string[] = [];
+    const startRootCounts: number[] = [];
     const channels = {
       stop: vi.fn(async (channel: ChannelKind, accountId?: string) => {
         events.push(`stop:${channel}:${accountId}`);
       }),
       start: vi.fn(async (channel: ChannelKind, accountId?: string) => {
         events.push(`start:${channel}:${accountId}`);
+        startRootCounts.push(getActiveGatewayRootWorkCount({ excludeCurrent: true }));
       }),
     };
     const { applyHotReload } = createReloadHandlersForTest(undefined, channels);
+    const root = tryBeginGatewayRootWorkAdmission();
+    expect(root).not.toBeNull();
 
-    await withChannelReloadsEnabled(async () => {
-      await withDiscordAccounts(["default", "alpha", "beta"], async () => {
-        await applyHotReload(createAccountReloadPlan(["alpha"]), {});
+    try {
+      await root?.run(async () => {
+        await withChannelReloadsEnabled(async () => {
+          await withDiscordAccounts(["default", "alpha", "beta"], async () => {
+            await applyHotReload(createAccountReloadPlan(["alpha"]), {});
+          });
+        });
       });
-    });
+    } finally {
+      root?.release();
+    }
 
     expect(events).toEqual(["stop:discord:alpha", "start:discord:alpha"]);
+    expect(startRootCounts).toEqual([1]);
   });
 
   it("continues targeted restarts after an account failure", async () => {

--- a/src/gateway/server-reload-handlers.ts
+++ b/src/gateway/server-reload-handlers.ts
@@ -1039,7 +1039,9 @@ export function createGatewayReloadHandlers(params: GatewayReloadHandlerParams) 
               if (isLifecycleReloadAborted()) {
                 continue;
               }
-              await params.startChannel(channel, accountId);
+              await runOutsideGatewayRootWorkAdmission(() =>
+                params.startChannel(channel, accountId),
+              );
             } catch (err) {
               accountRestartFailures.push(`${channel}[${accountId}]`);
               params.logChannels.error(

--- a/src/gateway/server-reload-handlers.ts
+++ b/src/gateway/server-reload-handlers.ts
@@ -960,9 +960,15 @@ export function createGatewayReloadHandlers(params: GatewayReloadHandlerParams) 
         ) {
           continue;
         }
-        const listedAccountIds = new Set(
-          getChannelPlugin(channel)?.config.listAccountIds(nextConfig) ?? [],
-        );
+        let listedAccountIds: Set<string>;
+        try {
+          listedAccountIds = new Set(
+            getChannelPlugin(channel)?.config.listAccountIds(nextConfig) ?? [],
+          );
+        } catch (err) {
+          scheduleRecoveryRestart(`channel account enumeration (${channel})`, err);
+          continue;
+        }
         if ([...accountIds].some((accountId) => !listedAccountIds.has(accountId))) {
           channelsToRestart.add(channel);
           continue;

--- a/src/gateway/server-reload-handlers.ts
+++ b/src/gateway/server-reload-handlers.ts
@@ -874,6 +874,8 @@ export function createGatewayReloadHandlers(params: GatewayReloadHandlerParams) 
     const hasLiveChannelTargets = [...channelTargets].some(
       (channel) => !channelsStoppedBeforePluginReload.has(channel),
     );
+    // Plugin replacement can admit new agent work while an account monitor stays live.
+    // Recheck that work here; durable ingress replay remains owned by the fresh monitor drain.
     if (!pluginReloadAborted && hasLiveChannelTargets && !shouldSkipChannelRestart) {
       pluginReloadAborted = await waitForActiveWorkBeforeChannelReload(
         channelTargets,

--- a/src/gateway/server-reload-handlers.ts
+++ b/src/gateway/server-reload-handlers.ts
@@ -960,16 +960,26 @@ export function createGatewayReloadHandlers(params: GatewayReloadHandlerParams) 
         ) {
           continue;
         }
+        const plugin = getChannelPlugin(channel);
         let listedAccountIds: Set<string>;
         try {
-          listedAccountIds = new Set(
-            getChannelPlugin(channel)?.config.listAccountIds(nextConfig) ?? [],
-          );
+          listedAccountIds = new Set(plugin?.config.listAccountIds(nextConfig) ?? []);
         } catch (err) {
           scheduleRecoveryRestart(`channel account enumeration (${channel})`, err);
           continue;
         }
         if ([...accountIds].some((accountId) => !listedAccountIds.has(accountId))) {
+          channelsToRestart.add(channel);
+          continue;
+        }
+        try {
+          for (const accountId of accountIds) {
+            plugin?.config.resolveAccount(nextConfig, accountId);
+          }
+        } catch (err) {
+          params.logChannels.info(
+            `promoting ${channel} account reload to whole-channel restart after account resolution failed: ${formatErrorMessage(err)}`,
+          );
           channelsToRestart.add(channel);
           continue;
         }

--- a/src/gateway/server-reload-handlers.ts
+++ b/src/gateway/server-reload-handlers.ts
@@ -568,7 +568,6 @@ export function createGatewayReloadHandlers(params: GatewayReloadHandlerParams) 
     const channelsStoppedBeforePluginReload = new Set<ChannelKind>();
     let activePluginChannelsAfterReload: ReadonlySet<ChannelKind> | null = null;
     let pluginReloadAborted = false;
-    let pluginReloadDeferredActiveWork = false;
     const isLifecycleReloadAborted = () =>
       abortGeneration !== undefined && myGeneration <= abortGeneration;
     const isPluginReloadAborted = () =>
@@ -774,7 +773,6 @@ export function createGatewayReloadHandlers(params: GatewayReloadHandlerParams) 
           pluginReloadAborted = true;
           return;
         }
-        pluginReloadDeferredActiveWork = true;
         const stopFailures = await collectChannelOperationFailures({
           channels: channelsToRestart,
           run: async (channel) => {
@@ -873,7 +871,10 @@ export function createGatewayReloadHandlers(params: GatewayReloadHandlerParams) 
     }
 
     const channelTargets = channelReloadTargets();
-    if (!pluginReloadDeferredActiveWork && channelTargets.size > 0 && !shouldSkipChannelRestart) {
+    const hasLiveChannelTargets = [...channelTargets].some(
+      (channel) => !channelsStoppedBeforePluginReload.has(channel),
+    );
+    if (!pluginReloadAborted && hasLiveChannelTargets && !shouldSkipChannelRestart) {
       pluginReloadAborted = await waitForActiveWorkBeforeChannelReload(
         channelTargets,
         nextConfig,

--- a/src/gateway/server-reload-handlers.ts
+++ b/src/gateway/server-reload-handlers.ts
@@ -10,6 +10,7 @@ import {
   warmCurrentProviderAuthStateOffMainThread,
 } from "../agents/model-provider-auth.js";
 import { getTotalPendingReplies } from "../auto-reply/reply/dispatcher-registry.js";
+import { getChannelPlugin } from "../channels/plugins/index.js";
 import type { CliDeps } from "../cli/deps.types.js";
 import { isRestartEnabled } from "../config/commands.flags.js";
 import { getConfigValueAtPath } from "../config/config-paths.js";
@@ -562,9 +563,12 @@ export function createGatewayReloadHandlers(params: GatewayReloadHandlerParams) 
     resetDirectoryCache();
 
     const channelsToRestart = new Set(plan.restartChannels);
+    const restartChannelAccounts =
+      plan.restartChannelAccounts ?? new Map<ChannelKind, Set<string>>();
     const channelsStoppedBeforePluginReload = new Set<ChannelKind>();
     let activePluginChannelsAfterReload: ReadonlySet<ChannelKind> | null = null;
     let pluginReloadAborted = false;
+    let pluginReloadDeferredActiveWork = false;
     const isLifecycleReloadAborted = () =>
       abortGeneration !== undefined && myGeneration <= abortGeneration;
     const isPluginReloadAborted = () =>
@@ -578,6 +582,8 @@ export function createGatewayReloadHandlers(params: GatewayReloadHandlerParams) 
     const shouldSkipChannelRestart =
       isTruthyEnvValue(candidateEnv.OPENCLAW_SKIP_CHANNELS) ||
       isTruthyEnvValue(candidateEnv.OPENCLAW_SKIP_PROVIDERS);
+    const channelReloadTargets = () =>
+      new Set<ChannelKind>([...channelsToRestart, ...restartChannelAccounts.keys()]);
     const getChannelAutostartSuppression = () => params.getChannelAutostartSuppression?.() ?? null;
     const logSuppressedChannelRestart = (
       channels: ReadonlySet<ChannelKind>,
@@ -757,22 +763,18 @@ export function createGatewayReloadHandlers(params: GatewayReloadHandlerParams) 
         for (const channel of channels) {
           channelsToRestart.add(channel);
         }
-        if (channelsToRestart.size === 0 || shouldSkipChannelRestart) {
+        const targets = channelReloadTargets();
+        if (targets.size === 0 || shouldSkipChannelRestart) {
           return;
         }
-        if (
-          await waitForActiveWorkBeforeChannelReload(
-            channelsToRestart,
-            nextConfig,
-            isTransactionCurrent,
-          )
-        ) {
+        if (await waitForActiveWorkBeforeChannelReload(targets, nextConfig, isTransactionCurrent)) {
           params.logChannels.info(
             "channel reload before plugin replace cancelled by config supersession or restart",
           );
           pluginReloadAborted = true;
           return;
         }
+        pluginReloadDeferredActiveWork = true;
         const stopFailures = await collectChannelOperationFailures({
           channels: channelsToRestart,
           run: async (channel) => {
@@ -870,9 +872,10 @@ export function createGatewayReloadHandlers(params: GatewayReloadHandlerParams) 
       }
     }
 
-    if (!plan.reloadPlugins && channelsToRestart.size > 0 && !shouldSkipChannelRestart) {
+    const channelTargets = channelReloadTargets();
+    if (!pluginReloadDeferredActiveWork && channelTargets.size > 0 && !shouldSkipChannelRestart) {
       pluginReloadAborted = await waitForActiveWorkBeforeChannelReload(
-        channelsToRestart,
+        channelTargets,
         nextConfig,
         isTransactionCurrent,
       );
@@ -946,7 +949,32 @@ export function createGatewayReloadHandlers(params: GatewayReloadHandlerParams) 
       }
     }
 
-    if (channelsToRestart.size > 0) {
+    // Suppressed and normal reloads share fallback selection so stale account
+    // ids always reach the wholesale path that evicts their old runtime.
+    const collectChannelAccountTargets = (): Array<[ChannelKind, string]> => {
+      const targets: Array<[ChannelKind, string]> = [];
+      for (const [channel, accountIds] of restartChannelAccounts) {
+        if (
+          channelsToRestart.has(channel) ||
+          (plan.reloadPlugins && activePluginChannelsAfterReload?.has(channel) === false)
+        ) {
+          continue;
+        }
+        const listedAccountIds = new Set(
+          getChannelPlugin(channel)?.config.listAccountIds(nextConfig) ?? [],
+        );
+        if ([...accountIds].some((accountId) => !listedAccountIds.has(accountId))) {
+          channelsToRestart.add(channel);
+          continue;
+        }
+        for (const accountId of accountIds) {
+          targets.push([channel, accountId]);
+        }
+      }
+      return targets;
+    };
+
+    if (channelsToRestart.size > 0 || restartChannelAccounts.size > 0) {
       if (shouldSkipChannelRestart) {
         params.logChannels.info(
           "skipping channel reload (OPENCLAW_SKIP_CHANNELS=1 or OPENCLAW_SKIP_PROVIDERS=1)",
@@ -956,6 +984,21 @@ export function createGatewayReloadHandlers(params: GatewayReloadHandlerParams) 
         if (cancelledByRestart) {
           params.logChannels.info("channel restart cancelled by in-process restart");
         } else {
+          const accountStops = collectChannelAccountTargets();
+          const accountStopFailures: string[] = [];
+          for (const [channel, accountId] of accountStops) {
+            try {
+              params.logChannels.info(
+                `stopping ${channel} account ${accountId} before suppressed hot reload`,
+              );
+              await params.stopChannel(channel, accountId, { manual: false });
+            } catch (err) {
+              accountStopFailures.push(`${channel}[${accountId}]`);
+              params.logChannels.error(
+                `failed to stop ${channel} account ${accountId} during suppressed hot reload: ${formatErrorMessage(err)}`,
+              );
+            }
+          }
           const stopFailures = await collectChannelOperationFailures({
             channels: channelsToRestart,
             run: async (channel) => {
@@ -976,16 +1019,34 @@ export function createGatewayReloadHandlers(params: GatewayReloadHandlerParams) 
               );
             },
           });
-          if (stopFailures.length > 0) {
-            scheduleRecoveryRestart(`channel stop (${stopFailures.join(", ")})`);
+          const allStopFailures = [...accountStopFailures, ...stopFailures];
+          if (allStopFailures.length > 0) {
+            scheduleRecoveryRestart(`channel stop (${allStopFailures.join(", ")})`);
           }
-          logSuppressedChannelRestart(channelsToRestart, "channel restart during hot reload");
+          logSuppressedChannelRestart(channelReloadTargets(), "channel restart during hot reload");
         }
       } else {
         const cancelledByRestart = pluginReloadAborted;
         if (cancelledByRestart) {
           params.logChannels.info("channel restart cancelled by in-process restart");
         } else {
+          const accountRestarts = collectChannelAccountTargets();
+          const accountRestartFailures: string[] = [];
+          for (const [channel, accountId] of accountRestarts) {
+            try {
+              params.logChannels.info(`restarting ${channel} account ${accountId}`);
+              await params.stopChannel(channel, accountId, { manual: false });
+              if (isLifecycleReloadAborted()) {
+                continue;
+              }
+              await params.startChannel(channel, accountId);
+            } catch (err) {
+              accountRestartFailures.push(`${channel}[${accountId}]`);
+              params.logChannels.error(
+                `failed to restart ${channel} account ${accountId} during hot reload: ${formatErrorMessage(err)}`,
+              );
+            }
+          }
           const restartChannel = async (name: ChannelKind) => {
             if (plan.reloadPlugins && activePluginChannelsAfterReload?.has(name) === false) {
               return;
@@ -1008,8 +1069,9 @@ export function createGatewayReloadHandlers(params: GatewayReloadHandlerParams) 
               );
             },
           });
-          if (restartFailures.length > 0) {
-            scheduleRecoveryRestart(`channel restart (${restartFailures.join(", ")})`);
+          const allRestartFailures = [...accountRestartFailures, ...restartFailures];
+          if (allRestartFailures.length > 0) {
+            scheduleRecoveryRestart(`channel restart (${allRestartFailures.join(", ")})`);
           }
         }
       }


### PR DESCRIPTION
Closes #99311

## What Problem This Solves

On Mattermost gateways running multiple accounts, a config change scoped to one account restarted the entire Mattermost channel. On a measured 9-account gateway, each account-scoped write disconnected and reconnected every account for 1.0–2.6 seconds and made `config.patch` 3–4× slower during the restart window.

## Why This Change Was Made

The reload planner now supports an explicit `reload.accountScopedRestart` channel capability. Only plugins that can prove account configuration and runtime ownership are isolated may opt in; Mattermost does. A change confined to `channels.mattermost.accounts.<non-default-id>.*` restarts only that `(channel, accountId)` pair through the existing account-aware stop/start lifecycle.

The modernization composes this scoped restart with Mattermost's account-keyed durable ingress instead of adding a second replay path. Stopping one account settles that account's accepted transport admissions and drain; the replacement monitor reopens the same account queue and recovers any durable row exactly once. A/B coverage proves that restarting account B does not settle, replay, or disturb account A.

The planner remains conservative. A seven-row promotion matrix covers named-account targeting, `accounts.default`, channel-global fields, removed or unlisted accounts, mixed scoped/unlisted changes, mixed scoped/global changes, and channels that do not opt in. Anything that can affect inheritance or cannot be resolved from the candidate config is promoted to a whole-channel restart.

Wholesale reload invariants remain intact: active-work deferral, abort-generation checks, failure aggregation, managed recovery after post-commit account-enumeration failure, plugin replacement re-drain, and `secrets.reload` fallback.

## User Impact

Mattermost operators with multi-account gateways no longer disconnect every sibling account when adding or changing one isolated account. Measured scoped reloads completed in 0.2–0.7 seconds and touched only the changed account. Telegram, WhatsApp, and other plugins retain whole-channel restart behavior unless they independently prove the isolation contract and opt in. Single-account deployments retain equivalent behavior.

## Evidence

- Original 9-account production measurement: whole-channel reloads took 1.0–2.6 seconds, caused 45 auto-restarts across 9 mounts, and made `config.patch` 3–4× slower; the scoped path touched one account in 0.2–0.7 seconds with no sibling disconnects.
- Mattermost A/B isolation plus durable-ingress recovery coverage proves account B restart settlement is isolated from account A and account B's accepted durable row is recovered exactly once.
- Seven-row planner promotion matrix covers all scoped-versus-wholesale decisions described above.
- Branch validation: 47 focused files / 872 tests green; Knip/dead-code zero across five runs; type-aware Oxlint clean; automated review clean.
- Exact rebased head `356aae2b5fb8368c1c6364862a0f476a4c5b5abe`: 5 focused files / 340 tests green; `git diff --check`; conflict-marker scan; `check-deadcode-exports` and `check-deadcode-unused-files` hard-zero gates green.
- Fresh exact-head autoreview: no accepted/actionable findings; patch correct, 0.78 confidence.

Thank you @ceckert for the original diagnosis, production measurements, implementation, and extensive regression coverage.

Co-authored-by: Chris Eckert <christopher.k.eckert@gmail.com>
