### PR TITLE
refactor(infra): establish shared error normalization foundation

### DIFF
--- a/src/infra/errors.test.ts
+++ b/src/infra/errors.test.ts
@@ -9,6 +9,7 @@ import {
   hasErrnoCode,
   isErrno,
   readErrorName,
+  toErrorObject,
 } from "./errors.js";
 
 function createCircularObject() {
@@ -65,9 +66,91 @@ describe("error helpers", () => {
   it.each([
     { value: 123n, expected: "123" },
     { value: false, expected: "false" },
+    { value: undefined, expected: "undefined" },
+    { value: Symbol("failure"), expected: "Symbol(failure)" },
     { value: createCircularObject(), expected: "[object Object]" },
   ])("formats error messages for case %#", ({ value, expected }) => {
     expect(formatErrorMessage(value)).toBe(expected);
+  });
+
+  it("tolerates throwing error accessors", () => {
+    const err = new Error("unused");
+    let accessorCalls = 0;
+    Object.defineProperties(err, {
+      message: {
+        configurable: true,
+        get() {
+          accessorCalls += 1;
+          throw new Error("message getter must not run");
+        },
+      },
+      cause: {
+        configurable: true,
+        get() {
+          accessorCalls += 1;
+          throw new Error("cause getter must not run");
+        },
+      },
+      code: {
+        configurable: true,
+        get() {
+          accessorCalls += 1;
+          throw new Error("code getter must not run");
+        },
+      },
+    });
+
+    expect(formatErrorMessage(err)).toBe("Error");
+    expect(extractErrorCode(err)).toBeUndefined();
+    expect(isErrno(err)).toBe(false);
+    expect(hasErrnoCode(err, "EFAIL")).toBe(false);
+    expect(accessorCalls).toBe(0);
+  });
+
+  it("preserves native DOMException diagnostics", () => {
+    const timeoutError = new DOMException("The operation timed out", "TimeoutError");
+
+    expect(readErrorName(timeoutError)).toBe("TimeoutError");
+    expect(extractErrorCode(timeoutError)).toBe("23");
+    expect(formatErrorMessage(timeoutError)).toBe("The operation timed out");
+  });
+
+  it("skips inherited Error subclass accessors", () => {
+    let accessorCalls = 0;
+    class HostileError extends Error {
+      override get name(): string {
+        accessorCalls += 1;
+        return "HostileError";
+      }
+
+      get code(): string {
+        accessorCalls += 1;
+        return "EHOSTILE";
+      }
+    }
+
+    const error = new HostileError("dependency failed");
+    expect(readErrorName(error)).toBe("Error");
+    expect(extractErrorCode(error)).toBeUndefined();
+    expect(formatErrorMessage(error)).toBe("dependency failed");
+    expect(accessorCalls).toBe(0);
+  });
+
+  it("reads Error fallback accessors only when needed", () => {
+    let nameAccessorCalls = 0;
+    class LazyNameError extends Error {
+      override get name(): string {
+        nameAccessorCalls += 1;
+        return "LazyNameError";
+      }
+    }
+
+    const error = new LazyNameError("specific message");
+    expect(formatErrorMessage(error)).toBe("specific message");
+    expect(nameAccessorCalls).toBe(0);
+    Object.defineProperty(error, "stack", { configurable: true, value: "specific stack" });
+    expect(formatUncaughtError(error)).toBe("specific stack");
+    expect(nameAccessorCalls).toBe(0);
   });
 
   it("traverses .cause chain to include nested error messages", () => {
@@ -120,6 +203,32 @@ describe("error helpers", () => {
     expect(formatted).toContain("authorization:");
     expect(formatted).not.toContain(appSecret);
     expect(formatted).not.toContain(tenantToken);
+  });
+
+  it("coerces unknown values without invoking accessors", () => {
+    const errorLike = { code: "EFAIL", message: "Unicode failure: 🦞" };
+    Object.defineProperty(errorLike, "status", {
+      enumerable: true,
+      get() {
+        throw new Error("status getter must not run");
+      },
+    });
+
+    const normalized = toErrorObject(errorLike, "fallback");
+
+    expect(normalized).toBeInstanceOf(Error);
+    expect(normalized.message).toBe("Unicode failure: 🦞");
+    expect((normalized as Error & { code?: string }).code).toBe("EFAIL");
+    expect(Object.hasOwn(normalized, "status")).toBe(false);
+    expect(toErrorObject("plain failure", "fallback").message).toBe("plain failure");
+  });
+
+  it("keeps Error coercion fields well-formed", () => {
+    const normalized = toErrorObject({ message: 42, name: false, stack: null }, "fallback");
+
+    expect(normalized.message).toBe("fallback");
+    expect(normalized.name).toBe("Error");
+    expect(typeof normalized.stack).toBe("string");
   });
 
   it.each([

--- a/src/infra/errors.ts
+++ b/src/infra/errors.ts
@@ -1,11 +1,102 @@
 // Normalizes error objects for codes, names, messages, and redacted logs.
 import { redactSensitiveText } from "../logging/redact.js";
 
-export function extractErrorCode(err: unknown): string | undefined {
-  if (!err || typeof err !== "object") {
+const nativeErrorStackGetter = Reflect.get(
+  Object.getOwnPropertyDescriptor(new Error(), "stack") ?? {},
+  "get",
+);
+
+function isObjectLike(value: unknown): value is object {
+  return (typeof value === "object" || typeof value === "function") && value !== null;
+}
+
+function isError(value: unknown): value is Error {
+  try {
+    return value instanceof Error;
+  } catch {
+    return false;
+  }
+}
+
+function isDomException(value: unknown): value is DOMException {
+  try {
+    return value instanceof DOMException;
+  } catch {
+    return false;
+  }
+}
+
+function readDataProperty(value: unknown, key: PropertyKey): unknown {
+  if (!isObjectLike(value)) {
     return undefined;
   }
-  const code = (err as { code?: unknown }).code;
+
+  const seen = new Set<object>();
+  let current: object | null = value;
+  while (current && !seen.has(current)) {
+    seen.add(current);
+    try {
+      const descriptor = Object.getOwnPropertyDescriptor(current, key);
+      if (descriptor) {
+        if ("value" in descriptor) {
+          return descriptor.value;
+        }
+        const getter = Reflect.get(descriptor, "get");
+        if (typeof getter === "function" && getter === nativeErrorStackGetter && isError(value)) {
+          try {
+            return Reflect.apply(getter, value, []);
+          } catch {
+            return undefined;
+          }
+        }
+        if (
+          current === DOMException.prototype &&
+          typeof getter === "function" &&
+          isDomException(value)
+        ) {
+          try {
+            return Reflect.apply(getter, value, []);
+          } catch {
+            return undefined;
+          }
+        }
+      }
+      current = Object.getPrototypeOf(current);
+    } catch {
+      return undefined;
+    }
+  }
+  return undefined;
+}
+
+function stringifyUnknownValue(value: unknown): string {
+  if (
+    value === undefined ||
+    typeof value === "string" ||
+    typeof value === "number" ||
+    typeof value === "boolean" ||
+    typeof value === "bigint" ||
+    typeof value === "symbol"
+  ) {
+    return String(value);
+  }
+  try {
+    const serialized = JSON.stringify(value);
+    if (typeof serialized === "string") {
+      return serialized;
+    }
+  } catch {
+    // Fall through to a stable object tag when JSON serialization is unavailable.
+  }
+  try {
+    return Object.prototype.toString.call(value);
+  } catch {
+    return `[${typeof value}]`;
+  }
+}
+
+export function extractErrorCode(err: unknown): string | undefined {
+  const code = readDataProperty(err, "code");
   if (typeof code === "string") {
     return code;
   }
@@ -16,10 +107,7 @@ export function extractErrorCode(err: unknown): string | undefined {
 }
 
 export function readErrorName(err: unknown): string {
-  if (!err || typeof err !== "object") {
-    return "";
-  }
-  const name = (err as { name?: unknown }).name;
+  const name = readDataProperty(err, "name");
   return typeof name === "string" ? name : "";
 }
 
@@ -56,41 +144,50 @@ export function collectErrorGraphCandidates(
  * Type guard for NodeJS.ErrnoException (any error with a `code` property).
  */
 export function isErrno(err: unknown): err is NodeJS.ErrnoException {
-  return Boolean(err && typeof err === "object" && "code" in err);
+  return readDataProperty(err, "code") !== undefined;
 }
 
 /**
  * Check if an error has a specific errno code.
  */
 export function hasErrnoCode(err: unknown, code: string): boolean {
-  return isErrno(err) && err.code === code;
+  return extractErrorCode(err) === code;
 }
 
 export function formatErrorMessage(err: unknown): string {
   let formatted: string;
-  if (err instanceof Error) {
-    formatted = err.message || err.name || "Error";
+  if (isError(err)) {
+    const message = readDataProperty(err, "message");
+    if (typeof message === "string" && message) {
+      formatted = message;
+    } else {
+      const name = readDataProperty(err, "name");
+      formatted = typeof name === "string" && name ? name : "Error";
+    }
     // Traverse .cause chain to include nested error messages (e.g. grammY HttpError wraps network errors in .cause)
-    let cause: unknown = err.cause;
+    let cause: unknown = readDataProperty(err, "cause");
     const seen = new Set<unknown>([err]);
     // Skip causes that repeat a message already emitted (e.g. coerceToFailoverError).
     const seenMessages = new Set<string>([formatted]);
-    const appendCauseMessage = (message: string): void => {
-      if (!message || seenMessages.has(message)) {
+    const appendCauseMessage = (causeMessage: string): void => {
+      if (!causeMessage || seenMessages.has(causeMessage)) {
         return;
       }
-      formatted += ` | ${message}`;
-      seenMessages.add(message);
+      formatted += ` | ${causeMessage}`;
+      seenMessages.add(causeMessage);
     };
     while (cause && !seen.has(cause)) {
       seen.add(cause);
-      if (cause instanceof Error) {
-        appendCauseMessage(cause.message);
+      if (isError(cause)) {
+        const causeMessage = readDataProperty(cause, "message");
+        if (typeof causeMessage === "string") {
+          appendCauseMessage(causeMessage);
+        }
         const code = extractErrorCode(cause);
         if (code) {
           appendCauseMessage(code);
         }
-        cause = cause.cause;
+        cause = readDataProperty(cause, "cause");
       } else if (typeof cause === "string") {
         appendCauseMessage(cause);
         break;
@@ -98,16 +195,8 @@ export function formatErrorMessage(err: unknown): string {
         break;
       }
     }
-  } else if (typeof err === "string") {
-    formatted = err;
-  } else if (typeof err === "number" || typeof err === "boolean" || typeof err === "bigint") {
-    formatted = String(err);
   } else {
-    try {
-      formatted = JSON.stringify(err);
-    } catch {
-      formatted = Object.prototype.toString.call(err);
-    }
+    formatted = stringifyUnknownValue(err);
   }
   // Security: best-effort token redaction before returning/logging.
   return redactSensitiveText(formatted);
@@ -118,32 +207,39 @@ export function formatErrorMessage(err: unknown): string {
  * a flattened error chain. Returns `[object Object]`-free text without throwing.
  */
 export function stringifyNonErrorCause(value: unknown): string {
-  if (value === null) {
-    return "null";
-  }
-  if (typeof value === "string") {
-    return value;
-  }
-  if (typeof value === "number" || typeof value === "boolean" || typeof value === "bigint") {
-    return String(value);
-  }
+  return stringifyUnknownValue(value);
+}
+
+function copyErrorDataProperties(source: object, target: Error): void {
   try {
-    return JSON.stringify(value) ?? Object.prototype.toString.call(value);
+    for (const key of Reflect.ownKeys(source)) {
+      const descriptor = Object.getOwnPropertyDescriptor(source, key);
+      if (!descriptor?.enumerable || !("value" in descriptor)) {
+        continue;
+      }
+      if (
+        (key === "message" || key === "name" || key === "stack") &&
+        typeof descriptor.value !== "string"
+      ) {
+        continue;
+      }
+      Object.defineProperty(target, key, { ...descriptor, configurable: true });
+    }
   } catch {
-    return Object.prototype.toString.call(value);
+    // Preserve the normalized Error when a hostile object rejects reflection.
   }
 }
 
 export function toErrorObject(value: unknown, fallbackMessage: string): Error {
-  if (value instanceof Error) {
+  if (isError(value)) {
     return value;
   }
   if (typeof value === "string") {
     return new Error(value);
   }
   const error = new Error(fallbackMessage, { cause: value });
-  if ((typeof value === "object" && value !== null) || typeof value === "function") {
-    Object.assign(error, value);
+  if (isObjectLike(value)) {
+    copyErrorDataProperties(value, error);
   }
   return error;
 }
@@ -152,9 +248,17 @@ export function formatUncaughtError(err: unknown): string {
   if (extractErrorCode(err) === "INVALID_CONFIG") {
     return formatErrorMessage(err);
   }
-  if (err instanceof Error) {
-    const stack = err.stack ?? err.message ?? err.name;
-    return redactSensitiveText(stack);
+  if (isError(err)) {
+    const stack = readDataProperty(err, "stack");
+    if (typeof stack === "string" && stack) {
+      return redactSensitiveText(stack);
+    }
+    const message = readDataProperty(err, "message");
+    if (typeof message === "string" && message) {
+      return redactSensitiveText(message);
+    }
+    const name = readDataProperty(err, "name");
+    return redactSensitiveText(typeof name === "string" && name ? name : "Error");
   }
   return formatErrorMessage(err);
 }


### PR DESCRIPTION
Related: #99314

## What Problem This Solves

Generic unknown-error handling is duplicated across core and bundled plugins, with inconsistent behavior for hostile accessors, native platform errors, causes, numeric codes, circular values, and secret redaction. Later caller migrations need one tested core contract before they can safely delete local coercion and formatter copies.

## Why This Change Was Made

This keeps the foundation limited to the existing `src/infra/errors.ts` API. It hardens property reads against throwing accessors and hostile proxies, preserves trusted native `Error.stack` and `DOMException` diagnostics, and makes `toErrorObject` copy only enumerable data properties without executing getters.

The earlier exploratory `serializeError` / `SerializableError` addition was removed. It had no caller in this slice, returned raw stack/message data without a settled redaction boundary, and leaked through the deprecated `infra-runtime` wildcard barrel. Serialization should be introduced only with its first concrete caller and deliberate SDK/redaction contract.

Caller migrations and plugin SDK exposure remain out of scope. The two later migration lanes can now use the existing canonical coercion/formatting helpers without adding a speculative public API here.

## User Impact

No intended user-visible behavior change. Maintainers gain a hostile-value-safe canonical error normalization contract while preserving the existing public export set.

## Evidence

- `node scripts/run-vitest.mjs src/infra/errors.test.ts` — 32 tests passed.
- `node scripts/run-oxlint.mjs src/infra/errors.ts src/infra/errors.test.ts` — passed, including plugin SDK boundary declaration preparation.
- `pnpm exec oxfmt --check src/infra/errors.ts src/infra/errors.test.ts` — passed.
- `git diff --check` — passed.
- `.agents/skills/autoreview/scripts/autoreview --mode local --engine codex --stream-engine-output` — clean; no accepted/actionable findings.
- Public export delta from `src/infra/errors.ts`: zero.
- Production diff: +104 net lines, reduced from the exploratory +222/-43 source shape by removing the unused serializer and speculative accessor machinery.
