### PR TITLE
test(number-coercion): add unit tests for resolveNonNegativeNumber

### DIFF
--- a/src/shared/number-coercion.test.ts
+++ b/src/shared/number-coercion.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "vitest";
+import { resolveNonNegativeNumber } from "./number-coercion.js";
+
+describe("resolveNonNegativeNumber", () => {
+  it("returns the value for positive numbers", () => {
+    expect(resolveNonNegativeNumber(5)).toBe(5);
+    expect(resolveNonNegativeNumber(3.14)).toBe(3.14);
+    expect(resolveNonNegativeNumber(Number.MAX_SAFE_INTEGER)).toBe(Number.MAX_SAFE_INTEGER);
+  });
+
+  it("returns 0 for zero", () => {
+    expect(resolveNonNegativeNumber(0)).toBe(0);
+  });
+
+  it("returns undefined for negative numbers", () => {
+    expect(resolveNonNegativeNumber(-1)).toBeUndefined();
+    expect(resolveNonNegativeNumber(-0.5)).toBeUndefined();
+  });
+
+  it("returns undefined for null and undefined", () => {
+    expect(resolveNonNegativeNumber(null)).toBeUndefined();
+    expect(resolveNonNegativeNumber(undefined)).toBeUndefined();
+  });
+
+  it("returns undefined for NaN and Infinity", () => {
+    expect(resolveNonNegativeNumber(NaN)).toBeUndefined();
+    expect(resolveNonNegativeNumber(Infinity)).toBeUndefined();
+    expect(resolveNonNegativeNumber(-Infinity)).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## What Problem This Solves

The `resolveNonNegativeNumber` helper in `src/shared/number-coercion.ts` filters out non-finite, negative, null, and undefined values, returning only valid non-negative numbers. Despite being a shared utility, this module had no unit tests.

## Why This Change Was Made

Add unit tests for the `resolveNonNegativeNumber` function covering:
- Positive numbers and decimals returned as-is
- Zero returned as `0`
- Negative numbers rejected (`undefined`)
- `null` and `undefined` rejected
- `NaN` and `Infinity` rejected

## Changes

- **`src/shared/number-coercion.test.ts`** — new test file with 5 focused test cases

## Evidence

Reproducibility: not applicable. This PR adds direct coverage for existing utility behavior. Source inspection confirms the utility behavior the tests target.

Direct behavior probe (no mocks — real functions exercised directly):

```text
$ node --import tsx -e "import(./src/shared/number-coercion.js).then((m) => { ... })"
[
  { "in": 5, "out": 5 },
  { "in": 0, "out": 0 },
  { "in": -1 },
  { "in": null },
  {},
  { "in": null },
  { "in": null },
  { "in": 3.14, "out": 3.14 }
]
```

> Note: `undefined` values are omitted by `JSON.stringify` (standard behavior). Each absent `out` field represents `undefined`.

## Related

N/A (self-contained test coverage improvement)

🤖 Generated with [Claude Code](https://claude.com/claude-code)