### PR TITLE
fix: suppress trailing post-message-tool meta-acknowledgements

### DIFF
--- a/src/agents/embedded-agent-helpers.ts
+++ b/src/agents/embedded-agent-helpers.ts
@@ -64,6 +64,7 @@ export { sanitizeSessionMessagesImages } from "./embedded-agent-helpers/images.j
 export {
   isMessagingToolDuplicate,
   isMessagingToolDuplicateNormalized,
+  isPostToolSendMetaCommentary,
   normalizeTextForComparison,
 } from "./embedded-agent-helpers/messaging-dedupe.js";
 

--- a/src/agents/embedded-agent-helpers/messaging-dedupe.ts
+++ b/src/agents/embedded-agent-helpers/messaging-dedupe.ts
@@ -5,6 +5,38 @@ import { normalizeLowercaseStringOrEmpty } from "@openclaw/normalization-core/st
 
 const MIN_DUPLICATE_TEXT_LENGTH = 10;
 const MIN_REVERSE_SUBSTRING_DUPLICATE_RATIO = 0.5;
+// Maximum length for a "post-tool-send meta commentary" candidate. Real
+// replies are longer than this; meta-acks ("已发 #22141", "Sent above")
+// are short trailing acknowledgements after a message-tool send.
+const MAX_META_COMMENTARY_LENGTH = 200;
+// Sentence-boundary delimiters for compound ack splitting.
+const SENTENCE_BOUNDARY_RE = /[.;,。，；！？!\n]\s*/g;
+
+/**
+ * Patterns that match a post-tool-send meta-acknowledgement phrase.
+ *
+ * Each pattern is anchored (`^...$`) and matches the ack phrase followed
+ * **only** by trailing punctuation, whitespace, parenthesised message refs
+ * (`(#22142)`), or numeric refs (`#22141`). The ack phrase itself must
+ * stand alone as the dominant content — prefix-only matches are rejected
+ * so that real replies like `Oklahoma weather`, `sentence fixed`,
+ * `已发现问题`, `okay let's go` are NOT suppressed.
+ *
+ * Compound meta-acks (`Sent. Replied in thread.`, `已发, 不再追加总结`,
+ * `OK. Done.`) are detected by splitting on sentence boundaries and
+ * checking that every segment independently matches a pattern from this
+ * list. See `isCompoundMetaCommentary`.
+ */
+const META_COMMENTARY_PATTERNS: readonly RegExp[] = [
+  // Chinese standalone acks: "已发", "已发送", "主回复已发", "好了", "收到"
+  /^(?:已发(?:送|完毕|完成)?|主回复已发|消息已发(?:出|送)?|回复已发|好了?|收到|完毕|完成|了解|知道了|明白)[\s.,。!；;?？、()#\d]*$/u,
+  // Chinese mid-text acks: "核心回答如下", "总结如下", "不再追加"
+  /^(?:核心回答如下|总结如下|以下为核心(?:回答|内容)?|以下为总结|不再追加(?:总结|内容)?|以下为回复|答案如下|如上|回复如上)[\s.,。!；;?？、()#\d]*$/u,
+  // English standalone acks: "OK", "Sent", "Done", "Roger", "Got it", ...
+  /^(?:sent(?:\s+(?:above|#\d+|\([^)]+\)))?|done\.?|replied(?:\s+(?:above|in\s+thread))?|see\s+above|as\s+above|posted\.?|acknowledged\.?|ok(?:ay)?|got\s+it|gotcha|roger|cop(?:y|ied)(?:\s+that)?|ack(?:nowledged)?|will\s+do|on\s+it|noted|understood|thanks|thx)[\s.,!；;?？()#\d]*$/i,
+  // English mid-text: "Replying above", "Answer below", "Response above"
+  /^(?:replying\s+(?:above|below|in\s+thread)|answer\s+below|response\s+above|sent\s+in\s+thread)[\s.,!；;?？()#\d]*$/i,
+];
 
 /**
  * Normalize text for duplicate comparison.
@@ -18,6 +50,60 @@ export function normalizeTextForComparison(text: string): string {
     .replace(/\p{Emoji_Presentation}|\p{Extended_Pictographic}/gu, "")
     .replace(/\s+/g, " ")
     .trim();
+}
+
+/**
+ * Detect compound meta-acks where every sentence-boundary-delimited
+ * segment is itself a short meta-acknowledgement.
+ *
+ * Used as a second pass after the full-text anchored pattern match
+ * so that multi-sentence acks like `Sent. Replied in thread.` and
+ * `已发, 不再追加总结` are caught, while mixed-form texts like
+ * `OK, that's the fix.` or `已发. Now let me explain...` are
+ * preserved because at least one segment does not match any ack
+ * pattern.
+ */
+function isCompoundMetaCommentary(normalized: string): boolean {
+  const segments = normalized.split(SENTENCE_BOUNDARY_RE).filter((s) => s.trim().length > 0);
+  if (segments.length < 2) return false;
+  // Every segment must independently match a meta-ack pattern.
+  // A single non-matching segment means the text has real content.
+  return segments.every((segment) =>
+    META_COMMENTARY_PATTERNS.some((pattern) => pattern.test(segment.trim())),
+  );
+}
+
+/**
+ * Detect short post-tool-send meta commentary.
+ *
+ * After an agent runs a message-tool send in the same turn, models
+ * sometimes append a trailing acknowledgement like "已发 #22141",
+ * "Sent above", "核心回答如下", "OK", "Roger" or "Got it". These
+ * acks add no information beyond the message-tool send itself and
+ * reach the channel as a second visible message — a well-known
+ * duplicate-reply pattern.
+ *
+ * Detection is intentionally conservative:
+ *  - Normalized text must be ≤ MAX_META_COMMENTARY_LENGTH chars
+ *  - Full-text anchored pattern match is attempted first (standalone
+ *    acks like `已发`, `OK`, `Sent above`)
+ *  - If that fails, compound ack detection splits on sentence
+ *    boundaries and verifies every segment is itself ack-like
+ *  - Used only when a message-tool send has already happened this
+ *    turn (caller responsibility — see
+ *    `filterMessagingToolMetaCommentary`)
+ */
+export function isPostToolSendMetaCommentary(text: string): boolean {
+  const normalized = normalizeTextForComparison(text);
+  if (!normalized || normalized.length > MAX_META_COMMENTARY_LENGTH) {
+    return false;
+  }
+  // Full-text anchored match first (standalone acks).
+  if (META_COMMENTARY_PATTERNS.some((pattern) => pattern.test(normalized))) {
+    return true;
+  }
+  // Second pass: compound ack detection.
+  return isCompoundMetaCommentary(normalized);
 }
 
 /** Compare already-normalized message text against prior sends. */

--- a/src/auto-reply/reply/agent-runner-payloads.ts
+++ b/src/auto-reply/reply/agent-runner-payloads.ts
@@ -347,7 +347,11 @@ export async function buildReplyPayloads(params: {
         payloads: mediaFiltered,
         sentTexts,
       });
-      dedupedPayloads.push(...textFiltered);
+      const metaFiltered = dedupeRuntime.filterMessagingToolMetaCommentary({
+        payloads: textFiltered,
+        sentTexts,
+      });
+      dedupedPayloads.push(...metaFiltered);
     }
   }
   const directlySentTextFragmentsByAssistantMessage = new Map<number | undefined, string[]>();

--- a/src/auto-reply/reply/followup-delivery.ts
+++ b/src/auto-reply/reply/followup-delivery.ts
@@ -19,6 +19,7 @@ import {
   applyReplyThreading,
   filterMessagingToolDuplicates,
   filterMessagingToolMediaDuplicates,
+  filterMessagingToolMetaCommentary,
   resolveMessagingToolPayloadDedupe,
 } from "./reply-payloads.js";
 import { createReplyDeliveryContext, resolveReplyToMode } from "./reply-threading.js";
@@ -134,7 +135,11 @@ export function resolveFollowupDeliveryPayloads(params: {
       payloads: mediaFiltered,
       sentTexts,
     });
-    dedupedPayloads.push(...textFiltered);
+    const metaFiltered = filterMessagingToolMetaCommentary({
+      payloads: textFiltered,
+      sentTexts,
+    });
+    dedupedPayloads.push(...metaFiltered);
   }
   return dedupedPayloads;
 }

--- a/src/auto-reply/reply/reply-payloads-dedupe.runtime.ts
+++ b/src/auto-reply/reply/reply-payloads-dedupe.runtime.ts
@@ -2,6 +2,7 @@
 export {
   filterMessagingToolDuplicates,
   filterMessagingToolMediaDuplicates,
+  filterMessagingToolMetaCommentary,
   resolveMessagingToolPayloadDedupe,
   shouldDedupeMessagingToolRepliesForRoute,
   type MessagingToolPayloadDedupeDecision,

--- a/src/auto-reply/reply/reply-payloads-dedupe.ts
+++ b/src/auto-reply/reply/reply-payloads-dedupe.ts
@@ -3,7 +3,12 @@ import {
   normalizeLowercaseStringOrEmpty,
   normalizeOptionalString,
 } from "@openclaw/normalization-core/string-coerce";
-import { isMessagingToolDuplicate } from "../../agents/embedded-agent-helpers.js";
+import {
+  isMessagingToolDuplicate,
+  isPostToolSendMetaCommentary,
+} from "../../agents/embedded-agent-helpers.js";
+
+export { isPostToolSendMetaCommentary };
 import type { MessagingToolSend } from "../../agents/embedded-agent-messaging.types.js";
 import { getChannelPlugin } from "../../channels/plugins/index.js";
 import { getLoadedChannelPluginForRead } from "../../channels/plugins/registry-loaded-read.js";
@@ -99,6 +104,39 @@ export function filterMessagingToolMediaDuplicates(params: {
   }
 
   return nextPayloads ?? payloads;
+}
+
+/**
+ * Removes trailing payloads that are short post-tool-send meta commentary.
+ *
+ * After an agent calls the message tool to deliver its main reply, models
+ * sometimes append a brief acknowledgement ("已发 #22141", "Sent above",
+ * "核心回答如下", "OK", "Roger"). These acks reach the channel as a second
+ * visible message and are a well-known duplicate-reply pattern. This filter
+ * only fires when the run already produced message-tool sends (`sentTexts`
+ * non-empty) — the agent has actually delivered its main reply and any
+ * final text that matches a meta-ack pattern is suppressing itself.
+ */
+export function filterMessagingToolMetaCommentary(params: {
+  payloads: ReplyPayload[];
+  sentTexts: string[];
+}): ReplyPayload[] {
+  const { payloads, sentTexts } = params;
+  if (sentTexts.length === 0) {
+    return payloads;
+  }
+  return payloads.filter((payload) => {
+    if (payload.mediaUrl || payload.mediaUrls?.length) {
+      // Media payloads always carry new information, even if the caption is
+      // meta-ack; never suppress them.
+      return true;
+    }
+    const text = payload.text ?? "";
+    if (!text) {
+      return true;
+    }
+    return !isPostToolSendMetaCommentary(text);
+  });
 }
 
 function normalizeMediaForDedupe(value: string): string {

--- a/src/auto-reply/reply/reply-payloads.test.ts
+++ b/src/auto-reply/reply/reply-payloads.test.ts
@@ -5,6 +5,8 @@ import { createOutboundTestPlugin, createTestRegistry } from "../../test-utils/c
 import { getReplyPayloadMetadata, setReplyPayloadMetadata } from "../reply-payload.js";
 import {
   filterMessagingToolMediaDuplicates,
+  filterMessagingToolMetaCommentary,
+  isPostToolSendMetaCommentary,
   resolveMessagingToolPayloadDedupe,
   shouldDedupeMessagingToolRepliesForRoute,
 } from "./reply-payloads.js";
@@ -381,5 +383,212 @@ describe("resolveMessagingToolPayloadDedupe", () => {
       useGlobalSentTextEvidenceFallback: false,
       useGlobalSentMediaUrlEvidenceFallback: false,
     });
+  });
+});
+
+describe("isPostToolSendMetaCommentary", () => {
+  it.each([
+    // Chinese standalone meta-acks
+    "已发",
+    "已发 #22141",
+    "已发送",
+    "已发完毕",
+    "主回复已发",
+    "主回复已发 (#22142)",
+    "消息已发出",
+    "回复已发",
+    "好了",
+    "收到",
+    "完毕",
+    "完成",
+    "了解",
+    "知道了",
+    "明白",
+    // Chinese mid-text acks
+    "核心回答如下",
+    "总结如下",
+    "以下为核心回答",
+    "以下为总结",
+    "不再追加总结",
+    "不再追加",
+    "以下为回复",
+    "答案如下",
+    "如上",
+    "回复如上",
+    // English standalone acks
+    "Sent",
+    "Sent above",
+    "Sent #22141",
+    "Done.",
+    "Replied above",
+    "Replied in thread",
+    "See above",
+    "As above",
+    "Posted.",
+    "Acknowledged.",
+    "OK",
+    "Okay",
+    "Roger",
+    "Got it",
+    "Gotcha",
+    "Copy that",
+    "Copied",
+    "Ack",
+    "Will do",
+    "On it",
+    "Noted",
+    "Understood",
+    "Thanks",
+    // English mid-text acks
+    "Replying above",
+    "Replying in thread",
+    "Answer below",
+    "Response above",
+    "Sent in thread",
+    // Case insensitivity + whitespace + punctuation
+    "OK 👍",
+    "  sent  ",
+    "OK...",
+    "已发.",
+    "ok",
+    "SENT ABOVE",
+  ])("returns true for standalone meta-ack %j", (text) => {
+    expect(isPostToolSendMetaCommentary(text)).toBe(true);
+  });
+
+  it.each([
+    // Compound acks — every segment is itself ack-like
+    "Sent. Replied in thread.",
+    "已发, 不再追加总结",
+    "已发. 不再追加.",
+    "OK. Done.",
+    "Roger, copy.",
+    "Done. Sent.",
+    "收到. 已发.",
+    "Sent above. Replying in thread.",
+    "Got it. Will do.",
+    "已发, 完成",
+    "OK, noted",
+    "了解, 收到",
+    "Copied, thanks",
+  ])("returns true for compound meta-ack %j", (text) => {
+    expect(isPostToolSendMetaCommentary(text)).toBe(true);
+  });
+
+  it.each([
+    // ClawSweeper-flagged false positives — prefix-only matches must NOT be
+    // suppressed (the ack must stand alone as the entire text or every
+    // segment must be ack-like).
+    "Oklahoma weather",
+    "sentence fixed",
+    "已发现问题",
+    "已发现",
+    "已收到消息",
+    "sentry deployed",
+    "okay let's go",
+    // Mixed compound forms — second segment has real content that is not
+    // ack-like, so these must NOT be suppressed.
+    "OK, that's the fix.",
+    "OK. That's the fix.",
+    "OK, let me check that.",
+    "已发. Now let me explain the actual fix in detail: the dedupe threshold is 10.",
+    "Got it, let me take a look at the code.",
+    "Done, the migration is complete.",
+    "Sent, but I noticed the logs have an error.",
+    "收到, 但是这个方案有一个问题",
+    // Real reply content (must never be suppressed)
+    "已发 now let me explain the actual fix in detail: the dedupe threshold is 10.",
+    "Here is my analysis of the situation.",
+    "I think we should rerun the test suite before pushing.",
+    "Yes, the migration is complete and tested on staging.",
+    "Let me check that for you — one moment.",
+    "The price is $4,235.67, up 2.3% on the day.",
+    // Long content that happens to start with an ack-like word
+    "OK so basically the issue is that the dedupe only fires for texts of length >= 10, which means the short meta-commentary escapes. Let me draft a fix.",
+    // Non-ack short replies
+    "No",
+    "Yes",
+    "Maybe",
+    "Please wait",
+    "Hold on",
+    "One moment",
+    "Checking",
+  ])("returns false for real reply content %j", (text) => {
+    expect(isPostToolSendMetaCommentary(text)).toBe(false);
+  });
+
+  it("returns false for empty / whitespace-only text", () => {
+    expect(isPostToolSendMetaCommentary("")).toBe(false);
+    expect(isPostToolSendMetaCommentary("   ")).toBe(false);
+  });
+
+  it("returns false for text exceeding MAX_META_COMMENTARY_LENGTH", () => {
+    expect(isPostToolSendMetaCommentary("OK " + "x".repeat(200))).toBe(false);
+  });
+});
+
+describe("filterMessagingToolMetaCommentary", () => {
+  it("does nothing when no message-tool sends happened this run", () => {
+    const filtered = filterMessagingToolMetaCommentary({
+      payloads: [{ text: "已发 #1" }],
+      sentTexts: [],
+    });
+    expect(filtered).toEqual([{ text: "已发 #1" }]);
+  });
+
+  it("drops standalone meta-acks when message-tool sends happened", () => {
+    const filtered = filterMessagingToolMetaCommentary({
+      payloads: [
+        { text: "已发 #22141" },
+        { text: "Sent above" },
+        { text: "OK" },
+        { text: "Here is the real follow-up analysis: ..." },
+      ],
+      sentTexts: ["main reply content (length >= 10)"],
+    });
+    expect(filtered.map((p) => p.text)).toEqual(["Here is the real follow-up analysis: ..."]);
+  });
+
+  it("drops compound meta-acks when message-tool sends happened", () => {
+    const filtered = filterMessagingToolMetaCommentary({
+      payloads: [
+        { text: "Sent. Replied in thread." },
+        { text: "已发, 不再追加总结" },
+        { text: "OK. Done." },
+        { text: "Real content here." },
+      ],
+      sentTexts: ["main reply"],
+    });
+    expect(filtered.map((p) => p.text)).toEqual(["Real content here."]);
+  });
+
+  it("preserves mixed compound forms that contain real content", () => {
+    const filtered = filterMessagingToolMetaCommentary({
+      payloads: [{ text: "OK, that's the fix." }, { text: "Done, the migration is complete." }],
+      sentTexts: ["main reply"],
+    });
+    expect(filtered.map((p) => p.text)).toEqual([
+      "OK, that's the fix.",
+      "Done, the migration is complete.",
+    ]);
+  });
+
+  it("never suppresses media payloads even if the caption is meta-ack", () => {
+    const filtered = filterMessagingToolMetaCommentary({
+      payloads: [
+        { text: "已发", mediaUrl: "https://example.com/chart.png" },
+        { text: "Sent", mediaUrls: ["https://example.com/photo.jpg"] },
+      ],
+      sentTexts: ["main reply"],
+    });
+    expect(filtered).toHaveLength(2);
+  });
+
+  it("preserves empty-text payloads", () => {
+    const filtered = filterMessagingToolMetaCommentary({
+      payloads: [{ text: "" }, { text: undefined }],
+      sentTexts: ["main reply"],
+    });
+    expect(filtered).toHaveLength(2);
   });
 });

--- a/src/auto-reply/reply/reply-payloads.ts
+++ b/src/auto-reply/reply/reply-payloads.ts
@@ -9,6 +9,8 @@ export {
 export {
   filterMessagingToolDuplicates,
   filterMessagingToolMediaDuplicates,
+  filterMessagingToolMetaCommentary,
+  isPostToolSendMetaCommentary,
   resolveMessagingToolPayloadDedupe,
   shouldDedupeMessagingToolRepliesForRoute,
 } from "./reply-payloads-dedupe.js";


### PR DESCRIPTION
Closes #96681

## What Problem This Solves

After an agent calls the `message` tool (`action=send`) to deliver its main reply, models often append a short trailing meta-acknowledgement -- patterns like `已发 #22141`, `Sent above`, `核心回答如下`, `OK`, `Roger`, `Got it`, and compound forms like `Sent. Replied in thread.`, `已发, 不再追加总结`.

These acks carry no information beyond the message-tool send that already went out, but OpenClaw currently delivers them as a **second** visible message in the channel.

The existing `filterMessagingToolDuplicates` only catches full-content duplicates via substring match with a 10-char minimum, so short meta-acks (e.g. `已发 #22141`, 9 chars) escape the floor and reach the channel as a duplicate message.

## Why This Change Was Made

This patch adds a **complementary** filter -- `filterMessagingToolMetaCommentary` -- that recognizes post-tool-send meta commentary by pattern (Chinese + English) and suppresses it from the final reply payload.

Key design decisions:

1. **Compound ack coverage** -- Two-pass detection: first try full-text anchored patterns, then split on sentence boundaries and verify **every segment** independently matches an ack pattern. Catches `Sent. Replied in thread.`, `已发, 不再追加总结`, `OK. Done.` while **preserving** mixed forms like `OK, that's the fix.`

2. **Only fires after message-tool sends** (`sentTexts.length > 0`). Agents with no message-tool sends are unaffected.

3. **Length-capped at 200 chars** and anchored patterns only -- prefix matches like `Oklahoma weather`, `已发现问题` are not suppressed.

4. **Media payloads always preserved**, even if caption is a meta-ack.

5. **Wired into both paths**: `agent-runner-payloads.ts` (final reply) and `followup-delivery.ts` (queued follow-up).

## Evidence

### Real behavior proof (tsx runtime)

```
============================================================
Real Behavior Proof: Post-Message-Tool Meta-Ack Filter
============================================================

[1] Meta-ack pattern detection:
  ✓ "已发 #22141" → true
  ✓ "Sent above" → true
  ✓ "OK" → true
  ✓ "核心回答如下" → true
  ✓ "Sent. Replied in thread." → true
  ✓ "已发, 不再追加总结" → true
  ✓ "OK. Done." → true
  ✓ "Got it. Will do." → true
  ✓ "了解, 收到" → true
  ✓ "OK, that's the fix." → false
  ✓ "Done, the migration is complete." → false
  ✓ "Got it, let me take a look at the code." → false
  ✓ "Oklahoma weather" → false
  ✓ "已发现问题" → false
  Accuracy: 14/14

[2] Pipeline: 3 meta-acks + 1 real reply → filters to 1 payload
  Output: 1 payloads, kept: "Here is the real follow-up analysis..."

[3] Media payloads always preserved:
  1 media payload(s) preserved after filter

✓ All behavior checks passed.
```

### Test coverage (reply-payloads.test.ts)

All **134 tests pass** (includes 109 new test cases for meta-ack detection):

```
 Test Files  1 passed (1)
      Tests  134 passed (134)
   Duration  5.10s
```

**Standalone meta-acks covered** (46 positive cases): `已发`, `已发 #22141`, `已发送`, `已发完毕`, `主回复已发`, `消息已发出`, `回复已发`, `好了`, `收到`, `完毕`, `完成`, `了解`, `知道了`, `明白`, `核心回答如下`, `总结如下`, `以下为核心回答`, `以下为总结`, `不再追加总结`, `不再追加`, `以下为回复`, `答案如下`, `如上`, `回复如上`, `Sent`, `Sent above`, `Done.`, `Replied above`, `Replied in thread`, `See above`, `As above`, `Posted.`, `Acknowledged.`, `OK`, `Okay`, `Roger`, `Got it`, `Gotcha`, `Copy that`, `Copied`, `Ack`, `Will do`, `On it`, `Noted`, `Understood`, `Thanks`

**Compound meta-acks covered** (13 cases): `Sent. Replied in thread.`, `已发, 不再追加总结`, `已发. 不再追加.`, `OK. Done.`, `Roger, copy.`, `Done. Sent.`, `收到. 已发.`, `Sent above. Replying in thread.`, `Got it. Will do.`, `已发, 完成`, `OK, noted`, `了解, 收到`, `Copied, thanks`

**False positives excluded** (18+ cases): `Oklahoma weather`, `sentence fixed`, `已发现问题`, `已发现`, `已收到消息`, `sentry deployed`, `okay let's go`, `OK, that's the fix.`, `Got it, let me take a look at the code.`, `Done, the migration is complete.`, `Sent, but I noticed the logs have an error.`, `收到, 但是这个方案有一个问题`, real reply content, and more.

### Build verification

The full project builds successfully with these changes:
```
[build-all] phase timings: total 506.3s
```
No type errors, no build failures.

## Merge Risk

Low. The new filter is additive and only activates when message-tool sends happened this run (`sentTexts.length > 0`). It does not modify the existing dedupe logic. Media payloads are explicitly preserved. The worst-case failure mode is a false positive suppressing a real reply, which the anchored patterns + 200-char limit + compound segment validation guard against.

🤖 Generated with [Claude Code](https://claude.com/claude-code)