### PR TITLE
test(boolean): add unit tests for asBoolean and parseBooleanValue

### DIFF
--- a/src/utils/boolean.test.ts
+++ b/src/utils/boolean.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from "vitest";
+import { asBoolean, parseBooleanValue } from "./boolean.js";
+
+describe("asBoolean", () => {
+  it("returns the value for actual booleans", () => {
+    expect(asBoolean(true)).toBe(true);
+    expect(asBoolean(false)).toBe(false);
+  });
+
+  it("returns undefined for non-boolean values", () => {
+    expect(asBoolean("true")).toBeUndefined();
+    expect(asBoolean("false")).toBeUndefined();
+    expect(asBoolean(1)).toBeUndefined();
+    expect(asBoolean(0)).toBeUndefined();
+    expect(asBoolean(null)).toBeUndefined();
+    expect(asBoolean(undefined)).toBeUndefined();
+    expect(asBoolean("yes")).toBeUndefined();
+  });
+});
+
+describe("parseBooleanValue", () => {
+  it("parses boolean values directly", () => {
+    expect(parseBooleanValue(true)).toBe(true);
+    expect(parseBooleanValue(false)).toBe(false);
+  });
+
+  it("parses default truthy string literals", () => {
+    expect(parseBooleanValue("true")).toBe(true);
+    expect(parseBooleanValue("TRUE")).toBe(true);
+    expect(parseBooleanValue("1")).toBe(true);
+    expect(parseBooleanValue("yes")).toBe(true);
+    expect(parseBooleanValue("on")).toBe(true);
+  });
+
+  it("parses default falsy string literals", () => {
+    expect(parseBooleanValue("false")).toBe(false);
+    expect(parseBooleanValue("FALSE")).toBe(false);
+    expect(parseBooleanValue("0")).toBe(false);
+    expect(parseBooleanValue("no")).toBe(false);
+    expect(parseBooleanValue("off")).toBe(false);
+  });
+
+  it("returns undefined for unrecognized strings", () => {
+    expect(parseBooleanValue("maybe")).toBeUndefined();
+    expect(parseBooleanValue("")).toBeUndefined();
+  });
+
+  it("returns undefined for non-string non-boolean values", () => {
+    expect(parseBooleanValue(42)).toBeUndefined();
+    expect(parseBooleanValue(null)).toBeUndefined();
+    expect(parseBooleanValue(undefined)).toBeUndefined();
+    expect(parseBooleanValue({})).toBeUndefined();
+  });
+
+  it("supports custom truthy and falsy literals", () => {
+    expect(parseBooleanValue("enabled", { truthy: ["enabled"] })).toBe(true);
+    expect(parseBooleanValue("disabled", { falsy: ["disabled"] })).toBe(false);
+  });
+});


### PR DESCRIPTION
## What Problem This Solves

The `asBoolean` and `parseBooleanValue` helpers in `src/utils/boolean.ts` provide strict and lenient boolean coercion for config, env, and plugin SDK inputs. Despite being shared utilities, they had no unit tests.

## Why This Change Was Made

Add unit tests covering:
- `asBoolean`: strict boolean passthrough, rejects strings, numbers, null, undefined
- `parseBooleanValue`: accepts booleans + default string literals (true/1/yes/on, false/0/no/off), case-insensitive, custom truthy/falsy options, unrecognized strings return undefined

## Changes

- **`src/utils/boolean.test.ts`** — new test file with 8 focused test cases

## Evidence

Reproducibility: not applicable. This PR adds direct coverage for existing utility behavior.

Direct behavior probe (no mocks — real functions exercised directly):

```text
$ node --import tsx -e "import(./src/utils/boolean.js).then((m) => { ... })"
asBoolean(true) → true, asBoolean("true") → undefined
parseBooleanValue("yes") → true, parseBooleanValue("no") → false
parseBooleanValue("TRUE") → true, parseBooleanValue("FALSE") → false
parseBooleanValue("maybe") → undefined, parseBooleanValue("") → undefined
custom truthy("enabled") → true, custom falsy("disabled") → false
```

## Related

N/A (self-contained test coverage improvement)

🤖 Generated with [Claude Code](https://claude.com/claude-code)