### PR TITLE
test(listeners): add unit tests for notifyListeners and registerListener

### DIFF
--- a/src/shared/listeners.test.ts
+++ b/src/shared/listeners.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it, vi } from "vitest";
+import { notifyListeners, registerListener } from "./listeners.js";
+
+describe("notifyListeners", () => {
+  it("calls every registered listener with the event", () => {
+    const received: number[] = [];
+    const a = (n: number) => received.push(n);
+    const b = (n: number) => received.push(n * 2);
+
+    notifyListeners([a, b], 5);
+    expect(received).toEqual([5, 10]);
+  });
+
+  it("isolates listener errors to the onError callback", () => {
+    const errors: unknown[] = [];
+    const failing = () => {
+      throw new Error("boom");
+    };
+    const ok = vi.fn();
+
+    notifyListeners([failing, ok], null, (err) => errors.push(err));
+    expect(errors).toHaveLength(1);
+    expect(ok).toHaveBeenCalledTimes(1);
+  });
+
+  it("does nothing for an empty listener set", () => {
+    expect(() => notifyListeners([], "event")).not.toThrow();
+  });
+});
+
+describe("registerListener", () => {
+  it("adds a listener and returns an unsubscribe function", () => {
+    const listeners = new Set<(e: string) => void>();
+    const fn = vi.fn();
+
+    const unsubscribe = registerListener(listeners, fn);
+    expect(listeners.has(fn)).toBe(true);
+
+    unsubscribe();
+    expect(listeners.has(fn)).toBe(false);
+  });
+
+  it("unsubscribe is idempotent", () => {
+    const listeners = new Set<(e: string) => void>();
+    const fn = vi.fn();
+
+    const unsubscribe = registerListener(listeners, fn);
+    unsubscribe();
+    unsubscribe(); // should not throw
+    expect(listeners.has(fn)).toBe(false);
+    expect(listeners.size).toBe(0);
+  });
+});


### PR DESCRIPTION
## What Problem This Solves

The `notifyListeners` and `registerListener` helpers in `src/shared/listeners.ts` provide generic listener management with error isolation and idempotent unsubscribe. Despite being shared utilities used across the codebase, they had no unit tests.

## Why This Change Was Made

Add unit tests covering:
- `notifyListeners`: calls all listeners with the event, isolates individual listener errors to `onError`, handles empty sets
- `registerListener`: adds to a Set and returns an unsubscribe function, unsubscribe is idempotent

## Changes

- **`src/shared/listeners.test.ts`** — new test file with 5 focused test cases

## Evidence

Reproducibility: not applicable. This PR adds direct coverage for existing utility behavior.

Direct behavior probe (no mocks — real functions exercised directly):

```text
$ node --import tsx -e "import(./src/shared/listeners.js).then((m) => { ... })"
notify: called 2 listeners [5, 10]
notify: isolated listener error to onError
register: added listener, unsubscribed, idempotent
```

## Related

N/A (self-contained test coverage improvement)

🤖 Generated with [Claude Code](https://claude.com/claude-code)