### PR TITLE
test(shell-argv): add unit tests for splitShellArgs

### DIFF
--- a/src/utils/shell-argv.test.ts
+++ b/src/utils/shell-argv.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from "vitest";
+import { splitShellArgs } from "./shell-argv.js";
+
+describe("splitShellArgs", () => {
+  it("splits plain whitespace-separated words", () => {
+    expect(splitShellArgs("a b c")).toEqual(["a", "b", "c"]);
+    expect(splitShellArgs("  hello   world  ")).toEqual(["hello", "world"]);
+  });
+
+  it("preserves single-quoted text literally", () => {
+    expect(splitShellArgs("echo 'hello world'")).toEqual(["echo", "hello world"]);
+    expect(splitShellArgs("'keep spaces'")).toEqual(["keep spaces"]);
+  });
+
+  it("preserves double-quoted text with POSIX escape handling", () => {
+    expect(splitShellArgs('echo "hello world"')).toEqual(["echo", "hello world"]);
+    expect(splitShellArgs('"escaped \\"quote\\""')).toEqual(['escaped "quote"']);
+  });
+
+  it("handles backslash escapes outside quotes", () => {
+    expect(splitShellArgs("path\\ with\\ spaces")).toEqual(["path with spaces"]);
+    expect(splitShellArgs("a\\ b c")).toEqual(["a b", "c"]);
+  });
+
+  it("stops at a word-start comment character", () => {
+    expect(splitShellArgs("run # this is a comment")).toEqual(["run"]);
+    expect(splitShellArgs("# comment")).toBeNull();
+  });
+
+  it("returns null for unterminated single quote", () => {
+    expect(splitShellArgs("echo 'unclosed")).toBeNull();
+  });
+
+  it("returns null for unterminated double quote", () => {
+    expect(splitShellArgs('echo "unclosed')).toBeNull();
+  });
+
+  it("returns null for trailing backslash", () => {
+    expect(splitShellArgs("trailing \\")).toBeNull();
+  });
+
+  it("returns null for empty input", () => {
+    expect(splitShellArgs("")).toBeNull();
+  });
+
+  it("handles mixed quoting and escaping", () => {
+    expect(splitShellArgs("cmd 'single arg' \"double arg\" escaped\\ arg")).toEqual([
+      "cmd",
+      "single arg",
+      "double arg",
+      "escaped arg",
+    ]);
+  });
+});


### PR DESCRIPTION
## What Problem This Solves

The `splitShellArgs` helper in `src/utils/shell-argv.ts` tokenizes shell-style argv strings with support for single quotes, double quotes (POSIX escapes), backslash escapes, and `#` comments. Despite being a shared utility, it had no unit tests.

## Why This Change Was Made

Add unit tests covering: plain word splitting, single/double quote preservation, POSIX escapes, backslash escapes, word-start comments, unterminated quotes returning null, empty input, and mixed quoting.

## Changes

- **`src/utils/shell-argv.test.ts`** — new test file with 10 focused test cases

## Evidence

Reproducibility: not applicable. This PR adds direct coverage for existing utility behavior.

Direct behavior probe (no mocks):

```
splitShellArgs("a b c")          -> ["a","b","c"]
splitShellArgs("echo 'hello'")   -> ["echo","hello"]
splitShellArgs("echo \"hello\"") -> ["echo","hello"]
splitShellArgs("path\ with")    -> ["path with"]
splitShellArgs("echo 'unclosed") -> null
splitShellArgs("")               -> null
splitShellArgs("run # comment")  -> ["run"]
```

## Related

N/A (self-contained test coverage improvement)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
