### PR TITLE
test(shared): add unit tests for balanced-json parser

### DIFF
--- a/src/shared/balanced-json.test.ts
+++ b/src/shared/balanced-json.test.ts
@@ -1,0 +1,233 @@
+// Balanced JSON tests cover extractBalancedJsonPrefix and extractBalancedJsonFragments.
+import { describe, expect, it } from "vitest";
+import { extractBalancedJsonPrefix, extractBalancedJsonFragments } from "./balanced-json.js";
+
+describe("shared/balanced-json", () => {
+  describe("extractBalancedJsonPrefix", () => {
+    it("extracts a simple JSON object", () => {
+      const result = extractBalancedJsonPrefix('{"a":1}');
+      expect(result).toEqual({
+        json: '{"a":1}',
+        startIndex: 0,
+        endIndex: 6,
+      });
+    });
+
+    it("extracts an empty object", () => {
+      const result = extractBalancedJsonPrefix("{}");
+      expect(result).toEqual({
+        json: "{}",
+        startIndex: 0,
+        endIndex: 1,
+      });
+    });
+
+    it("skips leading text before the JSON", () => {
+      const result = extractBalancedJsonPrefix('prefix text {"a":1}');
+      expect(result).toEqual({
+        json: '{"a":1}',
+        startIndex: 12,
+        endIndex: 18,
+      });
+    });
+
+    it("extracts a simple array", () => {
+      const result = extractBalancedJsonPrefix("[1,2,3]");
+      expect(result).toEqual({
+        json: "[1,2,3]",
+        startIndex: 0,
+        endIndex: 6,
+      });
+    });
+
+    it("extracts nested objects", () => {
+      const result = extractBalancedJsonPrefix('{"a":{"b":2}}');
+      expect(result).toEqual({
+        json: '{"a":{"b":2}}',
+        startIndex: 0,
+        endIndex: 12,
+      });
+    });
+
+    it("extracts nested arrays", () => {
+      const result = extractBalancedJsonPrefix("[[1,2],[3,4]]");
+      expect(result).toEqual({
+        json: "[[1,2],[3,4]]",
+        startIndex: 0,
+        endIndex: 12,
+      });
+    });
+
+    it("extracts mixed nested structures", () => {
+      const result = extractBalancedJsonPrefix('{"a":[1,2],"b":{"c":3}}');
+      expect(result).toEqual({
+        json: '{"a":[1,2],"b":{"c":3}}',
+        startIndex: 0,
+        endIndex: 22,
+      });
+    });
+
+    it("handles strings containing delimiters", () => {
+      const result = extractBalancedJsonPrefix('{"a":"{}[]"}');
+      expect(result).toEqual({
+        json: '{"a":"{}[]"}',
+        startIndex: 0,
+        endIndex: 11,
+      });
+    });
+
+    it("handles escaped quotes inside strings", () => {
+      const result = extractBalancedJsonPrefix('{"a":"\\"{}\\"\\"\\""}');
+      expect(result).not.toBeNull();
+      expect(result!.json).toBe('{"a":"\\"{}\\"\\"\\""}');
+    });
+
+    it("handles backslash escapes inside strings", () => {
+      const result = extractBalancedJsonPrefix('{"a":"text\\\\nmore"}');
+      expect(result).toEqual({
+        json: '{"a":"text\\\\nmore"}',
+        startIndex: 0,
+        endIndex: 18,
+      });
+    });
+
+    it("returns null when no JSON delimiter is found", () => {
+      expect(extractBalancedJsonPrefix("hello world")).toBeNull();
+    });
+
+    it("returns null for empty string", () => {
+      expect(extractBalancedJsonPrefix("")).toBeNull();
+    });
+
+    it("returns null for pure whitespace", () => {
+      expect(extractBalancedJsonPrefix("   ")).toBeNull();
+    });
+
+    it("returns null for incomplete object (no closing brace)", () => {
+      const result = extractBalancedJsonPrefix('{"a":1');
+      expect(result).toBeNull();
+    });
+
+    it("returns null for incomplete array (no closing bracket)", () => {
+      const result = extractBalancedJsonPrefix("[1,2,3");
+      expect(result).toBeNull();
+    });
+
+    it("returns first object when multiple top-level objects exist", () => {
+      const result = extractBalancedJsonPrefix('{"a":1}{"b":2}');
+      expect(result).toEqual({
+        json: '{"a":1}',
+        startIndex: 0,
+        endIndex: 6,
+      });
+    });
+
+    it("respects openers restriction: only brackets", () => {
+      const result = extractBalancedJsonPrefix('{"a":1}[1,2,3]', {
+        openers: ["["],
+      });
+      expect(result).toEqual({
+        json: "[1,2,3]",
+        startIndex: 7,
+        endIndex: 13,
+      });
+    });
+
+    it("respects openers restriction: only braces", () => {
+      const result = extractBalancedJsonPrefix('[1,2,3]{"a":1}', {
+        openers: ["{"],
+      });
+      expect(result).toEqual({
+        json: '{"a":1}',
+        startIndex: 7,
+        endIndex: 13,
+      });
+    });
+
+    it("skips opening delimiter in strings", () => {
+      const result = extractBalancedJsonPrefix('"not json {"');
+      expect(result).toBeNull();
+    });
+
+    it("skips closing delimiter in strings", () => {
+      const result = extractBalancedJsonPrefix('{"a":"}"}');
+      expect(result).toEqual({
+        json: '{"a":"}"}',
+        startIndex: 0,
+        endIndex: 8,
+      });
+    });
+
+    it("handles deeply nested unbalanced input gracefully", () => {
+      const result = extractBalancedJsonPrefix('{{"a":1}');
+      expect(result).toBeNull();
+    });
+  });
+
+  describe("extractBalancedJsonFragments", () => {
+    it("extracts multiple objects", () => {
+      const result = extractBalancedJsonFragments('{"a":1}{"b":2}');
+      expect(result).toHaveLength(2);
+      expect(result[0].json).toBe('{"a":1}');
+      expect(result[1].json).toBe('{"b":2}');
+    });
+
+    it("extracts mixed object and array fragments", () => {
+      const result = extractBalancedJsonFragments('{"a":1}[1,2,3]');
+      expect(result).toHaveLength(2);
+      expect(result[0].json).toBe('{"a":1}');
+      expect(result[1].json).toBe("[1,2,3]");
+    });
+
+    it("extracts fragments separated by text", () => {
+      const result = extractBalancedJsonFragments('{"a":1} some text [1,2]');
+      expect(result).toHaveLength(2);
+      expect(result[0].json).toBe('{"a":1}');
+      expect(result[1].json).toBe("[1,2]");
+    });
+
+    it("returns empty array when no fragments found", () => {
+      expect(extractBalancedJsonFragments("hello world")).toEqual([]);
+    });
+
+    it("returns empty array for empty string", () => {
+      expect(extractBalancedJsonFragments("")).toEqual([]);
+    });
+
+    it("skips incomplete fragments and stops", () => {
+      const result = extractBalancedJsonFragments('{"a":1} {"b');
+      expect(result).toHaveLength(1);
+      expect(result[0].json).toBe('{"a":1}');
+    });
+
+    it("tracks correct start and end indices across fragments", () => {
+      const result = extractBalancedJsonFragments('xx {"a":1} yy [2]');
+      expect(result).toHaveLength(2);
+      expect(result[0].startIndex).toBe(3);
+      expect(result[0].endIndex).toBe(9);
+      expect(result[1].startIndex).toBe(14);
+      expect(result[1].endIndex).toBe(16);
+    });
+
+    it("respects openers restriction for multiple fragments", () => {
+      const result = extractBalancedJsonFragments('{"a":1}[1,2]', {
+        openers: ["["],
+      });
+      expect(result).toHaveLength(1);
+      expect(result[0].json).toBe("[1,2]");
+    });
+
+    it("extracts nested fragments only at top level", () => {
+      const result = extractBalancedJsonFragments('{"a":{"b":2}}');
+      expect(result).toHaveLength(1);
+      expect(result[0].json).toBe('{"a":{"b":2}}');
+    });
+
+    it("handles fragments with strings containing braces", () => {
+      const result = extractBalancedJsonFragments('{"a":"}"} {"b":"{"}');
+      expect(result).toHaveLength(2);
+      expect(result[0].json).toBe('{"a":"}"}');
+      expect(result[1].json).toBe('{"b":"{"}');
+    });
+  });
+});


### PR DESCRIPTION
## What Problem This Solves

The `balanced-json.ts` module in `src/shared/balanced-json.ts` provides defensive JSON fragment extraction utilities (`extractBalancedJsonPrefix`, `extractBalancedJsonFragments`) used across config parsing and diagnostic output. Despite being a shared parsing utility with non-trivial edge cases (nested structures, escape sequences, string-delimiter interaction), this module had no unit tests.

## Why This Change Was Made

Add unit tests for both exported functions covering:

**extractBalancedJsonPrefix:**
- Simple/empty/nested objects and arrays
- Leading text before the JSON fragment
- Strings containing delimiters (`"{}[]"`)
- Escaped quotes and backslash sequences inside strings
- No JSON delimiter in input, empty string, whitespace-only
- Incomplete/unbalanced JSON (missing closing bracket/brace, deeply nested)
- Multiple top-level objects (only first returned)
- `openers` restriction: braces only, brackets only

**extractBalancedJsonFragments:**
- Multiple consecutive objects and arrays
- Fragments separated by arbitrary text
- Empty/no-fragment input
- Incomplete trailing fragment (stops gracefully)
- Correct start/end index tracking across fragments
- `openers` restriction for multiple fragments
- Nested structures count as one fragment (top-level only)
- Strings containing braces across multiple fragments

This improves test coverage and documents the parser behavioral contract via tests, especially for the string-escape and nesting edge cases that are easy to regress.

## User Impact

No user-visible changes. For developers, the balanced-json parser behavioral contract is now documented via tests, enabling safe refactoring of this shared parsing utility.

## Evidence

Reproducibility: not applicable. This PR adds direct coverage for existing parser behavior rather than reporting a user-visible runtime bug.

Direct behavior probe (no mocks — real functions exercised directly):

```text
$ node --import tsx -e "import('./src/shared/balanced-json.js').then((m) => {
  const r = [];
  r.push({ test: 'simple object', result: m.extractBalancedJsonPrefix('{\"a\":1}') });
  r.push({ test: 'text before json', result: m.extractBalancedJsonPrefix('text{\"a\":1}') });
  r.push({ test: 'no json', result: m.extractBalancedJsonPrefix('invalid') });
  r.push({ test: 'bracket in string', result: m.extractBalancedJsonPrefix('{\"a\":\"}\"}') });
  r.push({ test: 'two fragments', result: m.extractBalancedJsonFragments('{\"a\":1}[1,2]') });
  r.push({ test: 'no fragments', result: m.extractBalancedJsonFragments('no json') });
  console.log(JSON.stringify(r, null, 2));
})"
[
  {
    "test": "simple object",
    "result": { "json": "{\"a\":1}", "startIndex": 0, "endIndex": 6 }
  },
  {
    "test": "text before json",
    "result": { "json": "{\"a\":1}", "startIndex": 4, "endIndex": 10 }
  },
  {
    "test": "no json",
    "result": null
  },
  {
    "test": "bracket in string",
    "result": { "json": "{\"a\":\"}\"}", "startIndex": 0, "endIndex": 8 }
  },
  {
    "test": "two fragments",
    "result": [
      { "json": "{\"a\":1}", "startIndex": 0, "endIndex": 6 },
      { "json": "[1,2]", "startIndex": 7, "endIndex": 11 }
    ]
  },
  {
    "test": "no fragments",
    "result": []
  }
]
```

Targeted test:

```text
$ npm test -- src/shared/balanced-json.test.ts --run

> openclaw@2026.6.11 test
> node scripts/test-projects.mjs src/shared/balanced-json.test.ts --run

[test] starting test/vitest/vitest.unit-fast.config.ts

 RUN  v4.1.8 /home/0668001457/openclaw


 Test Files  1 passed (1)
      Tests  31 passed (31)
   Start at  10:55:46
   Duration  1.07s

[test] passed 1 Vitest shard in 17.37s
```

Formatting:

```text
$ npx oxfmt --check src/shared/balanced-json.ts src/shared/balanced-json.test.ts
Checking formatting...

All matched files use the correct format.
```

Whitespace:

```text
$ git diff --check
```
