### PR TITLE
fix(shared/text): strip standalone <parameter> tags while preserving content

### DIFF
--- a/src/shared/text/assistant-visible-text.test.ts
+++ b/src/shared/text/assistant-visible-text.test.ts
@@ -614,6 +614,28 @@ describe("stripToolCallXmlTags", () => {
     );
   });
 
+  it("strips standalone <parameter> wrappers outside a <function> block (#98557)", () => {
+    expect(
+      stripToolCallXmlTags('prefix\n<parameter name="assumptions">\nvalue\n</parameter>\nsuffix'),
+    ).toBe("prefix\n\nvalue\n\nsuffix");
+  });
+
+  it("preserves inner markup when stripping standalone <parameter> wrappers", () => {
+    expect(
+      stripToolCallXmlTags('prefix\n<parameter name="x">\n<b>value</b>\n</parameter>\nsuffix'),
+    ).toBe("prefix\n\n<b>value</b>\n\nsuffix");
+  });
+
+  it("preserves <parameter> tags inside fenced code blocks", () => {
+    const input = '```xml\n<parameter name="x">value</parameter>\n```\nAfter';
+    expect(stripToolCallXmlTags(input)).toBe(input);
+  });
+
+  it("preserves inline <parameter> examples in prose", () => {
+    const input = 'prefix <parameter name="x">value</parameter> suffix';
+    expect(stripToolCallXmlTags(input)).toBe(input);
+  });
+
   it("strips function_response adjacent to an opt-in stripped function_calls block", () => {
     const input = [
       '<function_calls><invoke name="exec">internal</invoke></function_calls><function_response>',
@@ -829,6 +851,43 @@ describe("sanitizeAssistantVisibleText", () => {
     ].join("\n");
 
     expect(sanitizeAssistantVisibleText(input)).toBe("Visible answer");
+  });
+
+  it("strips standalone <parameter> wrappers that leak into rich message content (#98557)", () => {
+    const input = [
+      "Here are the results.",
+      "",
+      '<parameter name="assumptions">',
+      "• 7-day window",
+      "• Direct employer filter",
+      "</parameter>",
+      "",
+      "Let me know if you need more.",
+    ].join("\n");
+
+    expect(sanitizeAssistantVisibleText(input)).toBe(
+      [
+        "Here are the results.",
+        "",
+        "",
+        "• 7-day window",
+        "• Direct employer filter",
+        "",
+        "",
+        "Let me know if you need more.",
+      ].join("\n"),
+    );
+  });
+
+  it("preserves inline <parameter> examples in prose", () => {
+    const input = 'Use <parameter name="x">value</parameter> in docs.';
+
+    expect(sanitizeAssistantVisibleText(input)).toBe(input);
+  });
+
+  it("preserves <parameter> tags inside fenced code blocks", () => {
+    const input = '```xml\n<parameter name="x">value</parameter>\n```\nAfter';
+    expect(sanitizeAssistantVisibleText(input)).toBe(input);
   });
 
   it("preserves prose examples of plural function-call XML on the delivery path", () => {

--- a/src/shared/text/assistant-visible-text.ts
+++ b/src/shared/text/assistant-visible-text.ts
@@ -41,6 +41,7 @@ const TOOL_CALL_TAG_NAMES = new Set([
   "tool_calls",
   "antml:invoke",
   "antml:parameter",
+  "parameter",
 ]);
 const TOOL_CALL_JSON_PAYLOAD_START_RE =
   /^(?:\s+[A-Za-z_:][-A-Za-z0-9_:.]*\s*=\s*(?:"[^"]*"|'[^']*'|[^\s"'=<>`]+))*\s*(?:\r?\n\s*)?[[{]/;
@@ -181,6 +182,24 @@ function isLikelyStandaloneFunctionToolCall(
   }
 
   return idx < 0 || text[idx] === "\n" || text[idx] === "\r" || /[.!?:]/.test(text[idx]);
+}
+
+function isLikelyStandaloneParameterWrapper(
+  text: string,
+  tagStart: number,
+  tag: ParsedToolCallTag,
+): boolean {
+  if (tag.tagName !== "parameter" || tag.isClose || tag.isSelfClosing || tag.isTruncated) {
+    return false;
+  }
+
+  if (findMatchingToolCallCloseIndex(text, tag.end, tag.tagName) === -1) {
+    return false;
+  }
+
+  return (
+    isStandaloneOpeningTagLine(text, tagStart, tag) || isOpeningTagFollowedByLineBreak(text, tag)
+  );
 }
 
 function isStandaloneOpeningTagLine(
@@ -345,6 +364,7 @@ export function stripToolCallXmlTags(
   let result = "";
   let lastIndex = 0;
   let inToolCallBlock = false;
+  let stripParameterTagsOnly = false;
   let toolCallBlockContentStart = 0;
   let toolCallBlockNeedsQuoteBalance = false;
   let toolCallBlockStart = 0;
@@ -433,6 +453,14 @@ export function stripToolCallXmlTags(
           (functionResponseCloseStart !== -1 &&
             isVisibleLineStart(result) &&
             isOpeningTagFollowedByLineBreak(text, tag)));
+      const shouldStripStandaloneParameter = isLikelyStandaloneParameterWrapper(text, idx, tag);
+      if (!tag.isClose && shouldStripStandaloneParameter) {
+        stripParameterTagsOnly = true;
+        toolCallBlockTagName = tag.tagName;
+        lastIndex = tag.end;
+        idx = Math.max(idx, tag.end - 1);
+        continue;
+      }
       if (
         !tag.isClose &&
         ((payloadKind && shouldStripStandaloneFunction) || shouldStripStandaloneResult)
@@ -458,6 +486,14 @@ export function stripToolCallXmlTags(
         idx = Math.max(idx, preserveEnd - 1);
         continue;
       }
+    } else if (stripParameterTagsOnly && tag.isClose && tag.tagName === toolCallBlockTagName) {
+      result += text.slice(lastIndex, idx);
+      stripParameterTagsOnly = false;
+      toolCallBlockTagName = null;
+      lastStrippedToolCallBlockEnd = tag.end;
+      lastIndex = tag.end;
+      idx = Math.max(idx, tag.end - 1);
+      continue;
     } else if (
       tag.isClose &&
       (tag.tagName === toolCallBlockTagName ||
@@ -478,7 +514,7 @@ export function stripToolCallXmlTags(
     idx = Math.max(idx, tag.end - 1);
   }
 
-  if (!inToolCallBlock) {
+  if (!inToolCallBlock || stripParameterTagsOnly) {
     result += text.slice(lastIndex);
   } else if (toolCallBlockTagName === "function") {
     result += text.slice(toolCallBlockStart);


### PR DESCRIPTION
## What Problem This Solves

Fixes #98557. When `channels.telegram.richMessages: true` is enabled, model-generated standalone `<parameter name="...">...</parameter>` XML wrappers inside rich content were not stripped by the assistant-visible-text sanitizer. Full `<function>...</function>` blocks were already removed, but the standalone parameter wrapper leaked through and was rendered as visible markup to the user.

This is a revised version of #99297, addressing the feedback that the first attempt dropped the entire block (including the human-readable content) instead of only removing the wrapper tags.

## Why This Change Was Made

`stripToolCallXmlTags` only entered a tool-call block when the payload looked like JSON or nested XML (e.g., `<function>` / `<tool_call>`). A bare `<parameter>` wrapper was parsed as a known tag but then preserved, so its XML tags stayed in the delivered message.

The fix adds a narrow "tag-only" strip path for standalone `<parameter>` wrappers: when the opening tag starts a line or is immediately followed by a line break, the opening and matching closing tags are removed but the inner content is kept. Inline prose examples and tags inside fenced code blocks are left untouched.

## User Impact

Telegram rich messages (and any other delivery path using `sanitizeAssistantVisibleText`) no longer expose raw `<parameter>` XML tags generated by the model. The assumptions/details inside the wrapper remain visible to the user instead of disappearing.

## Evidence

- Added unit tests in `src/shared/text/assistant-visible-text.test.ts` covering:
  - standalone `<parameter>` wrappers are stripped while their content is preserved;
  - inner markup is preserved;
  - inline prose examples are not modified;
  - `<parameter>` tags inside fenced code blocks are preserved.
- Ran the affected test file: `node scripts/run-vitest.mjs run src/shared/text/assistant-visible-text.test.ts` → **116 passed**.
- Ran related sanitizer tests: `node scripts/run-vitest.mjs run src/shared/text/assistant-visible-text.test.ts src/shared/text/tool-call-shaped-text.test.ts` → **121 passed**.
- Formatted and linted the changed files with `oxfmt` and `oxlint`; 0 warnings/errors.

Fixes #98557