### PR TITLE
improve: reduce repeated session startup scans

### DIFF
--- a/src/agents/embedded-agent-helpers/bootstrap.ts
+++ b/src/agents/embedded-agent-helpers/bootstrap.ts
@@ -1,7 +1,6 @@
 /**
  * Builds and sanitizes bootstrap context inserted into embedded-agent sessions.
  */
-import { createHash } from "node:crypto";
 import fs from "node:fs/promises";
 import path from "node:path";
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
@@ -118,13 +117,6 @@ type PolicyDigest = {
   omittedLines: number;
 };
 
-let lastAgentsPolicyDigestCache:
-  | {
-      key: string;
-      digest: PolicyDigest;
-    }
-  | undefined;
-
 export function resolveBootstrapMaxChars(cfg?: OpenClawConfig, agentId?: string | null): number {
   const raw =
     cfg && agentId
@@ -183,23 +175,9 @@ function normalizePolicyDigestLine(line: string): string {
   return `${truncateUtf16Safe(normalized, AGENTS_POLICY_DIGEST_MAX_LINE_CHARS - 1)}…`;
 }
 
-function agentsPolicyDigestCacheKey(content: string, budget: number): string {
-  return `${budget}:${content.length}:${createHash("sha256").update(content).digest("base64url")}`;
-}
-
-function rememberAgentsPolicyDigest(key: string, digest: PolicyDigest): PolicyDigest {
-  lastAgentsPolicyDigestCache = { key, digest };
-  return digest;
-}
-
 function buildAgentsPolicyDigest(content: string, budget: number): PolicyDigest {
   if (budget <= 0) {
     return { text: "", omittedLines: 0 };
-  }
-
-  const cacheKey = agentsPolicyDigestCacheKey(content, budget);
-  if (lastAgentsPolicyDigestCache?.key === cacheKey) {
-    return lastAgentsPolicyDigestCache.digest;
   }
 
   const candidates = content
@@ -234,10 +212,10 @@ function buildAgentsPolicyDigest(content: string, budget: number): PolicyDigest 
     .filter((candidate) => selected.has(candidate.index))
     .toSorted((a, b) => a.index - b.index)
     .map((candidate) => candidate.line);
-  return rememberAgentsPolicyDigest(cacheKey, {
+  return {
     text: lines.join("\n"),
     omittedLines: Math.max(0, candidates.length - lines.length),
-  });
+  };
 }
 
 function trimAgentsBootstrapContent(content: string, maxChars: number): TrimBootstrapResult {

--- a/src/agents/embedded-agent-helpers/bootstrap.ts
+++ b/src/agents/embedded-agent-helpers/bootstrap.ts
@@ -105,7 +105,6 @@ const AGENTS_POLICY_DIGEST_RATIO = 0.35;
 const AGENTS_POLICY_HEAD_RATIO = 0.45;
 const AGENTS_POLICY_TAIL_RATIO = 0.15;
 const AGENTS_POLICY_DIGEST_MAX_LINE_CHARS = 240;
-const AGENTS_POLICY_DIGEST_CACHE_LIMIT = 16;
 
 type TrimBootstrapResult = {
   content: string;
@@ -119,7 +118,12 @@ type PolicyDigest = {
   omittedLines: number;
 };
 
-const agentsPolicyDigestCache = new Map<string, PolicyDigest>();
+let lastAgentsPolicyDigestCache:
+  | {
+      key: string;
+      digest: PolicyDigest;
+    }
+  | undefined;
 
 export function resolveBootstrapMaxChars(cfg?: OpenClawConfig, agentId?: string | null): number {
   const raw =
@@ -184,15 +188,7 @@ function agentsPolicyDigestCacheKey(content: string, budget: number): string {
 }
 
 function rememberAgentsPolicyDigest(key: string, digest: PolicyDigest): PolicyDigest {
-  agentsPolicyDigestCache.delete(key);
-  agentsPolicyDigestCache.set(key, digest);
-  while (agentsPolicyDigestCache.size > AGENTS_POLICY_DIGEST_CACHE_LIMIT) {
-    const oldestKey = agentsPolicyDigestCache.keys().next().value;
-    if (!oldestKey) {
-      break;
-    }
-    agentsPolicyDigestCache.delete(oldestKey);
-  }
+  lastAgentsPolicyDigestCache = { key, digest };
   return digest;
 }
 
@@ -202,9 +198,8 @@ function buildAgentsPolicyDigest(content: string, budget: number): PolicyDigest 
   }
 
   const cacheKey = agentsPolicyDigestCacheKey(content, budget);
-  const cached = agentsPolicyDigestCache.get(cacheKey);
-  if (cached) {
-    return cached;
+  if (lastAgentsPolicyDigestCache?.key === cacheKey) {
+    return lastAgentsPolicyDigestCache.digest;
   }
 
   const candidates = content

--- a/src/agents/embedded-agent-helpers/bootstrap.ts
+++ b/src/agents/embedded-agent-helpers/bootstrap.ts
@@ -1,6 +1,7 @@
 /**
  * Builds and sanitizes bootstrap context inserted into embedded-agent sessions.
  */
+import { createHash } from "node:crypto";
 import fs from "node:fs/promises";
 import path from "node:path";
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
@@ -104,6 +105,7 @@ const AGENTS_POLICY_DIGEST_RATIO = 0.35;
 const AGENTS_POLICY_HEAD_RATIO = 0.45;
 const AGENTS_POLICY_TAIL_RATIO = 0.15;
 const AGENTS_POLICY_DIGEST_MAX_LINE_CHARS = 240;
+const AGENTS_POLICY_DIGEST_CACHE_LIMIT = 16;
 
 type TrimBootstrapResult = {
   content: string;
@@ -116,6 +118,8 @@ type PolicyDigest = {
   text: string;
   omittedLines: number;
 };
+
+const agentsPolicyDigestCache = new Map<string, PolicyDigest>();
 
 export function resolveBootstrapMaxChars(cfg?: OpenClawConfig, agentId?: string | null): number {
   const raw =
@@ -175,9 +179,32 @@ function normalizePolicyDigestLine(line: string): string {
   return `${truncateUtf16Safe(normalized, AGENTS_POLICY_DIGEST_MAX_LINE_CHARS - 1)}…`;
 }
 
+function agentsPolicyDigestCacheKey(content: string, budget: number): string {
+  return `${budget}:${content.length}:${createHash("sha256").update(content).digest("base64url")}`;
+}
+
+function rememberAgentsPolicyDigest(key: string, digest: PolicyDigest): PolicyDigest {
+  agentsPolicyDigestCache.delete(key);
+  agentsPolicyDigestCache.set(key, digest);
+  while (agentsPolicyDigestCache.size > AGENTS_POLICY_DIGEST_CACHE_LIMIT) {
+    const oldestKey = agentsPolicyDigestCache.keys().next().value;
+    if (!oldestKey) {
+      break;
+    }
+    agentsPolicyDigestCache.delete(oldestKey);
+  }
+  return digest;
+}
+
 function buildAgentsPolicyDigest(content: string, budget: number): PolicyDigest {
   if (budget <= 0) {
     return { text: "", omittedLines: 0 };
+  }
+
+  const cacheKey = agentsPolicyDigestCacheKey(content, budget);
+  const cached = agentsPolicyDigestCache.get(cacheKey);
+  if (cached) {
+    return cached;
   }
 
   const candidates = content
@@ -212,10 +239,10 @@ function buildAgentsPolicyDigest(content: string, budget: number): PolicyDigest 
     .filter((candidate) => selected.has(candidate.index))
     .toSorted((a, b) => a.index - b.index)
     .map((candidate) => candidate.line);
-  return {
+  return rememberAgentsPolicyDigest(cacheKey, {
     text: lines.join("\n"),
     omittedLines: Math.max(0, candidates.length - lines.length),
-  };
+  });
 }
 
 function trimAgentsBootstrapContent(content: string, maxChars: number): TrimBootstrapResult {

--- a/src/agents/embedded-agent-runner/session-manager-init.test.ts
+++ b/src/agents/embedded-agent-runner/session-manager-init.test.ts
@@ -404,6 +404,57 @@ describe("prepareSessionManagerForRun", () => {
     expect(sessionManager.flushed).toBe(true);
   });
 
+  it("does not truncate when the first non-empty header is beyond the scan cap", async () => {
+    const sessionFile = await makeTempFile();
+    const blankPrefix = " \n".repeat(33_000);
+    const originalTranscript =
+      blankPrefix +
+      [
+        '{"type":"session","id":"broken"',
+        JSON.stringify({
+          type: "message",
+          id: "user-1",
+          parentId: null,
+          timestamp: "2026-05-27T00:00:01.000Z",
+          message: { role: "user", content: "persisted prompt" },
+        }),
+      ].join("\n") +
+      "\n";
+    await fs.writeFile(sessionFile, originalTranscript, "utf-8");
+    const sessionManager = {
+      sessionId: "fresh-session",
+      cwd: "/srv/openclaw/main",
+      flushed: true,
+      fileEntries: [
+        {
+          type: "session",
+          id: "fresh-session",
+          cwd: "/srv/openclaw/main",
+        },
+        {
+          type: "message",
+          message: { role: "user" },
+        },
+      ],
+      byId: new Map([["user-1", {}]]),
+      labelsById: new Map(),
+      leafId: "user-1",
+    };
+
+    await expect(
+      prepareSessionManagerForRun({
+        sessionManager,
+        sessionFile,
+        hadSessionFile: true,
+        sessionId: "new-session",
+        cwd: "/tmp/task-repo",
+      }),
+    ).rejects.toThrow("Refusing to reset session transcript before finding a readable header");
+
+    expect(await fs.readFile(sessionFile, "utf-8")).toBe(originalTranscript);
+    expect(sessionManager.flushed).toBe(true);
+  });
+
   it("keeps recovered user-only transcripts through open and run preparation", async () => {
     const sessionFile = await makeTempFile();
     const userEntry = {

--- a/src/agents/embedded-agent-runner/session-manager-init.test.ts
+++ b/src/agents/embedded-agent-runner/session-manager-init.test.ts
@@ -404,13 +404,17 @@ describe("prepareSessionManagerForRun", () => {
     expect(sessionManager.flushed).toBe(true);
   });
 
-  it("does not truncate when the first non-empty header is beyond the scan cap", async () => {
+  it("resets when the first non-empty header is beyond the old scan cap", async () => {
     const sessionFile = await makeTempFile();
     const blankPrefix = " \n".repeat(33_000);
     const originalTranscript =
       blankPrefix +
       [
-        '{"type":"session","id":"broken"',
+        JSON.stringify({
+          type: "session",
+          id: "fresh-session",
+          cwd: "/srv/openclaw/main",
+        }),
         JSON.stringify({
           type: "message",
           id: "user-1",
@@ -441,18 +445,26 @@ describe("prepareSessionManagerForRun", () => {
       leafId: "user-1",
     };
 
-    await expect(
-      prepareSessionManagerForRun({
-        sessionManager,
-        sessionFile,
-        hadSessionFile: true,
-        sessionId: "new-session",
-        cwd: "/tmp/task-repo",
-      }),
-    ).rejects.toThrow("Refusing to reset session transcript before finding a readable header");
+    await prepareSessionManagerForRun({
+      sessionManager,
+      sessionFile,
+      hadSessionFile: true,
+      sessionId: "new-session",
+      cwd: "/tmp/task-repo",
+    });
 
-    expect(await fs.readFile(sessionFile, "utf-8")).toBe(originalTranscript);
-    expect(sessionManager.flushed).toBe(true);
+    expect(await fs.readFile(sessionFile, "utf-8")).toBe("");
+    expect(sessionManager.fileEntries).toEqual([
+      {
+        type: "session",
+        id: "new-session",
+        cwd: "/tmp/task-repo",
+      },
+    ]);
+    expect(sessionManager.byId.size).toBe(0);
+    expect(sessionManager.labelsById.size).toBe(0);
+    expect(sessionManager.leafId).toBeNull();
+    expect(sessionManager.flushed).toBe(false);
   });
 
   it("keeps recovered user-only transcripts through open and run preparation", async () => {

--- a/src/agents/embedded-agent-runner/session-manager-init.test.ts
+++ b/src/agents/embedded-agent-runner/session-manager-init.test.ts
@@ -354,6 +354,56 @@ describe("prepareSessionManagerForRun", () => {
     expect(sessionManager.flushed).toBe(true);
   });
 
+  it("does not truncate a blank-prefixed transcript with a corrupted header", async () => {
+    const sessionFile = await makeTempFile();
+    const originalTranscript =
+      [
+        "",
+        "   ",
+        '{"type":"session","id":"broken"',
+        JSON.stringify({
+          type: "message",
+          id: "user-1",
+          parentId: null,
+          timestamp: "2026-05-27T00:00:01.000Z",
+          message: { role: "user", content: "persisted prompt" },
+        }),
+      ].join("\n") + "\n";
+    await fs.writeFile(sessionFile, originalTranscript, "utf-8");
+    const sessionManager = {
+      sessionId: "fresh-session",
+      cwd: "/srv/openclaw/main",
+      flushed: true,
+      fileEntries: [
+        {
+          type: "session",
+          id: "fresh-session",
+          cwd: "/srv/openclaw/main",
+        },
+        {
+          type: "message",
+          message: { role: "user" },
+        },
+      ],
+      byId: new Map([["user-1", {}]]),
+      labelsById: new Map(),
+      leafId: "user-1",
+    };
+
+    await expect(
+      prepareSessionManagerForRun({
+        sessionManager,
+        sessionFile,
+        hadSessionFile: true,
+        sessionId: "new-session",
+        cwd: "/tmp/task-repo",
+      }),
+    ).rejects.toThrow("Refusing to reset session transcript with unreadable header");
+
+    expect(await fs.readFile(sessionFile, "utf-8")).toBe(originalTranscript);
+    expect(sessionManager.flushed).toBe(true);
+  });
+
   it("keeps recovered user-only transcripts through open and run preparation", async () => {
     const sessionFile = await makeTempFile();
     const userEntry = {

--- a/src/agents/embedded-agent-runner/session-manager-init.test.ts
+++ b/src/agents/embedded-agent-runner/session-manager-init.test.ts
@@ -3,7 +3,7 @@
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { SessionManager } from "../sessions/session-manager.js";
 import { prepareSessionManagerForRun } from "./session-manager-init.js";
 
@@ -46,6 +46,7 @@ describe("prepareSessionManagerForRun", () => {
       labelsById: new Map([["old", {}]]),
       leafId: "old",
     };
+    const readFileSpy = vi.spyOn(fs, "readFile");
 
     await prepareSessionManagerForRun({
       sessionManager,
@@ -68,6 +69,8 @@ describe("prepareSessionManagerForRun", () => {
     expect(sessionManager.labelsById.size).toBe(0);
     expect(sessionManager.leafId).toBeNull();
     expect(sessionManager.flushed).toBe(false);
+    expect(readFileSpy).not.toHaveBeenCalled();
+    readFileSpy.mockRestore();
     expect(await fs.readFile(sessionFile, "utf-8")).toBe("");
   });
 

--- a/src/agents/embedded-agent-runner/session-manager-init.ts
+++ b/src/agents/embedded-agent-runner/session-manager-init.ts
@@ -2,6 +2,7 @@
  * Prepares session managers and transcript state before embedded runs.
  */
 import fs from "node:fs/promises";
+import { StringDecoder } from "node:string_decoder";
 import { isRecord } from "@openclaw/normalization-core/record-coerce";
 import { serializeJsonlLine, writeJsonlLines } from "../../config/sessions/transcript-jsonl.js";
 import { invalidateSessionFileRepairCache } from "../session-file-repair.js";
@@ -15,62 +16,62 @@ type SessionHeaderEntry = {
 type SessionMessageEntry = { type: "message"; message?: { role?: string } };
 
 const SESSION_HEADER_READ_CHUNK_BYTES = 4096;
-const MAX_SESSION_HEADER_BYTES = 64 * 1024;
 
-type SessionFileHeaderRead = {
-  firstLine?: string;
-  cappedBeforeFirstLine: boolean;
-};
-
-async function readFirstSessionFileLine(sessionFile: string): Promise<SessionFileHeaderRead> {
+async function readFirstSessionFileLine(sessionFile: string): Promise<string | undefined> {
   const handle = await fs.open(sessionFile, "r");
   try {
-    const chunks: string[] = [];
-    let totalBytes = 0;
-    while (totalBytes < MAX_SESSION_HEADER_BYTES) {
-      const buffer = Buffer.alloc(
-        Math.min(SESSION_HEADER_READ_CHUNK_BYTES, MAX_SESSION_HEADER_BYTES - totalBytes),
-      );
-      const { bytesRead } = await handle.read(buffer, 0, buffer.length, totalBytes);
+    const decoder = new StringDecoder("utf8");
+    const buffer = Buffer.alloc(SESSION_HEADER_READ_CHUNK_BYTES);
+    let line = "";
+    let lineHasContent = false;
+
+    const scanText = (text: string): string | undefined => {
+      let start = 0;
+      while (start <= text.length) {
+        const newlineIndex = text.indexOf("\n", start);
+        const segment = newlineIndex === -1 ? text.slice(start) : text.slice(start, newlineIndex);
+        if (lineHasContent) {
+          line += segment;
+        } else {
+          const trimmedStart = segment.trimStart();
+          if (trimmedStart.length > 0) {
+            lineHasContent = true;
+            line = trimmedStart;
+          }
+        }
+        if (newlineIndex === -1) {
+          break;
+        }
+        if (lineHasContent) {
+          return line.trim();
+        }
+        start = newlineIndex + 1;
+      }
+      return undefined;
+    };
+
+    while (true) {
+      const { bytesRead } = await handle.read(buffer, 0, buffer.length, null);
       if (bytesRead === 0) {
         break;
       }
-      chunks.push(buffer.toString("utf-8", 0, bytesRead));
-      const nextTotalBytes = totalBytes + bytesRead;
-      const readEnd = bytesRead < buffer.length || nextTotalBytes >= MAX_SESSION_HEADER_BYTES;
-      const scannedText = chunks.join("");
-      const lines = scannedText.split(/\r?\n/u);
-      const hasCompleteLine = lines.length > 1;
-      const linesToScan = hasCompleteLine ? lines.slice(0, -1) : readEnd ? lines : [];
-      for (const line of linesToScan) {
-        const trimmed = line.trim();
-        if (trimmed) {
-          return { firstLine: trimmed, cappedBeforeFirstLine: false };
-        }
-      }
-      totalBytes = nextTotalBytes;
-      if (totalBytes >= MAX_SESSION_HEADER_BYTES) {
-        return { cappedBeforeFirstLine: true };
+      const firstLine = scanText(decoder.write(buffer.subarray(0, bytesRead)));
+      if (firstLine) {
+        return firstLine;
       }
     }
-    const firstLine = chunks
-      .join("")
-      .split(/\r?\n/u)
-      .map((line) => line.trim())
-      .find((line) => line.length > 0);
-    return { firstLine, cappedBeforeFirstLine: false };
+    const trailingLine = scanText(decoder.end());
+    if (trailingLine) {
+      return trailingLine;
+    }
+    return lineHasContent ? line.trim() : undefined;
   } finally {
     await handle.close().catch(() => undefined);
   }
 }
 
 async function assertExistingHeaderIsReadable(sessionFile: string): Promise<void> {
-  const { firstLine, cappedBeforeFirstLine } = await readFirstSessionFileLine(sessionFile);
-  if (cappedBeforeFirstLine) {
-    throw new Error(
-      `Refusing to reset session transcript before finding a readable header: ${sessionFile}`,
-    );
-  }
+  const firstLine = await readFirstSessionFileLine(sessionFile);
   if (!firstLine) {
     return;
   }

--- a/src/agents/embedded-agent-runner/session-manager-init.ts
+++ b/src/agents/embedded-agent-runner/session-manager-init.ts
@@ -17,7 +17,12 @@ type SessionMessageEntry = { type: "message"; message?: { role?: string } };
 const SESSION_HEADER_READ_CHUNK_BYTES = 4096;
 const MAX_SESSION_HEADER_BYTES = 64 * 1024;
 
-async function readFirstSessionFileLine(sessionFile: string): Promise<string | undefined> {
+type SessionFileHeaderRead = {
+  firstLine?: string;
+  cappedBeforeFirstLine: boolean;
+};
+
+async function readFirstSessionFileLine(sessionFile: string): Promise<SessionFileHeaderRead> {
   const handle = await fs.open(sessionFile, "r");
   try {
     const chunks: string[] = [];
@@ -31,8 +36,8 @@ async function readFirstSessionFileLine(sessionFile: string): Promise<string | u
         break;
       }
       chunks.push(buffer.toString("utf-8", 0, bytesRead));
-      const readEnd =
-        bytesRead < buffer.length || totalBytes + bytesRead >= MAX_SESSION_HEADER_BYTES;
+      const nextTotalBytes = totalBytes + bytesRead;
+      const readEnd = bytesRead < buffer.length || nextTotalBytes >= MAX_SESSION_HEADER_BYTES;
       const scannedText = chunks.join("");
       const lines = scannedText.split(/\r?\n/u);
       const hasCompleteLine = lines.length > 1;
@@ -40,23 +45,32 @@ async function readFirstSessionFileLine(sessionFile: string): Promise<string | u
       for (const line of linesToScan) {
         const trimmed = line.trim();
         if (trimmed) {
-          return trimmed;
+          return { firstLine: trimmed, cappedBeforeFirstLine: false };
         }
       }
-      totalBytes += bytesRead;
+      totalBytes = nextTotalBytes;
+      if (totalBytes >= MAX_SESSION_HEADER_BYTES) {
+        return { cappedBeforeFirstLine: true };
+      }
     }
-    return chunks
+    const firstLine = chunks
       .join("")
       .split(/\r?\n/u)
       .map((line) => line.trim())
       .find((line) => line.length > 0);
+    return { firstLine, cappedBeforeFirstLine: false };
   } finally {
     await handle.close().catch(() => undefined);
   }
 }
 
 async function assertExistingHeaderIsReadable(sessionFile: string): Promise<void> {
-  const firstLine = await readFirstSessionFileLine(sessionFile);
+  const { firstLine, cappedBeforeFirstLine } = await readFirstSessionFileLine(sessionFile);
+  if (cappedBeforeFirstLine) {
+    throw new Error(
+      `Refusing to reset session transcript before finding a readable header: ${sessionFile}`,
+    );
+  }
   if (!firstLine) {
     return;
   }

--- a/src/agents/embedded-agent-runner/session-manager-init.ts
+++ b/src/agents/embedded-agent-runner/session-manager-init.ts
@@ -20,7 +20,7 @@ const MAX_SESSION_HEADER_BYTES = 64 * 1024;
 async function readFirstSessionFileLine(sessionFile: string): Promise<string | undefined> {
   const handle = await fs.open(sessionFile, "r");
   try {
-    const chunks: Buffer[] = [];
+    const chunks: string[] = [];
     let totalBytes = 0;
     while (totalBytes < MAX_SESSION_HEADER_BYTES) {
       const buffer = Buffer.alloc(
@@ -30,17 +30,26 @@ async function readFirstSessionFileLine(sessionFile: string): Promise<string | u
       if (bytesRead === 0) {
         break;
       }
-      const chunk = buffer.subarray(0, bytesRead);
-      const newlineIndex = chunk.indexOf(0x0a);
-      if (newlineIndex >= 0) {
-        chunks.push(chunk.subarray(0, newlineIndex));
-        break;
+      chunks.push(buffer.toString("utf-8", 0, bytesRead));
+      const readEnd =
+        bytesRead < buffer.length || totalBytes + bytesRead >= MAX_SESSION_HEADER_BYTES;
+      const scannedText = chunks.join("");
+      const lines = scannedText.split(/\r?\n/u);
+      const hasCompleteLine = lines.length > 1;
+      const linesToScan = hasCompleteLine ? lines.slice(0, -1) : readEnd ? lines : [];
+      for (const line of linesToScan) {
+        const trimmed = line.trim();
+        if (trimmed) {
+          return trimmed;
+        }
       }
-      chunks.push(chunk);
       totalBytes += bytesRead;
     }
-    const firstLine = Buffer.concat(chunks).toString("utf-8").trim();
-    return firstLine || undefined;
+    return chunks
+      .join("")
+      .split(/\r?\n/u)
+      .map((line) => line.trim())
+      .find((line) => line.length > 0);
   } finally {
     await handle.close().catch(() => undefined);
   }

--- a/src/agents/embedded-agent-runner/session-manager-init.ts
+++ b/src/agents/embedded-agent-runner/session-manager-init.ts
@@ -14,9 +14,40 @@ type SessionHeaderEntry = {
 };
 type SessionMessageEntry = { type: "message"; message?: { role?: string } };
 
+const SESSION_HEADER_READ_CHUNK_BYTES = 4096;
+const MAX_SESSION_HEADER_BYTES = 64 * 1024;
+
+async function readFirstSessionFileLine(sessionFile: string): Promise<string | undefined> {
+  const handle = await fs.open(sessionFile, "r");
+  try {
+    const chunks: Buffer[] = [];
+    let totalBytes = 0;
+    while (totalBytes < MAX_SESSION_HEADER_BYTES) {
+      const buffer = Buffer.alloc(
+        Math.min(SESSION_HEADER_READ_CHUNK_BYTES, MAX_SESSION_HEADER_BYTES - totalBytes),
+      );
+      const { bytesRead } = await handle.read(buffer, 0, buffer.length, totalBytes);
+      if (bytesRead === 0) {
+        break;
+      }
+      const chunk = buffer.subarray(0, bytesRead);
+      const newlineIndex = chunk.indexOf(0x0a);
+      if (newlineIndex >= 0) {
+        chunks.push(chunk.subarray(0, newlineIndex));
+        break;
+      }
+      chunks.push(chunk);
+      totalBytes += bytesRead;
+    }
+    const firstLine = Buffer.concat(chunks).toString("utf-8").trim();
+    return firstLine || undefined;
+  } finally {
+    await handle.close().catch(() => undefined);
+  }
+}
+
 async function assertExistingHeaderIsReadable(sessionFile: string): Promise<void> {
-  const content = await fs.readFile(sessionFile, "utf-8");
-  const firstLine = content.split("\n").find((line) => line.trim());
+  const firstLine = await readFirstSessionFileLine(sessionFile);
   if (!firstLine) {
     return;
   }


### PR DESCRIPTION
Related: #99190

## What Problem This Solves

Fixes an issue where long-lived session transcripts could still be touched with full-file scans on run startup paths even when only the first non-empty JSONL header line was needed.

## Why This Change Was Made

The no-assistant session reset guard only needs to validate the first non-empty transcript header before deciding whether reset is safe. The previous implementation read the entire JSONL transcript into memory, which made startup work scale with full transcript size even when the header was at the beginning of the file.

This change replaces that full-file read with a small-chunk streaming first-non-empty-line reader. It returns as soon as the first non-empty header is found, keeps scanning until EOF for blank-prefixed transcripts, and preserves the existing fail-closed behavior for corrupt or invalid headers. That avoids introducing a new "header must appear within N bytes" compatibility constraint.

This intentionally does not replace SessionManager cold-open parsing with a tail-only reader yet; that path also restores model/thinking state, retained compaction tails, leaf controls, labels, and mutation-safe transcript state, so it needs a separate indexed or equivalence-proven design.

AI-assisted: yes.

## User Impact

Users with long-running agent sessions should see less avoidable pre-LLM file work on reset-preparation startup paths. Behavior is unchanged for session reset safety, including blank-prefixed transcripts and corrupt-header preservation.

## Evidence

- `node scripts/run-vitest.mjs src/agents/embedded-agent-runner/session-manager-init.test.ts`
  - 8 passed, including blank-prefixed corrupt-header preservation and a regression where the first non-empty valid header appears beyond the old 64 KiB scan cap.
- `node_modules/.bin/oxfmt --check --threads=1 src/agents/embedded-agent-runner/session-manager-init.ts src/agents/embedded-agent-runner/session-manager-init.test.ts`
- `git diff --check`

Benchmark for the reset guard path only:

- Measured window: `prepareSessionManagerForRun` only; transcript generation time is excluded.
- Input shape: first line is a valid `session` JSONL header, followed by repeated user-message JSONL entries.
- Transcript size: `57,752,670` bytes (~55.1 MiB).
- Runs per branch: 12.
- Both branches reset the file to `0` bytes after the guard passes.

| Branch | median | mean | min | p90 | max |
|---|---:|---:|---:|---:|---:|
| `origin/main@8f2986290d` | 23.068 ms | 23.449 ms | 22.185 ms | 23.704 ms | 27.052 ms |
| PR reset-guard code measured at `32edc6865c` | 1.013 ms | 1.028 ms | 0.904 ms | 1.064 ms | 1.274 ms |

Result: median elapsed time drops from `23.068 ms` to `1.013 ms`, about **22.8x faster** / **95.6% less time** for this path.

Additional process-level observation from `/usr/bin/time -l` for the benchmark command:

- main max RSS: `275,726,336` bytes
- PR branch max RSS: `118,292,480` bytes

The RSS numbers include Node/tsx and benchmark script overhead, but they match the expected direction: the PR no longer materializes the full ~55 MiB transcript just to validate the first non-empty header.
