### PR TITLE
fix(llm): tool results vanish for OpenAI-compatible providers (DeepSeek)

### DIFF
--- a/src/llm/providers/tool-result-text.test.ts
+++ b/src/llm/providers/tool-result-text.test.ts
@@ -142,6 +142,29 @@ describe("extractToolResultText", () => {
     expect(text).not.toContain("extra structured detail");
   });
 
+  it("falls back to structured text for a media-typed block with no payload instead of vanishing (#98673)", () => {
+    const text = extractToolResultText([{ type: "image" }]);
+
+    expect(text).toContain('"type":"image"');
+  });
+
+  it("keeps other blocks' text when one entry is a payload-less media block", () => {
+    const text = extractToolResultText([
+      { type: "text", text: "actual tool output" },
+      { type: "image_url" },
+    ]);
+
+    expect(text).toBe("actual tool output");
+  });
+
+  it("still excludes a genuinely populated image_url block from replay text", () => {
+    const text = extractToolResultText([
+      { type: "image_url", image_url: { url: "https://example.com/a.png" } },
+    ]);
+
+    expect(text).toBe("");
+  });
+
   it("truncates structured fallback text before provider replay", () => {
     const tail = "tail-marker";
     const text = extractToolResultText([
@@ -181,5 +204,17 @@ describe("describeToolResultMediaPlaceholder", () => {
         { type: "audio", mimeType: "audio/mpeg", data: "audio" },
       ]),
     ).toBe("(see attached media)");
+  });
+
+  it("does not claim attached media for a payload-less image-typed block (#98673)", () => {
+    expect(describeToolResultMediaPlaceholder([{ type: "image" }])).toBeUndefined();
+  });
+
+  it("does not treat a text block's own mimeType metadata field as attached media", () => {
+    expect(
+      describeToolResultMediaPlaceholder([
+        { type: "text", text: "<svg>...</svg>", mimeType: "image/svg+xml" },
+      ]),
+    ).toBeUndefined();
   });
 });

--- a/src/llm/providers/tool-result-text.ts
+++ b/src/llm/providers/tool-result-text.ts
@@ -45,6 +45,36 @@ function isBinaryMimeType(mimeType: string): boolean {
   return normalized ? !TEXTUAL_MIME_PATTERN.test(normalized) : false;
 }
 
+function isNonEmptyString(value: unknown): value is string {
+  return typeof value === "string" && value.trim().length > 0;
+}
+
+// A block can be *labeled* image/audio (record.type in MEDIA_ONLY_TOOL_RESULT_TYPES)
+// without actually carrying a payload -- e.g. a malformed/legacy-shaped block that
+// leaked through from an older session, a replay-reconstructed wire-format block, or
+// upstream normalization that emitted `{ type: "image" }` with no data. Trusting the
+// label alone (as this module used to) silently discards the block's content instead
+// of treating it as text, which is exactly the "not text => image" class of bug fixed
+// for the Anthropic path in #90710 -- unvalidated media-type blocks must never cause
+// real (or potentially recoverable) content to vanish. See #98673/#98728.
+function hasMediaPayload(record: Record<string, unknown>): boolean {
+  if (isNonEmptyString(record.data)) {
+    return true;
+  }
+  const imageUrl = record.image_url;
+  if (isNonEmptyString(imageUrl)) {
+    return true;
+  }
+  if (isRecord(imageUrl) && isNonEmptyString(imageUrl.url)) {
+    return true;
+  }
+  const inputAudio = record.input_audio;
+  if (isRecord(inputAudio) && isNonEmptyString(inputAudio.data)) {
+    return true;
+  }
+  return false;
+}
+
 function describeOmittedValue(value: unknown, label: string): string {
   const length = typeof value === "string" ? value.length : JSON.stringify(value)?.length;
   return length ? `[${label} omitted: ${length} chars]` : `[${label} omitted]`;
@@ -134,17 +164,19 @@ export function describeToolResultMediaPlaceholder(blocks: readonly unknown[]): 
     const record = block as Record<string, unknown>;
     const type = typeof record.type === "string" ? record.type : undefined;
     const mimeType = readMimeType(record);
+    // A type-only match with no payload isn't real media -- don't advertise media
+    // that was never actually attached (#98673).
+    const labeledImage = type
+      ? IMAGE_TOOL_RESULT_TYPES.has(type) && hasMediaPayload(record)
+      : false;
+    const labeledAudio = type
+      ? AUDIO_TOOL_RESULT_TYPES.has(type) && hasMediaPayload(record)
+      : false;
 
-    if (
-      (type && IMAGE_TOOL_RESULT_TYPES.has(type)) ||
-      mimeType?.toLowerCase().startsWith("image/")
-    ) {
+    if (labeledImage || (type !== "text" && mimeType?.toLowerCase().startsWith("image/"))) {
       hasImage = true;
     }
-    if (
-      (type && AUDIO_TOOL_RESULT_TYPES.has(type)) ||
-      mimeType?.toLowerCase().startsWith("audio/")
-    ) {
+    if (labeledAudio || (type !== "text" && mimeType?.toLowerCase().startsWith("audio/"))) {
       hasAudio = true;
     }
   }
@@ -166,7 +198,14 @@ export function extractToolResultBlockText(block: unknown): string | undefined {
     return undefined;
   }
   const record = block as Record<string, unknown>;
-  if (typeof record.type === "string" && MEDIA_ONLY_TOOL_RESULT_TYPES.has(record.type)) {
+  if (
+    typeof record.type === "string" &&
+    MEDIA_ONLY_TOOL_RESULT_TYPES.has(record.type) &&
+    hasMediaPayload(record)
+  ) {
+    // Only exclude blocks that are genuinely carrying media. A block merely
+    // labeled image/audio with no payload falls through to the structured
+    // stringify path below instead of silently vanishing (#98673/#98728).
     return undefined;
   }
   if (record.type === "text") {


### PR DESCRIPTION
Closes #98673
See also #90710, #98728

## What Problem This Solves

Fixes an issue where users of OpenAI-compatible providers (DeepSeek, and potentially others using the `openai-completions` code path) would lose tool results entirely. The model would report being unable to see tool outputs — `web_fetch`, `exec`, `read`, and similar tools would return results that the LLM perceived as blank or image blocks rather than text.

This gets progressively worse over a session because the corrupted blocks accumulate in conversation history with each turn. The only workaround was `/reset`.

## Why This Change Was Made

The same class of bug fixed for the Anthropic provider path in #90710 was never applied to the `openai-completions` code path. In `tool-result-text.ts`, the `describeToolResultMediaPlaceholder` and `extractToolResultBlockText` functions trusted a block's `type` label alone (`MEDIA_ONLY_TOOL_RESULT_TYPES.has(record.type)`) without validating that the block actually carried media data. Malformed blocks with `type: "image"` but no `data`/`image_url` payload were silently classified as media, and their real text content was discarded.

The fix adds `hasMediaPayload()` — a guard that checks for actual payload presence (`data`, `image_url`, or `input_audio.data`) before treating a block as media. Payload-less blocks now fall through to the structured text stringify path. This mirrors the approach taken in #90710 for the Anthropic path.

**Changes:** 2 files, +83/−9
- `src/llm/providers/tool-result-text.ts` — new `hasMediaPayload()` guard wired into both `describeToolResultMediaPlaceholder` and `extractToolResultBlockText`
- `src/llm/providers/tool-result-text.test.ts` — test coverage for payload-less media-typed blocks

## User Impact

Users of DeepSeek and other OpenAI-compatible providers can now use tool calls without tool results silently vanishing. Sessions no longer degrade over time due to accumulating corrupted blocks. No config changes, no workarounds needed.

## Evidence

**Before (reproducible on `openclaw/openclaw` main, DeepSeek v4):**
- Tool results returned as unreadable blocks — the model reported tool outputs appeared as base64 images or blank
- Each subsequent turn made it worse as corrupted blocks accumulated in history
- Only workaround was `/reset`

**After (this PR, same model, same gateway):**
Tested live on `deepseek/deepseek-v4-pro` with three different tool types:

| Tool | Result |
|------|--------|
| `web_fetch` (example.com) | Structured JSON with readable `text` field returned cleanly |
| `exec` (echo) | Plain text output returned verbatim |
| `read` (file) | File contents returned as readable markdown |

All tool results arrived as proper text — no image blocks, no base64, no garbling. Previously reproducible on the same model/provider path.
