### PR TITLE
fix(infra): enforce maxBytes in body-less HTTP error snippet path

### DIFF
--- a/src/infra/http-error-body.test.ts
+++ b/src/infra/http-error-body.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, it } from "vitest";
+import { readResponseBodySnippet } from "./http-error-body.js";
+
+function bodyLessResponse(text: string): Response {
+  return {
+    body: null,
+    text: async () => text,
+  } as unknown as Response;
+}
+
+describe("readResponseBodySnippet", () => {
+  it("returns full text when under both limits (body-less path)", async () => {
+    const text = "short text";
+    const result = await readResponseBodySnippet(bodyLessResponse(text), {
+      maxBytes: 1024,
+      maxChars: 50,
+    });
+    expect(result).toBe(text);
+  });
+
+  it("truncates by maxChars when under maxBytes (body-less path)", async () => {
+    const text = "abcdefghij";
+    const result = await readResponseBodySnippet(bodyLessResponse(text), {
+      maxBytes: 1024,
+      maxChars: 5,
+    });
+    expect(result).toBe("abcde");
+  });
+
+  it("truncates by maxBytes in the body-less path", async () => {
+    const text = "a".repeat(200);
+    const result = await readResponseBodySnippet(bodyLessResponse(text), {
+      maxBytes: 50,
+      maxChars: 500,
+    });
+    const byteLen = new TextEncoder().encode(result).length;
+    expect(byteLen).toBeLessThanOrEqual(50);
+    expect(result.length).toBeLessThan(text.length);
+  });
+
+  it("enforces maxBytes before maxChars in the body-less path", async () => {
+    const text = "a".repeat(500);
+    const result = await readResponseBodySnippet(bodyLessResponse(text), {
+      maxBytes: 30,
+      maxChars: 500,
+    });
+    const byteLen = new TextEncoder().encode(result).length;
+    expect(byteLen).toBeLessThanOrEqual(30);
+  });
+
+  it("does not split multi-byte UTF-8 characters at the byte boundary", async () => {
+    // U+1F600 (😀) is 4 bytes in UTF-8: F0 9F 98 80
+    const text = "ab😀cd";
+    // 2 ASCII bytes (ab) + cut before the 4-byte emoji
+    const result = await readResponseBodySnippet(bodyLessResponse(text), {
+      maxBytes: 3,
+      maxChars: 100,
+    });
+    // With stream:true, incomplete multi-byte sequence is dropped
+    expect(result).toBe("ab");
+  });
+
+  it("stream path still enforces maxBytes", async () => {
+    const data = new Uint8Array(500).fill(97); // 500 'a' bytes
+    const response = new Response(new Blob([data]).stream());
+    const result = await readResponseBodySnippet(response, {
+      maxBytes: 100,
+      maxChars: 500,
+    });
+    const byteLen = new TextEncoder().encode(result).length;
+    expect(byteLen).toBeLessThanOrEqual(100);
+  });
+
+  it("stream path still enforces maxChars", async () => {
+    const data = new Uint8Array(500).fill(97);
+    const response = new Response(new Blob([data]).stream());
+    const result = await readResponseBodySnippet(response, {
+      maxBytes: 200,
+      maxChars: 10,
+    });
+    expect(result.length).toBeLessThanOrEqual(10);
+  });
+
+  it("returns empty string when maxBytes is 0 (body-less path)", async () => {
+    const result = await readResponseBodySnippet(bodyLessResponse("some text"), {
+      maxBytes: 0,
+      maxChars: 100,
+    });
+    expect(result).toBe("");
+  });
+
+  it("returns empty string for empty response body", async () => {
+    const result = await readResponseBodySnippet(bodyLessResponse(""), {
+      maxBytes: 1024,
+      maxChars: 50,
+    });
+    expect(result).toBe("");
+  });
+});

--- a/src/infra/http-error-body.ts
+++ b/src/infra/http-error-body.ts
@@ -5,7 +5,16 @@ export async function readResponseBodySnippet(
   try {
     const body = response.body;
     if (!body || typeof body.getReader !== "function") {
-      return (await response.text()).slice(0, limits.maxChars);
+      const text = await response.text();
+      const encoded = new TextEncoder().encode(text);
+      if (encoded.byteLength > limits.maxBytes) {
+        return new TextDecoder()
+          .decode(encoded.subarray(0, limits.maxBytes), {
+            stream: true,
+          })
+          .slice(0, limits.maxChars);
+      }
+      return text.slice(0, limits.maxChars);
     }
 
     const reader = body.getReader();


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where `readResponseBodySnippet` would bypass the `maxBytes` limit when reading provider error bodies from responses whose `body` is null or lacks a `getReader` function. A malformed response entering this fallback path would buffer the entire body via `response.text()` before applying the `maxChars` truncation — the `maxBytes` guard was never enforced. The stream path (normal ReadableStream responses) already enforced `maxBytes` correctly.

## Why This Change Was Made

The body-less path now encodes the text and truncates at `maxBytes` before decoding and applying `maxChars`, matching the existing stream path contract. The truncated byte buffer is decoded with `{ stream: true }` so an incomplete multi-byte UTF-8 sequence at the cut point is dropped rather than rendered as a replacement character.

## User Impact

Provider error snippets (used in MiniMax VLM and native PDF provider error messages) now respect the configured byte budget in all response shapes. No API or config surface changes.

## Evidence

**Real behavior proof (fix).** The body-less path now enforces `maxBytes`:

```
[case 1] body-less path: text under maxBytes returns unmodified
  ok: returns original text
[case 2] body-less path: text exceeding maxBytes is truncated
  ok: result within maxBytes
  bytes returned: 100 / 100 max
[case 3] body-less path: UTF-8 multi-byte not corrupted at byte boundary
  ok: no replacement character
  ok: returns ab
  result: "ab" (bytes=2)
[case 4] stream path: enforces maxBytes (regression guard)
  ok: stream path respects maxBytes
[case 5] maxBytes=0 returns empty string
  ok: maxBytes=0 returns empty

ALL PROOF ASSERTIONS: 6 passed, 0 failed
```

**Negative control (pre-fix main).** Same proof script against `origin/main` — `maxBytes` is ignored, full text returned:

```
[case 2] body-less path: text exceeding maxBytes is truncated
  FAIL: result within maxBytes
  bytes returned: 5000 / 100 max
[case 3] body-less path: UTF-8 multi-byte not corrupted at byte boundary
  FAIL: returns ab
  result: "ab😀cd" (bytes=8)
[case 5] maxBytes=0 returns empty string
  FAIL: maxBytes=0 returns empty

ALL PROOF ASSERTIONS: 3 passed, 3 failed
exit=1
```

**Focused tests:**

```
node scripts/run-vitest.mjs src/infra/http-error-body.test.ts
Tests  9 passed (9)
```

**Caller regression:**

```
node scripts/run-vitest.mjs src/agents/minimax-vlm.normalizes-api-key.test.ts
Tests  12 passed (12)

node scripts/run-vitest.mjs src/agents/tools/pdf-native-providers.test.ts
Tests  20 passed (20)
```

**Format:** `oxfmt --check` clean on both changed files.