### PR TITLE
fix(web-search): advertise the selected provider's real parameters

### DIFF
--- a/docs/tools/web.md
+++ b/docs/tools/web.md
@@ -368,10 +368,16 @@ show the `x_search` prompt.
 
 ## Tool parameters
 
+The `web_search` tool advertises the parameter schema of the provider it will
+actually use, so the exact parameters the model sees depend on your selected (or
+auto-detected) provider (for example, Exa also exposes `type` and `contents`,
+and allows a higher `count`). When no provider can be resolved yet, it falls
+back to the superset below, which keeps every historically supported parameter.
+
 | Parameter             | Description                                           |
 | --------------------- | ----------------------------------------------------- |
 | `query`               | Search query (required)                               |
-| `count`               | Results to return (1-10, default: 5)                  |
+| `count`               | Results to return (fallback range 1-10, default: 5)   |
 | `country`             | 2-letter ISO country code (e.g. "US", "DE")           |
 | `language`            | ISO 639-1 language code (e.g. "en", "de")             |
 | `search_lang`         | Search-language code (Brave only)                     |

--- a/src/agents/tools/web-search.late-bind.test.ts
+++ b/src/agents/tools/web-search.late-bind.test.ts
@@ -12,6 +12,7 @@ const mocks = vi.hoisted(() => ({
 
 vi.mock("../../web-search/runtime.js", () => ({
   resolveWebSearchProviderId: vi.fn(() => "mock"),
+  resolveWebSearchToolSchema: vi.fn(() => undefined),
   runWebSearch: mocks.runWebSearch,
 }));
 

--- a/src/agents/tools/web-search.signal.test.ts
+++ b/src/agents/tools/web-search.signal.test.ts
@@ -9,6 +9,7 @@ const mocks = vi.hoisted(() => ({
 
 vi.mock("../../web-search/runtime.js", () => ({
   resolveWebSearchProviderId: vi.fn(() => "mock"),
+  resolveWebSearchToolSchema: vi.fn(() => undefined),
   runWebSearch: mocks.runWebSearch,
 }));
 

--- a/src/agents/tools/web-search.test.ts
+++ b/src/agents/tools/web-search.test.ts
@@ -1,6 +1,8 @@
 // Web search tests cover model-facing schema limits, provider-specific time
 // filters, unsupported filter errors, and scoped provider config merging.
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it } from "vitest";
+import { createEmptyPluginRegistry } from "../../plugins/registry-empty.js";
+import { setActivePluginRegistry } from "../../plugins/runtime.js";
 import {
   MAX_SEARCH_COUNT,
   buildUnsupportedSearchFilterResponse,
@@ -219,5 +221,227 @@ describe("web_search scoped config merge", () => {
     expect(Object.keys(merged ?? {})).toEqual(["enabled", "provider"]);
 
     expect(Object.getOwnPropertyDescriptor(merged, "perplexity")?.enumerable).toBe(false);
+  });
+});
+
+describe("web_search tool schema reflects the active provider", () => {
+  // unit-fast shares globals across files; always restore an empty registry.
+  afterEach(() => {
+    setActivePluginRegistry(createEmptyPluginRegistry());
+  });
+
+  function registerProviderWithSchema(parameters: Record<string, unknown>): void {
+    const registry = createEmptyPluginRegistry();
+    registry.webSearchProviders.push({
+      pluginId: "custom-search",
+      pluginName: "Custom Search",
+      source: "test",
+      provider: {
+        id: "custom",
+        label: "Custom Search",
+        hint: "Custom provider",
+        envVars: [],
+        placeholder: "custom-...",
+        signupUrl: "https://example.com",
+        autoDetectOrder: 1,
+        credentialPath: "tools.web.search.custom.apiKey",
+        getCredentialValue: () => "configured",
+        setCredentialValue: () => {},
+        createTool: () => ({
+          description: "custom tool",
+          parameters,
+          execute: async () => ({ ok: true }),
+        }),
+      },
+    });
+    setActivePluginRegistry(registry);
+  }
+
+  it("advertises the selected provider's own parameter schema", () => {
+    registerProviderWithSchema({
+      type: "object",
+      required: ["query"],
+      properties: {
+        query: { type: "string" },
+        custom_knob: { type: "string", description: "provider-specific knob" },
+      },
+    });
+
+    const tool = createWebSearchTool({
+      config: { tools: { web: { search: { provider: "custom" } } } },
+    });
+    const parameters = tool?.parameters as { properties?: Record<string, unknown> } | undefined;
+    const properties = parameters?.properties;
+
+    // Provider-owned schema is surfaced verbatim; core no longer hardcodes it.
+    expect(properties?.custom_knob).toBeDefined();
+  });
+
+  it("falls back to the back-compat superset when no provider is active", () => {
+    setActivePluginRegistry(createEmptyPluginRegistry());
+
+    const tool = createWebSearchTool({
+      config: { tools: { web: { search: { provider: "custom" } } } },
+    });
+    const parameters = tool?.parameters as { properties?: Record<string, unknown> } | undefined;
+    const properties = parameters?.properties;
+
+    // Fallback keeps every historically shipped parameter (Brave/Perplexity
+    // knobs included) so nothing is lost when no provider is active; unknown
+    // provider-specific knobs still do not leak in.
+    expect(properties?.country).toBeDefined();
+    expect(properties?.search_lang).toBeDefined();
+    expect(properties?.custom_knob).toBeUndefined();
+  });
+
+  it("does not advertise a backup provider's schema for an explicitly selected unavailable provider", () => {
+    // runWebSearch throws (no fallback) when an explicitly configured provider
+    // is unavailable, so the schema must not leak a different provider's
+    // parameters. It falls back to the superset instead.
+    const registry = createEmptyPluginRegistry();
+    registry.webSearchProviders.push(
+      {
+        pluginId: "unavailable-search",
+        pluginName: "Unavailable Search",
+        source: "test",
+        provider: {
+          id: "unavailable",
+          label: "Unavailable Search",
+          hint: "Unavailable provider",
+          envVars: [],
+          placeholder: "unavailable-...",
+          signupUrl: "https://example.com",
+          autoDetectOrder: 1,
+          credentialPath: "tools.web.search.unavailable.apiKey",
+          getCredentialValue: () => "configured",
+          setCredentialValue: () => {},
+          createTool: () => null,
+        },
+      },
+      {
+        pluginId: "backup-search",
+        pluginName: "Backup Search",
+        source: "test",
+        provider: {
+          id: "backup",
+          label: "Backup Search",
+          hint: "Backup provider",
+          envVars: [],
+          placeholder: "backup-...",
+          signupUrl: "https://example.com",
+          autoDetectOrder: 2,
+          credentialPath: "tools.web.search.backup.apiKey",
+          getCredentialValue: () => "configured",
+          setCredentialValue: () => {},
+          createTool: () => ({
+            description: "backup tool",
+            parameters: {
+              type: "object",
+              required: ["query"],
+              properties: {
+                query: { type: "string" },
+                backup_knob: { type: "string" },
+              },
+            },
+            execute: async () => ({ ok: true }),
+          }),
+        },
+      },
+    );
+    setActivePluginRegistry(registry);
+
+    const tool = createWebSearchTool({
+      config: { tools: { web: { search: { provider: "unavailable" } } } },
+    });
+    const parameters = tool?.parameters as { properties?: Record<string, unknown> } | undefined;
+    const properties = parameters?.properties;
+
+    // Explicit selection never falls back to another provider: no backup_knob.
+    expect(properties?.backup_knob).toBeUndefined();
+    // Superset fallback is advertised instead so the model keeps usable filters.
+    expect(properties?.country).toBeDefined();
+    expect(properties?.search_lang).toBeDefined();
+  });
+
+  function makeProviderEntry(opts: {
+    id: string;
+    autoDetectOrder: number;
+    signal: boolean;
+    schema: Record<string, unknown> | null;
+  }) {
+    return {
+      pluginId: `${opts.id}-search`,
+      pluginName: `${opts.id} Search`,
+      source: "test",
+      provider: {
+        id: opts.id,
+        label: `${opts.id} Search`,
+        hint: `${opts.id} provider`,
+        requiresCredential: opts.signal ? undefined : false,
+        envVars: [],
+        placeholder: `${opts.id}-...`,
+        signupUrl: "https://example.com",
+        autoDetectOrder: opts.autoDetectOrder,
+        credentialPath: `tools.web.search.${opts.id}.apiKey`,
+        getConfiguredCredentialValue: () => (opts.signal ? "configured-key" : undefined),
+        getCredentialValue: () => (opts.signal ? "configured-key" : undefined),
+        setCredentialValue: () => {},
+        createTool: () =>
+          opts.schema === null
+            ? null
+            : {
+                description: `${opts.id} tool`,
+                parameters: opts.schema,
+                execute: async () => ({ ok: true }),
+              },
+      },
+    } as never;
+  }
+
+  const backupSchema = {
+    type: "object",
+    required: ["query"],
+    properties: { query: { type: "string" }, backup_knob: { type: "string" } },
+  };
+
+  it("does not advertise an unconfigured backup provider's schema during auto-detect", () => {
+    // Auto-detect only falls through to providers execution would try
+    // (hasImplicitProviderSelectionSignal). The preferred provider has a
+    // credential signal but is unavailable; the backup has no signal, so its
+    // schema must not be advertised.
+    const registry = createEmptyPluginRegistry();
+    registry.webSearchProviders.push(
+      makeProviderEntry({ id: "preferred", autoDetectOrder: 1, signal: true, schema: null }),
+      makeProviderEntry({ id: "backup", autoDetectOrder: 2, signal: false, schema: backupSchema }),
+    );
+    setActivePluginRegistry(registry);
+
+    const tool = createWebSearchTool({
+      config: { tools: { web: { search: { enabled: true } } } },
+    });
+    const properties = (tool?.parameters as { properties?: Record<string, unknown> } | undefined)
+      ?.properties;
+
+    expect(properties?.backup_knob).toBeUndefined();
+    expect(properties?.country).toBeDefined();
+  });
+
+  it("advertises a configured backup provider's schema during auto-detect fallback", () => {
+    // A backup provider that execution would try (has a credential signal) is
+    // advertised when the preferred provider is unavailable.
+    const registry = createEmptyPluginRegistry();
+    registry.webSearchProviders.push(
+      makeProviderEntry({ id: "preferred", autoDetectOrder: 1, signal: true, schema: null }),
+      makeProviderEntry({ id: "backup", autoDetectOrder: 2, signal: true, schema: backupSchema }),
+    );
+    setActivePluginRegistry(registry);
+
+    const tool = createWebSearchTool({
+      config: { tools: { web: { search: { enabled: true } } } },
+    });
+    const properties = (tool?.parameters as { properties?: Record<string, unknown> } | undefined)
+      ?.properties;
+
+    expect(properties?.backup_knob).toBeDefined();
   });
 });

--- a/src/agents/tools/web-search.ts
+++ b/src/agents/tools/web-search.ts
@@ -5,13 +5,24 @@
  */
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import type { RuntimeWebSearchMetadata } from "../../secrets/runtime-web-tools.types.js";
-import { resolveWebSearchProviderId, runWebSearch } from "../../web-search/runtime.js";
+import {
+  resolveWebSearchProviderId,
+  resolveWebSearchToolSchema,
+  runWebSearch,
+} from "../../web-search/runtime.js";
 import type { AnyAgentTool } from "./common.js";
 import { asToolParamsRecord, jsonResult } from "./common.js";
 import { MAX_SEARCH_COUNT, SEARCH_CACHE } from "./web-search-provider-common.js";
 import { resolveWebSearchToolRuntimeContext } from "./web-tool-runtime-context.js";
 
-const WebSearchSchema = {
+// Back-compat fallback schema. When a concrete provider can be resolved at
+// build time, resolveWebSearchToolSchema returns that provider's own (more
+// accurate) schema instead. This union is advertised only when no provider is
+// active yet (before startup activation, or when nothing is configured /
+// detected). It intentionally keeps every historically shipped parameter so the
+// model never loses parameters it had before this fast path existed; keep it as
+// the union of provider-specific knobs.
+const WEB_SEARCH_FALLBACK_SCHEMA = {
   type: "object",
   required: ["query"],
   properties: {
@@ -86,11 +97,29 @@ export function createWebSearchTool(options?: {
     return null;
   }
 
+  // Advertise the schema of the provider this tool would actually use, so the
+  // model sees provider-accurate parameters instead of a hand-maintained
+  // superset. Uses the same late-bound runtime context as execution; falls back
+  // to the generic base schema when no concrete provider resolves.
+  const schemaContext = resolveWebSearchToolRuntimeContext({
+    config: options?.config,
+    lateBindRuntimeConfig: options?.lateBindRuntimeConfig,
+    runtimeWebSearch: options?.runtimeWebSearch,
+  });
+  const parameters =
+    resolveWebSearchToolSchema({
+      config: schemaContext.config,
+      agentDir: options?.agentDir,
+      sandboxed: options?.sandboxed,
+      runtimeWebSearch: schemaContext.runtimeWebSearch,
+      preferRuntimeProviders: schemaContext.preferRuntimeProviders,
+    }) ?? WEB_SEARCH_FALLBACK_SCHEMA;
+
   return {
     label: "Web Search",
     name: "web_search",
     description: "Search web for current info; returns normalized provider results.",
-    parameters: WebSearchSchema,
+    parameters,
     execute: async (_toolCallId, args, signal) => {
       // Late binding lets long-lived agents pick up runtime web-search credentials/config without
       // rebuilding the tool object.

--- a/src/agents/tools/web-tools.enabled-defaults.test.ts
+++ b/src/agents/tools/web-tools.enabled-defaults.test.ts
@@ -81,6 +81,7 @@ vi.mock("../../web-search/runtime.js", async () => {
   return {
     resolveWebSearchDefinition: resolveRuntimeDefinition,
     resolveWebSearchProviderId: () => "",
+    resolveWebSearchToolSchema: () => undefined,
     runWebSearch: async (options: {
       config?: unknown;
       args: Record<string, unknown>;

--- a/src/plugins/web-search-providers.runtime.ts
+++ b/src/plugins/web-search-providers.runtime.ts
@@ -2,6 +2,7 @@
 import { loadOpenClawPlugins } from "./loader.js";
 import type { PluginLoadOptions } from "./loader.js";
 import type { PluginManifestRecord } from "./manifest-registry.js";
+import { getActivePluginRegistry } from "./runtime.js";
 import type { PluginWebSearchProviderEntry } from "./types.js";
 import { resolveBundledWebSearchProvidersFromPublicArtifacts } from "./web-provider-public-artifacts.js";
 import {
@@ -62,6 +63,20 @@ export function resolvePluginWebSearchProviders(params: {
     mapRegistryProviders: mapRegistryWebSearchProviders,
     resolveBundledPublicArtifactProviders: resolveBundledWebSearchProvidersFromPublicArtifacts,
   });
+}
+
+/**
+ * Reads web-search providers from the already-active plugin registry without
+ * triggering a plugin load. Building model-facing tool schema runs on the agent
+ * hot path (and in isolated tool tests), so it must never cold-load the full
+ * plugin runtime; callers fall back to a generic schema when nothing is active.
+ */
+export function resolveActiveWebSearchProviders(): PluginWebSearchProviderEntry[] {
+  const registry = getActivePluginRegistry();
+  if (!registry) {
+    return [];
+  }
+  return mapRegistryWebSearchProviders({ registry });
 }
 
 export function resolveRuntimeWebSearchProviders(params: {

--- a/src/web-search/runtime.ts
+++ b/src/web-search/runtime.ts
@@ -4,6 +4,13 @@ import {
   normalizeOptionalLowercaseString,
 } from "@openclaw/normalization-core/string-coerce";
 import { uniqueStrings } from "@openclaw/normalization-core/string-normalization";
+import type { TSchema } from "typebox";
+import {
+  hasWebProviderEntryCredential,
+  providerRequiresCredential,
+  readWebProviderEnvValue,
+  resolveWebProviderConfig,
+} from "../../packages/web-content-core/src/provider-runtime-shared.js";
 import { resolveDefaultAgentDir } from "../agents/agent-scope-config.js";
 import { hasAuthProfileForProvider } from "../agents/tools/model-config.helpers.js";
 import {
@@ -16,18 +23,13 @@ import { logVerbose } from "../globals.js";
 import { resolveManifestContractOwnerPluginId } from "../plugins/plugin-registry-contributions.js";
 import type { PluginWebSearchProviderEntry } from "../plugins/types.js";
 import {
+  resolveActiveWebSearchProviders,
   resolvePluginWebSearchProviders,
   resolveRuntimeWebSearchProviders,
 } from "../plugins/web-search-providers.runtime.js";
 import { sortWebSearchProvidersForAutoDetect } from "../plugins/web-search-providers.shared.js";
 import { getActiveRuntimeWebToolsMetadata } from "../secrets/runtime-web-tools-state.js";
 import type { RuntimeWebSearchMetadata } from "../secrets/runtime-web-tools.types.js";
-import {
-  hasWebProviderEntryCredential,
-  providerRequiresCredential,
-  readWebProviderEnvValue,
-  resolveWebProviderConfig,
-} from "../../packages/web-content-core/src/provider-runtime-shared.js";
 import type {
   ResolveWebSearchDefinitionParams,
   RunWebSearchParams,
@@ -443,6 +445,101 @@ function isStructuredAvailabilityError(result: unknown): result is { error: stri
   }
   const error = (result as { error?: unknown }).error;
   return typeof error === "string" && /^missing_[a-z0-9_]*api_key$/i.test(error);
+}
+
+/**
+ * Resolves the model-facing web_search schema from the provider that a request
+ * would actually use. Provider plugins own their own parameter shape, so the
+ * tool advertises exactly what the resolved provider supports (Brave's
+ * search_lang/ui_lang, Perplexity's domain_filter/max_tokens, Exa's type/
+ * contents, and so on) instead of a hand-maintained core superset. Mirrors
+ * runWebSearch selection semantics: explicit selection never falls back, while
+ * implicit auto-detect only falls through to providers execution would try
+ * (same credential-signal filter as runWebSearch). Returns undefined when no
+ * provider can be resolved so the tool falls back to the superset schema.
+ * Best-effort: any resolution failure yields undefined.
+ */
+export function resolveWebSearchToolSchema(
+  options?: ResolveWebSearchDefinitionParams,
+): TSchema | undefined {
+  try {
+    const { config, search, runtimeWebSearch } = resolveWebSearchRequestContext(options);
+    if (!resolveWebSearchEnabled({ search, sandboxed: options?.sandboxed })) {
+      return undefined;
+    }
+    // Read only the already-active registry; schema construction must never
+    // cold-load the plugin runtime. Fall back to the base schema when nothing
+    // is active yet.
+    const providers = sortWebSearchProvidersForAutoDetect(resolveActiveWebSearchProviders());
+    if (providers.length === 0) {
+      return undefined;
+    }
+    const targetId =
+      resolveExplicitWebSearchProviderId({
+        search,
+        runtimeWebSearch,
+        providerId: options?.providerId,
+        includeRuntimeSelection: true,
+      }) ??
+      resolveRuntimePreferredWebSearchProviderId({
+        config,
+        search,
+        runtimeWebSearch,
+        providers,
+        agentDir: options?.agentDir,
+      }) ??
+      resolveWebSearchProviderId({ config, search, providers, agentDir: options?.agentDir });
+    if (!targetId) {
+      return undefined;
+    }
+    const targetEntry = providers.find((provider) => provider.id === targetId);
+    if (!targetEntry) {
+      return undefined;
+    }
+    const buildParameters = (provider: PluginWebSearchProviderEntry): TSchema | undefined =>
+      provider.createTool({
+        config,
+        agentDir: options?.agentDir,
+        searchConfig: search as Record<string, unknown> | undefined,
+        runtimeMetadata: runtimeWebSearch,
+      })?.parameters;
+
+    // Mirror runWebSearch selection semantics. Explicit selection (configured
+    // or runtime-pinned provider) never falls back: runWebSearch throws when the
+    // selected provider is unavailable rather than running another one, so the
+    // schema must advertise only that provider (or the superset when it yields
+    // no definition), never a backup provider's parameters.
+    const allowFallback = !hasExplicitWebSearchSelection({
+      search,
+      runtimeWebSearch,
+      providerId: options?.providerId,
+      providers,
+    });
+    if (!allowFallback) {
+      return buildParameters(targetEntry);
+    }
+    // Implicit auto-detect can fall through, but only to providers execution
+    // would actually try. runWebSearch filters implicit fallback candidates by
+    // hasImplicitProviderSelectionSignal, so mirror that filter here: never
+    // advertise the schema of an unconfigured provider that execution would skip.
+    const orderedCandidates = [
+      targetEntry,
+      ...providers.filter(
+        (provider) =>
+          provider.id !== targetId &&
+          hasImplicitProviderSelectionSignal(provider, config, search, options?.agentDir),
+      ),
+    ];
+    for (const candidate of orderedCandidates) {
+      const parameters = buildParameters(candidate);
+      if (parameters) {
+        return parameters;
+      }
+    }
+    return undefined;
+  } catch {
+    return undefined;
+  }
 }
 
 /** Executes web_search with fallback when selection was not explicit. */


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where the `web_search` tool advertised the wrong parameters to the agent for the configured search provider.

Because the tool exposed a single fixed core parameter set (a hand-maintained superset), the parameters the model saw did not match the active provider:

- **Exa capabilities were unreachable.** Exa's `type` (search mode) and `contents` (highlights/text/summary) options, and its higher `count` limit (up to 100 vs the fixed max of 10), were never advertised, so the model could not use them even with Exa selected.
- **Other providers surfaced invalid parameters.** With providers such as Gemini, Grok, Kimi, or xAI, the model still saw Brave/Perplexity-only knobs (`search_lang`, `ui_lang`, `domain_filter`, `max_tokens`, `max_tokens_per_page`) that those providers ignore or reject, wasting tokens and encouraging invalid tool calls.

## Why This Change Was Made

The tool now builds its parameter schema from the resolved provider's own definition, so the model sees exactly what the selected (or auto-detected) provider supports. Schema resolution reads only the already-active plugin registry and never cold-loads plugins, keeping tool construction cheap on the agent hot path. When no provider can be resolved yet, the tool falls back to the previous superset, so prior behavior is preserved and no parameters are lost.

Schema selection mirrors `runWebSearch` execution semantics. Explicit selection (a configured or runtime-pinned provider) never falls back: if the selected provider is unavailable it advertises the superset rather than a different provider's parameters, matching `runWebSearch`, which throws for an explicit selection instead of running another provider. Only implicit auto-detect walks on to the next available provider. The tool description stays provider-agnostic; only the input parameters follow the selected provider.

## User Impact

- With Exa selected, the agent can use `type`, `contents`, and request up to Exa's higher result count.
- With answer-style or other providers, the agent no longer sees parameters the provider cannot honor.
- No configuration changes are required; the fallback preserves prior behavior when no provider is active.

## Evidence

### Real behavior: advertised schema per provider

Loaded the real bundled web-search provider registry (15 providers: `brave, codex, duckduckgo, exa, firecrawl, gemini, grok, kimi, minimax, ollama, parallel, parallel-free, perplexity, searxng, tavily`) and built the `web_search` tool through the production path (`createWebSearchTool`), then captured the exact parameter schema the agent advertises for each configured provider. Output is schema-only (no prompt or message text).

| `tools.web.search.provider` | `count` max | provider-specific params present | notes |
| --- | --- | --- | --- |
| `exa` | 100 | `type`, `contents` | Exa capabilities now reachable (previously never advertised) |
| `brave` | 10 | `search_lang`, `ui_lang` | Brave-only locale knobs |
| `perplexity` | 10 | `domain_filter`, `max_tokens`, `max_tokens_per_page` | Perplexity-only content controls |
| `gemini` | 10 | none of `search_lang` / `ui_lang` / `domain_filter` | answer-style provider no longer sees unusable knobs |
| `codex` (native search disabled) | 10 | superset (`search_lang` **and** `domain_filter` both present) | explicitly selected but unavailable -> falls back to the superset, not another provider's schema |

The `codex` row is the explicit-selection fallback check: an explicitly selected provider whose `createTool()` returns `null` (native Codex search disabled) advertises the back-compat superset (Brave and Perplexity knobs together), never a single backup provider's parameters, matching `runWebSearch` no-fallback behavior for explicit selection.

### Focused tests

```
pnpm test \
  src/agents/tools/web-search.test.ts \
  src/agents/tools/web-search.signal.test.ts \
  src/agents/tools/web-search.late-bind.test.ts \
  src/agents/tools/web-tools.enabled-defaults.test.ts \
  src/web-search/runtime.test.ts \
  extensions/brave/src/brave-web-search-provider.test.ts \
  extensions/perplexity/src/perplexity-web-search-provider.test.ts

Tests  113 passed
```

New behavior tests assert the fix directly:

- With an active provider selected, the tool advertises that provider's own schema (a provider-specific parameter is present).
- An explicitly selected but unavailable provider falls back to the superset (generic filters plus the Brave/Perplexity knobs) and does not leak a backup provider's parameters.
- `src/web-search/runtime.test.ts` continues to assert that explicit provider selection does not fall back at execution time, so the advertised schema and execution stay in sync.

### Snapshots

The prompt-snapshot fixtures under `test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/` are unchanged: the snapshot generator resolves no active web_search provider, so it uses the fallback superset, which is byte-aligned with the previous schema, and the tool description is unchanged.

`pnpm build`, `pnpm check`, and the Linux-only prompt-snapshot check run in CI on this branch.
