### PR TITLE
fix: recognize limited Photos access on iOS

### DIFF
--- a/apps/.i18n/native-source.json
+++ b/apps/.i18n/native-source.json
@@ -10125,9 +10125,9 @@
       "kind": "plist-string",
       "line": 74,
       "path": "apps/ios/Sources/Info.plist",
-      "source": "OpenClaw needs photo library access when you choose existing photos to share with your assistant.",
+      "source": "OpenClaw needs photo library access when you choose existing photos to share with your assistant or allow your Gateway to return recent photos.",
       "surface": "apple",
-      "id": "native.apple.b6c35a14bb309193"
+      "id": "native.apple.cb1f8b07fe11df22"
     },
     {
       "kind": "plist-string",
@@ -11115,7 +11115,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 14,
+      "line": 16,
       "path": "apps/ios/Sources/Settings/PrivacyAccessSectionView.swift",
       "source": "Privacy & Access",
       "surface": "apple",
@@ -11123,7 +11123,23 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 16,
+      "line": 18,
+      "path": "apps/ios/Sources/Settings/PrivacyAccessSectionView.swift",
+      "source": "Photos",
+      "surface": "apple",
+      "id": "native.apple.eda8d96e40bcc36a"
+    },
+    {
+      "kind": "ui-named-argument",
+      "line": 21,
+      "path": "apps/ios/Sources/Settings/PrivacyAccessSectionView.swift",
+      "source": "Allow the Gateway to read photos you grant to OpenClaw.",
+      "surface": "apple",
+      "id": "native.apple.74c1204cac0d231b"
+    },
+    {
+      "kind": "ui-named-argument",
+      "line": 26,
       "path": "apps/ios/Sources/Settings/PrivacyAccessSectionView.swift",
       "source": "Contacts",
       "surface": "apple",
@@ -11131,7 +11147,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 19,
+      "line": 29,
       "path": "apps/ios/Sources/Settings/PrivacyAccessSectionView.swift",
       "source": "Search and add contacts from the assistant.",
       "surface": "apple",
@@ -11139,7 +11155,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 24,
+      "line": 34,
       "path": "apps/ios/Sources/Settings/PrivacyAccessSectionView.swift",
       "source": "Calendar (Add Events)",
       "surface": "apple",
@@ -11147,7 +11163,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 27,
+      "line": 37,
       "path": "apps/ios/Sources/Settings/PrivacyAccessSectionView.swift",
       "source": "Add events with least privilege.",
       "surface": "apple",
@@ -11155,7 +11171,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 32,
+      "line": 42,
       "path": "apps/ios/Sources/Settings/PrivacyAccessSectionView.swift",
       "source": "Calendar (View Events)",
       "surface": "apple",
@@ -11163,7 +11179,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 35,
+      "line": 45,
       "path": "apps/ios/Sources/Settings/PrivacyAccessSectionView.swift",
       "source": "List and read calendar events.",
       "surface": "apple",
@@ -11171,7 +11187,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 40,
+      "line": 50,
       "path": "apps/ios/Sources/Settings/PrivacyAccessSectionView.swift",
       "source": "Reminders",
       "surface": "apple",
@@ -11179,7 +11195,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 43,
+      "line": 53,
       "path": "apps/ios/Sources/Settings/PrivacyAccessSectionView.swift",
       "source": "List, add, and complete reminders.",
       "surface": "apple",
@@ -11187,7 +11203,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 236,
+      "line": 277,
       "path": "apps/ios/Sources/Settings/PrivacyAccessSectionView.swift",
       "source": "Allowed",
       "surface": "apple",
@@ -11195,7 +11211,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 238,
+      "line": 279,
       "path": "apps/ios/Sources/Settings/PrivacyAccessSectionView.swift",
       "source": "Add-Only",
       "surface": "apple",
@@ -11203,7 +11219,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 240,
+      "line": 281,
       "path": "apps/ios/Sources/Settings/PrivacyAccessSectionView.swift",
       "source": "Not Set",
       "surface": "apple",
@@ -11211,7 +11227,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 242,
+      "line": 283,
       "path": "apps/ios/Sources/Settings/PrivacyAccessSectionView.swift",
       "source": "Not Allowed",
       "surface": "apple",
@@ -11219,7 +11235,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 244,
+      "line": 285,
       "path": "apps/ios/Sources/Settings/PrivacyAccessSectionView.swift",
       "source": "Unknown",
       "surface": "apple",

--- a/apps/ios/Sources/Gateway/GatewayConnectionController.swift
+++ b/apps/ios/Sources/Gateway/GatewayConnectionController.swift
@@ -1121,8 +1121,7 @@ extension GatewayConnectionController {
             status: locationStatus)
         permissions["screenRecording"] = RPScreenRecorder.shared().isAvailable
 
-        let photoStatus = PHPhotoLibrary.authorizationStatus(for: .readWrite)
-        permissions["photos"] = photoStatus == .authorized || photoStatus == .limited
+        permissions["photos"] = PhotoLibraryPermission.isAllowed(PhotoLibraryPermission.authorizationStatus())
         let contactsStatus = CNContactStore.authorizationStatus(for: .contacts)
         permissions["contacts"] = contactsStatus == .authorized || contactsStatus == .limited
 

--- a/apps/ios/Sources/Info.plist
+++ b/apps/ios/Sources/Info.plist
@@ -71,7 +71,7 @@
 	<key>NSMotionUsageDescription</key>
 	<string>OpenClaw may use motion data to support device-aware interactions and automations.</string>
 	<key>NSPhotoLibraryUsageDescription</key>
-	<string>OpenClaw needs photo library access when you choose existing photos to share with your assistant.</string>
+	<string>OpenClaw needs photo library access when you choose existing photos to share with your assistant or allow your Gateway to return recent photos.</string>
 	<key>NSRemindersFullAccessUsageDescription</key>
 	<string>OpenClaw uses your reminders to list, add, and complete tasks when you enable reminders access.</string>
 	<key>NSSpeechRecognitionUsageDescription</key>

--- a/apps/ios/Sources/Media/PhotoLibraryPermission.swift
+++ b/apps/ios/Sources/Media/PhotoLibraryPermission.swift
@@ -1,0 +1,45 @@
+import Photos
+
+enum PhotoLibraryPermission {
+    enum Action: Equatable {
+        case requestAccess
+        case openSettings
+    }
+
+    struct State: Equatable {
+        let statusText: String
+        let isAllowed: Bool
+        let action: Action?
+    }
+
+    static func authorizationStatus() -> PHAuthorizationStatus {
+        PHPhotoLibrary.authorizationStatus(for: .readWrite)
+    }
+
+    static func isAllowed(_ status: PHAuthorizationStatus) -> Bool {
+        self.state(for: status).isAllowed
+    }
+
+    static func state(for status: PHAuthorizationStatus) -> State {
+        switch status {
+        case .authorized:
+            State(statusText: "Allowed", isAllowed: true, action: nil)
+        case .limited:
+            State(statusText: "Limited", isAllowed: true, action: nil)
+        case .notDetermined:
+            State(statusText: "Not Set", isAllowed: false, action: .requestAccess)
+        case .denied, .restricted:
+            State(statusText: "Not Allowed", isAllowed: false, action: .openSettings)
+        @unknown default:
+            State(statusText: "Unknown", isAllowed: false, action: nil)
+        }
+    }
+
+    static func requestReadWriteAccess() async -> Bool {
+        await PermissionRequestBridge.awaitRequest { completion in
+            PHPhotoLibrary.requestAuthorization(for: .readWrite) { status in
+                completion(self.isAllowed(status))
+            }
+        }
+    }
+}

--- a/apps/ios/Sources/Media/PhotoLibraryService.swift
+++ b/apps/ios/Sources/Media/PhotoLibraryService.swift
@@ -56,7 +56,7 @@ final class PhotoLibraryService: PhotosServicing {
 
     private static func ensureAuthorization() async -> PHAuthorizationStatus {
         // Don’t prompt during node.invoke; prompts block the invoke and lead to timeouts.
-        PHPhotoLibrary.authorizationStatus(for: .readWrite)
+        PhotoLibraryPermission.authorizationStatus()
     }
 
     private static func renderAsset(

--- a/apps/ios/Sources/Settings/PrivacyAccessSectionView.swift
+++ b/apps/ios/Sources/Settings/PrivacyAccessSectionView.swift
@@ -1,9 +1,11 @@
 import Contacts
 import EventKit
+import Photos
 import SwiftUI
 import UIKit
 
 struct PrivacyAccessSectionView: View {
+    @State private var photosStatus: PHAuthorizationStatus = PhotoLibraryPermission.authorizationStatus()
     @State private var contactsStatus: CNAuthorizationStatus = CNContactStore.authorizationStatus(for: .contacts)
     @State private var calendarStatus: EKAuthorizationStatus = EKEventStore.authorizationStatus(for: .event)
     @State private var remindersStatus: EKAuthorizationStatus = EKEventStore.authorizationStatus(for: .reminder)
@@ -12,6 +14,14 @@ struct PrivacyAccessSectionView: View {
 
     var body: some View {
         DisclosureGroup("Privacy & Access") {
+            self.permissionRow(
+                title: "Photos",
+                icon: "photo.on.rectangle",
+                status: self.photosPermissionState.statusText,
+                detail: "Allow the Gateway to read photos you grant to OpenClaw.",
+                actionTitle: self.photosActionTitle,
+                action: self.handlePhotosAction)
+
             self.permissionRow(
                 title: "Contacts",
                 icon: "person.crop.circle",
@@ -82,7 +92,7 @@ struct PrivacyAccessSectionView: View {
 
     private func statusColor(for status: String) -> Color {
         switch status {
-        case "Allowed":
+        case "Allowed", "Limited":
             OpenClawBrand.ok
         case "Not Set":
             OpenClawBrand.warn
@@ -90,6 +100,37 @@ struct PrivacyAccessSectionView: View {
             OpenClawBrand.warn
         default:
             OpenClawBrand.danger
+        }
+    }
+
+    private var photosPermissionState: PhotoLibraryPermission.State {
+        PhotoLibraryPermission.state(for: self.photosStatus)
+    }
+
+    private var photosActionTitle: String? {
+        switch self.photosPermissionState.action {
+        case .requestAccess:
+            "Request Access"
+        case .openSettings:
+            "Open Settings"
+        case nil:
+            nil
+        }
+    }
+
+    private func handlePhotosAction() {
+        switch self.photosPermissionState.action {
+        case .requestAccess:
+            Task {
+                _ = await PhotoLibraryPermission.requestReadWriteAccess()
+                await MainActor.run {
+                    self.refreshAll()
+                }
+            }
+        case .openSettings:
+            self.openSettings()
+        case nil:
+            break
         }
     }
 
@@ -279,6 +320,7 @@ struct PrivacyAccessSectionView: View {
     }
 
     private func refreshAll() {
+        self.photosStatus = PhotoLibraryPermission.authorizationStatus()
         self.contactsStatus = CNContactStore.authorizationStatus(for: .contacts)
         self.calendarStatus = EKEventStore.authorizationStatus(for: .event)
         self.remindersStatus = EKEventStore.authorizationStatus(for: .reminder)

--- a/apps/ios/Sources/sv.lproj/InfoPlist.strings
+++ b/apps/ios/Sources/sv.lproj/InfoPlist.strings
@@ -9,6 +9,6 @@
 "NSLocationAlwaysAndWhenInUseUsageDescription" = "OpenClaw kan dela din plats i bakgrunden när du aktiverar Alltid.";
 "NSMicrophoneUsageDescription" = "OpenClaw använder mikrofonen för realtidschatt, röstaktivering och tryck-och-prata.";
 "NSMotionUsageDescription" = "OpenClaw kan använda rörelsedata för att stödja enhetsmedvetna interaktioner och automatiseringar.";
-"NSPhotoLibraryUsageDescription" = "OpenClaw behöver åtkomst till bildbiblioteket när du väljer befintliga bilder att dela med din assistent.";
+"NSPhotoLibraryUsageDescription" = "OpenClaw behöver åtkomst till bildbiblioteket när du väljer befintliga bilder att dela med din assistent eller låter din Gateway returnera senaste bilder.";
 "NSRemindersFullAccessUsageDescription" = "OpenClaw använder dina påminnelser för att lista, lägga till och slutföra uppgifter när du aktiverar åtkomst till påminnelser.";
 "NSSpeechRecognitionUsageDescription" = "OpenClaw använder taligenkänning på enheten för Talk-läge och röstaktivering.";

--- a/apps/ios/Tests/PhotoLibraryPermissionTests.swift
+++ b/apps/ios/Tests/PhotoLibraryPermissionTests.swift
@@ -1,0 +1,29 @@
+import Photos
+import Testing
+@testable import OpenClaw
+
+struct PhotoLibraryPermissionTests {
+    @Test func `limited photo access is a usable gateway permission`() {
+        let state = PhotoLibraryPermission.state(for: .limited)
+
+        #expect(state.statusText == "Limited")
+        #expect(state.isAllowed)
+        #expect(state.action == nil)
+    }
+
+    @Test func `undetermined photo access can be requested from settings`() {
+        let state = PhotoLibraryPermission.state(for: .notDetermined)
+
+        #expect(state.statusText == "Not Set")
+        #expect(state.isAllowed == false)
+        #expect(state.action == .requestAccess)
+    }
+
+    @Test func `denied photo access routes to system settings`() {
+        let state = PhotoLibraryPermission.state(for: .denied)
+
+        #expect(state.statusText == "Not Allowed")
+        #expect(state.isAllowed == false)
+        #expect(state.action == .openSettings)
+    }
+}

--- a/apps/ios/project.yml
+++ b/apps/ios/project.yml
@@ -170,7 +170,7 @@ targets:
         NSLocationAlwaysAndWhenInUseUsageDescription: OpenClaw can share your location in the background when you enable Always.
         NSMicrophoneUsageDescription: OpenClaw uses the microphone for realtime chat, voice wake, and push-to-talk.
         NSMotionUsageDescription: OpenClaw may use motion data to support device-aware interactions and automations.
-        NSPhotoLibraryUsageDescription: OpenClaw needs photo library access when you choose existing photos to share with your assistant.
+        NSPhotoLibraryUsageDescription: OpenClaw needs photo library access when you choose existing photos to share with your assistant or allow your Gateway to return recent photos.
         NSRemindersFullAccessUsageDescription: OpenClaw uses your reminders to list, add, and complete tasks when you enable reminders access.
         NSSpeechRecognitionUsageDescription: OpenClaw uses on-device speech recognition for talk mode and voice wake.
         NSSupportsLiveActivities: true


### PR DESCRIPTION
Closes #99046

## What Problem This Solves

Fixes an issue where iOS users who granted Photos Limited Access would still see the Gateway report Photos as unavailable when using photo access from the paired node.

## Why This Change Was Made

The iOS app now centralizes Photos permission state so `.limited` is treated as a usable read permission everywhere the Gateway reports or checks photo access. Settings also exposes a Photos row so users can request access before invoking photo commands, while `photos.latest` still avoids prompting during node invocation.

## User Impact

Users who choose Limited Access for Photos can use Gateway photo reads for the photos they granted to OpenClaw instead of being blocked as if Photos access were missing. Users who have not granted Photos access can request it from Settings.

## Evidence

- `git diff --check`
- `node --import tsx scripts/native-app-i18n.ts check`
- `xcodebuild -project apps/ios/OpenClaw.xcodeproj -scheme OpenClaw -destination 'platform=iOS Simulator,name=iPhone 17' -configuration Debug test -only-testing:OpenClawTests/PhotoLibraryPermissionTests`
  - Passed: `PhotoLibraryPermissionTests`, 3/3
- `.agents/skills/autoreview/scripts/autoreview --mode local`
  - Clean: no accepted/actionable findings

Notes:
- The App Store screenshot lane was intentionally not used as PR proof because it captures store screenshots, not this Photos permission flow.
