### PR TITLE
fix(ios): add Photos permission controls

### DIFF
--- a/apps/.i18n/native-source.json
+++ b/apps/.i18n/native-source.json
@@ -11227,7 +11227,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 136,
+      "line": 137,
       "path": "apps/ios/Sources/Settings/PrivacyAccessSectionView.swift",
       "source": "Limited",
       "surface": "apple",
@@ -11235,7 +11235,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 149,
+      "line": 150,
       "path": "apps/ios/Sources/Settings/PrivacyAccessSectionView.swift",
       "source": "Read photos you select for the assistant.",
       "surface": "apple",
@@ -11243,7 +11243,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 149,
+      "line": 150,
       "path": "apps/ios/Sources/Settings/PrivacyAccessSectionView.swift",
       "source": "Read recent photos for the assistant.",
       "surface": "apple",
@@ -11251,7 +11251,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 296,
+      "line": 297,
       "path": "apps/ios/Sources/Settings/PrivacyAccessSectionView.swift",
       "source": "Allowed",
       "surface": "apple",
@@ -11259,7 +11259,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 298,
+      "line": 299,
       "path": "apps/ios/Sources/Settings/PrivacyAccessSectionView.swift",
       "source": "Add-Only",
       "surface": "apple",
@@ -11267,7 +11267,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 300,
+      "line": 301,
       "path": "apps/ios/Sources/Settings/PrivacyAccessSectionView.swift",
       "source": "Not Set",
       "surface": "apple",
@@ -11275,7 +11275,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 302,
+      "line": 303,
       "path": "apps/ios/Sources/Settings/PrivacyAccessSectionView.swift",
       "source": "Not Allowed",
       "surface": "apple",
@@ -11283,7 +11283,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 304,
+      "line": 305,
       "path": "apps/ios/Sources/Settings/PrivacyAccessSectionView.swift",
       "source": "Unknown",
       "surface": "apple",

--- a/apps/.i18n/native-source.json
+++ b/apps/.i18n/native-source.json
@@ -10157,13 +10157,13 @@
       "kind": "plist-string",
       "line": 74,
       "path": "apps/ios/Sources/Info.plist",
-      "source": "OpenClaw needs photo library access when you choose existing photos to share with your assistant.",
+      "source": "OpenClaw lets your assistant read photos you allow and lets you choose photos to share.",
       "surface": "apple",
-      "id": "native.apple.b6c35a14bb309193"
+      "id": "native.apple.40ed4259ec869f1b"
     },
     {
       "kind": "plist-string",
-      "line": 76,
+      "line": 78,
       "path": "apps/ios/Sources/Info.plist",
       "source": "OpenClaw uses your reminders to list, add, and complete tasks when you enable reminders access.",
       "surface": "apple",
@@ -10171,7 +10171,7 @@
     },
     {
       "kind": "plist-string",
-      "line": 78,
+      "line": 80,
       "path": "apps/ios/Sources/Info.plist",
       "source": "OpenClaw uses on-device speech recognition for talk mode and voice wake.",
       "surface": "apple",
@@ -11147,7 +11147,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 14,
+      "line": 17,
       "path": "apps/ios/Sources/Settings/PrivacyAccessSectionView.swift",
       "source": "Privacy & Access",
       "surface": "apple",
@@ -11155,7 +11155,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 16,
+      "line": 19,
       "path": "apps/ios/Sources/Settings/PrivacyAccessSectionView.swift",
       "source": "Contacts",
       "surface": "apple",
@@ -11163,7 +11163,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 19,
+      "line": 22,
       "path": "apps/ios/Sources/Settings/PrivacyAccessSectionView.swift",
       "source": "Search and add contacts from the assistant.",
       "surface": "apple",
@@ -11171,7 +11171,15 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 24,
+      "line": 27,
+      "path": "apps/ios/Sources/Settings/PrivacyAccessSectionView.swift",
+      "source": "Photos",
+      "surface": "apple",
+      "id": "native.apple.eda8d96e40bcc36a"
+    },
+    {
+      "kind": "ui-named-argument",
+      "line": 35,
       "path": "apps/ios/Sources/Settings/PrivacyAccessSectionView.swift",
       "source": "Calendar (Add Events)",
       "surface": "apple",
@@ -11179,7 +11187,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 27,
+      "line": 38,
       "path": "apps/ios/Sources/Settings/PrivacyAccessSectionView.swift",
       "source": "Add events with least privilege.",
       "surface": "apple",
@@ -11187,7 +11195,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 32,
+      "line": 43,
       "path": "apps/ios/Sources/Settings/PrivacyAccessSectionView.swift",
       "source": "Calendar (View Events)",
       "surface": "apple",
@@ -11195,7 +11203,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 35,
+      "line": 46,
       "path": "apps/ios/Sources/Settings/PrivacyAccessSectionView.swift",
       "source": "List and read calendar events.",
       "surface": "apple",
@@ -11203,7 +11211,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 40,
+      "line": 51,
       "path": "apps/ios/Sources/Settings/PrivacyAccessSectionView.swift",
       "source": "Reminders",
       "surface": "apple",
@@ -11211,7 +11219,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 43,
+      "line": 54,
       "path": "apps/ios/Sources/Settings/PrivacyAccessSectionView.swift",
       "source": "List, add, and complete reminders.",
       "surface": "apple",
@@ -11219,7 +11227,31 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 236,
+      "line": 136,
+      "path": "apps/ios/Sources/Settings/PrivacyAccessSectionView.swift",
+      "source": "Limited",
+      "surface": "apple",
+      "id": "native.apple.651cc89381dd69c0"
+    },
+    {
+      "kind": "conditional-branch",
+      "line": 149,
+      "path": "apps/ios/Sources/Settings/PrivacyAccessSectionView.swift",
+      "source": "Read photos you select for the assistant.",
+      "surface": "apple",
+      "id": "native.apple.ab998419291361da"
+    },
+    {
+      "kind": "conditional-branch",
+      "line": 149,
+      "path": "apps/ios/Sources/Settings/PrivacyAccessSectionView.swift",
+      "source": "Read recent photos for the assistant.",
+      "surface": "apple",
+      "id": "native.apple.e8c07f7c48d086f9"
+    },
+    {
+      "kind": "conditional-branch",
+      "line": 296,
       "path": "apps/ios/Sources/Settings/PrivacyAccessSectionView.swift",
       "source": "Allowed",
       "surface": "apple",
@@ -11227,7 +11259,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 238,
+      "line": 298,
       "path": "apps/ios/Sources/Settings/PrivacyAccessSectionView.swift",
       "source": "Add-Only",
       "surface": "apple",
@@ -11235,7 +11267,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 240,
+      "line": 300,
       "path": "apps/ios/Sources/Settings/PrivacyAccessSectionView.swift",
       "source": "Not Set",
       "surface": "apple",
@@ -11243,7 +11275,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 242,
+      "line": 302,
       "path": "apps/ios/Sources/Settings/PrivacyAccessSectionView.swift",
       "source": "Not Allowed",
       "surface": "apple",
@@ -11251,7 +11283,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 244,
+      "line": 304,
       "path": "apps/ios/Sources/Settings/PrivacyAccessSectionView.swift",
       "source": "Unknown",
       "surface": "apple",

--- a/apps/ios/Sources/Gateway/GatewayConnectionController.swift
+++ b/apps/ios/Sources/Gateway/GatewayConnectionController.swift
@@ -1121,8 +1121,7 @@ extension GatewayConnectionController {
             status: locationStatus)
         permissions["screenRecording"] = RPScreenRecorder.shared().isAvailable
 
-        let photoStatus = PHPhotoLibrary.authorizationStatus(for: .readWrite)
-        permissions["photos"] = photoStatus == .authorized || photoStatus == .limited
+        permissions["photos"] = PhotoLibraryAccess.canRead(PhotoLibraryAccess.authorizationStatus())
         let contactsStatus = CNContactStore.authorizationStatus(for: .contacts)
         permissions["contacts"] = contactsStatus == .authorized || contactsStatus == .limited
 

--- a/apps/ios/Sources/Info.plist
+++ b/apps/ios/Sources/Info.plist
@@ -71,7 +71,9 @@
 	<key>NSMotionUsageDescription</key>
 	<string>OpenClaw may use motion data to support device-aware interactions and automations.</string>
 	<key>NSPhotoLibraryUsageDescription</key>
-	<string>OpenClaw needs photo library access when you choose existing photos to share with your assistant.</string>
+	<string>OpenClaw lets your assistant read photos you allow and lets you choose photos to share.</string>
+	<key>PHPhotoLibraryPreventAutomaticLimitedAccessAlert</key>
+	<true/>
 	<key>NSRemindersFullAccessUsageDescription</key>
 	<string>OpenClaw uses your reminders to list, add, and complete tasks when you enable reminders access.</string>
 	<key>NSSpeechRecognitionUsageDescription</key>

--- a/apps/ios/Sources/Media/PhotoLibraryService.swift
+++ b/apps/ios/Sources/Media/PhotoLibraryService.swift
@@ -3,6 +3,20 @@ import OpenClawKit
 import Photos
 import UIKit
 
+enum PhotoLibraryAccess {
+    static func authorizationStatus() -> PHAuthorizationStatus {
+        PHPhotoLibrary.authorizationStatus(for: .readWrite)
+    }
+
+    static func canRead(_ status: PHAuthorizationStatus) -> Bool {
+        status == .authorized || status == .limited
+    }
+
+    static func requestReadWrite() async -> PHAuthorizationStatus {
+        await PHPhotoLibrary.requestAuthorization(for: .readWrite)
+    }
+}
+
 final class PhotoLibraryService: PhotosServicing {
     // The gateway WebSocket has a max payload size; returning large base64 blobs
     // can cause the gateway to close the connection. Keep photo payloads small
@@ -15,7 +29,7 @@ final class PhotoLibraryService: PhotosServicing {
 
     func latest(params: OpenClawPhotosLatestParams) async throws -> OpenClawPhotosLatestPayload {
         let status = await Self.ensureAuthorization()
-        guard status == .authorized || status == .limited else {
+        guard PhotoLibraryAccess.canRead(status) else {
             throw NSError(domain: "Photos", code: 1, userInfo: [
                 NSLocalizedDescriptionKey: "PHOTOS_PERMISSION_REQUIRED: grant Photos permission",
             ])
@@ -56,7 +70,7 @@ final class PhotoLibraryService: PhotosServicing {
 
     private static func ensureAuthorization() async -> PHAuthorizationStatus {
         // Don’t prompt during node.invoke; prompts block the invoke and lead to timeouts.
-        PHPhotoLibrary.authorizationStatus(for: .readWrite)
+        PhotoLibraryAccess.authorizationStatus()
     }
 
     private static func renderAsset(

--- a/apps/ios/Sources/Settings/PrivacyAccessSectionView.swift
+++ b/apps/ios/Sources/Settings/PrivacyAccessSectionView.swift
@@ -1,12 +1,15 @@
 import Contacts
 import EventKit
+import Photos
 import SwiftUI
 import UIKit
 
 struct PrivacyAccessSectionView: View {
+    @Environment(GatewayConnectionController.self) private var gatewayController
     @State private var contactsStatus: CNAuthorizationStatus = CNContactStore.authorizationStatus(for: .contacts)
     @State private var calendarStatus: EKAuthorizationStatus = EKEventStore.authorizationStatus(for: .event)
     @State private var remindersStatus: EKAuthorizationStatus = EKEventStore.authorizationStatus(for: .reminder)
+    @State private var photosStatus = PhotoLibraryAccess.authorizationStatus()
 
     @Environment(\.scenePhase) private var scenePhase
 
@@ -19,6 +22,14 @@ struct PrivacyAccessSectionView: View {
                 detail: "Search and add contacts from the assistant.",
                 actionTitle: self.actionTitle(for: self.contactsStatus),
                 action: self.handleContactsAction)
+
+            self.permissionRow(
+                title: "Photos",
+                icon: "photo.on.rectangle",
+                status: self.photosStatusText,
+                detail: self.photosDetail,
+                actionTitle: self.photosActionTitle,
+                action: self.handlePhotosAction)
 
             self.permissionRow(
                 title: "Calendar (Add Events)",
@@ -75,6 +86,7 @@ struct PrivacyAccessSectionView: View {
                 Button(actionTitle, action: action)
                     .font(.footnote)
                     .buttonStyle(.bordered)
+                    .accessibilityIdentifier("privacy-access-\(title)-action")
             }
         }
         .padding(.vertical, 2)
@@ -82,7 +94,7 @@ struct PrivacyAccessSectionView: View {
 
     private func statusColor(for status: String) -> Color {
         switch status {
-        case "Allowed":
+        case "Allowed", "Limited":
             OpenClawBrand.ok
         case "Not Set":
             OpenClawBrand.warn
@@ -114,6 +126,54 @@ struct PrivacyAccessSectionView: View {
             "Open Settings"
         default:
             nil
+        }
+    }
+
+    private var photosStatusText: String {
+        switch self.photosStatus {
+        case .authorized:
+            "Allowed"
+        case .limited:
+            "Limited"
+        case .notDetermined:
+            "Not Set"
+        case .denied, .restricted:
+            "Not Allowed"
+        @unknown default:
+            "Unknown"
+        }
+    }
+
+    private var photosDetail: String {
+        self.photosStatus == .limited
+            ? "Read photos you select for the assistant."
+            : "Read recent photos for the assistant."
+    }
+
+    private var photosActionTitle: String? {
+        switch self.photosStatus {
+        case .notDetermined:
+            "Request Access"
+        case .limited:
+            "Manage Access"
+        case .denied, .restricted:
+            "Open Settings"
+        default:
+            nil
+        }
+    }
+
+    private func handlePhotosAction() {
+        switch self.photosStatus {
+        case .notDetermined:
+            Task {
+                let status = await PhotoLibraryAccess.requestReadWrite()
+                await MainActor.run { self.updatePhotosStatus(status) }
+            }
+        case .limited, .denied, .restricted:
+            self.openSettings()
+        default:
+            break
         }
     }
 
@@ -282,6 +342,15 @@ struct PrivacyAccessSectionView: View {
         self.contactsStatus = CNContactStore.authorizationStatus(for: .contacts)
         self.calendarStatus = EKEventStore.authorizationStatus(for: .event)
         self.remindersStatus = EKEventStore.authorizationStatus(for: .reminder)
+        self.updatePhotosStatus(PhotoLibraryAccess.authorizationStatus())
+    }
+
+    private func updatePhotosStatus(_ status: PHAuthorizationStatus) {
+        let changed = self.photosStatus != status
+        self.photosStatus = status
+        if changed {
+            self.gatewayController.refreshActiveGatewayRegistrationFromSettings()
+        }
     }
 
     private func requestCalendarWriteOnly() async -> Bool {

--- a/apps/ios/Sources/Settings/PrivacyAccessSectionView.swift
+++ b/apps/ios/Sources/Settings/PrivacyAccessSectionView.swift
@@ -78,6 +78,7 @@ struct PrivacyAccessSectionView: View {
                 Text(status)
                     .font(.footnote.weight(.medium))
                     .foregroundStyle(self.statusColor(for: status))
+                    .accessibilityIdentifier("privacy-access-\(title)-status")
             }
             Text(detail)
                 .font(.footnote)

--- a/apps/ios/Sources/sv.lproj/InfoPlist.strings
+++ b/apps/ios/Sources/sv.lproj/InfoPlist.strings
@@ -9,6 +9,6 @@
 "NSLocationAlwaysAndWhenInUseUsageDescription" = "OpenClaw kan dela din plats i bakgrunden när du aktiverar Alltid.";
 "NSMicrophoneUsageDescription" = "OpenClaw använder mikrofonen för realtidschatt, röstaktivering och tryck-och-prata.";
 "NSMotionUsageDescription" = "OpenClaw kan använda rörelsedata för att stödja enhetsmedvetna interaktioner och automatiseringar.";
-"NSPhotoLibraryUsageDescription" = "OpenClaw behöver åtkomst till bildbiblioteket när du väljer befintliga bilder att dela med din assistent.";
+"NSPhotoLibraryUsageDescription" = "OpenClaw låter din assistent läsa bilder som du tillåter och låter dig välja bilder att dela.";
 "NSRemindersFullAccessUsageDescription" = "OpenClaw använder dina påminnelser för att lista, lägga till och slutföra uppgifter när du aktiverar åtkomst till påminnelser.";
 "NSSpeechRecognitionUsageDescription" = "OpenClaw använder taligenkänning på enheten för Talk-läge och röstaktivering.";

--- a/apps/ios/Tests/PermissionRequestBridgeTests.swift
+++ b/apps/ios/Tests/PermissionRequestBridgeTests.swift
@@ -1,3 +1,4 @@
+import Photos
 import Testing
 @testable import OpenClaw
 
@@ -22,5 +23,17 @@ import Testing
         }
 
         #expect(granted == true)
+    }
+}
+
+struct PhotoLibraryAccessTests {
+    @Test(arguments: [PHAuthorizationStatus.authorized, .limited])
+    func `read access includes full and limited authorization`(_ status: PHAuthorizationStatus) {
+        #expect(PhotoLibraryAccess.canRead(status))
+    }
+
+    @Test(arguments: [PHAuthorizationStatus.notDetermined, .denied, .restricted])
+    func `read access excludes unavailable authorization`(_ status: PHAuthorizationStatus) {
+        #expect(!PhotoLibraryAccess.canRead(status))
     }
 }

--- a/apps/ios/UITests/OpenClawSnapshotUITests.swift
+++ b/apps/ios/UITests/OpenClawSnapshotUITests.swift
@@ -437,6 +437,42 @@ final class OpenClawSnapshotUITests: XCTestCase {
         self.attachScreenshot(named: "manual-auth-retry-connected")
     }
 
+    func testPhotosLimitedAccess() throws {
+        try XCTSkipUnless(
+            ProcessInfo.processInfo.environment["OPENCLAW_IOS_PHOTOS_E2E"] == "1",
+            "Set OPENCLAW_IOS_PHOTOS_E2E=1 to exercise the system Photos prompt")
+        addUIInterruptionMonitor(withDescription: "Photos access") { alert in
+            for title in ["Limit Access…", "Select Photos…"] where alert.buttons[title].exists {
+                alert.buttons[title].tap()
+                return true
+            }
+            return false
+        }
+        self.launchApp(for: ScreenshotTarget(
+            initialTab: "settings",
+            initialDestination: "settings",
+            name: "photos-limited-access"))
+
+        let permissions = try XCTUnwrap(
+            self.app?.buttons.containing(.staticText, identifier: "Permissions").firstMatch)
+        XCTAssertTrue(permissions.waitForExistence(timeout: 8))
+        permissions.tap()
+
+        let privacy = try XCTUnwrap(
+            self.app?.buttons.containing(.staticText, identifier: "Privacy & Access").firstMatch)
+        XCTAssertTrue(privacy.waitForExistence(timeout: 8))
+        privacy.tap()
+
+        let request = try XCTUnwrap(self.app?.buttons["privacy-access-Photos-action"])
+        XCTAssertTrue(request.waitForExistence(timeout: 5))
+        request.tap()
+        self.app?.tap()
+
+        self.app?.activate()
+        XCTAssertTrue(self.app?.staticTexts["Limited"].waitForExistence(timeout: 8) == true)
+        self.attachScreenshot(named: "photos-limited-access")
+    }
+
     private func launchApp(for target: ScreenshotTarget, appearance: String? = "dark") {
         self.app?.terminate()
 

--- a/apps/ios/UITests/OpenClawSnapshotUITests.swift
+++ b/apps/ios/UITests/OpenClawSnapshotUITests.swift
@@ -468,8 +468,20 @@ final class OpenClawSnapshotUITests: XCTestCase {
         request.tap()
         self.app?.tap()
 
+        // The limited picker is an out-of-process system surface without stable accessibility identifiers.
+        // Normalized taps are confined to this opt-in simulator test; app-owned state proves completion below.
+        let screen = XCUIApplication(bundleIdentifier: "com.apple.springboard")
+        screen.coordinate(withNormalizedOffset: CGVector(dx: 0.17, dy: 0.43)).tap()
+        screen.coordinate(withNormalizedOffset: CGVector(dx: 0.90, dy: 0.16)).tap()
+
         self.app?.activate()
-        XCTAssertTrue(self.app?.staticTexts["Limited"].waitForExistence(timeout: 8) == true)
+        let limitedStatus = try XCTUnwrap(self.app?.staticTexts.matching(
+            NSPredicate(
+                format: "identifier == %@ AND label == %@",
+                "privacy-access-Photos-status",
+                "Limited")).firstMatch)
+        XCTAssertTrue(limitedStatus.waitForExistence(timeout: 8))
+        XCTAssertEqual(self.app?.buttons["privacy-access-Photos-action"].label, "Manage Access")
         self.attachScreenshot(named: "photos-limited-access")
     }
 

--- a/apps/ios/project.yml
+++ b/apps/ios/project.yml
@@ -170,7 +170,8 @@ targets:
         NSLocationAlwaysAndWhenInUseUsageDescription: OpenClaw can share your location in the background when you enable Always.
         NSMicrophoneUsageDescription: OpenClaw uses the microphone for realtime chat, voice wake, and push-to-talk.
         NSMotionUsageDescription: OpenClaw may use motion data to support device-aware interactions and automations.
-        NSPhotoLibraryUsageDescription: OpenClaw needs photo library access when you choose existing photos to share with your assistant.
+        NSPhotoLibraryUsageDescription: OpenClaw lets your assistant read photos you allow and lets you choose photos to share.
+        PHPhotoLibraryPreventAutomaticLimitedAccessAlert: true
         NSRemindersFullAccessUsageDescription: OpenClaw uses your reminders to list, add, and complete tasks when you enable reminders access.
         NSSpeechRecognitionUsageDescription: OpenClaw uses on-device speech recognition for talk mode and voice wake.
         NSSupportsLiveActivities: true


### PR DESCRIPTION
## What Problem This Solves

Fixes #99046.

The iOS app could report `permissions.photos=false` and reject `photos.latest` after a user chose Limited Photos access. The app understood `.limited` in the command handler, but it had no user-facing read/write authorization request and did not refresh the active gateway registration when the native grant changed.

## Why This Change Was Made

Photos authorization now has one canonical owner used by the Settings UI, gateway permission snapshot, and `photos.latest`. Settings requests PhotoKit `.readWrite` access, shows Limited as a readable state, and refreshes the active registration after a change. The app also suppresses PhotoKit's automatic limited-library prompt so a later gateway invocation cannot block on system UI; users retain the explicit Manage Access path. This follows Apple's [limited-library picker contract](https://developer.apple.com/documentation/photos/phphotolibrary/presentlimitedlibrarypicker%28from%3A%29) and [Photos usage-description contract](https://developer.apple.com/documentation/bundleresources/information-property-list/nsphotolibraryusagedescription).

## User Impact

Users can grant or manage Photos access from Settings → Permissions → Privacy & Access. Both full and limited grants are reported as readable, and the English and Swedish system permission disclosures now accurately explain assistant-driven reads.

## Before / After

| Before | After |
| --- | --- |
| Privacy & Access had no Photos row or request action. | Photos shows Not Set, Allowed, Limited, or Not Allowed with the appropriate action. |
| A grant change could leave the active gateway registration stale. | Changing Photos authorization immediately refreshes the active registration. |
| The English and Swedish system disclosures only described manually sharing a chosen image. | Both disclosures state that the assistant can read allowed photos and that users can choose photos to share. |
| Limited-library fetches could trigger automatic system UI during `node.invoke`. | Automatic limited-library alerts are suppressed; management remains explicit. |

## Evidence

- Exact-head iPhone 17 simulator, iOS 26.5: Settings → Permissions → Privacy & Access → Photos → Request Access; selected **Limit Access…** in the real system prompt, selected a photo, confirmed the system picker, and returned to OpenClaw. The app-owned Photos row displayed **Limited** with **Manage Access**; the XCUITest passed in 13.664 seconds and attached the after screenshot to its `.xcresult`.
- Focused Swift tests: `xcodebuild -project apps/ios/OpenClaw.xcodeproj -scheme OpenClaw -destination 'platform=iOS Simulator,id=E617A5DF-735E-442C-98EC-31C140517359' -derivedDataPath /tmp/openclaw-dd-issue99046-rebased CODE_SIGNING_ALLOWED=NO test -only-testing:OpenClawTests/PermissionRequestBridgeTests -only-testing:OpenClawTests/PhotoLibraryAccessTests` — 4 tests in 2 suites passed.
- Built app plist verified `PHPhotoLibraryPreventAutomaticLimitedAccessAlert=true` and the updated `NSPhotoLibraryUsageDescription`.
- `xcodegen generate`, plist lint for the base and Swedish privacy strings, `swiftformat --config config/swiftformat ...`, and `git diff --check` passed.
- Fresh full-branch autoreview repaired the automatic-prompt behavior, base disclosure, and stale Swedish disclosure (clean at 0.99). A final local autoreview then caught and repaired the incomplete picker proof and its asynchronous status wait; the rerun reported no accepted/actionable findings, confidence 0.93.
