### PR TITLE
fix(ci): restore Telegram boundary checks

### DIFF
--- a/extensions/telegram/src/bot-message-context.prompt-context.test.ts
+++ b/extensions/telegram/src/bot-message-context.prompt-context.test.ts
@@ -1,6 +1,8 @@
+import {
+  buildInboundUserContextPrefix,
+  buildReplyPromptEnvelopeBase,
+} from "openclaw/plugin-sdk/plugin-test-runtime";
 import { describe, expect, it } from "vitest";
-import { buildInboundUserContextPrefix } from "../../../src/auto-reply/reply/inbound-meta.js";
-import { buildReplyPromptEnvelopeBase } from "../../../src/auto-reply/reply/prompt-prelude.js";
 import { buildTelegramMessageContextForTest } from "./bot-message-context.test-harness.js";
 import type { TelegramPromptContextEntry } from "./bot-message-context.types.js";
 

--- a/extensions/telegram/src/bot-message-context.prompt-context.test.ts
+++ b/extensions/telegram/src/bot-message-context.prompt-context.test.ts
@@ -1,30 +1,6 @@
-import {
-  buildInboundUserContextPrefix,
-  buildReplyPromptEnvelopeBase,
-} from "openclaw/plugin-sdk/plugin-test-runtime";
 import { describe, expect, it } from "vitest";
 import { buildTelegramMessageContextForTest } from "./bot-message-context.test-harness.js";
 import type { TelegramPromptContextEntry } from "./bot-message-context.types.js";
-
-type RoomEventPromptContext = Parameters<typeof buildInboundUserContextPrefix>[0] &
-  Parameters<typeof buildReplyPromptEnvelopeBase>[0]["ctx"];
-
-function renderRoomEventPromptText(ctx: RoomEventPromptContext): string {
-  const inboundUserContext = buildInboundUserContextPrefix(ctx);
-  return (
-    buildReplyPromptEnvelopeBase({
-      ctx,
-      sessionCtx: ctx,
-      baseBody: ctx.BodyForAgent ?? ctx.Body ?? ctx.RawBody ?? "",
-      hasUserBody: true,
-      inboundUserContext,
-      isBareSessionReset: false,
-      startupAction: "new",
-      inboundEventKind: "room_event",
-      sourceReplyDeliveryMode: "message_tool_only",
-    }).currentInboundContext?.text ?? ""
-  );
-}
 
 const telegramChatWindowContext: TelegramPromptContextEntry = {
   label: "Conversation context",
@@ -230,7 +206,7 @@ describe("buildTelegramMessageContext prompt context", () => {
     );
   });
 
-  it("omits transcript-owned ambient rows from steady-state room-event prompt text", async () => {
+  it("omits transcript-owned ambient rows from steady-state room-event context", async () => {
     const ctx = await buildTelegramMessageContextForTest({
       message: {
         message_id: 12,
@@ -278,11 +254,13 @@ describe("buildTelegramMessageContext prompt context", () => {
     if (!ctx) {
       throw new Error("Expected room-event context");
     }
-    const promptText = renderRoomEventPromptText(ctx.ctxPayload as RoomEventPromptContext);
-    expect(promptText).toContain("[OpenClaw room event]");
-    expect(promptText).toContain("Current event:\n#12 Pat: current ambient");
-    expect(promptText).not.toContain("persisted ambient");
-    expect(promptText).not.toContain("Chat history since last reply");
+    expect(ctx.ctxPayload).toMatchObject({
+      BodyForAgent: "current ambient",
+      InboundEventKind: "room_event",
+      MessageSid: "12",
+      SenderName: "Pat",
+    });
     expect(ctx.ctxPayload.InboundHistory).toBeUndefined();
+    expect(ctx.ctxPayload.UntrustedStructuredContext).toBeUndefined();
   });
 });

--- a/extensions/telegram/src/bot-message-dispatch.test.ts
+++ b/extensions/telegram/src/bot-message-dispatch.test.ts
@@ -5,10 +5,12 @@ import {
   createPluginStateSyncKeyedStoreForTests,
   resetPluginStateStoreForTests,
 } from "openclaw/plugin-sdk/plugin-state-test-runtime";
+import {
+  buildInboundUserContextPrefix,
+  buildReplyPromptEnvelopeBase,
+} from "openclaw/plugin-sdk/plugin-test-runtime";
 import { setReplyPayloadMetadata } from "openclaw/plugin-sdk/reply-payload-testing";
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
-import { buildInboundUserContextPrefix } from "../../../src/auto-reply/reply/inbound-meta.js";
-import { buildReplyPromptEnvelopeBase } from "../../../src/auto-reply/reply/prompt-prelude.js";
 import { resolveAutoTopicLabelConfig as resolveAutoTopicLabelConfigRuntime } from "./auto-topic-label-config.js";
 import type { TelegramBotDeps } from "./bot-deps.js";
 import {

--- a/extensions/telegram/src/bot-message-dispatch.test.ts
+++ b/extensions/telegram/src/bot-message-dispatch.test.ts
@@ -5,10 +5,6 @@ import {
   createPluginStateSyncKeyedStoreForTests,
   resetPluginStateStoreForTests,
 } from "openclaw/plugin-sdk/plugin-state-test-runtime";
-import {
-  buildInboundUserContextPrefix,
-  buildReplyPromptEnvelopeBase,
-} from "openclaw/plugin-sdk/plugin-test-runtime";
 import { setReplyPayloadMetadata } from "openclaw/plugin-sdk/reply-payload-testing";
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { resolveAutoTopicLabelConfig as resolveAutoTopicLabelConfigRuntime } from "./auto-topic-label-config.js";
@@ -30,8 +26,6 @@ import type { TelegramRuntime } from "./runtime.types.js";
 type DispatchReplyWithBufferedBlockDispatcherArgs = Parameters<
   TelegramBotDeps["dispatchReplyWithBufferedBlockDispatcher"]
 >[0];
-type RoomEventPromptContext = Parameters<typeof buildInboundUserContextPrefix>[0] &
-  Parameters<typeof buildReplyPromptEnvelopeBase>[0]["ctx"];
 
 const createTelegramDraftStream = vi.hoisted(() => vi.fn());
 const dispatchReplyWithBufferedBlockDispatcher = vi.hoisted(() =>
@@ -427,23 +421,6 @@ describe("dispatchTelegramMessage draft streaming", () => {
     expect(calls.length).toBeGreaterThan(0);
     const preview = calls[calls.length - 1][0] as { text?: string };
     expect(preview.text).toBe(barText);
-  }
-
-  function renderRoomEventPromptText(ctx: RoomEventPromptContext): string {
-    const inboundUserContext = buildInboundUserContextPrefix(ctx);
-    return (
-      buildReplyPromptEnvelopeBase({
-        ctx,
-        sessionCtx: ctx,
-        baseBody: ctx.BodyForAgent ?? ctx.Body ?? ctx.RawBody ?? "",
-        hasUserBody: true,
-        inboundUserContext,
-        isBareSessionReset: false,
-        startupAction: "new",
-        inboundEventKind: "room_event",
-        sourceReplyDeliveryMode: "message_tool_only",
-      }).currentInboundContext?.text ?? ""
-    );
   }
 
   function createContext(overrides?: Partial<TelegramMessageContext>): TelegramMessageContext {
@@ -1211,7 +1188,7 @@ describe("dispatchTelegramMessage draft streaming", () => {
     ]);
   });
 
-  it("omits transcript-owned ambient rows from recovered room-event prompt text", async () => {
+  it("omits transcript-owned ambient rows from recovered room-event context", async () => {
     const oldHistoryKey = "-1003774691294:topic:1";
     const recoveredHistoryKey = "-1003774691294:topic:3731";
     const groupHistories = new Map([
@@ -1277,12 +1254,14 @@ describe("dispatchTelegramMessage draft streaming", () => {
     const dispatchParams = mockCallArg(
       dispatchReplyWithBufferedBlockDispatcher,
     ) as DispatchReplyWithBufferedBlockDispatcherArgs;
-    const promptText = renderRoomEventPromptText(dispatchParams.ctx as RoomEventPromptContext);
-    expect(promptText).toContain("[OpenClaw room event]");
-    expect(promptText).toContain("Current event:\n#27787 Cara: ambient current");
-    expect(promptText).not.toContain("persisted recovered ambient");
-    expect(promptText).not.toContain("Chat history since last reply");
+    expect(dispatchParams.ctx).toMatchObject({
+      BodyForAgent: "ambient current",
+      InboundEventKind: "room_event",
+      MessageSid: "27787",
+      SenderName: "Cara",
+    });
     expect(dispatchParams.ctx.InboundHistory).toBeUndefined();
+    expect(dispatchParams.ctx.UntrustedStructuredContext).toBeUndefined();
   });
 
   it("moves recovered user-request history out of the original topic", async () => {

--- a/scripts/plugin-sdk-surface-report.mjs
+++ b/scripts/plugin-sdk-surface-report.mjs
@@ -202,8 +202,8 @@ let publicDeprecatedExportsByEntrypointBudget;
 try {
   budgets = {
     publicEntrypoints: readBudgetEnv("OPENCLAW_PLUGIN_SDK_MAX_PUBLIC_ENTRYPOINTS", 323),
-    publicExports: readBudgetEnv("OPENCLAW_PLUGIN_SDK_MAX_PUBLIC_EXPORTS", 10408),
-    publicFunctionExports: readBudgetEnv("OPENCLAW_PLUGIN_SDK_MAX_PUBLIC_FUNCTION_EXPORTS", 5224),
+    publicExports: readBudgetEnv("OPENCLAW_PLUGIN_SDK_MAX_PUBLIC_EXPORTS", 10412),
+    publicFunctionExports: readBudgetEnv("OPENCLAW_PLUGIN_SDK_MAX_PUBLIC_FUNCTION_EXPORTS", 5227),
     publicDeprecatedExports: readBudgetEnv(
       "OPENCLAW_PLUGIN_SDK_MAX_PUBLIC_DEPRECATED_EXPORTS",
       3261,

--- a/src/channels/turn/message-turn-guardrails.test.ts
+++ b/src/channels/turn/message-turn-guardrails.test.ts
@@ -26,7 +26,7 @@ const migratedMessageTurnFiles = [
   "extensions/zalouser/src/monitor.ts",
 ];
 
-const historyWindowFiles = [
+const directHistoryWindowFiles = [
   "extensions/discord/src/monitor/message-handler.context.ts",
   "extensions/feishu/src/bot.ts",
   "extensions/imessage/src/monitor/inbound-processing.ts",
@@ -37,7 +37,6 @@ const historyWindowFiles = [
   "extensions/qqbot/src/bridge/sdk-adapter.ts",
   "extensions/signal/src/monitor/event-handler.ts",
   "extensions/slack/src/monitor/message-handler/prepare.ts",
-  "extensions/telegram/src/bot-message-context.session.ts",
   "extensions/telegram/src/bot-message-dispatch.ts",
   "extensions/telegram/src/group-history-window.ts",
   "extensions/whatsapp/src/auto-reply/monitor/group-gating.ts",
@@ -148,7 +147,7 @@ describe("message turn migration guardrails", () => {
   });
 
   it("keeps migrated history users on the channel history window facade", () => {
-    for (const file of historyWindowFiles) {
+    for (const file of directHistoryWindowFiles) {
       expect(readRepoFile(file), `${file} should keep using createChannelHistoryWindow`).toContain(
         "createChannelHistoryWindow",
       );

--- a/src/plugin-sdk/plugin-test-runtime.ts
+++ b/src/plugin-sdk/plugin-test-runtime.ts
@@ -1,6 +1,8 @@
 // Focused public test helpers for plugin runtime, registry, and setup fixtures.
 
 export { setDefaultChannelPluginRegistryForTests } from "../commands/channel-test-registry.js";
+export { buildInboundUserContextPrefix } from "../auto-reply/reply/inbound-meta.js";
+export { buildReplyPromptEnvelopeBase } from "../auto-reply/reply/prompt-prelude.js";
 export {
   createEmptyPluginRegistry,
   createPluginRegistry,

--- a/src/plugin-sdk/plugin-test-runtime.ts
+++ b/src/plugin-sdk/plugin-test-runtime.ts
@@ -1,8 +1,6 @@
 // Focused public test helpers for plugin runtime, registry, and setup fixtures.
 
 export { setDefaultChannelPluginRegistryForTests } from "../commands/channel-test-registry.js";
-export { buildInboundUserContextPrefix } from "../auto-reply/reply/inbound-meta.js";
-export { buildReplyPromptEnvelopeBase } from "../auto-reply/reply/prompt-prelude.js";
 export {
   createEmptyPluginRegistry,
   createPluginRegistry,


### PR DESCRIPTION
Related: #99306

## What Problem This Solves

Resolves CI regressions where the Telegram history refactor left extension tests importing core internals directly, left the message-turn guardrail expecting a file that no longer directly owns the history-window facade, and added intentional session-store SDK exports without advancing the exact surface budget.

## Why This Change Was Made

Keeps Telegram tests at their channel-context owner boundary, narrows the guardrail inventory to direct `createChannelHistoryWindow` users, and advances the SDK budget by the measured #99306 delta: four exports, three callable. Runtime behavior is unchanged; existing core prompt tests continue to own final prompt rendering.

## User Impact

No user-visible behavior change. The affected boundary and channel test lanes pass again without weakening their architectural checks.

## Evidence

Before:

- `pnpm lint:plugins:no-extension-test-core-imports` rejected the two Telegram test imports.
- `message-turn-guardrails.test.ts` expected `bot-message-context.session.ts` to call `createChannelHistoryWindow` after that responsibility moved to `group-history-window.ts`.
- The plugin SDK surface report measured 10,412 public exports and 5,227 callable exports against the pre-#99306 budgets of 10,408 and 5,224.

After:

- `node scripts/run-vitest.mjs src/channels/turn/message-turn-guardrails.test.ts` — 4 tests passed.
- `node scripts/check-no-extension-test-core-imports.ts` through the repository TSX runtime — 2,206 extension files checked.
- `node scripts/run-vitest.mjs extensions/telegram/src/bot-message-context.prompt-context.test.ts extensions/telegram/src/bot-message-dispatch.test.ts` — 173 tests passed.
- `node scripts/run-vitest.mjs src/channels/turn/message-turn-guardrails.test.ts test/scripts/plugin-sdk-surface-report.test.ts` — 12 tests passed.
- `node scripts/plugin-sdk-surface-report.mjs --check` — exact public SDK counts passed.
- Fresh autoreview: clean; no accepted/actionable findings.
