### PR TITLE
fix(ci): restore Telegram and plugin SDK guard checks

### DIFF
--- a/extensions/telegram/src/bot-message-context.prompt-context.test.ts
+++ b/extensions/telegram/src/bot-message-context.prompt-context.test.ts
@@ -1,28 +1,6 @@
 import { describe, expect, it } from "vitest";
-import { buildInboundUserContextPrefix } from "../../../src/auto-reply/reply/inbound-meta.js";
-import { buildReplyPromptEnvelopeBase } from "../../../src/auto-reply/reply/prompt-prelude.js";
 import { buildTelegramMessageContextForTest } from "./bot-message-context.test-harness.js";
 import type { TelegramPromptContextEntry } from "./bot-message-context.types.js";
-
-type RoomEventPromptContext = Parameters<typeof buildInboundUserContextPrefix>[0] &
-  Parameters<typeof buildReplyPromptEnvelopeBase>[0]["ctx"];
-
-function renderRoomEventPromptText(ctx: RoomEventPromptContext): string {
-  const inboundUserContext = buildInboundUserContextPrefix(ctx);
-  return (
-    buildReplyPromptEnvelopeBase({
-      ctx,
-      sessionCtx: ctx,
-      baseBody: ctx.BodyForAgent ?? ctx.Body ?? ctx.RawBody ?? "",
-      hasUserBody: true,
-      inboundUserContext,
-      isBareSessionReset: false,
-      startupAction: "new",
-      inboundEventKind: "room_event",
-      sourceReplyDeliveryMode: "message_tool_only",
-    }).currentInboundContext?.text ?? ""
-  );
-}
 
 const telegramChatWindowContext: TelegramPromptContextEntry = {
   label: "Conversation context",
@@ -228,6 +206,49 @@ describe("buildTelegramMessageContext prompt context", () => {
     );
   });
 
+  it("applies the ambient watermark before truncating the history window", async () => {
+    const ctx = await buildTelegramMessageContextForTest({
+      message: {
+        message_id: 13,
+        chat: { id: -1001234567890, type: "supergroup", title: "Forum" },
+        from: { id: 1234, first_name: "Pat" },
+        text: "@bot what happened?",
+        entities: [{ type: "mention", offset: 0, length: 4 }],
+      },
+      historyLimit: 1,
+      groupHistories: new Map([
+        [
+          "-1001234567890",
+          [
+            {
+              messageId: "12",
+              sender: "Mira",
+              timestamp: 1_700_000_002_000,
+              body: "unpersisted gap",
+            },
+            {
+              messageId: "11",
+              sender: "Lee",
+              timestamp: 1_700_000_001_000,
+              body: "late persisted ambient",
+            },
+          ],
+        ],
+      ]),
+      sessionRuntime: {
+        readAmbientTranscriptWatermark: () => ({
+          messageId: "11",
+          timestampMs: 1_700_000_001_000,
+          updatedAt: 1_700_000_003_000,
+        }),
+      },
+    });
+
+    expect(ctx?.ctxPayload.InboundHistory).toEqual([
+      expect.objectContaining({ messageId: "12", body: "unpersisted gap" }),
+    ]);
+  });
+
   it("omits transcript-owned ambient rows from steady-state room-event prompt text", async () => {
     const ctx = await buildTelegramMessageContextForTest({
       message: {
@@ -276,11 +297,13 @@ describe("buildTelegramMessageContext prompt context", () => {
     if (!ctx) {
       throw new Error("Expected room-event context");
     }
-    const promptText = renderRoomEventPromptText(ctx.ctxPayload as RoomEventPromptContext);
-    expect(promptText).toContain("[OpenClaw room event]");
-    expect(promptText).toContain("Current event:\n#12 Pat: current ambient");
-    expect(promptText).not.toContain("persisted ambient");
-    expect(promptText).not.toContain("Chat history since last reply");
+    expect(ctx.ctxPayload).toMatchObject({
+      BodyForAgent: "current ambient",
+      InboundEventKind: "room_event",
+      MessageSid: "12",
+      SenderName: "Pat",
+    });
     expect(ctx.ctxPayload.InboundHistory).toBeUndefined();
+    expect(ctx.ctxPayload.UntrustedStructuredContext).toBeUndefined();
   });
 });

--- a/extensions/telegram/src/bot-message-context.session.ts
+++ b/extensions/telegram/src/bot-message-context.session.ts
@@ -20,7 +20,7 @@ import type {
 } from "openclaw/plugin-sdk/config-contracts";
 import { resolveChannelContextVisibilityMode } from "openclaw/plugin-sdk/context-visibility-runtime";
 import { timestampMsToIsoString } from "openclaw/plugin-sdk/number-runtime";
-import type { HistoryEntry } from "openclaw/plugin-sdk/reply-history";
+import { createChannelHistoryWindow, type HistoryEntry } from "openclaw/plugin-sdk/reply-history";
 import type { ResolvedAgentRoute } from "openclaw/plugin-sdk/routing";
 import { logVerbose, shouldLogVerbose } from "openclaw/plugin-sdk/runtime-env";
 import { evaluateSupplementalContextVisibility } from "openclaw/plugin-sdk/security-runtime";
@@ -447,7 +447,13 @@ export async function buildTelegramInboundContextPayload(params: {
   let watermarkedGroupHistoryEntries: HistoryEntry[] | undefined;
   let groupHistoryPromptEntries: HistoryEntry[] = [];
   if (hasGroupHistoryContext && historyKey && historyLimit > 0) {
-    const fullGroupHistoryEntries = (groupHistories.get(historyKey) ?? [])
+    const bufferedHistoryCount = groupHistories.get(historyKey)?.length ?? 0;
+    const fullGroupHistoryEntries = (
+      createChannelHistoryWindow({ historyMap: groupHistories }).buildInboundHistory({
+        historyKey,
+        limit: bufferedHistoryCount,
+      }) ?? []
+    )
       .filter((entry) =>
         isTelegramHistoryEntryAfterAmbientWatermark(entry, ambientTranscriptWatermark),
       )

--- a/extensions/telegram/src/bot-message-dispatch.test.ts
+++ b/extensions/telegram/src/bot-message-dispatch.test.ts
@@ -7,8 +7,6 @@ import {
 } from "openclaw/plugin-sdk/plugin-state-test-runtime";
 import { setReplyPayloadMetadata } from "openclaw/plugin-sdk/reply-payload-testing";
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
-import { buildInboundUserContextPrefix } from "../../../src/auto-reply/reply/inbound-meta.js";
-import { buildReplyPromptEnvelopeBase } from "../../../src/auto-reply/reply/prompt-prelude.js";
 import { resolveAutoTopicLabelConfig as resolveAutoTopicLabelConfigRuntime } from "./auto-topic-label-config.js";
 import type { TelegramBotDeps } from "./bot-deps.js";
 import {
@@ -28,8 +26,6 @@ import type { TelegramRuntime } from "./runtime.types.js";
 type DispatchReplyWithBufferedBlockDispatcherArgs = Parameters<
   TelegramBotDeps["dispatchReplyWithBufferedBlockDispatcher"]
 >[0];
-type RoomEventPromptContext = Parameters<typeof buildInboundUserContextPrefix>[0] &
-  Parameters<typeof buildReplyPromptEnvelopeBase>[0]["ctx"];
 
 const createTelegramDraftStream = vi.hoisted(() => vi.fn());
 const dispatchReplyWithBufferedBlockDispatcher = vi.hoisted(() =>
@@ -425,23 +421,6 @@ describe("dispatchTelegramMessage draft streaming", () => {
     expect(calls.length).toBeGreaterThan(0);
     const preview = calls[calls.length - 1][0] as { text?: string };
     expect(preview.text).toBe(barText);
-  }
-
-  function renderRoomEventPromptText(ctx: RoomEventPromptContext): string {
-    const inboundUserContext = buildInboundUserContextPrefix(ctx);
-    return (
-      buildReplyPromptEnvelopeBase({
-        ctx,
-        sessionCtx: ctx,
-        baseBody: ctx.BodyForAgent ?? ctx.Body ?? ctx.RawBody ?? "",
-        hasUserBody: true,
-        inboundUserContext,
-        isBareSessionReset: false,
-        startupAction: "new",
-        inboundEventKind: "room_event",
-        sourceReplyDeliveryMode: "message_tool_only",
-      }).currentInboundContext?.text ?? ""
-    );
   }
 
   function createContext(overrides?: Partial<TelegramMessageContext>): TelegramMessageContext {
@@ -1275,12 +1254,14 @@ describe("dispatchTelegramMessage draft streaming", () => {
     const dispatchParams = mockCallArg(
       dispatchReplyWithBufferedBlockDispatcher,
     ) as DispatchReplyWithBufferedBlockDispatcherArgs;
-    const promptText = renderRoomEventPromptText(dispatchParams.ctx as RoomEventPromptContext);
-    expect(promptText).toContain("[OpenClaw room event]");
-    expect(promptText).toContain("Current event:\n#27787 Cara: ambient current");
-    expect(promptText).not.toContain("persisted recovered ambient");
-    expect(promptText).not.toContain("Chat history since last reply");
+    expect(dispatchParams.ctx).toMatchObject({
+      BodyForAgent: "ambient current",
+      InboundEventKind: "room_event",
+      MessageSid: "27787",
+      SenderName: "Cara",
+    });
     expect(dispatchParams.ctx.InboundHistory).toBeUndefined();
+    expect(dispatchParams.ctx.UntrustedStructuredContext).toBeUndefined();
   });
 
   it("moves recovered user-request history out of the original topic", async () => {

--- a/scripts/plugin-sdk-surface-report.mjs
+++ b/scripts/plugin-sdk-surface-report.mjs
@@ -202,8 +202,8 @@ let publicDeprecatedExportsByEntrypointBudget;
 try {
   budgets = {
     publicEntrypoints: readBudgetEnv("OPENCLAW_PLUGIN_SDK_MAX_PUBLIC_ENTRYPOINTS", 323),
-    publicExports: readBudgetEnv("OPENCLAW_PLUGIN_SDK_MAX_PUBLIC_EXPORTS", 10408),
-    publicFunctionExports: readBudgetEnv("OPENCLAW_PLUGIN_SDK_MAX_PUBLIC_FUNCTION_EXPORTS", 5224),
+    publicExports: readBudgetEnv("OPENCLAW_PLUGIN_SDK_MAX_PUBLIC_EXPORTS", 10412),
+    publicFunctionExports: readBudgetEnv("OPENCLAW_PLUGIN_SDK_MAX_PUBLIC_FUNCTION_EXPORTS", 5227),
     publicDeprecatedExports: readBudgetEnv(
       "OPENCLAW_PLUGIN_SDK_MAX_PUBLIC_DEPRECATED_EXPORTS",
       3261,


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where the main CI workflow failed in the Telegram extension boundary check, the channel history-window guardrail, and the plugin SDK surface-budget tests after recent changes landed.

## Why This Change Was Made

Telegram tests now verify the plugin-owned context payload without importing core prompt internals. Telegram session history selection again reads through `createChannelHistoryWindow` while preserving watermark-before-truncation behavior, and the plugin SDK budget is pinned to the four intended exports added by the ambient transcript work.

## User Impact

No user-visible behavior changes. Maintainers regain green CI coverage for extension boundaries, Telegram history-window ownership, and plugin SDK surface growth.

## Evidence

- Reproduced all three failures on the main CI push run: https://github.com/openclaw/openclaw/actions/runs/28635726933
- `node --import tsx scripts/check-no-extension-test-core-imports.ts`
- `node scripts/run-vitest.mjs src/channels/turn/message-turn-guardrails.test.ts test/scripts/plugin-sdk-surface-report.test.ts extensions/telegram/src/bot-message-context.prompt-context.test.ts extensions/telegram/src/bot-message-dispatch.test.ts`
  - 3 shards passed
  - 4 test files passed
  - 186 tests passed
- `node scripts/run-oxlint.mjs --tsconfig extensions/telegram/tsconfig.json extensions/telegram/src/bot-message-context.prompt-context.test.ts extensions/telegram/src/bot-message-context.session.ts extensions/telegram/src/bot-message-dispatch.test.ts`
- `node scripts/run-tsgo.mjs -p extensions/telegram/tsconfig.json --noEmit`
- Fresh Codex autoreview: no accepted/actionable findings, confidence 0.97
- Full local build was not used because the linked worktree correctly stopped at pnpm dependency reconciliation; PR CI provides the broad build proof.
