### PR TITLE
fix(find-tool): call stopChild in child process error handler

### DIFF
--- a/src/agents/sessions/tools/find.ts
+++ b/src/agents/sessions/tools/find.ts
@@ -296,6 +296,7 @@ export function createFindToolDefinition(
 
             child.on("error", (error) => {
               cleanup();
+              stopChild?.();
               settle(() => reject(new Error(`Failed to run fd: ${error.message}`)));
             });
 


### PR DESCRIPTION
## Summary

The `child.on("error")` handler in the find tool calls `cleanup()` but not `stopChild?.()`, unlike the `child.on("close")` handler which calls both. On error paths where the child process is still running, the process may not be killed.

## Root Cause

`src/agents/sessions/tools/find.ts:297-299` — Error handler has asymmetric cleanup compared to close handler at line 302.

## What changed

Add `stopChild?.()` after `cleanup()` in the error handler (1 line).

## Evidence

Source inspection: compare `child.on("error")` at line 297 (cleanup only) with `child.on("close")` at 302 (cleanup + stopChild).

## Risk checklist

**Risk level**: Minimal — 1-line additive fix that makes error and close handlers symmetric. No behavior change for the normal path.

Fixes #98961