### PR TITLE
fix(usage-bar): evict oldest template cache entry when size exceeds limit

### DIFF
--- a/src/auto-reply/usage-bar/template.ts
+++ b/src/auto-reply/usage-bar/template.ts
@@ -8,6 +8,7 @@ import type { UsageBarTemplate } from "./translator.js";
 export type UsageTemplateConfig = string | Record<string, unknown> | undefined;
 
 type CacheEntry = { template: UsageBarTemplate | undefined; watcher?: FSWatcher };
+const MAX_FILE_CACHE_SIZE = 64;
 const fileCache = new Map<string, CacheEntry>();
 const warnedTemplateOverrides = new Set<string>();
 const usageTemplateLog = createSubsystemLogger("usage-template");
@@ -141,6 +142,16 @@ function cacheTemplateFile(path: string): UsageBarTemplate | undefined {
       entry.watcher = watcher;
     } catch {
       // Cache remains valid without live refresh.
+    }
+  }
+  // Evict oldest entry when cache exceeds the limit so the Map and its live
+  // fs.watch watchers do not grow without bound across long-running gateways.
+  if (fileCache.size >= MAX_FILE_CACHE_SIZE) {
+    const oldestKey = fileCache.keys().next().value;
+    if (oldestKey !== undefined) {
+      const oldest = fileCache.get(oldestKey);
+      oldest?.watcher?.close();
+      fileCache.delete(oldestKey);
     }
   }
   fileCache.set(path, entry);


### PR DESCRIPTION
## Summary

The module-level `fileCache` Map in template.ts grows without bound. Each entry holds a live `fs.watch` watcher. Watchers are never closed and entries are never evicted — only `clearUsageBarTemplateCacheForTest()` closes them.

## Root Cause

`src/auto-reply/usage-bar/template.ts:146` — `cacheTemplateFile()` inserts without checking cache size.

## What changed

Add `MAX_FILE_CACHE_SIZE = 64` and evict the oldest entry (closing its watcher) before inserting new entries when the cache is full.

## Evidence

Source inspection: `fileCache.set(path, entry)` at line 146 never evicts. Each new template file path creates a persistent watcher that lives for the gateway lifetime.

## Risk checklist

**Risk level**: Low — cache eviction is LRU by insertion order (Map iteration order). A re-fetched cache-miss just reloads the file. 64 unique template paths is far above any real usage.

Fixes #98960