### PR TITLE
refactor(shared): consolidate core record guards

### DIFF
--- a/src/agents/code-mode.worker.ts
+++ b/src/agents/code-mode.worker.ts
@@ -5,6 +5,7 @@ import { randomUUID } from "node:crypto";
 import { readFile } from "node:fs/promises";
 import { createRequire } from "node:module";
 import { parentPort, workerData } from "node:worker_threads";
+import { isRecord } from "@openclaw/normalization-core/record-coerce";
 import { EvalFlags, Intrinsics, JSException, QuickJS, type JSValueHandle } from "quickjs-wasi";
 const require = createRequire(import.meta.url);
 const QUICKJS_WASM_PATH = require.resolve("quickjs-wasi/quickjs.wasm");
@@ -149,10 +150,6 @@ function getQuickJsWasmModule(): Promise<WebAssembly.Module> {
     WebAssembly.compile(bytes),
   );
   return quickJsWasmModulePromise;
-}
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return Boolean(value && typeof value === "object" && !Array.isArray(value));
 }
 
 // QuickJS error stacks are backtrace frames only ("    at file:line:col"), with

--- a/src/agents/openai-tool-projection.ts
+++ b/src/agents/openai-tool-projection.ts
@@ -1,3 +1,4 @@
+import { isRecord } from "@openclaw/normalization-core/record-coerce";
 import type OpenAI from "openai";
 import type { ResponseCreateParamsStreaming } from "openai/resources/responses/responses.js";
 import { projectRuntimeToolInputSchema } from "./tool-schema-json-projection.js";
@@ -42,10 +43,6 @@ export type OpenAICompletionsToolChoice = Exclude<
   OpenAICompletionsSdkToolChoice,
   { type: "custom" }
 >;
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return Boolean(value) && typeof value === "object" && !Array.isArray(value);
-}
 
 function unreadableToolDiagnostic(toolIndex: number): OpenAIToolProjectionDiagnostic {
   return {

--- a/src/agents/plugin-text-transforms.ts
+++ b/src/agents/plugin-text-transforms.ts
@@ -1,3 +1,4 @@
+import { isRecord } from "@openclaw/normalization-core/record-coerce";
 /**
  * Plugin-defined text replacement transforms for stream boundaries.
  *
@@ -39,10 +40,6 @@ export function applyPluginTextReplacements(
     next = next.replace(replacement.from, replacement.to);
   }
   return next;
-}
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return Boolean(value && typeof value === "object" && !Array.isArray(value));
 }
 
 function transformContentText(content: unknown, replacements?: PluginTextReplacement[]): unknown {

--- a/src/agents/sessions/keybindings.ts
+++ b/src/agents/sessions/keybindings.ts
@@ -13,6 +13,7 @@ import {
   TUI_KEYBINDINGS,
   KeybindingsManager as TuiKeybindingsManager,
 } from "@earendil-works/pi-tui";
+import { isRecord } from "@openclaw/normalization-core/record-coerce";
 import { getAgentDir } from "../config.js";
 
 /** OpenClaw-specific key ids added to the shared pi-tui keybinding registry. */
@@ -270,10 +271,6 @@ const KEYBINDING_NAME_MIGRATIONS = {
   deleteSession: "app.session.delete",
   deleteSessionNoninvasive: "app.session.deleteNoninvasive",
 } as const satisfies Record<string, Keybinding>;
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === "object" && value !== null && !Array.isArray(value);
-}
 
 function isLegacyKeybindingName(key: string): key is keyof typeof KEYBINDING_NAME_MIGRATIONS {
   return key in KEYBINDING_NAME_MIGRATIONS;

--- a/src/auto-reply/reply/session-fork.runtime.ts
+++ b/src/auto-reply/reply/session-fork.runtime.ts
@@ -2,6 +2,7 @@
 import crypto from "node:crypto";
 import fs from "node:fs/promises";
 import path from "node:path";
+import { isRecord } from "@openclaw/normalization-core/record-coerce";
 import {
   migrateSessionEntries,
   parseSessionEntries,
@@ -114,10 +115,6 @@ export async function resolveParentForkTokenCountRuntime(params: {
   }
 
   return maxPositiveTokenCount(cachedTokens, byteEstimateTokens);
-}
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 
 function generateEntryId(existingIds: Set<string>): string {

--- a/src/channels/mention-pattern-policy.ts
+++ b/src/channels/mention-pattern-policy.ts
@@ -1,3 +1,4 @@
+import { isRecord } from "@openclaw/normalization-core/record-coerce";
 /**
  * Mention-pattern policy resolver.
  *
@@ -40,10 +41,6 @@ function normalizeIdList(values?: string[]): Set<string> {
 }
 
 function isMentionPatternsPolicyConfig(value: unknown): value is MentionPatternsPolicyConfig {
-  return value != null && typeof value === "object" && !Array.isArray(value);
-}
-
-function isRecord(value: unknown): value is Record<string, unknown> {
   return value != null && typeof value === "object" && !Array.isArray(value);
 }
 

--- a/src/commands/sessions-tail.ts
+++ b/src/commands/sessions-tail.ts
@@ -6,6 +6,7 @@
  */
 import fs from "node:fs";
 import path from "node:path";
+import { isRecord } from "@openclaw/normalization-core/record-coerce";
 import { readAcpSessionMeta } from "../acp/runtime/session-meta.js";
 import { getRuntimeConfig } from "../config/config.js";
 import { resolveSessionFilePath } from "../config/sessions/paths.js";
@@ -97,10 +98,6 @@ function parseTailCount(value: string | number | undefined): number | null {
     return null;
   }
   return Number.parseInt(trimmed, 10);
-}
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 
 function toOptionalString(value: unknown): string | undefined {

--- a/src/infra/diagnostic-llm-content.ts
+++ b/src/infra/diagnostic-llm-content.ts
@@ -1,3 +1,5 @@
+import { isRecord } from "@openclaw/normalization-core/record-coerce";
+
 /** Per-field policy for diagnostic traces that may include model-visible content. */
 export type DiagnosticModelContentCapturePolicy = {
   /** Capture chat/message payloads sent to a model. */
@@ -25,10 +27,6 @@ const NO_MODEL_CONTENT_CAPTURE: DiagnosticModelContentCapturePolicy = Object.fre
   toolDefinitions: false,
   anyModelContent: false,
 });
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return Boolean(value) && typeof value === "object" && !Array.isArray(value);
-}
 
 // Clone captured content so private diagnostic payloads never alias live runtime
 // objects (tool params/results, model messages) that callers keep mutating.

--- a/src/infra/install-source-utils.ts
+++ b/src/infra/install-source-utils.ts
@@ -2,6 +2,7 @@
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
+import { isRecord } from "@openclaw/normalization-core/record-coerce";
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import { normalizeStringEntries } from "@openclaw/normalization-core/string-normalization";
 import { runCommandWithTimeout } from "../process/exec.js";
@@ -163,10 +164,6 @@ export async function resolveArchiveSourcePath(archivePath: string): Promise<
   }
 
   return { ok: true, path: resolved };
-}
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 
 function parseResolvedSpecFromId(id: string): string | undefined {

--- a/src/infra/outbound/message-action-params.ts
+++ b/src/infra/outbound/message-action-params.ts
@@ -3,6 +3,7 @@
 import { canonicalizeBase64, estimateBase64DecodedBytes } from "@openclaw/media-core/base64";
 import { basenameFromAnyPath } from "@openclaw/media-core/file-name";
 import { extensionForMime } from "@openclaw/media-core/mime";
+import { isRecord } from "@openclaw/normalization-core/record-coerce";
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import { assertMediaNotDataUrl, resolveSandboxedMediaSource } from "../../agents/sandbox-paths.js";
 import { readStringArrayParam, readStringParam } from "../../agents/tools/common.js";
@@ -62,10 +63,6 @@ type StructuredAttachmentMode = "selected" | "all";
 
 function readMediaParam(args: Record<string, unknown>, key: string): string | undefined {
   return readStringParam(args, key, { trim: false });
-}
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return Boolean(value && typeof value === "object" && !Array.isArray(value));
 }
 
 function resolveMediaParamEntry(

--- a/src/llm/providers/stream-wrappers/anthropic-family-tool-payload-compat.ts
+++ b/src/llm/providers/stream-wrappers/anthropic-family-tool-payload-compat.ts
@@ -1,3 +1,4 @@
+import { isRecord } from "@openclaw/normalization-core/record-coerce";
 // Anthropic-family tool payload compatibility wraps provider tool payload shapes.
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import type { StreamFn } from "../../../agents/runtime/index.js";
@@ -24,10 +25,6 @@ type OpenAiFunctionToolsProjection = {
   readonly functionNames: ReadonlySet<string>;
   readonly tools: readonly Record<string, unknown>[];
 };
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return Boolean(value) && typeof value === "object" && !Array.isArray(value);
-}
 
 function readPayloadField(record: Record<string, unknown>, field: string): PayloadFieldRead {
   try {

--- a/src/llm/providers/stream-wrappers/openai.ts
+++ b/src/llm/providers/stream-wrappers/openai.ts
@@ -1,3 +1,4 @@
+import { isRecord } from "@openclaw/normalization-core/record-coerce";
 // OpenAI stream wrapper normalizes OpenAI-compatible streamed tool and text events.
 import {
   normalizeFastMode,
@@ -265,10 +266,6 @@ function shouldStripOpenAICompletionMessageKeys(model: {
       ? (model.compat as { strictMessageKeys?: unknown })
       : undefined;
   return model.api === "openai-completions" && compat?.strictMessageKeys === true;
-}
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return Boolean(value && typeof value === "object" && !Array.isArray(value));
 }
 
 function hasResponsesWebSearchTool(tools: unknown): boolean {

--- a/src/llm/providers/tool-result-text.ts
+++ b/src/llm/providers/tool-result-text.ts
@@ -1,3 +1,4 @@
+import { isRecord } from "@openclaw/normalization-core/record-coerce";
 import { redactSecrets, redactToolPayloadText } from "../../logging/redact.js";
 import { truncateUtf16Safe } from "../../shared/utf16-slice.js";
 import { sanitizeSurrogates } from "../utils/sanitize-unicode.js";
@@ -22,10 +23,6 @@ const MIME_KEY_CANDIDATES = [
 const TEXTUAL_MIME_PATTERN =
   /^(?:text\/|application\/(?:json|ld\+json|x-ndjson|xml|javascript|x-www-form-urlencoded)|[^/]+\/[^+]+\+(?:json|xml)$)/i;
 const OPAQUE_OR_BINARY_FIELD_RE = /^(?:blob|buffer|bytes|encrypted_content|encrypted_stdout)$/i;
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return value !== null && typeof value === "object" && !Array.isArray(value);
-}
 
 function readMimeType(value: unknown): string | undefined {
   if (!isRecord(value)) {

--- a/src/mcp/plugin-tools-handlers.ts
+++ b/src/mcp/plugin-tools-handlers.ts
@@ -1,3 +1,4 @@
+import { isRecord } from "@openclaw/normalization-core/record-coerce";
 // Plugin MCP tool handlers route plugin tool calls through the active runtime.
 import {
   isToolWrappedWithBeforeToolCallHook,
@@ -12,10 +13,6 @@ type CallPluginToolParams = {
   name: string;
   arguments?: unknown;
 };
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return value !== null && typeof value === "object" && !Array.isArray(value);
-}
 
 function toMcpContentBlock(block: unknown): unknown {
   if (!isRecord(block)) {

--- a/src/media-understanding/image.ts
+++ b/src/media-understanding/image.ts
@@ -1,6 +1,7 @@
 // Model-backed image understanding runtime for providers without a native media
 // provider hook.
 import { clampPositiveTimerTimeoutMs } from "@openclaw/normalization-core/number-coercion";
+import { isRecord } from "@openclaw/normalization-core/record-coerce";
 import { resolveModelAsync } from "../agents/embedded-agent-runner/model.js";
 import { isMinimaxVlmModel, minimaxUnderstandImage } from "../agents/minimax-vlm.js";
 import {
@@ -41,10 +42,6 @@ function resolveImageToolMaxTokens(modelMaxTokens: number | undefined, requested
     return requestedMaxTokens;
   }
   return Math.min(requestedMaxTokens, modelMaxTokens);
-}
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return Boolean(value) && typeof value === "object" && !Array.isArray(value);
 }
 
 function isNativeResponsesReasoningPayload(model: Model): boolean {

--- a/src/shared/json-schema-defaults.ts
+++ b/src/shared/json-schema-defaults.ts
@@ -1,3 +1,4 @@
+import { isRecord } from "@openclaw/normalization-core/record-coerce";
 // JSON schema default helpers fill object values from TypeBox schema defaults.
 import { Compile } from "typebox/compile";
 import type { JsonSchemaObject } from "./json-schema.types.js";
@@ -78,10 +79,6 @@ const schemaIntegerKeywords = new Set([
   "minProperties",
 ]);
 const schemaBooleanKeywords = new Set(["deprecated", "readOnly", "uniqueItems", "writeOnly"]);
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return Boolean(value && typeof value === "object" && !Array.isArray(value));
-}
 
 function schemaTypeIncludes(schema: Record<string, unknown>, type: string): boolean {
   return schema.type === type || (Array.isArray(schema.type) && schema.type.includes(type));

--- a/src/trajectory/runtime-file.ts
+++ b/src/trajectory/runtime-file.ts
@@ -1,6 +1,7 @@
 // Trajectory runtime file helpers create and append trajectory log files.
 import fsp from "node:fs/promises";
 import path from "node:path";
+import { isRecord } from "@openclaw/normalization-core/record-coerce";
 import {
   resolveTrajectoryFilePath,
   resolveTrajectoryPointerFilePath,
@@ -9,10 +10,6 @@ import {
 
 // Runtime trajectory file discovery for exporters. Pointer files are treated as
 // advisory only and must resolve to regular non-symlink files before use.
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return Boolean(value) && typeof value === "object" && !Array.isArray(value);
-}
-
 export async function isRegularNonSymlinkFile(filePath: string): Promise<boolean> {
   try {
     const linkStat = await fsp.lstat(filePath);


### PR DESCRIPTION
Related: #99351

## What Problem This Solves

Core repeatedly defines the same non-array object type guard even though `@openclaw/normalization-core/record-coerce` already owns that exact contract. These copies add maintenance surface without domain-specific behavior.

## Why This Change Was Made

This migrates 17 exact duplicate guards under `src/` to the canonical `isRecord` export. Package-local copies remain untouched because adding five new workspace dependency edges for three-line helpers triggers the dependency guard and is not worth an admin override. Exported compatibility helpers, specialized predicates, and proxy-safe guards also remain intentionally local.

## User Impact

No intended user-visible behavior change. Maintainers have one fewer repeated boundary primitive, and production code shrinks by 50 net lines.

## Evidence

- Search proof: all 17 selected files import `@openclaw/normalization-core/record-coerce`; none retains a local `isRecord` definition.
- `node scripts/run-vitest.mjs <11 direct test files>` — 154 tests passed across 5 shards after the final rebase.
- `OPENCLAW_HEAVY_CHECK_LOCK_SCOPE=worktree node scripts/run-oxlint.mjs <changed TypeScript files>` — passed.
- `pnpm exec oxfmt --check <changed files>` — passed.
- `OPENCLAW_HEAVY_CHECK_LOCK_SCOPE=worktree pnpm tsgo:core` — passed.
- `OPENCLAW_HEAVY_CHECK_LOCK_SCOPE=worktree pnpm tsgo:core:test` — passed.
- `pnpm build` — passed after the final rebase.
- Fresh autoreview: clean, confidence 0.99.
- Diff: 18 insertions, 68 deletions across 17 files; net −50 lines.

