### PR TITLE
fix(browser): bound client-fetch JSON response reads to prevent OOM

### DIFF
--- a/extensions/browser/src/browser/client-fetch.ts
+++ b/extensions/browser/src/browser/client-fetch.ts
@@ -106,6 +106,7 @@ const BROWSER_TOOL_MODEL_HINT =
   "Use an alternative approach or inform the user that the browser is currently unavailable.";
 
 const BROWSER_ERROR_BODY_LIMIT_BYTES = 16 * 1024;
+const BROWSER_RESPONSE_LIMIT_BYTES = 16 * 1024 * 1024; // 16 MiB shared JSON/control-plane response cap
 
 function isRateLimitStatus(status: number): boolean {
   return status === 429;
@@ -277,7 +278,8 @@ async function fetchHttpJson<T>(
       const text = body ? new TextDecoder().decode(body) : "";
       throw new BrowserServiceError(text || `HTTP ${res.status}`);
     }
-    return (await res.json()) as T;
+    const body = await readResponseWithLimit(res, BROWSER_RESPONSE_LIMIT_BYTES);
+    return JSON.parse(new TextDecoder().decode(body)) as T;
   } finally {
     clearTimeout(t);
     await release?.();


### PR DESCRIPTION
## What Problem This Solves

`fetchHttpJson` in the browser control transport reads JSON response bodies
with an unbounded `await res.json()` call on the success path. A misbehaving
browser-service endpoint that returns an oversized JSON payload can exhaust
gateway memory.

The error path in the same function already handles this — it reads error
bodies through `readResponseWithLimit` with a 16 KiB cap. The success path was
simply missed.

## Why This Change Was Made

Replace the raw `res.json()` with the already-imported `readResponseWithLimit`
helper, using a 16 MiB cap. The stream is cancelled on overflow.

## Evidence

`readResponseWithLimit` is already imported (line 9) and used on the error
path (line 275) in the same file. The fix applies the same helper to the
success path.

```diff
@@ -277,7 +278,8 @@ async function fetchHttpJson<T>(
-    return (await res.json()) as T;
+    const body = await readResponseWithLimit(res, BROWSER_RESPONSE_LIMIT_BYTES);
+    return JSON.parse(new TextDecoder().decode(body)) as T;
```

Real behavior proof — `readResponseWithLimit` rejects an oversized body:

```text
$ node --import tsx proof-browser-bound.mjs
ok: 11-byte response read successfully (cap: 256)
overflow: 512 bytes with 256-byte cap
OVERFLOW CAUGHT: Content too large: 512 bytes (limit: 256 bytes)
PASS
```

Format check:

```text
$ pnpm exec oxfmt --check --threads=1 extensions/browser/src/browser/client-fetch.ts
Finished in 2ms on 1 files using 1 threads.
```

Note: `/snapshot` requests use the CDP transport, not `fetchHttpJson` /
`fetchBrowserJson`, so the snapshot `maxChars=0` uncapped contract is not
affected by this change.

AI-assisted: built with Codex
