### PR TITLE
fix(mattermost): reject oversized websocket events

### DIFF
--- a/extensions/mattermost/src/mattermost/monitor-websocket.test.ts
+++ b/extensions/mattermost/src/mattermost/monitor-websocket.test.ts
@@ -239,7 +239,7 @@ describe("mattermost websocket monitor", () => {
           }),
         );
         socket.send(largePostEnvelope);
-        socket.send("x".repeat(MATTERMOST_WEBSOCKET_MAX_PAYLOAD_BYTES + 1));
+        socket.send(Buffer.alloc(MATTERMOST_WEBSOCKET_MAX_PAYLOAD_BYTES + 1, 0x78));
       });
     });
 

--- a/extensions/mattermost/src/mattermost/monitor-websocket.test.ts
+++ b/extensions/mattermost/src/mattermost/monitor-websocket.test.ts
@@ -1,8 +1,11 @@
 // Mattermost tests cover monitor websocket plugin behavior.
+import { once } from "node:events";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { WebSocketServer } from "ws";
 import type { RuntimeEnv } from "../../runtime-api.js";
 import {
   createMattermostConnectOnce,
+  MATTERMOST_WEBSOCKET_MAX_PAYLOAD_BYTES,
   type MattermostWebSocketLike,
   WebSocketClosedBeforeOpenError,
 } from "./monitor-websocket.js";
@@ -192,6 +195,78 @@ describe("mattermost websocket monitor", () => {
     });
     expect(countMatching(patches, (patch) => patch.connected === true)).toBe(1);
     expect(countMatching(patches, (patch) => patch.connected === false)).toBe(2);
+  });
+
+  it("accepts large valid post envelopes and rejects oversized websocket payloads", async () => {
+    const server = new WebSocketServer({ host: "127.0.0.1", port: 0 });
+    await once(server, "listening");
+    const address = server.address();
+    if (!address || typeof address === "string") {
+      throw new Error("expected TCP websocket server address");
+    }
+
+    const quotedCardBody = '"'.repeat(380_000);
+    const largeProps = { cards: [{ body: quotedCardBody }] };
+    const largePostEnvelope = JSON.stringify({
+      event: "posted",
+      data: {
+        post: JSON.stringify({
+          id: "post-large",
+          message: "large Mattermost integration post",
+          props: largeProps,
+        }),
+      },
+    });
+    expect(JSON.stringify(largeProps).length).toBeLessThan(800_000);
+    expect(Buffer.byteLength(largePostEnvelope)).toBeGreaterThan(1024 * 1024);
+    expect(Buffer.byteLength(largePostEnvelope)).toBeLessThan(
+      MATTERMOST_WEBSOCKET_MAX_PAYLOAD_BYTES,
+    );
+
+    const runtime = testRuntime();
+    const onPosted = vi.fn(async () => {});
+    server.on("connection", (socket) => {
+      socket.once("message", () => {
+        socket.send(
+          JSON.stringify({
+            event: "posted",
+            data: {
+              post: JSON.stringify({
+                id: "post-1",
+                message: "normal Mattermost post",
+              }),
+            },
+          }),
+        );
+        socket.send(largePostEnvelope);
+        socket.send("x".repeat(MATTERMOST_WEBSOCKET_MAX_PAYLOAD_BYTES + 1));
+      });
+    });
+
+    try {
+      await createMattermostConnectOnce({
+        wsUrl: `ws://127.0.0.1:${address.port}`,
+        botToken: "token",
+        runtime,
+        nextSeq: () => 1,
+        onPosted,
+      })();
+    } finally {
+      server.close();
+      await once(server, "close");
+    }
+
+    expect(onPosted).toHaveBeenCalledWith(
+      expect.objectContaining({ id: "post-1", message: "normal Mattermost post" }),
+      expect.any(Object),
+    );
+    expect(onPosted).toHaveBeenCalledWith(
+      expect.objectContaining({ id: "post-large", props: largeProps }),
+      expect.any(Object),
+    );
+    expect(runtime.error).toHaveBeenCalledWith(
+      expect.stringContaining("Max payload size exceeded"),
+    );
   });
 
   it("dispatches reaction events to the reaction handler", async () => {

--- a/extensions/mattermost/src/mattermost/monitor-websocket.ts
+++ b/extensions/mattermost/src/mattermost/monitor-websocket.ts
@@ -44,9 +44,9 @@ export type MattermostWebSocketLike = {
 };
 
 export type MattermostWebSocketFactory = (url: string) => MattermostWebSocketLike;
-// Mattermost permits large post props/cards; keep the transport cap above a
-// valid posted-event envelope while still far below the ws default 100 MiB.
-export const MATTERMOST_WEBSOCKET_MAX_PAYLOAD_BYTES = 4 * 1024 * 1024;
+// Mattermost events can include double-encoded post props plus server/plugin metadata.
+// Keep channel-compatible headroom while bounding ws's 100 MiB default before parsing.
+export const MATTERMOST_WEBSOCKET_MAX_PAYLOAD_BYTES = 16 * 1024 * 1024;
 const MattermostEventPayloadSchema = z.object({
   event: z.string().optional(),
   data: z

--- a/extensions/mattermost/src/mattermost/monitor-websocket.ts
+++ b/extensions/mattermost/src/mattermost/monitor-websocket.ts
@@ -44,6 +44,9 @@ export type MattermostWebSocketLike = {
 };
 
 export type MattermostWebSocketFactory = (url: string) => MattermostWebSocketLike;
+// Mattermost permits large post props/cards; keep the transport cap above a
+// valid posted-event envelope while still far below the ws default 100 MiB.
+export const MATTERMOST_WEBSOCKET_MAX_PAYLOAD_BYTES = 4 * 1024 * 1024;
 const MattermostEventPayloadSchema = z.object({
   event: z.string().optional(),
   data: z
@@ -113,7 +116,10 @@ type CreateMattermostConnectOnceOpts = {
 
 const defaultMattermostWebSocketFactory: MattermostWebSocketFactory = (url) => {
   const agent = createDebugProxyWebSocketAgent(resolveDebugProxySettings());
-  return new WebSocket(url, agent ? { agent } : undefined) as MattermostWebSocketLike;
+  return new WebSocket(url, {
+    ...(agent ? { agent } : {}),
+    maxPayload: MATTERMOST_WEBSOCKET_MAX_PAYLOAD_BYTES,
+  }) as MattermostWebSocketLike;
 };
 
 function parsePostedPayload(


### PR DESCRIPTION
## Summary

Bounds inbound Mattermost monitor WebSocket messages at 16 MiB before application parsing, instead of inheriting the pinned `ws` client's 100 MiB default.

## What Problem This Solves

A buggy or hostile self-hosted Mattermost server could make the monitor buffer a very large WebSocket message before JSON/schema validation had a chance to reject it. The production connection factory supplied no `maxPayload`, so `ws` 8.21.0 allowed up to 100 MiB per message.

## Why This Change Was Made

The default Mattermost WebSocket factory is the narrow transport owner that can reject a complete fragmented or compressed message before it reaches capture and JSON parsing. A fixed 16 MiB ceiling:

- removes 84% of the upstream default exposure;
- matches the established Discord channel WebSocket ceiling;
- stays well above Mattermost's large, double-encoded post-props/card envelopes;
- leaves compatibility headroom for server-generated metadata and custom self-hosted/plugin events without adding another operator config surface.

The loopback regression uses the real production factory. It dispatches a normal post and a 1+ MiB valid post envelope, then sends a 16 MiB + 1 byte frame and verifies the `ws` receiver reports `Max payload size exceeded`.

## User Impact

Normal Mattermost posts, cards, reactions, and integration events continue to work. An inbound WebSocket message above 16 MiB closes and reconnects the monitor instead of being buffered up to 100 MiB.

## Evidence

- Pinned dependency source: [`ws` 8.21.0 defaults client `maxPayload` to 100 MiB](https://github.com/websockets/ws/blob/8.21.0/lib/websocket.js#L675) and rejects excess length in the receiver before message emission.
- Mattermost source: [`PostPropsMaxRunes` is 800,000](https://github.com/mattermost/mattermost/blob/cdc2d4535850ce4295f25e041a441adf41410eee/server/public/model/post.go#L81-L82), and `posted` events serialize the post into the event data as a JSON string.
- Sanitized AWS Crabbox `cbx_78e494d6dac7`, exact head `8839d638f956256cbdbb2ab0ccb620fa2b45c0f3`:
  - `run_a5a491b2ad1b`: all 11 focused Mattermost monitor WebSocket tests passed, including production-factory normal/large-valid/oversized behavior.
  - `run_dd52e6322300`: `pnpm check:changed` passed, including project type checks, lint/format guards, and runtime import-cycle checks.
- Fresh pre-commit autoreview: no accepted or actionable findings.

Co-authored-by: sunlit-deng <yang.jiajun1@xydigit.com>
