### PR TITLE
fix(agents): repair payload-less image blocks in session files

### DIFF
--- a/src/agents/session-file-repair.test.ts
+++ b/src/agents/session-file-repair.test.ts
@@ -493,6 +493,71 @@ describe("repairSessionFileIfNeeded", () => {
     ]);
   });
 
+  it("rewrites payload-less image blocks (missing data) so replay can continue", async () => {
+    const { file } = await createTempSessionPath();
+    const { header } = buildSessionHeaderAndMessage();
+    const payloadlessToolResultEntry = {
+      type: "message",
+      id: "msg-payloadless-image",
+      parentId: null,
+      timestamp: new Date().toISOString(),
+      message: {
+        role: "toolResult",
+        toolCallId: "call-1",
+        content: [
+          { type: "text", text: "inspect this" },
+          { type: "image", mimeType: "image/png" },
+        ],
+      },
+    };
+    const original = `${JSON.stringify(header)}\n${JSON.stringify(payloadlessToolResultEntry)}\n`;
+    await fs.writeFile(file, original, "utf-8");
+
+    const debug = vi.fn();
+    const result = await repairSessionFileIfNeeded({ sessionFile: file, debug });
+
+    expect(result.repaired).toBe(true);
+    expect(result.removedCorruptedImageBlocks).toBe(1);
+    expect(requireFirstLogMessage(debug)).toContain("removed 1 corrupted image block(s)");
+    const repaired = await fs.readFile(file, "utf-8");
+    const repairedEntry = JSON.parse(repaired.trim().split("\n")[1] ?? "{}");
+    expect(repairedEntry.message.content).toEqual([
+      { type: "text", text: "inspect this" },
+      { type: "text", text: CORRUPTED_IMAGE_FALLBACK_TEXT },
+    ]);
+  });
+
+  it("rewrites image blocks with empty-string data and no mimeType so replay can continue", async () => {
+    const { file } = await createTempSessionPath();
+    const { header } = buildSessionHeaderAndMessage();
+    const emptyDataEntry = {
+      type: "message",
+      id: "msg-empty-image",
+      parentId: null,
+      timestamp: new Date().toISOString(),
+      message: {
+        role: "user",
+        content: [
+          { type: "text", text: "inspect this" },
+          { type: "image", data: "" },
+        ],
+      },
+    };
+    const original = `${JSON.stringify(header)}\n${JSON.stringify(emptyDataEntry)}\n`;
+    await fs.writeFile(file, original, "utf-8");
+
+    const result = await repairSessionFileIfNeeded({ sessionFile: file });
+
+    expect(result.repaired).toBe(true);
+    expect(result.removedCorruptedImageBlocks).toBe(1);
+    const repaired = await fs.readFile(file, "utf-8");
+    const repairedEntry = JSON.parse(repaired.trim().split("\n")[1] ?? "{}");
+    expect(repairedEntry.message.content).toEqual([
+      { type: "text", text: "inspect this" },
+      { type: "text", text: CORRUPTED_IMAGE_FALLBACK_TEXT },
+    ]);
+  });
+
   it("preserves valid image blocks during repair", async () => {
     const { file } = await createTempSessionPath();
     const { header } = buildSessionHeaderAndMessage();

--- a/src/agents/session-file-repair.ts
+++ b/src/agents/session-file-repair.ts
@@ -246,8 +246,16 @@ function isCorruptedImageContentBlock(block: unknown): boolean {
     mediaType?: unknown;
     media_type?: unknown;
   };
-  if (record.type !== "image" || typeof record.data !== "string") {
+  if (record.type !== "image") {
     return false;
+  }
+  // A payload-less `{ type: "image" }` block (missing/empty `data`) is never a
+  // legitimate canonical shape -- ImageContent always carries inline base64 --
+  // so treat it as corrupted the same as a garbled payload. Left un-repaired,
+  // it replays to providers as an opaque media block with nothing to show,
+  // silently dropping the underlying content (#98673).
+  if (typeof record.data !== "string" || record.data.trim().length === 0) {
+    return true;
   }
   const mimeType = [record.mimeType, record.mediaType, record.media_type].find(isImageMimeType);
   if (!mimeType) {


### PR DESCRIPTION
Related: #98673

## What Problem This Solves

Resolves a problem where a persisted session transcript containing a tool-result/user image content block with no actual image payload (`{type: "image"}` with `data` missing or empty) would replay to the model provider unrepaired, reaching providers as an opaque media block with nothing to show and silently dropping the underlying content.

## Why This Change Was Made

`isCorruptedImageContentBlock` in `src/agents/session-file-repair.ts` only flagged image content blocks whose `data` was a *corrupt string* (garbled base64, non-ASCII). A block with `data` missing entirely failed the `typeof data !== "string"` check and returned `false`, so it passed through session repair un-repaired. The canonical `ImageContent` shape always requires inline base64 `data` — there is no legitimate reference-by-path variant — so a payload-less block is always corruption, never intentional. This change treats missing/empty `data` the same as a garbled payload: it gets rewritten to the existing `[image omitted: corrupted base64 payload]` text fallback during repair.

This is a narrow extension of existing repair logic; it does not change behavior for image blocks that already carry valid base64 data.

## User Impact

Sessions with a payload-less image block (however it got created) now get that block cleaned up on session-file repair, the same as any other corrupted image block, instead of silently replaying an invisible media placeholder to the model on every future turn.

## Evidence

- New regression tests in `src/agents/session-file-repair.test.ts`:
  - `rewrites payload-less image blocks (missing data) so replay can continue`
  - `rewrites image blocks with empty-string data and no mimeType so replay can continue`
- Existing tests confirm valid image blocks (real base64 `data` present) are still preserved untouched (`preserves valid image blocks during repair`, `preserves valid non-browser image blocks during repair`).
- `node scripts/run-vitest.mjs run src/agents/session-file-repair.test.ts` — 38/38 passed.