### PR TITLE
fix(file-transfer): don't inline zero-byte files as image content blocks

### DIFF
--- a/extensions/file-transfer/src/node-host/file-fetch.test.ts
+++ b/extensions/file-transfer/src/node-host/file-fetch.test.ts
@@ -86,8 +86,8 @@ describe("handleFileFetch — fs errors", () => {
 });
 
 describe("handleFileFetch — zero-byte round-trip", () => {
-  it("fetches an empty file with size=0 and base64=''", async () => {
-    const target = path.join(tmpRoot, "empty.bin");
+  it("fetches an empty image-named file with extension-derived MIME", async () => {
+    const target = path.join(tmpRoot, "empty.png");
     await fs.writeFile(target, "");
 
     const r = await handleFileFetch({ path: target });
@@ -95,6 +95,7 @@ describe("handleFileFetch — zero-byte round-trip", () => {
       throw new Error(`expected ok, got ${r.code}: ${r.message}`);
     }
     expect(r.size).toBe(0);
+    expect(r.mimeType).toBe("image/png");
     expect(r.base64).toBe("");
     // SHA-256 of empty input.
     expect(r.sha256).toBe("e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855");

--- a/extensions/file-transfer/src/tools/file-fetch-tool.test.ts
+++ b/extensions/file-transfer/src/tools/file-fetch-tool.test.ts
@@ -79,4 +79,72 @@ describe("file_fetch tool", () => {
     expect(text).toContain("[[END_MARKER_SANITIZED]]");
     expect(text).not.toContain('<<<END_EXTERNAL_UNTRUSTED_CONTENT id="deadbeef12345678">>>'); // pragma: allowlist secret
   });
+
+  it("falls back to text for a zero-byte file with an image-extension mimeType", async () => {
+    vi.mocked(listNodes).mockResolvedValue([{ nodeId: "node-1", displayName: "Node One" }]);
+    vi.mocked(resolveNodeIdFromList).mockReturnValue("node-1");
+    vi.mocked(callGatewayTool).mockResolvedValue({
+      payload: {
+        ok: true,
+        path: "/tmp/empty.png",
+        size: 0,
+        // Extension-derived MIME fallback for a zero-byte file that content
+        // sniffing could not classify -- see detectFetchedFileMime.
+        mimeType: "image/png",
+        base64: "",
+        sha256: crypto.createHash("sha256").update(Buffer.alloc(0)).digest("hex"),
+      },
+    });
+    vi.mocked(saveMediaBuffer).mockResolvedValue({
+      id: "media-1",
+      path: "/gateway/media/file-transfer/empty.png",
+      size: 0,
+      contentType: "image/png",
+    });
+
+    const result = await createFileFetchTool().execute("tool-call-1", {
+      node: "node-1",
+      path: "/tmp/empty.png",
+    });
+
+    expect(result.content).toHaveLength(1);
+    expect(result.content[0]?.type).toBe("text");
+    const text = result.content[0]?.type === "text" ? result.content[0].text : "";
+    expect(text).toContain("Fetched /tmp/empty.png");
+    expect(text).toContain("saved at /gateway/media/file-transfer/empty.png");
+  });
+
+  it("still inlines a non-empty image payload", async () => {
+    const buffer = Buffer.from([1, 2, 3, 4]);
+    vi.mocked(listNodes).mockResolvedValue([{ nodeId: "node-1", displayName: "Node One" }]);
+    vi.mocked(resolveNodeIdFromList).mockReturnValue("node-1");
+    vi.mocked(callGatewayTool).mockResolvedValue({
+      payload: {
+        ok: true,
+        path: "/tmp/photo.png",
+        size: buffer.byteLength,
+        mimeType: "image/png",
+        base64: buffer.toString("base64"),
+        sha256: crypto.createHash("sha256").update(buffer).digest("hex"),
+      },
+    });
+    vi.mocked(saveMediaBuffer).mockResolvedValue({
+      id: "media-1",
+      path: "/gateway/media/file-transfer/photo.png",
+      size: buffer.byteLength,
+      contentType: "image/png",
+    });
+
+    const result = await createFileFetchTool().execute("tool-call-1", {
+      node: "node-1",
+      path: "/tmp/photo.png",
+    });
+
+    expect(result.content).toHaveLength(1);
+    expect(result.content[0]).toEqual({
+      type: "image",
+      data: buffer.toString("base64"),
+      mimeType: "image/png",
+    });
+  });
 });

--- a/extensions/file-transfer/src/tools/file-fetch-tool.test.ts
+++ b/extensions/file-transfer/src/tools/file-fetch-tool.test.ts
@@ -88,8 +88,6 @@ describe("file_fetch tool", () => {
         ok: true,
         path: "/tmp/empty.png",
         size: 0,
-        // Extension-derived MIME fallback for a zero-byte file that content
-        // sniffing could not classify -- see detectFetchedFileMime.
         mimeType: "image/png",
         base64: "",
         sha256: crypto.createHash("sha256").update(Buffer.alloc(0)).digest("hex"),

--- a/extensions/file-transfer/src/tools/file-fetch-tool.ts
+++ b/extensions/file-transfer/src/tools/file-fetch-tool.ts
@@ -73,7 +73,13 @@ export function createFileFetchTool(): AnyAgentTool {
       const localPath = saved.path;
       const shortHash = sha256.slice(0, 12);
 
-      const isInlineImage = IMAGE_MIME_INLINE_SET.has(mimeType);
+      // detectFetchedFileMime falls back to the extension-derived MIME type when
+      // content sniffing finds nothing (e.g. a zero-byte file), so an empty
+      // ".png"/".jpg" fetch can carry an image mimeType with base64="". Require
+      // a real payload before inlining as an image block -- an empty inline
+      // image block reaches the provider as an unrecoverable placeholder
+      // instead of the "saved at <path>" text fallback below. See #98673.
+      const isInlineImage = IMAGE_MIME_INLINE_SET.has(mimeType) && base64.length > 0;
       const isInlineText = TEXT_INLINE_MIME_SET.has(mimeType) && size <= TEXT_INLINE_MAX_BYTES;
 
       const content: Array<

--- a/extensions/file-transfer/src/tools/file-fetch-tool.ts
+++ b/extensions/file-transfer/src/tools/file-fetch-tool.ts
@@ -73,12 +73,8 @@ export function createFileFetchTool(): AnyAgentTool {
       const localPath = saved.path;
       const shortHash = sha256.slice(0, 12);
 
-      // detectFetchedFileMime falls back to the extension-derived MIME type when
-      // content sniffing finds nothing (e.g. a zero-byte file), so an empty
-      // ".png"/".jpg" fetch can carry an image mimeType with base64="". Require
-      // a real payload before inlining as an image block -- an empty inline
-      // image block reaches the provider as an unrecoverable placeholder
-      // instead of the "saved at <path>" text fallback below. See #98673.
+      // Extension-derived image MIME can accompany an empty payload when there
+      // are no bytes to sniff. Keep those fetches on the saved-path text fallback.
       const isInlineImage = IMAGE_MIME_INLINE_SET.has(mimeType) && base64.length > 0;
       const isInlineText = TEXT_INLINE_MIME_SET.has(mimeType) && size <= TEXT_INLINE_MAX_BYTES;
 


### PR DESCRIPTION
Related: #98673

## What Problem This Solves

Fetching a zero-byte file with an image extension through `file_fetch` produced an image content block with an empty payload. Providers cannot render that block, so the model receives no useful fetch result.

## Why This Change Was Made

The node host accepts legitimate zero-byte transfers and MIME detection falls back to the filename extension when there are no bytes to sniff. An empty `.png` therefore arrives as `image/png` with `base64: ""`.

`file_fetch` now requires a non-empty payload before constructing an inline image block. Empty image-named files remain saved in the media store and return the existing saved-path text result. Non-empty images keep the existing inline behavior.

The sibling `dir_fetch` path only orders media URLs and does not construct model-visible image blocks, so it is unaffected.

## User Impact

Fetching an empty image-named file now gives the model a readable saved-path result instead of an invalid empty image block.

## Evidence

- Exact head: `e6b4302e13f3908f12e5570a788f7f811e2d343c`
- Real node-host regression proves a zero-byte `.png` returns `size: 0`, `mimeType: "image/png"`, and empty base64.
- Tool regressions prove empty image payloads use text fallback and non-empty images remain inline.
- `node scripts/run-vitest.mjs extensions/file-transfer/src/node-host/file-fetch.test.ts extensions/file-transfer/src/tools/file-fetch-tool.test.ts` - 20/20 passed.
- Scoped oxlint, oxfmt, and `git diff --check` passed.
- Fresh autoreview: clean, patch correct, confidence 0.98.
- Exact-head hosted CI passed, including QA Smoke CI.
