### PR TITLE
improve(qa): standardize script evidence output

### DIFF
--- a/extensions/qa-lab/api.ts
+++ b/extensions/qa-lab/api.ts
@@ -27,6 +27,15 @@ export {
 export { isQaLabCliAvailable, registerQaLabCli } from "./src/cli.js";
 export { createQaRunnerRuntime } from "./src/harness-runtime.js";
 export {
+  buildScriptEvidenceSummary,
+  QA_EVIDENCE_FILENAME,
+  type QaEvidencePackageSource,
+  type QaEvidenceStatus,
+  type QaEvidenceSummaryJson,
+  validateQaEvidenceSummaryJson,
+} from "./src/evidence-summary.js";
+export type { QaProviderMode } from "./src/providers/index.js";
+export {
   type QaLabLatestReport,
   type QaLabScenarioOutcome,
   type QaLabScenarioRun,

--- a/test/e2e/qa-lab/media/hosted-media-provider-live.test.ts
+++ b/test/e2e/qa-lab/media/hosted-media-provider-live.test.ts
@@ -86,7 +86,6 @@ describe("hosted media provider live QA producer", () => {
     const evidence = buildHostedMediaEvidence({
       options,
       result: {
-        artifacts: [{ kind: "log", path: "hosted-media-live.log" }],
         durationMs: 10,
         status: "pass",
       },

--- a/test/e2e/qa-lab/media/hosted-media-provider-live.ts
+++ b/test/e2e/qa-lab/media/hosted-media-provider-live.ts
@@ -1,15 +1,18 @@
 // Hosted media provider live runner and QA Lab evidence producer.
 import { spawn } from "node:child_process";
-import fs from "node:fs/promises";
 import path from "node:path";
 import { pathToFileURL } from "node:url";
 import {
-  buildScriptEvidenceSummary,
   QA_EVIDENCE_FILENAME,
-  type QaEvidenceStatus,
   type QaEvidenceSummaryJson,
-} from "../../../../extensions/qa-lab/src/evidence-summary.js";
+} from "../../../../extensions/qa-lab/api.js";
 import { spawnPnpmRunner as _spawnPnpmRunner } from "../../../../scripts/pnpm-runner.mjs";
+import { createBoundedChildOutput } from "../../../helpers/bounded-child-output.js";
+import {
+  createQaScriptBlockedStatusTracker,
+  createQaScriptEvidenceWriter,
+  type QaScriptEvidenceStatus,
+} from "../runtime/script-evidence.js";
 
 const SOURCE_PATH = "test/e2e/qa-lab/media/hosted-media-provider-live.ts";
 const DEFAULT_PROVIDERS_ENV = "OPENCLAW_QA_HOSTED_MEDIA_PROVIDERS";
@@ -127,10 +130,10 @@ type HostedMediaSuiteDefinition = {
 };
 
 type HostedMediaProofResult = {
-  artifacts: Array<{ kind: string; path: string }>;
+  artifacts?: Array<{ filePath: string; kind: string }>;
   details?: string;
   durationMs: number;
-  status: QaEvidenceStatus;
+  status: QaScriptEvidenceStatus;
 };
 
 const EVIDENCE_SUITES: Record<EvidenceSuiteId, HostedMediaSuiteDefinition> = {
@@ -667,20 +670,6 @@ export function parseHostedMediaOptions(argv: readonly string[]): HostedMediaOpt
   };
 }
 
-async function writeJson(filePath: string, value: unknown) {
-  await fs.mkdir(path.dirname(filePath), { recursive: true });
-  await fs.writeFile(filePath, `${JSON.stringify(value, null, 2)}\n`, "utf8");
-}
-
-async function appendText(filePath: string, text: string) {
-  await fs.mkdir(path.dirname(filePath), { recursive: true });
-  await fs.appendFile(filePath, text, "utf8");
-}
-
-function relativeArtifactPath(options: HostedMediaOptions, filePath: string) {
-  return path.relative(options.artifactBase, filePath) || path.basename(filePath);
-}
-
 function suiteProviderFilter(options: HostedMediaOptions, env: NodeJS.ProcessEnv) {
   const suiteEnv = `OPENCLAW_QA_HOSTED_${options.suiteId.toUpperCase()}_PROVIDERS`;
   return env[suiteEnv]?.trim() || env[options.providersEnv]?.trim() || "";
@@ -707,30 +696,52 @@ export function buildHostedMediaCommand(params: {
   };
 }
 
-export function classifyHostedMediaFailureStatus(message: string): QaEvidenceStatus {
-  const blockedPatterns = [
-    /no runnable providers matched available auth/i,
-    /no runnable providers matched the explicit provider selection/i,
-    /no runnable providers matched explicit provider selection/i,
-    /no providers with usable auth/i,
-  ];
-  return blockedPatterns.some((pattern) => pattern.test(message)) ? "blocked" : "fail";
+const HOSTED_MEDIA_BLOCKED_PATTERNS = [
+  /no runnable providers matched available auth/i,
+  /no runnable providers matched the explicit provider selection/i,
+  /no runnable providers matched explicit provider selection/i,
+  /no providers with usable auth/i,
+];
+
+export function classifyHostedMediaFailureStatus(message: string): QaScriptEvidenceStatus {
+  const tracker = createQaScriptBlockedStatusTracker(HOSTED_MEDIA_BLOCKED_PATTERNS);
+  tracker.append(message);
+  return tracker.status();
 }
 
 function formatCommand(command: string, args: readonly string[]) {
   return [command, ...args].map((arg) => JSON.stringify(arg)).join(" ");
 }
 
-async function runHostedMediaProof(options: HostedMediaOptions): Promise<HostedMediaProofResult> {
+function createHostedMediaEvidenceWriter(options: HostedMediaOptions) {
+  const definition = EVIDENCE_SUITES[options.suiteId];
+  return createQaScriptEvidenceWriter({
+    artifactBase: options.artifactBase,
+    logFileName: "hosted-media-live.log",
+    primaryModel: "live-media/hosted-media-provider",
+    providerMode: "live-frontier",
+    repoRoot: options.repoRoot,
+    target: {
+      id: definition.scenarioId,
+      title: definition.title,
+      sourcePath: SOURCE_PATH,
+      primaryCoverageIds: definition.primaryCoverageIds,
+      secondaryCoverageIds: definition.secondaryCoverageIds,
+      docsRefs: definition.docsRefs,
+      codeRefs: definition.codeRefs,
+    },
+  });
+}
+
+async function runHostedMediaProof(
+  options: HostedMediaOptions,
+  writer: ReturnType<typeof createHostedMediaEvidenceWriter>,
+): Promise<HostedMediaProofResult> {
   const startedAt = Date.now();
-  await fs.mkdir(options.artifactBase, { recursive: true });
-  const logPath = path.join(options.artifactBase, "hosted-media-live.log");
-  const artifacts = [{ kind: "log", path: relativeArtifactPath(options, logPath) }];
   const command = buildHostedMediaCommand({ options });
 
-  await appendText(logPath, `$ ${formatCommand(command.command, command.args)}\n`);
-  await appendText(
-    logPath,
+  writer.appendLog(`$ ${formatCommand(command.command, command.args)}\n`);
+  writer.appendLog(
     `suite: ${options.suiteId}\nprovidersEnv: ${options.providersEnv}\nvideoFullModes: ${String(EVIDENCE_SUITES[options.suiteId].videoFullModes === true)}\n`,
   );
 
@@ -740,46 +751,46 @@ async function runHostedMediaProof(options: HostedMediaOptions): Promise<HostedM
       env: command.env,
       stdio: ["ignore", "pipe", "pipe"],
     });
-    let stdout = "";
-    let stderr = "";
+    const stdout = createBoundedChildOutput();
+    const stderr = createBoundedChildOutput();
+    const statusTracker = createQaScriptBlockedStatusTracker(HOSTED_MEDIA_BLOCKED_PATTERNS);
     child.stdout.setEncoding("utf8");
     child.stderr.setEncoding("utf8");
     child.stdout.on("data", (chunk: string) => {
-      stdout += chunk;
+      stdout.append(chunk);
+      statusTracker.append(chunk);
     });
     child.stderr.on("data", (chunk: string) => {
-      stderr += chunk;
+      stderr.append(chunk);
+      statusTracker.append(chunk);
     });
     child.on("error", reject);
     child.on("close", (status, signal) => {
+      const stdoutText = stdout.text();
+      const stderrText = stderr.text();
       const output = [
-        stdout ? `\n--- stdout ---\n${stdout}` : "",
-        stderr ? `\n--- stderr ---\n${stderr}` : "",
+        stdoutText ? `\n--- stdout ---\n${stdoutText}` : "",
+        stderrText ? `\n--- stderr ---\n${stderrText}` : "",
       ].join("");
-      appendText(logPath, output)
-        .then(() => {
-          const durationMs = Math.max(1, Date.now() - startedAt);
-          if (status === 0 && !signal) {
-            resolve({
-              artifacts,
-              details: `${options.suiteId} hosted media live suite passed`,
-              durationMs,
-              status: "pass",
-            });
-            return;
-          }
-          const details = signal
-            ? `${options.suiteId} hosted media live suite terminated by ${signal}`
-            : `${options.suiteId} hosted media live suite exited with ${status ?? 1}`;
-          const combined = `${details}\n${stderr || stdout}`;
-          resolve({
-            artifacts,
-            details: combined,
-            durationMs,
-            status: classifyHostedMediaFailureStatus(combined),
-          });
-        })
-        .catch(reject);
+      writer.appendLog(output);
+      const durationMs = Math.max(1, Date.now() - startedAt);
+      if (status === 0 && !signal) {
+        resolve({
+          details: `${options.suiteId} hosted media live suite passed`,
+          durationMs,
+          status: "pass",
+        });
+        return;
+      }
+      const details = signal
+        ? `${options.suiteId} hosted media live suite terminated by ${signal}`
+        : `${options.suiteId} hosted media live suite exited with ${status ?? 1}`;
+      const combined = `${details}\n${stderrText || stdoutText}`;
+      resolve({
+        details: combined,
+        durationMs,
+        status: statusTracker.status(),
+      });
     });
   });
 }
@@ -788,48 +799,15 @@ export function buildHostedMediaEvidence(params: {
   options: HostedMediaOptions;
   result: HostedMediaProofResult;
 }): QaEvidenceSummaryJson {
-  const definition = EVIDENCE_SUITES[params.options.suiteId];
-  return buildScriptEvidenceSummary({
-    artifactPaths: params.result.artifacts,
-    evidenceMode: "full",
-    env: process.env,
-    generatedAt: new Date().toISOString(),
-    primaryModel: "live-media/hosted-media-provider",
-    providerMode: "live-frontier",
-    repoRoot: params.options.repoRoot,
-    runner: "script",
-    targets: [
-      {
-        id: definition.scenarioId,
-        title: definition.title,
-        sourcePath: SOURCE_PATH,
-        primaryCoverageIds: definition.primaryCoverageIds,
-        secondaryCoverageIds: definition.secondaryCoverageIds,
-        docsRefs: definition.docsRefs,
-        codeRefs: definition.codeRefs,
-      },
-    ],
-    results: [
-      {
-        id: definition.scenarioId,
-        status: params.result.status,
-        durationMs: params.result.durationMs,
-        failureMessage: params.result.details,
-      },
-    ],
-  });
+  return createHostedMediaEvidenceWriter(params.options).build(params.result);
 }
 
 export async function runHostedMediaProviderLiveProducer(
   options: HostedMediaOptions,
 ): Promise<QaEvidenceSummaryJson> {
-  const result = await runHostedMediaProof(options);
-  const evidence = buildHostedMediaEvidence({ options, result });
-  await writeJson(path.join(options.artifactBase, QA_EVIDENCE_FILENAME), evidence);
-  await writeJson(path.join(options.artifactBase, "latest-run.json"), {
-    qaEvidence: QA_EVIDENCE_FILENAME,
-  });
-  return evidence;
+  const writer = createHostedMediaEvidenceWriter(options);
+  const result = await runHostedMediaProof(options, writer);
+  return await writer.write(result);
 }
 
 async function main(argv: string[]) {

--- a/test/e2e/qa-lab/plugins/clawhub-release-candidate-install.test.ts
+++ b/test/e2e/qa-lab/plugins/clawhub-release-candidate-install.test.ts
@@ -1,0 +1,59 @@
+// ClawHub release candidate producer tests cover blocked script evidence output.
+import { spawnSync } from "node:child_process";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { validateQaEvidenceSummaryJson } from "../../../../extensions/qa-lab/api.js";
+
+const SOURCE_PATH = "test/e2e/qa-lab/plugins/clawhub-release-candidate-install.ts";
+const tempRoots: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(
+    tempRoots.splice(0).map((root) => fs.rm(root, { recursive: true, force: true })),
+  );
+});
+
+describe("ClawHub release candidate install producer", () => {
+  it("writes blocked evidence when no candidate tarball is available", async () => {
+    const artifactBase = await fs.mkdtemp(
+      path.join(os.tmpdir(), "openclaw-clawhub-release-evidence-"),
+    );
+    tempRoots.push(artifactBase);
+    const missingTarballEnv = "OPENCLAW_TEST_MISSING_RELEASE_CANDIDATE_TARBALL";
+    const env = { ...process.env };
+    delete env[missingTarballEnv];
+
+    const result = spawnSync(
+      process.execPath,
+      [
+        "--import",
+        "tsx",
+        SOURCE_PATH,
+        "--artifact-base",
+        artifactBase,
+        "--tarball-env",
+        missingTarballEnv,
+      ],
+      { cwd: process.cwd(), encoding: "utf8", env },
+    );
+
+    expect(result.status).toBe(0);
+    const evidence = validateQaEvidenceSummaryJson(
+      JSON.parse(await fs.readFile(path.join(artifactBase, "qa-evidence.json"), "utf8")),
+    );
+    expect(evidence.entries[0]).toMatchObject({
+      execution: {
+        artifacts: [{ kind: "log", path: "parallels-npm-update.log", source: "script" }],
+      },
+      result: {
+        status: "blocked",
+        failure: {
+          reason: expect.stringContaining(`${missingTarballEnv} is not set`),
+        },
+      },
+    });
+    expect(result.stdout).toContain("ClawHub release-candidate install status: blocked");
+  });
+});

--- a/test/e2e/qa-lab/plugins/clawhub-release-candidate-install.ts
+++ b/test/e2e/qa-lab/plugins/clawhub-release-candidate-install.ts
@@ -5,11 +5,15 @@ import path from "node:path";
 import { pathToFileURL } from "node:url";
 import { promisify } from "node:util";
 import {
-  buildScriptEvidenceSummary,
   QA_EVIDENCE_FILENAME,
-  type QaEvidenceStatus,
   type QaEvidenceSummaryJson,
-} from "../../../../extensions/qa-lab/src/evidence-summary.js";
+} from "../../../../extensions/qa-lab/api.js";
+import { createBoundedChildOutput } from "../../../helpers/bounded-child-output.js";
+import {
+  createQaScriptBlockedStatusTracker,
+  createQaScriptEvidenceWriter,
+  type QaScriptEvidenceStatus,
+} from "../runtime/script-evidence.js";
 
 const SCENARIO_ID = "clawhub-release-candidate-checklist";
 const SCENARIO_TITLE = "ClawHub release candidate npm package install proof";
@@ -18,6 +22,16 @@ const COVERAGE_ID = "clawhub.npm-pack-local-release-candidate-installs";
 const DEFAULT_TARBALL_ENV = "OPENCLAW_QA_RELEASE_CANDIDATE_TARBALL";
 const CHECKOUT_BUILD_RESULT_PREFIX = "__OPENCLAW_QA_RELEASE_CANDIDATE_TARBALL__";
 const execFileAsync = promisify(execFile);
+const CLAWHUB_BLOCKED_PREREQUISITE_PATTERNS = [
+  /\bprlctl\b/i,
+  /failed to detect parallels host ip/i,
+  /vm .*not found/i,
+  /could not resolve .*vm/i,
+  /no .*vm/i,
+  /parallels desktop .*not/i,
+  /api key/i,
+  /provider auth/i,
+];
 
 type ProducerOptions = {
   artifactBase: string;
@@ -36,11 +50,21 @@ type ParallelsSummary = {
 };
 
 type ProofResult = {
-  artifacts: Array<{ kind: string; path: string }>;
+  artifacts?: Array<{ filePath: string; kind: string }>;
   details?: string;
   durationMs: number;
-  status: QaEvidenceStatus;
+  status: QaScriptEvidenceStatus;
 };
+
+class ParallelsProofError extends Error {
+  constructor(
+    message: string,
+    readonly evidenceStatus: QaScriptEvidenceStatus,
+  ) {
+    super(message);
+    this.name = "ParallelsProofError";
+  }
+}
 
 function usage() {
   return `Usage: node --import tsx ${SOURCE_PATH} --artifact-base <dir> [options]
@@ -142,15 +166,6 @@ async function writeJson(filePath: string, value: unknown) {
   await fs.writeFile(filePath, `${JSON.stringify(value, null, 2)}\n`, "utf8");
 }
 
-async function appendText(filePath: string, text: string) {
-  await fs.mkdir(path.dirname(filePath), { recursive: true });
-  await fs.appendFile(filePath, text, "utf8");
-}
-
-function relativeArtifactPath(options: ProducerOptions, filePath: string) {
-  return path.relative(options.artifactBase, filePath) || path.basename(filePath);
-}
-
 function formatErrorMessage(error: unknown) {
   return error instanceof Error ? error.message : String(error);
 }
@@ -223,9 +238,9 @@ async function validateCandidateTarball(tarballPath: string) {
 }
 
 async function runParallelsProof(params: {
-  logPath: string;
   options: ProducerOptions;
   tarballPath: string;
+  writer: ReturnType<typeof createClawHubEvidenceWriter>;
 }) {
   const args = [
     "scripts/e2e/parallels-npm-update-smoke.sh",
@@ -236,7 +251,7 @@ async function runParallelsProof(params: {
   if (params.options.platform) {
     args.push("--platform", params.options.platform);
   }
-  await appendText(params.logPath, `$ bash ${args.map((arg) => JSON.stringify(arg)).join(" ")}\n`);
+  params.writer.appendLog(`$ bash ${args.map((arg) => JSON.stringify(arg)).join(" ")}\n`);
 
   return await new Promise<{ stderr: string; stdout: string }>((resolve, reject) => {
     const child = spawn("bash", args, {
@@ -244,34 +259,38 @@ async function runParallelsProof(params: {
       env: process.env,
       stdio: ["ignore", "pipe", "pipe"],
     });
-    let stdout = "";
-    let stderr = "";
+    const stdout = createBoundedChildOutput(1024 * 1024);
+    const stderr = createBoundedChildOutput();
+    const statusTracker = createQaScriptBlockedStatusTracker(CLAWHUB_BLOCKED_PREREQUISITE_PATTERNS);
     child.stdout.setEncoding("utf8");
     child.stderr.setEncoding("utf8");
     child.stdout.on("data", (chunk: string) => {
-      stdout += chunk;
+      stdout.append(chunk);
+      statusTracker.append(chunk);
     });
     child.stderr.on("data", (chunk: string) => {
-      stderr += chunk;
+      stderr.append(chunk);
+      statusTracker.append(chunk);
     });
     child.on("error", reject);
     child.on("close", (status, signal) => {
+      const stdoutText = stdout.text();
+      const stderrText = stderr.text();
       const output = [
-        stdout ? `\n--- stdout ---\n${stdout}` : "",
-        stderr ? `\n--- stderr ---\n${stderr}` : "",
+        stdoutText ? `\n--- stdout ---\n${stdoutText}` : "",
+        stderrText ? `\n--- stderr ---\n${stderrText}` : "",
       ].join("");
-      appendText(params.logPath, output)
-        .then(() => {
-          if (status === 0 && !signal) {
-            resolve({ stderr, stdout });
-            return;
-          }
-          const reason = signal
-            ? `Parallels npm-update proof terminated by ${signal}`
-            : `Parallels npm-update proof exited with ${status ?? 1}`;
-          reject(new Error(`${reason}\n${stderr || stdout}`));
-        })
-        .catch(reject);
+      params.writer.appendLog(output);
+      if (status === 0 && !signal) {
+        resolve({ stderr: stderrText, stdout: stdoutText });
+        return;
+      }
+      const reason = signal
+        ? `Parallels npm-update proof terminated by ${signal}`
+        : `Parallels npm-update proof exited with ${status ?? 1}`;
+      reject(
+        new ParallelsProofError(`${reason}\n${stderrText || stdoutText}`, statusTracker.status()),
+      );
     });
   });
 }
@@ -343,30 +362,44 @@ function assertParallelsSummary(params: {
 }
 
 function isBlockedPrerequisiteFailure(message: string) {
-  return [
-    /\bprlctl\b/i,
-    /failed to detect parallels host ip/i,
-    /vm .*not found/i,
-    /could not resolve .*vm/i,
-    /no .*vm/i,
-    /parallels desktop .*not/i,
-    /api key/i,
-    /provider auth/i,
-  ].some((pattern) => pattern.test(message));
+  return CLAWHUB_BLOCKED_PREREQUISITE_PATTERNS.some((pattern) => pattern.test(message));
 }
 
-async function produceProof(options: ProducerOptions): Promise<ProofResult> {
+function createClawHubEvidenceWriter(options: ProducerOptions) {
+  return createQaScriptEvidenceWriter({
+    artifactBase: options.artifactBase,
+    logFileName: "parallels-npm-update.log",
+    primaryModel: "mock-openai/gpt-5.5",
+    providerMode: "mock-openai",
+    repoRoot: options.repoRoot,
+    target: {
+      id: SCENARIO_ID,
+      title: SCENARIO_TITLE,
+      sourcePath: SOURCE_PATH,
+      primaryCoverageIds: [COVERAGE_ID],
+      docsRefs: ["docs/help/testing.md", "docs/concepts/qa-e2e-automation.md"],
+      codeRefs: [
+        SOURCE_PATH,
+        "scripts/e2e/parallels-npm-update-smoke.sh",
+        "scripts/e2e/parallels/npm-update-smoke.ts",
+        "test/scripts/release-candidate-checklist.test.ts",
+      ],
+    },
+  });
+}
+
+async function produceProof(
+  options: ProducerOptions,
+  writer: ReturnType<typeof createClawHubEvidenceWriter>,
+): Promise<ProofResult> {
   const startedAt = Date.now();
   await fs.mkdir(options.artifactBase, { recursive: true });
-  const logPath = path.join(options.artifactBase, "parallels-npm-update.log");
   const summaryPath = path.join(options.artifactBase, "parallels-summary.json");
-  const artifacts = [{ kind: "log", path: relativeArtifactPath(options, logPath) }];
 
   try {
     const tarballPath = await resolveCandidateTarball(options);
     if (!tarballPath) {
       return {
-        artifacts,
         details: `${options.tarballEnv} is not set; provide a candidate .tgz or pass --build-from-checkout.`,
         durationMs: Math.max(1, Date.now() - startedAt),
         status: "blocked",
@@ -374,11 +407,10 @@ async function produceProof(options: ProducerOptions): Promise<ProofResult> {
     }
     await fs.access(tarballPath);
     const metadata = await validateCandidateTarball(tarballPath);
-    await appendText(
-      logPath,
+    writer.appendLog(
       `candidate: ${tarballPath}\nversion: ${metadata.version}\nbuild commit: ${metadata.buildCommit}\n`,
     );
-    const commandResult = await runParallelsProof({ logPath, options, tarballPath });
+    const commandResult = await runParallelsProof({ options, tarballPath, writer });
     const summary = parseParallelsSummary(commandResult.stdout);
     assertParallelsSummary({
       summary,
@@ -387,20 +419,21 @@ async function produceProof(options: ProducerOptions): Promise<ProofResult> {
     });
     await writeJson(summaryPath, summary);
     return {
-      artifacts: [
-        ...artifacts,
-        { kind: "summary", path: relativeArtifactPath(options, summaryPath) },
-      ],
+      artifacts: [{ kind: "summary", filePath: "parallels-summary.json" }],
       details: `candidate ${metadata.version} installed fresh and updated through Parallels npm semantics`,
       durationMs: Math.max(1, Date.now() - startedAt),
       status: "pass",
     };
   } catch (error) {
     const details = formatErrorMessage(error);
-    const status: QaEvidenceStatus = isBlockedPrerequisiteFailure(details) ? "blocked" : "fail";
-    await appendText(logPath, `\n${status}: ${details}\n`);
+    const status: QaScriptEvidenceStatus =
+      error instanceof ParallelsProofError
+        ? error.evidenceStatus
+        : isBlockedPrerequisiteFailure(details)
+          ? "blocked"
+          : "fail";
+    writer.appendLog(`\n${status}: ${details}\n`);
     return {
-      artifacts,
       details,
       durationMs: Math.max(1, Date.now() - startedAt),
       status,
@@ -408,55 +441,12 @@ async function produceProof(options: ProducerOptions): Promise<ProofResult> {
   }
 }
 
-function buildEvidence(params: {
-  options: ProducerOptions;
-  result: ProofResult;
-}): QaEvidenceSummaryJson {
-  return buildScriptEvidenceSummary({
-    artifactPaths: params.result.artifacts,
-    evidenceMode: "full",
-    env: process.env,
-    generatedAt: new Date().toISOString(),
-    primaryModel: "mock-openai/gpt-5.5",
-    providerMode: "mock-openai",
-    repoRoot: params.options.repoRoot,
-    runner: "script",
-    targets: [
-      {
-        id: SCENARIO_ID,
-        title: SCENARIO_TITLE,
-        sourcePath: SOURCE_PATH,
-        primaryCoverageIds: [COVERAGE_ID],
-        docsRefs: ["docs/help/testing.md", "docs/concepts/qa-e2e-automation.md"],
-        codeRefs: [
-          SOURCE_PATH,
-          "scripts/e2e/parallels-npm-update-smoke.sh",
-          "scripts/e2e/parallels/npm-update-smoke.ts",
-          "test/scripts/release-candidate-checklist.test.ts",
-        ],
-      },
-    ],
-    results: [
-      {
-        id: SCENARIO_ID,
-        status: params.result.status,
-        durationMs: params.result.durationMs,
-        failureMessage: params.result.details,
-      },
-    ],
-  });
-}
-
 export async function runClawHubReleaseCandidateInstallProducer(
   options: ProducerOptions,
 ): Promise<QaEvidenceSummaryJson> {
-  const result = await produceProof(options);
-  const evidence = buildEvidence({ options, result });
-  await writeJson(path.join(options.artifactBase, QA_EVIDENCE_FILENAME), evidence);
-  await writeJson(path.join(options.artifactBase, "latest-run.json"), {
-    qaEvidence: QA_EVIDENCE_FILENAME,
-  });
-  return evidence;
+  const writer = createClawHubEvidenceWriter(options);
+  const result = await produceProof(options, writer);
+  return await writer.write(result);
 }
 
 if (import.meta.url === pathToFileURL(process.argv[1] ?? "").href) {

--- a/test/e2e/qa-lab/runtime/script-evidence.test.ts
+++ b/test/e2e/qa-lab/runtime/script-evidence.test.ts
@@ -1,0 +1,154 @@
+// QA script evidence writer tests cover status, bounded logs, and artifact paths.
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { validateQaEvidenceSummaryJson } from "../../../../extensions/qa-lab/api.js";
+import {
+  createQaScriptBlockedStatusTracker,
+  createQaScriptEvidenceWriter,
+} from "./script-evidence.js";
+
+const tempRoots: string[] = [];
+
+async function makeWriter(params: { maxDetailsBytes?: number; maxLogBytes?: number } = {}) {
+  const repoRoot = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-script-evidence-"));
+  tempRoots.push(repoRoot);
+  return {
+    artifactBase: path.join(repoRoot, ".artifacts", "qa-e2e", "script"),
+    writer: createQaScriptEvidenceWriter({
+      artifactBase: path.join(repoRoot, ".artifacts", "qa-e2e", "script"),
+      logFileName: "producer.log",
+      maxDetailsBytes: params.maxDetailsBytes,
+      maxLogBytes: params.maxLogBytes ?? 64,
+      primaryModel: "mock-openai/gpt-5.5",
+      providerMode: "mock-openai",
+      repoRoot,
+      target: {
+        id: "script-evidence-test",
+        title: "Script evidence test",
+        sourcePath: "test/e2e/qa-lab/runtime/script-evidence.test.ts",
+        primaryCoverageIds: ["qa.script-evidence"],
+      },
+    }),
+  };
+}
+
+afterEach(async () => {
+  await Promise.all(
+    tempRoots.splice(0).map((root) => fs.rm(root, { recursive: true, force: true })),
+  );
+});
+
+describe("QA script evidence writer", () => {
+  for (const status of ["pass", "fail", "blocked"] as const) {
+    it(`writes ${status} evidence with normalized artifact paths`, async () => {
+      const { artifactBase, writer } = await makeWriter();
+      const summaryPath = path.join(artifactBase, "nested", "summary.json");
+      await fs.mkdir(path.dirname(summaryPath), { recursive: true });
+      await fs.writeFile(summaryPath, "{}\n", "utf8");
+      writer.appendLog("producer output\n");
+
+      const evidence = await writer.write({
+        artifacts: [{ kind: "summary", filePath: summaryPath }],
+        details: `${status} details`,
+        durationMs: 25,
+        status,
+      });
+
+      expect(evidence.entries[0]).toMatchObject({
+        execution: {
+          artifacts: [
+            { kind: "log", path: "producer.log", source: "script" },
+            { kind: "summary", path: path.join("nested", "summary.json"), source: "script" },
+          ],
+        },
+        result: {
+          status,
+          timing: { wallMs: 25 },
+        },
+      });
+      const diskEvidence = validateQaEvidenceSummaryJson(
+        JSON.parse(await fs.readFile(path.join(artifactBase, "qa-evidence.json"), "utf8")),
+      );
+      expect(diskEvidence).toEqual(evidence);
+      expect(
+        JSON.parse(await fs.readFile(path.join(artifactBase, "latest-run.json"), "utf8")),
+      ).toEqual({ qaEvidence: "qa-evidence.json" });
+    });
+  }
+
+  it("keeps only the bounded log tail", async () => {
+    const { artifactBase, writer } = await makeWriter({ maxLogBytes: 24 });
+    writer.appendLog(`discard-me-${"x".repeat(64)}`);
+    writer.appendLog("recent-tail");
+
+    await writer.write({ durationMs: 1, status: "pass" });
+
+    const log = await fs.readFile(path.join(artifactBase, "producer.log"), "utf8");
+    expect(log).toContain("recent-tail");
+    expect(log).not.toContain("discard-me");
+    expect(Buffer.byteLength(log, "utf8")).toBeLessThanOrEqual(24);
+  });
+
+  it("keeps only the bounded failure detail tail", async () => {
+    const { writer } = await makeWriter({ maxDetailsBytes: 24 });
+
+    const evidence = writer.build({
+      details: `discard-me-${"x".repeat(64)}recent-reason`,
+      durationMs: 1,
+      status: "fail",
+    });
+
+    const reason = evidence.entries[0]?.result.failure?.reason ?? "";
+    expect(reason).toContain("recent-reason");
+    expect(reason).not.toContain("discard-me");
+    expect(Buffer.byteLength(reason, "utf8")).toBeLessThanOrEqual(24);
+  });
+
+  it("keeps UTF-8 logs and failure details within byte limits", async () => {
+    const { artifactBase, writer } = await makeWriter({
+      maxDetailsBytes: 9,
+      maxLogBytes: 9,
+    });
+    const diagnostic = `${"🙂".repeat(32)}done`;
+    writer.appendLog(diagnostic);
+
+    const evidence = await writer.write({
+      details: diagnostic,
+      durationMs: 1,
+      status: "fail",
+    });
+
+    const log = await fs.readFile(path.join(artifactBase, "producer.log"), "utf8");
+    const reason = evidence.entries[0]?.result.failure?.reason ?? "";
+    expect(log).toContain("done");
+    expect(reason).toContain("done");
+    expect(Buffer.byteLength(log, "utf8")).toBeLessThanOrEqual(9);
+    expect(Buffer.byteLength(reason, "utf8")).toBeLessThanOrEqual(9);
+  });
+
+  it.each(["..", "../outside.log"])(
+    "rejects artifact path %s outside the producer output directory",
+    async (filePath) => {
+      const { writer } = await makeWriter();
+
+      expect(() =>
+        writer.build({
+          artifacts: [{ kind: "log", filePath }],
+          durationMs: 1,
+          status: "fail",
+        }),
+      ).toThrow("QA evidence artifact must be inside artifact base");
+    },
+  );
+
+  it("tracks blocked output before discarded diagnostic tails", () => {
+    const tracker = createQaScriptBlockedStatusTracker([/missing provider auth/i]);
+
+    tracker.append("missing provider ");
+    tracker.append(`auth\n${"x".repeat(4096)}`);
+
+    expect(tracker.status()).toBe("blocked");
+  });
+});

--- a/test/e2e/qa-lab/runtime/script-evidence.ts
+++ b/test/e2e/qa-lab/runtime/script-evidence.ts
@@ -1,0 +1,191 @@
+// Shared QA script evidence writer keeps producer logs and artifact paths bounded.
+import fs from "node:fs/promises";
+import path from "node:path";
+import {
+  buildScriptEvidenceSummary,
+  QA_EVIDENCE_FILENAME,
+  type QaEvidencePackageSource,
+  type QaEvidenceStatus,
+  type QaEvidenceSummaryJson,
+  type QaProviderMode,
+} from "../../../../extensions/qa-lab/api.js";
+import {
+  createBoundedChildOutput,
+  DEFAULT_CHILD_OUTPUT_TAIL_BYTES,
+} from "../../../helpers/bounded-child-output.js";
+
+export const DEFAULT_QA_SCRIPT_EVIDENCE_DETAILS_BYTES = 32 * 1024;
+const QA_SCRIPT_STATUS_MATCH_CARRY_CHARS = 1024;
+
+type QaScriptEvidenceArtifactInput = {
+  filePath: string;
+  kind: string;
+};
+
+type QaScriptEvidenceTarget = {
+  codeRefs?: readonly string[];
+  docsRefs?: readonly string[];
+  id: string;
+  primaryCoverageIds?: readonly string[];
+  secondaryCoverageIds?: readonly string[];
+  sourcePath: string;
+  title: string;
+};
+
+export type QaScriptEvidenceStatus = Exclude<QaEvidenceStatus, "skipped">;
+
+type QaScriptEvidenceResult = {
+  artifacts?: readonly QaScriptEvidenceArtifactInput[];
+  details?: string;
+  durationMs: number;
+  status: QaScriptEvidenceStatus;
+};
+
+type QaScriptEvidenceWriterOptions = {
+  artifactBase: string;
+  env?: NodeJS.ProcessEnv;
+  evidenceMode?: "full" | "slim";
+  logFileName: string;
+  maxDetailsBytes?: number;
+  maxLogBytes?: number;
+  packageSource?: QaEvidencePackageSource;
+  primaryModel: string;
+  providerMode: QaProviderMode;
+  repoRoot: string;
+  target: QaScriptEvidenceTarget;
+};
+
+function resolveArtifactPath(artifactBase: string, filePath: string) {
+  const absoluteArtifactBase = path.resolve(artifactBase);
+  const absoluteFilePath = path.resolve(absoluteArtifactBase, filePath);
+  const relativePath = path.relative(absoluteArtifactBase, absoluteFilePath);
+  const escapesArtifactBase =
+    relativePath === ".." ||
+    relativePath.startsWith(`..${path.sep}`) ||
+    path.isAbsolute(relativePath);
+  if (!relativePath || escapesArtifactBase) {
+    throw new Error(`QA evidence artifact must be inside artifact base: ${filePath}`);
+  }
+  return { absoluteFilePath, relativePath };
+}
+
+async function writeJson(filePath: string, value: unknown) {
+  await fs.mkdir(path.dirname(filePath), { recursive: true });
+  await fs.writeFile(filePath, `${JSON.stringify(value, null, 2)}\n`, "utf8");
+}
+
+function resolveByteLimit(value: number | undefined, fallback: number) {
+  return Number.isInteger(value) && Number(value) > 0 ? Number(value) : fallback;
+}
+
+function utf8Tail(text: string, maxBytes: number) {
+  const buffer = Buffer.from(text, "utf8");
+  if (buffer.byteLength <= maxBytes) {
+    return text;
+  }
+  let start = buffer.byteLength - maxBytes;
+  while (start < buffer.byteLength && (buffer[start]! & 0xc0) === 0x80) {
+    start += 1;
+  }
+  return buffer.subarray(start).toString("utf8");
+}
+
+export function createQaScriptBlockedStatusTracker(blockedPatterns: readonly RegExp[]) {
+  let blocked = false;
+  let carry = "";
+
+  return {
+    append(chunk: unknown) {
+      if (blocked) {
+        return;
+      }
+      const text = `${carry}${String(chunk)}`;
+      blocked = blockedPatterns.some((pattern) => {
+        pattern.lastIndex = 0;
+        return pattern.test(text);
+      });
+      // Keep enough overlap for a prerequisite phrase split across stream chunks.
+      carry = text.slice(-QA_SCRIPT_STATUS_MATCH_CARRY_CHARS);
+    },
+    status(): QaScriptEvidenceStatus {
+      return blocked ? "blocked" : "fail";
+    },
+  };
+}
+
+export function createQaScriptEvidenceWriter(options: QaScriptEvidenceWriterOptions) {
+  const maxLogBytes = resolveByteLimit(options.maxLogBytes, DEFAULT_CHILD_OUTPUT_TAIL_BYTES);
+  const log = createBoundedChildOutput(maxLogBytes);
+  const logFile = resolveArtifactPath(options.artifactBase, options.logFileName);
+  const maxDetailsBytes = resolveByteLimit(
+    options.maxDetailsBytes,
+    DEFAULT_QA_SCRIPT_EVIDENCE_DETAILS_BYTES,
+  );
+  const boundedLogText = () => utf8Tail(log.text(), maxLogBytes);
+
+  const boundedDetails = (details: string | undefined) => {
+    if (!details) {
+      return undefined;
+    }
+    const output = createBoundedChildOutput(maxDetailsBytes);
+    output.append(details);
+    return utf8Tail(output.text(), maxDetailsBytes);
+  };
+
+  const normalizeArtifacts = (artifacts: readonly QaScriptEvidenceArtifactInput[] = []) => {
+    const normalized = [
+      { kind: "log", path: logFile.relativePath },
+      ...artifacts.map((artifact) => ({
+        kind: artifact.kind,
+        path: resolveArtifactPath(options.artifactBase, artifact.filePath).relativePath,
+      })),
+    ];
+    return [
+      ...new Map(
+        normalized.map((artifact) => [`${artifact.kind}:${artifact.path}`, artifact]),
+      ).values(),
+    ];
+  };
+
+  const build = (result: QaScriptEvidenceResult): QaEvidenceSummaryJson =>
+    buildScriptEvidenceSummary({
+      artifactPaths: normalizeArtifacts(result.artifacts),
+      evidenceMode: options.evidenceMode ?? "full",
+      env: options.env ?? process.env,
+      generatedAt: new Date().toISOString(),
+      packageSource: options.packageSource,
+      primaryModel: options.primaryModel,
+      providerMode: options.providerMode,
+      repoRoot: options.repoRoot,
+      runner: "script",
+      targets: [options.target],
+      results: [
+        {
+          id: options.target.id,
+          status: result.status,
+          durationMs: result.durationMs,
+          failureMessage: boundedDetails(result.details),
+        },
+      ],
+    });
+
+  return {
+    appendLog(chunk: unknown) {
+      log.append(chunk);
+    },
+    build,
+    logText() {
+      return boundedLogText();
+    },
+    async write(result: QaScriptEvidenceResult) {
+      const evidence = build(result);
+      await fs.mkdir(options.artifactBase, { recursive: true });
+      await fs.writeFile(logFile.absoluteFilePath, boundedLogText(), "utf8");
+      await writeJson(path.join(options.artifactBase, QA_EVIDENCE_FILENAME), evidence);
+      await writeJson(path.join(options.artifactBase, "latest-run.json"), {
+        qaEvidence: QA_EVIDENCE_FILENAME,
+      });
+      return evidence;
+    },
+  };
+}


### PR DESCRIPTION
## What Problem This Solves

Resolves a QA maintenance problem where script-backed scenarios assembled `qa-evidence.json`, logs, and artifact references independently. This allowed unbounded diagnostic output, inconsistent artifact paths, and blocked prerequisite messages to be lost after output truncation.

## Why This Change Was Made

Adds one shared QA script evidence writer that owns schema construction, UTF-8 byte-bounded logs and failure details, contained artifact paths, and streaming blocked-status detection. The existing hosted-media and ClawHub release-candidate producers now use the shared path instead of maintaining separate evidence plumbing.

## User Impact

There is no user-visible product behavior change. QA maintainers get consistent pass/fail/blocked evidence, reliable artifact links, and bounded diagnostics for script-backed scenarios.

## Evidence

- `node scripts/run-vitest.mjs test/e2e/qa-lab/runtime/script-evidence.test.ts test/e2e/qa-lab/media/hosted-media-provider-live.test.ts test/e2e/qa-lab/plugins/clawhub-release-candidate-install.test.ts` — 28 tests passed.
- Blacksmith Testbox through Crabbox `tbx_01kwk5g33qx6398swb0pdzyvw7` — `check:changed` and `check:test-types` passed.
- GitHub Actions hydration/proof run: https://github.com/openclaw/openclaw/actions/runs/28639451493
- Final Codex autoreview: clean, no accepted/actionable findings.
