### PR TITLE
fix: clean up codex run-attempt on post-registration failure

### DIFF
--- a/extensions/codex/src/app-server/run-attempt.cleanup-window.test.ts
+++ b/extensions/codex/src/app-server/run-attempt.cleanup-window.test.ts
@@ -1,0 +1,101 @@
+// Codex tests cover run attempt cleanup-window plugin behavior.
+import path from "node:path";
+import { describe, expect, it, vi } from "vitest";
+import {
+  createParams,
+  mockClientRuntimeMethods,
+  setupRunAttemptTestHooks,
+  tempDir,
+  threadStartResult,
+  turnStartResult,
+  runCodexAppServerAttempt,
+  setCodexAppServerClientFactoryForTest,
+} from "./run-attempt-test-harness.js";
+
+const activeRunRegistrationMocks = vi.hoisted(() => ({
+  clearActiveEmbeddedRun: vi.fn(),
+  setActiveEmbeddedRun: vi.fn(),
+}));
+
+vi.mock("openclaw/plugin-sdk/agent-harness-runtime", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("openclaw/plugin-sdk/agent-harness-runtime")>();
+  return {
+    ...actual,
+    clearActiveEmbeddedRun: (
+      ...args: Parameters<typeof actual.clearActiveEmbeddedRun>
+    ): ReturnType<typeof actual.clearActiveEmbeddedRun> => {
+      activeRunRegistrationMocks.clearActiveEmbeddedRun(...args);
+      return actual.clearActiveEmbeddedRun(...args);
+    },
+    setActiveEmbeddedRun: (
+      ...args: Parameters<typeof actual.setActiveEmbeddedRun>
+    ): ReturnType<typeof actual.setActiveEmbeddedRun> => {
+      activeRunRegistrationMocks.setActiveEmbeddedRun(...args);
+      return actual.setActiveEmbeddedRun(...args);
+    },
+  };
+});
+
+vi.mock("./transcript-mirror.js", () => ({
+  createCodexAppServerUserMessagePersistenceNotifier: vi.fn(() => {
+    throw new Error("boom after turn acceptance");
+  }),
+  mirrorPromptAtTurnStartBestEffort: vi.fn(),
+}));
+
+setupRunAttemptTestHooks();
+
+describe("Codex app-server cleanup window", () => {
+  it("cleans up the active run if notifier construction throws after registration", async () => {
+    let notificationCleanupCalled = 0;
+    let requestCleanupCalled = 0;
+    const request = vi.fn(async (method: string) => {
+      if (method === "thread/start") {
+        return threadStartResult("thread-1");
+      }
+      if (method === "turn/start") {
+        return turnStartResult("turn-1", "inProgress");
+      }
+      return {};
+    });
+
+    setCodexAppServerClientFactoryForTest(
+      async () =>
+        ({
+          ...mockClientRuntimeMethods(),
+          request,
+          addNotificationHandler: () => () => {
+            notificationCleanupCalled += 1;
+          },
+          addRequestHandler: () => () => {
+            requestCleanupCalled += 1;
+          },
+        }) as never,
+    );
+
+    const params = createParams(
+      path.join(tempDir, "cleanup-window-session.jsonl"),
+      path.join(tempDir, "cleanup-window-workspace"),
+    );
+    params.sessionId = "cleanup-window-session";
+    params.sessionKey = "agent:main:cleanup-window-session";
+    params.runId = "run-cleanup-window-session";
+
+    await expect(runCodexAppServerAttempt(params)).rejects.toThrow("boom after turn acceptance");
+
+    expect(activeRunRegistrationMocks.setActiveEmbeddedRun).toHaveBeenCalledWith(
+      params.sessionId,
+      expect.anything(),
+      params.sessionKey,
+      params.sessionFile,
+    );
+    expect(activeRunRegistrationMocks.clearActiveEmbeddedRun).toHaveBeenCalledWith(
+      params.sessionId,
+      expect.anything(),
+      params.sessionKey,
+      params.sessionFile,
+    );
+    expect(notificationCleanupCalled).toBe(1);
+    expect(requestCleanupCalled).toBe(1);
+  }, 20_000);
+});

--- a/extensions/codex/src/app-server/run-attempt.cleanup-window.test.ts
+++ b/extensions/codex/src/app-server/run-attempt.cleanup-window.test.ts
@@ -1,6 +1,6 @@
 // Codex tests cover run attempt cleanup-window plugin behavior.
 import path from "node:path";
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   createParams,
   mockClientRuntimeMethods,
@@ -12,9 +12,13 @@ import {
   setCodexAppServerClientFactoryForTest,
 } from "./run-attempt-test-harness.js";
 
-const activeRunRegistrationMocks = vi.hoisted(() => ({
-  clearActiveEmbeddedRun: vi.fn(),
-  setActiveEmbeddedRun: vi.fn(),
+const cleanupWindowMocks = vi.hoisted(() => ({
+  activeRunRegistration: {
+    clearActiveEmbeddedRun: vi.fn(),
+    setActiveEmbeddedRun: vi.fn(),
+  },
+  throwOnSteeringQueueCreation: false,
+  throwOnNotifierConstruction: false,
 }));
 
 vi.mock("openclaw/plugin-sdk/agent-harness-runtime", async (importOriginal) => {
@@ -24,13 +28,13 @@ vi.mock("openclaw/plugin-sdk/agent-harness-runtime", async (importOriginal) => {
     clearActiveEmbeddedRun: (
       ...args: Parameters<typeof actual.clearActiveEmbeddedRun>
     ): ReturnType<typeof actual.clearActiveEmbeddedRun> => {
-      activeRunRegistrationMocks.clearActiveEmbeddedRun(...args);
+      cleanupWindowMocks.activeRunRegistration.clearActiveEmbeddedRun(...args);
       return actual.clearActiveEmbeddedRun(...args);
     },
     setActiveEmbeddedRun: (
       ...args: Parameters<typeof actual.setActiveEmbeddedRun>
     ): ReturnType<typeof actual.setActiveEmbeddedRun> => {
-      activeRunRegistrationMocks.setActiveEmbeddedRun(...args);
+      cleanupWindowMocks.activeRunRegistration.setActiveEmbeddedRun(...args);
       return actual.setActiveEmbeddedRun(...args);
     },
   };
@@ -38,15 +42,41 @@ vi.mock("openclaw/plugin-sdk/agent-harness-runtime", async (importOriginal) => {
 
 vi.mock("./transcript-mirror.js", () => ({
   createCodexAppServerUserMessagePersistenceNotifier: vi.fn(() => {
-    throw new Error("boom after turn acceptance");
+    if (cleanupWindowMocks.throwOnNotifierConstruction) {
+      throw new Error("boom after turn acceptance");
+    }
+    return vi.fn();
   }),
   mirrorPromptAtTurnStartBestEffort: vi.fn(),
 }));
 
+vi.mock("./attempt-steering.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./attempt-steering.js")>();
+  return {
+    ...actual,
+    createCodexSteeringQueue: vi.fn(
+      (...args: Parameters<typeof actual.createCodexSteeringQueue>) => {
+        if (cleanupWindowMocks.throwOnSteeringQueueCreation) {
+          throw new Error("boom before active run registration");
+        }
+        return actual.createCodexSteeringQueue(...args);
+      },
+    ),
+  };
+});
+
 setupRunAttemptTestHooks();
+
+afterEach(() => {
+  cleanupWindowMocks.throwOnSteeringQueueCreation = false;
+  cleanupWindowMocks.throwOnNotifierConstruction = false;
+  cleanupWindowMocks.activeRunRegistration.clearActiveEmbeddedRun.mockClear();
+  cleanupWindowMocks.activeRunRegistration.setActiveEmbeddedRun.mockClear();
+});
 
 describe("Codex app-server cleanup window", () => {
   it("cleans up the active run if notifier construction throws after registration", async () => {
+    cleanupWindowMocks.throwOnNotifierConstruction = true;
     let notificationCleanupCalled = 0;
     let requestCleanupCalled = 0;
     const request = vi.fn(async (method: string) => {
@@ -83,18 +113,62 @@ describe("Codex app-server cleanup window", () => {
 
     await expect(runCodexAppServerAttempt(params)).rejects.toThrow("boom after turn acceptance");
 
-    expect(activeRunRegistrationMocks.setActiveEmbeddedRun).toHaveBeenCalledWith(
+    expect(cleanupWindowMocks.activeRunRegistration.setActiveEmbeddedRun).toHaveBeenCalledWith(
       params.sessionId,
       expect.anything(),
       params.sessionKey,
       params.sessionFile,
     );
-    expect(activeRunRegistrationMocks.clearActiveEmbeddedRun).toHaveBeenCalledWith(
+    expect(cleanupWindowMocks.activeRunRegistration.clearActiveEmbeddedRun).toHaveBeenCalledWith(
       params.sessionId,
       expect.anything(),
       params.sessionKey,
       params.sessionFile,
     );
+    expect(notificationCleanupCalled).toBe(1);
+    expect(requestCleanupCalled).toBe(1);
+  }, 20_000);
+
+  it("cleans up shared handlers if steering queue setup throws before active run registration", async () => {
+    cleanupWindowMocks.throwOnSteeringQueueCreation = true;
+    let notificationCleanupCalled = 0;
+    let requestCleanupCalled = 0;
+    const request = vi.fn(async (method: string) => {
+      if (method === "thread/start") {
+        return threadStartResult("thread-1");
+      }
+      if (method === "turn/start") {
+        return turnStartResult("turn-1", "inProgress");
+      }
+      return {};
+    });
+
+    setCodexAppServerClientFactoryForTest(
+      async () =>
+        ({
+          ...mockClientRuntimeMethods(),
+          request,
+          addNotificationHandler: () => () => {
+            notificationCleanupCalled += 1;
+          },
+          addRequestHandler: () => () => {
+            requestCleanupCalled += 1;
+          },
+        }) as never,
+    );
+
+    const params = createParams(
+      path.join(tempDir, "cleanup-window-phase-session.jsonl"),
+      path.join(tempDir, "cleanup-window-phase-workspace"),
+    );
+    params.sessionId = "cleanup-window-phase-session";
+    params.sessionKey = "agent:main:cleanup-window-phase-session";
+    params.runId = "run-cleanup-window-phase-session";
+
+    await expect(runCodexAppServerAttempt(params)).rejects.toThrow("boom before active run");
+
+    expect(cleanupWindowMocks.activeRunRegistration.setActiveEmbeddedRun).not.toHaveBeenCalled();
+    expect(cleanupWindowMocks.activeRunRegistration.clearActiveEmbeddedRun).not.toHaveBeenCalled();
     expect(notificationCleanupCalled).toBe(1);
     expect(requestCleanupCalled).toBe(1);
   }, 20_000);

--- a/extensions/codex/src/app-server/run-attempt.ts
+++ b/extensions/codex/src/app-server/run-attempt.ts
@@ -2849,6 +2849,80 @@ export async function runCodexAppServerAttempt(
     turnWatches.clearAllTimers();
     resolveCompletion?.();
   });
+  let abortListener: (() => void) | undefined;
+  let turnAttemptCleanupFinished = false;
+  const cleanupTurnAttempt = async () => {
+    if (turnAttemptCleanupFinished) {
+      return;
+    }
+    turnAttemptCleanupFinished = true;
+    if (params.isFinalFallbackAttempt !== false) {
+      await maybeEmitFastModeAutoResetBestEffort();
+    }
+    codexModelCallDiagnostics.emitError(
+      "codex app-server run completed without model-call terminal event",
+    );
+    emitLifecycleTerminal({
+      phase: "error",
+      error: "codex app-server run completed without lifecycle terminal event",
+    });
+    if (trajectoryRecorder && !trajectoryEndRecorded) {
+      trajectoryRecorder.recordEvent("session.ended", {
+        status:
+          timedOut || (runAbortController.signal.aborted && !clientClosedAbort)
+            ? "interrupted"
+            : "cleanup",
+        threadId: thread.threadId,
+        turnId: activeTurnId,
+        timedOut,
+        aborted: runAbortController.signal.aborted && !clientClosedAbort,
+      });
+    }
+    await runAgentCleanupStep({
+      runId: params.runId,
+      sessionId: params.sessionId,
+      step: "codex-trajectory-flush",
+      log: embeddedAgentLog,
+      cleanup: async () => {
+        await trajectoryRecorder?.flush();
+      },
+    });
+    if (!timedOut && !runAbortController.signal.aborted) {
+      await steeringQueueRef.current?.flushPending();
+    }
+    if (!timedOut) {
+      await unsubscribeCodexThreadBestEffort(client, {
+        threadId: thread.threadId,
+        timeoutMs: CODEX_APP_SERVER_UNSUBSCRIBE_TIMEOUT_MS,
+      });
+    }
+    userInputBridgeRef.current?.cancelPending();
+    turnWatches.clearAllTimers();
+    notificationCleanup();
+    requestCleanup();
+    closeCleanup?.();
+    await releaseSharedClientLeaseAndRetireOneShotClient();
+    if (nativeHookRelay) {
+      if (shouldDelayNativeHookRelayUnregister) {
+        // Codex hook subprocesses can outlive a completed app-server turn by a
+        // few seconds. Keep the relay available briefly so late
+        // nativeHook.invoke RPCs can still reach before_tool_call enforcement.
+        scheduleCodexNativeHookRelayUnregister({
+          relay: nativeHookRelay,
+          hookTimeoutSec: options.nativeHookRelay?.hookTimeoutSec,
+        });
+      } else {
+        nativeHookRelay.unregister();
+      }
+    }
+    await releaseSandboxExecEnvironment();
+    if (abortListener) {
+      runAbortController.signal.removeEventListener("abort", abortListener);
+    }
+    params.abortSignal?.removeEventListener("abort", abortFromUpstream);
+    steeringQueueRef.current?.cancel();
+    clearActiveEmbeddedRun(params.sessionId, handle, params.sessionKey, params.sessionFile);
+  };
   emitLifecycleStart();
   const activeProjector = projectorRef.current;
   if (!activeProjector) {
@@ -2892,46 +2966,46 @@ export async function runCodexAppServerAttempt(
     cancel: () => runAbortController.abort("cancelled"),
     abort: () => runAbortController.abort("aborted"),
   };
-  setActiveEmbeddedRun(params.sessionId, handle, params.sessionKey, params.sessionFile);
-  const notifyUserMessagePersisted = createCodexAppServerUserMessagePersistenceNotifier(params);
-  void mirrorPromptAtTurnStartBestEffort({
-    params,
-    agentId: sessionAgentId,
-    notifyUserMessagePersisted,
-    sessionKey: sandboxSessionKey,
-    cwd: effectiveCwd,
-    threadId: thread.threadId,
-    turnId: activeTurnId,
-  });
-
-  const abortListener = () => {
-    const shouldRetireClient = timedOut;
-    if (shouldRetireClient) {
-      void (async () => {
-        // Timed-out native turns cannot be safely resumed on the same thread.
-        await clearCodexAppServerBindingForThread(activeSessionFile, thread.threadId);
-        await retireCodexAppServerClientAfterTimedOutTurn(client, {
-          threadId: thread.threadId,
-          turnId: activeTurnId,
-          reason: String(runAbortController.signal.reason ?? "timeout"),
-        });
-      })().finally(() => {
-        resolveCompletion?.();
-      });
-      return;
-    }
-    interruptCodexTurnBestEffort(client, {
+  try {
+    setActiveEmbeddedRun(params.sessionId, handle, params.sessionKey, params.sessionFile);
+    const notifyUserMessagePersisted = createCodexAppServerUserMessagePersistenceNotifier(params);
+    void mirrorPromptAtTurnStartBestEffort({
+      params,
+      agentId: sessionAgentId,
+      notifyUserMessagePersisted,
+      sessionKey: sandboxSessionKey,
+      cwd: effectiveCwd,
       threadId: thread.threadId,
       turnId: activeTurnId,
     });
-    resolveCompletion?.();
-  };
-  runAbortController.signal.addEventListener("abort", abortListener, { once: true });
-  if (runAbortController.signal.aborted) {
-    abortListener();
-  }
 
-  try {
+    abortListener = () => {
+      const shouldRetireClient = timedOut;
+      if (shouldRetireClient) {
+        void (async () => {
+          // Timed-out native turns cannot be safely resumed on the same thread.
+          await clearCodexAppServerBindingForThread(activeSessionFile, thread.threadId);
+          await retireCodexAppServerClientAfterTimedOutTurn(client, {
+            threadId: thread.threadId,
+            turnId: activeTurnId,
+            reason: String(runAbortController.signal.reason ?? "timeout"),
+          });
+        })().finally(() => {
+          resolveCompletion?.();
+        });
+        return;
+      }
+      interruptCodexTurnBestEffort(client, {
+        threadId: thread.threadId,
+        turnId: activeTurnId,
+      });
+      resolveCompletion?.();
+    };
+    runAbortController.signal.addEventListener("abort", abortListener, { once: true });
+    if (runAbortController.signal.aborted) {
+      abortListener();
+    }
+
     await completion;
     // Timeout completion can win while a received notification is still being
     // projected, for example while persisting raw image-generation media. Wait
@@ -3219,70 +3293,7 @@ export async function runCodexAppServerAttempt(
       systemPromptReport,
     };
   } finally {
-    if (params.isFinalFallbackAttempt !== false) {
-      await maybeEmitFastModeAutoResetBestEffort();
-    }
-    codexModelCallDiagnostics.emitError(
-      "codex app-server run completed without model-call terminal event",
-    );
-    emitLifecycleTerminal({
-      phase: "error",
-      error: "codex app-server run completed without lifecycle terminal event",
-    });
-    if (trajectoryRecorder && !trajectoryEndRecorded) {
-      trajectoryRecorder.recordEvent("session.ended", {
-        status:
-          timedOut || (runAbortController.signal.aborted && !clientClosedAbort)
-            ? "interrupted"
-            : "cleanup",
-        threadId: thread.threadId,
-        turnId: activeTurnId,
-        timedOut,
-        aborted: runAbortController.signal.aborted && !clientClosedAbort,
-      });
-    }
-    await runAgentCleanupStep({
-      runId: params.runId,
-      sessionId: params.sessionId,
-      step: "codex-trajectory-flush",
-      log: embeddedAgentLog,
-      cleanup: async () => {
-        await trajectoryRecorder?.flush();
-      },
-    });
-    if (!timedOut && !runAbortController.signal.aborted) {
-      await steeringQueueRef.current?.flushPending();
-    }
-    if (!timedOut) {
-      await unsubscribeCodexThreadBestEffort(client, {
-        threadId: thread.threadId,
-        timeoutMs: CODEX_APP_SERVER_UNSUBSCRIBE_TIMEOUT_MS,
-      });
-    }
-    userInputBridgeRef.current?.cancelPending();
-    turnWatches.clearAllTimers();
-    notificationCleanup();
-    requestCleanup();
-    closeCleanup?.();
-    await releaseSharedClientLeaseAndRetireOneShotClient();
-    if (nativeHookRelay) {
-      if (shouldDelayNativeHookRelayUnregister) {
-        // Codex hook subprocesses can outlive a completed app-server turn by a
-        // few seconds. Keep the relay available briefly so late
-        // nativeHook.invoke RPCs can still reach before_tool_call enforcement.
-        scheduleCodexNativeHookRelayUnregister({
-          relay: nativeHookRelay,
-          hookTimeoutSec: options.nativeHookRelay?.hookTimeoutSec,
-        });
-      } else {
-        nativeHookRelay.unregister();
-      }
-    }
-    await releaseSandboxExecEnvironment();
-    runAbortController.signal.removeEventListener("abort", abortListener);
-    params.abortSignal?.removeEventListener("abort", abortFromUpstream);
-    steeringQueueRef.current?.cancel();
-    clearActiveEmbeddedRun(params.sessionId, handle, params.sessionKey, params.sessionFile);
+    await cleanupTurnAttempt();
   }
 }
 

--- a/extensions/codex/src/app-server/run-attempt.ts
+++ b/extensions/codex/src/app-server/run-attempt.ts
@@ -2850,6 +2850,8 @@ export async function runCodexAppServerAttempt(
     resolveCompletion?.();
   });
   let abortListener: (() => void) | undefined;
+  let activeSteeringQueue: ReturnType<typeof createCodexSteeringQueue> | undefined;
+  let handle: Parameters<typeof setActiveEmbeddedRun>[1] | undefined;
   let turnAttemptCleanupFinished = false;
   const cleanupTurnAttempt = async () => {
     if (turnAttemptCleanupFinished) {
@@ -2920,53 +2922,55 @@ export async function runCodexAppServerAttempt(
       runAbortController.signal.removeEventListener("abort", abortListener);
     }
     params.abortSignal?.removeEventListener("abort", abortFromUpstream);
-    steeringQueueRef.current?.cancel();
-    clearActiveEmbeddedRun(params.sessionId, handle, params.sessionKey, params.sessionFile);
-  };
-  emitLifecycleStart();
-  const activeProjector = projectorRef.current;
-  if (!activeProjector) {
-    throw new Error("codex app-server projector was not initialized");
-  }
-  turnWatches.armTerminalIdleWatch();
-  turnWatches.touchActivity("turn:start", { arm: true });
-  turnWatches.armAttemptIdleWatch();
-  turnWatches.touchActivity("turn:start", { attemptProgress: true });
-  for (const notification of pendingNotifications.splice(0)) {
-    await enqueueNotification(notification);
-  }
-  if (!completed && isTerminalTurnStatus(turn.turn.status)) {
-    await enqueueNotification({
-      method: "turn/completed",
-      params: {
-        threadId: thread.threadId,
-        turnId: activeTurnId,
-        turn: turn.turn as unknown as JsonObject,
-      },
-    });
-  }
-
-  const activeSteeringQueue = createCodexSteeringQueue({
-    client,
-    threadId: thread.threadId,
-    turnId: activeTurnId,
-    answerPendingUserInput: (text) =>
-      userInputBridgeRef.current?.handleQueuedMessage(text) ?? false,
-    signal: runAbortController.signal,
-  });
-  steeringQueueRef.current = activeSteeringQueue;
-  const handle = {
-    kind: "embedded" as const,
-    queueMessage: async (text: string, optionsLocal?: CodexSteeringQueueOptions) =>
-      activeSteeringQueue.queue(text, optionsLocal),
-    isStreaming: () => !completed && !runAbortController.signal.aborted,
-    isStopped: () => completed || timedOut || runAbortController.signal.aborted,
-    isCompacting: () => projectorRef.current?.isCompacting() ?? false,
-    sourceReplyDeliveryMode: params.sourceReplyDeliveryMode,
-    cancel: () => runAbortController.abort("cancelled"),
-    abort: () => runAbortController.abort("aborted"),
+    activeSteeringQueue?.cancel();
+    if (handle) {
+      clearActiveEmbeddedRun(params.sessionId, handle, params.sessionKey, params.sessionFile);
+    }
   };
   try {
+    emitLifecycleStart();
+    const activeProjector = projectorRef.current;
+    if (!activeProjector) {
+      throw new Error("codex app-server projector was not initialized");
+    }
+    turnWatches.armTerminalIdleWatch();
+    turnWatches.touchActivity("turn:start", { arm: true });
+    turnWatches.armAttemptIdleWatch();
+    turnWatches.touchActivity("turn:start", { attemptProgress: true });
+    for (const notification of pendingNotifications.splice(0)) {
+      await enqueueNotification(notification);
+    }
+    if (!completed && isTerminalTurnStatus(turn.turn.status)) {
+      await enqueueNotification({
+        method: "turn/completed",
+        params: {
+          threadId: thread.threadId,
+          turnId: activeTurnId,
+          turn: turn.turn as unknown as JsonObject,
+        },
+      });
+    }
+
+    activeSteeringQueue = createCodexSteeringQueue({
+      client,
+      threadId: thread.threadId,
+      turnId: activeTurnId,
+      answerPendingUserInput: (text) =>
+        userInputBridgeRef.current?.handleQueuedMessage(text) ?? false,
+      signal: runAbortController.signal,
+    });
+    steeringQueueRef.current = activeSteeringQueue;
+    handle = {
+      kind: "embedded" as const,
+      queueMessage: async (text: string, optionsLocal?: CodexSteeringQueueOptions) =>
+        activeSteeringQueue.queue(text, optionsLocal),
+      isStreaming: () => !completed && !runAbortController.signal.aborted,
+      isStopped: () => completed || timedOut || runAbortController.signal.aborted,
+      isCompacting: () => projectorRef.current?.isCompacting() ?? false,
+      sourceReplyDeliveryMode: params.sourceReplyDeliveryMode,
+      cancel: () => runAbortController.abort("cancelled"),
+      abort: () => runAbortController.abort("aborted"),
+    };
     setActiveEmbeddedRun(params.sessionId, handle, params.sessionKey, params.sessionFile);
     const notifyUserMessagePersisted = createCodexAppServerUserMessagePersistenceNotifier(params);
     void mirrorPromptAtTurnStartBestEffort({

--- a/extensions/codex/src/app-server/run-attempt.ts
+++ b/extensions/codex/src/app-server/run-attempt.ts
@@ -2951,7 +2951,7 @@ export async function runCodexAppServerAttempt(
       });
     }
 
-    activeSteeringQueue = createCodexSteeringQueue({
+    const createdSteeringQueue = createCodexSteeringQueue({
       client,
       threadId: thread.threadId,
       turnId: activeTurnId,
@@ -2959,11 +2959,12 @@ export async function runCodexAppServerAttempt(
         userInputBridgeRef.current?.handleQueuedMessage(text) ?? false,
       signal: runAbortController.signal,
     });
-    steeringQueueRef.current = activeSteeringQueue;
+    activeSteeringQueue = createdSteeringQueue;
+    steeringQueueRef.current = createdSteeringQueue;
     handle = {
       kind: "embedded" as const,
       queueMessage: async (text: string, optionsLocal?: CodexSteeringQueueOptions) =>
-        activeSteeringQueue.queue(text, optionsLocal),
+        createdSteeringQueue.queue(text, optionsLocal),
       isStreaming: () => !completed && !runAbortController.signal.aborted,
       isStopped: () => completed || timedOut || runAbortController.signal.aborted,
       isCompacting: () => projectorRef.current?.isCompacting() ?? false,

--- a/test/vitest/vitest.extension-codex-app-server-attempt-extra.config.ts
+++ b/test/vitest/vitest.extension-codex-app-server-attempt-extra.config.ts
@@ -7,6 +7,7 @@ export function createExtensionCodexAppServerAttemptExtraVitestConfig(
   return createScopedVitestConfig(
     [
       "extensions/codex/src/app-server/run-attempt-thread-cleanup.test.ts",
+      "extensions/codex/src/app-server/run-attempt.cleanup-window.test.ts",
       "extensions/codex/src/app-server/run-attempt.context-engine.test.ts",
       "extensions/codex/src/app-server/run-attempt.dynamic-tools.test.ts",
       "extensions/codex/src/app-server/run-attempt.hooks.test.ts",


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where a Codex app-server turn could start successfully and then leak the active run registration if post-start setup threw synchronously. In that failure window, the shared-client cleanup handlers were skipped and the run stayed registered until process cleanup.

Closes #99271

## Why This Change Was Made

The post-start setup now lives inside the same guarded teardown path as the rest of the attempt so any synchronous exception after `turn/start` still unwinds through the shared cleanup logic. This keeps cleanup behavior single-path and avoids leaving a phantom active run behind.

## User Impact

Codex turns that fail immediately after start now clean up correctly instead of leaving the session stuck or the shared client handlers orphaned. Normal successful turns and the existing cleanup path are unchanged.

## Evidence

- `node scripts/run-vitest.mjs extensions/codex/src/app-server/run-attempt.cleanup-window.test.ts extensions/codex/src/app-server/run-attempt-thread-cleanup.test.ts test/scripts/test-projects.test.ts`
- `pnpm build`
- `OPENCLAW_LIVE_CODEX_HARNESS=1 OPENCLAW_LIVE_CODEX_HARNESS_MODEL=openai/gpt-5.5 pnpm test:live -- src/gateway/gateway-codex-harness.live.test.ts`

## Real Behavior Proof

- Local cleanup-window regression: `node scripts/run-vitest.mjs extensions/codex/src/app-server/run-attempt.cleanup-window.test.ts extensions/codex/src/app-server/run-attempt-thread-cleanup.test.ts`
  - terminal output: `Test Files  2 passed (2)`
  - terminal output: `Tests  4 passed (4)`
- Routing coverage: `test/scripts/test-projects.test.ts`
  - terminal output: `Test Files  1 passed (1)`
  - terminal output: `Tests  184 passed (184)`
- Build proof: `pnpm build`
  - terminal output: `CLI bootstrap import guard passed.`
  - terminal output: `✓ built in 666ms`
- Live gateway proof: `OPENCLAW_LIVE_CODEX_HARNESS=1 OPENCLAW_LIVE_CODEX_HARNESS_MODEL=openai/gpt-5.5 pnpm test:live -- src/gateway/gateway-codex-harness.live.test.ts`
  - terminal output: `Test Files  1 passed (1)`
  - terminal output: `Tests  1 passed | 1 skipped (2)`
  - terminal output: the live harness ran the real gateway session path and spawned real agent runs
- Behavior addressed: synchronous throw from `createCodexAppServerUserMessagePersistenceNotifier` after `setActiveEmbeddedRun` and synchronous throw from `createCodexSteeringQueue` before `setActiveEmbeddedRun`.

## AI Disclosure

This patch was prepared with AI assistance and reviewed with focused automated tests and commit review.
