### PR TITLE
fix: keep heredoc bodies out of exec summaries

### DIFF
--- a/src/agents/tool-display-exec-shell.ts
+++ b/src/agents/tool-display-exec-shell.ts
@@ -237,7 +237,7 @@ export function unwrapShellWrapper(command: string): string {
   return inner ? (stripOuterQuotes(inner) ?? command) : command;
 }
 
-function scanTopLevelChars(
+export function scanTopLevelChars(
   command: string,
   visit: (char: string, index: number) => boolean | void,
 ): void {

--- a/src/agents/tool-display-exec.ts
+++ b/src/agents/tool-display-exec.ts
@@ -11,6 +11,7 @@ import {
   firstPositional,
   optionValue,
   positionalArgs,
+  scanTopLevelChars,
   splitShellWords,
   splitTopLevelPipes,
   splitTopLevelStages,
@@ -298,6 +299,115 @@ function summarizePipeline(stage: string): string {
   return summarizeKnownExec(trimLeadingEnv(splitShellWords(stage)));
 }
 
+type HeredocTerminator = {
+  value: string;
+  stripLeadingTabs: boolean;
+};
+
+function collectHeredocTerminators(commandLine: string): HeredocTerminator[] {
+  const terminators: HeredocTerminator[] = [];
+  scanTopLevelChars(commandLine, (char, index) => {
+    if (char !== "<" || commandLine[index + 1] !== "<" || commandLine[index + 2] === "<") {
+      return true;
+    }
+
+    const stripLeadingTabs = commandLine[index + 2] === "-";
+    const parsed = parseHeredocTerminator(commandLine, index + (stripLeadingTabs ? 3 : 2));
+    if (parsed) {
+      terminators.push({ value: parsed, stripLeadingTabs });
+    }
+    return true;
+  });
+  return terminators;
+}
+
+function parseHeredocTerminator(commandLine: string, rawStart: number): string | undefined {
+  let start = rawStart;
+  while (/\s/u.test(commandLine[start] ?? "")) {
+    start += 1;
+  }
+
+  let value = "";
+  let quote: '"' | "'" | undefined;
+
+  for (let index = start; index < commandLine.length; index += 1) {
+    const char = commandLine[index] ?? "";
+
+    if (quote) {
+      if (char === quote) {
+        quote = undefined;
+        continue;
+      }
+      if (quote === '"' && char === "\\" && index + 1 < commandLine.length) {
+        index += 1;
+        value += commandLine[index] ?? "";
+        continue;
+      }
+      value += char;
+      continue;
+    }
+
+    if (/[\s;&|<>]/u.test(char)) {
+      break;
+    }
+    if (char === "'" || char === '"') {
+      quote = char;
+      continue;
+    }
+    if (char === "\\" && index + 1 < commandLine.length) {
+      index += 1;
+      value += commandLine[index] ?? "";
+      continue;
+    }
+    value += char;
+  }
+
+  return value || undefined;
+}
+
+function commandWithoutHeredocBodies(command: string): string | undefined {
+  if (!command.includes("\n")) {
+    return undefined;
+  }
+
+  const lines = command.split(/\r?\n/u);
+  const summaryLines: string[] = [];
+  let foundHeredoc = false;
+
+  for (let index = 0; index < lines.length; index += 1) {
+    const line = lines[index] ?? "";
+    summaryLines.push(line);
+
+    const terminators = collectHeredocTerminators(line);
+    if (terminators.length === 0) {
+      continue;
+    }
+    foundHeredoc = true;
+
+    for (const terminator of terminators) {
+      index += 1;
+      while (index < lines.length) {
+        const candidate = terminator.stripLeadingTabs
+          ? (lines[index] ?? "").replace(/^\t+/u, "")
+          : (lines[index] ?? "");
+        if (candidate === terminator.value) {
+          break;
+        }
+        index += 1;
+      }
+    }
+  }
+
+  if (!foundHeredoc) {
+    return undefined;
+  }
+
+  return summaryLines
+    .map((line) => line.trim())
+    .filter(Boolean)
+    .join("; ");
+}
+
 type ExecSummary = {
   text: string;
   chdirPath?: string;
@@ -361,7 +471,8 @@ function summarizeExecCommand(command: string): ExecSummary | undefined {
     return chdirPath ? { text: "", chdirPath } : undefined;
   }
 
-  const stages = splitTopLevelStages(cleaned);
+  const summaryCommand = commandWithoutHeredocBodies(cleaned) ?? cleaned;
+  const stages = splitTopLevelStages(summaryCommand);
   if (stages.length === 0) {
     return undefined;
   }

--- a/src/agents/tool-display.test.ts
+++ b/src/agents/tool-display.test.ts
@@ -464,6 +464,61 @@ describe("tool display details", () => {
     expect(nodeShortCheckDetail).toContain("check js syntax for /tmp/test.js");
   });
 
+  it("does not split heredoc body content into exec stages", () => {
+    const detail = formatToolDetail(
+      resolveToolDisplay({
+        name: "exec",
+        args: {
+          command: [
+            "python3 <<'PY'",
+            "const slugify = () => 'court-mix';",
+            "if (true) console.log('a') && console.log('b');",
+            "cat <<YAML",
+            "- uses: subosito/flutter-action@v2",
+            "YAML",
+            "PY",
+          ].join("\n"),
+          workdir: "/Users/example/.openclaw/workspace",
+        },
+        detailMode: "explain",
+      }),
+    );
+
+    expect(detail).toBe("run python3 inline script (heredoc) (agent)");
+  });
+
+  it("keeps command stages after a heredoc terminator", () => {
+    const detail = formatToolDetail(
+      resolveToolDisplay({
+        name: "exec",
+        args: {
+          command: ["python3 <<'PY'", "print('body && not a command')", "PY", "npm test"].join(
+            "\n",
+          ),
+        },
+        detailMode: "explain",
+      }),
+    );
+
+    expect(detail).toBe("run python3 inline script (heredoc) → run tests");
+  });
+
+  it("matches shell-quoted heredoc terminators before keeping later stages", () => {
+    const detail = formatToolDetail(
+      resolveToolDisplay({
+        name: "exec",
+        args: {
+          command: ["python3 <<\\PY", "print('body && not a command')", "PY", "npm test"].join(
+            "\n",
+          ),
+        },
+        detailMode: "explain",
+      }),
+    );
+
+    expect(detail).toBe("run python3 inline script (heredoc) → run tests");
+  });
+
   it("appends node name to exec detail when node is set", () => {
     const detail = formatToolDetail(
       resolveToolDisplay({


### PR DESCRIPTION
Closes #99367

## What Problem This Solves

Fixes an issue where users watching exec/tool progress would see heredoc body contents reported as extra command stages when the heredoc text contained shell-like separators or generated YAML/JavaScript. A single inline script could be displayed as a chain such as `run python3 inline script (heredoc) -> run if -> run console.log(b) -> show <<YAML`, which made generated file contents look like commands that actually ran.

## Why This Change Was Made

The exec display summarizer now removes heredoc bodies before top-level stage splitting while keeping the heredoc launcher and any real command stages that appear after the heredoc terminator. The parser reuses the existing top-level shell scanner and applies shell quote removal to heredoc delimiter words so quoted and backslash-quoted delimiters do not hide later commands.

## User Impact

Operators get quieter and more accurate tool-progress summaries for inline scripts and file-generation commands. Heredoc body text no longer appears as executed shell stages, while real commands after the heredoc terminator remain visible.

## Evidence

Before the fix, the current display path summarized heredoc body fragments as commands:

```text
run python3 inline script (heredoc) -> run if -> run console.log(b) -> show <<YAML (agent)
```

After the fix, the same display path omits body-only fragments and still preserves a real post-heredoc command:

```text
run python3 inline script (heredoc) -> run tests (agent)
```

Real exec-summary path proof from a local terminal, using the same `resolveToolDisplay` + `formatToolDetail` path that channel progress uses through `src/channels/streaming.ts`:

```sh
node --import tsx --input-type=module <<'EOF'
import { formatToolDetail, resolveToolDisplay } from "./src/agents/tool-display.ts";

const command = [
  "python3 <<'PY'",
  "const slugify = () => 'court-mix';",
  "if (true) console.log('a') && console.log('b');",
  "cat <<YAML",
  "- uses: subosito/flutter-action@v2",
  "YAML",
  "PY",
  "npm test",
].join("\n");

console.log(
  formatToolDetail(
    resolveToolDisplay({
      name: "exec",
      args: { command, workdir: "repo" },
      detailMode: "explain",
    }),
  ),
);
EOF
```

Output:

```text
run python3 inline script (heredoc) → run tests (in repo)
```

The heredoc body intentionally includes `&&`, a nested `cat <<YAML`, and generated YAML-like content. Those body fragments no longer appear as command stages, while the real `npm test` after the `PY` terminator remains visible.

Actual channel progress draft proof, using the exported progress-line path from `src/channels/streaming.ts`:

```sh
node --import tsx --input-type=module <<'EOF'
import { formatChannelProgressDraftLineForEntry } from "./src/channels/streaming.ts";

const command = [
  "python3 <<'PY'",
  "const slugify = () => 'court-mix';",
  "if (true) console.log('a') && console.log('b');",
  "cat <<YAML",
  "- uses: subosito/flutter-action@v2",
  "YAML",
  "PY",
  "npm test",
].join("\n");

const entry = { streaming: { mode: "progress", progress: { commandText: "summary" } } };
const line = formatChannelProgressDraftLineForEntry(entry, {
  event: "tool",
  name: "exec",
  args: { command, workdir: "repo" },
  phase: "start",
});
console.log(line);
EOF
```

Output:

```text
🛠️ run python3 inline script (heredoc) → run tests (in repo)
```

Focused validation:

```text
node scripts/run-vitest.mjs src/agents/tool-display.test.ts
[test] passed 1 Vitest shard

node scripts/run-vitest.mjs src/agents/embedded-agent-runner/run/payloads.errors.test.ts
[test] passed 1 Vitest shard

node scripts/run-tsgo.mjs -p tsconfig.core.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/core.tsbuildinfo
passed

node scripts/run-tsgo.mjs -p test/tsconfig/tsconfig.core.test.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/core-test.tsbuildinfo
passed

node_modules/.bin/oxfmt --check --threads=1 src/agents/tool-display-exec.ts src/agents/tool-display-exec-shell.ts src/agents/tool-display.test.ts
All matched files use the correct format.

node_modules/.bin/oxlint src/agents/tool-display-exec.ts src/agents/tool-display-exec-shell.ts src/agents/tool-display.test.ts
passed

node scripts/build-all.mjs
passed
```

Live/local behavior proof:

```text
node scripts/run-node.mjs agent --local --agent main --session-key agent:main:proof-99367 --model deepseek/deepseek-v4-pro --message "Reply exactly: OPENCLAW_DEEPSEEK_OK" --json --timeout 120
provider=deepseek model=deepseek-v4-pro stopReason=stop finalAssistantVisibleText=OPENCLAW_DEEPSEEK_OK
```

Dependency/source contract checked:

```text
../codex/codex-rs/app-server-protocol/src/protocol/v2/item.rs
../codex/codex-rs/app-server/src/bespoke_event_handling.rs
extensions/codex/src/app-server/event-projector.ts
```

Codex app-server exposes raw `command`, `cwd`, and `status` for command execution items, and OpenClaw maps Codex `declined` command status separately from this display summary path, so this PR keeps the fix in OpenClaw exec display formatting.

Local autoreview:

```text
.agents/skills/autoreview/scripts/autoreview --mode local
autoreview clean: no accepted/actionable findings reported
```

AI-assisted: implementation and validation were prepared with AI assistance; proof was run locally.
