### PR TITLE
feat: add model auth profile removal command

### DIFF
--- a/docs/cli/models.md
+++ b/docs/cli/models.md
@@ -168,6 +168,8 @@ openclaw models fallbacks list
 ```bash
 openclaw models auth add
 openclaw models auth list [--provider <id>] [--json]
+openclaw models auth remove <profileId> [--yes]
+openclaw models auth remove --provider <id> --all [--yes]
 openclaw models auth login --provider <id>
 openclaw models auth login --provider openai --profile-id openai:work
 openclaw models auth paste-api-key --provider <id>
@@ -183,11 +185,17 @@ provider you choose.
 printing token, API-key, or OAuth secret material. Use `--provider <id>` to
 filter to one provider, such as `openai`, and `--json` for scripting.
 
+`models auth remove <profileId>` removes one saved profile from the selected
+agent store and prunes matching order, last-good, and usage state. Use
+`--dry-run` to preview the target without writing. To remove every saved profile
+for a provider, pass both `--provider <id>` and `--all`; `--provider` alone only
+lists the matching candidates in the error message.
+
 `models auth login` runs a provider plugin's auth flow (OAuth/API key). Use
 `openclaw plugins list` to see which providers are installed.
 Use `openclaw models auth --agent <id> <subcommand>` to write auth results to a
 specific configured agent store. The parent `--agent` flag is honored by
-`add`, `list`, `login`, `paste-api-key`, `setup-token`, `paste-token`, and
+`add`, `list`, `remove`, `login`, `paste-api-key`, `setup-token`, `paste-token`, and
 `login-github-copilot`.
 
 For OpenAI models, `--provider openai` defaults to ChatGPT/Codex account login.
@@ -202,6 +210,7 @@ openclaw models auth login --provider openai --set-default
 openclaw models auth login --provider openai --method api-key
 openclaw models auth paste-api-key --provider openai
 openclaw models auth list --provider openai
+openclaw models auth remove openai:user@example.com --yes
 ```
 
 Notes:

--- a/docs/cli/models.md
+++ b/docs/cli/models.md
@@ -189,7 +189,9 @@ filter to one provider, such as `openai`, and `--json` for scripting.
 agent store and prunes matching order, last-good, and usage state. Use
 `--dry-run` to preview the target without writing. To remove every saved profile
 for a provider, pass both `--provider <id>` and `--all`; `--provider` alone only
-lists the matching candidates in the error message.
+lists the matching candidates in the error message. Profiles inherited from the
+default agent remain owned by that default agent store; remove them with
+`--agent <default-agent-id>` instead of from the inheriting agent.
 
 `models auth login` runs a provider plugin's auth flow (OAuth/API key). Use
 `openclaw plugins list` to see which providers are installed.

--- a/docs/gateway/authentication.md
+++ b/docs/gateway/authentication.md
@@ -194,7 +194,9 @@ key in the provider dashboard when you need provider-side invalidation.
 To remove saved profiles from the CLI, use `openclaw models auth remove
 <profileId> --yes` for one profile, or `openclaw models auth remove --provider
 <id> --all --yes` for every saved profile for a provider. Use `--dry-run` first
-to preview the affected profiles without writing.
+to preview the affected profiles without writing. When an agent only inherits a
+profile from the default agent store, remove that profile from the default agent
+instead of from the inheriting agent.
 
 ## Controlling which credential is used
 

--- a/docs/gateway/authentication.md
+++ b/docs/gateway/authentication.md
@@ -191,6 +191,11 @@ stopped because credentials were removed.
 Removing saved auth does not revoke keys at the provider. Rotate or revoke the
 key in the provider dashboard when you need provider-side invalidation.
 
+To remove saved profiles from the CLI, use `openclaw models auth remove
+<profileId> --yes` for one profile, or `openclaw models auth remove --provider
+<id> --all --yes` for every saved profile for a provider. Use `--dry-run` first
+to preview the affected profiles without writing.
+
 ## Controlling which credential is used
 
 ### OpenAI and legacy `openai-codex` ids

--- a/src/agents/auth-profiles.ts
+++ b/src/agents/auth-profiles.ts
@@ -37,6 +37,7 @@ export {
   dedupeProfileIds,
   listProfilesForProvider,
   markAuthProfileSuccess,
+  removeAuthProfilesWithLock,
   removeProviderAuthProfilesWithLock,
   resolveSubscriptionAuthModeForProfiles,
   setAuthProfileOrder,

--- a/src/agents/auth-profiles/profile-list.ts
+++ b/src/agents/auth-profiles/profile-list.ts
@@ -8,7 +8,7 @@ import { resolveProviderIdForAuth } from "../provider-auth-aliases.js";
 import type { AuthProfileStore } from "./types.js";
 
 /** Deduplicates profile ids while preserving first-seen order. */
-export function dedupeProfileIds(profileIds: string[]): string[] {
+export function dedupeProfileIds(profileIds: readonly string[]): string[] {
   return uniqueStrings(profileIds);
 }
 

--- a/src/agents/auth-profiles/profiles.test.ts
+++ b/src/agents/auth-profiles/profiles.test.ts
@@ -16,6 +16,7 @@ import { loadPersistedAuthProfileStore } from "./persisted.js";
 import {
   clearLastGoodProfileWithLock,
   promoteAuthProfileInOrder,
+  removeAuthProfilesWithLock,
   upsertAuthProfileWithLock,
 } from "./profiles.js";
 import {
@@ -599,6 +600,55 @@ describe("promoteAuthProfileInOrder", () => {
       });
 
       expect(loadAuthProfileStoreForRuntime(agentDir).lastGood?.["openai"]).toBe(goodProfileId);
+    });
+  });
+
+  it("removes selected profiles and prunes auth state references", async () => {
+    await withAuthProfileTestState("openclaw-auth-remove-profile-", async ({ agentDir }) => {
+      fs.mkdirSync(agentDir, { recursive: true });
+      saveAuthProfileStore(
+        {
+          version: AUTH_STORE_VERSION,
+          profiles: {
+            "openai:remove": {
+              type: "api_key",
+              provider: "openai",
+              key: "sk-remove",
+            },
+            "openai:keep": {
+              type: "api_key",
+              provider: "openai",
+              key: "sk-keep",
+            },
+            "anthropic:keep": {
+              type: "token",
+              provider: "anthropic",
+              token: "anthropic-token",
+            },
+          },
+          order: { openai: ["openai:remove", "openai:keep"] },
+          lastGood: { openai: "openai:remove", anthropic: "anthropic:keep" },
+          usageStats: {
+            "openai:remove": { errorCount: 2 },
+            "openai:keep": { errorCount: 1 },
+          },
+        },
+        agentDir,
+      );
+
+      await removeAuthProfilesWithLock({
+        agentDir,
+        profileIds: ["openai:remove"],
+      });
+
+      const updated = loadAuthProfileStoreForRuntime(agentDir);
+      expect(updated.profiles["openai:remove"]).toBeUndefined();
+      expect(updated.profiles["openai:keep"]).toBeDefined();
+      expect(updated.order?.["openai"]).toEqual(["openai:keep"]);
+      expect(updated.lastGood?.["openai"]).toBeUndefined();
+      expect(updated.lastGood?.["anthropic"]).toBe("anthropic:keep");
+      expect(updated.usageStats?.["openai:remove"]).toBeUndefined();
+      expect(updated.usageStats?.["openai:keep"]?.errorCount).toBe(1);
     });
   });
 });

--- a/src/agents/auth-profiles/profiles.ts
+++ b/src/agents/auth-profiles/profiles.ts
@@ -197,42 +197,74 @@ export async function removeProviderAuthProfilesWithLock(params: {
   provider: string;
   agentDir?: string;
 }): Promise<AuthProfileStore | null> {
-  const providerKey = resolveProviderIdForAuth(params.provider);
-  const storeOrderKey = normalizeProviderId(params.provider);
+  const store = ensureAuthProfileStoreForLocalUpdate(params.agentDir);
+  return await removeAuthProfilesWithLock({
+    agentDir: params.agentDir,
+    profileIds: listProfilesForProvider(store, params.provider),
+  });
+}
+
+function removeAuthProfileEntries(store: AuthProfileStore, profileIds: readonly string[]): boolean {
+  const targetProfileIds = new Set(profileIds.map((profileId) => profileId.trim()).filter(Boolean));
+  if (targetProfileIds.size === 0) {
+    return false;
+  }
+
+  let changed = false;
+  for (const profileId of targetProfileIds) {
+    if (store.profiles[profileId]) {
+      delete store.profiles[profileId];
+      changed = true;
+    }
+    if (store.usageStats?.[profileId]) {
+      delete store.usageStats[profileId];
+      changed = true;
+    }
+  }
+
+  for (const [provider, order] of Object.entries(store.order ?? {})) {
+    const next = order.filter((profileId) => !targetProfileIds.has(profileId));
+    if (next.length !== order.length) {
+      changed = true;
+      if (next.length > 0) {
+        store.order = { ...store.order, [provider]: next };
+      } else {
+        delete store.order?.[provider];
+      }
+    }
+  }
+  if (store.order && Object.keys(store.order).length === 0) {
+    store.order = undefined;
+  }
+
+  for (const [provider, profileId] of Object.entries(store.lastGood ?? {})) {
+    if (targetProfileIds.has(profileId)) {
+      delete store.lastGood?.[provider];
+      changed = true;
+    }
+  }
+  if (store.lastGood && Object.keys(store.lastGood).length === 0) {
+    store.lastGood = undefined;
+  }
+
+  if (store.usageStats && Object.keys(store.usageStats).length === 0) {
+    store.usageStats = undefined;
+  }
+  return changed;
+}
+
+/** Removes selected auth profiles and related state. */
+export async function removeAuthProfilesWithLock(params: {
+  profileIds: readonly string[];
+  agentDir?: string;
+}): Promise<AuthProfileStore | null> {
+  const profileIds = dedupeProfileIds(params.profileIds);
   return await updateAuthProfileStoreWithLock({
     agentDir: params.agentDir,
-    updater: (store) => {
-      const profileIds = listProfilesForProvider(store, params.provider);
-      let changed = false;
-      for (const profileId of profileIds) {
-        if (store.profiles[profileId]) {
-          delete store.profiles[profileId];
-          changed = true;
-        }
-        if (store.usageStats?.[profileId]) {
-          delete store.usageStats[profileId];
-          changed = true;
-        }
-      }
-      if (store.order?.[storeOrderKey]) {
-        delete store.order[storeOrderKey];
-        changed = true;
-        if (Object.keys(store.order).length === 0) {
-          store.order = undefined;
-        }
-      }
-      if (store.lastGood?.[providerKey]) {
-        delete store.lastGood[providerKey];
-        changed = true;
-        if (Object.keys(store.lastGood).length === 0) {
-          store.lastGood = undefined;
-        }
-      }
-      if (store.usageStats && Object.keys(store.usageStats).length === 0) {
-        store.usageStats = undefined;
-      }
-      return changed;
+    saveOptions: {
+      pruneOrderProfileIds: profileIds,
     },
+    updater: (store) => removeAuthProfileEntries(store, profileIds),
   });
 }
 

--- a/src/cli/models-cli.test.ts
+++ b/src/cli/models-cli.test.ts
@@ -14,6 +14,7 @@ const mocks = vi.hoisted(() => ({
   modelsAuthLoginCommand: vi.fn().mockResolvedValue(undefined),
   modelsAuthPasteApiKeyCommand: vi.fn().mockResolvedValue(undefined),
   modelsAuthPasteTokenCommand: vi.fn().mockResolvedValue(undefined),
+  modelsAuthRemoveCommand: vi.fn().mockResolvedValue(undefined),
   modelsAuthSetupTokenCommand: vi.fn().mockResolvedValue(undefined),
 }));
 
@@ -23,6 +24,7 @@ const {
   modelsAuthLoginCommand,
   modelsAuthPasteApiKeyCommand,
   modelsAuthPasteTokenCommand,
+  modelsAuthRemoveCommand,
   modelsAuthSetupTokenCommand,
   modelsSetCommand,
   modelsSetImageCommand,
@@ -44,6 +46,9 @@ vi.mock("../commands/models/auth.js", () => ({
 }));
 vi.mock("../commands/models/auth-list.js", () => ({
   modelsAuthListCommand: mocks.modelsAuthListCommand,
+}));
+vi.mock("../commands/models/auth-remove.js", () => ({
+  modelsAuthRemoveCommand: mocks.modelsAuthRemoveCommand,
 }));
 vi.mock("../commands/models/auth-order.js", () => ({
   modelsAuthOrderClearCommand: mocks.noopAsync,
@@ -84,6 +89,7 @@ describe("models cli", () => {
     modelsAuthLoginCommand.mockClear();
     modelsAuthPasteApiKeyCommand.mockClear();
     modelsAuthPasteTokenCommand.mockClear();
+    modelsAuthRemoveCommand.mockClear();
     modelsAuthSetupTokenCommand.mockClear();
     modelsSetCommand.mockClear();
     modelsSetImageCommand.mockClear();
@@ -174,6 +180,26 @@ describe("models cli", () => {
       expected: { agent: "poe", provider: "openai" },
     },
     {
+      label: "remove",
+      args: [
+        "models",
+        "auth",
+        "--agent",
+        "poe",
+        "remove",
+        "openai:user@example.com",
+        "--yes",
+        "--json",
+      ],
+      command: modelsAuthRemoveCommand,
+      expected: {
+        agent: "poe",
+        profileId: "openai:user@example.com",
+        yes: true,
+        json: true,
+      },
+    },
+    {
       label: "setup-token",
       args: ["models", "auth", "--agent", "poe", "setup-token", "--provider", "anthropic"],
       command: modelsAuthSetupTokenCommand,
@@ -201,6 +227,24 @@ describe("models cli", () => {
     await runModelsCommand(args);
 
     expectCommandOptions(command, expected);
+  });
+
+  it("passes provider-wide remove options through models auth remove", async () => {
+    await runModelsCommand([
+      "models",
+      "auth",
+      "remove",
+      "--provider",
+      "openai",
+      "--all",
+      "--dry-run",
+    ]);
+
+    expectCommandOptions(modelsAuthRemoveCommand, {
+      provider: "openai",
+      all: true,
+      dryRun: true,
+    });
   });
 
   it("passes --method through models auth login", async () => {

--- a/src/cli/models-cli.ts
+++ b/src/cli/models-cli.ts
@@ -25,6 +25,9 @@ const loadModelsImageFallbacksCommands = createModuleLoader(
   () => import("../commands/models/image-fallbacks.js"),
 );
 const loadModelsAuthCommands = createModuleLoader(() => import("../commands/models/auth.js"));
+const loadModelsAuthRemoveCommands = createModuleLoader(
+  () => import("../commands/models/auth-remove.js"),
+);
 const loadModelsAuthOrderCommands = createModuleLoader(
   () => import("../commands/models/auth-order.js"),
 );
@@ -324,6 +327,34 @@ export function registerModelsCli(program: Command) {
           {
             provider: opts.provider as string | undefined,
             agent,
+            json: Boolean(opts.json),
+          },
+          defaultRuntime,
+        );
+      });
+    });
+
+  auth
+    .command("remove [profileId]")
+    .description("Remove saved auth profiles")
+    .option("--provider <id>", "Provider id for --all removal or profile validation")
+    .option("--all", "Remove all saved profiles for --provider", false)
+    .option("--agent <id>", "Agent id (default: configured default agent)")
+    .option("--dry-run", "Preview profiles that would be removed without writing", false)
+    .option("--yes", "Skip confirmation prompt", false)
+    .option("--json", "Output JSON", false)
+    .action(async (profileId: string | undefined, opts, command) => {
+      await withModelsRuntime(async ({ defaultRuntime, resolveModelAgentOption }) => {
+        const agent = resolveModelAgentOption(command, opts);
+        const { modelsAuthRemoveCommand } = await loadModelsAuthRemoveCommands();
+        await modelsAuthRemoveCommand(
+          {
+            profileId,
+            provider: opts.provider as string | undefined,
+            all: Boolean(opts.all),
+            agent,
+            dryRun: Boolean(opts.dryRun),
+            yes: Boolean(opts.yes),
             json: Boolean(opts.json),
           },
           defaultRuntime,

--- a/src/commands/models/auth-remove.test.ts
+++ b/src/commands/models/auth-remove.test.ts
@@ -4,12 +4,17 @@ import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import type { OutputRuntimeEnv } from "../../runtime.js";
 import { modelsAuthRemoveCommand } from "./auth-remove.js";
 
+type ResolvePersistedAuthProfileOwnerAgentDir = (params: {
+  agentDir: string;
+  profileId: string;
+}) => string | undefined;
+
 const mocks = vi.hoisted(() => ({
   loadAuthProfileStoreWithoutExternalProfiles: vi.fn(),
   loadModelsConfig: vi.fn(),
   removeAuthProfilesWithLock: vi.fn(),
   resolveAuthProfileDisplayLabel: vi.fn(({ profileId }: { profileId: string }) => profileId),
-  resolvePersistedAuthProfileOwnerAgentDir: vi.fn(
+  resolvePersistedAuthProfileOwnerAgentDir: vi.fn<ResolvePersistedAuthProfileOwnerAgentDir>(
     ({ agentDir }: { agentDir: string; profileId: string }) => agentDir,
   ),
   resolveModelsTargetAgent: vi.fn((_cfg: OpenClawConfig, rawAgentId?: string) => {

--- a/src/commands/models/auth-remove.test.ts
+++ b/src/commands/models/auth-remove.test.ts
@@ -185,7 +185,22 @@ describe("modelsAuthRemoveCommand", () => {
         { profileId: "openai:user@example.com", agent: "coder", yes: true },
         runtime,
       ),
-    ).rejects.toThrow("is inherited from main");
+    ).rejects.toThrow("is inherited from the main auth store");
+
+    expect(mocks.removeAuthProfilesWithLock).not.toHaveBeenCalled();
+  });
+
+  it("rejects inherited profiles when the configured default agent is not the main auth store", async () => {
+    const runtime = createRuntime();
+    mocks.resolveModelsTargetAgent.mockImplementationOnce(() => ({
+      agentDir: "/tmp/openclaw/agents/coder",
+      agentId: "coder",
+    }));
+    mocks.resolvePersistedAuthProfileOwnerAgentDir.mockImplementation(() => undefined);
+
+    await expect(
+      modelsAuthRemoveCommand({ profileId: "openai:user@example.com", yes: true }, runtime),
+    ).rejects.toThrow("is inherited from the main auth store");
 
     expect(mocks.removeAuthProfilesWithLock).not.toHaveBeenCalled();
   });

--- a/src/commands/models/auth-remove.test.ts
+++ b/src/commands/models/auth-remove.test.ts
@@ -1,0 +1,176 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { AuthProfileStore } from "../../agents/auth-profiles.js";
+import type { OpenClawConfig } from "../../config/types.openclaw.js";
+import type { OutputRuntimeEnv } from "../../runtime.js";
+import { modelsAuthRemoveCommand } from "./auth-remove.js";
+
+const mocks = vi.hoisted(() => ({
+  loadAuthProfileStoreWithoutExternalProfiles: vi.fn(),
+  loadModelsConfig: vi.fn(),
+  removeAuthProfilesWithLock: vi.fn(),
+  resolveAuthProfileDisplayLabel: vi.fn(({ profileId }: { profileId: string }) => profileId),
+  resolveModelsTargetAgent: vi.fn((_cfg: OpenClawConfig, rawAgentId?: string) => {
+    const agentId = rawAgentId ?? "main";
+    return { agentDir: `/tmp/openclaw/agents/${agentId}`, agentId };
+  }),
+}));
+
+vi.mock("../../agents/auth-profiles.js", () => ({
+  loadAuthProfileStoreWithoutExternalProfiles: mocks.loadAuthProfileStoreWithoutExternalProfiles,
+  removeAuthProfilesWithLock: mocks.removeAuthProfilesWithLock,
+  resolveAuthProfileDisplayLabel: mocks.resolveAuthProfileDisplayLabel,
+  resolveAuthStatePathForDisplay: (agentDir: string) => `${agentDir}/openclaw-agent.sqlite`,
+}));
+
+vi.mock("./load-config.js", () => ({
+  loadModelsConfig: mocks.loadModelsConfig,
+}));
+
+vi.mock("./shared.js", () => ({
+  resolveModelsTargetAgent: mocks.resolveModelsTargetAgent,
+}));
+
+function createRuntime(): OutputRuntimeEnv & { logs: string[]; jsonPayloads: unknown[] } {
+  const logs: string[] = [];
+  const jsonPayloads: unknown[] = [];
+  return {
+    logs,
+    jsonPayloads,
+    log: (...args: unknown[]) => {
+      logs.push(args.map((value) => String(value)).join(" "));
+    },
+    error: vi.fn(),
+    exit: vi.fn((code: number) => {
+      throw new Error(`exit ${code}`);
+    }),
+    writeStdout: vi.fn(),
+    writeJson: (value: unknown) => {
+      jsonPayloads.push(value);
+    },
+  };
+}
+
+function createStore(): AuthProfileStore {
+  return {
+    version: 1,
+    profiles: {
+      "openai:user@example.com": {
+        type: "oauth",
+        provider: "openai",
+        access: "access-secret",
+        refresh: "refresh-secret",
+        expires: 1_800_000_000_000,
+        email: "user@example.com",
+      },
+      "openai:backup": {
+        type: "api_key",
+        provider: "openai",
+        key: "sk-secret",
+      },
+      "anthropic:manual": {
+        type: "token",
+        provider: "anthropic",
+        token: "token-secret",
+      },
+    },
+  };
+}
+
+describe("modelsAuthRemoveCommand", () => {
+  beforeEach(() => {
+    mocks.loadModelsConfig.mockReset().mockResolvedValue({} as OpenClawConfig);
+    mocks.loadAuthProfileStoreWithoutExternalProfiles.mockReset().mockReturnValue(createStore());
+    mocks.removeAuthProfilesWithLock.mockReset().mockResolvedValue({ version: 1, profiles: {} });
+    mocks.resolveAuthProfileDisplayLabel.mockClear();
+    mocks.resolveModelsTargetAgent.mockClear();
+  });
+
+  it("removes one explicit profile without printing secret material", async () => {
+    const runtime = createRuntime();
+
+    await modelsAuthRemoveCommand(
+      { profileId: "openai:user@example.com", agent: "coder", yes: true, json: true },
+      runtime,
+    );
+
+    expect(mocks.loadAuthProfileStoreWithoutExternalProfiles).toHaveBeenCalledWith(
+      "/tmp/openclaw/agents/coder",
+    );
+    expect(mocks.removeAuthProfilesWithLock).toHaveBeenCalledWith({
+      agentDir: "/tmp/openclaw/agents/coder",
+      profileIds: ["openai:user@example.com"],
+    });
+    expect(runtime.jsonPayloads).toStrictEqual([
+      {
+        agentDir: "/tmp/openclaw/agents/coder",
+        agentId: "coder",
+        authStatePath: "/tmp/openclaw/agents/coder/openclaw-agent.sqlite",
+        dryRun: false,
+        removed: [
+          {
+            id: "openai:user@example.com",
+            label: "openai:user@example.com",
+            provider: "openai",
+            type: "oauth",
+          },
+        ],
+        wouldRemove: [],
+      },
+    ]);
+    expect(JSON.stringify(runtime.jsonPayloads[0])).not.toContain("secret");
+  });
+
+  it("previews provider-wide removal without writing", async () => {
+    const runtime = createRuntime();
+
+    await modelsAuthRemoveCommand(
+      { provider: "openai", all: true, dryRun: true, json: true },
+      runtime,
+    );
+
+    expect(mocks.removeAuthProfilesWithLock).not.toHaveBeenCalled();
+    expect(runtime.jsonPayloads).toStrictEqual([
+      {
+        agentDir: "/tmp/openclaw/agents/main",
+        agentId: "main",
+        authStatePath: "/tmp/openclaw/agents/main/openclaw-agent.sqlite",
+        dryRun: true,
+        removed: [],
+        wouldRemove: [
+          {
+            id: "openai:backup",
+            label: "openai:backup",
+            provider: "openai",
+            type: "api_key",
+          },
+          {
+            id: "openai:user@example.com",
+            label: "openai:user@example.com",
+            provider: "openai",
+            type: "oauth",
+          },
+        ],
+      },
+    ]);
+  });
+
+  it("requires --all for provider-wide removal", async () => {
+    const runtime = createRuntime();
+
+    await expect(
+      modelsAuthRemoveCommand({ provider: "openai", yes: true }, runtime),
+    ).rejects.toThrow("without --all");
+
+    expect(mocks.removeAuthProfilesWithLock).not.toHaveBeenCalled();
+  });
+
+  it("requires --yes when not attached to an interactive terminal", async () => {
+    const runtime = createRuntime();
+
+    await expect(
+      modelsAuthRemoveCommand({ profileId: "openai:user@example.com" }, runtime),
+    ).rejects.toThrow("requires --yes");
+
+    expect(mocks.removeAuthProfilesWithLock).not.toHaveBeenCalled();
+  });
+});

--- a/src/commands/models/auth-remove.test.ts
+++ b/src/commands/models/auth-remove.test.ts
@@ -9,6 +9,9 @@ const mocks = vi.hoisted(() => ({
   loadModelsConfig: vi.fn(),
   removeAuthProfilesWithLock: vi.fn(),
   resolveAuthProfileDisplayLabel: vi.fn(({ profileId }: { profileId: string }) => profileId),
+  resolvePersistedAuthProfileOwnerAgentDir: vi.fn(
+    ({ agentDir }: { agentDir: string; profileId: string }) => agentDir,
+  ),
   resolveModelsTargetAgent: vi.fn((_cfg: OpenClawConfig, rawAgentId?: string) => {
     const agentId = rawAgentId ?? "main";
     return { agentDir: `/tmp/openclaw/agents/${agentId}`, agentId };
@@ -19,6 +22,7 @@ vi.mock("../../agents/auth-profiles.js", () => ({
   loadAuthProfileStoreWithoutExternalProfiles: mocks.loadAuthProfileStoreWithoutExternalProfiles,
   removeAuthProfilesWithLock: mocks.removeAuthProfilesWithLock,
   resolveAuthProfileDisplayLabel: mocks.resolveAuthProfileDisplayLabel,
+  resolvePersistedAuthProfileOwnerAgentDir: mocks.resolvePersistedAuthProfileOwnerAgentDir,
   resolveAuthStatePathForDisplay: (agentDir: string) => `${agentDir}/openclaw-agent.sqlite`,
 }));
 
@@ -82,6 +86,9 @@ describe("modelsAuthRemoveCommand", () => {
     mocks.loadAuthProfileStoreWithoutExternalProfiles.mockReset().mockReturnValue(createStore());
     mocks.removeAuthProfilesWithLock.mockReset().mockResolvedValue({ version: 1, profiles: {} });
     mocks.resolveAuthProfileDisplayLabel.mockClear();
+    mocks.resolvePersistedAuthProfileOwnerAgentDir
+      .mockReset()
+      .mockImplementation(({ agentDir }: { agentDir: string; profileId: string }) => agentDir);
     mocks.resolveModelsTargetAgent.mockClear();
   });
 
@@ -160,6 +167,20 @@ describe("modelsAuthRemoveCommand", () => {
     await expect(
       modelsAuthRemoveCommand({ provider: "openai", yes: true }, runtime),
     ).rejects.toThrow("without --all");
+
+    expect(mocks.removeAuthProfilesWithLock).not.toHaveBeenCalled();
+  });
+
+  it("rejects profiles inherited from the default agent store", async () => {
+    const runtime = createRuntime();
+    mocks.resolvePersistedAuthProfileOwnerAgentDir.mockReturnValue(undefined);
+
+    await expect(
+      modelsAuthRemoveCommand(
+        { profileId: "openai:user@example.com", agent: "coder", yes: true },
+        runtime,
+      ),
+    ).rejects.toThrow("is inherited from main");
 
     expect(mocks.removeAuthProfilesWithLock).not.toHaveBeenCalled();
   });

--- a/src/commands/models/auth-remove.test.ts
+++ b/src/commands/models/auth-remove.test.ts
@@ -173,7 +173,7 @@ describe("modelsAuthRemoveCommand", () => {
 
   it("rejects profiles inherited from the default agent store", async () => {
     const runtime = createRuntime();
-    mocks.resolvePersistedAuthProfileOwnerAgentDir.mockReturnValue(undefined);
+    mocks.resolvePersistedAuthProfileOwnerAgentDir.mockImplementation(() => undefined);
 
     await expect(
       modelsAuthRemoveCommand(

--- a/src/commands/models/auth-remove.ts
+++ b/src/commands/models/auth-remove.ts
@@ -178,7 +178,7 @@ export async function modelsAuthRemoveCommand(
       cfg,
       store,
       profileId,
-      profile: store.profiles[profileId]!,
+      profile: store.profiles[profileId],
     }),
   );
 

--- a/src/commands/models/auth-remove.ts
+++ b/src/commands/models/auth-remove.ts
@@ -1,0 +1,182 @@
+import {
+  loadAuthProfileStoreWithoutExternalProfiles,
+  removeAuthProfilesWithLock,
+  resolveAuthProfileDisplayLabel,
+  resolveAuthStatePathForDisplay,
+  type AuthProfileCredential,
+  type AuthProfileStore,
+} from "../../agents/auth-profiles.js";
+/** Command helper for removing saved model auth profiles. */
+import { resolveProviderIdForAuth } from "../../agents/provider-auth-aliases.js";
+import { formatCliCommand } from "../../cli/command-format.js";
+import { promptYesNo } from "../../cli/prompt.js";
+import { type RuntimeEnv, writeRuntimeJson } from "../../runtime.js";
+import { shortenHomePath } from "../../utils.js";
+import { loadModelsConfig } from "./load-config.js";
+import { resolveModelsTargetAgent } from "./shared.js";
+
+type RemovedAuthProfileSummary = {
+  id: string;
+  provider: string;
+  type: AuthProfileCredential["type"];
+  label: string;
+};
+
+function summarizeProfile(params: {
+  cfg: Awaited<ReturnType<typeof loadModelsConfig>>;
+  store: AuthProfileStore;
+  profileId: string;
+  profile: AuthProfileCredential;
+}): RemovedAuthProfileSummary {
+  return {
+    id: params.profileId,
+    provider: resolveProviderIdForAuth(params.profile.provider),
+    type: params.profile.type,
+    label: resolveAuthProfileDisplayLabel({
+      cfg: params.cfg,
+      store: params.store,
+      profileId: params.profileId,
+    }),
+  };
+}
+
+function listProfilesForAuthProvider(store: AuthProfileStore, provider: string): string[] {
+  const providerKey = resolveProviderIdForAuth(provider);
+  return Object.entries(store.profiles)
+    .filter(([, profile]) => resolveProviderIdForAuth(profile.provider) === providerKey)
+    .map(([profileId]) => profileId)
+    .toSorted((a, b) => a.localeCompare(b));
+}
+
+function resolveProfilesToRemove(params: {
+  profileId?: string;
+  provider?: string;
+  all?: boolean;
+  store: AuthProfileStore;
+}): string[] {
+  const profileId = params.profileId?.trim();
+  const provider = params.provider?.trim();
+
+  if (profileId) {
+    if (params.all) {
+      throw new Error("Pass either <profileId> or --all, not both.");
+    }
+    if (!params.store.profiles[profileId]) {
+      throw new Error(
+        `Auth profile "${profileId}" not found. Run ${formatCliCommand("openclaw models auth list")} to see saved profiles.`,
+      );
+    }
+    if (
+      provider &&
+      resolveProviderIdForAuth(params.store.profiles[profileId].provider) !==
+        resolveProviderIdForAuth(provider)
+    ) {
+      throw new Error(`Auth profile "${profileId}" is not for provider ${provider}.`);
+    }
+    return [profileId];
+  }
+
+  if (!provider) {
+    throw new Error(
+      `Missing auth profile id. Run ${formatCliCommand("openclaw models auth list")} to choose a profile.`,
+    );
+  }
+
+  const profileIds = listProfilesForAuthProvider(params.store, provider);
+  if (!params.all) {
+    const suffix =
+      profileIds.length > 0
+        ? ` Saved profiles: ${profileIds.join(", ")}.`
+        : " No saved profiles matched this provider.";
+    throw new Error(
+      `Refusing to remove all ${resolveProviderIdForAuth(provider)} auth profiles without --all.${suffix}`,
+    );
+  }
+  if (profileIds.length === 0) {
+    throw new Error(
+      `No saved auth profiles found for provider ${resolveProviderIdForAuth(provider)}.`,
+    );
+  }
+  return profileIds;
+}
+
+async function confirmRemoval(params: {
+  profileIds: readonly string[];
+  dryRun?: boolean;
+  yes?: boolean;
+}): Promise<void> {
+  if (params.dryRun || params.yes) {
+    return;
+  }
+  if (!process.stdin.isTTY) {
+    throw new Error("Non-interactive auth profile removal requires --yes.");
+  }
+  const ok = await promptYesNo(
+    `Remove ${params.profileIds.length} auth profile(s): ${params.profileIds.join(", ")}?`,
+    false,
+  );
+  if (!ok) {
+    throw new Error("Cancelled auth profile removal.");
+  }
+}
+
+export async function modelsAuthRemoveCommand(
+  opts: {
+    profileId?: string;
+    provider?: string;
+    all?: boolean;
+    agent?: string;
+    dryRun?: boolean;
+    yes?: boolean;
+    json?: boolean;
+  },
+  runtime: RuntimeEnv,
+) {
+  const cfg = await loadModelsConfig({ commandName: "models auth remove", runtime });
+  const { agentId, agentDir } = resolveModelsTargetAgent(cfg, opts.agent);
+  const store = loadAuthProfileStoreWithoutExternalProfiles(agentDir);
+  const profileIds = resolveProfilesToRemove({
+    profileId: opts.profileId,
+    provider: opts.provider,
+    all: opts.all,
+    store,
+  });
+  const profiles = profileIds.map((profileId) =>
+    summarizeProfile({
+      cfg,
+      store,
+      profileId,
+      profile: store.profiles[profileId]!,
+    }),
+  );
+
+  await confirmRemoval({ profileIds, dryRun: opts.dryRun, yes: opts.yes });
+
+  if (!opts.dryRun) {
+    const updated = await removeAuthProfilesWithLock({ agentDir, profileIds });
+    if (!updated) {
+      throw new Error(
+        `Failed to update auth profiles; the auth state lock may be busy. Wait a moment and rerun ${formatCliCommand("openclaw models auth remove <profileId> --yes")}.`,
+      );
+    }
+  }
+
+  if (opts.json) {
+    writeRuntimeJson(runtime, {
+      agentId,
+      agentDir: shortenHomePath(agentDir),
+      authStatePath: shortenHomePath(resolveAuthStatePathForDisplay(agentDir)),
+      dryRun: Boolean(opts.dryRun),
+      removed: opts.dryRun ? [] : profiles,
+      wouldRemove: opts.dryRun ? profiles : [],
+    });
+    return;
+  }
+
+  runtime.log(`Agent: ${agentId}`);
+  runtime.log(`Auth state store: ${shortenHomePath(resolveAuthStatePathForDisplay(agentDir))}`);
+  runtime.log(opts.dryRun ? "Would remove auth profiles:" : "Removed auth profiles:");
+  for (const profile of profiles) {
+    runtime.log(`- ${profile.label} [${profile.provider}/${profile.type}]`);
+  }
+}

--- a/src/commands/models/auth-remove.ts
+++ b/src/commands/models/auth-remove.ts
@@ -1,4 +1,3 @@
-import { resolveDefaultAgentId } from "../../agents/agent-scope.js";
 import {
   loadAuthProfileStoreWithoutExternalProfiles,
   removeAuthProfilesWithLock,
@@ -8,6 +7,7 @@ import {
   type AuthProfileCredential,
   type AuthProfileStore,
 } from "../../agents/auth-profiles.js";
+import { resolveAuthStorePath } from "../../agents/auth-profiles/paths.js";
 /** Command helper for removing saved model auth profiles. */
 import { resolveProviderIdForAuth } from "../../agents/provider-auth-aliases.js";
 import { formatCliCommand } from "../../cli/command-format.js";
@@ -104,10 +104,10 @@ function resolveProfilesToRemove(params: {
 
 function assertProfilesOwnedBySelectedAgent(params: {
   agentDir: string;
-  agentId: string;
-  defaultAgentId: string;
   profileIds: readonly string[];
 }): void {
+  const selectedAuthStorePath = resolveAuthStorePath(params.agentDir);
+  const mainAuthStorePath = resolveAuthStorePath();
   for (const profileId of params.profileIds) {
     const ownerAgentDir = resolvePersistedAuthProfileOwnerAgentDir({
       agentDir: params.agentDir,
@@ -116,12 +116,12 @@ function assertProfilesOwnedBySelectedAgent(params: {
     if (ownerAgentDir === params.agentDir) {
       continue;
     }
-    if (!ownerAgentDir && params.agentId === params.defaultAgentId) {
+    if (!ownerAgentDir && selectedAuthStorePath === mainAuthStorePath) {
       continue;
     }
-    const ownerAgentLabel = ownerAgentDir ? "another agent" : params.defaultAgentId;
+    const ownerAgentLabel = ownerAgentDir ? "another agent" : "the main auth store";
     throw new Error(
-      `Auth profile "${profileId}" is inherited from ${ownerAgentLabel}; remove it with ${formatCliCommand(`openclaw models auth remove ${profileId} --agent ${params.defaultAgentId}`)} instead.`,
+      `Auth profile "${profileId}" is inherited from ${ownerAgentLabel}; remove it from the owning agent store instead.`,
     );
   }
 }
@@ -169,8 +169,6 @@ export async function modelsAuthRemoveCommand(
   });
   assertProfilesOwnedBySelectedAgent({
     agentDir,
-    agentId,
-    defaultAgentId: resolveDefaultAgentId(cfg),
     profileIds,
   });
   const profiles = profileIds.map((profileId) =>

--- a/src/commands/models/auth-remove.ts
+++ b/src/commands/models/auth-remove.ts
@@ -1,7 +1,9 @@
+import { resolveDefaultAgentId } from "../../agents/agent-scope.js";
 import {
   loadAuthProfileStoreWithoutExternalProfiles,
   removeAuthProfilesWithLock,
   resolveAuthProfileDisplayLabel,
+  resolvePersistedAuthProfileOwnerAgentDir,
   resolveAuthStatePathForDisplay,
   type AuthProfileCredential,
   type AuthProfileStore,
@@ -100,6 +102,30 @@ function resolveProfilesToRemove(params: {
   return profileIds;
 }
 
+function assertProfilesOwnedBySelectedAgent(params: {
+  agentDir: string;
+  agentId: string;
+  defaultAgentId: string;
+  profileIds: readonly string[];
+}): void {
+  for (const profileId of params.profileIds) {
+    const ownerAgentDir = resolvePersistedAuthProfileOwnerAgentDir({
+      agentDir: params.agentDir,
+      profileId,
+    });
+    if (ownerAgentDir === params.agentDir) {
+      continue;
+    }
+    if (!ownerAgentDir && params.agentId === params.defaultAgentId) {
+      continue;
+    }
+    const ownerAgentLabel = ownerAgentDir ? "another agent" : params.defaultAgentId;
+    throw new Error(
+      `Auth profile "${profileId}" is inherited from ${ownerAgentLabel}; remove it with ${formatCliCommand(`openclaw models auth remove ${profileId} --agent ${params.defaultAgentId}`)} instead.`,
+    );
+  }
+}
+
 async function confirmRemoval(params: {
   profileIds: readonly string[];
   dryRun?: boolean;
@@ -140,6 +166,12 @@ export async function modelsAuthRemoveCommand(
     provider: opts.provider,
     all: opts.all,
     store,
+  });
+  assertProfilesOwnedBySelectedAgent({
+    agentDir,
+    agentId,
+    defaultAgentId: resolveDefaultAgentId(cfg),
+    profileIds,
   });
   const profiles = profileIds.map((profileId) =>
     summarizeProfile({


### PR DESCRIPTION
Closes #99380

AI-assisted: yes. I understand the behavior and validation described below.

## What Problem This Solves

Users can list and create model auth profiles, but there is no supported CLI path to remove a saved profile. That leaves stale or orphaned credentials to manual store edits, which is easy to get wrong because profile storage also carries order, last-good, usage state, and detached/SQLite-backed secret material.

## Why This Change Was Made

This adds `openclaw models auth remove [profileId]` under the existing model auth CLI. It favors explicit profile-id deletion, requires `--provider <id> --all` for provider-wide removal, supports `--dry-run`, `--yes`, `--json`, and scopes through `--agent` like the existing auth commands. Deletion resolves candidates from the persisted local store without external CLI overlays, then saves through the existing auth profile path so related state is pruned consistently.

## User Impact

Users can safely remove one saved model auth profile or intentionally remove all saved profiles for one provider without hand-editing OpenClaw state. Automation can use `--json --yes`, while interactive/manual use can preview with `--dry-run` first.

## Evidence

Targeted tests on latest `origin/main` after rebase:

```bash
node scripts/run-vitest.mjs run --config test/vitest/vitest.commands.config.ts src/commands/models/auth-remove.test.ts
# Test Files 1 passed; Tests 4 passed

node scripts/run-vitest.mjs run --config test/vitest/vitest.cli.config.ts src/cli/models-cli.test.ts
# Test Files 1 passed; Tests 18 passed

node scripts/run-vitest.mjs run --config test/vitest/vitest.agents.config.ts src/agents/auth-profiles/profiles.test.ts
# Test Files 1 passed; Tests 12 passed
```

Formatting/lint:

```bash
node_modules/.bin/oxfmt --check docs/cli/models.md docs/gateway/authentication.md src/agents/auth-profiles.ts src/agents/auth-profiles/profiles.test.ts src/agents/auth-profiles/profiles.ts src/cli/models-cli.test.ts src/cli/models-cli.ts src/commands/models/auth-remove.ts src/commands/models/auth-remove.test.ts
# All matched files use the correct format.

node_modules/.bin/oxlint src/agents/auth-profiles.ts src/agents/auth-profiles/profiles.test.ts src/agents/auth-profiles/profiles.ts src/cli/models-cli.test.ts src/cli/models-cli.ts src/commands/models/auth-remove.ts src/commands/models/auth-remove.test.ts
# passed
```

Manual source smoke:

```bash
node --import tsx src/entry.ts models auth remove --help
# printed the new `models auth remove [profileId]` help and options
```

Temporary-state store smoke:

- Saved three real auth profiles through `saveAuthProfileStore`
- Invoked `modelsAuthRemoveCommand` against the real auth store helpers
- Verified the requested profile was removed, unrelated profiles remained, `order`/`lastGood`/`usageStats` references were pruned, and JSON output did not include secret material

Docker build and CLI smoke:

```bash
docker compose --progress plain build openclaw-gateway
# openclaw:local Built

docker run --rm --entrypoint openclaw openclaw:local models auth remove --help
# printed the new command help
```

Containerized end-to-end auth profile flow with an isolated mounted state directory:

```bash
printf 'sk-test-secret\n' | docker run --rm -i -v "$TMP:/state" --entrypoint openclaw \
  -e OPENCLAW_HOME=/state \
  -e OPENCLAW_STATE_DIR=/state \
  -e OPENCLAW_CONFIG_PATH=/state/openclaw.json \
  -e OPENCLAW_TEST_FAST=1 \
  openclaw:local models auth paste-api-key --provider openai --profile-id openai:user@example.com
# Auth profile: openai:user@example.com (openai/api_key)

docker run --rm -v "$TMP:/state" --entrypoint openclaw ... openclaw:local models auth list --json
# profiles contains openai:user@example.com

docker run --rm -v "$TMP:/state" --entrypoint openclaw ... openclaw:local models auth remove openai:user@example.com --yes --json
# removed contains openai:user@example.com

docker run --rm -v "$TMP:/state" --entrypoint openclaw ... openclaw:local models auth list --json
# profiles is []
```
