### PR TITLE
fix(agents): thinking-enabled Anthropic sessions fail with "Invalid signature" after tool loops

### DIFF
--- a/packages/ai/src/providers/anthropic-thinking-replay.ts
+++ b/packages/ai/src/providers/anthropic-thinking-replay.ts
@@ -2,6 +2,7 @@ type ReplayMessage = {
   role?: unknown;
   content?: unknown;
   toolCallId?: unknown;
+  runtimeContextCarrier?: unknown;
 };
 
 export const ANTHROPIC_OMITTED_REASONING_TEXT = "[assistant reasoning omitted]";
@@ -17,6 +18,10 @@ function asReplayMessage(value: unknown): ReplayMessage | undefined {
 export function findActiveAnthropicToolTurnAssistantIndex(messages: readonly unknown[]): number {
   const toolResultIds = new Set<string>();
   let index = messages.length - 1;
+
+  while (index >= 0 && asReplayMessage(messages[index])?.runtimeContextCarrier === true) {
+    index -= 1;
+  }
 
   while (index >= 0) {
     const message = asReplayMessage(messages[index]);
@@ -55,4 +60,15 @@ export function findActiveAnthropicToolTurnAssistantIndex(messages: readonly unk
   }
 
   return [...toolResultIds].every((toolCallId) => toolCallIds.has(toolCallId)) ? index : -1;
+}
+
+/** The latest user message starts the current turn. */
+export function findAnthropicCurrentTurnStartIndex(messages: readonly unknown[]): number {
+  for (let index = messages.length - 1; index >= 0; index -= 1) {
+    const message = asReplayMessage(messages[index]);
+    if (message?.role === "user" && message.runtimeContextCarrier !== true) {
+      return index;
+    }
+  }
+  return -1;
 }

--- a/packages/ai/src/providers/anthropic.test.ts
+++ b/packages/ai/src/providers/anthropic.test.ts
@@ -568,7 +568,7 @@ describe("Anthropic provider", () => {
     expect(result.usage.contextUsage).toEqual({ state: "unavailable" });
   });
 
-  it("preserves provider-signed Anthropic thinking and drops reasoning_content placeholders", async () => {
+  it("drops completed Fable thinking while preserving the visible tool turn", async () => {
     const highSurrogate = String.fromCharCode(0xd83d);
     const signedThinking = `keep${highSurrogate}signed`;
     let capturedPayload: unknown;
@@ -634,10 +634,26 @@ describe("Anthropic provider", () => {
               },
               {
                 type: "thinking",
+                thinking: "[Reasoning redacted]",
+                thinkingSignature: "opaque_1",
+                redacted: true,
+              },
+              {
+                type: "thinking",
                 thinking: `sanitize${highSurrogate}synthetic`,
                 thinkingSignature: "reasoning_content",
               },
+              { type: "toolCall", id: "call_1", name: "lookup", arguments: {} },
+              { type: "text", text: "Visible answer." },
             ],
+          },
+          {
+            role: "toolResult",
+            toolCallId: "call_1",
+            toolName: "lookup",
+            content: [{ type: "text", text: "42" }],
+            isError: false,
+            timestamp: 0,
           },
           { role: "user", content: "again", timestamp: 0 },
         ],
@@ -655,18 +671,10 @@ describe("Anthropic provider", () => {
 
     const payload = capturedPayload as { messages: Array<{ role: string; content: unknown[] }> };
     const assistantMessage = payload.messages.find((message) => message.role === "assistant");
-    expect(JSON.stringify(assistantMessage?.content)).not.toContain("reasoning_content");
+    expect(JSON.stringify(assistantMessage?.content)).not.toContain("thinking");
     expect(assistantMessage?.content).toEqual([
-      {
-        type: "thinking",
-        thinking: signedThinking,
-        signature: "sig_1",
-      },
-      {
-        type: "thinking",
-        thinking: "",
-        signature: "sig_omitted",
-      },
+      { type: "tool_use", id: "call_1", name: "lookup", input: {} },
+      { type: "text", text: "Visible answer." },
     ]);
     expect(result.responseModel).toBe("claude-fable-5");
   });
@@ -683,6 +691,13 @@ describe("Anthropic provider", () => {
       label: "explicitly disabled",
       thinkingEnabled: false,
       expectedThinking: { type: "disabled" },
+      visibleText: "Visible answer.",
+      expectedContent: [{ type: "text", text: "Visible answer." }],
+    },
+    {
+      label: "enabled on a completed turn",
+      thinkingEnabled: true,
+      expectedThinking: { type: "adaptive", display: "summarized" },
       visibleText: "Visible answer.",
       expectedContent: [{ type: "text", text: "Visible answer." }],
     },
@@ -751,67 +766,87 @@ describe("Anthropic provider", () => {
     },
   );
 
-  it("preserves signed thinking for an active tool turn when new thinking is disabled", async () => {
-    let capturedPayload: unknown;
-    const stream = streamAnthropic(
-      makeAnthropicModel(),
-      {
-        messages: [
-          { role: "user", content: "look it up", timestamp: 0 },
-          {
-            role: "assistant",
-            provider: "anthropic",
-            api: "anthropic-messages",
-            model: "claude-sonnet-4-6",
-            stopReason: "toolUse",
-            timestamp: 0,
-            usage: {
-              input: 0,
-              output: 0,
-              cacheRead: 0,
-              cacheWrite: 0,
-              totalTokens: 0,
-              cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
-            },
-            content: [
-              {
-                type: "thinking",
-                thinking: "call lookup",
-                thinkingSignature: "sig_tool",
+  it.each([
+    {
+      label: "disabled Sonnet",
+      model: makeAnthropicModel(),
+      thinkingEnabled: false,
+    },
+    {
+      label: "adaptive Fable",
+      model: makeAnthropicModel({ id: "claude-fable-5", name: "Claude Fable 5" }),
+      thinkingEnabled: undefined,
+    },
+  ])(
+    "preserves signed thinking for an active $label tool turn",
+    async ({ model, thinkingEnabled }) => {
+      let capturedPayload: unknown;
+      const stream = streamAnthropic(
+        model,
+        {
+          messages: [
+            { role: "user", content: "look it up", timestamp: 0 },
+            {
+              role: "assistant",
+              provider: "anthropic",
+              api: "anthropic-messages",
+              model: model.id,
+              stopReason: "toolUse",
+              timestamp: 0,
+              usage: {
+                input: 0,
+                output: 0,
+                cacheRead: 0,
+                cacheWrite: 0,
+                totalTokens: 0,
+                cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
               },
-              { type: "toolCall", id: "call_1", name: "lookup", arguments: {} },
-            ],
-          },
-          {
-            role: "toolResult",
-            toolCallId: "call_1",
-            toolName: "lookup",
-            content: [{ type: "text", text: "42" }],
-            isError: false,
-            timestamp: 0,
-          },
-        ],
-      },
-      {
-        apiKey: "sk-ant-provider",
-        thinkingEnabled: false,
-        onPayload: (payload) => {
-          capturedPayload = payload;
-          throw new Error("stop before network");
+              content: [
+                {
+                  type: "thinking",
+                  thinking: "call lookup",
+                  thinkingSignature: "sig_tool",
+                },
+                { type: "toolCall", id: "call_1", name: "lookup", arguments: {} },
+              ],
+            },
+            {
+              role: "toolResult",
+              toolCallId: "call_1",
+              toolName: "lookup",
+              content: [{ type: "text", text: "42" }],
+              isError: false,
+              timestamp: 0,
+            },
+            {
+              role: "user",
+              content: "current runtime context",
+              timestamp: 0,
+              runtimeContextCarrier: true,
+            },
+          ],
         },
-      },
-    );
+        {
+          apiKey: "sk-ant-provider",
+          thinkingEnabled,
+          onPayload: (payload) => {
+            capturedPayload = payload;
+            throw new Error("stop before network");
+          },
+        },
+      );
 
-    await stream.result();
+      await stream.result();
 
-    const payload = capturedPayload as {
-      messages: Array<{ role: string; content: unknown[] }>;
-    };
-    expect(payload.messages.find((message) => message.role === "assistant")?.content).toEqual([
-      { type: "thinking", thinking: "call lookup", signature: "sig_tool" },
-      { type: "tool_use", id: "call_1", name: "lookup", input: {} },
-    ]);
-  });
+      const payload = capturedPayload as {
+        messages: Array<{ role: string; content: unknown[] }>;
+      };
+      expect(payload.messages.find((message) => message.role === "assistant")?.content).toEqual([
+        { type: "thinking", thinking: "call lookup", signature: "sig_tool" },
+        { type: "tool_use", id: "call_1", name: "lookup", input: {} },
+      ]);
+    },
+  );
 
   it("preserves mixed text and image tool-result order", async () => {
     let capturedPayload: unknown;

--- a/packages/ai/src/providers/anthropic.test.ts
+++ b/packages/ai/src/providers/anthropic.test.ts
@@ -568,7 +568,7 @@ describe("Anthropic provider", () => {
     expect(result.usage.contextUsage).toEqual({ state: "unavailable" });
   });
 
-  it("drops completed Fable thinking while preserving the visible tool turn", async () => {
+  it("drops corrupted completed Fable thinking while preserving the visible tool turn", async () => {
     const highSurrogate = String.fromCharCode(0xd83d);
     const signedThinking = `keep${highSurrogate}signed`;
     let capturedPayload: unknown;
@@ -625,7 +625,7 @@ describe("Anthropic provider", () => {
               {
                 type: "thinking",
                 thinking: signedThinking,
-                thinkingSignature: "sig_1",
+                thinkingSignature: "opaque…corrupted",
               },
               {
                 type: "thinking",

--- a/packages/ai/src/providers/anthropic.ts
+++ b/packages/ai/src/providers/anthropic.ts
@@ -68,6 +68,7 @@ import {
 import {
   ANTHROPIC_OMITTED_REASONING_TEXT,
   findActiveAnthropicToolTurnAssistantIndex,
+  findAnthropicCurrentTurnStartIndex,
 } from "./anthropic-thinking-replay.js";
 import {
   projectAnthropicTools,
@@ -1444,9 +1445,11 @@ function convertMessages(
 
   // Transform messages for cross-provider compatibility
   const transformedMessages = transformMessages(messages, model, normalizeToolCallId);
-  const activeToolTurnAssistantIndex = replayThinkingEnabled
-    ? -1
-    : findActiveAnthropicToolTurnAssistantIndex(transformedMessages);
+  const activeToolTurnAssistantIndex =
+    findActiveAnthropicToolTurnAssistantIndex(transformedMessages);
+  const currentTurnStartIndex = replayThinkingEnabled
+    ? findAnthropicCurrentTurnStartIndex(transformedMessages)
+    : -1;
 
   for (let i = 0; i < transformedMessages.length; i++) {
     const msg = transformedMessages[i];
@@ -1511,7 +1514,8 @@ function convertMessages(
             text: sanitizeSurrogates(block.text),
           });
         } else if (block.type === "thinking") {
-          if (!replayThinkingEnabled && i !== activeToolTurnAssistantIndex) {
+          const isCompletedTurn = currentTurnStartIndex >= 0 && i < currentTurnStartIndex;
+          if (i !== activeToolTurnAssistantIndex && (!replayThinkingEnabled || isCompletedTurn)) {
             omittedThinking = true;
             continue;
           }

--- a/src/agents/anthropic-transport-stream.test.ts
+++ b/src/agents/anthropic-transport-stream.test.ts
@@ -2681,7 +2681,7 @@ describe("anthropic transport stream", () => {
     ]);
   });
 
-  it("preserves provider-signed Anthropic thinking text on replay", async () => {
+  it("drops completed Fable thinking while preserving the visible tool turn", async () => {
     const highSurrogate = String.fromCharCode(0xd83d);
     const signedThinking = `keep${highSurrogate}signed`;
     await runTransportStream(
@@ -2710,7 +2710,22 @@ describe("anthropic transport stream", () => {
                 thinking: "",
                 thinkingSignature: "sig_omitted",
               },
+              {
+                type: "thinking",
+                thinking: "[Reasoning redacted]",
+                thinkingSignature: "opaque_1",
+                redacted: true,
+              },
+              { type: "toolCall", id: "call_1", name: "lookup", arguments: {} },
+              { type: "text", text: "Visible answer." },
             ],
+          },
+          {
+            role: "toolResult",
+            toolCallId: "call_1",
+            toolName: "lookup",
+            content: [{ type: "text", text: "42" }],
+            isError: false,
           },
           { role: "user", content: "again" },
         ],
@@ -2726,16 +2741,8 @@ describe("anthropic transport stream", () => {
       (record) => record.role === "assistant",
     );
     expect(assistantMessage.content).toEqual([
-      {
-        type: "thinking",
-        thinking: signedThinking,
-        signature: "sig_1",
-      },
-      {
-        type: "thinking",
-        thinking: "",
-        signature: "sig_omitted",
-      },
+      { type: "tool_use", id: "call_1", name: "lookup", input: {} },
+      { type: "text", text: "Visible answer." },
     ]);
   });
 
@@ -2782,9 +2789,20 @@ describe("anthropic transport stream", () => {
     ]);
   });
 
-  it("preserves signed thinking for an active tool turn when new thinking is disabled", async () => {
+  it.each([
+    {
+      label: "disabled Sonnet",
+      model: makeAnthropicTransportModel(),
+      options: { apiKey: "sk-ant-api" } as AnthropicStreamOptions,
+    },
+    {
+      label: "adaptive Fable",
+      model: makeAnthropicTransportModel({ id: "claude-fable-5", name: "Claude Fable 5" }),
+      options: { apiKey: "sk-ant-api", reasoning: "high" } as AnthropicStreamOptions,
+    },
+  ])("preserves signed thinking for an active $label tool turn", async ({ model, options }) => {
     await runTransportStream(
-      makeAnthropicTransportModel(),
+      model,
       {
         messages: [
           { role: "user", content: "look it up" },
@@ -2792,7 +2810,7 @@ describe("anthropic transport stream", () => {
             role: "assistant",
             provider: "anthropic",
             api: "anthropic-messages",
-            model: "claude-sonnet-4-6",
+            model: model.id,
             stopReason: "toolUse",
             timestamp: 0,
             content: [
@@ -2811,11 +2829,14 @@ describe("anthropic transport stream", () => {
             content: [{ type: "text", text: "42" }],
             isError: false,
           },
+          {
+            role: "user",
+            content: "current runtime context",
+            runtimeContextCarrier: true,
+          },
         ],
       } as AnthropicStreamContext,
-      {
-        apiKey: "sk-ant-api",
-      } as AnthropicStreamOptions,
+      options,
     );
 
     const assistantMessage = findRecord(

--- a/src/agents/anthropic-transport-stream.test.ts
+++ b/src/agents/anthropic-transport-stream.test.ts
@@ -2681,7 +2681,7 @@ describe("anthropic transport stream", () => {
     ]);
   });
 
-  it("drops completed Fable thinking while preserving the visible tool turn", async () => {
+  it("drops corrupted completed Fable thinking while preserving the visible tool turn", async () => {
     const highSurrogate = String.fromCharCode(0xd83d);
     const signedThinking = `keep${highSurrogate}signed`;
     await runTransportStream(
@@ -2703,7 +2703,7 @@ describe("anthropic transport stream", () => {
               {
                 type: "thinking",
                 thinking: signedThinking,
-                thinkingSignature: "sig_1",
+                thinkingSignature: "opaque…corrupted",
               },
               {
                 type: "thinking",

--- a/src/agents/anthropic-transport-stream.ts
+++ b/src/agents/anthropic-transport-stream.ts
@@ -8,6 +8,7 @@ import {
   defaultsClaudeAdaptiveThinking,
   applyAnthropicRefusal,
   findActiveAnthropicToolTurnAssistantIndex,
+  findAnthropicCurrentTurnStartIndex,
   omitFoundryBearerCredentialHeaders,
   prepareClaudeSonnet5RequestContext,
   projectAnthropicTools,
@@ -405,9 +406,11 @@ function convertAnthropicMessages(
   const allowReasoningContentReplay = options.allowReasoningContentReplay === true;
   const replayThinkingEnabled = options.replayThinkingEnabled !== false;
   const transformedMessages = transformTransportMessages(messages, model, normalizeToolCallId);
-  const activeToolTurnAssistantIndex = replayThinkingEnabled
-    ? -1
-    : findActiveAnthropicToolTurnAssistantIndex(transformedMessages);
+  const activeToolTurnAssistantIndex =
+    findActiveAnthropicToolTurnAssistantIndex(transformedMessages);
+  const currentTurnStartIndex = replayThinkingEnabled
+    ? findAnthropicCurrentTurnStartIndex(transformedMessages)
+    : -1;
   for (let i = 0; i < transformedMessages.length; i += 1) {
     const msg = transformedMessages[i];
     if (msg.role === "user") {
@@ -482,7 +485,12 @@ function convertAnthropicMessages(
         if (block.type === "thinking") {
           const thinkingSignature = block.thinkingSignature?.trim();
           const isReasoningContent = thinkingSignature === "reasoning_content";
-          if (!replayThinkingEnabled && i !== activeToolTurnAssistantIndex && !isReasoningContent) {
+          const isCompletedTurn = currentTurnStartIndex >= 0 && i < currentTurnStartIndex;
+          if (
+            i !== activeToolTurnAssistantIndex &&
+            (!replayThinkingEnabled || isCompletedTurn) &&
+            !isReasoningContent
+          ) {
             omittedThinking = true;
             continue;
           }


### PR DESCRIPTION
Closes #99382

## What Problem This Solves

Anthropic validates signed `thinking` blocks even when they belong to completed prior turns. If a stored signature is stale or corrupted, replaying that completed-turn block makes every later request fail with HTTP 400 `Invalid signature in thinking block`.

The July 10 production report on #99382 adds a concrete capture-time variant: a completed Fable 5 signature contained a literal U+2026 character and poisoned every later turn. The signature was already corrupted in the completed message snapshot, so retrying the same history could not recover the session.

This affects both native Anthropic payload builders: the AI SDK provider converter and the managed transport converter.

## Why This Change Was Made

The provider contract has two distinct requirements:

- completed prior-turn thinking may be omitted;
- an active tool-use turn's thinking must be passed back complete and unchanged.

Both converters now use the latest real user message as the current-turn boundary. Native `thinking` and `redacted_thinking` blocks before that boundary are omitted, while the active tool-use assistant turn is preserved. Runtime-context carrier messages are ignored when finding both boundaries.

This is deliberately a payload-boundary policy, not a signature parser. Anthropic signatures are opaque, so the implementation does not guess their encoding, length, or cryptographic validity. The new U+2026 regression fixtures prove that an already-corrupted completed signature is omitted without adding a base64 heuristic.

Recent merged fixes are complementary:

- #104043 prevents interrupted managed-transport streams from publishing partial `signature_delta` bytes before `content_block_stop`.
- #103628 prevents transcript redaction from rewriting recognized provider-owned replay payloads.
- #90163 strips stale pre-compaction signatures at the compaction boundary.
- #95430 and the existing replay repair path recover after a provider rejection.

This PR covers the remaining request-boundary invariant: completed historical thinking cannot brick a later Anthropic request regardless of how an invalid stored signature originated. It does not change signature capture, transcript redaction, compaction, recovery routing, configuration, dependencies, or tool IDs.

## User Impact

Long-running Anthropic sessions can continue after a completed turn even when that turn contains an unusable thinking signature. Active tool continuations still receive the exact thinking block Anthropic requires.

The tradeoff is intentional: omitting completed-turn thinking can reduce prompt-cache continuity for modern Claude models. The PR prioritizes session availability over retaining opaque historical reasoning that can hard-fail the entire request; visible assistant text and tool history remain intact.

## Evidence

- AI-assisted: I reviewed the implementation and understand the affected replay policy.
- Current base: `openclaw/openclaw@f5eacacea5`.
- Current head: `83e6b975b7`.
- `git range-diff` confirms the production patch is content-identical to the previously live-proven head after rebase.
- `node scripts/run-vitest.mjs packages/ai/src/providers/anthropic.test.ts src/agents/anthropic-transport-stream.test.ts` — 2 files, 178 tests passed.
- Targeted `oxfmt --check` and `oxlint` on all five changed files — passed.
- Final `$autoreview` — no accepted or actionable findings, confidence 0.82.
- The two converter suites now include the reported U+2026-corrupted completed signature and verify that it never reaches the outbound payload.

### Live Anthropic provider proof

The content-identical production patch was previously exercised against `claude-fable-5` with adaptive thinking. No keys, signatures, or thinking content were logged.

| Transcript shape | Provider result |
| --- | --- |
| Active tool turn with the original thinking block replayed unchanged | HTTP 200 |
| Completed prior tool turn with a tampered thinking signature | HTTP 400 `invalid_request_error` |
| Same completed prior turn with thinking omitted and `tool_use` / `tool_result` retained | HTTP 200 |

The current environment did not expose Anthropic credentials for a fresh live rerun. The rebase preserved the production patch byte-for-byte; only the completed-signature regression fixtures were updated to match the U+2026 production report.
