### PR TITLE
fix(compaction): count nested toolResult block payloads in estimateTokens

### DIFF
--- a/packages/agent-core/src/harness/compaction/compaction-toolresult-tokens.test.ts
+++ b/packages/agent-core/src/harness/compaction/compaction-toolresult-tokens.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import type { AgentMessage } from "../../types.js";
 import { estimateTokens } from "./compaction.js";
+import { serializeConversation } from "./utils.js";
 
 const TOOL_OUTPUT = "x".repeat(4000);
 
@@ -8,7 +9,7 @@ const TOOL_OUTPUT = "x".repeat(4000);
 // content block carrying the payload in both `text` and `content` (see
 // extensions/codex/src/app-server/event-projector.ts#createToolResultMessage),
 // rather than as a plain "text" block.
-function codexToolResult(timestamp: number): AgentMessage {
+function codexToolResult(timestamp: number, payload: string = TOOL_OUTPUT): AgentMessage {
   return {
     role: "toolResult",
     toolCallId: "call-1",
@@ -21,8 +22,8 @@ function codexToolResult(timestamp: number): AgentMessage {
         name: "exec",
         toolName: "exec",
         toolCallId: "call-1",
-        content: TOOL_OUTPUT,
-        text: TOOL_OUTPUT,
+        content: payload,
+        text: payload,
       },
     ],
     timestamp,
@@ -44,5 +45,17 @@ describe("estimateTokens tool-result accounting", () => {
     // Payload lives in both `text` and `content`; it must be counted once, so
     // the estimate matches an equivalent plain-text message rather than double.
     expect(tokens).toBe(estimateTokens(userText(TOOL_OUTPUT, 1)));
+  });
+
+  it("renders nested toolResult payloads into the summarization prompt", () => {
+    // The estimator counting these blocks means compaction can drop them, so the
+    // summary prompt must also include their payload or that history is lost
+    // (issue #99375). Serialize a short codex-shaped tool result (under the
+    // summary truncation cap) and assert the payload survives, exactly once.
+    const marker = "codex-tool-output-marker";
+    const serialized = serializeConversation([codexToolResult(1, marker)]);
+
+    expect(serialized).toContain(marker);
+    expect(serialized.split(marker).length - 1).toBe(1);
   });
 });

--- a/packages/agent-core/src/harness/compaction/compaction-toolresult-tokens.test.ts
+++ b/packages/agent-core/src/harness/compaction/compaction-toolresult-tokens.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "vitest";
+import type { AgentMessage } from "../../types.js";
+import { estimateTokens } from "./compaction.js";
+
+const TOOL_OUTPUT = "x".repeat(4000);
+
+// The codex app-server runtime persists tool results as a nested "toolResult"
+// content block carrying the payload in both `text` and `content` (see
+// extensions/codex/src/app-server/event-projector.ts#createToolResultMessage),
+// rather than as a plain "text" block.
+function codexToolResult(timestamp: number): AgentMessage {
+  return {
+    role: "toolResult",
+    toolCallId: "call-1",
+    toolName: "exec",
+    isError: false,
+    content: [
+      {
+        type: "toolResult",
+        id: "call-1",
+        name: "exec",
+        toolName: "exec",
+        toolCallId: "call-1",
+        content: TOOL_OUTPUT,
+        text: TOOL_OUTPUT,
+      },
+    ],
+    timestamp,
+  } as unknown as AgentMessage;
+}
+
+function userText(text: string, timestamp: number): AgentMessage {
+  return { role: "user", content: [{ type: "text", text }], timestamp };
+}
+
+describe("estimateTokens tool-result accounting", () => {
+  it("counts nested toolResult block payloads instead of estimating zero", () => {
+    // Regression for #99375: nested "toolResult" blocks used to be ignored by
+    // the char counter, so tool-heavy sessions estimated ~0 tokens and the
+    // compaction cut point collapsed to the first message (permanent no-op).
+    const tokens = estimateTokens(codexToolResult(1));
+
+    expect(tokens).toBeGreaterThan(0);
+    // Payload lives in both `text` and `content`; it must be counted once, so
+    // the estimate matches an equivalent plain-text message rather than double.
+    expect(tokens).toBe(estimateTokens(userText(TOOL_OUTPUT, 1)));
+  });
+});

--- a/packages/agent-core/src/harness/compaction/compaction.ts
+++ b/packages/agent-core/src/harness/compaction/compaction.ts
@@ -246,13 +246,29 @@ export function shouldCompact(
 
 const IMAGE_BLOCK_CHARS = 4800;
 
-function countContentBlockChars(content: Array<{ type: string; text?: string }>): number {
+function countContentBlockChars(
+  content: Array<{ type: string; text?: string; content?: unknown }>,
+): number {
   let chars = 0;
   for (const block of content) {
     if (block.type === "text" && block.text) {
       chars += block.text.length;
     } else if (block.type === "image") {
       chars += IMAGE_BLOCK_CHARS;
+    } else if (block.type === "toolResult") {
+      // Some runtimes (e.g. the codex app-server) persist tool results as nested
+      // "toolResult" blocks that carry their payload in `text`/`content` rather
+      // than a plain "text" block. Count that payload so tool-heavy sessions are
+      // not estimated at ~0 tokens, which collapses the compaction cut point and
+      // makes compaction a permanent no-op (issue #99375). Prefer `text` and only
+      // fall back to `content` so the same payload is not counted twice.
+      if (typeof block.text === "string" && block.text.length > 0) {
+        chars += block.text.length;
+      } else if (typeof block.content === "string") {
+        chars += block.content.length;
+      } else if (Array.isArray(block.content)) {
+        chars += countContentBlockChars(block.content as Array<{ type: string; text?: string }>);
+      }
     }
   }
   return chars;

--- a/packages/agent-core/src/harness/compaction/utils.ts
+++ b/packages/agent-core/src/harness/compaction/utils.ts
@@ -109,6 +109,35 @@ function truncateForSummary(text: string, maxChars: number): string {
   return `${text.slice(0, maxChars)}\n\n[... ${truncatedChars} more characters truncated]`;
 }
 
+/**
+ * Extract tool-result text for the summarization prompt. Mirrors the token
+ * estimator in compaction.ts: besides plain "text" blocks, render the payload of
+ * nested "toolResult" blocks (used by runtimes like the codex app-server, which
+ * store it in `text`/`content`). Without this the summary would omit tool output
+ * that compaction is about to drop, losing that history (issue #99375).
+ */
+function extractToolResultSummaryText(
+  content: Array<{ type: string; text?: string; content?: unknown }>,
+): string {
+  const parts: string[] = [];
+  for (const block of content) {
+    if (block.type === "text" && typeof block.text === "string") {
+      parts.push(block.text);
+    } else if (block.type === "toolResult") {
+      if (typeof block.text === "string" && block.text.length > 0) {
+        parts.push(block.text);
+      } else if (typeof block.content === "string") {
+        parts.push(block.content);
+      } else if (Array.isArray(block.content)) {
+        parts.push(
+          extractToolResultSummaryText(block.content as Array<{ type: string; text?: string }>),
+        );
+      }
+    }
+  }
+  return parts.join("");
+}
+
 /** Serialize LLM messages to plain text for summarization prompts. */
 export function serializeConversation(messages: Message[]): string {
   const parts: string[] = [];
@@ -154,10 +183,7 @@ export function serializeConversation(messages: Message[]): string {
         parts.push(`[Assistant tool calls]: ${toolCalls.join("; ")}`);
       }
     } else if (msg.role === "toolResult") {
-      const content = msg.content
-        .filter((c): c is { type: "text"; text: string } => c.type === "text")
-        .map((c) => c.text)
-        .join("");
+      const content = extractToolResultSummaryText(msg.content);
       if (content) {
         parts.push(`[Tool result]: ${truncateForSummary(content, TOOL_RESULT_MAX_CHARS)}`);
       }


### PR DESCRIPTION
## What Problem This Solves

On tool-heavy sessions, compaction becomes a permanent no-op and the safeguard
hook fires indefinitely (reported in #99375, likely the root cause of #90639).

`countContentBlockChars` in `packages/agent-core/src/harness/compaction/compaction.ts`
only counts blocks of `type: "text"` or `"image"`. Runtimes such as the codex
app-server persist tool results as a nested `type: "toolResult"` content block that
carries its payload in `text`/`content` (see
`extensions/codex/src/app-server/event-projector.ts` → `createToolResultMessage`),
not as a plain `text` block. So `estimateTokens` returns **0** for every tool-result
message, undercounting total context 10–20× on tool-heavy sessions.

Consequence chain from the issue:

1. In `findCutPoint`, backward keep-recent accumulation never reaches
   `keepRecentTokens` (everything estimates ~0), so the cut collapses to the first
   user message in range.
2. `prepareCompaction` then produces an empty `messagesToSummarize`.
3. The compaction-safeguard hook summarizes the whole branch but writes
   `firstKeptEntryId` = the first message, so nothing is ever dropped.
4. The trigger stays true, so compaction re-fires every turn. Only a session reset
   breaks the cycle.

## Why This Change Was Made

Count the nested `toolResult` block's payload in `countContentBlockChars`, so
tool-result messages contribute their real size to the estimate. The codex shape
carries the same string in both `text` and `content`, so the fix prefers `text` and
only falls back to `content` (string or nested array) — the payload is counted once,
never doubled. Text and image blocks are untouched.

## User Impact

Tool-heavy sessions now estimate their true context size, so `findCutPoint` lands a
real cut, compaction actually drops history, and the safeguard stops re-firing every
turn. No change for sessions whose tool results already arrive as plain text/image
blocks.

## Evidence

Regression test `compaction-toolresult-tokens.test.ts` added next to the existing
`compaction-image-tokens.test.ts`: asserts a codex-shaped nested `toolResult` message
estimates `> 0` tokens and equals an equivalent plain-text message (no double count).
Fails before the fix (estimate is 0), passes after.

## Real behavior proof

**Behavior addressed:** `estimateTokens` now counts nested `toolResult` block payloads
instead of returning 0, so tool-result messages contribute their real token estimate.

**Environment tested:** Node v24.18.0 on Windows; production function invoked directly
via `node --import tsx` against the fix branch.

**Steps run after the patch:** Called the actual patched `estimateTokens` from
`packages/agent-core/src/harness/compaction/compaction.ts` on a message built to the
exact codex app-server shape, comparing before/after and against controls.

**Evidence after fix:** Before the patch, the real function returns 0 for a codex-shaped
tool result:

```text
codex toolResult estimateTokens : 0 (undercount -> 0)
```

After the patch:

```text
codex toolResult estimateTokens : 1000 (expect ~1000, was 0 before fix)
canonical text estimateTokens   : 1000 (unchanged control)
image-only toolResult           : 1200 (unchanged control)
```

Regression-test assertions checked against the production function:

```text
tokens>0: true ( 1000 )
equals plain-text (no double count): true ( 1000 vs 1000 )
ASSERTIONS PASS: true
```

**Observed result after the fix:** A 4000-char codex tool result now estimates 1000
tokens (was 0); the payload present in both `text` and `content` is counted once; text
and image controls are unchanged.

**Not tested:** A full live compaction cycle on a running gateway (safeguard firing →
cut point → history drop) was not exercised; verification was against the production
token-estimation function that gates the cut point.

Closes #99375
