### PR TITLE
fix(auto-reply): restore per-turn message-tool delivery contract

### DIFF
--- a/src/agents/system-prompt.test.ts
+++ b/src/agents/system-prompt.test.ts
@@ -1104,7 +1104,7 @@ describe("buildAgentSystemPrompt", () => {
       );
       expect(prompt).not.toContain("Attach media: `MEDIA:<path-or-url>`");
       expect(prompt).toContain(
-        "Group/channel etiquette: message-tool-only delivery does not require visible output",
+        "Group/channel etiquette: for stale threads, jokes, lightweight acknowledgements, or low-value chatter, prefer a reaction when available or no channel message; when a visible reply is warranted, use `message(action=send)` because final text stays private.",
       );
       expect(prompt).toContain("The target defaults to the current source channel");
       expect(prompt).toContain("do not repeat that visible content in your final answer");
@@ -1131,7 +1131,7 @@ describe("buildAgentSystemPrompt", () => {
 
     expect(prompt).toContain("include `target` and `message`; `target` is required for this turn");
     expect(prompt).toContain(
-      "Group/channel etiquette: message-tool-only delivery does not require visible output",
+      "Group/channel etiquette: for stale threads, jokes, lightweight acknowledgements, or low-value chatter, prefer a reaction when available or no channel message; when a visible reply is warranted, use `message(action=send)` because final text stays private.",
     );
     expect(prompt).not.toContain("The target defaults to the current source channel");
   });

--- a/src/agents/system-prompt.ts
+++ b/src/agents/system-prompt.ts
@@ -538,7 +538,7 @@ function buildMessagingSection(params: {
           "### message tool",
           "- Use `message` for proactive sends + channel actions (polls, reactions, etc.).",
           groupMessageToolOnly
-            ? "- Group/channel etiquette: message-tool-only delivery does not require visible output. For stale threads, jokes, lightweight acknowledgements, or low-value chatter, prefer a reaction when available or no channel message; post only when you have concrete value to add."
+            ? "- Group/channel etiquette: for stale threads, jokes, lightweight acknowledgements, or low-value chatter, prefer a reaction when available or no channel message; when a visible reply is warranted, use `message(action=send)` because final text stays private."
             : "",
           messageToolOnly
             ? params.requireExplicitMessageTarget

--- a/src/auto-reply/reply/get-reply-run.media-only.test.ts
+++ b/src/auto-reply/reply/get-reply-run.media-only.test.ts
@@ -10,6 +10,7 @@ import {
 } from "../../agents/embedded-agent-runner/runs.js";
 import type { SessionEntry } from "../../config/sessions.js";
 import { HEARTBEAT_RUN_SCOPE } from "../../infra/heartbeat-run-scope.js";
+import { MESSAGE_TOOL_ONLY_DELIVERY_HINT } from "../../plugin-sdk/message-tool-delivery-hints.js";
 import { createReplyOperation } from "./reply-run-registry.js";
 
 vi.mock("../../agents/auth-profiles/session-override.js", () => ({
@@ -512,6 +513,56 @@ describe("runPreparedReply media-only handling", () => {
       },
       expect.anything(),
     );
+  });
+
+  it("keeps addressed message-tool delivery hints out of persisted transcript rows", async () => {
+    vi.mocked(buildInboundUserContextPrefix).mockReturnValueOnce(
+      "Current message:\nchat_id=-100123\ninbound_event_kind: user_request",
+    );
+
+    await runPreparedReply(
+      baseParams({
+        opts: { sourceReplyDeliveryMode: "message_tool_only" },
+        ctx: {
+          Body: "@bot please answer here",
+          RawBody: "@bot please answer here",
+          CommandBody: "please answer here",
+          OriginatingChannel: "telegram",
+          OriginatingTo: "-100123",
+          ChatType: "group",
+        },
+        sessionCtx: {
+          Body: "@bot please answer here",
+          BodyStripped: "please answer here",
+          Provider: "telegram",
+          OriginatingChannel: "telegram",
+          OriginatingTo: "-100123",
+          ChatType: "group",
+          InboundEventKind: "user_request",
+        },
+      }),
+    );
+
+    const call = requireLastRunReplyAgentCall();
+    expect(call.commandBody).toBe("please answer here");
+    expect(call.transcriptCommandBody).toBe("please answer here");
+    expect(call.followupRun.prompt).toBe("please answer here");
+    expect(call.followupRun.transcriptPrompt).toBe("please answer here");
+    expect(call.followupRun.currentInboundContext?.text).toBe(
+      [
+        "Current message:\nchat_id=-100123\ninbound_event_kind: user_request",
+        MESSAGE_TOOL_ONLY_DELIVERY_HINT,
+      ].join("\n\n"),
+    );
+    const persistedUserMessage = call.followupRun.userTurnTranscriptRecorder?.message;
+    if (!persistedUserMessage) {
+      throw new Error("persisted user turn message missing");
+    }
+    expect(persistedUserMessage).toMatchObject({
+      role: "user",
+      content: "please answer here",
+    });
+    expect(persistedUserMessage.content).not.toContain(MESSAGE_TOOL_ONLY_DELIVERY_HINT);
   });
 
   it.each(["direct", "dm"] as const)(

--- a/src/auto-reply/reply/prompt-prelude.test.ts
+++ b/src/auto-reply/reply/prompt-prelude.test.ts
@@ -1,7 +1,12 @@
 // Tests prompt prelude construction for sender, routing, and context metadata.
 import { describe, expect, it } from "vitest";
+import { MESSAGE_TOOL_ONLY_DELIVERY_HINT } from "../../plugin-sdk/message-tool-delivery-hints.js";
 import { finalizeInboundContext } from "./inbound-context.js";
 import { buildReplyPromptEnvelope } from "./prompt-prelude.js";
+
+function countOccurrences(text: string | undefined, needle: string): number {
+  return (text?.split(needle).length ?? 1) - 1;
+}
 
 describe("buildReplyPromptEnvelope", () => {
   it("keeps bare reset runtime context in the model prompt and out of transcript/current-turn context", () => {
@@ -57,6 +62,64 @@ describe("buildReplyPromptEnvelope", () => {
       promptJoiner: " ",
     });
   });
+
+  it("adds one message-tool delivery hint to user-request runtime context only", () => {
+    const sessionCtx = finalizeInboundContext({
+      Body: "@bot what changed?",
+      BodyStripped: "what changed?",
+      Provider: "telegram",
+      ChatType: "group",
+      InboundEventKind: "user_request",
+    });
+
+    const envelope = buildReplyPromptEnvelope({
+      ctx: sessionCtx,
+      sessionCtx,
+      baseBody: "what changed?",
+      prefixedBody: "what changed?",
+      hasUserBody: true,
+      inboundUserContext: "Current message:\nchat_id=-100123",
+      isBareSessionReset: false,
+      startupAction: "new",
+      inboundEventKind: "user_request",
+      sourceReplyDeliveryMode: "message_tool_only",
+    });
+
+    expect(
+      countOccurrences(envelope.currentInboundContext?.text, MESSAGE_TOOL_ONLY_DELIVERY_HINT),
+    ).toBe(1);
+    expect(envelope.prefixedCommandBody).toBe("what changed?");
+    expect(envelope.transcriptCommandBody).toBe("what changed?");
+    expect(envelope.transcriptCommandBody).not.toContain(MESSAGE_TOOL_ONLY_DELIVERY_HINT);
+  });
+
+  it.each([undefined, "automatic"] as const)(
+    "omits user-request delivery hints for %s delivery",
+    (sourceReplyDeliveryMode) => {
+      const sessionCtx = finalizeInboundContext({
+        Body: "@bot what changed?",
+        BodyStripped: "what changed?",
+        Provider: "telegram",
+        ChatType: "group",
+        InboundEventKind: "user_request",
+      });
+
+      const envelope = buildReplyPromptEnvelope({
+        ctx: sessionCtx,
+        sessionCtx,
+        baseBody: "what changed?",
+        prefixedBody: "what changed?",
+        hasUserBody: true,
+        inboundUserContext: "Current message:\nchat_id=-100123",
+        isBareSessionReset: false,
+        startupAction: "new",
+        inboundEventKind: "user_request",
+        sourceReplyDeliveryMode,
+      });
+
+      expect(envelope.currentInboundContext?.text).not.toContain(MESSAGE_TOOL_ONLY_DELIVERY_HINT);
+    },
+  );
 
   it("projects room events as context instead of user requests", () => {
     const sessionCtx = finalizeInboundContext({

--- a/src/auto-reply/reply/prompt-prelude.ts
+++ b/src/auto-reply/reply/prompt-prelude.ts
@@ -2,6 +2,7 @@
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import type { CurrentInboundPromptContext } from "../../agents/embedded-agent-runner/run/params.js";
 import type { InboundEventKind } from "../../channels/inbound-event/kind.js";
+import { MESSAGE_TOOL_ONLY_DELIVERY_HINT } from "../../plugin-sdk/message-tool-delivery-hints.js";
 import { annotateInterSessionPromptText } from "../../sessions/input-provenance.js";
 import type { SourceReplyDeliveryMode } from "../get-reply-options.types.js";
 import { HEARTBEAT_TRANSCRIPT_PROMPT } from "../heartbeat.js";
@@ -147,13 +148,28 @@ function resolveRoomEventTranscriptBody(params: ReplyPromptEnvelopeBaseParams): 
   );
 }
 
+function resolvePerTurnDeliveryDirective(params: {
+  inboundEventKind?: InboundEventKind;
+  sourceReplyDeliveryMode?: SourceReplyDeliveryMode;
+}): string | undefined {
+  if (params.inboundEventKind === "room_event") {
+    return params.sourceReplyDeliveryMode === "message_tool_only"
+      ? "Treat this as observed room activity. Default: no reply; most room events need no response from you. Send a visible reply via message(action=send) only when you are directly addressed or have concrete value to add; your final text here stays private either way."
+      : "Treat this as observed room activity. Default: no reply; most room events need no response from you. Reply only when you are directly addressed or have concrete value to add.";
+  }
+  if (
+    params.inboundEventKind === "user_request" &&
+    params.sourceReplyDeliveryMode === "message_tool_only"
+  ) {
+    return MESSAGE_TOOL_ONLY_DELIVERY_HINT;
+  }
+  return undefined;
+}
+
 function buildRoomEventContext(params: ReplyPromptEnvelopeBaseParams, roomContext: string): string {
   const roomEventBody = resolveRoomEventTranscriptBody(params);
   const roomContextBlock = roomContext.trim() ? `Room context:\n${roomContext.trim()}` : "";
-  const deliveryDirective =
-    params.sourceReplyDeliveryMode === "message_tool_only"
-      ? "Treat this as observed room activity. Default: no reply; most room events need no response from you. Send a visible reply via message(action=send) only when you are directly addressed or have concrete value to add; your final text here stays private either way."
-      : "Treat this as observed room activity. Default: no reply; most room events need no response from you. Reply only when you are directly addressed or have concrete value to add.";
+  const deliveryDirective = resolvePerTurnDeliveryDirective(params);
   return [
     "[OpenClaw room event]",
     "inbound_event_kind: room_event",
@@ -186,7 +202,13 @@ export function buildReplyPromptEnvelopeBase(
   const resumableRoomEventContext = isRoomEvent
     ? buildRoomEventContext(params, buildResumableRoomContext(inboundUserContext))
     : undefined;
-  const currentInboundContextText = isRoomEvent ? roomEventContext : inboundUserContext;
+  const userRequestDeliveryDirective = resolvePerTurnDeliveryDirective({
+    inboundEventKind: params.inboundEventKind,
+    sourceReplyDeliveryMode: params.sourceReplyDeliveryMode,
+  });
+  const currentInboundContextText = isRoomEvent
+    ? roomEventContext
+    : [inboundUserContext, userRequestDeliveryDirective].filter(Boolean).join("\n\n");
   const resetModelBody = params.isBareSessionReset
     ? [
         params.inboundUserContext,


### PR DESCRIPTION
## What Problem This Solves

Fixes #99371. Under `message_tool_only` delivery, directly addressed turns carried no per-turn delivery contract after 63cbb350566 removed the inbound delivery hint as duplication: the only remaining statement was one line buried in the appended system prompt (for CLI backends, ~line 595 of a ~54KB appended section behind the harness's own system prompt). In production this swallowed visible replies: the model composed answers as plain final text, `source-reply/private-final` kept them private, and ~25 consecutive addressed turns delivered nothing. Success was only intermittent — resumed CLI sessions with a prior in-context `message` tool call kept working; fresh sessions coin-flipped. The generalized group etiquette line ("message-tool-only delivery does not require visible output … prefer no channel message", e08102820e0) compounded it by reading as license to answer privately.

Room-event turns were unaffected because they already carry a per-turn delivery directive. The asymmetry was the bug.

## Why This Change Was Made

- One owner now decides the per-turn delivery directive for all turn kinds: `resolvePerTurnDeliveryDirective(inboundEventKind, sourceReplyDeliveryMode)` in `src/auto-reply/reply/prompt-prelude.ts`. Room-event wording is moved verbatim (test-pinned, byte-identical); `user_request` + `message_tool_only` appends the existing `MESSAGE_TOOL_ONLY_DELIVERY_HINT` constant to the runtime-only inbound context, adjacent to the current message. Other delivery modes get no directive.
- Exactly one emission per turn: nothing returns to `buildInboundUserContextPrefix`, and the pre-63cbb350566 3-5x duplication does not come back. The hint constant is already a recognized `strip-inbound-meta` sentinel, so replayed shipped transcripts keep stripping with zero stripper changes, and the persisted transcript row for the turn stays bare (proven by regression test: `currentInboundContext` carries the hint, the transcript row does not).
- The group etiquette line keeps its reaction/silence guidance but closes the private-answer loophole: when a visible reply is warranted, `message(action=send)` is the path because final text stays private.

## User Impact

`message_tool_only` deployments (Telegram/Discord group bots) reliably deliver replies to direct mentions again, on both fresh and resumed CLI sessions. Ambient room-event behavior (default-silent, #99144) is unchanged.

## Evidence

- Fail-confirmed regressions: prompt-prelude asserts exactly one hint occurrence for `user_request`+`message_tool_only` and zero for other modes (reverted fix: `expected +0 to be 1`); get-reply-run asserts the hint in `currentInboundContext` with a bare transcript row (reverted fix: hint missing); existing `strip-inbound-meta` test covers replayed-row stripping.
- Live provenance: captured raw claude-cli turn input from the affected deployment shows the addressed envelope with zero delivery instruction while the system prompt carried the contract — confirming the per-turn line is load-bearing for CLI backends.
- `node scripts/run-vitest.mjs` (system-prompt, prompt-prelude, get-reply-run.media-only, strip-inbound-meta), `pnpm tsgo`, `pnpm check:test-types`, scoped oxlint, `pnpm prompt:snapshots:check`: exit 0.
- Blacksmith Testbox `check:changed` on the rebased branch: exit 0 (run `tbx_01kwk9dvqegybpsvbfdhw5fd5q`).
- Prod LOC: `prompt-prelude.ts +27/-5`, `system-prompt.ts +1/-1`; the rest is tests.
