### PR TITLE
fix(compaction): count nested tool result content

### DIFF
--- a/packages/agent-core/src/harness/compaction/compaction-trailing-toolresult.test.ts
+++ b/packages/agent-core/src/harness/compaction/compaction-trailing-toolresult.test.ts
@@ -41,18 +41,19 @@ function toolResultText(text: string, timestamp: number): AgentMessage {
   };
 }
 
-function codexToolResultText(text: string, timestamp: number): AgentMessage {
+function nestedToolResult(
+  block: { type: string; content?: unknown; text?: string },
+  timestamp: number,
+): AgentMessage {
   return {
     role: "toolResult",
     toolCallId: "call-1",
     toolName: "codex_progress",
     content: [
       {
-        type: "toolResult",
         id: "call-1",
         toolUseId: "call-1",
-        content: text,
-        text,
+        ...block,
       },
     ],
     isError: false,
@@ -101,15 +102,20 @@ describe("findCutPoint with a trailing oversized tool result", () => {
     expect(result.firstKeptEntryIndex).toBe(3);
   });
 
-  it("counts Codex nested toolResult block content", () => {
-    const trailing = codexToolResultText(LARGE_TOOL_OUTPUT, 5);
+  it.each([
+    {
+      name: "Codex toolResult text",
+      block: { type: "toolResult", content: "duplicate", text: LARGE_TOOL_OUTPUT },
+    },
+    {
+      name: "snake-case tool_result content",
+      block: { type: "tool_result", content: LARGE_TOOL_OUTPUT },
+    },
+  ])("counts and trims the prefix for $name", ({ block }) => {
+    const trailing = nestedToolResult(block, 5);
+    const entries = buildTranscriptWithToolResult(trailing);
 
     expect(estimateTokens(trailing)).toBeGreaterThanOrEqual(KEEP_RECENT_TOKENS);
-  });
-
-  it("trims the prefix for Codex nested toolResult block content", () => {
-    const entries = buildTranscriptWithToolResult(codexToolResultText(LARGE_TOOL_OUTPUT, 5));
-
     const result = findCutPoint(entries, 0, entries.length, KEEP_RECENT_TOKENS);
 
     expect(result.firstKeptEntryIndex).toBeGreaterThan(0);

--- a/packages/agent-core/src/harness/compaction/compaction-trailing-toolresult.test.ts
+++ b/packages/agent-core/src/harness/compaction/compaction-trailing-toolresult.test.ts
@@ -41,6 +41,25 @@ function toolResultText(text: string, timestamp: number): AgentMessage {
   };
 }
 
+function codexToolResultText(text: string, timestamp: number): AgentMessage {
+  return {
+    role: "toolResult",
+    toolCallId: "call-1",
+    toolName: "codex_progress",
+    content: [
+      {
+        type: "toolResult",
+        id: "call-1",
+        toolUseId: "call-1",
+        content: text,
+        text,
+      },
+    ],
+    isError: false,
+    timestamp,
+  } as unknown as AgentMessage;
+}
+
 function messageEntry(message: AgentMessage, index: number): SessionTreeEntry {
   return {
     type: "message",
@@ -52,12 +71,16 @@ function messageEntry(message: AgentMessage, index: number): SessionTreeEntry {
 }
 
 function buildTranscript(): SessionTreeEntry[] {
+  return buildTranscriptWithToolResult(toolResultText(LARGE_TOOL_OUTPUT, 5));
+}
+
+function buildTranscriptWithToolResult(toolResult: AgentMessage): SessionTreeEntry[] {
   const messages: AgentMessage[] = [
     userText("start of the conversation", 1),
     assistantText("first reply", 2),
     userText("please run the command", 3),
     assistantText("running it now", 4),
-    toolResultText(LARGE_TOOL_OUTPUT, 5),
+    toolResult,
   ];
   return messages.map((message, index) => messageEntry(message, index));
 }
@@ -71,6 +94,21 @@ describe("findCutPoint with a trailing oversized tool result", () => {
 
   it("trims the prefix instead of keeping the whole transcript", () => {
     const entries = buildTranscript();
+
+    const result = findCutPoint(entries, 0, entries.length, KEEP_RECENT_TOKENS);
+
+    expect(result.firstKeptEntryIndex).toBeGreaterThan(0);
+    expect(result.firstKeptEntryIndex).toBe(3);
+  });
+
+  it("counts Codex nested toolResult block content", () => {
+    const trailing = codexToolResultText(LARGE_TOOL_OUTPUT, 5);
+
+    expect(estimateTokens(trailing)).toBeGreaterThanOrEqual(KEEP_RECENT_TOKENS);
+  });
+
+  it("trims the prefix for Codex nested toolResult block content", () => {
+    const entries = buildTranscriptWithToolResult(codexToolResultText(LARGE_TOOL_OUTPUT, 5));
 
     const result = findCutPoint(entries, 0, entries.length, KEEP_RECENT_TOKENS);
 

--- a/packages/agent-core/src/harness/compaction/compaction.ts
+++ b/packages/agent-core/src/harness/compaction/compaction.ts
@@ -37,6 +37,7 @@ import {
   extractFileOpsFromMessage,
   type FileOperations,
   formatFileOperations,
+  getCompactionContentBlockText,
   serializeConversation,
 } from "./utils.js";
 
@@ -251,16 +252,10 @@ function countContentBlockChars(
 ): number {
   let chars = 0;
   for (const block of content) {
-    if (block.type === "text" && block.text) {
-      chars += block.text.length;
-    } else if (block.type === "image") {
+    if (block.type === "image") {
       chars += IMAGE_BLOCK_CHARS;
-    } else if (block.type === "toolResult" || block.type === "tool_result") {
-      if (block.text) {
-        chars += block.text.length;
-      } else if (typeof block.content === "string") {
-        chars += block.content.length;
-      }
+    } else {
+      chars += getCompactionContentBlockText(block).length;
     }
   }
   return chars;

--- a/packages/agent-core/src/harness/compaction/compaction.ts
+++ b/packages/agent-core/src/harness/compaction/compaction.ts
@@ -246,13 +246,21 @@ export function shouldCompact(
 
 const IMAGE_BLOCK_CHARS = 4800;
 
-function countContentBlockChars(content: Array<{ type: string; text?: string }>): number {
+function countContentBlockChars(
+  content: Array<{ type: string; content?: unknown; text?: string }>,
+): number {
   let chars = 0;
   for (const block of content) {
     if (block.type === "text" && block.text) {
       chars += block.text.length;
     } else if (block.type === "image") {
       chars += IMAGE_BLOCK_CHARS;
+    } else if (block.type === "toolResult" || block.type === "tool_result") {
+      if (block.text) {
+        chars += block.text.length;
+      } else if (typeof block.content === "string") {
+        chars += block.content.length;
+      }
     }
   }
   return chars;

--- a/packages/agent-core/src/harness/compaction/utils.test.ts
+++ b/packages/agent-core/src/harness/compaction/utils.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "vitest";
+import type { Message } from "../../../../llm-core/src/index.js";
+import { serializeConversation } from "./utils.js";
+
+describe("serializeConversation", () => {
+  it.each([
+    {
+      name: "Codex nested toolResult text",
+      block: {
+        type: "toolResult",
+        id: "call-1",
+        toolUseId: "call-1",
+        content: "duplicate fallback",
+        text: "codex nested output",
+      },
+      expected: "codex nested output",
+    },
+    {
+      name: "snake-case nested tool_result content fallback",
+      block: {
+        type: "tool_result",
+        content: "fallback output",
+      },
+      expected: "fallback output",
+    },
+  ])("serializes $name", ({ block, expected }) => {
+    const messages = [
+      {
+        role: "toolResult",
+        content: [block],
+      },
+    ] as unknown as Message[];
+
+    expect(serializeConversation(messages)).toBe(`[Tool result]: ${expected}`);
+  });
+});

--- a/packages/agent-core/src/harness/compaction/utils.ts
+++ b/packages/agent-core/src/harness/compaction/utils.ts
@@ -109,7 +109,12 @@ function truncateForSummary(text: string, maxChars: number): string {
   return `${text.slice(0, maxChars)}\n\n[... ${truncatedChars} more characters truncated]`;
 }
 
-function toolResultBlockText(block: { type: string; content?: unknown; text?: string }): string {
+/** Extract text that compaction both estimates and includes in summary prompts. */
+export function getCompactionContentBlockText(block: {
+  type: string;
+  content?: unknown;
+  text?: string;
+}): string {
   if (block.type === "text" && block.text) {
     return block.text;
   }
@@ -167,7 +172,7 @@ export function serializeConversation(messages: Message[]): string {
         parts.push(`[Assistant tool calls]: ${toolCalls.join("; ")}`);
       }
     } else if (msg.role === "toolResult") {
-      const content = msg.content.map(toolResultBlockText).join("");
+      const content = msg.content.map(getCompactionContentBlockText).join("");
       if (content) {
         parts.push(`[Tool result]: ${truncateForSummary(content, TOOL_RESULT_MAX_CHARS)}`);
       }

--- a/packages/agent-core/src/harness/compaction/utils.ts
+++ b/packages/agent-core/src/harness/compaction/utils.ts
@@ -109,6 +109,19 @@ function truncateForSummary(text: string, maxChars: number): string {
   return `${text.slice(0, maxChars)}\n\n[... ${truncatedChars} more characters truncated]`;
 }
 
+function toolResultBlockText(block: { type: string; content?: unknown; text?: string }): string {
+  if (block.type === "text" && block.text) {
+    return block.text;
+  }
+  if (block.type !== "toolResult" && block.type !== "tool_result") {
+    return "";
+  }
+  if (block.text) {
+    return block.text;
+  }
+  return typeof block.content === "string" ? block.content : "";
+}
+
 /** Serialize LLM messages to plain text for summarization prompts. */
 export function serializeConversation(messages: Message[]): string {
   const parts: string[] = [];
@@ -154,10 +167,7 @@ export function serializeConversation(messages: Message[]): string {
         parts.push(`[Assistant tool calls]: ${toolCalls.join("; ")}`);
       }
     } else if (msg.role === "toolResult") {
-      const content = msg.content
-        .filter((c): c is { type: "text"; text: string } => c.type === "text")
-        .map((c) => c.text)
-        .join("");
+      const content = msg.content.map(toolResultBlockText).join("");
       if (content) {
         parts.push(`[Tool result]: ${truncateForSummary(content, TOOL_RESULT_MAX_CHARS)}`);
       }


### PR DESCRIPTION
## What Problem This Solves

Fixes #99375.

Fixes an issue where users in tool-heavy Codex sessions could see compaction repeatedly retain the full transcript when recent context was dominated by Codex tool-result blocks. Those blocks were preserved in transcript content as nested `toolResult` payloads, but the compaction estimator did not count their text, so the cut point could collapse back to the start of the transcript.

## Why This Change Was Made

The shared compaction estimator now counts nested `toolResult`/`tool_result` text payloads in the same content-block pass that already accounts for text and image blocks. The compaction summary serializer now preserves the same nested tool-result payloads exactly once before summarized history is dropped, using `text` first and falling back to string `content` only when `text` is absent.

Dependency contract checked against OpenAI Codex protocol sources in sibling `../codex`: `codex-rs/protocol/src/items.rs` for tool-call/result item shapes and `codex-rs/protocol/src/dynamic_tools.rs` for dynamic tool output content items.

## User Impact

Tool-heavy Codex conversations can choose a real compaction cut point instead of no-oping when the newest retained transcript contains nested tool-result output. When older Codex tool-result output is compacted into the replacement summary, that payload remains available to the summarizer instead of being silently omitted.

## Evidence

- Red first: `node scripts/run-vitest.mjs packages/agent-core/src/harness/compaction/compaction-trailing-toolresult.test.ts` failed before the estimator implementation because the new nested `toolResult` case estimated `0` tokens and retained entry index `0`.
- Red first for review fix: `node scripts/run-vitest.mjs packages/agent-core/src/harness/compaction/utils.test.ts` failed before the serializer implementation because `serializeConversation` returned an empty string for Codex nested `toolResult` content.
- Runtime compaction proof with `prepareCompaction` + `compact` fake stream captured the actual summarization prompt:

```json
{
  "firstKeptEntryId": "entry-3",
  "summarizedRoles": ["user", "assistant", "toolResult"],
  "summarizedToolPayloadChars": 120039,
  "promptContainsMarker": true,
  "markerOccurrencesInPrompt": 1,
  "compactOk": true,
  "summary": "summary from captured prompt"
}
```

- `node scripts/run-vitest.mjs packages/agent-core/src/harness/compaction/utils.test.ts packages/agent-core/src/harness/compaction/compaction.test.ts packages/agent-core/src/harness/compaction/compaction-trailing-toolresult.test.ts packages/agent-core/src/harness/compaction/compaction-image-tokens.test.ts src/agents/embedded-agent-runner/transcript-file-state.test.ts` (5 files, 35 tests passed)
- `pnpm tsgo:core`
- `pnpm tsgo:core:test`
- `pnpm exec oxfmt --check packages/agent-core/src/harness/compaction/utils.ts packages/agent-core/src/harness/compaction/utils.test.ts packages/agent-core/src/harness/compaction/compaction.ts packages/agent-core/src/harness/compaction/compaction-trailing-toolresult.test.ts`
- `git diff --check`

Known local proof gap: `node scripts/run-vitest.mjs extensions/codex/src/app-server/run-attempt.context-engine.test.ts` was attempted earlier, but this local Windows worktree does not have the `codex-context-test-sandbox` backend registered. The run failed before exercising this compaction change, with `turn/start` not observed and an unhandled sandbox backend registration error.