### PR TITLE
fix(discord): deliver text fallback when media send fails

### DIFF
--- a/extensions/discord/src/send.outbound.ts
+++ b/extensions/discord/src/send.outbound.ts
@@ -98,6 +98,17 @@ function resolveDiscordSuppressEmbeds(params: {
   return params.override ?? params.configured ?? true;
 }
 
+function isDiscordOversizedMediaError(err: unknown): boolean {
+  if (!err || typeof err !== "object") return false;
+  const status =
+    "status" in err
+      ? (err as { status?: unknown }).status
+      : "statusCode" in err
+        ? (err as { statusCode?: unknown }).statusCode
+        : undefined;
+  return status === 413;
+}
+
 /** Discord thread names are capped at 100 characters. */
 const DISCORD_THREAD_NAME_LIMIT = 100;
 
@@ -358,13 +369,30 @@ export async function sendMessageDiscord(
       );
     }
   } catch (err) {
-    throw await buildDiscordSendError(err, {
-      channelId,
-      cfg,
-      rest,
-      token,
-      hasMedia: Boolean(opts.mediaUrl),
-    });
+    if (opts.mediaUrl && isDiscordOversizedMediaError(err) && textWithMentions.trim()) {
+      result = await sendDiscordText(
+        rest,
+        channelId,
+        textWithMentions,
+        opts.replyTo,
+        request,
+        maxLinesPerMessage,
+        opts.components,
+        opts.embeds,
+        chunkMode,
+        opts.silent,
+        suppressEmbeds,
+        textLimit,
+      );
+    } else {
+      throw await buildDiscordSendError(err, {
+        channelId,
+        cfg,
+        rest,
+        token,
+        hasMedia: Boolean(opts.mediaUrl),
+      });
+    }
   }
 
   recordChannelActivity({

--- a/extensions/discord/src/send.outbound.ts
+++ b/extensions/discord/src/send.outbound.ts
@@ -99,14 +99,23 @@ function resolveDiscordSuppressEmbeds(params: {
 }
 
 function isDiscordOversizedMediaError(err: unknown): boolean {
-  if (!err || typeof err !== "object") return false;
-  const status =
-    "status" in err
-      ? (err as { status?: unknown }).status
-      : "statusCode" in err
-        ? (err as { statusCode?: unknown }).statusCode
-        : undefined;
-  return status === 413;
+  if (!err || typeof err !== "object") {
+    return false;
+  }
+  const obj = err as Record<string, unknown>;
+  if (obj.status === 413 || obj.statusCode === 413) {
+    return true;
+  }
+  if (obj.code === 40005) {
+    return true;
+  }
+  if (obj.rawError && typeof obj.rawError === "object") {
+    const raw = obj.rawError as Record<string, unknown>;
+    if (raw.code === 40005) {
+      return true;
+    }
+  }
+  return false;
 }
 
 /** Discord thread names are capped at 100 characters. */

--- a/extensions/discord/src/send.outbound.ts
+++ b/extensions/discord/src/send.outbound.ts
@@ -358,7 +358,7 @@ export async function sendMessageDiscord(
       );
     }
   } catch (err) {
-    if (opts.mediaUrl && textWithMentions.trim()) {
+    if (opts.mediaUrl && !result && textWithMentions.trim()) {
       result = await sendDiscordText(
         rest,
         channelId,

--- a/extensions/discord/src/send.outbound.ts
+++ b/extensions/discord/src/send.outbound.ts
@@ -319,6 +319,7 @@ export async function sendMessageDiscord(
   }
 
   let result: DiscordChannelMessageResult | undefined;
+  let mediaFallback = false;
   try {
     if (opts.mediaUrl) {
       result = await sendDiscordMedia(
@@ -359,6 +360,7 @@ export async function sendMessageDiscord(
     }
   } catch (err) {
     if (opts.mediaUrl && !result && textWithMentions.trim()) {
+      mediaFallback = true;
       result = await sendDiscordText(
         rest,
         channelId,
@@ -390,7 +392,13 @@ export async function sendMessageDiscord(
     direction: "outbound",
   });
   return toDiscordSendResult(result!, channelId, {
-    kind: opts.mediaUrl ? "media" : opts.components || opts.embeds ? "card" : "text",
+    kind: mediaFallback
+      ? "text"
+      : opts.mediaUrl
+        ? "media"
+        : opts.components || opts.embeds
+          ? "card"
+          : "text",
     replyToId: opts.replyTo,
   });
 }

--- a/extensions/discord/src/send.outbound.ts
+++ b/extensions/discord/src/send.outbound.ts
@@ -98,26 +98,6 @@ function resolveDiscordSuppressEmbeds(params: {
   return params.override ?? params.configured ?? true;
 }
 
-function isDiscordOversizedMediaError(err: unknown): boolean {
-  if (!err || typeof err !== "object") {
-    return false;
-  }
-  const obj = err as Record<string, unknown>;
-  if (obj.status === 413 || obj.statusCode === 413) {
-    return true;
-  }
-  if (obj.code === 40005) {
-    return true;
-  }
-  if (obj.rawError && typeof obj.rawError === "object") {
-    const raw = obj.rawError as Record<string, unknown>;
-    if (raw.code === 40005) {
-      return true;
-    }
-  }
-  return false;
-}
-
 /** Discord thread names are capped at 100 characters. */
 const DISCORD_THREAD_NAME_LIMIT = 100;
 
@@ -378,7 +358,7 @@ export async function sendMessageDiscord(
       );
     }
   } catch (err) {
-    if (opts.mediaUrl && isDiscordOversizedMediaError(err) && textWithMentions.trim()) {
+    if (opts.mediaUrl && textWithMentions.trim()) {
       result = await sendDiscordText(
         rest,
         channelId,

--- a/extensions/discord/src/send.outbound.ts
+++ b/extensions/discord/src/send.outbound.ts
@@ -318,7 +318,7 @@ export async function sendMessageDiscord(
     );
   }
 
-  let result: DiscordChannelMessageResult;
+  let result: DiscordChannelMessageResult | undefined;
   try {
     if (opts.mediaUrl) {
       result = await sendDiscordMedia(
@@ -389,7 +389,7 @@ export async function sendMessageDiscord(
     accountId: accountInfo.accountId,
     direction: "outbound",
   });
-  return toDiscordSendResult(result, channelId, {
+  return toDiscordSendResult(result!, channelId, {
     kind: opts.mediaUrl ? "media" : opts.components || opts.embeds ? "card" : "text",
     replyToId: opts.replyTo,
   });

--- a/extensions/discord/src/send.sends-basic-channel-messages.test.ts
+++ b/extensions/discord/src/send.sends-basic-channel-messages.test.ts
@@ -693,6 +693,25 @@ describe("sendMessageDiscord", () => {
     expectReplyReference(firstBody, "orig-123");
     expectReplyReference(secondBody, "orig-123");
   });
+
+  it("falls back to text-only send when Discord rejects oversized media (#99021)", async () => {
+    const { rest, postMock, getMock } = makeDiscordRest();
+    getMock.mockResolvedValueOnce({ type: ChannelType.GuildText });
+    const oversized = Object.assign(new Error("Request entity too large"), { status: 413 });
+    postMock
+      .mockRejectedValueOnce(oversized)
+      .mockResolvedValueOnce({ id: "fallback-1", channel_id: "789" });
+
+    const result = await sendMessageDiscord("channel:789", "song ready", {
+      rest,
+      token: "t",
+      cfg: DISCORD_TEST_CFG,
+      mediaUrl: "file:///tmp/song.mp3",
+    });
+
+    expect(postMock).toHaveBeenCalledTimes(2);
+    expect(result?.messageId).toBe("fallback-1");
+  });
 });
 
 describe("reactMessageDiscord", () => {

--- a/extensions/discord/src/send.sends-basic-channel-messages.test.ts
+++ b/extensions/discord/src/send.sends-basic-channel-messages.test.ts
@@ -712,6 +712,31 @@ describe("sendMessageDiscord", () => {
     expect(postMock).toHaveBeenCalledTimes(2);
     expect(result?.messageId).toBe("fallback-1");
   });
+
+  it("does not fallback when media succeeded but a trailing chunk fails", async () => {
+    // sendDiscordMedia sends media first, then trailing text chunks.
+    // If media succeeds but a trailing chunk fails, we must not resend the
+    // whole text — result is already set and the original error should propagate.
+    const { rest, postMock, getMock } = makeDiscordRest();
+    getMock.mockResolvedValueOnce({ type: ChannelType.GuildText });
+    const trailingError = new Error("trailing chunk network error");
+    postMock
+      .mockResolvedValueOnce({ id: "media-ok", channel_id: "789" })
+      .mockRejectedValueOnce(trailingError);
+
+    await expect(
+      sendMessageDiscord("channel:789", "text\nthat\nchunks\ninto\nmultiple\nmessages", {
+        rest,
+        token: "t",
+        cfg: DISCORD_TEST_CFG,
+        mediaUrl: "file:///tmp/song.mp3",
+        maxLinesPerMessage: 1,
+      }),
+    ).rejects.toThrow("trailing chunk network error");
+
+    // 2 calls: media (ok) + first trailing text chunk (failed)
+    expect(postMock).toHaveBeenCalledTimes(2);
+  });
 });
 
 describe("reactMessageDiscord", () => {

--- a/extensions/discord/src/send.sends-basic-channel-messages.test.ts
+++ b/extensions/discord/src/send.sends-basic-channel-messages.test.ts
@@ -711,6 +711,7 @@ describe("sendMessageDiscord", () => {
 
     expect(postMock).toHaveBeenCalledTimes(2);
     expect(result?.messageId).toBe("fallback-1");
+    expect(result?.receipt.parts[0]?.kind).toBe("text");
   });
 
   it("does not fallback when media succeeded but a trailing chunk fails", async () => {


### PR DESCRIPTION
## What Problem This Solves

When Discord rejects media (oversized attachment, aborted upload, or any delivery error), the entire reply — text AND media — is silently lost.

Closes #99021

## Root Cause / Fix

`sendMessageDiscord` had no recovery path for media errors. On media send failure with no message delivered yet (`!result`), fall back to `sendDiscordText` with the original text.  Do NOT fallback on partial success (media delivered, trailing chunk failed).

## Evidence

### Real Discord proof — text fallback works

```
pnpm openclaw message send --channel discord \
  --target "channel:1522419241314156677" \
  --message "413 fix proof — text survives after error" \
  --media /tmp/huge.zip  # 26 MB

→ ✅ Sent via Discord. Message ID: 1522490696362098799
```

### Tests

```
✓ falls back to text-only send when Discord rejects oversized media (#99021)
✓ does not fallback when media succeeded but a trailing chunk fails
```

## Change Type
- [x] Bug fix
## Scope
- [x] Discord channel (send layer)
## Security Impact
- New permissions? No · Secrets changed? No · New network calls? No