### PR TITLE
fix(cli): reject unsafe sessions tail counts

### DIFF
--- a/src/commands/sessions-tail.test.ts
+++ b/src/commands/sessions-tail.test.ts
@@ -188,6 +188,18 @@ describe("sessionsTailCommand", () => {
     expect(output).toContain("tool.result");
   });
 
+  it("rejects tail counts that exceed JavaScript safe integer precision", async () => {
+    const runtime = makeRuntime();
+
+    await sessionsTailCommand({ store: storePath, sessionKey, tail: "9007199254740992" }, runtime);
+
+    expect(runtime.error).toHaveBeenCalledWith(
+      "--tail must be a non-negative integer, for example --tail 25.",
+    );
+    expect(runtime.exit).toHaveBeenCalledWith(1);
+    expect(runtime.log).not.toHaveBeenCalled();
+  });
+
   it("uses a session trajectory pointer for relocated runtime files", async () => {
     const runtime = makeRuntime();
     const relocatedDir = path.join(tmpDir, "relocated-trajectories");

--- a/src/commands/sessions-tail.ts
+++ b/src/commands/sessions-tail.ts
@@ -14,6 +14,7 @@ import { listSessionEntries } from "../config/sessions/session-accessor.js";
 import type { SessionEntry } from "../config/sessions/types.js";
 import { resolveStoredSessionKeyForAgentStore } from "../gateway/session-store-key.js";
 import { formatErrorMessage } from "../infra/errors.js";
+import { parseStrictNonNegativeInteger } from "../infra/parse-finite-number.js";
 import { resolveAgentIdFromSessionKey } from "../routing/session-key.js";
 import type { RuntimeEnv } from "../runtime.js";
 import {
@@ -90,15 +91,7 @@ function parseTailCount(value: string | number | undefined): number | null {
   if (value === undefined) {
     return DEFAULT_TAIL_COUNT;
   }
-  if (typeof value === "number") {
-    return Number.isSafeInteger(value) && value >= 0 ? value : null;
-  }
-  const trimmed = value.trim();
-  if (!/^\d+$/.test(trimmed)) {
-    return null;
-  }
-  const parsed = Number(trimmed);
-  return Number.isSafeInteger(parsed) ? parsed : null;
+  return parseStrictNonNegativeInteger(value) ?? null;
 }
 
 function toOptionalString(value: unknown): string | undefined {

--- a/src/commands/sessions-tail.ts
+++ b/src/commands/sessions-tail.ts
@@ -91,13 +91,14 @@ function parseTailCount(value: string | number | undefined): number | null {
     return DEFAULT_TAIL_COUNT;
   }
   if (typeof value === "number") {
-    return Number.isInteger(value) && value >= 0 ? value : null;
+    return Number.isSafeInteger(value) && value >= 0 ? value : null;
   }
   const trimmed = value.trim();
   if (!/^\d+$/.test(trimmed)) {
     return null;
   }
-  return Number.parseInt(trimmed, 10);
+  const parsed = Number(trimmed);
+  return Number.isSafeInteger(parsed) ? parsed : null;
 }
 
 function toOptionalString(value: unknown): string | undefined {


### PR DESCRIPTION
<!--
Optional linked context:
Add a visible `Closes #<issue-number>` or `Related: #<issue-number>` line
below this comment.

Required PR title:
type: user-facing description
Use a parenthesized scope only when it adds clarity:
fix(auth): login redirect loops when session cookie is expired

Types: feat, fix, improve, refactor, docs, chore.
For fixes, describe the user-visible symptom and trigger:
fix: task list fails to load when user has no environments
or:
fix: add null check to task query
-->

## What Problem This Solves

Improves direct CLI validation for `openclaw sessions tail --tail` so counts larger than JavaScript can represent safely are rejected instead of being accepted after lossy numeric parsing.

This is a small direct PR because the affected behavior is a narrow command-line input validation edge case with a focused test and no new product surface.

## Why This Change Was Made

`--tail` already rejected non-numeric and negative values, but digit-only values larger than `Number.MAX_SAFE_INTEGER` still passed through parsing. The command now accepts only non-negative safe integers through the shared strict integer parser before rendering trajectory history.

## User Impact

Users get a clear validation error for unsafe `--tail` counts instead of the command proceeding with an imprecise, potentially surprising count.

## Evidence

- Claim proved: unsafe `openclaw sessions tail --tail` counts are rejected, while a safe `--tail` count still reaches the normal sessions tail command path.
- Current head proved: `55a246b3c2decc43f6b0010424476e67fa075e0c`.
- Parser-boundary follow-up: replaced the local `--tail` safe-integer parsing branch with the existing shared `parseStrictNonNegativeInteger` facade from `src/infra/parse-finite-number.ts`.
- Commands / artifacts:
  - `pnpm --silent openclaw sessions tail --tail 9007199254740992`
  - `pnpm --silent openclaw sessions tail --tail 0`
  - `node scripts/run-vitest.mjs src/commands/sessions-tail.test.ts`
  - `node_modules\.bin\oxfmt.CMD --check --threads=1 src/commands/sessions-tail.ts src/commands/sessions-tail.test.ts`
  - `git diff --check -- src/commands/sessions-tail.ts src/commands/sessions-tail.test.ts`
  - `git diff --check`
  - `git diff --check HEAD~1 HEAD`
  - `python .agents\skills\autoreview\scripts\autoreview --mode local`
- Observed result:
  - Real CLI unsafe-count proof:

    ```text
    $ pnpm --silent openclaw sessions tail --tail 9007199254740992
    --tail must be a non-negative integer, for example --tail 25.
    Exit code: 1
    ```

  - Real CLI safe-count proof:

    ```text
    $ pnpm --silent openclaw sessions tail --tail 0
    No sessions found.
    Exit code: 0
    ```

  - Focused Vitest passed: 1 test file, 11 tests.
  - Diff whitespace checks passed.
  - oxfmt reported both touched files use the correct format.
  - Current-head GitHub CI passed after the parser-boundary follow-up and rebase.
  - Fresh maintainer autoreview passed with no accepted/actionable findings (0.98 confidence).
- Not tested / proof gaps:
  - No additional live session transcript rendering fixture was created; the safe-count CLI run confirms the validator allows a safe value into the normal command path in this local profile, which currently has no sessions.
