### PR TITLE
fix(pdf): reject fractional page selections

### DIFF
--- a/src/agents/tools/pdf-tool.helpers.test.ts
+++ b/src/agents/tools/pdf-tool.helpers.test.ts
@@ -74,6 +74,11 @@ describe("parsePageRange", () => {
     expect(() => parsePageRange("abc", 20)).toThrow("Invalid page number");
   });
 
+  it("throws on fractional page numbers", () => {
+    expect(() => parsePageRange("1.5", 20)).toThrow('Invalid page number: "1.5"');
+    expect(() => parsePageRange("1,2.5", 20)).toThrow('Invalid page number: "2.5"');
+  });
+
   it("throws on invalid range (start > end)", () => {
     expect(() => parsePageRange("5-3", 20)).toThrow("Invalid page range");
   });

--- a/src/agents/tools/pdf-tool.helpers.ts
+++ b/src/agents/tools/pdf-tool.helpers.ts
@@ -65,8 +65,10 @@ export function parsePageRange(range: string, maxPages: number): number[] {
         pages.add(i);
       }
     } else {
-      const pageMatch = /^\d+$/.exec(part);
-      const num = pageMatch ? Number(pageMatch[0]) : Number.NaN;
+      if (!/^\d+$/.test(part)) {
+        throw new Error(`Invalid page number: "${part}"`);
+      }
+      const num = Number(part);
       if (!Number.isFinite(num) || num < 1) {
         throw new Error(`Invalid page number: "${part}"`);
       }

--- a/src/agents/tools/pdf-tool.helpers.ts
+++ b/src/agents/tools/pdf-tool.helpers.ts
@@ -65,7 +65,8 @@ export function parsePageRange(range: string, maxPages: number): number[] {
         pages.add(i);
       }
     } else {
-      const num = Number(part);
+      const pageMatch = /^\d+$/.exec(part);
+      const num = pageMatch ? Number(pageMatch[0]) : Number.NaN;
       if (!Number.isFinite(num) || num < 1) {
         throw new Error(`Invalid page number: "${part}"`);
       }

--- a/src/agents/tools/pdf-tool.test.ts
+++ b/src/agents/tools/pdf-tool.test.ts
@@ -568,31 +568,34 @@ describe("createPdfTool", () => {
     });
   });
 
-  it("rejects fractional page selections before fallback extraction", async () => {
-    await withTempPdfAgentDir(async (agentDir) => {
-      await stubPdfToolInfra(agentDir, {
-        provider: "openai",
-        api: "openai-responses",
-        input: ["text"],
-      });
-      const extractSpy = vi.spyOn(pdfExtractModule, "extractPdfContent").mockResolvedValue({
-        text: "Extracted content",
-        images: [],
-      });
-      const cfg = withPdfModel(OPENAI_PDF_MODEL);
-      const tool = requirePdfTool((await loadCreatePdfTool())({ config: cfg, agentDir }));
+  it.each(["1.5", "1,2.5"])(
+    "rejects fractional page selection %s before fallback extraction",
+    async (pages) => {
+      await withTempPdfAgentDir(async (agentDir) => {
+        await stubPdfToolInfra(agentDir, {
+          provider: "openai",
+          api: "openai-responses",
+          input: ["text"],
+        });
+        const extractSpy = vi.spyOn(pdfExtractModule, "extractPdfContent").mockResolvedValue({
+          text: "Extracted content",
+          images: [],
+        });
+        const cfg = withPdfModel(OPENAI_PDF_MODEL);
+        const tool = requirePdfTool((await loadCreatePdfTool())({ config: cfg, agentDir }));
 
-      await expect(
-        tool.execute("t1", {
-          prompt: "summarize",
-          pdf: "/tmp/doc.pdf",
-          pages: "1.5",
-        }),
-      ).rejects.toThrow('Invalid page number: "1.5"');
-      expect(extractSpy).not.toHaveBeenCalled();
-      expect(completeMock).not.toHaveBeenCalled();
-    });
-  });
+        await expect(
+          tool.execute("t1", {
+            prompt: "summarize",
+            pdf: "/tmp/doc.pdf",
+            pages,
+          }),
+        ).rejects.toThrow(`Invalid page number: "${pages.includes(",") ? "2.5" : pages}"`);
+        expect(extractSpy).not.toHaveBeenCalled();
+        expect(completeMock).not.toHaveBeenCalled();
+      });
+    },
+  );
 
   it("rejects password parameter for native PDF providers", async () => {
     await withTempPdfAgentDir(async (agentDir) => {

--- a/src/agents/tools/pdf-tool.test.ts
+++ b/src/agents/tools/pdf-tool.test.ts
@@ -568,11 +568,14 @@ describe("createPdfTool", () => {
     });
   });
 
-  it.each(["1.5", "1,2.5"])(
-    "rejects fractional page selection %s before fallback extraction",
-    async (pages) => {
+  it.each([
+    ["1.5", "1.5"],
+    ["1,2.5", "2.5"],
+  ])(
+    "rejects fractional page selection %s before loading or fallback extraction",
+    async (pages, invalidPage) => {
       await withTempPdfAgentDir(async (agentDir) => {
-        await stubPdfToolInfra(agentDir, {
+        const { loadSpy } = await stubPdfToolInfra(agentDir, {
           provider: "openai",
           api: "openai-responses",
           input: ["text"],
@@ -590,7 +593,8 @@ describe("createPdfTool", () => {
             pdf: "/tmp/doc.pdf",
             pages,
           }),
-        ).rejects.toThrow(`Invalid page number: "${pages.includes(",") ? "2.5" : pages}"`);
+        ).rejects.toThrow(`Invalid page number: "${invalidPage}"`);
+        expect(loadSpy).not.toHaveBeenCalled();
         expect(extractSpy).not.toHaveBeenCalled();
         expect(completeMock).not.toHaveBeenCalled();
       });

--- a/src/agents/tools/pdf-tool.test.ts
+++ b/src/agents/tools/pdf-tool.test.ts
@@ -568,6 +568,32 @@ describe("createPdfTool", () => {
     });
   });
 
+  it("rejects fractional page selections before fallback extraction", async () => {
+    await withTempPdfAgentDir(async (agentDir) => {
+      await stubPdfToolInfra(agentDir, {
+        provider: "openai",
+        api: "openai-responses",
+        input: ["text"],
+      });
+      const extractSpy = vi.spyOn(pdfExtractModule, "extractPdfContent").mockResolvedValue({
+        text: "Extracted content",
+        images: [],
+      });
+      const cfg = withPdfModel(OPENAI_PDF_MODEL);
+      const tool = requirePdfTool((await loadCreatePdfTool())({ config: cfg, agentDir }));
+
+      await expect(
+        tool.execute("t1", {
+          prompt: "summarize",
+          pdf: "/tmp/doc.pdf",
+          pages: "1.5",
+        }),
+      ).rejects.toThrow('Invalid page number: "1.5"');
+      expect(extractSpy).not.toHaveBeenCalled();
+      expect(completeMock).not.toHaveBeenCalled();
+    });
+  });
+
   it("rejects password parameter for native PDF providers", async () => {
     await withTempPdfAgentDir(async (agentDir) => {
       await stubPdfToolInfra(agentDir, { provider: "anthropic", input: ["text", "document"] });

--- a/src/agents/tools/pdf-tool.ts
+++ b/src/agents/tools/pdf-tool.ts
@@ -374,6 +374,7 @@ export function createPdfTool(options?: {
 
       // Parse page range
       const pagesRaw = normalizeOptionalString(record.pages);
+      const pageNumbers = pagesRaw ? parsePageRange(pagesRaw, configuredMaxPages) : undefined;
       const password = typeof record.password === "string" ? record.password : undefined;
 
       const pdfModelConfig =
@@ -494,8 +495,6 @@ export function createPdfTool(options?: {
             : {}),
         });
       }
-
-      const pageNumbers = pagesRaw ? parsePageRange(pagesRaw, configuredMaxPages) : undefined;
 
       const getExtractions = async (): Promise<PdfExtractedContent[]> => {
         const extractedAll: PdfExtractedContent[] = [];


### PR DESCRIPTION
Closes #99393

## What Problem This Solves

Fixes an issue where users who pass fractional PDF `pages` values, such as `1.5`, could have the PDF tool accept the input even though downstream extraction only keeps integer page numbers. In fallback extraction mode that can leave the request with no selected PDF page content instead of a clear input error.

## Why This Change Was Made

The PDF tool parser is the source-of-truth boundary for converting user `pages` text into page numbers. This change makes single-page tokens match the same positive-integer contract already used by range tokens, so fractional values fail fast as invalid page numbers before any provider or extractor path sees them.

## User Impact

Users now get an actionable `Invalid page number` error for fractional PDF page selections. Valid integer pages, ranges, sorting, deduping, max-page clamping, and the existing empty-selection error remain unchanged.

## Evidence

Current prepared head: `f3233b1c22b95fe4901ef2419e614cf108060549` (rebased onto `89f911f322c90c3e7e3ec51120686256de19b4b1`).

- Claim proved: fractional PDF page selections now reject at the shared PDF tool parser boundary before fallback extraction or model analysis can run.
- Before-fix source behavior on main: `parsePageRange("1.5", 20)` accepted the fractional token as `[1.5]`, and `parsePageRange("1,1.5", 20)` accepted `[1,1.5]`.
- After-fix helper behavior: `parsePageRange("1.5", 20)` and `parsePageRange("1,2.5", 20)` reject with `Invalid page number`.
- Real tool-boundary behavior: `createPdfTool().execute(...)` rejects `pages: "1.5"` and `pages: "1,2.5"` before media loading, extraction, or model completion. A separate exact-head runtime smoke uses a nonexistent PDF and no configured model yet still returns `Invalid page number: "1.5"`, proving parser validation runs before file/network I/O and model resolution.
- Focused validation:
  - Sanitized direct AWS Crabbox `cbx_864980d2079c` on reviewed pre-rebase head `6ef2bbecb1e64800de50851f28a60cfd56feafda`, public networking/no Tailscale/no instance profile. The later native sync only rebased the same four-file patch.
  - `pnpm test src/agents/tools/pdf-tool.helpers.test.ts src/agents/tools/pdf-tool.test.ts`: passed, 2 files / 51 tests ([run](https://crabbox.openclaw.ai/portal/runs/run_c061ea451ba5)).
  - Exact-head runtime smoke: passed ([run](https://crabbox.openclaw.ai/portal/runs/run_c9eaed8a4f8e)).
  - Fresh AutoReview on final prepared head: clean, no accepted/actionable findings; correctness 0.86.
  - Targeted `oxfmt --check` and `git diff --check`: passed.
- Final prepared-head hosted CI: every relevant check passed ([run](https://github.com/openclaw/openclaw/actions/runs/28770101689)). Native `OPENCLAW_TESTBOX=1 scripts/pr prepare-run 99399` recorded `gates_mode=hosted_exact_head` for `f3233b1c22b95fe4901ef2419e614cf108060549`.
- Competing PR note: #99403 is an open proof-positive candidate for the same issue. This PR now includes equivalent real tool-boundary proof; maintainers should choose exactly one landing candidate and should not merge both independently.
- Not tested / proof gaps:
  - No live provider API call was made because the invalid `pages` input is rejected before fallback extraction or model completion.
