### PR TITLE
fix(clickclack): wrap websocket message rejections with Error for diagnostics

### DIFF
--- a/extensions/clickclack/src/gateway.test.ts
+++ b/extensions/clickclack/src/gateway.test.ts
@@ -256,3 +256,28 @@ describe("ClickClack gateway", () => {
     });
   });
 });
+
+  it("wraps non-Error ws message rejections with the original value in the message", async () => {
+    const rejection = await new Promise<unknown>((_, reject) => {
+      Promise.resolve()
+        .then(() => {
+          throw "connection reset";
+        })
+        .catch((e: unknown) =>
+          reject(
+            e instanceof Error
+              ? e
+              : new Error(`ClickClack ws message failed: ${String(e)}`, { cause: e }),
+          ),
+        );
+    }).then(
+      (v) => ({ ok: true, value: v }),
+      (e) => ({ ok: false, error: e }),
+    );
+
+    expect(rejection.ok).toBe(false);
+    const err = rejection.ok ? undefined : (rejection.error as Error);
+    expect(err).toBeInstanceOf(Error);
+    expect(err!.message).toBe("ClickClack ws message failed: connection reset");
+    expect(err!.cause).toBe("connection reset");
+  });

--- a/extensions/clickclack/src/gateway.test.ts
+++ b/extensions/clickclack/src/gateway.test.ts
@@ -255,29 +255,41 @@ describe("ClickClack gateway", () => {
       running: false,
     });
   });
-});
 
   it("wraps non-Error ws message rejections with the original value in the message", async () => {
-    const rejection = await new Promise<unknown>((_, reject) => {
-      Promise.resolve()
-        .then(() => {
-          throw "connection reset";
-        })
-        .catch((e: unknown) =>
-          reject(
-            e instanceof Error
-              ? e
-              : new Error(`ClickClack ws message failed: ${String(e)}`, { cause: e }),
-          ),
-        );
-    }).then(
-      (v) => ({ ok: true, value: v }),
-      (e: unknown) => ({ ok: false, error: e }),
+    const socket = new FakeSocket();
+    mocks.client.websocket.mockReturnValue(socket);
+    const rejection = { code: "ECONNRESET", retryable: true };
+    mocks.resolveClickClackInboundAccess.mockRejectedValue(rejection);
+    const abort = new AbortController();
+    const ctx = createGatewayContext(abort.signal);
+    const run = startClickClackGatewayAccount(ctx);
+
+    await vi.waitFor(() => expect(mocks.client.websocket).toHaveBeenCalledTimes(1));
+
+    socket.emit(
+      "message",
+      Buffer.from(
+        JSON.stringify({
+          id: "evt-1",
+          cursor: "cursor-1",
+          type: "message.created",
+          workspace_id: "workspace-1",
+          channel_id: "chan-1",
+          seq: 2,
+          created_at: "2026-01-01T00:00:00.000Z",
+          payload: { message_id: "msg-1", author_id: "human-1" },
+        }),
+      ),
     );
 
-    expect(rejection.ok).toBe(false);
-    const err = rejection.ok ? undefined : (rejection.error as Error);
-    expect(err).toBeInstanceOf(Error);
-    expect(err!.message).toBe("ClickClack ws message failed: connection reset");
-    expect(err!.cause).toBe("connection reset");
+    await expect(run).rejects.toMatchObject({
+      message: 'ClickClack ws message failed: {"code":"ECONNRESET","retryable":true}',
+      cause: rejection,
+    });
+    expect(ctx.setStatus).toHaveBeenLastCalledWith({
+      accountId: "default",
+      running: false,
+    });
   });
+});

--- a/extensions/clickclack/src/gateway.test.ts
+++ b/extensions/clickclack/src/gateway.test.ts
@@ -272,7 +272,7 @@ describe("ClickClack gateway", () => {
         );
     }).then(
       (v) => ({ ok: true, value: v }),
-      (e) => ({ ok: false, error: e }),
+      (e: unknown) => ({ ok: false, error: e }),
     );
 
     expect(rejection.ok).toBe(false);

--- a/extensions/clickclack/src/gateway.ts
+++ b/extensions/clickclack/src/gateway.ts
@@ -206,7 +206,7 @@ export async function startClickClackGatewayAccount(
             });
           })().catch((e: unknown) =>
             reject(
-              e instanceof Error ? e : new Error("ClickClack ws message failed", { cause: e }),
+              e instanceof Error ? e : new Error(`ClickClack ws message failed: ${String(e)}`, { cause: e }),
             ),
           );
         });

--- a/extensions/clickclack/src/gateway.ts
+++ b/extensions/clickclack/src/gateway.ts
@@ -204,7 +204,7 @@ export async function startClickClackGatewayAccount(
               event,
               botUserId: account.botUserId ?? "",
             });
-          })().catch((e) =>
+          })().catch((e: unknown) =>
             reject(
               e instanceof Error ? e : new Error("ClickClack ws message failed", { cause: e }),
             ),

--- a/extensions/clickclack/src/gateway.ts
+++ b/extensions/clickclack/src/gateway.ts
@@ -204,7 +204,11 @@ export async function startClickClackGatewayAccount(
               event,
               botUserId: account.botUserId ?? "",
             });
-          })().catch(reject);
+          })().catch((e) =>
+            reject(
+              e instanceof Error ? e : new Error("ClickClack ws message failed", { cause: e }),
+            ),
+          );
         });
         socket.on("close", finishSocketCycle);
         socket.on("error", (error) => {

--- a/extensions/clickclack/src/gateway.ts
+++ b/extensions/clickclack/src/gateway.ts
@@ -3,6 +3,7 @@
  * websocket, and dispatching user messages into OpenClaw.
  */
 import type { ChannelGatewayContext } from "openclaw/plugin-sdk/channel-contract";
+import { formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
 import type { RawData } from "ws";
 import { resolveClickClackInboundAccess } from "./access.js";
 import { resolveClickClackAccount } from "./accounts.js";
@@ -206,7 +207,11 @@ export async function startClickClackGatewayAccount(
             });
           })().catch((e: unknown) =>
             reject(
-              e instanceof Error ? e : new Error(`ClickClack ws message failed: ${String(e)}`, { cause: e }),
+              e instanceof Error
+                ? e
+                : new Error(`ClickClack ws message failed: ${formatErrorMessage(e)}`, {
+                    cause: e,
+                  }),
             ),
           );
         });


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where ClickClack gateway WebSocket message handling could wrap non-`Error` async rejections with lossy stringification, reducing the diagnostic value of structured rejection values.

## Why This Change Was Made

The gateway rejection wrapper now uses `formatErrorMessage(e)` so non-`Error` values are rendered consistently with JSON-safe diagnostics while preserving the original value as the `cause`.

The regression test now drives the real `startClickClackGatewayAccount()` WebSocket `message.created` path instead of copying the local catch expression in isolation.

## User Impact

ClickClack gateway failures from structured non-`Error` rejections keep useful details in the thrown `Error` message while retaining the original rejection value for debugging.

## Evidence

- `openclaw/clickclack` dev-bootstrap service on `http://127.0.0.1:18080`: created a real workspace/channel and bot token, then drove a real HTTP message into the real ClickClack websocket `message.created` path.
- `node scripts/run-vitest.mjs extensions/clickclack/src/gateway.test.ts --reporter=verbose --testTimeout=20000 --hookTimeout=20000`: 1 file, 6 tests passed.
- `pnpm exec oxfmt --check extensions/clickclack/src/gateway.ts extensions/clickclack/src/gateway.test.ts`: passed.

```text
$ CLICKCLACK_PROOF_BASE_URL=http://127.0.0.1:18080 CLICKCLACK_PROOF_TOKEN=<redacted> CLICKCLACK_PROOF_WORKSPACE=clickclack CLICKCLACK_PROOF_CHANNEL=chn_01kwmajmznx1ewmcyv40cf0r0s node scripts/run-vitest.mjs extensions/clickclack/src/gateway.live-proof.test.ts --reporter=verbose --testTimeout=20000 --hookTimeout=20000
[test] starting test/vitest/vitest.extensions.config.ts

stdout | extensions/clickclack/src/gateway.live-proof.test.ts > ClickClack live gateway proof > wraps a structured access rejection from a real ClickClack websocket message
[proof] service=openclaw/clickclack dev-bootstrap
[proof] baseUrl=http://127.0.0.1:18080 token=redacted workspace=clickclack channel=chn_01kwmajmznx1ewmcyv40cf0r0s
[proof] emitted real HTTP message -> real websocket message.created
[proof] observed wrapped Error message="ClickClack ws message failed: {\"code\":\"ECONNRESET\",\"retryable\":true}"
[proof] cause_preserved=true running_status_cleared=true

 Test Files  1 passed (1)
      Tests  1 passed (1)
```

AI-assisted: built with Codex
