### PR TITLE
feat(cli): render claude CLI native thinking with /reasoning gating

### DIFF
--- a/src/agents/cli-output.test.ts
+++ b/src/agents/cli-output.test.ts
@@ -1053,6 +1053,401 @@ describe("createCliJsonlStreamingParser", () => {
     });
   });
 
+  it("streams thinking deltas, skips signature deltas, and dedupes the snapshot", () => {
+    const thinking: Array<{ text: string; delta: string; isReasoningSnapshot?: boolean }> = [];
+    const parser = createCliJsonlStreamingParser({
+      backend: {
+        command: "local-cli",
+        output: "jsonl",
+        jsonlDialect: "claude-stream-json",
+        sessionIdFields: ["session_id"],
+      },
+      providerId: "local-cli",
+      onAssistantDelta: () => {},
+      onThinkingDelta: (delta) => thinking.push(delta),
+    });
+
+    parser.push(
+      [
+        JSON.stringify({
+          type: "stream_event",
+          event: {
+            type: "content_block_delta",
+            index: 0,
+            delta: { type: "thinking_delta", thinking: "Let me think" },
+          },
+        }),
+        JSON.stringify({
+          type: "stream_event",
+          event: {
+            type: "content_block_delta",
+            index: 0,
+            delta: { type: "thinking_delta", thinking: " harder." },
+          },
+        }),
+        JSON.stringify({
+          type: "stream_event",
+          event: {
+            type: "content_block_delta",
+            index: 0,
+            delta: { type: "signature_delta", signature: "opaque-signature" },
+          },
+        }),
+        JSON.stringify({
+          type: "assistant",
+          message: {
+            id: "msg-1",
+            content: [
+              { type: "thinking", thinking: "Let me think harder.", signature: "opaque-signature" },
+              { type: "text", text: "Answer." },
+            ],
+          },
+        }),
+      ].join("\n"),
+    );
+    parser.finish();
+
+    expect(thinking).toEqual([
+      { text: "Let me think", delta: "Let me think", isReasoningSnapshot: true },
+      { text: "Let me think harder.", delta: " harder.", isReasoningSnapshot: true },
+    ]);
+  });
+
+  it("emits snapshot thinking blocks when no thinking deltas streamed", () => {
+    const thinking: Array<{ text: string; delta: string; isReasoningSnapshot?: boolean }> = [];
+    const parser = createCliJsonlStreamingParser({
+      backend: {
+        command: "local-cli",
+        output: "jsonl",
+        jsonlDialect: "claude-stream-json",
+        sessionIdFields: ["session_id"],
+      },
+      providerId: "local-cli",
+      onAssistantDelta: () => {},
+      onThinkingDelta: (delta) => thinking.push(delta),
+    });
+
+    parser.push(
+      JSON.stringify({
+        type: "assistant",
+        message: {
+          id: "msg-1",
+          content: [
+            { type: "thinking", thinking: "Snapshot-only reasoning.", signature: "sig" },
+            { type: "redacted_thinking", data: "opaque-blob" },
+            { type: "text", text: "Answer." },
+          ],
+        },
+      }),
+    );
+    parser.finish();
+
+    expect(thinking).toEqual([
+      {
+        text: "Snapshot-only reasoning.",
+        delta: "Snapshot-only reasoning.",
+        isReasoningSnapshot: true,
+      },
+    ]);
+  });
+
+  it("replaces per-index thinking when assistant snapshots revise non-prefix text", () => {
+    const thinking: Array<{ text: string; delta: string; isReasoningSnapshot?: boolean }> = [];
+    const parser = createCliJsonlStreamingParser({
+      backend: {
+        command: "local-cli",
+        output: "jsonl",
+        jsonlDialect: "claude-stream-json",
+        sessionIdFields: ["session_id"],
+      },
+      providerId: "local-cli",
+      onAssistantDelta: () => {},
+      onThinkingDelta: (delta) => thinking.push(delta),
+    });
+
+    parser.push(
+      [
+        JSON.stringify({
+          type: "stream_event",
+          event: {
+            type: "content_block_delta",
+            index: 0,
+            delta: { type: "thinking_delta", thinking: "rough draft" },
+          },
+        }),
+        JSON.stringify({
+          type: "assistant",
+          message: {
+            id: "msg-1",
+            content: [
+              { type: "thinking", thinking: "revised thought", signature: "sig" },
+              { type: "text", text: "Answer." },
+            ],
+          },
+        }),
+      ].join("\n"),
+    );
+    parser.finish();
+
+    expect(thinking).toEqual([
+      { text: "rough draft", delta: "rough draft", isReasoningSnapshot: true },
+      { text: "revised thought", delta: "revised thought", isReasoningSnapshot: true },
+    ]);
+  });
+
+  it("dedupes per content-block index across multiple thinking blocks", () => {
+    const thinking: Array<{ text: string; delta: string; isReasoningSnapshot?: boolean }> = [];
+    const parser = createCliJsonlStreamingParser({
+      backend: {
+        command: "local-cli",
+        output: "jsonl",
+        jsonlDialect: "claude-stream-json",
+        sessionIdFields: ["session_id"],
+      },
+      providerId: "local-cli",
+      onAssistantDelta: () => {},
+      onThinkingDelta: (delta) => thinking.push(delta),
+    });
+
+    parser.push(
+      [
+        JSON.stringify({
+          type: "stream_event",
+          event: {
+            type: "content_block_delta",
+            index: 0,
+            delta: { type: "thinking_delta", thinking: "A" },
+          },
+        }),
+        JSON.stringify({
+          type: "stream_event",
+          event: {
+            type: "content_block_delta",
+            index: 1,
+            delta: { type: "thinking_delta", thinking: "B" },
+          },
+        }),
+        JSON.stringify({
+          type: "assistant",
+          message: {
+            id: "msg-1",
+            content: [
+              { type: "thinking", thinking: "A", signature: "sig-a" },
+              { type: "thinking", thinking: "B", signature: "sig-b" },
+            ],
+          },
+        }),
+      ].join("\n"),
+    );
+    parser.finish();
+
+    // Snapshot blocks "A" (index 0) and "B" (index 1) were already streamed on
+    // their own indexes, so the snapshot must not re-emit either one.
+    expect(thinking).toEqual([
+      { text: "A", delta: "A", isReasoningSnapshot: true },
+      { text: "AB", delta: "B", isReasoningSnapshot: true },
+    ]);
+  });
+
+  it("dedupes snapshot thinking after tool-interleaved multi-block streaming", () => {
+    const thinking: Array<{ text: string; delta: string; isReasoningSnapshot?: boolean }> = [];
+    const parser = createCliJsonlStreamingParser({
+      backend: {
+        command: "local-cli",
+        output: "jsonl",
+        jsonlDialect: "claude-stream-json",
+        sessionIdFields: ["session_id"],
+      },
+      providerId: "local-cli",
+      onAssistantDelta: () => {},
+      onThinkingDelta: (delta) => thinking.push(delta),
+    });
+
+    parser.push(
+      [
+        JSON.stringify({
+          type: "stream_event",
+          event: {
+            type: "content_block_delta",
+            index: 0,
+            delta: { type: "thinking_delta", thinking: "A" },
+          },
+        }),
+        JSON.stringify({
+          type: "stream_event",
+          event: {
+            type: "content_block_start",
+            index: 1,
+            content_block: { type: "tool_use", id: "tool-1", name: "Read" },
+          },
+        }),
+        JSON.stringify({
+          type: "stream_event",
+          event: {
+            type: "content_block_delta",
+            index: 1,
+            delta: { type: "input_json_delta", partial_json: "{\"file_path\":\"x\"}" },
+          },
+        }),
+        JSON.stringify({
+          type: "stream_event",
+          event: { type: "content_block_stop", index: 1 },
+        }),
+        JSON.stringify({
+          type: "stream_event",
+          event: {
+            type: "content_block_delta",
+            index: 2,
+            delta: { type: "thinking_delta", thinking: "B" },
+          },
+        }),
+        JSON.stringify({
+          type: "assistant",
+          message: {
+            id: "msg-1",
+            content: [
+              { type: "thinking", thinking: "A", signature: "sig-a" },
+              { type: "tool_use", id: "tool-1", name: "Read", input: { file_path: "x" } },
+              { type: "thinking", thinking: "B", signature: "sig-b" },
+            ],
+          },
+        }),
+      ].join("\n"),
+    );
+    parser.finish();
+
+    expect(thinking).toEqual([
+      { text: "A", delta: "A", isReasoningSnapshot: true },
+      { text: "AB", delta: "B", isReasoningSnapshot: true },
+    ]);
+  });
+
+  it("resets per-index thinking state on a new message within the same turn (tool round-trip)", () => {
+    const thinking: Array<{ text: string; delta: string; isReasoningSnapshot?: boolean }> = [];
+    const parser = createCliJsonlStreamingParser({
+      backend: {
+        command: "local-cli",
+        output: "jsonl",
+        jsonlDialect: "claude-stream-json",
+        sessionIdFields: ["session_id"],
+      },
+      providerId: "local-cli",
+      onAssistantDelta: () => {},
+      onThinkingDelta: (delta) => thinking.push(delta),
+    });
+
+    parser.push(
+      [
+        JSON.stringify({
+          type: "stream_event",
+          event: {
+            type: "message_start",
+            message: { id: "msg-A" },
+          },
+        }),
+        JSON.stringify({
+          type: "stream_event",
+          event: {
+            type: "content_block_delta",
+            index: 0,
+            delta: { type: "thinking_delta", thinking: "Hello " },
+          },
+        }),
+        JSON.stringify({
+          type: "stream_event",
+          event: {
+            type: "content_block_delta",
+            index: 0,
+            delta: { type: "thinking_delta", thinking: "world" },
+          },
+        }),
+        JSON.stringify({
+          type: "assistant",
+          message: {
+            id: "msg-A",
+            content: [{ type: "thinking", thinking: "Hello world" }],
+          },
+        }),
+        JSON.stringify({
+          type: "stream_event",
+          event: {
+            type: "message_start",
+            message: { id: "msg-B" },
+          },
+        }),
+        JSON.stringify({
+          type: "stream_event",
+          event: {
+            type: "content_block_delta",
+            index: 0,
+            delta: { type: "thinking_delta", thinking: "New " },
+          },
+        }),
+        JSON.stringify({
+          type: "stream_event",
+          event: {
+            type: "content_block_delta",
+            index: 0,
+            delta: { type: "thinking_delta", thinking: "thought" },
+          },
+        }),
+        JSON.stringify({
+          type: "assistant",
+          message: {
+            id: "msg-B",
+            content: [{ type: "thinking", thinking: "New thought" }],
+          },
+        }),
+      ].join("\n"),
+    );
+    parser.finish();
+
+    expect(thinking).toEqual([
+      { text: "Hello ", delta: "Hello ", isReasoningSnapshot: true },
+      { text: "Hello world", delta: "world", isReasoningSnapshot: true },
+      { text: "New ", delta: "New ", isReasoningSnapshot: true },
+      { text: "New thought", delta: "thought", isReasoningSnapshot: true },
+    ]);
+  });
+
+  it("ignores thinking deltas without a numeric content-block index", () => {
+    const thinking: Array<{ text: string; delta: string; isReasoningSnapshot?: boolean }> = [];
+    const parser = createCliJsonlStreamingParser({
+      backend: {
+        command: "local-cli",
+        output: "jsonl",
+        jsonlDialect: "claude-stream-json",
+        sessionIdFields: ["session_id"],
+      },
+      providerId: "local-cli",
+      onAssistantDelta: () => {},
+      onThinkingDelta: (delta) => thinking.push(delta),
+    });
+
+    parser.push(
+      [
+        JSON.stringify({
+          type: "stream_event",
+          event: {
+            type: "content_block_delta",
+            delta: { type: "thinking_delta", thinking: "orphaned" },
+          },
+        }),
+        JSON.stringify({
+          type: "stream_event",
+          event: {
+            type: "content_block_delta",
+            index: "0",
+            delta: { type: "thinking_delta", thinking: "also orphaned" },
+          },
+        }),
+      ].join("\n"),
+    );
+    parser.finish();
+
+    expect(thinking).toEqual([]);
+  });
+
   it("streams Gemini message deltas and tool events", () => {
     const deltas: Array<{ text: string; delta: string; sessionId?: string }> = [];
     const starts: CliToolUseStartDelta[] = [];

--- a/src/agents/cli-output.ts
+++ b/src/agents/cli-output.ts
@@ -76,6 +76,13 @@ export type CliStreamJsonOutputLimits = {
   maxTurnLines: number;
 };
 
+/** Incremental thinking text emitted while parsing a streaming CLI response. */
+export type CliThinkingDelta = {
+  text: string;
+  delta: string;
+  isReasoningSnapshot?: boolean;
+};
+
 /** Tool-call start event reconstructed from CLI stream output. */
 export type CliToolUseStartDelta = {
   toolCallId: string;
@@ -778,6 +785,133 @@ function dispatchClaudeCliStreamingToolEvent(params: {
   }
 }
 
+type ThinkingTracker = {
+  currentMessageId?: string;
+  // Thinking text already streamed via thinking_delta, keyed by the Anthropic
+  // content-block index. Snapshot frames repeat streamed thinking, so each block
+  // is deduped against its own index; a single global concatenation misfires
+  // once a message carries more than one thinking block (re-emits or reorders).
+  streamedByIndex: Map<number, string>;
+  // Full thinking already emitted for the message in block order. The callback
+  // contract exposes this as the running snapshot text for downstream coalescing,
+  // so it stays a message-level concatenation, not a per-index value.
+  emittedText: string;
+};
+
+function createThinkingTracker(): ThinkingTracker {
+  return { streamedByIndex: new Map(), emittedText: "" };
+}
+
+function resetThinkingTrackerForMessage(
+  tracker: ThinkingTracker,
+  messageId: string | undefined,
+): void {
+  if (messageId && messageId === tracker.currentMessageId) {
+    return;
+  }
+  if (messageId && tracker.currentMessageId === undefined) {
+    tracker.currentMessageId = messageId;
+    return;
+  }
+  // Anthropic content-block indexes restart at 0 for each message, so a prior
+  // tool-round message's per-index thinking must not bleed into the next one.
+  tracker.streamedByIndex.clear();
+  tracker.emittedText = "";
+  tracker.currentMessageId = messageId;
+}
+
+function assembleThinkingTextByIndex(streamedByIndex: Map<number, string>): string {
+  return [...streamedByIndex.entries()]
+    .toSorted(([left], [right]) => left - right)
+    .map(([, text]) => text)
+    .join("");
+}
+
+function emitClaudeThinking(
+  tracker: ThinkingTracker,
+  index: number,
+  streamed: string,
+  delta: string,
+  onThinkingDelta: (delta: CliThinkingDelta) => void,
+): void {
+  tracker.streamedByIndex.set(index, `${streamed}${delta}`);
+  tracker.emittedText = assembleThinkingTextByIndex(tracker.streamedByIndex);
+  onThinkingDelta({ text: tracker.emittedText, delta, isReasoningSnapshot: true });
+}
+
+function dispatchClaudeCliThinking(params: {
+  backend: CliBackendConfig;
+  providerId: string;
+  parsed: Record<string, unknown>;
+  tracker: ThinkingTracker;
+  onThinkingDelta: (delta: CliThinkingDelta) => void;
+}): void {
+  if (!supportsCliJsonlToolEvents(params)) {
+    return;
+  }
+  const tracker = params.tracker;
+
+  if (params.parsed.type === "stream_event" && isRecord(params.parsed.event)) {
+    const event = params.parsed.event;
+    if (event.type === "message_start") {
+      const message = isRecord(event.message) ? event.message : undefined;
+      resetThinkingTrackerForMessage(
+        tracker,
+        typeof message?.id === "string" ? message.id : undefined,
+      );
+      return;
+    }
+    if (event.type !== "content_block_delta" || !isRecord(event.delta)) {
+      return;
+    }
+    // Thinking state is per content-block; a delta without a numeric index cannot
+    // be attributed to a block, so it is dropped rather than mixed into another.
+    if (typeof event.index !== "number") {
+      return;
+    }
+    // signature_delta carries opaque continuation material; the Claude CLI owns
+    // its own session transcript, so it never enters the thinking text lane.
+    if (event.delta.type !== "thinking_delta" || typeof event.delta.thinking !== "string") {
+      return;
+    }
+    if (!event.delta.thinking) {
+      return;
+    }
+    const streamed = tracker.streamedByIndex.get(event.index) ?? "";
+    emitClaudeThinking(
+      tracker,
+      event.index,
+      streamed,
+      event.delta.thinking,
+      params.onThinkingDelta,
+    );
+    return;
+  }
+
+  if (params.parsed.type === "assistant" && isRecord(params.parsed.message)) {
+    resetThinkingTrackerForMessage(
+      tracker,
+      typeof params.parsed.message.id === "string" ? params.parsed.message.id : undefined,
+    );
+    const content = Array.isArray(params.parsed.message.content)
+      ? params.parsed.message.content
+      : [];
+    for (const [index, block] of content.entries()) {
+      // redacted_thinking blocks are opaque provider material with no text lane.
+      if (!isRecord(block) || block.type !== "thinking" || typeof block.thinking !== "string") {
+        continue;
+      }
+      tracker.streamedByIndex.set(index, block.thinking);
+      const text = assembleThinkingTextByIndex(tracker.streamedByIndex);
+      if (text === tracker.emittedText) {
+        continue;
+      }
+      tracker.emittedText = text;
+      params.onThinkingDelta({ text, delta: block.thinking, isReasoningSnapshot: true });
+    }
+  }
+}
+
 function dispatchGeminiCliStreamingToolEvent(params: {
   backend: CliBackendConfig;
   providerId: string;
@@ -854,6 +988,7 @@ export function createCliJsonlStreamingParser(params: {
   backend: CliBackendConfig;
   providerId: string;
   onAssistantDelta: (delta: CliStreamingDelta) => void;
+  onThinkingDelta?: (delta: CliThinkingDelta) => void;
   onToolUseStart?: (delta: CliToolUseStartDelta) => void;
   onToolResult?: (delta: CliToolResultDelta) => void;
   onCommentaryText?: (text: string) => void;
@@ -874,6 +1009,7 @@ export function createCliJsonlStreamingParser(params: {
   // always has a destination; a separate enable flag let it be dropped (#92092).
   const classifyClaudeCommentary =
     Boolean(params.onCommentaryText) && supportsCliJsonlToolEvents(params);
+  const thinkingTracker = createThinkingTracker();
 
   const flushPendingClaudeAssistantText = () => {
     if (!pendingClaudeText) {
@@ -967,6 +1103,16 @@ export function createCliJsonlStreamingParser(params: {
       } else if (evt.type === "content_block_start" || evt.type === "message_stop") {
         flushPendingClaudeAssistantText();
       }
+    }
+
+    if (params.onThinkingDelta) {
+      dispatchClaudeCliThinking({
+        backend: params.backend,
+        providerId: params.providerId,
+        parsed,
+        tracker: thinkingTracker,
+        onThinkingDelta: params.onThinkingDelta,
+      });
     }
 
     if (params.onToolUseStart || params.onToolResult) {

--- a/src/agents/cli-runner/claude-live-session.ts
+++ b/src/agents/cli-runner/claude-live-session.ts
@@ -31,6 +31,7 @@ import {
   type CliOutput,
   type CliStreamJsonOutputLimits,
   type CliStreamingDelta,
+  type CliThinkingDelta,
   type CliToolResultDelta,
   type CliToolUseStartDelta,
   resolveCliStreamJsonOutputLimits,
@@ -1098,6 +1099,7 @@ function createTurn(params: {
   context: PreparedCliRunContext;
   noOutputTimeoutMs: number;
   onAssistantDelta: (delta: CliStreamingDelta) => void;
+  onThinkingDelta?: (delta: CliThinkingDelta) => void;
   onToolUseStart?: (delta: CliToolUseStartDelta) => void;
   onToolResult?: (delta: CliToolResultDelta) => void;
   onCommentaryText?: (text: string) => void;
@@ -1126,6 +1128,7 @@ function createTurn(params: {
       backend: params.context.preparedBackend.backend,
       providerId: params.context.backendResolved.id,
       onAssistantDelta: params.onAssistantDelta,
+      onThinkingDelta: params.onThinkingDelta,
       onToolUseStart: params.onToolUseStart,
       onToolResult: params.onToolResult,
       onCommentaryText: params.onCommentaryText,
@@ -1197,6 +1200,7 @@ export async function runClaudeLiveSessionTurn(params: {
   noOutputTimeoutMs: number;
   getProcessSupervisor: () => ProcessSupervisor;
   onAssistantDelta: (delta: CliStreamingDelta) => void;
+  onThinkingDelta?: (delta: CliThinkingDelta) => void;
   onToolUseStart?: (delta: CliToolUseStartDelta) => void;
   onToolResult?: (delta: CliToolResultDelta) => void;
   onCommentaryText?: (text: string) => void;
@@ -1320,6 +1324,7 @@ export async function runClaudeLiveSessionTurn(params: {
       context: params.context,
       noOutputTimeoutMs: params.noOutputTimeoutMs,
       onAssistantDelta: params.onAssistantDelta,
+      onThinkingDelta: params.onThinkingDelta,
       onToolUseStart: params.onToolUseStart,
       onToolResult: params.onToolResult,
       onCommentaryText: params.onCommentaryText,

--- a/src/agents/cli-runner/execute.ts
+++ b/src/agents/cli-runner/execute.ts
@@ -34,6 +34,7 @@ import {
   parseCliOutput,
   type CliOutput,
   type CliStreamingDelta,
+  type CliThinkingDelta,
 } from "../cli-output.js";
 import { classifyFailoverReason } from "../embedded-agent-helpers.js";
 import {
@@ -1017,6 +1018,28 @@ export async function executePreparedCliRun(
             },
           });
         };
+        // Emit-always: thinking reaches the agent-event bus and session archive
+        // like the embedded reasoning stream; /reasoning and /verbose gate only
+        // presentation. Text stays raw here to match the thinking-stream contract
+        // shared with embedded-agent-subscribe, which archives untransformed
+        // reasoning regardless of source.
+        const emitCliThinkingDelta = ({
+          text,
+          delta,
+          isReasoningSnapshot,
+        }: CliThinkingDelta) => {
+          if (text || delta) {
+            observedCliActivity = true;
+          }
+          if (!emitLiveEvents) {
+            return;
+          }
+          emitAgentEvent({
+            runId: params.runId,
+            stream: "thinking",
+            data: { text, delta, ...(isReasoningSnapshot ? { isReasoningSnapshot } : {}) },
+          });
+        };
         if (shouldUseClaudeLiveSession(context)) {
           if (!hasJsonlOutput) {
             throw new Error("Claude live session requires JSONL streaming parser");
@@ -1037,6 +1060,7 @@ export async function executePreparedCliRun(
             noOutputTimeoutMs,
             getProcessSupervisor: executeDeps.getProcessSupervisor,
             onAssistantDelta: emitCliAssistantDelta,
+            onThinkingDelta: emitCliThinkingDelta,
             onToolUseStart: emitCliToolUseStart,
             onToolResult: emitCliToolResult,
             onCommentaryText:
@@ -1064,6 +1088,7 @@ export async function executePreparedCliRun(
                 backend,
                 providerId: context.backendResolved.id,
                 onAssistantDelta: emitCliAssistantDelta,
+                onThinkingDelta: emitCliThinkingDelta,
                 onToolUseStart: emitCliToolUseStart,
                 onToolResult: emitCliToolResult,
                 onCommentaryText:

--- a/src/auto-reply/reply/agent-runner-cli-dispatch.test.ts
+++ b/src/auto-reply/reply/agent-runner-cli-dispatch.test.ts
@@ -8,6 +8,7 @@ import {
   onAgentEvent,
   resetAgentEventsForTest,
 } from "../../infra/agent-events.js";
+import type { ReasoningTextPayload } from "./agent-runner-cli-dispatch.js";
 import {
   createCliToolSummaryTracker,
   keepCliSessionBindingOnlyWhenReused,
@@ -29,6 +30,121 @@ afterEach(() => {
 });
 
 describe("runCliAgentWithLifecycle", () => {
+  it("bridges thinking events to reasoning text and dedupes identical snapshots", async () => {
+    cliDispatchState.runCliAgentMock.mockImplementationOnce(async (params: { runId: string }) => {
+      emitAgentEvent({
+        runId: params.runId,
+        stream: "thinking",
+        data: { text: "Thinking", delta: "Thinking", isReasoningSnapshot: true },
+      });
+      emitAgentEvent({
+        runId: params.runId,
+        stream: "thinking",
+        data: { text: "Thinking", delta: "", isReasoningSnapshot: true },
+      });
+      emitAgentEvent({
+        runId: params.runId,
+        stream: "thinking",
+        data: { text: "Thinking more", delta: " more", isReasoningSnapshot: true },
+      });
+      emitAgentEvent({
+        runId: params.runId,
+        stream: "assistant",
+        data: { text: "Visible answer", delta: "Visible answer" },
+      });
+      return { payloads: [{ text: "Visible answer" }], meta: { durationMs: 1 } };
+    });
+    const onReasoningText = vi.fn<(payload: ReasoningTextPayload) => Promise<void>>(
+      async () => undefined,
+    );
+
+    const result = await runCliAgentWithLifecycle({
+      runId: "run-thinking-bridge",
+      provider: "claude-cli",
+      onReasoningText,
+      runParams: {
+        sessionId: "session-1",
+        sessionFile: "/tmp/session.jsonl",
+        workspaceDir: "/tmp/workspace",
+        prompt: "hello",
+        provider: "claude-cli",
+        model: "claude",
+        thinkLevel: "high",
+        timeoutMs: 1_000,
+        runId: "run-thinking-bridge",
+      },
+    });
+
+    expect(onReasoningText).toHaveBeenCalledTimes(2);
+    expect(onReasoningText.mock.calls.map((call) => call[0])).toEqual([
+      { text: "Thinking", isReasoningSnapshot: true },
+      { text: "Thinking more", isReasoningSnapshot: true },
+    ]);
+    expect(result.payloads).toEqual([
+      { text: "Thinking more", isReasoning: true },
+      { text: "Visible answer" },
+    ]);
+  });
+
+  it("keeps durable reasoning when the CLI has no visible final answer", async () => {
+    cliDispatchState.runCliAgentMock.mockImplementationOnce(async (params: { runId: string }) => {
+      emitAgentEvent({
+        runId: params.runId,
+        stream: "thinking",
+        data: { text: "Only thinking", delta: "Only thinking", isReasoningSnapshot: true },
+      });
+      emitAgentEvent({
+        runId: params.runId,
+        stream: "thinking",
+        data: { text: "Only thinking more", delta: " more", isReasoningSnapshot: true },
+      });
+      return { payloads: [], meta: { durationMs: 1 } };
+    });
+
+    const result = await runCliAgentWithLifecycle({
+      runId: "run-thinking-without-answer",
+      provider: "claude-cli",
+      runParams: {
+        sessionId: "session-1",
+        sessionFile: "/tmp/session.jsonl",
+        workspaceDir: "/tmp/workspace",
+        prompt: "hello",
+        provider: "claude-cli",
+        model: "claude",
+        thinkLevel: "high",
+        timeoutMs: 1_000,
+        runId: "run-thinking-without-answer",
+      },
+    });
+
+    expect(result.payloads).toEqual([{ text: "Only thinking more", isReasoning: true }]);
+  });
+
+  it("does not add a durable reasoning payload when the CLI emits no thinking", async () => {
+    cliDispatchState.runCliAgentMock.mockResolvedValueOnce({
+      payloads: [{ text: "Visible answer" }],
+      meta: { durationMs: 1 },
+    } satisfies EmbeddedAgentRunResult);
+
+    const result = await runCliAgentWithLifecycle({
+      runId: "run-no-thinking",
+      provider: "claude-cli",
+      runParams: {
+        sessionId: "session-1",
+        sessionFile: "/tmp/session.jsonl",
+        workspaceDir: "/tmp/workspace",
+        prompt: "hello",
+        provider: "claude-cli",
+        model: "claude",
+        thinkLevel: "high",
+        timeoutMs: 1_000,
+        runId: "run-no-thinking",
+      },
+    });
+
+    expect(result.payloads).toEqual([{ text: "Visible answer" }]);
+  });
+
   it("keeps the captured lifecycle generation on start and terminal events", async () => {
     const events: Array<{
       stream?: string;

--- a/src/auto-reply/reply/agent-runner-cli-dispatch.ts
+++ b/src/auto-reply/reply/agent-runner-cli-dispatch.ts
@@ -1,9 +1,6 @@
 // Builds CLI runtime dispatch inputs for agent runner executions.
 import { isRecord } from "@openclaw/normalization-core/record-coerce";
-import {
-  normalizeLowercaseStringOrEmpty,
-  normalizeOptionalString,
-} from "@openclaw/normalization-core/string-coerce";
+import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import { runCliAgent } from "../../agents/cli-runner.js";
 import type { RunCliAgentParams } from "../../agents/cli-runner/types.js";
 import { clearCliSession } from "../../agents/cli-session.js";
@@ -31,14 +28,6 @@ import {
 import { FAST_MODE_AUTO_PROGRESS_KIND, type ReplyPayload } from "../reply-payload.js";
 import { formatToolAggregate } from "../tool-meta.js";
 import { resolveAgentLifecycleTerminalMetadata } from "./agent-lifecycle-terminal.js";
-
-function isClaudeCliProvider(provider: string): boolean {
-  return normalizeLowercaseStringOrEmpty(provider) === "claude-cli";
-}
-
-function shouldBridgeCliAssistantTextToReasoning(provider: string): boolean {
-  return isClaudeCliProvider(provider);
-}
 
 function createAgentEventBridge<T>(params: {
   runId: string;
@@ -116,6 +105,38 @@ function createAssistantTextBridge(params: {
       }
       lastText = text;
       return text;
+    },
+  });
+}
+
+export type ReasoningTextPayload = {
+  text: string;
+  isReasoningSnapshot?: boolean;
+};
+
+function createReasoningTextBridge(params: {
+  runId: string;
+  suppressed?: boolean;
+  deliver?: (payload: ReasoningTextPayload) => Promise<void>;
+}) {
+  let lastText: string | undefined;
+  return createAgentEventBridge({
+    runId: params.runId,
+    suppressed: params.suppressed,
+    deliver: params.deliver,
+    read: (evt) => {
+      if (evt.stream !== "thinking") {
+        return undefined;
+      }
+      const text = typeof evt.data.text === "string" ? evt.data.text : undefined;
+      if (text === undefined || text === lastText) {
+        return undefined;
+      }
+      lastText = text;
+      return {
+        text,
+        ...(evt.data.isReasoningSnapshot === true ? { isReasoningSnapshot: true } : {}),
+      };
     },
   });
 }
@@ -342,7 +363,7 @@ type RunCliAgentWithLifecycleParams = {
   onAgentRunStart?: () => void;
   suppressAssistantBridge?: boolean;
   onAssistantText?: (text: string) => Promise<void>;
-  onReasoningText?: (text: string) => Promise<void>;
+  onReasoningText?: (payload: ReasoningTextPayload) => Promise<void>;
   onToolEvent?: (payload: CliToolEventPayload) => Promise<void>;
   onCommentaryText?: (payload: CommentaryTextPayload) => Promise<void>;
   onFastModeAutoProgress?: (payload: ReplyPayload) => Promise<void>;
@@ -450,12 +471,14 @@ async function runCliAgentWithLifecycleInternal(
     suppressed: params.suppressAssistantBridge,
     deliver: params.onAssistantText,
   });
-  const reasoningBridge = createAssistantTextBridge({
+  let finalReasoningText: string | undefined;
+  const reasoningBridge = createReasoningTextBridge({
     runId: params.runId,
     suppressed: params.suppressAssistantBridge,
-    deliver: shouldBridgeCliAssistantTextToReasoning(params.provider)
-      ? params.onReasoningText
-      : undefined,
+    deliver: async (payload) => {
+      finalReasoningText = normalizeOptionalString(payload.text);
+      await params.onReasoningText?.(payload);
+    },
   });
   const toolBridge = createToolEventBridge({
     runId: params.runId,
@@ -493,6 +516,16 @@ async function runCliAgentWithLifecycleInternal(
     await stopAgentEventBridges(bridges);
 
     const cliText = normalizeOptionalString(result.payloads?.[0]?.text);
+    const durableReasoningText = normalizeOptionalString(finalReasoningText);
+    const resultWithReasoning = durableReasoningText
+      ? {
+          ...result,
+          payloads: [
+            { text: durableReasoningText, isReasoning: true },
+            ...(result.payloads ?? []),
+          ],
+        }
+      : result;
     if (cliText) {
       emitAgentEvent({
         runId: params.runId,
@@ -518,7 +551,7 @@ async function runCliAgentWithLifecycleInternal(
       });
       lifecycleTerminalEmitted = true;
     }
-    return result;
+    return resultWithReasoning;
   } catch (err) {
     await stopAgentEventBridges(bridges);
     await params.onErrorBeforeLifecycle?.(err);

--- a/src/auto-reply/reply/agent-runner-execution.test.ts
+++ b/src/auto-reply/reply/agent-runner-execution.test.ts
@@ -3246,7 +3246,7 @@ describe("runAgentTurnWithFallback", () => {
     expect(onPartialReply).not.toHaveBeenCalled();
   });
 
-  it("bridges CLI assistant agent events into onReasoningStream for live reasoning preview (opus-4-7 text_delta path)", async () => {
+  it("bridges CLI thinking agent events into onReasoningStream with the reasoning opt-in gate", async () => {
     state.isCliProviderMock.mockReturnValue(true);
     state.runWithModelFallbackMock.mockImplementationOnce(async (params: FallbackRunnerParams) => ({
       result: await params.run("claude-cli", "claude-opus-4-7"),
@@ -3260,13 +3260,18 @@ describe("runAgentTurnWithFallback", () => {
       );
       realAgentEvents.emitAgentEvent({
         runId: params.runId,
-        stream: "assistant",
-        data: { text: "Thinking", delta: "Thinking" },
+        stream: "thinking",
+        data: { text: "Thinking", delta: "Thinking", isReasoningSnapshot: true },
       });
       realAgentEvents.emitAgentEvent({
         runId: params.runId,
-        stream: "assistant",
-        data: { text: "Thinking about it", delta: " about it" },
+        stream: "thinking",
+        data: { text: "Thinking", delta: "", isReasoningSnapshot: true },
+      });
+      realAgentEvents.emitAgentEvent({
+        runId: params.runId,
+        stream: "thinking",
+        data: { text: "Thinking about it", delta: " about it", isReasoningSnapshot: true },
       });
       return { payloads: [{ text: "Thinking about it" }], meta: {} };
     });
@@ -3302,11 +3307,21 @@ describe("runAgentTurnWithFallback", () => {
       resolvedVerboseLevel: "off",
     });
 
-    const reasoningTexts = onReasoningStream.mock.calls.map((call) => call[0].text);
-    expect(reasoningTexts).toEqual(["Thinking", "Thinking about it"]);
+    expect(onReasoningStream.mock.calls.map((call) => call[0])).toEqual([
+      {
+        text: "Thinking",
+        isReasoningSnapshot: true,
+        requiresReasoningProgressOptIn: true,
+      },
+      {
+        text: "Thinking about it",
+        isReasoningSnapshot: true,
+        requiresReasoningProgressOptIn: true,
+      },
+    ]);
   });
 
-  it("does not bridge CLI assistant events to onReasoningStream when silentExpected is set", async () => {
+  it("does not bridge CLI thinking events to onReasoningStream when silentExpected is set", async () => {
     state.isCliProviderMock.mockReturnValue(true);
     state.runWithModelFallbackMock.mockImplementationOnce(async (params: FallbackRunnerParams) => ({
       result: await params.run("claude-cli", "claude-opus-4-7"),
@@ -3320,12 +3335,12 @@ describe("runAgentTurnWithFallback", () => {
       );
       realAgentEvents.emitAgentEvent({
         runId: params.runId,
-        stream: "assistant",
+        stream: "thinking",
         data: { text: "heartbeat scratch text", delta: "heartbeat scratch text" },
       });
       realAgentEvents.emitAgentEvent({
         runId: params.runId,
-        stream: "assistant",
+        stream: "thinking",
         data: { text: "NO_REPLY do not preview reasoning", delta: " do not preview reasoning" },
       });
       return { payloads: [{ text: "final" }], meta: {} };

--- a/src/auto-reply/reply/agent-runner-execution.ts
+++ b/src/auto-reply/reply/agent-runner-execution.ts
@@ -2356,9 +2356,10 @@ export async function runAgentTurnWithFallback(params: {
                     }
                     await params.opts.onPartialReply({ text: textForTyping });
                   },
-                  onReasoningText: async (text) => {
+                  onReasoningText: async ({ text, isReasoningSnapshot }) => {
                     await params.opts?.onReasoningStream?.({
                       text,
+                      ...(isReasoningSnapshot ? { isReasoningSnapshot } : {}),
                       requiresReasoningProgressOptIn: true,
                     });
                   },

--- a/src/auto-reply/reply/followup-delivery.test.ts
+++ b/src/auto-reply/reply/followup-delivery.test.ts
@@ -11,6 +11,31 @@ vi.mock("../../channels/plugins/index.js", () => ({
 const baseConfig = {} as OpenClawConfig;
 
 describe("resolveFollowupDeliveryPayloads", () => {
+  it("drops a durable reasoning payload when reasoningPayloadsEnabled is not set", () => {
+    expect(
+      resolveFollowupDeliveryPayloads({
+        cfg: baseConfig,
+        payloads: [
+          { text: "internal reasoning", isReasoning: true },
+          { text: "final answer" },
+        ],
+      }),
+    ).toEqual([{ text: "final answer" }]);
+  });
+
+  it("keeps a durable reasoning payload when reasoningPayloadsEnabled is true", () => {
+    expect(
+      resolveFollowupDeliveryPayloads({
+        cfg: baseConfig,
+        payloads: [
+          { text: "internal reasoning", isReasoning: true },
+          { text: "final answer" },
+        ],
+        reasoningPayloadsEnabled: true,
+      }),
+    ).toEqual([{ text: "internal reasoning", isReasoning: true }, { text: "final answer" }]);
+  });
+
   it("drops heartbeat ack payloads without media", () => {
     expect(
       resolveFollowupDeliveryPayloads({

--- a/src/auto-reply/reply/followup-delivery.ts
+++ b/src/auto-reply/reply/followup-delivery.ts
@@ -41,6 +41,7 @@ export function resolveFollowupDeliveryPayloads(params: {
   originatingReplyToMode?: ReplyToMode;
   originatingTo?: string;
   originatingThreadId?: string | number;
+  reasoningPayloadsEnabled?: boolean;
   sentMediaUrls?: string[];
   sentTargets?: MessagingToolSend[];
   sentTexts?: string[];
@@ -68,8 +69,11 @@ export function resolveFollowupDeliveryPayloads(params: {
         ...(accountId ? { accountId } : {}),
       }
     : undefined;
+  const deliverablePayloads = params.payloads.filter(
+    (payload) => !(payload.isReasoning === true && params.reasoningPayloadsEnabled !== true),
+  );
   const sanitizedPayloads: ReplyPayload[] = [];
-  for (const payload of params.payloads) {
+  for (const payload of deliverablePayloads) {
     const text = payload.text;
     if (!text || !text.includes("HEARTBEAT_OK")) {
       sanitizedPayloads.push(payload);

--- a/src/auto-reply/reply/followup-runner.test.ts
+++ b/src/auto-reply/reply/followup-runner.test.ts
@@ -1467,6 +1467,127 @@ describe("createFollowupRunner runtime config", () => {
     );
   });
 
+  it("does not deliver durable reasoning for a queued CLI followup when reasoning payloads are disabled", async () => {
+    const runtimeConfig: OpenClawConfig = {
+      agents: {
+        defaults: {
+          cliBackends: {
+            "claude-cli": { command: "claude" },
+          },
+          models: {
+            "anthropic/claude-opus-4-7": { agentRuntime: { id: "claude-cli" } },
+          },
+        },
+      },
+    };
+    runCliAgentMock.mockResolvedValueOnce({
+      payloads: [
+        { text: "internal reasoning", isReasoning: true },
+        { text: "final answer" },
+      ],
+      meta: {},
+    });
+    const runner = createFollowupRunner({
+      typing: createMockTypingController(),
+      typingMode: "instant",
+      sessionKey: "main",
+      defaultModel: "anthropic/claude-opus-4-7",
+      opts: { reasoningPayloadsEnabled: false },
+    });
+
+    await runner(
+      createQueuedRun({
+        originatingChannel: "telegram",
+        originatingTo: "telegram:-100123",
+        run: {
+          config: runtimeConfig,
+          provider: "anthropic",
+          model: "claude-opus-4-7",
+        },
+      }),
+    );
+
+    expect(routeReplyMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        payload: { text: "final answer" },
+      }),
+    );
+    expect(
+      routeReplyMock.mock.calls.some((call) => {
+        const payload = requireRecord(
+          requireRecord(call[0], "route reply params").payload,
+          "payload",
+        );
+        return payload.isReasoning === true;
+      }),
+    ).toBe(false);
+  });
+
+  // Resolver-level gate, not an end-to-end delivery proof: route-reply.js is
+  // mocked above (routeReplyMock), but resolveFollowupDeliveryPayloads is the
+  // REAL implementation, so this still proves the gate itself fires correctly
+  // for a queued CLI followup — the runner only forwards a reasoning payload
+  // to routing when opts.reasoningPayloadsEnabled is true. Whether the
+  // real routeReply then delivers it is a separate, pre-existing question:
+  // routeReply unconditionally suppresses isReasoning payloads on the
+  // origin-routing branch (route-reply.ts:131, shouldSuppressReasoningPayload,
+  // predates this change, shared with the embedded runner) and that
+  // suppression is intentionally out of scope here — see route-reply.test.ts.
+  it("passes the durable reasoning payload through to routing for a queued CLI followup when reasoning payloads are enabled", async () => {
+    const runtimeConfig: OpenClawConfig = {
+      agents: {
+        defaults: {
+          cliBackends: {
+            "claude-cli": { command: "claude" },
+          },
+          models: {
+            "anthropic/claude-opus-4-7": { agentRuntime: { id: "claude-cli" } },
+          },
+        },
+      },
+    };
+    runCliAgentMock.mockResolvedValueOnce({
+      payloads: [
+        { text: "internal reasoning", isReasoning: true },
+        { text: "final answer" },
+      ],
+      meta: {},
+    });
+    const runner = createFollowupRunner({
+      typing: createMockTypingController(),
+      typingMode: "instant",
+      sessionKey: "main",
+      defaultModel: "anthropic/claude-opus-4-7",
+      opts: { reasoningPayloadsEnabled: true },
+    });
+
+    await runner(
+      createQueuedRun({
+        originatingChannel: "telegram",
+        originatingTo: "telegram:-100123",
+        run: {
+          config: runtimeConfig,
+          provider: "anthropic",
+          model: "claude-opus-4-7",
+        },
+      }),
+    );
+
+    // Proves the resolver kept the reasoning payload (it survived
+    // resolveFollowupDeliveryPayloads) and the runner routed it — not that a
+    // real channel received it (routeReply is mocked; see comment above).
+    expect(routeReplyMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        payload: { text: "internal reasoning", isReasoning: true },
+      }),
+    );
+    expect(routeReplyMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        payload: { text: "final answer" },
+      }),
+    );
+  });
+
   it("keeps queued CLI tool progress quiet when verbose progress is disabled", async () => {
     const realAgentEvents = await vi.importActual<typeof import("../../infra/agent-events.js")>(
       "../../infra/agent-events.js",

--- a/src/auto-reply/reply/followup-runner.ts
+++ b/src/auto-reply/reply/followup-runner.ts
@@ -671,6 +671,7 @@ export function createFollowupRunner(params: {
           originatingChatType: queued.originatingChatType,
           originatingReplyToMode: queued.originatingReplyToMode,
           originatingTo: queued.originatingTo,
+          reasoningPayloadsEnabled: opts?.reasoningPayloadsEnabled === true,
         });
         if (noticePayloads.length === 0) {
           return;
@@ -1421,6 +1422,7 @@ export function createFollowupRunner(params: {
         originatingReplyToMode: queued.originatingReplyToMode,
         originatingTo: queued.originatingTo,
         originatingThreadId: queued.originatingThreadId,
+        reasoningPayloadsEnabled: opts?.reasoningPayloadsEnabled === true,
         sentMediaUrls: runResult.messagingToolSentMediaUrls,
         sentTargets: runResult.messagingToolSentTargets,
         sentTexts: runResult.messagingToolSentTexts,


### PR DESCRIPTION
## Summary

**Problem.** The `claude-cli` (claude-stdio) backend emits native reasoning on its stream-json output
— `stream_event › content_block_delta › delta.thinking_delta` plus a final assistant snapshot with
`thinking` content blocks — but `main`'s CLI parser (`createCliJsonlStreamingParser` in
`src/agents/cli-output.ts`) has no thinking handling at all. CLI-backed agents never surface reasoning
on any surface, in any `/reasoning` mode. Related open feature requests: #68374, #97526.

**Why now.** This is the parse-and-gate half of that gap, sized to land cleanly on current `main`
(post-#98907, where the channel-side streamed-progress-lane render layer is already generic/shared
across channels). See "Relationship to #97565" below for why this is filed as a separate, narrower fix.

**Outcome.** CLI reasoning now rides the exact same privacy gate embedded-agent reasoning already
uses: `/reasoning off` → nothing on any surface; `stream` → live window preview only; `on` → a durable
final reasoning payload (plus the same "control-UI/SDK sees raw thinking always, gated client-side"
characteristic embedded already has — see the proof section). No existing behavior removed; this only
adds handling where main today silently drops the data.

**Out of scope.** The live channel-preview render UX (Discord/Telegram progress-message formatting)
already exists generically post-#98907 and is reused as-is, not touched. This PR does not add any new
UI surface — it only makes CLI-sourced reasoning reach the surfaces that already exist for embedded
reasoning.

**Success criteria.** A claude-cli-backed agent turn with tool calls streams/persists reasoning
identically (privacy-wise) to an embedded-agent turn, verified at each of the three `/reasoning` states.

**Reviewer focus.** (1) the per-Anthropic-message reset in `cli-output.ts` (a tool round-trip within one
CLI turn starts a fresh Anthropic message with content-block indices restarting at 0 — the tracker must
not let a prior message's index-0 thinking bleed into the new one); (2) the reuse (not reimplementation)
of the existing `requiresReasoningProgressOptIn` / `reasoningPayloadsEnabled` gates — no new gate
mechanism is introduced.

## Maintainer-ready classification

- **Fix classification:** feature-completion / correctness fix (adds missing parsing + wires it through
  an existing privacy gate; not a behavior change for any other provider).
- **Root cause:** `src/agents/cli-output.ts`'s CLI stream-json parser never implemented thinking-block
  handling, so `stream:"thinking"` was never emitted for CLI-backed turns, and the CLI dispatch layer
  (`src/auto-reply/reply/agent-runner-cli-dispatch.ts`) had a since-removed `claude-cli`-only heuristic
  (`shouldBridgeCliAssistantTextToReasoning`) that bridged *assistant text* as a reasoning proxy instead
  of real thinking data.
- **Architecture / source-of-truth check:** reuses the identical mechanism embedded-agent reasoning uses
  end-to-end — same `stream:"thinking"` event shape (`{text, delta, isReasoningSnapshot}`), same
  `onReasoningStream({text, requiresReasoningProgressOptIn: true})` call contract consumed by Discord
  (`extensions/discord/src/monitor/message-handler.process.ts`) and Telegram
  (`extensions/telegram/src/bot-message-dispatch.ts`), same durable-payload shape
  (`{text, isReasoning: true}`) consumed by the universal drop gate in
  `src/auto-reply/reply/dispatch-from-config.ts` (`reply.isReasoning === true && !reasoningPayloadsEnabled`
  → drop). No new gate, no new payload shape, no channel-specific code added.
- **Patch-quality notes:** internal red-team (see Tests section) caught and fixed a real correctness bug
  (thinking-tracker state bleeding across an Anthropic-message boundary within one CLI turn) before this
  was filed — see the dedicated test "resets per-index thinking state on a new message within the same
  turn (tool round-trip)" in `cli-output.test.ts`.
- **Related-PR scan:** see below.

## Relationship to #97565

#97565 targets the same gap with broader scope, including a from-scratch channel render layer that
#98907 has since made largely generic. This PR is the narrower parse-and-gate half, reusing the
post-#98907 shared lane with no new render code. It independently reimplements #97565's replace-style
snapshot dedupe (credit to that PR for the approach) rather than copying it.

## Linked context

- Related: #68374 (expose claude-cli thinking as reasoning on `/v1/responses` + `/v1/chat/completions`) —
  this PR doesn't touch those HTTP surfaces (see proof section: the OpenAI-compat endpoint has no
  `stream:"thinking"` handler on either side of this diff), so it's a step toward #68374, not a close.
- Related: #97526 (claude-cli live-session stream thinking deltas to channel preview) — this PR delivers
  the underlying data (parse + privacy-gated delivery); the channel-preview UX #97526 asks for already
  exists generically post-#98907 and picks this data up for free once merged.
- Related (not a duplicate — see above): #97565.

## Real behavior proof (required for external PRs)

**Behavior addressed:** CLI-backed (claude-stdio) agent turns now surface native reasoning through the
standard thinking stream and durable-reasoning payload, gated by `/reasoning` off/stream/on exactly like
embedded-agent reasoning.

**Real environment tested:** An isolated gateway (`~/openclaw-p6-home`, port :19791, channels off, own
`OPENCLAW_HOME`) running an authenticated `claude-cli/claude-sonnet-4-6` agent, with a tee shim on the
real `claude` binary (v2.1.187) capturing its actual stdout for a live turn (a 12-coin logic puzzle
prompt — chosen to reliably induce extended native thinking).

**Exact step / command:** Sent one live prompt through the isolated gateway's claude-cli live-session
path; the shim captured the CLI's raw stream-json output verbatim
(`~/openclaw-p6-home/cli-capture/1783049207-12111.stdout`, 119 KB, 251 raw JSONL lines). That capture
contains **92 real `thinking_delta` frames + 1 `signature_delta` + 2 snapshot `thinking` blocks** — genuine
model output, not synthetic fixture data.

**Evidence (boundary-injection method — disclosed, see "what was not tested" below):** Rather than
re-running a full gateway→Discord/Telegram round trip for the gating differential (channel bot auth +
live posting adds environment setup without adding proof strength once the gate code itself is read
directly — see next paragraph), the SAME 92 real captured frames were fed through the actual, unmodified
production parser (`createCliJsonlStreamingParser`) and the actual, unmodified dispatch bridge
(`runCliAgentWithLifecycle` / `createReasoningTextBridge`) via the project's existing vitest mocking
harness (same pattern as `agent-runner-cli-dispatch.test.ts`), and the resulting window-stream events +
durable payload were passed through the REAL downstream gate predicates, copied verbatim with citations,
from the actual channel code:
- `extensions/discord/src/monitor/message-handler.process.ts:631-632` —
  `reasoningDurableEnabled = reasoningLevel === "on"`, `reasoningWindowEnabled = reasoningLevel === "stream"`
- `extensions/discord/src/monitor/message-handler.process.ts:1201` — window drop:
  `payload?.requiresReasoningProgressOptIn === true && !reasoningWindowEnabled`
- `src/auto-reply/reply/dispatch-from-config.ts:~3533` — durable drop:
  `reply.isReasoning === true && !reasoningPayloadsEnabled`

Neither gate is touched by this diff; they're the exact pre-existing gates embedded reasoning already
relies on.

**Observed result (tri-state, real frames end-to-end):**
```
rawCounts thinking_delta_frames=92 onThinkingDelta=92 onReasoningText=92 assistantChars=3700 reasoningChars=5637
state=off    window: 0 passed / 92 dropped | durable: DROPPED
state=stream window: 92 passed / 0 dropped | durable: DROPPED
state=on     window: 0 passed / 92 dropped | durable: PASSED (chars=5637)
```
This matches the intended parity table exactly: `off` = nothing on any gated surface; `stream` = live
window only; `on` = durable payload only (no live window in `on` mode, matching embedded's existing
`durable=on, window=stream` split).

**Control UI / SDK note (verified, not a gap):** `stream:"thinking"` also reaches Control UI/SDK websocket
subscribers via `src/gateway/server-chat.ts`, which relays the generic agent-event bus without its own
`reasoningLevel` check — this is true for embedded reasoning too (documented in
`src/agents/embedded-agent-subscribe.ts`: "the thinking stream always reaches the bus... display surfaces
... gate presentation on their side"). Control UI applies its own **client-side** gate
(`ui/src/ui/views/chat.ts:2137`: `showReasoning = props.showThinking && reasoningLevel !== "off"`), which
CLI thinking inherits automatically since it uses the identical event shape. Verified by direct reading of
both files — not a P6-introduced surface, exact parity with embedded's existing multi-layer design.

**What was not tested (superseded — see Live transport proof below):** ~~a full live gateway conversation through an actual Discord/Telegram bot~~ — now supplied. Original disclosure kept for review history: a full live gateway conversation through an actual Discord/Telegram bot with
screen-captured render output at each `/reasoning` state (the earlier, now-superseded emit-always
iteration of this branch did do a live gateway run — see the superseded commit's history — but the
gating differential proven above is at the code layer these channel renderers consume from, which is
where the actual privacy decision is made).

**Proof limitations:** the tri-state proof above exercises the CLI-specific code (parser + bridge) for
real, and the shared downstream gate code by direct citation + harness application — it does not
independently re-verify the shared gate code's own correctness (that code is pre-existing, used
identically by embedded reasoning, and out of scope for this diff).

**Before evidence:** on `main` (no `stream:"thinking"` handling in `cli-output.ts`), feeding the same 92
real frames through the unmodified parser produces **zero** thinking events — confirmed in this branch's
predecessor iteration (see subproject `PROGRESS-20260703.md`, "Step 3 — LIVE before/after proof").

**Proof pack:**
- [tristate-proof.txt](https://raw.githubusercontent.com/Marvinthebored/openclaw/proof-assets-claude-cli-thinking/claude-cli-thinking/tristate-proof.txt) — the tri-state harness output above.
- [harness-tristate.test.ts](https://raw.githubusercontent.com/Marvinthebored/openclaw/proof-assets-claude-cli-thinking/claude-cli-thinking/harness-tristate.test.ts) — the harness that feeds the 92 real captured frames through the real parser + bridge + downstream gate predicates.

**Live transport proof (Discord + Telegram, all three `/reasoning` states)** — full live gateway runs
of this branch with real `claude-cli/claude-sonnet-4-6` turns (fresh `/new` + explicit `/model` per
run, visible in-frame; full grid with per-cell notes in
[this PR comment](https://github.com/openclaw/openclaw/pull/99401#issuecomment-4876925511)):

| `/reasoning` | Discord | Telegram |
|---|---|---|
| stream (live 🧠 window → collapse, GIF) | [discord-stream.gif](https://raw.githubusercontent.com/Marvinthebored/openclaw/56cdc89e8c/claude-cli-thinking/visual/discord-stream.gif) | [telegram-stream.gif](https://raw.githubusercontent.com/Marvinthebored/openclaw/56cdc89e8c/claude-cli-thinking/visual/telegram-stream.gif) |
| on (durable 🧠 persists) | [discord-on-settled.png](https://raw.githubusercontent.com/Marvinthebored/openclaw/56cdc89e8c/claude-cli-thinking/visual/discord-on-settled.png) | [telegram-on-settled.png](https://raw.githubusercontent.com/Marvinthebored/openclaw/56cdc89e8c/claude-cli-thinking/visual/telegram-on-settled.png) |
| off (no reasoning rendered) | [discord-off-settled.png](https://raw.githubusercontent.com/Marvinthebored/openclaw/56cdc89e8c/claude-cli-thinking/visual/discord-off-settled.png) | [telegram-off-settled.png](https://raw.githubusercontent.com/Marvinthebored/openclaw/56cdc89e8c/claude-cli-thinking/visual/telegram-off-settled.png) |

Off-state turns are full-size claude-cli sessions in the gateway log (e.g. Telegram off: 23.0s, 75
raw stream-json lines — comparable to the on runs), i.e. thinking was generated upstream and
display-gated, not absent. This closes the earlier "what was not tested" item: the live
Discord/Telegram tri-state transport run is now supplied.

## Tests and validation

- `export PATH="/Users/marvin/node24/bin:$PATH"; node scripts/run-vitest.mjs src/agents/cli-output.test.ts
  src/agents/cli-runner src/auto-reply/reply/agent-runner-cli-dispatch.test.ts
  src/auto-reply/reply/agent-runner-execution.test.ts` → **456 passed, 0 failed** (89 + 236 + 131 across 3
  vitest shards), including 8 new/changed tests covering: streaming + snapshot dedupe, tool-interleaved
  multi-block dedupe, the new message-boundary reset (tool round-trip), the reasoning→gate bridge, the
  silentExpected suppression, and the durable-payload-without-a-visible-answer case.
- `OPENCLAW_BUILD_ALL_NO_PNPM=1 node scripts/build-all.mjs` → clean build, no errors.
- Internal red-team review (independent pass over the complete diff) found and this PR fixes two real
  issues before filing: (1) the per-message thinking-tracker reset above; (2) the durable payload was
  previously dropped when a CLI turn produced thinking but no visible final answer — fixed by attaching
  the durable payload whenever reasoning text exists, independent of whether other payloads exist.


---

## Update — Round 2: queued follow-up reasoning gate

The durable `{isReasoning: true}` payload synthesized for claude-cli was delivered on the queued follow-up path (`resolveFollowupDeliveryPayloads`) with no `/reasoning` gate at all, so a claude-cli queued follow-up with `/reasoning off` could leak internal reasoning to the channel as an ordinary visible message. `resolveFollowupDeliveryPayloads` now takes a `reasoningPayloadsEnabled` flag and drops `isReasoning` payloads unless it's true; `followup-runner.ts` threads the real `opts.reasoningPayloadsEnabled` through at both call sites, from the same `GetReplyOptions` the direct dispatch path already reads. **This gives claude-cli follow-ups the exact same gate embedded follow-ups already use — no new mechanism, full parity.**

Proof: [`08-followup-proof.txt`](https://raw.githubusercontent.com/Marvinthebored/openclaw/proof-assets-claude-cli-thinking/claude-cli-thinking/08-followup-proof.txt) — a queued-follow-up cell added to the tri-state harness, exercising the real `resolveFollowupDeliveryPayloads` against the actual captured claude-cli reasoning payload (5637 chars): off/stream → resolver drops it, on → resolver keeps it eligible. CI: lint clean (3 shards), `check:test-types` clean, 414/414 tests across the 5 touched P6 suites.

**Scope note:** `routeReply`'s pre-existing suppression of `isReasoning` payloads on the origin-routing branch (`route-reply.ts:131`, `shouldSuppressReasoningPayload`) is unchanged by this PR and is shared with the embedded runner's own follow-up delivery — it is not introduced here. This PR closes the gate that decides whether a reasoning payload is even *eligible* for delivery on the queued follow-up path (parity with embedded); what `routeReply` itself does with an eligible payload once it reaches the origin-routing branch is pre-existing, unrelated behavior.

