### PR TITLE
fix: reject fractional PDF page selections

### DIFF
--- a/src/agents/tools/pdf-tool.helpers.test.ts
+++ b/src/agents/tools/pdf-tool.helpers.test.ts
@@ -74,6 +74,14 @@ describe("parsePageRange", () => {
     expect(() => parsePageRange("abc", 20)).toThrow("Invalid page number");
   });
 
+  it("throws on fractional page number", () => {
+    expect(() => parsePageRange("1.5", 20)).toThrow('Invalid page number: "1.5"');
+  });
+
+  it("throws when any comma-separated page number is fractional", () => {
+    expect(() => parsePageRange("1,1.5", 20)).toThrow('Invalid page number: "1.5"');
+  });
+
   it("throws on invalid range (start > end)", () => {
     expect(() => parsePageRange("5-3", 20)).toThrow("Invalid page range");
   });

--- a/src/agents/tools/pdf-tool.helpers.ts
+++ b/src/agents/tools/pdf-tool.helpers.ts
@@ -65,6 +65,9 @@ export function parsePageRange(range: string, maxPages: number): number[] {
         pages.add(i);
       }
     } else {
+      if (!/^\d+$/.test(part)) {
+        throw new Error(`Invalid page number: "${part}"`);
+      }
       const num = Number(part);
       if (!Number.isFinite(num) || num < 1) {
         throw new Error(`Invalid page number: "${part}"`);

--- a/src/agents/tools/pdf-tool.test.ts
+++ b/src/agents/tools/pdf-tool.test.ts
@@ -568,6 +568,26 @@ describe("createPdfTool", () => {
     });
   });
 
+  it("rejects fractional pages before native PDF analysis", async () => {
+    await withTempPdfAgentDir(async (agentDir) => {
+      await stubPdfToolInfra(agentDir, { provider: "anthropic", input: ["text", "document"] });
+      const nativeSpy = vi
+        .spyOn(pdfNativeProviders, "anthropicAnalyzePdf")
+        .mockResolvedValue("native summary");
+      const cfg = withPdfModel(ANTHROPIC_PDF_MODEL);
+      const tool = requirePdfTool((await loadCreatePdfTool())({ config: cfg, agentDir }));
+
+      await expect(
+        tool.execute("t1", {
+          prompt: "summarize",
+          pdf: "/tmp/doc.pdf",
+          pages: "1.5",
+        }),
+      ).rejects.toThrow('Invalid page number: "1.5"');
+      expect(nativeSpy).not.toHaveBeenCalled();
+    });
+  });
+
   it("rejects password parameter for native PDF providers", async () => {
     await withTempPdfAgentDir(async (agentDir) => {
       await stubPdfToolInfra(agentDir, { provider: "anthropic", input: ["text", "document"] });


### PR DESCRIPTION
Closes #99393

## What Problem This Solves

Fixes an issue where users could pass fractional PDF page filters such as `pages: "1.5"` and have the value accepted by the PDF tool parser. In extraction fallback mode, that non-integer page selection could later be filtered out before extraction, which made the request continue without the page content the user asked for instead of returning a clear input error.

Authoring: AI-assisted.

## Why This Change Was Made

The PDF page parser now rejects single-page tokens unless they use integer page syntax, matching the documented 1-based page-number contract and the existing integer-only range parser. The fix stays at the shared parser boundary so invalid input is rejected before native-provider checks or extraction fallback receive page numbers.

## User Impact

Users now get an actionable `Invalid page number: "1.5"` error for fractional PDF page filters instead of a potentially misleading PDF analysis result based on no selected extracted pages.

## Evidence

Before the change, the parser accepted fractional single-page tokens on current main:

```text
node --import tsx -e 'import { parsePageRange } from "./src/agents/tools/pdf-tool.helpers.ts"; console.log(JSON.stringify(parsePageRange("1.5", 20))); console.log(JSON.stringify(parsePageRange("1,1.5", 20)));'
[1.5]
[1,1.5]
```

After the change, the same parser inputs fail at the public input boundary:

```text
1.5 Invalid page number: "1.5"
1,1.5 Invalid page number: "1.5"
```

Real PDF tool execution with `pdfModel.primary = "deepseek/deepseek-v4-pro"` and a local PDF fixture now rejects the fractional page selection before model analysis:

```text
Invalid page number: "1.5"
```

Focused validation:

```text
node scripts/run-vitest.mjs src/agents/tools/pdf-tool.helpers.test.ts
[test] passed 1 Vitest shard ... Tests 24 passed

node scripts/run-vitest.mjs src/agents/tools/pdf-tool.test.ts
[test] passed 1 Vitest shard ... Tests 27 passed

oxfmt --check --threads=1 src/agents/tools/pdf-tool.helpers.ts src/agents/tools/pdf-tool.helpers.test.ts src/agents/tools/pdf-tool.test.ts
All matched files use the correct format.

tsgo -p tsconfig.core.json --noEmit --declaration false --singleThreaded --checkers 1
passed

tsgo -p test/tsconfig/tsconfig.test.src.json --noEmit --declaration false --singleThreaded --checkers 1
passed

git diff --check
passed
```

Build/runtime smoke:

```text
node scripts/run-node.mjs --version
OpenClaw 2026.6.11
```

Live DeepSeek agent lane:

```text
node scripts/run-node.mjs qa manual --provider-mode live-frontier --model deepseek/deepseek-v4-pro --alt-model deepseek/deepseek-v4-pro ...
status: ok
model: deepseek/deepseek-v4-pro
```

The QA manual tool inventory did not expose `pdf`, so the PDF-specific behavior proof above uses the actual `createPdfTool` execution path rather than the QA manual agent surface.
