### PR TITLE
test(levenshtein): add unit tests for levenshteinDistance

### DIFF
--- a/src/shared/levenshtein-distance.test.ts
+++ b/src/shared/levenshtein-distance.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "vitest";
+import { levenshteinDistance } from "./levenshtein-distance.js";
+
+describe("levenshteinDistance", () => {
+  it("returns 0 for identical strings", () => {
+    expect(levenshteinDistance("hello", "hello")).toBe(0);
+    expect(levenshteinDistance("", "")).toBe(0);
+  });
+
+  it("returns the length of the other string when one is empty", () => {
+    expect(levenshteinDistance("", "abc")).toBe(3);
+    expect(levenshteinDistance("abc", "")).toBe(3);
+  });
+
+  it("returns 1 for a single substitution", () => {
+    expect(levenshteinDistance("cat", "bat")).toBe(1);
+    expect(levenshteinDistance("abc", "abd")).toBe(1);
+  });
+
+  it("returns 1 for a single insertion", () => {
+    expect(levenshteinDistance("cat", "cats")).toBe(1);
+  });
+
+  it("returns 1 for a single deletion", () => {
+    expect(levenshteinDistance("cats", "cat")).toBe(1);
+  });
+
+  it("computes correct distance for known examples", () => {
+    expect(levenshteinDistance("kitten", "sitting")).toBe(3);
+    expect(levenshteinDistance("saturday", "sunday")).toBe(3);
+  });
+
+  it("handles Unicode characters correctly", () => {
+    expect(levenshteinDistance("cafe", "café")).toBe(1);
+    expect(levenshteinDistance("你好", "你好吗")).toBe(1);
+  });
+});


### PR DESCRIPTION
## What Problem This Solves

The `levenshteinDistance` helper in `src/shared/levenshtein-distance.ts` implements the classic edit distance algorithm used for similarity-based suggestions in edit operations. Despite being a pure algorithmic utility with no external dependencies, it had no unit tests.

## Changes

- **`src/shared/levenshtein-distance.test.ts`** — new test file with 7 focused test cases

## Evidence

Direct behavior probe — classic algorithm, mathematically self-evident:

```text
$ node --import tsx -e "import('./src/shared/levenshtein-distance.js').then(...)"
  "hello" vs "hello" = 0
  "" vs "" = 0
  "" vs "abc" = 3
  "cat" vs "bat" = 1
  "cat" vs "cats" = 1
  "cats" vs "cat" = 1
  "kitten" vs "sitting" = 3
  "saturday" vs "sunday" = 3
  "cafe" vs "café" = 1
  "你好" vs "你好吗" = 1
```

- Pure algorithm, zero external dependencies, no auth/SDK/API
- Behavior is mathematically defined by Wagner-Fischer algorithm

## Related

N/A (self-contained test coverage improvement)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
