### PR TITLE
fix(llm): preserve structured tool result replay

### DIFF
--- a/src/agents/anthropic-transport-stream.test.ts
+++ b/src/agents/anthropic-transport-stream.test.ts
@@ -2380,6 +2380,112 @@ describe("anthropic transport stream", () => {
     expect(toolResult.is_error).toBe(false);
   });
 
+  it("serializes structured non-image blocks in tool results as JSON text", async () => {
+    await runTransportStream(
+      makeAnthropicTransportModel({ id: "claude-sonnet-4-6" }),
+      {
+        messages: [
+          {
+            role: "assistant",
+            provider: "anthropic",
+            api: "anthropic-messages",
+            model: "claude-sonnet-4-6",
+            stopReason: "toolUse",
+            timestamp: 0,
+            content: [{ type: "toolCall", id: "tool_1", name: "fetch", arguments: {} }],
+          },
+          {
+            role: "toolResult",
+            toolCallId: "tool_1",
+            content: [
+              { type: "text", text: "ok" },
+              {
+                type: "resource",
+                resource: {
+                  uri: "https://example.com/data.json",
+                  mimeType: "application/json",
+                  text: '{"key":"value"}',
+                },
+              },
+            ],
+            isError: false,
+          },
+        ],
+      } as AnthropicStreamContext,
+      {
+        apiKey: "sk-ant-api",
+      } as AnthropicStreamOptions,
+    );
+
+    const userMessage = findRecord(
+      latestAnthropicRequest().payload.messages,
+      (record) => record.role === "user",
+    );
+    const toolResult = findRecord(
+      userMessage.content,
+      (record) => record.type === "tool_result" && record.tool_use_id === "tool_1",
+    );
+    // No images → returns sanitized text string, not array
+    expect(typeof toolResult.content).toBe("string");
+    expect(toolResult.content).toContain('"type":"resource"');
+    expect(toolResult.content).toContain("ok");
+    expect(toolResult.is_error).toBe(false);
+  });
+
+  it("includes serialized structured blocks alongside images in tool results", async () => {
+    const imageData = Buffer.from("image").toString("base64");
+
+    await runTransportStream(
+      makeAnthropicTransportModel({ id: "claude-sonnet-4-6" }),
+      {
+        messages: [
+          {
+            role: "assistant",
+            provider: "anthropic",
+            api: "anthropic-messages",
+            model: "claude-sonnet-4-6",
+            stopReason: "toolUse",
+            timestamp: 0,
+            content: [{ type: "toolCall", id: "tool_1", name: "screenshot", arguments: {} }],
+          },
+          {
+            role: "toolResult",
+            toolCallId: "tool_1",
+            content: [
+              {
+                type: "resource",
+                resource: {
+                  uri: "https://example.com/data.json",
+                  mimeType: "application/json",
+                  text: '{"key":"value"}',
+                },
+              },
+              { type: "image", data: imageData, mimeType: "image/png" },
+            ],
+            isError: false,
+          },
+        ],
+      } as AnthropicStreamContext,
+      {
+        apiKey: "sk-ant-api",
+      } as AnthropicStreamOptions,
+    );
+
+    const userMessage = findRecord(
+      latestAnthropicRequest().payload.messages,
+      (record) => record.role === "user",
+    );
+    const toolResult = findRecord(
+      userMessage.content,
+      (record) => record.type === "tool_result" && record.tool_use_id === "tool_1",
+    );
+    // When images are present, content is an array
+    const textBlock = findRecord(toolResult.content, (record) => record.type === "text");
+    // Structured block should be serialized as text alongside the image
+    expect(textBlock.text).toEqual(expect.stringContaining('{"type":"resource"'));
+    expect(toolResult.is_error).toBe(false);
+  });
+
   it("cancels stalled SSE body reads when the abort signal fires mid-stream", async () => {
     const controller = new AbortController();
     const abortReason = new Error("anthropic test abort");

--- a/src/agents/anthropic-transport-stream.ts
+++ b/src/agents/anthropic-transport-stream.ts
@@ -13,6 +13,7 @@ import {
   findActiveAnthropicToolTurnAssistantIndex,
 } from "../llm/providers/anthropic-thinking-replay.js";
 import type { AnthropicOptions } from "../llm/providers/anthropic.js";
+import { extractToolResultText } from "../llm/providers/tool-result-text.js";
 import type {
   AssistantMessageDiagnostic,
   Context,
@@ -295,16 +296,16 @@ function toClaudeCodeName(name: string): string {
   return CLAUDE_CODE_TOOL_LOOKUP.get(normalizeLowercaseStringOrEmpty(name)) ?? name;
 }
 
-function convertContentBlocks(
-  content: Array<
-    { type: "text"; text: string } | { type: "image"; data: string; mimeType: string }
-  >,
-) {
-  const hasImages = content.some((item) => item.type === "image");
-  if (!hasImages) {
-    return sanitizeNonEmptyTransportPayloadText(
-      content.map((item) => ("text" in item ? item.text : "")).join("\n"),
+function convertContentBlocks(content: readonly unknown[]) {
+  const text = extractToolResultText(content);
+  const hasImages =
+    Array.isArray(content) &&
+    content.some(
+      (item) =>
+        item && typeof item === "object" && (item as Record<string, unknown>).type === "image",
     );
+  if (!hasImages) {
+    return sanitizeNonEmptyTransportPayloadText(text);
   }
   const blocks: Array<
     | { type: "text"; text: string }
@@ -313,27 +314,27 @@ function convertContentBlocks(
         source: { type: "base64"; media_type: string; data: string };
       }
   > = [];
-  let hasTextBlock = false;
-  for (const block of content) {
-    if (block.type === "text") {
-      const text = sanitizeTransportPayloadText(block.text);
-      if (text.trim().length > 0) {
-        blocks.push({ type: "text", text });
-        hasTextBlock = true;
-      }
-    } else {
-      blocks.push({
-        type: "image" as const,
-        source: {
-          type: "base64",
-          media_type: block.mimeType,
-          data: block.data,
-        },
-      });
-    }
+  if (text.trim().length > 0) {
+    blocks.push({ type: "text", text: sanitizeTransportPayloadText(text) });
+  } else {
+    blocks.push({ type: "text", text: "(see attached image)" });
   }
-  if (!hasTextBlock) {
-    return [{ type: "text", text: "(see attached image)" }, ...blocks];
+  for (const block of Array.isArray(content) ? content : []) {
+    if (!block || typeof block !== "object") {
+      continue;
+    }
+    const record = block as Record<string, unknown>;
+    if (record.type !== "image") {
+      continue;
+    }
+    blocks.push({
+      type: "image" as const,
+      source: {
+        type: "base64",
+        media_type: typeof record.mimeType === "string" ? record.mimeType : "image/png",
+        data: typeof record.data === "string" ? record.data : "",
+      },
+    });
   }
   return blocks;
 }

--- a/src/agents/embedded-agent-subscribe.tools.ts
+++ b/src/agents/embedded-agent-subscribe.tools.ts
@@ -15,6 +15,7 @@ import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { normalizeTargetForProvider } from "../infra/outbound/target-normalization.js";
 import { normalizeInteractiveReply, normalizeMessagePresentation } from "../interactive/payload.js";
 import { redactSensitiveFieldValue, redactToolPayloadText } from "../logging/redact.js";
+import { serializeStructuredToolResultBlock } from "../logging/tool-result-serialization.js";
 import { truncateUtf16Safe } from "../utils.js";
 import { collectTextContentBlocks } from "./content-blocks.js";
 import { isMessagingToolTargetEvidenceAction } from "./embedded-agent-messaging.js";
@@ -34,15 +35,6 @@ export { isToolResultError };
 const TOOL_RESULT_MAX_CHARS = 8000;
 const TOOL_ERROR_MAX_CHARS = 400;
 const TOOL_DENIAL_ERROR_CODES = ["SYSTEM_RUN_DENIED", "INVALID_REQUEST"] as const;
-const OPAQUE_STRUCTURED_RESULT_FIELDS = new Set(["encrypted_content", "encrypted_stdout"]);
-const SENSITIVE_STRUCTURED_HEADER_FIELDS = new Set([
-  "authorization",
-  "proxy-authorization",
-  "cookie",
-  "set-cookie",
-  "x-api-key",
-  "x-auth-token",
-]);
 
 function truncateToolText(text: string): string {
   if (text.length <= TOOL_RESULT_MAX_CHARS) {
@@ -178,7 +170,7 @@ export function buildToolLifecycleErrorResult(error: unknown): {
   const nodeError = readRecord(rawDetails?.nodeError);
   const gatewayCode =
     readErrorCodeField(errorRecord?.gatewayCode) ?? readErrorCodeField(errorRecord?.code);
-  const message = error instanceof Error ? error.message : String(error);
+  const message = formatLifecycleErrorMessage(error);
   return {
     details: {
       status: "error",
@@ -187,6 +179,23 @@ export function buildToolLifecycleErrorResult(error: unknown): {
       ...(nodeError ? { nodeError } : {}),
     },
   };
+}
+
+function formatLifecycleErrorMessage(error: unknown): string {
+  if (error instanceof Error) {
+    return error.message;
+  }
+  if (typeof error === "string") {
+    return error;
+  }
+  if (typeof error === "number" || typeof error === "boolean" || typeof error === "bigint") {
+    return `${error}`;
+  }
+  try {
+    return JSON.stringify(error);
+  } catch {
+    return "Unknown error";
+  }
 }
 
 function extractAggregatedErrorField(value: unknown): string | undefined {
@@ -280,89 +289,12 @@ export function sanitizeToolResult(result: unknown): unknown {
   return out;
 }
 
-function redactInlineDataUriValue(value: string): string {
-  const trimmed = value.trimStart();
-  if (!trimmed.toLowerCase().startsWith("data:")) {
-    return value;
-  }
-  return `[inline data URI: ${value.length} chars]`;
-}
-
-function carriesBinaryData(record: Record<string, unknown>): boolean {
-  const type = normalizeOptionalLowercaseString(record.type);
-  if (type === "audio" || type === "image" || type === "base64") {
-    return true;
-  }
-  const mediaType = normalizeOptionalLowercaseString(record.media_type ?? record.mimeType);
-  return (
-    mediaType?.startsWith("image/") === true ||
-    mediaType?.startsWith("audio/") === true ||
-    mediaType?.startsWith("video/") === true ||
-    mediaType === "application/pdf"
-  );
-}
-
-function sanitizeStructuredToolResultValue(
-  value: unknown,
-  key = "",
-  parentCarriesBinaryData = false,
-  seen = new WeakSet<object>(),
-): unknown {
-  if (typeof value === "string") {
-    if (SENSITIVE_STRUCTURED_HEADER_FIELDS.has(key.toLowerCase())) {
-      return "***";
-    }
-    if (key === "blob" || (key === "data" && parentCarriesBinaryData)) {
-      return `[binary omitted: ${value.length} chars]`;
-    }
-    // Claude CLI result blocks carry replay-only ciphertext that is not useful display text.
-    if (OPAQUE_STRUCTURED_RESULT_FIELDS.has(key)) {
-      return `[opaque data omitted: ${value.length} chars]`;
-    }
-    return truncateToolText(redactInlineDataUriValue(redactSensitiveFieldValue(key, value)));
-  }
-  if (typeof value === "bigint") {
-    return value.toString();
-  }
-  if (!value || typeof value !== "object") {
-    return value;
-  }
-  if (seen.has(value)) {
-    return "[Circular]";
-  }
-  seen.add(value);
-  if (Array.isArray(value)) {
-    // Keep the owning key so arrays of credentials inherit the same redaction policy.
-    return value.map((item) =>
-      sanitizeStructuredToolResultValue(item, key, parentCarriesBinaryData, seen),
-    );
-  }
-  const record = value as Record<string, unknown>;
-  const hasBinaryData = carriesBinaryData(record);
-  return Object.fromEntries(
-    Object.entries(record).map(([childKey, child]) => [
-      childKey,
-      sanitizeStructuredToolResultValue(child, childKey, hasBinaryData, seen),
-    ]),
-  );
-}
-
 function stringifyStructuredToolResultContent(block: unknown): string | undefined {
-  if (!block || typeof block !== "object") {
-    return undefined;
-  }
-  const record = block as Record<string, unknown>;
-  const type = readStringValue(record.type);
-  if (type === "text" || type === "image" || type === "image_url" || type === "audio") {
-    return undefined;
-  }
-  try {
-    const serialized = JSON.stringify(sanitizeStructuredToolResultValue(record));
-    const redacted = serialized ? redactToolPayloadText(serialized) : serialized;
-    return redacted && redacted !== "{}" ? redacted : undefined;
-  } catch {
-    return undefined;
-  }
+  return serializeStructuredToolResultBlock(block, {
+    maxChars: TOOL_RESULT_MAX_CHARS,
+    dataUriRedaction: "inline",
+    skipTypes: ["text", "image", "image_url", "audio"],
+  });
 }
 
 function resolveToolResultContentBlocks(result: object): unknown[] {

--- a/src/agents/openai-transport-stream.test.ts
+++ b/src/agents/openai-transport-stream.test.ts
@@ -5191,6 +5191,74 @@ describe("openai transport stream", () => {
     ]);
   });
 
+  it("serializes structured tool result content into Responses function_call_output text", () => {
+    const params = buildOpenAIResponsesParams(
+      {
+        id: "gpt-5.5",
+        name: "GPT-5.5",
+        api: "openai-responses",
+        provider: "openai",
+        baseUrl: "https://api.openai.com/v1",
+        reasoning: true,
+        input: ["text"],
+        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+        contextWindow: 200000,
+        maxTokens: 8192,
+      } satisfies Model<"openai-responses">,
+      {
+        systemPrompt: "system",
+        messages: [
+          {
+            role: "assistant",
+            api: "openai-responses",
+            provider: "openai",
+            model: "gpt-5.5",
+            usage: {
+              input: 0,
+              output: 0,
+              cacheRead: 0,
+              cacheWrite: 0,
+              totalTokens: 0,
+              cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+            },
+            stopReason: "toolUse",
+            timestamp: 1,
+            content: [
+              {
+                type: "toolCall",
+                id: "call_lookup",
+                name: "lookup",
+                arguments: { query: "price" },
+              },
+            ],
+          },
+          {
+            role: "toolResult",
+            toolCallId: "call_lookup",
+            toolName: "lookup",
+            content: [{ type: "json", payload: { price: 42, currency: "USD" } }],
+            isError: false,
+            timestamp: 2,
+          },
+          { role: "user", content: "continue", timestamp: 3 },
+        ],
+        tools: [],
+      } as never,
+      undefined,
+    ) as {
+      input?: Array<{ type?: string; call_id?: string; output?: unknown }>;
+    };
+
+    const output = params.input?.find((item) => item.type === "function_call_output");
+    expect(output).toBeDefined();
+    expect(output?.call_id).toBe("call_lookup");
+    const outputText = output?.output as string;
+    expect(typeof outputText).toBe("string");
+    expect(outputText).toContain("price");
+    expect(outputText).toContain("42");
+    expect(outputText).not.toBe("(see attached image)");
+  });
+
   it("omits distinct overlong Copilot Responses replay item ids when store is disabled", () => {
     const sharedToolItemPrefix = "iVec" + "A".repeat(160);
     const firstToolCallId = `call_first|${sharedToolItemPrefix}Aa`;

--- a/src/agents/openai-transport-stream.ts
+++ b/src/agents/openai-transport-stream.ts
@@ -27,6 +27,7 @@ import { resolveAzureDeploymentNameFromMap } from "../llm/providers/azure-deploy
 import { convertMessages } from "../llm/providers/openai-completions.js";
 import { clampOpenAIPromptCacheKey } from "../llm/providers/openai-prompt-cache.js";
 import { mapOpenAIStopReason } from "../llm/providers/openai-stop-reason.js";
+import { extractToolResultText } from "../llm/providers/tool-result-text.js";
 import type { Api, Context, Model } from "../llm/types.js";
 import { createAssistantMessageEventStream } from "../llm/utils/event-stream.js";
 import { parseStreamingJson } from "../llm/utils/json-parse.js";
@@ -1274,10 +1275,7 @@ function convertResponsesMessages(
         messages.push(...output);
       }
     } else if (msg.role === "toolResult") {
-      const textResult = msg.content
-        .filter((item) => item.type === "text")
-        .map((item) => item.text)
-        .join("\n");
+      const textResult = extractToolResultText(msg.content);
       const sanitizedTextResult = sanitizeTransportPayloadText(textResult);
       const hasText = sanitizedTextResult.trim().length > 0;
       const hasImages = msg.content.some((item) => item.type === "image");

--- a/src/llm/providers/anthropic.ts
+++ b/src/llm/providers/anthropic.ts
@@ -43,7 +43,6 @@ import type {
   AssistantMessageEvent,
   CacheRetention,
   Context,
-  ImageContent,
   Message,
   Model,
   ModelThinkingLevel,
@@ -69,6 +68,7 @@ import { resolveCacheRetention } from "./cache-retention.js";
 import { resolveCloudflareBaseUrl } from "./cloudflare.js";
 import { buildCopilotDynamicHeaders, hasCopilotVisionInput } from "./github-copilot-headers.js";
 import { adjustMaxTokensForThinking, buildBaseOptions } from "./simple-options.js";
+import { extractToolResultText } from "./tool-result-text.js";
 import { transformMessages } from "./transform-messages.js";
 
 const ANTHROPIC_CACHE_CONTROL_LIMIT = 4;
@@ -123,7 +123,7 @@ const toClaudeCodeName = (name: string) => ccToolLookup.get(name.toLowerCase()) 
 /**
  * Convert content blocks to Anthropic API format
  */
-function convertContentBlocks(content: (TextContent | ImageContent)[]):
+function convertContentBlocks(content: readonly unknown[]):
   | string
   | Array<
       | { type: "text"; text: string }
@@ -136,36 +136,55 @@ function convertContentBlocks(content: (TextContent | ImageContent)[]):
           };
         }
     > {
-  // If only text blocks, return as concatenated string for simplicity
-  const hasImages = content.some((c) => c.type === "image");
+  const text = extractToolResultText(content);
+  const hasImages =
+    Array.isArray(content) &&
+    content.some(
+      (item) =>
+        item && typeof item === "object" && (item as Record<string, unknown>).type === "image",
+    );
+
   if (!hasImages) {
-    return sanitizeSurrogates(content.map((c) => (c as TextContent).text).join("\n"));
+    return sanitizeSurrogates(text);
   }
 
-  // If we have images, convert to content block array
-  const blocks = content.map((block) => {
-    if (block.type === "text") {
-      return {
-        type: "text" as const,
-        text: sanitizeSurrogates(block.text),
-      };
+  const blocks: Array<
+    | { type: "text"; text: string }
+    | {
+        type: "image";
+        source: {
+          type: "base64";
+          media_type: "image/jpeg" | "image/png" | "image/gif" | "image/webp";
+          data: string;
+        };
+      }
+  > = [];
+
+  if (text.trim().length > 0) {
+    blocks.push({ type: "text" as const, text: sanitizeSurrogates(text) });
+  } else {
+    blocks.push({ type: "text" as const, text: "(see attached image)" });
+  }
+
+  for (const block of Array.isArray(content) ? content : []) {
+    if (!block || typeof block !== "object") {
+      continue;
     }
-    return {
+    const record = block as Record<string, unknown>;
+    if (record.type !== "image") {
+      continue;
+    }
+    blocks.push({
       type: "image" as const,
       source: {
         type: "base64" as const,
-        media_type: block.mimeType as "image/jpeg" | "image/png" | "image/gif" | "image/webp",
-        data: block.data,
+        media_type: (typeof record.mimeType === "string" ? record.mimeType : "image/jpeg") as
+          | "image/jpeg"
+          | "image/png"
+          | "image/gif"
+          | "image/webp",
+        data: typeof record.data === "string" ? record.data : "",
       },
-    };
-  });
-
-  // If only images (no text), add placeholder text block
-  const hasText = blocks.some((b) => b.type === "text");
-  if (!hasText) {
-    blocks.unshift({
-      type: "text" as const,
-      text: "(see attached image)",
     });
   }
 

--- a/src/llm/providers/google-shared.convert.test.ts
+++ b/src/llm/providers/google-shared.convert.test.ts
@@ -375,4 +375,29 @@ describe("google-shared convertMessages", () => {
     expect(asRecord(toolCall.functionCall).id).toBeUndefined();
     expect(asRecord(toolResponse.functionResponse).id).toBeUndefined();
   });
+
+  it("serializes structured tool results into function responses", () => {
+    const model = makeModel("gemini-1.5-pro");
+    const context = {
+      messages: [
+        {
+          role: "toolResult",
+          toolCallId: "call_1",
+          toolName: "session_status",
+          content: [{ type: "json", payload: { sessionKey: "current", status: "ok" } }],
+          isError: false,
+          timestamp: 0,
+        },
+      ],
+    } as unknown as Context;
+    const contents = convertMessagesForTest(model, context);
+    const toolResponsePart = contents[0]?.parts?.find(
+      (part) => typeof part === "object" && part !== null && "functionResponse" in part,
+    );
+    expect(toolResponsePart).toBeDefined();
+    const toolResponse = requireRecordProperty(asRecord(toolResponsePart), "functionResponse");
+    expect(asRecord(toolResponse.response).output).toBe(
+      '{"type":"json","payload":{"sessionKey":"current","status":"ok"}}',
+    );
+  });
 });

--- a/src/llm/providers/google-shared.ts
+++ b/src/llm/providers/google-shared.ts
@@ -32,6 +32,7 @@ import type {
 } from "../types.js";
 import type { AssistantMessageEventStream } from "../utils/event-stream.js";
 import { sanitizeSurrogates } from "../utils/sanitize-unicode.js";
+import { extractToolResultText } from "./tool-result-text.js";
 import { transformMessages } from "./transform-messages.js";
 
 export type GoogleApiType = "google-generative-ai" | "google-vertex";
@@ -278,8 +279,7 @@ export function convertMessages<T extends GoogleApiType>(
       });
     } else if (msg.role === "toolResult") {
       // Extract text and image content
-      const textContent = msg.content.filter((c): c is TextContent => c.type === "text");
-      const textResult = textContent.map((c) => c.text).join("\n");
+      const textResult = extractToolResultText(msg.content);
       const imageContent = model.input.includes("image")
         ? msg.content.filter((c): c is ImageContent => c.type === "image")
         : [];

--- a/src/llm/providers/mistral.test.ts
+++ b/src/llm/providers/mistral.test.ts
@@ -235,4 +235,109 @@ describe("Mistral provider", () => {
     expect(systemMessage?.content).toBe("Stable\nDynamic");
     expect(JSON.stringify(payload)).not.toContain("OPENCLAW_CACHE_BOUNDARY");
   });
+
+  it("serializes structured non-image blocks in tool results as JSON text", async () => {
+    const testContext = {
+      messages: [
+        {
+          role: "user",
+          content: "hello",
+          timestamp: 1,
+        },
+        {
+          role: "assistant",
+          provider: "mistral",
+          api: "mistral-conversations",
+          model: "mistral-large-latest",
+          stopReason: "toolUse",
+          timestamp: 0,
+          content: [{ type: "toolCall", id: "tool_1", name: "fetch", arguments: {} }],
+        },
+        {
+          role: "toolResult",
+          toolCallId: "tool_1",
+          content: [
+            { type: "text", text: "ok" },
+            {
+              type: "resource",
+              resource: {
+                uri: "https://example.com/data.json",
+                mimeType: "application/json",
+                text: '{"key":"value"}',
+              },
+            },
+          ],
+          isError: false,
+          timestamp: 0,
+        },
+      ],
+    } as unknown as Context;
+
+    const stream = streamMistral(makeMistralModel(), testContext, {
+      apiKey: "sk-mistral-provider",
+    });
+    await stream.result();
+
+    const payload = mistralMockState.payloads[0] as {
+      messages: Array<{ role: string; content: string | Array<{ type: string; text?: string }> }>;
+    };
+    const toolMessage = payload.messages.find((message) => message.role === "tool");
+    expect(toolMessage).toBeDefined();
+    const toolContent = Array.isArray(toolMessage!.content) ? toolMessage!.content : [];
+    const textBlock = toolContent.find((block) => block.type === "text");
+    expect(textBlock?.text).toEqual(expect.stringContaining('{"type":"resource"'));
+    expect(textBlock?.text).toContain("ok");
+  });
+
+  it("serializes structured-only tool results instead of empty fallback", async () => {
+    const testContext = {
+      messages: [
+        {
+          role: "user",
+          content: "hello",
+          timestamp: 1,
+        },
+        {
+          role: "assistant",
+          provider: "mistral",
+          api: "mistral-conversations",
+          model: "mistral-large-latest",
+          stopReason: "toolUse",
+          timestamp: 0,
+          content: [{ type: "toolCall", id: "tool_1", name: "get_file", arguments: {} }],
+        },
+        {
+          role: "toolResult",
+          toolCallId: "tool_1",
+          content: [
+            {
+              type: "resource_link",
+              uri: "https://example.com/file.txt",
+              name: "file.txt",
+              mimeType: "text/plain",
+              size: 100,
+            },
+          ],
+          isError: false,
+          timestamp: 0,
+        },
+      ],
+    } as unknown as Context;
+
+    const stream = streamMistral(makeMistralModel(), testContext, {
+      apiKey: "sk-mistral-provider",
+    });
+    await stream.result();
+
+    const payload = mistralMockState.payloads[0] as {
+      messages: Array<{ role: string; content: string | Array<{ type: string; text?: string }> }>;
+    };
+    const toolMessage = payload.messages.find((message) => message.role === "tool");
+    expect(toolMessage).toBeDefined();
+    const toolContent = Array.isArray(toolMessage!.content) ? toolMessage!.content : [];
+    const textBlock = toolContent.find((block) => block.type === "text");
+    // Structured blocks should provide the output, not an empty fallback
+    expect(textBlock?.text).toEqual(expect.stringContaining('{"type":"resource_link"'));
+    expect(textBlock?.text).not.toContain("(no tool output)");
+  });
 });

--- a/src/llm/providers/mistral.ts
+++ b/src/llm/providers/mistral.ts
@@ -29,6 +29,7 @@ import { shortHash } from "../utils/hash.js";
 import { parseStreamingJson } from "../utils/json-parse.js";
 import { sanitizeSurrogates } from "../utils/sanitize-unicode.js";
 import { buildBaseOptions } from "./simple-options.js";
+import { extractToolResultText } from "./tool-result-text.js";
 import { transformMessages } from "./transform-messages.js";
 
 const MISTRAL_TOOL_CALL_ID_LENGTH = 9;
@@ -625,10 +626,7 @@ function toChatMessages(
     }
 
     const toolContent: ContentChunk[] = [];
-    const textResult = msg.content
-      .filter((part) => part.type === "text")
-      .map((part) => (part.type === "text" ? sanitizeSurrogates(part.text) : ""))
-      .join("\n");
+    const textResult = extractToolResultText(msg.content);
     const hasImages = msg.content.some((part) => part.type === "image");
     const toolText = buildToolResultText(textResult, hasImages, supportsImages, msg.isError);
     toolContent.push({ type: "text", text: toolText });

--- a/src/llm/providers/openai-completions.test.ts
+++ b/src/llm/providers/openai-completions.test.ts
@@ -1173,4 +1173,201 @@ describe("openai-completions stop-reason tool-call guard", () => {
     expect(result.stopReason).toBe("stop");
     expect(result.content.filter((b) => b.type === "toolCall")).toStrictEqual([]);
   });
+
+  it("serializes structured tool results as tool text", async () => {
+    let capturedPayload: Record<string, unknown> | undefined;
+    const stream = streamOpenAICompletions(
+      model,
+      {
+        messages: [
+          {
+            role: "toolResult",
+            toolCallId: "call_1",
+            toolName: "session_status",
+            content: [{ type: "json", payload: { sessionKey: "current", status: "ok" } }],
+            isError: false,
+            timestamp: 0,
+          },
+        ],
+      } as unknown as Context,
+      {
+        apiKey: "sk-test",
+        onPayload(payload) {
+          capturedPayload = payload as Record<string, unknown>;
+          throw new Error("stop before network");
+        },
+      },
+    );
+
+    const result = await stream.result();
+
+    expect(result.stopReason).toBe("error");
+    expect(capturedPayload?.messages).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          role: "tool",
+          tool_call_id: "call_1",
+          content: expect.stringContaining('"type":"json"'),
+        }),
+      ]),
+    );
+  });
+
+  it("redacts sensitive fields, omits binary data, and handles opaque payloads in tool results", async () => {
+    let capturedPayload: Record<string, unknown> | undefined;
+    const circularRef: Record<string, unknown> = { type: "resource", name: "loop" };
+    circularRef.self = circularRef;
+
+    const stream = streamOpenAICompletions(
+      model,
+      {
+        messages: [
+          {
+            role: "toolResult",
+            toolCallId: "call_sensitive",
+            toolName: "inspect",
+            content: [
+              {
+                type: "resource",
+                headers: {
+                  authorization: "Bearer sk-live-secret-token",
+                  "x-api-key": "sk-ant-key-12345",
+                },
+                credentials: {
+                  token: "ghp_personal_access_token",
+                  password: "super-secret-pw",
+                },
+                binary: {
+                  mimeType: "image/png",
+                  data: "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk",
+                  blob: "raw-binary-blob-content",
+                },
+                opaque: {
+                  encrypted_content: "AES256-CIPHERTEXT-LONG-BASE64",
+                  encrypted_stdout: "encrypted-stdout-bytes",
+                },
+                ephemeral: circularRef,
+              },
+            ],
+            isError: false,
+            timestamp: 0,
+          },
+        ],
+      } as unknown as Context,
+      {
+        apiKey: "sk-test",
+        onPayload(payload) {
+          capturedPayload = payload as Record<string, unknown>;
+          throw new Error("stop before network");
+        },
+      },
+    );
+
+    const result = await stream.result();
+    expect(result.stopReason).toBe("error");
+
+    const messages = capturedPayload?.messages as Array<Record<string, unknown>> | undefined;
+    const toolMsg = messages?.find((m) => m.role === "tool") as { content?: string } | undefined;
+    const content = toolMsg?.content;
+    expect(typeof content).toBe("string");
+    const text = content as string;
+
+    // Sensitive fields redacted
+    expect(text).toContain('"authorization":"***"');
+    expect(text).toContain('"x-api-key":"***"');
+    expect(text).toContain('"token":"***"');
+    expect(text).toContain('"password":"***"');
+    expect(text).not.toContain("sk-live-secret-token");
+    expect(text).not.toContain("ghp_personal_access_token");
+    expect(text).not.toContain("super-secret-pw");
+
+    // Binary data omitted
+    expect(text).toContain('"data":"[binary omitted: 60 chars]"');
+    expect(text).toContain('"blob":"[binary omitted: 23 chars]"');
+    expect(text).not.toContain("iVBORw0KGgo");
+
+    // Opaque fields omitted
+    expect(text).toContain('"encrypted_content":"[opaque data omitted: 29 chars]"');
+    expect(text).toContain('"encrypted_stdout":"[opaque data omitted: 22 chars]"');
+    expect(text).not.toContain("AES256-CIPHERTEXT");
+
+    // Circular reference safe
+    expect(text).toContain('"self":"[Circular]"');
+  });
+
+  it("caps oversized tool result payload text", async () => {
+    let capturedPayload: Record<string, unknown> | undefined;
+    const stream = streamOpenAICompletions(
+      model,
+      {
+        messages: [
+          {
+            role: "toolResult",
+            toolCallId: "call_big",
+            toolName: "log",
+            content: [{ type: "resource", data: "x".repeat(9000) }],
+            isError: false,
+            timestamp: 0,
+          },
+        ],
+      } as unknown as Context,
+      {
+        apiKey: "sk-test",
+        onPayload(payload) {
+          capturedPayload = payload as Record<string, unknown>;
+          throw new Error("stop before network");
+        },
+      },
+    );
+
+    const result = await stream.result();
+    expect(result.stopReason).toBe("error");
+
+    const messages = capturedPayload?.messages as Array<Record<string, unknown>> | undefined;
+    const toolMsg = messages?.find((m) => m.role === "tool") as { content?: string } | undefined;
+    const text = toolMsg?.content;
+    expect(typeof text).toBe("string");
+    expect(text).toContain("…(truncated)…");
+    expect((text as string).length).toBeLessThan(8100);
+  });
+
+  it("caps aggregate structured tool result payload text after merge", async () => {
+    let capturedPayload: Record<string, unknown> | undefined;
+    const stream = streamOpenAICompletions(
+      model,
+      {
+        messages: [
+          {
+            role: "toolResult",
+            toolCallId: "call_aggregate",
+            toolName: "logs",
+            content: Array.from({ length: 4 }, (_, index) => ({
+              type: "resource",
+              index,
+              data: "x".repeat(2500),
+            })),
+            isError: false,
+            timestamp: 0,
+          },
+        ],
+      } as unknown as Context,
+      {
+        apiKey: "sk-test",
+        onPayload(payload) {
+          capturedPayload = payload as Record<string, unknown>;
+          throw new Error("stop before network");
+        },
+      },
+    );
+
+    const result = await stream.result();
+    expect(result.stopReason).toBe("error");
+
+    const messages = capturedPayload?.messages as Array<Record<string, unknown>> | undefined;
+    const toolMsg = messages?.find((m) => m.role === "tool") as { content?: string } | undefined;
+    const text = toolMsg?.content;
+    expect(typeof text).toBe("string");
+    expect(text).toContain("…(truncated)…");
+    expect((text as string).length).toBeLessThan(8100);
+  });
 });

--- a/src/llm/providers/openai-completions.ts
+++ b/src/llm/providers/openai-completions.ts
@@ -51,6 +51,7 @@ import { buildCopilotDynamicHeaders, hasCopilotVisionInput } from "./github-copi
 import { clampOpenAIPromptCacheKey } from "./openai-prompt-cache.js";
 import { mapOpenAIStopReason } from "./openai-stop-reason.js";
 import { buildBaseOptions } from "./simple-options.js";
+import { extractToolResultText } from "./tool-result-text.js";
 import { transformMessages } from "./transform-messages.js";
 
 /**
@@ -1136,10 +1137,7 @@ export function convertMessages(
         const toolMsg = transformedMessages[j] as ToolResultMessage;
 
         // Extract text and image content
-        const textResult = toolMsg.content
-          .filter(isTextContentBlock)
-          .map((block) => block.text)
-          .join("\n");
+        const textResult = extractToolResultText(toolMsg.content);
         const hasImages = toolMsg.content.some((c) => c.type === "image");
 
         // Always send tool result with text (or placeholder if only images)

--- a/src/llm/providers/openai-responses-shared.test.ts
+++ b/src/llm/providers/openai-responses-shared.test.ts
@@ -62,6 +62,8 @@ const proxyOpenAIModel = {
   baseUrl: "https://proxy.example.com/v1",
 } satisfies Model<"openai-responses">;
 
+const testAllowedToolCallProviders = new Set(["openai", "openai-codex", "opencode"]);
+
 function createAssistantOutput(): AssistantMessage {
   return {
     role: "assistant",
@@ -239,7 +241,7 @@ describe("convertResponsesTools", () => {
 });
 
 describe("convertResponsesMessages", () => {
-  const allowedToolCallProviders = new Set(["openai", "openai-codex", "opencode"]);
+  const allowedToolCallProviders = testAllowedToolCallProviders;
 
   it("adds explicit message item types for system and user input items", () => {
     const input = convertResponsesMessages(
@@ -620,6 +622,94 @@ describe("convertResponsesMessages", () => {
       encrypted_content: "ciphertext",
       summary: [],
     });
+  });
+
+  it("serializes structured tool results as text instead of image placeholders", () => {
+    const input = convertResponsesMessages(
+      nativeOpenAIModel,
+      {
+        systemPrompt: "system",
+        messages: [
+          {
+            role: "toolResult",
+            toolCallId: "call_structured",
+            toolName: "session_status",
+            content: [
+              {
+                type: "json",
+                encrypted_content: "opaque-provider-ciphertext",
+                payload: {
+                  sessionKey: "current",
+                  model: "openai/gpt-5.4",
+                  status: "ok",
+                  headers: { authorization: "Bearer provider-secret-token" },
+                  artifact: {
+                    mimeType: "application/octet-stream",
+                    data: "opaque-binary-payload",
+                  },
+                },
+              },
+            ],
+            isError: false,
+            timestamp: 1,
+          },
+        ],
+      } as unknown as Context,
+      testAllowedToolCallProviders,
+      { includeSystemPrompt: false, replayResponsesItemIds: false },
+    ) as unknown as Array<Record<string, unknown>>;
+    const outputItem = input.find((item) => item.type === "function_call_output");
+    const output = outputItem?.output;
+    if (typeof output !== "string") {
+      throw new Error("expected function_call_output string output");
+    }
+
+    expect(outputItem).toMatchObject({
+      type: "function_call_output",
+      call_id: "call_structured",
+    });
+    expect(output).toContain('"type":"json"');
+    expect(output).toContain('"authorization":"***"');
+    expect(output).toContain('"data":"[binary omitted:');
+    expect(output).toContain('"encrypted_content":"[opaque data omitted:');
+    expect(output).not.toContain("provider-secret-token");
+    expect(output).not.toContain("opaque-binary-payload");
+    expect(output).not.toContain("opaque-provider-ciphertext");
+  });
+
+  it("handles circular structured references and caps oversized tool result output", () => {
+    const circularRef: Record<string, unknown> = { type: "log", label: "self-loop" };
+    circularRef.parent = circularRef;
+
+    const input = convertResponsesMessages(
+      nativeOpenAIModel,
+      {
+        systemPrompt: "system",
+        messages: [
+          {
+            role: "toolResult",
+            toolCallId: "call_circular",
+            toolName: "inspect",
+            content: [circularRef, { type: "resource", data: "x".repeat(9000) }],
+            isError: false,
+            timestamp: 1,
+          },
+        ],
+      } as unknown as Context,
+      testAllowedToolCallProviders,
+      { includeSystemPrompt: false, replayResponsesItemIds: false },
+    ) as unknown as Array<Record<string, unknown>>;
+    const outputItem = input.find((item) => item.type === "function_call_output");
+    const output = outputItem?.output;
+    if (typeof output !== "string") {
+      throw new Error("expected function_call_output string output");
+    }
+
+    // Circular reference detected (no throw)
+    expect(output).toContain('"parent":"[Circular]"');
+    // Truncation applied to oversized payload
+    expect(output).toContain("…(truncated)…");
+    expect(output.length).toBeLessThan(8100);
   });
 });
 

--- a/src/llm/providers/openai-responses-shared.ts
+++ b/src/llm/providers/openai-responses-shared.ts
@@ -45,6 +45,7 @@ import { headersToRecord } from "../utils/headers.js";
 import { parseStreamingJson } from "../utils/json-parse.js";
 import { sanitizeSurrogates } from "../utils/sanitize-unicode.js";
 import { convertResponsesToolPayload, convertResponsesTools } from "./openai-responses-tools.js";
+import { extractToolResultText } from "./tool-result-text.js";
 import { transformMessages } from "./transform-messages.js";
 
 // =============================================================================
@@ -380,10 +381,7 @@ export function convertResponsesMessages<TApi extends Api>(
       }
       messages.push(...output);
     } else if (msg.role === "toolResult") {
-      const textResult = msg.content
-        .filter((c): c is TextContent => c.type === "text")
-        .map((c) => c.text)
-        .join("\n");
+      const textResult = extractToolResultText(msg.content);
       const sanitizedTextResult = sanitizeSurrogates(textResult);
       const hasImages = msg.content.some((c): c is ImageContent => c.type === "image");
       const hasText = sanitizedTextResult.trim().length > 0;

--- a/src/llm/providers/tool-result-text.test.ts
+++ b/src/llm/providers/tool-result-text.test.ts
@@ -1,0 +1,147 @@
+import { describe, expect, it } from "vitest";
+import { truncateStructuredToolResultText } from "../../logging/tool-result-serialization.js";
+import { extractToolResultText } from "./tool-result-text.js";
+
+const TRUNCATION_MARKER = "…(truncated)…";
+
+describe("extractToolResultText", () => {
+  it("keeps text blocks and serializes structured non-image blocks", () => {
+    expect(
+      extractToolResultText([
+        { type: "text", text: "plain output" },
+        {
+          type: "resource",
+          uri: "file:///tmp/result.json",
+          mimeType: "application/json",
+          data: { ok: true },
+        },
+      ]),
+    ).toBe(
+      'plain output\n\n{"type":"resource","uri":"file:///tmp/result.json","mimeType":"application/json","data":{"ok":true}}',
+    );
+  });
+
+  it("ignores media blocks for text extraction", () => {
+    expect(
+      extractToolResultText([
+        { type: "image", mimeType: "image/png", data: "base64-image-bytes" },
+        { type: "image_url", image_url: { url: "data:image/png;base64,preview-bytes" } },
+        { type: "audio", mimeType: "audio/mpeg", data: "base64-audio-bytes" },
+        { type: "resource", value: "visible" },
+      ]),
+    ).toBe('{"type":"resource","value":"visible"}');
+  });
+
+  it("does not rewrite ordinary structured strings containing data colon substrings", () => {
+    expect(
+      extractToolResultText([
+        { type: "resource", status: "metadata:ready", note: "data: is just prose here" },
+      ]),
+    ).toBe('{"type":"resource","status":"metadata:ready","note":"data: is just prose here"}');
+  });
+
+  it("redacts actual data URI tokens inside structured strings", () => {
+    expect(
+      extractToolResultText([
+        {
+          type: "resource",
+          preview: "thumbnail=data:image/png;base64,aW1hZ2UtYnl0ZXM= done",
+        },
+      ]),
+    ).toBe('{"type":"resource","preview":"thumbnail=[redacted data URI] done"}');
+  });
+
+  it("redacts nested sensitive fields before provider replay", () => {
+    expect(
+      extractToolResultText([
+        {
+          type: "resource",
+          headers: {
+            authorization: "Bearer live-token",
+            "x-api-key": "live-api-key",
+          },
+          token: "nested-token",
+        },
+      ]),
+    ).toBe('{"type":"resource","headers":{"authorization":"***","x-api-key":"***"},"token":"***"}');
+  });
+
+  it("omits opaque and binary structured payloads before provider replay", () => {
+    expect(
+      extractToolResultText([
+        {
+          type: "resource",
+          mimeType: "image/png",
+          data: "base64-image-bytes",
+          blob: "raw-blob-bytes",
+          encrypted_content: "opaque-ciphertext",
+        },
+      ]),
+    ).toBe(
+      '{"type":"resource","mimeType":"image/png","data":"[binary omitted: 18 chars]","blob":"[binary omitted: 14 chars]","encrypted_content":"[opaque data omitted: 17 chars]"}',
+    );
+  });
+
+  it.each([
+    ["mime_type", { mime_type: "application/octet-stream" }],
+    ["mediaType", { mediaType: "audio/mpeg" }],
+    ["contentType", { contentType: "application/pdf" }],
+    ["content_type", { content_type: "video/mp4" }],
+  ])("treats %s aliases as binary structured payloads", (_label, alias) => {
+    expect(
+      extractToolResultText([
+        {
+          type: "resource",
+          ...alias,
+          data: "binary-payload-bytes",
+        },
+      ]),
+    ).toBe(JSON.stringify({ type: "resource", ...alias, data: "[binary omitted: 20 chars]" }));
+  });
+
+  it("handles circular structured payloads without throwing", () => {
+    const block: Record<string, unknown> = { type: "resource", value: "visible" };
+    block.self = block;
+
+    expect(extractToolResultText([block])).toBe(
+      '{"type":"resource","value":"visible","self":"[Circular]"}',
+    );
+  });
+
+  it("caps large structured payload text before provider replay", () => {
+    const text = extractToolResultText([{ type: "resource", data: "x".repeat(9000) }]);
+
+    expect(text).toContain(TRUNCATION_MARKER);
+    expect(text.length).toBeLessThan(8100);
+  });
+
+  it("caps aggregate provider text after merging many individually bounded blocks", () => {
+    const text = extractToolResultText(
+      Array.from({ length: 5 }, (_, index) => ({
+        type: "resource",
+        index,
+        data: "x".repeat(3000),
+      })),
+    );
+
+    expect(text).toContain(TRUNCATION_MARKER);
+    expect(text.length).toBeLessThan(8100);
+  });
+
+  it("uses the shared truncation helper for aggregate provider text caps", () => {
+    const text = extractToolResultText([
+      { type: "resource", first: "x".repeat(4000) },
+      { type: "resource", second: "y".repeat(4000) },
+    ]);
+
+    expect(text).toBe(
+      truncateStructuredToolResultText(
+        '{"type":"resource","first":"' +
+          "x".repeat(4000) +
+          '"}\n\n{"type":"resource","second":"' +
+          "y".repeat(4000) +
+          '"}',
+      ),
+    );
+  });
+});

--- a/src/llm/providers/tool-result-text.ts
+++ b/src/llm/providers/tool-result-text.ts
@@ -1,0 +1,50 @@
+import {
+  serializeStructuredToolResultBlock,
+  stringifyProviderToolTextValue,
+  truncateStructuredToolResultText,
+} from "../../logging/tool-result-serialization.js";
+
+type ToolResultContentBlock = {
+  type?: string;
+  text?: unknown;
+  [key: string]: unknown;
+};
+
+const MEDIA_TOOL_RESULT_TYPES = new Set(["image", "image_url", "audio"]);
+
+export function extractToolResultText(content: readonly unknown[]): string {
+  const chunks: string[] = [];
+
+  for (const part of content) {
+    if (!isRecord(part)) {
+      const text = stringifyProviderToolTextValue(part);
+      if (text.length > 0) {
+        chunks.push(text);
+      }
+      continue;
+    }
+
+    if (typeof part.type === "string" && MEDIA_TOOL_RESULT_TYPES.has(part.type)) {
+      continue;
+    }
+
+    if (part.type === "text") {
+      const text = stringifyProviderToolTextValue(part.text);
+      if (text.length > 0) {
+        chunks.push(text);
+      }
+      continue;
+    }
+
+    const serialized = serializeStructuredToolResultBlock(part);
+    if (serialized) {
+      chunks.push(serialized);
+    }
+  }
+
+  return truncateStructuredToolResultText(chunks.join("\n\n"));
+}
+
+function isRecord(value: unknown): value is ToolResultContentBlock {
+  return typeof value === "object" && value !== null;
+}

--- a/src/logging/tool-result-serialization.test.ts
+++ b/src/logging/tool-result-serialization.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from "vitest";
+import { serializeStructuredToolResultBlock } from "./tool-result-serialization.js";
+
+describe("serializeStructuredToolResultBlock", () => {
+  it.each([
+    ["media_type", { media_type: "image/png" }],
+    ["mime_type", { mime_type: "application/octet-stream" }],
+    ["mimeType", { mimeType: "application/pdf" }],
+    ["mediaType", { mediaType: "audio/mpeg" }],
+    ["contentType", { contentType: "application/pdf" }],
+    ["content_type", { content_type: "video/mp4" }],
+  ])("omits binary data for %s media aliases", (_label, alias) => {
+    expect(
+      serializeStructuredToolResultBlock({
+        type: "resource",
+        ...alias,
+        data: "binary-payload-bytes",
+      }),
+    ).toBe(JSON.stringify({ type: "resource", ...alias, data: "[binary omitted: 20 chars]" }));
+  });
+});

--- a/src/logging/tool-result-serialization.ts
+++ b/src/logging/tool-result-serialization.ts
@@ -1,0 +1,202 @@
+import { truncateUtf16Safe } from "../shared/utf16-slice.js";
+import { redactSensitiveFieldValue, redactToolPayloadText } from "./redact.js";
+
+type DataUriRedactionMode = "inline" | "tokens";
+
+type SerializeStructuredToolResultOptions = {
+  maxChars?: number;
+  dataUriRedaction?: DataUriRedactionMode;
+  skipTypes?: readonly string[];
+};
+
+export const DEFAULT_STRUCTURED_TOOL_RESULT_MAX_CHARS = 8000;
+const DATA_URI_TOKEN_RE =
+  /\bdata:[a-z][a-z0-9.+-]*\/[a-z0-9.+-]+(?:;[a-z0-9.+-]+=[^\s"'<>;,]+)*(?:;base64)?,[^\s"'<>]+/gi;
+const REDACTED_DATA_URI = "[redacted data URI]";
+const OPAQUE_STRUCTURED_RESULT_FIELDS = new Set(["encryptedcontent", "encryptedstdout"]);
+const SENSITIVE_STRUCTURED_FIELD_KEYS = new Set([
+  "authorization",
+  "proxyauthorization",
+  "cookie",
+  "setcookie",
+  "xapikey",
+  "xauthtoken",
+  "apikey",
+  "accesstoken",
+  "refreshtoken",
+  "idtoken",
+  "clientsecret",
+  "password",
+  "privatekey",
+  "secret",
+  "token",
+]);
+
+export function serializeStructuredToolResultBlock(
+  block: unknown,
+  options: SerializeStructuredToolResultOptions = {},
+): string | undefined {
+  if (!block || typeof block !== "object") {
+    return undefined;
+  }
+  const record = block as Record<string, unknown>;
+  const type = readLowercaseString(record.type);
+  if (type && shouldSkipStructuredToolResultType(type, options.skipTypes)) {
+    return undefined;
+  }
+
+  try {
+    const maxChars = options.maxChars ?? DEFAULT_STRUCTURED_TOOL_RESULT_MAX_CHARS;
+    const serialized = JSON.stringify(
+      sanitizeStructuredToolResultValue(record, {
+        dataUriRedaction: options.dataUriRedaction ?? "tokens",
+        maxChars,
+      }),
+    );
+    const redacted = serialized ? redactToolPayloadText(serialized) : serialized;
+    const truncated = redacted ? truncateStructuredToolResultText(redacted, maxChars) : redacted;
+    return truncated && truncated !== "{}" ? truncated : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+export function stringifyProviderToolTextValue(
+  value: unknown,
+  maxChars = DEFAULT_STRUCTURED_TOOL_RESULT_MAX_CHARS,
+): string {
+  if (typeof value === "string") {
+    return truncateStructuredToolResultText(redactDataUriTokens(value), maxChars);
+  }
+  if (typeof value === "bigint") {
+    return value.toString();
+  }
+  if (typeof value === "number" || typeof value === "boolean") {
+    return `${value}`;
+  }
+  return "";
+}
+
+function sanitizeStructuredToolResultValue(
+  value: unknown,
+  options: Required<Pick<SerializeStructuredToolResultOptions, "dataUriRedaction" | "maxChars">>,
+  key = "",
+  parentCarriesBinaryData = false,
+  seen = new WeakSet<object>(),
+): unknown {
+  if (typeof value === "string") {
+    return sanitizeStructuredString(value, key, parentCarriesBinaryData, options);
+  }
+  if (typeof value === "bigint") {
+    return value.toString();
+  }
+  if (!value || typeof value !== "object") {
+    return value;
+  }
+  if (seen.has(value)) {
+    return "[Circular]";
+  }
+  seen.add(value);
+  if (Array.isArray(value)) {
+    const out = value.map((item) =>
+      sanitizeStructuredToolResultValue(item, options, key, parentCarriesBinaryData, seen),
+    );
+    seen.delete(value);
+    return out;
+  }
+
+  const record = value as Record<string, unknown>;
+  const hasBinaryData = carriesBinaryData(record);
+  const out = Object.fromEntries(
+    Object.entries(record).map(([childKey, child]) => [
+      childKey,
+      sanitizeStructuredToolResultValue(child, options, childKey, hasBinaryData, seen),
+    ]),
+  );
+  seen.delete(value);
+  return out;
+}
+
+function sanitizeStructuredString(
+  value: string,
+  key: string,
+  parentCarriesBinaryData: boolean,
+  options: Required<Pick<SerializeStructuredToolResultOptions, "dataUriRedaction" | "maxChars">>,
+): string {
+  const normalizedKey = normalizeStructuredKey(key);
+  if (SENSITIVE_STRUCTURED_FIELD_KEYS.has(normalizedKey)) {
+    return "***";
+  }
+  if (OPAQUE_STRUCTURED_RESULT_FIELDS.has(normalizedKey)) {
+    return `[opaque data omitted: ${value.length} chars]`;
+  }
+  if (normalizedKey === "blob" || (normalizedKey === "data" && parentCarriesBinaryData)) {
+    return `[binary omitted: ${value.length} chars]`;
+  }
+
+  const redacted = redactSensitiveFieldValue(key, value);
+  const dataUriRedacted =
+    options.dataUriRedaction === "inline"
+      ? redactInlineDataUriValue(redacted)
+      : redactDataUriTokens(redacted);
+  return truncateStructuredToolResultText(dataUriRedacted, options.maxChars);
+}
+
+function carriesBinaryData(record: Record<string, unknown>): boolean {
+  const type = readLowercaseString(record.type);
+  if (type === "audio" || type === "image" || type === "base64") {
+    return true;
+  }
+  const mediaType = readLowercaseString(
+    record.media_type ??
+      record.mime_type ??
+      record.mimeType ??
+      record.mediaType ??
+      record.contentType ??
+      record.content_type,
+  );
+  return (
+    mediaType?.startsWith("image/") === true ||
+    mediaType?.startsWith("audio/") === true ||
+    mediaType?.startsWith("video/") === true ||
+    mediaType === "application/pdf" ||
+    mediaType === "application/octet-stream"
+  );
+}
+
+function readLowercaseString(value: unknown): string | undefined {
+  return typeof value === "string" ? value.toLowerCase() : undefined;
+}
+
+function shouldSkipStructuredToolResultType(
+  type: string,
+  skipTypes: readonly string[] | undefined,
+): boolean {
+  return skipTypes?.some((skipType) => skipType.toLowerCase() === type) === true;
+}
+
+function normalizeStructuredKey(key: string): string {
+  return key.toLowerCase().replace(/[-_]/g, "");
+}
+
+export function truncateStructuredToolResultText(
+  text: string,
+  maxChars = DEFAULT_STRUCTURED_TOOL_RESULT_MAX_CHARS,
+): string {
+  if (text.length <= maxChars) {
+    return text;
+  }
+  return `${truncateUtf16Safe(text, maxChars)}\n…(truncated)…`;
+}
+
+function redactInlineDataUriValue(value: string): string {
+  const trimmed = value.trimStart();
+  if (!trimmed.toLowerCase().startsWith("data:")) {
+    return value;
+  }
+  return `[inline data URI: ${value.length} chars]`;
+}
+
+function redactDataUriTokens(value: string): string {
+  return value.replace(DATA_URI_TOKEN_RE, REDACTED_DATA_URI);
+}


### PR DESCRIPTION
## Summary
- Preserve structured, non-media tool result blocks when replaying tool outputs into provider-specific message formats.
- Share structured result serialization/redaction across provider replay and logging paths.
- Add regression coverage for OpenAI Responses/Completions, Anthropic, Google, Mistral, agent transport streams, and logging serialization.

## Problem
Tool results that arrived as structured non-text blocks could be dropped during provider replay because replay extraction only preserved explicit text blocks and skipped the rest. That can make command/file-read outputs disappear in subsequent model turns even when the tool call itself succeeded.

## Implementation
- Added `extractToolResultText` and shared structured serialization helpers.
- Redacts sensitive fields, opaque encrypted payloads, and data URI tokens before replay.
- Omits media blocks from provider text replay while preserving structured non-media blocks as bounded JSON text.
- Reused the same structured serialization in logging to keep behavior consistent.

## Validation
Local lightweight checks performed before PR creation:
- `git diff --check upstream/main...HEAD` passed.
- Direct source inspection confirmed the patch is limited to provider replay/logging serialization paths and associated unit tests.

Cloud validation is expected through repository CI after PR creation. This PR intentionally does not include local build artifacts.

## Risk
- Main behavior change is that structured non-media tool result payloads are now visible to provider replay as redacted, truncated JSON text instead of being omitted.
- Binary/media payloads remain omitted or redacted to avoid leaking large or unsafe content into text replay.
