### PR TITLE
fix(plugins): keep load-path plugins with installed index

### DIFF
--- a/src/plugins/discovery.ts
+++ b/src/plugins/discovery.ts
@@ -1445,42 +1445,17 @@ export function discoverOpenClawPlugins(params: {
   const scopedResult = tracePluginLifecyclePhase(
     "discovery scan",
     () => {
-      const result = createDiscoveryResult();
       const seen = new Set<string>();
-      const extra = params.extraPaths ?? [];
-      for (const extraPath of extra) {
-        if (typeof extraPath !== "string") {
-          continue;
-        }
-        const trimmed = extraPath.trim();
-        if (!trimmed) {
-          continue;
-        }
-        const bundledAlias = resolvePackagedBundledLoadPathAlias({
-          bundledRoot: roots.stock,
-          loadPath: resolveUserPath(trimmed, env),
-        });
-        if (bundledAlias) {
-          result.diagnostics.push({
-            level: "warn",
-            source: trimmed,
-            message: `ignored plugins.load.paths entry that points at OpenClaw's ${bundledAlias.kind} bundled plugin directory; remove this redundant path or run openclaw doctor --fix`,
-          });
-          continue;
-        }
-        discoverFromPath({
-          rawPath: trimmed,
-          origin: "config",
-          ownershipUid: params.ownershipUid,
-          workspaceDir,
-          env,
-          candidates: result.candidates,
-          diagnostics: result.diagnostics,
-          seen,
-          realpathCache,
-          packageManifestCache,
-        });
-      }
+      const result = discoverConfiguredPluginLoadPaths({
+        workspaceDir,
+        extraPaths: params.extraPaths,
+        ownershipUid: params.ownershipUid,
+        env,
+        bundledRoot: roots.stock,
+        realpathCache,
+        packageManifestCache,
+        seen,
+      });
       const workspaceMatchesBundledRoot = resolvesToSameDirectory(
         workspaceRoot,
         roots.stock,
@@ -1631,5 +1606,57 @@ export function discoverOpenClawPlugins(params: {
   mergeDiscoveryResult(result, scopedResult, seenSources, seenDiagnostics);
   mergeDiscoveryResult(result, sharedResult, seenSources, seenDiagnostics);
   addMissingRequiredPluginDiagnostics(result);
+  return result;
+}
+
+export function discoverConfiguredPluginLoadPaths(params: {
+  workspaceDir?: string | undefined;
+  extraPaths?: string[] | undefined;
+  ownershipUid?: number | null;
+  env?: NodeJS.ProcessEnv;
+  bundledRoot?: string | undefined;
+  realpathCache?: Map<string, string>;
+  packageManifestCache?: Map<string, PackageManifest | null>;
+  seen?: Set<string>;
+}): PluginDiscoveryResult {
+  const env = params.env ?? process.env;
+  const result = createDiscoveryResult();
+  const seen = params.seen ?? new Set<string>();
+  const realpathCache = params.realpathCache ?? new Map<string, string>();
+  const packageManifestCache =
+    params.packageManifestCache ?? new Map<string, PackageManifest | null>();
+  for (const extraPath of params.extraPaths ?? []) {
+    if (typeof extraPath !== "string") {
+      continue;
+    }
+    const trimmed = extraPath.trim();
+    if (!trimmed) {
+      continue;
+    }
+    const bundledAlias = resolvePackagedBundledLoadPathAlias({
+      bundledRoot: params.bundledRoot,
+      loadPath: resolveUserPath(trimmed, env),
+    });
+    if (bundledAlias) {
+      result.diagnostics.push({
+        level: "warn",
+        source: trimmed,
+        message: `ignored plugins.load.paths entry that points at OpenClaw's ${bundledAlias.kind} bundled plugin directory; remove this redundant path or run openclaw doctor --fix`,
+      });
+      continue;
+    }
+    discoverFromPath({
+      rawPath: trimmed,
+      origin: "config",
+      ownershipUid: params.ownershipUid,
+      workspaceDir: params.workspaceDir,
+      env,
+      candidates: result.candidates,
+      diagnostics: result.diagnostics,
+      seen,
+      realpathCache,
+      packageManifestCache,
+    });
+  }
   return result;
 }

--- a/src/plugins/manifest-registry-installed.test.ts
+++ b/src/plugins/manifest-registry-installed.test.ts
@@ -478,6 +478,40 @@ describe("loadPluginManifestRegistryForInstalledIndex", () => {
     expect(registry.plugins.map((plugin) => plugin.origin)).toEqual(["config", "global"]);
   });
 
+  it("ignores redundant bundled load paths while reconstructing an installed-index registry", () => {
+    const installedRoot = makeTempDir();
+    const packageRoot = path.join(makeTempDir(), "node_modules", "openclaw");
+    const bundledRoot = path.join(packageRoot, "dist", "extensions");
+    const bundledPluginRoot = path.join(bundledRoot, "telegram");
+    writePlugin(installedRoot, "installed", "installed-");
+    fs.mkdirSync(bundledPluginRoot, { recursive: true });
+    writePlugin(bundledPluginRoot, "telegram", "telegram-");
+
+    const registry = loadPluginManifestRegistryForInstalledIndex({
+      index: createIndex(installedRoot),
+      config: {
+        plugins: {
+          load: { paths: [bundledPluginRoot] },
+        },
+      },
+      env: {
+        OPENCLAW_VERSION: "2026.4.25",
+        VITEST: "true",
+        OPENCLAW_TEST_TRUST_BUNDLED_PLUGINS_DIR: "1",
+        OPENCLAW_BUNDLED_PLUGINS_DIR: bundledRoot,
+      },
+      includeDisabled: true,
+    });
+
+    expect(registry.plugins.map((plugin) => plugin.id)).toEqual(["installed"]);
+    expect(registry.diagnostics).toHaveLength(1);
+    expect(registry.diagnostics[0]).toMatchObject({
+      level: "warn",
+      source: bundledPluginRoot,
+    });
+    expect(registry.diagnostics[0]?.message).toContain("ignored plugins.load.paths entry");
+  });
+
   it("reconstructs bundle candidates with their bundle manifest format", () => {
     const rootDir = makeTempDir();
     fs.mkdirSync(path.join(rootDir, ".claude-plugin"), { recursive: true });

--- a/src/plugins/manifest-registry-installed.test.ts
+++ b/src/plugins/manifest-registry-installed.test.ts
@@ -449,6 +449,35 @@ describe("loadPluginManifestRegistryForInstalledIndex", () => {
     });
   });
 
+  it("keeps configured load path plugins when reconstructing an installed-index registry", () => {
+    const installedRoot = makeTempDir();
+    const workspacePluginRoot = makeTempDir();
+    writePlugin(installedRoot, "installed", "installed-");
+    writePlugin(workspacePluginRoot, "workspace", "workspace-");
+
+    const registry = loadPluginManifestRegistryForInstalledIndex({
+      index: createIndex(installedRoot),
+      config: {
+        plugins: {
+          load: { paths: [workspacePluginRoot] },
+          entries: {
+            workspace: { enabled: true },
+          },
+          allow: ["workspace"],
+        },
+      },
+      env: {
+        OPENCLAW_VERSION: "2026.4.25",
+        VITEST: "true",
+      },
+      includeDisabled: true,
+    });
+
+    expect(registry.diagnostics).toStrictEqual([]);
+    expect(registry.plugins.map((plugin) => plugin.id)).toEqual(["workspace", "installed"]);
+    expect(registry.plugins.map((plugin) => plugin.origin)).toEqual(["config", "global"]);
+  });
+
   it("reconstructs bundle candidates with their bundle manifest format", () => {
     const rootDir = makeTempDir();
     fs.mkdirSync(path.join(rootDir, ".claude-plugin"), { recursive: true });

--- a/src/plugins/manifest-registry-installed.test.ts
+++ b/src/plugins/manifest-registry-installed.test.ts
@@ -478,6 +478,62 @@ describe("loadPluginManifestRegistryForInstalledIndex", () => {
     expect(registry.plugins.map((plugin) => plugin.origin)).toEqual(["config", "global"]);
   });
 
+  it("skips configured load path discovery when load.paths is empty", () => {
+    const installedRoot = makeTempDir();
+    writePlugin(installedRoot, "installed", "installed-");
+    const registry = loadPluginManifestRegistryForInstalledIndex({
+      index: createIndex(installedRoot),
+      config: {
+        plugins: {
+          load: { paths: [] },
+        },
+      },
+      env: {
+        OPENCLAW_VERSION: "2026.4.25",
+        VITEST: "true",
+      },
+      includeDisabled: true,
+    });
+
+    expect(registry.diagnostics).toStrictEqual([]);
+    expect(registry.plugins.map((plugin) => plugin.id)).toEqual(["installed"]);
+  });
+
+  it("preserves plugin id scoping for configured load path candidates", () => {
+    const installedRoot = makeTempDir();
+    const workspacePluginRoot = makeTempDir();
+    const unrelatedPluginRoot = makeTempDir();
+    writePlugin(installedRoot, "installed", "installed-");
+    writePlugin(workspacePluginRoot, "workspace", "workspace-");
+    writePlugin(unrelatedPluginRoot, "unrelated", "unrelated-");
+
+    const registry = loadPluginManifestRegistryForInstalledIndex({
+      index: createIndex(installedRoot),
+      config: {
+        plugins: {
+          load: { paths: [workspacePluginRoot, unrelatedPluginRoot] },
+          entries: {
+            workspace: { enabled: true },
+            unrelated: { enabled: true },
+          },
+          allow: ["workspace", "unrelated"],
+        },
+      },
+      env: {
+        OPENCLAW_VERSION: "2026.4.25",
+        VITEST: "true",
+      },
+      pluginIds: ["workspace"],
+      includeDisabled: true,
+    });
+
+    expect(registry.diagnostics).toStrictEqual([]);
+    expect(registry.plugins.map((plugin) => plugin.id)).toEqual(["workspace"]);
+    expect(registry.plugins[0]?.modelSupport).toEqual({
+      modelPrefixes: ["workspace-"],
+    });
+  });
+
   it("ignores redundant bundled load paths while reconstructing an installed-index registry", () => {
     const installedRoot = makeTempDir();
     const packageRoot = path.join(makeTempDir(), "node_modules", "openclaw");

--- a/src/plugins/manifest-registry-installed.ts
+++ b/src/plugins/manifest-registry-installed.ts
@@ -6,6 +6,7 @@ import { normalizeOptionalString } from "@openclaw/normalization-core/string-coe
 import { normalizeOptionalTrimmedStringList } from "@openclaw/normalization-core/string-normalization";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { tryReadJsonSync } from "../infra/json-files.js";
+import { resolveBundledPluginsDir } from "./bundled-dir.js";
 import { normalizePluginsConfig } from "./config-state.js";
 import { discoverConfiguredPluginLoadPaths, type PluginCandidate } from "./discovery.js";
 import { hashJson } from "./installed-plugin-index-hash.js";
@@ -615,12 +616,14 @@ export function loadPluginManifestRegistryForInstalledIndex(params: {
       const realpathCache = new Map<string, string>();
       const installRecords = extractPluginInstallRecordsFromInstalledPluginIndex(params.index);
       const configuredLoadPaths = normalizePluginsConfig(params.config?.plugins).loadPaths;
+      const bundledRoot = resolveBundledPluginsDir(env);
       const loadPathDiscovery =
         configuredLoadPaths.length > 0
           ? discoverConfiguredPluginLoadPaths({
               workspaceDir: params.workspaceDir,
               extraPaths: configuredLoadPaths,
               env,
+              bundledRoot,
             })
           : { candidates: [], diagnostics: [] };
       const diagnostics = pluginIdSet

--- a/src/plugins/manifest-registry-installed.ts
+++ b/src/plugins/manifest-registry-installed.ts
@@ -6,7 +6,8 @@ import { normalizeOptionalString } from "@openclaw/normalization-core/string-coe
 import { normalizeOptionalTrimmedStringList } from "@openclaw/normalization-core/string-normalization";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { tryReadJsonSync } from "../infra/json-files.js";
-import type { PluginCandidate } from "./discovery.js";
+import { normalizePluginsConfig } from "./config-state.js";
+import { discoverConfiguredPluginLoadPaths, type PluginCandidate } from "./discovery.js";
 import { hashJson } from "./installed-plugin-index-hash.js";
 import type { InstalledPluginFileSignature } from "./installed-plugin-index-hash.js";
 import type { InstalledPluginIndex, InstalledPluginIndexRecord } from "./installed-plugin-index.js";
@@ -612,6 +613,16 @@ export function loadPluginManifestRegistryForInstalledIndex(params: {
       const env = params.env ?? process.env;
       const pluginIdSet = params.pluginIds?.length ? new Set(params.pluginIds) : null;
       const realpathCache = new Map<string, string>();
+      const installRecords = extractPluginInstallRecordsFromInstalledPluginIndex(params.index);
+      const configuredLoadPaths = normalizePluginsConfig(params.config?.plugins).loadPaths;
+      const loadPathDiscovery =
+        configuredLoadPaths.length > 0
+          ? discoverConfiguredPluginLoadPaths({
+              workspaceDir: params.workspaceDir,
+              extraPaths: configuredLoadPaths,
+              env,
+            })
+          : { candidates: [], diagnostics: [] };
       const diagnostics = pluginIdSet
         ? params.index.diagnostics.filter((diagnostic) => {
             const pluginId = diagnostic.pluginId;
@@ -622,13 +633,22 @@ export function loadPluginManifestRegistryForInstalledIndex(params: {
         .filter((plugin) => params.includeDisabled || plugin.enabled)
         .filter((plugin) => !pluginIdSet || pluginIdSet.has(plugin.pluginId))
         .map((plugin) => toPluginCandidate(plugin, realpathCache));
+      const loadPathCandidates = pluginIdSet
+        ? loadPathDiscovery.candidates.filter((candidate) => pluginIdSet.has(candidate.idHint))
+        : loadPathDiscovery.candidates;
+      const loadPathDiagnostics = pluginIdSet
+        ? loadPathDiscovery.diagnostics.filter((diagnostic) => {
+            const pluginId = diagnostic.pluginId;
+            return !pluginId || pluginIdSet.has(pluginId);
+          })
+        : loadPathDiscovery.diagnostics;
       return loadPluginManifestRegistry({
         config: params.config,
         workspaceDir: params.workspaceDir,
         env,
-        candidates,
-        diagnostics: [...diagnostics],
-        installRecords: extractPluginInstallRecordsFromInstalledPluginIndex(params.index),
+        candidates: [...loadPathCandidates, ...candidates],
+        diagnostics: [...loadPathDiagnostics, ...diagnostics],
+        installRecords,
         ...(params.bundledChannelConfigCollector
           ? { bundledChannelConfigCollector: params.bundledChannelConfigCollector }
           : {}),


### PR DESCRIPTION
﻿Closes #99185

## What Problem This Solves

Fixes an issue where users with workspace plugins configured through `plugins.load.paths` would lose those plugins after a managed npm plugin populated the installed plugin index. The dropped workspace plugins then surfaced as stale `plugin not found` config warnings even though their files were still present.

## Why This Change Was Made

The installed-index manifest registry reconstruction now merges configured `plugins.load.paths` discovery candidates with the persisted installed-index candidates instead of treating the index as the only candidate source. The configured load-path scanner is shared with normal discovery so the same load-path validation and bundled-path diagnostics apply without broadening the installed-index path to bundled/global auto-discovery.

## User Impact

Users can install or enable managed npm plugins without breaking existing workspace plugins loaded from `plugins.load.paths`. Gateway startup and CLI config validation should continue to see both managed installed plugins and configured workspace plugins.

## Evidence

Current head: `a9a484b5dd20609fdd757842b759ba6ff8c014d3`.

- Claim proved: installed-index registry reconstruction keeps explicitly configured `plugins.load.paths` workspace plugins alongside installed-index plugins, preserves scoped lookups, and keeps normal bundled-load-path filtering behavior.
- Related PR quality gate: #99196 is an open proof-positive competing PR for #99185. This branch now includes the same critical behavior coverage points so maintainers can compare the implementations directly.
- Focused validation:
  - `node scripts/run-vitest.mjs src/plugins/manifest-registry-installed.test.ts`
  - Result: passed, 1 file / 20 passed / 1 skipped.
  - `git diff --check`
  - Result: clean.
- Behavior covered by the focused registry test suite:
  - Installed-index plugin plus `plugins.load.paths` workspace plugin both appear in the reconstructed registry.
  - Empty `plugins.load.paths` stays a no-op and returns only the installed-index plugin.
  - `pluginIds: ["workspace"]` scoped lookup returns the configured workspace plugin without leaking unrelated load-path plugins or installed-index plugins.
  - Redundant load paths pointing at OpenClaw bundled plugin directories are skipped with the existing `ignored plugins.load.paths entry` warning.
- Earlier supporting evidence from this PR:
  - `node_modules\.bin\oxlint --tsconfig config/tsconfig/oxlint.core.json src/plugins/manifest-registry-installed.ts src/plugins/manifest-registry-installed.test.ts` passed.
  - `node scripts/run-vitest.mjs src/plugins/manifest-registry-installed.test.ts` previously passed: 17 passed, 1 skipped.
  - `node scripts/run-vitest.mjs src/config/config.plugin-validation.test.ts` completed all assertions with 57 passed, 1 skipped, then failed during Windows temp SQLite cleanup with `EBUSY`; no test assertion failed after the code fix.
- Not tested / proof gaps:
  - No full live npm registry install plus gateway restart was run locally. The focused proof exercises the installed-index registry reconstruction seam directly with generated installed-index and workspace-plugin fixtures.
  - Because #99196 is already proof-positive, maintainers still need to choose one canonical landing branch for #99185.
