### PR TITLE
fix(android): expose exact gateway recovery actions

### DIFF
--- a/apps/.i18n/native-source.json
+++ b/apps/.i18n/native-source.json
@@ -179,7 +179,7 @@
     },
     {
       "kind": "ui-state-text",
-      "line": 497,
+      "line": 498,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Offline",
       "surface": "android",
@@ -187,7 +187,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1992,
+      "line": 1993,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Failed: this host requires wss:// or Tailscale Serve. No TLS endpoint detected.",
       "surface": "android",
@@ -195,7 +195,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1994,
+      "line": 1995,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Failed: secure endpoint reached, but TLS fingerprint verification timed out. Check Tailscale Serve or gateway TLS and retry.",
       "surface": "android",
@@ -203,7 +203,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1996,
+      "line": 1997,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Failed: couldn't reach the secure gateway endpoint for this host.",
       "surface": "android",
@@ -1957,9 +1957,9 @@
       "kind": "conditional-branch",
       "line": 1355,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
-      "source": "Gateway authentication is not configured. Edit this connection and try again.",
+      "source": "Gateway authentication is not configured. Configure it on the gateway host, then retry.",
       "surface": "android",
-      "id": "native.android.214b03b4cd2199b1"
+      "id": "native.android.3f61f2c34784ed0f"
     },
     {
       "kind": "conditional-branch",

--- a/apps/.i18n/native-source.json
+++ b/apps/.i18n/native-source.json
@@ -1242,8 +1242,80 @@
       "id": "native.android.732f5b59ba7e1513"
     },
     {
+      "kind": "conditional-branch",
+      "line": 86,
+      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/GatewayDiagnostics.kt",
+      "source": "Setup code expired",
+      "surface": "android",
+      "id": "native.android.b331b5b54e147e41"
+    },
+    {
+      "kind": "conditional-branch",
+      "line": 87,
+      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/GatewayDiagnostics.kt",
+      "source": "Gateway token needed",
+      "surface": "android",
+      "id": "native.android.fd29725b5271ffcc"
+    },
+    {
+      "kind": "conditional-branch",
+      "line": 88,
+      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/GatewayDiagnostics.kt",
+      "source": "Gateway token not configured",
+      "surface": "android",
+      "id": "native.android.a20706c18b04439c"
+    },
+    {
+      "kind": "conditional-branch",
+      "line": 89,
+      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/GatewayDiagnostics.kt",
+      "source": "Gateway password needed",
+      "surface": "android",
+      "id": "native.android.ef63577677f434bd"
+    },
+    {
+      "kind": "conditional-branch",
+      "line": 90,
+      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/GatewayDiagnostics.kt",
+      "source": "Gateway password invalid",
+      "surface": "android",
+      "id": "native.android.841612944fc3c917"
+    },
+    {
+      "kind": "conditional-branch",
+      "line": 91,
+      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/GatewayDiagnostics.kt",
+      "source": "Gateway password not configured",
+      "surface": "android",
+      "id": "native.android.746689fea659f156"
+    },
+    {
+      "kind": "conditional-branch",
+      "line": 92,
+      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/GatewayDiagnostics.kt",
+      "source": "Gateway access needs review",
+      "surface": "android",
+      "id": "native.android.3b34fd01c808e358"
+    },
+    {
+      "kind": "conditional-branch",
+      "line": 93,
+      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/GatewayDiagnostics.kt",
+      "source": "Saved auth invalid",
+      "surface": "android",
+      "id": "native.android.baaf14ba36d7cc94"
+    },
+    {
+      "kind": "conditional-branch",
+      "line": 94,
+      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/GatewayDiagnostics.kt",
+      "source": "Device identity required",
+      "surface": "android",
+      "id": "native.android.ec80b07c46a3bb1f"
+    },
+    {
       "kind": "ui-toast",
-      "line": 146,
+      "line": 177,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/GatewayDiagnostics.kt",
       "source": "Copied gateway diagnostics",
       "surface": "android",
@@ -1827,7 +1899,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1330,
+      "line": 1338,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Setup code expired. Scan a fresh setup QR.",
       "surface": "android",
@@ -1835,7 +1907,15 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1334,
+      "line": 1345,
+      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
+      "source": "Gateway access needs review. Check gateway authentication scopes, then retry.",
+      "surface": "android",
+      "id": "native.android.e03bb4ea463ba7a5"
+    },
+    {
+      "kind": "conditional-branch",
+      "line": 1346,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Gateway password is required. Enter it again or edit this connection.",
       "surface": "android",
@@ -1843,7 +1923,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1335,
+      "line": 1347,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Gateway password is invalid. Re-enter it or reset this gateway connection.",
       "surface": "android",
@@ -1851,7 +1931,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1336,
+      "line": 1348,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Gateway token is required. Enter it again or edit this connection.",
       "surface": "android",
@@ -1859,7 +1939,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1338,
+      "line": 1350,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Gateway requires this device identity. Re-authenticate or reset this gateway connection.",
       "surface": "android",
@@ -1867,7 +1947,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1342,
+      "line": 1354,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Saved authentication is invalid. Re-authenticate or reset this gateway connection.",
       "surface": "android",
@@ -1875,7 +1955,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1343,
+      "line": 1355,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Gateway authentication is not configured. Edit this connection and try again.",
       "surface": "android",
@@ -1883,7 +1963,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1344,
+      "line": 1356,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Gateway authentication needs review. Check gateway settings, then retry.",
       "surface": "android",
@@ -1891,7 +1971,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1361,
+      "line": 1373,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "$summary $it",
       "surface": "android",
@@ -1899,7 +1979,7 @@
     },
     {
       "kind": "ui-toast",
-      "line": 1408,
+      "line": 1420,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Approval command copied",
       "surface": "android",
@@ -1907,7 +1987,7 @@
     },
     {
       "kind": "ui-toast",
-      "line": 1435,
+      "line": 1447,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Diagnostic copied",
       "surface": "android",

--- a/apps/.i18n/native-source.json
+++ b/apps/.i18n/native-source.json
@@ -187,7 +187,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1993,
+      "line": 1994,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Failed: this host requires wss:// or Tailscale Serve. No TLS endpoint detected.",
       "surface": "android",
@@ -195,7 +195,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1995,
+      "line": 1996,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Failed: secure endpoint reached, but TLS fingerprint verification timed out. Check Tailscale Serve or gateway TLS and retry.",
       "surface": "android",
@@ -203,7 +203,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1997,
+      "line": 1998,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Failed: couldn't reach the secure gateway endpoint for this host.",
       "surface": "android",
@@ -1667,7 +1667,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 438,
+      "line": 437,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "OPENCLAW",
       "surface": "android",
@@ -1675,7 +1675,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 443,
+      "line": 442,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Your personal AI assistant.\nExfoliate! Exfoliate!",
       "surface": "android",
@@ -1683,7 +1683,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 453,
+      "line": 452,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Connect Gateway",
       "surface": "android",
@@ -1691,7 +1691,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 597,
+      "line": 596,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Setup code issue",
       "surface": "android",
@@ -1699,7 +1699,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 614,
+      "line": 613,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Advanced",
       "surface": "android",
@@ -1707,7 +1707,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 623,
+      "line": 622,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Setup code",
       "surface": "android",
@@ -1715,7 +1715,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 625,
+      "line": 624,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Host",
       "surface": "android",
@@ -1723,7 +1723,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 626,
+      "line": 625,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Port",
       "surface": "android",
@@ -1731,7 +1731,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 629,
+      "line": 628,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "TLS off",
       "surface": "android",
@@ -1739,7 +1739,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 629,
+      "line": 628,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "TLS on",
       "surface": "android",
@@ -1747,7 +1747,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 630,
+      "line": 629,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Local",
       "surface": "android",
@@ -1755,7 +1755,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 632,
+      "line": 631,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Token optional",
       "surface": "android",
@@ -1763,7 +1763,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 633,
+      "line": 632,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Password optional",
       "surface": "android",
@@ -1771,7 +1771,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 638,
+      "line": 637,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Pair with Gateway",
       "surface": "android",
@@ -1779,7 +1779,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 711,
+      "line": 710,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Last gateway",
       "surface": "android",
@@ -1787,7 +1787,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 776,
+      "line": 775,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Edit connection",
       "surface": "android",
@@ -1795,7 +1795,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 779,
+      "line": 778,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Copy diagnostic",
       "surface": "android",
@@ -1803,7 +1803,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 826,
+      "line": 825,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Copy approval command",
       "surface": "android",
@@ -1811,7 +1811,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 853,
+      "line": 852,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Allow permissions",
       "surface": "android",
@@ -1819,7 +1819,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 858,
+      "line": 857,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "These permissions keep OpenClaw secure\nand useful.",
       "surface": "android",
@@ -1827,7 +1827,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 936,
+      "line": 935,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Open $title",
       "surface": "android",
@@ -1835,7 +1835,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 997,
+      "line": 996,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Choose what this phone can share with OpenClaw. You can change these later in Settings.",
       "surface": "android",
@@ -1843,7 +1843,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1018,
+      "line": 1017,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Back",
       "surface": "android",
@@ -1851,7 +1851,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1022,
+      "line": 1021,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Permission Setup",
       "surface": "android",
@@ -1859,7 +1859,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1077,
+      "line": 1076,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Granted",
       "surface": "android",
@@ -1867,7 +1867,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1077,
+      "line": 1076,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Not granted",
       "surface": "android",
@@ -1875,7 +1875,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1102,
+      "line": 1101,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Continue",
       "surface": "android",
@@ -1883,7 +1883,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1157,
+      "line": 1156,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Scan fresh setup code",
       "surface": "android",
@@ -1891,7 +1891,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1159,
+      "line": 1158,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Retry connection",
       "surface": "android",
@@ -1899,7 +1899,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1338,
+      "line": 1337,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Setup code expired. Scan a fresh setup QR.",
       "surface": "android",
@@ -1907,7 +1907,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1345,
+      "line": 1344,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Gateway access needs review. Check gateway authentication scopes, then retry.",
       "surface": "android",
@@ -1915,7 +1915,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1346,
+      "line": 1345,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Gateway password is required. Enter it again or edit this connection.",
       "surface": "android",
@@ -1923,7 +1923,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1347,
+      "line": 1346,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Gateway password is invalid. Re-enter it or reset this gateway connection.",
       "surface": "android",
@@ -1931,7 +1931,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1348,
+      "line": 1347,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Gateway token is required. Enter it again or edit this connection.",
       "surface": "android",
@@ -1939,7 +1939,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1350,
+      "line": 1349,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Gateway requires this device identity. Re-authenticate or reset this gateway connection.",
       "surface": "android",
@@ -1947,7 +1947,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1354,
+      "line": 1353,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Saved authentication is invalid. Re-authenticate or reset this gateway connection.",
       "surface": "android",
@@ -1955,7 +1955,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1355,
+      "line": 1354,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Gateway authentication is not configured. Configure it on the gateway host, then retry.",
       "surface": "android",
@@ -1963,7 +1963,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1356,
+      "line": 1355,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Gateway authentication needs review. Check gateway settings, then retry.",
       "surface": "android",
@@ -1971,7 +1971,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1373,
+      "line": 1372,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "$summary $it",
       "surface": "android",
@@ -1979,7 +1979,7 @@
     },
     {
       "kind": "ui-toast",
-      "line": 1420,
+      "line": 1419,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Approval command copied",
       "surface": "android",
@@ -1987,7 +1987,7 @@
     },
     {
       "kind": "ui-toast",
-      "line": 1447,
+      "line": 1446,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Diagnostic copied",
       "surface": "android",

--- a/apps/.i18n/native-source.json
+++ b/apps/.i18n/native-source.json
@@ -179,7 +179,7 @@
     },
     {
       "kind": "ui-state-text",
-      "line": 496,
+      "line": 497,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Offline",
       "surface": "android",
@@ -187,7 +187,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1991,
+      "line": 1992,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Failed: this host requires wss:// or Tailscale Serve. No TLS endpoint detected.",
       "surface": "android",
@@ -195,7 +195,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1993,
+      "line": 1994,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Failed: secure endpoint reached, but TLS fingerprint verification timed out. Check Tailscale Serve or gateway TLS and retry.",
       "surface": "android",
@@ -203,7 +203,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1995,
+      "line": 1996,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Failed: couldn't reach the secure gateway endpoint for this host.",
       "surface": "android",
@@ -371,7 +371,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1093,
+      "line": 1095,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/gateway/GatewaySession.kt",
       "source": "Connecting…",
       "surface": "android",
@@ -379,7 +379,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1093,
+      "line": 1095,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/gateway/GatewaySession.kt",
       "source": "Reconnecting…",
       "surface": "android",
@@ -1243,7 +1243,7 @@
     },
     {
       "kind": "ui-toast",
-      "line": 113,
+      "line": 146,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/GatewayDiagnostics.kt",
       "source": "Copied gateway diagnostics",
       "surface": "android",
@@ -1435,7 +1435,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 53,
+      "line": 55,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/NodesDevicesSettingsScreen.kt",
       "source": "Nodes & Devices",
       "surface": "android",
@@ -1443,7 +1443,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 69,
+      "line": 71,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/NodesDevicesSettingsScreen.kt",
       "source": "Refresh",
       "surface": "android",
@@ -1451,7 +1451,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 69,
+      "line": 71,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/NodesDevicesSettingsScreen.kt",
       "source": "Refreshing",
       "surface": "android",
@@ -1459,7 +1459,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 83,
+      "line": 85,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/NodesDevicesSettingsScreen.kt",
       "source": "Connect the gateway to load nodes and paired devices.",
       "surface": "android",
@@ -1467,7 +1467,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 88,
+      "line": 90,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/NodesDevicesSettingsScreen.kt",
       "source": "No nodes or paired devices.",
       "surface": "android",
@@ -1475,7 +1475,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 89,
+      "line": 91,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/NodesDevicesSettingsScreen.kt",
       "source": "Linked phones and node hosts will appear here after pairing.",
       "surface": "android",
@@ -1483,7 +1483,23 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 106,
+      "line": 111,
+      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/NodesDevicesSettingsScreen.kt",
+      "source": "Node approval required",
+      "surface": "android",
+      "id": "native.android.e177c7f189c1a472"
+    },
+    {
+      "kind": "ui-named-argument",
+      "line": 112,
+      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/NodesDevicesSettingsScreen.kt",
+      "source": "Run on the Gateway host:",
+      "surface": "android",
+      "id": "native.android.a850defd5857e7d1"
+    },
+    {
+      "kind": "ui-named-argument",
+      "line": 127,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/NodesDevicesSettingsScreen.kt",
       "source": "Pending Requests",
       "surface": "android",
@@ -1491,7 +1507,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 116,
+      "line": 137,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/NodesDevicesSettingsScreen.kt",
       "source": "Nodes",
       "surface": "android",
@@ -1499,7 +1515,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 126,
+      "line": 147,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/NodesDevicesSettingsScreen.kt",
       "source": "Paired Devices",
       "surface": "android",
@@ -1507,7 +1523,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 170,
+      "line": 196,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/NodesDevicesSettingsScreen.kt",
       "source": "Repair",
       "surface": "android",
@@ -1515,7 +1531,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 170,
+      "line": 196,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/NodesDevicesSettingsScreen.kt",
       "source": "Review",
       "surface": "android",
@@ -1523,7 +1539,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 208,
+      "line": 234,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/NodesDevicesSettingsScreen.kt",
       "source": "Paired",
       "surface": "android",
@@ -1531,7 +1547,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 208,
+      "line": 234,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/NodesDevicesSettingsScreen.kt",
       "source": "Unpaired",
       "surface": "android",
@@ -1539,7 +1555,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 220,
+      "line": 246,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/NodesDevicesSettingsScreen.kt",
       "source": "Needs approval",
       "surface": "android",
@@ -1547,7 +1563,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 221,
+      "line": 247,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/NodesDevicesSettingsScreen.kt",
       "source": "Needs reapproval",
       "surface": "android",
@@ -1555,7 +1571,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 222,
+      "line": 248,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/NodesDevicesSettingsScreen.kt",
       "source": "Unapproved",
       "surface": "android",
@@ -1563,7 +1579,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 223,
+      "line": 249,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/NodesDevicesSettingsScreen.kt",
       "source": "Offline",
       "surface": "android",
@@ -1571,7 +1587,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 223,
+      "line": 249,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/NodesDevicesSettingsScreen.kt",
       "source": "Online",
       "surface": "android",
@@ -1579,7 +1595,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 428,
+      "line": 429,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "OPENCLAW",
       "surface": "android",
@@ -1587,7 +1603,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 433,
+      "line": 434,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Your personal AI assistant.\nExfoliate! Exfoliate!",
       "surface": "android",
@@ -1595,7 +1611,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 443,
+      "line": 444,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Connect Gateway",
       "surface": "android",
@@ -1603,7 +1619,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 587,
+      "line": 588,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Setup code issue",
       "surface": "android",
@@ -1611,7 +1627,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 604,
+      "line": 605,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Advanced",
       "surface": "android",
@@ -1619,7 +1635,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 613,
+      "line": 614,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Setup code",
       "surface": "android",
@@ -1627,7 +1643,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 615,
+      "line": 616,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Host",
       "surface": "android",
@@ -1635,7 +1651,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 616,
+      "line": 617,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Port",
       "surface": "android",
@@ -1643,7 +1659,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 619,
+      "line": 620,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "TLS off",
       "surface": "android",
@@ -1651,7 +1667,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 619,
+      "line": 620,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "TLS on",
       "surface": "android",
@@ -1659,7 +1675,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 620,
+      "line": 621,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Local",
       "surface": "android",
@@ -1667,7 +1683,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 622,
+      "line": 623,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Token optional",
       "surface": "android",
@@ -1675,7 +1691,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 623,
+      "line": 624,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Password optional",
       "surface": "android",
@@ -1683,7 +1699,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 628,
+      "line": 629,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Pair with Gateway",
       "surface": "android",
@@ -1691,23 +1707,15 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 697,
+      "line": 701,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Last gateway",
       "surface": "android",
       "id": "native.android.82b296ed39647687"
     },
     {
-      "kind": "conditional-branch",
-      "line": 739,
-      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
-      "source": "Retry connection",
-      "surface": "android",
-      "id": "native.android.3b169db8b57795b5"
-    },
-    {
       "kind": "ui-named-argument",
-      "line": 744,
+      "line": 767,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Edit connection",
       "surface": "android",
@@ -1715,7 +1723,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 745,
+      "line": 770,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Copy diagnostic",
       "surface": "android",
@@ -1723,7 +1731,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 779,
+      "line": 817,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Copy approval command",
       "surface": "android",
@@ -1731,7 +1739,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 806,
+      "line": 844,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Allow permissions",
       "surface": "android",
@@ -1739,7 +1747,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 811,
+      "line": 849,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "These permissions keep OpenClaw secure\nand useful.",
       "surface": "android",
@@ -1747,7 +1755,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 889,
+      "line": 927,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Open $title",
       "surface": "android",
@@ -1755,7 +1763,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 950,
+      "line": 988,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Choose what this phone can share with OpenClaw. You can change these later in Settings.",
       "surface": "android",
@@ -1763,7 +1771,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 971,
+      "line": 1009,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Back",
       "surface": "android",
@@ -1771,7 +1779,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 975,
+      "line": 1013,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Permission Setup",
       "surface": "android",
@@ -1779,7 +1787,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1030,
+      "line": 1068,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Granted",
       "surface": "android",
@@ -1787,7 +1795,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1030,
+      "line": 1068,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Not granted",
       "surface": "android",
@@ -1795,7 +1803,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1055,
+      "line": 1093,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Continue",
       "surface": "android",
@@ -1803,7 +1811,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1239,
+      "line": 1315,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Setup code expired. Scan a fresh setup QR.",
       "surface": "android",
@@ -1811,7 +1819,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1243,
+      "line": 1319,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Gateway password is required. Enter it again or edit this connection.",
       "surface": "android",
@@ -1819,7 +1827,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1244,
+      "line": 1320,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Gateway password is invalid. Re-enter it or reset this gateway connection.",
       "surface": "android",
@@ -1827,7 +1835,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1245,
+      "line": 1321,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Gateway token is required. Enter it again or edit this connection.",
       "surface": "android",
@@ -1835,7 +1843,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1247,
+      "line": 1323,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Gateway requires this device identity. Re-authenticate or reset this gateway connection.",
       "surface": "android",
@@ -1843,7 +1851,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1251,
+      "line": 1327,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Saved authentication is invalid. Re-authenticate or reset this gateway connection.",
       "surface": "android",
@@ -1851,7 +1859,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1252,
+      "line": 1328,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Gateway authentication is not configured. Edit this connection and try again.",
       "surface": "android",
@@ -1859,7 +1867,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1253,
+      "line": 1329,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Gateway authentication needs review. Check gateway settings, then retry.",
       "surface": "android",
@@ -1867,7 +1875,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1270,
+      "line": 1346,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "$summary $it",
       "surface": "android",
@@ -1875,7 +1883,7 @@
     },
     {
       "kind": "ui-toast",
-      "line": 1308,
+      "line": 1393,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Approval command copied",
       "surface": "android",
@@ -1883,7 +1891,7 @@
     },
     {
       "kind": "ui-toast",
-      "line": 1334,
+      "line": 1420,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Diagnostic copied",
       "surface": "android",

--- a/apps/.i18n/native-source.json
+++ b/apps/.i18n/native-source.json
@@ -1595,7 +1595,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 429,
+      "line": 438,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "OPENCLAW",
       "surface": "android",
@@ -1603,7 +1603,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 434,
+      "line": 443,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Your personal AI assistant.\nExfoliate! Exfoliate!",
       "surface": "android",
@@ -1611,7 +1611,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 444,
+      "line": 453,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Connect Gateway",
       "surface": "android",
@@ -1619,7 +1619,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 588,
+      "line": 597,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Setup code issue",
       "surface": "android",
@@ -1627,7 +1627,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 605,
+      "line": 614,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Advanced",
       "surface": "android",
@@ -1635,7 +1635,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 614,
+      "line": 623,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Setup code",
       "surface": "android",
@@ -1643,7 +1643,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 616,
+      "line": 625,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Host",
       "surface": "android",
@@ -1651,7 +1651,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 617,
+      "line": 626,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Port",
       "surface": "android",
@@ -1659,7 +1659,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 620,
+      "line": 629,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "TLS off",
       "surface": "android",
@@ -1667,7 +1667,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 620,
+      "line": 629,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "TLS on",
       "surface": "android",
@@ -1675,7 +1675,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 621,
+      "line": 630,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Local",
       "surface": "android",
@@ -1683,7 +1683,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 623,
+      "line": 632,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Token optional",
       "surface": "android",
@@ -1691,7 +1691,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 624,
+      "line": 633,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Password optional",
       "surface": "android",
@@ -1699,7 +1699,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 629,
+      "line": 638,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Pair with Gateway",
       "surface": "android",
@@ -1707,7 +1707,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 701,
+      "line": 711,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Last gateway",
       "surface": "android",
@@ -1715,7 +1715,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 767,
+      "line": 776,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Edit connection",
       "surface": "android",
@@ -1723,7 +1723,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 770,
+      "line": 779,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Copy diagnostic",
       "surface": "android",
@@ -1731,7 +1731,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 817,
+      "line": 826,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Copy approval command",
       "surface": "android",
@@ -1739,7 +1739,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 844,
+      "line": 853,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Allow permissions",
       "surface": "android",
@@ -1747,7 +1747,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 849,
+      "line": 858,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "These permissions keep OpenClaw secure\nand useful.",
       "surface": "android",
@@ -1755,7 +1755,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 927,
+      "line": 936,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Open $title",
       "surface": "android",
@@ -1763,7 +1763,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 988,
+      "line": 997,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Choose what this phone can share with OpenClaw. You can change these later in Settings.",
       "surface": "android",
@@ -1771,7 +1771,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1009,
+      "line": 1018,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Back",
       "surface": "android",
@@ -1779,7 +1779,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1013,
+      "line": 1022,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Permission Setup",
       "surface": "android",
@@ -1787,7 +1787,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1068,
+      "line": 1077,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Granted",
       "surface": "android",
@@ -1795,7 +1795,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1068,
+      "line": 1077,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Not granted",
       "surface": "android",
@@ -1803,7 +1803,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1093,
+      "line": 1102,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Continue",
       "surface": "android",
@@ -1811,7 +1811,23 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1315,
+      "line": 1157,
+      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
+      "source": "Scan fresh setup code",
+      "surface": "android",
+      "id": "native.android.547f11a819721ffb"
+    },
+    {
+      "kind": "conditional-branch",
+      "line": 1159,
+      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
+      "source": "Retry connection",
+      "surface": "android",
+      "id": "native.android.3b169db8b57795b5"
+    },
+    {
+      "kind": "conditional-branch",
+      "line": 1330,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Setup code expired. Scan a fresh setup QR.",
       "surface": "android",
@@ -1819,7 +1835,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1319,
+      "line": 1334,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Gateway password is required. Enter it again or edit this connection.",
       "surface": "android",
@@ -1827,7 +1843,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1320,
+      "line": 1335,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Gateway password is invalid. Re-enter it or reset this gateway connection.",
       "surface": "android",
@@ -1835,7 +1851,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1321,
+      "line": 1336,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Gateway token is required. Enter it again or edit this connection.",
       "surface": "android",
@@ -1843,7 +1859,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1323,
+      "line": 1338,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Gateway requires this device identity. Re-authenticate or reset this gateway connection.",
       "surface": "android",
@@ -1851,7 +1867,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1327,
+      "line": 1342,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Saved authentication is invalid. Re-authenticate or reset this gateway connection.",
       "surface": "android",
@@ -1859,7 +1875,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1328,
+      "line": 1343,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Gateway authentication is not configured. Edit this connection and try again.",
       "surface": "android",
@@ -1867,7 +1883,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1329,
+      "line": 1344,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Gateway authentication needs review. Check gateway settings, then retry.",
       "surface": "android",
@@ -1875,7 +1891,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1346,
+      "line": 1361,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "$summary $it",
       "surface": "android",
@@ -1883,7 +1899,7 @@
     },
     {
       "kind": "ui-toast",
-      "line": 1393,
+      "line": 1408,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Approval command copied",
       "surface": "android",
@@ -1891,7 +1907,7 @@
     },
     {
       "kind": "ui-toast",
-      "line": 1420,
+      "line": 1435,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Diagnostic copied",
       "surface": "android",

--- a/apps/android/app/src/main/java/ai/openclaw/app/MainViewModel.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/MainViewModel.kt
@@ -113,8 +113,8 @@ class MainViewModel(
 
   val isConnected: StateFlow<Boolean> = runtimeState(initial = false) { it.isConnected }
   val isNodeConnected: StateFlow<Boolean> = runtimeState(initial = false) { it.nodeConnected }
-  val nodeCapabilityApprovalState: StateFlow<GatewayNodeApprovalState> =
-    runtimeState(initial = GatewayNodeApprovalState.Loading) { it.nodeCapabilityApprovalState }
+  val nodeCapabilityApproval: StateFlow<GatewayNodeCapabilityApproval> =
+    runtimeState(initial = GatewayNodeCapabilityApproval.Loading) { it.nodeCapabilityApproval }
   val statusText: StateFlow<String> = runtimeState(initial = "Offline") { it.statusText }
   val gatewayConnectionProblem: StateFlow<GatewayConnectionProblem?> = runtimeState(initial = null) { it.gatewayConnectionProblem }
   val gatewayConnectionDisplay: StateFlow<GatewayConnectionDisplay> =

--- a/apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt
@@ -83,6 +83,7 @@ import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.atomic.AtomicLong
 
 private const val MAX_PENDING_NOTIFICATION_EVENTS = 128
+private const val NODE_APPROVAL_COMMAND_FRESH_MS = 30_000L
 
 internal data class PendingNotificationNodeEvent(
   val event: String,
@@ -2433,7 +2434,11 @@ class NodeRuntime(
       nodeApprovalRefreshGuard.publishIfCurrent(refreshGeneration) {
         _nodesDevicesRefreshing.value = true
         _nodesDevicesErrorText.value = null
-        _nodeCapabilityApproval.value = GatewayNodeCapabilityApproval.Loading
+        if (_nodeCapabilityApproval.value !is GatewayNodeCapabilityApproval.PendingApproval &&
+          _nodeCapabilityApproval.value !is GatewayNodeCapabilityApproval.PendingReapproval
+        ) {
+          _nodeCapabilityApproval.value = GatewayNodeCapabilityApproval.Loading
+        }
       }
     if (!refreshStarted) return
     if (!operatorConnected) {
@@ -2464,6 +2469,7 @@ class NodeRuntime(
       if (!publishedApproval) {
         return
       }
+      scheduleNodeApprovalCommandRefresh(refreshGeneration, approval)
       val devicesRoot =
         try {
           val devicesRes = operatorSession.request("device.pair.list", "{}")
@@ -2487,6 +2493,26 @@ class NodeRuntime(
     } finally {
       nodeApprovalRefreshGuard.publishIfCurrent(refreshGeneration) {
         _nodesDevicesRefreshing.value = false
+      }
+    }
+  }
+
+  private fun scheduleNodeApprovalCommandRefresh(
+    refreshGeneration: Long,
+    approval: GatewayNodeCapabilityApproval,
+  ) {
+    val fallback = approval.withoutExactRequestId() ?: return
+    scope.launch {
+      delay(NODE_APPROVAL_COMMAND_FRESH_MS)
+      // Pairing request IDs expire on the Gateway. Age out cached commands before rechecking so
+      // recovery never leaves an old exact ID visible when a refresh fails or races disconnect.
+      val shouldRefresh =
+        nodeApprovalRefreshGuard.publishIfCurrent(refreshGeneration) {
+          _nodeCapabilityApproval.value = fallback
+          _nodesDevicesSummary.value = _nodesDevicesSummary.value.withoutExactApprovalRequestIds()
+        }
+      if (shouldRefresh && operatorConnected) {
+        refreshNodesDevicesFromGateway()
       }
     }
   }
@@ -3495,6 +3521,17 @@ sealed interface GatewayNodeCapabilityApproval {
 
   data object Unapproved : GatewayNodeCapabilityApproval
 }
+
+internal fun GatewayNodeCapabilityApproval.withoutExactRequestId(): GatewayNodeCapabilityApproval? =
+  when (this) {
+    is GatewayNodeCapabilityApproval.PendingApproval ->
+      requestId?.let { GatewayNodeCapabilityApproval.PendingApproval(requestId = null) }
+    is GatewayNodeCapabilityApproval.PendingReapproval ->
+      requestId?.let { GatewayNodeCapabilityApproval.PendingReapproval(requestId = null) }
+    else -> null
+  }
+
+internal fun GatewayNodesDevicesSummary.withoutExactApprovalRequestIds(): GatewayNodesDevicesSummary = copy(nodes = nodes.map { node -> node.copy(pendingRequestId = null) })
 
 /** Prevents older node.list responses from overwriting newer approval state. */
 internal class GatewayNodeApprovalRefreshGuard {

--- a/apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt
@@ -2435,7 +2435,12 @@ class NodeRuntime(
       nodeApprovalRefreshGuard.publishIfCurrent(refreshGeneration) {
         _nodesDevicesRefreshing.value = true
         _nodesDevicesErrorText.value = null
-        if (_nodeCapabilityApproval.value !is GatewayNodeCapabilityApproval.PendingApproval &&
+        _nodesDevicesSummary.value = _nodesDevicesSummary.value.withoutExactApprovalRequestIds()
+        val pendingFallback = _nodeCapabilityApproval.value.withoutExactRequestId()
+        if (pendingFallback != null) {
+          _nodeCapabilityApproval.value = pendingFallback
+        } else if (
+          _nodeCapabilityApproval.value !is GatewayNodeCapabilityApproval.PendingApproval &&
           _nodeCapabilityApproval.value !is GatewayNodeCapabilityApproval.PendingReapproval
         ) {
           _nodeCapabilityApproval.value = GatewayNodeCapabilityApproval.Loading

--- a/apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt
@@ -14,6 +14,7 @@ import ai.openclaw.app.gateway.GatewayTlsProbeFailure
 import ai.openclaw.app.gateway.GatewayTlsProbeResult
 import ai.openclaw.app.gateway.GatewayUpdateAvailableSummary
 import ai.openclaw.app.gateway.NodeEventSendOutcome
+import ai.openclaw.app.gateway.normalizeGatewayApprovalRequestId
 import ai.openclaw.app.gateway.normalizeGatewayTlsFingerprint
 import ai.openclaw.app.gateway.parseChatSendAck
 import ai.openclaw.app.gateway.probeGatewayTlsFingerprint
@@ -488,8 +489,8 @@ class NodeRuntime(
   val isConnected: StateFlow<Boolean> = _isConnected.asStateFlow()
   private val _nodeConnected = MutableStateFlow(false)
   val nodeConnected: StateFlow<Boolean> = _nodeConnected.asStateFlow()
-  private val _nodeCapabilityApprovalState = MutableStateFlow(GatewayNodeApprovalState.Loading)
-  val nodeCapabilityApprovalState: StateFlow<GatewayNodeApprovalState> = _nodeCapabilityApprovalState.asStateFlow()
+  private val _nodeCapabilityApproval = MutableStateFlow<GatewayNodeCapabilityApproval>(GatewayNodeCapabilityApproval.Loading)
+  val nodeCapabilityApproval: StateFlow<GatewayNodeCapabilityApproval> = _nodeCapabilityApproval.asStateFlow()
 
   private val _gatewayConnectionDisplay = MutableStateFlow(GatewayConnectionDisplay(false, "Offline", null))
   val gatewayConnectionDisplay: StateFlow<GatewayConnectionDisplay> = _gatewayConnectionDisplay.asStateFlow()
@@ -2432,7 +2433,7 @@ class NodeRuntime(
       nodeApprovalRefreshGuard.publishIfCurrent(refreshGeneration) {
         _nodesDevicesRefreshing.value = true
         _nodesDevicesErrorText.value = null
-        _nodeCapabilityApprovalState.value = GatewayNodeApprovalState.Loading
+        _nodeCapabilityApproval.value = GatewayNodeCapabilityApproval.Loading
       }
     if (!refreshStarted) return
     if (!operatorConnected) {
@@ -2451,14 +2452,14 @@ class NodeRuntime(
       val nodesRes = operatorSession.request("node.list", "{}")
       val nodesRoot = json.parseToJsonElement(nodesRes).asObjectOrNull()
       val nodes = parseGatewayNodes(nodesRoot?.get("nodes") as? JsonArray)
-      val approvalState =
-        currentNodeCapabilityApprovalState(
+      val approval =
+        currentNodeCapabilityApproval(
           nodes = nodes,
           selfNodeId = identityStore.loadOrCreate().deviceId,
         )
       val publishedApproval =
         nodeApprovalRefreshGuard.publishIfCurrent(refreshGeneration) {
-          _nodeCapabilityApprovalState.value = approvalState
+          _nodeCapabilityApproval.value = approval
         }
       if (!publishedApproval) {
         return
@@ -2683,7 +2684,7 @@ class NodeRuntime(
   private fun invalidateNodeCapabilityApprovalState() {
     val refreshGeneration = nodeApprovalRefreshGuard.begin()
     nodeApprovalRefreshGuard.publishIfCurrent(refreshGeneration) {
-      _nodeCapabilityApprovalState.value = GatewayNodeApprovalState.Loading
+      _nodeCapabilityApproval.value = GatewayNodeCapabilityApproval.Loading
       _nodesDevicesRefreshing.value = false
     }
   }
@@ -3476,6 +3477,25 @@ enum class GatewayNodeApprovalState {
   Unapproved,
 }
 
+/** Current phone approval state; only pending variants can carry an approval target. */
+sealed interface GatewayNodeCapabilityApproval {
+  data object Loading : GatewayNodeCapabilityApproval
+
+  data object Unsupported : GatewayNodeCapabilityApproval
+
+  data object Approved : GatewayNodeCapabilityApproval
+
+  data class PendingApproval(
+    val requestId: String?,
+  ) : GatewayNodeCapabilityApproval
+
+  data class PendingReapproval(
+    val requestId: String?,
+  ) : GatewayNodeCapabilityApproval
+
+  data object Unapproved : GatewayNodeCapabilityApproval
+}
+
 /** Prevents older node.list responses from overwriting newer approval state. */
 internal class GatewayNodeApprovalRefreshGuard {
   private val lock = Any()
@@ -3508,14 +3528,26 @@ internal fun parseGatewayNodeApprovalState(raw: String?): GatewayNodeApprovalSta
     else -> GatewayNodeApprovalState.Loading
   }
 
-internal fun currentNodeCapabilityApprovalState(
+internal fun currentNodeCapabilityApproval(
   nodes: List<GatewayNodeSummary>,
   selfNodeId: String,
-): GatewayNodeApprovalState =
-  nodes
-    .firstOrNull { it.id == selfNodeId }
-    ?.approvalState
-    ?: GatewayNodeApprovalState.Loading
+): GatewayNodeCapabilityApproval {
+  val node = nodes.firstOrNull { it.id == selfNodeId } ?: return GatewayNodeCapabilityApproval.Loading
+  return when (node.approvalState) {
+    GatewayNodeApprovalState.Loading -> GatewayNodeCapabilityApproval.Loading
+    GatewayNodeApprovalState.Unsupported -> GatewayNodeCapabilityApproval.Unsupported
+    GatewayNodeApprovalState.Approved -> GatewayNodeCapabilityApproval.Approved
+    GatewayNodeApprovalState.PendingApproval ->
+      GatewayNodeCapabilityApproval.PendingApproval(
+        normalizeGatewayApprovalRequestId(node.pendingRequestId),
+      )
+    GatewayNodeApprovalState.PendingReapproval ->
+      GatewayNodeCapabilityApproval.PendingReapproval(
+        normalizeGatewayApprovalRequestId(node.pendingRequestId),
+      )
+    GatewayNodeApprovalState.Unapproved -> GatewayNodeCapabilityApproval.Unapproved
+  }
+}
 
 internal fun parseGatewayNodeSummary(item: JsonElement): GatewayNodeSummary? {
   val obj = item.asObjectOrNull() ?: return null
@@ -3536,7 +3568,7 @@ internal fun parseGatewayNodeSummary(item: JsonElement): GatewayNodeSummary? {
       } else {
         GatewayNodeApprovalState.Unsupported
       },
-    pendingRequestId = obj["pendingRequestId"].asStringOrNull()?.trim()?.takeIf { it.isNotEmpty() },
+    pendingRequestId = normalizeGatewayApprovalRequestId(obj["pendingRequestId"].asStringOrNull()),
     capabilities = parseGatewayStringArray(obj["caps"] as? JsonArray),
     commands = parseGatewayStringArray(obj["commands"] as? JsonArray),
   )

--- a/apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt
@@ -1895,6 +1895,7 @@ class NodeRuntime(
   ) {
     // A user-selected connect target must never inherit notification content from another gateway.
     notificationOutbox.clear()
+    invalidateNodeCapabilityApprovalState()
     val connectAttemptId = connectAttemptSeq.incrementAndGet()
     _pendingGatewayTrust.value = null
     val tls = connectionManager.resolveTlsParams(endpoint)
@@ -2711,6 +2712,7 @@ class NodeRuntime(
     val refreshGeneration = nodeApprovalRefreshGuard.begin()
     nodeApprovalRefreshGuard.publishIfCurrent(refreshGeneration) {
       _nodeCapabilityApproval.value = GatewayNodeCapabilityApproval.Loading
+      _nodesDevicesSummary.value = _nodesDevicesSummary.value.withoutExactApprovalRequestIds()
       _nodesDevicesRefreshing.value = false
     }
   }

--- a/apps/android/app/src/main/java/ai/openclaw/app/gateway/GatewaySession.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/gateway/GatewaySession.kt
@@ -1352,6 +1352,8 @@ internal fun shouldPauseGatewayReconnectAfterAuthFailure(
         )
     )
   }
+  // Gateway rate limits last minutes; generic retry advice must not trigger the short reconnect loop.
+  if (code == "AUTH_RATE_LIMITED") return true
   when (details?.recommendedNextStep) {
     "wait_then_retry" -> return false
     "retry_with_device_token" -> return !pendingDeviceTokenRetry
@@ -1369,7 +1371,6 @@ internal fun shouldPauseGatewayReconnectAfterAuthFailure(
     "AUTH_PASSWORD_MISMATCH",
     "AUTH_PASSWORD_NOT_CONFIGURED",
     "AUTH_SCOPE_MISMATCH",
-    "AUTH_RATE_LIMITED",
     "CONTROL_UI_DEVICE_IDENTITY_REQUIRED",
     "DEVICE_IDENTITY_REQUIRED",
     -> true

--- a/apps/android/app/src/main/java/ai/openclaw/app/gateway/GatewaySession.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/gateway/GatewaySession.kt
@@ -85,6 +85,14 @@ data class GatewayConnectErrorDetails(
   val minimumProbeProtocol: Int? = null,
 )
 
+private val gatewayApprovalRequestIdPattern = Regex("^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$")
+
+/** Keeps copied approval commands single-argument and safe for a gateway host shell. */
+internal fun normalizeGatewayApprovalRequestId(requestId: String?): String? {
+  val trimmed = requestId?.trim()?.takeIf { it.isNotEmpty() } ?: return null
+  return trimmed.takeIf { gatewayApprovalRequestIdPattern.matches(it) }
+}
+
 /**
  * Server hello fields cached by the Android runtime after a successful connect.
  */
@@ -144,7 +152,6 @@ class GatewaySession(
   private companion object {
     // Keep connect timeout above observed gateway unauthorized close on lower-end devices.
     private const val CONNECT_RPC_TIMEOUT_MS = 12_000L
-    private val PAIRING_REQUEST_ID_PATTERN = Regex("^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$")
   }
 
   /**
@@ -944,7 +951,7 @@ class GatewaySession(
                 recommendedNextStep = it["recommendedNextStep"].asStringOrNull(),
                 pauseReconnect = it["pauseReconnect"].asBooleanOrNull(),
                 reason = it["reason"].asStringOrNull(),
-                requestId = normalizePairingRequestId(it["requestId"].asStringOrNull()),
+                requestId = normalizeGatewayApprovalRequestId(it["requestId"].asStringOrNull()),
                 retryable = it["retryable"].asBooleanOrNull() == true,
                 clientMinProtocol = it["clientMinProtocol"].asIntOrNull(),
                 clientMaxProtocol = it["clientMaxProtocol"].asIntOrNull(),
@@ -973,11 +980,6 @@ class GatewaySession(
         return
       }
       onEvent(event, payloadJson)
-    }
-
-    private fun normalizePairingRequestId(requestId: String?): String? {
-      val trimmed = requestId?.trim()?.takeIf { it.isNotEmpty() } ?: return null
-      return trimmed.takeIf { PAIRING_REQUEST_ID_PATTERN.matches(it) }
     }
 
     private suspend fun awaitConnectNonce(): String =

--- a/apps/android/app/src/main/java/ai/openclaw/app/gateway/GatewaySession.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/gateway/GatewaySession.kt
@@ -1336,34 +1336,50 @@ internal fun shouldPauseGatewayReconnectAfterAuthFailure(
   role: String?,
   scopes: List<String>,
   pendingDeviceTokenRetry: Boolean,
-): Boolean =
-  when (error.details?.code) {
+): Boolean {
+  val details = error.details
+  val code = details?.code
+  if (code == "PAIRING_REQUIRED") {
+    val pairingDetails = details
+    return !(
+      hasBootstrapToken &&
+        role?.trim() == "node" &&
+        scopes.isEmpty() &&
+        pairingDetails.reason == "not-paired" &&
+        (
+          pairingDetails.pauseReconnect == false ||
+            pairingDetails.recommendedNextStep == "wait_then_retry"
+        )
+    )
+  }
+  when (details?.recommendedNextStep) {
+    "wait_then_retry" -> return false
+    "retry_with_device_token" -> return !pendingDeviceTokenRetry
+    "update_auth_configuration",
+    "update_auth_credentials",
+    "review_auth_configuration",
+    -> return true
+  }
+  return when (code) {
     "AUTH_TOKEN_MISSING",
+    "AUTH_TOKEN_NOT_CONFIGURED",
     "AUTH_DEVICE_TOKEN_MISMATCH",
     "AUTH_BOOTSTRAP_TOKEN_INVALID",
     "AUTH_PASSWORD_MISSING",
     "AUTH_PASSWORD_MISMATCH",
+    "AUTH_PASSWORD_NOT_CONFIGURED",
+    "AUTH_SCOPE_MISMATCH",
     "AUTH_RATE_LIMITED",
     "CONTROL_UI_DEVICE_IDENTITY_REQUIRED",
     "DEVICE_IDENTITY_REQUIRED",
     -> true
-    "PAIRING_REQUIRED" ->
-      !(
-        hasBootstrapToken &&
-          role?.trim() == "node" &&
-          scopes.isEmpty() &&
-          error.details.reason == "not-paired" &&
-          (
-            error.details.pauseReconnect == false ||
-              error.details.recommendedNextStep == "wait_then_retry"
-          )
-      )
     // The first shared-token mismatch may schedule one trusted stored-device-token retry.
     // Once no retry is pending, keep the terminal recovery action visible until credentials change.
     "AUTH_TOKEN_MISMATCH" -> !pendingDeviceTokenRetry
     "PROTOCOL_MISMATCH" -> true
     else -> false
   }
+}
 
 /** Builds the gateway WebSocket URL from endpoint authority and TLS policy. */
 internal fun buildGatewayWebSocketUrl(

--- a/apps/android/app/src/main/java/ai/openclaw/app/gateway/GatewaySession.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/gateway/GatewaySession.kt
@@ -1312,7 +1312,6 @@ class GatewaySession(
       hasBootstrapToken = target?.bootstrapToken?.trim()?.isNotEmpty() == true,
       role = target?.options?.role,
       scopes = target?.options?.scopes ?: emptyList(),
-      deviceTokenRetryBudgetUsed = deviceTokenRetryBudgetUsed,
       pendingDeviceTokenRetry = pendingDeviceTokenRetry,
     )
   }
@@ -1336,11 +1335,11 @@ internal fun shouldPauseGatewayReconnectAfterAuthFailure(
   hasBootstrapToken: Boolean,
   role: String?,
   scopes: List<String>,
-  deviceTokenRetryBudgetUsed: Boolean,
   pendingDeviceTokenRetry: Boolean,
 ): Boolean =
   when (error.details?.code) {
     "AUTH_TOKEN_MISSING",
+    "AUTH_DEVICE_TOKEN_MISMATCH",
     "AUTH_BOOTSTRAP_TOKEN_INVALID",
     "AUTH_PASSWORD_MISSING",
     "AUTH_PASSWORD_MISMATCH",
@@ -1359,7 +1358,9 @@ internal fun shouldPauseGatewayReconnectAfterAuthFailure(
               error.details.recommendedNextStep == "wait_then_retry"
           )
       )
-    "AUTH_TOKEN_MISMATCH" -> deviceTokenRetryBudgetUsed && !pendingDeviceTokenRetry
+    // The first shared-token mismatch may schedule one trusted stored-device-token retry.
+    // Once no retry is pending, keep the terminal recovery action visible until credentials change.
+    "AUTH_TOKEN_MISMATCH" -> !pendingDeviceTokenRetry
     "PROTOCOL_MISMATCH" -> true
     else -> false
   }

--- a/apps/android/app/src/main/java/ai/openclaw/app/ui/GatewayDiagnostics.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/ui/GatewayDiagnostics.kt
@@ -48,19 +48,50 @@ internal fun gatewayStatusLooksLikePairing(statusText: String): Boolean {
 }
 
 /** Maps structured gateway auth failures to the compact labels used by status surfaces. */
-internal fun gatewayAuthRecoveryLabel(problem: GatewayConnectionProblem?): String? =
-  when (problem?.code) {
-    "AUTH_BOOTSTRAP_TOKEN_INVALID" -> "Setup code expired"
-    "AUTH_TOKEN_MISSING" -> "Gateway token needed"
-    "AUTH_PASSWORD_MISSING" -> "Gateway password needed"
-    "AUTH_PASSWORD_MISMATCH" -> "Gateway password invalid"
-    "AUTH_TOKEN_MISMATCH",
-    "AUTH_DEVICE_TOKEN_MISMATCH",
-    -> "Saved auth invalid"
-    "CONTROL_UI_DEVICE_IDENTITY_REQUIRED",
-    "DEVICE_IDENTITY_REQUIRED",
-    -> "Device identity required"
-    else -> null
+internal fun gatewayAuthRecoveryLabel(problem: GatewayConnectionProblem?): String? {
+  val kind =
+    when (problem?.code) {
+      "AUTH_BOOTSTRAP_TOKEN_INVALID" -> GatewayAuthRecoveryLabelKind.SETUP_CODE_EXPIRED
+      "AUTH_TOKEN_MISSING" -> GatewayAuthRecoveryLabelKind.TOKEN_NEEDED
+      "AUTH_TOKEN_NOT_CONFIGURED" -> GatewayAuthRecoveryLabelKind.TOKEN_NOT_CONFIGURED
+      "AUTH_PASSWORD_MISSING" -> GatewayAuthRecoveryLabelKind.PASSWORD_NEEDED
+      "AUTH_PASSWORD_MISMATCH" -> GatewayAuthRecoveryLabelKind.PASSWORD_INVALID
+      "AUTH_PASSWORD_NOT_CONFIGURED" -> GatewayAuthRecoveryLabelKind.PASSWORD_NOT_CONFIGURED
+      "AUTH_SCOPE_MISMATCH" -> GatewayAuthRecoveryLabelKind.ACCESS_NEEDS_REVIEW
+      "AUTH_TOKEN_MISMATCH",
+      "AUTH_DEVICE_TOKEN_MISMATCH",
+      -> GatewayAuthRecoveryLabelKind.SAVED_AUTH_INVALID
+      "CONTROL_UI_DEVICE_IDENTITY_REQUIRED",
+      "DEVICE_IDENTITY_REQUIRED",
+      -> GatewayAuthRecoveryLabelKind.DEVICE_IDENTITY_REQUIRED
+      else -> return null
+    }
+  return gatewayAuthRecoveryLabel(kind)
+}
+
+private enum class GatewayAuthRecoveryLabelKind {
+  SETUP_CODE_EXPIRED,
+  TOKEN_NEEDED,
+  TOKEN_NOT_CONFIGURED,
+  PASSWORD_NEEDED,
+  PASSWORD_INVALID,
+  PASSWORD_NOT_CONFIGURED,
+  ACCESS_NEEDS_REVIEW,
+  SAVED_AUTH_INVALID,
+  DEVICE_IDENTITY_REQUIRED,
+}
+
+private fun gatewayAuthRecoveryLabel(kind: GatewayAuthRecoveryLabelKind): String =
+  when (kind) {
+    GatewayAuthRecoveryLabelKind.SETUP_CODE_EXPIRED -> "Setup code expired"
+    GatewayAuthRecoveryLabelKind.TOKEN_NEEDED -> "Gateway token needed"
+    GatewayAuthRecoveryLabelKind.TOKEN_NOT_CONFIGURED -> "Gateway token not configured"
+    GatewayAuthRecoveryLabelKind.PASSWORD_NEEDED -> "Gateway password needed"
+    GatewayAuthRecoveryLabelKind.PASSWORD_INVALID -> "Gateway password invalid"
+    GatewayAuthRecoveryLabelKind.PASSWORD_NOT_CONFIGURED -> "Gateway password not configured"
+    GatewayAuthRecoveryLabelKind.ACCESS_NEEDS_REVIEW -> "Gateway access needs review"
+    GatewayAuthRecoveryLabelKind.SAVED_AUTH_INVALID -> "Saved auth invalid"
+    GatewayAuthRecoveryLabelKind.DEVICE_IDENTITY_REQUIRED -> "Device identity required"
   }
 
 /** Returns the exact host command for one node's approval state when available. */

--- a/apps/android/app/src/main/java/ai/openclaw/app/ui/GatewayDiagnostics.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/ui/GatewayDiagnostics.kt
@@ -2,6 +2,9 @@ package ai.openclaw.app.ui
 
 import ai.openclaw.app.BuildConfig
 import ai.openclaw.app.GatewayConnectionProblem
+import ai.openclaw.app.GatewayNodeApprovalState
+import ai.openclaw.app.GatewayNodeCapabilityApproval
+import ai.openclaw.app.gateway.normalizeGatewayApprovalRequestId
 import android.content.ClipData
 import android.content.ClipboardManager
 import android.content.Context
@@ -58,6 +61,36 @@ internal fun gatewayAuthRecoveryLabel(problem: GatewayConnectionProblem?): Strin
     "DEVICE_IDENTITY_REQUIRED",
     -> "Device identity required"
     else -> null
+  }
+
+/** Returns the exact host command for one node's approval state when available. */
+internal fun gatewayNodeApprovalCommand(
+  state: GatewayNodeApprovalState,
+  requestId: String?,
+): String? =
+  when (state) {
+    GatewayNodeApprovalState.PendingApproval,
+    GatewayNodeApprovalState.PendingReapproval,
+    -> normalizeGatewayApprovalRequestId(requestId)?.let { "openclaw nodes approve $it" } ?: "openclaw nodes status"
+    GatewayNodeApprovalState.Unapproved -> "openclaw nodes status"
+    GatewayNodeApprovalState.Loading,
+    GatewayNodeApprovalState.Unsupported,
+    GatewayNodeApprovalState.Approved,
+    -> null
+  }
+
+internal fun gatewayNodeApprovalCommand(approval: GatewayNodeCapabilityApproval): String? =
+  when (approval) {
+    is GatewayNodeCapabilityApproval.PendingApproval ->
+      gatewayNodeApprovalCommand(GatewayNodeApprovalState.PendingApproval, approval.requestId)
+    is GatewayNodeCapabilityApproval.PendingReapproval ->
+      gatewayNodeApprovalCommand(GatewayNodeApprovalState.PendingReapproval, approval.requestId)
+    GatewayNodeCapabilityApproval.Unapproved ->
+      gatewayNodeApprovalCommand(GatewayNodeApprovalState.Unapproved, requestId = null)
+    GatewayNodeCapabilityApproval.Loading,
+    GatewayNodeCapabilityApproval.Unsupported,
+    GatewayNodeCapabilityApproval.Approved,
+    -> null
   }
 
 /** Builds the copyable support prompt with device, endpoint, and exact status context. */

--- a/apps/android/app/src/main/java/ai/openclaw/app/ui/NodesDevicesSettingsScreen.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/ui/NodesDevicesSettingsScreen.kt
@@ -19,6 +19,7 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.text.selection.SelectionContainer
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Cloud
 import androidx.compose.material3.HorizontalDivider
@@ -28,6 +29,7 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.unit.dp
 
 /** Settings screen for gateway nodes, paired devices, and pending pairing requests. */
@@ -102,6 +104,25 @@ private fun NodesDevicesPanel(summary: GatewayNodesDevicesSummary) {
         Text(text = devicePairingAdminUnavailableText(), style = ClawTheme.type.body, color = ClawTheme.colors.textMuted)
       }
     }
+    val approvalCommands = summary.nodes.mapNotNull(::nodeApprovalCommandRow)
+    if (approvalCommands.isNotEmpty()) {
+      ClawPanel {
+        Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+          Text(text = "Node approval required", style = ClawTheme.type.section, color = ClawTheme.colors.text)
+          Text(text = "Run on the Gateway host:", style = ClawTheme.type.body, color = ClawTheme.colors.textMuted)
+          approvalCommands.forEach { (label, command) ->
+            Text(text = label, style = ClawTheme.type.caption, color = ClawTheme.colors.textMuted)
+            SelectionContainer {
+              Text(
+                text = command,
+                style = ClawTheme.type.body.copy(fontFamily = FontFamily.Monospace),
+                color = ClawTheme.colors.text,
+              )
+            }
+          }
+        }
+      }
+    }
     if (summary.pendingDevices.isNotEmpty()) {
       NodesSection(title = "Pending Requests") {
         summary.pendingDevices.forEachIndexed { index, device ->
@@ -133,6 +154,11 @@ private fun NodesDevicesPanel(summary: GatewayNodesDevicesSummary) {
       }
     }
   }
+}
+
+private fun nodeApprovalCommandRow(node: GatewayNodeSummary): Pair<String, String>? {
+  val command = gatewayNodeApprovalCommand(node.approvalState, node.pendingRequestId) ?: return null
+  return (node.displayName ?: node.id) to command
 }
 
 @Composable

--- a/apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt
@@ -1,11 +1,12 @@
 package ai.openclaw.app.ui
 
 import ai.openclaw.app.GatewayConnectionProblem
-import ai.openclaw.app.GatewayNodeApprovalState
+import ai.openclaw.app.GatewayNodeCapabilityApproval
 import ai.openclaw.app.LocationMode
 import ai.openclaw.app.MainViewModel
 import ai.openclaw.app.R
 import ai.openclaw.app.SensitiveFeatureConfig
+import ai.openclaw.app.gateway.normalizeGatewayApprovalRequestId
 import ai.openclaw.app.hasPhotoReadPermission
 import ai.openclaw.app.node.DeviceNotificationListenerService
 import ai.openclaw.app.photoReadPermissionsForRequest
@@ -144,7 +145,7 @@ fun OnboardingFlow(
     val gatewayConnectionProblem = gatewayConnectionDisplay.problem
     val isConnected = gatewayConnectionDisplay.isConnected
     val isNodeConnected by viewModel.isNodeConnected.collectAsState()
-    val nodeCapabilityApprovalState by viewModel.nodeCapabilityApprovalState.collectAsState()
+    val nodeCapabilityApproval by viewModel.nodeCapabilityApproval.collectAsState()
     val runtimeInitialized by viewModel.runtimeInitialized.collectAsState()
     val serverName by viewModel.serverName.collectAsState()
     val remoteAddress by viewModel.remoteAddress.collectAsState()
@@ -160,7 +161,7 @@ fun OnboardingFlow(
       canFinishOnboarding(
         isConnected = isConnected,
         isNodeConnected = isNodeConnected,
-        nodeCapabilityApprovalState = nodeCapabilityApprovalState,
+        nodeCapabilityApproval = nodeCapabilityApproval,
       )
 
     var step by rememberSaveable { mutableStateOf(OnboardingStep.Welcome) }
@@ -368,7 +369,7 @@ fun OnboardingFlow(
           attemptedGatewayName = attemptedGatewayName,
           remoteAddress = remoteAddress,
           ready = ready,
-          nodeCapabilityApprovalState = nodeCapabilityApprovalState,
+          nodeCapabilityApproval = nodeCapabilityApproval,
           gatewayConnectionProblem = gatewayConnectionProblem,
           connectSettling = recoveryNowMs - connectAttemptStartedAtMs < GATEWAY_CONNECT_SETTLING_MS,
           onBack = { step = OnboardingStep.Gateway },
@@ -637,7 +638,7 @@ private fun GatewayRecoveryScreen(
   attemptedGatewayName: String?,
   remoteAddress: String?,
   ready: Boolean,
-  nodeCapabilityApprovalState: GatewayNodeApprovalState,
+  nodeCapabilityApproval: GatewayNodeCapabilityApproval,
   gatewayConnectionProblem: GatewayConnectionProblem?,
   connectSettling: Boolean,
   onBack: () -> Unit,
@@ -651,9 +652,10 @@ private fun GatewayRecoveryScreen(
       ready = ready,
       statusText = statusText,
       connectSettling = connectSettling,
-      nodeCapabilityApprovalState = nodeCapabilityApprovalState,
+      nodeCapabilityApproval = nodeCapabilityApproval,
       gatewayConnectionProblem = gatewayConnectionProblem,
     )
+  val primaryAction = gatewayRecoveryPrimaryAction(ready, gatewayConnectionProblem)
   val context = LocalContext.current
 
   ClawScaffold(modifier = modifier, contentPadding = PaddingValues(horizontal = 18.dp, vertical = 16.dp)) {
@@ -667,6 +669,7 @@ private fun GatewayRecoveryScreen(
               GatewayRecoveryUiState.Connected -> Icons.Default.CheckCircle
               GatewayRecoveryUiState.NodeCapabilityApprovalPending -> Icons.Default.WifiTethering
               GatewayRecoveryUiState.ApprovalRequired -> Icons.Default.WifiTethering
+              GatewayRecoveryUiState.AuthenticationRequired -> Icons.Default.Security
               GatewayRecoveryUiState.Pairing -> Icons.Default.WifiTethering
               GatewayRecoveryUiState.Finishing -> Icons.Default.WifiTethering
               GatewayRecoveryUiState.Failed -> Icons.Default.ErrorOutline
@@ -678,6 +681,7 @@ private fun GatewayRecoveryScreen(
               GatewayRecoveryUiState.Connected -> ClawTheme.colors.success
               GatewayRecoveryUiState.NodeCapabilityApprovalPending -> ClawTheme.colors.warning
               GatewayRecoveryUiState.ApprovalRequired -> ClawTheme.colors.warning
+              GatewayRecoveryUiState.AuthenticationRequired -> ClawTheme.colors.warning
               GatewayRecoveryUiState.Pairing -> ClawTheme.colors.text
               GatewayRecoveryUiState.Finishing -> ClawTheme.colors.text
               GatewayRecoveryUiState.Failed -> ClawTheme.colors.warning
@@ -702,13 +706,13 @@ private fun GatewayRecoveryScreen(
                 ready = ready,
                 remoteAddress = remoteAddress,
                 statusText = statusText,
-                nodeCapabilityApprovalState = nodeCapabilityApprovalState,
+                nodeCapabilityApproval = nodeCapabilityApproval,
                 gatewayConnectionProblem = gatewayConnectionProblem,
               ),
             style = ClawTheme.type.body,
             color = ClawTheme.colors.textMuted,
           )
-          recoveryGatewayApprovalCommand(gatewayConnectionProblem)?.let { command ->
+          recoveryGatewayApprovalCommand(nodeCapabilityApproval, gatewayConnectionProblem)?.let { command ->
             ApprovalCommandBlock(command = command, onCopy = { copyApprovalCommand(context, command) })
           }
           ClawStatusPill(
@@ -717,6 +721,7 @@ private fun GatewayRecoveryScreen(
                 GatewayRecoveryUiState.Connected -> "Healthy"
                 GatewayRecoveryUiState.NodeCapabilityApprovalPending -> "Node approval"
                 GatewayRecoveryUiState.ApprovalRequired -> "Needs approval"
+                GatewayRecoveryUiState.AuthenticationRequired -> "Needs authentication"
                 GatewayRecoveryUiState.Pairing -> "Pairing"
                 GatewayRecoveryUiState.Finishing -> "Connecting"
                 GatewayRecoveryUiState.Failed -> "Needs attention"
@@ -726,6 +731,7 @@ private fun GatewayRecoveryScreen(
                 GatewayRecoveryUiState.Connected -> ClawStatus.Success
                 GatewayRecoveryUiState.NodeCapabilityApprovalPending -> ClawStatus.Warning
                 GatewayRecoveryUiState.ApprovalRequired -> ClawStatus.Warning
+                GatewayRecoveryUiState.AuthenticationRequired -> ClawStatus.Warning
                 GatewayRecoveryUiState.Pairing -> ClawStatus.Neutral
                 GatewayRecoveryUiState.Finishing -> ClawStatus.Neutral
                 GatewayRecoveryUiState.Failed -> ClawStatus.Warning
@@ -736,13 +742,45 @@ private fun GatewayRecoveryScreen(
 
       Column(verticalArrangement = Arrangement.spacedBy(10.dp)) {
         ClawPrimaryButton(
-          text = if (ready) "Continue" else "Retry connection",
-          icon = if (ready) Icons.Default.CheckCircle else Icons.Default.Refresh,
-          onClick = if (ready) onContinue else onRetry,
+          text = primaryAction.label,
+          icon =
+            when (primaryAction) {
+              GatewayRecoveryPrimaryAction.Continue -> Icons.Default.CheckCircle
+              GatewayRecoveryPrimaryAction.ScanFreshSetupCode -> Icons.Default.QrCode2
+              GatewayRecoveryPrimaryAction.EditConnection -> Icons.Default.Edit
+              GatewayRecoveryPrimaryAction.RetryConnection -> Icons.Default.Refresh
+            },
+          onClick =
+            when (primaryAction) {
+              GatewayRecoveryPrimaryAction.Continue -> onContinue
+              GatewayRecoveryPrimaryAction.ScanFreshSetupCode,
+              GatewayRecoveryPrimaryAction.EditConnection,
+              -> onEdit
+              GatewayRecoveryPrimaryAction.RetryConnection -> onRetry
+            },
           modifier = Modifier.fillMaxWidth(),
         )
-        OutlinedAction(title = "Edit connection", icon = Icons.Default.Edit, onClick = onEdit)
-        OutlinedAction(title = "Copy diagnostic", icon = Icons.Default.ContentCopy, onClick = { copyGatewayDiagnostic(context, statusText, serverName, remoteAddress, ready, gatewayConnectionProblem) })
+        if (
+          primaryAction != GatewayRecoveryPrimaryAction.ScanFreshSetupCode &&
+          primaryAction != GatewayRecoveryPrimaryAction.EditConnection
+        ) {
+          OutlinedAction(title = "Edit connection", icon = Icons.Default.Edit, onClick = onEdit)
+        }
+        OutlinedAction(
+          title = "Copy diagnostic",
+          icon = Icons.Default.ContentCopy,
+          onClick = {
+            copyGatewayDiagnostic(
+              context,
+              statusText,
+              serverName,
+              remoteAddress,
+              ready,
+              nodeCapabilityApproval,
+              gatewayConnectionProblem,
+            )
+          },
+        )
       }
     }
   }
@@ -1075,6 +1113,10 @@ internal enum class GatewayRecoveryUiState(
     title = "Pairing Gateway",
     message = "Approve this phone on the gateway.\nThen retry the connection.",
   ),
+  AuthenticationRequired(
+    title = "Authentication needed",
+    message = "Update this Gateway connection to continue.",
+  ),
   NodeCapabilityApprovalPending(
     title = "Node Approval Pending",
     message = "Gateway pairing worked.\nApprove this phone's node capabilities from an operator UI.",
@@ -1092,6 +1134,42 @@ internal enum class GatewayRecoveryUiState(
     message = "We could not reach your Gateway.\nLet's fix this.",
   ),
 }
+
+internal enum class GatewayRecoveryPrimaryAction(
+  val label: String,
+) {
+  Continue("Continue"),
+  ScanFreshSetupCode("Scan fresh setup code"),
+  EditConnection("Edit connection"),
+  RetryConnection("Retry connection"),
+}
+
+/** Selects the action that can actually recover the current structured gateway failure. */
+internal fun gatewayRecoveryPrimaryAction(
+  ready: Boolean,
+  problem: GatewayConnectionProblem?,
+): GatewayRecoveryPrimaryAction =
+  when {
+    ready -> GatewayRecoveryPrimaryAction.Continue
+    problem?.code == "AUTH_BOOTSTRAP_TOKEN_INVALID" -> GatewayRecoveryPrimaryAction.ScanFreshSetupCode
+    gatewayProblemNeedsCredentialUpdate(problem) -> GatewayRecoveryPrimaryAction.EditConnection
+    else -> GatewayRecoveryPrimaryAction.RetryConnection
+  }
+
+private fun gatewayProblemNeedsCredentialUpdate(problem: GatewayConnectionProblem?): Boolean =
+  when (problem?.code) {
+    "AUTH_DEVICE_TOKEN_MISMATCH",
+    "AUTH_TOKEN_MISMATCH",
+    "AUTH_PASSWORD_MISSING",
+    "AUTH_PASSWORD_MISMATCH",
+    "AUTH_TOKEN_MISSING",
+    "CONTROL_UI_DEVICE_IDENTITY_REQUIRED",
+    "DEVICE_IDENTITY_REQUIRED",
+    -> true
+    else ->
+      problem?.recommendedNextStep == "update_auth_credentials" ||
+        problem?.recommendedNextStep == "update_auth_configuration"
+  }
 
 internal data class NearbyGatewayUiState(
   val subtitle: String,
@@ -1136,19 +1214,19 @@ internal fun gatewayRecoveryUiState(
   ready: Boolean,
   statusText: String,
   connectSettling: Boolean,
-  nodeCapabilityApprovalState: GatewayNodeApprovalState,
+  nodeCapabilityApproval: GatewayNodeCapabilityApproval,
   gatewayConnectionProblem: GatewayConnectionProblem? = null,
 ): GatewayRecoveryUiState =
   when {
     ready -> GatewayRecoveryUiState.Connected
-    nodeCapabilityApprovalState == GatewayNodeApprovalState.PendingApproval ||
-      nodeCapabilityApprovalState == GatewayNodeApprovalState.PendingReapproval ||
-      nodeCapabilityApprovalState == GatewayNodeApprovalState.Unapproved -> GatewayRecoveryUiState.NodeCapabilityApprovalPending
+    nodeCapabilityApproval.needsApproval() -> GatewayRecoveryUiState.NodeCapabilityApprovalPending
     gatewayConnectionProblem?.isPairingRequired == true &&
       !gatewayConnectionProblem.canAutoRetry -> GatewayRecoveryUiState.ApprovalRequired
     gatewayConnectionProblem?.isPairingRequired == true -> GatewayRecoveryUiState.Pairing
+    gatewayRecoveryPrimaryAction(ready = false, problem = gatewayConnectionProblem) !=
+      GatewayRecoveryPrimaryAction.RetryConnection -> GatewayRecoveryUiState.AuthenticationRequired
     gatewayConnectionProblem?.pauseReconnect == true -> GatewayRecoveryUiState.Failed
-    nodeCapabilityApprovalState == GatewayNodeApprovalState.Loading -> GatewayRecoveryUiState.Finishing
+    nodeCapabilityApproval == GatewayNodeCapabilityApproval.Loading -> GatewayRecoveryUiState.Finishing
     connectSettling -> GatewayRecoveryUiState.Finishing
     gatewayStatusLooksLikePairing(statusText) -> GatewayRecoveryUiState.Pairing
     gatewayStatusLooksLikePartialConnect(statusText) -> GatewayRecoveryUiState.Finishing
@@ -1204,26 +1282,24 @@ internal fun recoveryGatewayDetail(
   ready: Boolean,
   remoteAddress: String?,
   statusText: String,
-  nodeCapabilityApprovalState: GatewayNodeApprovalState,
+  nodeCapabilityApproval: GatewayNodeCapabilityApproval,
   gatewayConnectionProblem: GatewayConnectionProblem?,
 ): String =
   if (ready) {
     remoteAddress?.takeIf { it.isNotBlank() } ?: "Ready for chat and voice"
-  } else if (
-    nodeCapabilityApprovalState == GatewayNodeApprovalState.PendingApproval ||
-    nodeCapabilityApprovalState == GatewayNodeApprovalState.PendingReapproval ||
-    nodeCapabilityApprovalState == GatewayNodeApprovalState.Unapproved
-  ) {
-    "Gateway paired. Waiting for node capability approval."
+  } else if (nodeCapabilityApproval.needsApproval()) {
+    recoveryGatewayApprovalCommand(nodeCapabilityApproval, gatewayConnectionProblem)
+      ?.let { "Gateway paired. Run this on the gateway host:" }
+      ?: "Gateway paired. Waiting for node capability approval."
   } else if (gatewayConnectionProblem?.isPairingRequired == true && !gatewayConnectionProblem.canAutoRetry) {
-    recoveryGatewayApprovalCommand(gatewayConnectionProblem)
+    recoveryGatewayApprovalCommand(nodeCapabilityApproval, gatewayConnectionProblem)
       ?.let { "Gateway approval is pending. Run this on the gateway host:" }
       ?: "Gateway approval is pending. Run openclaw devices list on the gateway host, approve this phone, then retry."
   } else if (gatewayConnectionProblem?.isPairingRequired == true && gatewayConnectionProblem.canAutoRetry) {
     "Gateway approval is in progress. OpenClaw will retry automatically."
   } else if (gatewayConnectionProblem != null) {
     recoveryGatewayAuthDetail(gatewayConnectionProblem)
-  } else if (nodeCapabilityApprovalState == GatewayNodeApprovalState.Loading) {
+  } else if (nodeCapabilityApproval == GatewayNodeCapabilityApproval.Loading) {
     "Gateway paired. Checking node capability approval."
   } else if (statusText.contains("operator offline", ignoreCase = true)) {
     "Gateway paired. Waiting for operator access."
@@ -1289,9 +1365,18 @@ private fun protocolMismatchVersions(
     ?.joinToString(prefix = "(", postfix = ").")
 }
 
-private fun recoveryGatewayApprovalCommand(gatewayConnectionProblem: GatewayConnectionProblem?): String? {
+private fun GatewayNodeCapabilityApproval.needsApproval(): Boolean =
+  this is GatewayNodeCapabilityApproval.PendingApproval ||
+    this is GatewayNodeCapabilityApproval.PendingReapproval ||
+    this == GatewayNodeCapabilityApproval.Unapproved
+
+internal fun recoveryGatewayApprovalCommand(
+  nodeCapabilityApproval: GatewayNodeCapabilityApproval,
+  gatewayConnectionProblem: GatewayConnectionProblem?,
+): String? {
+  gatewayNodeApprovalCommand(nodeCapabilityApproval)?.let { return it }
   if (gatewayConnectionProblem?.isPairingRequired != true || gatewayConnectionProblem.canAutoRetry) return null
-  val requestId = gatewayConnectionProblem.requestId?.trim()?.takeIf { it.isNotEmpty() }
+  val requestId = normalizeGatewayApprovalRequestId(gatewayConnectionProblem.requestId)
   return if (requestId != null) {
     "openclaw devices approve $requestId"
   } else {
@@ -1315,9 +1400,10 @@ private fun copyGatewayDiagnostic(
   serverName: String?,
   remoteAddress: String?,
   ready: Boolean,
+  nodeCapabilityApproval: GatewayNodeCapabilityApproval,
   gatewayConnectionProblem: GatewayConnectionProblem?,
 ) {
-  val approvalCommand = recoveryGatewayApprovalCommand(gatewayConnectionProblem)
+  val approvalCommand = recoveryGatewayApprovalCommand(nodeCapabilityApproval, gatewayConnectionProblem)
   val diagnostic =
     listOfNotNull(
       "OpenClaw Android gateway diagnostic",
@@ -1353,18 +1439,18 @@ private class PermissionState(
 internal fun canFinishOnboarding(
   isConnected: Boolean,
   isNodeConnected: Boolean,
-  nodeCapabilityApprovalState: GatewayNodeApprovalState,
+  nodeCapabilityApproval: GatewayNodeCapabilityApproval,
 ): Boolean =
   isConnected &&
     isNodeConnected &&
-    when (nodeCapabilityApprovalState) {
-      GatewayNodeApprovalState.PendingApproval,
-      GatewayNodeApprovalState.PendingReapproval,
-      GatewayNodeApprovalState.Unapproved,
-      GatewayNodeApprovalState.Loading,
+    when (nodeCapabilityApproval) {
+      is GatewayNodeCapabilityApproval.PendingApproval,
+      is GatewayNodeCapabilityApproval.PendingReapproval,
+      GatewayNodeCapabilityApproval.Unapproved,
+      GatewayNodeCapabilityApproval.Loading,
       -> false
-      GatewayNodeApprovalState.Approved,
-      GatewayNodeApprovalState.Unsupported,
+      GatewayNodeCapabilityApproval.Approved,
+      GatewayNodeCapabilityApproval.Unsupported,
       -> true
     }
 

--- a/apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt
@@ -213,7 +213,6 @@ fun OnboardingFlow(
       )
 
     fun scanGatewaySetupCode() {
-      setupCode = ""
       setupError = null
       qrScanner
         .startScan()

--- a/apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt
@@ -212,6 +212,41 @@ fun OnboardingFlow(
         password = password,
       )
 
+    fun scanGatewaySetupCode() {
+      setupCode = ""
+      setupError = null
+      qrScanner
+        .startScan()
+        .addOnSuccessListener { barcode ->
+          val scanned = resolveScannedSetupCodeResult(barcode.rawValue.orEmpty())
+          val scannedSetupCode = scanned.setupCode
+          if (scannedSetupCode == null) {
+            setupError =
+              gatewayEndpointValidationMessage(
+                scanned.error ?: GatewayEndpointValidationError.INVALID_URL,
+                GatewayEndpointInputSource.QR_SCAN,
+              )
+            step = OnboardingStep.Gateway
+            return@addOnSuccessListener
+          }
+          val plan = resolveCurrentGatewayPlan(setupCodeValue = scannedSetupCode)
+          if (plan == null) {
+            setupError =
+              gatewayEndpointValidationMessage(
+                GatewayEndpointValidationError.INVALID_URL,
+                GatewayEndpointInputSource.QR_SCAN,
+              )
+            step = OnboardingStep.Gateway
+            return@addOnSuccessListener
+          }
+          setupCode = scannedSetupCode
+          connectToGatewayPlan(plan)
+        }.addOnFailureListener {
+          setupError = "Could not open the scanner."
+          step = OnboardingStep.Gateway
+        }
+    }
+
     LaunchedEffect(startAtGatewaySetup) {
       if (startAtGatewaySetup) {
         step = OnboardingStep.Gateway
@@ -301,34 +336,7 @@ fun OnboardingFlow(
           discoveryStarted = runtimeInitialized,
           error = setupError,
           onBack = { step = OnboardingStep.Welcome },
-          onScan = {
-            setupError = null
-            qrScanner
-              .startScan()
-              .addOnSuccessListener { barcode ->
-                val scanned = resolveScannedSetupCodeResult(barcode.rawValue.orEmpty())
-                val scannedSetupCode = scanned.setupCode
-                if (scannedSetupCode == null) {
-                  setupError =
-                    gatewayEndpointValidationMessage(
-                      scanned.error ?: GatewayEndpointValidationError.INVALID_URL,
-                      GatewayEndpointInputSource.QR_SCAN,
-                    )
-                  return@addOnSuccessListener
-                }
-                val plan = resolveCurrentGatewayPlan(setupCodeValue = scannedSetupCode)
-                if (plan == null) {
-                  setupError =
-                    gatewayEndpointValidationMessage(
-                      GatewayEndpointValidationError.INVALID_URL,
-                      GatewayEndpointInputSource.QR_SCAN,
-                    )
-                  return@addOnSuccessListener
-                }
-                setupCode = scannedSetupCode
-                connectToGatewayPlan(plan)
-              }.addOnFailureListener { setupError = "Could not open the scanner." }
-          },
+          onScan = ::scanGatewaySetupCode,
           onSetupCodeChange = {
             setupCode = it
             setupError = null
@@ -378,6 +386,7 @@ fun OnboardingFlow(
             connectToGatewayPlan(plan.copy(savedAuthAction = GatewaySavedAuthAction.PRESERVE))
           },
           onEdit = { step = OnboardingStep.Gateway },
+          onScan = ::scanGatewaySetupCode,
           onContinue = { step = OnboardingStep.Permissions },
         )
       OnboardingStep.Permissions ->
@@ -644,6 +653,7 @@ private fun GatewayRecoveryScreen(
   onBack: () -> Unit,
   onRetry: () -> Unit,
   onEdit: () -> Unit,
+  onScan: () -> Unit,
   onContinue: () -> Unit,
   modifier: Modifier = Modifier,
 ) {
@@ -742,7 +752,7 @@ private fun GatewayRecoveryScreen(
 
       Column(verticalArrangement = Arrangement.spacedBy(10.dp)) {
         ClawPrimaryButton(
-          text = primaryAction.label,
+          text = gatewayRecoveryPrimaryActionLabel(primaryAction),
           icon =
             when (primaryAction) {
               GatewayRecoveryPrimaryAction.Continue -> Icons.Default.CheckCircle
@@ -753,9 +763,8 @@ private fun GatewayRecoveryScreen(
           onClick =
             when (primaryAction) {
               GatewayRecoveryPrimaryAction.Continue -> onContinue
-              GatewayRecoveryPrimaryAction.ScanFreshSetupCode,
-              GatewayRecoveryPrimaryAction.EditConnection,
-              -> onEdit
+              GatewayRecoveryPrimaryAction.ScanFreshSetupCode -> onScan
+              GatewayRecoveryPrimaryAction.EditConnection -> onEdit
               GatewayRecoveryPrimaryAction.RetryConnection -> onRetry
             },
           modifier = Modifier.fillMaxWidth(),
@@ -1135,14 +1144,20 @@ internal enum class GatewayRecoveryUiState(
   ),
 }
 
-internal enum class GatewayRecoveryPrimaryAction(
-  val label: String,
-) {
-  Continue("Continue"),
-  ScanFreshSetupCode("Scan fresh setup code"),
-  EditConnection("Edit connection"),
-  RetryConnection("Retry connection"),
+internal enum class GatewayRecoveryPrimaryAction {
+  Continue,
+  ScanFreshSetupCode,
+  EditConnection,
+  RetryConnection,
 }
+
+internal fun gatewayRecoveryPrimaryActionLabel(action: GatewayRecoveryPrimaryAction): String =
+  when (action) {
+    GatewayRecoveryPrimaryAction.Continue -> "Continue"
+    GatewayRecoveryPrimaryAction.ScanFreshSetupCode -> "Scan fresh setup code"
+    GatewayRecoveryPrimaryAction.EditConnection -> "Edit connection"
+    GatewayRecoveryPrimaryAction.RetryConnection -> "Retry connection"
+  }
 
 /** Selects the action that can actually recover the current structured gateway failure. */
 internal fun gatewayRecoveryPrimaryAction(

--- a/apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt
@@ -1175,8 +1175,10 @@ private fun gatewayProblemNeedsCredentialUpdate(problem: GatewayConnectionProble
   when (problem?.code) {
     "AUTH_DEVICE_TOKEN_MISMATCH",
     "AUTH_TOKEN_MISMATCH",
+    "AUTH_TOKEN_NOT_CONFIGURED",
     "AUTH_PASSWORD_MISSING",
     "AUTH_PASSWORD_MISMATCH",
+    "AUTH_PASSWORD_NOT_CONFIGURED",
     "AUTH_TOKEN_MISSING",
     "CONTROL_UI_DEVICE_IDENTITY_REQUIRED",
     "DEVICE_IDENTITY_REQUIRED",
@@ -1185,6 +1187,12 @@ private fun gatewayProblemNeedsCredentialUpdate(problem: GatewayConnectionProble
       problem?.recommendedNextStep == "update_auth_credentials" ||
         problem?.recommendedNextStep == "update_auth_configuration"
   }
+
+private fun gatewayProblemNeedsAuthenticationRecovery(problem: GatewayConnectionProblem?): Boolean =
+  gatewayProblemNeedsCredentialUpdate(problem) ||
+    problem?.code == "AUTH_BOOTSTRAP_TOKEN_INVALID" ||
+    problem?.code == "AUTH_SCOPE_MISMATCH" ||
+    problem?.recommendedNextStep == "review_auth_configuration"
 
 internal data class NearbyGatewayUiState(
   val subtitle: String,
@@ -1238,8 +1246,8 @@ internal fun gatewayRecoveryUiState(
     gatewayConnectionProblem?.isPairingRequired == true &&
       !gatewayConnectionProblem.canAutoRetry -> GatewayRecoveryUiState.ApprovalRequired
     gatewayConnectionProblem?.isPairingRequired == true -> GatewayRecoveryUiState.Pairing
-    gatewayRecoveryPrimaryAction(ready = false, problem = gatewayConnectionProblem) !=
-      GatewayRecoveryPrimaryAction.RetryConnection -> GatewayRecoveryUiState.AuthenticationRequired
+    gatewayProblemNeedsAuthenticationRecovery(gatewayConnectionProblem) ->
+      GatewayRecoveryUiState.AuthenticationRequired
     gatewayConnectionProblem?.pauseReconnect == true -> GatewayRecoveryUiState.Failed
     nodeCapabilityApproval == GatewayNodeCapabilityApproval.Loading -> GatewayRecoveryUiState.Finishing
     connectSettling -> GatewayRecoveryUiState.Finishing
@@ -1331,6 +1339,10 @@ internal fun recoveryGatewayAuthDetail(gatewayConnectionProblem: GatewayConnecti
     "AUTH_DEVICE_TOKEN_MISMATCH",
     "AUTH_TOKEN_MISMATCH",
     -> "Saved authentication is invalid. Re-authenticate or reset this gateway connection."
+    "AUTH_TOKEN_NOT_CONFIGURED",
+    "AUTH_PASSWORD_NOT_CONFIGURED",
+    -> "Gateway authentication is not configured. Edit this connection and try again."
+    "AUTH_SCOPE_MISMATCH" -> "Gateway access needs review. Check gateway authentication scopes, then retry."
     "AUTH_PASSWORD_MISSING" -> "Gateway password is required. Enter it again or edit this connection."
     "AUTH_PASSWORD_MISMATCH" -> "Gateway password is invalid. Re-enter it or reset this gateway connection."
     "AUTH_TOKEN_MISSING" -> "Gateway token is required. Enter it again or edit this connection."

--- a/apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt
@@ -1175,23 +1175,23 @@ private fun gatewayProblemNeedsCredentialUpdate(problem: GatewayConnectionProble
   when (problem?.code) {
     "AUTH_DEVICE_TOKEN_MISMATCH",
     "AUTH_TOKEN_MISMATCH",
-    "AUTH_TOKEN_NOT_CONFIGURED",
     "AUTH_PASSWORD_MISSING",
     "AUTH_PASSWORD_MISMATCH",
-    "AUTH_PASSWORD_NOT_CONFIGURED",
     "AUTH_TOKEN_MISSING",
     "CONTROL_UI_DEVICE_IDENTITY_REQUIRED",
     "DEVICE_IDENTITY_REQUIRED",
     -> true
     else ->
-      problem?.recommendedNextStep == "update_auth_credentials" ||
-        problem?.recommendedNextStep == "update_auth_configuration"
+      problem?.recommendedNextStep == "update_auth_credentials"
   }
 
 private fun gatewayProblemNeedsAuthenticationRecovery(problem: GatewayConnectionProblem?): Boolean =
   gatewayProblemNeedsCredentialUpdate(problem) ||
     problem?.code == "AUTH_BOOTSTRAP_TOKEN_INVALID" ||
+    problem?.code == "AUTH_TOKEN_NOT_CONFIGURED" ||
+    problem?.code == "AUTH_PASSWORD_NOT_CONFIGURED" ||
     problem?.code == "AUTH_SCOPE_MISMATCH" ||
+    problem?.recommendedNextStep == "update_auth_configuration" ||
     problem?.recommendedNextStep == "review_auth_configuration"
 
 internal data class NearbyGatewayUiState(
@@ -1341,7 +1341,7 @@ internal fun recoveryGatewayAuthDetail(gatewayConnectionProblem: GatewayConnecti
     -> "Saved authentication is invalid. Re-authenticate or reset this gateway connection."
     "AUTH_TOKEN_NOT_CONFIGURED",
     "AUTH_PASSWORD_NOT_CONFIGURED",
-    -> "Gateway authentication is not configured. Edit this connection and try again."
+    -> "Gateway authentication is not configured. Configure it on the gateway host, then retry."
     "AUTH_SCOPE_MISMATCH" -> "Gateway access needs review. Check gateway authentication scopes, then retry."
     "AUTH_PASSWORD_MISSING" -> "Gateway password is required. Enter it again or edit this connection."
     "AUTH_PASSWORD_MISMATCH" -> "Gateway password is invalid. Re-enter it or reset this gateway connection."
@@ -1352,7 +1352,7 @@ internal fun recoveryGatewayAuthDetail(gatewayConnectionProblem: GatewayConnecti
     else ->
       when (gatewayConnectionProblem.recommendedNextStep) {
         "update_auth_credentials" -> "Saved authentication is invalid. Re-authenticate or reset this gateway connection."
-        "update_auth_configuration" -> "Gateway authentication is not configured. Edit this connection and try again."
+        "update_auth_configuration" -> "Gateway authentication is not configured. Configure it on the gateway host, then retry."
         "review_auth_configuration" -> "Gateway authentication needs review. Check gateway settings, then retry."
         else -> gatewayConnectionProblem.message.takeIf { it.isNotBlank() } ?: "Gateway authentication needs attention."
       }

--- a/apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt
@@ -1174,6 +1174,7 @@ private fun gatewayProblemNeedsCredentialUpdate(problem: GatewayConnectionProble
   when (problem?.code) {
     "AUTH_DEVICE_TOKEN_MISMATCH",
     "AUTH_TOKEN_MISMATCH",
+    "AUTH_SCOPE_MISMATCH",
     "AUTH_PASSWORD_MISSING",
     "AUTH_PASSWORD_MISMATCH",
     "AUTH_TOKEN_MISSING",
@@ -1189,7 +1190,6 @@ private fun gatewayProblemNeedsAuthenticationRecovery(problem: GatewayConnection
     problem?.code == "AUTH_BOOTSTRAP_TOKEN_INVALID" ||
     problem?.code == "AUTH_TOKEN_NOT_CONFIGURED" ||
     problem?.code == "AUTH_PASSWORD_NOT_CONFIGURED" ||
-    problem?.code == "AUTH_SCOPE_MISMATCH" ||
     problem?.recommendedNextStep == "update_auth_configuration" ||
     problem?.recommendedNextStep == "review_auth_configuration"
 

--- a/apps/android/app/src/test/java/ai/openclaw/app/GatewayNodeApprovalStateTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/GatewayNodeApprovalStateTest.kt
@@ -54,8 +54,8 @@ class GatewayNodeApprovalStateTest {
     requireNotNull(node)
     assertEquals(GatewayNodeApprovalState.Unsupported, node.approvalState)
     assertEquals(
-      GatewayNodeApprovalState.Unsupported,
-      currentNodeCapabilityApprovalState(nodes = listOf(node), selfNodeId = "android-node"),
+      GatewayNodeCapabilityApproval.Unsupported,
+      currentNodeCapabilityApproval(nodes = listOf(node), selfNodeId = "android-node"),
     )
     assertNull(node.pendingRequestId)
   }
@@ -93,26 +93,56 @@ class GatewayNodeApprovalStateTest {
       )
 
     assertEquals(
-      GatewayNodeApprovalState.PendingApproval,
-      currentNodeCapabilityApprovalState(nodes = nodes, selfNodeId = "self"),
+      GatewayNodeCapabilityApproval.PendingApproval(requestId = null),
+      currentNodeCapabilityApproval(nodes = nodes, selfNodeId = "self"),
     )
     assertEquals(
-      GatewayNodeApprovalState.Loading,
-      currentNodeCapabilityApprovalState(nodes = nodes, selfNodeId = "missing"),
+      GatewayNodeCapabilityApproval.Loading,
+      currentNodeCapabilityApproval(nodes = nodes, selfNodeId = "missing"),
+    )
+  }
+
+  @Test
+  fun currentPhoneApprovalCarriesOnlySafePendingRequestIds() {
+    val safe = pendingNode(requestId = "request-1")
+    val unsafe = pendingNode(requestId = "request-1;echo unsafe")
+
+    assertEquals(
+      GatewayNodeCapabilityApproval.PendingApproval("request-1"),
+      currentNodeCapabilityApproval(nodes = listOf(safe), selfNodeId = "self"),
+    )
+    assertEquals(
+      GatewayNodeCapabilityApproval.PendingApproval(requestId = null),
+      currentNodeCapabilityApproval(nodes = listOf(unsafe), selfNodeId = "self"),
     )
   }
 
   @Test
   fun ignoresStaleNodeApprovalRefreshResults() {
     val guard = GatewayNodeApprovalRefreshGuard()
-    var approvalState = GatewayNodeApprovalState.Loading
+    var approval: GatewayNodeCapabilityApproval = GatewayNodeCapabilityApproval.Loading
     val staleRefresh = guard.begin()
     val currentRefresh = guard.begin()
 
-    assertFalse(guard.publishIfCurrent(staleRefresh) { approvalState = GatewayNodeApprovalState.Approved })
+    assertFalse(guard.publishIfCurrent(staleRefresh) { approval = GatewayNodeCapabilityApproval.Approved })
     assertTrue(
-      guard.publishIfCurrent(currentRefresh) { approvalState = GatewayNodeApprovalState.PendingReapproval },
+      guard.publishIfCurrent(currentRefresh) { approval = GatewayNodeCapabilityApproval.PendingReapproval("request-2") },
     )
-    assertEquals(GatewayNodeApprovalState.PendingReapproval, approvalState)
+    assertEquals(GatewayNodeCapabilityApproval.PendingReapproval("request-2"), approval)
   }
+
+  private fun pendingNode(requestId: String): GatewayNodeSummary =
+    GatewayNodeSummary(
+      id = "self",
+      displayName = null,
+      remoteIp = null,
+      version = null,
+      deviceFamily = null,
+      paired = true,
+      connected = true,
+      approvalState = GatewayNodeApprovalState.PendingApproval,
+      pendingRequestId = requestId,
+      capabilities = emptyList(),
+      commands = emptyList(),
+    )
 }

--- a/apps/android/app/src/test/java/ai/openclaw/app/GatewayNodeApprovalStateTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/GatewayNodeApprovalStateTest.kt
@@ -9,6 +9,33 @@ import org.junit.Test
 
 class GatewayNodeApprovalStateTest {
   @Test
+  fun exactApprovalCommandsAgeOutToStatusFallbacks() {
+    assertEquals(
+      GatewayNodeCapabilityApproval.PendingApproval(requestId = null),
+      GatewayNodeCapabilityApproval.PendingApproval(requestId = "request-1").withoutExactRequestId(),
+    )
+    assertEquals(
+      GatewayNodeCapabilityApproval.PendingReapproval(requestId = null),
+      GatewayNodeCapabilityApproval.PendingReapproval(requestId = "request-2").withoutExactRequestId(),
+    )
+    assertNull(GatewayNodeCapabilityApproval.PendingApproval(requestId = null).withoutExactRequestId())
+
+    val summary =
+      GatewayNodesDevicesSummary(
+        nodes = listOf(pendingNode(requestId = "request-1")),
+        pendingDevices = emptyList(),
+        pairedDevices = emptyList(),
+      )
+    assertNull(
+      summary
+        .withoutExactApprovalRequestIds()
+        .nodes
+        .single()
+        .pendingRequestId,
+    )
+  }
+
+  @Test
   fun parsesGatewayNodeApprovalState() {
     assertEquals(GatewayNodeApprovalState.Approved, parseGatewayNodeApprovalState("approved"))
     assertEquals(GatewayNodeApprovalState.PendingApproval, parseGatewayNodeApprovalState("pending-approval"))

--- a/apps/android/app/src/test/java/ai/openclaw/app/gateway/GatewaySessionReconnectTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/gateway/GatewaySessionReconnectTest.kt
@@ -308,7 +308,6 @@ class GatewaySessionReconnectTest {
         hasBootstrapToken = true,
         role = "node",
         scopes = emptyList(),
-        deviceTokenRetryBudgetUsed = false,
         pendingDeviceTokenRetry = false,
       ),
     )
@@ -335,7 +334,6 @@ class GatewaySessionReconnectTest {
         hasBootstrapToken = true,
         role = "node",
         scopes = emptyList(),
-        deviceTokenRetryBudgetUsed = false,
         pendingDeviceTokenRetry = false,
       ),
     )
@@ -362,10 +360,43 @@ class GatewaySessionReconnectTest {
         hasBootstrapToken = false,
         role = "node",
         scopes = emptyList(),
-        deviceTokenRetryBudgetUsed = false,
         pendingDeviceTokenRetry = false,
       ),
     )
+  }
+
+  @Test
+  fun tokenFailuresPauseUnlessOneDeviceTokenRetryIsPending() {
+    val cases =
+      listOf(
+        Triple("AUTH_TOKEN_MISMATCH", false, true),
+        Triple("AUTH_TOKEN_MISMATCH", true, false),
+        Triple("AUTH_DEVICE_TOKEN_MISMATCH", false, true),
+      )
+
+    for ((code, pendingDeviceTokenRetry, expected) in cases) {
+      val error =
+        GatewaySession.ErrorShape(
+          code = "INVALID_REQUEST",
+          message = "authentication failed",
+          details =
+            GatewayConnectErrorDetails(
+              code = code,
+              canRetryWithDeviceToken = false,
+              recommendedNextStep = null,
+            ),
+        )
+      val actual =
+        shouldPauseGatewayReconnectAfterAuthFailure(
+          error = error,
+          hasBootstrapToken = false,
+          role = "operator",
+          scopes = listOf("operator.read"),
+          pendingDeviceTokenRetry = pendingDeviceTokenRetry,
+        )
+
+      assertEquals("$code pending=$pendingDeviceTokenRetry", expected, actual)
+    }
   }
 
   @Test
@@ -392,7 +423,6 @@ class GatewaySessionReconnectTest {
         hasBootstrapToken = false,
         role = "node",
         scopes = emptyList(),
-        deviceTokenRetryBudgetUsed = false,
         pendingDeviceTokenRetry = false,
       ),
     )
@@ -419,7 +449,6 @@ class GatewaySessionReconnectTest {
         hasBootstrapToken = true,
         role = "node",
         scopes = emptyList(),
-        deviceTokenRetryBudgetUsed = false,
         pendingDeviceTokenRetry = false,
       ),
     )

--- a/apps/android/app/src/test/java/ai/openclaw/app/gateway/GatewaySessionReconnectTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/gateway/GatewaySessionReconnectTest.kt
@@ -440,6 +440,31 @@ class GatewaySessionReconnectTest {
   }
 
   @Test
+  fun authRateLimitPausesDespiteRetryAdvice() {
+    val error =
+      GatewaySession.ErrorShape(
+        code = "INVALID_REQUEST",
+        message = "authentication rate limited",
+        details =
+          GatewayConnectErrorDetails(
+            code = "AUTH_RATE_LIMITED",
+            canRetryWithDeviceToken = false,
+            recommendedNextStep = "wait_then_retry",
+          ),
+      )
+
+    assertTrue(
+      shouldPauseGatewayReconnectAfterAuthFailure(
+        error = error,
+        hasBootstrapToken = false,
+        role = "operator",
+        scopes = listOf("operator.read"),
+        pendingDeviceTokenRetry = false,
+      ),
+    )
+  }
+
+  @Test
   fun protocolMismatchPausesReconnect() {
     val error =
       GatewaySession.ErrorShape(

--- a/apps/android/app/src/test/java/ai/openclaw/app/gateway/GatewaySessionReconnectTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/gateway/GatewaySessionReconnectTest.kt
@@ -372,6 +372,9 @@ class GatewaySessionReconnectTest {
         Triple("AUTH_TOKEN_MISMATCH", false, true),
         Triple("AUTH_TOKEN_MISMATCH", true, false),
         Triple("AUTH_DEVICE_TOKEN_MISMATCH", false, true),
+        Triple("AUTH_TOKEN_NOT_CONFIGURED", false, true),
+        Triple("AUTH_PASSWORD_NOT_CONFIGURED", false, true),
+        Triple("AUTH_SCOPE_MISMATCH", false, true),
       )
 
     for ((code, pendingDeviceTokenRetry, expected) in cases) {
@@ -396,6 +399,43 @@ class GatewaySessionReconnectTest {
         )
 
       assertEquals("$code pending=$pendingDeviceTokenRetry", expected, actual)
+    }
+  }
+
+  @Test
+  fun structuredRecoveryAdviceControlsReconnectPause() {
+    val cases =
+      listOf(
+        Triple("wait_then_retry", false, false),
+        Triple("retry_with_device_token", true, false),
+        Triple("retry_with_device_token", false, true),
+        Triple("update_auth_configuration", false, true),
+        Triple("update_auth_credentials", false, true),
+        Triple("review_auth_configuration", false, true),
+      )
+
+    for ((nextStep, pendingDeviceTokenRetry, expected) in cases) {
+      val error =
+        GatewaySession.ErrorShape(
+          code = "INVALID_REQUEST",
+          message = "authentication failed",
+          details =
+            GatewayConnectErrorDetails(
+              code = "AUTH_UNAUTHORIZED",
+              canRetryWithDeviceToken = nextStep == "retry_with_device_token",
+              recommendedNextStep = nextStep,
+            ),
+        )
+      val actual =
+        shouldPauseGatewayReconnectAfterAuthFailure(
+          error = error,
+          hasBootstrapToken = false,
+          role = "operator",
+          scopes = listOf("operator.read"),
+          pendingDeviceTokenRetry = pendingDeviceTokenRetry,
+        )
+
+      assertEquals("$nextStep pending=$pendingDeviceTokenRetry", expected, actual)
     }
   }
 

--- a/apps/android/app/src/test/java/ai/openclaw/app/ui/GatewayDiagnosticsTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/ui/GatewayDiagnosticsTest.kt
@@ -12,8 +12,11 @@ class GatewayDiagnosticsTest {
       mapOf(
         "AUTH_BOOTSTRAP_TOKEN_INVALID" to "Setup code expired",
         "AUTH_TOKEN_MISSING" to "Gateway token needed",
+        "AUTH_TOKEN_NOT_CONFIGURED" to "Gateway token not configured",
         "AUTH_PASSWORD_MISSING" to "Gateway password needed",
         "AUTH_PASSWORD_MISMATCH" to "Gateway password invalid",
+        "AUTH_PASSWORD_NOT_CONFIGURED" to "Gateway password not configured",
+        "AUTH_SCOPE_MISMATCH" to "Gateway access needs review",
         "AUTH_TOKEN_MISMATCH" to "Saved auth invalid",
         "AUTH_DEVICE_TOKEN_MISMATCH" to "Saved auth invalid",
         "CONTROL_UI_DEVICE_IDENTITY_REQUIRED" to "Device identity required",

--- a/apps/android/app/src/test/java/ai/openclaw/app/ui/OnboardingFlowLogicTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/ui/OnboardingFlowLogicTest.kt
@@ -1,7 +1,7 @@
 package ai.openclaw.app.ui
 
 import ai.openclaw.app.GatewayConnectionProblem
-import ai.openclaw.app.GatewayNodeApprovalState
+import ai.openclaw.app.GatewayNodeCapabilityApproval
 import android.Manifest
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.launch
@@ -16,48 +16,60 @@ import java.util.Base64
 class OnboardingFlowLogicTest {
   @Test
   fun blocksFinishWhenOnlyOperatorIsConnected() {
-    assertFalse(canFinishOnboarding(isConnected = true, isNodeConnected = false, nodeCapabilityApprovalState = GatewayNodeApprovalState.Approved))
+    assertFalse(canFinishOnboarding(isConnected = true, isNodeConnected = false, nodeCapabilityApproval = GatewayNodeCapabilityApproval.Approved))
   }
 
   @Test
   fun blocksFinishWhenDisconnected() {
-    assertFalse(canFinishOnboarding(isConnected = false, isNodeConnected = false, nodeCapabilityApprovalState = GatewayNodeApprovalState.Approved))
+    assertFalse(canFinishOnboarding(isConnected = false, isNodeConnected = false, nodeCapabilityApproval = GatewayNodeCapabilityApproval.Approved))
   }
 
   @Test
   fun blocksFinishWhenOnlyNodeIsConnected() {
-    assertFalse(canFinishOnboarding(isConnected = false, isNodeConnected = true, nodeCapabilityApprovalState = GatewayNodeApprovalState.Approved))
+    assertFalse(canFinishOnboarding(isConnected = false, isNodeConnected = true, nodeCapabilityApproval = GatewayNodeCapabilityApproval.Approved))
   }
 
   @Test
   fun blocksFinishWhenNodeCapabilityApprovalIsPending() {
-    assertFalse(canFinishOnboarding(isConnected = true, isNodeConnected = true, nodeCapabilityApprovalState = GatewayNodeApprovalState.PendingApproval))
-    assertFalse(canFinishOnboarding(isConnected = true, isNodeConnected = true, nodeCapabilityApprovalState = GatewayNodeApprovalState.PendingReapproval))
-    assertFalse(canFinishOnboarding(isConnected = true, isNodeConnected = true, nodeCapabilityApprovalState = GatewayNodeApprovalState.Unapproved))
+    assertFalse(
+      canFinishOnboarding(
+        isConnected = true,
+        isNodeConnected = true,
+        nodeCapabilityApproval = GatewayNodeCapabilityApproval.PendingApproval(requestId = "request-1"),
+      ),
+    )
+    assertFalse(
+      canFinishOnboarding(
+        isConnected = true,
+        isNodeConnected = true,
+        nodeCapabilityApproval = GatewayNodeCapabilityApproval.PendingReapproval(requestId = "request-2"),
+      ),
+    )
+    assertFalse(canFinishOnboarding(isConnected = true, isNodeConnected = true, nodeCapabilityApproval = GatewayNodeCapabilityApproval.Unapproved))
   }
 
   @Test
   fun allowsFinishWhenOperatorNodeAndCapabilityApprovalAreReady() {
-    assertTrue(canFinishOnboarding(isConnected = true, isNodeConnected = true, nodeCapabilityApprovalState = GatewayNodeApprovalState.Approved))
+    assertTrue(canFinishOnboarding(isConnected = true, isNodeConnected = true, nodeCapabilityApproval = GatewayNodeCapabilityApproval.Approved))
   }
 
   @Test
   fun blocksFinishWhileDelayedNodeListResolvesPendingApproval() =
     runTest {
-      val delayedNodeList = CompletableDeferred<GatewayNodeApprovalState>()
-      var approvalState = GatewayNodeApprovalState.Loading
+      val delayedNodeList = CompletableDeferred<GatewayNodeCapabilityApproval>()
+      var approvalState: GatewayNodeCapabilityApproval = GatewayNodeCapabilityApproval.Loading
       val refresh = launch { approvalState = delayedNodeList.await() }
 
-      assertFalse(canFinishOnboarding(isConnected = true, isNodeConnected = true, nodeCapabilityApprovalState = approvalState))
+      assertFalse(canFinishOnboarding(isConnected = true, isNodeConnected = true, nodeCapabilityApproval = approvalState))
 
-      delayedNodeList.complete(GatewayNodeApprovalState.PendingApproval)
+      delayedNodeList.complete(GatewayNodeCapabilityApproval.PendingApproval(requestId = "request-1"))
       refresh.join()
-      assertFalse(canFinishOnboarding(isConnected = true, isNodeConnected = true, nodeCapabilityApprovalState = approvalState))
+      assertFalse(canFinishOnboarding(isConnected = true, isNodeConnected = true, nodeCapabilityApproval = approvalState))
     }
 
   @Test
   fun allowsFinishWhenSuccessfulLegacyNodeListOmitsApprovalState() {
-    assertTrue(canFinishOnboarding(isConnected = true, isNodeConnected = true, nodeCapabilityApprovalState = GatewayNodeApprovalState.Unsupported))
+    assertTrue(canFinishOnboarding(isConnected = true, isNodeConnected = true, nodeCapabilityApproval = GatewayNodeCapabilityApproval.Unsupported))
   }
 
   @Test
@@ -171,7 +183,7 @@ class OnboardingFlowLogicTest {
         ready = false,
         statusText = "Gateway error: pairing required; approval in progress",
         connectSettling = false,
-        nodeCapabilityApprovalState = GatewayNodeApprovalState.Approved,
+        nodeCapabilityApproval = GatewayNodeCapabilityApproval.Approved,
       ),
     )
   }
@@ -184,7 +196,7 @@ class OnboardingFlowLogicTest {
         ready = true,
         statusText = "Gateway error: pairing required",
         connectSettling = false,
-        nodeCapabilityApprovalState = GatewayNodeApprovalState.Approved,
+        nodeCapabilityApproval = GatewayNodeCapabilityApproval.Approved,
       ),
     )
   }
@@ -197,7 +209,7 @@ class OnboardingFlowLogicTest {
         ready = false,
         statusText = "Connected",
         connectSettling = false,
-        nodeCapabilityApprovalState = GatewayNodeApprovalState.PendingApproval,
+        nodeCapabilityApproval = GatewayNodeCapabilityApproval.PendingApproval(requestId = "request-1"),
       ),
     )
   }
@@ -210,7 +222,7 @@ class OnboardingFlowLogicTest {
         ready = false,
         statusText = "Connected",
         connectSettling = false,
-        nodeCapabilityApprovalState = GatewayNodeApprovalState.Loading,
+        nodeCapabilityApproval = GatewayNodeCapabilityApproval.Loading,
       ),
     )
   }
@@ -223,7 +235,7 @@ class OnboardingFlowLogicTest {
         ready = false,
         statusText = "Connecting…",
         connectSettling = false,
-        nodeCapabilityApprovalState = GatewayNodeApprovalState.Approved,
+        nodeCapabilityApproval = GatewayNodeCapabilityApproval.Approved,
         gatewayConnectionProblem =
           GatewayConnectionProblem(
             code = "PAIRING_REQUIRED",
@@ -246,7 +258,7 @@ class OnboardingFlowLogicTest {
         ready = false,
         statusText = "Connecting…",
         connectSettling = false,
-        nodeCapabilityApprovalState = GatewayNodeApprovalState.Approved,
+        nodeCapabilityApproval = GatewayNodeCapabilityApproval.Approved,
         gatewayConnectionProblem =
           GatewayConnectionProblem(
             code = "PAIRING_REQUIRED",
@@ -269,7 +281,7 @@ class OnboardingFlowLogicTest {
         ready = false,
         remoteAddress = null,
         statusText = "Connected (node offline)",
-        nodeCapabilityApprovalState = GatewayNodeApprovalState.Approved,
+        nodeCapabilityApproval = GatewayNodeCapabilityApproval.Approved,
         gatewayConnectionProblem =
           GatewayConnectionProblem(
             code = "PAIRING_REQUIRED",
@@ -292,7 +304,7 @@ class OnboardingFlowLogicTest {
         ready = false,
         remoteAddress = "wss://gateway.example.test",
         statusText = "Connected (node offline)",
-        nodeCapabilityApprovalState = GatewayNodeApprovalState.Approved,
+        nodeCapabilityApproval = GatewayNodeCapabilityApproval.Approved,
         gatewayConnectionProblem =
           GatewayConnectionProblem(
             code = "AUTH_DEVICE_TOKEN_MISMATCH",
@@ -315,7 +327,7 @@ class OnboardingFlowLogicTest {
         ready = false,
         remoteAddress = "wss://gateway.example.test",
         statusText = "Connected (node offline)",
-        nodeCapabilityApprovalState = GatewayNodeApprovalState.Loading,
+        nodeCapabilityApproval = GatewayNodeCapabilityApproval.Loading,
         gatewayConnectionProblem =
           GatewayConnectionProblem(
             code = "AUTH_DEVICE_TOKEN_MISMATCH",
@@ -357,6 +369,84 @@ class OnboardingFlowLogicTest {
         ),
       )
     }
+  }
+
+  @Test
+  fun authFailuresStopShowingAConnectingState() {
+    val cases =
+      listOf(
+        "AUTH_BOOTSTRAP_TOKEN_INVALID" to "scan_fresh_setup_code",
+        "AUTH_DEVICE_TOKEN_MISMATCH" to "update_auth_credentials",
+      )
+
+    for ((code, nextStep) in cases) {
+      assertEquals(
+        GatewayRecoveryUiState.AuthenticationRequired,
+        gatewayRecoveryUiState(
+          ready = false,
+          statusText = "Connecting…",
+          connectSettling = true,
+          nodeCapabilityApproval = GatewayNodeCapabilityApproval.Loading,
+          gatewayConnectionProblem = authProblem(code = code, recommendedNextStep = nextStep),
+        ),
+      )
+    }
+  }
+
+  @Test
+  fun recoveryPrimaryActionRepairsTheStructuredAuthFailure() {
+    assertEquals(
+      GatewayRecoveryPrimaryAction.ScanFreshSetupCode,
+      gatewayRecoveryPrimaryAction(
+        ready = false,
+        problem = authProblem(code = "AUTH_BOOTSTRAP_TOKEN_INVALID"),
+      ),
+    )
+    assertEquals(
+      GatewayRecoveryPrimaryAction.EditConnection,
+      gatewayRecoveryPrimaryAction(
+        ready = false,
+        problem = authProblem(code = "AUTH_DEVICE_TOKEN_MISMATCH", recommendedNextStep = "update_auth_credentials"),
+      ),
+    )
+    assertEquals(
+      GatewayRecoveryPrimaryAction.RetryConnection,
+      gatewayRecoveryPrimaryAction(ready = false, problem = null),
+    )
+  }
+
+  @Test
+  fun recoveryApprovalCommandPrefersTheExactNodeRequestId() {
+    assertEquals(
+      "openclaw nodes approve request-1",
+      recoveryGatewayApprovalCommand(
+        GatewayNodeCapabilityApproval.PendingApproval(requestId = "request-1"),
+        gatewayConnectionProblem = null,
+      ),
+    )
+    assertEquals(
+      "openclaw nodes status",
+      recoveryGatewayApprovalCommand(
+        GatewayNodeCapabilityApproval.PendingApproval(requestId = "request-1; unsafe"),
+        gatewayConnectionProblem = null,
+      ),
+    )
+    assertEquals(
+      "openclaw devices list",
+      recoveryGatewayApprovalCommand(
+        GatewayNodeCapabilityApproval.Approved,
+        gatewayConnectionProblem =
+          GatewayConnectionProblem(
+            code = "PAIRING_REQUIRED",
+            message = "pairing required",
+            reason = "not-paired",
+            requestId = "request-1; unsafe",
+            recommendedNextStep = null,
+            pauseReconnect = true,
+            retryable = false,
+          ),
+      ),
+    )
   }
 
   @Test
@@ -461,7 +551,7 @@ class OnboardingFlowLogicTest {
         ready = false,
         statusText = "Offline",
         connectSettling = true,
-        nodeCapabilityApprovalState = GatewayNodeApprovalState.Approved,
+        nodeCapabilityApproval = GatewayNodeCapabilityApproval.Approved,
       ),
     )
   }
@@ -474,7 +564,7 @@ class OnboardingFlowLogicTest {
         ready = false,
         statusText = "Connected (node offline)",
         connectSettling = false,
-        nodeCapabilityApprovalState = GatewayNodeApprovalState.Approved,
+        nodeCapabilityApproval = GatewayNodeCapabilityApproval.Approved,
       ),
     )
   }
@@ -487,10 +577,24 @@ class OnboardingFlowLogicTest {
         ready = false,
         statusText = "Gateway error: connection refused",
         connectSettling = false,
-        nodeCapabilityApprovalState = GatewayNodeApprovalState.Approved,
+        nodeCapabilityApproval = GatewayNodeCapabilityApproval.Approved,
       ),
     )
   }
+
+  private fun authProblem(
+    code: String,
+    recommendedNextStep: String? = null,
+  ): GatewayConnectionProblem =
+    GatewayConnectionProblem(
+      code = code,
+      message = "authentication needed",
+      reason = null,
+      requestId = null,
+      recommendedNextStep = recommendedNextStep,
+      pauseReconnect = true,
+      retryable = false,
+    )
 
   @Test
   fun resolvesOnboardingSetupCodeConnectConfigForScannedQr() {

--- a/apps/android/app/src/test/java/ai/openclaw/app/ui/OnboardingFlowLogicTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/ui/OnboardingFlowLogicTest.kt
@@ -348,6 +348,8 @@ class OnboardingFlowLogicTest {
       listOf(
         "AUTH_BOOTSTRAP_TOKEN_INVALID" to "Setup code expired. Scan a fresh setup QR.",
         "AUTH_DEVICE_TOKEN_MISMATCH" to "Saved authentication is invalid. Re-authenticate or reset this gateway connection.",
+        "AUTH_TOKEN_NOT_CONFIGURED" to "Gateway authentication is not configured. Edit this connection and try again.",
+        "AUTH_SCOPE_MISMATCH" to "Gateway access needs review. Check gateway authentication scopes, then retry.",
         "AUTH_PASSWORD_MISMATCH" to "Gateway password is invalid. Re-enter it or reset this gateway connection.",
         "AUTH_TOKEN_MISSING" to "Gateway token is required. Enter it again or edit this connection.",
         "DEVICE_IDENTITY_REQUIRED" to "Gateway requires this device identity. Re-authenticate or reset this gateway connection.",
@@ -377,6 +379,8 @@ class OnboardingFlowLogicTest {
       listOf(
         "AUTH_BOOTSTRAP_TOKEN_INVALID" to "scan_fresh_setup_code",
         "AUTH_DEVICE_TOKEN_MISMATCH" to "update_auth_credentials",
+        "AUTH_TOKEN_NOT_CONFIGURED" to "update_auth_configuration",
+        "AUTH_SCOPE_MISMATCH" to "review_auth_configuration",
       )
 
     for ((code, nextStep) in cases) {
@@ -407,6 +411,20 @@ class OnboardingFlowLogicTest {
       gatewayRecoveryPrimaryAction(
         ready = false,
         problem = authProblem(code = "AUTH_DEVICE_TOKEN_MISMATCH", recommendedNextStep = "update_auth_credentials"),
+      ),
+    )
+    assertEquals(
+      GatewayRecoveryPrimaryAction.EditConnection,
+      gatewayRecoveryPrimaryAction(
+        ready = false,
+        problem = authProblem(code = "AUTH_TOKEN_NOT_CONFIGURED"),
+      ),
+    )
+    assertEquals(
+      GatewayRecoveryPrimaryAction.RetryConnection,
+      gatewayRecoveryPrimaryAction(
+        ready = false,
+        problem = authProblem(code = "AUTH_SCOPE_MISMATCH", recommendedNextStep = "review_auth_configuration"),
       ),
     )
     assertEquals(

--- a/apps/android/app/src/test/java/ai/openclaw/app/ui/OnboardingFlowLogicTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/ui/OnboardingFlowLogicTest.kt
@@ -416,6 +416,21 @@ class OnboardingFlowLogicTest {
   }
 
   @Test
+  fun recoveryPrimaryActionLabelsDescribeTheirActualAction() {
+    val expected =
+      mapOf(
+        GatewayRecoveryPrimaryAction.Continue to "Continue",
+        GatewayRecoveryPrimaryAction.ScanFreshSetupCode to "Scan fresh setup code",
+        GatewayRecoveryPrimaryAction.EditConnection to "Edit connection",
+        GatewayRecoveryPrimaryAction.RetryConnection to "Retry connection",
+      )
+
+    for ((action, label) in expected) {
+      assertEquals(label, gatewayRecoveryPrimaryActionLabel(action))
+    }
+  }
+
+  @Test
   fun recoveryApprovalCommandPrefersTheExactNodeRequestId() {
     assertEquals(
       "openclaw nodes approve request-1",

--- a/apps/android/app/src/test/java/ai/openclaw/app/ui/OnboardingFlowLogicTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/ui/OnboardingFlowLogicTest.kt
@@ -421,7 +421,7 @@ class OnboardingFlowLogicTest {
       ),
     )
     assertEquals(
-      GatewayRecoveryPrimaryAction.RetryConnection,
+      GatewayRecoveryPrimaryAction.EditConnection,
       gatewayRecoveryPrimaryAction(
         ready = false,
         problem = authProblem(code = "AUTH_SCOPE_MISMATCH", recommendedNextStep = "review_auth_configuration"),

--- a/apps/android/app/src/test/java/ai/openclaw/app/ui/OnboardingFlowLogicTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/ui/OnboardingFlowLogicTest.kt
@@ -348,7 +348,7 @@ class OnboardingFlowLogicTest {
       listOf(
         "AUTH_BOOTSTRAP_TOKEN_INVALID" to "Setup code expired. Scan a fresh setup QR.",
         "AUTH_DEVICE_TOKEN_MISMATCH" to "Saved authentication is invalid. Re-authenticate or reset this gateway connection.",
-        "AUTH_TOKEN_NOT_CONFIGURED" to "Gateway authentication is not configured. Edit this connection and try again.",
+        "AUTH_TOKEN_NOT_CONFIGURED" to "Gateway authentication is not configured. Configure it on the gateway host, then retry.",
         "AUTH_SCOPE_MISMATCH" to "Gateway access needs review. Check gateway authentication scopes, then retry.",
         "AUTH_PASSWORD_MISMATCH" to "Gateway password is invalid. Re-enter it or reset this gateway connection.",
         "AUTH_TOKEN_MISSING" to "Gateway token is required. Enter it again or edit this connection.",
@@ -414,7 +414,7 @@ class OnboardingFlowLogicTest {
       ),
     )
     assertEquals(
-      GatewayRecoveryPrimaryAction.EditConnection,
+      GatewayRecoveryPrimaryAction.RetryConnection,
       gatewayRecoveryPrimaryAction(
         ready = false,
         problem = authProblem(code = "AUTH_TOKEN_NOT_CONFIGURED"),
@@ -547,7 +547,7 @@ class OnboardingFlowLogicTest {
   @Test
   fun recoveryGatewayAuthDetailUsesRecommendedNextStepFallbacks() {
     assertEquals(
-      "Gateway authentication is not configured. Edit this connection and try again.",
+      "Gateway authentication is not configured. Configure it on the gateway host, then retry.",
       recoveryGatewayAuthDetail(
         GatewayConnectionProblem(
           code = "UNKNOWN",

--- a/apps/android/app/src/test/java/ai/openclaw/app/ui/SettingsScreensTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/ui/SettingsScreensTest.kt
@@ -1,6 +1,7 @@
 package ai.openclaw.app.ui
 
 import ai.openclaw.app.GatewayConnectionProblem
+import ai.openclaw.app.GatewayNodeCapabilityApproval
 import org.junit.Assert.assertEquals
 import org.junit.Test
 
@@ -65,6 +66,19 @@ class SettingsScreensTest {
     assertEquals(true, text.contains("approve new phone pairing"))
     assertEquals(true, text.contains("Node capability approval is separate"))
     assertEquals(true, text.contains("nodes approve <request id>"))
+  }
+
+  @Test
+  fun nodeApprovalCommandUsesOnlyASafeExactRequestId() {
+    assertEquals(
+      "openclaw nodes approve request-1",
+      gatewayNodeApprovalCommand(GatewayNodeCapabilityApproval.PendingApproval("request-1")),
+    )
+    assertEquals(
+      "openclaw nodes status",
+      gatewayNodeApprovalCommand(GatewayNodeCapabilityApproval.PendingReapproval("request-1; unsafe")),
+    )
+    assertEquals(null, gatewayNodeApprovalCommand(GatewayNodeCapabilityApproval.Approved))
   }
 
   private fun authProblem(code: String): GatewayConnectionProblem =

--- a/src/gateway/server-methods/nodes.ts
+++ b/src/gateway/server-methods/nodes.ts
@@ -139,18 +139,29 @@ function canReadPendingNodePairing(client: GatewayClient | null): boolean {
   return scopes.includes(ADMIN_SCOPE) || scopes.includes(PAIRING_SCOPE);
 }
 
-function safeNodeReadProjection(node: NodeListNode): NodeListNode | null {
+function safeNodeReadProjection(
+  node: NodeListNode,
+  ownDeviceId: string | undefined,
+): NodeListNode | null {
   if (!node.paired && !node.connected) {
     return null;
   }
   const {
-    pendingRequestId: _pendingRequestId,
+    pendingRequestId,
     pendingDeclaredCaps: _pendingDeclaredCaps,
     pendingDeclaredCommands: _pendingDeclaredCommands,
     pendingDeclaredPermissions: _pendingDeclaredPermissions,
     ...safeNode
   } = node;
-  return safeNode;
+  // A read-scoped mobile client may guide its user to approve this phone, but must not expose
+  // another node's approval target or any pending capability declaration.
+  return node.nodeId === ownDeviceId && pendingRequestId
+    ? { ...safeNode, pendingRequestId }
+    : safeNode;
+}
+
+function nodeReadCallerDeviceId(client: GatewayClient | null): string | undefined {
+  return normalizeOptionalString(client?.connect?.device?.id);
 }
 
 function isVisibleNode(node: NodeListNode | null): node is NodeListNode {
@@ -174,7 +185,8 @@ function listNodesForClient(params: {
   if (canReadPendingNodePairing(params.client)) {
     return nodes;
   }
-  return nodes.map(safeNodeReadProjection).filter(isVisibleNode);
+  const ownDeviceId = nodeReadCallerDeviceId(params.client);
+  return nodes.map((node) => safeNodeReadProjection(node, ownDeviceId)).filter(isVisibleNode);
 }
 
 function normalizeBrowserProxyPath(value: string): string {
@@ -1195,7 +1207,7 @@ export const nodeHandlers: GatewayRequestHandlers = {
         catalogNode && canReadPendingNodePairing(client)
           ? catalogNode
           : catalogNode
-            ? safeNodeReadProjection(catalogNode)
+            ? safeNodeReadProjection(catalogNode, nodeReadCallerDeviceId(client))
             : null;
       if (!node) {
         respond(false, undefined, errorShape(ErrorCodes.INVALID_REQUEST, "unknown nodeId"));

--- a/src/gateway/server.node-pairing-authz.test.ts
+++ b/src/gateway/server.node-pairing-authz.test.ts
@@ -2,11 +2,7 @@
 // command scopes, and gateway enforcement around node client identity.
 import { afterAll, beforeAll, describe, expect, test, vi } from "vitest";
 import { WebSocket } from "ws";
-import {
-  approveNodePairing,
-  listNodePairing,
-  requestNodePairing,
-} from "../infra/node-pairing.js";
+import { approveNodePairing, listNodePairing, requestNodePairing } from "../infra/node-pairing.js";
 import { createSuiteTempRootTracker } from "../test-helpers/temp-dir.js";
 import { GATEWAY_CLIENT_MODES, GATEWAY_CLIENT_NAMES } from "../utils/message-channel.js";
 import { callGateway } from "./call.js";
@@ -383,10 +379,15 @@ describe("gateway node pairing authorization", () => {
       );
     });
 
-    test("hides pending pairing records from read-only callers", async () => {
+    test("shows only the caller's pending request id to read-only callers", async () => {
       const pairedNodeId = "node-read-only-paired";
       const pendingOnlyNodeId = "node-read-only-pending";
       const visiblePendingNode = await pairDeviceIdentity({
+        name: "node-read-only-visible-pending",
+        role: "operator",
+        scopes: ["operator.read"],
+      });
+      await pairDeviceIdentity({
         name: "node-read-only-visible-pending",
         role: "node",
         scopes: [],
@@ -411,7 +412,7 @@ describe("gateway node pairing authorization", () => {
         platform: "macos",
         commands: ["system.run"],
       });
-      await requestNodePairing({
+      const visiblePending = await requestNodePairing({
         nodeId: visiblePendingNode.identity.deviceId,
         platform: "android",
         commands: ["device.status"],
@@ -487,6 +488,40 @@ describe("gateway node pairing authorization", () => {
         const pendingOnly = await rpcReq(ws, "node.describe", { nodeId: pendingOnlyNodeId });
         expect(pendingOnly.ok).toBe(false);
         expect(pendingOnly.error?.message).toContain("unknown nodeId");
+
+        const selfWs = await openTrackedWs(getStarted().port);
+        try {
+          await connectOk(selfWs, {
+            token: "secret",
+            scopes: ["operator.read"],
+            deviceIdentityPath: visiblePendingNode.identityPath,
+          });
+          const selfListed = await rpcReq<{ nodes?: NodeDiagnostics[] }>(selfWs, "node.list", {});
+          const selfNodes = selfListed.payload?.nodes ?? [];
+          expect(
+            selfNodes.find((node) => node.nodeId === visiblePendingNode.identity.deviceId),
+          ).toEqual(
+            expect.objectContaining({
+              approvalState: "pending-approval",
+              pendingRequestId: visiblePending.request.requestId,
+            }),
+          );
+          expect(selfNodes.find((node) => node.nodeId === pairedNodeId)).not.toHaveProperty(
+            "pendingRequestId",
+          );
+
+          const selfDescribed = await rpcReq<NodeDiagnostics>(selfWs, "node.describe", {
+            nodeId: visiblePendingNode.identity.deviceId,
+          });
+          expect(selfDescribed.payload).toEqual(
+            expect.objectContaining({
+              approvalState: "pending-approval",
+              pendingRequestId: visiblePending.request.requestId,
+            }),
+          );
+        } finally {
+          selfWs.close();
+        }
       } finally {
         ws.close();
       }

--- a/test/scripts/native-app-i18n.test.ts
+++ b/test/scripts/native-app-i18n.test.ts
@@ -60,6 +60,8 @@ describe("native app i18n inventory", () => {
         (entry) => entry.source === "Talk failed: Realtime provider closed unexpectedly.",
       ),
     ).toBe(true);
+    expect(entries.some((entry) => entry.source === "Scan fresh setup code")).toBe(true);
+    expect(entries.some((entry) => entry.source === "Retry connection")).toBe(true);
     expect(entries.some((entry) => entry.source === "Searching…")).toBe(true);
     expect(entries.some((entry) => entry.source === "Run now")).toBe(true);
     expect(entries.some((entry) => entry.source === "Loading chat")).toBe(true);


### PR DESCRIPTION
Closes #98046
Closes #98045

AI-assisted: yes. Sanitized transcript logs were not included.

## What Problem This Solves

Android Gateway Recovery collapsed stale credentials, expired setup codes, and pending node capability approval into generic status and retry actions. Even when the Gateway knew the pending node request ID, a read-scoped Android client could not display the exact safe approval command.

## Why This Change Was Made

The Gateway now includes a pending node request ID only when a signed read-scoped client is reading its own device-backed node. Pending capability declarations and every other node's request ID remain redacted.

Android carries the current phone's capability approval state and optional request ID as one closed value. Onboarding and Nodes & Devices share one command mapper, so a safe request ID produces an exact `openclaw nodes approve <id>` command and malformed or unavailable IDs fall back to `openclaw nodes status`.

Exact approval IDs are gateway-local and short-lived. Android clears them when the target changes, ages cached commands to the status fallback, and refreshes `node.list` while approval remains pending.

Structured connection problems now select the recovery action that can resolve them: an expired bootstrap token scans a fresh setup code, stale client credentials edit the connection, Gateway-host auth configuration stays on an explicit retry path, and transient failures remain retryable. Terminal structured auth advice pauses automatic reconnect so the recovery UI is not immediately overwritten.

## User Impact

Android users can distinguish the three common recovery paths and act directly. Pending approval shows a selectable exact host command, expired setup codes lead to a fresh scan, and stale stored authentication leads to connection editing instead of another ineffective retry.

## Evidence

- Gateway authorization test: unrelated read-only clients cannot see pending request IDs; the same signed device identity can see only its own request ID in `node.list` and `node.describe`.
- Focused Gateway proof: 20 tests passed in `src/gateway/server.node-pairing-authz.test.ts`.
- Focused Android proof: node approval, onboarding recovery, and Settings tests passed; ktlint and Play debug APK assembly passed.
- Repository proof: production build, native i18n inventory, oxlint, and whitespace checks passed.
- Real source Gateway + Android emulator matrix:
  - pending node approval exposed the exact safe command for this phone;
  - expired bootstrap rendered `Authentication needed` with `Scan fresh setup code`;
  - stale token rendered `Authentication needed` with `Edit connection`;
  - the recovery scanner launched Google Code Scanner from the exact Play APK.

Screenshots are attached in the PR comments, not committed to the repository. No physical Android device was available.
