### PR TITLE
fix(cli): include aliases in shell completion

### DIFF
--- a/src/cli/command-catalog.ts
+++ b/src/cli/command-catalog.ts
@@ -273,6 +273,7 @@ export const cliCommandCatalog: readonly CliCommandCatalogEntry[] = [
       loadPlugins: "never",
     },
   },
+  { commandPath: ["exec-approvals"], policy: { networkProxy: "bypass" } },
   { commandPath: ["exec-policy"], policy: { networkProxy: "bypass" } },
   { commandPath: ["hooks"], policy: { networkProxy: "bypass" } },
   { commandPath: ["logs"], policy: { networkProxy: "bypass" } },

--- a/src/cli/completion-cli.test.ts
+++ b/src/cli/completion-cli.test.ts
@@ -169,6 +169,21 @@ describe("completion-cli", () => {
     expect(script).toContain("--token");
     expect(script).not.toContain("-t,");
   });
+
+  it("generates valid Bash completion without subcommands", () => {
+    if (process.platform === "win32") {
+      return;
+    }
+
+    const script = getCompletionScript("bash", new Command().name("openclaw"));
+    const result = spawnSync("bash", ["--noprofile", "--norc", "-n"], {
+      encoding: "utf8",
+      input: script,
+    });
+
+    expect(result.stderr).toBe("");
+    expect(result.status).toBe(0);
+  });
 });
 
 // Commander aliases are typeable commands (`openclaw capability` == `openclaw infer`),
@@ -176,6 +191,7 @@ describe("completion-cli", () => {
 function createAliasedCompletionProgram(): Command {
   const program = new Command();
   program.name("openclaw");
+  program.option("--profile <name>", "Profile");
   const infer = program.command("infer").alias("capability").description("Run inference");
   infer.command("embed").description("Embed text").option("--model <id>", "Model id");
   const cron = program.command("cron").description("Cron commands");
@@ -197,12 +213,51 @@ describe("completion-cli command aliases", () => {
     expect(script).toContain("(add|create) _openclaw_cron_add ;;");
   });
 
-  it("completes root and nested aliases in bash word lists and case labels", () => {
+  it("completes root and nested aliases in bash command paths", () => {
     const script = getCompletionScript("bash", createAliasedCompletionProgram());
 
-    expect(script).toContain("infer capability cron");
-    expect(script).toContain("infer|capability)");
-    expect(script).toContain("add create");
+    expect(script).toContain('opts="infer capability cron --profile"');
+    expect(script).toContain('"infer"|"capability")');
+    expect(script).toContain('"cron")');
+    expect(script).toContain('opts="add create"');
+    expect(script).toContain('"cron add"|"cron create")');
+    expect(script).toContain('opts="--at"');
+  });
+
+  it("offers options after a nested alias in bash", () => {
+    if (process.platform === "win32") {
+      return;
+    }
+
+    const script = getCompletionScript("bash", createAliasedCompletionProgram());
+    const result = spawnSync(
+      "bash",
+      [
+        "--noprofile",
+        "--norc",
+        "-c",
+        `${script}
+COMP_WORDS=(openclaw --profile work cron create --a)
+COMP_CWORD=5
+_openclaw_completion
+printf '%s\\n' "\${COMPREPLY[@]}"
+`,
+      ],
+      { encoding: "utf8" },
+    );
+    if (result.error) {
+      if (
+        "code" in result.error &&
+        (result.error.code === "ENOENT" || result.error.code === "EACCES")
+      ) {
+        return;
+      }
+      throw result.error;
+    }
+
+    expect(result.stderr).toBe("");
+    expect(result.status).toBe(0);
+    expect(result.stdout.trim()).toBe("--at");
   });
 
   it("completes aliases and their subtrees in fish", () => {
@@ -212,20 +267,20 @@ describe("completion-cli command aliases", () => {
       'complete -c openclaw -n "__fish_use_subcommand" -a "capability" -d \'Run inference\'',
     );
     expect(script).toContain(
-      'complete -c openclaw -n "__openclaw_command_path_matches capability --" -a "embed" -d \'Embed text\'',
+      'complete -c openclaw -n "__openclaw_command_path_matches capability -- --profile" -a "embed" -d \'Embed text\'',
     );
     expect(script).toContain(
-      'complete -c openclaw -n "__openclaw_command_path_matches cron --" -a "create" -d \'Add a job\'',
+      'complete -c openclaw -n "__openclaw_command_path_matches cron -- --profile" -a "create" -d \'Add a job\'',
     );
     expect(script).toContain(
-      "complete -c openclaw -n \"__openclaw_command_path_matches cron create -- --at\" -l at -d 'Schedule time'",
+      "complete -c openclaw -n \"__openclaw_command_path_matches cron create -- --profile --at\" -l at -d 'Schedule time'",
     );
   });
 
   it("completes aliases and alias command paths in PowerShell", () => {
     const script = getCompletionScript("powershell", createAliasedCompletionProgram());
 
-    expect(script).toContain("$completions = @('infer','capability','cron')");
+    expect(script).toContain("$completions = @('infer','capability','cron','--profile')");
     expect(script).toContain("if ($commandPath -eq 'capability') {");
     expect(script).toContain("if ($commandPath -eq 'cron create') {");
   });

--- a/src/cli/completion-cli.test.ts
+++ b/src/cli/completion-cli.test.ts
@@ -170,3 +170,63 @@ describe("completion-cli", () => {
     expect(script).not.toContain("-t,");
   });
 });
+
+// Commander aliases are typeable commands (`openclaw capability` == `openclaw infer`),
+// so every shell must complete alias names and keep completing after an alias.
+function createAliasedCompletionProgram(): Command {
+  const program = new Command();
+  program.name("openclaw");
+  const infer = program.command("infer").alias("capability").description("Run inference");
+  infer.command("embed").description("Embed text").option("--model <id>", "Model id");
+  const cron = program.command("cron").description("Cron commands");
+  cron
+    .command("add")
+    .alias("create")
+    .description("Add a job")
+    .option("--at <time>", "Schedule time");
+  return program;
+}
+
+describe("completion-cli command aliases", () => {
+  it("completes root and nested aliases in zsh lists and dispatch", () => {
+    const script = getCompletionScript("zsh", createAliasedCompletionProgram());
+
+    expect(script).toContain("'capability[Run inference]'");
+    expect(script).toContain("(infer|capability) _openclaw_infer ;;");
+    expect(script).toContain("'create[Add a job]'");
+    expect(script).toContain("(add|create) _openclaw_cron_add ;;");
+  });
+
+  it("completes root and nested aliases in bash word lists and case labels", () => {
+    const script = getCompletionScript("bash", createAliasedCompletionProgram());
+
+    expect(script).toContain("infer capability cron");
+    expect(script).toContain("infer|capability)");
+    expect(script).toContain("add create");
+  });
+
+  it("completes aliases and their subtrees in fish", () => {
+    const script = getCompletionScript("fish", createAliasedCompletionProgram());
+
+    expect(script).toContain(
+      'complete -c openclaw -n "__fish_use_subcommand" -a "capability" -d \'Run inference\'',
+    );
+    expect(script).toContain(
+      'complete -c openclaw -n "__openclaw_command_path_matches capability --" -a "embed" -d \'Embed text\'',
+    );
+    expect(script).toContain(
+      'complete -c openclaw -n "__openclaw_command_path_matches cron --" -a "create" -d \'Add a job\'',
+    );
+    expect(script).toContain(
+      "complete -c openclaw -n \"__openclaw_command_path_matches cron create -- --at\" -l at -d 'Schedule time'",
+    );
+  });
+
+  it("completes aliases and alias command paths in PowerShell", () => {
+    const script = getCompletionScript("powershell", createAliasedCompletionProgram());
+
+    expect(script).toContain("$completions = @('infer','capability','cron')");
+    expect(script).toContain("if ($commandPath -eq 'capability') {");
+    expect(script).toContain("if ($commandPath -eq 'cron create') {");
+  });
+});

--- a/src/cli/completion-cli.ts
+++ b/src/cli/completion-cli.ts
@@ -48,7 +48,7 @@ function fishWords(values: readonly string[]): string {
   return values.join(" ");
 }
 
-function fishOptionFlags(options: Command["options"], wantsValue: boolean): string[] {
+function completionOptionFlags(options: Command["options"], wantsValue: boolean): string[] {
   return options.flatMap((option) => {
     if ((option.required || option.optional) !== wantsValue) {
       return [];
@@ -78,7 +78,7 @@ function collectFishPathOptionFlags(
   parents: readonly string[],
   wantsValue: boolean,
 ): string[] {
-  const flags = new Set(fishOptionFlags(program.options, wantsValue));
+  const flags = new Set(completionOptionFlags(program.options, wantsValue));
   let current: Command | undefined = program;
   for (const name of parents) {
     // Path segments can be aliases when the user typed one; resolve both forms.
@@ -86,7 +86,7 @@ function collectFishPathOptionFlags(
     if (!current) {
       break;
     }
-    for (const flag of fishOptionFlags(current.options, wantsValue)) {
+    for (const flag of completionOptionFlags(current.options, wantsValue)) {
       flags.add(flag);
     }
   }
@@ -393,31 +393,42 @@ ${funcName}() {
 }
 
 function generateBashCompletion(program: Command): string {
-  // Simplified Bash completion using dynamic iteration logic (often hardcoded in static scripts)
-  // For a robust implementation, usually one maps out the tree.
-  // This assumes a simple structure.
   const rootCmd = program.name();
-
-  // We can use a recursive function to build the case statements
+  const rootCompletions = [
+    ...program.commands.flatMap((command) => commandNameVariants(command)),
+    ...program.options.map((option) => preferredCompletionFlag(option.flags)),
+  ];
+  const rootValueOptions = completionOptionFlags(program.options, true);
+  const contexts = collectBashCompletionContexts(program, rootValueOptions);
+  const commandPathUpdate = generateBashCommandPathUpdate(contexts);
   return `
 _${rootCmd}_completion() {
-    local cur prev opts
+    local cur opts command_path candidate_path value_options word flag i
     COMPREPLY=()
     cur="\${COMP_WORDS[COMP_CWORD]}"
-    prev="\${COMP_WORDS[COMP_CWORD-1]}"
-    
-    # Simple top-level completion for now
-    opts="${program.commands.flatMap((c) => commandNameVariants(c)).join(" ")} ${program.options.map((o) => preferredCompletionFlag(o.flags)).join(" ")}"
-    
-    case "\${prev}" in
-      ${program.commands.map((cmd) => generateBashSubcommand(cmd)).join("\n      ")}
-    esac
+    opts="${rootCompletions.join(" ")}"
+    value_options="${rootValueOptions.join(" ")}"
+    command_path=""
 
-    if [[ \${cur} == -* ]] ; then
-        COMPREPLY=( $(compgen -W "\${opts}" -- \${cur}) )
-        return 0
-    fi
-    
+    for ((i = 1; i < COMP_CWORD; i++)); do
+        word="\${COMP_WORDS[i]}"
+        if [[ \${word} == -* ]]; then
+            flag="\${word%%=*}"
+            if [[ \${word} != *=* && " \${value_options} " == *" \${flag} "* ]]; then
+                i=$((i + 1))
+            fi
+            continue
+        fi
+
+        if [[ -n "\${command_path}" ]]; then
+            candidate_path="\${command_path} \${word}"
+        else
+            candidate_path="\${word}"
+        fi
+
+${commandPathUpdate}
+    done
+
     COMPREPLY=( $(compgen -W "\${opts}" -- \${cur}) )
 }
 
@@ -425,14 +436,69 @@ complete -F _${rootCmd}_completion ${rootCmd}
 `;
 }
 
-function generateBashSubcommand(cmd: Command): string {
-  // This is a naive implementation; fully recursive bash completion is complex to generate as a single string without improved state tracking.
-  // For now, let's provide top-level command recognition.
-  return `${commandNameVariants(cmd).join("|")})
-        opts="${cmd.commands.flatMap((c) => commandNameVariants(c)).join(" ")} ${cmd.options.map((o) => preferredCompletionFlag(o.flags)).join(" ")}"
-        COMPREPLY=( $(compgen -W "\${opts}" -- \${cur}) )
-        return 0
-        ;;`;
+type BashCompletionContext = {
+  pathVariants: string[][];
+  completions: string[];
+  valueOptions: string[];
+};
+
+function collectBashCompletionContexts(
+  program: Command,
+  rootValueOptions: string[],
+): BashCompletionContext[] {
+  const contexts: BashCompletionContext[] = [];
+
+  const visit = (cmd: Command, pathVariants: string[][], inheritedValueOptions: string[]) => {
+    const completions = [
+      ...cmd.commands.flatMap((command) => commandNameVariants(command)),
+      ...cmd.options.map((option) => preferredCompletionFlag(option.flags)),
+    ];
+    const valueOptions = [
+      ...new Set([...inheritedValueOptions, ...completionOptionFlags(cmd.options, true)]),
+    ];
+    contexts.push({ pathVariants, completions, valueOptions });
+
+    for (const sub of cmd.commands) {
+      visit(sub, childPathVariants(pathVariants, sub), valueOptions);
+    }
+  };
+
+  for (const sub of program.commands) {
+    visit(sub, childPathVariants([[]], sub), rootValueOptions);
+  }
+
+  return contexts;
+}
+
+function generateBashCompletionContextCases(contexts: BashCompletionContext[]): string {
+  const segments = contexts.map((context) => {
+    const patterns = context.pathVariants
+      .map((commandPath) => `"${commandPath.join(" ")}"`)
+      .join("|");
+    return `              ${patterns})
+                opts="${context.completions.join(" ")}"
+                value_options="${context.valueOptions.join(" ")}"
+                ;;`;
+  });
+  return segments.join("\n");
+}
+
+function generateBashCommandPathUpdate(contexts: BashCompletionContext[]): string {
+  if (contexts.length === 0) {
+    return "";
+  }
+  const commandPathPatterns = contexts
+    .flatMap((context) => context.pathVariants)
+    .map((commandPath) => `"${commandPath.join(" ")}"`)
+    .join("|");
+  return `        case "\${candidate_path}" in
+          ${commandPathPatterns})
+            command_path="\${candidate_path}"
+            case "\${command_path}" in
+${generateBashCompletionContextCases(contexts)}
+            esac
+            ;;
+        esac`;
 }
 
 function generatePowerShellCompletion(program: Command): string {

--- a/src/cli/completion-cli.ts
+++ b/src/cli/completion-cli.ts
@@ -63,6 +63,16 @@ function commandNameVariants(cmd: Command): string[] {
   return [cmd.name(), ...cmd.aliases()];
 }
 
+// Alias-typed paths must keep completing like the canonical command. Variants
+// multiply by (1 + alias count) per aliased ancestor, so nesting aliased
+// commands under each other grows emitted paths multiplicatively; today no
+// aliased command nests under another.
+function childPathVariants(parentVariants: readonly string[][], sub: Command): string[][] {
+  return parentVariants.flatMap((parents) =>
+    commandNameVariants(sub).map((name) => parents.concat(name)),
+  );
+}
+
 function collectFishPathOptionFlags(
   program: Command,
   parents: readonly string[],
@@ -455,14 +465,7 @@ function generatePowerShellCompletion(program: Command): string {
     }
 
     for (const sub of cmd.commands) {
-      // Alias-typed paths must keep completing like the canonical command; the
-      // variant count stays bounded because it grows only under aliased ancestors.
-      visit(
-        sub,
-        pathVariants.flatMap((parentPath) =>
-          commandNameVariants(sub).map((name) => parentPath.concat(name)),
-        ),
-      );
+      visit(sub, childPathVariants(pathVariants, sub));
     }
   };
 
@@ -542,12 +545,7 @@ function generateFishCompletion(program: Command): string {
     }
 
     for (const sub of cmd.commands) {
-      visit(
-        sub,
-        parentVariants.flatMap((parents) =>
-          commandNameVariants(sub).map((name) => parents.concat(name)),
-        ),
-      );
+      visit(sub, childPathVariants(parentVariants, sub));
     }
   };
 

--- a/src/cli/completion-cli.ts
+++ b/src/cli/completion-cli.ts
@@ -57,6 +57,12 @@ function fishOptionFlags(options: Command["options"], wantsValue: boolean): stri
   });
 }
 
+// Aliases are typeable command words; every completion surface must offer them
+// alongside the canonical name or advertised commands appear nonexistent.
+function commandNameVariants(cmd: Command): string[] {
+  return [cmd.name(), ...cmd.aliases()];
+}
+
 function collectFishPathOptionFlags(
   program: Command,
   parents: readonly string[],
@@ -65,7 +71,8 @@ function collectFishPathOptionFlags(
   const flags = new Set(fishOptionFlags(program.options, wantsValue));
   let current: Command | undefined = program;
   for (const name of parents) {
-    current = current?.commands.find((cmd) => cmd.name() === name);
+    // Path segments can be aliases when the user typed one; resolve both forms.
+    current = current?.commands.find((cmd) => commandNameVariants(cmd).includes(name));
     if (!current) {
       break;
     }
@@ -258,7 +265,7 @@ _${rootCmd}_root_completion() {
   case $state in
     (args)
       case $line[1] in
-        ${program.commands.map((cmd) => `(${cmd.name()}) _${rootCmd}_${cmd.name().replace(/-/g, "_")} ;;`).join("\n        ")}
+        ${program.commands.map((cmd) => `(${commandNameVariants(cmd).join("|")}) _${rootCmd}_${cmd.name().replace(/-/g, "_")} ;;`).join("\n        ")}
       esac
       ;;
   esac
@@ -304,14 +311,14 @@ function generateZshArgs(cmd: Command): string {
 
 function generateZshSubcmdList(cmd: Command): string {
   const list = cmd.commands
-    .map((c) => {
+    .flatMap((c) => {
       const desc = c
         .description()
         .replace(/\\/g, "\\\\")
         .replace(/'/g, "'\\''")
         .replace(/\[/g, "\\[")
         .replace(/\]/g, "\\]");
-      return `'${c.name()}[${desc}]'`;
+      return commandNameVariants(c).map((name) => `'${name}[${desc}]'`);
     })
     .join(" ");
   return `"1: :_values 'command' ${list}"`;
@@ -353,7 +360,7 @@ ${funcName}() {
   case $state in
     (args)
       case $line[1] in
-        ${subCommands.map((sub) => `(${sub.name()}) ${funcName}_${sub.name().replace(/-/g, "_")} ;;`).join("\n        ")}
+        ${subCommands.map((sub) => `(${commandNameVariants(sub).join("|")}) ${funcName}_${sub.name().replace(/-/g, "_")} ;;`).join("\n        ")}
       esac
       ;;
   esac
@@ -390,7 +397,7 @@ _${rootCmd}_completion() {
     prev="\${COMP_WORDS[COMP_CWORD-1]}"
     
     # Simple top-level completion for now
-    opts="${program.commands.map((c) => c.name()).join(" ")} ${program.options.map((o) => preferredCompletionFlag(o.flags)).join(" ")}"
+    opts="${program.commands.flatMap((c) => commandNameVariants(c)).join(" ")} ${program.options.map((o) => preferredCompletionFlag(o.flags)).join(" ")}"
     
     case "\${prev}" in
       ${program.commands.map((cmd) => generateBashSubcommand(cmd)).join("\n      ")}
@@ -411,8 +418,8 @@ complete -F _${rootCmd}_completion ${rootCmd}
 function generateBashSubcommand(cmd: Command): string {
   // This is a naive implementation; fully recursive bash completion is complex to generate as a single string without improved state tracking.
   // For now, let's provide top-level command recognition.
-  return `${cmd.name()})
-        opts="${cmd.commands.map((c) => c.name()).join(" ")} ${cmd.options.map((o) => preferredCompletionFlag(o.flags)).join(" ")}"
+  return `${commandNameVariants(cmd).join("|")})
+        opts="${cmd.commands.flatMap((c) => commandNameVariants(c)).join(" ")} ${cmd.options.map((o) => preferredCompletionFlag(o.flags)).join(" ")}"
         COMPREPLY=( $(compgen -W "\${opts}" -- \${cur}) )
         return 0
         ;;`;
@@ -424,16 +431,19 @@ function generatePowerShellCompletion(program: Command): string {
   const formatPowerShellArray = (entries: string[]) =>
     entries.length > 0 ? `@(${entries.map((entry) => `'${entry}'`).join(",")})` : "@()";
 
-  const visit = (cmd: Command, pathSegments: string[]) => {
-    const fullPath = pathSegments.join(" ");
-
+  const visit = (cmd: Command, pathVariants: string[][]) => {
     // Command completion for this level
-    const subCommands = cmd.commands.map((c) => c.name());
+    const subCommands = cmd.commands.flatMap((c) => commandNameVariants(c));
     const options = cmd.options.map((o) => preferredCompletionFlag(o.flags));
     const allCompletions = formatPowerShellArray([...subCommands, ...options]);
 
-    if (fullPath.length > 0 && [...subCommands, ...options].length > 0) {
-      segments.push(`
+    if ([...subCommands, ...options].length > 0) {
+      for (const pathSegments of pathVariants) {
+        const fullPath = pathSegments.join(" ");
+        if (fullPath.length === 0) {
+          continue;
+        }
+        segments.push(`
             if ($commandPath -eq '${fullPath}') {
                 $completions = ${allCompletions}
                 $completions | Where-Object { $_ -like "$wordToComplete*" } | ForEach-Object {
@@ -441,14 +451,22 @@ function generatePowerShellCompletion(program: Command): string {
                 }
             }
 `);
+      }
     }
 
     for (const sub of cmd.commands) {
-      visit(sub, [...pathSegments, sub.name()]);
+      // Alias-typed paths must keep completing like the canonical command; the
+      // variant count stays bounded because it grows only under aliased ancestors.
+      visit(
+        sub,
+        pathVariants.flatMap((parentPath) =>
+          commandNameVariants(sub).map((name) => parentPath.concat(name)),
+        ),
+      );
     }
   };
 
-  visit(program, []);
+  visit(program, [[]]);
   const rootBody = segments.join("");
 
   return `
@@ -471,7 +489,7 @@ Register-ArgumentCompleter -Native -CommandName ${rootCmd} -ScriptBlock {
     # Root command
     if ($commandPath -eq "") {
          $completions = ${formatPowerShellArray([
-           ...program.commands.map((command) => command.name()),
+           ...program.commands.flatMap((command) => commandNameVariants(command)),
            ...program.options.map((option) => preferredCompletionFlag(option.flags)),
          ])}
          $completions | Where-Object { $_ -like "$wordToComplete*" } | ForEach-Object {
@@ -488,43 +506,27 @@ function generateFishCompletion(program: Command): string {
   const rootCmd = program.name();
   const segments: string[] = [generateFishPathHelper(rootCmd)];
 
-  const visit = (cmd: Command, parents: string[]) => {
-    // Root logic
-    if (parents.length === 0) {
-      // Subcommands of root
+  const visit = (cmd: Command, parentVariants: string[][]) => {
+    // One condition per alias-expanded parent path so completion keeps working
+    // after the user typed an alias segment.
+    const conditions = parentVariants.map((parents) =>
+      parents.length === 0
+        ? "__fish_use_subcommand"
+        : fishCommandPathCondition(program, rootCmd, parents),
+    );
+    for (const condition of conditions) {
+      // Subcommands (canonical names and aliases)
       for (const sub of cmd.commands) {
-        segments.push(
-          buildFishSubcommandCompletionLine({
-            rootCmd,
-            condition: "__fish_use_subcommand",
-            name: sub.name(),
-            description: sub.description(),
-          }),
-        );
-      }
-      // Options of root
-      for (const opt of cmd.options) {
-        segments.push(
-          buildFishOptionCompletionLine({
-            rootCmd,
-            condition: "__fish_use_subcommand",
-            flags: opt.flags,
-            description: opt.description,
-          }),
-        );
-      }
-    } else {
-      const condition = fishCommandPathCondition(program, rootCmd, parents);
-      // Subcommands
-      for (const sub of cmd.commands) {
-        segments.push(
-          buildFishSubcommandCompletionLine({
-            rootCmd,
-            condition,
-            name: sub.name(),
-            description: sub.description(),
-          }),
-        );
+        for (const name of commandNameVariants(sub)) {
+          segments.push(
+            buildFishSubcommandCompletionLine({
+              rootCmd,
+              condition,
+              name,
+              description: sub.description(),
+            }),
+          );
+        }
       }
       // Options
       for (const opt of cmd.options) {
@@ -540,10 +542,15 @@ function generateFishCompletion(program: Command): string {
     }
 
     for (const sub of cmd.commands) {
-      visit(sub, parents.length === 0 ? [sub.name()] : [...parents, sub.name()]);
+      visit(
+        sub,
+        parentVariants.flatMap((parents) =>
+          commandNameVariants(sub).map((name) => parents.concat(name)),
+        ),
+      );
     }
   };
 
-  visit(program, []);
+  visit(program, [[]]);
   return segments.join("");
 }

--- a/src/cli/program/register.subclis-core.ts
+++ b/src/cli/program/register.subclis-core.ts
@@ -127,7 +127,9 @@ const entrySpecs: readonly CommandGroupDescriptorSpec<SubCliRegistrar>[] = [
       exportName: "registerCapabilityCli",
     },
     {
-      commandNames: ["approvals"],
+      // exec-approvals is a commander alias on the approvals command; the lazy
+      // router only routes names listed here, so the alias must be owned too.
+      commandNames: ["approvals", "exec-approvals"],
       loadModule: () => import("../exec-approvals-cli.js"),
       exportName: "registerExecApprovalsCli",
     },

--- a/src/cli/program/register.subclis.test.ts
+++ b/src/cli/program/register.subclis.test.ts
@@ -38,6 +38,14 @@ const { inferAction, registerCapabilityCli } = vi.hoisted(() => {
   return { inferAction: action, registerCapabilityCli: register };
 });
 
+const { approvalsAction, registerExecApprovalsCli } = vi.hoisted(() => {
+  const action = vi.fn();
+  const register = vi.fn((program: Command) => {
+    program.command("approvals").alias("exec-approvals").action(action);
+  });
+  return { approvalsAction: action, registerExecApprovalsCli: register };
+});
+
 const { registerPluginsCli, registerPluginCliCommandsFromValidatedConfig } = vi.hoisted(() => ({
   registerPluginsCli: vi.fn((program: Command) => {
     const plugins = program.command("plugins");
@@ -72,6 +80,7 @@ vi.mock("../gateway-cli.js", () => ({ registerGatewayCli }));
 vi.mock("../gateway-cli/run-command.js", () => ({ addGatewayRunCommand }));
 vi.mock("../nodes-cli.js", () => ({ registerNodesCli }));
 vi.mock("../capability-cli.js", () => ({ registerCapabilityCli }));
+vi.mock("../exec-approvals-cli.js", () => ({ registerExecApprovalsCli }));
 vi.mock("../plugins-cli.js", () => ({ registerPluginsCli }));
 vi.mock("../channels-cli.js", () => ({ registerChannelsCli }));
 vi.mock("../../plugins/cli.js", () => ({ registerPluginCliCommandsFromValidatedConfig }));
@@ -113,6 +122,8 @@ describe("registerSubCliCommands", () => {
     loadPrivateQaCliModule.mockClear();
     registerCapabilityCli.mockClear();
     inferAction.mockClear();
+    registerExecApprovalsCli.mockClear();
+    approvalsAction.mockClear();
     registerPluginsCli.mockClear();
     registerPluginCliCommandsFromValidatedConfig.mockClear();
     registerChannelsCli.mockClear();
@@ -191,6 +202,17 @@ describe("registerSubCliCommands", () => {
 
     expect(registerCapabilityCli).toHaveBeenCalledTimes(1);
     expect(inferAction).toHaveBeenCalledTimes(1);
+  });
+
+  it("registers the exec-approvals placeholder and dispatches through the approvals registrar", async () => {
+    const program = createRegisteredProgram(["node", "openclaw", "exec-approvals"], "openclaw");
+
+    expect(program.commands.map((cmd) => cmd.name())).toEqual(["exec-approvals", "completion"]);
+
+    await program.parseAsync(["exec-approvals"], { from: "user" });
+
+    expect(registerExecApprovalsCli).toHaveBeenCalledTimes(1);
+    expect(approvalsAction).toHaveBeenCalledTimes(1);
   });
 
   it("replaces placeholder when registering a subcommand by name", async () => {

--- a/src/cli/program/subcli-descriptors.ts
+++ b/src/cli/program/subcli-descriptors.ts
@@ -46,6 +46,11 @@ const subCliCommandCatalog = defineCommandDescriptorCatalog([
     parentDefaultHelp: true,
   },
   {
+    name: "exec-approvals",
+    description: "Manage exec approvals (alias for approvals)",
+    hasSubcommands: true,
+  },
+  {
     name: "exec-policy",
     description: "Show or synchronize requested exec policy with host approvals",
     hasSubcommands: true,


### PR DESCRIPTION
Closes #99406

## What Problem This Solves

Generated zsh, Bash, fish, and PowerShell completion omitted Commander command aliases. Advertised names such as `capability`, `terminal`, `chat`, nested cron aliases, and the documented `exec-approvals` alias either did not complete or lost their completion context.

## Why This Change Was Made

The generators now derive accepted command names from the canonical Commander name plus `aliases()`. Alias-expanded paths are shared by the recursive generators, and the lazy CLI registry now routes the documented `exec-approvals` alias through the existing approvals owner.

The maintainer repair also makes Bash track complete canonical-or-alias command paths. It skips values for root and ancestor options, so flows such as `openclaw --profile work cron create <TAB>` retain the `cron add|create` completion context. The recursive Bash approach from #99431 is preserved with co-author credit.

## User Impact

Installed shell completion now matches the CLI names accepted at runtime. Canonical names continue to work, aliases are offered at each level, and completion continues after aliases across all four supported shells.

## Evidence

- Local focused completion/routing suites: 75 tests passed.
- Generated full-command-tree scripts for Bash, zsh, fish, and PowerShell contain the expected aliases.
- `bash -n` and `zsh -n` passed on generated scripts.
- The generated Bash function returns `--at` for `openclaw --profile work cron create --a`.
- `openclaw exec-approvals --help` and `openclaw approvals --help` both report `Usage: openclaw approvals|exec-approvals`.
- Blacksmith Testbox `tbx_01kwr0t6zc13gcfy7r9k82vv0d`: 75 focused tests passed and path-scoped `pnpm check:changed` passed.
- Fresh autoreview against current `origin/main`: no actionable findings.
