### PR TITLE
fix(infra): add NaN guard for unparseable timestamp in cost usage

### DIFF
--- a/src/infra/session-cost-usage.ts
+++ b/src/infra/session-cost-usage.ts
@@ -2730,6 +2730,9 @@ export async function loadSessionLogs(params: {
       let timestamp = 0;
       if (typeof parsed.timestamp === "string") {
         timestamp = new Date(parsed.timestamp).getTime();
+        if (Number.isNaN(timestamp)) {
+          timestamp = 0;
+        }
       } else if (typeof message.timestamp === "number") {
         timestamp = message.timestamp;
       }


### PR DESCRIPTION
## What Problem This Solves

`new Date(parsed.timestamp).getTime()` in `session-cost-usage.ts` can return `NaN` when the timestamp string is unparseable (e.g. "not-a-date", empty string, malformed). Without a guard, NaN silently propagates into downstream usage/cost calculations, corrupting billing data.

## Evidence

### Real behavior proof (before vs after NaN guard)

```
============================================================
Proof: NaN timestamp guard in session-cost-usage.ts
============================================================
  "valid ISO 8601": 1705314600000 ✓
  "garbage string": fallback to 0 ✓
  "empty string": fallback to 0 ✓
  "non-date keyword": fallback to 0 ✓
  "'null' string": fallback to 0 ✓

  All 5/5 cases NaN-safe ✓
```

Without the guard, the 4 non-date inputs produce `NaN` which corrupts downstream calculations. With the guard, they safely fall back to 0 (the same default as when no timestamp key is present).

### Existing tests

57 of 58 session-cost-usage tests pass (the 1 failure is a pre-existing DST/Intl stub issue unrelated to this change).

### Build verification

Full project builds successfully with the change.

## Why This Change Was Made

This is a "present-but-invalid" boundary case — the timestamp key exists as a string, so we enter the `typeof parsed.timestamp === "string"` branch, but the parsed value is garbage. The same guard pattern already exists elsewhere in the codebase. The fix is a 3-line addition with no change to any other code path.

## Merge Risk

Zero. The guard only activates when `new Date(...).getTime()` returns `NaN`, which was previously unhandled and would propagate corrupt data. All valid timestamps pass through unchanged.

Fixes #99413

🤖 Generated with [Claude Code](https://claude.com/claude-code)