### PR TITLE
docs(agents): update timeoutSeconds examples to reflect 48h default

### DIFF
--- a/docs/gateway/config-agents.md
+++ b/docs/gateway/config-agents.md
@@ -408,7 +408,7 @@ Time format in system prompt. Default: `auto` (OS preference).
       toolProgressDetail: "explain",
       reasoningDefault: "off",
       elevatedDefault: "on",
-      timeoutSeconds: 600,
+      timeoutSeconds: 172800, // default 48h, unset to use the built-in default
       mediaMaxMb: 5,
       contextTokens: 200000,
       maxConcurrent: 3,

--- a/docs/gateway/configuration-examples.md
+++ b/docs/gateway/configuration-examples.md
@@ -268,7 +268,7 @@ Save to `~/.openclaw/openclaw.json` and you can DM the bot from that number.
       humanDelay: {
         mode: "natural",
       },
-      timeoutSeconds: 600,
+      timeoutSeconds: 172800, // default 48h, unset to use the built-in default
       mediaMaxMb: 5,
       typingIntervalSeconds: 5,
       maxConcurrent: 3,


### PR DESCRIPTION
## What Problem This Solves

The built-in default for `agents.defaults.timeoutSeconds` is now `172800` (48h) as defined in `src/agents/timeout.ts:12`. However, config examples in `docs/gateway/config-agents.md` and `docs/gateway/configuration-examples.md` still show `timeoutSeconds: 600`, misleading users into capping long-running agents at 10 minutes.

Closes #98180

## Changes

- **`docs/gateway/config-agents.md`** — update example from `600` to `172800 // default 48h`
- **`docs/gateway/configuration-examples.md`** — same

## Evidence

Source code confirms the current default:

```text
$ grep -n DEFAULT_AGENT_TIMEOUT src/agents/timeout.ts
12: const DEFAULT_AGENT_TIMEOUT_SECONDS = 48 * 60 * 60;

$ grep timeoutSeconds docs/gateway/config-agents.md docs/gateway/configuration-examples.md
(before): timeoutSeconds: 600,
(after):  timeoutSeconds: 172800, // default 48h
```

## Related

Closes #98180

🤖 Generated with [Claude Code](https://claude.com/claude-code)