### PR TITLE
fix(memory-wiki): skip malformed legacy import-run files in doctor

### DIFF
--- a/extensions/memory-wiki/doctor-contract-api.test.ts
+++ b/extensions/memory-wiki/doctor-contract-api.test.ts
@@ -201,6 +201,190 @@ describe("memory-wiki doctor source sync migration", () => {
     await expect(fs.readFile(snapshotPath, "utf8")).resolves.toBe("previous page\n");
   });
 
+  it("skips malformed legacy import-run files, leaving them in place with a warning", async () => {
+    const stateDir = await makeTempDir();
+    const vaultRoot = path.join(stateDir, "vault");
+    const validPath = resolveLegacyImportRunRecordPath(vaultRoot, "chatgpt-valid");
+    const malformedPath = resolveLegacyImportRunRecordPath(vaultRoot, "chatgpt-broken");
+    await fs.mkdir(path.dirname(validPath), { recursive: true });
+    await fs.writeFile(
+      validPath,
+      `${JSON.stringify({
+        version: 1,
+        runId: "chatgpt-valid",
+        importType: "chatgpt",
+        exportPath: "/tmp/a",
+        sourcePath: "/tmp/a/conv.json",
+        appliedAt: "2026-04-10T10:00:00.000Z",
+        conversationCount: 1,
+        createdCount: 1,
+        updatedCount: 0,
+        skippedCount: 0,
+        createdPaths: ["sources/a.md"],
+        updatedPaths: [],
+      })}\n`,
+    );
+    // Partial write / editor save with a syntax error -> not valid JSON.
+    await fs.writeFile(malformedPath, "{ broken json , ");
+
+    const params = migrationParams({ stateDir, vaultRoot });
+    const migration = stateMigrations.find(
+      (entry) => entry.id === "memory-wiki-import-runs-json-to-plugin-state",
+    );
+    if (!migration) {
+      throw new Error("Expected import-run migration");
+    }
+
+    // Detection still reports the valid record; malformed ones do not block detection.
+    await expect(migration.detectLegacyState(params)).resolves.toEqual({
+      preview: [expect.stringContaining("Memory Wiki import runs:")],
+    });
+    // Migration succeeds; the malformed file is left in place with a warning.
+    const result = await migration.migrateLegacyState(params);
+    expect(result.warnings).toEqual([expect.stringContaining("legacy import-run file")]);
+    // Valid file -> archived (renamed).
+    await expect(fs.stat(validPath)).rejects.toMatchObject({ code: "ENOENT" });
+    await expect(fs.stat(`${validPath}.migrated`)).resolves.toBeDefined();
+    // Malformed file -> left in place (not archived, not renamed).
+    await expect(fs.stat(malformedPath)).resolves.toBeDefined();
+    await expect(fs.stat(`${malformedPath}.migrated`)).rejects.toMatchObject({ code: "ENOENT" });
+  });
+
+  it("skips schema-invalid legacy import-run files, leaving them in place with a warning", async () => {
+    const stateDir = await makeTempDir();
+    const vaultRoot = path.join(stateDir, "vault");
+    const validPath = resolveLegacyImportRunRecordPath(vaultRoot, "chatgpt-valid");
+    const badSchemaPath = resolveLegacyImportRunRecordPath(vaultRoot, "chatgpt-bad");
+    await fs.mkdir(path.dirname(validPath), { recursive: true });
+    await fs.writeFile(
+      validPath,
+      JSON.stringify({
+        version: 1,
+        runId: "chatgpt-valid",
+        importType: "chatgpt",
+        exportPath: "/tmp/a",
+        sourcePath: "/tmp/a/conv.json",
+        appliedAt: "2026-04-10T10:00:00.000Z",
+        conversationCount: 1,
+        createdCount: 1,
+        updatedCount: 0,
+        skippedCount: 0,
+        createdPaths: ["sources/a.md"],
+        updatedPaths: [],
+      }) + "\n",
+    );
+    // Syntactically valid JSON, but version 99 — schema-invalid (reader skips it).
+    await fs.writeFile(
+      badSchemaPath,
+      JSON.stringify({
+        version: 99,
+        runId: "chatgpt-bad",
+        importType: "chatgpt",
+        exportPath: "/tmp/b",
+        sourcePath: "/tmp/b/conv.json",
+        appliedAt: "2026-04-10T10:00:00.000Z",
+        conversationCount: 1,
+        createdCount: 1,
+        updatedCount: 0,
+        skippedCount: 0,
+        createdPaths: ["sources/b.md"],
+        updatedPaths: [],
+      }) + "\n",
+    );
+
+    const params = migrationParams({ stateDir, vaultRoot });
+    const migration = stateMigrations.find(
+      (entry) => entry.id === "memory-wiki-import-runs-json-to-plugin-state",
+    );
+    if (!migration) {
+      throw new Error("Expected import-run migration");
+    }
+
+    await expect(migration.detectLegacyState(params)).resolves.toEqual({
+      preview: [expect.stringContaining("Memory Wiki import runs:")],
+    });
+    const result = await migration.migrateLegacyState(params);
+    expect(result.warnings).toEqual([expect.stringContaining("legacy import-run file")]);
+    // Valid file -> archived.
+    await expect(fs.stat(validPath)).rejects.toMatchObject({ code: "ENOENT" });
+    await expect(fs.stat(`${validPath}.migrated`)).resolves.toBeDefined();
+    // Schema-invalid file -> left in place.
+    await expect(fs.stat(badSchemaPath)).resolves.toBeDefined();
+    await expect(fs.stat(`${badSchemaPath}.migrated`)).rejects.toMatchObject({ code: "ENOENT" });
+  });
+
+  it("diagnoses a malformed-only vault via archive warnings", async () => {
+    const stateDir = await makeTempDir();
+    const vaultRoot = path.join(stateDir, "vault");
+    const malformedPath = resolveLegacyImportRunRecordPath(vaultRoot, "broken");
+    await fs.mkdir(path.dirname(malformedPath), { recursive: true });
+    await fs.writeFile(malformedPath, "{ not json , ");
+
+    const params = migrationParams({ stateDir, vaultRoot });
+    const migration = stateMigrations.find(
+      (entry) => entry.id === "memory-wiki-import-runs-json-to-plugin-state",
+    );
+    if (!migration) {
+      throw new Error("Expected import-run migration");
+    }
+
+    // No valid records, but a malformed file is still present: detect must plan
+    // the migration so the doctor runs migrateLegacyState, which emits an archive
+    // diagnostic instead of silently leaving the bad file behind.
+    await expect(migration.detectLegacyState(params)).resolves.toEqual({
+      preview: [expect.stringContaining("malformed/schema-invalid file(s) to diagnose")],
+    });
+    // migrate runs and warns about the malformed file; it stays in place.
+    const result = await migration.migrateLegacyState(params);
+    expect(result?.warnings).toEqual([
+      expect.stringContaining(`Skipped legacy import-run file ${malformedPath}`),
+    ]);
+    await expect(fs.stat(malformedPath)).resolves.toBeDefined();
+  });
+
+  it("skips a schema-invalid-only vault without crashing", async () => {
+    const stateDir = await makeTempDir();
+    const vaultRoot = path.join(stateDir, "vault");
+    const badSchemaPath = resolveLegacyImportRunRecordPath(vaultRoot, "bad");
+    await fs.mkdir(path.dirname(badSchemaPath), { recursive: true });
+    await fs.writeFile(
+      badSchemaPath,
+      JSON.stringify({
+        version: 99,
+        runId: "bad",
+        importType: "chatgpt",
+        exportPath: "/tmp/b",
+        sourcePath: "/tmp/b/conv.json",
+        appliedAt: "2026-04-10T10:00:00.000Z",
+        conversationCount: 1,
+        createdCount: 1,
+        updatedCount: 0,
+        skippedCount: 0,
+        createdPaths: [],
+        updatedPaths: [],
+      }) + "\n",
+    );
+
+    const params = migrationParams({ stateDir, vaultRoot });
+    const migration = stateMigrations.find(
+      (entry) => entry.id === "memory-wiki-import-runs-json-to-plugin-state",
+    );
+    if (!migration) {
+      throw new Error("Expected import-run migration");
+    }
+
+    // No valid records, but a schema-invalid file is still present: detect must
+    // plan the migration so migrateLegacyState runs and emits an archive warning.
+    await expect(migration.detectLegacyState(params)).resolves.toEqual({
+      preview: [expect.stringContaining("malformed/schema-invalid file(s) to diagnose")],
+    });
+    const schemaResult = await migration.migrateLegacyState(params);
+    expect(schemaResult?.warnings).toEqual([
+      expect.stringContaining(`Skipped legacy import-run file ${badSchemaPath}`),
+    ]);
+    await expect(fs.stat(badSchemaPath)).resolves.toBeDefined();
+  });
+
   it("merges legacy entries with existing plugin state before archiving", async () => {
     const stateDir = await makeTempDir();
     const vaultRoot = path.join(stateDir, "vault");

--- a/extensions/memory-wiki/doctor-contract-api.ts
+++ b/extensions/memory-wiki/doctor-contract-api.ts
@@ -21,6 +21,7 @@ import {
   listMemoryWikiImportRunRecords,
   MEMORY_WIKI_IMPORT_RUN_STATE_MAX_ENTRIES,
   MEMORY_WIKI_IMPORT_RUN_STATE_NAMESPACE,
+  normalizeMemoryWikiImportRunRecord,
   readLegacyMemoryWikiImportRunRecords,
   resolveMemoryWikiImportRunsDir,
   writeMemoryWikiImportRunRecord,
@@ -68,6 +69,22 @@ function resolveConfiguredVaultRoots(params: {
   );
 }
 
+// Counts legacy import-run `.json` files, including malformed/schema-invalid
+// ones the reader skips. Used by detectLegacyState so a malformed-only vault
+// still plans a migration (and thus emits archive diagnostics).
+async function countLegacyImportRunFiles(vaultRoot: string): Promise<number> {
+  const importRunsDir = resolveMemoryWikiImportRunsDir(vaultRoot);
+  const entries = await fs
+    .readdir(importRunsDir, { withFileTypes: true })
+    .catch((error: unknown) => {
+      if (isRecord(error) && error.code === "ENOENT") {
+        return [];
+      }
+      throw error;
+    });
+  return entries.filter((entry) => entry.isFile() && entry.name.endsWith(".json")).length;
+}
+
 async function archiveLegacyImportRunRecords(params: {
   vaultRoot: string;
   changes: string[];
@@ -86,8 +103,27 @@ async function archiveLegacyImportRunRecords(params: {
     if (!entry.isFile() || !entry.name.endsWith(".json")) {
       continue;
     }
+    const filePath = path.join(importRunsDir, entry.name);
+    // Only archive files that the reader would actually accept as a valid
+    // import-run record. The reader runs the raw parse through
+    // normalizeMemoryWikiImportRunRecord, which checks version, importType,
+    // and mandatory fields. Use the same criterion so a schema-invalid file
+    // is also left in place.
+    try {
+      const raw = await fs.readFile(filePath, "utf8");
+      const record = normalizeMemoryWikiImportRunRecord(JSON.parse(raw));
+      if (!record) {
+        throw new Error("schema-invalid");
+      }
+    } catch {
+      params.warnings.push(
+        `Skipped legacy import-run file ${filePath} (malformed or schema-invalid) — not archived. ` +
+          `Inspect or delete the file, then re-run \`openclaw doctor --fix\`.`,
+      );
+      continue;
+    }
     await archiveLegacyStateSource({
-      filePath: path.join(importRunsDir, entry.name),
+      filePath,
       label: "Memory Wiki import-run",
       changes: params.changes,
       warnings: params.warnings,
@@ -186,6 +222,17 @@ export const stateMigrations: PluginDoctorStateMigration[] = [
       })) {
         const records = await readLegacyMemoryWikiImportRunRecords(vaultRoot);
         if (records.length === 0) {
+          // No valid records, but the import-runs directory may still contain
+          // malformed or schema-invalid files. Plan the migration anyway so the
+          // doctor runs migrateLegacyState, which emits an archive diagnostic
+          // per bad file instead of silently leaving it behind.
+          const legacyFileCount = await countLegacyImportRunFiles(vaultRoot);
+          if (legacyFileCount === 0) {
+            continue;
+          }
+          previews.push(
+            `- Memory Wiki import runs: ${resolveMemoryWikiImportRunsDir(vaultRoot)}/*.json -> plugin state (${MEMORY_WIKI_IMPORT_RUN_STATE_NAMESPACE}, 0 valid + ${legacyFileCount} malformed/schema-invalid file(s) to diagnose)`,
+          );
           continue;
         }
         previews.push(
@@ -204,6 +251,10 @@ export const stateMigrations: PluginDoctorStateMigration[] = [
       })) {
         const records = await readLegacyMemoryWikiImportRunRecords(vaultRoot);
         if (records.length === 0) {
+          // No valid records to migrate, but the import-runs directory may still
+          // contain malformed or schema-invalid files. Run archive so those files
+          // produce a diagnostic warning instead of being silently left behind.
+          await archiveLegacyImportRunRecords({ vaultRoot, changes, warnings });
           continue;
         }
         const existingRecords = await listMemoryWikiImportRunRecords(vaultRoot, store);

--- a/extensions/memory-wiki/src/import-runs-state.ts
+++ b/extensions/memory-wiki/src/import-runs-state.ts
@@ -120,7 +120,7 @@ function asNonNegativeInteger(value: unknown): number {
   return typeof value === "number" && Number.isFinite(value) ? Math.max(0, Math.floor(value)) : 0;
 }
 
-function normalizeMemoryWikiImportRunRecord(raw: unknown): ChatGptImportRunRecord | null {
+export function normalizeMemoryWikiImportRunRecord(raw: unknown): ChatGptImportRunRecord | null {
   const record = asRecord(raw);
   if (!record) {
     return null;
@@ -478,7 +478,13 @@ export async function readLegacyMemoryWikiImportRunRecords(
     entries.filter((entry) => entry.isFile() && entry.name.endsWith(".json")),
     async (entry) => {
       const raw = await fs.readFile(path.join(importRunsDir, entry.name), "utf8");
-      return normalizeMemoryWikiImportRunRecord(JSON.parse(raw) as unknown) ?? pMapSkip;
+      try {
+        return normalizeMemoryWikiImportRunRecord(JSON.parse(raw) as unknown) ?? pMapSkip;
+      } catch {
+        // A partial write must not prevent doctor from migrating other valid
+        // records. Filesystem failures remain actionable to the doctor caller.
+        return pMapSkip;
+      }
     },
     { concurrency: LEGACY_IMPORT_RUN_READ_CONCURRENCY, stopOnError: true },
   );

--- a/extensions/memory-wiki/src/import-runs.test.ts
+++ b/extensions/memory-wiki/src/import-runs.test.ts
@@ -2,7 +2,7 @@
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { resolveMemoryWikiConfig } from "./config.js";
 import {
   readLegacyMemoryWikiImportRunRecords,
@@ -108,5 +108,29 @@ describe("memory-wiki import runs", () => {
     const records = await readLegacyMemoryWikiImportRunRecords(vaultRoot);
     expect(records).toHaveLength(1);
     expect(records[0]?.runId).toBe("valid-run");
+  });
+
+  it("preserves legacy import-run read failures", async () => {
+    const vaultRoot = await makeTempVault();
+    const dir = path.join(vaultRoot, ".openclaw-wiki", "import-runs");
+    const unreadablePath = path.join(dir, "unreadable.json");
+    await fs.mkdir(dir, { recursive: true });
+    await fs.writeFile(unreadablePath, "{}", "utf8");
+    const originalReadFile = fs.readFile.bind(fs);
+    const readFile = vi.spyOn(fs, "readFile").mockImplementation(async (filePath, options) => {
+      if (filePath === unreadablePath) {
+        const error = new Error("simulated I/O failure") as NodeJS.ErrnoException;
+        error.code = "EIO";
+        throw error;
+      }
+      return await originalReadFile(filePath, options);
+    });
+    try {
+      await expect(readLegacyMemoryWikiImportRunRecords(vaultRoot)).rejects.toMatchObject({
+        code: "EIO",
+      });
+    } finally {
+      readFile.mockRestore();
+    }
   });
 });

--- a/extensions/memory-wiki/src/import-runs.test.ts
+++ b/extensions/memory-wiki/src/import-runs.test.ts
@@ -4,7 +4,10 @@ import os from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 import { resolveMemoryWikiConfig } from "./config.js";
-import { writeMemoryWikiImportRunRecord } from "./import-runs-state.js";
+import {
+  readLegacyMemoryWikiImportRunRecords,
+  writeMemoryWikiImportRunRecord,
+} from "./import-runs-state.js";
 import { listMemoryWikiImportRuns } from "./import-runs.js";
 
 const tempDirs: string[] = [];
@@ -76,5 +79,34 @@ describe("memory-wiki import runs", () => {
       activeRuns: 1,
       rolledBackRuns: 1,
     });
+  });
+
+  it("skips malformed legacy import-run files instead of throwing", async () => {
+    const vaultRoot = await makeTempVault();
+    const dir = path.join(vaultRoot, ".openclaw-wiki", "import-runs");
+    await fs.mkdir(dir, { recursive: true });
+    await fs.writeFile(
+      path.join(dir, "valid.json"),
+      JSON.stringify({
+        version: 1,
+        runId: "valid-run",
+        importType: "chatgpt",
+        exportPath: "/tmp/old",
+        sourcePath: "/tmp/old/conversations.json",
+        appliedAt: "2026-04-09T10:00:00.000Z",
+        conversationCount: 1,
+        createdCount: 1,
+        updatedCount: 0,
+        skippedCount: 0,
+        createdPaths: ["sources/old.md"],
+        updatedPaths: [],
+      }),
+    );
+    // Partial write / editor save with a syntax error -> not valid JSON.
+    await fs.writeFile(path.join(dir, "broken.json"), "{ not valid json , ");
+
+    const records = await readLegacyMemoryWikiImportRunRecords(vaultRoot);
+    expect(records).toHaveLength(1);
+    expect(records[0]?.runId).toBe("valid-run");
   });
 });


### PR DESCRIPTION
## What Problem This Solves

`readLegacyMemoryWikiImportRunRecords` in `extensions/memory-wiki/src/import-runs-state.ts` parsed each `.openclaw-wiki/import-runs/*.json` file with an unguarded `JSON.parse` inside the bounded-concurrency legacy reader. A single partially-written or syntax-broken file (interrupted ChatGPT import, OOM kill, editor save with a syntax error) threw a raw `SyntaxError` that short-circuited the whole map, killing the Memory Wiki legacy migration during `openclaw doctor --fix` — with no mention of which file was corrupt.

A second gap surfaced during review: even after the reader was hardened to skip malformed files, a vault containing *only* malformed or schema-invalid import-run files produced no doctor plan at all — `detectLegacyState` returned `null`, so `migrateLegacyState` never ran and the bad files were silently left behind with no operator-visible warning. This is now fixed: `detectLegacyState` plans the migration whenever the import-runs directory contains `.json` files, so the doctor runs `migrateLegacyState` and emits an archive diagnostic per bad file.

## Why This Change Was Made

The modern SQLite-backed sibling `listMemoryWikiImportRunRecords` deserializes rows defensively and returns only the ones that parse. The legacy file-based path now matches for malformed or schema-invalid content: skip the bad file, keep the good ones. Filesystem read failures remain actionable and propagate instead of being mislabeled as bad content.

The detection fix closes the gap where a malformed-only or schema-invalid-only vault was invisible to the doctor. `migrateLegacyState` already called `archiveLegacyImportRunRecords` to emit a per-file warning when no valid records exist — it just was never reached because `detectLegacyState` returned `null`. Detection now counts the legacy import-run `.json` files even when none parse, and plans the migration so the archive diagnostics run.

## User Impact

A user upgrading from a pre-SQLite Memory Wiki install with one corrupted `import-runs/<id>.json` no longer has `openclaw doctor --fix` die with an opaque `SyntaxError`; the corrupted file is skipped and the rest of the import-run records still migrate. A vault containing *only* corrupted files now gets a clear per-file `Skipped legacy import-run file ... (malformed or schema-invalid) — not archived. Inspect or delete the file, then re-run \`openclaw doctor --fix\`.` warning instead of silent no-op. Well-formed files are unchanged.


## Rebase note

Rebased onto current `upstream/main` `661cf9644df5ca46582cc02122c86b110f159c3b`. The conflict was resolved by preserving main's current `pMap` reader with concurrency 16 and adding tolerant per-file parsing inside that architecture; the obsolete `Promise.all` implementation was not restored. The accumulated review commits were consolidated into one content-identical commit with `scripts/committer` to reduce review noise.

## Real behavior proof

- **Behavior addressed:** (1) A single malformed `.openclaw-wiki/import-runs/*.json` file threw a raw `SyntaxError`, killing the whole Memory Wiki legacy migration pass. (2) A malformed-only or schema-invalid-only vault produced no doctor plan, so the archive diagnostic was never emitted.
- **Real environment tested:** Linux x86_64, Node v26.5.0, commit `b7bcd3d75f2e02ac27a1954ca310c892bf194f2f` on branch `fix/memory-wiki-import-runs-jsonparse`, rebased onto `upstream/main` `661cf9644df5ca46582cc02122c86b110f159c3b`.
- **Exact steps or command run after this patch:** `node --import tsx verify-memory-wiki-doctor.mjs` — drives the REAL `stateMigrations[import-runs]` entry from `doctor-contract-api.ts` (`detectLegacyState` then `migrateLegacyState`) over four REAL temp vaults with real `.openclaw-wiki/import-runs/*.json` files and a real temp state DB. No mocks: real fs, real plugin migration code, real keyed-store context.
- **Evidence after fix:** Terminal capture of `node` runtime verification (live stdout, copied verbatim — real fs + real migration code + real temp state DB):

  ```text
  $ node --import tsx /tmp/verify-memory-wiki-doctor.mts
  valid-only: planned=true changes=2 warnings=0 remaining=valid.json.migrated result=PASS
  malformed-only: planned=true changes=0 warnings=1 remaining=broken.json result=PASS
  schema-invalid-only: planned=true changes=0 warnings=1 remaining=bad.json result=PASS
  mixed: planned=true changes=2 warnings=1 remaining=broken.json,valid.json.migrated result=PASS
  node=v26.5.0
  ```

- **Observed result after fix:** All four scenarios plan the migration and run it. valid-only imports + archives; malformed-only and schema-invalid-only now plan + run migrate and emit a per-file archive warning (previously silent); mixed imports the valid record + warns on the malformed one. The valid record is migrated and archived; bad files are left in place for the user.
- **What was not tested:** A live `openclaw doctor --fix` invocation on a production pre-SQLite machine. The proof drives the exact same `stateMigrations` entry the doctor loads, over real temp vaults + real state DB, so the migration code path is the production one.

## Tests and validation

```text
$ node scripts/run-vitest.mjs run extensions/memory-wiki/doctor-contract-api.test.ts extensions/memory-wiki/src/import-runs.test.ts
Test Files  2 passed (2)
Tests       11 passed (11)

$ ./node_modules/.bin/oxfmt --check <four changed files>
All matched files use the correct format.

$ node scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.extensions.json <four changed files>
Found 0 warnings and 0 errors.

$ node scripts/run-tsgo.mjs -p tsconfig.extensions.json --incremental --tsBuildInfoFile /tmp/openclaw-99422-extensions.tsbuildinfo
(exit 0)

$ node scripts/run-tsgo.mjs -p test/tsconfig/tsconfig.extensions.test.json --incremental --tsBuildInfoFile /tmp/openclaw-99422-extension-tests.tsbuildinfo
(exit 0)

$ node scripts/build-all.mjs
(exit 0)
```

The focused tests cover valid-only, malformed-only, schema-invalid-only, mixed, storage migration, warning, retention, archive behavior, and a simulated `EIO` read failure that must reject rather than silently omit a record. The Node runtime proof drives the real migration entry over real temporary files and plugin state.

## Risk checklist

- User-visible behavior: Yes (intended, bounded) - a corrupted legacy `import-runs/*.json` is now skipped with a per-file warning instead of killing `openclaw doctor --fix`; a malformed-only/schema-invalid-only vault now produces a doctor plan + per-file warnings instead of a silent no-op; well-formed files and the happy path unchanged.
- Config/env/migration behavior: No - no config or env surface touched; only the legacy-file read path and detection planning.
- Security/auth/secrets/network/tool execution: No - only error handling around an existing JSON.parse of local legacy files.
- Plugins/providers/channels/SDK: Yes (bounded) - internal to the memory-wiki plugin doctor migration; no public API change.
- Highest-risk area: planning a migration for a malformed-only vault surfaces a warning but performs no state write (0 valid records); the bad file is left in place for the user to repair/re-import. Filesystem read failures remain explicit rather than being treated as malformed content.
- Mitigation: 8 doctor-contract-api tests + 3 import-runs tests (including EIO propagation), Node v26.5.0 runtime verification over four real temp-vault scenarios, format/oxlint, prod/test tsgo, and full build.

## CI provenance

The previous exact-head CI failures were inspected from their job logs. Both `check-lint` failures are the same existing upstream `src/agents/model-fallback.test.ts:3764` `preserve-caught-error` violation, and both `check-dependencies` failures are the existing upstream dead export `extensions/browser/src/browser/routes/types.ts: BrowserRouteHandler`. Neither file is in this PR diff.

Closes: N/A (no existing issue)


---
Supersedes #98889 (force-pushed branch could not be reopened).


## Conflict-resolution refresh

GitHub mergeability was refreshed after rebasing the original branch onto `upstream/main` `21382b3755fafd7253339b2f3146b8667c5a7bde`. The only real conflict was in `extensions/memory-wiki/src/import-runs-state.ts`: current main now uses `pMapSkip` for rejected legacy records. The resolution preserves that current-main architecture while keeping the PR invariant that JSON/schema-invalid content is skipped, filesystem read failures propagate, valid records migrate/archive, and invalid-only vaults produce diagnostics.

Current exact head: `507a615dabb4546169c4961d09d50be0f20a025a`. GitHub API now reports `mergeable: true`; any `behind` indication is ordinary base drift after main advanced during validation, not a conflict.
