### PR TITLE
feat: add slash command picker in chat composer

### DIFF
--- a/apps/.i18n/native-source.json
+++ b/apps/.i18n/native-source.json
@@ -19507,7 +19507,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 666,
+      "line": 667,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatComposer.swift",
       "source": "Commands unavailable",
       "surface": "apple",
@@ -19515,7 +19515,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 672,
+      "line": 676,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatComposer.swift",
       "source": "Retry",
       "surface": "apple",
@@ -19523,7 +19523,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 681,
+      "line": 685,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatComposer.swift",
       "source": "No matching commands",
       "surface": "apple",
@@ -19531,7 +19531,7 @@
     },
     {
       "kind": "ui-modifier",
-      "line": 814,
+      "line": 822,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatComposer.swift",
       "source": "Stop response",
       "surface": "apple",
@@ -19539,7 +19539,7 @@
     },
     {
       "kind": "ui-modifier",
-      "line": 839,
+      "line": 847,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatComposer.swift",
       "source": "Send message",
       "surface": "apple",
@@ -19547,7 +19547,7 @@
     },
     {
       "kind": "ui-modifier",
-      "line": 854,
+      "line": 862,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatComposer.swift",
       "source": "Refresh",
       "surface": "apple",
@@ -19555,7 +19555,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 962,
+      "line": 970,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatComposer.swift",
       "source": "Connecting...",
       "surface": "apple",
@@ -19563,7 +19563,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 962,
+      "line": 970,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatComposer.swift",
       "source": "Gateway connected",
       "surface": "apple",

--- a/apps/.i18n/native-source.json
+++ b/apps/.i18n/native-source.json
@@ -19419,7 +19419,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 176,
+      "line": 193,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatComposer.swift",
       "source": "Thinking",
       "surface": "apple",
@@ -19427,7 +19427,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 195,
+      "line": 212,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatComposer.swift",
       "source": "Model",
       "surface": "apple",
@@ -19435,7 +19435,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 218,
+      "line": 235,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatComposer.swift",
       "source": "Session",
       "surface": "apple",
@@ -19443,7 +19443,7 @@
     },
     {
       "kind": "ui-modifier",
-      "line": 282,
+      "line": 299,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatComposer.swift",
       "source": "Add Image",
       "surface": "apple",
@@ -19451,7 +19451,7 @@
     },
     {
       "kind": "ui-modifier",
-      "line": 283,
+      "line": 300,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatComposer.swift",
       "source": "Attachments",
       "surface": "apple",
@@ -19459,7 +19459,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 428,
+      "line": 470,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatComposer.swift",
       "source": "Talk",
       "surface": "apple",
@@ -19467,7 +19467,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 474,
+      "line": 516,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatComposer.swift",
       "source": "Start realtime chat",
       "surface": "apple",
@@ -19475,7 +19475,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 474,
+      "line": 516,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatComposer.swift",
       "source": "Stop realtime chat",
       "surface": "apple",
@@ -19483,7 +19483,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 507,
+      "line": 549,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatComposer.swift",
       "source": "Start",
       "surface": "apple",
@@ -19491,7 +19491,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 507,
+      "line": 549,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatComposer.swift",
       "source": "Stop",
       "surface": "apple",
@@ -19499,7 +19499,47 @@
     },
     {
       "kind": "ui-modifier",
-      "line": 603,
+      "line": 673,
+      "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatComposer.swift",
+      "source": "Slash command category",
+      "surface": "apple",
+      "id": "native.apple.d2883f6f10cc0575"
+    },
+    {
+      "kind": "ui-call",
+      "line": 683,
+      "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatComposer.swift",
+      "source": "Loading commands",
+      "surface": "apple",
+      "id": "native.apple.9d4bdedcbf74d86c"
+    },
+    {
+      "kind": "ui-call",
+      "line": 691,
+      "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatComposer.swift",
+      "source": "Commands unavailable",
+      "surface": "apple",
+      "id": "native.apple.fdd34aa94629c962"
+    },
+    {
+      "kind": "ui-call",
+      "line": 697,
+      "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatComposer.swift",
+      "source": "Retry",
+      "surface": "apple",
+      "id": "native.apple.a1953e3e9be8b8d5"
+    },
+    {
+      "kind": "ui-call",
+      "line": 706,
+      "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatComposer.swift",
+      "source": "No matching commands",
+      "surface": "apple",
+      "id": "native.apple.0f942ca442f88936"
+    },
+    {
+      "kind": "ui-modifier",
+      "line": 834,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatComposer.swift",
       "source": "Stop response",
       "surface": "apple",
@@ -19507,7 +19547,7 @@
     },
     {
       "kind": "ui-modifier",
-      "line": 628,
+      "line": 859,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatComposer.swift",
       "source": "Send message",
       "surface": "apple",
@@ -19515,7 +19555,7 @@
     },
     {
       "kind": "ui-modifier",
-      "line": 643,
+      "line": 874,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatComposer.swift",
       "source": "Refresh",
       "surface": "apple",
@@ -19523,7 +19563,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 751,
+      "line": 982,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatComposer.swift",
       "source": "Connecting...",
       "surface": "apple",
@@ -19531,7 +19571,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 751,
+      "line": 982,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatComposer.swift",
       "source": "Gateway connected",
       "surface": "apple",

--- a/apps/.i18n/native-source.json
+++ b/apps/.i18n/native-source.json
@@ -19531,7 +19531,7 @@
     },
     {
       "kind": "ui-modifier",
-      "line": 822,
+      "line": 817,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatComposer.swift",
       "source": "Stop response",
       "surface": "apple",
@@ -19539,7 +19539,7 @@
     },
     {
       "kind": "ui-modifier",
-      "line": 847,
+      "line": 842,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatComposer.swift",
       "source": "Send message",
       "surface": "apple",
@@ -19547,7 +19547,7 @@
     },
     {
       "kind": "ui-modifier",
-      "line": 862,
+      "line": 857,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatComposer.swift",
       "source": "Refresh",
       "surface": "apple",
@@ -19555,7 +19555,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 970,
+      "line": 965,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatComposer.swift",
       "source": "Connecting...",
       "surface": "apple",
@@ -19563,7 +19563,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 970,
+      "line": 965,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatComposer.swift",
       "source": "Gateway connected",
       "surface": "apple",

--- a/apps/.i18n/native-source.json
+++ b/apps/.i18n/native-source.json
@@ -19419,7 +19419,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 193,
+      "line": 192,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatComposer.swift",
       "source": "Thinking",
       "surface": "apple",
@@ -19427,7 +19427,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 212,
+      "line": 211,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatComposer.swift",
       "source": "Model",
       "surface": "apple",
@@ -19435,7 +19435,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 235,
+      "line": 234,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatComposer.swift",
       "source": "Session",
       "surface": "apple",
@@ -19443,7 +19443,7 @@
     },
     {
       "kind": "ui-modifier",
-      "line": 299,
+      "line": 298,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatComposer.swift",
       "source": "Add Image",
       "surface": "apple",
@@ -19451,7 +19451,7 @@
     },
     {
       "kind": "ui-modifier",
-      "line": 300,
+      "line": 299,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatComposer.swift",
       "source": "Attachments",
       "surface": "apple",
@@ -19459,7 +19459,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 470,
+      "line": 469,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatComposer.swift",
       "source": "Talk",
       "surface": "apple",
@@ -19467,7 +19467,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 516,
+      "line": 515,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatComposer.swift",
       "source": "Start realtime chat",
       "surface": "apple",
@@ -19475,7 +19475,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 516,
+      "line": 515,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatComposer.swift",
       "source": "Stop realtime chat",
       "surface": "apple",
@@ -19483,7 +19483,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 549,
+      "line": 548,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatComposer.swift",
       "source": "Start",
       "surface": "apple",
@@ -19491,23 +19491,15 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 549,
+      "line": 548,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatComposer.swift",
       "source": "Stop",
       "surface": "apple",
       "id": "native.apple.72e5aa4446eaca9e"
     },
     {
-      "kind": "ui-modifier",
-      "line": 673,
-      "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatComposer.swift",
-      "source": "Slash command category",
-      "surface": "apple",
-      "id": "native.apple.d2883f6f10cc0575"
-    },
-    {
       "kind": "ui-call",
-      "line": 683,
+      "line": 658,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatComposer.swift",
       "source": "Loading commands",
       "surface": "apple",
@@ -19515,7 +19507,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 691,
+      "line": 666,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatComposer.swift",
       "source": "Commands unavailable",
       "surface": "apple",
@@ -19523,7 +19515,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 697,
+      "line": 672,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatComposer.swift",
       "source": "Retry",
       "surface": "apple",
@@ -19531,7 +19523,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 706,
+      "line": 681,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatComposer.swift",
       "source": "No matching commands",
       "surface": "apple",
@@ -19539,7 +19531,7 @@
     },
     {
       "kind": "ui-modifier",
-      "line": 834,
+      "line": 814,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatComposer.swift",
       "source": "Stop response",
       "surface": "apple",
@@ -19547,7 +19539,7 @@
     },
     {
       "kind": "ui-modifier",
-      "line": 859,
+      "line": 839,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatComposer.swift",
       "source": "Send message",
       "surface": "apple",
@@ -19555,7 +19547,7 @@
     },
     {
       "kind": "ui-modifier",
-      "line": 874,
+      "line": 854,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatComposer.swift",
       "source": "Refresh",
       "surface": "apple",
@@ -19563,7 +19555,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 982,
+      "line": 962,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatComposer.swift",
       "source": "Connecting...",
       "surface": "apple",
@@ -19571,7 +19563,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 982,
+      "line": 962,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatComposer.swift",
       "source": "Gateway connected",
       "surface": "apple",

--- a/apps/ios/Sources/Chat/IOSGatewayChatTransport.swift
+++ b/apps/ios/Sources/Chat/IOSGatewayChatTransport.swift
@@ -39,6 +39,12 @@ struct IOSGatewayChatTransport: OpenClawChatTransport {
         var idempotencyKey: String
     }
 
+    private struct CommandsListRequestParams: Codable {
+        var scope: String
+        var includeArgs: Bool
+        var agentId: String?
+    }
+
     private struct AgentWaitParams: Codable {
         var runId: String
         var timeoutMs: Int
@@ -92,6 +98,22 @@ struct IOSGatewayChatTransport: OpenClawChatTransport {
             timeoutMs: self.defaultChatSendTimeoutMs,
             idempotencyKey: idempotencyKey)
         return try self.encodeParams(params)
+    }
+
+    static func makeCommandsListParamsJSON(sessionKey: String? = nil) throws -> String {
+        try self.encodeParams(CommandsListRequestParams(
+            scope: "text",
+            includeArgs: true,
+            agentId: self.agentID(fromSessionKey: sessionKey)))
+    }
+
+    static func agentID(fromSessionKey sessionKey: String?) -> String? {
+        let parts = (sessionKey ?? "")
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .split(separator: ":", omittingEmptySubsequences: false)
+        guard parts.count >= 3, parts[0].lowercased() == "agent" else { return nil }
+        let agentID = String(parts[1]).trimmingCharacters(in: .whitespacesAndNewlines)
+        return agentID.isEmpty ? nil : agentID
     }
 
     static func decodeAgentWaitCompletion(_ data: Data, fallbackRunId: String) throws -> AgentWaitCompletion {
@@ -192,6 +214,17 @@ struct IOSGatewayChatTransport: OpenClawChatTransport {
         return try JSONDecoder().decode(OpenClawChatHistoryPayload.self, from: res)
     }
 
+    var supportsSlashCommandCatalog: Bool {
+        true
+    }
+
+    func listCommands(sessionKey: String) async throws -> [OpenClawChatCommandChoice] {
+        let json = try Self.makeCommandsListParamsJSON(sessionKey: sessionKey)
+        let res = try await self.gateway.request(method: "commands.list", paramsJSON: json, timeoutSeconds: 15)
+        let decoded = try JSONDecoder().decode(CommandsListResult.self, from: res)
+        return decoded.commands.map(Self.mapCommandChoice)
+    }
+
     func sendMessage(
         sessionKey: String,
         message: String,
@@ -222,6 +255,37 @@ struct IOSGatewayChatTransport: OpenClawChatTransport {
             GatewayDiagnostics.log("chat.send failed error=\(error.localizedDescription)")
             throw error
         }
+    }
+
+    private static func mapCommandChoice(_ entry: CommandEntry) -> OpenClawChatCommandChoice {
+        let sourceValue = (entry.source.value as? String)?
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .lowercased()
+        let source: OpenClawChatCommandChoice.Source = switch sourceValue {
+        case "native":
+            .command
+        case "skill":
+            .skill
+        case "plugin":
+            .plugin
+        default:
+            .unknown
+        }
+        let aliases = (entry.textaliases ?? [])
+            .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+            .filter { !$0.isEmpty }
+        let id = [
+            source.rawValue,
+            entry.name.trimmingCharacters(in: .whitespacesAndNewlines),
+            aliases.first ?? "",
+        ].joined(separator: ":")
+        return OpenClawChatCommandChoice(
+            id: id,
+            name: entry.name,
+            textAliases: aliases,
+            description: entry.description,
+            source: source,
+            acceptsArgs: entry.acceptsargs)
     }
 
     func waitForRunCompletion(runId rawRunId: String, timeoutMs: Int) async -> Bool {

--- a/apps/ios/Tests/IOSGatewayChatTransportTests.swift
+++ b/apps/ios/Tests/IOSGatewayChatTransportTests.swift
@@ -41,6 +41,21 @@ import Testing
         #expect(params["limit"] as? Int == 12)
     }
 
+    @Test func commandsListParamsRequestTextScopeWithArgs() throws {
+        let params = try self.object(from: IOSGatewayChatTransport.makeCommandsListParamsJSON())
+        #expect(params["scope"] as? String == "text")
+        #expect(params["includeArgs"] as? Bool == true)
+        #expect(params["agentId"] == nil)
+    }
+
+    @Test func commandsListParamsIncludeAgentForAgentScopedSession() throws {
+        let params = try self.object(
+            from: IOSGatewayChatTransport.makeCommandsListParamsJSON(sessionKey: "agent:reviewer:ios-main"))
+        #expect(params["scope"] as? String == "text")
+        #expect(params["includeArgs"] as? Bool == true)
+        #expect(params["agentId"] as? String == "reviewer")
+    }
+
     @Test func chatSendParamsOmitEmptyAttachmentsAndKeepSessionFields() throws {
         let params = try self.object(
             from: IOSGatewayChatTransport.makeChatSendParamsJSON(

--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatComposer.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatComposer.swift
@@ -64,6 +64,15 @@ private struct CleanChatComposerSurface: ViewModifier {
     }
 }
 
+#if !os(macOS)
+private struct SlashPanelHeightKey: PreferenceKey {
+    static let defaultValue: CGFloat = 0
+    static func reduce(value: inout CGFloat, nextValue: () -> CGFloat) {
+        value = max(value, nextValue())
+    }
+}
+#endif
+
 @MainActor
 struct OpenClawChatComposer: View {
     @Bindable var viewModel: OpenClawChatViewModel
@@ -80,6 +89,10 @@ struct OpenClawChatComposer: View {
 
     #if !os(macOS)
     @State private var pickerItems: [PhotosPickerItem] = []
+    @State private var slashPickerFilter: OpenClawChatCommandFilter = .all
+    @State private var isSlashPopoverPresented = false
+    @State private var suppressNextSlashPopoverUpdate = false
+    @State private var slashPanelHeight: CGFloat = 0
     @FocusState private var isFocused: Bool
     #else
     @State private var shouldFocusTextView = false
@@ -143,7 +156,11 @@ struct OpenClawChatComposer: View {
         .onChange(of: self.isComposerEnabled) { _, isEnabled in
                 if !isEnabled {
                     self.isFocused = false
+                    self.setSlashPanelPresented(false)
                 }
+            }
+            .onAppear {
+                self.viewModel.loadSlashCommandsIfNeeded()
             }
         #endif
     }
@@ -339,6 +356,31 @@ struct OpenClawChatComposer: View {
 
     @ViewBuilder
     private var editor: some View {
+        #if os(macOS)
+        self.editorContent
+        #else
+        self.editorContent
+            .overlay(alignment: .top) {
+                if self.isSlashPopoverPresented {
+                    self.slashCommandPanel
+                        .background(
+                            GeometryReader { geo in
+                                Color.clear.preference(
+                                    key: SlashPanelHeightKey.self,
+                                    value: geo.size.height)
+                            })
+                        .offset(y: -(self.slashPanelHeight + 8))
+                        .transition(.opacity)
+                }
+            }
+            .onPreferenceChange(SlashPanelHeightKey.self) { newHeight in
+                self.slashPanelHeight = newHeight
+            }
+        #endif
+    }
+
+    @ViewBuilder
+    private var editorContent: some View {
         if self.composerChrome == .clean {
             self.cleanEditor
         } else {
@@ -575,9 +617,198 @@ struct OpenClawChatComposer: View {
                 .focused(self.$isFocused)
                 .disabled(!self.isComposerEnabled)
                 .accessibilityIdentifier("chat-message-input")
+                .onChange(of: self.viewModel.input) { _, _ in
+                    self.updateSlashPopoverPresentation()
+                }
+                .onChange(of: self.isFocused) { _, focused in
+                    if focused {
+                        self.updateSlashPopoverPresentation()
+                    } else {
+                        self.setSlashPanelPresented(false)
+                    }
+                }
             #endif
         }
     }
+
+    #if !os(macOS)
+    private var slashQuery: String? {
+        let text = self.viewModel.input.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard text.hasPrefix("/"), !text.hasPrefix("//") else { return nil }
+        let body = String(text.dropFirst())
+        guard !body.isEmpty else { return "" }
+        let lower = body.lowercased()
+        if lower == "skill" || lower.hasPrefix("skill ") {
+            return body
+        }
+        if body.contains(where: \.isWhitespace) {
+            return nil
+        }
+        return body
+    }
+
+    private var slashCommandPanel: some View {
+        let query = self.slashQuery ?? ""
+        let matches = self.viewModel.slashCommandMatches(
+            query: query,
+            filter: self.slashPickerFilter)
+        return VStack(alignment: .leading, spacing: 0) {
+            HStack(spacing: 10) {
+                Text(self.slashPickerFilter.rawValue)
+                    .font(.headline)
+                    .lineLimit(1)
+
+                Spacer(minLength: 8)
+
+                Menu {
+                    ForEach(OpenClawChatCommandFilter.allCases, id: \.self) { filter in
+                        Button(filter.rawValue) {
+                            self.slashPickerFilter = filter
+                        }
+                    }
+                } label: {
+                    Image(systemName: "line.3.horizontal.decrease.circle")
+                        .font(.system(size: 18, weight: .semibold))
+                }
+                .accessibilityLabel("Slash command category")
+            }
+            .padding(.horizontal, 14)
+            .padding(.vertical, 12)
+
+            Divider()
+
+            if self.viewModel.isLoadingSlashCommands, self.viewModel.slashCommands.isEmpty {
+                HStack(spacing: 10) {
+                    ProgressView()
+                    Text("Loading commands")
+                        .foregroundStyle(.secondary)
+                }
+                .frame(maxWidth: .infinity, minHeight: 96)
+            } else if let error = self.viewModel.slashCommandsErrorText,
+                      self.viewModel.slashCommands.isEmpty
+            {
+                VStack(alignment: .leading, spacing: 10) {
+                    Text("Commands unavailable")
+                        .font(.subheadline.weight(.semibold))
+                    Text(error)
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                        .lineLimit(3)
+                    Button("Retry") {
+                        self.viewModel.refreshSlashCommands()
+                    }
+                    .buttonStyle(.bordered)
+                    .controlSize(.small)
+                }
+                .padding(14)
+                .frame(maxWidth: .infinity, alignment: .leading)
+            } else if matches.isEmpty {
+                Text("No matching commands")
+                    .foregroundStyle(.secondary)
+                    .frame(maxWidth: .infinity, minHeight: 96)
+            } else {
+                ScrollView {
+                    LazyVStack(alignment: .leading, spacing: 2) {
+                        ForEach(matches) { command in
+                            Button {
+                                self.selectSlashCommand(command)
+                            } label: {
+                                self.slashCommandRow(command)
+                            }
+                            .buttonStyle(.plain)
+                            .accessibilityLabel(command.displayInvocation)
+                        }
+                    }
+                    .padding(8)
+                }
+                .frame(maxHeight: .infinity)
+            }
+        }
+        .frame(height: 340)
+        .background(
+            .regularMaterial,
+            in: RoundedRectangle(cornerRadius: 16, style: .continuous))
+        .overlay(
+            RoundedRectangle(cornerRadius: 16, style: .continuous)
+                .strokeBorder(Color.secondary.opacity(0.15), lineWidth: 0.5))
+        .clipShape(RoundedRectangle(cornerRadius: 16, style: .continuous))
+        .shadow(color: .black.opacity(0.12), radius: 12, y: 4)
+    }
+
+    private func slashCommandRow(_ command: OpenClawChatCommandChoice) -> some View {
+        HStack(alignment: .top, spacing: 10) {
+            Image(systemName: command.source == .skill ? "sparkle.magnifyingglass" : "terminal")
+                .font(.system(size: 15, weight: .semibold))
+                .foregroundStyle(.secondary)
+                .frame(width: 22, height: 22)
+
+            VStack(alignment: .leading, spacing: 3) {
+                HStack(spacing: 6) {
+                    Text(command.displayInvocation)
+                        .font(.system(.subheadline, design: .monospaced).weight(.semibold))
+                        .lineLimit(1)
+                    Text(self.slashCommandSourceLabel(command.source))
+                        .font(.caption2.weight(.semibold))
+                        .foregroundStyle(.secondary)
+                        .padding(.horizontal, 6)
+                        .padding(.vertical, 2)
+                        .background(
+                            Capsule()
+                                .fill(Color.secondary.opacity(0.12)))
+                }
+                if !command.description.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+                    Text(command.description)
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                        .lineLimit(2)
+                }
+            }
+
+            Spacer(minLength: 0)
+        }
+        .padding(.horizontal, 8)
+        .padding(.vertical, 8)
+        .contentShape(Rectangle())
+    }
+
+    private func slashCommandSourceLabel(_ source: OpenClawChatCommandChoice.Source) -> String {
+        switch source {
+        case .skill:
+            "Skill"
+        case .plugin:
+            "Command"
+        case .command, .unknown:
+            "Command"
+        }
+    }
+
+    private func selectSlashCommand(_ command: OpenClawChatCommandChoice) {
+        self.suppressNextSlashPopoverUpdate = true
+        self.viewModel.applySlashCommandSelection(command)
+        self.setSlashPanelPresented(false)
+        self.isFocused = true
+    }
+
+    private func setSlashPanelPresented(_ presented: Bool) {
+        withAnimation(.easeInOut(duration: 0.18)) {
+            self.isSlashPopoverPresented = presented
+        }
+    }
+
+    private func updateSlashPopoverPresentation() {
+        if self.suppressNextSlashPopoverUpdate {
+            self.suppressNextSlashPopoverUpdate = false
+            return
+        }
+        let shouldShow = self.isComposerEnabled && self.isFocused && self.slashQuery != nil
+        if shouldShow {
+            self.viewModel.loadSlashCommandsIfNeeded()
+        }
+        if shouldShow != self.isSlashPopoverPresented {
+            self.setSlashPanelPresented(shouldShow)
+        }
+    }
+    #endif
 
     private var sendButton: some View {
         Group {

--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatComposer.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatComposer.swift
@@ -743,13 +743,13 @@ struct OpenClawChatComposer: View {
 
     private var slashCommandScrollAffordance: some View {
         VStack(spacing: 0) {
-            LinearGradient(
-                colors: [
-                    .clear,
-                    OpenClawChatTheme.composerBackground.opacity(0.94),
-                ],
-                startPoint: .top,
-                endPoint: .bottom)
+            Rectangle()
+                .fill(.regularMaterial)
+                .mask(
+                    LinearGradient(
+                        colors: [.clear, .black],
+                        startPoint: .top,
+                        endPoint: .bottom))
                 .frame(height: 34)
 
             Image(systemName: "chevron.compact.down")
@@ -757,7 +757,7 @@ struct OpenClawChatComposer: View {
                 .foregroundStyle(.secondary)
                 .frame(maxWidth: .infinity)
                 .padding(.bottom, 6)
-                .background(OpenClawChatTheme.composerBackground.opacity(0.94))
+                .background(.regularMaterial)
         }
         .allowsHitTesting(false)
     }

--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatComposer.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatComposer.swift
@@ -89,7 +89,6 @@ struct OpenClawChatComposer: View {
 
     #if !os(macOS)
     @State private var pickerItems: [PhotosPickerItem] = []
-    @State private var slashPickerFilter: OpenClawChatCommandFilter = .all
     @State private var isSlashPopoverPresented = false
     @State private var suppressNextSlashPopoverUpdate = false
     @State private var slashPanelHeight: CGFloat = 0
@@ -651,32 +650,8 @@ struct OpenClawChatComposer: View {
         let query = self.slashQuery ?? ""
         let matches = self.viewModel.slashCommandMatches(
             query: query,
-            filter: self.slashPickerFilter)
+            filter: .all)
         return VStack(alignment: .leading, spacing: 0) {
-            HStack(spacing: 10) {
-                Text(self.slashPickerFilter.rawValue)
-                    .font(.headline)
-                    .lineLimit(1)
-
-                Spacer(minLength: 8)
-
-                Menu {
-                    ForEach(OpenClawChatCommandFilter.allCases, id: \.self) { filter in
-                        Button(filter.rawValue) {
-                            self.slashPickerFilter = filter
-                        }
-                    }
-                } label: {
-                    Image(systemName: "line.3.horizontal.decrease.circle")
-                        .font(.system(size: 18, weight: .semibold))
-                }
-                .accessibilityLabel("Slash command category")
-            }
-            .padding(.horizontal, 14)
-            .padding(.vertical, 12)
-
-            Divider()
-
             if self.viewModel.isLoadingSlashCommands, self.viewModel.slashCommands.isEmpty {
                 HStack(spacing: 10) {
                     ProgressView()
@@ -722,6 +697,11 @@ struct OpenClawChatComposer: View {
                     .padding(8)
                 }
                 .frame(maxHeight: .infinity)
+                .overlay(alignment: .bottom) {
+                    if matches.count > 4 {
+                        self.slashCommandScrollAffordance
+                    }
+                }
             }
         }
         .frame(height: 340)
@@ -743,19 +723,9 @@ struct OpenClawChatComposer: View {
                 .frame(width: 22, height: 22)
 
             VStack(alignment: .leading, spacing: 3) {
-                HStack(spacing: 6) {
-                    Text(command.displayInvocation)
-                        .font(.system(.subheadline, design: .monospaced).weight(.semibold))
-                        .lineLimit(1)
-                    Text(self.slashCommandSourceLabel(command.source))
-                        .font(.caption2.weight(.semibold))
-                        .foregroundStyle(.secondary)
-                        .padding(.horizontal, 6)
-                        .padding(.vertical, 2)
-                        .background(
-                            Capsule()
-                                .fill(Color.secondary.opacity(0.12)))
-                }
+                Text(command.displayInvocation)
+                    .font(.system(.subheadline, design: .monospaced).weight(.semibold))
+                    .lineLimit(1)
                 if !command.description.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
                     Text(command.description)
                         .font(.caption)
@@ -771,15 +741,25 @@ struct OpenClawChatComposer: View {
         .contentShape(Rectangle())
     }
 
-    private func slashCommandSourceLabel(_ source: OpenClawChatCommandChoice.Source) -> String {
-        switch source {
-        case .skill:
-            "Skill"
-        case .plugin:
-            "Command"
-        case .command, .unknown:
-            "Command"
+    private var slashCommandScrollAffordance: some View {
+        VStack(spacing: 0) {
+            LinearGradient(
+                colors: [
+                    .clear,
+                    OpenClawChatTheme.composerBackground.opacity(0.94),
+                ],
+                startPoint: .top,
+                endPoint: .bottom)
+                .frame(height: 34)
+
+            Image(systemName: "chevron.compact.down")
+                .font(.system(size: 16, weight: .semibold))
+                .foregroundStyle(.secondary)
+                .frame(maxWidth: .infinity)
+                .padding(.bottom, 6)
+                .background(OpenClawChatTheme.composerBackground.opacity(0.94))
         }
+        .allowsHitTesting(false)
     }
 
     private func selectSlashCommand(_ command: OpenClawChatCommandChoice) {

--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatComposer.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatComposer.swift
@@ -656,6 +656,7 @@ struct OpenClawChatComposer: View {
                 HStack(spacing: 10) {
                     ProgressView()
                     Text("Loading commands")
+                        .font(OpenClawChatTypography.caption)
                         .foregroundStyle(.secondary)
                 }
                 .frame(maxWidth: .infinity, minHeight: 96)
@@ -664,13 +665,16 @@ struct OpenClawChatComposer: View {
             {
                 VStack(alignment: .leading, spacing: 10) {
                     Text("Commands unavailable")
-                        .font(.subheadline.weight(.semibold))
+                        .font(OpenClawChatTypography.footnoteSemiBold)
                     Text(error)
-                        .font(.caption)
+                        .font(OpenClawChatTypography.caption)
                         .foregroundStyle(.secondary)
                         .lineLimit(3)
-                    Button("Retry") {
+                    Button {
                         self.viewModel.refreshSlashCommands()
+                    } label: {
+                        Text("Retry")
+                            .font(OpenClawChatTypography.captionSemiBold)
                     }
                     .buttonStyle(.bordered)
                     .controlSize(.small)
@@ -679,6 +683,7 @@ struct OpenClawChatComposer: View {
                 .frame(maxWidth: .infinity, alignment: .leading)
             } else if matches.isEmpty {
                 Text("No matching commands")
+                    .font(OpenClawChatTypography.caption)
                     .foregroundStyle(.secondary)
                     .frame(maxWidth: .infinity, minHeight: 96)
             } else {
@@ -724,11 +729,14 @@ struct OpenClawChatComposer: View {
 
             VStack(alignment: .leading, spacing: 3) {
                 Text(command.displayInvocation)
-                    .font(.system(.subheadline, design: .monospaced).weight(.semibold))
+                    .font(OpenClawChatTypography.mono(
+                        size: 15,
+                        weight: .semibold,
+                        relativeTo: .subheadline))
                     .lineLimit(1)
                 if !command.description.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
                     Text(command.description)
-                        .font(.caption)
+                        .font(OpenClawChatTypography.caption)
                         .foregroundStyle(.secondary)
                         .lineLimit(2)
                 }

--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatComposer.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatComposer.swift
@@ -721,12 +721,7 @@ struct OpenClawChatComposer: View {
     }
 
     private func slashCommandRow(_ command: OpenClawChatCommandChoice) -> some View {
-        HStack(alignment: .top, spacing: 10) {
-            Image(systemName: command.source == .skill ? "sparkle.magnifyingglass" : "terminal")
-                .font(.system(size: 15, weight: .semibold))
-                .foregroundStyle(.secondary)
-                .frame(width: 22, height: 22)
-
+        HStack(alignment: .top, spacing: 0) {
             VStack(alignment: .leading, spacing: 3) {
                 Text(command.displayInvocation)
                     .font(OpenClawChatTypography.mono(

--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatModels.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatModels.swift
@@ -13,6 +13,53 @@ import UIKit
 public typealias OpenClawPlatformImage = UIImage
 #endif
 
+public enum OpenClawChatCommandFilter: String, CaseIterable, Sendable {
+    case all = "All"
+    case commands = "Commands"
+    case skills = "Skills"
+}
+
+public struct OpenClawChatCommandChoice: Identifiable, Hashable, Sendable {
+    public enum Source: String, Sendable {
+        case command
+        case skill
+        case plugin
+        case unknown
+    }
+
+    public let id: String
+    public let name: String
+    public let textAliases: [String]
+    public let description: String
+    public let source: Source
+    public let acceptsArgs: Bool
+
+    public init(
+        id: String,
+        name: String,
+        textAliases: [String],
+        description: String,
+        source: Source,
+        acceptsArgs: Bool)
+    {
+        self.id = id
+        self.name = name
+        self.textAliases = textAliases
+        self.description = description
+        self.source = source
+        self.acceptsArgs = acceptsArgs
+    }
+
+    public var preferredInvocation: String {
+        self.textAliases.first { $0.trimmingCharacters(in: .whitespacesAndNewlines).hasPrefix("/") }
+            ?? "/\(self.name)"
+    }
+
+    public var displayInvocation: String {
+        self.preferredInvocation.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+}
+
 public struct OpenClawChatUsageCost: Codable, Hashable, Sendable {
     public let input: Double?
     public let output: Double?

--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatTransport.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatTransport.swift
@@ -17,6 +17,8 @@ public protocol OpenClawChatTransport: Sendable {
 
     func requestHistory(sessionKey: String) async throws -> OpenClawChatHistoryPayload
     func listModels() async throws -> [OpenClawChatModelChoice]
+    var supportsSlashCommandCatalog: Bool { get }
+    func listCommands(sessionKey: String) async throws -> [OpenClawChatCommandChoice]
     func sendMessage(
         sessionKey: String,
         message: String,
@@ -89,6 +91,14 @@ extension OpenClawChatTransport {
             domain: "OpenClawChatTransport",
             code: 0,
             userInfo: [NSLocalizedDescriptionKey: "models.list not supported by this transport"])
+    }
+
+    public var supportsSlashCommandCatalog: Bool {
+        false
+    }
+
+    public func listCommands(sessionKey _: String) async throws -> [OpenClawChatCommandChoice] {
+        []
     }
 
     public func setSessionModel(sessionKey _: String, model _: String?) async throws {

--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatViewModel.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatViewModel.swift
@@ -19,6 +19,19 @@ public final class OpenClawChatViewModel {
     public private(set) var thinkingLevelOptions: [OpenClawChatThinkingLevelOption]
     public private(set) var modelSelectionID: String = "__default__"
     public private(set) var modelChoices: [OpenClawChatModelChoice] = []
+    public private(set) var slashCommands: [OpenClawChatCommandChoice] = []
+    public private(set) var isLoadingSlashCommands = false
+    public private(set) var slashCommandsErrorText: String?
+    public private(set) var hasLoadedSlashCommands = false
+    @ObservationIgnored
+    private var slashFilterCache: SlashFilterCache?
+
+    private struct SlashFilterCache {
+        let query: String
+        let filter: OpenClawChatCommandFilter
+        let result: [OpenClawChatCommandChoice]
+    }
+
     public private(set) var isLoading = false
     public private(set) var isSending = false
     public private(set) var isAborting = false
@@ -232,6 +245,36 @@ public final class OpenClawChatViewModel {
 
     public func selectModel(_ selectionID: String) {
         Task { await self.performSelectModel(selectionID) }
+    }
+
+    public func loadSlashCommandsIfNeeded() {
+        guard self.transport.supportsSlashCommandCatalog else { return }
+        guard !self.hasLoadedSlashCommands, !self.isLoadingSlashCommands else { return }
+        Task { await self.loadSlashCommands(force: false) }
+    }
+
+    public func refreshSlashCommands() {
+        guard self.transport.supportsSlashCommandCatalog else { return }
+        Task { await self.loadSlashCommands(force: true) }
+    }
+
+    public func slashCommandMatches(
+        query: String,
+        filter: OpenClawChatCommandFilter) -> [OpenClawChatCommandChoice]
+    {
+        if let cache = self.slashFilterCache, cache.query == query, cache.filter == filter {
+            return cache.result
+        }
+        let result = Self.filteredSlashCommands(self.slashCommands, query: query, filter: filter)
+        self.slashFilterCache = SlashFilterCache(query: query, filter: filter, result: result)
+        return result
+    }
+
+    public func applySlashCommandSelection(_ command: OpenClawChatCommandChoice) {
+        let invocation = command.preferredInvocation.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !invocation.isEmpty else { return }
+        self.input = command.acceptsArgs ? "\(invocation) " : invocation
+        self.errorText = nil
     }
 
     public var sessionChoices: [OpenClawChatSessionEntry] {
@@ -962,6 +1005,223 @@ public final class OpenClawChatViewModel {
     private static let resetTriggers: Set<String> = ["/reset", "/clear"]
     private static let compactTriggers: Set<String> = ["/compact"]
 
+    private func loadSlashCommands(force: Bool) async {
+        guard self.transport.supportsSlashCommandCatalog else { return }
+        guard force || !self.hasLoadedSlashCommands else { return }
+        guard !self.isLoadingSlashCommands else { return }
+        let sessionSnapshot = self.currentSessionSnapshot()
+        self.isLoadingSlashCommands = true
+        defer { self.isLoadingSlashCommands = false }
+
+        do {
+            let commands = try await self.transport.listCommands(sessionKey: sessionSnapshot.key)
+            guard self.isCurrentSession(sessionSnapshot) else { return }
+            self.slashCommands = commands
+            self.slashFilterCache = nil
+            self.slashCommandsErrorText = nil
+            self.hasLoadedSlashCommands = true
+        } catch {
+            guard self.isCurrentSession(sessionSnapshot) else { return }
+            self.slashCommandsErrorText = error.localizedDescription
+        }
+    }
+
+    private func waitForSlashCommandLoadIfNeeded() async {
+        guard self.transport.supportsSlashCommandCatalog else { return }
+        if !self.hasLoadedSlashCommands, !self.isLoadingSlashCommands {
+            await self.loadSlashCommands(force: false)
+            return
+        }
+        while self.isLoadingSlashCommands {
+            do {
+                try await Task.sleep(nanoseconds: 50_000_000)
+            } catch {
+                return
+            }
+        }
+    }
+
+    private func validateSlashCommandDraftForSend(trimmed: String) async -> Bool {
+        guard let slashName = Self.slashCommandName(from: trimmed) else {
+            return true
+        }
+        guard !slashName.isEmpty else {
+            self.errorText = "Choose a command."
+            return false
+        }
+
+        await self.waitForSlashCommandLoadIfNeeded()
+
+        if self.hasLoadedSlashCommands,
+           Self.isKnownSlashCommandText(trimmed, commands: self.slashCommands),
+           !self.attachments.isEmpty
+        {
+            self.errorText = "Commands cannot be sent with attachments."
+            return false
+        }
+        return true
+    }
+
+    private func resetSlashCommandCatalog() {
+        self.slashCommands = []
+        self.slashFilterCache = nil
+        self.slashCommandsErrorText = nil
+        self.hasLoadedSlashCommands = false
+    }
+
+    private static func slashCommandName(from text: String) -> String? {
+        let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard trimmed.hasPrefix("/"), !trimmed.hasPrefix("//") else { return nil }
+        let body = trimmed.dropFirst()
+        guard let rawName = body.split(whereSeparator: { $0.isWhitespace }).first else {
+            return ""
+        }
+        let name = rawName.split(separator: "@", maxSplits: 1, omittingEmptySubsequences: true).first ?? ""
+        return String(name).trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+    }
+
+    private static func isKnownSlashCommandText(
+        _ text: String,
+        commands: [OpenClawChatCommandChoice]) -> Bool
+    {
+        guard let commandName = self.slashCommandName(from: text), !commandName.isEmpty else {
+            return false
+        }
+        if self.commands(commands, containInvocationName: commandName) {
+            return true
+        }
+        guard commandName == "skill" else { return false }
+        let parts = text.trimmingCharacters(in: .whitespacesAndNewlines)
+            .split(whereSeparator: { $0.isWhitespace })
+        guard parts.count >= 2 else {
+            return self.commands(commands, containInvocationName: commandName)
+        }
+        let skillName = String(parts[1]).lowercased()
+        return commands.contains { command in
+            command.source == .skill && self.command(command, matchesInvocationName: skillName)
+        }
+    }
+
+    private static func commands(
+        _ commands: [OpenClawChatCommandChoice],
+        containInvocationName name: String) -> Bool
+    {
+        commands.contains { self.command($0, matchesInvocationName: name) }
+    }
+
+    private static func command(
+        _ command: OpenClawChatCommandChoice,
+        matchesInvocationName name: String) -> Bool
+    {
+        let normalizedName = name.lowercased()
+        if command.name.trimmingCharacters(in: .whitespacesAndNewlines).lowercased() == normalizedName {
+            return true
+        }
+        return command.textAliases.contains { alias in
+            self.slashCommandName(from: alias) == normalizedName
+        }
+    }
+
+    private static func filteredSlashCommands(
+        _ commands: [OpenClawChatCommandChoice],
+        query rawQuery: String,
+        filter: OpenClawChatCommandFilter) -> [OpenClawChatCommandChoice]
+    {
+        let trimmed = rawQuery.trimmingCharacters(in: .whitespacesAndNewlines)
+        let query = self.normalizedSlashQuery(trimmed)
+        let effectiveFilter: OpenClawChatCommandFilter =
+            self.queryTargetsSkills(trimmed) && filter == .all ? .skills : filter
+        return commands.enumerated()
+            .compactMap { index, command -> (Int, Int, OpenClawChatCommandChoice)? in
+                guard self.command(command, isIncludedIn: effectiveFilter) else { return nil }
+                guard let rank = self.commandSearchRank(command, query: query) else { return nil }
+                return (rank, index, command)
+            }
+            .sorted {
+                if $0.0 != $1.0 { return $0.0 < $1.0 }
+                return $0.1 < $1.1
+            }
+            .map(\.2)
+    }
+
+    private static func normalizedSlashQuery(_ query: String) -> String {
+        let withoutSlash = query.hasPrefix("/") ? String(query.dropFirst()) : query
+        let lower = withoutSlash.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        if lower == "skill" {
+            return ""
+        }
+        if lower.hasPrefix("skill ") {
+            return String(lower.dropFirst("skill ".count)).trimmingCharacters(in: .whitespacesAndNewlines)
+        }
+        return lower
+    }
+
+    private static func queryTargetsSkills(_ query: String) -> Bool {
+        let withoutSlash = query.hasPrefix("/") ? String(query.dropFirst()) : query
+        let lower = withoutSlash.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        return lower == "skill" || lower.hasPrefix("skill ")
+    }
+
+    private static func command(
+        _ command: OpenClawChatCommandChoice,
+        isIncludedIn filter: OpenClawChatCommandFilter) -> Bool
+    {
+        switch filter {
+        case .all:
+            true
+        case .commands:
+            command.source != .skill
+        case .skills:
+            command.source == .skill
+        }
+    }
+
+    private static func commandSearchRank(
+        _ command: OpenClawChatCommandChoice,
+        query: String) -> Int?
+    {
+        guard !query.isEmpty else { return 0 }
+        let names = ([command.name, command.preferredInvocation] + command.textAliases)
+            .map { candidate in
+                let trimmed = candidate.trimmingCharacters(in: .whitespacesAndNewlines)
+                let withoutSlash = trimmed.hasPrefix("/") ? String(trimmed.dropFirst()) : trimmed
+                return withoutSlash.lowercased()
+            }
+            .filter { !$0.isEmpty }
+        if names.contains(where: { $0.hasPrefix(query) }) {
+            return 0
+        }
+        if names.contains(where: { $0.contains(query) }) {
+            return 1
+        }
+        if command.description.lowercased().contains(query) {
+            return 2
+        }
+        if command.source.rawValue.lowercased().contains(query) {
+            return 3
+        }
+        return nil
+    }
+
+    private func handleLocalSlashCommandIfNeeded(_ command: String) async -> Bool {
+        if command == "/new" {
+            self.input = ""
+            await self.performStartNewSession()
+            return true
+        }
+        if Self.resetTriggers.contains(command) {
+            self.input = ""
+            await self.performReset()
+            return true
+        }
+        if Self.compactTriggers.contains(command) {
+            self.input = ""
+            await self.performCompact()
+            return true
+        }
+        return false
+    }
+
     private func performSend() async {
         guard !self.isSending else {
             self.logDiagnostic("chat.ui send ignored reason=sending sessionKey=\(self.sessionKey)")
@@ -980,19 +1240,10 @@ public final class OpenClawChatViewModel {
         }
 
         let command = trimmed.lowercased()
-        if command == "/new" {
-            self.input = ""
-            await self.performStartNewSession()
+        if await self.handleLocalSlashCommandIfNeeded(command) {
             return
         }
-        if Self.resetTriggers.contains(command) {
-            self.input = ""
-            await self.performReset()
-            return
-        }
-        if Self.compactTriggers.contains(command) {
-            self.input = ""
-            await self.performCompact()
+        guard await self.validateSlashCommandDraftForSend(trimmed: trimmed) else {
             return
         }
 
@@ -1186,6 +1437,7 @@ public final class OpenClawChatViewModel {
         self.sessionId = nil
         self.pendingToolCallsById = [:]
         self.updateStreamingAssistantText(nil)
+        self.resetSlashCommandCatalog()
         self.clearPendingRuns(reason: nil)
         self.startBootstrap(sessionKey: next)
     }
@@ -1222,6 +1474,7 @@ public final class OpenClawChatViewModel {
         self.sessionId = nil
         self.pendingToolCallsById = [:]
         self.updateStreamingAssistantText(nil)
+        self.resetSlashCommandCatalog()
         self.clearPendingRuns(reason: nil)
         self.errorText = nil
         self.startBootstrap()

--- a/apps/shared/OpenClawKit/Tests/OpenClawKitTests/ChatViewModelTests.swift
+++ b/apps/shared/OpenClawKit/Tests/OpenClawKitTests/ChatViewModelTests.swift
@@ -119,11 +119,28 @@ private func modelChoice(id: String, name: String, provider: String = "anthropic
     OpenClawChatModelChoice(modelID: id, name: name, provider: provider, contextWindow: nil)
 }
 
+private func commandChoice(
+    name: String,
+    aliases: [String],
+    description: String = "",
+    source: OpenClawChatCommandChoice.Source = .command,
+    acceptsArgs: Bool = false) -> OpenClawChatCommandChoice
+{
+    OpenClawChatCommandChoice(
+        id: "\(source.rawValue):\(name)",
+        name: name,
+        textAliases: aliases,
+        description: description,
+        source: source,
+        acceptsArgs: acceptsArgs)
+}
+
 private func makeViewModel(
     sessionKey: String = "main",
     historyResponses: [OpenClawChatHistoryPayload],
     sessionsResponses: [OpenClawChatSessionsListResponse] = [],
     modelResponses: [[OpenClawChatModelChoice]] = [],
+    commandResponses: [[OpenClawChatCommandChoice]] = [],
     requestHistoryHook: (@Sendable (String) async throws -> Void)? = nil,
     setActiveSessionHook: (@Sendable (String) async throws -> Void)? = nil,
     createSessionHook: (@Sendable (String, String?) async throws -> Void)? = nil,
@@ -143,6 +160,7 @@ private func makeViewModel(
         historyResponses: historyResponses,
         sessionsResponses: sessionsResponses,
         modelResponses: modelResponses,
+        commandResponses: commandResponses,
         requestHistoryHook: requestHistoryHook,
         setActiveSessionHook: setActiveSessionHook,
         createSessionHook: createSessionHook,
@@ -349,6 +367,7 @@ private actor TestChatTransportState {
     var historyCallCount: Int = 0
     var sessionsCallCount: Int = 0
     var modelsCallCount: Int = 0
+    var commandsCallCount: Int = 0
     var healthCallCount: Int = 0
     var activeSessionKeys: [String] = []
     var createdSessionKeys: [String] = []
@@ -356,7 +375,9 @@ private actor TestChatTransportState {
     var resetSessionKeys: [String] = []
     var compactSessionKeys: [String] = []
     var sentSessionKeys: [String] = []
+    var sentMessages: [String] = []
     var sentRunIds: [String] = []
+    var commandSessionKeys: [String] = []
     var sentThinkingLevels: [String] = []
     var abortedRunIds: [String] = []
     var waitCompletionRunIds: [String] = []
@@ -369,6 +390,7 @@ private final class TestChatTransport: @unchecked Sendable, OpenClawChatTranspor
     private let historyResponses: [OpenClawChatHistoryPayload]
     private let sessionsResponses: [OpenClawChatSessionsListResponse]
     private let modelResponses: [[OpenClawChatModelChoice]]
+    private let commandResponses: [[OpenClawChatCommandChoice]]
     private let requestHistoryHook: (@Sendable (String) async throws -> Void)?
     private let setActiveSessionHook: (@Sendable (String) async throws -> Void)?
     private let createSessionHook: (@Sendable (String, String?) async throws -> Void)?
@@ -387,6 +409,7 @@ private final class TestChatTransport: @unchecked Sendable, OpenClawChatTranspor
         historyResponses: [OpenClawChatHistoryPayload],
         sessionsResponses: [OpenClawChatSessionsListResponse] = [],
         modelResponses: [[OpenClawChatModelChoice]] = [],
+        commandResponses: [[OpenClawChatCommandChoice]] = [],
         requestHistoryHook: (@Sendable (String) async throws -> Void)? = nil,
         setActiveSessionHook: (@Sendable (String) async throws -> Void)? = nil,
         createSessionHook: (@Sendable (String, String?) async throws -> Void)? = nil,
@@ -401,6 +424,7 @@ private final class TestChatTransport: @unchecked Sendable, OpenClawChatTranspor
         self.historyResponses = historyResponses
         self.sessionsResponses = sessionsResponses
         self.modelResponses = modelResponses
+        self.commandResponses = commandResponses
         self.requestHistoryHook = requestHistoryHook
         self.setActiveSessionHook = setActiveSessionHook
         self.createSessionHook = createSessionHook
@@ -459,12 +483,13 @@ private final class TestChatTransport: @unchecked Sendable, OpenClawChatTranspor
 
     func sendMessage(
         sessionKey: String,
-        message _: String,
+        message: String,
         thinking: String,
         idempotencyKey: String,
         attachments _: [OpenClawChatAttachmentPayload]) async throws -> OpenClawChatSendResponse
     {
         await self.state.sentSessionKeysAppend(sessionKey)
+        await self.state.sentMessagesAppend(message)
         await self.state.sentRunIdsAppend(idempotencyKey)
         await self.state.sentThinkingLevelsAppend(thinking)
         if let sendMessageHook {
@@ -496,6 +521,19 @@ private final class TestChatTransport: @unchecked Sendable, OpenClawChatTranspor
             return self.modelResponses[idx]
         }
         return self.modelResponses.last ?? []
+    }
+
+    var supportsSlashCommandCatalog: Bool {
+        !self.commandResponses.isEmpty
+    }
+
+    func listCommands(sessionKey: String) async throws -> [OpenClawChatCommandChoice] {
+        await self.state.commandSessionKeysAppend(sessionKey)
+        let idx = await self.state.nextCommandsCallIndex()
+        if idx < self.commandResponses.count {
+            return self.commandResponses[idx]
+        }
+        return self.commandResponses.last ?? []
     }
 
     func setSessionModel(sessionKey _: String, model: String?) async throws {
@@ -550,6 +588,14 @@ private final class TestChatTransport: @unchecked Sendable, OpenClawChatTranspor
 
     func sentRunIds() async -> [String] {
         await self.state.sentRunIds
+    }
+
+    func sentMessages() async -> [String] {
+        await self.state.sentMessages
+    }
+
+    func commandSessionKeys() async -> [String] {
+        await self.state.commandSessionKeys
     }
 
     func lastSentSessionKey() async -> String? {
@@ -614,6 +660,11 @@ extension TestChatTransportState {
         return self.modelsCallCount
     }
 
+    fileprivate func nextCommandsCallIndex() -> Int {
+        defer { self.commandsCallCount += 1 }
+        return self.commandsCallCount
+    }
+
     fileprivate func nextHealthCallIndex() -> Int {
         defer { self.healthCallCount += 1 }
         return self.healthCallCount
@@ -625,6 +676,10 @@ extension TestChatTransportState {
 
     fileprivate func sentRunIdsAppend(_ v: String) {
         self.sentRunIds.append(v)
+    }
+
+    fileprivate func commandSessionKeysAppend(_ v: String) {
+        self.commandSessionKeys.append(v)
     }
 
     fileprivate func abortedRunIdsAppend(_ v: String) {
@@ -665,6 +720,10 @@ extension TestChatTransportState {
 
     fileprivate func sentSessionKeysAppend(_ v: String) {
         self.sentSessionKeys.append(v)
+    }
+
+    fileprivate func sentMessagesAppend(_ v: String) {
+        self.sentMessages.append(v)
     }
 }
 
@@ -2285,6 +2344,117 @@ struct ChatViewModelTests {
             await transport.compactSessionKeys() == ["main", "main"]
         }
         #expect(await MainActor.run { vm.errorText } == nil)
+    }
+
+    @Test func `slash command catalog filters commands and skills`() async throws {
+        let commands = [
+            commandChoice(
+                name: "compact",
+                aliases: ["/compact"],
+                description: "Compact the session",
+                source: .command),
+            commandChoice(
+                name: "review",
+                aliases: ["/review"],
+                description: "Review the current change",
+                source: .skill,
+                acceptsArgs: true),
+        ]
+        let (_, vm) = await makeViewModel(
+            historyResponses: [historyPayload()],
+            commandResponses: [commands])
+
+        await MainActor.run { vm.loadSlashCommandsIfNeeded() }
+        try await waitUntil("slash commands loaded") {
+            await MainActor.run { vm.hasLoadedSlashCommands }
+        }
+
+        let allMatches = await MainActor.run {
+            vm.slashCommandMatches(query: "/", filter: .all).map(\.name)
+        }
+        #expect(allMatches == ["compact", "review"])
+
+        let commandMatches = await MainActor.run {
+            vm.slashCommandMatches(query: "/co", filter: .commands).map(\.name)
+        }
+        #expect(commandMatches == ["compact"])
+
+        let skillMatches = await MainActor.run {
+            vm.slashCommandMatches(query: "/skill re", filter: .all).map(\.name)
+        }
+        #expect(skillMatches == ["review"])
+
+        await MainActor.run {
+            vm.applySlashCommandSelection(commands[1])
+        }
+        #expect(await MainActor.run { vm.input } == "/review ")
+    }
+
+    @Test func `known slash command sends through chat send`() async throws {
+        let commands = [
+            commandChoice(
+                name: "model",
+                aliases: ["/model"],
+                description: "Change model",
+                source: .command,
+                acceptsArgs: true),
+        ]
+        let (transport, vm) = await makeViewModel(
+            historyResponses: [historyPayload(), historyPayload()],
+            commandResponses: [commands])
+        try await loadAndWaitBootstrap(vm: vm)
+
+        await sendUserMessage(vm, text: "/model gpt-5")
+        _ = try await waitForLastSentRunId(transport)
+
+        #expect(await transport.sentMessages() == ["/model gpt-5"])
+    }
+
+    @Test func `slash command catalog loads for current session`() async throws {
+        let commands = [
+            commandChoice(name: "model", aliases: ["/model"], source: .command, acceptsArgs: true),
+        ]
+        let (transport, vm) = await makeViewModel(
+            sessionKey: "agent:reviewer:main",
+            historyResponses: [historyPayload()],
+            commandResponses: [commands])
+
+        await MainActor.run { vm.loadSlashCommandsIfNeeded() }
+        try await waitUntil("slash commands loaded") {
+            await MainActor.run { vm.hasLoadedSlashCommands }
+        }
+
+        #expect(await transport.commandSessionKeys() == ["agent:reviewer:main"])
+    }
+
+    @Test func `unknown leading slash is sent to gateway after command catalog loads`() async throws {
+        let commands = [
+            commandChoice(name: "model", aliases: ["/model"], source: .command, acceptsArgs: true),
+        ]
+        let (transport, vm) = await makeViewModel(
+            historyResponses: [historyPayload(), historyPayload()],
+            commandResponses: [commands])
+        try await loadAndWaitBootstrap(vm: vm)
+
+        await sendUserMessage(vm, text: "/does-not-exist")
+        _ = try await waitForLastSentRunId(transport)
+
+        #expect(await transport.sentMessages() == ["/does-not-exist"])
+    }
+
+    @Test func `double slash sends as ordinary text`() async throws {
+        let commands = [
+            commandChoice(name: "model", aliases: ["/model"], source: .command, acceptsArgs: true),
+        ]
+        let (transport, vm) = await makeViewModel(
+            historyResponses: [historyPayload(), historyPayload()],
+            commandResponses: [commands])
+        try await loadAndWaitBootstrap(vm: vm)
+
+        await sendUserMessage(vm, text: "//does-not-trigger")
+        _ = try await waitForLastSentRunId(transport)
+
+        #expect(await transport.sentMessages() == ["//does-not-trigger"])
     }
 
     @Test func `bootstraps model selection from session and defaults`() async throws {


### PR DESCRIPTION
## What Problem This Solves

OpenClaw has many slash commands, but the iOS chat composer did not provide an in-context way to discover, filter, and select them. Users had to know command names ahead of time, and the composer did not have enough local slash-command awareness to present the Gateway command catalog cleanly.

This PR adds a slash command picker that opens when the user types `/`, shows a unified command/skill list, filters results as the user types, and inserts the selected command into the composer. It also wires the iOS Gateway command catalog transport through the active agent/session context so the picker reflects the correct command surface.

## Why This Change Was Made

The composer is the right place for command discovery because it keeps the user in message context while they choose a command. The current UI intentionally preserves monospace command names for scanability, but routes the text through `OpenClawChatTypography.mono(...)` so it follows the iOS branded typography policy.

## User Impact

Users can type `/` in chat and pick a command without memorizing command names. The picker now avoids category tabs/badges, keeps command rows compact, and includes a bottom scroll affordance when more commands are available.

## Evidence

Current iOS simulator proof from head `437a7ba6b67c9a503d3625f753e50b355dbf7a60`:

![Current iOS slash command picker](https://files.catbox.moe/z575fm.jpg)

Local verification:

- Fresh XcodeBuildMCP simulator build/install/launch passed on iPhone 17 for bundle `ai.openclawfoundation.app.test.solvely-2ql5khqak5`.
- `swift test --package-path apps/shared/OpenClawKit --filter 'slash command'` passed: 3 tests.
- Xcode simulator `-only-testing:OpenClawTests/OpenClawTypographyTests` passed: 9 tests.
- `git diff --check` passed.

Coverage added/updated:

- `apps/shared/OpenClawKit/Tests/OpenClawKitTests/ChatViewModelTests.swift` covers slash command catalog loading, filtering, and send behavior.
- `apps/ios/Tests/IOSGatewayChatTransportTests.swift` covers the command catalog transport surface.
- The picker UI uses the existing bundled JetBrains Mono via `OpenClawChatTypography.mono(...)`; no new font files are added. JetBrains Mono licensing is already covered by `apps/ios/Resources/Licenses/JetBrains Mono.txt` and `apps/ios/THIRD_PARTY_FONTS.md`.
