### PR TITLE
fix(logging): redact Telegram bot tokens from timeout URLs

### DIFF
--- a/packages/net-policy/src/redact-sensitive-url.test.ts
+++ b/packages/net-policy/src/redact-sensitive-url.test.ts
@@ -5,6 +5,7 @@ import {
   isSensitiveUrlConfigPath,
   SENSITIVE_URL_HINT_TAG,
   hasSensitiveUrlHintTag,
+  redactBotTokenPath,
   redactSensitiveUrl,
   redactSensitiveUrlLikeString,
 } from "./redact-sensitive-url.js";
@@ -131,5 +132,76 @@ describe("sensitive URL config metadata", () => {
     expect(SENSITIVE_URL_HINT_TAG).toBe("url-secret");
     expect(hasSensitiveUrlHintTag({ tags: [SENSITIVE_URL_HINT_TAG] })).toBe(true);
     expect(hasSensitiveUrlHintTag({ tags: ["security"] })).toBe(false);
+  });
+});
+
+describe("redactBotTokenPath", () => {
+  const SYNTHETIC_TELEGRAM_BOT_TOKEN = "123456:ABCDEFGHIJKLMNOPQRSTUVWXYZ_abcd";
+
+  it("redacts Telegram bot token from absolute URLs with a matching hostname", () => {
+    expect(
+      redactBotTokenPath(
+        `https://api.telegram.org/bot${SYNTHETIC_TELEGRAM_BOT_TOKEN}/sendMessage`,
+        "api.telegram.org",
+      ),
+    ).toBe("https://api.telegram.org/bot***/sendMessage");
+  });
+
+  it("redacts Telegram bot token with percent-encoded colon (%3A)", () => {
+    const colonEncoded = SYNTHETIC_TELEGRAM_BOT_TOKEN.replace(":", "%3A");
+    expect(
+      redactBotTokenPath(`https://api.telegram.org/bot${colonEncoded}/getMe`, "api.telegram.org"),
+    ).toBe("https://api.telegram.org/bot***/getMe");
+  });
+
+  it("redacts Telegram bot token in last path segment (no trailing slash)", () => {
+    expect(
+      redactBotTokenPath(
+        `https://api.telegram.org/bot${SYNTHETIC_TELEGRAM_BOT_TOKEN}`,
+        "api.telegram.org",
+      ),
+    ).toBe("https://api.telegram.org/bot***");
+  });
+
+  it("redacts Telegram bot token in fallback strings when no hostname is given", () => {
+    expect(
+      redactBotTokenPath(
+        `timeout /bot${SYNTHETIC_TELEGRAM_BOT_TOKEN}/sendMessage and keep /bot/settings`,
+      ),
+    ).toBe("timeout /bot***/sendMessage and keep /bot/settings");
+  });
+
+  it("does not redact non-matching hostname URLs", () => {
+    expect(
+      redactBotTokenPath(
+        `https://example.com/bot${SYNTHETIC_TELEGRAM_BOT_TOKEN}/sendMessage`,
+        "example.com",
+      ),
+    ).toBe(`https://example.com/bot${SYNTHETIC_TELEGRAM_BOT_TOKEN}/sendMessage`);
+  });
+
+  it.each([
+    "/bot/settings",
+    "/bots/chat",
+    "/robot/test",
+    "/bot123:status",
+    "/bot123456:short",
+    "/bota1:token",
+  ])("keeps ordinary bot-like path %s unchanged", (path) => {
+    expect(redactBotTokenPath(`https://example.com${path}`)).toBe(`https://example.com${path}`);
+  });
+
+  it("does not match short token IDs (less than 6 digits)", () => {
+    expect(
+      redactBotTokenPath(
+        "https://api.telegram.org/bot12345:ABCDEFGHIJKLMNOPQRSTUVWXYZ_abcd/status",
+      ),
+    ).toBe("https://api.telegram.org/bot12345:ABCDEFGHIJKLMNOPQRSTUVWXYZ_abcd/status");
+  });
+
+  it("does not match short token secrets (less than 20 characters)", () => {
+    expect(
+      redactBotTokenPath("https://api.telegram.org/bot123456:ABCDEFGHIJKLMNOPQRS/status"),
+    ).toBe("https://api.telegram.org/bot123456:ABCDEFGHIJKLMNOPQRS/status");
   });
 });

--- a/packages/net-policy/src/redact-sensitive-url.test.ts
+++ b/packages/net-policy/src/redact-sensitive-url.test.ts
@@ -5,7 +5,6 @@ import {
   isSensitiveUrlConfigPath,
   SENSITIVE_URL_HINT_TAG,
   hasSensitiveUrlHintTag,
-  redactBotTokenPath,
   redactSensitiveUrl,
   redactSensitiveUrlLikeString,
 } from "./redact-sensitive-url.js";
@@ -45,6 +44,19 @@ describe("redactSensitiveUrl", () => {
     expect(redactSensitiveUrl("https://example.com/mcp?safe=value")).toBe(
       "https://example.com/mcp?safe=value",
     );
+  });
+
+  it("redacts Telegram bot tokens from URL paths", () => {
+    expect(
+      redactSensitiveUrl(
+        "https://telegram.internal/bot123456:ABCDEFGHIJKLMNOPQRSTUVWXYZ_abcd/getMe",
+      ),
+    ).toBe("https://telegram.internal/bot***/getMe");
+    expect(
+      redactSensitiveUrl(
+        "https://api.telegram.org/bot123456%3AABCDEFGHIJKLMNOPQRSTUVWXYZ_abcd/getMe",
+      ),
+    ).toBe("https://api.telegram.org/bot***/getMe");
   });
 });
 
@@ -90,6 +102,14 @@ describe("redactSensitiveUrlLikeString", () => {
       ),
     ).toBe("wss://***:***@[bad-host/socket?token=***&keep=visible)");
   });
+
+  it("redacts Telegram bot tokens from URL-like fallback strings", () => {
+    expect(
+      redactSensitiveUrlLikeString(
+        "timeout /bot123456:ABCDEFGHIJKLMNOPQRSTUVWXYZ_abcd/sendMessage and keep /bot/settings",
+      ),
+    ).toBe("timeout /bot***/sendMessage and keep /bot/settings");
+  });
 });
 
 describe("isSensitiveUrlQueryParamName", () => {
@@ -132,94 +152,5 @@ describe("sensitive URL config metadata", () => {
     expect(SENSITIVE_URL_HINT_TAG).toBe("url-secret");
     expect(hasSensitiveUrlHintTag({ tags: [SENSITIVE_URL_HINT_TAG] })).toBe(true);
     expect(hasSensitiveUrlHintTag({ tags: ["security"] })).toBe(false);
-  });
-});
-
-describe("redactBotTokenPath", () => {
-  const SYNTHETIC_TELEGRAM_BOT_TOKEN = "123456:ABCDEFGHIJKLMNOPQRSTUVWXYZ_abcd";
-
-  it("redacts Telegram bot token from absolute URLs with a matching hostname", () => {
-    expect(
-      redactBotTokenPath(
-        `https://api.telegram.org/bot${SYNTHETIC_TELEGRAM_BOT_TOKEN}/sendMessage`,
-        "api.telegram.org",
-      ),
-    ).toBe("https://api.telegram.org/bot***/sendMessage");
-  });
-
-  it("redacts Telegram bot token with percent-encoded colon (%3A)", () => {
-    const colonEncoded = SYNTHETIC_TELEGRAM_BOT_TOKEN.replace(":", "%3A");
-    expect(
-      redactBotTokenPath(`https://api.telegram.org/bot${colonEncoded}/getMe`, "api.telegram.org"),
-    ).toBe("https://api.telegram.org/bot***/getMe");
-  });
-
-  it("redacts Telegram bot token in last path segment (no trailing slash)", () => {
-    expect(
-      redactBotTokenPath(
-        `https://api.telegram.org/bot${SYNTHETIC_TELEGRAM_BOT_TOKEN}`,
-        "api.telegram.org",
-      ),
-    ).toBe("https://api.telegram.org/bot***");
-  });
-
-  it("redacts Telegram bot token in fallback strings when no hostname is given", () => {
-    expect(
-      redactBotTokenPath(
-        `timeout /bot${SYNTHETIC_TELEGRAM_BOT_TOKEN}/sendMessage and keep /bot/settings`,
-      ),
-    ).toBe("timeout /bot***/sendMessage and keep /bot/settings");
-  });
-
-  it("redacts Telegram bot token for any hostname (universal redactor)", () => {
-    expect(
-      redactBotTokenPath(
-        `https://example.com/bot${SYNTHETIC_TELEGRAM_BOT_TOKEN}/sendMessage`,
-        "example.com",
-      ),
-    ).toBe("https://example.com/bot***/sendMessage");
-  });
-
-  it("redacts Telegram bot token on custom self-hosted API roots", () => {
-    expect(
-      redactBotTokenPath(
-        `https://telegram.internal/bot${SYNTHETIC_TELEGRAM_BOT_TOKEN}/getMe`,
-        "telegram.internal",
-      ),
-    ).toBe("https://telegram.internal/bot***/getMe");
-  });
-
-  it("redacts Telegram bot token on proxy API roots", () => {
-    expect(
-      redactBotTokenPath(
-        `https://tg-proxy.example.com/bot${SYNTHETIC_TELEGRAM_BOT_TOKEN}/sendMessage`,
-        "tg-proxy.example.com",
-      ),
-    ).toBe("https://tg-proxy.example.com/bot***/sendMessage");
-  });
-
-  it.each([
-    "/bot/settings",
-    "/bots/chat",
-    "/robot/test",
-    "/bot123:status",
-    "/bot123456:short",
-    "/bota1:token",
-  ])("keeps ordinary bot-like path %s unchanged", (path) => {
-    expect(redactBotTokenPath(`https://example.com${path}`)).toBe(`https://example.com${path}`);
-  });
-
-  it("does not match short token IDs (less than 6 digits)", () => {
-    expect(
-      redactBotTokenPath(
-        "https://api.telegram.org/bot12345:ABCDEFGHIJKLMNOPQRSTUVWXYZ_abcd/status",
-      ),
-    ).toBe("https://api.telegram.org/bot12345:ABCDEFGHIJKLMNOPQRSTUVWXYZ_abcd/status");
-  });
-
-  it("does not match short token secrets (less than 20 characters)", () => {
-    expect(
-      redactBotTokenPath("https://api.telegram.org/bot123456:ABCDEFGHIJKLMNOPQRS/status"),
-    ).toBe("https://api.telegram.org/bot123456:ABCDEFGHIJKLMNOPQRS/status");
   });
 });

--- a/packages/net-policy/src/redact-sensitive-url.test.ts
+++ b/packages/net-policy/src/redact-sensitive-url.test.ts
@@ -171,13 +171,31 @@ describe("redactBotTokenPath", () => {
     ).toBe("timeout /bot***/sendMessage and keep /bot/settings");
   });
 
-  it("does not redact non-matching hostname URLs", () => {
+  it("redacts Telegram bot token for any hostname (universal redactor)", () => {
     expect(
       redactBotTokenPath(
         `https://example.com/bot${SYNTHETIC_TELEGRAM_BOT_TOKEN}/sendMessage`,
         "example.com",
       ),
-    ).toBe(`https://example.com/bot${SYNTHETIC_TELEGRAM_BOT_TOKEN}/sendMessage`);
+    ).toBe("https://example.com/bot***/sendMessage");
+  });
+
+  it("redacts Telegram bot token on custom self-hosted API roots", () => {
+    expect(
+      redactBotTokenPath(
+        `https://telegram.internal/bot${SYNTHETIC_TELEGRAM_BOT_TOKEN}/getMe`,
+        "telegram.internal",
+      ),
+    ).toBe("https://telegram.internal/bot***/getMe");
+  });
+
+  it("redacts Telegram bot token on proxy API roots", () => {
+    expect(
+      redactBotTokenPath(
+        `https://tg-proxy.example.com/bot${SYNTHETIC_TELEGRAM_BOT_TOKEN}/sendMessage`,
+        "tg-proxy.example.com",
+      ),
+    ).toBe("https://tg-proxy.example.com/bot***/sendMessage");
   });
 
   it.each([

--- a/packages/net-policy/src/redact-sensitive-url.ts
+++ b/packages/net-policy/src/redact-sensitive-url.ts
@@ -41,6 +41,38 @@ const SENSITIVE_URL_QUERY_PARAM_NAMES = new Set([
 // category Lo, so \p{C}\p{Z} alone would let them splice sensitive key names.
 const URL_QUERY_NAME_SEPARATOR_RE = /[\p{C}\p{Z}\u115F\u1160\u3164\uFFA0+]/gu;
 
+// Bot API credential path segments must be redacted even in diagnostic/log URLs.
+// Require the real Telegram token shape (\u22656 digits, colon or %3A, \u226520 secret chars)
+// so ordinary `/bot` application routes are not hidden.
+const TELEGRAM_BOT_TOKEN_PATH_RE = /\/bot\d{6,}(?::|%3[aA])[A-Za-z0-9_-]{20,}(?=\/|$)/giu;
+
+function redactTelegramBotTokenPath(value: string): string {
+  return value.replace(TELEGRAM_BOT_TOKEN_PATH_RE, "/bot***");
+}
+
+// Registry of known Bot API path-token redactors keyed by hostname.
+// A hostname entry applies only to that host; pass no hostname to apply all policies.
+const BOT_TOKEN_PATH_REDACTORS: Record<string, (value: string) => string> = {
+  "api.telegram.org": redactTelegramBotTokenPath,
+};
+
+/**
+ * Redact known Bot API credential path segments from a URL string.
+ * When `hostname` is provided, only matching hostname policies apply.
+ * When omitted, all registered policies are applied (useful for unparseable URL-like strings).
+ */
+export function redactBotTokenPath(value: string, hostname?: string): string {
+  if (hostname) {
+    const redactor = BOT_TOKEN_PATH_REDACTORS[hostname];
+    return redactor ? redactor(value) : value;
+  }
+  let result = value;
+  for (const redactor of Object.values(BOT_TOKEN_PATH_REDACTORS)) {
+    result = redactor(result);
+  }
+  return result;
+}
+
 function normalizeUrlQueryParamName(name: string): string {
   const stripped = name.replace(URL_QUERY_NAME_SEPARATOR_RE, "");
   try {

--- a/packages/net-policy/src/redact-sensitive-url.ts
+++ b/packages/net-policy/src/redact-sensitive-url.ts
@@ -41,48 +41,12 @@ const SENSITIVE_URL_QUERY_PARAM_NAMES = new Set([
 // category Lo, so \p{C}\p{Z} alone would let them splice sensitive key names.
 const URL_QUERY_NAME_SEPARATOR_RE = /[\p{C}\p{Z}\u115F\u1160\u3164\uFFA0+]/gu;
 
-// Bot API credential path segments must be redacted even in diagnostic/log URLs.
-// Require the real Telegram token shape (\u22656 digits, colon or %3A, \u226520 secret chars)
-// so ordinary `/bot` application routes are not hidden.
+// Telegram Bot API credentials live in `/bot<token>/...` path segments rather
+// than userinfo or query params. Keep this shape aligned with logging/redact.ts.
 const TELEGRAM_BOT_TOKEN_PATH_RE = /\/bot\d{6,}(?::|%3[aA])[A-Za-z0-9_-]{20,}(?=\/|$)/giu;
 
-function redactTelegramBotTokenPath(value: string): string {
+function redactSensitiveUrlPath(value: string): string {
   return value.replace(TELEGRAM_BOT_TOKEN_PATH_RE, "/bot***");
-}
-
-// Universal bot token path redactors applied to every URL regardless of hostname.
-// The regex is strict enough (≥6-digit id + ≥20-char secret) to avoid false positives
-// on ordinary /bot application routes, so hostname-gating is unnecessary.
-const UNIVERSAL_BOT_TOKEN_PATH_REDACTORS: Array<(value: string) => string> = [
-  redactTelegramBotTokenPath,
-];
-
-// Registry of hostname-specific Bot API path-token redactors for future extensibility.
-// A matching hostname entry runs in addition to the universal redactors above.
-const BOT_TOKEN_PATH_REDACTORS: Record<string, (value: string) => string> = {};
-
-/**
- * Redact known Bot API credential path segments from a URL string.
- * Universal redactors (Telegram bot token path) always apply.
- * When `hostname` is provided and matches a hostname-specific policy, that
- * policy also runs. When omitted, all hostname-specific policies run too.
- */
-export function redactBotTokenPath(value: string, hostname?: string): string {
-  let result = value;
-  for (const redactor of UNIVERSAL_BOT_TOKEN_PATH_REDACTORS) {
-    result = redactor(result);
-  }
-  if (hostname) {
-    const hostRedactor = BOT_TOKEN_PATH_REDACTORS[hostname];
-    if (hostRedactor) {
-      result = hostRedactor(result);
-    }
-  } else {
-    for (const redactor of Object.values(BOT_TOKEN_PATH_REDACTORS)) {
-      result = redactor(result);
-    }
-  }
-  return result;
 }
 
 function normalizeUrlQueryParamName(name: string): string {
@@ -126,6 +90,11 @@ export function redactSensitiveUrl(value: string): string {
   try {
     const parsed = new URL(value);
     let mutated = false;
+    const redactedPath = redactSensitiveUrlPath(parsed.pathname);
+    if (redactedPath !== parsed.pathname) {
+      parsed.pathname = redactedPath;
+      mutated = true;
+    }
     if (parsed.username || parsed.password) {
       parsed.username = parsed.username ? "***" : "";
       parsed.password = parsed.password ? "***" : "";
@@ -149,9 +118,10 @@ export function redactSensitiveUrlLikeString(value: string): string {
   if (redactedUrl !== value) {
     return redactedUrl;
   }
-  return value
+  const redactedFallback = value
     .replace(/\/\/([^@/?#\s]+)@/g, "//***:***@")
     .replace(/([?&])([^=&]+)=([^&]*)/g, (match, prefix: string, key: string) =>
       isSensitiveUrlQueryParamName(key) ? `${prefix}${key}=***` : match,
     );
+  return redactSensitiveUrlPath(redactedFallback);
 }

--- a/packages/net-policy/src/redact-sensitive-url.ts
+++ b/packages/net-policy/src/redact-sensitive-url.ts
@@ -50,25 +50,37 @@ function redactTelegramBotTokenPath(value: string): string {
   return value.replace(TELEGRAM_BOT_TOKEN_PATH_RE, "/bot***");
 }
 
-// Registry of known Bot API path-token redactors keyed by hostname.
-// A hostname entry applies only to that host; pass no hostname to apply all policies.
-const BOT_TOKEN_PATH_REDACTORS: Record<string, (value: string) => string> = {
-  "api.telegram.org": redactTelegramBotTokenPath,
-};
+// Universal bot token path redactors applied to every URL regardless of hostname.
+// The regex is strict enough (≥6-digit id + ≥20-char secret) to avoid false positives
+// on ordinary /bot application routes, so hostname-gating is unnecessary.
+const UNIVERSAL_BOT_TOKEN_PATH_REDACTORS: Array<(value: string) => string> = [
+  redactTelegramBotTokenPath,
+];
+
+// Registry of hostname-specific Bot API path-token redactors for future extensibility.
+// A matching hostname entry runs in addition to the universal redactors above.
+const BOT_TOKEN_PATH_REDACTORS: Record<string, (value: string) => string> = {};
 
 /**
  * Redact known Bot API credential path segments from a URL string.
- * When `hostname` is provided, only matching hostname policies apply.
- * When omitted, all registered policies are applied (useful for unparseable URL-like strings).
+ * Universal redactors (Telegram bot token path) always apply.
+ * When `hostname` is provided and matches a hostname-specific policy, that
+ * policy also runs. When omitted, all hostname-specific policies run too.
  */
 export function redactBotTokenPath(value: string, hostname?: string): string {
-  if (hostname) {
-    const redactor = BOT_TOKEN_PATH_REDACTORS[hostname];
-    return redactor ? redactor(value) : value;
-  }
   let result = value;
-  for (const redactor of Object.values(BOT_TOKEN_PATH_REDACTORS)) {
+  for (const redactor of UNIVERSAL_BOT_TOKEN_PATH_REDACTORS) {
     result = redactor(result);
+  }
+  if (hostname) {
+    const hostRedactor = BOT_TOKEN_PATH_REDACTORS[hostname];
+    if (hostRedactor) {
+      result = hostRedactor(result);
+    }
+  } else {
+    for (const redactor of Object.values(BOT_TOKEN_PATH_REDACTORS)) {
+      result = redactor(result);
+    }
   }
   return result;
 }

--- a/src/utils/fetch-timeout.test.ts
+++ b/src/utils/fetch-timeout.test.ts
@@ -13,6 +13,17 @@ vi.mock("../logging/subsystem.js", () => ({
 import { buildTimeoutAbortSignal, fetchWithTimeout } from "./fetch-timeout.js";
 import { MAX_SAFE_TIMEOUT_DELAY_MS } from "./timer-delay.js";
 
+function captureTimeoutLogUrl(url: string): Promise<Record<string, unknown>> {
+  const { cleanup } = buildTimeoutAbortSignal({ timeoutMs: 25, operation: "unit-test", url });
+  return vi.advanceTimersByTimeAsync(25).then(() => {
+    const record = requireWarnRecord(0);
+    cleanup();
+    return record;
+  });
+}
+
+const SYNTHETIC_TELEGRAM_BOT_TOKEN = "123456:ABCDEFGHIJKLMNOPQRSTUVWXYZ_abcd";
+
 function requireWarnCall(callIndex: number): [string, Record<string, unknown>] {
   const call = warn.mock.calls[callIndex];
   if (!call) {
@@ -142,6 +153,34 @@ describe("buildTimeoutAbortSignal", () => {
     expect(requireWarnRecord(0).url).toBe("/api/responses");
 
     cleanup();
+  });
+
+  it("redacts Telegram bot tokens from parseable timeout URLs", async () => {
+    const record = await captureTimeoutLogUrl(
+      `https://api.telegram.org/bot${SYNTHETIC_TELEGRAM_BOT_TOKEN}/sendMessage?chat_id=1`,
+    );
+
+    expect(record.url).toBe("https://api.telegram.org/bot***/sendMessage");
+    expect(JSON.stringify(record)).not.toContain(SYNTHETIC_TELEGRAM_BOT_TOKEN);
+  });
+
+  it("redacts Telegram bot tokens from unparseable (fallback) timeout URL strings", async () => {
+    const record = await captureTimeoutLogUrl(
+      `/bot${SYNTHETIC_TELEGRAM_BOT_TOKEN}/sendMessage?chat_id=1`,
+    );
+
+    expect(record.url).toBe("/bot***/sendMessage");
+    expect(JSON.stringify(record)).not.toContain(SYNTHETIC_TELEGRAM_BOT_TOKEN);
+  });
+
+  it.each([
+    ["https://example.com/bot/settings?safe=1", "https://example.com/bot/settings"],
+    ["https://example.com/bots/chat?safe=1", "https://example.com/bots/chat"],
+    ["https://example.com/robot/test?safe=1", "https://example.com/robot/test"],
+    ["/bot123:status?safe=1", "/bot123:status"],
+    ["/bot123456:short/status?safe=1", "/bot123456:short/status"],
+  ])("keeps ordinary bot-like timeout path %s visible", async (input, expected) => {
+    expect((await captureTimeoutLogUrl(input)).url).toBe(expected);
   });
 
   it("tags fetch timeout aborts so callers can distinguish them from parent aborts", async () => {

--- a/src/utils/fetch-timeout.test.ts
+++ b/src/utils/fetch-timeout.test.ts
@@ -164,6 +164,24 @@ describe("buildTimeoutAbortSignal", () => {
     expect(JSON.stringify(record)).not.toContain(SYNTHETIC_TELEGRAM_BOT_TOKEN);
   });
 
+  it("redacts Telegram bot tokens from custom self-hosted API root timeout URLs", async () => {
+    const record = await captureTimeoutLogUrl(
+      `https://telegram.internal/bot${SYNTHETIC_TELEGRAM_BOT_TOKEN}/getMe?chat_id=1`,
+    );
+
+    expect(record.url).toBe("https://telegram.internal/bot***/getMe");
+    expect(JSON.stringify(record)).not.toContain(SYNTHETIC_TELEGRAM_BOT_TOKEN);
+  });
+
+  it("redacts Telegram bot tokens from proxy API root timeout URLs", async () => {
+    const record = await captureTimeoutLogUrl(
+      `https://tg-proxy.example.com/bot${SYNTHETIC_TELEGRAM_BOT_TOKEN}/sendMessage?foo=bar`,
+    );
+
+    expect(record.url).toBe("https://tg-proxy.example.com/bot***/sendMessage");
+    expect(JSON.stringify(record)).not.toContain(SYNTHETIC_TELEGRAM_BOT_TOKEN);
+  });
+
   it("redacts Telegram bot tokens from unparseable (fallback) timeout URL strings", async () => {
     const record = await captureTimeoutLogUrl(
       `/bot${SYNTHETIC_TELEGRAM_BOT_TOKEN}/sendMessage?chat_id=1`,

--- a/src/utils/fetch-timeout.ts
+++ b/src/utils/fetch-timeout.ts
@@ -1,4 +1,5 @@
 // Fetch timeout helpers wrap fetch calls with timeout and abort behavior.
+import { redactBotTokenPath } from "@openclaw/net-policy/redact-sensitive-url";
 import { createSubsystemLogger } from "../logging/subsystem.js";
 import { resolveSafeTimeoutDelayMs } from "./timer-delay.js";
 
@@ -39,15 +40,17 @@ function sanitizeTimeoutLogUrl(rawUrl: string | undefined): string | undefined {
     parsed.password = "";
     parsed.search = "";
     parsed.hash = "";
-    const value = parsed.toString();
+    const value = redactBotTokenPath(parsed.toString(), parsed.hostname);
     return value.length > LOG_URL_MAX_CHARS ? `${value.slice(0, LOG_URL_MAX_CHARS)}...` : value;
   } catch {
     const withoutQueryOrHash = trimmed.split(URL_SECRET_SUFFIX_PATTERN, 1)[0] ?? "";
-    const cleaned = withoutQueryOrHash
-      .replace(/[\r\n\u2028\u2029]+/g, " ")
-      .replace(/\p{Cc}+/gu, " ")
-      .replace(/\s+/g, " ")
-      .trim();
+    const cleaned = redactBotTokenPath(
+      withoutQueryOrHash
+        .replace(/[\r\n\u2028\u2029]+/g, " ")
+        .replace(/\p{Cc}+/gu, " ")
+        .replace(/\s+/g, " ")
+        .trim(),
+    );
     if (!cleaned) {
       return undefined;
     }

--- a/src/utils/fetch-timeout.ts
+++ b/src/utils/fetch-timeout.ts
@@ -1,5 +1,5 @@
 // Fetch timeout helpers wrap fetch calls with timeout and abort behavior.
-import { redactBotTokenPath } from "@openclaw/net-policy/redact-sensitive-url";
+import { redactSensitiveUrlLikeString } from "@openclaw/net-policy/redact-sensitive-url";
 import { createSubsystemLogger } from "../logging/subsystem.js";
 import { resolveSafeTimeoutDelayMs } from "./timer-delay.js";
 
@@ -40,11 +40,11 @@ function sanitizeTimeoutLogUrl(rawUrl: string | undefined): string | undefined {
     parsed.password = "";
     parsed.search = "";
     parsed.hash = "";
-    const value = redactBotTokenPath(parsed.toString(), parsed.hostname);
+    const value = redactSensitiveUrlLikeString(parsed.toString());
     return value.length > LOG_URL_MAX_CHARS ? `${value.slice(0, LOG_URL_MAX_CHARS)}...` : value;
   } catch {
     const withoutQueryOrHash = trimmed.split(URL_SECRET_SUFFIX_PATTERN, 1)[0] ?? "";
-    const cleaned = redactBotTokenPath(
+    const cleaned = redactSensitiveUrlLikeString(
       withoutQueryOrHash
         .replace(/[\r\n\u2028\u2029]+/g, " ")
         .replace(/\p{Cc}+/gu, " ")


### PR DESCRIPTION
Fixes #96982.

## What Problem This Solves

Telegram Bot API credentials are part of the request path (`/bot<TOKEN>/METHOD`). Fetch-timeout diagnostics removed userinfo, query strings, and fragments but retained that credential-bearing path, so a timeout could expose the full bot token when downstream configurable log redaction was disabled.

Custom Bot API and proxy roots have the same path contract. The fix therefore cannot be gated to `api.telegram.org`.

## Why This Change Was Made

The final implementation keeps one canonical owner: `redactSensitiveUrl` / `redactSensitiveUrlLikeString` in the net-policy package now redact the documented Telegram token path shape, and fetch-timeout reuses that existing API after applying its stricter diagnostic policy.

Deep review removed the submitted empty hostname registry, universal-redactor array, and one-purpose public export. The result protects existing sensitive-URL consumers too, without speculative policy surface.

Telegram documents Bot API requests as `https://api.telegram.org/bot<token>/METHOD_NAME`: https://core.telegram.org/bots/api#making-requests

## User Impact

Timeout logs retain the Bot API host and method but replace the credential segment with `/bot***`, including custom `apiRoot` values. Ordinary `/bot/settings`, `/bots/...`, and other non-token paths remain visible.

## Evidence

Exact prepared head: `89b6f9bce765a37be894f4646608a107352f2964`.

- `node scripts/run-vitest.mjs packages/net-policy/src/redact-sensitive-url.test.ts src/utils/fetch-timeout.test.ts` — 2 shards, 37 tests passed on the exact head.
- Live custom-root probe: a real `probeTelegram` call targeted a deliberately stalled local Bot API server with `logging.redactSensitive: off`. The real timeout line was `[fetch-timeout] ... url=http://127.0.0.1:<port>/bot***/getMe`; the probe returned its expected timeout and the synthetic token was absent.
- `node_modules/.bin/oxfmt --check --threads=1 ...` — passed for all four touched files.
- `node_modules/.bin/oxlint ...` and `git diff --check` — passed.
- Fresh Codex autoreview after the maintainer rewrite: no accepted/actionable findings; patch correct at 0.94 confidence.
- Hosted exact-head CI run `28658133224`, attempt 3: passed, including QA smoke, build, lint, type, security, and all selected Node shards. Attempts 1-2 exposed unrelated QA flakes (`runtime-inventory-drift-check`, then a 5-second `native-command-session-target` timeout); downloaded evidence showed the alternate scenario passed on each retry, and attempt 3 passed the full profile without code changes.

Duplicate convergence: #97003 is an older conflicting copy of this fix; #97013 is already closed. After this PR lands, #97003 will be closed with the canonical commit and proof.

## AI Assistance

- AI-assisted: yes
- Maintainer review/rewrite: Codex
