### PR TITLE
fix(cli): tab-complete command aliases

### DIFF
--- a/src/cli/completion-cli.test.ts
+++ b/src/cli/completion-cli.test.ts
@@ -34,6 +34,20 @@ function createCompletionProgram(): Command {
   return program;
 }
 
+function createAliasedCompletionProgram(): Command {
+  const program = new Command();
+  program.name("openclaw");
+
+  const infer = program.command("infer").alias("capability").description("Infer commands");
+  infer.command("status").description("Show infer status");
+
+  const cron = program.command("cron").description("Cron commands");
+  cron.command("add").alias("create").description("Add a cron job").option("--json", "JSON output");
+  cron.command("rm").alias("remove").alias("delete").description("Remove a cron job");
+
+  return program;
+}
+
 describe("completion-cli", () => {
   it("generates zsh functions for nested subcommands", () => {
     const script = getCompletionScript("zsh", createCompletionProgram());
@@ -44,6 +58,17 @@ describe("completion-cli", () => {
     expect(script).toContain("--force[Force the action]");
     expect(script).toContain("\\`models status --json\\`");
     expect(script).toContain("\\$OPENCLAW_STATE_DIR");
+  });
+
+  it("includes command aliases in zsh completion dispatch", () => {
+    const script = getCompletionScript("zsh", createAliasedCompletionProgram());
+
+    expect(script).toContain("'capability[Infer commands]'");
+    expect(script).toContain("(infer|capability) _openclaw_infer ;;");
+    expect(script).toContain("'create[Add a cron job]'");
+    expect(script).toContain("(add|create) _openclaw_cron_add ;;");
+    expect(script).toContain("'remove[Remove a cron job]'");
+    expect(script).toContain("'delete[Remove a cron job]'");
   });
 
   it("escapes zsh option descriptions for double-quoted arguments specs", () => {
@@ -122,6 +147,18 @@ describe("completion-cli", () => {
     expect(script).not.toContain("'-t,'");
   });
 
+  it("includes command aliases in PowerShell completion paths", () => {
+    const script = getCompletionScript("powershell", createAliasedCompletionProgram());
+
+    expect(script).toContain("$completions = @('infer','capability','cron')");
+    expect(script).toContain("if ($commandPath -eq 'infer') {");
+    expect(script).toContain("if ($commandPath -eq 'capability') {");
+    expect(script).toContain("$completions = @('status')");
+    expect(script).toContain("if ($commandPath -eq 'cron add') {");
+    expect(script).toContain("if ($commandPath -eq 'cron create') {");
+    expect(script).toContain("$completions = @('--json')");
+  });
+
   it("generates valid PowerShell root arrays when commands or options are empty", () => {
     const commandsOnly = new Command().name("openclaw");
     commandsOnly.command("status");
@@ -152,6 +189,23 @@ describe("completion-cli", () => {
     expect(script).toContain("if contains -- $flag $value_options");
   });
 
+  it("includes command aliases in fish completion paths", () => {
+    const script = getCompletionScript("fish", createAliasedCompletionProgram());
+
+    expect(script).toContain(
+      'complete -c openclaw -n "__fish_use_subcommand" -a "capability" -d \'Infer commands\'',
+    );
+    expect(script).toContain(
+      'complete -c openclaw -n "__openclaw_command_path_matches capability --" -a "status" -d \'Show infer status\'',
+    );
+    expect(script).toContain(
+      'complete -c openclaw -n "__openclaw_command_path_matches cron --" -a "create" -d \'Add a cron job\'',
+    );
+    expect(script).toContain(
+      "complete -c openclaw -n \"__openclaw_command_path_matches cron create --\" -l json -d 'JSON output'",
+    );
+  });
+
   it("scopes fish value-taking option skips to the active command path", () => {
     const script = getCompletionScript("fish", createCompletionProgram());
 
@@ -168,5 +222,15 @@ describe("completion-cli", () => {
 
     expect(script).toContain("--token");
     expect(script).not.toContain("-t,");
+  });
+
+  it("includes command aliases in Bash completion paths", () => {
+    const script = getCompletionScript("bash", createAliasedCompletionProgram());
+
+    expect(script).toContain('opts="infer capability cron"');
+    expect(script).toContain('"infer"|"capability")');
+    expect(script).toContain('opts="status"');
+    expect(script).toContain('"cron add"|"cron create")');
+    expect(script).toContain('opts="--json"');
   });
 });

--- a/src/cli/completion-cli.ts
+++ b/src/cli/completion-cli.ts
@@ -44,6 +44,24 @@ function preferredCompletionFlag(flags: string): string {
   return parts.find((flag) => flag.startsWith("--")) ?? parts[0] ?? flags;
 }
 
+function commandCompletionNames(command: Command): string[] {
+  return [...new Set([command.name(), ...command.aliases()])];
+}
+
+function subcommandCompletionNames(command: Command): string[] {
+  return command.commands.flatMap(commandCompletionNames);
+}
+
+function commandPathVariants(commands: readonly Command[]): string[] {
+  let variants = [""];
+  for (const command of commands) {
+    variants = variants.flatMap((prefix) =>
+      commandCompletionNames(command).map((name) => (prefix ? `${prefix} ${name}` : name)),
+    );
+  }
+  return variants;
+}
+
 function fishWords(values: readonly string[]): string {
   return values.join(" ");
 }
@@ -59,17 +77,12 @@ function fishOptionFlags(options: Command["options"], wantsValue: boolean): stri
 
 function collectFishPathOptionFlags(
   program: Command,
-  parents: readonly string[],
+  parents: readonly Command[],
   wantsValue: boolean,
 ): string[] {
   const flags = new Set(fishOptionFlags(program.options, wantsValue));
-  let current: Command | undefined = program;
-  for (const name of parents) {
-    current = current?.commands.find((cmd) => cmd.name() === name);
-    if (!current) {
-      break;
-    }
-    for (const flag of fishOptionFlags(current.options, wantsValue)) {
+  for (const command of parents) {
+    for (const flag of fishOptionFlags(command.options, wantsValue)) {
       flags.add(flag);
     }
   }
@@ -129,8 +142,9 @@ function fishCommandPathCondition(
   program: Command,
   rootCmd: string,
   parents: readonly string[],
+  parentCommands: readonly Command[],
 ): string {
-  const valueOptions = collectFishPathOptionFlags(program, parents, true);
+  const valueOptions = collectFishPathOptionFlags(program, parentCommands, true);
   return `__${rootCmd}_command_path_matches ${parents.join(" ")} -- ${fishWords(valueOptions)}`.trimEnd();
 }
 
@@ -258,7 +272,7 @@ _${rootCmd}_root_completion() {
   case $state in
     (args)
       case $line[1] in
-        ${program.commands.map((cmd) => `(${cmd.name()}) _${rootCmd}_${cmd.name().replace(/-/g, "_")} ;;`).join("\n        ")}
+        ${program.commands.map((cmd) => `(${commandCompletionNames(cmd).join("|")}) _${rootCmd}_${cmd.name().replace(/-/g, "_")} ;;`).join("\n        ")}
       esac
       ;;
   esac
@@ -304,14 +318,14 @@ function generateZshArgs(cmd: Command): string {
 
 function generateZshSubcmdList(cmd: Command): string {
   const list = cmd.commands
-    .map((c) => {
+    .flatMap((c) => {
       const desc = c
         .description()
         .replace(/\\/g, "\\\\")
         .replace(/'/g, "'\\''")
         .replace(/\[/g, "\\[")
         .replace(/\]/g, "\\]");
-      return `'${c.name()}[${desc}]'`;
+      return commandCompletionNames(c).map((name) => `'${name}[${desc}]'`);
     })
     .join(" ");
   return `"1: :_values 'command' ${list}"`;
@@ -353,7 +367,7 @@ ${funcName}() {
   case $state in
     (args)
       case $line[1] in
-        ${subCommands.map((sub) => `(${sub.name()}) ${funcName}_${sub.name().replace(/-/g, "_")} ;;`).join("\n        ")}
+        ${subCommands.map((sub) => `(${commandCompletionNames(sub).join("|")}) ${funcName}_${sub.name().replace(/-/g, "_")} ;;`).join("\n        ")}
       esac
       ;;
   esac
@@ -376,24 +390,33 @@ ${funcName}() {
 }
 
 function generateBashCompletion(program: Command): string {
-  // Simplified Bash completion using dynamic iteration logic (often hardcoded in static scripts)
-  // For a robust implementation, usually one maps out the tree.
-  // This assumes a simple structure.
   const rootCmd = program.name();
+  const rootCompletions = [
+    ...subcommandCompletionNames(program),
+    ...program.options.map((o) => preferredCompletionFlag(o.flags)),
+  ];
 
-  // We can use a recursive function to build the case statements
   return `
 _${rootCmd}_completion() {
-    local cur prev opts
+    local cur opts command_path word i
     COMPREPLY=()
     cur="\${COMP_WORDS[COMP_CWORD]}"
-    prev="\${COMP_WORDS[COMP_CWORD-1]}"
+    opts="${rootCompletions.join(" ")}"
+    command_path=""
+
+    for ((i = 1; i < COMP_CWORD; i++)); do
+        word="\${COMP_WORDS[i]}"
+        if [[ \${word} == -* ]]; then
+            break
+        fi
+        if [[ -n "\${command_path}" ]]; then
+            command_path+=" "
+        fi
+        command_path+="\${word}"
+    done
     
-    # Simple top-level completion for now
-    opts="${program.commands.map((c) => c.name()).join(" ")} ${program.options.map((o) => preferredCompletionFlag(o.flags)).join(" ")}"
-    
-    case "\${prev}" in
-      ${program.commands.map((cmd) => generateBashSubcommand(cmd)).join("\n      ")}
+    case "\${command_path}" in
+${generateBashSubcommands(program)}
     esac
 
     if [[ \${cur} == -* ]] ; then
@@ -408,14 +431,31 @@ complete -F _${rootCmd}_completion ${rootCmd}
 `;
 }
 
-function generateBashSubcommand(cmd: Command): string {
-  // This is a naive implementation; fully recursive bash completion is complex to generate as a single string without improved state tracking.
-  // For now, let's provide top-level command recognition.
-  return `${cmd.name()})
-        opts="${cmd.commands.map((c) => c.name()).join(" ")} ${cmd.options.map((o) => preferredCompletionFlag(o.flags)).join(" ")}"
-        COMPREPLY=( $(compgen -W "\${opts}" -- \${cur}) )
-        return 0
-        ;;`;
+function generateBashSubcommands(program: Command): string {
+  const segments: string[] = [];
+
+  const visit = (cmd: Command, pathCommands: Command[]) => {
+    const completions = [
+      ...subcommandCompletionNames(cmd),
+      ...cmd.options.map((o) => preferredCompletionFlag(o.flags)),
+    ];
+    const patterns = commandPathVariants(pathCommands)
+      .map((pathValue) => `"${pathValue}"`)
+      .join("|");
+    segments.push(`      ${patterns})
+        opts="${completions.join(" ")}"
+        ;;`);
+
+    for (const sub of cmd.commands) {
+      visit(sub, [...pathCommands, sub]);
+    }
+  };
+
+  for (const sub of program.commands) {
+    visit(sub, [sub]);
+  }
+
+  return segments.join("\n");
 }
 
 function generatePowerShellCompletion(program: Command): string {
@@ -424,27 +464,27 @@ function generatePowerShellCompletion(program: Command): string {
   const formatPowerShellArray = (entries: string[]) =>
     entries.length > 0 ? `@(${entries.map((entry) => `'${entry}'`).join(",")})` : "@()";
 
-  const visit = (cmd: Command, pathSegments: string[]) => {
-    const fullPath = pathSegments.join(" ");
-
+  const visit = (cmd: Command, pathCommands: Command[]) => {
     // Command completion for this level
-    const subCommands = cmd.commands.map((c) => c.name());
+    const subCommands = subcommandCompletionNames(cmd);
     const options = cmd.options.map((o) => preferredCompletionFlag(o.flags));
     const allCompletions = formatPowerShellArray([...subCommands, ...options]);
 
-    if (fullPath.length > 0 && [...subCommands, ...options].length > 0) {
-      segments.push(`
-            if ($commandPath -eq '${fullPath}') {
+    if (pathCommands.length > 0 && [...subCommands, ...options].length > 0) {
+      for (const variant of commandPathVariants(pathCommands)) {
+        segments.push(`
+            if ($commandPath -eq '${variant}') {
                 $completions = ${allCompletions}
                 $completions | Where-Object { $_ -like "$wordToComplete*" } | ForEach-Object {
                     [System.Management.Automation.CompletionResult]::new($_, $_, 'ParameterName', $_)
                 }
             }
 `);
+      }
     }
 
     for (const sub of cmd.commands) {
-      visit(sub, [...pathSegments, sub.name()]);
+      visit(sub, [...pathCommands, sub]);
     }
   };
 
@@ -471,7 +511,7 @@ Register-ArgumentCompleter -Native -CommandName ${rootCmd} -ScriptBlock {
     # Root command
     if ($commandPath -eq "") {
          $completions = ${formatPowerShellArray([
-           ...program.commands.map((command) => command.name()),
+           ...subcommandCompletionNames(program),
            ...program.options.map((option) => preferredCompletionFlag(option.flags)),
          ])}
          $completions | Where-Object { $_ -like "$wordToComplete*" } | ForEach-Object {
@@ -488,19 +528,21 @@ function generateFishCompletion(program: Command): string {
   const rootCmd = program.name();
   const segments: string[] = [generateFishPathHelper(rootCmd)];
 
-  const visit = (cmd: Command, parents: string[]) => {
+  const visit = (cmd: Command, parents: string[], parentCommands: Command[]) => {
     // Root logic
     if (parents.length === 0) {
       // Subcommands of root
       for (const sub of cmd.commands) {
-        segments.push(
-          buildFishSubcommandCompletionLine({
-            rootCmd,
-            condition: "__fish_use_subcommand",
-            name: sub.name(),
-            description: sub.description(),
-          }),
-        );
+        for (const name of commandCompletionNames(sub)) {
+          segments.push(
+            buildFishSubcommandCompletionLine({
+              rootCmd,
+              condition: "__fish_use_subcommand",
+              name,
+              description: sub.description(),
+            }),
+          );
+        }
       }
       // Options of root
       for (const opt of cmd.options) {
@@ -514,17 +556,19 @@ function generateFishCompletion(program: Command): string {
         );
       }
     } else {
-      const condition = fishCommandPathCondition(program, rootCmd, parents);
+      const condition = fishCommandPathCondition(program, rootCmd, parents, parentCommands);
       // Subcommands
       for (const sub of cmd.commands) {
-        segments.push(
-          buildFishSubcommandCompletionLine({
-            rootCmd,
-            condition,
-            name: sub.name(),
-            description: sub.description(),
-          }),
-        );
+        for (const name of commandCompletionNames(sub)) {
+          segments.push(
+            buildFishSubcommandCompletionLine({
+              rootCmd,
+              condition,
+              name,
+              description: sub.description(),
+            }),
+          );
+        }
       }
       // Options
       for (const opt of cmd.options) {
@@ -540,10 +584,16 @@ function generateFishCompletion(program: Command): string {
     }
 
     for (const sub of cmd.commands) {
-      visit(sub, parents.length === 0 ? [sub.name()] : [...parents, sub.name()]);
+      for (const variant of commandCompletionNames(sub)) {
+        visit(
+          sub,
+          parents.length === 0 ? [variant] : [...parents, variant],
+          parents.length === 0 ? [sub] : [...parentCommands, sub],
+        );
+      }
     }
   };
 
-  visit(program, []);
+  visit(program, [], []);
   return segments.join("");
 }


### PR DESCRIPTION
Closes #99406

## What Problem This Solves

Fixes an issue where users installing OpenClaw shell completion could not tab-complete documented command aliases such as `capability`, `chat`, `terminal`, or nested aliases like `cron create`.

## Why This Change Was Made

The completion generators now derive command names from Commander canonical names plus aliases and use alias-expanded command paths for nested dispatch. The change is limited to shell completion output generation and regression coverage.

## User Impact

Users can tab-complete both canonical commands and their documented aliases in zsh, Bash, fish, and PowerShell, including nested alias paths and options under those paths.

## Evidence

- `node scripts/run-vitest.mjs src/cli/completion-cli.test.ts` passed.
- `COREPACK_HOME=/tmp/openclaw-corepack pnpm exec oxfmt --check --threads=1 src/cli/completion-cli.ts src/cli/completion-cli.test.ts` passed.
- `COREPACK_HOME=/tmp/openclaw-corepack pnpm exec oxlint src/cli/completion-cli.ts src/cli/completion-cli.test.ts` passed.
- `git diff --check` passed.
