### PR TITLE
fix: classify overloaded 429 provider errors

### DIFF
--- a/src/agents/embedded-agent-helpers/errors.ts
+++ b/src/agents/embedded-agent-helpers/errors.ts
@@ -818,6 +818,9 @@ function classifyFailoverClassificationFromHttpStatus(
     if (message && isBilling429MessageForProvider(message, provider)) {
       return toReasonClassification("billing");
     }
+    if (messageReason === "overloaded") {
+      return messageClassification;
+    }
     return toReasonClassification("rate_limit");
   }
   if (status === 401 || status === 403) {

--- a/src/agents/failover-error.test.ts
+++ b/src/agents/failover-error.test.ts
@@ -264,6 +264,12 @@ describe("failover-error", () => {
     ).toBe("overloaded");
     expect(
       resolveFailoverReasonFromError({
+        status: 429,
+        message: ANTHROPIC_OVERLOADED_PAYLOAD,
+      }),
+    ).toBe("overloaded");
+    expect(
+      resolveFailoverReasonFromError({
         status: 499,
         message: ANTHROPIC_OVERLOADED_PAYLOAD,
       }),


### PR DESCRIPTION
Fixes #99432

## What Problem This Solves

Fixes an issue where provider failures with HTTP 429 would be treated as rate limits even when the provider payload explicitly said the service was overloaded. Operators could see the wrong failure category and OpenClaw could apply the rate-limit retry/fallback policy to a transient overload response.

## Why This Change Was Made

The failover classifier already derives `overloaded` from structured payloads such as `overloaded_error`, but the 429 status branch overwrote every non-billing 429 as `rate_limit`. This change keeps the existing billing precedence, preserves an already-derived overloaded classification, and leaves plain 429 responses on the rate-limit path.

## User Impact

Users and operators get more accurate retry/fallback behavior for overloaded provider responses that happen to arrive with HTTP 429. Generic 429 rate-limit and quota responses continue to behave as before.

## Evidence

- Source-level before proof on `origin/main` at `24e6b9fbe1b9449b837fecddf1f9b160ed7bb896`: the `status === 429` branch in `src/agents/embedded-agent-helpers/errors.ts` preserved billing-shaped 429s but otherwise returned `rate_limit`, discarding a previously derived `overloaded` payload classification.
- Focused regression: `node scripts/run-vitest.mjs src/agents/failover-error.test.ts --testNamePattern="classifies documented provider error shapes at the error boundary"` -> 1 test passed.
- Full focused file: `node scripts/run-vitest.mjs src/agents/failover-error.test.ts` -> 93 tests passed.
- Static checks: `pnpm exec oxlint src/agents/embedded-agent-helpers/errors.ts src/agents/failover-error.test.ts`
- Format check: `pnpm exec oxfmt --check src/agents/embedded-agent-helpers/errors.ts src/agents/failover-error.test.ts`
- Diff hygiene: `git diff --check`
- `autoreview clean: no accepted/actionable findings reported` (`python .agents\skills\autoreview\scripts\autoreview --mode branch --base origin/main`).
