### PR TITLE
Handle mid-turn precheck compaction end to end

### DIFF
--- a/packages/agent-core/src/agent.ts
+++ b/packages/agent-core/src/agent.ts
@@ -59,6 +59,14 @@ const DEFAULT_MODEL = {
   maxTokens: 0,
 } satisfies Model;
 
+function isMidTurnPrecheckSignal(error: unknown): boolean {
+  return (
+    error instanceof Error &&
+    error.name === "MidTurnPrecheckSignal" &&
+    error.message === "Context overflow: prompt too large for the model (mid-turn precheck)."
+  );
+}
+
 type MutableAgentState = Omit<
   AgentState,
   "isStreaming" | "streamingMessage" | "pendingToolCalls" | "errorMessage"
@@ -526,6 +534,9 @@ export class Agent {
     try {
       await executor(abortController.signal);
     } catch (error) {
+      if (isMidTurnPrecheckSignal(error)) {
+        throw error;
+      }
       await this.handleRunFailure(error, abortController.signal.aborted);
     } finally {
       this.finishRun();

--- a/packages/agent-core/src/harness/agent-harness.ts
+++ b/packages/agent-core/src/harness/agent-harness.ts
@@ -730,6 +730,9 @@ export class CoreAgentHarness<
       return await this.executeTurn(turnState, text, options);
     } catch (error) {
       this.phase = "idle";
+      if (isMidTurnPrecheckSignal(error)) {
+        throw error;
+      }
       throw normalizeHarnessError(error, "unknown");
     } finally {
       finishRunPromise();
@@ -754,6 +757,9 @@ export class CoreAgentHarness<
       );
     } catch (error) {
       this.phase = "idle";
+      if (isMidTurnPrecheckSignal(error)) {
+        throw error;
+      }
       throw normalizeHarnessError(error, "unknown");
     } finally {
       finishRunPromise();
@@ -777,6 +783,9 @@ export class CoreAgentHarness<
       return await this.executeTurn(turnState, formatPromptTemplateInvocation(template, args));
     } catch (error) {
       this.phase = "idle";
+      if (isMidTurnPrecheckSignal(error)) {
+        throw error;
+      }
       throw normalizeHarnessError(error, "unknown");
     } finally {
       finishRunPromise();

--- a/packages/agent-core/src/harness/agent-harness.ts
+++ b/packages/agent-core/src/harness/agent-harness.ts
@@ -197,6 +197,14 @@ function normalizeHookError(error: unknown): AgentHarnessError {
   return normalizeHarnessError(error, "hook");
 }
 
+function isMidTurnPrecheckSignal(error: unknown): boolean {
+  return (
+    error instanceof Error &&
+    error.name === "MidTurnPrecheckSignal" &&
+    error.message === "Context overflow: prompt too large for the model (mid-turn precheck)."
+  );
+}
+
 interface AgentHarnessTurnState<
   TSkill extends Skill = Skill,
   TPromptTemplate extends PromptTemplate = PromptTemplate,
@@ -671,6 +679,9 @@ export class CoreAgentHarness<
           this.createStreamFn(getTurnState),
         );
       } catch (error) {
+        if (isMidTurnPrecheckSignal(error)) {
+          throw error;
+        }
         try {
           return await this.emitRunFailure(
             activeTurnState.model,

--- a/src/agents/command/cli-compaction.ts
+++ b/src/agents/command/cli-compaction.ts
@@ -172,6 +172,11 @@ function getSessionBranchMessages(sessionManager: SessionManagerLike): AgentMess
     );
 }
 
+function isSessionAlreadyCompacted(sessionManager: SessionManagerLike): boolean {
+  const branch = sessionManager.getBranch();
+  return branch[branch.length - 1]?.type === "compaction";
+}
+
 function resolveSessionTokenSnapshot(sessionEntry: SessionEntry | undefined): number | undefined {
   return resolvePositiveInteger(
     sessionEntry?.totalTokensFresh === false ? undefined : sessionEntry?.totalTokens,
@@ -553,6 +558,10 @@ export async function runCliTurnCompactionLifecycle(params: {
     !preemptiveCompaction.shouldCompact &&
     currentTokenCount <= preemptiveCompaction.promptBudgetBeforeReserve
   ) {
+    return params.sessionEntry;
+  }
+
+  if (isSessionAlreadyCompacted(sessionManager)) {
     return params.sessionEntry;
   }
 


### PR DESCRIPTION
## Summary

- rethrow mid-turn precheck signals before persisting assistant failure messages
- let the lower-level Agent lifecycle bubble the same signal to overflow recovery
- skip CLI transcript compaction when the session branch is already compacted

## Why

Mid-turn tool-result precheck throws `MidTurnPrecheckSignal` so the embedded runner can compact and retry before the next model call. Both harness and lower-level agent lifecycle paths must let that control-flow signal escape instead of writing an assistant error. After recovery, the CLI lifecycle can see the session still over its budget and try to compact again; if the branch already ends with a compaction entry, that second pass should be treated as complete instead of failing with `Already compacted`.

## Validation

- patched local OpenClaw runtime and restarted gateway
- forced `agents.defaults.contextTokens=90000` during testing to trigger mid-turn pressure
- verified CLI returns `status: "ok"` with final output `MIDTURN_COMPACT_FINAL_OK`
- verified session JSONL has `compactions=1`, `assistantErrors=0`, final assistant `stop`