### PR TITLE
fix(anthropic): prevent stale signed thinking replay for non-Fable-5 models (#99387)

### DIFF
--- a/src/agents/anthropic-transport-stream.ts
+++ b/src/agents/anthropic-transport-stream.ts
@@ -366,7 +366,12 @@ function convertAnthropicMessages(
   const allowReasoningContentReplay = options?.allowReasoningContentReplay === true;
   const replayThinkingEnabled = options?.replayThinkingEnabled !== false;
   const transformedMessages = transformTransportMessages(messages, model, normalizeToolCallId);
-  const activeToolTurnAssistantIndex = replayThinkingEnabled
+  // Only Fable 5 natively preserves signed thinking blocks across all turns.
+  // Non-Fable-5 models (e.g. Sonnet 4.6) with thinking enabled should only
+  // replay thinking for the active tool turn — completed turns' signatures are
+  // cryptographically bound to a prior request context and the API rejects them.
+  const preserveAllThinking = replayThinkingEnabled && usesClaudeFable5MessagesContract(model);
+  const activeToolTurnAssistantIndex = preserveAllThinking
     ? -1
     : findActiveAnthropicToolTurnAssistantIndex(transformedMessages);
   for (let i = 0; i < transformedMessages.length; i += 1) {
@@ -434,7 +439,7 @@ function convertAnthropicMessages(
         if (block.type === "thinking") {
           const thinkingSignature = block.thinkingSignature?.trim();
           const isReasoningContent = thinkingSignature === "reasoning_content";
-          if (!replayThinkingEnabled && i !== activeToolTurnAssistantIndex && !isReasoningContent) {
+          if (!preserveAllThinking && i !== activeToolTurnAssistantIndex && !isReasoningContent) {
             omittedThinking = true;
             continue;
           }

--- a/src/llm/providers/anthropic.ts
+++ b/src/llm/providers/anthropic.ts
@@ -1180,7 +1180,12 @@ function convertMessages(
 
   // Transform messages for cross-provider compatibility
   const transformedMessages = transformMessages(messages, model, normalizeToolCallId);
-  const activeToolTurnAssistantIndex = replayThinkingEnabled
+  // Only Fable 5 natively preserves signed thinking blocks across all turns.
+  // Non-Fable-5 models (e.g. Sonnet 4.6) with thinking enabled should only
+  // replay thinking for the active tool turn — completed turns' signatures are
+  // cryptographically bound to a prior request context and the API rejects them.
+  const preserveAllThinking = replayThinkingEnabled && usesClaudeFable5MessagesContract(model);
+  const activeToolTurnAssistantIndex = preserveAllThinking
     ? -1
     : findActiveAnthropicToolTurnAssistantIndex(transformedMessages);
 
@@ -1240,7 +1245,7 @@ function convertMessages(
             text: sanitizeSurrogates(block.text),
           });
         } else if (block.type === "thinking") {
-          if (!replayThinkingEnabled && i !== activeToolTurnAssistantIndex) {
+          if (!preserveAllThinking && i !== activeToolTurnAssistantIndex) {
             omittedThinking = true;
             continue;
           }


### PR DESCRIPTION
## What Problem This Solves

Non-Fable-5 Anthropic models with thinking enabled (e.g. `claude-sonnet-4-6`) intermittently fail with "provider rejected the request schema or tool payload" during tool-heavy conversations. The error fires 2-3 times in a 5-minute window and requires `/new` to recover.

**Root cause:** `replayThinkingEnabled` is set to `true` for ANY model with thinking enabled (not just Fable 5). This causes the message converters to replay ALL signed thinking blocks from ALL prior turns, including completed turns whose cryptographic signatures are bound to a prior request context. The Anthropic API rejects these stale signatures.

## Evidence

### Tests
- `src/llm/providers/anthropic.test.ts` — **37 passed** ✅
- `src/agents/anthropic-transport-stream.test.ts` — **164 passed** ✅
- `src/agents/embedded-agent-runner/thinking.test.ts` — **96 passed** ✅
- TypeScript type-check — **passed** ✅

### Code Analysis

The bug is in two symmetric code paths:

**1. `src/llm/providers/anthropic.ts:1183-1185` (and line 1243):**
```typescript
// BEFORE (bug):
const activeToolTurnAssistantIndex = replayThinkingEnabled
  ? -1  // forces ALL thinking blocks preserved for non-Fable-5 models too
  : findActiveAnthropicToolTurnAssistantIndex(transformedMessages);

// at line 1243:
if (!replayThinkingEnabled && i !== activeToolTurnAssistantIndex) {
  // never reached when replayThinkingEnabled=true — no filtering at all
}
```

**2. `src/agents/anthropic-transport-stream.ts:369-371` (and line 437):** identical pattern.

**How `replayThinkingEnabled` becomes `true` for non-Fable-5 models** (`anthropic.ts:1055-1056`):
```typescript
const fable5 = usesClaudeFable5MessagesContract(model); // false for sonnet-4-6
const replayThinkingEnabled = fable5 || options?.thinkingEnabled === true; 
// → true because requiresClaudeAdaptiveThinking forces thinkingEnabled
```

`requiresClaudeAdaptiveThinking` (in `packages/llm-core/src/model-contracts/anthropic.ts:57`) matches `sonnet-4-6`, so adaptive thinking is mandatory, making `replayThinkingEnabled=true` for a non-Fable-5 model. But the converter treats this identically to Fable 5 — preserving ALL thinking signatures.

### Affected Models
`claude-sonnet-4-6`, `claude-opus-4-5`, `claude-opus-4-6`, `claude-opus-4-7`, `claude-opus-4-8`, `claude-haiku-4-5` — all non-`claude-fable-5` Claude 4.5+ models with thinking enabled.

### Fix Summary

Introduces `preserveAllThinking` boolean that is only `true` when BOTH `replayThinkingEnabled` AND Fable 5 model contract are confirmed:

```typescript
const preserveAllThinking =
  replayThinkingEnabled && usesClaudeFable5MessagesContract(model);
```

Non-Fable-5 models now always compute `activeToolTurnAssistantIndex` via `findActiveAnthropicToolTurnAssistantIndex`, limiting thinking replay to the active tool turn only.

| Model | Before | After |
|-------|--------|-------|
| `claude-fable-5` | Preserve all thinking | Preserve all thinking (unchanged) |
| `claude-sonnet-4-6` + thinking | Preserve all thinking ❌ | Only active tool turn thinking ✅ |
| Models without thinking | Only active tool turn | Only active tool turn (unchanged) |

### Existing APIs Reused
- `usesClaudeFable5MessagesContract` (already imported in both files)
- `findActiveAnthropicToolTurnAssistantIndex` (already imported in both files)

Zero new imports, zero new functions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)