### PR TITLE
fix(signal): bound container websocket payload at 16 MiB

### DIFF
--- a/extensions/signal/src/client-container.ts
+++ b/extensions/signal/src/client-container.ts
@@ -53,6 +53,7 @@ export type ContainerWebSocketMessage = {
 };
 
 const DEFAULT_TIMEOUT_MS = 10_000;
+const SIGNAL_WS_MAX_PAYLOAD_BYTES = 16 * 1024 * 1024;
 const DEFAULT_ATTACHMENT_RESPONSE_MAX_BYTES = 1_048_576;
 const CONTAINER_TEXT_STYLE_MARKERS: Record<string, string> = {
   BOLD: "**",
@@ -176,7 +177,7 @@ function containerReceiveCheck(
       resolve(result);
     };
     try {
-      ws = new WebSocket(wsUrl);
+      ws = new WebSocket(wsUrl, { maxPayload: SIGNAL_WS_MAX_PAYLOAD_BYTES });
     } catch (err) {
       settle({
         ok: false,
@@ -328,7 +329,7 @@ export async function streamContainerEvents(params: {
     };
 
     try {
-      ws = new WebSocket(wsUrl);
+      ws = new WebSocket(wsUrl, { maxPayload: SIGNAL_WS_MAX_PAYLOAD_BYTES });
     } catch (err) {
       logError(
         `[signal-ws] failed to create WebSocket: ${err instanceof Error ? err.message : String(err)}`,


### PR DESCRIPTION
## What Problem This Solves

The `ws` library constructor defaults to 100 MiB `maxPayload`. The Signal
container WS client creates two WebSocket connections without an explicit
limit, so a misbehaving container could send oversized frames that exhaust
gateway memory.

## Why This Change Was Made

Add `maxPayload: SIGNAL_WS_MAX_PAYLOAD_BYTES` (16 MiB) to both `new WebSocket`
constructors. The `ws` library enforces this internally: frames exceeding the
limit are rejected with close code 1009 (Message Too Big).

## Evidence

```diff
-      ws = new WebSocket(wsUrl);
+      ws = new WebSocket(wsUrl, { maxPayload: SIGNAL_WS_MAX_PAYLOAD_BYTES });
```

Real behavior proof — `ws` library rejects oversized frames when maxPayload is set:

```text
RangeError: Max payload size exceeded
    at Receiver.haveLength (.../ws/lib/receiver.js:441:28)
    ...
    code: 'WS_ERR_UNSUPPORTED_MESSAGE_LENGTH',
    Symbol(status-code): 1009
```

AI-assisted: built with Codex
