### PR TITLE
Add Arven Memory provider plugin

### DIFF
--- a/docs/concepts/memory-arven.md
+++ b/docs/concepts/memory-arven.md
@@ -1,0 +1,90 @@
+---
+title: "Arven Memory"
+summary: "Use Arven Memory as an OpenClaw memory slot through the bundled MCP adapter"
+read_when:
+  - You want OpenClaw's memory dropdown to include Arven Memory
+  - You want legacy memory provider configs to point at Arven Memory
+  - You need a memory backend that survives OpenClaw UI updates
+---
+
+# Arven Memory
+
+The bundled `arven-memory` plugin lets OpenClaw use an Arven Memory MCP bridge
+as the active memory slot. It is intentionally implemented as a normal plugin,
+not a UI patch, so provider selection keeps working when OpenClaw UI surfaces
+change.
+
+## Configuration
+
+Point the plugin at the Arven HTTP MCP endpoint and select it as the memory
+slot:
+
+```json5
+{
+  plugins: {
+    entries: {
+      "arven-memory": {
+        enabled: true,
+        config: {
+          baseUrl: "http://127.0.0.1:8765/mcp",
+          authHeaderEnv: "ARVEN_MEMORY_AUTH_HEADER", // optional
+        },
+      },
+    },
+    slots: {
+      memory: "arven-memory",
+    },
+  },
+}
+```
+
+The plugin registers `arven_memory_recall`, `arven_memory_get`,
+`arven_memory_store`, and `arven_memory_status`. It also aliases recall/get to
+the standard `memory_search` and `memory_get` tool names so agents can keep
+using the normal memory tool surface when the Arven slot is selected.
+
+## Bridge tool names
+
+By default, the adapter calls these MCP tools on the configured endpoint:
+
+| Adapter action | MCP tool        |
+| -------------- | --------------- |
+| Recall         | `memory_search` |
+| Get            | `memory_get`    |
+| Store          | `memory_store`  |
+| Status         | `memory_status` |
+
+If the Arven bridge exposes different names, override them in plugin config:
+
+```json5
+{
+  plugins: {
+    entries: {
+      "arven-memory": {
+        config: {
+          baseUrl: "http://127.0.0.1:8765/mcp",
+          recallTool: "arven_recall",
+          getTool: "arven_get",
+          storeTool: "arven_store",
+          statusTool: "arven_status",
+        },
+      },
+    },
+    slots: { memory: "arven-memory" },
+  },
+}
+```
+
+## Legacy provider compatibility
+
+For configs or migrations that previously used a memory provider string, map
+the provider to the OpenClaw slot instead of editing the dropdown:
+
+| Provider value | OpenClaw slot config                    |
+| -------------- | --------------------------------------- |
+| `arven`        | `plugins.slots.memory = "arven-memory"` |
+| `arven-memory` | `plugins.slots.memory = "arven-memory"` |
+
+This keeps the integration update-agnostic: importers can continue to emit a
+provider label, while OpenClaw resolves the active backend through the plugin
+manifest and slot registry.

--- a/docs/docs_map.md
+++ b/docs/docs_map.md
@@ -2381,6 +2381,15 @@ Do not edit it by hand; run `pnpm docs:map:gen`.
   - H2: Common gotchas
   - H2: Related
 
+## concepts/memory-arven.md
+
+- Route: /concepts/memory-arven
+- Headings:
+  - H1: Arven Memory
+  - H2: Configuration
+  - H2: Bridge tool names
+  - H2: Legacy provider compatibility
+
 ## concepts/memory-builtin.md
 
 - Route: /concepts/memory-builtin
@@ -5785,6 +5794,14 @@ Do not edit it by hand; run `pnpm docs:map:gen`.
   - H2: Distribution
   - H2: Surface
   - H2: Related docs
+
+## plugins/reference/arven-memory.md
+
+- Route: /plugins/reference/arven-memory
+- Headings:
+  - H1: Arven Memory plugin
+  - H2: Distribution
+  - H2: Surface
 
 ## plugins/reference/azure-speech.md
 

--- a/docs/plugins/plugin-inventory.md
+++ b/docs/plugins/plugin-inventory.md
@@ -51,13 +51,15 @@ Each entry lists the package, distribution route, and description.
 
 ## Core npm package
 
-59 plugins
+60 plugins
 
 - **[admin-http-rpc](/plugins/reference/admin-http-rpc)** (`@openclaw/admin-http-rpc`) - included in OpenClaw. OpenClaw admin HTTP RPC endpoint.
 
 - **[alibaba](/plugins/reference/alibaba)** (`@openclaw/alibaba-provider`) - included in OpenClaw. Adds video generation provider support.
 
 - **[anthropic](/plugins/reference/anthropic)** (`@openclaw/anthropic-provider`) - included in OpenClaw. Adds Anthropic model provider support to OpenClaw.
+
+- **[arven-memory](/plugins/reference/arven-memory)** (`-`) - included in OpenClaw. Adds agent-callable tools.
 
 - **[azure-speech](/plugins/reference/azure-speech)** (`@openclaw/azure-speech`) - included in OpenClaw. Azure AI Speech text-to-speech (MP3, native Ogg/Opus voice notes, PCM telephony).
 

--- a/docs/plugins/reference.md
+++ b/docs/plugins/reference.md
@@ -15,5 +15,5 @@ This page is generated from `extensions/*/package.json` and
 pnpm plugins:inventory:gen
 ```
 
-Use [Plugin inventory](/plugins/plugin-inventory) to browse all 129
+Use [Plugin inventory](/plugins/plugin-inventory) to browse all 130
 generated plugin reference pages by distribution, package, and description.

--- a/docs/plugins/reference/arven-memory.md
+++ b/docs/plugins/reference/arven-memory.md
@@ -1,0 +1,19 @@
+---
+summary: "Adds agent-callable tools."
+read_when:
+  - You are installing, configuring, or auditing the arven-memory plugin
+title: "Arven Memory plugin"
+---
+
+# Arven Memory plugin
+
+Adds agent-callable tools.
+
+## Distribution
+
+- Package: `-`
+- Install route: included in OpenClaw
+
+## Surface
+
+contracts: tools

--- a/docs/plugins/reference/ollama.md
+++ b/docs/plugins/reference/ollama.md
@@ -16,7 +16,7 @@ Adds Ollama, Ollama Cloud model provider support to OpenClaw.
 
 ## Surface
 
-providers: ollama, ollama-cloud; contracts: memoryEmbeddingProviders, webSearchProviders
+providers: ollama, ollama-cloud; contracts: memoryEmbeddingProviders, tools, webSearchProviders
 
 ## Related docs
 

--- a/extensions/arven-memory/index.test.ts
+++ b/extensions/arven-memory/index.test.ts
@@ -1,0 +1,212 @@
+import { describe, expect, it, vi } from "vitest";
+import arvenMemoryPlugin from "./index.js";
+
+const { fetchWithSsrFGuardMock } = vi.hoisted(() => ({
+  fetchWithSsrFGuardMock: vi.fn(),
+}));
+
+vi.mock("openclaw/plugin-sdk/ssrf-runtime", () => ({
+  fetchWithSsrFGuard: fetchWithSsrFGuardMock,
+  ssrfPolicyFromHttpBaseUrlAllowedOrigin: (baseUrl: string) => ({
+    allowedOrigins: [new URL(baseUrl).origin.toLowerCase()],
+  }),
+}));
+
+function registerPlugin(config: Record<string, unknown>) {
+  const registrations: Array<{ tool: any; opts: { names?: string[] } }> = [];
+  arvenMemoryPlugin.register({
+    pluginConfig: config,
+    logger: {
+      debug: vi.fn(),
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+    },
+    registerTool: (tool: any, opts: { names?: string[] }) => registrations.push({ tool, opts }),
+  } as any);
+  return registrations;
+}
+
+function findRegisteredTool(
+  registrations: Array<{ tool: any; opts: { names?: string[] } }>,
+  name: string,
+) {
+  const tool = registrations.find((entry) => entry.opts.names?.includes(name))?.tool;
+  if (!tool) {
+    throw new Error(`${name} tool was not registered`);
+  }
+  return tool;
+}
+
+describe("arven-memory plugin", () => {
+  it("declares itself as a memory slot plugin", () => {
+    expect(arvenMemoryPlugin.id).toBe("arven-memory");
+    expect(arvenMemoryPlugin.kind).toBe("memory");
+  });
+
+  it("registers compatibility and namespaced tools", () => {
+    const registrations = registerPlugin({ baseUrl: "http://127.0.0.1:8765/mcp" });
+    const names = registrations.flatMap((entry) => entry.opts.names ?? []);
+
+    expect(names).toContain("arven_memory_recall");
+    expect(names).toContain("memory_search");
+    expect(names).toContain("arven_memory_get");
+    expect(names).toContain("memory_get");
+    expect(names).toContain("arven_memory_store");
+    expect(names).toContain("arven_memory_status");
+  });
+
+  it("calls the configured MCP recall tool through the guarded fetch path", async () => {
+    const release = vi.fn();
+    fetchWithSsrFGuardMock.mockResolvedValueOnce({
+      release,
+      response: {
+        ok: true,
+        json: async () => ({
+          jsonrpc: "2.0",
+          result: {
+            content: [{ type: "text", text: "matched memory" }],
+          },
+        }),
+      },
+    });
+
+    try {
+      const registrations = registerPlugin({
+        baseUrl: "http://127.0.0.1:8765/mcp",
+        recallTool: "arven_recall",
+      });
+      const recall = findRegisteredTool(registrations, "arven_memory_recall");
+      const result = await recall.execute("call-1", { query: "release gate", limit: 3 });
+
+      expect(fetchWithSsrFGuardMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          url: "http://127.0.0.1:8765/mcp",
+          auditContext: "arven-memory.mcp",
+          policy: { allowedOrigins: ["http://127.0.0.1:8765"] },
+          timeoutMs: 10000,
+          init: expect.objectContaining({
+            method: "POST",
+            body: expect.stringContaining('"name":"arven_recall"'),
+          }),
+        }),
+      );
+      expect(fetchWithSsrFGuardMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          init: expect.objectContaining({
+            body: expect.stringContaining('"query":"release gate"'),
+          }),
+        }),
+      );
+      expect(fetchWithSsrFGuardMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          init: expect.objectContaining({
+            body: expect.stringContaining('"question":"release gate"'),
+          }),
+        }),
+      );
+      expect(fetchWithSsrFGuardMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          init: expect.objectContaining({
+            headers: expect.objectContaining({
+              accept: "application/json",
+              "content-type": "application/json",
+            }),
+          }),
+        }),
+      );
+      expect(release).toHaveBeenCalled();
+      expect(result.content[0].text).toBe("matched memory");
+    } finally {
+      fetchWithSsrFGuardMock.mockReset();
+    }
+  });
+
+  it("threads optional authorization headers from env without storing credentials", async () => {
+    const release = vi.fn();
+    fetchWithSsrFGuardMock.mockResolvedValueOnce({
+      release,
+      response: {
+        ok: true,
+        json: async () => ({
+          jsonrpc: "2.0",
+          result: "ok",
+        }),
+      },
+    });
+    process.env.ARVEN_TEST_AUTH_HEADER = "Bearer test-token";
+
+    try {
+      const registrations = registerPlugin({
+        baseUrl: "http://127.0.0.1:8765/mcp",
+        authHeaderEnv: "ARVEN_TEST_AUTH_HEADER",
+      });
+      const status = findRegisteredTool(registrations, "arven_memory_status");
+      await status.execute("call-1", {});
+
+      expect(fetchWithSsrFGuardMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          init: expect.objectContaining({
+            headers: expect.objectContaining({
+              authorization: "Bearer test-token",
+            }),
+          }),
+        }),
+      );
+    } finally {
+      delete process.env.ARVEN_TEST_AUTH_HEADER;
+      fetchWithSsrFGuardMock.mockReset();
+    }
+  });
+
+  it("uses configured timeout and releases guarded fetch resources on MCP errors", async () => {
+    const release = vi.fn();
+    fetchWithSsrFGuardMock.mockResolvedValueOnce({
+      release,
+      response: {
+        ok: true,
+        json: async () => ({
+          jsonrpc: "2.0",
+          error: { code: -32000, message: "bridge failed" },
+        }),
+      },
+    });
+
+    try {
+      const registrations = registerPlugin({
+        baseUrl: "http://127.0.0.1:8765/mcp",
+        timeoutMs: 2500,
+      });
+      const status = findRegisteredTool(registrations, "arven_memory_status");
+
+      await expect(status.execute("call-1", {})).rejects.toThrow("bridge failed");
+      expect(fetchWithSsrFGuardMock).toHaveBeenCalledWith(
+        expect.objectContaining({ timeoutMs: 2500 }),
+      );
+      expect(release).toHaveBeenCalled();
+    } finally {
+      fetchWithSsrFGuardMock.mockReset();
+    }
+  });
+
+  it("reports HTTP failures and releases guarded fetch resources", async () => {
+    const release = vi.fn();
+    fetchWithSsrFGuardMock.mockResolvedValueOnce({
+      release,
+      response: {
+        ok: false,
+        status: 503,
+      },
+    });
+
+    try {
+      const registrations = registerPlugin({ baseUrl: "http://127.0.0.1:8765/mcp" });
+      const status = findRegisteredTool(registrations, "arven_memory_status");
+
+      await expect(status.execute("call-1", {})).rejects.toThrow("Arven Memory HTTP 503");
+      expect(release).toHaveBeenCalled();
+    } finally {
+      fetchWithSsrFGuardMock.mockReset();
+    }
+  });
+});

--- a/extensions/arven-memory/index.ts
+++ b/extensions/arven-memory/index.ts
@@ -1,0 +1,257 @@
+import { definePluginEntry } from "openclaw/plugin-sdk/plugin-entry";
+import {
+  fetchWithSsrFGuard,
+  ssrfPolicyFromHttpBaseUrlAllowedOrigin,
+} from "openclaw/plugin-sdk/ssrf-runtime";
+
+type ArvenMemoryConfig = {
+  baseUrl: string;
+  authHeaderEnv?: string;
+  recallTool?: string;
+  getTool?: string;
+  storeTool?: string;
+  statusTool?: string;
+  timeoutMs?: number;
+};
+
+type JsonRpcResponse = {
+  result?: unknown;
+  error?: {
+    code?: number;
+    message?: string;
+    data?: unknown;
+  };
+};
+
+const DEFAULT_TIMEOUT_MS = 10000;
+
+function asConfig(value: Record<string, unknown> | undefined): ArvenMemoryConfig {
+  const cfg = value ?? {};
+  return {
+    baseUrl: typeof cfg.baseUrl === "string" ? cfg.baseUrl.trim() : "",
+    authHeaderEnv: typeof cfg.authHeaderEnv === "string" ? cfg.authHeaderEnv.trim() : undefined,
+    recallTool: typeof cfg.recallTool === "string" ? cfg.recallTool.trim() : undefined,
+    getTool: typeof cfg.getTool === "string" ? cfg.getTool.trim() : undefined,
+    storeTool: typeof cfg.storeTool === "string" ? cfg.storeTool.trim() : undefined,
+    statusTool: typeof cfg.statusTool === "string" ? cfg.statusTool.trim() : undefined,
+    timeoutMs: typeof cfg.timeoutMs === "number" ? cfg.timeoutMs : DEFAULT_TIMEOUT_MS,
+  };
+}
+
+function resultText(payload: unknown): string {
+  if (payload && typeof payload === "object" && "content" in payload) {
+    const content = (payload as { content?: unknown }).content;
+    if (Array.isArray(content)) {
+      const text = content
+        .map((item) =>
+          item && typeof item === "object" && "text" in item
+            ? typeof (item as { text?: unknown }).text === "string"
+              ? (item as { text: string }).text
+              : ""
+            : "",
+        )
+        .filter(Boolean)
+        .join("\n");
+      if (text) {
+        return text;
+      }
+    }
+  }
+  if (typeof payload === "string") {
+    return payload;
+  }
+  return JSON.stringify(payload, null, 2);
+}
+
+async function callMcpTool(
+  cfg: ArvenMemoryConfig,
+  toolName: string,
+  args: Record<string, unknown>,
+) {
+  if (!cfg.baseUrl) {
+    throw new Error("Arven Memory baseUrl is required.");
+  }
+
+  const headers: Record<string, string> = {
+    "content-type": "application/json",
+    accept: "application/json",
+  };
+  if (cfg.authHeaderEnv) {
+    const auth = process.env[cfg.authHeaderEnv];
+    if (auth) {
+      headers.authorization = auth;
+    }
+  }
+
+  const { response, release } = await fetchWithSsrFGuard({
+    url: cfg.baseUrl,
+    init: {
+      method: "POST",
+      headers,
+      body: JSON.stringify({
+        jsonrpc: "2.0",
+        id: `arven-memory-${Date.now()}`,
+        method: "tools/call",
+        params: {
+          name: toolName,
+          arguments: args,
+        },
+      }),
+    },
+    timeoutMs: cfg.timeoutMs ?? DEFAULT_TIMEOUT_MS,
+    policy: ssrfPolicyFromHttpBaseUrlAllowedOrigin(cfg.baseUrl),
+    auditContext: "arven-memory.mcp",
+  });
+
+  try {
+    if (!response.ok) {
+      throw new Error(`Arven Memory HTTP ${response.status}`);
+    }
+
+    const payload = (await response.json()) as JsonRpcResponse;
+    if (payload.error) {
+      throw new Error(
+        payload.error.message ?? `Arven Memory MCP error ${payload.error.code ?? ""}`,
+      );
+    }
+    return payload.result;
+  } finally {
+    await release();
+  }
+}
+
+export const arvenMemoryConfigJsonSchema = {
+  type: "object",
+  additionalProperties: false,
+  properties: {
+    baseUrl: { type: "string" },
+    authHeaderEnv: { type: "string" },
+    recallTool: { type: "string" },
+    getTool: { type: "string" },
+    storeTool: { type: "string" },
+    statusTool: { type: "string" },
+    timeoutMs: { type: "number", minimum: 1000, maximum: 120000 },
+  },
+  required: ["baseUrl"],
+} as const;
+
+const recallParameters = {
+  type: "object",
+  additionalProperties: false,
+  properties: {
+    query: { type: "string", description: "Search query" },
+    limit: { type: "number", description: "Maximum result count" },
+  },
+  required: ["query"],
+} as const;
+
+const getParameters = {
+  type: "object",
+  additionalProperties: false,
+  properties: {
+    id: { type: "string", description: "Memory item id or URI" },
+  },
+  required: ["id"],
+} as const;
+
+const storeParameters = {
+  type: "object",
+  additionalProperties: false,
+  properties: {
+    text: { type: "string", description: "Memory text to store" },
+    project: { type: "string", description: "Optional project or namespace" },
+  },
+  required: ["text"],
+} as const;
+
+const emptyParameters = {
+  type: "object",
+  additionalProperties: false,
+  properties: {},
+} as const;
+
+export default definePluginEntry({
+  id: "arven-memory",
+  name: "Arven Memory",
+  description: "Update-stable MCP adapter for Arven Memory",
+  kind: "memory" as const,
+  configSchema: { jsonSchema: arvenMemoryConfigJsonSchema },
+  register(api) {
+    const cfg = asConfig(api.pluginConfig);
+    const recallTool = cfg.recallTool || "memory_search";
+    const getTool = cfg.getTool || "memory_get";
+    const storeTool = cfg.storeTool || "memory_store";
+    const statusTool = cfg.statusTool || "memory_status";
+
+    api.registerTool(
+      {
+        name: "arven_memory_recall",
+        label: "Arven Memory Recall",
+        description: "Search Arven Memory through the configured MCP bridge.",
+        parameters: recallParameters,
+        async execute(_toolCallId, params) {
+          const { query, limit } = params as { query: string; limit?: number };
+          const result = await callMcpTool(cfg, recallTool, { query, question: query, limit });
+          return {
+            content: [{ type: "text" as const, text: resultText(result) }],
+            details: result,
+          };
+        },
+      },
+      { names: ["arven_memory_recall", "memory_search"] },
+    );
+
+    api.registerTool(
+      {
+        name: "arven_memory_get",
+        label: "Arven Memory Get",
+        description: "Fetch a specific Arven Memory item through the configured MCP bridge.",
+        parameters: getParameters,
+        async execute(_toolCallId, params) {
+          const { id } = params as { id: string };
+          const result = await callMcpTool(cfg, getTool, { id });
+          return {
+            content: [{ type: "text" as const, text: resultText(result) }],
+            details: result,
+          };
+        },
+      },
+      { names: ["arven_memory_get", "memory_get"] },
+    );
+
+    api.registerTool(
+      {
+        name: "arven_memory_store",
+        label: "Arven Memory Store",
+        description: "Store durable memory through the configured Arven MCP bridge.",
+        parameters: storeParameters,
+        async execute(_toolCallId, params) {
+          const { text, project } = params as { text: string; project?: string };
+          const result = await callMcpTool(cfg, storeTool, { text, project });
+          return {
+            content: [{ type: "text" as const, text: resultText(result) }],
+            details: result,
+          };
+        },
+      },
+      { names: ["arven_memory_store"] },
+    );
+
+    api.registerTool(
+      {
+        name: "arven_memory_status",
+        label: "Arven Memory Status",
+        description: "Check the configured Arven Memory MCP bridge.",
+        parameters: emptyParameters,
+        async execute() {
+          const result = await callMcpTool(cfg, statusTool, {});
+          return {
+            content: [{ type: "text" as const, text: resultText(result) }],
+            details: result,
+          };
+        },
+      },
+      { names: ["arven_memory_status"] },
+    );
+  },
+});

--- a/extensions/arven-memory/openclaw.plugin.json
+++ b/extensions/arven-memory/openclaw.plugin.json
@@ -1,0 +1,83 @@
+{
+  "id": "arven-memory",
+  "kind": "memory",
+  "contracts": {
+    "tools": [
+      "arven_memory_recall",
+      "arven_memory_get",
+      "arven_memory_store",
+      "arven_memory_status",
+      "memory_search",
+      "memory_get"
+    ]
+  },
+  "uiHints": {
+    "baseUrl": {
+      "label": "Arven MCP URL",
+      "placeholder": "http://127.0.0.1:8765/mcp",
+      "help": "HTTP MCP endpoint for the Arven Memory bridge."
+    },
+    "authHeaderEnv": {
+      "label": "Auth Header Env",
+      "placeholder": "ARVEN_MEMORY_AUTH_HEADER",
+      "help": "Optional environment variable containing a full Authorization header value.",
+      "sensitive": true,
+      "advanced": true
+    },
+    "recallTool": {
+      "label": "Recall Tool",
+      "placeholder": "memory_search",
+      "advanced": true
+    },
+    "getTool": {
+      "label": "Get Tool",
+      "placeholder": "memory_get",
+      "advanced": true
+    },
+    "storeTool": {
+      "label": "Store Tool",
+      "placeholder": "memory_store",
+      "advanced": true
+    },
+    "statusTool": {
+      "label": "Status Tool",
+      "placeholder": "memory_status",
+      "advanced": true
+    },
+    "timeoutMs": {
+      "label": "Timeout",
+      "placeholder": "10000",
+      "advanced": true
+    }
+  },
+  "configSchema": {
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {
+      "baseUrl": {
+        "type": "string"
+      },
+      "authHeaderEnv": {
+        "type": "string"
+      },
+      "recallTool": {
+        "type": "string"
+      },
+      "getTool": {
+        "type": "string"
+      },
+      "storeTool": {
+        "type": "string"
+      },
+      "statusTool": {
+        "type": "string"
+      },
+      "timeoutMs": {
+        "type": "number",
+        "minimum": 1000,
+        "maximum": 120000
+      }
+    },
+    "required": ["baseUrl"]
+  }
+}

--- a/extensions/arven-memory/package.json
+++ b/extensions/arven-memory/package.json
@@ -1,0 +1,10 @@
+{
+  "private": true,
+  "description": "OpenClaw Arven Memory MCP adapter",
+  "type": "module",
+  "openclaw": {
+    "extensions": [
+      "./index.ts"
+    ]
+  }
+}


### PR DESCRIPTION
## What Problem This Solves

OpenClaw can select memory providers through plugin metadata and memory slots, but local/self-hosted Arven-compatible MCP memory bridges did not appear as a first-class bundled memory slot.

This adds an `arven-memory` bundled plugin that surfaces through the normal `kind: "memory"` manifest path and `plugins.slots.memory = "arven-memory"`, without hardcoding dropdown or UI provider lists.

## Evidence

- Local build passed: `corepack pnpm build`.
- Extension typecheck passed: `corepack pnpm tsgo:extensions`.
- Focused lint passed: `node_modules/.bin/oxlint extensions/arven-memory/index.ts extensions/arven-memory/index.test.ts`.
- Focused format check passed for the touched plugin/docs files.
- Contract coverage passed: `node_modules/.bin/vitest run extensions/arven-memory/index.test.ts src/plugins/contracts/plugin-tool-contracts.test.ts`.
- Bundled plugin/package contracts passed: `node_modules/.bin/vitest run src/plugins/bundled-plugin-naming.test.ts src/plugins/contracts/plugin-tool-contracts.test.ts` and `node_modules/.bin/vitest run test/plugin-npm-release.test.ts test/plugin-npm-package-manifest.test.ts`.
- Generated docs checks passed: `corepack pnpm docs:map:check`, `corepack pnpm plugins:inventory:check`, markdownlint, MDX, and link audit.
- Runtime dogfood smoke passed locally against a loopback MCP bridge: isolated `OPENCLAW_HOME` selected `plugins.slots.memory = "arven-memory"`; runtime inspection loaded the plugin and exposed `arven_memory_recall`, `memory_search`, `arven_memory_get`, `memory_get`, `arven_memory_store`, and `arven_memory_status`; calls reached configured bridge tool names (`custom_search`, `custom_get`, `custom_store`, `custom_status`).
- Real local Arven wrapper dogfood passed after recall argument compatibility fix: with `recallTool = "memory.recall"`, `memory_search` now forwards both `query` and `question`; local `http://127.0.0.1:8765/mcp` returned the requested question instead of an empty search.
- Security/privacy review passed: no secrets, tokens, private keys, personal identifiers, Telegram IDs, private machine names, or private local paths in the diff. Example endpoint is loopback only; optional auth is read from an operator-named environment variable and marked sensitive in UI hints.

## Design Notes

- Uses `kind: "memory"` plugin metadata.
- Bridges to a user-run local/self-hosted HTTP MCP endpoint.
- Uses OpenClaw's guarded fetch path with an explicit private-network policy because this adapter is intentionally for local/self-hosted MCP bridges.
- Tool names are configurable (`recallTool`, `getTool`, `storeTool`, `statusTool`) so bridge changes do not require OpenClaw code changes.