### PR TITLE
fix(openai): bound realtime voice websocket payload at 16 MiB

### DIFF
--- a/extensions/openai/realtime-voice-provider.test.ts
+++ b/extensions/openai/realtime-voice-provider.test.ts
@@ -333,13 +333,16 @@ describe("buildOpenAIRealtimeVoiceProvider", () => {
     bridge.close();
 
     const socket = FakeWebSocket.instances[0];
-    const options = socket?.args[1] as { headers?: Record<string, string> } | undefined;
+    const options = socket?.args[1] as
+      | { headers?: Record<string, string>; maxPayload?: number }
+      | undefined;
     expectRecordFields(options?.headers, "websocket headers", {
       originator: "openclaw",
       version: "2026.3.22",
       "User-Agent": "openclaw/2026.3.22",
     });
     expect(options?.headers).not.toHaveProperty("OpenAI-Beta");
+    expect(options?.maxPayload).toBe(16 * 1024 * 1024);
   });
 
   it("requires a Platform API key for native realtime websocket bridges", async () => {

--- a/extensions/openai/realtime-voice-provider.ts
+++ b/extensions/openai/realtime-voice-provider.ts
@@ -93,6 +93,7 @@ const OPENAI_REALTIME_ACTIVE_RESPONSE_ERROR_PREFIX =
 const OPENAI_REALTIME_NO_ACTIVE_RESPONSE_CANCEL_ERROR =
   "Cancellation failed: no active response found";
 const OPENAI_REALTIME_MAX_SESSION_DURATION_FRAGMENT = "maximum duration";
+const OPENAI_VOICE_WS_MAX_PAYLOAD_BYTES = 16 * 1024 * 1024;
 const OPENAI_REALTIME_DEFAULT_MIN_BARGE_IN_AUDIO_END_MS = 250;
 // Realtime validates this character set but accepts names beyond the 64-character
 // cap used by other OpenAI tool surfaces.
@@ -616,6 +617,7 @@ class OpenAIRealtimeVoiceBridge implements RealtimeVoiceBridge {
         const proxyAgent = createDebugProxyWebSocketAgent(debugProxy);
         const ws = new WebSocket(connection.url, {
           headers: connection.headers,
+          maxPayload: OPENAI_VOICE_WS_MAX_PAYLOAD_BYTES,
           ...(proxyAgent ? { agent: proxyAgent } : {}),
         });
         this.ws = ws;


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where the OpenAI realtime voice backend WebSocket could accept inbound frames up to the `ws` dependency default of 100 MiB when the provider path did not set an explicit payload cap.

## Why This Change Was Made

The OpenAI realtime voice bridge now passes `maxPayload: 16 * 1024 * 1024` to its backend WebSocket constructor. This is an intentional hardening cap for the provider relay path; frames above 16 MiB fail closed with WebSocket close status 1009.

## User Impact

Gateway voice sessions have a bounded inbound WebSocket frame size instead of inheriting the larger dependency default.

## Evidence

- `node --import tsx outputs/pr-99450/verify-openai-voice-ws-max-payload.mjs`: loopback proof through `buildOpenAIRealtimeVoiceProvider().createBridge()` and the realtime voice WebSocket constructor.

```text
[proof] provider=openai capability=realtime-voice maxPayload=16777216
[server] connection path=/v1/realtime?model=gpt-realtime-2
[server] observed client session frame bytes=447
[server] sent oversized frame bytes=16778240 limit=16777216
[client] connect rejected name=RangeError message="Max payload size exceeded" code=WS_ERR_UNSUPPORTED_MESSAGE_LENGTH status=1009
[server] close code=1009 reason=""
[proof] serverObservedClose1009=true
```

AI-assisted: built with Codex
