### PR TITLE
fix(subagents): sanitize subagent formatting and prevent internal content leakage

### DIFF
--- a/src/agents/subagent-announce-delivery.ts
+++ b/src/agents/subagent-announce-delivery.ts
@@ -77,6 +77,7 @@ import type { DeliveryContext } from "./subagent-announce-origin.js";
 import { getSubagentDepthFromSessionStore } from "./subagent-depth.js";
 import { resolveRequesterStoreKey } from "./subagent-requester-store-key.js";
 import type { SpawnSubagentMode } from "./subagent-spawn.types.js";
+import { isUnsafeSubagentDeliverableText } from "./subagent-announce-output.js";
 
 const DEFAULT_SUBAGENT_ANNOUNCE_TIMEOUT_MS = 120_000;
 type SubagentAnnounceDeliveryDeps = {
@@ -1020,7 +1021,7 @@ function resolveTextCompletionDirectFallback(events: readonly AgentInternalEvent
       continue;
     }
     const result = typeof event.result === "string" ? event.result.trim() : "";
-    if (result && result !== "(no output)") {
+    if (result && result !== "(no output)" && !isUnsafeSubagentDeliverableText(result)) {
       return result;
     }
   }

--- a/src/agents/subagent-announce-output.ts
+++ b/src/agents/subagent-announce-output.ts
@@ -183,14 +183,56 @@ function summarizeSubagentOutputHistory(messages: Array<unknown>): SubagentOutpu
   return snapshot;
 }
 
+export function isUnsafeSubagentDeliverableText(text: string | null | undefined): boolean {
+  const trimmed = text?.trim() ?? "";
+  if (!trimmed) {
+    return false;
+  }
+  if (trimmed.includes("<<<BEGIN_OPENCLAW_INTERNAL_CONTEXT>>>") || trimmed.includes("<<<END_OPENCLAW_INTERNAL_CONTEXT>>>")) {
+    return true;
+  }
+  if (trimmed.includes("<<<BEGIN_UNTRUSTED_CHILD_RESULT>>>") || trimmed.includes("<<<END_UNTRUSTED_CHILD_RESULT>>>")) {
+    return true;
+  }
+  if (trimmed.includes("<<<EXTERNAL_UNTRUSTED_CONTENT") || trimmed.includes("<<<END_EXTERNAL_UNTRUSTED_CONTENT")) {
+    return true;
+  }
+  if (/SECURITY NOTICE:\s*The following content is from an EXTERNAL, UNTRUSTED source/i.test(trimmed)) {
+    return true;
+  }
+  if (/"externalContent"\s*:\s*\{/.test(trimmed) && /"untrusted"\s*:\s*true/.test(trimmed)) {
+    return true;
+  }
+  if (/"sourceTool"\s*:\s*"subagent_announce"/.test(trimmed)) {
+    return true;
+  }
+  if (/^\s*\{[\s\S]*"url"\s*:[\s\S]*"status"\s*:[\s\S]*"contentType"\s*:[\s\S]*"text"\s*:/.test(trimmed)) {
+    return true;
+  }
+  try {
+    const parsed = JSON.parse(trimmed);
+    if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
+      const record = parsed as Record<string, unknown>;
+      const externalContent = record.externalContent;
+      if (externalContent && typeof externalContent === "object" && (externalContent as Record<string, unknown>).untrusted === true) {
+        return true;
+      }
+      if (typeof record.url === "string" && (typeof record.status === "number" || typeof record.status === "string") && typeof record.contentType === "string" && typeof record.text === "string") {
+        return true;
+      }
+    }
+  } catch {}
+  return false;
+}
+
 function selectSubagentOutputText(snapshot: SubagentOutputSnapshot): string | undefined {
   if (snapshot.waitingForContinuation) {
     return undefined;
   }
-  if (snapshot.latestSilentText) {
+  if (snapshot.latestSilentText && !isUnsafeSubagentDeliverableText(snapshot.latestSilentText)) {
     return snapshot.latestSilentText;
   }
-  if (snapshot.latestAssistantText) {
+  if (snapshot.latestAssistantText && !isUnsafeSubagentDeliverableText(snapshot.latestAssistantText)) {
     return snapshot.latestAssistantText;
   }
   if (snapshot.latestToolCallCount && snapshot.latestToolCallCount > 0) {
@@ -335,7 +377,7 @@ function formatChildResultData(resultText?: string | null): string {
   return (
     wrapPromptDataBlock({
       label: "Child result",
-      text: resultText?.trim() || "(no output)",
+      text: typeof resultText === "string" && resultText.trim() ? resultText : "(no output)",
     }) || "Child result: (no output)"
   );
 }


### PR DESCRIPTION
## Summary
This PR adds output sanitation to subagent completion formatting to prevent internal system delimiters, untrusted content markers, and raw wrapper payloads from leaking into user channels.

### Problems Solved
1. **Internal Delimiter Leakage**: Delimiters like `<<<BEGIN_OPENCLAW_INTERNAL_CONTEXT>>>`, `<<<BEGIN_UNTRUSTED_CHILD_RESULT>>>`, and security notice templates could leak directly to chats when a subagent fails or completes with unhandled output.
2. **Raw JSON Payload Leakage**: Raw JSON properties returned from CLI tools (like web_fetch results) were occasionally exposed, confusing messaging clients.
3. **Explicit Empty States**: Normalizes empty subagent runs to an explicit `(no output)` status block rather than failing format resolution or falling back to raw tool logs.

### Changes
* Introduced `isUnsafeSubagentDeliverableText(text)` checking for raw JSON shapes, security notice headers, and internal wrapper tags.
* Added sanitize check inside `selectSubagentOutputText` (output capture) and `resolveTextCompletionDirectFallback` (delivery).
* Added explicit fallbacks for empty event.result formatting in `formatChildResultData`.
