### PR TITLE
fix(subagents): fail closed on thread binding without routable delivery origin

### DIFF
--- a/src/agents/subagent-spawn.ts
+++ b/src/agents/subagent-spawn.ts
@@ -1418,6 +1418,22 @@ export async function spawnSubagentDirect(
     }
     threadBindingReady = true;
     hasBoundThreadDeliveryOrigin = hasRoutableDeliveryOrigin(bindResult.deliveryOrigin);
+    if (spawnMode === "session" && !hasBoundThreadDeliveryOrigin) {
+      try {
+        await callSubagentGateway({
+          method: "sessions.delete",
+          params: { key: childSessionKey, deleteTranscript: true, emitLifecycleHooks: false },
+          timeoutMs: SUBAGENT_CONTROL_GATEWAY_TIMEOUT_MS,
+        });
+      } catch {
+        // Best-effort cleanup only.
+      }
+      return {
+        status: "error",
+        error: "Thread-bound session hook returned threadBindingReady=true without a routable deliveryOrigin; refusing to mix bound-session delivery with auto-announce.",
+        childSessionKey,
+      };
+    }
     childSessionOrigin =
       mergeDeliveryContext(bindResult.deliveryOrigin, childSessionOrigin) ?? childSessionOrigin;
   }


### PR DESCRIPTION
## Summary
This PR enforces a fail-closed pattern when spawning a persistent thread-bound session subagent that fails to obtain a routable delivery origin during setup.

### Problems Solved
If a thread-bound session subagent (e.g. spawned via `sessions_spawn` with `spawnMode === "session"`) completes target binding successfully but without a routable `deliveryOrigin` (due to hook timeouts or channel anomalies), the provisional session is left alive, consuming context space and model API cycles, but remains unreachable for subsequent delivery or command routing.

### Changes
* Under `spawnMode === "session"`, if `hasBoundThreadDeliveryOrigin` yields `false` from `hasRoutableDeliveryOrigin(bindResult.deliveryOrigin)` but setup succeeds, the provisional child session is deleted immediately (`sessions.delete`).
* An explicit error is returned preventing the session state from drifting into an unrouted "zombie" state.
