### PR TITLE
fix: prevent doctor --fix from exiting 1 when shell completion install fails

### DIFF
--- a/src/commands/doctor-completion.test.ts
+++ b/src/commands/doctor-completion.test.ts
@@ -2,14 +2,25 @@
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { captureEnv, setTestEnvValue } from "../test-utils/env.js";
 import {
   checkShellCompletionStatus,
+  doctorShellCompletion,
   shellCompletionStatusToHealthFindings,
   shellCompletionStatusToRepairEffects,
   type ShellCompletionStatus,
 } from "./doctor-completion.js";
+
+const installCompletionMock = vi.hoisted(() => vi.fn());
+
+vi.mock("../cli/completion-runtime.js", async (importOriginal) => {
+  const original = (await importOriginal()) as Record<string, unknown>;
+  return {
+    ...original,
+    installCompletion: (...args: unknown[]) => installCompletionMock(...args),
+  };
+});
 
 const originalEnv = captureEnv(["HOME", "OPENCLAW_STATE_DIR", "SHELL"]);
 const tempDirs: string[] = [];
@@ -100,5 +111,63 @@ describe("shell completion health mapping", () => {
 
     expect(shellCompletionStatusToHealthFindings(current)).toEqual([]);
     expect(shellCompletionStatusToRepairEffects(current)).toEqual([]);
+  });
+});
+
+describe("doctorShellCompletion", () => {
+  beforeEach(() => {
+    installCompletionMock.mockReset();
+  });
+
+  it("does not throw when installCompletion fails with EACCES in the slow-pattern upgrade path", async () => {
+    const homeDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-completion-home-"));
+    const stateDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-completion-state-"));
+    tempDirs.push(homeDir, stateDir);
+    setTestEnvValue("HOME", homeDir);
+    setTestEnvValue("OPENCLAW_STATE_DIR", stateDir);
+    setTestEnvValue("SHELL", "/bin/zsh");
+
+    // Create .zshrc with a slow dynamic completion line so usesSlowDynamicCompletion is true
+    const zshrc = path.join(homeDir, ".zshrc");
+    await fs.writeFile(zshrc, "source <(openclaw completion zsh)\n", "utf8");
+
+    installCompletionMock.mockRejectedValue(
+      new Error("EACCES: permission denied, open '/some/.zshrc'"),
+    );
+
+    await expect(
+      doctorShellCompletion(
+        { log: vi.fn(), error: vi.fn() } as unknown as import("../runtime.js").RuntimeEnv,
+        {
+          confirm: vi.fn(),
+          shouldRepair: true,
+        } as unknown as import("./doctor-prompter.js").DoctorPrompter,
+        { nonInteractive: false },
+      ),
+    ).resolves.toBeUndefined();
+  });
+
+  it("does not throw when installCompletion fails with EACCES in the new-install path", async () => {
+    const homeDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-completion-home-"));
+    const stateDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-completion-state-"));
+    tempDirs.push(homeDir, stateDir);
+    setTestEnvValue("HOME", homeDir);
+    setTestEnvValue("OPENCLAW_STATE_DIR", stateDir);
+    setTestEnvValue("SHELL", "/bin/zsh");
+
+    installCompletionMock.mockRejectedValue(
+      new Error("EACCES: permission denied, open '/some/.zshrc'"),
+    );
+
+    await expect(
+      doctorShellCompletion(
+        { log: vi.fn(), error: vi.fn() } as unknown as import("../runtime.js").RuntimeEnv,
+        {
+          confirm: vi.fn().mockResolvedValue(true),
+          shouldRepair: true,
+        } as unknown as import("./doctor-prompter.js").DoctorPrompter,
+        { nonInteractive: false },
+      ),
+    ).resolves.toBeUndefined();
   });
 });

--- a/src/commands/doctor-completion.ts
+++ b/src/commands/doctor-completion.ts
@@ -195,8 +195,15 @@ export async function doctorShellCompletion(
       }
     }
 
-    await installCompletion(status.shell, true, cliName);
-    note(formatCompletionReloadNote(status.shell, "upgraded"), "Shell completion");
+    try {
+      await installCompletion(status.shell, true, cliName);
+      note(formatCompletionReloadNote(status.shell, "upgraded"), "Shell completion");
+    } catch {
+      note(
+        `Shell completion not installed: ${resolveCompletionProfilePath(status.shell)} is not writable. Run \`${cliName} completion install\` against a writable shell profile.`,
+        "Shell completion",
+      );
+    }
     return;
   }
 
@@ -237,8 +244,15 @@ export async function doctorShellCompletion(
         return;
       }
 
-      await installCompletion(status.shell, true, cliName);
-      note(formatCompletionReloadNote(status.shell, "installed"), "Shell completion");
+      try {
+        await installCompletion(status.shell, true, cliName);
+        note(formatCompletionReloadNote(status.shell, "installed"), "Shell completion");
+      } catch {
+        note(
+          `Shell completion not installed: ${resolveCompletionProfilePath(status.shell)} is not writable. Run \`${cliName} completion install\` against a writable shell profile.`,
+          "Shell completion",
+        );
+      }
     }
   }
 }


### PR DESCRIPTION
## What Problem This Solves

`openclaw doctor --fix` completes every doctor check green, then throws `Error: Failed to install completion: EACCES: permission denied` and exits 1 when the shell rc file (e.g. ~/.bashrc) is read-only. This happens deterministically in sandboxed environments like NVIDIA NemoClaw where ~/.bashrc is root-owned mode 444 for security hardening.

Fixes #99237

## Why This Change Was Made

The `doctorShellCompletion()` function in `src/commands/doctor-completion.ts` calls `installCompletion()` to write shell completion blocks into the user's rc file. Both call sites (slow-pattern upgrade and new-install paths) could throw on EACCES, propagating an uncaught error that set the doctor exit code to 1.

Shell completion is an optional step — doctor already skips it in `--non-interactive` mode. The fix wraps both `installCompletion()` calls in try/catch and emits a `note()` with the profile path and a hint to run `openclaw completion install` against a writable rc file instead.

## Evidence

### Tests

```
✓ |commands| ../../src/commands/doctor-completion.test.ts (6 tests)
  ✓ shell completion health mapping > checks an explicit shell instead of the detected environment shell
  ✓ shell completion health mapping > reports slow dynamic shell completion with dry-run effects
  ✓ shell completion health mapping > reports missing completion cache with a dry-run cache effect
  ✓ shell completion health mapping > keeps healthy shell completion quiet
  ✓ doctorShellCompletion > does not throw when installCompletion fails with EACCES in the slow-pattern upgrade path
  ✓ doctorShellCompletion > does not throw when installCompletion fails with EACCES in the new-install path
```

### Before-fix vs After-fix

**Before**: With a read-only .zshrc, `doctor --fix` exits 1:
```
$ openclaw doctor --fix; echo "exit:$?"
...
Error: Failed to install completion: EACCES: permission denied, open '/sandbox/.bashrc'
exit:1
```

**After**: With the same read-only rc file, doctor completes with a warning note and exits 0:
```
◇  Shell completion ─────────────────────────────────────────────────╮
│  Shell completion not installed:                                   │
│  /home/user/.zshrc is not writable. Run                           │
│  `openclaw completion install` against a writable shell profile.  │
├────────────────────────────────────────────────────────────────────╯
```

## Merge Risk

Low. The change only adds try/catch guards around optional shell completion writes. Core doctor checks (config, auth, skills, plugins, state integrity, security) are unaffected.