### PR TITLE
fix: long mobile media recordings time out

### DIFF
--- a/src/agents/tools/nodes-tool-media.ts
+++ b/src/agents/tools/nodes-tool-media.ts
@@ -66,6 +66,7 @@ type NodeMediaAction =
   | "screen_record"
   | "screen_snapshot";
 const MAX_RECORDING_DURATION_MS = 300_000;
+const RECORDING_INVOKE_GRACE_MS = 30_000;
 
 type ExecuteNodeMediaActionParams = {
   action: NodeMediaAction;
@@ -74,6 +75,10 @@ type ExecuteNodeMediaActionParams = {
   modelHasVision?: boolean;
   imageSanitization: ImageSanitizationLimits;
 };
+
+function resolveRecordingTimeoutMs(gatewayOpts: GatewayCallOptions, durationMs: number): number {
+  return gatewayOpts.timeoutMs ?? durationMs + RECORDING_INVOKE_GRACE_MS;
+}
 
 export async function executeNodeMediaAction(
   input: ExecuteNodeMediaActionParams,
@@ -322,7 +327,9 @@ async function executeCameraClip({
     typeof params.deviceId === "string" && params.deviceId.trim()
       ? params.deviceId.trim()
       : undefined;
-  const raw = await callGatewayTool<{ payload: unknown }>("node.invoke", gatewayOpts, {
+  const timeoutMs = resolveRecordingTimeoutMs(gatewayOpts, durationMs);
+  const invokeGatewayOpts = { ...gatewayOpts, timeoutMs };
+  const raw = await callGatewayTool<{ payload: unknown }>("node.invoke", invokeGatewayOpts, {
     nodeId,
     command: "camera.clip",
     params: {
@@ -332,6 +339,7 @@ async function executeCameraClip({
       format: "mp4",
       deviceId,
     },
+    timeoutMs,
     idempotencyKey: crypto.randomUUID(),
   });
   const payload = parseCameraClipPayload(raw?.payload);
@@ -370,7 +378,9 @@ async function executeScreenRecord({
     }) ?? 10;
   const screenIndex = readNonNegativeIntegerParam(params, "screenIndex") ?? 0;
   const includeAudio = typeof params.includeAudio === "boolean" ? params.includeAudio : true;
-  const raw = await callGatewayTool<{ payload: unknown }>("node.invoke", gatewayOpts, {
+  const timeoutMs = resolveRecordingTimeoutMs(gatewayOpts, durationMs);
+  const invokeGatewayOpts = { ...gatewayOpts, timeoutMs };
+  const raw = await callGatewayTool<{ payload: unknown }>("node.invoke", invokeGatewayOpts, {
     nodeId,
     command: "screen.record",
     params: {
@@ -380,6 +390,7 @@ async function executeScreenRecord({
       format: "mp4",
       includeAudio,
     },
+    timeoutMs,
     idempotencyKey: crypto.randomUUID(),
   });
   const payload = parseScreenRecordPayload(raw?.payload);

--- a/src/agents/tools/nodes-tool-media.ts
+++ b/src/agents/tools/nodes-tool-media.ts
@@ -67,6 +67,7 @@ type NodeMediaAction =
   | "screen_snapshot";
 const MAX_RECORDING_DURATION_MS = 300_000;
 const RECORDING_INVOKE_GRACE_MS = 30_000;
+const RECORDING_TRANSPORT_GRACE_MS = 30_000;
 
 type ExecuteNodeMediaActionParams = {
   action: NodeMediaAction;
@@ -76,8 +77,22 @@ type ExecuteNodeMediaActionParams = {
   imageSanitization: ImageSanitizationLimits;
 };
 
-function resolveRecordingTimeoutMs(gatewayOpts: GatewayCallOptions, durationMs: number): number {
-  return gatewayOpts.timeoutMs ?? durationMs + RECORDING_INVOKE_GRACE_MS;
+function resolveRecordingTimeouts(params: {
+  input: Record<string, unknown>;
+  gatewayOpts: GatewayCallOptions;
+  durationMs: number;
+}): { gatewayOpts: GatewayCallOptions; invokeTimeoutMs: number } {
+  const invokeTimeoutMs =
+    readPositiveIntegerParam(params.input, "invokeTimeoutMs") ??
+    params.durationMs + RECORDING_INVOKE_GRACE_MS;
+  // The Gateway transport starts before the forwarded node timer and must outlive it.
+  // Keep explicit transport and invoke overrides independent so callers can cancel either layer.
+  const transportTimeoutMs =
+    params.gatewayOpts.timeoutMs ?? invokeTimeoutMs + RECORDING_TRANSPORT_GRACE_MS;
+  return {
+    gatewayOpts: { ...params.gatewayOpts, timeoutMs: transportTimeoutMs },
+    invokeTimeoutMs,
+  };
 }
 
 export async function executeNodeMediaAction(
@@ -327,9 +342,8 @@ async function executeCameraClip({
     typeof params.deviceId === "string" && params.deviceId.trim()
       ? params.deviceId.trim()
       : undefined;
-  const timeoutMs = resolveRecordingTimeoutMs(gatewayOpts, durationMs);
-  const invokeGatewayOpts = { ...gatewayOpts, timeoutMs };
-  const raw = await callGatewayTool<{ payload: unknown }>("node.invoke", invokeGatewayOpts, {
+  const timeouts = resolveRecordingTimeouts({ input: params, gatewayOpts, durationMs });
+  const raw = await callGatewayTool<{ payload: unknown }>("node.invoke", timeouts.gatewayOpts, {
     nodeId,
     command: "camera.clip",
     params: {
@@ -339,7 +353,7 @@ async function executeCameraClip({
       format: "mp4",
       deviceId,
     },
-    timeoutMs,
+    timeoutMs: timeouts.invokeTimeoutMs,
     idempotencyKey: crypto.randomUUID(),
   });
   const payload = parseCameraClipPayload(raw?.payload);
@@ -378,9 +392,8 @@ async function executeScreenRecord({
     }) ?? 10;
   const screenIndex = readNonNegativeIntegerParam(params, "screenIndex") ?? 0;
   const includeAudio = typeof params.includeAudio === "boolean" ? params.includeAudio : true;
-  const timeoutMs = resolveRecordingTimeoutMs(gatewayOpts, durationMs);
-  const invokeGatewayOpts = { ...gatewayOpts, timeoutMs };
-  const raw = await callGatewayTool<{ payload: unknown }>("node.invoke", invokeGatewayOpts, {
+  const timeouts = resolveRecordingTimeouts({ input: params, gatewayOpts, durationMs });
+  const raw = await callGatewayTool<{ payload: unknown }>("node.invoke", timeouts.gatewayOpts, {
     nodeId,
     command: "screen.record",
     params: {
@@ -390,7 +403,7 @@ async function executeScreenRecord({
       format: "mp4",
       includeAudio,
     },
-    timeoutMs,
+    timeoutMs: timeouts.invokeTimeoutMs,
     idempotencyKey: crypto.randomUUID(),
   });
   const payload = parseScreenRecordPayload(raw?.payload);

--- a/src/agents/tools/nodes-tool.test.ts
+++ b/src/agents/tools/nodes-tool.test.ts
@@ -221,17 +221,18 @@ describe("createNodesTool screen_record duration guardrails", () => {
 
     expect(gatewayMocks.callGatewayTool).toHaveBeenCalledTimes(1);
     const call = gatewayMocks.callGatewayTool.mock.calls[0] as
-      | [string, unknown, { params?: { durationMs?: unknown } }]
+      | [string, unknown, { params?: { durationMs?: unknown }; timeoutMs?: unknown }]
       | undefined;
     if (!call) {
       throw new Error("expected callGatewayTool to be called");
     }
     expect(call[0]).toBe("node.invoke");
-    expect(call[1]).toStrictEqual({});
+    expect(call[1]).toStrictEqual({ timeoutMs: 330_000 });
     expect(call[2].params?.durationMs).toBe(300_000);
+    expect(call[2].timeoutMs).toBe(330_000);
   });
 
-  it("clamps camera_clip durationMs argument to 300000 before gateway invoke", async () => {
+  it("clamps camera_clip durationMs argument and extends gateway invoke timeout", async () => {
     gatewayMocks.callGatewayTool.mockResolvedValue({ payload: { ok: true } });
     nodesCameraMocks.parseCameraClipPayload.mockReturnValue({
       base64: "ZmFrZQ==",
@@ -249,10 +250,32 @@ describe("createNodesTool screen_record duration guardrails", () => {
     });
 
     const call = gatewayMocks.callGatewayTool.mock.calls[0] as
-      | [string, unknown, { params?: { durationMs?: unknown } }]
+      | [string, unknown, { params?: { durationMs?: unknown }; timeoutMs?: unknown }]
       | undefined;
     expect(call?.[0]).toBe("node.invoke");
+    expect(call?.[1]).toStrictEqual({ timeoutMs: 330_000 });
     expect(call?.[2].params?.durationMs).toBe(300_000);
+    expect(call?.[2].timeoutMs).toBe(330_000);
+  });
+
+  it("preserves explicit recording timeout for gateway and node invoke", async () => {
+    gatewayMocks.readGatewayCallOptions.mockReturnValueOnce({ timeoutMs: 5_000 });
+    gatewayMocks.callGatewayTool.mockResolvedValue({ payload: { ok: true } });
+    const tool = createNodesTool();
+
+    await tool.execute("call-explicit-timeout", {
+      action: "screen_record",
+      node: "macbook",
+      durationMs: 60_000,
+      timeoutMs: 5_000,
+    });
+
+    const call = gatewayMocks.callGatewayTool.mock.calls[0] as
+      | [string, unknown, { timeoutMs?: unknown }]
+      | undefined;
+    expect(call?.[0]).toBe("node.invoke");
+    expect(call?.[1]).toStrictEqual({ timeoutMs: 5_000 });
+    expect(call?.[2].timeoutMs).toBe(5_000);
   });
 
   it.each([

--- a/src/agents/tools/nodes-tool.test.ts
+++ b/src/agents/tools/nodes-tool.test.ts
@@ -209,56 +209,36 @@ describe("createNodesTool screen_record duration guardrails", () => {
     expect(schema.properties?.invokeTimeoutMs).toMatchObject({ type: "integer", minimum: 1 });
   });
 
-  it("clamps screen_record durationMs argument to 300000 before gateway invoke", async () => {
-    gatewayMocks.callGatewayTool.mockResolvedValue({ payload: { ok: true } });
-    const tool = createNodesTool();
+  it.each(["screen_record", "camera_clip"])(
+    "clamps %s to the tool duration limit and budgets both timeout layers",
+    async (action) => {
+      gatewayMocks.callGatewayTool.mockResolvedValue({ payload: { ok: true } });
+      nodesCameraMocks.parseCameraClipPayload.mockReturnValue({
+        base64: "ZmFrZQ==",
+        format: "mp4",
+        durationMs: 300_000,
+        hasAudio: true,
+      });
+      nodesCameraMocks.writeCameraClipPayloadToFile.mockResolvedValue("/tmp/clip.mp4");
+      const tool = createNodesTool();
 
-    await tool.execute("call-1", {
-      action: "screen_record",
-      node: "macbook",
-      durationMs: 900_000,
-    });
+      await tool.execute(`call-${action}`, {
+        action,
+        node: "macbook",
+        durationMs: 900_000,
+      });
 
-    expect(gatewayMocks.callGatewayTool).toHaveBeenCalledTimes(1);
-    const call = gatewayMocks.callGatewayTool.mock.calls[0] as
-      | [string, unknown, { params?: { durationMs?: unknown }; timeoutMs?: unknown }]
-      | undefined;
-    if (!call) {
-      throw new Error("expected callGatewayTool to be called");
-    }
-    expect(call[0]).toBe("node.invoke");
-    expect(call[1]).toStrictEqual({ timeoutMs: 330_000 });
-    expect(call[2].params?.durationMs).toBe(300_000);
-    expect(call[2].timeoutMs).toBe(330_000);
-  });
+      const call = gatewayMocks.callGatewayTool.mock.calls[0] as
+        | [string, unknown, { params?: { durationMs?: unknown }; timeoutMs?: unknown }]
+        | undefined;
+      expect(call?.[0]).toBe("node.invoke");
+      expect(call?.[1]).toStrictEqual({ timeoutMs: 360_000 });
+      expect(call?.[2].params?.durationMs).toBe(300_000);
+      expect(call?.[2].timeoutMs).toBe(330_000);
+    },
+  );
 
-  it("clamps camera_clip durationMs argument and extends gateway invoke timeout", async () => {
-    gatewayMocks.callGatewayTool.mockResolvedValue({ payload: { ok: true } });
-    nodesCameraMocks.parseCameraClipPayload.mockReturnValue({
-      base64: "ZmFrZQ==",
-      format: "mp4",
-      durationMs: 300_000,
-      hasAudio: true,
-    });
-    nodesCameraMocks.writeCameraClipPayloadToFile.mockResolvedValue("/tmp/clip.mp4");
-    const tool = createNodesTool();
-
-    await tool.execute("call-clip", {
-      action: "camera_clip",
-      node: "macbook",
-      durationMs: 900_000,
-    });
-
-    const call = gatewayMocks.callGatewayTool.mock.calls[0] as
-      | [string, unknown, { params?: { durationMs?: unknown }; timeoutMs?: unknown }]
-      | undefined;
-    expect(call?.[0]).toBe("node.invoke");
-    expect(call?.[1]).toStrictEqual({ timeoutMs: 330_000 });
-    expect(call?.[2].params?.durationMs).toBe(300_000);
-    expect(call?.[2].timeoutMs).toBe(330_000);
-  });
-
-  it("preserves explicit recording timeout for gateway and node invoke", async () => {
+  it("preserves independent explicit transport and node invoke timeouts", async () => {
     gatewayMocks.readGatewayCallOptions.mockReturnValueOnce({ timeoutMs: 5_000 });
     gatewayMocks.callGatewayTool.mockResolvedValue({ payload: { ok: true } });
     const tool = createNodesTool();
@@ -268,6 +248,7 @@ describe("createNodesTool screen_record duration guardrails", () => {
       node: "macbook",
       durationMs: 60_000,
       timeoutMs: 5_000,
+      invokeTimeoutMs: 10_000,
     });
 
     const call = gatewayMocks.callGatewayTool.mock.calls[0] as
@@ -275,7 +256,7 @@ describe("createNodesTool screen_record duration guardrails", () => {
       | undefined;
     expect(call?.[0]).toBe("node.invoke");
     expect(call?.[1]).toStrictEqual({ timeoutMs: 5_000 });
-    expect(call?.[2].timeoutMs).toBe(5_000);
+    expect(call?.[2].timeoutMs).toBe(10_000);
   });
 
   it.each([


### PR DESCRIPTION
## What Problem This Solves

Long `camera_clip` and `screen_record` actions could outlive the default 30-second agent-to-Gateway transport timeout. The forwarded node invocation has its own timer, so one shared timeout value also left the enclosing transport with no time to receive and process the node result.

## Why This Change Was Made

Recording actions now use two lifecycle-owned budgets:

- node invoke: requested duration plus 30 seconds;
- enclosing Gateway transport: node invoke budget plus another 30 seconds.

The existing 300-second tool duration cap remains unchanged. Explicit `timeoutMs` and `invokeTimeoutMs` overrides remain independent so callers retain cancellation control at either layer.

The same helper owns both `camera_clip` and `screen_record`, avoiding parallel timeout policy.

AI-assisted: yes. Maintainer deep review rewrote the original shared-timeout approach, added focused table-driven coverage, ran fresh autoreview, and exercised the final path against a real source Gateway and Android emulator node.

## User Impact

Long mobile camera clips and screen recordings can finish without the outer Gateway request expiring first. Existing short recordings, duration limits, dangerous-command opt-in, and explicit timeout behavior remain intact.

## Evidence

Exact head: `b6b05aad0b257353c18ad3b54fc1c3a0d1ff460c`

- `node scripts/run-vitest.mjs src/agents/tools/nodes-tool.test.ts`
  - 42 tests passed.
  - Both recording actions prove the 300-second clamp, 330-second node deadline, and 360-second transport deadline.
  - Explicit 5-second transport and 10-second node deadlines remain independent.
- Fresh autoreview
  - Clean at 0.94 confidence after restoring the shipped 300-second duration cap.
- Current-source Android live proof
  - Built `:app:assemblePlayDebug`, installed on `emulator-5554`, connected and re-approved through an exact-source Gateway.
  - Invoked `camera_clip` through the patched agent `nodes` tool with `durationMs=31000` and audio disabled.
  - Completed in 33.979 seconds, crossing the former 30-second boundary.
  - Returned a 2,903,226-byte MP4; `ffprobe` duration: 30.781767 seconds.
- Duplicate search
  - No competing open issue or pull request found for this timeout ownership bug.

Screen recording requires an interactive Android MediaProjection consent prompt, so live proof uses `camera_clip`; focused tests cover the identical shared timeout path for both actions.
