### PR TITLE
fix(hooks): flag hook event names that no core trigger emits

### DIFF
--- a/docs/automation/hooks.md
+++ b/docs/automation/hooks.md
@@ -47,10 +47,11 @@ openclaw hooks info session-memory
 
 Hooks subscribe to a specific key from this table, or to a bare family name
 (`command`, `session`, `agent`, `gateway`, `message`) to receive every action
-in that family. Any other event name never fires: the hook loader logs a
-warning for unknown names (typos like `command:nwe`), and
-`openclaw hooks info <name>` flags them, so a hook that silently never runs is
-diagnosable.
+in that family. OpenClaw core emits nothing else, so any other name is almost
+always a typo that leaves the hook silently dead (only a plugin emitting a
+custom event could fire it). The hook loader logs a warning for such names
+(for example `command:nwe`), and `openclaw hooks info <name>` flags them, so a
+hook that never runs is diagnosable.
 
 | Event                    | When it fires                                              |
 | ------------------------ | ---------------------------------------------------------- |

--- a/docs/automation/hooks.md
+++ b/docs/automation/hooks.md
@@ -45,6 +45,10 @@ openclaw hooks info session-memory
 
 ## Event types
 
+Event names outside this table never fire. The hook loader logs a warning for
+unknown names (typos like `command:nwe`), and `openclaw hooks info <name>`
+flags them, so a hook that silently never runs is diagnosable.
+
 | Event                    | When it fires                                              |
 | ------------------------ | ---------------------------------------------------------- |
 | `command:new`            | `/new` command issued                                      |

--- a/docs/automation/hooks.md
+++ b/docs/automation/hooks.md
@@ -45,9 +45,12 @@ openclaw hooks info session-memory
 
 ## Event types
 
-Event names outside this table never fire. The hook loader logs a warning for
-unknown names (typos like `command:nwe`), and `openclaw hooks info <name>`
-flags them, so a hook that silently never runs is diagnosable.
+Hooks subscribe to a specific key from this table, or to a bare family name
+(`command`, `session`, `agent`, `gateway`, `message`) to receive every action
+in that family. Any other event name never fires: the hook loader logs a
+warning for unknown names (typos like `command:nwe`), and
+`openclaw hooks info <name>` flags them, so a hook that silently never runs is
+diagnosable.
 
 | Event                    | When it fires                                              |
 | ------------------------ | ---------------------------------------------------------- |

--- a/src/cli/hooks-cli.test.ts
+++ b/src/cli/hooks-cli.test.ts
@@ -20,6 +20,7 @@ const report: HookStatusReport = {
       emoji: "💾",
       homepage: "https://docs.openclaw.ai/automation/hooks#session-memory",
       events: ["command:new"],
+      unknownEvents: [],
       always: false,
       enabledByConfig: true,
       requirementsSatisfied: true,
@@ -48,6 +49,7 @@ function createPluginManagedHookReport(): HookStatusReport {
         emoji: "🔗",
         homepage: undefined,
         events: ["command:new"],
+        unknownEvents: [],
         always: false,
         enabledByConfig: true,
         requirementsSatisfied: true,
@@ -77,6 +79,24 @@ describe("hooks cli formatting", () => {
 
     const output = formatHooksList(pluginReport, {});
     expect(output).toContain("plugin:voice-call");
+  });
+
+  it("warns about unknown events in hook info", () => {
+    const typoReport: HookStatusReport = {
+      workspaceDir: "/tmp/workspace",
+      managedHooksDir: "/tmp/hooks",
+      hooks: [
+        {
+          ...report.hooks[0],
+          name: "typo-hook",
+          events: ["command:nwe", "command:new"],
+          unknownEvents: ["command:nwe"],
+        },
+      ],
+    };
+
+    const output = formatHookInfo(typoReport, "typo-hook", {});
+    expect(output).toContain("Unknown event (never fire): command:nwe");
   });
 
   it("shows plugin-managed details in hook info", () => {

--- a/src/cli/hooks-cli.test.ts
+++ b/src/cli/hooks-cli.test.ts
@@ -96,7 +96,7 @@ describe("hooks cli formatting", () => {
     };
 
     const output = formatHookInfo(typoReport, "typo-hook", {});
-    expect(output).toContain("Unknown event (never fire): command:nwe");
+    expect(output).toContain("Event not emitted by core (likely typo): command:nwe");
   });
 
   it("shows plugin-managed details in hook info", () => {

--- a/src/cli/hooks-cli.ts
+++ b/src/cli/hooks-cli.ts
@@ -304,7 +304,7 @@ export function formatHookInfo(
   if (hook.unknownEvents.length > 0) {
     lines.push(
       theme.warn(
-        `  ⚠ Unknown event${hook.unknownEvents.length === 1 ? "" : "s"} (never fire): ${hook.unknownEvents.join(", ")}`,
+        `  ⚠ Event${hook.unknownEvents.length === 1 ? "" : "s"} not emitted by core (likely typo): ${hook.unknownEvents.join(", ")}`,
       ),
     );
   }

--- a/src/cli/hooks-cli.ts
+++ b/src/cli/hooks-cli.ts
@@ -191,6 +191,7 @@ export function formatHooksList(report: HookStatusReport, opts: HooksListOptions
         source: h.source,
         pluginId: h.pluginId,
         events: h.events,
+        unknownEvents: h.unknownEvents,
         homepage: h.homepage,
         missing: h.missing,
         managedByPlugin: h.managedByPlugin,
@@ -299,6 +300,13 @@ export function formatHookInfo(
   }
   if (hook.events.length > 0) {
     lines.push(`${theme.muted("  Events:")} ${hook.events.join(", ")}`);
+  }
+  if (hook.unknownEvents.length > 0) {
+    lines.push(
+      theme.warn(
+        `  ⚠ Unknown event${hook.unknownEvents.length === 1 ? "" : "s"} (never fire): ${hook.unknownEvents.join(", ")}`,
+      ),
+    );
   }
   if (hook.managedByPlugin) {
     lines.push(theme.muted("  Managed by plugin; enable/disable via hooks CLI not available."));

--- a/src/commands/onboard-hooks.test.ts
+++ b/src/commands/onboard-hooks.test.ts
@@ -115,6 +115,7 @@ describe("onboard-hooks", () => {
       ? undefined
       : "missing requirements") as HookStatusEntry["blockedReason"],
     ...params,
+    unknownEvents: [],
     source: "openclaw-bundled" as const,
     pluginId: undefined,
     homepage: undefined,

--- a/src/hooks/hooks-status.ts
+++ b/src/hooks/hooks-status.ts
@@ -5,6 +5,7 @@ import { evaluateEntryRequirementsForCurrentPlatform } from "../shared/entry-sta
 import type { RequirementConfigCheck, Requirements } from "../shared/requirements.js";
 import { CONFIG_DIR } from "../utils.js";
 import { hasBinary, isConfigPathTruthy } from "./config.js";
+import { isKnownInternalHookEventKey } from "./internal-hook-types.js";
 import {
   resolveHookConfig,
   resolveHookEnableState,
@@ -35,6 +36,8 @@ export type HookStatusEntry = {
   emoji?: string;
   homepage?: string;
   events: string[];
+  /** Declared events that no core trigger site emits (typos — they never fire). */
+  unknownEvents: string[];
   always: boolean;
   enabledByConfig: boolean;
   requirementsSatisfied: boolean;
@@ -96,6 +99,7 @@ function buildHookStatus(
   const enableState = resolveHookEnableState({ entry, config, hookConfig });
   const always = entry.metadata?.always === true;
   const events = entry.metadata?.events ?? [];
+  const unknownEvents = events.filter((event) => !isKnownInternalHookEventKey(event));
   const isEnvSatisfied = (envName: string) =>
     Boolean(process.env[envName] || hookConfig?.env?.[envName]);
   const isConfigSatisfied = (pathStr: string) => isConfigPathTruthy(config, pathStr);
@@ -127,6 +131,7 @@ function buildHookStatus(
     emoji,
     homepage,
     events,
+    unknownEvents,
     always,
     enabledByConfig,
     requirementsSatisfied,

--- a/src/hooks/hooks-status.ts
+++ b/src/hooks/hooks-status.ts
@@ -36,7 +36,7 @@ export type HookStatusEntry = {
   emoji?: string;
   homepage?: string;
   events: string[];
-  /** Declared events that no core trigger site emits (typos — they never fire). */
+  /** Declared events no core trigger site emits (likely typos; fire only if a plugin emits them). */
   unknownEvents: string[];
   always: boolean;
   enabledByConfig: boolean;

--- a/src/hooks/internal-hook-types.test.ts
+++ b/src/hooks/internal-hook-types.test.ts
@@ -1,0 +1,35 @@
+// Internal hook event key validation tests.
+import { describe, expect, it } from "vitest";
+import {
+  isKnownInternalHookEventKey,
+  KNOWN_INTERNAL_HOOK_EVENT_KEYS,
+} from "./internal-hook-types.js";
+
+describe("isKnownInternalHookEventKey", () => {
+  it("accepts every emitted type:action key", () => {
+    for (const key of KNOWN_INTERNAL_HOOK_EVENT_KEYS) {
+      expect(isKnownInternalHookEventKey(key), key).toBe(true);
+    }
+  });
+
+  it("accepts bare family keys that subscribe to every action", () => {
+    for (const family of ["command", "session", "agent", "gateway", "message"]) {
+      expect(isKnownInternalHookEventKey(family), family).toBe(true);
+    }
+  });
+
+  it("rejects typos, bare actions, and unknown families", () => {
+    for (const key of [
+      "command:nwe",
+      "message:recieved",
+      "startup", // bare action without its family
+      "gateway:started",
+      "session:compact", // partial multi-segment action
+      "webhook:received",
+      "",
+      "COMMAND:NEW",
+    ]) {
+      expect(isKnownInternalHookEventKey(key), key).toBe(false);
+    }
+  });
+});

--- a/src/hooks/internal-hook-types.ts
+++ b/src/hooks/internal-hook-types.ts
@@ -1,6 +1,44 @@
 // Internal hook types define runtime hook event families and payload contracts.
 export type InternalHookEventType = "command" | "session" | "agent" | "gateway" | "message";
 
+const KNOWN_INTERNAL_HOOK_EVENT_FAMILIES = [
+  "command",
+  "session",
+  "agent",
+  "gateway",
+  "message",
+] as const satisfies readonly InternalHookEventType[];
+
+/**
+ * Event keys emitted by core trigger sites (see docs/automation/hooks.md
+ * events table — keep both in sync when adding a trigger). Hooks can also
+ * subscribe to a bare family key to receive every action of that family.
+ * Anything outside this set never fires, so loader/status flag it as a typo.
+ */
+export const KNOWN_INTERNAL_HOOK_EVENT_KEYS = [
+  "agent:bootstrap",
+  "command:new",
+  "command:reset",
+  "command:stop",
+  "gateway:pre-restart",
+  "gateway:shutdown",
+  "gateway:startup",
+  "message:preprocessed",
+  "message:received",
+  "message:sent",
+  "message:transcribed",
+  "session:compact:after",
+  "session:compact:before",
+  "session:patch",
+] as const;
+
+export function isKnownInternalHookEventKey(key: string): boolean {
+  return (
+    (KNOWN_INTERNAL_HOOK_EVENT_KEYS as readonly string[]).includes(key) ||
+    (KNOWN_INTERNAL_HOOK_EVENT_FAMILIES as readonly string[]).includes(key)
+  );
+}
+
 export interface InternalHookEvent {
   /** The type of event (command, session, agent, gateway, etc.) */
   type: InternalHookEventType;

--- a/src/hooks/internal-hook-types.ts
+++ b/src/hooks/internal-hook-types.ts
@@ -13,7 +13,9 @@ const KNOWN_INTERNAL_HOOK_EVENT_FAMILIES = [
  * Event keys emitted by core trigger sites (see docs/automation/hooks.md
  * events table — keep both in sync when adding a trigger). Hooks can also
  * subscribe to a bare family key to receive every action of that family.
- * Anything outside this set never fires, so loader/status flag it as a typo.
+ * Plugins can emit additional keys via the deprecated plugin-sdk/hook-runtime
+ * barrel, so anything outside this set is flagged as a likely typo
+ * (advisory), not rejected.
  */
 export const KNOWN_INTERNAL_HOOK_EVENT_KEYS = [
   "agent:bootstrap",

--- a/src/hooks/loader.test.ts
+++ b/src/hooks/loader.test.ts
@@ -279,6 +279,18 @@ describe("loader", () => {
       expect(event.messages).toEqual(["typo-hook"]);
     });
 
+    it("registers legacy handler events with unknown keys anyway (advisory)", async () => {
+      const handlerPath = await writeHandlerModule("legacy-typo-handler.js");
+
+      const cfg = createEnabledHooksConfig([
+        { event: "command:nwe", module: path.basename(handlerPath) },
+      ]);
+
+      const count = await loadInternalHooks(cfg, tmpDir);
+      expect(count).toBe(1);
+      expect(getRegisteredEventKeys()).toContain("command:nwe");
+    });
+
     it("should load multiple handlers", async () => {
       // Create test handler modules
       const handler1Path = await writeHandlerModule("handler1.js");

--- a/src/hooks/loader.test.ts
+++ b/src/hooks/loader.test.ts
@@ -52,17 +52,19 @@ describe("loader", () => {
     sourceDir?: string;
     hookName: string;
     handlerCode?: string;
+    events?: string[];
   }): Promise<string> {
     const sourceDir = params.sourceDir ?? path.join(tmpDir, "hooks");
     const hookDir = path.join(sourceDir, params.hookName);
     await fs.mkdir(hookDir, { recursive: true });
+    const events = params.events ?? ["command:new"];
     await fs.writeFile(
       path.join(hookDir, "HOOK.md"),
       [
         "---",
         `name: ${params.hookName}`,
         `description: ${params.hookName} test hook`,
-        'metadata: {"openclaw":{"events":["command:new"]}}',
+        `metadata: {"openclaw":{"events":${JSON.stringify(events)}}}`,
         "---",
         "",
         `# ${params.hookName}`,
@@ -242,6 +244,39 @@ describe("loader", () => {
       const event = createInternalHookEvent("command", "new", "test-session");
       await triggerInternalHook(event);
       expect(event.messages).toEqual(["keep-hook"]);
+    });
+
+    it("registers unknown event keys anyway (advisory warning, not a load failure)", async () => {
+      const hooksDir = path.join(tmpDir, "managed-hooks");
+      await writeDiscoveredHook({
+        sourceDir: hooksDir,
+        hookName: "typo-hook",
+        events: ["command:nwe", "command:new"],
+      });
+
+      const count = await loadInternalHooks(
+        {
+          hooks: {
+            internal: {
+              entries: {
+                "typo-hook": { enabled: true },
+              },
+            },
+          },
+        } satisfies OpenClawConfig,
+        tmpDir,
+        { managedHooksDir: hooksDir, bundledHooksDir: "/nonexistent/bundled/hooks" },
+      );
+
+      // The typo'd key never fires, but validation is advisory: the hook still
+      // loads and its valid subscriptions keep working.
+      expect(count).toBe(1);
+      const keys = getRegisteredEventKeys();
+      expect(keys).toContain("command:nwe");
+      expect(keys).toContain("command:new");
+      const event = createInternalHookEvent("command", "new", "test-session");
+      await triggerInternalHook(event);
+      expect(event.messages).toEqual(["typo-hook"]);
     });
 
     it("should load multiple handlers", async () => {

--- a/src/hooks/loader.ts
+++ b/src/hooks/loader.ts
@@ -169,14 +169,16 @@ export async function loadInternalHooks(
           continue;
         }
 
-        // Core is the only emitter of internal hook events, so a key outside
-        // the known set can never fire — surface the typo instead of letting
-        // the hook register silently dead. Still registered: advisory only.
+        // Core never emits keys outside the known set, so these are almost
+        // always typos that leave the hook silently dead (a plugin could emit
+        // custom keys via plugin-sdk/hook-runtime, hence advisory: warn but
+        // still register).
         const unknownEvents = events.filter((event) => !isKnownInternalHookEventKey(event));
         if (unknownEvents.length > 0) {
           log.warn(
-            `Hook '${safeLogValue(entry.hook.name)}' subscribes to unknown event${unknownEvents.length === 1 ? "" : "s"} ` +
-              `${unknownEvents.map((event) => safeLogValue(event)).join(", ")} that will never fire. ` +
+            `Hook '${safeLogValue(entry.hook.name)}' subscribes to event${unknownEvents.length === 1 ? "" : "s"} ` +
+              `${unknownEvents.map((event) => safeLogValue(event)).join(", ")} not emitted by OpenClaw core — ` +
+              `likely a typo; unless a plugin emits it, the hook never fires. ` +
               `Known events: https://docs.openclaw.ai/automation/hooks`,
           );
         }

--- a/src/hooks/loader.ts
+++ b/src/hooks/loader.ts
@@ -16,6 +16,7 @@ import { resolveGlobalSingleton } from "../shared/global-singleton.js";
 import { shouldIncludeHook } from "./config.js";
 import { hasConfiguredInternalHooks, resolveConfiguredInternalHookNames } from "./configured.js";
 import { buildImportUrl } from "./import-url.js";
+import { isKnownInternalHookEventKey } from "./internal-hook-types.js";
 import type { InternalHookHandler } from "./internal-hooks.js";
 import { registerInternalHook, unregisterInternalHook } from "./internal-hooks.js";
 import { getLegacyInternalHookHandlers } from "./legacy-config.js";
@@ -166,6 +167,18 @@ export async function loadInternalHooks(
         if (events.length === 0) {
           log.warn(`Hook '${safeLogValue(entry.hook.name)}' has no events defined in metadata`);
           continue;
+        }
+
+        // Core is the only emitter of internal hook events, so a key outside
+        // the known set can never fire — surface the typo instead of letting
+        // the hook register silently dead. Still registered: advisory only.
+        const unknownEvents = events.filter((event) => !isKnownInternalHookEventKey(event));
+        if (unknownEvents.length > 0) {
+          log.warn(
+            `Hook '${safeLogValue(entry.hook.name)}' subscribes to unknown event${unknownEvents.length === 1 ? "" : "s"} ` +
+              `${unknownEvents.map((event) => safeLogValue(event)).join(", ")} that will never fire. ` +
+              `Known events: https://docs.openclaw.ai/automation/hooks`,
+          );
         }
 
         for (const event of events) {

--- a/src/hooks/loader.ts
+++ b/src/hooks/loader.ts
@@ -274,6 +274,15 @@ export async function loadInternalHooks(
         continue;
       }
 
+      // Same advisory typo check as directory-discovered hooks above.
+      if (!isKnownInternalHookEventKey(handlerConfig.event)) {
+        log.warn(
+          `Legacy hook handler ${safeLogValue(rawModule)} subscribes to event ` +
+            `${safeLogValue(handlerConfig.event)} not emitted by OpenClaw core — ` +
+            `likely a typo; unless a plugin emits it, the hook never fires. ` +
+            `Known events: https://docs.openclaw.ai/automation/hooks`,
+        );
+      }
       registerInternalHook(handlerConfig.event, handler);
       loadedHookRegistrations.push({ event: handlerConfig.event, handler });
       log.debug(


### PR DESCRIPTION
## What Problem This Solves

A hook's `HOOK.md` frontmatter declares which internal events it subscribes to (`metadata.openclaw.events`), but the loader accepts any string: `registerInternalHook(eventKey)` registers arbitrary keys, and only an *empty* events array produces a warning (`src/hooks/loader.ts`). Since core is the only emitter of internal hook events, a misspelled name (`command:nwe`, `message:recieved`, `gateway:started`) loads "successfully" and then silently never fires — no loader warning, nothing in `openclaw hooks list`/`info`, no way to tell a dead subscription from a hook that simply hasn't triggered yet. Debugging "my hook never runs" today means reading core source to discover the valid key set.

## Why This Change Was Made

The core-emitted key set is small, closed, and already documented (the events table in `docs/automation/hooks.md`): core trigger sites emit exactly 14 `family:action` keys, and hooks may also subscribe to a bare family (`command`, `session`, `agent`, `gateway`, `message`) to receive every action. Plugins *can* emit additional keys through the deprecated `plugin-sdk/hook-runtime` barrel (all bundled plugins emit only known keys — Telegram/Slack/Signal/WhatsApp emit `message:received`/`message:sent`), so a name outside the core set is *almost always* a typo — the diagnostics say so honestly ("not emitted by OpenClaw core — likely a typo; unless a plugin emits it, the hook never fires") and stay strictly advisory.

This change makes that set checkable:

- `KNOWN_INTERNAL_HOOK_EVENT_KEYS` + `isKnownInternalHookEventKey` in `src/hooks/internal-hook-types.ts` (colocated with the `InternalHookEventType` union; the list mirrors the docs table and each entry was verified against its `createInternalHookEvent` call site, including the dynamic ones — `performGatewaySessionReset` emits `"new" | "reset"`, reset-command hooks emit `ResetCommandAction = "new" | "reset"`).
- The loader warns when a hook declares events outside the core-emitted set, naming the hook, the keys, and the docs URL — for both directory-discovered `HOOK.md` hooks and the legacy `hooks.internal.handlers` config shape. The hook is **still registered unchanged** — validation is advisory, zero behavior change, so plugin-emitted custom events and version skew degrade to today's behavior plus a warning rather than a refusal to load.
- `HookStatusEntry` gains `unknownEvents`; `openclaw hooks info <name>` renders a `⚠ Event not emitted by core (likely typo): …` line and the JSON report includes the field, so the diagnosis is visible after load time too.
- `docs/automation/hooks.md` documents the behavior next to the events table.

## User Impact

Hook authors find out about dead subscriptions immediately (gateway log at load) and on demand (`openclaw hooks info`), instead of shipping a hook that silently does nothing. Existing hooks with valid events see no change; hooks with typos keep loading exactly as before but are no longer silent about it.

## Evidence

HEAD: `f9b756725354debd4aa64cc62b36e411245b8e00` (base upstream/main `df350e6720`)

Real behavior proof (no mocks — a real `HOOK.md` declaring `["command:nwe", "command:new"]` loaded through the production `loadInternalHooks`, then rendered by the production status builder and CLI; captured at `607ca0ff76` — the one commit since, `f9b75672`, only adds the same advisory to the legacy `hooks.internal.handlers` path and does not touch the surfaces proven here):

```
=== 1. production loadInternalHooks over a real HOOK.md (watch the warning) ===
[hooks:loader] Hook 'typo-hook' subscribes to event command:nwe not emitted by OpenClaw core — likely a typo; unless a plugin emits it, the hook never fires. Known events: https://docs.openclaw.ai/automation/hooks
loaded hooks: 1; registered keys: command:nwe, command:new

=== 2. production hooks status report ===
hook=typo-hook events=[command:nwe, command:new] unknownEvents=[command:nwe]

=== 3. production `openclaw hooks info` rendering ===
  Events: command:nwe, command:new
  ⚠ Event not emitted by core (likely typo): command:nwe
```

Focused tests (all green locally):

- `src/hooks/internal-hook-types.test.ts` (new) — accept matrix for all 14 keys + 5 bare families; reject matrix for typos, bare actions, unknown families, case mismatches
- `src/hooks/loader.test.ts` — typo'd key still registers (advisory) and the valid subscription keeps firing; legacy config handlers get the same advisory treatment
- `src/cli/hooks-cli.test.ts` — `hooks info` renders the ⚠ line
- `src/commands/onboard-hooks.test.ts` — fixture updated for the new required field
- `pnpm tsgo:core` + `pnpm tsgo:core:test` clean

External structured review: Codex (GPT-5.5), 5 rounds — flagged docs wording (bare-family subscriptions), an overclaim in this body ("plugins cannot emit new keys" vs. the deprecated `plugin-sdk/hook-runtime` re-export → diagnostics reworded to "not emitted by core / likely a typo"), and a missed sibling seam (the legacy `hooks.internal.handlers` path registered events without the advisory check → covered); final pass clean.

Known limits / Non-scope: advisory only — no fail-closed loading, no doctor check (the hooks CLI is the existing diagnostic surface), no change to the separate plugin-SDK hook API, no fuzzy matching/normalization of event names; no attempt to track plugin-emitted custom keys. New core trigger sites must add their key to the list + docs table (called out in a code comment at the list).

---

🤖 AI-assisted (Claude Fable 5 + Codex GPT-5.5 review loop). Prompt lineage: translate agentic-coding-tool hook-validation patterns (Claude Code hook-matcher fixes) into OpenClaw's internal hook loader; implementation, tests, review rounds, and the real-behavior proof were run locally as shown above.
