### PR TITLE
fix: redact dotted API key activity previews

### DIFF
--- a/ui/src/ui/activity-model.test.ts
+++ b/ui/src/ui/activity-model.test.ts
@@ -42,12 +42,13 @@ describe("activity model output preview redaction", () => {
 
   it("redacts dotted API keys in object-shaped tool results", () => {
     const preview = buildResultPreview({
-      "app.api.key": "visible secret with spaces",
+      "app.api.key": 'visible secret with spaces, apostrophe: don\'t, quote: "keep hidden"',
       "server.port": 8080,
     });
 
     expect(preview).toContain('"app.api.key": "[redacted]"');
     expect(preview).toContain('"server.port": 8080');
-    expect(preview).not.toContain("visible secret with spaces");
+    expect(preview).not.toContain("visible secret");
+    expect(preview).not.toContain("keep hidden");
   });
 });

--- a/ui/src/ui/activity-model.test.ts
+++ b/ui/src/ui/activity-model.test.ts
@@ -1,0 +1,42 @@
+// @vitest-environment node
+import { describe, expect, it } from "vitest";
+import { updateActivityFromToolEvent, type ActivityEntry } from "./activity-model.ts";
+
+function buildResultPreview(result: unknown): string {
+  const host = { activityEntries: [] as ActivityEntry[] };
+
+  updateActivityFromToolEvent(host, {
+    runId: "run-1",
+    ts: 1,
+    data: {
+      toolCallId: "tool-1",
+      name: "bash",
+      phase: "result",
+      result,
+    },
+  });
+
+  const entry = host.activityEntries[0];
+  if (!entry?.outputPreview) {
+    throw new Error("Expected activity output preview");
+  }
+  return entry.outputPreview;
+}
+
+describe("activity model output preview redaction", () => {
+  it("redacts dotted API key assignments emitted by tool output", () => {
+    const preview = buildResultPreview({
+      text: [
+        "app.api.key=visible-leaked-value-1234567890",
+        "spring.datasource.password=visible-db-password-1234567890",
+        "server.port=8080",
+      ].join("\n"),
+    });
+
+    expect(preview).toContain("app.api.key=[redacted]");
+    expect(preview).toContain("spring.datasource.password=[redacted]");
+    expect(preview).toContain("server.port=8080");
+    expect(preview).not.toContain("visible-leaked-value-1234567890");
+    expect(preview).not.toContain("visible-db-password-1234567890");
+  });
+});

--- a/ui/src/ui/activity-model.test.ts
+++ b/ui/src/ui/activity-model.test.ts
@@ -39,4 +39,15 @@ describe("activity model output preview redaction", () => {
     expect(preview).not.toContain("visible-leaked-value-1234567890");
     expect(preview).not.toContain("visible-db-password-1234567890");
   });
+
+  it("redacts dotted API keys in object-shaped tool results", () => {
+    const preview = buildResultPreview({
+      "app.api.key": "visible secret with spaces",
+      "server.port": 8080,
+    });
+
+    expect(preview).toContain('"app.api.key": "[redacted]"');
+    expect(preview).toContain('"server.port": 8080');
+    expect(preview).not.toContain("visible secret with spaces");
+  });
 });

--- a/ui/src/ui/activity-model.ts
+++ b/ui/src/ui/activity-model.ts
@@ -43,8 +43,12 @@ const SECRET_PATTERNS: Array<[RegExp, string]> = [
   [/\b(Authorization|Cookie|Set-Cookie)\s*:\s*[^\n\r]+/gi, "$1: [redacted]"],
   [/\b(Bearer\s+)[A-Za-z0-9._~+/=-]{12,}/gi, "$1[redacted]"],
   [
-    /\b(api[_.-]?key|token|secret|password|passwd|authorization)\b(["'])(\s*:\s*)(["'])[^"'\r\n]*\4/gi,
-    "$1$2$3$4[redacted]$4",
+    /\b(api[_.-]?key|token|secret|password|passwd|authorization)\b(["'])(\s*:\s*)"(?:\\.|[^"\\\r\n])*"/gi,
+    '$1$2$3"[redacted]"',
+  ],
+  [
+    /\b(api[_.-]?key|token|secret|password|passwd|authorization)\b(["'])(\s*:\s*)'(?:\\.|[^'\\\r\n])*'/gi,
+    "$1$2$3'[redacted]'",
   ],
   [
     /\b(api[_.-]?key|token|secret|password|passwd|authorization)\b(\s*[:=]\s*)["']?[^"',\s}]+/gi,

--- a/ui/src/ui/activity-model.ts
+++ b/ui/src/ui/activity-model.ts
@@ -43,7 +43,7 @@ const SECRET_PATTERNS: Array<[RegExp, string]> = [
   [/\b(Authorization|Cookie|Set-Cookie)\s*:\s*[^\n\r]+/gi, "$1: [redacted]"],
   [/\b(Bearer\s+)[A-Za-z0-9._~+/=-]{12,}/gi, "$1[redacted]"],
   [
-    /\b(api[_-]?key|token|secret|password|passwd|authorization)\b(\s*[:=]\s*)["']?[^"',\s}]+/gi,
+    /\b(api[_.-]?key|token|secret|password|passwd|authorization)\b(\s*[:=]\s*)["']?[^"',\s}]+/gi,
     "$1$2[redacted]",
   ],
   [

--- a/ui/src/ui/activity-model.ts
+++ b/ui/src/ui/activity-model.ts
@@ -43,6 +43,10 @@ const SECRET_PATTERNS: Array<[RegExp, string]> = [
   [/\b(Authorization|Cookie|Set-Cookie)\s*:\s*[^\n\r]+/gi, "$1: [redacted]"],
   [/\b(Bearer\s+)[A-Za-z0-9._~+/=-]{12,}/gi, "$1[redacted]"],
   [
+    /\b(api[_.-]?key|token|secret|password|passwd|authorization)\b(["'])(\s*:\s*)(["'])[^"'\r\n]*\4/gi,
+    "$1$2$3$4[redacted]$4",
+  ],
+  [
     /\b(api[_.-]?key|token|secret|password|passwd|authorization)\b(\s*[:=]\s*)["']?[^"',\s}]+/gi,
     "$1$2[redacted]",
   ],


### PR DESCRIPTION
Closes #99459

## What Problem This Solves

Control UI Activity output previews could expose dotted credential assignments such as `app.api.key=...`. Object-shaped tool results were also vulnerable because `stringifyOutput` adds quoted JSON keys before preview redaction.

## Why This Change Was Made

The Activity preview owner now handles both reachable shapes:

- properties/config text with dotted, underscored, dashed, or joined API-key names;
- quoted object/JSON keys and quoted values, including spaces, apostrophes, and escaped quote punctuation.

Non-sensitive dotted fields remain visible. The Activity-local rules retain full masking and path redaction; the sibling browser detail redactor intentionally partial-masks values, so replacing this owner with that helper would change the secrecy contract.

AI-assisted: yes. Maintainer deep review expanded the original one-character regex change after fresh autoreview found two additional object-result bypasses.

## User Impact

Activity previews no longer display dotted API-key values from text or structured tool results. Ordinary config context such as `server.port` remains readable.

## Evidence

Exact head: `96ef4176e33fa999cbb66582bf08f187aa8ca33b`

- `node scripts/run-vitest.mjs ui/src/ui/activity-model.test.ts ui/src/ui/app-tool-stream.node.test.ts ui/src/ui/views/activity.test.ts`
  - 32 tests passed before exact-head rebase; exact CI reruns on the final head.
  - Production `updateActivityFromToolEvent` coverage proves properties text, object-shaped JSON, punctuation/escaped quotes, and non-sensitive preservation.
- Fresh autoreview
  - First accepted finding: quoted JSON property names bypassed the original PR.
  - Second accepted finding: apostrophes inside double-quoted values bypassed the first repair.
  - Final run: clean, no accepted/actionable findings, 0.97 confidence.
- Duplicate search
  - #99459 is the canonical issue; no competing open issue or pull request found.

Rendered-browser proof gap: the required existing-profile Chrome attachment returned no user tabs. Per the browser-use safety rule, no isolated browser substitute was used. The production model path, rendered Activity consumer, focused tests, and exact-head hosted CI remain the available proof.
