### PR TITLE
fix: add claude-sonnet-5 to Anthropic model catalog and GA-1M context prefixes

### DIFF
--- a/extensions/anthropic/openclaw.plugin.json
+++ b/extensions/anthropic/openclaw.plugin.json
@@ -46,6 +46,17 @@
             "maxTokens": 64000
           },
           {
+            "id": "claude-sonnet-5",
+            "name": "Claude Sonnet 5 (Claude CLI)",
+            "reasoning": true,
+            "input": ["text", "image"],
+            "mediaInput": {
+              "image": { "maxSidePx": 1568, "preferredSidePx": 1568, "tokenMode": "provider" }
+            },
+            "contextWindow": 1048576,
+            "maxTokens": 128000
+          },
+          {
             "id": "claude-opus-4-6",
             "name": "Claude Opus 4.6 (Claude CLI)",
             "reasoning": true,
@@ -134,6 +145,17 @@
             },
             "contextWindow": 200000,
             "maxTokens": 64000
+          },
+          {
+            "id": "claude-sonnet-5",
+            "name": "Claude Sonnet 5",
+            "reasoning": true,
+            "input": ["text", "image"],
+            "mediaInput": {
+              "image": { "maxSidePx": 1568, "preferredSidePx": 1568, "tokenMode": "provider" }
+            },
+            "contextWindow": 1000000,
+            "maxTokens": 128000
           },
           {
             "id": "claude-opus-4-6",

--- a/extensions/anthropic/stream-wrappers.ts
+++ b/extensions/anthropic/stream-wrappers.ts
@@ -31,6 +31,8 @@ const ANTHROPIC_GA_1M_MODEL_PREFIXES = [
   "claude-opus-4.7",
   "claude-sonnet-4-6",
   "claude-sonnet-4.6",
+  "claude-sonnet-5",
+  "claude-sonnet-5.0",
 ] as const;
 const OPENCLAW_DEFAULT_ANTHROPIC_BETAS = [
   "fine-grained-tool-streaming-2025-05-14",

--- a/src/agents/context-resolution.ts
+++ b/src/agents/context-resolution.ts
@@ -39,6 +39,8 @@ const ANTHROPIC_GA_1M_MODEL_PREFIXES = [
   "claude-opus-4.7",
   "claude-sonnet-4-6",
   "claude-sonnet-4.6",
+  "claude-sonnet-5",
+  "claude-sonnet-5.0",
 ] as const;
 export const ANTHROPIC_CONTEXT_1M_TOKENS = 1_048_576;
 export const ANTHROPIC_VERTEX_CONTEXT_1M_TOKENS = 1_000_000;


### PR DESCRIPTION
## What Problem This Solves

Claude Sonnet 5 (`claude-sonnet-5`, released 2026-06-30) ships from Anthropic with a 1,000,000-token context window. OpenClaw 2026.6.11's bundled Anthropic plugin catalog has no entry for it, and the model is also missing from `ANTHROPIC_GA_1M_MODEL_PREFIXES` (duplicated in `context-resolution.ts` and `stream-wrappers.ts`).

Users who add `claude-sonnet-5` as a custom model (with `contextWindow: 1000000`) still see the model treated as 200k-context wherever the bundled static catalog or GA-1M prefix check is consulted.

Fixes #99239

## Why This Change Was Made

Three locations needed updates:

1. **`extensions/anthropic/openclaw.plugin.json`** — add model to both `claude-cli` and `anthropic` provider lists with correct `contextWindow` and `maxTokens`:
   - Claude CLI: `contextWindow: 1048576`, `maxTokens: 128000` (consistent with claude-opus-4-8)
   - Anthropic: `contextWindow: 1000000`, `maxTokens: 128000` (consistent with claude-fable-5)

2. **`src/agents/context-resolution.ts`** — add `claude-sonnet-5` / `claude-sonnet-5.0` to `ANTHROPIC_GA_1M_MODEL_PREFIXES` so `resolveAnthropicFixedContextWindow()` recognizes it

3. **`extensions/anthropic/stream-wrappers.ts`** — add same prefixes to the duplicated constant so `isAnthropic1MModel()` treats it as GA-1M (skips legacy beta header)

## Evidence

### Tests

```
✓ extension-anthropic stream-wrappers.test.ts (21 tests)
✓ extension-anthropic openclaw.plugin.test.ts (1 test)
```

### Before vs After (sanity check)

**Before**: claude-sonnet-5 is NOT a GA-1M model prefix
```
$ node -e "
const prefixes = ['claude-opus-4-8','claude-opus-4.8','claude-opus-4-6','claude-opus-4.6','claude-opus-4-7','claude-opus-4.7','claude-sonnet-4-6','claude-sonnet-4.6'];
console.log('sonnet-5 is GA-1M:', prefixes.some(p => 'claude-sonnet-5'.startsWith(p)));
"
// sonnet-5 is GA-1M: false
```

**After**: claude-sonnet-5 is recognized as GA-1M
```
// sonnet-5 is GA-1M: true
```

### Plugin JSON validation

```bash
$ node -e "const p = require('./extensions/anthropic/openclaw.plugin.json');
const cliCL = p.modelCatalog.providers['claude-cli'].models.find(m => m.id === 'claude-sonnet-5');
const anth = p.modelCatalog.providers.anthropic.models.find(m => m.id === 'claude-sonnet-5');
console.log('claude-cli:', cliCL?.contextWindow, cliCL?.maxTokens);
console.log('anthropic:', anth?.contextWindow, anth?.maxTokens);"
// claude-cli: 1048576 128000
// anthropic: 1000000 128000
```

## Merge Risk

Low. This is a static catalog addition. The GA-1M prefix entry enables 1M-context semantics for the model, replacing the 200k fallback. No functional changes to existing models.