### PR TITLE
improve: tighten iOS Control row density

### DIFF
--- a/apps/.i18n/native-source.json
+++ b/apps/.i18n/native-source.json
@@ -8323,7 +8323,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 132,
+      "line": 130,
       "path": "apps/ios/Sources/Design/RootTabsPhoneControlHub.swift",
       "source": "Overview",
       "surface": "apple",
@@ -8331,7 +8331,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 154,
+      "line": 152,
       "path": "apps/ios/Sources/Design/RootTabsPhoneControlHub.swift",
       "source": "Instances",
       "surface": "apple",
@@ -8339,7 +8339,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 163,
+      "line": 161,
       "path": "apps/ios/Sources/Design/RootTabsPhoneControlHub.swift",
       "source": "Dreaming",
       "surface": "apple",
@@ -8347,7 +8347,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 168,
+      "line": 166,
       "path": "apps/ios/Sources/Design/RootTabsPhoneControlHub.swift",
       "source": "Usage",
       "surface": "apple",
@@ -8355,7 +8355,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 173,
+      "line": 171,
       "path": "apps/ios/Sources/Design/RootTabsPhoneControlHub.swift",
       "source": "Cron Jobs",
       "surface": "apple",
@@ -8363,7 +8363,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 243,
+      "line": 241,
       "path": "apps/ios/Sources/Design/RootTabsPhoneControlHub.swift",
       "source": "Online",
       "surface": "apple",
@@ -8371,7 +8371,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 244,
+      "line": 242,
       "path": "apps/ios/Sources/Design/RootTabsPhoneControlHub.swift",
       "source": "Connecting",
       "surface": "apple",
@@ -8379,7 +8379,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 245,
+      "line": 243,
       "path": "apps/ios/Sources/Design/RootTabsPhoneControlHub.swift",
       "source": "Attention",
       "surface": "apple",
@@ -8387,7 +8387,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 246,
+      "line": 244,
       "path": "apps/ios/Sources/Design/RootTabsPhoneControlHub.swift",
       "source": "Offline",
       "surface": "apple",

--- a/apps/ios/Sources/Design/RootTabsPhoneControlHub.swift
+++ b/apps/ios/Sources/Design/RootTabsPhoneControlHub.swift
@@ -109,13 +109,11 @@ struct RootTabsPhoneControlHub: View {
     }
 
     private func rowLabel(_ destination: RootTabs.SidebarDestination) -> some View {
-        HStack(alignment: .center, spacing: 12) {
-            ProIconBadge(systemName: destination.systemImage, color: .secondary)
+        Label {
             Text(destination.title)
-                .font(.subheadline.weight(.semibold))
-                .foregroundStyle(.primary)
+        } icon: {
+            ProIconBadge(systemName: destination.systemImage, color: .secondary)
         }
-        .padding(.vertical, 3)
     }
 
     @ViewBuilder

--- a/apps/ios/Tests/RootTabsSourceGuardTests.swift
+++ b/apps/ios/Tests/RootTabsSourceGuardTests.swift
@@ -87,36 +87,6 @@ struct RootTabsSourceGuardTests {
         #expect(phoneTabContent.matches(of: /PhoneTabSettingsHost(?:\([^\n]+\))? \{/).count == 3)
     }
 
-    @Test func `phone control destination rows use label badge density`() throws {
-        let phoneSource = try String(contentsOf: Self.phoneHubSourceURL(), encoding: .utf8)
-        let rootSource = try String(contentsOf: Self.rootTabsSourceURL(), encoding: .utf8)
-        let rowLabel = try Self.extract(
-            phoneSource,
-            from: "private func rowLabel(_ destination: RootTabs.SidebarDestination) -> some View",
-            to: "@ViewBuilder")
-        let gatewayRow = try Self.extract(
-            phoneSource,
-            from: "private var gatewayRow: some View",
-            to: "@ViewBuilder\n    private func destinationRow")
-        let sidebarDestinationButton = try Self.extract(
-            rootSource,
-            from: "private func sidebarDestinationButton(",
-            to: "@ViewBuilder\n    private var sidebarDetail")
-
-        #expect(rowLabel.contains("Label {"))
-        #expect(rowLabel.contains("Text(destination.title)"))
-        #expect(rowLabel.contains("ProIconBadge(systemName: destination.systemImage, color: .secondary)"))
-        #expect(!rowLabel.contains("HStack(alignment: .center, spacing: 12)"))
-        #expect(!rowLabel.contains(".font(.subheadline.weight(.semibold))"))
-        #expect(!rowLabel.contains(".padding(.vertical, 3)"))
-
-        #expect(gatewayRow.contains("ProIconBadge("))
-        #expect(gatewayRow.contains(".padding(.vertical, 4)"))
-        #expect(sidebarDestinationButton.contains("Label(title ?? destination.sidebarTitle"))
-        #expect(sidebarDestinationButton.contains(".padding(.vertical, 8)"))
-        #expect(rootSource.contains(".listStyle(.sidebar)"))
-    }
-
     @Test func `sidebar keeps navigation model destination only`() throws {
         let source = try String(contentsOf: Self.rootTabsSourceURL(), encoding: .utf8)
         let navigationSource = try String(contentsOf: Self.rootTabsNavigationSourceURL(), encoding: .utf8)

--- a/apps/ios/Tests/RootTabsSourceGuardTests.swift
+++ b/apps/ios/Tests/RootTabsSourceGuardTests.swift
@@ -87,6 +87,36 @@ struct RootTabsSourceGuardTests {
         #expect(phoneTabContent.matches(of: /PhoneTabSettingsHost(?:\([^\n]+\))? \{/).count == 3)
     }
 
+    @Test func `phone control destination rows use label badge density`() throws {
+        let phoneSource = try String(contentsOf: Self.phoneHubSourceURL(), encoding: .utf8)
+        let rootSource = try String(contentsOf: Self.rootTabsSourceURL(), encoding: .utf8)
+        let rowLabel = try Self.extract(
+            phoneSource,
+            from: "private func rowLabel(_ destination: RootTabs.SidebarDestination) -> some View",
+            to: "@ViewBuilder")
+        let gatewayRow = try Self.extract(
+            phoneSource,
+            from: "private var gatewayRow: some View",
+            to: "@ViewBuilder\n    private func destinationRow")
+        let sidebarDestinationButton = try Self.extract(
+            rootSource,
+            from: "private func sidebarDestinationButton(",
+            to: "@ViewBuilder\n    private var sidebarDetail")
+
+        #expect(rowLabel.contains("Label {"))
+        #expect(rowLabel.contains("Text(destination.title)"))
+        #expect(rowLabel.contains("ProIconBadge(systemName: destination.systemImage, color: .secondary)"))
+        #expect(!rowLabel.contains("HStack(alignment: .center, spacing: 12)"))
+        #expect(!rowLabel.contains(".font(.subheadline.weight(.semibold))"))
+        #expect(!rowLabel.contains(".padding(.vertical, 3)"))
+
+        #expect(gatewayRow.contains("ProIconBadge("))
+        #expect(gatewayRow.contains(".padding(.vertical, 4)"))
+        #expect(sidebarDestinationButton.contains("Label(title ?? destination.sidebarTitle"))
+        #expect(sidebarDestinationButton.contains(".padding(.vertical, 8)"))
+        #expect(rootSource.contains(".listStyle(.sidebar)"))
+    }
+
     @Test func `sidebar keeps navigation model destination only`() throws {
         let source = try String(contentsOf: Self.rootTabsSourceURL(), encoding: .utf8)
         let navigationSource = try String(contentsOf: Self.rootTabsNavigationSourceURL(), encoding: .utf8)


### PR DESCRIPTION
Closes #99439

## What Problem This Solves

Resolves a problem where iPhone users opening the Control tab would see destination rows that felt taller and emptier than the content required. The row composition made the Control list feel less balanced than the rest of the iOS app.

## Why This Change Was Made

The phone Control destination rows now use SwiftUI's native `Label` structure with the existing `ProIconBadge` as the icon content. This keeps the app's established icon badge treatment while removing the custom row wrapper, explicit title font override, and extra vertical padding that made the rows feel oversized.

The change is intentionally limited to the phone Control destination rows. The Gateway row, tab bar icons, chevrons, navigation behavior, and iPad sidebar/control UI remain unchanged.

## User Impact

iPhone users get a denser, cleaner Control tab list that still matches the app's existing row icon style. The Control screen should feel less empty without changing where rows navigate or how status information is shown.

## Evidence

Focused verification:
- Exact repaired head: `efb52790f48dec0924edec62a48a047630b97e64`.
- `SwiftUIRenderSmokeTests` + `RootTabsPresentationTests`: 62 passed, 0 failed on iPhone 17 / iOS 26.5 simulator.
- `OpenClawSnapshotUITests.testControlOverviewNavigation`: 1 passed, 0 failed; found Overview, navigated into the detail, verified Back to Control and Gateway settings, and kept the app foreground.
- Installed and launched the exact repaired head in screenshot fixture mode; fresh light and dark Control captures visually match the attached after state.
- Native i18n inventory check: 2,437 entries, `changed=false`.
- `git diff --check`
- Fresh Codex autoreview against current `origin/main`: clean, confidence 0.96.

Review improvement: removed a 30-line source-string test that locked implementation details without testing user-visible behavior. Existing render smoke plus the focused UI navigation scenario provide the meaningful automated coverage.

### iPhone Control Light

| Before | After |
| --- | --- |
| <img width="260" alt="iphone-control-before-light" src="https://github.com/user-attachments/assets/62f88768-4476-43e3-846a-bdcd19d76b14" /> | <img width="260" alt="iphone-control-after-light" src="https://github.com/user-attachments/assets/b9638c2c-7c48-4567-9095-92fc5ae1986c" /> |

### iPhone Control Dark

| Before | After |
| --- | --- |
| <img width="260" alt="iphone-control-before-dark" src="https://github.com/user-attachments/assets/9f9f76a5-adf7-4e70-b29e-388f4c3353fd" /> | <img width="260" alt="iphone-control-after-dark" src="https://github.com/user-attachments/assets/4a1405c1-809c-405b-82ff-3d36660bad3f" /> |

Notes:
- Screenshot files are PR evidence only and are not committed.
