### PR TITLE
fix: sync placeholder CLI command descriptions with registered descriptions

### DIFF
--- a/src/cli/program/core-command-descriptors.ts
+++ b/src/cli/program/core-command-descriptors.ts
@@ -8,17 +8,17 @@ export type CoreCliCommandDescriptor = NamedCommandDescriptor;
 const coreCliCommandCatalog = defineCommandDescriptorCatalog([
   {
     name: "crestodian",
-    description: "Open the interactive setup and repair assistant",
+    description: "Open the ring-zero setup and repair helper",
     hasSubcommands: false,
   },
   {
     name: "setup",
-    description: "Initialize local config and an agent workspace",
+    description: "Alias for openclaw onboard",
     hasSubcommands: false,
   },
   {
     name: "onboard",
-    description: "Interactive onboarding for gateway, workspace, and skills",
+    description: "Guided setup for auth, models, Gateway, workspace, channels, and skills",
     hasSubcommands: false,
   },
   {
@@ -29,7 +29,7 @@ const coreCliCommandCatalog = defineCommandDescriptorCatalog([
   {
     name: "config",
     description:
-      "Non-interactive config helpers (get/set/unset/file/validate). Default: starts guided setup.",
+      "Non-interactive config helpers (get/set/patch/unset/file/schema/validate). Run without subcommand for guided setup.",
     hasSubcommands: true,
   },
   {
@@ -44,7 +44,7 @@ const coreCliCommandCatalog = defineCommandDescriptorCatalog([
   },
   {
     name: "doctor",
-    description: "Diagnose and repair config, Gateway, plugin, and channel problems",
+    description: "Health checks + quick fixes for the gateway and channels",
     hasSubcommands: false,
   },
   {
@@ -64,12 +64,12 @@ const coreCliCommandCatalog = defineCommandDescriptorCatalog([
   },
   {
     name: "message",
-    description: "Send, read, and manage channel messages",
+    description: "Send, read, and manage messages and channel actions",
     hasSubcommands: true,
   },
   {
     name: "mcp",
-    description: "Manage OpenClaw MCP config and channel bridge",
+    description: "Manage OpenClaw mcp.servers config and channel bridge",
     hasSubcommands: true,
     parentDefaultHelp: true,
   },
@@ -80,22 +80,22 @@ const coreCliCommandCatalog = defineCommandDescriptorCatalog([
   },
   {
     name: "agent",
-    description: "Run one agent turn via the Gateway",
+    description: "Run an agent turn via the Gateway (use --local for embedded)",
     hasSubcommands: false,
   },
   {
     name: "agents",
-    description: "Manage isolated agents (workspaces, auth, routing)",
+    description: "Manage isolated agents (workspaces + auth + routing)",
     hasSubcommands: true,
   },
   {
     name: "status",
-    description: "Show Gateway, channel, model, and recent-session status",
+    description: "Show channel health and recent session recipients",
     hasSubcommands: false,
   },
   {
     name: "health",
-    description: "Fetch detailed health from the running Gateway",
+    description: "Fetch health from the running gateway",
     hasSubcommands: false,
   },
   {
@@ -110,7 +110,7 @@ const coreCliCommandCatalog = defineCommandDescriptorCatalog([
   },
   {
     name: "tasks",
-    description: "Inspect durable background tasks and flows",
+    description: "Inspect durable background tasks and TaskFlow state",
     hasSubcommands: true,
   },
 ] as const satisfies ReadonlyArray<CoreCliCommandDescriptor>);

--- a/src/cli/program/subcli-descriptors.ts
+++ b/src/cli/program/subcli-descriptors.ts
@@ -7,31 +7,31 @@ import { isPrivateQaCliEnabled } from "./private-qa-cli.js";
 export type SubCliDescriptor = NamedCommandDescriptor;
 
 const subCliCommandCatalog = defineCommandDescriptorCatalog([
-  { name: "acp", description: "Run and manage ACP-backed coding agents", hasSubcommands: true },
+  { name: "acp", description: "Run an ACP bridge backed by the Gateway", hasSubcommands: true },
   {
     name: "gateway",
-    description: "Run, inspect, and query the OpenClaw Gateway",
+    description: "Run, inspect, and query the WebSocket Gateway",
     hasSubcommands: true,
   },
   {
     name: "daemon",
-    description: "Manage the Gateway service (legacy alias)",
+    description: "Manage the Gateway service (launchd/systemd/schtasks)",
     hasSubcommands: true,
   },
-  { name: "logs", description: "Tail Gateway logs locally or via RPC", hasSubcommands: false },
+  { name: "logs", description: "Tail gateway file logs via RPC", hasSubcommands: false },
   {
     name: "system",
-    description: "System events, heartbeat, and presence",
+    description: "System tools (events, heartbeat, presence)",
     hasSubcommands: true,
   },
   {
     name: "models",
-    description: "List, scan, and set model providers",
+    description: "Model discovery, scanning, and configuration",
     hasSubcommands: true,
   },
   {
     name: "infer",
-    description: "Run provider-backed model, media, search, and embedding commands",
+    description: "Run provider-backed inference commands through a stable CLI surface",
     hasSubcommands: true,
   },
   {
@@ -52,12 +52,12 @@ const subCliCommandCatalog = defineCommandDescriptorCatalog([
   },
   {
     name: "nodes",
-    description: "Pair nodes and run node-host commands through the Gateway",
+    description: "Manage gateway-owned nodes (pairing, status, invoke, and media)",
     hasSubcommands: true,
   },
   {
     name: "devices",
-    description: "Device pairing + token management",
+    description: "Device pairing and auth tokens",
     hasSubcommands: true,
     parentDefaultHelp: true,
   },
@@ -68,7 +68,7 @@ const subCliCommandCatalog = defineCommandDescriptorCatalog([
   },
   {
     name: "sandbox",
-    description: "Manage sandbox containers for agent isolation",
+    description: "Manage sandbox containers (Docker-based agent isolation)",
     hasSubcommands: true,
   },
   {
@@ -93,7 +93,7 @@ const subCliCommandCatalog = defineCommandDescriptorCatalog([
   },
   {
     name: "cron",
-    description: "Schedule and inspect Gateway background jobs",
+    description: "Manage cron jobs (via Gateway)",
     hasSubcommands: true,
     parentDefaultHelp: true,
   },
@@ -129,7 +129,7 @@ const subCliCommandCatalog = defineCommandDescriptorCatalog([
   },
   {
     name: "qr",
-    description: "Generate mobile pairing QR/setup code",
+    description: "Generate a mobile pairing QR code and setup code",
     hasSubcommands: false,
   },
   {
@@ -144,13 +144,13 @@ const subCliCommandCatalog = defineCommandDescriptorCatalog([
   },
   {
     name: "plugins",
-    description: "Install, enable, disable, and inspect plugins",
+    description: "Manage OpenClaw plugins and extensions",
     hasSubcommands: true,
     parentDefaultHelp: true,
   },
   {
     name: "channels",
-    description: "Add, remove, login, and inspect messaging channels",
+    description: "Manage connected chat channels and accounts",
     hasSubcommands: true,
     parentDefaultHelp: true,
   },


### PR DESCRIPTION
## What Problem This Solves

Fixes #98978. The static command descriptor catalogs (`core-command-descriptors.ts` and `subcli-descriptors.ts`) contain placeholder descriptions used in `openclaw --help` output. These had drifted out of sync with the actual descriptions registered at command registration time, causing different text between `openclaw --help` and `<command> --help`.

## Why This Change Was Made

Updated 12 core command descriptions and 14 sub-CLI command descriptions to match the current registered descriptions from the actual command registration code.

## Evidence

Before (`openclaw --help` showed stale descriptions):
- `setup` → "Initialize local config and an agent workspace" (actual: "Alias for openclaw onboard")
- `doctor` → "Diagnose and repair config, Gateway, plugin, and channel problems" (actual: "Health checks + quick fixes for the gateway and channels")
- `agents` → "Manage isolated agents (workspaces, auth, routing)" (actual: "Manage isolated agents (workspaces + auth + routing)")
- etc.

After (descriptors match):
```
$ npx tsx -e "
const { CORE_CLI_COMMAND_DESCRIPTORS } = require('./dist/cli/program/core-command-descriptors.js');
CORE_CLI_COMMAND_DESCRIPTORS.forEach(d => console.log(d.name + ': ' + d.description));
"
```

All 26 updated descriptions now match the registered command descriptions exactly.

## Merge Risk

Low — text-only changes to placeholder descriptions, no logic changes.