### PR TITLE
fix(cli): complete command aliases in shell completion

### DIFF
--- a/src/cli/completion-cli.test.ts
+++ b/src/cli/completion-cli.test.ts
@@ -31,6 +31,17 @@ function createCompletionProgram(): Command {
   sessions.option("--verbose", "Verbose output");
   sessions.command("cleanup").description("Clean sessions").option("--dry-run", "Preview cleanup");
 
+  const infer = program.command("infer").alias("capability").description("Infer capabilities");
+  infer.option("--json", "JSON output");
+  infer.command("scan").description("Scan project");
+
+  const cron = program.command("cron").description("Cron commands");
+  cron.command("add").alias("create").description("Add a cron job").option("--json", "JSON output");
+  cron.command("rm").aliases(["remove", "delete"]).description("Remove a cron job");
+
+  const plugins = program.command("plugins").description("Plugin commands");
+  plugins.command("inspect").alias("info").description("Inspect plugin");
+
   return program;
 }
 
@@ -44,6 +55,18 @@ describe("completion-cli", () => {
     expect(script).toContain("--force[Force the action]");
     expect(script).toContain("\\`models status --json\\`");
     expect(script).toContain("\\$OPENCLAW_STATE_DIR");
+  });
+
+  it("includes command aliases in zsh completions and dispatch cases", () => {
+    const script = getCompletionScript("zsh", createCompletionProgram());
+
+    expect(script).toContain("'capability[Infer capabilities]'");
+    expect(script).toContain("(infer|capability) _openclaw_infer ;;");
+    expect(script).toContain("'create[Add a cron job]'");
+    expect(script).toContain("(add|create) _openclaw_cron_add ;;");
+    expect(script).toContain("'remove[Remove a cron job]'");
+    expect(script).toContain("'delete[Remove a cron job]'");
+    expect(script).toContain("'info[Inspect plugin]'");
   });
 
   it("escapes zsh option descriptions for double-quoted arguments specs", () => {
@@ -122,6 +145,17 @@ describe("completion-cli", () => {
     expect(script).not.toContain("'-t,'");
   });
 
+  it("includes command aliases in PowerShell completions and command paths", () => {
+    const script = getCompletionScript("powershell", createCompletionProgram());
+
+    expect(script).toContain("'infer','capability'");
+    expect(script).toContain("if ($commandPath -eq 'capability') {");
+    expect(script).toContain("$completions = @('scan','--json')");
+    expect(script).toContain("$completions = @('add','create','rm','remove','delete')");
+    expect(script).toContain("if ($commandPath -eq 'cron create') {");
+    expect(script).toContain("$completions = @('inspect','info')");
+  });
+
   it("generates valid PowerShell root arrays when commands or options are empty", () => {
     const commandsOnly = new Command().name("openclaw");
     commandsOnly.command("status");
@@ -152,6 +186,23 @@ describe("completion-cli", () => {
     expect(script).toContain("if contains -- $flag $value_options");
   });
 
+  it("includes command aliases in fish completions and alias path conditions", () => {
+    const script = getCompletionScript("fish", createCompletionProgram());
+
+    expect(script).toContain(
+      'complete -c openclaw -n "__fish_use_subcommand" -a "capability" -d \'Infer capabilities\'',
+    );
+    expect(script).toContain(
+      'complete -c openclaw -n "__openclaw_command_path_matches cron --" -a "create" -d \'Add a cron job\'',
+    );
+    expect(script).toContain(
+      "complete -c openclaw -n \"__openclaw_command_path_matches cron add --; or __openclaw_command_path_matches cron create --\" -l json -d 'JSON output'",
+    );
+    expect(script).toContain(
+      'complete -c openclaw -n "__openclaw_command_path_matches plugins --" -a "info" -d \'Inspect plugin\'',
+    );
+  });
+
   it("scopes fish value-taking option skips to the active command path", () => {
     const script = getCompletionScript("fish", createCompletionProgram());
 
@@ -168,5 +219,15 @@ describe("completion-cli", () => {
 
     expect(script).toContain("--token");
     expect(script).not.toContain("-t,");
+  });
+
+  it("includes command aliases in Bash completions and case labels", () => {
+    const script = getCompletionScript("bash", createCompletionProgram());
+
+    expect(script).toContain("infer capability");
+    expect(script).toContain("infer|capability)");
+    expect(script).toContain('opts="add create rm remove delete');
+    expect(script).toContain("add create");
+    expect(script).toContain("inspect info");
   });
 });

--- a/src/cli/completion-cli.ts
+++ b/src/cli/completion-cli.ts
@@ -48,6 +48,47 @@ function fishWords(values: readonly string[]): string {
   return values.join(" ");
 }
 
+function uniqueCompletionWords(values: readonly string[]): string[] {
+  const seen = new Set<string>();
+  const result: string[] = [];
+  for (const value of values) {
+    if (value.length === 0 || seen.has(value)) {
+      continue;
+    }
+    seen.add(value);
+    result.push(value);
+  }
+  return result;
+}
+
+function commandCompletionNames(cmd: Command): string[] {
+  return uniqueCompletionWords([cmd.name(), ...cmd.aliases()]);
+}
+
+function commandCompletionPattern(cmd: Command): string {
+  return commandCompletionNames(cmd).join("|");
+}
+
+function subcommandCompletionNames(cmd: Command): string[] {
+  return uniqueCompletionWords(cmd.commands.flatMap((sub) => commandCompletionNames(sub)));
+}
+
+function commandPathNameVariants(commands: readonly Command[]): string[][] {
+  let variants: string[][] = [[]];
+  for (const command of commands) {
+    const names = commandCompletionNames(command);
+    variants = variants.flatMap((variant) => names.map((name) => [...variant, name]));
+  }
+  return variants;
+}
+
+function commandPathStrings(commands: readonly Command[]): string[] {
+  if (commands.length === 0) {
+    return [];
+  }
+  return commandPathNameVariants(commands).map((variant) => variant.join(" "));
+}
+
 function fishOptionFlags(options: Command["options"], wantsValue: boolean): string[] {
   return options.flatMap((option) => {
     if ((option.required || option.optional) !== wantsValue) {
@@ -59,17 +100,12 @@ function fishOptionFlags(options: Command["options"], wantsValue: boolean): stri
 
 function collectFishPathOptionFlags(
   program: Command,
-  parents: readonly string[],
+  parents: readonly Command[],
   wantsValue: boolean,
 ): string[] {
   const flags = new Set(fishOptionFlags(program.options, wantsValue));
-  let current: Command | undefined = program;
-  for (const name of parents) {
-    current = current?.commands.find((cmd) => cmd.name() === name);
-    if (!current) {
-      break;
-    }
-    for (const flag of fishOptionFlags(current.options, wantsValue)) {
+  for (const command of parents) {
+    for (const flag of fishOptionFlags(command.options, wantsValue)) {
       flags.add(flag);
     }
   }
@@ -128,10 +164,14 @@ end
 function fishCommandPathCondition(
   program: Command,
   rootCmd: string,
-  parents: readonly string[],
+  parents: readonly Command[],
 ): string {
   const valueOptions = collectFishPathOptionFlags(program, parents, true);
-  return `__${rootCmd}_command_path_matches ${parents.join(" ")} -- ${fishWords(valueOptions)}`.trimEnd();
+  return commandPathNameVariants(parents)
+    .map((variant) =>
+      `__${rootCmd}_command_path_matches ${variant.join(" ")} -- ${fishWords(valueOptions)}`.trimEnd(),
+    )
+    .join("; or ");
 }
 
 async function writeCompletionCache(params: {
@@ -258,7 +298,7 @@ _${rootCmd}_root_completion() {
   case $state in
     (args)
       case $line[1] in
-        ${program.commands.map((cmd) => `(${cmd.name()}) _${rootCmd}_${cmd.name().replace(/-/g, "_")} ;;`).join("\n        ")}
+        ${program.commands.map((cmd) => `(${commandCompletionPattern(cmd)}) _${rootCmd}_${cmd.name().replace(/-/g, "_")} ;;`).join("\n        ")}
       esac
       ;;
   esac
@@ -304,14 +344,14 @@ function generateZshArgs(cmd: Command): string {
 
 function generateZshSubcmdList(cmd: Command): string {
   const list = cmd.commands
-    .map((c) => {
+    .flatMap((c) => {
       const desc = c
         .description()
         .replace(/\\/g, "\\\\")
         .replace(/'/g, "'\\''")
         .replace(/\[/g, "\\[")
         .replace(/\]/g, "\\]");
-      return `'${c.name()}[${desc}]'`;
+      return commandCompletionNames(c).map((name) => `'${name}[${desc}]'`);
     })
     .join(" ");
   return `"1: :_values 'command' ${list}"`;
@@ -353,7 +393,7 @@ ${funcName}() {
   case $state in
     (args)
       case $line[1] in
-        ${subCommands.map((sub) => `(${sub.name()}) ${funcName}_${sub.name().replace(/-/g, "_")} ;;`).join("\n        ")}
+        ${subCommands.map((sub) => `(${commandCompletionPattern(sub)}) ${funcName}_${sub.name().replace(/-/g, "_")} ;;`).join("\n        ")}
       esac
       ;;
   esac
@@ -390,7 +430,7 @@ _${rootCmd}_completion() {
     prev="\${COMP_WORDS[COMP_CWORD-1]}"
     
     # Simple top-level completion for now
-    opts="${program.commands.map((c) => c.name()).join(" ")} ${program.options.map((o) => preferredCompletionFlag(o.flags)).join(" ")}"
+    opts="${subcommandCompletionNames(program).join(" ")} ${program.options.map((o) => preferredCompletionFlag(o.flags)).join(" ")}"
     
     case "\${prev}" in
       ${program.commands.map((cmd) => generateBashSubcommand(cmd)).join("\n      ")}
@@ -411,8 +451,8 @@ complete -F _${rootCmd}_completion ${rootCmd}
 function generateBashSubcommand(cmd: Command): string {
   // This is a naive implementation; fully recursive bash completion is complex to generate as a single string without improved state tracking.
   // For now, let's provide top-level command recognition.
-  return `${cmd.name()})
-        opts="${cmd.commands.map((c) => c.name()).join(" ")} ${cmd.options.map((o) => preferredCompletionFlag(o.flags)).join(" ")}"
+  return `${commandCompletionPattern(cmd)})
+        opts="${subcommandCompletionNames(cmd).join(" ")} ${cmd.options.map((o) => preferredCompletionFlag(o.flags)).join(" ")}"
         COMPREPLY=( $(compgen -W "\${opts}" -- \${cur}) )
         return 0
         ;;`;
@@ -424,16 +464,17 @@ function generatePowerShellCompletion(program: Command): string {
   const formatPowerShellArray = (entries: string[]) =>
     entries.length > 0 ? `@(${entries.map((entry) => `'${entry}'`).join(",")})` : "@()";
 
-  const visit = (cmd: Command, pathSegments: string[]) => {
-    const fullPath = pathSegments.join(" ");
+  const visit = (cmd: Command, pathSegments: Command[]) => {
+    const fullPaths = commandPathStrings(pathSegments);
 
     // Command completion for this level
-    const subCommands = cmd.commands.map((c) => c.name());
+    const subCommands = subcommandCompletionNames(cmd);
     const options = cmd.options.map((o) => preferredCompletionFlag(o.flags));
     const allCompletions = formatPowerShellArray([...subCommands, ...options]);
 
-    if (fullPath.length > 0 && [...subCommands, ...options].length > 0) {
-      segments.push(`
+    if (fullPaths.length > 0 && [...subCommands, ...options].length > 0) {
+      for (const fullPath of fullPaths) {
+        segments.push(`
             if ($commandPath -eq '${fullPath}') {
                 $completions = ${allCompletions}
                 $completions | Where-Object { $_ -like "$wordToComplete*" } | ForEach-Object {
@@ -441,10 +482,11 @@ function generatePowerShellCompletion(program: Command): string {
                 }
             }
 `);
+      }
     }
 
     for (const sub of cmd.commands) {
-      visit(sub, [...pathSegments, sub.name()]);
+      visit(sub, [...pathSegments, sub]);
     }
   };
 
@@ -471,7 +513,7 @@ Register-ArgumentCompleter -Native -CommandName ${rootCmd} -ScriptBlock {
     # Root command
     if ($commandPath -eq "") {
          $completions = ${formatPowerShellArray([
-           ...program.commands.map((command) => command.name()),
+           ...subcommandCompletionNames(program),
            ...program.options.map((option) => preferredCompletionFlag(option.flags)),
          ])}
          $completions | Where-Object { $_ -like "$wordToComplete*" } | ForEach-Object {
@@ -488,19 +530,21 @@ function generateFishCompletion(program: Command): string {
   const rootCmd = program.name();
   const segments: string[] = [generateFishPathHelper(rootCmd)];
 
-  const visit = (cmd: Command, parents: string[]) => {
+  const visit = (cmd: Command, parents: Command[]) => {
     // Root logic
     if (parents.length === 0) {
       // Subcommands of root
       for (const sub of cmd.commands) {
-        segments.push(
-          buildFishSubcommandCompletionLine({
-            rootCmd,
-            condition: "__fish_use_subcommand",
-            name: sub.name(),
-            description: sub.description(),
-          }),
-        );
+        for (const name of commandCompletionNames(sub)) {
+          segments.push(
+            buildFishSubcommandCompletionLine({
+              rootCmd,
+              condition: "__fish_use_subcommand",
+              name,
+              description: sub.description(),
+            }),
+          );
+        }
       }
       // Options of root
       for (const opt of cmd.options) {
@@ -517,14 +561,16 @@ function generateFishCompletion(program: Command): string {
       const condition = fishCommandPathCondition(program, rootCmd, parents);
       // Subcommands
       for (const sub of cmd.commands) {
-        segments.push(
-          buildFishSubcommandCompletionLine({
-            rootCmd,
-            condition,
-            name: sub.name(),
-            description: sub.description(),
-          }),
-        );
+        for (const name of commandCompletionNames(sub)) {
+          segments.push(
+            buildFishSubcommandCompletionLine({
+              rootCmd,
+              condition,
+              name,
+              description: sub.description(),
+            }),
+          );
+        }
       }
       // Options
       for (const opt of cmd.options) {
@@ -540,7 +586,7 @@ function generateFishCompletion(program: Command): string {
     }
 
     for (const sub of cmd.commands) {
-      visit(sub, parents.length === 0 ? [sub.name()] : [...parents, sub.name()]);
+      visit(sub, parents.length === 0 ? [sub] : [...parents, sub]);
     }
   };
 


### PR DESCRIPTION
Closes #99406

## What Problem This Solves

Fixes an issue where users who rely on shell completion could type accepted command aliases such as `openclaw capability`, `openclaw chat`, `openclaw terminal`, or `openclaw cron create`, but those aliases did not tab-complete and did not keep nested completion working after the alias segment.

## Why This Change Was Made

The completion generators now use each Commander's canonical command name plus registered aliases when building command lists, dispatch patterns, and nested path checks. The fix stays inside completion generation and does not change command registration, parsing, or runtime command behavior.

## User Impact

Users get tab completion for the same command spellings that the CLI already accepts. Root aliases and nested aliases complete across zsh, bash, fish, and PowerShell, and completion continues after an alias path such as `cron create`.

## Evidence

- `node scripts/run-vitest.mjs src/cli/completion-cli.test.ts src/cli/completion-fish.test.ts src/cli/program/register.subclis.test.ts` -> passed 2 Vitest shards.
- `./node_modules/.bin/oxfmt --check --threads=1 src/cli/completion-cli.ts src/cli/completion-cli.test.ts` -> all matched files use the correct format.
- `git diff --check` -> passed.
- `node scripts/run-tsgo.mjs -p test/tsconfig/tsconfig.core.test.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/core-test.tsbuildinfo` -> passed.

## Real behavior proof

**Behavior addressed:** Shell completion generation now includes registered Commander command aliases and keeps nested completion working when an alias appears in the command path.

**Environment tested:** Linux source checkout, Node with `tsx`, Commander-backed real OpenClaw CLI registrars for capability, TUI, exec approvals, cron, and plugins.

**Steps run after the patch:** Called the actual `getCompletionScript` production function from source after registering the real affected CLI command groups, then wrote zsh, bash, PowerShell, and fish completion scripts under `/tmp` and counted the alias entries.

```bash
env TMPDIR=/tmp/openclaw-99406-proof node --import tsx --no-warnings -e 'import { Command } from "commander";
import { writeFileSync } from "node:fs";
import { getCompletionScript } from "./src/cli/completion-cli.ts";
import { registerCapabilityCli } from "./src/cli/capability-cli.ts";
import { registerTuiCli } from "./src/cli/tui-cli.ts";
import { registerExecApprovalsCli } from "./src/cli/exec-approvals-cli.ts";
import { registerCronCli } from "./src/cli/cron-cli.ts";
import { registerPluginsCli } from "./src/cli/plugins-cli.ts";
const quote = String.fromCharCode(39);
const program = new Command().name("openclaw");
registerCapabilityCli(program);
registerTuiCli(program);
registerExecApprovalsCli(program);
registerCronCli(program);
registerPluginsCli(program);
const checks = {
  zsh: [quote + "capability[", quote + "terminal[", quote + "chat[", quote + "exec-approvals[", quote + "create[Add a cron job]" + quote, quote + "remove[", quote + "delete[", quote + "info["],
  bash: ["capability", "terminal", "chat", "exec-approvals", "create", "remove", "delete", "info"],
  powershell: [quote + "capability" + quote, quote + "terminal" + quote, quote + "chat" + quote, quote + "exec-approvals" + quote, quote + "create" + quote, quote + "remove" + quote, quote + "delete" + quote, quote + "info" + quote, "cron create"],
  fish: ["-a \"capability\"", "-a \"terminal\"", "-a \"chat\"", "-a \"exec-approvals\"", "-a \"create\"", "-a \"remove\"", "-a \"delete\"", "-a \"info\"", "cron create"],
};
for (const shell of ["zsh", "bash", "powershell", "fish"]) {
  const script = getCompletionScript(shell, program);
  writeFileSync("/tmp/openclaw-99406-" + shell + ".completion", script);
  console.log(shell + ":");
  for (const needle of checks[shell]) {
    const count = script.split(needle).length - 1;
    console.log("  " + needle + " => " + count);
  }
}'
```

**Evidence after fix:**

```text
zsh:
  'capability[ => 1
  'terminal[ => 1
  'chat[ => 1
  'exec-approvals[ => 1
  'create[Add a cron job]' => 1
  'remove[ => 2
  'delete[ => 1
  'info[ => 1
bash:
  capability => 2
  terminal => 2
  chat => 2
  exec-approvals => 2
  create => 1
  remove => 1
  delete => 1
  info => 1
powershell:
  'capability' => 2
  'terminal' => 2
  'chat' => 2
  'exec-approvals' => 2
  'create' => 3
  'remove' => 3
  'delete' => 1
  'info' => 1
  cron create => 1
fish:
  -a "capability" => 1
  -a "terminal" => 1
  -a "chat" => 1
  -a "exec-approvals" => 1
  -a "create" => 2
  -a "remove" => 2
  -a "delete" => 1
  -a "info" => 1
  cron create => 46
```

**Observed result after the fix:** Each shell completion script contains the accepted aliases from the real command registrations, and alias path output is present for nested paths such as `cron create`.

**Not tested:** I did not source the completion scripts inside interactive zsh, bash, fish, or PowerShell sessions; this verification covers the production completion scripts and focused generator tests.
