### PR TITLE
fix(ios): contacts.add crashes the app via unfetched CNContactFormatter keys

### DIFF
--- a/apps/ios/Sources/Contacts/ContactsService.swift
+++ b/apps/ios/Sources/Contacts/ContactsService.swift
@@ -11,10 +11,9 @@ final class ContactsService: ContactsServicing {
             CNContactOrganizationNameKey as CNKeyDescriptor,
             CNContactPhoneNumbersKey as CNKeyDescriptor,
             CNContactEmailAddressesKey as CNKeyDescriptor,
-            // CNContactFormatter reads name components (middle name, prefixes, phonetic
-            // fields) beyond the ones above. Without its descriptor the formatter accesses
-            // an unfetched key and CNContact raises CNPropertyNotFetchedException, which is
-            // an Objective-C exception that crashes the app. See payload(from:).
+            // CNContactFormatter requires more keys than payload(from:) accesses directly.
+            // Fetch its declared key set; formatting a partial contact otherwise raises an
+            // Objective-C CNContactPropertyNotFetchedException and crashes the app.
             CNContactFormatter.descriptorForRequiredKeys(for: .fullName),
         ]
     }

--- a/apps/ios/Sources/Contacts/ContactsService.swift
+++ b/apps/ios/Sources/Contacts/ContactsService.swift
@@ -11,6 +11,11 @@ final class ContactsService: ContactsServicing {
             CNContactOrganizationNameKey as CNKeyDescriptor,
             CNContactPhoneNumbersKey as CNKeyDescriptor,
             CNContactEmailAddressesKey as CNKeyDescriptor,
+            // CNContactFormatter reads name components (middle name, prefixes, phonetic
+            // fields) beyond the ones above. Without its descriptor the formatter accesses
+            // an unfetched key and CNContact raises CNPropertyNotFetchedException, which is
+            // an Objective-C exception that crashes the app. See payload(from:).
+            CNContactFormatter.descriptorForRequiredKeys(for: .fullName),
         ]
     }
 

--- a/extensions/feishu/src/streaming-card.test.ts
+++ b/extensions/feishu/src/streaming-card.test.ts
@@ -187,6 +187,37 @@ describe("FeishuStreamingSession", () => {
     });
   });
 
+  it("handles a rejected scheduled flush update", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(1_500);
+    const updateBodies: string[] = [];
+    mockFetches(updateBodies);
+    const log = vi.fn();
+    const session = new FeishuStreamingSession(
+      {} as never,
+      { appId: "app_rejected_pending_flush", appSecret: "secret" },
+      log,
+    );
+    setStreamingSessionInternals(session, {
+      state: {
+        cardId: "card_rejected_flush",
+        messageId: "om_rejected_flush",
+        sequence: 1,
+        currentText: "hello",
+        sentText: "hello",
+        hasNote: false,
+      },
+      lastUpdateTime: 1_500,
+    });
+
+    await session.update("hello small");
+    vi.spyOn(session, "update").mockRejectedValueOnce(new Error("flush exploded"));
+    await vi.advanceTimersByTimeAsync(160);
+
+    expect(log).toHaveBeenCalledWith("Scheduled flush update failed: Error: flush exploded");
+    expect(updateBodies).toHaveLength(0);
+  });
+
   it("pushes natural-boundary updates immediately inside the throttle window", async () => {
     vi.useFakeTimers();
     vi.setSystemTime(2_000);

--- a/extensions/feishu/src/streaming-card.ts
+++ b/extensions/feishu/src/streaming-card.ts
@@ -452,7 +452,9 @@ export class FeishuStreamingSession {
       if (!pending || this.closed) {
         return;
       }
-      void this.update(pending);
+      void this.update(pending).catch((error: unknown) =>
+        this.log?.(`Scheduled flush update failed: ${String(error)}`),
+      );
     }, delayMs);
   }
 

--- a/packages/agent-core/src/harness/compaction/compaction-trailing-toolresult.test.ts
+++ b/packages/agent-core/src/harness/compaction/compaction-trailing-toolresult.test.ts
@@ -41,6 +41,26 @@ function toolResultText(text: string, timestamp: number): AgentMessage {
   };
 }
 
+function nestedToolResult(
+  block: { type: string; content?: unknown; text?: string },
+  timestamp: number,
+): AgentMessage {
+  return {
+    role: "toolResult",
+    toolCallId: "call-1",
+    toolName: "codex_progress",
+    content: [
+      {
+        id: "call-1",
+        toolUseId: "call-1",
+        ...block,
+      },
+    ],
+    isError: false,
+    timestamp,
+  } as unknown as AgentMessage;
+}
+
 function messageEntry(message: AgentMessage, index: number): SessionTreeEntry {
   return {
     type: "message",
@@ -52,12 +72,16 @@ function messageEntry(message: AgentMessage, index: number): SessionTreeEntry {
 }
 
 function buildTranscript(): SessionTreeEntry[] {
+  return buildTranscriptWithToolResult(toolResultText(LARGE_TOOL_OUTPUT, 5));
+}
+
+function buildTranscriptWithToolResult(toolResult: AgentMessage): SessionTreeEntry[] {
   const messages: AgentMessage[] = [
     userText("start of the conversation", 1),
     assistantText("first reply", 2),
     userText("please run the command", 3),
     assistantText("running it now", 4),
-    toolResultText(LARGE_TOOL_OUTPUT, 5),
+    toolResult,
   ];
   return messages.map((message, index) => messageEntry(message, index));
 }
@@ -72,6 +96,26 @@ describe("findCutPoint with a trailing oversized tool result", () => {
   it("trims the prefix instead of keeping the whole transcript", () => {
     const entries = buildTranscript();
 
+    const result = findCutPoint(entries, 0, entries.length, KEEP_RECENT_TOKENS);
+
+    expect(result.firstKeptEntryIndex).toBeGreaterThan(0);
+    expect(result.firstKeptEntryIndex).toBe(3);
+  });
+
+  it.each([
+    {
+      name: "Codex toolResult text",
+      block: { type: "toolResult", content: "duplicate", text: LARGE_TOOL_OUTPUT },
+    },
+    {
+      name: "snake-case tool_result content",
+      block: { type: "tool_result", content: LARGE_TOOL_OUTPUT },
+    },
+  ])("counts and trims the prefix for $name", ({ block }) => {
+    const trailing = nestedToolResult(block, 5);
+    const entries = buildTranscriptWithToolResult(trailing);
+
+    expect(estimateTokens(trailing)).toBeGreaterThanOrEqual(KEEP_RECENT_TOKENS);
     const result = findCutPoint(entries, 0, entries.length, KEEP_RECENT_TOKENS);
 
     expect(result.firstKeptEntryIndex).toBeGreaterThan(0);

--- a/packages/agent-core/src/harness/compaction/compaction.ts
+++ b/packages/agent-core/src/harness/compaction/compaction.ts
@@ -37,6 +37,7 @@ import {
   extractFileOpsFromMessage,
   type FileOperations,
   formatFileOperations,
+  getCompactionContentBlockText,
   serializeConversation,
 } from "./utils.js";
 
@@ -246,13 +247,15 @@ export function shouldCompact(
 
 const IMAGE_BLOCK_CHARS = 4800;
 
-function countContentBlockChars(content: Array<{ type: string; text?: string }>): number {
+function countContentBlockChars(
+  content: Array<{ type: string; content?: unknown; text?: string }>,
+): number {
   let chars = 0;
   for (const block of content) {
-    if (block.type === "text" && block.text) {
-      chars += block.text.length;
-    } else if (block.type === "image") {
+    if (block.type === "image") {
       chars += IMAGE_BLOCK_CHARS;
+    } else {
+      chars += getCompactionContentBlockText(block).length;
     }
   }
   return chars;

--- a/packages/agent-core/src/harness/compaction/utils.test.ts
+++ b/packages/agent-core/src/harness/compaction/utils.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "vitest";
+import type { Message } from "../../../../llm-core/src/index.js";
+import { serializeConversation } from "./utils.js";
+
+describe("serializeConversation", () => {
+  it.each([
+    {
+      name: "Codex nested toolResult text",
+      block: {
+        type: "toolResult",
+        id: "call-1",
+        toolUseId: "call-1",
+        content: "duplicate fallback",
+        text: "codex nested output",
+      },
+      expected: "codex nested output",
+    },
+    {
+      name: "snake-case nested tool_result content fallback",
+      block: {
+        type: "tool_result",
+        content: "fallback output",
+      },
+      expected: "fallback output",
+    },
+  ])("serializes $name", ({ block, expected }) => {
+    const messages = [
+      {
+        role: "toolResult",
+        content: [block],
+      },
+    ] as unknown as Message[];
+
+    expect(serializeConversation(messages)).toBe(`[Tool result]: ${expected}`);
+  });
+});

--- a/packages/agent-core/src/harness/compaction/utils.ts
+++ b/packages/agent-core/src/harness/compaction/utils.ts
@@ -109,6 +109,24 @@ function truncateForSummary(text: string, maxChars: number): string {
   return `${text.slice(0, maxChars)}\n\n[... ${truncatedChars} more characters truncated]`;
 }
 
+/** Extract text that compaction both estimates and includes in summary prompts. */
+export function getCompactionContentBlockText(block: {
+  type: string;
+  content?: unknown;
+  text?: string;
+}): string {
+  if (block.type === "text" && block.text) {
+    return block.text;
+  }
+  if (block.type !== "toolResult" && block.type !== "tool_result") {
+    return "";
+  }
+  if (block.text) {
+    return block.text;
+  }
+  return typeof block.content === "string" ? block.content : "";
+}
+
 /** Serialize LLM messages to plain text for summarization prompts. */
 export function serializeConversation(messages: Message[]): string {
   const parts: string[] = [];
@@ -154,10 +172,7 @@ export function serializeConversation(messages: Message[]): string {
         parts.push(`[Assistant tool calls]: ${toolCalls.join("; ")}`);
       }
     } else if (msg.role === "toolResult") {
-      const content = msg.content
-        .filter((c): c is { type: "text"; text: string } => c.type === "text")
-        .map((c) => c.text)
-        .join("");
+      const content = msg.content.map(getCompactionContentBlockText).join("");
       if (content) {
         parts.push(`[Tool result]: ${truncateForSummary(content, TOOL_RESULT_MAX_CHARS)}`);
       }

--- a/src/agents/memory-search.test.ts
+++ b/src/agents/memory-search.test.ts
@@ -2,6 +2,13 @@
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import type { OpenClawConfig } from "../config/config.js";
 import {
+  clearEmbeddingProviders,
+  listRegisteredEmbeddingProviders,
+  registerEmbeddingProvider,
+  restoreRegisteredEmbeddingProviders,
+  type RegisteredEmbeddingProvider,
+} from "../plugins/embedding-providers.js";
+import {
   clearMemoryEmbeddingProviders,
   registerMemoryEmbeddingProvider,
 } from "../plugins/memory-embedding-providers.js";
@@ -10,6 +17,7 @@ import { resolveOpenClawAgentSqlitePath } from "../state/openclaw-agent-db.paths
 import { resolveMemorySearchConfig, resolveMemorySearchSyncConfig } from "./memory-search.js";
 
 const asConfig = (cfg: OpenClawConfig): OpenClawConfig => cfg;
+let registeredEmbeddingProvidersSnapshot: RegisteredEmbeddingProvider[];
 
 function registerBaseMemoryEmbeddingProviders(options?: { includeGemini?: boolean }): void {
   // Register provider contracts locally so config tests do not depend on the
@@ -67,12 +75,15 @@ function registerBaseMemoryEmbeddingProviders(options?: { includeGemini?: boolea
 
 describe("memory search config", () => {
   beforeEach(() => {
+    registeredEmbeddingProvidersSnapshot = listRegisteredEmbeddingProviders();
+    clearEmbeddingProviders();
     clearMemoryEmbeddingProviders();
     registerBaseMemoryEmbeddingProviders();
   });
 
   afterEach(() => {
     clearMemoryEmbeddingProviders();
+    restoreRegisteredEmbeddingProviders(registeredEmbeddingProvidersSnapshot);
   });
 
   function configWithDefaultProvider(provider: string): OpenClawConfig {
@@ -225,6 +236,21 @@ describe("memory search config", () => {
     const resolved = resolveMemorySearchConfig(configWithDefaultProvider("local"), "main");
 
     expect(resolved?.provider).toBe("local");
+  });
+
+  it("resolves providers from the generic embedding provider registry", () => {
+    registerEmbeddingProvider({
+      id: "generic-local",
+      defaultModel: "local-gguf-default",
+      transport: "local",
+      create: async () => ({ provider: null }),
+    });
+
+    const resolved = resolveMemorySearchConfig(configWithDefaultProvider("generic-local"), "main");
+
+    expect(resolved?.provider).toBe("generic-local");
+    expect(resolved?.model).toBe("local-gguf-default");
+    expect(resolved?.remote).toBeUndefined();
   });
 
   it("resolves explicit provider-none", () => {

--- a/src/agents/memory-search.ts
+++ b/src/agents/memory-search.ts
@@ -135,6 +135,12 @@ const DEFAULT_REMOTE_BATCH_POLL_INTERVAL_MS = 2_000;
 const DEFAULT_REMOTE_BATCH_TIMEOUT_MINUTES = 60;
 const MAX_REMOTE_BATCH_TIMEOUT_MINUTES = Math.floor(MAX_TIMER_TIMEOUT_MS / 60_000);
 
+type ConfiguredMemoryEmbeddingProvider = {
+  defaultModel?: string;
+  transport?: "local" | "remote";
+  supportsMultimodalEmbeddings?: (params: { model: string }) => boolean;
+};
+
 function resolveRemoteBatchPollIntervalMs(
   overrideValue: number | undefined,
   defaultValue: number | undefined,
@@ -178,10 +184,14 @@ function normalizeSources(
 function getConfiguredMemoryEmbeddingProvider(
   providerId: string,
   cfg: OpenClawConfig,
-): ReturnType<typeof getMemoryEmbeddingProvider> {
+): ConfiguredMemoryEmbeddingProvider | undefined {
   const directAdapter = getMemoryEmbeddingProvider(providerId);
   if (directAdapter) {
     return directAdapter;
+  }
+  const genericAdapter = getEmbeddingProvider(providerId, cfg);
+  if (genericAdapter) {
+    return genericAdapter;
   }
   const providerConfig = findNormalizedProviderValue(cfg.models?.providers, providerId);
   const ownerApi = providerConfig?.api?.trim();

--- a/src/auto-reply/reply/commands-name.test.ts
+++ b/src/auto-reply/reply/commands-name.test.ts
@@ -170,6 +170,7 @@ describe("name command", () => {
         totalTokens: 0,
         totalTokensFresh: true,
         label: "Billing rework",
+        displayName: "Dashboard session",
       },
     });
 
@@ -177,6 +178,7 @@ describe("name command", () => {
     const result = await handleNameCommand(params, true);
 
     expect(result?.reply?.text).toContain("Current session name: Billing rework");
+    expect(result?.reply?.text).toContain("Suggested name: Dashboard session");
   });
 
   it("seeds a brand-new native session entry that is not yet persisted", async () => {

--- a/src/auto-reply/reply/commands-name.ts
+++ b/src/auto-reply/reply/commands-name.ts
@@ -83,7 +83,8 @@ export const handleNameCommand: CommandHandler = async (params, allowTextCommand
       getSessionEntry({ sessionKey: params.sessionKey, storePath: params.storePath }) ??
       params.sessionEntry;
     const current = normalizeOptionalString(entry?.label);
-    const suggestion = deriveSessionTitle(entry);
+    const suggestionEntry = entry ? { ...entry, label: undefined } : undefined;
+    const suggestion = deriveSessionTitle(suggestionEntry);
     const lines: string[] = [];
     lines.push(
       current ? `Current session name: ${current}` : "This session has no custom name yet.",

--- a/src/commands/status-all/gateway.test.ts
+++ b/src/commands/status-all/gateway.test.ts
@@ -1,6 +1,17 @@
 // Status-all gateway tests cover log-tail summaries for auth and runtime diagnostic lines.
-import { describe, expect, it } from "vitest";
-import { summarizeLogTail } from "./gateway.js";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { readFileTailLines, summarizeLogTail } from "./gateway.js";
+
+const tempDirs: string[] = [];
+
+afterEach(() => {
+  for (const dir of tempDirs.splice(0)) {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
 
 describe("summarizeLogTail", () => {
   it("marks permanent OAuth refresh failures as reauth-required", () => {
@@ -11,5 +22,20 @@ describe("summarizeLogTail", () => {
     ]);
 
     expect(lines).toEqual(["[openai] token refresh 401 invalid_grant · re-auth required"]);
+  });
+});
+
+describe("readFileTailLines", () => {
+  it("returns complete recent lines from a bounded large-file tail", async () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-status-log-tail-"));
+    tempDirs.push(dir);
+    const file = path.join(dir, "gateway.log");
+    fs.writeFileSync(
+      file,
+      `${"x".repeat(300_000)} partial stale line\nrecent one\nrecent two\n`,
+      "utf8",
+    );
+
+    await expect(readFileTailLines(file, 2)).resolves.toEqual(["recent one", "recent two"]);
   });
 });

--- a/src/commands/status-all/gateway.ts
+++ b/src/commands/status-all/gateway.ts
@@ -1,17 +1,16 @@
 // Gateway log-tail helpers for status diagnostics.
 // Summaries compact repeated auth/runtime failures while preserving enough context for operators.
 
-import fs from "node:fs/promises";
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import { classifyOAuthRefreshFailureReason } from "../../agents/auth-profiles/oauth-refresh-failure.js";
+import { readGatewayLogTailLines } from "../../daemon/diagnostics.js";
 
 /** Reads the last non-empty lines from a gateway log file, returning an empty list on read failure. */
 export async function readFileTailLines(filePath: string, maxLines: number): Promise<string[]> {
-  const raw = await fs.readFile(filePath, "utf8").catch(() => "");
-  if (!raw.trim()) {
+  const lines = await readGatewayLogTailLines(filePath).catch(() => []);
+  if (lines.length === 0) {
     return [];
   }
-  const lines = raw.replace(/\r/g, "").split("\n");
   const out = lines.slice(Math.max(0, lines.length - maxLines));
   return out.map((line) => line.trimEnd()).filter((line) => line.trim().length > 0);
 }

--- a/src/daemon/diagnostics.test.ts
+++ b/src/daemon/diagnostics.test.ts
@@ -1,14 +1,23 @@
 // Daemon diagnostics tests cover service diagnostic collection and formatting.
 import fs from "node:fs";
+import fsPromises from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
-import { afterEach, describe, expect, it } from "vitest";
-import { readLastGatewayErrorLine } from "./diagnostics.js";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { readGatewayLogTailLines, readLastGatewayErrorLine } from "./diagnostics.js";
 import { resolveGatewayLogPaths, resolveGatewaySupervisorLogPaths } from "./restart-logs.js";
 
 const tempDirs: string[] = [];
+const DIAGNOSTIC_TAIL_BYTES = 256 * 1024;
+type PositionalRead = (
+  buffer: Buffer,
+  offset: number,
+  length: number,
+  position: number,
+) => Promise<{ bytesRead: number; buffer: Buffer }>;
 
 afterEach(() => {
+  vi.restoreAllMocks();
   for (const dir of tempDirs.splice(0)) {
     fs.rmSync(dir, { recursive: true, force: true });
   }
@@ -52,5 +61,67 @@ describe("readLastGatewayErrorLine", () => {
     await expect(readLastGatewayErrorLine(env, { platform: "linux" })).resolves.toBe(
       "failed to bind gateway socket EADDRINUSE",
     );
+  });
+
+  it("ignores stale stdout errors outside the bounded diagnostic tail", async () => {
+    const stateDir = makeTempStateDir();
+    const homeDir = makeTempStateDir();
+    const env = { HOME: homeDir, OPENCLAW_STATE_DIR: stateDir };
+    const stateLogs = resolveGatewayLogPaths(env);
+    fs.mkdirSync(stateLogs.logDir, { recursive: true });
+    fs.writeFileSync(
+      stateLogs.stdoutPath,
+      [
+        "gateway start blocked: stale prior reason",
+        "non-error filler line\n".repeat(20_000),
+        "gateway stdout current",
+        "",
+      ].join("\n"),
+      "utf8",
+    );
+
+    await expect(readLastGatewayErrorLine(env, { platform: "linux" })).resolves.toBe(
+      "gateway stdout current",
+    );
+  });
+
+  it("ignores a matching partial line at the bounded tail boundary", async () => {
+    const stateDir = makeTempStateDir();
+    const homeDir = makeTempStateDir();
+    const env = { HOME: homeDir, OPENCLAW_STATE_DIR: stateDir };
+    const stateLogs = resolveGatewayLogPaths(env);
+    fs.mkdirSync(stateLogs.logDir, { recursive: true });
+    fs.writeFileSync(
+      stateLogs.stdoutPath,
+      `${"x".repeat(DIAGNOSTIC_TAIL_BYTES + 1)} gateway start blocked: partial stale reason\n` +
+        "gateway stdout current\n",
+      "utf8",
+    );
+
+    await expect(readLastGatewayErrorLine(env, { platform: "linux" })).resolves.toBe(
+      "gateway stdout current",
+    );
+  });
+
+  it("fills short positional reads before decoding the tail", async () => {
+    const dir = makeTempStateDir();
+    const file = path.join(dir, "gateway.log");
+    fs.writeFileSync(file, "old line\nrecent one\nrecent two\n", "utf8");
+    const realOpen = fsPromises.open.bind(fsPromises);
+    vi.spyOn(fsPromises, "open").mockImplementation(async (...args) => {
+      const handle = await realOpen(...args);
+      const realRead = handle.read.bind(handle) as PositionalRead;
+      const shortRead = vi.fn<PositionalRead>((buffer, offset, length, position) =>
+        realRead(buffer, offset, Math.min(length, 3), position),
+      );
+      Object.defineProperty(handle, "read", { configurable: true, value: shortRead });
+      return handle;
+    });
+
+    await expect(readGatewayLogTailLines(file)).resolves.toEqual([
+      "old line",
+      "recent one",
+      "recent two",
+    ]);
   });
 });

--- a/src/daemon/diagnostics.ts
+++ b/src/daemon/diagnostics.ts
@@ -1,5 +1,5 @@
 /** Reads recent gateway service logs for actionable daemon restart diagnostics. */
-import fs from "node:fs/promises";
+import fs, { type FileHandle } from "node:fs/promises";
 import { resolveGatewayLogPaths, resolveGatewaySupervisorLogPaths } from "./restart-logs.js";
 
 // Error patterns worth surfacing from gateway service logs after failed starts.
@@ -11,19 +11,74 @@ const GATEWAY_LOG_ERROR_PATTERNS = [
   /tailscale .* requires/i,
 ];
 
-async function readLastLogLine(filePath: string): Promise<string | null> {
+const GATEWAY_DIAGNOSTIC_LOG_TAIL_BYTES = 256 * 1024;
+
+async function readTailWindow(handle: FileHandle, size: number) {
+  const length = Math.min(size, GATEWAY_DIAGNOSTIC_LOG_TAIL_BYTES);
+  const readStart = size - length;
+  const buffer = Buffer.alloc(length);
+  let bytesRead = 0;
+  while (bytesRead < length) {
+    const result = await handle.read(buffer, bytesRead, length - bytesRead, readStart + bytesRead);
+    if (result.bytesRead === 0) {
+      break;
+    }
+    bytesRead += result.bytesRead;
+  }
+  return { buffer, bytesRead, readStart };
+}
+
+/** Reads complete lines from a bounded gateway log tail. */
+export async function readGatewayLogTailLines(filePath: string): Promise<string[]> {
+  const handle = await fs.open(filePath, "r");
   try {
-    const raw = await fs.readFile(filePath, "utf8");
-    const lines = raw.split(/\r?\n/).map((line) => line.trim());
-    for (let i = lines.length - 1; i >= 0; i -= 1) {
-      if (lines[i]) {
-        return lines[i];
+    const stat = await handle.stat();
+    if (!stat.isFile() || stat.size <= 0) {
+      return [];
+    }
+    let window = await readTailWindow(handle, stat.size);
+    if (window.bytesRead < window.buffer.length) {
+      const refreshedStat = await handle.stat();
+      if (!refreshedStat.isFile() || refreshedStat.size <= 0) {
+        return [];
+      }
+      if (refreshedStat.size !== stat.size) {
+        window = await readTailWindow(handle, refreshedStat.size);
       }
     }
-    return null;
-  } catch {
-    return null;
+    const { buffer, bytesRead, readStart } = window;
+    let textStart = 0;
+    if (readStart > 0) {
+      const precedingByte = Buffer.alloc(1);
+      const precedingRead = await handle.read(precedingByte, 0, 1, readStart - 1);
+      if (precedingRead.bytesRead !== 1 || precedingByte[0] !== 0x0a) {
+        // A byte-bound tail can start inside a line or UTF-8 sequence. Drop that
+        // fragment so diagnostics never report a stale, corrupted partial line.
+        const firstNewline = buffer.subarray(0, bytesRead).indexOf(0x0a);
+        if (firstNewline === -1) {
+          return [];
+        }
+        textStart = firstNewline + 1;
+      }
+    }
+    const lines = buffer.subarray(textStart, bytesRead).toString("utf8").split(/\r?\n/u);
+    if (lines.at(-1) === "") {
+      lines.pop();
+    }
+    return lines;
+  } finally {
+    await handle.close();
   }
+}
+
+function findLastNonEmptyLine(lines: string[]): string | null {
+  for (let i = lines.length - 1; i >= 0; i -= 1) {
+    const line = lines[i]?.trim();
+    if (line) {
+      return line;
+    }
+  }
+  return null;
 }
 
 export async function readLastGatewayErrorLine(
@@ -38,14 +93,12 @@ export async function readLastGatewayErrorLine(
     platform === "darwin"
       ? resolveGatewaySupervisorLogPaths(env, { platform })
       : resolveGatewayLogPaths(env);
-  const stderrRaw = readStderr ? await fs.readFile(stderrPath, "utf8").catch(() => "") : "";
-  const stdoutRaw = await fs.readFile(stdoutPath, "utf8").catch(() => "");
+  const stderrLines = readStderr ? await readGatewayLogTailLines(stderrPath).catch(() => []) : [];
+  const stdoutLines = await readGatewayLogTailLines(stdoutPath).catch(() => []);
   // stderr is the strongest failure signal on non-darwin platforms, so place it
   // last and scan from the end: the most recent stderr error line then wins over
   // any (possibly stale) stdout match, matching the stderr-first fallback below.
-  const lines = [...stdoutRaw.split(/\r?\n/), ...stderrRaw.split(/\r?\n/)].map((line) =>
-    line.trim(),
-  );
+  const lines = [...stdoutLines, ...stderrLines].map((line) => line.trim());
   for (let i = lines.length - 1; i >= 0; i -= 1) {
     const line = lines[i];
     if (!line) {
@@ -56,6 +109,6 @@ export async function readLastGatewayErrorLine(
     }
   }
   return readStderr
-    ? ((await readLastLogLine(stderrPath)) ?? (await readLastLogLine(stdoutPath)))
-    : await readLastLogLine(stdoutPath);
+    ? (findLastNonEmptyLine(stderrLines) ?? findLastNonEmptyLine(stdoutLines))
+    : findLastNonEmptyLine(stdoutLines);
 }

--- a/src/gateway/session-utils.test.ts
+++ b/src/gateway/session-utils.test.ts
@@ -2510,6 +2510,34 @@ describe("deriveSessionTitle", () => {
     } as SessionEntry;
     expect(deriveSessionTitle(entry)).toBe("Actual Subject");
   });
+
+  test.each([
+    {
+      name: "uses a label before the first user message",
+      fields: { label: "Label via /name" },
+      firstUserMessage: "Hello, what can you do?",
+      expected: "Label via /name",
+    },
+    {
+      name: "prefers an explicit label over display and group metadata",
+      fields: {
+        displayName: "Display Name",
+        subject: "Group Subject",
+        label: "Label via /name",
+      },
+      firstUserMessage: undefined,
+      expected: "Label via /name",
+    },
+    {
+      name: "ignores a blank label",
+      fields: { label: "   " },
+      firstUserMessage: "Hello!",
+      expected: "Hello!",
+    },
+  ])("$name", ({ fields, firstUserMessage, expected }) => {
+    const entry = { sessionId: "abc123", updatedAt: Date.now(), ...fields } as SessionEntry;
+    expect(deriveSessionTitle(entry, firstUserMessage)).toBe(expected);
+  });
 });
 
 describe("resolveGatewayModelSupportsImages", () => {

--- a/src/gateway/session-utils.ts
+++ b/src/gateway/session-utils.ts
@@ -244,6 +244,11 @@ export function deriveSessionTitle(
     return undefined;
   }
 
+  const label = normalizeOptionalString(entry.label);
+  if (label) {
+    return label;
+  }
+
   if (normalizeOptionalString(entry.displayName)) {
     return normalizeOptionalString(entry.displayName);
   }

--- a/src/infra/gateway-lock.test.ts
+++ b/src/infra/gateway-lock.test.ts
@@ -377,6 +377,36 @@ describe("gateway lock", () => {
     openSpy.mockRestore();
   });
 
+  it("closes handle and removes lock file when writeFile fails after open succeeds", async () => {
+    vi.useRealTimers();
+    const env = await makeEnv();
+    const { lockPath } = resolveLockPath(env);
+
+    const writeError = Object.assign(new Error("ENOSPC: no space left on device"), {
+      code: "ENOSPC",
+    });
+    const close = vi.fn<() => Promise<void>>().mockResolvedValue(undefined);
+    const mockHandle = {
+      writeFile: vi.fn().mockImplementation(async () => {
+        await fs.writeFile(lockPath, "partial", "utf8");
+        throw writeError;
+      }),
+      close,
+    };
+
+    const openSpy = vi.spyOn(fs, "open").mockResolvedValueOnce(mockHandle as never);
+
+    await expect(acquireForTest(env)).rejects.toMatchObject({
+      name: "GatewayLockError",
+      cause: writeError,
+    });
+
+    expect(close).toHaveBeenCalledTimes(1);
+    await expect(fs.access(lockPath)).rejects.toMatchObject({ code: "ENOENT" });
+
+    openSpy.mockRestore();
+  });
+
   it("clears stale lock on win32 when process cmdline is not a gateway", async () => {
     vi.useRealTimers();
     const env = await makeEnv();

--- a/src/infra/gateway-lock.ts
+++ b/src/infra/gateway-lock.ts
@@ -262,16 +262,24 @@ export async function acquireGatewayLock(
   while (now() - startedAt < timeoutMs) {
     try {
       const handle = await fs.open(lockPath, "wx");
-      const startTime = platform === "linux" ? readLinuxStartTime(process.pid) : null;
-      const payload: LockPayload = {
-        pid: process.pid,
-        createdAt: resolveTimestampMsToIsoString(now()),
-        configPath,
-      };
-      if (typeof startTime === "number" && Number.isFinite(startTime)) {
-        payload.startTime = startTime;
+      try {
+        const startTime = platform === "linux" ? readLinuxStartTime(process.pid) : null;
+        const payload: LockPayload = {
+          pid: process.pid,
+          createdAt: resolveTimestampMsToIsoString(now()),
+          configPath,
+        };
+        if (typeof startTime === "number" && Number.isFinite(startTime)) {
+          payload.startTime = startTime;
+        }
+        await handle.writeFile(JSON.stringify(payload), "utf8");
+      } catch (error) {
+        // Acquisition owns both resources until the release callback exists.
+        // Unwind them if payload preparation fails before ownership transfers.
+        await handle.close().catch(() => undefined);
+        await fs.rm(lockPath, { force: true }).catch(() => undefined);
+        throw error;
       }
-      await handle.writeFile(JSON.stringify(payload), "utf8");
       return {
         lockPath,
         configPath,


### PR DESCRIPTION
Related: #99056

## What Problem This Solves

Fixes an issue where invoking the `contacts.add` node command on the iOS app crashes it immediately (the node disconnects and the app must be reopened). This is the `contacts.add` half of #99056. The `screen.record` crash reported in the same issue is a separate ReplayKit path and is not addressed here.

## Why This Change Was Made

`ContactsService.payload(from:)` formats each contact with `CNContactFormatter.string(from:style:)`, but `ContactsService.payloadKeys` only fetched given name, family name, organization, phones, and emails. `CNContactFormatter` for `.fullName` also reads other name components (middle name, prefixes, phonetic fields). When it touches a key that was not fetched, `CNContact` raises `CNPropertyNotFetchedException` — an Objective-C exception that Swift `try/catch` cannot catch, so the app terminates.

The fix adds `CNContactFormatter.descriptorForRequiredKeys(for: .fullName)` to `payloadKeys`, so every key the formatter reads is fetched. `contacts.search` uses the same key set and is fixed by the same change.

## User Impact

`contacts.add` (and `contacts.search` on results whose formatting touches an unfetched key) no longer crash the app. The command completes and returns the contact payload.

## Evidence

Reproduced and fixed on the iPhone 17 simulator (iOS 26.5) against a source-built dev gateway, current `main` (`1fef99962edf`).

**Before (crash):** invoking `contacts.add` after granting Contacts permission terminated the app. Crash report (`OpenClaw-2026-07-03-121532.ips`), faulting backtrace:

```
EXC_BREAKPOINT (SIGTRAP)  — uncaught Objective-C exception

Contacts        -[CNContact middleName]
Contacts        -[CNContactFormatter fullNameForContact:attributes:style:]
Contacts        +[CNContactFormatter stringFromContact:style:]
OpenClaw        static ContactsService.payload(from:)
OpenClaw        ContactsService.add(params:)
```

**After (this branch):** identical invoke returns success, app stays alive, no crash report generated:

```
node.invoke contacts.add → ok
payload: {"contact":{"displayName":"Test Kisi","phoneNumbers":["13800000000"],
          "identifier":"…:ABPerson", …}}
```

Build: `xcodebuild -project apps/ios/OpenClaw.xcodeproj -scheme OpenClaw -destination 'platform=iOS Simulator,name=iPhone 17' CODE_SIGNING_ALLOWED=NO build` → BUILD SUCCEEDED.

Note: I did not add a unit test because reproducing this requires the Contacts framework returning a partially-keyed `CNContact`; happy to add focused coverage if maintainers want it and can point me at the preferred test seam.
