### PR TITLE
docs(feishu): fix textChunkLimit default from 2000 to 4000

### DIFF
--- a/docs/channels/feishu.md
+++ b/docs/channels/feishu.md
@@ -265,7 +265,7 @@ per account.
 
 ### Message limits
 
-- `textChunkLimit` - outbound text chunk size (default: `2000` chars)
+- `textChunkLimit` - outbound text chunk size (default: `4000` chars)
 - `mediaMaxMb` - media upload/download limit (default: `30` MB)
 
 ### Streaming
@@ -580,7 +580,7 @@ Full configuration: [Gateway configuration](/gateway/configuration)
 | `channels.feishu.dynamicAgentCreation.workspaceTemplate` | Path template for dynamic agent workspaces                                       | `~/.openclaw/workspace-{agentId}`    |
 | `channels.feishu.dynamicAgentCreation.agentDirTemplate`  | Agent directory name template                                                    | `~/.openclaw/agents/{agentId}/agent` |
 | `channels.feishu.dynamicAgentCreation.maxAgents`         | Maximum number of dynamic agents to create                                       | unlimited                            |
-| `channels.feishu.textChunkLimit`                         | Message chunk size                                                               | `2000`                               |
+| `channels.feishu.textChunkLimit`                         | Message chunk size                                                               | `4000`                               |
 | `channels.feishu.mediaMaxMb`                             | Media size limit                                                                 | `30`                                 |
 | `channels.feishu.streaming`                              | Streaming card output                                                            | `true`                               |
 | `channels.feishu.blockStreaming`                         | Completed-block reply streaming                                                  | `false`                              |


### PR DESCRIPTION
## What Problem This Solves

Feishu documentation (`docs/channels/feishu.md`) states `textChunkLimit` defaults to 2000 characters, but the actual runtime default is 4000.

## Why This Change Was Made

`textChunkLimit` for Feishu resolves through three code paths, all using 4000 as the default, not 2000. The documentation must match the shipped behavior.

## Evidence

| Source | Code |
|--------|------|
| Reply path | [`extensions/feishu/src/reply-dispatcher.ts#L256`](https://github.com/openclaw/openclaw/blob/36dd9ee3c3c188cc0619f0a3277c64c4b96a9615/extensions/feishu/src/reply-dispatcher.ts#L256) — `fallbackLimit: 4000` |
| Channel plugin | [`extensions/feishu/src/channel.ts#L1369`](https://github.com/openclaw/openclaw/blob/36dd9ee3c3c188cc0619f0a3277c64c4b96a9615/extensions/feishu/src/channel.ts#L1369) — `textChunkLimit: 4000` |
| Outbound adapter | [`extensions/feishu/src/outbound.ts#L491`](https://github.com/openclaw/openclaw/blob/36dd9ee3c3c188cc0619f0a3277c64c4b96a9615/extensions/feishu/src/outbound.ts#L491) — `textChunkLimit: 4000` |
| Shared default | [`src/auto-reply/chunk.ts#L32`](https://github.com/openclaw/openclaw/blob/36dd9ee3c3c188cc0619f0a3277c64c4b96a9615/src/auto-reply/chunk.ts#L32) — `const DEFAULT_CHUNK_LIMIT = 4000` |

No reference to 2000 exists in the Feishu plugin source (`extensions/feishu/`).

## User Impact

No runtime change. Users relying on the documented default of 2000 were already receiving chunks up to 4000 characters.