### PR TITLE
fix: avoid iOS node permission prompts

### DIFF
--- a/apps/ios/Sources/Calendar/CalendarService.swift
+++ b/apps/ios/Sources/Calendar/CalendarService.swift
@@ -3,14 +3,19 @@ import Foundation
 import OpenClawKit
 
 final class CalendarService: CalendarServicing {
+    private let eventAuthorizationStatus: @Sendable () -> EKAuthorizationStatus
+
+    init(
+        eventAuthorizationStatus: @escaping @Sendable () -> EKAuthorizationStatus = {
+            EKEventStore.authorizationStatus(for: .event)
+        })
+    {
+        self.eventAuthorizationStatus = eventAuthorizationStatus
+    }
+
     func events(params: OpenClawCalendarEventsParams) async throws -> OpenClawCalendarEventsPayload {
-        let status = EKEventStore.authorizationStatus(for: .event)
-        let authorized: Bool = if status == .notDetermined || status == .writeOnly {
-            await Self.requestFullEventAccess()
-        } else {
-            EventKitAuthorization.allowsRead(status: status)
-        }
-        guard authorized else {
+        let status = self.eventAuthorizationStatus()
+        guard EventKitAuthorization.allowsRead(status: status) else {
             throw NSError(domain: "Calendar", code: 1, userInfo: [
                 NSLocalizedDescriptionKey: "CALENDAR_PERMISSION_REQUIRED: grant Calendar permission",
             ])
@@ -41,13 +46,8 @@ final class CalendarService: CalendarServicing {
     }
 
     func add(params: OpenClawCalendarAddParams) async throws -> OpenClawCalendarAddPayload {
-        let status = EKEventStore.authorizationStatus(for: .event)
-        let authorized: Bool = if status == .notDetermined {
-            await Self.requestWriteOnlyEventAccess()
-        } else {
-            EventKitAuthorization.allowsWrite(status: status)
-        }
-        guard authorized else {
+        let status = self.eventAuthorizationStatus()
+        guard EventKitAuthorization.allowsWrite(status: status) else {
             throw NSError(domain: "Calendar", code: 2, userInfo: [
                 NSLocalizedDescriptionKey: "CALENDAR_PERMISSION_REQUIRED: grant Calendar permission",
             ])
@@ -101,24 +101,6 @@ final class CalendarService: CalendarServicing {
             calendarTitle: event.calendar.title)
 
         return OpenClawCalendarAddPayload(event: payload)
-    }
-
-    private static func requestFullEventAccess() async -> Bool {
-        await PermissionRequestBridge.awaitRequest { completion in
-            let store = EKEventStore()
-            store.requestFullAccessToEvents { granted, _ in
-                completion(granted)
-            }
-        }
-    }
-
-    private static func requestWriteOnlyEventAccess() async -> Bool {
-        await PermissionRequestBridge.awaitRequest { completion in
-            let store = EKEventStore()
-            store.requestWriteOnlyAccessToEvents { granted, _ in
-                completion(granted)
-            }
-        }
     }
 
     private static func resolveCalendar(

--- a/apps/ios/Sources/Contacts/ContactsService.swift
+++ b/apps/ios/Sources/Contacts/ContactsService.swift
@@ -3,6 +3,16 @@ import Foundation
 import OpenClawKit
 
 final class ContactsService: ContactsServicing {
+    private let authorizationStatus: @Sendable () -> CNAuthorizationStatus
+
+    init(
+        authorizationStatus: @escaping @Sendable () -> CNAuthorizationStatus = {
+            CNContactStore.authorizationStatus(for: .contacts)
+        })
+    {
+        self.authorizationStatus = authorizationStatus
+    }
+
     private static var payloadKeys: [CNKeyDescriptor] {
         [
             CNContactIdentifierKey as CNKeyDescriptor,
@@ -19,7 +29,7 @@ final class ContactsService: ContactsServicing {
     }
 
     func search(params: OpenClawContactsSearchParams) async throws -> OpenClawContactsSearchPayload {
-        let store = try await Self.authorizedStore()
+        let store = try self.authorizedStore()
 
         let limit = max(1, min(params.limit ?? 25, 200))
 
@@ -44,7 +54,7 @@ final class ContactsService: ContactsServicing {
     }
 
     func add(params: OpenClawContactsAddParams) async throws -> OpenClawContactsAddPayload {
-        let store = try await Self.authorizedStore()
+        let store = try self.authorizedStore()
 
         let givenName = params.givenName?.trimmingCharacters(in: .whitespacesAndNewlines)
         let familyName = params.familyName?.trimmingCharacters(in: .whitespacesAndNewlines)
@@ -101,17 +111,12 @@ final class ContactsService: ContactsServicing {
         return OpenClawContactsAddPayload(contact: Self.payload(from: persisted))
     }
 
-    private static func ensureAuthorization(status: CNAuthorizationStatus) async -> Bool {
+    private static func ensureAuthorization(status: CNAuthorizationStatus) -> Bool {
         switch status {
         case .authorized, .limited:
             return true
         case .notDetermined:
-            return await PermissionRequestBridge.awaitRequest { completion in
-                let store = CNContactStore()
-                store.requestAccess(for: .contacts) { granted, _ in
-                    completion(granted)
-                }
-            }
+            return false
         case .restricted, .denied:
             return false
         @unknown default:
@@ -119,9 +124,9 @@ final class ContactsService: ContactsServicing {
         }
     }
 
-    private static func authorizedStore() async throws -> CNContactStore {
-        let status = CNContactStore.authorizationStatus(for: .contacts)
-        let authorized = await Self.ensureAuthorization(status: status)
+    private func authorizedStore() throws -> CNContactStore {
+        let status = self.authorizationStatus()
+        let authorized = Self.ensureAuthorization(status: status)
         guard authorized else {
             throw NSError(domain: "Contacts", code: 1, userInfo: [
                 NSLocalizedDescriptionKey: "CONTACTS_PERMISSION_REQUIRED: grant Contacts permission",

--- a/apps/ios/Sources/Reminders/RemindersService.swift
+++ b/apps/ios/Sources/Reminders/RemindersService.swift
@@ -3,14 +3,19 @@ import Foundation
 import OpenClawKit
 
 final class RemindersService: RemindersServicing {
+    private let reminderAuthorizationStatus: @Sendable () -> EKAuthorizationStatus
+
+    init(
+        reminderAuthorizationStatus: @escaping @Sendable () -> EKAuthorizationStatus = {
+            EKEventStore.authorizationStatus(for: .reminder)
+        })
+    {
+        self.reminderAuthorizationStatus = reminderAuthorizationStatus
+    }
+
     func list(params: OpenClawRemindersListParams) async throws -> OpenClawRemindersListPayload {
-        let status = EKEventStore.authorizationStatus(for: .reminder)
-        let authorized: Bool = if status == .notDetermined || status == .writeOnly {
-            await Self.requestFullReminderAccess()
-        } else {
-            EventKitAuthorization.allowsRead(status: status)
-        }
-        guard authorized else {
+        let status = self.reminderAuthorizationStatus()
+        guard EventKitAuthorization.allowsRead(status: status) else {
             throw NSError(domain: "Reminders", code: 1, userInfo: [
                 NSLocalizedDescriptionKey: "REMINDERS_PERMISSION_REQUIRED: grant Reminders permission",
             ])
@@ -52,13 +57,8 @@ final class RemindersService: RemindersServicing {
     }
 
     func add(params: OpenClawRemindersAddParams) async throws -> OpenClawRemindersAddPayload {
-        let status = EKEventStore.authorizationStatus(for: .reminder)
-        let authorized: Bool = if status == .notDetermined {
-            await Self.requestFullReminderAccess()
-        } else {
-            EventKitAuthorization.allowsWrite(status: status)
-        }
-        guard authorized else {
+        let status = self.reminderAuthorizationStatus()
+        guard EventKitAuthorization.allowsWrite(status: status) else {
             throw NSError(domain: "Reminders", code: 2, userInfo: [
                 NSLocalizedDescriptionKey: "REMINDERS_PERMISSION_REQUIRED: grant Reminders permission",
             ])
@@ -106,15 +106,6 @@ final class RemindersService: RemindersServicing {
             listName: reminder.calendar.title)
 
         return OpenClawRemindersAddPayload(reminder: payload)
-    }
-
-    private static func requestFullReminderAccess() async -> Bool {
-        await PermissionRequestBridge.awaitRequest { completion in
-            let store = EKEventStore()
-            store.requestFullAccessToReminders { granted, _ in
-                completion(granted)
-            }
-        }
     }
 
     private static func resolveList(

--- a/apps/ios/Tests/NodeServicePermissionTests.swift
+++ b/apps/ios/Tests/NodeServicePermissionTests.swift
@@ -1,0 +1,86 @@
+import Contacts
+import EventKit
+import OpenClawKit
+import Testing
+@testable import OpenClaw
+
+@Suite struct NodeServicePermissionTests {
+    @Test func `calendar events do not request access from node invoke`() async throws {
+        let service = CalendarService(eventAuthorizationStatus: { .notDetermined })
+
+        await expectPermissionError(
+            code: "CALENDAR_PERMISSION_REQUIRED",
+            performing: {
+                _ = try await service.events(params: OpenClawCalendarEventsParams())
+            })
+    }
+
+    @Test func `calendar add does not request access from node invoke`() async throws {
+        let service = CalendarService(eventAuthorizationStatus: { .notDetermined })
+
+        await expectPermissionError(
+            code: "CALENDAR_PERMISSION_REQUIRED",
+            performing: {
+                _ = try await service.add(params: calendarAddParams())
+            })
+    }
+
+    @Test func `reminders list does not request access from node invoke`() async throws {
+        let service = RemindersService(reminderAuthorizationStatus: { .notDetermined })
+
+        await expectPermissionError(
+            code: "REMINDERS_PERMISSION_REQUIRED",
+            performing: {
+                _ = try await service.list(params: OpenClawRemindersListParams())
+            })
+    }
+
+    @Test func `reminders add does not request access from node invoke`() async throws {
+        let service = RemindersService(reminderAuthorizationStatus: { .notDetermined })
+
+        await expectPermissionError(
+            code: "REMINDERS_PERMISSION_REQUIRED",
+            performing: {
+                _ = try await service.add(params: OpenClawRemindersAddParams(title: "Follow up"))
+            })
+    }
+
+    @Test func `contacts search does not request access from node invoke`() async throws {
+        let service = ContactsService(authorizationStatus: { .notDetermined })
+
+        await expectPermissionError(
+            code: "CONTACTS_PERMISSION_REQUIRED",
+            performing: {
+                _ = try await service.search(params: OpenClawContactsSearchParams(query: "Ada"))
+            })
+    }
+
+    @Test func `contacts add does not request access from node invoke`() async throws {
+        let service = ContactsService(authorizationStatus: { .notDetermined })
+
+        await expectPermissionError(
+            code: "CONTACTS_PERMISSION_REQUIRED",
+            performing: {
+                _ = try await service.add(params: OpenClawContactsAddParams(givenName: "Ada"))
+            })
+    }
+}
+
+private func calendarAddParams() -> OpenClawCalendarAddParams {
+    OpenClawCalendarAddParams(
+        title: "Review",
+        startISO: "2026-07-03T09:00:00Z",
+        endISO: "2026-07-03T09:30:00Z")
+}
+
+private func expectPermissionError(
+    code: String,
+    performing operation: () async throws -> Void) async
+{
+    do {
+        try await operation()
+        Issue.record("Expected \(code)")
+    } catch {
+        #expect(error.localizedDescription.contains(code))
+    }
+}


### PR DESCRIPTION
## What Problem This Solves

iOS node commands for Calendar, Reminders, and Contacts could trigger native permission prompts from inside `node.invoke`.

That is the wrong execution boundary for gateway-driven agent calls:

- `calendar.events` and `calendar.add` called EventKit request APIs when calendar access was `.notDetermined`.
- `reminders.list` and `reminders.add` called EventKit request APIs when reminders access was `.notDetermined`.
- `contacts.search` and `contacts.add` called `CNContactStore.requestAccess` when contacts access was `.notDetermined`.

Those prompts require foreground user interaction, but the gateway call is waiting for a node response. If the user does not notice or cannot answer the native sheet, the agent turn can hang until the gateway/client timeout instead of getting an immediate permission-required error it can explain.

Photos already had the intended contract in `apps/ios/Sources/Media/PhotoLibraryService.swift`: node services should not prompt during `node.invoke` because prompts block the invoke path. This PR applies that same rule to Calendar, Reminders, and Contacts.

## Why This Change Was Made

The iOS app already has an explicit permissions surface in `apps/ios/Sources/Settings/PrivacyAccessSectionView.swift`. That UI is the right owner for showing native TCC prompts because the user is intentionally managing app permissions there.

This change keeps node services transport-friendly:

- Calendar and Reminders now read the current EventKit authorization status and use `EventKitAuthorization.allowsRead` / `allowsWrite`.
- Contacts now reads the current Contacts authorization status and treats `.notDetermined` as unavailable.
- The service-layer request helper methods were removed from Calendar and Reminders.
- Contacts no longer calls `PermissionRequestBridge.awaitRequest` or `CNContactStore.requestAccess`.
- Small authorization-status closures were added so tests can force `.notDetermined` without reaching real TCC state.

## User Impact

When an agent invokes calendar, reminders, or contacts commands before the user has granted iOS permission, the app now returns the existing `*_PERMISSION_REQUIRED` error promptly instead of opening a native permission prompt from the gateway call.

Users can still grant permissions from the Settings permissions page. After permission is granted there, the node commands continue through the same service methods and EventKit/Contacts stores as before.

## Evidence

- Added `apps/ios/Tests/NodeServicePermissionTests.swift` covering `.notDetermined` for:
  - `calendar.events`
  - `calendar.add`
  - `reminders.list`
  - `reminders.add`
  - `contacts.search`
  - `contacts.add`

### Before / after

- **Before (`main`)**: a real paired-gateway `contacts.search` invocation opened the native Contacts prompt from the node call. Leaving it unanswered caused the gateway invocation to time out; Calendar then timed out behind the same prompt-bound path.
- **After (exact head `26855644f5720da44d9de8d25abcaa27f2202cdc`, permissions denied)**: `contacts.search`, `calendar.events`, and `reminders.list` immediately returned their service-specific `*_PERMISSION_REQUIRED` errors. The app remained foreground for 75 seconds with no native alert.
- **After (same exact head, permissions granted)**: all three gateway calls succeeded. The app remained foreground for another 75 seconds with Contacts, both Calendar permissions, and Reminders shown as allowed.

### Validation

- `xcodebuild ... -only-testing:OpenClawTests/NodeServicePermissionTests test`
  - 6 tests passed on iPhone 17 / iOS 26.5 simulator.
- Two real setup-code pairings against an isolated local Gateway:
  - denied path: three expected permission errors, no prompt, foreground preserved;
  - granted path: three successful node responses, foreground preserved.
- Verified service prompt ownership with `rg`: prompt APIs remain in the foreground Settings permissions UI, not the Calendar, Contacts, or Reminders node services.
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main --stream-engine-output`
  - clean; no accepted/actionable findings, 0.96 confidence.
- Hosted CI on the exact repaired head: `ios-build`, `macos-swift`, `macos-node`, `native-i18n`, security, dependency, and static-analysis checks passed.
- `git diff --check`
