### PR TITLE
fix(openai): bound Codex OAuth token response body reads with readResponseWithLimit

### DIFF
--- a/extensions/openai/openai-chatgpt-oauth-flow.runtime.test.ts
+++ b/extensions/openai/openai-chatgpt-oauth-flow.runtime.test.ts
@@ -1,4 +1,5 @@
 // Openai tests cover openai chatgpt oauth flow plugin behavior.
+import { createServer, type Server } from "node:http";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 const ssrfMocks = vi.hoisted(() => ({
@@ -173,5 +174,100 @@ describe("OpenAI Codex OAuth flow", () => {
       type: "failed",
       message: "OpenAI Codex token refresh response missing fields: expires_in",
     });
+  });
+});
+
+async function listenLoopbackServer(server: Server): Promise<number> {
+  return await new Promise<number>((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", () => {
+      server.off("error", reject);
+      const address = server.address();
+      if (!address || typeof address === "string") {
+        reject(new Error("expected loopback TCP address"));
+        return;
+      }
+      resolve(address.port);
+    });
+  });
+}
+
+async function closeServer(server: Server): Promise<void> {
+  await new Promise<void>((resolve) => {
+    server.close(() => resolve());
+  });
+}
+
+describe("OpenAI Codex OAuth bounded token response reads", () => {
+  it("reads under-cap token exchange responses from a real loopback HTTP server", async () => {
+    const validPayload = {
+      access_token: "access-token-loopback",
+      refresh_token: "refresh-token-loopback",
+      expires_in: 3600,
+    };
+    const server = createServer((_req, res) => {
+      res.writeHead(200, { "content-type": "application/json" });
+      res.end(JSON.stringify(validPayload));
+    });
+    const port = await listenLoopbackServer(server);
+
+    try {
+      ssrfMocks.fetchWithSsrFGuard.mockImplementation(async ({ init, signal }) => {
+        const response = await globalThis.fetch(`http://127.0.0.1:${port}`, {
+          ...init,
+          signal,
+        });
+        return { response, release: vi.fn(async () => undefined) };
+      });
+
+      const result = await testing.exchangeAuthorizationCode(
+        "code-loopback",
+        "verifier-loopback",
+        "http://localhost:1455/auth/callback",
+        { timeoutMs: 5000 },
+      );
+
+      expect(result).toMatchObject({
+        type: "success",
+        access: "access-token-loopback",
+        refresh: "refresh-token-loopback",
+      });
+      expect(
+        (result as { type: "success"; access: string; refresh: string; expires: number }).expires,
+      ).toBeGreaterThan(0);
+    } finally {
+      await closeServer(server);
+    }
+  });
+
+  it("rejects oversized token exchange responses from a real loopback HTTP server", async () => {
+    const oversizedPayload = "o".repeat(2 * 1024 * 1024); // 2 MiB > 1 MiB cap
+    const server = createServer((_req, res) => {
+      res.writeHead(200, { "content-type": "application/json" });
+      res.end(oversizedPayload);
+    });
+    const port = await listenLoopbackServer(server);
+
+    try {
+      ssrfMocks.fetchWithSsrFGuard.mockImplementation(async ({ init, signal }) => {
+        const response = await globalThis.fetch(`http://127.0.0.1:${port}`, {
+          ...init,
+          signal,
+        });
+        return { response, release: vi.fn(async () => undefined) };
+      });
+
+      const result = await testing.exchangeAuthorizationCode(
+        "code-loopback",
+        "verifier-loopback",
+        "http://localhost:1455/auth/callback",
+        { timeoutMs: 5000 },
+      );
+
+      expect(result).toMatchObject({ type: "failed" });
+      expect((result as { type: "failed"; message: string }).message).toContain("too large");
+    } finally {
+      await closeServer(server);
+    }
   });
 });

--- a/extensions/openai/openai-chatgpt-oauth-flow.runtime.test.ts
+++ b/extensions/openai/openai-chatgpt-oauth-flow.runtime.test.ts
@@ -210,6 +210,7 @@ describe("OpenAI Codex OAuth bounded token response reads", () => {
       res.end(JSON.stringify(validPayload));
     });
     const port = await listenLoopbackServer(server);
+    const release = vi.fn(async () => undefined);
 
     try {
       ssrfMocks.fetchWithSsrFGuard.mockImplementation(async ({ init, signal }) => {
@@ -217,7 +218,7 @@ describe("OpenAI Codex OAuth bounded token response reads", () => {
           ...init,
           signal,
         });
-        return { response, release: vi.fn(async () => undefined) };
+        return { response, release };
       });
 
       const result = await testing.exchangeAuthorizationCode(
@@ -235,6 +236,7 @@ describe("OpenAI Codex OAuth bounded token response reads", () => {
       expect(
         (result as { type: "success"; access: string; refresh: string; expires: number }).expires,
       ).toBeGreaterThan(0);
+      expect(release).toHaveBeenCalledOnce();
     } finally {
       await closeServer(server);
     }
@@ -247,6 +249,7 @@ describe("OpenAI Codex OAuth bounded token response reads", () => {
       res.end(oversizedPayload);
     });
     const port = await listenLoopbackServer(server);
+    const release = vi.fn(async () => undefined);
 
     try {
       ssrfMocks.fetchWithSsrFGuard.mockImplementation(async ({ init, signal }) => {
@@ -254,7 +257,7 @@ describe("OpenAI Codex OAuth bounded token response reads", () => {
           ...init,
           signal,
         });
-        return { response, release: vi.fn(async () => undefined) };
+        return { response, release };
       });
 
       const result = await testing.exchangeAuthorizationCode(
@@ -266,6 +269,7 @@ describe("OpenAI Codex OAuth bounded token response reads", () => {
 
       expect(result).toMatchObject({ type: "failed" });
       expect((result as { type: "failed"; message: string }).message).toContain("too large");
+      expect(release).toHaveBeenCalledOnce();
     } finally {
       await closeServer(server);
     }

--- a/extensions/openai/openai-chatgpt-oauth-flow.runtime.ts
+++ b/extensions/openai/openai-chatgpt-oauth-flow.runtime.ts
@@ -190,7 +190,7 @@ async function postTokenForm(
           ),
       },
     );
-    return new Response(responseBody, {
+    return new Response(new Uint8Array(responseBody), {
       status: response.status,
       statusText: response.statusText,
       headers: response.headers,

--- a/extensions/openai/openai-chatgpt-oauth-flow.runtime.ts
+++ b/extensions/openai/openai-chatgpt-oauth-flow.runtime.ts
@@ -11,6 +11,7 @@ import {
   resolveOAuthTokenExpiresAt,
   resolveOAuthTokenLifetimeMs,
 } from "openclaw/plugin-sdk/provider-oauth-runtime";
+import { readResponseWithLimit } from "openclaw/plugin-sdk/response-limit-runtime";
 import { fetchWithSsrFGuard } from "openclaw/plugin-sdk/ssrf-runtime";
 import { resolveCodexAuthIdentity } from "./openai-chatgpt-auth-identity.js";
 import {
@@ -39,6 +40,7 @@ const REDIRECT_URI = resolveRedirectUri(CALLBACK_HOST);
 const MANUAL_PROMPT_FALLBACK_MS = 15_000;
 const TOKEN_REQUEST_TIMEOUT_MS = 30_000;
 const SCOPE = "openid profile email offline_access";
+const OAUTH_TOKEN_RESPONSE_BODY_LIMIT_BYTES = 1 * 1024 * 1024;
 
 type TokenSuccess = { type: "success"; access: string; refresh: string; expires: number };
 type TokenFailure = { type: "failed"; message: string; status?: number };
@@ -178,7 +180,16 @@ async function postTokenForm(
     auditContext: "openai-chatgpt-oauth-token",
   });
   try {
-    const responseBody = await response.arrayBuffer();
+    const responseBody = await readResponseWithLimit(
+      response,
+      OAUTH_TOKEN_RESPONSE_BODY_LIMIT_BYTES,
+      {
+        onOverflow: ({ size, maxBytes }) =>
+          new Error(
+            `OpenAI Codex OAuth token response body too large: ${size} bytes (limit: ${maxBytes} bytes)`,
+          ),
+      },
+    );
     return new Response(responseBody, {
       status: response.status,
       statusText: response.statusText,


### PR DESCRIPTION
## What Problem This Solves

The shared ChatGPT OAuth token request helper buffered `https://auth.openai.com/oauth/token` responses with an unbounded `response.arrayBuffer()`. Both authorization-code exchange and token refresh used that helper, so a malfunctioning or hostile response could exhaust Gateway memory before either caller parsed it.

## Why This Change Was Made

`postTokenForm` is the single network-read owner for both operations. It now uses the existing streaming `readResponseWithLimit` helper with a 1 MiB cap, materializes the bounded bytes into the same `Response` shape, and keeps the existing status, headers, JSON parsing, error text, timeout, abort, and guarded-fetch release behavior.

This is cleaner than the overlapping alternatives:

- #98113 adds redundant second-stage readers and uses a broader 16 MiB ceiling.
- #101075 parses and reserializes inside the transport helper, changing response bytes and coupling that helper to success JSON.

The current Codex implementation confirms the same token endpoint and response contract: [authorization-code exchange](https://github.com/openai/codex/blob/d61ad78abc9b35f59e6d3a7eb2bd6b6ca9338230/codex-rs/login/src/server.rs#L732-L805) and [refresh](https://github.com/openai/codex/blob/d61ad78abc9b35f59e6d3a7eb2bd6b6ca9338230/codex-rs/login/src/auth/manager.rs#L1330-L1370).

## User Impact

Normal ChatGPT OAuth sign-in and refresh behavior is unchanged. Oversized token responses now fail through the existing provider result shape after the response stream is cancelled and the guarded fetch is released.

## Evidence

- Exact head: `5b037990765a7341b77dba31abc2886e82f99516`
- Sanitized AWS Crabbox: `cbx_6a45fcced145`, public networking, no Tailscale, no instance profile
- Run: [run_4794c8a54d94](https://crabbox.openclaw.ai/portal/runs/run_4794c8a54d94)
- Environment: Linux x86_64, Node 24.15.0, pnpm 11.2.2
- Command: `pnpm test extensions/openai/openai-chatgpt-oauth-flow.runtime.test.ts`
- Result: 12/12 tests passed, including real loopback HTTP under-cap and over-cap paths plus guarded-fetch release assertions
- Fresh GPT-5.5 autoreview: no accepted/actionable findings; patch correctness confidence 0.98
- Direct dependency audit: `packages/media-core/src/read-response-with-limit.ts` cancels the response reader on overflow before throwing the contextual error

Not exercised: a credentialed live OpenAI login. The changed surface is the response-stream boundary, and the real loopback server drives that production path without requiring or exposing user credentials.

Contributor: @Pandah97
