### PR TITLE
fix(usage-bar): add max size limit to template file cache

### DIFF
--- a/src/auto-reply/usage-bar/template.ts
+++ b/src/auto-reply/usage-bar/template.ts
@@ -9,6 +9,7 @@ export type UsageTemplateConfig = string | Record<string, unknown> | undefined;
 
 type CacheEntry = { template: UsageBarTemplate | undefined; watcher?: FSWatcher };
 const fileCache = new Map<string, CacheEntry>();
+const MAX_TEMPLATE_CACHE_SIZE = 32;
 const warnedTemplateOverrides = new Set<string>();
 const usageTemplateLog = createSubsystemLogger("usage-template");
 
@@ -141,6 +142,14 @@ function cacheTemplateFile(path: string): UsageBarTemplate | undefined {
       entry.watcher = watcher;
     } catch {
       // Cache remains valid without live refresh.
+    }
+  }
+  if (fileCache.size >= MAX_TEMPLATE_CACHE_SIZE) {
+    const oldestKey = fileCache.keys().next().value;
+    if (oldestKey) {
+      const oldest = fileCache.get(oldestKey);
+      oldest?.watcher?.close();
+      fileCache.delete(oldestKey);
     }
   }
   fileCache.set(path, entry);


### PR DESCRIPTION
## What Problem This Solves

Fixes #98960: In `src/auto-reply/usage-bar/template.ts`, the module-level `fileCache` Map holds a live `fs.watch` watcher for each cached template file path. The cache grows without bound — entries are never evicted, and watchers are only closed in `clearUsageBarTemplateCacheForTest()`.

## Root Cause

`cacheTemplateFile()` at line ~146 inserts into `fileCache` without checking cache size. Each new file path creates a persistent `fs.watch` watcher. On long-running gateway instances, new template paths accumulate watchers and memory indefinitely — there is no eviction path in production code.

## Why This Change Was Made

Unbounded watcher growth causes:
1. **Memory leak**: Each `fs.watch` watcher holds kernel resources and V8 heap
2. **FD exhaustion**: Watchers consume file descriptors; on systems with low `ulimit -n`, this can exhaust the fd table
3. **No recovery**: The only cleanup path (`clearUsageBarTemplateCacheForTest`) is test-only

Adding a bounded cache with oldest-entry eviction (closing the evicted watcher) keeps resource usage constant regardless of uptime.

## Changes

- `src/auto-reply/usage-bar/template.ts`: +9 lines
  - Added `MAX_TEMPLATE_CACHE_SIZE = 32` constant
  - Before `fileCache.set()`, evict the oldest entry (closing its watcher via `oldest.watcher?.close()`) when at capacity

## Evidence

### Verification environment

| Item    | Value                 |
| ------- | --------------------- |
| OS      | Linux 4.19.112 x86_64 |
| Node.js | v22.19.0              |
| Vitest  | v4.1.8                |

### Regression tests — usage-bar (25/25)

```
 ✓ loads default template when not configured
 ✓ loads inline template from config object
 ✓ loads template from file path
 ✓ reloads template on file change via fs.watch
 ✓ falls back when template file is invalid JSON
 ✓ falls back when template file is unreadable
 ✓ deduplicates warning for same file+reason
 ✓ expands ~ to home directory
 ✓ resolves relative paths
 ✓ handles empty template file
 ✓ handles empty inline template object
 ✓ handles template with segments only
 ✓ handles template with output surfaces
 ✓ handles template with default output
 ✓ handles template with surface-specific segments
 Test Files  2 passed (2) | Tests  25 passed (25)
```

### Real-process verification

```
$ pnpm openclaw --version
OpenClaw 2026.6.11 (f2ed83f)

$ pnpm openclaw doctor
# exits 0, no crashes
```

## User Impact

- Long-running gateway instances no longer leak watchers/memory from template file caching
- Cache bounded at 32 entries; oldest evicted when full
- Transparent to users; no config or behavior changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)