### PR TITLE
fix: remove Android camera clip release logs

### DIFF
--- a/apps/android/app/src/main/java/ai/openclaw/app/node/CameraCaptureManager.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/node/CameraCaptureManager.kt
@@ -258,13 +258,7 @@ class CameraCaptureManager(
       val deviceId = parseDeviceId(params)
       if (includeAudio) ensureMicPermission()
 
-      android.util.Log.w(
-        "CameraCaptureManager",
-        "clip: start facing=$facing duration=$durationMs audio=$includeAudio deviceId=${deviceId ?: "-"}",
-      )
-
       val provider = context.cameraProvider()
-      android.util.Log.w("CameraCaptureManager", "clip: got camera provider")
 
       // Use LOWEST quality for smallest files over WebSocket
       val recorder =
@@ -300,65 +294,39 @@ class CameraCaptureManager(
           check(!file.exists() || file.delete()) { "failed to delete temporary camera clip" }
         },
       ).use { session ->
-        android.util.Log.w("CameraCaptureManager", "clip: binding preview + videoCapture to lifecycle")
-        val camera = provider.bindToLifecycle(owner, selector, preview, videoCapture)
-        android.util.Log.w("CameraCaptureManager", "clip: bound, cameraInfo=${camera.cameraInfo}")
+        provider.bindToLifecycle(owner, selector, preview, videoCapture)
 
         // Give camera pipeline time to initialize before recording
-        android.util.Log.w("CameraCaptureManager", "clip: warming up camera 1.5s...")
         kotlinx.coroutines.delay(1_500)
 
         val clipFile = session.ownFile(File.createTempFile("openclaw-clip-", ".mp4", context.cacheDir))
         val outputOptions = FileOutputOptions.Builder(clipFile).build()
 
         val finalized = kotlinx.coroutines.CompletableDeferred<VideoRecordEvent.Finalize>()
-        android.util.Log.w("CameraCaptureManager", "clip: starting recording to ${clipFile.absolutePath}")
         val recording =
           videoCapture.output
             .prepareRecording(context, outputOptions)
             .apply {
               if (includeAudio) withAudioEnabled()
             }.start(context.mainExecutor()) { event ->
-              android.util.Log.w("CameraCaptureManager", "clip: event ${event.javaClass.simpleName}")
-              if (event is VideoRecordEvent.Status) {
-                android.util.Log.w("CameraCaptureManager", "clip: recording status update")
-              }
               if (event is VideoRecordEvent.Finalize) {
-                android.util.Log.w(
-                  "CameraCaptureManager",
-                  "clip: finalize hasError=${event.hasError()} error=${event.error} cause=${event.cause}",
-                )
                 finalized.complete(event)
               }
             }
         session.ownRecording(recording)
 
-        android.util.Log.w("CameraCaptureManager", "clip: recording started, delaying ${durationMs}ms")
         kotlinx.coroutines.delay(durationMs.toLong())
-        android.util.Log.w("CameraCaptureManager", "clip: stopping recording")
         recording.close()
 
         val finalizeEvent =
           try {
             withTimeout(15_000) { finalized.await() }
-          } catch (err: kotlinx.coroutines.TimeoutCancellationException) {
-            android.util.Log.e("CameraCaptureManager", "clip: finalize timed out", err)
+          } catch (_: kotlinx.coroutines.TimeoutCancellationException) {
             throw IllegalStateException("UNAVAILABLE: camera clip finalize timed out")
           }
         if (finalizeEvent.hasError()) {
-          android.util.Log.e(
-            "CameraCaptureManager",
-            "clip: FAILED error=${finalizeEvent.error}, cause=${finalizeEvent.cause}",
-            finalizeEvent.cause,
-          )
-          // Check file size for debugging
-          val fileSize = withContext(Dispatchers.IO) { if (clipFile.exists()) clipFile.length() else -1 }
-          android.util.Log.e("CameraCaptureManager", "clip: file exists=${clipFile.exists()} size=$fileSize")
           throw IllegalStateException("UNAVAILABLE: camera clip failed (error=${finalizeEvent.error})")
         }
-
-        val fileSize = withContext(Dispatchers.IO) { clipFile.length() }
-        android.util.Log.w("CameraCaptureManager", "clip: SUCCESS file size=$fileSize")
 
         FilePayload(
           file = session.transferFile(),


### PR DESCRIPTION
## What Problem This Solves

`camera.clip` on Android emitted verbose `CameraCaptureManager` logs from the production capture path.

Those logs included runtime details that do not belong in release logs:

- selected facing
- requested duration
- audio setting
- optional Camera2 device id
- CameraX camera info
- temporary MP4 output path
- recording lifecycle events
- finalize error/cause details
- captured file existence and size

This is especially noisy for a gateway node command because `camera.clip` can be invoked by an agent while recording real local camera/audio state.

## Why This Change Was Made

The Android camera stack already has debug-only diagnostics in `apps/android/app/src/main/java/ai/openclaw/app/node/CameraHandler.kt`. Those logs are guarded by `BuildConfig.DEBUG` and write to the debug camera log only in debug builds.

`CameraCaptureManager` does not need a second unconditional logging path underneath that handler. This PR removes the direct `android.util.Log` calls from the manager and deletes the temporary values that only existed to feed those logs.

The recording flow is otherwise unchanged:

- permission checks still run first
- CameraX provider/selector setup is unchanged
- preview + video capture still bind to the lifecycle
- the warmup delay is unchanged
- finalize timeout/error handling is unchanged
- temporary file ownership and transfer are unchanged
- `CameraHandler` still performs payload-size enforcement and deletes encoded files

## User Impact

Release builds no longer write camera clip recording details to Android logs during `camera.clip`.

Debug builds still have the existing `CameraHandler` debug diagnostics for local troubleshooting.

## Evidence

- Source boundary check:
  - `rg -n "android\\.util\\.Log|\\bLog\\.[dwie]" apps/android/app/src/main/java/ai/openclaw/app/node/CameraCaptureManager.kt apps/android/app/src/main/java/ai/openclaw/app/node/CameraHandler.kt`
  - Result: no `CameraCaptureManager` log calls remain; only `CameraHandler` debug-gated log lines remain.
- `git diff --check`
- `cd apps/android && ./gradlew :app:ktlintCheck`
- `cd apps/android && ./gradlew --no-daemon -Dorg.gradle.java.home=/opt/homebrew/opt/openjdk/libexec/openjdk.jdk/Contents/Home :app:testPlayDebugUnitTest --tests ai.openclaw.app.node.CameraHandlerTest`
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base upstream/main`
  - Result: `autoreview clean: no accepted/actionable findings reported`
