### PR TITLE
fix(mcp-grant): guard sessionKey.trim() against undefined input

### DIFF
--- a/src/gateway/mcp-grant-store.ts
+++ b/src/gateway/mcp-grant-store.ts
@@ -28,7 +28,7 @@ export function mintAttachGrant(params: {
   ttlMs?: number;
   nowMs?: number;
 }): McpAttachGrant {
-  const sessionKey = params.sessionKey.trim();
+  const sessionKey = params.sessionKey?.trim() ?? "";
   if (!sessionKey) {
     throw new Error("mintAttachGrant: sessionKey is required");
   }


### PR DESCRIPTION
## What Problem This Solves

`mintAttachGrant` calls `params.sessionKey.trim()` assuming a string, but the caller resolves it via `readString() ?? resolveMainSessionKey()`. If both return `undefined`, `.trim()` throws `TypeError` instead of reaching the validation guard.

## Why This Change Was Made

`params.sessionKey?.trim() ?? ""` — undefined flows through to `if (!sessionKey)` check instead of crashing.

## User Impact

Prevents TypeError crash when MCP attach grants are requested without a valid session key.

## Evidence

![runtime proof](https://raw.githubusercontent.com/zhangLei99586/openclaw/proof-screenshots/pr-99488-99490-proof.png)

- OLD: `TypeError: Cannot read properties of undefined (reading 'trim')`
- NEW: gracefully reaches validation guard "sessionKey is required"