### PR TITLE
feat(cli): add `openclaw stats` usage command

### DIFF
--- a/docs/cli/index.md
+++ b/docs/cli/index.md
@@ -25,7 +25,7 @@ Use the setup commands by intent:
 | Setup and onboarding | [`crestodian`](/cli/crestodian) · [`setup`](/cli/setup) · [`onboard`](/cli/onboard) · [`configure`](/cli/configure) · [`config`](/cli/config) · [`completion`](/cli/completion) · [`doctor`](/cli/doctor) · [`dashboard`](/cli/dashboard) |
 | Reset and uninstall  | [`backup`](/cli/backup) · [`reset`](/cli/reset) · [`uninstall`](/cli/uninstall) · [`update`](/cli/update)                                                                                                                                 |
 | Messaging and agents | [`message`](/cli/message) · [`agent`](/cli/agent) · [`agents`](/cli/agents) · [`attach`](/cli/attach) · [`acp`](/cli/acp) · [`mcp`](/cli/mcp)                                                                                             |
-| Health and sessions  | [`status`](/cli/status) · [`health`](/cli/health) · [`sessions`](/cli/sessions)                                                                                                                                                           |
+| Health and sessions  | [`status`](/cli/status) · [`health`](/cli/health) · [`sessions`](/cli/sessions) · [`stats`](/cli/stats)                                                                                                                                   |
 | Gateway and logs     | [`gateway`](/cli/gateway) · [`logs`](/cli/logs) · [`system`](/cli/system)                                                                                                                                                                 |
 | Models and inference | [`models`](/cli/models) · [`infer`](/cli/infer) · `capability` (alias for [`infer`](/cli/infer)) · [`memory`](/cli/memory) · [`commitments`](/cli/commitments) · [`wiki`](/cli/wiki)                                                      |
 | Network and nodes    | [`directory`](/cli/directory) · [`nodes`](/cli/nodes) · [`devices`](/cli/devices) · [`node`](/cli/node)                                                                                                                                   |
@@ -205,6 +205,8 @@ openclaw [--dev] [--profile <name>] <command>
   health
   sessions
     cleanup
+  stats
+    usage
   tasks
     list
     audit

--- a/docs/cli/stats.md
+++ b/docs/cli/stats.md
@@ -1,0 +1,72 @@
+---
+summary: "CLI reference for `openclaw stats` (aggregate token usage and cost from stored sessions)"
+read_when:
+  - You want a quick token usage and cost summary for your agents
+  - You need per-agent or per-provider usage totals from the terminal
+  - You are scripting usage reporting and want machine-readable output
+title: "Stats CLI"
+---
+
+# `openclaw stats`
+
+Aggregate token usage and estimated cost from stored session metadata. This CLI
+is read-only: it reads the same session stores as [`sessions`](/cli/sessions)
+and never writes state or calls provider APIs.
+
+Bare `openclaw stats` runs the usage summary; `openclaw stats usage` is the
+explicit form.
+
+## Commands
+
+```bash
+openclaw stats
+openclaw stats usage
+openclaw stats --agent work
+openclaw stats --all-agents
+openclaw stats --since 7d
+openclaw stats --until 2026-01-31
+openclaw stats --provider anthropic
+openclaw stats --json
+```
+
+## Options
+
+- `--store <path>`: read a specific session store instead of the configured one.
+- `--agent <id>`: scope to a single agent (default: configured default agent).
+- `--all-agents`: aggregate across all configured agents.
+- `--since <when>`: only include sessions updated at or after this bound.
+- `--until <when>`: only include sessions updated at or before this bound.
+- `--provider <id>`: only include sessions for a model provider (case-insensitive).
+- `--json`: print machine-readable output.
+
+`--since` and `--until` accept either a duration relative to now (for example
+`7d`, `24h`, `1h30m`; a bare number means days) or an absolute ISO date such as
+`2026-01-31`.
+
+## Output
+
+Token totals sum each session's recorded input and output tokens. They are not
+the per-session context-window snapshot shown by `sessions`, so they can be
+added up meaningfully across sessions. Sessions without recorded usage still
+count toward the session total with zero tokens.
+
+The human-readable summary reports overall totals, then a per-agent breakdown
+(when more than one agent is in scope) and a per-provider breakdown. Breakdown
+rows are ordered by total tokens descending, then by name.
+
+```text
+Session store: /Users/alex/.openclaw/agents/main/agent/sessions.json
+Sessions: 42
+Input tokens: 1,204,880
+Output tokens: 210,455
+Total tokens: 1,415,335
+Estimated cost: $12.4021
+By provider:
+  anthropic  sessions=30  in=1,000,000  out=180,000  total=1,180,000  cost=$10.5000
+  openai     sessions=12  in=204,880    out=30,455    total=235,335    cost=$1.9021
+```
+
+`--json` returns an object with the resolved `stores`, the applied `since` /
+`until` / `provider` filters, overall `totals`, and `byAgent` / `byProvider`
+arrays. Each totals object has `sessions`, `inputTokens`, `outputTokens`,
+`totalTokens`, and `estimatedCostUsd`.

--- a/docs/docs_map.md
+++ b/docs/docs_map.md
@@ -1907,6 +1907,15 @@ Do not edit it by hand; run `pnpm docs:map:gen`.
   - H2: Skill Workshop
   - H2: Related
 
+## cli/stats.md
+
+- Route: /cli/stats
+- Headings:
+  - H1: openclaw stats
+  - H2: Commands
+  - H2: Options
+  - H2: Output
+
 ## cli/status.md
 
 - Route: /cli/status

--- a/src/cli/program/command-registry-core.ts
+++ b/src/cli/program/command-registry-core.ts
@@ -113,6 +113,11 @@ const coreEntrySpecs: readonly CommandGroupDescriptorSpec<
         loadModule: () => import("./register.transcripts.js"),
         exportName: "registerTranscriptsCli",
       },
+      {
+        commandNames: ["stats"],
+        loadModule: () => import("./register.stats.js"),
+        exportName: "registerStatsCli",
+      },
     ]),
   ),
   defineImportedCommandGroupSpec(

--- a/src/cli/program/core-command-descriptors.ts
+++ b/src/cli/program/core-command-descriptors.ts
@@ -79,6 +79,11 @@ const coreCliCommandCatalog = defineCommandDescriptorCatalog([
     hasSubcommands: true,
   },
   {
+    name: "stats",
+    description: "Show local agent usage statistics",
+    hasSubcommands: true,
+  },
+  {
     name: "agent",
     description: "Run one agent turn via the Gateway",
     hasSubcommands: false,

--- a/src/cli/program/register.stats.ts
+++ b/src/cli/program/register.stats.ts
@@ -1,0 +1,76 @@
+// `openclaw stats`: local usage statistics aggregated from session stores.
+import type { Command } from "commander";
+import { theme } from "../../../packages/terminal-core/src/theme.js";
+import { setVerbose } from "../../globals.js";
+import { defaultRuntime } from "../../runtime.js";
+import { formatHelpExamples } from "../help-format.js";
+
+type StatsUsageCliOptions = {
+  json?: boolean;
+  verbose?: boolean;
+  store?: string;
+  agent?: string;
+  allAgents?: boolean;
+  since?: string;
+  until?: string;
+  provider?: string;
+};
+
+function addStatsUsageOptions(command: Command): Command {
+  return command
+    .option("--json", "Output as JSON", false)
+    .option("--verbose", "Verbose logging", false)
+    .option("--store <path>", "Path to session store (default: resolved from config)")
+    .option("--agent <id>", "Agent id to inspect (default: configured default agent)")
+    .option("--all-agents", "Aggregate usage across all configured agents", false)
+    .option("--since <when>", "Only include sessions updated since a duration (e.g. 7d) or date")
+    .option("--until <when>", "Only include sessions updated before a duration (e.g. 1d) or date")
+    .option("--provider <id>", "Only include sessions for a model provider");
+}
+
+async function runStatsUsageCli(opts: StatsUsageCliOptions): Promise<void> {
+  setVerbose(Boolean(opts.verbose));
+  const { statsUsageCommand } = await import("../../commands/stats.js");
+  await statsUsageCommand(
+    {
+      json: Boolean(opts.json),
+      store: opts.store,
+      agent: opts.agent,
+      allAgents: Boolean(opts.allAgents),
+      since: opts.since,
+      until: opts.until,
+      provider: opts.provider,
+    },
+    defaultRuntime,
+  );
+}
+
+/** Register the `stats` command group and its `usage` subcommand. */
+export function registerStatsCli(program: Command): void {
+  // Bare `openclaw stats` runs the usage summary; the explicit `usage`
+  // subcommand shares the same options and action.
+  const stats = addStatsUsageOptions(
+    program.command("stats").description("Show local agent usage statistics"),
+  )
+    .addHelpText(
+      "after",
+      () =>
+        `\n${theme.heading("Examples:")}\n${formatHelpExamples([
+          ["openclaw stats", "Aggregate token usage across sessions."],
+          ["openclaw stats --agent work", "Usage for one agent."],
+          ["openclaw stats --all-agents", "Aggregate usage across agents."],
+          ["openclaw stats --since 7d", "Only sessions from the last 7 days."],
+          ["openclaw stats --provider anthropic", "Only sessions for one provider."],
+          ["openclaw stats --json", "Machine-readable output."],
+        ])}`,
+    )
+    .action(async (opts: StatsUsageCliOptions) => {
+      await runStatsUsageCli(opts);
+    });
+
+  addStatsUsageOptions(
+    stats.command("usage").description("Aggregate token usage across stored sessions"),
+  ).action(async (opts: StatsUsageCliOptions) => {
+    await runStatsUsageCli(opts);
+  });
+}

--- a/src/commands/stats.test.ts
+++ b/src/commands/stats.test.ts
@@ -1,0 +1,184 @@
+// Stats usage command tests cover aggregation math, filters, JSON output, and ordering.
+import fs from "node:fs";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  makeRuntime,
+  mockSessionsConfig,
+  resetMockSessionsConfig,
+  writeStore,
+} from "./sessions.test-helpers.js";
+
+// Disable colors for deterministic output.
+process.env.FORCE_COLOR = "0";
+
+mockSessionsConfig();
+
+import { statsUsageCommand } from "./stats.js";
+
+type StatsJson = {
+  totals: {
+    sessions: number;
+    inputTokens: number;
+    outputTokens: number;
+    totalTokens: number;
+    estimatedCostUsd: number;
+  };
+  provider: string | null;
+  since: string | null;
+  byProvider: Array<{
+    name: string;
+    sessions: number;
+    inputTokens: number;
+    outputTokens: number;
+    totalTokens: number;
+    estimatedCostUsd: number;
+  }>;
+};
+
+async function runStatsJson(
+  store: string,
+  opts?: { provider?: string; since?: string; until?: string },
+): Promise<StatsJson> {
+  const { runtime, logs } = makeRuntime();
+  try {
+    await statsUsageCommand({ store, json: true, ...opts }, runtime);
+  } finally {
+    fs.rmSync(store, { force: true });
+  }
+  return JSON.parse(logs[0] ?? "{}") as StatsJson;
+}
+
+describe("statsUsageCommand", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-07-03T00:00:00Z"));
+  });
+
+  afterEach(() => {
+    resetMockSessionsConfig();
+    vi.useRealTimers();
+  });
+
+  it("aggregates token usage and cost across sessions", async () => {
+    const store = writeStore({
+      a: {
+        sessionId: "a",
+        updatedAt: Date.now(),
+        inputTokens: 1000,
+        outputTokens: 500,
+        estimatedCostUsd: 0.25,
+        modelProvider: "anthropic",
+      },
+      b: {
+        sessionId: "b",
+        updatedAt: Date.now(),
+        inputTokens: 200,
+        outputTokens: 100,
+        estimatedCostUsd: 0.05,
+        modelProvider: "openai",
+      },
+    });
+
+    const payload = await runStatsJson(store);
+    expect(payload.totals.sessions).toBe(2);
+    expect(payload.totals.inputTokens).toBe(1200);
+    expect(payload.totals.outputTokens).toBe(600);
+    expect(payload.totals.totalTokens).toBe(1800);
+    expect(payload.totals.estimatedCostUsd).toBeCloseTo(0.3, 10);
+  });
+
+  it("orders provider breakdown by total tokens descending", async () => {
+    const store = writeStore({
+      a: {
+        sessionId: "a",
+        updatedAt: Date.now(),
+        inputTokens: 10,
+        outputTokens: 5,
+        modelProvider: "small",
+        model: "m",
+      },
+      b: {
+        sessionId: "b",
+        updatedAt: Date.now(),
+        inputTokens: 5000,
+        outputTokens: 5000,
+        modelProvider: "big",
+        model: "m",
+      },
+      c: {
+        sessionId: "c",
+        updatedAt: Date.now(),
+        inputTokens: 100,
+        outputTokens: 100,
+        modelProvider: "mid",
+        model: "m",
+      },
+    });
+
+    const payload = await runStatsJson(store);
+    expect(payload.byProvider.map((row) => row.name)).toEqual(["big", "mid", "small"]);
+  });
+
+  it("filters by provider", async () => {
+    const store = writeStore({
+      a: {
+        sessionId: "a",
+        updatedAt: Date.now(),
+        inputTokens: 1000,
+        outputTokens: 0,
+        modelProvider: "anthropic",
+        model: "m",
+      },
+      b: {
+        sessionId: "b",
+        updatedAt: Date.now(),
+        inputTokens: 7,
+        outputTokens: 3,
+        modelProvider: "openai",
+        model: "m",
+      },
+    });
+
+    const payload = await runStatsJson(store, { provider: "openai" });
+    expect(payload.provider).toBe("openai");
+    expect(payload.totals.sessions).toBe(1);
+    expect(payload.totals.totalTokens).toBe(10);
+    expect(payload.byProvider.map((row) => row.name)).toEqual(["openai"]);
+  });
+
+  it("filters by --since duration window", async () => {
+    const store = writeStore({
+      recent: {
+        sessionId: "recent",
+        updatedAt: Date.now() - 60_000,
+        inputTokens: 40,
+        outputTokens: 10,
+      },
+      stale: {
+        sessionId: "stale",
+        updatedAt: Date.now() - 10 * 86_400_000,
+        inputTokens: 999,
+        outputTokens: 999,
+      },
+    });
+
+    const payload = await runStatsJson(store, { since: "7d" });
+    expect(payload.totals.sessions).toBe(1);
+    expect(payload.totals.totalTokens).toBe(50);
+    expect(payload.since).not.toBeNull();
+  });
+
+  it("counts sessions without recorded usage as zero tokens", async () => {
+    const store = writeStore({
+      a: { sessionId: "a", updatedAt: Date.now(), modelProvider: "anthropic" },
+    });
+
+    const { runtime, logs } = makeRuntime();
+    await statsUsageCommand({ store }, runtime);
+    fs.rmSync(store, { force: true });
+
+    const text = logs.join("\n");
+    expect(text).toContain("Sessions: 1");
+    expect(text).toContain("Total tokens: 0");
+  });
+});

--- a/src/commands/stats.ts
+++ b/src/commands/stats.ts
@@ -1,0 +1,237 @@
+/**
+ * Usage statistics command.
+ *
+ * Aggregates per-session token usage and estimated cost from one or more agent
+ * session stores into overall totals plus per-agent and per-provider
+ * breakdowns. Read-only: it reuses the same session accessor as `sessions` and
+ * never writes state.
+ */
+import { normalizeOptionalLowercaseString } from "@openclaw/normalization-core/string-coerce";
+import { parseDurationMs } from "../cli/parse-duration.js";
+import { getRuntimeConfig } from "../config/config.js";
+import { listSessionEntries } from "../config/sessions/session-accessor.js";
+import type { SessionEntry } from "../config/sessions/types.js";
+import { formatErrorMessage } from "../infra/errors.js";
+import { type RuntimeEnv, writeRuntimeJson } from "../runtime.js";
+import { resolveSessionStoreTargetsOrExit } from "./session-store-targets.js";
+
+/** CLI options accepted by `openclaw stats usage`. */
+export type StatsUsageOptions = {
+  json?: boolean;
+  store?: string;
+  agent?: string;
+  allAgents?: boolean;
+  since?: string;
+  until?: string;
+  provider?: string;
+};
+
+/** Aggregated usage counters shared by overall totals and breakdown rows. */
+type UsageTotals = {
+  sessions: number;
+  inputTokens: number;
+  outputTokens: number;
+  totalTokens: number;
+  estimatedCostUsd: number;
+};
+
+/** A named breakdown row (per agent or per provider). */
+type UsageBreakdownRow = UsageTotals & { name: string };
+
+const UNKNOWN_PROVIDER = "unknown";
+
+function emptyTotals(): UsageTotals {
+  return {
+    sessions: 0,
+    inputTokens: 0,
+    outputTokens: 0,
+    totalTokens: 0,
+    estimatedCostUsd: 0,
+  };
+}
+
+function resolveNonNegative(value: number | undefined): number {
+  return typeof value === "number" && Number.isFinite(value) && value > 0 ? value : 0;
+}
+
+/**
+ * Adds one session's usage into a totals accumulator. Token totals sum the
+ * per-run input/output counts rather than `entry.totalTokens`, which is a
+ * context-window snapshot for the latest run and is not additive across
+ * sessions.
+ */
+function addSessionUsage(totals: UsageTotals, entry: SessionEntry): void {
+  const input = resolveNonNegative(entry.inputTokens);
+  const output = resolveNonNegative(entry.outputTokens);
+  totals.sessions += 1;
+  totals.inputTokens += input;
+  totals.outputTokens += output;
+  totals.totalTokens += input + output;
+  totals.estimatedCostUsd += resolveNonNegative(entry.estimatedCostUsd);
+}
+
+function upsertBreakdown(map: Map<string, UsageTotals>, key: string, entry: SessionEntry): void {
+  const totals = map.get(key) ?? emptyTotals();
+  addSessionUsage(totals, entry);
+  map.set(key, totals);
+}
+
+/** Sort breakdown rows by total tokens descending, then name ascending, for stable output. */
+function toSortedBreakdown(map: Map<string, UsageTotals>): UsageBreakdownRow[] {
+  return Array.from(map, ([name, totals]) => ({ name, ...totals })).toSorted(
+    (left, right) => right.totalTokens - left.totalTokens || left.name.localeCompare(right.name),
+  );
+}
+
+/**
+ * Parses a `--since`/`--until` bound. Values containing a date separator
+ * (`-`, `:`, `T`, `/`) are treated as absolute dates; everything else is a
+ * duration relative to now (e.g. `7d`, `24h`), with bare numbers meaning days.
+ */
+function parseTimeBound(raw: string, flag: string): number {
+  const trimmed = raw.trim();
+  if (/[-:T/]/.test(trimmed)) {
+    const parsed = Date.parse(trimmed);
+    if (Number.isNaN(parsed)) {
+      throw new Error(`Invalid ${flag} date: "${raw}". Use an ISO date like 2026-01-31.`);
+    }
+    return parsed;
+  }
+  // parseDurationMs throws with its own guidance for malformed durations.
+  return Date.now() - parseDurationMs(trimmed, { defaultUnit: "d" });
+}
+
+function formatInt(value: number): string {
+  return Math.round(value).toLocaleString("en-US");
+}
+
+function formatCost(value: number): string {
+  return `$${value.toFixed(4)}`;
+}
+
+function formatBreakdownRow(row: UsageBreakdownRow): string {
+  return [
+    `  ${row.name}`,
+    `sessions=${formatInt(row.sessions)}`,
+    `in=${formatInt(row.inputTokens)}`,
+    `out=${formatInt(row.outputTokens)}`,
+    `total=${formatInt(row.totalTokens)}`,
+    `cost=${formatCost(row.estimatedCostUsd)}`,
+  ].join("  ");
+}
+
+/** Aggregates and reports token usage across the selected session stores. */
+export async function statsUsageCommand(
+  opts: StatsUsageOptions,
+  runtime: RuntimeEnv,
+): Promise<void> {
+  const cfg = getRuntimeConfig();
+  const targets = resolveSessionStoreTargetsOrExit({
+    cfg,
+    opts: {
+      store: opts.store,
+      agent: opts.agent,
+      allAgents: opts.allAgents,
+    },
+    runtime,
+  });
+  if (!targets) {
+    return;
+  }
+
+  let sinceMs: number | undefined;
+  let untilMs: number | undefined;
+  try {
+    sinceMs = opts.since !== undefined ? parseTimeBound(opts.since, "--since") : undefined;
+    untilMs = opts.until !== undefined ? parseTimeBound(opts.until, "--until") : undefined;
+  } catch (error) {
+    runtime.error(formatErrorMessage(error));
+    runtime.exit(1);
+    return;
+  }
+
+  const providerFilter = normalizeOptionalLowercaseString(opts.provider);
+
+  const overall = emptyTotals();
+  const byAgent = new Map<string, UsageTotals>();
+  const byProvider = new Map<string, UsageTotals>();
+
+  for (const target of targets) {
+    const entries = listSessionEntries({ agentId: target.agentId, storePath: target.storePath });
+    for (const { entry } of entries) {
+      const updatedAt = entry.updatedAt;
+      if (sinceMs !== undefined && !(typeof updatedAt === "number" && updatedAt >= sinceMs)) {
+        continue;
+      }
+      if (untilMs !== undefined && !(typeof updatedAt === "number" && updatedAt <= untilMs)) {
+        continue;
+      }
+      const provider = normalizeOptionalLowercaseString(entry.modelProvider);
+      if (providerFilter !== undefined && provider !== providerFilter) {
+        continue;
+      }
+      addSessionUsage(overall, entry);
+      upsertBreakdown(byAgent, target.agentId, entry);
+      upsertBreakdown(byProvider, provider ?? UNKNOWN_PROVIDER, entry);
+    }
+  }
+
+  const agentRows = toSortedBreakdown(byAgent);
+  const providerRows = toSortedBreakdown(byProvider);
+
+  if (opts.json) {
+    writeRuntimeJson(runtime, {
+      stores: targets.map((target) => ({ agentId: target.agentId, path: target.storePath })),
+      allAgents: opts.allAgents === true ? true : undefined,
+      since: sinceMs !== undefined ? new Date(sinceMs).toISOString() : null,
+      until: untilMs !== undefined ? new Date(untilMs).toISOString() : null,
+      provider: providerFilter ?? null,
+      totals: overall,
+      byAgent: agentRows,
+      byProvider: providerRows,
+    });
+    return;
+  }
+
+  const scope =
+    targets.length === 1 && targets[0]
+      ? `Session store: ${targets[0].storePath}`
+      : `Session stores: ${targets.length} (${targets.map((t) => t.agentId).join(", ")})`;
+  runtime.log(scope);
+
+  const filters: string[] = [];
+  if (sinceMs !== undefined) {
+    filters.push(`since ${new Date(sinceMs).toISOString()}`);
+  }
+  if (untilMs !== undefined) {
+    filters.push(`until ${new Date(untilMs).toISOString()}`);
+  }
+  if (providerFilter !== undefined) {
+    filters.push(`provider ${providerFilter}`);
+  }
+  if (filters.length > 0) {
+    runtime.log(`Filters: ${filters.join(", ")}`);
+  }
+
+  runtime.log(`Sessions: ${formatInt(overall.sessions)}`);
+  runtime.log(`Input tokens: ${formatInt(overall.inputTokens)}`);
+  runtime.log(`Output tokens: ${formatInt(overall.outputTokens)}`);
+  runtime.log(`Total tokens: ${formatInt(overall.totalTokens)}`);
+  runtime.log(`Estimated cost: ${formatCost(overall.estimatedCostUsd)}`);
+
+  if (overall.sessions === 0) {
+    runtime.log("No matching sessions found.");
+    return;
+  }
+
+  if (agentRows.length > 1) {
+    runtime.log("By agent:");
+    for (const row of agentRows) {
+      runtime.log(formatBreakdownRow(row));
+    }
+  }
+  runtime.log("By provider:");
+  for (const row of providerRows) {
+    runtime.log(formatBreakdownRow(row));
+  }
+}


### PR DESCRIPTION
## What Problem This Solves

Operators running one or more OpenClaw agents have no first-class way to see
aggregate token usage or estimated cost from the CLI. The data already lives in
the session stores, but is only viewable per-session through `openclaw sessions`.

## Why This Change Was Made

Adds a read-only `openclaw stats` command (with an explicit `usage` subcommand)
that aggregates per-session token usage and estimated cost into overall totals
plus per-agent and per-provider breakdowns. It reuses the existing session
accessor used by `openclaw sessions`, so it introduces no new persisted state,
no new config keys or env vars, and makes no provider API calls — consistent
with the storage-neutral session boundary.

Token totals sum each session's recorded input/output tokens rather than the
per-session context-window snapshot (`entry.totalTokens`), which is not additive
across sessions.

## User Impact

New command: `openclaw stats` / `openclaw stats usage`.

- Flags: `--agent`, `--all-agents`, `--store`, `--since`, `--until`,
  `--provider`, `--json`.
- `--since` / `--until` accept a duration (`7d`, `24h`) or an ISO date.
- Bare `openclaw stats` prints the usage summary; `usage` is the explicit form.

No existing behavior changes; no config or migration impact.

## Evidence

- Unit tests: `pnpm test src/commands/stats.test.ts` — 5/5 pass (aggregation
  math, provider ordering, provider filter, `--since` window, zero-usage
  sessions).
- Typecheck: `pnpm tsgo` clean.
- Lint: `node scripts/run-oxlint.mjs` on new files — 0 warnings / 0 errors.
- Format: `oxfmt --check` clean (code); docs formatter clean.
- Descriptor consistency: `pnpm test src/cli/program/command-group-descriptors.test.ts` passes.
- Manual e2e: `pnpm openclaw stats --help` renders options + the `usage`
  subcommand; `pnpm openclaw stats --store <file>` and
  `pnpm openclaw stats --store <file> --provider anthropic --json` produce
  correct totals and per-provider/per-agent breakdowns.

Docs: adds `docs/cli/stats.md` and wires it into `docs/cli/index.md`.

Agent conversation: https://app.warp.dev/conversation/fa6a78c3-27a4-4a6c-ac4d-a772503c0141

Co-Authored-By: Oz <oz-agent@warp.dev>
