### PR TITLE
fix(runtime): guard JSON.stringify against circular references in tool output

### DIFF
--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -81,7 +81,11 @@ function createRuntimeIo(): Pick<OutputRuntimeEnv, "log" | "error" | "writeStdou
     },
     writeStdout,
     writeJson: (value: unknown, space = 2) => {
-      writeStdout(JSON.stringify(value, null, space > 0 ? space : undefined));
+      try {
+        writeStdout(JSON.stringify(value, null, space > 0 ? space : undefined));
+      } catch {
+        writeStdout(JSON.stringify(String(value)));
+      }
     },
   };
 }
@@ -113,5 +117,9 @@ export function writeRuntimeJson(
     runtime.writeJson(value, space);
     return;
   }
-  runtime.log(JSON.stringify(value, null, space > 0 ? space : undefined));
+  try {
+    runtime.log(JSON.stringify(value, null, space > 0 ? space : undefined));
+  } catch {
+    runtime.log(JSON.stringify(String(value)));
+  }
 }


### PR DESCRIPTION
## What Problem This Solves

`writeJson()` and `writeRuntimeJson()` call `JSON.stringify(value)` on arbitrary tool return values. Circular references cause `TypeError: Converting circular structure to JSON`, crashing the output path.

## Why This Change Was Made

Wrap both `JSON.stringify` calls in try-catch. On failure, fallback to `JSON.stringify(String(value))`.

## User Impact

Prevents runtime crash when tools return objects with circular references.

## Evidence

![runtime proof](https://raw.githubusercontent.com/zhangLei99586/openclaw/proof-screenshots/pr-99488-99490-proof.png)

- OLD: `TypeError: Converting circular structure to JSON`
- NEW: caught → fallback → `"[object Object]"` — no crash