### PR TITLE
fix(cli): include command aliases in shell completion scripts

### DIFF
--- a/src/cli/completion-cli.test.ts
+++ b/src/cli/completion-cli.test.ts
@@ -31,6 +31,12 @@ function createCompletionProgram(): Command {
   sessions.option("--verbose", "Verbose output");
   sessions.command("cleanup").description("Clean sessions").option("--dry-run", "Preview cleanup");
 
+  // Register aliases so completion tests cover the alias-aware generators.
+  const tui = program.command("tui").alias("terminal").alias("chat");
+  tui.command("start").description("Start the TUI");
+
+  gateway.command("logs").alias("log").description("Show gateway logs");
+
   return program;
 }
 
@@ -118,7 +124,9 @@ describe("completion-cli", () => {
     expect(script).toContain("if ($commandPath -eq 'gateway') {");
     expect(script).toContain("if ($commandPath -eq 'gateway status') {");
     expect(script).not.toContain("if ($commandPath -eq 'openclaw gateway') {");
-    expect(script).toContain("$completions = @('status','restart','--force','--token')");
+    expect(script).toContain(
+      "$completions = @('status','restart','logs','log','--force','--token')",
+    );
     expect(script).not.toContain("'-t,'");
   });
 
@@ -168,5 +176,63 @@ describe("completion-cli", () => {
 
     expect(script).toContain("--token");
     expect(script).not.toContain("-t,");
+  });
+
+  it("zsh completion includes alias names in subcommand list", () => {
+    const script = getCompletionScript("zsh", createCompletionProgram());
+
+    expect(script).toContain("'terminal[");
+    expect(script).toContain("'chat[");
+    expect(script).toContain("'tui[");
+    expect(script).toContain("'log[Show gateway logs]'");
+  });
+
+  it("zsh dispatch patterns match alias names", () => {
+    const script = getCompletionScript("zsh", createCompletionProgram());
+
+    expect(script).toContain("(tui|terminal|chat)");
+    expect(script).toContain("(logs|log)");
+  });
+
+  it("bash completion includes alias names in opts and case labels", () => {
+    const script = getCompletionScript("bash", createCompletionProgram());
+
+    expect(script).toContain("tui");
+    expect(script).toContain("terminal");
+    expect(script).toContain("chat");
+    expect(script).toContain("tui|terminal|chat)");
+    expect(script).toContain("logs");
+    expect(script).toContain("log");
+  });
+
+  it("PowerShell generates command path blocks for alias paths", () => {
+    const script = getCompletionScript("powershell", createCompletionProgram());
+
+    expect(script).toContain("if ($commandPath -eq 'tui') {");
+    expect(script).toContain("if ($commandPath -eq 'terminal') {");
+    expect(script).toContain("if ($commandPath -eq 'chat') {");
+  });
+
+  it("PowerShell root completions include alias names", () => {
+    const script = getCompletionScript("powershell", createCompletionProgram());
+
+    expect(script).toContain("'terminal'");
+    expect(script).toContain("'chat'");
+    expect(script).toContain("'tui'");
+  });
+
+  it("fish generates completion lines for alias names", () => {
+    const script = getCompletionScript("fish", createCompletionProgram());
+
+    expect(script).toContain('-a "terminal"');
+    expect(script).toContain('-a "chat"');
+    expect(script).toContain('-a "log"');
+  });
+
+  it("fish generates path conditions for alias paths", () => {
+    const script = getCompletionScript("fish", createCompletionProgram());
+
+    expect(script).toContain("__openclaw_command_path_matches terminal");
+    expect(script).toContain("__openclaw_command_path_matches chat");
   });
 });

--- a/src/cli/completion-cli.ts
+++ b/src/cli/completion-cli.ts
@@ -65,7 +65,7 @@ function collectFishPathOptionFlags(
   const flags = new Set(fishOptionFlags(program.options, wantsValue));
   let current: Command | undefined = program;
   for (const name of parents) {
-    current = current?.commands.find((cmd) => cmd.name() === name);
+    current = current?.commands.find((cmd) => cmd.name() === name || cmd.aliases().includes(name));
     if (!current) {
       break;
     }
@@ -258,7 +258,7 @@ _${rootCmd}_root_completion() {
   case $state in
     (args)
       case $line[1] in
-        ${program.commands.map((cmd) => `(${cmd.name()}) _${rootCmd}_${cmd.name().replace(/-/g, "_")} ;;`).join("\n        ")}
+        ${program.commands.map((cmd) => `(${[cmd.name(), ...cmd.aliases()].join("|")}) _${rootCmd}_${cmd.name().replace(/-/g, "_")} ;;`).join("\n        ")}
       esac
       ;;
   esac
@@ -304,14 +304,14 @@ function generateZshArgs(cmd: Command): string {
 
 function generateZshSubcmdList(cmd: Command): string {
   const list = cmd.commands
-    .map((c) => {
+    .flatMap((c) => {
       const desc = c
         .description()
         .replace(/\\/g, "\\\\")
         .replace(/'/g, "'\\''")
         .replace(/\[/g, "\\[")
         .replace(/\]/g, "\\]");
-      return `'${c.name()}[${desc}]'`;
+      return [c.name(), ...c.aliases()].map((name) => `'${name}[${desc}]'`);
     })
     .join(" ");
   return `"1: :_values 'command' ${list}"`;
@@ -353,7 +353,7 @@ ${funcName}() {
   case $state in
     (args)
       case $line[1] in
-        ${subCommands.map((sub) => `(${sub.name()}) ${funcName}_${sub.name().replace(/-/g, "_")} ;;`).join("\n        ")}
+        ${subCommands.map((sub) => `(${[sub.name(), ...sub.aliases()].join("|")}) ${funcName}_${sub.name().replace(/-/g, "_")} ;;`).join("\n        ")}
       esac
       ;;
   esac
@@ -390,7 +390,7 @@ _${rootCmd}_completion() {
     prev="\${COMP_WORDS[COMP_CWORD-1]}"
     
     # Simple top-level completion for now
-    opts="${program.commands.map((c) => c.name()).join(" ")} ${program.options.map((o) => preferredCompletionFlag(o.flags)).join(" ")}"
+    opts="${program.commands.flatMap((c) => [c.name(), ...c.aliases()]).join(" ")} ${program.options.map((o) => preferredCompletionFlag(o.flags)).join(" ")}"
     
     case "\${prev}" in
       ${program.commands.map((cmd) => generateBashSubcommand(cmd)).join("\n      ")}
@@ -411,8 +411,8 @@ complete -F _${rootCmd}_completion ${rootCmd}
 function generateBashSubcommand(cmd: Command): string {
   // This is a naive implementation; fully recursive bash completion is complex to generate as a single string without improved state tracking.
   // For now, let's provide top-level command recognition.
-  return `${cmd.name()})
-        opts="${cmd.commands.map((c) => c.name()).join(" ")} ${cmd.options.map((o) => preferredCompletionFlag(o.flags)).join(" ")}"
+  return `${[cmd.name(), ...cmd.aliases()].join("|")})
+        opts="${cmd.commands.flatMap((c) => [c.name(), ...c.aliases()]).join(" ")} ${cmd.options.map((o) => preferredCompletionFlag(o.flags)).join(" ")}"
         COMPREPLY=( $(compgen -W "\${opts}" -- \${cur}) )
         return 0
         ;;`;
@@ -428,7 +428,7 @@ function generatePowerShellCompletion(program: Command): string {
     const fullPath = pathSegments.join(" ");
 
     // Command completion for this level
-    const subCommands = cmd.commands.map((c) => c.name());
+    const subCommands = cmd.commands.flatMap((c) => [c.name(), ...c.aliases()]);
     const options = cmd.options.map((o) => preferredCompletionFlag(o.flags));
     const allCompletions = formatPowerShellArray([...subCommands, ...options]);
 
@@ -445,6 +445,9 @@ function generatePowerShellCompletion(program: Command): string {
 
     for (const sub of cmd.commands) {
       visit(sub, [...pathSegments, sub.name()]);
+      for (const alias of sub.aliases()) {
+        visit(sub, [...pathSegments, alias]);
+      }
     }
   };
 
@@ -471,7 +474,7 @@ Register-ArgumentCompleter -Native -CommandName ${rootCmd} -ScriptBlock {
     # Root command
     if ($commandPath -eq "") {
          $completions = ${formatPowerShellArray([
-           ...program.commands.map((command) => command.name()),
+           ...program.commands.flatMap((command) => [command.name(), ...command.aliases()]),
            ...program.options.map((option) => preferredCompletionFlag(option.flags)),
          ])}
          $completions | Where-Object { $_ -like "$wordToComplete*" } | ForEach-Object {
@@ -493,14 +496,16 @@ function generateFishCompletion(program: Command): string {
     if (parents.length === 0) {
       // Subcommands of root
       for (const sub of cmd.commands) {
-        segments.push(
-          buildFishSubcommandCompletionLine({
-            rootCmd,
-            condition: "__fish_use_subcommand",
-            name: sub.name(),
-            description: sub.description(),
-          }),
-        );
+        for (const name of [sub.name(), ...sub.aliases()]) {
+          segments.push(
+            buildFishSubcommandCompletionLine({
+              rootCmd,
+              condition: "__fish_use_subcommand",
+              name,
+              description: sub.description(),
+            }),
+          );
+        }
       }
       // Options of root
       for (const opt of cmd.options) {
@@ -517,14 +522,16 @@ function generateFishCompletion(program: Command): string {
       const condition = fishCommandPathCondition(program, rootCmd, parents);
       // Subcommands
       for (const sub of cmd.commands) {
-        segments.push(
-          buildFishSubcommandCompletionLine({
-            rootCmd,
-            condition,
-            name: sub.name(),
-            description: sub.description(),
-          }),
-        );
+        for (const name of [sub.name(), ...sub.aliases()]) {
+          segments.push(
+            buildFishSubcommandCompletionLine({
+              rootCmd,
+              condition,
+              name,
+              description: sub.description(),
+            }),
+          );
+        }
       }
       // Options
       for (const opt of cmd.options) {
@@ -541,6 +548,9 @@ function generateFishCompletion(program: Command): string {
 
     for (const sub of cmd.commands) {
       visit(sub, parents.length === 0 ? [sub.name()] : [...parents, sub.name()]);
+      for (const alias of sub.aliases()) {
+        visit(sub, parents.length === 0 ? [alias] : [...parents, alias]);
+      }
     }
   };
 


### PR DESCRIPTION
## What Problem This Solves

Fixes #99406 — shell completion (`openclaw completion`) omits all command aliases registered via Commander `.alias()`. Users see commands like `capability`, `terminal`, `chat`, `exec-approvals` in `--help` but cannot tab-complete them, and completion breaks after typing an alias.

## Why This Change Was Made

All four shell generators (zsh, bash, fish, PowerShell) built their command lists, dispatch patterns, and path conditions exclusively from `command.name()` and never consulted `command.aliases()`. This change makes every generator alias-aware:

- **zsh/bash**: add alias names to `_values` lists/`opts` strings; use `(name|alias)` alternation in case dispatch patterns
- **PowerShell**: include aliases in completion arrays; recurse with alias path variants to generate matching `$commandPath -eq` blocks
- **fish**: emit `complete` lines for alias subcommand names; recurse with alias path variants; make `collectFishPathOptionFlags` alias-aware

## User Impact

All 8 registered aliases now tab-complete in every supported shell, and completion continues to work for the segments after an alias — matching the behavior of canonical names and the commands advertised in `openclaw --help`.

## Evidence

- **Tests**: 15/15 unit tests pass (`completion-cli.test.ts`), including 7 new alias-specific test cases
- **Additional tests**: 3/3 fish tests, 18/18 subcli registration tests — all green
- **Real-world proof**: Generated completion scripts for all 4 shells and grep-verified alias entries (`capability`, `terminal`, `chat`, `exec-approvals`) plus alias-aware dispatch patterns (`(infer|capability)`, `(tui|terminal|chat)`) and path conditions (`command_path_matches capability/terminal/chat`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)