### PR TITLE
fix(reply): deliver durable reasoning on the origin-route when /reasoning opts in

### DIFF
--- a/src/auto-reply/reply/dispatch-from-config.ts
+++ b/src/auto-reply/reply/dispatch-from-config.ts
@@ -1825,6 +1825,7 @@ export async function dispatchReplyFromConfig(
       groupId,
       replyKind: options?.kind ?? "final",
       runId: params.replyOptions?.runId,
+      reasoningPayloadsEnabled: params.replyOptions?.reasoningPayloadsEnabled === true,
     });
   };
 

--- a/src/auto-reply/reply/route-reply.test.ts
+++ b/src/auto-reply/reply/route-reply.test.ts
@@ -11,6 +11,8 @@ import {
   createChannelTestPluginBase,
   createTestRegistry,
 } from "../../test-utils/channel-plugins.js";
+import { formatReasoningMessage } from "../../agents/embedded-agent-utils.js";
+import { createOutboundPayloadPlan } from "../../infra/outbound/payloads.js";
 import { setReplyPayloadMetadata } from "../reply-payload.js";
 import { SILENT_REPLY_TOKEN } from "../tokens.js";
 
@@ -267,8 +269,43 @@ describe("routeReply", () => {
     await expectSlackNoDelivery({});
   });
 
-  it("suppresses reasoning payloads", async () => {
+  it("suppresses reasoning payloads by default", async () => {
     await expectSlackNoDelivery({ text: "step", isReasoning: true });
+  });
+
+  it("keeps suppressing reasoning payloads when reasoning delivery is disabled", async () => {
+    await expectSlackNoDelivery(
+      { text: "step", isReasoning: true },
+      { reasoningPayloadsEnabled: false },
+    );
+  });
+
+  it("delivers reasoning payloads when reasoning delivery is enabled", async () => {
+    mocks.deliverOutboundPayloads.mockClear();
+    const res = await routeReply({
+      payload: { text: "step", isReasoning: true },
+      channel: "slack",
+      to: "channel:C123",
+      cfg: {} as never,
+      reasoningPayloadsEnabled: true,
+    });
+    expect(res.ok).toBe(true);
+    expect(mocks.deliverOutboundPayloads).toHaveBeenCalledTimes(1);
+    // Converted to a normal renderable message (isReasoning dropped) so it is not
+    // re-suppressed by outbound planning downstream.
+    const delivered = lastDeliveryPayload();
+    expect(delivered.isReasoning).toBeUndefined();
+    expect(String(delivered.text)).toContain("step");
+  });
+
+  it("keeps converted reasoning through the real outbound planner", () => {
+    // Second suppression point (createOutboundPayloadPlan): a payload still marked
+    // isReasoning is dropped, but the converted (formatted, flag-stripped) payload
+    // the enabled route produces is retained.
+    expect(createOutboundPayloadPlan([{ text: "step", isReasoning: true }])).toHaveLength(0);
+    const converted = createOutboundPayloadPlan([{ text: formatReasoningMessage("step") }]);
+    expect(converted.length).toBeGreaterThan(0);
+    expect(String(converted[0]?.payload.text)).toContain("step");
   });
 
   it("drops silent token payloads", async () => {

--- a/src/auto-reply/reply/route-reply.ts
+++ b/src/auto-reply/reply/route-reply.ts
@@ -31,6 +31,7 @@ import {
   formatBtwTextForExternalDelivery,
   shouldSuppressReasoningPayload,
 } from "./reply-payloads.js";
+import { formatReasoningMessage } from "../../agents/embedded-agent-utils.js";
 
 const messageRuntimeLoader = createLazyImportLoader(
   () => import("../../channels/message/runtime.js"),
@@ -103,6 +104,8 @@ type RouteReplyParams = {
   replyKind: ReplyDispatchKind;
   /** Agent run id for hook context. */
   runId?: string;
+  /** Whether durable reasoning payloads may be delivered (tri-state /reasoning opt-in). */
+  reasoningPayloadsEnabled?: boolean;
 };
 
 type RouteReplyResult = {
@@ -119,6 +122,22 @@ type RouteReplyResult = {
 };
 
 /**
+ * Converts an opted-in durable reasoning payload into a normal renderable
+ * message: formats the text as reasoning and drops the isReasoning flag. Mirrors
+ * the per-channel conversion the direct-dispatch path applies (e.g.
+ * formatDiscordReasoningPayload) so the payload survives outbound planning, which
+ * otherwise suppresses anything still marked isReasoning.
+ */
+function toRoutedReasoningDeliveryPayload(payload: ReplyPayload): ReplyPayload {
+  const next: ReplyPayload = {
+    ...payload,
+    text: formatReasoningMessage(typeof payload.text === "string" ? payload.text.trim() : ""),
+  };
+  delete next.isReasoning;
+  return next;
+}
+
+/**
  * Routes a reply payload to the specified channel.
  *
  * This function provides a unified interface for sending messages to any
@@ -127,7 +146,18 @@ type RouteReplyResult = {
  * are set.
  */
 export async function routeReply(params: RouteReplyParams): Promise<RouteReplyResult> {
-  const { payload, channel, to, accountId, threadId, cfg, abortSignal } = params;
+  const { channel, to, accountId, threadId, cfg, abortSignal } = params;
+  // Durable reasoning is a channel-owned lane. When the session opted in
+  // (reasoningPayloadsEnabled), convert the reasoning payload into a normal
+  // renderable message the same way the direct-dispatch path does per channel
+  // (e.g. formatDiscordReasoningPayload): format the text and drop the isReasoning
+  // flag so it survives outbound planning, which otherwise suppresses any payload
+  // still marked isReasoning (createOutboundPayloadPlan -> shouldSuppressReasoningPayload).
+  // Without the opt-in, keep the historical suppression.
+  const payload =
+    params.reasoningPayloadsEnabled === true && params.payload.isReasoning === true
+      ? toRoutedReasoningDeliveryPayload(params.payload)
+      : params.payload;
   if (shouldSuppressReasoningPayload(payload)) {
     return { ok: true };
   }


### PR DESCRIPTION
## What Problem This Solves

On the **origin-routing** delivery path, durable reasoning for `/reasoning on` was silently lost when a reply was routed back to its originating channel. There are **two** blanket `isReasoning` suppression points:

- `routeReply` — `src/auto-reply/reply/route-reply.ts:131` (`shouldSuppressReasoningPayload`).
- the shared outbound planner — `src/infra/outbound/payloads.ts:210` (`createOutboundPayloadPlanEntry`), downstream of `routeReply`.

The **direct** dispatch path delivers durable reasoning fine because the channel **converts** the reasoning payload into a normal renderable message before planning — discord `formatDiscordReasoningPayload`, telegram `normalizeDeliveryPayload` — each using the shared `formatReasoningMessage` helper and dropping the `isReasoning` flag. The provider-agnostic `routeReply` never performed that conversion, so the payload hit both drops.

**Outcome:** mirror the direct path on the routed path. When the session opted in (`reasoningPayloadsEnabled`), `routeReply` converts the reasoning payload via the shared `formatReasoningMessage(text)` and drops the `isReasoning` flag (`toRoutedReasoningDeliveryPayload`), so the flag-stripped payload survives **both** suppression points and is delivered. `routeReplyToOriginating` threads the resolved flag. Default (no opt-in) keeps the historical suppression, byte-identical for every other caller.

## Evidence

Exercised through the **real `routeReply` and the real `createOutboundPayloadPlan`** (the second suppression point is no longer mocked away).

`pnpm exec vitest run src/auto-reply/reply/route-reply.test.ts -t "reasoning|planner"`

- `suppresses reasoning payloads by default` ✓ — no opt-in → dropped.
- `keeps suppressing reasoning payloads when reasoning delivery is disabled` ✓ — `reasoningPayloadsEnabled: false` → dropped.
- `delivers reasoning payloads when reasoning delivery is enabled` ✓ — delivered payload has `isReasoning` undefined and text contains the reasoning.
- `keeps converted reasoning through the real outbound planner` ✓ — **runs the actual `createOutboundPayloadPlan`**: a payload still flagged `isReasoning` → plan length 0 (reproduces the 2nd drop); the converted, flag-stripped payload → retained with its text.

**Evidence after fix — before/after at the second (real) suppression point:**
```
// BEFORE (flag intact) — the real planner drops it:
createOutboundPayloadPlan([{ text: "step", isReasoning: true }])  // => []  (length 0)
// AFTER (converted, flag stripped) — the real planner retains it:
createOutboundPayloadPlan([{ text: formatReasoningMessage("step") }])  // => [ { payload: { text: "Thinking…step…" } } ]
```

- **Gates:** `pnpm lint --threads=8` + `pnpm check:test-types` green. Full files (`route-reply` + `dispatch-from-config` + `infra/outbound/payloads`) = **312 tests pass**.
- **Independent review:** codex found no double-delivery/double-path issue (direct vs routed are mutually exclusive per turn) and confirmed default suppression is intact for all non-opted-in callers.

## Known limitation (documented)

On **Telegram**, the native `🧠` reasoning *lane* is rendered by Telegram's *turn-dispatch* (`normalizeDeliveryPayload` / `splitTelegramReasoningText`, keyed on `isReasoning === true`). The origin-routed send goes through the **generic** outbound path (`deliver.ts` → `createOutboundPayloadPlan`), which never invokes that turn-dispatch — so routed Telegram reasoning is delivered as a normal "Thinking…" message, **not** the native lane. This is **pre-existing** (the routed path never had the lane) and this change does not regress it — it is a strict improvement (delivered vs dropped). **Discord** gets full native fidelity (the conversion is identical to `formatDiscordReasoningPayload`). Full Telegram-lane fidelity on the routed path would require routing durable sends through the channel's turn-dispatch lane rendering — a larger change overlapping the broader Telegram durable-reasoning work, intentionally out of scope here.

## Reviewer focus / exactly-once

The change does not alter which payloads exist or the streamed-vs-final dedupe; it converts an already-produced reasoning payload before delivery. Direct and routed delivery are mutually exclusive per turn (`shouldRouteToOriginating`), and the routed path uses the generic `sendDurableMessageBatch` (never the channels' own reasoning-aware turn-dispatch), so there is no double-conversion or double-render.

## Scope — intentionally out of scope

- **Queued follow-up** (`followup-runner.ts`) and **ACP delivery** (`dispatch-acp-delivery.ts`): those paths do not emit a durable reasoning payload today (no `reasoningPayloadsEnabled` / `onReasoningStream`), so this flag does not affect them.
- `commands-private-route` / `commands-reset-hooks` route command acks / reset notices, never `isReasoning` — they keep the default suppress.
- No change to `shouldSuppressReasoningPayload`, the direct-dispatch path, channel plugins, provider routing, config schema, or public API.

## Linked context

- Closes #99492.
- Related #90943 (wired the blanket suppression onto the origin/follow-up path).
- Related #99401 (tri-state CLI thinking + follow-up resolver gate; its Scope note documents this origin-route boundary). Not stacked on it.
- Not requested by a maintainer; follow-up extending durable-reasoning delivery to the origin route.
