### PR TITLE
fix(dispatch): let unmentioned plugin-fallback messages reach normal dispatch

### DIFF
--- a/src/auto-reply/reply/dispatch-from-config.ts
+++ b/src/auto-reply/reply/dispatch-from-config.ts
@@ -2208,13 +2208,12 @@ export async function dispatchReplyFromConfig(
             ctx.WasMentioned === false &&
             !isExplicitSourceReplyCommand(ctx, cfg)
           ) {
-            markIdle("plugin_binding_fallback_unmentioned");
-            recordProcessed("completed", { reason: pluginFallbackReason });
-            commitInboundDedupeIfClaimed();
-            return attachSourceReplyDeliveryMode({
-              queuedFinal: false,
-              counts: dispatcher.getQueuedCounts(),
-            });
+            // Don't send a plugin-unavailable notice for unmentioned group
+            // traffic, and let normal agent dispatch process the message.
+            // For always-on routes where mention gating is disabled the
+            // message should still reach the agent; for mention-required
+            // routes the normal dispatch path applies its own mention gate.
+            break;
           }
           if (!hasShownPluginBindingFallbackNotice(pluginOwnedBinding.bindingId)) {
             const didSendNotice = await sendBindingNotice(


### PR DESCRIPTION
## Summary

**Problem**: When a plugin-bound inbound group/channel message is unmentioned and the plugin claim returns `missing_plugin` or `no_handler`, the dispatch logic drops the message before normal agent dispatch via `recordProcessed("completed")` + `return`. Always-on group routes where mention gating is disabled silently lose messages.

**Solution**: Replace the early `return` block with `break`, so unmentioned plugin-fallback messages fall through to normal agent dispatch instead of being dropped. The plugin-unavailable notice is still suppressed (the notice block is guarded by `hasShownPluginBindingFallbackNotice`), and normal dispatch applies its own mention gate.

**What changed**: `src/auto-reply/reply/dispatch-from-config.ts` — replace 5 lines of message-dropping code with `break` + comment.

**What did NOT change**: The `hasShownPluginBindingFallbackNotice` guard for plugin-unavailable notices. The normal dispatch mention-gating logic. The `declined` and `error` plugin claim cases.

Fixes #99457

## What Problem This Solves

Always-on group agents (iMessage groups, Telegram groups, Discord channels where mention gating is disabled) silently lose unmentioned messages when plugin-bound routing falls back. The message is archived but never reaches the agent session.

## Root Cause

`dispatch-from-config.ts:2211-2217` — The `plugin_binding_fallback_unmentioned` branch calls `recordProcessed("completed")` + `return`, marking the message as handled and dropping it before normal agent dispatch can process it.

## Real behavior proof

**Behavior addressed**: Unmentioned group messages silently dropped when plugin binding returns `missing_plugin`/`no_handler` on always-on routes.

**Real environment tested**: Node 24.13.1, Linux x86_64. Code path analysis via source inspection of PR head.

**Exact steps or command run after this patch**: Source-level analysis: the `break` at the plugin fallback switch exits to normal dispatch at line 2262, which handles both always-on and mention-required routing correctly.

**After-fix evidence**: 
```
Code path comparison:

BEFORE:
  plugin fallback → WasMentioned===false → markIdle + return → DROPPED

AFTER:
  plugin fallback → WasMentioned===false → break → normal dispatch (line 2262) → agent
```

**Observed result after the fix**: Unmentioned plugin-fallback messages break out of the switch and reach normal agent dispatch. For always-on groups the message is delivered to the agent; for mention-required groups the normal dispatch mention gate filters it.

**What was not tested**: Live iMessage/Telegram/Discord group with real plugin-bound routing. No external channel environment available. The fix is a straightforward replacement of `return` with `break`, restoring the intended fallthrough behavior.

**Evidence provenance**: Source-level code path analysis on PR head, 2026-07-03.

## Evidence

### Code path analysis

The fix removes 5 lines of message-dropping code:
- `markIdle("plugin_binding_fallback_unmentioned")`
- `recordProcessed("completed", ...)`
- `commitInboundDedupeIfClaimed()`
- `return attachSourceReplyDeliveryMode(...)`

And replaces them with `break;` which exits the switch block to normal dispatch at line 2262. The plugin-unavailable notice remains suppressed for unmentioned messages because the notice block at line 2219 is guarded by the same `WasMentioned === false` check that now causes the `break`.

## Risk checklist

**Highest-risk area**: In mention-required groups, a message could trigger a plugin-unavailable notice. The existing `hasShownPluginBindingFallbackNotice` guard limits this to once per binding per session.

**Risk level**: Low — replaces 5 lines of message-dropping code with a `break`. Normal dispatch already handles mention gating.

**Merge risk declaration**: No merge risk. Single-file change. No lockfile or changelog changes.

## Linked context

| Issue/PR | Status | Relationship |
|----------|--------|-------------|
| #99457 | Open | Canonical tracker |
