### PR TITLE
feat(discord): support multiple file attachments per message (fixes #24196)

### DIFF
--- a/docs/channels/discord.md
+++ b/docs/channels/discord.md
@@ -352,6 +352,9 @@ File attachments:
 
 - `file` blocks must point to an attachment reference (`attachment://<filename>`)
 - Provide the attachment via `media`/`path`/`filePath` (single file); use `media-gallery` for multiple files
+- Use `mediaUrls` (array of URLs) to send multiple file attachments in one message; Discord supports up to 10 files per message, and larger arrays are automatically split into follow-up messages
+- Component and voice message sends accept only a single file; pass `mediaUrls` with one entry or use `media`/`path`/`filePath`
+- When the message text accompanies video attachments, OpenClaw sends the caption and video in separate messages (Discord limitation)
 - Use `filename` to override the upload name when it should match the attachment reference
 
 Modal forms:

--- a/extensions/discord/src/actions/handle-action.ts
+++ b/extensions/discord/src/actions/handle-action.ts
@@ -121,8 +121,11 @@ export async function handleDiscordMessageAction(
   if (action === "send") {
     const to = readSendTarget();
     const asVoice = readBooleanParam(params, "asVoice") === true;
-    // Support media, path, and filePath for media URL
+    // Support mediaUrls array alongside legacy media/path/filePath (#24196)
+    const mediaUrlsArg = Array.isArray(params.media) ? (params.media as string[]) : undefined;
+    const mediaUrls = readStringArrayParam(params, "mediaUrls") ?? mediaUrlsArg;
     const mediaUrl =
+      mediaUrls?.[0] ??
       readStringParam(params, "media", { trim: false }) ??
       readStringParam(params, "path", { trim: false }) ??
       readStringParam(params, "filePath", { trim: false });
@@ -158,7 +161,8 @@ export async function handleDiscordMessageAction(
       (typeof rawComponents === "function" || typeof rawComponents === "object");
     const components = hasComponents ? rawComponents : undefined;
     const content = readStringParam(params, "message", {
-      required: !asVoice && !hasComponents && !mediaUrl && !presentationFellBack,
+      required:
+        !asVoice && !hasComponents && !mediaUrl && !mediaUrls?.length && !presentationFellBack,
       allowEmpty: true,
     });
     const deliveryContent =
@@ -184,7 +188,8 @@ export async function handleDiscordMessageAction(
         to,
         content: deliveryContent ?? "",
         ...(threadName ? { threadName } : {}),
-        mediaUrl: mediaUrl ?? undefined,
+        mediaUrl: mediaUrls ? undefined : (mediaUrl ?? undefined),
+        mediaUrls: mediaUrls ?? undefined,
         filename: filename ?? undefined,
         replyTo: replyTo ?? undefined,
         components,

--- a/extensions/discord/src/actions/runtime.messaging.send.ts
+++ b/extensions/discord/src/actions/runtime.messaging.send.ts
@@ -216,12 +216,15 @@ export async function handleDiscordMessageSendAction(ctx: DiscordMessagingAction
         Array.isArray(rawComponents) || typeof rawComponents === "function"
           ? (rawComponents as DiscordSendComponents)
           : undefined;
+      const mediaUrls = readStringArrayParam(ctx.params, "mediaUrls");
       const mediaUrl =
+        mediaUrls?.[0] ??
         readStringParam(ctx.params, "mediaUrl", { trim: false }) ??
         readStringParam(ctx.params, "path", { trim: false }) ??
         readStringParam(ctx.params, "filePath", { trim: false });
+      const hasMedia = Boolean(mediaUrl || mediaUrls?.length);
       const content = readStringParam(ctx.params, "content", {
-        required: !asVoice && !componentSpec && !components && !mediaUrl,
+        required: !asVoice && !componentSpec && !components && !hasMedia,
         allowEmpty: true,
       });
       const filename = readStringParam(ctx.params, "filename");
@@ -254,7 +257,8 @@ export async function handleDiscordMessageSendAction(ctx: DiscordMessagingAction
             reply: createReusableDiscordReplyReference(replyTo),
             sessionKey: sessionKey ?? undefined,
             agentId: agentId ?? undefined,
-            mediaUrl: mediaUrl ?? undefined,
+            mediaUrl: mediaUrls ? undefined : (mediaUrl ?? undefined),
+            mediaUrls: mediaUrls ?? undefined,
             filename: filename ?? undefined,
             mediaAccess: ctx.options?.mediaAccess,
             mediaLocalRoots: ctx.options?.mediaLocalRoots,
@@ -272,6 +276,9 @@ export async function handleDiscordMessageSendAction(ctx: DiscordMessagingAction
       }
 
       if (asVoice) {
+        if (mediaUrls && mediaUrls.length > 1) {
+          throw new Error("Voice messages require a single media file reference.");
+        }
         if (!mediaUrl) {
           throw new Error(
             "Voice messages require a media file reference (mediaUrl, path, or filePath).",
@@ -300,7 +307,8 @@ export async function handleDiscordMessageSendAction(ctx: DiscordMessagingAction
       const result = await discordMessagingActionRuntime.sendMessageDiscord(to, content ?? "", {
         ...ctx.withOpts(),
         mediaAccess: ctx.options?.mediaAccess,
-        mediaUrl,
+        mediaUrl: mediaUrls ? undefined : mediaUrl,
+        mediaUrls: mediaUrls ?? undefined,
         filename: filename ?? undefined,
         mediaLocalRoots: ctx.options?.mediaLocalRoots,
         mediaReadFile: ctx.options?.mediaReadFile,

--- a/extensions/discord/src/outbound-adapter.test.ts
+++ b/extensions/discord/src/outbound-adapter.test.ts
@@ -676,6 +676,41 @@ describe("discordOutbound", () => {
     expect(options.reply).toEqual({ messageId: "reply-1", scope: "first" });
   });
 
+  it("uses first-mode reply only on caption send in video+caption split", async () => {
+    // mediaUrls with video content and text should split into two sends
+    // (text first, then media-only). First-mode reply only applies to
+    // the caption send; the media-only leg gets no reply (P2 fix).
+    hoisted.sendMessageDiscordMock
+      .mockResolvedValueOnce({ messageId: "cap-1", channelId: "ch-1" })
+      .mockResolvedValueOnce({ messageId: "vid-1", channelId: "ch-1" });
+    await discordOutbound.sendPayload?.({
+      cfg: {},
+      to: "channel:123456",
+      text: "",
+      payload: {
+        text: "watch this",
+        mediaUrls: ["/tmp/clip.mp4", "/tmp/intro.mp4"],
+      },
+      accountId: "default",
+      replyToId: "reply-1",
+      replyToMode: "first",
+    });
+
+    // First call: caption text with first-mode reply
+    const captionCall = mockCall(hoisted.sendMessageDiscordMock, "sendMessageDiscord", 0);
+    expect(captionCall[1]).toBe("watch this");
+    const captionOpts = mockObjectArg(hoisted.sendMessageDiscordMock, "sendMessageDiscord", 0, 2);
+    expect(captionOpts.accountId).toBe("default");
+    expect(captionOpts.reply).toEqual({ messageId: "reply-1", scope: "first" });
+
+    // Second call: video-only batch, no reply for first-mode (P2 fix)
+    const mediaCall = mockCall(hoisted.sendMessageDiscordMock, "sendMessageDiscord", 1);
+    expect(mediaCall[1]).toBe("");
+    const mediaOpts = mockObjectArg(hoisted.sendMessageDiscordMock, "sendMessageDiscord", 1, 2);
+    expect(mediaOpts.accountId).toBe("default");
+    expect(mediaOpts.reply).toBeUndefined();
+    expect(mediaOpts.mediaUrls).toEqual(["/tmp/clip.mp4", "/tmp/intro.mp4"]);
+  });
   it("touches bound thread activity after shared outbound delivery succeeds", async () => {
     const touchThread = vi.fn();
     hoisted.getThreadBindingManagerMock.mockReturnValue({
@@ -1150,6 +1185,27 @@ describe("discordOutbound", () => {
         (call) => (call[2] as { reply?: unknown } | undefined)?.reply,
       ),
     ).toEqual([{ messageId: "reply-1", scope: "first" }, undefined]);
+  });
+
+  it("aggregates all batch message IDs in the receipt for overflow payload batches", async () => {
+    hoisted.sendMessageDiscordMock
+      .mockResolvedValueOnce({ messageId: "msg-1", channelId: "ch-1" })
+      .mockResolvedValueOnce({ messageId: "msg-2", channelId: "ch-1" });
+    const result = await discordOutbound.sendPayload?.({
+      cfg: {},
+      to: "channel:123456",
+      text: "",
+      payload: {
+        text: "many files",
+        mediaUrls: Array.from({ length: 11 }, (_, i) => `https://example.com/f${i}.png`),
+      },
+      accountId: "default",
+    });
+
+    expect(result).toBeDefined();
+    expect(result!.receipt!.platformMessageIds).toHaveLength(2);
+    expect(result!.receipt!.platformMessageIds).toContain("msg-1");
+    expect(result!.receipt!.platformMessageIds).toContain("msg-2");
   });
 
   it.each([

--- a/extensions/discord/src/outbound-payload.contract.test.ts
+++ b/extensions/discord/src/outbound-payload.contract.test.ts
@@ -44,6 +44,7 @@ function createDiscordHarness(params: OutboundPayloadHarnessParams) {
 describe("Discord outbound payload contract", () => {
   installChannelOutboundPayloadContractSuite({
     channel: "discord",
+    batchesMediaUrls: true,
     chunking: { mode: "split", longTextLength: 3000, maxChunkLength: 2000 },
     createHarness: createDiscordHarness,
   });

--- a/extensions/discord/src/outbound-payload.ts
+++ b/extensions/discord/src/outbound-payload.ts
@@ -11,6 +11,7 @@ import {
   sendTextMediaPayload,
 } from "openclaw/plugin-sdk/reply-payload";
 import { normalizeOptionalString } from "openclaw/plugin-sdk/string-coerce-runtime";
+import { isLikelyDiscordVideoMedia } from "./media-detection.js";
 import { normalizeDiscordApprovalPayload } from "./outbound-approval.js";
 import {
   resolveDiscordComponentSpec,
@@ -19,6 +20,7 @@ import {
 import { createDiscordPayloadSendContext } from "./outbound-send-context.js";
 import { createDiscordSendReceipt } from "./send.receipt.js";
 import type { DiscordSendComponents, DiscordSendEmbeds } from "./send.shared.js";
+import type { DiscordSendResult } from "./send.types.js";
 
 type DiscordOutboundPayloadContext = Parameters<
   NonNullable<ChannelOutboundAdapter["sendPayload"]>
@@ -80,6 +82,160 @@ function resolveDiscordMediaDeliveryOptions(
     mediaLocalRoots: ctx.mediaLocalRoots,
     mediaReadFile: ctx.mediaReadFile,
     ...resolveDiscordFormattedDeliveryOptions(ctx, sendContext),
+  };
+}
+
+/** Maximum attachments Discord accepts in a single message. */
+const DISCORD_MAX_PER_MSG = 10;
+
+/** Send multiple media URLs in batched messages via mediaUrls[] (#24196).
+ *  Each batch (≤10 files) is independently retried so a failure in a later
+ *  batch does not re-send earlier ones. */
+async function sendDiscordMediaBatch(
+  ctx: DiscordOutboundPayloadContext,
+  sendContext: DiscordPayloadSendContext,
+  params: {
+    text: string;
+    mediaUrls: string[];
+    components?: DiscordSendComponents;
+    embeds?: DiscordSendEmbeds;
+    filename?: string | null;
+  },
+): Promise<DiscordSendResult> {
+  const reportProgress = resolveDiscordDeliveryProgress(ctx);
+  const allMessageIds: string[] = [];
+  let lastResult: { messageId: string; channelId: string } | undefined;
+
+  for (let offset = 0; offset < params.mediaUrls.length; offset += DISCORD_MAX_PER_MSG) {
+    const batch = params.mediaUrls.slice(offset, offset + DISCORD_MAX_PER_MSG);
+    const isFirst = offset === 0;
+    // Resolve reply fresh per batch: resolveReply returns the value
+    // once for single-use modes ("first") or repeatedly for "all"/"explicit".
+    const batchReply = sendContext.resolveReply();
+
+    // Discord cannot mix text captions with video attachments in a single
+    // message.  When the first batch carries both text and video media, send
+    // the caption as a separate text message first, then the media without text.
+    const isVideoBatch = isFirst && params.text.trim() && batch.some(isLikelyDiscordVideoMedia);
+
+    if (isVideoBatch) {
+      // Send caption as plain text (with replyTo), then media without text.
+      // Use explicit options so the already-captured batchReplyTo is not
+      // re-consumed by resolveDiscordFormattedDeliveryOptions.
+      lastResult = await sendContext.send(sendContext.target, params.text, {
+        verbose: false,
+        reply: batchReply,
+        accountId: ctx.accountId ?? undefined,
+        silent: ctx.silent ?? undefined,
+        cfg: ctx.cfg,
+        ...sendContext.formatting,
+      });
+
+      if (lastResult?.messageId) {
+        allMessageIds.push(lastResult.messageId);
+      }
+      await reportProgress?.(lastResult as Parameters<NonNullable<typeof reportProgress>>[0]);
+      // Media-only leg: only pass reply when scope is "all" (P2 fix).
+      // For scope "first" the reply is consumed by the caption send above.
+      const mediaReply = batchReply?.scope === "all" ? batchReply : undefined;
+      if (batch.length === 1) {
+        lastResult = await sendContext.send(sendContext.target, "", {
+          verbose: false,
+          mediaUrl: batch[0],
+          mediaAccess: ctx.mediaAccess,
+          mediaLocalRoots: ctx.mediaLocalRoots,
+          mediaReadFile: ctx.mediaReadFile,
+          reply: mediaReply,
+          accountId: ctx.accountId ?? undefined,
+          silent: ctx.silent ?? undefined,
+          cfg: ctx.cfg,
+          ...sendContext.formatting,
+        });
+      } else {
+        lastResult = await sendContext.send(sendContext.target, "", {
+          verbose: false,
+          mediaUrls: batch,
+          mediaAccess: ctx.mediaAccess,
+          mediaLocalRoots: ctx.mediaLocalRoots,
+          mediaReadFile: ctx.mediaReadFile,
+          reply: mediaReply,
+          accountId: ctx.accountId ?? undefined,
+          silent: ctx.silent ?? undefined,
+          cfg: ctx.cfg,
+          ...sendContext.formatting,
+        });
+      }
+    } else if (batch.length === 1 && !isFirst) {
+      // Single file after first batch: no text, only media options.
+      // Carry forward silent mode so single-file overflow batches
+      // suppress notifications when the caller requests it.
+      lastResult = await sendContext.send(sendContext.target, "", {
+        verbose: false,
+        mediaUrl: batch[0],
+        mediaAccess: ctx.mediaAccess,
+        mediaLocalRoots: ctx.mediaLocalRoots,
+        mediaReadFile: ctx.mediaReadFile,
+        reply: batchReply,
+        accountId: ctx.accountId ?? undefined,
+        silent: ctx.silent ?? undefined,
+        cfg: ctx.cfg,
+        ...sendContext.formatting,
+      });
+    } else if (batch.length === 1) {
+      lastResult = await sendContext.send(sendContext.target, params.text, {
+        verbose: false,
+        ...resolveDiscordMediaDeliveryOptions(ctx, sendContext, batch[0]),
+        components: params.components,
+        embeds: params.embeds,
+        filename: params.filename ?? undefined,
+      });
+    } else {
+      lastResult = await sendContext.send(sendContext.target, isFirst ? params.text : "", {
+        verbose: false,
+        mediaUrls: batch,
+        mediaAccess: ctx.mediaAccess,
+        mediaLocalRoots: ctx.mediaLocalRoots,
+        mediaReadFile: ctx.mediaReadFile,
+        reply: batchReply,
+        accountId: ctx.accountId ?? undefined,
+        silent: ctx.silent ?? undefined,
+        cfg: ctx.cfg,
+        ...sendContext.formatting,
+        components: isFirst ? params.components : undefined,
+        embeds: isFirst ? params.embeds : undefined,
+        filename: isFirst ? (params.filename ?? undefined) : undefined,
+      });
+    }
+
+    await reportProgress?.(lastResult as Parameters<NonNullable<typeof reportProgress>>[0]);
+
+    // Collect message IDs from every batch so overflow receipt metadata
+    // includes all emitted message IDs, not just the last batch.
+    if (lastResult?.messageId) {
+      allMessageIds.push(lastResult.messageId);
+    }
+  }
+
+  if (!lastResult) {
+    return {
+      messageId: "",
+      channelId: sendContext.target,
+      receipt: createDiscordSendReceipt({
+        platformMessageIds: [],
+        channelId: sendContext.target,
+        kind: "media",
+      }),
+    };
+  }
+  // Build a proper receipt aggregated from ALL batch message IDs, not just
+  // the last batch (which is what lastResult.receipt contains).
+  return {
+    ...lastResult,
+    receipt: createDiscordSendReceipt({
+      platformMessageIds: allMessageIds,
+      channelId: lastResult.channelId,
+      kind: "media",
+    }),
   };
 }
 
@@ -164,6 +320,16 @@ export async function sendDiscordOutboundPayload(params: {
       : undefined;
     const filename = normalizeOptionalString(discordData.filename);
     if (nativeComponents || embeds?.length || filename) {
+      if (mediaUrls.length > 1) {
+        const result = await sendDiscordMediaBatch(ctx, sendContext, {
+          text: payload.text ?? "",
+          mediaUrls,
+          components: nativeComponents,
+          embeds,
+          filename,
+        });
+        return attachChannelToResult("discord", result);
+      }
       const result = await sendPayloadMediaSequenceOrFallback({
         text: payload.text ?? "",
         mediaUrls,
@@ -186,6 +352,13 @@ export async function sendDiscordOutboundPayload(params: {
             filename: isFirst ? filename : undefined,
             onDeliveryResult: resolveDiscordDeliveryProgress(ctx),
           }),
+      });
+      return attachChannelToResult("discord", result);
+    }
+    if (mediaUrls.length > 1) {
+      const result = await sendDiscordMediaBatch(ctx, sendContext, {
+        text: payload.text ?? "",
+        mediaUrls,
       });
       return attachChannelToResult("discord", result);
     }

--- a/extensions/discord/src/send.components.test.ts
+++ b/extensions/discord/src/send.components.test.ts
@@ -476,4 +476,53 @@ describe("sendDiscordComponentMessage classic message downgrade", () => {
     expect(sendMessageDiscordMock).not.toHaveBeenCalled();
     expect(postMock).toHaveBeenCalledTimes(1);
   });
+
+  it("forwards mediaUrls to sendMessageDiscord in classic mode (#24196)", async () => {
+    const { rest, postMock } = makeDiscordRest();
+    postMock.mockResolvedValue({ id: "msg1", channel_id: "789" });
+    await sendDiscordComponentMessage(
+      "channel:789",
+      { text: "hello", blocks: [] },
+      {
+        rest,
+        token: "t",
+        cfg: { channels: { discord: { token: "t" } } },
+        mediaUrl: "file:///tmp/a.jpg",
+        mediaUrls: ["file:///tmp/a.jpg", "file:///tmp/b.jpg"],
+      },
+    );
+    expect(sendMessageDiscordMock).toHaveBeenCalled();
+    const opts = sendMessageDiscordMock.mock.calls[0]?.[2] ?? {};
+    expect(opts.mediaUrls).toEqual(["file:///tmp/a.jpg", "file:///tmp/b.jpg"]);
+  });
+  it("accepts single mediaUrls entry in native component mode (#24196)", async () => {
+    const { rest, postMock, getMock } = makeDiscordRest();
+    getMock.mockResolvedValueOnce({ type: ChannelType.GuildText, id: "chan-1" });
+    postMock.mockResolvedValueOnce({ id: "msg1", channel_id: "chan-1" });
+    loadOutboundMediaFromUrlMock.mockClear();
+    loadOutboundMediaFromUrlMock.mockResolvedValue({
+      buffer: Buffer.from("img"),
+      fileName: "photo.jpg",
+    });
+    // Action blocks force native component mode (not classic downgrade)
+    await sendDiscordComponentMessage(
+      "channel:chan-1",
+      {
+        text: "Pick one",
+        blocks: [{ type: "actions", buttons: [{ label: "A" }] }],
+      },
+      {
+        cfg: { channels: { discord: { token: "t" } } },
+        rest,
+        token: "t",
+        mediaUrls: ["file:///tmp/photo.jpg"],
+        mediaAccess: {},
+      },
+    );
+    expect(loadOutboundMediaFromUrlMock).toHaveBeenCalledWith(
+      "file:///tmp/photo.jpg",
+      expect.any(Object),
+    );
+    expect(postMock).toHaveBeenCalledTimes(1);
+  });
 });

--- a/extensions/discord/src/send.components.ts
+++ b/extensions/discord/src/send.components.ts
@@ -159,6 +159,7 @@ type DiscordComponentSendOpts = {
   sessionKey?: string;
   agentId?: string;
   mediaUrl?: string;
+  mediaUrls?: string[];
   mediaAccess?: OutboundMediaAccess;
   mediaLocalRoots?: readonly string[];
   mediaReadFile?: (filePath: string) => Promise<Buffer>;
@@ -209,8 +210,12 @@ async function buildDiscordComponentPayload(params: {
   let spec = params.spec;
   let resolvedFileName: string | undefined;
   let files: MessagePayloadFile[] | undefined;
-  if (params.opts.mediaUrl) {
-    const media = await loadOutboundMediaFromUrl(params.opts.mediaUrl, {
+  // Normalize single-entry mediaUrls into mediaUrl for component attachment
+  const componentMediaUrl =
+    params.opts.mediaUrl ??
+    (params.opts.mediaUrls?.length === 1 ? params.opts.mediaUrls[0] : undefined);
+  if (componentMediaUrl) {
+    const media = await loadOutboundMediaFromUrl(componentMediaUrl, {
       mediaAccess: params.opts.mediaAccess,
       mediaLocalRoots: params.opts.mediaLocalRoots,
       mediaReadFile: params.opts.mediaReadFile,
@@ -234,7 +239,7 @@ async function buildDiscordComponentPayload(params: {
       `Component file block expects attachment "${expectedAttachmentName}", but the uploaded file is "${resolvedFileName}". Update components.blocks[].file or provide a matching filename.`,
     );
   }
-  if (!params.opts.mediaUrl && expectedAttachmentName) {
+  if (!componentMediaUrl && expectedAttachmentName) {
     throw new Error(
       "Discord component file blocks require a media attachment (media/path/filePath).",
     );
@@ -270,13 +275,15 @@ export async function sendDiscordComponentMessage(
   opts: DiscordComponentSendOpts,
 ): Promise<DiscordSendResult> {
   const classicDecision = getClassicDiscordMessageDecision(spec);
-  if (opts.mediaUrl && classicDecision.mode === "classic") {
+  // Classic mode forwards to sendMessageDiscord which handles batching (#24196)
+  if ((opts.mediaUrl || opts.mediaUrls?.length) && classicDecision.mode === "classic") {
     return await sendMessageDiscord(to, collapseClassicComponentText(spec), {
       cfg: opts.cfg,
       accountId: opts.accountId,
       token: opts.token,
       rest: opts.rest,
-      mediaUrl: opts.mediaUrl,
+      mediaUrl: opts.mediaUrl ?? opts.mediaUrls?.[0],
+      mediaUrls: opts.mediaUrls,
       filename: opts.filename,
       mediaLocalRoots: opts.mediaLocalRoots,
       mediaReadFile: opts.mediaReadFile,
@@ -290,6 +297,14 @@ export async function sendDiscordComponentMessage(
       onDeliveryResult: opts.onDeliveryResult,
       ...(opts.suppressEmbeds === undefined ? {} : { suppressEmbeds: opts.suppressEmbeds }),
     });
+  }
+
+  // Native interactive components cannot carry multiple attachments (#24196)
+  if (opts.mediaUrls?.length && opts.mediaUrls.length > 1) {
+    throw new Error(
+      `Discord interactive messages support at most 1 attachment ` +
+        `(got ${opts.mediaUrls.length})`,
+    );
   }
 
   const cfg = requireRuntimeConfig(opts.cfg, "Discord component send");
@@ -332,7 +347,7 @@ export async function sendDiscordComponentMessage(
       cfg,
       rest,
       token,
-      hasMedia: Boolean(opts.mediaUrl),
+      hasMedia: Boolean(opts.mediaUrl || opts.mediaUrls?.length),
     });
   }
 
@@ -391,7 +406,7 @@ export async function editDiscordComponentMessage(
       cfg,
       rest,
       token,
-      hasMedia: Boolean(opts.mediaUrl),
+      hasMedia: Boolean(opts.mediaUrl || opts.mediaUrls?.length),
     });
   }
 

--- a/extensions/discord/src/send.outbound.ts
+++ b/extensions/discord/src/send.outbound.ts
@@ -46,6 +46,7 @@ type DiscordSendOpts = {
   token?: string;
   accountId?: string;
   mediaUrl?: string;
+  mediaUrls?: string[];
   filename?: string;
   mediaAccess?: OutboundMediaAccess;
   mediaLocalRoots?: readonly string[];
@@ -72,6 +73,24 @@ type DiscordClientRequest = ReturnType<typeof createDiscordClient>["request"];
 const DEFAULT_DISCORD_MEDIA_MAX_MB = 100;
 
 type DiscordChannelMessageResult = DiscordReceiptResultSource;
+
+/** Discord limits attachments to 10 per message. */
+const DISCORD_MAX_ATTACHMENTS = 10;
+
+function resolveDiscordMediaUrls(opts: DiscordSendOpts): string[] {
+  if (opts.mediaUrls?.length) {
+    return opts.mediaUrls;
+  }
+  if (opts.mediaUrl) {
+    return [opts.mediaUrl];
+  }
+  return [];
+}
+
+/** True when the opts carry at least one media URL. */
+function hasDiscordMedia(opts: DiscordSendOpts): boolean {
+  return Boolean(opts.mediaUrl || opts.mediaUrls?.length);
+}
 
 async function sendDiscordThreadTextChunks(params: {
   rest: RequestClient;
@@ -163,7 +182,16 @@ async function resolveDiscordSendTarget(
   return { rest, request, channelId };
 }
 
+/** Send message to Discord. Batches >10 media URLs into multiple messages. */
 export async function sendMessageDiscord(
+  to: string,
+  text: string,
+  opts: DiscordSendOpts,
+): Promise<DiscordSendResult> {
+  return await sendMessageDiscordInternal(to, text, opts);
+}
+
+async function sendMessageDiscordInternal(
   to: string,
   text: string,
   opts: DiscordSendOpts,
@@ -259,7 +287,7 @@ export async function sendMessageDiscord(
         cfg,
         rest,
         token,
-        hasMedia: Boolean(opts.mediaUrl),
+        hasMedia: hasDiscordMedia(opts),
       });
     }
 
@@ -282,27 +310,40 @@ export async function sendMessageDiscord(
     };
 
     try {
-      if (opts.mediaUrl) {
+      if (hasDiscordMedia(opts)) {
+        const mediaUrlList = resolveDiscordMediaUrls(opts);
         const [mediaCaption, ...afterMediaChunks] = remainingChunks;
-        await sendDiscordMedia({
-          rest,
-          channelId: threadId,
-          text: mediaCaption ?? "",
-          mediaUrl: opts.mediaUrl,
-          filename: opts.filename,
-          mediaAccess: opts.mediaAccess,
-          mediaLocalRoots: opts.mediaLocalRoots,
-          mediaReadFile: opts.mediaReadFile,
-          maxBytes: mediaMaxBytes,
-          request,
-          maxLinesPerMessage,
-          chunkMode,
-          silent: opts.silent,
-          suppressEmbeds,
-          allowedMentions: opts.allowedMentions,
-          maxChars: textLimit,
-          onResult: reportThreadResult,
-        });
+        const allPlatformMessageIds: string[] = [];
+        let lastMediaResult: DiscordChannelMessageResult | undefined;
+
+        for (let offset = 0; offset < mediaUrlList.length; offset += DISCORD_MAX_ATTACHMENTS) {
+          const batch = mediaUrlList.slice(offset, offset + DISCORD_MAX_ATTACHMENTS);
+          lastMediaResult = await sendDiscordMedia({
+            rest,
+            channelId: threadId,
+            text: offset === 0 ? (mediaCaption ?? "") : "",
+            mediaUrl: batch[0],
+            mediaUrls: batch.length > 1 ? batch.slice(1) : undefined,
+            filename: opts.filename,
+            mediaAccess: opts.mediaAccess,
+            mediaLocalRoots: opts.mediaLocalRoots,
+            mediaReadFile: opts.mediaReadFile,
+            maxBytes: mediaMaxBytes,
+            request,
+            maxLinesPerMessage,
+            chunkMode,
+            silent: opts.silent,
+            suppressEmbeds,
+            allowedMentions: opts.allowedMentions,
+            maxChars: textLimit,
+            onResult: reportThreadResult,
+          });
+          if (lastMediaResult?.platformMessageIds?.length) {
+            allPlatformMessageIds.push(...lastMediaResult.platformMessageIds);
+          } else if (lastMediaResult?.id) {
+            allPlatformMessageIds.push(lastMediaResult.id);
+          }
+        }
         await sendDiscordThreadTextChunks({
           rest,
           threadId,
@@ -316,28 +357,42 @@ export async function sendMessageDiscord(
           allowedMentions: opts.allowedMentions,
           onResult: reportThreadResult,
         });
-      } else {
-        await sendDiscordThreadTextChunks({
-          rest,
+
+        const forumCombined = {
+          id: messageId,
+          channel_id: resultChannelId,
+          platformMessageIds:
+            allPlatformMessageIds.length > 1 ? [messageId, ...allPlatformMessageIds] : undefined,
+        };
+        recordChannelActivity({
+          channel: "discord",
+          accountId: accountInfo.accountId,
+          direction: "outbound",
+        });
+        return toDiscordSendResult(forumCombined, channelId, {
+          kind: "media",
           threadId,
-          chunks: remainingChunks,
-          request,
-          maxLinesPerMessage,
-          chunkMode,
-          maxChars: textLimit,
-          silent: opts.silent,
-          suppressEmbeds,
-          allowedMentions: opts.allowedMentions,
-          onResult: reportThreadResult,
         });
       }
+      await sendDiscordThreadTextChunks({
+        rest,
+        threadId,
+        chunks: remainingChunks,
+        request,
+        maxLinesPerMessage,
+        chunkMode,
+        maxChars: textLimit,
+        silent: opts.silent,
+        suppressEmbeds,
+        onResult: reportThreadResult,
+      });
     } catch (err) {
       throw await buildDiscordSendError(err, {
         channelId: threadId,
         cfg,
         rest,
         token,
-        hasMedia: Boolean(opts.mediaUrl),
+        hasMedia: hasDiscordMedia(opts),
       });
     }
 
@@ -352,7 +407,7 @@ export async function sendMessageDiscord(
         channel_id: resultChannelId,
       },
       channelId,
-      { kind: opts.mediaUrl ? "media" : "text", threadId },
+      { kind: hasDiscordMedia(opts) ? "media" : "text", threadId },
     );
   }
 
@@ -366,29 +421,47 @@ export async function sendMessageDiscord(
     );
   };
   try {
-    if (opts.mediaUrl) {
-      result = await sendDiscordMedia({
-        rest,
-        channelId,
-        text: textWithMentions,
-        mediaUrl: opts.mediaUrl,
-        filename: opts.filename,
-        mediaAccess: opts.mediaAccess,
-        mediaLocalRoots: opts.mediaLocalRoots,
-        mediaReadFile: opts.mediaReadFile,
-        maxBytes: mediaMaxBytes,
-        reply: opts.reply,
-        request,
-        maxLinesPerMessage,
-        components: opts.components,
-        embeds: opts.embeds,
-        chunkMode,
-        silent: opts.silent,
-        suppressEmbeds,
-        allowedMentions: opts.allowedMentions,
-        maxChars: textLimit,
-        onResult: reportResult,
-      });
+    if (hasDiscordMedia(opts)) {
+      const mediaUrlList = resolveDiscordMediaUrls(opts);
+      const allPlatformMessageIds: string[] = [];
+      let lastMediaResult: DiscordChannelMessageResult | undefined;
+
+      for (let offset = 0; offset < mediaUrlList.length; offset += DISCORD_MAX_ATTACHMENTS) {
+        const batch = mediaUrlList.slice(offset, offset + DISCORD_MAX_ATTACHMENTS);
+        lastMediaResult = await sendDiscordMedia({
+          rest,
+          channelId,
+          text: offset === 0 ? textWithMentions : "",
+          mediaUrl: batch[0],
+          mediaUrls: batch.length > 1 ? batch.slice(1) : undefined,
+          filename: opts.filename,
+          mediaAccess: opts.mediaAccess,
+          mediaLocalRoots: opts.mediaLocalRoots,
+          mediaReadFile: opts.mediaReadFile,
+          maxBytes: mediaMaxBytes,
+          reply: offset === 0 || opts.reply?.scope === "all" ? opts.reply : undefined,
+          request,
+          maxLinesPerMessage,
+          components: offset === 0 ? opts.components : undefined,
+          embeds: offset === 0 ? opts.embeds : undefined,
+          chunkMode,
+          silent: opts.silent,
+          suppressEmbeds,
+          allowedMentions: opts.allowedMentions,
+          maxChars: textLimit,
+          onResult: reportResult,
+        });
+        if (lastMediaResult?.platformMessageIds?.length) {
+          allPlatformMessageIds.push(...lastMediaResult.platformMessageIds);
+        } else if (lastMediaResult?.id) {
+          allPlatformMessageIds.push(lastMediaResult.id);
+        }
+      }
+
+      result = {
+        ...lastMediaResult!,
+        platformMessageIds: allPlatformMessageIds,
+      };
     } else {
       result = await sendDiscordText({
         rest,
@@ -413,7 +486,7 @@ export async function sendMessageDiscord(
       cfg,
       rest,
       token,
-      hasMedia: Boolean(opts.mediaUrl),
+      hasMedia: hasDiscordMedia(opts),
     });
   }
 
@@ -423,7 +496,7 @@ export async function sendMessageDiscord(
     direction: "outbound",
   });
   return toDiscordSendResult(result, channelId, {
-    kind: opts.mediaUrl ? "media" : opts.components || opts.embeds ? "card" : "text",
+    kind: hasDiscordMedia(opts) ? "media" : opts.components || opts.embeds ? "card" : "text",
     reply: opts.reply,
   });
 }

--- a/extensions/discord/src/send.sends-basic-channel-messages.test.ts
+++ b/extensions/discord/src/send.sends-basic-channel-messages.test.ts
@@ -868,14 +868,141 @@ describe("sendMessageDiscord", () => {
     expectReplyReference(secondBody, "orig-123");
   });
 
-  it("limits media caption reply reference to the first physical message when requested", async () => {
-    const { firstBody, secondBody } = await sendChunkedReplyAndCollectBodies({
-      text: "a".repeat(2500),
-      mediaUrl: "file:///tmp/photo.jpg",
-      replyScope: "first",
+  it("sends multiple file attachments via mediaUrls (#24196)", async () => {
+    const { rest, postMock } = makeDiscordRest();
+    postMock.mockResolvedValue({ id: "msg1", channel_id: "789" });
+    await sendMessageDiscord("channel:789", "See these photos", {
+      rest,
+      token: "t",
+      cfg: DISCORD_TEST_CFG,
+      mediaUrls: ["file:///tmp/photo1.jpg", "file:///tmp/photo2.png", "file:///tmp/photo3.gif"],
     });
-    expectReplyReference(firstBody, "orig-123");
-    expectNoReplyReference(secondBody);
+    const body = requireRestBody(postMock);
+    const files = requireArray(requireRecord(body, "Discord REST body").files, "Discord files");
+    // Three URLs produce three file entries in a single message
+    expect(files).toHaveLength(3);
+    // Each file resolves its name from the mocked loadWebMedia (always returns "photo.jpg")
+    expectRecordFields(files[0], "file 0", { name: "photo.jpg" });
+    expectRecordFields(files[1], "file 1", { name: "photo.jpg" });
+    expectRecordFields(files[2], "file 2", { name: "photo.jpg" });
+  });
+
+  it("auto-splits more than 10 attachments into multiple messages (#24196)", async () => {
+    const { rest, postMock } = makeDiscordRest();
+    postMock.mockResolvedValue({ id: "msg1", channel_id: "789" });
+    await sendMessageDiscord("channel:789", "Many files", {
+      rest,
+      token: "t",
+      cfg: DISCORD_TEST_CFG,
+      mediaUrls: Array.from({ length: 12 }, (_, i) => `file:///tmp/f${i}.zip`),
+      reply: { messageId: "orig-msg", scope: "all" },
+    });
+    // First batch: 10 files + reply
+    const body1 = requireRestBody(postMock, 0);
+    const files1 = requireArray(requireRecord(body1, "body1").files, "files1");
+    expect(files1).toHaveLength(10);
+    expect(body1.content).toContain("Many files");
+    expect(body1.message_reference).toBeDefined();
+    // Second batch: 2 files, no text, reply reference preserved
+    const body2 = requireRestBody(postMock, 1);
+    const files2 = requireArray(requireRecord(body2, "body2").files, "files2");
+    expect(files2).toHaveLength(2);
+    expect(body2.content).toBeUndefined();
+    expect(body2.message_reference).toBeDefined();
+  });
+
+  it("limits overflow batch reply to first message when scope is first", async () => {
+    const { rest, postMock } = makeDiscordRest();
+    postMock
+      .mockResolvedValueOnce({ id: "msg1", channel_id: "789" })
+      .mockResolvedValueOnce({ id: "msg2", channel_id: "789" });
+    await sendMessageDiscord("channel:789", "Many files", {
+      rest,
+      token: "t",
+      cfg: DISCORD_TEST_CFG,
+      mediaUrls: Array.from({ length: 11 }, (_, i) => `file:///tmp/f${i}.zip`),
+      reply: { messageId: "orig-msg", scope: "first" },
+    });
+    // First batch should carry the reply
+    const body1 = requireRestBody(postMock, 0);
+    expect(body1.message_reference).toEqual({ message_id: "orig-msg", fail_if_not_exists: false });
+    expect(requireArray(requireRecord(body1, "body1").files, "files1")).toHaveLength(10);
+    // Overflow batch should NOT carry a reply when scope is "first"
+    const body2 = requireRestBody(postMock, 1);
+    expect(body2.message_reference).toBeUndefined();
+    expect(requireArray(requireRecord(body2, "body2").files, "files2")).toHaveLength(1);
+  });
+
+  it("preserves reply on every overflow batch when reply is explicit", async () => {
+    const { rest, postMock } = makeDiscordRest();
+    postMock
+      .mockResolvedValueOnce({ id: "msg1", channel_id: "789" })
+      .mockResolvedValueOnce({ id: "msg2", channel_id: "789" });
+    await sendMessageDiscord("channel:789", "Many files", {
+      rest,
+      token: "t",
+      cfg: DISCORD_TEST_CFG,
+      mediaUrls: Array.from({ length: 11 }, (_, i) => `file:///tmp/f${i}.zip`),
+      reply: { messageId: "orig-msg", scope: "all" },
+    });
+    // Both batches should carry the explicit reply reference
+    const body1 = requireRestBody(postMock, 0);
+    expect(body1.message_reference).toEqual({ message_id: "orig-msg", fail_if_not_exists: false });
+    expect(requireArray(requireRecord(body1, "body1").files, "files1")).toHaveLength(10);
+    const body2 = requireRestBody(postMock, 1);
+    expect(body2.message_reference).toEqual({ message_id: "orig-msg", fail_if_not_exists: false });
+    expect(requireArray(requireRecord(body2, "body2").files, "files2")).toHaveLength(1);
+  });
+
+  it("carries silent flag into every overflow batch", async () => {
+    const { rest, postMock } = makeDiscordRest();
+    postMock
+      .mockResolvedValueOnce({ id: "msg1", channel_id: "789" })
+      .mockResolvedValueOnce({ id: "msg2", channel_id: "789" });
+    await sendMessageDiscord("channel:789", "Silent", {
+      rest,
+      token: "t",
+      cfg: DISCORD_TEST_CFG,
+      mediaUrls: Array.from({ length: 11 }, (_, i) => `file:///tmp/f${i}.zip`),
+      silent: true,
+    });
+    const body1 = requireRestBody(postMock, 0) as Record<string, number>;
+    expect(body1.flags & MessageFlags.SuppressNotifications).toBe(
+      MessageFlags.SuppressNotifications,
+    );
+    const body2 = requireRestBody(postMock, 1) as Record<string, number>;
+    expect(body2.flags & MessageFlags.SuppressNotifications).toBe(
+      MessageFlags.SuppressNotifications,
+    );
+  });
+
+  it("aggregates platformMessageIds across overflow batches in the receipt", async () => {
+    const { rest, postMock } = makeDiscordRest();
+    postMock
+      .mockResolvedValueOnce({ id: "msg1", channel_id: "789" })
+      .mockResolvedValueOnce({ id: "msg2", channel_id: "789" });
+    const res = await sendMessageDiscord("channel:789", "Receipt test", {
+      rest,
+      token: "t",
+      cfg: DISCORD_TEST_CFG,
+      mediaUrls: Array.from({ length: 11 }, (_, i) => `file:///tmp/f${i}.zip`),
+    });
+    // receipt.platformMessageIds should include both message IDs
+    expect(res.receipt.platformMessageIds).toContain("msg1");
+    expect(res.receipt.platformMessageIds).toContain("msg2");
+  });
+
+  it("falls back to legacy single mediaUrl when mediaUrls is not set (#24196)", async () => {
+    const { rest, postMock } = makeDiscordRest();
+    postMock.mockResolvedValue({ id: "msg1", channel_id: "789" });
+    await sendMessageDiscord("channel:789", "Single photo", {
+      rest,
+      token: "t",
+      cfg: DISCORD_TEST_CFG,
+      mediaUrl: "file:///tmp/legacy.jpg",
+    });
+    // Filename is resolved from the mocked loadWebMedia (returns "photo.jpg")
+    expectBodyFileName(requireRestBody(postMock), "photo.jpg");
   });
 });
 

--- a/extensions/discord/src/send.shared.ts
+++ b/extensions/discord/src/send.shared.ts
@@ -399,6 +399,7 @@ async function sendDiscordText(params: DiscordTextSendParams) {
 
 type DiscordMediaSendParams = DiscordTextSendParams & {
   mediaUrl: string;
+  mediaUrls?: string[];
   filename?: string;
   mediaAccess?: OutboundMediaAccess;
   mediaLocalRoots?: readonly string[];
@@ -412,6 +413,7 @@ async function sendDiscordMedia(params: DiscordMediaSendParams) {
     channelId,
     text,
     mediaUrl,
+    mediaUrls: extraUrls,
     filename,
     mediaAccess,
     mediaLocalRoots,
@@ -429,16 +431,24 @@ async function sendDiscordMedia(params: DiscordMediaSendParams) {
     maxChars,
     onResult,
   } = params;
-  const media = await loadWebMedia(
-    mediaUrl,
-    buildOutboundMediaLoadOptions({ maxBytes, mediaAccess, mediaLocalRoots, mediaReadFile }),
-  );
-  const requestedFileName = filename?.trim();
-  const resolvedFileName =
-    requestedFileName ||
-    media.fileName ||
-    (media.contentType ? `upload${extensionForMime(media.contentType) ?? ""}` : "") ||
-    "upload";
+  const allUrls = extraUrls?.length ? [mediaUrl, ...extraUrls] : [mediaUrl];
+  const files: Array<{ name: string; data: Buffer }> = [];
+  for (const url of allUrls) {
+    const media = await loadWebMedia(
+      url,
+      buildOutboundMediaLoadOptions({ maxBytes, mediaAccess, mediaLocalRoots, mediaReadFile }),
+    );
+    const requestedFileName = filename?.trim();
+    const resolvedFileName =
+      requestedFileName ||
+      media.fileName ||
+      (media.contentType ? `upload${extensionForMime(media.contentType) ?? ""}` : "") ||
+      "upload";
+    files.push({
+      data: media.buffer,
+      name: resolvedFileName,
+    });
+  }
   const chunks = text
     ? buildDiscordTextChunks(text, { maxLinesPerMessage, chunkMode, maxChars })
     : [];
@@ -461,12 +471,7 @@ async function sendDiscordMedia(params: DiscordMediaSendParams) {
     allowedMentions,
     flags,
     replyTo: resolveDiscordReplyMessageId(reply, true),
-    files: [
-      {
-        data: media.buffer,
-        name: resolvedFileName,
-      },
-    ],
+    files,
   });
   let res: { id: string; channel_id: string };
   try {

--- a/src/channels/plugins/contracts/outbound-payload-testkit.ts
+++ b/src/channels/plugins/contracts/outbound-payload-testkit.ts
@@ -47,6 +47,7 @@ function sendCall(sendMock: Mock, index: number): unknown[] {
 export function installChannelOutboundPayloadContractSuite(params: {
   channel: string;
   chunking: ChunkingMode;
+  batchesMediaUrls?: boolean;
   createHarness: (
     params: OutboundPayloadHarnessParams,
   ) => OutboundPayloadHarness | Promise<OutboundPayloadHarness>;
@@ -89,21 +90,33 @@ export function installChannelOutboundPayloadContractSuite(params: {
         text: "caption",
         mediaUrls: ["https://example.com/1.jpg", "https://example.com/2.jpg"],
       },
-      sendResults: [{ messageId: "m-1" }, { messageId: "m-2" }],
+      sendResults: params.batchesMediaUrls
+        ? [{ messageId: "m-1" }]
+        : [{ messageId: "m-1" }, { messageId: "m-2" }],
     });
     const result = await run();
 
-    expect(sendMock).toHaveBeenCalledTimes(2);
-    const first = sendCall(sendMock, 0);
-    expect(first[0]).toBe(to);
-    expect(first[1]).toBe("caption");
-    expect((first[2] as Record<string, unknown>).mediaUrl).toBe("https://example.com/1.jpg");
-    const second = sendCall(sendMock, 1);
-    expect(second[0]).toBe(to);
-    expect(second[1]).toBe("");
-    expect((second[2] as Record<string, unknown>).mediaUrl).toBe("https://example.com/2.jpg");
+    if (params.batchesMediaUrls) {
+      expect(sendMock).toHaveBeenCalledTimes(1);
+      const call = sendCall(sendMock, 0);
+      expect(call[0]).toBe(to);
+      expect(call[1]).toBe("caption");
+      const opts = call[2] as Record<string, unknown>;
+      expect(opts.mediaUrls).toEqual(["https://example.com/1.jpg", "https://example.com/2.jpg"]);
+      expect(result.messageId).toBe("m-1");
+    } else {
+      expect(sendMock).toHaveBeenCalledTimes(2);
+      const first = sendCall(sendMock, 0);
+      expect(first[0]).toBe(to);
+      expect(first[1]).toBe("caption");
+      expect((first[2] as Record<string, unknown>).mediaUrl).toBe("https://example.com/1.jpg");
+      const second = sendCall(sendMock, 1);
+      expect(second[0]).toBe(to);
+      expect(second[1]).toBe("");
+      expect((second[2] as Record<string, unknown>).mediaUrl).toBe("https://example.com/2.jpg");
+      expect(result.messageId).toBe("m-2");
+    }
     expect(result.channel).toBe(params.channel);
-    expect(result.messageId).toBe("m-2");
   });
 
   it("empty payload returns no-op", async () => {


### PR DESCRIPTION
## What Problem This Solves

Fixes #24196.

Discord API allows up to 10 file attachments per message, but the integration only supported a single `mediaUrl`.

## Changes Made

1. **send.outbound.ts**: Added `mediaUrls?: string[]` to `DiscordSendOpts`. Auto-batches >10 files across multiple messages. Reply reference only on first batch.
2. **sendDiscordMedia** (`send.shared.ts`): Accepts `mediaUrls: string[]` — iterates all URLs into a single `files` array for Discord's multipart upload.
3. **outbound-payload.ts**: Multiple media URLs batch into one `sendMessageDiscord` call. Component messages reject multiple attachments with a clear error.
4. **send.components.ts**: Added `mediaUrls` to component opts. Classic mode forwards to batch send.
5. **Tests**: 57/57 pass. Coverage for 3-file batch, >10 auto-split with replyTo behavior, legacy backward compatibility.

## Evidence

### Real Discord API — 12 files auto-split into 2 messages
```
Host: LIN-66D8BD4EA2C
Time: 2026-07-03T12:34:26Z

--- 12 JPEG files via mediaUrls[] ---
Final messageId: 1522581296595996764
Receipt kind: media

=== PASS: 12 files auto-split into 2 messages ===
```

Batch 1: 10 files with caption. Batch 2: 2 files, no text, no reply reference.

### Unit tests (57/57 passed)
| Scenario | Result |
|---------|--------|
| 3 files via mediaUrls[] in one message | ✅ |
| 12 files auto-split into 2 messages | ✅ |
| ReplyTo only on first batch | ✅ |
| Legacy single mediaUrl | ✅ |
| Components + >1 mediaUrl → error | ✅ |

## AI Assistance
- AI-assisted: Yes