### PR TITLE
fix(gateway): declare the dev agent required by the gateway e2e session key

### DIFF
--- a/src/gateway/gateway.test.ts
+++ b/src/gateway/gateway.test.ts
@@ -206,6 +206,9 @@ describe("gateway e2e", () => {
               },
             },
           },
+          // The request below runs sessionKey "agent:dev:mock-openai"; the
+          // gateway rejects session keys whose agent id is not declared.
+          list: [{ id: "dev", default: true }],
         },
         models: {
           mode: "replace",


### PR DESCRIPTION
## What Problem This Solves

Fixes #99513.

The clean-checkout e2e test `src/gateway/gateway.test.ts > gateway e2e > accepts a gateway agent request over ws and returns a run id` fails on current `main`:

```
GatewayClientRequestError: Agent "dev" no longer exists in configuration
```

Because it reproduces on an untouched checkout, it blocks contributors' local pre-push gates (`pnpm check:changed` and precheck flows that run the gateway lane) regardless of what they changed.

## Why This Change Was Made

The failure is a broken test fixture, not a product bug: the test requests `sessionKey = "agent:dev:mock-openai"`, but its gateway config declares only `agents.defaults` — no `agents.list` entry with id `dev` — so the gateway's deleted-agent guard correctly rejects the run. The sibling test in the same file declares `agents.list: [{ id: "main", default: true, ... }]` and passes.

The smallest repair is to declare the agent the test's own session key requires:

```ts
agents: {
  defaults: { ... },
  list: [{ id: "dev", default: true }],
},
```

Declaring `dev` (rather than switching the session key to `main`) preserves the tested session identity; `default: true` is unambiguous in a single-agent test config. The config object is local to this one test, so no other case relies on the previous shape.

Note: this is a fixture repair that restores the test's intent — it does not weaken or bypass the deleted-agent validation (the guard behaves correctly and stays untouched). #98686 previously attempted a broader fix for scheduled live/e2e failures in this area but was closed unmerged with no public discussion; this PR takes only the single-fixture slice with a fresh reproduction on current `main`.

## User Impact

`pnpm test src/gateway/gateway.test.ts` passes on a clean checkout again, so contributor pre-push gates and the gateway e2e lane stop failing on an upstream fixture bug. No runtime behavior changes.

## Evidence

HEAD: `9addbdeb73ceff8bd912e7ed491d7745f8cb9b1d` (base upstream/main `0cc9927577`)

Before (clean `main`, reproduced at `776b34a4e642`, `df350e6720`, `8d535fb039` — details in #99513):

```
 ❯ src/gateway/gateway.test.ts (4 tests | 1 failed)
     × accepts a gateway agent request over ws and returns a run id
GatewayClientRequestError: Agent "dev" no longer exists in configuration
```

After (this branch):

```
node scripts/run-vitest.mjs src/gateway/gateway.test.ts
 Test Files  1 passed (1)
      Tests  4 passed (4)
```

`OPENCLAW_CHECK_CHANGED_REMOTE_CHILD=1 pnpm check:changed -- src/gateway/gateway.test.ts` exit 0; `git diff --check` clean.

Non-scope: no runtime gateway behavior change; no change to deleted-agent validation; no `gateway-models.profiles.live.test.ts` changes (not reproduced on current `main`, deliberately excluded).

---

🤖 AI-assisted (Claude Fable 5 + Codex GPT-5.5 review). The failure, root cause, and fix were verified by hand at the SHAs above; structured review round clean ("patch is correct", including the declare-vs-rename design question).
