### PR TITLE
fix(gateway): declare dev agent in gateway.test.ts e2e config

### DIFF
--- a/src/gateway/gateway.test.ts
+++ b/src/gateway/gateway.test.ts
@@ -206,6 +206,7 @@ describe("gateway e2e", () => {
               },
             },
           },
+          list: [{ id: "dev" }],
         },
         models: {
           mode: "replace",


### PR DESCRIPTION
Fixes #99513

## What Problem This Solves

Fixes #99513. `src/gateway/gateway.test.ts` fails on a clean main checkout because the test requests `sessionKey = "agent:dev:mock-openai"`, but the gateway config only defines `agents.defaults` and omits `dev` from `agents.list`. Gateway rejects the run with `Agent "dev" no longer exists in configuration`.

## Why This Change Was Made

Add `agents.list: [{ id: "dev" }]` to the failing test's gateway config so the `dev` agent is recognized. This keeps the test's original intent of exercising a non-default agent id, and all other fields inherit from `agents.defaults`. The sibling test in the same file already uses the same `agents.list` pattern for `main`.

## User Impact

Contributors running `pnpm test src/gateway/gateway.test.ts` on a clean main checkout will no longer hit this e2e failure during pre-push gates.

## Evidence

Before fix:
```
 ❯ src/gateway/gateway.test.ts (4 tests | 1 failed | 3 skipped)
     × accepts a gateway agent request over ws and returns a run id
GatewayClientRequestError: Agent "dev" no longer exists in configuration
```

After fix:
```
 ✓ src/gateway/gateway.test.ts (4 tests | 3 skipped)
     ✓ accepts a gateway agent request over ws and returns a run id  2480ms

 Test Files  1 passed (1)
      Tests  1 passed | 3 skipped (4)
```

Format / lint verification:
- `npx oxfmt --check src/gateway/gateway.test.ts` passes
- `npx oxlint@latest src/gateway/gateway.test.ts` passes

