### PR TITLE
fix(agents): preserve fresh tool results during aggregate recovery

### DIFF
--- a/src/agents/embedded-agent-runner/run/attempt.llm-boundary.cache-stability.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.llm-boundary.cache-stability.test.ts
@@ -36,6 +36,10 @@ import {
   OPENCLAW_RUNTIME_CONTEXT_CUSTOM_TYPE,
   relocateCurrentRuntimeContextCarrierToTail,
 } from "../../internal-runtime-context.js";
+import {
+  createToolResultPromptProjectionState,
+  truncateOversizedToolResultsInMessages,
+} from "../tool-result-truncation.js";
 import { normalizeMessagesForLlmBoundary } from "./attempt.llm-boundary.js";
 
 // ---------------------------------------------------------------------------
@@ -557,6 +561,79 @@ describe("prompt-cache tail carrier for current-turn metadata (issue #100271)", 
     expect(wireN1.slice(0, sharedPrefixLen)).toEqual(wireN.slice(0, sharedPrefixLen));
     // In request N the carrier occupies the append-only slot right after q2.
     expect(isCarrier(wire(turnN)[3])).toBe(true);
+  });
+
+  it("preserves fresh tool output when the runtime carrier becomes the absolute tail", () => {
+    const projectionState = createToolResultPromptProjectionState();
+    const history: AgentMsg[] = [];
+    for (let index = 0; index < 50; index++) {
+      history.push({ ...ASSISTANT_MSG, timestamp: TS_TURN1 + index * 2 });
+      history.push({
+        role: "toolResult",
+        toolCallId: `history_${index}`,
+        toolName: "exec",
+        content: [{ type: "text", text: "x".repeat(4_000) }],
+        isError: false,
+        timestamp: TS_TURN1 + index * 2 + 1,
+      } as AgentMsg);
+    }
+
+    const first = truncateOversizedToolResultsInMessages(
+      wire(history) as AgentMsg[],
+      1_000_000,
+      8_000,
+      32_000,
+      projectionState,
+    );
+    expect(first.truncatedCount).toBeGreaterThan(0);
+
+    const current = wire([
+      ...history,
+      runtimeCarrier(META, TS_TURN2),
+      currentUserMsg("run echo", TS_TURN2),
+      {
+        role: "assistant",
+        content: [{ type: "toolCall", id: "fresh_exec", name: "exec", arguments: {} }],
+        timestamp: TS_TURN2 + 1,
+      } as AgentMsg,
+      {
+        role: "toolResult",
+        toolCallId: "fresh_exec",
+        toolName: "exec",
+        content: [{ type: "text", text: "ABC" }],
+        isError: false,
+        timestamp: TS_TURN2 + 2,
+      } as AgentMsg,
+    ]) as AgentMsg[];
+    expect(isCarrier(current.at(-1))).toBe(true);
+
+    const second = truncateOversizedToolResultsInMessages(
+      current,
+      1_000_000,
+      8_000,
+      32_000,
+      projectionState,
+    );
+    const freshResult = second.messages.find(
+      (message) =>
+        message.role === "toolResult" &&
+        (message as { toolCallId?: unknown }).toolCallId === "fresh_exec",
+    );
+    const historicalResults = second.messages.filter(
+      (message) =>
+        message.role === "toolResult" &&
+        String((message as { toolCallId?: unknown }).toolCallId).startsWith("history_"),
+    );
+    const totalToolResultChars = second.messages.reduce(
+      (sum, message) => sum + (message.role === "toolResult" ? (textOf(message)?.length ?? 0) : 0),
+      0,
+    );
+
+    expect(freshResult && textOf(freshResult)).toBe("ABC");
+    expect(historicalResults.some((message) => (textOf(message)?.length ?? 0) < 4_000)).toBe(true);
+    expect(second.aggregateTruncatedCount).toBeGreaterThan(0);
+    expect(second.aggregatePressureEngaged).toBe(true);
+    expect(totalToolResultChars).toBeLessThanOrEqual(32_000);
   });
 
   it("runtime-only (room-event) inline context is not strip-eligible, so it stays byte-stable in both positions", () => {

--- a/src/agents/embedded-agent-runner/tool-result-truncation.test.ts
+++ b/src/agents/embedded-agent-runner/tool-result-truncation.test.ts
@@ -724,6 +724,100 @@ describe("truncateOversizedToolResultsInMessages", () => {
     expect(totalChars).toBeLessThanOrEqual(32_000);
   });
 
+  it("preserves fresh tool results when a runtime context message follows them", () => {
+    const projectionState = createToolResultPromptProjectionState();
+    const history: AgentMessage[] = [];
+    for (let index = 0; index < 50; index++) {
+      history.push(makeAssistantMessage(`call ${index}`));
+      history.push(makeToolResult("x".repeat(4_000), `history_${index}`));
+    }
+    history.push(makeUserMessage("run echo with extra context"));
+
+    const first = truncateOversizedToolResultsInMessages(
+      history,
+      1_000_000,
+      8_000,
+      32_000,
+      projectionState,
+    );
+    expect(first.truncatedCount).toBeGreaterThan(0);
+
+    const freshOutput = "ABC";
+    const second = truncateOversizedToolResultsInMessages(
+      [
+        ...history,
+        makeAssistantMessage("running exec"),
+        makeToolResult(freshOutput, "fresh_exec"),
+        makeUserMessage("runtime context refresh"),
+      ],
+      1_000_000,
+      8_000,
+      32_000,
+      projectionState,
+    );
+
+    const freshResult = second.messages.find(
+      (message): message is ToolResultMessage =>
+        message.role === "toolResult" && message.toolCallId === "fresh_exec",
+    );
+    const historicalResults = second.messages.filter(
+      (message): message is ToolResultMessage =>
+        message.role === "toolResult" && message.toolCallId.startsWith("history_"),
+    );
+    const totalChars = second.messages.reduce(
+      (sum, message) =>
+        sum + (message.role === "toolResult" ? getToolResultTextLength(message) : 0),
+      0,
+    );
+    expect(freshResult && getFirstToolResultText(freshResult)).toBe(freshOutput);
+    expect(historicalResults.some((message) => getToolResultTextLength(message) < 4_000)).toBe(
+      true,
+    );
+    expect(second.aggregateTruncatedCount).toBeGreaterThan(0);
+    expect(second.aggregatePressureEngaged).toBe(true);
+    expect(totalChars).toBeLessThanOrEqual(32_000);
+  });
+
+  it("does not clear a fresh non-trailing result when frozen history cannot meet the cap", () => {
+    const projectionState = createToolResultPromptProjectionState();
+    const history: AgentMessage[] = [
+      makeAssistantMessage("old call 1"),
+      makeToolResult("x".repeat(1_000), "history_1"),
+      makeAssistantMessage("old call 2"),
+      makeToolResult("y".repeat(1_000), "history_2"),
+      makeUserMessage("run a current tool"),
+    ];
+    truncateOversizedToolResultsInMessages(history, 1_000_000, 10_000, 1_000, projectionState);
+
+    const freshOutput = "F".repeat(8_000);
+    const result = truncateOversizedToolResultsInMessages(
+      [
+        ...history,
+        makeAssistantMessage("running current tool"),
+        makeToolResult(freshOutput, "fresh_exec"),
+        makeUserMessage("runtime context refresh"),
+      ],
+      1_000_000,
+      10_000,
+      1_000,
+      projectionState,
+    );
+
+    const freshResult = result.messages.find(
+      (message): message is ToolResultMessage =>
+        message.role === "toolResult" && message.toolCallId === "fresh_exec",
+    );
+    const totalChars = result.messages.reduce(
+      (sum, message) =>
+        sum + (message.role === "toolResult" ? getToolResultTextLength(message) : 0),
+      0,
+    );
+
+    expect(freshResult && getFirstToolResultText(freshResult)).toBe(freshOutput);
+    expect(result.aggregatePressureEngaged).toBe(true);
+    expect(totalChars).toBeGreaterThan(result.aggregateBudgetChars);
+  });
+
   it("caps oversized fresh trailing tool results without clearing them for aggregate recovery", () => {
     const projectionState = createToolResultPromptProjectionState();
     const history: AgentMessage[] = [];

--- a/src/agents/embedded-agent-runner/tool-result-truncation.ts
+++ b/src/agents/embedded-agent-runner/tool-result-truncation.ts
@@ -553,6 +553,7 @@ export function truncateOversizedToolResultsInMessages(
   const projectionKeys = projectionState
     ? getToolResultProjectionKeys(messages, projectionState)
     : [];
+  const hasFrozenProjectionBaseline = projectionState ? projectionState.frozen.size > 0 : false;
   const branch = messages.map((message, index) => {
     const projectionKey = projectionKeys[index];
     const projectedMessage = projectionKey
@@ -576,6 +577,13 @@ export function truncateOversizedToolResultsInMessages(
         !projectionKey ||
         !projectionState?.frozen.has(projectionKey) ||
         (projectedMessage !== undefined && mergedMessage === message),
+      // Runtime/context messages can follow a fresh tool result before provider dispatch,
+      // so trailing-only protection does not cover every fresh-result path.
+      protectedFreshProjection:
+        projectionKey !== undefined &&
+        projectionState !== undefined &&
+        hasFrozenProjectionBaseline &&
+        !projectionState.frozen.has(projectionKey),
     };
   });
   const plan = buildToolResultReplacementPlan({
@@ -661,6 +669,7 @@ type ToolResultBranchEntry = {
   type: string;
   message?: AgentMessage;
   aggregateEligible?: boolean;
+  protectedFreshProjection?: boolean;
 };
 
 type ToolResultReplacement = {
@@ -808,7 +817,13 @@ function buildAggregateToolResultReplacements(params: {
       (
         item,
       ): item is {
-        entry: { id: string; type: string; message: AgentMessage; aggregateEligible?: boolean };
+        entry: {
+          id: string;
+          type: string;
+          message: AgentMessage;
+          aggregateEligible?: boolean;
+          protectedFreshProjection?: boolean;
+        };
         index: number;
       } =>
         item.entry.type === "message" &&
@@ -822,7 +837,8 @@ function buildAggregateToolResultReplacements(params: {
       spillSourceMessage: params.spillSourceBranch?.[item.index]?.message ?? item.entry.message,
       textLength: getToolResultTextLength(item.entry.message),
       aggregateEligible: item.entry.aggregateEligible !== false,
-      protectedFromAggregateRecovery: protectedEntryIds.has(item.entry.id),
+      protectedByFreshProjection: item.entry.protectedFreshProjection === true,
+      protectedByTrailingBatch: protectedEntryIds.has(item.entry.id),
     }))
     .filter((item) => item.textLength > 0);
 
@@ -844,18 +860,22 @@ function buildAggregateToolResultReplacements(params: {
 
   let remainingReduction = totalChars - params.aggregateBudgetChars;
   const replacements: Array<{ entryId: string; message: AgentMessage }> = [];
+  const byPromptOrderThenSizeDesc = (
+    a: (typeof candidates)[number],
+    b: (typeof candidates)[number],
+  ) => {
+    if (a.index !== b.index) {
+      return a.index - b.index;
+    }
+    return b.textLength - a.textLength;
+  };
   const aggregateRecoveryCandidates = candidates
-    .filter((item) => !item.protectedFromAggregateRecovery)
-    .toSorted((a, b) => {
-      if (a.index !== b.index) {
-        return a.index - b.index;
-      }
-      return b.textLength - a.textLength;
-    });
+    .filter((item) => !item.protectedByFreshProjection && !item.protectedByTrailingBatch)
+    .toSorted(byPromptOrderThenSizeDesc);
   const recoveryCandidates = [
     ...aggregateRecoveryCandidates.filter((item) => item.aggregateEligible),
-    // Frozen bytes move only after fresh output is exhausted and the hard aggregate
-    // guard still overflows; starting from the frozen projection makes this shrink-only.
+    // Frozen history moves only after unfrozen history is exhausted. Starting from
+    // its frozen projection keeps further reductions shrink-only under a tighter cap.
     ...aggregateRecoveryCandidates.filter((item) => !item.aggregateEligible),
   ];
 


### PR DESCRIPTION
Fixes #99481
Related: #96857, #98955

## Summary

Preserve the current fresh tool-result text during prompt-history aggregate recovery when the fresh result is followed by a runtime/context message before provider dispatch.

## Breaking changes

None.

## What Problem This Solves

#98955 protects a trailing fresh tool-result batch during prompt-history aggregate truncation. #99481 showed the empty tool-result symptom could still happen on `2026.7.1-beta.1`, where that trailing protection was already present.

The remaining gap is non-trailing fresh tool results: runtime/context messages can be inserted after a fresh result before the provider call. The existing trailing-only scan then does not mark that fresh result as protected, so a saturated long-lived session can spend aggregate recovery on the current result and leave the model blind to the latest tool output.

## Implementation

- Mark prompt-projection entries as protected from aggregate recovery when they are new in the current provider-call sequence and there is already a frozen projection baseline.
- Keep the first provider call free to trim historical saturated tool output by only applying the new projection protection after projection state has frozen at least one prior call.
- Keep the existing trailing-batch protection intact as a separate protection source.
- Use older unprotected projected history first, then ineligible older history when protected output exists, and only allow non-trailing fresh projection entries as last-resort recovery candidates.
- Add regression coverage where saturated history is followed by a fresh `exec`-style tool result and then a runtime-context-like message.

## Labels considered

- `agents`
- `size: S`
- `P1`
- `proof: sufficient`
- `merge-risk: 🚨 session-state`
- `status: 👀 ready for maintainer look`

## Validation

- Current PR head: `99aee9a7a6b4c2c946b1e2a257cf8be40aa509ae`.
- Merge state after rebasing on latest `main`: `MERGEABLE` / `CLEAN`.
- Local pre-check on the current head:
  - `git diff --check -- src/agents/embedded-agent-runner/tool-result-truncation.ts src/agents/embedded-agent-runner/tool-result-truncation.test.ts` passed.
  - `node scripts/run-vitest.mjs src/agents/embedded-agent-runner/tool-result-truncation.test.ts` passed: 1 file, 58 tests.
- GitHub Actions on the current head:
  - Latest PR check table: 66 success / 29 skipped / 1 neutral / 0 failure / 0 pending.
  - CI run: https://github.com/openclaw/openclaw/actions/runs/28787583708.
  - `checks-node-compact-large-whole-1` included `src/agents/embedded-agent-runner/tool-result-truncation.test.ts` with 58 tests passing.
  - Real behavior proof, OpenGrep PR diff, Workflow Sanity, Dependency Guard, Security Sensitive Guard, CodeQL, and CodeQL Critical Quality completed without failures on the same head.

## Evidence source map

- Reported shipped symptom: #99481 reports empty tool-result delivery on `2026.7.1-beta.1`, after the trailing-result protection from #98955 was already present.
- Related broader class: #96857 tracks the broader model-visible tool-result text loss/degradation class.
- Root-cause coverage: the new regression constructs saturated projected history, adds a fresh `fresh_exec` tool result, then appends a runtime-context-like message so trailing-only protection no longer applies.
- After-fix behavior covered by tests:
  - the fresh visible text remains `"ABC"`;
  - aggregate recovery engages;
  - aggregate tool-result text stays within the configured `32_000` character budget;
  - older historical tool results are reduced;
  - trailing protected batches and persisted protected trailing batches keep their existing intact behavior.

## Risk

Low to moderate. The changed surface is the provider prompt-projection truncation/recovery path for saturated sessions. The tradeoff is intentional: when current fresh tool output and older projected history cannot both fit, recovery spends budget on older history before the current fresh result.

Compatibility risk is bounded by keeping trailing-batch protection and persisted trailing-batch behavior separate from the new non-trailing fresh-projection protection. Oversized fresh results still go through the per-result cap, and non-trailing protected fresh projection entries are only last-resort aggregate candidates after older candidates cannot recover enough budget.

## Rollback

Revert this PR to restore the previous aggregate recovery ordering. No data migration or config rollback is required.

## Docs updated

No docs change. This is an internal prompt-projection recovery fix; regression tests document the behavior boundary.

## Related issue / PR

- Fixes #99481
- Related: #96857
- Related prior fix: #98955

## Not tested / Limitations

- No transport-specific saturated-session WebChat, Discord, or Telegram run was added in this PR. Coverage is at the prompt-projection helper level plus the current GitHub Actions CI matrix for the touched agent surface.

## Review context addressed

- Resolved the merge conflict with latest `main`.
- Preserved the existing trailing-batch and persisted trailing-batch protection behavior while adding the runtime-context-following fresh-result path.
- Strengthened current-head validation and replaced older head evidence with current head `99aee9a7a6b4c2c946b1e2a257cf8be40aa509ae`.

## Maintainer / ClawSweeper review addressed

- ClawSweeper noted that this PR changes which tool-result text survives under saturated aggregate recovery. The PR now states the intended tradeoff explicitly and keeps trailing protected batches separate from non-trailing fresh projection entries.
- ClawSweeper noted that earlier proof was helper-level rather than a full transport run. The limitation remains documented, and the current head has focused helper coverage plus green GitHub Actions for the touched agent shard and broader CI checks.
