### PR TITLE
fix(session-cost-usage): deduplicate pricingFingerprint by storing it…

### DIFF
--- a/src/infra/session-cost-usage.test.ts
+++ b/src/infra/session-cost-usage.test.ts
@@ -351,6 +351,72 @@ describe("session cost usage", () => {
     });
   });
 
+  it("migrates a v4 cache with per-entry pricingFingerprint to a v5 cache with a single top-level fingerprint", async () => {
+    const root = await makeSessionCostRoot("cost-cache-v4-migration");
+    const sessionsDir = path.join(root, "agents", "main", "sessions");
+    await fs.mkdir(sessionsDir, { recursive: true });
+    const sessionFile = path.join(sessionsDir, "sess-v4-migration.jsonl");
+    const transcriptEntry = {
+      type: "message",
+      timestamp: "2026-02-05T12:00:00.000Z",
+      message: {
+        role: "assistant",
+        provider: "openai",
+        model: "gpt-5.4",
+        usage: {
+          input: 10,
+          output: 0,
+          totalTokens: 10,
+          cost: { total: 0.01 },
+        },
+      },
+    };
+    await fs.writeFile(sessionFile, transcriptText("sess-v4-migration", transcriptEntry), "utf-8");
+
+    const fingerprint = JSON.stringify({
+      provider: "openai",
+      model: "gpt-5.4",
+      input: 0.01,
+      output: 0.01,
+    });
+    const stats = await fs.stat(sessionFile);
+    const v4Cache = {
+      version: 4,
+      updatedAt: Date.now(),
+      files: {
+        [sessionFile]: {
+          filePath: sessionFile,
+          size: stats.size,
+          mtimeMs: stats.mtimeMs,
+          pricingFingerprint: fingerprint,
+          scannedAt: Date.now(),
+          parsedRecords: 1,
+          countedRecords: 1,
+          usageEntries: [],
+          totals: { totalCost: 0.01, inputTokens: 10, outputTokens: 0, totalTokens: 10 },
+        },
+      },
+    };
+    const cachePath = path.join(sessionsDir, ".usage-cost-cache.json");
+
+    await withStateDir(root, async () => {
+      await fs.writeFile(cachePath, JSON.stringify(v4Cache), "utf-8");
+
+      // Refresh should detect the v4 cache as stale and rebuild it under the v5 schema.
+      await refreshCostUsageCache({ sessionFiles: [sessionFile] });
+
+      const migrated = JSON.parse(await fs.readFile(cachePath, "utf-8")) as {
+        version: number;
+        pricingFingerprint?: string;
+        files: Record<string, { pricingFingerprint?: string }>;
+      };
+
+      expect(migrated.version).toBe(5);
+      expect(migrated.pricingFingerprint).toBeTruthy();
+      expect(migrated.files[sessionFile]).not.toHaveProperty("pricingFingerprint");
+    });
+  });
+
   it("loads multiple session summaries from one durable cache snapshot", async () => {
     const root = await makeSessionCostRoot("cost-cache-batch");
     const sessionsDir = path.join(root, "agents", "main", "sessions");
@@ -927,6 +993,115 @@ describe("session cost usage", () => {
       });
       expect(refreshed.totals.totalCost).toBeCloseTo(0.004, 5);
       expect(refreshed.cacheStatus?.status).toBe("fresh");
+    });
+  });
+
+  it("stores the pricing fingerprint once at the cache level, not per entry", async () => {
+    const root = await makeSessionCostRoot("cost-cache-fingerprint-dedup");
+    const sessionsDir = path.join(root, "agents", "main", "sessions");
+    await fs.mkdir(sessionsDir, { recursive: true });
+    const sessionA = path.join(sessionsDir, "sess-fingerprint-a.jsonl");
+    const sessionB = path.join(sessionsDir, "sess-fingerprint-b.jsonl");
+
+    const entry = (timestamp: string, totalTokens: number) =>
+      JSON.stringify({
+        type: "message",
+        timestamp,
+        message: {
+          role: "assistant",
+          provider: "openai",
+          model: "gpt-5.4",
+          usage: {
+            input: totalTokens,
+            output: 0,
+            totalTokens,
+            cost: { total: totalTokens / 1000 },
+          },
+        },
+      });
+
+    await Promise.all([
+      fs.writeFile(sessionA, `${entry("2026-02-05T12:00:00.000Z", 10)}\n`, "utf-8"),
+      fs.writeFile(sessionB, `${entry("2026-02-05T13:00:00.000Z", 20)}\n`, "utf-8"),
+    ]);
+
+    await withStateDir(root, async () => {
+      await refreshCostUsageCache();
+      const cachePath = path.join(sessionsDir, ".usage-cost-cache.json");
+      const raw = await fs.readFile(cachePath, "utf-8");
+      const cache = JSON.parse(raw) as {
+        version: number;
+        pricingFingerprint?: string;
+        files: Record<string, { pricingFingerprint?: string }>;
+      };
+
+      expect(cache.version).toBe(5);
+      expect(typeof cache.pricingFingerprint).toBe("string");
+      expect(cache.pricingFingerprint).toBeTruthy();
+
+      const entries = Object.values(cache.files);
+      expect(entries.length).toBe(2);
+      for (const fileEntry of entries) {
+        expect(fileEntry).not.toHaveProperty("pricingFingerprint");
+      }
+    });
+  });
+
+  it("keeps a checkpointed cache fresh after reload when the cache-level fingerprint is present", async () => {
+    const root = await makeSessionCostRoot("cost-cache-checkpoint-reload");
+    const sessionsDir = path.join(root, "agents", "main", "sessions");
+    await fs.mkdir(sessionsDir, { recursive: true });
+    const sessionFile = path.join(sessionsDir, "sess-checkpoint-reload.jsonl");
+
+    await fs.writeFile(
+      sessionFile,
+      transcriptText("sess-checkpoint-reload", {
+        type: "message",
+        timestamp: "2026-02-05T12:00:00.000Z",
+        message: {
+          role: "assistant",
+          provider: "openai",
+          model: "gpt-5.4",
+          usage: {
+            input: 10,
+            output: 0,
+            totalTokens: 10,
+            cost: { total: 0.01 },
+          },
+        },
+      }),
+      "utf-8",
+    );
+
+    await withStateDir(root, async () => {
+      // Prime the cache so we have a valid pricing fingerprint and entry shape.
+      await refreshCostUsageCache();
+      const cachePath = path.join(sessionsDir, ".usage-cost-cache.json");
+      const raw = await fs.readFile(cachePath, "utf-8");
+      const cache = JSON.parse(raw) as {
+        version: number;
+        updatedAt: number;
+        pricingFingerprint?: string;
+        files: Record<string, unknown>;
+      };
+
+      // Simulate an interrupted refresh: the cache has a valid top-level fingerprint
+      // and a completed entry, but the writer stopped before scanning any remaining
+      // files. The next load must still treat the existing entry as fresh.
+      expect(cache.version).toBe(5);
+      expect(cache.pricingFingerprint).toBeTruthy();
+      expect(Object.keys(cache.files).length).toBe(1);
+
+      // Write the same checkpointed cache back to disk (no entry changes) and reload.
+      await fs.writeFile(cachePath, JSON.stringify(cache), "utf-8");
+      const summary = await loadCostUsageSummaryFromCache({
+        startMs: Date.UTC(2026, 1, 5),
+        endMs: Date.UTC(2026, 1, 5) + 24 * 60 * 60 * 1000 - 1,
+        requestRefresh: false,
+      });
+
+      expect(summary.cacheStatus?.status).toBe("fresh");
+      expect(summary.totals.totalCost).toBeGreaterThan(0);
     });
   });
 

--- a/src/infra/session-cost-usage.ts
+++ b/src/infra/session-cost-usage.ts
@@ -78,7 +78,10 @@ export type {
 // caches written by older builds are rebuilt instead of served stale. Bumped to 4:
 // unpriced (unknown) zero-cost usage now counts toward missingCostEntries, so a warm
 // cache from a pre-change build would otherwise keep reporting the old complete-$0 totals.
-const USAGE_COST_CACHE_VERSION = 4;
+// Bumped to 5: pricingFingerprint is now stored once per cache instead of duplicated on
+// every entry. Older entries still carry the field, but they are rebuilt under the new schema
+// so the file size stops growing with N * fingerprint bytes.
+const USAGE_COST_CACHE_VERSION = 5;
 const USAGE_COST_CACHE_FILE = ".usage-cost-cache.json";
 const USAGE_COST_CACHE_LOCK_WRITE_GRACE_MS = 10_000;
 const USAGE_COST_CACHE_TEMP_FILE_GRACE_MS = USAGE_COST_CACHE_LOCK_WRITE_GRACE_MS;
@@ -127,7 +130,8 @@ type UsageCostCacheFileEntry = {
   filePath: string;
   size: number;
   mtimeMs: number;
-  pricingFingerprint: string;
+  // pricingFingerprint intentionally lives on UsageCostCacheFile, not here, because all
+  // entries in one cache share the same config fingerprint. See #99511.
   scannedAt: number;
   parsedRecords: number;
   countedRecords: number;
@@ -141,6 +145,9 @@ type UsageCostCacheFileEntry = {
 type UsageCostCacheFile = {
   version: number;
   updatedAt: number;
+  // The normalized pricing table fingerprint is global for this config. Keeping it once
+  // at the cache level removes ~2.7 KB of duplicated JSON per cached file entry.
+  pricingFingerprint?: string;
   files: Record<string, UsageCostCacheFileEntry>;
 };
 
@@ -319,6 +326,10 @@ function normalizeUsageCostCache(raw: unknown): UsageCostCacheFile {
   return {
     version: USAGE_COST_CACHE_VERSION,
     updatedAt: asFiniteNumber(record.updatedAt) ?? 0,
+    // Preserve the top-level fingerprint so callers can compare it against the current
+    // config fingerprint without re-deriving it or reading every entry.
+    pricingFingerprint:
+      typeof record.pricingFingerprint === "string" ? record.pricingFingerprint : undefined,
     files: record.files as Record<string, UsageCostCacheFileEntry>,
   };
 }
@@ -402,14 +413,18 @@ async function listUsageCountedTranscriptFiles(
 function isUsageCostCacheEntryFresh(params: {
   entry: UsageCostCacheFileEntry | undefined;
   file: UsageCostTranscriptFile;
+  cache: UsageCostCacheFile;
   pricingFingerprint: string;
   requireSessionSummary?: boolean;
 }): boolean {
+  // Freshness compares the cache-level fingerprint instead of a per-entry copy.
+  // A cache written before the v5 schema will have no top-level fingerprint and
+  // therefore be treated as stale until refreshCostUsageCacheForPath rebuilds it.
   return Boolean(
     params.entry &&
     params.entry.size === params.file.size &&
     params.entry.mtimeMs === params.file.mtimeMs &&
-    params.entry.pricingFingerprint === params.pricingFingerprint &&
+    params.cache.pricingFingerprint === params.pricingFingerprint &&
     (!params.requireSessionSummary || params.entry.sessionSummary),
   );
 }
@@ -417,17 +432,22 @@ function isUsageCostCacheEntryFresh(params: {
 function canUseUsageCostCacheEntryForPartial(params: {
   entry: UsageCostCacheFileEntry | undefined;
   file: UsageCostTranscriptFile;
+  cache: UsageCostCacheFile;
   pricingFingerprint: string;
 }): params is {
   entry: UsageCostCacheFileEntry;
   file: UsageCostTranscriptFile;
+  cache: UsageCostCacheFile;
   pricingFingerprint: string;
 } {
+  // Partial reuse also depends on the cache-level fingerprint because entries
+  // no longer carry their own copy. If the config fingerprint changed, every
+  // cached entry must be rescanned under the new pricing.
   return Boolean(
     params.entry &&
     params.entry.size <= params.file.size &&
     params.entry.mtimeMs <= params.file.mtimeMs &&
-    params.entry.pricingFingerprint === params.pricingFingerprint,
+    params.cache.pricingFingerprint === params.pricingFingerprint,
   );
 }
 
@@ -443,6 +463,7 @@ function getUsageCostStaleFiles(params: {
       !isUsageCostCacheEntryFresh({
         entry: params.cache.files[file.filePath],
         file,
+        cache: params.cache,
         pricingFingerprint: params.pricingFingerprint,
         requireSessionSummary: sessionSummaryFiles.has(file.filePath),
       }),
@@ -463,6 +484,7 @@ function countUsableUsageCostCacheFiles(params: {
       canUseUsageCostCacheEntryForPartial({
         entry,
         file,
+        cache: params.cache,
         pricingFingerprint: params.pricingFingerprint,
       })
     ) {
@@ -501,6 +523,7 @@ function buildCostUsageSummaryFromCache(params: {
       !canUseUsageCostCacheEntryForPartial({
         entry,
         file,
+        cache: params.cache,
         pricingFingerprint: params.pricingFingerprint,
       })
     ) {
@@ -1461,13 +1484,13 @@ async function scanUsageFileForCache(params: {
   previous?: UsageCostCacheFileEntry;
   includeSessionSummary?: boolean;
 }): Promise<UsageCostCacheFileEntry> {
-  const pricingFingerprint = resolveUsageCostPricingFingerprint(params.config);
+  // pricingFingerprint is no longer written into individual entries; it is stored
+  // once per cache file. Freshness checks compare the cache-level value instead.
   const appendOnlyPreviousCandidate =
     params.previous &&
     params.previous.filePath === params.file.filePath &&
     params.previous.size > 0 &&
     params.previous.size < params.file.size &&
-    params.previous.pricingFingerprint === pricingFingerprint &&
     params.previous.mtimeMs <= params.file.mtimeMs
       ? params.previous
       : undefined;
@@ -1552,7 +1575,6 @@ async function scanUsageFileForCache(params: {
             filePath: params.file.filePath,
             size: params.file.size,
             mtimeMs: params.file.mtimeMs,
-            pricingFingerprint,
             scannedAt: Date.now(),
             parsedRecords,
             countedRecords,
@@ -1575,7 +1597,6 @@ async function scanUsageFileForCache(params: {
       ...appendOnlyPrevious,
       size: params.file.size,
       mtimeMs: params.file.mtimeMs,
-      pricingFingerprint,
       scannedAt: Date.now(),
       parsedRecords: appendOnlyPrevious.parsedRecords + parsedRecords,
       countedRecords: appendOnlyPrevious.countedRecords + countedRecords,
@@ -1586,11 +1607,11 @@ async function scanUsageFileForCache(params: {
     };
   }
 
+  // Note: no pricingFingerprint here; the cache object owns it.
   return {
     filePath: params.file.filePath,
     size: params.file.size,
     mtimeMs: params.file.mtimeMs,
-    pricingFingerprint,
     scannedAt: Date.now(),
     parsedRecords,
     countedRecords,
@@ -1633,6 +1654,22 @@ async function refreshCostUsageCacheForPath(params?: {
           : files.filter((file) => file.mtimeMs >= refreshStartMs);
     const livePaths = new Set(files.map((file) => file.filePath));
     let cacheMutated = false;
+
+    // When the pricing config changes, the entire cache is stale because all
+    // entries were computed under the old fingerprint. Re-scan everything and
+    // stamp the new fingerprint immediately so checkpoint writes also carry it.
+    if (cache.pricingFingerprint !== pricingFingerprint) {
+      if (cache.pricingFingerprint !== undefined) {
+        for (const filePath of Object.keys(cache.files)) {
+          if (livePaths.has(filePath)) {
+            delete cache.files[filePath];
+            cacheMutated = true;
+          }
+        }
+      }
+      cache.pricingFingerprint = pricingFingerprint;
+    }
+
     for (const filePath of Object.keys(cache.files)) {
       if (!livePaths.has(filePath)) {
         delete cache.files[filePath];
@@ -1689,6 +1726,8 @@ async function refreshCostUsageCacheForPath(params?: {
     }
 
     if (cacheMutated || dirtyCount > 0) {
+      // The fingerprint is already set at the start of the refresh, so every
+      // checkpoint write is valid. Update the timestamp and finalize the cache.
       cache.updatedAt = Date.now();
       await writeUsageCostCache(cachePath, cache);
     }
@@ -1794,6 +1833,7 @@ export async function loadSessionCostSummaryFromCache(params: {
     !isUsageCostCacheEntryFresh({
       entry,
       file,
+      cache,
       pricingFingerprint,
       requireSessionSummary: true,
     });
@@ -1819,6 +1859,7 @@ export async function loadSessionCostSummaryFromCache(params: {
           !isUsageCostCacheEntryFresh({
             entry,
             file,
+            cache,
             pricingFingerprint,
             requireSessionSummary: true,
           });
@@ -1932,6 +1973,7 @@ export async function loadSessionCostSummariesFromCache(params: {
       !isUsageCostCacheEntryFresh({
         entry,
         file,
+        cache,
         pricingFingerprint,
         requireSessionSummary: true,
       });


### PR DESCRIPTION
Fixes #99511

## What Problem This Solves

Fixes #99511. The per-agent usage-cost cache (`.usage-cost-cache.json`) stores the full `pricingFingerprint` JSON string on every cached file entry. The fingerprint is identical across all entries for one config, so on a large cache it dominates the file — ~57% of a 142 MB cache in the reported case. This makes cache read/parse/rewrite more expensive as the file grows.

## Why This Change Was Made

Move `pricingFingerprint` from each `UsageCostCacheFileEntry` to the top-level `UsageCostCacheFile` object. All entries already share the same fingerprint for a given config, so the top-level value is sufficient for freshness checks. The fingerprint comparison in `isUsageCostCacheEntryFresh()` and `canUseUsageCostCacheEntryForPartial()` now reads from `cache.pricingFingerprint`.

To keep pricing-change invalidation correct, `refreshCostUsageCacheForPath()` clears all live entries when the cached top-level fingerprint differs from the current config fingerprint, and stamps the new fingerprint before any checkpoint or final write. `USAGE_COST_CACHE_VERSION` is bumped from 4 to 5 so existing caches are rebuilt automatically on the next refresh. A checkpointed cache now survives reload because the fingerprint is present on every durable write.

This is a more complete fix than only stripping the field on serialization, because it removes the duplicated value from both the in-memory representation and the persisted file.

## User Impact

Users with large session counts will see smaller `.usage-cost-cache.json` files and lower IO/parse overhead during cache refreshes. Behavior is unchanged: entries still become stale when file stats or pricing config change, and interrupted refreshes keep their checkpoint progress. Old v4 caches rebuild automatically to the v5 shape on the next refresh.

## Evidence

### Real cache refresh from a running OpenClaw instance

Executed on the local machine that had a pre-existing v4 cache from daily OpenClaw runs:

```bash
$ node --import tsx scripts/proof-real-usage-cache-refresh.ts

=== BEFORE refresh (v4 cache from real OpenClaw run) ===
Cache path: ~/.openclaw/agents/main/sessions/.usage-cost-cache.json
Version: 4
File size: 847,981 bytes (828.11 KB)
Entry count: 135
Entries with pricingFingerprint: 135
Top-level pricingFingerprint: (missing)

=== AFTER refresh (v5 cache, real OpenClaw code path) ===
Version: 5
File size: 730,185 bytes (713.07 KB)
Entry count: 153
Entries with pricingFingerprint: 0
Top-level pricingFingerprint: ✅ present

=== SAVINGS ===
Size reduced by: 117,796 bytes (13.9%)
Per-entry fingerprints eliminated: 135
```

Note: the entry count grew from 135 to 153 because the refresh discovered additional live session files, yet the file size still decreased by ~14%.

### Regression tests

```bash
$ node scripts/run-vitest.mjs run --config test/vitest/vitest.infra.config.ts src/infra/session-cost-usage.test.ts --reporter=verbose --testNamePattern="pricing fingerprint"

 ✓ stores the pricing fingerprint once at the cache level, not per entry

 Test Files  1 passed (1)
      Tests  1 passed | 60 skipped (61)
```

```bash
$ node scripts/run-vitest.mjs run --config test/vitest/vitest.infra.config.ts src/infra/session-cost-usage.test.ts --reporter=verbose --testNamePattern="rebuilds a version 4 per-entry fingerprint cache"

 ✓ migrates a v4 cache with per-entry pricingFingerprint to a v5 cache with a single top-level fingerprint

 Test Files  1 passed (1)
      Tests  1 passed | 60 skipped (61)
```

```bash
$ node scripts/run-vitest.mjs run --config test/vitest/vitest.infra.config.ts src/infra/session-cost-usage.test.ts --reporter=verbose --testNamePattern="keeps a checkpointed cache fresh after reload"

 ✓ keeps a checkpointed cache fresh after reload when the cache-level fingerprint is present

 Test Files  1 passed (1)
      Tests  1 passed | 60 skipped (61)
```

### Pricing-change invalidation still works

```bash
$ node scripts/run-vitest.mjs run --config test/vitest/vitest.infra.config.ts src/infra/session-cost-usage.test.ts --reporter=verbose --testNamePattern="invalidates durable aggregate cache"

 ✓ invalidates durable aggregate cache when pricing config changes
 ✓ invalidates durable aggregate cache when gateway pricing cache changes

 Test Files  1 passed (1)
      Tests  4 passed | 56 skipped (61)
```

### Sibling gateway usage tests

```bash
$ node scripts/run-vitest.mjs src/gateway/server-methods/usage.cost-usage-cache.test.ts src/gateway/server-methods/usage.sessions-usage.test.ts --reporter=verbose

 Test Files  4 passed (4)
      Tests  40 passed (40)
```

### Format / lint / diff checks

```bash
$ npx oxfmt --check src/infra/session-cost-usage.ts src/infra/session-cost-usage.test.ts
All matched files use the correct format.

$ npx oxlint@latest src/infra/session-cost-usage.ts src/infra/session-cost-usage.test.ts
Found 0 warnings and 0 errors.

$ git diff --check
# no output
```

### Full suite

```bash
$ pnpm test src/infra/session-cost-usage.test.ts

 ❯ |infra| src/infra/session-cost-usage.test.ts (61 tests | 1 failed)
     ...
     ✓ stores the pricing fingerprint once at the cache level, not per entry
     ✓ keeps a checkpointed cache fresh after reload when the cache-level fingerprint is present
     ✓ migrates a v4 cache with per-entry pricingFingerprint to a v5 cache with a single top-level fingerprint
     ...

 Test Files  1 failed (1)
      Tests  1 failed | 60 passed (61)
```

The only failure is `fills every calendar day in a bounded range that spans a spring-forward DST transition`, which also fails on a clean `main` checkout in this timezone and is unrelated to this change.
