### PR TITLE
test(ui): cover text-only tool result rendering

### DIFF
--- a/src/agents/agent-hooks/context-pruning/pruner.test.ts
+++ b/src/agents/agent-hooks/context-pruning/pruner.test.ts
@@ -471,4 +471,96 @@ describe("pruneContextMessages", () => {
     const toolResult = result[1] as Extract<AgentMessage, { role: "toolResult" }>;
     expect(toolResult.content).toEqual([{ type: "text", text: placeholder }]);
   });
+
+  // issue #99241: text-only toolResult must retain text during soft/hard trim
+  // without using image/attachment placeholders.
+  describe("issue #99241 – text-only toolResult trimming preserves text", () => {
+    const MARKER = "EXACT_TOOL_TEXT_99241_BOUNDARY";
+
+    it("soft-trims text-only toolResult preserving text, no image placeholders", () => {
+      const largeText = MARKER + "\n" + "x".repeat(4_000);
+      const messages: AgentMessage[] = [
+        makeUser("summarize this"),
+        makeToolResult([{ type: "text", text: largeText }]),
+        makeAssistant([{ type: "text", text: "done" }]),
+      ];
+
+      const result = pruneContextMessages({
+        messages,
+        settings: {
+          ...DEFAULT_CONTEXT_PRUNING_SETTINGS,
+          keepLastAssistants: 1,
+          softTrimRatio: 0,
+          hardClearRatio: 10,
+          hardClear: { ...DEFAULT_CONTEXT_PRUNING_SETTINGS.hardClear, enabled: false },
+          softTrim: {
+            maxChars: 200,
+            headChars: 100,
+            tailChars: 50,
+          },
+        },
+        ctx: CONTEXT_WINDOW_1M,
+        isToolPrunable: () => true,
+        contextWindowTokensOverride: 100,
+      });
+
+      const toolResult = result[1] as Extract<AgentMessage, { role: "toolResult" }>;
+      expect(toolResult.content).toHaveLength(1);
+      expect(toolResult.content[0]?.type).toBe("text");
+      const textBlock = toolResult.content[0] as { type: "text"; text: string };
+
+      // Must NOT use image/attachment placeholders
+      expect(textBlock.text).not.toContain("(see attached image)");
+      expect(textBlock.text).not.toContain("Attached image(s) from tool result:");
+      expect(textBlock.text).not.toContain("image_url");
+      expect(textBlock.text).not.toContain("[image removed");
+
+      // Must include trimming notice (confirms text was trimmed, not replaced)
+      expect(textBlock.text).toContain("Tool result trimmed");
+
+      // Must still contain the original marker text (trimmed, not replaced)
+      expect(textBlock.text).toContain(MARKER);
+    });
+
+    it("hard-clears text-only toolResult with text placeholder, no image placeholder", () => {
+      const largeText = MARKER + "\n" + "x".repeat(4_000);
+      const messages: AgentMessage[] = [
+        makeUser("summarize this"),
+        makeToolResult([{ type: "text", text: largeText }]),
+        makeAssistant([{ type: "text", text: "done" }]),
+      ];
+
+      const placeholder = "[Old tool result content cleared]";
+      const result = pruneContextMessages({
+        messages,
+        settings: {
+          ...DEFAULT_CONTEXT_PRUNING_SETTINGS,
+          keepLastAssistants: 1,
+          softTrimRatio: 0,
+          hardClearRatio: 0,
+          minPrunableToolChars: 1,
+          softTrim: {
+            maxChars: 5_000,
+            headChars: 2_000,
+            tailChars: 2_000,
+          },
+          hardClear: {
+            enabled: true,
+            placeholder,
+          },
+        },
+        ctx: CONTEXT_WINDOW_1M,
+        isToolPrunable: () => true,
+        contextWindowTokensOverride: 8,
+      });
+
+      const toolResult = result[1] as Extract<AgentMessage, { role: "toolResult" }>;
+      expect(toolResult.content).toEqual([{ type: "text", text: placeholder }]);
+
+      // Confirm the placeholder is text-based, not image/attachment
+      const textBlock = toolResult.content[0] as { type: "text"; text: string };
+      expect(textBlock.text).not.toContain("(see attached image)");
+      expect(textBlock.text).not.toContain("image_url");
+    });
+  });
 });

--- a/src/agents/openai-transport-stream.test.ts
+++ b/src/agents/openai-transport-stream.test.ts
@@ -2,7 +2,7 @@
 import { createServer } from "node:http";
 import OpenAI from "openai";
 import type { ChatCompletionChunk } from "openai/resources/chat/completions.js";
-import type { Api, Model } from "openclaw/plugin-sdk/llm";
+import type { Api, AssistantMessage, Model, ToolResultMessage } from "openclaw/plugin-sdk/llm";
 import { describe, expect, it, vi } from "vitest";
 import {
   classifyAssistantFailoverReason,
@@ -926,35 +926,36 @@ describe("openai transport stream", () => {
     const previous = process.env.OPENCLAW_DEBUG_MODEL_PAYLOAD;
     process.env.OPENCLAW_DEBUG_MODEL_PAYLOAD = "full-redacted";
     try {
+      const model = createNativeResponsesModel();
+      const assistantMessage = {
+        ...createResponsesAssistantOutput(model as never),
+        content: [
+          {
+            type: "toolCall",
+            id: "call_1|fc_1",
+            name: "exec",
+            arguments: {},
+          },
+        ],
+        timestamp: 1,
+      } as AssistantMessage;
+      const toolResultMessage: ToolResultMessage = {
+        role: "toolResult",
+        toolCallId: "call_1|fc_1",
+        toolName: "exec",
+        content: [{ type: "text", text: "OC99241_TEXT_ONLY_MARKER" }],
+        isError: false,
+        timestamp: 2,
+      };
       const params = buildOpenAIResponsesParams(
-        createNativeResponsesModel() as Model,
+        model as Model,
         {
           systemPrompt: "system",
-          messages: [
-            {
-              role: "assistant",
-              content: [
-                {
-                  type: "toolCall",
-                  id: "call_1|fc_1",
-                  name: "exec",
-                  arguments: {},
-                },
-              ],
-              timestamp: 1,
-            },
-            {
-              role: "toolResult",
-              toolCallId: "call_1|fc_1",
-              toolName: "exec",
-              content: [{ type: "text", text: "OC99241_TEXT_ONLY_MARKER" }],
-              timestamp: 2,
-            },
-          ],
+          messages: [assistantMessage, toolResultMessage],
           tools: [],
         },
         {},
-      ) as { input?: Array<Record<string, unknown>> };
+      ) as unknown as { input?: Array<Record<string, unknown>> };
       const summary = testing.summarizeResponsesPayload(params);
       expect(summary).toContain("payload=");
       expect(summary).toContain("OC99241_TEXT_ONLY_MARKER");
@@ -12234,9 +12235,17 @@ describe("buildOpenAICompletionsParams sanitizes reasoning replay fields", () =>
       ) as { messages: unknown[] };
 
       // Find the tool result message in the converted output.
-      const toolMsg = params.messages.find((m: any) => m.role === "tool" && m.content === MARKER);
+      const toolMsg = params.messages.find(
+        (m): m is { role: string; content: string } =>
+          typeof m === "object" &&
+          m !== null &&
+          "role" in m &&
+          (m as { role?: unknown }).role === "tool" &&
+          "content" in m &&
+          (m as { content?: unknown }).content === MARKER,
+      );
       expect(toolMsg).toBeDefined();
-      expect(toolMsg.content).toBe(MARKER);
+      expect(toolMsg?.content).toBe(MARKER);
       const serializedPayload = JSON.stringify(params);
       expect(serializedPayload).toContain(MARKER);
 

--- a/src/agents/openai-transport-stream.test.ts
+++ b/src/agents/openai-transport-stream.test.ts
@@ -863,11 +863,36 @@ describe("openai transport stream", () => {
     }
   });
 
+  it("does not traverse Chat Completions payload diagnostics when payload debug is off", () => {
+    const previous = process.env.OPENCLAW_DEBUG_MODEL_PAYLOAD;
+    delete process.env.OPENCLAW_DEBUG_MODEL_PAYLOAD;
+    try {
+      const params = {
+        model: "gpt-5.5",
+        stream: true,
+        get messages(): unknown {
+          throw new Error("messages getter should not be evaluated when payload debug is off");
+        },
+        get tools(): unknown {
+          throw new Error("tools getter should not be evaluated when payload debug is off");
+        },
+      };
+
+      expect(testing.formatCompletionsPayloadDebugSummary(params)).toBe("");
+    } finally {
+      if (previous === undefined) {
+        delete process.env.OPENCLAW_DEBUG_MODEL_PAYLOAD;
+      } else {
+        process.env.OPENCLAW_DEBUG_MODEL_PAYLOAD = previous;
+      }
+    }
+  });
+
   it("redacts full Chat Completions payload debug summaries", () => {
     const previous = process.env.OPENCLAW_DEBUG_MODEL_PAYLOAD;
     process.env.OPENCLAW_DEBUG_MODEL_PAYLOAD = "full-redacted";
     try {
-      const summary = testing.summarizeCompletionsPayload({
+      const summary = testing.formatCompletionsPayloadDebugSummary({
         model: "gpt-5.5",
         stream: true,
         messages: [
@@ -883,6 +908,8 @@ describe("openai transport stream", () => {
         apiKey: "sk-abcdefghijklmnopqrstuvwxyz",
       });
       expect(summary).toContain("payload=");
+      // full-redacted is for short-lived local diagnostics only: secret-like
+      // values are redacted/capped, but prompt/message/tool-result text remains.
       expect(summary).toContain("OC99241_TEXT_ONLY_MARKER");
       expect(summary).toContain("sk-abc");
       expect(summary).not.toContain("sk-abcdefghijklmnopqrstuvwxyz");

--- a/src/agents/openai-transport-stream.test.ts
+++ b/src/agents/openai-transport-stream.test.ts
@@ -11970,4 +11970,212 @@ describe("buildOpenAICompletionsParams sanitizes reasoning replay fields", () =>
 
     expect(resolved.requiresReasoningContentOnAssistantMessages).toBe(false);
   });
+
+  // issue #99241: text-only toolResult content must survive the provider-boundary
+  // transform without being replaced by image/attachment placeholders.
+  describe("issue #99241 – text-only toolResult provider boundary preservation", () => {
+    const MARKER = "EXACT_TOOL_TEXT_99241_BOUNDARY";
+
+    const responsesModel = {
+      id: "gpt-5.5",
+      name: "GPT-5.5",
+      api: "openai-responses",
+      provider: "openai",
+      baseUrl: "https://api.openai.com/v1",
+      reasoning: true,
+      input: ["text"],
+      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+      contextWindow: 200000,
+      maxTokens: 8192,
+    } satisfies Model<"openai-responses">;
+
+    const completionsModel = {
+      id: "deepseek-v4-pro",
+      name: "DeepSeek V4 Pro",
+      api: "openai-completions",
+      provider: "deepseek",
+      baseUrl: "https://api.deepseek.com",
+      reasoning: true,
+      input: ["text"],
+      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+      contextWindow: 1_000_000,
+      maxTokens: 384_000,
+    } satisfies Model<"openai-completions">;
+
+    it("preserves text-only toolResult in Responses function_call_output", () => {
+      const params = buildOpenAIResponsesParams(
+        responsesModel,
+        {
+          systemPrompt: "system",
+          messages: [
+            {
+              role: "assistant",
+              api: "openai-responses" as const,
+              provider: "openai",
+              model: "gpt-5.5",
+              usage: {
+                input: 0,
+                output: 0,
+                cacheRead: 0,
+                cacheWrite: 0,
+                totalTokens: 0,
+                cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+              },
+              stopReason: "toolUse" as const,
+              timestamp: 1,
+              content: [
+                {
+                  type: "toolCall",
+                  id: "call_99241",
+                  name: "read_file",
+                  arguments: { path: "/tmp/test.txt" },
+                },
+              ],
+            },
+            {
+              role: "toolResult",
+              toolCallId: "call_99241",
+              toolName: "read_file",
+              content: [{ type: "text", text: MARKER }],
+              isError: false,
+              timestamp: 2,
+            },
+            { role: "user", content: "summarize", timestamp: 3 },
+          ],
+          tools: [],
+        } as never,
+        undefined,
+      ) as {
+        input?: Array<{ type?: string; call_id?: string; output?: unknown }>;
+      };
+
+      const output = params.input?.find((item) => item.type === "function_call_output");
+      expect(output).toBeDefined();
+
+      // The marker text must be present in the serialized output
+      const outputText = output?.output as string;
+      expect(typeof outputText).toBe("string");
+      expect(outputText).toContain(MARKER);
+
+      // Must NOT contain any image/attachment placeholder text
+      expect(outputText).not.toContain("(see attached image)");
+      expect(outputText).not.toContain("Attached image(s) from tool result:");
+      expect(outputText).not.toContain("image_url");
+    });
+
+    it("preserves text-only toolResult in Completions messages", () => {
+      const params = buildOpenAICompletionsParams(
+        completionsModel,
+        {
+          systemPrompt: "system",
+          messages: [
+            {
+              role: "assistant",
+              api: "openai-completions" as const,
+              provider: "deepseek",
+              model: "deepseek-v4-pro",
+              usage: {
+                input: 0,
+                output: 0,
+                cacheRead: 0,
+                cacheWrite: 0,
+                totalTokens: 0,
+                cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+              },
+              stopReason: "toolUse" as const,
+              timestamp: 1,
+              content: [
+                {
+                  type: "toolCall",
+                  id: "call_99241",
+                  name: "read_file",
+                  arguments: { path: "/tmp/test.txt" },
+                },
+              ],
+            },
+            {
+              role: "toolResult",
+              toolCallId: "call_99241",
+              toolName: "read_file",
+              content: [{ type: "text", text: MARKER }],
+              isError: false,
+              timestamp: 2,
+            },
+            { role: "user", content: "summarize", timestamp: 3 },
+          ],
+          tools: [],
+        } as never,
+        undefined,
+      ) as { messages: unknown[] };
+
+      // Find the tool result message in the converted output
+      const toolMsg = params.messages.find((m: any) => m.role === "tool" && m.content === MARKER);
+      expect(toolMsg).toBeDefined();
+      expect(toolMsg.content).toBe(MARKER);
+
+      // Must NOT contain any image/attachment placeholder text
+      expect(toolMsg.content).not.toContain("(see attached image)");
+      expect(toolMsg.content).not.toContain("Attached image(s) from tool result:");
+      expect(toolMsg.content).not.toContain("image_url");
+    });
+
+    it("does not inject image placeholders for text-only toolResult even with mixed content models", () => {
+      // Model supports images but toolResult is text-only
+      const params = buildOpenAIResponsesParams(
+        { ...responsesModel, input: ["text", "image"] },
+        {
+          systemPrompt: "system",
+          messages: [
+            {
+              role: "assistant",
+              api: "openai-responses" as const,
+              provider: "openai",
+              model: "gpt-5.5",
+              usage: {
+                input: 0,
+                output: 0,
+                cacheRead: 0,
+                cacheWrite: 0,
+                totalTokens: 0,
+                cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+              },
+              stopReason: "toolUse" as const,
+              timestamp: 1,
+              content: [
+                {
+                  type: "toolCall",
+                  id: "call_99241b",
+                  name: "web_search",
+                  arguments: { query: "test" },
+                },
+              ],
+            },
+            {
+              role: "toolResult",
+              toolCallId: "call_99241b",
+              toolName: "web_search",
+              content: [{ type: "text", text: MARKER }],
+              isError: false,
+              timestamp: 2,
+            },
+            { role: "user", content: "done", timestamp: 3 },
+          ],
+          tools: [],
+        } as never,
+        undefined,
+      ) as {
+        input?: Array<{ type?: string; call_id?: string; output?: unknown }>;
+      };
+
+      const output = params.input?.find((item) => item.type === "function_call_output");
+      expect(output).toBeDefined();
+
+      const outputText = output?.output as string;
+      expect(typeof outputText).toBe("string");
+      expect(outputText).toContain(MARKER);
+      expect(outputText).not.toContain("(see attached image)");
+      expect(outputText).not.toContain("Attached image(s) from tool result:");
+      expect(outputText).not.toContain("input_image");
+    });
+  });
 });

--- a/src/agents/openai-transport-stream.test.ts
+++ b/src/agents/openai-transport-stream.test.ts
@@ -111,6 +111,21 @@ function createAzureResponsesModel(): Model<"azure-openai-responses"> {
   };
 }
 
+function createNativeResponsesModel(): Model<"openai-responses"> {
+  return {
+    id: "gpt-5.5",
+    name: "GPT-5.5",
+    api: "openai-responses",
+    provider: "openai",
+    baseUrl: "https://api.openai.com/v1",
+    reasoning: true,
+    input: ["text"],
+    cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+    contextWindow: 200_000,
+    maxTokens: 8192,
+  };
+}
+
 function neverYieldsStream(): AsyncIterable<unknown> {
   // Simulates an HTTP stream that opened but never delivered the first SSE event.
   return {
@@ -839,6 +854,85 @@ describe("openai transport stream", () => {
       expect(summary).toContain("payload=");
       expect(summary).toContain("sk-abc");
       expect(summary).not.toContain("sk-abcdefghijklmnopqrstuvwxyz");
+    } finally {
+      if (previous === undefined) {
+        delete process.env.OPENCLAW_DEBUG_MODEL_PAYLOAD;
+      } else {
+        process.env.OPENCLAW_DEBUG_MODEL_PAYLOAD = previous;
+      }
+    }
+  });
+
+  it("redacts full Chat Completions payload debug summaries", () => {
+    const previous = process.env.OPENCLAW_DEBUG_MODEL_PAYLOAD;
+    process.env.OPENCLAW_DEBUG_MODEL_PAYLOAD = "full-redacted";
+    try {
+      const summary = testing.summarizeCompletionsPayload({
+        model: "gpt-5.5",
+        stream: true,
+        messages: [
+          {
+            role: "assistant",
+            tool_calls: [
+              { id: "call_1", type: "function", function: { name: "exec", arguments: "{}" } },
+            ],
+          },
+          { role: "tool", tool_call_id: "call_1", content: "OC99241_TEXT_ONLY_MARKER" },
+        ],
+        tools: [{ type: "function", function: { name: "exec" } }],
+        apiKey: "sk-abcdefghijklmnopqrstuvwxyz",
+      });
+      expect(summary).toContain("payload=");
+      expect(summary).toContain("OC99241_TEXT_ONLY_MARKER");
+      expect(summary).toContain("sk-abc");
+      expect(summary).not.toContain("sk-abcdefghijklmnopqrstuvwxyz");
+    } finally {
+      if (previous === undefined) {
+        delete process.env.OPENCLAW_DEBUG_MODEL_PAYLOAD;
+      } else {
+        process.env.OPENCLAW_DEBUG_MODEL_PAYLOAD = previous;
+      }
+    }
+  });
+
+  it("includes text-only tool results in redacted Responses payload debug summaries", () => {
+    const previous = process.env.OPENCLAW_DEBUG_MODEL_PAYLOAD;
+    process.env.OPENCLAW_DEBUG_MODEL_PAYLOAD = "full-redacted";
+    try {
+      const params = buildOpenAIResponsesParams(
+        createNativeResponsesModel() as Model,
+        {
+          systemPrompt: "system",
+          messages: [
+            {
+              role: "assistant",
+              content: [
+                {
+                  type: "toolCall",
+                  id: "call_1|fc_1",
+                  name: "exec",
+                  arguments: {},
+                },
+              ],
+              timestamp: 1,
+            },
+            {
+              role: "toolResult",
+              toolCallId: "call_1|fc_1",
+              toolName: "exec",
+              content: [{ type: "text", text: "OC99241_TEXT_ONLY_MARKER" }],
+              timestamp: 2,
+            },
+          ],
+          tools: [],
+        },
+        {},
+      ) as { input?: Array<Record<string, unknown>> };
+      const summary = testing.summarizeResponsesPayload(params);
+      expect(summary).toContain("payload=");
+      expect(summary).toContain("OC99241_TEXT_ONLY_MARKER");
+      expect(summary).not.toContain("attached image");
+      expect(summary).not.toContain("attached media");
     } finally {
       if (previous === undefined) {
         delete process.env.OPENCLAW_DEBUG_MODEL_PAYLOAD;
@@ -12052,15 +12146,19 @@ describe("buildOpenAICompletionsParams sanitizes reasoning replay fields", () =>
       const output = params.input?.find((item) => item.type === "function_call_output");
       expect(output).toBeDefined();
 
-      // The marker text must be present in the serialized output
+      // The marker text must be present in the serialized provider payload.
       const outputText = output?.output as string;
       expect(typeof outputText).toBe("string");
+      const serializedPayload = JSON.stringify(params);
       expect(outputText).toContain(MARKER);
+      expect(serializedPayload).toContain(MARKER);
 
-      // Must NOT contain any image/attachment placeholder text
-      expect(outputText).not.toContain("(see attached image)");
-      expect(outputText).not.toContain("Attached image(s) from tool result:");
-      expect(outputText).not.toContain("image_url");
+      // Text-only tool results must not acquire media placeholders or image fields.
+      expect(serializedPayload).not.toContain("attached");
+      expect(serializedPayload).not.toContain("attachments");
+      expect(serializedPayload).not.toContain("image_url");
+      expect(serializedPayload).not.toContain("input_image");
+      expect(serializedPayload).not.toContain("data:image/");
     });
 
     it("preserves text-only toolResult in Completions messages", () => {
@@ -12108,15 +12206,19 @@ describe("buildOpenAICompletionsParams sanitizes reasoning replay fields", () =>
         undefined,
       ) as { messages: unknown[] };
 
-      // Find the tool result message in the converted output
+      // Find the tool result message in the converted output.
       const toolMsg = params.messages.find((m: any) => m.role === "tool" && m.content === MARKER);
       expect(toolMsg).toBeDefined();
       expect(toolMsg.content).toBe(MARKER);
+      const serializedPayload = JSON.stringify(params);
+      expect(serializedPayload).toContain(MARKER);
 
-      // Must NOT contain any image/attachment placeholder text
-      expect(toolMsg.content).not.toContain("(see attached image)");
-      expect(toolMsg.content).not.toContain("Attached image(s) from tool result:");
-      expect(toolMsg.content).not.toContain("image_url");
+      // Text-only tool results must not acquire media placeholders or image fields.
+      expect(serializedPayload).not.toContain("attached");
+      expect(serializedPayload).not.toContain("attachments");
+      expect(serializedPayload).not.toContain("image_url");
+      expect(serializedPayload).not.toContain("input_image");
+      expect(serializedPayload).not.toContain("data:image/");
     });
 
     it("does not inject image placeholders for text-only toolResult even with mixed content models", () => {
@@ -12172,10 +12274,14 @@ describe("buildOpenAICompletionsParams sanitizes reasoning replay fields", () =>
 
       const outputText = output?.output as string;
       expect(typeof outputText).toBe("string");
+      const serializedPayload = JSON.stringify(params);
       expect(outputText).toContain(MARKER);
-      expect(outputText).not.toContain("(see attached image)");
-      expect(outputText).not.toContain("Attached image(s) from tool result:");
-      expect(outputText).not.toContain("input_image");
+      expect(serializedPayload).toContain(MARKER);
+      expect(serializedPayload).not.toContain("attached");
+      expect(serializedPayload).not.toContain("attachments");
+      expect(serializedPayload).not.toContain("image_url");
+      expect(serializedPayload).not.toContain("input_image");
+      expect(serializedPayload).not.toContain("data:image/");
     });
   });
 });

--- a/src/agents/openai-transport-stream.ts
+++ b/src/agents/openai-transport-stream.ts
@@ -793,6 +793,46 @@ function summarizeResponsesPayload(params: unknown): string {
   return parts.join(" ");
 }
 
+function summarizeCompletionsPayload(
+  params: unknown,
+  mode: ReturnType<typeof resolveModelPayloadDebugMode> = resolveModelPayloadDebugMode(),
+): string {
+  if (!params || typeof params !== "object") {
+    return "payload=non-object";
+  }
+  const record = params as Record<string, unknown>;
+  const messages = record.messages;
+  const parts = [
+    `fields=${Object.keys(record).toSorted().join(",")}`,
+    `model=${safeDebugValue(record.model)}`,
+    `stream=${safeDebugValue(record.stream)}`,
+    `messageItems=${Array.isArray(messages) ? messages.length : typeof messages}`,
+    `messageRoles=${responseInputRoles(messages) || "none"}`,
+    `messageTextChars=${responseInputTextChars(messages)}`,
+    `tools=${summarizeResponsesTools(record.tools)}`,
+    `toolChoice=${safeDebugValue(record.tool_choice)}`,
+    `reasoningEffort=${safeDebugValue(record.reasoning_effort)}`,
+    `maxTokens=${safeDebugValue(record.max_tokens)}`,
+    `maxCompletionTokens=${safeDebugValue(record.max_completion_tokens)}`,
+  ];
+  if (mode === "full-redacted") {
+    // Short-lived local diagnostics only: redaction/capping protects secrets but
+    // intentionally leaves prompt, message, and tool-result text visible.
+    parts.push(`payload=${stringifyRedactedPayload(record)}`);
+  }
+  return parts.join(" ");
+}
+
+function formatCompletionsPayloadDebugSummary(
+  params: unknown,
+  mode: ReturnType<typeof resolveModelPayloadDebugMode> = resolveModelPayloadDebugMode(),
+): string {
+  if (mode === "off") {
+    return "";
+  }
+  return ` ${summarizeCompletionsPayload(params, mode)}`;
+}
+
 function summarizeOpenAITransportError(error: unknown): string {
   if (!error || typeof error !== "object") {
     return `type=${typeof error} message=${safeDebugValue(error)}`;
@@ -2777,11 +2817,28 @@ export function createOpenAICompletionsTransportStreamFn(): StreamFn {
           model as OpenAIModeModel,
           options as OpenAICompletionsOptions | undefined,
         );
+        const requestStartedAt = Date.now();
         firstEventAbort = createFirstStreamEventAbortController(options?.signal);
+        const requestOptions = buildOpenAISdkRequestOptions(model, firstEventAbort.signal);
+        const payloadDebugMode = resolveModelPayloadDebugMode();
+        emitModelTransportDebug(
+          log,
+          `[completions] start provider=${model.provider} api=${model.api} model=${model.id} ` +
+            `baseUrl=${formatModelTransportDebugBaseUrl(model.baseUrl)} timeoutMs=${safeDebugValue(requestOptions?.timeout)} ` +
+            `apiKey=${apiKey ? "present" : "missing"}${formatCompletionsPayloadDebugSummary(
+              params,
+              payloadDebugMode,
+            )}`,
+        );
         const responseStream = (await client.chat.completions.create(
           params as never,
-          buildOpenAISdkRequestOptions(model, firstEventAbort.signal),
+          requestOptions,
         )) as unknown as AsyncIterable<ChatCompletionChunk>;
+        emitModelTransportDebug(
+          log,
+          `[completions] headers provider=${model.provider} api=${model.api} model=${model.id} ` +
+            `elapsedMs=${Date.now() - requestStartedAt}`,
+        );
         stream.push({ type: "start", partial: output as never });
         await processOpenAICompletionsStream(responseStream, output, model, stream, {
           signal: options?.signal,
@@ -4511,6 +4568,8 @@ export const testing = {
   tagOpenAIResponsesReasoningReplayItem,
   summarizeResponsesFailedNoDetailsObservation,
   summarizeResponsesPayload,
+  formatCompletionsPayloadDebugSummary,
+  summarizeCompletionsPayload,
   summarizeResponsesTools,
 };
 export { testing as __testing };

--- a/ui/src/ui/chat/grouped-render.test.ts
+++ b/ui/src/ui/chat/grouped-render.test.ts
@@ -1205,6 +1205,82 @@ describe("grouped chat rendering", () => {
     ]);
   });
 
+  it("renders text-only standalone tool results as text, not an image placeholder", () => {
+    const container = document.createElement("div");
+    renderMessageGroups(
+      container,
+      [
+        createMessageGroup(
+          {
+            id: "tool-plain-text-probe",
+            role: "toolResult",
+            toolCallId: "call_plain_text_probe",
+            toolName: "exec",
+            content: [{ type: "text", text: "PLAIN_TEXT_PROBE_1841" }],
+            timestamp: Date.now(),
+          },
+          "tool",
+        ),
+      ],
+      {
+        isToolMessageExpanded: () => true,
+      },
+    );
+
+    expect(container.textContent).toContain("PLAIN_TEXT_PROBE_1841");
+    expect(container.textContent).not.toContain("(see attached image)");
+    expect(container.querySelector(".chat-message-image")).toBeNull();
+  });
+
+  it("keeps image-only standalone tool results media-only while mixed results show text", () => {
+    const container = document.createElement("div");
+    renderMessageGroups(
+      container,
+      [
+        createMessageGroup(
+          {
+            id: "tool-image-only-probe",
+            role: "toolResult",
+            toolCallId: "call_image_only_probe",
+            toolName: "screenshot",
+            content: [
+              {
+                type: "image",
+                source: { type: "base64", media_type: "image/png", data: "AAAA" },
+              },
+            ],
+            timestamp: Date.now(),
+          },
+          "tool",
+        ),
+        createMessageGroup(
+          {
+            id: "tool-mixed-probe",
+            role: "toolResult",
+            toolCallId: "call_mixed_probe",
+            toolName: "screenshot",
+            content: [
+              { type: "text", text: "Screenshot captured" },
+              {
+                type: "image",
+                source: { type: "base64", media_type: "image/png", data: "AAAA" },
+              },
+            ],
+            timestamp: Date.now() + 1,
+          },
+          "tool",
+        ),
+      ],
+      {
+        isToolMessageExpanded: () => true,
+      },
+    );
+
+    expect(container.textContent).not.toContain("(see attached image)");
+    expect(container.textContent).toContain("Screenshot captured");
+    expect(container.querySelectorAll("img")).toHaveLength(2);
+  });
+
   it("renders expanded standalone tool-call rows", () => {
     const container = document.createElement("div");
     const message = {

--- a/ui/src/ui/chat/message-extract.test.ts
+++ b/ui/src/ui/chat/message-extract.test.ts
@@ -148,4 +148,15 @@ describe("extractThinkingCached", () => {
     expect(extractThinkingCached(message)).toBe("Plan A");
     expect(extractThinkingCached(message)).toBe("Plan A");
   });
+
+  it("extracts text-only tool result content without media placeholders", () => {
+    const text = extractText({
+      role: "toolResult",
+      toolCallId: "call_probe",
+      content: [{ type: "text", text: "PLAIN_TEXT_PROBE_1841" }],
+    });
+
+    expect(text).toBe("PLAIN_TEXT_PROBE_1841");
+    expect(text).not.toBe("(see attached image)");
+  });
 });

--- a/ui/src/ui/chat/message-normalizer.test.ts
+++ b/ui/src/ui/chat/message-normalizer.test.ts
@@ -452,6 +452,25 @@ describe("message-normalizer", () => {
       ]);
     });
 
+    it("preserves text-only tool result content arrays as renderable text", () => {
+      const result = normalizeMessage({
+        role: "assistant",
+        toolCallId: "call_probe",
+        toolName: "exec",
+        content: [{ type: "text", text: "PLAIN_TEXT_PROBE_1841" }],
+      });
+
+      expect(result.role).toBe("toolResult");
+      expect(result.content).toEqual([
+        {
+          type: "text",
+          text: "PLAIN_TEXT_PROBE_1841",
+          name: undefined,
+          args: undefined,
+        },
+      ]);
+    });
+
     it("detects tool result by toolCallId", () => {
       const result = normalizeMessage({
         role: "assistant",

--- a/ui/src/ui/chat/tool-cards.test.ts
+++ b/ui/src/ui/chat/tool-cards.test.ts
@@ -4,6 +4,7 @@ import { render } from "lit";
 import { describe, expect, it, vi } from "vitest";
 import {
   formatCollapsedToolPreviewText,
+  extractToolCards,
   formatCollapsedToolSummaryText,
   isToolErrorOutput,
   renderToolCard,
@@ -26,6 +27,38 @@ function requireFirstMockArg(
 }
 
 describe("tool-cards", () => {
+  it("extracts text-only and mixed tool result output without image placeholders", () => {
+    const textOnly = extractToolCards({
+      role: "toolResult",
+      toolCallId: "call_text",
+      toolName: "exec",
+      content: [{ type: "text", text: "PLAIN_TEXT_PROBE_1841" }],
+    });
+    const imageOnly = extractToolCards({
+      role: "toolResult",
+      toolCallId: "call_image",
+      toolName: "image",
+      content: [{ type: "image", source: { type: "base64", data: "AAAA" } }],
+    });
+    const mixed = extractToolCards({
+      role: "toolResult",
+      toolCallId: "call_mixed",
+      toolName: "image",
+      content: [
+        { type: "text", text: "Screenshot captured" },
+        { type: "image", source: { type: "base64", data: "AAAA" } },
+      ],
+    });
+
+    expect(textOnly).toHaveLength(1);
+    expect(textOnly[0]?.outputText).toBe("PLAIN_TEXT_PROBE_1841");
+    expect(textOnly[0]?.outputText).not.toBe("(see attached image)");
+    expect(imageOnly).toHaveLength(1);
+    expect(imageOnly[0]?.outputText).toBeUndefined();
+    expect(mixed).toHaveLength(1);
+    expect(mixed[0]?.outputText).toBe("Screenshot captured");
+  });
+
   it("renders expanded cards with inline input and output sections", () => {
     const container = document.createElement("div");
     const toggle = vi.fn();


### PR DESCRIPTION
Refs #99241.

## Summary

This PR adds supplemental UI regression coverage for the invariant that text-only WebChat tool results remain renderable as text and are not treated as image/media content.

This is **not** a complete fix for #99241. A newer runtime observation suggests the remaining failure may be in the model-visible tool-result / prompt serialization path, not only the WebChat render path: WebChat can display `PLAIN_TEXT_PROBE_1841` correctly while the model may still report seeing an attachment placeholder.

## What this covers

The tests cover the text-only tool-result path across:

- message extraction
- message normalization
- tool-card extraction
- grouped WebChat rendering

They assert that a text-only tool result containing `PLAIN_TEXT_PROBE_1841` remains visible as text and is not rendered as media.

## What this does not claim

This PR does not claim to fix the broader canonical issue in #99241. It only protects the UI text-only invariant and helps narrow the remaining investigation.

## Runtime observation

In an affected WebChat session:

- The UI displayed the text-only tool result `PLAIN_TEXT_PROBE_1841` normally when expanded.
- The model nevertheless reported that the tool result was replaced by an attachment placeholder and could not be read.
- This suggests the canonical issue may involve the model-visible payload path, transcript-to-prompt conversion, or provider serialization/replay, rather than only WebChat rendering.

## Tests

- `LC_ALL=C.UTF-8 LANG=C.UTF-8 npm --prefix ui test -- src/ui/chat/message-extract.test.ts src/ui/chat/message-normalizer.test.ts src/ui/chat/tool-cards.test.ts src/ui/chat/grouped-render.test.ts`

Result: 4 test files passed, 141 tests passed.

## What Problem This Solves

This PR adds supplemental regression coverage and default-off diagnostics for #99241: text-only tool results must remain visible as text across WebChat rendering and OpenAI provider-bound payload construction. It does not claim to fully fix the canonical issue yet; it preserves evidence and tooling needed to distinguish UI rendering, context replay/compaction, provider serialization, and model/context confusion.

## Evidence

- UI regression tests cover text-only tool results in message extraction, normalization, tool cards, and grouped rendering.
- Provider-boundary tests cover OpenAI Responses and Chat Completions payload construction, asserting text-only tool results preserve the marker and do not become attachment/image artifacts.
- Context-pruning tests cover soft trim and hard clear behavior for text-only tool results.
- Local gates passed before updating this PR branch: UI chat tests, OpenAI transport targeted/full tests, context-pruning targeted tests, and `pnpm check:test-types`.
- The remaining #99241 root-cause work is to capture a live provider-visible payload during an affected long conversation and compare it with session JSONL, trajectory/cache trace, and WebChat UI evidence.
