### PR TITLE
fix(discord): prevent approval command previews from splitting emoji when truncated

### DIFF
--- a/extensions/discord/src/approval-handler.runtime.test.ts
+++ b/extensions/discord/src/approval-handler.runtime.test.ts
@@ -2,7 +2,54 @@
 import { describe, expect, it } from "vitest";
 import { discordApprovalNativeRuntime } from "./approval-handler.runtime.js";
 
+async function buildExecApprovalPayloadText(commandText: string): Promise<string> {
+  const pending = await discordApprovalNativeRuntime.presentation.buildPendingPayload({
+    cfg: {} as never,
+    accountId: "main",
+    context: {
+      token: "discord-token",
+      config: {} as never,
+    },
+    request: {
+      id: "approval-1",
+      request: {
+        command: commandText,
+      },
+      createdAtMs: 0,
+      expiresAtMs: 1_000,
+    },
+    approvalKind: "exec",
+    nowMs: 0,
+    view: {
+      approvalKind: "exec",
+      phase: "pending",
+      approvalId: "approval-1",
+      title: "Exec Approval Required",
+      commandText,
+      commandPreview: null,
+      expiresAtMs: 1_000,
+      metadata: [],
+      actions: [
+        {
+          label: "Allow",
+          decision: "allow-once",
+          style: "success",
+          command: "/approve approval-1 allow-once",
+        },
+      ],
+    },
+  });
+  return JSON.stringify(pending);
+}
+
 describe("discordApprovalNativeRuntime", () => {
+  it("does not split emoji graphemes when truncating exec command previews", async () => {
+    const prefix = "a".repeat(999);
+
+    await expect(buildExecApprovalPayloadText(`${prefix}😀x`)).resolves.toContain(`${prefix}...`);
+    await expect(buildExecApprovalPayloadText(`${prefix}🇺🇸x`)).resolves.toContain(`${prefix}...`);
+  });
+
   it("routes origin approval updates to the Discord thread channel when threadId is present", async () => {
     const prepared = await discordApprovalNativeRuntime.transport.prepareTarget({
       cfg: {} as never,

--- a/extensions/discord/src/approval-handler.runtime.ts
+++ b/extensions/discord/src/approval-handler.runtime.ts
@@ -159,10 +159,38 @@ function buildExecApprovalPayload(container: DiscordUiContainer): MessagePayload
   return { components };
 }
 
+const commandPreviewSegmenter =
+  typeof Intl !== "undefined" && "Segmenter" in Intl
+    ? new Intl.Segmenter(undefined, { granularity: "grapheme" })
+    : null;
+
+function* iterateCommandPreviewSegments(commandText: string): Iterable<string> {
+  if (!commandPreviewSegmenter) {
+    yield* Array.from(commandText);
+    return;
+  }
+  try {
+    for (const segment of commandPreviewSegmenter.segment(commandText)) {
+      yield segment.segment;
+    }
+  } catch {
+    yield* Array.from(commandText);
+  }
+}
+
+function truncateCommandPreview(commandText: string, maxChars: number): string {
+  let commandRaw = "";
+  for (const segment of iterateCommandPreviewSegments(commandText)) {
+    if (commandRaw.length + segment.length > maxChars) {
+      return `${commandRaw}...`;
+    }
+    commandRaw += segment;
+  }
+  return commandText;
+}
+
 function formatCommandPreview(commandText: string, maxChars: number): string {
-  const commandRaw =
-    commandText.length > maxChars ? `${commandText.slice(0, maxChars)}...` : commandText;
-  return commandRaw.replace(/`/g, "\u200b`");
+  return truncateCommandPreview(commandText, maxChars).replace(/`/g, "\u200b`");
 }
 
 function formatOptionalCommandPreview(


### PR DESCRIPTION
Related: problem-mode user report; no public issue number

## What Problem This Solves

Fixes an issue where Discord approval command previews could split emoji characters when a long command was truncated exactly at an emoji boundary. The broken preview could render a replacement character or a partial emoji instead of preserving readable Discord text.

## Why This Change Was Made

Discord approval previews now truncate command text on grapheme boundaries while preserving the existing preview length budget and backtick escaping behavior. The truncation stops as soon as the next grapheme would exceed the budget, so long commands do not need to be expanded into a full character array.

## User Impact

Users reviewing long command approvals in Discord will see stable previews that do not contain half emoji, lone surrogate replacement characters, or partial flag emoji when truncation occurs.

## Evidence

Base checked: origin/main 0cc9927577c6663a5839a4d2ad3e5708df04157a still used raw UTF-16 `.slice(0, maxChars)` for Discord command previews.

Before-fix proof on the old truncation logic:

```text
"aaaa\\ud83d..."
true
```

After-fix runtime proof through the Discord approval presentation payload:

```text
single emoji boundary keeps budget and appends ellipsis: true
single emoji boundary has lone surrogate escape: false
flag emoji boundary keeps budget and appends ellipsis: true
flag emoji boundary has partial regional indicator: false
```

Live Discord message rendering proof after this patch:

```text
proof: live Discord message create/read/delete via Discord REST API
channelIdRedacted: xxxxxxxxxxxxxxx0484
messageCount: 2
allCasesPassed: true
single emoji boundary:
  discordMessageCreated: true
  discordMessageFetched: true
  componentTextDisplayFound: true
  oldSliceHadLoneSurrogate: true
  renderedPreviewEqualsExpected: true
  renderedPreviewEndsWithEllipsis: true
  renderedPreviewHasLoneSurrogate: false
  renderedPreviewContainsReplacementCharacter: false
  renderedPreviewContainsSingleEmoji: false
  renderedPreviewContainsFlagEmoji: false
  renderedPreviewLength: 1002
flag emoji boundary:
  discordMessageCreated: true
  discordMessageFetched: true
  componentTextDisplayFound: true
  oldSliceHadLoneSurrogate: true
  renderedPreviewEqualsExpected: true
  renderedPreviewEndsWithEllipsis: true
  renderedPreviewHasLoneSurrogate: false
  renderedPreviewContainsReplacementCharacter: false
  renderedPreviewContainsSingleEmoji: false
  renderedPreviewContainsFlagEmoji: false
  renderedPreviewLength: 1002
```

The live proof built the approval payload from this branch, posted it as real Discord Components V2 messages in a Discord test channel, fetched each message back from Discord, verified the rendered Command text display contained the expected truncated preview, and deleted the proof messages afterwards.

Regression and changed-file checks:

```text
node scripts/run-vitest.mjs extensions/discord/src/approval-handler.runtime.test.ts
Test Files  1 passed (1)
Tests  2 passed (2)

OPENCLAW_CHECK_CHANGED_REMOTE_CHILD=1 OPENCLAW_CHANGED_LANES_RAW_SYNC=1 CI=1 PNPM_CONFIG_VERIFY_DEPS_BEFORE_RUN=false corepack pnpm check:changed -- extensions/discord/src/approval-handler.runtime.ts extensions/discord/src/approval-handler.runtime.test.ts
check:changed passed
```