### PR TITLE
fix(memory): keep local embedding worker forks working after Homebrew Node upgrades

### DIFF
--- a/packages/memory-host-sdk/src/host/embeddings-worker-stale-execpath.test.ts
+++ b/packages/memory-host-sdk/src/host/embeddings-worker-stale-execpath.test.ts
@@ -1,0 +1,146 @@
+import { EventEmitter } from "node:events";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const forkMock = vi.hoisted(() => vi.fn());
+const accessMock = vi.hoisted(() => vi.fn());
+
+vi.mock("node:child_process", () => ({
+  fork: forkMock,
+}));
+
+vi.mock("node:fs/promises", () => ({
+  default: {
+    access: accessMock,
+  },
+}));
+
+function createMockChild() {
+  const child = new EventEmitter() as EventEmitter & {
+    connected: boolean;
+    killed: boolean;
+    send: (message: unknown, callback?: (err: Error | null) => void) => void;
+    disconnect: () => void;
+    kill: () => void;
+  };
+  child.connected = true;
+  child.killed = false;
+  child.disconnect = vi.fn(() => {
+    child.connected = false;
+  });
+  child.kill = vi.fn(() => {
+    child.killed = true;
+  });
+  child.send = vi.fn((message: unknown, callback?: (err: Error | null) => void) => {
+    callback?.(null);
+    const id = (message as { id?: number }).id;
+    queueMicrotask(() => {
+      child.emit("message", { id, ok: true });
+    });
+  });
+  return child;
+}
+
+async function importWorkerModule() {
+  return await import("./embeddings-worker.js");
+}
+
+describe("local embedding worker stable execPath", () => {
+  const originalExecPath = process.execPath;
+
+  beforeEach(() => {
+    vi.resetModules();
+    forkMock.mockReset();
+    accessMock.mockReset();
+  });
+
+  afterEach(() => {
+    process.execPath = originalExecPath;
+  });
+
+  it("passes the Homebrew opt symlink as fork execPath for Cellar Node paths", async () => {
+    process.execPath = "/opt/homebrew/Cellar/node/26.3.0/bin/node";
+    accessMock.mockImplementation(async (candidate: string) => {
+      if (candidate === "/opt/homebrew/opt/node/bin/node") {
+        return;
+      }
+      throw Object.assign(new Error("missing"), { code: "ENOENT" });
+    });
+    forkMock.mockReturnValue(createMockChild());
+    const { createLocalEmbeddingWorkerProvider } = await importWorkerModule();
+
+    const provider = await createLocalEmbeddingWorkerProvider(
+      { config: {} as never, provider: "local", model: "", fallback: "none" },
+      { workerScriptPath: "/tmp/embedding-worker.cjs" },
+    );
+
+    expect(forkMock).toHaveBeenCalledWith(
+      "/tmp/embedding-worker.cjs",
+      [],
+      expect.objectContaining({ execPath: "/opt/homebrew/opt/node/bin/node" }),
+    );
+    await provider.close?.();
+  });
+
+  it("falls back to the Homebrew bin symlink for the default node formula", async () => {
+    process.execPath = "/usr/local/Cellar/node/26.3.0/bin/node";
+    accessMock.mockImplementation(async (candidate: string) => {
+      if (candidate === "/usr/local/bin/node") {
+        return;
+      }
+      throw Object.assign(new Error("missing"), { code: "ENOENT" });
+    });
+    forkMock.mockReturnValue(createMockChild());
+    const { createLocalEmbeddingWorkerProvider } = await importWorkerModule();
+
+    const provider = await createLocalEmbeddingWorkerProvider(
+      { config: {} as never, provider: "local", model: "", fallback: "none" },
+      { workerScriptPath: "/tmp/embedding-worker.cjs" },
+    );
+
+    expect(forkMock).toHaveBeenCalledWith(
+      "/tmp/embedding-worker.cjs",
+      [],
+      expect.objectContaining({ execPath: "/usr/local/bin/node" }),
+    );
+    await provider.close?.();
+  });
+
+  it("keeps non-Cellar execPath unchanged", async () => {
+    process.execPath = "/usr/bin/node";
+    forkMock.mockReturnValue(createMockChild());
+    const { createLocalEmbeddingWorkerProvider } = await importWorkerModule();
+
+    const provider = await createLocalEmbeddingWorkerProvider(
+      { config: {} as never, provider: "local", model: "", fallback: "none" },
+      { workerScriptPath: "/tmp/embedding-worker.cjs" },
+    );
+
+    expect(forkMock).toHaveBeenCalledWith(
+      "/tmp/embedding-worker.cjs",
+      [],
+      expect.objectContaining({ execPath: "/usr/bin/node" }),
+    );
+    expect(accessMock).not.toHaveBeenCalled();
+    await provider.close?.();
+  });
+
+  it("does not send a request when the signal aborts while reusing the child", async () => {
+    process.execPath = "/usr/bin/node";
+    const child = createMockChild();
+    forkMock.mockReturnValue(child);
+    const { createLocalEmbeddingWorkerProvider } = await importWorkerModule();
+    const provider = await createLocalEmbeddingWorkerProvider(
+      { config: {} as never, provider: "local", model: "", fallback: "none" },
+      { workerScriptPath: "/tmp/embedding-worker.cjs" },
+    );
+    vi.mocked(child.send).mockClear();
+    const abortController = new AbortController();
+
+    const embedPromise = provider.embedQuery("cancelled", { signal: abortController.signal });
+    abortController.abort(new Error("cancelled before send"));
+
+    await expect(embedPromise).rejects.toThrow("cancelled before send");
+    expect(child.send).not.toHaveBeenCalled();
+    await provider.close?.();
+  });
+});

--- a/packages/memory-host-sdk/src/host/embeddings-worker.ts
+++ b/packages/memory-host-sdk/src/host/embeddings-worker.ts
@@ -1,5 +1,6 @@
 // Memory Host SDK module implements embeddings worker behavior.
 import { fork, type ChildProcess } from "node:child_process";
+import fs from "node:fs/promises";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { DEFAULT_LOCAL_MODEL } from "./embedding-defaults.js";
@@ -145,6 +146,48 @@ const WORKER_UNSAFE_EXEC_ARGV_OPTION_PREFIXES = [
 
 const WORKER_CLOSE_GRACE_MS = 250;
 
+let stableWorkerExecPathPromise: Promise<string> | null = null;
+
+/**
+ * Homebrew resolves process.execPath to the versioned Cellar binary, which can
+ * disappear after `brew upgrade`. Fork workers via stable symlinks when present.
+ */
+async function resolveStableWorkerExecPath(): Promise<string> {
+  stableWorkerExecPathPromise ??= (async () => {
+    const execPath = process.execPath;
+    const cellarMatch = execPath.match(
+      /^(.+?)[\\/]Cellar[\\/]([^\\/]+)[\\/][^\\/]+[\\/]bin[\\/]node(?:\.exe)?$/,
+    );
+    if (!cellarMatch) {
+      return execPath;
+    }
+
+    const prefix = cellarMatch[1];
+    const formula = cellarMatch[2];
+    const pathModule = execPath.includes("\\") ? path.win32 : path.posix;
+    const optPath = pathModule.join(prefix, "opt", formula, "bin", path.basename(execPath));
+    try {
+      await fs.access(optPath);
+      return optPath;
+    } catch {
+      // Fall through to the default formula's bin symlink.
+    }
+
+    if (formula === "node") {
+      const binPath = pathModule.join(prefix, "bin", path.basename(execPath));
+      try {
+        await fs.access(binPath);
+        return binPath;
+      } catch {
+        // Fall through to process.execPath when no stable symlink exists.
+      }
+    }
+
+    return execPath;
+  })();
+  return await stableWorkerExecPathPromise;
+}
+
 /** Drop execArgv flags that would make forked workers debug/eval stateful or unsafe. */
 function resolveWorkerExecArgv(): string[] {
   const args: string[] = [];
@@ -228,12 +271,18 @@ class LocalEmbeddingWorkerClient {
   }
 
   /** Ensure the child process exists and has lifecycle failure handlers installed. */
-  private ensureChild(): ChildProcess {
+  private async ensureChild(): Promise<ChildProcess> {
+    if (this.child?.connected) {
+      return this.child;
+    }
+
+    const execPath = await resolveStableWorkerExecPath();
     if (this.child?.connected) {
       return this.child;
     }
 
     const child = fork(this.scriptPath, [], {
+      execPath,
       execArgv: resolveWorkerExecArgv(),
       serialization: "json",
       stdio: ["ignore", "ignore", "ignore", "ipc"],
@@ -268,7 +317,8 @@ class LocalEmbeddingWorkerClient {
     options?: EmbeddingProviderCallOptions,
   ): Promise<number[] | number[][] | undefined> {
     options?.signal?.throwIfAborted();
-    const child = this.ensureChild();
+    const child = await this.ensureChild();
+    options?.signal?.throwIfAborted();
     const id = this.nextRequestId++;
     const payload = { ...request, id } as LocalEmbeddingWorkerRequest;
     return await new Promise((resolve, reject) => {


### PR DESCRIPTION
Closes #99183

## What Problem This Solves

Fixes an issue where users running the Gateway with Homebrew-managed Node could lose fresh local embedding worker forks after Homebrew upgrades Node and removes the old Cellar binary.

## Why This Change Was Made

The local embedding worker now resolves Homebrew Cellar `process.execPath` values to stable Homebrew symlinks before calling `fork()`. Non-Cellar paths keep the existing executable unchanged, and the change stays inside the memory host worker supervisor without adding config, public API, or a new worker error code.

## User Impact

Local semantic-memory embeddings can continue starting fresh worker processes after a Homebrew Node upgrade instead of failing with `spawn ... ENOENT` until the Gateway is restarted.

## Evidence

- Claim proved: stale Homebrew Cellar worker forks use a stable Node executable path before `fork()`, while non-Cellar paths remain unchanged.
- Commands / artifacts:
  - `node scripts/run-vitest.mjs packages/memory-host-sdk/src/host/embeddings-worker-stale-execpath.test.ts` -> passed, 4 tests.
  - `node scripts/run-vitest.mjs packages/memory-host-sdk/src/host/embeddings.test.ts` -> passed, 18 tests.
  - `git diff --check HEAD~1..HEAD` -> passed.
  - `python .agents\skills\autoreview\scripts\autoreview --mode local` -> worker reported clean, no accepted/actionable findings.
  - Real macOS/Homebrew proof: https://github.com/qingminglong/openclaw/actions/runs/28698715497 -> passed on `macos-15-arm64`, artifact `pr-99541-macos-homebrew-proof`.
- Observed result:
  - Unit tests verify Cellar paths are passed to `fork()` as `/opt/homebrew/opt/node/bin/node` or `/usr/local/bin/node`, non-Cellar paths pass through unchanged, and aborts during the new async boundary do not send cancelled requests.
  - The macOS proof ran on macOS 15.7.7 arm64 with Homebrew prefix `/opt/homebrew` and Homebrew Node 26.4.0.
  - The parent process started from a Homebrew Cellar Node executable: `/opt/homebrew/Cellar/node/openclaw-proof-99541-28698715497-1/bin/node`.
  - After that Cellar executable was removed, a raw `child_process.fork()` without explicit `execPath` failed with `spawn /opt/homebrew/Cellar/node/openclaw-proof-99541-28698715497-1/bin/node ENOENT`.
  - The PR worker path then completed successfully while the stale Cellar executable remained unavailable; the child process ran through the stable Homebrew Node path, with child `argv0` recorded as `/opt/homebrew/opt/node/bin/node` and child `execPath` resolving to `/opt/homebrew/Cellar/node/26.4.0/bin/node`.