### PR TITLE
improve(agents): skip whole-history deep clone on every turn when no context hook is registered

### DIFF
--- a/src/agents/sessions/extensions/runner.test.ts
+++ b/src/agents/sessions/extensions/runner.test.ts
@@ -1,0 +1,88 @@
+// Focused tests for emitContext clone gating: the per-turn deep clone of the
+// session history must be skipped when no extension registered a "context"
+// handler, while handler runs keep receiving an isolated clone.
+import { describe, expect, it } from "vitest";
+import type { AgentMessage } from "../../runtime/index.js";
+import type { ModelRegistry } from "../model-registry.js";
+import type { SessionManager } from "../session-manager.js";
+import { ExtensionRunner } from "./runner.js";
+import type { Extension, ExtensionRuntime } from "./types.js";
+
+type TestHandler = (...args: unknown[]) => Promise<unknown>;
+
+function buildExtension(handlers?: Record<string, TestHandler[]>): Extension {
+  return {
+    path: "/tmp/test-extension.ts",
+    resolvedPath: "/tmp/test-extension.ts",
+    sourceInfo: {
+      path: "/tmp/test-extension.ts",
+      source: "test",
+      scope: "temporary",
+      origin: "top-level",
+    },
+    handlers: new Map(Object.entries(handlers ?? {})),
+    tools: new Map(),
+    messageRenderers: new Map(),
+    commands: new Map(),
+    flags: new Map(),
+    shortcuts: new Map(),
+  } as Extension;
+}
+
+function buildRunner(extensions: Extension[]): ExtensionRunner {
+  return new ExtensionRunner(
+    extensions,
+    {} as ExtensionRuntime,
+    "/tmp",
+    {} as SessionManager,
+    {} as ModelRegistry,
+  );
+}
+
+function buildMessages(): AgentMessage[] {
+  return [
+    { role: "user", content: [{ type: "text", text: "hello" }] },
+    { role: "assistant", content: [{ type: "text", text: "hi" }] },
+  ] as AgentMessage[];
+}
+
+describe("ExtensionRunner.emitContext", () => {
+  it("returns the original array without cloning when no context handlers are registered", async () => {
+    const messages = buildMessages();
+
+    const noExtensions = buildRunner([]);
+    expect(await noExtensions.emitContext(messages)).toBe(messages);
+
+    const otherHandlersOnly = buildRunner([buildExtension({ user_bash: [async () => undefined] })]);
+    expect(await otherHandlersOnly.emitContext(messages)).toBe(messages);
+  });
+
+  it("keeps handler mutations isolated from the caller's messages", async () => {
+    const messages = buildMessages();
+    const handler: TestHandler = async (event) => {
+      const contextEvent = event as { messages: AgentMessage[] };
+      contextEvent.messages.push({
+        role: "user",
+        content: [{ type: "text", text: "injected" }],
+      } as AgentMessage);
+      return undefined;
+    };
+    const runner = buildRunner([buildExtension({ context: [handler] })]);
+
+    const result = await runner.emitContext(messages);
+
+    expect(result).not.toBe(messages);
+    expect(result).toHaveLength(3);
+    expect(messages).toHaveLength(2);
+  });
+
+  it("applies replacement messages returned by a context handler", async () => {
+    const replacement = [
+      { role: "user", content: [{ type: "text", text: "replaced" }] },
+    ] as AgentMessage[];
+    const handler: TestHandler = async () => ({ messages: replacement });
+    const runner = buildRunner([buildExtension({ context: [handler] })]);
+
+    expect(await runner.emitContext(buildMessages())).toBe(replacement);
+  });
+});

--- a/src/agents/sessions/extensions/runner.ts
+++ b/src/agents/sessions/extensions/runner.ts
@@ -910,6 +910,12 @@ export class ExtensionRunner {
   }
 
   async emitContext(messages: AgentMessage[]): Promise<AgentMessage[]> {
+    // Cloning the full session history is expensive (it can carry image
+    // payloads) and runs every turn, so skip it unless a context handler
+    // is actually registered. Handlers still receive an isolated clone.
+    if (!this.hasHandlers("context")) {
+      return messages;
+    }
     const ctx = this.createContext();
     let currentMessages = structuredClone(messages);
 

--- a/src/agents/sessions/sdk.ts
+++ b/src/agents/sessions/sdk.ts
@@ -514,9 +514,7 @@ async function createAgentSessionImpl(
     sessionId: sessionManager.getSessionId(),
     transformContext: async (messages) => {
       const runner = extensionRunnerRef.current;
-      // Gate like onPayload/onResponse: emitContext deep-clones the whole
-      // message history, which is wasted work when no context handler exists.
-      if (!runner?.hasHandlers("context")) {
+      if (!runner) {
         return messages;
       }
       return runner.emitContext(messages);

--- a/src/agents/sessions/sdk.ts
+++ b/src/agents/sessions/sdk.ts
@@ -514,7 +514,9 @@ async function createAgentSessionImpl(
     sessionId: sessionManager.getSessionId(),
     transformContext: async (messages) => {
       const runner = extensionRunnerRef.current;
-      if (!runner) {
+      // Gate like onPayload/onResponse: emitContext deep-clones the whole
+      // message history, which is wasted work when no context handler exists.
+      if (!runner?.hasHandlers("context")) {
         return messages;
       }
       return runner.emitContext(messages);


### PR DESCRIPTION
## What Problem This Solves

Every agent turn deep-clones the entire session message history (`structuredClone`) before checking whether any extension actually registered a `"context"` handler. With no context-hook extension configured — the default setup — the clone is pure wasted work: on long or image-heavy sessions the history reaches megabytes, so every turn pays avoidable latency and GC pressure before the provider request is even built.

## Why This Change Was Made

Gate the clone the same way the sibling hooks already do. `transformContext` in `src/agents/sessions/sdk.ts` now checks `runner.hasHandlers("context")` — exactly mirroring the existing `onPayload` (`before_provider_request`) and `onResponse` (`after_provider_response`) gates in the same object literal — and `ExtensionRunner.emitContext` early-returns the original array when no context handler exists, so any future caller gets the same protection. When a context handler is registered, behavior is unchanged: handlers still receive an isolated clone, and handler-returned replacement messages are still honored. Returning the original array in the no-handler case matches the documented `transformContext` contract ("Return the original messages or another safe fallback value", `packages/agent-core/src/types.ts`), and the consumer (`packages/agent-core/src/agent-loop.ts` `streamAssistantResponse`) only reads the result to build the LLM payload.

## User Impact

Sessions without a context-hook extension (the default) skip one full-history deep clone per agent turn. On a 2.4 MB history that removes ~1 ms plus one large transient allocation per turn; the saving scales linearly with history size (image-heavy sessions reach tens of MB). No user-visible behavior change; no change at all when a context handler is registered.

## Evidence

Focused unit tests (new `src/agents/sessions/extensions/runner.test.ts`, 3 tests):
- no context handlers → `emitContext` returns the identical array reference (no clone),
- with a context handler → handler mutations stay isolated from the caller's array (clone semantics preserved),
- handler-returned replacement messages are honored.

Real-behavior harness (`node --import tsx`, production `ExtensionRunner` constructor with zero extensions, 121-message / ~2.4 MB history including a ~2.2 MB image payload, 25 simulated turns, `globalThis.structuredClone` wrapped with a call counter):

```
=== base 153fed790a ===
{"turns":25,"historyMessages":121,"approxHistoryBytes":2427029,"structuredCloneCalls":25,"totalMs":25.7,"perTurnMs":1.03}
=== this branch ===
{"turns":25,"historyMessages":121,"approxHistoryBytes":2427029,"structuredCloneCalls":0,"totalMs":0,"perTurnMs":0}
```

(The branch's `totalMs`/`perTurnMs` are below timer resolution, not literally zero — the meaningful signal is `structuredCloneCalls` dropping from 25 to 0.)

Validation: `pnpm tsgo:core` and `pnpm tsgo:core:test` clean; targeted suites pass (`runner.test.ts` 3/3; `embedded-agent-runner.extensions.test.ts` + `codex-app-server.extensions.test.ts` + `loader.test.ts` 29/29); `oxfmt` / `oxlint` clean. Codex review against `upstream/main`: "No actionable correctness issues found in the changed context-handler gating."
