### PR TITLE
test(shared): add unit tests for message content block visitor

### DIFF
--- a/src/shared/message-content-blocks.test.ts
+++ b/src/shared/message-content-blocks.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it, vi } from "vitest";
+import { visitObjectContentBlocks } from "./message-content-blocks.js";
+
+describe("visitObjectContentBlocks", () => {
+  it("does not visit when message is null", () => {
+    const visitor = vi.fn();
+    visitObjectContentBlocks(null, visitor);
+    expect(visitor).not.toHaveBeenCalled();
+  });
+
+  it("does not visit when message is undefined", () => {
+    const visitor = vi.fn();
+    visitObjectContentBlocks(undefined, visitor);
+    expect(visitor).not.toHaveBeenCalled();
+  });
+
+  it("does not visit when message is a string", () => {
+    const visitor = vi.fn();
+    visitObjectContentBlocks("hello", visitor);
+    expect(visitor).not.toHaveBeenCalled();
+  });
+
+  it("does not visit when message is a number", () => {
+    const visitor = vi.fn();
+    visitObjectContentBlocks(42, visitor);
+    expect(visitor).not.toHaveBeenCalled();
+  });
+
+  it("does not visit when message has no content property", () => {
+    const visitor = vi.fn();
+    visitObjectContentBlocks({ role: "user" }, visitor);
+    expect(visitor).not.toHaveBeenCalled();
+  });
+
+  it("does not visit when content is not an array", () => {
+    const visitor = vi.fn();
+    visitObjectContentBlocks({ content: "plain text" }, visitor);
+    expect(visitor).not.toHaveBeenCalled();
+  });
+
+  it("visits each object block in the content array", () => {
+    const visitor = vi.fn();
+    visitObjectContentBlocks(
+      {
+        content: [
+          { type: "text", text: "hello" },
+          { type: "image", url: "x" },
+        ],
+      },
+      visitor,
+    );
+    expect(visitor).toHaveBeenCalledTimes(2);
+    expect(visitor).toHaveBeenNthCalledWith(1, { type: "text", text: "hello" });
+    expect(visitor).toHaveBeenNthCalledWith(2, { type: "image", url: "x" });
+  });
+
+  it("skips non-object entries in the content array", () => {
+    const visitor = vi.fn();
+    visitObjectContentBlocks(
+      { content: ["not-an-object", null, { type: "text", text: "ok" }, 123] },
+      visitor,
+    );
+    expect(visitor).toHaveBeenCalledTimes(1);
+    expect(visitor).toHaveBeenCalledWith({ type: "text", text: "ok" });
+  });
+
+  it("returns undefined (void)", () => {
+    const visitor = vi.fn();
+    const result = visitObjectContentBlocks({ content: [{ type: "text", text: "x" }] }, visitor);
+    expect(result).toBeUndefined();
+  });
+
+  it("handles empty content array", () => {
+    const visitor = vi.fn();
+    visitObjectContentBlocks({ content: [] }, visitor);
+    expect(visitor).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## What Problem This Solves

The `visitObjectContentBlocks` utility in `src/shared/message-content-blocks.ts` has no dedicated unit tests, leaving the content-block traversal logic unverified against regressions.

## Why This Change Was Made

Adds comprehensive unit test coverage for the message content block visitor, covering:
- null / undefined message (no-op)
- Non-object messages (string, number — no-op)
- Object without a content property
- Content that is not an array
- Normal traversal visiting each object block
- Skipping non-object entries (strings, null, numbers) within the content array
- Empty content array
- Void return value

## User Impact

- Purely additive: one new test file, no production code changes
- No risk of breaking existing behavior

## Evidence

```
$ npx vitest run src/shared/message-content-blocks.test.ts --reporter=verbose

 ✓ |shared-core| src/shared/message-content-blocks.test.ts > visitObjectContentBlocks > does not visit when message is null
 ✓ |shared-core| src/shared/message-content-blocks.test.ts > visitObjectContentBlocks > does not visit when message is undefined
 ✓ |shared-core| src/shared/message-content-blocks.test.ts > visitObjectContentBlocks > does not visit when message is a string
 ✓ |shared-core| src/shared/message-content-blocks.test.ts > visitObjectContentBlocks > does not visit when message is a number
 ✓ |shared-core| src/shared/message-content-blocks.test.ts > visitObjectContentBlocks > does not visit when message has no content property
 ✓ |shared-core| src/shared/message-content-blocks.test.ts > visitObjectContentBlocks > does not visit when content is not an array
 ✓ |shared-core| src/shared/message-content-blocks.test.ts > visitObjectContentBlocks > visits each object block in the content array
 ✓ |shared-core| src/shared/message-content-blocks.test.ts > visitObjectContentBlocks > skips non-object entries in the content array
 ✓ |shared-core| src/shared/message-content-blocks.test.ts > visitObjectContentBlocks > returns undefined (void)
 ✓ |shared-core| src/shared/message-content-blocks.test.ts > visitObjectContentBlocks > handles empty content array

 Test Files  1 passed (1)
      Tests  10 passed (10)
```