### PR TITLE
fix(telegram): strip directive tags from prompt context dedupe key

### DIFF
--- a/extensions/telegram/src/bot-handlers-dedupe.test.ts
+++ b/extensions/telegram/src/bot-handlers-dedupe.test.ts
@@ -1,0 +1,79 @@
+// Tests that prompt-context text dedupe keys handle directive-tag
+// differences and timestamp drift between session transcript rows and
+// Telegram cache rows (#99117 / #99546).
+import { describe, expect, it } from "vitest";
+import { resolvePromptContextTextDedupeKey } from "./bot-handlers.runtime.js";
+
+function row(
+  body: string,
+  timestampMs: number,
+  role: "assistant" | "user" = "assistant",
+  sender?: string,
+) {
+  return { body, timestamp_ms: timestampMs, role, sender };
+}
+
+describe("resolvePromptContextTextDedupeKey", () => {
+  it("dedupes bot rows when only difference is directive tags (same timestamp)", () => {
+    const sessionRow = row("[[reply_to_current]]Hello, world!", 1_778_474_760_000);
+    const cacheRow = row("Hello, world!", 1_778_474_760_000);
+
+    expect(resolvePromptContextTextDedupeKey(sessionRow)).toBe(
+      resolvePromptContextTextDedupeKey(cacheRow),
+    );
+  });
+
+  it("dedupes bot rows with timestamp drift (6s apart)", () => {
+    const sessionRow = row("[[reply_to_current]]Duplicate context row", 1_778_474_760_000);
+    const cacheRow = row("Duplicate context row", 1_778_474_766_000);
+
+    expect(resolvePromptContextTextDedupeKey(sessionRow)).toBe(
+      resolvePromptContextTextDedupeKey(cacheRow),
+    );
+  });
+
+  it("dedupes bot rows with different sender display names but same role", () => {
+    // Session says "OpenClaw", cache says "MyBot" — both assistant.
+    const sessionRow = row("status update", 1_700_000_000_000, "assistant", "OpenClaw");
+    const cacheRow = row("status update", 1_700_000_000_500, "assistant", "MyBot");
+
+    expect(resolvePromptContextTextDedupeKey(sessionRow)).toBe(
+      resolvePromptContextTextDedupeKey(cacheRow),
+    );
+  });
+
+  it("does not dedupe user rows with same text at different timestamps", () => {
+    const msg1 = row("hello", 1_778_474_760_000, "user", "User");
+    const msg2 = row("hello", 1_778_474_820_000, "user", "User");
+
+    const key1 = resolvePromptContextTextDedupeKey(msg1);
+    const key2 = resolvePromptContextTextDedupeKey(msg2);
+
+    expect(key1).not.toBe(key2);
+    expect(key1).toContain("hello");
+    expect(key2).toContain("hello");
+  });
+
+  it("does not cross-dedupe a user row and a bot row with same text", () => {
+    // User says "ok" at 12:00:00, bot also replies "ok" at 12:00:05.
+    // They must not be collapsed.
+    const userRow = row("ok", 1_700_000_000_000, "user", "John Smith");
+    const botRow = row("ok", 1_700_000_005_000, "assistant", "MyBot");
+
+    const userKey = resolvePromptContextTextDedupeKey(userRow);
+    const botKey = resolvePromptContextTextDedupeKey(botRow);
+
+    expect(userKey).not.toBe(botKey);
+    // User key has timestamp, bot key does not.
+    expect(userKey).toBe("1700000000000:ok");
+    expect(botKey).toBe("ok");
+  });
+
+  it("returns undefined for empty body", () => {
+    expect(resolvePromptContextTextDedupeKey(row("  ", 1_700_000_000_000))).toBe(undefined);
+  });
+
+  it("returns undefined for non-finite timestamp", () => {
+    expect(resolvePromptContextTextDedupeKey(row("hello", Number.NaN))).toBeUndefined();
+  });
+});

--- a/extensions/telegram/src/bot-handlers.runtime.ts
+++ b/extensions/telegram/src/bot-handlers.runtime.ts
@@ -47,6 +47,7 @@ import {
   resolveAmbientTranscriptWatermarkKey,
 } from "openclaw/plugin-sdk/session-store-runtime";
 import { normalizeStringEntries } from "openclaw/plugin-sdk/string-coerce-runtime";
+import { stripInlineDirectiveTagsForDelivery } from "openclaw/plugin-sdk/text-chunking";
 import { expandTelegramAllowFromWithAccessGroups } from "./access-groups.js";
 import { resolveTelegramAccount, resolveTelegramMediaRuntimeOptions } from "./accounts.js";
 import { withTelegramApiErrorLogging } from "./api-logging.js";
@@ -180,9 +181,10 @@ import { buildTelegramSessionTranscriptPromptMessages } from "./session-transcri
 type TelegramPromptContextMessageForDedupe = {
   body?: unknown;
   timestamp_ms?: unknown;
+  role?: unknown;
 };
 
-function resolvePromptContextTextDedupeKey(
+export function resolvePromptContextTextDedupeKey(
   message: TelegramPromptContextMessageForDedupe,
 ): string | undefined {
   if (typeof message.body !== "string" || !message.body.trim()) {
@@ -191,7 +193,21 @@ function resolvePromptContextTextDedupeKey(
   if (typeof message.timestamp_ms !== "number" || !Number.isFinite(message.timestamp_ms)) {
     return undefined;
   }
-  return `${message.timestamp_ms}:${message.body.trim()}`;
+  // Strip inline directive tags (e.g. `[[reply_to_current]]`) so
+  // session-transcript rows and Telegram cache rows with the same visible
+  // text produce the same dedupe key (#99117).
+  const stripped = stripInlineDirectiveTagsForDelivery(message.body).text.trim();
+  if (!stripped) {
+    return undefined;
+  }
+  // Bot-owned rows (role === "assistant" from session transcript or cache)
+  // may have timestamps that drift by several seconds for the same physical
+  // reply. Use only stripped text as the key so they still dedupe.
+  // User rows keep timestamp to preserve real repeated messages (#99546).
+  if (message.role === "assistant") {
+    return stripped;
+  }
+  return `${message.timestamp_ms}:${stripped}`;
 }
 
 export const registerTelegramHandlers = ({
@@ -1262,6 +1278,8 @@ export const registerTelegramHandlers = ({
     media_ref: media?.path ? undefined : node.mediaRef,
     reply_to_id: node.replyToId,
     is_reply_target: flags?.replyTarget === true ? true : undefined,
+    role:
+      String(node.senderId) === String(bot.botInfo.id) ? ("assistant" as const) : ("user" as const),
   });
 
   const buildPromptContextForMessage = async (

--- a/extensions/telegram/src/session-transcript-context.ts
+++ b/extensions/telegram/src/session-transcript-context.ts
@@ -29,6 +29,7 @@ function toSessionTranscriptPromptMessage(
     sender: entry.sourceChannel ? `${sender} (${entry.sourceChannel})` : sender,
     ...(entry.timestamp !== undefined ? { timestamp_ms: entry.timestamp } : {}),
     body: entry.text,
+    role: entry.role,
     ...(entry.sourceChannel ? { source_channel: entry.sourceChannel } : {}),
   };
 }


### PR DESCRIPTION
## What Problem This Solves

Telegram assistant replies appear twice in prompt context — once from session transcript (with directive tags like `[[reply_to_current]]`) and once from the Telegram message cache (without tags). The dedupe key uses exact `timestamp_ms:body` matching. Two issues prevent correct deduplication:

1. **Directive tags**: `[[reply_to_current]]Hello` ≠ `Hello` — different bodies, different keys
2. **Timestamp drift**: Session transcript and cache may record the same physical reply seconds apart — different timestamps, different keys

Refs #99117

## Root Cause / Fix

**Strip directive tags** via `stripInlineDirectiveTagsForDelivery` before computing the key.

**Handle timestamp drift** with role-based scoping: assistant/bot-owned rows use text-only keys (no timestamp), while user rows keep `timestamp_ms:text` to preserve real repeated messages.

**Role detection**: Session transcript rows carry `entry.role` ("assistant" / "user"). Cache rows compare `senderId` against `bot.botInfo.id`.

Changes:
- `session-transcript-context.ts`: Add `role` field to output
- `bot-handlers.runtime.ts`: Compute `role` in `toPromptContextMessage`, update `resolvePromptContextTextDedupeKey` to strip tags + scope by role
- `bot-handlers-dedupe.test.ts`: 7 tests covering same-timestamp, timestamp-drift, cross-role separation, user dedupe, empty body, and NaN timestamp

## Evidence

### Test Runner
```
node scripts/run-vitest.mjs extensions/telegram/src/bot-handlers-dedupe.test.ts

 Test Files  1 passed (1)
      Tests  7 passed (7)
```

### Formatting
```
pnpm exec oxfmt --check ...  → All matched files use the correct format.
pnpm exec oxlint ...         → clean
```

## Change Type
- [x] Bug fix
## Scope
- [x] Telegram channel (prompt context)
## Security Impact
- No new permissions, secrets, or network calls.