### PR TITLE
fix(android): session filters, talk config booleans, notification loop guard, IPv6 zone hosts

### DIFF
--- a/apps/android/app/src/main/java/ai/openclaw/app/NotificationForwardingPolicy.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/NotificationForwardingPolicy.kt
@@ -27,12 +27,17 @@ internal data class NotificationForwardingPolicy(
   val quietEnd: String,
   val maxEventsPerMinute: Int,
   val sessionKey: String?,
+  val selfPackageName: String = "",
 )
 
 /** Applies the operator-configured package allow/block list after trimming input. */
 internal fun NotificationForwardingPolicy.allowsPackage(packageName: String): Boolean {
   val normalized = packageName.trim()
   if (normalized.isEmpty()) {
+    return false
+  }
+  val self = selfPackageName.trim()
+  if (self.isNotEmpty() && normalized == self) {
     return false
   }
   return when (mode) {

--- a/apps/android/app/src/main/java/ai/openclaw/app/SecurePrefs.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/SecurePrefs.kt
@@ -313,6 +313,7 @@ class SecurePrefs(
       quietEnd = quietEnd,
       maxEventsPerMinute = maxEvents.coerceAtLeast(1),
       sessionKey = sessionKey,
+      selfPackageName = normalizedAppPackage,
     )
   }
 

--- a/apps/android/app/src/main/java/ai/openclaw/app/ui/GatewayConfigResolver.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/ui/GatewayConfigResolver.kt
@@ -201,11 +201,7 @@ internal fun parseGatewayEndpointResult(rawInput: String): GatewayEndpointParseR
   val uri =
     runCatching { URI(normalized) }.getOrNull()
       ?: return GatewayEndpointParseResult(error = GatewayEndpointValidationError.INVALID_URL)
-  val host =
-    uri.host
-      ?.trim()
-      ?.trim('[', ']')
-      .orEmpty()
+  val host = normalizeGatewayConnectionHost(uri.host?.trim()?.trim('[', ']').orEmpty())
   if (host.isEmpty()) return GatewayEndpointParseResult(error = GatewayEndpointValidationError.INVALID_URL)
 
   val scheme =
@@ -340,6 +336,16 @@ internal fun composeGatewayManualUrl(
   if (port !in 1..65535) return null
   val scheme = if (tls) "https" else "http"
   return "$scheme://${ai.openclaw.app.gateway.formatGatewayAuthority(bareHost, port)}"
+}
+
+/** Strips IPv6 interface zones so parsed hosts match socket-ready literals. */
+internal fun normalizeGatewayConnectionHost(rawHost: String): String {
+  var host = rawHost.trim().trim('[', ']')
+  val zoneIndex = host.indexOf('%')
+  if (zoneIndex >= 0) {
+    host = host.substring(0, zoneIndex)
+  }
+  return host
 }
 
 private fun parseJsonObject(input: String): JsonObject? = runCatching { gatewaySetupJson.parseToJsonElement(input).jsonObject }.getOrNull()

--- a/apps/android/app/src/main/java/ai/openclaw/app/ui/chat/SessionFilters.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/ui/chat/SessionFilters.kt
@@ -1,6 +1,7 @@
 package ai.openclaw.app.ui.chat
 
 import ai.openclaw.app.chat.ChatSessionEntry
+import java.util.Locale
 
 private const val RECENT_WINDOW_MS = 24 * 60 * 60 * 1000L
 
@@ -17,6 +18,56 @@ fun friendlySessionName(key: String): String {
 
   val result = words.joinToString(" ")
   return result.ifBlank { key }
+}
+
+/** Mirrors iOS CommandCenterTab.isRecentChatSession for thread-picker parity. */
+internal fun isSelectableChatSession(
+  key: String,
+  mainSessionKey: String,
+): Boolean {
+  val trimmed = key.trim()
+  if (trimmed.isEmpty()) return false
+  val mainKey = mainSessionKey.trim().ifEmpty { "main" }
+  if (trimmed == mainKey) return false
+  val normalized = trimmed.lowercase(Locale.US)
+  val defaultBase = sessionBaseKey(mainKey)
+  if (!normalized.contains(":") && isDirectSessionBase(normalized, defaultBase)) {
+    return false
+  }
+  if (isHiddenInternalSession(trimmed)) return false
+  return !isAgentDeviceSession(trimmed, mainKey)
+}
+
+private fun isHiddenInternalSession(key: String): Boolean {
+  val trimmed = key.trim()
+  if (trimmed.isEmpty()) return false
+  return trimmed == "onboarding" || trimmed.endsWith(":onboarding")
+}
+
+private fun isAgentDeviceSession(
+  key: String,
+  mainSessionKey: String,
+): Boolean {
+  val parts = key.trim().split(':', ignoreCase = false)
+  if (parts.size < 3 || parts[0].lowercase(Locale.US) != "agent") return false
+  if (parts.size != 3 && parts.getOrNull(3)?.lowercase(Locale.US) != "thread") return false
+
+  val base = parts[2].trim().lowercase(Locale.US)
+  val defaultBase = sessionBaseKey(mainSessionKey)
+  return isDirectSessionBase(base, defaultBase)
+}
+
+private fun isDirectSessionBase(
+  base: String,
+  defaultBase: String,
+): Boolean = base == defaultBase || base == "main" || base == "global" || base.startsWith("node-")
+
+private fun sessionBaseKey(key: String): String {
+  val parts = key.trim().split(':', ignoreCase = false)
+  if (parts.size < 3 || parts[0].lowercase(Locale.US) != "agent") {
+    return key.trim().lowercase(Locale.US)
+  }
+  return parts[2].trim().lowercase(Locale.US)
 }
 
 /** Builds the selectable recent-session list while preserving the active session. */
@@ -36,6 +87,7 @@ fun resolveSessionChoices(
   for (entry in sorted) {
     // Hide the legacy main alias when the gateway has supplied a canonical main session key.
     if (aliasKey != null && entry.key == aliasKey) continue
+    if (!isSelectableChatSession(entry.key, mainKey)) continue
     if (!seen.add(entry.key)) continue
     if ((entry.updatedAtMs ?: 0L) < cutoff) continue
     recent.add(entry)
@@ -58,7 +110,7 @@ fun resolveSessionChoices(
     }
   }
 
-  if (current.isNotEmpty() && !included.contains(current)) {
+  if (current.isNotEmpty() && !included.contains(current) && isSelectableChatSession(current, mainKey)) {
     // Keep the active session selectable even if it is old or missing from the recent list.
     result.add(ChatSessionEntry(key = current, updatedAtMs = null))
   }

--- a/apps/android/app/src/main/java/ai/openclaw/app/voice/TalkModeGatewayConfig.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/voice/TalkModeGatewayConfig.kt
@@ -46,7 +46,14 @@ private fun JsonElement?.asStringOrNull(): String? =
 
 private fun JsonElement?.asBooleanOrNull(): Boolean? {
   val primitive = this as? JsonPrimitive ?: return null
-  return primitive.booleanOrNull
+  primitive.booleanOrNull?.let { return it }
+  val content = primitive.content.trim().lowercase()
+  // Accept gateway config-style booleans in addition to strict JSON literals.
+  return when (content) {
+    "true", "yes", "1" -> true
+    "false", "no", "0" -> false
+    else -> null
+  }
 }
 
 private fun JsonElement?.asObjectOrNull(): JsonObject? = this as? JsonObject

--- a/apps/android/app/src/test/java/ai/openclaw/app/NotificationForwardingPolicyTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/NotificationForwardingPolicyTest.kt
@@ -78,6 +78,25 @@ class NotificationForwardingPolicyTest {
   }
 
   @Test
+  fun allowsPackage_neverForwardsSelfPackageEvenInAllowlist() {
+    val policy =
+      NotificationForwardingPolicy(
+        enabled = true,
+        mode = NotificationPackageFilterMode.Allowlist,
+        packages = setOf("ai.openclaw.app", "com.other.app"),
+        quietHoursEnabled = false,
+        quietStart = "22:00",
+        quietEnd = "07:00",
+        maxEventsPerMinute = 20,
+        sessionKey = null,
+        selfPackageName = "ai.openclaw.app",
+      )
+
+    assertFalse(policy.allowsPackage("ai.openclaw.app"))
+    assertTrue(policy.allowsPackage("com.other.app"))
+  }
+
+  @Test
   fun isWithinQuietHours_handlesWindowCrossingMidnight() {
     val policy =
       NotificationForwardingPolicy(

--- a/apps/android/app/src/test/java/ai/openclaw/app/SecurePrefsNotificationForwardingTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/SecurePrefsNotificationForwardingTest.kt
@@ -128,4 +128,20 @@ class SecurePrefsNotificationForwardingTest {
     assertFalse(policy.enabled)
     assertEquals(NotificationPackageFilterMode.Blocklist, policy.mode)
   }
+
+  @Test
+  fun getNotificationForwardingPolicy_blocksSelfPackageInAllowlistMode() {
+    val context = RuntimeEnvironment.getApplication()
+    val plainPrefs = context.getSharedPreferences("openclaw.node", Context.MODE_PRIVATE)
+    plainPrefs.edit().clear().commit()
+
+    val prefs = SecurePrefs(context)
+    prefs.setNotificationForwardingMode(NotificationPackageFilterMode.Allowlist)
+    prefs.setNotificationForwardingPackages(listOf("ai.openclaw.app", "com.other.app"))
+
+    val policy = prefs.getNotificationForwardingPolicy(appPackageName = "ai.openclaw.app")
+
+    assertFalse(policy.allowsPackage("ai.openclaw.app"))
+    assertTrue(policy.allowsPackage("com.other.app"))
+  }
 }

--- a/apps/android/app/src/test/java/ai/openclaw/app/ui/GatewayConfigResolverTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/ui/GatewayConfigResolverTest.kt
@@ -192,20 +192,20 @@ class GatewayConfigResolverTest {
   fun parseGatewayEndpointAllowsLinkLocalIpv6ZoneCleartextWsUrls() {
     val parsed = parseGatewayEndpoint("ws://[fe80::1%25eth0]")
 
-    assertEquals("fe80::1%25eth0", parsed?.host)
+    assertEquals("fe80::1", parsed?.host)
     assertEquals(18789, parsed?.port)
     assertEquals(false, parsed?.tls)
-    assertEquals("http://[fe80::1%25eth0]:18789", parsed?.displayUrl)
+    assertEquals("http://[fe80::1]:18789", parsed?.displayUrl)
   }
 
   @Test
   fun parseGatewayEndpointAllowsSecureIpv6ZoneUrls() {
     val parsed = parseGatewayEndpoint("wss://[fe80::1%25wlan0]:443")
 
-    assertEquals("fe80::1%25wlan0", parsed?.host)
+    assertEquals("fe80::1", parsed?.host)
     assertEquals(443, parsed?.port)
     assertEquals(true, parsed?.tls)
-    assertEquals("https://[fe80::1%25wlan0]", parsed?.displayUrl)
+    assertEquals("https://[fe80::1]", parsed?.displayUrl)
   }
 
   @Test

--- a/apps/android/app/src/test/java/ai/openclaw/app/ui/chat/SessionFiltersTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/ui/chat/SessionFiltersTest.kt
@@ -2,6 +2,8 @@ package ai.openclaw.app.ui.chat
 
 import ai.openclaw.app.chat.ChatSessionEntry
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
 import org.junit.Test
 
 class SessionFiltersTest {
@@ -56,5 +58,30 @@ class SessionFiltersTest {
       ).map { it.key }
 
     assertEquals(listOf("main", "active-old", "recent-1", "recent-2"), result)
+  }
+
+  @Test
+  fun sessionChoicesFilterAgentDeviceAndInternalSessions() {
+    val now = 1_700_000_000_000L
+    val recent = now - 10 * 60 * 1000L
+    val sessions =
+      listOf(
+        ChatSessionEntry(key = "agent:main:node-android", updatedAtMs = recent),
+        ChatSessionEntry(key = "agent:main:slack:channel:C1", updatedAtMs = recent),
+        ChatSessionEntry(key = "agent:main:main", updatedAtMs = recent),
+        ChatSessionEntry(key = "main", updatedAtMs = recent),
+      )
+
+    val result = resolveSessionChoices("main", sessions, mainSessionKey = "main", nowMs = now).map { it.key }
+
+    assertEquals(listOf("main", "agent:main:slack:channel:C1"), result)
+  }
+
+  @Test
+  fun isSelectableChatSession_matchesIosRecentSessionFilter() {
+    assertFalse(isSelectableChatSession("agent:main:node-0b88d67b7e42", "main"))
+    assertFalse(isSelectableChatSession("agent:main:main", "main"))
+    assertFalse(isSelectableChatSession("onboarding", "main"))
+    assertTrue(isSelectableChatSession("agent:main:slack:channel:C1", "main"))
   }
 }

--- a/apps/android/app/src/test/java/ai/openclaw/app/voice/TalkModeConfigParsingTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/voice/TalkModeConfigParsingTest.kt
@@ -62,4 +62,23 @@ class TalkModeConfigParsingTest {
       TalkModeGatewayConfigParser.resolvedSilenceTimeoutMs(talk),
     )
   }
+
+  @Test
+  fun parsesStringInterruptOnSpeechFlag() {
+    val config =
+      json
+        .parseToJsonElement(
+          """
+          {
+            "talk": {
+              "interruptOnSpeech": "true"
+            }
+          }
+          """.trimIndent(),
+        ).jsonObject
+
+    val parsed = TalkModeGatewayConfigParser.parse(config)
+
+    assertEquals(true, parsed.interruptOnSpeech)
+  }
 }


### PR DESCRIPTION
## What Problem This Solves

Four small Android parity/correctness bugs:

1. **SessionFilters** — device/internal sessions (`agent:main:node-*`, `agent:main:main`, onboarding) appeared in thread picker unlike iOS `isRecentChatSession`.
2. **TalkModeGatewayConfig** — interruptOnSpeech: true` string config was ignored while sibling parsers accept string booleans.
3. **Notification forwarding** — allowlist mode could forward OpenClaw's own notifications, risking gateway/node loops (blocklist already blocked self).
4. **GatewayConfigResolver** — IPv6 zone URLs like `ws://[fe80::1%25eth0]` passed cleartext validation but stored `%25eth0` in the connection host, breaking socket connect.

## Why This Change Was Made

Align Android behavior with iOS session filtering, existing boolean parsing conventions, fail-closed notification forwarding, and socket-ready gateway host normalization used elsewhere in cleartext host checks.

## User Impact

- Cleaner session picker without device/internal noise.
- Talk interrupt-on-speech respects string gateway config values.
- Notification allowlists cannot accidentally forward the OpenClaw app itself.
- Link-local IPv6 manual/QR gateway URLs connect using bare literals (`fe80::1`).

## Evidence

- `SessionFiltersTest.sessionChoicesFilterAgentDeviceAndInternalSessions`
- `SessionFiltersTest.isSelectableChatSession_matchesIosRecentSessionFilter`
- `TalkModeConfigParsingTest.parsesStringInterruptOnSpeechFlag`
- `NotificationForwardingPolicyTest.allowsPackage_neverForwardsSelfPackageEvenInAllowlist`
- `SecurePrefsNotificationForwardingTest.getNotificationForwardingPolicy_blocksSelfPackageInAllowlistMode`
- Updated `GatewayConfigResolverTest` IPv6 zone expectations

Proof command:

```bash
cd apps/android
./gradlew :app:testPlayDebugUnitTest \
  --tests ai.openclaw.app.ui.chat.SessionFiltersTest \
  --tests ai.openclaw.app.voice.TalkModeConfigParsingTest \
  --tests ai.openclaw.app.NotificationForwardingPolicyTest \
  --tests ai.openclaw.app.SecurePrefsNotificationForwardingTest \
  --tests ai.openclaw.app.ui.GatewayConfigResolverTest.parseGatewayEndpointAllowsLinkLocalIpv6ZoneCleartextWsUrls \
  --tests ai.openclaw.app.ui.GatewayConfigResolverTest.parseGatewayEndpointAllowsSecureIpv6ZoneUrls
```