### PR TITLE
fix(auto-reply): don't block reply completion on transcript mirror

### DIFF
--- a/src/auto-reply/dispatch-dispatcher.ts
+++ b/src/auto-reply/dispatch-dispatcher.ts
@@ -1,6 +1,31 @@
 // Reply dispatcher lifecycle helpers used by auto-reply dispatch paths.
 import type { ReplyDispatcher } from "./reply/reply-dispatcher.types.js";
 
+type ReplyDispatcherSettledTask = () => Promise<void> | void;
+
+const settledTasksByDispatcher = new WeakMap<ReplyDispatcher, Set<ReplyDispatcherSettledTask>>();
+
+/** Register post-delivery work owned by the dispatcher's settle lifecycle. */
+export function registerReplyDispatcherSettledTask(
+  dispatcher: ReplyDispatcher,
+  task: ReplyDispatcherSettledTask,
+): void {
+  const tasks = settledTasksByDispatcher.get(dispatcher) ?? new Set<ReplyDispatcherSettledTask>();
+  tasks.add(task);
+  settledTasksByDispatcher.set(dispatcher, tasks);
+}
+
+async function runReplyDispatcherSettledTasks(dispatcher: ReplyDispatcher): Promise<void> {
+  const tasks = settledTasksByDispatcher.get(dispatcher);
+  if (!tasks) {
+    return;
+  }
+  settledTasksByDispatcher.delete(dispatcher);
+  for (const task of tasks) {
+    await task();
+  }
+}
+
 /** Mark a dispatcher complete, wait for pending work, then run optional cleanup. */
 export async function settleReplyDispatcher(params: {
   dispatcher: ReplyDispatcher;
@@ -9,7 +34,9 @@ export async function settleReplyDispatcher(params: {
   params.dispatcher.markComplete();
   try {
     await params.dispatcher.waitForIdle();
+    await runReplyDispatcherSettledTasks(params.dispatcher);
   } finally {
+    settledTasksByDispatcher.delete(params.dispatcher);
     await params.onSettled?.();
   }
 }

--- a/src/auto-reply/dispatch.test.ts
+++ b/src/auto-reply/dispatch.test.ts
@@ -2,6 +2,7 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../config/config.js";
 import { onDiagnosticEvent, resetDiagnosticEventsForTest } from "../infra/diagnostic-events.js";
+import { registerReplyDispatcherSettledTask } from "./dispatch-dispatcher.js";
 import { getReplyPayloadMetadata, setReplyPayloadMetadata } from "./reply-payload.js";
 import type { ReplyDispatchBeforeDeliver, ReplyDispatcher } from "./reply/reply-dispatcher.js";
 import { buildTestCtx } from "./reply/test-ctx.js";
@@ -201,6 +202,9 @@ describe("withReplyDispatcher", () => {
   it("always marks complete and waits for idle after success", async () => {
     const order: string[] = [];
     const dispatcher = createDispatcher(order);
+    registerReplyDispatcherSettledTask(dispatcher, () => {
+      order.push("settledTask");
+    });
 
     const result = await withReplyDispatcher({
       dispatcher,
@@ -214,7 +218,7 @@ describe("withReplyDispatcher", () => {
     });
 
     expect(result).toBe("ok");
-    expect(order).toEqual(["run", "markComplete", "waitForIdle", "onSettled"]);
+    expect(order).toEqual(["run", "markComplete", "waitForIdle", "settledTask", "onSettled"]);
   });
 
   it("still drains dispatcher after run throws", async () => {

--- a/src/auto-reply/reply/dispatch-from-config.reply-dispatch.test.ts
+++ b/src/auto-reply/reply/dispatch-from-config.reply-dispatch.test.ts
@@ -349,6 +349,63 @@ describe("dispatchReplyFromConfig reply_dispatch hook", () => {
     }
   });
 
+  it("completes the final reply even if the transcript mirror's dispatcher-idle wait never resolves", async () => {
+    // Regression: the delivered-transcript mirror awaits dispatcher.waitForIdle()
+    // as post-delivery bookkeeping. When a follow-up is queued the dispatcher
+    // never goes idle until this operation clears — and awaiting the mirror here
+    // blocked the operation from clearing, a completion<->idle deadlock that left
+    // the reply op phase=running (stalled_agent_run, recovery=none). The mirror
+    // now runs fire-and-forget, so completion must not depend on waitForIdle.
+    hookMocks.runner.hasHooks.mockReturnValue(false);
+    sessionStoreMocks.currentEntry = { sessionKey: "agent:test:session" };
+    sessionStoreMocks.resolveSessionStoreEntry.mockReturnValue({
+      existing: sessionStoreMocks.currentEntry,
+    });
+    mocks.routeReply.mockResolvedValue({ ok: true, messageId: "mock" });
+    const dispatcher = createDispatcher();
+    // Simulate a busy dispatcher (queued follow-up): idle never arrives.
+    vi.mocked(dispatcher.waitForIdle).mockImplementation(() => new Promise<void>(() => {}));
+
+    const result = await dispatchReplyFromConfig({
+      ctx: createHookCtx(),
+      cfg: emptyConfig,
+      dispatcher,
+      replyResolver: async () => ({ text: "first reply" }),
+    });
+
+    expect(result.queuedFinal).toBe(true);
+    expect(dispatcher.sendFinalReply).toHaveBeenCalledWith({ text: "first reply" });
+    // The mirror was still kicked off (fire-and-forget) — it just no longer gates completion.
+    expect(dispatcher.waitForIdle).toHaveBeenCalled();
+  });
+
+  it("does not fail the reply when the background transcript mirror rejects", async () => {
+    // The detached mirror's failure must be swallowed in the background (logged via
+    // .catch), never surfaced as an unhandled rejection or a failed reply.
+    hookMocks.runner.hasHooks.mockReturnValue(false);
+    sessionStoreMocks.currentEntry = { sessionKey: "agent:test:session" };
+    sessionStoreMocks.resolveSessionStoreEntry.mockReturnValue({
+      existing: sessionStoreMocks.currentEntry,
+    });
+    mocks.routeReply.mockResolvedValue({ ok: true, messageId: "mock" });
+    const dispatcher = createDispatcher();
+    vi.mocked(dispatcher.waitForIdle).mockRejectedValue(new Error("mirror idle wait failed"));
+
+    const result = await dispatchReplyFromConfig({
+      ctx: createHookCtx(),
+      cfg: emptyConfig,
+      dispatcher,
+      replyResolver: async () => ({ text: "first reply" }),
+    });
+
+    expect(result.queuedFinal).toBe(true);
+    // Let the detached mirror's rejection settle; a missing .catch would surface
+    // as an unhandled rejection and fail this test.
+    await vi.waitFor(() => {
+      expect(dispatcher.waitForIdle).toHaveBeenCalled();
+    });
+  });
+
   it("clears the reply lane but defers follow-up admission until final delivery settles", async () => {
     const deliveryOrder: string[] = [];
     let startDelivery: () => void = () => {};

--- a/src/auto-reply/reply/dispatch-from-config.reply-dispatch.test.ts
+++ b/src/auto-reply/reply/dispatch-from-config.reply-dispatch.test.ts
@@ -349,63 +349,6 @@ describe("dispatchReplyFromConfig reply_dispatch hook", () => {
     }
   });
 
-  it("completes the final reply even if the transcript mirror's dispatcher-idle wait never resolves", async () => {
-    // Regression: the delivered-transcript mirror awaits dispatcher.waitForIdle()
-    // as post-delivery bookkeeping. When a follow-up is queued the dispatcher
-    // never goes idle until this operation clears — and awaiting the mirror here
-    // blocked the operation from clearing, a completion<->idle deadlock that left
-    // the reply op phase=running (stalled_agent_run, recovery=none). The mirror
-    // now runs fire-and-forget, so completion must not depend on waitForIdle.
-    hookMocks.runner.hasHooks.mockReturnValue(false);
-    sessionStoreMocks.currentEntry = { sessionKey: "agent:test:session" };
-    sessionStoreMocks.resolveSessionStoreEntry.mockReturnValue({
-      existing: sessionStoreMocks.currentEntry,
-    });
-    mocks.routeReply.mockResolvedValue({ ok: true, messageId: "mock" });
-    const dispatcher = createDispatcher();
-    // Simulate a busy dispatcher (queued follow-up): idle never arrives.
-    vi.mocked(dispatcher.waitForIdle).mockImplementation(() => new Promise<void>(() => {}));
-
-    const result = await dispatchReplyFromConfig({
-      ctx: createHookCtx(),
-      cfg: emptyConfig,
-      dispatcher,
-      replyResolver: async () => ({ text: "first reply" }),
-    });
-
-    expect(result.queuedFinal).toBe(true);
-    expect(dispatcher.sendFinalReply).toHaveBeenCalledWith({ text: "first reply" });
-    // The mirror was still kicked off (fire-and-forget) — it just no longer gates completion.
-    expect(dispatcher.waitForIdle).toHaveBeenCalled();
-  });
-
-  it("does not fail the reply when the background transcript mirror rejects", async () => {
-    // The detached mirror's failure must be swallowed in the background (logged via
-    // .catch), never surfaced as an unhandled rejection or a failed reply.
-    hookMocks.runner.hasHooks.mockReturnValue(false);
-    sessionStoreMocks.currentEntry = { sessionKey: "agent:test:session" };
-    sessionStoreMocks.resolveSessionStoreEntry.mockReturnValue({
-      existing: sessionStoreMocks.currentEntry,
-    });
-    mocks.routeReply.mockResolvedValue({ ok: true, messageId: "mock" });
-    const dispatcher = createDispatcher();
-    vi.mocked(dispatcher.waitForIdle).mockRejectedValue(new Error("mirror idle wait failed"));
-
-    const result = await dispatchReplyFromConfig({
-      ctx: createHookCtx(),
-      cfg: emptyConfig,
-      dispatcher,
-      replyResolver: async () => ({ text: "first reply" }),
-    });
-
-    expect(result.queuedFinal).toBe(true);
-    // Let the detached mirror's rejection settle; a missing .catch would surface
-    // as an unhandled rejection and fail this test.
-    await vi.waitFor(() => {
-      expect(dispatcher.waitForIdle).toHaveBeenCalled();
-    });
-  });
-
   it("clears the reply lane but defers follow-up admission until final delivery settles", async () => {
     const deliveryOrder: string[] = [];
     let startDelivery: () => void = () => {};

--- a/src/auto-reply/reply/dispatch-from-config.test.ts
+++ b/src/auto-reply/reply/dispatch-from-config.test.ts
@@ -33,6 +33,7 @@ import {
   createTestRegistry,
 } from "../../test-utils/channel-plugins.js";
 import { createInternalHookEventPayload } from "../../test-utils/internal-hook-event-payload.js";
+import { settleReplyDispatcher } from "../dispatch-dispatcher.js";
 import { getReplyPayloadMetadata } from "../reply-payload.js";
 import type { MsgContext } from "../templating.js";
 import { setReplyPayloadMetadata, type GetReplyOptions, type ReplyPayload } from "../types.js";
@@ -1354,6 +1355,7 @@ describe("dispatchReplyFromConfig", () => {
       replyOptions: { runId: "slack-run-1" },
       replyResolver: async () => ({ text: "Slack command reply" }),
     });
+    await settleReplyDispatcher({ dispatcher });
 
     expect(result.queuedFinal).toBe(true);
     expect(mocks.routeReply).not.toHaveBeenCalled();
@@ -1415,6 +1417,7 @@ describe("dispatchReplyFromConfig", () => {
         return { text: "✅ New session started." };
       },
     });
+    await settleReplyDispatcher({ dispatcher });
 
     expect(transcriptMocks.appendAssistantMessageToSessionTranscript).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -1447,6 +1450,7 @@ describe("dispatchReplyFromConfig", () => {
       replyResolver: async () =>
         setReplyPayloadMetadata({ text: "Persisted runtime reply" }, metadata),
     });
+    await settleReplyDispatcher({ dispatcher });
 
     expect(result.queuedFinal).toBe(true);
     expect(transcriptMocks.appendAssistantMessageToSessionTranscript).not.toHaveBeenCalled();
@@ -1572,6 +1576,7 @@ describe("dispatchReplyFromConfig", () => {
       dispatcher,
       replyResolver: async () => ({ text: "Secret Slack reply" }),
     });
+    await settleReplyDispatcher({ dispatcher });
 
     expect(transcriptMocks.appendAssistantMessageToSessionTranscript).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -1603,6 +1608,7 @@ describe("dispatchReplyFromConfig", () => {
       dispatcher,
       replyResolver: async () => ({ text: "Hidden Slack reply" }),
     });
+    await settleReplyDispatcher({ dispatcher });
 
     expect(transcriptMocks.appendAssistantMessageToSessionTranscript).not.toHaveBeenCalled();
   });
@@ -10543,6 +10549,7 @@ describe("sendPolicy deny — suppress delivery, not processing (#53328)", () =>
         sourceReplyDeliveryMode: "message_tool_only",
       },
     });
+    await settleReplyDispatcher({ dispatcher });
 
     expect(result.queuedFinal).toBe(true);
     expect(dispatcher.sendFinalReply).toHaveBeenCalledWith(sourceReply);
@@ -10607,6 +10614,7 @@ describe("sendPolicy deny — suppress delivery, not processing (#53328)", () =>
         sourceReplyDeliveryMode: "message_tool_only",
       },
     });
+    await settleReplyDispatcher({ dispatcher });
 
     expect(result.queuedFinal).toBe(true);
     expect(dispatcher.sendFinalReply).toHaveBeenCalledWith(sourceReply);
@@ -10622,6 +10630,84 @@ describe("sendPolicy deny — suppress delivery, not processing (#53328)", () =>
       config: emptyConfig,
       beforeMessageWrite: expect.any(Function),
     });
+  });
+
+  it("lets a queued same-session turn finish before mirroring delivered source replies", async () => {
+    setNoAbort();
+    sessionStoreMocks.currentEntry = {
+      sessionId: "s1",
+      sessionKey: "agent:main",
+      updatedAt: 0,
+      sendPolicy: "allow",
+    };
+    const order: string[] = [];
+    let followupDispatch: Promise<unknown> | undefined;
+    const firstDispatcher = createReplyDispatcher({
+      deliver: async () => {
+        if (!followupDispatch) {
+          throw new Error("expected queued follow-up dispatch");
+        }
+        await followupDispatch;
+        order.push("first-delivery");
+      },
+    });
+    const firstReply = setReplyPayloadMetadata(
+      { text: "first reply" },
+      {
+        deliverDespiteSourceReplySuppression: true,
+        sourceReplyTranscriptMirror: {
+          sessionKey: "agent:main",
+          agentId: "main",
+          text: "first reply",
+          idempotencyKey: "run-1:internal-source-reply:queued",
+        },
+      },
+    );
+    transcriptMocks.appendAssistantMessageToSessionTranscript.mockImplementationOnce(async () => {
+      order.push("mirror");
+      return { ok: true, sessionFile: "/tmp/session.jsonl", messageId: "message-1" };
+    });
+
+    const firstResult = await dispatchReplyFromConfig({
+      ctx: buildTestCtx({
+        MessageSid: "first-message",
+        Provider: "webchat",
+        Surface: "webchat",
+        SessionKey: "agent:main",
+      }),
+      cfg: emptyConfig,
+      dispatcher: firstDispatcher,
+      replyOptions: { sourceReplyDeliveryMode: "message_tool_only" },
+      replyResolver: async () => {
+        followupDispatch = dispatchReplyFromConfig({
+          ctx: buildTestCtx({
+            Body: "follow up",
+            MessageSid: "followup-message",
+            Provider: "webchat",
+            Surface: "webchat",
+            SessionKey: "agent:main",
+          }),
+          cfg: emptyConfig,
+          dispatcher: createDispatcher(),
+          replyResolver: async () => {
+            order.push("followup");
+            return { text: "second reply" };
+          },
+        });
+        await Promise.resolve();
+        return firstReply;
+      },
+    });
+
+    expect(firstResult.queuedFinal).toBe(true);
+    await settleReplyDispatcher({ dispatcher: firstDispatcher });
+    await followupDispatch;
+
+    expect(order).toEqual(["followup", "first-delivery", "mirror"]);
+    const queuedMirrorCalls = transcriptMocks.appendAssistantMessageToSessionTranscript.mock.calls
+      .map(([params]) => params as { idempotencyKey?: string })
+      .filter((params) => params.idempotencyKey === "run-1:internal-source-reply:queued");
+    expect(queuedMirrorCalls).toHaveLength(1);
   });
 
   it("does not mirror internal source replies cancelled by dispatcher hooks", async () => {
@@ -10661,6 +10747,7 @@ describe("sendPolicy deny — suppress delivery, not processing (#53328)", () =>
         sourceReplyDeliveryMode: "message_tool_only",
       },
     });
+    await settleReplyDispatcher({ dispatcher });
 
     expect(result.queuedFinal).toBe(true);
     expect(dispatcher.sendFinalReply).toHaveBeenCalledWith(sourceReply);

--- a/src/auto-reply/reply/dispatch-from-config.ts
+++ b/src/auto-reply/reply/dispatch-from-config.ts
@@ -2589,11 +2589,27 @@ export async function dispatchReplyFromConfig(
       });
       const queuedFinal = dispatcher.sendFinalReply(normalizedPayload);
       if (queuedFinal) {
-        await mirrorTranscriptAfterDispatcherDelivery({
+        // Fire-and-forget: the transcript mirror waits for the dispatcher to go
+        // idle, but awaiting it here blocks the reply operation's completion — and
+        // idle cannot arrive until this op clears when a follow-up is queued
+        // (queueDepth>=2). That is a completion<->dispatcher-idle deadlock: the op
+        // stays phase=running and surfaces as stalled_agent_run (recovery=none)
+        // until the stuck-session abort. Running the mirror in the background lets
+        // the op complete immediately — the queued follow-up proceeds, the
+        // dispatcher goes idle, and the (detached) mirror then records the
+        // transcript. Mirroring is post-delivery bookkeeping; it does not need to
+        // gate completion.
+        void mirrorTranscriptAfterDispatcherDelivery({
           dispatcher,
           before: finalOutcomeBefore,
           metadata: deliveredTranscriptMirror,
           cfg,
+        }).catch((error: unknown) => {
+          logVerbose(
+            `dispatch-from-config: background transcript mirror failed: ${formatErrorMessage(
+              error,
+            )}`,
+          );
         });
       }
       return {

--- a/src/auto-reply/reply/dispatch-from-config.ts
+++ b/src/auto-reply/reply/dispatch-from-config.ts
@@ -115,6 +115,7 @@ import {
   normalizeCommandBody,
   resolveTextCommand,
 } from "../commands-registry.js";
+import { registerReplyDispatcherSettledTask } from "../dispatch-dispatcher.js";
 import type { BlockReplyContext, GetReplyOptions } from "../get-reply-options.types.js";
 import {
   copyReplyPayloadMetadata,
@@ -897,13 +898,12 @@ function captureDeliveredTranscriptMirror(params: {
   return () => (observedFinal ? deliveredMetadata : metadata);
 }
 
-async function mirrorTranscriptAfterDispatcherDelivery(params: {
+async function mirrorTranscriptAfterDispatcherSettled(params: {
   dispatcher: ReplyDispatcher;
   before: { cancelled: number; failed: number };
   metadata: () => TranscriptMirror | undefined;
   cfg: OpenClawConfig;
 }): Promise<void> {
-  await params.dispatcher.waitForIdle();
   const after = getDispatcherFinalOutcomeCounts(params.dispatcher);
   if (after.cancelled > params.before.cancelled || after.failed > params.before.failed) {
     return;
@@ -2582,35 +2582,25 @@ export async function dispatchReplyFromConfig(
             )
           : undefined);
       markInboundDedupeReplayUnsafe();
-      const finalOutcomeBefore = getDispatcherFinalOutcomeCounts(dispatcher);
-      const deliveredTranscriptMirror = captureDeliveredTranscriptMirror({
-        dispatcher,
-        metadata: transcriptMirror,
-      });
+      const finalOutcomeBefore = transcriptMirror
+        ? getDispatcherFinalOutcomeCounts(dispatcher)
+        : undefined;
+      const deliveredTranscriptMirror = transcriptMirror
+        ? captureDeliveredTranscriptMirror({ dispatcher, metadata: transcriptMirror })
+        : undefined;
       const queuedFinal = dispatcher.sendFinalReply(normalizedPayload);
-      if (queuedFinal) {
-        // Fire-and-forget: the transcript mirror waits for the dispatcher to go
-        // idle, but awaiting it here blocks the reply operation's completion — and
-        // idle cannot arrive until this op clears when a follow-up is queued
-        // (queueDepth>=2). That is a completion<->dispatcher-idle deadlock: the op
-        // stays phase=running and surfaces as stalled_agent_run (recovery=none)
-        // until the stuck-session abort. Running the mirror in the background lets
-        // the op complete immediately — the queued follow-up proceeds, the
-        // dispatcher goes idle, and the (detached) mirror then records the
-        // transcript. Mirroring is post-delivery bookkeeping; it does not need to
-        // gate completion.
-        void mirrorTranscriptAfterDispatcherDelivery({
-          dispatcher,
-          before: finalOutcomeBefore,
-          metadata: deliveredTranscriptMirror,
-          cfg,
-        }).catch((error: unknown) => {
-          logVerbose(
-            `dispatch-from-config: background transcript mirror failed: ${formatErrorMessage(
-              error,
-            )}`,
-          );
-        });
+      if (queuedFinal && deliveredTranscriptMirror && finalOutcomeBefore) {
+        // The common settle owner runs this after successful delivery or
+        // cancellation. Keeping reconciliation out of the reply operation lets a
+        // newer foreground turn settle without creating an operation/idle cycle.
+        registerReplyDispatcherSettledTask(dispatcher, () =>
+          mirrorTranscriptAfterDispatcherSettled({
+            dispatcher,
+            before: finalOutcomeBefore,
+            metadata: deliveredTranscriptMirror,
+            cfg,
+          }),
+        );
       }
       return {
         queuedFinal,


### PR DESCRIPTION
## What Problem This Solves

A user who sends a second message while the agent is still answering the first can freeze that conversation until stuck-session recovery fires. Neither the first reply nor the queued follow-up completes, despite the model turn itself having finished.

## Problem

The reply operation used to await `mirrorTranscriptAfterDispatcherDelivery()`. That mirror first awaited dispatcher idle. With a same-session follow-up queued, the foreground freshness fence waited for the newer turn, the newer turn waited for the current `ReplyOperation` to clear, and the current operation waited for dispatcher idle through transcript mirroring.

That forms a cycle:

```text
foreground delivery -> newer same-session turn -> current reply operation -> dispatcher idle
        ^                                                                  |
        +------------------------------------------------------------------+
```

The user-visible result is a running reply operation plus queued follow-ups and no progress:

```text
stalled session: state=processing queueDepth=3 reason=active_work_without_progress
classification=stalled_agent_run activeWorkKind=embedded_run recovery=none
```

## Why This Change Was Made

The initial PR correctly removed transcript mirroring from the reply operation's awaited completion path, but detached it as an unowned background promise. That promise could remain pending forever if dispatcher idle never arrived.

The maintainer rewrite instead gives post-delivery work one lifecycle owner:

- successful final delivery registers a one-shot dispatcher settlement task;
- dispatcher settlement drains those tasks after delivery becomes idle;
- final cancellation/failure counters suppress mirroring for undelivered replies;
- settlement always clears the task registry, including failure paths;
- the actual post-hook payload remains the mirrored payload.

The reply operation can therefore clear before dispatcher settlement, unblocking the queued same-session turn, while transcript mirroring remains owned and bounded rather than fire-and-forget.

## User Impact

Rapid same-session follow-ups no longer wedge reply completion. Delivered source replies still reach the transcript exactly once; cancelled or failed final deliveries are not mirrored.

## Evidence

### Before

The contributor reproduced the bug on a live Gateway across LMStudio OpenAI-compatible completions, `claude-cli`, and DeepSeek. An instrumented stalled run reached final delivery and then stopped inside the mirror's dispatcher-idle wait:

```text
sendfinal-enter -> sf-tts-exit -> sf-route-exit ok=n -> sf-dispsend queuedFinal=y
  -> mirror-after-enter -> (silence; op never clears)
```

### After

- Focused regression suite: 4 files, 274 tests passed. It includes the real two-dispatch same-session cycle, settlement ordering, cancellation/failure suppression, and cleanup.
- Fresh `$autoreview`: clean; no accepted/actionable findings.
- Blacksmith Testbox-through-Crabbox `tbx_01kwnay65cktjv6sezewjvgx57`: built the source and passed the real Gateway + WebSocket/channel 20-turn same-session QA flow with the deterministic OpenAI-compatible provider. [Run](https://github.com/openclaw/openclaw/actions/runs/28690380122)
- Blacksmith Testbox-through-Crabbox `tbx_01kwnb2209p1meyspqaykh7xz8`: exact-tree `check:changed` passed core/core-test typechecks, lint, import cycles, and runtime/persistence guards. [Run](https://github.com/openclaw/openclaw/actions/runs/28690432827)
- Exact PR head: `11c4e2fc322f5340e95183885ca1680d2da7ac15`.

No external provider key is required for this lifecycle defect: the deterministic provider makes the queue timing reproducible while the Gateway, WebSocket, channel, session, delivery, and transcript paths remain real.

## Workaround

Before upgrading to a build containing this fix, serialize inbound messages per conversation so a second message is not admitted until the first reply operation completes.

## Related Work

- #92443 described a similar Slack-visible stall but was fixed by #90943. This PR repairs a later, distinct transcript-mirror cycle.
- #98416 and #98835 concern reply-session initialization conflicts, not this post-run delivery deadlock.
- #96703 concerns context-engine post-turn maintenance, not dispatcher settlement.
