### PR TITLE
fix(gateway): redact Responses media blocks in chat history sanitization

### DIFF
--- a/scripts/proof-chat-history-sanitize-input-image.mjs
+++ b/scripts/proof-chat-history-sanitize-input-image.mjs
@@ -1,0 +1,286 @@
+#!/usr/bin/env node
+// Projection-level proof for chat history inline-media redaction shapes.
+// Real gateway endpoint proof lives in
+// src/gateway/server-methods/chat-history-inline-media-redaction-request.test.ts
+// (real WS `chat.history` + `chat.message.get` over on-disk transcripts).
+// Run: node --import tsx scripts/proof-chat-history-sanitize-input-image.mjs
+import assert from "node:assert/strict";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+import {
+  projectRecentChatDisplayMessages,
+  sanitizeChatHistoryMessages,
+} from "../src/gateway/chat-display-projection.ts";
+
+function assertDeepEqual(actual, expected, label) {
+  assert.deepEqual(actual, expected, label);
+  console.log(`OK: ${label}`);
+}
+
+const REDACT_OPTS = { redactInlineMedia: true };
+
+async function main() {
+  const payload = Buffer.from("png-bytes").toString("base64");
+  const dataUrl = `data:image/png;base64,${payload}`;
+
+  const inputImageResult = sanitizeChatHistoryMessages(
+    [
+      {
+        role: "assistant",
+        content: [{ type: "input_image", image_url: dataUrl }],
+        timestamp: 1,
+      },
+    ],
+    undefined,
+    REDACT_OPTS,
+  );
+  assertDeepEqual(
+    inputImageResult,
+    [
+      {
+        role: "assistant",
+        content: [
+          {
+            type: "input_image",
+            omitted: true,
+            bytes: Buffer.byteLength(dataUrl, "utf8"),
+          },
+        ],
+        timestamp: 1,
+      },
+    ],
+    "input_image.image_url data URL redacted",
+  );
+
+  const mixedCaseDataUrl = `DATA:image/png;BASE64,${payload}`;
+  const mixedCaseInputImageResult = sanitizeChatHistoryMessages(
+    [
+      {
+        role: "assistant",
+        content: [{ type: "input_image", image_url: mixedCaseDataUrl }],
+        timestamp: 1,
+      },
+    ],
+    undefined,
+    REDACT_OPTS,
+  );
+  assertDeepEqual(
+    mixedCaseInputImageResult,
+    [
+      {
+        role: "assistant",
+        content: [
+          {
+            type: "input_image",
+            omitted: true,
+            bytes: Buffer.byteLength(mixedCaseDataUrl, "utf8"),
+          },
+        ],
+        timestamp: 1,
+      },
+    ],
+    "mixed-case input_image.image_url data URL redacted",
+  );
+
+  const imageUrlResult = sanitizeChatHistoryMessages(
+    [
+      {
+        role: "user",
+        content: [{ type: "image", url: dataUrl }],
+        timestamp: 2,
+      },
+    ],
+    undefined,
+    REDACT_OPTS,
+  );
+  assertDeepEqual(
+    imageUrlResult,
+    [
+      {
+        role: "user",
+        content: [
+          {
+            type: "image",
+            omitted: true,
+            bytes: Buffer.byteLength(dataUrl, "utf8"),
+          },
+        ],
+        timestamp: 2,
+      },
+    ],
+    "image.url data URL redacted",
+  );
+
+  const imageData = Buffer.from("png-bytes").toString("base64");
+  const imageDataResult = sanitizeChatHistoryMessages([
+    {
+      role: "assistant",
+      content: [{ type: "image", data: imageData }],
+      timestamp: 3,
+    },
+  ]);
+  assertDeepEqual(
+    imageDataResult,
+    [
+      {
+        role: "assistant",
+        content: [
+          {
+            type: "image",
+            omitted: true,
+            bytes: Buffer.byteLength(imageData, "utf8"),
+          },
+        ],
+        timestamp: 3,
+      },
+    ],
+    "image.data base64 still redacted",
+  );
+
+  const imageSourceDataResult = sanitizeChatHistoryMessages(
+    [
+      {
+        role: "assistant",
+        content: [
+          {
+            type: "image",
+            source: { type: "base64", media_type: "image/png", data: imageData },
+          },
+        ],
+        timestamp: 4,
+      },
+    ],
+    undefined,
+    REDACT_OPTS,
+  );
+  assertDeepEqual(
+    imageSourceDataResult,
+    [
+      {
+        role: "assistant",
+        content: [
+          {
+            type: "image",
+            source: {
+              type: "base64",
+              media_type: "image/png",
+              omitted: true,
+              bytes: Buffer.byteLength(imageData, "utf8"),
+            },
+          },
+        ],
+        timestamp: 4,
+      },
+    ],
+    "image.source.data redacted",
+  );
+
+  const nestedImageUrlResult = sanitizeChatHistoryMessages(
+    [
+      {
+        role: "assistant",
+        content: [{ type: "input_image", image_url: { url: dataUrl } }],
+        timestamp: 5,
+      },
+    ],
+    undefined,
+    REDACT_OPTS,
+  );
+  assertDeepEqual(
+    nestedImageUrlResult,
+    [
+      {
+        role: "assistant",
+        content: [
+          {
+            type: "input_image",
+            image_url: {
+              omitted: true,
+              bytes: Buffer.byteLength(dataUrl, "utf8"),
+            },
+          },
+        ],
+        timestamp: 5,
+      },
+    ],
+    "input_image.image_url.url data URL redacted",
+  );
+
+  const broadcastResult = sanitizeChatHistoryMessages([
+    {
+      role: "assistant",
+      content: [{ type: "input_image", image_url: dataUrl }],
+      timestamp: 6,
+    },
+  ]);
+  assertDeepEqual(
+    broadcastResult,
+    [
+      {
+        role: "assistant",
+        content: [{ type: "input_image", image_url: dataUrl }],
+        timestamp: 6,
+      },
+    ],
+    "input_image preserved when redactInlineMedia is disabled",
+  );
+
+  const historyProjectionResult = projectRecentChatDisplayMessages(
+    [
+      {
+        role: "assistant",
+        content: [{ type: "input_image", image_url: dataUrl }],
+        timestamp: 8,
+      },
+    ],
+    { redactInlineMedia: true },
+  );
+  assertDeepEqual(
+    historyProjectionResult,
+    [
+      {
+        role: "assistant",
+        content: [
+          {
+            type: "input_image",
+            omitted: true,
+            bytes: Buffer.byteLength(dataUrl, "utf8"),
+          },
+        ],
+        timestamp: 8,
+      },
+    ],
+    "projectRecentChatDisplayMessages redacts inline media for history callers",
+  );
+
+  const httpsUrl = "https://example.test/photo.png";
+  const httpsResult = sanitizeChatHistoryMessages(
+    [
+      {
+        role: "assistant",
+        content: [{ type: "image", url: httpsUrl }],
+        timestamp: 7,
+      },
+    ],
+    undefined,
+    REDACT_OPTS,
+  );
+  assertDeepEqual(
+    httpsResult,
+    [
+      {
+        role: "assistant",
+        content: [{ type: "image", url: httpsUrl }],
+        timestamp: 7,
+      },
+    ],
+    "https image URL preserved",
+  );
+
+  console.log("\nAll proof checks passed.");
+}
+
+const entry = process.argv[1];
+if (entry && import.meta.url === pathToFileURL(path.resolve(entry)).href) {
+  await main();
+}

--- a/src/agents/tools/embedded-gateway-stub.test.ts
+++ b/src/agents/tools/embedded-gateway-stub.test.ts
@@ -204,6 +204,7 @@ describe("embedded gateway stub", () => {
     expect(runtime.projectRecentChatDisplayMessages).toHaveBeenCalledWith(rawMessages, {
       maxChars: 100_000,
       maxMessages: 200,
+      redactInlineMedia: true,
     });
     expect(runtime.readSessionMessagesAsync).toHaveBeenCalledWith(
       {
@@ -271,6 +272,7 @@ describe("embedded gateway stub", () => {
     expect(runtime.projectRecentChatDisplayMessages).toHaveBeenCalledWith(rawMessages, {
       maxChars: 100_000,
       maxMessages: 1,
+      redactInlineMedia: true,
     });
     expect(runtime.readSessionMessagesAsync).toHaveBeenCalledWith(
       {
@@ -330,6 +332,7 @@ describe("embedded gateway stub", () => {
     );
     expect(runtime.projectChatDisplayMessages).toHaveBeenCalledWith(rawMessages.slice(0, 2), {
       maxChars: 100_000,
+      redactInlineMedia: true,
     });
     expect(result).toMatchObject({
       messages: rawMessages.slice(0, 2),
@@ -367,6 +370,7 @@ describe("embedded gateway stub", () => {
 
     expect(runtime.projectChatDisplayMessages).toHaveBeenCalledWith([rawMessages[1]], {
       maxChars: 100_000,
+      redactInlineMedia: true,
     });
     expect(result.messages).toEqual([projectedMessages[1]]);
     expect(result.nextOffset).toBe(2);
@@ -402,6 +406,7 @@ describe("embedded gateway stub", () => {
     expect(runtime.dropPreSessionStartAnnouncePairs).toHaveBeenCalledWith(rawMessages, 1234);
     expect(runtime.projectChatDisplayMessages).toHaveBeenCalledWith(filteredMessages, {
       maxChars: 100_000,
+      redactInlineMedia: true,
     });
     expect(result.messages).toEqual(filteredMessages);
   });
@@ -466,6 +471,7 @@ describe("embedded gateway stub", () => {
     expect(runtime.projectRecentChatDisplayMessages).toHaveBeenCalledWith(rawMessages, {
       maxChars: 100_000,
       maxMessages: 2,
+      redactInlineMedia: true,
     });
     expect(result).toMatchObject({
       messages: projectedMessages,
@@ -520,6 +526,7 @@ describe("embedded gateway stub", () => {
     expect(runtime.projectRecentChatDisplayMessages).toHaveBeenCalledWith(rawMessages, {
       maxChars: 100_000,
       maxMessages: 2,
+      redactInlineMedia: true,
     });
     expect(runtime.readSessionMessagesAsync).toHaveBeenCalledWith(
       {

--- a/src/agents/tools/embedded-gateway-stub.ts
+++ b/src/agents/tools/embedded-gateway-stub.ts
@@ -67,10 +67,13 @@ interface EmbeddedGatewayRuntime {
     messages: unknown[],
     sessionStartedAt: number | undefined,
   ) => unknown[];
-  projectChatDisplayMessages: (msgs: unknown[], opts?: { maxChars?: number }) => unknown[];
+  projectChatDisplayMessages: (
+    msgs: unknown[],
+    opts?: { maxChars?: number; redactInlineMedia?: boolean },
+  ) => unknown[];
   projectRecentChatDisplayMessages: (
     msgs: unknown[],
-    opts?: { maxChars?: number; maxMessages?: number },
+    opts?: { maxChars?: number; maxMessages?: number; redactInlineMedia?: boolean },
   ) => unknown[];
   capArrayByJsonBytes: (items: unknown[], maxBytes: number) => { items: unknown[] };
   listSessionsFromStoreAsync: (opts: {
@@ -425,13 +428,18 @@ async function handleChatHistory(params: Record<string, unknown>): Promise<{
       ? rt.projectRecentChatDisplayMessages(recencyFilteredMessages, {
           maxChars: effectiveMaxChars,
           maxMessages: max,
+          redactInlineMedia: true,
         })
       : offset === 0
         ? rt.projectRecentChatDisplayMessages(recencyFilteredMessages, {
             maxChars: effectiveMaxChars,
             maxMessages: max,
+            redactInlineMedia: true,
           })
-        : rt.projectChatDisplayMessages(recencyFilteredMessages, { maxChars: effectiveMaxChars });
+        : rt.projectChatDisplayMessages(recencyFilteredMessages, {
+            maxChars: effectiveMaxChars,
+            redactInlineMedia: true,
+          });
   const windowed =
     params.offset === undefined || offset === 0
       ? projected

--- a/src/gateway/chat-display-projection.core.ts
+++ b/src/gateway/chat-display-projection.core.ts
@@ -22,6 +22,7 @@ import { isSuppressedControlReplyText } from "./control-reply-text.js";
 
 type ChatDisplayProjectionOptions = {
   maxChars?: number;
+  redactInlineMedia?: boolean;
   stripEnvelope?: boolean;
   turnBoundaryPending?: boolean;
 };
@@ -169,7 +170,9 @@ export function projectChatDisplayMessagesWithState(
   const projectedErrors = projectEmptyAssistantErrorMessages(toProjectedMessages(mirrored));
   const filtered = filterVisibleProjectedHistoryMessages(
     projectSessionsSendInterSessionMessages(
-      toProjectedMessages(sanitizeChatHistoryMessages(projectedErrors, Number.MAX_SAFE_INTEGER)),
+      toProjectedMessages(
+        sanitizeChatHistoryMessages(projectedErrors, Number.MAX_SAFE_INTEGER, { redactInlineMedia: options?.redactInlineMedia }),
+      ),
     ),
     options?.turnBoundaryPending,
   );
@@ -177,6 +180,7 @@ export function projectChatDisplayMessagesWithState(
     messages: sanitizeChatHistoryMessages(
       mergeTtsSupplementMessages(filtered.messages),
       options?.maxChars ?? DEFAULT_CHAT_HISTORY_TEXT_MAX_CHARS,
+      { redactInlineMedia: options?.redactInlineMedia },
     ) as Array<Record<string, unknown>>,
     turnBoundaryPending: filtered.turnBoundaryPending,
   };

--- a/src/gateway/chat-display-projection.sanitize.ts
+++ b/src/gateway/chat-display-projection.sanitize.ts
@@ -1,4 +1,5 @@
 import { estimateBase64DecodedBytes } from "@openclaw/media-core/base64";
+import { classifyMediaReferenceSource } from "../media/media-reference.js";
 import { asFiniteNumber } from "@openclaw/normalization-core/number-coercion";
 import { asOptionalRecord as readRecord } from "@openclaw/normalization-core/record-coerce";
 import {
@@ -30,9 +31,13 @@ import {
   WORKSPACE_CONFLICT_TRANSCRIPT_TYPE,
 } from "./worker-environments/workspace-conflicts.js";
 
+type ChatHistorySanitizeOpts = { preserveExactToolPayload?: boolean; maxChars?: number; redactInlineMedia?: boolean };
+function redactInlineMediaBytes(value: string): { omitted: true; bytes: number } { return { omitted: true, bytes: Buffer.byteLength(value, "utf8") }; }
+function isInlineDataUrl(value: string): boolean { return classifyMediaReferenceSource(value).isDataUrl; }
+
 export function sanitizeChatHistoryContentBlock(
   block: unknown,
-  opts?: { preserveExactToolPayload?: boolean; maxChars?: number },
+  opts?: ChatHistorySanitizeOpts,
 ): { block: unknown; changed: boolean } {
   if (!block || typeof block !== "object") {
     return { block, changed: false };
@@ -103,6 +108,11 @@ export function sanitizeChatHistoryContentBlock(
     entry.omitted = true;
     entry.bytes = bytes;
     changed = true;
+  }
+  if (opts?.redactInlineMedia === true) {
+    if (type === "image" && typeof entry.url === "string" && isInlineDataUrl(entry.url)) { const redacted = redactInlineMediaBytes(entry.url); delete entry.url; entry.omitted = redacted.omitted; entry.bytes = redacted.bytes; changed = true; }
+    if (type === "image" && entry.source && typeof entry.source === "object") { const source = { ...(entry.source as Record<string, unknown>) }; if (typeof source.data === "string") { const redacted = redactInlineMediaBytes(source.data); delete source.data; source.omitted = redacted.omitted; source.bytes = redacted.bytes; entry.source = source; changed = true; } else if (typeof source.url === "string" && isInlineDataUrl(source.url)) { const redacted = redactInlineMediaBytes(source.url); delete source.url; source.omitted = redacted.omitted; source.bytes = redacted.bytes; entry.source = source; changed = true; } }
+    if (type === "input_image") { if (typeof entry.image_url === "string" && isInlineDataUrl(entry.image_url)) { const redacted = redactInlineMediaBytes(entry.image_url); delete entry.image_url; entry.omitted = redacted.omitted; entry.bytes = redacted.bytes; changed = true; } else if (entry.image_url && typeof entry.image_url === "object") { const imageUrl = { ...(entry.image_url as Record<string, unknown>) }; if (typeof imageUrl.url === "string" && isInlineDataUrl(imageUrl.url)) { const redacted = redactInlineMediaBytes(imageUrl.url); delete imageUrl.url; imageUrl.omitted = redacted.omitted; imageUrl.bytes = redacted.bytes; entry.image_url = imageUrl; changed = true; } } if (entry.source && typeof entry.source === "object") { const source = { ...(entry.source as Record<string, unknown>) }; if (typeof source.data === "string") { const redacted = redactInlineMediaBytes(source.data); delete source.data; source.omitted = redacted.omitted; source.bytes = redacted.bytes; entry.source = source; changed = true; } } }
   }
   if (type === "audio" && entry.source && typeof entry.source === "object") {
     const source = { ...(entry.source as Record<string, unknown>) };
@@ -281,6 +291,7 @@ function projectWorkspaceConflictDetails(
 export function sanitizeChatHistoryMessage(
   message: unknown,
   maxChars: number = DEFAULT_CHAT_HISTORY_TEXT_MAX_CHARS,
+  opts?: Pick<ChatHistorySanitizeOpts, "redactInlineMedia">,
 ): { message: unknown; changed: boolean } {
   if (!message || typeof message !== "object") {
     return { message, changed: false };
@@ -364,6 +375,7 @@ export function sanitizeChatHistoryMessage(
       const sanitized = sanitizeChatHistoryContentBlock(block, {
         preserveExactToolPayload,
         maxChars,
+        redactInlineMedia: opts?.redactInlineMedia,
       });
       if (
         !stripAssistantControlTokens ||
@@ -480,6 +492,7 @@ export function shouldDropAssistantHistoryMessage(message: unknown): boolean {
 export function sanitizeChatHistoryMessages(
   messages: unknown[],
   maxChars: number = DEFAULT_CHAT_HISTORY_TEXT_MAX_CHARS,
+  opts?: Pick<ChatHistorySanitizeOpts, "redactInlineMedia">,
 ): unknown[] {
   if (messages.length === 0) {
     return messages;
@@ -491,7 +504,7 @@ export function sanitizeChatHistoryMessages(
       changed = true;
       continue;
     }
-    const res = sanitizeChatHistoryMessage(message, maxChars);
+    const res = sanitizeChatHistoryMessage(message, maxChars, opts);
     changed ||= res.changed;
     if (shouldDropAssistantHistoryMessage(res.message)) {
       changed = true;

--- a/src/gateway/server-methods/chat-history-inline-media-redaction-request.test.ts
+++ b/src/gateway/server-methods/chat-history-inline-media-redaction-request.test.ts
@@ -1,0 +1,130 @@
+// Real-behavior proof that full `chat.history` and `chat.message.get` Gateway
+// requests — issued over a real WebSocket to a booted Gateway server, reading a
+// real on-disk transcript — redact inline `data:` media on Responses blocks.
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import type { AssistantMessage } from "openclaw/plugin-sdk/llm";
+import { describe, expect, test } from "vitest";
+import type { WebSocket } from "ws";
+import { SessionManager } from "../../agents/sessions/session-manager.js";
+import { installGatewayTestHooks, rpcReq, testState, writeSessionStore } from "../test-helpers.js";
+import { installConnectedControlUiServerSuite } from "../test-with-server.js";
+
+installGatewayTestHooks({ scope: "suite" });
+
+let ws: WebSocket;
+installConnectedControlUiServerSuite((started) => {
+  ws = started.ws;
+});
+
+const INLINE_PAYLOAD = "cG5n";
+const DATA_URL = `data:image/png;base64,${INLINE_PAYLOAD}`;
+
+type SeededInlineMediaTranscript = {
+  messageId: string;
+};
+
+async function seedInlineMediaTranscript(dir: string): Promise<SeededInlineMediaTranscript> {
+  testState.sessionStorePath = path.join(dir, "sessions.json");
+  const session = SessionManager.create(dir, dir);
+  const sessionId = session.getSessionId();
+  const transcriptPath = session.getSessionFile();
+  if (!sessionId || !transcriptPath) {
+    throw new Error("expected SessionManager to expose session id and transcript path");
+  }
+
+  session.appendMessage({
+    role: "user",
+    content: "inline media redaction proof",
+    timestamp: Date.now(),
+  });
+  const messageId = session.appendMessage({
+    role: "assistant",
+    content: [{ type: "input_image", image_url: DATA_URL }],
+    timestamp: Date.now(),
+    api: "responses",
+    provider: "openai",
+    model: "gpt-test",
+  } as unknown as AssistantMessage);
+
+  await writeSessionStore({
+    entries: {
+      main: {
+        sessionId,
+        sessionFile: transcriptPath,
+        updatedAt: Date.now(),
+      },
+    },
+  });
+
+  return { messageId };
+}
+
+function expectRedactedInlineMediaBlock(content: unknown) {
+  expect(content).toEqual([
+    {
+      type: "input_image",
+      omitted: true,
+      bytes: Buffer.byteLength(DATA_URL, "utf8"),
+    },
+  ]);
+}
+
+describe("chat history inline media redaction (real WS gateway)", () => {
+  test("chat.history redacts input_image data URLs from a real transcript read", async () => {
+    const dir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-chat-history-redact-"));
+    try {
+      await seedInlineMediaTranscript(dir);
+
+      const res = await rpcReq<{ messages?: Array<Record<string, unknown>> }>(ws, "chat.history", {
+        sessionKey: "main",
+        limit: 10,
+      });
+
+      expect(res.ok).toBe(true);
+      const messages = res.payload?.messages ?? [];
+      const assistantMessage = messages.find((message) => message.role === "assistant");
+      expect(assistantMessage).toBeDefined();
+      expectRedactedInlineMediaBlock(assistantMessage?.content);
+      expect(JSON.stringify(messages)).not.toContain(DATA_URL);
+      expect(JSON.stringify(messages)).not.toContain(INLINE_PAYLOAD);
+
+      console.log(
+        `chat.history real-request redaction: ${JSON.stringify(assistantMessage?.content ?? null)}`,
+      );
+    } finally {
+      testState.sessionStorePath = undefined;
+      await fs.rm(dir, { recursive: true, force: true, maxRetries: 5, retryDelay: 50 });
+    }
+  });
+
+  test("chat.message.get redacts input_image data URLs from a real transcript read", async () => {
+    const dir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-chat-message-get-redact-"));
+    try {
+      const { messageId } = await seedInlineMediaTranscript(dir);
+
+      const res = await rpcReq<{ ok?: boolean; message?: Record<string, unknown> }>(
+        ws,
+        "chat.message.get",
+        {
+          sessionKey: "main",
+          messageId,
+        },
+      );
+
+      expect(res.ok).toBe(true);
+      expect(res.payload?.ok).toBe(true);
+      expectRedactedInlineMediaBlock(res.payload?.message?.content);
+      expect(JSON.stringify(res.payload)).not.toContain(DATA_URL);
+      expect(JSON.stringify(res.payload)).not.toContain(INLINE_PAYLOAD);
+
+      console.log(
+        `chat.message.get real-request redaction: ${JSON.stringify(res.payload?.message?.content ?? null)}`,
+      );
+    } finally {
+      testState.sessionStorePath = undefined;
+      await fs.rm(dir, { recursive: true, force: true, maxRetries: 5, retryDelay: 50 });
+    }
+  });
+});

--- a/src/gateway/server-methods/chat-history-pages.ts
+++ b/src/gateway/server-methods/chat-history-pages.ts
@@ -319,11 +319,13 @@ export async function readChatHistoryPage(params: {
     const projected = isTailPage
       ? projectRecentChatDisplayMessages(recencyFilteredMessages, {
           maxChars: effectiveMaxChars,
+          redactInlineMedia: true,
           maxMessages: max,
           turnBoundaryPending: isHeartbeatHistoryTurnBoundaryMessage(overreadContextMessage),
         })
       : projectChatDisplayMessages(recencyFilteredMessages, {
           maxChars: effectiveMaxChars,
+          redactInlineMedia: true,
           turnBoundaryPending: isHeartbeatHistoryTurnBoundaryMessage(overreadContextMessage),
         });
     const windowed = messageId
@@ -415,6 +417,7 @@ export async function readChatHistoryPage(params: {
     );
     const displayMessages = projectChatDisplayMessages(mergedMessages, {
       maxChars: effectiveMaxChars,
+          redactInlineMedia: true,
     });
     return {
       activeLeafEntryId,
@@ -439,6 +442,7 @@ export async function readChatHistoryPage(params: {
   );
   const displayMessages = projectRecentChatDisplayMessages(recencyFilteredMessages, {
     maxChars: effectiveMaxChars,
+          redactInlineMedia: true,
     maxMessages: max,
     turnBoundaryPending,
   });

--- a/src/gateway/server-methods/chat-message-get-handler.ts
+++ b/src/gateway/server-methods/chat-message-get-handler.ts
@@ -134,6 +134,7 @@ export const chatMessageGetHandlers: GatewayRequestHandlers = {
     const projectedMessage = resolved.message
       ? projectChatDisplayMessage(resolved.message, {
           maxChars: effectiveMaxChars,
+          redactInlineMedia: true,
         })
       : undefined;
     const projected = projectedMessage

--- a/src/gateway/server-methods/server-methods.test.ts
+++ b/src/gateway/server-methods/server-methods.test.ts
@@ -32,6 +32,7 @@ import {
   DEFAULT_CHAT_HISTORY_TEXT_MAX_CHARS,
   augmentChatHistoryWithCanvasBlocks,
   dropPreSessionStartAnnouncePairs,
+  projectChatDisplayMessage,
   projectRecentChatDisplayMessages,
   resolveEffectiveChatHistoryMaxChars,
   sanitizeChatHistoryMessages,
@@ -858,6 +859,276 @@ describe("sanitizeChatHistoryMessages", () => {
     ]);
   });
 
+  it("redacts base64 image content blocks from chat history", () => {
+    const image = Buffer.from("png-bytes");
+    const data = image.toString("base64");
+    const result = sanitizeChatHistoryMessages([
+      {
+        role: "assistant",
+        content: [{ type: "image", data }],
+        timestamp: 1,
+      },
+    ]);
+
+    expect(result).toEqual([
+      {
+        role: "assistant",
+        content: [
+          {
+            type: "image",
+            omitted: true,
+            bytes: image.byteLength,
+          },
+        ],
+        timestamp: 1,
+      },
+    ]);
+  });
+
+  it("redacts data-url image blocks from chat history", () => {
+    const payload = Buffer.from("png-bytes").toString("base64");
+    const url = `data:image/png;base64,${payload}`;
+    const result = sanitizeChatHistoryMessages(
+      [
+        {
+          role: "user",
+          content: [
+            { type: "text", text: "see this" },
+            { type: "image", url },
+          ],
+          timestamp: 1,
+        },
+      ],
+      DEFAULT_CHAT_HISTORY_TEXT_MAX_CHARS,
+      { redactInlineMedia: true },
+    );
+
+    expect(result).toEqual([
+      {
+        role: "user",
+        content: [
+          { type: "text", text: "see this" },
+          {
+            type: "image",
+            omitted: true,
+            bytes: Buffer.byteLength(url, "utf8"),
+          },
+        ],
+        timestamp: 1,
+      },
+    ]);
+  });
+
+  it("redacts WebChat Responses input_image blocks from chat history", () => {
+    const payload = Buffer.from("png-bytes").toString("base64");
+    const image_url = `data:image/png;base64,${payload}`;
+    const result = sanitizeChatHistoryMessages(
+      [
+        {
+          role: "assistant",
+          content: [{ type: "input_image", image_url }],
+          timestamp: 1,
+        },
+      ],
+      DEFAULT_CHAT_HISTORY_TEXT_MAX_CHARS,
+      { redactInlineMedia: true },
+    );
+
+    expect(result).toEqual([
+      {
+        role: "assistant",
+        content: [
+          {
+            type: "input_image",
+            omitted: true,
+            bytes: Buffer.byteLength(image_url, "utf8"),
+          },
+        ],
+        timestamp: 1,
+      },
+    ]);
+  });
+
+  it("preserves non-data image URLs in chat history", () => {
+    const url = "https://example.test/photo.png";
+    const result = sanitizeChatHistoryMessages(
+      [
+        {
+          role: "assistant",
+          content: [{ type: "image", url }],
+          timestamp: 1,
+        },
+      ],
+      DEFAULT_CHAT_HISTORY_TEXT_MAX_CHARS,
+      { redactInlineMedia: true },
+    );
+
+    expect(result).toEqual([
+      {
+        role: "assistant",
+        content: [{ type: "image", url }],
+        timestamp: 1,
+      },
+    ]);
+  });
+
+  it("redacts image.source.data blocks from chat history", () => {
+    const data = Buffer.from("png-bytes").toString("base64");
+    const result = sanitizeChatHistoryMessages(
+      [
+        {
+          role: "assistant",
+          content: [
+            {
+              type: "image",
+              source: { type: "base64", media_type: "image/png", data },
+            },
+          ],
+          timestamp: 1,
+        },
+      ],
+      DEFAULT_CHAT_HISTORY_TEXT_MAX_CHARS,
+      { redactInlineMedia: true },
+    );
+
+    expect(result).toEqual([
+      {
+        role: "assistant",
+        content: [
+          {
+            type: "image",
+            source: {
+              type: "base64",
+              media_type: "image/png",
+              omitted: true,
+              bytes: Buffer.byteLength(data, "utf8"),
+            },
+          },
+        ],
+        timestamp: 1,
+      },
+    ]);
+  });
+
+  it("redacts input_image.source.data blocks from chat history", () => {
+    const data = Buffer.from("png-bytes").toString("base64");
+    const result = sanitizeChatHistoryMessages(
+      [
+        {
+          role: "assistant",
+          content: [
+            {
+              type: "input_image",
+              source: { type: "base64", media_type: "image/png", data },
+            },
+          ],
+          timestamp: 1,
+        },
+      ],
+      DEFAULT_CHAT_HISTORY_TEXT_MAX_CHARS,
+      { redactInlineMedia: true },
+    );
+
+    expect(result).toEqual([
+      {
+        role: "assistant",
+        content: [
+          {
+            type: "input_image",
+            source: {
+              type: "base64",
+              media_type: "image/png",
+              omitted: true,
+              bytes: Buffer.byteLength(data, "utf8"),
+            },
+          },
+        ],
+        timestamp: 1,
+      },
+    ]);
+  });
+
+  it("redacts nested input_image.image_url.url data URLs from chat history", () => {
+    const payload = Buffer.from("png-bytes").toString("base64");
+    const url = `data:image/png;base64,${payload}`;
+    const result = sanitizeChatHistoryMessages(
+      [
+        {
+          role: "assistant",
+          content: [{ type: "input_image", image_url: { url } }],
+          timestamp: 1,
+        },
+      ],
+      DEFAULT_CHAT_HISTORY_TEXT_MAX_CHARS,
+      { redactInlineMedia: true },
+    );
+
+    expect(result).toEqual([
+      {
+        role: "assistant",
+        content: [
+          {
+            type: "input_image",
+            image_url: {
+              omitted: true,
+              bytes: Buffer.byteLength(url, "utf8"),
+            },
+          },
+        ],
+        timestamp: 1,
+      },
+    ]);
+  });
+
+  it("redacts mixed-case data URLs from chat history", () => {
+    const payload = Buffer.from("png-bytes").toString("base64");
+    const image_url = `DATA:image/png;BASE64,${payload}`;
+    const result = sanitizeChatHistoryMessages(
+      [
+        {
+          role: "assistant",
+          content: [{ type: "input_image", image_url }],
+          timestamp: 1,
+        },
+      ],
+      DEFAULT_CHAT_HISTORY_TEXT_MAX_CHARS,
+      { redactInlineMedia: true },
+    );
+
+    expect(result).toEqual([
+      {
+        role: "assistant",
+        content: [
+          {
+            type: "input_image",
+            omitted: true,
+            bytes: Buffer.byteLength(image_url, "utf8"),
+          },
+        ],
+        timestamp: 1,
+      },
+    ]);
+  });
+
+  it("preserves input_image data URLs when inline media redaction is disabled", () => {
+    const image_url = "data:image/png;base64,cG5n";
+    const result = sanitizeChatHistoryMessages([
+      {
+        role: "assistant",
+        content: [{ type: "input_image", image_url }],
+        timestamp: 1,
+      },
+    ]);
+
+    expect(result).toEqual([
+      {
+        role: "assistant",
+        content: [{ type: "input_image", image_url }],
+        timestamp: 1,
+      },
+    ]);
+  });
+
   it("strips internal reasoning replay metadata from chat history", () => {
     const result = sanitizeChatHistoryMessages([
       {
@@ -960,6 +1231,26 @@ describe("sanitizeChatHistoryMessages", () => {
         role: "assistant",
         content: [{ type: "text", text: "real reply" }],
         timestamp: 3,
+      },
+    ]);
+  });
+
+  it("redacts input_image data URLs for the single-message reader used by chat.message.get", () => {
+    const image_url = "data:image/png;base64,cG5n";
+    const projected = projectChatDisplayMessage(
+      {
+        role: "assistant",
+        content: [{ type: "input_image", image_url }],
+      },
+      { redactInlineMedia: true },
+    );
+
+    expect(projected).toBeDefined();
+    expect(projected!.content).toEqual([
+      {
+        type: "input_image",
+        omitted: true,
+        bytes: Buffer.byteLength(image_url, "utf8"),
       },
     ]);
   });

--- a/src/gateway/session-history-state.ts
+++ b/src/gateway/session-history-state.ts
@@ -163,6 +163,7 @@ export function buildSessionHistorySnapshot(params: {
 }): SessionHistorySnapshot {
   const projected = projectChatDisplayMessagesWithState(params.rawMessages, {
     maxChars: params.maxChars ?? DEFAULT_CHAT_HISTORY_TEXT_MAX_CHARS,
+    redactInlineMedia: true,
   });
   const visibleMessages = toSessionHistoryMessages(projected.messages);
   const history = paginateSessionMessages(visibleMessages, params.limit, params.cursor);
@@ -296,6 +297,7 @@ export class SessionHistorySseState {
     const hadPendingTurnBoundary = this.turnBoundaryPending;
     const nextProjection = projectChatDisplayMessagesWithState([nextMessage], {
       maxChars: this.maxChars,
+      redactInlineMedia: true,
       turnBoundaryPending: hadPendingTurnBoundary,
     });
     this.turnBoundaryPending = nextProjection.turnBoundaryPending;
@@ -305,6 +307,7 @@ export class SessionHistorySseState {
     const projectedMessages = toSessionHistoryMessages(
       projectChatDisplayMessages([...this.sentHistory.messages, nextMessage], {
         maxChars: this.maxChars,
+      redactInlineMedia: true,
       }),
     );
     if (projectedMessages.length > this.sentHistory.messages.length) {
@@ -392,6 +395,7 @@ export class SessionHistorySseState {
     return buildSessionHistorySnapshot({
       rawMessages: rawSnapshot.rawMessages,
       maxChars: this.maxChars,
+      redactInlineMedia: true,
       limit: this.limit,
       cursor: this.cursor,
       ...(typeof rawSnapshot.rawTranscriptSeq === "number"

--- a/src/tui/embedded-backend.test.ts
+++ b/src/tui/embedded-backend.test.ts
@@ -62,6 +62,9 @@ const readSessionMessagesAsyncMock = vi.fn(
     _opts?: unknown,
   ): Promise<unknown[]> => [],
 );
+const projectRecentChatDisplayMessagesMock = vi.hoisted(() =>
+  vi.fn((messages: unknown[], _opts?: unknown) => messages),
+);
 type LoadSessionEntryMockResult = {
   cfg: Record<string, unknown>;
   canonicalKey: string;
@@ -185,7 +188,10 @@ vi.mock("../gateway/cli-session-history.js", () => ({
 
 vi.mock("../gateway/chat-display-projection.js", () => ({
   projectChatDisplayMessages: (messages: unknown[]) => messages,
-  projectRecentChatDisplayMessages: (messages: unknown[]) => messages,
+  projectRecentChatDisplayMessages: (
+    messages: unknown[],
+    opts?: { maxChars?: number; maxMessages?: number; redactInlineMedia?: boolean },
+  ) => projectRecentChatDisplayMessagesMock(messages, opts),
   resolveEffectiveChatHistoryMaxChars: () => 100_000,
 }));
 
@@ -357,6 +363,8 @@ describe("EmbeddedTuiBackend", () => {
     loadGatewayModelCatalogMock.mockReturnValue([]);
     readSessionMessagesAsyncMock.mockReset();
     readSessionMessagesAsyncMock.mockResolvedValue([]);
+    projectRecentChatDisplayMessagesMock.mockReset();
+    projectRecentChatDisplayMessagesMock.mockImplementation((messages: unknown[]) => messages);
     loadSessionEntryMock.mockReset();
     loadSessionEntryMock.mockImplementation((sessionKey: string) => ({
       cfg: {},
@@ -1028,6 +1036,10 @@ describe("EmbeddedTuiBackend", () => {
         maxBytes: 1024 * 1024,
         allowResetArchiveFallback: true,
       },
+    );
+    expect(projectRecentChatDisplayMessagesMock).toHaveBeenCalledWith(
+      [],
+      expect.objectContaining({ redactInlineMedia: true }),
     );
   });
 

--- a/src/tui/embedded-backend.ts
+++ b/src/tui/embedded-backend.ts
@@ -654,6 +654,7 @@ export class EmbeddedTuiBackend implements TuiBackend {
       projectRecentChatDisplayMessages(rawMessages, {
         maxChars: effectiveMaxChars,
         maxMessages: max,
+        redactInlineMedia: true,
       }),
     );
     const perMessageHardCap = Math.min(CHAT_HISTORY_MAX_SINGLE_MESSAGE_BYTES, maxHistoryBytes);


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users viewing chat history in Control UI / WebChat would still receive embedded `data:` image payloads on Responses-style media blocks (`input_image.image_url` and legacy `image.url`) after history sanitization, even though other base64 and data-URL media paths were already redacted.

Also fixes CI failures in `chat.directive-tags.test.ts`: live WebChat broadcast must keep `{ type: "input_image", image_url: "data:..." }` for QR/image delivery, so inline media redaction is scoped to history-only paths.

ClawSweeper follow-up: mixed-case data URLs such as `DATA:image/png;BASE64,...` could bypass history redaction because sanitization used case-sensitive `startsWith("data:")`.

## Why This Change Was Made

`sanitizeChatHistoryContentBlock()` now treats Responses media blocks the same as existing image/audio redaction when `redactInlineMedia: true` is passed from history paths only. Data URLs are removed from the projected history payload, replaced with `omitted: true` plus a byte count, while non-`data:` http(s) URLs remain intact for display/linking. Live broadcast via `projectChatDisplayMessages` keeps the default (`redactInlineMedia: false`) so inline images are preserved.

Data URL detection for history redaction reuses `classifyMediaReferenceSource().isDataUrl` (`/^data:/i`) via a local `isInlineDataUrl()` helper, matching `src/media/media-reference.ts` and closing the mixed-case bypass.

All chat.history-style callers now opt in: main gateway (`chat.ts`), session SSE snapshots (`session-history-state.ts`), embedded gateway stub, and TUI embedded backend.

## User Impact

Chat history fetched through the gateway, embedded agent tools, or TUI no longer leaks inline base64 image data for WebChat Responses `input_image` blocks or data-URL `image.url` blocks. Operators and users still see that media was present (via `omitted` + `bytes`) without shipping the raw payload over the wire. Remote https image links continue to display normally. Live WebChat broadcasts (QR codes, media replies) continue to deliver `input_image` data URLs to the client.

## Evidence

### Unit tests

```text
pnpm test src/gateway/server-methods/server-methods.test.ts -- -t "sanitizeChatHistoryMessages"
# 13 passed (includes mixed-case DATA: URL case)

pnpm test src/gateway/server-methods/chat.directive-tags.test.ts -- -t "broadcast|input_image|media"
# 90 passed

pnpm test src/agents/tools/embedded-gateway-stub.test.ts -- -t "chat.history"
# 11 passed

pnpm test src/tui/embedded-backend.test.ts -- -t "embedded TUI history"
# 1 passed (redactInlineMedia asserted on loadHistory)
```

New/updated cases cover:
- sanitizer shapes: `input_image.image_url`, `image.url`, `image.source.data`, nested `image_url.url`, mixed-case `DATA:...`, https preservation, broadcast preservation
- embedded gateway stub: all `chat.history` projection calls pass `redactInlineMedia: true`
- TUI embedded backend: `loadHistory` passes `redactInlineMedia: true` to `projectRecentChatDisplayMessages`

### Projection-level proof script

```text
node --import tsx scripts/proof-chat-history-sanitize-input-image.mjs
# All proof checks passed (9 cases including mixed-case DATA: URL + projectRecentChatDisplayMessages history path)
```

### Real WS gateway endpoint proof (live Gateway + on-disk transcript)

Test file: `src/gateway/server-methods/chat-history-inline-media-redaction-request.test.ts`

Seeded transcript uses canonical `SessionManager.appendMessage(...)` (parent-linked JSONL). Payload: `input_image.image_url = data:image/png;base64,cG5n` (26 UTF-8 bytes). Requests are issued over a real WebSocket to a booted Gateway server reading that transcript from disk.

Command (local, HEAD `5d88714f81`, Windows):

```text
node scripts/run-vitest.mjs run src/gateway/server-methods/chat-history-inline-media-redaction-request.test.ts
```

Stdout (real endpoint responses; raw `data:` payload absent from JSON):

```text
chat.history real-request redaction: [{"type":"input_image","omitted":true,"bytes":26}]
chat.message.get real-request redaction: [{"type":"input_image","omitted":true,"bytes":26}]

 Test Files  2 passed (2)
      Tests  4 passed (4)
```

CI (prior green on earlier SHAs; refreshed CI expected on `5d88714f81`):
- QA Smoke CI: https://github.com/openclaw/openclaw/actions/runs/28745356582/job/85235242425
- Real behavior proof: https://github.com/openclaw/openclaw/actions/runs/28745713805/job/85236143316
- check-test-types: https://github.com/openclaw/openclaw/actions/runs/28745356582/job/85235242466
