### PR TITLE
fix(android): filter device and internal sessions from thread picker

### DIFF
--- a/apps/.i18n/native-source.json
+++ b/apps/.i18n/native-source.json
@@ -5147,7 +5147,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 310,
+      "line": 326,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "All",
       "surface": "android",
@@ -5155,7 +5155,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 361,
+      "line": 377,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "OpenClaw",
       "surface": "android",
@@ -5163,7 +5163,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 382,
+      "line": 398,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Refresh chat",
       "surface": "android",
@@ -5171,7 +5171,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 385,
+      "line": 401,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Chat",
       "surface": "android",
@@ -5179,7 +5179,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 509,
+      "line": 525,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Loading session",
       "surface": "android",
@@ -5187,7 +5187,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 536,
+      "line": 552,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Jump to latest",
       "surface": "android",
@@ -5195,7 +5195,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 556,
+      "line": 572,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Ready when you are",
       "surface": "android",
@@ -5203,7 +5203,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 587,
+      "line": 603,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Fix connection",
       "surface": "android",
@@ -5211,7 +5211,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 588,
+      "line": 604,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Copy diagnostics",
       "surface": "android",
@@ -5219,7 +5219,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 725,
+      "line": 741,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Tools running",
       "surface": "android",
@@ -5227,7 +5227,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 730,
+      "line": 746,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "+${toolCalls.size - 4} more",
       "surface": "android",
@@ -5235,7 +5235,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 740,
+      "line": 756,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Thinking",
       "surface": "android",
@@ -5243,7 +5243,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 741,
+      "line": 757,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "OpenClaw is preparing a response.",
       "surface": "android",
@@ -5251,7 +5251,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 834,
+      "line": 850,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Stop",
       "surface": "android",
@@ -5259,7 +5259,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 851,
+      "line": 867,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Gateway offline",
       "surface": "android",
@@ -5267,7 +5267,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 941,
+      "line": 957,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Attach image",
       "surface": "android",
@@ -5275,7 +5275,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 956,
+      "line": 972,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Message OpenClaw",
       "surface": "android",
@@ -5283,7 +5283,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 971,
+      "line": 987,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Voice",
       "surface": "android",
@@ -5291,7 +5291,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1009,
+      "line": 1025,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Remove attachment",
       "surface": "android",
@@ -5299,7 +5299,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1021,
+      "line": 1037,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "New chat",
       "surface": "android",
@@ -5307,7 +5307,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1030,
+      "line": 1046,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Main",
       "surface": "android",
@@ -5315,7 +5315,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1086,
+      "line": 1102,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Send",
       "surface": "android",
@@ -5323,7 +5323,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1125,
+      "line": 1141,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "$contextLabel · ${contextMeterThinkingLabel(thinkingLevel)}",
       "surface": "android",

--- a/apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt
@@ -286,7 +286,15 @@ private fun ChatSessionSwitcher(
         mainSessionKey = mainSessionKey,
       )
     }
-  if (allChoices.size <= 1) return
+  val hasMoreSessions =
+    remember(sessions, choices, mainSessionKey) {
+      hasAdditionalSessionChoices(
+        sessions = sessions,
+        displayedChoices = choices,
+        mainSessionKey = mainSessionKey,
+      )
+    }
+  if (choices.size <= 1 && !hasMoreSessions) return
 
   Row(
     modifier = Modifier.fillMaxWidth().horizontalScroll(rememberScrollState()),
@@ -300,7 +308,7 @@ private fun ChatSessionSwitcher(
         onClick = { onSelectSession(entry.key) },
       )
     }
-    if (allChoices.size > choices.size) {
+    if (hasMoreSessions) {
       Surface(
         onClick = onOpenSessions,
         modifier = Modifier.heightIn(min = ClawTheme.spacing.touchTarget),

--- a/apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt
@@ -270,15 +270,23 @@ private fun ChatSessionSwitcher(
   onSelectSession: (String) -> Unit,
   onOpenSessions: () -> Unit,
 ) {
-  val choices =
+  val allChoices =
     remember(sessionKey, sessions, mainSessionKey) {
-      resolveCompactSessionChoices(
+      resolveSessionChoices(
         currentSessionKey = sessionKey,
         sessions = sessions,
         mainSessionKey = mainSessionKey,
       )
     }
-  if (choices.size <= 1 && sessions.size <= 1) return
+  val choices =
+    remember(sessionKey, allChoices, mainSessionKey) {
+      compactSessionChoices(
+        choices = allChoices,
+        currentSessionKey = sessionKey,
+        mainSessionKey = mainSessionKey,
+      )
+    }
+  if (allChoices.size <= 1) return
 
   Row(
     modifier = Modifier.fillMaxWidth().horizontalScroll(rememberScrollState()),
@@ -292,7 +300,7 @@ private fun ChatSessionSwitcher(
         onClick = { onSelectSession(entry.key) },
       )
     }
-    if (sessions.size > choices.size) {
+    if (allChoices.size > choices.size) {
       Surface(
         onClick = onOpenSessions,
         modifier = Modifier.heightIn(min = ClawTheme.spacing.touchTarget),

--- a/apps/android/app/src/main/java/ai/openclaw/app/ui/chat/SessionFilters.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/ui/chat/SessionFilters.kt
@@ -1,6 +1,7 @@
 package ai.openclaw.app.ui.chat
 
 import ai.openclaw.app.chat.ChatSessionEntry
+import java.util.Locale
 
 private const val RECENT_WINDOW_MS = 24 * 60 * 60 * 1000L
 
@@ -17,6 +18,56 @@ fun friendlySessionName(key: String): String {
 
   val result = words.joinToString(" ")
   return result.ifBlank { key }
+}
+
+/** Mirrors iOS CommandCenterTab.isRecentChatSession for thread-picker parity. */
+internal fun isSelectableChatSession(
+  key: String,
+  mainSessionKey: String,
+): Boolean {
+  val trimmed = key.trim()
+  if (trimmed.isEmpty()) return false
+  val mainKey = mainSessionKey.trim().ifEmpty { "main" }
+  if (trimmed == mainKey) return false
+  val normalized = trimmed.lowercase(Locale.US)
+  val defaultBase = sessionBaseKey(mainKey)
+  if (!normalized.contains(":") && isDirectSessionBase(normalized, defaultBase)) {
+    return false
+  }
+  if (isHiddenInternalSession(trimmed)) return false
+  return !isAgentDeviceSession(trimmed, mainKey)
+}
+
+private fun isHiddenInternalSession(key: String): Boolean {
+  val trimmed = key.trim()
+  if (trimmed.isEmpty()) return false
+  return trimmed == "onboarding" || trimmed.endsWith(":onboarding")
+}
+
+private fun isAgentDeviceSession(
+  key: String,
+  mainSessionKey: String,
+): Boolean {
+  val parts = key.trim().split(':', ignoreCase = false)
+  if (parts.size < 3 || parts[0].lowercase(Locale.US) != "agent") return false
+  if (parts.size != 3 && parts.getOrNull(3)?.lowercase(Locale.US) != "thread") return false
+
+  val base = parts[2].trim().lowercase(Locale.US)
+  val defaultBase = sessionBaseKey(mainSessionKey)
+  return isDirectSessionBase(base, defaultBase)
+}
+
+private fun isDirectSessionBase(
+  base: String,
+  defaultBase: String,
+): Boolean = base == defaultBase || base == "main" || base == "global" || base.startsWith("node-")
+
+private fun sessionBaseKey(key: String): String {
+  val parts = key.trim().split(':', ignoreCase = false)
+  if (parts.size < 3 || parts[0].lowercase(Locale.US) != "agent") {
+    return key.trim().lowercase(Locale.US)
+  }
+  return parts[2].trim().lowercase(Locale.US)
 }
 
 /** Builds the selectable recent-session list while preserving the active session. */
@@ -36,6 +87,7 @@ fun resolveSessionChoices(
   for (entry in sorted) {
     // Hide the legacy main alias when the gateway has supplied a canonical main session key.
     if (aliasKey != null && entry.key == aliasKey) continue
+    if (!isSelectableChatSession(entry.key, mainKey)) continue
     if (!seen.add(entry.key)) continue
     if ((entry.updatedAtMs ?: 0L) < cutoff) continue
     recent.add(entry)
@@ -58,7 +110,7 @@ fun resolveSessionChoices(
     }
   }
 
-  if (current.isNotEmpty() && !included.contains(current)) {
+  if (current.isNotEmpty() && !included.contains(current) && isSelectableChatSession(current, mainKey)) {
     // Keep the active session selectable even if it is old or missing from the recent list.
     result.add(ChatSessionEntry(key = current, updatedAtMs = null))
   }

--- a/apps/android/app/src/main/java/ai/openclaw/app/ui/chat/SessionFilters.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/ui/chat/SessionFilters.kt
@@ -1,7 +1,6 @@
 package ai.openclaw.app.ui.chat
 
 import ai.openclaw.app.chat.ChatSessionEntry
-import java.util.Locale
 
 private const val RECENT_WINDOW_MS = 24 * 60 * 60 * 1000L
 
@@ -20,41 +19,26 @@ fun friendlySessionName(key: String): String {
   return result.ifBlank { key }
 }
 
-/** Mirrors iOS CommandCenterTab.isRecentChatSession for thread-picker parity. */
+/** Keeps transport/device sessions out of chat pickers while preserving channel conversations. */
 internal fun isSelectableChatSession(
   key: String,
   mainSessionKey: String,
 ): Boolean {
-  val trimmed = key.trim()
-  if (trimmed.isEmpty()) return false
+  val sessionKey = key.trim()
+  if (sessionKey.isEmpty()) return false
   val mainKey = mainSessionKey.trim().ifEmpty { "main" }
-  if (trimmed == mainKey) return false
-  val normalized = trimmed.lowercase(Locale.US)
-  val defaultBase = sessionBaseKey(mainKey)
-  if (!normalized.contains(":") && isDirectSessionBase(normalized, defaultBase)) {
+  if (sessionKey == mainKey || sessionKey == "onboarding" || sessionKey.endsWith(":onboarding")) {
     return false
   }
-  if (isHiddenInternalSession(trimmed)) return false
-  return !isAgentDeviceSession(trimmed, mainKey)
-}
 
-private fun isHiddenInternalSession(key: String): Boolean {
-  val trimmed = key.trim()
-  if (trimmed.isEmpty()) return false
-  return trimmed == "onboarding" || trimmed.endsWith(":onboarding")
-}
-
-private fun isAgentDeviceSession(
-  key: String,
-  mainSessionKey: String,
-): Boolean {
-  val parts = key.trim().split(':', ignoreCase = false)
-  if (parts.size < 3 || parts[0].lowercase(Locale.US) != "agent") return false
-  if (parts.size != 3 && parts.getOrNull(3)?.lowercase(Locale.US) != "thread") return false
-
-  val base = parts[2].trim().lowercase(Locale.US)
-  val defaultBase = sessionBaseKey(mainSessionKey)
-  return isDirectSessionBase(base, defaultBase)
+  val parts = sessionKey.lowercase().split(':')
+  val directBase =
+    when {
+      parts.size == 1 -> parts.single()
+      parts.size >= 3 && parts[0] == "agent" && (parts.size == 3 || parts[3] == "thread") -> parts[2].trim()
+      else -> return true
+    }
+  return !isDirectSessionBase(directBase, sessionBaseKey(mainKey))
 }
 
 private fun isDirectSessionBase(
@@ -63,11 +47,9 @@ private fun isDirectSessionBase(
 ): Boolean = base == defaultBase || base == "main" || base == "global" || base.startsWith("node-")
 
 private fun sessionBaseKey(key: String): String {
-  val parts = key.trim().split(':', ignoreCase = false)
-  if (parts.size < 3 || parts[0].lowercase(Locale.US) != "agent") {
-    return key.trim().lowercase(Locale.US)
-  }
-  return parts[2].trim().lowercase(Locale.US)
+  val normalized = key.trim().lowercase()
+  val parts = normalized.split(':')
+  return if (parts.size >= 3 && parts[0] == "agent") parts[2].trim() else normalized
 }
 
 /** Builds the selectable recent-session list while preserving the active session. */
@@ -132,6 +114,20 @@ fun resolveCompactSessionChoices(
       mainSessionKey = mainSessionKey,
       nowMs = nowMs,
     )
+  return compactSessionChoices(
+    choices = allChoices,
+    currentSessionKey = currentSessionKey,
+    mainSessionKey = mainSessionKey,
+    maxOptions = maxOptions,
+  )
+}
+
+internal fun compactSessionChoices(
+  choices: List<ChatSessionEntry>,
+  currentSessionKey: String,
+  mainSessionKey: String,
+  maxOptions: Int = 5,
+): List<ChatSessionEntry> {
   val mainKey = mainSessionKey.trim().ifEmpty { "main" }
   val current = currentSessionKey.trim().let { if (it == "main" && mainKey != "main") mainKey else it }
   val pinnedRank =
@@ -142,7 +138,7 @@ fun resolveCompactSessionChoices(
       .associate { it.value to it.index }
   val unpinnedRank = pinnedRank.size
 
-  return allChoices
+  return choices
     .withIndex()
     .sortedWith(compareBy({ pinnedRank[it.value.key] ?: unpinnedRank }, { it.index }))
     .take(maxOptions)

--- a/apps/android/app/src/main/java/ai/openclaw/app/ui/chat/SessionFilters.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/ui/chat/SessionFilters.kt
@@ -144,3 +144,18 @@ internal fun compactSessionChoices(
     .take(maxOptions)
     .map { it.value }
 }
+
+internal fun hasAdditionalSessionChoices(
+  sessions: List<ChatSessionEntry>,
+  displayedChoices: List<ChatSessionEntry>,
+  mainSessionKey: String,
+): Boolean {
+  val mainKey = mainSessionKey.trim().ifEmpty { "main" }
+  val aliasKey = if (mainKey == "main") null else "main"
+  val displayedKeys = displayedChoices.mapTo(mutableSetOf()) { it.key }
+  return sessions.any { entry ->
+    entry.key != aliasKey &&
+      entry.key !in displayedKeys &&
+      (entry.key == mainKey || isSelectableChatSession(entry.key, mainKey))
+  }
+}

--- a/apps/android/app/src/test/java/ai/openclaw/app/ui/chat/SessionFiltersTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/ui/chat/SessionFiltersTest.kt
@@ -2,6 +2,8 @@ package ai.openclaw.app.ui.chat
 
 import ai.openclaw.app.chat.ChatSessionEntry
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
 import org.junit.Test
 
 class SessionFiltersTest {
@@ -56,5 +58,30 @@ class SessionFiltersTest {
       ).map { it.key }
 
     assertEquals(listOf("main", "active-old", "recent-1", "recent-2"), result)
+  }
+
+  @Test
+  fun sessionChoicesFilterAgentDeviceAndInternalSessions() {
+    val now = 1_700_000_000_000L
+    val recent = now - 10 * 60 * 1000L
+    val sessions =
+      listOf(
+        ChatSessionEntry(key = "agent:main:node-android", updatedAtMs = recent),
+        ChatSessionEntry(key = "agent:main:slack:channel:C1", updatedAtMs = recent),
+        ChatSessionEntry(key = "agent:main:main", updatedAtMs = recent),
+        ChatSessionEntry(key = "main", updatedAtMs = recent),
+      )
+
+    val result = resolveSessionChoices("main", sessions, mainSessionKey = "main", nowMs = now).map { it.key }
+
+    assertEquals(listOf("main", "agent:main:slack:channel:C1"), result)
+  }
+
+  @Test
+  fun isSelectableChatSession_matchesIosRecentSessionFilter() {
+    assertFalse(isSelectableChatSession("agent:main:node-0b88d67b7e42", "main"))
+    assertFalse(isSelectableChatSession("agent:main:main", "main"))
+    assertFalse(isSelectableChatSession("onboarding", "main"))
+    assertTrue(isSelectableChatSession("agent:main:slack:channel:C1", "main"))
   }
 }

--- a/apps/android/app/src/test/java/ai/openclaw/app/ui/chat/SessionFiltersTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/ui/chat/SessionFiltersTest.kt
@@ -84,6 +84,21 @@ class SessionFiltersTest {
   }
 
   @Test
+  fun additionalChoicesIgnoreHiddenSessionsButIncludeStaleChats() {
+    val displayed = listOf(ChatSessionEntry(key = "main", updatedAtMs = null))
+    val hiddenOnly =
+      listOf(
+        ChatSessionEntry(key = "main", updatedAtMs = null),
+        ChatSessionEntry(key = "agent:main:node-android", updatedAtMs = null),
+        ChatSessionEntry(key = "agent:main:onboarding", updatedAtMs = null),
+      )
+    assertFalse(hasAdditionalSessionChoices(hiddenOnly, displayed, mainSessionKey = "main"))
+
+    val withStaleChat = hiddenOnly + ChatSessionEntry(key = "old-channel", updatedAtMs = 1L)
+    assertTrue(hasAdditionalSessionChoices(withStaleChat, displayed, mainSessionKey = "main"))
+  }
+
+  @Test
   fun isSelectableChatSession_matchesIosRecentSessionFilter() {
     val hidden =
       listOf(

--- a/apps/android/app/src/test/java/ai/openclaw/app/ui/chat/SessionFiltersTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/ui/chat/SessionFiltersTest.kt
@@ -72,16 +72,52 @@ class SessionFiltersTest {
         ChatSessionEntry(key = "main", updatedAtMs = recent),
       )
 
-    val result = resolveSessionChoices("main", sessions, mainSessionKey = "main", nowMs = now).map { it.key }
+    val result =
+      resolveSessionChoices(
+        "agent:main:node-current",
+        sessions,
+        mainSessionKey = "main",
+        nowMs = now,
+      ).map { it.key }
 
     assertEquals(listOf("main", "agent:main:slack:channel:C1"), result)
   }
 
   @Test
   fun isSelectableChatSession_matchesIosRecentSessionFilter() {
-    assertFalse(isSelectableChatSession("agent:main:node-0b88d67b7e42", "main"))
-    assertFalse(isSelectableChatSession("agent:main:main", "main"))
-    assertFalse(isSelectableChatSession("onboarding", "main"))
-    assertTrue(isSelectableChatSession("agent:main:slack:channel:C1", "main"))
+    val hidden =
+      listOf(
+        "main" to "main",
+        "agent:main:main" to "main",
+        "agent:rust-claw:main" to "main",
+        "agent:main:node-0b88d67b7e42" to "main",
+        "agent:main:work" to "work",
+        "main" to "agent:rust-claw:work",
+        "global" to "agent:rust-claw:work",
+        "node-0b88d67b7e42" to "agent:rust-claw:work",
+        "work" to "agent:rust-claw:work",
+        "agent:main:work" to "agent:rust-claw:work",
+        "agent:main:main:thread:42" to "main",
+        "agent:support:main:thread:1234:42" to "main",
+        "agent:main:node-0b88d67b7e42:thread:42" to "main",
+        "agent:main:work:thread:42" to "work",
+        "agent:main:work:thread:42" to "agent:rust-claw:work",
+        "onboarding" to "main",
+        "agent:main:onboarding" to "main",
+      )
+    for ((key, mainKey) in hidden) {
+      assertFalse("expected hidden session: $key (main: $mainKey)", isSelectableChatSession(key, mainKey))
+    }
+
+    val selectable =
+      listOf(
+        "agent:main:signal:direct:+15555550123",
+        "agent:rust-claw:mattermost:channel:abc123",
+        "agent:rust-claw:cron:3cd2eb6f-b8a5-4db7-b74a-f6a3f7eab3d3",
+        "agent:main:slack:channel:c1:thread:123",
+      )
+    for (key in selectable) {
+      assertTrue("expected selectable session: $key", isSelectableChatSession(key, "main"))
+    }
   }
 }


### PR DESCRIPTION
## What Problem This Solves

Android's chat thread picker exposed transport/device and internal sessions such as `agent:main:node-*`, main aliases, and onboarding. Raw hidden sessions could also create a misleading **All** chip, while counting only recent visible sessions would hide **All** when valid older conversations existed.

## Why This Change Was Made

- Centralize selectable-session classification beside Android session-choice resolution, with the full iOS behavior table as parity coverage.
- Filter before injecting the active session so a hidden current device session cannot reappear.
- Derive the **All** affordance from undisplayed selectable sessions, not raw session count or only the 24-hour recent subset.
- Preserve pinned main/current behavior and compact chips without adding parallel filtering paths.

## User Impact

The picker now shows user-facing conversations only. Device, direct/internal, main-alias, and onboarding rows disappear; channel conversations remain selectable; and valid older sessions remain reachable through **All**.

## Evidence

Exact head: `51a96cab192b560d9762d851e4728f97af705335`

- `ANDROID_HOME=$HOME/Library/Android/sdk ./gradlew :app:testPlayDebugUnitTest --tests ai.openclaw.app.ui.chat.SessionFiltersTest :app:assemblePlayDebug`
- `node --import tsx scripts/native-app-i18n.ts check`
- Fresh Codex autoreview after fixing its stale-session navigation finding: no actionable findings.
- Android 16 emulator connected to an isolated real Gateway seeded with synthetic main, device, onboarding, and channel sessions.

| Before | After |
| --- | --- |
| <img width="1080" alt="Before: picker shows Main, Device Node Proof, and Onboarding Proof" src="https://github.com/user-attachments/assets/3d26aad4-da11-4bcb-9f81-10ba72a08da7" /> | <img width="1080" alt="After: picker shows only Main and Channel Proof" src="https://github.com/user-attachments/assets/2f86e616-7a0c-445a-b920-2e4755ccfef1" /> |

The screenshots contain synthetic session labels only. The candidate also removes the bogus **All** row caused solely by filtered internal sessions; focused tests preserve **All** when an undisplayed selectable conversation is stale or compacted.
