### PR TITLE
fix(android): parse string booleans in talk gateway config

### DIFF
--- a/apps/android/app/src/main/java/ai/openclaw/app/voice/TalkModeGatewayConfig.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/voice/TalkModeGatewayConfig.kt
@@ -46,7 +46,14 @@ private fun JsonElement?.asStringOrNull(): String? =
 
 private fun JsonElement?.asBooleanOrNull(): Boolean? {
   val primitive = this as? JsonPrimitive ?: return null
-  return primitive.booleanOrNull
+  primitive.booleanOrNull?.let { return it }
+  val content = primitive.content.trim().lowercase()
+  // Accept gateway config-style booleans in addition to strict JSON literals.
+  return when (content) {
+    "true", "yes", "1" -> true
+    "false", "no", "0" -> false
+    else -> null
+  }
 }
 
 private fun JsonElement?.asObjectOrNull(): JsonObject? = this as? JsonObject

--- a/apps/android/app/src/test/java/ai/openclaw/app/voice/TalkModeConfigParsingTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/voice/TalkModeConfigParsingTest.kt
@@ -62,4 +62,23 @@ class TalkModeConfigParsingTest {
       TalkModeGatewayConfigParser.resolvedSilenceTimeoutMs(talk),
     )
   }
+
+  @Test
+  fun parsesStringInterruptOnSpeechFlag() {
+    val config =
+      json
+        .parseToJsonElement(
+          """
+          {
+            "talk": {
+              "interruptOnSpeech": "true"
+            }
+          }
+          """.trimIndent(),
+        ).jsonObject
+
+    val parsed = TalkModeGatewayConfigParser.parse(config)
+
+    assertEquals(true, parsed.interruptOnSpeech)
+  }
 }


### PR DESCRIPTION
## What Problem This Solves

Gateway talk config values like interruptOnSpeech: true` were ignored because `TalkModeGatewayConfigParser` only accepted JSON boolean literals.

## Why This Change Was Made

Reuse the same string boolean parsing convention already used by `TalkDirectiveParser` and `GatewaySession`.

## User Impact

Talk interrupt-on-speech honors string gateway config values.

## Evidence

- `TalkModeConfigParsingTest.parsesStringInterruptOnSpeechFlag`

```bash
cd apps/android
./gradlew :app:testPlayDebugUnitTest --tests ai.openclaw.app.voice.TalkModeConfigParsingTest
```