### PR TITLE
fix(android): block self-package notification forwarding in allowlist mode

### DIFF
--- a/apps/android/app/src/main/java/ai/openclaw/app/NotificationForwardingPolicy.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/NotificationForwardingPolicy.kt
@@ -27,12 +27,17 @@ internal data class NotificationForwardingPolicy(
   val quietEnd: String,
   val maxEventsPerMinute: Int,
   val sessionKey: String?,
+  val selfPackageName: String = "",
 )
 
 /** Applies the operator-configured package allow/block list after trimming input. */
 internal fun NotificationForwardingPolicy.allowsPackage(packageName: String): Boolean {
   val normalized = packageName.trim()
   if (normalized.isEmpty()) {
+    return false
+  }
+  val self = selfPackageName.trim()
+  if (self.isNotEmpty() && normalized == self) {
     return false
   }
   return when (mode) {

--- a/apps/android/app/src/main/java/ai/openclaw/app/SecurePrefs.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/SecurePrefs.kt
@@ -313,6 +313,7 @@ class SecurePrefs(
       quietEnd = quietEnd,
       maxEventsPerMinute = maxEvents.coerceAtLeast(1),
       sessionKey = sessionKey,
+      selfPackageName = normalizedAppPackage,
     )
   }
 

--- a/apps/android/app/src/test/java/ai/openclaw/app/NotificationForwardingPolicyTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/NotificationForwardingPolicyTest.kt
@@ -78,6 +78,25 @@ class NotificationForwardingPolicyTest {
   }
 
   @Test
+  fun allowsPackage_neverForwardsSelfPackageEvenInAllowlist() {
+    val policy =
+      NotificationForwardingPolicy(
+        enabled = true,
+        mode = NotificationPackageFilterMode.Allowlist,
+        packages = setOf("ai.openclaw.app", "com.other.app"),
+        quietHoursEnabled = false,
+        quietStart = "22:00",
+        quietEnd = "07:00",
+        maxEventsPerMinute = 20,
+        sessionKey = null,
+        selfPackageName = "ai.openclaw.app",
+      )
+
+    assertFalse(policy.allowsPackage("ai.openclaw.app"))
+    assertTrue(policy.allowsPackage("com.other.app"))
+  }
+
+  @Test
   fun isWithinQuietHours_handlesWindowCrossingMidnight() {
     val policy =
       NotificationForwardingPolicy(

--- a/apps/android/app/src/test/java/ai/openclaw/app/SecurePrefsNotificationForwardingTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/SecurePrefsNotificationForwardingTest.kt
@@ -128,4 +128,20 @@ class SecurePrefsNotificationForwardingTest {
     assertFalse(policy.enabled)
     assertEquals(NotificationPackageFilterMode.Blocklist, policy.mode)
   }
+
+  @Test
+  fun getNotificationForwardingPolicy_blocksSelfPackageInAllowlistMode() {
+    val context = RuntimeEnvironment.getApplication()
+    val plainPrefs = context.getSharedPreferences("openclaw.node", Context.MODE_PRIVATE)
+    plainPrefs.edit().clear().commit()
+
+    val prefs = SecurePrefs(context)
+    prefs.setNotificationForwardingMode(NotificationPackageFilterMode.Allowlist)
+    prefs.setNotificationForwardingPackages(listOf("ai.openclaw.app", "com.other.app"))
+
+    val policy = prefs.getNotificationForwardingPolicy(appPackageName = "ai.openclaw.app")
+
+    assertFalse(policy.allowsPackage("ai.openclaw.app"))
+    assertTrue(policy.allowsPackage("com.other.app"))
+  }
 }


### PR DESCRIPTION
## What Problem This Solves

Notification allowlist mode could forward OpenClaw's own notifications when the app package was allowlisted, risking gateway/node forwarding loops. Blocklist mode already blocked self by default.

## Why This Change Was Made

Carry the app package through `NotificationForwardingPolicy.selfPackageName` and fail closed in `allowsPackage` regardless of filter mode.

## User Impact

Allowlists cannot accidentally forward OpenClaw app notifications to the gateway.

## Evidence

- `NotificationForwardingPolicyTest.allowsPackage_neverForwardsSelfPackageEvenInAllowlist`
- `SecurePrefsNotificationForwardingTest.getNotificationForwardingPolicy_blocksSelfPackageInAllowlistMode`

```bash
cd apps/android
./gradlew :app:testPlayDebugUnitTest --tests ai.openclaw.app.NotificationForwardingPolicyTest --tests ai.openclaw.app.SecurePrefsNotificationForwardingTest
```