### PR TITLE
fix(android): normalize IPv6 zone IDs in gateway endpoint hosts

### DIFF
--- a/apps/android/app/src/main/java/ai/openclaw/app/ui/GatewayConfigResolver.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/ui/GatewayConfigResolver.kt
@@ -201,11 +201,7 @@ internal fun parseGatewayEndpointResult(rawInput: String): GatewayEndpointParseR
   val uri =
     runCatching { URI(normalized) }.getOrNull()
       ?: return GatewayEndpointParseResult(error = GatewayEndpointValidationError.INVALID_URL)
-  val host =
-    uri.host
-      ?.trim()
-      ?.trim('[', ']')
-      .orEmpty()
+  val host = normalizeGatewayConnectionHost(uri.host?.trim()?.trim('[', ']').orEmpty())
   if (host.isEmpty()) return GatewayEndpointParseResult(error = GatewayEndpointValidationError.INVALID_URL)
 
   val scheme =
@@ -340,6 +336,16 @@ internal fun composeGatewayManualUrl(
   if (port !in 1..65535) return null
   val scheme = if (tls) "https" else "http"
   return "$scheme://${ai.openclaw.app.gateway.formatGatewayAuthority(bareHost, port)}"
+}
+
+/** Strips IPv6 interface zones so parsed hosts match socket-ready literals. */
+internal fun normalizeGatewayConnectionHost(rawHost: String): String {
+  var host = rawHost.trim().trim('[', ']')
+  val zoneIndex = host.indexOf('%')
+  if (zoneIndex >= 0) {
+    host = host.substring(0, zoneIndex)
+  }
+  return host
 }
 
 private fun parseJsonObject(input: String): JsonObject? = runCatching { gatewaySetupJson.parseToJsonElement(input).jsonObject }.getOrNull()

--- a/apps/android/app/src/test/java/ai/openclaw/app/ui/GatewayConfigResolverTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/ui/GatewayConfigResolverTest.kt
@@ -192,20 +192,20 @@ class GatewayConfigResolverTest {
   fun parseGatewayEndpointAllowsLinkLocalIpv6ZoneCleartextWsUrls() {
     val parsed = parseGatewayEndpoint("ws://[fe80::1%25eth0]")
 
-    assertEquals("fe80::1%25eth0", parsed?.host)
+    assertEquals("fe80::1", parsed?.host)
     assertEquals(18789, parsed?.port)
     assertEquals(false, parsed?.tls)
-    assertEquals("http://[fe80::1%25eth0]:18789", parsed?.displayUrl)
+    assertEquals("http://[fe80::1]:18789", parsed?.displayUrl)
   }
 
   @Test
   fun parseGatewayEndpointAllowsSecureIpv6ZoneUrls() {
     val parsed = parseGatewayEndpoint("wss://[fe80::1%25wlan0]:443")
 
-    assertEquals("fe80::1%25wlan0", parsed?.host)
+    assertEquals("fe80::1", parsed?.host)
     assertEquals(443, parsed?.port)
     assertEquals(true, parsed?.tls)
-    assertEquals("https://[fe80::1%25wlan0]", parsed?.displayUrl)
+    assertEquals("https://[fe80::1]", parsed?.displayUrl)
   }
 
   @Test


### PR DESCRIPTION
## What Problem This Solves

IPv6 zone URLs such as `ws://[fe80::1%25eth0]` passed cleartext validation but stored `%25eth0` in the connection host, which can break socket connect even though cleartext policy checks strip the zone.

## Why This Change Was Made

Normalize gateway endpoint hosts with `normalizeGatewayConnectionHost` so parsed hosts are socket-ready literals like `fe80::1`.

## User Impact

Link-local IPv6 manual/QR gateway URLs connect using bare IPv6 literals.

## Evidence

- Updated `GatewayConfigResolverTest.parseGatewayEndpointAllowsLinkLocalIpv6ZoneCleartextWsUrls`
- Updated `GatewayConfigResolverTest.parseGatewayEndpointAllowsSecureIpv6ZoneUrls`

```bash
cd apps/android
./gradlew :app:testPlayDebugUnitTest --tests ai.openclaw.app.ui.GatewayConfigResolverTest.parseGatewayEndpointAllowsLinkLocalIpv6ZoneCleartextWsUrls --tests ai.openclaw.app.ui.GatewayConfigResolverTest.parseGatewayEndpointAllowsSecureIpv6ZoneUrls
```