### PR TITLE
fix(memory): spawn embedding worker from launched node

### DIFF
--- a/packages/memory-host-sdk/src/host/embeddings-worker.ts
+++ b/packages/memory-host-sdk/src/host/embeddings-worker.ts
@@ -234,6 +234,7 @@ class LocalEmbeddingWorkerClient {
     }
 
     const child = fork(this.scriptPath, [], {
+      execPath: process.argv[0],
       execArgv: resolveWorkerExecArgv(),
       serialization: "json",
       stdio: ["ignore", "ignore", "ignore", "ipc"],

--- a/packages/memory-host-sdk/src/host/embeddings.test.ts
+++ b/packages/memory-host-sdk/src/host/embeddings.test.ts
@@ -555,6 +555,50 @@ process.on("message", (message) => {
     }
   });
 
+  it("uses the launched node path when process.execPath points at a deleted binary", async () => {
+    const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-local-embedding-worker-"));
+    const workerScript = path.join(tempDir, "worker.cjs");
+    await fs.writeFile(
+      workerScript,
+      `
+process.on("message", (message) => {
+  if (message.type === "initialize" || message.type === "close") {
+    process.send({ id: message.id, ok: true });
+    return;
+  }
+  process.send({ id: message.id, ok: true, value: [1] });
+});
+`,
+      "utf8",
+    );
+
+    const originalExecPathDescriptor = Object.getOwnPropertyDescriptor(process, "execPath");
+    let provider: Awaited<ReturnType<typeof createLocalEmbeddingWorkerProvider>> | undefined;
+    try {
+      Object.defineProperty(process, "execPath", {
+        value: path.join(tempDir, "deleted-node"),
+        configurable: true,
+        enumerable: true,
+        writable: true,
+      });
+      provider = await createLocalEmbeddingWorkerProvider(
+        {
+          config: {} as never,
+          provider: "local",
+          model: "",
+          fallback: "none",
+        },
+        { workerScriptPath: workerScript },
+      );
+      await expect(provider.embedQuery("hello")).resolves.toEqual([1]);
+    } finally {
+      if (originalExecPathDescriptor) {
+        Object.defineProperty(process, "execPath", originalExecPathDescriptor);
+      }
+      await provider?.close?.();
+    }
+  });
+
   it("reports worker initialization failures during provider creation", async () => {
     const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-local-embedding-worker-"));
     const workerScript = path.join(tempDir, "worker.cjs");


### PR DESCRIPTION
## Summary
- spawn local embedding workers with the launched Node executable (`process.argv[0]`) instead of the resolved `process.execPath`
- cover the deleted-`execPath` case so worker startup keeps working after a Homebrew Node upgrade removes the old Cellar path

## Test plan
- `node scripts/run-vitest.mjs packages/memory-host-sdk/src/host/embeddings.test.ts -- --reporter=dot --maxWorkers=1 --testTimeout=10000 --teardownTimeout=5000`
- `git diff --check`