### PR TITLE
fix(android): block self-package notification forwarding in allowlist mode

### DIFF
--- a/apps/android/app/src/main/java/ai/openclaw/app/NotificationForwardingPolicy.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/NotificationForwardingPolicy.kt
@@ -27,12 +27,17 @@ internal data class NotificationForwardingPolicy(
   val quietEnd: String,
   val maxEventsPerMinute: Int,
   val sessionKey: String?,
+  val selfPackageName: String = "",
 )
 
 /** Applies the operator-configured package allow/block list after trimming input. */
 internal fun NotificationForwardingPolicy.allowsPackage(packageName: String): Boolean {
   val normalized = packageName.trim()
   if (normalized.isEmpty()) {
+    return false
+  }
+  val self = selfPackageName.trim()
+  if (self.isNotEmpty() && normalized == self) {
     return false
   }
   return when (mode) {

--- a/apps/android/app/src/main/java/ai/openclaw/app/SecurePrefs.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/SecurePrefs.kt
@@ -313,6 +313,7 @@ class SecurePrefs(
       quietEnd = quietEnd,
       maxEventsPerMinute = maxEvents.coerceAtLeast(1),
       sessionKey = sessionKey,
+      selfPackageName = normalizedAppPackage,
     )
   }
 

--- a/apps/android/app/src/test/java/ai/openclaw/app/NotificationForwardingPolicyTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/NotificationForwardingPolicyTest.kt
@@ -78,6 +78,25 @@ class NotificationForwardingPolicyTest {
   }
 
   @Test
+  fun allowsPackage_neverForwardsSelfPackageEvenInAllowlist() {
+    val policy =
+      NotificationForwardingPolicy(
+        enabled = true,
+        mode = NotificationPackageFilterMode.Allowlist,
+        packages = setOf("ai.openclaw.app", "com.other.app"),
+        quietHoursEnabled = false,
+        quietStart = "22:00",
+        quietEnd = "07:00",
+        maxEventsPerMinute = 20,
+        sessionKey = null,
+        selfPackageName = "ai.openclaw.app",
+      )
+
+    assertFalse(policy.allowsPackage("ai.openclaw.app"))
+    assertTrue(policy.allowsPackage("com.other.app"))
+  }
+
+  @Test
   fun isWithinQuietHours_handlesWindowCrossingMidnight() {
     val policy =
       NotificationForwardingPolicy(

--- a/apps/android/app/src/test/java/ai/openclaw/app/SecurePrefsNotificationForwardingTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/SecurePrefsNotificationForwardingTest.kt
@@ -128,4 +128,20 @@ class SecurePrefsNotificationForwardingTest {
     assertFalse(policy.enabled)
     assertEquals(NotificationPackageFilterMode.Blocklist, policy.mode)
   }
+
+  @Test
+  fun getNotificationForwardingPolicy_blocksSelfPackageInAllowlistMode() {
+    val context = RuntimeEnvironment.getApplication()
+    val plainPrefs = context.getSharedPreferences("openclaw.node", Context.MODE_PRIVATE)
+    plainPrefs.edit().clear().commit()
+
+    val prefs = SecurePrefs(context)
+    prefs.setNotificationForwardingMode(NotificationPackageFilterMode.Allowlist)
+    prefs.setNotificationForwardingPackages(listOf("ai.openclaw.app", "com.other.app"))
+
+    val policy = prefs.getNotificationForwardingPolicy(appPackageName = "ai.openclaw.app")
+
+    assertFalse(policy.allowsPackage("ai.openclaw.app"))
+    assertTrue(policy.allowsPackage("com.other.app"))
+  }
 }


### PR DESCRIPTION
## What Problem This Solves

Android notification forwarding implicitly excluded OpenClaw's own package in blocklist mode, but retained it in allowlist mode. That left the canonical queued-event authorization path capable of accepting self-package events and forced listener callbacks to carry duplicate loop guards.

## Why This Change Was Made

- Resolve one final package policy in `SecurePrefs`: remove OpenClaw from allowlists and add it to blocklists.
- Delete callback-specific self-package branches so posted, removed, and queued/reconnect delivery all consume the same invariant.
- Add callback-level regression coverage showing self notifications are suppressed while another allowlisted package still forwards.

## User Impact

OpenClaw can no longer forward its own Android notifications back to the Gateway, even when stale settings contain its package in an allowlist. Other configured notification forwarding behavior is unchanged.

## Evidence

Exact head: `607c481ca9d5e6edcd242ce5c852f4d2e6a6084a`

- `ANDROID_HOME=$HOME/Library/Android/sdk ./gradlew :app:testPlayDebugUnitTest --tests ai.openclaw.app.NotificationForwardingPolicyTest --tests ai.openclaw.app.SecurePrefsNotificationForwardingTest --tests ai.openclaw.app.node.DeviceNotificationListenerServiceTest :app:assemblePlayDebug`
- Fresh Codex autoreview: no actionable findings.
- Android 16 emulator connected as a real node to an isolated Gateway, with forwarding enabled and a deliberately stale allowlist containing `ai.openclaw.app`.
- A real `system.notify` node invocation posted **Loop Proof** from `ai.openclaw.app`; a subsequent real `notifications.list` invocation returned that exact notification, proving the listener received and stored it. No `notifications.changed` / `node.event` reached Gateway ingress.

No screenshot is attached because this change has no UI delta; command output and ingress behavior are the relevant end-to-end proof.
