### PR TITLE
fix(android): parse string booleans in talk gateway config

### DIFF
--- a/apps/android/app/src/main/java/ai/openclaw/app/voice/TalkModeGatewayConfig.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/voice/TalkModeGatewayConfig.kt
@@ -46,7 +46,14 @@ private fun JsonElement?.asStringOrNull(): String? =
 
 private fun JsonElement?.asBooleanOrNull(): Boolean? {
   val primitive = this as? JsonPrimitive ?: return null
-  return primitive.booleanOrNull
+  primitive.booleanOrNull?.let { return it }
+  val content = primitive.content.trim().lowercase()
+  // Accept gateway config-style booleans in addition to strict JSON literals.
+  return when (content) {
+    "true", "yes", "1" -> true
+    "false", "no", "0" -> false
+    else -> null
+  }
 }
 
 private fun JsonElement?.asObjectOrNull(): JsonObject? = this as? JsonObject

--- a/apps/android/app/src/main/java/ai/openclaw/app/voice/TalkModeGatewayConfig.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/voice/TalkModeGatewayConfig.kt
@@ -48,10 +48,10 @@ private fun JsonElement?.asBooleanOrNull(): Boolean? {
   val primitive = this as? JsonPrimitive ?: return null
   primitive.booleanOrNull?.let { return it }
   val content = primitive.content.trim().lowercase()
-  // Accept gateway config-style booleans in addition to strict JSON literals.
+  // Accept only JSON-style string booleans; gateway schema defines interruptOnSpeech as Boolean.
   return when (content) {
-    "true", "yes", "1" -> true
-    "false", "no", "0" -> false
+    "true" -> true
+    "false" -> false
     else -> null
   }
 }

--- a/apps/android/app/src/test/java/ai/openclaw/app/voice/TalkModeConfigParsingTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/voice/TalkModeConfigParsingTest.kt
@@ -62,4 +62,23 @@ class TalkModeConfigParsingTest {
       TalkModeGatewayConfigParser.resolvedSilenceTimeoutMs(talk),
     )
   }
+
+  @Test
+  fun parsesStringInterruptOnSpeechFlag() {
+    val config =
+      json
+        .parseToJsonElement(
+          """
+          {
+            "talk": {
+              "interruptOnSpeech": "true"
+            }
+          }
+          """.trimIndent(),
+        ).jsonObject
+
+    val parsed = TalkModeGatewayConfigParser.parse(config)
+
+    assertEquals(true, parsed.interruptOnSpeech)
+  }
 }


### PR DESCRIPTION
## What Problem This Solves

`TalkModeGatewayConfigParser` only accepted strict JSON boolean literals for `interruptOnSpeech`. Gateway configs that serialize booleans as strings — for example `"interruptOnSpeech": "true"` — were silently ignored.

## Why This Change Was Made

Accept only JSON-style string booleans (`"true"` / `"false"`, case-insensitive) after trying `booleanOrNull`, matching the gateway schema's Boolean type. Does **not** accept off-contract aliases such as `"yes"`, `"no"`, `"1"`, or `"0"`.

## User Impact

Operators whose gateway config emits string `"true"`/`"false"` for talk settings will see `interruptOnSpeech` honored in Talk mode.

## Evidence

**Unit tests**
- `TalkModeConfigParsingTest.parsesStringInterruptOnSpeechFlag`
- `TalkModeConfigParsingTest.readsMainSessionKeyAndInterruptFlag`

**Local proof (Windows, branch `640ada7c6d`)**
```powershell
cd apps/android
.\gradlew.bat :app:testPlayDebugUnitTest --tests ai.openclaw.app.voice.TalkModeConfigParsingTest
```
- Result: `BUILD SUCCESSFUL in 57s`
- JUnit: 5 tests, 0 failures

**ClawSweeper follow-up:** narrowed string parsing to `"true"`/`"false"` only (removed `yes`/`no`/`1`/`0` aliases) per schema contract feedback.
