### PR TITLE
fix(litellm): honor Anthropic cache retention

### DIFF
--- a/docs/docs_map.md
+++ b/docs/docs_map.md
@@ -8734,6 +8734,7 @@ Do not edit it by hand; run `pnpm docs:map:gen`.
   - H3: OpenAI (direct API)
   - H3: Amazon Bedrock
   - H3: OpenRouter
+  - H3: LiteLLM
   - H3: Google Gemini (direct API)
   - H3: CLI-harness providers (Claude Code, Gemini CLI)
   - H3: Other providers

--- a/docs/providers/litellm.md
+++ b/docs/providers/litellm.md
@@ -63,6 +63,10 @@ spend limits, and backend failover without changing OpenClaw config.
             input: ["text", "image"],
             contextWindow: 200000,
             maxTokens: 64000,
+            compat: {
+              cacheControlFormat: "anthropic",
+              supportsLongCacheRetention: true,
+            },
           },
           {
             id: "gpt-4o",
@@ -176,8 +180,10 @@ without a global private-network override. For a LAN-hosted proxy, set
     - OpenClaw connects through LiteLLM's proxy-style OpenAI-compatible `/v1` endpoint.
     - Native-OpenAI-only request shaping does not apply through a configured LiteLLM base URL:
       no `service_tier`, no Responses `store`, no OpenAI reasoning-effort payload shaping. Anthropic
-      `cache_control` prompt-cache hints are only forwarded for Claude model IDs when
-      `cacheRetention` is explicitly set.
+      `cache_control` prompt-cache hints are only forwarded when the model explicitly sets
+      `compat.cacheControlFormat: "anthropic"` and `cacheRetention` is configured. Set
+      `compat.supportsLongCacheRetention: false` if the proxy/backend does not accept Anthropic's
+      one-hour `ttl: "1h"` cache control.
     - Hidden OpenClaw attribution headers (`originator`, `version`, `User-Agent`) are only sent to
       verified native OpenAI endpoints, so they are not injected on a custom LiteLLM base URL.
   </Accordion>

--- a/docs/providers/litellm.md
+++ b/docs/providers/litellm.md
@@ -175,8 +175,9 @@ without a global private-network override. For a LAN-hosted proxy, set
     - LiteLLM runs on `http://localhost:4000` by default.
     - OpenClaw connects through LiteLLM's proxy-style OpenAI-compatible `/v1` endpoint.
     - Native-OpenAI-only request shaping does not apply through a configured LiteLLM base URL:
-      no `service_tier`, no Responses `store`, no prompt-cache hints, no OpenAI reasoning-effort
-      payload shaping.
+      no `service_tier`, no Responses `store`, no OpenAI reasoning-effort payload shaping. Anthropic
+      `cache_control` prompt-cache hints are only forwarded for Claude model IDs when
+      `cacheRetention` is explicitly set.
     - Hidden OpenClaw attribution headers (`originator`, `version`, `User-Agent`) are only sent to
       verified native OpenAI endpoints, so they are not injected on a custom LiteLLM base URL.
   </Accordion>

--- a/docs/reference/prompt-caching.md
+++ b/docs/reference/prompt-caching.md
@@ -107,6 +107,15 @@ Source: `extensions/openrouter/index.ts` (`OPENROUTER_CACHE_TTL_MODEL_PREFIXES`)
 
 DeepSeek cache construction on OpenRouter is best-effort and can take a few seconds; an immediate follow-up request may still show `cached_tokens: 0`. Verify with a repeated same-prefix request after a short delay, using `usage.prompt_tokens_details.cached_tokens` as the cache-hit signal.
 
+### LiteLLM
+
+LiteLLM routes use the OpenAI-compatible transport, so OpenClaw cannot safely infer the backend's
+cache-control contract from the model name. For a LiteLLM route backed by Anthropic, set
+`compat.cacheControlFormat: "anthropic"` on the model and configure `cacheRetention` explicitly.
+`"short"` sends Anthropic's default ephemeral marker; `"long"` also sends `ttl: "1h"` unless
+`compat.supportsLongCacheRetention` is `false`. See [LiteLLM](/providers/litellm) for a complete
+configuration example.
+
 ### Google Gemini (direct API)
 
 - Direct Gemini transport (`api: "google-generative-ai"`) reports cache hits through upstream `cachedContentTokenCount`, mapped to `cacheRead`.

--- a/packages/ai/src/providers/openai-completions.test.ts
+++ b/packages/ai/src/providers/openai-completions.test.ts
@@ -975,6 +975,157 @@ describe("OpenAI-compatible completions params", () => {
     expect(JSON.stringify(carrierMsg)).not.toContain("cache_control");
   });
 
+  it("applies Anthropic cache control for explicit LiteLLM Claude cacheRetention", async () => {
+    let capturedMessages: unknown;
+    const stream = streamOpenAICompletions(
+      {
+        ...createModel(32_000),
+        id: "claude-sonnet-4-6",
+        provider: "litellm",
+        baseUrl: "https://litellm.example.com/v1",
+      },
+      {
+        systemPrompt: `Stable prefix${SYSTEM_PROMPT_CACHE_BOUNDARY}Dynamic suffix`,
+        messages: [{ role: "user", content: "hi", timestamp: 1 }],
+      },
+      {
+        apiKey: "sk-test",
+        cacheRetention: "short",
+        onPayload(payload) {
+          capturedMessages = (payload as { messages?: unknown }).messages;
+          throw new Error("stop before network");
+        },
+      },
+    );
+
+    const result = await stream.result();
+
+    expect(result.stopReason).toBe("error");
+    const messages = capturedMessages as Array<{ role: string; content: unknown }>;
+    expect(messages[0]).toEqual({
+      role: "system",
+      content: [
+        {
+          type: "text",
+          text: "Stable prefix",
+          cache_control: { type: "ephemeral" },
+        },
+        {
+          type: "text",
+          text: "Dynamic suffix",
+        },
+      ],
+    });
+  });
+
+  it("adds long-retention ttl for explicit LiteLLM Claude cacheRetention", async () => {
+    let capturedMessages: unknown;
+    const stream = streamOpenAICompletions(
+      {
+        ...createModel(32_000),
+        id: "anthropic/claude-opus-4-6",
+        provider: "litellm",
+        baseUrl: "https://litellm.example.com/v1",
+      },
+      {
+        systemPrompt: `Stable prefix${SYSTEM_PROMPT_CACHE_BOUNDARY}Dynamic suffix`,
+        messages: [{ role: "user", content: "hi", timestamp: 1 }],
+      },
+      {
+        apiKey: "sk-test",
+        cacheRetention: "long",
+        onPayload(payload) {
+          capturedMessages = (payload as { messages?: unknown }).messages;
+          throw new Error("stop before network");
+        },
+      },
+    );
+
+    const result = await stream.result();
+
+    expect(result.stopReason).toBe("error");
+    const messages = capturedMessages as Array<{ role: string; content: unknown }>;
+    expect(messages[0]).toEqual({
+      role: "system",
+      content: [
+        {
+          type: "text",
+          text: "Stable prefix",
+          cache_control: { type: "ephemeral", ttl: "1h" },
+        },
+        {
+          type: "text",
+          text: "Dynamic suffix",
+        },
+      ],
+    });
+  });
+
+  it("does not inject LiteLLM Claude cache control without explicit cacheRetention", async () => {
+    let capturedMessages: unknown;
+    const stream = streamOpenAICompletions(
+      {
+        ...createModel(32_000),
+        id: "claude-sonnet-4-6",
+        provider: "litellm",
+        baseUrl: "https://litellm.example.com/v1",
+      },
+      {
+        systemPrompt: `Stable prefix${SYSTEM_PROMPT_CACHE_BOUNDARY}Dynamic suffix`,
+        messages: [{ role: "user", content: "hi", timestamp: 1 }],
+      },
+      {
+        apiKey: "sk-test",
+        onPayload(payload) {
+          capturedMessages = (payload as { messages?: unknown }).messages;
+          throw new Error("stop before network");
+        },
+      },
+    );
+
+    const result = await stream.result();
+
+    expect(result.stopReason).toBe("error");
+    const messages = capturedMessages as Array<{ role: string; content: unknown }>;
+    expect(messages[0]).toEqual({
+      role: "system",
+      content: "Stable prefix\nDynamic suffix",
+    });
+  });
+
+  it("does not inject Anthropic cache control for non-Claude LiteLLM models", async () => {
+    let capturedMessages: unknown;
+    const stream = streamOpenAICompletions(
+      {
+        ...createModel(32_000),
+        id: "gpt-5.5",
+        provider: "litellm",
+        baseUrl: "https://litellm.example.com/v1",
+      },
+      {
+        systemPrompt: `Stable prefix${SYSTEM_PROMPT_CACHE_BOUNDARY}Dynamic suffix`,
+        messages: [{ role: "user", content: "hi", timestamp: 1 }],
+      },
+      {
+        apiKey: "sk-test",
+        cacheRetention: "short",
+        onPayload(payload) {
+          capturedMessages = (payload as { messages?: unknown }).messages;
+          throw new Error("stop before network");
+        },
+      },
+    );
+
+    const result = await stream.result();
+
+    expect(result.stopReason).toBe("error");
+    const messages = capturedMessages as Array<{ role: string; content: unknown }>;
+    expect(messages[0]).toEqual({
+      role: "system",
+      content: "Stable prefix\nDynamic suffix",
+    });
+  });
+
   it("adds reasoning_content replay fields for Xiaomi MiMo assistant tool history", async () => {
     let capturedMessages: unknown;
     const stream = streamOpenAICompletions(

--- a/packages/ai/src/providers/openai-completions.test.ts
+++ b/packages/ai/src/providers/openai-completions.test.ts
@@ -975,7 +975,7 @@ describe("OpenAI-compatible completions params", () => {
     expect(JSON.stringify(carrierMsg)).not.toContain("cache_control");
   });
 
-  it("applies Anthropic cache control for explicit LiteLLM Claude cacheRetention", async () => {
+  it("applies Anthropic cache control for explicitly capable LiteLLM cacheRetention", async () => {
     let capturedMessages: unknown;
     const stream = streamOpenAICompletions(
       {
@@ -983,6 +983,7 @@ describe("OpenAI-compatible completions params", () => {
         id: "claude-sonnet-4-6",
         provider: "litellm",
         baseUrl: "https://litellm.example.com/v1",
+        compat: { cacheControlFormat: "anthropic" },
       },
       {
         systemPrompt: `Stable prefix${SYSTEM_PROMPT_CACHE_BOUNDARY}Dynamic suffix`,
@@ -1018,7 +1019,7 @@ describe("OpenAI-compatible completions params", () => {
     });
   });
 
-  it("adds long-retention ttl for explicit LiteLLM Claude cacheRetention", async () => {
+  it("adds long-retention ttl for explicitly capable LiteLLM cacheRetention", async () => {
     let capturedMessages: unknown;
     const stream = streamOpenAICompletions(
       {
@@ -1026,6 +1027,7 @@ describe("OpenAI-compatible completions params", () => {
         id: "anthropic/claude-opus-4-6",
         provider: "litellm",
         baseUrl: "https://litellm.example.com/v1",
+        compat: { cacheControlFormat: "anthropic" },
       },
       {
         systemPrompt: `Stable prefix${SYSTEM_PROMPT_CACHE_BOUNDARY}Dynamic suffix`,
@@ -1061,7 +1063,7 @@ describe("OpenAI-compatible completions params", () => {
     });
   });
 
-  it("does not inject LiteLLM Claude cache control without explicit cacheRetention", async () => {
+  it("does not inject explicitly capable LiteLLM cache control without cacheRetention", async () => {
     let capturedMessages: unknown;
     const stream = streamOpenAICompletions(
       {
@@ -1069,6 +1071,7 @@ describe("OpenAI-compatible completions params", () => {
         id: "claude-sonnet-4-6",
         provider: "litellm",
         baseUrl: "https://litellm.example.com/v1",
+        compat: { cacheControlFormat: "anthropic" },
       },
       {
         systemPrompt: `Stable prefix${SYSTEM_PROMPT_CACHE_BOUNDARY}Dynamic suffix`,
@@ -1093,12 +1096,12 @@ describe("OpenAI-compatible completions params", () => {
     });
   });
 
-  it("does not inject Anthropic cache control for non-Claude LiteLLM models", async () => {
+  it("does not infer Anthropic cache control from a LiteLLM model name", async () => {
     let capturedMessages: unknown;
     const stream = streamOpenAICompletions(
       {
         ...createModel(32_000),
-        id: "gpt-5.5",
+        id: "claude-sonnet-4-6",
         provider: "litellm",
         baseUrl: "https://litellm.example.com/v1",
       },

--- a/packages/ai/src/providers/openai-completions.ts
+++ b/packages/ai/src/providers/openai-completions.ts
@@ -124,6 +124,7 @@ type ResolvedOpenAICompletionsCompat = Omit<
 > & {
   cacheControlFormat?: OpenAICompletionsCompat["cacheControlFormat"];
   sessionAffinityFormat: "openai" | "openrouter";
+  requiresExplicitCacheConfigForCacheControl: boolean;
 };
 
 type EncryptedReasoningDetail = {
@@ -703,7 +704,9 @@ function buildParams(
   compat: ResolvedOpenAICompletionsCompat = getCompat(model),
   cacheRetention: CacheRetention = resolveCacheRetention(options?.cacheRetention),
 ) {
-  const cacheControl = getCompatCacheControl(compat, cacheRetention);
+  const cacheControl = getCompatCacheControl(compat, cacheRetention, {
+    hasExplicitCacheConfig: options?.cacheRetention !== undefined,
+  });
   // Transient runtime-context carrier indexes skip cache anchoring so the breakpoint
   // stays on the last stable user turn; conversion-to-policy must not splice messages.
   const cacheOptOutIndexes = new Set<number>();
@@ -889,8 +892,12 @@ function clampOpenAICompletionsMaxTokens(
 function getCompatCacheControl(
   compat: ResolvedOpenAICompletionsCompat,
   cacheRetention: CacheRetention,
+  options: { hasExplicitCacheConfig: boolean },
 ): OpenAICompatCacheControl | undefined {
   if (compat.cacheControlFormat !== "anthropic" || cacheRetention === "none") {
+    return undefined;
+  }
+  if (compat.requiresExplicitCacheConfigForCacheControl && !options.hasExplicitCacheConfig) {
     return undefined;
   }
 
@@ -1428,6 +1435,7 @@ function detectCompat(model: Model<"openai-completions">): ResolvedOpenAIComplet
     model.compat?.openRouterRouting !== undefined;
   const cacheControlFormat =
     provider === "openrouter" && model.id.startsWith("anthropic/") ? "anthropic" : undefined;
+  const isLiteLLM = provider === "litellm";
 
   return {
     supportsStore: !isNonStandard,
@@ -1456,6 +1464,7 @@ function detectCompat(model: Model<"openai-completions">): ResolvedOpenAIComplet
     zaiToolStream: false,
     supportsStrictMode: !isMoonshot && !isTogether && !isCloudflareAiGateway,
     cacheControlFormat,
+    requiresExplicitCacheConfigForCacheControl: isLiteLLM,
     sendSessionAffinityHeaders: false,
     sessionAffinityFormat: usesOpenRouterSessionAffinity ? "openrouter" : "openai",
     supportsPromptCacheKey: false,
@@ -1494,6 +1503,7 @@ function getCompat(model: Model<"openai-completions">): ResolvedOpenAICompletion
     zaiToolStream: model.compat.zaiToolStream ?? detected.zaiToolStream,
     supportsStrictMode: model.compat.supportsStrictMode ?? detected.supportsStrictMode,
     cacheControlFormat: model.compat.cacheControlFormat ?? detected.cacheControlFormat,
+    requiresExplicitCacheConfigForCacheControl: detected.requiresExplicitCacheConfigForCacheControl,
     sendSessionAffinityHeaders:
       model.compat.sendSessionAffinityHeaders ?? detected.sendSessionAffinityHeaders,
     sessionAffinityFormat: detected.sessionAffinityFormat,

--- a/src/agents/embedded-agent-runner/prompt-cache-retention.test.ts
+++ b/src/agents/embedded-agent-runner/prompt-cache-retention.test.ts
@@ -74,6 +74,42 @@ describe("prompt cache retention", () => {
     ).toBeUndefined();
   });
 
+  it("passes explicit cacheRetention through for LiteLLM-proxied Claude models (issue #37966)", () => {
+    expect(
+      resolveCacheRetention(
+        { cacheRetention: "short" },
+        "litellm",
+        "openai-completions",
+        "claude-sonnet-4-6",
+      ),
+    ).toBe("short");
+    expect(
+      resolveCacheRetention(
+        { cacheRetention: "long" },
+        "litellm",
+        "openai-completions",
+        "anthropic/claude-opus-4-6",
+      ),
+    ).toBe("long");
+    expect(
+      resolveCacheRetention(
+        { cacheRetention: "none" },
+        "litellm",
+        "openai-completions",
+        "litellm/claude-haiku-4-6",
+      ),
+    ).toBe("none");
+  });
+
+  it("keeps LiteLLM cacheRetention disabled without explicit Claude model evidence", () => {
+    expect(
+      resolveCacheRetention({ cacheRetention: "long" }, "litellm", "openai-completions", "gpt-5.5"),
+    ).toBeUndefined();
+    expect(
+      resolveCacheRetention(undefined, "litellm", "openai-completions", "claude-sonnet-4-6"),
+    ).toBeUndefined();
+  });
+
   it("does not honor explicit cacheRetention for openai-completions without supportsPromptCacheKey", () => {
     // Providers that route via openai-completions but do not advertise prompt
     // caching must keep retention out of outgoing payloads.

--- a/src/agents/embedded-agent-runner/prompt-cache-retention.test.ts
+++ b/src/agents/embedded-agent-runner/prompt-cache-retention.test.ts
@@ -74,13 +74,15 @@ describe("prompt cache retention", () => {
     ).toBeUndefined();
   });
 
-  it("passes explicit cacheRetention through for LiteLLM-proxied Claude models (issue #37966)", () => {
+  it("passes explicit cacheRetention through for LiteLLM models with Anthropic cache capability (issue #37966)", () => {
     expect(
       resolveCacheRetention(
         { cacheRetention: "short" },
         "litellm",
         "openai-completions",
         "claude-sonnet-4-6",
+        undefined,
+        "anthropic",
       ),
     ).toBe("short");
     expect(
@@ -89,6 +91,8 @@ describe("prompt cache retention", () => {
         "litellm",
         "openai-completions",
         "anthropic/claude-opus-4-6",
+        undefined,
+        "anthropic",
       ),
     ).toBe("long");
     expect(
@@ -97,11 +101,13 @@ describe("prompt cache retention", () => {
         "litellm",
         "openai-completions",
         "litellm/claude-haiku-4-6",
+        undefined,
+        "anthropic",
       ),
     ).toBe("none");
   });
 
-  it("keeps LiteLLM cacheRetention disabled without explicit Claude model evidence", () => {
+  it("keeps LiteLLM cacheRetention disabled without explicit cache capability", () => {
     expect(
       resolveCacheRetention({ cacheRetention: "long" }, "litellm", "openai-completions", "gpt-5.5"),
     ).toBeUndefined();

--- a/src/agents/embedded-agent-runner/prompt-cache-retention.ts
+++ b/src/agents/embedded-agent-runner/prompt-cache-retention.ts
@@ -27,6 +27,7 @@ export function resolveCacheRetention(
   modelApi?: string,
   modelId?: string,
   supportsPromptCacheKey?: boolean,
+  cacheControlFormat?: "anthropic",
 ): CacheRetention | undefined {
   const hasExplicitCacheConfig =
     extraParams?.cacheRetention !== undefined || extraParams?.cacheControlTtl !== undefined;
@@ -45,8 +46,9 @@ export function resolveCacheRetention(
   // openai-completions wire (amazon-bedrock + amazon.* nova models) leave
   // the flag unset, so the existing family gate still applies to them.
   const cacheKeyEligible = supportsPromptCacheKey === true;
+  const anthropicCacheControlEligible = cacheControlFormat === "anthropic";
 
-  if (!family && !googleEligible && !cacheKeyEligible) {
+  if (!family && !googleEligible && !cacheKeyEligible && !anthropicCacheControlEligible) {
     return undefined;
   }
 
@@ -56,10 +58,10 @@ export function resolveCacheRetention(
   }
 
   const legacy = extraParams?.cacheControlTtl;
-  if (legacy === "5m" && (family || googleEligible)) {
+  if (legacy === "5m" && (family || googleEligible || anthropicCacheControlEligible)) {
     return "short";
   }
-  if (legacy === "1h" && (family || googleEligible)) {
+  if (legacy === "1h" && (family || googleEligible || anthropicCacheControlEligible)) {
     return "long";
   }
 

--- a/src/agents/embedded-agent-runner/run/attempt-stream-transport.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-stream-transport.ts
@@ -176,6 +176,8 @@ export async function prepareEmbeddedAttemptTransport(input: {
     attempt.provider,
     attempt.model.api,
     attempt.modelId,
+    attempt.model.compat?.supportsPromptCacheKey,
+    attempt.model.compat?.cacheControlFormat,
   );
   const agentTransportOverride = resolveAgentTransportOverride({
     settingsManager: input.settingsManager,

--- a/src/agents/embedded-agent-runner/run/attempt-stream-transport.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-stream-transport.ts
@@ -1,3 +1,4 @@
+import type { ModelCompatConfig } from "../../../config/types.models.js";
 /**
  * Selects and configures the provider transport for one embedded attempt.
  */
@@ -171,13 +172,14 @@ export async function prepareEmbeddedAttemptTransport(input: {
       codeModeToolSurfaceEnabled: true,
     });
   }
+  const modelCompat = attempt.model.compat as ModelCompatConfig | undefined;
   const effectivePromptCacheRetention = resolveCacheRetention(
     effectiveExtraParams,
     attempt.provider,
     attempt.model.api,
     attempt.modelId,
-    attempt.model.compat?.supportsPromptCacheKey,
-    attempt.model.compat?.cacheControlFormat,
+    modelCompat?.supportsPromptCacheKey,
+    modelCompat?.cacheControlFormat,
   );
   const agentTransportOverride = resolveAgentTransportOverride({
     settingsManager: input.settingsManager,

--- a/src/llm/providers/stream-wrappers/anthropic-family-cache-semantics.test.ts
+++ b/src/llm/providers/stream-wrappers/anthropic-family-cache-semantics.test.ts
@@ -1,40 +1,34 @@
 import { describe, expect, it } from "vitest";
-import {
-  isLiteLLMAnthropicModel,
-  resolveAnthropicCacheRetentionFamily,
-} from "./anthropic-family-cache-semantics.js";
+import { resolveAnthropicCacheRetentionFamily } from "./anthropic-family-cache-semantics.js";
 
 describe("LiteLLM Anthropic cache semantics", () => {
-  it("recognizes Claude model IDs that LiteLLM commonly routes to Anthropic", () => {
-    expect(isLiteLLMAnthropicModel("claude-sonnet-4-6")).toBe(true);
-    expect(isLiteLLMAnthropicModel("anthropic/claude-opus-4-6")).toBe(true);
-    expect(isLiteLLMAnthropicModel("litellm/claude-haiku-4-6")).toBe(true);
-  });
+  it.each(["claude-sonnet-4-6", "anthropic/claude-opus-4-6", "litellm/claude-haiku-4-6"])(
+    "classifies explicit LiteLLM Claude model %s as custom Anthropic API semantics",
+    (modelId) => {
+      expect(
+        resolveAnthropicCacheRetentionFamily({
+          provider: "litellm",
+          modelId,
+          modelApi: "openai-completions",
+          hasExplicitCacheConfig: true,
+        }),
+      ).toBe("custom-anthropic-api");
+    },
+  );
 
-  it("rejects non-Claude LiteLLM model IDs", () => {
-    expect(isLiteLLMAnthropicModel("gpt-5.5")).toBe(false);
-    expect(isLiteLLMAnthropicModel("gemini-3-pro")).toBe(false);
-    expect(isLiteLLMAnthropicModel("mistral-large")).toBe(false);
-  });
-
-  it("classifies explicit LiteLLM Claude cache config as custom Anthropic API semantics", () => {
-    expect(
-      resolveAnthropicCacheRetentionFamily({
-        provider: "litellm",
-        modelId: "claude-sonnet-4-6",
-        modelApi: "openai-completions",
-        hasExplicitCacheConfig: true,
-      }),
-    ).toBe("custom-anthropic-api");
-    expect(
-      resolveAnthropicCacheRetentionFamily({
-        provider: "litellm",
-        modelId: "anthropic/claude-opus-4-6",
-        modelApi: "openai-completions",
-        hasExplicitCacheConfig: true,
-      }),
-    ).toBe("custom-anthropic-api");
-  });
+  it.each(["gpt-5.5", "gemini-3-pro", "mistral-large"])(
+    "rejects non-Claude LiteLLM model %s",
+    (modelId) => {
+      expect(
+        resolveAnthropicCacheRetentionFamily({
+          provider: "litellm",
+          modelId,
+          modelApi: "openai-completions",
+          hasExplicitCacheConfig: true,
+        }),
+      ).toBeUndefined();
+    },
+  );
 
   it("does not opt LiteLLM into Anthropic cache semantics without explicit config", () => {
     expect(

--- a/src/llm/providers/stream-wrappers/anthropic-family-cache-semantics.test.ts
+++ b/src/llm/providers/stream-wrappers/anthropic-family-cache-semantics.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from "vitest";
+import {
+  isLiteLLMAnthropicModel,
+  resolveAnthropicCacheRetentionFamily,
+} from "./anthropic-family-cache-semantics.js";
+
+describe("LiteLLM Anthropic cache semantics", () => {
+  it("recognizes Claude model IDs that LiteLLM commonly routes to Anthropic", () => {
+    expect(isLiteLLMAnthropicModel("claude-sonnet-4-6")).toBe(true);
+    expect(isLiteLLMAnthropicModel("anthropic/claude-opus-4-6")).toBe(true);
+    expect(isLiteLLMAnthropicModel("litellm/claude-haiku-4-6")).toBe(true);
+  });
+
+  it("rejects non-Claude LiteLLM model IDs", () => {
+    expect(isLiteLLMAnthropicModel("gpt-5.5")).toBe(false);
+    expect(isLiteLLMAnthropicModel("gemini-3-pro")).toBe(false);
+    expect(isLiteLLMAnthropicModel("mistral-large")).toBe(false);
+  });
+
+  it("classifies explicit LiteLLM Claude cache config as custom Anthropic API semantics", () => {
+    expect(
+      resolveAnthropicCacheRetentionFamily({
+        provider: "litellm",
+        modelId: "claude-sonnet-4-6",
+        modelApi: "openai-completions",
+        hasExplicitCacheConfig: true,
+      }),
+    ).toBe("custom-anthropic-api");
+    expect(
+      resolveAnthropicCacheRetentionFamily({
+        provider: "litellm",
+        modelId: "anthropic/claude-opus-4-6",
+        modelApi: "openai-completions",
+        hasExplicitCacheConfig: true,
+      }),
+    ).toBe("custom-anthropic-api");
+  });
+
+  it("does not opt LiteLLM into Anthropic cache semantics without explicit config", () => {
+    expect(
+      resolveAnthropicCacheRetentionFamily({
+        provider: "litellm",
+        modelId: "claude-sonnet-4-6",
+        modelApi: "openai-completions",
+        hasExplicitCacheConfig: false,
+      }),
+    ).toBeUndefined();
+  });
+
+  it("does not opt non-Claude LiteLLM models into Anthropic cache semantics", () => {
+    expect(
+      resolveAnthropicCacheRetentionFamily({
+        provider: "litellm",
+        modelId: "gpt-5.5",
+        modelApi: "openai-completions",
+        hasExplicitCacheConfig: true,
+      }),
+    ).toBeUndefined();
+  });
+});

--- a/src/llm/providers/stream-wrappers/anthropic-family-cache-semantics.test.ts
+++ b/src/llm/providers/stream-wrappers/anthropic-family-cache-semantics.test.ts
@@ -1,23 +1,9 @@
 import { describe, expect, it } from "vitest";
 import { resolveAnthropicCacheRetentionFamily } from "./anthropic-family-cache-semantics.js";
 
-describe("LiteLLM Anthropic cache semantics", () => {
+describe("Anthropic cache semantics", () => {
   it.each(["claude-sonnet-4-6", "anthropic/claude-opus-4-6", "litellm/claude-haiku-4-6"])(
-    "classifies explicit LiteLLM Claude model %s as custom Anthropic API semantics",
-    (modelId) => {
-      expect(
-        resolveAnthropicCacheRetentionFamily({
-          provider: "litellm",
-          modelId,
-          modelApi: "openai-completions",
-          hasExplicitCacheConfig: true,
-        }),
-      ).toBe("custom-anthropic-api");
-    },
-  );
-
-  it.each(["gpt-5.5", "gemini-3-pro", "mistral-large"])(
-    "rejects non-Claude LiteLLM model %s",
+    "does not infer LiteLLM cache capability from model name %s",
     (modelId) => {
       expect(
         resolveAnthropicCacheRetentionFamily({

--- a/src/llm/providers/stream-wrappers/anthropic-family-cache-semantics.ts
+++ b/src/llm/providers/stream-wrappers/anthropic-family-cache-semantics.ts
@@ -46,11 +46,6 @@ function isAnthropicBedrockModel(modelId: string): boolean {
   return false;
 }
 
-function isLiteLLMAnthropicModel(modelId: string): boolean {
-  const normalized = normalizeLowercaseStringOrEmpty(modelId);
-  return normalized.startsWith("anthropic/") || normalized.includes("claude");
-}
-
 export function isAnthropicFamilyCacheTtlEligible(params: {
   provider: string;
   modelApi?: string;
@@ -94,14 +89,6 @@ export function resolveAnthropicCacheRetentionFamily(params: {
     ) {
       return "anthropic-bedrock";
     }
-  }
-  if (
-    normalizedProvider === "litellm" &&
-    params.hasExplicitCacheConfig &&
-    typeof params.modelId === "string" &&
-    isLiteLLMAnthropicModel(params.modelId)
-  ) {
-    return "custom-anthropic-api";
   }
   if (
     normalizedProvider !== "amazon-bedrock" &&

--- a/src/llm/providers/stream-wrappers/anthropic-family-cache-semantics.ts
+++ b/src/llm/providers/stream-wrappers/anthropic-family-cache-semantics.ts
@@ -46,6 +46,11 @@ function isAnthropicBedrockModel(modelId: string): boolean {
   return false;
 }
 
+export function isLiteLLMAnthropicModel(modelId: string): boolean {
+  const normalized = normalizeLowercaseStringOrEmpty(modelId);
+  return normalized.startsWith("anthropic/") || normalized.includes("claude");
+}
+
 export function isAnthropicFamilyCacheTtlEligible(params: {
   provider: string;
   modelApi?: string;
@@ -89,6 +94,14 @@ export function resolveAnthropicCacheRetentionFamily(params: {
     ) {
       return "anthropic-bedrock";
     }
+  }
+  if (
+    normalizedProvider === "litellm" &&
+    params.hasExplicitCacheConfig &&
+    typeof params.modelId === "string" &&
+    isLiteLLMAnthropicModel(params.modelId)
+  ) {
+    return "custom-anthropic-api";
   }
   if (
     normalizedProvider !== "amazon-bedrock" &&

--- a/src/llm/providers/stream-wrappers/anthropic-family-cache-semantics.ts
+++ b/src/llm/providers/stream-wrappers/anthropic-family-cache-semantics.ts
@@ -46,7 +46,7 @@ function isAnthropicBedrockModel(modelId: string): boolean {
   return false;
 }
 
-export function isLiteLLMAnthropicModel(modelId: string): boolean {
+function isLiteLLMAnthropicModel(modelId: string): boolean {
   const normalized = normalizeLowercaseStringOrEmpty(modelId);
   return normalized.startsWith("anthropic/") || normalized.includes("claude");
 }


### PR DESCRIPTION
Closes #37966

## What Problem This Solves

Fixes an issue where users routing Claude models through LiteLLM could explicitly set `cacheRetention`, but OpenClaw still dropped the Anthropic `cache_control` prompt-cache markers before sending the OpenAI-compatible request. That made LiteLLM-proxied Claude usage miss the expected prompt-cache behavior and its cost/latency benefits.

## Why This Change Was Made

This keeps LiteLLM's OpenAI-compatible path conservative: only model IDs that look like Claude/Anthropic get Anthropic cache-control shaping, and only when the caller explicitly set `cacheRetention`. Non-Claude LiteLLM models and LiteLLM Claude models without explicit cache retention keep the existing plain payload behavior.

## User Impact

Users can now configure `cacheRetention: "short"` or `cacheRetention: "long"` for LiteLLM-proxied Claude models and have OpenClaw forward Anthropic `cache_control` markers through LiteLLM. Existing LiteLLM configs without explicit cache retention are unchanged.

## Evidence

- `node scripts/run-vitest.mjs src/agents/embedded-agent-runner/prompt-cache-retention.test.ts src/llm/providers/stream-wrappers/anthropic-family-cache-semantics.test.ts src/llm/providers/openai-completions.test.ts` — PASS, 2 Vitest shards, 56 tests.
- `corepack pnpm exec oxfmt --check src/agents/embedded-agent-runner/prompt-cache-retention.test.ts src/llm/providers/openai-completions.ts src/llm/providers/openai-completions.test.ts src/llm/providers/stream-wrappers/anthropic-family-cache-semantics.ts src/llm/providers/stream-wrappers/anthropic-family-cache-semantics.test.ts docs/providers/litellm.md` — PASS.
- `corepack pnpm exec oxlint --config .oxlintrc.json --tsconfig config/tsconfig/oxlint.core.json src/agents/embedded-agent-runner/prompt-cache-retention.test.ts src/llm/providers/openai-completions.ts src/llm/providers/openai-completions.test.ts src/llm/providers/stream-wrappers/anthropic-family-cache-semantics.ts src/llm/providers/stream-wrappers/anthropic-family-cache-semantics.test.ts` — PASS, 0 warnings/errors.
- `corepack pnpm lint:docs -- docs/providers/litellm.md` — PASS, 0 errors.
- `git diff --check` — PASS.
- Diff secret scan — PASS.

Live LiteLLM-to-Anthropic cache read/write proof was not run because this change was validated with deterministic payload-shaping tests and no test LiteLLM proxy credentials were available in this checkout.
