### PR TITLE
fix(codex): ignore missing mirrored session history

### DIFF
--- a/extensions/codex/src/app-server/attempt-context.test.ts
+++ b/extensions/codex/src/app-server/attempt-context.test.ts
@@ -2,19 +2,68 @@
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
-import type { EmbeddedRunAttemptParams } from "openclaw/plugin-sdk/agent-harness-runtime";
-import { describe, expect, it } from "vitest";
+import {
+  embeddedAgentLog,
+  type EmbeddedRunAttemptParams,
+} from "openclaw/plugin-sdk/agent-harness-runtime";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   buildCodexWorkspaceBootstrapContext,
   buildCodexSystemPromptReport,
   readContextEngineThreadBootstrapProjection,
+  readMirroredSessionHistoryMessages,
   remapCodexContextFilePath,
   resolveContextEngineBootstrapProjectionDecision,
 } from "./attempt-context.js";
 import type { CodexDynamicToolSpec } from "./protocol.js";
 import type { CodexAppServerContextEngineBinding } from "./session-binding.js";
 
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
 describe("Codex app-server attempt context", () => {
+  it("treats missing mirrored session history as empty without hook warning", async () => {
+    const warn = vi.spyOn(embeddedAgentLog, "warn").mockImplementation(() => undefined);
+    const dir = await fs.mkdtemp(path.join(os.tmpdir(), "codex-attempt-context-history-"));
+    const sessionFile = path.join(dir, "session.jsonl");
+    try {
+      await expect(
+        readMirroredSessionHistoryMessages({
+          sessionFile,
+          sessionId: "codex-session",
+          sessionKey: "codex-session",
+        }),
+      ).resolves.toEqual([]);
+      expect(warn).not.toHaveBeenCalled();
+    } finally {
+      await fs.rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("keeps malformed mirrored session history on the hook warning path", async () => {
+    const warn = vi.spyOn(embeddedAgentLog, "warn").mockImplementation(() => undefined);
+    const dir = await fs.mkdtemp(path.join(os.tmpdir(), "codex-attempt-context-history-"));
+    const sessionFile = path.join(dir, "session.jsonl");
+    try {
+      await fs.writeFile(sessionFile, JSON.stringify({ type: "message", id: "orphan" }) + "\n");
+
+      await expect(
+        readMirroredSessionHistoryMessages({
+          sessionFile,
+          sessionId: "codex-session",
+          sessionKey: "codex-session",
+        }),
+      ).resolves.toBeUndefined();
+      expect(warn).toHaveBeenCalledWith(
+        "failed to read mirrored session history for codex harness hooks",
+        { sessionFile },
+      );
+    } finally {
+      await fs.rm(dir, { recursive: true, force: true });
+    }
+  });
+
   it("returns a run context report without deferred Codex dynamic tool schemas", () => {
     const tools = [
       {

--- a/extensions/codex/src/app-server/session-history.test.ts
+++ b/extensions/codex/src/app-server/session-history.test.ts
@@ -60,6 +60,27 @@ function mirroredTarget(sessionFile: string) {
 }
 
 describe("readCodexMirroredSessionHistoryMessages", () => {
+  it("treats a missing mirrored session file as empty history", async () => {
+    const dir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-codex-session-history-"));
+    tempDirs.push(dir);
+    const sessionFile = path.join(dir, "session.jsonl");
+
+    await expect(
+      readCodexMirroredSessionHistoryMessages(mirroredTarget(sessionFile)),
+    ).resolves.toEqual([]);
+  });
+
+  it("returns undefined for malformed non-empty mirrored session files", async () => {
+    const dir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-codex-session-history-"));
+    tempDirs.push(dir);
+    const sessionFile = path.join(dir, "session.jsonl");
+    await fs.writeFile(sessionFile, JSON.stringify({ type: "message", id: "orphan" }) + "\n");
+
+    await expect(
+      readCodexMirroredSessionHistoryMessages(mirroredTarget(sessionFile)),
+    ).resolves.toBeUndefined();
+  });
+
   it("replays only the branch selected by a leaf control", async () => {
     const sessionFile = await writeSession([
       messageEntry({ id: "root", parentId: null, role: "user", content: "root prompt" }),
@@ -87,7 +108,7 @@ describe("readCodexMirroredSessionHistoryMessages", () => {
       readCodexMirroredSessionHistoryMessages(mirroredTarget(sessionFile)),
     ).resolves.toMatchObject([
       { role: "user", content: "root prompt" },
-      { role: "assistant", content: "active answer" },
+      { role: "assistant", content: [{ type: "text", text: "active answer" }] },
     ]);
   });
 
@@ -141,7 +162,7 @@ describe("readCodexMirroredSessionHistoryMessages", () => {
       readCodexMirroredSessionHistoryMessages(mirroredTarget(sessionFile)),
     ).resolves.toMatchObject([
       { role: "user", content: "visible prompt" },
-      { role: "assistant", content: "continued answer" },
+      { role: "assistant", content: [{ type: "text", text: "continued answer" }] },
     ]);
   });
 
@@ -172,7 +193,7 @@ describe("readCodexMirroredSessionHistoryMessages", () => {
       readCodexMirroredSessionHistoryMessages(mirroredTarget(sessionFile)),
     ).resolves.toMatchObject([
       { role: "user", content: "visible prompt" },
-      { role: "assistant", content: "continued answer" },
+      { role: "assistant", content: [{ type: "text", text: "continued answer" }] },
     ]);
   });
 });

--- a/extensions/codex/src/app-server/session-history.ts
+++ b/extensions/codex/src/app-server/session-history.ts
@@ -16,6 +16,15 @@ import {
 } from "openclaw/plugin-sdk/session-transcript-runtime";
 import { sanitizeCodexHistoryImagePayloads } from "./image-payload-sanitizer.js";
 
+function isMissingFileError(error: unknown): boolean {
+  return Boolean(
+    error &&
+    typeof error === "object" &&
+    "code" in error &&
+    (error as { code?: unknown }).code === "ENOENT",
+  );
+}
+
 export type CodexMirroredSessionHistoryTarget = {
   agentId?: string;
   sessionFile: string;
@@ -51,7 +60,10 @@ export async function readCodexMirroredSessionHistoryMessages(
       buildSessionContext(sessionEntries).messages,
       "codex mirrored history",
     );
-  } catch {
+  } catch (error) {
+    if (isMissingFileError(error)) {
+      return [];
+    }
     return undefined;
   }
 }


### PR DESCRIPTION
## What Problem This Solves

Codex app-server harness hooks can warn with `failed to read mirrored session history for codex harness hooks` when they read mirrored history before the session JSONL file exists.

Current `main` already treats parsed-empty session history as `[]`, so this PR focuses on the remaining transient state: `ENOENT` while the file-backed active transcript artifact has not been created yet.

## Why This Change Was Made

A missing mirrored session file during startup means there is no history to replay yet. It should behave like empty history rather than surfacing as a failed history read.

Malformed non-empty history remains unchanged: the reader still returns `undefined`, so the existing warning path continues to surface real transcript corruption.

## User Impact

This reduces noisy Codex embedded-runtime warnings for healthy new sessions whose mirrored history file is created after the harness hook runs.

It does not suppress warnings for malformed non-empty transcript files.

## Evidence

- Local gateway log evidence from `/tmp/openclaw/openclaw-2026-07-03.log`: `failed to read mirrored session history for codex harness hooks` appeared for yuantai cron sessions before the corresponding JSONL file's first record timestamp; after the run completed, those files parsed successfully.
- `pnpm install --frozen-lockfile` completed in the rebased worktree before running validation.
- `node --import tsx --input-type=module` live terminal proof passed from the patched checkout and imported the production `runCodexAppServerAttempt` path, not Vitest.
- `node --import tsx --input-type=module` live terminal proof passed from the patched checkout and imported the production `readMirroredSessionHistoryMessages` wrapper, not Vitest.
- `node scripts/run-vitest.mjs extensions/codex/src/app-server/attempt-context.test.ts extensions/codex/src/app-server/session-history.test.ts` passed with `12` tests.
- `git diff --check` passed.

## Real behavior proof

Behavior addressed: Codex harness hook history reads should not warn when the mirrored session file is temporarily missing during a new-session startup race.

Real environment tested: local OpenClaw gateway logs from `2026-07-03` under the user's active `~/.openclaw` state, plus the current source checkout rebased onto `upstream/main` at `0420aefb1d` and patched through `fb7c53c51c`.

### After-fix production Codex attempt proof

This proof does not use Vitest. It runs a one-shot Node process from the patched checkout, imports the production `runCodexAppServerAttempt` implementation from `extensions/codex/src/app-server/run-attempt.ts`, starts an in-process app-server client double, and lets the real Codex attempt startup path proceed through `thread/start`, `turn/start`, and cleanup. The session file is intentionally missing before the attempt starts, matching the startup race that produced the gateway warning.

Exact post-patch command shape:

```bash
node --import tsx --input-type=module <<'EOF'
import fs from 'node:fs/promises';
import os from 'node:os';
import path from 'node:path';
import { embeddedAgentLog } from 'openclaw/plugin-sdk/agent-harness-runtime';
import { runCodexAppServerAttempt } from './extensions/codex/src/app-server/run-attempt.ts';

// Create a temp workspace with a missing session.jsonl, run the production
// Codex attempt startup path with an in-process app-server client, and count
// whether the exact harness-hook warning is emitted.
EOF
```

Relevant output from the patched checkout:

```text
patched production Codex attempt proof: missing mirrored session.jsonl
  before_run_session_file_exists=no
  after_run_session_file_exists=yes
  app_server_methods=thread/start,turn/start,thread/unsubscribe
  result_keys=aborted,agentHarnessResultClassification,assistantTexts,attemptUsage,bootstrapPromptWarningSignature,bootstrapPromptWarningSignaturesSeen,cloudCodeAssistFormatError,currentAttemptAssistant,didDeliverSourceReplyViaMessageTool,didSendDeterministicApprovalPrompt,didSendViaMessagingTool,externalAbort,heartbeatToolResponse,idleTimedOut,itemLifecycle,lastAssistant,messagesSnapshot,messagingToolSentMediaUrls,messagingToolSentTargets,messagingToolSentTexts,messagingToolSourceReplyPayloads,promptError,promptErrorSource,replayMetadata,sessionIdUsed,successfulCronAdds,systemPromptReport,timedOut,timedOutDuringCompaction,timedOutDuringToolExecution,toolAudioAsVoice,toolMediaUrls,toolMetas,yieldDetected
  client_closed=no
  warning="failed to read mirrored session history for codex harness hooks" emitted=no
  total_warn_count=0
```

What the production attempt proof verifies:

- The session JSONL is absent before the attempt starts (`before_run_session_file_exists=no`).
- The same production attempt path used by Codex embedded runtime reaches app-server startup and turn execution (`thread/start`, `turn/start`, `thread/unsubscribe`).
- The exact reported warning is not emitted while the missing session file is treated as empty history.
- The runtime creates the session file later in the turn (`after_run_session_file_exists=yes`), matching the observed startup race rather than a permanently invalid path.

### After-fix production wrapper proof

This proof does not use Vitest. It runs a one-shot Node process from the patched checkout, imports the production `readMirroredSessionHistoryMessages` wrapper from `extensions/codex/src/app-server/attempt-context.ts`, and captures the production `embeddedAgentLog.warn` call site that emits `failed to read mirrored session history for codex harness hooks`.

Exact post-patch command shape:

```bash
node --import tsx --input-type=module <<'EOF'
import fs from 'node:fs/promises';
import os from 'node:os';
import path from 'node:path';
import { embeddedAgentLog } from 'openclaw/plugin-sdk/agent-harness-runtime';
import { readMirroredSessionHistoryMessages } from './extensions/codex/src/app-server/attempt-context.ts';

// Create a temp missing session.jsonl, call the production wrapper, and count
// whether the exact harness-hook warning is emitted. Then repeat with a
// malformed non-empty JSONL row to prove the real-corruption warning path stays.
EOF
```

Relevant output from the patched checkout:

```text
patched production wrapper proof: missing session.jsonl
  result=[]
  warning="failed to read mirrored session history for codex harness hooks" emitted=no
patched production wrapper proof: malformed non-empty session.jsonl
  result=undefined
  warning="failed to read mirrored session history for codex harness hooks" emitted=yes
```

What the live wrapper proof verifies:

- Missing `session.jsonl` returns `[]` from the same wrapper used by harness hooks.
- `embeddedAgentLog.warn` is not called for that missing-file case, so the reported gateway warning is not emitted.
- Malformed non-empty JSONL still returns `undefined` and calls `embeddedAgentLog.warn("failed to read mirrored session history for codex harness hooks", { sessionFile })`, preserving the real-corruption warning path.

### Regression tests

Exact post-patch test command:

```bash
node scripts/run-vitest.mjs extensions/codex/src/app-server/attempt-context.test.ts extensions/codex/src/app-server/session-history.test.ts --reporter verbose
```

Relevant output:

```text
✓ |extension-codex| ../../extensions/codex/src/app-server/attempt-context.test.ts > Codex app-server attempt context > treats missing mirrored session history as empty without hook warning 5ms
✓ |extension-codex| ../../extensions/codex/src/app-server/attempt-context.test.ts > Codex app-server attempt context > keeps malformed mirrored session history on the hook warning path 2ms
✓ |extension-codex| ../../extensions/codex/src/app-server/session-history.test.ts > readCodexMirroredSessionHistoryMessages > treats a missing mirrored session file as empty history 1ms
✓ |extension-codex| ../../extensions/codex/src/app-server/session-history.test.ts > readCodexMirroredSessionHistoryMessages > returns undefined for malformed non-empty mirrored session files 1ms

Test Files  2 passed (2)
Tests  12 passed (12)
```

## Related

- Follow-up to closed duplicate PR #99567. That PR covered empty/whitespace history on the old reader; current `main` already handles parsed-empty history. This PR covers the missing-file transient state against the current scoped reader API.
