### PR TITLE
Reject surrogate HTML numeric entities

### DIFF
--- a/src/agents/tools/web-fetch-utils.test.ts
+++ b/src/agents/tools/web-fetch-utils.test.ts
@@ -12,6 +12,15 @@ describe("web-fetch-utils htmlToMarkdown entity decoding", () => {
     expect(htmlToMarkdown(`<p>&#x1D54B;</p>`).text).toBe(doubleT);
   });
 
+  it("preserves surrogate numeric entities as literal text", () => {
+    const highSurrogate = String.fromCharCode(0xd800);
+
+    expect(htmlToMarkdown(`<p>bad &#xD800; end</p>`).text).toBe("bad &#xD800; end");
+    expect(htmlToMarkdown(`<p>bad &#55296; end</p>`).text).toBe("bad &#55296; end");
+    expect(htmlToMarkdown(`<p>bad &#xDFFF; end</p>`).text).toBe("bad &#xDFFF; end");
+    expect(htmlToMarkdown(`<p>bad &#xD800; end</p>`).text).not.toContain(highSurrogate);
+  });
+
   it("decodes &amp; last so an escaped entity is not double-decoded", () => {
     // "&amp;#39;" is the correct HTML encoding of the literal text "&#39;" and must survive intact.
     expect(htmlToMarkdown(`<p>Tom &amp;#39;s pub</p>`).text).toBe("Tom &#39;s pub");

--- a/src/agents/utils/html.ts
+++ b/src/agents/utils/html.ts
@@ -11,7 +11,12 @@ interface DecodedHtmlEntity {
 }
 
 function decodeCodePoint(codePoint: number): string | undefined {
-  if (!Number.isInteger(codePoint) || codePoint < 0 || codePoint > 0x10ffff) {
+  if (
+    !Number.isInteger(codePoint) ||
+    codePoint < 0 ||
+    codePoint > 0x10ffff ||
+    (codePoint >= 0xd800 && codePoint <= 0xdfff)
+  ) {
     return undefined;
   }
   return String.fromCodePoint(codePoint);


### PR DESCRIPTION
## What Problem This Solves

HTML numeric entities for surrogate code points (for example, `&#xD800;`) currently decode into lone surrogate UTF-16 code units. That can make extracted markdown/text no longer well-formed UTF-16 and can break downstream serialization/encoding paths.

## Why This Change Was Made

`decodeCodePoint()` now rejects surrogate code points in addition to malformed, negative, and out-of-range values. Invalid numeric entities continue to be preserved literally, while valid BMP and astral code points still decode normally.

## User Impact

Fetched or syntax-highlighted HTML that contains malformed surrogate numeric entities remains stable literal text instead of introducing invalid lone surrogates. Existing valid entity decoding behavior is unchanged.

## Evidence

- `pnpm test src/agents/tools/web-fetch-utils.test.ts`
- `pnpm test src/agents/tools/web-fetch-utils.test.ts src/agents/utils/syntax-highlight.test.ts`
- `pnpm format:check src/agents/utils/html.ts src/agents/tools/web-fetch-utils.test.ts`
- `git diff --check`

Real behavior proof from the PR branch using the web_fetch extraction runtime path (`extractBasicHtmlContent`):

```text
{"text":"bad &#xD800; end\ndecimal &#55296;\nlow &#xDFFF;\nemoji 😀"}
literalHex=true
literalDecimal=true
literalLow=true
emojiDecoded=true
encodeURIComponent=bad%20%26%23xD800%3B%20end%0Adecimal%20%26%2355296%3B%0Alow%20%26%23xDFFF%3B%0Aemoji%20%F0%9F%98%80
```

The proof shows surrogate entities stay literal, the valid astral entity still decodes, and `encodeURIComponent` succeeds on the extracted text.

Note: local commands emitted the existing engine warning because this Windows checkout is on Node v22.17.0 while the repo requests >=22.19.0; the focused tests and format check passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
