### PR TITLE
fix: PDF tool accepts fractional page numbers that select no extracted pages

### DIFF
--- a/src/agents/tools/pdf-tool.helpers.test.ts
+++ b/src/agents/tools/pdf-tool.helpers.test.ts
@@ -86,6 +86,14 @@ describe("parsePageRange", () => {
     expect(() => parsePageRange("-1", 20)).toThrow("Invalid page number");
   });
 
+  it("throws on fractional page number", () => {
+    expect(() => parsePageRange("1.5", 20)).toThrow("Invalid page number");
+  });
+
+  it("throws on fractional page number in a comma-separated list", () => {
+    expect(() => parsePageRange("1,1.5", 20)).toThrow("Invalid page number");
+  });
+
   it("handles empty parts gracefully", () => {
     expect(parsePageRange("1,,3", 20)).toEqual([1, 3]);
   });

--- a/src/agents/tools/pdf-tool.helpers.ts
+++ b/src/agents/tools/pdf-tool.helpers.ts
@@ -66,7 +66,7 @@ export function parsePageRange(range: string, maxPages: number): number[] {
       }
     } else {
       const num = Number(part);
-      if (!Number.isFinite(num) || num < 1) {
+      if (!Number.isFinite(num) || !Number.isInteger(num) || num < 1) {
         throw new Error(`Invalid page number: "${part}"`);
       }
       if (num <= maxPages) {


### PR DESCRIPTION
Closes #99393

## What Problem This Solves

Fixes an issue where users of the `pdf` tool could pass fractional page numbers (e.g. `pages: "1.5"`) that silently produced empty extraction results. The parser accepted fractional values via `Number(part)`, but the document-extract fallback later filtered them out with `Number.isInteger(p)`, so the request continued with no selected PDF content instead of a clear input error.

## Why This Change Was Made

Added a `Number.isInteger(num)` check to the single-page token path in `parsePageRange`, so fractional input is rejected at parse time with an `Invalid page number` error — consistent with how invalid ranges, zero, and negative values are already handled. The dash-range path already uses `^\d+$` regex matching, so it is unaffected.

## User Impact

Users who accidentally pass fractional page numbers to the `pdf` tool now get an immediate, clear error instead of a silently empty result. Integer page numbers and ranges continue to work unchanged.

## Evidence

- New tests: `parsePageRange("1.5", 20)` and `parsePageRange("1,1.5", 20)` both throw `Invalid page number`
- All 24 tests in `src/agents/tools/pdf-tool.helpers.test.ts` pass

```
node scripts/run-vitest.mjs src/agents/tools/pdf-tool.helpers.test.ts
→ 24 tests passed (1 file)
```
