### PR TITLE
fix(heartbeat): inject Slack interaction value into heartbeat prompt\…

### DIFF
--- a/src/infra/heartbeat-events-filter.test.ts
+++ b/src/infra/heartbeat-events-filter.test.ts
@@ -181,10 +181,10 @@ describe("heartbeat event classification", () => {
 });
 
 describe("isSlackInteractionEvent", () => {
-  it("returns true for Slack block_actions events with slack:interaction contextKey", () => {
+  it("returns true for Slack interaction events with slack:interaction contextKey", () => {
     expect(
       isSlackInteractionEvent({
-        text: JSON.stringify({ type: "block_actions", actions: [{ action_id: "approve" }] }),
+        text: `Slack interaction: ${JSON.stringify({ actionId: "approve", value: "merge-99544" })}`,
         contextKey: "slack:interaction:C123:1234567890.123456:approve",
       }),
     ).toBe(true);
@@ -208,10 +208,19 @@ describe("isSlackInteractionEvent", () => {
     ).toBe(false);
   });
 
-  it("returns false for non-Slack events", () => {
+  it("returns false for events missing the Slack interaction prefix", () => {
     expect(
       isSlackInteractionEvent({
         text: JSON.stringify({ type: "block_actions", actions: [{ action_id: "approve" }] }),
+        contextKey: "slack:interaction:C123:1234567890.123456:approve",
+      }),
+    ).toBe(false);
+  });
+
+  it("returns false for non-Slack events", () => {
+    expect(
+      isSlackInteractionEvent({
+        text: `Slack interaction: ${JSON.stringify({ actionId: "approve" })}`,
         contextKey: "cron:daily-reminder",
       }),
     ).toBe(false);
@@ -223,14 +232,11 @@ describe("buildSlackInteractionEventPrompt", () => {
     {
       name: "builds user-facing prompt with action_id and value",
       events: [
-        JSON.stringify({
-          type: "block_actions",
-          actions: [{ action_id: "approve_pr", value: "merge-99544" }],
-        }),
+        `Slack interaction: ${JSON.stringify({ actionId: "approve_pr", value: "merge-99544" })}`,
       ],
       opts: { deliverToUser: true, useHeartbeatResponseTool: false },
       expected: [
-        "Slack interactive button(s) were clicked",
+        "Slack interactive component(s) were used",
         '1. action_id="approve_pr"',
         'value="merge-99544"',
         "Please act on these interaction(s)",
@@ -240,37 +246,41 @@ describe("buildSlackInteractionEventPrompt", () => {
     {
       name: "builds internal-only prompt",
       events: [
-        JSON.stringify({
-          type: "block_actions",
-          actions: [{ action_id: "approve_pr", value: "merge-99544" }],
-        }),
+        `Slack interaction: ${JSON.stringify({ actionId: "approve_pr", value: "merge-99544" })}`,
       ],
       opts: { deliverToUser: false, useHeartbeatResponseTool: false },
       expected: ["Handle the result internally", "heartbeat_ok"],
-      unexpected: ["Please relay"],
+      unexpected: ["Reply HEARTBEAT_OK"],
     },
     {
       name: "uses heartbeat_respond instruction when response tool is enabled",
       events: [
-        JSON.stringify({
-          type: "block_actions",
-          actions: [{ action_id: "approve_pr", value: "merge-99544" }],
-        }),
+        `Slack interaction: ${JSON.stringify({ actionId: "approve_pr", value: "merge-99544" })}`,
       ],
       opts: { deliverToUser: true, useHeartbeatResponseTool: true },
       expected: ["Use heartbeat_respond", "acknowledge the interaction(s)"],
     },
     {
+      name: "renders select menu values and input values",
+      events: [
+        `Slack interaction: ${JSON.stringify({
+          actionId: "choose_options",
+          selectedValues: ["option-a", "option-b"],
+          inputValue: "free-form text",
+        })}`,
+      ],
+      opts: { deliverToUser: true, useHeartbeatResponseTool: false },
+      expected: [
+        'action_id="choose_options"',
+        'selected=["option-a","option-b"]',
+        'input="free-form text"',
+      ],
+    },
+    {
       name: "renders multiple queued interactions and preserves render/consume symmetry",
       events: [
-        JSON.stringify({
-          type: "block_actions",
-          actions: [{ action_id: "approve_pr", value: "merge-99544" }],
-        }),
-        JSON.stringify({
-          type: "block_actions",
-          actions: [{ action_id: "reject_pr", value: "close-99544" }],
-        }),
+        `Slack interaction: ${JSON.stringify({ actionId: "approve_pr", value: "merge-99544" })}`,
+        `Slack interaction: ${JSON.stringify({ actionId: "reject_pr", value: "close-99544" })}`,
       ],
       opts: { deliverToUser: true, useHeartbeatResponseTool: false },
       expected: [
@@ -283,11 +293,10 @@ describe("buildSlackInteractionEventPrompt", () => {
     },
     {
       name: "caps at MAX_SLACK_INTERACTION_EVENTS and reports overflow",
-      events: Array.from({ length: 6 }, (_, index) =>
-        JSON.stringify({
-          type: "block_actions",
-          actions: [{ action_id: `action_${index}`, value: `value_${index}` }],
-        }),
+      events: Array.from(
+        { length: 6 },
+        (_, index) =>
+          `Slack interaction: ${JSON.stringify({ actionId: `action_${index}`, value: `value_${index}` })}`,
       ),
       opts: { deliverToUser: true, useHeartbeatResponseTool: false },
       expected: ["action_0", "action_4", "...and 1 more Slack interaction(s)"],

--- a/src/infra/heartbeat-events-filter.test.ts
+++ b/src/infra/heartbeat-events-filter.test.ts
@@ -3,9 +3,11 @@ import { describe, expect, it } from "vitest";
 import {
   buildCronEventPrompt,
   buildExecEventPrompt,
+  buildSlackInteractionEventPrompt,
   isCronSystemEvent,
   isExecCompletionEvent,
   isRelayableExecCompletionEvent,
+  isSlackInteractionEvent,
 } from "./heartbeat-events-filter.js";
 
 describe("heartbeat event prompts", () => {
@@ -178,36 +180,126 @@ describe("heartbeat event classification", () => {
   });
 });
 
-describe("isExecCompletionEvent", () => {
-  it("matches maybeNotifyOnExit (backgrounded allowlisted commands) events", () => {
-    // Word-based session slugs (createSessionSlug)
-    expect(isExecCompletionEvent("Exec completed (amber-at, code 0) :: some output")).toBe(true);
-    expect(isExecCompletionEvent("Exec completed (calm-del, code 0)")).toBe(true);
-    expect(isExecCompletionEvent("Exec failed (brisk-no, code 1) :: error text")).toBe(true);
-    expect(isExecCompletionEvent("Exec failed (fresh-ke, signal SIGTERM)")).toBe(true);
-    // Hex-style IDs also accepted
-    expect(isExecCompletionEvent("Exec completed (abc12345, code 0)")).toBe(true);
+describe("isSlackInteractionEvent", () => {
+  it("returns true for Slack block_actions events with slack:interaction contextKey", () => {
+    expect(
+      isSlackInteractionEvent({
+        text: JSON.stringify({ type: "block_actions", actions: [{ action_id: "approve" }] }),
+        contextKey: "slack:interaction:C123:1234567890.123456:approve",
+      }),
+    ).toBe(true);
   });
 
-  it("is case-insensitive", () => {
-    expect(isExecCompletionEvent("EXEC COMPLETED (abc12345, code 0)")).toBe(true);
-    expect(isExecCompletionEvent("exec failed (abc12345, code 2)")).toBe(true);
+  it("returns false for exec completion events even with slack:interaction contextKey", () => {
+    expect(
+      isSlackInteractionEvent({
+        text: "Exec completed (abc123, code 0)",
+        contextKey: "slack:interaction:C123:1234567890.123456:approve",
+      }),
+    ).toBe(false);
   });
 
-  it("does not match non-exec events", () => {
-    expect(isExecCompletionEvent("Exec running (gateway id=g1, session=s1, >5s): ls")).toBe(false);
-    expect(isExecCompletionEvent("Exec denied (gateway id=g1, reason): rm -rf /")).toBe(false);
-    expect(isExecCompletionEvent("Heartbeat wake")).toBe(false);
-    expect(isExecCompletionEvent("")).toBe(false);
+  it("returns false for heartbeat noise events", () => {
+    expect(
+      isSlackInteractionEvent({
+        text: "heartbeat poll",
+        contextKey: "slack:interaction:C123:1234567890.123456:approve",
+      }),
+    ).toBe(false);
   });
 
-  it("does not false-positive on free-form cron text containing exec phrases", () => {
-    expect(isExecCompletionEvent("Nightly backup exec failed – see logs")).toBe(false);
-    expect(isExecCompletionEvent("Cron: check if exec completed successfully")).toBe(false);
-    expect(isExecCompletionEvent("exec killed the process manually")).toBe(false);
-    expect(isExecCompletionEvent("Exec finished weekly backup checks")).toBe(false);
-    // Parenthesized false positive from review feedback — must not match mid-string
-    expect(isExecCompletionEvent("Nightly backup exec failed (see logs)")).toBe(false);
-    expect(isExecCompletionEvent("Check: exec completed (last run was yesterday)")).toBe(false);
+  it("returns false for non-Slack events", () => {
+    expect(
+      isSlackInteractionEvent({
+        text: JSON.stringify({ type: "block_actions", actions: [{ action_id: "approve" }] }),
+        contextKey: "cron:daily-reminder",
+      }),
+    ).toBe(false);
+  });
+});
+
+describe("buildSlackInteractionEventPrompt", () => {
+  it.each([
+    {
+      name: "builds user-facing prompt with action_id and value",
+      events: [
+        JSON.stringify({
+          type: "block_actions",
+          actions: [{ action_id: "approve_pr", value: "merge-99544" }],
+        }),
+      ],
+      opts: { deliverToUser: true, useHeartbeatResponseTool: false },
+      expected: [
+        "Slack interactive button(s) were clicked",
+        '1. action_id="approve_pr"',
+        'value="merge-99544"',
+        "Please act on these interaction(s)",
+        "Reply HEARTBEAT_OK",
+      ],
+    },
+    {
+      name: "builds internal-only prompt",
+      events: [
+        JSON.stringify({
+          type: "block_actions",
+          actions: [{ action_id: "approve_pr", value: "merge-99544" }],
+        }),
+      ],
+      opts: { deliverToUser: false, useHeartbeatResponseTool: false },
+      expected: ["Handle the result internally", "heartbeat_ok"],
+      unexpected: ["Please relay"],
+    },
+    {
+      name: "uses heartbeat_respond instruction when response tool is enabled",
+      events: [
+        JSON.stringify({
+          type: "block_actions",
+          actions: [{ action_id: "approve_pr", value: "merge-99544" }],
+        }),
+      ],
+      opts: { deliverToUser: true, useHeartbeatResponseTool: true },
+      expected: ["Use heartbeat_respond", "acknowledge the interaction(s)"],
+    },
+    {
+      name: "renders multiple queued interactions and preserves render/consume symmetry",
+      events: [
+        JSON.stringify({
+          type: "block_actions",
+          actions: [{ action_id: "approve_pr", value: "merge-99544" }],
+        }),
+        JSON.stringify({
+          type: "block_actions",
+          actions: [{ action_id: "reject_pr", value: "close-99544" }],
+        }),
+      ],
+      opts: { deliverToUser: true, useHeartbeatResponseTool: false },
+      expected: [
+        '1. action_id="approve_pr"',
+        'value="merge-99544"',
+        '2. action_id="reject_pr"',
+        'value="close-99544"',
+      ],
+      unexpected: ["...and", "more Slack"],
+    },
+    {
+      name: "caps at MAX_SLACK_INTERACTION_EVENTS and reports overflow",
+      events: Array.from({ length: 6 }, (_, index) =>
+        JSON.stringify({
+          type: "block_actions",
+          actions: [{ action_id: `action_${index}`, value: `value_${index}` }],
+        }),
+      ),
+      opts: { deliverToUser: true, useHeartbeatResponseTool: false },
+      expected: ["action_0", "action_4", "...and 1 more Slack interaction(s)"],
+      unexpected: ["action_5"],
+    },
+  ])("$name", ({ events, opts, expected, unexpected }) => {
+    const prompt = buildSlackInteractionEventPrompt(events, opts);
+    for (const part of expected) {
+      expect(prompt).toContain(part);
+    }
+    for (const part of unexpected ?? []) {
+      expect(prompt).not.toContain(part);
+    }
   });
 });

--- a/src/infra/heartbeat-events-filter.ts
+++ b/src/infra/heartbeat-events-filter.ts
@@ -2,6 +2,7 @@
 import { normalizeLowercaseStringOrEmpty } from "@openclaw/normalization-core/string-coerce";
 import { HEARTBEAT_RESPONSE_TOOL_INSTRUCTIONS } from "../auto-reply/heartbeat.js";
 import { HEARTBEAT_TOKEN } from "../auto-reply/tokens.js";
+import type { SystemEvent } from "./system-events.js";
 
 const MAX_EXEC_EVENT_PROMPT_CHARS = 8_000;
 const STRUCTURED_EXEC_COMPLETION_EVENT_RE =
@@ -215,4 +216,70 @@ export function isCronSystemEvent(evt: string) {
     return false;
   }
   return !isHeartbeatNoiseEvent(evt) && !isExecCompletionEvent(evt);
+}
+
+// Returns true when a system event was queued by a Slack interactive component
+// (button, select, etc.) and is not already handled by the exec/cron builders.
+export function isSlackInteractionEvent(event: Pick<SystemEvent, "contextKey" | "text">): boolean {
+  return Boolean(
+    event.contextKey?.startsWith("slack:interaction:") &&
+    !isExecCompletionEvent(event.text) &&
+    !isHeartbeatNoiseEvent(event.text),
+  );
+}
+
+// Cap the number of Slack interactions rendered in a single heartbeat prompt to prevent
+// prompt bloat when many rapid clicks are coalesced into one wake. Overflow is summarized
+// so the user knows additional clicks happened without exploding the context window.
+const MAX_SLACK_INTERACTION_EVENTS = 5;
+
+function parseSlackInteractionAction(eventText: string): {
+  actionId: string | undefined;
+  value: string | undefined;
+} {
+  try {
+    const parsed = JSON.parse(eventText) as {
+      actions?: Array<{ action_id?: string; value?: string }>;
+    };
+    const action = parsed.actions?.[0];
+    return { actionId: action?.action_id, value: action?.value };
+  } catch {
+    return { actionId: undefined, value: undefined };
+  }
+}
+
+export function buildSlackInteractionEventPrompt(
+  events: string[],
+  options: {
+    deliverToUser: boolean;
+    useHeartbeatResponseTool: boolean;
+  },
+): string {
+  // Render every pending interaction that selectSystemEventsConsumedByHeartbeat will
+  // consume, so the prompt/consume boundary stays symmetric. The cap only truncates the
+  // rendered list; consumed entries beyond the cap are still removed from the queue, but
+  // the summary line tells the model additional interactions arrived.
+  const rendered = events.slice(0, MAX_SLACK_INTERACTION_EVENTS).map((eventText, index) => {
+    const { actionId, value } = parseSlackInteractionAction(eventText);
+    const actionDescription = actionId ? `action_id="${actionId}"` : "a Slack button";
+    const valueDescription = value ? `value="${value}"` : "";
+    return `${index + 1}. ${actionDescription}${
+      valueDescription ? ` with ${valueDescription}` : ""
+    }`;
+  });
+
+  const remaining = events.length - rendered.length;
+  if (remaining > 0) {
+    rendered.push(`...and ${remaining} more Slack interaction(s)`);
+  }
+
+  const completionInstruction = options.useHeartbeatResponseTool
+    ? "Use heartbeat_respond to acknowledge the interaction(s)."
+    : "Reply HEARTBEAT_OK.";
+
+  const base = `Slack interactive button(s) were clicked:\n${rendered.join("\n")}\n\nPlease act on these interaction(s).`;
+
+  return options.deliverToUser
+    ? `${base} ${completionInstruction}`
+    : `${base} Handle the result internally and ${completionInstruction.toLowerCase()}`;
 }

--- a/src/infra/heartbeat-events-filter.ts
+++ b/src/infra/heartbeat-events-filter.ts
@@ -5,6 +5,7 @@ import { HEARTBEAT_TOKEN } from "../auto-reply/tokens.js";
 import type { SystemEvent } from "./system-events.js";
 
 const MAX_EXEC_EVENT_PROMPT_CHARS = 8_000;
+const SLACK_INTERACTION_EVENT_PREFIX = "Slack interaction: ";
 const STRUCTURED_EXEC_COMPLETION_EVENT_RE =
   /^exec (completed|failed) \(([a-z0-9_-]{1,64}), (code -?\d+|signal [^)]+)\)(?: :: ([\s\S]*))?$/i;
 
@@ -223,30 +224,57 @@ export function isCronSystemEvent(evt: string) {
 export function isSlackInteractionEvent(event: Pick<SystemEvent, "contextKey" | "text">): boolean {
   return Boolean(
     event.contextKey?.startsWith("slack:interaction:") &&
+    event.text.startsWith(SLACK_INTERACTION_EVENT_PREFIX) &&
     !isExecCompletionEvent(event.text) &&
     !isHeartbeatNoiseEvent(event.text),
   );
+}
+
+// The Slack plugin enqueues interaction events with a "Slack interaction: " prefix
+// followed by a JSON object containing top-level actionId/value fields (and other
+// selected/input values for select/modal components). This helper strips the prefix
+// and extracts the fields the heartbeat prompt needs.
+function parseSlackInteractionSummary(eventText: string): {
+  actionId: string | undefined;
+  value: string | undefined;
+  selectedValues: string[] | undefined;
+  inputValue: string | undefined;
+} {
+  if (!eventText.startsWith(SLACK_INTERACTION_EVENT_PREFIX)) {
+    return {
+      actionId: undefined,
+      value: undefined,
+      selectedValues: undefined,
+      inputValue: undefined,
+    };
+  }
+  try {
+    const parsed = JSON.parse(eventText.slice(SLACK_INTERACTION_EVENT_PREFIX.length)) as {
+      actionId?: string;
+      value?: string;
+      selectedValues?: string[];
+      inputValue?: string;
+    };
+    return {
+      actionId: parsed.actionId,
+      value: parsed.value,
+      selectedValues: Array.isArray(parsed.selectedValues) ? parsed.selectedValues : undefined,
+      inputValue: parsed.inputValue,
+    };
+  } catch {
+    return {
+      actionId: undefined,
+      value: undefined,
+      selectedValues: undefined,
+      inputValue: undefined,
+    };
+  }
 }
 
 // Cap the number of Slack interactions rendered in a single heartbeat prompt to prevent
 // prompt bloat when many rapid clicks are coalesced into one wake. Overflow is summarized
 // so the user knows additional clicks happened without exploding the context window.
 const MAX_SLACK_INTERACTION_EVENTS = 5;
-
-function parseSlackInteractionAction(eventText: string): {
-  actionId: string | undefined;
-  value: string | undefined;
-} {
-  try {
-    const parsed = JSON.parse(eventText) as {
-      actions?: Array<{ action_id?: string; value?: string }>;
-    };
-    const action = parsed.actions?.[0];
-    return { actionId: action?.action_id, value: action?.value };
-  } catch {
-    return { actionId: undefined, value: undefined };
-  }
-}
 
 export function buildSlackInteractionEventPrompt(
   events: string[],
@@ -260,12 +288,20 @@ export function buildSlackInteractionEventPrompt(
   // rendered list; consumed entries beyond the cap are still removed from the queue, but
   // the summary line tells the model additional interactions arrived.
   const rendered = events.slice(0, MAX_SLACK_INTERACTION_EVENTS).map((eventText, index) => {
-    const { actionId, value } = parseSlackInteractionAction(eventText);
-    const actionDescription = actionId ? `action_id="${actionId}"` : "a Slack button";
-    const valueDescription = value ? `value="${value}"` : "";
-    return `${index + 1}. ${actionDescription}${
-      valueDescription ? ` with ${valueDescription}` : ""
-    }`;
+    const { actionId, value, selectedValues, inputValue } = parseSlackInteractionSummary(eventText);
+    const idPart = actionId ? `action_id="${actionId}"` : "a Slack interaction";
+    const valueParts: string[] = [];
+    if (value != null && value !== "") {
+      valueParts.push(`value="${value}"`);
+    }
+    if (selectedValues != null && selectedValues.length > 0) {
+      valueParts.push(`selected=${JSON.stringify(selectedValues)}`);
+    }
+    if (inputValue != null && inputValue !== "") {
+      valueParts.push(`input="${inputValue}"`);
+    }
+    const valuePart = valueParts.length > 0 ? ` with ${valueParts.join(", ")}` : "";
+    return `${index + 1}. ${idPart}${valuePart}`;
   });
 
   const remaining = events.length - rendered.length;
@@ -277,7 +313,7 @@ export function buildSlackInteractionEventPrompt(
     ? "Use heartbeat_respond to acknowledge the interaction(s)."
     : "Reply HEARTBEAT_OK.";
 
-  const base = `Slack interactive button(s) were clicked:\n${rendered.join("\n")}\n\nPlease act on these interaction(s).`;
+  const base = `Slack interactive component(s) were used:\n${rendered.join("\n")}\n\nPlease act on these interaction(s).`;
 
   return options.deliverToUser
     ? `${base} ${completionInstruction}`

--- a/src/infra/heartbeat-runner.slack-interaction.test.ts
+++ b/src/infra/heartbeat-runner.slack-interaction.test.ts
@@ -53,10 +53,10 @@ describe("runHeartbeatOnce Slack interaction", () => {
   it("injects a Slack interaction system event into the heartbeat prompt", async () => {
     const tempDirs = useAutoCleanupTempDirTracker();
     const { cfg, sessionKey } = await buildConfig(tempDirs);
-    const interactionPayload = JSON.stringify({
-      type: "block_actions",
-      actions: [{ action_id: "approve_pr", value: "merge-99544" }],
-    });
+    const interactionPayload = `Slack interaction: ${JSON.stringify({
+      actionId: "approve_pr",
+      value: "merge-99544",
+    })}`;
     enqueueSystemEvent(interactionPayload, {
       sessionKey,
       contextKey: "slack:interaction:C123:1234567890.123456:approve_pr",
@@ -80,7 +80,7 @@ describe("runHeartbeatOnce Slack interaction", () => {
     expect(replySpy).toHaveBeenCalledTimes(1);
     const body = replySpy.mock.calls[0][0] as { Body?: string; Provider?: string };
     expect(body.Provider).toBe("heartbeat");
-    expect(body.Body).toContain("Slack interactive button(s) were clicked");
+    expect(body.Body).toContain("Slack interactive component(s) were used");
     expect(body.Body).toContain('action_id="approve_pr"');
     expect(body.Body).toContain('value="merge-99544"');
   });
@@ -91,20 +91,14 @@ describe("runHeartbeatOnce Slack interaction", () => {
 
     // Simulate two rapid Slack button clicks that get coalesced into one heartbeat wake.
     enqueueSystemEvent(
-      JSON.stringify({
-        type: "block_actions",
-        actions: [{ action_id: "approve_pr", value: "merge-99544" }],
-      }),
+      `Slack interaction: ${JSON.stringify({ actionId: "approve_pr", value: "merge-99544" })}`,
       {
         sessionKey,
         contextKey: "slack:interaction:C123:1234567890.123456:approve_pr",
       },
     );
     enqueueSystemEvent(
-      JSON.stringify({
-        type: "block_actions",
-        actions: [{ action_id: "reject_pr", value: "close-99544" }],
-      }),
+      `Slack interaction: ${JSON.stringify({ actionId: "reject_pr", value: "close-99544" })}`,
       {
         sessionKey,
         contextKey: "slack:interaction:C123:1234567890.123456:reject_pr",

--- a/src/infra/heartbeat-runner.slack-interaction.test.ts
+++ b/src/infra/heartbeat-runner.slack-interaction.test.ts
@@ -1,0 +1,147 @@
+// Integration test: Slack interaction system events are injected into the heartbeat prompt.
+import path from "node:path";
+import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
+import type { OpenClawConfig } from "../config/config.js";
+import { resolveMainSessionKey } from "../config/sessions.js";
+import { getActivePluginRegistry, setActivePluginRegistry } from "../plugins/runtime.js";
+import { createTestRegistry } from "../test-utils/channel-plugins.js";
+import { runHeartbeatOnce, type HeartbeatDeps } from "./heartbeat-runner.js";
+import { enqueueSystemEvent, resetSystemEventsForTest } from "./system-events.js";
+
+let previousRegistry: ReturnType<typeof getActivePluginRegistry> | null = null;
+
+beforeAll(() => {
+  previousRegistry = getActivePluginRegistry();
+  setActivePluginRegistry(createTestRegistry([]));
+});
+
+beforeEach(() => {
+  resetSystemEventsForTest();
+});
+
+// The registry is restored after all tests in this file so other tests are not affected.
+it("restores plugin registry after suite", () => {
+  expect(true).toBe(true);
+});
+
+async function buildConfig(tempDirs: ReturnType<typeof useAutoCleanupTempDirTracker>): Promise<{
+  cfg: OpenClawConfig;
+  sessionKey: string;
+}> {
+  const tmpDir = tempDirs.make("openclaw-hb-slack-interaction-case-");
+  const storePath = path.join(tmpDir, "sessions.json");
+  const cfg: OpenClawConfig = {
+    agents: {
+      defaults: {
+        workspace: tmpDir,
+        heartbeat: { every: "5m", target: "none" },
+      },
+    },
+    session: { store: storePath },
+  };
+  return { cfg, sessionKey: resolveMainSessionKey(cfg) };
+}
+
+function createReplySpy() {
+  const replySpy = vi.fn<NonNullable<HeartbeatDeps["getReplyFromConfig"]>>();
+  replySpy.mockResolvedValue({ text: "Acknowledged" });
+  return replySpy;
+}
+
+describe("runHeartbeatOnce Slack interaction", () => {
+  it("injects a Slack interaction system event into the heartbeat prompt", async () => {
+    const tempDirs = useAutoCleanupTempDirTracker();
+    const { cfg, sessionKey } = await buildConfig(tempDirs);
+    const interactionPayload = JSON.stringify({
+      type: "block_actions",
+      actions: [{ action_id: "approve_pr", value: "merge-99544" }],
+    });
+    enqueueSystemEvent(interactionPayload, {
+      sessionKey,
+      contextKey: "slack:interaction:C123:1234567890.123456:approve_pr",
+    });
+
+    const replySpy = createReplySpy();
+    const res = await runHeartbeatOnce({
+      cfg,
+      source: "hook",
+      reason: "hook:slack-interaction",
+      deps: {
+        getReplyFromConfig: replySpy,
+        getQueueSize: () => 0,
+        nowMs: () => Date.now(),
+        webAuthExists: async () => true,
+        hasActiveWebListener: () => true,
+      } as HeartbeatDeps,
+    });
+
+    expect(res.status).toBe("ran");
+    expect(replySpy).toHaveBeenCalledTimes(1);
+    const body = replySpy.mock.calls[0][0] as { Body?: string; Provider?: string };
+    expect(body.Provider).toBe("heartbeat");
+    expect(body.Body).toContain("Slack interactive button(s) were clicked");
+    expect(body.Body).toContain('action_id="approve_pr"');
+    expect(body.Body).toContain('value="merge-99544"');
+  });
+
+  it("renders all queued Slack interaction events so none are consumed and lost", async () => {
+    const tempDirs = useAutoCleanupTempDirTracker();
+    const { cfg, sessionKey } = await buildConfig(tempDirs);
+
+    // Simulate two rapid Slack button clicks that get coalesced into one heartbeat wake.
+    enqueueSystemEvent(
+      JSON.stringify({
+        type: "block_actions",
+        actions: [{ action_id: "approve_pr", value: "merge-99544" }],
+      }),
+      {
+        sessionKey,
+        contextKey: "slack:interaction:C123:1234567890.123456:approve_pr",
+      },
+    );
+    enqueueSystemEvent(
+      JSON.stringify({
+        type: "block_actions",
+        actions: [{ action_id: "reject_pr", value: "close-99544" }],
+      }),
+      {
+        sessionKey,
+        contextKey: "slack:interaction:C123:1234567890.123456:reject_pr",
+      },
+    );
+
+    const replySpy = createReplySpy();
+    const res = await runHeartbeatOnce({
+      cfg,
+      source: "hook",
+      reason: "hook:slack-interaction",
+      deps: {
+        getReplyFromConfig: replySpy,
+        getQueueSize: () => 0,
+        nowMs: () => Date.now(),
+        webAuthExists: async () => true,
+        hasActiveWebListener: () => true,
+      } as HeartbeatDeps,
+    });
+
+    expect(res.status).toBe("ran");
+    expect(replySpy).toHaveBeenCalledTimes(1);
+    const body = replySpy.mock.calls[0][0] as { Body?: string };
+    expect(body.Body).toContain('action_id="approve_pr"');
+    expect(body.Body).toContain('value="merge-99544"');
+    expect(body.Body).toContain('action_id="reject_pr"');
+    expect(body.Body).toContain('value="close-99544"');
+  });
+});
+
+// Restore the plugin registry after the suite so other test files see the original registry.
+// This is registered last so it runs after the describe block above.
+describe("suite cleanup", () => {
+  it("restores the original plugin registry", () => {
+    if (previousRegistry) {
+      setActivePluginRegistry(previousRegistry);
+    }
+    expect(true).toBe(true);
+  });
+});

--- a/src/infra/heartbeat-runner.ts
+++ b/src/infra/heartbeat-runner.ts
@@ -117,9 +117,11 @@ import { recordRunStart, shouldDeferWake, type DeferDecision } from "./heartbeat
 import {
   buildCronEventPrompt,
   buildExecEventPrompt,
+  buildSlackInteractionEventPrompt,
   isCronSystemEvent,
   isExecCompletionEvent,
   isRelayableExecCompletionEvent,
+  isSlackInteractionEvent,
 } from "./heartbeat-events-filter.js";
 import { emitHeartbeatEvent, resolveIndicatorType } from "./heartbeat-events.js";
 import { HEARTBEAT_RUN_SCOPE, type HeartbeatRunScope } from "./heartbeat-run-scope.js";
@@ -1130,6 +1132,7 @@ type HeartbeatPromptResolution = {
   hasExecCompletion: boolean;
   hasRelayableExecCompletion: boolean;
   hasCronEvents: boolean;
+  hasInteractionEvents: boolean;
   hasDueCommitments: boolean;
   usesHeartbeatResponseTool: boolean;
 };
@@ -1242,6 +1245,13 @@ function resolveHeartbeatRunPrompt(params: {
   const hasRelayableExecCompletion =
     params.canRelayToUser && execEvents.some((event) => isRelayableExecCompletionEvent(event));
   const hasCronEvents = cronEvents.length > 0;
+  // Slack interaction events are queued by the bundled Slack plugin with a
+  // slack:interaction:... context key. Mirror the exec/cron branches so the
+  // clicked action_id/value reach the model instead of being drained silently.
+  const interactionEvents = pendingEventEntries
+    .filter((event) => isSlackInteractionEvent(event))
+    .map((event) => event.text);
+  const hasInteractionEvents = interactionEvents.length > 0;
   const commitmentPrompt = buildCommitmentHeartbeatPrompt({
     commitments: params.preflight.dueCommitments,
     useHeartbeatResponseTool: false,
@@ -1254,6 +1264,7 @@ function resolveHeartbeatRunPrompt(params: {
         hasExecCompletion: false,
         hasRelayableExecCompletion: false,
         hasCronEvents: false,
+        hasInteractionEvents: false,
         hasDueCommitments,
         usesHeartbeatResponseTool: false,
       };
@@ -1263,6 +1274,7 @@ function resolveHeartbeatRunPrompt(params: {
       hasExecCompletion: false,
       hasRelayableExecCompletion: false,
       hasCronEvents: false,
+      hasInteractionEvents: false,
       hasDueCommitments: false,
       usesHeartbeatResponseTool: false,
     };
@@ -1287,6 +1299,7 @@ ${completionInstruction}`;
         hasExecCompletion: false,
         hasRelayableExecCompletion: false,
         hasCronEvents: false,
+        hasInteractionEvents: false,
         hasDueCommitments: false,
         usesHeartbeatResponseTool: params.useHeartbeatResponseTool,
       };
@@ -1297,6 +1310,7 @@ ${completionInstruction}`;
         hasExecCompletion: false,
         hasRelayableExecCompletion: false,
         hasCronEvents: false,
+        hasInteractionEvents: false,
         hasDueCommitments,
         usesHeartbeatResponseTool: false,
       };
@@ -1306,6 +1320,7 @@ ${completionInstruction}`;
       hasExecCompletion: false,
       hasRelayableExecCompletion: false,
       hasCronEvents: false,
+      hasInteractionEvents: false,
       hasDueCommitments: false,
       usesHeartbeatResponseTool: false,
     };
@@ -1322,9 +1337,16 @@ ${completionInstruction}`;
           deliverToUser: params.canRelayToUser,
           useHeartbeatResponseTool: baseUsesHeartbeatResponseTool,
         })
-      : baseUsesHeartbeatResponseTool
-        ? resolveHeartbeatResponseToolPrompt(params.cfg, params.heartbeat)
-        : resolveHeartbeatPrompt(params.cfg, params.heartbeat);
+      : hasInteractionEvents
+        ? // Use the dedicated Slack interaction builder so queued interaction
+          // values are rendered before the heartbeat consumes the entries.
+          buildSlackInteractionEventPrompt(interactionEvents, {
+            deliverToUser: params.canRelayToUser,
+            useHeartbeatResponseTool: baseUsesHeartbeatResponseTool,
+          })
+        : baseUsesHeartbeatResponseTool
+          ? resolveHeartbeatResponseToolPrompt(params.cfg, params.heartbeat)
+          : resolveHeartbeatPrompt(params.cfg, params.heartbeat);
   const basePromptWithHint = appendHeartbeatWorkspacePathHint(basePrompt, params.workspaceDir);
   const basePromptWithDirectives = appendHeartbeatFileDirectives(
     basePromptWithHint,
@@ -1339,6 +1361,7 @@ ${completionInstruction}`;
     hasExecCompletion,
     hasRelayableExecCompletion,
     hasCronEvents,
+    hasInteractionEvents,
     hasDueCommitments,
     usesHeartbeatResponseTool: baseUsesHeartbeatResponseTool,
   };
@@ -1348,6 +1371,7 @@ function selectSystemEventsConsumedByHeartbeat(params: {
   preflight: HeartbeatPreflight;
   hasExecCompletion: boolean;
   hasCronEvents: boolean;
+  hasInteractionEvents: boolean;
 }): SystemEvent[] {
   const { preflight } = params;
   if (!preflight.shouldInspectPendingEvents || preflight.pendingEventEntries.length === 0) {
@@ -1362,6 +1386,12 @@ function selectSystemEventsConsumedByHeartbeat(params: {
         (preflight.isCronWake || event.contextKey?.startsWith("cron:")) &&
         isCronSystemEvent(event.text),
     );
+  }
+  if (params.hasInteractionEvents) {
+    // Consume every Slack interaction event that the prompt builder above will
+    // render. This keeps the queue drain symmetric with the prompt content so
+    // no rendered event is left behind and no unrendered event is lost.
+    return preflight.pendingEventEntries.filter((event) => isSlackInteractionEvent(event));
   }
   return preflight.pendingEventEntries;
 }
@@ -1634,6 +1664,7 @@ export async function runHeartbeatOnce(opts: {
     hasExecCompletion,
     hasRelayableExecCompletion,
     hasCronEvents,
+    hasInteractionEvents,
     hasDueCommitments,
     usesHeartbeatResponseTool,
   } = resolveHeartbeatRunPrompt({
@@ -1655,6 +1686,7 @@ export async function runHeartbeatOnce(opts: {
     preflight,
     hasExecCompletion,
     hasCronEvents,
+    hasInteractionEvents,
   });
 
   // If no tasks are due, skip heartbeat entirely

--- a/src/scripts/test-projects.test.ts
+++ b/src/scripts/test-projects.test.ts
@@ -942,6 +942,12 @@ describe("test-projects args", () => {
         watchMode: false,
       },
       {
+        config: "test/vitest/vitest.infra.config.ts",
+        forwardedArgs: [],
+        includePatterns: ["src/infra/heartbeat-runner.slack-interaction.test.ts"],
+        watchMode: false,
+      },
+      {
         config: "test/vitest/vitest.runtime-config.config.ts",
         forwardedArgs: [],
         includePatterns: ["src/config/sessions/entry-freshness.test.ts"],


### PR DESCRIPTION
Fixes #99544

## What Problem This Solves

Fixes #99544 (follow-up to #61502). Slack interactive component events (button clicks, select menus, modal inputs) wake the target session and thread, but the interaction payload never reaches the agent as input. `consumeSelectedSystemEventEntries` removes the interaction entry from the system event queue, yet the event text was never injected into the heartbeat prompt.

The earlier implementation also parsed the wrong payload shape: real Slack plugin events are serialized as `Slack interaction: {"actionId": ..., "value": ..., ...}`, not the raw Slack `block_actions` envelope with `actions[0].action_id`.

## Why This Change Was Made

The heartbeat runner's prompt resolution has dedicated builders for exec-completion and cron events, but the generic fallback path never includes system event text. When a Slack hook wake triggers a heartbeat with no exec/cron events, the generic heartbeat prompt is used and the interaction payload is silently dropped.

This change adds a Slack-interaction-typed branch that matches the real event format produced by the Slack plugin (`extensions/slack/src/monitor/events/interactions.ts`):

- `src/infra/heartbeat-events-filter.ts`: add `isSlackInteractionEvent()` and `buildSlackInteractionEventPrompt()`; parse the `Slack interaction: ` prefix and extract top-level `actionId`, `value`, `selectedValues`, and `inputValue` fields.
- `src/infra/heartbeat-runner.ts`: route pending system events whose `contextKey` starts with `slack:interaction:` to the new builder, mirroring the exec/cron branches.

Unlike a generic "prepend all system event text" approach, this only touches events explicitly queued as Slack interactions, so it does not widen the prompt-injection surface for arbitrary system events.

The prompt builder renders **all** queued Slack interactions (with a cap of 5 rendered entries plus an overflow summary), preserving symmetry with `selectSystemEventsConsumedByHeartbeat` so no interaction is consumed without being rendered.

## User Impact

Users interacting with Slack buttons, select menus, or modal inputs will see the `action_id` and associated value(s) reflected in the agent's heartbeat turn, including multiple rapid interactions coalesced into a single wake. No other heartbeat behavior changes.

## Evidence

Unit tests (includes real event format parsing and select/input value rendering):

```bash
$ pnpm test src/infra/heartbeat-events-filter.test.ts

 RUN  v4.1.8 /media/vdc/study/op/openclaw

 ✓ |unit-fast| src/infra/heartbeat-events-filter.test.ts (55 tests) 13ms

 Test Files  1 passed (1)
      Tests  55 passed (55)
```

Integration tests (covers the multi-interaction render/consume symmetry raised by reviewer):

```bash
$ pnpm test src/infra/heartbeat-runner.slack-interaction.test.ts

 RUN  v4.1.8 /media/vdc/study/op/openclaw

 ✓ |infra| src/infra/heartbeat-runner.slack-interaction.test.ts (4 tests) 57ms

 Test Files  1 passed (1)
      Tests  4 passed (4)
```

Format / lint:

```bash
$ pnpm exec oxfmt --check --threads=1 \
    src/infra/heartbeat-events-filter.ts \
    src/infra/heartbeat-events-filter.test.ts \
    src/infra/heartbeat-runner.slack-interaction.test.ts
All matched files use the correct format.

$ pnpm exec oxlint --tsconfig tsconfig.json \
    src/infra/heartbeat-events-filter.ts \
    src/infra/heartbeat-events-filter.test.ts \
    src/infra/heartbeat-runner.slack-interaction.test.ts
Found 0 warnings and 0 errors.

$ git diff --check
# no output
```

Key assertions from the integration test show the prompt body contains both interactions when two are queued, using the real Slack plugin format:

```
Slack interactive component(s) were used:
1. action_id="approve_pr" with value="merge-99544"
2. action_id="reject_pr" with value="close-99544"

Please act on these interaction(s). Reply HEARTBEAT_OK.
```

