### PR TITLE
fix(ollama): bound native streaming 200 success-body NDJSON reads at 16 MiB

### DIFF
--- a/extensions/ollama/src/setup.test.ts
+++ b/extensions/ollama/src/setup.test.ts
@@ -557,6 +557,59 @@ describe("ollama setup", () => {
       }
     });
 
+    it("bounds oversized pull body and cancels the stream", async () => {
+      const chunk = new Uint8Array(1024 * 1024); // 1 MiB chunk
+      let readCount = 0;
+      let canceled = false;
+      // 64 chunks × 1 MiB = 64 MiB — exceeds the 16 MiB cap
+      const oversizedBody = new ReadableStream<Uint8Array>({
+        pull(controller) {
+          if (readCount >= 64) {
+            controller.close();
+            return;
+          }
+          readCount += 1;
+          controller.enqueue(chunk);
+        },
+        cancel() {
+          canceled = true;
+        },
+      });
+
+      const progress = { update: vi.fn(), stop: vi.fn() };
+      const prompter = {
+        progress: vi.fn(() => progress),
+      } as unknown as WizardPrompter;
+
+      const fetchMock = vi.fn(async (input: string | URL | Request) => {
+        const url = requestUrl(input);
+        if (url.endsWith("/api/tags")) {
+          return jsonResponse({ models: [] });
+        }
+        if (url.endsWith("/api/pull")) {
+          return new Response(oversizedBody, { status: 200 });
+        }
+        throw new Error(`Unexpected fetch: ${url}`);
+      });
+      vi.stubGlobal("fetch", fetchMock);
+
+      await ensureOllamaModelPulled({
+        config: createDefaultOllamaConfig("ollama/gemma4"),
+        model: "ollama/gemma4",
+        prompter,
+      }).catch((err: unknown) => err);
+
+      // Stream must be cancelled well before all 64 MiB are consumed.
+      expect(readCount).toBeLessThan(64);
+      expect(canceled).toBe(true);
+      // The spinner must surface the canonical bounded-read error.
+      expect(progress.stop).toHaveBeenCalledWith(
+        expect.stringMatching(
+          /^Failed to download gemma4: Ollama pull body exceeded \d+ bytes \(received \d+\)$/,
+        ),
+      );
+    });
+
     it("skips pull when model is already available", async () => {
       const prompter = {} as unknown as WizardPrompter;
 

--- a/extensions/ollama/src/setup.ts
+++ b/extensions/ollama/src/setup.ts
@@ -18,6 +18,7 @@ import { applyAgentDefaultModelPrimary } from "openclaw/plugin-sdk/provider-onbo
 import type { RuntimeEnv } from "openclaw/plugin-sdk/runtime";
 import { WizardCancelledError, type WizardPrompter } from "openclaw/plugin-sdk/setup";
 import { fetchWithSsrFGuard } from "openclaw/plugin-sdk/ssrf-runtime";
+import { createSseByteGuard } from "./sse-byte-guard.js";
 import {
   normalizeLowercaseStringOrEmpty,
   normalizeOptionalLowercaseString,
@@ -48,6 +49,7 @@ const OLLAMA_CONTEXT_ENRICH_LIMIT = 200;
 const OLLAMA_CLOUD_MAX_DISCOVERED_MODELS = 500;
 const OLLAMA_PULL_RESPONSE_TIMEOUT_MS = 30_000;
 const OLLAMA_PULL_STREAM_IDLE_TIMEOUT_MS = 300_000;
+const OLLAMA_PULL_STREAM_MAX_BYTES = 16 * 1024 * 1024;
 
 type OllamaSetupOptions = {
   customBaseUrl?: string;
@@ -177,7 +179,7 @@ type OllamaPullChunk = {
 type OllamaPullResult = { ok: true } | { ok: false; message: string };
 
 async function readOllamaPullChunkWithIdleTimeout(
-  reader: ReadableStreamDefaultReader<Uint8Array>,
+  reader: Pick<ReadableStreamDefaultReader<Uint8Array>, "read" | "cancel">,
 ): Promise<ReadableStreamReadResult<Uint8Array>> {
   let timeoutId: ReturnType<typeof setTimeout> | undefined;
   let timedOut = false;
@@ -251,7 +253,12 @@ async function pullOllamaModelCore(params: {
         return { ok: false, message: `Failed to download ${modelName} (no response body)` };
       }
 
-      const reader = response.body.getReader();
+      const rawReader = response.body.getReader();
+      const reader = createSseByteGuard(rawReader, {
+        maxBytes: OLLAMA_PULL_STREAM_MAX_BYTES,
+        onOverflow: ({ size, maxBytes }) =>
+          new Error(`Ollama pull body exceeded ${maxBytes} bytes (received ${size})`),
+      });
       const decoder = new TextDecoder();
       let buffer = "";
       const layers = new Map<string, { total: number; completed: number }>();

--- a/extensions/ollama/src/sse-byte-guard.ts
+++ b/extensions/ollama/src/sse-byte-guard.ts
@@ -1,0 +1,86 @@
+/**
+ * Plugin-local bounded SSE / NDJSON stream reader guard.
+ *
+ * Internal seam until `createSseByteGuard` is promoted to a public Plugin SDK
+ * subpath in a future PR. The canonical implementation lives in
+ * `packages/ai/src/utils/streaming-byte-guard.ts`.
+ *
+ * Wraps a `ReadableStreamDefaultReader<Uint8Array>` so the caller's existing
+ * chunk-by-chunk parsing logic is unchanged, but accumulated bytes are tracked
+ * against a hard cap. On overflow the underlying reader is cancelled and a
+ * canonical error is thrown.
+ */
+
+export type SseStreamOverflow = {
+  size: number;
+  maxBytes: number;
+};
+
+export type ReadSseStreamWithLimitOptions = {
+  maxBytes: number;
+  onOverflow?: (params: SseStreamOverflow) => Error;
+};
+
+export type SseByteGuard = {
+  read(): Promise<ReadableStreamReadResult<Uint8Array>>;
+  cancel(reason?: unknown): Promise<void>;
+  totalBytes(): number;
+  overflowed(): boolean;
+  cancelled(): boolean;
+};
+
+export function createSseByteGuard(
+  reader: ReadableStreamDefaultReader<Uint8Array>,
+  opts: ReadSseStreamWithLimitOptions,
+): SseByteGuard {
+  if (!Number.isFinite(opts.maxBytes) || opts.maxBytes < 0) {
+    throw new RangeError(`maxBytes must be a non-negative finite number: ${opts.maxBytes}`);
+  }
+  const onOverflow =
+    opts.onOverflow ??
+    ((params) =>
+      new Error(`SSE stream exceeds ${params.maxBytes} bytes (received ${params.size})`));
+  let total = 0;
+  let overflowedFlag = false;
+  let cancelledFlag = false;
+  return {
+    read: async () => {
+      if (overflowedFlag || cancelledFlag) {
+        return { done: true, value: undefined };
+      }
+      const result = await reader.read();
+      if (result.done) {
+        return result;
+      }
+      const chunkLen = result.value?.byteLength ?? 0;
+      const next = total + chunkLen;
+      if (next > opts.maxBytes) {
+        overflowedFlag = true;
+        cancelledFlag = true;
+        const err = onOverflow({ size: next, maxBytes: opts.maxBytes });
+        try {
+          await reader.cancel(err);
+        } catch {
+          // best-effort cancellation; caller observes the overflow error
+        }
+        throw err;
+      }
+      total = next;
+      return result;
+    },
+    cancel: async (reason?: unknown) => {
+      if (overflowedFlag) {
+        return;
+      }
+      cancelledFlag = true;
+      try {
+        await reader.cancel(reason);
+      } catch {
+        // best-effort cancellation
+      }
+    },
+    totalBytes: () => total,
+    overflowed: () => overflowedFlag,
+    cancelled: () => cancelledFlag,
+  };
+}

--- a/extensions/ollama/src/stream-runtime.test.ts
+++ b/extensions/ollama/src/stream-runtime.test.ts
@@ -1,3 +1,4 @@
+import { createSseByteGuard } from "./sse-byte-guard.js";
 // Ollama tests cover stream runtime plugin behavior.
 import { afterEach, describe, expect, it, vi } from "vitest";
 
@@ -1600,6 +1601,182 @@ describe("parseNdjsonStream", () => {
       | undefined;
     expect(args?.retries).toBe(3);
     expect(args?.delayMs).toBe(2500);
+  });
+});
+
+describe("parseNdjsonStream bounded read (16 MiB cap)", () => {
+  // Layer 1: inline deterministic overflow. 32 × 1 MiB chunks advertised by a
+  // fake pull stream. The wrapped reader must cancel and throw the canonical
+  // overflow error after ~16 MiB, long before the full 32 MiB is drained.
+  it("cancels and throws when bytes exceed 16 MiB", async () => {
+    const CHUNK = 1024 * 1024; // 1 MiB
+    const TOTAL_CHUNKS = 32; // 32 MiB server-side
+    let pullCount = 0;
+    let cancelReason: unknown;
+    const overflowing = new ReadableStream<Uint8Array>({
+      pull(controller) {
+        pullCount += 1;
+        if (pullCount > TOTAL_CHUNKS) {
+          controller.close();
+          return;
+        }
+        controller.enqueue(new Uint8Array(CHUNK));
+      },
+      cancel(reason) {
+        cancelReason = reason;
+      },
+    });
+    const guarded = createSseByteGuard(overflowing.getReader(), {
+      maxBytes: 16 * 1024 * 1024,
+      onOverflow: ({ size, maxBytes }) =>
+        new Error(`Ollama streaming body exceeded ${maxBytes} bytes (received ${size})`),
+    });
+
+    let thrown: Error | undefined;
+    try {
+      for await (const _ of parseNdjsonStream(guarded)) {
+        // exhaust — overflow must fire on the read that crosses 16 MiB
+      }
+    } catch (err) {
+      thrown = err as Error;
+    }
+
+    expect(thrown).toBeInstanceOf(Error);
+    expect(thrown?.message).toMatch(
+      /^Ollama streaming body exceeded 16777216 bytes \(received \d+\)$/,
+    );
+    // pullCount must be capped somewhere in [17, 20]: 16 MiB exact cap leaves
+    // room for one in-flight chunk read plus one TCP-coalesced tail.
+    expect(pullCount).toBeGreaterThanOrEqual(17);
+    expect(pullCount).toBeLessThanOrEqual(20);
+    expect(cancelReason).toBeInstanceOf(Error);
+    expect(guarded.overflowed()).toBe(true);
+    expect(guarded.cancelled()).toBe(true);
+  });
+
+  // Layer 2: negative control. A small valid NDJSON response must drain
+  // end-to-end without overflow. Proves the cap is the cause of rejection,
+  // not body structure.
+  it("drains small valid NDJSON without overflow", async () => {
+    const lines = [
+      '{"model":"m","created_at":"t","message":{"role":"assistant","content":"hello"},"done":false}',
+      '{"model":"m","created_at":"t","message":{"role":"assistant","content":""},"done":true,"prompt_eval_count":5,"eval_count":2}',
+    ];
+    const reader = mockNdjsonReader(lines);
+    const guarded = createSseByteGuard(reader, {
+      maxBytes: 16 * 1024 * 1024,
+      onOverflow: ({ size, maxBytes }) =>
+        new Error(`Ollama streaming body exceeded ${maxBytes} bytes (received ${size})`),
+    });
+
+    const chunks = [];
+    for await (const chunk of parseNdjsonStream(guarded)) {
+      chunks.push(chunk);
+    }
+    expect(chunks).toHaveLength(2);
+    expect(chunks[1].done).toBe(true);
+    expect(guarded.totalBytes()).toBeLessThan(16 * 1024 * 1024);
+    expect(guarded.overflowed()).toBe(false);
+  });
+
+  // Layer 3: loopback http.createServer real-wire proof. Drives the
+  // production `createSseByteGuard` over a real TCP socket. Server streams
+  // unbounded 1 MiB chunks with no newline terminator; client overflows at
+  // 16 MiB and observes the same canonical error message.
+  it("bounds real TCP-streamed NDJSON body without content-length", async () => {
+    const { createServer } = await import("node:http");
+    type AddressInfo = { address: string; family: string; port: number };
+    const CHUNK = 1024 * 1024;
+    const TOTAL_CHUNKS = 64;
+    let bytesSent = 0;
+    let aborted = false;
+
+    const server = createServer((req, res) => {
+      res.writeHead(200, {
+        "Content-Type": "application/x-ndjson",
+        "Transfer-Encoding": "chunked",
+      });
+      let i = 0;
+      const interval = setInterval(() => {
+        if (aborted || i >= TOTAL_CHUNKS) {
+          clearInterval(interval);
+          res.end();
+          return;
+        }
+        i += 1;
+        bytesSent += CHUNK;
+        res.write(new Uint8Array(CHUNK));
+      }, 1);
+      req.on("close", () => {
+        aborted = true;
+        clearInterval(interval);
+      });
+    });
+
+    await new Promise<void>((resolve) => {
+      server.listen(0, "127.0.0.1", () => resolve());
+    });
+    const address = server.address() as AddressInfo;
+    const port = address.port;
+
+    try {
+      const response = await fetch(`http://127.0.0.1:${port}/api/chat`, {
+        method: "POST",
+        body: "{}",
+      });
+      if (!response.body) {
+        throw new Error("loopback test setup: empty response body");
+      }
+      const guarded = createSseByteGuard(response.body.getReader(), {
+        maxBytes: 16 * 1024 * 1024,
+        onOverflow: ({ size, maxBytes }) =>
+          new Error(`Ollama streaming body exceeded ${maxBytes} bytes (received ${size})`),
+      });
+
+      let thrown: Error | undefined;
+      let totalRead = 0;
+      try {
+        // Keep reading until overflow throws or stream closes. Don't cap the
+        // read count; trust the server will cancel once the cap fires.
+        while (true) {
+          const result = await guarded.read();
+          if (result.done) {
+            break;
+          }
+          totalRead += result.value.byteLength;
+        }
+      } catch (err) {
+        thrown = err as Error;
+      }
+
+      // Print quantitative read-out for PR body evidence.
+      console.log(
+        `[layer3 loopback proof] cap=16777216, totalRead=${totalRead}, bytesSent=${bytesSent}, overflowed=${guarded.overflowed()}, cancelled=${guarded.cancelled()}, receivedBytes=${thrown?.message.match(/received (\d+)/)?.[1] ?? "?"}`,
+      );
+
+      expect(thrown).toBeInstanceOf(Error);
+      expect(thrown?.message).toMatch(
+        /^Ollama streaming body exceeded 16777216 bytes \(received \d+\)$/,
+      );
+      // The cap fires when `total + chunkLen > cap`. The thrown error's
+      // `size` is that crossed value, so receivedBytes is strictly > cap.
+      // totalRead is the sum of chunks actually returned (none cross cap),
+      // so totalRead <= cap. bytesSent is what the server kept writing
+      // before our cancel propagated, so bytesSent > totalRead.
+      const receivedMatch = thrown?.message.match(/received (\d+)/);
+      const receivedBytes = receivedMatch ? Number(receivedMatch[1]) : 0;
+      expect(receivedBytes).toBeGreaterThan(16 * 1024 * 1024);
+      expect(totalRead).toBeLessThanOrEqual(16 * 1024 * 1024);
+      expect(totalRead).toBeLessThan(bytesSent);
+      expect(bytesSent).toBeLessThanOrEqual(TOTAL_CHUNKS * CHUNK);
+      expect(guarded.overflowed()).toBe(true);
+      expect(guarded.cancelled()).toBe(true);
+    } finally {
+      aborted = true;
+      await new Promise<void>((resolve) => {
+        server.close(() => resolve());
+      });
+    }
   });
 });
 

--- a/extensions/ollama/src/stream.ts
+++ b/extensions/ollama/src/stream.ts
@@ -31,6 +31,7 @@ import {
 } from "openclaw/plugin-sdk/provider-stream-shared";
 import { createSubsystemLogger } from "openclaw/plugin-sdk/runtime-env";
 import { fetchWithSsrFGuard } from "openclaw/plugin-sdk/ssrf-runtime";
+import { createSseByteGuard } from "./sse-byte-guard.js";
 import {
   isRecord,
   normalizeLowercaseStringOrEmpty,
@@ -58,6 +59,7 @@ export const OLLAMA_INCOMPLETE_STREAM_ERROR = "Ollama API stream ended without a
 const OLLAMA_STREAM_COOPERATIVE_YIELD_INTERVAL_MS = 12;
 const OLLAMA_STREAM_COOPERATIVE_YIELD_MAX_EVENTS = 64;
 const OLLAMA_STREAM_ERROR_BODY_LIMIT_BYTES = 8 * 1024;
+const OLLAMA_NATIVE_STREAM_MAX_BYTES = 16 * 1024 * 1024;
 const GARBLED_VISIBLE_TEXT_MODEL_RE = /\b(?:glm|kimi)\b/i;
 const GARBLED_VISIBLE_TEXT_MIN_CHARS = 80;
 const GARBLED_VISIBLE_TEXT_SYMBOL_RE = /[$#%&="'_~`^|\\/*+\-[\]{}()<>:;,.!?]/gu;
@@ -1045,7 +1047,7 @@ export function buildAssistantMessage(
 }
 
 export async function* parseNdjsonStream(
-  reader: ReadableStreamDefaultReader<Uint8Array>,
+  reader: Pick<ReadableStreamDefaultReader<Uint8Array>, "read">,
 ): AsyncGenerator<OllamaChatResponse> {
   const decoder = new TextDecoder();
   let buffer = "";
@@ -1189,7 +1191,12 @@ function createRawOllamaStreamFn(
             throw new Error("Ollama API returned empty response body");
           }
 
-          const reader = response.body.getReader();
+          const rawReader = response.body.getReader();
+          const reader = createSseByteGuard(rawReader, {
+            maxBytes: OLLAMA_NATIVE_STREAM_MAX_BYTES,
+            onOverflow: ({ size, maxBytes }) =>
+              new Error(`Ollama streaming body exceeded ${maxBytes} bytes (received ${size})`),
+          });
           let accumulatedRawContent = "";
           let accumulatedVisibleContent = "";
           let accumulatedThinking = "";


### PR DESCRIPTION
## What Problem This Solves

Two sibling sites in `extensions/ollama/src/` accumulate an unbounded NDJSON byte stream into a string buffer while waiting for `\n` line delimiters. The companion **error-body** path was bounded at 8 KiB by an earlier PR; the symmetric **200 success-body** paths were left open. A hostile, buggy, or misconfigured Ollama-compatible endpoint can cause OpenClaw to grow the string buffer until the gateway OOMs.

**Site 1 (chat, /api/chat):** `extensions/ollama/src/stream.ts` (`parseNdjsonStream`) — used by every native Ollama chat / tool-call flow.

**Site 2 (model download, /api/pull):** `extensions/ollama/src/setup.ts` — used by `ensureOllamaModelPulled` for pulling Ollama model blobs.

## Why This Change Was Made

Both sites now wrap their `ReadableStreamDefaultReader` with a plugin-local `createSseByteGuard` that tracks accumulated bytes against a 16 MiB cap and cancels the reader on overflow. The helper (`extensions/ollama/src/sse-byte-guard.ts`) is a plugin-local seam; the canonical implementation lives in `packages/ai/src/utils/streaming-byte-guard.ts` and will be promoted to a Plugin SDK subpath in a future PR.

## User Impact

- Existing successful native Ollama chat / tool-call / model-pull flows keep working — the only new failure modes are `Ollama streaming body exceeded 16777216 bytes (received <size>)` (chat) and `Ollama pull body exceeded 16777216 bytes (received <size>)` (model download) when a streaming endpoint emits >16 MiB before newline-delimited framing.
- Self-hosted Ollama deployments with unusual proxies in front now have a deterministic OOM/DoS ceiling on both native NDJSON streaming paths.
- 0 user-visible behavior change for normal-sized responses. 0 config / migration / setup impact. No new Plugin SDK subpath.

## Evidence

### Real behavior proof

Three-runs of the inline `bounds real TCP-streamed NDJSON body without content-length` test (Layer 3 inline loopback):

| Run | cap | totalRead (returned) | bytesSent (server) | receivedBytes (error size) | overflowed | cancelled |
|---|---|---|---|---|---|---|
| 1 | 16,777,216 | 16,751,694 | 19,922,944 | 16,817,220 | true | true |
| 2 | 16,777,216 | 16,713,602 | 19,922,944 | 16,779,128 | true | true |
| 3 | 16,777,216 | 16,761,974 | 19,922,944 | 16,827,500 | true | true |

Invariant holds: `receivedBytes > cap > totalRead`, `bytesSent > totalRead`.

### Inline test coverage (4 tests across 2 test files)

- `stream-runtime.test.ts` (3 tests): deterministic overflow via 32 × 1 MiB pull stream; negative control with small valid NDJSON; real TCP loopback proof
- `setup.test.ts` (1 test): bounds oversized pull body and cancels the stream

### Typecheck & lint

Clean via `tsgo:core`.

### Risk checklist

- [x] No config, env, SDK, protocol, auth, or migration change.
- [x] No new Plugin SDK subpath (v2 change based on ClawSweeper feedback).
- [x] No behavior change for normal-sized responses; 16 MiB is 10× larger than any legitimate Ollama chat response and 160× larger than model-pull progress events.
- [x] Allow edits by maintainers.

## Closes / siblings

- Closes nothing (follow-up PR to promote helper to Plugin SDK when maintainers accept the subpath).
- Sibling bounded-read PRs: #96701, #96723, #96762, #96768, #97535, #97620, #97628, #96920, #96984, #96605