### PR TITLE
fix(shell-utils): escape control chars instead of deleting them\n\nFi…

### DIFF
--- a/scripts/proof-exec-sanitizer.ts
+++ b/scripts/proof-exec-sanitizer.ts
@@ -44,7 +44,7 @@ async function main() {
   console.log(`NUL escaped: ${aggregated.includes("\\x00")}`);
 }
 
-main().catch((err) => {
+main().catch((err: unknown) => {
   console.error(err);
   process.exit(1);
 });

--- a/scripts/proof-exec-sanitizer.ts
+++ b/scripts/proof-exec-sanitizer.ts
@@ -1,0 +1,50 @@
+import { resetProcessRegistryForTests } from "../src/agents/bash-process-registry.js";
+import { runExecProcess } from "../src/agents/bash-tools.exec-runtime.js";
+
+function currentEnv(): Record<string, string> {
+  return Object.fromEntries(
+    Object.entries(process.env).filter((entry): entry is [string, string] => entry[1] != null),
+  );
+}
+
+async function main() {
+  resetProcessRegistryForTests();
+
+  const command =
+    "node -e \"process.stdout.write('\\x1b[1;32mHello from OpenClaw exec\\x1b[0m\\x07\\x00\\n')\"";
+
+  const run = await runExecProcess({
+    command,
+    workdir: process.cwd(),
+    env: currentEnv(),
+    usePty: true,
+    warnings: [],
+    maxOutput: 20_000,
+    pendingMaxOutput: 20_000,
+    notifyOnExit: false,
+    timeoutSec: 5,
+  });
+
+  const outcome = await run.promise;
+
+  console.log("=== Command ===");
+  console.log(command);
+  console.log();
+  console.log("=== Exit status ===");
+  console.log(outcome.status);
+  console.log();
+  console.log("=== Aggregated output after sanitizeBinaryOutput ===");
+  console.log(outcome.aggregated);
+  console.log();
+  console.log("=== Checks ===");
+  const aggregated = outcome.aggregated;
+  console.log(`Contains readable text: ${aggregated.includes("Hello from OpenClaw exec")}`);
+  console.log(`ANSI ESC stripped: ${!aggregated.includes("\x1b")}`);
+  console.log(`BEL escaped: ${aggregated.includes("\\x07")}`);
+  console.log(`NUL escaped: ${aggregated.includes("\\x00")}`);
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/scripts/proof-sanitize-binary-output.ts
+++ b/scripts/proof-sanitize-binary-output.ts
@@ -1,0 +1,79 @@
+import { sanitizeBinaryOutput } from "../src/agents/shell-utils.js";
+
+// Reproduces the old sanitizer behavior for comparison: it drops every C0
+// control byte except tab, newline, and carriage return.
+function sanitizeBinaryOutputOld(text: string): string {
+  const scrubbed = text.replace(/[\p{Format}\p{Surrogate}]/gu, "");
+  if (!scrubbed) {
+    return scrubbed;
+  }
+  const chunks: string[] = [];
+  for (const char of scrubbed) {
+    const code = char.codePointAt(0);
+    if (code == null) {
+      continue;
+    }
+    if (code === 0x09 || code === 0x0a || code === 0x0d) {
+      chunks.push(char);
+      continue;
+    }
+    if (code < 0x20) {
+      continue;
+    }
+    chunks.push(char);
+  }
+  return chunks.join("");
+}
+
+// Simulated SSH banner / PTY output with ANSI color, cursor movement, window
+// title OSC, BEL, and a NUL byte. This is representative of the output that was
+// disappearing into an empty/image placeholder before the fix.
+const terminalOutput = [
+  "\x1b[0m\x1b[H\x1b[J", // reset / home / clear
+  "\x1b[1;32mWelcome to the server\x1b[0m\x07\n",
+  "\x1b]0;remote-host\x07", // window title OSC
+  "\x1b[33mWarning\x1b[0m: disk usage at 85%\x00\n",
+  "\x1b[?2004h", // bracketed paste enable
+  "\x1b[1m> \x1b[0m",
+].join("");
+
+function visible(input: string): string {
+  const esc = String.fromCharCode(0x1b);
+  const bel = String.fromCharCode(0x07);
+  const nul = String.fromCharCode(0x00);
+  return input
+    .split(esc)
+    .join("\\x1b")
+    .split(bel)
+    .join("\\x07")
+    .split(nul)
+    .join("\\x00")
+    .split("\n")
+    .join("\\n\n");
+}
+
+console.log("=== Raw terminal output (control bytes visible) ===");
+console.log(visible(terminalOutput));
+console.log();
+
+console.log("=== Old sanitizer (all C0 controls deleted) ===");
+const oldResult = sanitizeBinaryOutputOld(terminalOutput);
+console.log(`length=${oldResult.length}`);
+console.log(oldResult || "(empty string -> binary/MIME placeholder fallback)");
+console.log();
+
+console.log("=== New sanitizer (ANSI/OSC stripped, residual controls escaped) ===");
+const newResult = sanitizeBinaryOutput(terminalOutput);
+console.log(`length=${newResult.length}`);
+console.log(newResult);
+console.log();
+
+console.log("=== Verification ===");
+console.log(`Old result length: ${oldResult.length}`);
+console.log(`New result length: ${newResult.length}`);
+console.log(
+  `New result contains human-readable text: ${newResult.includes("Welcome to the server")}`,
+);
+console.log(`New result escapes NUL: ${newResult.includes("\\x00")}`);
+console.log(`New result escapes BEL: ${newResult.includes("\\x07")}`);
+console.log(`ANSI stripped: ${!newResult.includes("\x1b") && !newResult.includes("\\x1b[")}`);

--- a/src/agents/shell-utils.test.ts
+++ b/src/agents/shell-utils.test.ts
@@ -412,24 +412,39 @@ describe("sanitizeBinaryOutput", () => {
     expect(sanitizeBinaryOutput("a\u200Cb")).toBe("ab");
   });
 
-  it("escapes control characters to hex form instead of deleting them", () => {
-    // ESC (27) and BEL (7) should become visible escapes, not disappear.
-    const input = "SSH banner: \x1B[0m alert \x07";
+  it("strips ANSI/OSC escape sequences before escaping residual controls", () => {
+    // SGR color, cursor home, and a window-title OSC sequence should disappear,
+    // leaving only the printable text and escaped residual control bytes.
+    const input = "\x1B[1;32mWelcome\x1B[0m \x1B]0;title\x07\x1B[H\x07";
     const output = sanitizeBinaryOutput(input);
-    expect(output).toContain("\\x1b");
+    expect(output).toBe("Welcome \\x07");
+  });
+
+  it("escapes non-ANSI control characters to hex form instead of deleting them", () => {
+    // BEL (7) and BS (8) should become visible escapes, not disappear.
+    const input = "SSH banner: \x07 alert \x08";
+    const output = sanitizeBinaryOutput(input);
     expect(output).toContain("\\x07");
+    expect(output).toContain("\\x08");
     expect(output).toContain("SSH banner:");
     expect(output).toContain("alert");
-    expect(output).not.toContain("\x1B");
     expect(output).not.toContain("\x07");
+    expect(output).not.toContain("\x08");
   });
 
   it("keeps output non-empty when only control characters are present", () => {
     // Previously this would return an empty string, causing binary/MIME fallback.
-    expect(sanitizeBinaryOutput("\x1B\x07\x08")).toBe("\\x1b\\x07\\x08");
+    expect(sanitizeBinaryOutput("\x07\x08\x0B")).toBe("\\x07\\x08\\x0b");
   });
 
   it("escapes NUL bytes", () => {
     expect(sanitizeBinaryOutput("a\x00b")).toBe("a\\x00b");
+  });
+
+  it("escapes residual controls after stripping ANSI sequences", () => {
+    // ANSI SGR is stripped, but the raw BEL and NUL inside the text are escaped.
+    const input = "\x1B[31merror\x07\x00\x1B[0m";
+    const output = sanitizeBinaryOutput(input);
+    expect(output).toBe("error\\x07\\x00");
   });
 });

--- a/src/agents/shell-utils.test.ts
+++ b/src/agents/shell-utils.test.ts
@@ -12,6 +12,7 @@ import {
   resolveShellFromPath,
   resolveShellFromWhich,
   resolveWindowsBashPath,
+  sanitizeBinaryOutput,
 } from "./shell-utils.js";
 
 const isWin = process.platform === "win32";
@@ -394,5 +395,41 @@ describe("resolvePowerShellPath", () => {
     delete process.env.WINDIR;
 
     expect(resolvePowerShellPath()).toBe(ps51Path);
+  });
+});
+
+describe("sanitizeBinaryOutput", () => {
+  it("leaves printable text unchanged", () => {
+    expect(sanitizeBinaryOutput("hello world")).toBe("hello world");
+  });
+
+  it("preserves tab, newline, and carriage return", () => {
+    expect(sanitizeBinaryOutput("line1\tline2\nline3\rline4")).toBe("line1\tline2\nline3\rline4");
+  });
+
+  it("strips Format and Surrogate code points", () => {
+    // U+200C (ZERO WIDTH NON-JOINER) is a Format character.
+    expect(sanitizeBinaryOutput("a\u200Cb")).toBe("ab");
+  });
+
+  it("escapes control characters to hex form instead of deleting them", () => {
+    // ESC (27) and BEL (7) should become visible escapes, not disappear.
+    const input = "SSH banner: \x1B[0m alert \x07";
+    const output = sanitizeBinaryOutput(input);
+    expect(output).toContain("\\x1b");
+    expect(output).toContain("\\x07");
+    expect(output).toContain("SSH banner:");
+    expect(output).toContain("alert");
+    expect(output).not.toContain("\x1B");
+    expect(output).not.toContain("\x07");
+  });
+
+  it("keeps output non-empty when only control characters are present", () => {
+    // Previously this would return an empty string, causing binary/MIME fallback.
+    expect(sanitizeBinaryOutput("\x1B\x07\x08")).toBe("\\x1b\\x07\\x08");
+  });
+
+  it("escapes NUL bytes", () => {
+    expect(sanitizeBinaryOutput("a\x00b")).toBe("a\\x00b");
   });
 });

--- a/src/agents/shell-utils.ts
+++ b/src/agents/shell-utils.ts
@@ -11,6 +11,7 @@ import {
   type KillProcessTreeOptions,
 } from "../process/kill-tree.js";
 import { getBinDir } from "./config.js";
+import { stripAnsi } from "./utils/ansi.js";
 
 export interface ShellConfig {
   shell: string;
@@ -262,19 +263,6 @@ export function detectRuntimeShell(): string | undefined {
 }
 
 // Strip ANSI CSI (ESC [ ... final) and OSC (ESC ] ... ST) sequences from
-// terminal output. This is kept local to shell-utils to avoid making core
-// agent code depend on the UI-facing terminal-core package; the regex is kept
-// intentionally conservative (matching packages/terminal-core/src/ansi.ts) so
-// cursor/SGR/color/OSC-8 hyperlink sequences disappear before the remaining
-// C0 controls are escaped for the model-visible transcript.
-const ANSI_CSI_PATTERN = "\\x1b\\[[\\x20-\\x3f]*[\\x40-\\x7e]";
-const ANSI_OSC_PATTERN = "\\x1b\\][^\\x07\\x1b]*(?:\\x1b\\\\|\\x07)";
-const ANSI_SEQUENCE_REGEX = new RegExp(`${ANSI_OSC_PATTERN}|${ANSI_CSI_PATTERN}`, "g");
-
-function stripAnsi(input: string): string {
-  return input.replace(ANSI_SEQUENCE_REGEX, "");
-}
-
 export function sanitizeBinaryOutput(text: string): string {
   const scrubbed = text.replace(/[\p{Format}\p{Surrogate}]/gu, "");
   if (!scrubbed) {
@@ -284,6 +272,8 @@ export function sanitizeBinaryOutput(text: string): string {
   // literal \x1b[...] noise in the rendered transcript. The remaining C0
   // controls are still escaped so the user can see that terminal bytes were
   // present without raw bytes polluting output or triggering a MIME fallback.
+  // Uses the agent-shared stripAnsi helper so exec and session rendering paths
+  // share the same ANSI transcript contract.
   const stripped = stripAnsi(scrubbed);
   if (!stripped) {
     return stripped;

--- a/src/agents/shell-utils.ts
+++ b/src/agents/shell-utils.ts
@@ -11,7 +11,6 @@ import {
   type KillProcessTreeOptions,
 } from "../process/kill-tree.js";
 import { getBinDir } from "./config.js";
-import { stripAnsi } from "./utils/ansi.js";
 
 export interface ShellConfig {
   shell: string;
@@ -263,6 +262,19 @@ export function detectRuntimeShell(): string | undefined {
 }
 
 // Strip ANSI CSI (ESC [ ... final) and OSC (ESC ] ... ST) sequences from
+// Strip ANSI CSI (ESC [ ... final) and OSC (ESC ] ... ST) sequences from
+// terminal output. This is kept local to shell-utils to avoid adding a build-time
+// dependency on a non-entry utility module (src/agents/utils/ansi.ts) that the
+// root dist graph does not expose as a stable entry, while keeping the same
+// regex contract used by the session/bash executor paths.
+const ANSI_CSI_PATTERN = "\\x1b\\[[\\x20-\\x3f]*[\\x40-\\x7e]";
+const ANSI_OSC_PATTERN = "\\x1b\\][^\\x07\\x1b]*(?:\\x1b\\\\|\\x07)";
+const ANSI_SEQUENCE_REGEX = new RegExp(`${ANSI_OSC_PATTERN}|${ANSI_CSI_PATTERN}`, "g");
+
+function stripAnsi(input: string): string {
+  return input.replace(ANSI_SEQUENCE_REGEX, "");
+}
+
 export function sanitizeBinaryOutput(text: string): string {
   const scrubbed = text.replace(/[\p{Format}\p{Surrogate}]/gu, "");
   if (!scrubbed) {
@@ -272,8 +284,8 @@ export function sanitizeBinaryOutput(text: string): string {
   // literal \x1b[...] noise in the rendered transcript. The remaining C0
   // controls are still escaped so the user can see that terminal bytes were
   // present without raw bytes polluting output or triggering a MIME fallback.
-  // Uses the agent-shared stripAnsi helper so exec and session rendering paths
-  // share the same ANSI transcript contract.
+  // stripAnsi is kept local (see top of file) to avoid a build-time dependency
+  // on a non-entry utility module in the root dist graph.
   const stripped = stripAnsi(scrubbed);
   if (!stripped) {
     return stripped;

--- a/src/agents/shell-utils.ts
+++ b/src/agents/shell-utils.ts
@@ -261,13 +261,35 @@ export function detectRuntimeShell(): string | undefined {
   return undefined;
 }
 
+// Strip ANSI CSI (ESC [ ... final) and OSC (ESC ] ... ST) sequences from
+// terminal output. This is kept local to shell-utils to avoid making core
+// agent code depend on the UI-facing terminal-core package; the regex is kept
+// intentionally conservative (matching packages/terminal-core/src/ansi.ts) so
+// cursor/SGR/color/OSC-8 hyperlink sequences disappear before the remaining
+// C0 controls are escaped for the model-visible transcript.
+const ANSI_CSI_PATTERN = "\\x1b\\[[\\x20-\\x3f]*[\\x40-\\x7e]";
+const ANSI_OSC_PATTERN = "\\x1b\\][^\\x07\\x1b]*(?:\\x1b\\\\|\\x07)";
+const ANSI_SEQUENCE_REGEX = new RegExp(`${ANSI_OSC_PATTERN}|${ANSI_CSI_PATTERN}`, "g");
+
+function stripAnsi(input: string): string {
+  return input.replace(ANSI_SEQUENCE_REGEX, "");
+}
+
 export function sanitizeBinaryOutput(text: string): string {
   const scrubbed = text.replace(/[\p{Format}\p{Surrogate}]/gu, "");
   if (!scrubbed) {
     return scrubbed;
   }
+  // Strip ANSI/OSC sequences first so cursor/SGR/color codes do not become
+  // literal \x1b[...] noise in the rendered transcript. The remaining C0
+  // controls are still escaped so the user can see that terminal bytes were
+  // present without raw bytes polluting output or triggering a MIME fallback.
+  const stripped = stripAnsi(scrubbed);
+  if (!stripped) {
+    return stripped;
+  }
   const chunks: string[] = [];
-  for (const char of scrubbed) {
+  for (const char of stripped) {
     const code = char.codePointAt(0);
     if (code == null) {
       continue;
@@ -277,10 +299,6 @@ export function sanitizeBinaryOutput(text: string): string {
       continue;
     }
     if (code < 0x20) {
-      // Escape control characters to hex form instead of deleting them. This
-      // preserves context (e.g. SSH banners, ANSI escape sequences, terminal
-      // control codes) without letting raw binary bytes pollute the rendered
-      // output or trigger a binary/MIME fallback that renders as a placeholder.
       chunks.push(`\\x${code.toString(16).padStart(2, "0")}`);
       continue;
     }

--- a/src/agents/shell-utils.ts
+++ b/src/agents/shell-utils.ts
@@ -277,6 +277,11 @@ export function sanitizeBinaryOutput(text: string): string {
       continue;
     }
     if (code < 0x20) {
+      // Escape control characters to hex form instead of deleting them. This
+      // preserves context (e.g. SSH banners, ANSI escape sequences, terminal
+      // control codes) without letting raw binary bytes pollute the rendered
+      // output or trigger a binary/MIME fallback that renders as a placeholder.
+      chunks.push(`\\x${code.toString(16).padStart(2, "0")}`);
       continue;
     }
     chunks.push(char);

--- a/tsdown.config.ts
+++ b/tsdown.config.ts
@@ -260,6 +260,9 @@ function buildCoreDistEntries(): Record<string, string> {
     "agents/auth-profiles.runtime": "src/agents/auth-profiles.runtime.ts",
     "agents/model-catalog.runtime": "src/agents/model-catalog.runtime.ts",
     "agents/models-config.runtime": "src/agents/models-config.runtime.ts",
+    // Exposed as a stable shared entry so agents runtime paths (shell-utils, bash-executor,
+    // session rendering) can import one ANSI stripper instead of duplicating the regex.
+    "agents/utils/ansi": "src/agents/utils/ansi.ts",
     "agents/code-mode.worker": "src/agents/code-mode.worker.ts",
     "agents/compaction-planning.worker": "src/agents/compaction-planning.worker.ts",
     "agents/model-provider-auth.worker": "src/agents/model-provider-auth.worker.ts",

--- a/tsdown.config.ts
+++ b/tsdown.config.ts
@@ -260,9 +260,6 @@ function buildCoreDistEntries(): Record<string, string> {
     "agents/auth-profiles.runtime": "src/agents/auth-profiles.runtime.ts",
     "agents/model-catalog.runtime": "src/agents/model-catalog.runtime.ts",
     "agents/models-config.runtime": "src/agents/models-config.runtime.ts",
-    // Exposed as a stable shared entry so agents runtime paths (shell-utils, bash-executor,
-    // session rendering) can import one ANSI stripper instead of duplicating the regex.
-    "agents/utils/ansi": "src/agents/utils/ansi.ts",
     "agents/code-mode.worker": "src/agents/code-mode.worker.ts",
     "agents/compaction-planning.worker": "src/agents/compaction-planning.worker.ts",
     "agents/model-provider-auth.worker": "src/agents/model-provider-auth.worker.ts",


### PR DESCRIPTION
Fixes #99552

## What Problem This Solves

Fixes #99552. `sanitizeBinaryOutput()` strips every ASCII control character with code point < 32 (except tab, newline, and carriage return). When exec output contains terminal control sequences — e.g. SSH banners with ANSI color codes, cursor movement, `BEL` (7), `NUL` (0), or other control bytes — the remaining printable text can become so short that the renderer falls back to binary/MIME placeholder rendering, making the result appear blank or as an image placeholder.

## Why This Change Was Made

Instead of deleting control bytes outright, the sanitizer now strips ANSI/OSC sequences first, then escapes any remaining C0 controls to readable `\xHH` form. This preserves human-readable context while keeping terminal escape noise out of the model-visible transcript.

Specifically:

- ANSI CSI (e.g. `\x1b[1;32m...\x1b[0m`) and OSC sequences (e.g. `\x1b]0;title\x07`) are stripped before escaping.
- Residual C0 controls such as `BEL` (7), `NUL` (0), and backspace become `\x07`, `\x00`, etc.
- Tab, newline, and carriage return remain unchanged.
- Format and Surrogate code points are still stripped as before.

The ANSI stripping logic is kept local to `shell-utils.ts` to avoid adding a build-time dependency on `src/agents/utils/ansi.ts`, which is not exposed as a stable entry in the root dist graph and would cause the packaged build to fail with `ERR_MODULE_NOT_FOUND`. The regex matches the same conservative CSI/OSC patterns used by `src/agents/utils/ansi.ts` and `packages/terminal-core/src/ansi.ts`, so the sanitizer stays consistent with the rest of the codebase. The remaining C0 controls are then escaped so the user can see that terminal bytes were present without raw bytes polluting output or triggering a MIME fallback.

This is a conservative, backward-compatible change: printable output is unchanged, and terminal bytes are now either removed (ANSI) or made visible (residual C0) rather than silently deleted.

## User Impact

Exec results from SSH, `qm guest exec`, and other terminal-bearing commands will no longer disappear into blank/image placeholders just because they contained ANSI escape sequences or low ASCII control bytes. Users see the cleaned text and escaped residual bytes.

## Evidence

Unit tests (now includes ANSI/OSC stripping and residual control escaping):

```bash
$ pnpm test src/agents/shell-utils.test.ts

 RUN  v4.1.8 /media/vdc/study/op/openclaw

 ✓ |agents| src/agents/shell-utils.test.ts (31 tests) 118ms

 Test Files  1 passed (1)
      Tests  31 passed (31)
```

Key assertions:

- `strips ANSI/OSC escape sequences before escaping residual controls`
- `escapes non-ANSI control characters to hex form instead of deleting them`
- `keeps output non-empty when only control characters are present`
- `escapes NUL bytes`
- `escapes residual controls after stripping ANSI sequences`

Real behavior proof via the actual OpenClaw exec runtime (`scripts/proof-exec-sanitizer.ts`):

```bash
$ node --import tsx scripts/proof-exec-sanitizer.ts

=== Command ===
node -e "process.stdout.write('\x1b[1;32mHello from OpenClaw exec\x1b[0m\x07\x00\n')"

=== Exit status ===
completed

=== Aggregated output after sanitizeBinaryOutput ===
Hello from OpenClaw exec\x07\x00

=== Checks ===
Contains readable text: true
ANSI ESC stripped: true
BEL escaped: true
NUL escaped: true
```

This demonstrates the user-visible path: a PTY exec command that emits ANSI color + `BEL` + `NUL` is stored as plain text with residual controls escaped, not as a blank or image placeholder.

For comparison, the old sanitizer (before this PR) would have deleted the ESC/BEL/NUL bytes and left the ANSI payload fragments in the output; `scripts/proof-sanitize-binary-output.ts` shows that contrast on simulated SSH/PTY banner output.

Format / lint:

```bash
$ pnpm exec oxfmt --check --threads=1 \
    src/agents/shell-utils.ts \
    src/agents/shell-utils.test.ts \
    scripts/proof-exec-sanitizer.ts \
    scripts/proof-sanitize-binary-output.ts
All matched files use the correct format.

$ node scripts/run-oxlint.mjs --tsconfig tsconfig.json \
    src/agents/shell-utils.ts \
    src/agents/shell-utils.test.ts \
    scripts/proof-exec-sanitizer.ts \
    scripts/proof-sanitize-binary-output.ts
Found 0 warnings and 0 errors.

$ git diff --check
# no output
```
