### PR TITLE
chore: bump docs i18n x/net

### DIFF
--- a/scripts/docs-i18n/go.mod
+++ b/scripts/docs-i18n/go.mod
@@ -4,6 +4,6 @@ go 1.25.0
 
 require (
 	github.com/yuin/goldmark v1.8.2
-	golang.org/x/net v0.53.0
+	golang.org/x/net v0.55.0
 	gopkg.in/yaml.v3 v3.0.1
 )

--- a/scripts/docs-i18n/go.sum
+++ b/scripts/docs-i18n/go.sum
@@ -1,7 +1,7 @@
 github.com/yuin/goldmark v1.8.2 h1:kEGpgqJXdgbkhcOgBxkC0X0PmoPG1ZyoZ117rDVp4zE=
 github.com/yuin/goldmark v1.8.2/go.mod h1:ip/1k0VRfGynBgxOz0yCqHrbZXhcjxyuS66Brc7iBKg=
-golang.org/x/net v0.53.0 h1:d+qAbo5L0orcWAr0a9JweQpjXF19LMXJE8Ey7hwOdUA=
-golang.org/x/net v0.53.0/go.mod h1:JvMuJH7rrdiCfbeHoo3fCQU24Lf5JJwT9W3sJFulfgs=
+golang.org/x/net v0.55.0 h1:bcvxaJn3e1U6InsFWt1JUq1aSjnRxLzT2rtD2KfkDF8=
+golang.org/x/net v0.55.0/go.mod h1:L5U2KuzuOe1lY7Z+aWVIKK6qEeJXnXV9yzGA+WCHJww=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=


### PR DESCRIPTION
## What Problem This Solves

Keeps the docs i18n Go helper current with the `golang.org/x/net` version Dependabot requested for `scripts/docs-i18n`.

## Why This Change Was Made

Bumps `golang.org/x/net` in `scripts/docs-i18n` from `v0.53.0` to `v0.55.0`. The change is scoped to the standalone docs i18n Go module and does not touch OpenClaw runtime code.

## User Impact

No runtime user-facing behavior changes. Maintainers get a narrow dependency refresh for the docs i18n helper module.

AI-assisted: yes, created with Codex.

## Evidence

- `go test ./... -count=1` from `scripts/docs-i18n`
- `node scripts/run-vitest.mjs test/scripts/docs-i18n.test.ts`
- `git diff --check`
