### PR TITLE
fix(android): preserve numeric invoke error codes

### DIFF
--- a/apps/android/app/src/main/java/ai/openclaw/app/gateway/InvokeErrorParser.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/gateway/InvokeErrorParser.kt
@@ -1,5 +1,7 @@
 package ai.openclaw.app.gateway
 
+private val invokeErrorCodePattern = Regex("^[A-Z][A-Z0-9_]*$")
+
 data class ParsedInvokeError(
   val code: String,
   val message: String,
@@ -24,7 +26,7 @@ fun parseInvokeErrorMessage(raw: String): ParsedInvokeError {
   if (parts.size == 2) {
     val code = parts[0].trim()
     val rest = parts[1].trim()
-    if (code.isNotEmpty() && code.all { it.isUpperCase() || it.isDigit() || it == '_' }) {
+    if (invokeErrorCodePattern.matches(code)) {
       return ParsedInvokeError(
         code = code,
         message = rest.ifEmpty { trimmed },

--- a/apps/android/app/src/main/java/ai/openclaw/app/gateway/InvokeErrorParser.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/gateway/InvokeErrorParser.kt
@@ -24,7 +24,7 @@ fun parseInvokeErrorMessage(raw: String): ParsedInvokeError {
   if (parts.size == 2) {
     val code = parts[0].trim()
     val rest = parts[1].trim()
-    if (code.isNotEmpty() && code.all { it.isUpperCase() || it == '_' }) {
+    if (code.isNotEmpty() && code.all { it.isUpperCase() || it.isDigit() || it == '_' }) {
       return ParsedInvokeError(
         code = code,
         message = rest.ifEmpty { trimmed },

--- a/apps/android/app/src/test/java/ai/openclaw/app/gateway/InvokeErrorParserTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/gateway/InvokeErrorParserTest.kt
@@ -25,10 +25,18 @@ class InvokeErrorParserTest {
 
   @Test
   fun parseInvokeErrorMessage_rejectsNonCanonicalCodePrefix() {
-    val parsed = parseInvokeErrorMessage("IllegalStateException: boom")
-    assertEquals("UNAVAILABLE", parsed.code)
-    assertEquals("IllegalStateException: boom", parsed.message)
-    assertFalse(parsed.hadExplicitCode)
+    listOf(
+        "IllegalStateException: boom",
+        "2FAST: boom",
+        "_PRIVATE: boom",
+        "CAMERA-PERMISSION: boom",
+      )
+      .forEach { raw ->
+        val parsed = parseInvokeErrorMessage(raw)
+        assertEquals("UNAVAILABLE", parsed.code)
+        assertEquals(raw, parsed.message)
+        assertFalse(parsed.hadExplicitCode)
+      }
   }
 
   @Test

--- a/apps/android/app/src/test/java/ai/openclaw/app/gateway/InvokeErrorParserTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/gateway/InvokeErrorParserTest.kt
@@ -16,6 +16,14 @@ class InvokeErrorParserTest {
   }
 
   @Test
+  fun parseInvokeErrorMessage_parsesNumericCodePrefix() {
+    val parsed = parseInvokeErrorMessage("A2UI_HOST_UNAVAILABLE: bundled A2UI host not reachable")
+    assertEquals("A2UI_HOST_UNAVAILABLE", parsed.code)
+    assertEquals("bundled A2UI host not reachable", parsed.message)
+    assertTrue(parsed.hadExplicitCode)
+  }
+
+  @Test
   fun parseInvokeErrorMessage_rejectsNonCanonicalCodePrefix() {
     val parsed = parseInvokeErrorMessage("IllegalStateException: boom")
     assertEquals("UNAVAILABLE", parsed.code)


### PR DESCRIPTION
## What Problem This Solves

Android parses gateway invoke failures from `CODE: message` strings so the UI can preserve stable error codes. The parser only accepted uppercase letters and underscores, so valid Android/gateway codes containing digits, such as `A2UI_HOST_UNAVAILABLE`, were downgraded to `UNAVAILABLE` and shown/classified as generic failures.

## Why This Change Was Made

Gateway and Android node errors already use canonical uppercase codes that can include digits. This change keeps the existing strict parser shape but allows digits alongside uppercase letters and underscores.

## User Impact

Android users now see the specific A2UI/gateway error code instead of a generic unavailable error when the code contains a numeric component.

## Evidence

- `JAVA_HOME='F:\Program Files\Android\Android Studio\jbr' ANDROID_HOME='F:\Android\Sdk' ANDROID_SDK_ROOT='F:\Android\Sdk' GRADLE_OPTS='-Xmx1g -Dfile.encoding=UTF-8' ./gradlew.bat --no-daemon :app:testPlayDebugUnitTest --tests ai.openclaw.app.gateway.InvokeErrorParserTest --console=plain`
- `python .agents\skills\autoreview\scripts\autoreview --mode local` reported clean with no accepted/actionable findings.