### PR TITLE
fix(android): parse talk directive aliases case-insensitively

### DIFF
--- a/apps/android/app/src/main/java/ai/openclaw/app/voice/TalkDirectiveParser.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/voice/TalkDirectiveParser.kt
@@ -154,7 +154,7 @@ object TalkDirectiveParser {
     keys: List<String>,
   ): String? {
     for (key in keys) {
-      val value = obj[key].asStringOrNull()?.trim()
+      val value = obj.valueForKey(key).asStringOrNull()?.trim()
       if (!value.isNullOrEmpty()) return value
     }
     return null
@@ -165,7 +165,7 @@ object TalkDirectiveParser {
     keys: List<String>,
   ): Double? {
     for (key in keys) {
-      val value = obj[key].asDoubleOrNull()
+      val value = obj.valueForKey(key).asDoubleOrNull()
       if (value != null) return value
     }
     return null
@@ -176,7 +176,7 @@ object TalkDirectiveParser {
     keys: List<String>,
   ): Int? {
     for (key in keys) {
-      val value = obj[key].asIntOrNull()
+      val value = obj.valueForKey(key).asIntOrNull()
       if (value != null) return value
     }
     return null
@@ -187,7 +187,7 @@ object TalkDirectiveParser {
     keys: List<String>,
   ): Long? {
     for (key in keys) {
-      val value = obj[key].asLongOrNull()
+      val value = obj.valueForKey(key).asLongOrNull()
       if (value != null) return value
     }
     return null
@@ -198,11 +198,14 @@ object TalkDirectiveParser {
     keys: List<String>,
   ): Boolean? {
     for (key in keys) {
-      val value = obj[key].asBooleanOrNull()
+      val value = obj.valueForKey(key).asBooleanOrNull()
       if (value != null) return value
     }
     return null
   }
+
+  private fun JsonObject.valueForKey(key: String): JsonElement? =
+    this[key] ?: entries.firstOrNull { it.key.equals(key, ignoreCase = true) }?.value
 }
 
 private fun JsonElement?.asStringOrNull(): String? = (this as? JsonPrimitive)?.takeIf { it.isString }?.content

--- a/apps/android/app/src/test/java/ai/openclaw/app/voice/TalkDirectiveParserTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/voice/TalkDirectiveParserTest.kt
@@ -46,6 +46,20 @@ class TalkDirectiveParserTest {
   }
 
   @Test
+  fun parsesAliasKeysCaseInsensitively() {
+    val input =
+      """
+      {"Voice":"voice-abc","NoSpeakerBoost":true,"Language_Code":"en"}
+      Speak clearly.
+      """.trimIndent()
+    val result = TalkDirectiveParser.parse(input)
+    assertEquals("voice-abc", result.directive?.voiceId)
+    assertEquals(false, result.directive?.speakerBoost)
+    assertEquals("en", result.directive?.language)
+    assertEquals(emptyList<String>(), result.unknownKeys)
+  }
+
+  @Test
   fun returnsNullWhenNoDirectivePresent() {
     val input =
       """


### PR DESCRIPTION
## What Problem This Solves

Talk directive known-key detection already treated aliases case-insensitively, but typed value lookup remained exact-only. Mixed-case JSON such as `{"Voice":"...","NoSpeakerBoost":true}` was therefore reported as known while silently failing to apply the directive. Android and shared Apple implementations had the same mismatch.

## Why This Change Was Made

- Apply case-insensitive alias lookup to every typed directive accessor on Android and in shared OpenClawKit.
- Preserve deterministic alias order and exact-key precedence.
- Reject multiple non-exact keys that fold to the same alias instead of depending on Android/Swift map iteration order.
- Cover strings, booleans, integers, doubles, exact duplicates, and ambiguous duplicates on both platforms.

## User Impact

Generated or dictated Talk directive JSON can vary key casing without losing voice, language, speed, latency, or boolean overrides. Ambiguous duplicate casing fails closed consistently across native clients.

## Evidence

Exact head: `4210df90305cf0a2808f39b0d27bf3b29c5bee52`

- `ANDROID_HOME=$HOME/Library/Android/sdk ./gradlew :app:testPlayDebugUnitTest --tests ai.openclaw.app.voice.TalkDirectiveParserTest`
- `ANDROID_HOME=$HOME/Library/Android/sdk ./gradlew :app:assemblePlayDebug`
- `swift test --package-path apps/shared/OpenClawKit --filter TalkDirectiveTests`
- Fresh Codex autoreview after fixing its deterministic-collision finding: no actionable findings.
- Final Android candidate installed on an Android 16 emulator connected to an isolated real Gateway; a real Gateway-to-node `talk.ptt.cancel` roundtrip returned `status: idle`.

Known live-proof boundary: the isolated Gateway has no configured speech provider, so it could not synthesize a live assistant reply containing the directive. The complete typed parser behavior and collision contract are exercised on both native implementations; the real Gateway/node smoke verifies the candidate Talk runtime remains connected and callable.

No screenshot is attached because the parser change has no UI delta.
