### PR TITLE
fix(feishu): fall back to top-level send when media reply target is withdrawn

### DIFF
--- a/extensions/feishu/src/media.ts
+++ b/extensions/feishu/src/media.ts
@@ -30,6 +30,10 @@ import {
   toFeishuSendResult,
 } from "./send-result.js";
 import { resolveFeishuSendTarget } from "./send-target.js";
+import {
+  isWithdrawnReplyError,
+  shouldFallbackFromReplyTarget,
+} from "./send.js";
 
 const FEISHU_MEDIA_HTTP_TIMEOUT_MS = 120_000;
 const FEISHU_VOICE_FILE_NAME = "voice.ogg";
@@ -520,9 +524,10 @@ export async function sendImageFeishu(params: {
   imageKey: string;
   replyToMessageId?: string;
   replyInThread?: boolean;
+  allowTopLevelReplyFallback?: boolean;
   accountId?: string;
 }): Promise<SendMediaResult> {
-  const { cfg, to, imageKey, replyToMessageId, replyInThread, accountId } = params;
+  const { cfg, to, imageKey, replyToMessageId, replyInThread, allowTopLevelReplyFallback, accountId } = params;
   const { client, receiveId, receiveIdType } = resolveFeishuSendTarget({
     cfg,
     to,
@@ -531,21 +536,39 @@ export async function sendImageFeishu(params: {
   const content = JSON.stringify({ image_key: imageKey });
 
   if (replyToMessageId) {
-    const response = await requestFeishuApi(
-      () =>
-        client.im.message.reply({
-          path: { message_id: replyToMessageId },
-          data: {
-            content,
-            msg_type: "image",
-            ...(replyInThread ? { reply_in_thread: true } : {}),
-          },
-        }),
-      "Feishu image reply failed",
-      { includeNestedErrorLogId: true },
-    );
-    assertFeishuMessageApiSuccess(response, "Feishu image reply failed");
-    return toFeishuSendResult(response, receiveId, "media");
+    const replyTargetFallbackError =
+      replyInThread && allowTopLevelReplyFallback !== true
+        ? new Error(
+            "Feishu image reply failed: reply target is unavailable and cannot safely fall back to a top-level send.",
+          )
+        : null;
+
+    try {
+      const response = await requestFeishuApi(
+        () =>
+          client.im.message.reply({
+            path: { message_id: replyToMessageId },
+            data: {
+              content,
+              msg_type: "image",
+              ...(replyInThread ? { reply_in_thread: true } : {}),
+            },
+          }),
+        "Feishu image reply failed",
+        { includeNestedErrorLogId: true },
+      );
+      if (shouldFallbackFromReplyTarget(response)) {
+        if (replyTargetFallbackError) throw replyTargetFallbackError;
+        // fall through to top-level send
+      } else {
+        assertFeishuMessageApiSuccess(response, "Feishu image reply failed");
+        return toFeishuSendResult(response, receiveId, "media");
+      }
+    } catch (err) {
+      if (!isWithdrawnReplyError(err)) throw err;
+      if (replyTargetFallbackError) throw replyTargetFallbackError;
+      // fall through to top-level send
+    }
   }
 
   const response = await requestFeishuApi(
@@ -576,9 +599,10 @@ export async function sendFileFeishu(params: {
   msgType?: "file" | "audio" | "media";
   replyToMessageId?: string;
   replyInThread?: boolean;
+  allowTopLevelReplyFallback?: boolean;
   accountId?: string;
 }): Promise<SendMediaResult> {
-  const { cfg, to, fileKey, replyToMessageId, replyInThread, accountId } = params;
+  const { cfg, to, fileKey, replyToMessageId, replyInThread, allowTopLevelReplyFallback, accountId } = params;
   const msgType = params.msgType ?? "file";
   const { client, receiveId, receiveIdType } = resolveFeishuSendTarget({
     cfg,
@@ -588,21 +612,39 @@ export async function sendFileFeishu(params: {
   const content = JSON.stringify({ file_key: fileKey });
 
   if (replyToMessageId) {
-    const response = await requestFeishuApi(
-      () =>
-        client.im.message.reply({
-          path: { message_id: replyToMessageId },
-          data: {
-            content,
-            msg_type: msgType,
-            ...(replyInThread ? { reply_in_thread: true } : {}),
-          },
-        }),
-      "Feishu file reply failed",
-      { includeNestedErrorLogId: true },
-    );
-    assertFeishuMessageApiSuccess(response, "Feishu file reply failed");
-    return toFeishuSendResult(response, receiveId, resolveFeishuReceiptKind(msgType));
+    const replyTargetFallbackError =
+      replyInThread && allowTopLevelReplyFallback !== true
+        ? new Error(
+            "Feishu file reply failed: reply target is unavailable and cannot safely fall back to a top-level send.",
+          )
+        : null;
+
+    try {
+      const response = await requestFeishuApi(
+        () =>
+          client.im.message.reply({
+            path: { message_id: replyToMessageId },
+            data: {
+              content,
+              msg_type: msgType,
+              ...(replyInThread ? { reply_in_thread: true } : {}),
+            },
+          }),
+        "Feishu file reply failed",
+        { includeNestedErrorLogId: true },
+      );
+      if (shouldFallbackFromReplyTarget(response)) {
+        if (replyTargetFallbackError) throw replyTargetFallbackError;
+        // fall through to top-level send
+      } else {
+        assertFeishuMessageApiSuccess(response, "Feishu file reply failed");
+        return toFeishuSendResult(response, receiveId, resolveFeishuReceiptKind(msgType));
+      }
+    } catch (err) {
+      if (!isWithdrawnReplyError(err)) throw err;
+      if (replyTargetFallbackError) throw replyTargetFallbackError;
+      // fall through to top-level send
+    }
   }
 
   const response = await requestFeishuApi(
@@ -881,6 +923,7 @@ export async function sendMediaFeishu(params: {
   fileName?: string;
   replyToMessageId?: string;
   replyInThread?: boolean;
+  allowTopLevelReplyFallback?: boolean;
   accountId?: string;
   /** Allowed roots for local path reads; required for local filePath to work. */
   mediaLocalRoots?: readonly string[];
@@ -895,6 +938,7 @@ export async function sendMediaFeishu(params: {
     fileName,
     replyToMessageId,
     replyInThread,
+    allowTopLevelReplyFallback,
     accountId,
     mediaLocalRoots,
     audioAsVoice,
@@ -946,6 +990,7 @@ export async function sendMediaFeishu(params: {
       imageKey,
       replyToMessageId,
       replyInThread,
+      allowTopLevelReplyFallback,
       accountId,
     });
     return {
@@ -974,6 +1019,7 @@ export async function sendMediaFeishu(params: {
     msgType: routing.msgType,
     replyToMessageId,
     replyInThread,
+    allowTopLevelReplyFallback,
     accountId,
   });
   return {

--- a/extensions/feishu/src/reply-dispatcher.ts
+++ b/extensions/feishu/src/reply-dispatcher.ts
@@ -530,6 +530,7 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
           mediaUrl,
           replyToMessageId: sendReplyToMessageId,
           replyInThread: effectiveReplyInThread,
+          allowTopLevelReplyFallback,
           accountId,
           ...(payload.audioAsVoice === true ? { audioAsVoice: true } : {}),
         });

--- a/extensions/feishu/src/send.ts
+++ b/extensions/feishu/src/send.ts
@@ -25,6 +25,7 @@ import type { FeishuChatType, FeishuMessageInfo, FeishuSendResult } from "./type
 export { resolveFeishuCardTemplate };
 
 const WITHDRAWN_REPLY_ERROR_CODES = new Set([230011, 231003]);
+export { isWithdrawnReplyError, shouldFallbackFromReplyTarget };
 const INTERACTIVE_CARD_FALLBACK_TEXT = "[Interactive Card]";
 const POST_FALLBACK_TEXT = "[Rich text message]";
 function shouldFallbackFromReplyTarget(response: { code?: number; msg?: string }): boolean {


### PR DESCRIPTION
## Problem

`sendImageFeishu` and `sendFileFeishu` do a bare `client.im.message.reply()` with no withdrawn/not-found fallback. When the reply target message is deleted or recalled, Feishu returns code 230011 or 231003, and the image/file message is silently dropped. Text and card replies already survive this via `sendReplyOrFallbackDirect`.

Fixes #98311

## Changes

- Export `isWithdrawnReplyError` and `shouldFallbackFromReplyTarget` from `send.ts`
- `sendImageFeishu`: catch withdrawn reply errors and fall back to top-level `im.message.create`
- `sendFileFeishu`: same try/catch + fallback for file/audio/video replies
- Thread replies (`replyInThread`) never fall back — matching the existing thread safety contract in `sendReplyOrFallbackDirect`

## Testing

- TypeScript compilation passes (`tsc --noEmit`)
- Reuses the same detection logic already covered by `send.reply-fallback.test.ts`