### PR TITLE
fix(mcp): demote conflicting loopback schema warnings from logWarn to logDebug

### DIFF
--- a/src/gateway/mcp-http.schema.ts
+++ b/src/gateway/mcp-http.schema.ts
@@ -2,7 +2,7 @@
 // Converts gateway-scoped tools into MCP tools/list-compatible schemas.
 import { isRecord } from "@openclaw/normalization-core/record-coerce";
 import { uniqueValues } from "@openclaw/normalization-core/string-normalization";
-import { logWarn } from "../logger.js";
+import { logDebug, logWarn } from "../logger.js";
 import { resolveGatewayScopedTools } from "./tool-resolution.js";
 
 // MCP loopback schema projection adapts gateway tool definitions into MCP
@@ -100,7 +100,7 @@ function flattenUnionSchema(raw: Record<string, unknown>): Record<string, unknow
         }
         if (!isRecord(existing) || !isRecord(incoming)) {
           if (existing !== incoming) {
-            logWarn(
+            logDebug(
               `mcp loopback: conflicting schema definitions for "${key}", keeping the first variant`,
             );
           }
@@ -122,7 +122,7 @@ function flattenUnionSchema(raw: Record<string, unknown>): Record<string, unknow
           mergedProps[key] = merged;
           continue;
         }
-        logWarn(
+        logDebug(
           `mcp loopback: conflicting schema definitions for "${key}", keeping the first variant`,
         );
       }


### PR DESCRIPTION
## Problem

The MCP loopback bundle emits thousands of `conflicting schema definitions` warnings per day (4,384 in 10 hours on a single main-session). These fire every time a CLI session or subagent bundle initializes, because different internal MCP servers (message, sessions, cron, gateway, web_fetch, etc.) legitimately define the same field names (`callId`, `action`, `message`, `sessionKey`, etc.) for their own tools.

The collision is expected and `keeping the first variant` is the correct runtime behavior — but the `logWarn` level floods production logs with noise.

Fixes #98437

## Changes

- `flattenUnionSchema`: demote two `logWarn` calls ("conflicting schema definitions for X, keeping the first variant") to `logDebug`
- The `logWarn` for genuinely malformed schema definitions is preserved
- Import `logDebug` alongside existing `logWarn`

## Testing

- TypeScript compilation passes (`tsc --noEmit`)
- No functional change — only log level adjustment