### PR TITLE
improve(status): show why plugins are disabled in /status plugins

### DIFF
--- a/src/status/status-plugin-health.test.ts
+++ b/src/status/status-plugin-health.test.ts
@@ -243,12 +243,75 @@ describe("plugin health status formatting", () => {
     );
     expect(text).toContain("Loaded: 1 (ok-plugin)");
     expect(text).toContain("Disabled: 1");
+    expect(text).toContain("- disabled: 1 (disabled-plugin)");
     expect(text).toContain("- bad-plugin [load]: module failed");
     expect(text).toContain("- bad_tool owner=plugin:bad-tools: unsupported anyOf");
     expect(text).toContain("- sms plugin=sms-plugin [setup]: setup failed");
     expect(text).toContain("Diagnostics: 0 errors · 1 warnings");
     expect(text).toContain("- WARN legacy-plugin [hook-only]: uses a compatibility shim");
     expect(text).toContain("Full inventory: /plugins list");
+  });
+
+  it("groups disabled plugins by their recorded disable reason", () => {
+    const text = formatDetailedPluginHealth({
+      plugins: [
+        { id: "zeta", status: "disabled", enabled: false, error: "not in allowlist" },
+        {
+          id: "alpha",
+          status: "disabled",
+          enabled: false,
+          error: "overridden by better-alpha plugin",
+        },
+        { id: "beta", status: "disabled", enabled: false, error: "not in allowlist" },
+        // No recorded reason (hand-built snapshot): falls back to a plain "disabled".
+        { id: "mid", status: "disabled", enabled: false },
+      ],
+      diagnostics: [],
+      contextEngineQuarantines: [],
+    });
+
+    const lines = text.split("\n");
+    const disabledAt = lines.indexOf("Disabled: 4");
+    expect(disabledAt).toBeGreaterThan(-1);
+    // One line per distinct reason, right under the count, in deterministic
+    // reason order with alphabetical plugin ids.
+    expect(lines.slice(disabledAt + 1, disabledAt + 4)).toEqual([
+      "- disabled: 1 (mid)",
+      "- not in allowlist: 2 (beta, zeta)",
+      "- overridden by better-alpha plugin: 1 (alpha)",
+    ]);
+  });
+
+  it("caps disabled reason lines and per-reason id lists", () => {
+    const distinctReasons = formatDetailedPluginHealth({
+      plugins: Array.from({ length: 9 }, (_, index) => ({
+        id: `plugin-${index}`,
+        status: "disabled" as const,
+        enabled: false,
+        error: `reason ${index}`,
+      })),
+      diagnostics: [],
+      contextEngineQuarantines: [],
+    });
+    expect(distinctReasons).toContain("Disabled: 9");
+    expect(distinctReasons).toContain("- reason 7: 1 (plugin-7)");
+    expect(distinctReasons).not.toContain("reason 8");
+    expect(distinctReasons).toContain("- +1 more reasons");
+
+    const sharedReason = formatDetailedPluginHealth({
+      plugins: Array.from({ length: 10 }, (_, index) => ({
+        id: `plugin-${index}`,
+        status: "disabled" as const,
+        enabled: false,
+        error: "not in allowlist",
+      })),
+      diagnostics: [],
+      contextEngineQuarantines: [],
+    });
+    expect(sharedReason).toContain("Disabled: 10");
+    expect(sharedReason).toContain(
+      "- not in allowlist: 10 (plugin-0, plugin-1, plugin-2, plugin-3, plugin-4, plugin-5, plugin-6, plugin-7, +2 more)",
+    );
   });
 
   it("separates runtime-loaded plugins from installed-but-not-active inventory", () => {

--- a/src/status/status-plugin-health.ts
+++ b/src/status/status-plugin-health.ts
@@ -295,7 +295,9 @@ export function formatDetailedPluginHealth(snapshot: StatusPluginHealthSnapshot)
         .filter((id) => !shouldRunNotLoadedSet.has(id))
         .toSorted(byLocale)
     : [];
-  const disabled = snapshot.plugins.filter((plugin) => plugin.status === "disabled").length;
+  const disabledPlugins = snapshot.plugins
+    .filter((plugin) => plugin.status === "disabled")
+    .toSorted((left, right) => byLocale(left.id, right.id));
   const errors = snapshot.plugins
     .filter((plugin) => plugin.status === "error")
     .toSorted((left, right) => byLocale(left.id, right.id));
@@ -325,8 +327,38 @@ export function formatDetailedPluginHealth(snapshot: StatusPluginHealthSnapshot)
   const lines = [
     formatCompactPluginHealthLine(snapshot),
     `Loaded: ${loaded.length}${loaded.length > 0 ? ` (${formatPluginList(loaded, 8)})` : ""}`,
-    `Disabled: ${disabled}`,
+    `Disabled: ${disabledPlugins.length}`,
   ];
+
+  if (disabledPlugins.length > 0) {
+    // Disable decisions record their reason on `error` (config off, allow/denylist,
+    // overridden-by/memory-slot arbitration). Group ids per distinct reason so the
+    // detailed view answers "why is this plugin off" without a /plugins round-trip,
+    // and a restrictive allowlist folds into one bounded line instead of dozens.
+    const disabledByReason = new Map<string, string[]>();
+    for (const plugin of disabledPlugins) {
+      const reason = plugin.error ?? "disabled";
+      const ids = disabledByReason.get(reason);
+      if (ids) {
+        ids.push(plugin.id);
+      } else {
+        disabledByReason.set(reason, [plugin.id]);
+      }
+    }
+    const reasonEntries = [...disabledByReason.entries()].toSorted((left, right) =>
+      byLocale(left[0], right[0]),
+    );
+    lines.push(
+      ...reasonEntries
+        .slice(0, 8)
+        .map(([reason, ids]) => `- ${reason}: ${ids.length} (${formatPluginList(ids, 8)})`),
+    );
+    if (reasonEntries.length > 8) {
+      // Unlike the per-plugin buckets, the count above tallies plugins, not
+      // reasons, so a reader cannot infer that reason lines were truncated.
+      lines.push(`- +${reasonEntries.length - 8} more reasons`);
+    }
+  }
 
   if (installedNotActive.length > 0) {
     // Installed/discovered plugins not loaded in the runtime registry. Neutral


### PR DESCRIPTION
**Prompt request:** Make `/status plugins` explain why plugins are disabled, grouped by reason, while keeping the compact summary line unchanged.

## What Problem This Solves

`/status plugins` reports how many plugins are disabled but never says why. Every other bucket in the detailed plugin health view (Errors, Dependency issues, quarantines, channel plugin failures, compatibility notices) lists per-item reasons; `Disabled:` is the only bare count. An operator asking "why is my plugin not running?" has to leave the chat surface and dig through `/plugins list` or logs, even though the loader records a reason for its disable decisions.

## Why This Change Was Made

Disable reasons already reach the renderer (`error` on `PluginHealthRecord`; production loader disable decisions carry the reason there, and the formatter falls back to a plain `disabled` for records without one). This change renders them: the detailed view groups disabled plugins by their recorded reason and prints one line per distinct reason, reusing the existing `formatPluginList` truncation helper (8 ids per reason, 8 reason lines, and an explicit `+N more reasons` marker when reasons themselves are truncated). Grouping by reason keeps the output bounded on restrictive-allowlist configs, where a bare `plugins.allow` disables the entire bundled catalog — that folds into a few lines instead of dozens of identical per-plugin ones. The compact one-line summary (`🔌 Plugins: ...`) is unchanged: disabled plugins are steady state, not a problem chip.

## User Impact

Operators can now see in `/status plugins` why disabled plugins are off, grouped and bounded by reason — e.g. `not in allowlist`, `blocked by denylist`, `bundled (disabled by default)`, `overridden by <other> plugin` — instead of a bare `Disabled: N` count. Display-only: no configuration or activation behavior changes.

## Evidence

Real production path (`openclaw.json` → `loadConfig()` → `buildStatusPluginsReply()` → `formatDetailedPluginHealth()`), isolated `OPENCLAW_STATE_DIR`, no mocks, config `{"commands": {"plugins": true}, "plugins": {"allow": ["telegram", "discord"], "deny": ["discord"]}}`:

Before (base `48e8965b10`):

```
🔌 Plugins: OK
Loaded: 0
Disabled: 134
Installed (not active): 1 (memory-core)
Full inventory: /plugins list
```

After (head `334b3fa78f`):

```
🔌 Plugins: OK
Loaded: 0
Disabled: 134
- blocked by denylist: 1 (discord)
- bundled (disabled by default): 1 (telegram)
- not in allowlist: 132 (acpx, active-memory, admin-http-rpc, alibaba, amazon-bedrock, amazon-bedrock-mantle, anthropic, anthropic-vertex, +124 more)
Installed (not active): 1 (memory-core)
Full inventory: /plugins list
```

Focused tests: all 20 tests in `src/status/status-plugin-health.test.ts` pass — adds reason-grouping, deterministic ordering, missing-reason fallback, per-reason id truncation, and the `+N more reasons` marker; existing merge and drift assertions unchanged.

Local validation before submission: `node scripts/check-changed.mjs --base upstream/main` (changed lanes: green) and `codex review --base upstream/main` (no actionable findings; local convention is to review against the upstream base).
