### PR TITLE
fix: outbound recovery can replay already sent replies

### DIFF
--- a/extensions/discord/src/outbound-adapter.test.ts
+++ b/extensions/discord/src/outbound-adapter.test.ts
@@ -309,6 +309,16 @@ describe("discordOutbound", () => {
   });
 
   it("routes audioAsVoice payloads through the Discord voice send helper", async () => {
+    const onDeliveryResult = vi.fn();
+    hoisted.sendMessageDiscordMock.mockImplementation(
+      async (_to: unknown, _text: unknown, options: unknown) => {
+        const deliveryResult = { messageId: "msg-1", channelId: "ch-1" };
+        const onProgress = (options as { onDeliveryResult?: (result: unknown) => Promise<void> })
+          .onDeliveryResult;
+        await onProgress?.(deliveryResult);
+        return deliveryResult;
+      },
+    );
     const result = await discordOutbound.sendPayload?.({
       cfg: {},
       to: "channel:123456",
@@ -321,6 +331,7 @@ describe("discordOutbound", () => {
       accountId: "default",
       replyToId: "reply-1",
       replyToMode: "first",
+      onDeliveryResult,
     });
 
     const voiceCall = mockCall(hoisted.sendVoiceMessageDiscordMock, "sendVoiceMessageDiscord");
@@ -359,6 +370,11 @@ describe("discordOutbound", () => {
       messageId: "msg-1",
       channelId: "ch-1",
     });
+    expect(onDeliveryResult.mock.calls.map((call) => call[0]?.messageId)).toEqual([
+      "voice-1",
+      "msg-1",
+      "msg-1",
+    ]);
   });
 
   it("keeps captured replyTo on audioAsVoice sends when replyToMode is batched", async () => {

--- a/extensions/discord/src/outbound-adapter.ts
+++ b/extensions/discord/src/outbound-adapter.ts
@@ -2,6 +2,7 @@
 import type { OutboundIdentity } from "openclaw/plugin-sdk/channel-outbound";
 import { resolveOutboundSendDep } from "openclaw/plugin-sdk/channel-outbound";
 import {
+  attachChannelToResult,
   type ChannelOutboundAdapter,
   createAttachedChannelResultAdapter,
 } from "openclaw/plugin-sdk/channel-send-result";
@@ -174,6 +175,7 @@ export const discordOutbound: ChannelOutboundAdapter = {
       identity,
       silent,
       formatting,
+      onDeliveryResult,
     }) => {
       if (!silent) {
         const webhookResult = await maybeSendDiscordWebhookText({
@@ -202,6 +204,11 @@ export const discordOutbound: ChannelOutboundAdapter = {
             silent: silent ?? undefined,
             cfg,
             ...resolveDiscordFormattingOptions({ formatting }),
+            onDeliveryResult: onDeliveryResult
+              ? async (result) => {
+                  await onDeliveryResult(attachChannelToResult("discord", result));
+                }
+              : undefined,
           }),
       });
     },
@@ -220,6 +227,7 @@ export const discordOutbound: ChannelOutboundAdapter = {
       threadId,
       silent,
       formatting,
+      onDeliveryResult,
     }) => {
       const send =
         resolveOutboundSendDep<DiscordSendFn>(deps, "discord") ??
@@ -254,6 +262,11 @@ export const discordOutbound: ChannelOutboundAdapter = {
               silent: silent ?? undefined,
               cfg,
               ...formattingOptions,
+              onDeliveryResult: onDeliveryResult
+                ? async (result) => {
+                    await onDeliveryResult(attachChannelToResult("discord", result));
+                  }
+                : undefined,
             }),
         });
         return await withDiscordDeliveryRetry({
@@ -270,6 +283,11 @@ export const discordOutbound: ChannelOutboundAdapter = {
               silent: silent ?? undefined,
               cfg,
               ...formattingOptions,
+              onDeliveryResult: onDeliveryResult
+                ? async (result) => {
+                    await onDeliveryResult(attachChannelToResult("discord", result));
+                  }
+                : undefined,
             }),
         });
       }
@@ -288,6 +306,11 @@ export const discordOutbound: ChannelOutboundAdapter = {
             silent: silent ?? undefined,
             cfg,
             ...formattingOptions,
+            onDeliveryResult: onDeliveryResult
+              ? async (result) => {
+                  await onDeliveryResult(attachChannelToResult("discord", result));
+                }
+              : undefined,
           }),
       });
     },

--- a/extensions/discord/src/outbound-payload.ts
+++ b/extensions/discord/src/outbound-payload.ts
@@ -23,6 +23,14 @@ type DiscordOutboundPayloadContext = Parameters<
 >[0];
 type DiscordPayloadSendContext = Awaited<ReturnType<typeof createDiscordPayloadSendContext>>;
 
+function resolveDiscordDeliveryProgress(ctx: DiscordOutboundPayloadContext) {
+  return ctx.onDeliveryResult
+    ? async (result: Awaited<ReturnType<DiscordPayloadSendContext["send"]>>) => {
+        await ctx.onDeliveryResult?.(attachChannelToResult("discord", result));
+      }
+    : undefined;
+}
+
 function createDiscordUnknownPayloadResult(target: string) {
   return {
     messageId: "",
@@ -94,6 +102,7 @@ export async function sendDiscordOutboundPayload(params: {
           replyTo: voiceReplyTo,
         }),
     );
+    await ctx.onDeliveryResult?.(attachChannelToResult("discord", lastResult));
     if (payload.text?.trim()) {
       lastResult = await sendContext.withRetry(
         async () =>
@@ -101,6 +110,7 @@ export async function sendDiscordOutboundPayload(params: {
             verbose: false,
             ...resolveDiscordFormattedDeliveryOptions(ctx, sendContext),
             replyTo: voiceReplyTo,
+            onDeliveryResult: resolveDiscordDeliveryProgress(ctx),
           }),
       );
     }
@@ -111,6 +121,7 @@ export async function sendDiscordOutboundPayload(params: {
             verbose: false,
             ...resolveDiscordMediaDeliveryOptions(ctx, sendContext, mediaUrl),
             replyTo: voiceReplyTo,
+            onDeliveryResult: resolveDiscordDeliveryProgress(ctx),
           }),
       );
     }
@@ -146,6 +157,7 @@ export async function sendDiscordOutboundPayload(params: {
                 embeds,
                 filename,
                 ...resolveDiscordFormattedDeliveryOptions(ctx, sendContext),
+                onDeliveryResult: resolveDiscordDeliveryProgress(ctx),
               }),
           ),
         send: async ({ text, mediaUrl, isFirst }) =>
@@ -157,6 +169,7 @@ export async function sendDiscordOutboundPayload(params: {
                 components: isFirst ? nativeComponents : undefined,
                 embeds: isFirst ? embeds : undefined,
                 filename: isFirst ? filename : undefined,
+                onDeliveryResult: resolveDiscordDeliveryProgress(ctx),
               }),
           ),
       });
@@ -176,19 +189,22 @@ export async function sendDiscordOutboundPayload(params: {
     text: payload.text ?? "",
     mediaUrls,
     fallbackResult: createDiscordUnknownPayloadResult(sendContext.target),
-    sendNoMedia: async () =>
-      await sendContext.withRetry(
+    sendNoMedia: async () => {
+      return await sendContext.withRetry(
         async () =>
           await sendDiscordComponentMessageLazy(sendContext.target, componentSpec, {
             ...resolveDiscordFormattedDeliveryOptions(ctx, sendContext),
+            onDeliveryResult: resolveDiscordDeliveryProgress(ctx),
           }),
-      ),
+      );
+    },
     send: async ({ text, mediaUrl, isFirst }) => {
       if (isFirst) {
         return await sendContext.withRetry(
           async () =>
             await sendDiscordComponentMessageLazy(sendContext.target, componentSpec, {
               ...resolveDiscordMediaDeliveryOptions(ctx, sendContext, mediaUrl),
+              onDeliveryResult: resolveDiscordDeliveryProgress(ctx),
             }),
         );
       }
@@ -197,6 +213,7 @@ export async function sendDiscordOutboundPayload(params: {
           await sendContext.send(sendContext.target, text, {
             verbose: false,
             ...resolveDiscordMediaDeliveryOptions(ctx, sendContext, mediaUrl),
+            onDeliveryResult: resolveDiscordDeliveryProgress(ctx),
           }),
       );
     },

--- a/extensions/discord/src/send.components.test.ts
+++ b/extensions/discord/src/send.components.test.ts
@@ -130,6 +130,27 @@ describe("sendDiscordComponentMessage", () => {
     );
   });
 
+  it("reports the platform send before component registry bookkeeping", async () => {
+    const { rest, postMock, getMock } = makeDiscordRest();
+    getMock.mockResolvedValueOnce({ type: ChannelType.GuildText, id: "chan-1" });
+    postMock.mockResolvedValueOnce({ id: "msg-progress", channel_id: "chan-1" });
+    registerMock.mockImplementationOnce(() => {
+      throw new Error("registry write failed");
+    });
+    const onDeliveryResult = vi.fn();
+
+    await expect(
+      sendDiscordComponentMessage(
+        "channel:chan-1",
+        { blocks: [{ type: "actions", buttons: [{ label: "Tap" }] }] },
+        { cfg: DISCORD_TEST_CFG, rest, token: "t", onDeliveryResult },
+      ),
+    ).rejects.toThrow("registry write failed");
+
+    expect(onDeliveryResult).toHaveBeenCalledOnce();
+    expect(onDeliveryResult.mock.calls[0]?.[0]?.messageId).toBe("msg-progress");
+  });
+
   it("edits component messages and refreshes component registry entries", async () => {
     const { rest, patchMock, getMock } = makeDiscordRest();
     getMock.mockResolvedValueOnce({
@@ -263,6 +284,7 @@ describe("sendDiscordComponentMessage classic message downgrade", () => {
   it("forwards mediaReadFile and mediaAccess to sendMessageDiscord", async () => {
     const readFileMock = vi.fn().mockResolvedValue(Buffer.from("pdf"));
     const mediaAccess = { localRoots: ["/tmp"], readFile: readFileMock };
+    const onDeliveryResult = vi.fn();
 
     await sendDiscordComponentMessage(
       "channel:chan-1",
@@ -273,6 +295,7 @@ describe("sendDiscordComponentMessage classic message downgrade", () => {
         mediaUrl: "https://example.com/report.pdf",
         mediaReadFile: readFileMock,
         mediaAccess,
+        onDeliveryResult,
       },
     );
 
@@ -296,6 +319,7 @@ describe("sendDiscordComponentMessage classic message downgrade", () => {
         maxLinesPerMessage: undefined,
         tableMode: undefined,
         chunkMode: undefined,
+        onDeliveryResult,
       },
     ]);
   });

--- a/extensions/discord/src/send.components.ts
+++ b/extensions/discord/src/send.components.ts
@@ -167,6 +167,8 @@ type DiscordComponentSendOpts = {
   tableMode?: MarkdownTableMode;
   chunkMode?: ChunkMode;
   suppressEmbeds?: boolean;
+  /** Persist the concrete platform send before component bookkeeping can fail. */
+  onDeliveryResult?: (result: DiscordSendResult) => Promise<void> | void;
 };
 
 export function registerBuiltDiscordComponentMessage(params: {
@@ -285,6 +287,7 @@ export async function sendDiscordComponentMessage(
       maxLinesPerMessage: opts.maxLinesPerMessage,
       tableMode: opts.tableMode,
       chunkMode: opts.chunkMode,
+      onDeliveryResult: opts.onDeliveryResult,
       ...(opts.suppressEmbeds === undefined ? {} : { suppressEmbeds: opts.suppressEmbeds }),
     });
   }
@@ -326,6 +329,14 @@ export async function sendDiscordComponentMessage(
     });
   }
 
+  const deliveryResult = createDiscordSendResult({
+    result,
+    fallbackChannelId: channelId,
+    kind: "card",
+    ...(opts.replyTo ? { replyToId: opts.replyTo } : {}),
+  });
+  await opts.onDeliveryResult?.(deliveryResult);
+
   registerBuiltDiscordComponentMessage({
     buildResult,
     messageId: result.id,
@@ -338,12 +349,7 @@ export async function sendDiscordComponentMessage(
     direction: "outbound",
   });
 
-  return createDiscordSendResult({
-    result,
-    fallbackChannelId: channelId,
-    kind: "card",
-    ...(opts.replyTo ? { replyToId: opts.replyTo } : {}),
-  });
+  return deliveryResult;
 }
 
 export async function editDiscordComponentMessage(

--- a/extensions/discord/src/send.outbound.ts
+++ b/extensions/discord/src/send.outbound.ts
@@ -29,6 +29,7 @@ import {
   resolveDiscordSendEmbeds,
   sendDiscordMedia,
   sendDiscordText,
+  type DiscordSendProgress,
   type DiscordSendComponents,
   type DiscordSendEmbeds,
 } from "./send.shared.js";
@@ -54,6 +55,8 @@ type DiscordSendOpts = {
   embeds?: DiscordSendEmbeds;
   silent?: boolean;
   suppressEmbeds?: boolean;
+  /** Persist each concrete platform send before any later chunk can fail. */
+  onDeliveryResult?: (result: DiscordSendResult) => Promise<void> | void;
 };
 
 type DiscordClientRequest = ReturnType<typeof createDiscordClient>["request"];
@@ -72,6 +75,7 @@ async function sendDiscordThreadTextChunks(params: {
   maxChars?: number;
   silent?: boolean;
   suppressEmbeds?: boolean;
+  onResult?: DiscordSendProgress;
 }): Promise<void> {
   for (const chunk of params.chunks) {
     await sendDiscordText(
@@ -87,6 +91,7 @@ async function sendDiscordThreadTextChunks(params: {
       params.silent,
       params.suppressEmbeds,
       params.maxChars,
+      params.onResult,
     );
   }
 }
@@ -245,6 +250,19 @@ export async function sendMessageDiscord(
     const messageId = threadRes.message?.id ?? threadId;
     const resultChannelId = threadRes.message?.channel_id ?? threadId;
     const remainingChunks = chunks.slice(1);
+    await opts.onDeliveryResult?.(
+      toDiscordSendResult(
+        {
+          id: messageId,
+          channel_id: resultChannelId,
+        },
+        channelId,
+        { kind: "text", threadId },
+      ),
+    );
+    const reportThreadResult: DiscordSendProgress = async (result, kind) => {
+      await opts.onDeliveryResult?.(toDiscordSendResult(result, threadId, { kind, threadId }));
+    };
 
     try {
       if (opts.mediaUrl) {
@@ -268,6 +286,7 @@ export async function sendMessageDiscord(
           opts.silent,
           suppressEmbeds,
           textLimit,
+          reportThreadResult,
         );
         await sendDiscordThreadTextChunks({
           rest,
@@ -279,6 +298,7 @@ export async function sendMessageDiscord(
           maxChars: textLimit,
           silent: opts.silent,
           suppressEmbeds,
+          onResult: reportThreadResult,
         });
       } else {
         await sendDiscordThreadTextChunks({
@@ -291,6 +311,7 @@ export async function sendMessageDiscord(
           maxChars: textLimit,
           silent: opts.silent,
           suppressEmbeds,
+          onResult: reportThreadResult,
         });
       }
     } catch (err) {
@@ -319,6 +340,14 @@ export async function sendMessageDiscord(
   }
 
   let result: DiscordChannelMessageResult;
+  const reportResult: DiscordSendProgress = async (progressResult, kind) => {
+    await opts.onDeliveryResult?.(
+      toDiscordSendResult(progressResult, channelId, {
+        kind,
+        replyToId: opts.replyTo,
+      }),
+    );
+  };
   try {
     if (opts.mediaUrl) {
       result = await sendDiscordMedia(
@@ -340,6 +369,7 @@ export async function sendMessageDiscord(
         opts.silent,
         suppressEmbeds,
         textLimit,
+        reportResult,
       );
     } else {
       result = await sendDiscordText(
@@ -355,6 +385,7 @@ export async function sendMessageDiscord(
         opts.silent,
         suppressEmbeds,
         textLimit,
+        reportResult,
       );
     }
   } catch (err) {

--- a/extensions/discord/src/send.sends-basic-channel-messages.test.ts
+++ b/extensions/discord/src/send.sends-basic-channel-messages.test.ts
@@ -219,6 +219,26 @@ describe("sendMessageDiscord", () => {
     expect(requireRestBody(postMock).flags).toBe(MessageFlags.SuppressEmbeds);
   });
 
+  it("reports the first Discord chunk before a later chunk fails", async () => {
+    const { rest, postMock, getMock } = makeDiscordRest();
+    getMock.mockResolvedValueOnce({ type: ChannelType.GuildText });
+    postMock
+      .mockResolvedValueOnce({ id: "msg1", channel_id: "789" })
+      .mockRejectedValueOnce(new Error("second chunk failed"));
+    const onDeliveryResult = vi.fn();
+
+    await expect(
+      sendMessageDiscord("channel:789", "a".repeat(2500), {
+        rest,
+        token: "t",
+        cfg: DISCORD_TEST_CFG,
+        onDeliveryResult,
+      }),
+    ).rejects.toThrow("second chunk failed");
+
+    expect(onDeliveryResult.mock.calls.map((call) => call[0]?.messageId)).toEqual(["msg1"]);
+  });
+
   it("allows Discord link embeds when suppressEmbeds is disabled", async () => {
     const { rest, postMock, getMock } = makeDiscordRest();
     getMock.mockResolvedValueOnce({ type: ChannelType.GuildText });

--- a/extensions/discord/src/send.shared.ts
+++ b/extensions/discord/src/send.shared.ts
@@ -294,6 +294,11 @@ export function toDiscordFileBlob(data: Blob | Uint8Array): Blob {
   return new Blob([arrayBuffer]);
 }
 
+export type DiscordSendProgress = (
+  result: { id: string; channel_id: string },
+  kind: "text" | "media",
+) => Promise<void> | void;
+
 async function sendDiscordText(
   rest: RequestClient,
   channelId: string,
@@ -307,6 +312,7 @@ async function sendDiscordText(
   silent?: boolean,
   suppressEmbeds?: boolean,
   maxChars?: number,
+  onResult?: DiscordSendProgress,
 ) {
   if (!text.trim()) {
     throw new Error("Message must be non-empty for Discord sends");
@@ -337,12 +343,14 @@ async function sendDiscordText(
   };
   if (chunks.length === 1) {
     const result = await sendChunk(chunks[0], true);
+    await onResult?.(result, "text");
     return { ...result, platformMessageIds: result.id ? [result.id] : [] };
   }
   const platformMessageIds: string[] = [];
   let last: { id: string; channel_id: string } | null = null;
   for (const [index, chunk] of chunks.entries()) {
     last = await sendChunk(chunk, index === 0);
+    await onResult?.(last, "text");
     if (last.id) {
       platformMessageIds.push(last.id);
     }
@@ -372,6 +380,7 @@ async function sendDiscordMedia(
   silent?: boolean,
   suppressEmbeds?: boolean,
   maxChars?: number,
+  onResult?: DiscordSendProgress,
 ) {
   const media = await loadWebMedia(
     mediaUrl,
@@ -415,6 +424,7 @@ async function sendDiscordMedia(
     () => createChannelMessage<{ id: string; channel_id: string }>(rest, channelId, { body }),
     "media",
   )) as { id: string; channel_id: string };
+  await onResult?.(res, "media");
   const platformMessageIds = res.id ? [res.id] : [];
   for (const chunk of chunks.slice(1)) {
     if (!chunk.trim()) {
@@ -433,6 +443,7 @@ async function sendDiscordMedia(
       silent,
       suppressEmbeds,
       maxChars,
+      onResult,
     );
     for (const id of followup.platformMessageIds) {
       if (id) {

--- a/extensions/feishu/src/channel.ts
+++ b/extensions/feishu/src/channel.ts
@@ -183,7 +183,18 @@ const feishuMessageAdapter = defineChannelMessageAdapter({
       if (!sendText) {
         throw new Error("Feishu text sending is not available.");
       }
-      return toFeishuMessageSendResult(await sendText(ctx), "text");
+      const { onDeliveryResult, ...outboundCtx } = ctx;
+      const result = await sendText({
+        ...outboundCtx,
+        ...(onDeliveryResult
+          ? {
+              onDeliveryResult: async (progress) => {
+                await onDeliveryResult(toFeishuMessageSendResult(progress, "text"));
+              },
+            }
+          : {}),
+      });
+      return toFeishuMessageSendResult(result, "text");
     },
     media: async (ctx) => {
       const runtime = await loadFeishuChannelRuntime();
@@ -191,7 +202,18 @@ const feishuMessageAdapter = defineChannelMessageAdapter({
       if (!sendMedia) {
         throw new Error("Feishu media sending is not available.");
       }
-      return toFeishuMessageSendResult(await sendMedia(ctx), "media");
+      const { onDeliveryResult, ...outboundCtx } = ctx;
+      const result = await sendMedia({
+        ...outboundCtx,
+        ...(onDeliveryResult
+          ? {
+              onDeliveryResult: async (progress) => {
+                await onDeliveryResult(toFeishuMessageSendResult(progress, "media"));
+              },
+            }
+          : {}),
+      });
+      return toFeishuMessageSendResult(result, "media");
     },
   },
 });

--- a/extensions/feishu/src/outbound.test.ts
+++ b/extensions/feishu/src/outbound.test.ts
@@ -250,17 +250,22 @@ describe("feishuOutbound.sendText local-image auto-convert", () => {
           expect(result.receipt.platformMessageIds).toEqual(["feishu-text-1"]);
         },
         media: async () => {
+          const onDeliveryResult = vi.fn();
           const result = await adapterSendMedia({
             cfg: emptyConfig,
             to: "chat:chat-1",
             text: "",
             mediaUrl: "https://example.com/image.png",
             accountId: "default",
+            onDeliveryResult,
           });
           expect(sendMediaCall()?.to).toBe("chat:chat-1");
           expect(sendMediaCall()?.mediaUrl).toBe("https://example.com/image.png");
           expect(sendMediaCall()?.accountId).toBe("default");
           expect(result.receipt.platformMessageIds).toEqual(["feishu-media-1"]);
+          expect(onDeliveryResult.mock.calls[0]?.[0]?.receipt.platformMessageIds).toEqual([
+            "feishu-media-1",
+          ]);
         },
       },
     });
@@ -1319,6 +1324,58 @@ describe("feishuOutbound.sendMedia replyToId forwarding", () => {
 
     expect(sendMessageCall()?.text).toBe("caption text");
     expect(sendMediaCall()?.mediaUrl).toBe("https://example.com/song.mp3");
+  });
+
+  it("reports a sent caption before media failure and avoids repeating it in fallback", async () => {
+    sendMessageFeishuMock
+      .mockResolvedValueOnce({ messageId: "caption_msg" })
+      .mockResolvedValueOnce({ messageId: "fallback_msg" });
+    sendMediaFeishuMock.mockRejectedValueOnce(new Error("upload failed"));
+    const onDeliveryResult = vi.fn();
+
+    const result = await feishuOutbound.sendMedia?.({
+      cfg: emptyConfig,
+      to: "chat_1",
+      text: "caption text",
+      mediaUrl: "https://example.com/image.png",
+      accountId: "main",
+      onDeliveryResult,
+    });
+
+    expect(sendMessageCall(0)?.text).toBe("caption text");
+    expect(sendMessageCall(1)?.text).toBe("📎 https://example.com/image.png");
+    expect(onDeliveryResult.mock.calls.map((call) => call[0]?.messageId)).toEqual([
+      "caption_msg",
+      "fallback_msg",
+    ]);
+    expectFeishuResult(result, "fallback_msg");
+  });
+
+  it("does not resend successful media when delivery progress persistence fails", async () => {
+    sendMessageFeishuMock.mockResolvedValueOnce({ messageId: "caption_msg" });
+    sendMediaFeishuMock.mockResolvedValueOnce({ messageId: "media_msg" });
+    const onDeliveryResult = vi
+      .fn()
+      .mockResolvedValueOnce(undefined)
+      .mockRejectedValueOnce(new Error("progress write failed"));
+
+    await expect(
+      feishuOutbound.sendMedia?.({
+        cfg: emptyConfig,
+        to: "chat_1",
+        text: "caption text",
+        mediaUrl: "https://example.com/image.png",
+        accountId: "main",
+        onDeliveryResult,
+      }),
+    ).rejects.toThrow("progress write failed");
+
+    expect(sendMediaFeishuMock).toHaveBeenCalledOnce();
+    expect(sendMessageFeishuMock).toHaveBeenCalledOnce();
+    expect(onDeliveryResult.mock.calls.map((call) => call[0]?.messageId)).toEqual([
+      "caption_msg",
+      "media_msg",
+    ]);
   });
 
   it("keeps skipped voice text in the upload failure fallback", async () => {

--- a/extensions/feishu/src/outbound.ts
+++ b/extensions/feishu/src/outbound.ts
@@ -29,7 +29,11 @@ import { cleanupAmbientCommentTypingReaction } from "./comment-reaction.js";
 import { parseFeishuCommentTarget } from "./comment-target.js";
 import { deliverCommentThreadText } from "./drive.js";
 import { resolveFeishuIdentityHeaderTitle } from "./identity-header.js";
-import { sendMediaFeishu, shouldSuppressFeishuTextForVoiceMedia } from "./media.js";
+import {
+  sendMediaFeishu,
+  shouldSuppressFeishuTextForVoiceMedia,
+  type SendMediaResult,
+} from "./media.js";
 import { chunkTextForOutbound, type ChannelOutboundAdapter } from "./outbound-runtime-api.js";
 import { buildFeishuPresentationCardElements } from "./presentation-card.js";
 import {
@@ -568,9 +572,15 @@ export const feishuOutbound: ChannelOutboundAdapter = {
     const mediaUrls = normalizeStringEntries(resolvePayloadMediaUrls(ctx.payload));
     return attachChannelToResult(
       "feishu",
-      await sendPayloadMediaSequenceAndFinalize({
+      await sendPayloadMediaSequenceAndFinalize<
+        SendMediaResult,
+        Awaited<ReturnType<typeof sendCardFeishu>>
+      >({
         text: ctx.payload.text ?? "",
         mediaUrls,
+        onResult: async (deliveryResult) => {
+          await ctx.onDeliveryResult?.(attachChannelToResult("feishu", deliveryResult));
+        },
         send: async ({ mediaUrl }) =>
           await sendMediaFeishu({
             cfg: ctx.cfg,
@@ -682,6 +692,7 @@ export const feishuOutbound: ChannelOutboundAdapter = {
       mediaLocalRoots,
       replyToId,
       threadId,
+      onDeliveryResult,
     }) => {
       const { replyToMessageId, replyInThread } = resolveFeishuMediaReplyMode({
         replyToId,
@@ -706,10 +717,14 @@ export const feishuOutbound: ChannelOutboundAdapter = {
           mediaUrl,
           audioAsVoice,
         });
+      const reportDelivery = async (result: Awaited<ReturnType<typeof sendOutboundText>>) => {
+        await onDeliveryResult?.(attachChannelToResult("feishu", result));
+      };
+      let textSent = false;
 
       // Send text first if provided, except for Feishu native voice bubbles.
       if (text?.trim() && !suppressTextForVoiceMedia) {
-        await sendOutboundText({
+        const textResult = await sendOutboundText({
           cfg,
           to,
           text,
@@ -717,12 +732,15 @@ export const feishuOutbound: ChannelOutboundAdapter = {
           replyToMessageId,
           replyInThread,
         });
+        textSent = true;
+        await reportDelivery(textResult);
       }
 
       // Upload and send media if URL or local path provided
       if (mediaUrl) {
+        let mediaResult: Awaited<ReturnType<typeof sendMediaFeishu>>;
         try {
-          const result = await sendMediaFeishu({
+          mediaResult = await sendMediaFeishu({
             cfg,
             to,
             mediaUrl,
@@ -732,23 +750,14 @@ export const feishuOutbound: ChannelOutboundAdapter = {
             replyInThread,
             ...(audioAsVoice === true ? { audioAsVoice: true } : {}),
           });
-          if (result.voiceIntentDegradedToFile && text?.trim()) {
-            await sendOutboundText({
-              cfg,
-              to,
-              text,
-              accountId: accountId ?? undefined,
-              replyToMessageId,
-              replyInThread,
-            });
-          }
-          return result;
         } catch (err) {
           // Log the error for debugging
           console.error(`[feishu] sendMediaFeishu failed:`, err);
           // Fallback to URL link if upload fails
-          const fallbackText = [text?.trim(), `📎 ${mediaUrl}`].filter(Boolean).join("\n\n");
-          return await sendOutboundText({
+          const fallbackText = [textSent ? undefined : text?.trim(), `📎 ${mediaUrl}`]
+            .filter(Boolean)
+            .join("\n\n");
+          const fallbackResult = await sendOutboundText({
             cfg,
             to,
             text: fallbackText,
@@ -756,7 +765,25 @@ export const feishuOutbound: ChannelOutboundAdapter = {
             replyToMessageId,
             replyInThread,
           });
+          await reportDelivery(fallbackResult);
+          return fallbackResult;
         }
+
+        // Upload fallback applies only to the platform send. Persistence and
+        // follow-up failures must not resend an attachment already accepted by Feishu.
+        await onDeliveryResult?.(attachChannelToResult("feishu", mediaResult));
+        if (mediaResult.voiceIntentDegradedToFile && text?.trim()) {
+          const textResult = await sendOutboundText({
+            cfg,
+            to,
+            text,
+            accountId: accountId ?? undefined,
+            replyToMessageId,
+            replyInThread,
+          });
+          await reportDelivery(textResult);
+        }
+        return mediaResult;
       }
 
       // No media URL, just return text result

--- a/extensions/line/src/channel.sendPayload.test.ts
+++ b/extensions/line/src/channel.sendPayload.test.ts
@@ -161,6 +161,31 @@ describe("line outbound sendPayload", () => {
     });
   });
 
+  it("reports each platform result for text and media payloads", async () => {
+    const { runtime } = createRuntime();
+    setLineRuntime(runtime);
+    const cfg = { channels: { line: {} } } as OpenClawConfig;
+    const onDeliveryResult = vi.fn();
+
+    await lineOutboundAdapter.sendPayload!({
+      to: "line:user:progress",
+      text: "Hello",
+      payload: {
+        text: "Hello",
+        mediaUrl: "https://example.com/image.jpg",
+      },
+      accountId: "default",
+      cfg,
+      onDeliveryResult,
+    });
+
+    expect(onDeliveryResult).toHaveBeenCalledTimes(2);
+    expect(onDeliveryResult.mock.calls.map(([result]) => result.messageId)).toEqual([
+      "m-text",
+      "m-media",
+    ]);
+  });
+
   it("sends template message without dropping text", async () => {
     const { runtime, mocks } = createRuntime();
     setLineRuntime(runtime);

--- a/extensions/line/src/outbound.ts
+++ b/extensions/line/src/outbound.ts
@@ -82,7 +82,7 @@ export const lineOutboundAdapter: NonNullable<ChannelPlugin<ResolvedLineAccount>
   deliveryMode: "direct",
   chunker: (text, limit) => getLineRuntime().channel.text.chunkMarkdownText(text, limit),
   textChunkLimit: 5000,
-  sendPayload: async ({ to, payload, accountId, cfg }) => {
+  sendPayload: async ({ to, payload, accountId, cfg, onDeliveryResult }) => {
     const runtime = getLineRuntime();
     const outboundRuntime = await loadLineOutboundRuntime();
     const lineData = (payload.channelData?.line as LineChannelDataWithMedia | undefined) ?? {};
@@ -100,6 +100,14 @@ export const lineOutboundAdapter: NonNullable<ChannelPlugin<ResolvedLineAccount>
       outboundRuntime.buildTemplateMessageFromPayload;
 
     let lastResult: LineSendResult | null = null;
+    const recordResult = async (
+      resultPromise: Promise<LineSendResult>,
+    ): Promise<LineSendResult> => {
+      const result = await resultPromise;
+      lastResult = result;
+      await onDeliveryResult?.(createEmptyChannelResult("line", { ...result }));
+      return result;
+    };
     const quickReplies = lineData.quickReplies ?? [];
     const hasQuickReplies = quickReplies.length > 0;
     const quickReply = hasQuickReplies
@@ -113,12 +121,13 @@ export const lineOutboundAdapter: NonNullable<ChannelPlugin<ResolvedLineAccount>
       }
       for (let i = 0; i < messages.length; i += 5) {
         const batch = messages.slice(i, i + 5) as unknown as Parameters<typeof sendBatch>[1];
-        const result = await sendBatch(to, batch, {
-          verbose: false,
-          cfg,
-          accountId: accountId ?? undefined,
-        });
-        lastResult = result;
+        await recordResult(
+          sendBatch(to, batch, {
+            verbose: false,
+            cfg,
+            accountId: accountId ?? undefined,
+          }),
+        );
       }
     };
 
@@ -144,15 +153,13 @@ export const lineOutboundAdapter: NonNullable<ChannelPlugin<ResolvedLineAccount>
           continue;
         }
         if (!useLineSpecificMedia) {
-          lastResult = await (lineRuntime?.sendMessageLine ?? outboundRuntime.sendMessageLine)(
-            to,
-            "",
-            {
+          await recordResult(
+            (lineRuntime?.sendMessageLine ?? outboundRuntime.sendMessageLine)(to, "", {
               verbose: false,
               mediaUrl: trimmed,
               cfg,
               accountId: accountId ?? undefined,
-            },
+            }),
           );
           continue;
         }
@@ -162,10 +169,8 @@ export const lineOutboundAdapter: NonNullable<ChannelPlugin<ResolvedLineAccount>
           durationMs: lineData.durationMs,
           trackingId: lineData.trackingId,
         });
-        lastResult = await (lineRuntime?.sendMessageLine ?? outboundRuntime.sendMessageLine)(
-          to,
-          "",
-          {
+        await recordResult(
+          (lineRuntime?.sendMessageLine ?? outboundRuntime.sendMessageLine)(to, "", {
             verbose: false,
             mediaUrl: resolved.mediaUrl,
             mediaKind: resolved.mediaKind,
@@ -174,7 +179,7 @@ export const lineOutboundAdapter: NonNullable<ChannelPlugin<ResolvedLineAccount>
             trackingId: resolved.trackingId,
             cfg,
             accountId: accountId ?? undefined,
-          },
+          }),
         );
       }
     };
@@ -182,39 +187,47 @@ export const lineOutboundAdapter: NonNullable<ChannelPlugin<ResolvedLineAccount>
     if (!shouldSendQuickRepliesInline) {
       if (lineData.flexMessage) {
         const flexContents = lineData.flexMessage.contents as Parameters<typeof sendFlex>[2];
-        lastResult = await sendFlex(to, lineData.flexMessage.altText, flexContents, {
-          verbose: false,
-          cfg,
-          accountId: accountId ?? undefined,
-        });
+        await recordResult(
+          sendFlex(to, lineData.flexMessage.altText, flexContents, {
+            verbose: false,
+            cfg,
+            accountId: accountId ?? undefined,
+          }),
+        );
       }
 
       if (lineData.templateMessage) {
         const template = buildTemplate(lineData.templateMessage);
         if (template) {
-          lastResult = await sendTemplate(to, template, {
-            verbose: false,
-            cfg,
-            accountId: accountId ?? undefined,
-          });
+          await recordResult(
+            sendTemplate(to, template, {
+              verbose: false,
+              cfg,
+              accountId: accountId ?? undefined,
+            }),
+          );
         }
       }
 
       if (lineData.location) {
-        lastResult = await sendLocation(to, lineData.location, {
-          verbose: false,
-          cfg,
-          accountId: accountId ?? undefined,
-        });
+        await recordResult(
+          sendLocation(to, lineData.location, {
+            verbose: false,
+            cfg,
+            accountId: accountId ?? undefined,
+          }),
+        );
       }
 
       for (const flexMsg of processed.flexMessages) {
         const flexContents = flexMsg.contents;
-        lastResult = await sendFlex(to, flexMsg.altText, flexContents, {
-          verbose: false,
-          cfg,
-          accountId: accountId ?? undefined,
-        });
+        await recordResult(
+          sendFlex(to, flexMsg.altText, flexContents, {
+            verbose: false,
+            cfg,
+            accountId: accountId ?? undefined,
+          }),
+        );
       }
     }
 
@@ -227,17 +240,21 @@ export const lineOutboundAdapter: NonNullable<ChannelPlugin<ResolvedLineAccount>
       for (let i = 0; i < chunks.length; i += 1) {
         const isLast = i === chunks.length - 1;
         if (isLast && hasQuickReplies) {
-          lastResult = await sendQuickReplies(to, chunks[i], quickReplies, {
-            verbose: false,
-            cfg,
-            accountId: accountId ?? undefined,
-          });
+          await recordResult(
+            sendQuickReplies(to, chunks[i], quickReplies, {
+              verbose: false,
+              cfg,
+              accountId: accountId ?? undefined,
+            }),
+          );
         } else {
-          lastResult = await sendText(to, chunks[i], {
-            verbose: false,
-            cfg,
-            accountId: accountId ?? undefined,
-          });
+          await recordResult(
+            sendText(to, chunks[i], {
+              verbose: false,
+              cfg,
+              accountId: accountId ?? undefined,
+            }),
+          );
         }
       }
     } else if (shouldSendQuickRepliesInline) {
@@ -302,15 +319,12 @@ export const lineOutboundAdapter: NonNullable<ChannelPlugin<ResolvedLineAccount>
         };
         await sendMessageBatch(quickReplyMessages);
       } else if (quickReply) {
-        lastResult = await sendQuickReplies(
-          to,
-          buildLineQuickReplyFallbackText(quickReplies),
-          quickReplies,
-          {
+        await recordResult(
+          sendQuickReplies(to, buildLineQuickReplyFallbackText(quickReplies), quickReplies, {
             verbose: false,
             cfg,
             accountId: accountId ?? undefined,
-          },
+          }),
         );
       }
     }
@@ -319,8 +333,9 @@ export const lineOutboundAdapter: NonNullable<ChannelPlugin<ResolvedLineAccount>
       await sendMediaMessages();
     }
 
-    if (lastResult) {
-      return createEmptyChannelResult("line", { ...lastResult });
+    const completedResult = lastResult as LineSendResult | null;
+    if (completedResult) {
+      return createEmptyChannelResult("line", { ...completedResult });
     }
     return createEmptyChannelResult("line", { messageId: "empty", chatId: to });
   },
@@ -400,17 +415,20 @@ export const lineMessageAdapter = defineChannelMessageAdapter({
     },
   },
   send: {
-    text: async ({ cfg, to, text, accountId }) => {
+    text: async ({ cfg, to, text, accountId, onDeliveryResult }) => {
       const result = await lineOutboundAdapter.sendPayload!({
         cfg,
         to,
         text,
         accountId,
         payload: { text },
+        onDeliveryResult: async (deliveryResult) => {
+          await onDeliveryResult?.(toLineMessageSendResult(deliveryResult, "text"));
+        },
       });
       return toLineMessageSendResult(result, "text");
     },
-    media: async ({ cfg, to, text, mediaUrl, accountId }) => {
+    media: async ({ cfg, to, text, mediaUrl, accountId, onDeliveryResult }) => {
       const result = await lineOutboundAdapter.sendPayload!({
         cfg,
         to,
@@ -418,6 +436,9 @@ export const lineMessageAdapter = defineChannelMessageAdapter({
         mediaUrl,
         accountId,
         payload: { text, mediaUrl },
+        onDeliveryResult: async (deliveryResult) => {
+          await onDeliveryResult?.(toLineMessageSendResult(deliveryResult, "media"));
+        },
       });
       return toLineMessageSendResult(result, "media");
     },

--- a/extensions/matrix/src/matrix/send.test.ts
+++ b/extensions/matrix/src/matrix/send.test.ts
@@ -685,6 +685,27 @@ describe("sendMessageMatrix threads", () => {
     expectTextReceiptPart(parts[2], "$m3");
   });
 
+  it("reports the first Matrix event before a later event fails", async () => {
+    const { client, sendMessage } = makeClient();
+    sendMessage
+      .mockReset()
+      .mockResolvedValueOnce("$m1")
+      .mockRejectedValueOnce(new Error("second event failed"));
+    convertMarkdownTablesMock.mockImplementation(() => "part1|part2");
+    chunkMarkdownTextWithModeMock.mockImplementation((text: string) => text.split("|"));
+    const onDeliveryResult = vi.fn();
+
+    await expect(
+      sendMessageMatrix("room:!room:example", "ignored", {
+        client,
+        cfg: {} as never,
+        onDeliveryResult,
+      }),
+    ).rejects.toThrow("second event failed");
+
+    expect(onDeliveryResult.mock.calls.map((call) => call[0]?.messageId)).toEqual(["$m1"]);
+  });
+
   it("merges extra content into only the first chunked text event", async () => {
     const { client, sendMessage } = makeClient();
     convertMarkdownTablesMock.mockImplementation(() => "first|second|third");

--- a/extensions/matrix/src/matrix/send.ts
+++ b/extensions/matrix/src/matrix/send.ts
@@ -259,10 +259,24 @@ export async function sendMessageMatrix(
         ? buildThreadRelation(threadId, opts.replyToId)
         : buildReplyRelation(opts.replyToId);
       let pendingExtraContent = opts.extraContent;
-      const sendContent = async (content: MatrixOutboundContent) => {
+      const sendContent = async (content: MatrixOutboundContent, kind: MessageReceiptPartKind) => {
         const contentWithExtra = withMatrixExtraContentFields(content, pendingExtraContent);
         pendingExtraContent = undefined;
         const eventId = await client.sendMessage(roomId, contentWithExtra);
+        if (eventId) {
+          await opts.onDeliveryResult?.({
+            messageId: eventId,
+            roomId,
+            primaryMessageId: eventId,
+            receipt: createMatrixSendReceipt({
+              roomId,
+              platformMessageIds: [eventId],
+              kind,
+              replyToId: opts.replyToId,
+              threadId,
+            }),
+          });
+        }
         return eventId;
       };
 
@@ -324,7 +338,7 @@ export async function sendMessageMatrix(
           content,
           markdown: captionMarkdown,
         });
-        const eventId = await sendContent(content);
+        const eventId = await sendContent(content, receiptKind);
         lastMessageId = eventId ?? lastMessageId;
         if (eventId) {
           platformMessageIds.push(eventId);
@@ -344,7 +358,7 @@ export async function sendMessageMatrix(
             content: followup,
             markdown: text,
           });
-          const followupEventId = await sendContent(followup);
+          const followupEventId = await sendContent(followup, "text");
           lastMessageId = followupEventId ?? lastMessageId;
           if (followupEventId) {
             platformMessageIds.push(followupEventId);
@@ -362,7 +376,7 @@ export async function sendMessageMatrix(
             content,
             markdown: text,
           });
-          const eventId = await sendContent(content);
+          const eventId = await sendContent(content, "text");
           lastMessageId = eventId ?? lastMessageId;
           if (eventId) {
             platformMessageIds.push(eventId);

--- a/extensions/matrix/src/matrix/send/types.ts
+++ b/extensions/matrix/src/matrix/send/types.ts
@@ -102,6 +102,8 @@ export type MatrixSendOpts = {
   extraContent?: MatrixExtraContentFields;
   /** Send audio as voice message instead of audio file. Defaults to false. */
   audioAsVoice?: boolean;
+  /** Persist each concrete platform send before any later event can fail. */
+  onDeliveryResult?: (result: MatrixSendResult) => Promise<void> | void;
 };
 
 export type MatrixMediaMsgType =

--- a/extensions/matrix/src/outbound.ts
+++ b/extensions/matrix/src/outbound.ts
@@ -94,6 +94,18 @@ function resolveMatrixExtraContent(payload: ReplyPayload): MatrixExtraContentFie
   return presentation ? { [MATRIX_OPENCLAW_PRESENTATION_KEY]: presentation } : undefined;
 }
 
+function resolveMatrixDeliveryProgress(
+  onDeliveryResult: Parameters<
+    NonNullable<ChannelOutboundAdapter["sendText"]>
+  >[0]["onDeliveryResult"],
+) {
+  return onDeliveryResult
+    ? async (result: Awaited<ReturnType<typeof sendMessageMatrix>>) => {
+        await onDeliveryResult({ channel: "matrix", ...result });
+      }
+    : undefined;
+}
+
 export const matrixOutbound: ChannelOutboundAdapter = {
   deliveryMode: "direct",
   chunker: chunkTextForOutbound,
@@ -128,6 +140,7 @@ export const matrixOutbound: ChannelOutboundAdapter = {
     threadId,
     accountId,
     audioAsVoice,
+    onDeliveryResult,
   }) => {
     const send =
       resolveOutboundSendDep<typeof sendMessageMatrix>(deps, "matrix") ?? sendMessageMatrix;
@@ -155,6 +168,7 @@ export const matrixOutbound: ChannelOutboundAdapter = {
           accountId: accountId ?? undefined,
           audioAsVoice: payload.audioAsVoice ?? audioAsVoice,
           extraContent: isFirst ? resolveMatrixExtraContent(payload) : undefined,
+          onDeliveryResult: resolveMatrixDeliveryProgress(onDeliveryResult),
         });
       }
       return {
@@ -174,6 +188,7 @@ export const matrixOutbound: ChannelOutboundAdapter = {
       accountId: accountId ?? undefined,
       audioAsVoice: payload.audioAsVoice ?? audioAsVoice,
       extraContent: resolveMatrixExtraContent(payload),
+      onDeliveryResult: resolveMatrixDeliveryProgress(onDeliveryResult),
     });
     return {
       channel: "matrix",
@@ -181,7 +196,17 @@ export const matrixOutbound: ChannelOutboundAdapter = {
       roomId: result.roomId,
     };
   },
-  sendText: async ({ cfg, to, text, deps, replyToId, threadId, accountId, audioAsVoice }) => {
+  sendText: async ({
+    cfg,
+    to,
+    text,
+    deps,
+    replyToId,
+    threadId,
+    accountId,
+    audioAsVoice,
+    onDeliveryResult,
+  }) => {
     const send =
       resolveOutboundSendDep<typeof sendMessageMatrix>(deps, "matrix") ?? sendMessageMatrix;
     const resolvedThreadId =
@@ -192,6 +217,7 @@ export const matrixOutbound: ChannelOutboundAdapter = {
       threadId: resolvedThreadId,
       accountId: accountId ?? undefined,
       audioAsVoice,
+      onDeliveryResult: resolveMatrixDeliveryProgress(onDeliveryResult),
     });
     return {
       channel: "matrix",
@@ -211,6 +237,7 @@ export const matrixOutbound: ChannelOutboundAdapter = {
     threadId,
     accountId,
     audioAsVoice,
+    onDeliveryResult,
   }) => {
     const send =
       resolveOutboundSendDep<typeof sendMessageMatrix>(deps, "matrix") ?? sendMessageMatrix;
@@ -225,6 +252,7 @@ export const matrixOutbound: ChannelOutboundAdapter = {
       threadId: resolvedThreadId,
       accountId: accountId ?? undefined,
       audioAsVoice,
+      onDeliveryResult: resolveMatrixDeliveryProgress(onDeliveryResult),
     });
     return {
       channel: "matrix",

--- a/extensions/msteams/src/outbound.ts
+++ b/extensions/msteams/src/outbound.ts
@@ -115,6 +115,7 @@ export const msteamsOutbound: ChannelOutboundAdapter = {
     mediaReadFile,
     payload,
     deps,
+    onDeliveryResult,
   }) => {
     const msteamsData = asObjectRecord(payload.channelData?.msteams);
     const presentationCard = msteamsData?.presentationCard;
@@ -138,9 +139,12 @@ export const msteamsOutbound: ChannelOutboundAdapter = {
     );
     if (mediaUrls.length > 0) {
       const send = resolveMSTeamsMediaSend({ cfg, deps });
-      const result = await sendPayloadMediaSequence({
+      const result = await sendPayloadMediaSequence<MSTeamsSendResult>({
         text,
         mediaUrls,
+        onResult: async (deliveryResult) => {
+          await onDeliveryResult?.(attachChannelToResult("msteams", deliveryResult));
+        },
         send: async ({ text: textLocal, mediaUrl: mediaUrlLocal }) =>
           await send(to, textLocal, { mediaUrl: mediaUrlLocal, mediaLocalRoots, mediaReadFile }),
       });
@@ -157,6 +161,7 @@ export const msteamsOutbound: ChannelOutboundAdapter = {
       let result: Awaited<ReturnType<MSTeamsTextSendFn>>;
       for (const chunk of chunks) {
         result = await send(to, chunk);
+        await onDeliveryResult?.(attachChannelToResult("msteams", result));
       }
       return attachChannelToResult("msteams", result!);
     }

--- a/extensions/signal/src/channel.ts
+++ b/extensions/signal/src/channel.ts
@@ -6,10 +6,7 @@ import { createChatChannelPlugin, type ChannelPlugin } from "openclaw/plugin-sdk
 import { defineChannelMessageAdapter } from "openclaw/plugin-sdk/channel-outbound";
 import { resolveOutboundSendDep } from "openclaw/plugin-sdk/channel-outbound";
 import { createPairingPrefixStripper } from "openclaw/plugin-sdk/channel-pairing";
-import {
-  attachChannelToResult,
-  attachChannelToResults,
-} from "openclaw/plugin-sdk/channel-send-result";
+import { attachChannelToResult } from "openclaw/plugin-sdk/channel-send-result";
 import { PAIRING_APPROVED_MESSAGE } from "openclaw/plugin-sdk/channel-status";
 import { createLazyRuntimeModule } from "openclaw/plugin-sdk/lazy-runtime";
 import { resolveMarkdownTableMode } from "openclaw/plugin-sdk/markdown-table-runtime";
@@ -219,6 +216,9 @@ async function sendFormattedSignalText(ctx: {
   accountId?: string | null;
   deps?: { [channelId: string]: unknown };
   abortSignal?: AbortSignal;
+  onDeliveryResult?: Parameters<
+    NonNullable<ChannelOutboundAdapter["sendFormattedText"]>
+  >[0]["onDeliveryResult"];
 }) {
   const { send, maxBytes } = await resolveSignalSendContext({
     cfg: ctx.cfg,
@@ -255,9 +255,14 @@ async function sendFormattedSignalText(ctx: {
       textMode: "plain",
       textStyles: chunk.styles,
     });
-    results.push(attachSignalVisibleText(result, chunk.text));
+    const deliveryResult = attachChannelToResult(
+      "signal",
+      attachSignalVisibleText(result, chunk.text),
+    );
+    results.push(deliveryResult);
+    await ctx.onDeliveryResult?.(deliveryResult);
   }
-  return attachChannelToResults("signal", results);
+  return results;
 }
 
 async function sendFormattedSignalMedia(ctx: {
@@ -549,7 +554,15 @@ export const signalPlugin: ChannelPlugin<ResolvedSignalAccount, SignalProbe> =
         afterDeliverPayload: async (params) =>
           await registerDeliveredSignalApprovalPayloadForReactions(params),
         renderPresentation: async (params) => await renderSignalApprovalPayloadForReactions(params),
-        sendFormattedText: async ({ cfg, to, text, accountId, deps, abortSignal }) =>
+        sendFormattedText: async ({
+          cfg,
+          to,
+          text,
+          accountId,
+          deps,
+          abortSignal,
+          onDeliveryResult,
+        }) =>
           await sendFormattedSignalText({
             cfg,
             to,
@@ -557,6 +570,7 @@ export const signalPlugin: ChannelPlugin<ResolvedSignalAccount, SignalProbe> =
             accountId,
             deps,
             abortSignal,
+            onDeliveryResult,
           }),
         sendFormattedMedia: async ({
           cfg,

--- a/extensions/signal/src/core.test.ts
+++ b/extensions/signal/src/core.test.ts
@@ -342,6 +342,30 @@ describe("signal outbound", () => {
     );
   });
 
+  it("reports a formatted Signal chunk before a later chunk fails", async () => {
+    const send = vi
+      .fn()
+      .mockResolvedValueOnce({ messageId: "signal-1" })
+      .mockRejectedValueOnce(new Error("second Signal chunk failed"));
+    const onDeliveryResult = vi.fn();
+
+    await expect(
+      signalPlugin.outbound?.sendFormattedText?.({
+        cfg: {} as OpenClawConfig,
+        to: "+15551234567",
+        text: "a".repeat(5000),
+        deps: { signal: send },
+        onDeliveryResult,
+      }),
+    ).rejects.toThrow("second Signal chunk failed");
+
+    expect(send).toHaveBeenCalledTimes(2);
+    expect(onDeliveryResult).toHaveBeenCalledTimes(1);
+    expect(onDeliveryResult).toHaveBeenCalledWith(
+      expect.objectContaining({ channel: "signal", messageId: "signal-1" }),
+    );
+  });
+
   it("resolves aliases before formatted Signal media sends", async () => {
     const send = vi.fn(async () => ({
       messageId: "signal-1",

--- a/extensions/slack/src/channel.test.ts
+++ b/extensions/slack/src/channel.test.ts
@@ -695,6 +695,34 @@ describe("slackPlugin outbound", () => {
     expect(result).toEqual({ channel: "slack", messageId: "m-text" });
   });
 
+  it("forwards partial-send progress through the registered Slack sender", async () => {
+    const sendSlack = vi.fn(async (...args: unknown[]) => {
+      const options = args[2] as {
+        onDeliveryResult?: (result: { messageId: string }) => Promise<void>;
+      };
+      await options.onDeliveryResult?.({ messageId: "m-first" });
+      throw new Error("later Slack chunk failed");
+    });
+    const onDeliveryResult = vi.fn();
+    const sendText = requireSlackSendText();
+
+    await expect(
+      sendText({
+        cfg,
+        to: "C123",
+        text: "long message",
+        accountId: "default",
+        deps: { sendSlack },
+        onDeliveryResult,
+      }),
+    ).rejects.toThrow("later Slack chunk failed");
+
+    expect(onDeliveryResult).toHaveBeenCalledWith({
+      channel: "slack",
+      messageId: "m-first",
+    });
+  });
+
   it("prefers replyToId over threadId for sendMedia", async () => {
     const sendSlack = vi.fn().mockResolvedValue({ messageId: "m-media" });
     const sendMedia = requireSlackSendMedia();

--- a/extensions/slack/src/channel.ts
+++ b/extensions/slack/src/channel.ts
@@ -13,6 +13,7 @@ import { createChannelMessageAdapterFromOutbound } from "openclaw/plugin-sdk/cha
 import { resolveOutboundSendDep } from "openclaw/plugin-sdk/channel-outbound";
 import { createPairingPrefixStripper } from "openclaw/plugin-sdk/channel-pairing";
 import {
+  attachChannelToResult,
   createAttachedChannelResultAdapter,
   type ChannelOutboundAdapter,
 } from "openclaw/plugin-sdk/channel-send-result";
@@ -454,7 +455,7 @@ const slackChannelOutbound: ChannelOutboundAdapter = {
   },
   ...createAttachedChannelResultAdapter({
     channel: "slack",
-    sendText: async ({ to, text, accountId, deps, replyToId, threadId, cfg }) => {
+    sendText: async ({ to, text, accountId, deps, replyToId, threadId, cfg, onDeliveryResult }) => {
       const { send, threadTsValue, tokenOverride } = await resolveSlackSendContext({
         cfg,
         accountId: accountId ?? undefined,
@@ -466,6 +467,11 @@ const slackChannelOutbound: ChannelOutboundAdapter = {
         cfg,
         threadTs: threadTsValue,
         accountId: accountId ?? undefined,
+        onDeliveryResult: onDeliveryResult
+          ? async (result) => {
+              await onDeliveryResult(attachChannelToResult("slack", result));
+            }
+          : undefined,
         ...(tokenOverride ? { token: tokenOverride } : {}),
       });
     },
@@ -479,6 +485,7 @@ const slackChannelOutbound: ChannelOutboundAdapter = {
       replyToId,
       threadId,
       cfg,
+      onDeliveryResult,
     }) => {
       const { send, threadTsValue, tokenOverride } = await resolveSlackSendContext({
         cfg,
@@ -493,6 +500,11 @@ const slackChannelOutbound: ChannelOutboundAdapter = {
         mediaLocalRoots,
         threadTs: threadTsValue,
         accountId: accountId ?? undefined,
+        onDeliveryResult: onDeliveryResult
+          ? async (result) => {
+              await onDeliveryResult(attachChannelToResult("slack", result));
+            }
+          : undefined,
         ...(tokenOverride ? { token: tokenOverride } : {}),
       });
     },

--- a/extensions/slack/src/outbound-adapter.ts
+++ b/extensions/slack/src/outbound-adapter.ts
@@ -80,6 +80,9 @@ async function sendSlackOutboundMessage(params: {
   replyToId?: string | null;
   threadId?: string | number | null;
   identity?: OutboundIdentity;
+  onDeliveryResult?: Parameters<
+    NonNullable<ChannelOutboundAdapter["sendText"]>
+  >[0]["onDeliveryResult"];
 }) {
   const send =
     resolveOutboundSendDep<SlackSendFn>(params.deps, "slack") ??
@@ -103,6 +106,11 @@ async function sendSlackOutboundMessage(params: {
       : {}),
     ...(params.blocks ? { blocks: params.blocks } : {}),
     ...(slackIdentity ? { identity: slackIdentity } : {}),
+    onDeliveryResult: params.onDeliveryResult
+      ? async (progress) => {
+          await params.onDeliveryResult?.(attachChannelToResult("slack", progress));
+        }
+      : undefined,
   });
   return result;
 }
@@ -228,6 +236,7 @@ export const slackOutbound: ChannelOutboundAdapter = {
             replyToId: ctx.replyToId,
             threadId: ctx.threadId,
             identity: ctx.identity,
+            onDeliveryResult: ctx.onDeliveryResult,
           }),
         finalize: async () =>
           await sendSlackOutboundMessage({
@@ -243,13 +252,24 @@ export const slackOutbound: ChannelOutboundAdapter = {
             replyToId: ctx.replyToId,
             threadId: ctx.threadId,
             identity: ctx.identity,
+            onDeliveryResult: ctx.onDeliveryResult,
           }),
       }),
     );
   },
   ...createAttachedChannelResultAdapter({
     channel: "slack",
-    sendText: async ({ cfg, to, text, accountId, deps, replyToId, threadId, identity }) =>
+    sendText: async ({
+      cfg,
+      to,
+      text,
+      accountId,
+      deps,
+      replyToId,
+      threadId,
+      identity,
+      onDeliveryResult,
+    }) =>
       await sendSlackOutboundMessage({
         cfg,
         to,
@@ -259,6 +279,7 @@ export const slackOutbound: ChannelOutboundAdapter = {
         replyToId,
         threadId,
         identity,
+        onDeliveryResult,
       }),
     sendMedia: async ({
       cfg,
@@ -273,6 +294,7 @@ export const slackOutbound: ChannelOutboundAdapter = {
       replyToId,
       threadId,
       identity,
+      onDeliveryResult,
     }) =>
       await sendSlackOutboundMessage({
         cfg,
@@ -287,6 +309,7 @@ export const slackOutbound: ChannelOutboundAdapter = {
         replyToId,
         threadId,
         identity,
+        onDeliveryResult,
       }),
   }),
 };

--- a/extensions/slack/src/send.blocks.test.ts
+++ b/extensions/slack/src/send.blocks.test.ts
@@ -1,5 +1,5 @@
 // Slack tests cover send.blocks plugin behavior.
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { createSlackSendTestClient } from "./blocks.test-helpers.js";
 import {
   clearSlackThreadParticipationCache,
@@ -201,6 +201,25 @@ describe("sendMessageSlack chunking", () => {
         .filter((text) => text.length === null || text.length > 8000),
     ).toStrictEqual([]);
     expect(postedTexts.join("")).toBe(message);
+  });
+
+  it("reports the first Slack chunk before a later chunk fails", async () => {
+    const client = createSlackSendTestClient();
+    client.chat.postMessage
+      .mockResolvedValueOnce({ ts: "m1", channel: "C123" })
+      .mockRejectedValueOnce(new Error("second chunk failed"));
+    const onDeliveryResult = vi.fn();
+
+    await expect(
+      sendMessageSlack("channel:C123", "a".repeat(8500), {
+        token: "xoxb-test",
+        cfg: SLACK_TEST_CFG,
+        client,
+        onDeliveryResult,
+      }),
+    ).rejects.toThrow("second chunk failed");
+
+    expect(onDeliveryResult.mock.calls.map((call) => call[0]?.messageId)).toEqual(["m1"]);
   });
 
   it("preserves the first canonical response thread across chunked sends", async () => {

--- a/extensions/slack/src/send.ts
+++ b/extensions/slack/src/send.ts
@@ -114,6 +114,8 @@ type SlackSendOpts = {
   identity?: SlackSendIdentity;
   blocks?: (Block | KnownBlock)[];
   metadata?: MessageMetadata;
+  /** Persist each concrete platform send before any later chunk can fail. */
+  onDeliveryResult?: (result: SlackSendResult) => Promise<void> | void;
 };
 
 type SlackWebApiErrorData = {
@@ -773,6 +775,10 @@ async function sendMessageSlackQueuedInner(params: {
         accountId: account.accountId,
         token,
       });
+  const reportDelivery = async (result: SlackSendResult) => {
+    await opts.onDeliveryResult?.(result);
+    return result;
+  };
   if (blocks) {
     if (opts.mediaUrl) {
       throw new Error("Slack send does not support blocks with mediaUrl");
@@ -796,7 +802,7 @@ async function sendMessageSlackQueuedInner(params: {
     const deliveredChannelId = resolvePostedMessageChannelId(response, channelId);
     const deliveredThreadTs =
       resolvePostedMessageThreadTs(response) ?? normalizeSlackThreadTsCandidate(opts.threadTs);
-    return {
+    return await reportDelivery({
       messageId,
       channelId: deliveredChannelId,
       threadTs: deliveredThreadTs,
@@ -806,7 +812,7 @@ async function sendMessageSlackQueuedInner(params: {
         kind: "card",
         threadTs: deliveredThreadTs,
       }),
-    };
+    });
   }
   const textLimit = resolveTextChunkLimit(cfg, "slack", account.accountId, {
     fallbackLimit: SLACK_TEXT_LIMIT,
@@ -852,6 +858,17 @@ async function sendMessageSlackQueuedInner(params: {
       maxBytes: mediaMaxBytes,
     });
     sentMessageIds.push(lastMessageId);
+    await reportDelivery({
+      messageId: lastMessageId,
+      channelId,
+      threadTs: normalizeSlackThreadTsCandidate(opts.threadTs),
+      receipt: createSlackSendReceipt({
+        platformMessageIds: [lastMessageId],
+        channelId,
+        kind: "media",
+        threadTs: normalizeSlackThreadTsCandidate(opts.threadTs),
+      }),
+    });
     chunksToPost = rest;
   } else {
     chunksToPost = resolvedChunks.length ? resolvedChunks : [""];
@@ -873,6 +890,20 @@ async function sendMessageSlackQueuedInner(params: {
     canonicalDeliveredThreadTs ??= resolvePostedMessageThreadTs(response);
     if (response.ts) {
       sentMessageIds.push(response.ts);
+      await reportDelivery({
+        messageId: response.ts,
+        channelId: deliveredChannelId,
+        threadTs:
+          resolvePostedMessageThreadTs(response) ?? normalizeSlackThreadTsCandidate(opts.threadTs),
+        receipt: createSlackSendReceipt({
+          platformMessageIds: [response.ts],
+          channelId: deliveredChannelId,
+          kind: "text",
+          threadTs:
+            resolvePostedMessageThreadTs(response) ??
+            normalizeSlackThreadTsCandidate(opts.threadTs),
+        }),
+      });
     }
   }
 

--- a/extensions/telegram/src/outbound-adapter.ts
+++ b/extensions/telegram/src/outbound-adapter.ts
@@ -68,6 +68,9 @@ async function resolveTelegramSendContext(params: {
   formatting?: OutboundDeliveryFormattingOptions;
   silent?: boolean;
   gatewayClientScopes?: readonly string[];
+  onDeliveryResult?: Parameters<
+    NonNullable<ChannelOutboundAdapter["sendText"]>
+  >[0]["onDeliveryResult"];
   resolveSend: ResolveTelegramSendFn;
 }): Promise<{
   send: TelegramSendFn;
@@ -83,6 +86,7 @@ async function resolveTelegramSendContext(params: {
     accountId?: string;
     silent?: boolean;
     gatewayClientScopes?: readonly string[];
+    onDeliveryResult?: TelegramSendOpts["onDeliveryResult"];
   };
 }> {
   const send = await params.resolveSend(params.deps);
@@ -98,6 +102,11 @@ async function resolveTelegramSendContext(params: {
       accountId: params.accountId ?? undefined,
       silent: params.silent,
       gatewayClientScopes: params.gatewayClientScopes,
+      onDeliveryResult: params.onDeliveryResult
+        ? async (result) => {
+            await params.onDeliveryResult?.(attachChannelToResult("telegram", result));
+          }
+        : undefined,
       ...(params.formatting?.parseMode === "HTML" ? { textMode: "html" as const } : {}),
       tableMode: params.formatting?.tableMode,
     },

--- a/extensions/telegram/src/send.test.ts
+++ b/extensions/telegram/src/send.test.ts
@@ -1479,6 +1479,24 @@ describe("sendMessageTelegram", () => {
     expect(chunks.every((chunk) => chunk.length <= 4000)).toBe(true);
   });
 
+  it("reports the first Telegram chunk before a later chunk fails", async () => {
+    botApi.sendMessage
+      .mockResolvedValueOnce({ message_id: 54, chat: { id: "123" } })
+      .mockRejectedValueOnce(new Error("second chunk failed"));
+    const onDeliveryResult = vi.fn();
+    const markdown = `# Long\n\n${"**section** with _style_ and `code`\n".repeat(3000)}`;
+
+    await expect(
+      sendMessageTelegram("123", markdown, {
+        cfg: TELEGRAM_TEST_CFG,
+        token: "tok",
+        onDeliveryResult,
+      }),
+    ).rejects.toThrow("second chunk failed");
+
+    expect(onDeliveryResult.mock.calls.map((call) => call[0]?.messageId)).toEqual(["54"]);
+  });
+
   it("chunks long inline markdown through the HTML text path", async () => {
     botApi.sendMessage.mockResolvedValue({ message_id: 52, chat: { id: "123" } });
     const markdown = `**${"A".repeat(70_000)}**`;

--- a/extensions/telegram/src/send.ts
+++ b/extensions/telegram/src/send.ts
@@ -144,6 +144,8 @@ type TelegramSendOpts = {
   buttons?: TelegramInlineButtons;
   /** Send image as document to avoid Telegram compression. Defaults to false. */
   forceDocument?: boolean;
+  /** Persist each concrete platform send before any later chunk can fail. */
+  onDeliveryResult?: (result: TelegramSendResult) => Promise<void> | void;
 };
 
 type TelegramSendResult = {
@@ -715,6 +717,12 @@ export async function sendMessageTelegram(
     verbose: opts.verbose,
     gatewayClientScopes: opts.gatewayClientScopes,
   });
+  const reportDelivery = async (messageId: string | number, deliveredChatId: string | number) => {
+    await opts.onDeliveryResult?.({
+      messageId: String(messageId),
+      chatId: String(deliveredChatId),
+    });
+  };
   const mediaUrl = opts.mediaUrl?.trim();
   const mediaMaxBytes =
     opts.maxBytes ??
@@ -892,6 +900,7 @@ export async function sendMessageTelegram(
       );
       const messageId = resolveTelegramMessageIdOrThrow(res, context);
       recordSentMessage(chatId, messageId, cfg);
+      await reportDelivery(messageId, res?.chat?.id ?? chatId);
       await recordOutboundMessageForPromptContext({
         cfg,
         account,
@@ -1072,6 +1081,7 @@ export async function sendMessageTelegram(
           );
           const fallbackMessageId = resolveTelegramMessageIdOrThrow(plainResult.result, context);
           recordSentMessage(chatId, fallbackMessageId, cfg);
+          await reportDelivery(fallbackMessageId, plainResult.result?.chat?.id ?? chatId);
           await recordOutboundMessageForPromptContext({
             cfg,
             account,
@@ -1095,6 +1105,7 @@ export async function sendMessageTelegram(
       }
       const messageId = resolveTelegramMessageIdOrThrow(result, context);
       recordSentMessage(chatId, messageId, cfg);
+      await reportDelivery(messageId, result?.chat?.id ?? chatId);
       await recordOutboundMessageForPromptContext({
         cfg,
         account,
@@ -1350,6 +1361,7 @@ export async function sendMessageTelegram(
     const mediaMessageId = resolveTelegramMessageIdOrThrow(result, "media send");
     const resolvedChatId = String(result?.chat?.id ?? chatId);
     recordSentMessage(chatId, mediaMessageId, cfg);
+    await reportDelivery(mediaMessageId, resolvedChatId);
     await recordOutboundMessageForPromptContext({
       cfg,
       account,

--- a/extensions/twitch/src/outbound.test.ts
+++ b/extensions/twitch/src/outbound.test.ts
@@ -228,6 +228,40 @@ describe("outbound", () => {
         { capability: "afterCommit", status: "not_declared" },
       ]);
     });
+
+    it("adapts outbound progress into message receipts", async () => {
+      const progress = {
+        channel: "twitch",
+        messageId: "twitch-progress-1",
+        receipt: twitchTestReceipt("twitch-progress-1"),
+      };
+      const sendText = twitchOutbound.sendText;
+      if (!sendText) {
+        throw new Error("Twitch text sending is not available.");
+      }
+      const sendSpy = vi.spyOn(twitchOutbound, "sendText").mockImplementationOnce(async (ctx) => {
+        await ctx.onDeliveryResult?.(progress);
+        return progress;
+      });
+      const onDeliveryResult = vi.fn();
+
+      try {
+        await twitchMessageAdapter.send?.text?.({
+          cfg: mockConfig,
+          to: "#testchannel",
+          text: "Hello Twitch!",
+          accountId: "default",
+          onDeliveryResult,
+        });
+      } finally {
+        sendSpy.mockRestore();
+      }
+
+      expect(onDeliveryResult).toHaveBeenCalledOnce();
+      expect(onDeliveryResult.mock.calls[0]?.[0]?.receipt.platformMessageIds).toEqual([
+        "twitch-progress-1",
+      ]);
+    });
   });
 
   describe("resolveTarget", () => {

--- a/extensions/twitch/src/outbound.ts
+++ b/extensions/twitch/src/outbound.ts
@@ -229,13 +229,35 @@ export const twitchMessageAdapter = defineChannelMessageAdapter({
       if (!twitchOutbound.sendText) {
         throw new Error("Twitch text sending is not available.");
       }
-      return toTwitchMessageSendResult(await twitchOutbound.sendText(ctx), "text");
+      const { onDeliveryResult, ...outboundCtx } = ctx;
+      const result = await twitchOutbound.sendText({
+        ...outboundCtx,
+        ...(onDeliveryResult
+          ? {
+              onDeliveryResult: async (progress) => {
+                await onDeliveryResult(toTwitchMessageSendResult(progress, "text"));
+              },
+            }
+          : {}),
+      });
+      return toTwitchMessageSendResult(result, "text");
     },
     media: async (ctx) => {
       if (!twitchOutbound.sendMedia) {
         throw new Error("Twitch media sending is not available.");
       }
-      return toTwitchMessageSendResult(await twitchOutbound.sendMedia(ctx), "media");
+      const { onDeliveryResult, ...outboundCtx } = ctx;
+      const result = await twitchOutbound.sendMedia({
+        ...outboundCtx,
+        ...(onDeliveryResult
+          ? {
+              onDeliveryResult: async (progress) => {
+                await onDeliveryResult(toTwitchMessageSendResult(progress, "media"));
+              },
+            }
+          : {}),
+      });
+      return toTwitchMessageSendResult(result, "media");
     },
   },
 });

--- a/extensions/whatsapp/src/channel-outbound.test.ts
+++ b/extensions/whatsapp/src/channel-outbound.test.ts
@@ -203,6 +203,7 @@ describe("whatsappChannelOutbound", () => {
       cfg: {},
       accountId: undefined,
       gifPlayback: undefined,
+      onDeliveryResult: expect.any(Function),
       preserveLeadingWhitespace: true,
     });
   });

--- a/extensions/whatsapp/src/channel-outbound.ts
+++ b/extensions/whatsapp/src/channel-outbound.ts
@@ -77,12 +77,16 @@ export const whatsappMessageAdapter = defineChannelMessageAdapter({
     },
   },
   send: {
-    text: async (ctx) =>
-      toWhatsAppMessageSendResult(
-        await whatsappChannelOutbound.sendText!({
-          ...ctx,
-        }),
-        ctx.replyToId,
-      ),
+    text: async ({ onDeliveryResult, ...ctx }) => {
+      const result = await whatsappChannelOutbound.sendText!({
+        ...ctx,
+        onDeliveryResult: onDeliveryResult
+          ? async (progress) => {
+              await onDeliveryResult(toWhatsAppMessageSendResult(progress, ctx.replyToId));
+            }
+          : undefined,
+      });
+      return toWhatsAppMessageSendResult(result, ctx.replyToId);
+    },
   },
 });

--- a/extensions/whatsapp/src/outbound-base.test.ts
+++ b/extensions/whatsapp/src/outbound-base.test.ts
@@ -106,6 +106,41 @@ describe("createWhatsAppOutboundBase", () => {
     expect(options.accountId).toBe("default");
   });
 
+  it("forwards internal send progress with channel identity", async () => {
+    const sendMessageWhatsApp = vi.fn(async (_to, _text, options) => {
+      await options.onDeliveryResult?.({
+        messageId: "msg-voice",
+        toJid: "15551234567@s.whatsapp.net",
+      });
+      return {
+        messageId: "msg-caption",
+        toJid: "15551234567@s.whatsapp.net",
+      };
+    });
+    const outbound = createWhatsAppOutboundBase({
+      chunker: (text) => [text],
+      sendMessageWhatsApp,
+      sendPollWhatsApp: vi.fn(),
+      shouldLogVerbose: () => false,
+      resolveTarget: ({ to }) => ({ ok: true as const, to: to ?? "" }),
+    });
+    const onDeliveryResult = vi.fn();
+
+    await outbound.sendMedia!({
+      cfg: {} as never,
+      to: "whatsapp:+15551234567",
+      text: "voice",
+      mediaUrl: "/tmp/voice.ogg",
+      onDeliveryResult,
+    });
+
+    expect(onDeliveryResult).toHaveBeenCalledWith({
+      channel: "whatsapp",
+      messageId: "msg-voice",
+      toJid: "15551234567@s.whatsapp.net",
+    });
+  });
+
   it("uses the configured default account for quote metadata lookup when accountId is omitted", async () => {
     cacheInboundMessageMeta("work", "15551234567@s.whatsapp.net", "reply-1", {
       participant: "111@s.whatsapp.net",

--- a/extensions/whatsapp/src/outbound-base.ts
+++ b/extensions/whatsapp/src/outbound-base.ts
@@ -7,6 +7,7 @@ import {
 } from "openclaw/plugin-sdk/account-core";
 import { resolveOutboundSendDep } from "openclaw/plugin-sdk/channel-outbound";
 import {
+  attachChannelToResult,
   createAttachedChannelResultAdapter,
   type ChannelOutboundAdapter,
 } from "openclaw/plugin-sdk/channel-send-result";
@@ -43,6 +44,8 @@ type WhatsAppSendTextOptions = {
     messageText?: string;
   };
   preserveLeadingWhitespace?: boolean;
+  /** Report each accepted internal platform send before the next fallible send. */
+  onDeliveryResult?: (result: { messageId: string; toJid: string }) => Promise<void> | void;
 };
 type WhatsAppSendMessage = (
   to: string,
@@ -159,7 +162,16 @@ export function createWhatsAppOutboundBase({
     resolveTarget,
     ...createAttachedChannelResultAdapter({
       channel: "whatsapp",
-      sendText: async ({ cfg, to, text, accountId, deps, gifPlayback, replyToId }) => {
+      sendText: async ({
+        cfg,
+        to,
+        text,
+        accountId,
+        deps,
+        gifPlayback,
+        replyToId,
+        onDeliveryResult,
+      }) => {
         const normalizedText = normalizeText(text);
         if (skipEmptyText && !normalizedText) {
           return { messageId: "" };
@@ -180,7 +192,14 @@ export function createWhatsAppOutboundBase({
           cfg,
           accountId: accountId ?? undefined,
           gifPlayback,
-          quotedMessageKey,
+          ...(quotedMessageKey ? { quotedMessageKey } : {}),
+          ...(onDeliveryResult
+            ? {
+                onDeliveryResult: async (result) => {
+                  await onDeliveryResult(attachChannelToResult("whatsapp", result));
+                },
+              }
+            : {}),
         });
       },
       sendMedia: async ({
@@ -197,6 +216,7 @@ export function createWhatsAppOutboundBase({
         gifPlayback,
         forceDocument,
         replyToId,
+        onDeliveryResult,
       }) => {
         const lookupAccountId = resolveQuoteLookupAccountId(cfg, accountId);
         const quotedMessageKey = resolveQuotedMessageKey({
@@ -220,7 +240,14 @@ export function createWhatsAppOutboundBase({
           accountId: accountId ?? undefined,
           gifPlayback,
           forceDocument,
-          quotedMessageKey,
+          ...(quotedMessageKey ? { quotedMessageKey } : {}),
+          ...(onDeliveryResult
+            ? {
+                onDeliveryResult: async (result) => {
+                  await onDeliveryResult(attachChannelToResult("whatsapp", result));
+                },
+              }
+            : {}),
         });
       },
       sendPoll: async ({ cfg, to, poll, accountId }) =>

--- a/extensions/whatsapp/src/send.test.ts
+++ b/extensions/whatsapp/src/send.test.ts
@@ -299,6 +299,33 @@ describe("web outbound", () => {
     expect(sendMessage).toHaveBeenNthCalledWith(2, "+1555", "voice note", undefined, undefined);
   });
 
+  it("reports the accepted voice send before a caption failure", async () => {
+    const buf = Buffer.from("audio");
+    loadWebMediaMock.mockResolvedValueOnce({
+      buffer: buf,
+      contentType: "audio/ogg",
+      kind: "audio",
+    });
+    sendMessage
+      .mockResolvedValueOnce(createAcceptedWhatsAppSendResult("media", "voice-accepted"))
+      .mockRejectedValueOnce(new Error("caption failed"));
+    const onDeliveryResult = vi.fn();
+
+    await expect(
+      sendMessageWhatsApp("+1555", "voice note", {
+        verbose: false,
+        cfg: WHATSAPP_TEST_CFG,
+        mediaUrl: "/tmp/voice.ogg",
+        onDeliveryResult,
+      }),
+    ).rejects.toThrow("caption failed");
+
+    expect(onDeliveryResult).toHaveBeenCalledOnce();
+    expect(onDeliveryResult).toHaveBeenCalledWith(
+      expect.objectContaining({ messageId: "voice-accepted" }),
+    );
+  });
+
   it.each([
     { name: "mp3", contentType: "audio/mpeg", fileName: "voice.mp3" },
     { name: "webm", contentType: "audio/webm", fileName: "voice.webm" },

--- a/extensions/whatsapp/src/send.ts
+++ b/extensions/whatsapp/src/send.ts
@@ -150,6 +150,8 @@ export async function sendMessageWhatsApp(
       messageText?: string;
     };
     preserveLeadingWhitespace?: boolean;
+    /** Report each accepted internal platform send before the next fallible send. */
+    onDeliveryResult?: (result: { messageId: string; toJid: string }) => Promise<void> | void;
   },
 ): Promise<{ messageId: string; toJid: string }> {
   let text = options.preserveLeadingWhitespace ? body : normalizeWhatsAppPayloadText(body);
@@ -244,15 +246,20 @@ export async function sendMessageWhatsApp(
     const result = sendOptions
       ? await active.sendMessage(to, text, mediaBuffer, mediaType, sendOptions)
       : await active.sendMessage(to, text, mediaBuffer, mediaType);
-    if (visibleTextAfterVoice) {
-      if (sendOptions) {
-        await active.sendMessage(to, visibleTextAfterVoice, undefined, undefined, sendOptions);
-      } else {
-        await active.sendMessage(to, visibleTextAfterVoice, undefined, undefined);
-      }
-    }
     const messageId = (result as { messageId?: string })?.messageId ?? "unknown";
     const sentRemoteJid = resolveActualSentRemoteJid(result, jid);
+    if (visibleTextAfterVoice) {
+      // Voice captions require a second platform send. Persist the accepted voice
+      // first so a caption failure cannot make recovery replay the voice note.
+      await options.onDeliveryResult?.({ messageId, toJid: sentRemoteJid });
+      const captionResult = sendOptions
+        ? await active.sendMessage(to, visibleTextAfterVoice, undefined, undefined, sendOptions)
+        : await active.sendMessage(to, visibleTextAfterVoice, undefined, undefined);
+      await options.onDeliveryResult?.({
+        messageId: (captionResult as { messageId?: string })?.messageId ?? "unknown",
+        toJid: resolveActualSentRemoteJid(captionResult, jid),
+      });
+    }
     if (messageId && messageId !== "unknown" && text) {
       registerWhatsAppApprovalReactionTargetForOutboundMessage({
         accountId: resolvedAccountId,

--- a/extensions/zalo/src/channel.ts
+++ b/extensions/zalo/src/channel.ts
@@ -304,6 +304,7 @@ export const zaloPlugin: ChannelPlugin<ResolvedZaloAccount, ZaloProbeResult> =
           sendText: (nextCtx) => zaloRawSendResultAdapter.sendText!(nextCtx),
           sendMedia: (nextCtx) => zaloRawSendResultAdapter.sendMedia!(nextCtx),
           emptyResult: createEmptyChannelResult("zalo"),
+          onResult: ctx.onDeliveryResult,
         }),
       ...zaloRawSendResultAdapter,
     },

--- a/extensions/zalouser/src/channel.adapters.ts
+++ b/extensions/zalouser/src/channel.adapters.ts
@@ -1,10 +1,14 @@
 // Zalouser plugin module implements channel.adapters behavior.
 import { createScopedDmSecurityResolver } from "openclaw/plugin-sdk/channel-config-helpers";
-import { defineChannelMessageAdapter } from "openclaw/plugin-sdk/channel-outbound";
+import {
+  defineChannelMessageAdapter,
+  type ChannelMessageSendResult,
+} from "openclaw/plugin-sdk/channel-outbound";
 import { createPairingPrefixStripper } from "openclaw/plugin-sdk/channel-pairing";
 import {
   createEmptyChannelResult,
-  createRawChannelSendResultAdapter,
+  type ChannelOutboundAdapter,
+  type OutboundDeliveryResult,
 } from "openclaw/plugin-sdk/channel-send-result";
 import { createStaticReplyToModeResolver } from "openclaw/plugin-sdk/conversation-runtime";
 import { createLazyRuntimeModule } from "openclaw/plugin-sdk/lazy-runtime";
@@ -40,6 +44,7 @@ import {
   parseZalouserOutboundTarget,
   resolveZalouserOutboundSessionRoute,
 } from "./session-route.js";
+import type { ZaloSendResult } from "./types.js";
 
 const loadZalouserChannelRuntime = createLazyRuntimeModule(() => import("./channel.runtime.js"));
 
@@ -50,6 +55,7 @@ type ZalouserSendTextContext = {
   text: string;
   accountId?: string | null;
   cfg: OpenClawConfig;
+  onDeliveryResult?: (result: ChannelMessageSendResult) => Promise<void> | void;
 };
 
 type ZalouserSendMediaContext = ZalouserSendTextContext & {
@@ -74,6 +80,13 @@ function resolveZalouserOutboundTextChunkLimit(cfg: OpenClawConfig, accountId?: 
   return getZalouserRuntime().channel.text.resolveTextChunkLimit(cfg, "zalouser", accountId, {
     fallbackLimit: ZALOUSER_TEXT_CHUNK_LIMIT,
   });
+}
+
+function toZalouserMessageSendResult(result: ZaloSendResult): ChannelMessageSendResult {
+  return {
+    messageId: result.messageId,
+    receipt: result.receipt,
+  };
 }
 
 function resolveZalouserGroupPolicyEntry(params: ChannelGroupContext) {
@@ -107,17 +120,27 @@ function resolveZalouserRequireMention(params: ChannelGroupContext): boolean {
   return true;
 }
 
-async function sendZalouserTextFromContext({ to, text, accountId, cfg }: ZalouserSendTextContext) {
+async function sendZalouserTextFromContext({
+  to,
+  text,
+  accountId,
+  cfg,
+  onDeliveryResult,
+}: ZalouserSendTextContext) {
   const { sendMessageZalouser } = await loadZalouserChannelRuntime();
   const account = resolveZalouserAccountSync({ cfg, accountId });
   const target = parseZalouserOutboundTarget(to);
-  return await sendMessageZalouser(target.threadId, text, {
+  const result = await sendMessageZalouser(target.threadId, text, {
     profile: account.profile,
     isGroup: target.isGroup,
     textMode: "markdown",
     textChunkMode: resolveZalouserOutboundChunkMode(cfg, account.accountId),
     textChunkLimit: resolveZalouserOutboundTextChunkLimit(cfg, account.accountId),
+    onDeliveryResult: async (progress) => {
+      await onDeliveryResult?.(toZalouserMessageSendResult(progress));
+    },
   });
+  return toZalouserMessageSendResult(result);
 }
 
 async function sendZalouserMediaFromContext({
@@ -128,11 +151,12 @@ async function sendZalouserMediaFromContext({
   cfg,
   mediaLocalRoots,
   mediaReadFile,
+  onDeliveryResult,
 }: ZalouserSendMediaContext) {
   const { sendMessageZalouser } = await loadZalouserChannelRuntime();
   const account = resolveZalouserAccountSync({ cfg, accountId });
   const target = parseZalouserOutboundTarget(to);
-  return await sendMessageZalouser(target.threadId, text, {
+  const result = await sendMessageZalouser(target.threadId, text, {
     profile: account.profile,
     isGroup: target.isGroup,
     mediaUrl,
@@ -141,14 +165,51 @@ async function sendZalouserMediaFromContext({
     textMode: "markdown",
     textChunkMode: resolveZalouserOutboundChunkMode(cfg, account.accountId),
     textChunkLimit: resolveZalouserOutboundTextChunkLimit(cfg, account.accountId),
+    onDeliveryResult: async (progress) => {
+      await onDeliveryResult?.(toZalouserMessageSendResult(progress));
+    },
+  });
+  return toZalouserMessageSendResult(result);
+}
+
+function adaptZalouserOutboundProgress(
+  onDeliveryResult: ((result: OutboundDeliveryResult) => Promise<void> | void) | undefined,
+) {
+  return onDeliveryResult
+    ? async (result: ChannelMessageSendResult) => {
+        await onDeliveryResult(toZalouserOutboundDeliveryResult(result));
+      }
+    : undefined;
+}
+
+function toZalouserOutboundDeliveryResult(
+  result: ChannelMessageSendResult,
+): OutboundDeliveryResult {
+  return createEmptyChannelResult("zalouser", {
+    messageId:
+      result.messageId ??
+      result.receipt.primaryPlatformMessageId ??
+      result.receipt.platformMessageIds[0],
+    receipt: result.receipt,
   });
 }
 
-const zalouserRawSendResultAdapter = createRawChannelSendResultAdapter({
-  channel: "zalouser",
-  sendText: sendZalouserTextFromContext,
-  sendMedia: sendZalouserMediaFromContext,
-});
+const zalouserRawSendResultAdapter: Pick<ChannelOutboundAdapter, "sendText" | "sendMedia"> = {
+  sendText: async ({ onDeliveryResult, ...ctx }) =>
+    toZalouserOutboundDeliveryResult(
+      await sendZalouserTextFromContext({
+        ...ctx,
+        onDeliveryResult: adaptZalouserOutboundProgress(onDeliveryResult),
+      }),
+    ),
+  sendMedia: async ({ onDeliveryResult, ...ctx }) =>
+    toZalouserOutboundDeliveryResult(
+      await sendZalouserMediaFromContext({
+        ...ctx,
+        onDeliveryResult: adaptZalouserOutboundProgress(onDeliveryResult),
+      }),
+    ),
+};
 
 export const zalouserMessageAdapter = defineChannelMessageAdapter({
   id: "zalouser",

--- a/extensions/zalouser/src/channel.sendpayload.test.ts
+++ b/extensions/zalouser/src/channel.sendpayload.test.ts
@@ -193,6 +193,59 @@ describe("zalouserPlugin outbound sendPayload", () => {
     expect(result.messageId).toBe("zlu-code");
   });
 
+  it("forwards internal chunk progress through the outbound adapter", async () => {
+    mockedSend.mockImplementationOnce(async (_threadId, _text, options) => {
+      const onDeliveryResult = options?.onDeliveryResult;
+      if (!onDeliveryResult) {
+        throw new Error("missing progress callback");
+      }
+      await onDeliveryResult({ ok: true, messageId: "zlu-part-1" } as never);
+      await onDeliveryResult({ ok: true, messageId: "zlu-part-2" } as never);
+      return { ok: true, messageId: "zlu-part-2" } as never;
+    });
+    const onDeliveryResult = vi.fn();
+    const sendPayload = requireZalouserSendPayload();
+
+    await sendPayload({
+      ...baseCtx({ text: "chunked internally" }),
+      to: "987654321",
+      onDeliveryResult,
+    });
+
+    expect(onDeliveryResult.mock.calls.map((call) => call[0]?.messageId)).toEqual([
+      "zlu-part-1",
+      "zlu-part-2",
+    ]);
+  });
+
+  it("forwards internal chunk progress through the message adapter", async () => {
+    const receipt = createMessageReceiptFromOutboundResults({
+      results: [{ channel: "zalouser", messageId: "zlu-message-part" }],
+      kind: "text",
+    });
+    mockedSend.mockImplementationOnce(async (_threadId, _text, options) => {
+      const onDeliveryResult = options?.onDeliveryResult;
+      if (!onDeliveryResult) {
+        throw new Error("missing progress callback");
+      }
+      await onDeliveryResult({ ok: true, messageId: "zlu-message-part", receipt } as never);
+      return { ok: true, messageId: "zlu-message-part", receipt } as never;
+    });
+    const onDeliveryResult = vi.fn();
+    const sendText = requireZalouserTextSender(requireZalouserMessageAdapter());
+
+    await sendText({
+      cfg: {},
+      to: "user:987654321",
+      text: "chunked internally",
+      onDeliveryResult,
+    });
+
+    expect(onDeliveryResult).toHaveBeenCalledOnce();
+    expect(onDeliveryResult.mock.calls[0]?.[0]?.messageId).toBe("zlu-message-part");
+    expect(onDeliveryResult.mock.calls[0]?.[0]?.receipt).toBe(receipt);
+  });
+
   it("declares message adapter durable text and media with receipt proofs", async () => {
     mockedSend.mockImplementation(async (_threadId, _text, opts: { mediaUrl?: string } = {}) =>
       opts.mediaUrl

--- a/extensions/zalouser/src/send.test.ts
+++ b/extensions/zalouser/src/send.test.ts
@@ -208,6 +208,26 @@ describe("zalouser send helpers", () => {
     expectResultFields(result, { ok: true, messageId: "mid-2c-2" });
   });
 
+  it("reports each completed internal chunk before a later chunk fails", async () => {
+    const firstResult = sendResult("mid-progress-1", "thread-progress");
+    mockSendText
+      .mockResolvedValueOnce(firstResult)
+      .mockResolvedValueOnce(sendFailure("second chunk failed", "thread-progress"));
+    const onDeliveryResult = vi.fn();
+
+    await expect(
+      sendMessageZalouser("thread-progress", "a".repeat(2001), {
+        textChunkLimit: 2000,
+        onDeliveryResult,
+      }),
+    ).rejects.toThrow("second chunk failed");
+
+    expect(mockSendText).toHaveBeenCalledTimes(2);
+    expect(onDeliveryResult).toHaveBeenCalledOnce();
+    expect(onDeliveryResult).toHaveBeenCalledWith(firstResult);
+    expect(requireSendTextOptions(0)).not.toHaveProperty("onDeliveryResult");
+  });
+
   it("preserves text styles when splitting long formatted markdown", async () => {
     const text = `**${"a".repeat(2501)}**`;
     mockSendText

--- a/extensions/zalouser/src/send.ts
+++ b/extensions/zalouser/src/send.ts
@@ -12,7 +12,10 @@ import {
 } from "./zalo-js.js";
 import { TextStyle } from "./zca-constants.js";
 
-type ZalouserSendOptions = ZaloSendOptions;
+type ZalouserSendOptions = ZaloSendOptions & {
+  /** Persist each concrete platform send before the next internal chunk starts. */
+  onDeliveryResult?: (result: ZaloSendResult) => Promise<void> | void;
+};
 type ZalouserSendResult = ZaloSendResult;
 
 const ZALO_TEXT_LIMIT = 2000;
@@ -30,25 +33,26 @@ export async function sendMessageZalouser(
   text: string,
   options: ZalouserSendOptions = {},
 ): Promise<ZalouserSendResult> {
+  const { onDeliveryResult, ...transportOptions } = options;
   const prepared =
-    options.textMode === "markdown"
+    transportOptions.textMode === "markdown"
       ? parseZalouserTextStyles(text)
-      : { text, styles: options.textStyles };
-  const textChunkLimit = options.textChunkLimit ?? ZALO_TEXT_LIMIT;
+      : { text, styles: transportOptions.textStyles };
+  const textChunkLimit = transportOptions.textChunkLimit ?? ZALO_TEXT_LIMIT;
   const chunks = splitStyledText(
     prepared.text,
     (prepared.styles?.length ?? 0) > 0 ? prepared.styles : undefined,
     textChunkLimit,
-    options.textChunkMode,
+    transportOptions.textChunkMode,
   );
 
   let lastResult: ZalouserSendResult | null = null;
   for (const [index, chunk] of chunks.entries()) {
     const chunkOptions =
       index === 0
-        ? { ...options, textStyles: chunk.styles }
+        ? { ...transportOptions, textStyles: chunk.styles }
         : {
-            ...options,
+            ...transportOptions,
             caption: undefined,
             mediaLocalRoots: undefined,
             mediaUrl: undefined,
@@ -56,8 +60,9 @@ export async function sendMessageZalouser(
           };
     const result = await sendZaloTextMessage(threadId, chunk.text, chunkOptions);
     if (!result.ok) {
-      return result;
+      throw new Error(result.error || "Failed to send Zalouser message");
     }
+    await onDeliveryResult?.(result);
     lastResult = result;
   }
 

--- a/src/channels/message/outbound-bridge.test.ts
+++ b/src/channels/message/outbound-bridge.test.ts
@@ -1,7 +1,10 @@
 // Outbound bridge tests cover channel message handoff from core to outbound adapters.
 import { describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
-import { createChannelMessageAdapterFromOutbound } from "./outbound-bridge.js";
+import {
+  createChannelMessageAdapterFromOutbound,
+  type ChannelMessageOutboundBridgeResult,
+} from "./outbound-bridge.js";
 import type {
   ChannelMessageSendPayloadContext,
   ChannelMessageSendPollContext,
@@ -77,6 +80,35 @@ describe("createChannelMessageAdapterFromOutbound", () => {
         replyToId: "parent-1",
       },
     ]);
+  });
+
+  it("normalizes outbound progress results before forwarding them to message callers", async () => {
+    const sendText = vi.fn(
+      async (request: {
+        onDeliveryResult?: (result: ChannelMessageOutboundBridgeResult) => Promise<void> | void;
+      }) => {
+        await request.onDeliveryResult?.({ channel: "demo", messageId: "chunk-1" });
+        return { channel: "demo", messageId: "chunk-2" };
+      },
+    );
+    const onDeliveryResult = vi.fn();
+    const adapter = createChannelMessageAdapterFromOutbound({ outbound: { sendText } });
+
+    await adapter.send?.text?.({
+      cfg,
+      to: "room-1",
+      text: "hello",
+      onDeliveryResult,
+    });
+
+    expect(onDeliveryResult).toHaveBeenCalledTimes(1);
+    expect(onDeliveryResult).toHaveBeenCalledWith({
+      messageId: "chunk-1",
+      receipt: expect.objectContaining({
+        primaryPlatformMessageId: "chunk-1",
+        platformMessageIds: ["chunk-1"],
+      }),
+    });
   });
 
   it("preserves an outbound receipt instead of rebuilding it", async () => {

--- a/src/channels/message/outbound-bridge.ts
+++ b/src/channels/message/outbound-bridge.ts
@@ -30,22 +30,26 @@ export type ChannelMessageOutboundBridgeResult = MessageReceiptSourceResult & {
   messageId?: string;
 };
 
+type ChannelMessageOutboundBridgeContext<TContext> = Omit<TContext, "onDeliveryResult"> & {
+  onDeliveryResult?: (result: ChannelMessageOutboundBridgeResult) => Promise<void> | void;
+};
+
 /** Legacy outbound adapter shape bridged into the channel message adapter contract. */
 export type ChannelMessageOutboundBridgeAdapter<TConfig = unknown> = {
   deliveryCapabilities?: {
     durableFinal?: DurableFinalDeliveryRequirementMap;
   };
   sendText?: (
-    ctx: ChannelMessageSendTextContext<TConfig>,
+    ctx: ChannelMessageOutboundBridgeContext<ChannelMessageSendTextContext<TConfig>>,
   ) => Promise<ChannelMessageOutboundBridgeResult>;
   sendMedia?: (
-    ctx: ChannelMessageSendMediaContext<TConfig>,
+    ctx: ChannelMessageOutboundBridgeContext<ChannelMessageSendMediaContext<TConfig>>,
   ) => Promise<ChannelMessageOutboundBridgeResult>;
   sendPayload?: (
-    ctx: ChannelMessageSendPayloadContext<TConfig>,
+    ctx: ChannelMessageOutboundBridgeContext<ChannelMessageSendPayloadContext<TConfig>>,
   ) => Promise<ChannelMessageOutboundBridgeResult>;
   sendPoll?: (
-    ctx: ChannelMessageSendPollContext<TConfig>,
+    ctx: ChannelMessageOutboundBridgeContext<ChannelMessageSendPollContext<TConfig>>,
   ) => Promise<ChannelMessageOutboundBridgeResult>;
 };
 
@@ -72,14 +76,16 @@ function resolveResultMessageId(result: ChannelMessageOutboundBridgeResult): str
   );
 }
 
+type MessageSendResultParams = {
+  kind: MessageReceiptPartKind;
+  normalizeReceiptKind?: boolean;
+  threadId?: string | number | null;
+  replyToId?: string | null;
+};
+
 function toMessageSendResult(
   result: ChannelMessageOutboundBridgeResult,
-  params: {
-    kind: MessageReceiptPartKind;
-    normalizeReceiptKind?: boolean;
-    threadId?: string | number | null;
-    replyToId?: string | null;
-  },
+  params: MessageSendResultParams,
 ): ChannelMessageSendResult {
   const receipt = result.receipt
     ? params.normalizeReceiptKind
@@ -99,6 +105,27 @@ function toMessageSendResult(
     ...(resolveResultMessageId({ ...result, receipt })
       ? {
           messageId: resolveResultMessageId({ ...result, receipt }),
+        }
+      : {}),
+  };
+}
+
+function adaptOutboundBridgeContext<
+  TContext extends {
+    onDeliveryResult?: (result: ChannelMessageSendResult) => Promise<void> | void;
+  },
+>(
+  ctx: TContext,
+  resultParams: MessageSendResultParams,
+): ChannelMessageOutboundBridgeContext<TContext> {
+  const { onDeliveryResult, ...outboundCtx } = ctx;
+  return {
+    ...outboundCtx,
+    ...(onDeliveryResult
+      ? {
+          onDeliveryResult: async (result: ChannelMessageOutboundBridgeResult) => {
+            await onDeliveryResult(toMessageSendResult(result, resultParams));
+          },
         }
       : {}),
   };
@@ -131,37 +158,57 @@ export function createChannelMessageAdapterFromOutbound<TConfig = unknown>(
 ): ChannelMessageAdapterShape<TConfig> {
   const send: NonNullable<ChannelMessageAdapterShape<TConfig>["send"]> = {};
   if (params.outbound.sendText) {
-    send.text = async (ctx) =>
-      toMessageSendResult(await params.outbound.sendText!(ctx), {
+    send.text = async (ctx) => {
+      const resultParams = {
         kind: "text",
         threadId: ctx.threadId,
         replyToId: ctx.replyToId,
-      });
+      } satisfies MessageSendResultParams;
+      return toMessageSendResult(
+        await params.outbound.sendText!(adaptOutboundBridgeContext(ctx, resultParams)),
+        resultParams,
+      );
+    };
   }
   if (params.outbound.sendMedia) {
-    send.media = async (ctx) =>
-      toMessageSendResult(await params.outbound.sendMedia!(ctx), {
+    send.media = async (ctx) => {
+      const resultParams = {
         kind: ctx.audioAsVoice ? "voice" : "media",
         threadId: ctx.threadId,
         replyToId: ctx.replyToId,
-      });
+      } satisfies MessageSendResultParams;
+      return toMessageSendResult(
+        await params.outbound.sendMedia!(adaptOutboundBridgeContext(ctx, resultParams)),
+        resultParams,
+      );
+    };
   }
   if (params.outbound.sendPayload) {
-    send.payload = async (ctx) =>
-      toMessageSendResult(await params.outbound.sendPayload!(ctx), {
+    send.payload = async (ctx) => {
+      const resultParams = {
         kind: resolvePayloadReceiptKind(ctx as ChannelMessageSendPayloadContext<unknown>),
         threadId: ctx.threadId,
         replyToId: ctx.replyToId,
-      });
+      } satisfies MessageSendResultParams;
+      return toMessageSendResult(
+        await params.outbound.sendPayload!(adaptOutboundBridgeContext(ctx, resultParams)),
+        resultParams,
+      );
+    };
   }
   if (params.outbound.sendPoll) {
-    send.poll = async (ctx) =>
-      toMessageSendResult(await params.outbound.sendPoll!(ctx), {
+    send.poll = async (ctx) => {
+      const resultParams = {
         kind: "poll",
         normalizeReceiptKind: true,
         threadId: ctx.threadId,
         replyToId: ctx.replyToId,
-      });
+      } satisfies MessageSendResultParams;
+      return toMessageSendResult(
+        await params.outbound.sendPoll!(adaptOutboundBridgeContext(ctx, resultParams)),
+        resultParams,
+      );
+    };
   }
 
   return {

--- a/src/channels/message/types.ts
+++ b/src/channels/message/types.ts
@@ -179,6 +179,8 @@ export type ChannelMessageSendTextContext<TConfig = OpenClawConfig> = {
   silent?: boolean;
   signal?: AbortSignal;
   gatewayClientScopes?: readonly string[];
+  /** @internal Report each completed platform sub-send before another fallible step. */
+  onDeliveryResult?: (result: ChannelMessageSendResult) => Promise<void> | void;
 };
 
 /** Media send context with validated access hooks and media presentation hints. */

--- a/src/channels/plugins/outbound.types.ts
+++ b/src/channels/plugins/outbound.types.ts
@@ -40,6 +40,8 @@ export type ChannelOutboundContext = {
   deps?: OutboundSendDeps;
   silent?: boolean;
   gatewayClientScopes?: readonly string[];
+  /** @internal Report each completed platform sub-send before starting another fallible step. */
+  onDeliveryResult?: (result: OutboundDeliveryResult) => Promise<void> | void;
 };
 
 export type ChannelOutboundPayloadContext = ChannelOutboundContext & {

--- a/src/infra/heartbeat-runner.respects-ackmaxchars-heartbeat-acks.test.ts
+++ b/src/infra/heartbeat-runner.respects-ackmaxchars-heartbeat-acks.test.ts
@@ -116,6 +116,7 @@ describe("runHeartbeatOnce ack handling", () => {
           mediaAccess: {},
           mediaLocalRoots: undefined,
           mediaReadFile: undefined,
+          onDeliveryResult: expect.any(Function),
           replyToIdSource: undefined,
           replyToMode: undefined,
           silent: undefined,

--- a/src/infra/outbound/deliver.queue-integration.test.ts
+++ b/src/infra/outbound/deliver.queue-integration.test.ts
@@ -7,7 +7,12 @@ import {
   setActivePluginRegistry,
 } from "../../plugins/runtime.js";
 import { createOutboundTestPlugin, createTestRegistry } from "../../test-utils/channel-plugins.js";
-import { drainPendingDeliveries, type DeliverFn, loadPendingDeliveries } from "./delivery-queue.js";
+import {
+  drainPendingDeliveries,
+  type DeliverFn,
+  enqueueDelivery,
+  loadPendingDeliveries,
+} from "./delivery-queue.js";
 import {
   createRecoveryLog,
   installDeliveryQueueTmpDirHooks,
@@ -120,6 +125,33 @@ describe("deliverOutboundPayloads queue integration: mid-batch failure with send
     expect(entry.retryCount).toBe(0);
     expect(entry.lastError).toBeUndefined();
     expect(sendMatrix).toHaveBeenCalledTimes(2);
+  });
+
+  it("marks an existing recovery entry before crossing the platform send boundary", async () => {
+    const id = await enqueueDelivery(
+      { channel: "matrix", to: "!room:example", payloads: [{ text: "recovered" }] },
+      tmpDir,
+    );
+    let stateAtSend: string | undefined;
+    const sendMatrix = vi.fn(async () => {
+      stateAtSend = (await loadPendingDeliveries(tmpDir))[0]?.recoveryState;
+      return { messageId: "m1" };
+    });
+
+    await deliverOutboundPayloads({
+      cfg: {} as OpenClawConfig,
+      channel: "matrix",
+      to: "!room:example",
+      payloads: [{ text: "recovered" }],
+      deps: { matrix: sendMatrix },
+      skipQueue: true,
+      deferCommitHooks: true,
+      deliveryQueueId: id,
+      deliveryQueueStateDir: tmpDir,
+    });
+
+    expect(stateAtSend).toBe("send_attempt_started");
+    expect((await loadPendingDeliveries(tmpDir))[0]?.recoveryState).toBe("send_attempt_started");
   });
 
   it("drain does not replay an unknown_after_send entry when no adapter reconciliation is available", async () => {

--- a/src/infra/outbound/deliver.queue-integration.test.ts
+++ b/src/infra/outbound/deliver.queue-integration.test.ts
@@ -7,12 +7,7 @@ import {
   setActivePluginRegistry,
 } from "../../plugins/runtime.js";
 import { createOutboundTestPlugin, createTestRegistry } from "../../test-utils/channel-plugins.js";
-import {
-  drainPendingDeliveries,
-  type DeliverFn,
-  enqueueDelivery,
-  loadPendingDeliveries,
-} from "./delivery-queue.js";
+import { drainPendingDeliveries, type DeliverFn, loadPendingDeliveries } from "./delivery-queue.js";
 import {
   createRecoveryLog,
   installDeliveryQueueTmpDirHooks,
@@ -62,7 +57,7 @@ async function drainMatrixReconnect(opts: { deliver: DeliverFn; stateDir: string
     log: createRecoveryLog(),
     stateDir: opts.stateDir,
     deliver: opts.deliver,
-    selectEntry: (entry) => ({ match: entry.channel === "matrix" }),
+    selectEntry: (entry) => ({ match: entry.channel === "matrix", bypassBackoff: true }),
   });
 }
 
@@ -114,44 +109,27 @@ describe("deliverOutboundPayloads queue integration: mid-batch failure with send
   });
 
   it("advances queued entry to unknown_after_send when a later payload fails after an earlier one succeeded", async () => {
-    const sendMatrix = createPartialSendFailure();
+    let sendCount = 0;
+    let stateBeforeSecondSend: string | undefined;
+    const sendMatrix = vi.fn(async () => {
+      sendCount += 1;
+      if (sendCount === 1) {
+        return { messageId: "m1" };
+      }
+      stateBeforeSecondSend = (await loadPendingDeliveries(tmpDir))[0]?.recoveryState;
+      throw new Error("second payload send failed");
+    });
 
     await deliverPartialMatrixBatch(sendMatrix, tmpDir);
 
+    expect(stateBeforeSecondSend).toBe("unknown_after_send");
     const entries = await loadPendingDeliveries(tmpDir);
     expect(entries).toHaveLength(1);
     const entry = entries[0];
     expect(entry.recoveryState).toBe("unknown_after_send");
-    expect(entry.retryCount).toBe(0);
-    expect(entry.lastError).toBeUndefined();
+    expect(entry.retryCount).toBe(1);
+    expect(entry.lastError).toContain("second payload send failed");
     expect(sendMatrix).toHaveBeenCalledTimes(2);
-  });
-
-  it("marks an existing recovery entry before crossing the platform send boundary", async () => {
-    const id = await enqueueDelivery(
-      { channel: "matrix", to: "!room:example", payloads: [{ text: "recovered" }] },
-      tmpDir,
-    );
-    let stateAtSend: string | undefined;
-    const sendMatrix = vi.fn(async () => {
-      stateAtSend = (await loadPendingDeliveries(tmpDir))[0]?.recoveryState;
-      return { messageId: "m1" };
-    });
-
-    await deliverOutboundPayloads({
-      cfg: {} as OpenClawConfig,
-      channel: "matrix",
-      to: "!room:example",
-      payloads: [{ text: "recovered" }],
-      deps: { matrix: sendMatrix },
-      skipQueue: true,
-      deferCommitHooks: true,
-      deliveryQueueId: id,
-      deliveryQueueStateDir: tmpDir,
-    });
-
-    expect(stateAtSend).toBe("send_attempt_started");
-    expect((await loadPendingDeliveries(tmpDir))[0]?.recoveryState).toBe("send_attempt_started");
   });
 
   it("drain does not replay an unknown_after_send entry when no adapter reconciliation is available", async () => {
@@ -169,7 +147,7 @@ describe("deliverOutboundPayloads queue integration: mid-batch failure with send
     expect(await loadPendingDeliveries(tmpDir)).toHaveLength(0);
   });
 
-  it("leaves entry for retry in send_attempt_started when no send evidence exists", async () => {
+  it("retains retryable send-attempt state when an adapter fails before returning a result", async () => {
     process.env.OPENCLAW_STATE_DIR = tmpDir;
     const sendMatrix = vi.fn().mockRejectedValueOnce(new Error("first payload send failed"));
 

--- a/src/infra/outbound/deliver.test.ts
+++ b/src/infra/outbound/deliver.test.ts
@@ -4,6 +4,7 @@ import path from "node:path";
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { chunkText } from "../../auto-reply/chunk.js";
 import { createMessageReceiptFromOutboundResults } from "../../channels/message/receipt.js";
+import type { ChannelMessageSendTextContext } from "../../channels/message/types.js";
 import type { ChannelOutboundAdapter } from "../../channels/plugins/types.js";
 import type { OpenClawConfig } from "../../config/config.js";
 import type { SessionTranscriptAppendResult } from "../../config/sessions/transcript.js";
@@ -55,6 +56,7 @@ const queueMocks = vi.hoisted(() => ({
   enqueueDelivery: vi.fn(async () => "mock-queue-id"),
   ackDelivery: vi.fn(async () => {}),
   failDelivery: vi.fn(async () => {}),
+  failDeliveryAfterPlatformSend: vi.fn(async () => {}),
   markDeliveryPlatformOutcomeUnknown: vi.fn(async () => {}),
   markDeliveryPlatformSendAttemptStarted: vi.fn(async () => {}),
   withActiveDeliveryClaim: vi.fn<
@@ -97,6 +99,7 @@ vi.mock("./delivery-queue.js", () => ({
   enqueueDelivery: queueMocks.enqueueDelivery,
   ackDelivery: queueMocks.ackDelivery,
   failDelivery: queueMocks.failDelivery,
+  failDeliveryAfterPlatformSend: queueMocks.failDeliveryAfterPlatformSend,
   markDeliveryPlatformOutcomeUnknown: queueMocks.markDeliveryPlatformOutcomeUnknown,
   markDeliveryPlatformSendAttemptStarted: queueMocks.markDeliveryPlatformSendAttemptStarted,
   withActiveDeliveryClaim: queueMocks.withActiveDeliveryClaim,
@@ -319,6 +322,8 @@ describe("deliverOutboundPayloads", () => {
     queueMocks.ackDelivery.mockResolvedValue(undefined);
     queueMocks.failDelivery.mockClear();
     queueMocks.failDelivery.mockResolvedValue(undefined);
+    queueMocks.failDeliveryAfterPlatformSend.mockClear();
+    queueMocks.failDeliveryAfterPlatformSend.mockResolvedValue(undefined);
     queueMocks.markDeliveryPlatformOutcomeUnknown.mockClear();
     queueMocks.markDeliveryPlatformOutcomeUnknown.mockResolvedValue(undefined);
     queueMocks.markDeliveryPlatformSendAttemptStarted.mockClear();
@@ -638,9 +643,6 @@ describe("deliverOutboundPayloads", () => {
     queueMocks.ackDelivery.mockImplementationOnce(async () => {
       order.push("ack");
     });
-    queueMocks.markDeliveryPlatformSendAttemptStarted.mockImplementationOnce(async () => {
-      order.push("mark-started");
-    });
     queueMocks.markDeliveryPlatformOutcomeUnknown.mockImplementationOnce(async () => {
       order.push("mark-unknown");
     });
@@ -707,7 +709,6 @@ describe("deliverOutboundPayloads", () => {
     expect(order).toEqual([
       "queue",
       "before",
-      "mark-started",
       "send",
       "after:pending-1:message-adapter-1",
       "mark-unknown",
@@ -757,9 +758,38 @@ describe("deliverOutboundPayloads", () => {
 
     expect(results).toStrictEqual([]);
     expect(sendMatrix).not.toHaveBeenCalled();
-    expect(queueMocks.markDeliveryPlatformSendAttemptStarted).not.toHaveBeenCalled();
     expect(queueMocks.markDeliveryPlatformOutcomeUnknown).not.toHaveBeenCalled();
     expect(queueMocks.ackDelivery).toHaveBeenCalledWith("mock-queue-id");
+  });
+
+  it("keeps a canceled zero-result delivery retryable when queue ack fails", async () => {
+    hookMocks.runner.hasHooks.mockImplementation(
+      (hookName?: string) => hookName === "message_sending",
+    );
+    hookMocks.runner.runMessageSending.mockResolvedValueOnce({
+      cancel: true,
+      content: "blocked",
+    });
+    queueMocks.ackDelivery.mockRejectedValueOnce(new Error("ack offline"));
+    const sendMatrix = vi.fn();
+
+    const results = await deliverOutboundPayloads({
+      cfg: {},
+      channel: "matrix",
+      to: "!room:example",
+      payloads: [{ text: "hello" }],
+      deps: { matrix: sendMatrix },
+      queuePolicy: "best_effort",
+    });
+
+    expect(results).toStrictEqual([]);
+    expect(sendMatrix).not.toHaveBeenCalled();
+    expect(queueMocks.failDelivery).toHaveBeenCalledWith(
+      "mock-queue-id",
+      expect.stringContaining("failed to ack unsent delivery"),
+    );
+    expect(queueMocks.failDeliveryAfterPlatformSend).not.toHaveBeenCalled();
+    expect(queueMocks.markDeliveryPlatformOutcomeUnknown).not.toHaveBeenCalled();
   });
 
   it("runs message adapter failure cleanup for failed sends with pending attempt tokens", async () => {
@@ -1020,31 +1050,6 @@ describe("deliverOutboundPayloads", () => {
     expect(queueMocks.ackDelivery).not.toHaveBeenCalled();
   });
 
-  it("requires the platform-send attempt marker before required durable platform I/O", async () => {
-    queueMocks.markDeliveryPlatformSendAttemptStarted.mockRejectedValueOnce(
-      new Error("marker offline"),
-    );
-    const sendMatrix = vi.fn().mockResolvedValue({ messageId: "m1" });
-
-    await expect(
-      deliverOutboundPayloads({
-        cfg: {},
-        channel: "matrix",
-        to: "!room:example",
-        payloads: [{ text: "hi" }],
-        deps: { matrix: sendMatrix },
-        queuePolicy: "required",
-      }),
-    ).rejects.toThrow("marker offline");
-
-    expect(queueMocks.markDeliveryPlatformSendAttemptStarted).toHaveBeenCalledWith("mock-queue-id");
-    expect(sendMatrix).not.toHaveBeenCalled();
-    const failDeliveryCall = requireMockCall(queueMocks.failDelivery, "failDelivery");
-    expect(failDeliveryCall[0]).toBe("mock-queue-id");
-    expect(String(failDeliveryCall[1])).toContain("marker offline");
-    expect(queueMocks.ackDelivery).not.toHaveBeenCalled();
-  });
-
   it("marks queued delivery as unknown-after-send (not failed) when a later payload fails after an earlier one succeeded", async () => {
     const sendMatrix = vi
       .fn()
@@ -1068,7 +1073,7 @@ describe("deliverOutboundPayloads", () => {
     expect(queueMocks.ackDelivery).not.toHaveBeenCalled();
   });
 
-  it("still calls failDelivery when a payload fails before any send succeeded", async () => {
+  it("retains retryable send-attempt state when the first platform call fails without a result", async () => {
     const sendMatrix = vi.fn().mockRejectedValueOnce(new Error("first payload send failed"));
 
     await expect(
@@ -1082,33 +1087,105 @@ describe("deliverOutboundPayloads", () => {
       }),
     ).rejects.toThrow("first payload send failed");
 
-    expect(queueMocks.failDelivery).toHaveBeenCalledWith(
+    expect(queueMocks.markDeliveryPlatformSendAttemptStarted).toHaveBeenCalledWith(
       "mock-queue-id",
-      expect.stringContaining("first payload send failed"),
+      undefined,
     );
     expect(queueMocks.markDeliveryPlatformOutcomeUnknown).not.toHaveBeenCalled();
+    expect(queueMocks.failDelivery).toHaveBeenCalledWith(
+      "mock-queue-id",
+      "first payload send failed",
+    );
     expect(queueMocks.ackDelivery).not.toHaveBeenCalled();
   });
 
-  it("fails required delivery when the post-send unknown marker cannot be written", async () => {
+  it("directly acks a sent delivery when the post-send unknown marker cannot be written", async () => {
     queueMocks.markDeliveryPlatformOutcomeUnknown.mockRejectedValueOnce(
       new Error("unknown marker offline"),
     );
     const sendMatrix = vi.fn().mockResolvedValue({ messageId: "m1" });
 
-    await expect(
-      deliverOutboundPayloads({
-        cfg: {},
-        channel: "matrix",
-        to: "!room:example",
-        payloads: [{ text: "hi" }],
-        deps: { matrix: sendMatrix },
-        queuePolicy: "required",
-      }),
-    ).rejects.toThrow("unknown marker offline");
+    await deliverOutboundPayloads({
+      cfg: {},
+      channel: "matrix",
+      to: "!room:example",
+      payloads: [{ text: "hi" }],
+      deps: { matrix: sendMatrix },
+      queuePolicy: "required",
+    });
 
     expect(sendMatrix).toHaveBeenCalled();
-    expect(queueMocks.ackDelivery).not.toHaveBeenCalled();
+    expect(queueMocks.ackDelivery).toHaveBeenCalledWith("mock-queue-id");
+    expect(queueMocks.failDelivery).not.toHaveBeenCalled();
+  });
+
+  it("runs sent-result commit hooks when marker fallback ack precedes a partial failure", async () => {
+    queueMocks.markDeliveryPlatformOutcomeUnknown.mockRejectedValueOnce(
+      new Error("unknown marker offline"),
+    );
+    const afterCommit = vi.fn();
+    const messageSendText = vi
+      .fn()
+      .mockResolvedValueOnce({
+        messageId: "message-adapter-1",
+        receipt: createMessageReceiptFromOutboundResults({
+          results: [{ channel: "matrix", messageId: "message-adapter-1" }],
+          kind: "text",
+        }),
+      })
+      .mockRejectedValueOnce(new Error("second send failed"));
+    setActivePluginRegistry(
+      createTestRegistry([
+        {
+          pluginId: "matrix",
+          source: "test",
+          plugin: {
+            id: "matrix",
+            message: {
+              id: "matrix",
+              durableFinal: { capabilities: { text: true, afterCommit: true } },
+              send: { lifecycle: { afterCommit }, text: messageSendText },
+            },
+          },
+        },
+      ]),
+    );
+
+    const results = await deliverOutboundPayloads({
+      cfg: {},
+      channel: "matrix",
+      to: "!room:example",
+      payloads: [{ text: "first" }, { text: "second" }],
+      bestEffort: true,
+      queuePolicy: "required",
+    });
+
+    expect(results).toHaveLength(1);
+    expect(queueMocks.ackDelivery).toHaveBeenCalledTimes(1);
+    expect(afterCommit).toHaveBeenCalledTimes(1);
+    expect(queueMocks.failDelivery).not.toHaveBeenCalled();
+  });
+
+  it("retains unknown-after-send evidence when both the marker and direct ack fail", async () => {
+    queueMocks.markDeliveryPlatformOutcomeUnknown.mockRejectedValueOnce(
+      new Error("unknown marker offline"),
+    );
+    queueMocks.ackDelivery.mockRejectedValueOnce(new Error("ack offline"));
+    const sendMatrix = vi.fn().mockResolvedValue({ messageId: "m1" });
+
+    await deliverOutboundPayloads({
+      cfg: {},
+      channel: "matrix",
+      to: "!room:example",
+      payloads: [{ text: "hi" }],
+      deps: { matrix: sendMatrix },
+      queuePolicy: "required",
+    });
+
+    expect(queueMocks.failDeliveryAfterPlatformSend).toHaveBeenCalledWith(
+      "mock-queue-id",
+      expect.stringContaining("marker=unknown marker offline; ack=ack offline"),
+    );
     expect(queueMocks.failDelivery).not.toHaveBeenCalled();
   });
 
@@ -1129,6 +1206,10 @@ describe("deliverOutboundPayloads", () => {
 
     expect(sendMatrix).toHaveBeenCalled();
     expect(queueMocks.markDeliveryPlatformOutcomeUnknown).toHaveBeenCalledWith("mock-queue-id");
+    expect(queueMocks.failDeliveryAfterPlatformSend).toHaveBeenCalledWith(
+      "mock-queue-id",
+      expect.stringContaining("failed to ack sent delivery: ack offline"),
+    );
     expect(queueMocks.failDelivery).not.toHaveBeenCalled();
   });
 
@@ -2154,6 +2235,179 @@ describe("deliverOutboundPayloads", () => {
     expect(sendMedia).not.toHaveBeenCalled();
   });
 
+  it("persists formatted sub-send results before a later adapter chunk fails", async () => {
+    const firstResult = { channel: "line" as const, messageId: "fmt-1" };
+    const sendFormattedText = vi.fn(
+      async (ctx: { onDeliveryResult?: (result: typeof firstResult) => Promise<void> | void }) => {
+        await ctx.onDeliveryResult?.(firstResult);
+        throw new Error("second formatted chunk failed");
+      },
+    );
+    setActivePluginRegistry(
+      createTestRegistry([
+        {
+          pluginId: "line",
+          source: "test",
+          plugin: createOutboundTestPlugin({
+            id: "line",
+            outbound: {
+              deliveryMode: "direct",
+              sendText: async () => firstResult,
+              sendFormattedText,
+            },
+          }),
+        },
+      ]),
+    );
+
+    await expect(
+      deliverOutboundPayloads({
+        cfg: {},
+        channel: "line",
+        to: "U123",
+        payloads: [{ text: "two chunks" }],
+        queuePolicy: "required",
+      }),
+    ).rejects.toThrow("second formatted chunk failed");
+
+    expect(queueMocks.markDeliveryPlatformOutcomeUnknown).toHaveBeenCalledWith("mock-queue-id");
+    expect(queueMocks.failDelivery).not.toHaveBeenCalled();
+    expect(queueMocks.ackDelivery).not.toHaveBeenCalled();
+  });
+
+  it("preserves repeated platform identities across separate adapter invocations", async () => {
+    const sendFormattedText = vi.fn(
+      async (ctx: {
+        onDeliveryResult?: (result: { channel: "line"; messageId: string }) => Promise<void> | void;
+      }) => {
+        const result = { channel: "line" as const, messageId: "push" };
+        await ctx.onDeliveryResult?.(result);
+        return [result];
+      },
+    );
+    setActivePluginRegistry(
+      createTestRegistry([
+        {
+          pluginId: "line",
+          source: "test",
+          plugin: createOutboundTestPlugin({
+            id: "line",
+            outbound: {
+              deliveryMode: "direct",
+              sendText: async () => ({ channel: "line", messageId: "push" }),
+              sendFormattedText,
+            },
+          }),
+        },
+      ]),
+    );
+
+    const results = await deliverOutboundPayloads({
+      cfg: {},
+      channel: "line",
+      to: "U123",
+      payloads: [{ text: "first" }, { text: "second" }],
+      queuePolicy: "required",
+    });
+
+    expect(sendFormattedText).toHaveBeenCalledTimes(2);
+    expect(results.map((result) => result.messageId)).toEqual(["push", "push"]);
+  });
+
+  it("replaces per-message progress with one aggregate final receipt", async () => {
+    const aggregateReceipt = createMessageReceiptFromOutboundResults({
+      results: [
+        { channel: "line", messageId: "m1" },
+        { channel: "line", messageId: "m2" },
+      ],
+      kind: "text",
+    });
+    const sendFormattedText = vi.fn(
+      async (ctx: {
+        onDeliveryResult?: (result: { channel: "line"; messageId: string }) => Promise<void> | void;
+      }) => {
+        await ctx.onDeliveryResult?.({ channel: "line", messageId: "m1" });
+        await ctx.onDeliveryResult?.({ channel: "line", messageId: "m2" });
+        return [
+          {
+            channel: "line" as const,
+            messageId: "m2",
+            receipt: aggregateReceipt,
+          },
+        ];
+      },
+    );
+    setActivePluginRegistry(
+      createTestRegistry([
+        {
+          pluginId: "line",
+          source: "test",
+          plugin: createOutboundTestPlugin({
+            id: "line",
+            outbound: {
+              deliveryMode: "direct",
+              sendText: async () => ({ channel: "line", messageId: "unused" }),
+              sendFormattedText,
+            },
+          }),
+        },
+      ]),
+    );
+
+    const results = await deliverOutboundPayloads({
+      cfg: {},
+      channel: "line",
+      to: "U123",
+      payloads: [{ text: "two chunks" }],
+      queuePolicy: "required",
+    });
+
+    expect(results).toHaveLength(1);
+    expect(results[0]?.receipt?.parts.map((part) => part.platformMessageId)).toEqual(["m1", "m2"]);
+  });
+
+  it("keeps commit hooks attached to a final result that replaces progress evidence", async () => {
+    const afterCommit = vi.fn();
+    const receipt = createMessageReceiptFromOutboundResults({
+      results: [{ channel: "matrix", messageId: "message-adapter-1" }],
+      kind: "text",
+    });
+    setActivePluginRegistry(
+      createTestRegistry([
+        {
+          pluginId: "matrix",
+          source: "test",
+          plugin: {
+            id: "matrix",
+            message: {
+              id: "matrix",
+              durableFinal: { capabilities: { text: true, afterCommit: true } },
+              send: {
+                lifecycle: { afterCommit },
+                text: async (ctx: ChannelMessageSendTextContext) => {
+                  const result = { messageId: "message-adapter-1", receipt };
+                  await ctx.onDeliveryResult?.(result);
+                  return result;
+                },
+              },
+            },
+          },
+        },
+      ]),
+    );
+
+    const results = await deliverOutboundPayloads({
+      cfg: {},
+      channel: "matrix",
+      to: "!room:example",
+      payloads: [{ text: "hello" }],
+      queuePolicy: "required",
+    });
+
+    expect(results).toHaveLength(1);
+    expect(afterCommit).toHaveBeenCalledTimes(1);
+  });
+
   it("includes OpenClaw tmp root in plugin mediaLocalRoots", async () => {
     const sendMatrix = vi.fn().mockResolvedValue({ messageId: "m-media", roomId: "!room" });
 
@@ -2820,6 +3074,30 @@ describe("deliverOutboundPayloads", () => {
     );
   });
 
+  it("records an all-failed bestEffort batch as a retryable attempt", async () => {
+    const sendMatrix = vi
+      .fn()
+      .mockRejectedValueOnce(new Error("first failed"))
+      .mockRejectedValueOnce(new Error("second failed"));
+
+    const results = await deliverOutboundPayloads({
+      cfg: {},
+      channel: "matrix",
+      to: "!room:example",
+      payloads: [{ text: "first" }, { text: "second" }],
+      deps: { matrix: sendMatrix },
+      bestEffort: true,
+    });
+
+    expect(results).toStrictEqual([]);
+    expect(queueMocks.failDelivery).toHaveBeenCalledWith(
+      "mock-queue-id",
+      "partial delivery failure (bestEffort)",
+    );
+    expect(queueMocks.ackDelivery).not.toHaveBeenCalled();
+    expect(queueMocks.markDeliveryPlatformOutcomeUnknown).not.toHaveBeenCalled();
+  });
+
   it("calls failDelivery instead of ackDelivery on bestEffort partial failure without onError", async () => {
     await runBestEffortPartialFailureDelivery({ onError: false });
 
@@ -2848,6 +3126,9 @@ describe("deliverOutboundPayloads", () => {
 
   it("logs a warning when failDelivery rejects in the error handler (#83113)", async () => {
     const sendMatrix = vi.fn().mockRejectedValue(new Error("native send failed"));
+    queueMocks.markDeliveryPlatformSendAttemptStarted.mockRejectedValueOnce(
+      new Error("pre-send marker offline"),
+    );
     queueMocks.failDelivery.mockRejectedValueOnce(new Error("db connection lost"));
 
     await expect(
@@ -2859,9 +3140,10 @@ describe("deliverOutboundPayloads", () => {
         deps: { matrix: sendMatrix },
         queuePolicy: "required",
       }),
-    ).rejects.toThrow("native send failed");
+    ).rejects.toThrow("pre-send marker offline");
 
     expect(queueMocks.failDelivery).toHaveBeenCalledWith("mock-queue-id", expect.any(String));
+    expect(sendMatrix).not.toHaveBeenCalled();
     const warnCall = requireMockCall(logMocks.warn, "warn");
     const warnMessage = String(warnCall[0]);
     expect(warnMessage).toContain("failed to mark queued delivery");
@@ -3171,6 +3453,50 @@ describe("deliverOutboundPayloads", () => {
     expect(appendOptions?.text).toBe("report.pdf");
     expect(appendOptions?.idempotencyKey).toBe("idem-deliver-1");
     expect(appendOptions?.config).toBe(cfg);
+  });
+
+  it("does not mirror a full payload when only an internal sub-send succeeded", async () => {
+    const partialResult = { channel: "line" as const, messageId: "partial-1" };
+    const sendFormattedText = vi.fn(
+      async (ctx: {
+        onDeliveryResult?: (result: typeof partialResult) => Promise<void> | void;
+      }) => {
+        await ctx.onDeliveryResult?.(partialResult);
+        throw new Error("second internal send failed");
+      },
+    );
+    setActivePluginRegistry(
+      createTestRegistry([
+        {
+          pluginId: "line",
+          source: "test",
+          plugin: createOutboundTestPlugin({
+            id: "line",
+            outbound: {
+              deliveryMode: "direct",
+              sendText: async () => partialResult,
+              sendFormattedText,
+            },
+          }),
+        },
+      ]),
+    );
+    mocks.appendAssistantMessageToSessionTranscript.mockClear();
+
+    const results = await deliverOutboundPayloads({
+      cfg: {},
+      channel: "line",
+      to: "U123",
+      payloads: [{ text: "first part and unsent second part" }],
+      bestEffort: true,
+      mirror: {
+        sessionKey: "agent:main:main",
+        text: "first part and unsent second part",
+      },
+    });
+
+    expect(results).toEqual([partialResult]);
+    expect(mocks.appendAssistantMessageToSessionTranscript).not.toHaveBeenCalled();
   });
 
   it("does not fail the channel send when the post-delivery transcript mirror throws", async () => {

--- a/src/infra/outbound/deliver.test.ts
+++ b/src/infra/outbound/deliver.test.ts
@@ -2314,6 +2314,103 @@ describe("deliverOutboundPayloads", () => {
     expect(results.map((result) => result.messageId)).toEqual(["push", "push"]);
   });
 
+  it("preserves repeated receipt IDs within one adapter invocation", async () => {
+    const receipt = createMessageReceiptFromOutboundResults({
+      results: [{ channel: "line", messageId: "push" }],
+      kind: "text",
+    });
+    const sendPayload = vi.fn(
+      async (ctx: {
+        onDeliveryResult?: (result: {
+          channel: "line";
+          messageId: string;
+          receipt: typeof receipt;
+        }) => Promise<void> | void;
+      }) => {
+        const result = { channel: "line" as const, messageId: "push", receipt };
+        await ctx.onDeliveryResult?.(result);
+        await ctx.onDeliveryResult?.(result);
+        return result;
+      },
+    );
+    setActivePluginRegistry(
+      createTestRegistry([
+        {
+          pluginId: "line",
+          source: "test",
+          plugin: createOutboundTestPlugin({
+            id: "line",
+            outbound: {
+              deliveryMode: "direct",
+              sendText: async () => ({ channel: "line", messageId: "unused" }),
+              sendPayload,
+            },
+          }),
+        },
+      ]),
+    );
+
+    const results = await deliverOutboundPayloads({
+      cfg: {},
+      channel: "line",
+      to: "U123",
+      payloads: [{ text: "text plus media", channelData: { line: { mode: "custom" } } }],
+      queuePolicy: "required",
+    });
+
+    expect(sendPayload).toHaveBeenCalledTimes(1);
+    expect(results.map((result) => result.messageId)).toEqual(["push", "push"]);
+  });
+
+  it("replaces repeated progress IDs covered by aggregate receipt parts", async () => {
+    const aggregateReceipt = createMessageReceiptFromOutboundResults({
+      results: [
+        { channel: "line", messageId: "push" },
+        { channel: "line", messageId: "push" },
+      ],
+      kind: "text",
+    });
+    const sendPayload = vi.fn(
+      async (ctx: {
+        onDeliveryResult?: (result: { channel: "line"; messageId: string }) => Promise<void> | void;
+      }) => {
+        await ctx.onDeliveryResult?.({ channel: "line", messageId: "push" });
+        await ctx.onDeliveryResult?.({ channel: "line", messageId: "push" });
+        return { channel: "line" as const, messageId: "push", receipt: aggregateReceipt };
+      },
+    );
+    setActivePluginRegistry(
+      createTestRegistry([
+        {
+          pluginId: "line",
+          source: "test",
+          plugin: createOutboundTestPlugin({
+            id: "line",
+            outbound: {
+              deliveryMode: "direct",
+              sendText: async () => ({ channel: "line", messageId: "unused" }),
+              sendPayload,
+            },
+          }),
+        },
+      ]),
+    );
+
+    const results = await deliverOutboundPayloads({
+      cfg: {},
+      channel: "line",
+      to: "U123",
+      payloads: [{ text: "two pushes", channelData: { line: { mode: "custom" } } }],
+      queuePolicy: "required",
+    });
+
+    expect(results).toHaveLength(1);
+    expect(results[0]?.receipt?.parts.map((part) => part.platformMessageId)).toEqual([
+      "push",
+      "push",
+    ]);
+  });
+
   it("replaces per-message progress with one aggregate final receipt", async () => {
     const aggregateReceipt = createMessageReceiptFromOutboundResults({
       results: [

--- a/src/infra/outbound/deliver.ts
+++ b/src/infra/outbound/deliver.ts
@@ -66,6 +66,7 @@ import {
   ackDelivery,
   enqueueDelivery,
   failDelivery,
+  failDeliveryAfterPlatformSend,
   markDeliveryPlatformOutcomeUnknown,
   markDeliveryPlatformSendAttemptStarted,
   type QueuedReplyPayloadSendingHook,
@@ -203,6 +204,7 @@ type ChannelHandlerParams = {
   mediaAccess?: OutboundMediaAccess;
   gatewayClientScopes?: readonly string[];
   onPlatformSendStart?: () => Promise<void>;
+  onDeliveryResult?: (result: OutboundDeliveryResult) => Promise<void> | void;
 };
 
 // Channel docking: outbound delivery delegates to plugin.outbound adapters.
@@ -345,6 +347,11 @@ function createPluginHandler(
   const sendMedia = outbound?.sendMedia;
   const chunker = outbound?.chunker ?? null;
   const chunkerMode = outbound?.chunkerMode;
+  const onMessageDeliveryResult = params.onDeliveryResult
+    ? async (result: ChannelMessageSendResult): Promise<void> => {
+        await params.onDeliveryResult?.(normalizeChannelMessageSendResult(params.channel, result));
+      }
+    : undefined;
   const resolveCtx = (overrides?: {
     replyToId?: string | null;
     replyToIdSource?: "explicit" | "implicit";
@@ -452,12 +459,16 @@ function createPluginHandler(
               payload,
             };
             if (messagePayload) {
+              const messagePayloadCtx = {
+                ...payloadCtx,
+                onDeliveryResult: onMessageDeliveryResult,
+              };
               const sent = await runChannelMessageSendWithLifecycle({
                 lifecycle: messageLifecycle,
-                ctx: payloadCtx,
+                ctx: messagePayloadCtx,
                 send: async () => {
                   await params.onPlatformSendStart?.();
-                  return await messagePayload(payloadCtx);
+                  return await messagePayload(messagePayloadCtx);
                 },
               });
               return attachOutboundDeliveryCommitHook(
@@ -495,12 +506,13 @@ function createPluginHandler(
         text,
       };
       if (messageText) {
+        const messageTextCtx = { ...textCtx, onDeliveryResult: onMessageDeliveryResult };
         const sent = await runChannelMessageSendWithLifecycle({
           lifecycle: messageLifecycle,
-          ctx: textCtx,
+          ctx: messageTextCtx,
           send: async () => {
             await params.onPlatformSendStart?.();
-            return await messageText(textCtx);
+            return await messageText(messageTextCtx);
           },
         });
         return attachOutboundDeliveryCommitHook(
@@ -520,12 +532,13 @@ function createPluginHandler(
         mediaUrl,
       };
       if (messageMedia) {
+        const messageMediaCtx = { ...mediaCtx, onDeliveryResult: onMessageDeliveryResult };
         const sent = await runChannelMessageSendWithLifecycle({
           lifecycle: messageLifecycle,
-          ctx: mediaCtx,
+          ctx: messageMediaCtx,
           send: async () => {
             await params.onPlatformSendStart?.();
-            return await messageMedia(mediaCtx);
+            return await messageMedia(messageMediaCtx);
           },
         });
         return attachOutboundDeliveryCommitHook(
@@ -580,6 +593,7 @@ function createChannelOutboundContextBase(
     mediaLocalRoots: params.mediaAccess?.localRoots,
     mediaReadFile: params.mediaAccess?.readFile,
     gatewayClientScopes: params.gatewayClientScopes,
+    onDeliveryResult: params.onDeliveryResult,
   };
 }
 
@@ -590,42 +604,55 @@ const isDeliveryAbortError = (err: unknown): boolean =>
   (err instanceof OutboundDeliveryError &&
     isAbortError((err as Error & { cause?: unknown }).cause));
 
-async function markQueuedPlatformSendAttemptStarted(params: {
+type QueuedPostSendState = "marked" | "acked" | "failed";
+
+type QueuedPreSendState = "marked" | "acked";
+
+async function persistQueuedPreSendState(params: {
   queueId: string;
   queuePolicy: OutboundDeliveryQueuePolicy;
   stateDir?: string;
-}): Promise<boolean> {
+}): Promise<QueuedPreSendState> {
   try {
-    if (params.stateDir === undefined) {
-      await markDeliveryPlatformSendAttemptStarted(params.queueId);
-    } else {
-      await markDeliveryPlatformSendAttemptStarted(params.queueId, params.stateDir);
-    }
-    return true;
-  } catch (err: unknown) {
+    await markDeliveryPlatformSendAttemptStarted(params.queueId, params.stateDir);
+    return "marked";
+  } catch (markErr: unknown) {
     if (params.queuePolicy === "required") {
-      throw err;
+      throw markErr;
     }
     log.warn(
-      `failed to mark queued delivery ${params.queueId} as platform-send-attempt-started; continuing best-effort delivery: ${formatErrorMessage(err)}`,
+      `failed to mark queued delivery ${params.queueId} as platform-send-attempt-started; removing replay intent before best-effort send: ${formatErrorMessage(markErr)}`,
     );
-    return false;
+    // If the pre-send marker is unavailable, remove the intent before crossing
+    // the platform boundary. An ack failure aborts the send, leaving safe retry state.
+    await ackDelivery(params.queueId, params.stateDir);
+    return "acked";
   }
 }
 
-async function markQueuedPlatformOutcomeUnknown(params: {
+async function persistQueuedPostSendState(params: {
   queueId: string;
   queuePolicy: OutboundDeliveryQueuePolicy;
-}): Promise<void> {
+}): Promise<QueuedPostSendState> {
   try {
     await markDeliveryPlatformOutcomeUnknown(params.queueId);
-  } catch (err: unknown) {
-    if (params.queuePolicy === "required") {
-      throw err;
-    }
+    return "marked";
+  } catch (markErr: unknown) {
     log.warn(
-      `failed to mark queued delivery ${params.queueId} as platform-outcome-unknown; continuing best-effort delivery: ${formatErrorMessage(err)}`,
+      `failed to mark queued delivery ${params.queueId} as platform-outcome-unknown; falling back to direct ack (${params.queuePolicy}): ${formatErrorMessage(markErr)}`,
     );
+    try {
+      // The platform already returned a result. If state marking is unavailable,
+      // deleting the intent is safer than leaving it replayable.
+      await ackDelivery(params.queueId);
+      return "acked";
+    } catch (ackErr: unknown) {
+      const error = `post-send state persistence failed: marker=${formatErrorMessage(markErr)}; ack=${formatErrorMessage(ackErr)}`;
+      // Keep the evidence in the same canonical row if both primary state
+      // transitions fail; a generic failure update would make it replayable.
+      await failDeliveryAfterPlatformSend(params.queueId, error);
+      return "failed";
+    }
   }
 }
 
@@ -650,15 +677,15 @@ type DeliverOutboundPayloadsCoreParams = {
   onError?: (err: unknown, payload: NormalizedOutboundPayload) => void;
   onPayload?: (payload: NormalizedOutboundPayload) => void;
   onPayloadDeliveryOutcome?: (outcome: OutboundPayloadDeliveryOutcome) => void;
+  /** @internal Runs after each identified platform result, before further fallible work. */
+  onDeliveryResult?: (result: OutboundDeliveryResult) => Promise<void> | void;
+  /** @internal Persists ambiguous-send state immediately before platform I/O. */
+  onPlatformSendStart?: () => Promise<void>;
   /** Session/agent context used for hooks and media local-root scoping. */
   session?: OutboundSessionContext;
   mirror?: DeliveryMirror;
   silent?: boolean;
   gatewayClientScopes?: readonly string[];
-};
-
-type DeliverOutboundPayloadsCoreRuntimeParams = DeliverOutboundPayloadsCoreParams & {
-  onPlatformSendStart?: () => Promise<void>;
 };
 
 /**
@@ -867,23 +894,6 @@ function hasDeliveryResultIdentity(result: OutboundDeliveryResult): boolean {
     result.toJid ||
     result.pollId,
   );
-}
-
-function pushIdentifiedDeliveryResult(
-  results: OutboundDeliveryResult[],
-  delivery: OutboundDeliveryResult,
-): boolean {
-  if (!hasDeliveryResultIdentity(delivery)) {
-    return false;
-  }
-  results.push(delivery);
-  return true;
-}
-
-function filterIdentifiedDeliveryResults(
-  results: readonly OutboundDeliveryResult[],
-): OutboundDeliveryResult[] {
-  return results.filter((result) => hasDeliveryResultIdentity(result));
 }
 
 function normalizeDeliveryPin(payload: ReplyPayload): ReplyPayloadDeliveryPin | undefined {
@@ -1335,40 +1345,61 @@ async function deliverOutboundPayloadsWithQueueCleanup(
   // without throwing — so the outer try/catch never fires. We track whether any
   // payload failed so we can call failDelivery instead of ackDelivery.
   let hadPartialFailure = false;
-  const wrappedParams = {
-    ...params,
-    onError: (err: unknown, payload: NormalizedOutboundPayload) => {
-      hadPartialFailure = true;
-      params.onError?.(err, payload);
-    },
-  };
+  let lastPayloadError: unknown;
   const queuePolicy = params.queuePolicy ?? "best_effort";
   const platformQueueId = queueId ?? params.deliveryQueueId;
   const platformQueuePolicy = queueId ? queuePolicy : "required";
   const platformQueueStateDir = queueId ? undefined : params.deliveryQueueStateDir;
+  let queuedPreSendState: QueuedPreSendState | undefined;
+  let queuedPostSendState: QueuedPostSendState | undefined;
+  let deliveredResults: OutboundDeliveryResult[] = [];
+  let commitHooksRun = false;
+  const runCommitHooksAfterAck = async (): Promise<void> => {
+    if (
+      queuedPostSendState !== "acked" ||
+      params.deferCommitHooks ||
+      commitHooksRun ||
+      deliveredResults.length === 0
+    ) {
+      return;
+    }
+    commitHooksRun = true;
+    await runOutboundDeliveryCommitHooks(deliveredResults);
+  };
+  const wrappedParams: DeliverOutboundPayloadsParams = {
+    ...params,
+    onPlatformSendStart: async () => {
+      if (platformQueueId && queuedPreSendState === undefined) {
+        queuedPreSendState = await persistQueuedPreSendState({
+          queueId: platformQueueId,
+          queuePolicy: platformQueuePolicy,
+          stateDir: platformQueueStateDir,
+        });
+        if (queueId && queuedPreSendState === "acked") {
+          queuedPostSendState = "acked";
+        }
+      }
+      await params.onPlatformSendStart?.();
+    },
+    onError: (err: unknown, payload: NormalizedOutboundPayload) => {
+      hadPartialFailure = true;
+      lastPayloadError = err;
+      params.onError?.(err, payload);
+    },
+    onDeliveryResult: async (result) => {
+      deliveredResults.push(result);
+      if (queueId && queuedPostSendState === undefined) {
+        queuedPostSendState = await persistQueuedPostSendState({ queueId, queuePolicy });
+      }
+      await params.onDeliveryResult?.(result);
+    },
+  };
   let platformResultsReturned = false;
-  let platformSendStarted = false;
 
   try {
-    const results = await deliverOutboundPayloadsCore({
-      ...wrappedParams,
-      ...(platformQueueId
-        ? {
-            onPlatformSendStart: async () => {
-              if (platformSendStarted) {
-                return;
-              }
-              // Recovery reuses its existing row. Mark it before crossing the
-              // platform boundary so later persistence failures cannot replay it.
-              platformSendStarted = await markQueuedPlatformSendAttemptStarted({
-                queueId: platformQueueId,
-                queuePolicy: platformQueuePolicy,
-                stateDir: platformQueueStateDir,
-              });
-            },
-          }
-        : {}),
-    });
+    const results = await deliverOutboundPayloadsCore(wrappedParams);
+    // Core reconciles adapter progress objects with hook-bearing final results.
+    deliveredResults = results;
     platformResultsReturned = true;
     if (!queueId) {
       if (!params.deferCommitHooks) {
@@ -1378,58 +1409,108 @@ async function deliverOutboundPayloadsWithQueueCleanup(
     }
     if (queueId) {
       if (hadPartialFailure) {
-        await failDelivery(queueId, "partial delivery failure (bestEffort)").catch(
-          (err: unknown) => {
+        const partialSendEvidence =
+          results.length > 0 ||
+          (lastPayloadError instanceof OutboundDeliveryError && lastPayloadError.sentBeforeError);
+        const postSendState =
+          queuedPostSendState ??
+          (partialSendEvidence
+            ? await persistQueuedPostSendState({ queueId, queuePolicy })
+            : undefined);
+        const error = "partial delivery failure (bestEffort)";
+        if (postSendState === undefined || postSendState === "marked") {
+          await failDelivery(queueId, error).catch((err: unknown) => {
             log.warn(
               `failed to mark queued delivery ${queueId} as failed after partial failure; continuing best-effort delivery: ${formatErrorMessage(err)}`,
             );
-          },
-        );
-      } else {
-        if (platformSendStarted) {
-          await markQueuedPlatformOutcomeUnknown({
-            queueId,
-            queuePolicy,
           });
+        } else if (postSendState === "acked") {
+          // Direct ack is the fallback when the post-send marker cannot be
+          // written. Once the row is gone, recovery cannot run these hooks.
+          await runCommitHooksAfterAck();
         }
-        const acked = await ackDelivery(queueId)
-          .then(() => true)
-          .catch((err: unknown) => {
-            if (queuePolicy === "required") {
-              throw err;
-            }
-            log.warn(
-              `failed to ack queued delivery ${queueId}; continuing best-effort delivery: ${formatErrorMessage(err)}`,
-            );
-            return false;
-          });
+      } else {
+        const postSendState =
+          queuedPostSendState ??
+          (results.length > 0 || queuedPreSendState === "marked"
+            ? await persistQueuedPostSendState({ queueId, queuePolicy })
+            : queuedPreSendState === "acked"
+              ? "acked"
+              : undefined);
+        const acked =
+          postSendState === "acked"
+            ? true
+            : postSendState === "failed"
+              ? false
+              : await ackDelivery(queueId)
+                  .then(() => true)
+                  .catch(async (err: unknown) => {
+                    const hasSendEvidence =
+                      deliveredResults.length > 0 || queuedPreSendState !== undefined;
+                    try {
+                      if (hasSendEvidence) {
+                        await failDeliveryAfterPlatformSend(
+                          queueId,
+                          `failed to ack sent delivery: ${formatErrorMessage(err)}`,
+                        );
+                        queuedPostSendState = "failed";
+                      } else {
+                        await failDelivery(
+                          queueId,
+                          `failed to ack unsent delivery: ${formatErrorMessage(err)}`,
+                        );
+                      }
+                    } catch (persistErr: unknown) {
+                      log.warn(
+                        `failed to preserve queued delivery ${queueId} after ack failure: ${formatErrorMessage(persistErr)}`,
+                      );
+                    }
+                    if (queuePolicy === "required") {
+                      throw err;
+                    }
+                    log.warn(
+                      hasSendEvidence
+                        ? `failed to ack queued delivery ${queueId}; preserved unknown-after-send state: ${formatErrorMessage(err)}`
+                        : `failed to ack unsent queued delivery ${queueId}; retained it for retry: ${formatErrorMessage(err)}`,
+                    );
+                    return false;
+                  });
         if (acked) {
-          await runOutboundDeliveryCommitHooks(results);
+          queuedPostSendState = "acked";
+          await runCommitHooksAfterAck();
         }
       }
     }
     return results;
   } catch (err) {
+    if (err instanceof OutboundDeliveryError && err.results.length > 0) {
+      deliveredResults = err.results;
+    }
     if (queueId) {
       if (isDeliveryAbortError(err)) {
         await ackDelivery(queueId).catch(() => {});
       } else if (!platformResultsReturned) {
         const sendEvidence =
-          platformSendStarted && err instanceof OutboundDeliveryError && err.sentBeforeError;
+          deliveredResults.length > 0 ||
+          (err instanceof OutboundDeliveryError && err.sentBeforeError);
         if (sendEvidence) {
-          await markQueuedPlatformOutcomeUnknown({
-            queueId,
-            queuePolicy,
-          }).catch((markErr: unknown) => {
-            log.warn(
-              `failed to mark queued delivery ${queueId} as platform-outcome-unknown after mid-send error; falling back to fail: ${formatErrorMessage(markErr)}`,
-            );
-            return failDelivery(queueId, formatErrorMessage(err)).catch((failErr: unknown) => {
-              log.warn(
-                `failed to mark queued delivery ${queueId} as failed: ${formatErrorMessage(failErr)}`,
-              );
+          try {
+            queuedPostSendState ??= await persistQueuedPostSendState({
+              queueId,
+              queuePolicy,
             });
-          });
+            if (queuedPostSendState === "marked") {
+              await failDeliveryAfterPlatformSend(queueId, formatErrorMessage(err));
+              queuedPostSendState = "failed";
+            }
+          } catch (persistErr: unknown) {
+            // Do not convert concrete send evidence back into a generic retry.
+            // All canonical state transitions failed, so retain the original row.
+            log.warn(
+              `failed to preserve queued delivery ${queueId} post-send evidence: ${formatErrorMessage(persistErr)}`,
+            );
+          }
+          await runCommitHooksAfterAck();
         } else {
           await failDelivery(queueId, formatErrorMessage(err)).catch((failErr: unknown) => {
             log.warn(
@@ -1445,7 +1526,7 @@ async function deliverOutboundPayloadsWithQueueCleanup(
 
 /** Core delivery logic (extracted for queue wrapper). */
 async function deliverOutboundPayloadsCore(
-  params: DeliverOutboundPayloadsCoreRuntimeParams,
+  params: DeliverOutboundPayloadsCoreParams,
 ): Promise<OutboundDeliveryResult[]> {
   const { cfg, channel, to, payloads } = params;
   const directiveOptions = await resolveChannelOutboundDirectiveOptions({ cfg, channel });
@@ -1459,6 +1540,150 @@ async function deliverOutboundPayloadsCore(
   const accountId = params.accountId;
   const deps = params.deps;
   const abortSignal = params.abortSignal;
+  const results: OutboundDeliveryResult[] = [];
+  let reportedResults: Array<{ identityKey: string; resultIndex: number }> = [];
+  const resultIdentityKey = (delivery: OutboundDeliveryResult): string =>
+    JSON.stringify([
+      delivery.channel,
+      delivery.messageId,
+      delivery.chatId,
+      delivery.channelId,
+      delivery.roomId,
+      delivery.conversationId,
+      delivery.timestamp,
+      delivery.toJid,
+      delivery.pollId,
+    ]);
+  const resultPlatformIds = (
+    delivery: OutboundDeliveryResult,
+    options?: { receiptOnly?: boolean },
+  ): Set<string> => {
+    const ids = new Set<string>();
+    const add = (value: string | undefined) => {
+      const id = value?.trim();
+      if (id && id !== "unknown" && id !== "suppressed") {
+        ids.add(id);
+      }
+    };
+    if (!options?.receiptOnly) {
+      add(delivery.messageId);
+    }
+    add(delivery.receipt?.primaryPlatformMessageId);
+    for (const id of delivery.receipt?.platformMessageIds ?? []) {
+      add(id);
+    }
+    for (const part of delivery.receipt?.parts ?? []) {
+      add(part.platformMessageId);
+    }
+    return ids;
+  };
+  const reportIdentifiedDeliveryResult = async (
+    delivery: OutboundDeliveryResult,
+  ): Promise<void> => {
+    if (!hasDeliveryResultIdentity(delivery)) {
+      return;
+    }
+    const resultIndex = results.length;
+    results.push(delivery);
+    reportedResults.push({ identityKey: resultIdentityKey(delivery), resultIndex });
+    // Persist concrete platform evidence before pinning, hooks, mirroring, or
+    // another send can fail or the process can stop.
+    await params.onDeliveryResult?.(delivery);
+  };
+  const recordIdentifiedDeliveryResults = async (
+    deliveries: readonly OutboundDeliveryResult[],
+    options?: { finalResultIsLastReported?: boolean },
+  ): Promise<boolean[]> => {
+    const reportedByIdentity = new Map<string, number[]>();
+    for (const reported of reportedResults) {
+      const matches = reportedByIdentity.get(reported.identityKey) ?? [];
+      matches.push(reported.resultIndex);
+      reportedByIdentity.set(reported.identityKey, matches);
+    }
+    try {
+      const recorded: boolean[] = [];
+      const availableReportedIndices = new Set(
+        reportedResults.map((reported) => reported.resultIndex),
+      );
+      const replacements = new Map<number, OutboundDeliveryResult>();
+      const removals = new Set<number>();
+      const appendResults: OutboundDeliveryResult[] = [];
+      for (const delivery of deliveries) {
+        if (!hasDeliveryResultIdentity(delivery)) {
+          recorded.push(false);
+          continue;
+        }
+        const receiptIds = resultPlatformIds(delivery, { receiptOnly: true });
+        const coveredIndices =
+          receiptIds.size === 0
+            ? []
+            : reportedResults
+                .filter(
+                  (reported) =>
+                    availableReportedIndices.has(reported.resultIndex) &&
+                    results[reported.resultIndex]?.channel === delivery.channel &&
+                    [...resultPlatformIds(results[reported.resultIndex])].some((id) =>
+                      receiptIds.has(id),
+                    ),
+                )
+                .map((reported) => reported.resultIndex);
+        let reportedIndex: number | undefined;
+        if (coveredIndices.length > 0) {
+          reportedIndex = Math.min(...coveredIndices);
+          for (const coveredIndex of coveredIndices) {
+            availableReportedIndices.delete(coveredIndex);
+            if (coveredIndex !== reportedIndex) {
+              removals.add(coveredIndex);
+            }
+          }
+        } else {
+          const reportedMatches = (
+            reportedByIdentity.get(resultIdentityKey(delivery)) ?? []
+          ).filter((index) => availableReportedIndices.has(index));
+          reportedIndex = options?.finalResultIsLastReported
+            ? reportedMatches.at(-1)
+            : reportedMatches[0];
+          if (reportedIndex !== undefined) {
+            availableReportedIndices.delete(reportedIndex);
+          }
+        }
+        if (reportedIndex !== undefined) {
+          // Replace all progress covered by an aggregate receipt with the final
+          // hook-bearing object, avoiding duplicate receipt parts.
+          replacements.set(reportedIndex, delivery);
+        } else {
+          appendResults.push(delivery);
+        }
+        recorded.push(true);
+      }
+      if (replacements.size > 0 || removals.size > 0) {
+        const reconciled = results.flatMap((result, index) => {
+          if (removals.has(index)) {
+            return [];
+          }
+          return [replacements.get(index) ?? result];
+        });
+        results.splice(0, results.length, ...reconciled);
+      }
+      for (const delivery of appendResults) {
+        results.push(delivery);
+        await params.onDeliveryResult?.(delivery);
+      }
+      return recorded;
+    } finally {
+      // Progress matching is scoped to exactly one adapter invocation. IDs such
+      // as LINE's constant "push" value can legitimately repeat later.
+      reportedResults = [];
+    }
+  };
+  const recordIdentifiedDeliveryResult = async (
+    delivery: OutboundDeliveryResult,
+  ): Promise<boolean> =>
+    (
+      await recordIdentifiedDeliveryResults([delivery], {
+        finalResultIsLastReported: true,
+      })
+    )[0] ?? false;
   const resolveMediaAccess = (mediaSources: readonly string[]): OutboundMediaAccess =>
     mediaSources.length > 0
       ? resolveAgentScopedOutboundMediaAccess({
@@ -1492,7 +1717,8 @@ async function deliverOutboundPayloadsCore(
       silent: params.silent,
       mediaAccess: resolveMediaAccess(mediaSources),
       gatewayClientScopes: params.gatewayClientScopes,
-      ...(params.onPlatformSendStart ? { onPlatformSendStart: params.onPlatformSendStart } : {}),
+      onPlatformSendStart: params.onPlatformSendStart,
+      onDeliveryResult: reportIdentifiedDeliveryResult,
     });
   const baseHandler = await createHandler([]);
   const handlerByMediaSources = new Map<string, Promise<ChannelHandler>>();
@@ -1509,7 +1735,6 @@ async function deliverOutboundPayloadsCore(
     handlerByMediaSources.set(key, created);
     return created;
   };
-  const results: OutboundDeliveryResult[] = [];
   const handler = baseHandler;
   const configuredTextLimit = handler.chunker
     ? resolveTextChunkLimit(cfg, channel, accountId, {
@@ -1553,7 +1778,7 @@ async function deliverOutboundPayloadsCore(
         continue;
       }
       throwIfAborted(abortSignal);
-      pushIdentifiedDeliveryResult(results, await sendHandler.sendText(unit.text, unit.overrides));
+      await recordIdentifiedDeliveryResult(await sendHandler.sendText(unit.text, unit.overrides));
     }
   };
   const normalizedPayloads = normalizePayloadsForChannelDelivery(outboundPayloadPlan, handler);
@@ -1572,7 +1797,7 @@ async function deliverOutboundPayloadsCore(
     payloadSummary: NormalizedOutboundPayload,
     deliveredResults: readonly OutboundDeliveryResult[],
   ): void => {
-    if (!params.mirror || !params.replyPayloadSendingHook || deliveredResults.length === 0) {
+    if (!params.mirror || deliveredResults.length === 0) {
       return;
     }
     deliveredMirrorPayloads.push(payloadSummary);
@@ -1765,11 +1990,14 @@ async function deliverOutboundPayloadsCore(
           }) ||
           effectivePayload.audioAsVoice === true)
       ) {
+        const beforeCount = results.length;
         const delivery = await deliveryHandler.sendPayload(
           effectivePayload,
           applySendReplyToConsumption(sendOverrides),
         );
-        if (!hasDeliveryResultIdentity(delivery)) {
+        await recordIdentifiedDeliveryResult(delivery);
+        const deliveredResults = results.slice(beforeCount);
+        if (deliveredResults.length === 0) {
           completeDeliveryDiagnostics(0);
           recordPayloadOutcome(
             suppressedPayloadOutcome({
@@ -1779,39 +2007,36 @@ async function deliverOutboundPayloadsCore(
           );
           continue;
         }
-        results.push(delivery);
-        recordPayloadOutcome({ index: payloadIndex, status: "sent", results: [delivery] });
-        recordDeliveredMirrorPayload(payloadSummary, [delivery]);
+        recordPayloadOutcome({ index: payloadIndex, status: "sent", results: deliveredResults });
+        recordDeliveredMirrorPayload(payloadSummary, deliveredResults);
         await maybePinDeliveredMessage({
           handler: deliveryHandler,
           payload: effectivePayload,
           target: deliveryTarget,
-          messageId: delivery.messageId,
+          messageId: deliveredResults.find((entry) => entry.messageId)?.messageId,
           gatewayClientScopes: params.gatewayClientScopes,
         });
         await maybeNotifyAfterDeliveredPayload({
           handler: deliveryHandler,
           payload: effectivePayload,
           target: deliveryTarget,
-          results: [delivery],
+          results: deliveredResults,
         });
-        completeDeliveryDiagnostics(1);
+        completeDeliveryDiagnostics(deliveredResults.length);
         emitMessageSent({
           success: true,
           content: payloadSummary.hookContent ?? payloadSummary.text,
-          messageId: delivery.messageId,
+          messageId: deliveredResults.at(-1)?.messageId,
         });
         continue;
       }
       if (payloadSummary.mediaUrls.length === 0) {
         const beforeCount = results.length;
         if (deliveryHandler.sendFormattedText) {
-          results.push(
-            ...filterIdentifiedDeliveryResults(
-              await deliveryHandler.sendFormattedText(
-                payloadSummary.text,
-                applySendReplyToConsumption(sendOverrides),
-              ),
+          await recordIdentifiedDeliveryResults(
+            await deliveryHandler.sendFormattedText(
+              payloadSummary.text,
+              applySendReplyToConsumption(sendOverrides),
             ),
           );
         } else {
@@ -1935,7 +2160,7 @@ async function deliverOutboundPayloadsCore(
               unit.overrides,
             )
           : await deliveryHandler.sendMedia(unit.caption ?? "", unit.mediaUrl, unit.overrides);
-        if (pushIdentifiedDeliveryResult(results, delivery)) {
+        if (await recordIdentifiedDeliveryResult(delivery)) {
           firstMessageId ??= delivery.messageId;
           lastMessageId = delivery.messageId;
         }
@@ -1976,6 +2201,9 @@ async function deliverOutboundPayloadsCore(
         messageId: lastMessageId,
       });
     } catch (err) {
+      // A rejected adapter has no final return to reconcile with its progress
+      // results. Keep the results, but never match them to a later payload.
+      reportedResults = [];
       recordPayloadOutcome({
         index: payloadIndex,
         status: "failed",
@@ -2000,17 +2228,14 @@ async function deliverOutboundPayloadsCore(
       params.onError?.(err, payloadSummary);
     }
   }
-  if (params.mirror && results.length > 0) {
-    const deliveredMirror =
-      deliveredMirrorPayloads.length > 0
-        ? {
-            text: deliveredMirrorPayloads
-              .map((payload) => payload.hookContent ?? payload.text)
-              .filter((text) => text.trim())
-              .join("\n"),
-            mediaUrls: deliveredMirrorPayloads.flatMap((payload) => payload.mediaUrls),
-          }
-        : params.mirror;
+  if (params.mirror && deliveredMirrorPayloads.length > 0) {
+    const deliveredMirror = {
+      text: deliveredMirrorPayloads
+        .map((payload) => payload.hookContent ?? payload.text)
+        .filter((text) => text.trim())
+        .join("\n"),
+      mediaUrls: deliveredMirrorPayloads.flatMap((payload) => payload.mediaUrls),
+    };
     const mirrorText = resolveMirroredTranscriptText({
       text: deliveredMirror.text,
       mediaUrls: deliveredMirror.mediaUrls,

--- a/src/infra/outbound/deliver.ts
+++ b/src/infra/outbound/deliver.ts
@@ -593,9 +593,14 @@ const isDeliveryAbortError = (err: unknown): boolean =>
 async function markQueuedPlatformSendAttemptStarted(params: {
   queueId: string;
   queuePolicy: OutboundDeliveryQueuePolicy;
+  stateDir?: string;
 }): Promise<boolean> {
   try {
-    await markDeliveryPlatformSendAttemptStarted(params.queueId);
+    if (params.stateDir === undefined) {
+      await markDeliveryPlatformSendAttemptStarted(params.queueId);
+    } else {
+      await markDeliveryPlatformSendAttemptStarted(params.queueId, params.stateDir);
+    }
     return true;
   } catch (err: unknown) {
     if (params.queuePolicy === "required") {
@@ -666,6 +671,10 @@ type DeliverOutboundPayloadsCoreRuntimeParams = DeliverOutboundPayloadsCoreParam
 export type DeliverOutboundPayloadsParams = DeliverOutboundPayloadsCoreParams & {
   /** @internal Skip write-ahead queue (used by crash-recovery to avoid re-enqueueing). */
   skipQueue?: boolean;
+  /** @internal Existing recovery queue entry to mark when the platform send begins. */
+  deliveryQueueId?: string;
+  /** @internal State directory that owns the existing recovery queue entry. */
+  deliveryQueueStateDir?: string;
   /** @internal Let recovery run commit hooks after it has acked the recovered queue entry. */
   deferCommitHooks?: boolean;
   queuePolicy?: OutboundDeliveryQueuePolicy;
@@ -1334,21 +1343,27 @@ async function deliverOutboundPayloadsWithQueueCleanup(
     },
   };
   const queuePolicy = params.queuePolicy ?? "best_effort";
+  const platformQueueId = queueId ?? params.deliveryQueueId;
+  const platformQueuePolicy = queueId ? queuePolicy : "required";
+  const platformQueueStateDir = queueId ? undefined : params.deliveryQueueStateDir;
   let platformResultsReturned = false;
   let platformSendStarted = false;
 
   try {
     const results = await deliverOutboundPayloadsCore({
       ...wrappedParams,
-      ...(queueId
+      ...(platformQueueId
         ? {
             onPlatformSendStart: async () => {
               if (platformSendStarted) {
                 return;
               }
+              // Recovery reuses its existing row. Mark it before crossing the
+              // platform boundary so later persistence failures cannot replay it.
               platformSendStarted = await markQueuedPlatformSendAttemptStarted({
-                queueId,
-                queuePolicy,
+                queueId: platformQueueId,
+                queuePolicy: platformQueuePolicy,
+                stateDir: platformQueueStateDir,
               });
             },
           }

--- a/src/infra/outbound/deliver.ts
+++ b/src/infra/outbound/deliver.ts
@@ -1613,20 +1613,34 @@ async function deliverOutboundPayloadsCore(
           recorded.push(false);
           continue;
         }
-        const receiptIds = resultPlatformIds(delivery, { receiptOnly: true });
-        const coveredIndices =
-          receiptIds.size === 0
-            ? []
-            : reportedResults
-                .filter(
-                  (reported) =>
-                    availableReportedIndices.has(reported.resultIndex) &&
-                    results[reported.resultIndex]?.channel === delivery.channel &&
-                    [...resultPlatformIds(results[reported.resultIndex])].some((id) =>
-                      receiptIds.has(id),
-                    ),
-                )
-                .map((reported) => reported.resultIndex);
+        const receiptPartIds = (delivery.receipt?.parts ?? [])
+          .map((part) => part.platformMessageId?.trim())
+          .filter((id): id is string => Boolean(id && id !== "unknown" && id !== "suppressed"));
+        const receiptIds =
+          receiptPartIds.length > 0
+            ? receiptPartIds
+            : [...resultPlatformIds(delivery, { receiptOnly: true })];
+        const coveredIndices: number[] = [];
+        for (const receiptId of receiptIds) {
+          const matchingIndices = reportedResults
+            .filter(
+              (reported) =>
+                availableReportedIndices.has(reported.resultIndex) &&
+                !coveredIndices.includes(reported.resultIndex) &&
+                results[reported.resultIndex]?.channel === delivery.channel &&
+                resultPlatformIds(results[reported.resultIndex]).has(receiptId),
+            )
+            .map((reported) => reported.resultIndex);
+          // One receipt part covers one progress result. Repeated parts preserve
+          // aggregate multiplicity, while one constant platform ID cannot erase
+          // other successful sends that the final receipt does not aggregate.
+          const matchingIndex = options?.finalResultIsLastReported
+            ? matchingIndices.at(-1)
+            : matchingIndices[0];
+          if (matchingIndex !== undefined && !coveredIndices.includes(matchingIndex)) {
+            coveredIndices.push(matchingIndex);
+          }
+        }
         let reportedIndex: number | undefined;
         if (coveredIndices.length > 0) {
           reportedIndex = Math.min(...coveredIndices);

--- a/src/infra/outbound/delivery-commit-hooks.ts
+++ b/src/infra/outbound/delivery-commit-hooks.ts
@@ -7,12 +7,6 @@ import type { OutboundDeliveryResult } from "./deliver-types.js";
 /** Callback attached to a delivery result and run after durable send commit. */
 export type OutboundDeliveryCommitHook = () => Promise<void>;
 
-export type OutboundDeliveryCommitHookFailure = {
-  channel: OutboundDeliveryResult["channel"];
-  messageId: string;
-  error: string;
-};
-
 const log = createSubsystemLogger("outbound/deliver");
 const outboundDeliveryCommitHooks = new WeakMap<
   OutboundDeliveryResult,
@@ -36,26 +30,22 @@ export function attachOutboundDeliveryCommitHook<T extends OutboundDeliveryResul
 /** Runs after-commit hooks for delivered results while isolating hook failures. */
 export async function runOutboundDeliveryCommitHooks(
   results: readonly OutboundDeliveryResult[],
-): Promise<OutboundDeliveryCommitHookFailure[]> {
-  const failures: OutboundDeliveryCommitHookFailure[] = [];
+): Promise<void> {
   for (const result of results) {
     for (const hook of outboundDeliveryCommitHooks.get(result) ?? []) {
       try {
         await hook();
       } catch (err) {
-        const error = formatErrorMessage(err);
-        failures.push({ channel: result.channel, messageId: result.messageId, error });
         // Commit hooks are side effects after successful send; failures are
         // logged but must not turn the already-committed delivery into failure.
         log.warn("Plugin message adapter after-commit hook failed.", {
           channel: result.channel,
           messageId: result.messageId,
-          error,
+          error: formatErrorMessage(err),
         });
       }
     }
   }
-  return failures;
 }
 
 /** Type guard for batched outbound delivery results crossing loose boundaries. */

--- a/src/infra/outbound/delivery-commit-hooks.ts
+++ b/src/infra/outbound/delivery-commit-hooks.ts
@@ -7,6 +7,12 @@ import type { OutboundDeliveryResult } from "./deliver-types.js";
 /** Callback attached to a delivery result and run after durable send commit. */
 export type OutboundDeliveryCommitHook = () => Promise<void>;
 
+export type OutboundDeliveryCommitHookFailure = {
+  channel: OutboundDeliveryResult["channel"];
+  messageId: string;
+  error: string;
+};
+
 const log = createSubsystemLogger("outbound/deliver");
 const outboundDeliveryCommitHooks = new WeakMap<
   OutboundDeliveryResult,
@@ -30,22 +36,26 @@ export function attachOutboundDeliveryCommitHook<T extends OutboundDeliveryResul
 /** Runs after-commit hooks for delivered results while isolating hook failures. */
 export async function runOutboundDeliveryCommitHooks(
   results: readonly OutboundDeliveryResult[],
-): Promise<void> {
+): Promise<OutboundDeliveryCommitHookFailure[]> {
+  const failures: OutboundDeliveryCommitHookFailure[] = [];
   for (const result of results) {
     for (const hook of outboundDeliveryCommitHooks.get(result) ?? []) {
       try {
         await hook();
       } catch (err) {
+        const error = formatErrorMessage(err);
+        failures.push({ channel: result.channel, messageId: result.messageId, error });
         // Commit hooks are side effects after successful send; failures are
         // logged but must not turn the already-committed delivery into failure.
         log.warn("Plugin message adapter after-commit hook failed.", {
           channel: result.channel,
           messageId: result.messageId,
-          error: formatErrorMessage(err),
+          error,
         });
       }
     }
   }
+  return failures;
 }
 
 /** Type guard for batched outbound delivery results crossing loose boundaries. */

--- a/src/infra/outbound/delivery-queue-recovery.ts
+++ b/src/infra/outbound/delivery-queue-recovery.ts
@@ -17,7 +17,11 @@ import {
 } from "../delivery-recovery.shared.js";
 import { formatErrorMessage } from "../errors.js";
 import { resolveOutboundChannelMessageAdapter } from "./channel-resolution.js";
-import type { OutboundDeliveryResult } from "./deliver-types.js";
+import {
+  isOutboundDeliveryError,
+  type OutboundDeliveryResult,
+  type OutboundPayloadDeliveryOutcome,
+} from "./deliver-types.js";
 import {
   isOutboundDeliveryResultArray,
   runOutboundDeliveryCommitHooks,
@@ -25,6 +29,7 @@ import {
 import {
   ackDelivery,
   failDelivery,
+  failDeliveryAfterPlatformSend,
   loadPendingDelivery,
   loadPendingDeliveries,
   markDeliveryPlatformOutcomeUnknown,
@@ -50,6 +55,8 @@ export type DeliverFn = (
       deliveryQueueStateDir?: string;
       skipQueue?: boolean;
       deferCommitHooks?: boolean;
+      onPayloadDeliveryOutcome?: (outcome: OutboundPayloadDeliveryOutcome) => void;
+      onDeliveryResult?: (result: OutboundDeliveryResult) => Promise<void> | void;
     },
 ) => Promise<unknown>;
 
@@ -339,6 +346,31 @@ export function isPermanentDeliveryError(error: string): boolean {
   return PERMANENT_ERROR_PATTERNS.some((re) => re.test(error));
 }
 
+async function persistRecoveredPostSendState(opts: {
+  entry: QueuedDelivery;
+  log: RecoveryLogger;
+  stateDir?: string;
+}): Promise<"marked" | "acked" | "failed"> {
+  try {
+    await markDeliveryPlatformOutcomeUnknown(opts.entry.id, opts.stateDir);
+    return "marked";
+  } catch (markErr) {
+    // A result proves at least one send completed. If the intermediate marker
+    // is unavailable, direct ack still removes the replayable intent.
+    opts.log.warn(
+      `Delivery entry ${opts.entry.id} failed to persist post-send state; falling back to direct ack: ${formatErrorMessage(markErr)}`,
+    );
+    try {
+      await ackDelivery(opts.entry.id, opts.stateDir);
+      return "acked";
+    } catch (ackErr) {
+      const error = `post-send state persistence failed: marker=${formatErrorMessage(markErr)}; ack=${formatErrorMessage(ackErr)}`;
+      await failDeliveryAfterPlatformSend(opts.entry.id, error, opts.stateDir);
+      return "failed";
+    }
+  }
+}
+
 async function drainQueuedEntry(opts: {
   entry: QueuedDelivery;
   cfg: OpenClawConfig;
@@ -427,23 +459,125 @@ async function drainQueuedEntry(opts: {
       return "failed";
     }
   }
+  const payloadOutcomes: OutboundPayloadDeliveryOutcome[] = [];
+  let postSendState: "marked" | "acked" | "failed" | undefined;
+  let deliveredResults: OutboundDeliveryResult[] = [];
+  let commitHooksRun = false;
+  const collectResults = (results: readonly OutboundDeliveryResult[]): void => {
+    for (const result of results) {
+      if (!deliveredResults.includes(result)) {
+        deliveredResults.push(result);
+      }
+    }
+  };
+  const runCommitHooksAfterAck = async (): Promise<void> => {
+    if (postSendState !== "acked" || commitHooksRun || deliveredResults.length === 0) {
+      return;
+    }
+    commitHooksRun = true;
+    await runOutboundDeliveryCommitHooks(deliveredResults);
+  };
   try {
-    const result = await opts.deliver(buildRecoveryDeliverParams(entry, opts.cfg, opts.stateDir));
+    const result = await opts.deliver({
+      ...buildRecoveryDeliverParams(entry, opts.cfg, opts.stateDir),
+      onPayloadDeliveryOutcome: (outcome) => payloadOutcomes.push(outcome),
+      onDeliveryResult: async (deliveryResult) => {
+        collectResults([deliveryResult]);
+        postSendState ??= await persistRecoveredPostSendState({
+          entry,
+          log: opts.log,
+          stateDir: opts.stateDir,
+        });
+      },
+    });
     const results = isOutboundDeliveryResultArray(result) ? result : [];
     if (results.length > 0) {
-      // Recovery bypasses the live queue hooks. Persist post-send ambiguity
-      // before ack so an interrupted ack cannot replay an already sent batch.
-      await markDeliveryPlatformOutcomeUnknown(entry.id, opts.stateDir);
+      deliveredResults = [...results];
     }
-    await ackDelivery(entry.id, opts.stateDir);
-    if (results.length > 0) {
-      await runOutboundDeliveryCommitHooks(results);
+    const failedOutcome = payloadOutcomes.find((outcome) => outcome.status === "failed");
+    if (failedOutcome) {
+      const errMsg = formatErrorMessage(failedOutcome.error);
+      opts.onFailed?.(entry, errMsg);
+      if (results.length > 0 || failedOutcome.sentBeforeError) {
+        postSendState ??= await persistRecoveredPostSendState({
+          entry,
+          log: opts.log,
+          stateDir: opts.stateDir,
+        });
+        opts.log.warn(
+          `Delivery entry ${entry.id} partially sent before best-effort recovery failed; preserving unknown_after_send`,
+        );
+        if (postSendState === "acked") {
+          await runCommitHooksAfterAck();
+        }
+      } else {
+        await failDelivery(entry.id, errMsg, opts.stateDir);
+      }
+      return "failed";
     }
+    postSendState ??=
+      results.length > 0
+        ? await persistRecoveredPostSendState({ entry, log: opts.log, stateDir: opts.stateDir })
+        : undefined;
+    if (postSendState === "failed") {
+      const errMsg = "recovered send completed but queue finalization failed";
+      opts.onFailed?.(entry, errMsg);
+      opts.log.warn(`Delivery entry ${entry.id} ${errMsg}; preserving unknown_after_send`);
+      return "failed";
+    }
+    if (postSendState !== "acked") {
+      try {
+        await ackDelivery(entry.id, opts.stateDir);
+        postSendState = "acked";
+      } catch (ackErr) {
+        const ackError = `failed to ack recovered delivery: ${formatErrorMessage(ackErr)}`;
+        if (results.length > 0) {
+          await failDeliveryAfterPlatformSend(entry.id, ackError, opts.stateDir);
+          postSendState = "failed";
+        } else {
+          await failDelivery(entry.id, ackError, opts.stateDir);
+        }
+        opts.onFailed?.(entry, ackError);
+        opts.log.warn(`Delivery entry ${entry.id} ${ackError}`);
+        return "failed";
+      }
+    }
+    await runCommitHooksAfterAck();
     opts.onRecovered?.(entry);
     return "recovered";
   } catch (err) {
     const errMsg = formatErrorMessage(err);
     opts.onFailed?.(entry, errMsg);
+    if (isOutboundDeliveryError(err) && err.results.length > 0) {
+      deliveredResults = [...err.results];
+    }
+    const hasSendEvidence =
+      deliveredResults.length > 0 ||
+      postSendState !== undefined ||
+      (isOutboundDeliveryError(err) && err.sentBeforeError);
+    if (hasSendEvidence) {
+      // A rejected batch can still contain successful earlier sends. Preserve
+      // that concrete evidence so reconnect recovery never replays the batch.
+      try {
+        postSendState ??= await persistRecoveredPostSendState({
+          entry,
+          log: opts.log,
+          stateDir: opts.stateDir,
+        });
+      } catch (persistErr) {
+        // Never overwrite concrete send evidence with a generic retry state.
+        opts.log.error(
+          `Delivery entry ${entry.id} could not persist post-send evidence: ${formatErrorMessage(persistErr)}`,
+        );
+      }
+      if (postSendState === "acked") {
+        await runCommitHooksAfterAck();
+      }
+      opts.log.warn(
+        `Delivery entry ${entry.id} partially sent before recovery failed; preserving unknown_after_send`,
+      );
+      return "failed";
+    }
     if (isPermanentDeliveryError(errMsg)) {
       try {
         await moveToFailed(entry.id, opts.stateDir);

--- a/src/infra/outbound/delivery-queue-recovery.ts
+++ b/src/infra/outbound/delivery-queue-recovery.ts
@@ -21,7 +21,6 @@ import type { OutboundDeliveryResult } from "./deliver-types.js";
 import {
   isOutboundDeliveryResultArray,
   runOutboundDeliveryCommitHooks,
-  type OutboundDeliveryCommitHookFailure,
 } from "./delivery-commit-hooks.js";
 import {
   ackDelivery,
@@ -30,7 +29,6 @@ import {
   loadPendingDeliveries,
   markDeliveryPlatformOutcomeUnknown,
   moveToFailed,
-  recordFailedDeliveryDiagnostic,
   type QueuedDelivery,
   type QueuedDeliveryPayload,
 } from "./delivery-queue-storage.js";
@@ -341,17 +339,6 @@ export function isPermanentDeliveryError(error: string): boolean {
   return PERMANENT_ERROR_PATTERNS.some((re) => re.test(error));
 }
 
-function formatCommitHookFailureMessage(
-  failures: readonly OutboundDeliveryCommitHookFailure[],
-): string {
-  if (failures.length === 1) {
-    return `post-send commit hook failed: ${failures[0]?.error ?? "unknown error"}`;
-  }
-  return `post-send commit hooks failed (${failures.length}): ${failures
-    .map((failure) => `${failure.channel}/${failure.messageId}: ${failure.error}`)
-    .join("; ")}`;
-}
-
 async function drainQueuedEntry(opts: {
   entry: QueuedDelivery;
   cfg: OpenClawConfig;
@@ -444,37 +431,13 @@ async function drainQueuedEntry(opts: {
     const result = await opts.deliver(buildRecoveryDeliverParams(entry, opts.cfg, opts.stateDir));
     const results = isOutboundDeliveryResultArray(result) ? result : [];
     if (results.length > 0) {
-      try {
-        await markDeliveryPlatformOutcomeUnknown(entry.id, opts.stateDir);
-      } catch (markErr) {
-        const errMsg = `failed to mark recovered delivery post-send state: ${formatErrorMessage(markErr)}`;
-        opts.onFailed?.(entry, errMsg);
-        try {
-          await recordFailedDeliveryDiagnostic(entry, errMsg, opts.stateDir);
-        } catch (recordErr) {
-          if (getErrnoCode(recordErr) === "ENOENT") {
-            return "already-gone";
-          }
-          opts.log.warn(
-            `Delivery entry ${entry.id} failed to record post-send diagnostic: ${formatErrorMessage(recordErr)}`,
-          );
-        }
-        return "failed";
-      }
+      // Recovery bypasses the live queue hooks. Persist post-send ambiguity
+      // before ack so an interrupted ack cannot replay an already sent batch.
+      await markDeliveryPlatformOutcomeUnknown(entry.id, opts.stateDir);
     }
     await ackDelivery(entry.id, opts.stateDir);
-    const commitHookFailures =
-      results.length > 0 ? await runOutboundDeliveryCommitHooks(results) : [];
-    if (commitHookFailures.length > 0) {
-      const errMsg = formatCommitHookFailureMessage(commitHookFailures);
-      try {
-        await recordFailedDeliveryDiagnostic(entry, errMsg, opts.stateDir);
-        opts.log.warn(`Delivery entry ${entry.id} ${errMsg}; recorded failed diagnostic`);
-      } catch (recordErr) {
-        opts.log.warn(
-          `Delivery entry ${entry.id} ${errMsg}; failed to record diagnostic: ${formatErrorMessage(recordErr)}`,
-        );
-      }
+    if (results.length > 0) {
+      await runOutboundDeliveryCommitHooks(results);
     }
     opts.onRecovered?.(entry);
     return "recovered";

--- a/src/infra/outbound/delivery-queue-recovery.ts
+++ b/src/infra/outbound/delivery-queue-recovery.ts
@@ -21,13 +21,16 @@ import type { OutboundDeliveryResult } from "./deliver-types.js";
 import {
   isOutboundDeliveryResultArray,
   runOutboundDeliveryCommitHooks,
+  type OutboundDeliveryCommitHookFailure,
 } from "./delivery-commit-hooks.js";
 import {
   ackDelivery,
   failDelivery,
   loadPendingDelivery,
   loadPendingDeliveries,
+  markDeliveryPlatformOutcomeUnknown,
   moveToFailed,
+  recordFailedDeliveryDiagnostic,
   type QueuedDelivery,
   type QueuedDeliveryPayload,
 } from "./delivery-queue-storage.js";
@@ -338,6 +341,17 @@ export function isPermanentDeliveryError(error: string): boolean {
   return PERMANENT_ERROR_PATTERNS.some((re) => re.test(error));
 }
 
+function formatCommitHookFailureMessage(
+  failures: readonly OutboundDeliveryCommitHookFailure[],
+): string {
+  if (failures.length === 1) {
+    return `post-send commit hook failed: ${failures[0]?.error ?? "unknown error"}`;
+  }
+  return `post-send commit hooks failed (${failures.length}): ${failures
+    .map((failure) => `${failure.channel}/${failure.messageId}: ${failure.error}`)
+    .join("; ")}`;
+}
+
 async function drainQueuedEntry(opts: {
   entry: QueuedDelivery;
   cfg: OpenClawConfig;
@@ -428,9 +442,39 @@ async function drainQueuedEntry(opts: {
   }
   try {
     const result = await opts.deliver(buildRecoveryDeliverParams(entry, opts.cfg, opts.stateDir));
+    const results = isOutboundDeliveryResultArray(result) ? result : [];
+    if (results.length > 0) {
+      try {
+        await markDeliveryPlatformOutcomeUnknown(entry.id, opts.stateDir);
+      } catch (markErr) {
+        const errMsg = `failed to mark recovered delivery post-send state: ${formatErrorMessage(markErr)}`;
+        opts.onFailed?.(entry, errMsg);
+        try {
+          await recordFailedDeliveryDiagnostic(entry, errMsg, opts.stateDir);
+        } catch (recordErr) {
+          if (getErrnoCode(recordErr) === "ENOENT") {
+            return "already-gone";
+          }
+          opts.log.warn(
+            `Delivery entry ${entry.id} failed to record post-send diagnostic: ${formatErrorMessage(recordErr)}`,
+          );
+        }
+        return "failed";
+      }
+    }
     await ackDelivery(entry.id, opts.stateDir);
-    if (isOutboundDeliveryResultArray(result)) {
-      await runOutboundDeliveryCommitHooks(result);
+    const commitHookFailures =
+      results.length > 0 ? await runOutboundDeliveryCommitHooks(results) : [];
+    if (commitHookFailures.length > 0) {
+      const errMsg = formatCommitHookFailureMessage(commitHookFailures);
+      try {
+        await recordFailedDeliveryDiagnostic(entry, errMsg, opts.stateDir);
+        opts.log.warn(`Delivery entry ${entry.id} ${errMsg}; recorded failed diagnostic`);
+      } catch (recordErr) {
+        opts.log.warn(
+          `Delivery entry ${entry.id} ${errMsg}; failed to record diagnostic: ${formatErrorMessage(recordErr)}`,
+        );
+      }
     }
     opts.onRecovered?.(entry);
     return "recovered";

--- a/src/infra/outbound/delivery-queue-storage.ts
+++ b/src/infra/outbound/delivery-queue-storage.ts
@@ -145,6 +145,22 @@ export async function failDelivery(id: string, error: string, stateDir?: string)
   }));
 }
 
+/** Record a failed attempt without losing evidence that platform delivery may have completed. */
+export async function failDeliveryAfterPlatformSend(
+  id: string,
+  error: string,
+  stateDir?: string,
+): Promise<void> {
+  updateQueuedDelivery(id, stateDir, (entry) => ({
+    ...entry,
+    retryCount: entry.retryCount + 1,
+    lastAttemptAt: Date.now(),
+    lastError: error,
+    platformSendStartedAt: entry.platformSendStartedAt ?? Date.now(),
+    recoveryState: "unknown_after_send",
+  }));
+}
+
 function updateQueuedDelivery(
   id: string,
   stateDir: string | undefined,

--- a/src/infra/outbound/delivery-queue-storage.ts
+++ b/src/infra/outbound/delivery-queue-storage.ts
@@ -145,29 +145,6 @@ export async function failDelivery(id: string, error: string, stateDir?: string)
   }));
 }
 
-export async function recordFailedDeliveryDiagnostic(
-  entry: QueuedDelivery,
-  error: string,
-  stateDir?: string,
-): Promise<void> {
-  const now = Date.now();
-  const failedEntry: QueuedDelivery = {
-    ...entry,
-    retryCount: entry.retryCount + 1,
-    lastAttemptAt: now,
-    lastError: error,
-    platformSendStartedAt: entry.platformSendStartedAt ?? now,
-    recoveryState: "unknown_after_send",
-  };
-  upsertDeliveryQueueEntry({
-    queueName: QUEUE_NAME,
-    entry: failedEntry,
-    metadata: queuedDeliveryMetadata(failedEntry),
-    status: "failed",
-    stateDir,
-  });
-}
-
 function updateQueuedDelivery(
   id: string,
   stateDir: string | undefined,

--- a/src/infra/outbound/delivery-queue-storage.ts
+++ b/src/infra/outbound/delivery-queue-storage.ts
@@ -145,6 +145,29 @@ export async function failDelivery(id: string, error: string, stateDir?: string)
   }));
 }
 
+export async function recordFailedDeliveryDiagnostic(
+  entry: QueuedDelivery,
+  error: string,
+  stateDir?: string,
+): Promise<void> {
+  const now = Date.now();
+  const failedEntry: QueuedDelivery = {
+    ...entry,
+    retryCount: entry.retryCount + 1,
+    lastAttemptAt: now,
+    lastError: error,
+    platformSendStartedAt: entry.platformSendStartedAt ?? now,
+    recoveryState: "unknown_after_send",
+  };
+  upsertDeliveryQueueEntry({
+    queueName: QUEUE_NAME,
+    entry: failedEntry,
+    metadata: queuedDeliveryMetadata(failedEntry),
+    status: "failed",
+    stateDir,
+  });
+}
+
 function updateQueuedDelivery(
   id: string,
   stateDir: string | undefined,

--- a/src/infra/outbound/delivery-queue.recovery.test.ts
+++ b/src/infra/outbound/delivery-queue.recovery.test.ts
@@ -3,12 +3,12 @@
 import { MAX_DATE_TIMESTAMP_MS } from "@openclaw/normalization-core/number-coercion";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { openOpenClawStateDatabase } from "../../state/openclaw-state-db.js";
+import { OutboundDeliveryError, type OutboundPayloadDeliveryOutcome } from "./deliver-types.js";
 import { attachOutboundDeliveryCommitHook } from "./delivery-commit-hooks.js";
 import {
   enqueueDelivery,
   loadPendingDeliveries,
   markDeliveryPlatformOutcomeUnknown,
-  markDeliveryPlatformSendAttemptStarted,
   MAX_RETRIES,
   recoverPendingDeliveries,
 } from "./delivery-queue.js";
@@ -134,6 +134,113 @@ describe("delivery-queue recovery", () => {
     expect(entries).toHaveLength(1);
     expect(entries[0]?.retryCount).toBe(1);
     expect(entries[0]?.lastError).toBe("network down");
+  });
+
+  it("does not replay a recovery batch that rejected after an earlier send succeeded", async () => {
+    const id = await enqueueDelivery(
+      {
+        channel: "demo-channel-c",
+        to: "#ch",
+        payloads: [{ text: "first" }, { text: "second" }],
+      },
+      tmpDir(),
+    );
+    const partialFailure = new OutboundDeliveryError("second send failed", {
+      cause: new Error("network down"),
+      results: [{ channel: "demo-channel-c", messageId: "m1" }],
+    });
+
+    const { result } = await runRecovery({
+      deliver: vi.fn().mockRejectedValue(partialFailure),
+    });
+
+    expect(result).toMatchObject({ recovered: 0, failed: 1 });
+    const entries = await loadPendingDeliveries(tmpDir());
+    expect(entries).toHaveLength(1);
+    expect(entries[0]?.id).toBe(id);
+    expect(entries[0]?.recoveryState).toBe("unknown_after_send");
+    expect(entries[0]?.retryCount).toBe(0);
+
+    const replay = vi.fn();
+    await runRecovery({ deliver: replay });
+    expect(replay).not.toHaveBeenCalled();
+    expect(await loadPendingDeliveries(tmpDir())).toHaveLength(0);
+    expect(readOutboundQueueStatus(tmpDir(), id)).toBe("failed");
+  });
+
+  it("keeps a best-effort recovery failure retryable when no payload was sent", async () => {
+    await enqueueDelivery(
+      {
+        channel: "demo-channel-c",
+        to: "#ch",
+        payloads: [{ text: "first" }],
+        bestEffort: true,
+      },
+      tmpDir(),
+    );
+    const deliver = vi.fn(
+      async (params: {
+        onPayloadDeliveryOutcome?: (outcome: OutboundPayloadDeliveryOutcome) => void;
+      }) => {
+        params.onPayloadDeliveryOutcome?.({
+          index: 0,
+          status: "failed",
+          error: new Error("network down"),
+          sentBeforeError: false,
+          stage: "platform_send",
+        });
+        return [];
+      },
+    );
+
+    const { result } = await runRecovery({ deliver });
+
+    expect(result).toMatchObject({ recovered: 0, failed: 1 });
+    const entries = await loadPendingDeliveries(tmpDir());
+    expect(entries).toHaveLength(1);
+    expect(entries[0]?.recoveryState).toBeUndefined();
+    expect(entries[0]?.retryCount).toBe(1);
+    expect(entries[0]?.lastError).toBe("network down");
+  });
+
+  it("does not ack a partially sent best-effort recovery batch", async () => {
+    const id = await enqueueDelivery(
+      {
+        channel: "demo-channel-c",
+        to: "#ch",
+        payloads: [{ text: "first" }, { text: "second" }],
+        bestEffort: true,
+      },
+      tmpDir(),
+    );
+    const deliver = vi.fn(
+      async (params: {
+        onPayloadDeliveryOutcome?: (outcome: OutboundPayloadDeliveryOutcome) => void;
+      }) => {
+        params.onPayloadDeliveryOutcome?.({
+          index: 1,
+          status: "failed",
+          error: new Error("second send failed"),
+          sentBeforeError: true,
+          stage: "platform_send",
+        });
+        return [{ channel: "demo-channel-c", messageId: "m1" }];
+      },
+    );
+
+    const { result } = await runRecovery({ deliver });
+
+    expect(result).toMatchObject({ recovered: 0, failed: 1 });
+    const entries = await loadPendingDeliveries(tmpDir());
+    expect(entries).toHaveLength(1);
+    expect(entries[0]?.id).toBe(id);
+    expect(entries[0]?.recoveryState).toBe("unknown_after_send");
+    expect(entries[0]?.retryCount).toBe(0);
+
+    const replay = vi.fn();
+    await runRecovery({ deliver: replay });
+    expect(replay).not.toHaveBeenCalled();
+    expect(readOutboundQueueStatus(tmpDir(), id)).toBe("failed");
   });
 
   it("moves entries abandoned after platform send may have started to failed without reconciliation", async () => {
@@ -466,7 +573,7 @@ describe("delivery-queue recovery", () => {
   });
 
   it("passes skipQueue: true to prevent re-enqueueing during recovery", async () => {
-    const id = await enqueueDelivery(
+    await enqueueDelivery(
       { channel: "demo-channel-a", to: "+1", payloads: [{ text: "a" }] },
       tmpDir(),
     );
@@ -474,13 +581,7 @@ describe("delivery-queue recovery", () => {
     const deliver = vi.fn().mockResolvedValue([]);
     await runRecovery({ deliver });
 
-    const deliverInput = mockCallArg(deliver) as {
-      deliveryQueueId?: string;
-      deliveryQueueStateDir?: string;
-      skipQueue?: boolean;
-    };
-    expect(deliverInput.deliveryQueueId).toBe(id);
-    expect(deliverInput.deliveryQueueStateDir).toBe(tmpDir());
+    const deliverInput = mockCallArg(deliver) as { skipQueue?: boolean };
     expect(deliverInput.skipQueue).toBe(true);
   });
 
@@ -608,7 +709,48 @@ describe("delivery-queue recovery", () => {
     }
   });
 
-  it("keeps a recovered send non-replayable when its post-send marker fails", async () => {
+  it("keeps a recovered zero-result delivery retryable when ack fails", async () => {
+    const id = await enqueueDelivery(
+      { channel: "demo-channel-a", to: "+1", payloads: [{ text: "a" }] },
+      tmpDir(),
+    );
+    vi.resetModules();
+    vi.doMock("./delivery-queue-storage.js", async () => {
+      const actual = await vi.importActual<typeof import("./delivery-queue-storage.js")>(
+        "./delivery-queue-storage.js",
+      );
+      return {
+        ...actual,
+        ackDelivery: vi.fn(async () => {
+          throw new Error("ack state db locked");
+        }),
+      };
+    });
+
+    try {
+      const { recoverPendingDeliveries: recoverWithAckFailure } =
+        await import("./delivery-queue-recovery.js");
+      const summary = await recoverWithAckFailure({
+        deliver: asDeliverFn(vi.fn().mockResolvedValue([])),
+        log: createRecoveryLog(),
+        cfg: baseCfg,
+        stateDir: tmpDir(),
+      });
+
+      expect(summary).toMatchObject({ recovered: 0, failed: 1 });
+      const pending = await loadPendingDeliveries(tmpDir());
+      expect(pending).toHaveLength(1);
+      expect(pending[0]?.id).toBe(id);
+      expect(pending[0]?.recoveryState).toBeUndefined();
+      expect(pending[0]?.retryCount).toBe(1);
+      expect(pending[0]?.lastError).toContain("ack state db locked");
+    } finally {
+      vi.doUnmock("./delivery-queue-storage.js");
+      vi.resetModules();
+    }
+  });
+
+  it("directly acks a recovered send when its post-send marker fails", async () => {
     const id = await enqueueDelivery(
       { channel: "demo-channel-a", to: "+1", payloads: [{ text: "a" }] },
       tmpDir(),
@@ -629,29 +771,138 @@ describe("delivery-queue recovery", () => {
     try {
       const { recoverPendingDeliveries: recoverWithMarkFailure } =
         await import("./delivery-queue-recovery.js");
+      const log = createRecoveryLog();
       const summary = await recoverWithMarkFailure({
         deliver: asDeliverFn(
-          vi.fn(async () => {
-            await markDeliveryPlatformSendAttemptStarted(id, tmpDir());
-            return [{ channel: "demo-channel-a", messageId: "m1" }];
-          }),
+          vi.fn().mockResolvedValue([{ channel: "demo-channel-a", messageId: "m1" }]),
+        ),
+        cfg: baseCfg,
+        stateDir: tmpDir(),
+        log,
+      });
+
+      expect(summary).toEqual({
+        recovered: 1,
+        failed: 0,
+        skippedMaxRetries: 0,
+        deferredBackoff: 0,
+      });
+      expect(await loadPendingDeliveries(tmpDir())).toHaveLength(0);
+      expect(readOutboundQueueStatus(tmpDir(), id)).toBeUndefined();
+      expectMockMessageContaining(log.warn, "falling back to direct ack");
+    } finally {
+      vi.doUnmock("./delivery-queue-storage.js");
+      vi.resetModules();
+    }
+  });
+
+  it("runs recovered commit hooks when marker fallback ack precedes a partial failure", async () => {
+    await enqueueDelivery(
+      {
+        channel: "demo-channel-a",
+        to: "+1",
+        payloads: [{ text: "first" }, { text: "second" }],
+        bestEffort: true,
+      },
+      tmpDir(),
+    );
+    const afterCommit = vi.fn();
+    vi.resetModules();
+    vi.doMock("./delivery-queue-storage.js", async () => {
+      const actual = await vi.importActual<typeof import("./delivery-queue-storage.js")>(
+        "./delivery-queue-storage.js",
+      );
+      return {
+        ...actual,
+        markDeliveryPlatformOutcomeUnknown: vi.fn(async () => {
+          throw new Error("post-send state db locked");
+        }),
+      };
+    });
+
+    try {
+      const { recoverPendingDeliveries: recoverWithMarkFailure } =
+        await import("./delivery-queue-recovery.js");
+      const { attachOutboundDeliveryCommitHook: attachHookAfterReset } =
+        await import("./delivery-commit-hooks.js");
+      const result = attachHookAfterReset(
+        { channel: "demo-channel-a", messageId: "m1" },
+        afterCommit,
+      );
+      const summary = await recoverWithMarkFailure({
+        deliver: asDeliverFn(
+          vi.fn(
+            async (params: {
+              onDeliveryResult?: (deliveryResult: typeof result) => Promise<void> | void;
+              onPayloadDeliveryOutcome?: (outcome: OutboundPayloadDeliveryOutcome) => void;
+            }) => {
+              await params.onDeliveryResult?.(result);
+              params.onPayloadDeliveryOutcome?.({
+                index: 1,
+                status: "failed",
+                error: new Error("second send failed"),
+                sentBeforeError: false,
+                stage: "platform_send",
+              });
+              return [result];
+            },
+          ),
         ),
         cfg: baseCfg,
         stateDir: tmpDir(),
         log: createRecoveryLog(),
       });
 
-      expect(summary).toEqual({
-        recovered: 0,
-        failed: 1,
-        skippedMaxRetries: 0,
-        deferredBackoff: 0,
+      expect(summary).toMatchObject({ recovered: 0, failed: 1 });
+      expect(afterCommit).toHaveBeenCalledTimes(1);
+      expect(await loadPendingDeliveries(tmpDir())).toHaveLength(0);
+    } finally {
+      vi.doUnmock("./delivery-queue-storage.js");
+      vi.resetModules();
+    }
+  });
+
+  it("retains unknown-after-send when recovered-send marking and ack both fail", async () => {
+    const id = await enqueueDelivery(
+      { channel: "demo-channel-a", to: "+1", payloads: [{ text: "a" }] },
+      tmpDir(),
+    );
+    vi.resetModules();
+    vi.doMock("./delivery-queue-storage.js", async () => {
+      const actual = await vi.importActual<typeof import("./delivery-queue-storage.js")>(
+        "./delivery-queue-storage.js",
+      );
+      return {
+        ...actual,
+        markDeliveryPlatformOutcomeUnknown: vi.fn(async () => {
+          throw new Error("post-send state db locked");
+        }),
+        ackDelivery: vi.fn(async () => {
+          throw new Error("ack state db locked");
+        }),
+      };
+    });
+
+    try {
+      const { recoverPendingDeliveries: recoverWithStateFailures } =
+        await import("./delivery-queue-recovery.js");
+      const summary = await recoverWithStateFailures({
+        deliver: asDeliverFn(
+          vi.fn().mockResolvedValue([{ channel: "demo-channel-a", messageId: "m1" }]),
+        ),
+        cfg: baseCfg,
+        stateDir: tmpDir(),
+        log: createRecoveryLog(),
       });
-      const pending = await loadPendingDeliveries(tmpDir());
-      expect(pending).toHaveLength(1);
-      expect(pending[0]?.id).toBe(id);
-      expect(pending[0]?.recoveryState).toBe("send_attempt_started");
-      expect(pending[0]?.lastError).toContain("post-send state db locked");
+
+      expect(summary).toMatchObject({ recovered: 0, failed: 1 });
+      const entries = await loadPendingDeliveries(tmpDir());
+      expect(entries).toHaveLength(1);
+      expect(entries[0]?.id).toBe(id);
+      expect(entries[0]?.recoveryState).toBe("unknown_after_send");
+      expect(entries[0]?.retryCount).toBe(1);
+      expect(entries[0]?.lastError).toContain("marker=post-send state db locked");
+      expect(entries[0]?.lastError).toContain("ack=ack state db locked");
     } finally {
       vi.doUnmock("./delivery-queue-storage.js");
       vi.resetModules();

--- a/src/infra/outbound/delivery-queue.recovery.test.ts
+++ b/src/infra/outbound/delivery-queue.recovery.test.ts
@@ -15,6 +15,7 @@ import {
   asDeliverFn,
   createRecoveryLog,
   installDeliveryQueueTmpDirHooks,
+  readQueuedEntry,
   setQueuedEntryState,
 } from "./delivery-queue.test-helpers.js";
 
@@ -530,6 +531,83 @@ describe("delivery-queue recovery", () => {
     expect(order).toEqual(["deliver", "commit-after-ack"]);
     expect(await loadPendingDeliveries(tmpDir())).toHaveLength(0);
     expect(readOutboundQueueStatus(tmpDir(), id)).toBeUndefined();
+  });
+
+  it("records a failed diagnostic when a recovered send commit hook fails after ack", async () => {
+    const id = await enqueueDelivery(
+      { channel: "demo-channel-a", to: "+1", payloads: [{ text: "a" }] },
+      tmpDir(),
+    );
+    const result = attachOutboundDeliveryCommitHook(
+      { channel: "demo-channel-a", messageId: "m1" },
+      async () => {
+        throw new Error("commit hook offline");
+      },
+    );
+    const deliver = vi.fn().mockResolvedValue([result]);
+
+    const { result: summary } = await runRecovery({ deliver });
+
+    expect(summary).toEqual({
+      recovered: 1,
+      failed: 0,
+      skippedMaxRetries: 0,
+      deferredBackoff: 0,
+    });
+    expect(await loadPendingDeliveries(tmpDir())).toHaveLength(0);
+    expect(readOutboundQueueStatus(tmpDir(), id)).toBe("failed");
+    const failedEntry = readQueuedEntry(tmpDir(), id);
+    expect(failedEntry.recoveryState).toBe("unknown_after_send");
+    expect(failedEntry.lastError).toContain("post-send commit hook failed");
+    expect(failedEntry.lastError).toContain("commit hook offline");
+  });
+
+  it("does not leave a sent recovery replay pending when post-send state marking fails", async () => {
+    const id = await enqueueDelivery(
+      { channel: "demo-channel-a", to: "+1", payloads: [{ text: "a" }] },
+      tmpDir(),
+    );
+    vi.resetModules();
+    vi.doMock("./delivery-queue-storage.js", async () => {
+      const actual = await vi.importActual<typeof import("./delivery-queue-storage.js")>(
+        "./delivery-queue-storage.js",
+      );
+      return {
+        ...actual,
+        markDeliveryPlatformOutcomeUnknown: vi.fn(async () => {
+          throw new Error("state db locked");
+        }),
+      };
+    });
+
+    try {
+      const { recoverPendingDeliveries: recoverWithMarkFailure } =
+        await import("./delivery-queue-recovery.js");
+      const summary = await recoverWithMarkFailure({
+        deliver: asDeliverFn(
+          vi.fn().mockResolvedValue([{ channel: "demo-channel-a", messageId: "m1" }]),
+        ),
+        log: createRecoveryLog(),
+        cfg: baseCfg,
+        stateDir: tmpDir(),
+      });
+
+      expect(summary).toEqual({
+        recovered: 0,
+        failed: 1,
+        skippedMaxRetries: 0,
+        deferredBackoff: 0,
+      });
+      expect(await loadPendingDeliveries(tmpDir())).toHaveLength(0);
+      expect(readOutboundQueueStatus(tmpDir(), id)).toBe("failed");
+      const failedEntry = readQueuedEntry(tmpDir(), id);
+      expect(failedEntry.recoveryState).toBe("unknown_after_send");
+      expect(failedEntry.lastError).toContain("failed to mark recovered delivery post-send state");
+      expect(failedEntry.lastError).toContain("state db locked");
+    } finally {
+      vi.doUnmock("./delivery-queue-storage.js");
+      vi.resetModules();
+    }
   });
 
   it("replays stored delivery options during recovery", async () => {

--- a/src/infra/outbound/delivery-queue.recovery.test.ts
+++ b/src/infra/outbound/delivery-queue.recovery.test.ts
@@ -8,6 +8,7 @@ import {
   enqueueDelivery,
   loadPendingDeliveries,
   markDeliveryPlatformOutcomeUnknown,
+  markDeliveryPlatformSendAttemptStarted,
   MAX_RETRIES,
   recoverPendingDeliveries,
 } from "./delivery-queue.js";
@@ -15,7 +16,6 @@ import {
   asDeliverFn,
   createRecoveryLog,
   installDeliveryQueueTmpDirHooks,
-  readQueuedEntry,
   setQueuedEntryState,
 } from "./delivery-queue.test-helpers.js";
 
@@ -533,7 +533,7 @@ describe("delivery-queue recovery", () => {
     expect(readOutboundQueueStatus(tmpDir(), id)).toBeUndefined();
   });
 
-  it("records a failed diagnostic when a recovered send commit hook fails after ack", async () => {
+  it("does not restore an acked entry when a recovered send commit hook fails", async () => {
     const id = await enqueueDelivery(
       { channel: "demo-channel-a", to: "+1", payloads: [{ text: "a" }] },
       tmpDir(),
@@ -555,18 +555,15 @@ describe("delivery-queue recovery", () => {
       deferredBackoff: 0,
     });
     expect(await loadPendingDeliveries(tmpDir())).toHaveLength(0);
-    expect(readOutboundQueueStatus(tmpDir(), id)).toBe("failed");
-    const failedEntry = readQueuedEntry(tmpDir(), id);
-    expect(failedEntry.recoveryState).toBe("unknown_after_send");
-    expect(failedEntry.lastError).toContain("post-send commit hook failed");
-    expect(failedEntry.lastError).toContain("commit hook offline");
+    expect(readOutboundQueueStatus(tmpDir(), id)).toBeUndefined();
   });
 
-  it("does not leave a sent recovery replay pending when post-send state marking fails", async () => {
+  it("marks a recovered send unknown before ack so ack failure cannot make it replayable", async () => {
     const id = await enqueueDelivery(
       { channel: "demo-channel-a", to: "+1", payloads: [{ text: "a" }] },
       tmpDir(),
     );
+    let recoveryStateAtAck: string | undefined;
     vi.resetModules();
     vi.doMock("./delivery-queue-storage.js", async () => {
       const actual = await vi.importActual<typeof import("./delivery-queue-storage.js")>(
@@ -574,16 +571,17 @@ describe("delivery-queue recovery", () => {
       );
       return {
         ...actual,
-        markDeliveryPlatformOutcomeUnknown: vi.fn(async () => {
-          throw new Error("state db locked");
+        ackDelivery: vi.fn(async (entryId: string, stateDir?: string) => {
+          recoveryStateAtAck = (await actual.loadPendingDelivery(entryId, stateDir))?.recoveryState;
+          throw new Error("ack state db locked");
         }),
       };
     });
 
     try {
-      const { recoverPendingDeliveries: recoverWithMarkFailure } =
+      const { recoverPendingDeliveries: recoverWithAckFailure } =
         await import("./delivery-queue-recovery.js");
-      const summary = await recoverWithMarkFailure({
+      const summary = await recoverWithAckFailure({
         deliver: asDeliverFn(
           vi.fn().mockResolvedValue([{ channel: "demo-channel-a", messageId: "m1" }]),
         ),
@@ -598,12 +596,62 @@ describe("delivery-queue recovery", () => {
         skippedMaxRetries: 0,
         deferredBackoff: 0,
       });
-      expect(await loadPendingDeliveries(tmpDir())).toHaveLength(0);
-      expect(readOutboundQueueStatus(tmpDir(), id)).toBe("failed");
-      const failedEntry = readQueuedEntry(tmpDir(), id);
-      expect(failedEntry.recoveryState).toBe("unknown_after_send");
-      expect(failedEntry.lastError).toContain("failed to mark recovered delivery post-send state");
-      expect(failedEntry.lastError).toContain("state db locked");
+      expect(recoveryStateAtAck).toBe("unknown_after_send");
+      const pending = await loadPendingDeliveries(tmpDir());
+      expect(pending).toHaveLength(1);
+      expect(pending[0]?.id).toBe(id);
+      expect(pending[0]?.recoveryState).toBe("unknown_after_send");
+      expect(pending[0]?.lastError).toContain("ack state db locked");
+    } finally {
+      vi.doUnmock("./delivery-queue-storage.js");
+      vi.resetModules();
+    }
+  });
+
+  it("keeps a recovered send non-replayable when its post-send marker fails", async () => {
+    const id = await enqueueDelivery(
+      { channel: "demo-channel-a", to: "+1", payloads: [{ text: "a" }] },
+      tmpDir(),
+    );
+    vi.resetModules();
+    vi.doMock("./delivery-queue-storage.js", async () => {
+      const actual = await vi.importActual<typeof import("./delivery-queue-storage.js")>(
+        "./delivery-queue-storage.js",
+      );
+      return {
+        ...actual,
+        markDeliveryPlatformOutcomeUnknown: vi.fn(async () => {
+          throw new Error("post-send state db locked");
+        }),
+      };
+    });
+
+    try {
+      const { recoverPendingDeliveries: recoverWithMarkFailure } =
+        await import("./delivery-queue-recovery.js");
+      const summary = await recoverWithMarkFailure({
+        deliver: asDeliverFn(
+          vi.fn(async () => {
+            await markDeliveryPlatformSendAttemptStarted(id, tmpDir());
+            return [{ channel: "demo-channel-a", messageId: "m1" }];
+          }),
+        ),
+        cfg: baseCfg,
+        stateDir: tmpDir(),
+        log: createRecoveryLog(),
+      });
+
+      expect(summary).toEqual({
+        recovered: 0,
+        failed: 1,
+        skippedMaxRetries: 0,
+        deferredBackoff: 0,
+      });
+      const pending = await loadPendingDeliveries(tmpDir());
+      expect(pending).toHaveLength(1);
+      expect(pending[0]?.id).toBe(id);
+      expect(pending[0]?.recoveryState).toBe("send_attempt_started");
+      expect(pending[0]?.lastError).toContain("post-send state db locked");
     } finally {
       vi.doUnmock("./delivery-queue-storage.js");
       vi.resetModules();

--- a/src/infra/outbound/delivery-queue.storage.test.ts
+++ b/src/infra/outbound/delivery-queue.storage.test.ts
@@ -7,6 +7,7 @@ import {
   ackDelivery,
   enqueueDelivery,
   failDelivery,
+  failDeliveryAfterPlatformSend,
   loadPendingDeliveries,
   markDeliveryPlatformOutcomeUnknown,
   markDeliveryPlatformSendAttemptStarted,
@@ -175,6 +176,22 @@ describe("delivery-queue storage", () => {
       expect(typeof entry.lastAttemptAt).toBe("number");
       expect((entry.lastAttemptAt as number) > 0).toBe(true);
       expect(entry.lastError).toBe("connection refused");
+    });
+
+    it("keeps post-send failure evidence while recording the retry failure", async () => {
+      const id = await enqueueTextDelivery({
+        channel: "forum",
+        to: "123",
+        payloads: [{ text: "test" }],
+      });
+
+      await failDeliveryAfterPlatformSend(id, "state update failed", tmpDir());
+
+      const entry = readQueuedEntry(tmpDir(), id);
+      expect(entry.retryCount).toBe(1);
+      expect(entry.lastError).toBe("state update failed");
+      expect(entry.recoveryState).toBe("unknown_after_send");
+      expect(typeof entry.platformSendStartedAt).toBe("number");
     });
   });
 

--- a/src/infra/outbound/delivery-queue.ts
+++ b/src/infra/outbound/delivery-queue.ts
@@ -3,6 +3,7 @@ export {
   ackDelivery,
   enqueueDelivery,
   failDelivery,
+  failDeliveryAfterPlatformSend,
   loadPendingDelivery,
   loadPendingDeliveries,
   markDeliveryPlatformOutcomeUnknown,

--- a/src/plugin-sdk/reply-payload.test.ts
+++ b/src/plugin-sdk/reply-payload.test.ts
@@ -116,6 +116,83 @@ describe("sendPayloadWithChunkedTextAndMedia", () => {
 });
 
 describe("sendTextMediaPayload", () => {
+  it("reports each completed text chunk before a later chunk fails", async () => {
+    const sendText = vi
+      .fn()
+      .mockResolvedValueOnce({ channel: "test", messageId: "ab" })
+      .mockRejectedValueOnce(new Error("second chunk failed"));
+    const onDeliveryResult = vi.fn();
+
+    await expect(
+      sendTextMediaPayload({
+        channel: "test",
+        ctx: {
+          cfg: {},
+          to: "target",
+          text: "",
+          payload: { text: "abcd" },
+          onDeliveryResult,
+        },
+        adapter: {
+          textChunkLimit: 2,
+          chunker: () => ["ab", "cd"],
+          sendText,
+        },
+      }),
+    ).rejects.toThrow("second chunk failed");
+
+    expect(onDeliveryResult).toHaveBeenCalledTimes(1);
+    expect(onDeliveryResult).toHaveBeenCalledWith({ channel: "test", messageId: "ab" });
+  });
+
+  it("does not report callback-aware text sends twice", async () => {
+    const onDeliveryResult = vi.fn();
+    const result = { channel: "test", messageId: "m1" };
+
+    await sendTextMediaPayload({
+      channel: "test",
+      ctx: {
+        cfg: {},
+        to: "target",
+        text: "",
+        payload: { text: "hello" },
+        onDeliveryResult,
+      },
+      adapter: {
+        sendText: async (ctx) => {
+          await ctx.onDeliveryResult?.(result);
+          return result;
+        },
+      },
+    });
+
+    expect(onDeliveryResult).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not report callback-aware media sends twice", async () => {
+    const onDeliveryResult = vi.fn();
+    const result = { channel: "test", messageId: "m1" };
+
+    await sendTextMediaPayload({
+      channel: "test",
+      ctx: {
+        cfg: {},
+        to: "target",
+        text: "",
+        payload: { mediaUrl: "https://example.com/a.png" },
+        onDeliveryResult,
+      },
+      adapter: {
+        sendMedia: async (ctx) => {
+          await ctx.onDeliveryResult?.(result);
+          return result;
+        },
+      },
+    });
+
+    expect(onDeliveryResult).toHaveBeenCalledTimes(1);
+  });
+
   it("uses an implicit single-use reply only for the first text chunk", async () => {
     const sendText = vi.fn(async ({ text }) => ({ channel: "test", messageId: text }));
 

--- a/src/plugin-sdk/reply-payload.ts
+++ b/src/plugin-sdk/reply-payload.ts
@@ -226,6 +226,8 @@ export async function sendPayloadWithChunkedTextAndMedia<
   sendMedia: (ctx: TContext & { text: string; mediaUrl: string }) => Promise<TResult>;
   /** Result returned when payload has neither text nor media. */
   emptyResult: TResult;
+  /** Host callback that persists each completed sub-send before the next one starts. */
+  onResult?: (result: TResult) => Promise<void> | void;
 }): Promise<TResult> {
   const payload = params.ctx.payload as { text?: string; mediaUrls?: string[]; mediaUrl?: string };
   const text = payload.text ?? "";
@@ -241,12 +243,14 @@ export async function sendPayloadWithChunkedTextAndMedia<
       text,
       mediaUrl: urls[0],
     });
+    await params.onResult?.(lastResult);
     for (let i = 1; i < urls.length; i++) {
       lastResult = await params.sendMedia({
         ...params.ctx,
         text: "",
         mediaUrl: urls[i],
       });
+      await params.onResult?.(lastResult);
     }
     return lastResult;
   }
@@ -255,6 +259,7 @@ export async function sendPayloadWithChunkedTextAndMedia<
   let lastResult: TResult;
   for (const chunk of chunks) {
     lastResult = await params.sendText({ ...params.ctx, text: chunk });
+    await params.onResult?.(lastResult);
   }
   return lastResult!;
 }
@@ -275,6 +280,8 @@ export async function sendPayloadMediaSequence<TResult>(params: {
     /** Whether this is the first media entry in the original sequence. */
     isFirst: boolean;
   }) => Promise<TResult>;
+  /** Called after each successful media send and before the next send starts. */
+  onResult?: (result: TResult) => Promise<void> | void;
 }): Promise<TResult | undefined> {
   let lastResult: TResult | undefined;
   for (let i = 0; i < params.mediaUrls.length; i += 1) {
@@ -288,6 +295,7 @@ export async function sendPayloadMediaSequence<TResult>(params: {
       index: i,
       isFirst: i === 0,
     });
+    await params.onResult?.(lastResult);
   }
   return lastResult;
 }
@@ -304,6 +312,7 @@ export async function sendPayloadMediaSequenceOrFallback<TResult>(params: {
     index: number;
     isFirst: boolean;
   }) => Promise<TResult>;
+  onResult?: (result: TResult) => Promise<void> | void;
   /** Result returned when no media result is available. */
   fallbackResult: TResult;
   /** Optional callback used instead of `fallbackResult` when there are no media URLs. */
@@ -327,6 +336,7 @@ export async function sendPayloadMediaSequenceAndFinalize<TMediaResult, TResult>
     index: number;
     isFirst: boolean;
   }) => Promise<TMediaResult>;
+  onResult?: (result: TMediaResult) => Promise<void> | void;
   /** Final callback whose result is returned after optional media sends. */
   finalize: () => Promise<TResult>;
 }): Promise<TResult> {
@@ -358,14 +368,24 @@ export async function sendTextMediaPayload(params: {
     const lastResult = await sendPayloadMediaSequence({
       text,
       mediaUrls: urls,
-      send: async ({ text: textLocal, mediaUrl }) =>
-        await params.adapter.sendMedia!({
+      send: async ({ text: textLocal, mediaUrl }) => {
+        let childReported = false;
+        const result = await params.adapter.sendMedia!({
           ...params.ctx,
           text: textLocal,
           mediaUrl,
           ...(audioAsVoice === undefined ? {} : { audioAsVoice }),
           replyToId: nextReplyToId(),
-        }),
+          onDeliveryResult: async (deliveryResult) => {
+            childReported = true;
+            await params.ctx.onDeliveryResult?.(deliveryResult);
+          },
+        });
+        if (!childReported) {
+          await params.ctx.onDeliveryResult?.(result);
+        }
+        return result;
+      },
     });
     return lastResult ?? { channel: params.channel, messageId: "" };
   }
@@ -376,11 +396,19 @@ export async function sendTextMediaPayload(params: {
       : [text];
   let lastResult: Awaited<ReturnType<NonNullable<typeof params.adapter.sendText>>>;
   for (const chunk of chunks) {
+    let childReported = false;
     lastResult = await params.adapter.sendText!({
       ...params.ctx,
       text: chunk,
       replyToId: nextReplyToId(),
+      onDeliveryResult: async (deliveryResult) => {
+        childReported = true;
+        await params.ctx.onDeliveryResult?.(deliveryResult);
+      },
     });
+    if (!childReported) {
+      await params.ctx.onDeliveryResult?.(lastResult);
+    }
   }
   return lastResult!;
 }


### PR DESCRIPTION
## What Problem This Solves

Outbound recovery could successfully send one or more platform messages, then fail during later persistence, acknowledgement, or adapter work while leaving the canonical queue row eligible for replay. After a restart, users could receive duplicate replies or attachments that had already reached the channel.

## Why This Change Was Made

Recovery now owns one canonical queue row through the full send lifecycle:

- persist `send_attempt_started` before crossing the platform boundary;
- record every concrete sub-send result before another send or hook can fail;
- advance sent evidence to `unknown_after_send` before acknowledgement;
- acknowledge before running fallible commit hooks;
- reconcile partial batches by receipt-part multiplicity, including platforms such as LINE that reuse a constant message ID.

The maintainer rewrite removes the original parallel failed-diagnostic path. The same typed result callback is carried through core message delivery and every bundled multi-send adapter, so recovery no longer has to infer whether a rejected adapter sent nothing or sent part of a batch.

## User Impact

Recovered outbound replies no longer replay after the platform accepted them. Partial multi-message deliveries retain exact progress across failure or restart, while genuine pre-send failures remain retryable. The behavior applies consistently across bundled channels, including Discord, Feishu, LINE, Matrix, Microsoft Teams, Signal, Slack, Telegram, Twitch, WhatsApp, Zalo, and Zalouser.

## Evidence

- Changed-surface tests: 805 tests across 22 files and 14 Vitest shards passed.
- Focused final receipt reconciliation: 125 tests passed across core outbound delivery and LINE payload delivery.
- Exact-head heartbeat + core + LINE regression set: 137 tests passed, including the CI-discovered heartbeat expectation for the propagated delivery-result callback.
- Broad Testbox changed gate: `tbx_01kwny7am5ze6ef3m5v1gy5mwm`, 10m04, passed.
- Real Gateway restart/recovery QA: `tbx_01kwnxyzfmqjg0pe8d5xpm31pf`, passed with the interrupted marker emitted at most once and the recovery marker emitted exactly once.
- Full-branch Codex autoreview: clean, 0 findings, 0.94 confidence after fixing two repeated-platform-ID findings. Final exact-head fixture autoreview: clean, 0 findings, 0.99 confidence.
- Exact-head hosted gates after the final mainline rebase: CI 44/44 passed, with CodeQL, critical-quality, OpenGrep, security/dependency guards, and real-behavior proof green. Native `scripts/pr prepare-run 99600` accepted the exact head in `hosted_exact_head` mode.
- Additional standalone Testbox/Azure reruns were blocked before command start by Blacksmith shutdown/rate-limit errors and an Azure lease timeout; the successful broad Testbox run, real-Gateway scenario, and exact-head hosted gates cover the landed behavior.

No before/after screenshot applies: this is internal queue/recovery behavior with no UI surface.
