### PR TITLE
fix(google): bound OAuth token error response reads

### DIFF
--- a/extensions/google/oauth.test.ts
+++ b/extensions/google/oauth.test.ts
@@ -938,31 +938,27 @@ describe("loginGeminiCliOAuth", () => {
     expect(requests.filter(({ url }) => url.includes("v1internal:loadCodeAssist"))).toHaveLength(3);
   });
 
-  it("bounds token exchange error bodies without using response.text()", async () => {
-    const { response, text } = responseTextBodyWithTextTrap("x".repeat(32 * 1024), 500);
+  it.each([
+    [
+      "exchange",
+      "x",
+      async () =>
+        (await import("./oauth.token.js")).exchangeCodeForTokens("oauth-code", "pkce-verifier"),
+    ],
+    [
+      "refresh",
+      "y",
+      async () =>
+        (await import("./oauth.token.js")).refreshTokensForGeminiCli({ refresh: "refresh-token" }),
+    ],
+  ])("bounds token %s error bodies without using response.text()", async (_flow, fill, request) => {
+    const { response, text } = responseTextBodyWithTextTrap(fill.repeat(32 * 1024), 500);
     installGeminiOAuthFetchMock(() => undefined, { tokenResponse: () => response });
 
-    const { exchangeCodeForTokens } = await import("./oauth.token.js");
-    const error = await exchangeCodeForTokens("oauth-code", "pkce-verifier").catch(
-      (err: unknown) => err,
-    );
+    const error = await request().catch((err: unknown) => err);
 
     expect(error).toBeInstanceOf(Error);
-    expect((error as Error).message).toBe(`Token exchange failed: ${"x".repeat(8 * 1024)}`);
-    expect(text).not.toHaveBeenCalled();
-  });
-
-  it("bounds token refresh error bodies without using response.text()", async () => {
-    const { response, text } = responseTextBodyWithTextTrap("y".repeat(32 * 1024), 500);
-    installGeminiOAuthFetchMock(() => undefined, { tokenResponse: () => response });
-
-    const { refreshTokensForGeminiCli } = await import("./oauth.token.js");
-    const error = await refreshTokensForGeminiCli({ refresh: "refresh-token" }).catch(
-      (err: unknown) => err,
-    );
-
-    expect(error).toBeInstanceOf(Error);
-    expect((error as Error).message).toBe(`Token exchange failed: ${"y".repeat(8 * 1024)}`);
+    expect((error as Error).message).toBe(`Token exchange failed: ${fill.repeat(8 * 1024)}`);
     expect(text).not.toHaveBeenCalled();
   });
 

--- a/extensions/google/oauth.test.ts
+++ b/extensions/google/oauth.test.ts
@@ -680,6 +680,17 @@ describe("loginGeminiCliOAuth", () => {
     });
   }
 
+  function responseTextBodyWithTextTrap(body: string, status = 500) {
+    const response = new Response(body, {
+      status,
+      headers: { "Content-Type": "text/plain" },
+    });
+    const text = vi
+      .spyOn(response, "text")
+      .mockRejectedValue(new Error("unexpected response.text() call"));
+    return { response, text };
+  }
+
   function tokenResponse(): Response {
     return responseJson({
       access_token: "access-token",
@@ -925,6 +936,34 @@ describe("loginGeminiCliOAuth", () => {
       /loadCodeAssist failed/i,
     );
     expect(requests.filter(({ url }) => url.includes("v1internal:loadCodeAssist"))).toHaveLength(3);
+  });
+
+  it("bounds token exchange error bodies without using response.text()", async () => {
+    const { response, text } = responseTextBodyWithTextTrap("x".repeat(32 * 1024), 500);
+    installGeminiOAuthFetchMock(() => undefined, { tokenResponse: () => response });
+
+    const { exchangeCodeForTokens } = await import("./oauth.token.js");
+    const error = await exchangeCodeForTokens("oauth-code", "pkce-verifier").catch(
+      (err: unknown) => err,
+    );
+
+    expect(error).toBeInstanceOf(Error);
+    expect((error as Error).message).toBe(`Token exchange failed: ${"x".repeat(8 * 1024)}`);
+    expect(text).not.toHaveBeenCalled();
+  });
+
+  it("bounds token refresh error bodies without using response.text()", async () => {
+    const { response, text } = responseTextBodyWithTextTrap("y".repeat(32 * 1024), 500);
+    installGeminiOAuthFetchMock(() => undefined, { tokenResponse: () => response });
+
+    const { refreshTokensForGeminiCli } = await import("./oauth.token.js");
+    const error = await refreshTokensForGeminiCli({ refresh: "refresh-token" }).catch(
+      (err: unknown) => err,
+    );
+
+    expect(error).toBeInstanceOf(Error);
+    expect((error as Error).message).toBe(`Token exchange failed: ${"y".repeat(8 * 1024)}`);
+    expect(text).not.toHaveBeenCalled();
   });
 
   it("falls back to GOOGLE_CLOUD_PROJECT when all loadCodeAssist endpoints fail", async () => {

--- a/extensions/google/oauth.token.ts
+++ b/extensions/google/oauth.token.ts
@@ -3,6 +3,7 @@ import {
   asDateTimestampMs,
   resolveExpiresAtMsFromDurationSeconds,
 } from "openclaw/plugin-sdk/number-runtime";
+import { readResponseTextLimited } from "openclaw/plugin-sdk/provider-http";
 import { resolveOAuthClientConfig } from "./oauth.credentials.js";
 import { fetchWithTimeout } from "./oauth.http.js";
 import { resolveGoogleOAuthIdentity, resolveGooglePersonalOAuthIdentity } from "./oauth.project.js";
@@ -10,6 +11,7 @@ import { isGeminiCliPersonalOAuth } from "./oauth.settings.js";
 import { REDIRECT_URI, TOKEN_URL, type GeminiCliOAuthCredentials } from "./oauth.shared.js";
 
 const TOKEN_EXPIRY_BUFFER_MS = 5 * 60 * 1000;
+const GOOGLE_OAUTH_TOKEN_ERROR_BODY_LIMIT_BYTES = 8 * 1024;
 
 async function requestTokenGrant(body: URLSearchParams): Promise<{
   access_token?: string;
@@ -27,7 +29,10 @@ async function requestTokenGrant(body: URLSearchParams): Promise<{
   });
 
   if (!response.ok) {
-    const errorText = await response.text();
+    const errorText = await readResponseTextLimited(
+      response,
+      GOOGLE_OAUTH_TOKEN_ERROR_BODY_LIMIT_BYTES,
+    );
     throw new Error(`Token exchange failed: ${errorText}`);
   }
 


### PR DESCRIPTION
## Summary

- Bound Google Gemini CLI OAuth token error response reads before including provider error text in failures.
- Add regression coverage for exchange and refresh failures so oversized diagnostic bodies are truncated instead of fully buffered.

## What Problem This Solves

Google OAuth token grant failures previously used `response.text()` on non-OK responses. That fully consumes an external HTTP response body before throwing, so a malformed upstream/proxy/provider failure body could force OpenClaw to buffer more diagnostic text than needed.

## User Impact

Users who hit Google Gemini CLI OAuth exchange or refresh failures still receive the provider diagnostic prefix, but the failure path no longer depends on buffering an unbounded response body.

- **Why it matters / User impact:** OAuth setup or token refresh can fail during normal Gemini CLI provider use; this keeps that auth-provider failure path diagnosable without letting an external diagnostic body define memory usage.

## Origin / follow-up

Follows #97808.

- **Gap this fills:** #97808 bounded Chutes OAuth token error response reads; the Google Gemini CLI OAuth token grant path had the same unbounded non-OK body read pattern.
- **Consistency:** This uses the existing `readResponseTextLimited` provider HTTP helper with the same 8 KiB diagnostic budget used by related OAuth/provider integrations.

## Competition / linked PR analysis

No linked issue is being closed. I searched open PRs for the Google OAuth token response/body-read target and found no existing open PR covering this exact follow-up. The change is limited to `extensions/google/oauth.token.ts` plus targeted regression tests in `extensions/google/oauth.test.ts`.

## Real behavior proof

- **Behavior or issue addressed:** Google Gemini CLI OAuth token exchange failures now return a bounded provider diagnostic while exercising the real Google OAuth token endpoint failure path.
- **Real environment tested:** Local OpenClaw checkout on Linux, current PR head `6c1d7950f1b8e9eccdc1c2481509c2635d7805fd`, calling production `exchangeCodeForTokens` against `https://oauth2.googleapis.com/token` with an invalid redacted client id and invalid code.
- **Exact steps or command run after this patch:**

```bash
OPENCLAW_GEMINI_OAUTH_CLIENT_ID=<redacted-invalid-client> \
OPENCLAW_GEMINI_OAUTH_CLIENT_SECRET= \
pnpm -C /media/vdb/code/ai/aispace/openclaw-worktrees/followup-97808 exec tsx -e '<import exchangeCodeForTokens and call it with an invalid OAuth code/verifier>'
```

- **Evidence after fix:**

```text
HEAD=6c1d7950f1b8e9eccdc1c2481509c2635d7805fd
Command: OPENCLAW_GEMINI_OAUTH_CLIENT_ID=<redacted-invalid-client> pnpm -C "$TASK_WORKTREE" exec tsx -e <exchangeCodeForTokens invalid code>
observed error prefix: Token exchange failed: {
  "error": "invalid_client",
  "error_d
contains Token exchange failed: true
message length: 112
```

- **Observed result after fix:** The production Google OAuth token exchange path reached the real Google token endpoint, surfaced a `Token exchange failed:` diagnostic, and completed without requiring credentials or a successful account login.
- **What was not tested:** I did not perform a successful live Google OAuth browser login or force Google to return an oversized live error body; Google controls the live error body size. Oversized-body truncation is covered separately by regression tests, not claimed as the real behavior proof.
- **Fix classification:** Root cause fix

## Review findings addressed

N/A — new follow-up PR, no review findings yet.

## Regression Test Plan

- **Target test file:** `extensions/google/oauth.test.ts`
- **Scenario locked in:** Token exchange and token refresh failures with oversized diagnostic bodies return the 8 KiB bounded prefix and do not call `response.text()`.
- **Why this is the smallest reliable guardrail:** The test stays at the Google OAuth token helper boundary, covering both callers of `requestTokenGrant` without changing OAuth request construction, identity discovery, or project discovery behavior.

```text
pnpm -C /media/vdb/code/ai/aispace/openclaw-worktrees/followup-97808 exec vitest run extensions/google/oauth.test.ts

Test Files  1 passed (1)
     Tests  29 passed (29)
```

## Merge risk

- **Risk labels considered:** auth-provider, security-boundary
- **Risk explanation:** The touched file owns Google Gemini CLI OAuth token exchange/refresh handling, and OAuth failure diagnostics cross an external provider boundary.
- **Why acceptable:** The diff only changes non-OK diagnostic body reading to the shared bounded helper; successful token JSON parsing, request parameters, headers, credential lookup, and identity/project discovery are unchanged, and the live proof exercises the real Google token endpoint failure path.

## Risk / Compatibility

Low risk. Successful token responses still use the existing JSON parsing path. Only non-OK diagnostic text is capped, so callers keep the same error prefix with a bounded body preview.

## What was not changed

- **What did NOT change:** OAuth request parameters, headers, client credential discovery, identity discovery, token success parsing, Google project discovery, and personal OAuth mode behavior are all out of scope and unchanged.
- Public API / schema / protocol / defaults: unchanged.
- Channel/provider/session/security behavior outside the fixed path: unchanged.
- Unrelated cleanup, docs, formatting, lockfiles: none.

## Root Cause

- **Root cause:** The source-of-truth Google OAuth token grant helper, `requestTokenGrant`, read non-OK Google OAuth token responses with `response.text()`, which fully buffered external diagnostic bodies before the auth-provider failure was reported.
- **Why this is root-cause fix:** The non-OK token grant path now reads provider diagnostics through `readResponseTextLimited`, bounding the body read at the source before the error is constructed, rather than trimming after an unbounded buffer already exists.
- **Maintainer-ready confidence:** High; the patch is a two-file auth-provider follow-up, uses the shared provider HTTP helper, has fresh live endpoint proof for the failure path, and has targeted regression coverage for the oversized-body guardrail.
- **Patch quality notes:** Patch quality warning considered: this touches an auth-provider/security-boundary file, but it is not a fallback, catch-all, or symptom mask; it removes the unbounded read at the owning helper and leaves successful OAuth behavior unchanged.
- **Architecture / source-of-truth check:** `extensions/google/oauth.token.ts` is the owner for Gemini CLI OAuth token exchange and refresh grants; the change happens before downstream credential construction, identity discovery, and project discovery, so the diagnostic body is bounded at the provider boundary.
