### PR TITLE
improve(doctor): warn when cron jobs keep failing consecutive runs

### DIFF
--- a/src/commands/doctor/cron/index.test.ts
+++ b/src/commands/doctor/cron/index.test.ts
@@ -472,6 +472,7 @@ describe("maybeRepairLegacyCronStore", () => {
       expectNoteContaining("1 cron job has failed 3+ runs in a row", "Cron");
       expectNoteContaining("re-fires it on error backoff", "Cron");
       expectNoteContaining("resets on the next successful run", "Cron");
+      expectNoteContaining("interrupted by a gateway restart", "Cron");
       expectNoteContaining("openclaw cron show <id>", "Cron");
 
       // Observer-only: no repair prompt and the failure counters stay untouched.

--- a/src/commands/doctor/cron/index.test.ts
+++ b/src/commands/doctor/cron/index.test.ts
@@ -452,6 +452,87 @@ describe("maybeRepairLegacyCronStore", () => {
     });
   });
 
+  describe("chronic failure advisory", () => {
+    it("warns about repeatedly failing jobs without touching the store", async () => {
+      const storePath = await makeTempStorePath();
+      await writeCurrentCronStore(storePath, [
+        createCurrentCronJob({
+          id: "failing-job",
+          state: { lastRunStatus: "error", consecutiveErrors: 5, lastError: "boom" },
+        }),
+      ]);
+      const prompter = makePrompter(true);
+
+      await maybeRepairLegacyCronStore({
+        cfg: createCronConfig(storePath),
+        options: {},
+        prompter,
+      });
+
+      expectNoteContaining("1 cron job has failed 3+ runs in a row", "Cron");
+      expectNoteContaining("re-fires it on error backoff", "Cron");
+      expectNoteContaining("resets on the next successful run", "Cron");
+      expectNoteContaining("openclaw cron show <id>", "Cron");
+
+      // Observer-only: no repair prompt and the failure counters stay untouched.
+      expect(prompter.confirm).not.toHaveBeenCalled();
+      const jobs = await readPersistedJobs(storePath);
+      const state = requireRecord(requirePersistedJob(jobs, 0).state, "cron state");
+      expect(state.consecutiveErrors).toBe(5);
+    });
+
+    it("pluralizes and only counts enabled jobs at or above the threshold", async () => {
+      const storePath = await makeTempStorePath();
+      await writeCurrentCronStore(storePath, [
+        createCurrentCronJob({
+          id: "failing-a",
+          state: { lastRunStatus: "error", consecutiveErrors: 3 },
+        }),
+        createCurrentCronJob({
+          id: "failing-b",
+          state: { lastRunStatus: "error", consecutiveErrors: 12 },
+        }),
+        createCurrentCronJob({
+          id: "recovering",
+          state: { lastRunStatus: "error", consecutiveErrors: 2 },
+        }),
+        // Exhausted one-shot jobs get disabled with their error state retained;
+        // they no longer re-fire, so the advisory must not count them.
+        createCurrentCronJob({
+          id: "disabled-exhausted",
+          enabled: false,
+          state: { lastRunStatus: "error", consecutiveErrors: 9 },
+        }),
+      ]);
+
+      await maybeRepairLegacyCronStore({
+        cfg: createCronConfig(storePath),
+        options: {},
+        prompter: makePrompter(true),
+      });
+
+      expectNoteContaining("2 cron jobs have failed 3+ runs in a row", "Cron");
+    });
+
+    it("stays silent when failure streaks are below the threshold", async () => {
+      const storePath = await makeTempStorePath();
+      await writeCurrentCronStore(storePath, [
+        createCurrentCronJob({
+          id: "single-failure",
+          state: { lastRunStatus: "error", consecutiveErrors: 2 },
+        }),
+      ]);
+
+      await maybeRepairLegacyCronStore({
+        cfg: createCronConfig(storePath),
+        options: {},
+        prompter: makePrompter(true),
+      });
+
+      expectNoNoteContaining("runs in a row", "Cron");
+    });
+  });
+
   it("repairs legacy cron store fields and migrates notify fallback to webhook delivery", async () => {
     const storePath = await makeTempStorePath();
     await writeCronStore(storePath, [createLegacyCronJob()]);

--- a/src/commands/doctor/cron/index.ts
+++ b/src/commands/doctor/cron/index.ts
@@ -89,9 +89,11 @@ function countInFlightCronJobs(jobs: Array<Record<string, unknown>>): number {
 const CHRONIC_FAILURE_MIN_CONSECUTIVE_ERRORS = 3;
 
 // Count enabled jobs stuck in repeated run failures. `state.consecutiveErrors`
-// resets to 0 on the next successful run, so a lasting value means every recent
-// run failed; failure alerts are opt-in, so by default nothing else surfaces the
-// streak. Disabled jobs no longer re-fire (e.g. the scheduler disables exhausted
+// resets to 0 on the next successful run and also increments for runs interrupted
+// by a gateway restart (startup marks in-flight runs failed, `src/cron/service/ops.ts`),
+// so a streak can mean task failures, interrupted runs, or a mix — the note says so.
+// Failure alerts are opt-in, so by default nothing else surfaces the streak.
+// Disabled jobs no longer re-fire (e.g. the scheduler disables exhausted
 // one-shot jobs with their error state retained), so they are excluded.
 function countChronicallyFailingCronJobs(jobs: Array<Record<string, unknown>>): number {
   return jobs.filter((job) => {
@@ -451,7 +453,7 @@ export async function maybeRepairLegacyCronStore(params: {
     note(
       [
         `${pluralize(chronicFailureCount, "cron job")} ${chronicFailureCount === 1 ? "has" : "have"} failed ${CHRONIC_FAILURE_MIN_CONSECUTIVE_ERRORS}+ runs in a row (\`state.consecutiveErrors\`), so the scheduler only re-fires ${chronicFailureCount === 1 ? "it" : "them"} on error backoff.`,
-        `- The count resets on the next successful run; a lasting streak usually means the job's prompt, session target, or provider needs attention. Failure alerts are opt-in, so this may be the only notice.`,
+        `- The count resets on the next successful run and also counts runs interrupted by a gateway restart, so a lasting streak means repeated task failures, repeatedly interrupted runs, or a mix. Failure alerts are opt-in, so this may be the only notice.`,
         `- Review with ${formatCliCommand("openclaw cron list")} or ${formatCliCommand("openclaw cron show <id>")}.`,
       ].join("\n"),
       "Cron",

--- a/src/commands/doctor/cron/index.ts
+++ b/src/commands/doctor/cron/index.ts
@@ -82,6 +82,36 @@ function countInFlightCronJobs(jobs: Array<Record<string, unknown>>): number {
   }).length;
 }
 
+// Fixed advisory threshold: three failures in a row is a clear chronic signal on
+// its own. It coincides with the scheduler's default transient-retry budget, but
+// `cron.retry.maxAttempts` is per-job configurable and doctor deliberately does
+// not mirror retry config or exhaustion semantics (`consecutiveErrors > maxAttempts`).
+const CHRONIC_FAILURE_MIN_CONSECUTIVE_ERRORS = 3;
+
+// Count enabled jobs stuck in repeated run failures. `state.consecutiveErrors`
+// resets to 0 on the next successful run, so a lasting value means every recent
+// run failed; failure alerts are opt-in, so by default nothing else surfaces the
+// streak. Disabled jobs no longer re-fire (e.g. the scheduler disables exhausted
+// one-shot jobs with their error state retained), so they are excluded.
+function countChronicallyFailingCronJobs(jobs: Array<Record<string, unknown>>): number {
+  return jobs.filter((job) => {
+    // Missing `enabled` counts as enabled, matching `isJobEnabled`
+    // (`src/cron/service/jobs.ts`); only an explicit `false` is excluded.
+    if (job.enabled === false) {
+      return false;
+    }
+    const state = job.state;
+    if (typeof state !== "object" || state === null) {
+      return false;
+    }
+    const consecutiveErrors = (state as { consecutiveErrors?: unknown }).consecutiveErrors;
+    return (
+      typeof consecutiveErrors === "number" &&
+      consecutiveErrors >= CHRONIC_FAILURE_MIN_CONSECUTIVE_ERRORS
+    );
+  }).length;
+}
+
 type LegacyCronRepairState = {
   storePath: string;
   quarantinePath: string;
@@ -410,6 +440,18 @@ export async function maybeRepairLegacyCronStore(params: {
       [
         `${pluralize(inFlightCount, "cron job")} ${inFlightCount === 1 ? "is" : "are"} still marked in-flight (\`state.runningAtMs\` is set), so ${formatCliCommand("openclaw cron list")} shows ${subject} as \`running\`.`,
         `- If no gateway is currently executing ${subject}, the marker is left over from an interrupted run; the gateway marks such runs interrupted the next time it starts.`,
+        `- Review with ${formatCliCommand("openclaw cron list")} or ${formatCliCommand("openclaw cron show <id>")}.`,
+      ].join("\n"),
+      "Cron",
+    );
+  }
+
+  const chronicFailureCount = countChronicallyFailingCronJobs(rawJobs);
+  if (chronicFailureCount > 0) {
+    note(
+      [
+        `${pluralize(chronicFailureCount, "cron job")} ${chronicFailureCount === 1 ? "has" : "have"} failed ${CHRONIC_FAILURE_MIN_CONSECUTIVE_ERRORS}+ runs in a row (\`state.consecutiveErrors\`), so the scheduler only re-fires ${chronicFailureCount === 1 ? "it" : "them"} on error backoff.`,
+        `- The count resets on the next successful run; a lasting streak usually means the job's prompt, session target, or provider needs attention. Failure alerts are opt-in, so this may be the only notice.`,
         `- Review with ${formatCliCommand("openclaw cron list")} or ${formatCliCommand("openclaw cron show <id>")}.`,
       ].join("\n"),
       "Cron",


### PR DESCRIPTION
Related: #99602

## What Problem This Solves

A cron job can fail every run for weeks — re-firing only on error backoff — and `openclaw doctor` says nothing. Failure alerts are opt-in (with no `failureAlert` config nothing is sent), so in a default setup a chronically failing job produces no notice anywhere: doctor is exactly the tool users run to ask "is anything wrong?", and it stays silent.

## Why This Change Was Made

The scheduler already persists the signal: `state.consecutiveErrors` increments on every failed run — including runs marked failed because a gateway restart interrupted them — and resets to 0 on the next success, so a lasting value means every recent run failed or was cut short. The advisory text states the interruption case explicitly so a crash-looping gateway is not misread as a broken job. This change adds an observer-only doctor advisory alongside the existing in-flight-marker advisory in the same check: it counts enabled jobs with a streak of 3 or more and prints a note pointing at `openclaw cron list` / `openclaw cron show <id>`. The threshold is a fixed advisory bar — three-in-a-row is a clear chronic signal on its own; it happens to coincide with the scheduler's default transient-retry budget, but `cron.retry.maxAttempts` is per-job configurable and the advisory deliberately does not mirror retry config or exhaustion semantics. Disabled jobs are excluded because they no longer re-fire (the scheduler disables exhausted one-shot jobs while retaining their error state for inspection); counting them would produce a permanent false positive. No store mutation, no `--fix` behavior, no prompt, and no change to retry or alerting policy. Schedule-computation errors are deliberately out of scope — those already auto-disable the job with a user notification after three strikes.

## User Impact

`openclaw doctor` now tells operators when cron jobs are stuck in a failure loop (for example, `2 cron jobs have failed 3+ runs in a row`) and where to look next. Healthy setups see no new output; the advisory only appears when at least one job crosses the threshold.

## Evidence

Real-behavior capture (local `node --import tsx` script over the production modules — not part of the diff — isolated `OPENCLAW_STATE_DIR`, no mocks): jobs written through the real `saveCronJobsStore()` into the shared SQLite state DB, then the real doctor cron check (`maybeRepairLegacyCronStore()`) run against it. The prompter stub throws if invoked, proving the advisory never prompts.

Before (base `0ad58848b3`) — a job that failed 12 consecutive runs produces no output at all:

```
=== real doctor cron check (maybeRepairLegacyCronStore) ===
=== done (no prompt was raised) ===
```

After (head `6c4ec234a2`):

```
=== real doctor cron check (maybeRepairLegacyCronStore) ===
│
◇  Cron ───────────────────────────────────────────────────────────────────╮
│                                                                          │
│  1 cron job has failed 3+ runs in a row (`state.consecutiveErrors`), so  │
│  the scheduler only re-fires it on error backoff.                        │
│  - The count resets on the next successful run and also counts runs      │
│    interrupted by a gateway restart, so a lasting streak means repeated  │
│    task failures, repeatedly interrupted runs, or a mix. Failure alerts  │
│    are opt-in, so this may be the only notice.                           │
│  - Review with openclaw cron list or openclaw cron show <id>.            │
│                                                                          │
├──────────────────────────────────────────────────────────────────────────╯
=== done (no prompt was raised) ===
```

Focused unit tests: all 53 tests in `src/commands/doctor/cron/index.test.ts` pass — the new cases drive the same real check over a temp store and cover the single-job advisory (asserting the store stays untouched and no repair prompt fires), pluralization with the threshold boundary (streaks of 3 and 12 counted; 2 not; a disabled exhausted job with a streak of 9 not), and silence below the threshold.

Focused tests were run with `node scripts/run-vitest.mjs src/commands/doctor/cron/index.test.ts`; changed-lane checks (`node scripts/check-changed.mjs --base upstream/main`) and `codex review` were run locally before submission.
