### PR TITLE
fix: keep Bedrock live smoke on Bedrock runtime

### DIFF
--- a/packages/ai/src/api-registry.test.ts
+++ b/packages/ai/src/api-registry.test.ts
@@ -1,11 +1,16 @@
 // LLM Runtime tests cover api registry behavior.
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   createApiRegistry,
   createAssistantMessageEventStream,
   createLlmRuntime,
   type Model,
 } from "./index.js";
+import {
+  getApiProvider,
+  streamSimple as streamSimpleDefault,
+  unregisterApiProviders,
+} from "./internal/default-runtime.js";
 
 const TEST_SOURCE_ID = "test:llm-runtime-api-registry";
 const emptyStream = () => createAssistantMessageEventStream();
@@ -24,6 +29,10 @@ const model = {
 } satisfies Model;
 
 describe("LLM API registry", () => {
+  afterEach(() => {
+    unregisterApiProviders(TEST_SOURCE_ID);
+  });
+
   it("rejects mismatched model API calls", () => {
     const registry = createApiRegistry();
     registry.registerApiProvider(
@@ -54,6 +63,27 @@ describe("LLM API registry", () => {
     expect(() => second.streamSimple(model, { messages: [] })).toThrow(
       "No API provider registered for api: test-api",
     );
+  });
+
+  it("shares default runtime registrations across duplicated module instances", async () => {
+    const duplicateRuntime = (await import(
+      ["./internal/default-runtime.js", "duplicate-runtime"].join("?")
+    )) as typeof import("./internal/default-runtime.js");
+    const streamSimple = vi.fn(emptyStream);
+    duplicateRuntime.registerApiProvider(
+      {
+        api: "test-api",
+        stream: emptyStream,
+        streamSimple,
+      },
+      TEST_SOURCE_ID,
+    );
+
+    expect(getApiProvider("test-api")).toBeDefined();
+
+    streamSimpleDefault(model, { messages: [] });
+
+    expect(streamSimple).toHaveBeenCalledOnce();
   });
 
   it("unregisters every provider owned by one source", () => {

--- a/packages/ai/src/internal/default-runtime.ts
+++ b/packages/ai/src/internal/default-runtime.ts
@@ -2,11 +2,32 @@
 // facade (src/llm). Deliberately not part of the public package API: external
 // consumers create isolated runtimes via createLlmRuntime(); exporting these
 // from the root barrel would reintroduce the mutable process-global registry.
-import { createApiRegistry } from "../api-registry.js";
-import { createLlmRuntime } from "../stream.js";
+import { createApiRegistry, type ApiRegistry } from "../api-registry.js";
+import { createLlmRuntime, type LlmRuntime } from "../stream.js";
 
-export const defaultApiRegistry = createApiRegistry();
-export const defaultLlmRuntime = createLlmRuntime(defaultApiRegistry);
+type DefaultRuntimeState = {
+  registry: ApiRegistry;
+  runtime: LlmRuntime;
+};
+
+const DEFAULT_RUNTIME_KEY = Symbol.for("openclaw.ai.defaultRuntime");
+
+function resolveDefaultRuntime(): DefaultRuntimeState {
+  const globalStore = globalThis as Record<PropertyKey, unknown>;
+  if (Object.hasOwn(globalStore, DEFAULT_RUNTIME_KEY)) {
+    return globalStore[DEFAULT_RUNTIME_KEY] as DefaultRuntimeState;
+  }
+  const registry = createApiRegistry();
+  const runtime = createLlmRuntime(registry);
+  const state = { registry, runtime };
+  globalStore[DEFAULT_RUNTIME_KEY] = state;
+  return state;
+}
+
+const defaultRuntime = resolveDefaultRuntime();
+
+export const defaultApiRegistry = defaultRuntime.registry;
+export const defaultLlmRuntime = defaultRuntime.runtime;
 
 export const {
   registerApiProvider,

--- a/src/gateway/gateway-models.profiles.live.test.ts
+++ b/src/gateway/gateway-models.profiles.live.test.ts
@@ -1156,13 +1156,37 @@ function resolveExplicitLiveFallbackApi(provider: string): Api {
   );
 }
 
-function resolveDefaultBedrockLiveBaseUrl(env: NodeJS.ProcessEnv = process.env): string {
+function resolveDefaultBedrockLiveBaseUrl(
+  params: {
+    cfg?: OpenClawConfig;
+    env?: NodeJS.ProcessEnv;
+  } = {},
+): string {
+  const env = params.env ?? process.env;
   const region =
+    resolveBedrockDiscoveryRegion(params.cfg) ??
     normalizeOptionalEnvValue(env.AWS_REGION) ??
     normalizeOptionalEnvValue(env.AWS_DEFAULT_REGION) ??
     resolveAwsProfileRegion(env) ??
     DEFAULT_BEDROCK_LIVE_REGION;
   return `https://bedrock-runtime.${region}.amazonaws.com`;
+}
+
+function resolveBedrockDiscoveryRegion(cfg: OpenClawConfig | undefined): string | undefined {
+  const pluginConfig = cfg?.plugins?.entries?.["amazon-bedrock"]?.config;
+  if (!isRecord(pluginConfig)) {
+    return undefined;
+  }
+  const discoveryConfig = pluginConfig.discovery;
+  if (!isRecord(discoveryConfig)) {
+    return undefined;
+  }
+  const region = discoveryConfig.region;
+  return typeof region === "string" ? normalizeOptionalEnvValue(region) : undefined;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 
 function resolveAwsProfileRegion(env: NodeJS.ProcessEnv): string | undefined {
@@ -1843,6 +1867,39 @@ describe("buildLiveGatewayConfig", () => {
 
       expect(cfg.models?.providers?.["amazon-bedrock"]?.baseUrl).toBe(
         "https://bedrock-runtime.ap-south-1.amazonaws.com",
+      );
+    } finally {
+      restoreOptionalEnv("AWS_REGION", previousAwsRegion);
+    }
+  });
+
+  it("uses configured Bedrock discovery regions for explicit fallback models", () => {
+    const previousAwsRegion = process.env.AWS_REGION;
+    setTestEnvValue("AWS_REGION", "eu-west-1");
+    try {
+      const cfg = buildLiveGatewayConfig({
+        cfg: {
+          plugins: {
+            entries: {
+              "amazon-bedrock": {
+                config: {
+                  discovery: {
+                    region: "ap-northeast-1",
+                  },
+                },
+              },
+            },
+          },
+        },
+        candidates: [
+          createExplicitLiveFallbackModel("amazon-bedrock", "global.anthropic.claude-sonnet-4-6"),
+        ],
+        liveAgentDir: GATEWAY_LIVE_CONFIG_TEST_AGENT_DIR,
+        liveAgentWorkspaceDir: GATEWAY_LIVE_CONFIG_TEST_WORKSPACE,
+      });
+
+      expect(cfg.models?.providers?.["amazon-bedrock"]?.baseUrl).toBe(
+        "https://bedrock-runtime.ap-northeast-1.amazonaws.com",
       );
     } finally {
       restoreOptionalEnv("AWS_REGION", previousAwsRegion);
@@ -3040,27 +3097,34 @@ function mergeLiveProviderConfig(params: {
   };
 }
 
-function buildLiveProviderConfigs(candidates: Array<Model>): Record<string, ModelProviderConfig> {
+function buildLiveProviderConfigs(params: {
+  candidates: Array<Model>;
+  cfg: OpenClawConfig;
+}): Record<string, ModelProviderConfig> {
   const providers: Record<string, ModelProviderConfig> = {};
-  for (const model of candidates) {
+  for (const model of params.candidates) {
     const existing = providers[model.provider];
     if (existing) {
       existing.models ??= [];
       existing.models.push(toLiveModelConfig(model));
       continue;
     }
-    providers[model.provider] = buildLiveProviderConfig(model);
+    providers[model.provider] = buildLiveProviderConfig({ model, cfg: params.cfg });
   }
   return providers;
 }
 
-function buildLiveProviderConfig(model: Model): ModelProviderConfig {
+function buildLiveProviderConfig(params: {
+  model: Model;
+  cfg: OpenClawConfig;
+}): ModelProviderConfig {
+  const { model } = params;
   const provider = normalizeProviderId(model.provider);
   const config: ModelProviderConfig = {
     api: model.api as ModelProviderConfig["api"],
     baseUrl:
       provider === "amazon-bedrock"
-        ? (model.baseUrl ?? resolveDefaultBedrockLiveBaseUrl())
+        ? (model.baseUrl ?? resolveDefaultBedrockLiveBaseUrl({ cfg: params.cfg }))
         : model.baseUrl,
     timeoutSeconds: resolveGatewayLiveProviderTimeoutSeconds(),
     models: [toLiveModelConfig(model)],
@@ -3217,7 +3281,10 @@ function buildLiveGatewayConfig(params: {
   const providerOverrides = params.providerOverrides ?? {};
   const lmstudioProvider = params.cfg.models?.providers?.lmstudio;
   const baseProviders = params.cfg.models?.providers ?? {};
-  const candidateProviders = buildLiveProviderConfigs(params.candidates);
+  const candidateProviders = buildLiveProviderConfigs({
+    candidates: params.candidates,
+    cfg: params.cfg,
+  });
   const discoveredProviders = Object.fromEntries(
     Object.entries(candidateProviders).map(([provider, discovered]) => [
       provider,

--- a/src/gateway/gateway-models.profiles.live.test.ts
+++ b/src/gateway/gateway-models.profiles.live.test.ts
@@ -1135,13 +1135,25 @@ function createGatewayLiveTestModel(provider: string, id: string): Model {
     provider,
     id,
     name: id,
-    api: "openai-responses",
+    api: resolveExplicitLiveFallbackApi(provider),
     input: ["text"],
     cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
     contextWindow: 1_000,
     maxTokens: 100,
     reasoning: false,
   } as Model;
+}
+
+const EXPLICIT_LIVE_FALLBACK_API_BY_PROVIDER: Partial<Record<string, Api>> = {
+  "amazon-bedrock": "bedrock-converse-stream",
+};
+
+const DEFAULT_BEDROCK_LIVE_BASE_URL = "https://bedrock-runtime.us-east-1.amazonaws.com";
+
+function resolveExplicitLiveFallbackApi(provider: string): Api {
+  return (
+    EXPLICIT_LIVE_FALLBACK_API_BY_PROVIDER[normalizeProviderId(provider)] ?? "openai-responses"
+  );
 }
 
 function createExplicitLiveFallbackModel(provider: string, id: string): Model {
@@ -1250,6 +1262,33 @@ describe("resolveExplicitLiveModelCandidates", () => {
     }
     expect(candidates).toEqual([createExplicitLiveFallbackModel("openai", "gpt-5.5")]);
     expect(candidates[0]?.contextWindow).toBeGreaterThanOrEqual(4_000);
+  });
+
+  it("uses the Bedrock Converse API for explicit Bedrock fallback candidates", () => {
+    const modelRef = "amazon-bedrock/global.anthropic.claude-sonnet-4-6";
+    const matcher = createLiveTargetMatcher({
+      providerFilter: new Set(["amazon-bedrock"]),
+      modelFilter: new Set([modelRef]),
+      env: {},
+    });
+    const candidates = resolveExplicitLiveModelCandidates({
+      modelRegistry: createGatewayLiveTestRegistry({
+        find(provider, modelId) {
+          expect(provider).toBe("amazon-bedrock");
+          expect(modelId).toBe("global.anthropic.claude-sonnet-4-6");
+          return undefined;
+        },
+      }),
+      modelFilter: new Set([modelRef]),
+      providerFilter: new Set(["amazon-bedrock"]),
+      targetMatcher: matcher,
+    });
+
+    expect(candidates?.[0]).toMatchObject({
+      provider: "amazon-bedrock",
+      id: "global.anthropic.claude-sonnet-4-6",
+      api: "bedrock-converse-stream",
+    });
   });
 
   it("falls back to enumeration for ambiguous model-only filters", () => {
@@ -1564,6 +1603,29 @@ describe("buildLiveGatewayConfig", () => {
     expect(cfg.models?.providers?.google?.timeoutSeconds).toBeGreaterThanOrEqual(
       Math.ceil(GATEWAY_LIVE_MODEL_TIMEOUT_MS / 1_000),
     );
+  });
+
+  it("writes valid AWS SDK provider config for explicit Bedrock fallback models", () => {
+    const cfg = buildLiveGatewayConfig({
+      cfg: {},
+      candidates: [
+        createExplicitLiveFallbackModel("amazon-bedrock", "global.anthropic.claude-sonnet-4-6"),
+      ],
+      liveAgentDir: GATEWAY_LIVE_CONFIG_TEST_AGENT_DIR,
+      liveAgentWorkspaceDir: GATEWAY_LIVE_CONFIG_TEST_WORKSPACE,
+    });
+
+    expect(cfg.models?.providers?.["amazon-bedrock"]).toMatchObject({
+      api: "bedrock-converse-stream",
+      auth: "aws-sdk",
+      baseUrl: DEFAULT_BEDROCK_LIVE_BASE_URL,
+      models: [
+        {
+          id: "global.anthropic.claude-sonnet-4-6",
+          api: "bedrock-converse-stream",
+        },
+      ],
+    });
   });
 });
 
@@ -2617,14 +2679,30 @@ function buildLiveProviderConfigs(candidates: Array<Model>): Record<string, Mode
       existing.models.push(toLiveModelConfig(model));
       continue;
     }
-    providers[model.provider] = {
-      api: model.api as ModelProviderConfig["api"],
-      baseUrl: model.baseUrl,
-      timeoutSeconds: resolveGatewayLiveProviderTimeoutSeconds(),
-      models: [toLiveModelConfig(model)],
-    };
+    providers[model.provider] = buildLiveProviderConfig(model);
   }
   return providers;
+}
+
+function buildLiveProviderConfig(model: Model): ModelProviderConfig {
+  const provider = normalizeProviderId(model.provider);
+  const config: ModelProviderConfig = {
+    api: model.api as ModelProviderConfig["api"],
+    baseUrl:
+      provider === "amazon-bedrock"
+        ? (model.baseUrl ?? DEFAULT_BEDROCK_LIVE_BASE_URL)
+        : model.baseUrl,
+    timeoutSeconds: resolveGatewayLiveProviderTimeoutSeconds(),
+    models: [toLiveModelConfig(model)],
+  };
+  if (provider === "amazon-bedrock") {
+    return {
+      ...config,
+      api: model.api as ModelProviderConfig["api"],
+      auth: "aws-sdk",
+    };
+  }
+  return config;
 }
 
 function parseExplicitLiveModelRef(

--- a/src/gateway/gateway-models.profiles.live.test.ts
+++ b/src/gateway/gateway-models.profiles.live.test.ts
@@ -1873,6 +1873,34 @@ describe("buildLiveGatewayConfig", () => {
     }
   });
 
+  it("keeps explicit Bedrock fallback models on the Bedrock runtime", () => {
+    const cfg = buildLiveGatewayConfig({
+      cfg: {
+        models: {
+          providers: {
+            "amazon-bedrock": {
+              api: "openai-responses",
+              auth: "api-key",
+              baseUrl: "https://bedrock-runtime.ap-south-1.amazonaws.com",
+              models: [],
+            },
+          },
+        },
+      },
+      candidates: [
+        createExplicitLiveFallbackModel("amazon-bedrock", "global.anthropic.claude-sonnet-4-6"),
+      ],
+      liveAgentDir: GATEWAY_LIVE_CONFIG_TEST_AGENT_DIR,
+      liveAgentWorkspaceDir: GATEWAY_LIVE_CONFIG_TEST_WORKSPACE,
+    });
+
+    expect(cfg.models?.providers?.["amazon-bedrock"]).toMatchObject({
+      api: "bedrock-converse-stream",
+      auth: "aws-sdk",
+      baseUrl: "https://bedrock-runtime.ap-south-1.amazonaws.com",
+    });
+  });
+
   it("uses configured Bedrock discovery regions for explicit fallback models", () => {
     const previousAwsRegion = process.env.AWS_REGION;
     setTestEnvValue("AWS_REGION", "eu-west-1");
@@ -3068,6 +3096,7 @@ function toLiveModelConfig(model: Model): NonNullable<ModelProviderConfig["model
 }
 
 function mergeLiveProviderConfig(params: {
+  provider: string;
   base: ModelProviderConfig | undefined;
   discovered: ModelProviderConfig;
 }): ModelProviderConfig {
@@ -3084,10 +3113,14 @@ function mergeLiveProviderConfig(params: {
       mergedModels.set(model.id, model);
     }
   }
+  const useDiscoveredRuntime = normalizeProviderId(params.provider) === "amazon-bedrock";
   return {
     ...params.discovered,
     ...params.base,
-    api: params.base?.api ?? params.discovered.api,
+    api: useDiscoveredRuntime ? params.discovered.api : (params.base?.api ?? params.discovered.api),
+    auth: useDiscoveredRuntime
+      ? params.discovered.auth
+      : (params.base?.auth ?? params.discovered.auth),
     baseUrl: params.base?.baseUrl ?? params.discovered.baseUrl,
     timeoutSeconds: Math.max(
       params.base?.timeoutSeconds ?? 0,
@@ -3288,7 +3321,7 @@ function buildLiveGatewayConfig(params: {
   const discoveredProviders = Object.fromEntries(
     Object.entries(candidateProviders).map(([provider, discovered]) => [
       provider,
-      mergeLiveProviderConfig({ base: baseProviders[provider], discovered }),
+      mergeLiveProviderConfig({ provider, base: baseProviders[provider], discovered }),
     ]),
   );
   const nextProviders = {

--- a/src/gateway/gateway-models.profiles.live.test.ts
+++ b/src/gateway/gateway-models.profiles.live.test.ts
@@ -1,6 +1,6 @@
 // Live model profile gateway tests sweep configured providers, auth profiles, model listing, and smoke prompts.
 import { randomBytes, randomUUID } from "node:crypto";
-import { writeSync } from "node:fs";
+import { existsSync, readFileSync, writeSync } from "node:fs";
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
@@ -1148,12 +1148,138 @@ const EXPLICIT_LIVE_FALLBACK_API_BY_PROVIDER: Partial<Record<string, Api>> = {
   "amazon-bedrock": "bedrock-converse-stream",
 };
 
-const DEFAULT_BEDROCK_LIVE_BASE_URL = "https://bedrock-runtime.us-east-1.amazonaws.com";
+const DEFAULT_BEDROCK_LIVE_REGION = "us-east-1";
 
 function resolveExplicitLiveFallbackApi(provider: string): Api {
   return (
     EXPLICIT_LIVE_FALLBACK_API_BY_PROVIDER[normalizeProviderId(provider)] ?? "openai-responses"
   );
+}
+
+function resolveDefaultBedrockLiveBaseUrl(env: NodeJS.ProcessEnv = process.env): string {
+  const region =
+    normalizeOptionalEnvValue(env.AWS_REGION) ??
+    normalizeOptionalEnvValue(env.AWS_DEFAULT_REGION) ??
+    resolveAwsProfileRegion(env) ??
+    DEFAULT_BEDROCK_LIVE_REGION;
+  return `https://bedrock-runtime.${region}.amazonaws.com`;
+}
+
+function resolveAwsProfileRegion(env: NodeJS.ProcessEnv): string | undefined {
+  const profile = normalizeOptionalEnvValue(env.AWS_PROFILE) ?? "default";
+  const homeDir = normalizeOptionalEnvValue(env.HOME) ?? os.homedir();
+  const credentialsRegion = readAwsProfileRegionFromFile(
+    resolveAwsSharedFilePath(
+      env.AWS_SHARED_CREDENTIALS_FILE,
+      homeDir,
+      path.join(".aws", "credentials"),
+    ),
+    profile,
+    "credentials",
+  );
+  if (credentialsRegion) {
+    return credentialsRegion;
+  }
+  return readAwsProfileRegionFromFile(
+    resolveAwsSharedFilePath(env.AWS_CONFIG_FILE, homeDir, path.join(".aws", "config")),
+    profile,
+    "config",
+  );
+}
+
+function resolveAwsSharedFilePath(
+  configuredPath: string | undefined,
+  homeDir: string,
+  defaultRelativePath: string,
+): string {
+  const normalized = normalizeOptionalEnvValue(configuredPath);
+  if (!normalized) {
+    return path.join(homeDir, defaultRelativePath);
+  }
+  if (normalized === "~") {
+    return homeDir;
+  }
+  if (normalized.startsWith("~/")) {
+    return path.join(homeDir, normalized.slice(2));
+  }
+  return path.resolve(normalized);
+}
+
+function readAwsProfileRegionFromFile(
+  filePath: string,
+  profile: string,
+  fileKind: "config" | "credentials",
+): string | undefined {
+  if (!existsSync(filePath)) {
+    return undefined;
+  }
+  try {
+    return parseAwsProfileRegion(readFileSync(filePath, "utf8"), profile, fileKind);
+  } catch {
+    return undefined;
+  }
+}
+
+function parseAwsProfileRegion(
+  contents: string,
+  profile: string,
+  fileKind: "config" | "credentials",
+): string | undefined {
+  let currentSection: string | undefined;
+  for (const rawLine of contents.split(/\r?\n/u)) {
+    const line = stripAwsSharedIniComment(rawLine).trim();
+    if (!line) {
+      continue;
+    }
+    const section = /^\[([^\]]+)\]$/u.exec(line);
+    if (section) {
+      currentSection = normalizeAwsProfileSection(section[1] ?? "", fileKind);
+      continue;
+    }
+    if (currentSection !== profile) {
+      continue;
+    }
+    const equalsIndex = line.indexOf("=");
+    if (equalsIndex <= 0) {
+      continue;
+    }
+    const key = line.slice(0, equalsIndex).trim();
+    const value = line.slice(equalsIndex + 1).trim();
+    if (key !== "region") {
+      continue;
+    }
+    return normalizeOptionalEnvValue(value);
+  }
+  return undefined;
+}
+
+function stripAwsSharedIniComment(value: string): string {
+  return value.split(/(^|\s)[;#]/u)[0] ?? "";
+}
+
+function normalizeAwsProfileSection(section: string, fileKind: "config" | "credentials"): string {
+  const trimmed = section.trim();
+  if (trimmed === "default" || fileKind === "credentials") {
+    return trimmed;
+  }
+  const profileSection = /^profile\s+(?:"([^"]+)"|'([^']+)'|([\w@+.%:/-]+))$/u.exec(trimmed);
+  return profileSection
+    ? (profileSection[1] ?? profileSection[2] ?? profileSection[3] ?? "")
+    : trimmed;
+}
+
+function normalizeOptionalEnvValue(value: string | undefined): string | undefined {
+  const trimmed = value?.trim();
+  if (!trimmed) {
+    return undefined;
+  }
+  if (
+    (trimmed.startsWith('"') && trimmed.endsWith('"')) ||
+    (trimmed.startsWith("'") && trimmed.endsWith("'"))
+  ) {
+    return trimmed.slice(1, -1).trim() || undefined;
+  }
+  return trimmed;
 }
 
 function createExplicitLiveFallbackModel(provider: string, id: string): Model {
@@ -1606,26 +1732,270 @@ describe("buildLiveGatewayConfig", () => {
   });
 
   it("writes valid AWS SDK provider config for explicit Bedrock fallback models", () => {
-    const cfg = buildLiveGatewayConfig({
-      cfg: {},
-      candidates: [
-        createExplicitLiveFallbackModel("amazon-bedrock", "global.anthropic.claude-sonnet-4-6"),
-      ],
-      liveAgentDir: GATEWAY_LIVE_CONFIG_TEST_AGENT_DIR,
-      liveAgentWorkspaceDir: GATEWAY_LIVE_CONFIG_TEST_WORKSPACE,
-    });
+    const previous = {
+      awsRegion: process.env.AWS_REGION,
+      awsDefaultRegion: process.env.AWS_DEFAULT_REGION,
+      awsProfile: process.env.AWS_PROFILE,
+      awsConfigFile: process.env.AWS_CONFIG_FILE,
+      awsSharedCredentialsFile: process.env.AWS_SHARED_CREDENTIALS_FILE,
+      home: process.env.HOME,
+    };
+    try {
+      deleteTestEnvValue("AWS_REGION");
+      deleteTestEnvValue("AWS_DEFAULT_REGION");
+      deleteTestEnvValue("AWS_PROFILE");
+      deleteTestEnvValue("AWS_CONFIG_FILE");
+      deleteTestEnvValue("AWS_SHARED_CREDENTIALS_FILE");
+      setTestEnvValue("HOME", path.join(os.tmpdir(), `openclaw-empty-aws-home-${randomUUID()}`));
 
-    expect(cfg.models?.providers?.["amazon-bedrock"]).toMatchObject({
-      api: "bedrock-converse-stream",
-      auth: "aws-sdk",
-      baseUrl: DEFAULT_BEDROCK_LIVE_BASE_URL,
-      models: [
-        {
-          id: "global.anthropic.claude-sonnet-4-6",
-          api: "bedrock-converse-stream",
+      const cfg = buildLiveGatewayConfig({
+        cfg: {},
+        candidates: [
+          createExplicitLiveFallbackModel("amazon-bedrock", "global.anthropic.claude-sonnet-4-6"),
+        ],
+        liveAgentDir: GATEWAY_LIVE_CONFIG_TEST_AGENT_DIR,
+        liveAgentWorkspaceDir: GATEWAY_LIVE_CONFIG_TEST_WORKSPACE,
+      });
+
+      expect(cfg.models?.providers?.["amazon-bedrock"]).toMatchObject({
+        api: "bedrock-converse-stream",
+        auth: "aws-sdk",
+        baseUrl: "https://bedrock-runtime.us-east-1.amazonaws.com",
+        models: [
+          {
+            id: "global.anthropic.claude-sonnet-4-6",
+            api: "bedrock-converse-stream",
+          },
+        ],
+      });
+    } finally {
+      restoreOptionalEnv("AWS_REGION", previous.awsRegion);
+      restoreOptionalEnv("AWS_DEFAULT_REGION", previous.awsDefaultRegion);
+      restoreOptionalEnv("AWS_PROFILE", previous.awsProfile);
+      restoreOptionalEnv("AWS_CONFIG_FILE", previous.awsConfigFile);
+      restoreOptionalEnv("AWS_SHARED_CREDENTIALS_FILE", previous.awsSharedCredentialsFile);
+      restoreOptionalEnv("HOME", previous.home);
+    }
+  });
+
+  it("uses AWS_REGION for explicit Bedrock fallback provider config", () => {
+    const previous = {
+      awsRegion: process.env.AWS_REGION,
+      awsDefaultRegion: process.env.AWS_DEFAULT_REGION,
+      awsProfile: process.env.AWS_PROFILE,
+      awsConfigFile: process.env.AWS_CONFIG_FILE,
+      awsSharedCredentialsFile: process.env.AWS_SHARED_CREDENTIALS_FILE,
+      home: process.env.HOME,
+    };
+    try {
+      setTestEnvValue("AWS_REGION", "eu-west-1");
+      deleteTestEnvValue("AWS_DEFAULT_REGION");
+      deleteTestEnvValue("AWS_PROFILE");
+      deleteTestEnvValue("AWS_CONFIG_FILE");
+      deleteTestEnvValue("AWS_SHARED_CREDENTIALS_FILE");
+      deleteTestEnvValue("HOME");
+
+      const cfg = buildLiveGatewayConfig({
+        cfg: {},
+        candidates: [
+          createExplicitLiveFallbackModel("amazon-bedrock", "global.anthropic.claude-sonnet-4-6"),
+        ],
+        liveAgentDir: GATEWAY_LIVE_CONFIG_TEST_AGENT_DIR,
+        liveAgentWorkspaceDir: GATEWAY_LIVE_CONFIG_TEST_WORKSPACE,
+      });
+
+      expect(cfg.models?.providers?.["amazon-bedrock"]?.baseUrl).toBe(
+        "https://bedrock-runtime.eu-west-1.amazonaws.com",
+      );
+    } finally {
+      restoreOptionalEnv("AWS_REGION", previous.awsRegion);
+      restoreOptionalEnv("AWS_DEFAULT_REGION", previous.awsDefaultRegion);
+      restoreOptionalEnv("AWS_PROFILE", previous.awsProfile);
+      restoreOptionalEnv("AWS_CONFIG_FILE", previous.awsConfigFile);
+      restoreOptionalEnv("AWS_SHARED_CREDENTIALS_FILE", previous.awsSharedCredentialsFile);
+      restoreOptionalEnv("HOME", previous.home);
+    }
+  });
+
+  it("preserves configured Bedrock provider endpoints for explicit fallback models", () => {
+    const previousAwsRegion = process.env.AWS_REGION;
+    setTestEnvValue("AWS_REGION", "eu-west-1");
+    try {
+      const cfg = buildLiveGatewayConfig({
+        cfg: {
+          models: {
+            providers: {
+              "amazon-bedrock": {
+                api: "bedrock-converse-stream",
+                auth: "aws-sdk",
+                baseUrl: "https://bedrock-runtime.ap-south-1.amazonaws.com",
+                models: [],
+              },
+            },
+          },
         },
-      ],
-    });
+        candidates: [
+          createExplicitLiveFallbackModel("amazon-bedrock", "global.anthropic.claude-sonnet-4-6"),
+        ],
+        liveAgentDir: GATEWAY_LIVE_CONFIG_TEST_AGENT_DIR,
+        liveAgentWorkspaceDir: GATEWAY_LIVE_CONFIG_TEST_WORKSPACE,
+      });
+
+      expect(cfg.models?.providers?.["amazon-bedrock"]?.baseUrl).toBe(
+        "https://bedrock-runtime.ap-south-1.amazonaws.com",
+      );
+    } finally {
+      restoreOptionalEnv("AWS_REGION", previousAwsRegion);
+    }
+  });
+
+  it("uses selected AWS profile region for explicit Bedrock fallback provider config", async () => {
+    const previous = {
+      awsRegion: process.env.AWS_REGION,
+      awsDefaultRegion: process.env.AWS_DEFAULT_REGION,
+      awsProfile: process.env.AWS_PROFILE,
+      awsConfigFile: process.env.AWS_CONFIG_FILE,
+      awsSharedCredentialsFile: process.env.AWS_SHARED_CREDENTIALS_FILE,
+      home: process.env.HOME,
+    };
+    const tempHome = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-bedrock-aws-home-"));
+    try {
+      const awsDir = path.join(tempHome, ".aws");
+      await fs.mkdir(awsDir, { recursive: true });
+      await fs.writeFile(
+        path.join(awsDir, "config"),
+        "[profile bedrock-live]\nregion = ap-southeast-2\n",
+        "utf8",
+      );
+      deleteTestEnvValue("AWS_REGION");
+      deleteTestEnvValue("AWS_DEFAULT_REGION");
+      setTestEnvValue("AWS_PROFILE", "bedrock-live");
+      deleteTestEnvValue("AWS_CONFIG_FILE");
+      deleteTestEnvValue("AWS_SHARED_CREDENTIALS_FILE");
+      setTestEnvValue("HOME", tempHome);
+
+      const cfg = buildLiveGatewayConfig({
+        cfg: {},
+        candidates: [
+          createExplicitLiveFallbackModel("amazon-bedrock", "global.anthropic.claude-sonnet-4-6"),
+        ],
+        liveAgentDir: GATEWAY_LIVE_CONFIG_TEST_AGENT_DIR,
+        liveAgentWorkspaceDir: GATEWAY_LIVE_CONFIG_TEST_WORKSPACE,
+      });
+
+      expect(cfg.models?.providers?.["amazon-bedrock"]?.baseUrl).toBe(
+        "https://bedrock-runtime.ap-southeast-2.amazonaws.com",
+      );
+    } finally {
+      restoreOptionalEnv("AWS_REGION", previous.awsRegion);
+      restoreOptionalEnv("AWS_DEFAULT_REGION", previous.awsDefaultRegion);
+      restoreOptionalEnv("AWS_PROFILE", previous.awsProfile);
+      restoreOptionalEnv("AWS_CONFIG_FILE", previous.awsConfigFile);
+      restoreOptionalEnv("AWS_SHARED_CREDENTIALS_FILE", previous.awsSharedCredentialsFile);
+      restoreOptionalEnv("HOME", previous.home);
+      await fs.rm(tempHome, { recursive: true, force: true, maxRetries: 5, retryDelay: 50 });
+    }
+  });
+
+  it("strips AWS profile region inline comments for explicit Bedrock fallback config", async () => {
+    const previous = {
+      awsRegion: process.env.AWS_REGION,
+      awsDefaultRegion: process.env.AWS_DEFAULT_REGION,
+      awsProfile: process.env.AWS_PROFILE,
+      awsConfigFile: process.env.AWS_CONFIG_FILE,
+      awsSharedCredentialsFile: process.env.AWS_SHARED_CREDENTIALS_FILE,
+      home: process.env.HOME,
+    };
+    const tempHome = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-bedrock-aws-home-"));
+    try {
+      const awsDir = path.join(tempHome, ".aws");
+      await fs.mkdir(awsDir, { recursive: true });
+      await fs.writeFile(
+        path.join(awsDir, "config"),
+        '[profile "bedrock-live"] # live smoke\nregion = eu-central-1 # live smoke\n',
+        "utf8",
+      );
+      deleteTestEnvValue("AWS_REGION");
+      deleteTestEnvValue("AWS_DEFAULT_REGION");
+      setTestEnvValue("AWS_PROFILE", "bedrock-live");
+      deleteTestEnvValue("AWS_CONFIG_FILE");
+      deleteTestEnvValue("AWS_SHARED_CREDENTIALS_FILE");
+      setTestEnvValue("HOME", tempHome);
+
+      const cfg = buildLiveGatewayConfig({
+        cfg: {},
+        candidates: [
+          createExplicitLiveFallbackModel("amazon-bedrock", "global.anthropic.claude-sonnet-4-6"),
+        ],
+        liveAgentDir: GATEWAY_LIVE_CONFIG_TEST_AGENT_DIR,
+        liveAgentWorkspaceDir: GATEWAY_LIVE_CONFIG_TEST_WORKSPACE,
+      });
+
+      expect(cfg.models?.providers?.["amazon-bedrock"]?.baseUrl).toBe(
+        "https://bedrock-runtime.eu-central-1.amazonaws.com",
+      );
+    } finally {
+      restoreOptionalEnv("AWS_REGION", previous.awsRegion);
+      restoreOptionalEnv("AWS_DEFAULT_REGION", previous.awsDefaultRegion);
+      restoreOptionalEnv("AWS_PROFILE", previous.awsProfile);
+      restoreOptionalEnv("AWS_CONFIG_FILE", previous.awsConfigFile);
+      restoreOptionalEnv("AWS_SHARED_CREDENTIALS_FILE", previous.awsSharedCredentialsFile);
+      restoreOptionalEnv("HOME", previous.home);
+      await fs.rm(tempHome, { recursive: true, force: true, maxRetries: 5, retryDelay: 50 });
+    }
+  });
+
+  it("prefers AWS credentials profile regions over config profile regions", async () => {
+    const previous = {
+      awsRegion: process.env.AWS_REGION,
+      awsDefaultRegion: process.env.AWS_DEFAULT_REGION,
+      awsProfile: process.env.AWS_PROFILE,
+      awsConfigFile: process.env.AWS_CONFIG_FILE,
+      awsSharedCredentialsFile: process.env.AWS_SHARED_CREDENTIALS_FILE,
+      home: process.env.HOME,
+    };
+    const tempHome = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-bedrock-aws-home-"));
+    try {
+      const awsDir = path.join(tempHome, ".aws");
+      await fs.mkdir(awsDir, { recursive: true });
+      await fs.writeFile(
+        path.join(awsDir, "config"),
+        "[profile bedrock-live]\nregion = us-west-2\n",
+        "utf8",
+      );
+      await fs.writeFile(
+        path.join(awsDir, "credentials"),
+        "[bedrock-live]\nregion = ca-central-1\n",
+        "utf8",
+      );
+      deleteTestEnvValue("AWS_REGION");
+      deleteTestEnvValue("AWS_DEFAULT_REGION");
+      setTestEnvValue("AWS_PROFILE", "bedrock-live");
+      deleteTestEnvValue("AWS_CONFIG_FILE");
+      deleteTestEnvValue("AWS_SHARED_CREDENTIALS_FILE");
+      setTestEnvValue("HOME", tempHome);
+
+      const cfg = buildLiveGatewayConfig({
+        cfg: {},
+        candidates: [
+          createExplicitLiveFallbackModel("amazon-bedrock", "global.anthropic.claude-sonnet-4-6"),
+        ],
+        liveAgentDir: GATEWAY_LIVE_CONFIG_TEST_AGENT_DIR,
+        liveAgentWorkspaceDir: GATEWAY_LIVE_CONFIG_TEST_WORKSPACE,
+      });
+
+      expect(cfg.models?.providers?.["amazon-bedrock"]?.baseUrl).toBe(
+        "https://bedrock-runtime.ca-central-1.amazonaws.com",
+      );
+    } finally {
+      restoreOptionalEnv("AWS_REGION", previous.awsRegion);
+      restoreOptionalEnv("AWS_DEFAULT_REGION", previous.awsDefaultRegion);
+      restoreOptionalEnv("AWS_PROFILE", previous.awsProfile);
+      restoreOptionalEnv("AWS_CONFIG_FILE", previous.awsConfigFile);
+      restoreOptionalEnv("AWS_SHARED_CREDENTIALS_FILE", previous.awsSharedCredentialsFile);
+      restoreOptionalEnv("HOME", previous.home);
+      await fs.rm(tempHome, { recursive: true, force: true, maxRetries: 5, retryDelay: 50 });
+    }
   });
 });
 
@@ -2690,7 +3060,7 @@ function buildLiveProviderConfig(model: Model): ModelProviderConfig {
     api: model.api as ModelProviderConfig["api"],
     baseUrl:
       provider === "amazon-bedrock"
-        ? (model.baseUrl ?? DEFAULT_BEDROCK_LIVE_BASE_URL)
+        ? (model.baseUrl ?? resolveDefaultBedrockLiveBaseUrl())
         : model.baseUrl,
     timeoutSeconds: resolveGatewayLiveProviderTimeoutSeconds(),
     models: [toLiveModelConfig(model)],


### PR DESCRIPTION
Related: #87876

AI-assisted: yes

## What Problem This Solves

Fixes an issue where maintainers running explicit Bedrock Gateway live smokes could select `amazon-bedrock/...` models but fail before exercising Bedrock Converse. Explicit fallback candidates were synthesized as OpenAI Responses models or written with an invalid temporary provider config, and duplicate source-module loading could hide the registered Bedrock API provider.

## Why This Change Was Made

The live harness now keeps explicit Bedrock fallback candidates on `bedrock-converse-stream`, writes a valid AWS SDK Bedrock provider config for temporary live model files, derives the temporary Bedrock runtime region from configured provider endpoints, AWS env, or the selected AWS profile instead of pinning `us-east-1`, and shares LLM API provider registrations across duplicate module instances in the same process.

## User Impact

Maintainers can use explicit Bedrock model refs in Gateway live smokes to validate the real Bedrock runtime path for their AWS profile/region setup instead of tripping over harness/setup failures. This PR is a test/live-smoke enabler and does not close #87876 by itself.

## Evidence

- `node scripts/run-vitest.mjs packages/llm-runtime/src/api-registry.test.ts`
- `node scripts/test-live.mjs -- src/gateway/gateway-models.profiles.live.test.ts -t "writes valid AWS SDK provider config|uses AWS_REGION|preserves configured Bedrock provider endpoints|uses configured Bedrock discovery regions|uses selected AWS profile region|strips AWS profile region inline comments|prefers AWS credentials profile regions|uses the Bedrock Converse API"`
- `git diff --check`
- `~/.agents/skills/autoreview/scripts/autoreview --mode local --prompt "Review autofix for PR #99607, https://github.com/openclaw/openclaw/pull/99607#issuecomment-4878396209. ..."` -> clean, no accepted/actionable findings.
- Real Bedrock Gateway live smoke with AWS profile auth only, no exported static AWS credentials and no `AWS_REGION`/`AWS_DEFAULT_REGION` in the smoke process:

```text
$ unset AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY AWS_SESSION_TOKEN AWS_REGION AWS_DEFAULT_REGION AWS_BEARER_TOKEN_BEDROCK
$ OPENCLAW_LIVE_USE_REAL_HOME=1 \
  OPENCLAW_LIVE_GATEWAY=1 \
  OPENCLAW_LIVE_GATEWAY_PROVIDERS=amazon-bedrock \
  OPENCLAW_LIVE_GATEWAY_MODELS=amazon-bedrock/global.anthropic.claude-sonnet-4-6 \
  OPENCLAW_LIVE_GATEWAY_MAX_MODELS=1 \
  OPENCLAW_LIVE_GATEWAY_SMOKE=1 \
  OPENCLAW_LIVE_GATEWAY_THINKING=off \
  AWS_PROFILE=<profile> AWS_SDK_LOAD_CONFIG=1 \
  node scripts/test-live.mjs --no-quiet -- src/gateway/gateway-models.profiles.live.test.ts -t "runs meaningful prompts across models with available keys"

[live] [all-models] wanted=1 total=133
[live] [all-models] candidates=1 skipped=0
[live] [all-models] selection=explicit
[gateway] auto-enabled plugins for this runtime without writing config:
- amazon-bedrock/global.anthropic.claude-sonnet-4-6 model configured, enabled automatically.
[gateway] agent model: amazon-bedrock/global.anthropic.claude-sonnet-4-6 (thinking=adaptive, fast=off)
[gateway] http server listening (11 plugins: acpx, amazon-bedrock, bonjour, browser, canvas, device-pair, file-transfer, memory-core, ollama, phone-control, talk-voice)
[live] [all-models] running 1 models (thinking=off)
[live] [all-models] 1/1 amazon-bedrock/global.anthropic.claude-sonnet-4-6: prompt
[agent] run <run-id> ended with stopReason=stop
[live] [all-models] 1/1 amazon-bedrock/global.anthropic.claude-sonnet-4-6: tool-read
[agent] run <run-id> ended with stopReason=stop
[live] [all-models] 1/1 amazon-bedrock/global.anthropic.claude-sonnet-4-6: done

 Test Files  1 passed (1)
      Tests  1 passed | 101 skipped (102)
   Duration  88.95s
```

