### PR TITLE
fix(openai): bound ChatGPT OAuth token error response reads

### DIFF
--- a/extensions/openai/openai-chatgpt-oauth-flow.runtime.test.ts
+++ b/extensions/openai/openai-chatgpt-oauth-flow.runtime.test.ts
@@ -29,6 +29,22 @@ function mockTokenResponseText(body: string, status = 200): void {
   });
 }
 
+function mockTokenErrorBodyWithBodyTraps(body: string, status = 500) {
+  const response = new Response(body, {
+    status,
+    headers: { "Content-Type": "text/plain" },
+  });
+  const text = vi
+    .spyOn(response, "text")
+    .mockRejectedValue(new Error("unexpected response.text() call"));
+  const arrayBuffer = vi
+    .spyOn(response, "arrayBuffer")
+    .mockRejectedValue(new Error("unexpected response.arrayBuffer() call"));
+  const release = vi.fn(async () => undefined);
+  ssrfMocks.fetchWithSsrFGuard.mockResolvedValueOnce({ response, release });
+  return { arrayBuffer, release, text };
+}
+
 afterEach(() => {
   ssrfMocks.fetchWithSsrFGuard.mockReset();
 });
@@ -143,6 +159,27 @@ describe("OpenAI Codex OAuth flow", () => {
     });
   });
 
+  it("bounds token exchange error bodies without materializing the full response", async () => {
+    const body = "x".repeat(32 * 1024);
+    const { arrayBuffer, release, text } = mockTokenErrorBodyWithBodyTraps(body, 500);
+
+    const result = await testing.exchangeAuthorizationCode(
+      "code",
+      "verifier",
+      testing.resolveRedirectUri("localhost"),
+      { timeoutMs: 5 },
+    );
+
+    expect(result).toEqual({
+      type: "failed",
+      status: 500,
+      message: `OpenAI Codex token exchange failed (500): ${"x".repeat(8 * 1024)}`,
+    });
+    expect(arrayBuffer).not.toHaveBeenCalled();
+    expect(text).not.toHaveBeenCalled();
+    expect(release).toHaveBeenCalledTimes(1);
+  });
+
   it("times out token refresh requests", async () => {
     ssrfMocks.fetchWithSsrFGuard.mockRejectedValueOnce(timeoutError());
 
@@ -173,5 +210,21 @@ describe("OpenAI Codex OAuth flow", () => {
       type: "failed",
       message: "OpenAI Codex token refresh response missing fields: expires_in",
     });
+  });
+
+  it("bounds token refresh error bodies without materializing the full response", async () => {
+    const body = "y".repeat(32 * 1024);
+    const { arrayBuffer, release, text } = mockTokenErrorBodyWithBodyTraps(body, 500);
+
+    const result = await testing.refreshAccessToken("old-refresh-token", { timeoutMs: 5 });
+
+    expect(result).toEqual({
+      type: "failed",
+      status: 500,
+      message: `OpenAI Codex token refresh failed (500): ${"y".repeat(8 * 1024)}`,
+    });
+    expect(arrayBuffer).not.toHaveBeenCalled();
+    expect(text).not.toHaveBeenCalled();
+    expect(release).toHaveBeenCalledTimes(1);
   });
 });

--- a/extensions/openai/openai-chatgpt-oauth-flow.runtime.ts
+++ b/extensions/openai/openai-chatgpt-oauth-flow.runtime.ts
@@ -6,6 +6,7 @@
  */
 
 import { createLazyRuntimeModule } from "openclaw/plugin-sdk/lazy-runtime";
+import { readResponseTextLimited } from "openclaw/plugin-sdk/provider-http";
 import {
   parseOAuthAuthorizationInput,
   resolveOAuthTokenExpiresAt,
@@ -38,6 +39,7 @@ const CALLBACK_HOST = resolveCallbackHost();
 const REDIRECT_URI = resolveRedirectUri(CALLBACK_HOST);
 const MANUAL_PROMPT_FALLBACK_MS = 15_000;
 const TOKEN_REQUEST_TIMEOUT_MS = 30_000;
+const OPENAI_CODEX_TOKEN_ERROR_BODY_LIMIT_BYTES = 8 * 1024;
 const SCOPE = "openid profile email offline_access";
 
 type TokenSuccess = { type: "success"; access: string; refresh: string; expires: number };
@@ -160,6 +162,17 @@ function formatTokenRequestError(
   return `OpenAI Codex token ${operation} error: ${error instanceof Error ? error.message : String(error)}`;
 }
 
+async function materializeTokenResponse(response: Response): Promise<Response> {
+  const responseBody = response.ok
+    ? await response.arrayBuffer()
+    : await readResponseTextLimited(response, OPENAI_CODEX_TOKEN_ERROR_BODY_LIMIT_BYTES);
+  return new Response(responseBody, {
+    status: response.status,
+    statusText: response.statusText,
+    headers: response.headers,
+  });
+}
+
 async function postTokenForm(
   body: URLSearchParams,
   options: TokenRequestOptions = {},
@@ -178,12 +191,7 @@ async function postTokenForm(
     auditContext: "openai-chatgpt-oauth-token",
   });
   try {
-    const responseBody = await response.arrayBuffer();
-    return new Response(responseBody, {
-      status: response.status,
-      statusText: response.statusText,
-      headers: response.headers,
-    });
+    return await materializeTokenResponse(response);
   } finally {
     await release();
   }
@@ -216,7 +224,10 @@ async function exchangeAuthorizationCode(
   }
 
   if (!response.ok) {
-    const text = await response.text().catch(() => "");
+    const text = await readResponseTextLimited(
+      response,
+      OPENAI_CODEX_TOKEN_ERROR_BODY_LIMIT_BYTES,
+    ).catch(() => "");
     return {
       type: "failed",
       status: response.status,
@@ -258,7 +269,10 @@ async function refreshAccessToken(
     );
 
     if (!response.ok) {
-      const text = await response.text().catch(() => "");
+      const text = await readResponseTextLimited(
+        response,
+        OPENAI_CODEX_TOKEN_ERROR_BODY_LIMIT_BYTES,
+      ).catch(() => "");
       return {
         type: "failed",
         status: response.status,


### PR DESCRIPTION
## Summary

- Bound OpenAI ChatGPT OAuth token error response materialization before returning token failure diagnostics.
- Keep successful token responses on the existing JSON path while capping non-OK token response bodies at 8 KiB.
- Add focused regression coverage for token exchange and refresh error paths.

## What Problem This Solves

OpenAI ChatGPT OAuth token exchange and refresh previously materialized every token response with `response.arrayBuffer()` before checking `response.ok`, then read non-OK diagnostics again with `response.text()`. That made the auth-provider failure path buffer external error bodies before OpenClaw could report a bounded diagnostic.

## User Impact

Users who hit ChatGPT OAuth token exchange or refresh failures still get the OpenAI status and diagnostic text, but OpenClaw no longer needs to materialize an unbounded token error body first.

- **Why it matters / User impact:** ChatGPT OAuth is part of Codex subscription provider setup and token refresh; bounding the external error body keeps that auth-provider failure path diagnosable without letting a provider/proxy error page define memory usage.

## Origin / follow-up

Follows #98496.

- **Gap this fills:** #98496 bounded Tlon external error response reads; the OpenAI ChatGPT OAuth token flow had the same class of non-OK external response materialization gap.
- **Consistency:** This follows the repository pattern of using `readResponseTextLimited` at provider boundaries and retaining targeted tests for oversized diagnostic bodies.

## Competition / linked PR analysis

No linked issue is being closed. I searched open PRs for this OpenAI ChatGPT OAuth token error-body target and found no existing open PR covering the same follow-up. The diff is limited to `extensions/openai/openai-chatgpt-oauth-flow.runtime.ts` and its focused runtime test file.

## Real behavior proof

- **Behavior or issue addressed:** The OpenAI token failure boundary can read a real non-OK OpenAI token response through OpenClaw guarded fetch and the same bounded diagnostic reader used by the patched token flow.
- **Real environment tested:** Local OpenClaw checkout on Linux, current PR head `2aaa9d6ffeed9c453515802c785fac47ec567b2d`, using OpenClaw `fetchWithSsrFGuard` with trusted environment proxy mode to reach `https://auth.openai.com/oauth/token`, then reading the real non-OK response with `readResponseTextLimited` at the 8 KiB token diagnostic budget.
- **Exact steps or command run after this patch:**

```bash
pnpm -C /media/vdb/code/ai/aispace/openclaw-worktrees/followup-98496 exec tsx -e '<fetchWithSsrFGuard trusted_env_proxy POST to real OpenAI token endpoint, then readResponseTextLimited(response, 8 * 1024)>'
```

- **Evidence after fix:**

```text
HEAD=2aaa9d6ffeed9c453515802c785fac47ec567b2d
Command: pnpm -C "$TASK_WORKTREE" exec tsx -e <fetchWithSsrFGuard trusted_env_proxy to real OpenAI token endpoint, then readResponseTextLimited>
real endpoint status: 403
real endpoint ok: false
bounded text prefix: {"error":{"code":"unsupported_country_region_territory","message":"Country, region, or territory not supported","param":
bounded text length: 153
release completed: true
```

- **Observed result after fix:** The proof reached the real OpenAI token endpoint, observed a real non-OK provider response, read it through the bounded diagnostic helper under the token error budget, and released the guarded fetch resource.
- **What was not tested:** I did not perform a successful browser OAuth login or force OpenAI to return an oversized live error body; OpenAI controls the live error body size. Oversized-body truncation is covered by focused regression tests, not claimed as the real behavior proof.
- **Fix classification:** Root cause fix

## Review findings addressed

N/A — new follow-up PR, no review findings yet.

## Regression Test Plan

- **Target test file:** `extensions/openai/openai-chatgpt-oauth-flow.runtime.test.ts`
- **Scenario locked in:** Token exchange and refresh failures with oversized diagnostic bodies avoid full `arrayBuffer()` materialization, avoid `response.text()`, preserve release handling, and return the 8 KiB bounded failure message.
- **Why this is the smallest reliable guardrail:** The test stays at the ChatGPT OAuth token runtime boundary, covering both callers of `postTokenForm` without touching callback-server login flow, PKCE, token success parsing, or account identity extraction.

```text
pnpm -C /media/vdb/code/ai/aispace/openclaw-worktrees/followup-98496 exec vitest run extensions/openai/openai-chatgpt-oauth-flow.runtime.test.ts

Test Files  1 passed (1)
     Tests  12 passed (12)
```

## Merge risk

- **Risk labels considered:** auth-provider, security-boundary
- **Risk explanation:** The touched file owns OpenAI ChatGPT OAuth token exchange and refresh, and the failure path crosses an external provider boundary.
- **Why acceptable:** The change is limited to non-OK diagnostic body materialization; successful token responses still use the existing JSON parsing path, and the live proof exercises a real OpenAI token endpoint failure while regression coverage locks in oversized-body behavior.

## Risk / Compatibility

Low risk. Successful token responses still materialize and parse as before. Only non-OK token diagnostics are capped before constructing the failure response, so callers keep the same status-aware failure shape with bounded text.

## What was not changed

- **What did NOT change:** OAuth authorization URL construction, callback handling, PKCE generation, token success parsing, refresh credential output, account identity extraction, and provider API key behavior are unchanged.
- Public API / schema / protocol / defaults: unchanged.
- Channel/provider/session/security behavior outside the token failure diagnostic path: unchanged.
- Unrelated cleanup, docs, formatting, lockfiles: none.

## Root Cause

- **Root cause:** The source-of-truth ChatGPT OAuth token request helper, `postTokenForm`, materialized every OpenAI token response with `response.arrayBuffer()` before the exchange/refresh code checked `response.ok`, and the failure branches then read diagnostic text with `response.text()`.
- **Why this is root-cause fix:** The token response materialization step now branches on `response.ok` and routes non-OK provider diagnostics through `readResponseTextLimited` at the provider boundary before the failure response exists, so the unbounded buffer is removed at its source rather than trimmed later.
- **Maintainer-ready confidence:** High; the patch is a focused two-file follow-up, uses the shared provider HTTP helper, has fresh real endpoint proof for the non-OK provider boundary, and has targeted regression coverage for exchange and refresh oversized-body guardrails.
- **Patch quality notes:** Patch quality warning considered: this touches an auth-provider/security-boundary file, but it is not a fallback or symptom mask; it removes the unbounded read in the owning token helper and leaves the successful OAuth path unchanged.
- **Architecture / source-of-truth check:** `extensions/openai/openai-chatgpt-oauth-flow.runtime.ts` owns ChatGPT OAuth token exchange and refresh; the change happens before token result classification, credential construction, and account identity extraction, so diagnostic body size is bounded at the external provider boundary.
