### PR TITLE
fix(lmstudio): embedding preload ignores configured context length

### DIFF
--- a/extensions/lmstudio/src/embedding-provider.test.ts
+++ b/extensions/lmstudio/src/embedding-provider.test.ts
@@ -1,0 +1,102 @@
+// Lmstudio tests cover embedding provider preload context-length wiring.
+import type { OpenClawConfig } from "openclaw/plugin-sdk/plugin-entry";
+import { afterAll, describe, expect, it, vi } from "vitest";
+import { createLmstudioEmbeddingProvider } from "./embedding-provider.js";
+
+const ensureLmstudioModelLoadedMock = vi.hoisted(() =>
+  vi.fn((_params?: unknown) => Promise.resolve("text-embedding-nomic-embed-text-v1.5")),
+);
+const resolveLmstudioProviderHeadersMock = vi.hoisted(() =>
+  vi.fn(async (_params?: unknown) => undefined),
+);
+const resolveLmstudioRuntimeApiKeyMock = vi.hoisted(() =>
+  vi.fn(async (_params?: unknown) => undefined),
+);
+
+vi.mock("./models.fetch.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./models.fetch.js")>();
+  return {
+    ...actual,
+    ensureLmstudioModelLoaded: (params: unknown) => ensureLmstudioModelLoadedMock(params),
+  };
+});
+
+vi.mock("./runtime.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./runtime.js")>();
+  return {
+    ...actual,
+    resolveLmstudioProviderHeaders: (params: unknown) => resolveLmstudioProviderHeadersMock(params),
+    resolveLmstudioRuntimeApiKey: (params: unknown) => resolveLmstudioRuntimeApiKeyMock(params),
+  };
+});
+
+afterAll(() => {
+  vi.doUnmock("./models.fetch.js");
+  vi.doUnmock("./runtime.js");
+  vi.resetModules();
+});
+
+const EMBEDDING_MODEL = "text-embedding-nomic-embed-text-v1.5";
+
+function buildConfig(model: Record<string, unknown>): OpenClawConfig {
+  return {
+    models: {
+      providers: {
+        lmstudio: {
+          baseUrl: "http://localhost:1234/v1",
+          models: [{ id: EMBEDDING_MODEL, ...model }],
+        },
+      },
+    },
+  } as unknown as OpenClawConfig;
+}
+
+async function createEmbeddingProvider(config: OpenClawConfig) {
+  await createLmstudioEmbeddingProvider({
+    config,
+    provider: "lmstudio",
+    model: EMBEDDING_MODEL,
+    fallback: "none",
+  } as unknown as Parameters<typeof createLmstudioEmbeddingProvider>[0]);
+}
+
+describe("createLmstudioEmbeddingProvider preload context length", () => {
+  it("prefers the configured contextTokens when preloading the embedding model", async () => {
+    ensureLmstudioModelLoadedMock.mockClear();
+
+    await createEmbeddingProvider(buildConfig({ contextWindow: 8192, contextTokens: 4096 }));
+
+    expect(ensureLmstudioModelLoadedMock).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        modelKey: EMBEDDING_MODEL,
+        requestedContextLength: 4096,
+      }),
+    );
+  });
+
+  it("falls back to the configured contextWindow when contextTokens is absent", async () => {
+    ensureLmstudioModelLoadedMock.mockClear();
+
+    await createEmbeddingProvider(buildConfig({ contextWindow: 8192 }));
+
+    expect(ensureLmstudioModelLoadedMock).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        modelKey: EMBEDDING_MODEL,
+        requestedContextLength: 8192,
+      }),
+    );
+  });
+
+  it("omits requestedContextLength when the model is not configured with a context size", async () => {
+    ensureLmstudioModelLoadedMock.mockClear();
+
+    await createEmbeddingProvider(buildConfig({}));
+
+    expect(ensureLmstudioModelLoadedMock).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        modelKey: EMBEDDING_MODEL,
+        requestedContextLength: undefined,
+      }),
+    );
+  });
+});

--- a/extensions/lmstudio/src/embedding-provider.ts
+++ b/extensions/lmstudio/src/embedding-provider.ts
@@ -11,7 +11,10 @@ import { resolveMemorySecretInputString } from "openclaw/plugin-sdk/memory-core-
 import { formatErrorMessage, type SsrFPolicy } from "openclaw/plugin-sdk/ssrf-runtime";
 import { LMSTUDIO_DEFAULT_EMBEDDING_MODEL, LMSTUDIO_PROVIDER_ID } from "./defaults.js";
 import { ensureLmstudioModelLoaded } from "./models.fetch.js";
-import { resolveLmstudioInferenceBase } from "./models.js";
+import {
+  normalizeLmstudioConfiguredCatalogEntries,
+  resolveLmstudioInferenceBase,
+} from "./models.js";
 import {
   buildLmstudioAuthHeaders,
   resolveLmstudioProviderHeaders,
@@ -120,6 +123,10 @@ export async function createLmstudioEmbeddingProvider(
     ssrfPolicy,
   };
 
+  const configuredModels = normalizeLmstudioConfiguredCatalogEntries(providerConfig?.models);
+  const matchedModel = configuredModels.find((m) => normalizeLmstudioModel(m.id) === model);
+  const requestedContextLength = matchedModel?.contextTokens ?? matchedModel?.contextWindow;
+
   try {
     await ensureLmstudioModelLoaded({
       baseUrl,
@@ -127,6 +134,7 @@ export async function createLmstudioEmbeddingProvider(
       headers: headerOverrides,
       ssrfPolicy,
       modelKey: model,
+      requestedContextLength,
       timeoutMs: 120_000,
     });
   } catch (error) {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users who set `contextTokens`/`contextWindow` for an LM Studio embedding model under `models.providers.lmstudio` would still have that model preloaded at the default context length. Memory/embedding search silently ran against a model warmed up with the wrong context size, ignoring the user's configuration.

## Why This Change Was Made

`createLmstudioEmbeddingProvider` warmed up the target embedding model via `ensureLmstudioModelLoaded` without forwarding the configured context size, so the preload always used the default. This change resolves the configured catalog entry for the model and passes its `contextTokens` (falling back to `contextWindow`) as `requestedContextLength`, mirroring the behavior already used on the inference-stream preload path. When the model has no configured context size, `requestedContextLength` is left `undefined` and the previous default behavior is preserved — so this is a no-op for anyone not configuring a context size.

## User Impact

LM Studio embedding models are now preloaded at the context length the user configured, so memory/embedding search honors `contextTokens`/`contextWindow` instead of the default. No configuration changes are required; existing setups without an explicit context size behave exactly as before.

## Evidence

New focused test `extensions/lmstudio/src/embedding-provider.test.ts` drives `createLmstudioEmbeddingProvider` (with `ensureLmstudioModelLoaded` mocked) and asserts the value forwarded to the preload:

```
 RUN  v4.1.8

 ✓ createLmstudioEmbeddingProvider preload context length (3)
   ✓ prefers the configured contextTokens when preloading the embedding model
   ✓ falls back to the configured contextWindow when contextTokens is absent
   ✓ omits requestedContextLength when the model is not configured with a context size

 Test Files  1 passed (1)
      Tests  3 passed (3)
```

---

*AI-assisted: this change was prepared with the help of Claude Code.*
