### PR TITLE
fix(opencode-go): enable xhigh/max thinking levels for DeepSeek V4

### DIFF
--- a/extensions/opencode-go/provider-catalog.ts
+++ b/extensions/opencode-go/provider-catalog.ts
@@ -7,6 +7,10 @@ const PROVIDER_ID = "opencode-go";
 const OPENCODE_GO_OPENAI_BASE_URL = "https://opencode.ai/zen/go/v1";
 const OPENCODE_GO_ANTHROPIC_BASE_URL = "https://opencode.ai/zen/go";
 
+type ProviderRuntimeModelWithThinkingLevelMap = ProviderRuntimeModel & {
+  thinkingLevelMap?: Record<string, string>;
+};
+
 const OPENCODE_GO_SUPPLEMENTAL_MODELS = (
   [
     {
@@ -30,6 +34,14 @@ const OPENCODE_GO_SUPPLEMENTAL_MODELS = (
         supportsReasoningEffort: true,
         maxTokensField: "max_tokens",
       },
+      thinkingLevelMap: {
+        minimal: "high",
+        low: "high",
+        medium: "high",
+        high: "max",
+        xhigh: "max",
+        max: "max",
+      },
     },
     {
       id: "deepseek-v4-flash",
@@ -52,8 +64,16 @@ const OPENCODE_GO_SUPPLEMENTAL_MODELS = (
         supportsReasoningEffort: true,
         maxTokensField: "max_tokens",
       },
+      thinkingLevelMap: {
+        minimal: "high",
+        low: "high",
+        medium: "high",
+        high: "max",
+        xhigh: "max",
+        max: "max",
+      },
     },
-  ] satisfies ProviderRuntimeModel[]
+  ] satisfies ProviderRuntimeModelWithThinkingLevelMap[]
 ).map((model) => normalizeModelCompat(model));
 
 export function listOpencodeGoSupplementalModelCatalogEntries(): ModelCatalogEntry[] {

--- a/extensions/opencode-go/stream.ts
+++ b/extensions/opencode-go/stream.ts
@@ -1,18 +1,72 @@
 import type { ProviderWrapStreamFnContext } from "openclaw/plugin-sdk/plugin-entry";
-import { createDeepSeekV4OpenAICompatibleThinkingWrapper } from "openclaw/plugin-sdk/provider-stream-shared";
+import { streamWithPayloadPatch } from "openclaw/plugin-sdk/provider-stream-shared";
 
 function isOpencodeGoDeepSeekV4ModelId(modelId: unknown): boolean {
   return modelId === "deepseek-v4-flash" || modelId === "deepseek-v4-pro";
+}
+
+function isDisabledDeepSeekV4ThinkingLevel(thinkingLevel: unknown): boolean {
+  const normalized = typeof thinkingLevel === "string" ? thinkingLevel.toLowerCase() : "";
+  return normalized === "off" || normalized === "none";
 }
 
 export function createOpencodeGoDeepSeekV4Wrapper(
   baseStreamFn: ProviderWrapStreamFnContext["streamFn"],
   thinkingLevel: ProviderWrapStreamFnContext["thinkingLevel"],
 ): ProviderWrapStreamFnContext["streamFn"] {
-  return createDeepSeekV4OpenAICompatibleThinkingWrapper({
-    baseStreamFn,
-    thinkingLevel,
-    shouldPatchModel: (model) =>
-      model.provider === "opencode-go" && isOpencodeGoDeepSeekV4ModelId(model.id),
-  });
+  if (!baseStreamFn) return undefined;
+  const underlying = baseStreamFn;
+  return (model, context, options) => {
+    if (!(model.provider === "opencode-go" && isOpencodeGoDeepSeekV4ModelId(model.id))) {
+      return underlying(model, context, options);
+    }
+    return streamWithPayloadPatch(underlying, model, context, options, (payload) => {
+      // Handle disabled thinking
+      if (isDisabledDeepSeekV4ThinkingLevel(thinkingLevel)) {
+        payload.thinking = { type: "disabled" };
+        delete payload.reasoning_effort;
+        delete payload.reasoning;
+        if (Array.isArray(payload.messages)) {
+          for (const msg of payload.messages) {
+            if (msg && typeof msg === "object") {
+              delete (msg as Record<string, unknown>).reasoning_content;
+            }
+          }
+        }
+        return;
+      }
+
+      // Use model.thinkingLevelMap if available, otherwise fall back to hardcoded mapping
+      const map = (model as unknown as Record<string, unknown>).thinkingLevelMap as
+        | Record<string, string | null>
+        | undefined;
+      const mappedEffort =
+        typeof map === "object" && map !== null ? map[String(thinkingLevel)] : undefined;
+      const reasoningEffort =
+        typeof mappedEffort === "string"
+          ? mappedEffort
+          : thinkingLevel === "xhigh" || thinkingLevel === "max"
+            ? "max"
+            : "high";
+
+      payload.thinking = { type: "enabled" };
+      payload.reasoning_effort = reasoningEffort;
+
+      // Backfill reasoning_content on assistant messages
+      if (Array.isArray(payload.messages)) {
+        for (const message of payload.messages) {
+          if (
+            message &&
+            typeof message === "object" &&
+            (message as Record<string, unknown>).role === "assistant"
+          ) {
+            const record = message as Record<string, unknown>;
+            if (!("reasoning_content" in record)) {
+              record.reasoning_content = "";
+            }
+          }
+        }
+      }
+    });
+  };
 }


### PR DESCRIPTION
## Summary

Fixes: #99617

### Problem

OpenClaw 的 thinking level 选择器对 opencode-go 的 DeepSeek V4 模型只能显示 `minimum`~`high`，`xhigh`/`max` 选项因为缺失 `thinkingLevelMap` 被 `getSupportedThinkingLevels()` 过滤掉。同时 stream wrapper 硬编码了 reasoning_effort 映射，不读取模型配置。

### Changes

**`extensions/opencode-go/provider-catalog.ts`**
- 为 `deepseek-v4-pro` 和 `deepseek-v4-flash` 新增 `thinkingLevelMap` 字段
- 映射: `minimal/low/medium → "high"`, `high/xhigh/max → "max"`
- 定义本地 `ProviderRuntimeModelWithThinkingLevelMap` 类型确保类型安全

**`extensions/opencode-go/stream.ts`**
- 用内联 `streamWithPayloadPatch` 逻辑替换 `createDeepSeekV4OpenAICompatibleThinkingWrapper`
- 运行时读取 `model.thinkingLevelMap`；无 map 时回退到硬编码映射
- 移除对共享 helper 的依赖，保持向后兼容

### Verification

- TypeScript 类型检查通过 (`npx tsc -p extensions/opencode-go/tsconfig.json --noEmit`)
- 向后兼容：无 `thinkingLevelMap` 时行为与旧代码完全一致