### PR TITLE
[codex] Add doctor lint for agent model runtime policy drift

### DIFF
--- a/src/commands/doctor-lint.test.ts
+++ b/src/commands/doctor-lint.test.ts
@@ -331,6 +331,43 @@ describe("runDoctorLintCli", () => {
     }
   });
 
+  it("accepts bare model keys used by runtime policy resolution", async () => {
+    mocks.readConfigFileSnapshot.mockResolvedValue({
+      exists: true,
+      valid: true,
+      config: {
+        agents: {
+          defaults: {
+            model: "openai/gpt-5.5",
+            models: {
+              "gpt-5.5": {
+                agentRuntime: { id: "pi" },
+              },
+            },
+          },
+        },
+      } as OpenClawConfig,
+      path: "/tmp/openclaw.json",
+    });
+
+    const stdout = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
+    try {
+      const exitCode = await runDoctorLintCli(runtime, {
+        json: true,
+        onlyIds: ["core/doctor/agent-model-runtime-policies"],
+      });
+
+      expect(exitCode).toBe(0);
+      expect(JSON.parse(String(stdout.mock.calls.at(-1)?.[0]))).toMatchObject({
+        ok: true,
+        checksRun: 1,
+        findings: [],
+      });
+    } finally {
+      stdout.mockRestore();
+    }
+  });
+
   it("fails informational findings when severity-min is explicit", async () => {
     mocks.readConfigFileSnapshot.mockResolvedValue({
       exists: true,

--- a/src/commands/doctor-lint.test.ts
+++ b/src/commands/doctor-lint.test.ts
@@ -264,6 +264,73 @@ describe("runDoctorLintCli", () => {
     }
   });
 
+  it("reports active agent model refs that drift from explicit runtime policies", async () => {
+    mocks.readConfigFileSnapshot.mockResolvedValue({
+      exists: true,
+      valid: true,
+      config: {
+        agents: {
+          list: [
+            {
+              id: "main",
+              model: {
+                primary: "openai-codex/gpt-5.5",
+                fallbacks: ["openai-codex/gpt-5.3-codex"],
+              },
+              heartbeat: {
+                model: "openai-codex/gpt-5.4-mini",
+              },
+              models: {
+                "openai/gpt-5.5": {
+                  agentRuntime: { id: "pi" },
+                },
+                "openai/gpt-5.3-codex": {
+                  agentRuntime: { id: "pi" },
+                },
+              },
+            },
+          ],
+        },
+      } as unknown as OpenClawConfig,
+      path: "/tmp/openclaw.json",
+    });
+
+    const stdout = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
+    try {
+      const exitCode = await runDoctorLintCli(runtime, {
+        json: true,
+        onlyIds: ["core/doctor/agent-model-runtime-policies"],
+      });
+
+      expect(exitCode).toBe(1);
+      const payload = JSON.parse(String(stdout.mock.calls.at(-1)?.[0]));
+      expect(payload).toMatchObject({
+        ok: false,
+        checksRun: 1,
+      });
+      expect(payload.findings).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            checkId: "core/doctor/agent-model-runtime-policies",
+            severity: "warning",
+            path: "agents.list.main.model.primary",
+            target: "openai-codex/gpt-5.5",
+          }),
+          expect.objectContaining({
+            checkId: "core/doctor/agent-model-runtime-policies",
+            severity: "warning",
+            path: "agents.list.main.models.openai/gpt-5.5.agentRuntime.id",
+            target: "openai/gpt-5.5",
+          }),
+        ]),
+      );
+      expect(payload.findings).toHaveLength(5);
+      expect(payload.findings[0].message).toContain("no matching model key");
+    } finally {
+      stdout.mockRestore();
+    }
+  });
+
   it("fails informational findings when severity-min is explicit", async () => {
     mocks.readConfigFileSnapshot.mockResolvedValue({
       exists: true,

--- a/src/flows/doctor-core-checks.ts
+++ b/src/flows/doctor-core-checks.ts
@@ -1,5 +1,6 @@
 // Doctor core checks collect environment, config, and runtime readiness diagnostics.
 import path from "node:path";
+import { normalizeProviderId } from "@openclaw/model-catalog-core/provider-id";
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import { resolveAgentWorkspaceDir, resolveDefaultAgentId } from "../agents/agent-scope.js";
 import {
@@ -609,15 +610,28 @@ function collectRuntimePolicySlots(params: { models: unknown; path: string }): R
 
 function runtimePolicyMatchesModelRef(policy: RuntimePolicySlot, modelKeyValue: string): boolean {
   const key = policy.key.trim();
-  if (!key.endsWith("/*")) {
+  const separatorIndex = modelKeyValue.indexOf("/");
+  if (separatorIndex <= 0) {
     return key === modelKeyValue;
   }
-  const provider = key.slice(0, -2).trim();
-  return Boolean(provider) && modelKeyValue.startsWith(`${provider}/`);
+  const provider = normalizeProviderId(modelKeyValue.slice(0, separatorIndex));
+  const modelId = modelKeyValue.slice(separatorIndex + 1);
+  if (key === modelId) {
+    return true;
+  }
+  const policySeparatorIndex = key.indexOf("/");
+  if (policySeparatorIndex <= 0) {
+    return false;
+  }
+  const policyProvider = normalizeProviderId(key.slice(0, policySeparatorIndex));
+  const policyModelId = key.slice(policySeparatorIndex + 1).trim();
+  return policyProvider === provider && (policyModelId === modelId || policyModelId === "*");
 }
 
-function formatAgentPath(path: string): string {
-  return path === "agents.defaults" ? "agents.defaults" : path.replace(/^agents\.list\./, "agent ");
+function formatAgentPath(agentPath: string): string {
+  return agentPath === "agents.defaults"
+    ? "agents.defaults"
+    : agentPath.replace(/^agents\.list\./, "agent ");
 }
 
 async function collectAgentModelRuntimePolicyFindings(

--- a/src/flows/doctor-core-checks.ts
+++ b/src/flows/doctor-core-checks.ts
@@ -1,5 +1,6 @@
 // Doctor core checks collect environment, config, and runtime readiness diagnostics.
 import path from "node:path";
+import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import { resolveAgentWorkspaceDir, resolveDefaultAgentId } from "../agents/agent-scope.js";
 import {
   detectLegacyClawdBrowserProfileResidue,
@@ -45,6 +46,7 @@ import type {
 } from "./health-checks.js";
 
 const BROWSER_CLAWD_PROFILE_RESIDUE_CHECK_ID = "core/doctor/browser-clawd-profile-residue";
+const AGENT_MODEL_RUNTIME_POLICIES_CHECK_ID = "core/doctor/agent-model-runtime-policies";
 const CODEX_SESSION_ROUTES_CHECK_ID = "core/doctor/codex-session-routes";
 const FINAL_CONFIG_VALIDATION_CHECK_ID = "core/doctor/final-config-validation";
 const GATEWAY_DAEMON_CHECK_ID = "core/doctor/gateway-daemon";
@@ -505,6 +507,261 @@ function createProviderCatalogProjectionCheck(deps: CoreHealthCheckDeps): Health
     },
   };
 }
+
+type ModelRefSlot = {
+  path: string;
+  value: string;
+};
+
+type RuntimePolicySlot = {
+  key: string;
+  path: string;
+};
+
+function asReadonlyRecord(value: unknown): Readonly<Record<string, unknown>> | undefined {
+  return typeof value === "object" && value !== null && !Array.isArray(value)
+    ? (value as Readonly<Record<string, unknown>>)
+    : undefined;
+}
+
+function collectModelConfigRefs(params: { path: string; value: unknown }): ModelRefSlot[] {
+  const direct = normalizeOptionalString(params.value);
+  if (direct) {
+    return [{ path: params.path, value: direct }];
+  }
+  const record = asReadonlyRecord(params.value);
+  if (!record) {
+    return [];
+  }
+  const refs: ModelRefSlot[] = [];
+  const primary = normalizeOptionalString(record.primary);
+  if (primary) {
+    refs.push({ path: `${params.path}.primary`, value: primary });
+  }
+  if (Array.isArray(record.fallbacks)) {
+    for (const [index, fallback] of record.fallbacks.entries()) {
+      const value = normalizeOptionalString(fallback);
+      if (value) {
+        refs.push({ path: `${params.path}.fallbacks.${index}`, value });
+      }
+    }
+  }
+  return refs;
+}
+
+function collectAgentRuntimeModelRefs(params: {
+  agent: unknown;
+  path: string;
+  inherited?: readonly ModelRefSlot[];
+}): ModelRefSlot[] {
+  const agent = asReadonlyRecord(params.agent);
+  const refs: ModelRefSlot[] = [];
+  if (agent && Object.hasOwn(agent, "model")) {
+    refs.push(...collectModelConfigRefs({ path: `${params.path}.model`, value: agent.model }));
+  } else {
+    refs.push(
+      ...(params.inherited?.filter((ref) => ref.path.startsWith("agents.defaults.model")) ?? []),
+    );
+  }
+  const heartbeat = asReadonlyRecord(agent?.heartbeat);
+  const heartbeatModel = normalizeOptionalString(heartbeat?.model);
+  if (heartbeatModel) {
+    refs.push({ path: `${params.path}.heartbeat.model`, value: heartbeatModel });
+  } else {
+    refs.push(
+      ...(params.inherited?.filter((ref) => ref.path === "agents.defaults.heartbeat.model") ?? []),
+    );
+  }
+  const subagents = asReadonlyRecord(agent?.subagents);
+  if (subagents && Object.hasOwn(subagents, "model")) {
+    refs.push(
+      ...collectModelConfigRefs({
+        path: `${params.path}.subagents.model`,
+        value: subagents.model,
+      }),
+    );
+  } else {
+    refs.push(
+      ...(params.inherited?.filter((ref) =>
+        ref.path.startsWith("agents.defaults.subagents.model"),
+      ) ?? []),
+    );
+  }
+  return refs;
+}
+
+function collectRuntimePolicySlots(params: { models: unknown; path: string }): RuntimePolicySlot[] {
+  const models = asReadonlyRecord(params.models);
+  if (!models) {
+    return [];
+  }
+  const slots: RuntimePolicySlot[] = [];
+  for (const [key, entry] of Object.entries(models)) {
+    const runtimeId = normalizeOptionalString(
+      asReadonlyRecord(asReadonlyRecord(entry)?.agentRuntime)?.id,
+    );
+    if (runtimeId) {
+      slots.push({ key, path: `${params.path}.${key}.agentRuntime.id` });
+    }
+  }
+  return slots;
+}
+
+function runtimePolicyMatchesModelRef(policy: RuntimePolicySlot, modelKeyValue: string): boolean {
+  const key = policy.key.trim();
+  if (!key.endsWith("/*")) {
+    return key === modelKeyValue;
+  }
+  const provider = key.slice(0, -2).trim();
+  return Boolean(provider) && modelKeyValue.startsWith(`${provider}/`);
+}
+
+function formatAgentPath(path: string): string {
+  return path === "agents.defaults" ? "agents.defaults" : path.replace(/^agents\.list\./, "agent ");
+}
+
+async function collectAgentModelRuntimePolicyFindings(
+  cfg: OpenClawConfig,
+): Promise<readonly HealthFinding[]> {
+  const { DEFAULT_PROVIDER } = await import("../agents/defaults.js");
+  const { buildModelAliasIndex, modelKey, resolveModelRefFromString } =
+    await import("../agents/model-selection.js");
+  const aliasIndex = buildModelAliasIndex({
+    cfg,
+    defaultProvider: DEFAULT_PROVIDER,
+    allowPluginNormalization: false,
+  });
+  const canonicalize = (ref: ModelRefSlot): ModelRefSlot | undefined => {
+    const resolved = resolveModelRefFromString({
+      cfg,
+      raw: ref.value,
+      defaultProvider: DEFAULT_PROVIDER,
+      aliasIndex,
+      allowPluginNormalization: false,
+    });
+    if (!resolved) {
+      return undefined;
+    }
+    return { path: ref.path, value: modelKey(resolved.ref.provider, resolved.ref.model) };
+  };
+  const canonicalizeRefs = (refs: readonly ModelRefSlot[]) =>
+    refs.map(canonicalize).filter((ref): ref is ModelRefSlot => Boolean(ref));
+  const findings: HealthFinding[] = [];
+  const addMissingPolicyFindings = (params: {
+    agentPath: string;
+    refs: readonly ModelRefSlot[];
+    policies: readonly RuntimePolicySlot[];
+  }) => {
+    if (params.policies.length === 0) {
+      return;
+    }
+    for (const ref of params.refs) {
+      if (params.policies.some((policy) => runtimePolicyMatchesModelRef(policy, ref.value))) {
+        continue;
+      }
+      findings.push({
+        checkId: AGENT_MODEL_RUNTIME_POLICIES_CHECK_ID,
+        severity: "warning",
+        message: `${ref.path} selects ${ref.value}, but ${formatAgentPath(
+          params.agentPath,
+        )} has explicit agentRuntime policies with no matching model key.`,
+        path: ref.path,
+        target: ref.value,
+        requirement: "Active agent model refs should have matching explicit runtime policies.",
+        fixHint:
+          "Add an agentRuntime policy for this model ref, or remove stale per-model runtime policies from the agent.",
+      });
+    }
+  };
+  const addUnusedPolicyFindings = (params: {
+    agentPath: string;
+    refs: readonly ModelRefSlot[];
+    policies: readonly RuntimePolicySlot[];
+  }) => {
+    const referencedKeys = new Set(params.refs.map((ref) => ref.value));
+    for (const policy of params.policies) {
+      if ([...referencedKeys].some((key) => runtimePolicyMatchesModelRef(policy, key))) {
+        continue;
+      }
+      findings.push({
+        checkId: AGENT_MODEL_RUNTIME_POLICIES_CHECK_ID,
+        severity: "warning",
+        message: `${policy.path} sets a runtime for ${policy.key}, but no active model ref in ${formatAgentPath(
+          params.agentPath,
+        )} uses that model key.`,
+        path: policy.path,
+        target: policy.key,
+        requirement:
+          "Per-model agentRuntime policies should correspond to active agent model refs.",
+        fixHint:
+          "Move the runtime policy to the active model key, or remove it if this agent no longer uses the model.",
+      });
+    }
+  };
+
+  const defaults = cfg.agents?.defaults;
+  const defaultRefs = collectAgentRuntimeModelRefs({
+    agent: defaults,
+    path: "agents.defaults",
+  });
+  const canonicalDefaultRefs = canonicalizeRefs(defaultRefs);
+  const defaultPolicies = collectRuntimePolicySlots({
+    models: defaults?.models,
+    path: "agents.defaults.models",
+  });
+  const allCanonicalRefs: ModelRefSlot[] = [...canonicalDefaultRefs];
+  addMissingPolicyFindings({
+    agentPath: "agents.defaults",
+    refs: canonicalDefaultRefs,
+    policies: defaultPolicies,
+  });
+  for (const [index, agent] of (cfg.agents?.list ?? []).entries()) {
+    const agentRecord = asReadonlyRecord(agent);
+    if (!agentRecord) {
+      continue;
+    }
+    const id = normalizeOptionalString(agentRecord.id) ?? String(index);
+    const agentPath = `agents.list.${id}`;
+    const refs = canonicalizeRefs(
+      collectAgentRuntimeModelRefs({
+        agent: agentRecord,
+        path: agentPath,
+        inherited: defaultRefs,
+      }),
+    );
+    allCanonicalRefs.push(...refs);
+    const policies = collectRuntimePolicySlots({
+      models: agentRecord.models,
+      path: `${agentPath}.models`,
+    });
+    addMissingPolicyFindings({
+      agentPath,
+      refs,
+      policies: [...defaultPolicies, ...policies],
+    });
+    addUnusedPolicyFindings({
+      agentPath,
+      refs,
+      policies,
+    });
+  }
+  addUnusedPolicyFindings({
+    agentPath: "agents.defaults",
+    refs: allCanonicalRefs,
+    policies: defaultPolicies,
+  });
+  return findings;
+}
+
+const agentModelRuntimePoliciesCheck: HealthCheck = {
+  id: AGENT_MODEL_RUNTIME_POLICIES_CHECK_ID,
+  kind: "core",
+  description: "Agent model refs and explicit agentRuntime policies describe the same routes.",
+  source: "doctor",
+  async detect(ctx) {
+    return collectAgentModelRuntimePolicyFindings(ctx.cfg);
+  },
+};
 
 function normalizeDoctorNoteLine(line: string): string {
   return line.replace(/^- /, "").trim();
@@ -1078,6 +1335,7 @@ function createConvertedWorkflowChecks(
     browserCheck,
     openAIOAuthTlsCheck,
     hooksModelCheck,
+    agentModelRuntimePoliciesCheck,
     bootstrapSizeCheck,
     createProviderCatalogProjectionCheck(deps),
     createRuntimeToolSchemaCheck(deps),

--- a/src/flows/doctor-health-contributions.ts
+++ b/src/flows/doctor-health-contributions.ts
@@ -1368,6 +1368,31 @@ async function runRuntimeToolSchemasHealth(ctx: DoctorHealthFlowContext): Promis
   note(formatHealthFindings(findings), "Doctor warnings");
 }
 
+async function runAgentModelRuntimePoliciesHealth(ctx: DoctorHealthFlowContext): Promise<void> {
+  const { registerCoreHealthChecks } = await loadDoctorCoreChecksModule();
+  const { getHealthCheck } = await loadHealthCheckRegistryModule();
+  const { resolveAgentWorkspaceDir, resolveDefaultAgentId } = await loadAgentScopeModule();
+  const { note } = await loadNoteModule();
+
+  registerCoreHealthChecks();
+  const check = getHealthCheck("core/doctor/agent-model-runtime-policies");
+  if (!check) {
+    return;
+  }
+  const findings = await check.detect({
+    mode: "doctor",
+    runtime: ctx.runtime,
+    cfg: ctx.cfg,
+    cwd: resolveAgentWorkspaceDir(ctx.cfg, resolveDefaultAgentId(ctx.cfg)),
+    configPath: ctx.configPath,
+  });
+  if (findings.length === 0) {
+    return;
+  }
+  ctx.healthOk = false;
+  note(formatHealthFindings(findings), "Doctor warnings");
+}
+
 export function resolveDoctorHealthContributions(): DoctorHealthContribution[] {
   return [
     createDoctorHealthContribution({
@@ -1821,6 +1846,12 @@ export function resolveDoctorHealthContributions(): DoctorHealthContribution[] {
       label: "Hooks model",
       healthCheckIds: ["core/doctor/hooks-model"],
       run: runHooksModelHealth,
+    }),
+    createDoctorHealthContribution({
+      id: "doctor:agent-model-runtime-policies",
+      label: "Agent model runtime policies",
+      healthCheckIds: ["core/doctor/agent-model-runtime-policies"],
+      run: runAgentModelRuntimePoliciesHealth,
     }),
     createDoctorHealthContribution({
       id: "doctor:tool-result-cap",


### PR DESCRIPTION
## What Problem This Solves

`openclaw doctor --lint` did not report a useful warning when active agent model refs drifted away from explicit per-model `agentRuntime` policies. This is one diagnostic slice of #84212: it helps surface contradictory config, but it does not hard-fail config save or reload.

## Why This Change Was Made

The issue's full config-save/reload rejection path is product-sensitive because existing schema-valid configs may become hard failures. This PR keeps the change warning-only and scoped to doctor lint:

- active agent model refs warn when an agent has explicit runtime policies but no matching policy for the active ref
- stale per-model runtime policy keys warn when no active model ref uses them
- policy matching mirrors runtime resolution for bare model IDs, provider-qualified IDs, normalized provider aliases, and provider wildcards
- per-agent checks account for inherited default runtime policies

## User Impact

Users get a direct `doctor --lint` warning for model/runtime-policy drift instead of discovering it later as model routing or no-candidate runtime degradation. This is partial mitigation only; #84212 should remain open for the broader config persistence/reload decision unless maintainers decide warning-only lint coverage is sufficient.

## Real behavior proof

Behavior or issue addressed:

Doctor lint should warn when the active model has no matching explicit runtime policy, while accepting a bare model key that runtime resolution treats as matching a provider-qualified active model.

Real environment tested:

WSL Ubuntu, source checkout at `12b3f07565d`, built source launcher `node openclaw.mjs`, and isolated local config/state directories. No provider or network call was needed.

Exact steps to reproduce or validate:

1. Create an isolated config with active model `openai/gpt-5.5` and only an `openai/gpt-5.4` runtime policy.
2. Run `OPENCLAW_STATE_DIR=/tmp/openclaw-99619-proof/state OPENCLAW_CONFIG_PATH=/tmp/openclaw-99619-proof/openclaw.json node openclaw.mjs doctor --lint --json --only core/doctor/agent-model-runtime-policies`.
3. Create a second isolated config with active model `openai/gpt-5.5` and bare runtime-policy key `gpt-5.5`.
4. Run `OPENCLAW_STATE_DIR=/tmp/openclaw-99619-proof/state-bare OPENCLAW_CONFIG_PATH=/tmp/openclaw-99619-proof/openclaw-bare-key.json node openclaw.mjs doctor --lint --json --only core/doctor/agent-model-runtime-policies`.

Evidence after fix:

The drift fixture returned structured JSON with `"ok": false`, `"checksRun": 1`, and exactly two warnings:

- `agents.defaults.model selects openai/gpt-5.5, but agents.defaults has explicit agentRuntime policies with no matching model key.`
- `agents.defaults.models.openai/gpt-5.4.agentRuntime.id sets a runtime for openai/gpt-5.4, but no active model ref in agents.defaults uses that model key.`

The bare-key fixture returned:

```json
{"ok":true,"checksRun":1,"checksSkipped":43,"findings":[]}
```

Observed result:

The real built launcher emitted both expected drift warnings and no bare-key false positive. The shell status was `0` for both launcher invocations, so this proof asserts the structured JSON and findings, not an exit-code change.

What was not tested:

No config save/reload hard failure, provider call, or gateway session was tested. Exit-code propagation through the generic built launcher is not part of this patch.

## Supporting verification

At `12b3f07565d` in WSL:

- `node_modules/.bin/oxfmt --check src/commands/doctor-lint.test.ts src/flows/doctor-core-checks.ts` -> passed
- `node scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.core.json src/commands/doctor-lint.test.ts src/flows/doctor-core-checks.ts` -> 0 warnings, 0 errors
- `OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs src/commands/doctor-lint.test.ts src/flows/doctor-core-checks.test.ts src/flows/doctor-lint-flow.test.ts src/flows/doctor-health-contributions.test.ts --reporter=dot` -> passed, 103 tests across two routed shards
- `git diff --check` -> passed

Refs #84212
