### PR TITLE
fix(android): check READ_MEDIA_VISUAL_USER_SELECTED for partial photo access on Android 14+

### DIFF
--- a/apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsSheet.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsSheet.kt
@@ -5,6 +5,8 @@ import ai.openclaw.app.LocationMode
 import ai.openclaw.app.MainViewModel
 import ai.openclaw.app.NotificationPackageFilterMode
 import ai.openclaw.app.SensitiveFeatureConfig
+import ai.openclaw.app.hasPhotoReadPermission
+import ai.openclaw.app.photoReadPermissionsForRequest
 import ai.openclaw.app.node.DeviceNotificationListenerService
 import ai.openclaw.app.normalizeLocalHourMinute
 import android.Manifest
@@ -213,12 +215,7 @@ fun SettingsSheet(viewModel: MainViewModel) {
     }
   val callLogPermissionAvailable = remember { SensitiveFeatureConfig.callLogEnabled }
   val photosPermissionAvailable = remember { SensitiveFeatureConfig.photosEnabled }
-  val photosPermission =
-    if (Build.VERSION.SDK_INT >= 33) {
-      Manifest.permission.READ_MEDIA_IMAGES
-    } else {
-      Manifest.permission.READ_EXTERNAL_STORAGE
-    }
+  val photoPermissions = remember { photoReadPermissionsForRequest() }
   val motionPermissionRequired = true
   val motionAvailable = remember(context) { hasMotionCapabilities(context) }
 
@@ -250,15 +247,15 @@ fun SettingsSheet(viewModel: MainViewModel) {
     remember {
       mutableStateOf(
         if (photosPermissionAvailable) {
-          ContextCompat.checkSelfPermission(context, photosPermission) == PackageManager.PERMISSION_GRANTED
+          hasPhotoReadPermission(context)
         } else {
           false
         },
       )
     }
   val photosPermissionLauncher =
-    rememberLauncherForActivityResult(ActivityResultContracts.RequestPermission()) { granted ->
-      photosPermissionGranted = granted
+    rememberLauncherForActivityResult(ActivityResultContracts.RequestMultiplePermissions()) {
+      photosPermissionGranted = hasPhotoReadPermission(context)
     }
 
   var contactsPermissionGranted by
@@ -357,7 +354,7 @@ fun SettingsSheet(viewModel: MainViewModel) {
           installedNotificationApps = queryInstalledApps(context, notificationForwardingPackages)
           photosPermissionGranted =
             if (photosPermissionAvailable) {
-              ContextCompat.checkSelfPermission(context, photosPermission) == PackageManager.PERMISSION_GRANTED
+              hasPhotoReadPermission(context)
             } else {
               false
             }
@@ -1004,7 +1001,7 @@ fun SettingsSheet(viewModel: MainViewModel) {
                     if (photosPermissionGranted) {
                       openAppSettings(context)
                     } else {
-                      photosPermissionLauncher.launch(photosPermission)
+                      photosPermissionLauncher.launch(photoPermissions.toTypedArray())
                     }
                   },
                   colors = settingsPrimaryButtonColors(),


### PR DESCRIPTION
## What Problem This Solves

Android 14 (API 34) introduced the `READ_MEDIA_VISUAL_USER_SELECTED` permission. When a user chooses "Select photos" (partial access) in the system photo picker, Android grants this permission instead of `READ_MEDIA_IMAGES`.

`SettingsSheet.kt` was the only file still using inline single-permission checks that only look at `READ_MEDIA_IMAGES`. The shared helpers `hasPhotoReadPermission()` and `photoReadPermissionsForRequest()` (from `PhotoPermissions.kt`) already handle the API 34+ case correctly, but `SettingsSheet.kt` was not using them.

This caused a false negative: the Settings UI showed "Grant" when the user had actually granted partial photo access, leading to an infinite loop (tap Grant → pick "Select photos" → UI still shows Grant).

## Why This Change Was Made

Three other photo-permission consumers already use the shared helpers:
- `PhotosHandler.kt` — `hasPermission()`
- `DeviceHandler.kt` — `permissionsPayloadJson()`
- `OnboardingFlow.kt` — `photosGranted` state

`SettingsSheet.kt` was the only straggler. This fix aligns it with the established pattern and eliminates the duplicated inline permission logic.

## User Impact

- **Before**: On Android 14+, choosing "Select photos" left the Settings page showing an incorrect "Grant" button; the actual photo permission was usable but misreported.
- **After**: The Settings page correctly recognises partial photo access and shows "Manage".

## Evidence

### Changed checkpoints (SettingsSheet.kt)

| Checkpoint | Before | After |
|---|---|---|
| Permission definition (L216) | `READ_MEDIA_IMAGES` only | `photoReadPermissionsForRequest()` |
| Initial state (L249) | `checkSelfPermission(context, photosPermission)` | `hasPhotoReadPermission(context)` |
| Launcher callback (L259) | `RequestPermission()` + single granted | `RequestMultiplePermissions()` + `hasPhotoReadPermission(context)` |
| ON_RESUME refresh (L358) | Same inline check | `hasPhotoReadPermission(context)` |
| UI launch call (L1007) | `launch(photosPermission)` | `launch(photoPermissions.toTypedArray())` |

### Android permission model

`AndroidManifest.xml` declares both `READ_MEDIA_IMAGES` (L16) and `READ_MEDIA_VISUAL_USER_SELECTED` (L17). The shared `PhotoPermissions.kt` helper requests both permissions on SDK_INT >= 34 and treats either grant as sufficient.

### Review

Change reviewed by `openclaw-pr-review` — clean, no findings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
