### PR TITLE
fix(plugins): surface runtime registry on partial plugin-id overlap

### DIFF
--- a/src/plugins/active-runtime-registry.test.ts
+++ b/src/plugins/active-runtime-registry.test.ts
@@ -98,6 +98,22 @@ describe("getLoadedRuntimePluginRegistry", () => {
     ).toBeUndefined();
   });
 
+  it("surfaces the registry when only some required plugins are loaded", () => {
+    // Tool-discovery passes the manifest superset of plugin ids, which can
+    // include plugins that are not loaded in the active runtime. The registry
+    // must still surface on partial overlap ("any") rather than being dropped
+    // whole — otherwise a single unloaded id hides every plugin's tools.
+    const registry = createRegistryWithPlugin("loaded-a");
+    setActivePluginRegistry(registry, "loaded-a", "default", "/tmp/ws");
+
+    expect(
+      getLoadedRuntimePluginRegistry({
+        workspaceDir: "/tmp/ws",
+        requiredPluginIds: ["loaded-a", "unloaded-b"],
+      }),
+    ).toBe(registry);
+  });
+
   it("does not reuse workspace-agnostic registries for workspace-specific requests", () => {
     setActivePluginRegistry(createRegistryWithPlugin("demo"), "demo");
 

--- a/src/plugins/active-runtime-registry.ts
+++ b/src/plugins/active-runtime-registry.ts
@@ -44,6 +44,7 @@ function normalizeRequiredPluginIds(ids?: readonly string[]): string[] | undefin
 export function registryContainsRuntimePluginIds(
   registry: PluginRegistry,
   pluginIds: readonly string[] | undefined,
+  match: "all" | "any" = "all",
 ): boolean {
   if (pluginIds === undefined) {
     return true;
@@ -81,7 +82,9 @@ export function registryContainsRuntimePluginIds(
   if (pluginIds.length === 0) {
     return present.size === 0;
   }
-  return pluginIds.every((pluginId) => loaded.has(pluginId));
+  return match === "any"
+    ? pluginIds.some((pluginId) => loaded.has(pluginId))
+    : pluginIds.every((pluginId) => loaded.has(pluginId));
 }
 
 function resolveSurfaceRegistry(
@@ -128,7 +131,13 @@ export function getLoadedRuntimePluginRegistry(
   if (!registry) {
     return undefined;
   }
-  if (!registryContainsRuntimePluginIds(registry, requiredPluginIds)) {
+  // Tool-discovery enumerates plugins from the manifest snapshot, which can
+  // include plugins that are not loaded into the active runtime. Accept the
+  // registry on partial overlap ("any") — the downstream per-entry consumers
+  // filter by pluginId anyway. A strict "all" match here silently dropped the
+  // ENTIRE registry whenever the requested set contained any unloaded plugin,
+  // so plugin-registered tools failed to surface.
+  if (!registryContainsRuntimePluginIds(registry, requiredPluginIds, "any")) {
     return undefined;
   }
   return registry;


### PR DESCRIPTION
## What Problem This Solves

`getLoadedRuntimePluginRegistry` validates the resolved surface registry with a strict `registryContainsRuntimePluginIds` — it requires **every** requested plugin id to be loaded. Tool-discovery, however, passes the manifest snapshot's plugin ids, which is a **superset** of what is actually loaded into the active runtime. So whenever the requested set contains a single unloaded (manifest-eligible but inactive) plugin, the strict match returns `false` and the **entire** registry is dropped — hiding every loaded plugin's tools, not just the absent one.

## Fix

Add an opt-in `match: "all" | "any"` parameter to `registryContainsRuntimePluginIds` (default `"all"`, no behavior change for existing callers), and use `"any"` at the tool-discovery surface check in `getLoadedRuntimePluginRegistry`. Partial overlap is safe there because the downstream per-entry consumers already filter by `pluginId`. The loader-cache compatibility path (active + `loadOptions`) keeps strict `"all"` matching.

## Evidence

- **Focused regression test** added to `active-runtime-registry.test.ts`: a registry with a single loaded plugin, requested with `["loaded-a", "unloaded-b"]`, now surfaces the registry instead of returning `undefined` (previously the whole registry was dropped). Reproduces the root cause and locks in the fix.
- **Live observation:** the same fix (tolerant partial-overlap match at the tool-discovery path) has been running in a downstream deployment that layers an extension registering tool + HTTP-route surfaces. Before it, that extension's tools failed to surface whenever the requested plugin set included any manifest-eligible-but-unloaded plugin; after it, they surface correctly.
- CI on this PR exercises the full suite against the change.

---
🤖 Authored with an LLM coding agent, reviewed by a human (per CONTRIBUTING's AI-transparency note).