### PR TITLE
fix(ui): route workspace copy-path through copyToClipboard helper

### DIFF
--- a/ui/src/ui/app-render.ts
+++ b/ui/src/ui/app-render.ts
@@ -29,6 +29,7 @@ import {
 } from "./app-render.helpers.ts";
 import { hasOperatorAdminAccess, hasOperatorWriteAccess, warnQueryToken } from "./app-settings.ts";
 import type { AppViewState } from "./app-view-state.ts";
+import { copyToClipboard } from "./chat/clipboard.ts";
 import { reconcileChatRunLifecycle } from "./chat/run-lifecycle.ts";
 import {
   renderChatQuotaPill,
@@ -2341,7 +2342,7 @@ export function renderApp(state: AppViewState) {
     }, 160);
   };
   const copyChatWorkspacePath = (filePath: string) => {
-    void globalThis.navigator?.clipboard?.writeText?.(filePath);
+    void copyToClipboard(filePath);
   };
   function loadChatWorkspaceFiles(opts?: { force?: boolean }) {
     if (!state.client || !state.connected) {


### PR DESCRIPTION
## Summary

The Session Workspace "Copy path" button in the Chat tab called the bare async
Clipboard API directly. On plain-HTTP deployments (e.g. `http://openclaw.local`
or LAN access), `navigator.clipboard` is undefined, so the call did nothing and
no error surfaced.

The shared `copyToClipboard` helper in `ui/src/ui/chat/clipboard.ts` already
handles this case: it tries `navigator.clipboard.writeText` first and falls
back to a `document.execCommand("copy")` path. Other copy affordances in the
Chat tab (`copy-as-markdown.ts`) already route through it.

This change routes `copyChatWorkspacePath` through the same helper so the
button keeps working on HTTP deployments and behaves consistently with the
rest of the chat surface.

## Test plan

- [x] Existing `ui/src/ui/chat/clipboard.test.ts` covers the helper paths
      (empty input, secure-context success, execCommand fallback, all-denied).
- [x] Existing `ui/src/ui/views/chat.test.ts` "renders session controls …"
      case still asserts `onCopyPath("/workspace/AGENTS.md")` is invoked on
      click of the row's copy button, end-to-end through the prop wiring.
- [x] Manual diff inspection confirms the only behavioural change is the
      routing swap; no new module surface, no call-site signature change.

Closes #98759
