### PR TITLE
fix: preserve OpenCode Go DeepSeek V4 max thinking

### DIFF
--- a/extensions/opencode-go/index.test.ts
+++ b/extensions/opencode-go/index.test.ts
@@ -1,4 +1,5 @@
 // Opencode Go tests cover index plugin behavior.
+import { clampThinkingLevel } from "openclaw/plugin-sdk/llm";
 import type { ProviderRuntimeModel } from "openclaw/plugin-sdk/plugin-entry";
 import {
   registerProviderPlugin,
@@ -38,6 +39,16 @@ function requireCatalogEntry(entries: readonly unknown[] | null | undefined, id:
   }
   return requireRecord(entry, `supplemental catalog entry ${id}`);
 }
+
+const EXPECTED_DEEPSEEK_V4_THINKING_LEVEL_MAP = {
+  off: null,
+  minimal: "low",
+  low: "low",
+  medium: "medium",
+  high: "high",
+  xhigh: "max",
+  max: "max",
+} as const;
 
 describe("opencode-go provider plugin", () => {
   beforeEach(() => {
@@ -126,6 +137,14 @@ describe("opencode-go provider plugin", () => {
     const deepSeekFlash = requireCatalogEntry(supplemental, "deepseek-v4-flash");
     expect(deepSeekFlash.provider).toBe("opencode-go");
     expect(deepSeekFlash.name).toBe("DeepSeek V4 Flash");
+
+    const deepSeekProModel = requireMapEntry(models, "deepseek-v4-pro");
+    expect(deepSeekProModel.thinkingLevelMap).toEqual(EXPECTED_DEEPSEEK_V4_THINKING_LEVEL_MAP);
+    expect(clampThinkingLevel(deepSeekProModel as never, "max")).toBe("max");
+
+    const deepSeekFlashModel = requireMapEntry(models, "deepseek-v4-flash");
+    expect(deepSeekFlashModel.thinkingLevelMap).toEqual(EXPECTED_DEEPSEEK_V4_THINKING_LEVEL_MAP);
+    expect(clampThinkingLevel(deepSeekFlashModel as never, "xhigh")).toBe("xhigh");
 
     const glm52 = requireMapEntry(models, "glm-5.2");
     expect(glm52.api).toBe("openai-completions");
@@ -241,6 +260,13 @@ describe("opencode-go provider plugin", () => {
   it("loads OpenCode Go model discovery through the provider runtime", () => {
     expect(manifest.providerCatalogEntry).toBe("./provider-discovery.ts");
     expect(manifest.modelCatalog.discovery["opencode-go"]).toBe("runtime");
+    const manifestModels = manifest.modelCatalog.providers["opencode-go"].models;
+    expect(
+      manifestModels.find((model) => model.id === "deepseek-v4-pro")?.thinkingLevelMap,
+    ).toEqual(EXPECTED_DEEPSEEK_V4_THINKING_LEVEL_MAP);
+    expect(
+      manifestModels.find((model) => model.id === "deepseek-v4-flash")?.thinkingLevelMap,
+    ).toEqual(EXPECTED_DEEPSEEK_V4_THINKING_LEVEL_MAP);
   });
 
   it("exposes the complete offline catalog through provider discovery", async () => {
@@ -249,6 +275,7 @@ describe("opencode-go provider plugin", () => {
       throw new Error("expected OpenCode Go static provider");
     }
     const deepSeekPro = result.provider.models.find((model) => model.id === "deepseek-v4-pro");
+    const deepSeekFlash = result.provider.models.find((model) => model.id === "deepseek-v4-flash");
     const glm52 = result.provider.models.find((model) => model.id === "glm-5.2");
 
     expect(result.provider.models).toHaveLength(20);
@@ -256,6 +283,13 @@ describe("opencode-go provider plugin", () => {
       provider: "opencode-go",
       contextWindow: 1_000_000,
       maxTokens: 384_000,
+      thinkingLevelMap: EXPECTED_DEEPSEEK_V4_THINKING_LEVEL_MAP,
+    });
+    expect(deepSeekFlash).toMatchObject({
+      provider: "opencode-go",
+      contextWindow: 1_000_000,
+      maxTokens: 384_000,
+      thinkingLevelMap: EXPECTED_DEEPSEEK_V4_THINKING_LEVEL_MAP,
     });
     expect(glm52).toMatchObject({
       provider: "opencode-go",

--- a/extensions/opencode-go/openclaw.plugin.json
+++ b/extensions/opencode-go/openclaw.plugin.json
@@ -30,6 +30,15 @@
             "id": "deepseek-v4-pro",
             "name": "DeepSeek V4 Pro",
             "reasoning": true,
+            "thinkingLevelMap": {
+              "off": null,
+              "minimal": "low",
+              "low": "low",
+              "medium": "medium",
+              "high": "high",
+              "xhigh": "max",
+              "max": "max"
+            },
             "input": ["text"],
             "contextWindow": 1000000,
             "maxTokens": 384000,
@@ -49,6 +58,15 @@
             "id": "deepseek-v4-flash",
             "name": "DeepSeek V4 Flash",
             "reasoning": true,
+            "thinkingLevelMap": {
+              "off": null,
+              "minimal": "low",
+              "low": "low",
+              "medium": "medium",
+              "high": "high",
+              "xhigh": "max",
+              "max": "max"
+            },
             "input": ["text"],
             "contextWindow": 1000000,
             "maxTokens": 384000,

--- a/extensions/opencode-go/provider-catalog.ts
+++ b/extensions/opencode-go/provider-catalog.ts
@@ -31,6 +31,16 @@ type OpencodeGoModelDefinition = ModelDefinitionConfig & {
   input: Array<"text" | "image">;
 };
 
+const OPENCODE_GO_DEEPSEEK_V4_THINKING_LEVEL_MAP = {
+  off: null,
+  minimal: "low",
+  low: "low",
+  medium: "medium",
+  high: "high",
+  xhigh: "max",
+  max: "max",
+} satisfies NonNullable<ModelDefinitionConfig["thinkingLevelMap"]>;
+
 const OPENCODE_GO_MODELS = (
   [
     {
@@ -40,6 +50,7 @@ const OPENCODE_GO_MODELS = (
       provider: PROVIDER_ID,
       baseUrl: OPENCODE_GO_OPENAI_BASE_URL,
       reasoning: true,
+      thinkingLevelMap: OPENCODE_GO_DEEPSEEK_V4_THINKING_LEVEL_MAP,
       input: ["text"],
       cost: {
         input: 1.74,
@@ -62,6 +73,7 @@ const OPENCODE_GO_MODELS = (
       provider: PROVIDER_ID,
       baseUrl: OPENCODE_GO_OPENAI_BASE_URL,
       reasoning: true,
+      thinkingLevelMap: OPENCODE_GO_DEEPSEEK_V4_THINKING_LEVEL_MAP,
       input: ["text"],
       cost: {
         input: 0.14,


### PR DESCRIPTION
Closes #99601

AI-assisted: yes (Codex).

## What Problem This Solves

Fixes an issue where users selecting `/think max` or `/think xhigh` with `opencode-go/deepseek-v4-pro` or `opencode-go/deepseek-v4-flash` would have the requested thinking level silently clamped down before the OpenCode Go DeepSeek V4 request was built.

## Why This Change Was Made

The OpenCode Go DeepSeek V4 model rows now carry an explicit thinking-level map in both runtime catalog data and manifest metadata: `off` disables thinking, normal levels map to DeepSeek's low/medium/high efforts, and `xhigh`/`max` map to DeepSeek's max effort. The fix stays inside the opencode-go provider metadata so the existing generic clamp and DeepSeek V4 OpenAI-compatible stream wrapper continue to own their current behavior.

## User Impact

OpenCode Go DeepSeek V4 users can use max/xhigh thinking and have the request reach the provider as max effort instead of being downgraded to high. Static model discovery and runtime provider discovery now agree on the same DeepSeek V4 thinking capabilities.

## Evidence

- `node scripts/run-vitest.mjs extensions/opencode-go/index.test.ts` (12 passed)
- `git diff --check`
- GitHub `Real behavior proof` context/evidence gate passed: https://github.com/openclaw/openclaw/actions/runs/28680430416
- Checked the relevant DeepSeek Thinking Mode docs for `reasoning_effort` values.

Redacted after-fix OpenCode Go payload proof at `eb996427e1c127760a99a3960b1ea87bc90a794a`:

```text
probe: opencode-go DeepSeek V4 thinking metadata + payload capture
models checked: opencode-go/deepseek-v4-pro, opencode-go/deepseek-v4-flash
network/API key use: none; local provider wrapper payload capture only

opencode-go/deepseek-v4-pro:
  thinkingLevelMap.xhigh = max
  thinkingLevelMap.max = max
  clampThinkingLevel(max) = max
  clampThinkingLevel(xhigh) = xhigh
  captured payload thinking = { type: enabled }
  captured payload reasoning_effort = max

opencode-go/deepseek-v4-flash:
  thinkingLevelMap.xhigh = max
  thinkingLevelMap.max = max
  clampThinkingLevel(max) = max
  clampThinkingLevel(xhigh) = xhigh
  captured payload thinking = { type: enabled }
  captured payload reasoning_effort = max
```

Stronger real-transport proof from the same checkout:

```text
probe: opencode-go real OpenAI-compatible transport through loopback SSE capture
entrypoints: registered OpenCode Go plugin -> provider.wrapStreamFn -> streamSimpleOpenAICompletions -> guarded OpenAI SDK HTTP transport
network/API key use: no external network; dummy API key redacted; local HTTP SSE endpoint captured outbound request bodies
models checked: opencode-go/deepseek-v4-pro, opencode-go/deepseek-v4-flash, opencode-go/glm-5

opencode-go/deepseek-v4-pro:
  POST /v1/chat/completions
  Authorization: present:redacted
  request.model = deepseek-v4-pro
  request.stream = true
  request.thinking = { type: enabled }
  request.reasoning_effort = max
  request.max_tokens = 8
  request.stream_options.include_usage = true
  final stream stopReason = stop
  final stream text = ok

opencode-go/deepseek-v4-flash:
  POST /v1/chat/completions
  Authorization: present:redacted
  request.model = deepseek-v4-flash
  request.stream = true
  request.thinking = { type: enabled }
  request.reasoning_effort = max
  request.max_tokens = 8
  request.stream_options.include_usage = true
  final stream stopReason = stop
  final stream text = ok

unrelated control, opencode-go/glm-5:
  POST /v1/chat/completions
  request.model = glm-5
  request.stream = true
  request.reasoning_effort = high
  request.max_completion_tokens = 8
  no DeepSeek V4 thinking object was added
  final stream stopReason = stop
  final stream text = ok
```

Known remaining validation-path proof from the same probes:

```text
opencode-go/deepseek-v4-pro command/profile levels: off, minimal, low, medium, high
opencode-go/deepseek-v4-pro commandSupportsXHigh = false
opencode-go/deepseek-v4-pro commandSupportsMax = false

opencode-go/deepseek-v4-flash command/profile levels: off, minimal, low, medium, high
opencode-go/deepseek-v4-flash commandSupportsXHigh = false
opencode-go/deepseek-v4-flash commandSupportsMax = false
```

That remaining validation-path result matches ClawSweeper's current code-path finding and is not claimed fixed by this proof-only evidence update.

Remote proof note: Testbox-through-Crabbox was attempted, but this operator environment does not have the `blacksmith` CLI installed. Brokered Crabbox also reports missing coordinator auth, so there is no remote `tbx_...` or `cbx_...` id for this proof run.

Autoreview was started, then interrupted at maintainer request to avoid blocking this draft PR; no autoreview verdict is included.
