### PR TITLE
fix: CLI agent session resume churns when owner and non-owner alternate in a group

### DIFF
--- a/src/agents/cli-runner/prepare.test.ts
+++ b/src/agents/cli-runner/prepare.test.ts
@@ -2117,6 +2117,131 @@ describe("shouldSkipLocalCliCredentialEpoch", () => {
     },
   );
 
+  it("reuses CLI session bindings across owner sender flips with stable prompt tool scope", async () => {
+    const { dir, sessionFile } = createSessionFile();
+    try {
+      const getActiveMcpLoopbackRuntime = vi.fn(() => ({
+        port: 31783,
+        ownerToken: "loopback-owner-token",
+        nonOwnerToken: "loopback-non-owner-token",
+      }));
+      const resolveMcpLoopbackScopedTools = vi.fn((scope: { senderIsOwner?: boolean }) => ({
+        agentId: "main",
+        tools: [
+          {
+            name: "message",
+            label: "Message",
+            description: "Send a message",
+            parameters: { type: "object", properties: {} },
+            execute: vi.fn(),
+          },
+          ...(scope.senderIsOwner === false
+            ? []
+            : [
+                {
+                  name: "gateway",
+                  label: "Gateway",
+                  description: "Manage the gateway",
+                  parameters: { type: "object", properties: {} },
+                  execute: vi.fn(),
+                },
+              ]),
+        ],
+      }));
+      setCliRunnerPrepareTestDeps({
+        getActiveMcpLoopbackRuntime,
+        resolveMcpLoopbackScopedTools,
+      });
+      cliBackendsTesting.setDepsForTest({
+        resolvePluginSetupCliBackend: () => undefined,
+        resolveRuntimeCliBackends: () => [
+          {
+            id: "native-cli",
+            pluginId: "native-plugin",
+            bundleMcp: true,
+            bundleMcpMode: "claude-config-file",
+            config: {
+              command: "native-cli",
+              args: ["--print"],
+              systemPromptArg: "--system-prompt",
+              systemPromptWhen: "first",
+              output: "text",
+              input: "arg",
+              sessionMode: "existing",
+            },
+          },
+        ],
+      });
+      const cliSessionBindingFacts = {
+        extraSystemPromptStatic: "group:telegram:group:message_tool_only",
+        sourceReplyDeliveryMode: "message_tool_only" as const,
+      };
+      const first = await prepareCliRunContext({
+        sessionId: "session-test",
+        sessionKey: "agent:main:telegram:group:chat123",
+        sessionFile,
+        workspaceDir: dir,
+        prompt: "first ask",
+        provider: "native-cli",
+        model: "test-model",
+        timeoutMs: 1_000,
+        runId: "run-test-owner-tool-scope-a",
+        extraSystemPrompt: "volatile owner turn",
+        currentMessageId: "owner-message",
+        senderIsOwner: true,
+        cliSessionBindingFacts,
+        config: createCliBackendConfig({ bundleMcp: true }),
+      });
+      const second = await prepareCliRunContext({
+        sessionId: "session-test",
+        sessionKey: "agent:main:telegram:group:chat123",
+        sessionFile,
+        workspaceDir: dir,
+        prompt: "second ask",
+        provider: "native-cli",
+        model: "test-model",
+        timeoutMs: 1_000,
+        runId: "run-test-owner-tool-scope-b",
+        extraSystemPrompt: "volatile non-owner turn",
+        currentMessageId: "non-owner-message",
+        senderIsOwner: false,
+        cliSessionBindingFacts,
+        cliSessionBinding: {
+          sessionId: "cli-session",
+          extraSystemPromptHash: first.extraSystemPromptHash,
+          messageToolPolicyHash: first.messageToolPolicyHash,
+          promptToolNamesHash: first.promptToolNamesHash,
+          cwdHash: hashCliSessionText(dir),
+          mcpConfigHash: first.preparedBackend.mcpConfigHash,
+          mcpResumeHash: first.preparedBackend.mcpResumeHash,
+        },
+        config: createCliBackendConfig({ bundleMcp: true }),
+      });
+
+      expect(resolveMcpLoopbackScopedTools).toHaveBeenCalledTimes(2);
+      expect(resolveMcpLoopbackScopedTools).toHaveBeenNthCalledWith(
+        1,
+        expect.objectContaining({
+          senderIsOwner: undefined,
+          currentMessageId: undefined,
+          sourceReplyDeliveryMode: "message_tool_only",
+        }),
+      );
+      expect(resolveMcpLoopbackScopedTools).toHaveBeenNthCalledWith(
+        2,
+        expect.objectContaining({
+          senderIsOwner: undefined,
+          currentMessageId: undefined,
+          sourceReplyDeliveryMode: "message_tool_only",
+        }),
+      );
+      expect(second.promptToolNamesHash).toBe(first.promptToolNamesHash);
+      expect(second.reusableCliSession).toEqual({ sessionId: "cli-session" });
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
   it("prepares raw-tail history for safe invalidations only when the backend opts in", async () => {
     const { dir, sessionFile } = createSessionFile();
     appendTranscriptEntry(sessionFile, {

--- a/src/agents/cli-runner/prepare.ts
+++ b/src/agents/cli-runner/prepare.ts
@@ -601,14 +601,16 @@ export async function prepareCliRunContext(
             sessionKey: params.sessionKey ?? "",
             messageProvider: params.messageChannel ?? params.messageProvider,
             currentChannelId: params.currentChannelId,
-            currentThreadTs: params.currentThreadTs,
-            currentMessageId: params.currentMessageId,
-            currentInboundAudio: params.currentInboundAudio,
+            // CLI binding hashes must use session-stable prompt facts. Per-sender
+            // and per-message scope stays in the runtime MCP env/list-call path.
+            currentThreadTs: undefined,
+            currentMessageId: undefined,
+            currentInboundAudio: undefined,
             accountId: params.agentAccountId,
-            inboundEventKind: params.currentInboundEventKind,
-            sourceReplyDeliveryMode: params.sourceReplyDeliveryMode,
-            requireExplicitMessageTarget,
-            senderIsOwner: params.senderIsOwner,
+            inboundEventKind: undefined,
+            sourceReplyDeliveryMode: bindingSourceReplyDeliveryMode,
+            requireExplicitMessageTarget: bindingRequireExplicitMessageTarget,
+            senderIsOwner: undefined,
           }).tools
         : [];
     const promptToolNamesHash =

--- a/src/gateway/tool-resolution.exclude.test.ts
+++ b/src/gateway/tool-resolution.exclude.test.ts
@@ -42,12 +42,12 @@ describe("resolveGatewayScopedTools excludeToolNames", () => {
     hoisted.createOpenClawToolsMock.mockClear();
   });
 
-  function readCreateToolsArgs(): {
+  function readCreateToolsArgs(index = 0): {
     cronCreatorToolAllowlist?: Array<string | { name: string; pluginId?: string }>;
     inheritedToolDenylist?: string[];
     pluginToolDenylist?: string[];
   } {
-    const args = hoisted.createOpenClawToolsMock.mock.calls[0]?.[0];
+    const args = hoisted.createOpenClawToolsMock.mock.calls[index]?.[0];
     if (!args || typeof args !== "object") {
       throw new Error("expected createOpenClawTools args");
     }
@@ -77,8 +77,16 @@ describe("resolveGatewayScopedTools excludeToolNames", () => {
     expect(args.inheritedToolDenylist).toEqual([]);
   });
 
-  it("filters owner-only core tools from non-owner loopback callers", () => {
-    const result = resolveGatewayScopedTools({
+  it("keeps owner-only core tools visible only for owner loopback callers", () => {
+    const ownerResult = resolveGatewayScopedTools({
+      cfg: {
+        gateway: { tools: { allow: ["gateway"] } },
+      } as OpenClawConfig,
+      sessionKey: "agent:main:direct:test",
+      surface: "loopback",
+      senderIsOwner: true,
+    });
+    const nonOwnerResult = resolveGatewayScopedTools({
       cfg: {
         gateway: { tools: { allow: ["gateway"] } },
       } as OpenClawConfig,
@@ -87,8 +95,15 @@ describe("resolveGatewayScopedTools excludeToolNames", () => {
       senderIsOwner: false,
     });
 
-    expect(result.tools.map((tool) => tool.name)).toEqual(["read", "sessions_spawn"]);
-    const args = readCreateToolsArgs();
+    expect(ownerResult.tools.map((tool) => tool.name)).toEqual([
+      "read",
+      "sessions_spawn",
+      "cron",
+      "gateway",
+      "nodes",
+    ]);
+    expect(nonOwnerResult.tools.map((tool) => tool.name)).toEqual(["read", "sessions_spawn"]);
+    const args = readCreateToolsArgs(1);
     expect(args.pluginToolDenylist).toEqual(["cron", "gateway", "nodes"]);
     expect(args.inheritedToolDenylist).toEqual(["cron", "gateway", "nodes"]);
   });


### PR DESCRIPTION
Closes #99633
Related: #99595, #99372

## What Problem This Solves

Fixes an issue where CLI-backend agents (e.g. Claude CLI) in group chats with more than one human keep abandoning their resumed session and starting a fresh one whenever the sender alternates between the owner and a non-owner. Each fresh start drops conversational continuity and re-pays session warm-up cost, so multi-person group threads feel like the agent has amnesia every other turn.

Follow-up to #99595, which made `extraSystemPromptHash` and `messageToolPolicyHash` session-stable but left one per-turn input in the reuse key.

## Why This Change Was Made

`resolveCliSessionReuse` invalidates a stored binding when `promptToolNamesHash` changes. That hash was derived from `promptTools`, which was resolved with per-turn, per-sender facts — including `senderIsOwner`. Because owner-only core tools (`cron`, `gateway`, `nodes`) are excluded for non-owner senders, the tool-name list — and therefore the hash — flipped on every owner↔non-owner alternation, invalidating the binding and forcing a new CLI session.

The fix resolves the prompt-side tool list from the session-stable `cliSessionBindingFacts` seam instead of per-turn params (`senderIsOwner`, `currentMessageId`, `currentThreadTs`, `currentInboundAudio`, `inboundEventKind` are nulled for this resolution; the session-stable `sourceReplyDeliveryMode` / `requireExplicitMessageTarget` binding values are used). This makes the prompt tool listing, the prompt report, and `promptToolNamesHash` sender-independent, so the binding survives alternating senders.

Non-goal / boundary: this does **not** change per-sender tool enforcement. Actual tool availability is still scoped per turn by the MCP loopback bearer token, which is minted from the real `senderIsOwner` (`prepare.ts`, `resolveMcpLoopbackBearerToken(..., params.senderIsOwner === true)`). A non-owner turn still cannot call owner-only tools — the model's prompt now lists them, but the runtime denies the call. `src/gateway/tool-resolution.ts` is untouched.

## User Impact

In multi-human group chats, a CLI-backed agent now keeps one resumed session across turns from different people instead of respawning whenever owner and non-owner alternate. Continuity and latency improve for the common "owner + others chatting with the bot" case. No change to what tools any sender is actually allowed to invoke.

## Evidence

- New fail-confirmed regression test in `src/agents/cli-runner/prepare.test.ts` mirroring the production owner↔non-owner alternation: asserts `promptToolNamesHash` is identical across an owner turn and a non-owner turn (pre-fix, the recorded bad inputs were `senderIsOwner: true` / `currentMessageId: "owner-message"` leaking into the hash).
- `src/gateway/tool-resolution.exclude.test.ts` reworked to prove the split: owner loopback callers still see `cron`/`gateway`/`nodes`, non-owner loopback callers still have them denied — the enforcement path is unchanged.
- Local validation (macOS): `pnpm tsgo` 0, `pnpm check:test-types` 0, `run-vitest` on `prepare.test.ts` / `tool-resolution.exclude.test.ts` / `cli-runner.reliability.test.ts` / `cli-runner.spawn.test.ts` all 0, `run-oxlint` 0, `pnpm prompt:snapshots:check` 0, `git diff --check` 0.
- Live canary: branch build deployed to a private HamVerBot instance (not merged) to confirm `reuse=` stays stable across real alternating owner/non-owner group traffic before landing. Observations to be added below.

Draft until the live canary shows sustained clean reuse.
