### PR TITLE
feat(providers): add Runware provider

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -533,6 +533,11 @@
   - changed-files:
       - any-glob-to-any-file:
           - "extensions/chutes/**"
+"extensions: runware":
+  - changed-files:
+      - any-glob-to-any-file:
+          - "extensions/runware/**"
+          - "docs/providers/runware.md"
 "extensions: diffs":
   - changed-files:
       - any-glob-to-any-file:

--- a/docs/.i18n/glossary.zh-CN.json
+++ b/docs/.i18n/glossary.zh-CN.json
@@ -1214,5 +1214,21 @@
   {
     "source": "Docs map",
     "target": "文档地图"
+  },
+    {
+    "source": "Runware",
+    "target": "Runware"
+  },
+  {
+    "source": "runware",
+    "target": "runware"
+  },
+  {
+    "source": "Runware plugin",
+    "target": "Runware 插件"
+  },
+  {
+    "source": "Runware (OpenAI-compatible, live model catalog)",
+    "target": "Runware（OpenAI 兼容，实时模型目录）"
   }
 ]

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -1466,6 +1466,7 @@
                   "providers/qianfan",
                   "providers/qwen",
                   "providers/qwen-oauth",
+                  "providers/runware",
                   "providers/runway",
                   "providers/senseaudio",
                   "providers/sglang",

--- a/docs/docs_map.md
+++ b/docs/docs_map.md
@@ -7748,6 +7748,15 @@ Do not edit it by hand; run `pnpm docs:map:gen`.
   - H2: Advanced configuration
   - H2: Related
 
+## providers/runware.md
+
+- Route: /providers/runware
+- Headings:
+  - H2: Getting started
+  - H2: Model discovery (no manual catalog)
+  - H2: Request compatibility fixes
+  - H2: Related
+
 ## providers/runway.md
 
 - Route: /providers/runway

--- a/docs/plugins/plugin-inventory.md
+++ b/docs/plugins/plugin-inventory.md
@@ -51,7 +51,7 @@ Each entry lists the package, distribution route, and description.
 
 ## Core npm package
 
-59 plugins
+60 plugins
 
 - **[admin-http-rpc](/plugins/reference/admin-http-rpc)** (`@openclaw/admin-http-rpc`) - included in OpenClaw. OpenClaw admin HTTP RPC endpoint.
 
@@ -138,6 +138,8 @@ Each entry lists the package, distribution route, and description.
 - **[openrouter](/plugins/reference/openrouter)** (`@openclaw/openrouter-provider`) - included in OpenClaw. Adds OpenRouter model provider support to OpenClaw.
 
 - **[policy](/plugins/reference/policy)** (`@openclaw/policy`) - included in OpenClaw. Adds policy-backed doctor checks for workspace conformance.
+
+- **[runware](/plugins/reference/runware)** (`@openclaw/runware-provider`) - included in OpenClaw. OpenClaw Runware provider plugin.
 
 - **[runway](/plugins/reference/runway)** (`@openclaw/runway-provider`) - included in OpenClaw. Adds video generation provider support.
 

--- a/docs/plugins/reference.md
+++ b/docs/plugins/reference.md
@@ -15,5 +15,5 @@ This page is generated from `extensions/*/package.json` and
 pnpm plugins:inventory:gen
 ```
 
-Use [Plugin inventory](/plugins/plugin-inventory) to browse all 129
+Use [Plugin inventory](/plugins/plugin-inventory) to browse all 130
 generated plugin reference pages by distribution, package, and description.

--- a/docs/plugins/reference/runware.md
+++ b/docs/plugins/reference/runware.md
@@ -1,0 +1,23 @@
+---
+summary: "OpenClaw Runware provider plugin."
+read_when:
+  - You are installing, configuring, or auditing the runware plugin
+title: "Runware plugin"
+---
+
+# Runware plugin
+
+OpenClaw Runware provider plugin.
+
+## Distribution
+
+- Package: `@openclaw/runware-provider`
+- Install route: included in OpenClaw
+
+## Surface
+
+providers: runware, runware-ai, runwareai
+
+## Related docs
+
+- [runware](/providers/runware)

--- a/docs/providers/index.md
+++ b/docs/providers/index.md
@@ -66,6 +66,7 @@ Looking for chat channel docs (WhatsApp/Telegram/Discord/Slack/Mattermost (plugi
 - [Qianfan](/providers/qianfan)
 - [Qwen Cloud](/providers/qwen)
 - [Qwen OAuth / Portal](/providers/qwen-oauth)
+- [Runware (OpenAI-compatible, live model catalog)](/providers/runware)
 - [Runway](/providers/runway)
 - [SenseAudio](/providers/senseaudio)
 - [SGLang (local models)](/providers/sglang)

--- a/docs/providers/runware.md
+++ b/docs/providers/runware.md
@@ -1,0 +1,101 @@
+---
+summary: "Runware setup (API key, live model discovery, request quirks)"
+title: "Runware"
+read_when:
+  - You want to use Runware with OpenClaw
+  - You want to know how Runware's model catalog is discovered
+---
+
+[Runware](https://runware.ai) exposes an OpenAI-compatible chat completions API
+in front of a live-updated catalog of hosted models (DeepSeek, Kimi, GLM, Grok,
+Gemma, MiniMax, Qwen, and more).
+
+| Property | Value                       |
+| -------- | --------------------------- |
+| Provider | `runware`                   |
+| API      | OpenAI-compatible           |
+| Base URL | `https://api.runware.ai/v1` |
+| Auth     | API key                     |
+
+## Getting started
+
+<Steps>
+  <Step title="Get an API key">
+    Create a key at [my.runware.ai/api-keys](https://my.runware.ai/api-keys).
+  </Step>
+  <Step title="Run onboarding or set the env var directly">
+    ```bash
+    openclaw onboard --auth-choice runware-api-key
+    ```
+
+    Or:
+
+    ```bash
+    export RUNWARE_API_KEY="your-key"
+    ```
+
+  </Step>
+  <Step title="Set a model">
+    ```json5
+    {
+      agents: {
+        defaults: {
+          model: { primary: "runware/deepseek-v4-flash" },
+        },
+      },
+    }
+    ```
+
+  </Step>
+</Steps>
+
+## Model discovery (no manual catalog)
+
+Runware's model list is **not** hand-maintained in this plugin. On every
+catalog refresh, OpenClaw calls:
+
+```
+GET https://api.runware.ai/v1/models
+```
+
+and maps each returned row — id, context length, max output tokens, input
+modalities, and per-token pricing — directly into an OpenClaw model entry.
+There is no bundled per-model table to fall out of date. `agents.defaults.models`
+allows `"runware/*"` by default so newly-added Runware models become usable
+immediately, with no plugin update required.
+
+`GET /v1/models` requires authentication, so `openclaw models list --all`
+(run before any API key is configured) shows a single illustrative
+placeholder rather than the real catalog. Once `RUNWARE_API_KEY` is set, the
+real live catalog takes over.
+
+<Note>
+Runware does not currently expose a reasoning-capability field in `/v1/models`.
+Every discovered model defaults to `reasoning: false` until that changes;
+misreporting a non-reasoning model as reasoning-capable would incorrectly
+alter prompt-building and thinking-UI behavior.
+</Note>
+
+## Request compatibility fixes
+
+OpenClaw's Runware plugin patches two request-shaping quirks in Runware's
+chat completions endpoint before dispatch:
+
+- **`max_tokens`**: Runware's server-side default can exceed a given model's
+  real completion-token cap. OpenClaw always sends an explicit `max_tokens`,
+  clamped to that model's live-discovered cap.
+- **Empty tool schemas**: Runware rejects the zero-argument tool shape
+  (`{"type":"object","properties":{}}`) that OpenClaw normally sends for
+  parameter-less tools. OpenClaw adds a harmless placeholder property to any
+  tool schema with no properties before sending the request.
+
+## Related
+
+<CardGroup cols={2}>
+  <Card title="Model selection" href="/concepts/model-providers" icon="layers">
+    Choosing providers, model refs, and failover behavior.
+  </Card>
+  <Card title="Provider directory" href="/providers/index" icon="list">
+    All supported model providers.
+  </Card>
+</CardGroup>

--- a/extensions/runware/api.ts
+++ b/extensions/runware/api.ts
@@ -1,0 +1,14 @@
+// Runware API module exposes the plugin public contract.
+export {
+  parseRunwareModelRow,
+  RUNWARE_BASE_URL,
+  RUNWARE_DEFAULT_MODEL_ID,
+  RUNWARE_DEFAULT_MODEL_REF,
+  RUNWARE_FALLBACK_MODELS,
+} from "./models.js";
+export {
+  buildRunwareProvider,
+  buildStaticRunwareProvider,
+  discoverRunwareModels,
+} from "./provider-catalog.js";
+export { applyRunwareApiKeyConfig } from "./onboard.js";

--- a/extensions/runware/index.test.ts
+++ b/extensions/runware/index.test.ts
@@ -20,7 +20,7 @@ describe("runware provider plugin", () => {
 
   it("returns null from catalog.run without a configured API key", async () => {
     const provider = await registerSingleProviderPlugin(plugin);
-    const result = await provider.catalog.run({
+    const result = await provider.catalog?.run({
       config: {},
       resolveProviderApiKey: () => ({ apiKey: undefined }),
     } as never);
@@ -50,7 +50,7 @@ describe("runware provider plugin", () => {
     );
 
     const provider = await registerSingleProviderPlugin(plugin);
-    const result = await provider.catalog.run({
+    const result = await provider.catalog?.run({
       config: {},
       resolveProviderApiKey: () => ({ apiKey: "rw_test_key" }),
     } as never);

--- a/extensions/runware/index.test.ts
+++ b/extensions/runware/index.test.ts
@@ -1,0 +1,103 @@
+import { registerSingleProviderPlugin } from "openclaw/plugin-sdk/plugin-test-runtime";
+// Runware tests cover index plugin behavior.
+import { clearLiveCatalogCacheForTests } from "openclaw/plugin-sdk/provider-catalog-live-runtime";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import plugin from "./index.js";
+
+afterEach(() => {
+  clearLiveCatalogCacheForTests();
+  vi.unstubAllGlobals();
+});
+
+describe("runware provider plugin", () => {
+  it("registers with the expected id, env var, and auth method", async () => {
+    const provider = await registerSingleProviderPlugin(plugin);
+    expect(provider.id).toBe("runware");
+    expect(provider.envVars).toEqual(["RUNWARE_API_KEY"]);
+    expect(provider.auth).toHaveLength(1);
+    expect(provider.auth[0]?.id).toBe("api-key");
+  });
+
+  it("returns null from catalog.run without a configured API key", async () => {
+    const provider = await registerSingleProviderPlugin(plugin);
+    const result = await provider.catalog.run({
+      config: {},
+      resolveProviderApiKey: () => ({ apiKey: undefined }),
+    } as never);
+    expect(result).toBeNull();
+  });
+
+  it("builds a live-discovered provider once an API key is resolved", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(
+        async () =>
+          new Response(
+            JSON.stringify({
+              object: "list",
+              data: [
+                {
+                  id: "deepseek-v4-flash",
+                  context_length: 128000,
+                  max_output_tokens: 65536,
+                  pricing: { prompt: "0.000001", completion: "0.000002" },
+                },
+              ],
+            }),
+            { status: 200, headers: { "Content-Type": "application/json" } },
+          ),
+      ) as unknown as typeof fetch,
+    );
+
+    const provider = await registerSingleProviderPlugin(plugin);
+    const result = await provider.catalog.run({
+      config: {},
+      resolveProviderApiKey: () => ({ apiKey: "rw_test_key" }),
+    } as never);
+
+    expect(result).toMatchObject({
+      provider: {
+        baseUrl: "https://api.runware.ai/v1",
+        api: "openai-completions",
+        apiKey: "rw_test_key",
+        models: [
+          {
+            id: "deepseek-v4-flash",
+            contextWindow: 128000,
+            maxTokens: 65536,
+            cost: { input: 1, output: 2, cacheRead: 0, cacheWrite: 0 },
+          },
+        ],
+      },
+    });
+  });
+
+  it("serves an offline placeholder from staticCatalog.run without network access", async () => {
+    const provider = await registerSingleProviderPlugin(plugin);
+    const result = await provider.staticCatalog?.run({} as never);
+    expect(result).toMatchObject({
+      provider: { baseUrl: "https://api.runware.ai/v1", api: "openai-completions" },
+    });
+    expect((result as { provider: { models: unknown[] } }).provider.models.length).toBeGreaterThan(
+      0,
+    );
+  });
+
+  it("only wraps the stream for the runware provider", async () => {
+    const provider = await registerSingleProviderPlugin(plugin);
+    expect(
+      provider.wrapStreamFn?.({
+        provider: "openai",
+        modelId: "gpt-5",
+        streamFn: undefined,
+      } as never),
+    ).toBeUndefined();
+    expect(
+      provider.wrapStreamFn?.({
+        provider: "runware",
+        modelId: "deepseek-v4-flash",
+        streamFn: undefined,
+      } as never),
+    ).toBeDefined();
+  });
+});

--- a/extensions/runware/index.ts
+++ b/extensions/runware/index.ts
@@ -1,0 +1,73 @@
+// Runware plugin entrypoint registers its OpenClaw integration.
+import { definePluginEntry } from "openclaw/plugin-sdk/plugin-entry";
+import { createProviderApiKeyAuthMethod } from "openclaw/plugin-sdk/provider-auth-api-key";
+import { buildProviderReplayFamilyHooks } from "openclaw/plugin-sdk/provider-model-shared";
+import { applyRunwareApiKeyConfig, RUNWARE_DEFAULT_MODEL_REF } from "./onboard.js";
+import { buildRunwareProvider, buildStaticRunwareProvider } from "./provider-catalog.js";
+import { wrapRunwareProviderStream } from "./stream.js";
+
+const PROVIDER_ID = "runware";
+
+export default definePluginEntry({
+  id: PROVIDER_ID,
+  name: "Runware Provider",
+  description: "Bundled Runware provider plugin",
+  register(api) {
+    api.registerProvider({
+      id: PROVIDER_ID,
+      label: "Runware",
+      docsPath: "/providers/runware",
+      envVars: ["RUNWARE_API_KEY"],
+      auth: [
+        createProviderApiKeyAuthMethod({
+          providerId: PROVIDER_ID,
+          methodId: "api-key",
+          label: "Runware API key",
+          hint: "OpenAI-compatible access to DeepSeek, Kimi, GLM, Grok, and more",
+          optionKey: "runwareApiKey",
+          flagName: "--runware-api-key",
+          envVar: "RUNWARE_API_KEY",
+          promptMessage: "Enter Runware API key",
+          defaultModel: RUNWARE_DEFAULT_MODEL_REF,
+          applyConfig: (cfg) => applyRunwareApiKeyConfig(cfg),
+          noteTitle: "Runware",
+          noteMessage: [
+            "Runware provides OpenAI-compatible access to a live-updated catalog of models.",
+            "Get your API key at: https://my.runware.ai/api-keys",
+          ].join("\n"),
+          wizard: {
+            choiceId: "runware-api-key",
+            choiceLabel: "Runware API key",
+            groupId: "runware",
+            groupLabel: "Runware",
+            groupHint: "API key",
+          },
+        }),
+      ],
+      catalog: {
+        order: "profile",
+        run: async (ctx) => {
+          const { apiKey, discoveryApiKey } = ctx.resolveProviderApiKey(PROVIDER_ID);
+          if (!apiKey) {
+            return null;
+          }
+          return {
+            provider: {
+              ...(await buildRunwareProvider(discoveryApiKey ?? apiKey)),
+              apiKey,
+            },
+          };
+        },
+      },
+      staticCatalog: {
+        order: "profile",
+        run: async () => ({ provider: buildStaticRunwareProvider() }),
+      },
+      ...buildProviderReplayFamilyHooks({
+        family: "openai-compatible",
+        dropReasoningFromHistory: false,
+      }),
+      wrapStreamFn: wrapRunwareProviderStream,
+    });
+  },
+});

--- a/extensions/runware/models.test.ts
+++ b/extensions/runware/models.test.ts
@@ -1,0 +1,91 @@
+// Runware tests cover model row parsing behavior.
+import { describe, expect, it } from "vitest";
+import { parseRunwareModelRow } from "./models.js";
+
+describe("parseRunwareModelRow", () => {
+  it("maps a full row with image input and pricing", () => {
+    const model = parseRunwareModelRow({
+      id: "moonshotai-kimi-k2-6",
+      name: "Kimi K2.6",
+      context_length: 262144,
+      max_output_tokens: 65536,
+      input_modalities: ["text", "image"],
+      pricing: {
+        prompt: "0.0000025",
+        completion: "0.00001",
+        input_cache_read: "0.000001",
+        input_cache_write: "0.000003",
+      },
+    });
+
+    expect(model).toEqual({
+      id: "moonshotai-kimi-k2-6",
+      name: "Kimi K2.6",
+      api: "openai-completions",
+      reasoning: false,
+      input: ["text", "image"],
+      cost: { input: 2.5, output: 10, cacheRead: 1, cacheWrite: 3 },
+      contextWindow: 262144,
+      maxTokens: 65536,
+    });
+  });
+
+  it("keeps input to text/image even when Runware advertises video/audio/file", () => {
+    // The on-disk model-catalog schema (ModelCatalogInput) only accepts
+    // "text" | "image" | "document" and rejects "video"/"audio" on write.
+    const model = parseRunwareModelRow({
+      id: "google-gemini-3-1-flash-lite",
+      context_length: 1048576,
+      max_output_tokens: 65536,
+      input_modalities: ["text", "image", "video", "audio", "file"],
+      pricing: { prompt: "0.00000025", completion: "0.0000015" },
+    });
+    expect(model?.input).toEqual(["text", "image"]);
+  });
+
+  it("maps a reasoning-flagged text-only row", () => {
+    const model = parseRunwareModelRow({
+      id: "deepseek-v4-pro",
+      context_length: 163840,
+      max_output_tokens: 512000,
+      reasoning: true,
+      pricing: { prompt: "0.000001", completion: "0.000002" },
+    });
+
+    expect(model?.reasoning).toBe(true);
+    expect(model?.input).toEqual(["text"]);
+    expect(model?.cost.cacheRead).toBe(0);
+    expect(model?.cost.cacheWrite).toBe(0);
+  });
+
+  it("humanizes the id into a display name when name is missing", () => {
+    const model = parseRunwareModelRow({ id: "xai-grok-4-3" });
+    expect(model?.name).toBe("Xai Grok 4 3");
+  });
+
+  it("defaults sanely when context_length/max_output_tokens/pricing are null or missing", () => {
+    // Real Runware rows for newly-added passthrough models ship exactly this shape.
+    const model = parseRunwareModelRow({
+      id: "openai-gpt-5-1",
+      context_length: null,
+      max_output_tokens: null,
+      input_modalities: ["text"],
+    });
+    expect(model).toEqual({
+      id: "openai-gpt-5-1",
+      name: "Openai Gpt 5 1",
+      api: "openai-completions",
+      reasoning: false,
+      input: ["text"],
+      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+      contextWindow: 128_000,
+      maxTokens: 4_096,
+    });
+  });
+
+  it("returns null for rows without a usable id", () => {
+    expect(parseRunwareModelRow({ name: "no id" })).toBeNull();
+    expect(parseRunwareModelRow(null)).toBeNull();
+    expect(parseRunwareModelRow("not-an-object")).toBeNull();
+  });
+});

--- a/extensions/runware/models.ts
+++ b/extensions/runware/models.ts
@@ -1,0 +1,87 @@
+// Runware plugin module implements model row parsing behavior.
+import type { ModelDefinitionConfig } from "openclaw/plugin-sdk/provider-model-shared";
+import {
+  asPositiveSafeInteger,
+  normalizeOptionalString,
+} from "openclaw/plugin-sdk/string-coerce-runtime";
+
+export const RUNWARE_BASE_URL = "https://api.runware.ai/v1";
+export const RUNWARE_DEFAULT_MODEL_ID = "deepseek-v4-flash";
+export const RUNWARE_DEFAULT_MODEL_REF = `runware/${RUNWARE_DEFAULT_MODEL_ID}`;
+
+// GET /v1/models requires auth (unauthenticated -> 401), so this single
+// illustrative entry is all buildStaticRunwareProvider can offer offline.
+export const RUNWARE_FALLBACK_MODELS: ModelDefinitionConfig[] = [
+  {
+    id: RUNWARE_DEFAULT_MODEL_ID,
+    name: "DeepSeek V4 Flash (illustrative)",
+    api: "openai-completions",
+    reasoning: false,
+    input: ["text"],
+    cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+    contextWindow: 128_000,
+    maxTokens: 65_536,
+  },
+];
+
+type RunwareModelRow = {
+  id?: unknown;
+  name?: unknown;
+  context_length?: unknown;
+  max_output_tokens?: unknown;
+  input_modalities?: unknown;
+  reasoning?: unknown;
+  supports_reasoning?: unknown;
+  pricing?: {
+    prompt?: unknown;
+    completion?: unknown;
+    input_cache_read?: unknown;
+    input_cache_write?: unknown;
+  };
+};
+
+// OpenClaw's persisted catalog schema (ModelCatalogInput) only accepts
+// "text" | "image" | "document", not "video"/"audio" — writing those values
+// gets the whole catalog rejected. No bundled provider uses beyond text/image.
+function mapRunwareInputModalities(raw: unknown): Array<"text" | "image"> {
+  const advertised = Array.isArray(raw) ? raw : [];
+  return advertised.includes("image") ? ["text", "image"] : ["text"];
+}
+
+function humanizeRunwareModelId(id: string): string {
+  return id.replace(/[-_]+/g, " ").replace(/\b\w/g, (letter) => letter.toUpperCase());
+}
+
+function parseRunwarePriceToPerMillion(value: unknown): number {
+  const parsed = typeof value === "string" ? Number.parseFloat(value) : value;
+  return typeof parsed === "number" && Number.isFinite(parsed) ? parsed * 1_000_000 : 0;
+}
+
+// Runware's /v1/models rows carry no reasoning-capability field; default false
+// (a false negative is safer than misreporting a model as reasoning-capable).
+export function parseRunwareModelRow(raw: unknown): ModelDefinitionConfig | null {
+  if (!raw || typeof raw !== "object") {
+    return null;
+  }
+  const row = raw as RunwareModelRow;
+  const id = normalizeOptionalString(row.id);
+  if (!id) {
+    return null;
+  }
+  const reasoning = row.reasoning === true || row.supports_reasoning === true;
+  return {
+    id,
+    name: normalizeOptionalString(row.name) ?? humanizeRunwareModelId(id),
+    api: "openai-completions",
+    reasoning,
+    input: mapRunwareInputModalities(row.input_modalities),
+    cost: {
+      input: parseRunwarePriceToPerMillion(row.pricing?.prompt),
+      output: parseRunwarePriceToPerMillion(row.pricing?.completion),
+      cacheRead: parseRunwarePriceToPerMillion(row.pricing?.input_cache_read),
+      cacheWrite: parseRunwarePriceToPerMillion(row.pricing?.input_cache_write),
+    },
+    contextWindow: asPositiveSafeInteger(row.context_length) ?? 128_000,
+    maxTokens: asPositiveSafeInteger(row.max_output_tokens) ?? 4_096,
+  };
+}

--- a/extensions/runware/onboard.ts
+++ b/extensions/runware/onboard.ts
@@ -1,0 +1,28 @@
+// Runware setup module handles plugin onboarding behavior.
+import {
+  applyAgentDefaultModelPrimary,
+  withAgentModelAliases,
+  type OpenClawConfig,
+} from "openclaw/plugin-sdk/provider-onboard";
+import { RUNWARE_DEFAULT_MODEL_REF } from "./models.js";
+
+export { RUNWARE_DEFAULT_MODEL_REF };
+
+const PROVIDER_ID = "runware";
+
+// Catalog is fully dynamic: no fixed per-model allowlist to maintain here.
+export function applyRunwareApiKeyConfig(cfg: OpenClawConfig): OpenClawConfig {
+  const next: OpenClawConfig = {
+    ...cfg,
+    agents: {
+      ...cfg.agents,
+      defaults: {
+        ...cfg.agents?.defaults,
+        models: withAgentModelAliases(cfg.agents?.defaults?.models, [
+          { modelRef: `${PROVIDER_ID}/*` },
+        ]),
+      },
+    },
+  };
+  return applyAgentDefaultModelPrimary(next, RUNWARE_DEFAULT_MODEL_REF);
+}

--- a/extensions/runware/openclaw.plugin.json
+++ b/extensions/runware/openclaw.plugin.json
@@ -1,0 +1,56 @@
+{
+  "id": "runware",
+  "name": "Runware",
+  "description": "OpenClaw Runware provider plugin.",
+  "activation": {
+    "onStartup": false
+  },
+  "enabledByDefault": true,
+  "providers": ["runware", "runware-ai", "runwareai"],
+  "providerAuthAliases": {
+    "runware-ai": "runware",
+    "runwareai": "runware"
+  },
+  "providerEndpoints": [
+    {
+      "endpointClass": "runware-native",
+      "hosts": ["api.runware.ai"]
+    }
+  ],
+  "providerRequest": {
+    "providers": {
+      "runware": { "family": "runware" },
+      "runware-ai": { "family": "runware" },
+      "runwareai": { "family": "runware" }
+    }
+  },
+  "setup": {
+    "providers": [
+      {
+        "id": "runware",
+        "envVars": ["RUNWARE_API_KEY"]
+      }
+    ]
+  },
+  "providerAuthChoices": [
+    {
+      "provider": "runware",
+      "method": "api-key",
+      "choiceId": "runware-api-key",
+      "choiceLabel": "Runware API key",
+      "choiceHint": "OpenAI-compatible access to a live-updated model catalog",
+      "groupId": "runware",
+      "groupLabel": "Runware",
+      "groupHint": "OpenAI-compatible access to a live-updated model catalog",
+      "optionKey": "runwareApiKey",
+      "cliFlag": "--runware-api-key",
+      "cliOption": "--runware-api-key <key>",
+      "cliDescription": "Runware API key"
+    }
+  ],
+  "configSchema": {
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {}
+  }
+}

--- a/extensions/runware/package.json
+++ b/extensions/runware/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "@openclaw/runware-provider",
+  "version": "2026.6.11",
+  "description": "OpenClaw Runware provider plugin",
+  "type": "module",
+  "devDependencies": {
+    "@openclaw/plugin-sdk": "workspace:*"
+  },
+  "openclaw": {
+    "extensions": ["./index.ts"]
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/openclaw/openclaw"
+  }
+}

--- a/extensions/runware/provider-catalog.test.ts
+++ b/extensions/runware/provider-catalog.test.ts
@@ -1,0 +1,104 @@
+// Runware tests cover provider catalog discovery and fallback behavior.
+import { clearLiveCatalogCacheForTests } from "openclaw/plugin-sdk/provider-catalog-live-runtime";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { RUNWARE_FALLBACK_MODELS } from "./models.js";
+import {
+  buildRunwareProvider,
+  buildStaticRunwareProvider,
+  discoverRunwareModels,
+} from "./provider-catalog.js";
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+// Real /v1/models responses are wrapped as { object: "list", data: [...] },
+// not a bare array.
+function modelsListResponse(rows: unknown[], status = 200): Response {
+  return jsonResponse({ object: "list", data: rows }, status);
+}
+
+afterEach(() => {
+  clearLiveCatalogCacheForTests();
+  vi.unstubAllGlobals();
+});
+
+describe("discoverRunwareModels", () => {
+  it("maps a real { object, data } /v1/models response into full model definitions", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () =>
+        modelsListResponse([
+          {
+            id: "deepseek-v4-flash",
+            name: "DeepSeek V4 Flash",
+            context_length: 128000,
+            max_output_tokens: 65536,
+            input_modalities: ["text"],
+            pricing: { prompt: "0.000001", completion: "0.000002" },
+          },
+        ]),
+      ) as unknown as typeof fetch,
+    );
+
+    const models = await discoverRunwareModels("test-key");
+    expect(models).toEqual([
+      {
+        id: "deepseek-v4-flash",
+        name: "DeepSeek V4 Flash",
+        api: "openai-completions",
+        reasoning: false,
+        input: ["text"],
+        cost: { input: 1, output: 2, cacheRead: 0, cacheWrite: 0 },
+        contextWindow: 128000,
+        maxTokens: 65536,
+      },
+    ]);
+  });
+
+  it("falls back to the illustrative catalog on HTTP failure", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => jsonResponse({ error: "unauthorized" }, 401)) as unknown as typeof fetch,
+    );
+
+    const models = await discoverRunwareModels("bad-key");
+    expect(models).toBe(RUNWARE_FALLBACK_MODELS);
+  });
+
+  it("falls back to the illustrative catalog when the response has no usable rows", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => modelsListResponse([{ name: "missing id" }])) as unknown as typeof fetch,
+    );
+
+    const models = await discoverRunwareModels("test-key");
+    expect(models).toBe(RUNWARE_FALLBACK_MODELS);
+  });
+});
+
+describe("buildRunwareProvider", () => {
+  it("builds a provider config pointed at the Runware base URL", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () =>
+        modelsListResponse([{ id: "deepseek-v4-flash" }]),
+      ) as unknown as typeof fetch,
+    );
+
+    const provider = await buildRunwareProvider("test-key");
+    expect(provider.baseUrl).toBe("https://api.runware.ai/v1");
+    expect(provider.api).toBe("openai-completions");
+    expect(provider.models).toHaveLength(1);
+  });
+});
+
+describe("buildStaticRunwareProvider", () => {
+  it("returns the offline catalog without any network access", () => {
+    const provider = buildStaticRunwareProvider();
+    expect(provider.models).toBe(RUNWARE_FALLBACK_MODELS);
+  });
+});

--- a/extensions/runware/provider-catalog.ts
+++ b/extensions/runware/provider-catalog.ts
@@ -1,0 +1,55 @@
+// Runware plugin module implements provider catalog behavior.
+import { getCachedLiveProviderModelRows } from "openclaw/plugin-sdk/provider-catalog-live-runtime";
+import type { ModelProviderConfig } from "openclaw/plugin-sdk/provider-model-shared";
+import { createSubsystemLogger } from "openclaw/plugin-sdk/runtime-env";
+import { ssrfPolicyFromHttpBaseUrlAllowedHostname } from "openclaw/plugin-sdk/ssrf-runtime";
+import { parseRunwareModelRow, RUNWARE_BASE_URL, RUNWARE_FALLBACK_MODELS } from "./models.js";
+
+const log = createSubsystemLogger("runware-models");
+const RUNWARE_DISCOVERY_TIMEOUT_MS = 10_000;
+const RUNWARE_DISCOVERY_CACHE_TTL_MS = 5 * 60 * 1000;
+
+// Runware returns { object: "list", data: [...] }; the default row reader
+// (readDefaultLiveModelCatalogRows) already unwraps that shape.
+async function fetchRunwareModelRows(apiKey: string): Promise<readonly unknown[]> {
+  return await getCachedLiveProviderModelRows({
+    providerId: "runware",
+    endpoint: `${RUNWARE_BASE_URL}/models`,
+    discoveryApiKey: apiKey,
+    timeoutMs: RUNWARE_DISCOVERY_TIMEOUT_MS,
+    ttlMs: RUNWARE_DISCOVERY_CACHE_TTL_MS,
+    policy: ssrfPolicyFromHttpBaseUrlAllowedHostname(RUNWARE_BASE_URL),
+    auditContext: "runware-model-discovery",
+  });
+}
+
+export async function discoverRunwareModels(apiKey: string) {
+  try {
+    const rows = await fetchRunwareModelRows(apiKey);
+    const models = rows.flatMap((row) => parseRunwareModelRow(row) ?? []);
+    if (models.length === 0) {
+      log.warn("No models in Runware /v1/models response, using illustrative fallback");
+      return RUNWARE_FALLBACK_MODELS;
+    }
+    return models;
+  } catch (error) {
+    log.warn(`Runware model discovery failed: ${String(error)}, using illustrative fallback`);
+    return RUNWARE_FALLBACK_MODELS;
+  }
+}
+
+export async function buildRunwareProvider(apiKey: string): Promise<ModelProviderConfig> {
+  return {
+    baseUrl: RUNWARE_BASE_URL,
+    api: "openai-completions",
+    models: await discoverRunwareModels(apiKey),
+  };
+}
+
+export function buildStaticRunwareProvider(): ModelProviderConfig {
+  return {
+    baseUrl: RUNWARE_BASE_URL,
+    api: "openai-completions",
+    models: RUNWARE_FALLBACK_MODELS,
+  };
+}

--- a/extensions/runware/stream.test.ts
+++ b/extensions/runware/stream.test.ts
@@ -1,0 +1,151 @@
+// Runware tests cover stream plugin behavior.
+import type { StreamFn } from "openclaw/plugin-sdk/agent-core";
+import type { Context, Model } from "openclaw/plugin-sdk/llm";
+import { describe, expect, it } from "vitest";
+import { wrapRunwareProviderStream } from "./stream.js";
+
+function capturePayload(params: {
+  initialPayload: Record<string, unknown>;
+  maxTokens?: number;
+  provider?: string;
+}): Record<string, unknown> {
+  let captured: Record<string, unknown> = {};
+  const baseStreamFn: StreamFn = (_model, _context, options) => {
+    const payload = { ...params.initialPayload };
+    options?.onPayload?.(payload, _model);
+    captured = payload;
+    return {} as ReturnType<StreamFn>;
+  };
+
+  const model = {
+    api: "openai-completions",
+    provider: params.provider ?? "runware",
+    id: "deepseek-v4-flash",
+    maxTokens: params.maxTokens ?? 65536,
+  } as Model<"openai-completions">;
+
+  const wrapped = wrapRunwareProviderStream({
+    provider: params.provider ?? "runware",
+    modelId: model.id,
+    model,
+    streamFn: baseStreamFn,
+  });
+  expect(wrapped).toBeDefined();
+  void wrapped!(model, { messages: [] } as Context, {});
+
+  return captured;
+}
+
+describe("wrapRunwareProviderStream", () => {
+  it("returns undefined for non-Runware providers", () => {
+    const wrapped = wrapRunwareProviderStream({
+      provider: "openai",
+      modelId: "gpt-5",
+      streamFn: undefined,
+    });
+    expect(wrapped).toBeUndefined();
+  });
+
+  it("injects the model's max_tokens when the request omits it", () => {
+    const payload = capturePayload({ initialPayload: {}, maxTokens: 65536 });
+    expect(payload.max_tokens).toBe(65536);
+  });
+
+  it("clamps an outgoing max_tokens that exceeds the model's cap", () => {
+    const payload = capturePayload({
+      initialPayload: { max_tokens: 999_999 },
+      maxTokens: 65536,
+    });
+    expect(payload.max_tokens).toBe(65536);
+  });
+
+  it("leaves a within-cap max_tokens untouched", () => {
+    const payload = capturePayload({
+      initialPayload: { max_tokens: 1024 },
+      maxTokens: 65536,
+    });
+    expect(payload.max_tokens).toBe(1024);
+  });
+
+  it("patches a tool with empty properties", () => {
+    const payload = capturePayload({
+      initialPayload: {
+        tools: [
+          {
+            type: "function",
+            function: { name: "ping", parameters: { type: "object", properties: {} } },
+          },
+        ],
+      },
+    });
+    expect(payload.tools).toEqual([
+      {
+        type: "function",
+        function: {
+          name: "ping",
+          parameters: {
+            type: "object",
+            properties: {
+              _unused: { type: "string", description: "Unused. This tool takes no parameters." },
+            },
+          },
+        },
+      },
+    ]);
+  });
+
+  it("leaves a tool with real parameters unchanged", () => {
+    const parameters = {
+      type: "object",
+      properties: { query: { type: "string" } },
+      required: ["query"],
+    };
+    const payload = capturePayload({
+      initialPayload: {
+        tools: [{ type: "function", function: { name: "search", parameters } }],
+      },
+    });
+    expect((payload.tools as never[])[0]).toEqual({
+      type: "function",
+      function: { name: "search", parameters },
+    });
+  });
+
+  it("re-patches an empty tool schema even after another sanitizer already ran", () => {
+    // Simulates a family-specific sanitizer (e.g. Kimi/Moonshot tool-call handling)
+    // running before this wrapper in the stream chain; the Runware fix must still apply.
+    let captured: Record<string, unknown> = {};
+    const innerStreamFn: StreamFn = (_model, _context, options) => {
+      const payload: Record<string, unknown> = {
+        tools: [
+          {
+            type: "function",
+            function: { name: "ping", parameters: { type: "object", properties: {} } },
+          },
+        ],
+      };
+      options?.onPayload?.(payload, _model);
+      captured = payload;
+      return {} as ReturnType<StreamFn>;
+    };
+    const model = {
+      api: "openai-completions",
+      provider: "runware",
+      id: "moonshotai-kimi-k2-6",
+      maxTokens: 65536,
+    } as Model<"openai-completions">;
+
+    const wrapped = wrapRunwareProviderStream({
+      provider: "runware",
+      modelId: model.id,
+      model,
+      streamFn: innerStreamFn,
+    });
+    void wrapped!(model, { messages: [] } as Context, {});
+
+    const tools = captured.tools as Array<{
+      function: { parameters: { properties: Record<string, unknown> } };
+    }>;
+    expect(Object.keys(tools[0].function.parameters.properties)).toEqual(["_unused"]);
+  });
+});

--- a/extensions/runware/stream.ts
+++ b/extensions/runware/stream.ts
@@ -1,0 +1,54 @@
+// Runware plugin module implements stream behavior.
+import type { StreamFn } from "openclaw/plugin-sdk/agent-core";
+import type { ProviderWrapStreamFnContext } from "openclaw/plugin-sdk/plugin-entry";
+import { normalizeProviderId } from "openclaw/plugin-sdk/provider-model-shared";
+import { createPayloadPatchStreamWrapper } from "openclaw/plugin-sdk/provider-stream-shared";
+
+type RunwareToolSchema = {
+  type?: string;
+  properties?: Record<string, unknown>;
+};
+
+type RunwareTool = {
+  type?: string;
+  function?: { parameters?: RunwareToolSchema };
+};
+
+// Runware's server-side max_tokens default can exceed a model's real cap and
+// 400. Clamp to the model's live-discovered maxTokens, not a hardcoded table.
+function clampRunwareMaxTokens(payload: Record<string, unknown>, modelMaxTokens: number): void {
+  const requested = payload.max_tokens;
+  if (typeof requested !== "number" || requested > modelMaxTokens) {
+    payload.max_tokens = modelMaxTokens;
+  }
+}
+
+// Runware 400s on {"type":"object","properties":{}}, which OpenClaw's tool
+// normalizer produces for parameter-less tools.
+function patchRunwareEmptyToolSchemas(payload: Record<string, unknown>): void {
+  const tools = payload.tools;
+  if (!Array.isArray(tools)) {
+    return;
+  }
+  for (const tool of tools as RunwareTool[]) {
+    const schema = tool?.function?.parameters;
+    if (!schema || typeof schema !== "object") {
+      continue;
+    }
+    if (!schema.properties || Object.keys(schema.properties).length === 0) {
+      schema.properties = {
+        _unused: { type: "string", description: "Unused. This tool takes no parameters." },
+      };
+    }
+  }
+}
+
+export function wrapRunwareProviderStream(ctx: ProviderWrapStreamFnContext): StreamFn | undefined {
+  if (normalizeProviderId(ctx.provider) !== "runware") {
+    return undefined;
+  }
+  return createPayloadPatchStreamWrapper(ctx.streamFn, ({ payload, model }) => {
+    clampRunwareMaxTokens(payload, model.maxTokens);
+    patchRunwareEmptyToolSchemas(payload);
+  });
+}

--- a/extensions/runware/tsconfig.json
+++ b/extensions/runware/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "extends": "../tsconfig.package-boundary.base.json",
+  "compilerOptions": {
+    "rootDir": "."
+  },
+  "include": ["./*.ts", "./src/**/*.ts"],
+  "exclude": [
+    "./**/*.test.ts",
+    "./dist/**",
+    "./node_modules/**",
+    "./src/test-support/**",
+    "./src/**/*test-helpers.ts",
+    "./src/**/*test-harness.ts",
+    "./src/**/*test-support.ts"
+  ]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1437,6 +1437,12 @@ importers:
         specifier: workspace:*
         version: link:../..
 
+  extensions/runware:
+    devDependencies:
+      '@openclaw/plugin-sdk':
+        specifier: workspace:*
+        version: link:../../packages/plugin-sdk
+
   extensions/runway:
     devDependencies:
       '@openclaw/plugin-sdk':


### PR DESCRIPTION
## What Problem This Solves
 
OpenClaw's provider list doesn't include Runware, so anyone who wants to run models through it (DeepSeek, GLM, Grok, Gemma, MiniMax, Qwen, plus OpenAI/Anthropic passthroughs) has no supported way to do it.
 
## Why This Change Was Made
 
Adds `extensions/runware` as a bundled provider with a fully dynamic model catalog pulled live from `GET /v1/models` — no per-model table to maintain, same discovery pattern as vllm/sglang/chutes rather than a baked static list.
Two Runware-specific request bugs are patched at the stream layer: a forced/clamped `max_tokens` and a fix for Runware rejecting the standard empty-argument tool schema.
 
## User Impact
`openclaw onboard --auth-choice runware-api-key` and any of Runware's ~34 live models work immediately under `runware/<id>`; new models Runware adds show up with no plugin update.
 
## Evidence
- `pnpm test:extension runware`: 4 files, 23 tests passing.
- `pnpm check` on the rebased branch: typecheck, lint, import-cycle, and  policy guards all clean.
- `models list --provider runware`: 34 models with correct per-model context  window and cost, confirming the catalog is live, not static.
- Real Control UI session against `runware/deepseek-v4-flash` and  `runware/deepseek-v4-pro`, both returning real completions.
- Real agent run with an actual tool call including a zero-argument tool (`get_goal`) — confirms the empty-schema patch holds against the live endpoint.