### PR TITLE
test: avoid cross-OS socket close event race

### DIFF
--- a/test/scripts/openclaw-cross-os-release-checks.test.ts
+++ b/test/scripts/openclaw-cross-os-release-checks.test.ts
@@ -974,6 +974,11 @@ describe("scripts/openclaw-cross-os-release-checks", () => {
         socket.once("connect", resolve);
         socket.once("error", reject);
       });
+      // Subscribe before shutdown because the one-shot client close event may
+      // arrive before the server close callback resolves.
+      const socketClosePromise = new Promise<void>((resolve) => {
+        socket.once("close", resolve);
+      });
       socket.write(`GET ${url.pathname} HTTP/1.1\r\nHost: ${url.host}\r\n\r\n`);
       await Promise.race([
         server.close(),
@@ -982,9 +987,7 @@ describe("scripts/openclaw-cross-os-release-checks", () => {
         }),
       ]);
       await Promise.race([
-        new Promise<void>((resolve) => {
-          socket.once("close", resolve);
-        }),
+        socketClosePromise,
         delay(1_000).then(() => {
           throw new Error("socket close timed out");
         }),


### PR DESCRIPTION
## What Problem This Solves

The cross-OS release-check test could fail after the static artifact server had already shut down successfully. In CI run 28639846548, job 84933576981, the test awaited `server.close()` and only then registered the client socket's one-shot `close` listener, allowing Linux/Node 24 to emit the event before the listener existed and hit the fixed one-second test timeout.

## Why This Change Was Made

Register the client socket close promise before starting server shutdown, then keep the existing server-close and socket-close timeout assertions. This fixes the observation race without increasing a timeout or changing production behavior; the server already tracks and destroys active sockets during shutdown.

## User Impact

No user-visible behavior changes. Release-check CI no longer depends on OS-specific ordering between the server close callback and the client socket's one-shot close event.

## Evidence

- Confirmed failure: https://github.com/openclaw/openclaw/actions/runs/28639846548/job/84933576981 on Ubuntu with Node v24.13.0 (`socket close timed out`).
- Local full file: 95/95 tests passed via `node scripts/run-vitest.mjs test/scripts/openclaw-cross-os-release-checks.test.ts --reporter=verbose`.
- Local stress: 100/100 focused repetitions passed on Node v26.3.0.
- Linux Node v24.13.0 Testbox: full file 95/95 plus 100/100 focused repetitions passed; Crabbox wrapper `exitCode=0`, Testbox `tbx_01kwmse0xrzdpm35tth1gb36gx`, hydration run https://github.com/openclaw/openclaw/actions/runs/28681253566.
- Remote changed gate: `pnpm check:changed` passed; Crabbox wrapper `exitCode=0`, Testbox `tbx_01kwmsndr0x48dq5tweaqv0mj1`, hydration run https://github.com/openclaw/openclaw/actions/runs/28681396353.
- Structured Codex autoreview: no findings; patch correct with 0.99 confidence.
