### PR TITLE
fix(opencode-go): expose DeepSeek V4 max thinking levels

### DIFF
--- a/extensions/opencode-go/index.test.ts
+++ b/extensions/opencode-go/index.test.ts
@@ -1,4 +1,5 @@
 // Opencode Go tests cover index plugin behavior.
+import { clampThinkingLevel } from "openclaw/plugin-sdk/llm";
 import type { ProviderRuntimeModel } from "openclaw/plugin-sdk/plugin-entry";
 import {
   registerProviderPlugin,
@@ -40,6 +41,36 @@ function requireCatalogEntry(entries: readonly unknown[] | null | undefined, id:
     throw new Error(`expected supplemental catalog entry ${id}`);
   }
   return requireRecord(entry, `supplemental catalog entry ${id}`);
+}
+
+const deepSeekV4ThinkingProfileLevelIds = [
+  "off",
+  "minimal",
+  "low",
+  "medium",
+  "high",
+  "xhigh",
+  "max",
+] as const;
+const deepSeekV4ThinkingProfile = {
+  levels: deepSeekV4ThinkingProfileLevelIds.map((id) => ({ id })),
+  defaultLevel: "high",
+};
+const deepSeekV4ThinkingLevelMap = {
+  minimal: "high",
+  low: "high",
+  medium: "high",
+  high: "high",
+  xhigh: "max",
+  max: "max",
+};
+
+function expectDeepSeekV4ThinkingLevels(model: ProviderRuntimeModel) {
+  expect(model.thinkingLevelMap).toEqual(deepSeekV4ThinkingLevelMap);
+  expect(clampThinkingLevel(model, "off")).toBe("off");
+  expect(clampThinkingLevel(model, "high")).toBe("high");
+  expect(clampThinkingLevel(model, "xhigh")).toBe("xhigh");
+  expect(clampThinkingLevel(model, "max")).toBe("max");
 }
 
 describe("opencode-go provider plugin", () => {
@@ -114,6 +145,17 @@ describe("opencode-go provider plugin", () => {
       models.set(model.id, model);
     }
     expect([...models.keys()]).toEqual(expectedModelIds);
+    expectDeepSeekV4ThinkingLevels(requireMapEntry(models, "deepseek-v4-pro"));
+    expectDeepSeekV4ThinkingLevels(requireMapEntry(models, "deepseek-v4-flash"));
+    expect(
+      provider.resolveThinkingProfile?.({ provider: "opencode-go", modelId: "deepseek-v4-pro" }),
+    ).toEqual(deepSeekV4ThinkingProfile);
+    expect(
+      provider.resolveThinkingProfile?.({ provider: "opencode-go", modelId: "deepseek-v4-flash" }),
+    ).toEqual(deepSeekV4ThinkingProfile);
+    expect(
+      provider.resolveThinkingProfile?.({ provider: "opencode-go", modelId: "glm-5" }),
+    ).toBeUndefined();
     const supplemental = await provider.augmentModelCatalog?.({
       entries: [...models.values()].map((model) => ({
         provider: model.provider,
@@ -242,6 +284,19 @@ describe("opencode-go provider plugin", () => {
   it("loads OpenCode Go model discovery through the provider runtime", () => {
     expect(manifest.providerCatalogEntry).toBe("./provider-discovery.ts");
     expect(manifest.modelCatalog.discovery["opencode-go"]).toBe("runtime");
+    const manifestProvider = requireRecord(
+      manifest.modelCatalog.providers["opencode-go"],
+      "manifest provider",
+    );
+    if (!Array.isArray(manifestProvider.models)) {
+      throw new Error("expected manifest models");
+    }
+    expect(
+      requireCatalogEntry(manifestProvider.models, "deepseek-v4-pro").thinkingLevelMap,
+    ).toEqual(deepSeekV4ThinkingLevelMap);
+    expect(
+      requireCatalogEntry(manifestProvider.models, "deepseek-v4-flash").thinkingLevelMap,
+    ).toEqual(deepSeekV4ThinkingLevelMap);
   });
 
   it("exposes the complete offline catalog through provider discovery", async () => {
@@ -250,6 +305,7 @@ describe("opencode-go provider plugin", () => {
       throw new Error("expected OpenCode Go static provider");
     }
     const deepSeekPro = result.provider.models.find((model) => model.id === "deepseek-v4-pro");
+    const deepSeekFlash = result.provider.models.find((model) => model.id === "deepseek-v4-flash");
     const glm52 = result.provider.models.find((model) => model.id === "glm-5.2");
 
     expect(result.provider.models).toHaveLength(18);
@@ -257,6 +313,13 @@ describe("opencode-go provider plugin", () => {
       provider: "opencode-go",
       contextWindow: 1_000_000,
       maxTokens: 384_000,
+      thinkingLevelMap: deepSeekV4ThinkingLevelMap,
+    });
+    expect(deepSeekFlash).toMatchObject({
+      provider: "opencode-go",
+      contextWindow: 1_000_000,
+      maxTokens: 384_000,
+      thinkingLevelMap: deepSeekV4ThinkingLevelMap,
     });
     expect(glm52).toMatchObject({
       provider: "opencode-go",
@@ -386,15 +449,93 @@ describe("opencode-go provider plugin", () => {
     expect(fallback.models.map((model) => model.id)).toContain("minimax-m3");
   });
 
-  it("disables invalid DeepSeek V4 reasoning_effort off payloads on OpenCode Go", async () => {
+  it.each(["deepseek-v4-pro", "deepseek-v4-flash"] as const)(
+    "disables invalid DeepSeek V4 reasoning_effort off payloads on OpenCode Go for %s",
+    async (modelId) => {
+      const provider = await registerSingleProviderPlugin(plugin);
+      const capturedPayloads: Record<string, unknown>[] = [];
+      const baseStreamFn = (_model: unknown, _context: unknown, options: unknown) => {
+        const payload = {
+          model: modelId,
+          reasoning_effort: "off",
+          reasoning: "off",
+        };
+        (options as { onPayload?: (payload: Record<string, unknown>) => void })?.onPayload?.(
+          payload,
+        );
+        capturedPayloads.push(payload);
+        return {} as never;
+      };
+
+      const streamFn = provider.wrapStreamFn?.({
+        streamFn: baseStreamFn as never,
+        providerId: "opencode-go",
+        modelId,
+        thinkingLevel: "off",
+      } as never);
+
+      expect(streamFn).toBeTypeOf("function");
+      await streamFn?.({ provider: "opencode-go", id: modelId } as never, {} as never, {});
+
+      expect(capturedPayloads).toEqual([
+        {
+          model: modelId,
+          thinking: { type: "disabled" },
+        },
+      ]);
+    },
+  );
+
+  it.each([
+    ["minimal", "high"],
+    ["low", "high"],
+    ["medium", "high"],
+    ["high", "high"],
+    ["xhigh", "max"],
+    ["max", "max"],
+  ] as const)(
+    "maps OpenCode Go DeepSeek V4 %s thinking to %s reasoning effort",
+    async (thinkingLevel, reasoningEffort) => {
+      const provider = await registerSingleProviderPlugin(plugin);
+      const capturedPayloads: Record<string, unknown>[] = [];
+      const baseStreamFn = (_model: unknown, _context: unknown, options: unknown) => {
+        const payload = { model: "deepseek-v4-flash" };
+        (options as { onPayload?: (payload: Record<string, unknown>) => void })?.onPayload?.(
+          payload,
+        );
+        capturedPayloads.push(payload);
+        return {} as never;
+      };
+
+      const streamFn = provider.wrapStreamFn?.({
+        streamFn: baseStreamFn as never,
+        providerId: "opencode-go",
+        modelId: "deepseek-v4-flash",
+        thinkingLevel,
+      } as never);
+
+      expect(streamFn).toBeTypeOf("function");
+      await streamFn?.(
+        { provider: "opencode-go", id: "deepseek-v4-flash" } as never,
+        {} as never,
+        {},
+      );
+
+      expect(capturedPayloads).toEqual([
+        {
+          model: "deepseek-v4-flash",
+          thinking: { type: "enabled" },
+          reasoning_effort: reasoningEffort,
+        },
+      ]);
+    },
+  );
+
+  it("does not apply DeepSeek V4 thinking payloads to unrelated OpenCode Go models", async () => {
     const provider = await registerSingleProviderPlugin(plugin);
     const capturedPayloads: Record<string, unknown>[] = [];
     const baseStreamFn = (_model: unknown, _context: unknown, options: unknown) => {
-      const payload = {
-        model: "deepseek-v4-flash",
-        reasoning_effort: "off",
-        reasoning: "off",
-      };
+      const payload = { model: "glm-5", reasoning_effort: "max" };
       (options as { onPayload?: (payload: Record<string, unknown>) => void })?.onPayload?.(payload);
       capturedPayloads.push(payload);
       return {} as never;
@@ -403,23 +544,14 @@ describe("opencode-go provider plugin", () => {
     const streamFn = provider.wrapStreamFn?.({
       streamFn: baseStreamFn as never,
       providerId: "opencode-go",
-      modelId: "deepseek-v4-flash",
-      thinkingLevel: "off",
+      modelId: "glm-5",
+      thinkingLevel: "max",
     } as never);
 
     expect(streamFn).toBeTypeOf("function");
-    await streamFn?.(
-      { provider: "opencode-go", id: "deepseek-v4-flash" } as never,
-      {} as never,
-      {},
-    );
+    await streamFn?.({ provider: "opencode-go", id: "glm-5" } as never, {} as never, {});
 
-    expect(capturedPayloads).toEqual([
-      {
-        model: "deepseek-v4-flash",
-        thinking: { type: "disabled" },
-      },
-    ]);
+    expect(capturedPayloads).toEqual([{ model: "glm-5", reasoning_effort: "max" }]);
   });
 
   it("strips unsupported Kimi reasoning payloads on OpenCode Go", async () => {

--- a/extensions/opencode-go/index.ts
+++ b/extensions/opencode-go/index.ts
@@ -12,6 +12,7 @@ import {
   normalizeOpencodeGoResolvedModel,
   resolveOpencodeGoModel,
 } from "./provider-catalog.js";
+import { resolveThinkingProfile } from "./provider-policy-api.js";
 import { createOpencodeGoWrapper } from "./stream.js";
 
 const PROVIDER_ID = "opencode-go";
@@ -136,6 +137,7 @@ export default definePluginEntry({
       },
       augmentModelCatalog: () => listOpencodeGoModelCatalogEntries(),
       ...buildProviderReplayFamilyHooks({ family: "passthrough-gemini" }),
+      resolveThinkingProfile,
       wrapStreamFn: (ctx) => createOpencodeGoWrapper(ctx.streamFn, ctx.thinkingLevel),
       isModernModelRef: () => true,
     });

--- a/extensions/opencode-go/openclaw.plugin.json
+++ b/extensions/opencode-go/openclaw.plugin.json
@@ -30,6 +30,14 @@
             "id": "deepseek-v4-pro",
             "name": "DeepSeek V4 Pro",
             "reasoning": true,
+            "thinkingLevelMap": {
+              "minimal": "high",
+              "low": "high",
+              "medium": "high",
+              "high": "high",
+              "xhigh": "max",
+              "max": "max"
+            },
             "input": ["text"],
             "contextWindow": 1000000,
             "maxTokens": 384000,
@@ -49,6 +57,14 @@
             "id": "deepseek-v4-flash",
             "name": "DeepSeek V4 Flash",
             "reasoning": true,
+            "thinkingLevelMap": {
+              "minimal": "high",
+              "low": "high",
+              "medium": "high",
+              "high": "high",
+              "xhigh": "max",
+              "max": "max"
+            },
             "input": ["text"],
             "contextWindow": 1000000,
             "maxTokens": 384000,

--- a/extensions/opencode-go/provider-catalog.ts
+++ b/extensions/opencode-go/provider-catalog.ts
@@ -23,6 +23,16 @@ const OPENCODE_GO_KIMI_NO_REASONING_MODEL_IDS = new Set([
 const OPENCODE_GO_MODELS_ENDPOINT = "https://opencode.ai/zen/go/v1/models";
 const OPENCODE_GO_MODELS_TIMEOUT_MS = 5_000;
 const OPENCODE_GO_MODELS_CACHE_TTL_MS = 60_000;
+// OpenCode Go exposes only high/max provider effort for DeepSeek V4. Lower
+// OpenClaw levels retain their existing high-effort behavior.
+const OPENCODE_GO_DEEPSEEK_V4_THINKING_LEVEL_MAP = {
+  minimal: "high",
+  low: "high",
+  medium: "high",
+  high: "high",
+  xhigh: "max",
+  max: "max",
+} as const;
 
 type OpencodeGoModelDefinition = ModelDefinitionConfig & {
   provider: typeof PROVIDER_ID;
@@ -40,6 +50,7 @@ const OPENCODE_GO_MODELS = (
       provider: PROVIDER_ID,
       baseUrl: OPENCODE_GO_OPENAI_BASE_URL,
       reasoning: true,
+      thinkingLevelMap: OPENCODE_GO_DEEPSEEK_V4_THINKING_LEVEL_MAP,
       input: ["text"],
       cost: {
         input: 1.74,
@@ -62,6 +73,7 @@ const OPENCODE_GO_MODELS = (
       provider: PROVIDER_ID,
       baseUrl: OPENCODE_GO_OPENAI_BASE_URL,
       reasoning: true,
+      thinkingLevelMap: OPENCODE_GO_DEEPSEEK_V4_THINKING_LEVEL_MAP,
       input: ["text"],
       cost: {
         input: 0.14,

--- a/extensions/opencode-go/provider-policy-api.ts
+++ b/extensions/opencode-go/provider-policy-api.ts
@@ -1,0 +1,43 @@
+// OpenCode Go policy module exposes thinking controls before runtime registration.
+import type {
+  ProviderDefaultThinkingPolicyContext,
+  ProviderThinkingProfile,
+} from "openclaw/plugin-sdk/plugin-entry";
+
+const OPENCODE_GO_DEEPSEEK_V4_MODEL_IDS = new Set(["deepseek-v4-flash", "deepseek-v4-pro"]);
+const OPENCODE_GO_DEEPSEEK_V4_THINKING_LEVEL_IDS = [
+  "off",
+  "minimal",
+  "low",
+  "medium",
+  "high",
+  "xhigh",
+  "max",
+] as const;
+const OPENCODE_GO_DEEPSEEK_V4_THINKING_PROFILE = {
+  levels: OPENCODE_GO_DEEPSEEK_V4_THINKING_LEVEL_IDS.map((id) => ({ id })),
+  defaultLevel: "high",
+} satisfies ProviderThinkingProfile;
+
+export function isOpencodeGoDeepSeekV4ModelId(modelId: unknown): boolean {
+  return (
+    typeof modelId === "string" &&
+    OPENCODE_GO_DEEPSEEK_V4_MODEL_IDS.has(modelId.trim().toLowerCase())
+  );
+}
+
+export function resolveOpencodeGoThinkingProfile(
+  modelId: string,
+): ProviderThinkingProfile | undefined {
+  return isOpencodeGoDeepSeekV4ModelId(modelId)
+    ? OPENCODE_GO_DEEPSEEK_V4_THINKING_PROFILE
+    : undefined;
+}
+
+export function resolveThinkingProfile(
+  context: ProviderDefaultThinkingPolicyContext,
+): ProviderThinkingProfile | undefined {
+  return context.provider.trim().toLowerCase() === "opencode-go"
+    ? resolveOpencodeGoThinkingProfile(context.modelId)
+    : undefined;
+}

--- a/extensions/opencode-go/stream.ts
+++ b/extensions/opencode-go/stream.ts
@@ -5,16 +5,13 @@ import {
   streamWithPayloadPatch,
 } from "openclaw/plugin-sdk/provider-stream-shared";
 import { isOpencodeGoKimiNoReasoningModelId } from "./provider-catalog.js";
+import { isOpencodeGoDeepSeekV4ModelId } from "./provider-policy-api.js";
 import { stripOpencodeGoKimiReasoningPayload } from "./reasoning-sanitizer.js";
 import {
   createOpencodeGoStalledStreamWrapper,
   OPENCODE_GO_STREAM_FIRST_EVENT_TIMEOUT_MS_DEFAULT,
   OPENCODE_GO_STREAM_IDLE_TIMEOUT_MS_DEFAULT,
 } from "./stream-termination.js";
-
-function isOpencodeGoDeepSeekV4ModelId(modelId: unknown): boolean {
-  return modelId === "deepseek-v4-flash" || modelId === "deepseek-v4-pro";
-}
 
 function createOpencodeGoDeepSeekV4Wrapper(
   baseStreamFn: ProviderWrapStreamFnContext["streamFn"],

--- a/src/plugins/provider-public-artifacts.test.ts
+++ b/src/plugins/provider-public-artifacts.test.ts
@@ -150,6 +150,31 @@ describe("provider public artifacts", () => {
     });
   });
 
+  it("loads OpenCode Go DeepSeek V4 thinking policy before runtime registration", () => {
+    const surface = resolveBundledProviderPolicySurface("opencode-go");
+
+    expect(
+      surface?.resolveThinkingProfile?.({
+        provider: "opencode-go",
+        modelId: "deepseek-v4-pro",
+      }),
+    ).toEqual({
+      levels: [
+        { id: "off" },
+        { id: "minimal" },
+        { id: "low" },
+        { id: "medium" },
+        { id: "high" },
+        { id: "xhigh" },
+        { id: "max" },
+      ],
+      defaultLevel: "high",
+    });
+    expect(
+      surface?.resolveThinkingProfile?.({ provider: "opencode-go", modelId: "glm-5" }),
+    ).toBeUndefined();
+  });
+
   it("loads trusted official external provider policy before runtime registration", () => {
     const bundledPluginsDir = fs.mkdtempSync(
       path.join(os.tmpdir(), "openclaw-empty-bundled-plugins-"),


### PR DESCRIPTION
## What Problem This Solves

Fixes #99601.

OpenCode Go's `deepseek-v4-pro` and `deepseek-v4-flash` accept provider effort `max`, but their OpenClaw catalog rows did not advertise `xhigh` or `max`. `/think max` was therefore clamped to `high` before the request reached the provider. The plugin also activates on demand, so cold `/think` and Gateway projection paths need the same provider-owned profile before runtime registration.

## Why This Change Was Made

- Adds the DeepSeek V4 thinking map to both OpenCode Go catalog sources.
- Adds a lightweight provider-policy artifact and reuses its model-family predicate from runtime registration and stream wrapping.
- Preserves shipped lower-level behavior: `minimal`, `low`, `medium`, and `high` continue to send provider effort `high`; only `xhigh` and `max` send provider effort `max`.
- Keeps `off` on the existing DeepSeek-specific disabled-thinking payload path.

This is intentionally narrower than changing lower-level quality, latency, or cost behavior.

## User Impact

OpenCode Go DeepSeek V4 users can select `xhigh` and `max` without silent downgrade. Cold Gateway/model-control projections expose the complete OpenClaw level set before the runtime plugin activates. Other OpenCode Go models are unchanged.

## Evidence

Exact head: `34391f75de7934e9600531d4a02f303f09aa93f8`

- `node scripts/run-vitest.mjs extensions/opencode-go/index.test.ts src/plugins/provider-public-artifacts.test.ts` — 35 tests passed.
- Gateway pre-activation projection for `opencode-go/deepseek-v4-pro` returned `thinkingDefault: max` and levels `off, minimal, low, medium, high, xhigh, max` before runtime registration.
- Live OpenCode Go `deepseek-v4-flash` requests returned HTTP 200 with reasoning output for provider efforts `high`, `max`, `low`, and `medium`. The branch deliberately retains lower OpenClaw levels at provider `high` to avoid a separate compatibility change.
- Blacksmith Testbox changed-file gate passed on the patch-identical pre-rebase tree: https://github.com/openclaw/openclaw/actions/runs/29811726070
- Final AutoReview reported no accepted/actionable findings.

## Compatibility / Decision

This adds provider capability and pre-activation policy surface, so it requires maintainer product/provider acceptance before merge. No config key, dependency, protocol, credential handling, or generic thinking policy changes.

Co-authored-by: 杨浩宇0668001029 <yang.haoyu@xydigit.com>
