### PR TITLE
fix(channels): retain failed ingress payloads

### DIFF
--- a/src/channels/message/ingress-queue.test.ts
+++ b/src/channels/message/ingress-queue.test.ts
@@ -477,6 +477,50 @@ describe("channel ingress queue", () => {
     });
   });
 
+  it("omits payload for old failed tombstones with cleared payload storage", async () => {
+    await withTempState(async (stateDir) => {
+      const queue = createChannelIngressQueue<{ text: string }>({
+        channelId: "test",
+        accountId: "account",
+        stateDir,
+        now: () => 10,
+      });
+
+      await queue.enqueue("old-failed", { text: "old payload" });
+      const claimed = await queue.claim("old-failed", { ownerId: "worker" });
+      if (!claimed) {
+        throw new Error("Expected a claimed ingress event");
+      }
+      await queue.fail(claimed, { reason: "poison", message: "bad", failedAt: 20 });
+
+      const database = openOpenClawStateDatabase({
+        env: createStateDirEnv(stateDir),
+      });
+      const kysely = getNodeSqliteKysely<ChannelIngressTestDatabase>(database.db);
+      executeSqliteQuerySync(
+        database.db,
+        kysely
+          .updateTable("channel_ingress_events")
+          .set({ payload_json: "null" })
+          .where("event_id", "=", "old-failed"),
+      );
+
+      expect(await queue.enqueue("old-failed", { text: "new payload" })).toEqual({
+        kind: "failed",
+        duplicate: true,
+        record: {
+          id: "old-failed",
+          channelId: "test",
+          accountId: "account",
+          queueName: JSON.stringify(["test", "account"]),
+          failedAt: 20,
+          reason: "poison",
+          message: "bad",
+        },
+      });
+    });
+  });
+
   it("recovers stale claims and prunes completed or failed rows", async () => {
     await withTempState(async (stateDir) => {
       const queue = createChannelIngressQueue<{ text: string }>({

--- a/src/channels/message/ingress-queue.test.ts
+++ b/src/channels/message/ingress-queue.test.ts
@@ -506,6 +506,17 @@ describe("channel ingress queue", () => {
 
       await queue.complete("old", { completedAt: 25 });
       await queue.fail(keep, { reason: "poison", message: "bad", failedAt: 25 });
+      const duplicateFailed = await queue.enqueue("keep", { text: "new poison" });
+      expect(duplicateFailed).toMatchObject({
+        kind: "failed",
+        duplicate: true,
+        record: {
+          id: "keep",
+          payload: { text: "keep" },
+          reason: "poison",
+          message: "bad",
+        },
+      });
       await queue.enqueue("retry", { text: "retry" });
       await queue.release("retry", { lastError: "stale retry text", releasedAt: 26 });
       await queue.complete("retry", { completedAt: 27 });
@@ -528,7 +539,7 @@ describe("channel ingress queue", () => {
           last_attempt_at: null,
           last_error: "bad",
           metadata_json: null,
-          payload_json: "null",
+          payload_json: JSON.stringify({ text: "keep" }),
         },
         {
           event_id: "old",

--- a/src/channels/message/ingress-queue.ts
+++ b/src/channels/message/ingress-queue.ts
@@ -67,7 +67,7 @@ export type ChannelIngressQueueCompletedRecord<TCompletedMetadata = unknown> = {
 };
 
 /** Failed ingress event tombstone retained for duplicate detection and diagnostics. */
-export type ChannelIngressQueueFailedRecord = {
+export type ChannelIngressQueueFailedRecord<TPayload = unknown> = {
   id: string;
   channelId: string;
   accountId: string;
@@ -75,6 +75,7 @@ export type ChannelIngressQueueFailedRecord = {
   failedAt: number;
   reason: string;
   message?: string;
+  payload?: TPayload;
 };
 
 /** Retention options for pending, completed, and failed ingress queue rows. */
@@ -114,7 +115,7 @@ export type ChannelIngressQueueEnqueueResult<TPayload, TMetadata, TCompletedMeta
   | {
       kind: "failed";
       duplicate: true;
-      record: ChannelIngressQueueFailedRecord;
+      record: ChannelIngressQueueFailedRecord<TPayload>;
     };
 
 /** Durable FIFO-ish ingress queue with claims, duplicate detection, and retention pruning. */
@@ -269,7 +270,7 @@ function completedRecord<TCompletedMetadata>(
   };
 }
 
-function failedRecord(row: ChannelIngressRow): ChannelIngressQueueFailedRecord {
+function failedRecord<TPayload>(row: ChannelIngressRow): ChannelIngressQueueFailedRecord<TPayload> {
   return {
     id: row.event_id,
     channelId: row.channel_id,
@@ -278,6 +279,7 @@ function failedRecord(row: ChannelIngressRow): ChannelIngressQueueFailedRecord {
     failedAt: row.failed_at ?? row.updated_at,
     reason: row.failed_reason ?? "failed",
     ...(row.last_error === null ? {} : { message: row.last_error }),
+    ...(row.payload_json === null ? {} : { payload: parseJson(row.payload_json) as TPayload }),
   };
 }
 
@@ -314,7 +316,7 @@ function rowToEnqueueResult<TPayload, TMetadata, TCompletedMetadata>(
     return { kind: "completed", duplicate: true, record: completedRecord(row) };
   }
   if (row.status === "failed") {
-    return { kind: "failed", duplicate: true, record: failedRecord(row) };
+    return { kind: "failed", duplicate: true, record: failedRecord<TPayload>(row) };
   }
   if (row.status === "claimed") {
     return { kind: "claimed", duplicate: true, record: claimedRecord(row) };
@@ -806,7 +808,6 @@ export function createChannelIngressQueue<
             failed_at: failedAt,
             failed_reason: failOptions.reason,
             last_error: failOptions.message ?? null,
-            payload_json: "null",
             metadata_json: null,
             claim_token: null,
             claim_owner: null,

--- a/src/channels/message/ingress-queue.ts
+++ b/src/channels/message/ingress-queue.ts
@@ -271,6 +271,7 @@ function completedRecord<TCompletedMetadata>(
 }
 
 function failedRecord<TPayload>(row: ChannelIngressRow): ChannelIngressQueueFailedRecord<TPayload> {
+  const payload = parseJson(row.payload_json);
   return {
     id: row.event_id,
     channelId: row.channel_id,
@@ -279,7 +280,7 @@ function failedRecord<TPayload>(row: ChannelIngressRow): ChannelIngressQueueFail
     failedAt: row.failed_at ?? row.updated_at,
     reason: row.failed_reason ?? "failed",
     ...(row.last_error === null ? {} : { message: row.last_error }),
-    ...(row.payload_json === null ? {} : { payload: parseJson(row.payload_json) as TPayload }),
+    ...(payload === null ? {} : { payload: payload as TPayload }),
   };
 }
 


### PR DESCRIPTION
## What Problem This Solves

Failed ingress-queue tasks could lose the original payload when they were serialised for failure/dead-letter handling. For Telegram/forum-topic ingress, that makes some missed updates unrecoverable: the system can see that work failed, but no longer has the original update needed to inspect, replay, or recover the prompt.

## Summary

- keep the original ingress queue payload available when a queued message fails
- preserve recoverability for dead-lettered Telegram/forum-topic updates
- keep old failed tombstones that stored `payload_json` as literal JSON `null` plugin-visible without `payload: null`
- add regression coverage for failed task serialisation and old failed tombstones

## Evidence

- `src/channels/message/ingress-queue.test.ts` adds coverage that a failed task keeps the original payload while recording the failure.
- `src/channels/message/ingress-queue.test.ts` adds coverage that old failed tombstones with cleared payload storage omit `payload` instead of exposing `payload: null`.
- After-fix focused test: `node scripts/run-vitest.mjs src/channels/message/ingress-queue.test.ts` -> 1 file passed, 17 tests passed.
- After-fix redacted runtime smoke with a Telegram/forum-topic-shaped ingress payload recovered the original failed payload on duplicate enqueue:

```json
{
  "kind": "failed",
  "duplicate": true,
  "reason": "handler-error",
  "recoveredText": "redacted prompt",
  "forumTopicId": "redacted-topic"
}
```

- PR diff is current on `main`, touching only `src/channels/message/ingress-queue.ts` and `src/channels/message/ingress-queue.test.ts`.
