### PR TITLE
Fix Slack retry for session init conflicts

### DIFF
--- a/extensions/slack/src/monitor/message-handler.test.ts
+++ b/extensions/slack/src/monitor/message-handler.test.ts
@@ -6,6 +6,7 @@ const flushKeyMock = vi.fn(async (_key: string) => {});
 const onFlushCallbacks: Array<(entries: Array<Record<string, unknown>>) => Promise<void>> = [];
 const prepareSlackMessageMock = vi.fn(async () => ({ ctxPayload: {} }));
 const dispatchPreparedSlackMessageMock = vi.fn(async () => {});
+const hasSlackInboundMessageDeliveryMock = vi.fn(async () => false);
 const recordSlackInboundMessageDeliveriesMock = vi.fn(async () => {});
 const resolveThreadTsMock = vi.fn(async ({ message }: { message: Record<string, unknown> }) => ({
   ...message,
@@ -46,7 +47,7 @@ vi.mock("./message-handler/pipeline.runtime.js", () => ({
 }));
 
 vi.mock("./inbound-delivery-state.js", () => ({
-  hasSlackInboundMessageDelivery: vi.fn(async () => false),
+  hasSlackInboundMessageDelivery: hasSlackInboundMessageDeliveryMock,
   recordSlackInboundMessageDeliveries: recordSlackInboundMessageDeliveriesMock,
 }));
 
@@ -102,6 +103,8 @@ describe("createSlackMessageHandler", () => {
     onFlushCallbacks.length = 0;
     prepareSlackMessageMock.mockClear();
     dispatchPreparedSlackMessageMock.mockClear();
+    hasSlackInboundMessageDeliveryMock.mockReset();
+    hasSlackInboundMessageDeliveryMock.mockResolvedValue(false);
     recordSlackInboundMessageDeliveriesMock.mockClear();
     resolveThreadTsMock.mockClear();
   });
@@ -273,7 +276,49 @@ describe("createSlackMessageHandler", () => {
     await Promise.all([handledFailure, flushFailure]);
   });
 
-  it("does not persist delivery for retryable reply session initialization conflicts", async () => {
+  it("retries native session initialization conflicts through the delivery gates", async () => {
+    const releaseSeenMessage = vi.fn();
+    dispatchPreparedSlackMessageMock.mockRejectedValueOnce(
+      new Error("Slack dispatch failed", {
+        cause: new Error(
+          "reply session initialization conflicted for agent:main:main:thread:123.456",
+        ),
+      }),
+    );
+    const { handler } = createHandlerWithTracker({ releaseSeenMessage });
+    await handler(
+      {
+        type: "message",
+        channel: "C111",
+        user: "U111",
+        ts: "1709000000.000700",
+        text: "native message",
+      } as never,
+      { source: "message" },
+    );
+
+    const entry = enqueueMock.mock.calls[0]?.[0] as Record<string, unknown>;
+    vi.useFakeTimers();
+    try {
+      await expect(onFlushCallbacks[0]?.([entry])).rejects.toThrow("Slack dispatch failed");
+      await vi.advanceTimersByTimeAsync(1000);
+
+      expect(releaseSeenMessage).toHaveBeenCalledWith("C111", "1709000000.000700");
+      expect(recordSlackInboundMessageDeliveriesMock).not.toHaveBeenCalled();
+      expect(hasSlackInboundMessageDeliveryMock).toHaveBeenCalledTimes(2);
+      expect(enqueueMock).toHaveBeenCalledTimes(2);
+      expect(enqueueMock.mock.calls[1]?.[0]).toMatchObject({
+        opts: {
+          retryAttempt: 1,
+        },
+      });
+      expect(enqueueMock.mock.calls[1]?.[0]).not.toHaveProperty("opts.dispatchCompletion");
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("leaves relay session conflict retries to unacknowledged redelivery", async () => {
     const releaseSeenMessage = vi.fn();
     dispatchPreparedSlackMessageMock.mockRejectedValueOnce(
       new Error("Slack dispatch failed", {
@@ -288,7 +333,7 @@ describe("createSlackMessageHandler", () => {
         type: "message",
         channel: "C111",
         user: "U111",
-        ts: "1709000000.000700",
+        ts: "1709000000.000800",
         text: "relay message",
       } as never,
       { source: "message", awaitDispatch: true },
@@ -305,15 +350,61 @@ describe("createSlackMessageHandler", () => {
       await Promise.all([handledFailure, flushFailure]);
       await vi.advanceTimersByTimeAsync(1000);
 
-      expect(releaseSeenMessage).toHaveBeenCalledWith("C111", "1709000000.000700");
+      expect(releaseSeenMessage).toHaveBeenCalledWith("C111", "1709000000.000800");
       expect(recordSlackInboundMessageDeliveriesMock).not.toHaveBeenCalled();
-      expect(enqueueMock).toHaveBeenCalledTimes(2);
-      expect(enqueueMock.mock.calls[1]?.[0]).toMatchObject({
-        opts: {
-          dispatchCompletion: undefined,
-          retryAttempt: 1,
-        },
-      });
+      expect(enqueueMock).toHaveBeenCalledTimes(1);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("settles an already-delivered relay event without enqueueing", async () => {
+    hasSlackInboundMessageDeliveryMock.mockResolvedValueOnce(true);
+    const { handler } = createHandlerWithTracker();
+
+    await expect(
+      handler(
+        {
+          type: "message",
+          channel: "C111",
+          user: "U111",
+          ts: "1709000000.000850",
+          text: "relay replay",
+        } as never,
+        { source: "message", awaitDispatch: true },
+      ),
+    ).resolves.toBeUndefined();
+
+    expect(enqueueMock).not.toHaveBeenCalled();
+  });
+
+  it("skips a native retry when another delivery already succeeded", async () => {
+    dispatchPreparedSlackMessageMock.mockRejectedValueOnce(
+      new Error("reply session initialization conflicted for agent:main:main:thread:123.456"),
+    );
+    hasSlackInboundMessageDeliveryMock.mockResolvedValueOnce(false).mockResolvedValueOnce(true);
+    const { handler } = createHandlerWithTracker();
+    await handler(
+      {
+        type: "message",
+        channel: "C111",
+        user: "U111",
+        ts: "1709000000.000900",
+        text: "native message",
+      } as never,
+      { source: "message" },
+    );
+
+    const entry = enqueueMock.mock.calls[0]?.[0] as Record<string, unknown>;
+    vi.useFakeTimers();
+    try {
+      await expect(onFlushCallbacks[0]?.([entry])).rejects.toThrow(
+        "reply session initialization conflicted",
+      );
+      await vi.advanceTimersByTimeAsync(1000);
+
+      expect(hasSlackInboundMessageDeliveryMock).toHaveBeenCalledTimes(2);
+      expect(enqueueMock).toHaveBeenCalledTimes(1);
     } finally {
       vi.useRealTimers();
     }

--- a/extensions/slack/src/monitor/message-handler.test.ts
+++ b/extensions/slack/src/monitor/message-handler.test.ts
@@ -6,6 +6,7 @@ const flushKeyMock = vi.fn(async (_key: string) => {});
 const onFlushCallbacks: Array<(entries: Array<Record<string, unknown>>) => Promise<void>> = [];
 const prepareSlackMessageMock = vi.fn(async () => ({ ctxPayload: {} }));
 const dispatchPreparedSlackMessageMock = vi.fn(async () => {});
+const recordSlackInboundMessageDeliveriesMock = vi.fn(async () => {});
 const resolveThreadTsMock = vi.fn(async ({ message }: { message: Record<string, unknown> }) => ({
   ...message,
 }));
@@ -46,7 +47,7 @@ vi.mock("./message-handler/pipeline.runtime.js", () => ({
 
 vi.mock("./inbound-delivery-state.js", () => ({
   hasSlackInboundMessageDelivery: vi.fn(async () => false),
-  recordSlackInboundMessageDeliveries: vi.fn(async () => {}),
+  recordSlackInboundMessageDeliveries: recordSlackInboundMessageDeliveriesMock,
 }));
 
 function createContext(overrides?: {
@@ -101,6 +102,7 @@ describe("createSlackMessageHandler", () => {
     onFlushCallbacks.length = 0;
     prepareSlackMessageMock.mockClear();
     dispatchPreparedSlackMessageMock.mockClear();
+    recordSlackInboundMessageDeliveriesMock.mockClear();
     resolveThreadTsMock.mockClear();
   });
 
@@ -269,5 +271,51 @@ describe("createSlackMessageHandler", () => {
     const handledFailure = expect(handled).rejects.toThrow("dispatch failed");
     const flushFailure = expect(onFlushCallbacks[0]?.([entry])).rejects.toThrow("dispatch failed");
     await Promise.all([handledFailure, flushFailure]);
+  });
+
+  it("does not persist delivery for retryable reply session initialization conflicts", async () => {
+    const releaseSeenMessage = vi.fn();
+    dispatchPreparedSlackMessageMock.mockRejectedValueOnce(
+      new Error("Slack dispatch failed", {
+        cause: new Error(
+          "reply session initialization conflicted for agent:main:main:thread:123.456",
+        ),
+      }),
+    );
+    const { handler } = createHandlerWithTracker({ releaseSeenMessage });
+    const handled = handler(
+      {
+        type: "message",
+        channel: "C111",
+        user: "U111",
+        ts: "1709000000.000700",
+        text: "relay message",
+      } as never,
+      { source: "message", awaitDispatch: true },
+    );
+
+    await vi.waitFor(() => expect(enqueueMock).toHaveBeenCalledTimes(1));
+    const entry = enqueueMock.mock.calls[0]?.[0] as Record<string, unknown>;
+    vi.useFakeTimers();
+    try {
+      const handledFailure = expect(handled).rejects.toThrow("Slack dispatch failed");
+      const flushFailure = expect(onFlushCallbacks[0]?.([entry])).rejects.toThrow(
+        "Slack dispatch failed",
+      );
+      await Promise.all([handledFailure, flushFailure]);
+      await vi.advanceTimersByTimeAsync(1000);
+
+      expect(releaseSeenMessage).toHaveBeenCalledWith("C111", "1709000000.000700");
+      expect(recordSlackInboundMessageDeliveriesMock).not.toHaveBeenCalled();
+      expect(enqueueMock).toHaveBeenCalledTimes(2);
+      expect(enqueueMock.mock.calls[1]?.[0]).toMatchObject({
+        opts: {
+          dispatchCompletion: undefined,
+          retryAttempt: 1,
+        },
+      });
+    } finally {
+      vi.useRealTimers();
+    }
   });
 });

--- a/extensions/slack/src/monitor/message-handler.ts
+++ b/extensions/slack/src/monitor/message-handler.ts
@@ -338,7 +338,7 @@ export function createSlackMessageHandler(params: {
     opts: IngressSlackMessageOptions,
   ): Promise<SlackDispatchCompletion | undefined> {
     if (opts.source === "message" && message.type !== "message") {
-      return;
+      return undefined;
     }
     if (
       opts.source === "message" &&
@@ -347,7 +347,7 @@ export function createSlackMessageHandler(params: {
       message.subtype !== "bot_message" &&
       message.subtype !== "thread_broadcast"
     ) {
-      return;
+      return undefined;
     }
     const seenMessageKey = buildSeenMessageKey(message.channel, message.ts);
     if (
@@ -358,7 +358,7 @@ export function createSlackMessageHandler(params: {
         ts: message.ts,
       }))
     ) {
-      return;
+      return undefined;
     }
     const wasSeen = seenMessageKey ? ctx.markMessageSeen(message.channel, message.ts) : false;
     if (seenMessageKey && opts.source === "message" && !wasSeen) {
@@ -370,7 +370,7 @@ export function createSlackMessageHandler(params: {
       // Allow exactly one app_mention retry if the same ts was previously dropped
       // from the message stream before it reached dispatch.
       if (opts.source !== "app_mention" || !consumeAppMentionRetryKey(seenMessageKey)) {
-        return;
+        return undefined;
       }
     }
     trackEvent?.();

--- a/extensions/slack/src/monitor/message-handler.ts
+++ b/extensions/slack/src/monitor/message-handler.ts
@@ -45,9 +45,12 @@ type SlackDispatchCompletion = {
   reject: (error: unknown) => void;
 };
 
-type QueuedSlackMessageOptions = Parameters<SlackMessageHandler>[1] & {
-  dispatchCompletion?: Omit<SlackDispatchCompletion, "promise">;
+type IngressSlackMessageOptions = Parameters<SlackMessageHandler>[1] & {
   retryAttempt?: number;
+};
+
+type QueuedSlackMessageOptions = IngressSlackMessageOptions & {
+  dispatchCompletion?: Omit<SlackDispatchCompletion, "promise">;
 };
 
 function createSlackDispatchCompletion(): SlackDispatchCompletion {
@@ -115,21 +118,25 @@ export function createSlackMessageHandler(params: {
     shouldDebounce: (entry) => shouldDebounceSlackMessage(entry.message, ctx.cfg),
     onFlush: async (entries) => {
       const retryEntries = (sourceError: unknown): boolean => {
-        const retryable = isRetryableSlackInboundError(sourceError);
-        if (!retryable) {
+        if (!isRetryableSlackInboundError(sourceError)) {
           return false;
         }
         const nextEntries = entries
           .map((entry) => {
+            // Relay delivery owns retry until its dispatch completion is acknowledged.
+            // Scheduling here as well can race the router redelivery and duplicate a reply.
+            if (entry.opts.dispatchCompletion) {
+              return null;
+            }
             const retryAttempt = entry.opts.retryAttempt ?? 0;
             if (retryAttempt >= RETRYABLE_FLUSH_MAX_ATTEMPTS) {
               return null;
             }
+            const { dispatchCompletion: _dispatchCompletion, ...retryOpts } = entry.opts;
             return {
               ...entry,
               opts: {
-                ...entry.opts,
-                dispatchCompletion: undefined,
+                ...retryOpts,
                 retryAttempt: retryAttempt + 1,
               },
             };
@@ -138,13 +145,16 @@ export function createSlackMessageHandler(params: {
         if (nextEntries.length === 0) {
           return false;
         }
-        setTimeout(() => {
+        const retryTimer = setTimeout(() => {
           for (const entry of nextEntries) {
-            void debouncer.enqueue(entry).catch((err: unknown) => {
+            // Re-enter ingress so a relay replay or another successful attempt wins
+            // through the normal delivery and seen-message gates before dispatch.
+            void enqueueSlackMessage(entry.message, entry.opts).catch((err: unknown) => {
               ctx.runtime.error?.(`slack inbound retry enqueue failed: ${formatErrorMessage(err)}`);
             });
           }
         }, RETRYABLE_FLUSH_RETRY_DELAY_MS);
+        retryTimer.unref?.();
         return true;
       };
       const completions = entries
@@ -243,10 +253,15 @@ export function createSlackMessageHandler(params: {
             }
           } catch (error) {
             if (isRetryableSlackInboundError(error)) {
-              if (seenMessageKey) {
-                appMentionDispatchedKeys.delete(seenMessageKey);
+              // Every buffered event passed the seen gate before this combined dispatch.
+              // Release all of them so the retry can rebuild the same batch.
+              for (const entry of entries) {
+                const entrySeenKey = buildSeenMessageKey(entry.message.channel, entry.message.ts);
+                if (entrySeenKey) {
+                  appMentionDispatchedKeys.delete(entrySeenKey);
+                }
+                ctx.releaseSeenMessage(entry.message.channel, entry.message.ts);
               }
-              ctx.releaseSeenMessage(last.message.channel, last.message.ts);
             }
             throw error;
           }
@@ -318,7 +333,10 @@ export function createSlackMessageHandler(params: {
     return true;
   };
 
-  return async (message, opts) => {
+  async function enqueueSlackMessage(
+    message: SlackMessageEvent,
+    opts: IngressSlackMessageOptions,
+  ): Promise<SlackDispatchCompletion | undefined> {
     if (opts.source === "message" && message.type !== "message") {
       return;
     }
@@ -389,6 +407,11 @@ export function createSlackMessageHandler(params: {
           : {}),
       },
     });
+    return dispatchCompletion;
+  }
+
+  return async (message, opts) => {
+    const dispatchCompletion = await enqueueSlackMessage(message, opts);
     await dispatchCompletion?.promise;
   };
 }

--- a/extensions/slack/src/monitor/message-handler.ts
+++ b/extensions/slack/src/monitor/message-handler.ts
@@ -3,7 +3,7 @@ import {
   createChannelInboundDebouncer,
   shouldDebounceTextInbound,
 } from "openclaw/plugin-sdk/channel-inbound";
-import { formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
+import { collectErrorGraphCandidates, formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
 import { createLazyRuntimeModule } from "openclaw/plugin-sdk/lazy-runtime";
 import {
   asDateTimestampMs,
@@ -47,6 +47,7 @@ type SlackDispatchCompletion = {
 
 type QueuedSlackMessageOptions = Parameters<SlackMessageHandler>[1] & {
   dispatchCompletion?: Omit<SlackDispatchCompletion, "promise">;
+  retryAttempt?: number;
 };
 
 function createSlackDispatchCompletion(): SlackDispatchCompletion {
@@ -60,12 +61,24 @@ function createSlackDispatchCompletion(): SlackDispatchCompletion {
 }
 
 const APP_MENTION_RETRY_TTL_MS = 60_000;
+const RETRYABLE_FLUSH_MAX_ATTEMPTS = 3;
+const RETRYABLE_FLUSH_RETRY_DELAY_MS = 1_000;
+const REPLY_SESSION_INIT_CONFLICT_MESSAGE_RE = /reply session initialization conflicted for \S+/u;
 
 export class SlackRetryableInboundError extends Error {
   constructor(message: string, options?: ErrorOptions) {
     super(message, options);
     this.name = "SlackRetryableInboundError";
   }
+}
+
+function isRetryableSlackInboundError(error: unknown): boolean {
+  if (error instanceof SlackRetryableInboundError) {
+    return true;
+  }
+  return collectErrorGraphCandidates(error, (current) => [current.cause, current.error]).some(
+    (candidate) => REPLY_SESSION_INIT_CONFLICT_MESSAGE_RE.test(formatErrorMessage(candidate)),
+  );
 }
 
 function shouldDebounceSlackMessage(message: SlackMessageEvent, cfg: SlackMonitorContext["cfg"]) {
@@ -101,6 +114,39 @@ export function createSlackMessageHandler(params: {
     buildKey: (entry) => buildSlackDebounceKey(entry.message, ctx.accountId),
     shouldDebounce: (entry) => shouldDebounceSlackMessage(entry.message, ctx.cfg),
     onFlush: async (entries) => {
+      const retryEntries = (sourceError: unknown): boolean => {
+        const retryable = isRetryableSlackInboundError(sourceError);
+        if (!retryable) {
+          return false;
+        }
+        const nextEntries = entries
+          .map((entry) => {
+            const retryAttempt = entry.opts.retryAttempt ?? 0;
+            if (retryAttempt >= RETRYABLE_FLUSH_MAX_ATTEMPTS) {
+              return null;
+            }
+            return {
+              ...entry,
+              opts: {
+                ...entry.opts,
+                dispatchCompletion: undefined,
+                retryAttempt: retryAttempt + 1,
+              },
+            };
+          })
+          .filter((entry) => entry !== null);
+        if (nextEntries.length === 0) {
+          return false;
+        }
+        setTimeout(() => {
+          for (const entry of nextEntries) {
+            void debouncer.enqueue(entry).catch((err: unknown) => {
+              ctx.runtime.error?.(`slack inbound retry enqueue failed: ${formatErrorMessage(err)}`);
+            });
+          }
+        }, RETRYABLE_FLUSH_RETRY_DELAY_MS);
+        return true;
+      };
       const completions = entries
         .map((entry) => entry.opts.dispatchCompletion)
         .filter((completion) => completion !== undefined);
@@ -187,7 +233,7 @@ export function createSlackMessageHandler(params: {
                 messages: entries.map((entry) => entry.message),
               });
             } catch (error) {
-              if (!(error instanceof SlackRetryableInboundError)) {
+              if (!isRetryableSlackInboundError(error)) {
                 await recordSlackInboundMessageDeliveries({
                   accountId: ctx.accountId,
                   messages: entries.map((entry) => entry.message),
@@ -196,7 +242,7 @@ export function createSlackMessageHandler(params: {
               throw error;
             }
           } catch (error) {
-            if (error instanceof SlackRetryableInboundError) {
+            if (isRetryableSlackInboundError(error)) {
               if (seenMessageKey) {
                 appMentionDispatchedKeys.delete(seenMessageKey);
               }
@@ -209,6 +255,7 @@ export function createSlackMessageHandler(params: {
           completion.resolve();
         }
       } catch (error) {
+        retryEntries(error);
         for (const completion of completions) {
           completion.reject(error);
         }


### PR DESCRIPTION
Summary:
- Treat wrapped Slack reply-session initialization conflicts as retryable inbound failures.
- Avoid recording inbound delivery for those transient conflicts and re-enqueue the debounce flush with bounded backoff.
- Add regression coverage for the wrapped `Slack dispatch failed` -> `reply session initialization conflicted ...` case.

Tests:
- `/home/dev-user/.local/share/crabbox-openai/openclaw/releases/fbfadbd806e16932f2c6bcaf4f283dbb1fc536f8/node_modules/.bin/oxfmt --check --threads=1 extensions/slack/src/monitor/message-handler.ts extensions/slack/src/monitor/message-handler.test.ts`
- `node scripts/run-vitest.mjs run extensions/slack/src/monitor/message-handler.app-mention-race.test.ts extensions/slack/src/monitor/message-handler.test.ts`
- `node scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.extensions.json extensions/slack/src/monitor/message-handler.ts extensions/slack/src/monitor/message-handler.test.ts`

Note: the fresh PR worktree could not run `pnpm install` directly because the internal registry returned 403 for `@openclaw/crabline`; tests and lint were run using the already-installed repo dependency set from the release checkout.