### PR TITLE
fix(qa): defer partial Crabline recorder rows

### DIFF
--- a/extensions/qa-lab/src/crabline-transport.test.ts
+++ b/extensions/qa-lab/src/crabline-transport.test.ts
@@ -103,6 +103,83 @@ describe("crabline transport", () => {
     });
   });
 
+  it("defers a partial recorder tail until Crabline finishes the JSONL record", async () => {
+    await withTempDir("qa-crabline-transport-", async (outputDir) => {
+      const transport = await createQaCrablineTransportAdapter({
+        outputDir,
+        selection: createSelection(),
+        state: createQaBusState(),
+      });
+      const manifest = JSON.parse(
+        await fs.readFile(path.join(outputDir, OPENCLAW_CRABLINE_MANIFEST_PATH), "utf8"),
+      ) as { recorderPath: string };
+      const recorderLine = JSON.stringify({
+        body: {
+          chat_id: "100001",
+          text: `partial recorder write ${"x".repeat(240)}`,
+        },
+        path: "/bot<redacted>/sendMessage",
+        type: "api",
+      });
+      const splitIndex = 191;
+
+      try {
+        await transport.reset();
+        await fs.appendFile(manifest.recorderPath, recorderLine.slice(0, splitIndex), "utf8");
+
+        await expect(transport.reset()).resolves.toBeUndefined();
+
+        await fs.appendFile(manifest.recorderPath, `${recorderLine.slice(splitIndex)}\n`, "utf8");
+        await expect(
+          transport.state.searchMessages({ query: "partial recorder write" }),
+        ).resolves.toHaveLength(1);
+      } finally {
+        await transport.cleanup?.();
+      }
+    });
+  });
+
+  it("rejects a malformed newline-terminated recorder record", async () => {
+    await withTempDir("qa-crabline-transport-", async (outputDir) => {
+      const transport = await createQaCrablineTransportAdapter({
+        outputDir,
+        selection: createSelection(),
+        state: createQaBusState(),
+      });
+      const manifest = JSON.parse(
+        await fs.readFile(path.join(outputDir, OPENCLAW_CRABLINE_MANIFEST_PATH), "utf8"),
+      ) as { recorderPath: string };
+
+      try {
+        await transport.reset();
+        await fs.appendFile(manifest.recorderPath, '{"broken":\n', "utf8");
+
+        await expect(transport.reset()).rejects.toThrow(SyntaxError);
+        await fs.writeFile(manifest.recorderPath, "", "utf8");
+      } finally {
+        await transport.cleanup?.();
+      }
+    });
+  });
+
+  it("rejects a permanently truncated recorder tail during cleanup", async () => {
+    await withTempDir("qa-crabline-transport-", async (outputDir) => {
+      const transport = await createQaCrablineTransportAdapter({
+        outputDir,
+        selection: createSelection(),
+        state: createQaBusState(),
+      });
+      const manifest = JSON.parse(
+        await fs.readFile(path.join(outputDir, OPENCLAW_CRABLINE_MANIFEST_PATH), "utf8"),
+      ) as { recorderPath: string };
+
+      await transport.reset();
+      await fs.appendFile(manifest.recorderPath, '{"unfinished":"recorder tail', "utf8");
+
+      await expect(transport.cleanup?.()).rejects.toThrow(SyntaxError);
+    });
+  });
+
   it("observes Telegram preview edits through the shared transport adapter", async () => {
     await withTempDir("qa-crabline-transport-", async (outputDir) => {
       const transport = await createQaCrablineTransportAdapter({

--- a/extensions/qa-lab/src/crabline-transport.ts
+++ b/extensions/qa-lab/src/crabline-transport.ts
@@ -52,6 +52,16 @@ type QaCrablineTransportState = QaTransportState & {
 
 const TELEGRAM_LIFECYCLE_METHOD_RE = /\/(sendMessage|editMessageText|deleteMessage)$/u;
 
+function readRecorderLines(text: string, options: { allowIncompleteTail: boolean }): string[] {
+  // Crabline appends each JSONL record asynchronously, so a concurrent read can end mid-record.
+  // Defer only the unterminated tail; newline-terminated malformed records must still fail parsing.
+  const lines = text.split(/\r?\n/u);
+  if (options.allowIncompleteTail && !text.endsWith("\n")) {
+    lines.pop();
+  }
+  return lines.filter((line) => line.trim().length > 0);
+}
+
 function readTelegramLifecycleEvent(params: {
   cursor: number;
   event: unknown;
@@ -217,43 +227,45 @@ function createCrablineState(params: {
   let recorderLineCursor = 0;
   let syncPromise: Promise<void> | null = null;
 
+  const syncRecorderSnapshot = async (options: { allowIncompleteTail: boolean }) => {
+    const text = await fs
+      .readFile(params.adapter.manifest.recorderPath, "utf8")
+      .catch((error: unknown) => {
+        if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+          return "";
+        }
+        throw error;
+      });
+    const lines = readRecorderLines(text, options);
+    for (const line of lines.slice(recorderLineCursor)) {
+      const parsed = JSON.parse(line) as unknown;
+      if (params.adapter.channel === "telegram") {
+        const lifecycle = readTelegramLifecycleEvent({
+          cursor: outboundEvents.length + 1,
+          event: parsed,
+          messageByProviderId: telegramMessageByProviderId,
+          pendingByChat: pendingTelegramMessagesByChat,
+        });
+        if (lifecycle) {
+          outboundEvents.push(lifecycle);
+        }
+      }
+      const outbound = params.adapter.createOutboundFromRecorderEvent({
+        event: parsed,
+        targetByProviderTarget,
+      }) as QaBusOutboundMessageInput | null;
+      if (outbound) {
+        baseState.addOutboundMessage(outbound);
+      }
+    }
+    recorderLineCursor = lines.length;
+  };
+
   const syncRecorder = async () => {
     if (syncPromise) {
       return await syncPromise;
     }
-    syncPromise = (async () => {
-      const text = await fs
-        .readFile(params.adapter.manifest.recorderPath, "utf8")
-        .catch((error: unknown) => {
-          if ((error as NodeJS.ErrnoException).code === "ENOENT") {
-            return "";
-          }
-          throw error;
-        });
-      const lines = text.split(/\r?\n/u).filter((line) => line.trim().length > 0);
-      for (const line of lines.slice(recorderLineCursor)) {
-        const parsed = JSON.parse(line) as unknown;
-        if (params.adapter.channel === "telegram") {
-          const lifecycle = readTelegramLifecycleEvent({
-            cursor: outboundEvents.length + 1,
-            event: parsed,
-            messageByProviderId: telegramMessageByProviderId,
-            pendingByChat: pendingTelegramMessagesByChat,
-          });
-          if (lifecycle) {
-            outboundEvents.push(lifecycle);
-          }
-        }
-        const outbound = params.adapter.createOutboundFromRecorderEvent({
-          event: parsed,
-          targetByProviderTarget,
-        }) as QaBusOutboundMessageInput | null;
-        if (outbound) {
-          baseState.addOutboundMessage(outbound);
-        }
-      }
-      recorderLineCursor = lines.length;
-    })();
+    syncPromise = syncRecorderSnapshot({ allowIncompleteTail: true });
     try {
       await syncPromise;
     } finally {
@@ -276,7 +288,7 @@ function createCrablineState(params: {
       outboundEvents.length = 0;
       recorderLineCursor = await fs
         .readFile(params.adapter.manifest.recorderPath, "utf8")
-        .then((text) => text.split(/\r?\n/u).filter((line) => line.trim().length > 0).length)
+        .then((text) => readRecorderLines(text, { allowIncompleteTail: true }).length)
         .catch(() => 0);
     },
     getSnapshot: baseState.getSnapshot.bind(baseState),
@@ -313,8 +325,11 @@ function createCrablineState(params: {
     },
     async cleanup() {
       clearInterval(interval);
-      await syncRecorder();
       await params.adapter.close();
+      if (syncPromise) {
+        await syncPromise;
+      }
+      await syncRecorderSnapshot({ allowIncompleteTail: false });
     },
   };
 }


### PR DESCRIPTION
## What Problem This Solves

Fixes #99648.

QA Lab polls Crabline's JSONL recorder while the provider is actively appending records. A read can end inside the final record, and the transport previously passed that fragment directly to `JSON.parse`. The observed failure was `Unterminated string in JSON at position 191` in `native-command-session-target`.

## Why This Change Was Made

- Defer only a non-newline-terminated trailing record during normal polling and reset.
- Parse the deferred record after Crabline finishes writing it.
- Close Crabline before a strict final recorder sync so permanently truncated output still fails.
- Keep newline-terminated malformed JSON visible as a parse failure.
- Use one recorder-line policy for polling, reset cursor accounting, and terminal validation.

## User Impact

Crabline-backed QA scenarios no longer fail when a recorder read overlaps a valid append. Corrupt completed records remain failures rather than being ignored.

## Evidence

- Failed job showing the intermittent parser error: https://github.com/openclaw/openclaw/actions/runs/28682242841/job/85068991903
- Artifact `8074574444` recorded 24 passing scenarios and only `native-command-session-target` failing at JSON byte 191.
- `node scripts/run-vitest.mjs extensions/qa-lab/src/crabline-transport.test.ts -- -t 'partial recorder tail|malformed newline-terminated|permanently truncated' --reporter=verbose` — 3 passed.
- Blacksmith Testbox `tbx_01kwmwgp9ysjr4p1vx3gcc8p01`: `corepack pnpm test extensions/qa-lab/src/crabline-transport.test.ts -- --reporter=verbose` — 18 passed.
- Same Testbox: private QA runtime build plus `corepack pnpm openclaw qa run --repo-root . --qa-profile smoke-ci --scenario native-command-session-target --concurrency 1 --output-dir .artifacts/qa-e2e/native-command-json-fix` — passed.
- Testbox action: https://github.com/openclaw/openclaw/actions/runs/28683172353
- Fresh autoreview: clean, no accepted/actionable findings.
