### PR TITLE
fix(gateway): hide CLI reseed wrappers in history

### DIFF
--- a/src/gateway/cli-session-history.claude.ts
+++ b/src/gateway/cli-session-history.claude.ts
@@ -102,12 +102,26 @@ function cloneJsonValue<T>(value: T): T {
   return structuredClone(value);
 }
 
+function unwrapOpenClawCliReseedPrompt(content: string): string | undefined {
+  if (
+    !content.startsWith(
+      "Continue this conversation using the OpenClaw transcript below as prior session history.",
+    )
+  ) {
+    return undefined;
+  }
+
+  const match = content.match(/<next_user_message>\n?([\s\S]*?)\n?<\/next_user_message>\s*$/);
+  return normalizeOptionalString(match?.[1]);
+}
+
 function normalizeClaudeCliContent(
   content: string | unknown[],
   toolNameRegistry: ToolNameRegistry,
 ): string | unknown[] {
   if (!Array.isArray(content)) {
-    return cloneJsonValue(content);
+    const unwrappedReseedPrompt = unwrapOpenClawCliReseedPrompt(content);
+    return unwrappedReseedPrompt ?? cloneJsonValue(content);
   }
 
   const normalized: ToolContentBlock[] = [];

--- a/src/gateway/cli-session-history.test.ts
+++ b/src/gateway/cli-session-history.test.ts
@@ -223,6 +223,45 @@ describe("cli session history", () => {
     });
   });
 
+  it("hides OpenClaw CLI reseed wrappers from imported Claude user history", async () => {
+    await withClaudeProjectsDir(async ({ homeDir, sessionId, filePath }) => {
+      await fs.writeFile(
+        filePath,
+        JSON.stringify({
+          type: "user",
+          uuid: "reseed-user",
+          timestamp: "2026-03-26T16:29:54.800Z",
+          message: {
+            role: "user",
+            content: [
+              "Continue this conversation using the OpenClaw transcript below as prior session history.",
+              "Treat it as authoritative context for this fresh CLI session.",
+              "",
+              "<conversation_history>",
+              "User: earlier private question",
+              "Assistant: earlier private answer",
+              "</conversation_history>",
+              "",
+              "<next_user_message>",
+              "show today's plan",
+              "</next_user_message>",
+            ].join("\n"),
+          },
+        }),
+        "utf-8",
+      );
+
+      const messages = readClaudeCliSessionMessages({ cliSessionId: sessionId, homeDir });
+      expect(messages).toHaveLength(1);
+      expectFields(messages[0], {
+        role: "user",
+        content: "show today's plan",
+      });
+      expect(String(messages[0]?.content)).not.toContain("conversation_history");
+      expect(String(messages[0]?.content)).not.toContain("earlier private question");
+    });
+  });
+
   it("deduplicates imported messages against similar local transcript entries", () => {
     const localMessages = [
       {


### PR DESCRIPTION
Closes #99646

## What Problem This Solves

Fixes an issue where Claude CLI users who resume from OpenClaw's raw transcript reseed prompt could later see the entire internal reseed wrapper rendered as a user chat bubble in chat history. The visible bubble could include the `<conversation_history>` replay and the `<next_user_message>` wrapper instead of only the message the user actually typed.

## Why This Change Was Made

The Claude CLI transcript importer now recognizes OpenClaw's reseed envelope when it appears as an imported Claude user row and projects only the wrapped `<next_user_message>` text into OpenClaw chat history. This keeps the model-facing reseed prompt unchanged while preventing history-API clients from displaying internal prompt scaffolding or replayed prior turns.

## User Impact

Users reloading chat history after a Claude CLI session invalidation/resume now see their actual message, not a fake long user bubble containing OpenClaw reseed instructions and prior transcript context. Existing normal Claude CLI user messages, assistant messages, and tool-call coalescing behavior are preserved.

## Evidence

- `node scripts/run-vitest.mjs src/gateway/cli-session-history.test.ts` — PASS, 4 files / 80 tests.
- `node scripts/run-vitest.mjs src/gateway/cli-session-history.test.ts src/gateway/server.chat.gateway-server-chat-b.test.ts` — PASS, 6 files / 168 tests.
- `corepack pnpm exec oxfmt --check src/gateway/cli-session-history.claude.ts src/gateway/cli-session-history.test.ts` — PASS.
- `corepack pnpm exec oxlint --config .oxlintrc.json --tsconfig config/tsconfig/oxlint.core.json src/gateway/cli-session-history.claude.ts src/gateway/cli-session-history.test.ts` — PASS, 0 warnings/errors.
- `git diff --check` — PASS.
- Diff secret scan — PASS (`SECRET_SCAN_MATCHES 0`).
