### PR TITLE
fix(cli): hide synthetic Claude reseed prompts

### DIFF
--- a/src/agents/agent-command.live-model-switch.test.ts
+++ b/src/agents/agent-command.live-model-switch.test.ts
@@ -1179,6 +1179,54 @@ describe("agentCommand – LiveSessionModelSwitchError retry", () => {
     expect(firstAttempt.fastModeStartedAtMs).toBe(secondAttempt.fastModeStartedAtMs);
   });
 
+  it("reuses durable user-turn proof across live model switch retries", async () => {
+    let fallbackInvocation = 0;
+    state.runWithModelFallbackMock.mockImplementation(async (params: FallbackRunnerParams) => {
+      fallbackInvocation += 1;
+      const result = await params.run(params.provider, params.model);
+      if (fallbackInvocation === 1) {
+        throw new LiveSessionModelSwitchError({
+          provider: "openai",
+          model: "gpt-5.4",
+        });
+      }
+      return {
+        result,
+        provider: params.provider,
+        model: params.model,
+        attempts: [],
+      };
+    });
+    state.runAgentAttemptMock.mockImplementation(async (attemptParams: unknown) => {
+      const attempt = attemptParams as {
+        userTurnTranscriptRecorder?: {
+          markRuntimePersisted: (message: { role: "user"; content: string }) => void;
+        };
+      };
+      if (state.runAgentAttemptMock.mock.calls.length === 1) {
+        attempt.userTurnTranscriptRecorder?.markRuntimePersisted({
+          role: "user",
+          content: "hello",
+        });
+      }
+      return makeSuccessResult("openai", "gpt-5.4");
+    });
+
+    await runBasicAgentCommand();
+
+    const firstAttempt = mockCallArg(state.runAgentAttemptMock, 0) as {
+      suppressPromptPersistenceOnRetry?: boolean;
+      userTurnTranscriptRecorder?: unknown;
+    };
+    const secondAttempt = mockCallArg(state.runAgentAttemptMock, 1) as {
+      suppressPromptPersistenceOnRetry?: boolean;
+      userTurnTranscriptRecorder?: unknown;
+    };
+    expect(secondAttempt.userTurnTranscriptRecorder).toBe(firstAttempt.userTurnTranscriptRecorder);
+    expect(firstAttempt.suppressPromptPersistenceOnRetry).toBe(false);
+    expect(secondAttempt.suppressPromptPersistenceOnRetry).toBe(true);
+  });
+
   it("uses an embedded queue rebound generation for terminal lifecycle and cleanup", async () => {
     setupSingleAttemptFallback();
     state.runAgentAttemptMock.mockImplementation(async (attemptParams: unknown) => {
@@ -2778,6 +2826,42 @@ describe("agentCommand – LiveSessionModelSwitchError retry", () => {
     expect(attemptCalls[1]?.suppressPromptPersistenceOnRetry).toBe(true);
   });
 
+  it("keeps a hook-blocked user turn suppressed across model fallback", async () => {
+    type AttemptCall = {
+      suppressPromptPersistenceOnRetry?: boolean;
+      userTurnTranscriptRecorder?: {
+        markBlocked: () => void;
+      };
+    };
+    const attemptCalls: AttemptCall[] = [];
+    state.runWithModelFallbackMock.mockImplementation(async (params: FallbackRunnerParams) => {
+      const first = await params.run(params.provider, params.model);
+      const result = await params.run(params.provider, params.model);
+      return {
+        result,
+        provider: params.provider,
+        model: params.model,
+        attempts: [first],
+      };
+    });
+    state.runAgentAttemptMock.mockImplementation(async (attemptParams: AttemptCall) => {
+      attemptCalls.push(attemptParams);
+      if (attemptCalls.length === 1) {
+        attemptParams.userTurnTranscriptRecorder?.markBlocked();
+      }
+      return makeSuccessResult("openai", "gpt-5.4");
+    });
+
+    await runBasicAgentCommand();
+
+    expect(attemptCalls).toHaveLength(2);
+    expect(attemptCalls[1]?.userTurnTranscriptRecorder).toBe(
+      attemptCalls[0]?.userTurnTranscriptRecorder,
+    );
+    expect(attemptCalls[0]?.suppressPromptPersistenceOnRetry).toBe(false);
+    expect(attemptCalls[1]?.suppressPromptPersistenceOnRetry).toBe(true);
+  });
+
   it("suppresses prompt persistence for internal handoffs on every fallback attempt", async () => {
     type AttemptCall = {
       suppressPromptPersistenceOnRetry?: boolean;
@@ -2795,7 +2879,18 @@ describe("agentCommand – LiveSessionModelSwitchError retry", () => {
     });
     state.runAgentAttemptMock.mockImplementation(async (attemptParams: AttemptCall) => {
       attemptCalls.push(attemptParams);
-      return makeSuccessResult("openai", "gpt-5.4");
+      const result = makeSuccessResult("openai", "gpt-5.4") as ReturnType<
+        typeof makeSuccessResult
+      > & {
+        meta: Record<string, unknown> & { executionTrace?: Record<string, unknown> };
+      };
+      result.meta.executionTrace = {
+        runner: "cli",
+        fallbackUsed: false,
+        winnerProvider: "openai",
+        winnerModel: "gpt-5.4",
+      };
+      return result;
     });
 
     await agentCommand({
@@ -2807,6 +2902,51 @@ describe("agentCommand – LiveSessionModelSwitchError retry", () => {
     expect(attemptCalls).toHaveLength(2);
     expect(attemptCalls[0]?.suppressPromptPersistenceOnRetry).toBe(true);
     expect(attemptCalls[1]?.suppressPromptPersistenceOnRetry).toBe(true);
+    expectRecordFields(mockCallArg(state.persistCliTurnTranscriptMock), {
+      skipUserTurn: true,
+    });
+  });
+
+  it("preserves an explicit empty transcript message as user-turn omission", async () => {
+    setupSingleAttemptFallback();
+    state.runAgentAttemptMock.mockResolvedValue(makeSuccessResult("openai", "gpt-5.4"));
+
+    await agentCommand({
+      message: "synthetic announce prompt",
+      transcriptMessage: "",
+      to: "+1234567890",
+    });
+
+    const attempt = mockCallArg(state.runAgentAttemptMock) as {
+      suppressPromptPersistenceOnRetry?: boolean;
+      userTurnTranscriptRecorder?: { message?: unknown };
+    };
+    expect(attempt.suppressPromptPersistenceOnRetry).toBe(true);
+    expect(attempt.userTurnTranscriptRecorder?.message).toBeUndefined();
+  });
+
+  it("uses a tracker-only recorder for text plus image turns", async () => {
+    setupSingleAttemptFallback();
+    state.runAgentAttemptMock.mockResolvedValue(makeSuccessResult("openai", "gpt-5.4"));
+
+    await agentCommand({
+      message: "inspect this image",
+      transcriptMessage: "canonical image caption",
+      images: [{ type: "image", data: "aGVsbG8=", mimeType: "image/png" }],
+      to: "+1234567890",
+    });
+
+    const attempt = mockCallArg(state.runAgentAttemptMock) as {
+      transcriptBody?: string;
+      suppressPromptPersistenceOnRetry?: boolean;
+      userTurnTranscriptRecorder?: { message?: unknown };
+    };
+    expect(attempt.transcriptBody).toBe("canonical image caption");
+    expect(attempt.suppressPromptPersistenceOnRetry).toBe(false);
+    expect(attempt.userTurnTranscriptRecorder?.message).toMatchObject({
+      role: "user",
+      content: "canonical image caption",
+    });
   });
 
   it("propagates non-switch errors without retrying and emits lifecycle error", async () => {

--- a/src/agents/agent-command.ts
+++ b/src/agents/agent-command.ts
@@ -53,6 +53,7 @@ import {
   repairProviderWrappedModelOverride,
 } from "../sessions/model-overrides.js";
 import { resolveSendPolicy } from "../sessions/send-policy.js";
+import { createUserTurnTranscriptRecorder } from "../sessions/user-turn-transcript.js";
 import { createLazyImportLoader } from "../shared/lazy-promise.js";
 import { resolveEffectiveAgentSkillFilter } from "../skills/discovery/agent-filter.js";
 import type { getRemoteSkillEligibility } from "../skills/runtime/remote.js";
@@ -108,6 +109,7 @@ import {
   mergeEmbeddedAgentRunResultForModelFallbackExhaustion,
 } from "./embedded-agent-runner/result-fallback-classifier.js";
 import { resolveFastModeState } from "./fast-mode.js";
+import { runAgentHarnessBeforeMessageWriteHook } from "./harness/hook-helpers.js";
 import { ensureSelectedAgentHarnessPlugin } from "./harness/runtime-plugin.js";
 import { resolveAvailableAgentHarnessPolicy } from "./harness/selection.js";
 import { prepareInternalSessionEffectsTranscript } from "./internal-session-effects.js";
@@ -1690,6 +1692,27 @@ async function agentCommandInternal(
       lifecycleEnded: false,
     };
     const attemptLifecycleCallbacks = createAgentAttemptLifecycleCallbacks(attemptLifecycleState);
+    const suppressUserTurnPersistence =
+      opts.suppressPromptPersistence === true || opts.transcriptMessage === "";
+    const recorderTranscriptText = transcriptBody || undefined;
+    const userTurnTranscriptRecorder = createUserTurnTranscriptRecorder({
+      ...(!suppressUserTurnPersistence && recorderTranscriptText
+        ? { input: { text: recorderTranscriptText } }
+        : {}),
+      target: {
+        transcriptPath: attemptSessionFile,
+        sessionId,
+        agentId: sessionAgentId,
+        ...(sessionKey ? { sessionKey } : {}),
+        cwd: cwd ?? workspaceDir,
+        config: cfg,
+      },
+      beforeMessageWrite: runAgentHarnessBeforeMessageWriteHook,
+      errorContext: "agent command user turn transcript",
+    });
+    if (suppressUserTurnPersistence) {
+      userTurnTranscriptRecorder.markBlocked();
+    }
     let lifecycleFinishingEmitted = false;
     const emitLifecycleFinishing = (runResult: AgentAttemptResult) => {
       if (
@@ -1928,6 +1951,7 @@ async function agentCommandInternal(
               workspaceDir,
               cwd,
               body,
+              transcriptBody,
               isFallbackRetry,
               resolvedThinkLevel,
               fastMode,
@@ -1958,8 +1982,11 @@ async function agentCommandInternal(
                 !isNewSession ||
                 (await attemptExecutionRuntime.sessionFileHasContent(attemptSessionFile)),
               suppressPromptPersistenceOnRetry:
-                opts.suppressPromptPersistence === true ||
+                suppressUserTurnPersistence ||
+                userTurnTranscriptRecorder.hasPersisted() ||
+                userTurnTranscriptRecorder.isBlocked() ||
                 (isFallbackRetry && attemptLifecycleState.currentTurnUserMessagePersisted),
+              userTurnTranscriptRecorder,
               onUserMessagePersisted: attemptLifecycleCallbacks.onUserMessagePersisted,
               onLifecycleGenerationChanged: (nextLifecycleGeneration) => {
                 lifecycleGeneration = nextLifecycleGeneration;
@@ -2220,6 +2247,10 @@ async function agentCommandInternal(
             sessionCwd: effectiveCwd,
             config: cfg,
             embeddedAssistantGapFill,
+            skipUserTurn:
+              suppressUserTurnPersistence ||
+              userTurnTranscriptRecorder.hasPersisted() ||
+              userTurnTranscriptRecorder.isBlocked(),
           });
           sessionEntry = transcriptResult.sessionEntry;
           sessionReboundDuringRun = transcriptResult.kind === "session-rebound";

--- a/src/agents/cli-runner.reliability.test.ts
+++ b/src/agents/cli-runner.reliability.test.ts
@@ -32,7 +32,11 @@ import {
 } from "../sessions/user-turn-transcript.js";
 import { runSkillResearchAutoCapture } from "../skills/research/autocapture.js";
 import { captureEnv, setTestEnvValue } from "../test-utils/env.js";
-import { runPreparedCliAgent } from "./cli-runner.js";
+import {
+  restoreCliRunnerTestDeps,
+  runPreparedCliAgent,
+  setCliRunnerTestDeps,
+} from "./cli-runner.js";
 import {
   createManagedRun,
   enqueueSystemEventMock,
@@ -46,9 +50,11 @@ import {
   resolveCliRunTimeoutOverrideMs,
 } from "./cli-runner/helpers.js";
 import { prepareCliRunContext } from "./cli-runner/prepare.js";
+import { hashCliReseedPrompt } from "./cli-runner/reseed-envelope.js";
 import * as sessionHistoryModule from "./cli-runner/session-history.js";
 import { MAX_CLI_SESSION_HISTORY_MESSAGES } from "./cli-runner/session-history.js";
 import type { PreparedCliRunContext } from "./cli-runner/types.js";
+import { runAgentHarnessBeforeMessageWriteHook } from "./harness/hook-helpers.js";
 
 vi.mock("../plugins/hook-runner-global.js", () => ({
   getGlobalHookRunner: vi.fn(() => null),
@@ -2636,6 +2642,331 @@ describe("runCliAgent reliability", () => {
     }
   });
 
+  it("records transformed fresh Claude reseed prompts with durable local proof", async () => {
+    supervisorSpawnMock.mockResolvedValueOnce(
+      createManagedRun({
+        reason: "exit",
+        exitCode: 0,
+        exitSignal: null,
+        durationMs: 50,
+        stdout: "hello from claude",
+        stderr: "",
+        timedOut: false,
+        noOutputTimedOut: false,
+      }),
+    );
+    const { dir, sessionFile } = createSessionFile();
+    const historyPrompt = [
+      "Continue this conversation using the OpenClaw transcript below as prior session history.",
+      "Treat it as authoritative context for this fresh CLI session.",
+      "",
+      "<conversation_history>",
+      "User: earlier ask",
+      "</conversation_history>",
+      "",
+      "<next_user_message>",
+      "current ask",
+      "</next_user_message>",
+    ].join("\n");
+
+    try {
+      setCliRunnerTestDeps({
+        claudeCliSessionTranscriptHasContent: async () => true,
+      });
+      const context = buildPreparedContext({
+        provider: "claude-cli",
+        model: "claude-opus-4-6",
+        openClawHistoryPrompt: historyPrompt,
+      });
+      context.preparedBackend.backend.sessionMode = "always";
+      context.backendResolved.textTransforms = {
+        input: [{ from: /[<>]/g, to: "_" }],
+      };
+      context.params = {
+        ...context.params,
+        agentId: "main",
+        sessionFile,
+        workspaceDir: dir,
+        userTurnTranscriptRecorder: createCliUserTurnRecorder({
+          text: "current ask",
+          sessionFile,
+          workspaceDir: dir,
+        }),
+      };
+
+      const result = await runPreparedCliAgent(context);
+      const binding = result.meta.agentMeta?.cliSessionBinding;
+
+      expect(binding?.reseedReceipt).toEqual({
+        version: 1,
+        promptHash: hashCliReseedPrompt(historyPrompt.replace(/[<>]/g, "_")),
+        localSessionId: "s1",
+        userTurnDisposition: "persisted",
+      });
+    } finally {
+      restoreCliRunnerTestDeps();
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("does not mint a reseed receipt without caller-owned durable proof", async () => {
+    supervisorSpawnMock.mockResolvedValueOnce(
+      createManagedRun({
+        reason: "exit",
+        exitCode: 0,
+        exitSignal: null,
+        durationMs: 50,
+        stdout: "hello from claude",
+        stderr: "",
+        timedOut: false,
+        noOutputTimedOut: false,
+      }),
+    );
+    const { dir, sessionFile } = createSessionFile();
+
+    try {
+      setCliRunnerTestDeps({
+        claudeCliSessionTranscriptHasContent: async () => true,
+      });
+      const context = buildPreparedContext({
+        provider: "claude-cli",
+        model: "claude-opus-4-6",
+        openClawHistoryPrompt: CLI_RESEED_PROMPT,
+      });
+      context.preparedBackend.backend.sessionMode = "always";
+      context.params = {
+        ...context.params,
+        agentId: "main",
+        sessionFile,
+        workspaceDir: dir,
+        transcriptPrompt: "canonical current ask",
+      };
+
+      const result = await runPreparedCliAgent(context);
+
+      expect(result.meta.agentMeta?.cliSessionBinding?.reseedReceipt).toBeUndefined();
+      expect(readTranscriptMessages(sessionFile)).not.toContainEqual(
+        expect.objectContaining({ role: "user" }),
+      );
+    } finally {
+      restoreCliRunnerTestDeps();
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("mints an omission receipt for a trusted suppressed reseed turn", async () => {
+    supervisorSpawnMock.mockResolvedValueOnce(
+      createManagedRun({
+        reason: "exit",
+        exitCode: 0,
+        exitSignal: null,
+        durationMs: 50,
+        stdout: "hello from claude",
+        stderr: "",
+        timedOut: false,
+        noOutputTimedOut: false,
+      }),
+    );
+    const { dir, sessionFile } = createSessionFile();
+    const recorder = createUserTurnTranscriptRecorder({
+      target: {
+        transcriptPath: sessionFile,
+        sessionId: "s1",
+        agentId: "main",
+        cwd: dir,
+      },
+    });
+    recorder.markBlocked();
+
+    try {
+      setCliRunnerTestDeps({
+        claudeCliSessionTranscriptHasContent: async () => true,
+      });
+      const context = buildPreparedContext({
+        provider: "claude-cli",
+        model: "claude-opus-4-6",
+        openClawHistoryPrompt: CLI_RESEED_PROMPT,
+      });
+      context.preparedBackend.backend.sessionMode = "always";
+      context.params = {
+        ...context.params,
+        agentId: "main",
+        sessionFile,
+        workspaceDir: dir,
+        suppressNextUserMessagePersistence: true,
+        userTurnTranscriptRecorder: recorder,
+      };
+
+      const result = await runPreparedCliAgent(context);
+
+      expect(result.meta.agentMeta?.cliSessionBinding?.reseedReceipt).toEqual({
+        version: 1,
+        promptHash: hashCliReseedPrompt(CLI_RESEED_PROMPT),
+        localSessionId: "s1",
+        userTurnDisposition: "omitted",
+      });
+      expect(readTranscriptMessages(sessionFile)).toEqual([]);
+    } finally {
+      restoreCliRunnerTestDeps();
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("reuses durable local proof when a fallback suppresses duplicate persistence", async () => {
+    supervisorSpawnMock.mockResolvedValueOnce(
+      createManagedRun({
+        reason: "exit",
+        exitCode: 0,
+        exitSignal: null,
+        durationMs: 50,
+        stdout: "hello from claude",
+        stderr: "",
+        timedOut: false,
+        noOutputTimedOut: false,
+      }),
+    );
+    const { dir, sessionFile } = createSessionFile();
+    const recorder = createCliUserTurnRecorder({
+      text: "current ask",
+      sessionFile,
+      workspaceDir: dir,
+    });
+
+    try {
+      const persisted = await recorder.persistApproved();
+      expect(persisted?.messageId).toEqual(expect.any(String));
+      setCliRunnerTestDeps({
+        claudeCliSessionTranscriptHasContent: async () => true,
+      });
+      const context = buildPreparedContext({
+        provider: "claude-cli",
+        model: "claude-opus-4-6",
+        openClawHistoryPrompt: CLI_RESEED_PROMPT,
+      });
+      context.preparedBackend.backend.sessionMode = "always";
+      const onUserMessagePersisted = vi.fn();
+      context.params = {
+        ...context.params,
+        agentId: "main",
+        sessionFile,
+        workspaceDir: dir,
+        suppressNextUserMessagePersistence: true,
+        userTurnTranscriptRecorder: recorder,
+        onUserMessagePersisted,
+      };
+
+      const result = await runPreparedCliAgent(context);
+
+      expect(result.meta.agentMeta?.cliSessionBinding?.reseedReceipt).toEqual({
+        version: 1,
+        promptHash: hashCliReseedPrompt(CLI_RESEED_PROMPT),
+        localSessionId: "s1",
+        userTurnDisposition: "persisted",
+      });
+      expect(onUserMessagePersisted).not.toHaveBeenCalled();
+    } finally {
+      restoreCliRunnerTestDeps();
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("uses runtime-owned persistence proof", async () => {
+    supervisorSpawnMock.mockResolvedValueOnce(
+      createManagedRun({
+        reason: "exit",
+        exitCode: 0,
+        exitSignal: null,
+        durationMs: 50,
+        stdout: "hello from claude",
+        stderr: "",
+        timedOut: false,
+        noOutputTimedOut: false,
+      }),
+    );
+    const { dir, sessionFile } = createSessionFile();
+    const recorder = createCliUserTurnRecorder({
+      text: "current ask",
+      sessionFile,
+      workspaceDir: dir,
+    });
+    recorder.markRuntimePersisted({
+      role: "user",
+      content: "current ask",
+      timestamp: Date.now(),
+    });
+
+    try {
+      setCliRunnerTestDeps({
+        claudeCliSessionTranscriptHasContent: async () => true,
+      });
+      const context = buildPreparedContext({
+        provider: "claude-cli",
+        model: "claude-opus-4-6",
+        openClawHistoryPrompt: CLI_RESEED_PROMPT,
+      });
+      context.preparedBackend.backend.sessionMode = "always";
+      context.params = {
+        ...context.params,
+        agentId: "main",
+        sessionFile,
+        workspaceDir: dir,
+        suppressNextUserMessagePersistence: true,
+        userTurnTranscriptRecorder: recorder,
+      };
+
+      const result = await runPreparedCliAgent(context);
+
+      expect(result.meta.agentMeta?.cliSessionBinding?.reseedReceipt).toEqual({
+        version: 1,
+        promptHash: hashCliReseedPrompt(CLI_RESEED_PROMPT),
+        localSessionId: "s1",
+        userTurnDisposition: "persisted",
+      });
+    } finally {
+      restoreCliRunnerTestDeps();
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("preserves a reseed receipt when reusing the same Claude CLI session", async () => {
+    supervisorSpawnMock.mockResolvedValueOnce(
+      createManagedRun({
+        reason: "exit",
+        exitCode: 0,
+        exitSignal: null,
+        durationMs: 50,
+        stdout: "hello again",
+        stderr: "",
+        timedOut: false,
+        noOutputTimedOut: false,
+      }),
+    );
+    const reseedReceipt = {
+      version: 1 as const,
+      promptHash: "a".repeat(64),
+      localSessionId: "s1",
+      userTurnDisposition: "persisted" as const,
+    };
+    const context = buildPreparedContext({
+      provider: "claude-cli",
+      model: "claude-opus-4-6",
+      cliSessionId: "existing-cli-session",
+    });
+    context.params.cliSessionBinding = {
+      sessionId: "existing-cli-session",
+      reseedReceipt,
+    };
+
+    setCliRunnerTestDeps({
+      claudeCliSessionTranscriptHasContent: async () => true,
+    });
+    const result = await runPreparedCliAgent(context).finally(() => {
+      restoreCliRunnerTestDeps();
+    });
+
+    expect(result.meta.agentMeta?.cliSessionBinding?.reseedReceipt).toEqual(reseedReceipt);
+  });
+
   it("lets before_message_write block CLI assistant persistence without delivery fallback", async () => {
     const hookRunner = {
       hasHooks: vi.fn((hookName: string) => hookName === "before_message_write"),
@@ -2942,6 +3273,63 @@ describe("runCliAgent reliability", () => {
     }
   });
 
+  it("marks a before_message_write-rejected CLI user turn as blocked", async () => {
+    const hookRunner = {
+      hasHooks: vi.fn((hookName: string) => hookName === "before_message_write"),
+      runBeforeMessageWrite: vi.fn(() => ({ block: true })),
+    };
+    setHookRunnerForTest(hookRunner);
+    supervisorSpawnMock.mockResolvedValueOnce(
+      createManagedRun({
+        reason: "exit",
+        exitCode: 0,
+        exitSignal: null,
+        durationMs: 50,
+        stdout: "hello from cli",
+        stderr: "",
+        timedOut: false,
+        noOutputTimedOut: false,
+      }),
+    );
+    const { dir, sessionFile } = createSessionFile();
+    const recorder = createUserTurnTranscriptRecorder({
+      input: { text: "blocked user turn" },
+      target: {
+        transcriptPath: sessionFile,
+        sessionId: "session-1",
+        sessionKey: "agent:main:main",
+        cwd: dir,
+      },
+      beforeMessageWrite: runAgentHarnessBeforeMessageWriteHook,
+    });
+
+    try {
+      const context = buildPreparedContext({
+        sessionKey: "agent:main:main",
+        runId: "run-blocked-cli-user-turn",
+      });
+      const result = await runPreparedCliAgent({
+        ...context,
+        params: {
+          ...context.params,
+          agentId: "main",
+          sessionFile,
+          workspaceDir: dir,
+          prompt: "runtime prompt",
+          userTurnTranscriptRecorder: recorder,
+        },
+      });
+
+      expect(result.payloads).toEqual([{ text: "hello from cli" }]);
+      expect(recorder.hasPersisted()).toBe(false);
+      expect(recorder.isBlocked()).toBe(true);
+      expect(readTranscriptMessages(sessionFile)).toEqual([]);
+      expect(hookRunner.runBeforeMessageWrite).toHaveBeenCalledOnce();
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
   it("does not fail CLI execution when persistence notification fails", async () => {
     supervisorSpawnMock.mockClear();
     supervisorSpawnMock.mockResolvedValueOnce(
@@ -3056,6 +3444,12 @@ describe("runCliAgent reliability", () => {
     const { dir, sessionFile } = createSessionFile({
       history: [{ role: "user", content: "earlier context" }],
     });
+    const userTurnTranscriptRecorder = createCliUserTurnRecorder({
+      text: "secret prompt",
+      sessionFile,
+      sessionKey: "agent:main:main",
+      workspaceDir: dir,
+    });
 
     try {
       let resolved = false;
@@ -3071,12 +3465,7 @@ describe("runCliAgent reliability", () => {
           sessionFile,
           workspaceDir: dir,
           prompt: "secret prompt",
-          userTurnTranscriptRecorder: createCliUserTurnRecorder({
-            text: "secret prompt",
-            sessionFile,
-            sessionKey: "agent:main:main",
-            workspaceDir: dir,
-          }),
+          userTurnTranscriptRecorder,
           onUserMessagePersisted,
         },
       }).then((result) => {
@@ -3103,6 +3492,7 @@ describe("runCliAgent reliability", () => {
       expect(supervisorSpawnMock).not.toHaveBeenCalled();
       expect(hookRunner.runLlmInput).not.toHaveBeenCalled();
       expect(onUserMessagePersisted).not.toHaveBeenCalled();
+      expect(userTurnTranscriptRecorder.isBlocked()).toBe(true);
       const beforeRunEvent = requireRecord(
         callArg(hookRunner.runBeforeAgentRun, 0, 0, "before_agent_run event"),
         "before_agent_run event",

--- a/src/agents/cli-runner.runtime.ts
+++ b/src/agents/cli-runner.runtime.ts
@@ -1,4 +1,10 @@
 // Runtime barrel for CLI agent execution and session id helpers. Keeps callers
 // importing this boundary instead of deep CLI runner/session modules.
 export { runCliAgent } from "./cli-runner.js";
-export { clearCliSession, getCliSessionId, setCliSessionId } from "./cli-session.js";
+export {
+  clearCliSession,
+  getCliSessionBinding,
+  getCliSessionId,
+  setCliSessionBinding,
+  setCliSessionId,
+} from "./cli-session.js";

--- a/src/agents/cli-runner.ts
+++ b/src/agents/cli-runner.ts
@@ -25,6 +25,7 @@ import {
   getCliMessagingDeliveryEvidence,
 } from "./cli-runner/delivery-evidence.js";
 import { cliBackendLog, formatCliBackendOutputDigest } from "./cli-runner/log.js";
+import { hashCliReseedPrompt } from "./cli-runner/reseed-envelope.js";
 import {
   loadCliSessionContextEngineMessages,
   loadCliSessionHistoryMessages,
@@ -256,9 +257,11 @@ async function runCliAgentEndHook(
   runAgentEndSideEffects(hookParams);
 }
 
-async function persistApprovedCliUserTurnTranscript(params: RunCliAgentParams): Promise<void> {
-  if (params.suppressNextUserMessagePersistence === true || !params.userTurnTranscriptRecorder) {
-    return;
+async function persistApprovedCliUserTurnTranscript(params: RunCliAgentParams): Promise<boolean> {
+  const recorder = params.userTurnTranscriptRecorder;
+  const reusingPersistedTurn = params.suppressNextUserMessagePersistence === true;
+  if (!recorder || (reusingPersistedTurn && !recorder.hasPersisted())) {
+    return recorder?.isBlocked() === true;
   }
 
   const target = {
@@ -269,8 +272,13 @@ async function persistApprovedCliUserTurnTranscript(params: RunCliAgentParams): 
     cwd: params.cwd ?? params.workspaceDir,
     ...(params.config ? { config: params.config } : {}),
   };
-  const persisted = await params.userTurnTranscriptRecorder.persistApproved({ target });
-  if (persisted) {
+  const persisted = await recorder.persistApproved({ target });
+  if (!persisted && !recorder.hasPersisted() && (await recorder.resolveMessage())) {
+    // A prepared user row can be rejected by before_message_write. Preserve
+    // that terminal decision so outer transcript mirrors do not retry it.
+    recorder.markBlocked();
+  }
+  if (persisted && !reusingPersistedTurn) {
     try {
       const notification = params.onUserMessagePersisted?.(persisted.message);
       if (notification) {
@@ -282,6 +290,7 @@ async function persistApprovedCliUserTurnTranscript(params: RunCliAgentParams): 
       log.warn(`CLI user turn persistence notification failed: ${formatErrorMessage(error)}`);
     }
   }
+  return persisted !== undefined || recorder.hasPersisted() || recorder.isBlocked();
 }
 
 async function persistCliAssistantTranscript(params: {
@@ -651,6 +660,7 @@ export async function runPreparedCliAgent(
   });
 
   let deliveredMessagingSideEffect = false;
+  let userTurnHandled = false;
   const buildCliSourceReplyMirrorPayloads = (
     evidence: Pick<
       CliOutput,
@@ -765,6 +775,7 @@ export async function runPreparedCliAgent(
     message: string;
     pluginId: string;
   }): Promise<void> => {
+    params.userTurnTranscriptRecorder?.markBlocked();
     try {
       const nowMs = Date.now();
       const sessionManager = SessionManager.open(params.sessionFile);
@@ -886,6 +897,8 @@ export async function runPreparedCliAgent(
       assistantText,
       lastAssistant,
       sourceReplyWasDelivered: sourceReplyMirror.delivered,
+      usedHistoryPrompt:
+        cliSessionIdToUse === undefined && context.openClawHistoryPrompt !== undefined,
     };
   };
 
@@ -894,6 +907,7 @@ export async function runPreparedCliAgent(
     effectiveCliSessionId?: string;
     bindingFlushOk?: boolean;
     assistantTranscriptOwned?: boolean;
+    usedHistoryPrompt: boolean;
   }): EmbeddedAgentRunResult => {
     const text = resultParams.output.text?.trim();
     const rawText = resultParams.output.rawText?.trim();
@@ -925,6 +939,27 @@ export async function runPreparedCliAgent(
     const persistedCliSessionId = unflushedCliSessionId
       ? undefined
       : resultParams.effectiveCliSessionId;
+    const createdReseedReceipt =
+      persistedCliSessionId &&
+      resultParams.usedHistoryPrompt &&
+      isClaudeCliProvider(params.provider) &&
+      resultParams.output.finalPromptText !== undefined &&
+      userTurnHandled &&
+      params.sessionId
+        ? {
+            version: 1 as const,
+            promptHash: hashCliReseedPrompt(resultParams.output.finalPromptText),
+            localSessionId: params.sessionId,
+            userTurnDisposition: params.userTurnTranscriptRecorder?.hasPersisted()
+              ? ("persisted" as const)
+              : ("omitted" as const),
+          }
+        : undefined;
+    const preservedReseedReceipt =
+      params.cliSessionBinding && persistedCliSessionId === params.cliSessionBinding.sessionId
+        ? params.cliSessionBinding.reseedReceipt
+        : undefined;
+    const reseedReceipt = createdReseedReceipt ?? preservedReseedReceipt;
     const agentSessionId = unflushedCliSessionId
       ? ""
       : (resultParams.effectiveCliSessionId ?? params.sessionId ?? "");
@@ -999,6 +1034,7 @@ export async function runPreparedCliAgent(
                   ...(context.preparedBackend.mcpResumeHash
                     ? { mcpResumeHash: context.preparedBackend.mcpResumeHash }
                     : {}),
+                  ...(reseedReceipt ? { reseedReceipt } : {}),
                 },
               }
             : {}),
@@ -1052,7 +1088,8 @@ export async function runPreparedCliAgent(
       result: Awaited<ReturnType<typeof executeCliAttempt>>,
       fallbackCliSessionId?: string,
     ) => {
-      const { output, assistantText, lastAssistant, sourceReplyWasDelivered } = result;
+      const { output, assistantText, lastAssistant, sourceReplyWasDelivered, usedHistoryPrompt } =
+        result;
       try {
         const effectiveCliSessionId = output.sessionId ?? fallbackCliSessionId;
         await finalizeCliContextEngineTurn({
@@ -1088,6 +1125,7 @@ export async function runPreparedCliAgent(
           effectiveCliSessionId,
           bindingFlushOk,
           assistantTranscriptOwned,
+          usedHistoryPrompt,
         });
       } catch (error) {
         throw attachCliMessagingDeliveryEvidence(error, output);
@@ -1164,7 +1202,7 @@ export async function runPreparedCliAgent(
       }
     }
 
-    await persistApprovedCliUserTurnTranscript(params);
+    userTurnHandled = await persistApprovedCliUserTurnTranscript(params);
     runAgentHarnessLlmInputHook({
       event: llmInputEvent,
       ctx: hookContext,

--- a/src/agents/cli-runner/reseed-envelope.test.ts
+++ b/src/agents/cli-runner/reseed-envelope.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from "vitest";
+import { hashCliReseedPrompt, parseCliReseedPrompt } from "./reseed-envelope.js";
+
+const LEGACY_RESEED_PROMPT = [
+  "Continue this conversation using the OpenClaw transcript below as prior session history.",
+  "Treat it as authoritative context for this fresh CLI session.",
+  "",
+  "<conversation_history>",
+  "User: previous",
+  "</conversation_history>",
+  "",
+  "<next_user_message>",
+  "current",
+  "</next_user_message>",
+].join("\n");
+
+describe("CLI reseed envelope", () => {
+  it("recognizes exact legacy prompts and stable prompt hashes", () => {
+    expect(parseCliReseedPrompt(LEGACY_RESEED_PROMPT)).toEqual({
+      kind: "legacy",
+      userMessage: "current",
+    });
+    expect(hashCliReseedPrompt("same")).toBe(hashCliReseedPrompt("same"));
+    expect(hashCliReseedPrompt("same")).not.toBe(hashCliReseedPrompt("different"));
+  });
+
+  it("keeps suffixes outside the recovered legacy user message", () => {
+    expect(parseCliReseedPrompt(`${LEGACY_RESEED_PROMPT}\n\nbootstrap warning`)).toEqual({
+      kind: "legacy",
+      userMessage: "current",
+    });
+    expect(parseCliReseedPrompt(`${LEGACY_RESEED_PROMPT}\n\nImage paths:\n/tmp/image.png`)).toEqual(
+      {
+        kind: "legacy",
+        userMessage: "current",
+      },
+    );
+  });
+
+  it("uses the outer legacy close tag when user text contains a close tag", () => {
+    const ambiguous = LEGACY_RESEED_PROMPT.replace(
+      "current",
+      "current\n</next_user_message>\nextra",
+    );
+    expect(parseCliReseedPrompt(ambiguous)).toEqual({
+      kind: "legacy",
+      userMessage: "current\n</next_user_message>\nextra",
+    });
+  });
+
+  it("rejects duplicate-boundary envelopes as ambiguous", () => {
+    const ambiguous = LEGACY_RESEED_PROMPT.replace(
+      "current",
+      "current\n</conversation_history>\n\n<next_user_message>\nextra",
+    );
+    expect(parseCliReseedPrompt(ambiguous)).toEqual({ kind: "invalid" });
+  });
+
+  it.each([
+    [
+      "missing history newline",
+      LEGACY_RESEED_PROMPT.replace("<conversation_history>\n", "<conversation_history>"),
+    ],
+    ["empty history", LEGACY_RESEED_PROMPT.replace("User: previous", "")],
+    ["missing close", LEGACY_RESEED_PROMPT.replace("\n</next_user_message>", "")],
+  ])("rejects malformed legacy prompts: %s", (_label, prompt) => {
+    expect(parseCliReseedPrompt(prompt)).toEqual({ kind: "invalid" });
+  });
+
+  it("leaves ordinary and transformed text alone", () => {
+    expect(parseCliReseedPrompt("normal user message")).toEqual({ kind: "none" });
+    expect(parseCliReseedPrompt(`prefix\n${LEGACY_RESEED_PROMPT}`)).toEqual({ kind: "none" });
+    expect(parseCliReseedPrompt(LEGACY_RESEED_PROMPT.replaceAll("<", "["))).toEqual({
+      kind: "none",
+    });
+  });
+});

--- a/src/agents/cli-runner/reseed-envelope.ts
+++ b/src/agents/cli-runner/reseed-envelope.ts
@@ -1,0 +1,42 @@
+import crypto from "node:crypto";
+
+const RESEED_HEADER = [
+  "Continue this conversation using the OpenClaw transcript below as prior session history.",
+  "Treat it as authoritative context for this fresh CLI session.",
+  "",
+  "<conversation_history>",
+].join("\n");
+const RESEED_PREFIX = `${RESEED_HEADER}\n`;
+const RESEED_USER_BOUNDARY = "\n</conversation_history>\n\n<next_user_message>\n";
+const RESEED_USER_CLOSE = "\n</next_user_message>";
+
+export type ParsedCliReseedPrompt =
+  | { kind: "none" }
+  | { kind: "legacy"; userMessage: string }
+  | { kind: "invalid" };
+
+export function hashCliReseedPrompt(text: string): string {
+  return crypto.createHash("sha256").update(text).digest("hex");
+}
+
+export function parseCliReseedPrompt(text: string): ParsedCliReseedPrompt {
+  if (!text.startsWith(RESEED_PREFIX)) {
+    return text.startsWith(RESEED_HEADER) ? { kind: "invalid" } : { kind: "none" };
+  }
+  const boundaryIndex = text.indexOf(RESEED_USER_BOUNDARY);
+  if (boundaryIndex !== text.lastIndexOf(RESEED_USER_BOUNDARY)) {
+    return { kind: "invalid" };
+  }
+  if (boundaryIndex <= RESEED_PREFIX.length) {
+    return { kind: "invalid" };
+  }
+  const promptStart = boundaryIndex + RESEED_USER_BOUNDARY.length;
+  const closeIndex = text.lastIndexOf(RESEED_USER_CLOSE);
+  if (closeIndex < promptStart) {
+    return { kind: "invalid" };
+  }
+  return {
+    kind: "legacy",
+    userMessage: text.slice(promptStart, closeIndex),
+  };
+}

--- a/src/agents/cli-session.test.ts
+++ b/src/agents/cli-session.test.ts
@@ -3,7 +3,11 @@
  * Verifies provider-keyed bindings, legacy Claude state, and reuse invalidation.
  */
 import { describe, expect, it } from "vitest";
-import type { SessionEntry } from "../config/sessions.js";
+import type { CliSessionReseedReceipt, SessionEntry } from "../config/sessions.js";
+import {
+  normalizeCliSessionReseedReceipt,
+  rebindCliSessionReseedReceiptsForReset,
+} from "../config/sessions/cli-session-binding.js";
 import {
   clearAllCliSessions,
   clearCliSession,
@@ -11,6 +15,7 @@ import {
   hashCliSessionText,
   resolveCliSessionReuse,
   setCliSessionBinding,
+  setCliSessionId,
 } from "./cli-session.js";
 
 describe("cli-session helpers", () => {
@@ -32,6 +37,12 @@ describe("cli-session helpers", () => {
       cwdHash: "cwd-hash",
       mcpConfigHash: "mcp-hash",
       mcpResumeHash: "mcp-resume-hash",
+      reseedReceipt: {
+        version: 1,
+        promptHash: "a".repeat(64),
+        localSessionId: "openclaw-session",
+        userTurnDisposition: "persisted",
+      },
     });
 
     expect(entry.cliSessionIds?.["claude-cli"]).toBe("cli-session-1");
@@ -48,7 +59,126 @@ describe("cli-session helpers", () => {
       cwdHash: "cwd-hash",
       mcpConfigHash: "mcp-hash",
       mcpResumeHash: "mcp-resume-hash",
+      reseedReceipt: {
+        version: 1,
+        promptHash: "a".repeat(64),
+        localSessionId: "openclaw-session",
+        userTurnDisposition: "persisted",
+      },
     });
+  });
+
+  it("drops malformed reseed receipts while preserving the session binding", () => {
+    const entry: SessionEntry = {
+      sessionId: "openclaw-session",
+      updatedAt: Date.now(),
+    };
+
+    setCliSessionBinding(entry, "claude-cli", {
+      sessionId: "cli-session-1",
+      reseedReceipt: {
+        version: 1,
+        promptHash: "not-a-digest",
+        localSessionId: "openclaw-session",
+        userTurnDisposition: "persisted",
+      },
+    });
+
+    expect(getCliSessionBinding(entry, "claude-cli")).toEqual({
+      sessionId: "cli-session-1",
+      authProfileId: undefined,
+      authEpoch: undefined,
+      authEpochVersion: undefined,
+      extraSystemPromptHash: undefined,
+      messageToolPolicyHash: undefined,
+      promptToolNamesHash: undefined,
+      cwdHash: undefined,
+      mcpConfigHash: undefined,
+      mcpResumeHash: undefined,
+      reseedReceipt: undefined,
+    });
+  });
+
+  it("rejects reseed receipts without a local session owner", () => {
+    expect(
+      normalizeCliSessionReseedReceipt({
+        version: 1,
+        promptHash: "a".repeat(64),
+      } as CliSessionReseedReceipt),
+    ).toBeUndefined();
+  });
+
+  it("rejects reseed receipts without a user-turn disposition", () => {
+    expect(
+      normalizeCliSessionReseedReceipt({
+        version: 1,
+        promptHash: "a".repeat(64),
+        localSessionId: "openclaw-session",
+      } as CliSessionReseedReceipt),
+    ).toBeUndefined();
+  });
+
+  it("rebinds only omitted receipts across binding-preserving resets", () => {
+    const bindings = {
+      "claude-cli": {
+        sessionId: "claude-session",
+        reseedReceipt: {
+          version: 1 as const,
+          promptHash: "a".repeat(64),
+          localSessionId: "old-local-session",
+          userTurnDisposition: "omitted" as const,
+        },
+      },
+      "other-cli": {
+        sessionId: "other-session",
+        reseedReceipt: {
+          version: 1 as const,
+          promptHash: "b".repeat(64),
+          localSessionId: "old-local-session",
+          userTurnDisposition: "persisted" as const,
+        },
+      },
+    };
+
+    expect(rebindCliSessionReseedReceiptsForReset(bindings, "new-local-session")).toEqual({
+      "claude-cli": {
+        sessionId: "claude-session",
+        reseedReceipt: {
+          version: 1,
+          promptHash: "a".repeat(64),
+          localSessionId: "new-local-session",
+          userTurnDisposition: "omitted",
+        },
+      },
+      "other-cli": bindings["other-cli"],
+    });
+    expect(bindings["claude-cli"].reseedReceipt.localSessionId).toBe("old-local-session");
+  });
+
+  it("preserves receipts only while updating the same native CLI session", () => {
+    const entry: SessionEntry = {
+      sessionId: "openclaw-session",
+      updatedAt: Date.now(),
+    };
+    const receipt = {
+      version: 1 as const,
+      promptHash: "a".repeat(64),
+      localSessionId: "openclaw-session",
+      userTurnDisposition: "persisted" as const,
+    };
+
+    setCliSessionBinding(entry, "claude-cli", {
+      sessionId: "cli-session-1",
+      reseedReceipt: receipt,
+    });
+    setCliSessionBinding(entry, "claude-cli", { sessionId: "cli-session-1" });
+    expect(getCliSessionBinding(entry, "claude-cli")?.reseedReceipt).toEqual(receipt);
+
+    setCliSessionId(entry, "claude-cli", "cli-session-1");
+    expect(getCliSessionBinding(entry, "claude-cli")?.reseedReceipt).toEqual(receipt);
+
+    setCliSessionBinding(entry, "claude-cli", { sessionId: "cli-session-2" });
+    expect(getCliSessionBinding(entry, "claude-cli")?.reseedReceipt).toBeUndefined();
   });
 
   it("force-reuses explicitly attached CLI sessions despite metadata drift", () => {

--- a/src/agents/cli-session.ts
+++ b/src/agents/cli-session.ts
@@ -7,6 +7,7 @@ import crypto from "node:crypto";
 import { normalizeProviderId } from "@openclaw/model-catalog-core/provider-id";
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import type { CliSessionBinding, SessionEntry } from "../config/sessions.js";
+import { normalizeCliSessionReseedReceipt } from "../config/sessions/cli-session-binding.js";
 export { getCliSessionBinding, getCliSessionId } from "../config/sessions/cli-session-binding.js";
 
 const CLAUDE_CLI_BACKEND_ID = "claude-cli";
@@ -36,6 +37,12 @@ export function setCliSessionBinding(
   if (!trimmed) {
     return;
   }
+  const previousBinding = entry.cliSessionBindings?.[normalized];
+  const previousReceipt =
+    normalizeOptionalString(previousBinding?.sessionId) === trimmed
+      ? normalizeCliSessionReseedReceipt(previousBinding?.reseedReceipt)
+      : undefined;
+  const reseedReceipt = normalizeCliSessionReseedReceipt(binding.reseedReceipt) ?? previousReceipt;
   entry.cliSessionBindings = {
     ...entry.cliSessionBindings,
     [normalized]: {
@@ -68,6 +75,7 @@ export function setCliSessionBinding(
       ...(normalizeOptionalString(binding.mcpResumeHash)
         ? { mcpResumeHash: normalizeOptionalString(binding.mcpResumeHash) }
         : {}),
+      ...(reseedReceipt ? { reseedReceipt } : {}),
     },
   };
   entry.cliSessionIds = { ...entry.cliSessionIds, [normalized]: trimmed };

--- a/src/agents/command/attempt-execution.cli.test.ts
+++ b/src/agents/command/attempt-execution.cli.test.ts
@@ -7,6 +7,7 @@ import type { SessionEntry } from "../../config/sessions.js";
 import { clearSessionStoreCacheForTest } from "../../config/sessions/store.js";
 import { appendSessionTranscriptMessage } from "../../config/sessions/transcript-append.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
+import { createUserTurnTranscriptRecorder } from "../../sessions/user-turn-transcript.js";
 import { captureEnv, setTestEnvValue } from "../../test-utils/env.js";
 import { saveAuthProfileStore } from "../auth-profiles/store.js";
 import type { EmbeddedAgentRunResult } from "../embedded-agent.js";
@@ -214,6 +215,9 @@ describe("CLI attempt execution", () => {
   async function runOpenClawEmbeddedAttemptForTest(overrides?: {
     opts?: Partial<RunAgentAttemptParams["opts"]>;
     runId?: string;
+    body?: string;
+    transcriptBody?: string;
+    userTurnTranscriptRecorder?: RunAgentAttemptParams["userTurnTranscriptRecorder"];
   }) {
     const runId = overrides?.runId ?? "run-embedded-live-stream-gate";
     const sessionKey = `agent:main:direct:${runId}`;
@@ -238,7 +242,8 @@ describe("CLI attempt execution", () => {
       sessionAgentId: "main",
       sessionFile: path.join(tmpDir, `${runId}.jsonl`),
       workspaceDir: tmpDir,
-      body: "stream gate",
+      body: overrides?.body ?? "stream gate",
+      transcriptBody: overrides?.transcriptBody,
       isFallbackRetry: false,
       resolvedThinkLevel: "medium",
       timeoutMs: 1_000,
@@ -258,6 +263,7 @@ describe("CLI attempt execution", () => {
       sessionStore,
       storePath,
       sessionHasHistory: false,
+      userTurnTranscriptRecorder: overrides?.userTurnTranscriptRecorder,
     });
 
     return firstEmbeddedAgentArg();
@@ -1316,6 +1322,52 @@ describe("CLI attempt execution", () => {
     expect(sessionStore[sessionKey]?.updatedAt).toBe(persisted[sessionKey]?.updatedAt);
   });
 
+  it("mirrors only the CLI reply when the shared recorder already persisted the user turn", async () => {
+    const sessionKey = "agent:main:direct:cli-recorder-owned-user";
+    const sessionFile = path.join(tmpDir, "session-cli-recorder-owned-user.jsonl");
+    const sessionEntry: SessionEntry = {
+      sessionId: "session-cli-recorder-owned-user",
+      sessionFile,
+      updatedAt: Date.now(),
+    };
+    const sessionStore: Record<string, SessionEntry> = { [sessionKey]: sessionEntry };
+    await fs.writeFile(storePath, JSON.stringify(sessionStore, null, 2), "utf-8");
+    await appendSessionTranscriptMessage({
+      transcriptPath: sessionFile,
+      sessionId: sessionEntry.sessionId,
+      cwd: tmpDir,
+      config: {},
+      message: {
+        role: "user",
+        content: "canonical current ask",
+        timestamp: Date.now(),
+      },
+    });
+
+    await persistCliTurnTranscript({
+      body: "canonical current ask",
+      result: makeCliResult("hello from cli"),
+      sessionId: sessionEntry.sessionId,
+      sessionKey,
+      sessionEntry,
+      sessionStore,
+      storePath,
+      sessionAgentId: "main",
+      sessionCwd: tmpDir,
+      config: {},
+      skipUserTurn: true,
+    });
+
+    const messages = await readSessionMessages(sessionFile);
+    expect(messages.filter((message) => message.role === "user")).toHaveLength(1);
+    expect(messages).toContainEqual(
+      expect.objectContaining({
+        role: "assistant",
+        content: [{ type: "text", text: "hello from cli" }],
+      }),
+    );
+  });
+
   it("does not append a CLI transcript after the session is deleted", async () => {
     const sessionKey = "agent:main:subagent:cli-transcript-deleted";
     const staleSessionFile = path.join(tmpDir, "session-cli-stale.jsonl");
@@ -1954,6 +2006,16 @@ describe("CLI attempt execution", () => {
     const sessionStore: Record<string, SessionEntry> = { [sessionKey]: sessionEntry };
     await fs.writeFile(storePath, JSON.stringify(sessionStore, null, 2), "utf-8");
     runCliAgentMock.mockResolvedValueOnce(makeCliResult("timestamped cli"));
+    const userTurnTranscriptRecorder = createUserTurnTranscriptRecorder({
+      input: { text: "canonical timestamp question" },
+      target: {
+        transcriptPath: path.join(tmpDir, "session.jsonl"),
+        sessionId: sessionEntry.sessionId,
+        sessionKey,
+        agentId: "main",
+        cwd: tmpDir,
+      },
+    });
 
     await runAgentAttempt({
       providerOverride: "claude-cli",
@@ -1967,6 +2029,7 @@ describe("CLI attempt execution", () => {
       sessionFile: path.join(tmpDir, "session.jsonl"),
       workspaceDir: tmpDir,
       body: "what time is it?",
+      transcriptBody: "canonical timestamp question",
       isFallbackRetry: false,
       resolvedThinkLevel: "medium",
       timeoutMs: 1_000,
@@ -1983,10 +2046,14 @@ describe("CLI attempt execution", () => {
       sessionStore,
       storePath,
       sessionHasHistory: false,
+      userTurnTranscriptRecorder,
     });
 
     expectMockArgFields(runCliAgentMock, {
       prompt: "[Wed 2024-06-05 15:30 UTC] what time is it?",
+      transcriptPrompt: "canonical timestamp question",
+      userTurnTranscriptRecorder,
+      suppressNextUserMessagePersistence: false,
     });
   });
 
@@ -2200,6 +2267,34 @@ describe("CLI attempt execution", () => {
     });
 
     expect(embeddedArg.suppressLiveStreamOutput).toBe(true);
+  });
+
+  it("forwards canonical transcript text without replacing embedded image content", async () => {
+    const recorder = createUserTurnTranscriptRecorder({
+      target: {
+        transcriptPath: path.join(tmpDir, "embedded-image-turn.jsonl"),
+        sessionId: "session-embedded-image-turn",
+        sessionKey: "agent:main:direct:embedded-image-turn",
+        agentId: "main",
+        cwd: tmpDir,
+      },
+    });
+    const images = [{ type: "image" as const, data: "aGVsbG8=", mimeType: "image/png" }];
+    const embeddedArg = await runOpenClawEmbeddedAttemptForTest({
+      runId: "embedded-image-turn",
+      body: "runtime image prompt",
+      transcriptBody: "canonical image caption",
+      opts: { images },
+      userTurnTranscriptRecorder: recorder,
+    });
+
+    expect(embeddedArg).toMatchObject({
+      prompt: "runtime image prompt",
+      transcriptPrompt: "canonical image caption",
+      images,
+      userTurnTranscriptRecorder: recorder,
+      suppressNextUserMessagePersistence: false,
+    });
   });
 
   it("forwards selected auth profiles through metadata-scoped provider aliases", async () => {

--- a/src/agents/command/attempt-execution.ts
+++ b/src/agents/command/attempt-execution.ts
@@ -25,6 +25,7 @@ import { annotateInterSessionPromptText } from "../../sessions/input-provenance.
 import {
   preparePersistedUserTurnMessageForTranscriptWrite,
   type PersistedUserTurnMessage,
+  type UserTurnTranscriptRecorder,
 } from "../../sessions/user-turn-transcript.js";
 import { buildWorkspaceSkillSnapshot } from "../../skills/loading/workspace.js";
 import { resolveUserPath } from "../../utils.js";
@@ -434,16 +435,18 @@ export async function persistCliTurnTranscript(params: {
   sessionCwd: string;
   config: OpenClawConfig;
   embeddedAssistantGapFill?: boolean;
+  skipUserTurn?: boolean;
 }): Promise<PersistTextTurnTranscriptResult> {
   const replyText = resolveCliTranscriptReplyText(params.result);
   const provider = params.result.meta.agentMeta?.provider?.trim() ?? "cli";
   const model = params.result.meta.agentMeta?.model?.trim() ?? "default";
   const gapFill = params.embeddedAssistantGapFill ?? false;
+  const skipUserTurn = gapFill || params.skipUserTurn === true;
 
   return await persistTextTurnTranscript({
-    body: gapFill ? "" : params.body,
-    transcriptBody: gapFill ? undefined : params.transcriptBody,
-    ...(!gapFill && params.userMessage ? { userMessage: params.userMessage } : {}),
+    body: skipUserTurn ? "" : params.body,
+    transcriptBody: skipUserTurn ? undefined : params.transcriptBody,
+    ...(!skipUserTurn && params.userMessage ? { userMessage: params.userMessage } : {}),
     finalText: replyText,
     sessionId: params.sessionId,
     sessionKey: params.sessionKey,
@@ -477,6 +480,7 @@ export function runAgentAttempt(params: {
   workspaceDir: string;
   cwd?: string;
   body: string;
+  transcriptBody?: string;
   isFallbackRetry: boolean;
   resolvedThinkLevel: ThinkLevel;
   fastMode?: FastMode;
@@ -511,6 +515,7 @@ export function runAgentAttempt(params: {
   modelFallbacksOverride?: string[];
   sessionHasHistory?: boolean;
   suppressPromptPersistenceOnRetry?: boolean;
+  userTurnTranscriptRecorder?: UserTurnTranscriptRecorder;
   onUserMessagePersisted?: (message: Extract<AgentMessage, { role: "user" }>) => void;
   onLifecycleGenerationChanged?: (lifecycleGeneration: string) => void;
 }) {
@@ -672,6 +677,7 @@ export function runAgentAttempt(params: {
         cwd: params.cwd,
         config: params.cfg,
         prompt: cliPrompt,
+        transcriptPrompt: params.transcriptBody,
         provider: cliExecutionProvider,
         model: params.modelOverride,
         thinkLevel: params.resolvedThinkLevel,
@@ -711,6 +717,8 @@ export function runAgentAttempt(params: {
         cleanupBundleMcpOnRunEnd: params.opts.cleanupBundleMcpOnRunEnd,
         cleanupCliLiveSessionOnRunEnd: params.opts.cleanupCliLiveSessionOnRunEnd,
         oneShotCliRun: params.opts.oneShotCliRun,
+        userTurnTranscriptRecorder: params.userTurnTranscriptRecorder,
+        suppressNextUserMessagePersistence: params.suppressPromptPersistenceOnRetry === true,
         ...(mutableCliSessionStore
           ? {
               onBeforeFreshCliSessionRetry: async (retry) => {
@@ -788,6 +796,7 @@ export function runAgentAttempt(params: {
     agentHarnessRuntimeOverride: embeddedAgentHarnessOverride,
     skillsSnapshot: params.skillsSnapshot,
     prompt: effectivePrompt,
+    transcriptPrompt: params.transcriptBody,
     images: params.isFallbackRetry ? undefined : params.opts.images,
     imageOrder: params.isFallbackRetry ? undefined : params.opts.imageOrder,
     clientTools: params.opts.clientTools,
@@ -833,6 +842,7 @@ export function runAgentAttempt(params: {
     deferTerminalLifecycle: params.deferTerminalLifecycle,
     deferTerminalLifecycleEnd: params.deferTerminalLifecycleEnd,
     suppressNextUserMessagePersistence: params.suppressPromptPersistenceOnRetry === true,
+    userTurnTranscriptRecorder: params.userTurnTranscriptRecorder,
     onUserMessagePersisted: params.onUserMessagePersisted,
     onExecutionStarted: (info) => {
       if (info?.lifecycleGeneration) {

--- a/src/agents/embedded-agent-runner/run/attempt.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.ts
@@ -2251,6 +2251,9 @@ export async function runEmbeddedAttempt(
         onUserMessagePersisted: (message) => {
           params.onUserMessagePersisted?.(message);
         },
+        onUserMessageBlocked: () => {
+          params.userTurnTranscriptRecorder?.markBlocked();
+        },
         onAssistantErrorMessagePersisted: (message) => {
           params.onAssistantErrorMessagePersisted?.(message);
         },

--- a/src/agents/session-tool-result-guard-wrapper.ts
+++ b/src/agents/session-tool-result-guard-wrapper.ts
@@ -48,6 +48,7 @@ export function guardSessionManager(
     onUserMessagePersisted?: (
       message: Extract<AgentMessage, { role: "user" }>,
     ) => void | Promise<void>;
+    onUserMessageBlocked?: (message: Extract<AgentMessage, { role: "user" }>) => void;
     onMessagePersisted?: (message: AgentMessage) => void | Promise<void>;
     withCompactionPersistence?: (
       append: () => string,
@@ -146,6 +147,7 @@ export function guardSessionManager(
     onMessagePersisted: opts?.onMessagePersisted,
     withCompactionPersistence: opts?.withCompactionPersistence,
     onUserMessagePersisted: opts?.onUserMessagePersisted,
+    onUserMessageBlocked: opts?.onUserMessageBlocked,
     onAssistantErrorMessagePersisted: opts?.onAssistantErrorMessagePersisted,
   });
   (sessionManager as GuardedSessionManager).flushPendingToolResults = guard.flushPendingToolResults;

--- a/src/agents/session-tool-result-guard.test.ts
+++ b/src/agents/session-tool-result-guard.test.ts
@@ -457,8 +457,12 @@ describe("installSessionToolResultGuard", () => {
 
   it("blocks persistence when before_message_write returns block=true", () => {
     const sm = SessionManager.inMemory();
+    const blockedUserMessages: AgentMessage[] = [];
     installSessionToolResultGuard(sm, {
       beforeMessageWriteHook: () => ({ block: true }),
+      onUserMessageBlocked: (message) => {
+        blockedUserMessages.push(message);
+      },
     });
 
     sm.appendMessage(
@@ -470,6 +474,8 @@ describe("installSessionToolResultGuard", () => {
     );
 
     expect(getPersistedMessages(sm)).toHaveLength(0);
+    expect(blockedUserMessages).toHaveLength(1);
+    expect(blockedUserMessages[0]).toMatchObject({ role: "user", content: "hidden" });
   });
 
   it("applies before_message_write message mutations before persistence", () => {

--- a/src/agents/session-tool-result-guard.ts
+++ b/src/agents/session-tool-result-guard.ts
@@ -609,6 +609,7 @@ export function installSessionToolResultGuard(
     onUserMessagePersisted?: (
       message: Extract<AgentMessage, { role: "user" }>,
     ) => void | Promise<void>;
+    onUserMessageBlocked?: (message: Extract<AgentMessage, { role: "user" }>) => void;
     onMessagePersisted?: (message: AgentMessage) => void | Promise<void>;
     withCompactionPersistence?: (
       append: () => string,
@@ -838,6 +839,9 @@ export function installSessionToolResultGuard(
     const transformedMessage = persistMessage(nextMessage);
     const finalWrite = applyBeforeWriteHook(transformedMessage);
     if (!finalWrite) {
+      if (isUserAgentMessage(transformedMessage)) {
+        opts?.onUserMessageBlocked?.(transformedMessage);
+      }
       return undefined;
     }
     const finalMessage = finalWrite.message;

--- a/src/config/sessions/cli-session-binding.ts
+++ b/src/config/sessions/cli-session-binding.ts
@@ -1,9 +1,65 @@
 // CLI session binding lookup shared by session lifecycle and agent runtime code.
 import { normalizeProviderId } from "@openclaw/model-catalog-core/provider-id";
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
-import type { CliSessionBinding, SessionEntry } from "./types.js";
+import type { CliSessionBinding, CliSessionReseedReceipt, SessionEntry } from "./types.js";
 
 const CLAUDE_CLI_BACKEND_ID = "claude-cli";
+const SHA256_HEX_PATTERN = /^[a-f0-9]{64}$/;
+
+export function normalizeCliSessionReseedReceipt(
+  value: CliSessionReseedReceipt | undefined,
+): CliSessionReseedReceipt | undefined {
+  const promptHash = normalizeOptionalString(value?.promptHash);
+  const localSessionId = normalizeOptionalString(value?.localSessionId);
+  const userTurnDisposition = value?.userTurnDisposition;
+  if (
+    value?.version !== 1 ||
+    !promptHash ||
+    !SHA256_HEX_PATTERN.test(promptHash) ||
+    !localSessionId ||
+    (userTurnDisposition !== "persisted" && userTurnDisposition !== "omitted")
+  ) {
+    return undefined;
+  }
+  return {
+    version: 1,
+    promptHash,
+    localSessionId,
+    userTurnDisposition,
+  };
+}
+
+/**
+ * Re-own omitted reseed receipts when a reset intentionally preserves the
+ * native CLI conversation. Persisted turns keep their old owner and fail open
+ * because their canonical user row belongs to the archived local transcript.
+ */
+export function rebindCliSessionReseedReceiptsForReset(
+  bindings: Record<string, CliSessionBinding> | undefined,
+  localSessionId: string,
+): Record<string, CliSessionBinding> | undefined {
+  const normalizedLocalSessionId = normalizeOptionalString(localSessionId);
+  if (!bindings || !normalizedLocalSessionId) {
+    return bindings;
+  }
+
+  let rebound: Record<string, CliSessionBinding> | undefined;
+  for (const [provider, binding] of Object.entries(bindings)) {
+    const receipt = normalizeCliSessionReseedReceipt(binding.reseedReceipt);
+    if (!receipt || receipt.userTurnDisposition !== "omitted") {
+      continue;
+    }
+    rebound ??= { ...bindings };
+    rebound[provider] = {
+      ...binding,
+      reseedReceipt: {
+        ...receipt,
+        localSessionId: normalizedLocalSessionId,
+      },
+    };
+  }
+  return rebound ?? bindings;
+}
 
 /** Read the stored CLI session binding for a provider, including legacy Claude state. */
 export function getCliSessionBinding(
@@ -29,6 +85,7 @@ export function getCliSessionBinding(
       cwdHash: normalizeOptionalString(fromBindings?.cwdHash),
       mcpConfigHash: normalizeOptionalString(fromBindings?.mcpConfigHash),
       mcpResumeHash: normalizeOptionalString(fromBindings?.mcpResumeHash),
+      reseedReceipt: normalizeCliSessionReseedReceipt(fromBindings?.reseedReceipt),
     };
   }
   const fromMap = entry.cliSessionIds?.[normalized];

--- a/src/config/sessions/types.ts
+++ b/src/config/sessions/types.ts
@@ -43,6 +43,13 @@ export type {
   SessionAcpMeta,
 };
 
+export type CliSessionReseedReceipt = {
+  version: 1;
+  promptHash: string;
+  localSessionId: string;
+  userTurnDisposition: "persisted" | "omitted";
+};
+
 export type CliSessionBinding = {
   sessionId: string;
   /** Trust an explicitly attached CLI session even when auth, prompt, or MCP fingerprints drift. */
@@ -56,6 +63,8 @@ export type CliSessionBinding = {
   cwdHash?: string;
   mcpConfigHash?: string;
   mcpResumeHash?: string;
+  /** Identifies one synthetic history prompt and the trusted local handling of its user turn. */
+  reseedReceipt?: CliSessionReseedReceipt;
 };
 
 export type SessionCompactionCheckpointReason =

--- a/src/cron/isolated-agent/run-execution-cli.runtime.ts
+++ b/src/cron/isolated-agent/run-execution-cli.runtime.ts
@@ -1,2 +1,6 @@
 // Heavy CLI-agent runtime imports kept behind the cron execution lazy boundary.
-export { getCliSessionId, runCliAgent } from "../../agents/cli-runner.runtime.js";
+export {
+  getCliSessionBinding,
+  getCliSessionId,
+  runCliAgent,
+} from "../../agents/cli-runner.runtime.js";

--- a/src/cron/isolated-agent/run-execution.runtime.ts
+++ b/src/cron/isolated-agent/run-execution.runtime.ts
@@ -31,6 +31,14 @@ export async function getCliSessionId(
   return runtime.getCliSessionId(...args);
 }
 
+/** Lazily resolves complete CLI bindings so cron continuations preserve reuse metadata. */
+export async function getCliSessionBinding(
+  ...args: Parameters<typeof import("../../agents/cli-session.js").getCliSessionBinding>
+): Promise<ReturnType<typeof import("../../agents/cli-session.js").getCliSessionBinding>> {
+  const runtime = await loadCronExecutionCliRuntime();
+  return runtime.getCliSessionBinding(...args);
+}
+
 /** Lazily runs the CLI-backed agent path used by isolated cron execution. */
 export async function runCliAgent(
   ...args: Parameters<typeof import("../../agents/cli-runner.js").runCliAgent>

--- a/src/cron/isolated-agent/run-executor.ts
+++ b/src/cron/isolated-agent/run-executor.ts
@@ -3,13 +3,19 @@ import { createHash } from "node:crypto";
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import type { BootstrapContextMode } from "../../agents/bootstrap-files.js";
 import type { FastModeAutoProgressState } from "../../agents/fast-mode.js";
+import { runAgentHarnessBeforeMessageWriteHook } from "../../agents/harness/hook-helpers.js";
 import { resolveCliRuntimeExecutionProvider } from "../../agents/model-runtime-aliases.js";
 import { wrapUntrustedPromptDataBlock } from "../../agents/sanitize-for-prompt.js";
 import { normalizeToolName } from "../../agents/tool-policy.js";
 import type { ThinkLevel, VerboseLevel } from "../../auto-reply/thinking.js";
+import type { CliSessionBinding } from "../../config/sessions.js";
 import type { AgentDefaultsConfig } from "../../config/types.agent-defaults.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import type { SourceDeliveryPlan } from "../../infra/outbound/source-delivery-plan.js";
+import {
+  createUserTurnTranscriptRecorder,
+  type UserTurnTranscriptRecorder,
+} from "../../sessions/user-turn-transcript.js";
 import { createLazyImportLoader } from "../../shared/lazy-promise.js";
 import type { SkillSnapshot } from "../../skills/types.js";
 import type { CronAgentExecutionPhaseUpdate, CronJob } from "../types.js";
@@ -19,8 +25,8 @@ import {
 } from "./channel-output-policy.js";
 import { resolveCronPayloadOutcome } from "./helpers.js";
 import {
-  getCliSessionId,
   ensureSelectedAgentHarnessPlugin,
+  getCliSessionBinding,
   isCliProvider,
   LiveSessionModelSwitchError,
   logWarn,
@@ -60,6 +66,10 @@ async function loadCronEmbeddedRuntime() {
 
 async function loadCronSubagentRegistryRuntime() {
   return await cronSubagentRegistryRuntimeLoader.load();
+}
+
+function hasCliSessionReuseMetadata(binding: CliSessionBinding): boolean {
+  return Object.entries(binding).some(([key, value]) => key !== "sessionId" && value !== undefined);
 }
 
 const COMMAND_STYLE_CRON_PREFIX =
@@ -278,8 +288,31 @@ export function createCronPromptExecutor(params: {
     resolvedDelivery: params.resolvedDelivery,
     sourceDelivery,
   });
+  let pendingUserTurn:
+    | {
+        promptText: string;
+        recorder: UserTurnTranscriptRecorder;
+      }
+    | undefined;
 
   const runPrompt = async (promptText: string) => {
+    const userTurnTranscriptRecorder =
+      pendingUserTurn?.promptText === promptText
+        ? pendingUserTurn.recorder
+        : createUserTurnTranscriptRecorder({
+            input: { text: promptText },
+            target: {
+              transcriptPath: sessionFile,
+              sessionId: params.cronSession.sessionEntry.sessionId,
+              agentId: params.agentId,
+              sessionKey: params.runSessionKey,
+              cwd: params.workspaceDir,
+              config: params.cfgWithAgentDefaults,
+            },
+            beforeMessageWrite: runAgentHarnessBeforeMessageWriteHook,
+            errorContext: "cron user turn transcript",
+          });
+    pendingUserTurn = { promptText, recorder: userTurnTranscriptRecorder };
     const modelPrompt = deliveryTargetRuntimeContext
       ? `${promptText}\n\n${deliveryTargetRuntimeContext}`.trim()
       : promptText;
@@ -322,9 +355,13 @@ export function createCronPromptExecutor(params: {
         // CLI providers can resume provider-native sessions; embedded providers
         // use OpenClaw's transcript/session file plus prompt-cache affinity.
         if (isCliProvider(executionProvider, params.cfgWithAgentDefaults)) {
-          const cliSessionId = params.cronSession.isNewSession
+          const cliSessionBinding = params.cronSession.isNewSession
             ? undefined
-            : await getCliSessionId(params.cronSession.sessionEntry, executionProvider);
+            : await getCliSessionBinding(params.cronSession.sessionEntry, executionProvider);
+          const guardedCliSessionBinding =
+            cliSessionBinding && hasCliSessionReuseMetadata(cliSessionBinding)
+              ? cliSessionBinding
+              : undefined;
           const result = await runCliAgent({
             sessionId: params.cronSession.sessionEntry.sessionId,
             sessionKey: params.runSessionKey,
@@ -344,7 +381,8 @@ export function createCronPromptExecutor(params: {
             timeoutMs: params.timeoutMs,
             runId: params.cronSession.sessionEntry.sessionId,
             lane: resolveCronAgentLane(params.lane),
-            cliSessionId,
+            cliSessionId: cliSessionBinding?.sessionId,
+            cliSessionBinding: guardedCliSessionBinding,
             skillsSnapshot: params.skillsSnapshot,
             messageChannel,
             sourceReplyDeliveryMode,
@@ -363,6 +401,9 @@ export function createCronPromptExecutor(params: {
             fastModeStartedAtMs,
             fastModeAutoProgressState,
             isFinalFallbackAttempt: runOptions?.isFinalFallbackAttempt,
+            userTurnTranscriptRecorder,
+            suppressNextUserMessagePersistence:
+              userTurnTranscriptRecorder.hasPersisted() || userTurnTranscriptRecorder.isBlocked(),
           });
           bootstrapPromptWarningSignaturesSeen = resolveBootstrapWarningSignaturesSeen(
             result.meta?.systemPromptReport,
@@ -457,6 +498,9 @@ export function createCronPromptExecutor(params: {
           onLaneWait: params.onLaneWait,
           bootstrapPromptWarningSignaturesSeen,
           bootstrapPromptWarningSignature,
+          userTurnTranscriptRecorder,
+          suppressNextUserMessagePersistence:
+            userTurnTranscriptRecorder.hasPersisted() || userTurnTranscriptRecorder.isBlocked(),
         });
         bootstrapPromptWarningSignaturesSeen = resolveBootstrapWarningSignaturesSeen(
           result.meta?.systemPromptReport,
@@ -470,6 +514,7 @@ export function createCronPromptExecutor(params: {
     params.liveSelection.provider = fallbackResult.provider;
     params.liveSelection.model = fallbackResult.model;
     runEndedAt = Date.now();
+    pendingUserTurn = undefined;
   };
 
   return {

--- a/src/cron/isolated-agent/run.cron-model-override-forwarding.test.ts
+++ b/src/cron/isolated-agent/run.cron-model-override-forwarding.test.ts
@@ -3,7 +3,7 @@ import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import {
   clearCliSessionMock,
   clearFastTestEnv,
-  getCliSessionIdMock,
+  getCliSessionBindingMock,
   isCliProviderMock,
   loadRunCronIsolatedAgentTurn,
   makeCronSession,
@@ -20,6 +20,7 @@ import {
   restoreFastTestEnv,
   runEmbeddedAgentMock,
   runWithModelFallbackMock,
+  setCliSessionBindingMock,
   updateSessionStoreMock,
   runCliAgentMock,
 } from "./run.test-harness.js";
@@ -237,8 +238,19 @@ describe("runCronIsolatedAgentTurn — cron model override forwarding (#58065)",
       }),
     );
     const getCliSessionStarted = createDeferred();
-    const releaseCliSessionLookup = createDeferred<string | undefined>();
-    getCliSessionIdMock.mockImplementation(async () => {
+    const releaseCliSessionLookup = createDeferred<
+      | {
+          sessionId: string;
+          reseedReceipt: {
+            version: 1;
+            promptHash: string;
+            localSessionId: string;
+            userTurnDisposition: "persisted" | "omitted";
+          };
+        }
+      | undefined
+    >();
+    getCliSessionBindingMock.mockImplementation(async () => {
       getCliSessionStarted.resolve();
       return await releaseCliSessionLookup.promise;
     });
@@ -271,12 +283,22 @@ describe("runCronIsolatedAgentTurn — cron model override forwarding (#58065)",
       }),
     ).toBe(false);
 
-    releaseCliSessionLookup.resolve("previous-cli-session");
+    const cliSessionBinding = {
+      sessionId: "previous-cli-session",
+      reseedReceipt: {
+        version: 1 as const,
+        promptHash: "a".repeat(64),
+        localSessionId: "openclaw-session",
+        userTurnDisposition: "persisted" as const,
+      },
+    };
+    releaseCliSessionLookup.resolve(cliSessionBinding);
     const result = await runPromise;
 
     expect(result.status).toBe("ok");
     const cliCall = firstMockArg(runCliAgentMock);
     expect(cliCall.cliSessionId).toBe("previous-cli-session");
+    expect(cliCall.cliSessionBinding).toEqual(cliSessionBinding);
     expect(typeof cliCall.onExecutionPhase).toBe("function");
     expect(
       hasPhaseWithFields(phases, {
@@ -323,6 +345,53 @@ describe("runCronIsolatedAgentTurn — cron model override forwarding (#58065)",
 
     expect(result.status).toBe("ok");
     expect(clearCliSessionMock).toHaveBeenCalledWith(cronSession.sessionEntry, "claude-cli");
+  });
+
+  it("persists complete CLI bindings after cron runs", async () => {
+    isCliProviderMock.mockReturnValue(true);
+    runWithModelFallbackMock.mockImplementation(async ({ provider, model, run }) => {
+      const result = await run(provider, model);
+      return { result, provider, model, attempts: [] };
+    });
+    const cronSession = makeCronSession({
+      sessionEntry: makeCronSessionEntry(),
+      isNewSession: false,
+    });
+    resolveCronSessionMock.mockReturnValue(cronSession);
+    const cliSessionBinding = {
+      sessionId: "fresh-cli-session",
+      reseedReceipt: {
+        version: 1 as const,
+        promptHash: "a".repeat(64),
+        localSessionId: cronSession.sessionEntry.sessionId,
+        userTurnDisposition: "persisted",
+      },
+    };
+    runCliAgentMock.mockResolvedValueOnce({
+      payloads: [{ text: "summary done" }],
+      meta: {
+        agentMeta: {
+          provider: "claude-cli",
+          model: "claude-opus-4-6",
+          sessionId: "fresh-cli-session",
+          cliSessionBinding,
+          usage: { input: 10, output: 20 },
+        },
+      },
+    });
+
+    const result = await runCronIsolatedAgentTurn(
+      makeParams({
+        job: makeJob({ sessionTarget: "session:existing-cron-session" }),
+      }),
+    );
+
+    expect(result.status).toBe("ok");
+    expect(setCliSessionBindingMock).toHaveBeenCalledWith(
+      cronSession.sessionEntry,
+      "claude-cli",
+      cliSessionBinding,
+    );
   });
 
   it("validates cron thinking with catalog reasoning metadata", async () => {

--- a/src/cron/isolated-agent/run.interim-retry.test.ts
+++ b/src/cron/isolated-agent/run.interim-retry.test.ts
@@ -17,8 +17,22 @@ import {
 
 const runCronIsolatedAgentTurn = await loadRunCronIsolatedAgentTurn();
 
-function requireEmbeddedAgentCall(index: number): { prompt?: string } {
-  const call = runEmbeddedAgentMock.mock.calls[index]?.[0] as { prompt?: string } | undefined;
+function requireEmbeddedAgentCall(index: number): {
+  prompt?: string;
+  suppressNextUserMessagePersistence?: boolean;
+  userTurnTranscriptRecorder?: {
+    markRuntimePersisted: (message: { role: "user"; content: string }) => void;
+  };
+} {
+  const call = runEmbeddedAgentMock.mock.calls[index]?.[0] as
+    | {
+        prompt?: string;
+        suppressNextUserMessagePersistence?: boolean;
+        userTurnTranscriptRecorder?: {
+          markRuntimePersisted: (message: { role: "user"; content: string }) => void;
+        };
+      }
+    | undefined;
   if (!call) {
     throw new Error(`Expected embedded OpenClaw agent call ${index}`);
   }
@@ -69,24 +83,39 @@ describe("runCronIsolatedAgentTurn — interim ack retry", () => {
   it("regression, retries once when cron returns interim acknowledgement and no descendants were spawned", async () => {
     usePayloadTextExtraction();
     runEmbeddedAgentMock
+      .mockImplementationOnce(async (request) => {
+        request.userTurnTranscriptRecorder?.markRuntimePersisted({
+          role: "user",
+          content: "test",
+        });
+        return {
+          payloads: [
+            {
+              text: "On it, grabbing current SF and SD weather now and I will summarize right after both come back.",
+            },
+          ],
+          meta: { agentMeta: { usage: { input: 10, output: 20 } } },
+        };
+      })
       .mockResolvedValueOnce({
         payloads: [
           {
-            text: "On it, grabbing current SF and SD weather now and I will summarize right after both come back.",
+            text: "SF is 62F and SD is 67F. SD is warmer by 5F.",
           },
         ],
-        meta: { agentMeta: { usage: { input: 10, output: 20 } } },
-      })
-      .mockResolvedValueOnce({
-        payloads: [{ text: "SF is 62F and SD is 67F. SD is warmer by 5F." }],
         meta: { agentMeta: { usage: { input: 10, output: 20 } } },
       });
 
     mockRunCronFallbackPassthrough();
     await runTurnAndExpectOk(2, 2);
-    expect(requireEmbeddedAgentCall(1).prompt).toContain(
-      "previous response was only an acknowledgement",
+    const firstCall = requireEmbeddedAgentCall(0);
+    const continuationCall = requireEmbeddedAgentCall(1);
+    expect(continuationCall.prompt).toContain("previous response was only an acknowledgement");
+    expect(continuationCall.userTurnTranscriptRecorder).not.toBe(
+      firstCall.userTurnTranscriptRecorder,
     );
+    expect(firstCall.suppressNextUserMessagePersistence).toBe(false);
+    expect(continuationCall.suppressNextUserMessagePersistence).toBe(false);
   });
 
   it("does not retry when the first turn is already a concrete result", async () => {

--- a/src/cron/isolated-agent/run.live-session-model-switch.test.ts
+++ b/src/cron/isolated-agent/run.live-session-model-switch.test.ts
@@ -71,6 +71,10 @@ function requireEmbeddedAgentCall(index: number): {
   model?: string;
   authProfileId?: string;
   authProfileIdSource?: string;
+  suppressNextUserMessagePersistence?: boolean;
+  userTurnTranscriptRecorder?: {
+    markRuntimePersisted: (message: { role: "user"; content: string }) => void;
+  };
 } {
   const call = runEmbeddedAgentMock.mock.calls[index]?.[0] as
     | {
@@ -78,6 +82,10 @@ function requireEmbeddedAgentCall(index: number): {
         model?: string;
         authProfileId?: string;
         authProfileIdSource?: string;
+        suppressNextUserMessagePersistence?: boolean;
+        userTurnTranscriptRecorder?: {
+          markRuntimePersisted: (message: { role: "user"; content: string }) => void;
+        };
       }
     | undefined;
   if (!call) {
@@ -203,14 +211,18 @@ describe("runCronIsolatedAgentTurn — LiveSessionModelSwitchError retry (#57206
       attempts: [],
     }));
     runEmbeddedAgentMock
-      .mockRejectedValueOnce(
-        new LiveSessionModelSwitchError({
+      .mockImplementationOnce(async (request) => {
+        request.userTurnTranscriptRecorder?.markRuntimePersisted({
+          role: "user",
+          content: "run task",
+        });
+        throw new LiveSessionModelSwitchError({
           provider: "anthropic",
           model: "claude-sonnet-4-6",
           authProfileId: "profile-b",
           authProfileIdSource: "user",
-        }),
-      )
+        });
+      })
       .mockResolvedValueOnce({
         payloads: [{ text: "task complete" }],
         meta: {
@@ -231,6 +243,10 @@ describe("runCronIsolatedAgentTurn — LiveSessionModelSwitchError retry (#57206
     expect(retryParams.model).toBe("claude-sonnet-4-6");
     expect(retryParams.authProfileId).toBe("profile-b");
     expect(retryParams.authProfileIdSource).toBe("user");
+    const firstParams = requireEmbeddedAgentCall(0);
+    expect(retryParams.userTurnTranscriptRecorder).toBe(firstParams.userTurnTranscriptRecorder);
+    expect(firstParams.suppressNextUserMessagePersistence).toBe(false);
+    expect(retryParams.suppressNextUserMessagePersistence).toBe(true);
     expect(cronSession.sessionEntry.authProfileOverride).toBe("profile-b");
     expect(cronSession.sessionEntry.authProfileOverrideSource).toBe("user");
   });

--- a/src/cron/isolated-agent/run.payload-fallbacks.test.ts
+++ b/src/cron/isolated-agent/run.payload-fallbacks.test.ts
@@ -108,9 +108,12 @@ describe("runCronIsolatedAgentTurn — payload.fallbacks", () => {
       provider: "anthropic",
       model: "claude-opus-4-6",
     });
-    runCliAgentMock.mockResolvedValue({
-      payloads: [{ text: "fallback ok" }],
-      meta: { agentMeta: {} },
+    runCliAgentMock.mockImplementation(async (request) => {
+      request.userTurnTranscriptRecorder?.markBlocked();
+      return {
+        payloads: [{ text: "fallback ok" }],
+        meta: { agentMeta: {} },
+      };
     });
     runWithModelFallbackMock.mockImplementation(async ({ provider, model, run }) => {
       const firstResult = await run(provider, model);
@@ -151,6 +154,14 @@ describe("runCronIsolatedAgentTurn — payload.fallbacks", () => {
       ["claude-cli", "claude-opus-4-6"],
       ["claude-cli", "claude-sonnet-4-6"],
     ]);
+    const firstCliRequest = runCliAgentMock.mock.calls[0]?.[0];
+    const secondCliRequest = runCliAgentMock.mock.calls[1]?.[0];
+    expect(firstCliRequest?.userTurnTranscriptRecorder).toBeDefined();
+    expect(secondCliRequest?.userTurnTranscriptRecorder).toBe(
+      firstCliRequest?.userTurnTranscriptRecorder,
+    );
+    expect(firstCliRequest?.suppressNextUserMessagePersistence).toBe(false);
+    expect(secondCliRequest?.suppressNextUserMessagePersistence).toBe(true);
   });
 
   it("forwards subagent fallbacks into the embedded runner for internal failover decisions", async () => {

--- a/src/cron/isolated-agent/run.skill-filter.test.ts
+++ b/src/cron/isolated-agent/run.skill-filter.test.ts
@@ -5,7 +5,7 @@ import { setupRunCronIsolatedAgentTurnSuite } from "./run.suite-helpers.js";
 import {
   buildWorkspaceSkillSnapshotMock,
   dispatchCronDeliveryMock,
-  getCliSessionIdMock,
+  getCliSessionBindingMock,
   isCliProviderMock,
   lookupContextTokensMock,
   loadRunCronIsolatedAgentTurn,
@@ -336,7 +336,7 @@ describe("runCronIsolatedAgentTurn — skill filter", () => {
 
     it("does not pass stored cliSessionId on fresh isolated runs (isNewSession=true)", async () => {
       // Simulate a persisted CLI session ID from a previous run.
-      getCliSessionIdMock.mockReturnValue("prev-cli-session-abc");
+      getCliSessionBindingMock.mockReturnValue({ sessionId: "prev-cli-session-abc" });
       isCliProviderMock.mockReturnValue(true);
       runCliAgentMock.mockResolvedValue({
         payloads: [{ text: "output" }],
@@ -367,7 +367,7 @@ describe("runCronIsolatedAgentTurn — skill filter", () => {
     });
 
     it("reuses stored cliSessionId on continuation runs (isNewSession=false)", async () => {
-      getCliSessionIdMock.mockReturnValue("existing-cli-session-def");
+      getCliSessionBindingMock.mockReturnValue({ sessionId: "existing-cli-session-def" });
       isCliProviderMock.mockReturnValue(true);
       runCliAgentMock.mockResolvedValue({
         payloads: [{ text: "output" }],

--- a/src/cron/isolated-agent/run.test-harness.ts
+++ b/src/cron/isolated-agent/run.test-harness.ts
@@ -57,8 +57,10 @@ export const runWithModelFallbackMock = createMock();
 export const runEmbeddedAgentMock = createMock();
 export const runCliAgentMock = createMock();
 export const lookupContextTokensMock = createMock();
+export const getCliSessionBindingMock = createMock();
 export const getCliSessionIdMock = createMock();
 export const clearCliSessionMock = createMock();
+export const setCliSessionBindingMock = createMock();
 export const updateSessionStoreMock = createMock();
 export const resolveCronSessionMock = createMock();
 export const logWarnMock = createMock();
@@ -239,6 +241,7 @@ vi.mock("./run-execution.runtime.js", () => ({
   resolveEffectiveModelFallbacks: resolveEffectiveModelFallbacksMock,
   resolveSubagentModelFallbacksOverride: resolveSubagentModelFallbacksOverrideMock,
   resolveBootstrapWarningSignaturesSeen: resolveBootstrapWarningSignaturesSeenMock,
+  getCliSessionBinding: getCliSessionBindingMock,
   getCliSessionId: getCliSessionIdMock,
   runCliAgent: runCliAgentMock,
   resolveFastModeState: resolveFastModeStateMock,
@@ -296,6 +299,7 @@ vi.mock("./run-subagent-registry.runtime.js", () => ({
 
 vi.mock("../../agents/cli-runner.runtime.js", () => ({
   clearCliSession: clearCliSessionMock,
+  setCliSessionBinding: setCliSessionBindingMock,
   setCliSessionId: vi.fn(),
 }));
 
@@ -517,6 +521,8 @@ function resetRunExecutionMocks(): void {
   runEmbeddedAgentMock.mockResolvedValue(makeDefaultEmbeddedResult());
   runCliAgentMock.mockReset();
   clearCliSessionMock.mockReset();
+  setCliSessionBindingMock.mockReset();
+  getCliSessionBindingMock.mockReturnValue(undefined);
   getCliSessionIdMock.mockReturnValue(undefined);
   countActiveDescendantRunsMock.mockReset();
   countActiveDescendantRunsMock.mockReturnValue(0);

--- a/src/cron/isolated-agent/run.ts
+++ b/src/cron/isolated-agent/run.ts
@@ -1049,10 +1049,14 @@ async function finalizeCronRun(params: {
     });
     prepared.cronSession.sessionEntry.contextTokens = contextTokens;
     if (isCliProvider(providerUsed, prepared.cfgWithAgentDefaults)) {
+      const cliSessionBinding = finalRunResult.meta?.agentMeta?.cliSessionBinding;
       const cliSessionId = finalRunResult.meta?.agentMeta?.sessionId?.trim();
       if (finalRunResult.meta?.agentMeta?.clearCliSessionBinding === true) {
         const { clearCliSession } = await loadCliRunnerRuntime();
         clearCliSession(prepared.cronSession.sessionEntry, providerUsed);
+      } else if (cliSessionBinding?.sessionId?.trim()) {
+        const { setCliSessionBinding } = await loadCliRunnerRuntime();
+        setCliSessionBinding(prepared.cronSession.sessionEntry, providerUsed, cliSessionBinding);
       } else if (cliSessionId) {
         const { setCliSessionId } = await loadCliRunnerRuntime();
         setCliSessionId(prepared.cronSession.sessionEntry, providerUsed, cliSessionId);

--- a/src/gateway/cli-session-history.claude.ts
+++ b/src/gateway/cli-session-history.claude.ts
@@ -5,13 +5,18 @@ import os from "node:os";
 import path from "node:path";
 import { asFiniteNumber } from "@openclaw/normalization-core/number-coercion";
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
+import { hashCliReseedPrompt, parseCliReseedPrompt } from "../agents/cli-runner/reseed-envelope.js";
 import {
   isToolCallBlock,
   isToolResultBlock,
   resolveToolUseId,
   type ToolContentBlock,
 } from "../chat/tool-content.js";
-import type { SessionEntry } from "../config/sessions.js";
+import type { CliSessionReseedReceipt, SessionEntry } from "../config/sessions.js";
+import {
+  getCliSessionBinding,
+  normalizeCliSessionReseedReceipt,
+} from "../config/sessions/cli-session-binding.js";
 import { attachOpenClawTranscriptMeta } from "./session-transcript-readers.js";
 
 export const CLAUDE_CLI_PROVIDER = "claude-cli";
@@ -22,6 +27,8 @@ type ClaudeCliProjectEntry = {
   timestamp?: unknown;
   uuid?: unknown;
   isSidechain?: unknown;
+  isMeta?: unknown;
+  isCompactSummary?: unknown;
   message?: {
     role?: unknown;
     content?: unknown;
@@ -40,6 +47,10 @@ type ClaudeCliMessage = NonNullable<ClaudeCliProjectEntry["message"]>;
 type ClaudeCliUsage = ClaudeCliMessage["usage"];
 type TranscriptLikeMessage = Record<string, unknown>;
 type ToolNameRegistry = Map<string, string>;
+type ReseedImportState = {
+  receipt?: CliSessionReseedReceipt;
+  inspectedFirstUser: boolean;
+};
 
 function resolveHistoryHomeDir(homeDir?: string): string {
   return normalizeOptionalString(homeDir) || process.env.HOME || os.homedir();
@@ -52,18 +63,7 @@ function resolveClaudeProjectsDir(homeDir?: string): string {
 export function resolveClaudeCliBindingSessionId(
   entry: SessionEntry | undefined,
 ): string | undefined {
-  const bindingSessionId = normalizeOptionalString(
-    entry?.cliSessionBindings?.[CLAUDE_CLI_PROVIDER]?.sessionId,
-  );
-  if (bindingSessionId) {
-    return bindingSessionId;
-  }
-  const legacyMapSessionId = normalizeOptionalString(entry?.cliSessionIds?.[CLAUDE_CLI_PROVIDER]);
-  if (legacyMapSessionId) {
-    return legacyMapSessionId;
-  }
-  const legacyClaudeSessionId = normalizeOptionalString(entry?.claudeCliSessionId);
-  return legacyClaudeSessionId || undefined;
+  return getCliSessionBinding(entry, CLAUDE_CLI_PROVIDER)?.sessionId;
 }
 
 function resolveTimestampMs(value: unknown): number | undefined {
@@ -217,10 +217,49 @@ function coalesceClaudeCliToolMessages(messages: TranscriptLikeMessage[]): Trans
   return coalesced;
 }
 
+type ClaudeCliPromptTextCandidate = {
+  text: string;
+  blockIndex?: number;
+};
+
+function resolveClaudeCliPromptTextCandidates(
+  entry: ClaudeCliProjectEntry,
+  content: string | unknown[],
+): ClaudeCliPromptTextCandidate[] {
+  if (entry.isMeta === true || entry.isCompactSummary === true) {
+    return [];
+  }
+  if (typeof content === "string") {
+    return [{ text: content }];
+  }
+  if (
+    content.some(
+      (item) =>
+        item !== null && typeof item === "object" && "type" in item && item.type === "tool_result",
+    )
+  ) {
+    return [];
+  }
+  return content.flatMap((item, blockIndex) =>
+    item !== null &&
+    typeof item === "object" &&
+    "type" in item &&
+    item.type === "text" &&
+    "text" in item &&
+    typeof item.text === "string"
+      ? [{ text: item.text, blockIndex }]
+      : [],
+  );
+}
+
 function parseClaudeCliHistoryEntry(
   entry: ClaudeCliProjectEntry,
   cliSessionId: string,
   toolNameRegistry: ToolNameRegistry,
+  options: {
+    reseedMode: "recover" | "preserve";
+    reseedState?: ReseedImportState;
+  },
 ): TranscriptLikeMessage | null {
   if (entry.isSidechain === true || !entry.message || typeof entry.message !== "object") {
     return null;
@@ -238,7 +277,7 @@ function parseClaudeCliHistoryEntry(
     ...(normalizeOptionalString(entry.uuid) ? { externalId: entry.uuid } : {}),
   };
 
-  const content =
+  let content =
     typeof entry.message.content === "string" || Array.isArray(entry.message.content)
       ? normalizeClaudeCliContent(entry.message.content, toolNameRegistry)
       : undefined;
@@ -247,6 +286,54 @@ function parseClaudeCliHistoryEntry(
   }
 
   if (type === "user") {
+    const reseedState = options.reseedState;
+    const promptTextCandidates = resolveClaudeCliPromptTextCandidates(entry, content);
+    if (
+      options.reseedMode === "recover" &&
+      reseedState &&
+      !reseedState.inspectedFirstUser &&
+      promptTextCandidates.length > 0
+    ) {
+      reseedState.inspectedFirstUser = true;
+      if (reseedState.receipt) {
+        // The binding is trusted state for this native session. Do not scan
+        // later rows or a repeated user message could be suppressed.
+        const candidate = promptTextCandidates.length === 1 ? promptTextCandidates[0] : undefined;
+        if (candidate && hashCliReseedPrompt(candidate.text) === reseedState.receipt.promptHash) {
+          if (candidate.blockIndex === undefined || !Array.isArray(content)) {
+            return null;
+          }
+          // The receipt proves only the matching text block is synthetic.
+          // Preserve sibling images or other native content that has no local duplicate proof.
+          const nextContent = cloneJsonValue(content);
+          nextContent.splice(candidate.blockIndex, 1);
+          if (nextContent.length === 0) {
+            return null;
+          }
+          content = nextContent;
+        }
+      } else {
+        for (const candidate of promptTextCandidates) {
+          const reseedPrompt = parseCliReseedPrompt(candidate.text);
+          if (reseedPrompt.kind === "legacy") {
+            if (!reseedPrompt.userMessage) {
+              return null;
+            }
+            if (candidate.blockIndex === undefined) {
+              content = reseedPrompt.userMessage;
+            } else if (Array.isArray(content)) {
+              const nextContent = cloneJsonValue(content);
+              const block = nextContent[candidate.blockIndex];
+              if (block && typeof block === "object") {
+                (block as Record<string, unknown>).text = reseedPrompt.userMessage;
+              }
+              content = nextContent;
+            }
+            break;
+          }
+        }
+      }
+    }
     return attachOpenClawTranscriptMeta(
       {
         role: "user",
@@ -320,6 +407,8 @@ export function resolveClaudeCliSessionFilePath(params: {
 export function readClaudeCliSessionMessages(params: {
   cliSessionId: string;
   homeDir?: string;
+  localSessionId?: string;
+  reseedReceipt?: CliSessionReseedReceipt;
 }): TranscriptLikeMessage[] {
   const filePath = resolveClaudeCliSessionFilePath(params);
   if (!filePath) {
@@ -335,13 +424,25 @@ export function readClaudeCliSessionMessages(params: {
 
   const messages: TranscriptLikeMessage[] = [];
   const toolNameRegistry: ToolNameRegistry = new Map();
+  const localSessionId = normalizeOptionalString(params.localSessionId);
+  const normalizedReceipt = normalizeCliSessionReseedReceipt(params.reseedReceipt);
+  const reseedState: ReseedImportState = {
+    receipt:
+      normalizedReceipt && normalizedReceipt.localSessionId === localSessionId
+        ? normalizedReceipt
+        : undefined,
+    inspectedFirstUser: false,
+  };
   for (const line of content.split(/\r?\n/)) {
     if (!line.trim()) {
       continue;
     }
     try {
       const parsed = JSON.parse(line) as ClaudeCliProjectEntry;
-      const message = parseClaudeCliHistoryEntry(parsed, params.cliSessionId, toolNameRegistry);
+      const message = parseClaudeCliHistoryEntry(parsed, params.cliSessionId, toolNameRegistry, {
+        reseedMode: "recover",
+        reseedState,
+      });
       if (message) {
         messages.push(message);
       }
@@ -446,7 +547,9 @@ export function readClaudeCliFallbackSeed(params: {
       continue;
     }
 
-    const message = parseClaudeCliHistoryEntry(parsed, params.cliSessionId, toolNameRegistry);
+    const message = parseClaudeCliHistoryEntry(parsed, params.cliSessionId, toolNameRegistry, {
+      reseedMode: "preserve",
+    });
     if (message) {
       windowedTurns.push(message);
     }

--- a/src/gateway/cli-session-history.test.ts
+++ b/src/gateway/cli-session-history.test.ts
@@ -1,9 +1,10 @@
 // CLI session history tests protect imported Claude CLI transcript lookup,
-// fallback seeding, marker metadata, and merge ordering with local chat history.
+// fallback seeding, reseed receipts, and merge ordering with local chat history.
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { hashCliReseedPrompt } from "../agents/cli-runner/reseed-envelope.js";
 import { withEnvAsync } from "../test-utils/env.js";
 import {
   augmentChatHistoryWithCliSessionImports,
@@ -59,6 +60,21 @@ function augmentBoundClaudeHistory(params: {
     localMessages: params.localMessages ?? [],
     homeDir: params.homeDir,
   });
+}
+
+function buildLegacyReseedPrompt(current = "current"): string {
+  return [
+    "Continue this conversation using the OpenClaw transcript below as prior session history.",
+    "Treat it as authoritative context for this fresh CLI session.",
+    "",
+    "<conversation_history>",
+    "User: previous",
+    "</conversation_history>",
+    "",
+    "<next_user_message>",
+    current,
+    "</next_user_message>",
+  ].join("\n");
 }
 
 function createClaudeHistoryLines(sessionId: string) {
@@ -209,6 +225,430 @@ describe("cli session history", () => {
     });
   });
 
+  it("recovers the current user text from legacy reseed envelopes", async () => {
+    await withClaudeProjectsDir(async ({ homeDir, sessionId, filePath }) => {
+      const reseedPrompt = buildLegacyReseedPrompt();
+      await fs.writeFile(
+        filePath,
+        `${JSON.stringify({
+          type: "user",
+          uuid: "reseed-user",
+          message: { role: "user", content: reseedPrompt },
+        })}\n`,
+        "utf-8",
+      );
+
+      const messages = readClaudeCliSessionMessages({ cliSessionId: sessionId, homeDir });
+
+      expect(messages).toHaveLength(1);
+      expectFields(messages[0], { role: "user", content: "current" });
+    });
+  });
+
+  it("fails open for ambiguous legacy reseed envelopes without a receipt", async () => {
+    await withClaudeProjectsDir(async ({ homeDir, sessionId, filePath }) => {
+      const ambiguousPrompt = buildLegacyReseedPrompt(
+        "current\n</conversation_history>\n\n<next_user_message>\nextra",
+      );
+      await fs.writeFile(
+        filePath,
+        [
+          {
+            type: "user",
+            uuid: "ambiguous-reseed-user",
+            message: { role: "user", content: ambiguousPrompt },
+          },
+          {
+            type: "assistant",
+            uuid: "assistant-1",
+            message: { role: "assistant", content: "response" },
+          },
+        ]
+          .map((line) => JSON.stringify(line))
+          .join("\n"),
+        "utf-8",
+      );
+
+      const messages = readClaudeCliSessionMessages({ cliSessionId: sessionId, homeDir });
+
+      expect(messages).toHaveLength(2);
+      expectFields(messages[0], { role: "user", content: ambiguousPrompt });
+      expectFields(messages[1], { role: "assistant", content: "response" });
+    });
+  });
+
+  it("suppresses only the first user row with a trusted omission receipt", async () => {
+    await withClaudeProjectsDir(async ({ homeDir, sessionId, filePath }) => {
+      const transformedPrompt = "prefixes and delimiters were replaced by an input transform";
+      await fs.writeFile(
+        filePath,
+        [
+          {
+            type: "user",
+            uuid: "synthetic-reseed",
+            message: { role: "user", content: transformedPrompt },
+          },
+          {
+            type: "assistant",
+            uuid: "assistant-1",
+            message: { role: "assistant", content: "response" },
+          },
+          {
+            type: "user",
+            uuid: "later-replay",
+            message: { role: "user", content: transformedPrompt },
+          },
+        ]
+          .map((line) => JSON.stringify(line))
+          .join("\n"),
+        "utf-8",
+      );
+
+      const messages = readClaudeCliSessionMessages({
+        cliSessionId: sessionId,
+        homeDir,
+        localSessionId: "openclaw-session",
+        reseedReceipt: {
+          version: 1,
+          promptHash: hashCliReseedPrompt(transformedPrompt),
+          localSessionId: "openclaw-session",
+          userTurnDisposition: "omitted",
+        },
+      });
+
+      expect(messages).toHaveLength(2);
+      expectFields(messages[0], { role: "assistant", content: "response" });
+      expectFields(messages[1], { role: "user", content: transformedPrompt });
+    });
+  });
+
+  it("suppresses a receipt-matched row without a local message id", async () => {
+    await withClaudeProjectsDir(async ({ homeDir, sessionId, filePath }) => {
+      const transformedPrompt = "transformed synthetic reseed prompt";
+      await fs.writeFile(
+        filePath,
+        [
+          {
+            type: "user",
+            uuid: "synthetic-reseed",
+            message: { role: "user", content: transformedPrompt },
+          },
+          {
+            type: "assistant",
+            uuid: "assistant-1",
+            message: { role: "assistant", content: "response" },
+          },
+        ]
+          .map((line) => JSON.stringify(line))
+          .join("\n"),
+        "utf-8",
+      );
+
+      const messages = readClaudeCliSessionMessages({
+        cliSessionId: sessionId,
+        homeDir,
+        localSessionId: "openclaw-session",
+        reseedReceipt: {
+          version: 1,
+          promptHash: hashCliReseedPrompt(transformedPrompt),
+          localSessionId: "openclaw-session",
+          userTurnDisposition: "persisted",
+        },
+      });
+
+      expect(messages).toHaveLength(1);
+      expectFields(messages[0], { role: "assistant", content: "response" });
+    });
+  });
+
+  it("fails open when the receipt belongs to a different local session", async () => {
+    await withClaudeProjectsDir(async ({ homeDir, sessionId, filePath }) => {
+      const transformedPrompt = "transformed synthetic reseed prompt";
+      await fs.writeFile(
+        filePath,
+        `${JSON.stringify({
+          type: "user",
+          uuid: "synthetic-reseed",
+          message: { role: "user", content: transformedPrompt },
+        })}\n`,
+        "utf-8",
+      );
+
+      const messages = readClaudeCliSessionMessages({
+        cliSessionId: sessionId,
+        homeDir,
+        localSessionId: "new-openclaw-session",
+        reseedReceipt: {
+          version: 1,
+          promptHash: hashCliReseedPrompt(transformedPrompt),
+          localSessionId: "old-openclaw-session",
+          userTurnDisposition: "persisted",
+        },
+      });
+
+      expect(messages).toHaveLength(1);
+      expectFields(messages[0], { role: "user", content: transformedPrompt });
+    });
+  });
+
+  it.each([
+    [
+      "metadata",
+      {
+        type: "user",
+        uuid: "metadata-user",
+        isMeta: true,
+        message: { role: "user", content: "metadata" },
+      },
+    ],
+    [
+      "compact summary",
+      {
+        type: "user",
+        uuid: "compact-summary-user",
+        isCompactSummary: true,
+        message: { role: "user", content: "summary" },
+      },
+    ],
+    [
+      "tool result",
+      {
+        type: "user",
+        uuid: "tool-result-user",
+        message: {
+          role: "user",
+          content: [{ type: "tool_result", tool_use_id: "tool-1", content: "done" }],
+        },
+      },
+    ],
+  ])("skips %s rows before checking the reseed receipt", async (_label, precursor) => {
+    await withClaudeProjectsDir(async ({ homeDir, sessionId, filePath }) => {
+      const transformedPrompt = "transformed synthetic reseed prompt";
+      await fs.writeFile(
+        filePath,
+        [
+          precursor,
+          {
+            type: "user",
+            uuid: "synthetic-reseed",
+            message: { role: "user", content: transformedPrompt },
+          },
+          {
+            type: "assistant",
+            uuid: "assistant-1",
+            message: { role: "assistant", content: "response" },
+          },
+        ]
+          .map((line) => JSON.stringify(line))
+          .join("\n"),
+        "utf-8",
+      );
+
+      const messages = readClaudeCliSessionMessages({
+        cliSessionId: sessionId,
+        homeDir,
+        localSessionId: "openclaw-session",
+        reseedReceipt: {
+          version: 1,
+          promptHash: hashCliReseedPrompt(transformedPrompt),
+          localSessionId: "openclaw-session",
+          userTurnDisposition: "persisted",
+        },
+      });
+
+      expect(JSON.stringify(messages)).not.toContain(transformedPrompt);
+      expect(JSON.stringify(messages)).toContain("response");
+    });
+  });
+
+  it("suppresses only receipt-matched text while preserving sibling attachments", async () => {
+    await withClaudeProjectsDir(async ({ homeDir, sessionId, filePath }) => {
+      const transformedPrompt = "transformed synthetic reseed prompt";
+      await fs.writeFile(
+        filePath,
+        [
+          {
+            type: "user",
+            uuid: "synthetic-reseed",
+            message: {
+              role: "user",
+              content: [
+                { type: "text", text: transformedPrompt },
+                { type: "image", source: { type: "base64", media_type: "image/png", data: "x" } },
+              ],
+            },
+          },
+          {
+            type: "assistant",
+            uuid: "assistant-1",
+            message: { role: "assistant", content: "response" },
+          },
+        ]
+          .map((line) => JSON.stringify(line))
+          .join("\n"),
+        "utf-8",
+      );
+
+      const messages = readClaudeCliSessionMessages({
+        cliSessionId: sessionId,
+        homeDir,
+        localSessionId: "openclaw-session",
+        reseedReceipt: {
+          version: 1,
+          promptHash: hashCliReseedPrompt(transformedPrompt),
+          localSessionId: "openclaw-session",
+          userTurnDisposition: "persisted",
+        },
+      });
+
+      expect(messages).toHaveLength(2);
+      expect(readRecord(messages[0]).content).toEqual([
+        { type: "image", source: { type: "base64", media_type: "image/png", data: "x" } },
+      ]);
+      expectFields(messages[1], { role: "assistant", content: "response" });
+    });
+  });
+
+  it("preserves receipt-matched arrays with multiple text blocks", async () => {
+    await withClaudeProjectsDir(async ({ homeDir, sessionId, filePath }) => {
+      const transformedPrompt = "transformed synthetic reseed prompt";
+      const content = [
+        { type: "text", text: transformedPrompt },
+        { type: "text", text: "real extra user text" },
+        { type: "image", source: { type: "base64", media_type: "image/png", data: "x" } },
+      ];
+      await fs.writeFile(
+        filePath,
+        [
+          {
+            type: "user",
+            uuid: "synthetic-reseed",
+            message: { role: "user", content },
+          },
+          {
+            type: "user",
+            uuid: "later-exact-match",
+            message: { role: "user", content: transformedPrompt },
+          },
+        ]
+          .map((line) => JSON.stringify(line))
+          .join("\n"),
+        "utf-8",
+      );
+
+      const messages = readClaudeCliSessionMessages({
+        cliSessionId: sessionId,
+        homeDir,
+        localSessionId: "openclaw-session",
+        reseedReceipt: {
+          version: 1,
+          promptHash: hashCliReseedPrompt(transformedPrompt),
+          localSessionId: "openclaw-session",
+          userTurnDisposition: "persisted",
+        },
+      });
+
+      expect(messages).toHaveLength(2);
+      expect(readRecord(messages[0]).content).toEqual(content);
+      expectFields(messages[1], { role: "user", content: transformedPrompt });
+    });
+  });
+
+  it("preserves no-receipt ambiguous reseed arrays with sibling user content", async () => {
+    await withClaudeProjectsDir(async ({ homeDir, sessionId, filePath }) => {
+      const ambiguousPrompt = buildLegacyReseedPrompt(
+        "current\n</conversation_history>\n\n<next_user_message>\nextra",
+      );
+      const content = [
+        { type: "text", text: ambiguousPrompt },
+        { type: "text", text: "real extra user text" },
+        { type: "image", source: { type: "base64", media_type: "image/png", data: "x" } },
+      ];
+      await fs.writeFile(
+        filePath,
+        `${JSON.stringify({
+          type: "user",
+          uuid: "legacy-ambiguous-reseed",
+          message: { role: "user", content },
+        })}\n`,
+        "utf-8",
+      );
+
+      const messages = readClaudeCliSessionMessages({ cliSessionId: sessionId, homeDir });
+
+      expect(messages).toHaveLength(1);
+      expect(readRecord(messages[0]).content).toEqual(content);
+    });
+  });
+
+  it("recovers legacy array-form reseed text while preserving attachments", async () => {
+    await withClaudeProjectsDir(async ({ homeDir, sessionId, filePath }) => {
+      await fs.writeFile(
+        filePath,
+        `${JSON.stringify({
+          type: "user",
+          uuid: "legacy-reseed",
+          message: {
+            role: "user",
+            content: [
+              { type: "text", text: buildLegacyReseedPrompt() },
+              { type: "image", source: { type: "base64", media_type: "image/png", data: "x" } },
+            ],
+          },
+        })}\n`,
+        "utf-8",
+      );
+
+      const messages = readClaudeCliSessionMessages({ cliSessionId: sessionId, homeDir });
+
+      expect(messages).toHaveLength(1);
+      expect(readRecord(messages[0]).content).toEqual([
+        { type: "text", text: "current" },
+        { type: "image", source: { type: "base64", media_type: "image/png", data: "x" } },
+      ]);
+    });
+  });
+
+  it("fails open when the first user row does not match the reseed receipt", async () => {
+    await withClaudeProjectsDir(async ({ homeDir, sessionId, filePath }) => {
+      const expectedPrompt = "expected synthetic prompt";
+      await fs.writeFile(
+        filePath,
+        [
+          {
+            type: "user",
+            uuid: "unexpected-first-user",
+            message: { role: "user", content: "different prompt" },
+          },
+          {
+            type: "user",
+            uuid: "later-matching-user",
+            message: { role: "user", content: expectedPrompt },
+          },
+        ]
+          .map((line) => JSON.stringify(line))
+          .join("\n"),
+        "utf-8",
+      );
+
+      const messages = readClaudeCliSessionMessages({
+        cliSessionId: sessionId,
+        homeDir,
+        localSessionId: "openclaw-session",
+        reseedReceipt: {
+          version: 1,
+          promptHash: hashCliReseedPrompt(expectedPrompt),
+          localSessionId: "openclaw-session",
+          userTurnDisposition: "persisted",
+        },
+      });
+
+      expect(messages).toHaveLength(2);
+      expectFields(messages[0], { role: "user", content: "different prompt" });
+      expectFields(messages[1], { role: "user", content: expectedPrompt });
+    });
+  });
+
   it("rejects path-like Claude CLI session ids", async () => {
     await withClaudeProjectsDir(async ({ homeDir }) => {
       expect(
@@ -332,6 +772,63 @@ describe("cli session history", () => {
         role: "user",
       });
       expectCliSessionMarker(messages[0], sessionId);
+    });
+  });
+
+  it("deduplicates a receipt-recovered user turn against local history", async () => {
+    await withClaudeProjectsDir(async ({ homeDir, sessionId, filePath }) => {
+      const syntheticPrompt = buildLegacyReseedPrompt(
+        "current\n</conversation_history>\n\n<next_user_message>\nextra",
+      );
+      await fs.writeFile(
+        filePath,
+        [
+          {
+            type: "user",
+            uuid: "synthetic-reseed",
+            message: { role: "user", content: syntheticPrompt },
+          },
+          {
+            type: "assistant",
+            uuid: "assistant-1",
+            message: { role: "assistant", content: "response" },
+          },
+        ]
+          .map((line) => JSON.stringify(line))
+          .join("\n"),
+        "utf-8",
+      );
+
+      const messages = augmentChatHistoryWithCliSessionImports({
+        entry: {
+          sessionId: "openclaw-session",
+          updatedAt: Date.now(),
+          cliSessionBindings: {
+            "claude-cli": {
+              sessionId,
+              reseedReceipt: {
+                version: 1,
+                promptHash: hashCliReseedPrompt(syntheticPrompt),
+                localSessionId: "openclaw-session",
+                userTurnDisposition: "persisted",
+              },
+            },
+          },
+        },
+        provider: "claude-cli",
+        localMessages: [
+          {
+            role: "user",
+            content: "current recovered ask",
+            __openclaw: { id: "local-user-1" },
+          },
+        ],
+        homeDir,
+      });
+
+      expect(messages).toHaveLength(2);
+      expectFields(messages[0], { role: "user", content: "current recovered ask" });
+      expectFields(messages[1], { role: "assistant", content: "response" });
     });
   });
 
@@ -502,6 +999,21 @@ describe("readClaudeCliFallbackSeed", () => {
     expect(fallbackSeed.recentTurns).toHaveLength(3);
     expectFields(fallbackSeed.recentTurns[0], { role: "user" });
     expectFields(fallbackSeed.recentTurns[2], { role: "user" });
+  });
+
+  it("preserves reseed envelopes in fallback model context", async () => {
+    const reseedPrompt = buildLegacyReseedPrompt();
+    await writeJsonl([
+      {
+        type: "user",
+        uuid: "u-1",
+        message: { role: "user", content: reseedPrompt },
+      },
+    ]);
+
+    const seed = requireFallbackSeed(readFallbackSeed(), "reseed session");
+
+    expectFields(seed.recentTurns[0], { role: "user", content: reseedPrompt });
   });
 
   it("uses the explicit /compact summary and drops pre-boundary turns", async () => {

--- a/src/gateway/cli-session-history.ts
+++ b/src/gateway/cli-session-history.ts
@@ -2,6 +2,7 @@
 // Augments local chat history with bound external Claude CLI transcripts.
 import { normalizeProviderId } from "../agents/model-selection.js";
 import type { SessionEntry } from "../config/sessions.js";
+import { getCliSessionBinding } from "../config/sessions/cli-session-binding.js";
 import {
   type ClaudeCliFallbackSeed,
   CLAUDE_CLI_PROVIDER,
@@ -30,7 +31,8 @@ export function augmentChatHistoryWithCliSessionImports(params: {
   localMessages: unknown[];
   homeDir?: string;
 }): unknown[] {
-  const cliSessionId = resolveClaudeCliBindingSessionId(params.entry);
+  const cliSessionBinding = getCliSessionBinding(params.entry, CLAUDE_CLI_PROVIDER);
+  const cliSessionId = cliSessionBinding?.sessionId;
   if (!cliSessionId) {
     return params.localMessages;
   }
@@ -48,6 +50,8 @@ export function augmentChatHistoryWithCliSessionImports(params: {
   const importedMessages = readClaudeCliSessionMessages({
     cliSessionId,
     homeDir: params.homeDir,
+    localSessionId: params.entry?.sessionId,
+    reseedReceipt: cliSessionBinding.reseedReceipt,
   });
   return mergeImportedChatHistoryMessages({
     localMessages: params.localMessages,

--- a/src/gateway/server.sessions.reset-hooks.test.ts
+++ b/src/gateway/server.sessions.reset-hooks.test.ts
@@ -326,17 +326,6 @@ function expectCliBindingsCleared(
   expect(nextEntry?.cliSessionIds).toBeUndefined();
 }
 
-function expectClaudeCliBinding(
-  nextEntry: SessionEntryWithCliBindings | undefined,
-  cliSessionId: string,
-) {
-  expect(nextEntry?.claudeCliSessionId).toBe(cliSessionId);
-  expect(nextEntry?.cliSessionBindings).toEqual({
-    "claude-cli": { sessionId: cliSessionId },
-  });
-  expect(nextEntry?.cliSessionIds).toEqual({ "claude-cli": cliSessionId });
-}
-
 test("sessions.reset emits internal command hook with reason", async () => {
   const { dir } = await createSessionStoreDir();
   await writeSingleLineSession(dir, "sess-main", "hello");
@@ -767,25 +756,38 @@ test("sessions.reset clears cli session bindings for parent-linked non-subagent 
 
 test("sessions.reset preserves cli session bindings for spawned subagents (Tak Hoffman's fa56682b3ced contract)", async () => {
   const { dir } = await createSessionStoreDir();
+  const reseedPromptHash = "a".repeat(64);
   const childTranscript = await writeMessageTranscript({
     dir,
     sessionId: "sess-spawned-child",
     content: "hello from spawned child",
     messageId: "m-child",
   });
+  const childEntry = cliBoundSessionEntry(
+    "sess-spawned-child",
+    childTranscript,
+    "claude-cli-child-session",
+    {
+      parentSessionKey: "agent:main:main",
+      spawnedBy: "agent:main:main",
+      subagentRole: "orchestrator",
+    },
+  );
+  childEntry.cliSessionBindings = {
+    "claude-cli": {
+      sessionId: "claude-cli-child-session",
+      reseedReceipt: {
+        version: 1,
+        promptHash: reseedPromptHash,
+        localSessionId: "sess-spawned-child",
+        userTurnDisposition: "omitted",
+      },
+    },
+  };
 
   await writeSessionStore({
     entries: {
-      "subagent:child": cliBoundSessionEntry(
-        "sess-spawned-child",
-        childTranscript,
-        "claude-cli-child-session",
-        {
-          parentSessionKey: "agent:main:main",
-          spawnedBy: "agent:main:main",
-          subagentRole: "orchestrator",
-        },
-      ),
+      "subagent:child": childEntry,
     },
   });
 
@@ -795,5 +797,19 @@ test("sessions.reset preserves cli session bindings for spawned subagents (Tak H
   const nextEntry = store["agent:main:subagent:child"];
   expect(nextEntry).toBeDefined();
   expect(nextEntry?.sessionId).not.toBe("sess-spawned-child");
-  expectClaudeCliBinding(nextEntry, "claude-cli-child-session");
+  expect(nextEntry?.claudeCliSessionId).toBe("claude-cli-child-session");
+  expect(nextEntry?.cliSessionIds).toEqual({
+    "claude-cli": "claude-cli-child-session",
+  });
+  expect(nextEntry?.cliSessionBindings).toEqual({
+    "claude-cli": {
+      sessionId: "claude-cli-child-session",
+      reseedReceipt: {
+        version: 1,
+        promptHash: reseedPromptHash,
+        localSessionId: nextEntry?.sessionId,
+        userTurnDisposition: "omitted",
+      },
+    },
+  });
 });

--- a/src/gateway/session-reset-service.ts
+++ b/src/gateway/session-reset-service.ts
@@ -32,6 +32,7 @@ import {
   type SessionEntry,
   resetSessionEntryLifecycle,
 } from "../config/sessions.js";
+import { rebindCliSessionReseedReceiptsForReset } from "../config/sessions/cli-session-binding.js";
 import { resolveSessionFilePath, resolveSessionFilePathOptions } from "../config/sessions/paths.js";
 import { resolveResetPreservedSelection } from "../config/sessions/reset-preserved-selection.js";
 import {
@@ -1075,6 +1076,11 @@ export async function performGatewaySessionReset(params: {
       // `parentSessionKey` (e.g. dashboard children) are not exempt.
       if (!isSubagentSessionKey(primaryKey)) {
         clearAllCliSessions(nextEntry);
+      } else {
+        nextEntry.cliSessionBindings = rebindCliSessionReseedReceiptsForReset(
+          nextEntry.cliSessionBindings,
+          nextSessionId,
+        );
       }
       return nextEntry;
     },

--- a/src/sessions/user-turn-transcript.test.ts
+++ b/src/sessions/user-turn-transcript.test.ts
@@ -220,6 +220,31 @@ describe("user turn transcript persistence", () => {
       ).toBe(blocked);
     });
 
+    it("preserves runtime multimodal content while merging prepared metadata", () => {
+      const recorder = createUserTurnTranscriptRecorder({
+        input: { text: "canonical image caption", timestamp: 123 },
+        target: { transcriptPath: "/tmp/session.jsonl" },
+      });
+      const runtimeContent = [
+        { type: "text", text: "canonical image caption" },
+        { type: "image", data: "aGVsbG8=", mimeType: "image/png" },
+      ];
+
+      expect(
+        mergePreparedUserTurnMessageForRuntime({
+          runtimeMessage: castAgentMessage({
+            role: "user",
+            content: runtimeContent,
+          }),
+          preparedMessage: recorder.message,
+        }),
+      ).toMatchObject({
+        role: "user",
+        content: runtimeContent,
+        timestamp: 123,
+      });
+    });
+
     it("does not apply prepared user metadata to assistant messages", () => {
       const recorder = createUserTurnTranscriptRecorder({
         input: { text: "display prompt" },

--- a/src/sessions/user-turn-transcript.ts
+++ b/src/sessions/user-turn-transcript.ts
@@ -274,6 +274,19 @@ function isBeforeAgentRunBlockedMessage(message: AgentMessage): boolean {
   return marker !== undefined;
 }
 
+function userMessageHasImageContent(message: AgentMessage): boolean {
+  return (
+    isUserMessage(message) &&
+    Array.isArray(message.content) &&
+    message.content.some(
+      (block) =>
+        typeof block === "object" &&
+        block !== null &&
+        (block as { type?: unknown }).type === "image",
+    )
+  );
+}
+
 // Runtime messages may lack transcript metadata because channel adapters prepare
 // display text separately. Merge only safe user messages, never block markers.
 export function mergePreparedUserTurnMessageForRuntime(params: {
@@ -290,6 +303,9 @@ export function mergePreparedUserTurnMessageForRuntime(params: {
   return {
     ...(params.runtimeMessage as unknown as Record<string, unknown>),
     ...(params.preparedMessage as unknown as Record<string, unknown>),
+    ...(userMessageHasImageContent(params.runtimeMessage)
+      ? { content: params.runtimeMessage.content }
+      : {}),
   } as unknown as AgentMessage;
 }
 


### PR DESCRIPTION
Fixes #99646

## What Problem This Solves

Claude CLI reseeds can write OpenClaw's internal history wrapper into the native CLI transcript. The gateway later imported that synthetic row as an ordinary user message, exposing internal context in chat history.

An importer-only regex fix is unsafe: it cannot prove that the canonical user turn was persisted, and prompt transforms, retries, fallback, images, or session resets can change the row shape.

## Why This Change Was Made

The repair carries durable proof across the full CLI lifecycle:

- direct and cron CLI paths share one user-turn transcript recorder;
- retries and fallback retain a closed `persisted` or `omitted` disposition;
- CLI session bindings store a versioned receipt with the prompt hash and local session owner;
- Claude history import suppresses only the first eligible exact receipt match;
- malformed, mismatched, ambiguous, or stale receipts fail open;
- mixed text/image rows remove only the proven synthetic text block;
- reset logic rebinds only omitted receipts, preserving archived transcript ownership for persisted turns.

Legacy reseed envelopes remain parser-only migration input. Normal runtime paths use the receipt.

## User Impact

Users keep the authoritative OpenClaw user turn, while the internal Claude CLI reseed copy no longer appears in visible history or fallback context. Images and unrelated native content remain intact.

## Evidence

- Final prepared head: `a2dcd01c326401c37d40bfc686e6726c7abdc247`
- Base: `1b84316a91dc32ce57fcd3f8b457f6de80f73dd3`
- Focused regression matrix: 14 files, 511/511 tests passed
- `git diff --check` passed
- Branch autoreview: clean, no actionable findings, confidence 0.90
- Blacksmith Testbox `tbx_01kwnsexns78ccvbg687mrj1yb`:
  - `pnpm check:changed` passed for core and core-tests
  - `pnpm build` passed
  - hydration run: https://github.com/openclaw/openclaw/actions/runs/28696212517
- Exact-head hosted CI: https://github.com/openclaw/openclaw/actions/runs/28696712318
