### PR TITLE
test(qa): use full-turn budget for native stop recovery

### DIFF
--- a/qa/scenarios/channels/native-command-session-target.yaml
+++ b/qa/scenarios/channels/native-command-session-target.yaml
@@ -34,8 +34,6 @@ scenario:
       requiredProviderMode: mock-openai
       conversationId: native-stop-target
       senderId: qa-native-operator
-      warmupPrompt: "Reply exactly: QA-NATIVE-STOP-WARMUP-OK"
-      warmupMarker: QA-NATIVE-STOP-WARMUP-OK
       delayedPrompt: "Subagent recovery worker native command target proof. Wait until stopped."
       abortReplyNeedle: Agent was aborted
       recoveryMarker: QA-NATIVE-STOP-RECOVERY-OK
@@ -55,27 +53,6 @@ flow:
           args:
             - ref: env
             - 60000
-        - resetTransport: true
-        # Gateway health intentionally precedes asynchronous provider/model warmups.
-        # Finish one real turn before timing active-run admission on a cold isolated worker.
-        - sendInbound:
-            conversation:
-              id:
-                expr: config.conversationId
-              kind: direct
-            senderId:
-              expr: config.senderId
-            senderName: QA Native Operator
-            text:
-              expr: config.warmupPrompt
-        - waitForOutbound:
-            conversation:
-              id:
-                expr: config.conversationId
-              kind: direct
-            textIncludes:
-              expr: config.warmupMarker
-            timeoutMs: 15000
         - resetTransport: true
         - sendInbound:
             conversation:
@@ -118,15 +95,6 @@ flow:
               expr: config.abortReplyNeedle
             timeoutMs: 15000
           saveAs: abortReply
-        # The native acknowledgement confirms command handling, not session-lane release.
-        # Wait for the aborted run to clear before proving that the next turn is unblocked.
-        - call: waitForCondition
-          args:
-            - lambda:
-                async: true
-                expr: "env.gateway.call('sessions.list', {}).then((result) => result.sessions?.find((session) => session.key === activeSession.key && session.hasActiveRun !== true))"
-            - 30000
-            - 100
         - sendInbound:
             conversation:
               id:
@@ -146,6 +114,7 @@ flow:
               ref: startIndex
             textIncludes:
               expr: config.recoveryMarker
-            timeoutMs: 15000
+            timeoutMs:
+              expr: liveTurnTimeoutMs(env, 30000)
           saveAs: recoveryReply
       detailsExpr: "`native command reply=${abortReply.text}; recovery reply=${recoveryReply.text}`"

--- a/qa/scenarios/channels/native-command-session-target.yaml
+++ b/qa/scenarios/channels/native-command-session-target.yaml
@@ -34,6 +34,8 @@ scenario:
       requiredProviderMode: mock-openai
       conversationId: native-stop-target
       senderId: qa-native-operator
+      warmupPrompt: "Reply exactly: QA-NATIVE-STOP-WARMUP-OK"
+      warmupMarker: QA-NATIVE-STOP-WARMUP-OK
       delayedPrompt: "Subagent recovery worker native command target proof. Wait until stopped."
       abortReplyNeedle: Agent was aborted
       recoveryMarker: QA-NATIVE-STOP-RECOVERY-OK
@@ -53,6 +55,27 @@ flow:
           args:
             - ref: env
             - 60000
+        - resetTransport: true
+        # Gateway health intentionally precedes asynchronous provider/model warmups.
+        # Finish one real turn before timing active-run admission on a cold isolated worker.
+        - sendInbound:
+            conversation:
+              id:
+                expr: config.conversationId
+              kind: direct
+            senderId:
+              expr: config.senderId
+            senderName: QA Native Operator
+            text:
+              expr: config.warmupPrompt
+        - waitForOutbound:
+            conversation:
+              id:
+                expr: config.conversationId
+              kind: direct
+            textIncludes:
+              expr: config.warmupMarker
+            timeoutMs: 15000
         - resetTransport: true
         - sendInbound:
             conversation:

--- a/qa/scenarios/channels/native-command-session-target.yaml
+++ b/qa/scenarios/channels/native-command-session-target.yaml
@@ -118,6 +118,15 @@ flow:
               expr: config.abortReplyNeedle
             timeoutMs: 15000
           saveAs: abortReply
+        # The native acknowledgement confirms command handling, not session-lane release.
+        # Wait for the aborted run to clear before proving that the next turn is unblocked.
+        - call: waitForCondition
+          args:
+            - lambda:
+                async: true
+                expr: "env.gateway.call('sessions.list', {}).then((result) => result.sessions?.find((session) => session.key === activeSession.key && session.hasActiveRun !== true))"
+            - 30000
+            - 100
         - sendInbound:
             conversation:
               id:


### PR DESCRIPTION
## What Problem This Solves

Fixes #99655.

The native command session-target scenario sends recovery immediately after `/stop` acknowledges. That acknowledgement proves command handling, but the aborted turn can still own the session lane while it unwinds. Exact QA artifacts recorded 16586ms and 18578ms session-lane waits, so the recovery marker arrived after the scenario's fixed 15000ms outbound timeout.

## Why This Change Was Made

The scenario now applies the repository's existing full-turn timeout policy to recovery:

- keeps the 5000ms active-run assertion unchanged;
- keeps native `/stop` and the abort acknowledgement assertion unchanged;
- keeps immediate recovery injection, so the scenario still proves queued next-turn recovery;
- waits for the recovery marker with `liveTurnTimeoutMs(env, 30000)`.

This is not a sleep. Mock providers preserve the 30000ms fallback, while live providers raise it to their model-specific full-turn floor. The discarded `sessions.list.hasActiveRun` idle poll was not valid because that projection clears before the command lane is released.

PR #99368 separately owns suppression of optional QA child startup warmups. This PR does not change gateway startup behavior or JSONL parsing.

## User Impact

QA Smoke CI retains the same native command targeting, abort acknowledgement, and recovery assertions without failing when normal abort cleanup consumes part of the next turn's queue budget.

## Evidence

- PR #99368 run 28639086776, job 84931413935, artifact 8058095433: recovery waited 18578ms behind the session lane after successful `/stop` acknowledgement.
- PR #99656 run 28684909956, job 85075721090, artifact 8075313865: `hasActiveRun` cleared before recovery was injected, but recovery still waited 16586ms for the lane and arrived after the 15000ms assertion expired.
- `extensions/qa-lab/src/live-timeout.test.ts` proves mock lanes preserve the caller fallback and live lanes use provider/model floors.
- `node scripts/run-vitest.mjs extensions/qa-lab/src/scenario-catalog.test.ts` — 32/32 tests passed.
- Four simultaneous exact Crabline Telegram workers — 4/4 passed; every recorder was parse-clean and contained both abort and recovery sends.
- Fresh artifact-aware autoreview — clean, no accepted/actionable findings.
- Blacksmith Testbox changed gate — provider `blacksmith-testbox`, ID `tbx_01kwn0fe5vm4gevwq0c3vks9r9`, exit 0.
- `git diff --check` — passed.
