### PR TITLE
refactor: share retry delay arithmetic

### DIFF
--- a/src/infra/retry-delay.test.ts
+++ b/src/infra/retry-delay.test.ts
@@ -1,0 +1,21 @@
+// Tests shared retry delay arithmetic.
+import { describe, expect, it } from "vitest";
+import { computeExponentialRetryDelayMs } from "./retry-delay.js";
+
+describe("computeExponentialRetryDelayMs", () => {
+  it("uses one-based attempts and treats lower values as the first delay", () => {
+    expect(computeExponentialRetryDelayMs(250, -1, 10_000)).toBe(250);
+    expect(computeExponentialRetryDelayMs(250, 0, 10_000)).toBe(250);
+    expect(computeExponentialRetryDelayMs(250, 1, 10_000)).toBe(250);
+    expect(computeExponentialRetryDelayMs(250, 2, 10_000)).toBe(500);
+  });
+
+  it("caps exponential growth, including overflow", () => {
+    expect(computeExponentialRetryDelayMs(250, 10, 1_000)).toBe(1_000);
+    expect(computeExponentialRetryDelayMs(Number.MAX_VALUE, 2, 30_000)).toBe(30_000);
+  });
+
+  it("leaves uncapped delays unchanged", () => {
+    expect(computeExponentialRetryDelayMs(125, 4)).toBe(1_000);
+  });
+});

--- a/src/infra/retry-delay.ts
+++ b/src/infra/retry-delay.ts
@@ -1,0 +1,10 @@
+// Computes retry delay arithmetic without owning retry policy or scheduling.
+
+/** Computes a 1-based exponential retry delay with an optional hard cap. */
+export function computeExponentialRetryDelayMs(
+  baseDelayMs: number,
+  attempt: number,
+  maxDelayMs = Number.POSITIVE_INFINITY,
+): number {
+  return Math.min(maxDelayMs, baseDelayMs * 2 ** Math.max(attempt - 1, 0));
+}

--- a/src/infra/retry.ts
+++ b/src/infra/retry.ts
@@ -3,6 +3,7 @@ import { asFiniteNumber } from "@openclaw/normalization-core/number-coercion";
 import { MAX_TIMER_TIMEOUT_MS, resolveTimerTimeoutMs } from "../shared/number-coercion.js";
 import { sleep } from "../utils.js";
 import { toErrorObject } from "./errors.js";
+import { computeExponentialRetryDelayMs } from "./retry-delay.js";
 import { generateSecureFraction } from "./secure-random.js";
 
 /** Retry timing knobs shared by generic retry runners and channel retry policies. */
@@ -121,7 +122,7 @@ export async function retryAsync<T>(
         if (i === attempts - 1) {
           break;
         }
-        const delay = resolveRetryDelayMs(initialDelayMs * 2 ** i);
+        const delay = resolveRetryDelayMs(computeExponentialRetryDelayMs(initialDelayMs, i + 1));
         await sleep(delay);
       }
     }
@@ -161,7 +162,7 @@ export async function retryAsync<T>(
       const hasRetryAfter = typeof retryAfterMs === "number" && Number.isFinite(retryAfterMs);
       const baseDelay = hasRetryAfter
         ? Math.max(retryAfterMs, minDelayMs)
-        : minDelayMs * 2 ** (attempt - 1);
+        : computeExponentialRetryDelayMs(minDelayMs, attempt, maxDelayMs);
       const delayCap = hasRetryAfter ? retryAfterMaxDelayMs : maxDelayMs;
       let delay = Math.min(baseDelay, delayCap);
       // Server-supplied Retry-After is a lower-bound contract with the

--- a/src/provider-runtime/operation-retry.test.ts
+++ b/src/provider-runtime/operation-retry.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it, vi } from "vitest";
 import {
   executeProviderOperationWithRetry,
   resolveTransientProviderAttempts,
+  resolveTransientProviderDelayMs,
 } from "./operation-retry.js";
 
 describe("resolveTransientProviderAttempts", () => {
@@ -16,6 +17,26 @@ describe("resolveTransientProviderAttempts", () => {
   it("keeps valid attempt counts as integers", () => {
     expect(resolveTransientProviderAttempts({ attempts: 0 })).toBe(1);
     expect(resolveTransientProviderAttempts({ attempts: 3 })).toBe(3);
+  });
+});
+
+describe("resolveTransientProviderDelayMs", () => {
+  it("uses one-based exponential delays and caps growth", () => {
+    const options = { attempts: 4, baseDelayMs: 250, maxDelayMs: 1_000 };
+
+    expect(resolveTransientProviderDelayMs(options, 0)).toBe(250);
+    expect(resolveTransientProviderDelayMs(options, 1)).toBe(250);
+    expect(resolveTransientProviderDelayMs(options, 2)).toBe(500);
+    expect(resolveTransientProviderDelayMs(options, 4)).toBe(1_000);
+  });
+
+  it("preserves provider delay normalization before calculation", () => {
+    expect(
+      resolveTransientProviderDelayMs(
+        { attempts: 2, baseDelayMs: Number.NaN, maxDelayMs: Number.NaN },
+        2,
+      ),
+    ).toBe(500);
   });
 });
 

--- a/src/provider-runtime/operation-retry.ts
+++ b/src/provider-runtime/operation-retry.ts
@@ -1,6 +1,7 @@
 // Provider operation retry helpers run retryable provider operations with backoff.
 import { sleepWithAbort } from "../infra/backoff.js";
 import { formatErrorMessage } from "../infra/errors.js";
+import { computeExponentialRetryDelayMs } from "../infra/retry-delay.js";
 
 export type ProviderOperationRetryStage = "read" | "poll" | "download" | "create";
 
@@ -195,7 +196,7 @@ export function resolveTransientProviderDelayMs(
     baseDelayMs,
     Math.round(Number.isFinite(rawMaxDelayMs) ? rawMaxDelayMs : 1_000),
   );
-  return Math.min(maxDelayMs, baseDelayMs * 2 ** Math.max(attemptNumber - 1, 0));
+  return computeExponentialRetryDelayMs(baseDelayMs, attemptNumber, maxDelayMs);
 }
 
 export function shouldRetrySameKeyProviderOperation(params: {


### PR DESCRIPTION
Closes #99670

## What Problem This Solves

Resolves a maintenance problem where identical one-based exponential retry-delay arithmetic was implemented separately in generic retry execution and provider-operation retries, allowing attempt indexing, cap, or overflow behavior to drift.

## Why This Change Was Made

Adds one internal pure delay calculator and migrates only the exact jitter-free contract. Retry-After handling, jitter, retryable-error classification, provider policy, maximum attempts, scheduling, logging, and remediation remain with their existing owners.

A third-party retry dependency was not added because the repository already owns the surrounding retry contracts and only the arithmetic primitive is shared.

## User Impact

No intended user-visible behavior change. Maintainers now have one tested calculation path for the matching generic and provider retry delays.

## Evidence

- `node scripts/run-vitest.mjs src/infra/retry-delay.test.ts src/infra/retry.test.ts src/infra/retry.retry-after-lower-bound.test.ts src/provider-runtime/operation-retry.test.ts src/agents/api-key-rotation.test.ts`
  - Passed 4 Vitest shards, 5 files, 49 tests.
- Remote changed gate through delegated Blacksmith Testbox `tbx_01kwn23tg03tq5rk3z764fpy6f`:
  - `OPENCLAW_CHECK_CHANGED_REMOTE_CHILD=1 OPENCLAW_CHANGED_LANES_RAW_SYNC=1 corepack pnpm check:changed`
  - Passed typecheck, lint, duplicate coverage, import-cycle, and repository guards.
- `.agents/skills/autoreview/scripts/autoreview --mode local --stream-engine-output`
  - Final run clean with no accepted/actionable findings.
