### PR TITLE
fix(build): forward default exports through stable runtime aliases

### DIFF
--- a/scripts/runtime-postbuild.mjs
+++ b/scripts/runtime-postbuild.mjs
@@ -299,6 +299,33 @@ export function listCoreRuntimePostBuildOutputs(params = {}) {
   ].toSorted((left, right) => left.localeCompare(right));
 }
 
+const RUNTIME_CHUNK_DEFAULT_EXPORT_PATTERN =
+  /(^|\n)\s*export\s+default[\s({[]|(^|\n)\s*export\s*\{[^}]*\bas default\b[^}]*\}/;
+
+/**
+ * Builds alias module source for a runtime chunk target. `export * from`
+ * never re-exports `default`, so when the target chunk has a default export
+ * the alias must forward it explicitly — otherwise lazy `import()` consumers
+ * that destructure `default` receive `undefined` (e.g. the post-compaction
+ * count reconcile failed this way with "TypeError: reconcile is not a
+ * function" on every compaction).
+ */
+function buildRuntimeAliasSource(params) {
+  const { distDir, fsImpl, targetFileName } = params;
+  const specifier = `./${targetFileName}`;
+  const starSource = `export * from ${JSON.stringify(specifier)};\n`;
+  let targetSource;
+  try {
+    targetSource = fsImpl.readFileSync(path.join(distDir, targetFileName), "utf8");
+  } catch {
+    return starSource;
+  }
+  if (!RUNTIME_CHUNK_DEFAULT_EXPORT_PATTERN.test(targetSource)) {
+    return starSource;
+  }
+  return `${starSource}export { default } from ${JSON.stringify(specifier)};\n`;
+}
+
 /**
  * Writes stable aliases for current hashed runtime chunks.
  */
@@ -320,7 +347,10 @@ export function writeStableRootRuntimeAliases(params = {}) {
       fsImpl.rmSync?.(aliasPath, { force: true });
       continue;
     }
-    writeTextFileIfChanged(aliasPath, `export * from "./${candidate}";\n`);
+    writeTextFileIfChanged(
+      aliasPath,
+      buildRuntimeAliasSource({ distDir, fsImpl, targetFileName: candidate }),
+    );
   }
 }
 
@@ -480,7 +510,10 @@ export function writeLegacyRootRuntimeCompatAliases(params = {}) {
     if (!targetFileName) {
       continue;
     }
-    writeTextFileIfChanged(legacyPath, `export * from "./${targetFileName}";\n`);
+    writeTextFileIfChanged(
+      legacyPath,
+      buildRuntimeAliasSource({ distDir, fsImpl, targetFileName }),
+    );
   }
 }
 

--- a/scripts/runtime-postbuild.mjs
+++ b/scripts/runtime-postbuild.mjs
@@ -200,7 +200,7 @@ function resolveStableRootRuntimeAliasCandidate(params) {
     return { candidate, source };
   });
   const implementationCandidates = candidatesWithSources.filter(
-    ({ source }) => source.trim() !== `export * from "./${aliasFileName}";`,
+    ({ source }) => !isRuntimeAliasSource(source, aliasFileName),
   );
   const candidateNames = implementationCandidates.map(({ candidate }) => candidate);
   if (candidateNames.length === 1) {
@@ -300,7 +300,21 @@ export function listCoreRuntimePostBuildOutputs(params = {}) {
 }
 
 const RUNTIME_CHUNK_DEFAULT_EXPORT_PATTERN =
-  /(^|\n)\s*export\s+default[\s({[]|(^|\n)\s*export\s*\{[^}]*\bas default\b[^}]*\}/;
+  /(^|\n)\s*export\b\s*(?:default\b|\{[^}]*(?:\bas\s+default\b|\bdefault\b\s*(?=[,}]))[^}]*\})/u;
+
+function formatRuntimeAliasSource(targetFileName, forwardDefault = false) {
+  const specifier = JSON.stringify(`./${targetFileName}`);
+  const starSource = `export * from ${specifier};\n`;
+  return forwardDefault ? `${starSource}export { default } from ${specifier};\n` : starSource;
+}
+
+function isRuntimeAliasSource(source, targetFileName) {
+  const normalizedSource = source.trim();
+  return (
+    normalizedSource === formatRuntimeAliasSource(targetFileName).trim() ||
+    normalizedSource === formatRuntimeAliasSource(targetFileName, true).trim()
+  );
+}
 
 /**
  * Builds alias module source for a runtime chunk target. `export * from`
@@ -312,18 +326,16 @@ const RUNTIME_CHUNK_DEFAULT_EXPORT_PATTERN =
  */
 function buildRuntimeAliasSource(params) {
   const { distDir, fsImpl, targetFileName } = params;
-  const specifier = `./${targetFileName}`;
-  const starSource = `export * from ${JSON.stringify(specifier)};\n`;
   let targetSource;
   try {
     targetSource = fsImpl.readFileSync(path.join(distDir, targetFileName), "utf8");
   } catch {
-    return starSource;
+    return formatRuntimeAliasSource(targetFileName);
   }
-  if (!RUNTIME_CHUNK_DEFAULT_EXPORT_PATTERN.test(targetSource)) {
-    return starSource;
-  }
-  return `${starSource}export { default } from ${JSON.stringify(specifier)};\n`;
+  return formatRuntimeAliasSource(
+    targetFileName,
+    RUNTIME_CHUNK_DEFAULT_EXPORT_PATTERN.test(targetSource),
+  );
 }
 
 /**

--- a/test/scripts/runtime-postbuild.test.ts
+++ b/test/scripts/runtime-postbuild.test.ts
@@ -1,6 +1,7 @@
 // Runtime Postbuild tests cover runtime postbuild script behavior.
 import fs from "node:fs/promises";
 import path from "node:path";
+import { pathToFileURL } from "node:url";
 import { describe, expect, it, vi } from "vitest";
 import {
   copyStaticExtensionAssetsToRuntimeOverlay,
@@ -361,15 +362,14 @@ describe("runtime postbuild static assets", () => {
     await expectPathMissing(path.join(distDir, "library.js"));
   });
 
-  it("forwards default exports through stable aliases (export * never re-exports default)", async () => {
+  it("forwards default exports through stable and legacy aliases", async () => {
     const rootDir = createTempDir("openclaw-runtime-postbuild-");
     const distDir = path.join(rootDir, "dist");
     await fs.mkdir(distDir, { recursive: true });
-    // Mirrors the real compaction-reconcile chunk shape: its ONLY export is default,
-    // and its caller lazy-imports `{ default: reconcile }` through the stable alias.
+    await fs.writeFile(path.join(rootDir, "package.json"), '{"type":"module"}\n', "utf8");
     await fs.writeFile(
-      path.join(distDir, "compaction.runtime-Hash111.js"),
-      "async function reconcile(params) { return params; }\nexport { reconcile as default };\n",
+      path.join(distDir, "runtime-plugins.runtime-Hash111.js"),
+      "function reconcile(value) { return value; }\nexport { reconcile as default };\n",
       "utf8",
     );
     await fs.writeFile(
@@ -377,17 +377,36 @@ describe("runtime postbuild static assets", () => {
       "export const named = true;\nexport default function run() {}\n",
       "utf8",
     );
+    await fs.writeFile(
+      path.join(distDir, "named-only.runtime-Hash333.js"),
+      'const marker = "export { marker as default }";\nexport { marker };\n',
+      "utf8",
+    );
 
     writeStableRootRuntimeAliases({ rootDir });
+    writeLegacyRootRuntimeCompatAliases({ rootDir });
 
-    expect(await fs.readFile(path.join(distDir, "compaction.runtime.js"), "utf8")).toBe(
-      'export * from "./compaction.runtime-Hash111.js";\n' +
-        'export { default } from "./compaction.runtime-Hash111.js";\n',
+    const stable = await import(
+      pathToFileURL(path.join(distDir, "runtime-plugins.runtime.js")).href
     );
-    expect(await fs.readFile(path.join(distDir, "mixed.runtime.js"), "utf8")).toBe(
-      'export * from "./mixed.runtime-Hash222.js";\n' +
-        'export { default } from "./mixed.runtime-Hash222.js";\n',
+    const legacy = await import(
+      pathToFileURL(path.join(distDir, "runtime-plugins.runtime-fLHuT7Vs.js")).href
     );
+    const mixed = await import(pathToFileURL(path.join(distDir, "mixed.runtime.js")).href);
+    const namedOnly = await import(pathToFileURL(path.join(distDir, "named-only.runtime.js")).href);
+
+    expect(stable.default("stable")).toBe("stable");
+    expect(legacy.default("legacy")).toBe("legacy");
+    expect(mixed.default).toBeTypeOf("function");
+    expect(namedOnly).not.toHaveProperty("default");
+
+    writeStableRootRuntimeAliases({ rootDir });
+    writeLegacyRootRuntimeCompatAliases({ rootDir });
+
+    const stableAfterRerun = await import(
+      `${pathToFileURL(path.join(distDir, "runtime-plugins.runtime.js")).href}?rerun=1`
+    );
+    expect(stableAfterRerun.default("rerun")).toBe("rerun");
   });
 
   it("does not write ambiguous stable aliases for colliding root runtime chunks", async () => {

--- a/test/scripts/runtime-postbuild.test.ts
+++ b/test/scripts/runtime-postbuild.test.ts
@@ -361,6 +361,35 @@ describe("runtime postbuild static assets", () => {
     await expectPathMissing(path.join(distDir, "library.js"));
   });
 
+  it("forwards default exports through stable aliases (export * never re-exports default)", async () => {
+    const rootDir = createTempDir("openclaw-runtime-postbuild-");
+    const distDir = path.join(rootDir, "dist");
+    await fs.mkdir(distDir, { recursive: true });
+    // Mirrors the real compaction-reconcile chunk shape: its ONLY export is default,
+    // and its caller lazy-imports `{ default: reconcile }` through the stable alias.
+    await fs.writeFile(
+      path.join(distDir, "compaction.runtime-Hash111.js"),
+      "async function reconcile(params) { return params; }\nexport { reconcile as default };\n",
+      "utf8",
+    );
+    await fs.writeFile(
+      path.join(distDir, "mixed.runtime-Hash222.js"),
+      "export const named = true;\nexport default function run() {}\n",
+      "utf8",
+    );
+
+    writeStableRootRuntimeAliases({ rootDir });
+
+    expect(await fs.readFile(path.join(distDir, "compaction.runtime.js"), "utf8")).toBe(
+      'export * from "./compaction.runtime-Hash111.js";\n' +
+        'export { default } from "./compaction.runtime-Hash111.js";\n',
+    );
+    expect(await fs.readFile(path.join(distDir, "mixed.runtime.js"), "utf8")).toBe(
+      'export * from "./mixed.runtime-Hash222.js";\n' +
+        'export { default } from "./mixed.runtime-Hash222.js";\n',
+    );
+  });
+
   it("does not write ambiguous stable aliases for colliding root runtime chunks", async () => {
     const rootDir = createTempDir("openclaw-runtime-postbuild-");
     const distDir = path.join(rootDir, "dist");


### PR DESCRIPTION
Fixes #99677.

> 🤖 **AI-assisted (Claude Code).** This bug was caught, diagnosed, and this fix proposed by the reporter's AI agent operating a live local OpenClaw deployment; I'm submitting as the deployment owner. Evidence is real measured behavior; validation below. (Prior contribution from this setup: #98267.)

## What Problem This Solves

`runtime-postbuild` writes stable runtime aliases as bare `export * from "./X-HASH.js"` — but `export * from` **never re-exports `default`**. One shipped alias (2026.6.10 and 2026.6.11 tarballs) points at a chunk whose only export is `default` (the compaction-reconcile runtime), so its lazy consumer destructuring `default` gets `undefined`; the remaining stable aliases are latent instances of the same generator defect (corrected from an earlier "seven affected" count — see the issue's correction note). Proven-broken path: after **every** successful auto-compaction,

```
late compaction count reconcile failed: TypeError: reconcile is not a function
```

(`selection` chunk lazy-imports `{ default: reconcile }` through the compaction runtime alias) — so the persisted `compactionCount` never updates. On local-model deployments the resulting repeat compactions each trigger a multi-minute full re-prefill (observed: 3 compactions in 25 minutes = an unresponsive agent).

## Why This Change Was Made

The alias writers (`writeStableRootRuntimeAliases`, `writeLegacyRootRuntimeCompatAliases`) now build alias source via a shared helper: if the target chunk contains a default export, the alias additionally emits `export { default } from ...`. Aliases for targets without a default are byte-identical to before. Conservative detection (anchored export-statement patterns) so aliases never claim a `default` their target lacks (which would be a hard `SyntaxError` at import time).

## User Impact

- Post-compaction bookkeeping persists again (the silent per-compaction failure stops for all users).
- Fixes the compaction-storm presentation on local models (each avoided re-compaction saves a multi-minute prefill).
- The six latent aliases stop being footguns for future `default` lazy-imports.

## Evidence

- Published-tarball verification: the compaction alias in `openclaw@2026.6.11` is a bare star re-export whose target's only export is `default`; the reconcile caller destructures `default` (see issue for excerpts + correction note).
- **Detection robustness, live-tested:** naive text matching for `as default` false-positives on string content in minified chunks — appending `export { default }` to an alias whose target lacks one is a hard `SyntaxError` at import (we hit exactly this on our deployment with a hasty local hotfix). This PR's anchored export-statement pattern was verified against all 7 real shipped chunks: no false positives, correct match on the compaction chunk.
- Live deployment: appending the default re-export to the 7 dist aliases stopped the error immediately; auto-compactions now reconcile (no repeat-compaction loop since).
- Tests: added a regression test mirroring the real reconcile chunk shape (star-only alias would fail it). `pnpm exec vitest run test/scripts/runtime-postbuild.test.ts` → **29 passed (29)**.

### Note for maintainers
`scripts/stage-bundled-plugin-runtime.mjs` emits the same bare `export * from` pattern for plugin runtime staging — I have not verified whether any plugin runtime target exports `default`; flagging as a possible sibling rather than expanding this PR's scope.



### Maintainer follow-up

Maintainer review found and repaired two same-surface edge cases before landing:

- direct `export { default } from ...` aliases now propagate their default through legacy compatibility aliases;
- generated default-forwarding wrappers are excluded from implementation-candidate selection, so repeated postbuild runs remain idempotent instead of deleting the stable alias.

Additional evidence on the repaired branch:

- `node scripts/run-vitest.mjs test/scripts/runtime-postbuild.test.ts` — 29/29 passed, including import-level stable/legacy and repeated-run coverage;
- targeted oxlint — clean;
- Testbox-through-Crabbox `tbx_01kwn4h68kbccmctj63t0s6h23`: `pnpm check:changed` and `pnpm build` passed;
- final structured autoreview on pushed head `8f29406f58df15538052ebaa76ff764e17771be0` — no actionable findings.
