### PR TITLE
refactor(models): consolidate catalog ref parsing

### DIFF
--- a/packages/model-catalog-core/src/configured-model-refs.ts
+++ b/packages/model-catalog-core/src/configured-model-refs.ts
@@ -1,5 +1,5 @@
 // Model Catalog Core module implements configured model refs behavior.
-import { normalizeProviderId } from "./provider-id.js";
+import { parseModelCatalogRef } from "./model-catalog-refs.js";
 
 // Collects configured model references from OpenClaw config-shaped objects.
 
@@ -134,10 +134,5 @@ export function collectConfiguredModelRefValues(
 
 /** Extract a normalized provider id from a provider/model reference. */
 export function extractProviderFromModelRef(value: string): string | null {
-  const trimmed = value.trim();
-  const slash = trimmed.indexOf("/");
-  if (slash <= 0) {
-    return null;
-  }
-  return normalizeProviderId(trimmed.slice(0, slash));
+  return parseModelCatalogRef(value)?.provider ?? null;
 }

--- a/packages/model-catalog-core/src/model-catalog-refs.test.ts
+++ b/packages/model-catalog-core/src/model-catalog-refs.test.ts
@@ -1,10 +1,28 @@
 // Model Catalog Core tests cover model catalog refs behavior.
 import { describe, expect, it } from "vitest";
-import { buildModelCatalogMergeKey, buildModelCatalogRef } from "./model-catalog-refs.js";
+import {
+  buildModelCatalogMergeKey,
+  buildModelCatalogRef,
+  parseModelCatalogRef,
+} from "./model-catalog-refs.js";
 
 describe("model catalog refs", () => {
   it("normalizes provider ids without lowercasing model ids in refs", () => {
     expect(buildModelCatalogRef("OpenAI", "GPT-5.4")).toBe("openai/GPT-5.4");
     expect(buildModelCatalogMergeKey("OpenAI", "GPT-5.4")).toBe("openai::gpt-5.4");
   });
+
+  it("parses strict refs while preserving nested model ids", () => {
+    expect(parseModelCatalogRef(" OpenRouter / meta-llama/llama-3.3 ")).toEqual({
+      provider: "openrouter",
+      modelId: "meta-llama/llama-3.3",
+    });
+  });
+
+  it.each(["", "openai", "/gpt-5.4", "openai/", " / gpt-5.4 "])(
+    "rejects incomplete ref %j",
+    (value) => {
+      expect(parseModelCatalogRef(value)).toBeNull();
+    },
+  );
 });

--- a/packages/model-catalog-core/src/model-catalog-refs.ts
+++ b/packages/model-catalog-core/src/model-catalog-refs.ts
@@ -3,6 +3,11 @@ import { normalizeLowercaseStringOrEmpty } from "./provider-id.js";
 
 // Stable model catalog ref and merge-key builders.
 
+export type ModelCatalogRef = {
+  provider: string;
+  modelId: string;
+};
+
 /** Normalize provider ids for catalog refs. */
 export function normalizeModelCatalogProviderId(provider: string): string {
   return normalizeLowercaseStringOrEmpty(provider);
@@ -11,6 +16,18 @@ export function normalizeModelCatalogProviderId(provider: string): string {
 /** Build a provider/model catalog reference. */
 export function buildModelCatalogRef(provider: string, modelId: string): string {
   return `${normalizeModelCatalogProviderId(provider)}/${modelId}`;
+}
+
+/** Parse a strict provider/model catalog reference. */
+export function parseModelCatalogRef(value: string): ModelCatalogRef | null {
+  const trimmed = value.trim();
+  const slashIndex = trimmed.indexOf("/");
+  if (slashIndex <= 0 || slashIndex >= trimmed.length - 1) {
+    return null;
+  }
+  const provider = normalizeModelCatalogProviderId(trimmed.slice(0, slashIndex));
+  const modelId = trimmed.slice(slashIndex + 1).trim();
+  return provider && modelId ? { provider, modelId } : null;
 }
 
 /** Build a case-insensitive merge key for provider/model rows. */

--- a/packages/model-catalog-core/src/provider-model-id-normalization.ts
+++ b/packages/model-catalog-core/src/provider-model-id-normalization.ts
@@ -1,4 +1,5 @@
 // Model Catalog Core module implements provider model id normalization behavior.
+import { parseModelCatalogRef } from "./model-catalog-refs.js";
 import { normalizeLowercaseStringOrEmpty } from "./provider-id.js";
 import {
   normalizeGooglePreviewModelId,
@@ -220,17 +221,17 @@ export function normalizeConfiguredProviderCatalogModelId(
 export function normalizeConfiguredProviderCatalogModelRef(providerModel: string): string {
   const googlePrefix = "google/";
   if (!providerModel.startsWith(googlePrefix)) {
-    const slash = providerModel.indexOf("/");
-    if (slash <= 0 || slash >= providerModel.length - 1) {
+    const parsed = parseModelCatalogRef(providerModel);
+    if (!parsed) {
       return providerModel;
     }
-    const prefix = providerModel.slice(0, slash + 1);
-    const suffix = providerModel.slice(slash + 1);
-    if (!suffix.startsWith(googlePrefix)) {
+    if (!parsed.modelId.startsWith(googlePrefix)) {
       return providerModel;
     }
-    const normalizedSuffix = normalizeGooglePreviewModelId(suffix);
-    return normalizedSuffix === suffix ? providerModel : `${prefix}${normalizedSuffix}`;
+    const normalizedModelId = normalizeGooglePreviewModelId(parsed.modelId);
+    return normalizedModelId === parsed.modelId
+      ? providerModel
+      : `${parsed.provider}/${normalizedModelId}`;
   }
   const modelId = providerModel.slice(googlePrefix.length);
   const normalizedModelId = normalizeGooglePreviewModelId(modelId);

--- a/src/agents/harness-runtimes.ts
+++ b/src/agents/harness-runtimes.ts
@@ -1,7 +1,7 @@
 /**
  * Collects configured native harness runtime ids from model provider config.
  */
-import { normalizeProviderId } from "@openclaw/model-catalog-core/provider-id";
+import { parseModelCatalogRef } from "@openclaw/model-catalog-core/model-catalog-refs";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { isRecord } from "../utils.js";
 import { OPENCLAW_AGENT_RUNTIME_ID, isDefaultAgentRuntimeId } from "./agent-runtime-id.js";
@@ -59,15 +59,7 @@ function parseConfiguredModelRef(
   if (typeof value !== "string") {
     return undefined;
   }
-  const trimmed = value.trim();
-  const slash = trimmed.indexOf("/");
-  if (slash <= 0 || slash >= trimmed.length - 1) {
-    return undefined;
-  }
-  return {
-    provider: normalizeProviderId(trimmed.slice(0, slash)),
-    modelId: trimmed.slice(slash + 1).trim(),
-  };
+  return parseModelCatalogRef(value) ?? undefined;
 }
 
 function resolveConfiguredModelHarnessRuntime(params: {

--- a/src/agents/model-runtime-aliases.ts
+++ b/src/agents/model-runtime-aliases.ts
@@ -1,6 +1,7 @@
 /**
  * Resolves CLI runtime aliases to provider/model auth labels and execution ids.
  */
+import { parseModelCatalogRef } from "@openclaw/model-catalog-core/model-catalog-refs";
 import { normalizeProviderId } from "@openclaw/model-catalog-core/provider-id";
 import { normalizeOptionalLowercaseString } from "@openclaw/normalization-core/string-coerce";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
@@ -73,28 +74,23 @@ function normalizeRuntimeModelRefForComparison(
   options: RuntimeAliasComparisonOptions = {},
 ): string {
   const trimmed = raw.trim();
-  const slash = trimmed.indexOf("/");
-  if (slash <= 0 || slash >= trimmed.length - 1) {
+  const parsed = parseModelCatalogRef(trimmed);
+  if (!parsed) {
     return normalizeProviderId(canonicalizeRuntimeAliasProvider(trimmed, options));
   }
-  const provider = trimmed.slice(0, slash).trim();
-  const model = trimmed.slice(slash + 1).trim();
   const canonicalProvider = normalizeProviderId(
-    canonicalizeRuntimeAliasProvider(provider, options),
+    canonicalizeRuntimeAliasProvider(parsed.provider, options),
   );
-  return model ? `${canonicalProvider}/${model}` : canonicalProvider;
+  return `${canonicalProvider}/${parsed.modelId}`;
 }
 
 function normalizeRuntimeModelRefWithoutAlias(raw: string): string {
   const trimmed = raw.trim();
-  const slash = trimmed.indexOf("/");
-  if (slash <= 0 || slash >= trimmed.length - 1) {
+  const parsed = parseModelCatalogRef(trimmed);
+  if (!parsed) {
     return normalizeProviderId(trimmed);
   }
-  const provider = trimmed.slice(0, slash).trim();
-  const model = trimmed.slice(slash + 1).trim();
-  const normalizedProvider = normalizeProviderId(provider);
-  return model ? `${normalizedProvider}/${model}` : normalizedProvider;
+  return `${parsed.provider}/${parsed.modelId}`;
 }
 
 export function areRuntimeModelRefsEquivalent(

--- a/src/config/codex-plugin-diagnostics.ts
+++ b/src/config/codex-plugin-diagnostics.ts
@@ -1,3 +1,4 @@
+import { parseModelCatalogRef } from "@openclaw/model-catalog-core/model-catalog-refs";
 // Builds diagnostics for Codex plugin config and provider wiring.
 import { normalizeProviderId } from "@openclaw/model-catalog-core/provider-id";
 import { normalizeLowercaseStringOrEmpty } from "@openclaw/normalization-core/string-coerce";
@@ -39,16 +40,6 @@ function isOpenAiCodexDefaultRuntimeSelection(params: {
     provider: OPENAI_PROVIDER_ID,
     config: params.cfg,
   });
-}
-
-function parseProviderModelRef(raw: string): { provider: string; model: string } | null {
-  const slashIndex = raw.indexOf("/");
-  if (slashIndex <= 0 || slashIndex >= raw.length - 1) {
-    return null;
-  }
-  const provider = normalizeProviderId(raw.slice(0, slashIndex));
-  const model = raw.slice(slashIndex + 1).trim();
-  return provider && model ? { provider, model } : null;
 }
 
 function codexPluginEntryEnabled(cfg: OpenClawConfig): boolean | undefined {
@@ -133,7 +124,7 @@ function agentModelsHaveCodexDefaultRuntimePolicy(
   models: Record<string, AgentModelEntryConfig> | undefined,
 ): boolean {
   for (const [modelRef, modelConfig] of Object.entries(models ?? {})) {
-    const parsed = parseProviderModelRef(modelRef);
+    const parsed = parseModelCatalogRef(modelRef);
     if (
       parsed?.provider === OPENAI_PROVIDER_ID &&
       isOpenAiCodexDefaultRuntimeSelection({
@@ -151,10 +142,10 @@ function openAiWildcardRuntimePolicy(
   models: Record<string, AgentModelEntryConfig> | undefined,
 ): AgentRuntimePolicyConfig | undefined {
   for (const [modelRef, modelConfig] of Object.entries(models ?? {})) {
-    const parsed = parseProviderModelRef(modelRef);
+    const parsed = parseModelCatalogRef(modelRef);
     if (
       parsed?.provider === OPENAI_PROVIDER_ID &&
-      parsed.model === "*" &&
+      parsed.modelId === "*" &&
       modelConfig?.agentRuntime?.id?.trim()
     ) {
       return modelConfig.agentRuntime;

--- a/src/config/model-input.ts
+++ b/src/config/model-input.ts
@@ -1,5 +1,5 @@
 // Normalizes model input config into provider and model references.
-import { normalizeProviderId } from "@openclaw/model-catalog-core/provider-id";
+import { parseModelCatalogRef } from "@openclaw/model-catalog-core/model-catalog-refs";
 import {
   normalizeGooglePreviewModelId,
   normalizeTogetherModelId,
@@ -61,13 +61,12 @@ const GOOGLE_PROVIDER_IDS = new Set(["google", "google-gemini-cli", "google-vert
 /** Canonicalizes provider/model refs before they are persisted to config. */
 export function normalizeAgentModelRefForConfig(model: string): string {
   const trimmed = model.trim();
-  const slash = trimmed.indexOf("/");
-  if (slash <= 0 || slash >= trimmed.length - 1) {
+  const parsed = parseModelCatalogRef(trimmed);
+  if (!parsed) {
     return trimmed;
   }
 
-  const provider = normalizeProviderId(trimmed.slice(0, slash));
-  const modelSuffix = trimmed.slice(slash + 1);
+  const { provider, modelId: modelSuffix } = parsed;
   const normalizedModel =
     GOOGLE_PROVIDER_IDS.has(provider) || modelSuffix.startsWith("google/")
       ? normalizeGooglePreviewModelId(modelSuffix)

--- a/src/gateway/server-plugins.ts
+++ b/src/gateway/server-plugins.ts
@@ -2,6 +2,7 @@
 // Loads plugin registries and builds fallback request context for non-WS paths.
 import { randomUUID } from "node:crypto";
 import { performance } from "node:perf_hooks";
+import { parseModelCatalogRef } from "@openclaw/model-catalog-core/model-catalog-refs";
 import { uniqueStrings } from "@openclaw/normalization-core/string-normalization";
 import {
   GATEWAY_CLIENT_IDS,
@@ -124,16 +125,11 @@ function normalizeAllowedModelRef(raw: string): string | null {
   if (trimmed === "*") {
     return "*";
   }
-  const slash = trimmed.indexOf("/");
-  if (slash <= 0 || slash >= trimmed.length - 1) {
+  const parsed = parseModelCatalogRef(trimmed);
+  if (!parsed) {
     return null;
   }
-  const providerRaw = trimmed.slice(0, slash).trim();
-  const modelRaw = trimmed.slice(slash + 1).trim();
-  if (!providerRaw || !modelRaw) {
-    return null;
-  }
-  const normalized = normalizeModelRef(providerRaw, modelRaw);
+  const normalized = normalizeModelRef(parsed.provider, parsed.modelId);
   return `${normalized.provider}/${normalized.model}`;
 }
 

--- a/src/plugins/gateway-startup-plugin-ids.ts
+++ b/src/plugins/gateway-startup-plugin-ids.ts
@@ -1,6 +1,9 @@
 /** Resolves plugin ids that should load during Gateway startup. */
 import { collectConfiguredModelRefs } from "@openclaw/model-catalog-core/configured-model-refs";
-import { buildModelCatalogMergeKey } from "@openclaw/model-catalog-core/model-catalog-refs";
+import {
+  buildModelCatalogMergeKey,
+  parseModelCatalogRef,
+} from "@openclaw/model-catalog-core/model-catalog-refs";
 import {
   findNormalizedProviderValue,
   normalizeProviderId,
@@ -406,19 +409,9 @@ function listModelProviderRefs(value: unknown): string[] {
 
 function listModelProviderRefParts(value: unknown): Array<{ providerId: string; modelId: string }> {
   return listModelProviderRefs(value)
-    .map((ref) => {
-      const slashIndex = ref.indexOf("/");
-      if (slashIndex <= 0 || slashIndex >= ref.length - 1) {
-        return undefined;
-      }
-      return {
-        providerId: normalizeProviderId(ref.slice(0, slashIndex)),
-        modelId: ref.slice(slashIndex + 1).trim(),
-      };
-    })
-    .filter((entry): entry is { providerId: string; modelId: string } =>
-      Boolean(entry?.providerId && entry.modelId),
-    );
+    .map(parseModelCatalogRef)
+    .filter((entry): entry is NonNullable<typeof entry> => entry !== null)
+    .map(({ provider, modelId }) => ({ providerId: provider, modelId }));
 }
 
 function collectModelProviderIds(value: unknown): ReadonlySet<string> {

--- a/src/plugins/runtime/runtime-llm.runtime.ts
+++ b/src/plugins/runtime/runtime-llm.runtime.ts
@@ -1,4 +1,5 @@
 // Runtime LLM helpers adapt plugin provider hooks into the core model runtime.
+import { parseModelCatalogRef } from "@openclaw/model-catalog-core/model-catalog-refs";
 import { asFiniteNumber } from "@openclaw/normalization-core/number-coercion";
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import { modelKey } from "../../agents/model-ref-shared.js";
@@ -229,16 +230,11 @@ function normalizeAllowedModelRef(raw: string): string | null {
   if (trimmed === "*") {
     return "*";
   }
-  const slash = trimmed.indexOf("/");
-  if (slash <= 0 || slash >= trimmed.length - 1) {
+  const parsed = parseModelCatalogRef(trimmed);
+  if (!parsed) {
     return null;
   }
-  const provider = trimmed.slice(0, slash).trim();
-  const model = trimmed.slice(slash + 1).trim();
-  if (!provider || !model) {
-    return null;
-  }
-  const normalized = normalizeModelRef(provider, model);
+  const normalized = normalizeModelRef(parsed.provider, parsed.modelId);
   return modelKey(normalized.provider, normalized.model);
 }
 


### PR DESCRIPTION
Closes #99674

## What Problem This Solves

OpenClaw had repeated implementations of the same strict provider/model reference grammar across model catalog, config, Gateway startup, and plugin runtime paths. The copies could drift on whitespace handling, provider normalization, incomplete refs, and slash-containing model IDs.

## Why This Change Was Made

Adds one mechanical `parseModelCatalogRef` contract to `@openclaw/model-catalog-core` and migrates only callers that already require the same strict normalized grammar. Provider selection, aliases, fallbacks, authentication, compatibility migrations, and provider-specific model normalization remain with their existing owners.

The parser trims segment edges, splits only on the first slash, requires non-empty provider and model segments, normalizes the provider ID, and preserves model casing plus nested slashes. The migration removes more production code than it adds.

## User Impact

No intended user-visible behavior change. Developers get one tested catalog-reference parser instead of maintaining repeated local split logic.

## Evidence

- `node scripts/run-vitest.mjs packages/model-catalog-core/src/model-catalog-refs.test.ts packages/model-catalog-core/src/configured-model-refs.test.ts packages/model-catalog-core/src/provider-model-id-normalization.test.ts src/agents/harness-runtimes.test.ts src/agents/model-runtime-aliases.test.ts src/plugins/runtime/runtime-llm.runtime.test.ts src/config/config.plugin-validation.test.ts src/plugins/bundled-plugin-metadata.test.ts src/gateway/server-plugins.test.ts` — 10 files / 254 tests passed after rebasing onto current `main`.
- Changed typecheck, lint, repository guards, and runtime import cycles passed on Blacksmith Testbox `tbx_01kwn23gfgd4ygebwv1x7dz2k3` (Actions run 28686311707).
- Full `pnpm build` passed on Blacksmith Testbox `tbx_01kwn2kd9bgp8ta63zwpax9vp4` (Actions run 28686564204).
- `git diff --numstat origin/main...HEAD` shows production code net reduction.
- Autoreview: clean, no accepted/actionable findings; patch correctness confidence 0.97.
