### PR TITLE
refactor(infra): consolidate SHA-256 digest helpers

### DIFF
--- a/src/acp/persistent-bindings.types.ts
+++ b/src/acp/persistent-bindings.types.ts
@@ -1,9 +1,9 @@
 /** Types and normalization helpers for configured channel-to-ACP persistent bindings. */
-import { createHash } from "node:crypto";
 import { normalizeText } from "@openclaw/acp-core/normalize-text";
 import type { AcpRuntimeSessionMode } from "@openclaw/acp-core/runtime/types";
 import { normalizeOptionalLowercaseString } from "@openclaw/normalization-core/string-coerce";
 import type { ChannelId } from "../channels/plugins/types.public.js";
+import { sha256HexPrefix } from "../infra/crypto-digest.js";
 import type { SessionBindingRecord } from "../infra/outbound/session-binding-service.js";
 import { normalizeAccountId, resolveAgentIdFromSessionKey } from "../routing/session-key.js";
 import { sanitizeAgentId } from "../routing/session-key.js";
@@ -66,10 +66,7 @@ function buildBindingHash(params: {
   accountId: string;
   conversationId: string;
 }): string {
-  return createHash("sha256")
-    .update(`${params.channel}:${params.accountId}:${params.conversationId}`)
-    .digest("hex")
-    .slice(0, 16);
+  return sha256HexPrefix(`${params.channel}:${params.accountId}:${params.conversationId}`, 16);
 }
 
 /** Builds the stable generated ACP session key for a configured binding. */

--- a/src/infra/clawhub.ts
+++ b/src/infra/clawhub.ts
@@ -13,6 +13,7 @@ import {
   normalizeOptionalString,
 } from "@openclaw/normalization-core/string-coerce";
 import { normalizeStringEntries } from "@openclaw/normalization-core/string-normalization";
+import { sha256Base64, sha256Hex as digestSha256Hex } from "./crypto-digest.js";
 import { parseStrictPositiveInteger } from "./parse-finite-number.js";
 import { isAtLeast, parseSemver } from "./runtime-guard.js";
 import { compareComparableSemver, parseComparableSemver } from "./semver-compare.js";
@@ -978,12 +979,11 @@ function buildGitHubZipUrl(repo: string, commit: string): string {
 }
 
 function formatSha256Integrity(bytes: Uint8Array): string {
-  const digest = createHash("sha256").update(bytes).digest("base64");
-  return `sha256-${digest}`;
+  return `sha256-${sha256Base64(bytes)}`;
 }
 
 function formatSha256Hex(bytes: Uint8Array): string {
-  return createHash("sha256").update(bytes).digest("hex");
+  return digestSha256Hex(bytes);
 }
 
 function formatSha512Integrity(bytes: Uint8Array): string {
@@ -1596,7 +1596,7 @@ export async function reportClawHubSkillInstallTelemetry(params: {
     json: {
       roots: [
         {
-          rootId: createHash("sha256").update(path.resolve(params.root)).digest("hex"),
+          rootId: digestSha256Hex(path.resolve(params.root)),
           label: formatTelemetryRootLabel(params.root),
           skills,
         },

--- a/src/infra/crypto-digest.test.ts
+++ b/src/infra/crypto-digest.test.ts
@@ -1,0 +1,37 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import { withTempDir } from "../test-helpers/temp-dir.js";
+import { sha256Base64, sha256File, sha256Hex, sha256HexPrefix } from "./crypto-digest.js";
+
+const HOSTILE_BYTES = Uint8Array.from([0, 255, 128, 195, 40, 226, 40, 161]);
+const HOSTILE_BYTES_SHA256 = "bd88bda48025bbcf78712d1ff89b55b1cca10c3a9b36c275af350f52b5987902";
+
+describe("crypto digest helpers", () => {
+  it("hashes Unicode strings as UTF-8", () => {
+    const input = "Iñtërnâtiônàlizætiøn☃💩";
+
+    expect(sha256Hex(input)).toBe(
+      "75781ac975ff76899629e996d8e96aa5e89db77315473d8b3281cb8aa700b2e6",
+    );
+    expect(sha256Base64(input)).toBe("dXgayXX/domWKemW2Olqpeidt3MVRz2LMoHLiqcAsuY=");
+  });
+
+  it("hashes arbitrary bytes without text decoding", () => {
+    expect(sha256Hex(HOSTILE_BYTES)).toBe(HOSTILE_BYTES_SHA256);
+    expect(sha256Base64(HOSTILE_BYTES)).toBe("vYi9pIAlu894cS0f+JtVscyhDDqbNsJ1rzUPUrWYeQI=");
+  });
+
+  it("returns an exact hexadecimal prefix", () => {
+    expect(sha256HexPrefix(HOSTILE_BYTES, 12)).toBe(HOSTILE_BYTES_SHA256.slice(0, 12));
+  });
+
+  it("streams file bytes through the same digest contract", async () => {
+    await withTempDir({ prefix: "openclaw-crypto-digest-" }, async (dir) => {
+      const filePath = path.join(dir, "hostile.bin");
+      await fs.writeFile(filePath, HOSTILE_BYTES);
+
+      await expect(sha256File(filePath)).resolves.toBe(HOSTILE_BYTES_SHA256);
+    });
+  });
+});

--- a/src/infra/crypto-digest.ts
+++ b/src/infra/crypto-digest.ts
@@ -1,0 +1,24 @@
+import { createHash } from "node:crypto";
+import { createReadStream } from "node:fs";
+
+type DigestInput = string | Uint8Array;
+
+export function sha256Hex(input: DigestInput): string {
+  return createHash("sha256").update(input).digest("hex");
+}
+
+export function sha256Base64(input: DigestInput): string {
+  return createHash("sha256").update(input).digest("base64");
+}
+
+export function sha256HexPrefix(input: DigestInput, length: number): string {
+  return sha256Hex(input).slice(0, length);
+}
+
+export async function sha256File(filePath: string): Promise<string> {
+  const digest = createHash("sha256");
+  for await (const chunk of createReadStream(filePath)) {
+    digest.update(chunk);
+  }
+  return digest.digest("hex");
+}

--- a/src/infra/diagnostic-error-metadata.ts
+++ b/src/infra/diagnostic-error-metadata.ts
@@ -1,5 +1,5 @@
 // Extracts provider diagnostic metadata from error objects and text.
-import crypto from "node:crypto";
+import { sha256HexPrefix } from "./crypto-digest.js";
 
 const HTTP_STATUS_MIN = 100;
 const HTTP_STATUS_MAX = 599;
@@ -85,11 +85,7 @@ function normalizeProviderRequestId(value: unknown): string | undefined {
 }
 
 function hashDiagnosticIdentifier(value: string): string {
-  return `sha256:${crypto
-    .createHash("sha256")
-    .update(value)
-    .digest("hex")
-    .slice(0, REQUEST_ID_HASH_PREFIX_LEN)}`;
+  return `sha256:${sha256HexPrefix(value, REQUEST_ID_HASH_PREFIX_LEN)}`;
 }
 
 function readDirectProviderRequestId(err: unknown): string | undefined {

--- a/src/infra/gateway-lock.ts
+++ b/src/infra/gateway-lock.ts
@@ -1,6 +1,5 @@
 // Coordinates gateway lock files, ports, and stale owner detection.
 import { execFileSync } from "node:child_process";
-import { createHash } from "node:crypto";
 import fsSync from "node:fs";
 import fs from "node:fs/promises";
 import net from "node:net";
@@ -14,6 +13,7 @@ import { z } from "zod";
 import { resolveConfigPath, resolveGatewayLockDir, resolveStateDir } from "../config/paths.js";
 import { isPidAlive } from "../shared/pid-alive.js";
 import { safeParseJsonWithSchema } from "../utils/zod-parse.js";
+import { sha256HexPrefix } from "./crypto-digest.js";
 import { isGatewayArgv, parseProcCmdline } from "./gateway-process-argv.js";
 import { readWindowsProcessArgsSync } from "./windows-port-pids.js";
 
@@ -221,7 +221,7 @@ async function readLockPayload(lockPath: string): Promise<LockPayload | null> {
 function resolveGatewayLockPath(env: NodeJS.ProcessEnv, lockDir = resolveGatewayLockDir()) {
   const stateDir = resolveStateDir(env);
   const configPath = resolveConfigPath(env, stateDir);
-  const hash = createHash("sha256").update(configPath).digest("hex").slice(0, 8);
+  const hash = sha256HexPrefix(configPath, 8);
   const lockPath = path.join(lockDir, `gateway.${hash}.lock`);
   return { lockPath, configPath };
 }

--- a/src/infra/push-web.ts
+++ b/src/infra/push-web.ts
@@ -1,8 +1,9 @@
 // Stores and verifies web push subscriptions and delivery payloads.
-import { createHash, randomUUID } from "node:crypto";
+import { randomUUID } from "node:crypto";
 import path from "node:path";
 import { resolveStateDir } from "../config/paths.js";
 import { createLazyRuntimeModule } from "../shared/lazy-runtime.js";
+import { sha256HexPrefix } from "./crypto-digest.js";
 import { createAsyncLock, tryReadJson, writeJson } from "./json-files.js";
 
 // --- Types ---
@@ -62,7 +63,7 @@ function resolveVapidKeysPath(baseDir?: string): string {
 }
 
 function hashEndpoint(endpoint: string): string {
-  return createHash("sha256").update(endpoint).digest("hex").slice(0, 32);
+  return sha256HexPrefix(endpoint, 32);
 }
 
 function isValidEndpoint(endpoint: string): boolean {

--- a/src/infra/session-delivery-queue-storage.ts
+++ b/src/infra/session-delivery-queue-storage.ts
@@ -1,6 +1,6 @@
 // Persists queued session deliveries for retry and recovery.
-import { createHash } from "node:crypto";
 import type { ChatType } from "../channels/chat-type.js";
+import { sha256Hex } from "./crypto-digest.js";
 import {
   deleteDeliveryQueueEntry,
   loadDeliveryQueueEntries,
@@ -68,7 +68,7 @@ function buildEntryId(idempotencyKey?: string): string {
   if (!idempotencyKey) {
     return generateSecureUuid();
   }
-  return createHash("sha256").update(idempotencyKey).digest("hex");
+  return sha256Hex(idempotencyKey);
 }
 
 function queuedSessionDeliveryMetadata(entry: QueuedSessionDelivery): DeliveryQueueRowMetadata {

--- a/src/infra/state-migrations.debug-proxy.ts
+++ b/src/infra/state-migrations.debug-proxy.ts
@@ -1,11 +1,11 @@
 // Debug proxy state migration imports the shipped capture sidecar into shared SQLite state.
-import { createHash } from "node:crypto";
 import fs from "node:fs";
 import path from "node:path";
 import type { DatabaseSync, SQLInputValue } from "node:sqlite";
 import { gunzipSync } from "node:zlib";
 import { runOpenClawStateWriteTransaction } from "../state/openclaw-state-db.js";
 import { resolveOpenClawStateSqlitePath } from "../state/openclaw-state-db.paths.js";
+import { sha256Hex } from "./crypto-digest.js";
 import { requireNodeSqlite } from "./node-sqlite.js";
 
 const DEBUG_PROXY_SQLITE_SIDECAR_SUFFIXES = ["", "-shm", "-wal", "-journal"] as const;
@@ -243,22 +243,21 @@ function readLegacyDebugProxyCapture(params: { sourcePath: string; blobDir: stri
     const blobs: LegacyCaptureBlobRow[] = [];
     for (const [blobId, referencingEvents] of blobEvents) {
       const candidateBlobDirs = [
-        ...new Set(
-          [
-            ...referencingEvents.map(
-              (event) => blobDirBySession.get(event.session_id) ?? params.blobDir,
-            ),
-            params.blobDir,
-          ],
-        ),
+        ...new Set([
+          ...referencingEvents.map(
+            (event) => blobDirBySession.get(event.session_id) ?? params.blobDir,
+          ),
+          params.blobDir,
+        ]),
       ];
       const blobPath =
         candidateBlobDirs
           .map((blobDir) => path.join(blobDir, `${blobId}.bin.gz`))
-          .find(fileExists) ?? path.join(candidateBlobDirs[0] ?? params.blobDir, `${blobId}.bin.gz`);
+          .find(fileExists) ??
+        path.join(candidateBlobDirs[0] ?? params.blobDir, `${blobId}.bin.gz`);
       const data = fs.readFileSync(blobPath);
       const raw = gunzipSync(data);
-      const sha256 = createHash("sha256").update(raw).digest("hex");
+      const sha256 = sha256Hex(raw);
       if (sha256.slice(0, 24) !== blobId) {
         throw new Error(`legacy debug proxy blob hash mismatch: ${blobPath}`);
       }

--- a/src/infra/system-run-approval-binding.ts
+++ b/src/infra/system-run-approval-binding.ts
@@ -1,5 +1,5 @@
+import { sha256Hex } from "./crypto-digest.js";
 // Binds system-run approval requests to stable command identities.
-import crypto from "node:crypto";
 import type {
   SystemRunApprovalBinding,
   SystemRunApprovalFileOperand,
@@ -90,7 +90,7 @@ function hashSystemRunEnvEntries(entries: NormalizedSystemRunEnvEntry[]): string
   if (entries.length === 0) {
     return null;
   }
-  return crypto.createHash("sha256").update(JSON.stringify(entries)).digest("hex");
+  return sha256Hex(JSON.stringify(entries));
 }
 
 export function buildSystemRunApprovalEnvBinding(env: unknown): {

--- a/src/logging/redact-identifier.ts
+++ b/src/logging/redact-identifier.ts
@@ -1,11 +1,11 @@
 // Identifier redaction helpers replace sensitive identifiers with stable hashes.
-import crypto from "node:crypto";
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
+import { sha256HexPrefix as digestSha256HexPrefix } from "../infra/crypto-digest.js";
 
 /** Returns a stable sha256 hex prefix for non-secret identifier correlation. */
 export function sha256HexPrefix(value: string, len = 12): string {
   const safeLen = Number.isFinite(len) ? Math.max(1, Math.floor(len)) : 12;
-  return crypto.createHash("sha256").update(value).digest("hex").slice(0, safeLen);
+  return digestSha256HexPrefix(value, safeLen);
 }
 
 /** Redacts an identifier to a stable hash label, or "-" for missing values. */

--- a/src/proxy-capture/store.sqlite.ts
+++ b/src/proxy-capture/store.sqlite.ts
@@ -1,11 +1,11 @@
 // Proxy capture SQLite store persists capture metadata and replayable exchanges.
-import { createHash } from "node:crypto";
 import fs from "node:fs";
 import path from "node:path";
 import type { DatabaseSync } from "node:sqlite";
 import { gunzipSync, gzipSync } from "node:zlib";
 import { normalizeNullableString as normalizeObservedValue } from "@openclaw/normalization-core/string-coerce";
 import { normalizeUniqueStringEntries } from "@openclaw/normalization-core/string-normalization";
+import { sha256Hex } from "../infra/crypto-digest.js";
 import { requireNodeSqlite } from "../infra/node-sqlite.js";
 import { applyPrivateModeSync } from "../infra/private-mode.js";
 import { resolveSqliteDatabaseFilePaths } from "../infra/sqlite-files.js";
@@ -50,8 +50,7 @@ function isInMemoryDatabasePath(dbPath: string): boolean {
   const fragmentIndex = dbPath.indexOf("#");
   const uriWithoutFragment = fragmentIndex === -1 ? dbPath : dbPath.slice(0, fragmentIndex);
   const queryIndex = uriWithoutFragment.indexOf("?");
-  const uriPath =
-    queryIndex === -1 ? uriWithoutFragment : uriWithoutFragment.slice(0, queryIndex);
+  const uriPath = queryIndex === -1 ? uriWithoutFragment : uriWithoutFragment.slice(0, queryIndex);
   try {
     if (decodeURIComponent(uriPath.slice("file:".length)) === ":memory:") {
       return true;
@@ -281,7 +280,7 @@ class DebugProxyCaptureStoreImpl {
   }
 
   persistPayload(data: Buffer, contentType?: string): CaptureBlobRecord | SharedCaptureBlobRecord {
-    const sha256 = createHash("sha256").update(data).digest("hex");
+    const sha256 = sha256Hex(data);
     const blobId = sha256.slice(0, 24);
     if (this.pathBased) {
       fs.mkdirSync(this.pathBased.blobDir, {
@@ -743,10 +742,12 @@ class DebugProxyCaptureStoreImpl {
           )
           .get(...sessionIds) as { count: number }
       ).count ?? 0;
-    this.db.prepare(`DELETE FROM capture_events WHERE session_id IN (${placeholders})`).run(
-      ...sessionIds,
-    );
-    this.db.prepare(`DELETE FROM capture_sessions WHERE id IN (${placeholders})`).run(...sessionIds);
+    this.db
+      .prepare(`DELETE FROM capture_events WHERE session_id IN (${placeholders})`)
+      .run(...sessionIds);
+    this.db
+      .prepare(`DELETE FROM capture_sessions WHERE id IN (${placeholders})`)
+      .run(...sessionIds);
     const candidateBlobIds = blobRows
       .map((row) => row.blobId?.trim())
       .filter((blobId): blobId is string => Boolean(blobId));
@@ -783,10 +784,7 @@ class DebugProxyCaptureStoreImpl {
 }
 
 export type DebugProxyCaptureStore = Omit<DebugProxyCaptureStoreImpl, "persistPayload"> & {
-  persistPayload(
-    data: Buffer,
-    contentType?: string,
-  ): CaptureBlobRecord | SharedCaptureBlobRecord;
+  persistPayload(data: Buffer, contentType?: string): CaptureBlobRecord | SharedCaptureBlobRecord;
 };
 
 export type LegacyDebugProxyCaptureStore = Omit<DebugProxyCaptureStoreImpl, "persistPayload"> & {
@@ -860,7 +858,10 @@ export function closeDebugProxyCaptureStore(): void {
 
 // Lease API keeps one cached capture-store wrapper alive across related
 // operations, then releases it without closing the shared state database.
-export function acquireDebugProxyCaptureStore(dbPath: string, blobDir: string): {
+export function acquireDebugProxyCaptureStore(
+  dbPath: string,
+  blobDir: string,
+): {
   store: LegacyDebugProxyCaptureStore;
   release: () => void;
 };
@@ -905,10 +906,7 @@ export function acquireDebugProxyCaptureStore(
 
 export function persistEventPayload(
   store: {
-    persistPayload(
-      data: Buffer,
-      contentType?: string,
-    ): CaptureBlobRecord | SharedCaptureBlobRecord;
+    persistPayload(data: Buffer, contentType?: string): CaptureBlobRecord | SharedCaptureBlobRecord;
   },
   params: { data?: Buffer | string | null; contentType?: string; previewLimit?: number },
 ): { dataText?: string; dataBlobId?: string; dataSha256?: string } {

--- a/src/skills/lifecycle/clawhub.ts
+++ b/src/skills/lifecycle/clawhub.ts
@@ -1,5 +1,4 @@
 // ClawHub lifecycle helpers fetch skill registry metadata and package details.
-import { createHash } from "node:crypto";
 import fsSync from "node:fs";
 import fs from "node:fs/promises";
 import path from "node:path";
@@ -26,6 +25,7 @@ import {
   type ClawHubSkillSearchResult,
   type ClawHubSkillVerificationResponse,
 } from "../../infra/clawhub.js";
+import { sha256Hex } from "../../infra/crypto-digest.js";
 import { formatErrorMessage } from "../../infra/errors.js";
 import { pathExists } from "../../infra/fs-safe.js";
 import { withExtractedArchiveRoot } from "../../infra/install-flow.js";
@@ -525,7 +525,7 @@ async function readInstalledSkillFileLock(
       const content = await fs.readFile(candidate);
       return {
         path: marker,
-        sha256: createHash("sha256").update(content).digest("hex"),
+        sha256: sha256Hex(content),
       };
     } catch {
       continue;

--- a/src/skills/lifecycle/install-extract.ts
+++ b/src/skills/lifecycle/install-extract.ts
@@ -1,6 +1,4 @@
 // Install extraction helpers validate and unpack skill archives into install roots.
-import { createHash } from "node:crypto";
-import fs from "node:fs";
 import { normalizeStringEntries } from "@openclaw/normalization-core/string-normalization";
 import {
   createTarEntryPreflightChecker,
@@ -9,6 +7,7 @@ import {
   prepareArchiveDestinationDir,
   withStagedArchiveDestination,
 } from "../../infra/archive.js";
+import { sha256File } from "../../infra/crypto-digest.js";
 import { formatErrorMessage } from "../../infra/errors.js";
 import { runCommandWithTimeout } from "../../process/exec.js";
 import { hasBinary } from "../loading/config.js";
@@ -19,20 +18,6 @@ type TarPreflightResult = {
   entries: string[];
   metadata: ReturnType<typeof parseTarVerboseMetadata>;
 };
-
-async function hashFileSha256(filePath: string): Promise<string> {
-  const hash = createHash("sha256");
-  const stream = fs.createReadStream(filePath);
-  return await new Promise<string>((resolve, reject) => {
-    stream.on("data", (chunk) => {
-      hash.update(chunk as Buffer);
-    });
-    stream.on("error", reject);
-    stream.on("end", () => {
-      resolve(hash.digest("hex"));
-    });
-  });
-}
 
 function commandFailureResult(
   result: { stdout: string; stderr: string; code: number | null },
@@ -96,7 +81,7 @@ async function verifyArchiveHashStable(params: {
   archivePath: string;
   expectedHash: string;
 }): Promise<ArchiveExtractResult | null> {
-  const postPreflightHash = await hashFileSha256(params.archivePath);
+  const postPreflightHash = await sha256File(params.archivePath);
   if (postPreflightHash === params.expectedHash) {
     return null;
   }
@@ -180,7 +165,7 @@ export async function extractArchive(params: {
       }
 
       const destinationRealDir = await prepareArchiveDestinationDir(targetDir);
-      const preflightHash = await hashFileSha256(archivePath);
+      const preflightHash = await sha256File(archivePath);
 
       // Preflight list to prevent zip-slip style traversal before extraction.
       const preflight = await readTarPreflight({ archivePath, timeoutMs });

--- a/src/skills/lifecycle/upload-store.ts
+++ b/src/skills/lifecycle/upload-store.ts
@@ -1,6 +1,5 @@
 // Skill upload store persists uploaded skill archives before installation.
-import { createHash, randomUUID } from "node:crypto";
-import { createReadStream } from "node:fs";
+import { randomUUID } from "node:crypto";
 import fs from "node:fs/promises";
 import path from "node:path";
 import {
@@ -10,6 +9,7 @@ import {
 } from "@openclaw/normalization-core/number-coercion";
 import { resolveStateDir } from "../../config/paths.js";
 import { DEFAULT_MAX_ARCHIVE_BYTES_ZIP } from "../../infra/archive.js";
+import { sha256File, sha256Hex } from "../../infra/crypto-digest.js";
 import { formatErrorMessage } from "../../infra/errors.js";
 import { createAsyncLock, readDurableJsonFile, writeJsonAtomic } from "../../infra/json-files.js";
 import { validateRequestedSkillSlug } from "./archive-install.js";
@@ -162,7 +162,7 @@ function validateIdempotencyKey(value: string | undefined): string | undefined {
 }
 
 function hashText(value: string): string {
-  return createHash("sha256").update(value).digest("hex");
+  return sha256Hex(value);
 }
 
 function resolveUploadsRoot(rootDir?: string): string {
@@ -224,14 +224,6 @@ async function assertNotExpired(
   if (validNow === undefined) {
     throw new SkillUploadRequestError("upload has expired");
   }
-}
-
-async function computeFileSha256(filePath: string): Promise<string> {
-  const digest = createHash("sha256");
-  for await (const chunk of createReadStream(filePath)) {
-    digest.update(chunk);
-  }
-  return digest.digest("hex");
 }
 
 async function readRecord(rootDir: string, uploadId: string): Promise<SkillUploadRecord> {
@@ -564,7 +556,7 @@ export function createSkillUploadStore(options?: {
         if (record.sha256 && requestedSha && record.sha256 !== requestedSha) {
           throw new SkillUploadRequestError("upload sha256 does not match begin sha256");
         }
-        const actualSha256 = await computeFileSha256(record.archivePath);
+        const actualSha256 = await sha256File(record.archivePath);
         const expectedSha = requestedSha ?? record.sha256;
         if (expectedSha && expectedSha !== actualSha256) {
           throw new SkillUploadRequestError("upload sha256 mismatch");

--- a/src/skills/loading/skill-version.ts
+++ b/src/skills/loading/skill-version.ts
@@ -1,7 +1,6 @@
 // Skill prompt versions are deterministic content markers for model-visible skill catalogs.
-import crypto from "node:crypto";
+import { sha256HexPrefix } from "../../infra/crypto-digest.js";
 
 export function computeSkillPromptVersion(content: string): string {
-  const digest = crypto.createHash("sha256").update(content).digest("hex").slice(0, 16);
-  return `sha256:${digest}`;
+  return `sha256:${sha256HexPrefix(content, 16)}`;
 }

--- a/src/skills/workshop/store.ts
+++ b/src/skills/workshop/store.ts
@@ -3,6 +3,7 @@ import fs from "node:fs/promises";
 import path from "node:path";
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import { resolveStateDir } from "../../config/paths.js";
+import { sha256Hex } from "../../infra/crypto-digest.js";
 import { type FileLockOptions, withFileLock } from "../../infra/file-lock.js";
 import { root } from "../../infra/fs-safe.js";
 import { tryReadJson } from "../../infra/json-files.js";
@@ -69,7 +70,7 @@ export function createSkillProposalId(name: string, now = new Date()): string {
 }
 
 export function hashSkillProposalContent(content: string): string {
-  return crypto.createHash("sha256").update(content).digest("hex");
+  return sha256Hex(content);
 }
 
 function contentSizeBytes(content: string): number {


### PR DESCRIPTION
Closes #99675

## What Problem This Solves

Core runtime code repeated exact SHA-256 hex/base64, prefix presentation, and streaming file-hash mechanics across cache keys, redacted identifiers, artifact validation, telemetry identifiers, and persisted records. This made byte/string input contracts, encodings, and file error behavior harder to audit consistently.

## Why This Change Was Made

Adds a focused `src/infra/crypto-digest.ts` owner for SHA-256 hex, base64, exact hexadecimal prefixes, and async file hashing. Migrates 15 exact-contract core callers and deletes two duplicate streaming file hashers while keeping domain names, labels, cache keys, truncation lengths, security protocols, multi-part hashes, packages, and plugins in their existing owners.

## User Impact

No intended user-visible behavior change. Existing identifiers, persisted hashes, integrity strings, and truncation lengths remain byte-for-byte compatible; maintainers gain one tested core digest contract and eight fewer production lines.

## Evidence

- `node scripts/run-vitest.mjs src/infra/crypto-digest.test.ts src/infra/diagnostic-error-metadata.test.ts src/infra/gateway-lock.test.ts src/infra/push-web.test.ts src/infra/system-run-approval-binding.test.ts src/proxy-capture/store.sqlite.test.ts src/skills/lifecycle/upload-store.test.ts src/acp/persistent-bindings.test.ts src/skills/lifecycle/clawhub.test.ts src/infra/session-delivery-queue.storage.test.ts src/infra/session-delivery-queue.recovery.test.ts src/commands/doctor-state-migrations.test.ts src/skills/workshop/service.test.ts src/skills/loading/workspace-snapshot.test.ts` — 14 files, 292 tests passed on head `3ef08a18d9`.
- Blacksmith Testbox `tbx_01kwn2ejzcm6b77f7d9ms43grn` / Actions run `28686486806` — `pnpm check:changed` passed core typechecks, core-test typechecks, lint, database-first guards, import-cycle checks, and related repository guards.
- Rebase patch-id remained `58fa9abfda2417f316af234fed715285c75c59b2`; the four intervening `main` commits had zero path overlap.
- `.agents/skills/autoreview/scripts/autoreview --mode local --prompt-file /tmp/digest-autoreview-context.md --stream-engine-output` — clean, no accepted/actionable findings.
- Search proof: removed `hashFileSha256` and `computeFileSha256`; migrated selected callers no longer contain local `createHash("sha256")` implementations.
- Production diff: `+81/-89`, net `-8` lines.
