### PR TITLE
refactor: consolidate safe JSON parsing

### DIFF
--- a/packages/normalization-core/src/index.ts
+++ b/packages/normalization-core/src/index.ts
@@ -2,6 +2,7 @@
 
 export * from "./boolean-coercion.js";
 export * from "./error-coercion.js";
+export * from "./json-coercion.js";
 export * from "./number-coercion.js";
 export * from "./record-coerce.js";
 export * from "./string-coerce.js";

--- a/packages/normalization-core/src/json-coercion.test.ts
+++ b/packages/normalization-core/src/json-coercion.test.ts
@@ -1,0 +1,12 @@
+import { describe, expect, it } from "vitest";
+import { safeParseJson } from "./json-coercion.js";
+
+describe("json-coercion", () => {
+  it.each<[string, unknown]>([
+    ['{"ok":true}', { ok: true }],
+    ["[1]", [1]],
+    ['"text"', "text"],
+    ["null", null],
+    ["{", undefined],
+  ])("parses %s", (value, expected) => expect(safeParseJson(value)).toEqual(expected));
+});

--- a/packages/normalization-core/src/json-coercion.ts
+++ b/packages/normalization-core/src/json-coercion.ts
@@ -1,0 +1,8 @@
+/** Parses JSON without throwing, returning undefined for invalid input. */
+export function safeParseJson(value: string): unknown {
+  try {
+    return JSON.parse(value) as unknown;
+  } catch {
+    return undefined;
+  }
+}

--- a/src/acp/runtime/session-meta.ts
+++ b/src/acp/runtime/session-meta.ts
@@ -1,5 +1,7 @@
 /** SQLite-backed ACP session metadata storage keyed through session-store entries. */
 import type { DatabaseSync } from "node:sqlite";
+import { safeParseJson } from "@openclaw/normalization-core";
+import { asOptionalRecord } from "@openclaw/normalization-core/record-coerce";
 import { normalizeLowercaseStringOrEmpty } from "@openclaw/normalization-core/string-coerce";
 import type { Insertable, Selectable } from "kysely";
 import { getRuntimeConfig } from "../../config/config.js";
@@ -29,7 +31,6 @@ import {
   type OpenClawStateDatabaseOptions,
   runOpenClawStateWriteTransaction,
 } from "../../state/openclaw-state-db.js";
-import { isRecord } from "../../utils.js";
 
 /** ACP metadata joined with its legacy session-store row and config context. */
 export type AcpSessionStoreEntry = {
@@ -89,21 +90,11 @@ function getAcpSessionKysely(db: DatabaseSync) {
   return getNodeSqliteKysely<AcpSessionMetaDatabase>(db);
 }
 
-function parseOptionalJsonRecord(raw: string | null): Record<string, unknown> | undefined {
-  if (raw == null || raw === "") {
-    return undefined;
-  }
-  try {
-    const parsed = JSON.parse(raw) as unknown;
-    return isRecord(parsed) ? parsed : undefined;
-  } catch {
-    return undefined;
-  }
-}
-
 function rowToAcpSessionMeta(row: AcpSessionRow): SessionAcpMeta {
-  const identity = parseOptionalJsonRecord(row.identity_json) as SessionAcpIdentity | undefined;
-  const runtimeOptions = parseOptionalJsonRecord(row.runtime_options_json) as
+  const identity = asOptionalRecord(safeParseJson(row.identity_json ?? "")) as
+    | SessionAcpIdentity
+    | undefined;
+  const runtimeOptions = asOptionalRecord(safeParseJson(row.runtime_options_json ?? "")) as
     | AcpSessionRuntimeOptions
     | undefined;
   return {

--- a/src/agents/embedded-agent-message-tool-source-reply.ts
+++ b/src/agents/embedded-agent-message-tool-source-reply.ts
@@ -1,6 +1,8 @@
 /**
  * Detects message-tool sends that delivered a visible reply to the current source.
  */
+import { safeParseJson } from "@openclaw/normalization-core";
+import { asOptionalRecord } from "@openclaw/normalization-core/record-coerce";
 import type { SourceReplyDeliveryMode } from "../auto-reply/get-reply-options.types.js";
 import {
   isMessageToolConversationCreateActionName,
@@ -70,14 +72,7 @@ function isBareSentDeliveryStatus(value: unknown): boolean {
 }
 
 function parseJsonRecord(value: string): Record<string, unknown> | undefined {
-  try {
-    const parsed = JSON.parse(value);
-    return parsed && typeof parsed === "object" && !Array.isArray(parsed)
-      ? (parsed as Record<string, unknown>)
-      : undefined;
-  } catch {
-    return undefined;
-  }
+  return asOptionalRecord(safeParseJson(value));
 }
 
 function recordHasDeliveredMessageId(record: Record<string, unknown>): boolean {

--- a/src/agents/subagent-yield-output.ts
+++ b/src/agents/subagent-yield-output.ts
@@ -3,6 +3,7 @@
  *
  * Accepts provider-specific tool-call and tool-result shapes used by transcript repair and announce capture.
  */
+import { safeParseJson } from "@openclaw/normalization-core";
 import { asOptionalRecord } from "@openclaw/normalization-core/record-coerce";
 import { readTrimmedStringAlias } from "../utils/string-readers.js";
 
@@ -50,11 +51,7 @@ function parseJsonObject(text: string): Record<string, unknown> | undefined {
   if (!trimmed.startsWith("{")) {
     return undefined;
   }
-  try {
-    return asOptionalRecord(JSON.parse(trimmed));
-  } catch {
-    return undefined;
-  }
+  return asOptionalRecord(safeParseJson(trimmed));
 }
 
 function readStructuredToolPayload(content: unknown): Record<string, unknown> | undefined {

--- a/src/chat/canvas-render.ts
+++ b/src/chat/canvas-render.ts
@@ -1,4 +1,5 @@
 // Renders chat canvas payloads into text and metadata for transcript output.
+import { safeParseJson } from "@openclaw/normalization-core";
 import { asFiniteNumber } from "@openclaw/normalization-core/number-coercion";
 import { asOptionalRecord } from "@openclaw/normalization-core/record-coerce";
 import { parseFenceSpans } from "../../packages/markdown-core/src/fences.js";
@@ -18,18 +19,6 @@ type CanvasPreview = {
   className?: string;
   style?: string;
 };
-
-function tryParseJsonRecord(value: string | undefined): Record<string, unknown> | undefined {
-  if (typeof value !== "string") {
-    return undefined;
-  }
-  try {
-    const parsed = JSON.parse(value);
-    return asOptionalRecord(parsed);
-  } catch {
-    return undefined;
-  }
-}
 
 function getRecordStringField(
   record: Record<string, unknown> | undefined,
@@ -184,7 +173,7 @@ export function extractCanvasFromText(
   outputText: string | undefined,
   _toolName?: string,
 ): CanvasPreview | undefined {
-  const parsed = tryParseJsonRecord(outputText);
+  const parsed = outputText ? asOptionalRecord(safeParseJson(outputText)) : undefined;
   return coerceCanvasPreview(parsed);
 }
 


### PR DESCRIPTION
Closes #99665

## What Problem This Solves

Pure tolerant JSON parsing was reimplemented in several core callers, mixing parsing mechanics with each caller's record coercion and fallback policy.

## Why This Change Was Made

Adds a dependency-free `safeParseJson(value: string): unknown` helper to the existing private `@openclaw/normalization-core` root export and migrates four record-only internal callers. The helper returns `undefined` only for syntax failures; callers still own record coercion, trimming, and defaults.

The earlier package-subpath approach was intentionally removed. This version adds no package export, resolver, tsconfig, Vitest, build-entry, extension-boundary, or Control UI alias plumbing. Logging/redaction parsing and the public `src/utils.ts` null-contract helper remain unchanged because their contracts differ.

## User Impact

No intended user-visible behavior change. The migrated caller slice now shares one parsing primitive while production code decreases.

## Evidence

- Focused tests: `OPENCLAW_HEAVY_CHECK_LOCK_SCOPE=worktree node scripts/run-vitest.mjs packages/normalization-core/src/json-coercion.test.ts src/acp/runtime/session-meta.test.ts src/agents/embedded-agent-message-tool-source-reply.test.ts src/chat/canvas-render.test.ts src/agents/tools/message-tool.internal-source-reply.integration.test.ts` — 37 tests passed across four Vitest shards.
- Build: `pnpm build` — passed, including normalization-core declarations/runtime output, plugin SDK export checks, and Control UI production build.
- Build artifact proof: `packages/normalization-core/dist/index.mjs` and `index.d.mts` export `safeParseJson` through the existing root entry.
- Autoreview: `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main --prompt-file /tmp/pr99688-autoreview.md --stream-engine-output` — clean, no accepted/actionable findings; correctness confidence 0.98.
- Testbox-through-Crabbox was attempted twice (`tbx_01kwqakqby8pg3gwnt3tf476gz`, `tbx_01kwqb2f7dn16tztfg12m8efzf`) but Blacksmith timed out while reading lease status before either command executed; both leases were stopped. AWS fallback was unavailable because broker auth is not configured in this environment.
- Search proof: the four migrated callers contain no direct `JSON.parse`.
- LOC: +34/-41 across 7 files, net -7 overall. Production LOC is +22/-41, net -19.
