### PR TITLE
refactor(infra): consolidate filesystem artifact helpers

### DIFF
--- a/src/acp/event-ledger.ts
+++ b/src/acp/event-ledger.ts
@@ -6,6 +6,7 @@ import type { ContentBlock, SessionUpdate } from "@agentclientprotocol/sdk";
 import { resolveIntegerOption } from "@openclaw/acp-core/numeric-options";
 import { resolveStateDir } from "../config/paths.js";
 import { withFileLock } from "../infra/file-lock.js";
+import { pathExists } from "../infra/fs-safe.js";
 import { readJsonFile } from "../infra/json-files.js";
 import {
   openOpenClawStateDatabase,
@@ -446,20 +447,11 @@ export function resolveDefaultAcpEventLedgerPath(env: NodeJS.ProcessEnv = proces
   return path.join(resolveStateDir(env), "acp", "event-ledger.json");
 }
 
-async function fileExists(filePath: string): Promise<boolean> {
-  try {
-    await fs.access(filePath);
-    return true;
-  } catch {
-    return false;
-  }
-}
-
 /** Migrates a legacy file ledger into the SQLite state database, preserving replay order. */
 export async function migrateFileAcpEventLedgerToSqlite(
   params: { filePath: string; archiveSource?: boolean } & OpenClawStateDatabaseOptions,
 ): Promise<{ importedSessions: number; importedEvents: number; archived?: boolean }> {
-  if (!(await fileExists(params.filePath))) {
+  if (!(await pathExists(params.filePath))) {
     return { importedSessions: 0, importedEvents: 0 };
   }
 
@@ -520,7 +512,7 @@ export async function migrateFileAcpEventLedgerToSqlite(
   }
   const archivePath = `${params.filePath}.migrated`;
   try {
-    if (!(await fileExists(archivePath))) {
+    if (!(await pathExists(archivePath))) {
       await fs.rename(params.filePath, archivePath);
       return { importedSessions, importedEvents, archived: true };
     }

--- a/src/agents/workspace-templates.ts
+++ b/src/agents/workspace-templates.ts
@@ -5,8 +5,8 @@
  */
 import path from "node:path";
 import { fileURLToPath } from "node:url";
+import { pathExists } from "../infra/fs-safe.js";
 import { resolveOpenClawPackageRoot } from "../infra/openclaw-root.js";
-import { pathExists } from "../utils.js";
 
 const FALLBACK_TEMPLATE_DIR = path.resolve(
   path.dirname(fileURLToPath(import.meta.url)),

--- a/src/cli/completion-runtime.ts
+++ b/src/cli/completion-runtime.ts
@@ -7,7 +7,7 @@ import {
   normalizeOptionalString,
 } from "@openclaw/normalization-core/string-coerce";
 import { resolveStateDir } from "../config/paths.js";
-import { pathExists } from "../utils.js";
+import { pathExists } from "../infra/fs-safe.js";
 
 export const COMPLETION_SHELLS = ["zsh", "bash", "powershell", "fish"] as const;
 export type CompletionShell = (typeof COMPLETION_SHELLS)[number];

--- a/src/cli/mcp-cli.ts
+++ b/src/cli/mcp-cli.ts
@@ -31,6 +31,7 @@ import {
 } from "../config/mcp-config.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { formatErrorMessage } from "../infra/errors.js";
+import { pathIsDirectory, pathIsFile } from "../infra/fs-safe-advanced.js";
 import { serveOpenClawChannelMcp } from "../mcp/channel-server.js";
 import { defaultRuntime } from "../runtime.js";
 import { formatCliCommand } from "./command-format.js";
@@ -218,24 +219,6 @@ function resolveConfiguredPath(filePath: string, cwd: unknown): string {
   return path.resolve(base, filePath);
 }
 
-async function fileExists(filePath: string): Promise<boolean> {
-  try {
-    const stat = await fs.stat(filePath);
-    return stat.isFile();
-  } catch {
-    return false;
-  }
-}
-
-async function directoryExists(filePath: string): Promise<boolean> {
-  try {
-    const stat = await fs.stat(filePath);
-    return stat.isDirectory();
-  } catch {
-    return false;
-  }
-}
-
 async function isExecutable(filePath: string): Promise<boolean> {
   try {
     await fs.access(filePath, process.platform === "win32" ? fsConstants.F_OK : fsConstants.X_OK);
@@ -322,7 +305,7 @@ async function collectMcpDoctorIssues(params: {
           issue("error", `stdio command not found or not executable: ${resolved.command}`),
         );
       }
-      if (resolved.cwd && !(await directoryExists(resolved.cwd))) {
+      if (resolved.cwd && !(await pathIsDirectory(resolved.cwd))) {
         issues.push(issue("error", `stdio cwd does not exist: ${resolved.cwd}`));
       }
     }
@@ -352,7 +335,7 @@ async function collectMcpDoctorIssues(params: {
       }
       if (
         resolved.clientCert &&
-        !(await fileExists(resolveConfiguredPath(resolved.clientCert, "")))
+        !(await pathIsFile(resolveConfiguredPath(resolved.clientCert, "")))
       ) {
         issues.push(
           issue("error", `client certificate file does not exist: ${resolved.clientCert}`),
@@ -360,7 +343,7 @@ async function collectMcpDoctorIssues(params: {
       }
       if (
         resolved.clientKey &&
-        !(await fileExists(resolveConfiguredPath(resolved.clientKey, "")))
+        !(await pathIsFile(resolveConfiguredPath(resolved.clientKey, "")))
       ) {
         issues.push(issue("error", `client key file does not exist: ${resolved.clientKey}`));
       }

--- a/src/cli/update-cli.test.ts
+++ b/src/cli/update-cli.test.ts
@@ -220,6 +220,14 @@ vi.mock("../process/exec.js", () => ({
   runCommandWithTimeout: vi.fn(),
 }));
 
+vi.mock("../infra/fs-safe.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../infra/fs-safe.js")>();
+  return {
+    ...actual,
+    pathExists: (...args: unknown[]) => pathExists(...args),
+  };
+});
+
 vi.mock("../utils.js", async (importOriginal) => {
   const actual = await importOriginal<typeof import("../utils.js")>();
   return {
@@ -227,7 +235,6 @@ vi.mock("../utils.js", async (importOriginal) => {
     displayString: (input: string) => input,
     isRecord: (value: unknown) =>
       typeof value === "object" && value !== null && !Array.isArray(value),
-    pathExists: (...args: unknown[]) => pathExists(...args),
     resolveConfigDir: () => "/tmp/openclaw-config",
   };
 });
@@ -888,7 +895,12 @@ describe("update-cli", () => {
       error: null,
       url: "ws://127.0.0.1:18789",
     });
-    pathExists.mockResolvedValue(false);
+    pathExists.mockImplementation(async (candidate: string) =>
+      fs.stat(candidate).then(
+        () => true,
+        () => false,
+      ),
+    );
     syncPluginsForUpdateChannel.mockResolvedValue({
       changed: false,
       config: baseConfig,

--- a/src/cli/update-cli/shared.ts
+++ b/src/cli/update-cli/shared.ts
@@ -5,6 +5,7 @@ import os from "node:os";
 import path from "node:path";
 import { normalizeLowercaseStringOrEmpty } from "@openclaw/normalization-core/string-coerce";
 import { theme } from "../../../packages/terminal-core/src/theme.js";
+import { pathExists } from "../../infra/fs-safe.js";
 import { resolveRequiredHomeDir } from "../../infra/home-dir.js";
 import { resolveOpenClawPackageRoot } from "../../infra/openclaw-root.js";
 import { readPackageName, readPackageVersion } from "../../infra/package-json.js";
@@ -24,7 +25,6 @@ import {
 import type { UpdateStepProgress, UpdateStepResult } from "../../infra/update-runner.js";
 import { runCommandWithTimeout } from "../../process/exec.js";
 import { defaultRuntime } from "../../runtime.js";
-import { pathExists } from "../../utils.js";
 import { COMPLETION_SKIP_PLUGIN_COMMANDS_ENV } from "../completion-runtime.js";
 
 export type UpdateCommandOptions = {

--- a/src/cli/update-cli/wizard.ts
+++ b/src/cli/update-cli/wizard.ts
@@ -5,6 +5,7 @@ import { selectStyled } from "../../../packages/terminal-core/src/prompt-select-
 import { stylePromptMessage } from "../../../packages/terminal-core/src/prompt-style.js";
 import { theme } from "../../../packages/terminal-core/src/theme.js";
 import { readConfigFileSnapshot } from "../../config/config.js";
+import { pathExists } from "../../infra/fs-safe.js";
 import {
   formatUpdateChannelLabel,
   normalizeUpdateChannel,
@@ -12,7 +13,6 @@ import {
 } from "../../infra/update-channels.js";
 import { checkUpdateStatus } from "../../infra/update-check.js";
 import { defaultRuntime } from "../../runtime.js";
-import { pathExists } from "../../utils.js";
 import {
   isEmptyDir,
   isGitCheckout,

--- a/src/commands/backup-shared.ts
+++ b/src/commands/backup-shared.ts
@@ -7,7 +7,8 @@ import {
   resolveOAuthDir,
   resolveStateDir,
 } from "../config/config.js";
-import { pathExists, shortenHomePath } from "../utils.js";
+import { pathExists } from "../infra/fs-safe.js";
+import { shortenHomePath } from "../utils.js";
 import { buildCleanupPlan, isPathWithin } from "./cleanup-utils.js";
 
 export type BackupAssetKind = "state" | "config" | "credentials" | "workspace";

--- a/src/daemon/gateway-entrypoint.ts
+++ b/src/daemon/gateway-entrypoint.ts
@@ -1,6 +1,6 @@
 /** Resolves gateway dist entrypoints used by installed daemon command lines. */
 import path from "node:path";
-import { pathExists } from "../utils.js";
+import { pathExists } from "../infra/fs-safe.js";
 
 const GATEWAY_DIST_ENTRYPOINT_BASENAMES = [
   "index.js",

--- a/src/infra/fs-safe-advanced.ts
+++ b/src/infra/fs-safe-advanced.ts
@@ -1,5 +1,6 @@
 // Provides stricter filesystem helpers for canonical path and symlink-sensitive operations.
 import "./fs-safe-defaults.js";
+import fs from "node:fs/promises";
 
 // Advanced fs-safe helpers for symlink, hardlink, and sibling-temp protections.
 export {
@@ -13,3 +14,19 @@ export {
   type AssertNoSymlinkParentsOptions,
   type FileIdentityStat,
 } from "@openclaw/fs-safe/advanced";
+
+/** Returns true when stat follows the path to a regular file. */
+export async function pathIsFile(filePath: string): Promise<boolean> {
+  return fs.stat(filePath).then(
+    (stat) => stat.isFile(),
+    () => false,
+  );
+}
+
+/** Returns true when stat follows the path to a directory. */
+export async function pathIsDirectory(filePath: string): Promise<boolean> {
+  return fs.stat(filePath).then(
+    (stat) => stat.isDirectory(),
+    () => false,
+  );
+}

--- a/src/infra/fs-safe.test.ts
+++ b/src/infra/fs-safe.test.ts
@@ -10,10 +10,11 @@ import {
   withRealpathSymlinkRebindRace,
 } from "../test-utils/symlink-rebind-race.js";
 import { createTrackedTempDirs } from "../test-utils/tracked-temp-dirs.js";
+import { pathIsDirectory, pathIsFile } from "./fs-safe-advanced.js";
 import {
-  resolveOpenedFileRealPathForHandle,
   FsSafeError,
   readLocalFileSafely,
+  resolveOpenedFileRealPathForHandle,
   root as openRoot,
   writeExternalFileWithinRoot,
 } from "./fs-safe.js";
@@ -121,6 +122,27 @@ async function setupSymlinkWriteRaceFixture(options?: { seedInsideTarget?: boole
 }
 
 describe("fs-safe", () => {
+  it("checks file and directory types with stat symlink semantics", async () => {
+    const dir = await tempDirs.make("openclaw-fs-safe-types-");
+    const file = path.join(dir, "payload.txt");
+    const fileLink = path.join(dir, "payload-link.txt");
+    const dirLink = path.join(dir, "dir-link");
+    const brokenLink = path.join(dir, "broken-link");
+    await fs.writeFile(file, "hello");
+    await fs.symlink(file, fileLink);
+    await fs.symlink(dir, dirLink, process.platform === "win32" ? "junction" : "dir");
+    await fs.symlink(path.join(dir, "missing"), brokenLink);
+
+    await expect(pathIsFile(file)).resolves.toBe(true);
+    await expect(pathIsFile(fileLink)).resolves.toBe(true);
+    await expect(pathIsFile(dir)).resolves.toBe(false);
+    await expect(pathIsDirectory(dir)).resolves.toBe(true);
+    await expect(pathIsDirectory(dirLink)).resolves.toBe(true);
+    await expect(pathIsDirectory(file)).resolves.toBe(false);
+    await expect(pathIsFile(brokenLink)).resolves.toBe(false);
+    await expect(pathIsDirectory(path.join(dir, "missing"))).resolves.toBe(false);
+  });
+
   it("reads a local file safely", async () => {
     const dir = await tempDirs.make("openclaw-fs-safe-");
     const file = path.join(dir, "payload.txt");

--- a/src/infra/json-files.ts
+++ b/src/infra/json-files.ts
@@ -82,6 +82,7 @@ export type WriteTextAtomicOptions = {
   dirMode?: number;
   trailingNewline?: boolean;
   durable?: boolean;
+  preserveExistingMode?: boolean;
   beforeRename?: WriteTextAtomicBeforeRename;
   /**
    * Prefix for the staged `<prefix>.<pid>.<uuid>.tmp` file. Defaults to the
@@ -104,6 +105,7 @@ export async function writeTextAtomic(
     mode: options?.mode ?? 0o600,
     dirMode: options?.dirMode ?? 0o777 & ~process.umask(),
     copyFallbackOnPermissionError: true,
+    preserveExistingMode: options?.preserveExistingMode,
     syncTempFile: options?.durable !== false,
     syncParentDir: options?.durable !== false,
     ...(options?.beforeRename ? { beforeRename: options.beforeRename } : {}),

--- a/src/infra/update-global.ts
+++ b/src/infra/update-global.ts
@@ -5,7 +5,7 @@ import os from "node:os";
 import path from "node:path";
 import { normalizeLowercaseStringOrEmpty } from "@openclaw/normalization-core/string-coerce";
 import { BUNDLED_RUNTIME_SIDECAR_PATHS } from "../plugins/runtime-sidecar-paths.js";
-import { pathExists } from "../utils.js";
+import { pathExists } from "./fs-safe.js";
 import {
   applyNpmFreshnessBypassEnv,
   applyPosixNpmScriptShellEnv,

--- a/src/infra/update-runner.test.ts
+++ b/src/infra/update-runner.test.ts
@@ -7,7 +7,7 @@ import { BUNDLED_RUNTIME_SIDECAR_PATHS } from "../plugins/runtime-sidecar-paths.
 import { createSuiteTempRootTracker } from "../test-helpers/temp-dir.js";
 import { withEnvAsync } from "../test-utils/env.js";
 import { withMockedWindowsPlatform } from "../test-utils/vitest-spies.js";
-import { pathExists } from "../utils.js";
+import { pathExists } from "./fs-safe.js";
 import { writePackageDistInventory } from "./package-dist-inventory.js";
 import { resolveStableNodePath } from "./stable-node-path.js";
 import { runGatewayUpdate } from "./update-runner.js";

--- a/src/plugin-sdk/account-core.ts
+++ b/src/plugin-sdk/account-core.ts
@@ -18,7 +18,8 @@ export {
   normalizeAccountId,
   normalizeOptionalAccountId,
 } from "../routing/session-key.js";
-export { normalizeE164, pathExists, resolveUserPath } from "../utils.js";
+export { pathExists } from "../infra/fs-safe.js";
+export { normalizeE164, resolveUserPath } from "../utils.js";
 export { listConfiguredAccountIds } from "./account-configured-ids.js";
 
 /** Resolve an account by id, then fall back to the default account when the primary lacks credentials. */

--- a/src/plugin-sdk/memory-host-core.ts
+++ b/src/plugin-sdk/memory-host-core.ts
@@ -4,20 +4,12 @@
 import fs from "node:fs/promises";
 import path from "node:path";
 import type { OpenClawConfig } from "../config/config.js";
+import { pathExists } from "../infra/fs-safe.js";
 import type { MemoryPluginPublicArtifact } from "../plugins/memory-state.js";
 import { resolveMemoryDreamingWorkspaces } from "./memory-core-host-status.js";
 import { resolveMemoryHostEventLogPath } from "./memory-host-events.js";
 
 export * from "./memory-core-host-runtime-core.js";
-
-async function pathExists(filePath: string): Promise<boolean> {
-  try {
-    await fs.access(filePath);
-    return true;
-  } catch {
-    return false;
-  }
-}
 
 async function listMarkdownFilesRecursive(rootDir: string): Promise<string[]> {
   const entries = await fs.readdir(rootDir, { withFileTypes: true }).catch(() => []);

--- a/src/plugin-sdk/migration-runtime.test.ts
+++ b/src/plugin-sdk/migration-runtime.test.ts
@@ -158,6 +158,43 @@ describe("copyMigrationFileItem", () => {
 });
 
 describe("writeMigrationReport", () => {
+  it("preserves hardened report permissions on reruns", async () => {
+    if (process.platform === "win32") {
+      return;
+    }
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-migration-report-mode-"));
+    try {
+      const reportDir = path.join(root, "report");
+      const reportPath = path.join(reportDir, "report.json");
+      const summaryPath = path.join(reportDir, "summary.md");
+      await fs.mkdir(reportDir, { mode: 0o700 });
+      await fs.writeFile(reportPath, "{}\n", { mode: 0o600 });
+      await fs.writeFile(summaryPath, "old\n", { mode: 0o600 });
+
+      await writeMigrationReport({
+        providerId: "hermes",
+        source: path.join(root, "hermes"),
+        summary: {
+          total: 0,
+          planned: 0,
+          migrated: 0,
+          skipped: 0,
+          conflicts: 0,
+          errors: 0,
+          sensitive: 0,
+        },
+        items: [],
+        reportDir,
+      });
+
+      expect((await fs.stat(reportDir)).mode & 0o777).toBe(0o700);
+      expect((await fs.stat(reportPath)).mode & 0o777).toBe(0o600);
+      expect((await fs.stat(summaryPath)).mode & 0o777).toBe(0o600);
+    } finally {
+      await fs.rm(root, { recursive: true, force: true });
+    }
+  });
+
   it("redacts nested secret-looking config values in JSON reports", async () => {
     const root = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-migration-report-"));
     const reportDir = path.join(root, "report");

--- a/src/plugin-sdk/migration-runtime.ts
+++ b/src/plugin-sdk/migration-runtime.ts
@@ -4,6 +4,7 @@ import crypto from "node:crypto";
 import fs from "node:fs/promises";
 import path from "node:path";
 import { pathExists } from "../infra/fs-safe.js";
+import { writeTextAtomic } from "../infra/json-files.js";
 import type {
   MigrationApplyResult,
   MigrationItem,
@@ -212,11 +213,21 @@ export async function writeMigrationReport(
   if (!result.reportDir) {
     return;
   }
-  await fs.mkdir(result.reportDir, { recursive: true });
-  await fs.writeFile(
+  const fileMode = 0o666 & ~process.umask();
+  // Atomic replacement chmods the parent, so retain report-directory hardening on reruns.
+  const dirMode = await fs.stat(result.reportDir).then(
+    (stat) => stat.mode & 0o7777,
+    (error: unknown) => {
+      if (error && typeof error === "object" && "code" in error && error.code === "ENOENT") {
+        return 0o777 & ~process.umask();
+      }
+      throw error;
+    },
+  );
+  await writeTextAtomic(
     path.join(result.reportDir, "report.json"),
     `${JSON.stringify(redactMigrationPlan(result), null, 2)}\n`,
-    "utf8",
+    { dirMode, mode: fileMode, preserveExistingMode: true, tempPrefix: "report.json" },
   );
   const lines = [
     `# ${opts.title ?? "Migration Report"}`,
@@ -234,5 +245,10 @@ export async function writeMigrationReport(
       (item) => `- ${item.status}: ${item.id}${item.reason ? ` (${item.reason})` : ""}`,
     ),
   ].filter((line): line is string => typeof line === "string");
-  await fs.writeFile(path.join(result.reportDir, "summary.md"), `${lines.join("\n")}\n`, "utf8");
+  await writeTextAtomic(path.join(result.reportDir, "summary.md"), `${lines.join("\n")}\n`, {
+    dirMode,
+    mode: fileMode,
+    preserveExistingMode: true,
+    tempPrefix: "summary.md",
+  });
 }

--- a/src/plugin-sdk/setup.ts
+++ b/src/plugin-sdk/setup.ts
@@ -25,9 +25,10 @@ export type {
 export { DEFAULT_ACCOUNT_ID, normalizeAccountId } from "../routing/session-key.js";
 export { formatCliCommand } from "../cli/command-format.js";
 export { detectBinary } from "../infra/detect-binary.js";
+export { pathExists } from "../infra/fs-safe.js";
 export { formatDocsLink } from "../../packages/terminal-core/src/links.js";
 export { hasConfiguredSecretInput, normalizeSecretInputString } from "../config/types.secrets.js";
-export { normalizeE164, pathExists } from "../utils.js";
+export { normalizeE164 } from "../utils.js";
 
 export {
   moveSingleAccountChannelSectionToDefaultAccount,

--- a/src/plugin-sdk/text-runtime.ts
+++ b/src/plugin-sdk/text-runtime.ts
@@ -52,7 +52,6 @@ export {
   escapeRegExp,
   isRecord,
   normalizeE164,
-  pathExists,
   resolveConfigDir,
   resolveHomeDir,
   resolveUserPath,
@@ -63,3 +62,4 @@ export {
   sliceUtf16Safe,
   truncateUtf16Safe,
 } from "../utils.js";
+export { pathExists } from "../infra/fs-safe.js";

--- a/src/plugin-sdk/text-utility-runtime.ts
+++ b/src/plugin-sdk/text-utility-runtime.ts
@@ -10,7 +10,6 @@ export {
   ensureDir,
   escapeRegExp,
   normalizeE164,
-  pathExists,
   resolveConfigDir,
   resolveHomeDir,
   resolveUserPath,
@@ -21,5 +20,6 @@ export {
   sliceUtf16Safe,
   truncateUtf16Safe,
 } from "../utils.js";
+export { pathExists } from "../infra/fs-safe.js";
 export { fetchWithTimeout } from "../utils/fetch-timeout.js";
 export { withTimeout } from "../utils/with-timeout.js";

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -2,7 +2,6 @@
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import { pathExists as fsSafePathExists } from "./infra/fs-safe.js";
 import {
   resolveEffectiveHomeDir,
   resolveHomeRelativePath,
@@ -176,10 +175,4 @@ export let CONFIG_DIR = resolveConfigDir();
 export function pinConfigDir(env: NodeJS.ProcessEnv = process.env): string {
   CONFIG_DIR = resolveConfigDir(env);
   return CONFIG_DIR;
-}
-/**
- * Check if a file or directory exists at the given path.
- */
-export async function pathExists(targetPath: string): Promise<boolean> {
-  return await fsSafePathExists(targetPath);
 }

--- a/src/wizard/setup.completion.ts
+++ b/src/wizard/setup.completion.ts
@@ -12,7 +12,7 @@ import {
   checkShellCompletionStatus,
   ensureCompletionCacheExists,
 } from "../commands/doctor-completion.js";
-import { pathExists } from "../utils.js";
+import { pathExists } from "../infra/fs-safe.js";
 import { t } from "./i18n/index.js";
 import type { WizardPrompter } from "./prompts.js";
 import type { WizardFlow } from "./setup.types.js";


### PR DESCRIPTION
## What Problem This Solves

Filesystem existence/type checks and named migration report writes still had duplicate owner-local implementations after the broader fs-safe extraction. That left stat/symlink/error semantics distributed across callers and kept migration artifacts on direct non-atomic writes.

Follow-up context: #56974 covered the earlier existence-helper extraction and is already closed as shipped.

## Why This Change Was Made

- Keep canonical `pathExists` in `src/infra/fs-safe.ts` and add internal stat-following `pathIsFile` and `pathIsDirectory` in `src/infra/fs-safe-advanced.ts` without expanding the plugin SDK surface.
- Remove the duplicate `src/utils.ts` implementation and route internal/public SDK exports to the infra owner.
- Migrate exact-contract MCP, memory artifact, and legacy ACP-to-SQLite checks while leaving lstat, sync, ENOENT-propagating, and cleanup-boundary variants local.
- Route plugin migration `report.json` and `summary.md` through `writeTextAtomic` with durable sibling-temp replacement, identifiable temp prefixes, cleanup, and preserved rerun permissions.
- Keep runtime state/cache file writers out of this helper migration; ACP file access remains migration-only and steady-state storage remains SQLite.

## User Impact

No user-facing API or config changes. Filesystem checks retain existing stat-following symlink behavior and false-on-stat-error behavior. Migration reports become crash-safe without widening existing file or directory permissions.

## Evidence

- `node scripts/run-vitest.mjs src/infra/fs-safe.test.ts src/infra/json-files.test.ts src/cli/mcp-cli.test.ts src/plugin-sdk/migration-runtime.test.ts`
- `node scripts/run-vitest.mjs src/cli/update-cli.test.ts`
- `node scripts/run-vitest.mjs src/plugin-sdk/api-baseline.test.ts`
- `node scripts/run-vitest.mjs src/acp/event-ledger.test.ts src/acp/translator.event-ledger.test.ts src/plugin-sdk/memory-host-core.test.ts`
- `node scripts/run-vitest.mjs run --config test/vitest/vitest.tooling.config.ts test/scripts/plugin-sdk-surface-report.test.ts --reporter=verbose`: 8 tests passed with no baseline edits.
- Blacksmith Testbox `tbx_01kwn5vzkws1j7y3bedj510wbp`: `corepack pnpm check:changed` passed on exact head `425d9b5a652119fec019350d5355bd575f693307` across core, tests, extensions, typechecks, lint, storage guards, and import-cycle checks.
- `.agents/skills/autoreview/scripts/autoreview --mode commit --commit HEAD --prompt-file tmp/autoreview-context.md --stream-engine-output`: final run clean, no accepted/actionable findings.
