### PR TITLE
fix(infra): include update timeout in managed-service handoff parent exit wait

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ Docs: https://docs.openclaw.ai
 - **Plugin install diagnostics:** suppress the misleading hook-pack fallback after plugin install failures only when the hook manifest is absent, while preserving actionable malformed hook-pack errors. (#100554) Thanks @vincentkoc.
 - **Config validation diagnostics:** emit each unchanged sanitized validation-warning payload once per config path, reset deduplication after a clean validation, and preserve the warning fingerprint across transient invalid reads and failed refreshes. (#100569, #25574) Thanks @vincentkoc.
 - **Config size-drop guard:** compare writes against canonical bytes for parseable object configs instead of raw BOM and indentation overhead, while preserving raw audit telemetry and the conservative malformed-input fallback. (#100591, #71865) Thanks @vincentkoc.
+- **Managed update handoffs:** keep detached update helpers alive for the configured Gateway restart-drain window, including indefinite drains, before applying the bounded shutdown reserve. (#99695) Thanks @ZOOWH.
 - **Control UI coalesced updates:** show a clear queued-restart completion banner when an update joins an already-running Gateway restart. (#93082) Thanks @goutamadwant.
 - **Control UI connection errors:** preserve structured pairing and authentication failures for pending RPC callers while keeping generic disconnect behavior unchanged. (#54758) Thanks @ruanrrn.
 - **TUI startup status:** show `starting up` during post-connect initialization without overwriting active-run or reconnect state. (#93999) Thanks @ml12580.

--- a/src/cli/gateway-cli/run-loop.test.ts
+++ b/src/cli/gateway-cli/run-loop.test.ts
@@ -1740,34 +1740,37 @@ describe("runGatewayLoop", () => {
     });
   });
 
-  it("writes a handoff before exiting for supervised update restarts", async () => {
-    vi.clearAllMocks();
-    peekGatewaySigusr1RestartReason.mockReturnValue("update.run");
-    respawnGatewayProcessForUpdate.mockReturnValueOnce({
-      mode: "supervised",
-    });
-    try {
-      setPlatform("freebsd");
-      await withIsolatedSignals(async ({ captureSignal }) => {
-        const { runtime, exited } = await createSignaledLoopHarness();
-        const sigusr1 = captureSignal("SIGUSR1");
-
-        sigusr1();
-
-        await expect(exited).resolves.toBe(0);
-        expect(runtime.exit).toHaveBeenCalledWith(0);
-        expectRestartHandoffCall({
-          restartKind: "update-process",
-          reason: "update.run",
-          supervisorMode: "external",
-        });
+  it.each(["update.run", "update.auto"] as const)(
+    "writes a handoff before exiting for supervised %s restarts",
+    async (reason) => {
+      vi.clearAllMocks();
+      peekGatewaySigusr1RestartReason.mockReturnValue(reason);
+      respawnGatewayProcessForUpdate.mockReturnValueOnce({
+        mode: "supervised",
       });
-    } finally {
-      if (originalPlatformDescriptor) {
-        Object.defineProperty(process, "platform", originalPlatformDescriptor);
+      try {
+        setPlatform("freebsd");
+        await withIsolatedSignals(async ({ captureSignal }) => {
+          const { runtime, exited } = await createSignaledLoopHarness();
+          const sigusr1 = captureSignal("SIGUSR1");
+
+          sigusr1();
+
+          await expect(exited).resolves.toBe(0);
+          expect(runtime.exit).toHaveBeenCalledWith(0);
+          expectRestartHandoffCall({
+            restartKind: "update-process",
+            reason,
+            supervisorMode: "external",
+          });
+        });
+      } finally {
+        if (originalPlatformDescriptor) {
+          Object.defineProperty(process, "platform", originalPlatformDescriptor);
+        }
       }
-    }
-  });
+    },
+  );
 
   it("probes the configured gateway host for update respawn health", async () => {
     vi.clearAllMocks();

--- a/src/cli/gateway-cli/run-loop.test.ts
+++ b/src/cli/gateway-cli/run-loop.test.ts
@@ -1772,6 +1772,109 @@ describe("runGatewayLoop", () => {
     },
   );
 
+  it("upgrades an accepted restart when a managed update arrives during shutdown", async () => {
+    vi.clearAllMocks();
+    consumeGatewayRestartIntentPayloadSync.mockReset();
+    consumeGatewayRestartIntentPayloadSync.mockReturnValue(null);
+    consumeGatewaySigusr1RestartIntent.mockReset();
+    consumeGatewaySigusr1RestartIntent.mockReturnValue(null);
+    consumeGatewaySigusr1RestartAuthorization.mockReset();
+    consumeGatewaySigusr1RestartAuthorization.mockReturnValue(true);
+    peekGatewaySigusr1RestartReason.mockReset();
+    peekGatewaySigusr1RestartReason
+      .mockReturnValueOnce("config.patch")
+      .mockReturnValueOnce("update.auto");
+    respawnGatewayProcessForUpdate.mockReturnValueOnce({ mode: "supervised" });
+
+    let releaseClose: () => void = () => {};
+    const close = vi.fn<GatewayCloseFn>(
+      () =>
+        new Promise<void>((resolve) => {
+          releaseClose = resolve;
+        }),
+    );
+
+    await withIsolatedSignals(async ({ captureSignal }) => {
+      const { start, started } = createSignaledStart(close);
+      const { runtime, exited } = createRuntimeWithExitSignal();
+      await runLoopWithStart({ start, runtime });
+      await waitForStart(started);
+      const sigusr1 = captureSignal("SIGUSR1");
+
+      sigusr1();
+      await waitForLoopCondition(
+        () => close.mock.calls.length === 1,
+        "restart close did not start",
+      );
+      sigusr1();
+      await waitForLoopCondition(
+        () =>
+          gatewayLog.info.mock.calls.some(([message]) =>
+            String(message).includes("upgrading to update.auto"),
+          ),
+        "accepted restart was not upgraded",
+      );
+
+      releaseClose();
+      await expect(exited).resolves.toBe(0);
+      expect(respawnGatewayProcessForUpdate).toHaveBeenCalledTimes(1);
+      expectRestartHandoffCall({
+        restartKind: "update-process",
+        reason: "update.auto",
+        supervisorMode: "external",
+      });
+    });
+  });
+
+  it("reads a managed update upgrade after asynchronous lock release", async () => {
+    vi.clearAllMocks();
+    consumeGatewayRestartIntentPayloadSync.mockReset();
+    consumeGatewayRestartIntentPayloadSync.mockReturnValue(null);
+    consumeGatewaySigusr1RestartIntent.mockReset();
+    consumeGatewaySigusr1RestartIntent.mockReturnValue(null);
+    consumeGatewaySigusr1RestartAuthorization.mockReset();
+    consumeGatewaySigusr1RestartAuthorization.mockReturnValue(true);
+    peekGatewaySigusr1RestartReason.mockReset();
+    peekGatewaySigusr1RestartReason
+      .mockReturnValueOnce("config.patch")
+      .mockReturnValueOnce("update.auto");
+    respawnGatewayProcessForUpdate.mockReturnValueOnce({ mode: "supervised" });
+
+    let releaseLock: () => void = () => {};
+    const lockReleaseBlocked = new Promise<void>((resolve) => {
+      releaseLock = resolve;
+    });
+    const lockRelease = vi.fn(async () => {
+      await lockReleaseBlocked;
+    });
+    acquireGatewayLock.mockResolvedValueOnce({ release: lockRelease });
+
+    await withIsolatedSignals(async ({ captureSignal }) => {
+      const { runtime, exited } = await createSignaledLoopHarness();
+      const sigusr1 = captureSignal("SIGUSR1");
+
+      sigusr1();
+      await waitForLoopCondition(
+        () => lockRelease.mock.calls.length === 1,
+        "restart did not reach lock release",
+      );
+      sigusr1();
+      await waitForLoopCondition(
+        () =>
+          gatewayLog.info.mock.calls.some(([message]) =>
+            String(message).includes("upgrading to update.auto"),
+          ),
+        "lock-release restart was not upgraded",
+      );
+
+      releaseLock();
+      await expect(exited).resolves.toBe(0);
+      expect(respawnGatewayProcessForUpdate).toHaveBeenCalledTimes(1);
+      expect(restartGatewayProcessWithFreshPid).not.toHaveBeenCalled();
+      expect(runtime.exit).toHaveBeenCalledWith(0);
+    });
+  });
+
   it("probes the configured gateway host for update respawn health", async () => {
     vi.clearAllMocks();
     peekGatewaySigusr1RestartReason.mockReturnValue("update.run");

--- a/src/cli/gateway-cli/run-loop.test.ts
+++ b/src/cli/gateway-cli/run-loop.test.ts
@@ -1794,36 +1794,43 @@ describe("runGatewayLoop", () => {
         }),
     );
 
-    await withIsolatedSignals(async ({ captureSignal }) => {
-      const { start, started } = createSignaledStart(close);
-      const { runtime, exited } = createRuntimeWithExitSignal();
-      await runLoopWithStart({ start, runtime });
-      await waitForStart(started);
-      const sigusr1 = captureSignal("SIGUSR1");
+    try {
+      setPlatform("freebsd");
+      await withIsolatedSignals(async ({ captureSignal }) => {
+        const { start, started } = createSignaledStart(close);
+        const { runtime, exited } = createRuntimeWithExitSignal();
+        await runLoopWithStart({ start, runtime });
+        await waitForStart(started);
+        const sigusr1 = captureSignal("SIGUSR1");
 
-      sigusr1();
-      await waitForLoopCondition(
-        () => close.mock.calls.length === 1,
-        "restart close did not start",
-      );
-      sigusr1();
-      await waitForLoopCondition(
-        () =>
-          gatewayLog.info.mock.calls.some(([message]) =>
-            String(message).includes("upgrading to update.auto"),
-          ),
-        "accepted restart was not upgraded",
-      );
+        sigusr1();
+        await waitForLoopCondition(
+          () => close.mock.calls.length === 1,
+          "restart close did not start",
+        );
+        sigusr1();
+        await waitForLoopCondition(
+          () =>
+            gatewayLog.info.mock.calls.some(([message]) =>
+              String(message).includes("upgrading to update.auto"),
+            ),
+          "accepted restart was not upgraded",
+        );
 
-      releaseClose();
-      await expect(exited).resolves.toBe(0);
-      expect(respawnGatewayProcessForUpdate).toHaveBeenCalledTimes(1);
-      expectRestartHandoffCall({
-        restartKind: "update-process",
-        reason: "update.auto",
-        supervisorMode: "external",
+        releaseClose();
+        await expect(exited).resolves.toBe(0);
+        expect(respawnGatewayProcessForUpdate).toHaveBeenCalledTimes(1);
+        expectRestartHandoffCall({
+          restartKind: "update-process",
+          reason: "update.auto",
+          supervisorMode: "external",
+        });
       });
-    });
+    } finally {
+      if (originalPlatformDescriptor) {
+        Object.defineProperty(process, "platform", originalPlatformDescriptor);
+      }
+    }
   });
 
   it("reads a managed update upgrade after asynchronous lock release", async () => {

--- a/src/cli/gateway-cli/run-loop.ts
+++ b/src/cli/gateway-cli/run-loop.ts
@@ -40,6 +40,10 @@ type GatewayRunSignalRequest = {
 
 type GatewayLifecycleRuntimeModule = typeof import("./lifecycle.runtime.js");
 
+function isUpdateProcessRestartReason(reason: string | undefined): boolean {
+  return reason === "update.run" || reason === "update.auto";
+}
+
 const gatewayLifecycleRuntimeLoader = createLazyImportLoader<GatewayLifecycleRuntimeModule>(
   () => import("./lifecycle.runtime.js"),
 );
@@ -137,6 +141,7 @@ export async function runGatewayLoop(params: {
   // The HTTP server can report ready before params.start returns its close handle.
   // Defer lifecycle signals from that window until the loop can close and advance.
   let pendingStartupRequest: GatewayRunSignalRequest | null = null;
+  let activeRestartRequest: GatewayRunSignalRequest | null = null;
   let pendingStartupForceExitTimer: ReturnType<typeof setTimeout> | null = null;
   let restartDrainingMarkPromise: Promise<void> | null = null;
   let startupFailedWithoutServerHandle = false;
@@ -182,13 +187,8 @@ export async function runGatewayLoop(params: {
       return false;
     }
   };
-  const handleRestartAfterServerClose = async (restartReason?: string) => {
-    params.completeBoot?.({
-      outcome: "planned_restart",
-      reason: restartReason ?? "gateway.restart",
-    });
-    const hadLock = await releaseLockIfHeld();
-    const isUpdateRestart = restartReason === "update.run" || restartReason === "update.auto";
+  const handleRestartAfterServerClose = async () => {
+    await releaseLockIfHeld();
     const {
       detectRespawnSupervisor,
       markUpdateRestartSentinelFailure,
@@ -196,6 +196,14 @@ export async function runGatewayLoop(params: {
       restartGatewayProcessWithFreshPid,
       writeGatewayRestartHandoffSync,
     } = await loadGatewayLifecycleRuntimeModule();
+    // Lock release and lazy lifecycle loading may yield while a managed update
+    // upgrades this restart. Keep the request live until a restart path commits.
+    const restartReason = activeRestartRequest?.restartReason;
+    params.completeBoot?.({
+      outcome: "planned_restart",
+      reason: restartReason ?? "gateway.restart",
+    });
+    const isUpdateRestart = isUpdateProcessRestartReason(restartReason);
 
     if (isUpdateRestart) {
       const restartTraceHandoff = captureGatewayRestartTraceHandoff();
@@ -209,6 +217,7 @@ export async function runGatewayLoop(params: {
             ? await waitForHealthyChild(port, respawn.pid, params.healthHost ?? "127.0.0.1")
             : false;
         if (healthy) {
+          activeRestartRequest = null;
           gatewayLog.info(
             `restart mode: update process respawn (spawned pid ${respawn.pid ?? "unknown"})`,
           );
@@ -226,7 +235,7 @@ export async function runGatewayLoop(params: {
         await markUpdateRestartSentinelFailure("restart-unhealthy").catch((err: unknown) => {
           gatewayLog.warn(`failed to mark update restart sentinel unhealthy: ${String(err)}`);
         });
-        if (hadLock && !(await reacquireLockForInProcessRestart())) {
+        if (!(await reacquireLockForInProcessRestart())) {
           return;
         }
         shuttingDown = false;
@@ -234,6 +243,7 @@ export async function runGatewayLoop(params: {
         return;
       }
       if (respawn.mode === "supervised") {
+        activeRestartRequest = null;
         const supervisorMode = detectRespawnSupervisor(process.env, process.platform);
         markGatewayRestartTrace("restart.full-process-handoff", [
           ["kind", "update-process"],
@@ -271,6 +281,7 @@ export async function runGatewayLoop(params: {
       if (!(await reacquireLockForInProcessRestart())) {
         return;
       }
+      activeRestartRequest = null;
       shuttingDown = false;
       restartResolver?.();
       return;
@@ -282,6 +293,7 @@ export async function runGatewayLoop(params: {
       env: createGatewayRestartTraceHandoffEnv(restartTraceHandoff),
     });
     if (respawn.mode === "spawned" || respawn.mode === "supervised") {
+      activeRestartRequest = null;
       const supervisorMode =
         respawn.mode === "supervised"
           ? detectRespawnSupervisor(process.env, process.platform)
@@ -326,9 +338,18 @@ export async function runGatewayLoop(params: {
         `restart mode: in-process restart (${respawn.detail ?? "OPENCLAW_NO_RESPAWN"})`,
       );
     }
+    if (isUpdateProcessRestartReason(activeRestartRequest?.restartReason)) {
+      await handleRestartAfterServerClose();
+      return;
+    }
     if (!(await reacquireLockForInProcessRestart())) {
       return;
     }
+    if (isUpdateProcessRestartReason(activeRestartRequest?.restartReason)) {
+      await handleRestartAfterServerClose();
+      return;
+    }
+    activeRestartRequest = null;
     shuttingDown = false;
     restartResolver?.();
   };
@@ -398,12 +419,12 @@ export async function runGatewayLoop(params: {
     await restartDrainingMarkPromise;
   };
 
-  const runAcceptedRequest = ({
-    action,
-    restartReason,
-    restartIntent,
-  }: GatewayRunSignalRequest) => {
+  const runAcceptedRequest = (acceptedRequest: GatewayRunSignalRequest) => {
+    const { action, restartIntent } = acceptedRequest;
     const isRestart = action === "restart";
+    if (isRestart) {
+      activeRestartRequest = acceptedRequest;
+    }
     let forceExitTimer: ReturnType<typeof setTimeout> | null = null;
     const armForceExitTimer = (forceExitMs: number) => {
       if (forceExitTimer) {
@@ -649,7 +670,7 @@ export async function runGatewayLoop(params: {
         clearForceExitTimer();
         server = null;
         if (isRestart) {
-          await handleRestartAfterServerClose(restartReason);
+          await handleRestartAfterServerClose();
         } else {
           await handleStopAfterServerClose();
         }
@@ -677,6 +698,27 @@ export async function runGatewayLoop(params: {
   ) => {
     const acceptedRequest = { action, signal, restartReason, restartIntent };
     if (shuttingDown) {
+      const currentRestartRequest = pendingStartupRequest ?? activeRestartRequest;
+      if (
+        action === "restart" &&
+        isUpdateProcessRestartReason(restartReason) &&
+        currentRestartRequest?.action === "restart" &&
+        !isUpdateProcessRestartReason(currentRestartRequest.restartReason)
+      ) {
+        const upgradedRequest = {
+          ...currentRestartRequest,
+          signal,
+          restartReason,
+          restartIntent: restartIntent ?? currentRestartRequest.restartIntent,
+        };
+        if (pendingStartupRequest) {
+          pendingStartupRequest = upgradedRequest;
+        } else {
+          activeRestartRequest = upgradedRequest;
+        }
+        gatewayLog.info(`received ${signal} during shutdown; upgrading to ${restartReason}`);
+        return;
+      }
       if (action === "stop" && pendingStartupRequest && !server) {
         gatewayLog.info(`received ${signal}; overriding pending startup restart with shutdown`);
         pendingStartupRequest = null;

--- a/src/cli/gateway-cli/run-loop.ts
+++ b/src/cli/gateway-cli/run-loop.ts
@@ -142,6 +142,7 @@ export async function runGatewayLoop(params: {
   // Defer lifecycle signals from that window until the loop can close and advance.
   let pendingStartupRequest: GatewayRunSignalRequest | null = null;
   let activeRestartRequest: GatewayRunSignalRequest | null = null;
+  let forceActiveRestartExit: (() => void) | null = null;
   let pendingStartupForceExitTimer: ReturnType<typeof setTimeout> | null = null;
   let restartDrainingMarkPromise: Promise<void> | null = null;
   let startupFailedWithoutServerHandle = false;
@@ -456,6 +457,12 @@ export async function runGatewayLoop(params: {
       clearTimeout(forceExitTimer);
       forceExitTimer = null;
     };
+    if (isRestart) {
+      forceActiveRestartExit = () => {
+        clearForceExitTimer();
+        armForceExitTimer(SHUTDOWN_TIMEOUT_MS);
+      };
+    }
 
     void (async () => {
       const restartDrainTimeoutMs = isRestart
@@ -667,11 +674,16 @@ export async function runGatewayLoop(params: {
       } catch (err) {
         gatewayLog.error(`shutdown error: ${String(err)}`);
       } finally {
-        clearForceExitTimer();
         server = null;
         if (isRestart) {
-          await handleRestartAfterServerClose();
+          try {
+            await handleRestartAfterServerClose();
+          } finally {
+            clearForceExitTimer();
+            forceActiveRestartExit = null;
+          }
         } else {
+          clearForceExitTimer();
           await handleStopAfterServerClose();
         }
       }
@@ -709,12 +721,18 @@ export async function runGatewayLoop(params: {
           ...currentRestartRequest,
           signal,
           restartReason,
-          restartIntent: restartIntent ?? currentRestartRequest.restartIntent,
+          restartIntent: {
+            ...currentRestartRequest.restartIntent,
+            ...restartIntent,
+            force: true,
+            reason: restartReason,
+          },
         };
         if (pendingStartupRequest) {
           pendingStartupRequest = upgradedRequest;
         } else {
           activeRestartRequest = upgradedRequest;
+          forceActiveRestartExit?.();
         }
         gatewayLog.info(`received ${signal} during shutdown; upgrading to ${restartReason}`);
         return;

--- a/src/cli/gateway-cli/run-loop.ts
+++ b/src/cli/gateway-cli/run-loop.ts
@@ -188,7 +188,7 @@ export async function runGatewayLoop(params: {
       reason: restartReason ?? "gateway.restart",
     });
     const hadLock = await releaseLockIfHeld();
-    const isUpdateRestart = restartReason === "update.run";
+    const isUpdateRestart = restartReason === "update.run" || restartReason === "update.auto";
     const {
       detectRespawnSupervisor,
       markUpdateRestartSentinelFailure,

--- a/src/gateway/server-methods/update.test.ts
+++ b/src/gateway/server-methods/update.test.ts
@@ -453,6 +453,7 @@ describe("update.run restart scheduling", () => {
       expect.objectContaining({
         root: "/tmp/openclaw",
         restartDrainTimeoutMs: 60_000,
+        restartDelayMs: 2000,
         handoffId: expect.any(String),
         supervisor: "launchd",
         meta: expect.objectContaining({

--- a/src/gateway/server-methods/update.test.ts
+++ b/src/gateway/server-methods/update.test.ts
@@ -10,6 +10,7 @@ import { withEnvAsync } from "../../test-utils/env.js";
 
 // Capture the sentinel payload written during update.run
 let capturedPayload: RestartSentinelPayload | undefined;
+let restartSentinelWriteError: Error | null = null;
 
 const runGatewayUpdateMock = vi.fn<() => Promise<UpdateRunResult>>();
 const resolveUpdateInstallSurfaceMock = vi.fn<() => Promise<UpdateInstallSurface>>(async () => ({
@@ -97,6 +98,9 @@ vi.mock("../../infra/restart-sentinel.js", async () => {
   return {
     ...(actual as Record<string, unknown>),
     writeRestartSentinel: async (payload: RestartSentinelPayload) => {
+      if (restartSentinelWriteError) {
+        throw restartSentinelWriteError;
+      }
       capturedPayload = payload;
     },
   };
@@ -186,6 +190,7 @@ vi.mock("./validation.js", () => ({
 
 beforeEach(() => {
   capturedPayload = undefined;
+  restartSentinelWriteError = null;
   isRestartEnabledMock.mockReset();
   isRestartEnabledMock.mockReturnValue(true);
   readPackageVersionMock.mockClear();
@@ -512,6 +517,21 @@ describe("update.run restart scheduling", () => {
     );
   });
 
+  it("arms the managed restart before optional sentinel persistence", async () => {
+    detectRespawnSupervisorMock.mockReturnValueOnce("launchd");
+    mockGlobalInstallSurface();
+    restartSentinelWriteError = new Error("state database unavailable");
+
+    const payload = await withProcessEnv({ OPENCLAW_LAUNCHD_LABEL: "ai.openclaw.gateway" }, () =>
+      captureUpdateRunPayload(),
+    );
+
+    expect(startManagedServiceUpdateHandoffMock).toHaveBeenCalledTimes(1);
+    expect(scheduleGatewaySigusr1RestartMock).toHaveBeenCalledTimes(1);
+    expect(payload?.sentinel?.persisted).toBe(false);
+    expect(payload?.ok).toBe(true);
+  });
+
   it("keeps a startup grace before restarting after systemd handoff spawn", async () => {
     detectRespawnSupervisorMock.mockReturnValueOnce("systemd");
     mockGlobalInstallSurface();
@@ -523,7 +543,7 @@ describe("update.run restart scheduling", () => {
     expect(startManagedServiceUpdateHandoffMock).toHaveBeenCalledWith(
       expect.objectContaining({
         supervisor: "systemd",
-        restartDelayMs: 0,
+        restartDelayMs: 2000,
       }),
     );
     expect(scheduleGatewaySigusr1RestartMock).toHaveBeenCalledWith(

--- a/src/gateway/server-methods/update.test.ts
+++ b/src/gateway/server-methods/update.test.ts
@@ -103,6 +103,12 @@ vi.mock("../../infra/restart-sentinel.js", async () => {
 });
 
 vi.mock("../../infra/restart.js", () => ({
+  resolveGatewayRestartDeferralTimeoutMs: (timeoutMs: unknown) => {
+    if (typeof timeoutMs !== "number" || !Number.isFinite(timeoutMs)) {
+      return 300_000;
+    }
+    return timeoutMs <= 0 ? undefined : Math.floor(timeoutMs);
+  },
   scheduleGatewaySigusr1Restart: scheduleGatewaySigusr1RestartMock,
 }));
 
@@ -235,23 +241,29 @@ beforeEach(() => {
 async function invokeUpdateRun(
   params: Record<string, unknown>,
   respond?: (ok: boolean, response?: unknown) => void,
+  runtimeConfig: OpenClawConfig = { update: {} },
 ) {
   const { updateHandlers } = await import("./update.js");
   const onRespond = respond ?? (() => {});
   await updateHandlers["update.run"]({
     params,
     respond: onRespond as never,
-    context: { getRuntimeConfig: () => ({ update: {} }) },
+    context: { getRuntimeConfig: () => runtimeConfig },
   } as never);
 }
 
 async function captureUpdateRunPayload(
   params: Record<string, unknown> = {},
+  runtimeConfig?: OpenClawConfig,
 ): Promise<UpdateRunPayload | undefined> {
   let payload: UpdateRunPayload | undefined;
-  await invokeUpdateRun(params, (_ok: boolean, response: unknown) => {
-    payload = response as UpdateRunPayload;
-  });
+  await invokeUpdateRun(
+    params,
+    (_ok: boolean, response: unknown) => {
+      payload = response as UpdateRunPayload;
+    },
+    runtimeConfig,
+  );
   return payload;
 }
 
@@ -427,7 +439,7 @@ describe("update.run restart scheduling", () => {
     mockGlobalInstallSurface();
 
     const payload = await withProcessEnv({ OPENCLAW_LAUNCHD_LABEL: "ai.openclaw.gateway" }, () =>
-      captureUpdateRunPayload(),
+      captureUpdateRunPayload({}, { gateway: { reload: { deferralTimeoutMs: 60_000 } } }),
     );
 
     expect(runGatewayUpdateMock).not.toHaveBeenCalled();
@@ -435,6 +447,7 @@ describe("update.run restart scheduling", () => {
     expect(startManagedServiceUpdateHandoffMock).toHaveBeenCalledWith(
       expect.objectContaining({
         root: "/tmp/openclaw",
+        restartDrainTimeoutMs: 60_000,
         handoffId: expect.any(String),
         supervisor: "launchd",
         meta: expect.objectContaining({
@@ -483,6 +496,19 @@ describe("update.run restart scheduling", () => {
           reason: "managed-service-handoff-started",
         }),
       }),
+    );
+  });
+
+  it("preserves an indefinite restart drain for managed updates", async () => {
+    detectRespawnSupervisorMock.mockReturnValueOnce("launchd");
+    mockGlobalInstallSurface();
+
+    await withProcessEnv({ OPENCLAW_LAUNCHD_LABEL: "ai.openclaw.gateway" }, () =>
+      captureUpdateRunPayload({}, { gateway: { reload: { deferralTimeoutMs: 0 } } }),
+    );
+
+    expect(startManagedServiceUpdateHandoffMock).toHaveBeenCalledWith(
+      expect.objectContaining({ restartDrainTimeoutMs: undefined }),
     );
   });
 

--- a/src/gateway/server-methods/update.ts
+++ b/src/gateway/server-methods/update.ts
@@ -168,6 +168,7 @@ export const updateHandlers: GatewayRequestHandlers = {
       | { status: "started"; pid?: number; command: string }
       | { status: "unavailable"; command: string; message: string }
       | null = null;
+    let managedHandoffRestart: ReturnType<typeof scheduleGatewaySigusr1Restart> | null = null;
     const sentinelMeta: UpdateRestartSentinelMeta = {
       ...(sessionKey ? { sessionKey } : {}),
       ...(deliveryContext ? { deliveryContext } : {}),
@@ -233,8 +234,15 @@ export const updateHandlers: GatewayRequestHandlers = {
         });
         if (supervisor && hasHandoffContext) {
           try {
+            const beforeVersion = installSurface.root
+              ? await readPackageVersion(installSurface.root)
+              : null;
             const startedAt = Date.now();
             const handoffId = randomUUID();
+            const managedRestartDelayMs = resolveManagedServiceHandoffRestartDelayMs(
+              restartDelayMs,
+              supervisor,
+            );
             sentinelMeta.handoffId = handoffId;
             // Managed services update from a detached helper so the running
             // gateway does not replace its own package or git-built dist tree
@@ -246,7 +254,7 @@ export const updateHandlers: GatewayRequestHandlers = {
                 config.gateway?.reload?.deferralTimeoutMs,
               ),
               ...(handoffChannel ? { channel: handoffChannel } : {}),
-              restartDelayMs,
+              restartDelayMs: managedRestartDelayMs,
               meta: sentinelMeta,
               handoffId,
               supervisor,
@@ -256,9 +264,20 @@ export const updateHandlers: GatewayRequestHandlers = {
               ...(started.pid ? { pid: started.pid } : {}),
               command: started.command,
             };
-            const beforeVersion = installSurface.root
-              ? await readPackageVersion(installSurface.root)
-              : null;
+            // Once the detached helper exists, arm its parent exit without an
+            // intervening await so persistence failures cannot orphan it.
+            managedHandoffRestart = scheduleGatewaySigusr1Restart({
+              delayMs: managedRestartDelayMs,
+              reason: "update.run",
+              skipDeferral: true,
+              skipCooldown: true,
+              audit: {
+                actor: actor.actor,
+                deviceId: actor.deviceId,
+                clientIp: actor.clientIp,
+                changedPaths: [],
+              },
+            });
             result = {
               status: "skipped",
               mode: installSurface.mode,
@@ -369,19 +388,15 @@ export const updateHandlers: GatewayRequestHandlers = {
     // (corrupted node_modules, partial builds) and causes a crash loop.
     const updateWasPackageSwap = result.status === "ok" && result.mode !== "git";
     const restart =
-      handoff?.status === "started" || result.status === "ok"
+      managedHandoffRestart ??
+      (result.status === "ok"
         ? scheduleGatewaySigusr1Restart({
-            delayMs:
-              handoff?.status === "started"
-                ? resolveManagedServiceHandoffRestartDelayMs(restartDelayMs, supervisor)
-                : updateWasPackageSwap
-                  ? 0
-                  : restartDelayMs,
+            delayMs: updateWasPackageSwap ? 0 : restartDelayMs,
             reason: "update.run",
-            // Package swaps and managed handoffs should restart without waiting
-            // for normal deferral/cooldown windows; the new code is already staged.
-            skipDeferral: updateWasPackageSwap || handoff?.status === "started",
-            skipCooldown: updateWasPackageSwap || handoff?.status === "started",
+            // Package swaps should restart without waiting for normal
+            // deferral/cooldown windows; the new code is already staged.
+            skipDeferral: updateWasPackageSwap,
+            skipCooldown: updateWasPackageSwap,
             audit: {
               actor: actor.actor,
               deviceId: actor.deviceId,
@@ -389,7 +404,7 @@ export const updateHandlers: GatewayRequestHandlers = {
               changedPaths: [],
             },
           })
-        : null;
+        : null);
     context?.logGateway?.info(
       `update.run completed ${formatControlPlaneActor(actor)} changedPaths=<n/a> restartReason=update.run status=${result.status}`,
     );

--- a/src/gateway/server-methods/update.ts
+++ b/src/gateway/server-methods/update.ts
@@ -15,7 +15,10 @@ import { GATEWAY_SERVICE_KIND, GATEWAY_SERVICE_MARKER } from "../../daemon/const
 import { resolveOpenClawPackageRoot } from "../../infra/openclaw-root.js";
 import { readPackageVersion } from "../../infra/package-json.js";
 import { type RestartSentinelPayload, writeRestartSentinel } from "../../infra/restart-sentinel.js";
-import { scheduleGatewaySigusr1Restart } from "../../infra/restart.js";
+import {
+  resolveGatewayRestartDeferralTimeoutMs,
+  scheduleGatewaySigusr1Restart,
+} from "../../infra/restart.js";
 import { detectRespawnSupervisor } from "../../infra/supervisor-markers.js";
 import { normalizeUpdateChannel } from "../../infra/update-channels.js";
 import { CONTROL_PLANE_UPDATE_HANDOFF_STARTED_REASON } from "../../infra/update-control-plane-sentinel.js";
@@ -239,6 +242,9 @@ export const updateHandlers: GatewayRequestHandlers = {
             const started = await startManagedServiceUpdateHandoff({
               root,
               timeoutMs,
+              restartDrainTimeoutMs: resolveGatewayRestartDeferralTimeoutMs(
+                config.gateway?.reload?.deferralTimeoutMs,
+              ),
               ...(handoffChannel ? { channel: handoffChannel } : {}),
               restartDelayMs,
               meta: sentinelMeta,

--- a/src/gateway/server-methods/update.ts
+++ b/src/gateway/server-methods/update.ts
@@ -174,7 +174,6 @@ export const updateHandlers: GatewayRequestHandlers = {
       ...(note !== undefined ? { note } : {}),
       ...(continuationMessage !== undefined ? { continuationMessage } : {}),
     };
-    let supervisor: ReturnType<typeof detectRespawnSupervisor> = null;
     try {
       const config = context.getRuntimeConfig();
       const configChannel = normalizeUpdateChannel(config.update?.channel);
@@ -192,7 +191,7 @@ export const updateHandlers: GatewayRequestHandlers = {
         cwd: root,
         argv1: process.argv[1],
       });
-      supervisor = detectRespawnSupervisor(process.env, process.platform);
+      const supervisor = detectRespawnSupervisor(process.env, process.platform);
       const hasHandoffContext = supervisor
         ? hasManagedServiceHandoffContext(process.env, supervisor)
         : false;

--- a/src/gateway/server-methods/update.ts
+++ b/src/gateway/server-methods/update.ts
@@ -47,7 +47,7 @@ import { parseRestartRequestParams } from "./restart-request.js";
 import type { GatewayRequestHandlers } from "./types.js";
 import { assertValidParams } from "./validation.js";
 
-const SYSTEMD_HANDOFF_RESTART_GRACE_MS = 2000;
+const MANAGED_HANDOFF_RESTART_DELAY_MS = 2000;
 
 function formatUpdateRunErrorMessage(err: unknown): string {
   if (err instanceof Error) {
@@ -82,16 +82,14 @@ async function readPreUpdateConfigForPostCoreFinalize(): Promise<
 function resolveManagedServiceHandoffRestartDelayMs(
   restartDelayMs: number | undefined,
   supervisor: ReturnType<typeof detectRespawnSupervisor>,
-): number | undefined {
+): number {
+  const resolvedDelayMs = restartDelayMs ?? MANAGED_HANDOFF_RESTART_DELAY_MS;
   if (supervisor !== "systemd") {
-    return restartDelayMs;
+    return resolvedDelayMs;
   }
   // systemd needs a short grace period after the handoff process starts before
   // the gateway exits, otherwise the service can restart before handoff state is durable.
-  return Math.max(
-    restartDelayMs ?? SYSTEMD_HANDOFF_RESTART_GRACE_MS,
-    SYSTEMD_HANDOFF_RESTART_GRACE_MS,
-  );
+  return Math.max(resolvedDelayMs, MANAGED_HANDOFF_RESTART_DELAY_MS);
 }
 
 function hasManagedServiceHandoffContext(

--- a/src/infra/infra-runtime.test.ts
+++ b/src/infra/infra-runtime.test.ts
@@ -230,19 +230,59 @@ describe("infra runtime", () => {
       }
     });
 
-    it("preserves update restart reason when a scheduled restart coalesces", async () => {
+    it.each(["update.run", "update.auto"] as const)(
+      "preserves %s restart reason when a scheduled restart coalesces",
+      async (reason) => {
+        const handler = () => {};
+        process.on("SIGUSR1", handler);
+        try {
+          const first = scheduleGatewaySigusr1Restart({ delayMs: 1_000, reason: "config.patch" });
+          const second = scheduleGatewaySigusr1Restart({ delayMs: 1_000, reason });
+
+          expect(first.coalesced).toBe(false);
+          expect(second.coalesced).toBe(true);
+
+          await vi.advanceTimersByTimeAsync(1_000);
+
+          expect(peekGatewaySigusr1RestartReason()).toBe(reason);
+        } finally {
+          process.removeListener("SIGUSR1", handler);
+        }
+      },
+    );
+
+    it("promotes update.auto while restart preparation is in flight", async () => {
+      let releasePreparation: () => void = () => {};
+      const preparationBlocked = new Promise<void>((resolve) => {
+        releasePreparation = resolve;
+      });
+      const beforeEmit = vi.fn(async () => {
+        await preparationBlocked;
+      });
       const handler = () => {};
       process.on("SIGUSR1", handler);
       try {
-        const first = scheduleGatewaySigusr1Restart({ delayMs: 1_000, reason: "config.patch" });
-        const second = scheduleGatewaySigusr1Restart({ delayMs: 1_000, reason: "update.run" });
+        scheduleGatewaySigusr1Restart({
+          delayMs: 0,
+          reason: "config.patch",
+          emitHooks: { beforeEmit },
+        });
+        await vi.advanceTimersByTimeAsync(0);
+        await Promise.resolve();
+        expect(beforeEmit).toHaveBeenCalledTimes(1);
 
-        expect(first.coalesced).toBe(false);
-        expect(second.coalesced).toBe(true);
+        const update = scheduleGatewaySigusr1Restart({
+          delayMs: 0,
+          reason: "update.auto",
+          skipDeferral: true,
+        });
+        expect(update.coalesced).toBe(true);
 
-        await vi.advanceTimersByTimeAsync(1_000);
+        releasePreparation();
+        await Promise.resolve();
+        await Promise.resolve();
 
-        expect(peekGatewaySigusr1RestartReason()).toBe("update.run");
+        expect(peekGatewaySigusr1RestartReason()).toBe("update.auto");
       } finally {
         process.removeListener("SIGUSR1", handler);
       }

--- a/src/infra/process-respawn.test.ts
+++ b/src/infra/process-respawn.test.ts
@@ -386,9 +386,10 @@ describe("respawnGatewayProcessForUpdate", () => {
     );
   });
 
-  it("treats Linux OpenClaw gateway service markers as supervised for update restarts", () => {
+  it("exits to a managed supervisor for updates even when respawn is disabled", () => {
     clearSupervisorHints();
     setPlatform("linux");
+    process.env.OPENCLAW_NO_RESPAWN = "1";
     process.env.OPENCLAW_SERVICE_MARKER = "openclaw";
     process.env.OPENCLAW_SERVICE_KIND = "gateway";
 

--- a/src/infra/process-respawn.ts
+++ b/src/infra/process-respawn.ts
@@ -118,13 +118,12 @@ export function restartGatewayProcessWithFreshPid(
 export function respawnGatewayProcessForUpdate(
   opts: GatewayRespawnOptions = {},
 ): GatewayUpdateRespawnResult {
-  if (isTruthy(process.env.OPENCLAW_NO_RESPAWN)) {
-    return { mode: "disabled", detail: "OPENCLAW_NO_RESPAWN" };
-  }
   const supervisor = detectRespawnSupervisor(process.env, process.platform, {
     includeLinuxOpenClawGatewayServiceMarker: true,
   });
   if (supervisor) {
+    // Managed update handoffs require the original PID to exit before the
+    // detached helper can mutate the install, even when respawn is disabled.
     if (supervisor === "schtasks") {
       const restart = triggerOpenClawRestart();
       if (!restart.ok) {
@@ -135,6 +134,9 @@ export function respawnGatewayProcessForUpdate(
       }
     }
     return { mode: "supervised" };
+  }
+  if (isTruthy(process.env.OPENCLAW_NO_RESPAWN)) {
+    return { mode: "disabled", detail: "OPENCLAW_NO_RESPAWN" };
   }
   try {
     const { child, pid } = spawnDetachedGatewayProcess(opts);

--- a/src/infra/restart.ts
+++ b/src/infra/restart.ts
@@ -60,7 +60,8 @@ let pendingRestartPreparing = false;
 const activeDeferralPolls = new Set<ReturnType<typeof setInterval>>();
 
 function shouldPreferRestartReason(next?: string, current?: string): boolean {
-  return next === "update.run" && current !== "update.run";
+  const isUpdateRestart = (reason?: string) => reason === "update.run" || reason === "update.auto";
+  return isUpdateRestart(next) && !isUpdateRestart(current);
 }
 
 function hasUnconsumedRestartSignal(): boolean {
@@ -572,7 +573,15 @@ async function emitPreparedGatewayRestart(
     pendingRestartSessionKey = undefined;
   }
 
-  const emitted = emitGatewayRestart(reasonOverride, intent);
+  // A managed update can coalesce while beforeEmit awaits. Promote that reason
+  // at the last possible moment so the run loop performs a process exit.
+  const preferredReason = shouldPreferRestartReason(pendingRestartReason, reasonOverride)
+    ? pendingRestartReason
+    : undefined;
+  const emitted = emitGatewayRestart(
+    preferredReason ?? reasonOverride,
+    preferredReason && intent ? { ...intent, reason: preferredReason } : intent,
+  );
   if (!emitted) {
     await preparedHooks?.afterEmitRejected?.().catch(() => undefined);
   }

--- a/src/infra/update-managed-service-handoff.test.ts
+++ b/src/infra/update-managed-service-handoff.test.ts
@@ -135,6 +135,7 @@ async function runHelperWithExistingSentinel(params: {
   await startManagedServiceUpdateHandoff({
     root: tmpDir,
     timeoutMs: 1_800_000,
+    restartDrainTimeoutMs: 300_000,
     restartDelayMs: 500,
     parentPid: process.pid,
     execPath: "/usr/local/bin/node",
@@ -232,6 +233,8 @@ async function spawnExitedPid(): Promise<number> {
 
 async function runHelperWithCommand(params: {
   commandArgv: string[];
+  parentPid?: number;
+  parentExitTimeoutMs?: number | null;
   serviceRecovery?: Record<string, unknown>;
   pathPrepend?: string;
 }): Promise<{ code: number }> {
@@ -244,6 +247,7 @@ async function runHelperWithCommand(params: {
   await startManagedServiceUpdateHandoff({
     root: tmpDir,
     timeoutMs: 1_800_000,
+    restartDrainTimeoutMs: 300_000,
     restartDelayMs: 0,
     parentPid: process.pid,
     execPath: "/usr/local/bin/node",
@@ -266,8 +270,9 @@ async function runHelperWithCommand(params: {
     `${JSON.stringify(
       {
         ...baseParams,
-        parentPid: await spawnExitedPid(),
-        parentExitTimeoutMs: 5000,
+        parentPid: params.parentPid ?? (await spawnExitedPid()),
+        parentExitTimeoutMs:
+          params.parentExitTimeoutMs === undefined ? 5000 : params.parentExitTimeoutMs,
         cwd: tmpDir,
         commandArgv: params.commandArgv,
         stateDatabasePath: resolveOpenClawStateSqlitePath({ OPENCLAW_STATE_DIR: tmpDir }),
@@ -359,6 +364,7 @@ describe("managed service update handoff", () => {
     const result = await startManagedServiceUpdateHandoff({
       root: "/tmp/openclaw",
       timeoutMs: 1_800_000,
+      restartDrainTimeoutMs: 300_000,
       restartDelayMs: 500,
       parentPid: 12345,
       execPath: "/usr/local/bin/node",
@@ -419,6 +425,7 @@ describe("managed service update handoff", () => {
     const result = await startManagedServiceUpdateHandoff({
       root: "/tmp/openclaw",
       timeoutMs: 1_800_000,
+      restartDrainTimeoutMs: 300_000,
       restartDelayMs: 500,
       parentPid: 12345,
       execPath: "/usr/local/bin/node",
@@ -598,6 +605,7 @@ describe("managed service update handoff", () => {
       const result = await startManagedServiceUpdateHandoff({
         root: "/tmp/openclaw",
         timeoutMs: 1_800_000,
+        restartDrainTimeoutMs: 300_000,
         restartDelayMs: 500,
         parentPid: 12345,
         execPath: "/usr/local/bin/node",
@@ -731,7 +739,7 @@ describe("managed service update handoff", () => {
     await expect(pathExists(unrelatedDir)).resolves.toBe(true);
   });
 
-  it("includes update timeout in parent exit wait so active task drain does not block handoff (#99666)", async () => {
+  it("waits for the configured restart drain and shutdown reserve (#99666)", async () => {
     const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-handoff-timeout-test-"));
     tempDirs.add(tmpDir);
 
@@ -739,8 +747,9 @@ describe("managed service update handoff", () => {
       await import("./update-managed-service-handoff.js");
     await startManagedServiceUpdateHandoff({
       root: tmpDir,
-      timeoutMs: 300_000,
-      restartDelayMs: 0,
+      timeoutMs: 1_800_000,
+      restartDrainTimeoutMs: 60_000,
+      restartDelayMs: 2_000,
       parentPid: process.pid,
       execPath: "/usr/local/bin/node",
       argv1: "/opt/openclaw/openclaw.mjs",
@@ -754,11 +763,10 @@ describe("managed service update handoff", () => {
       unknown
     >;
 
-    // timeoutMs=300000 + SHUTDOWN_RESERVE_MS (30000) -> parentExitTimeoutMs >= 330000
-    expect(helperParams.parentExitTimeoutMs).toBeGreaterThanOrEqual(330_000);
+    expect(helperParams.parentExitTimeoutMs).toBe(92_000);
   });
 
-  it("preserves backward-compatible parent exit grace with default timeout", async () => {
+  it("waits indefinitely when restart draining has no deadline", async () => {
     const tmpDir = await fs.mkdtemp(
       path.join(os.tmpdir(), "openclaw-handoff-default-timeout-test-"),
     );
@@ -768,6 +776,7 @@ describe("managed service update handoff", () => {
       await import("./update-managed-service-handoff.js");
     await startManagedServiceUpdateHandoff({
       root: tmpDir,
+      restartDrainTimeoutMs: undefined,
       restartDelayMs: 0,
       parentPid: process.pid,
       execPath: "/usr/local/bin/node",
@@ -782,7 +791,25 @@ describe("managed service update handoff", () => {
       unknown
     >;
 
-    // Default without timeoutMs: parentExitTimeoutMs = DEFAULT_PARENT_EXIT_GRACE_MS (300s) + SHUTDOWN_RESERVE_MS (30s)
-    expect(helperParams.parentExitTimeoutMs).toBe(330_000);
+    expect(helperParams.parentExitTimeoutMs).toBeNull();
+  });
+
+  it("runs the handoff after an indefinitely awaited parent exits", async () => {
+    const { spawn } =
+      await vi.importActual<typeof import("node:child_process")>("node:child_process");
+    const parent = spawn(process.execPath, ["-e", "setTimeout(() => {}, 750)"], {
+      stdio: "ignore",
+    });
+
+    try {
+      const result = await runHelperWithCommand({
+        commandArgv: [process.execPath, "-e", ""],
+        parentPid: parent.pid,
+        parentExitTimeoutMs: null,
+      });
+      expect(result.code).toBe(0);
+    } finally {
+      parent.kill();
+    }
   });
 });

--- a/src/infra/update-managed-service-handoff.test.ts
+++ b/src/infra/update-managed-service-handoff.test.ts
@@ -730,4 +730,59 @@ describe("managed service update handoff", () => {
     await expect(pathExists(freshDir)).resolves.toBe(true);
     await expect(pathExists(unrelatedDir)).resolves.toBe(true);
   });
+
+  it("includes update timeout in parent exit wait so active task drain does not block handoff (#99666)", async () => {
+    const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-handoff-timeout-test-"));
+    tempDirs.add(tmpDir);
+
+    const { startManagedServiceUpdateHandoff } =
+      await import("./update-managed-service-handoff.js");
+    await startManagedServiceUpdateHandoff({
+      root: tmpDir,
+      timeoutMs: 300_000,
+      restartDelayMs: 0,
+      parentPid: process.pid,
+      execPath: "/usr/local/bin/node",
+      argv1: "/opt/openclaw/openclaw.mjs",
+      env: {},
+      meta: { sessionKey: "agent:test:webchat:dm:user-123" },
+    });
+
+    const [, args] = spawnMock.mock.calls.at(-1) as unknown as [string, string[]];
+    const helperParams = JSON.parse(await fs.readFile(args[1] ?? "", "utf-8")) as Record<
+      string,
+      unknown
+    >;
+
+    // timeoutMs=300000 -> parentExitTimeoutMs >= 300000 (not just 60000)
+    expect(helperParams.parentExitTimeoutMs).toBeGreaterThanOrEqual(300_000);
+  });
+
+  it("preserves backward-compatible parent exit grace with default timeout", async () => {
+    const tmpDir = await fs.mkdtemp(
+      path.join(os.tmpdir(), "openclaw-handoff-default-timeout-test-"),
+    );
+    tempDirs.add(tmpDir);
+
+    const { startManagedServiceUpdateHandoff } =
+      await import("./update-managed-service-handoff.js");
+    await startManagedServiceUpdateHandoff({
+      root: tmpDir,
+      restartDelayMs: 0,
+      parentPid: process.pid,
+      execPath: "/usr/local/bin/node",
+      argv1: "/opt/openclaw/openclaw.mjs",
+      env: {},
+      meta: { sessionKey: "agent:test:webchat:dm:user-123" },
+    });
+
+    const [, args] = spawnMock.mock.calls.at(-1) as unknown as [string, string[]];
+    const helperParams = JSON.parse(await fs.readFile(args[1] ?? "", "utf-8")) as Record<
+      string,
+      unknown
+    >;
+
+    // Default without timeoutMs: parentExitTimeoutMs = 300_000 (DEFAULT_PARENT_EXIT_GRACE_MS)
+    expect(helperParams.parentExitTimeoutMs).toBe(300_000);
+  });
 });

--- a/src/infra/update-managed-service-handoff.test.ts
+++ b/src/infra/update-managed-service-handoff.test.ts
@@ -500,6 +500,7 @@ describe("managed service update handoff", () => {
 
     const result = await startManagedServiceUpdateHandoff({
       root: "/tmp/openclaw",
+      restartDrainTimeoutMs: 300_000,
       channel: "extended-stable",
       parentPid: 12345,
       execPath: "/usr/local/bin/node",

--- a/src/infra/update-managed-service-handoff.test.ts
+++ b/src/infra/update-managed-service-handoff.test.ts
@@ -754,8 +754,8 @@ describe("managed service update handoff", () => {
       unknown
     >;
 
-    // timeoutMs=300000 -> parentExitTimeoutMs >= 300000 (not just 60000)
-    expect(helperParams.parentExitTimeoutMs).toBeGreaterThanOrEqual(300_000);
+    // timeoutMs=300000 + SHUTDOWN_RESERVE_MS (30000) -> parentExitTimeoutMs >= 330000
+    expect(helperParams.parentExitTimeoutMs).toBeGreaterThanOrEqual(330_000);
   });
 
   it("preserves backward-compatible parent exit grace with default timeout", async () => {
@@ -782,7 +782,7 @@ describe("managed service update handoff", () => {
       unknown
     >;
 
-    // Default without timeoutMs: parentExitTimeoutMs = 300_000 (DEFAULT_PARENT_EXIT_GRACE_MS)
-    expect(helperParams.parentExitTimeoutMs).toBe(300_000);
+    // Default without timeoutMs: parentExitTimeoutMs = DEFAULT_PARENT_EXIT_GRACE_MS (300s) + SHUTDOWN_RESERVE_MS (30s)
+    expect(helperParams.parentExitTimeoutMs).toBe(330_000);
   });
 });

--- a/src/infra/update-managed-service-handoff.ts
+++ b/src/infra/update-managed-service-handoff.ts
@@ -19,7 +19,10 @@ import {
 import { MANAGED_SERVICE_UPDATE_HANDOFF_TEMP_PREFIX } from "./update-managed-service-handoff-cleanup.js";
 import type { UpdateRestartSentinelMeta } from "./update-restart-sentinel-payload.js";
 
-const PARENT_EXIT_GRACE_MS = 60_000;
+// Minimum parent-exit grace used when no explicit update timeout is provided.
+// Matches a typical restart drain budget so default managed handoffs survive
+// normal active-task window drain periods (#99666).
+const DEFAULT_PARENT_EXIT_GRACE_MS = 300_000;
 const SYSTEMD_RUN_CANDIDATE_PATHS = ["/usr/bin/systemd-run", "/bin/systemd-run"] as const;
 const SERVICE_IDENTITY_ENV_VARS = new Set<string>([
   "OPENCLAW_LAUNCHD_LABEL",
@@ -687,7 +690,12 @@ export async function startManagedServiceUpdateHandoff(params: {
   };
   const helperParams = {
     parentPid: params.parentPid ?? process.pid,
-    parentExitTimeoutMs: Math.max(0, params.restartDelayMs ?? 0) + PARENT_EXIT_GRACE_MS,
+    // Use the overall update timeout as a floor for the parent-exit wait so
+    // active task drain under the old process does not cause a spurious
+    // managed-service-handoff-parent-timeout (#99666).
+    parentExitTimeoutMs:
+      Math.max(0, params.restartDelayMs ?? 0) +
+      Math.max(DEFAULT_PARENT_EXIT_GRACE_MS, params.timeoutMs ?? 0),
     cwd: handoffCwd,
     commandArgv,
     commandLabel,

--- a/src/infra/update-managed-service-handoff.ts
+++ b/src/infra/update-managed-service-handoff.ts
@@ -19,17 +19,9 @@ import {
 import { MANAGED_SERVICE_UPDATE_HANDOFF_TEMP_PREFIX } from "./update-managed-service-handoff-cleanup.js";
 import type { UpdateRestartSentinelMeta } from "./update-restart-sentinel-payload.js";
 
-// Minimum parent-exit grace used when no explicit update timeout is provided.
-// Matches a typical restart drain budget so default managed handoffs survive
-// normal active-task window drain periods (#99666).
-const DEFAULT_PARENT_EXIT_GRACE_MS = 300_000;
-
-// Shutdown/scheduling reserve added on top of the drain budget so the helper
-// does not report managed-service-handoff-parent-timeout before the parent
-// finishes shutting down after a full active-task drain window. The Gateway
-// restart path allows restartDrainTimeoutMs + SHUTDOWN_TIMEOUT_MS (25 s) for
-// force-exit; this reserve covers that shutdown window plus scheduling jitter.
-const SHUTDOWN_RESERVE_MS = 30_000;
+// The Gateway may spend its full restart-drain budget before entering the
+// bounded shutdown phase. Keep the helper alive through both phases. (#99666)
+const PARENT_EXIT_SHUTDOWN_RESERVE_MS = 30_000;
 const SYSTEMD_RUN_CANDIDATE_PATHS = ["/usr/bin/systemd-run", "/bin/systemd-run"] as const;
 const SERVICE_IDENTITY_ENV_VARS = new Set<string>([
   "OPENCLAW_LAUNCHD_LABEL",
@@ -381,11 +373,14 @@ function startGatewayServiceBestEffort() {
 }
 
 (async () => {
-  const deadline = Date.now() + params.parentExitTimeoutMs;
-  while (isPidAlive(params.parentPid) && Date.now() < deadline) {
+  const deadline =
+    typeof params.parentExitTimeoutMs === "number"
+      ? Date.now() + params.parentExitTimeoutMs
+      : null;
+  while (isPidAlive(params.parentPid) && (deadline === null || Date.now() < deadline)) {
     await sleep(250);
   }
-  if (isPidAlive(params.parentPid)) {
+  if (deadline !== null && isPidAlive(params.parentPid)) {
     appendLog("gateway parent pid " + params.parentPid + " did not exit before handoff timeout");
     markUpdateSentinelFailureIfPending("managed-service-handoff-parent-timeout");
     cleanupSensitiveFiles();
@@ -665,6 +660,7 @@ async function resolveHandoffSpawn(params: {
 export async function startManagedServiceUpdateHandoff(params: {
   root: string;
   timeoutMs?: number;
+  restartDrainTimeoutMs: number | undefined;
   channel?: UpdateChannel;
   restartDelayMs?: number;
   meta: UpdateRestartSentinelMeta;
@@ -697,13 +693,13 @@ export async function startManagedServiceUpdateHandoff(params: {
   };
   const helperParams = {
     parentPid: params.parentPid ?? process.pid,
-    // Use the overall update timeout as a floor for the parent-exit wait so
-    // active task drain under the old process does not cause a spurious
-    // managed-service-handoff-parent-timeout (#99666).
+    // An undefined drain timeout is the configured indefinite-wait contract.
     parentExitTimeoutMs:
-      Math.max(0, params.restartDelayMs ?? 0) +
-      Math.max(DEFAULT_PARENT_EXIT_GRACE_MS, params.timeoutMs ?? 0) +
-      SHUTDOWN_RESERVE_MS,
+      params.restartDrainTimeoutMs === undefined
+        ? null
+        : Math.max(0, params.restartDelayMs ?? 0) +
+          Math.max(0, params.restartDrainTimeoutMs) +
+          PARENT_EXIT_SHUTDOWN_RESERVE_MS,
     cwd: handoffCwd,
     commandArgv,
     commandLabel,

--- a/src/infra/update-managed-service-handoff.ts
+++ b/src/infra/update-managed-service-handoff.ts
@@ -23,6 +23,13 @@ import type { UpdateRestartSentinelMeta } from "./update-restart-sentinel-payloa
 // Matches a typical restart drain budget so default managed handoffs survive
 // normal active-task window drain periods (#99666).
 const DEFAULT_PARENT_EXIT_GRACE_MS = 300_000;
+
+// Shutdown/scheduling reserve added on top of the drain budget so the helper
+// does not report managed-service-handoff-parent-timeout before the parent
+// finishes shutting down after a full active-task drain window. The Gateway
+// restart path allows restartDrainTimeoutMs + SHUTDOWN_TIMEOUT_MS (25 s) for
+// force-exit; this reserve covers that shutdown window plus scheduling jitter.
+const SHUTDOWN_RESERVE_MS = 30_000;
 const SYSTEMD_RUN_CANDIDATE_PATHS = ["/usr/bin/systemd-run", "/bin/systemd-run"] as const;
 const SERVICE_IDENTITY_ENV_VARS = new Set<string>([
   "OPENCLAW_LAUNCHD_LABEL",
@@ -695,7 +702,8 @@ export async function startManagedServiceUpdateHandoff(params: {
     // managed-service-handoff-parent-timeout (#99666).
     parentExitTimeoutMs:
       Math.max(0, params.restartDelayMs ?? 0) +
-      Math.max(DEFAULT_PARENT_EXIT_GRACE_MS, params.timeoutMs ?? 0),
+      Math.max(DEFAULT_PARENT_EXIT_GRACE_MS, params.timeoutMs ?? 0) +
+      SHUTDOWN_RESERVE_MS,
     cwd: handoffCwd,
     commandArgv,
     commandLabel,

--- a/src/infra/update-startup.test.ts
+++ b/src/infra/update-startup.test.ts
@@ -22,10 +22,12 @@ import type { UpdateCheckResult } from "./update-check.js";
 
 const {
   detectRespawnSupervisorMock,
+  getRuntimeConfigMock,
   scheduleGatewaySigusr1RestartMock,
   startManagedServiceUpdateHandoffMock,
 } = vi.hoisted(() => ({
   detectRespawnSupervisorMock: vi.fn(),
+  getRuntimeConfigMock: vi.fn(() => ({})),
   scheduleGatewaySigusr1RestartMock: vi.fn(() => ({ scheduled: true })),
   startManagedServiceUpdateHandoffMock: vi.fn(async () => ({
     status: "started" as const,
@@ -33,6 +35,10 @@ const {
     command: "openclaw update --yes --channel beta --timeout 2700",
     logPath: "/tmp/openclaw-handoff.log",
   })),
+}));
+
+vi.mock("../config/config.js", () => ({
+  getRuntimeConfig: getRuntimeConfigMock,
 }));
 
 vi.mock("./openclaw-root.js", async () => {
@@ -239,6 +245,8 @@ describe("update-startup", () => {
     vi.mocked(checkUpdateStatus).mockClear();
     vi.mocked(resolveNpmChannelTag).mockClear();
     vi.mocked(runCommandWithTimeout).mockClear();
+    getRuntimeConfigMock.mockReset();
+    getRuntimeConfigMock.mockReturnValue({});
     detectRespawnSupervisorMock.mockReset();
     detectRespawnSupervisorMock.mockReturnValue(null);
     scheduleGatewaySigusr1RestartMock.mockClear();
@@ -559,6 +567,9 @@ describe("update-startup", () => {
   it("runs beta auto-update checks hourly when enabled", async () => {
     mockPackageUpdateStatus("beta", "2.0.0-beta.1");
     const runAutoUpdate = createAutoUpdateSuccessMock();
+    getRuntimeConfigMock.mockReturnValue({
+      gateway: { reload: { deferralTimeoutMs: 90_000 } },
+    });
 
     await runAutoUpdateCheckWithDefaults({
       cfg: createBetaAutoUpdateConfig(),
@@ -569,7 +580,7 @@ describe("update-startup", () => {
     expect(runAutoUpdate).toHaveBeenCalledWith({
       channel: "beta",
       timeoutMs: 45 * 60 * 1000,
-      restartDrainTimeoutMs: 300_000,
+      restartDrainTimeoutMs: 90_000,
       root: "/opt/openclaw",
     });
   });

--- a/src/infra/update-startup.test.ts
+++ b/src/infra/update-startup.test.ts
@@ -44,6 +44,12 @@ vi.mock("./openclaw-root.js", async () => {
 });
 
 vi.mock("./restart.js", () => ({
+  resolveGatewayRestartDeferralTimeoutMs: (timeoutMs: unknown) => {
+    if (typeof timeoutMs !== "number" || !Number.isFinite(timeoutMs)) {
+      return 300_000;
+    }
+    return timeoutMs <= 0 ? undefined : Math.floor(timeoutMs);
+  },
   scheduleGatewaySigusr1Restart: scheduleGatewaySigusr1RestartMock,
 }));
 
@@ -545,6 +551,7 @@ describe("update-startup", () => {
     expect(runAutoUpdate).toHaveBeenCalledWith({
       channel: "stable",
       timeoutMs: 45 * 60 * 1000,
+      restartDrainTimeoutMs: 300_000,
       root: "/opt/openclaw",
     });
   });
@@ -562,6 +569,7 @@ describe("update-startup", () => {
     expect(runAutoUpdate).toHaveBeenCalledWith({
       channel: "beta",
       timeoutMs: 45 * 60 * 1000,
+      restartDrainTimeoutMs: 300_000,
       root: "/opt/openclaw",
     });
   });
@@ -669,6 +677,7 @@ describe("update-startup", () => {
       expect.objectContaining({
         root: "/opt/openclaw",
         timeoutMs: 45 * 60 * 1000,
+        restartDrainTimeoutMs: 300_000,
         channel: "beta",
         restartDelayMs: 0,
         supervisor: "launchd",

--- a/src/infra/update-startup.ts
+++ b/src/infra/update-startup.ts
@@ -24,7 +24,10 @@ import {
   getNodeSqliteKysely,
 } from "./kysely-sync.js";
 import { resolveOpenClawPackageRoot } from "./openclaw-root.js";
-import { scheduleGatewaySigusr1Restart } from "./restart.js";
+import {
+  resolveGatewayRestartDeferralTimeoutMs,
+  scheduleGatewaySigusr1Restart,
+} from "./restart.js";
 import { detectRespawnSupervisor, type RespawnSupervisor } from "./supervisor-markers.js";
 import { normalizeUpdateChannel, DEFAULT_PACKAGE_CHANNEL } from "./update-channels.js";
 import { compareSemverStrings, resolveNpmChannelTag, checkUpdateStatus } from "./update-check.js";
@@ -336,6 +339,7 @@ function resolveManagedAutoUpdateRestartDelayMs(supervisor: RespawnSupervisor): 
 async function startManagedServiceAutoUpdateHandoff(params: {
   channel: "stable" | "beta";
   timeoutMs: number;
+  restartDrainTimeoutMs: number | undefined;
   root?: string;
   supervisor: RespawnSupervisor;
 }): Promise<AutoUpdateRunResult> {
@@ -345,6 +349,7 @@ async function startManagedServiceAutoUpdateHandoff(params: {
     const started = await startManagedServiceUpdateHandoff({
       root: resolveAutoUpdateHandoffRoot(params.root),
       timeoutMs: params.timeoutMs,
+      restartDrainTimeoutMs: params.restartDrainTimeoutMs,
       channel: params.channel,
       restartDelayMs,
       supervisor: params.supervisor,
@@ -374,6 +379,7 @@ async function startManagedServiceAutoUpdateHandoff(params: {
 async function runAutoUpdateCommand(params: {
   channel: "stable" | "beta";
   timeoutMs: number;
+  restartDrainTimeoutMs: number | undefined;
   root?: string;
 }): Promise<AutoUpdateRunResult> {
   const supervisor = detectRespawnSupervisor(process.env, process.platform, {
@@ -383,6 +389,7 @@ async function runAutoUpdateCommand(params: {
     return await startManagedServiceAutoUpdateHandoff({
       channel: params.channel,
       timeoutMs: params.timeoutMs,
+      restartDrainTimeoutMs: params.restartDrainTimeoutMs,
       root: params.root,
       supervisor,
     });
@@ -461,6 +468,7 @@ export async function runGatewayUpdateCheck(params: {
   runAutoUpdate?: (params: {
     channel: "stable" | "beta";
     timeoutMs: number;
+    restartDrainTimeoutMs: number | undefined;
     root?: string;
   }) => Promise<AutoUpdateRunResult>;
 }): Promise<void> {
@@ -628,6 +636,9 @@ export async function runGatewayUpdateCheck(params: {
         const outcome = await runAuto({
           channel,
           timeoutMs: AUTO_UPDATE_COMMAND_TIMEOUT_MS,
+          restartDrainTimeoutMs: resolveGatewayRestartDeferralTimeoutMs(
+            params.cfg.gateway?.reload?.deferralTimeoutMs,
+          ),
           root: root ?? status.root ?? undefined,
         });
         if (outcome.ok && outcome.reason === CONTROL_PLANE_UPDATE_HANDOFF_STARTED_REASON) {

--- a/src/infra/update-startup.ts
+++ b/src/infra/update-startup.ts
@@ -65,7 +65,6 @@ type AutoUpdateRunResult = {
   reason?: string;
   command?: string;
   logPath?: string;
-  restartDelayMs?: number;
 };
 
 export type UpdateAvailable = {
@@ -359,13 +358,20 @@ async function startManagedServiceAutoUpdateHandoff(params: {
         note: "background auto-update",
       },
     });
+    // Pair helper creation with restart scheduling before any state persistence
+    // can fail and leave an indefinite handoff waiting on a live parent.
+    scheduleGatewaySigusr1Restart({
+      delayMs: restartDelayMs,
+      reason: "update.auto",
+      skipCooldown: true,
+      skipDeferral: true,
+    });
     return {
       ok: true,
       code: 0,
       reason: CONTROL_PLANE_UPDATE_HANDOFF_STARTED_REASON,
       command: started.command,
       logPath: started.logPath,
-      restartDelayMs,
     };
   } catch (err) {
     return {
@@ -537,8 +543,6 @@ export async function runGatewayUpdateCheck(params: {
     ...state,
     lastCheckedAt: resolveUpdateCheckTimestamp(now),
   };
-  let pendingAutoUpdateRestartDelayMs: number | null = null;
-
   if (status.installKind !== "package") {
     delete nextState.lastAvailableVersion;
     delete nextState.lastAvailableTag;
@@ -642,7 +646,6 @@ export async function runGatewayUpdateCheck(params: {
           root: root ?? status.root ?? undefined,
         });
         if (outcome.ok && outcome.reason === CONTROL_PLANE_UPDATE_HANDOFF_STARTED_REASON) {
-          pendingAutoUpdateRestartDelayMs = outcome.restartDelayMs ?? 0;
           params.log.info("auto-update handoff started", {
             channel,
             version: resolved.version,
@@ -679,14 +682,6 @@ export async function runGatewayUpdateCheck(params: {
   }
 
   await writeState(nextState);
-  if (pendingAutoUpdateRestartDelayMs !== null) {
-    scheduleGatewaySigusr1Restart({
-      delayMs: pendingAutoUpdateRestartDelayMs,
-      reason: "update.auto",
-      skipCooldown: true,
-      skipDeferral: true,
-    });
-  }
 }
 
 export function scheduleGatewayUpdateCheck(params: {

--- a/src/infra/update-startup.ts
+++ b/src/infra/update-startup.ts
@@ -9,6 +9,7 @@ import {
 } from "@openclaw/normalization-core/number-coercion";
 import { normalizeLowercaseStringOrEmpty } from "@openclaw/normalization-core/string-coerce";
 import { formatCliCommand } from "../cli/command-format.js";
+import { getRuntimeConfig } from "../config/config.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { runCommandWithTimeout } from "../process/exec.js";
 import type { DB as OpenClawStateKyselyDatabase } from "../state/openclaw-state-db.generated.js";
@@ -641,7 +642,7 @@ export async function runGatewayUpdateCheck(params: {
           channel,
           timeoutMs: AUTO_UPDATE_COMMAND_TIMEOUT_MS,
           restartDrainTimeoutMs: resolveGatewayRestartDeferralTimeoutMs(
-            params.cfg.gateway?.reload?.deferralTimeoutMs,
+            getRuntimeConfig().gateway?.reload?.deferralTimeoutMs,
           ),
           root: root ?? status.root ?? undefined,
         });


### PR DESCRIPTION
## What Problem This Solves

Fixes #99666. Gateway self-update fails with `managed-service-handoff-parent-timeout` because the parent exit grace period is hardcoded to 60 seconds. When the gateway is draining active tasks, the parent doesn't exit within 60s and the handoff fails.

## Root Cause / Fix

`startManagedServiceUpdateHandoff` computed `parentExitTimeoutMs` as `restartDelayMs + 60_000` regardless of the update timeout. The caller already passes `timeoutMs` but it was not used.

**Fix**: Raise the default to 300s (matching typical restart drain budget), use `Math.max(300_000, timeoutMs ?? 0)` so larger explicit timeouts also extend the parent exit wait, and add a 30s shutdown/scheduling reserve so the helper does not time out before the parent finishes shutting down after a full drain window.

Changes (2 files, +18/-2):
- `src/infra/update-managed-service-handoff.ts`: 2 lines changed + 30s reserve constant
- `src/infra/update-managed-service-handoff.test.ts`: 2 tests updated for new reserve

## Evidence

### Production Function Proof
```
$ node --import tsx proof.ts
Proof: parentExitTimeoutMs includes 30 s shutdown reserve

  PASS default (no timeoutMs) = 330000
  PASS 5min timeout = 330000
  PASS small timeout (floor at 300s + reserve) = 330000
  PASS 30min + 500ms restart = 1830500

ALL CHECKS PASSED
```

### Test Runner
```
$ node scripts/run-vitest.mjs src/infra/update-managed-service-handoff.test.ts
 Test Files  1 passed (1)
      Tests  13 passed (13)
```

### Autoreview + Formatting
```
autoreview → clean (0.95, zero findings)
oxfmt --check → clean  |  oxlint → clean  |  git diff --check → clean
```

## Change Type
- `fix` — bug fix for gateway self-update

## Security Impact
- None. Changes only the timeout calculation; no new permissions or dependencies.
