### PR TITLE
refactor(scripts): centralize path separator normalization

### DIFF
--- a/scripts/check-gateway-watch-regression.mjs
+++ b/scripts/check-gateway-watch-regression.mjs
@@ -14,6 +14,7 @@ import {
   writeBuildStamp,
   writeRuntimePostBuildStamp,
 } from "./lib/local-build-metadata.mjs";
+import { toPosixPathSeparators } from "./lib/path-normalization.mjs";
 import { resolveBuildRequirement } from "./run-node.mjs";
 
 const DEFAULTS = {
@@ -182,10 +183,6 @@ function lstatIfExists(targetPath) {
   }
 }
 
-function normalizePath(filePath) {
-  return filePath.replaceAll("\\", "/");
-}
-
 function listTreeEntries(rootName) {
   const rootPath = path.join(process.cwd(), rootName);
   if (!fs.existsSync(rootPath)) {
@@ -210,7 +207,7 @@ function listTreeEntries(rootName) {
     }
     for (const dirent of dirents) {
       const fullPath = path.join(current, dirent.name);
-      const relativePath = normalizePath(path.relative(process.cwd(), fullPath));
+      const relativePath = toPosixPathSeparators(path.relative(process.cwd(), fullPath));
       entries.push(relativePath);
       if (dirent.isDirectory()) {
         queue.push(fullPath);

--- a/scripts/check-no-raw-http2-imports.mjs
+++ b/scripts/check-no-raw-http2-imports.mjs
@@ -1,6 +1,7 @@
 // Rejects raw Node http2 imports in source and extension code.
 import fs from "node:fs";
 import path from "node:path";
+import { toPosixPathSeparators } from "./lib/path-normalization.mjs";
 const SOURCE_ROOTS = ["src", "extensions"];
 const DEFAULT_SKIPPED_DIR_NAMES = new Set(["node_modules", "dist", "coverage", ".generated"]);
 
@@ -44,10 +45,6 @@ function collectFilesSync(rootDir, options) {
   return files;
 }
 
-function toPosixPath(filePath) {
-  return filePath.replaceAll("\\", "/");
-}
-
 const FORBIDDEN_HTTP2_MODULES = new Set(["node:http2", "http2"]);
 const ALLOWED_PRODUCTION_FILES = new Set(["src/infra/push-apns-http2.ts"]);
 
@@ -63,7 +60,7 @@ function lineNumberForOffset(content, offset) {
 }
 
 function collectHttp2ImportOffenders(filePath) {
-  const relativePath = toPosixPath(path.relative(process.cwd(), filePath));
+  const relativePath = toPosixPathSeparators(path.relative(process.cwd(), filePath));
   if (ALLOWED_PRODUCTION_FILES.has(relativePath) || isTestFile(relativePath)) {
     return [];
   }

--- a/scripts/docs-link-audit.mjs
+++ b/scripts/docs-link-audit.mjs
@@ -7,6 +7,7 @@ import os from "node:os";
 import path from "node:path";
 import { pathToFileURL } from "node:url";
 import { resolveClawHubRepoPath, syncClawHubDocsTree } from "./docs-sync-publish.mjs";
+import { toPosixPathSeparators } from "./lib/path-normalization.mjs";
 import { createPnpmRunnerSpawnSpec } from "./pnpm-runner.mjs";
 
 const ROOT = process.cwd();
@@ -42,11 +43,6 @@ function walk(dir) {
     }
   }
   return out;
-}
-
-/** @param {string} p */
-function normalizeSlashes(p) {
-  return p.replace(/\\/g, "/");
 }
 
 /**
@@ -97,18 +93,20 @@ function buildAuditIndex(docsDir = DOCS_DIR, options = {}) {
   const docsConfig = JSON.parse(fs.readFileSync(docsJsonPath, "utf8"));
   const redirects = createRedirectMap(docsConfig);
   const allFiles = walk(docsDir);
-  const relAllFiles = new Set(allFiles.map((abs) => normalizeSlashes(path.relative(docsDir, abs))));
+  const relAllFiles = new Set(
+    allFiles.map((abs) => toPosixPathSeparators(path.relative(docsDir, abs))),
+  );
   const markdownFiles = allFiles.filter((abs) => {
     if (!/\.(md|mdx)$/i.test(abs)) {
       return false;
     }
-    const rel = normalizeSlashes(path.relative(docsDir, abs));
+    const rel = toPosixPathSeparators(path.relative(docsDir, abs));
     return !isGeneratedTranslatedDoc(rel);
   });
   const routes = new Set();
 
   for (const abs of markdownFiles) {
-    const rel = normalizeSlashes(path.relative(docsDir, abs));
+    const rel = toPosixPathSeparators(path.relative(docsDir, abs));
     const text = fs.readFileSync(abs, "utf8");
     const slug = rel.replace(/\.(md|mdx)$/i, "");
     addRoute(routes, slug);
@@ -429,8 +427,8 @@ export function auditDocsLinks(options = {}) {
   let checked = 0;
 
   for (const abs of index.markdownFiles) {
-    const rel = normalizeSlashes(path.relative(index.docsDir, abs));
-    const baseDir = normalizeSlashes(path.dirname(rel));
+    const rel = toPosixPathSeparators(path.relative(index.docsDir, abs));
+    const baseDir = toPosixPathSeparators(path.dirname(rel));
     const rawText = fs.readFileSync(abs, "utf8");
     const lines = rawText.split("\n");
 
@@ -490,7 +488,7 @@ export function auditDocsLinks(options = {}) {
           continue;
         }
 
-        const normalizedRel = normalizeSlashes(path.normalize(path.join(baseDir, clean)));
+        const normalizedRel = toPosixPathSeparators(path.normalize(path.join(baseDir, clean)));
 
         if (/\.[a-zA-Z0-9]+$/.test(normalizedRel)) {
           if (!index.relAllFiles.has(normalizedRel)) {

--- a/scripts/generate-docs-map.mjs
+++ b/scripts/generate-docs-map.mjs
@@ -4,6 +4,7 @@
 import { existsSync, readdirSync, readFileSync, statSync, writeFileSync } from "node:fs";
 import { join, relative } from "node:path";
 import { fileURLToPath } from "node:url";
+import { toPosixPathSeparators } from "./lib/path-normalization.mjs";
 
 const ROOT = process.cwd();
 const DOCS_DIR = join(ROOT, "docs");
@@ -29,16 +30,12 @@ if (!statSync(DOCS_DIR).isDirectory()) {
   process.exit(1);
 }
 
-function normalizeSlashes(value) {
-  return value.replace(/\\/gu, "/");
-}
-
 function isMarkdownFile(name) {
   return MARKDOWN_EXTENSIONS.test(name);
 }
 
 function shouldSkipFile(relativePath) {
-  const parts = normalizeSlashes(relativePath).split("/");
+  const parts = toPosixPathSeparators(relativePath).split("/");
   if (parts.some((part) => part.startsWith("."))) {
     return true;
   }
@@ -66,7 +63,7 @@ function walkMarkdownFiles(dir, base = dir) {
     if (!entry.isFile() || !isMarkdownFile(entry.name) || shouldSkipFile(relativePath)) {
       continue;
     }
-    files.push(normalizeSlashes(relativePath));
+    files.push(toPosixPathSeparators(relativePath));
   }
   return files.toSorted((left, right) => (left < right ? -1 : left > right ? 1 : 0));
 }
@@ -196,7 +193,7 @@ function main() {
   }
 
   writeFileSync(OUTPUT_PATH, content, "utf8");
-  console.log(`docs:map: wrote ${normalizeSlashes(relative(ROOT, OUTPUT_PATH))}.`);
+  console.log(`docs:map: wrote ${toPosixPathSeparators(relative(ROOT, OUTPUT_PATH))}.`);
 }
 
 const isMain = process.argv[1] ? fileURLToPath(import.meta.url) === process.argv[1] : false;

--- a/scripts/lib/bundled-plugin-build-entries.mjs
+++ b/scripts/lib/bundled-plugin-build-entries.mjs
@@ -8,6 +8,7 @@ import {
   bundledPluginFile,
 } from "./bundled-plugin-paths.mjs";
 import { shouldBuildBundledCluster } from "./optional-bundled-clusters.mjs";
+import { toPosixPathSeparators } from "./path-normalization.mjs";
 
 const TOP_LEVEL_PUBLIC_SURFACE_EXTENSIONS = new Set([".ts", ".js", ".mts", ".cts", ".mjs", ".cjs"]);
 /** Bundled plugin directories built with core but not packaged as standalone npm plugins. */
@@ -16,8 +17,6 @@ const EXCLUDED_CORE_BUNDLED_PLUGIN_DIRS = new Set(["qqbot", "whatsapp"]);
 const BUNDLED_PLUGIN_BUILD_IDS_ENV = "OPENCLAW_BUNDLED_PLUGIN_BUILD_IDS";
 const TOP_LEVEL_PRIVATE_TEST_SURFACE_RE =
   /(?:^|[._-])(?:test|spec|test-support|test-helpers|test-fixtures|test-harness|mock-setup)(?:[._-]|$)/u;
-const toPosixPath = (value) => value.replaceAll("\\", "/");
-
 function parseBundledPluginBuildIdFilter(env = process.env) {
   const raw = env[BUNDLED_PLUGIN_BUILD_IDS_ENV];
   if (typeof raw !== "string" || raw.trim() === "") {
@@ -146,7 +145,7 @@ function collectTrackedBundledPluginFiles(cwd) {
 
   const filesByPlugin = new Map();
   for (const rawLine of result.stdout.split("\n")) {
-    const line = toPosixPath(rawLine.trim());
+    const line = toPosixPathSeparators(rawLine.trim());
     const match = new RegExp(`^${BUNDLED_PLUGIN_ROOT_DIR}/([^/]+)/(.+)$`).exec(line);
     if (!match) {
       continue;
@@ -260,7 +259,10 @@ export function listBundledPluginBuildEntries(params = {}) {
       sourceEntries.map((entry) => {
         const normalizedEntry = entry.replace(/^\.\//, "");
         const entryKey = bundledPluginFile(id, normalizedEntry.replace(/\.[^.]+$/u, ""));
-        return [entryKey, toPosixPath(path.join(BUNDLED_PLUGIN_ROOT_DIR, id, normalizedEntry))];
+        return [
+          entryKey,
+          toPosixPathSeparators(path.join(BUNDLED_PLUGIN_ROOT_DIR, id, normalizedEntry)),
+        ];
       }),
     ),
   );

--- a/scripts/lib/extension-source-classifier.mjs
+++ b/scripts/lib/extension-source-classifier.mjs
@@ -1,4 +1,6 @@
 // Classifies bundled extension files as production, barrel, test-like, or infra artifacts.
+import { toPosixPathSeparators } from "./path-normalization.mjs";
+
 const CODE_FILE_RE = /\.(?:[cm]?ts|[cm]?js|tsx|jsx)$/u;
 const DECLARATION_FILE_RE = /\.d\.ts$/u;
 const RUNTIME_API_BARREL_RE = /(^|\/)runtime-api\.(?:[cm]?ts|[cm]?js|tsx|jsx)$/u;
@@ -14,13 +16,9 @@ const SUFFIX_SKIP_RE = /\.(?:test|spec|fixture)\./u;
 const INFRA_DIR_RE = /(^|\/)(?:coverage|dist|node_modules)(?:\/|$)/u;
 const INFRA_NAME_RE = /(test-harness|test-support|test-helpers|test-fixtures)/u;
 
-function normalizeExtensionSourcePath(filePath) {
-  return filePath.replaceAll("\\", "/");
-}
-
 /** Classify one bundled extension source path for boundary and packaging guards. */
 export function classifyBundledExtensionSourcePath(filePath) {
-  const normalizedPath = normalizeExtensionSourcePath(filePath);
+  const normalizedPath = toPosixPathSeparators(filePath);
   const isCodeFile = CODE_FILE_RE.test(normalizedPath) && !DECLARATION_FILE_RE.test(normalizedPath);
   const isRuntimeApiBarrel = RUNTIME_API_BARREL_RE.test(normalizedPath);
   const isPublicApiBarrel = PUBLIC_API_BARREL_RE.test(normalizedPath);

--- a/scripts/lib/path-normalization.d.mts
+++ b/scripts/lib/path-normalization.d.mts
@@ -1,0 +1,1 @@
+export function toPosixPathSeparators(value: string): string;

--- a/scripts/lib/path-normalization.mjs
+++ b/scripts/lib/path-normalization.mjs
@@ -1,0 +1,3 @@
+export function toPosixPathSeparators(value) {
+  return value.replaceAll("\\", "/");
+}

--- a/test/scripts/path-normalization.test.ts
+++ b/test/scripts/path-normalization.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from "vitest";
+import { toPosixPathSeparators } from "../../scripts/lib/path-normalization.mjs";
+
+describe("toPosixPathSeparators", () => {
+  it.each([
+    ["", ""],
+    ["relative/path", "relative/path"],
+    ["relative\\path\\..\\file", "relative/path/../file"],
+    ["/", "/"],
+    ["C:\\", "C:/"],
+    ["C:\\Users\\Alice\\File.TXT", "C:/Users/Alice/File.TXT"],
+    ["\\\\server\\share\\folder\\", "//server/share/folder/"],
+  ])("normalizes separators without changing other path semantics: %s", (input, expected) => {
+    expect(toPosixPathSeparators(input)).toBe(expected);
+  });
+});


### PR DESCRIPTION
Closes #99692

## What Problem This Solves

Repository docs, build, and guard scripts carried separate helpers for the same platform-neutral backslash-to-forward-slash conversion. The duplicate concepts made identical Windows/POSIX path formatting behavior easier to drift.

## Why This Change Was Made

Adds one script-owned separator conversion primitive and routes six exact-contract callers through it. The helper only replaces backslashes; it does not normalize dot segments, roots, case, absoluteness, URLs, containment, home paths, realpaths, or other filesystem policy. Packaged standalone and workflow-filtered owners remain local because their lifecycle contracts differ.

## User Impact

No user-visible behavior change. Maintainers get one canonical implementation for this exact script-tooling contract, with six local helper concepts removed and a net reduction of seven non-test lines.

## Evidence

- Focused contract/owner proof: 316 tests passed via `node scripts/run-vitest.mjs ...` across the new helper, docs map/link audit, bundled plugin build entries, extension source classification, gateway watch regression, changed-test routing, runtime postbuild, and release checks.
- Direct guard proof: `node scripts/check-no-raw-http2-imports.mjs` passed.
- Exact rebased-head remote gate: Blacksmith Testbox through Crabbox `tbx_01kwn4ddqya075fzxsy35ynxgj`, Actions run `28687482507`, `corepack pnpm check:changed`, exit 0.
- Structured review: `.agents/skills/autoreview/scripts/autoreview --mode local --prompt-file tmp/notes.md --stream-engine-output` returned no accepted/actionable findings after excluding packaged postinstall and workflow-filtered docs-publish owners.
- Diff shape: six local helper concepts removed; net non-test delta `-7` lines.
