### PR TITLE
improve(qa): execute runtime scenarios through Docker

### DIFF
--- a/extensions/qa-lab/src/scenario-catalog.test.ts
+++ b/extensions/qa-lab/src/scenario-catalog.test.ts
@@ -242,14 +242,36 @@ describe("qa scenario catalog", () => {
     expect(readQaScenarioById("openai-web-search-minimal").coverage?.secondary).toContain(
       "runtime.reasoning-and-cache-controls",
     );
-    expect(
-      readQaScenarioById("openai-web-search-native-assertions").coverage?.secondary,
-    ).toEqual(
-      expect.arrayContaining(["web-search.openai-native-web-search", "plugins.web-search-and-fetch"]),
+    expect(readQaScenarioById("openai-web-search-native-assertions").coverage?.secondary).toEqual(
+      expect.arrayContaining([
+        "web-search.openai-native-web-search",
+        "plugins.web-search-and-fetch",
+      ]),
     );
     expect(readQaScenarioById("openwebui-openai-compatible").coverage?.secondary).toEqual(
       expect.arrayContaining(["gateway.openai-compatible-apis", "runtime.hosted-provider-turns"]),
     );
+  });
+
+  it("routes Docker runtime scenarios through the shared lane adapter", () => {
+    const scenarioLanes = [
+      ["openai-compatible-chat-tools", "openai-chat-tools"],
+      ["openai-web-search-minimal", "openai-web-search-minimal"],
+      ["openai-web-search-native-assertions", "openai-web-search-minimal"],
+      ["openwebui-openai-compatible", "openwebui"],
+      ["plugin-lifecycle-probe", "plugin-lifecycle-matrix"],
+      ["packaged-bundled-plugin-install-uninstall", "bundled-plugin-install-uninstall"],
+    ] as const;
+
+    for (const [scenarioId, lane] of scenarioLanes) {
+      const execution = readQaScenarioById(scenarioId).execution;
+      expect(execution.kind).toBe("script");
+      if (execution.kind !== "script") {
+        throw new Error(`expected script scenario, got ${execution.kind}`);
+      }
+      expect(execution.path).toBe("test/e2e/qa-lab/runtime/docker-e2e-lane.ts");
+      expect(execution.args).toStrictEqual(["--lane", lane]);
+    }
   });
 
   it("loads runtime parity tier metadata for first-hour and soak lanes", () => {

--- a/qa/scenarios/plugins/packaged-bundled-plugin-install-uninstall.yaml
+++ b/qa/scenarios/plugins/packaged-bundled-plugin-install-uninstall.yaml
@@ -20,9 +20,17 @@ scenario:
     - docs/cli/plugins.md
     - docs/help/testing.md
   codeRefs:
+    - scripts/e2e/bundled-plugin-install-uninstall-docker.sh
+    - scripts/e2e/lib/bundled-plugin-install-uninstall/sweep.sh
     - scripts/e2e/lib/bundled-plugin-install-uninstall/probe.mjs
+    - scripts/e2e/lib/bundled-plugin-install-uninstall/runtime-smoke.mjs
+    - test/e2e/qa-lab/runtime/docker-e2e-lane.ts
     - test/scripts/bundled-plugin-install-uninstall-probe.test.ts
   execution:
-    kind: vitest
-    path: test/scripts/bundled-plugin-install-uninstall-probe.test.ts
-    summary: Vitest coverage for packaged bundled plugin root discovery and install/uninstall record assertions.
+    kind: script
+    path: test/e2e/qa-lab/runtime/docker-e2e-lane.ts
+    summary: Runs the packaged bundled-plugin Docker sweep and asserts install, runtime load, and uninstall evidence for each selected plugin.
+    timeoutMs: 7200000
+    args:
+      - --lane
+      - bundled-plugin-install-uninstall

--- a/qa/scenarios/plugins/plugin-lifecycle-probe.yaml
+++ b/qa/scenarios/plugins/plugin-lifecycle-probe.yaml
@@ -8,18 +8,26 @@ scenario:
       - plugins.lifecycle
       - cli.plugin-validation-repair
       - plugins.setup-flows
-  objective: Exercise strict plugin load/uninstall proof parsing through QA Lab evidence.
+  objective: Exercise packaged plugin install, inspect, disable, enable, update, downgrade, and uninstall behavior in a clean Docker runtime.
   successCriteria:
-    - Enabled loaded plugin inspect JSON is accepted as proof.
-    - Pending or missing inspect JSON is rejected instead of treated as loaded.
-    - Malformed config during uninstall proof fails with a bounded diagnostic.
+    - A clean container installs the candidate OpenClaw package and fixture plugin package.
+    - Runtime inspect reports the installed plugin as enabled and loaded.
+    - Disable and enable commands persist the expected plugin state.
+    - Update and downgrade commands replace the installed plugin version while preserving the npm project root.
+    - Forced uninstall succeeds after installed plugin code is removed and emits a bounded resource summary.
   docsRefs:
     - docs/plugins/manifest.md
     - docs/cli/plugins.md
     - docs/concepts/qa-e2e-automation.md
   codeRefs:
+    - scripts/e2e/plugin-lifecycle-matrix-docker.sh
+    - test/e2e/qa-lab/plugins/plugin-lifecycle-probe-runtime.ts
+    - test/e2e/qa-lab/runtime/docker-e2e-lane.ts
     - test/e2e/qa-lab/plugins/plugin-lifecycle-probe.e2e.test.ts
   execution:
-    kind: vitest
-    path: test/e2e/qa-lab/plugins/plugin-lifecycle-probe.e2e.test.ts
-    summary: Vitest coverage for plugin lifecycle proof parsing.
+    kind: script
+    path: test/e2e/qa-lab/runtime/docker-e2e-lane.ts
+    summary: Runs the packaged plugin lifecycle matrix in a clean Docker runtime and asserts each emitted lifecycle phase.
+    args:
+      - --lane
+      - plugin-lifecycle-matrix

--- a/qa/scenarios/runtime/openai-compatible-chat-tools.yaml
+++ b/qa/scenarios/runtime/openai-compatible-chat-tools.yaml
@@ -21,8 +21,12 @@ scenario:
     - scripts/e2e/lib/openai-chat-tools/client.mjs
     - scripts/e2e/lib/openai-chat-tools/write-config.mjs
     - scripts/e2e/openai-chat-tools-docker.sh
+    - test/e2e/qa-lab/runtime/docker-e2e-lane.ts
     - test/e2e/qa-lab/runtime/openai-compatible-chat-tools.e2e.test.ts
   execution:
-    kind: vitest
-    path: test/e2e/qa-lab/runtime/openai-compatible-chat-tools.e2e.test.ts
-    summary: Vitest coverage for OpenAI-compatible chat-completions tool-call API behavior.
+    kind: script
+    path: test/e2e/qa-lab/runtime/docker-e2e-lane.ts
+    summary: Runs the OpenAI chat-tools Docker E2E lane against a real Gateway and the OpenAI-compatible chat-completions API.
+    args:
+      - --lane
+      - openai-chat-tools

--- a/qa/scenarios/runtime/openai-web-search-minimal.yaml
+++ b/qa/scenarios/runtime/openai-web-search-minimal.yaml
@@ -21,8 +21,12 @@ scenario:
   codeRefs:
     - scripts/e2e/lib/openai-web-search-minimal/client.mjs
     - scripts/e2e/openai-web-search-minimal-docker.sh
+    - test/e2e/qa-lab/runtime/docker-e2e-lane.ts
     - test/e2e/qa-lab/runtime/openai-web-search-minimal.e2e.test.ts
   execution:
-    kind: vitest
-    path: test/e2e/qa-lab/runtime/openai-web-search-minimal.e2e.test.ts
-    summary: Vitest coverage for OpenAI web_search minimal-reasoning success and rejection validation.
+    kind: script
+    path: test/e2e/qa-lab/runtime/docker-e2e-lane.ts
+    summary: Runs the OpenAI web_search Docker E2E lane through a real Gateway with a container-local OpenAI Responses mock.
+    args:
+      - --lane
+      - openai-web-search-minimal

--- a/qa/scenarios/runtime/openai-web-search-native-assertions.yaml
+++ b/qa/scenarios/runtime/openai-web-search-native-assertions.yaml
@@ -22,8 +22,13 @@ scenario:
   codeRefs:
     - scripts/e2e/lib/openai-web-search-minimal/assertions.mjs
     - scripts/e2e/lib/openai-web-search-minimal/mock-server.mjs
+    - scripts/e2e/openai-web-search-minimal-docker.sh
+    - test/e2e/qa-lab/runtime/docker-e2e-lane.ts
     - test/e2e/qa-lab/runtime/openai-web-search-minimal-assertions.e2e.test.ts
   execution:
-    kind: vitest
-    path: test/e2e/qa-lab/runtime/openai-web-search-minimal-assertions.e2e.test.ts
-    summary: Vitest coverage for native OpenAI web_search request-log assertions.
+    kind: script
+    path: test/e2e/qa-lab/runtime/docker-e2e-lane.ts
+    summary: Runs the OpenAI web_search Docker E2E lane and asserts the emitted native Responses request log.
+    args:
+      - --lane
+      - openai-web-search-minimal

--- a/qa/scenarios/runtime/openwebui-openai-compatible.yaml
+++ b/qa/scenarios/runtime/openwebui-openai-compatible.yaml
@@ -20,8 +20,12 @@ scenario:
   codeRefs:
     - scripts/e2e/openwebui-probe.mjs
     - scripts/e2e/openwebui-docker.sh
+    - test/e2e/qa-lab/runtime/docker-e2e-lane.ts
     - test/e2e/qa-lab/runtime/openwebui-probe.e2e.test.ts
   execution:
-    kind: vitest
-    path: test/e2e/qa-lab/runtime/openwebui-probe.e2e.test.ts
-    summary: Vitest coverage for OpenWebUI model and chat-completions probe behavior.
+    kind: script
+    path: test/e2e/qa-lab/runtime/docker-e2e-lane.ts
+    summary: Runs the OpenWebUI Docker topology and probes its OpenAI-compatible model and chat APIs against OpenClaw.
+    args:
+      - --lane
+      - openwebui

--- a/test/e2e/qa-lab/plugins/plugin-lifecycle-probe-runtime.ts
+++ b/test/e2e/qa-lab/plugins/plugin-lifecycle-probe-runtime.ts
@@ -6,9 +6,24 @@ import os from "node:os";
 import path from "node:path";
 import { readPluginInstallRecords } from "../../../../scripts/e2e/lib/plugin-index-sqlite.mjs";
 import { resolveWindowsTaskkillPath } from "../../../../scripts/lib/windows-taskkill.mjs";
-import { createTempDirTracker } from "../../../helpers/temp-dir.js";
 
-const tempDirs = createTempDirTracker();
+// The Docker entrypoint runs without Vitest installed, so keep cleanup local to this runtime probe.
+const tempDirs = (() => {
+  const dirs = new Set<string>();
+  return {
+    make(prefix: string): string {
+      const dir = fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+      dirs.add(dir);
+      return dir;
+    },
+    cleanup(): void {
+      for (const dir of dirs) {
+        fs.rmSync(dir, { recursive: true, force: true, maxRetries: 5, retryDelay: 20 });
+      }
+      dirs.clear();
+    },
+  };
+})();
 
 type ProbeEnv = Pick<NodeJS.ProcessEnv, "HOME" | "OPENCLAW_CONFIG_PATH" | "OPENCLAW_STATE_DIR">;
 


### PR DESCRIPTION
## What Problem This Solves

Resolves a QA coverage gap where six runtime and plugin scenarios reported helper-level Vitest proof instead of exercising their existing Docker runtime topology and product-facing APIs.

## Why This Change Was Made

Routes the six scenario definitions through the shared Docker E2E lane adapter, preserving the existing lane implementations and focused helper tests. The native web-search assertion scenario intentionally shares the same runtime lane as the minimal web-search scenario because that lane emits and validates both the successful native Responses request and the minimal-reasoning rejection evidence.

The plugin lifecycle runtime probe also keeps its temporary-directory cleanup local so the package-installed bare Docker image does not need the Vitest-only test helper dependency.

## User Impact

No product behavior changes. Maintainers now receive real container/runtime evidence for OpenAI-compatible chat tools, OpenAI native web search, OpenWebUI compatibility, plugin lifecycle operations, and packaged bundled-plugin install/uninstall coverage when these QA scenarios run.

## Evidence

- Exact-head targeted Docker run `28688381529` passed at `37783c3502e427b47a24370af24fb4c50ef0c625`:
  - `openai-chat-tools`
  - `openai-web-search-minimal` (covers both minimal and native-request assertion scenarios)
  - `openwebui`
  - `plugin-lifecycle-matrix`
  - `bundled-plugin-install-uninstall` (all scheduler-expanded shards)
- The targeted workflow reused `docker-e2e-package` from run `28568249540` because current `main` and the initial exact-head run both fail package preparation at the same pre-existing `write-plugin-sdk-entry-dts` build step. The source run's package preparation job succeeded; this PR changes no package contents or Docker lane implementations.
- `node scripts/run-vitest.mjs test/e2e/qa-lab/plugins/plugin-lifecycle-probe.e2e.test.ts extensions/qa-lab/src/scenario-catalog.test.ts test/e2e/qa-lab/runtime/docker-e2e-lane.fixture.test.ts --reporter=verbose` — 47 tests passed after the final rebase.
- Targeted `oxfmt --check` and `git diff --check` passed.
- Blacksmith Testbox changed-file gate passed on `tbx_01kwn62778hx14fh400ahcjq78` (Actions run `28688249628`).
- Structured Codex autoreview reported no accepted/actionable findings with 0.98 correctness confidence.

Known CI gap: exact-head CI run `28688380283` failed `QA Smoke CI` because Docker script scenarios and QA flow partitions concurrently mutate/read the shared `dist/` build. The single failed-job rerun reproduced the race (`dist/index.js` missing, then a generated chunk missing). Current `main` QA Smoke passes without these newly script-backed scenarios. This shared QA-runner orchestration fix is intentionally not mixed into this PR and has been requested as a separate micro-fix.
