### PR TITLE
refactor: consolidate URL mechanics

### DIFF
--- a/extensions/alibaba/video-generation-provider.ts
+++ b/extensions/alibaba/video-generation-provider.ts
@@ -4,7 +4,10 @@
  */
 import { isProviderApiKeyConfigured } from "openclaw/plugin-sdk/provider-auth";
 import { resolveApiKeyForProvider } from "openclaw/plugin-sdk/provider-auth-runtime";
-import { resolveProviderHttpRequestConfig } from "openclaw/plugin-sdk/provider-http";
+import {
+  normalizeBaseUrl,
+  resolveProviderHttpRequestConfig,
+} from "openclaw/plugin-sdk/provider-http";
 import {
   DASHSCOPE_WAN_VIDEO_CAPABILITIES,
   DASHSCOPE_WAN_VIDEO_MODELS,
@@ -23,10 +26,6 @@ const DEFAULT_ALIBABA_VIDEO_MODEL = DEFAULT_DASHSCOPE_WAN_VIDEO_MODEL;
 
 function resolveAlibabaVideoBaseUrl(req: VideoGenerationRequest): string {
   return req.cfg?.models?.providers?.alibaba?.baseUrl?.trim() || DEFAULT_ALIBABA_VIDEO_BASE_URL;
-}
-
-function resolveDashscopeAigcApiBaseUrl(baseUrl: string): string {
-  return baseUrl.replace(/\/+$/u, "");
 }
 
 /** Build the Alibaba/DashScope video generation provider descriptor. */
@@ -70,13 +69,14 @@ export function buildAlibabaVideoGenerationProvider(): VideoGenerationProvider {
         });
 
       const model = req.model?.trim() || DEFAULT_ALIBABA_VIDEO_MODEL;
+      const apiBaseUrl = normalizeBaseUrl(baseUrl, DEFAULT_ALIBABA_VIDEO_BASE_URL);
       return await runDashscopeVideoGenerationTask({
         providerLabel: "Alibaba Wan",
         model,
         req,
-        url: `${resolveDashscopeAigcApiBaseUrl(baseUrl)}/api/v1/services/aigc/video-generation/video-synthesis`,
+        url: `${apiBaseUrl}/api/v1/services/aigc/video-generation/video-synthesis`,
         headers,
-        baseUrl: resolveDashscopeAigcApiBaseUrl(baseUrl),
+        baseUrl: apiBaseUrl,
         timeoutMs: req.timeoutMs,
         fetchFn,
         allowPrivateNetwork,

--- a/extensions/brave/src/brave-web-search-provider.runtime.ts
+++ b/extensions/brave/src/brave-web-search-provider.runtime.ts
@@ -4,6 +4,7 @@
  */
 import {
   assertOkOrThrowProviderError,
+  normalizeBaseUrl,
   readProviderJsonResponse,
 } from "openclaw/plugin-sdk/provider-http";
 import type { SearchConfigRecord } from "openclaw/plugin-sdk/provider-web-search";
@@ -102,7 +103,7 @@ function resolveBraveBaseUrl(braveConfig: { baseUrl?: unknown } | undefined): st
     braveConfig?.baseUrl,
     "plugins.entries.brave.config.webSearch.baseUrl",
   );
-  return configured?.replace(/\/+$/u, "") || DEFAULT_BRAVE_BASE_URL;
+  return normalizeBaseUrl(configured, DEFAULT_BRAVE_BASE_URL);
 }
 
 function buildBraveEndpointUrl(params: { baseUrl: string; endpointPath: string }): URL {

--- a/extensions/openai/tts.ts
+++ b/extensions/openai/tts.ts
@@ -1,6 +1,7 @@
 // Openai plugin module implements tts behavior.
 import {
   assertOkOrThrowProviderError,
+  normalizeBaseUrl,
   resolveProviderRequestHeaders,
 } from "openclaw/plugin-sdk/provider-http";
 import {
@@ -38,11 +39,7 @@ export const OPENAI_TTS_VOICES = [
 type OpenAiTtsVoice = (typeof OPENAI_TTS_VOICES)[number];
 
 export function normalizeOpenAITtsBaseUrl(baseUrl?: string): string {
-  const trimmed = baseUrl?.trim();
-  if (!trimmed) {
-    return DEFAULT_OPENAI_BASE_URL;
-  }
-  return trimmed.replace(/\/+$/, "");
+  return normalizeBaseUrl(baseUrl, DEFAULT_OPENAI_BASE_URL);
 }
 
 function isCustomOpenAIEndpoint(baseUrl?: string): boolean {

--- a/extensions/together/video-generation-provider.ts
+++ b/extensions/together/video-generation-provider.ts
@@ -8,6 +8,7 @@ import {
   createProviderOperationDeadline,
   createProviderOperationTimeoutResolver,
   fetchProviderDownloadResponse,
+  normalizeBaseUrl,
   pollProviderOperationJson,
   postJsonRequest,
   readProviderJsonResponse,
@@ -72,15 +73,11 @@ function resolveTogetherVideoBaseUrl(req: VideoGenerationRequest): string {
   const configuredBaseUrl = normalizeOptionalString(req.cfg?.models?.providers?.together?.baseUrl);
   if (
     !configuredBaseUrl ||
-    stripTrailingSlash(configuredBaseUrl) === stripTrailingSlash(TOGETHER_BASE_URL)
+    normalizeBaseUrl(configuredBaseUrl) === normalizeBaseUrl(TOGETHER_BASE_URL)
   ) {
     return TOGETHER_VIDEO_BASE_URL;
   }
   return configuredBaseUrl;
-}
-
-function stripTrailingSlash(value: string): string {
-  return value.replace(/\/+$/u, "");
 }
 
 function extractTogetherVideoUrl(payload: TogetherVideoResponse): string | undefined {

--- a/extensions/xai/tts.ts
+++ b/extensions/xai/tts.ts
@@ -1,5 +1,9 @@
 // Xai plugin module implements tts behavior.
-import { assertOkOrThrowProviderError, postJsonRequest } from "openclaw/plugin-sdk/provider-http";
+import {
+  assertOkOrThrowProviderError,
+  normalizeBaseUrl,
+  postJsonRequest,
+} from "openclaw/plugin-sdk/provider-http";
 import { readResponseWithLimit } from "openclaw/plugin-sdk/response-limit-runtime";
 import { trimToUndefined } from "openclaw/plugin-sdk/speech";
 import { XAI_BASE_URL } from "./api.js";
@@ -12,11 +16,7 @@ export const XAI_TTS_VOICES = ["eve", "ara", "rex", "sal", "leo", "una"] as cons
 type XaiTtsVoice = (typeof XAI_TTS_VOICES)[number];
 
 export function normalizeXaiTtsBaseUrl(baseUrl?: string): string {
-  const trimmed = baseUrl?.trim();
-  if (!trimmed) {
-    return XAI_BASE_URL;
-  }
-  return trimmed.replace(/\/+$/, "");
+  return normalizeBaseUrl(baseUrl, XAI_BASE_URL);
 }
 
 export function isValidXaiTtsVoice(voice: string, baseUrl?: string): voice is XaiTtsVoice {

--- a/extensions/xiaomi/speech-provider.ts
+++ b/extensions/xiaomi/speech-provider.ts
@@ -3,6 +3,7 @@ import { transcodeAudioBufferToOpus } from "openclaw/plugin-sdk/media-runtime";
 import { resolveTimerTimeoutMs } from "openclaw/plugin-sdk/number-runtime";
 import {
   assertOkOrThrowProviderError,
+  normalizeBaseUrl,
   readProviderJsonResponse,
 } from "openclaw/plugin-sdk/provider-http";
 import { normalizeResolvedSecretInputString } from "openclaw/plugin-sdk/secret-input";
@@ -59,7 +60,7 @@ type XiaomiTtsOverrides = {
 };
 
 function normalizeXiaomiTtsBaseUrl(baseUrl?: string): string {
-  return (baseUrl?.trim() || DEFAULT_XIAOMI_TTS_BASE_URL).replace(/\/+$/, "");
+  return normalizeBaseUrl(baseUrl, DEFAULT_XIAOMI_TTS_BASE_URL);
 }
 
 function normalizeXiaomiTtsFormat(value: unknown): XiaomiTtsFormat | undefined {

--- a/src/hooks/gmail.ts
+++ b/src/hooks/gmail.ts
@@ -13,6 +13,7 @@ import {
   isWindowsBatchCommand,
   resolveTrustedWindowsCmdExe,
 } from "../process/windows-command.js";
+import { appendUrlPath } from "../shared/url.js";
 
 export const DEFAULT_GMAIL_LABEL = "INBOX";
 export const DEFAULT_GMAIL_TOPIC = "gog-gmail-watch";
@@ -104,7 +105,7 @@ export function buildDefaultHookUrl(
 ): string {
   const basePath = normalizeHooksPath(hooksPath);
   const baseUrl = `http://127.0.0.1:${port}`;
-  return joinUrl(baseUrl, `${basePath}/gmail`);
+  return appendUrlPath(baseUrl, `${basePath}/gmail`).toString();
 }
 
 export function resolveGmailHookRuntimeConfig(
@@ -300,12 +301,4 @@ export function parseTopicPath(topic: string): { projectId: string; topicName: s
     return null;
   }
   return { projectId: match[1] ?? "", topicName: match[2] ?? "" };
-}
-
-function joinUrl(base: string, pathLocal: string): string {
-  const url = new URL(base);
-  const basePath = url.pathname.replace(/\/+$/, "");
-  const extra = pathLocal.startsWith("/") ? pathLocal : `/${pathLocal}`;
-  url.pathname = `${basePath}${extra}`;
-  return url.toString();
 }

--- a/src/infra/clawhub.ts
+++ b/src/infra/clawhub.ts
@@ -13,6 +13,7 @@ import {
   normalizeOptionalString,
 } from "@openclaw/normalization-core/string-coerce";
 import { normalizeStringEntries } from "@openclaw/normalization-core/string-normalization";
+import { appendUrlPath } from "../shared/url.js";
 import { sha256Base64, sha256Hex as digestSha256Hex } from "./crypto-digest.js";
 import { parseStrictPositiveInteger } from "./parse-finite-number.js";
 import { isAtLeast, parseSemver } from "./runtime-guard.js";
@@ -677,10 +678,7 @@ function buildUrl(params: Pick<ClawHubRequestParams, "baseUrl" | "path" | "searc
   if (!params.path) {
     throw new Error("ClawHub request path is required");
   }
-  const url = new URL(`${normalizeBaseUrl(params.baseUrl)}/`);
-  const basePath = url.pathname.replace(/\/+$/, "");
-  const requestPath = params.path.startsWith("/") ? params.path : `/${params.path}`;
-  url.pathname = `${basePath}${requestPath}`;
+  const url = appendUrlPath(normalizeBaseUrl(params.baseUrl), params.path);
   for (const [key, value] of Object.entries(params.search ?? {})) {
     if (!value) {
       continue;

--- a/src/plugin-sdk/test-helpers/provider-http-mocks.ts
+++ b/src/plugin-sdk/test-helpers/provider-http-mocks.ts
@@ -275,6 +275,8 @@ vi.mock("openclaw/plugin-sdk/provider-http", () => ({
   fetchProviderOperationResponse: providerHttpMocks.fetchProviderOperationResponseMock,
   fetchWithTimeout: providerHttpMocks.fetchWithTimeoutMock,
   fetchWithTimeoutGuarded: providerHttpMocks.fetchWithTimeoutGuardedMock,
+  normalizeBaseUrl: (baseUrl?: string, fallback?: string) =>
+    (baseUrl?.trim() || fallback?.trim())?.replace(/\/+$/, ""),
   pollProviderOperationJson: providerHttpMocks.pollProviderOperationJsonMock,
   postJsonRequest: providerHttpMocks.postJsonRequestMock,
   postMultipartRequest: providerHttpMocks.postMultipartRequestMock,

--- a/src/shared/url.test.ts
+++ b/src/shared/url.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from "vitest";
+import { appendUrlPath } from "./url.js";
+
+describe("appendUrlPath", () => {
+  it("preserves base path prefixes and URL state", () => {
+    expect(
+      appendUrlPath("https://example.com/proxy/?mode=1#section", "/v1/models").toString(),
+    ).toBe("https://example.com/proxy/v1/models?mode=1#section");
+  });
+
+  it("normalizes the path boundary without changing path contents", () => {
+    expect(appendUrlPath("https://example.com/proxy///", "v1/models").toString()).toBe(
+      "https://example.com/proxy/v1/models",
+    );
+  });
+});

--- a/src/shared/url.ts
+++ b/src/shared/url.ts
@@ -1,0 +1,8 @@
+/** Appends a path while preserving any path prefix already present on the base URL. */
+export function appendUrlPath(baseUrl: string | URL, path: string): URL {
+  const url = new URL(baseUrl);
+  const basePath = url.pathname.replace(/\/+$/, "");
+  const suffix = path.startsWith("/") ? path : `/${path}`;
+  url.pathname = `${basePath}${suffix}`;
+  return url;
+}


### PR DESCRIPTION
Related: #99701

## What Problem This Solves

OpenClaw had repeated implementations for trimming provider base URLs and appending endpoint paths to URL prefixes. These copies made exact behavior easier to drift across provider, hook, and ClawHub request paths.

## Why This Change Was Made

This reuses the existing `normalizeBaseUrl` contract already published through `openclaw/plugin-sdk/provider-http` in bundled plugins that already import that subpath. Core URL pathname joining now uses one private helper that preserves reverse-proxy path prefixes without adding a new SDK/package/lazy boundary or absorbing provider-specific validation and policy.

## User Impact

No intended user-visible behavior change. Maintainers and plugin developers get fewer duplicate URL mechanics, while existing fallback, trimming, path-prefix, query, and fragment behavior remains unchanged.

## Evidence

- Focused owner proof: `node scripts/run-vitest.mjs ...` across 12 files — 208 tests passed in 8 shards.
- Plugin SDK contract proof: `src/plugins/contracts/plugin-sdk-subpaths.test.ts` passed as part of the focused batch.
- Post-rebase proof: shared URL, Gmail, and ClawHub tests — 73 tests passed.
- Formatting: scoped `pnpm format:check -- ...` and `git diff --check` passed.
- Changed-surface gate: Testbox-through-Crabbox `tbx_01kwn4n1twrps56q8p1cbvgk3m`, Actions run 28687596818, exit 0; core/extension types, lint, import cycles, and repository guards passed.
- Fresh autoreview: `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main --prompt-file tmp/notes.md --stream-engine-output` — clean, no accepted/actionable findings.
- Production LOC: net -3 counting shared test-mock support; net -5 excluding test-only support.
