### PR TITLE
fix(build): Docker package preparation misses plugin SDK declarations

### DIFF
--- a/scripts/package-openclaw-for-docker.mjs
+++ b/scripts/package-openclaw-for-docker.mjs
@@ -352,7 +352,7 @@ export async function buildPackageArtifacts(sourceDir, options = {}) {
       env: {
         ...process.env,
         OPENCLAW_BUILD_ALL_NO_PNPM: "1",
-        OPENCLAW_RUN_NODE_SKIP_DTS_BUILD: "1",
+        OPENCLAW_RUN_NODE_SKIP_DTS_BUILD: "0",
       },
       timeoutMs: resolveTimeoutMs(
         "OPENCLAW_DOCKER_PACKAGE_BUILD_TIMEOUT_MS",

--- a/test/e2e/qa-lab/runtime/package-openclaw-for-docker.e2e.test.ts
+++ b/test/e2e/qa-lab/runtime/package-openclaw-for-docker.e2e.test.ts
@@ -135,7 +135,7 @@ describe("package-openclaw-for-docker", () => {
     );
   });
 
-  it("uses build-all as the single bounded package artifact build step", async () => {
+  it("uses build-all with declaration generation for package artifacts", async () => {
     const calls: Array<{
       command: string;
       args: string[];
@@ -145,7 +145,9 @@ describe("package-openclaw-for-docker", () => {
       timeoutMs: number | undefined;
     }> = [];
     const previousTimeout = process.env.OPENCLAW_DOCKER_PACKAGE_BUILD_TIMEOUT_MS;
+    const previousSkipDts = process.env.OPENCLAW_RUN_NODE_SKIP_DTS_BUILD;
     process.env.OPENCLAW_DOCKER_PACKAGE_BUILD_TIMEOUT_MS = "1234";
+    process.env.OPENCLAW_RUN_NODE_SKIP_DTS_BUILD = "1";
 
     try {
       await buildPackageArtifacts("/repo", {
@@ -171,6 +173,11 @@ describe("package-openclaw-for-docker", () => {
       } else {
         process.env.OPENCLAW_DOCKER_PACKAGE_BUILD_TIMEOUT_MS = previousTimeout;
       }
+      if (previousSkipDts === undefined) {
+        delete process.env.OPENCLAW_RUN_NODE_SKIP_DTS_BUILD;
+      } else {
+        process.env.OPENCLAW_RUN_NODE_SKIP_DTS_BUILD = previousSkipDts;
+      }
     }
 
     expect(calls).toEqual([
@@ -179,7 +186,7 @@ describe("package-openclaw-for-docker", () => {
         args: ["scripts/build-all.mjs"],
         cwd: "/repo",
         noPnpm: "1",
-        skipDts: "1",
+        skipDts: "0",
         timeoutMs: 1234,
       },
     ]);


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where Docker package preparation failed on a clean checkout with `Missing canonical plugin SDK declaration: dist/plugin-sdk/index.d.ts` while building the package artifact.

The failure was observed in `prepare_docker_e2e_image` in workflow runs 28687921359 and 28687855362.

## Why This Change Was Made

Docker package preparation now explicitly enables declaration generation for its full `build-all` invocation, overriding any inherited declaration-skip setting. This keeps `tsdown` as the canonical declaration owner and preserves the existing fail-closed declaration validation instead of adding a fallback or skipping the check.

The regression test seeds the parent process with `OPENCLAW_RUN_NODE_SKIP_DTS_BUILD=1` and verifies that package preparation overrides it to `0`.

## User Impact

Maintainers and release automation can prepare Docker/package artifacts from clean checkouts without the plugin SDK declaration build failing. There is no runtime product behavior change.

## Evidence

- Before: current `main` reproduced the exact failure with `node scripts/package-openclaw-for-docker.mjs --output-dir .artifacts/plugin-sdk-dts-ci-repro --output-name openclaw-plugin-sdk-dts-ci.tgz`.
- Focused regression: `node scripts/run-vitest.mjs test/e2e/qa-lab/runtime/package-openclaw-for-docker.e2e.test.ts` — 18 tests passed.
- Blacksmith Testbox-through-Crabbox: `tbx_01kwn60w3mp8m74crwz14w3gyp`, Actions run 28688231221 — clean package build with inherited `OPENCLAW_RUN_NODE_SKIP_DTS_BUILD=1`; canonical declaration present; tarball integrity passed; exit 0.
- Auto Review: final local branch review reported no accepted/actionable findings.
