### PR TITLE
fix(discord): send fresh final messages after previews

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- **Discord streamed finals:** send completion replies as fresh messages so inactive channels become unread, while preserving targeted mentions without escalating `@everyone` or `@here`. (#99711, #99662) Thanks @davelutztx.
 - **Agent auth copy order:** preserve the source agent's portable auth-profile precedence when copying credentials to a new agent while excluding skipped profiles and transient auth state. (#100833) Thanks @machine3at.
 - **Cron edit delivery:** preserve each job's implicit delivery mode when applying partial delivery updates, so disabling best-effort delivery no longer turns detached job announcements off. (#100846) Thanks @machine3at.
 - **Control UI session creation:** keep newly created sessions at the front of the stable sidebar order after selecting another session. Thanks @shakkernerd.

--- a/extensions/discord/src/channel.message-adapter.test.ts
+++ b/extensions/discord/src/channel.message-adapter.test.ts
@@ -242,7 +242,7 @@ describe("discord channel message adapter", () => {
           expect(adapter.live?.finalizer?.capabilities?.discardPending).toBe(true);
         },
         previewFinalization: () => {
-          expect(adapter.live?.finalizer?.capabilities?.finalEdit).toBe(true);
+          expect(adapter.live?.finalizer?.capabilities?.normalFallback).toBe(true);
         },
         progressUpdates: () => {
           expect(adapter.live?.capabilities?.draftPreview).toBe(true);
@@ -255,7 +255,7 @@ describe("discord channel message adapter", () => {
       adapter,
       proofs: {
         finalEdit: () => {
-          expect(adapter.live?.capabilities?.previewFinalization).toBe(true);
+          expect(adapter.live?.finalizer?.capabilities?.finalEdit).toBe(false);
         },
         normalFallback: () => {
           expect(sendText).toBeTypeOf("function");

--- a/extensions/discord/src/channel.ts
+++ b/extensions/discord/src/channel.ts
@@ -95,7 +95,7 @@ const discordMessageAdapter = createChannelMessageAdapterFromOutbound({
     },
     finalizer: {
       capabilities: {
-        finalEdit: true,
+        finalEdit: false,
         normalFallback: true,
         discardPending: true,
       },

--- a/extensions/discord/src/monitor/message-handler.process.test.ts
+++ b/extensions/discord/src/monitor/message-handler.process.test.ts
@@ -2074,6 +2074,7 @@ describe("processDiscordMessage draft streaming", () => {
   it("sends a fresh final message for broadcast mentions like @everyone", async () => {
     dispatchInboundMessage.mockImplementationOnce(async (params?: DispatchInboundParams) => {
       await params?.dispatcher.sendFinalReply({ text: "heads up @everyone" });
+      await params?.dispatcher.waitForIdle();
       return { queuedFinal: true, counts: { final: 1, tool: 0, block: 0 } };
     });
 
@@ -2092,6 +2093,7 @@ describe("processDiscordMessage draft streaming", () => {
   it("sends a fresh final message when a targeted mention is mixed with @everyone", async () => {
     dispatchInboundMessage.mockImplementationOnce(async (params?: DispatchInboundParams) => {
       await params?.dispatcher.sendFinalReply({ text: "heads up @Sentinel @everyone" });
+      await params?.dispatcher.waitForIdle();
       return { queuedFinal: true, counts: { final: 1, tool: 0, block: 0 } };
     });
 

--- a/extensions/discord/src/monitor/message-handler.process.test.ts
+++ b/extensions/discord/src/monitor/message-handler.process.test.ts
@@ -2084,7 +2084,9 @@ describe("processDiscordMessage draft streaming", () => {
     await runProcessDiscordMessage(ctx);
 
     expect(editMessageDiscord).not.toHaveBeenCalled();
-    expect(deliverDiscordReply).toHaveBeenCalledTimes(1);
+    expect(firstMockArg(deliverDiscordReply, "deliverDiscordReply")).toMatchObject({
+      allowedMentions: { parse: ["users", "roles"] },
+    });
   });
 
   it("sends a fresh final message when a targeted mention is mixed with @everyone", async () => {
@@ -2103,7 +2105,9 @@ describe("processDiscordMessage draft streaming", () => {
     await runProcessDiscordMessage(ctx);
 
     expect(editMessageDiscord).not.toHaveBeenCalled();
-    expect(deliverDiscordReply).toHaveBeenCalledTimes(1);
+    expect(firstMockArg(deliverDiscordReply, "deliverDiscordReply")).toMatchObject({
+      allowedMentions: { parse: ["users", "roles"] },
+    });
   });
 
   it("accepts streaming=true alias for partial preview mode", async () => {

--- a/extensions/discord/src/monitor/message-handler.process.test.ts
+++ b/extensions/discord/src/monitor/message-handler.process.test.ts
@@ -1,5 +1,4 @@
 // Discord tests cover message handler.process plugin behavior.
-import { MessageFlags } from "discord-api-types/v10";
 import { DEFAULT_EMOJIS, DEFAULT_TIMING } from "openclaw/plugin-sdk/channel-feedback";
 import {
   recordChannelBotPairLoopAndCheckSuppression,
@@ -731,19 +730,6 @@ function createMockDraftStreamForTest() {
   const draftStream = createMockDraftStream();
   createDiscordDraftStream.mockReturnValueOnce(draftStream);
   return draftStream;
-}
-
-function expectPreviewEditContent(content: string) {
-  const call = firstMockCall(editMessageDiscord, "preview edit");
-  expect(call[0]).toBe("c1");
-  expect(call[1]).toBe("preview-1");
-  expect(call[2]).toEqual({ content, flags: MessageFlags.SuppressEmbeds });
-  requireRecord(requireRecord(call[3], "preview edit options").rest, "preview edit REST client");
-}
-
-function expectSinglePreviewEdit() {
-  expectPreviewEditContent("Hello\nWorld");
-  expect(deliverDiscordReply).not.toHaveBeenCalled();
 }
 
 function expectProgressSummaryEdit(...parts: string[]) {
@@ -2028,9 +2014,10 @@ describe("processDiscordMessage draft streaming", () => {
     });
   }
 
-  it("finalizes via preview edit when final fits one chunk", async () => {
+  it("sends a fresh final message when final fits one chunk", async () => {
     await runSingleChunkFinalScenario({ streamMode: "partial", maxLinesPerMessage: 5 });
-    expectSinglePreviewEdit();
+    expect(editMessageDiscord).not.toHaveBeenCalled();
+    expectFreshFinalText("Hello\nWorld");
   });
 
   it("delivers a fresh message instead of a preview edit when the final reply resolves a mention alias", async () => {
@@ -2048,8 +2035,6 @@ describe("processDiscordMessage draft streaming", () => {
 
     await runProcessDiscordMessage(ctx);
 
-    // Discord only fires mention notifications on create, never on edits, so the
-    // streamed preview must be abandoned and the mention delivered fresh.
     expect(editMessageDiscord).not.toHaveBeenCalled();
     expect(deliverDiscordReply).toHaveBeenCalledTimes(1);
   });
@@ -2070,7 +2055,7 @@ describe("processDiscordMessage draft streaming", () => {
     expect(deliverDiscordReply).toHaveBeenCalledTimes(1);
   });
 
-  it("still finalizes via preview edit when an unaliased handle stays plain text", async () => {
+  it("sends a fresh final message when an unaliased handle stays plain text", async () => {
     dispatchInboundMessage.mockImplementationOnce(async (params?: DispatchInboundParams) => {
       await params?.dispatcher.sendFinalReply({ text: "On it @Sentinel" });
       return { queuedFinal: true, counts: { final: 1, tool: 0, block: 0 } };
@@ -2082,11 +2067,11 @@ describe("processDiscordMessage draft streaming", () => {
 
     await runProcessDiscordMessage(ctx);
 
-    expect(editMessageDiscord).toHaveBeenCalledTimes(1);
-    expect(deliverDiscordReply).not.toHaveBeenCalled();
+    expect(editMessageDiscord).not.toHaveBeenCalled();
+    expect(deliverDiscordReply).toHaveBeenCalledTimes(1);
   });
 
-  it("still finalizes via preview edit for broadcast mentions like @everyone", async () => {
+  it("sends a fresh final message for broadcast mentions like @everyone", async () => {
     dispatchInboundMessage.mockImplementationOnce(async (params?: DispatchInboundParams) => {
       await params?.dispatcher.sendFinalReply({ text: "heads up @everyone" });
       return { queuedFinal: true, counts: { final: 1, tool: 0, block: 0 } };
@@ -2098,11 +2083,11 @@ describe("processDiscordMessage draft streaming", () => {
 
     await runProcessDiscordMessage(ctx);
 
-    expect(editMessageDiscord).toHaveBeenCalledTimes(1);
-    expect(deliverDiscordReply).not.toHaveBeenCalled();
+    expect(editMessageDiscord).not.toHaveBeenCalled();
+    expect(deliverDiscordReply).toHaveBeenCalledTimes(1);
   });
 
-  it("still finalizes via preview edit when a targeted mention is mixed with @everyone", async () => {
+  it("sends a fresh final message when a targeted mention is mixed with @everyone", async () => {
     dispatchInboundMessage.mockImplementationOnce(async (params?: DispatchInboundParams) => {
       await params?.dispatcher.sendFinalReply({ text: "heads up @Sentinel @everyone" });
       return { queuedFinal: true, counts: { final: 1, tool: 0, block: 0 } };
@@ -2117,14 +2102,14 @@ describe("processDiscordMessage draft streaming", () => {
 
     await runProcessDiscordMessage(ctx);
 
-    // Mixed targeted + broadcast must not escalate into a create that pings @everyone.
-    expect(editMessageDiscord).toHaveBeenCalledTimes(1);
-    expect(deliverDiscordReply).not.toHaveBeenCalled();
+    expect(editMessageDiscord).not.toHaveBeenCalled();
+    expect(deliverDiscordReply).toHaveBeenCalledTimes(1);
   });
 
   it("accepts streaming=true alias for partial preview mode", async () => {
     await runSingleChunkFinalScenario({ streaming: true, maxLinesPerMessage: 5 });
-    expectSinglePreviewEdit();
+    expect(editMessageDiscord).not.toHaveBeenCalled();
+    expectFreshFinalText("Hello\nWorld");
   });
 
   it("defaults unset Discord preview streaming to progress mode without drafting text-only turns", async () => {
@@ -2418,8 +2403,9 @@ describe("processDiscordMessage draft streaming", () => {
     expect(draftStream.clear).toHaveBeenCalledTimes(1);
   });
 
-  it("uses root discord maxLinesPerMessage for preview finalization when runtime config omits it", async () => {
+  it("uses root discord maxLinesPerMessage for fresh final delivery when runtime config omits it", async () => {
     const longReply = Array.from({ length: 20 }, (_value, index) => `Line ${index + 1}`).join("\n");
+    const draftStream = createMockDraftStreamForTest();
     dispatchInboundMessage.mockImplementationOnce(async (params?: DispatchInboundParams) => {
       await params?.dispatcher.sendFinalReply({ text: longReply });
       return { queuedFinal: true, counts: { final: 1, tool: 0, block: 0 } };
@@ -2440,8 +2426,10 @@ describe("processDiscordMessage draft streaming", () => {
 
     await runProcessDiscordMessage(ctx);
 
-    expectPreviewEditContent(longReply);
-    expect(deliverDiscordReply).not.toHaveBeenCalled();
+    expect(editMessageDiscord).not.toHaveBeenCalled();
+    expectFreshFinalText(longReply);
+    expect(draftStream.discardPending).toHaveBeenCalledTimes(1);
+    expect(draftStream.clear).toHaveBeenCalledTimes(1);
   });
 
   it("falls back to standard delivery for explicit reply-tag finals", async () => {
@@ -2488,7 +2476,7 @@ describe("processDiscordMessage draft streaming", () => {
     expect(deliverDiscordReply).toHaveBeenCalledTimes(1);
   });
 
-  it("keeps the preview and sends media-only for TTS supplement finals", async () => {
+  it("sends a fresh visible TTS supplement final and clears the preview", async () => {
     const draftStream = createMockDraftStreamForTest();
     dispatchInboundMessage.mockImplementationOnce(async (params?: DispatchInboundParams) => {
       await params?.dispatcher.sendFinalReply({
@@ -2507,15 +2495,16 @@ describe("processDiscordMessage draft streaming", () => {
 
     await runProcessDiscordMessage(ctx);
 
-    expect(draftStream.flush).toHaveBeenCalledTimes(1);
-    expect(draftStream.discardPending).not.toHaveBeenCalled();
-    expect(draftStream.clear).not.toHaveBeenCalled();
-    expectPreviewEditContent("Spoken answer");
+    expect(draftStream.flush).not.toHaveBeenCalled();
+    expect(draftStream.discardPending).toHaveBeenCalledTimes(1);
+    expect(draftStream.clear).toHaveBeenCalledTimes(1);
+    expect(editMessageDiscord).not.toHaveBeenCalled();
     expect(deliverDiscordReply).toHaveBeenCalledTimes(1);
     expect(firstMockArg(deliverDiscordReply, "deliverDiscordReply")).toMatchObject({
       replyToId: "m1",
       replies: [
         {
+          text: "Spoken answer",
           mediaUrl: "https://example.com/tts.mp3",
           audioAsVoice: true,
           spokenText: "Spoken answer",
@@ -2525,9 +2514,8 @@ describe("processDiscordMessage draft streaming", () => {
     });
   });
 
-  it("falls back with visible text when TTS supplement preview finalization fails", async () => {
+  it("sends fresh visible text for TTS supplement finals", async () => {
     const draftStream = createMockDraftStreamForTest();
-    editMessageDiscord.mockRejectedValueOnce(new Error("edit failed"));
     dispatchInboundMessage.mockImplementationOnce(async (params?: DispatchInboundParams) => {
       await params?.dispatcher.sendFinalReply({
         mediaUrl: "https://example.com/tts.mp3",
@@ -2544,9 +2532,10 @@ describe("processDiscordMessage draft streaming", () => {
 
     await runProcessDiscordMessage(ctx);
 
-    expect(draftStream.flush).toHaveBeenCalledTimes(1);
+    expect(draftStream.flush).not.toHaveBeenCalled();
     expect(draftStream.discardPending).toHaveBeenCalled();
     expect(draftStream.clear).toHaveBeenCalled();
+    expect(editMessageDiscord).not.toHaveBeenCalled();
     expect(deliverDiscordReply).toHaveBeenCalledTimes(1);
     expect(firstMockArg(deliverDiscordReply, "deliverDiscordReply")).toMatchObject({
       replies: [
@@ -2636,10 +2625,11 @@ describe("processDiscordMessage draft streaming", () => {
 
     await runProcessDiscordMessage(ctx);
 
-    expectPreviewEditContent("delivery survived");
-    expect(draftStream.clear).not.toHaveBeenCalled();
-    expect(draftStream.messageId()).toBe("preview-1");
-    expect(deliverDiscordReply).not.toHaveBeenCalled();
+    expect(editMessageDiscord).not.toHaveBeenCalled();
+    expectFreshFinalText("delivery survived");
+    expect(draftStream.discardPending).toHaveBeenCalledTimes(1);
+    expect(draftStream.clear).toHaveBeenCalledTimes(1);
+    expect(deliverDiscordReply).toHaveBeenCalledTimes(1);
   });
 
   it("drops earlier tool warning finals when recovered replies arrive", async () => {
@@ -2657,10 +2647,11 @@ describe("processDiscordMessage draft streaming", () => {
 
     await runProcessDiscordMessage(ctx);
 
-    expectPreviewEditContent("delivery recovered");
-    expect(draftStream.clear).not.toHaveBeenCalled();
-    expect(draftStream.messageId()).toBe("preview-1");
-    expect(deliverDiscordReply).not.toHaveBeenCalled();
+    expect(editMessageDiscord).not.toHaveBeenCalled();
+    expectFreshFinalText("delivery recovered");
+    expect(draftStream.discardPending).toHaveBeenCalledTimes(1);
+    expect(draftStream.clear).toHaveBeenCalledTimes(1);
+    expect(deliverDiscordReply).toHaveBeenCalledTimes(1);
   });
 
   it("suppresses pure tool warning finals when no recovered reply is available", async () => {
@@ -2723,9 +2714,11 @@ describe("processDiscordMessage draft streaming", () => {
 
     await runProcessDiscordMessage(ctx);
 
-    expectPreviewEditContent("Done.");
-    expect(draftStream.clear).not.toHaveBeenCalled();
-    expect(deliverDiscordReply).not.toHaveBeenCalled();
+    expect(editMessageDiscord).not.toHaveBeenCalled();
+    expectFreshFinalText("Done.");
+    expect(draftStream.discardPending).toHaveBeenCalledTimes(1);
+    expect(draftStream.clear).toHaveBeenCalledTimes(1);
+    expect(deliverDiscordReply).toHaveBeenCalledTimes(1);
   });
 
   it("renders reasoning block payloads as a 🧠 blockquote", async () => {

--- a/extensions/discord/src/monitor/message-handler.process.ts
+++ b/extensions/discord/src/monitor/message-handler.process.ts
@@ -1,5 +1,5 @@
 // Discord plugin module implements message handler.process behavior.
-import { MessageFlags } from "discord-api-types/v10";
+import { AllowedMentionsTypes, MessageFlags } from "discord-api-types/v10";
 import { resolveAckReaction, resolveHumanDelayConfig } from "openclaw/plugin-sdk/agent-runtime";
 import {
   createStatusReactionController,
@@ -44,6 +44,7 @@ import { resolveDiscordMaxLinesPerMessage } from "../accounts.js";
 import { chunkDiscordTextWithMode } from "../chunk.js";
 import { createDiscordRestClient } from "../client.js";
 import { beginDiscordInboundEventDeliveryCorrelation } from "../inbound-event-delivery.js";
+import { discordTextHasBroadcastMention } from "../mentions.js";
 import { removeReactionDiscord } from "../send.js";
 import { editMessageDiscord } from "../send.messages.js";
 import { resolveDiscordTargetChannelId } from "../send.shared.js";
@@ -883,6 +884,8 @@ async function processDiscordMessageInner(
             id: draftStream.messageId,
           },
           buildFinalEdit: (): DiscordMessageEdit | undefined => {
+            // Final replies need MESSAGE_CREATE so Discord advances unread state.
+            // Editing the preview only emits MESSAGE_UPDATE and can stay unnoticed.
             return undefined;
           },
           editFinal: async (previewMessageId, edit) => {
@@ -917,6 +920,11 @@ async function processDiscordMessageInner(
             !deliverablePayload.text?.trim()
               ? { ...deliverablePayload, text: ttsSupplement.spokenText }
               : deliverablePayload;
+          // Fresh bot messages parse broadcasts by default. Preserve intended
+          // user/role pings without escalating @everyone or @here.
+          const allowedMentions = discordTextHasBroadcastMention(fallbackPayload.text ?? "")
+            ? { parse: [AllowedMentionsTypes.User, AllowedMentionsTypes.Role] }
+            : undefined;
           const replyToId = replyReference.use();
           notifyFinalReplyStart();
           await deliverDiscordReply({
@@ -936,6 +944,7 @@ async function processDiscordMessageInner(
             sessionKey: ctxPayload.SessionKey,
             threadBindings,
             mediaLocalRoots,
+            allowedMentions,
             kind: info.kind,
           });
           return true;

--- a/extensions/discord/src/monitor/message-handler.process.ts
+++ b/extensions/discord/src/monitor/message-handler.process.ts
@@ -1,5 +1,6 @@
 // Discord plugin module implements message handler.process behavior.
-import { AllowedMentionsTypes, MessageFlags } from "discord-api-types/v10";
+import { MessageFlags } from "discord-api-types/v10";
+import type { APIAllowedMentions } from "discord-api-types/v10";
 import { resolveAckReaction, resolveHumanDelayConfig } from "openclaw/plugin-sdk/agent-runtime";
 import {
   createStatusReactionController,
@@ -68,6 +69,9 @@ import {
 } from "./timeouts.js";
 
 const loadReplyRuntime = createLazyRuntimeModule(() => import("openclaw/plugin-sdk/reply-runtime"));
+const TARGETED_ONLY_ALLOWED_MENTIONS = {
+  parse: ["users", "roles"],
+} as APIAllowedMentions;
 
 function isProcessAborted(abortSignal?: AbortSignal): boolean {
   return Boolean(abortSignal?.aborted);
@@ -923,7 +927,7 @@ async function processDiscordMessageInner(
           // Fresh bot messages parse broadcasts by default. Preserve intended
           // user/role pings without escalating @everyone or @here.
           const allowedMentions = discordTextHasBroadcastMention(fallbackPayload.text ?? "")
-            ? { parse: [AllowedMentionsTypes.User, AllowedMentionsTypes.Role] }
+            ? TARGETED_ONLY_ALLOWED_MENTIONS
             : undefined;
           const replyToId = replyReference.use();
           notifyFinalReplyStart();

--- a/extensions/discord/src/monitor/message-handler.process.ts
+++ b/extensions/discord/src/monitor/message-handler.process.ts
@@ -32,7 +32,6 @@ import { getAgentScopedMediaLocalRoots } from "openclaw/plugin-sdk/media-runtime
 import { resolveChunkMode } from "openclaw/plugin-sdk/reply-chunking";
 import { createChannelHistoryWindow } from "openclaw/plugin-sdk/reply-history";
 import {
-  buildTtsSupplementMediaPayload,
   getReplyPayloadTtsSupplement,
   isReplyPayloadNonTerminalToolErrorWarning,
   resolveSendableOutboundReplyParts,
@@ -41,18 +40,14 @@ import type { ReplyDispatchKind, ReplyPayload } from "openclaw/plugin-sdk/reply-
 import { danger, logVerbose, shouldLogVerbose, sleep } from "openclaw/plugin-sdk/runtime-env";
 import { getSessionEntry, resolveStorePath } from "openclaw/plugin-sdk/session-store-runtime";
 import { readLatestAssistantTextByIdentity } from "openclaw/plugin-sdk/session-transcript-runtime";
-import { resolveDiscordAccount, resolveDiscordMaxLinesPerMessage } from "../accounts.js";
+import { resolveDiscordMaxLinesPerMessage } from "../accounts.js";
 import { chunkDiscordTextWithMode } from "../chunk.js";
 import { createDiscordRestClient } from "../client.js";
 import { beginDiscordInboundEventDeliveryCorrelation } from "../inbound-event-delivery.js";
-import {
-  discordTextHasBroadcastMention,
-  discordTextHasTargetedMention,
-  rewriteDiscordKnownMentions,
-} from "../mentions.js";
 import { removeReactionDiscord } from "../send.js";
 import { editMessageDiscord } from "../send.messages.js";
 import { resolveDiscordTargetChannelId } from "../send.shared.js";
+import type { DiscordMessageEdit } from "../send.types.js";
 import { resolveDiscordChannelId } from "../targets.js";
 import {
   createDiscordAckReactionAdapter,
@@ -874,16 +869,7 @@ async function processDiscordMessageInner(
     const shouldFinalizeDraftPreview =
       draftStream && isFinal && !draftPreview.isProgressMode && !deliverablePayload.isError;
     if (shouldFinalizeDraftPreview) {
-      const reply = resolveSendableOutboundReplyParts(deliverablePayload);
-      const hasMedia = reply.hasMedia;
       const ttsSupplement = getReplyPayloadTtsSupplement(deliverablePayload);
-      const previewSourceText = deliverablePayload.text ?? ttsSupplement?.spokenText;
-      const previewFinalText = draftPreview.resolvePreviewFinalText(previewSourceText);
-      const previewReplyToId = replyReference.peek();
-      const hasExplicitReplyDirective =
-        Boolean(deliverablePayload.replyToTag || deliverablePayload.replyToCurrent) ||
-        (typeof previewSourceText === "string" &&
-          /\[\[\s*reply_to(?:_current|\s*:)/i.test(previewSourceText));
 
       const result = await deliverWithFinalizableLivePreviewAdapter({
         kind: info.kind,
@@ -896,31 +882,8 @@ async function processDiscordMessageInner(
             seal: () => draftStream.seal(),
             id: draftStream.messageId,
           },
-          buildFinalEdit: () => {
-            if (
-              draftPreview.finalizedViaPreviewMessage ||
-              (hasMedia && !ttsSupplement) ||
-              typeof previewFinalText !== "string" ||
-              hasExplicitReplyDirective ||
-              deliverablePayload.isError
-            ) {
-              return undefined;
-            }
-            // Discord pings only on create, not edits: send a targeted mention fresh, but keep mixed @everyone/@here in place so the create cannot escalate a broadcast.
-            const rewrittenFinal = rewriteDiscordKnownMentions(previewFinalText, {
-              accountId,
-              mentionAliases: resolveDiscordAccount({ cfg, accountId }).config.mentionAliases,
-            });
-            if (
-              discordTextHasTargetedMention(rewrittenFinal) &&
-              !discordTextHasBroadcastMention(rewrittenFinal)
-            ) {
-              return undefined;
-            }
-            return {
-              content: previewFinalText,
-              ...(finalPreviewFlags ? { flags: finalPreviewFlags } : {}),
-            };
+          buildFinalEdit: (): DiscordMessageEdit | undefined => {
+            return undefined;
           },
           editFinal: async (previewMessageId, edit) => {
             if (isProcessAborted(abortSignal)) {
@@ -937,41 +900,6 @@ async function processDiscordMessageInner(
             markUserFacingFinalDelivered();
             draftPreview.markPreviewFinalized();
             replyReference.markSent();
-          },
-          buildSupplementalPayload: () =>
-            ttsSupplement ? buildTtsSupplementMediaPayload(deliverablePayload) : undefined,
-          deliverSupplemental: async (supplementalPayload) => {
-            if (isProcessAborted(abortSignal)) {
-              return false;
-            }
-            const supplementalReplyToId =
-              previewReplyToId ??
-              replyReference.peek() ??
-              (replyToMode === "all"
-                ? typeof message.id === "string" && message.id
-                  ? message.id
-                  : ctxPayload.MessageSid
-                : undefined);
-            await deliverDiscordReply({
-              cfg,
-              replies: [supplementalPayload],
-              target: deliverTarget,
-              token,
-              accountId,
-              rest: deliveryRest,
-              runtime,
-              replyToId: supplementalReplyToId,
-              replyToMode,
-              textLimit,
-              maxLinesPerMessage,
-              tableMode,
-              chunkMode,
-              sessionKey: ctxPayload.SessionKey,
-              threadBindings,
-              mediaLocalRoots,
-              kind: info.kind,
-            });
-            return true;
           },
           logPreviewEditFailure: (err) => {
             logVerbose(

--- a/extensions/discord/src/monitor/reply-delivery.test.ts
+++ b/extensions/discord/src/monitor/reply-delivery.test.ts
@@ -120,6 +120,7 @@ describe("deliverDiscordReply", () => {
       textLimit: 2000,
       replyToId: "reply-1",
       replyToMode: "all",
+      allowedMentions: { parse: [] },
       kind: "final",
     });
 
@@ -139,6 +140,7 @@ describe("deliverDiscordReply", () => {
     expect(sendOptions.cfg).toBe(params.cfg);
     expect(sendOptions.token).toBe("token");
     expect(sendOptions.rest).toBe(rest);
+    expect(sendOptions.allowedMentions).toEqual({ parse: [] });
   });
 
   it("formats reasoning replies as visible Discord payloads before shared outbound", async () => {

--- a/extensions/discord/src/monitor/reply-delivery.ts
+++ b/extensions/discord/src/monitor/reply-delivery.ts
@@ -19,6 +19,7 @@ import type { RuntimeEnv } from "openclaw/plugin-sdk/runtime-env";
 import { normalizeOptionalString } from "openclaw/plugin-sdk/string-coerce-runtime";
 import type { RequestClient } from "../internal/discord.js";
 import { sendMessageDiscord, sendVoiceMessageDiscord } from "../send.js";
+import type { DiscordAllowedMentions } from "../send.shared.js";
 import { sanitizeDiscordFrontChannelReplyPayloads } from "./reply-safety.js";
 
 export type DiscordThreadBindingLookupRecord = {
@@ -88,14 +89,18 @@ function createDiscordDeliveryDeps(params: {
   cfg: OpenClawConfig;
   token: string;
   rest?: RequestClient;
+  allowedMentions?: DiscordAllowedMentions;
 }): OutboundSendDeps {
   return {
+    // Discord webhooks default to user-only parsing; bot messages need this
+    // explicit policy to prevent a fresh preview final from broadcasting.
     discord: (to: string, text: string, opts?: Parameters<typeof sendMessageDiscord>[2]) =>
       sendMessageDiscord(to, text, {
         ...opts,
         cfg: opts?.cfg ?? params.cfg,
         token: params.token,
         rest: params.rest,
+        ...(params.allowedMentions ? { allowedMentions: params.allowedMentions } : {}),
       }),
     discordVoice: (
       to: string,
@@ -186,6 +191,7 @@ export async function deliverDiscordReply(params: {
   sessionKey?: string;
   threadBindings?: DiscordThreadBindingLookup;
   mediaLocalRoots?: readonly string[];
+  allowedMentions?: DiscordAllowedMentions;
   kind: "tool" | "block" | "final";
 }) {
   void params.runtime;
@@ -213,6 +219,7 @@ export async function deliverDiscordReply(params: {
       cfg: params.cfg,
       token: params.token,
       rest: params.rest,
+      allowedMentions: params.allowedMentions,
     }),
     mediaAccess: delivery.mediaAccess,
     session: buildOutboundSessionContext({

--- a/extensions/discord/src/send.message-request.ts
+++ b/extensions/discord/src/send.message-request.ts
@@ -1,5 +1,5 @@
 // Discord plugin module implements send.message request behavior.
-import { MessageFlags, type APIEmbed } from "discord-api-types/v10";
+import { MessageFlags, type APIAllowedMentions, type APIEmbed } from "discord-api-types/v10";
 import {
   Embed,
   serializePayload,
@@ -14,6 +14,7 @@ export const SUPPRESS_NOTIFICATIONS_FLAG = MessageFlags.SuppressNotifications;
 export type DiscordSendComponentFactory = (text: string) => TopLevelComponents[];
 export type DiscordSendComponents = TopLevelComponents[] | DiscordSendComponentFactory;
 export type DiscordSendEmbeds = Array<APIEmbed | Embed>;
+export type DiscordAllowedMentions = APIAllowedMentions;
 
 export function resolveDiscordSendComponents(params: {
   components?: DiscordSendComponents;
@@ -49,6 +50,7 @@ export function buildDiscordMessagePayload(params: {
   text: string;
   components?: TopLevelComponents[];
   embeds?: Embed[];
+  allowedMentions?: DiscordAllowedMentions;
   flags?: number;
   files?: MessagePayloadFile[];
 }): MessagePayloadObject {
@@ -63,6 +65,9 @@ export function buildDiscordMessagePayload(params: {
   }
   if (!hasV2 && params.embeds?.length) {
     payload.embeds = params.embeds;
+  }
+  if (params.allowedMentions) {
+    payload.allowed_mentions = params.allowedMentions;
   }
   if (params.flags !== undefined) {
     payload.flags = params.flags;
@@ -91,6 +96,7 @@ export function buildDiscordMessageRequest(params: {
   text: string;
   components?: TopLevelComponents[];
   embeds?: Embed[];
+  allowedMentions?: DiscordAllowedMentions;
   files?: MessagePayloadFile[];
   flags?: number;
   replyTo?: string;

--- a/extensions/discord/src/send.outbound.ts
+++ b/extensions/discord/src/send.outbound.ts
@@ -33,6 +33,7 @@ import {
   resolveDiscordSendEmbeds,
   sendDiscordMedia,
   sendDiscordText,
+  type DiscordAllowedMentions,
   type DiscordSendProgress,
   type DiscordSendComponents,
   type DiscordSendEmbeds,
@@ -59,6 +60,7 @@ type DiscordSendOpts = {
   embeds?: DiscordSendEmbeds;
   silent?: boolean;
   suppressEmbeds?: boolean;
+  allowedMentions?: DiscordAllowedMentions;
   /** Persist each concrete platform send before any later chunk can fail. */
   onDeliveryResult?: (result: DiscordSendResult) => Promise<void> | void;
 };
@@ -79,6 +81,7 @@ async function sendDiscordThreadTextChunks(params: {
   maxChars?: number;
   silent?: boolean;
   suppressEmbeds?: boolean;
+  allowedMentions?: DiscordAllowedMentions;
   onResult?: DiscordSendProgress;
 }): Promise<void> {
   for (const chunk of params.chunks) {
@@ -91,6 +94,7 @@ async function sendDiscordThreadTextChunks(params: {
       chunkMode: params.chunkMode,
       silent: params.silent,
       suppressEmbeds: params.suppressEmbeds,
+      allowedMentions: params.allowedMentions,
       maxChars: params.maxChars,
       onResult: params.onResult,
     });
@@ -220,6 +224,7 @@ export async function sendMessageDiscord(
       components: starterComponents,
       embeds: starterEmbeds,
       flags: starterFlags,
+      allowedMentions: opts.allowedMentions,
     });
     let threadRes: { id: string; message?: { id: string; channel_id: string } };
     try {
@@ -283,6 +288,7 @@ export async function sendMessageDiscord(
           chunkMode,
           silent: opts.silent,
           suppressEmbeds,
+          allowedMentions: opts.allowedMentions,
           maxChars: textLimit,
           onResult: reportThreadResult,
         });
@@ -296,6 +302,7 @@ export async function sendMessageDiscord(
           maxChars: textLimit,
           silent: opts.silent,
           suppressEmbeds,
+          allowedMentions: opts.allowedMentions,
           onResult: reportThreadResult,
         });
       } else {
@@ -309,6 +316,7 @@ export async function sendMessageDiscord(
           maxChars: textLimit,
           silent: opts.silent,
           suppressEmbeds,
+          allowedMentions: opts.allowedMentions,
           onResult: reportThreadResult,
         });
       }
@@ -366,6 +374,7 @@ export async function sendMessageDiscord(
         chunkMode,
         silent: opts.silent,
         suppressEmbeds,
+        allowedMentions: opts.allowedMentions,
         maxChars: textLimit,
         onResult: reportResult,
       });
@@ -382,6 +391,7 @@ export async function sendMessageDiscord(
         chunkMode,
         silent: opts.silent,
         suppressEmbeds,
+        allowedMentions: opts.allowedMentions,
         maxChars: textLimit,
         onResult: reportResult,
       });

--- a/extensions/discord/src/send.sends-basic-channel-messages.test.ts
+++ b/extensions/discord/src/send.sends-basic-channel-messages.test.ts
@@ -316,6 +316,21 @@ describe("sendMessageDiscord", () => {
     );
   });
 
+  it("applies explicit allowed mentions to fresh messages", async () => {
+    const { rest, postMock, getMock } = makeDiscordRest();
+    getMock.mockResolvedValueOnce({ type: ChannelType.GuildText });
+    postMock.mockResolvedValue({ id: "msg1", channel_id: "789" });
+
+    await sendMessageDiscord("channel:789", "heads up @everyone <@123>", {
+      rest,
+      token: "t",
+      cfg: DISCORD_TEST_CFG,
+      allowedMentions: { parse: [] },
+    });
+
+    expect(requireRestBody(postMock).allowed_mentions).toEqual({ parse: [] });
+  });
+
   it("does not suppress explicit Discord embeds by default", async () => {
     const { rest, postMock, getMock } = makeDiscordRest();
     getMock.mockResolvedValueOnce({ type: ChannelType.GuildText });

--- a/extensions/discord/src/send.shared.ts
+++ b/extensions/discord/src/send.shared.ts
@@ -53,6 +53,7 @@ export {
   SUPPRESS_EMBEDS_FLAG,
   SUPPRESS_NOTIFICATIONS_FLAG,
   type DiscordSendComponentFactory,
+  type DiscordAllowedMentions,
   type DiscordSendComponents,
   type DiscordSendEmbeds,
 } from "./send.message-request.js";
@@ -61,6 +62,7 @@ import {
   resolveDiscordMessageFlags,
   resolveDiscordSendComponents,
   resolveDiscordSendEmbeds,
+  type DiscordAllowedMentions,
   type DiscordSendComponents,
   type DiscordSendEmbeds,
 } from "./send.message-request.js";
@@ -327,6 +329,7 @@ type DiscordTextSendParams = {
   maxLinesPerMessage?: number;
   components?: DiscordSendComponents;
   embeds?: DiscordSendEmbeds;
+  allowedMentions?: DiscordAllowedMentions;
   chunkMode?: ChunkMode;
   silent?: boolean;
   suppressEmbeds?: boolean;
@@ -344,6 +347,7 @@ async function sendDiscordText(params: DiscordTextSendParams) {
     maxLinesPerMessage,
     components,
     embeds,
+    allowedMentions,
     chunkMode,
     silent,
     suppressEmbeds,
@@ -370,6 +374,7 @@ async function sendDiscordText(params: DiscordTextSendParams) {
       text: chunk,
       components: chunkComponents,
       embeds: chunkEmbeds,
+      allowedMentions,
       flags,
       replyTo: chunkReplyTo,
     });
@@ -425,6 +430,7 @@ async function sendDiscordMedia(params: DiscordMediaSendParams) {
     maxLinesPerMessage,
     components,
     embeds,
+    allowedMentions,
     chunkMode,
     silent,
     suppressEmbeds,
@@ -460,6 +466,7 @@ async function sendDiscordMedia(params: DiscordMediaSendParams) {
     text: caption,
     components: captionComponents,
     embeds: captionEmbeds,
+    allowedMentions,
     flags,
     replyTo: resolveDiscordReplyMessageId(reply, true),
     files: [
@@ -491,6 +498,7 @@ async function sendDiscordMedia(params: DiscordMediaSendParams) {
       chunkMode,
       silent,
       suppressEmbeds,
+      allowedMentions,
       maxChars,
       onResult,
     });
@@ -512,6 +520,7 @@ async function sendDiscordMedia(params: DiscordMediaSendParams) {
       chunkMode,
       silent,
       suppressEmbeds,
+      allowedMentions,
       maxChars,
       onResult,
     });


### PR DESCRIPTION
## What Problem This Solves

Discord partial streaming finalized an answer by editing the existing preview message. If the user left the channel during a long turn, that `MESSAGE_UPDATE` did not reliably advance Discord's unread/channel highlight, so a completed answer could arrive unnoticed.

Fixes #99662.

## Why This Change Was Made

The durable final now uses the normal send path, producing a fresh message after preview cleanup. This matches Discord's separate [Create Message](https://docs.discord.com/developers/resources/message#create-message) and [Gateway message event](https://docs.discord.com/developers/events/gateway-events#message-create) contracts and removes the second in-place finalization path.

Fresh bot messages normally parse broadcast mentions, unlike the old edit path. The maintained version therefore carries an explicit `allowed_mentions` policy through text, media, chunked, and forum delivery: targeted user and role pings remain enabled, while `@everyone` and `@here` cannot escalate.

## User Impact

- Completed streamed Discord answers arrive as a new message and can restore the normal unread/channel cue.
- The preview is cleared only after the fresh final succeeds; a failed send retains the visible preview.
- Targeted user/role mentions continue to work without enabling broadcast pings.
- Media, TTS, error, chunking, reply, forum, and progress-summary routes keep their existing delivery behavior.

## Evidence

- Exact prepared head: `0041b7ffa47e128242fc2f3bc2a55b4eb30985b1`.
- Hosted exact-head CI: [run 28811114011](https://github.com/openclaw/openclaw/actions/runs/28811114011), including production/test typechecks, lint, build, guards, QA smoke, and relevant compact shards.
- Blacksmith Testbox `tbx_01kww6wp8mafqazb1d425qyf36`: 183 focused Discord tests passed; `pnpm check:changed` passed extension production/test typechecks, full extension lint, and repository guards.
- Sanitized AWS Crabbox `run_ade515667559`: the exact pushed fork head passed the same 183 focused tests with public networking, no Tailscale, no instance role, and no hydrated credentials.
- Live Discord sandbox on the exact pushed head: preview and final had distinct increasing message IDs; both messages were readable; literal `@everyone` produced `mention_everyone=false`; both test messages deleted successfully with HTTP 204.
- Fresh autoreview after the runtime-enum repair: no accepted/actionable findings, confidence 0.96.

## Implementation Notes

- Declares Discord in-place `finalEdit` support disabled while retaining normal fallback and preview cleanup.
- Deletes the duplicate final-edit/chunking branches and delegates lifecycle ordering to the shared finalizable-preview helper.
- Adds focused regression coverage for fresh finals, mention safety, TTS/media/error fallback, and failed-send preview retention.
