### PR TITLE
perf(usage): shrink durable usage cache entries

### DIFF
--- a/src/infra/session-cost-usage.test.ts
+++ b/src/infra/session-cost-usage.test.ts
@@ -529,7 +529,7 @@ describe("session cost usage", () => {
       await refreshCostUsageCache({ sessionFiles: [sessionFile] });
       const cachePath = path.join(sessionsDir, ".usage-cost-cache.json");
       const cache = JSON.parse(await fs.readFile(cachePath, "utf-8")) as { version: number };
-      cache.version = 4;
+      cache.version = 5;
       await fs.writeFile(cachePath, `${JSON.stringify(cache)}\n`, "utf-8");
 
       // The pre-upgrade cache must be treated as stale (not served), forcing a rebuild
@@ -1102,6 +1102,15 @@ describe("session cost usage", () => {
 
     await withStateDir(root, async () => {
       await refreshCostUsageCache({ config: configFor(1, 1) });
+      const cachePath = path.join(sessionsDir, ".usage-cost-cache.json");
+      const cache = JSON.parse(await fs.readFile(cachePath, "utf-8")) as {
+        pricingFingerprint?: unknown;
+        files: Record<string, Record<string, unknown>>;
+      };
+      expect(typeof cache.pricingFingerprint).toBe("string");
+      expect(cache.files[sessionFile]).not.toHaveProperty("pricingFingerprint");
+      expect(cache.files[sessionFile]).not.toHaveProperty("filePath");
+      expect(cache.files[sessionFile]).not.toHaveProperty("sessionId");
 
       const stale = await loadCostUsageSummaryFromCache({
         startMs: Date.UTC(2026, 1, 5),

--- a/src/infra/session-cost-usage.ts
+++ b/src/infra/session-cost-usage.ts
@@ -74,11 +74,9 @@ export type {
   UsageCacheStatus,
 } from "./session-cost-usage.types.js";
 
-// Bump when the *meaning* of cached totals changes (not just their inputs), so durable
-// caches written by older builds are rebuilt instead of served stale. Bumped to 5:
-// recorded zero costs for known-priced token usage are recomputed, and unpriced
-// zero-cost usage counts toward missingCostEntries.
-const USAGE_COST_CACHE_VERSION = 5;
+// Bump when the durable cache schema or the meaning of cached totals changes, so
+// older builds are rebuilt instead of served stale.
+const USAGE_COST_CACHE_VERSION = 6;
 const USAGE_COST_CACHE_FILE = ".usage-cost-cache.json";
 const USAGE_COST_CACHE_LOCK_WRITE_GRACE_MS = 10_000;
 const USAGE_COST_CACHE_TEMP_FILE_GRACE_MS = USAGE_COST_CACHE_LOCK_WRITE_GRACE_MS;
@@ -124,23 +122,21 @@ type UsageCostCachedTranscriptEntry = {
 };
 
 type UsageCostCacheFileEntry = {
-  filePath: string;
   size: number;
   mtimeMs: number;
-  pricingFingerprint: string;
   scannedAt: number;
   parsedRecords: number;
   countedRecords: number;
   usageEntries: UsageCostCachedUsageEntry[];
   transcriptEntries?: UsageCostCachedTranscriptEntry[];
   totals: CostUsageTotals;
-  sessionId?: string;
   sessionSummary?: SessionCostSummary;
 };
 
 type UsageCostCacheFile = {
   version: number;
   updatedAt: number;
+  pricingFingerprint: string;
   files: Record<string, UsageCostCacheFileEntry>;
 };
 
@@ -306,19 +302,21 @@ async function acquireUsageCostCacheRefreshLock(cachePath: string): Promise<{
 
 function normalizeUsageCostCache(raw: unknown): UsageCostCacheFile {
   if (!raw || typeof raw !== "object") {
-    return { version: USAGE_COST_CACHE_VERSION, updatedAt: 0, files: {} };
+    return { version: USAGE_COST_CACHE_VERSION, updatedAt: 0, pricingFingerprint: "", files: {} };
   }
   const record = raw as Record<string, unknown>;
   if (
     record.version !== USAGE_COST_CACHE_VERSION ||
+    typeof record.pricingFingerprint !== "string" ||
     !record.files ||
     typeof record.files !== "object"
   ) {
-    return { version: USAGE_COST_CACHE_VERSION, updatedAt: 0, files: {} };
+    return { version: USAGE_COST_CACHE_VERSION, updatedAt: 0, pricingFingerprint: "", files: {} };
   }
   return {
     version: USAGE_COST_CACHE_VERSION,
     updatedAt: asFiniteNumber(record.updatedAt) ?? 0,
+    pricingFingerprint: record.pricingFingerprint,
     files: record.files as Record<string, UsageCostCacheFileEntry>,
   };
 }
@@ -328,7 +326,7 @@ async function readUsageCostCache(cachePath: string): Promise<UsageCostCacheFile
     const raw = await fs.promises.readFile(cachePath, "utf-8");
     return normalizeUsageCostCache(JSON.parse(raw));
   } catch {
-    return { version: USAGE_COST_CACHE_VERSION, updatedAt: 0, files: {} };
+    return { version: USAGE_COST_CACHE_VERSION, updatedAt: 0, pricingFingerprint: "", files: {} };
   }
 }
 
@@ -402,14 +400,12 @@ async function listUsageCountedTranscriptFiles(
 function isUsageCostCacheEntryFresh(params: {
   entry: UsageCostCacheFileEntry | undefined;
   file: UsageCostTranscriptFile;
-  pricingFingerprint: string;
   requireSessionSummary?: boolean;
 }): boolean {
   return Boolean(
     params.entry &&
     params.entry.size === params.file.size &&
     params.entry.mtimeMs === params.file.mtimeMs &&
-    params.entry.pricingFingerprint === params.pricingFingerprint &&
     (!params.requireSessionSummary || params.entry.sessionSummary),
   );
 }
@@ -417,17 +413,14 @@ function isUsageCostCacheEntryFresh(params: {
 function canUseUsageCostCacheEntryForPartial(params: {
   entry: UsageCostCacheFileEntry | undefined;
   file: UsageCostTranscriptFile;
-  pricingFingerprint: string;
 }): params is {
   entry: UsageCostCacheFileEntry;
   file: UsageCostTranscriptFile;
-  pricingFingerprint: string;
 } {
   return Boolean(
     params.entry &&
     params.entry.size <= params.file.size &&
-    params.entry.mtimeMs <= params.file.mtimeMs &&
-    params.entry.pricingFingerprint === params.pricingFingerprint,
+    params.entry.mtimeMs <= params.file.mtimeMs,
   );
 }
 
@@ -437,13 +430,15 @@ function getUsageCostStaleFiles(params: {
   pricingFingerprint: string;
   sessionSummaryFiles?: Set<string>;
 }): UsageCostTranscriptFile[] {
+  if (params.cache.pricingFingerprint !== params.pricingFingerprint) {
+    return params.files;
+  }
   const sessionSummaryFiles = params.sessionSummaryFiles ?? new Set<string>();
   return params.files.filter(
     (file) =>
       !isUsageCostCacheEntryFresh({
         entry: params.cache.files[file.filePath],
         file,
-        pricingFingerprint: params.pricingFingerprint,
         requireSessionSummary: sessionSummaryFiles.has(file.filePath),
       }),
   );
@@ -454,6 +449,9 @@ function countUsableUsageCostCacheFiles(params: {
   files: UsageCostTranscriptFile[];
   pricingFingerprint: string;
 }): number {
+  if (params.cache.pricingFingerprint !== params.pricingFingerprint) {
+    return 0;
+  }
   const filesByPath = new Map(params.files.map((file) => [file.filePath, file]));
   let cachedFiles = 0;
   for (const [filePath, entry] of Object.entries(params.cache.files)) {
@@ -463,7 +461,6 @@ function countUsableUsageCostCacheFiles(params: {
       canUseUsageCostCacheEntryForPartial({
         entry,
         file,
-        pricingFingerprint: params.pricingFingerprint,
       })
     ) {
       cachedFiles += 1;
@@ -494,27 +491,28 @@ function buildCostUsageSummaryFromCache(params: {
     pricingFingerprint: params.pricingFingerprint,
   });
 
-  for (const [filePath, entry] of Object.entries(params.cache.files)) {
-    const file = filesByPath.get(filePath);
-    if (
-      !file ||
-      !canUseUsageCostCacheEntryForPartial({
-        entry,
-        file,
-        pricingFingerprint: params.pricingFingerprint,
-      })
-    ) {
-      continue;
-    }
-    for (const usageEntry of entry.usageEntries) {
-      if (usageEntry.timestamp < params.startMs || usageEntry.timestamp > params.endMs) {
+  if (params.cache.pricingFingerprint === params.pricingFingerprint) {
+    for (const [filePath, entry] of Object.entries(params.cache.files)) {
+      const file = filesByPath.get(filePath);
+      if (
+        !file ||
+        !canUseUsageCostCacheEntryForPartial({
+          entry,
+          file,
+        })
+      ) {
         continue;
       }
-      const date = formatDayKey(new Date(usageEntry.timestamp));
-      const bucket = dailyMap.get(date) ?? emptyTotals();
-      addTotals(bucket, usageEntry);
-      dailyMap.set(date, bucket);
-      addTotals(totals, usageEntry);
+      for (const usageEntry of entry.usageEntries) {
+        if (usageEntry.timestamp < params.startMs || usageEntry.timestamp > params.endMs) {
+          continue;
+        }
+        const date = formatDayKey(new Date(usageEntry.timestamp));
+        const bucket = dailyMap.get(date) ?? emptyTotals();
+        addTotals(bucket, usageEntry);
+        dailyMap.set(date, bucket);
+        addTotals(totals, usageEntry);
+      }
     }
   }
 
@@ -1496,13 +1494,10 @@ async function scanUsageFileForCache(params: {
   previous?: UsageCostCacheFileEntry;
   includeSessionSummary?: boolean;
 }): Promise<UsageCostCacheFileEntry> {
-  const pricingFingerprint = resolveUsageCostPricingFingerprint(params.config);
   const appendOnlyPreviousCandidate =
     params.previous &&
-    params.previous.filePath === params.file.filePath &&
     params.previous.size > 0 &&
     params.previous.size < params.file.size &&
-    params.previous.pricingFingerprint === pricingFingerprint &&
     params.previous.mtimeMs <= params.file.mtimeMs
       ? params.previous
       : undefined;
@@ -1584,17 +1579,14 @@ async function scanUsageFileForCache(params: {
     (params.includeSessionSummary || appendOnlyPrevious?.sessionSummary)
       ? (buildSessionCostSummaryFromCacheEntry({
           entry: {
-            filePath: params.file.filePath,
             size: params.file.size,
             mtimeMs: params.file.mtimeMs,
-            pricingFingerprint,
             scannedAt: Date.now(),
             parsedRecords,
             countedRecords,
             usageEntries,
             transcriptEntries: combinedTranscriptEntries,
             totals,
-            sessionId,
           },
           sessionId,
           sessionFile: params.file.filePath,
@@ -1610,7 +1602,6 @@ async function scanUsageFileForCache(params: {
       ...appendOnlyPrevious,
       size: params.file.size,
       mtimeMs: params.file.mtimeMs,
-      pricingFingerprint,
       scannedAt: Date.now(),
       parsedRecords: appendOnlyPrevious.parsedRecords + parsedRecords,
       countedRecords: appendOnlyPrevious.countedRecords + countedRecords,
@@ -1622,17 +1613,14 @@ async function scanUsageFileForCache(params: {
   }
 
   return {
-    filePath: params.file.filePath,
     size: params.file.size,
     mtimeMs: params.file.mtimeMs,
-    pricingFingerprint,
     scannedAt: Date.now(),
     parsedRecords,
     countedRecords,
     usageEntries,
     transcriptEntries: combinedTranscriptEntries,
     totals,
-    sessionId,
     sessionSummary,
   };
 }
@@ -1658,6 +1646,12 @@ async function refreshCostUsageCacheForPath(params?: {
     const files = await listUsageCountedTranscriptFiles(params?.agentId, {
       sessionsDir: params?.sessionsDir,
     });
+    let cacheMutated = false;
+    if (cache.pricingFingerprint !== pricingFingerprint) {
+      cache.files = {};
+      cache.pricingFingerprint = pricingFingerprint;
+      cacheMutated = true;
+    }
     const sessionSummaryFiles = new Set(params?.sessionFiles ?? []);
     const refreshStartMs = params?.startMs;
     const refreshFiles =
@@ -1667,7 +1661,6 @@ async function refreshCostUsageCacheForPath(params?: {
           ? files
           : files.filter((file) => file.mtimeMs >= refreshStartMs);
     const livePaths = new Set(files.map((file) => file.filePath));
-    let cacheMutated = false;
     for (const filePath of Object.keys(cache.files)) {
       if (!livePaths.has(filePath)) {
         delete cache.files[filePath];
@@ -1825,11 +1818,11 @@ export async function loadSessionCostSummaryFromCache(params: {
     : undefined;
   let entry = cache.files[params.sessionFile];
   let stale =
+    cache.pricingFingerprint !== pricingFingerprint ||
     !file ||
     !isUsageCostCacheEntryFresh({
       entry,
       file,
-      pricingFingerprint,
       requireSessionSummary: true,
     });
   let refreshRequested = false;
@@ -1850,11 +1843,11 @@ export async function loadSessionCostSummaryFromCache(params: {
           : undefined;
         entry = cache.files[params.sessionFile];
         stale =
+          cache.pricingFingerprint !== pricingFingerprint ||
           !file ||
           !isUsageCostCacheEntryFresh({
             entry,
             file,
-            pricingFingerprint,
             requireSessionSummary: true,
           });
       } else {
@@ -1963,11 +1956,11 @@ export async function loadSessionCostSummariesFromCache(params: {
       : undefined;
     const entry = cache.files[session.sessionFile];
     const stale =
+      cache.pricingFingerprint !== pricingFingerprint ||
       !file ||
       !isUsageCostCacheEntryFresh({
         entry,
         file,
-        pricingFingerprint,
         requireSessionSummary: true,
       });
     if (stale) {

--- a/src/infra/session-cost-usage.ts
+++ b/src/infra/session-cost-usage.ts
@@ -300,18 +300,23 @@ async function acquireUsageCostCacheRefreshLock(cachePath: string): Promise<{
   }
 }
 
-function normalizeUsageCostCache(raw: unknown): UsageCostCacheFile {
+function createEmptyUsageCostCache(pricingFingerprint: string): UsageCostCacheFile {
+  return { version: USAGE_COST_CACHE_VERSION, updatedAt: 0, pricingFingerprint, files: {} };
+}
+
+function normalizeUsageCostCache(raw: unknown, pricingFingerprint: string): UsageCostCacheFile {
   if (!raw || typeof raw !== "object") {
-    return { version: USAGE_COST_CACHE_VERSION, updatedAt: 0, pricingFingerprint: "", files: {} };
+    return createEmptyUsageCostCache(pricingFingerprint);
   }
   const record = raw as Record<string, unknown>;
   if (
     record.version !== USAGE_COST_CACHE_VERSION ||
     typeof record.pricingFingerprint !== "string" ||
+    record.pricingFingerprint !== pricingFingerprint ||
     !record.files ||
     typeof record.files !== "object"
   ) {
-    return { version: USAGE_COST_CACHE_VERSION, updatedAt: 0, pricingFingerprint: "", files: {} };
+    return createEmptyUsageCostCache(pricingFingerprint);
   }
   return {
     version: USAGE_COST_CACHE_VERSION,
@@ -321,12 +326,15 @@ function normalizeUsageCostCache(raw: unknown): UsageCostCacheFile {
   };
 }
 
-async function readUsageCostCache(cachePath: string): Promise<UsageCostCacheFile> {
+async function readUsageCostCache(
+  cachePath: string,
+  pricingFingerprint: string,
+): Promise<UsageCostCacheFile> {
   try {
     const raw = await fs.promises.readFile(cachePath, "utf-8");
-    return normalizeUsageCostCache(JSON.parse(raw));
+    return normalizeUsageCostCache(JSON.parse(raw), pricingFingerprint);
   } catch {
-    return { version: USAGE_COST_CACHE_VERSION, updatedAt: 0, pricingFingerprint: "", files: {} };
+    return createEmptyUsageCostCache(pricingFingerprint);
   }
 }
 
@@ -427,12 +435,8 @@ function canUseUsageCostCacheEntryForPartial(params: {
 function getUsageCostStaleFiles(params: {
   cache: UsageCostCacheFile;
   files: UsageCostTranscriptFile[];
-  pricingFingerprint: string;
   sessionSummaryFiles?: Set<string>;
 }): UsageCostTranscriptFile[] {
-  if (params.cache.pricingFingerprint !== params.pricingFingerprint) {
-    return params.files;
-  }
   const sessionSummaryFiles = params.sessionSummaryFiles ?? new Set<string>();
   return params.files.filter(
     (file) =>
@@ -447,11 +451,7 @@ function getUsageCostStaleFiles(params: {
 function countUsableUsageCostCacheFiles(params: {
   cache: UsageCostCacheFile;
   files: UsageCostTranscriptFile[];
-  pricingFingerprint: string;
 }): number {
-  if (params.cache.pricingFingerprint !== params.pricingFingerprint) {
-    return 0;
-  }
   const filesByPath = new Map(params.files.map((file) => [file.filePath, file]));
   let cachedFiles = 0;
   for (const [filePath, entry] of Object.entries(params.cache.files)) {
@@ -474,7 +474,6 @@ function buildCostUsageSummaryFromCache(params: {
   files: UsageCostTranscriptFile[];
   startMs: number;
   endMs: number;
-  pricingFingerprint: string;
   refreshing: boolean;
 }): CostUsageSummary {
   const dailyMap = new Map<string, CostUsageTotals>();
@@ -483,36 +482,32 @@ function buildCostUsageSummaryFromCache(params: {
   const staleFiles = getUsageCostStaleFiles({
     cache: params.cache,
     files: params.files,
-    pricingFingerprint: params.pricingFingerprint,
   });
   const cachedFiles = countUsableUsageCostCacheFiles({
     cache: params.cache,
     files: params.files,
-    pricingFingerprint: params.pricingFingerprint,
   });
 
-  if (params.cache.pricingFingerprint === params.pricingFingerprint) {
-    for (const [filePath, entry] of Object.entries(params.cache.files)) {
-      const file = filesByPath.get(filePath);
-      if (
-        !file ||
-        !canUseUsageCostCacheEntryForPartial({
-          entry,
-          file,
-        })
-      ) {
+  for (const [filePath, entry] of Object.entries(params.cache.files)) {
+    const file = filesByPath.get(filePath);
+    if (
+      !file ||
+      !canUseUsageCostCacheEntryForPartial({
+        entry,
+        file,
+      })
+    ) {
+      continue;
+    }
+    for (const usageEntry of entry.usageEntries) {
+      if (usageEntry.timestamp < params.startMs || usageEntry.timestamp > params.endMs) {
         continue;
       }
-      for (const usageEntry of entry.usageEntries) {
-        if (usageEntry.timestamp < params.startMs || usageEntry.timestamp > params.endMs) {
-          continue;
-        }
-        const date = formatDayKey(new Date(usageEntry.timestamp));
-        const bucket = dailyMap.get(date) ?? emptyTotals();
-        addTotals(bucket, usageEntry);
-        dailyMap.set(date, bucket);
-        addTotals(totals, usageEntry);
-      }
+      const date = formatDayKey(new Date(usageEntry.timestamp));
+      const bucket = dailyMap.get(date) ?? emptyTotals();
+      addTotals(bucket, usageEntry);
+      dailyMap.set(date, bucket);
+      addTotals(totals, usageEntry);
     }
   }
 
@@ -1642,16 +1637,13 @@ async function refreshCostUsageCacheForPath(params?: {
   try {
     await cleanupStaleUsageCostCacheTempFiles(cachePath);
     const pricingFingerprint = resolveUsageCostPricingFingerprint(params?.config);
-    const cache = await readUsageCostCache(cachePath);
+    const cache = await readUsageCostCache(cachePath, pricingFingerprint);
     const files = await listUsageCountedTranscriptFiles(params?.agentId, {
       sessionsDir: params?.sessionsDir,
     });
-    let cacheMutated = false;
-    if (cache.pricingFingerprint !== pricingFingerprint) {
-      cache.files = {};
-      cache.pricingFingerprint = pricingFingerprint;
-      cacheMutated = true;
-    }
+    // Empty caches come from missing/corrupt files and version/pricing mismatches.
+    // Persist the empty current-shape cache even when this refresh scans no files.
+    let cacheMutated = cache.updatedAt === 0;
     const sessionSummaryFiles = new Set(params?.sessionFiles ?? []);
     const refreshStartMs = params?.startMs;
     const refreshFiles =
@@ -1675,7 +1667,6 @@ async function refreshCostUsageCacheForPath(params?: {
     const staleFiles = getUsageCostStaleFiles({
       cache,
       files: refreshFiles,
-      pricingFingerprint,
       sessionSummaryFiles,
     })
       .toSorted((a, b) => {
@@ -1747,19 +1738,17 @@ export async function loadCostUsageSummaryFromCache(params: {
   const cachePath = resolveUsageCostCachePath(params.agentId);
   const pricingFingerprint = resolveUsageCostPricingFingerprint(params.config);
   let [cache, files] = await Promise.all([
-    readUsageCostCache(cachePath),
+    readUsageCostCache(cachePath, pricingFingerprint),
     listUsageCountedTranscriptFiles(params.agentId),
   ]);
   const staleFiles = getUsageCostStaleFiles({
     cache,
     files,
-    pricingFingerprint,
   });
   if (params.requestRefresh !== false && staleFiles.length > 0) {
     const cachedFiles = countUsableUsageCostCacheFiles({
       cache,
       files,
-      pricingFingerprint,
     });
     if (params.refreshMode === "sync-when-empty" && cachedFiles === 0) {
       const result = await refreshCostUsageCache({
@@ -1768,14 +1757,13 @@ export async function loadCostUsageSummaryFromCache(params: {
         startMs: params.startMs,
       });
       [cache, files] = await Promise.all([
-        readUsageCostCache(cachePath),
+        readUsageCostCache(cachePath, pricingFingerprint),
         listUsageCountedTranscriptFiles(params.agentId),
       ]);
       if (result === "refreshed") {
         const remainingStaleFiles = getUsageCostStaleFiles({
           cache,
           files,
-          pricingFingerprint,
         });
         if (remainingStaleFiles.length > 0) {
           requestCostUsageCacheRefresh({ config: params.config, agentId: params.agentId });
@@ -1791,7 +1779,6 @@ export async function loadCostUsageSummaryFromCache(params: {
     files,
     startMs: params.startMs,
     endMs: params.endMs,
-    pricingFingerprint,
     refreshing: usageCostRefreshes.has(cachePath) || refreshRunning,
   });
 }
@@ -1810,7 +1797,7 @@ export async function loadSessionCostSummaryFromCache(params: {
   const cachePath = resolveUsageCostCachePath(params.agentId);
   const pricingFingerprint = resolveUsageCostPricingFingerprint(params.config);
   let [cache, stats] = await Promise.all([
-    readUsageCostCache(cachePath),
+    readUsageCostCache(cachePath, pricingFingerprint),
     fs.promises.stat(params.sessionFile).catch(() => null),
   ]);
   let file = stats
@@ -1818,7 +1805,6 @@ export async function loadSessionCostSummaryFromCache(params: {
     : undefined;
   let entry = cache.files[params.sessionFile];
   let stale =
-    cache.pricingFingerprint !== pricingFingerprint ||
     !file ||
     !isUsageCostCacheEntryFresh({
       entry,
@@ -1835,7 +1821,7 @@ export async function loadSessionCostSummaryFromCache(params: {
       });
       if (result === "refreshed") {
         [cache, stats] = await Promise.all([
-          readUsageCostCache(cachePath),
+          readUsageCostCache(cachePath, pricingFingerprint),
           fs.promises.stat(params.sessionFile).catch(() => null),
         ]);
         file = stats
@@ -1843,7 +1829,6 @@ export async function loadSessionCostSummaryFromCache(params: {
           : undefined;
         entry = cache.files[params.sessionFile];
         stale =
-          cache.pricingFingerprint !== pricingFingerprint ||
           !file ||
           !isUsageCostCacheEntryFresh({
             entry,
@@ -1943,7 +1928,7 @@ export async function loadSessionCostSummariesFromCache(params: {
     limit: USAGE_COST_TRANSCRIPT_STAT_CONCURRENCY,
   }).then(({ results }) => results);
   const [cache, stats, refreshRunning] = await Promise.all([
-    readUsageCostCache(cachePath),
+    readUsageCostCache(cachePath, pricingFingerprint),
     statsPromise,
     isUsageCostCacheRefreshRunning(cachePath),
   ]);
@@ -1956,7 +1941,6 @@ export async function loadSessionCostSummariesFromCache(params: {
       : undefined;
     const entry = cache.files[session.sessionFile];
     const stale =
-      cache.pricingFingerprint !== pricingFingerprint ||
       !file ||
       !isUsageCostCacheEntryFresh({
         entry,


### PR DESCRIPTION
## What Problem This Solves

`.usage-cost-cache.json` currently repeats the same `pricingFingerprint` on every file entry. Each entry also persists `filePath` and `sessionId` even though the file path is already the map key and readers pass or derive session ids separately. On large session histories, that creates avoidable durable cache bloat.

Fixes #99511.

## What changed

This shrinks the durable usage-cost cache format:

- stores `pricingFingerprint` once at the cache root instead of on every file entry
- stops persisting per-entry `filePath`, since the map key is already the file path
- stops persisting per-entry `sessionId`, since readers pass or derive session ids separately
- bumps `USAGE_COST_CACHE_VERSION` from 5 to 6 so existing v5 caches rebuild cleanly
- keeps pricing-change invalidation by comparing the cache-level fingerprint before using entries

This overlaps with #99528, #99529, #99533, and #99543. Those branches move `pricingFingerprint` to the cache root; this branch also removes the redundant per-entry `filePath` and `sessionId` fields.

## Evidence

Weco dashboard: https://dashboard.weco.ai/share/ankGL2KavnU4j1hab4767Zm8CgJcQn9B

Measured with the usage-cost-cache eval harness on synthetic session JSONL files. The harness exercises the real `refreshCostUsageCache()` path and measures the generated `.usage-cost-cache.json` size.

| Branch | 250 sessions x 4 records | Reduction | 1000 sessions x 4 records | Reduction |
| --- | ---: | ---: | ---: | ---: |
| current main | 368,800 bytes | baseline | 1,475,050 bytes | baseline |
| #99528 | 331,449 bytes | 10.13% | 1,326,199 bytes | 10.09% |
| #99529 | 331,449 bytes | 10.13% | 1,325,230 bytes | 10.16% |
| #99533 | 331,699 bytes | 10.06% | 1,326,111 bytes | 10.10% |
| #99543 | 331,699 bytes | 10.06% | 1,326,199 bytes | 10.09% |
| this PR | 304,449 bytes | 17.45% | 1,217,199 bytes | 17.48% |

The eval also verified the cache shape changed as intended: entries no longer have `pricingFingerprint`; the cache root does.

## Validation

Passed against this PR branch (`024deb755c`):

```bash
git diff --check

node scripts/run-vitest.mjs run --config test/vitest/vitest.infra.config.ts src/infra/session-cost-usage.test.ts
# 61 tests passed

node_modules/.bin/oxfmt --check --threads=1 src/infra/session-cost-usage.ts src/infra/session-cost-usage.test.ts
node_modules/.bin/oxlint src/infra/session-cost-usage.ts src/infra/session-cost-usage.test.ts
node scripts/run-tsgo.mjs -p test/tsconfig/tsconfig.core.test.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/core-test.tsbuildinfo
```
