### PR TITLE
refactor: consolidate image data URL formatting

### DIFF
--- a/extensions/byteplus/video-generation-provider.ts
+++ b/extensions/byteplus/video-generation-provider.ts
@@ -1,6 +1,7 @@
 /**
  * BytePlus Seedance video generation provider implementation.
  */
+import { toImageDataUrl } from "openclaw/plugin-sdk/image-generation";
 import { extensionForMime } from "openclaw/plugin-sdk/media-mime";
 import { isProviderApiKeyConfigured } from "openclaw/plugin-sdk/provider-auth";
 import { resolveApiKeyForProvider } from "openclaw/plugin-sdk/provider-auth-runtime";
@@ -115,10 +116,6 @@ function resolveGeneratedVideoMaxBytes(req: VideoGenerationRequest): number {
   return DEFAULT_GENERATED_VIDEO_MAX_BYTES;
 }
 
-function toDataUrl(buffer: Buffer, mimeType: string): string {
-  return `data:${mimeType};base64,${buffer.toString("base64")}`;
-}
-
 function resolveBytePlusImageUrl(req: VideoGenerationRequest): string | undefined {
   const input = req.inputImages?.[0];
   if (!input) {
@@ -131,7 +128,7 @@ function resolveBytePlusImageUrl(req: VideoGenerationRequest): string | undefine
   if (!input.buffer) {
     throw new Error("BytePlus reference image is missing image data.");
   }
-  return toDataUrl(input.buffer, normalizeOptionalString(input.mimeType) ?? "image/png");
+  return toImageDataUrl({ ...input, buffer: input.buffer, defaultMimeType: "image/png" });
 }
 
 function resolveBytePlusSeed(value: unknown): number | undefined {

--- a/extensions/minimax/video-generation-provider.ts
+++ b/extensions/minimax/video-generation-provider.ts
@@ -1,4 +1,5 @@
 // Minimax provider module implements model/runtime integration.
+import { toImageDataUrl } from "openclaw/plugin-sdk/image-generation";
 import { extensionForMime } from "openclaw/plugin-sdk/media-mime";
 import { isProviderApiKeyConfigured } from "openclaw/plugin-sdk/provider-auth";
 import { resolveApiKeyForProvider } from "openclaw/plugin-sdk/provider-auth-runtime";
@@ -99,10 +100,6 @@ function assertMinimaxBaseResp(baseResp: MinimaxBaseResp | undefined, context: s
   );
 }
 
-function toDataUrl(buffer: Buffer, mimeType: string): string {
-  return `data:${mimeType};base64,${buffer.toString("base64")}`;
-}
-
 function resolveFirstFrameImage(req: VideoGenerationRequest): string | undefined {
   const input = req.inputImages?.[0];
   if (!input) {
@@ -115,7 +112,7 @@ function resolveFirstFrameImage(req: VideoGenerationRequest): string | undefined
   if (!input.buffer) {
     throw new Error("MiniMax image-to-video input is missing image data.");
   }
-  return toDataUrl(input.buffer, normalizeOptionalString(input.mimeType) ?? "image/png");
+  return toImageDataUrl({ ...input, buffer: input.buffer, defaultMimeType: "image/png" });
 }
 
 function resolveDurationSeconds(params: {

--- a/extensions/openai/shared.ts
+++ b/extensions/openai/shared.ts
@@ -35,10 +35,6 @@ type SyntheticOpenAIModelCatalogEntry = {
 
 const OPENAI_API_BASE_URL = "https://api.openai.com/v1";
 
-export function toOpenAIDataUrl(buffer: Buffer, mimeType: string): string {
-  return `data:${mimeType};base64,${buffer.toString("base64")}`;
-}
-
 export function resolveConfiguredOpenAIBaseUrl(cfg: OpenClawConfig | undefined): string {
   return normalizeOptionalString(cfg?.models?.providers?.openai?.baseUrl) ?? OPENAI_API_BASE_URL;
 }

--- a/extensions/openai/video-generation-provider.ts
+++ b/extensions/openai/video-generation-provider.ts
@@ -1,4 +1,5 @@
 // Openai provider module implements model/runtime integration.
+import { toImageDataUrl } from "openclaw/plugin-sdk/image-generation";
 import { extensionForMime } from "openclaw/plugin-sdk/media-mime";
 import { isProviderApiKeyConfigured } from "openclaw/plugin-sdk/provider-auth";
 import { resolveApiKeyForProvider } from "openclaw/plugin-sdk/provider-auth-runtime";
@@ -25,7 +26,7 @@ import type {
   VideoGenerationProvider,
   VideoGenerationRequest,
 } from "openclaw/plugin-sdk/video-generation";
-import { resolveConfiguredOpenAIBaseUrl, toOpenAIDataUrl } from "./shared.js";
+import { resolveConfiguredOpenAIBaseUrl } from "./shared.js";
 
 const DEFAULT_OPENAI_VIDEO_BASE_URL = "https://api.openai.com/v1";
 const DEFAULT_OPENAI_VIDEO_MODEL = "sora-2";
@@ -368,7 +369,7 @@ export function buildOpenAIVideoGenerationProvider(): VideoGenerationProvider {
                   ...(seconds ? { seconds } : {}),
                   ...(size ? { size } : {}),
                   input_reference: {
-                    image_url: toOpenAIDataUrl(referenceAsset.buffer, referenceAsset.mimeType),
+                    image_url: toImageDataUrl(referenceAsset),
                   },
                 },
                 timeoutMs: resolveProviderOperationTimeoutMs({

--- a/extensions/openrouter/music-generation-provider.ts
+++ b/extensions/openrouter/music-generation-provider.ts
@@ -1,4 +1,5 @@
 // Openrouter provider module implements model/runtime integration.
+import { toImageDataUrl } from "openclaw/plugin-sdk/image-generation";
 import type {
   MusicGenerationProvider,
   MusicGenerationRequest,
@@ -46,7 +47,7 @@ function imageToContentPart(image: MusicGenerationSourceImage): {
   const url =
     normalizeOptionalString(image.url) ??
     (image.buffer
-      ? `data:${normalizeOptionalString(image.mimeType) ?? "image/png"};base64,${image.buffer.toString("base64")}`
+      ? toImageDataUrl({ ...image, buffer: image.buffer, defaultMimeType: "image/png" })
       : undefined);
   if (!url) {
     throw new Error("OpenRouter music generation reference image is missing data.");

--- a/extensions/openrouter/video-generation-provider.ts
+++ b/extensions/openrouter/video-generation-provider.ts
@@ -1,4 +1,5 @@
 // Openrouter provider module implements model/runtime integration.
+import { toImageDataUrl } from "openclaw/plugin-sdk/image-generation";
 import { extensionForMime } from "openclaw/plugin-sdk/media-mime";
 import { isProviderApiKeyConfigured } from "openclaw/plugin-sdk/provider-auth";
 import { resolveApiKeyForProvider } from "openclaw/plugin-sdk/provider-auth-runtime";
@@ -118,8 +119,7 @@ function readOpenRouterVideoResponse(payload: Record<string, unknown>): OpenRout
 
 function toDataUrl(asset: VideoGenerationSourceAsset): string {
   if (asset.buffer) {
-    const mimeType = normalizeOptionalString(asset.mimeType) ?? "image/png";
-    return `data:${mimeType};base64,${asset.buffer.toString("base64")}`;
+    return toImageDataUrl({ ...asset, buffer: asset.buffer, defaultMimeType: "image/png" });
   }
   const url = normalizeOptionalString(asset.url);
   if (url) {

--- a/extensions/together/video-generation-provider.ts
+++ b/extensions/together/video-generation-provider.ts
@@ -1,4 +1,5 @@
 // Together provider module implements model/runtime integration.
+import { toImageDataUrl } from "openclaw/plugin-sdk/image-generation";
 import { extensionForMime } from "openclaw/plugin-sdk/media-mime";
 import { isProviderApiKeyConfigured } from "openclaw/plugin-sdk/provider-auth";
 import { resolveApiKeyForProvider } from "openclaw/plugin-sdk/provider-auth-runtime";
@@ -80,10 +81,6 @@ function resolveTogetherVideoBaseUrl(req: VideoGenerationRequest): string {
 
 function stripTrailingSlash(value: string): string {
   return value.replace(/\/+$/u, "");
-}
-
-function toDataUrl(buffer: Buffer, mimeType: string): string {
-  return `data:${mimeType};base64,${buffer.toString("base64")}`;
 }
 
 function extractTogetherVideoUrl(payload: TogetherVideoResponse): string | undefined {
@@ -269,7 +266,7 @@ export function buildTogetherVideoGenerationProvider(): VideoGenerationProvider 
         const value = normalizeOptionalString(input.url)
           ? normalizeOptionalString(input.url)
           : input.buffer
-            ? toDataUrl(input.buffer, normalizeOptionalString(input.mimeType) ?? "image/png")
+            ? toImageDataUrl({ ...input, buffer: input.buffer, defaultMimeType: "image/png" })
             : undefined;
         if (!value) {
           throw new Error("Together reference image is missing image data.");

--- a/extensions/xai/video-generation-provider.ts
+++ b/extensions/xai/video-generation-provider.ts
@@ -1,4 +1,5 @@
 // Xai provider module implements model/runtime integration.
+import { toImageDataUrl } from "openclaw/plugin-sdk/image-generation";
 import { extensionForMime } from "openclaw/plugin-sdk/media-mime";
 import { isProviderApiKeyConfigured } from "openclaw/plugin-sdk/provider-auth";
 import { resolveApiKeyForProvider } from "openclaw/plugin-sdk/provider-auth-runtime";
@@ -128,10 +129,6 @@ function resolveGeneratedVideoMaxBytes(req: VideoGenerationRequest): number {
   return DEFAULT_GENERATED_VIDEO_MAX_BYTES;
 }
 
-function toDataUrl(buffer: Buffer, mimeType: string): string {
-  return `data:${mimeType};base64,${buffer.toString("base64")}`;
-}
-
 function resolveImageUrl(input: VideoGenerationSourceInput | undefined): string | undefined {
   if (!input) {
     return undefined;
@@ -143,7 +140,7 @@ function resolveImageUrl(input: VideoGenerationSourceInput | undefined): string 
   if (!input.buffer) {
     throw new Error("xAI image-to-video input is missing image data.");
   }
-  return toDataUrl(input.buffer, normalizeOptionalString(input.mimeType) ?? "image/png");
+  return toImageDataUrl({ ...input, buffer: input.buffer, defaultMimeType: "image/png" });
 }
 
 function resolveRequiredImageUrl(input: VideoGenerationSourceInput): string {


### PR DESCRIPTION
Related: #99703

## What Problem This Solves

Media-generation providers repeated the same image buffer-to-data-URL formatting even though OpenClaw already exposes the canonical image asset helper. The duplicates added provider-local concepts that could drift from the shared MIME/default/base64 contract.

## Why This Change Was Made

Reuse `toImageDataUrl` through `plugin-sdk/image-generation` for the provider paths whose MIME values are already normalized and whose fallback/output behavior is identical. Generic video/audio data URLs, parsers, MIME maps, sniffing, validation, provider restrictions, and caller-specific fallback behavior remain separate.

## User Impact

No user-visible behavior change. Plugin maintainers now have one fewer repeated image data-URL implementation pattern, with 14 net production lines removed across the affected providers.

## Evidence

- `node scripts/run-vitest.mjs src/image-generation/image-assets.test.ts extensions/byteplus/video-generation-provider.test.ts extensions/minimax/video-generation-provider.test.ts extensions/openai/video-generation-provider.test.ts extensions/openrouter/music-generation-provider.test.ts extensions/openrouter/video-generation-provider.test.ts extensions/together/video-generation-provider.test.ts extensions/xai/video-generation-provider.test.ts`
  - 91 assertions passed across 3 Vitest shards.
- Blacksmith Testbox through Crabbox: `tbx_01kwn6c54emgsyvh6phs55w4xb`
  - Actions run: https://github.com/openclaw/openclaw/actions/runs/28688386971
  - `pnpm check:changed` passed, including extension typechecks, lint, guards, and import-cycle check.
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main --prompt-file /tmp/media-primitives-review.md --stream-engine-output`
  - Clean: no accepted/actionable findings.
- `git diff --check origin/main...HEAD`
- Production diff: +15 / -29, net -14 LOC.
