### PR TITLE
Surface empty interactive reply completions

### DIFF
--- a/src/auto-reply/reply/agent-runner.runreplyagent.e2e.test.ts
+++ b/src/auto-reply/reply/agent-runner.runreplyagent.e2e.test.ts
@@ -942,6 +942,40 @@ describe("runReplyAgent typing (heartbeat)", () => {
     expect(res).toBeUndefined();
   });
 
+  it("surfaces an empty interactive completion instead of silently dropping the reply", async () => {
+    state.runEmbeddedAgentMock.mockResolvedValueOnce({
+      payloads: [],
+      meta: {},
+    });
+
+    const { run } = createMinimalRun({
+      sessionCtx: {
+        Provider: "telegram",
+        OriginatingChannel: "telegram",
+        MessageSid: "8836419572",
+      },
+    });
+    const res = await run();
+    const payload = Array.isArray(res) ? res[0] : res;
+
+    expect(payload?.isError).toBe(true);
+    expect(payload?.text).toContain("did not produce a visible reply");
+  });
+
+  it("preserves empty message-tool-only completions as intentional silence", async () => {
+    state.runEmbeddedAgentMock.mockResolvedValueOnce({
+      payloads: [],
+      meta: {},
+    });
+
+    const { run } = createMinimalRun({
+      opts: { sourceReplyDeliveryMode: "message_tool_only" },
+      runOverrides: { sourceReplyDeliveryMode: "message_tool_only" },
+    });
+
+    await expect(run()).resolves.toBeUndefined();
+  });
+
   it("does not start typing on assistant message start without prior text in message mode", async () => {
     state.runEmbeddedAgentMock.mockImplementationOnce(async (params: AgentRunParams) => {
       await params.onAssistantMessageStart?.();

--- a/src/auto-reply/reply/agent-runner.ts
+++ b/src/auto-reply/reply/agent-runner.ts
@@ -56,6 +56,7 @@ import {
   buildFallbackNotice,
   resolveFallbackTransition,
 } from "../fallback-state.js";
+import type { SourceReplyDeliveryMode } from "../get-reply-options.types.js";
 import { DEFAULT_HEARTBEAT_ACK_MAX_CHARS, stripHeartbeatToken } from "../heartbeat.js";
 import {
   isReplyPayloadStatusNotice,
@@ -131,6 +132,8 @@ import type { TypingController } from "./typing.js";
 const BLOCK_REPLY_SEND_TIMEOUT_MS = 15_000;
 const RESTART_LIFECYCLE_REPLY_TEXT =
   "⚠️ Gateway is restarting. Please wait a few seconds and try again.";
+const EMPTY_INTERACTIVE_REPLY_TEXT =
+  "⚠️ I finished this turn, but it did not produce a visible reply. Please try again, or use /new if this keeps happening.";
 
 function scheduleFollowupDrainAfterReplyOperationClear(params: {
   operation: ReplyOperation;
@@ -180,6 +183,28 @@ function buildSilentFallbackFailurePayload(params: {
     text:
       `⚠️ I couldn't reach the configured model backend ${params.fallbackTransition.selectedModelRef}. ` +
       `Fallback used ${params.fallbackTransition.activeModelRef}, but it produced no visible reply.`,
+    isError: true,
+  });
+}
+
+function buildEmptyInteractiveReplyPayload(params: {
+  isHeartbeat: boolean;
+  hasSuccessfulSideEffectDelivery: boolean;
+  allowEmptyAssistantReplyAsSilent?: boolean;
+  silentExpected?: boolean;
+  sourceReplyDeliveryMode?: SourceReplyDeliveryMode;
+}): ReplyPayload | undefined {
+  if (
+    params.isHeartbeat ||
+    params.allowEmptyAssistantReplyAsSilent === true ||
+    params.silentExpected === true ||
+    params.sourceReplyDeliveryMode === "message_tool_only" ||
+    params.hasSuccessfulSideEffectDelivery
+  ) {
+    return undefined;
+  }
+  return markReplyPayloadForSourceSuppressionDelivery({
+    text: EMPTY_INTERACTIVE_REPLY_TEXT,
     isError: true,
   });
 }
@@ -2017,6 +2042,27 @@ export async function runReplyAgent(params: {
       await signalTypingIfNeeded([silentFallbackFailurePayload], typingSignals);
       return returnWithQueuedFollowupDrain(silentFallbackFailurePayload);
     };
+    const returnEmptyInteractiveReplyFailureIfNeeded = async (): Promise<
+      ReplyPayload | undefined
+    > => {
+      const emptyInteractiveReplyPayload = buildEmptyInteractiveReplyPayload({
+        isHeartbeat,
+        hasSuccessfulSideEffectDelivery: successfulSideEffectDelivery,
+        allowEmptyAssistantReplyAsSilent: followupRun.run.allowEmptyAssistantReplyAsSilent,
+        silentExpected: followupRun.run.silentExpected,
+        sourceReplyDeliveryMode:
+          followupRun.run.sourceReplyDeliveryMode ?? opts?.sourceReplyDeliveryMode,
+      });
+      if (!emptyInteractiveReplyPayload) {
+        return undefined;
+      }
+      replyOperation.fail(
+        "run_failed",
+        new Error("agent completed without a visible reply payload"),
+      );
+      await signalTypingIfNeeded([emptyInteractiveReplyPayload], typingSignals);
+      return returnWithQueuedFollowupDrain(emptyInteractiveReplyPayload);
+    };
 
     const fallbackNoticePayloads: ReplyPayload[] = [];
     if (
@@ -2094,6 +2140,10 @@ export async function runReplyAgent(params: {
       if (silentFallbackFailurePayload) {
         return silentFallbackFailurePayload;
       }
+      const emptyInteractiveReplyPayload = await returnEmptyInteractiveReplyFailureIfNeeded();
+      if (emptyInteractiveReplyPayload) {
+        return emptyInteractiveReplyPayload;
+      }
       return returnWithQueuedFollowupDrain(undefined);
     }
 
@@ -2147,6 +2197,10 @@ export async function runReplyAgent(params: {
       const silentFallbackFailurePayload = await returnSilentFallbackFailureIfNeeded();
       if (silentFallbackFailurePayload) {
         return silentFallbackFailurePayload;
+      }
+      const emptyInteractiveReplyPayload = await returnEmptyInteractiveReplyFailureIfNeeded();
+      if (emptyInteractiveReplyPayload) {
+        return emptyInteractiveReplyPayload;
       }
       return returnWithQueuedFollowupDrain(undefined);
     }


### PR DESCRIPTION
## Summary

- Surface a user-visible error payload when an interactive `runReplyAgent` turn completes with no visible reply payload.
- Preserve intentional silence for heartbeat, `silentExpected`, `allowEmptyAssistantReplyAsSilent`, `message_tool_only`, and runs that already delivered a successful side effect.
- Add e2e coverage for the ordinary empty interactive completion and the `message_tool_only` empty-completion exception.

Fixes #99712

## Tests

- `node scripts/run-vitest.mjs run --config test/vitest/vitest.e2e.config.ts src/auto-reply/reply/agent-runner.runreplyagent.e2e.test.ts`
- `corepack pnpm exec oxlint src/auto-reply/reply/agent-runner.ts src/auto-reply/reply/agent-runner.runreplyagent.e2e.test.ts`
