### PR TITLE
refactor(net): consolidate URL protocol predicates

### DIFF
--- a/packages/net-policy/package.json
+++ b/packages/net-policy/package.json
@@ -29,6 +29,11 @@
       "import": "./dist/redact-sensitive-url.mjs",
       "default": "./dist/redact-sensitive-url.mjs"
     },
+    "./url-protocol": {
+      "types": "./dist/url-protocol.d.mts",
+      "import": "./dist/url-protocol.mjs",
+      "default": "./dist/url-protocol.mjs"
+    },
     "./url-userinfo": {
       "types": "./dist/url-userinfo.d.mts",
       "import": "./dist/url-userinfo.mjs",
@@ -36,7 +41,7 @@
     }
   },
   "scripts": {
-    "build": "tsdown src/index.ts src/ip.ts src/ipv4.ts src/redact-sensitive-url.ts src/url-userinfo.ts --no-config --platform node --format esm --dts --out-dir dist --clean"
+    "build": "tsdown src/index.ts src/ip.ts src/ipv4.ts src/redact-sensitive-url.ts src/url-protocol.ts src/url-userinfo.ts --no-config --platform node --format esm --dts --out-dir dist --clean"
   },
   "dependencies": {
     "ipaddr.js": "2.4.0"

--- a/packages/net-policy/src/index.ts
+++ b/packages/net-policy/src/index.ts
@@ -3,4 +3,5 @@
 export * from "./ip.js";
 export * from "./ipv4.js";
 export * from "./redact-sensitive-url.js";
+export * from "./url-protocol.js";
 export * from "./url-userinfo.js";

--- a/packages/net-policy/src/url-protocol.test.ts
+++ b/packages/net-policy/src/url-protocol.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "vitest";
+import { hasHttpUrlPrefix, isHttpsUrl, isHttpUrl, isWebSocketUrl } from "./url-protocol.js";
+
+describe("hasHttpUrlPrefix", () => {
+  it.each([
+    ["http://example.com", true],
+    ["HTTPS://user:pass@example.com:8443/path", true],
+    ["https://", true],
+    [" https://example.com", false],
+    ["//example.com", false],
+    ["example.com", false],
+    ["wss://example.com", false],
+  ])("classifies %j", (value, expected) => {
+    expect(hasHttpUrlPrefix(value)).toBe(expected);
+  });
+});
+
+describe("parsed URL protocol predicates", () => {
+  it.each([
+    ["http://example.com", true, false, false],
+    ["HTTPS://user:pass@example.com:8443/path", true, true, false],
+    ["ws://example.com", false, false, true],
+    ["WSS://example.com:9443/socket", false, false, true],
+    ["file:///tmp/example", false, false, false],
+  ])("classifies %s", (value, http, https, websocket) => {
+    const url = new URL(value);
+    expect(isHttpUrl(url)).toBe(http);
+    expect(isHttpsUrl(url)).toBe(https);
+    expect(isWebSocketUrl(url)).toBe(websocket);
+  });
+
+  it("returns false for malformed and relative strings", () => {
+    expect(isHttpUrl("https://")).toBe(false);
+    expect(isHttpsUrl("/relative")).toBe(false);
+    expect(isWebSocketUrl("not a URL")).toBe(false);
+  });
+
+  it("parses string inputs without changing URL constructor behavior", () => {
+    expect(isHttpUrl("  HTTP://user:pass@example.com:8080/path  ")).toBe(true);
+    expect(isHttpsUrl(" HTTPS://example.com ")).toBe(true);
+    expect(isWebSocketUrl(" WSS://example.com:9443/socket ")).toBe(true);
+  });
+});

--- a/packages/net-policy/src/url-protocol.ts
+++ b/packages/net-policy/src/url-protocol.ts
@@ -1,0 +1,30 @@
+const HTTP_URL_PREFIX_RE = /^https?:\/\//i;
+
+function parseUrl(value: string | URL): URL | null {
+  if (value instanceof URL) {
+    return value;
+  }
+  try {
+    return new URL(value);
+  } catch {
+    return null;
+  }
+}
+
+export function hasHttpUrlPrefix(value: string): boolean {
+  return HTTP_URL_PREFIX_RE.test(value);
+}
+
+export function isHttpUrl(value: string | URL): boolean {
+  const url = parseUrl(value);
+  return url?.protocol === "http:" || url?.protocol === "https:";
+}
+
+export function isHttpsUrl(value: string | URL): boolean {
+  return parseUrl(value)?.protocol === "https:";
+}
+
+export function isWebSocketUrl(value: string | URL): boolean {
+  const url = parseUrl(value);
+  return url?.protocol === "ws:" || url?.protocol === "wss:";
+}

--- a/src/acp/event-mapper.ts
+++ b/src/acp/event-mapper.ts
@@ -7,6 +7,7 @@ import type {
   ToolKind,
 } from "@agentclientprotocol/sdk";
 import { asRecord } from "@openclaw/acp-core/record-shared";
+import { hasHttpUrlPrefix } from "@openclaw/net-policy/url-protocol";
 import {
   hasNonEmptyString,
   normalizeLowercaseStringOrEmpty,
@@ -114,7 +115,7 @@ function normalizeToolLocationPath(value: string): string | undefined {
   ) {
     return undefined;
   }
-  if (/^https?:\/\//i.test(trimmed)) {
+  if (hasHttpUrlPrefix(trimmed)) {
     return undefined;
   }
   if (/^file:\/\//i.test(trimmed)) {

--- a/src/config/zod-schema.proxy.ts
+++ b/src/config/zod-schema.proxy.ts
@@ -1,15 +1,7 @@
 // Defines proxy-related Zod schema fragments for config parsing.
+import { isHttpUrl } from "@openclaw/net-policy/url-protocol";
 import { z } from "zod";
 import { sensitive } from "./zod-schema.sensitive.js";
-
-function isHttpOrHttpsProxyUrl(value: string): boolean {
-  try {
-    const url = new URL(value);
-    return url.protocol === "http:" || url.protocol === "https:";
-  } catch {
-    return false;
-  }
-}
 
 export const ProxyLoopbackModeSchema = z.enum(["gateway-only", "proxy", "block"]);
 
@@ -25,7 +17,7 @@ export const ProxyConfigSchema = z
     enabled: z.boolean().optional(),
     proxyUrl: z
       .url()
-      .refine(isHttpOrHttpsProxyUrl, {
+      .refine(isHttpUrl, {
         message: "proxyUrl must use http:// or https://",
       })
       .register(sensitive)

--- a/src/config/zod-schema.ts
+++ b/src/config/zod-schema.ts
@@ -1,3 +1,4 @@
+import { isHttpsUrl, isHttpUrl } from "@openclaw/net-policy/url-protocol";
 // Assembles the canonical Zod schema for OpenClaw config parsing.
 import {
   normalizeLowercaseStringOrEmpty,
@@ -241,20 +242,14 @@ const MemorySchema = z
   .strict()
   .optional();
 
-const HttpUrlSchema = z
-  .string()
-  .url()
-  .refine((value) => {
-    const protocol = new URL(value).protocol;
-    return protocol === "http:" || protocol === "https:";
-  }, "Expected http:// or https:// URL");
+const HttpUrlSchema = z.string().url().refine(isHttpUrl, "Expected http:// or https:// URL");
 
 const McpOAuthClientMetadataUrlSchema = z
   .string()
   .url()
   .refine((value) => {
     const url = new URL(value);
-    return url.protocol === "https:" && url.pathname !== "/";
+    return isHttpsUrl(url) && url.pathname !== "/";
   }, "Expected https:// URL with a non-root pathname");
 
 const ResponsesEndpointUrlFetchShape = {

--- a/src/cron/webhook-url.ts
+++ b/src/cron/webhook-url.ts
@@ -1,7 +1,4 @@
-/** Normalizes cron webhook destination URLs. */
-function isAllowedWebhookProtocol(protocol: string) {
-  return protocol === "http:" || protocol === "https:";
-}
+import { isHttpUrl } from "@openclaw/net-policy/url-protocol";
 
 /** Normalizes cron webhook URLs while rejecting empty, malformed, and non-HTTP(S) values. */
 export function normalizeHttpWebhookUrl(value: unknown): string | null {
@@ -12,13 +9,8 @@ export function normalizeHttpWebhookUrl(value: unknown): string | null {
   if (!trimmed) {
     return null;
   }
-  try {
-    const parsed = new URL(trimmed);
-    if (!isAllowedWebhookProtocol(parsed.protocol)) {
-      return null;
-    }
-    return trimmed;
-  } catch {
+  if (!isHttpUrl(trimmed)) {
     return null;
   }
+  return trimmed;
 }

--- a/src/gateway/server-methods/artifacts.ts
+++ b/src/gateway/server-methods/artifacts.ts
@@ -1,6 +1,7 @@
 // Artifact gateway methods collect generated artifacts from session transcripts
 // and expose list/get/download RPCs scoped by session, run, task, or agent.
 import { createHash } from "node:crypto";
+import { isHttpUrl } from "@openclaw/net-policy/url-protocol";
 import { asOptionalRecord } from "@openclaw/normalization-core/record-coerce";
 import { normalizeOptionalString as asNonEmptyString } from "@openclaw/normalization-core/string-coerce";
 import {
@@ -257,12 +258,7 @@ function isSafeDownloadUrl(value: string): boolean {
   if (trimmed.startsWith("/")) {
     return !trimmed.startsWith("//") && trimmed.startsWith("/api/");
   }
-  try {
-    const parsed = new URL(trimmed);
-    return parsed.protocol === "http:" || parsed.protocol === "https:";
-  } catch {
-    return false;
-  }
+  return isHttpUrl(trimmed);
 }
 
 /** Generates a stable id from transcript position plus display metadata. */

--- a/src/infra/net/proxy/proxy-lifecycle.ts
+++ b/src/infra/net/proxy/proxy-lifecycle.ts
@@ -9,6 +9,7 @@ import type { ProxyConfig } from "../../../config/zod-schema.proxy.js";
 
 type ProxyLoopbackMode = NonNullable<NonNullable<ProxyConfig>["loopbackMode"]>;
 import { isLoopbackIpAddress } from "@openclaw/net-policy/ip";
+import { isHttpUrl, isWebSocketUrl } from "@openclaw/net-policy/url-protocol";
 import { logInfo, logWarn } from "../../../logger.js";
 import { forceResetGlobalDispatcher } from "../undici-global-dispatcher.js";
 import {
@@ -146,15 +147,6 @@ function stopActiveProxyRegistration(registration: ActiveManagedProxyRegistratio
   restoreInactiveProxyRuntime(restoreSnapshot);
 }
 
-function isSupportedProxyUrl(value: string): boolean {
-  try {
-    const url = new URL(value);
-    return url.protocol === "http:" || url.protocol === "https:";
-  } catch {
-    return false;
-  }
-}
-
 function resolveProxyUrl(config: ProxyConfig | undefined): string {
   const candidate = config?.proxyUrl?.trim() || process.env["OPENCLAW_PROXY_URL"]?.trim();
   if (!candidate) {
@@ -163,7 +155,7 @@ function resolveProxyUrl(config: ProxyConfig | undefined): string {
         "or OPENCLAW_PROXY_URL to an http:// or https:// forward proxy.",
     );
   }
-  if (!isSupportedProxyUrl(candidate)) {
+  if (!isHttpUrl(candidate)) {
     throw new Error(
       "proxy: enabled but proxy URL is invalid; set proxy.proxyUrl " +
         "or OPENCLAW_PROXY_URL to an http:// or https:// forward proxy.",
@@ -187,7 +179,7 @@ export function ensureInheritedManagedProxyRoutingActive(): void {
     return;
   }
   const proxyUrl = process.env["HTTP_PROXY"];
-  if (!proxyUrl || !isSupportedProxyUrl(proxyUrl)) {
+  if (!proxyUrl || !isHttpUrl(proxyUrl)) {
     return;
   }
   const proxyCaFile = resolveManagedProxyCaFileForUrl({
@@ -299,15 +291,11 @@ function parseGatewayControlPlaneUrl(value: string): URL | null {
   }
 }
 
-function isGatewayControlPlaneProtocol(protocol: string): boolean {
-  return protocol === "ws:" || protocol === "wss:" || protocol === "http:" || protocol === "https:";
-}
-
 function getGatewayControlPlaneBypassAuthority(value: string): string | null {
   const url = parseGatewayControlPlaneUrl(value);
   if (
     url === null ||
-    !isGatewayControlPlaneProtocol(url.protocol) ||
+    (!isHttpUrl(url) && !isWebSocketUrl(url)) ||
     !isGatewayControlPlaneLoopbackHost(url.hostname)
   ) {
     return null;

--- a/src/infra/net/proxy/proxy-validation.ts
+++ b/src/infra/net/proxy/proxy-validation.ts
@@ -2,6 +2,7 @@
 // APNs destinations through an explicit HTTP(S) forward proxy.
 import { randomUUID } from "node:crypto";
 import { createServer, type Server } from "node:http";
+import { isHttpUrl } from "@openclaw/net-policy/url-protocol";
 import type { ProxyConfig } from "../../../config/zod-schema.proxy.js";
 import { probeApnsHttp2ReachabilityViaProxy } from "../../push-apns-http2.js";
 import { fetchWithRuntimeDispatcher } from "../runtime-fetch.js";
@@ -115,20 +116,11 @@ function normalizeProxyUrl(value: string | undefined): string | undefined {
   return trimmed ? trimmed : undefined;
 }
 
-function isHttpOrHttpsProxyUrl(value: string): boolean {
-  try {
-    const url = new URL(value);
-    return url.protocol === "http:" || url.protocol === "https:";
-  } catch {
-    return false;
-  }
-}
-
 function validateProxyUrl(value: string | undefined): string[] {
   if (!value) {
     return ["proxy validation requires proxy.proxyUrl, --proxy-url, or OPENCLAW_PROXY_URL"];
   }
-  if (!isHttpOrHttpsProxyUrl(value)) {
+  if (!isHttpUrl(value)) {
     return ["proxyUrl must use http:// or https://"];
   }
   return [];
@@ -297,15 +289,6 @@ function normalizeTimeoutMs(value: number | undefined): number {
   return Math.floor(value);
 }
 
-function isValidHttpTargetUrl(value: string): boolean {
-  try {
-    const url = new URL(value);
-    return url.protocol === "http:" || url.protocol === "https:";
-  } catch {
-    return false;
-  }
-}
-
 type ProxyValidationDeniedTarget = {
   url: string;
   expectedCanaryToken?: string;
@@ -392,7 +375,7 @@ async function runAllowedCheck(params: {
   timeoutMs: number;
   fetchCheck: ProxyValidationFetchCheck;
 }): Promise<ProxyValidationCheck> {
-  if (!isValidHttpTargetUrl(params.url)) {
+  if (!isHttpUrl(params.url)) {
     return {
       kind: "allowed",
       url: params.url,
@@ -435,7 +418,7 @@ async function runDeniedCheck(params: {
   timeoutMs: number;
   fetchCheck: ProxyValidationFetchCheck;
 }): Promise<ProxyValidationCheck> {
-  if (!isValidHttpTargetUrl(params.target.url)) {
+  if (!isHttpUrl(params.target.url)) {
     return {
       kind: "denied",
       url: params.target.url,

--- a/src/media-understanding/runtime.ts
+++ b/src/media-understanding/runtime.ts
@@ -2,6 +2,7 @@
 // structured extraction calls outside normal channel message handling.
 import path from "node:path";
 import { kindFromMime, mimeTypeFromFilePath } from "@openclaw/media-core/mime";
+import { hasHttpUrlPrefix } from "@openclaw/net-policy/url-protocol";
 import type { OpenClawConfig } from "../config/types.js";
 import { readLocalFileSafely } from "../infra/fs-safe.js";
 import { DEFAULT_MAX_BYTES } from "./defaults.constants.js";
@@ -107,7 +108,7 @@ function buildFileContext(params: {
 }
 
 function isRemoteMediaReference(value: string): boolean {
-  return /^https?:\/\//i.test(value.trim());
+  return hasHttpUrlPrefix(value.trim());
 }
 
 function concreteMime(mime: string | undefined): string | undefined {

--- a/src/media/media-reference.ts
+++ b/src/media/media-reference.ts
@@ -1,6 +1,7 @@
 // Media reference helpers resolve media refs to file, URL, or inline payloads.
 import fs from "node:fs/promises";
 import path from "node:path";
+import { hasHttpUrlPrefix } from "@openclaw/net-policy/url-protocol";
 import { safeFileURLToPath } from "../infra/local-file-access.js";
 import { resolveUserPath } from "../utils.js";
 import { getMediaDir, resolveMediaBufferPath } from "./store.js";
@@ -58,7 +59,7 @@ export function classifyMediaReferenceSource(
   const looksLikeWindowsDrivePath = /^[a-zA-Z]:[\\/]/.test(source);
   const hasScheme = /^[a-z][a-z0-9+.-]*:/i.test(source);
   const isFileUrl = /^file:/i.test(source);
-  const isHttpUrl = /^https?:\/\//i.test(source);
+  const isHttpUrl = hasHttpUrlPrefix(source);
   const isDataUrl = /^data:/i.test(source);
   const isMediaStoreUrl = /^media:\/\//i.test(source);
   const hasUnsupportedScheme =

--- a/src/media/parse.ts
+++ b/src/media/parse.ts
@@ -9,6 +9,7 @@ import {
   parseCanonicalIpAddress,
   parseLooseIpAddress,
 } from "@openclaw/net-policy/ip";
+import { hasHttpUrlPrefix } from "@openclaw/net-policy/url-protocol";
 import { parseFenceSpans } from "../../packages/markdown-core/src/fences.js";
 import { parseAudioTag } from "./audio-tags.js";
 
@@ -171,7 +172,7 @@ function isValidMedia(
   if (!opts?.allowSpaces && /\s/.test(candidate)) {
     return false;
   }
-  if (/^https?:\/\//i.test(candidate)) {
+  if (hasHttpUrlPrefix(candidate)) {
     return isAllowedRemoteMediaUrl(candidate);
   }
 
@@ -257,7 +258,7 @@ function findMatchingBracket(
 }
 
 function isRemoteMarkdownImageMedia(candidate: string): boolean {
-  return /^https?:\/\//i.test(candidate) && isValidMedia(candidate);
+  return hasHttpUrlPrefix(candidate) && isValidMedia(candidate);
 }
 
 function parseMarkdownTitle(input: string, start: number): number | undefined {

--- a/src/media/store.ts
+++ b/src/media/store.ts
@@ -13,6 +13,7 @@ import {
   nameFromAnyPath,
 } from "@openclaw/media-core/file-name";
 import { detectMime, extensionForMime } from "@openclaw/media-core/mime";
+import { hasHttpUrlPrefix } from "@openclaw/net-policy/url-protocol";
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import { toErrorObject } from "../infra/errors.js";
 import { fileStore } from "../infra/file-store.js";
@@ -216,7 +217,7 @@ export async function cleanOldMedia(ttlMs = DEFAULT_TTL_MS, options: CleanOldMed
 }
 
 function looksLikeUrl(src: string) {
-  return /^https?:\/\//i.test(src);
+  return hasHttpUrlPrefix(src);
 }
 
 function discardIgnoredHttpResponse(res: NodeJS.ReadableStream): void {

--- a/src/media/web-media.ts
+++ b/src/media/web-media.ts
@@ -11,6 +11,7 @@ import {
   mimeTypeFromFilePath,
   normalizeMimeType,
 } from "@openclaw/media-core/mime";
+import { hasHttpUrlPrefix } from "@openclaw/net-policy/url-protocol";
 import { uniqueValues } from "@openclaw/normalization-core/string-normalization";
 import { logVerbose, shouldLogVerbose } from "../globals.js";
 import { formatErrorMessage } from "../infra/errors.js";
@@ -969,7 +970,7 @@ async function loadWebMediaInternal(
     };
   };
 
-  if (/^https?:\/\//i.test(mediaUrl)) {
+  if (hasHttpUrlPrefix(mediaUrl)) {
     // Enforce a download cap during fetch to avoid unbounded memory usage.
     // For optimized images, allow fetching larger payloads before compression.
     const defaultFetchCap = maxBytesForKind("document");

--- a/src/plugins/git-install.ts
+++ b/src/plugins/git-install.ts
@@ -3,6 +3,7 @@ import "../infra/fs-safe-defaults.js";
 import { createHash } from "node:crypto";
 import path from "node:path";
 import { redactSensitiveUrlLikeString } from "@openclaw/net-policy/redact-sensitive-url";
+import { hasHttpUrlPrefix } from "@openclaw/net-policy/url-protocol";
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import { sanitizeForLog } from "../../packages/terminal-core/src/ansi.js";
 import { pathExists } from "../infra/fs-safe.js";
@@ -111,10 +112,6 @@ function looksLikeGitHubHostPath(value: string): boolean {
   return /^github\.com\/[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+(?:\.git)?$/i.test(value);
 }
 
-function isHttpUrl(value: string): boolean {
-  return /^https?:\/\//i.test(value);
-}
-
 function isGitUrl(value: string): boolean {
   return (
     /^(?:ssh|git|file):\/\//i.test(value) || looksLikeScpGitUrl(value) || value.endsWith(".git")
@@ -153,7 +150,7 @@ function normalizeGitHubRepo(value: string): { url: string; label: string } {
 }
 
 function normalizeGitLabel(value: string): string {
-  if (isHttpUrl(value) || /^(?:ssh|git|file):\/\//i.test(value)) {
+  if (hasHttpUrlPrefix(value) || /^(?:ssh|git|file):\/\//i.test(value)) {
     try {
       const url = new URL(value);
       return stripGitSuffix(`${url.hostname}${url.pathname}`).replace(/^\/+/, "");
@@ -193,7 +190,7 @@ export function parseGitPluginSpec(raw: string): ParsedGitPluginSpec | null {
   }
 
   if (
-    isHttpUrl(base) ||
+    hasHttpUrlPrefix(base) ||
     isGitUrl(base) ||
     base.startsWith("./") ||
     base.startsWith("../") ||

--- a/src/plugins/marketplace.ts
+++ b/src/plugins/marketplace.ts
@@ -3,6 +3,7 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { redactSensitiveUrlLikeString } from "@openclaw/net-policy/redact-sensitive-url";
+import { hasHttpUrlPrefix } from "@openclaw/net-policy/url-protocol";
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import { sanitizeForLog } from "../../packages/terminal-core/src/ansi.js";
 import { resolveArchiveKind } from "../infra/archive.js";
@@ -114,10 +115,6 @@ export type MarketplaceShortcutResolution =
     }
   | null;
 
-function isHttpUrl(value: string): boolean {
-  return /^https?:\/\//i.test(value);
-}
-
 function isGitUrl(value: string): boolean {
   return (
     /^git@/i.test(value) || /^ssh:\/\//i.test(value) || /^https?:\/\/.+\.git(?:#.*)?$/i.test(value)
@@ -148,7 +145,7 @@ function normalizeEntrySource(
     if (!trimmed) {
       return { ok: false, error: "empty plugin source" };
     }
-    if (isHttpUrl(trimmed)) {
+    if (hasHttpUrlPrefix(trimmed)) {
       return { ok: true, source: { kind: "url", url: trimmed } };
     }
     return { ok: true, source: { kind: "path", path: trimmed } };
@@ -290,7 +287,7 @@ function marketplaceInstallPolicySource(params: {
     if (
       params.marketplaceOrigin === "remote" &&
       params.source.kind === "path" &&
-      !isHttpUrl(params.source.path)
+      !hasHttpUrlPrefix(params.source.path)
     ) {
       return {
         kind: "archive",
@@ -299,7 +296,7 @@ function marketplaceInstallPolicySource(params: {
         network: true,
       };
     }
-    if (params.source.kind === "path" && !isHttpUrl(params.source.path)) {
+    if (params.source.kind === "path" && !hasHttpUrlPrefix(params.source.path)) {
       return { kind: "archive", authority: "user", mutable: true, network: false };
     }
     return { kind: "archive", authority: "third-party", mutable: entryMutable, network: true };
@@ -308,13 +305,13 @@ function marketplaceInstallPolicySource(params: {
   if (
     params.marketplaceOrigin === "remote" &&
     params.source.kind === "path" &&
-    !isHttpUrl(params.source.path)
+    !hasHttpUrlPrefix(params.source.path)
   ) {
     return { kind: "git", authority: "third-party", mutable: marketplaceMutable, network: true };
   }
 
   if (params.source.kind === "path") {
-    if (isHttpUrl(params.source.path)) {
+    if (hasHttpUrlPrefix(params.source.path)) {
       return { kind: "archive", authority: "third-party", mutable: true, network: true };
     }
     return { kind: "local-path", authority: "user", mutable: true, network: false };
@@ -498,7 +495,7 @@ function normalizeGitCloneSource(
     };
   }
 
-  if (isHttpUrl(source)) {
+  if (hasHttpUrlPrefix(source)) {
     try {
       const url = new URL(split.base);
       if (url.hostname !== "github.com") {
@@ -1033,7 +1030,7 @@ async function validateMarketplaceManifest(params: {
   for (const plugin of params.manifest.plugins) {
     const source = plugin.source;
     if (source.kind === "path") {
-      if (isHttpUrl(source.path)) {
+      if (hasHttpUrlPrefix(source.path)) {
         return {
           ok: false,
           error:
@@ -1090,7 +1087,7 @@ async function resolveMarketplaceEntryInstallPath(params: {
     }
 > {
   if (params.source.kind === "path") {
-    if (isHttpUrl(params.source.path)) {
+    if (hasHttpUrlPrefix(params.source.path)) {
       if (resolveArchiveKind(params.source.path)) {
         return await downloadUrlToTempFile(params.source.path, params.timeoutMs);
       }

--- a/src/plugins/sdk-alias.test.ts
+++ b/src/plugins/sdk-alias.test.ts
@@ -1593,6 +1593,12 @@ describe("plugin sdk alias helpers", () => {
       srcFile: "ip.ts",
       distFile: "ip.mjs",
     });
+    const netPolicyUrlProtocol = writeWorkspacePackageEntry({
+      root: fixture.root,
+      packageDir: "net-policy",
+      srcFile: "url-protocol.ts",
+      distFile: "url-protocol.mjs",
+    });
     const modelCatalogProviderId = writeWorkspacePackageEntry({
       root: fixture.root,
       packageDir: "model-catalog-core",
@@ -1617,6 +1623,7 @@ describe("plugin sdk alias helpers", () => {
     fs.rmSync(terminalCoreTheme.distFile);
     fs.rmSync(netPolicy.distFile);
     fs.rmSync(netPolicyIp.distFile);
+    fs.rmSync(netPolicyUrlProtocol.distFile);
     fs.rmSync(modelCatalogProviderId.distFile);
     const sourcePluginEntry = writePluginEntry(
       fixture.root,
@@ -1680,6 +1687,9 @@ describe("plugin sdk alias helpers", () => {
     );
     expect(fs.realpathSync(aliases["@openclaw/net-policy/ip"] ?? "")).toBe(
       fs.realpathSync(netPolicyIp.srcFile),
+    );
+    expect(fs.realpathSync(aliases["@openclaw/net-policy/url-protocol"] ?? "")).toBe(
+      fs.realpathSync(netPolicyUrlProtocol.srcFile),
     );
     expect(fs.realpathSync(aliases["@openclaw/model-catalog-core/provider-id"] ?? "")).toBe(
       fs.realpathSync(modelCatalogProviderId.srcFile),
@@ -1762,8 +1772,8 @@ describe("plugin sdk alias helpers", () => {
     const netPolicy = writeWorkspacePackageEntry({
       root: fixture.root,
       packageDir: "net-policy",
-      srcFile: "redact-sensitive-url.ts",
-      distFile: "redact-sensitive-url.mjs",
+      srcFile: "url-protocol.ts",
+      distFile: "url-protocol.mjs",
     });
     const modelCatalogCore = writeWorkspacePackageEntry({
       root: fixture.root,
@@ -1804,7 +1814,7 @@ describe("plugin sdk alias helpers", () => {
     expect(fs.realpathSync(aliases["@openclaw/terminal-core/links"] ?? "")).toBe(
       fs.realpathSync(terminalCoreRootDistFile),
     );
-    expect(fs.realpathSync(aliases["@openclaw/net-policy/redact-sensitive-url"] ?? "")).toBe(
+    expect(fs.realpathSync(aliases["@openclaw/net-policy/url-protocol"] ?? "")).toBe(
       fs.realpathSync(netPolicy.distFile),
     );
     expect(

--- a/src/plugins/sdk-alias.ts
+++ b/src/plugins/sdk-alias.ts
@@ -948,6 +948,13 @@ const WORKSPACE_PACKAGE_ALIAS_ENTRIES: WorkspacePackageAliasEntry[] = [
   {
     packageName: "@openclaw/net-policy",
     packageDir: "net-policy",
+    subpath: "url-protocol",
+    srcFile: "url-protocol.ts",
+    distFile: "url-protocol.mjs",
+  },
+  {
+    packageName: "@openclaw/net-policy",
+    packageDir: "net-policy",
     subpath: "url-userinfo",
     srcFile: "url-userinfo.ts",
     distFile: "url-userinfo.mjs",

--- a/test/vitest/vitest.shared.config.ts
+++ b/test/vitest/vitest.shared.config.ts
@@ -344,6 +344,10 @@ export const sharedVitestConfig = {
         ),
       },
       {
+        find: "@openclaw/net-policy/url-protocol",
+        replacement: path.join(repoRoot, "packages", "net-policy", "src", "url-protocol.ts"),
+      },
+      {
         find: "@openclaw/net-policy/url-userinfo",
         replacement: path.join(repoRoot, "packages", "net-policy", "src", "url-userinfo.ts"),
       },

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -208,6 +208,7 @@
       "@openclaw/net-policy/redact-sensitive-url": [
         "./packages/net-policy/src/redact-sensitive-url.ts"
       ],
+      "@openclaw/net-policy/url-protocol": ["./packages/net-policy/src/url-protocol.ts"],
       "@openclaw/net-policy/url-userinfo": ["./packages/net-policy/src/url-userinfo.ts"],
       "@openclaw/net-policy/*": ["./packages/net-policy/src/*"],
       "@openclaw/web-content-core": ["./packages/web-content-core/src/index.ts"],

--- a/tsdown.config.ts
+++ b/tsdown.config.ts
@@ -387,6 +387,7 @@ function buildNetPolicyDistEntries(): Record<string, string> {
     ip: "packages/net-policy/src/ip.ts",
     ipv4: "packages/net-policy/src/ipv4.ts",
     "redact-sensitive-url": "packages/net-policy/src/redact-sensitive-url.ts",
+    "url-protocol": "packages/net-policy/src/url-protocol.ts",
     "url-userinfo": "packages/net-policy/src/url-userinfo.ts",
   };
 }


### PR DESCRIPTION
## What Problem This Solves

OpenClaw had repeated HTTP(S) and WebSocket URL syntax checks across config, proxy, media, plugin-install, and gateway artifact paths. Those copies encoded the same contracts separately, making case, whitespace, malformed-input, and URL parsing behavior easier to drift.

## Why This Change Was Made

Adds a focused `@openclaw/net-policy/url-protocol` surface for raw HTTP(S) prefix recognition and parsed HTTP, HTTPS, and WebSocket protocol predicates, then migrates only callers with identical contracts. SSRF/private-network policy, URL canonicalization, endpoint defaults, path handling, DNS, and transport behavior remain unchanged and separately owned.

## User Impact

No intended user-visible behavior change. Developers get one tested URL protocol contract, while production code removes duplicate predicates and parse wrappers with a net reduction in production LOC.

## Evidence

- `node scripts/run-vitest.mjs packages/net-policy/src/url-protocol.test.ts src/acp/event-mapper.test.ts src/config/zod-schema.proxy.test.ts src/config/schema.test.ts src/gateway/server-methods/artifacts.test.ts src/infra/net/proxy/proxy-lifecycle.test.ts src/infra/net/proxy/proxy-validation.test.ts src/media-understanding/runtime.test.ts src/media/media-reference.test.ts src/media/parse.test.ts src/media/web-media.test.ts src/plugins/git-install.test.ts src/plugins/marketplace.test.ts src/plugins/sdk-alias.test.ts` — 489 tests passed across 8 shards.
- `pnpm build` — passed.
- `node --import tsx scripts/check-import-cycles.ts` — 0 runtime value cycles.
- Blacksmith Testbox through Crabbox `tbx_01kwn6ctmkz3mjj707mxavcdqa` — `check:changed` passed; Actions run 28688397107.
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main --prompt-file tmp/autoreview-scope.md --stream-engine-output` — clean, no accepted/actionable findings (0.98 confidence).
