### PR TITLE
policy: repair channel ingress findings

### DIFF
--- a/docs/cli/policy.md
+++ b/docs/cli/policy.md
@@ -947,6 +947,10 @@ workspace config:
   `agents.list[].tools.deny` when policy requires those tools to be denied
 - set insecure `gateway.controlUi.*` toggles to `false`
 - set `gateway.mode=local` when policy denies remote gateway mode
+- set reported channel ingress `groupPolicy` paths to `allowlist` when policy
+  denies open group ingress
+- set reported channel ingress `requireMention` paths to `true` when policy
+  requires group mentions
 - set `logging.redactSensitive=tools` when policy requires sensitive logging
   redaction
 - set `diagnostics.otel.captureContent=false`, or
@@ -962,6 +966,10 @@ Scoped required-deny repairs are skipped when the finding reports inherited
 root `tools.deny`, because adding the required tool to root config would affect
 more than the scoped policy target. Agent-local required-deny repairs can update
 the reported `agents.list[].tools.deny` path.
+
+Scoped channel ingress repairs are skipped when the finding reports inherited
+`channels.defaults.*`, because changing the shared channel default would affect
+more than the scoped policy target.
 
 ```jsonc
 {

--- a/extensions/policy/src/doctor/automatic-repairs.ts
+++ b/extensions/policy/src/doctor/automatic-repairs.ts
@@ -22,6 +22,8 @@ const AUTOMATIC_REPAIR_CHECK_IDS = new Set<PolicyCheckId>([
   CHECK_IDS.policyToolsRequiredDenyMissing,
   CHECK_IDS.policyGatewayControlUiInsecure,
   CHECK_IDS.policyGatewayRemoteEnabled,
+  CHECK_IDS.policyIngressOpenGroupsDenied,
+  CHECK_IDS.policyIngressGroupMentionRequired,
   CHECK_IDS.policyDataHandlingRedactionDisabled,
   CHECK_IDS.policyDataHandlingTelemetryContentCapture,
 ]);
@@ -95,6 +97,10 @@ function applyAutomaticPatch(
       return disableInsecureControlUi(cfg, findings);
     case CHECK_IDS.policyGatewayRemoteEnabled:
       return disableRemoteGatewayMode(cfg, findings);
+    case CHECK_IDS.policyIngressOpenGroupsDenied:
+      return setFindingConfigValues(cfg, findings, "groupPolicy", "allowlist");
+    case CHECK_IDS.policyIngressGroupMentionRequired:
+      return setFindingConfigValues(cfg, findings, "requireMention", true);
     case CHECK_IDS.policyDataHandlingRedactionDisabled:
       if (hasScopedPolicyRequirement(findings)) {
         return skippedUnsafeScopedRepair(
@@ -245,6 +251,29 @@ function disableTelemetryContentCapture(cfg: OpenClawConfig): RepairPatch {
   };
 }
 
+function setFindingConfigValues(
+  cfg: OpenClawConfig,
+  findings: readonly HealthFinding[],
+  fieldName: string,
+  value: unknown,
+): RepairPatch {
+  const next = cloneConfig(cfg);
+  const changes: string[] = [];
+  for (const finding of findings) {
+    if (
+      finding.ocPath === undefined ||
+      configPathSegments(finding.ocPath).at(-1) !== fieldName ||
+      !setValueAtOcPath(next, finding.ocPath, value)
+    ) {
+      continue;
+    }
+    changes.push(`Set ${configPathLabel(finding.ocPath)}=${String(value)} for policy conformance.`);
+  }
+  return changes.length > 0
+    ? { config: next as OpenClawConfig, changes: uniqueStrings(changes) }
+    : { config: cfg, changes };
+}
+
 function cloneConfig(cfg: OpenClawConfig): ConfigRecord {
   return structuredClone(cfg) as ConfigRecord;
 }
@@ -298,7 +327,15 @@ function configPathSegments(ocPath: string): readonly string[] {
   if (!ocPath.startsWith(prefix)) {
     return [];
   }
-  return ocPath.slice(prefix.length).split("/").filter(Boolean);
+  return ocPath
+    .slice(prefix.length)
+    .split("/")
+    .filter(Boolean)
+    .map((segment) =>
+      segment.length >= 2 && segment.startsWith('"') && segment.endsWith('"')
+        ? segment.slice(1, -1)
+        : segment,
+    );
 }
 
 function configPathLabel(ocPath: string): string {
@@ -315,6 +352,40 @@ function configPathLabel(ocPath: string): string {
 
 function missingRequiredTool(finding: HealthFinding): string | undefined {
   return finding.message.match(/required tool '([^']+)'/)?.[1]?.trim();
+}
+
+function setValueAtOcPath(cfg: ConfigRecord, ocPath: string, value: unknown): boolean {
+  const segments = configPathSegments(ocPath);
+  if (segments.length === 0) {
+    return false;
+  }
+  let current: unknown = cfg;
+  for (let index = 0; index < segments.length - 1; index += 1) {
+    const segment = segments[index];
+    if (segment === undefined || segment.startsWith("#")) {
+      return false;
+    }
+    if (!isRecord(current)) {
+      return false;
+    }
+    const existing = current[segment];
+    if (existing !== undefined && !isRecord(existing)) {
+      return false;
+    }
+    if (existing === undefined) {
+      current[segment] = {};
+    }
+    current = current[segment];
+  }
+  if (!isRecord(current)) {
+    return false;
+  }
+  const last = segments.at(-1);
+  if (last === undefined || last.startsWith("#") || current[last] === value) {
+    return false;
+  }
+  current[last] = value;
+  return true;
 }
 
 function workspaceRepairsEnabled(ctx: HealthRepairContext): boolean {

--- a/extensions/policy/src/doctor/automatic-repairs.ts
+++ b/extensions/policy/src/doctor/automatic-repairs.ts
@@ -259,7 +259,14 @@ function setFindingConfigValues(
 ): RepairPatch {
   const next = cloneConfig(cfg);
   const changes: string[] = [];
+  const warnings: string[] = [];
   for (const finding of findings) {
+    if (isScopedInheritedChannelDefaultFinding(finding)) {
+      warnings.push(
+        `Skipped scoped channel ingress repair for ${configPathLabel(finding.ocPath ?? "")}. The finding reports inherited channels.defaults config, so changing it would affect more than the scoped channel target.`,
+      );
+      continue;
+    }
     if (
       finding.ocPath === undefined ||
       configPathSegments(finding.ocPath).at(-1) !== fieldName ||
@@ -270,8 +277,8 @@ function setFindingConfigValues(
     changes.push(`Set ${configPathLabel(finding.ocPath)}=${String(value)} for policy conformance.`);
   }
   return changes.length > 0
-    ? { config: next as OpenClawConfig, changes: uniqueStrings(changes) }
-    : { config: cfg, changes };
+    ? { config: next as OpenClawConfig, changes: uniqueStrings(changes), warnings }
+    : { config: cfg, changes, warnings: uniqueStrings(warnings) };
 }
 
 function cloneConfig(cfg: OpenClawConfig): ConfigRecord {
@@ -327,15 +334,41 @@ function configPathSegments(ocPath: string): readonly string[] {
   if (!ocPath.startsWith(prefix)) {
     return [];
   }
-  return ocPath
-    .slice(prefix.length)
-    .split("/")
-    .filter(Boolean)
-    .map((segment) =>
-      segment.length >= 2 && segment.startsWith('"') && segment.endsWith('"')
-        ? segment.slice(1, -1)
-        : segment,
-    );
+  return splitConfigPath(ocPath.slice(prefix.length));
+}
+
+function splitConfigPath(path: string): readonly string[] {
+  const segments: string[] = [];
+  let current = "";
+  let quoted = false;
+  let escaped = false;
+  for (const char of path) {
+    if (escaped) {
+      current += char;
+      escaped = false;
+      continue;
+    }
+    if (quoted && char === "\\") {
+      escaped = true;
+      continue;
+    }
+    if (char === '"') {
+      quoted = !quoted;
+      continue;
+    }
+    if (!quoted && char === "/") {
+      if (current !== "") {
+        segments.push(current);
+      }
+      current = "";
+      continue;
+    }
+    current += char;
+  }
+  if (current !== "") {
+    segments.push(current);
+  }
+  return quoted ? [] : segments;
 }
 
 function configPathLabel(ocPath: string): string {
@@ -413,6 +446,13 @@ function hasScopedPolicyRequirement(findings: readonly HealthFinding[]): boolean
 
 function skippedUnsafeScopedRepair(cfg: OpenClawConfig, warning: string): RepairPatch {
   return { config: cfg, changes: [], warnings: [warning] };
+}
+
+function isScopedInheritedChannelDefaultFinding(finding: HealthFinding): boolean {
+  return (
+    hasScopedPolicyRequirement([finding]) &&
+    finding.ocPath?.startsWith("oc://openclaw.config/channels/defaults/") === true
+  );
 }
 
 function ensureRecord(parent: ConfigRecord, key: string): ConfigRecord {

--- a/extensions/policy/src/doctor/register.test.ts
+++ b/extensions/policy/src/doctor/register.test.ts
@@ -1803,6 +1803,97 @@ describe("registerPolicyDoctorChecks", () => {
     });
   });
 
+  it("repairs quoted channel ingress paths without splitting slash segments", async () => {
+    const configPath = join(workspaceDir, "openclaw.jsonc");
+    const cfg = {
+      ...cfgWithPolicy({ workspaceRepairs: true }),
+      channels: {
+        "team/sebby": {
+          requireMention: false,
+        },
+      },
+    } as unknown as OpenClawConfig;
+    await fs.writeFile(configPath, "{}", "utf-8");
+    await fs.writeFile(
+      join(workspaceDir, "policy.jsonc"),
+      JSON.stringify({
+        ingress: {
+          channels: {
+            requireMentionInGroups: true,
+          },
+        },
+      }),
+      "utf-8",
+    );
+
+    const result = await runPolicyRepairCheck(
+      "policy/ingress-group-mention-required",
+      repairCtx(configPath, cfg),
+    );
+
+    expect(result.status).toBe("repaired");
+    expect(result.findings).toEqual([
+      expect.objectContaining({
+        ocPath: 'oc://openclaw.config/channels/"team/sebby"/requireMention',
+      }),
+    ]);
+    expect(result.changes).toEqual([
+      "Set channels.team/sebby.requireMention=true for policy conformance.",
+    ]);
+    expect(result.remainingFindings).toEqual([]);
+    expect(result.config.channels?.["team/sebby"]).toEqual({ requireMention: true });
+    expect(result.config.channels).not.toHaveProperty('"team');
+  });
+
+  it("skips scoped channel ingress repairs that would mutate inherited defaults", async () => {
+    const configPath = join(workspaceDir, "openclaw.jsonc");
+    const cfg = {
+      ...cfgWithPolicy({ workspaceRepairs: true }),
+      channels: {
+        defaults: { groupPolicy: "open" },
+        telegram: {},
+      },
+    } as unknown as OpenClawConfig;
+    await fs.writeFile(configPath, "{}", "utf-8");
+    await fs.writeFile(
+      join(workspaceDir, "policy.jsonc"),
+      JSON.stringify({
+        scopes: {
+          telegram: {
+            channelIds: ["telegram"],
+            ingress: {
+              channels: {
+                denyOpenGroups: true,
+              },
+            },
+          },
+        },
+      }),
+      "utf-8",
+    );
+
+    const result = await runPolicyRepairCheck(
+      "policy/ingress-open-groups-denied",
+      repairCtx(configPath, cfg),
+    );
+
+    expect(result.status).toBe("skipped");
+    expect(result.reason).toBe("policy automatic repair had no config changes to apply");
+    expect(result.changes).toEqual([]);
+    expect(result.warnings).toEqual([
+      "Skipped scoped channel ingress repair for channels.defaults.groupPolicy. The finding reports inherited channels.defaults config, so changing it would affect more than the scoped channel target.",
+    ]);
+    expect(result.config.channels?.defaults).toEqual({ groupPolicy: "open" });
+    expect(result.config.channels?.telegram).toEqual({});
+    expect(result.remainingFindings).toEqual([
+      expect.objectContaining({
+        checkId: "policy/ingress-open-groups-denied",
+        ocPath: "oc://openclaw.config/channels/defaults/groupPolicy",
+        requirement: "oc://policy.jsonc/scopes/telegram/ingress/channels/denyOpenGroups",
+      }),
+    ]);
+  });
+
   it("does not repair channel ingress config without workspace repair opt-in", async () => {
     const configPath = join(workspaceDir, "openclaw.jsonc");
     const cfg = {
@@ -1829,7 +1920,8 @@ describe("registerPolicyDoctorChecks", () => {
 
     expect(result.status).toBe("skipped");
     expect(result.reason).toBe("workspace repairs are disabled");
-    expect(result.changes).toEqual([
+    expect(result.changes).toEqual([]);
+    expect(result.warnings).toEqual([
       "Skipped policy config repair. Enable plugins.entries.policy.config.workspaceRepairs to let doctor --fix edit workspace policy config.",
     ]);
     expect(result.config.channels?.telegram).toEqual({ groupPolicy: "open" });

--- a/extensions/policy/src/doctor/register.test.ts
+++ b/extensions/policy/src/doctor/register.test.ts
@@ -1739,6 +1739,102 @@ describe("registerPolicyDoctorChecks", () => {
     });
   });
 
+  it("repairs automatic channel ingress narrowing findings", async () => {
+    const configPath = join(workspaceDir, "openclaw.jsonc");
+    const cfg = {
+      ...cfgWithPolicy({ workspaceRepairs: true }),
+      channels: {
+        telegram: {
+          groupPolicy: "open",
+          requireMention: false,
+          groups: {
+            ops: {
+              topics: {
+                incidents: { requireMention: false },
+              },
+            },
+          },
+        },
+      },
+    } as unknown as OpenClawConfig;
+    await fs.writeFile(configPath, "{}", "utf-8");
+    await fs.writeFile(
+      join(workspaceDir, "policy.jsonc"),
+      JSON.stringify({
+        ingress: {
+          channels: {
+            denyOpenGroups: true,
+            requireMentionInGroups: true,
+          },
+        },
+      }),
+      "utf-8",
+    );
+
+    const openGroups = await runPolicyRepairCheck(
+      "policy/ingress-open-groups-denied",
+      repairCtx(configPath, cfg),
+    );
+    const mentions = await runPolicyRepairCheck(
+      "policy/ingress-group-mention-required",
+      repairCtx(configPath, openGroups.config),
+    );
+
+    expect([...openGroups.changes, ...mentions.changes]).toEqual([
+      "Set channels.telegram.groupPolicy=allowlist for policy conformance.",
+      "Set channels.telegram.groups.ops.topics.incidents.requireMention=true for policy conformance.",
+      "Set channels.telegram.requireMention=true for policy conformance.",
+    ]);
+    expect(mentions.remainingFindings).toEqual([]);
+    expect(mentions.config).toMatchObject({
+      channels: {
+        telegram: {
+          groupPolicy: "allowlist",
+          requireMention: true,
+          groups: {
+            ops: {
+              topics: {
+                incidents: { requireMention: true },
+              },
+            },
+          },
+        },
+      },
+    });
+  });
+
+  it("does not repair channel ingress config without workspace repair opt-in", async () => {
+    const configPath = join(workspaceDir, "openclaw.jsonc");
+    const cfg = {
+      ...cfgWithPolicy(),
+      channels: { telegram: { groupPolicy: "open" } },
+    } as unknown as OpenClawConfig;
+    await fs.writeFile(configPath, "{}", "utf-8");
+    await fs.writeFile(
+      join(workspaceDir, "policy.jsonc"),
+      JSON.stringify({
+        ingress: {
+          channels: {
+            denyOpenGroups: true,
+          },
+        },
+      }),
+      "utf-8",
+    );
+
+    const result = await runPolicyRepairCheck(
+      "policy/ingress-open-groups-denied",
+      repairCtx(configPath, cfg),
+    );
+
+    expect(result.status).toBe("skipped");
+    expect(result.reason).toBe("workspace repairs are disabled");
+    expect(result.changes).toEqual([
+      "Skipped policy config repair. Enable plugins.entries.policy.config.workspaceRepairs to let doctor --fix edit workspace policy config.",
+    ]);
+    expect(result.config.channels?.telegram).toEqual({ groupPolicy: "open" });
+  });
+
   it("dry-runs required tool deny repairs without mutating config", async () => {
     const configPath = join(workspaceDir, "openclaw.jsonc");
     const cfg = {

--- a/extensions/policy/src/doctor/scopes/channels.ts
+++ b/extensions/policy/src/doctor/scopes/channels.ts
@@ -1,5 +1,6 @@
 // Policy doctor health-check factories for one policy scope.
 import type { HealthCheck } from "openclaw/plugin-sdk/health";
+import { repairPolicyAutomaticNarrower } from "../automatic-repairs.js";
 import { CHECK_IDS } from "../metadata.js";
 import type { PolicyDoctorCheckDeps } from "../types.js";
 
@@ -84,6 +85,9 @@ export function createPolicyIngressChecks(deps: PolicyDoctorCheckDeps): readonly
     async detect(ctx) {
       return findingsForCheck(await evaluatePolicy(ctx), CHECK_IDS.policyIngressOpenGroupsDenied);
     },
+    async repair(ctx, findings) {
+      return repairPolicyAutomaticNarrower(ctx, findings, CHECK_IDS.policyIngressOpenGroupsDenied);
+    },
   };
   const policyIngressGroupMentionRequiredCheck: HealthCheck = {
     id: CHECK_IDS.policyIngressGroupMentionRequired,
@@ -93,6 +97,13 @@ export function createPolicyIngressChecks(deps: PolicyDoctorCheckDeps): readonly
     async detect(ctx) {
       return findingsForCheck(
         await evaluatePolicy(ctx),
+        CHECK_IDS.policyIngressGroupMentionRequired,
+      );
+    },
+    async repair(ctx, findings) {
+      return repairPolicyAutomaticNarrower(
+        ctx,
+        findings,
         CHECK_IDS.policyIngressGroupMentionRequired,
       );
     },

--- a/src/commands/doctor-lint.test.ts
+++ b/src/commands/doctor-lint.test.ts
@@ -242,6 +242,10 @@ describe("runDoctorLintCli", () => {
             checkId: "plugin/example/lint",
             severity: "info",
             message: "plugin finding",
+            fixRecommendation: {
+              fixClass: "manual",
+              summary: "Review the plugin finding.",
+            },
           },
         ];
       },
@@ -281,6 +285,10 @@ describe("runDoctorLintCli", () => {
             checkId: "plugin/example/lint",
             severity: "info",
             message: "plugin finding",
+            fixRecommendation: {
+              fixClass: "manual",
+              summary: "Review the plugin finding.",
+            },
           },
         ];
       },
@@ -302,6 +310,10 @@ describe("runDoctorLintCli", () => {
           checkId: "plugin/example/lint",
           severity: "info",
           message: "plugin finding",
+          fixRecommendation: {
+            fixClass: "manual",
+            summary: "Review the plugin finding.",
+          },
         },
       ]);
     } finally {

--- a/src/commands/doctor-lint.test.ts
+++ b/src/commands/doctor-lint.test.ts
@@ -242,10 +242,7 @@ describe("runDoctorLintCli", () => {
             checkId: "plugin/example/lint",
             severity: "info",
             message: "plugin finding",
-            fixRecommendation: {
-              fixClass: "manual",
-              summary: "Review the plugin finding.",
-            },
+            fixHint: "Review the plugin finding.",
           },
         ];
       },
@@ -285,10 +282,7 @@ describe("runDoctorLintCli", () => {
             checkId: "plugin/example/lint",
             severity: "info",
             message: "plugin finding",
-            fixRecommendation: {
-              fixClass: "manual",
-              summary: "Review the plugin finding.",
-            },
+            fixHint: "Review the plugin finding.",
           },
         ];
       },
@@ -310,10 +304,7 @@ describe("runDoctorLintCli", () => {
           checkId: "plugin/example/lint",
           severity: "info",
           message: "plugin finding",
-          fixRecommendation: {
-            fixClass: "manual",
-            summary: "Review the plugin finding.",
-          },
+          fixHint: "Review the plugin finding.",
         },
       ]);
     } finally {

--- a/src/commands/doctor-lint.ts
+++ b/src/commands/doctor-lint.ts
@@ -164,6 +164,5 @@ function toJsonFinding(f: HealthFinding): Record<string, unknown> {
     ...(f.target !== undefined ? { target: f.target } : {}),
     ...(f.requirement !== undefined ? { requirement: f.requirement } : {}),
     ...(f.fixHint !== undefined ? { fixHint: f.fixHint } : {}),
-    ...(f.fixRecommendation !== undefined ? { fixRecommendation: f.fixRecommendation } : {}),
   };
 }

--- a/src/commands/doctor-lint.ts
+++ b/src/commands/doctor-lint.ts
@@ -164,5 +164,6 @@ function toJsonFinding(f: HealthFinding): Record<string, unknown> {
     ...(f.target !== undefined ? { target: f.target } : {}),
     ...(f.requirement !== undefined ? { requirement: f.requirement } : {}),
     ...(f.fixHint !== undefined ? { fixHint: f.fixHint } : {}),
+    ...(f.fixRecommendation !== undefined ? { fixRecommendation: f.fixRecommendation } : {}),
   };
 }


### PR DESCRIPTION
## Summary

- Add the channel ingress automatic repair slice after merged #99700.
- Repair `policy/ingress-open-groups-denied` by setting the exact reported `groupPolicy` path to `allowlist`.
- Repair `policy/ingress-group-mention-required` by setting the exact reported `requireMention` path to `true`.
- Keep the existing `workspaceRepairs=true` opt-in and skip scoped findings that inherit shared `channels.defaults.*` config.
- Document the expanded policy repair surface for channel ingress repairs.

## Validation

Pre-restack validation on the same policy repair diff:
- `node scripts/run-vitest.mjs extensions/policy/src/doctor/register.test.ts extensions/policy/src/cli.test.ts src/commands/doctor-lint.test.ts src/flows/doctor-repair-flow.test.ts --reporter=dot` passed: 3 shards / 350 tests.
- `node scripts/run-tsgo.mjs -p tsconfig.extensions.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/extensions.tsbuildinfo` passed.
- `OPENCLAW_OXLINT_SKIP_PREPARE=1 node scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.extensions.json extensions/policy/src/cli.ts extensions/policy/src/doctor/automatic-repairs.ts extensions/policy/src/doctor/register.test.ts extensions/policy/src/doctor/scopes/channels.ts src/commands/doctor-lint.test.ts src/commands/doctor-lint.ts` passed.
- `node --import tsx scripts/check-policy-config-coverage.ts --check --json` passed with no unclassified, unmatched, or stale monitored paths.
- `git diff --check` passed.

Post-#99700-merge restack validation:
- Replayed the two commits onto current `upstream/main` without conflicts.
- Added docs coverage for the ingress repair surface and inherited-default skip.
- `git diff --stat upstream/main...HEAD` shows six files: 332 insertions / 1 deletion.
- `git diff --check` passed.

## Stack

- #99700 has merged.
- Current head: `d5ed28d6`.
- Marked ready for review; waiting on refreshed non-draft CI after the doctor-lint type fix.

## Real behavior proof

Behavior or issue addressed:
`doctor --fix` repairs policy channel ingress narrowing findings by updating only the reported OpenClaw config path for `groupPolicy` or `requireMention`, while skipping scoped inherited `channels.defaults.*` findings that would mutate shared defaults.

Real environment tested:
Windows PowerShell disposable source checkout with dependencies installed by `pnpm install --frozen-lockfile`. The behavior proof was captured at `2b77202638d52c6f888a6908c22458ec3cf66487`; the later `d5ed28d6c77f9b47188c10805d0a3aeb9dc06cac` commit only removes generic doctor-lint recommendation serialization and does not change the channel ingress repair path. The proof used the dev CLI `pnpm openclaw doctor --fix --yes` against an isolated `OPENCLAW_HOME`, `OPENCLAW_STATE_DIR`, `OPENCLAW_CONFIG_PATH`, and `agents.defaults.workspace`; no live provider or LLM call was started.

Exact steps or command run after this patch:
1. `pnpm install --frozen-lockfile`
2. Seed isolated `openclaw.jsonc` with `plugins.entries.policy.config.workspaceRepairs=true`, `agents.defaults.workspace=<temp>`, `channels.telegram.groupPolicy="open"`, and `channels.telegram.groups.ops.topics.incidents.requireMention=false`.
3. Seed `<temp>/policy.jsonc` with `ingress.channels.denyOpenGroups=true` and `ingress.channels.requireMentionInGroups=true`.
4. `pnpm openclaw doctor --fix --yes`
5. Supporting source-entry proof: `node --import tsx .\proof-99720.mts`
6. Supporting validation: focused Vitest, extension tsgo, targeted oxlint, policy config coverage, and `git diff --check`.

Evidence after fix:
```text
CLI2_ROOT=C:\Users\giodl\AppData\Local\Temp\oc-policy-ingress-cli-127272f216ce44c9902db114fd45f4fb
CLI2_BEFORE={"telegram":{"groups":{"ops":{"topics":{"incidents":{"requireMention":false}}}},"groupPolicy":"open"}}

Doctor changes:
  Set channels.telegram.groupPolicy=allowlist for policy conformance.
  Set channels.telegram.groups.ops.topics.incidents.requireMention=true for policy conformance.

Updated config: $OPENCLAW_HOME\openclaw.jsonc
Doctor complete.

CLI2_AFTER={"telegram":{"groups":{"ops":{"topics":{"incidents":{"requireMention":true}}}},"groupPolicy":"allowlist"}}
```

Supporting source-entry transcript from the real Policy doctor registration, `runDoctorHealthRepairs`, and `replaceConfigFile`:
```text
HEAD=2b77202638d52c6f888a6908c22458ec3cf66487
BEFORE_FINDINGS=[{"checkId":"policy/ingress-open-groups-denied","target":"oc://openclaw.config/channels/telegram/groupPolicy","ocPath":"oc://openclaw.config/channels/telegram/groupPolicy"},{"checkId":"policy/ingress-group-mention-required","target":"oc://openclaw.config/channels/telegram/groups/ops/topics/incidents/requireMention","ocPath":"oc://openclaw.config/channels/telegram/groups/ops/topics/incidents/requireMention"},{"checkId":"policy/ingress-group-mention-required","target":"oc://openclaw.config/channels/telegram/requireMention","ocPath":"oc://openclaw.config/channels/telegram/requireMention"}]
CHANGES=["Set channels.telegram.groupPolicy=allowlist for policy conformance.","Set channels.telegram.groups.ops.topics.incidents.requireMention=true for policy conformance.","Set channels.telegram.requireMention=true for policy conformance."]
AFTER_CONFIG={"groupPolicy":"allowlist","requireMention":true,"topicRequireMention":true}
REMAINING_FINDINGS=0
AFTER_FINDINGS=[]
```

Observed result after fix:
The dev CLI started with an open Telegram group policy and a disabled nested mention gate, printed the policy repair changes, wrote the isolated config, and the persisted config reread showed `groupPolicy="allowlist"` and nested `requireMention=true`. The source-entry re-detect also returned zero remaining channel ingress findings after persisting the repaired config.

What was not tested:
No live provider run, live channel delivery, or live LLM call was run for this proof.


