### PR TITLE
refactor: consolidate async timing helpers

### DIFF
--- a/extensions/browser/src/browser/cdp.helpers.ts
+++ b/extensions/browser/src/browser/cdp.helpers.ts
@@ -5,6 +5,7 @@
  * redaction/headers, and request/response correlation over WebSocket.
  */
 import { parseBrowserHttpUrl, redactCdpUrl } from "openclaw/plugin-sdk/browser-config";
+import { sleep } from "openclaw/plugin-sdk/runtime-env";
 import { fetchWithSsrFGuard } from "openclaw/plugin-sdk/ssrf-runtime";
 import WebSocket from "ws";
 import { isLoopbackHost } from "../gateway/net.js";
@@ -422,12 +423,6 @@ type CdpSocketOptions = {
   handshakeRetryDelayMs?: number;
   handshakeMaxRetryDelayMs?: number;
 };
-
-function sleep(ms: number): Promise<void> {
-  return new Promise((resolve) => {
-    setTimeout(resolve, ms);
-  });
-}
 
 function normalizeRetryCount(value: number | undefined, fallback: number): number {
   if (typeof value !== "number" || !Number.isFinite(value)) {

--- a/extensions/browser/src/browser/routes/agent.act.ts
+++ b/extensions/browser/src/browser/routes/agent.act.ts
@@ -4,6 +4,7 @@
  * Dispatches normalized actions to either Playwright-backed OpenClaw browser
  * control or Chrome MCP existing-session operations with navigation guards.
  */
+import { sleep } from "openclaw/plugin-sdk/runtime-env";
 import { formatErrorMessage } from "../../infra/errors.js";
 import {
   clickChromeMcpElement,
@@ -50,12 +51,6 @@ import { EXISTING_SESSION_LIMITS } from "./existing-session-limits.js";
 import { readRoutePositiveInteger, readRouteTimerTimeoutMs } from "./route-numeric.js";
 import type { BrowserRouteRegistrar } from "./types.js";
 import { asyncBrowserRoute, jsonError, toStringOrEmpty } from "./utils.js";
-
-function sleep(ms: number): Promise<void> {
-  return new Promise((resolve) => {
-    setTimeout(resolve, ms);
-  });
-}
 
 const EXISTING_SESSION_INTERACTION_NAVIGATION_RECHECK_DELAYS_MS = [0, 250, 500] as const;
 

--- a/extensions/codex/src/migration/apply.ts
+++ b/extensions/codex/src/migration/apply.ts
@@ -22,6 +22,7 @@ import type {
   MigrationPlan,
   MigrationProviderContext,
 } from "openclaw/plugin-sdk/plugin-entry";
+import { sleep } from "openclaw/plugin-sdk/runtime-env";
 import { uniqueStrings } from "openclaw/plugin-sdk/string-coerce-runtime";
 import { defaultCodexAppInventoryCache } from "../app-server/app-inventory-cache.js";
 import {
@@ -383,12 +384,6 @@ function isCodexPluginLoadWarningItem(item: MigrationItem): boolean {
     item.status === "warning" &&
     item.details?.warningReason === CODEX_PLUGIN_LOAD_WARNING
   );
-}
-
-async function sleep(ms: number): Promise<void> {
-  await new Promise((resolve) => {
-    setTimeout(resolve, ms);
-  });
 }
 
 async function buildTargetCodexPluginAppCacheKey(ctx: MigrationProviderContext): Promise<string> {

--- a/extensions/discord/src/monitor/message-handler.process.ts
+++ b/extensions/discord/src/monitor/message-handler.process.ts
@@ -38,7 +38,7 @@ import {
   resolveSendableOutboundReplyParts,
 } from "openclaw/plugin-sdk/reply-payload";
 import type { ReplyDispatchKind, ReplyPayload } from "openclaw/plugin-sdk/reply-runtime";
-import { danger, logVerbose, shouldLogVerbose } from "openclaw/plugin-sdk/runtime-env";
+import { danger, logVerbose, shouldLogVerbose, sleep } from "openclaw/plugin-sdk/runtime-env";
 import { getSessionEntry, resolveStorePath } from "openclaw/plugin-sdk/session-store-runtime";
 import { readLatestAssistantTextByIdentity } from "openclaw/plugin-sdk/session-transcript-runtime";
 import { resolveDiscordAccount, resolveDiscordMaxLinesPerMessage } from "../accounts.js";
@@ -70,12 +70,6 @@ import {
   DISCORD_ATTACHMENT_IDLE_TIMEOUT_MS,
   DISCORD_ATTACHMENT_TOTAL_TIMEOUT_MS,
 } from "./timeouts.js";
-
-function sleep(ms: number): Promise<void> {
-  return new Promise((resolve) => {
-    setTimeout(resolve, ms);
-  });
-}
 
 const loadReplyRuntime = createLazyRuntimeModule(() => import("openclaw/plugin-sdk/reply-runtime"));
 

--- a/extensions/feishu/src/app-registration.ts
+++ b/extensions/feishu/src/app-registration.ts
@@ -1,5 +1,6 @@
 // Feishu plugin module implements app registration behavior.
 import { finiteSecondsToTimerSafeMilliseconds } from "openclaw/plugin-sdk/number-runtime";
+import { sleep } from "openclaw/plugin-sdk/runtime-env";
 /**
  * Feishu app registration via OAuth device-code flow.
  *
@@ -338,12 +339,6 @@ export async function getAppOwnerOpenId(params: {
   } catch {
     return undefined;
   }
-}
-
-function sleep(ms: number): Promise<void> {
-  return new Promise((resolve) => {
-    setTimeout(resolve, ms);
-  });
 }
 
 function sleepRegistrationPollInterval(intervalSeconds: number): Promise<void> {

--- a/extensions/imessage/src/send.ts
+++ b/extensions/imessage/src/send.ts
@@ -15,6 +15,7 @@ import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import { resolveMarkdownTableMode } from "openclaw/plugin-sdk/markdown-table-runtime";
 import { kindFromMime, resolveOutboundAttachmentFromUrl } from "openclaw/plugin-sdk/media-runtime";
 import { requireRuntimeConfig } from "openclaw/plugin-sdk/plugin-config-runtime";
+import { sleep as delay } from "openclaw/plugin-sdk/runtime-env";
 import { convertMarkdownTables } from "openclaw/plugin-sdk/text-chunking";
 import { stripInlineDirectiveTagsForDelivery } from "openclaw/plugin-sdk/text-chunking";
 import { resolveIMessageAccount, type ResolvedIMessageAccount } from "./accounts.js";
@@ -417,12 +418,6 @@ async function resolveApprovalBindingMessageGuid(params: {
       messageId,
     }),
   );
-}
-
-function delay(ms: number): Promise<void> {
-  return new Promise((resolve) => {
-    setTimeout(resolve, ms);
-  });
 }
 
 async function resolveFallbackSentMessageGuid(params: {

--- a/extensions/memory-core/src/memory/watch-settle.ts
+++ b/extensions/memory-core/src/memory/watch-settle.ts
@@ -1,6 +1,7 @@
 // Memory Core plugin module implements watch settle behavior.
 import fsSync from "node:fs";
 import path from "node:path";
+import { sleep as delay } from "openclaw/plugin-sdk/runtime-env";
 
 export type MemoryWatchEventStats = {
   isDirectory?: () => boolean;
@@ -44,12 +45,6 @@ function snapshotPath(filePath: string): WatchPathSnapshot | null {
   } catch {
     return null;
   }
-}
-
-async function delay(ms: number): Promise<void> {
-  await new Promise<void>((resolve) => {
-    setTimeout(resolve, ms);
-  });
 }
 
 export function recordMemoryWatchEventPath(

--- a/extensions/memory-core/src/short-term-promotion.ts
+++ b/extensions/memory-core/src/short-term-promotion.ts
@@ -9,6 +9,7 @@ import {
   isSameMemoryDreamingDay,
 } from "openclaw/plugin-sdk/memory-core-host-status";
 import { appendMemoryHostEvent } from "openclaw/plugin-sdk/memory-host-events";
+import { sleep } from "openclaw/plugin-sdk/runtime-env";
 import {
   normalizeLowercaseStringOrEmpty,
   normalizeStringEntries,
@@ -845,12 +846,6 @@ function isProcessLikelyAlive(pid: number): boolean {
     // EPERM and unknown errors are treated as alive to avoid stealing active locks.
     return true;
   }
-}
-
-async function sleep(ms: number): Promise<void> {
-  await new Promise<void>((resolve) => {
-    setTimeout(resolve, ms);
-  });
 }
 
 async function withInProcessShortTermLock<T>(lockPath: string, task: () => Promise<T>): Promise<T> {

--- a/extensions/qqbot/src/engine/api/media-chunked.ts
+++ b/extensions/qqbot/src/engine/api/media-chunked.ts
@@ -37,6 +37,7 @@
 import * as crypto from "node:crypto";
 import type { FileHandle } from "node:fs/promises";
 import { readResponseTextLimited } from "openclaw/plugin-sdk/provider-http";
+import { sleep } from "openclaw/plugin-sdk/runtime-env";
 import { fetchWithSsrFGuard } from "openclaw/plugin-sdk/ssrf-runtime";
 import type { MediaSource, OpenedLocalFile } from "../messaging/media-source.js";
 import { openLocalFile } from "../messaging/media-source.js";
@@ -630,10 +631,4 @@ async function runWithConcurrency(
     const batch = tasks.slice(i, i + maxConcurrent);
     await Promise.all(batch.map((task) => task()));
   }
-}
-
-function sleep(ms: number): Promise<void> {
-  return new Promise((resolve) => {
-    setTimeout(resolve, ms);
-  });
 }

--- a/extensions/qqbot/src/engine/api/retry.ts
+++ b/extensions/qqbot/src/engine/api/retry.ts
@@ -10,6 +10,7 @@
  * parameterized by `RetryPolicy` and optional `PersistentRetryPolicy`.
  */
 
+import { sleep } from "openclaw/plugin-sdk/runtime-env";
 import type { EngineLogger } from "../types.js";
 import { formatErrorMessage } from "../utils/format.js";
 
@@ -144,12 +145,6 @@ async function persistentRetryLoop<T>(
     `[qqbot:retry] Persistent retry timed out after ${policy.timeoutMs / 1000}s (${attempt} attempts)`,
   );
   throw lastError ?? new Error(`Persistent retry timed out (${policy.timeoutMs / 1000}s)`);
-}
-
-function sleep(ms: number): Promise<void> {
-  return new Promise((resolve) => {
-    setTimeout(resolve, ms);
-  });
 }
 
 // ============ Pre-built Retry Policies ============

--- a/extensions/signal/src/monitor/event-handler.ts
+++ b/extensions/signal/src/monitor/event-handler.ts
@@ -44,7 +44,12 @@ import { dispatchInboundMessage } from "openclaw/plugin-sdk/reply-runtime";
 import { createReplyDispatcherWithTyping } from "openclaw/plugin-sdk/reply-runtime";
 import { settleReplyDispatcher } from "openclaw/plugin-sdk/reply-runtime";
 import { resolveAgentRoute, resolveInboundLastRouteSessionKey } from "openclaw/plugin-sdk/routing";
-import { danger, logVerbose, shouldLogVerbose } from "openclaw/plugin-sdk/runtime-env";
+import {
+  danger,
+  logVerbose,
+  shouldLogVerbose,
+  sleep as delay,
+} from "openclaw/plugin-sdk/runtime-env";
 import { resolvePinnedMainDmOwnerFromAllowlist } from "openclaw/plugin-sdk/security-runtime";
 import { readSessionUpdatedAt, resolveStorePath } from "openclaw/plugin-sdk/session-store-runtime";
 import { normalizeOptionalString } from "openclaw/plugin-sdk/string-coerce-runtime";
@@ -139,12 +144,6 @@ function hasSignalStatusReplyDeliveryFailure(result: SignalStatusDispatchResult)
     (failedCounts?.block ?? 0) > 0 ||
     (failedCounts?.final ?? 0) > 0
   );
-}
-
-function delay(ms: number): Promise<void> {
-  return new Promise((resolve) => {
-    setTimeout(resolve, ms);
-  });
 }
 
 function resolveSignalStatusReactionEmojis(

--- a/extensions/xai/xai-oauth.ts
+++ b/extensions/xai/xai-oauth.ts
@@ -5,7 +5,6 @@ import {
   resolveExpiresAtMsFromDurationSeconds,
   resolveExpiresAtMsFromEpochSeconds,
 } from "openclaw/plugin-sdk/number-runtime";
-import { readResponseWithLimit } from "openclaw/plugin-sdk/response-limit-runtime";
 import type { ProviderAuthContext, ProviderAuthMethod } from "openclaw/plugin-sdk/plugin-entry";
 import {
   buildOauthProviderAuthResult,
@@ -13,6 +12,8 @@ import {
   type OAuthCredential,
   type ProviderAuthResult,
 } from "openclaw/plugin-sdk/provider-auth";
+import { readResponseWithLimit } from "openclaw/plugin-sdk/response-limit-runtime";
+import { sleep } from "openclaw/plugin-sdk/runtime-env";
 import { applyXaiConfig, XAI_DEFAULT_MODEL_REF } from "./onboard.js";
 import { xaiUserAgent } from "./src/xai-user-agent.js";
 
@@ -297,12 +298,6 @@ function describeXaiOAuthTokenFailure(params: {
       : formatXaiOAuthError({ context, status, body: body.json }),
     retryable: isCloudflareChallenge,
   };
-}
-
-async function sleep(ms: number): Promise<void> {
-  await new Promise<void>((resolve) => {
-    setTimeout(resolve, ms);
-  });
 }
 
 async function exchangeXaiOAuthToken(

--- a/scripts/check-gateway-watch-regression.mjs
+++ b/scripts/check-gateway-watch-regression.mjs
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
-
 // Measures gateway watch idle CPU and dist/runtime artifact churn.
+
 import { spawn, spawnSync } from "node:child_process";
 import fs from "node:fs";
 import net from "node:net";
@@ -14,6 +14,7 @@ import {
   writeBuildStamp,
   writeRuntimePostBuildStamp,
 } from "./lib/local-build-metadata.mjs";
+import { sleep } from "./lib/sleep.mjs";
 import { resolveBuildRequirement } from "./run-node.mjs";
 
 const DEFAULTS = {
@@ -332,12 +333,6 @@ function runCheckedCommand(command, args) {
     return;
   }
   throw new Error(`${command} ${args.join(" ")} failed with status ${result.status ?? "unknown"}`);
-}
-
-function sleep(ms) {
-  return new Promise((resolve) => {
-    setTimeout(resolve, ms);
-  });
 }
 
 function parsePsCpuTimeMs(timeText) {

--- a/scripts/control-ui-i18n.ts
+++ b/scripts/control-ui-i18n.ts
@@ -8,6 +8,7 @@ import { fileURLToPath, pathToFileURL } from "node:url";
 import { completeSimple, type AssistantMessage, type Model } from "openclaw/plugin-sdk/llm";
 import * as ts from "typescript";
 import { formatErrorMessage } from "../src/infra/errors.ts";
+import { sleep } from "./lib/sleep.mjs";
 import { resolveWindowsTaskkillPath } from "./lib/windows-taskkill.mjs";
 
 const { formatGeneratedModule } = (await import(
@@ -632,12 +633,6 @@ function buildBatchPrompt(items: readonly TranslationBatchItem[]): string {
     "",
     JSON.stringify(payload, null, 2),
   ].join("\n");
-}
-
-function sleep(ms: number) {
-  return new Promise((resolve) => {
-    setTimeout(resolve, ms);
-  });
 }
 
 function formatDuration(ms: number): string {

--- a/scripts/dev/discord-acp-plain-language-smoke.ts
+++ b/scripts/dev/discord-acp-plain-language-smoke.ts
@@ -17,6 +17,7 @@ import {
   redactForDevToolLog,
   redactHomePath,
 } from "../lib/dev-tooling-safety.ts";
+import { sleep } from "../lib/sleep.mjs";
 
 function writeStdoutLine(message: string): void {
   process.stdout.write(`${message}\n`);
@@ -155,12 +156,6 @@ const VALUE_OPTIONS = new Set([
 
 class CliArgumentError extends Error {
   override name = "CliArgumentError";
-}
-
-function sleep(ms: number): Promise<void> {
-  return new Promise((resolve) => {
-    setTimeout(resolve, ms);
-  });
 }
 
 function remainingTimeoutMs(deadlineMs: number, nowMs = Date.now()): number {

--- a/scripts/dev/tui-pty-test-watch.ts
+++ b/scripts/dev/tui-pty-test-watch.ts
@@ -4,6 +4,7 @@ import { mkdir, open, writeFile } from "node:fs/promises";
 import { createRequire } from "node:module";
 import path from "node:path";
 import { pathToFileURL } from "node:url";
+import { sleep as delay } from "../lib/sleep.mjs";
 import { resolveWindowsTaskkillPath } from "../lib/windows-taskkill.mjs";
 
 type Options = {
@@ -117,12 +118,6 @@ function parseOptions(args = process.argv.slice(2)): Options {
     mode: readMode(ownArgs),
     vitestArgs,
   };
-}
-
-function delay(ms: number): Promise<void> {
-  return new Promise((resolve) => {
-    setTimeout(resolve, ms);
-  });
 }
 
 function shouldUseAltScreen(options: Options) {

--- a/scripts/e2e/lib/config-reload/assert-log.mjs
+++ b/scripts/e2e/lib/config-reload/assert-log.mjs
@@ -1,4 +1,5 @@
 // Log assertions for config reload E2E scenarios.
+import { sleep } from "../../../lib/sleep.mjs";
 import { readPositiveIntEnv } from "../env-limits.mjs";
 import { createConfigReloadLogScanner } from "./log-scanner.mjs";
 
@@ -6,10 +7,6 @@ const logPath = process.env.OPENCLAW_CONFIG_RELOAD_LOG_PATH ?? "/tmp/config-relo
 const deadlineMs = Date.now() + readPositiveIntEnv("OPENCLAW_CONFIG_RELOAD_LOG_TIMEOUT_MS", 30_000);
 const maxReadBytes = readPositiveIntEnv("OPENCLAW_CONFIG_RELOAD_LOG_MAX_READ_BYTES", 256 * 1024);
 
-const sleep = (ms) =>
-  new Promise((resolve) => {
-    setTimeout(resolve, ms);
-  });
 const scanner = createConfigReloadLogScanner(logPath, {
   maxReadBytes,
   tailLineLimit: 160,

--- a/scripts/e2e/lib/gateway-network/client.mjs
+++ b/scripts/e2e/lib/gateway-network/client.mjs
@@ -1,15 +1,10 @@
 // WebSocket client helpers for gateway network E2E scenarios.
 import { pathToFileURL } from "node:url";
 import { WebSocket } from "ws";
+import { sleep as delay } from "../../../lib/sleep.mjs";
 import { waitForWebSocketOpen } from "../websocket-open.mjs";
 import { readGatewayNetworkClientConnectTimeoutMs } from "./limits.mjs";
 import { onceFrame } from "./ws-frames.mjs";
-
-function delay(ms) {
-  return new Promise((resolve) => {
-    setTimeout(resolve, ms);
-  });
-}
 
 function remainingDeadlineMs(deadline) {
   return Math.max(1, deadline - Date.now());

--- a/scripts/e2e/parallels/guest-transports.ts
+++ b/scripts/e2e/parallels/guest-transports.ts
@@ -1,5 +1,6 @@
 // Guest Transports script supports OpenClaw repository automation.
 import { randomUUID } from "node:crypto";
+import { sleep } from "../../lib/sleep.mjs";
 import { run } from "./host-command.ts";
 import type { PhaseRunner } from "./phase-runner.ts";
 import { encodePowerShell, psSingleQuote } from "./powershell.ts";
@@ -42,12 +43,6 @@ function appendOutput(
 
 function timeoutBefore(deadline: number, fallbackMs: number): number {
   return Math.min(fallbackMs, Math.max(1_000, deadline - Date.now()));
-}
-
-function sleep(ms: number): Promise<void> {
-  return new Promise((resolve) => {
-    setTimeout(resolve, ms);
-  });
 }
 
 function throwIfFailed(label: string, result: CommandResult, check: boolean | undefined): void {

--- a/scripts/e2e/parallels/host-server.ts
+++ b/scripts/e2e/parallels/host-server.ts
@@ -3,6 +3,7 @@ import { spawn, type ChildProcessWithoutNullStreams } from "node:child_process";
 import { createServer } from "node:http";
 import { createConnection } from "node:net";
 import path from "node:path";
+import { sleep as delay } from "../../lib/sleep.mjs";
 import { die, run, say, sh, warn } from "./host-command.ts";
 import type { HostServer } from "./types.ts";
 
@@ -192,12 +193,6 @@ async function canConnect(port: number): Promise<boolean> {
       socket.destroy();
       resolve(false);
     });
-  });
-}
-
-async function delay(ms: number): Promise<void> {
-  await new Promise((resolve) => {
-    setTimeout(resolve, ms);
   });
 }
 

--- a/scripts/e2e/parallels/package-artifact.ts
+++ b/scripts/e2e/parallels/package-artifact.ts
@@ -3,6 +3,7 @@ import { randomUUID } from "node:crypto";
 import { copyFile, mkdir, readFile, rm, stat, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
+import { sleep as delay } from "../../lib/sleep.mjs";
 import { readPositiveIntEnv } from "./env-limits.ts";
 import { exists, readJson } from "./filesystem.ts";
 import { die, repoRoot, run, say, sh } from "./host-command.ts";
@@ -292,12 +293,6 @@ function isProcessAlive(pid: number): boolean {
 
 function isErrorCode(error: unknown, code: string): boolean {
   return Boolean(error && typeof error === "object" && "code" in error && error.code === code);
-}
-
-async function delay(ms: number): Promise<void> {
-  await new Promise((resolve) => {
-    setTimeout(resolve, ms);
-  });
 }
 
 export const testing = {

--- a/scripts/e2e/telegram-user-crabbox-proof.ts
+++ b/scripts/e2e/telegram-user-crabbox-proof.ts
@@ -13,6 +13,7 @@ import os from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { clampTimerTimeoutMs } from "@openclaw/normalization-core/number-coercion";
+import { sleep } from "../lib/sleep.mjs";
 import { resolveWindowsTaskkillPath } from "../lib/windows-taskkill.mjs";
 import { createPnpmRunnerSpawnSpec } from "../pnpm-runner.mjs";
 import { readPositiveIntEnv } from "./lib/env-limits.mjs";
@@ -993,12 +994,6 @@ function spawnDaemon(params: {
   child.unref();
   fs.closeSync(log);
   return child.pid;
-}
-
-function sleep(ms: number) {
-  return new Promise((resolve) => {
-    setTimeout(resolve, ms);
-  });
 }
 
 function waitForChildExit(child: ChildProcess) {

--- a/scripts/lib/gateway-bench-child.ts
+++ b/scripts/lib/gateway-bench-child.ts
@@ -1,6 +1,9 @@
 // Gateway Bench Child script supports OpenClaw repository automation.
 import { spawnSync, type ChildProcessWithoutNullStreams } from "node:child_process";
+import { sleep as delay } from "./sleep.mjs";
 import { resolveWindowsTaskkillPath } from "./windows-taskkill.mjs";
+
+export { delay };
 
 const TEARDOWN_GRACE_MS = 2_000;
 const TEARDOWN_KILL_GRACE_MS = 1_000;
@@ -21,12 +24,6 @@ export type StopChildOptions = {
   runTaskkill?: typeof spawnSync;
   teardownGraceMs?: number;
 };
-
-export function delay(ms: number): Promise<void> {
-  return new Promise((resolve) => {
-    setTimeout(resolve, ms);
-  });
-}
 
 export async function stopChild(
   child: ChildProcessWithoutNullStreams,

--- a/scripts/lib/sleep.d.mts
+++ b/scripts/lib/sleep.d.mts
@@ -1,0 +1,2 @@
+/** Promise-based sleep that preserves the native global timer contract. */
+export declare function sleep(ms: number): Promise<void>;

--- a/scripts/lib/sleep.mjs
+++ b/scripts/lib/sleep.mjs
@@ -1,0 +1,6 @@
+/** Promise-based sleep that preserves the native global timer contract. */
+export function sleep(ms) {
+  return new Promise((resolve) => {
+    setTimeout(resolve, ms);
+  });
+}

--- a/scripts/measure-rpc-rtt.mjs
+++ b/scripts/measure-rpc-rtt.mjs
@@ -10,6 +10,7 @@ import path from "node:path";
 import { performance } from "node:perf_hooks";
 import { fileURLToPath, pathToFileURL } from "node:url";
 import { readBoundedResponseText } from "./lib/bounded-response.mjs";
+import { sleep } from "./lib/sleep.mjs";
 import { resolveWindowsTaskkillPath } from "./lib/windows-taskkill.mjs";
 
 const DEFAULT_METHODS = ["health", "config.get"];
@@ -136,12 +137,6 @@ async function getFreePort() {
         reject(new Error("failed to allocate loopback port"));
       });
     });
-  });
-}
-
-async function sleep(ms) {
-  await new Promise((resolve) => {
-    setTimeout(resolve, ms);
   });
 }
 

--- a/scripts/run-node.mjs
+++ b/scripts/run-node.mjs
@@ -21,6 +21,7 @@ import {
   writeBuildStamp as writeDistBuildStamp,
   writeRuntimePostBuildStamp as writeDistRuntimePostBuildStamp,
 } from "./lib/local-build-metadata.mjs";
+import { sleep } from "./lib/sleep.mjs";
 import {
   discoverStaticExtensionAssets,
   listStaticExtensionAssetSources,
@@ -685,11 +686,6 @@ const parsePositiveIntegerEnv = (env, name, fallback) => {
   const parsed = Number(raw);
   return Number.isInteger(parsed) && parsed > 0 ? parsed : fallback;
 };
-
-const sleep = (ms) =>
-  new Promise((resolve) => {
-    setTimeout(resolve, ms);
-  });
 
 const resolveRunNodeOutputLogPath = (deps) => {
   const outputLog = deps.env[RUN_NODE_OUTPUT_LOG_ENV]?.trim();

--- a/scripts/test-docker-all.mjs
+++ b/scripts/test-docker-all.mjs
@@ -28,6 +28,7 @@ import {
   parseProfile,
   resolveDockerE2ePlan,
 } from "./lib/docker-e2e-plan.mjs";
+import { sleep } from "./lib/sleep.mjs";
 
 const SCRIPT_ROOT_DIR = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
 const ROOT_DIR = path.resolve(process.env.OPENCLAW_DOCKER_E2E_REPO_ROOT || SCRIPT_ROOT_DIR);
@@ -224,12 +225,6 @@ function orderLanes(poolLanes, timingStore) {
     .map((poolLane, index) => ({ index, poolLane, seconds: timingSeconds(timingStore, poolLane) }))
     .toSorted((a, b) => b.seconds - a.seconds || a.index - b.index)
     .map(({ poolLane }) => poolLane);
-}
-
-function sleep(ms) {
-  return new Promise((resolve) => {
-    setTimeout(resolve, ms);
-  });
 }
 
 function utcStampForPath() {

--- a/scripts/verify-plugin-npm-published-runtime.mjs
+++ b/scripts/verify-plugin-npm-published-runtime.mjs
@@ -1,13 +1,14 @@
 #!/usr/bin/env node
-
 // Verifies published plugin npm packages include built runtime entries and
 // metadata expected by OpenClaw.
+
 import { execFileSync } from "node:child_process";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { pathToFileURL } from "node:url";
 import * as tar from "tar";
+import { sleep } from "./lib/sleep.mjs";
 
 const DEFAULT_NPM_COMMAND_TIMEOUT_MS = 5 * 60 * 1000;
 const DEFAULT_NPM_COMMAND_MAX_BUFFER_BYTES = 16 * 1024 * 1024;
@@ -269,12 +270,6 @@ export function parseNpmReadmeMetadata(raw) {
 
 function npmViewReadme(spec) {
   return runPluginNpmCommand(["view", spec, "readme", "--json", "--prefer-online"]);
-}
-
-function sleep(ms) {
-  return new Promise((resolve) => {
-    setTimeout(resolve, ms);
-  });
 }
 
 async function packPublishedPackage(spec, destinationDir) {

--- a/scripts/watch-node.mjs
+++ b/scripts/watch-node.mjs
@@ -7,6 +7,7 @@ import fs from "node:fs";
 import path from "node:path";
 import process from "node:process";
 import { pathToFileURL } from "node:url";
+import { sleep } from "./lib/sleep.mjs";
 import { isRestartRelevantRunNodePath, runNodeWatchedPaths } from "./run-node-watch-paths.mjs";
 
 const WATCH_NODE_RUNNER = "scripts/run-node.mjs";
@@ -94,11 +95,6 @@ const isProcessAlive = (pid, signalProcess) => {
   }
   return true;
 };
-
-const sleep = (ms) =>
-  new Promise((resolve) => {
-    setTimeout(resolve, ms);
-  });
 
 const createWatchLockKey = (cwd, args) =>
   createHash("sha256").update(cwd).update("\0").update(args.join("\0")).digest("hex").slice(0, 12);

--- a/src/cli/cron-cli/register.cron-simple.ts
+++ b/src/cli/cron-cli/register.cron-simple.ts
@@ -8,6 +8,7 @@ import type { Command } from "commander";
 import type { CronDeliveryPreview, CronJob } from "../../cron/types.js";
 import { parseStrictPositiveInteger } from "../../infra/parse-finite-number.js";
 import { defaultRuntime } from "../../runtime.js";
+import { sleep } from "../../utils/sleep.js";
 import type { GatewayRpcOpts } from "../gateway-rpc.js";
 import { addGatewayClientOptions, callGatewayFromCli } from "../gateway-rpc.js";
 import { parseDurationMs } from "../parse-duration.js";
@@ -35,12 +36,6 @@ type CronRunCommandResult = {
 type CronRunLogEntryResult = {
   status?: "ok" | "error" | "skipped";
 };
-
-function sleep(ms: number): Promise<void> {
-  return new Promise((resolve) => {
-    setTimeout(resolve, ms);
-  });
-}
 
 function parseCronRunWaitDuration(raw: unknown, label: string): number {
   const input =

--- a/src/commands/doctor-whatsapp-responsiveness.ts
+++ b/src/commands/doctor-whatsapp-responsiveness.ts
@@ -5,6 +5,7 @@ import { note } from "../../packages/terminal-core/src/note.js";
 import { formatCliCommand } from "../cli/command-format.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import type { HealthFinding } from "../flows/health-checks.js";
+import { sleep } from "../utils/sleep.js";
 import type { StatusSummary } from "./status.types.js";
 
 type LocalTuiProcess = {
@@ -139,12 +140,6 @@ function isProcessAlive(controller: ProcessController, pid: number): boolean {
   } catch {
     return false;
   }
-}
-
-async function sleep(ms: number): Promise<void> {
-  await new Promise((resolve) => {
-    setTimeout(resolve, ms);
-  });
 }
 
 /** Terminates local TUI processes with SIGTERM, then SIGKILL for remaining pids. */

--- a/src/config/io.clobber-snapshot.ts
+++ b/src/config/io.clobber-snapshot.ts
@@ -1,5 +1,6 @@
 // Detects suspicious config clobbers and finds recovery snapshots.
 import path from "node:path";
+import { sleep } from "../utils/sleep.js";
 
 /** Maximum retained clobbered-config snapshots per config file. */
 const CONFIG_CLOBBER_SNAPSHOT_LIMIT = 32;
@@ -50,12 +51,6 @@ function isFsErrorCode(error: unknown, code: string): boolean {
     typeof (error as { code?: unknown }).code === "string" &&
     (error as { code: string }).code === code
   );
-}
-
-function sleep(ms: number): Promise<void> {
-  return new Promise((resolve) => {
-    setTimeout(resolve, ms);
-  });
 }
 
 function resolveClobberPaths(configPath: string): {

--- a/src/gateway/agent-command.test-helpers.ts
+++ b/src/gateway/agent-command.test-helpers.ts
@@ -1,6 +1,7 @@
 // Gateway agent-command test helpers.
 // Waits for mocked agent command dispatches in async gateway tests.
 import { vi } from "vitest";
+import { sleep } from "../utils/sleep.js";
 import { agentCommand } from "./test-helpers.runtime-state.js";
 
 type AgentCommandCall = Record<string, unknown>;
@@ -8,11 +9,6 @@ type AgentCommandCall = Record<string, unknown>;
 function agentCommandCalls(): Array<[AgentCommandCall]> {
   return vi.mocked(agentCommand).mock.calls as unknown as Array<[AgentCommandCall]>;
 }
-
-const sleep = (ms: number) =>
-  new Promise<void>((resolve) => {
-    setTimeout(resolve, ms);
-  });
 
 /** Waits until the mocked `agentCommand` receives a call for a specific run id. */
 export async function waitForAgentCommandCall(runId: string): Promise<AgentCommandCall> {

--- a/src/gateway/gateway-cli-backend.live-helpers.ts
+++ b/src/gateway/gateway-cli-backend.live-helpers.ts
@@ -23,6 +23,7 @@ import {
 import { isTruthyEnvValue } from "../infra/env.js";
 import { getFreePortBlockWithPermissionFallback } from "../test-utils/ports.js";
 import { GATEWAY_CLIENT_MODES, GATEWAY_CLIENT_NAMES } from "../utils/message-channel.js";
+import { sleep } from "../utils/sleep.js";
 import { startGatewayClientWhenEventLoopReady } from "./client-start-readiness.js";
 import { GatewayClient, type GatewayClientOptions } from "./client.js";
 
@@ -309,12 +310,6 @@ export async function createBootstrapWorkspace(
   await fs.writeFile(path.join(workspaceDir, "IDENTITY.md"), `IDENTITY-${randomUUID()}\n`);
   await fs.writeFile(path.join(workspaceDir, "USER.md"), `USER-${randomUUID()}\n`);
   return { expectedInjectedFiles, workspaceDir, workspaceRootDir };
-}
-
-function sleep(ms: number): Promise<void> {
-  return new Promise((resolve) => {
-    setTimeout(resolve, ms);
-  });
 }
 
 export function shouldRetryCliCronMcpProbeReply(text: string): boolean {

--- a/src/gateway/gateway-cli-backend.live-probe-helpers.ts
+++ b/src/gateway/gateway-cli-backend.live-probe-helpers.ts
@@ -5,6 +5,7 @@ import { normalizeLowercaseStringOrEmpty } from "@openclaw/normalization-core/st
 import { renderCatFacePngBase64 } from "../../test/helpers/live-image-probe.js";
 import { isTruthyEnvValue } from "../infra/env.js";
 import { parseStrictPositiveInteger } from "../infra/parse-finite-number.js";
+import { sleep } from "../utils/sleep.js";
 import type { GatewayClient } from "./client.js";
 import {
   shouldRetryCliCronMcpProbeReply,
@@ -43,12 +44,6 @@ function logCliCronProbe(step: string, details?: Record<string, unknown>): void 
   }
   const suffix = details && Object.keys(details).length > 0 ? ` ${JSON.stringify(details)}` : "";
   console.error(`[gateway-cli-live:cron] ${step}${suffix}`);
-}
-
-function sleep(ms: number): Promise<void> {
-  return new Promise((resolve) => {
-    setTimeout(resolve, ms);
-  });
 }
 
 async function pollCliCronJobVisible(params: {

--- a/src/plugin-sdk/runtime-env.ts
+++ b/src/plugin-sdk/runtime-env.ts
@@ -16,7 +16,7 @@ export {
   success,
   warn,
 } from "../globals.js";
-export { sleep } from "../utils.js";
+export { sleep } from "../utils/sleep.js";
 export { withTimeout } from "../utils/with-timeout.js";
 export { isTruthyEnvValue } from "../infra/env.js";
 export * from "../logging.js";

--- a/src/talk/fast-context-runtime.test.ts
+++ b/src/talk/fast-context-runtime.test.ts
@@ -14,6 +14,7 @@ import { resolveRealtimeVoiceFastContextConsult } from "./fast-context-runtime.j
 
 describe("resolveRealtimeVoiceFastContextConsult", () => {
   afterEach(() => {
+    vi.useRealTimers();
     vi.restoreAllMocks();
     mocks.getActiveMemorySearchManager.mockReset();
   });
@@ -44,5 +45,38 @@ describe("resolveRealtimeVoiceFastContextConsult", () => {
     ).resolves.toEqual({ handled: false });
 
     expect(setTimeoutSpy).toHaveBeenCalledWith(expect.any(Function), MAX_TIMER_TIMEOUT_MS);
+  });
+
+  it("preserves the fast-context timeout error and clears the timer", async () => {
+    vi.useFakeTimers();
+    const logger = { debug: vi.fn() };
+    mocks.getActiveMemorySearchManager.mockResolvedValue({
+      manager: {
+        search: vi.fn(() => new Promise<never>(() => {})),
+      },
+    });
+
+    const result = resolveRealtimeVoiceFastContextConsult({
+      cfg: {},
+      agentId: "main",
+      sessionKey: "voice:15550001234",
+      config: {
+        enabled: true,
+        timeoutMs: 25,
+        maxResults: 3,
+        sources: ["memory", "sessions"],
+        fallbackToConsult: true,
+      },
+      args: { question: "What do you remember?" },
+      logger,
+    });
+
+    await vi.advanceTimersByTimeAsync(25);
+
+    await expect(result).resolves.toEqual({ handled: false });
+    expect(logger.debug).toHaveBeenCalledWith(
+      "[talk] fast context lookup failed: fast context lookup timed out after 25ms",
+    );
+    expect(vi.getTimerCount()).toBe(0);
   });
 });

--- a/src/talk/fast-context-runtime.ts
+++ b/src/talk/fast-context-runtime.ts
@@ -9,6 +9,7 @@ import { resolveTimerTimeoutMs } from "@openclaw/normalization-core/number-coerc
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { formatErrorMessage } from "../infra/errors.js";
 import { getActiveMemorySearchManager } from "../plugins/memory-runtime.js";
+import { withTimeout } from "../utils/with-timeout.js";
 import type { RealtimeVoiceAgentConsultResult } from "./agent-consult-runtime.js";
 import { parseRealtimeVoiceAgentConsultArgs } from "./agent-consult-tool.js";
 
@@ -112,28 +113,6 @@ function buildMissText(query: string, labels: RealtimeVoiceFastContextLabels): s
   ].join("\n\n");
 }
 
-async function withTimeout<T>(promise: Promise<T>, timeoutMs: number): Promise<T> {
-  const resolvedTimeoutMs = resolveTimerTimeoutMs(timeoutMs, 1);
-  let timer: ReturnType<typeof setTimeout> | undefined;
-  try {
-    return await Promise.race([
-      promise,
-      new Promise<T>((_resolve, reject) => {
-        // resolveTimerTimeoutMs caps huge configured deadlines before they
-        // reach Node's timer APIs.
-        timer = setTimeout(
-          () => reject(new RealtimeFastContextTimeoutError(resolvedTimeoutMs)),
-          resolvedTimeoutMs,
-        );
-      }),
-    ]);
-  } finally {
-    if (timer) {
-      clearTimeout(timer);
-    }
-  }
-}
-
 async function lookupFastContext(params: {
   cfg: OpenClawConfig;
   agentId: string;
@@ -178,6 +157,7 @@ export async function resolveRealtimeVoiceFastContextConsult(params: {
   const labels = resolveLabels(params.labels);
   const query = buildSearchQuery(params.args);
   try {
+    const timeoutMs = resolveTimerTimeoutMs(params.config.timeoutMs, 1);
     const lookup = await withTimeout(
       lookupFastContext({
         cfg: params.cfg,
@@ -186,7 +166,8 @@ export async function resolveRealtimeVoiceFastContextConsult(params: {
         config: params.config,
         query,
       }),
-      params.config.timeoutMs,
+      timeoutMs,
+      { createError: () => new RealtimeFastContextTimeoutError(timeoutMs) },
     );
     if (lookup.status === "unavailable") {
       params.logger.debug?.(`[talk] fast context unavailable: ${lookup.error}`);

--- a/src/tui/gateway-chat.ts
+++ b/src/tui/gateway-chat.ts
@@ -28,6 +28,7 @@ import { startGatewayClientWhenEventLoopReady } from "../gateway/client-start-re
 import { GatewayClient, GatewayClientRequestError } from "../gateway/client.js";
 import { isLoopbackHost } from "../gateway/net.js";
 import { formatErrorMessage } from "../infra/errors.js";
+import { sleep } from "../utils/sleep.js";
 import { VERSION } from "../version.js";
 import { TUI_SETUP_AUTH_SOURCE_CONFIG, TUI_SETUP_AUTH_SOURCE_ENV } from "./setup-launch-env.js";
 import type {
@@ -93,12 +94,6 @@ function resolveStartupRetryDelayMs(err: GatewayClientRequestError): number {
   const retryAfterMs =
     typeof err.retryAfterMs === "number" ? err.retryAfterMs : STARTUP_CHAT_HISTORY_DEFAULT_RETRY_MS;
   return Math.min(Math.max(retryAfterMs, 100), STARTUP_CHAT_HISTORY_MAX_RETRY_MS);
-}
-
-function sleep(ms: number): Promise<void> {
-  return new Promise((resolve) => {
-    setTimeout(resolve, ms);
-  });
 }
 
 function nonEmptyString(value: unknown): string | undefined {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -9,8 +9,8 @@ import {
   resolveRequiredHomeDir,
 } from "./infra/home-dir.js";
 import { isPlainObject } from "./infra/plain-object.js";
-import { resolveTimerTimeoutMs } from "./shared/number-coercion.js";
 export { escapeRegExp } from "./shared/regexp.js";
+export { sleep } from "./utils/sleep.js";
 
 /** Creates a directory tree if it does not already exist. */
 export async function ensureDir(dir: string) {
@@ -60,13 +60,6 @@ export function normalizeE164(number: string): string {
     return `+${digits.slice(1)}`;
   }
   return `+${digits}`;
-}
-
-/** Promise-based sleep that clamps timer inputs through the shared timeout resolver. */
-export function sleep(ms: number) {
-  return new Promise((resolve) => {
-    setTimeout(resolve, resolveTimerTimeoutMs(ms, 0, 0));
-  });
 }
 
 // Surrogate-safe slicing helpers live in a node-free leaf module so browser/UI

--- a/src/utils/sleep.ts
+++ b/src/utils/sleep.ts
@@ -1,0 +1,8 @@
+import { resolveTimerTimeoutMs } from "../shared/number-coercion.js";
+
+/** Promise-based sleep that clamps timer inputs through the shared timeout resolver. */
+export function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => {
+    setTimeout(resolve, resolveTimerTimeoutMs(ms, 0, 0));
+  });
+}

--- a/test/scripts/sleep.test.ts
+++ b/test/scripts/sleep.test.ts
@@ -1,0 +1,22 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { sleep } from "../../scripts/lib/sleep.mjs";
+
+describe("scripts/lib/sleep.mjs", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it.each([0, -1, Number.NaN, Number.POSITIVE_INFINITY])(
+    "preserves the native global timer delay for %s",
+    async (delayMs) => {
+      const setTimeoutSpy = vi.spyOn(globalThis, "setTimeout").mockImplementation((callback) => {
+        queueMicrotask(() => callback());
+        return 0 as unknown as ReturnType<typeof setTimeout>;
+      });
+
+      await expect(sleep(delayMs)).resolves.toBeUndefined();
+
+      expect(setTimeoutSpy).toHaveBeenCalledWith(expect.any(Function), delayMs);
+    },
+  );
+});


### PR DESCRIPTION
## What Problem This Solves

OpenClaw had many exact-contract `setTimeout` promise wrappers spread across core, bundled plugins, and scripts, plus a local `Promise.race` timeout that duplicated the shared timeout lifecycle. These copies obscured which timing differences were intentional and repeated timer mechanics across owner boundaries.

## Why This Change Was Made

- Reuses the existing clamped core `sleep` contract through a focused utility leaf and the Plugin SDK runtime export.
- Adds one scripts-boundary raw sleep helper for `.mjs` callers whose durations must be forwarded directly to global `setTimeout`.
- Reuses the existing `withTimeout` helper for realtime fast-context lookup while preserving duration normalization, custom error identity/message, race behavior, and timer cleanup.
- Leaves abortable sleeps, unref timers, retry/backoff/jitter policy, polling cadence, subprocess lifecycle, provider/channel timeout policy, and distinct deadline/result semantics with their current owners.
- Deletes 175 net non-test lines while keeping one canonical path per identical contract.

## User Impact

No intended user-visible behavior change. Timing resolution/rejection shapes, timer observability for fake clocks, zero/negative/infinite duration handling, and caller-specific timeout errors remain unchanged.

## Evidence

- `node scripts/run-vitest.mjs test/scripts/sleep.test.ts src/utils.test.ts src/talk/fast-context-runtime.test.ts extensions/feishu/src/app-registration.test.ts`
- Additional focused shards covered migrated browser, channel, memory, CLI, config, doctor, and talk callers.
- `check:changed` passed in Blacksmith Testbox `tbx_01kwn79rj5gdj387ryb9h4yf05` on exact head `da57a754670f` (Actions run 28688802468).
- Fresh branch autoreview reported no accepted/actionable findings and rated the patch correct with 0.96 confidence.
- `git diff --check origin/main...HEAD`
- Runtime import-cycle guard passed in the changed gate.
