### PR TITLE
fix(memory-wiki): preserve ChatGPT Notes dollar sequences

### DIFF
--- a/extensions/memory-wiki/src/chatgpt-import.ts
+++ b/extensions/memory-wiki/src/chatgpt-import.ts
@@ -583,7 +583,7 @@ function replaceSimpleManagedBlock(params: {
   const escapedStart = params.startMarker.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
   const escapedEnd = params.endMarker.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
   const blockPattern = new RegExp(`${escapedStart}[\\s\\S]*?${escapedEnd}`);
-  return params.original.replace(blockPattern, params.replacement);
+  return params.original.replace(blockPattern, () => params.replacement);
 }
 
 function extractSimpleManagedBlock(params: {

--- a/extensions/memory-wiki/src/wiki-notes-read-retry.test.ts
+++ b/extensions/memory-wiki/src/wiki-notes-read-retry.test.ts
@@ -479,6 +479,30 @@ describe("memory-wiki existing-page read retry", () => {
     expect(after).toContain(userNote);
   });
 
+  it("preserves ChatGPT Notes dollar sequences literally across re-import", async () => {
+    const { config, exportDir, pagePath } = await createChatGptImportFixture(
+      "memory-wiki-chatgpt-dollar-notes-",
+    );
+    const userNote = "Energy identity $$E=mc^2$$ and match $& and prefix $` and suffix $' end.";
+    const edited = (await fs.readFile(pagePath, "utf8")).replace(
+      "<!-- openclaw:human:start -->\n<!-- openclaw:human:end -->",
+      () => `<!-- openclaw:human:start -->\n${userNote}\n<!-- openclaw:human:end -->`,
+    );
+    await fs.writeFile(pagePath, edited, "utf8");
+
+    const second = await importChatGptConversations({
+      config,
+      exportPath: exportDir,
+      nowMs: Date.UTC(2026, 3, 6, 12, 0, 0),
+    });
+
+    const after = await fs.readFile(pagePath, "utf8");
+    expect(second.createdCount).toBe(0);
+    expect(after).toContain(
+      `<!-- openclaw:human:start -->\n${userNote}\n<!-- openclaw:human:end -->`,
+    );
+  });
+
   it("leaves a ChatGPT page unchanged after a persistent existing-page read failure", async () => {
     const { config, exportDir, pagePath } = await createChatGptImportFixture(
       "memory-wiki-chatgpt-persistent-read-",


### PR DESCRIPTION
Closes #99708.

## What Problem This Solves

Fixes an issue where Memory Wiki users re-importing ChatGPT exports could have human-authored Notes silently corrupted when the Notes text contained JavaScript replacement-pattern dollar sequences.

## Why This Change Was Made

The ChatGPT import preservation path now inserts the extracted human Notes block literally instead of passing it as a string replacement. A regression covers re-importing Notes with `$$`, `$&`, `$`` and `$'` so those sequences remain byte-for-byte user text.

## User Impact

Users can safely keep Markdown math and dollar-sign snippets in ChatGPT import Notes without losing or splicing content during a later import.

## Evidence

- `node scripts/run-vitest.mjs extensions/memory-wiki/src/wiki-notes-read-retry.test.ts extensions/memory-wiki/src/cli.test.ts`
- `node scripts/run-oxlint.mjs extensions/memory-wiki/src/chatgpt-import.ts extensions/memory-wiki/src/wiki-notes-read-retry.test.ts`
- `git diff --check`
