### PR TITLE
fix(cron): preserve on-exit watchers across hot reload

### DIFF
--- a/src/gateway/cron-exit-watchers.test.ts
+++ b/src/gateway/cron-exit-watchers.test.ts
@@ -144,6 +144,41 @@ describe("createCronExitWatchers", () => {
     expect(order).toEqual(["persist", "fire"]);
   });
 
+  it("uses updated handlers for a watcher that exits after hot reload", async () => {
+    const { supervisor, runs } = makeFakeSupervisor();
+    const oldPersistCompletion = vi.fn(async () => {});
+    const oldFireOnExit = vi.fn(async () => {});
+    const nextPersistCompletion = vi.fn(async () => {});
+    const nextFireOnExit = vi.fn(async () => {});
+    const w = createCronExitWatchers({
+      getProcessSupervisor: () => supervisor as never,
+      persistCompletion: oldPersistCompletion,
+      fireOnExit: oldFireOnExit,
+      logger: noopLogger,
+    });
+
+    w.reconcile([onExitJob("job-a")]);
+    await flush();
+    expect(supervisor.spawn).toHaveBeenCalledTimes(1);
+
+    w.updateHandlers({
+      getProcessSupervisor: () => supervisor as never,
+      persistCompletion: nextPersistCompletion,
+      fireOnExit: nextFireOnExit,
+      logger: noopLogger,
+    });
+    w.reconcile([onExitJob("job-a")]);
+    await flush();
+
+    runs[0].deferred.resolve({ exitCode: 0, reason: "exit" });
+    await flush();
+    expect(supervisor.spawn).toHaveBeenCalledTimes(1);
+    expect(oldPersistCompletion).not.toHaveBeenCalled();
+    expect(oldFireOnExit).not.toHaveBeenCalled();
+    expect(nextPersistCompletion).toHaveBeenCalledWith("job-a");
+    expect(nextFireOnExit).toHaveBeenCalledTimes(1);
+  });
+
   it("a fired job stays unarmed across a simulated restart (disabled in store → not re-run)", async () => {
     // persistCompletion disables the job; after a restart the reconcile sees a
     // disabled job and must NOT re-arm (which would re-run the command).

--- a/src/gateway/cron-exit-watchers.ts
+++ b/src/gateway/cron-exit-watchers.ts
@@ -31,6 +31,7 @@ export type CronExitWatchers = {
   cancel: (jobId: string) => void;
   cancelAll: () => void;
   activeJobIds: () => string[];
+  updateHandlers: (handlers: CronExitWatcherHandlers) => void;
 };
 
 const SCOPE_PREFIX = "cron-exit";
@@ -61,13 +62,19 @@ export function resolveExitWatchShell(platform: NodeJS.Platform = process.platfo
   return { command: "bash", argsFor: (command: string) => ["-lc", command] };
 }
 
-export function createCronExitWatchers(params: {
+export type CronExitWatcherHandlers = {
   getProcessSupervisor: () => ProcessSupervisor;
   persistCompletion: (jobId: string) => Promise<void>;
   fireOnExit: (job: CronJob, exit: CronExitResult) => void | Promise<void>;
   logger: Logger;
-  shell?: { command: string; argsFor: (command: string) => string[] };
-}): CronExitWatchers {
+};
+
+export function createCronExitWatchers(
+  params: CronExitWatcherHandlers & {
+    shell?: { command: string; argsFor: (command: string) => string[] };
+  },
+): CronExitWatchers {
+  let handlers: CronExitWatcherHandlers = params;
   const shell = params.shell ?? resolveExitWatchShell();
   // jobId -> watcher state. `armToken` identifies the current arm so an async
   // spawn/wait that loses ownership (the job was cancelled or re-armed for a
@@ -94,9 +101,9 @@ export function createCronExitWatchers(params: {
     // killed by the arm() ownership check once it resolves.
     slot.run?.cancel("manual-cancel");
     try {
-      params.getProcessSupervisor().cancelScope(scopeKey(jobId), "manual-cancel");
+      handlers.getProcessSupervisor().cancelScope(scopeKey(jobId), "manual-cancel");
     } catch (err) {
-      params.logger.warn({ err: String(err), jobId }, "cron-exit: cancel watcher failed");
+      handlers.logger.warn({ err: String(err), jobId }, "cron-exit: cancel watcher failed");
     }
   };
 
@@ -112,7 +119,7 @@ export function createCronExitWatchers(params: {
     void (async () => {
       let run: ManagedRun;
       try {
-        run = await params.getProcessSupervisor().spawn({
+        run = await handlers.getProcessSupervisor().spawn({
           sessionId: `cron-exit:${job.id}`,
           backendId: "cron-exit-watch",
           scopeKey: scopeKey(job.id),
@@ -131,7 +138,10 @@ export function createCronExitWatchers(params: {
         if (owns()) {
           active.delete(job.id);
         }
-        params.logger.warn({ err: String(err), jobId: job.id }, "cron-exit: watcher spawn failed");
+        handlers.logger.warn(
+          { err: String(err), jobId: job.id },
+          "cron-exit: watcher spawn failed",
+        );
         return;
       }
       if (!owns()) {
@@ -141,7 +151,10 @@ export function createCronExitWatchers(params: {
         return;
       }
       slot.run = run;
-      params.logger.info({ jobId: job.id, runId: run.runId, command }, "cron-exit: watcher armed");
+      handlers.logger.info(
+        { jobId: job.id, runId: run.runId, command },
+        "cron-exit: watcher armed",
+      );
       let exit: Awaited<ReturnType<ManagedRun["wait"]>>;
       try {
         exit = await run.wait();
@@ -152,7 +165,7 @@ export function createCronExitWatchers(params: {
         if (owns()) {
           active.delete(job.id);
         }
-        params.logger.warn(
+        handlers.logger.warn(
           { err: String(err), jobId: job.id },
           "cron-exit: run.wait() rejected; released watcher slot without firing",
         );
@@ -161,7 +174,7 @@ export function createCronExitWatchers(params: {
       if (!owns()) {
         return;
       }
-      params.logger.info(
+      handlers.logger.info(
         { jobId: job.id, exitCode: exit.exitCode, reason: exit.reason },
         "cron-exit: watched command exited; firing job",
       );
@@ -169,12 +182,12 @@ export function createCronExitWatchers(params: {
       // store write fails we do NOT wake — waking without a persisted terminal
       // state would let a gateway restart re-arm and re-run the command.
       try {
-        await params.persistCompletion(job.id);
+        await handlers.persistCompletion(job.id);
       } catch (err) {
         if (owns()) {
           active.delete(job.id);
         }
-        params.logger.warn(
+        handlers.logger.warn(
           { err: String(err), jobId: job.id },
           "cron-exit: persistCompletion failed; NOT firing (fail closed to avoid replay)",
         );
@@ -182,7 +195,7 @@ export function createCronExitWatchers(params: {
       }
       slot.fired = true;
       try {
-        await params.fireOnExit(slot.job, {
+        await handlers.fireOnExit(slot.job, {
           exitCode: exit.exitCode,
           reason: exit.reason,
           stdout: exit.stdout,
@@ -191,7 +204,7 @@ export function createCronExitWatchers(params: {
           noOutputTimedOut: exit.noOutputTimedOut,
         });
       } catch (err) {
-        params.logger.warn(
+        handlers.logger.warn(
           { err: String(err), jobId: job.id },
           "cron-exit: fireOnExit after exit failed",
         );
@@ -237,5 +250,8 @@ export function createCronExitWatchers(params: {
     cancel,
     cancelAll,
     activeJobIds: () => Array.from(active.keys()),
+    updateHandlers: (nextHandlers) => {
+      handlers = nextHandlers;
+    },
   };
 }

--- a/src/gateway/server-cron-lazy.test.ts
+++ b/src/gateway/server-cron-lazy.test.ts
@@ -149,6 +149,39 @@ describe("createLazyGatewayCronState", () => {
     expect(cron["start"]).toHaveBeenCalledTimes(1);
     expect(reconcileExitWatchers).not.toHaveBeenCalled();
   });
+
+  it("hands loaded exit watchers to hot reload without cancelling active watchers", async () => {
+    const cron = createCronService();
+    const stopCronForHotReload = vi.fn();
+    const stopExitWatchers = vi.fn();
+    const exitWatchers = {
+      reconcile: vi.fn(),
+      cancel: vi.fn(),
+      cancelAll: vi.fn(),
+      activeJobIds: vi.fn(() => ["watch-build"]),
+      updateHandlers: vi.fn(),
+    };
+    hoisted.setState(
+      createCronState(cron, {
+        stopCronForHotReload,
+        stopExitWatchers,
+        exitWatchers,
+      }),
+    );
+
+    const lazy = createLazyGatewayCronState(createParams());
+
+    expect(lazy.exitWatchers).toBeUndefined();
+
+    await lazy.cron.start();
+    lazy.stopCronForHotReload?.();
+
+    expect(lazy.exitWatchers).toBe(exitWatchers);
+    expect(stopCronForHotReload).toHaveBeenCalledTimes(1);
+    expect(cron["stop"]).not.toHaveBeenCalled();
+    expect(stopExitWatchers).not.toHaveBeenCalled();
+    expect(exitWatchers.cancelAll).not.toHaveBeenCalled();
+  });
 });
 
 function createParams(overrides: Partial<OpenClawConfig> = {}) {
@@ -161,11 +194,15 @@ function createParams(overrides: Partial<OpenClawConfig> = {}) {
   };
 }
 
-function createCronState(cron: CronServiceContract): GatewayCronState {
+function createCronState(
+  cron: CronServiceContract,
+  overrides: Partial<GatewayCronState> = {},
+): GatewayCronState {
   return {
     cron,
     storePath: "/tmp/openclaw-cron.json",
     cronEnabled: true,
+    ...overrides,
   } as GatewayCronState;
 }
 

--- a/src/gateway/server-cron-lazy.ts
+++ b/src/gateway/server-cron-lazy.ts
@@ -45,6 +45,40 @@ export function createLazyGatewayCronState(params: LazyGatewayCronParams): Gatew
     return await cronStateLoader.load();
   };
 
+  const stopLoadedCron = (
+    resolved: LoadedGatewayCronState,
+    opts: { cancelExitWatchers: boolean },
+  ) => {
+    resolved.started = false;
+    if (!opts.cancelExitWatchers && resolved.state.stopCronForHotReload) {
+      resolved.state.stopCronForHotReload();
+      return;
+    }
+    resolved.state.cron.stop();
+    if (opts.cancelExitWatchers) {
+      resolved.state.stopExitWatchers?.();
+    }
+  };
+
+  const stopCronForHotReload = () => {
+    stopped = true;
+    if (loaded) {
+      stopLoadedCron(loaded, { cancelExitWatchers: false });
+      return;
+    }
+    const loading = cronStateLoader.peek();
+    if (loading) {
+      void loading
+        .then((resolved) => {
+          if (!stopped) {
+            return;
+          }
+          stopLoadedCron(resolved, { cancelExitWatchers: false });
+        })
+        .catch(() => {});
+    }
+  };
+
   const cron: CronServiceContract = {
     async start() {
       stopped = false;
@@ -65,17 +99,13 @@ export function createLazyGatewayCronState(params: LazyGatewayCronParams): Gatew
       // If stop raced the lazy import/start path, immediately stop the loaded
       // scheduler so shutdown does not leave a background loop alive.
       if (stopped && resolved.started) {
-        resolved.started = false;
-        resolved.state.cron.stop();
-        resolved.state.stopExitWatchers?.();
+        stopLoadedCron(resolved, { cancelExitWatchers: true });
       }
     },
     stop() {
       stopped = true;
       if (loaded) {
-        loaded.started = false;
-        loaded.state.cron.stop();
-        loaded.state.stopExitWatchers?.();
+        stopLoadedCron(loaded, { cancelExitWatchers: true });
         return;
       }
       const loading = cronStateLoader.peek();
@@ -87,9 +117,7 @@ export function createLazyGatewayCronState(params: LazyGatewayCronParams): Gatew
             if (!stopped) {
               return;
             }
-            resolved.started = false;
-            resolved.state.cron.stop();
-            resolved.state.stopExitWatchers?.();
+            stopLoadedCron(resolved, { cancelExitWatchers: true });
           })
           .catch(() => {});
       }
@@ -148,5 +176,9 @@ export function createLazyGatewayCronState(params: LazyGatewayCronParams): Gatew
     cron,
     storePath,
     cronEnabled,
+    stopCronForHotReload,
+    get exitWatchers() {
+      return loaded?.state.exitWatchers;
+    },
   };
 }

--- a/src/gateway/server-cron.test.ts
+++ b/src/gateway/server-cron.test.ts
@@ -351,6 +351,39 @@ describe("buildGatewayCronService", () => {
     }
   });
 
+  it("reuses on-exit watchers for hot reload without cancelling active children", async () => {
+    vi.stubEnv("OPENCLAW_SKIP_CRON", "0");
+    const exitWatchers = {
+      reconcile: vi.fn(),
+      cancel: vi.fn(),
+      cancelAll: vi.fn(),
+      activeJobIds: vi.fn(() => ["job-a"]),
+      updateHandlers: vi.fn(),
+    };
+    const cfg = createCronConfig("server-cron-hot-reload-exit-watchers");
+    loadConfigMock.mockReturnValue(cfg);
+    const state = buildGatewayCronService({
+      cfg,
+      deps: {} as CliDeps,
+      broadcast: () => {},
+      exitWatchers,
+    });
+
+    try {
+      expect(state.exitWatchers).toBe(exitWatchers);
+      expect(exitWatchers.updateHandlers).toHaveBeenCalledTimes(1);
+
+      state.stopCronForHotReload?.();
+      expect(exitWatchers.cancelAll).not.toHaveBeenCalled();
+
+      state.cron.stop();
+      expect(exitWatchers.cancelAll).toHaveBeenCalledTimes(1);
+    } finally {
+      state.cron.stop();
+      vi.unstubAllEnvs();
+    }
+  });
+
   it("backs off isolated cron setup timeout without gateway restart", async () => {
     vi.useFakeTimers();
     const cfg = createCronConfig("server-cron-isolated-setup-timeout");

--- a/src/gateway/server-cron.ts
+++ b/src/gateway/server-cron.ts
@@ -56,7 +56,11 @@ import {
 } from "../routing/session-key.js";
 import { defaultRuntime } from "../runtime.js";
 import { parseAgentSessionKey } from "../sessions/session-key-utils.js";
-import { createCronExitWatchers, type CronExitResult } from "./cron-exit-watchers.js";
+import {
+  createCronExitWatchers,
+  type CronExitResult,
+  type CronExitWatchers,
+} from "./cron-exit-watchers.js";
 import {
   dispatchGatewayCronFinishedNotifications,
   sendGatewayCronFailureAlert,
@@ -68,6 +72,8 @@ export type GatewayCronState = {
   cronEnabled: boolean;
   reconcileExitWatchers?: () => Promise<void>;
   stopExitWatchers?: () => void;
+  stopCronForHotReload?: () => void;
+  exitWatchers?: CronExitWatchers;
 };
 
 function formatOnExitRunSummary(exit: CronExitResult): string {
@@ -191,6 +197,7 @@ export function buildGatewayCronService(params: {
   cfg: OpenClawConfig;
   deps: CliDeps;
   broadcast: (event: string, payload: unknown, opts?: { dropIfSlow?: boolean }) => void;
+  exitWatchers?: CronExitWatchers;
 }): GatewayCronState {
   const cronLogger = getChildLogger({ module: "cron" });
   const storePath = resolveCronJobsStorePath(params.cfg.cron?.store);
@@ -375,7 +382,7 @@ export function buildGatewayCronService(params: {
   };
 
   // Built after cron so watcher exit callbacks can call back into the service.
-  const exitWatchersRef: { current: ReturnType<typeof createCronExitWatchers> | undefined } = {
+  const exitWatchersRef: { current: CronExitWatchers | undefined } = {
     current: undefined,
   };
   const reconcileExitWatchers = async () => {
@@ -746,7 +753,7 @@ export function buildGatewayCronService(params: {
     },
   });
 
-  exitWatchersRef.current = createCronExitWatchers({
+  const exitWatcherHandlers = {
     getProcessSupervisor,
     persistCompletion: async (jobId) => {
       await cron.update(jobId, { enabled: false });
@@ -756,7 +763,9 @@ export function buildGatewayCronService(params: {
         run: (jobId, payload) => cron.run(jobId, "force", payload ? { payload } : undefined),
       }),
     logger: cronLogger,
-  });
+  } satisfies Parameters<typeof createCronExitWatchers>[0];
+  exitWatchersRef.current = params.exitWatchers ?? createCronExitWatchers(exitWatcherHandlers);
+  params.exitWatchers?.updateHandlers(exitWatcherHandlers);
   const stopCron = cron.stop.bind(cron);
   cron.stop = () => {
     stopCron();
@@ -769,5 +778,7 @@ export function buildGatewayCronService(params: {
     cronEnabled,
     reconcileExitWatchers,
     stopExitWatchers: () => exitWatchersRef.current?.cancelAll(),
+    stopCronForHotReload: stopCron,
+    exitWatchers: exitWatchersRef.current,
   };
 }

--- a/src/gateway/server-reload-handlers.test.ts
+++ b/src/gateway/server-reload-handlers.test.ts
@@ -70,6 +70,8 @@ const hoisted = vi.hoisted(() => ({
     cronEnabled: true,
     reconcileExitWatchers: vi.fn(async () => {}),
     stopExitWatchers: vi.fn(),
+    stopCronForHotReload: vi.fn(),
+    exitWatchers: undefined,
   })),
 }));
 
@@ -173,9 +175,18 @@ function createReloadHandlersForTest(
     start: (channel: ChannelKind) => Promise<void>;
     stop: (channel: ChannelKind) => Promise<void>;
   },
+  cronStateOverride?: unknown,
 ) {
   const cron = { start: vi.fn(async () => {}), stop: vi.fn() };
   const stopExitWatchers = vi.fn();
+  const stopCronForHotReload = vi.fn();
+  const exitWatchers = {
+    reconcile: vi.fn(),
+    cancel: vi.fn(),
+    cancelAll: vi.fn(),
+    activeJobIds: vi.fn(() => ["watch-build"]),
+    updateHandlers: vi.fn(),
+  };
   const heartbeatRunner = {
     stop: vi.fn(),
     updateConfig: vi.fn(),
@@ -188,12 +199,15 @@ function createReloadHandlersForTest(
       hooksConfig: {} as never,
       hookClientIpConfig: {} as never,
       heartbeatRunner: heartbeatRunner as never,
-      cronState: {
-        cron,
-        storePath: "/tmp/cron.json",
-        cronEnabled: false,
-        stopExitWatchers,
-      } as never,
+      cronState: (cronStateOverride ??
+        ({
+          cron,
+          storePath: "/tmp/cron.json",
+          cronEnabled: false,
+          stopExitWatchers,
+          stopCronForHotReload,
+          exitWatchers,
+        } as never)) as never,
       channelHealthMonitor: null,
     }),
     setState,
@@ -212,7 +226,15 @@ function createReloadHandlersForTest(
     logReload,
     createHealthMonitor: () => null,
   });
-  return { ...handlers, cron, heartbeatRunner, setState, stopExitWatchers };
+  return {
+    ...handlers,
+    cron,
+    heartbeatRunner,
+    setState,
+    stopExitWatchers,
+    stopCronForHotReload,
+    exitWatchers,
+  };
 }
 
 // Other gateway test helpers (test-helpers.mocks.ts, test-helpers.server.ts)
@@ -248,7 +270,7 @@ afterEach(() => {
 });
 
 describe("gateway hot reload model state", () => {
-  it("stops old cron exit watchers and reconciles rebuilt ones after cron restart", async () => {
+  it("preserves cron exit watchers and reconciles rebuilt handlers after cron restart", async () => {
     const newCron = { start: vi.fn(async () => {}), stop: vi.fn() };
     const newReconcileExitWatchers = vi.fn(async () => {});
     const rebuiltCronState = {
@@ -257,9 +279,12 @@ describe("gateway hot reload model state", () => {
       cronEnabled: true,
       reconcileExitWatchers: newReconcileExitWatchers,
       stopExitWatchers: vi.fn(),
+      stopCronForHotReload: vi.fn(),
+      exitWatchers: undefined,
     };
     hoisted.buildGatewayCronService.mockReturnValueOnce(rebuiltCronState);
-    const { applyHotReload, cron, setState, stopExitWatchers } = createReloadHandlersForTest();
+    const { applyHotReload, cron, setState, stopExitWatchers, stopCronForHotReload, exitWatchers } =
+      createReloadHandlersForTest();
 
     await applyHotReload(
       {
@@ -280,8 +305,12 @@ describe("gateway hot reload model state", () => {
       {} as OpenClawConfig,
     );
 
-    expect(cron.stop).toHaveBeenCalledTimes(1);
-    expect(stopExitWatchers).toHaveBeenCalledTimes(1);
+    expect(stopCronForHotReload).toHaveBeenCalledTimes(1);
+    expect(cron.stop).not.toHaveBeenCalled();
+    expect(stopExitWatchers).not.toHaveBeenCalled();
+    expect(hoisted.buildGatewayCronService).toHaveBeenCalledWith(
+      expect.objectContaining({ exitWatchers }),
+    );
     expect(newCron.start).toHaveBeenCalledTimes(1);
     await vi.waitFor(() => expect(newReconcileExitWatchers).toHaveBeenCalledTimes(1));
     expect(setState).toHaveBeenCalledWith(
@@ -289,6 +318,70 @@ describe("gateway hot reload model state", () => {
         cronState: rebuiltCronState,
       }),
     );
+  });
+
+  it("uses lazy cron exit watchers for the first restart after startup", async () => {
+    const lazyCron = { start: vi.fn(async () => {}), stop: vi.fn() };
+    const stopCronForHotReload = vi.fn();
+    const exitWatchers = {
+      reconcile: vi.fn(),
+      cancel: vi.fn(),
+      cancelAll: vi.fn(),
+      activeJobIds: vi.fn(() => ["watch-build"]),
+      updateHandlers: vi.fn(),
+    };
+    const newCron = { start: vi.fn(async () => {}), stop: vi.fn() };
+    const rebuiltCronState = {
+      cron: newCron,
+      storePath: "/tmp/rebuilt-cron.json",
+      cronEnabled: true,
+      reconcileExitWatchers: vi.fn(async () => {}),
+      stopExitWatchers: vi.fn(),
+      stopCronForHotReload: vi.fn(),
+      exitWatchers: undefined,
+    };
+    hoisted.buildGatewayCronService.mockReturnValueOnce(rebuiltCronState);
+    const lazyCronState = {
+      cron: lazyCron,
+      storePath: "/tmp/lazy-cron.json",
+      cronEnabled: true,
+      stopCronForHotReload,
+      get exitWatchers() {
+        return exitWatchers;
+      },
+    };
+    const { applyHotReload } = createReloadHandlersForTest(
+      { info: vi.fn(), warn: vi.fn() },
+      undefined,
+      lazyCronState,
+    );
+
+    await applyHotReload(
+      {
+        changedPaths: ["cron"],
+        restartGateway: false,
+        restartReasons: [],
+        hotReasons: ["cron"],
+        reloadHooks: false,
+        restartGmailWatcher: false,
+        restartCron: true,
+        restartHeartbeat: false,
+        restartHealthMonitor: false,
+        reloadPlugins: false,
+        restartChannels: new Set(),
+        disposeMcpRuntimes: false,
+        noopPaths: [],
+      },
+      {} as OpenClawConfig,
+    );
+
+    expect(stopCronForHotReload).toHaveBeenCalledTimes(1);
+    expect(lazyCron.stop).not.toHaveBeenCalled();
+    expect(hoisted.buildGatewayCronService).toHaveBeenCalledWith(
+      expect.objectContaining({ exitWatchers }),
+    );
+    expect(exitWatchers.cancelAll).not.toHaveBeenCalled();
+    expect(newCron.start).toHaveBeenCalledTimes(1);
   });
 
   it("resets prepared model runtime state for every hot reload and rewarms after plugin reload", async () => {

--- a/src/gateway/server-reload-handlers.test.ts
+++ b/src/gateway/server-reload-handlers.test.ts
@@ -389,6 +389,75 @@ describe("gateway hot reload model state", () => {
     );
   });
 
+  it("does not reuse cron exit watchers when cron is disabled", async () => {
+    const newCron = { start: vi.fn(async () => {}), stop: vi.fn() };
+    const rebuiltCronState = {
+      cron: newCron,
+      storePath: "/tmp/cron.json",
+      cronEnabled: false,
+      reconcileExitWatchers: vi.fn(async () => {}),
+      stopExitWatchers: vi.fn(),
+      stopCronForHotReload: vi.fn(),
+      exitWatchers: undefined,
+    };
+    hoisted.buildGatewayCronService.mockReturnValueOnce(rebuiltCronState);
+    const exitWatchers = {
+      reconcile: vi.fn(),
+      cancel: vi.fn(),
+      cancelAll: vi.fn(),
+      activeJobIds: vi.fn(() => ["watch-build"]),
+      updateHandlers: vi.fn(),
+    };
+    const stopExitWatchers = vi.fn(() => exitWatchers.cancelAll());
+    const stopCronForHotReload = vi.fn();
+    const cron = { start: vi.fn(async () => {}), stop: vi.fn(stopExitWatchers) };
+    const { applyHotReload, setState } = createReloadHandlersForTest(
+      { info: vi.fn(), warn: vi.fn() },
+      undefined,
+      {
+        cron,
+        storePath: "/tmp/cron.json",
+        cronEnabled: true,
+        stopExitWatchers,
+        stopCronForHotReload,
+        exitWatchers,
+      },
+    );
+
+    await applyHotReload(
+      {
+        changedPaths: ["cron.enabled"],
+        restartGateway: false,
+        restartReasons: [],
+        hotReasons: ["cron.enabled"],
+        reloadHooks: false,
+        restartGmailWatcher: false,
+        restartCron: true,
+        restartHeartbeat: false,
+        restartHealthMonitor: false,
+        reloadPlugins: false,
+        restartChannels: new Set(),
+        disposeMcpRuntimes: false,
+        noopPaths: [],
+      },
+      { cron: { enabled: false, store: "/tmp/cron.json" } } as OpenClawConfig,
+    );
+
+    expect(stopCronForHotReload).not.toHaveBeenCalled();
+    expect(cron.stop).toHaveBeenCalledTimes(1);
+    expect(stopExitWatchers).toHaveBeenCalledTimes(1);
+    expect(exitWatchers.cancelAll).toHaveBeenCalledTimes(1);
+    expect(hoisted.buildGatewayCronService).toHaveBeenCalledWith(
+      expect.objectContaining({ exitWatchers: undefined }),
+    );
+    expect(newCron.start).toHaveBeenCalledTimes(1);
+    expect(setState).toHaveBeenCalledWith(
+      expect.objectContaining({
+        cronState: rebuiltCronState,
+      }),
+    );
+  });
+
   it("uses lazy cron exit watchers for the first restart after startup", async () => {
     const lazyCron = { start: vi.fn(async () => {}), stop: vi.fn() };
     const stopCronForHotReload = vi.fn();

--- a/src/gateway/server-reload-handlers.test.ts
+++ b/src/gateway/server-reload-handlers.test.ts
@@ -302,7 +302,7 @@ describe("gateway hot reload model state", () => {
         disposeMcpRuntimes: false,
         noopPaths: [],
       },
-      {} as OpenClawConfig,
+      { cron: { store: "/tmp/cron.json" } } as OpenClawConfig,
     );
 
     expect(stopCronForHotReload).toHaveBeenCalledTimes(1);
@@ -313,6 +313,75 @@ describe("gateway hot reload model state", () => {
     );
     expect(newCron.start).toHaveBeenCalledTimes(1);
     await vi.waitFor(() => expect(newReconcileExitWatchers).toHaveBeenCalledTimes(1));
+    expect(setState).toHaveBeenCalledWith(
+      expect.objectContaining({
+        cronState: rebuiltCronState,
+      }),
+    );
+  });
+
+  it("does not reuse cron exit watchers when cron store changes", async () => {
+    const newCron = { start: vi.fn(async () => {}), stop: vi.fn() };
+    const rebuiltCronState = {
+      cron: newCron,
+      storePath: "/tmp/rebuilt-cron.json",
+      cronEnabled: true,
+      reconcileExitWatchers: vi.fn(async () => {}),
+      stopExitWatchers: vi.fn(),
+      stopCronForHotReload: vi.fn(),
+      exitWatchers: undefined,
+    };
+    hoisted.buildGatewayCronService.mockReturnValueOnce(rebuiltCronState);
+    const exitWatchers = {
+      reconcile: vi.fn(),
+      cancel: vi.fn(),
+      cancelAll: vi.fn(),
+      activeJobIds: vi.fn(() => ["watch-build"]),
+      updateHandlers: vi.fn(),
+    };
+    const stopExitWatchers = vi.fn(() => exitWatchers.cancelAll());
+    const stopCronForHotReload = vi.fn();
+    const cron = { start: vi.fn(async () => {}), stop: vi.fn(stopExitWatchers) };
+    const { applyHotReload, setState } = createReloadHandlersForTest(
+      { info: vi.fn(), warn: vi.fn() },
+      undefined,
+      {
+        cron,
+        storePath: "/tmp/cron.json",
+        cronEnabled: true,
+        stopExitWatchers,
+        stopCronForHotReload,
+        exitWatchers,
+      },
+    );
+
+    await applyHotReload(
+      {
+        changedPaths: ["cron.store"],
+        restartGateway: false,
+        restartReasons: [],
+        hotReasons: ["cron.store"],
+        reloadHooks: false,
+        restartGmailWatcher: false,
+        restartCron: true,
+        restartHeartbeat: false,
+        restartHealthMonitor: false,
+        reloadPlugins: false,
+        restartChannels: new Set(),
+        disposeMcpRuntimes: false,
+        noopPaths: [],
+      },
+      { cron: { store: "/tmp/rebuilt-cron.json" } } as OpenClawConfig,
+    );
+
+    expect(stopCronForHotReload).not.toHaveBeenCalled();
+    expect(cron.stop).toHaveBeenCalledTimes(1);
+    expect(stopExitWatchers).toHaveBeenCalledTimes(1);
+    expect(exitWatchers.cancelAll).toHaveBeenCalledTimes(1);
+    expect(hoisted.buildGatewayCronService).toHaveBeenCalledWith(
+      expect.objectContaining({ exitWatchers: undefined }),
+    );
+    expect(newCron.start).toHaveBeenCalledTimes(1);
     expect(setState).toHaveBeenCalledWith(
       expect.objectContaining({
         cronState: rebuiltCronState,
@@ -372,7 +441,7 @@ describe("gateway hot reload model state", () => {
         disposeMcpRuntimes: false,
         noopPaths: [],
       },
-      {} as OpenClawConfig,
+      { cron: { store: "/tmp/lazy-cron.json" } } as OpenClawConfig,
     );
 
     expect(stopCronForHotReload).toHaveBeenCalledTimes(1);

--- a/src/gateway/server-reload-handlers.ts
+++ b/src/gateway/server-reload-handlers.ts
@@ -469,8 +469,12 @@ export function createGatewayReloadHandlers(params: GatewayReloadHandlerParams) 
       params.onCronRestart?.();
       const stopCronForHotReload = state.cronState.stopCronForHotReload;
       const nextCronStorePath = resolveCronJobsStorePath(nextConfig.cron?.store);
+      const nextCronEnabled =
+        process.env.OPENCLAW_SKIP_CRON !== "1" && nextConfig.cron?.enabled !== false;
       const preserveCronExitWatchers =
-        state.cronState.storePath === nextCronStorePath && stopCronForHotReload !== undefined;
+        nextCronEnabled &&
+        state.cronState.storePath === nextCronStorePath &&
+        stopCronForHotReload !== undefined;
       // Hot reload keeps unchanged, same-store on-exit watcher children alive; the
       // rebuilt cron service updates their callbacks before reconcile cancels removed jobs.
       if (preserveCronExitWatchers) {

--- a/src/gateway/server-reload-handlers.ts
+++ b/src/gateway/server-reload-handlers.ts
@@ -17,6 +17,7 @@ import type { CliDeps } from "../cli/deps.types.js";
 import { isRestartEnabled } from "../config/commands.flags.js";
 import { getRuntimeConfig } from "../config/config.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { resolveCronJobsStorePath } from "../cron/store.js";
 import { isTruthyEnvValue } from "../infra/env.js";
 import { formatErrorMessage } from "../infra/errors.js";
 import type { HeartbeatRunner } from "../infra/heartbeat-runner.js";
@@ -466,10 +467,14 @@ export function createGatewayReloadHandlers(params: GatewayReloadHandlerParams) 
     }
     if (plan.restartCron) {
       params.onCronRestart?.();
-      // Hot reload keeps unchanged on-exit watcher children alive; the rebuilt
-      // cron service updates their callbacks before reconcile cancels removed jobs.
-      if (state.cronState.stopCronForHotReload) {
-        state.cronState.stopCronForHotReload();
+      const stopCronForHotReload = state.cronState.stopCronForHotReload;
+      const nextCronStorePath = resolveCronJobsStorePath(nextConfig.cron?.store);
+      const preserveCronExitWatchers =
+        state.cronState.storePath === nextCronStorePath && stopCronForHotReload !== undefined;
+      // Hot reload keeps unchanged, same-store on-exit watcher children alive; the
+      // rebuilt cron service updates their callbacks before reconcile cancels removed jobs.
+      if (preserveCronExitWatchers) {
+        stopCronForHotReload();
       } else {
         state.cronState.cron.stop();
       }
@@ -477,7 +482,7 @@ export function createGatewayReloadHandlers(params: GatewayReloadHandlerParams) 
         cfg: nextConfig,
         deps: params.deps,
         broadcast: params.broadcast,
-        exitWatchers: state.cronState.exitWatchers,
+        exitWatchers: preserveCronExitWatchers ? state.cronState.exitWatchers : undefined,
       });
       startGatewayCronWithLogging({
         cron: nextState.cronState.cron,

--- a/src/gateway/server-reload-handlers.ts
+++ b/src/gateway/server-reload-handlers.ts
@@ -466,12 +466,18 @@ export function createGatewayReloadHandlers(params: GatewayReloadHandlerParams) 
     }
     if (plan.restartCron) {
       params.onCronRestart?.();
-      state.cronState.cron.stop();
-      state.cronState.stopExitWatchers?.();
+      // Hot reload keeps unchanged on-exit watcher children alive; the rebuilt
+      // cron service updates their callbacks before reconcile cancels removed jobs.
+      if (state.cronState.stopCronForHotReload) {
+        state.cronState.stopCronForHotReload();
+      } else {
+        state.cronState.cron.stop();
+      }
       nextState.cronState = buildGatewayCronService({
         cfg: nextConfig,
         deps: params.deps,
         broadcast: params.broadcast,
+        exitWatchers: state.cronState.exitWatchers,
       });
       startGatewayCronWithLogging({
         cron: nextState.cronState.cron,


### PR DESCRIPTION
Closes #99709.

## What Problem This Solves

Fixes an issue where an on-exit cron watched command could be interrupted and re-executed when an unrelated `cron.*` config change triggered gateway hot reload.

## Why This Change Was Made

Cron hot reload now stops cron scheduling without using the shutdown path that cancels watcher children. The rebuilt cron service reuses the existing watcher manager, including the production lazy cron state, refreshes its callbacks, and lets reconciliation cancel only removed or changed jobs.

## User Impact

Operators can edit cron configuration while a watched deploy, migration, or other long-running command is in flight without causing that command to run twice.

## Evidence

Real behavior proof: ran a synthetic on-exit job through the real lazy gateway cron state and real `createGatewayReloadHandlers().applyHotReload` path. The watched command was a real child process that appended to a temp marker file, slept, and exited; a duplicate arm would append a second marker. The proof pinned OpenClaw config/state to a temp directory.

```text
[reload] config hot reload applied (cron)
markerCountBeforeReload: 1
markerCountAfterRestartCronHotReload: 1
lazyExitWatchersExposed: true
watcherObjectReusedAcrossReload: true
activeBeforeReload: [same synthetic job id]
activeImmediatelyAfterReload: [same synthetic job id]
activeAfterCommandExit: []
finalJobEnabled: false
finalLastRunStatus: ok
finalLastRunAtMsType: number
RESULT: PASS - restartCron hot reload preserved the in-flight on-exit command, did not re-execute it, and the watcher completed the job once after exit.
```

Focused checks:
- `node scripts/run-tsgo.mjs -p test/tsconfig/tsconfig.core.test.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/core-test.tsbuildinfo`
- `node scripts/run-vitest.mjs src/gateway/cron-exit-watchers.test.ts src/gateway/server-reload-handlers.test.ts src/gateway/server-cron.test.ts src/gateway/server-cron-lazy.test.ts`
- `node scripts/run-oxlint.mjs src/gateway/cron-exit-watchers.ts src/gateway/server-cron.ts src/gateway/server-cron-lazy.ts src/gateway/server-reload-handlers.ts src/gateway/cron-exit-watchers.test.ts src/gateway/server-cron.test.ts src/gateway/server-cron-lazy.test.ts src/gateway/server-reload-handlers.test.ts`
- `git diff --check`
