### PR TITLE
fix(memory-wiki): preserve dollar notes on reimport

### DIFF
--- a/extensions/memory-wiki/src/chatgpt-import.ts
+++ b/extensions/memory-wiki/src/chatgpt-import.ts
@@ -583,7 +583,7 @@ function replaceSimpleManagedBlock(params: {
   const escapedStart = params.startMarker.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
   const escapedEnd = params.endMarker.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
   const blockPattern = new RegExp(`${escapedStart}[\\s\\S]*?${escapedEnd}`);
-  return params.original.replace(blockPattern, params.replacement);
+  return params.original.replace(blockPattern, () => params.replacement);
 }
 
 function extractSimpleManagedBlock(params: {

--- a/extensions/memory-wiki/src/wiki-notes-read-retry.test.ts
+++ b/extensions/memory-wiki/src/wiki-notes-read-retry.test.ts
@@ -479,6 +479,35 @@ describe("memory-wiki existing-page read retry", () => {
     expect(after).toContain(userNote);
   });
 
+  it("preserves chatgpt conversation notes containing replacement-pattern dollar sequences", async () => {
+    const { config, exportDir, pagePath } = await createChatGptImportFixture(
+      "memory-wiki-chatgpt-dollar-notes-",
+    );
+    const userNote = "Energy identity $$E=mc^2$$ and match $& and prefix $` and suffix $' end.";
+    const noteBlock = [
+      "<!-- openclaw:human:start -->",
+      userNote,
+      "<!-- openclaw:human:end -->",
+    ].join("\n");
+    const edited = (await fs.readFile(pagePath, "utf8")).replace(
+      "<!-- openclaw:human:start -->\n<!-- openclaw:human:end -->",
+      () => noteBlock,
+    );
+    await fs.writeFile(pagePath, edited, "utf8");
+
+    const second = await importChatGptConversations({
+      config,
+      exportPath: exportDir,
+      nowMs: Date.UTC(2026, 3, 6, 12, 0, 0),
+    });
+
+    const after = await fs.readFile(pagePath, "utf8");
+    expect(second.createdCount).toBe(0);
+    expect(second.updatedCount).toBe(0);
+    expect(second.skippedCount).toBe(1);
+    expect(after).toContain(userNote);
+  });
+
   it("leaves a ChatGPT page unchanged after a persistent existing-page read failure", async () => {
     const { config, exportDir, pagePath } = await createChatGptImportFixture(
       "memory-wiki-chatgpt-persistent-read-",


### PR DESCRIPTION
## What Problem This Solves

Memory Wiki conversation export re-import preserved the existing human `## Notes` block through `String.prototype.replace` with a string replacement. User-authored dollar sequences such as `$$`, `$&`, `$`` and `$'` were interpreted as replacement patterns, so notes could be silently corrupted during a re-import.

Closes #99708

## Why This Change Was Made

- Inserts the preserved human block with a replacer callback so the block is copied literally.
- Adds a regression that drives the real re-import path after planting a Notes block containing replacement-pattern dollar sequences.
- Keeps the fix scoped to the existing managed-block preservation helper used by this import path.

## User Impact

Users can re-import the same conversation export without corrupting human Notes that contain dollar-sign syntax, including math notation and literal replacement-pattern text.

## Evidence

- `node scripts/run-vitest.mjs extensions/memory-wiki/src/wiki-notes-read-retry.test.ts` passed.
- `node scripts/run-vitest.mjs extensions/memory-wiki/src/wiki-notes-read-retry.test.ts extensions/memory-wiki/src/cli.test.ts` passed.
- `./node_modules/.bin/oxfmt --check --threads=1 extensions/memory-wiki/src/chatgpt-import.ts extensions/memory-wiki/src/wiki-notes-read-retry.test.ts` passed.
- `node scripts/run-oxlint.mjs extensions/memory-wiki/src/chatgpt-import.ts extensions/memory-wiki/src/wiki-notes-read-retry.test.ts` exited 0.
- `git diff --check` passed.
- Structured local review found no introduced correctness issues.

## Real behavior proof

**Behavior addressed:** Conversation export re-import preserves a user-authored Memory Wiki Notes block containing literal dollar sequences.

**Environment tested:** Linux, Node with `tsx`, local OpenClaw checkout on branch `fix/99708-memory-wiki-notes-dollar`.

**Steps run after the patch:** Called the real production import entry point from source, created a temporary on-disk vault and export, planted a Notes block containing `$$`, `$&`, `$`` and `$'`, re-imported the export, then read the page from disk.

**Evidence after fix:**

```text
$ node --import tsx --no-warnings /tmp/openclaw-99708-proof.mjs
temporary vault: /tmp/openclaw-99708-proof-usTY7k/vault
planted note verbatim before re-import: true
second import counts: created=0 updated=0 skipped=1
note preserved verbatim after re-import: true
notes line after re-import:
Energy identity $$E=mc^2$$ and match $& and prefix $` and suffix $' end.
```

**Observed result after fix:** The re-import skipped the already-current page and the Notes line was preserved byte-for-byte with all dollar sequences intact.

**Not tested:** Full CLI invocation with a large real user export was not run; the proof used the production import function directly against a temporary on-disk vault.
