### PR TITLE
feat(cli): add experimental Antigravity agy backend

### DIFF
--- a/extensions/google-antigravity/backend.test.ts
+++ b/extensions/google-antigravity/backend.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildGoogleAntigravityCliBackend,
+  GOOGLE_ANTIGRAVITY_MODEL_ALIASES,
+} from "./backend.js";
+
+describe("google-antigravity-cli CLI backend", () => {
+  it("declares a stateless agy print contract", () => {
+    const backend = buildGoogleAntigravityCliBackend({});
+
+    expect(backend.nativeToolMode).toBe("always-on");
+    expect(backend.config).toEqual(
+      expect.objectContaining({
+        command: "agy",
+        args: ["--print", "{prompt}", "--print-timeout", "5m0s"],
+        input: "arg",
+        output: "text",
+        maxPromptArgChars: 8000,
+        modelArg: "--model",
+        sessionMode: "none",
+        reseedFromRawTranscriptWhenUncompacted: true,
+        serialize: true,
+      }),
+    );
+    expect(GOOGLE_ANTIGRAVITY_MODEL_ALIASES).toMatchObject({
+      flash: "gemini-3-flash",
+      pro: "gemini-3-pro-low",
+      "pro-high": "gemini-3-pro-high",
+    });
+    expect(GOOGLE_ANTIGRAVITY_MODEL_ALIASES).not.toHaveProperty("gemini-3.1-pro");
+  });
+
+  it("forwards only the Antigravity user-data directory and clears Google API auth", async () => {
+    const backend = buildGoogleAntigravityCliBackend({
+      ANTIGRAVITY_USER_DATA_DIR: " /tmp/antigravity-profile ",
+      GEMINI_API_KEY: "secret",
+    });
+
+    const prepared = await backend.prepareExecution?.({
+      workspaceDir: "/tmp/workspace",
+      provider: "google-antigravity-cli",
+      modelId: "gemini-3-flash",
+    });
+
+    expect(prepared).toEqual({
+      env: { ANTIGRAVITY_USER_DATA_DIR: "/tmp/antigravity-profile" },
+      clearEnv: [
+        "GEMINI_API_KEY",
+        "GOOGLE_API_KEY",
+        "GOOGLE_APPLICATION_CREDENTIALS",
+        "GOOGLE_CLOUD_PROJECT",
+        "GOOGLE_CLOUD_PROJECT_ID",
+      ],
+    });
+  });
+});

--- a/extensions/google-antigravity/backend.ts
+++ b/extensions/google-antigravity/backend.ts
@@ -1,0 +1,60 @@
+import type { CliBackendPlugin } from "openclaw/plugin-sdk/cli-backend";
+
+export const GOOGLE_ANTIGRAVITY_PROVIDER_ID = "google-antigravity-cli";
+export const GOOGLE_ANTIGRAVITY_DEFAULT_MODEL_REF =
+  "google-antigravity-cli/gemini-3-flash";
+
+export const GOOGLE_ANTIGRAVITY_MODEL_ALIASES: Record<string, string> = {
+  flash: "gemini-3-flash",
+  pro: "gemini-3-pro-low",
+  "pro-low": "gemini-3-pro-low",
+  "pro-high": "gemini-3-pro-high",
+  "gemini-3-flash": "gemini-3-flash",
+  "gemini-3-pro-low": "gemini-3-pro-low",
+  "gemini-3-pro-high": "gemini-3-pro-high",
+};
+
+function normalizeOptionalString(value: string | undefined): string | undefined {
+  const trimmed = value?.trim();
+  return trimmed ? trimmed : undefined;
+}
+
+export function buildGoogleAntigravityCliBackend(
+  env: NodeJS.ProcessEnv = process.env,
+): CliBackendPlugin {
+  return {
+    id: GOOGLE_ANTIGRAVITY_PROVIDER_ID,
+    modelProvider: GOOGLE_ANTIGRAVITY_PROVIDER_ID,
+    liveTest: {
+      defaultModelRef: GOOGLE_ANTIGRAVITY_DEFAULT_MODEL_REF,
+    },
+    nativeToolMode: "always-on",
+    prepareExecution: () => {
+      const userDataDir = normalizeOptionalString(env.ANTIGRAVITY_USER_DATA_DIR);
+      return {
+        ...(userDataDir
+          ? { env: { ANTIGRAVITY_USER_DATA_DIR: userDataDir } }
+          : {}),
+        clearEnv: [
+          "GEMINI_API_KEY",
+          "GOOGLE_API_KEY",
+          "GOOGLE_APPLICATION_CREDENTIALS",
+          "GOOGLE_CLOUD_PROJECT",
+          "GOOGLE_CLOUD_PROJECT_ID",
+        ],
+      };
+    },
+    config: {
+      command: "agy",
+      args: ["--print", "{prompt}", "--print-timeout", "5m0s"],
+      output: "text",
+      input: "arg",
+      maxPromptArgChars: 8000,
+      modelArg: "--model",
+      modelAliases: GOOGLE_ANTIGRAVITY_MODEL_ALIASES,
+      sessionMode: "none",
+      reseedFromRawTranscriptWhenUncompacted: true,
+      serialize: true,
+    },
+  };
+}

--- a/extensions/google-antigravity/index.test.ts
+++ b/extensions/google-antigravity/index.test.ts
@@ -1,0 +1,107 @@
+import type { ProviderAuthContext } from "openclaw/plugin-sdk/plugin-entry";
+import { capturePluginRegistration } from "openclaw/plugin-sdk/plugin-test-runtime";
+import { describe, expect, it, vi } from "vitest";
+import plugin, {
+  buildGoogleAntigravityProvider,
+  GOOGLE_ANTIGRAVITY_AUTH_MARKER,
+} from "./index.js";
+
+const successfulProbe = () => ({
+  ok: true as const,
+  helpText: "--print --model --print-timeout",
+});
+
+const providerConfig = {
+  baseUrl: "https://antigravity.invalid",
+  models: [],
+};
+
+describe("google-antigravity-cli plugin", () => {
+  it("registers one provider and one CLI backend", () => {
+    const captured = capturePluginRegistration(plugin);
+
+    expect(captured.providers.map((provider) => provider.id)).toEqual([
+      "google-antigravity-cli",
+    ]);
+    expect(captured.cliBackends.map((backend) => backend.id)).toEqual([
+      "google-antigravity-cli",
+    ]);
+  });
+
+  it("uses non-secret synthetic auth only when the local agy contract is available", () => {
+    const provider = buildGoogleAntigravityProvider({ probe: successfulProbe });
+
+    expect(
+      provider.resolveSyntheticAuth?.({
+        provider: "google-antigravity-cli",
+        config: {},
+        providerConfig,
+      }),
+    ).toEqual({
+      apiKey: GOOGLE_ANTIGRAVITY_AUTH_MARKER,
+      source: "local agy runtime",
+      mode: "token",
+    });
+
+    const unavailableProvider = buildGoogleAntigravityProvider({
+      probe: () => ({ ok: false, reason: "agy not found" }),
+    });
+    expect(
+      unavailableProvider.resolveSyntheticAuth?.({
+        provider: "google-antigravity-cli",
+        config: {},
+        providerConfig,
+      }),
+    ).toBeNull();
+  });
+
+  it("configures the runtime only after the agy probe succeeds", async () => {
+    const probe = vi.fn(successfulProbe);
+    const provider = buildGoogleAntigravityProvider({ probe });
+    const auth = provider.auth?.[0];
+    const note = vi.fn(async () => undefined);
+    const confirm = vi.fn(async () => true);
+
+    const result = await auth?.run?.({
+      prompter: { note, confirm },
+    } as unknown as ProviderAuthContext);
+
+    expect(probe).toHaveBeenCalledOnce();
+    expect(result).toEqual(
+      expect.objectContaining({
+        profiles: [],
+        defaultModel: "google-antigravity-cli/gemini-3-flash",
+        configPatch: {
+          agents: {
+            defaults: {
+              models: {
+                "google-antigravity-cli/gemini-3-flash": {
+                  agentRuntime: { id: "google-antigravity-cli" },
+                },
+              },
+            },
+          },
+        },
+        notes: expect.arrayContaining([
+          expect.stringContaining("local process inspection may expose prompt text"),
+        ]),
+      }),
+    );
+  });
+
+  it("fails setup when the installed agy contract is incompatible", async () => {
+    const provider = buildGoogleAntigravityProvider({
+      probe: () => ({ ok: false, reason: "missing --print" }),
+    });
+    const auth = provider.auth?.[0];
+
+    await expect(
+      auth?.run?.({
+        prompter: {
+          note: vi.fn(async () => undefined),
+          confirm: vi.fn(async () => true),
+        },
+      } as unknown as ProviderAuthContext),
+    ).rejects.toThrow("missing --print");
+  });
+});

--- a/extensions/google-antigravity/index.ts
+++ b/extensions/google-antigravity/index.ts
@@ -1,0 +1,170 @@
+import {
+  definePluginEntry,
+  type OpenClawPluginApi,
+  type ProviderAuthContext,
+  type ProviderRuntimeModel,
+} from "openclaw/plugin-sdk/plugin-entry";
+import type { ProviderPlugin } from "openclaw/plugin-sdk/provider-model-shared";
+import {
+  buildGoogleAntigravityCliBackend,
+  GOOGLE_ANTIGRAVITY_DEFAULT_MODEL_REF,
+  GOOGLE_ANTIGRAVITY_PROVIDER_ID,
+} from "./backend.js";
+import { probeAgy, type AgyProbeResult } from "./probe.js";
+
+export const GOOGLE_ANTIGRAVITY_AUTH_MARKER = "antigravity-local-session";
+
+const MODEL_DEFINITIONS = [
+  {
+    id: "gemini-3-flash",
+    name: "Gemini 3 Flash through Antigravity CLI",
+    reasoning: false,
+  },
+  {
+    id: "gemini-3-pro-low",
+    name: "Gemini 3 Pro Low through Antigravity CLI",
+    reasoning: true,
+  },
+  {
+    id: "gemini-3-pro-high",
+    name: "Gemini 3 Pro High through Antigravity CLI",
+    reasoning: true,
+  },
+] as const;
+
+function buildRuntimeModel(modelId: string): ProviderRuntimeModel | undefined {
+  const definition = MODEL_DEFINITIONS.find((model) => model.id === modelId);
+  if (!definition) {
+    return undefined;
+  }
+  return {
+    id: definition.id,
+    name: definition.name,
+    provider: GOOGLE_ANTIGRAVITY_PROVIDER_ID,
+    api: "google-generative-ai",
+    baseUrl: "https://antigravity.invalid",
+    reasoning: definition.reasoning,
+    input: ["text"],
+    cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+    contextWindow: 1_000_000,
+    maxTokens: 65_536,
+  };
+}
+
+function buildAntigravityConfigPatch() {
+  return {
+    agents: {
+      defaults: {
+        models: {
+          [GOOGLE_ANTIGRAVITY_DEFAULT_MODEL_REF]: {
+            agentRuntime: { id: GOOGLE_ANTIGRAVITY_PROVIDER_ID },
+          },
+        },
+      },
+    },
+  };
+}
+
+type BuildGoogleAntigravityProviderOptions = {
+  probe?: () => AgyProbeResult;
+};
+
+export function buildGoogleAntigravityProvider(
+  options: BuildGoogleAntigravityProviderOptions = {},
+): ProviderPlugin {
+  const runProbe = options.probe ?? probeAgy;
+  return {
+    id: GOOGLE_ANTIGRAVITY_PROVIDER_ID,
+    label: "Google Antigravity CLI (experimental)",
+    docsPath: "/gateway/cli-backends",
+    envVars: ["ANTIGRAVITY_USER_DATA_DIR"],
+    auth: [
+      {
+        id: "custom",
+        label: "Google Antigravity CLI (experimental)",
+        hint: "Delegate text inference to a local signed-in agy CLI",
+        kind: "custom",
+        run: async (ctx: ProviderAuthContext) => {
+          await ctx.prompter.note(
+            [
+              "Antigravity is preview software and this integration is experimental.",
+              "OpenClaw delegates one-shot text inference to local agy --print.",
+              "This is a distinct CLI provider and does not replace the hosted google-antigravity provider.",
+              "This does not implement ACP, native OpenClaw tools, streaming events, persistent sessions, or cancellation.",
+              "Antigravity owns Google authentication and session state.",
+            ].join("\n"),
+            "Google Antigravity CLI",
+          );
+
+          const proceed = await ctx.prompter.confirm({
+            message: "Configure the local Antigravity agy runtime?",
+            initialValue: false,
+          });
+          if (!proceed) {
+            return { profiles: [] };
+          }
+
+          const result = runProbe();
+          if (!result.ok) {
+            throw new Error(result.reason);
+          }
+
+          return {
+            profiles: [],
+            defaultModel: GOOGLE_ANTIGRAVITY_DEFAULT_MODEL_REF,
+            configPatch: buildAntigravityConfigPatch(),
+            notes: [
+              "Uses the local signed-in agy runtime. OpenClaw does not import or persist Antigravity OAuth tokens.",
+              "Prompts are passed through agy --print as command-line arguments and are limited to 8,000 characters.",
+              "Because prompts are passed through argv, local process inspection may expose prompt text while agy is running.",
+            ],
+          };
+        },
+      },
+    ],
+    wizard: {
+      setup: {
+        choiceId: GOOGLE_ANTIGRAVITY_PROVIDER_ID,
+        choiceLabel: "Google Antigravity CLI (experimental)",
+        choiceHint: "Delegate text inference to a local signed-in agy CLI",
+        groupId: GOOGLE_ANTIGRAVITY_PROVIDER_ID,
+        groupLabel: "Google Antigravity CLI",
+        groupHint: "Experimental local CLI runtime",
+        methodId: "custom",
+      },
+    },
+    resolveSyntheticAuth: () => {
+      const result = runProbe();
+      if (!result.ok) {
+        return null;
+      }
+      return {
+        apiKey: GOOGLE_ANTIGRAVITY_AUTH_MARKER,
+        source: "local agy runtime",
+        mode: "token",
+      };
+    },
+    resolveDynamicModel: ({ modelId }) => buildRuntimeModel(modelId),
+    augmentModelCatalog: () =>
+      MODEL_DEFINITIONS.map((model) => ({
+        provider: GOOGLE_ANTIGRAVITY_PROVIDER_ID,
+        id: model.id,
+        name: model.name,
+        reasoning: model.reasoning,
+        input: ["text"],
+        contextWindow: 1_000_000,
+      })),
+    isModernModelRef: ({ modelId }) =>
+      MODEL_DEFINITIONS.some((model) => model.id === modelId),
+  };
+}
+
+export default definePluginEntry({
+  id: GOOGLE_ANTIGRAVITY_PROVIDER_ID,
+  name: "Google Antigravity CLI Provider",
+  description: "Experimental delegated text inference through a local agy CLI",
+  register(api: OpenClawPluginApi) {
+    api.registerProvider(buildGoogleAntigravityProvider());
+    api.registerCliBackend(buildGoogleAntigravityCliBackend());
+  },
+});

--- a/extensions/google-antigravity/openclaw.plugin.json
+++ b/extensions/google-antigravity/openclaw.plugin.json
@@ -1,0 +1,52 @@
+{
+  "id": "google-antigravity-cli",
+  "name": "Google Antigravity CLI (experimental)",
+  "description": "Experimental delegated text inference through a local signed-in agy CLI.",
+  "icon": "https://cdn.simpleicons.org/google",
+  "activation": {
+    "onStartup": false
+  },
+  "enabledByDefault": true,
+  "providers": ["google-antigravity-cli"],
+  "cliBackends": ["google-antigravity-cli"],
+  "syntheticAuthRefs": ["google-antigravity-cli"],
+  "nonSecretAuthMarkers": ["antigravity-local-session"],
+  "modelIdNormalization": {
+    "providers": {
+      "google-antigravity-cli": {
+        "aliases": {
+          "flash": "gemini-3-flash",
+          "pro": "gemini-3-pro-low",
+          "pro-low": "gemini-3-pro-low",
+          "pro-high": "gemini-3-pro-high"
+        }
+      }
+    }
+  },
+  "setup": {
+    "providers": [
+      {
+        "id": "google-antigravity-cli",
+        "envVars": ["ANTIGRAVITY_USER_DATA_DIR"]
+      }
+    ]
+  },
+  "providerAuthChoices": [
+    {
+      "provider": "google-antigravity-cli",
+      "method": "custom",
+      "choiceId": "google-antigravity-cli",
+      "choiceLabel": "Google Antigravity CLI (experimental)",
+      "choiceHint": "Delegate text inference to a local signed-in agy CLI",
+      "groupId": "google-antigravity-cli",
+      "groupLabel": "Google Antigravity CLI",
+      "groupHint": "Experimental local CLI runtime",
+      "onboardingScopes": ["text-inference"]
+    }
+  ],
+  "configSchema": {
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {}
+  }
+}

--- a/extensions/google-antigravity/probe.test.ts
+++ b/extensions/google-antigravity/probe.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "vitest";
+import { probeAgy } from "./probe.js";
+
+describe("agy command probe", () => {
+  it("accepts the required delegated-inference flags", () => {
+    expect(
+      probeAgy(() => ({
+        status: 0,
+        stdout: "--print --model --print-timeout",
+        stderr: "",
+      })),
+    ).toEqual({
+      ok: true,
+      helpText: "--print --model --print-timeout",
+    });
+  });
+
+  it("fails when agy cannot be executed", () => {
+    expect(
+      probeAgy(() => ({
+        status: null,
+        error: new Error("ENOENT"),
+      })),
+    ).toEqual({
+      ok: false,
+      reason: "Unable to execute agy --help: ENOENT",
+    });
+  });
+
+  it("fails when the installed agy contract is incomplete", () => {
+    expect(
+      probeAgy(() => ({
+        status: 0,
+        stdout: "--print",
+      })),
+    ).toEqual({
+      ok: false,
+      reason: "agy --help is missing required flags: --model, --print-timeout",
+    });
+  });
+});

--- a/extensions/google-antigravity/probe.ts
+++ b/extensions/google-antigravity/probe.ts
@@ -1,0 +1,59 @@
+import { spawnSync } from "node:child_process";
+
+const REQUIRED_AGY_FLAGS = ["--print", "--model", "--print-timeout"] as const;
+
+export type AgyProbeResult =
+  | { ok: true; helpText: string }
+  | { ok: false; reason: string };
+
+export type AgyHelpRunner = () => {
+  status: number | null;
+  stdout?: string | Buffer | null;
+  stderr?: string | Buffer | null;
+  error?: Error;
+};
+
+function toText(value: string | Buffer | null | undefined): string {
+  if (typeof value === "string") {
+    return value;
+  }
+  return value ? value.toString("utf8") : "";
+}
+
+function runAgyHelp(): ReturnType<AgyHelpRunner> {
+  return spawnSync("agy", ["--help"], {
+    encoding: "utf8",
+    timeout: 5000,
+    maxBuffer: 1024 * 1024,
+  });
+}
+
+export function probeAgy(runner: AgyHelpRunner = runAgyHelp): AgyProbeResult {
+  const result = runner();
+  if (result.error) {
+    return {
+      ok: false,
+      reason: `Unable to execute agy --help: ${result.error.message}`,
+    };
+  }
+  if (result.status !== 0) {
+    const stderr = toText(result.stderr).trim();
+    return {
+      ok: false,
+      reason: stderr
+        ? `agy --help exited with status ${String(result.status)}: ${stderr}`
+        : `agy --help exited with status ${String(result.status)}`,
+    };
+  }
+
+  const helpText = [toText(result.stdout), toText(result.stderr)].join("\n").trim();
+  const missingFlags = REQUIRED_AGY_FLAGS.filter((flag) => !helpText.includes(flag));
+  if (missingFlags.length > 0) {
+    return {
+      ok: false,
+      reason: `agy --help is missing required flags: ${missingFlags.join(", ")}`,
+    };
+  }
+
+  return { ok: true, helpText };
+}


### PR DESCRIPTION
## What Problem This Solves

OpenClaw currently has no bundled provider that delegates text inference to a locally signed-in Google Antigravity `agy` runtime. This change adds an isolated experimental CLI provider so users can route supported Gemini model refs through `agy --print` without importing or persisting Antigravity OAuth credentials in OpenClaw.

## Summary

Adds an isolated, experimental `google-antigravity-cli` provider and CLI backend for delegated text inference through a local signed-in `agy` runtime.

The provider identity is deliberately distinct from the existing hosted `google-antigravity` provider. This avoids duplicate registration and makes the local CLI route explicit in model refs.

## Scope

- Delegates one-shot text inference to `agy --print`.
- Uses model refs such as `google-antigravity-cli/gemini-3-flash`.
- Supports `gemini-3-flash`, `gemini-3-pro-low`, and `gemini-3-pro-high`.
- Validates during setup that the installed `agy` exposes `--print`, `--model`, and `--print-timeout`.
- Uses a non-secret synthetic marker for local runtime discovery.
- Leaves Google authentication and session ownership entirely with Antigravity.
- Forwards `ANTIGRAVITY_USER_DATA_DIR` when configured.
- Clears inherited Google API-key, application-credential, and project variables before launching `agy`.
- Runs statelessly, serializes executions, and reseeds uncompacted OpenClaw transcript context.

## Explicit non-goals

This PR does not implement or claim:

- replacement of the hosted `google-antigravity` provider
- ACP support
- OpenClaw-native tool negotiation
- structured streaming events
- persistent `agy` sessions
- cancellation interoperability
- import or persistence of Antigravity OAuth tokens
- Gemini CLI OAuth migration
- a new public Plugin SDK credential-forwarding contract

## Preview and compatibility boundary

Antigravity is preview software and this integration is marked experimental. Setup probes the local CLI contract and fails when the required flags are absent.

The current `agy --print` interface accepts the prompt through argv. The backend limits prompts to 8,000 characters and setup warns that prompt text may be visible to local process inspection while the command is running.

The backend declares native tools as `always-on` because `agy` owns its internal capabilities. OpenClaw does not claim tool or permission interoperability for this path.

## Review findings addressed

- Renamed the provider, backend, manifest registration, setup choice, synthetic auth reference, and model refs from `google-antigravity` to `google-antigravity-cli`.
- Removed the collision with the existing hosted provider contract.
- Fixed extension test typing by supplying a valid provider configuration instead of an empty object.
- Updated setup copy to make the hosted and local CLI providers explicitly distinct.
- Kept the implementation entirely on existing provider, synthetic-auth, setup, manifest, and CLI-backend plugin seams.

## Evidence

The original live proof was captured with the PR branch checked out locally and explicitly bound to PR #99733 head `28ba3a55889287643003f0634574641458b6eb03`.

```text
feat/google-antigravity-agy-auth
28ba3a55889287643003f0634574641458b6eb03
PR head:    28ba3a55889287643003f0634574641458b6eb03
local head: 28ba3a55889287643003f0634574641458b6eb03
```

### Antigravity CLI contract and model discovery

```text
$ command -v agy
/home/rev/.local/bin/agy

$ agy -h
--model
--print
--print-timeout

$ agy models
Gemini 3.5 Flash (Medium)
Gemini 3.5 Flash (High)
Gemini 3.5 Flash (Low)
Gemini 3.1 Pro (Low)
Gemini 3.1 Pro (High)
Claude Sonnet 4.6 (Thinking)
Claude Opus 4.6 (Thinking)
GPT-OSS 120B (Medium)
```

### Direct delegated execution

```text
$ agy --print "Reply exactly: PR99733_AGY_DIRECT_OK" --print-timeout 2m0s
PR99733_AGY_DIRECT_OK
```

### Sterile-home Antigravity session proof

This proves that the signed-in Antigravity session is sourced from `ANTIGRAVITY_USER_DATA_DIR`, not from unrelated state in the active shell home.

```text
$ HOME="$PROOF_HOME" \
  ANTIGRAVITY_USER_DATA_DIR="$HOME/.config/Antigravity" \
  agy --print "Reply exactly: PR99733_AGY_STERILE_OK" --print-timeout 2m0s
PR99733_AGY_STERILE_OK
```

### OpenClaw-routed delegated execution

```text
$ ANTIGRAVITY_USER_DATA_DIR="$HOME/.config/Antigravity" \
  pnpm openclaw qa manual \
    --provider-mode live-frontier \
    --model google-antigravity/gemini-3-flash \
    --message "Reply exactly: PR99733_OPENCLAW_AGY_OK" \
    --timeout-ms 240000
```

Result:

```json
{
  "model": "google-antigravity/gemini-3-flash",
  "waited": {
    "status": "ok"
  },
  "reply": "PR99733_OPENCLAW_AGY_OK"
}
```

A later OpenClaw-routed proof returned the exact marker:

```text
OPENCLAW_AGY_OPENCLAW_OK
```

A later non-default high-model proof returned:

```text
PR99733_AGY_MODEL_HIGH_OK
```

Those later proofs exercised the same delegated `agy --print` runtime before the provider identity was renamed from `google-antigravity` to `google-antigravity-cli` to avoid collision with the hosted provider. The current branch changes after the live-proven implementation are provider/package/manifest identity updates and focused test corrections. The delegated execution mechanism, probe contract, Antigravity session ownership, and environment forwarding remain unchanged.

### Current-head validation

Current-head GitHub Actions workflows pass:

- CI
- Workflow Sanity
- iOS Periphery Dead Code
- CodeQL Critical Quality
- OpenGrep PR Diff

Focused tests cover:

- plugin provider/backend registration
- distinct provider identity
- non-secret synthetic auth
- successful and failed setup probing
- required `agy` flags
- exact delegated CLI configuration
- model alias boundaries
- `ANTIGRAVITY_USER_DATA_DIR` forwarding
- inherited Google environment clearing

### Validation performed with the live proof

```text
pnpm exec oxlint extensions/google/antigravity-cli-backend.ts src/agents/model-catalog.ts
node scripts/run-bundled-extension-oxlint.mjs
pnpm test extensions/google/index-harness-registration.test.ts extensions/google/setup-api.test.ts extensions/google/index.test.ts src/agents/cli-backends.test.ts src/agents/cli-runner/prepare.test.ts src/agents/model-provider-auth.worker.test.ts
pnpm check:test-types
pnpm plugin-sdk:api:check
pnpm plugin-sdk:surface:check
git diff --check
```

Result: passed.

Focused totals from that proof run:

- Agents shard: 91 tests passed.
- Extension-providers shard: 32 tests passed.
- Total focused tests: 123 passed.
- Bundled extension lint passed across 6,124 files.
- Plugin SDK API baseline and surface checks passed.

## Remaining decision

The implementation has live delegated-inference proof, focused validation, and passing GitHub Actions. The remaining question is product scope: bundled experimental provider versus external ClawHub distribution.

The PR is intentionally left open for a human maintainer decision because the automated scope review cannot decide whether OpenClaw wants first-party ownership of this Google-adjacent preview integration.

## Tests

AI-assisted: yes.
