### PR TITLE
test: add executable runtime fixture canaries

### DIFF
--- a/extensions/voice-call/src/manager.test-harness.ts
+++ b/extensions/voice-call/src/manager.test-harness.ts
@@ -8,7 +8,11 @@ import { VoiceCallConfigSchema } from "./config.js";
 import { CallManager } from "./manager.js";
 import { persistCallRecord } from "./manager/store.js";
 import type { VoiceCallProvider } from "./providers/base.js";
-import { getOptionalVoiceCallStateRuntime, setVoiceCallStateRuntime } from "./runtime-state.js";
+import {
+  getOptionalVoiceCallStateRuntime,
+  setVoiceCallStateRuntime,
+  type VoiceCallStateRuntime,
+} from "./runtime-state.js";
 import { CallRecordSchema } from "./types.js";
 import type {
   GetCallStatusInput,
@@ -78,23 +82,24 @@ export function createTestStorePath(): string {
   return fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-voice-call-test-"));
 }
 
+export function createVoiceCallStateRuntimeForTests(): VoiceCallStateRuntime["state"] {
+  return {
+    resolveStateDir: () => "",
+    openKeyedStore: (() => {
+      throw new Error("openKeyedStore is not used by voice-call manager tests");
+    }) as VoiceCallStateRuntime["state"]["openKeyedStore"],
+    openSyncKeyedStore: <T>(options: OpenKeyedStoreOptions) =>
+      createPluginStateSyncKeyedStoreForTests<T>("voice-call", options),
+    openChannelIngressQueue: (() => {
+      throw new Error("openChannelIngressQueue is not used by voice-call manager tests");
+    }) as VoiceCallStateRuntime["state"]["openChannelIngressQueue"],
+  };
+}
+
 export function installVoiceCallStateRuntimeForTests(): void {
-  if (getOptionalVoiceCallStateRuntime()) {
-    return;
+  if (!getOptionalVoiceCallStateRuntime()) {
+    setVoiceCallStateRuntime({ state: createVoiceCallStateRuntimeForTests() });
   }
-  setVoiceCallStateRuntime({
-    state: {
-      resolveStateDir: () => "",
-      openKeyedStore: (() => {
-        throw new Error("openKeyedStore is not used by voice-call manager tests");
-      }) as never,
-      openSyncKeyedStore: (options: OpenKeyedStoreOptions) =>
-        createPluginStateSyncKeyedStoreForTests("voice-call", options),
-      openChannelIngressQueue: (() => {
-        throw new Error("openChannelIngressQueue is not used by voice-call manager tests");
-      }) as never,
-    },
-  });
 }
 
 export async function createManagerHarness(

--- a/extensions/voice-call/src/voice-call-cli-rpc-agent-tool.e2e.test.ts
+++ b/extensions/voice-call/src/voice-call-cli-rpc-agent-tool.e2e.test.ts
@@ -1,7 +1,6 @@
 // Voice Call E2E tests cover CLI, Gateway RPC, and agent tool through the mock provider.
 import fs from "node:fs";
 import { createServer } from "node:net";
-import os from "node:os";
 import path from "node:path";
 import { Command } from "commander";
 import type { OpenClawPluginApi } from "openclaw/plugin-sdk/plugin-entry";
@@ -12,6 +11,7 @@ import plugin from "../index.js";
 import { testing as voiceCallCliTesting } from "./cli.js";
 import {
   createVoiceCallStateRuntimeForTests,
+  createTestStorePath,
   installVoiceCallStateRuntimeForTests,
 } from "./manager.test-harness.js";
 import { clearVoiceCallStateRuntime } from "./runtime-state.js";
@@ -48,8 +48,11 @@ function isAddressInUseError(error: unknown): boolean {
   return error instanceof Error && `${error.message}\n${error.stack ?? ""}`.includes("EADDRINUSE");
 }
 
+const tempDirs = new Set<string>();
+
 async function runVoiceCallEntryPointFixture(): Promise<void> {
-  const stateDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-voice-call-qa-"));
+  const stateDir = createTestStorePath();
+  tempDirs.add(stateDir);
   vi.stubEnv("OPENCLAW_STATE_DIR", stateDir);
   resetPluginStateStoreForTests();
   installVoiceCallStateRuntimeForTests();
@@ -167,7 +170,6 @@ async function runVoiceCallEntryPointFixture(): Promise<void> {
     resetPluginStateStoreForTests();
     vi.unstubAllEnvs();
     vi.restoreAllMocks();
-    fs.rmSync(stateDir, { force: true, recursive: true });
   }
 }
 
@@ -178,6 +180,10 @@ describe("QA Voice Call CLI, RPC, and agent tool", () => {
     resetPluginStateStoreForTests();
     vi.unstubAllEnvs();
     vi.restoreAllMocks();
+    for (const dir of tempDirs) {
+      fs.rmSync(dir, { force: true, recursive: true });
+    }
+    tempDirs.clear();
   });
 
   it("routes all three entry points through one mock-provider runtime", async () => {

--- a/extensions/voice-call/src/voice-call-cli-rpc-agent-tool.e2e.test.ts
+++ b/extensions/voice-call/src/voice-call-cli-rpc-agent-tool.e2e.test.ts
@@ -1,0 +1,198 @@
+// Voice Call E2E tests cover CLI, Gateway RPC, and agent tool through the mock provider.
+import fs from "node:fs";
+import { createServer } from "node:net";
+import os from "node:os";
+import path from "node:path";
+import { Command } from "commander";
+import type { OpenClawPluginApi } from "openclaw/plugin-sdk/plugin-entry";
+import { resetPluginStateStoreForTests } from "openclaw/plugin-sdk/plugin-state-test-runtime";
+import { createTestPluginApi } from "openclaw/plugin-sdk/plugin-test-api";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import plugin from "../index.js";
+import { testing as voiceCallCliTesting } from "./cli.js";
+import {
+  createVoiceCallStateRuntimeForTests,
+  installVoiceCallStateRuntimeForTests,
+} from "./manager.test-harness.js";
+import { clearVoiceCallStateRuntime } from "./runtime-state.js";
+import { createVoiceCallBaseConfig } from "./test-fixtures.js";
+
+type GatewayHandler = (request: {
+  params?: Record<string, unknown>;
+  respond: (ok: boolean, payload?: unknown, error?: { message?: string }) => void;
+}) => Promise<void>;
+
+function asOptionalRecord(value: unknown): Record<string, unknown> | undefined {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : undefined;
+}
+
+async function reserveLocalPort(): Promise<number> {
+  return await new Promise((resolve, reject) => {
+    const server = createServer();
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", () => {
+      const address = server.address();
+      if (!address || typeof address === "string") {
+        server.close();
+        reject(new Error("failed to reserve local voice-call port"));
+        return;
+      }
+      server.close((error) => (error ? reject(error) : resolve(address.port)));
+    });
+  });
+}
+
+function isAddressInUseError(error: unknown): boolean {
+  return error instanceof Error && `${error.message}\n${error.stack ?? ""}`.includes("EADDRINUSE");
+}
+
+async function runVoiceCallEntryPointFixture(): Promise<void> {
+  const stateDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-voice-call-qa-"));
+  vi.stubEnv("OPENCLAW_STATE_DIR", stateDir);
+  resetPluginStateStoreForTests();
+  installVoiceCallStateRuntimeForTests();
+  const stateRuntime = createVoiceCallStateRuntimeForTests();
+  const config = createVoiceCallBaseConfig({ provider: "mock" });
+  config.maxConcurrentCalls = 3;
+  config.store = path.join(stateDir, "voice-calls");
+  config.serve.port = await reserveLocalPort();
+
+  const methods = new Map<string, GatewayHandler>();
+  const tools: Array<{
+    name: string;
+    execute: (toolCallId: string, params: unknown) => Promise<{ details?: unknown }>;
+  }> = [];
+  let cliRegistrar: ((context: { program: Command }) => void) | undefined;
+  let service:
+    | {
+        stop?: (context: { config: unknown; stateDir: string; logger: unknown }) => Promise<void>;
+      }
+    | undefined;
+  const logger = { info() {}, warn() {}, error() {}, debug() {} };
+  const api = createTestPluginApi({
+    id: "voice-call",
+    name: "Voice Call",
+    source: "qa",
+    config: {},
+    pluginConfig: config,
+    logger,
+    runtime: {
+      agent: {},
+      state: stateRuntime,
+      tts: { textToSpeechTelephony: vi.fn() },
+    } as unknown as OpenClawPluginApi["runtime"],
+    registerGatewayMethod: (method, handler) => {
+      methods.set(method, handler as GatewayHandler);
+    },
+    registerTool: (tool) => {
+      tools.push(tool as (typeof tools)[number]);
+    },
+    registerCli: (registrar) => {
+      cliRegistrar = registrar as typeof cliRegistrar;
+    },
+    registerService: (registeredService) => {
+      service = registeredService as typeof service;
+    },
+  });
+  plugin.register(api);
+
+  const invokeGateway = async (
+    method: string,
+    params?: Record<string, unknown>,
+  ): Promise<Record<string, unknown>> => {
+    const handler = methods.get(method);
+    if (!handler) {
+      throw new Error(`missing Gateway handler: ${method}`);
+    }
+    return await new Promise<Record<string, unknown>>((resolve, reject) => {
+      void handler({
+        params,
+        respond(ok, payload, error) {
+          if (ok) {
+            const record = asOptionalRecord(payload);
+            if (!record) {
+              reject(new Error(`${method} returned a non-object payload`));
+              return;
+            }
+            resolve(record);
+            return;
+          }
+          reject(new Error(error?.message ?? `${method} failed`));
+        },
+      }).catch(reject);
+    });
+  };
+
+  voiceCallCliTesting.setCallGatewayFromCliForTests(async (method, _options, params) =>
+    invokeGateway(method, asOptionalRecord(params)),
+  );
+  const program = new Command();
+  cliRegistrar?.({ program });
+  const stdout = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
+
+  try {
+    await program.parseAsync(
+      ["voicecall", "start", "--to", "+15550001111", "--message", "CLI fixture"],
+      { from: "user" },
+    );
+
+    const rpcResult = await invokeGateway("voicecall.initiate", {
+      to: "+15550002222",
+      message: "RPC fixture",
+      mode: "notify",
+    });
+    expect(rpcResult).toMatchObject({ initiated: true, callId: expect.any(String) });
+
+    const voiceCallTool = tools.find((tool) => tool.name === "voice_call");
+    if (!voiceCallTool) {
+      throw new Error("voice_call tool was not registered");
+    }
+    const toolResult = await voiceCallTool.execute("tool-call", {
+      action: "initiate_call",
+      to: "+15550003333",
+      message: "Agent tool fixture",
+      mode: "conversation",
+    });
+    expect(toolResult.details).toMatchObject({ initiated: true, callId: expect.any(String) });
+
+    const status = (await invokeGateway("voicecall.status")) as { calls?: unknown[] };
+    expect(status.calls).toHaveLength(3);
+    expect(stdout).toHaveBeenCalled();
+  } finally {
+    await service?.stop?.({ config: {}, stateDir, logger }).catch(() => undefined);
+    voiceCallCliTesting.setCallGatewayFromCliForTests();
+    clearVoiceCallStateRuntime();
+    resetPluginStateStoreForTests();
+    vi.unstubAllEnvs();
+    vi.restoreAllMocks();
+    fs.rmSync(stateDir, { force: true, recursive: true });
+  }
+}
+
+describe("QA Voice Call CLI, RPC, and agent tool", () => {
+  afterEach(() => {
+    voiceCallCliTesting.setCallGatewayFromCliForTests();
+    clearVoiceCallStateRuntime();
+    resetPluginStateStoreForTests();
+    vi.unstubAllEnvs();
+    vi.restoreAllMocks();
+  });
+
+  it("routes all three entry points through one mock-provider runtime", async () => {
+    let lastError: unknown;
+    for (let attempt = 0; attempt < 3; attempt += 1) {
+      try {
+        await runVoiceCallEntryPointFixture();
+        return;
+      } catch (error) {
+        lastError = error;
+        if (!isAddressInUseError(error)) {
+          throw error;
+        }
+      }
+    }
+    throw lastError;
+  });
+});

--- a/qa/scenarios/media/webchat-auto-tts.yaml
+++ b/qa/scenarios/media/webchat-auto-tts.yaml
@@ -8,11 +8,12 @@ scenario:
     secondary:
       - media.tts
       - media.outbound-voice-audio-delivery
-  objective: Verify WebChat auto-TTS synthesizes only the final reply tail and exposes trusted local audio blocks for browser delivery.
+  objective: Verify WebChat auto-TTS synthesizes only the final reply tail and serves trusted local audio through scoped browser media tickets.
   successCriteria:
     - WebChat block delivery does not synthesize intermediate TTS audio.
     - WebChat final delivery synthesizes one local TTS audio file with spoken text metadata.
     - Trusted local TTS media becomes a WebChat audio attachment while untrusted local paths are rejected.
+    - The real Gateway HTTP route mints a scoped ticket and serves the synthesized audio only with that ticket.
   docsRefs:
     - docs/tools/tts.md
     - docs/tools/media-overview.md
@@ -20,8 +21,9 @@ scenario:
   codeRefs:
     - packages/speech-core/src/tts.ts
     - src/gateway/server-methods/chat-webchat-media.ts
+    - src/gateway/control-ui.ts
     - test/e2e/qa-lab/media/webchat-auto-tts.e2e.test.ts
   execution:
     kind: vitest
     path: test/e2e/qa-lab/media/webchat-auto-tts.e2e.test.ts
-    summary: Vitest QA Lab coverage for WebChat auto-TTS synthesis and trusted local audio delivery.
+    summary: Vitest QA Lab coverage for mock WebChat TTS synthesis and real scoped media-ticket delivery.

--- a/qa/scenarios/plugins/voice-call-cli-rpc-agent-tool.yaml
+++ b/qa/scenarios/plugins/voice-call-cli-rpc-agent-tool.yaml
@@ -1,0 +1,28 @@
+title: Voice Call CLI, RPC, and agent tool mock-provider flow
+
+scenario:
+  id: voice-call-cli-rpc-agent-tool
+  surface: voice-call-channel
+  category: voice-call-channel.channel-setup-and-operations
+  coverage:
+    primary:
+      - voice-call.cli-rpc-agent-tool
+  objective: Verify the Voice Call CLI, Gateway RPC, and agent tool share one executable mock-provider runtime.
+  successCriteria:
+    - The CLI starts an outbound call through its Gateway RPC path.
+    - The registered Gateway RPC starts an outbound call through the mock provider.
+    - The registered agent tool starts an outbound call through the same runtime.
+    - Runtime status reports all calls and cleanup stops the local webhook fixture.
+  docsRefs:
+    - docs/cli/voicecall.md
+    - docs/plugins/voice-call.md
+    - docs/gateway/protocol.md
+  codeRefs:
+    - extensions/voice-call/index.ts
+    - extensions/voice-call/src/cli.ts
+    - extensions/voice-call/src/manager.test-harness.ts
+    - extensions/voice-call/src/voice-call-cli-rpc-agent-tool.e2e.test.ts
+  execution:
+    kind: vitest
+    path: extensions/voice-call/src/voice-call-cli-rpc-agent-tool.e2e.test.ts
+    summary: Vitest QA Lab coverage for Voice Call CLI, RPC, and agent tool entry points using the mock provider.

--- a/qa/scenarios/runtime/active-talk-agent-run-status.yaml
+++ b/qa/scenarios/runtime/active-talk-agent-run-status.yaml
@@ -1,0 +1,26 @@
+title: Active Talk agent-run control boundaries
+
+scenario:
+  id: active-talk-agent-run-status
+  surface: voice-and-realtime-talk
+  category: voice-and-realtime-talk.realtime-talk-sessions
+  coverage:
+    secondary:
+      - voice.active-talk-agent-run-status
+  objective: Verify a mock realtime Talk session wires status, steering, follow-up, and cancellation through the active-run control contract.
+  successCriteria:
+    - A registered mock realtime provider creates a browser-owned Talk session with consult and control tools.
+    - Status formatting reports the latest supplied non-control tool progress.
+    - Steering and follow-up invoke the injected queue boundary with the expected modes.
+    - Cancellation invokes the injected abort boundary for the resolved active session.
+  docsRefs:
+    - docs/nodes/talk.md
+    - docs/web/control-ui.md
+  codeRefs:
+    - src/gateway/server-methods/talk-client.ts
+    - src/talk/agent-run-control.ts
+    - test/e2e/qa-lab/voice/active-talk-agent-run-status.e2e.test.ts
+  execution:
+    kind: vitest
+    path: test/e2e/qa-lab/voice/active-talk-agent-run-status.e2e.test.ts
+    summary: Vitest QA Lab boundary coverage for mock realtime session creation and active Talk run-control dependencies.

--- a/qa/scenarios/runtime/qa-otel-smoke.yaml
+++ b/qa/scenarios/runtime/qa-otel-smoke.yaml
@@ -4,24 +4,36 @@ scenario:
   id: qa-otel-smoke
   surface: telemetry
   coverage:
-    secondary:
+    primary:
       - telemetry.otel
+    secondary:
       - harness.qa-lab
       - telemetry.plugin-sdk-runtime-exports
-  objective: Exercise bounded local OTLP capture and OpenTelemetry smoke assertions through QA Lab evidence.
+  objective: Execute the bounded local OTLP runtime producer directly and publish its OpenTelemetry assertions through the shared QA script evidence writer.
   successCriteria:
-    - Package-manager forwarded QA OTEL smoke arguments parse correctly.
-    - Body-size limits are strict positive integers.
-    - Local OTLP receiver rejects malformed, oversized, or truncated protobuf payloads with bounded diagnostics.
-    - Captured OTLP body text is bounded and leak needles remain detectable.
-    - Active local receiver sockets close during cleanup.
-    - Smoke assertions fail on non-2xx OTLP requests and missing release-critical signals.
+    - QA Lab launches the runtime producer directly with a bounded local collector configuration.
+    - The producer emits shared script evidence plus its OTEL assertion summary.
+    - The producer captures release-critical traces, metrics, and correlated logs from a real QA runtime execution.
+    - Smoke assertions reject failed OTLP requests, missing required signals, and configured leak needles.
   docsRefs:
     - docs/gateway/opentelemetry.md
     - docs/concepts/qa-e2e-automation.md
   codeRefs:
-    - test/e2e/qa-lab/runtime/qa-otel-smoke.e2e.test.ts
+    - test/e2e/qa-lab/runtime/script-evidence.ts
+    - test/e2e/qa-lab/runtime/qa-otel-smoke-runtime.ts
   execution:
-    kind: vitest
-    path: test/e2e/qa-lab/runtime/qa-otel-smoke.e2e.test.ts
-    summary: Vitest coverage for QA OTEL smoke receiver bounds and signal assertions.
+    kind: script
+    path: test/e2e/qa-lab/runtime/qa-otel-smoke-runtime.ts
+    config:
+      requiredProviderMode: mock-openai
+    args:
+      - --output-dir
+      - ${outputDir}
+      - --provider-mode
+      - mock-openai
+      - --scenario
+      - otel-both-log-smoke
+      - --logs-exporter
+      - both
+    timeoutMs: 120000
+    summary: Direct QA OTEL runtime producer coverage with shared script evidence.

--- a/qa/scenarios/scheduling/heartbeat-active-hours.yaml
+++ b/qa/scenarios/scheduling/heartbeat-active-hours.yaml
@@ -10,6 +10,7 @@ scenario:
       - automation.heartbeat-scheduling
   objective: Link active-hours heartbeat scheduler e2e coverage to automation maturity accounting.
   successCriteria:
+    - A bounded real-timer scheduler fires with an explicit all-day UTC active-hours window.
     - Heartbeat timers skip quiet-hours phase slots.
     - In-window phase slots fire without duplicate scheduling loops.
     - Hot reload recomputes active-hours and timezone schedule changes.
@@ -20,4 +21,4 @@ scenario:
   execution:
     kind: vitest
     path: src/infra/heartbeat-runner.active-hours-schedule.e2e.test.ts
-    summary: Vitest e2e coverage for active-hours-aware heartbeat scheduling.
+    summary: Vitest e2e coverage for bounded real and fake-time active-hours-aware heartbeat scheduling.

--- a/qa/scenarios/ui/browser-talk-start-stop.yaml
+++ b/qa/scenarios/ui/browser-talk-start-stop.yaml
@@ -5,6 +5,8 @@ scenario:
   surface: browser-control-ui-and-webchat
   category: browser-control-ui-and-webchat.browser-realtime-talk
   coverage:
+    primary:
+      - voice.browser-talk-start-stop-ui
     secondary:
       - ui.browser-talk-start-stop
   objective: Link deterministic browser realtime Talk transport start/stop coverage to UI maturity accounting.
@@ -16,8 +18,9 @@ scenario:
     - docs/web/control-ui.md
     - docs/help/testing.md
   codeRefs:
-    - ui/src/ui/realtime-talk-google-live.test.ts
+    - ui/src/ui/e2e/browser-talk-start-stop.e2e.test.ts
+    - ui/src/test-helpers/control-ui-e2e.ts
   execution:
-    kind: vitest
-    path: ui/src/ui/realtime-talk-google-live.test.ts
-    summary: Vitest coverage for browser realtime Talk transport start and stop behavior.
+    kind: playwright
+    path: ui/src/ui/e2e/browser-talk-start-stop.e2e.test.ts
+    summary: Playwright coverage for browser realtime Talk start and stop through the Control UI.

--- a/src/infra/heartbeat-runner.active-hours-schedule.e2e.test.ts
+++ b/src/infra/heartbeat-runner.active-hours-schedule.e2e.test.ts
@@ -112,6 +112,46 @@ describe("heartbeat scheduler: activeHours-aware scheduling (#75487)", () => {
     runner.stop();
   });
 
+  it("runs a bounded real scheduler with active-hours enabled", async () => {
+    const startedAt = Date.now();
+    let resolveRun: (() => void) | undefined;
+    const ran = new Promise<void>((resolve) => {
+      resolveRun = resolve;
+    });
+    const runSpy: RunOnce = vi.fn().mockImplementation(async () => {
+      resolveRun?.();
+      return { status: "ran", durationMs: 1 };
+    });
+    const runner = startHeartbeatRunner({
+      cfg: heartbeatConfig({
+        every: "50ms",
+        activeHours: { start: "00:00", end: "24:00", timezone: "UTC" },
+      }),
+      runOnce: runSpy,
+      stableSchedulerSeed: TEST_SCHEDULER_SEED,
+    });
+    let timeout: ReturnType<typeof setTimeout> | undefined;
+
+    try {
+      await Promise.race([
+        ran,
+        new Promise<never>((_, reject) => {
+          timeout = setTimeout(
+            () => reject(new Error("real heartbeat scheduler did not fire")),
+            2_000,
+          );
+        }),
+      ]);
+      expect(runSpy).toHaveBeenCalled();
+      expect(Date.now() - startedAt).toBeLessThan(2_000);
+    } finally {
+      if (timeout) {
+        clearTimeout(timeout);
+      }
+      runner.stop();
+    }
+  });
+
   it("seeks forward correctly with a non-UTC timezone (e.g. America/New_York)", async () => {
     // 09:00–17:00 ET (EDT = UTC-4 in June) → 13:00–21:00 UTC.
     // Start at 21:30 UTC (17:30 ET = outside window).

--- a/test/e2e/qa-lab/media/webchat-auto-tts.e2e.test.ts
+++ b/test/e2e/qa-lab/media/webchat-auto-tts.e2e.test.ts
@@ -4,13 +4,23 @@ import path from "node:path";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import { afterEach, describe, expect, it } from "vitest";
 import { maybeApplyTtsToPayload } from "../../../../packages/speech-core/src/tts.ts";
+import { setRuntimeConfigSnapshot } from "../../../../src/config/config.ts";
 import { buildWebchatAudioContentBlocksFromReplyPayloads } from "../../../../src/gateway/server-methods/chat-webchat-media.ts";
+import {
+  installGatewayTestHooks,
+  setTestPluginRegistry,
+  testState,
+  withGatewayServer,
+} from "../../../../src/gateway/test-helpers.ts";
 import { createPluginRecord } from "../../../../src/plugins/loader-records.ts";
 import { createPluginRegistry } from "../../../../src/plugins/registry.ts";
-import {
-  resetPluginRuntimeStateForTest,
-  setActivePluginRegistry,
-} from "../../../../src/plugins/runtime.ts";
+import { getActivePluginRegistry } from "../../../../src/plugins/runtime.ts";
+import { resetPluginRuntimeStateForTest } from "../../../../src/plugins/runtime.ts";
+import { getSpeechProvider } from "../../../../src/tts/provider-registry.ts";
+
+installGatewayTestHooks({ scope: "suite" });
+
+const CONTROL_UI_E2E_TOKEN = "test-gateway-token-1234567890";
 
 const noopLogger = {
   info() {},
@@ -50,7 +60,7 @@ function installMockTtsProvider() {
       };
     },
   });
-  setActivePluginRegistry(registry.registry);
+  setTestPluginRegistry(registry.registry);
   return synthesizeCalls;
 }
 
@@ -76,6 +86,12 @@ describe("QA WebChat auto TTS", () => {
           },
         },
       } satisfies OpenClawConfig;
+      setRuntimeConfigSnapshot(cfg, cfg);
+
+      expect(getActivePluginRegistry()?.speechProviders.map((entry) => entry.provider.id)).toEqual([
+        "mock",
+      ]);
+      expect(getSpeechProvider("mock", cfg)?.id).toBe("mock");
 
       const blockResult = await maybeApplyTtsToPayload({
         payload: { text },
@@ -132,6 +148,41 @@ describe("QA WebChat auto TTS", () => {
         },
       });
       expect(untrustedBlocks).toHaveLength(0);
+
+      const source = trustedBlocks[0]?.type === "attachment" ? trustedBlocks[0].attachment.url : "";
+      testState.gatewayAuth = { mode: "token", token: CONTROL_UI_E2E_TOKEN };
+      await withGatewayServer(
+        async ({ port }) => {
+          const route = `http://127.0.0.1:${port}/__openclaw__/assistant-media`;
+          const sourceParam = encodeURIComponent(source);
+          const metadata = await fetch(`${route}?meta=1&source=${sourceParam}`, {
+            headers: { Authorization: `Bearer ${CONTROL_UI_E2E_TOKEN}` },
+          });
+          expect(metadata.status).toBe(200);
+          const ticket = (await metadata.json()) as {
+            available?: boolean;
+            mediaTicket?: string;
+          };
+          expect(ticket.available).toBe(true);
+          expect(ticket.mediaTicket).toMatch(/^v1\./);
+
+          const withoutTicket = await fetch(`${route}?source=${sourceParam}`);
+          expect(withoutTicket.status).toBe(401);
+
+          const ticketed = await fetch(
+            `${route}?source=${sourceParam}&mediaTicket=${encodeURIComponent(ticket.mediaTicket ?? "")}`,
+          );
+          expect(ticketed.status).toBe(200);
+          expect(ticketed.headers.get("content-type")).toContain("audio/ogg");
+          expect(Buffer.from(await ticketed.arrayBuffer())).toEqual(Buffer.from("voice"));
+        },
+        {
+          serverOptions: {
+            auth: { mode: "token", token: CONTROL_UI_E2E_TOKEN },
+            controlUiEnabled: true,
+          },
+        },
+      );
     } finally {
       if (mediaPath) {
         fs.rmSync(path.dirname(mediaPath), { recursive: true, force: true });

--- a/test/e2e/qa-lab/runtime/qa-otel-smoke-runtime.ts
+++ b/test/e2e/qa-lab/runtime/qa-otel-smoke-runtime.ts
@@ -13,6 +13,7 @@ import { gunzipSync } from "node:zlib";
 import { resolveTimerTimeoutMs } from "@openclaw/normalization-core/number-coercion";
 import { stripLeadingPackageManagerSeparator } from "../../../../scripts/lib/arg-utils.mjs";
 import { resolveWindowsTaskkillPath } from "../../../../scripts/lib/windows-taskkill.mjs";
+import { createQaScriptEvidenceWriter } from "./script-evidence.js";
 
 type CollectorMode = "local" | "docker";
 type OtelLogsExporter = "otlp" | "stdout" | "both";
@@ -58,6 +59,13 @@ type CliOptions = {
   alternateModel?: string;
   help: boolean;
 };
+
+type OtelSmokeEvidenceContext = {
+  startedAt: number;
+  writer: ReturnType<typeof createQaScriptEvidenceWriter>;
+};
+
+let activeEvidenceContext: OtelSmokeEvidenceContext | undefined;
 
 type CapturedRequest = {
   path: string;
@@ -1809,11 +1817,38 @@ async function main() {
   }
 
   await mkdir(options.outputDir, { recursive: true });
+  const writer = createQaScriptEvidenceWriter({
+    artifactBase: options.outputDir,
+    logFileName: "qa-otel-smoke.log",
+    primaryModel: options.primaryModel ?? "gpt-5.5",
+    providerMode: options.providerMode as "mock-openai" | "live-frontier",
+    repoRoot: process.cwd(),
+    target: {
+      id: "qa-otel-smoke",
+      title: "QA OTEL smoke evidence",
+      sourcePath: "test/e2e/qa-lab/runtime/qa-otel-smoke-runtime.ts",
+      primaryCoverageIds: ["telemetry.otel"],
+      secondaryCoverageIds: ["harness.qa-lab", "telemetry.plugin-sdk-runtime-exports"],
+      docsRefs: ["docs/gateway/opentelemetry.md", "docs/concepts/qa-e2e-automation.md"],
+      codeRefs: [
+        "test/e2e/qa-lab/runtime/qa-otel-smoke-runtime.ts",
+        "extensions/diagnostics-otel/src/service.ts",
+      ],
+    },
+  });
+  const startedAt = Date.now();
+  activeEvidenceContext = { startedAt, writer };
+  const writeStdout = (chunk: unknown) => {
+    writer.appendLog(chunk);
+    process.stdout.write(String(chunk));
+  };
+  const writeStderr = (chunk: unknown) => {
+    writer.appendLog(chunk);
+    process.stderr.write(String(chunk));
+  };
   const receiver = startLocalOtlpReceiver(disallowedBodyNeedles(options));
   const port = await receiver.listen();
-  process.stdout.write(
-    `qa-otel-smoke: local OTLP receiver listening on http://127.0.0.1:${port}\n`,
-  );
+  writeStdout(`qa-otel-smoke: local OTLP receiver listening on http://127.0.0.1:${port}\n`);
 
   let collector: Awaited<ReturnType<typeof startDockerOtelCollector>> | undefined;
   let childExitCode = 1;
@@ -1823,7 +1858,7 @@ async function main() {
     if (options.collectorMode === "docker") {
       collector = await startDockerOtelCollector(port);
       exportPort = collector.port;
-      process.stdout.write(
+      writeStdout(
         `qa-otel-smoke: OpenTelemetry Collector ${collector.image} listening on http://127.0.0.1:${exportPort} (${collector.network} network)\n`,
       );
     }
@@ -1832,9 +1867,9 @@ async function main() {
     const cleanupSignalRelay = relayParentSignalsToChild(child);
     child.stdout?.on("data", (chunk) => {
       stdoutDiagnosticLogs.append(chunk);
-      process.stdout.write(chunk);
+      writeStdout(chunk);
     });
-    child.stderr?.on("data", (chunk) => process.stderr.write(chunk));
+    child.stderr?.on("data", writeStderr);
     try {
       childExitCode = await waitForChild(child);
     } finally {
@@ -1922,40 +1957,47 @@ async function main() {
   };
   const summaryPath = path.join(options.outputDir, "otel-smoke-summary.json");
   await writeFile(summaryPath, `${JSON.stringify(summary, null, 2)}\n`, "utf8");
-  process.stdout.write(`qa-otel-smoke: summary ${summaryPath}\n`);
+  writeStdout(`qa-otel-smoke: summary ${summaryPath}\n`);
 
   if (!assertion.passed) {
     for (const failure of assertion.failures) {
-      process.stderr.write(`qa-otel-smoke: ${failure}\n`);
+      writeStderr(`qa-otel-smoke: ${failure}\n`);
     }
-    process.stderr.write(
+    writeStderr(
       `qa-otel-smoke: captured request counts traces=${assertion.signalRequestCounts.traces} ` +
         `metrics=${assertion.signalRequestCounts.metrics} logs=${assertion.signalRequestCounts.logs}\n`,
     );
-    process.stderr.write(
+    writeStderr(
       `qa-otel-smoke: captured decoded counts spans=${receiver.capturedSpans.length} ` +
         `metrics=${receiver.capturedMetrics.length} logs=${receiver.capturedLogRecords.length} ` +
         `stdoutLogs=${stdoutDiagnosticLogs.records.length}\n`,
     );
-    process.stderr.write(
+    writeStderr(
       `qa-otel-smoke: captured span names: ${formatBoundedList(assertion.spanNames, 40)}\n`,
     );
-    process.stderr.write(
+    writeStderr(
       `qa-otel-smoke: captured metric names: ${formatBoundedList(assertion.metricNames, 40)}\n`,
     );
     for (const [signal, contexts] of Object.entries(assertion.leakContexts)) {
       for (const context of contexts ?? []) {
-        process.stderr.write(`qa-otel-smoke: ${signal} leak context: ${context}\n`);
+        writeStderr(`qa-otel-smoke: ${signal} leak context: ${context}\n`);
       }
     }
     const collectorOutput = collector?.output();
     if (collectorOutput) {
-      process.stderr.write(`qa-otel-smoke: collector output:\n${collectorOutput}\n`);
+      writeStderr(`qa-otel-smoke: collector output:\n${collectorOutput}\n`);
     }
+    await writer.write({
+      artifacts: [{ kind: "summary", filePath: path.resolve(summaryPath) }],
+      details: assertion.failures.join("\n"),
+      durationMs: Math.max(1, Date.now() - startedAt),
+      status: "fail",
+    });
+    activeEvidenceContext = undefined;
     process.exitCode = 1;
     return;
   }
-  process.stdout.write(
+  writeStdout(
     `qa-otel-smoke: passed spans=${receiver.capturedSpans.length} ` +
       `metrics=${receiver.capturedMetrics.length} logs=${receiver.capturedLogRecords.length} ` +
       `stdoutLogs=${stdoutDiagnosticLogs.records.length} ` +
@@ -1963,6 +2005,13 @@ async function main() {
       `metricRequests=${assertion.signalRequestCounts.metrics} ` +
       `logRequests=${assertion.signalRequestCounts.logs}\n`,
   );
+  await writer.write({
+    artifacts: [{ kind: "summary", filePath: path.resolve(summaryPath) }],
+    details: `captured spans=${receiver.capturedSpans.length} metrics=${receiver.capturedMetrics.length} logs=${receiver.capturedLogRecords.length}`,
+    durationMs: Math.max(1, Date.now() - startedAt),
+    status: "pass",
+  });
+  activeEvidenceContext = undefined;
 }
 
 export const testing = {
@@ -1985,10 +2034,21 @@ export const testing = {
 };
 
 if (import.meta.url === pathToFileURL(process.argv[1] ?? "").href) {
-  main().catch((error: unknown) => {
-    process.stderr.write(
-      `qa-otel-smoke: ${error instanceof Error ? error.stack || error.message : String(error)}\n`,
-    );
+  main().catch(async (error: unknown) => {
+    const details = error instanceof Error ? error.stack || error.message : String(error);
+    process.stderr.write(`qa-otel-smoke: ${details}\n`);
+    const evidenceContext = activeEvidenceContext;
+    if (evidenceContext) {
+      evidenceContext.writer.appendLog(`qa-otel-smoke: ${details}\n`);
+      await evidenceContext.writer
+        .write({
+          details,
+          durationMs: Math.max(1, Date.now() - evidenceContext.startedAt),
+          status: "fail",
+        })
+        .catch(() => undefined);
+      activeEvidenceContext = undefined;
+    }
     process.exitCode = 1;
   });
 }

--- a/test/e2e/qa-lab/voice/active-talk-agent-run-status.e2e.test.ts
+++ b/test/e2e/qa-lab/voice/active-talk-agent-run-status.e2e.test.ts
@@ -1,0 +1,173 @@
+// QA Talk E2E tests cover provider session creation and active-run voice controls.
+import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { talkHandlers } from "../../../../src/gateway/server-methods/talk.ts";
+import { createPluginRecord } from "../../../../src/plugins/loader-records.ts";
+import { createPluginRegistry } from "../../../../src/plugins/registry.ts";
+import {
+  resetPluginRuntimeStateForTest,
+  setActivePluginRegistry,
+} from "../../../../src/plugins/runtime.ts";
+import { controlRealtimeVoiceAgentRun } from "../../../../src/talk/agent-run-control.ts";
+import type { TalkEvent } from "../../../../src/talk/talk-events.ts";
+
+const noopLogger = {
+  info() {},
+  warn() {},
+  error() {},
+  debug() {},
+};
+
+function installMockRealtimeProvider() {
+  const registry = createPluginRegistry({
+    logger: noopLogger,
+    runtime: {},
+    activateGlobalSideEffects: false,
+  });
+  const record = createPluginRecord({
+    id: "qa-talk-realtime",
+    name: "QA Talk Realtime",
+    source: "test/e2e/qa-lab/voice/active-talk-agent-run-status.e2e.test.ts",
+    origin: "global",
+    enabled: true,
+    configSchema: false,
+  });
+  const createBrowserSession = vi.fn(async () => ({
+    provider: "qa-realtime",
+    transport: "provider-websocket" as const,
+    protocol: "google-live-bidi" as const,
+    clientSecret: "auth_tokens/qa-talk",
+    websocketUrl:
+      "wss://generativelanguage.googleapis.com/ws/google.ai.generativelanguage.v1alpha.GenerativeService.BidiGenerateContentConstrained",
+    audio: {
+      inputEncoding: "pcm16" as const,
+      inputSampleRateHz: 16_000,
+      outputEncoding: "pcm16" as const,
+      outputSampleRateHz: 24_000,
+    },
+  }));
+  registry.registerRealtimeVoiceProvider(record, {
+    id: "qa-realtime",
+    label: "QA Realtime",
+    isConfigured: () => true,
+    createBrowserSession,
+    createBridge: vi.fn(),
+  });
+  setActivePluginRegistry(registry.registry);
+  return createBrowserSession;
+}
+
+function createControlDeps() {
+  return {
+    abortEmbeddedAgentRun: vi.fn(() => true),
+    queueEmbeddedAgentMessageWithOutcomeAsync: vi.fn(async (sessionId: string) => ({
+      queued: true as const,
+      sessionId,
+      target: "embedded_run" as const,
+      gatewayHealth: "live" as const,
+      enqueuedAtMs: 123,
+    })),
+    getDiagnosticSessionActivitySnapshot: vi.fn(() => ({
+      activeWorkKind: "embedded_run" as const,
+      hasActiveEmbeddedRun: true,
+    })),
+    resolveActiveEmbeddedRunSessionId: vi.fn(() => "session-active"),
+  };
+}
+
+describe("QA active Talk agent-run status", () => {
+  afterEach(() => {
+    resetPluginRuntimeStateForTest();
+  });
+
+  it("creates a mock realtime session and controls one active agent run", async () => {
+    const createBrowserSession = installMockRealtimeProvider();
+    const respond = vi.fn();
+    await talkHandlers["talk.client.create"]({
+      req: { type: "req", id: "create", method: "talk.client.create" },
+      params: { sessionKey: "agent:main:main", provider: "qa-realtime" },
+      client: { connId: "qa-talk" },
+      isWebchatConnect: () => true,
+      respond,
+      context: {
+        getRuntimeConfig: () =>
+          ({
+            talk: {
+              realtime: {
+                provider: "qa-realtime",
+                providers: { "qa-realtime": {} },
+              },
+            },
+          }) satisfies OpenClawConfig,
+      },
+    } as never);
+
+    expect(createBrowserSession).toHaveBeenCalledTimes(1);
+    expect(createBrowserSession.mock.calls[0]?.[0]).toMatchObject({
+      tools: [
+        expect.objectContaining({ name: "openclaw_agent_consult" }),
+        expect.objectContaining({ name: "openclaw_agent_control" }),
+      ],
+    });
+    expect(respond).toHaveBeenCalledWith(
+      true,
+      expect.objectContaining({ provider: "qa-realtime", transport: "provider-websocket" }),
+      undefined,
+    );
+
+    const deps = createControlDeps();
+    const recentEvents = [
+      {
+        id: "event-1",
+        type: "tool.progress",
+        sessionId: "talk-1",
+        seq: 1,
+        timestamp: new Date(0).toISOString(),
+        mode: "realtime",
+        transport: "provider-websocket",
+        brain: "agent-consult",
+        payload: { name: "exec_command", phase: "running" },
+      } satisfies TalkEvent,
+    ];
+
+    await expect(
+      controlRealtimeVoiceAgentRun(
+        {
+          sessionKey: "agent:main:main",
+          text: "status",
+          mode: "status",
+          recentEvents,
+        },
+        deps,
+      ),
+    ).resolves.toMatchObject({
+      ok: true,
+      active: true,
+      message: "OpenClaw is working in exec_command (running).",
+    });
+
+    await expect(
+      controlRealtimeVoiceAgentRun(
+        { sessionKey: "agent:main:main", text: "use the safer path", mode: "steer" },
+        deps,
+      ),
+    ).resolves.toMatchObject({ ok: true, mode: "steer", queued: true });
+    await expect(
+      controlRealtimeVoiceAgentRun(
+        { sessionKey: "agent:main:main", text: "also check migration", mode: "followup" },
+        deps,
+      ),
+    ).resolves.toMatchObject({ ok: true, mode: "followup", queued: true });
+    expect(deps.queueEmbeddedAgentMessageWithOutcomeAsync.mock.calls[1]?.[1]).toContain(
+      "Spoken follow-up for the current voice call.",
+    );
+
+    await expect(
+      controlRealtimeVoiceAgentRun(
+        { sessionKey: "agent:main:main", text: "cancel", mode: "cancel" },
+        deps,
+      ),
+    ).resolves.toMatchObject({ ok: true, mode: "cancel", aborted: true });
+    expect(deps.abortEmbeddedAgentRun).toHaveBeenCalledWith("session-active");
+  });
+});

--- a/ui/src/test-helpers/control-ui-e2e.ts
+++ b/ui/src/test-helpers/control-ui-e2e.ts
@@ -61,11 +61,13 @@ export type ControlUiE2eServer = {
 
 export type MockGatewayControls = {
   closeLatest: (code?: number, reason?: string) => Promise<void>;
+  deliverLatest: (frame: unknown) => Promise<void>;
   deferNext: (method: string) => Promise<void>;
   emitChatFinal: (params: { runId: string; sessionKey?: string; text: string }) => Promise<void>;
   emitGatewayEvent: (event: string, payload?: unknown) => Promise<void>;
   getRequests: (method?: string) => Promise<MockGatewayRequest[]>;
   getSocketCount: () => Promise<number>;
+  getSocketUrls: () => Promise<string[]>;
   rejectDeferred: (
     method: string,
     error?: { code?: string; message?: string; details?: unknown; retryable?: boolean },
@@ -256,6 +258,7 @@ function installControlUiMockGateway(input: {
   };
   type ExposedGateway = {
     closeLatest: (code?: number, reason?: string) => void;
+    deliverLatest: (frame: unknown) => void;
     deferNext: (method: string) => void;
     emit: (event: string, payload?: unknown) => void;
     findRequests: (method?: string) => BrowserRequest[];
@@ -267,6 +270,7 @@ function installControlUiMockGateway(input: {
     resolveDeferred: (method: string, payload?: unknown) => void;
     setHistoryMessages: (messages: unknown[]) => void;
     socketCount: () => number;
+    socketUrls: () => string[];
   };
   type WindowWithGateway = Window & {
     openclawControlUiE2eGateway?: ExposedGateway;
@@ -277,7 +281,7 @@ function installControlUiMockGateway(input: {
   const deferredMethods: string[] = [...scenario.deferredMethods];
   const deferredResponses: DeferredResponse[] = [];
   const requests: BrowserRequest[] = [];
-  const sockets: unknown[] = [];
+  const sockets: Array<{ readonly url: string }> = [];
   let seq = 0;
 
   function isRecord(value: unknown): value is Record<string, unknown> {
@@ -631,6 +635,9 @@ function installControlUiMockGateway(input: {
     closeLatest(code, reason) {
       MockWebSocket.latest?.close(code ?? 1006, reason ?? "mock close");
     },
+    deliverLatest(frame) {
+      MockWebSocket.latest?.deliver(frame);
+    },
     deferNext(method) {
       deferredMethods.push(method);
     },
@@ -683,6 +690,9 @@ function installControlUiMockGateway(input: {
     socketCount() {
       return sockets.length;
     },
+    socketUrls() {
+      return sockets.map((socket) => socket.url);
+    },
   };
 
   (window as WindowWithGateway).openclawControlUiE2eGateway = exposed;
@@ -725,6 +735,22 @@ function createMockGatewayControls(page: Page, defaultSessionKey: string): MockG
     );
   };
 
+  const deliverLatest = async (frame: unknown) => {
+    await page.evaluate((payload) => {
+      const gateway = (
+        window as Window & {
+          openclawControlUiE2eGateway?: {
+            deliverLatest: (frame: unknown) => void;
+          };
+        }
+      ).openclawControlUiE2eGateway;
+      if (!gateway) {
+        throw new Error("Mock Gateway is not installed");
+      }
+      gateway.deliverLatest(payload);
+    }, frame);
+  };
+
   const getRequests = async (method?: string) =>
     page.evaluate((targetMethod) => {
       const gateway = (
@@ -756,6 +782,7 @@ function createMockGatewayControls(page: Page, defaultSessionKey: string): MockG
         { closeCode: code, closeReason: reason },
       );
     },
+    deliverLatest,
     async deferNext(method) {
       await page.evaluate((targetMethod) => {
         const gateway = (
@@ -795,6 +822,18 @@ function createMockGatewayControls(page: Page, defaultSessionKey: string): MockG
           }
         ).openclawControlUiE2eGateway;
         return gateway?.socketCount() ?? 0;
+      });
+    },
+    async getSocketUrls() {
+      return await page.evaluate(() => {
+        const gateway = (
+          window as Window & {
+            openclawControlUiE2eGateway?: {
+              socketUrls: () => string[];
+            };
+          }
+        ).openclawControlUiE2eGateway;
+        return gateway?.socketUrls() ?? [];
       });
     },
     async rejectDeferred(method, error) {

--- a/ui/src/ui/e2e/browser-talk-start-stop.e2e.test.ts
+++ b/ui/src/ui/e2e/browser-talk-start-stop.e2e.test.ts
@@ -1,0 +1,144 @@
+// Control UI E2E tests cover browser Talk start and stop through a real page.
+import { chromium, type Page } from "playwright";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import {
+  canRunPlaywrightChromium,
+  installMockGateway,
+  resolvePlaywrightChromiumExecutablePath,
+  startControlUiE2eServer,
+  type ControlUiE2eServer,
+} from "../../test-helpers/control-ui-e2e.ts";
+
+const chromiumExecutablePath = resolvePlaywrightChromiumExecutablePath(chromium.executablePath());
+const chromiumAvailable = canRunPlaywrightChromium(chromiumExecutablePath);
+const allowMissingChromium = process.env.OPENCLAW_UI_E2E_ALLOW_MISSING_CHROMIUM === "1";
+const describeControlUiE2e = chromiumAvailable || !allowMissingChromium ? describe : describe.skip;
+
+let server: ControlUiE2eServer;
+
+async function installTalkBrowserFixtures(page: Page) {
+  await page.addInitScript(() => {
+    const state = { audioContextsClosed: 0, tracksStopped: 0 };
+    const track = { stop: () => (state.tracksStopped += 1) };
+    Object.defineProperty(navigator, "mediaDevices", {
+      configurable: true,
+      value: {
+        getUserMedia: async () => ({ getTracks: () => [track] }),
+      },
+    });
+
+    class MockAudioContext {
+      readonly currentTime = 0;
+      readonly destination = {};
+      readonly sampleRate: number;
+
+      constructor(options?: { sampleRate?: number }) {
+        this.sampleRate = options?.sampleRate ?? 24_000;
+      }
+
+      createMediaStreamSource() {
+        return { connect() {}, disconnect() {} };
+      }
+
+      createScriptProcessor() {
+        return { connect() {}, disconnect() {}, onaudioprocess: null };
+      }
+
+      async close() {
+        state.audioContextsClosed += 1;
+      }
+    }
+
+    Object.defineProperty(window, "AudioContext", {
+      configurable: true,
+      value: MockAudioContext,
+    });
+    Object.defineProperty(window, "openclawTalkE2eState", {
+      configurable: true,
+      value: state,
+    });
+  });
+}
+
+describeControlUiE2e("Control UI browser Talk", () => {
+  beforeAll(async () => {
+    server = await startControlUiE2eServer();
+  });
+
+  afterAll(async () => {
+    await server?.close();
+  });
+
+  it("starts a provider WebSocket session and stops browser audio resources", async () => {
+    const browser = await chromium.launch({ executablePath: chromiumExecutablePath });
+    const context = await browser.newContext({ permissions: ["microphone"] });
+    const page = await context.newPage();
+    const gateway = await installMockGateway(page, {
+      methodResponses: {
+        "talk.client.create": {
+          provider: "google",
+          transport: "provider-websocket",
+          protocol: "google-live-bidi",
+          clientSecret: "auth_tokens/browser-talk-e2e",
+          websocketUrl:
+            "wss://generativelanguage.googleapis.com/ws/google.ai.generativelanguage.v1alpha.GenerativeService.BidiGenerateContentConstrained",
+          audio: {
+            inputEncoding: "pcm16",
+            inputSampleRateHz: 16_000,
+            outputEncoding: "pcm16",
+            outputSampleRateHz: 24_000,
+          },
+        },
+      },
+    });
+    await installTalkBrowserFixtures(page);
+
+    try {
+      await page.goto(`${server.baseUrl}chat`);
+      await page.getByRole("button", { name: "Start Talk" }).click();
+
+      const createRequest = await gateway.waitForRequest("talk.client.create");
+      expect(createRequest.params).toMatchObject({ sessionKey: "main" });
+      await expect
+        .poll(async () =>
+          (await gateway.getSocketUrls()).filter((url) => url.includes("BidiGenerateContent")),
+        )
+        .toEqual([
+          "wss://generativelanguage.googleapis.com/ws/google.ai.generativelanguage.v1alpha.GenerativeService.BidiGenerateContentConstrained?access_token=auth_tokens%2Fbrowser-talk-e2e",
+        ]);
+
+      await gateway.deliverLatest({ setupComplete: {} });
+      await expect
+        .poll(async () =>
+          (await page.locator(".agent-chat__talk-status-text").textContent())?.trim(),
+        )
+        .toBe("Talk live");
+
+      await page.getByRole("button", { name: "Stop Talk" }).click();
+      await expect
+        .poll(() => page.getByRole("button", { name: "Start Talk" }).isVisible())
+        .toBe(true);
+      await expect.poll(() => page.locator(".agent-chat__talk-status-text").count()).toBe(0);
+      await expect
+        .poll(() =>
+          page.evaluate(
+            () =>
+              (
+                window as Window & {
+                  openclawTalkE2eState?: { audioContextsClosed: number; tracksStopped: number };
+                }
+              ).openclawTalkE2eState,
+          ),
+        )
+        .toEqual({ audioContextsClosed: 2, tracksStopped: 1 });
+
+      await gateway.deliverLatest({ setupComplete: {} });
+      await expect
+        .poll(() => page.getByRole("button", { name: "Start Talk" }).isVisible())
+        .toBe(true);
+    } finally {
+      await context.close();
+      await browser.close();
+    }
+  });
+});


### PR DESCRIPTION
## What Problem This Solves

Several QA scenario rows described media delivery, browser Talk lifecycle, Voice Call entry points, heartbeat scheduling, and OpenTelemetry behavior without executing the corresponding runtime boundaries. That left the scenario catalog able to report coverage from helper-only or design-level checks rather than reusable executable fixtures.

## Why This Change Was Made

This adds bounded canaries at the existing owner seams: mock speech synthesis followed by the real WebChat media-ticket route, a real Playwright page for browser Talk start/stop, mock realtime and Voice Call providers behind actual Gateway/plugin entry points, a real-timer heartbeat schedule check, and direct OTEL producer execution through the shared script evidence writer. The active-run control fixture remains secondary evidence because its embedded-run dependencies are intentionally injected test boundaries.

## User Impact

There is no production behavior change. Maintainers get executable, reusable QA evidence for media, Talk, Voice Call, scheduler, and telemetry paths, with evidence claims constrained to the boundaries each fixture actually runs.

## Evidence

- `node scripts/run-vitest.mjs test/e2e/qa-lab/media/webchat-auto-tts.e2e.test.ts test/e2e/qa-lab/voice/active-talk-agent-run-status.e2e.test.ts extensions/voice-call/src/voice-call-cli-rpc-agent-tool.e2e.test.ts src/infra/heartbeat-runner.active-hours-schedule.e2e.test.ts test/e2e/qa-lab/runtime/qa-otel-smoke.e2e.test.ts extensions/qa-lab/src/test-file-scenario-runner.test.ts extensions/qa-lab/src/scenario-catalog.test.ts` — 98 assertions passed across the E2E and QA Lab shards.
- `node scripts/run-vitest.mjs run --config test/vitest/vitest.ui-e2e.config.ts --configLoader runner ui/src/ui/e2e/browser-talk-start-stop.e2e.test.ts --reporter=verbose` — Playwright Talk lifecycle passed.
- Direct `qa-otel-smoke-runtime.ts` execution — shared evidence status `pass`, relative summary artifact resolved correctly, and traces/metrics/correlated logs captured.
- Testbox-through-Crabbox `tbx_01kwnapfrp056k2ndxkmrmx2wr` — `check:changed` passed typecheck, lint, import-cycle, and repository guard lanes. Actions run: https://github.com/openclaw/openclaw/actions/runs/28690272139
- Final autoreview: no accepted/actionable findings.
