### PR TITLE
fix: stabilize QA smoke on constrained CI runners

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -882,7 +882,7 @@ jobs:
               pnpm openclaw qa run \
                 --repo-root . \
                 --qa-profile smoke-ci \
-                --concurrency 8 \
+                --concurrency 4 \
                 --output-dir "$output_dir" || qa_exit_code=$?
               echo "QA smoke profile evidence: \`${output_dir}\`" >> "$GITHUB_STEP_SUMMARY"
               if [ "$qa_exit_code" -ne 0 ]; then

--- a/test/scripts/ci-workflow-guards.test.ts
+++ b/test/scripts/ci-workflow-guards.test.ts
@@ -911,7 +911,7 @@ describe("ci workflow guards", () => {
       '{ check_name: "QA Smoke CI", runtime: "node", task: "qa-smoke-ci" }',
     );
     expect(runStep.run).toContain("--qa-profile smoke-ci");
-    expect(runStep.run).toContain("--concurrency 8");
+    expect(runStep.run).toContain("--concurrency 4");
     expect(runStep.run).not.toContain("--category");
     expect(runStep.run).not.toContain("--allow-failures");
     expect(runStep.run).toContain("qa_exit_code=0");


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where the QA smoke CI check could time out intermittently on unrelated pull requests when eight isolated gateway scenarios competed on the 4-vCPU worker.

The same pattern appeared on first attempts for PRs #99694 and #99713, then passed on immediate reruns. Retained artifacts showed both the reported `native-command-session-target` timeout and an adjacent gateway/startup timeout under the same concurrency setting.

## Why This Change Was Made

Limit the existing `smoke-ci` profile to four scenario workers in the CI workflow and keep the workflow guard synchronized. This preserves the profile, scenario coverage, failure behavior, and evidence upload contract while matching concurrency to the runner capacity; it does not change the QA runner or product behavior.

## User Impact

Contributors should see fewer unrelated QA smoke reruns. The lane may trade some wall-clock speed for more stable execution on the constrained CI worker.

## Evidence

- Retained CI artifacts: concurrency 8 produced a first-attempt `native-command-session-target` 30-second timeout and a separate run with gateway/startup stalls; both runs passed their immediate reruns without code changes.
- `git diff --check`
- `node scripts/run-vitest.mjs test/scripts/ci-workflow-guards.test.ts` — 33/33 passed on the final base.
- Delegated Blacksmith Testbox `check:changed` — `tbx_01kwnatxgsedr6t8azw1sqwxtb`, run `28690336758`, exit 0.
- Delegated Blacksmith Testbox `check:workflows` — `tbx_01kwnaykgyaaf8sp2b2dx9fqm6`, run `28690385743`, exit 0.
- Final structured autoreview — no accepted/actionable findings; patch correct at 0.99 confidence.
