### PR TITLE
fix: keep Codex delegation controls directly available

### DIFF
--- a/extensions/codex/src/app-server/dynamic-tools.test.ts
+++ b/extensions/codex/src/app-server/dynamic-tools.test.ts
@@ -209,7 +209,11 @@ describe("createCodexDynamicToolBridge", () => {
       namespace: CODEX_OPENCLAW_DYNAMIC_TOOL_NAMESPACE,
       deferLoading: true,
     });
-    expectNoNamespace(heartbeat);
+    expectDynamicSpec(heartbeat, {
+      name: HEARTBEAT_RESPONSE_TOOL_NAME,
+      namespace: CODEX_OPENCLAW_DYNAMIC_TOOL_NAMESPACE,
+      deferLoading: true,
+    });
     expectNoNamespace(agentsList);
     expectNoNamespace(sessionsSpawn);
     expectNoNamespace(sessionsYield);
@@ -254,7 +258,7 @@ describe("createCodexDynamicToolBridge", () => {
     });
 
     expect(specNames(bridge.availableSpecs)).toEqual(["message"]);
-    expect(specNames(bridge.specs).toSorted()).toEqual([HEARTBEAT_RESPONSE_TOOL_NAME, "message"]);
+    expect(specNames(bridge.specs)).toEqual(["message", HEARTBEAT_RESPONSE_TOOL_NAME]);
 
     const result = await bridge.handleToolCall(
       {

--- a/extensions/codex/src/app-server/dynamic-tools.test.ts
+++ b/extensions/codex/src/app-server/dynamic-tools.test.ts
@@ -178,7 +178,7 @@ afterEach(() => {
 });
 
 describe("createCodexDynamicToolBridge", () => {
-  it("keeps turn-yield direct while deferring OpenClaw session spawn", () => {
+  it("keeps OpenClaw control-path tools direct while deferring broad tools", () => {
     const bridge = createCodexDynamicToolBridge({
       tools: [
         createTool({ name: "web_search" }),
@@ -207,16 +207,8 @@ describe("createCodexDynamicToolBridge", () => {
       namespace: CODEX_OPENCLAW_DYNAMIC_TOOL_NAMESPACE,
       deferLoading: true,
     });
-    expectDynamicSpec(heartbeat, {
-      name: HEARTBEAT_RESPONSE_TOOL_NAME,
-      namespace: CODEX_OPENCLAW_DYNAMIC_TOOL_NAMESPACE,
-      deferLoading: true,
-    });
-    expectDynamicSpec(sessionsSpawn, {
-      name: "sessions_spawn",
-      namespace: CODEX_OPENCLAW_DYNAMIC_TOOL_NAMESPACE,
-      deferLoading: true,
-    });
+    expectNoNamespace(heartbeat);
+    expectNoNamespace(sessionsSpawn);
     expectNoNamespace(sessionsYield);
   });
 
@@ -259,7 +251,7 @@ describe("createCodexDynamicToolBridge", () => {
     });
 
     expect(specNames(bridge.availableSpecs)).toEqual(["message"]);
-    expect(specNames(bridge.specs)).toEqual(["message", HEARTBEAT_RESPONSE_TOOL_NAME]);
+    expect(specNames(bridge.specs).sort()).toEqual([HEARTBEAT_RESPONSE_TOOL_NAME, "message"]);
 
     const result = await bridge.handleToolCall(
       {

--- a/extensions/codex/src/app-server/dynamic-tools.test.ts
+++ b/extensions/codex/src/app-server/dynamic-tools.test.ts
@@ -184,6 +184,7 @@ describe("createCodexDynamicToolBridge", () => {
         createTool({ name: "web_search" }),
         createTool({ name: "message" }),
         createTool({ name: HEARTBEAT_RESPONSE_TOOL_NAME }),
+        createTool({ name: "agents_list" }),
         createTool({ name: "sessions_spawn" }),
         createTool({ name: "sessions_yield" }),
       ],
@@ -194,6 +195,7 @@ describe("createCodexDynamicToolBridge", () => {
     const webSearch = specs.find((tool) => tool.name === "web_search");
     const message = specs.find((tool) => tool.name === "message");
     const heartbeat = specs.find((tool) => tool.name === HEARTBEAT_RESPONSE_TOOL_NAME);
+    const agentsList = specs.find((tool) => tool.name === "agents_list");
     const sessionsSpawn = specs.find((tool) => tool.name === "sessions_spawn");
     const sessionsYield = specs.find((tool) => tool.name === "sessions_yield");
 
@@ -208,6 +210,7 @@ describe("createCodexDynamicToolBridge", () => {
       deferLoading: true,
     });
     expectNoNamespace(heartbeat);
+    expectNoNamespace(agentsList);
     expectNoNamespace(sessionsSpawn);
     expectNoNamespace(sessionsYield);
   });

--- a/extensions/codex/src/app-server/dynamic-tools.test.ts
+++ b/extensions/codex/src/app-server/dynamic-tools.test.ts
@@ -251,7 +251,7 @@ describe("createCodexDynamicToolBridge", () => {
     });
 
     expect(specNames(bridge.availableSpecs)).toEqual(["message"]);
-    expect(specNames(bridge.specs).sort()).toEqual([HEARTBEAT_RESPONSE_TOOL_NAME, "message"]);
+    expect(specNames(bridge.specs).toSorted()).toEqual([HEARTBEAT_RESPONSE_TOOL_NAME, "message"]);
 
     const result = await bridge.handleToolCall(
       {

--- a/extensions/codex/src/app-server/dynamic-tools.ts
+++ b/extensions/codex/src/app-server/dynamic-tools.ts
@@ -435,9 +435,6 @@ export function createCodexDynamicToolBridge(params: {
     ...ALWAYS_DIRECT_DYNAMIC_TOOL_NAMES,
     ...(params.directToolNames ?? []),
   ]);
-  if (availableTools.some((entry) => entry.name === HEARTBEAT_RESPONSE_TOOL_NAME)) {
-    directToolNames.add(HEARTBEAT_RESPONSE_TOOL_NAME);
-  }
   return {
     availableSpecs: createCodexDynamicToolSpecs({
       entries: availableTools,

--- a/extensions/codex/src/app-server/dynamic-tools.ts
+++ b/extensions/codex/src/app-server/dynamic-tools.ts
@@ -353,9 +353,14 @@ export type CodexDynamicToolBridge = {
 /** Namespace attached to OpenClaw-owned dynamic tools exposed to Codex. */
 export const CODEX_OPENCLAW_DYNAMIC_TOOL_NAMESPACE = "openclaw";
 
-// Keep OpenClaw session spawning searchable in Codex mode so Codex's native
-// spawn_agent remains the primary Codex subagent surface.
-const ALWAYS_DIRECT_DYNAMIC_TOOL_NAMES = new Set(["sessions_yield"]);
+// Keep OpenClaw control-path tools directly callable even when Codex tool_search
+// is unavailable or resolves a connector-only universe. Developer instructions
+// still steer normal Codex subagents to native spawn_agent.
+const ALWAYS_DIRECT_DYNAMIC_TOOL_NAMES = new Set([
+  HEARTBEAT_RESPONSE_TOOL_NAME,
+  "sessions_spawn",
+  "sessions_yield",
+]);
 const EXPLICIT_MESSAGE_PROVIDER_KEYS = ["channel", "provider"];
 const EXPLICIT_MESSAGE_TARGET_KEYS = ["target", "to", "channelId"];
 const EXPLICIT_MESSAGE_THREAD_KEYS = ["threadId", "thread_id", "messageThreadId", "topicId"];

--- a/extensions/codex/src/app-server/dynamic-tools.ts
+++ b/extensions/codex/src/app-server/dynamic-tools.ts
@@ -357,7 +357,7 @@ export const CODEX_OPENCLAW_DYNAMIC_TOOL_NAMESPACE = "openclaw";
 // is unavailable or resolves a connector-only universe. Developer instructions
 // still steer normal Codex subagents to native spawn_agent.
 const ALWAYS_DIRECT_DYNAMIC_TOOL_NAMES = new Set([
-  HEARTBEAT_RESPONSE_TOOL_NAME,
+  "agents_list",
   "sessions_spawn",
   "sessions_yield",
 ]);
@@ -435,6 +435,9 @@ export function createCodexDynamicToolBridge(params: {
     ...ALWAYS_DIRECT_DYNAMIC_TOOL_NAMES,
     ...(params.directToolNames ?? []),
   ]);
+  if (availableTools.some((entry) => entry.name === HEARTBEAT_RESPONSE_TOOL_NAME)) {
+    directToolNames.add(HEARTBEAT_RESPONSE_TOOL_NAME);
+  }
   return {
     availableSpecs: createCodexDynamicToolSpecs({
       entries: availableTools,

--- a/extensions/codex/src/app-server/run-attempt.test.ts
+++ b/extensions/codex/src/app-server/run-attempt.test.ts
@@ -1594,7 +1594,7 @@ describe("runCodexAppServerAttempt", () => {
     expect(dynamicToolNames).toEqual(["message"]);
   });
 
-  it("keeps searchable OpenClaw dynamic tools when code-mode-only is enabled", () => {
+  it("keeps OpenClaw control-path tools direct when code-mode-only is enabled", () => {
     const tools = [
       createRuntimeDynamicTool("message"),
       createRuntimeDynamicTool("web_search"),
@@ -1619,10 +1619,10 @@ describe("runCodexAppServerAttempt", () => {
     expect(message).not.toHaveProperty("deferLoading");
     expect(webSearch?.namespace).toBe(CODEX_OPENCLAW_DYNAMIC_TOOL_NAMESPACE);
     expect(webSearch?.deferLoading).toBe(true);
-    expect(heartbeat?.namespace).toBe(CODEX_OPENCLAW_DYNAMIC_TOOL_NAMESPACE);
-    expect(heartbeat?.deferLoading).toBe(true);
-    expect(sessionsSpawn?.namespace).toBe(CODEX_OPENCLAW_DYNAMIC_TOOL_NAMESPACE);
-    expect(sessionsSpawn?.deferLoading).toBe(true);
+    expect(heartbeat).not.toHaveProperty("namespace");
+    expect(heartbeat).not.toHaveProperty("deferLoading");
+    expect(sessionsSpawn).not.toHaveProperty("namespace");
+    expect(sessionsSpawn).not.toHaveProperty("deferLoading");
     expect(sessionsYield).not.toHaveProperty("namespace");
     expect(sessionsYield).not.toHaveProperty("deferLoading");
   });
@@ -1683,8 +1683,9 @@ describe("runCodexAppServerAttempt", () => {
       registeredTools,
     );
 
-    expect(specNames(heartbeatBridge.specs)).toEqual(registeredToolNames);
-    expect(specNames(nextNormalBridge.specs)).toEqual(registeredToolNames);
+    const sortedRegisteredToolNames = [...registeredToolNames].sort();
+    expect(specNames(heartbeatBridge.specs).sort()).toEqual(sortedRegisteredToolNames);
+    expect(specNames(nextNormalBridge.specs).sort()).toEqual(sortedRegisteredToolNames);
   });
 
   it("keeps message in the registered schema when disabled for an internal turn", async () => {

--- a/extensions/codex/src/app-server/run-attempt.test.ts
+++ b/extensions/codex/src/app-server/run-attempt.test.ts
@@ -1621,8 +1621,8 @@ describe("runCodexAppServerAttempt", () => {
     expect(message).not.toHaveProperty("deferLoading");
     expect(webSearch?.namespace).toBe(CODEX_OPENCLAW_DYNAMIC_TOOL_NAMESPACE);
     expect(webSearch?.deferLoading).toBe(true);
-    expect(heartbeat).not.toHaveProperty("namespace");
-    expect(heartbeat).not.toHaveProperty("deferLoading");
+    expect(heartbeat?.namespace).toBe(CODEX_OPENCLAW_DYNAMIC_TOOL_NAMESPACE);
+    expect(heartbeat?.deferLoading).toBe(true);
     expect(agentsList).not.toHaveProperty("namespace");
     expect(agentsList).not.toHaveProperty("deferLoading");
     expect(sessionsSpawn).not.toHaveProperty("namespace");
@@ -1631,7 +1631,7 @@ describe("runCodexAppServerAttempt", () => {
     expect(sessionsYield).not.toHaveProperty("deferLoading");
   });
 
-  it("registers heartbeat response durably without advertising it on normal turns", async () => {
+  it("keeps the heartbeat schema deferred and stable across normal and heartbeat turns", async () => {
     testing.setOpenClawCodingToolsFactoryForTests((options) => [
       createRuntimeDynamicTool("message"),
       ...(options?.enableHeartbeatTool === true
@@ -1644,11 +1644,9 @@ describe("runCodexAppServerAttempt", () => {
       const params = createParams(sessionFile, workspaceDir);
       params.disableTools = false;
       params.runtimePlan = createCodexRuntimePlanFixture();
+      params.sourceReplyDeliveryMode = "message_tool_only";
       if (trigger) {
         params.trigger = trigger;
-      }
-      if (trigger === "heartbeat") {
-        params.sourceReplyDeliveryMode = "message_tool_only";
       }
       return params;
     };
@@ -1665,46 +1663,76 @@ describe("runCodexAppServerAttempt", () => {
     const normalInstructions = testing.buildDeveloperInstructions(createRunParams(), {
       dynamicTools: normalBridge.availableSpecs,
     });
+    const heartbeatParams = createRunParams("heartbeat");
+    const heartbeatBridge = createCodexToolBridgeForTest(
+      heartbeatParams,
+      [createRuntimeDynamicTool("message"), createRuntimeDynamicTool("heartbeat_respond")],
+      registeredTools,
+    );
+    const heartbeatInstructions = testing.buildDeveloperInstructions(heartbeatParams, {
+      dynamicTools: heartbeatBridge.availableSpecs,
+    });
+    const nextNormalParams = createRunParams();
+    const nextNormalBridge = createCodexToolBridgeForTest(
+      nextNormalParams,
+      [createRuntimeDynamicTool("message")],
+      registeredTools,
+    );
     const registeredToolNames = specNames(normalBridge.specs);
 
     expect(registeredToolNames).toContain("message");
     expect(registeredToolNames).toContain("heartbeat_respond");
-    expect(normalInstructions).toContain(
-      "Deferred searchable OpenClaw dynamic tools available: message.",
-    );
     expect(normalInstructions).not.toContain(
       "Deferred searchable OpenClaw dynamic tools available: heartbeat_respond",
     );
-
-    const heartbeatBridge = createCodexToolBridgeForTest(
-      createRunParams("heartbeat"),
-      [createRuntimeDynamicTool("message"), createRuntimeDynamicTool("heartbeat_respond")],
-      registeredTools,
+    expect(heartbeatInstructions).toContain(
+      "Deferred searchable OpenClaw dynamic tools available: heartbeat_respond.",
     );
-    const nextNormalBridge = createCodexToolBridgeForTest(
-      createRunParams(),
-      [createRuntimeDynamicTool("message")],
-      registeredTools,
-    );
-
-    const sortedRegisteredToolNames = registeredToolNames.toSorted();
-    expect(specNames(heartbeatBridge.specs).toSorted()).toEqual(sortedRegisteredToolNames);
-    expect(specNames(nextNormalBridge.specs).toSorted()).toEqual(sortedRegisteredToolNames);
-    expect(
-      heartbeatBridge.specs.find(
-        (tool) => tool.type === "function" && tool.name === "heartbeat_respond",
-      ),
-    ).toBeDefined();
-    expect(
-      nextNormalBridge.specs.find(
-        (tool) => tool.type === "function" && tool.name === "heartbeat_respond",
-      ),
-    ).toBeUndefined();
-    expect(
-      flattenSpecsWithNamespace(nextNormalBridge.specs).find(
+    for (const bridge of [normalBridge, heartbeatBridge, nextNormalBridge]) {
+      const heartbeat = flattenSpecsWithNamespace(bridge.specs).find(
         (tool) => tool.name === "heartbeat_respond",
-      )?.namespace,
-    ).toBe(CODEX_OPENCLAW_DYNAMIC_TOOL_NAMESPACE);
+      );
+      expect(heartbeat?.namespace).toBe(CODEX_OPENCLAW_DYNAMIC_TOOL_NAMESPACE);
+      expect(heartbeat?.deferLoading).toBe(true);
+    }
+    expect(codexDynamicToolsFingerprint(heartbeatBridge.specs)).toBe(
+      codexDynamicToolsFingerprint(normalBridge.specs),
+    );
+    expect(codexDynamicToolsFingerprint(nextNormalBridge.specs)).toBe(
+      codexDynamicToolsFingerprint(normalBridge.specs),
+    );
+
+    let startedThreadId: string | undefined;
+    const request = vi.fn(async (method: string) => {
+      if (method === "thread/start") {
+        startedThreadId = "thread-stable-heartbeat";
+        return threadStartResult(startedThreadId);
+      }
+      if (method === "thread/resume") {
+        return threadStartResult(startedThreadId);
+      }
+      throw new Error(`unexpected method: ${method}`);
+    });
+    const turns = [
+      { params: createRunParams(), bridge: normalBridge },
+      { params: heartbeatParams, bridge: heartbeatBridge },
+      { params: nextNormalParams, bridge: nextNormalBridge },
+    ];
+    for (const turn of turns) {
+      await startOrResumeThread({
+        client: { request } as never,
+        params: turn.params,
+        cwd: workspaceDir,
+        dynamicTools: turn.bridge.specs,
+        appServer: createThreadLifecycleAppServerOptions(),
+      });
+    }
+
+    expect(request.mock.calls.map(([method]) => method)).toEqual([
+      "thread/start",
+      "thread/resume",
+      "thread/resume",
+    ]);
   });
 
   it("keeps message in the registered schema when disabled for an internal turn", async () => {

--- a/extensions/codex/src/app-server/run-attempt.test.ts
+++ b/extensions/codex/src/app-server/run-attempt.test.ts
@@ -1683,9 +1683,9 @@ describe("runCodexAppServerAttempt", () => {
       registeredTools,
     );
 
-    const sortedRegisteredToolNames = [...registeredToolNames].sort();
-    expect(specNames(heartbeatBridge.specs).sort()).toEqual(sortedRegisteredToolNames);
-    expect(specNames(nextNormalBridge.specs).sort()).toEqual(sortedRegisteredToolNames);
+    const sortedRegisteredToolNames = registeredToolNames.toSorted();
+    expect(specNames(heartbeatBridge.specs).toSorted()).toEqual(sortedRegisteredToolNames);
+    expect(specNames(nextNormalBridge.specs).toSorted()).toEqual(sortedRegisteredToolNames);
   });
 
   it("keeps message in the registered schema when disabled for an internal turn", async () => {

--- a/extensions/codex/src/app-server/run-attempt.test.ts
+++ b/extensions/codex/src/app-server/run-attempt.test.ts
@@ -1599,6 +1599,7 @@ describe("runCodexAppServerAttempt", () => {
       createRuntimeDynamicTool("message"),
       createRuntimeDynamicTool("web_search"),
       createRuntimeDynamicTool("heartbeat_respond"),
+      createRuntimeDynamicTool("agents_list"),
       createRuntimeDynamicTool("sessions_spawn"),
       createRuntimeDynamicTool("sessions_yield"),
     ];
@@ -1612,6 +1613,7 @@ describe("runCodexAppServerAttempt", () => {
     const message = specs.find((tool) => tool.name === "message");
     const webSearch = specs.find((tool) => tool.name === "web_search");
     const heartbeat = specs.find((tool) => tool.name === "heartbeat_respond");
+    const agentsList = specs.find((tool) => tool.name === "agents_list");
     const sessionsSpawn = specs.find((tool) => tool.name === "sessions_spawn");
     const sessionsYield = specs.find((tool) => tool.name === "sessions_yield");
 
@@ -1621,6 +1623,8 @@ describe("runCodexAppServerAttempt", () => {
     expect(webSearch?.deferLoading).toBe(true);
     expect(heartbeat).not.toHaveProperty("namespace");
     expect(heartbeat).not.toHaveProperty("deferLoading");
+    expect(agentsList).not.toHaveProperty("namespace");
+    expect(agentsList).not.toHaveProperty("deferLoading");
     expect(sessionsSpawn).not.toHaveProperty("namespace");
     expect(sessionsSpawn).not.toHaveProperty("deferLoading");
     expect(sessionsYield).not.toHaveProperty("namespace");
@@ -1686,6 +1690,21 @@ describe("runCodexAppServerAttempt", () => {
     const sortedRegisteredToolNames = registeredToolNames.toSorted();
     expect(specNames(heartbeatBridge.specs).toSorted()).toEqual(sortedRegisteredToolNames);
     expect(specNames(nextNormalBridge.specs).toSorted()).toEqual(sortedRegisteredToolNames);
+    expect(
+      heartbeatBridge.specs.find(
+        (tool) => tool.type === "function" && tool.name === "heartbeat_respond",
+      ),
+    ).toBeDefined();
+    expect(
+      nextNormalBridge.specs.find(
+        (tool) => tool.type === "function" && tool.name === "heartbeat_respond",
+      ),
+    ).toBeUndefined();
+    expect(
+      flattenSpecsWithNamespace(nextNormalBridge.specs).find(
+        (tool) => tool.name === "heartbeat_respond",
+      )?.namespace,
+    ).toBe(CODEX_OPENCLAW_DYNAMIC_TOOL_NAMESPACE);
   });
 
   it("keeps message in the registered schema when disabled for an internal turn", async () => {

--- a/extensions/codex/src/app-server/run-attempt.ts
+++ b/extensions/codex/src/app-server/run-attempt.ts
@@ -3801,10 +3801,10 @@ function handleApprovalRequest(params: {
 }
 
 function resolveCodexDynamicToolDirectNames(params: EmbeddedRunAttemptParams): string[] {
-  if (params.sourceReplyDeliveryMode === "message_tool_only") {
-    return ["message"];
+  if (params.sourceReplyDeliveryMode !== "message_tool_only") {
+    return [];
   }
-  return [];
+  return ["message"];
 }
 
 export const testing = {

--- a/extensions/codex/src/app-server/run-attempt.ts
+++ b/extensions/codex/src/app-server/run-attempt.ts
@@ -3801,10 +3801,10 @@ function handleApprovalRequest(params: {
 }
 
 function resolveCodexDynamicToolDirectNames(params: EmbeddedRunAttemptParams): string[] {
-  if (params.sourceReplyDeliveryMode !== "message_tool_only") {
-    return [];
+  if (params.sourceReplyDeliveryMode === "message_tool_only") {
+    return ["message"];
   }
-  return ["message"];
+  return [];
 }
 
 export const testing = {

--- a/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/codex-dynamic-tools.discord-group.json
+++ b/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/codex-dynamic-tools.discord-group.json
@@ -125,6 +125,99 @@
     "type": "function"
   },
   {
+    "description": "Spawn clean child session; default `runtime=\"subagent\"`. `mode=\"run\"` one-shot; `mode=\"session\"` persistent/thread-bound, only when requester channel supports thread bindings. Subagents inherit parent workspace. Native subagents get task in first visible `[Subagent Task]` message. Native only: `context=\"fork\"` only when child needs current transcript; else omit or `isolated`. Use for fresh child-session work. Delegate sidecar/parallel tasks: batch file reads, multi-step searches, data collection. Avoid delegating quick lookups or single-file reads unless policy prefers delegation. After spawning, do non-overlapping work; run-mode results return, session-mode output stays in thread.",
+    "inputSchema": {
+      "properties": {
+        "agentId": {
+          "type": "string"
+        },
+        "attachAs": {
+          "properties": {
+            "mountPath": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "attachments": {
+          "items": {
+            "properties": {
+              "content": {
+                "type": "string"
+              },
+              "encoding": {
+                "enum": ["utf8", "base64"],
+                "type": "string"
+              },
+              "mimeType": {
+                "type": "string"
+              },
+              "name": {
+                "type": "string"
+              }
+            },
+            "required": ["name", "content"],
+            "type": "object"
+          },
+          "maxItems": 50,
+          "type": "array"
+        },
+        "cleanup": {
+          "enum": ["delete", "keep"],
+          "type": "string"
+        },
+        "context": {
+          "description": "Native context. Omit/\"isolated\" for clean child; \"fork\" only when child needs requester transcript.",
+          "enum": ["isolated", "fork"],
+          "type": "string"
+        },
+        "cwd": {
+          "type": "string"
+        },
+        "label": {
+          "type": "string"
+        },
+        "lightContext": {
+          "description": "Light bootstrap context; runtime=\"subagent\" only.",
+          "type": "boolean"
+        },
+        "mode": {
+          "enum": ["run", "session"],
+          "type": "string"
+        },
+        "model": {
+          "type": "string"
+        },
+        "runtime": {
+          "enum": ["subagent"],
+          "type": "string"
+        },
+        "sandbox": {
+          "enum": ["inherit", "require"],
+          "type": "string"
+        },
+        "task": {
+          "type": "string"
+        },
+        "taskName": {
+          "description": "Stable alias for later targeting; lowercase letters/digits/underscores/hyphens, starts letter.",
+          "type": "string"
+        },
+        "thinking": {
+          "type": "string"
+        },
+        "thread": {
+          "description": "Bind spawn to new chat thread when supported. `thread=true` defaults mode=\"session\".",
+          "type": "boolean"
+        }
+      },
+      "required": ["task"],
+      "type": "object"
+    },
+    "name": "sessions_spawn",
+    "type": "function"
+  },
+  {
     "description": "End current turn. Use after spawning subagents; results arrive as next message.",
     "inputSchema": {
       "properties": {
@@ -1115,100 +1208,6 @@
           "type": "object"
         },
         "name": "sessions_send",
-        "type": "function"
-      },
-      {
-        "deferLoading": true,
-        "description": "Spawn clean child session; default `runtime=\"subagent\"`. `mode=\"run\"` one-shot; `mode=\"session\"` persistent/thread-bound, only when requester channel supports thread bindings. Subagents inherit parent workspace. Native subagents get task in first visible `[Subagent Task]` message. Native only: `context=\"fork\"` only when child needs current transcript; else omit or `isolated`. Use for fresh child-session work. Delegate sidecar/parallel tasks: batch file reads, multi-step searches, data collection. Avoid delegating quick lookups or single-file reads unless policy prefers delegation. After spawning, do non-overlapping work; run-mode results return, session-mode output stays in thread.",
-        "inputSchema": {
-          "properties": {
-            "agentId": {
-              "type": "string"
-            },
-            "attachAs": {
-              "properties": {
-                "mountPath": {
-                  "type": "string"
-                }
-              },
-              "type": "object"
-            },
-            "attachments": {
-              "items": {
-                "properties": {
-                  "content": {
-                    "type": "string"
-                  },
-                  "encoding": {
-                    "enum": ["utf8", "base64"],
-                    "type": "string"
-                  },
-                  "mimeType": {
-                    "type": "string"
-                  },
-                  "name": {
-                    "type": "string"
-                  }
-                },
-                "required": ["name", "content"],
-                "type": "object"
-              },
-              "maxItems": 50,
-              "type": "array"
-            },
-            "cleanup": {
-              "enum": ["delete", "keep"],
-              "type": "string"
-            },
-            "context": {
-              "description": "Native context. Omit/\"isolated\" for clean child; \"fork\" only when child needs requester transcript.",
-              "enum": ["isolated", "fork"],
-              "type": "string"
-            },
-            "cwd": {
-              "type": "string"
-            },
-            "label": {
-              "type": "string"
-            },
-            "lightContext": {
-              "description": "Light bootstrap context; runtime=\"subagent\" only.",
-              "type": "boolean"
-            },
-            "mode": {
-              "enum": ["run", "session"],
-              "type": "string"
-            },
-            "model": {
-              "type": "string"
-            },
-            "runtime": {
-              "enum": ["subagent"],
-              "type": "string"
-            },
-            "sandbox": {
-              "enum": ["inherit", "require"],
-              "type": "string"
-            },
-            "task": {
-              "type": "string"
-            },
-            "taskName": {
-              "description": "Stable alias for later targeting; lowercase letters/digits/underscores/hyphens, starts letter.",
-              "type": "string"
-            },
-            "thinking": {
-              "type": "string"
-            },
-            "thread": {
-              "description": "Bind spawn to new chat thread when supported. `thread=true` defaults mode=\"session\".",
-              "type": "boolean"
-            }
-          },
-          "required": ["task"],
-          "type": "object"
-        },
-        "name": "sessions_spawn",
         "type": "function"
       },
       {

--- a/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/codex-dynamic-tools.discord-group.json
+++ b/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/codex-dynamic-tools.discord-group.json
@@ -125,6 +125,15 @@
     "type": "function"
   },
   {
+    "description": "List agent ids allowed for `sessions_spawn runtime=\"subagent\"`.",
+    "inputSchema": {
+      "properties": {},
+      "type": "object"
+    },
+    "name": "agents_list",
+    "type": "function"
+  },
+  {
     "description": "Spawn clean child session; default `runtime=\"subagent\"`. `mode=\"run\"` one-shot; `mode=\"session\"` persistent/thread-bound, only when requester channel supports thread bindings. Subagents inherit parent workspace. Native subagents get task in first visible `[Subagent Task]` message. Native only: `context=\"fork\"` only when child needs current transcript; else omit or `isolated`. Use for fresh child-session work. Delegate sidecar/parallel tasks: batch file reads, multi-step searches, data collection. Avoid delegating quick lookups or single-file reads unless policy prefers delegation. After spawning, do non-overlapping work; run-mode results return, session-mode output stays in thread.",
     "inputSchema": {
       "properties": {
@@ -1092,16 +1101,6 @@
           "type": "object"
         },
         "name": "gateway",
-        "type": "function"
-      },
-      {
-        "deferLoading": true,
-        "description": "List agent ids allowed for `sessions_spawn runtime=\"subagent\"`.",
-        "inputSchema": {
-          "properties": {},
-          "type": "object"
-        },
-        "name": "agents_list",
         "type": "function"
       },
       {

--- a/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/codex-dynamic-tools.heartbeat-turn.json
+++ b/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/codex-dynamic-tools.heartbeat-turn.json
@@ -125,41 +125,6 @@
     "type": "function"
   },
   {
-    "description": "Record heartbeat result. `notify=false` no visible send. `notify=true` needs concise notificationText.",
-    "inputSchema": {
-      "additionalProperties": false,
-      "properties": {
-        "nextCheck": {
-          "type": "string"
-        },
-        "notificationText": {
-          "type": "string"
-        },
-        "notify": {
-          "type": "boolean"
-        },
-        "outcome": {
-          "enum": ["no_change", "progress", "done", "blocked", "needs_attention"],
-          "type": "string"
-        },
-        "priority": {
-          "enum": ["low", "normal", "high"],
-          "type": "string"
-        },
-        "reason": {
-          "type": "string"
-        },
-        "summary": {
-          "type": "string"
-        }
-      },
-      "required": ["outcome", "notify", "summary"],
-      "type": "object"
-    },
-    "name": "heartbeat_respond",
-    "type": "function"
-  },
-  {
     "description": "List agent ids allowed for `sessions_spawn runtime=\"subagent\"`.",
     "inputSchema": {
       "properties": {},
@@ -1038,6 +1003,42 @@
           "type": "object"
         },
         "name": "cron",
+        "type": "function"
+      },
+      {
+        "deferLoading": true,
+        "description": "Record heartbeat result. `notify=false` no visible send. `notify=true` needs concise notificationText.",
+        "inputSchema": {
+          "additionalProperties": false,
+          "properties": {
+            "nextCheck": {
+              "type": "string"
+            },
+            "notificationText": {
+              "type": "string"
+            },
+            "notify": {
+              "type": "boolean"
+            },
+            "outcome": {
+              "enum": ["no_change", "progress", "done", "blocked", "needs_attention"],
+              "type": "string"
+            },
+            "priority": {
+              "enum": ["low", "normal", "high"],
+              "type": "string"
+            },
+            "reason": {
+              "type": "string"
+            },
+            "summary": {
+              "type": "string"
+            }
+          },
+          "required": ["outcome", "notify", "summary"],
+          "type": "object"
+        },
+        "name": "heartbeat_respond",
         "type": "function"
       },
       {

--- a/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/codex-dynamic-tools.heartbeat-turn.json
+++ b/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/codex-dynamic-tools.heartbeat-turn.json
@@ -125,6 +125,130 @@
     "type": "function"
   },
   {
+    "description": "Record heartbeat result. `notify=false` no visible send. `notify=true` needs concise notificationText.",
+    "inputSchema": {
+      "additionalProperties": false,
+      "properties": {
+        "nextCheck": {
+          "type": "string"
+        },
+        "notificationText": {
+          "type": "string"
+        },
+        "notify": {
+          "type": "boolean"
+        },
+        "outcome": {
+          "enum": ["no_change", "progress", "done", "blocked", "needs_attention"],
+          "type": "string"
+        },
+        "priority": {
+          "enum": ["low", "normal", "high"],
+          "type": "string"
+        },
+        "reason": {
+          "type": "string"
+        },
+        "summary": {
+          "type": "string"
+        }
+      },
+      "required": ["outcome", "notify", "summary"],
+      "type": "object"
+    },
+    "name": "heartbeat_respond",
+    "type": "function"
+  },
+  {
+    "description": "Spawn clean child session; default `runtime=\"subagent\"`. `mode=\"run\"` one-shot background work. Subagents inherit parent workspace. Native subagents get task in first visible `[Subagent Task]` message. Native only: `context=\"fork\"` only when child needs current transcript; else omit or `isolated`. Use for fresh child-session work. Delegate sidecar/parallel tasks: batch file reads, multi-step searches, data collection. Avoid delegating quick lookups or single-file reads unless policy prefers delegation. After spawning, do non-overlapping work while run-mode results return.",
+    "inputSchema": {
+      "properties": {
+        "agentId": {
+          "type": "string"
+        },
+        "attachAs": {
+          "properties": {
+            "mountPath": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "attachments": {
+          "items": {
+            "properties": {
+              "content": {
+                "type": "string"
+              },
+              "encoding": {
+                "enum": ["utf8", "base64"],
+                "type": "string"
+              },
+              "mimeType": {
+                "type": "string"
+              },
+              "name": {
+                "type": "string"
+              }
+            },
+            "required": ["name", "content"],
+            "type": "object"
+          },
+          "maxItems": 50,
+          "type": "array"
+        },
+        "cleanup": {
+          "enum": ["delete", "keep"],
+          "type": "string"
+        },
+        "context": {
+          "description": "Native context. Omit/\"isolated\" for clean child; \"fork\" only when child needs requester transcript.",
+          "enum": ["isolated", "fork"],
+          "type": "string"
+        },
+        "cwd": {
+          "type": "string"
+        },
+        "label": {
+          "type": "string"
+        },
+        "lightContext": {
+          "description": "Light bootstrap context; runtime=\"subagent\" only.",
+          "type": "boolean"
+        },
+        "mode": {
+          "enum": ["run"],
+          "type": "string"
+        },
+        "model": {
+          "type": "string"
+        },
+        "runtime": {
+          "enum": ["subagent"],
+          "type": "string"
+        },
+        "sandbox": {
+          "enum": ["inherit", "require"],
+          "type": "string"
+        },
+        "task": {
+          "type": "string"
+        },
+        "taskName": {
+          "description": "Stable alias for later targeting; lowercase letters/digits/underscores/hyphens, starts letter.",
+          "type": "string"
+        },
+        "thinking": {
+          "type": "string"
+        }
+      },
+      "required": ["task"],
+      "type": "object"
+    },
+    "name": "sessions_spawn",
+    "type": "function"
+  },
+  {
     "description": "End current turn. Use after spawning subagents; results arrive as next message.",
     "inputSchema": {
       "properties": {
@@ -909,42 +1033,6 @@
       },
       {
         "deferLoading": true,
-        "description": "Record heartbeat result. `notify=false` no visible send. `notify=true` needs concise notificationText.",
-        "inputSchema": {
-          "additionalProperties": false,
-          "properties": {
-            "nextCheck": {
-              "type": "string"
-            },
-            "notificationText": {
-              "type": "string"
-            },
-            "notify": {
-              "type": "boolean"
-            },
-            "outcome": {
-              "enum": ["no_change", "progress", "done", "blocked", "needs_attention"],
-              "type": "string"
-            },
-            "priority": {
-              "enum": ["low", "normal", "high"],
-              "type": "string"
-            },
-            "reason": {
-              "type": "string"
-            },
-            "summary": {
-              "type": "string"
-            }
-          },
-          "required": ["outcome", "notify", "summary"],
-          "type": "object"
-        },
-        "name": "heartbeat_respond",
-        "type": "function"
-      },
-      {
-        "deferLoading": true,
         "description": "Use only for explicit audio intent (voice/speech/TTS) or active TTS config. Never use for ordinary text replies. Audio auto-delivered from tool result; after success follow reply instructions, no duplicate text/audio.",
         "inputSchema": {
           "properties": {
@@ -1151,96 +1239,6 @@
           "type": "object"
         },
         "name": "sessions_send",
-        "type": "function"
-      },
-      {
-        "deferLoading": true,
-        "description": "Spawn clean child session; default `runtime=\"subagent\"`. `mode=\"run\"` one-shot background work. Subagents inherit parent workspace. Native subagents get task in first visible `[Subagent Task]` message. Native only: `context=\"fork\"` only when child needs current transcript; else omit or `isolated`. Use for fresh child-session work. Delegate sidecar/parallel tasks: batch file reads, multi-step searches, data collection. Avoid delegating quick lookups or single-file reads unless policy prefers delegation. After spawning, do non-overlapping work while run-mode results return.",
-        "inputSchema": {
-          "properties": {
-            "agentId": {
-              "type": "string"
-            },
-            "attachAs": {
-              "properties": {
-                "mountPath": {
-                  "type": "string"
-                }
-              },
-              "type": "object"
-            },
-            "attachments": {
-              "items": {
-                "properties": {
-                  "content": {
-                    "type": "string"
-                  },
-                  "encoding": {
-                    "enum": ["utf8", "base64"],
-                    "type": "string"
-                  },
-                  "mimeType": {
-                    "type": "string"
-                  },
-                  "name": {
-                    "type": "string"
-                  }
-                },
-                "required": ["name", "content"],
-                "type": "object"
-              },
-              "maxItems": 50,
-              "type": "array"
-            },
-            "cleanup": {
-              "enum": ["delete", "keep"],
-              "type": "string"
-            },
-            "context": {
-              "description": "Native context. Omit/\"isolated\" for clean child; \"fork\" only when child needs requester transcript.",
-              "enum": ["isolated", "fork"],
-              "type": "string"
-            },
-            "cwd": {
-              "type": "string"
-            },
-            "label": {
-              "type": "string"
-            },
-            "lightContext": {
-              "description": "Light bootstrap context; runtime=\"subagent\" only.",
-              "type": "boolean"
-            },
-            "mode": {
-              "enum": ["run"],
-              "type": "string"
-            },
-            "model": {
-              "type": "string"
-            },
-            "runtime": {
-              "enum": ["subagent"],
-              "type": "string"
-            },
-            "sandbox": {
-              "enum": ["inherit", "require"],
-              "type": "string"
-            },
-            "task": {
-              "type": "string"
-            },
-            "taskName": {
-              "description": "Stable alias for later targeting; lowercase letters/digits/underscores/hyphens, starts letter.",
-              "type": "string"
-            },
-            "thinking": {
-              "type": "string"
-            }
-          },
-          "required": ["task"],
-          "type": "object"
-        },
-        "name": "sessions_spawn",
         "type": "function"
       },
       {

--- a/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/codex-dynamic-tools.heartbeat-turn.json
+++ b/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/codex-dynamic-tools.heartbeat-turn.json
@@ -160,6 +160,15 @@
     "type": "function"
   },
   {
+    "description": "List agent ids allowed for `sessions_spawn runtime=\"subagent\"`.",
+    "inputSchema": {
+      "properties": {},
+      "type": "object"
+    },
+    "name": "agents_list",
+    "type": "function"
+  },
+  {
     "description": "Spawn clean child session; default `runtime=\"subagent\"`. `mode=\"run\"` one-shot background work. Subagents inherit parent workspace. Native subagents get task in first visible `[Subagent Task]` message. Native only: `context=\"fork\"` only when child needs current transcript; else omit or `isolated`. Use for fresh child-session work. Delegate sidecar/parallel tasks: batch file reads, multi-step searches, data collection. Avoid delegating quick lookups or single-file reads unless policy prefers delegation. After spawning, do non-overlapping work while run-mode results return.",
     "inputSchema": {
       "properties": {
@@ -1123,16 +1132,6 @@
           "type": "object"
         },
         "name": "gateway",
-        "type": "function"
-      },
-      {
-        "deferLoading": true,
-        "description": "List agent ids allowed for `sessions_spawn runtime=\"subagent\"`.",
-        "inputSchema": {
-          "properties": {},
-          "type": "object"
-        },
-        "name": "agents_list",
         "type": "function"
       },
       {

--- a/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/codex-dynamic-tools.telegram-direct.json
+++ b/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/codex-dynamic-tools.telegram-direct.json
@@ -125,6 +125,95 @@
     "type": "function"
   },
   {
+    "description": "Spawn clean child session; default `runtime=\"subagent\"`. `mode=\"run\"` one-shot background work. Subagents inherit parent workspace. Native subagents get task in first visible `[Subagent Task]` message. Native only: `context=\"fork\"` only when child needs current transcript; else omit or `isolated`. Use for fresh child-session work. Delegate sidecar/parallel tasks: batch file reads, multi-step searches, data collection. Avoid delegating quick lookups or single-file reads unless policy prefers delegation. After spawning, do non-overlapping work while run-mode results return.",
+    "inputSchema": {
+      "properties": {
+        "agentId": {
+          "type": "string"
+        },
+        "attachAs": {
+          "properties": {
+            "mountPath": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "attachments": {
+          "items": {
+            "properties": {
+              "content": {
+                "type": "string"
+              },
+              "encoding": {
+                "enum": ["utf8", "base64"],
+                "type": "string"
+              },
+              "mimeType": {
+                "type": "string"
+              },
+              "name": {
+                "type": "string"
+              }
+            },
+            "required": ["name", "content"],
+            "type": "object"
+          },
+          "maxItems": 50,
+          "type": "array"
+        },
+        "cleanup": {
+          "enum": ["delete", "keep"],
+          "type": "string"
+        },
+        "context": {
+          "description": "Native context. Omit/\"isolated\" for clean child; \"fork\" only when child needs requester transcript.",
+          "enum": ["isolated", "fork"],
+          "type": "string"
+        },
+        "cwd": {
+          "type": "string"
+        },
+        "label": {
+          "type": "string"
+        },
+        "lightContext": {
+          "description": "Light bootstrap context; runtime=\"subagent\" only.",
+          "type": "boolean"
+        },
+        "mode": {
+          "enum": ["run"],
+          "type": "string"
+        },
+        "model": {
+          "type": "string"
+        },
+        "runtime": {
+          "enum": ["subagent"],
+          "type": "string"
+        },
+        "sandbox": {
+          "enum": ["inherit", "require"],
+          "type": "string"
+        },
+        "task": {
+          "type": "string"
+        },
+        "taskName": {
+          "description": "Stable alias for later targeting; lowercase letters/digits/underscores/hyphens, starts letter.",
+          "type": "string"
+        },
+        "thinking": {
+          "type": "string"
+        }
+      },
+      "required": ["task"],
+      "type": "object"
+    },
+    "name": "sessions_spawn",
+    "type": "function"
+  },
+  {
     "description": "End current turn. Use after spawning subagents; results arrive as next message.",
     "inputSchema": {
       "properties": {
@@ -1115,96 +1204,6 @@
           "type": "object"
         },
         "name": "sessions_send",
-        "type": "function"
-      },
-      {
-        "deferLoading": true,
-        "description": "Spawn clean child session; default `runtime=\"subagent\"`. `mode=\"run\"` one-shot background work. Subagents inherit parent workspace. Native subagents get task in first visible `[Subagent Task]` message. Native only: `context=\"fork\"` only when child needs current transcript; else omit or `isolated`. Use for fresh child-session work. Delegate sidecar/parallel tasks: batch file reads, multi-step searches, data collection. Avoid delegating quick lookups or single-file reads unless policy prefers delegation. After spawning, do non-overlapping work while run-mode results return.",
-        "inputSchema": {
-          "properties": {
-            "agentId": {
-              "type": "string"
-            },
-            "attachAs": {
-              "properties": {
-                "mountPath": {
-                  "type": "string"
-                }
-              },
-              "type": "object"
-            },
-            "attachments": {
-              "items": {
-                "properties": {
-                  "content": {
-                    "type": "string"
-                  },
-                  "encoding": {
-                    "enum": ["utf8", "base64"],
-                    "type": "string"
-                  },
-                  "mimeType": {
-                    "type": "string"
-                  },
-                  "name": {
-                    "type": "string"
-                  }
-                },
-                "required": ["name", "content"],
-                "type": "object"
-              },
-              "maxItems": 50,
-              "type": "array"
-            },
-            "cleanup": {
-              "enum": ["delete", "keep"],
-              "type": "string"
-            },
-            "context": {
-              "description": "Native context. Omit/\"isolated\" for clean child; \"fork\" only when child needs requester transcript.",
-              "enum": ["isolated", "fork"],
-              "type": "string"
-            },
-            "cwd": {
-              "type": "string"
-            },
-            "label": {
-              "type": "string"
-            },
-            "lightContext": {
-              "description": "Light bootstrap context; runtime=\"subagent\" only.",
-              "type": "boolean"
-            },
-            "mode": {
-              "enum": ["run"],
-              "type": "string"
-            },
-            "model": {
-              "type": "string"
-            },
-            "runtime": {
-              "enum": ["subagent"],
-              "type": "string"
-            },
-            "sandbox": {
-              "enum": ["inherit", "require"],
-              "type": "string"
-            },
-            "task": {
-              "type": "string"
-            },
-            "taskName": {
-              "description": "Stable alias for later targeting; lowercase letters/digits/underscores/hyphens, starts letter.",
-              "type": "string"
-            },
-            "thinking": {
-              "type": "string"
-            }
-          },
-          "required": ["task"],
-          "type": "object"
-        },
-        "name": "sessions_spawn",
         "type": "function"
       },
       {

--- a/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/codex-dynamic-tools.telegram-direct.json
+++ b/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/codex-dynamic-tools.telegram-direct.json
@@ -125,6 +125,15 @@
     "type": "function"
   },
   {
+    "description": "List agent ids allowed for `sessions_spawn runtime=\"subagent\"`.",
+    "inputSchema": {
+      "properties": {},
+      "type": "object"
+    },
+    "name": "agents_list",
+    "type": "function"
+  },
+  {
     "description": "Spawn clean child session; default `runtime=\"subagent\"`. `mode=\"run\"` one-shot background work. Subagents inherit parent workspace. Native subagents get task in first visible `[Subagent Task]` message. Native only: `context=\"fork\"` only when child needs current transcript; else omit or `isolated`. Use for fresh child-session work. Delegate sidecar/parallel tasks: batch file reads, multi-step searches, data collection. Avoid delegating quick lookups or single-file reads unless policy prefers delegation. After spawning, do non-overlapping work while run-mode results return.",
     "inputSchema": {
       "properties": {
@@ -1088,16 +1097,6 @@
           "type": "object"
         },
         "name": "gateway",
-        "type": "function"
-      },
-      {
-        "deferLoading": true,
-        "description": "List agent ids allowed for `sessions_spawn runtime=\"subagent\"`.",
-        "inputSchema": {
-          "properties": {},
-          "type": "object"
-        },
-        "name": "agents_list",
         "type": "function"
       },
       {

--- a/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/discord-group-codex-message-tool.md
+++ b/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/discord-group-codex-message-tool.md
@@ -88,13 +88,13 @@
   "developerInstructions": "<see Reconstructed Model-Bound Prompt Layers>",
   "dynamicTools": [
     "message",
+    "agents_list",
     "sessions_spawn",
     "sessions_yield",
     "nodes",
     "cron",
     "tts",
     "gateway",
-    "agents_list",
     "sessions_list",
     "sessions_history",
     "sessions_send",
@@ -227,20 +227,20 @@ This is the deterministic model-bound layer stack OpenClaw can snapshot for the 
     "roughTokens": 0
   },
   "dynamicToolsJson": {
-    "chars": 50461,
-    "roughTokens": 12616
+    "chars": 50395,
+    "roughTokens": 12599
   },
   "openClawDeveloperInstructions": {
-    "chars": 3058,
-    "roughTokens": 765
+    "chars": 3045,
+    "roughTokens": 762
   },
   "totalTextOnly": {
-    "chars": 27676,
-    "roughTokens": 6919
+    "chars": 27663,
+    "roughTokens": 6916
   },
   "totalWithDynamicToolsJson": {
-    "chars": 78139,
-    "roughTokens": 19535
+    "chars": 78060,
+    "roughTokens": 19515
   },
   "userInputText": {
     "chars": 1535,
@@ -427,7 +427,7 @@ Approval policy is currently never. Do not provide the `sandbox_permissions` for
 ````text
 You are a personal agent running inside OpenClaw. OpenClaw has dynamic tools for OpenClaw-owned messaging, cron, sessions, media, gateway, and nodes.
 
-Deferred searchable OpenClaw dynamic tools available: agents_list, cron, gateway, nodes, session_status, sessions_history, sessions_list, sessions_send, subagents, tts, web_fetch, web_search. Use `tool_search` to load exact callable specs before use.
+Deferred searchable OpenClaw dynamic tools available: cron, gateway, nodes, session_status, sessions_history, sessions_list, sessions_send, subagents, tts, web_fetch, web_search. Use `tool_search` to load exact callable specs before use.
 
 Use Codex native `spawn_agent` for Codex subagents. Use OpenClaw `sessions_spawn` only for OpenClaw or ACP delegation.
 
@@ -560,13 +560,13 @@ Full JSON: `codex-dynamic-tools.discord-group.json`
 ```json
 [
   "message",
+  "agents_list",
   "sessions_spawn",
   "sessions_yield",
   "nodes",
   "cron",
   "tts",
   "gateway",
-  "agents_list",
   "sessions_list",
   "sessions_history",
   "sessions_send",

--- a/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/discord-group-codex-message-tool.md
+++ b/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/discord-group-codex-message-tool.md
@@ -88,6 +88,7 @@
   "developerInstructions": "<see Reconstructed Model-Bound Prompt Layers>",
   "dynamicTools": [
     "message",
+    "sessions_spawn",
     "sessions_yield",
     "nodes",
     "cron",
@@ -97,7 +98,6 @@
     "sessions_list",
     "sessions_history",
     "sessions_send",
-    "sessions_spawn",
     "subagents",
     "session_status",
     "web_search",
@@ -227,20 +227,20 @@ This is the deterministic model-bound layer stack OpenClaw can snapshot for the 
     "roughTokens": 0
   },
   "dynamicToolsJson": {
-    "chars": 50951,
-    "roughTokens": 12738
+    "chars": 50461,
+    "roughTokens": 12616
   },
   "openClawDeveloperInstructions": {
-    "chars": 3074,
-    "roughTokens": 769
+    "chars": 3058,
+    "roughTokens": 765
   },
   "totalTextOnly": {
-    "chars": 27692,
-    "roughTokens": 6923
+    "chars": 27676,
+    "roughTokens": 6919
   },
   "totalWithDynamicToolsJson": {
-    "chars": 78645,
-    "roughTokens": 19662
+    "chars": 78139,
+    "roughTokens": 19535
   },
   "userInputText": {
     "chars": 1535,
@@ -427,7 +427,7 @@ Approval policy is currently never. Do not provide the `sandbox_permissions` for
 ````text
 You are a personal agent running inside OpenClaw. OpenClaw has dynamic tools for OpenClaw-owned messaging, cron, sessions, media, gateway, and nodes.
 
-Deferred searchable OpenClaw dynamic tools available: agents_list, cron, gateway, nodes, session_status, sessions_history, sessions_list, sessions_send, sessions_spawn, subagents, tts, web_fetch, web_search. Use `tool_search` to load exact callable specs before use.
+Deferred searchable OpenClaw dynamic tools available: agents_list, cron, gateway, nodes, session_status, sessions_history, sessions_list, sessions_send, subagents, tts, web_fetch, web_search. Use `tool_search` to load exact callable specs before use.
 
 Use Codex native `spawn_agent` for Codex subagents. Use OpenClaw `sessions_spawn` only for OpenClaw or ACP delegation.
 
@@ -560,6 +560,7 @@ Full JSON: `codex-dynamic-tools.discord-group.json`
 ```json
 [
   "message",
+  "sessions_spawn",
   "sessions_yield",
   "nodes",
   "cron",
@@ -569,7 +570,6 @@ Full JSON: `codex-dynamic-tools.discord-group.json`
   "sessions_list",
   "sessions_history",
   "sessions_send",
-  "sessions_spawn",
   "subagents",
   "session_status",
   "web_search",

--- a/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/telegram-direct-codex-message-tool.md
+++ b/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/telegram-direct-codex-message-tool.md
@@ -88,13 +88,13 @@
   "developerInstructions": "<see Reconstructed Model-Bound Prompt Layers>",
   "dynamicTools": [
     "message",
+    "agents_list",
     "sessions_spawn",
     "sessions_yield",
     "nodes",
     "cron",
     "tts",
     "gateway",
-    "agents_list",
     "sessions_list",
     "sessions_history",
     "sessions_send",
@@ -227,20 +227,20 @@ This is the deterministic model-bound layer stack OpenClaw can snapshot for the 
     "roughTokens": 0
   },
   "dynamicToolsJson": {
-    "chars": 50150,
-    "roughTokens": 12538
+    "chars": 50084,
+    "roughTokens": 12521
   },
   "openClawDeveloperInstructions": {
-    "chars": 1949,
-    "roughTokens": 488
+    "chars": 1936,
+    "roughTokens": 484
   },
   "totalTextOnly": {
-    "chars": 26065,
-    "roughTokens": 6517
+    "chars": 26052,
+    "roughTokens": 6513
   },
   "totalWithDynamicToolsJson": {
-    "chars": 76217,
-    "roughTokens": 19055
+    "chars": 76138,
+    "roughTokens": 19035
   },
   "userInputText": {
     "chars": 1033,
@@ -427,7 +427,7 @@ Approval policy is currently never. Do not provide the `sandbox_permissions` for
 ````text
 You are a personal agent running inside OpenClaw. OpenClaw has dynamic tools for OpenClaw-owned messaging, cron, sessions, media, gateway, and nodes.
 
-Deferred searchable OpenClaw dynamic tools available: agents_list, cron, gateway, nodes, session_status, sessions_history, sessions_list, sessions_send, subagents, tts, web_fetch, web_search. Use `tool_search` to load exact callable specs before use.
+Deferred searchable OpenClaw dynamic tools available: cron, gateway, nodes, session_status, sessions_history, sessions_list, sessions_send, subagents, tts, web_fetch, web_search. Use `tool_search` to load exact callable specs before use.
 
 Use Codex native `spawn_agent` for Codex subagents. Use OpenClaw `sessions_spawn` only for OpenClaw or ACP delegation.
 
@@ -537,13 +537,13 @@ Full JSON: `codex-dynamic-tools.telegram-direct.json`
 ```json
 [
   "message",
+  "agents_list",
   "sessions_spawn",
   "sessions_yield",
   "nodes",
   "cron",
   "tts",
   "gateway",
-  "agents_list",
   "sessions_list",
   "sessions_history",
   "sessions_send",

--- a/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/telegram-direct-codex-message-tool.md
+++ b/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/telegram-direct-codex-message-tool.md
@@ -88,6 +88,7 @@
   "developerInstructions": "<see Reconstructed Model-Bound Prompt Layers>",
   "dynamicTools": [
     "message",
+    "sessions_spawn",
     "sessions_yield",
     "nodes",
     "cron",
@@ -97,7 +98,6 @@
     "sessions_list",
     "sessions_history",
     "sessions_send",
-    "sessions_spawn",
     "subagents",
     "session_status",
     "web_search",
@@ -227,20 +227,20 @@ This is the deterministic model-bound layer stack OpenClaw can snapshot for the 
     "roughTokens": 0
   },
   "dynamicToolsJson": {
-    "chars": 50620,
-    "roughTokens": 12655
+    "chars": 50150,
+    "roughTokens": 12538
   },
   "openClawDeveloperInstructions": {
-    "chars": 1965,
-    "roughTokens": 492
+    "chars": 1949,
+    "roughTokens": 488
   },
   "totalTextOnly": {
-    "chars": 26081,
-    "roughTokens": 6521
+    "chars": 26065,
+    "roughTokens": 6517
   },
   "totalWithDynamicToolsJson": {
-    "chars": 76703,
-    "roughTokens": 19176
+    "chars": 76217,
+    "roughTokens": 19055
   },
   "userInputText": {
     "chars": 1033,
@@ -427,7 +427,7 @@ Approval policy is currently never. Do not provide the `sandbox_permissions` for
 ````text
 You are a personal agent running inside OpenClaw. OpenClaw has dynamic tools for OpenClaw-owned messaging, cron, sessions, media, gateway, and nodes.
 
-Deferred searchable OpenClaw dynamic tools available: agents_list, cron, gateway, nodes, session_status, sessions_history, sessions_list, sessions_send, sessions_spawn, subagents, tts, web_fetch, web_search. Use `tool_search` to load exact callable specs before use.
+Deferred searchable OpenClaw dynamic tools available: agents_list, cron, gateway, nodes, session_status, sessions_history, sessions_list, sessions_send, subagents, tts, web_fetch, web_search. Use `tool_search` to load exact callable specs before use.
 
 Use Codex native `spawn_agent` for Codex subagents. Use OpenClaw `sessions_spawn` only for OpenClaw or ACP delegation.
 
@@ -537,6 +537,7 @@ Full JSON: `codex-dynamic-tools.telegram-direct.json`
 ```json
 [
   "message",
+  "sessions_spawn",
   "sessions_yield",
   "nodes",
   "cron",
@@ -546,7 +547,6 @@ Full JSON: `codex-dynamic-tools.telegram-direct.json`
   "sessions_list",
   "sessions_history",
   "sessions_send",
-  "sessions_spawn",
   "subagents",
   "session_status",
   "web_search",

--- a/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/telegram-heartbeat-codex-tool.md
+++ b/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/telegram-heartbeat-codex-tool.md
@@ -88,12 +88,12 @@
   "developerInstructions": "<see Reconstructed Model-Bound Prompt Layers>",
   "dynamicTools": [
     "message",
-    "heartbeat_respond",
     "agents_list",
     "sessions_spawn",
     "sessions_yield",
     "nodes",
     "cron",
+    "heartbeat_respond",
     "tts",
     "gateway",
     "sessions_list",
@@ -228,20 +228,20 @@ This is the deterministic model-bound layer stack OpenClaw can snapshot for the 
     "roughTokens": 0
   },
   "dynamicToolsJson": {
-    "chars": 51148,
-    "roughTokens": 12787
+    "chars": 51374,
+    "roughTokens": 12844
   },
   "openClawDeveloperInstructions": {
-    "chars": 1936,
-    "roughTokens": 484
+    "chars": 1955,
+    "roughTokens": 489
   },
   "totalTextOnly": {
-    "chars": 26976,
-    "roughTokens": 6744
+    "chars": 26995,
+    "roughTokens": 6749
   },
   "totalWithDynamicToolsJson": {
-    "chars": 78126,
-    "roughTokens": 19532
+    "chars": 78371,
+    "roughTokens": 19593
   },
   "userInputText": {
     "chars": 1271,
@@ -428,7 +428,7 @@ Approval policy is currently never. Do not provide the `sandbox_permissions` for
 ````text
 You are a personal agent running inside OpenClaw. OpenClaw has dynamic tools for OpenClaw-owned messaging, cron, sessions, media, gateway, and nodes.
 
-Deferred searchable OpenClaw dynamic tools available: cron, gateway, nodes, session_status, sessions_history, sessions_list, sessions_send, subagents, tts, web_fetch, web_search. Use `tool_search` to load exact callable specs before use.
+Deferred searchable OpenClaw dynamic tools available: cron, gateway, heartbeat_respond, nodes, session_status, sessions_history, sessions_list, sessions_send, subagents, tts, web_fetch, web_search. Use `tool_search` to load exact callable specs before use.
 
 Use Codex native `spawn_agent` for Codex subagents. Use OpenClaw `sessions_spawn` only for OpenClaw or ACP delegation.
 
@@ -547,12 +547,12 @@ Full JSON: `codex-dynamic-tools.heartbeat-turn.json`
 ```json
 [
   "message",
-  "heartbeat_respond",
   "agents_list",
   "sessions_spawn",
   "sessions_yield",
   "nodes",
   "cron",
+  "heartbeat_respond",
   "tts",
   "gateway",
   "sessions_list",
@@ -695,6 +695,7 @@ Full JSON: `codex-dynamic-tools.heartbeat-turn.json`
     "type": "function"
   },
   {
+    "deferLoading": true,
     "description": "Record heartbeat result. `notify=false` no visible send. `notify=true` needs concise notificationText.",
     "inputSchema": {
       "additionalProperties": false,

--- a/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/telegram-heartbeat-codex-tool.md
+++ b/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/telegram-heartbeat-codex-tool.md
@@ -88,17 +88,17 @@
   "developerInstructions": "<see Reconstructed Model-Bound Prompt Layers>",
   "dynamicTools": [
     "message",
+    "heartbeat_respond",
+    "sessions_spawn",
     "sessions_yield",
     "nodes",
     "cron",
-    "heartbeat_respond",
     "tts",
     "gateway",
     "agents_list",
     "sessions_list",
     "sessions_history",
     "sessions_send",
-    "sessions_spawn",
     "subagents",
     "session_status",
     "web_search",
@@ -228,20 +228,20 @@ This is the deterministic model-bound layer stack OpenClaw can snapshot for the 
     "roughTokens": 0
   },
   "dynamicToolsJson": {
-    "chars": 51910,
-    "roughTokens": 12978
+    "chars": 51214,
+    "roughTokens": 12804
   },
   "openClawDeveloperInstructions": {
-    "chars": 1984,
-    "roughTokens": 496
+    "chars": 1949,
+    "roughTokens": 488
   },
   "totalTextOnly": {
-    "chars": 27024,
-    "roughTokens": 6756
+    "chars": 26989,
+    "roughTokens": 6748
   },
   "totalWithDynamicToolsJson": {
-    "chars": 78936,
-    "roughTokens": 19734
+    "chars": 78205,
+    "roughTokens": 19552
   },
   "userInputText": {
     "chars": 1271,
@@ -428,7 +428,7 @@ Approval policy is currently never. Do not provide the `sandbox_permissions` for
 ````text
 You are a personal agent running inside OpenClaw. OpenClaw has dynamic tools for OpenClaw-owned messaging, cron, sessions, media, gateway, and nodes.
 
-Deferred searchable OpenClaw dynamic tools available: agents_list, cron, gateway, heartbeat_respond, nodes, session_status, sessions_history, sessions_list, sessions_send, sessions_spawn, subagents, tts, web_fetch, web_search. Use `tool_search` to load exact callable specs before use.
+Deferred searchable OpenClaw dynamic tools available: agents_list, cron, gateway, nodes, session_status, sessions_history, sessions_list, sessions_send, subagents, tts, web_fetch, web_search. Use `tool_search` to load exact callable specs before use.
 
 Use Codex native `spawn_agent` for Codex subagents. Use OpenClaw `sessions_spawn` only for OpenClaw or ACP delegation.
 
@@ -547,17 +547,17 @@ Full JSON: `codex-dynamic-tools.heartbeat-turn.json`
 ```json
 [
   "message",
+  "heartbeat_respond",
+  "sessions_spawn",
   "sessions_yield",
   "nodes",
   "cron",
-  "heartbeat_respond",
   "tts",
   "gateway",
   "agents_list",
   "sessions_list",
   "sessions_history",
   "sessions_send",
-  "sessions_spawn",
   "subagents",
   "session_status",
   "web_search",
@@ -695,7 +695,6 @@ Full JSON: `codex-dynamic-tools.heartbeat-turn.json`
     "type": "function"
   },
   {
-    "deferLoading": true,
     "description": "Record heartbeat result. `notify=false` no visible send. `notify=true` needs concise notificationText.",
     "inputSchema": {
       "additionalProperties": false,

--- a/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/telegram-heartbeat-codex-tool.md
+++ b/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/telegram-heartbeat-codex-tool.md
@@ -89,13 +89,13 @@
   "dynamicTools": [
     "message",
     "heartbeat_respond",
+    "agents_list",
     "sessions_spawn",
     "sessions_yield",
     "nodes",
     "cron",
     "tts",
     "gateway",
-    "agents_list",
     "sessions_list",
     "sessions_history",
     "sessions_send",
@@ -228,20 +228,20 @@ This is the deterministic model-bound layer stack OpenClaw can snapshot for the 
     "roughTokens": 0
   },
   "dynamicToolsJson": {
-    "chars": 51214,
-    "roughTokens": 12804
+    "chars": 51148,
+    "roughTokens": 12787
   },
   "openClawDeveloperInstructions": {
-    "chars": 1949,
-    "roughTokens": 488
+    "chars": 1936,
+    "roughTokens": 484
   },
   "totalTextOnly": {
-    "chars": 26989,
-    "roughTokens": 6748
+    "chars": 26976,
+    "roughTokens": 6744
   },
   "totalWithDynamicToolsJson": {
-    "chars": 78205,
-    "roughTokens": 19552
+    "chars": 78126,
+    "roughTokens": 19532
   },
   "userInputText": {
     "chars": 1271,
@@ -428,7 +428,7 @@ Approval policy is currently never. Do not provide the `sandbox_permissions` for
 ````text
 You are a personal agent running inside OpenClaw. OpenClaw has dynamic tools for OpenClaw-owned messaging, cron, sessions, media, gateway, and nodes.
 
-Deferred searchable OpenClaw dynamic tools available: agents_list, cron, gateway, nodes, session_status, sessions_history, sessions_list, sessions_send, subagents, tts, web_fetch, web_search. Use `tool_search` to load exact callable specs before use.
+Deferred searchable OpenClaw dynamic tools available: cron, gateway, nodes, session_status, sessions_history, sessions_list, sessions_send, subagents, tts, web_fetch, web_search. Use `tool_search` to load exact callable specs before use.
 
 Use Codex native `spawn_agent` for Codex subagents. Use OpenClaw `sessions_spawn` only for OpenClaw or ACP delegation.
 
@@ -548,13 +548,13 @@ Full JSON: `codex-dynamic-tools.heartbeat-turn.json`
 [
   "message",
   "heartbeat_respond",
+  "agents_list",
   "sessions_spawn",
   "sessions_yield",
   "nodes",
   "cron",
   "tts",
   "gateway",
-  "agents_list",
   "sessions_list",
   "sessions_history",
   "sessions_send",


### PR DESCRIPTION
Closes #99464
Related: #99561

AI-assisted. This branch preserves the original #99561 commits by @100yenadmin and adjusts the final behavior to the independently validated fix direction.

## What Problem This Solves

Fixes an issue where Codex app-server users could be told that deferred OpenClaw delegation tools were searchable, but an explicit `tool_search` for `sessions_spawn` did not make the OpenClaw tool callable. The model could then answer without spawning the requested child session.

It also avoids changing the registered `heartbeat_respond` schema between normal and heartbeat turns on a resumed Codex thread.

## Why This Change Was Made

Keep the small, stable OpenClaw control set (`agents_list`, `sessions_spawn`, and `sessions_yield`) directly available on every Codex app-server turn. Broad tools remain deferred behind `tool_search`, and `heartbeat_respond` remains deferred with a stable registration across normal and heartbeat turns.

This keeps delegation controls reliable without making the entire OpenClaw tool catalog direct, and preserves the Codex app-server requirement that a resumed thread retain the same registered dynamic-tool definitions.

## User Impact

Codex app-server agents can reliably list agents, spawn subagents, and yield without depending on connector-oriented `tool_search` resolution. Existing deferred-tool behavior remains in place for the broader catalog, and heartbeat turns no longer risk a thread schema mismatch.

## Evidence

- Live AWS Crabbox before/after proof: run `run_0a496ddc9d30`, provider `aws`, lease `cbx_60d63e7d43b5` (`harbor-prawn`).
  - Current `main` at `574556cd32` reproduced the regression: after explicit `tool_search(query="sessions_spawn")`, no OpenClaw `sessions_spawn` start event occurred.
  - Branch HEAD `3c0d0536e3` passed the same probe: `sessions_spawn` emitted successful start/result events and the child Codex lifecycle started.
- Focused tests: `node scripts/run-vitest.mjs extensions/codex/src/app-server/dynamic-tools.test.ts extensions/codex/src/app-server/run-attempt.test.ts extensions/codex/src/app-server/thread-lifecycle.test.ts` (274 passed).
- Prompt snapshots: `pnpm prompt:snapshots:check` (current, 7 files).
- Remote changed gate: Blacksmith Testbox `tbx_01kwnaa6h31cbzfqkr97zjrs8x`, Actions run `28690098532` (typecheck, lint, guards, snapshots, and import cycles passed).
- Pre-commit autoreview: no accepted or actionable findings; overall verdict `patch correct`, confidence `0.97`.
