### PR TITLE
fix: avoid native command QA timeout under CI contention

### DIFF
--- a/qa/scenarios/channels/native-command-session-target.yaml
+++ b/qa/scenarios/channels/native-command-session-target.yaml
@@ -70,7 +70,7 @@ flow:
             - lambda:
                 async: true
                 expr: "env.gateway.call('sessions.list', {}).then((result) => result.sessions?.find((session) => session.hasActiveRun === true))"
-            - 5000
+            - expr: liveTurnTimeoutMs(env, 15000)
             - 100
         - set: startIndex
           value:
@@ -115,6 +115,6 @@ flow:
             textIncludes:
               expr: config.recoveryMarker
             timeoutMs:
-              expr: liveTurnTimeoutMs(env, 30000)
+              expr: liveTurnTimeoutMs(env, 60000)
           saveAs: recoveryReply
       detailsExpr: "`native command reply=${abortReply.text}; recovery reply=${recoveryReply.text}`"


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where the `native-command-session-target` QA smoke scenario could fail intermittently under normal CI contention even though native `/stop` targeting and recovery were correct.

Two unrelated pull-request runs hit the scenario's polling ceilings—once while waiting up to 5 seconds for the active run projection, and once while waiting up to 30 seconds for the recovery turn—then passed on immediate reruns.

## Why This Change Was Made

Keep the smoke lane at concurrency 8 and preserve the scenario's action order and assertions, while raising only the two observed polling ceilings:

- active-run discovery: provider-aware 15 seconds instead of a fixed 5 seconds;
- recovery marker: provider-aware 60 seconds instead of 30 seconds.

Both waits return immediately when their conditions are met. This adds no sleep, serialization, workflow change, or successful-path delay.

## User Impact

Contributors should see fewer unrelated QA smoke reruns without making the required CI action take minutes longer. Normal successful executions retain the existing concurrency and complete as soon as the same assertions pass.

## Evidence

- Retained post-#99656 artifacts: one first attempt failed at `timed out after 5000ms`; another failed at `timed out after 30000ms`; immediate reruns passed without code changes.
- `node scripts/run-vitest.mjs extensions/qa-lab/src/scenario-catalog.test.ts` — 33/33 passed on final `main` base.
- Concurrency-8 focused stress proof — two runs passed in 32s and 24s; Testbox `tbx_01kwnbrcmwc3gzp6sk1beevs8w`, run `28690725713`.
- Delegated `check:changed` — full typecheck, lint, and import-cycle checks passed; Testbox `tbx_01kwnbwdvx2fxejbcrf8dgh7gd`, run `28690776973`.
- `git diff --check` — passed.
- Final structured autoreview — no accepted/actionable findings; patch correct at 0.98 confidence.

A broader current-main smoke attempt expanded to 81 scenarios and encountered an unrelated missing generated `acpx` artifact before this focused scenario proof completed. That build-output race was subsequently addressed by #99736; the all-flow focused proof above avoids conflating that separate script-rebuild failure with this timeout change.
