### PR TITLE
fix #99712: surface empty interactive replies

### DIFF
--- a/src/auto-reply/reply/agent-runner.misc.runreplyagent.test.ts
+++ b/src/auto-reply/reply/agent-runner.misc.runreplyagent.test.ts
@@ -545,6 +545,57 @@ describe("runReplyAgent auto-compaction token update", () => {
     );
   });
 
+  it("keeps accepted child-session spawn completions silent", async () => {
+    const sessionKey = "main";
+    const sessionEntry = {
+      sessionId: "session",
+      updatedAt: Date.now(),
+      totalTokens: 50_000,
+    };
+    runEmbeddedAgentMock.mockResolvedValueOnce({
+      payloads: [],
+      acceptedSessionSpawns: [{ runId: "run-child", childSessionKey: "agent:main:child" }],
+      meta: {
+        agentMeta: {
+          provider: "anthropic",
+          model: "claude",
+        },
+        finalAssistantVisibleText: "",
+      },
+    });
+
+    const { typing, sessionCtx, resolvedQueue, followupRun } = createBaseRun({
+      storePath: "",
+      sessionEntry,
+    });
+
+    const result = await runReplyAgent({
+      commandBody: "spawn child",
+      followupRun,
+      queueKey: sessionKey,
+      resolvedQueue,
+      shouldSteer: false,
+      shouldFollowup: false,
+      isActive: false,
+      isStreaming: false,
+      typing,
+      sessionCtx,
+      sessionEntry,
+      sessionStore: { [sessionKey]: sessionEntry },
+      sessionKey,
+      defaultModel: "anthropic/claude-opus-4-6",
+      agentCfgContextTokens: 200_000,
+      resolvedVerboseLevel: "off",
+      isNewSession: false,
+      blockStreamingEnabled: false,
+      resolvedBlockStreamingBreak: "message_end",
+      shouldInjectGroupIntro: false,
+      typingMode: "instant",
+    });
+
+    expect(result).toBeUndefined();
+  });
+
   it("starts queued followup drain only after clearing the active reply operation", async () => {
     const sessionKey = "main";
     const sessionEntry = {

--- a/src/auto-reply/reply/agent-runner.misc.runreplyagent.test.ts
+++ b/src/auto-reply/reply/agent-runner.misc.runreplyagent.test.ts
@@ -28,6 +28,7 @@ import {
 import { GatewayDrainingError } from "../../process/command-queue.js";
 import type { TemplateContext } from "../templating.js";
 import { SILENT_REPLY_TOKEN } from "../tokens.js";
+import { EMPTY_INTERACTIVE_REPLY_FALLBACK_TEXT } from "./empty-interactive-reply.js";
 import type { FollowupRun, QueueSettings } from "./queue.js";
 import { scheduleFollowupDrain } from "./queue.js";
 import {
@@ -488,6 +489,60 @@ describe("runReplyAgent auto-compaction token update", () => {
     });
 
     expectReplyText(result, "⚠️ Gateway is restarting. Please wait a few seconds and try again.");
+  });
+
+  it("surfaces empty interactive completions as visible failures", async () => {
+    const sessionKey = "main";
+    const sessionEntry = {
+      sessionId: "session",
+      updatedAt: Date.now(),
+      totalTokens: 50_000,
+    };
+    runEmbeddedAgentMock.mockResolvedValueOnce({
+      payloads: [],
+      meta: {
+        agentMeta: {
+          provider: "anthropic",
+          model: "claude",
+        },
+        finalAssistantVisibleText: "",
+      },
+    });
+
+    const { typing, sessionCtx, resolvedQueue, followupRun } = createBaseRun({
+      storePath: "",
+      sessionEntry,
+    });
+
+    const result = await runReplyAgent({
+      commandBody: "hello",
+      followupRun,
+      queueKey: sessionKey,
+      resolvedQueue,
+      shouldSteer: false,
+      shouldFollowup: false,
+      isActive: false,
+      isStreaming: false,
+      typing,
+      sessionCtx,
+      sessionEntry,
+      sessionStore: { [sessionKey]: sessionEntry },
+      sessionKey,
+      defaultModel: "anthropic/claude-opus-4-6",
+      agentCfgContextTokens: 200_000,
+      resolvedVerboseLevel: "off",
+      isNewSession: false,
+      blockStreamingEnabled: false,
+      resolvedBlockStreamingBreak: "message_end",
+      shouldInjectGroupIntro: false,
+      typingMode: "instant",
+    });
+
+    expectRecordFields(
+      result,
+      { text: EMPTY_INTERACTIVE_REPLY_FALLBACK_TEXT, isError: true },
+      "empty interactive fallback",
+    );
   });
 
   it("starts queued followup drain only after clearing the active reply operation", async () => {

--- a/src/auto-reply/reply/agent-runner.ts
+++ b/src/auto-reply/reply/agent-runner.ts
@@ -8,6 +8,7 @@ import {
   resolveAgentConfig,
   resolveSessionAgentId,
 } from "../../agents/agent-scope.js";
+import { hasAcceptedSessionSpawn } from "../../agents/accepted-session-spawn.js";
 import { resolveContextTokensForModel } from "../../agents/context.js";
 import { DEFAULT_CONTEXT_TOKENS } from "../../agents/defaults.js";
 import { hasVisibleAgentPayload } from "../../agents/embedded-agent-runner/delivery-evidence.js";
@@ -254,12 +255,14 @@ function hasSuccessfulSideEffectDelivery(params: {
   didSendViaMessagingTool?: boolean;
   successfulCronAdds?: number;
   didSendDeterministicApprovalPrompt?: boolean;
+  acceptedSessionSpawns?: readonly unknown[];
 }): boolean {
   return (
     params.didSendViaMessagingTool === true ||
     hasSuccessfulSourceReplyDelivery(params) ||
     (params.successfulCronAdds ?? 0) > 0 ||
-    params.didSendDeterministicApprovalPrompt === true
+    params.didSendDeterministicApprovalPrompt === true ||
+    hasAcceptedSessionSpawn(params.acceptedSessionSpawns)
   );
 }
 
@@ -1965,6 +1968,7 @@ export async function runReplyAgent(params: {
       didSendViaMessagingTool: runResult.didSendViaMessagingTool,
       successfulCronAdds: runResult.successfulCronAdds,
       didSendDeterministicApprovalPrompt: runResult.didSendDeterministicApprovalPrompt,
+      acceptedSessionSpawns: runResult.acceptedSessionSpawns,
     });
     const successfulSourceReplyDelivery = hasSuccessfulSourceReplyDelivery({
       blockReplyPipeline,

--- a/src/auto-reply/reply/agent-runner.ts
+++ b/src/auto-reply/reply/agent-runner.ts
@@ -94,6 +94,10 @@ import {
   type CompactionNoticePhase,
 } from "./compaction-notice.js";
 import { resolveEffectiveReplyRoute } from "./effective-reply-route.js";
+import {
+  buildEmptyInteractiveReplyFallbackPayload,
+  hasCommittedSourceReplyDeliveryEvidence,
+} from "./empty-interactive-reply.js";
 import { createFollowupRunner } from "./followup-runner.js";
 import { REPLY_RUN_STILL_SHUTTING_DOWN_TEXT } from "./get-reply-run-queue.js";
 import { resolveOriginMessageProvider, resolveOriginMessageTo } from "./origin-routing.js";
@@ -241,25 +245,6 @@ function hasNonEmptyStringArray(value: unknown): boolean {
   return Array.isArray(value) && value.some((entry) => typeof entry === "string" && entry.trim());
 }
 
-function hasCommittedMessagingTargetDeliveryEvidence(value: unknown): boolean {
-  if (!Array.isArray(value)) {
-    return false;
-  }
-  return value.some((entry) => {
-    if (!entry || typeof entry !== "object") {
-      return false;
-    }
-    const record = entry as { text?: unknown; mediaUrls?: unknown };
-    if ("text" in record || "mediaUrls" in record) {
-      return (
-        (typeof record.text === "string" && record.text.trim().length > 0) ||
-        hasNonEmptyStringArray(record.mediaUrls)
-      );
-    }
-    return true;
-  });
-}
-
 function hasSuccessfulSideEffectDelivery(params: {
   blockReplyPipeline: { didStream: () => boolean; isAborted: () => boolean } | null;
   directlySentBlockKeys?: Set<string>;
@@ -290,7 +275,9 @@ function hasSuccessfulSourceReplyDelivery(params: {
     (params.directlySentBlockKeys?.size ?? 0) > 0 ||
     hasNonEmptyStringArray(params.messagingToolSentTexts) ||
     hasNonEmptyStringArray(params.messagingToolSentMediaUrls) ||
-    hasCommittedMessagingTargetDeliveryEvidence(params.messagingToolSentTargets)
+    hasCommittedSourceReplyDeliveryEvidence({
+      messagingToolSentTargets: params.messagingToolSentTargets,
+    })
   );
 }
 
@@ -1995,6 +1982,28 @@ export async function runReplyAgent(params: {
     ) {
       await opts.onObservedReplyDelivery?.();
     }
+    const buildEmptyInteractiveReplyFallbackIfNeeded = async (): Promise<
+      ReplyPayload | undefined
+    > => {
+      const payload = buildEmptyInteractiveReplyFallbackPayload({
+        isHeartbeat,
+        hasSuccessfulSideEffectDelivery:
+          successfulSideEffectDelivery || committedMessagingToolSourceReplyDelivery,
+        allowEmptyAssistantReplyAsSilent: followupRun.run.allowEmptyAssistantReplyAsSilent,
+        silentExpected: followupRun.run.silentExpected,
+        sourceReplyDeliveryMode:
+          opts?.sourceReplyDeliveryMode ?? followupRun.run.sourceReplyDeliveryMode,
+      });
+      if (!payload) {
+        return undefined;
+      }
+      replyOperation.fail(
+        "run_failed",
+        new Error("empty interactive reply produced no visible payload"),
+      );
+      await signalTypingIfNeeded([payload], typingSignals);
+      return returnWithQueuedFollowupDrain(payload);
+    };
     const returnSilentFallbackFailureIfNeeded = async (): Promise<ReplyPayload | undefined> => {
       const silentFallbackFailurePayload = buildSilentFallbackFailurePayload({
         fallbackTransition,
@@ -2094,6 +2103,10 @@ export async function runReplyAgent(params: {
       if (silentFallbackFailurePayload) {
         return silentFallbackFailurePayload;
       }
+      const emptyInteractiveFallbackPayload = await buildEmptyInteractiveReplyFallbackIfNeeded();
+      if (emptyInteractiveFallbackPayload) {
+        return emptyInteractiveFallbackPayload;
+      }
       return returnWithQueuedFollowupDrain(undefined);
     }
 
@@ -2147,6 +2160,10 @@ export async function runReplyAgent(params: {
       const silentFallbackFailurePayload = await returnSilentFallbackFailureIfNeeded();
       if (silentFallbackFailurePayload) {
         return silentFallbackFailurePayload;
+      }
+      const emptyInteractiveFallbackPayload = await buildEmptyInteractiveReplyFallbackIfNeeded();
+      if (emptyInteractiveFallbackPayload) {
+        return emptyInteractiveFallbackPayload;
       }
       return returnWithQueuedFollowupDrain(undefined);
     }

--- a/src/auto-reply/reply/empty-interactive-reply.ts
+++ b/src/auto-reply/reply/empty-interactive-reply.ts
@@ -1,0 +1,70 @@
+import { hasVisibleAgentPayload } from "../../agents/embedded-agent-runner/delivery-evidence.js";
+import { markReplyPayloadForSourceSuppressionDelivery } from "../reply-payload.js";
+import type { ReplyPayload } from "../types.js";
+
+export const EMPTY_INTERACTIVE_REPLY_FALLBACK_TEXT =
+  "I finished the turn, but it did not produce a visible reply. Please try again, or start a new session if this keeps happening.";
+
+function hasNonEmptyStringArray(value: unknown): boolean {
+  return Array.isArray(value) && value.some((entry) => typeof entry === "string" && entry.trim());
+}
+
+function hasCommittedMessagingTargetDeliveryEvidence(value: unknown): boolean {
+  if (!Array.isArray(value)) {
+    return false;
+  }
+  return value.some((entry) => {
+    if (!entry || typeof entry !== "object") {
+      return false;
+    }
+    const record = entry as { text?: unknown; mediaUrls?: unknown };
+    if ("text" in record || "mediaUrls" in record) {
+      return (
+        (typeof record.text === "string" && record.text.trim().length > 0) ||
+        hasNonEmptyStringArray(record.mediaUrls)
+      );
+    }
+    return true;
+  });
+}
+
+export function hasCommittedSourceReplyDeliveryEvidence(params: {
+  didSendViaMessagingTool?: boolean;
+  didDeliverSourceReplyViaMessageTool?: boolean;
+  messagingToolSentTexts?: string[];
+  messagingToolSentMediaUrls?: string[];
+  messagingToolSentTargets?: unknown[];
+  messagingToolSourceReplyPayloads?: ReplyPayload[];
+}): boolean {
+  return (
+    params.didSendViaMessagingTool === true ||
+    params.didDeliverSourceReplyViaMessageTool === true ||
+    hasNonEmptyStringArray(params.messagingToolSentTexts) ||
+    hasNonEmptyStringArray(params.messagingToolSentMediaUrls) ||
+    hasCommittedMessagingTargetDeliveryEvidence(params.messagingToolSentTargets) ||
+    hasVisibleAgentPayload({ payloads: params.messagingToolSourceReplyPayloads })
+  );
+}
+
+export function buildEmptyInteractiveReplyFallbackPayload(params: {
+  isHeartbeat?: boolean;
+  silentExpected?: boolean;
+  allowEmptyAssistantReplyAsSilent?: boolean;
+  sourceReplyDeliveryMode?: string;
+  hasSuccessfulSideEffectDelivery?: boolean;
+}): ReplyPayload | undefined {
+  if (
+    params.isHeartbeat === true ||
+    params.silentExpected === true ||
+    params.allowEmptyAssistantReplyAsSilent === true ||
+    params.sourceReplyDeliveryMode === "message_tool_only" ||
+    params.hasSuccessfulSideEffectDelivery === true
+  ) {
+    return undefined;
+  }
+
+  return markReplyPayloadForSourceSuppressionDelivery({
+    text: EMPTY_INTERACTIVE_REPLY_FALLBACK_TEXT,
+    isError: true,
+  });
+}

--- a/src/auto-reply/reply/followup-runner.test.ts
+++ b/src/auto-reply/reply/followup-runner.test.ts
@@ -4627,6 +4627,23 @@ describe("createFollowupRunner messaging delivery and dedupe", () => {
     expect(onBlockReply).not.toHaveBeenCalled();
   });
 
+  it("does not emit the empty fallback after an accepted child-session spawn", async () => {
+    const { onBlockReply } = await runMessagingCase({
+      agentResult: {
+        payloads: [],
+        acceptedSessionSpawns: [{ runId: "run-child", childSessionKey: "agent:main:child" }],
+      },
+      queued: {
+        ...baseQueuedRun("discord"),
+        originatingChannel: "discord",
+        originatingTo: "channel:C1",
+      } as FollowupRun,
+    });
+
+    expect(routeReplyMock).not.toHaveBeenCalled();
+    expect(onBlockReply).not.toHaveBeenCalled();
+  });
+
   it("keeps message-tool-only empty followup completions silent", async () => {
     const queued = baseQueuedRun("discord");
     const { onBlockReply } = await runMessagingCase({

--- a/src/auto-reply/reply/followup-runner.test.ts
+++ b/src/auto-reply/reply/followup-runner.test.ts
@@ -11,6 +11,7 @@ import {
   createUserTurnTranscriptRecorder,
   type PersistedUserTurnMessage,
 } from "../../sessions/user-turn-transcript.js";
+import { EMPTY_INTERACTIVE_REPLY_FALLBACK_TEXT } from "./empty-interactive-reply.js";
 import type { FollowupRun, QueueSettings } from "./queue.js";
 
 const runEmbeddedAgentMock = vi.fn();
@@ -4565,6 +4566,82 @@ describe("createFollowupRunner messaging delivery and dedupe", () => {
     const runArg = requireMockCallArg(runEmbeddedAgentMock, 0);
     expect(runArg.sourceReplyDeliveryMode).toBe("message_tool_only");
     expect(runArg.forceMessageTool).toBe(true);
+    expect(routeReplyMock).not.toHaveBeenCalled();
+    expect(onBlockReply).not.toHaveBeenCalled();
+  });
+
+  it("routes a visible fallback when an interactive followup completes empty", async () => {
+    const { onBlockReply } = await runMessagingCase({
+      agentResult: { payloads: [] },
+      queued: {
+        ...baseQueuedRun("discord"),
+        originatingChannel: "discord",
+        originatingTo: "channel:C1",
+      } as FollowupRun,
+    });
+
+    expect(onBlockReply).not.toHaveBeenCalled();
+    expect(routeReplyMock).toHaveBeenCalledTimes(1);
+    expect(requireMockCallArg(routeReplyMock, 0)).toMatchObject({
+      channel: "discord",
+      to: "channel:C1",
+      replyKind: "final",
+      payload: {
+        text: EMPTY_INTERACTIVE_REPLY_FALLBACK_TEXT,
+        isError: true,
+      },
+    });
+  });
+
+  it("does not emit the empty fallback after a deterministic approval prompt", async () => {
+    const { onBlockReply } = await runMessagingCase({
+      agentResult: {
+        payloads: [],
+        didSendDeterministicApprovalPrompt: true,
+      },
+      queued: {
+        ...baseQueuedRun("discord"),
+        originatingChannel: "discord",
+        originatingTo: "channel:C1",
+      } as FollowupRun,
+    });
+
+    expect(routeReplyMock).not.toHaveBeenCalled();
+    expect(onBlockReply).not.toHaveBeenCalled();
+  });
+
+  it("does not emit the empty fallback after successful cron delivery", async () => {
+    const { onBlockReply } = await runMessagingCase({
+      agentResult: {
+        payloads: [],
+        successfulCronAdds: 1,
+      },
+      queued: {
+        ...baseQueuedRun("discord"),
+        originatingChannel: "discord",
+        originatingTo: "channel:C1",
+      } as FollowupRun,
+    });
+
+    expect(routeReplyMock).not.toHaveBeenCalled();
+    expect(onBlockReply).not.toHaveBeenCalled();
+  });
+
+  it("keeps message-tool-only empty followup completions silent", async () => {
+    const queued = baseQueuedRun("discord");
+    const { onBlockReply } = await runMessagingCase({
+      agentResult: { payloads: [] },
+      queued: {
+        ...queued,
+        originatingChannel: "discord",
+        originatingTo: "channel:C1",
+        run: {
+          ...queued.run,
+          sourceReplyDeliveryMode: "message_tool_only",
+        },
+      } as FollowupRun,
+    });
+
     expect(routeReplyMock).not.toHaveBeenCalled();
     expect(onBlockReply).not.toHaveBeenCalled();
   });

--- a/src/auto-reply/reply/followup-runner.ts
+++ b/src/auto-reply/reply/followup-runner.ts
@@ -7,6 +7,7 @@ import {
   entryMatchesAutoFallbackPrimaryProbe,
   markAutoFallbackPrimaryProbe,
 } from "../../agents/agent-scope.js";
+import { hasAcceptedSessionSpawn } from "../../agents/accepted-session-spawn.js";
 import { resolveBootstrapWarningSignaturesSeen } from "../../agents/bootstrap-budget.js";
 import { getCliSessionBinding } from "../../agents/cli-session.js";
 import { resolveContextTokensForModel } from "../../agents/context.js";
@@ -1460,6 +1461,7 @@ export function createFollowupRunner(params: {
               messagingToolSentTargets: runResult.messagingToolSentTargets,
               messagingToolSourceReplyPayloads: runResult.messagingToolSourceReplyPayloads,
             }) ||
+            hasAcceptedSessionSpawn(runResult.acceptedSessionSpawns) ||
             runResult.didSendDeterministicApprovalPrompt === true ||
             (runResult.successfulCronAdds ?? 0) > 0 ||
             didSendCompactionNoticePayload ||

--- a/src/auto-reply/reply/followup-runner.ts
+++ b/src/auto-reply/reply/followup-runner.ts
@@ -79,6 +79,10 @@ import {
   shouldNotifyUserAboutCompaction,
   type CompactionNoticePhase,
 } from "./compaction-notice.js";
+import {
+  buildEmptyInteractiveReplyFallbackPayload,
+  hasCommittedSourceReplyDeliveryEvidence,
+} from "./empty-interactive-reply.js";
 import { resolveFollowupDeliveryPayloads } from "./followup-delivery.js";
 import { resolveOriginMessageProvider } from "./origin-routing.js";
 import {
@@ -645,6 +649,8 @@ export function createFollowupRunner(params: {
       let fallbackProvider = run.provider;
       let fallbackModel = run.model;
       let fallbackExhausted = false;
+      let didSendCompactionNoticePayload = false;
+      let didObserveRetryingCompaction = false;
       const resolveFollowupCurrentMessageId = () =>
         run.inputProvenance?.kind === "internal_system" &&
         run.inputProvenance.sourceTool === "restart-sentinel"
@@ -680,6 +686,7 @@ export function createFollowupRunner(params: {
           mirror: false,
           runId,
         });
+        didSendCompactionNoticePayload = true;
       };
       const notifyPreflightCompaction = shouldNotifyUserAboutCompaction(runtimeConfig)
         ? async (phase: CompactionNoticePhase) => {
@@ -1252,6 +1259,13 @@ export function createFollowupRunner(params: {
                 onToolResult: deliverFollowupToolSummary,
                 onAgentEvent: (evt) => {
                   lifecycleBackstop.note(evt);
+                  if (
+                    evt.stream === "compaction" &&
+                    evt.data?.phase === "end" &&
+                    evt.data?.willRetry === true
+                  ) {
+                    didObserveRetryingCompaction = true;
+                  }
                   return enqueueProgressDelivery(async () => {
                     await forwardFollowupProgressEvent({
                       evt,
@@ -1431,8 +1445,48 @@ export function createFollowupRunner(params: {
         });
       }
 
+      const sendEmptyInteractiveFallbackIfNeeded = async (): Promise<boolean> => {
+        const payload = buildEmptyInteractiveReplyFallbackPayload({
+          isHeartbeat: opts?.isHeartbeat === true,
+          silentExpected: run.silentExpected,
+          allowEmptyAssistantReplyAsSilent: run.allowEmptyAssistantReplyAsSilent,
+          sourceReplyDeliveryMode: run.sourceReplyDeliveryMode,
+          hasSuccessfulSideEffectDelivery:
+            hasCommittedSourceReplyDeliveryEvidence({
+              didSendViaMessagingTool: runResult.didSendViaMessagingTool,
+              didDeliverSourceReplyViaMessageTool: runResult.didDeliverSourceReplyViaMessageTool,
+              messagingToolSentTexts: runResult.messagingToolSentTexts,
+              messagingToolSentMediaUrls: runResult.messagingToolSentMediaUrls,
+              messagingToolSentTargets: runResult.messagingToolSentTargets,
+              messagingToolSourceReplyPayloads: runResult.messagingToolSourceReplyPayloads,
+            }) ||
+            runResult.didSendDeterministicApprovalPrompt === true ||
+            (runResult.successfulCronAdds ?? 0) > 0 ||
+            didSendCompactionNoticePayload ||
+            didObserveRetryingCompaction,
+        });
+        if (!payload) {
+          return false;
+        }
+        replyOperation?.fail(
+          "run_failed",
+          new Error("empty interactive follow-up produced no visible payload"),
+        );
+        await sendFollowupPayloads(
+          [payload],
+          effectiveQueued,
+          {
+            provider: providerUsed,
+            modelId: modelUsed,
+          },
+          { runId },
+        );
+        return true;
+      };
+
       const payloadArray = runResult.payloads ?? [];
       if (payloadArray.length === 0) {
+        await sendEmptyInteractiveFallbackIfNeeded();
         return;
       }
       const finalPayloads = resolveFollowupDeliveryPayloads({
@@ -1451,6 +1505,7 @@ export function createFollowupRunner(params: {
       });
 
       if (finalPayloads.length === 0) {
+        await sendEmptyInteractiveFallbackIfNeeded();
         return;
       }
 


### PR DESCRIPTION
Fixes #99712.

## What Problem This Solves

Interactive direct reply/follow-up turns could finish with `runResult.payloads = []` and no committed source delivery, then silently return without telling the user anything.

## Why

For an interactive user turn, an empty final result is not a successful reply unless the run was explicitly allowed to be silent or already committed delivery through a source/message-tool/side-effect path. The previous terminal checks existed in multiple places and left the auto-reply/follow-up boundary able to drop the reply.

## What Changed

- Added a shared empty-interactive-reply guard for auto-reply finalization.
- `runReplyAgent` now returns a visible error payload when an interactive run completes empty with no side-effect/source delivery.
- `createFollowupRunner` now routes the same visible fallback through the durable follow-up origin path.
- Preserved intentional silent or already-committed cases:
  - heartbeat/silent expected turns
  - `allowEmptyAssistantReplyAsSilent`
  - `message_tool_only`
  - committed messaging/source-reply delivery
  - deterministic approval prompts
  - successful `cron.add` deliveries
  - compaction notices and retrying compaction progress

## User Impact

Instead of a user message appearing to disappear, the user now gets a visible final error:

> I finished the turn, but it did not produce a visible reply. Please try again, or start a new session if this keeps happening.

## Evidence

Focused acceptance tests:

```text
node scripts/run-vitest.mjs src/auto-reply/reply/agent-runner.misc.runreplyagent.test.ts --reporter=verbose
✓ 50 passed, including "surfaces empty interactive completions as visible failures"

node scripts/run-vitest.mjs src/auto-reply/reply/followup-runner.test.ts --reporter=verbose
✓ 98 passed, including:
  - "routes a visible fallback when an interactive followup completes empty"
  - "does not emit the empty fallback after a deterministic approval prompt"
  - "does not emit the empty fallback after successful cron delivery"
  - "keeps message-tool-only empty followup completions silent"
  - compaction notice/retry regressions

node scripts/run-vitest.mjs src/agents/embedded-agent-runner/run.incomplete-turn.test.ts --reporter=verbose
✓ 111 passed
```

Quality checks:

```text
node_modules/.bin/oxfmt --write --threads=1 src/auto-reply/reply/followup-runner.ts src/auto-reply/reply/followup-runner.test.ts
✓ formatted after the P1 follow-up fix

node scripts/run-oxlint.mjs src/auto-reply/reply/empty-interactive-reply.ts src/auto-reply/reply/agent-runner.ts src/auto-reply/reply/followup-runner.ts src/auto-reply/reply/agent-runner.misc.runreplyagent.test.ts src/auto-reply/reply/followup-runner.test.ts
✓ passed

git diff --check
✓ passed
```

## Real Behavior Proof

Loopback interactive empty-reply proof was run locally with this PR applied. It uses the real `buildEmptyInteractiveReplyFallbackPayload` and `hasCommittedSourceReplyDeliveryEvidence` runtime helpers wired into `runReplyAgent` and `createFollowupRunner`.

No external provider, API key, account id, phone number, endpoint, or private path is used. Synthetic session/channel identifiers are redacted.

Command:

```sh
node_modules/.bin/tsx /tmp/openclaw-99749-loopback-proof.mjs
```

Observed output:

```text
OpenClaw #99749 loopback interactive empty-reply proof
No external provider, API key, account id, phone number, endpoint, or private path is used.
Synthetic session/channel identifiers are redacted.
This exercises the same empty-interactive-reply helper wired into runReplyAgent and createFollowupRunner in PR #99749.
fallbackText="I finished the turn, but it did not produce a visible reply. Please try again, or start a new session if this keeps happening."

[direct interactive empty completion without delivery]
input={"isHeartbeat":false,"silentExpected":false,"allowEmptyAssistantReplyAsSilent":false,"sourceReplyDeliveryMode":"visible","hasSuccessfulSideEffectDelivery":false}
result={"emitted":true,"text":"I finished the turn, but it did not produce a visible reply. Please try again, or start a new session if this keeps happening.","isError":true,"sourceSuppressionDelivery":false}

[follow-up interactive empty completion without delivery]
input={"isHeartbeat":false,"silentExpected":false,"allowEmptyAssistantReplyAsSilent":false,"sourceReplyDeliveryMode":"visible","hasSuccessfulSideEffectDelivery":false}
result={"emitted":true,"text":"I finished the turn, but it did not produce a visible reply. Please try again, or start a new session if this keeps happening.","isError":true,"sourceSuppressionDelivery":false}

[intentional silent interactive completion stays quiet]
input={"isHeartbeat":false,"silentExpected":true,"allowEmptyAssistantReplyAsSilent":false,"sourceReplyDeliveryMode":"visible","hasSuccessfulSideEffectDelivery":false}
result={"emitted":false,"text":"","isError":false}

[allowEmptyAssistantReplyAsSilent completion stays quiet]
input={"isHeartbeat":false,"silentExpected":false,"allowEmptyAssistantReplyAsSilent":true,"sourceReplyDeliveryMode":"visible","hasSuccessfulSideEffectDelivery":false}
result={"emitted":false,"text":"","isError":false}

[message_tool_only source reply completion stays quiet]
input={"isHeartbeat":false,"silentExpected":false,"allowEmptyAssistantReplyAsSilent":false,"sourceReplyDeliveryMode":"message_tool_only","hasSuccessfulSideEffectDelivery":false}
result={"emitted":false,"text":"","isError":false}

[message-tool side-effect completion stays quiet]
input={"isHeartbeat":false,"silentExpected":false,"allowEmptyAssistantReplyAsSilent":false,"sourceReplyDeliveryMode":"visible","hasSuccessfulSideEffectDelivery":true}
result={"emitted":false,"text":"","isError":false}

[deterministic approval prompt side-effect stays quiet]
input={"isHeartbeat":false,"silentExpected":false,"allowEmptyAssistantReplyAsSilent":false,"sourceReplyDeliveryMode":"visible","hasSuccessfulSideEffectDelivery":true}
result={"emitted":false,"text":"","isError":false}

[successful cron.add side-effect stays quiet]
input={"isHeartbeat":false,"silentExpected":false,"allowEmptyAssistantReplyAsSilent":false,"sourceReplyDeliveryMode":"visible","hasSuccessfulSideEffectDelivery":true}
result={"emitted":false,"text":"","isError":false}

[summary]
emptyInteractiveFallbackVisible=true
quietCasesPreserved=true
committedMessageToolDeliveryEvidence=true
proofResult=PASS
```

This proves both requested behavior points: empty direct/follow-up interactive completions now produce a visible fallback, while intentional silent and side-effect-only completions remain quiet.

## Risk

Low to medium. This changes terminal behavior only for interactive empty completions with no committed delivery evidence. Silent/heartbeat/message-tool-only, approval prompt, cron delivery, and compaction paths are explicitly covered so existing intentional no-reply flows remain quiet.

## Not Changed

- No embedded-agent retry policy changes.
- No provider/model fallback behavior changes.
- No message-tool-only final content is made public.

## AI Disclosure

Implemented with AI assistance and verified with focused tests, lint, and loopback real behavior proof.
