### PR TITLE
refactor: consolidate exact boolean coercion

### DIFF
--- a/extensions/whatsapp/src/channel-react-action.ts
+++ b/extensions/whatsapp/src/channel-react-action.ts
@@ -1,4 +1,5 @@
 // Whatsapp plugin module implements channel react action behavior.
+import { readBooleanParam } from "openclaw/plugin-sdk/boolean-param";
 import { jsonResult } from "openclaw/plugin-sdk/channel-actions";
 import {
   isWhatsAppGroupJid,
@@ -52,24 +53,6 @@ function readUploadFileCaptionText(args: Record<string, unknown>): string {
     readStringParam(args, "caption", { allowEmpty: true }) ??
     ""
   );
-}
-
-function readBooleanParam(args: Record<string, unknown>, key: string): boolean | undefined {
-  const value = args[key];
-  if (typeof value === "boolean") {
-    return value;
-  }
-  if (typeof value !== "string") {
-    return undefined;
-  }
-  const normalized = value.trim().toLowerCase();
-  if (normalized === "true") {
-    return true;
-  }
-  if (normalized === "false") {
-    return false;
-  }
-  return undefined;
 }
 
 function hasUploadFileBufferPayload(args: Record<string, unknown>): boolean {

--- a/packages/normalization-core/package.json
+++ b/packages/normalization-core/package.json
@@ -14,6 +14,11 @@
       "import": "./dist/index.mjs",
       "default": "./dist/index.mjs"
     },
+    "./boolean-coercion": {
+      "types": "./dist/boolean-coercion.d.mts",
+      "import": "./dist/boolean-coercion.mjs",
+      "default": "./dist/boolean-coercion.mjs"
+    },
     "./number-coercion": {
       "types": "./dist/number-coercion.d.mts",
       "import": "./dist/number-coercion.mjs",
@@ -36,6 +41,6 @@
     }
   },
   "scripts": {
-    "build": "tsdown src/index.ts src/number-coercion.ts src/record-coerce.ts src/string-coerce.ts src/string-normalization.ts --no-config --platform node --format esm --dts --out-dir dist --clean"
+    "build": "tsdown src/index.ts src/boolean-coercion.ts src/number-coercion.ts src/record-coerce.ts src/string-coerce.ts src/string-normalization.ts --no-config --platform node --format esm --dts --out-dir dist --clean"
   }
 }

--- a/packages/normalization-core/src/boolean-coercion.test.ts
+++ b/packages/normalization-core/src/boolean-coercion.test.ts
@@ -1,0 +1,22 @@
+// Normalization Core tests cover boolean coerce behavior.
+import { parseBoolean } from "@openclaw/normalization-core/boolean-coercion";
+import { describe, expect, it } from "vitest";
+
+describe("normalization-core/boolean-coercion", () => {
+  it.each([
+    [true, true],
+    [false, false],
+    ["true", true],
+    [" FALSE ", false],
+    ["TrUe", true],
+  ])("parses %j as %s", (value, expected) => {
+    expect(parseBoolean(value)).toBe(expected);
+  });
+
+  it.each([undefined, null, 0, 1, "", "yes", "no", "on", "off", "1", "0"])(
+    "rejects unsupported value %j",
+    (value) => {
+      expect(parseBoolean(value)).toBeUndefined();
+    },
+  );
+});

--- a/packages/normalization-core/src/boolean-coercion.ts
+++ b/packages/normalization-core/src/boolean-coercion.ts
@@ -1,0 +1,17 @@
+/** Parses booleans and case-insensitive `true`/`false` string tokens. */
+export function parseBoolean(value: unknown): boolean | undefined {
+  if (typeof value === "boolean") {
+    return value;
+  }
+  if (typeof value !== "string") {
+    return undefined;
+  }
+  const normalized = value.trim().toLowerCase();
+  if (normalized === "true") {
+    return true;
+  }
+  if (normalized === "false") {
+    return false;
+  }
+  return undefined;
+}

--- a/packages/normalization-core/src/index.ts
+++ b/packages/normalization-core/src/index.ts
@@ -1,5 +1,6 @@
 // Public barrel for shared coercion and normalization helpers.
 
+export * from "./boolean-coercion.js";
 export * from "./number-coercion.js";
 export * from "./record-coerce.js";
 export * from "./string-coerce.js";

--- a/scripts/lib/extension-package-boundary.ts
+++ b/scripts/lib/extension-package-boundary.ts
@@ -176,9 +176,6 @@ export const EXTENSION_PACKAGE_BOUNDARY_BASE_PATHS = {
     "../dist/plugin-sdk/packages/media-core/src/read-response-with-limit.d.ts",
   ],
   "@openclaw/media-core/*": ["../dist/plugin-sdk/packages/media-core/src/*.d.ts"],
-  "@openclaw/normalization-core/boolean-coercion": [
-    "../dist/plugin-sdk/packages/normalization-core/src/boolean-coercion.d.ts",
-  ],
   "@openclaw/normalization-core/record-coerce": [
     "../dist/plugin-sdk/packages/normalization-core/src/record-coerce.d.ts",
   ],

--- a/scripts/lib/extension-package-boundary.ts
+++ b/scripts/lib/extension-package-boundary.ts
@@ -176,6 +176,9 @@ export const EXTENSION_PACKAGE_BOUNDARY_BASE_PATHS = {
     "../dist/plugin-sdk/packages/media-core/src/read-response-with-limit.d.ts",
   ],
   "@openclaw/media-core/*": ["../dist/plugin-sdk/packages/media-core/src/*.d.ts"],
+  "@openclaw/normalization-core/boolean-coercion": [
+    "../dist/plugin-sdk/packages/normalization-core/src/boolean-coercion.d.ts",
+  ],
   "@openclaw/normalization-core/record-coerce": [
     "../dist/plugin-sdk/packages/normalization-core/src/record-coerce.d.ts",
   ],

--- a/scripts/prepare-extension-package-boundary-artifacts.mjs
+++ b/scripts/prepare-extension-package-boundary-artifacts.mjs
@@ -181,6 +181,7 @@ const PACKAGE_DTS_REQUIRED_OUTPUTS = [
   "packages/plugin-sdk/dist/packages/model-catalog-core/src/provider-model-id-normalization.d.ts",
   "packages/plugin-sdk/dist/packages/model-catalog-core/src/provider-model-id-normalize.d.ts",
   "packages/plugin-sdk/dist/packages/normalization-core/src/index.d.ts",
+  "packages/plugin-sdk/dist/packages/normalization-core/src/boolean-coercion.d.ts",
   "packages/plugin-sdk/dist/packages/normalization-core/src/number-coercion.d.ts",
   "packages/plugin-sdk/dist/packages/normalization-core/src/record-coerce.d.ts",
   "packages/plugin-sdk/dist/packages/normalization-core/src/string-coerce.d.ts",

--- a/src/agents/tools/media-tool-shared.test.ts
+++ b/src/agents/tools/media-tool-shared.test.ts
@@ -8,6 +8,7 @@ import { withEnv } from "../../test-utils/env.js";
 import {
   hasGenerationToolAvailability,
   isCapabilityProviderConfigured,
+  readBooleanToolParam,
   resolveMediaToolInboundRoots,
   resolveCapabilityModelConfigForTool,
   resolveMediaToolLocalRoots,
@@ -58,6 +59,14 @@ function createModelRegistryStub(resolve: (provider: string, modelId: string) =>
     },
   };
 }
+
+describe("readBooleanToolParam", () => {
+  it("parses booleans and true/false string tokens", () => {
+    expect(readBooleanToolParam({ audio: true }, "audio")).toBe(true);
+    expect(readBooleanToolParam({ audio: " FALSE " }, "audio")).toBe(false);
+    expect(readBooleanToolParam({ audio: "yes" }, "audio")).toBeUndefined();
+  });
+});
 
 describe("resolveMediaToolLocalRoots", () => {
   it("does not widen default local roots from media sources", () => {

--- a/src/agents/tools/media-tool-shared.ts
+++ b/src/agents/tools/media-tool-shared.ts
@@ -5,6 +5,7 @@
  */
 import { normalizeInboundPathRoots } from "@openclaw/media-core/inbound-path-policy";
 import { normalizeProviderId } from "@openclaw/model-catalog-core/provider-id";
+import { parseBoolean } from "@openclaw/normalization-core/boolean-coercion";
 import {
   normalizeOptionalLowercaseString,
   normalizeOptionalString,
@@ -470,20 +471,7 @@ export function readBooleanToolParam(
   params: Record<string, unknown>,
   key: string,
 ): boolean | undefined {
-  const raw = readSnakeCaseParamRaw(params, key);
-  if (typeof raw === "boolean") {
-    return raw;
-  }
-  if (typeof raw === "string") {
-    const normalized = normalizeOptionalLowercaseString(raw);
-    if (normalized === "true") {
-      return true;
-    }
-    if (normalized === "false") {
-      return false;
-    }
-  }
-  return undefined;
+  return parseBoolean(readSnakeCaseParamRaw(params, key));
 }
 
 /**

--- a/src/cron/normalize.ts
+++ b/src/cron/normalize.ts
@@ -1,4 +1,5 @@
 /** Normalizes cron create/patch payloads before validation and persistence. */
+import { parseBoolean } from "@openclaw/normalization-core/boolean-coercion";
 import { timestampMsToIsoString } from "@openclaw/normalization-core/number-coercion";
 import {
   normalizeLowercaseStringOrEmpty,
@@ -558,17 +559,9 @@ export function normalizeCronJobInput(
   }
 
   if ("enabled" in base) {
-    const enabled = base.enabled;
-    if (typeof enabled === "boolean") {
+    const enabled = parseBoolean(base.enabled);
+    if (enabled !== undefined) {
       next.enabled = enabled;
-    } else if (typeof enabled === "string") {
-      const trimmed = normalizeOptionalLowercaseString(enabled);
-      if (trimmed === "true") {
-        next.enabled = true;
-      }
-      if (trimmed === "false") {
-        next.enabled = false;
-      }
     }
   }
 

--- a/src/memory-host-sdk/dreaming.test.ts
+++ b/src/memory-host-sdk/dreaming.test.ts
@@ -57,6 +57,24 @@ describe("memory dreaming host helpers", () => {
     expect(resolved.phases.deep.maxAgeDays).toBe(30);
   });
 
+  it("parses true/false strings while keeping invalid-value defaults local", () => {
+    const resolved = resolveMemoryDreamingConfig({
+      pluginConfig: {
+        dreaming: {
+          enabled: " TRUE ",
+          verboseLogging: "false",
+          storage: { separateReports: "invalid" },
+          phases: { light: { enabled: " FALSE " } },
+        },
+      },
+    });
+
+    expect(resolved.enabled).toBe(true);
+    expect(resolved.verboseLogging).toBe(false);
+    expect(resolved.storage.separateReports).toBe(false);
+    expect(resolved.phases.light.enabled).toBe(false);
+  });
+
   it("lets execution defaults and phase execution override the top-level dreaming model", () => {
     const resolved = resolveMemoryDreamingConfig({
       pluginConfig: {

--- a/src/memory-host-sdk/dreaming.ts
+++ b/src/memory-host-sdk/dreaming.ts
@@ -1,5 +1,6 @@
 // Memory host dreaming helpers record and load memory dreaming artifacts.
 import path from "node:path";
+import { parseBoolean } from "@openclaw/normalization-core/boolean-coercion";
 import { asNullableRecord } from "@openclaw/normalization-core/record-coerce";
 import {
   lowercasePreservingWhitespace,
@@ -213,19 +214,7 @@ function normalizeOptionalPositiveInt(value: unknown): number | undefined {
 }
 
 function normalizeBoolean(value: unknown, fallback: boolean): boolean {
-  if (typeof value === "boolean") {
-    return value;
-  }
-  if (typeof value === "string") {
-    const normalized = normalizeLowercaseStringOrEmpty(value);
-    if (normalized === "true") {
-      return true;
-    }
-    if (normalized === "false") {
-      return false;
-    }
-  }
-  return fallback;
+  return parseBoolean(value) ?? fallback;
 }
 
 function normalizeScore(value: unknown, fallback: number): number {

--- a/src/plugin-sdk/boolean-param.ts
+++ b/src/plugin-sdk/boolean-param.ts
@@ -1,21 +1,10 @@
 // Boolean parameter helpers parse plugin-facing string flags into stable booleans.
-import { normalizeOptionalLowercaseString } from "../../packages/normalization-core/src/string-coerce.js";
+import { parseBoolean } from "../../packages/normalization-core/src/boolean-coercion.js";
 
 /** Read loose boolean params from tool input that may arrive as booleans or "true"/"false" strings. */
 export function readBooleanParam(
   params: Record<string, unknown>,
   key: string,
 ): boolean | undefined {
-  const raw = params[key];
-  if (typeof raw === "boolean") {
-    return raw;
-  }
-  const normalized = normalizeOptionalLowercaseString(raw);
-  if (normalized === "true") {
-    return true;
-  }
-  if (normalized === "false") {
-    return false;
-  }
-  return undefined;
+  return parseBoolean(params[key]);
 }

--- a/src/plugins/plugin-sdk-native-resolver.test.ts
+++ b/src/plugins/plugin-sdk-native-resolver.test.ts
@@ -384,6 +384,11 @@ describe("installOpenClawPluginSdkNativeResolver", () => {
     const root = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-sdk-native-core-internal-"));
     const { loaderModulePath } = writeFakeOpenClawPackage(root);
     const normalizationSource = writeNormalizationCoreSource(root);
+    const booleanCoercionSource = writeInternalCorePackageSource(
+      root,
+      "normalization-core",
+      "boolean-coercion.ts",
+    );
     const mediaCoreSource = writeInternalCorePackageSource(root, "media-core", "mime.ts");
     const acpCoreSource = writeInternalCorePackageSource(
       root,
@@ -403,6 +408,7 @@ describe("installOpenClawPluginSdkNativeResolver", () => {
     });
 
     expect(installedAliases).toContain("@openclaw/normalization-core/string-coerce");
+    expect(installedAliases).toContain("@openclaw/normalization-core/boolean-coercion");
     expect(installedAliases).toContain("@openclaw/media-core/mime");
     expect(installedAliases).toContain("@openclaw/acp-core/runtime/types");
     expect(installedAliases).toContain("@openclaw/llm-core");
@@ -411,6 +417,11 @@ describe("installOpenClawPluginSdkNativeResolver", () => {
     expect(
       fs.realpathSync(requireFromCoreSource.resolve("@openclaw/normalization-core/string-coerce")),
     ).toBe(fs.realpathSync(normalizationSource));
+    expect(
+      fs.realpathSync(
+        requireFromCoreSource.resolve("@openclaw/normalization-core/boolean-coercion"),
+      ),
+    ).toBe(fs.realpathSync(booleanCoercionSource));
     expect(fs.realpathSync(requireFromCoreSource.resolve("@openclaw/media-core/mime"))).toBe(
       fs.realpathSync(mediaCoreSource),
     );
@@ -421,6 +432,9 @@ describe("installOpenClawPluginSdkNativeResolver", () => {
       fs.realpathSync(llmCoreSource),
     );
     expect(() => requireFromPlugin.resolve("@openclaw/normalization-core/string-coerce")).toThrow();
+    expect(() =>
+      requireFromPlugin.resolve("@openclaw/normalization-core/boolean-coercion"),
+    ).toThrow();
     expect(() => requireFromPlugin.resolve("@openclaw/media-core/mime")).toThrow();
     expect(() => requireFromPlugin.resolve("@openclaw/acp-core/runtime/types")).toThrow();
     expect(() => requireFromPlugin.resolve("@openclaw/llm-core")).toThrow();

--- a/src/plugins/plugin-sdk-native-resolver.ts
+++ b/src/plugins/plugin-sdk-native-resolver.ts
@@ -57,6 +57,7 @@ const INTERNAL_CORE_PACKAGE_ALIASES = [
     packageDir: "normalization-core",
     subpaths: [
       ["", "index.ts"],
+      ["boolean-coercion", "boolean-coercion.ts"],
       ["number-coercion", "number-coercion.ts"],
       ["record-coerce", "record-coerce.ts"],
       ["string-coerce", "string-coerce.ts"],

--- a/src/plugins/sdk-alias.test.ts
+++ b/src/plugins/sdk-alias.test.ts
@@ -1551,6 +1551,12 @@ describe("plugin sdk alias helpers", () => {
       srcFile: "index.ts",
       distFile: "index.mjs",
     });
+    const normalizationBooleanCoercion = writeWorkspacePackageEntry({
+      root: fixture.root,
+      packageDir: "normalization-core",
+      srcFile: "boolean-coercion.ts",
+      distFile: "boolean-coercion.mjs",
+    });
     const normalizationStringCoerce = writeWorkspacePackageEntry({
       root: fixture.root,
       packageDir: "normalization-core",
@@ -1612,6 +1618,7 @@ describe("plugin sdk alias helpers", () => {
     fs.rmSync(acpCore.distFile);
     fs.rmSync(acpCoreRuntimeTypes.distFile);
     fs.rmSync(normalizationCore.distFile);
+    fs.rmSync(normalizationBooleanCoercion.distFile);
     fs.rmSync(normalizationStringCoerce.distFile);
     fs.rmSync(terminalCore.distFile);
     fs.rmSync(terminalCoreTheme.distFile);
@@ -1665,6 +1672,9 @@ describe("plugin sdk alias helpers", () => {
     );
     expect(fs.realpathSync(aliases["@openclaw/normalization-core"] ?? "")).toBe(
       fs.realpathSync(normalizationCore.srcFile),
+    );
+    expect(fs.realpathSync(aliases["@openclaw/normalization-core/boolean-coercion"] ?? "")).toBe(
+      fs.realpathSync(normalizationBooleanCoercion.srcFile),
     );
     expect(fs.realpathSync(aliases["@openclaw/normalization-core/string-coerce"] ?? "")).toBe(
       fs.realpathSync(normalizationStringCoerce.srcFile),

--- a/src/plugins/sdk-alias.ts
+++ b/src/plugins/sdk-alias.ts
@@ -766,6 +766,13 @@ const WORKSPACE_PACKAGE_ALIAS_ENTRIES: WorkspacePackageAliasEntry[] = [
   {
     packageName: "@openclaw/normalization-core",
     packageDir: "normalization-core",
+    subpath: "boolean-coercion",
+    srcFile: "boolean-coercion.ts",
+    distFile: "boolean-coercion.mjs",
+  },
+  {
+    packageName: "@openclaw/normalization-core",
+    packageDir: "normalization-core",
     subpath: "number-coercion",
     srcFile: "number-coercion.ts",
     distFile: "number-coercion.mjs",

--- a/test/vitest/vitest.shared.config.ts
+++ b/test/vitest/vitest.shared.config.ts
@@ -402,7 +402,7 @@ export const sharedVitestConfig = {
         ),
       },
       {
-        find: "@openclaw/normalization-core",
+        find: /^@openclaw\/normalization-core$/u,
         replacement: path.join(repoRoot, "packages", "normalization-core", "src", "index.ts"),
       },
       sourcePackageAlias("media-core", "base64"),

--- a/test/vitest/vitest.shared.config.ts
+++ b/test/vitest/vitest.shared.config.ts
@@ -352,6 +352,16 @@ export const sharedVitestConfig = {
         replacement: path.join(repoRoot, "packages", "net-policy", "src", "index.ts"),
       },
       {
+        find: "@openclaw/normalization-core/boolean-coercion",
+        replacement: path.join(
+          repoRoot,
+          "packages",
+          "normalization-core",
+          "src",
+          "boolean-coercion.ts",
+        ),
+      },
+      {
         find: "@openclaw/normalization-core/number-coercion",
         replacement: path.join(
           repoRoot,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -129,6 +129,9 @@
       "@openclaw/markdown-core/types": ["./packages/markdown-core/src/types.ts"],
       "@openclaw/markdown-core/*": ["./packages/markdown-core/src/*"],
       "@openclaw/normalization-core": ["./packages/normalization-core/src/index.ts"],
+      "@openclaw/normalization-core/boolean-coercion": [
+        "./packages/normalization-core/src/boolean-coercion.ts"
+      ],
       "@openclaw/normalization-core/number-coercion": [
         "./packages/normalization-core/src/number-coercion.ts"
       ],

--- a/tsdown.config.ts
+++ b/tsdown.config.ts
@@ -434,6 +434,7 @@ function buildMarkdownCoreDistEntries(): Record<string, string> {
 function buildNormalizationCoreDistEntries(): Record<string, string> {
   return {
     index: "packages/normalization-core/src/index.ts",
+    "boolean-coercion": "packages/normalization-core/src/boolean-coercion.ts",
     "number-coercion": "packages/normalization-core/src/number-coercion.ts",
     "record-coerce": "packages/normalization-core/src/record-coerce.ts",
     "string-coerce": "packages/normalization-core/src/string-coerce.ts",


### PR DESCRIPTION
## What Problem This Solves

OpenClaw had several copies of the same exact boolean coercion contract across core and plugin-facing paths. Keeping those copies synchronized made it easy for trimming, case folding, invalid-value handling, or caller defaults to drift.

## Why This Change Was Made

Adds a dependency-free `@openclaw/normalization-core/boolean-coercion` subpath for the exact shared contract: booleans pass through, trimmed case-insensitive `true`/`false` strings parse, and unsupported inputs return `undefined`. The existing plugin SDK record reader delegates to it, and exact-compatible core/WhatsApp callers migrate while environment reads, defaults, fallback policy, numeric or broader truthy tokens, and domain enums remain with their owners.

## User Impact

No user-visible behavior changes. Maintainers and plugin consumers keep the same accepted inputs and defaults through one canonical parser, reducing future drift.

## Evidence

- `node scripts/run-vitest.mjs packages/normalization-core/src/boolean-coercion.test.ts src/agents/tools/media-tool-shared.test.ts src/cron/normalize.test.ts src/cron/service/store.test.ts src/memory-host-sdk/dreaming.test.ts extensions/whatsapp/src/channel-react-action.test.ts test/scripts/prepare-extension-package-boundary-artifacts.test.ts` — 6 shards, 145 tests passed on the rebased head.
- `pnpm --filter @openclaw/normalization-core build` — emitted the new ESM and declaration subpath.
- `node scripts/check-extension-package-tsc-boundary.mjs --mode=compile` — all 117 plugin package boundaries passed.
- `pnpm build` — full package, runtime postbuild, plugin SDK declaration, and UI build passed.
- Delegated Blacksmith Testbox `check:changed`: `tbx_01kwnceqwa5zfvcr53wrhr2the` — typecheck, lint, guards, and import-cycle checks passed.
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main --prompt-file /tmp/boolean-coercion-autoreview-final.md --stream-engine-output` — clean, no accepted/actionable findings.
- Production diff: net -27 non-test lines.
