### PR TITLE
fix: preserve OpenClaw profile env in macOS launch-at-login plist

### DIFF
--- a/apps/macos/Sources/OpenClaw/LaunchAgentManager.swift
+++ b/apps/macos/Sources/OpenClaw/LaunchAgentManager.swift
@@ -31,33 +31,62 @@ enum LaunchAgentManager {
     }
 
     static func plistContents(bundlePath: String) -> String {
-        """
-        <?xml version="1.0" encoding="UTF-8"?>
-        <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-        <plist version="1.0">
-        <dict>
-          <key>Label</key>
-          <string>ai.openclaw.mac</string>
-          <key>ProgramArguments</key>
-          <array>
-            <string>\(bundlePath)/Contents/MacOS/OpenClaw</string>
-          </array>
-          <key>WorkingDirectory</key>
-          <string>\(FileManager().homeDirectoryForCurrentUser.path)</string>
-          <key>RunAtLoad</key>
-          <true/>
-          <key>EnvironmentVariables</key>
-          <dict>
-            <key>PATH</key>
-            <string>\(CommandResolver.preferredPaths().joined(separator: ":"))</string>
-          </dict>
-          <key>StandardOutPath</key>
-          <string>\(LogLocator.launchdLogPath)</string>
-          <key>StandardErrorPath</key>
-          <string>\(LogLocator.launchdLogPath)</string>
-        </dict>
-        </plist>
-        """
+        let environmentVariables = self.launchAgentEnvironmentVariables()
+            .flatMap { key, value in
+                [
+                    "            <key>\(self.escapePlistText(key))</key>",
+                    "            <string>\(self.escapePlistText(value))</string>",
+                ]
+            }
+
+        return ([
+            "<?xml version=\"1.0\" encoding=\"UTF-8\"?>",
+            "<!DOCTYPE plist PUBLIC \"-//Apple//DTD PLIST 1.0//EN\" " +
+                "\"http://www.apple.com/DTDs/PropertyList-1.0.dtd\">",
+            "<plist version=\"1.0\">",
+            "<dict>",
+            "  <key>Label</key>",
+            "  <string>ai.openclaw.mac</string>",
+            "  <key>ProgramArguments</key>",
+            "  <array>",
+            "    <string>\(bundlePath)/Contents/MacOS/OpenClaw</string>",
+            "  </array>",
+            "  <key>WorkingDirectory</key>",
+            "  <string>\(FileManager().homeDirectoryForCurrentUser.path)</string>",
+            "  <key>RunAtLoad</key>",
+            "  <true/>",
+            "  <key>EnvironmentVariables</key>",
+            "  <dict>",
+        ] + environmentVariables + [
+            "  </dict>",
+            "  <key>StandardOutPath</key>",
+            "  <string>\(LogLocator.launchdLogPath)</string>",
+            "  <key>StandardErrorPath</key>",
+            "  <string>\(LogLocator.launchdLogPath)</string>",
+            "</dict>",
+            "</plist>",
+        ]).joined(separator: "\n")
+    }
+
+    private static func launchAgentEnvironmentVariables() -> [(String, String)] {
+        var entries = [("PATH", CommandResolver.preferredPaths().joined(separator: ":"))]
+        let environment = ProcessInfo.processInfo.environment
+        for key in ["OPENCLAW_CONFIG_PATH", "OPENCLAW_STATE_DIR"] {
+            guard let value = environment[key]?.trimmingCharacters(in: .whitespacesAndNewlines),
+                  !value.isEmpty
+            else {
+                continue
+            }
+            entries.append((key, value))
+        }
+        return entries
+    }
+
+    private static func escapePlistText(_ value: String) -> String {
+        value
+            .replacingOccurrences(of: "&", with: "&amp;")
+            .replacingOccurrences(of: "<", with: "&lt;")
+            .replacingOccurrences(of: ">", with: "&gt;")
     }
 
     @discardableResult

--- a/apps/macos/Sources/OpenClaw/LaunchAgentManager.swift
+++ b/apps/macos/Sources/OpenClaw/LaunchAgentManager.swift
@@ -30,8 +30,11 @@ enum LaunchAgentManager {
         try? plist.write(to: self.plistURL, atomically: true, encoding: .utf8)
     }
 
-    static func plistContents(bundlePath: String) -> String {
-        let path = self.escapePlistText(CommandResolver.preferredPaths().joined(separator: ":"))
+    static func plistContents(
+        bundlePath: String,
+        preferredPaths: [String] = CommandResolver.preferredPaths()) -> String
+    {
+        let path = self.escapePlistText(preferredPaths.joined(separator: ":"))
         let profileEnvironment = self.profileEnvironmentPlistEntries()
         return """
         <?xml version="1.0" encoding="UTF-8"?>

--- a/apps/macos/Sources/OpenClaw/LaunchAgentManager.swift
+++ b/apps/macos/Sources/OpenClaw/LaunchAgentManager.swift
@@ -31,55 +31,46 @@ enum LaunchAgentManager {
     }
 
     static func plistContents(bundlePath: String) -> String {
-        let environmentVariables = self.launchAgentEnvironmentVariables()
-            .flatMap { key, value in
-                [
-                    "            <key>\(self.escapePlistText(key))</key>",
-                    "            <string>\(self.escapePlistText(value))</string>",
-                ]
-            }
-
-        return ([
-            "<?xml version=\"1.0\" encoding=\"UTF-8\"?>",
-            "<!DOCTYPE plist PUBLIC \"-//Apple//DTD PLIST 1.0//EN\" " +
-                "\"http://www.apple.com/DTDs/PropertyList-1.0.dtd\">",
-            "<plist version=\"1.0\">",
-            "<dict>",
-            "  <key>Label</key>",
-            "  <string>ai.openclaw.mac</string>",
-            "  <key>ProgramArguments</key>",
-            "  <array>",
-            "    <string>\(bundlePath)/Contents/MacOS/OpenClaw</string>",
-            "  </array>",
-            "  <key>WorkingDirectory</key>",
-            "  <string>\(FileManager().homeDirectoryForCurrentUser.path)</string>",
-            "  <key>RunAtLoad</key>",
-            "  <true/>",
-            "  <key>EnvironmentVariables</key>",
-            "  <dict>",
-        ] + environmentVariables + [
-            "  </dict>",
-            "  <key>StandardOutPath</key>",
-            "  <string>\(LogLocator.launchdLogPath)</string>",
-            "  <key>StandardErrorPath</key>",
-            "  <string>\(LogLocator.launchdLogPath)</string>",
-            "</dict>",
-            "</plist>",
-        ]).joined(separator: "\n")
+        let path = self.escapePlistText(CommandResolver.preferredPaths().joined(separator: ":"))
+        let profileEnvironment = self.profileEnvironmentPlistEntries()
+        return """
+        <?xml version="1.0" encoding="UTF-8"?>
+        <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+        <plist version="1.0">
+        <dict>
+          <key>Label</key>
+          <string>ai.openclaw.mac</string>
+          <key>ProgramArguments</key>
+          <array>
+            <string>\(bundlePath)/Contents/MacOS/OpenClaw</string>
+          </array>
+          <key>WorkingDirectory</key>
+          <string>\(FileManager().homeDirectoryForCurrentUser.path)</string>
+          <key>RunAtLoad</key>
+          <true/>
+          <key>EnvironmentVariables</key>
+          <dict>
+            <key>PATH</key>
+            <string>\(path)</string>\(profileEnvironment)
+          </dict>
+          <key>StandardOutPath</key>
+          <string>\(LogLocator.launchdLogPath)</string>
+          <key>StandardErrorPath</key>
+          <string>\(LogLocator.launchdLogPath)</string>
+        </dict>
+        </plist>
+        """
     }
 
-    private static func launchAgentEnvironmentVariables() -> [(String, String)] {
-        var entries = [("PATH", CommandResolver.preferredPaths().joined(separator: ":"))]
-        let environment = ProcessInfo.processInfo.environment
-        for key in ["OPENCLAW_CONFIG_PATH", "OPENCLAW_STATE_DIR"] {
-            guard let value = environment[key]?.trimmingCharacters(in: .whitespacesAndNewlines),
-                  !value.isEmpty
-            else {
-                continue
-            }
-            entries.append((key, value))
-        }
-        return entries
+    private static func profileEnvironmentPlistEntries() -> String {
+        ["OPENCLAW_CONFIG_PATH", "OPENCLAW_STATE_DIR"].compactMap { key in
+            guard let value = OpenClawEnv.path(key) else { return nil }
+            return """
+
+                        <key>\(key)</key>
+                        <string>\(self.escapePlistText(value))</string>
+            """
+        }.joined()
     }
 
     private static func escapePlistText(_ value: String) -> String {
@@ -87,6 +78,8 @@ enum LaunchAgentManager {
             .replacingOccurrences(of: "&", with: "&amp;")
             .replacingOccurrences(of: "<", with: "&lt;")
             .replacingOccurrences(of: ">", with: "&gt;")
+            .replacingOccurrences(of: "\"", with: "&quot;")
+            .replacingOccurrences(of: "'", with: "&apos;")
     }
 
     @discardableResult

--- a/apps/macos/Tests/OpenClawIPCTests/LaunchAgentManagerTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/LaunchAgentManagerTests.swift
@@ -15,4 +15,23 @@ struct LaunchAgentManagerTests {
         let args = try #require(object["ProgramArguments"] as? [String])
         #expect(args == ["/Applications/OpenClaw.app/Contents/MacOS/OpenClaw"])
     }
+
+    @Test func `launch at login plist preserves OpenClaw profile environment overrides`() throws {
+        setenv("OPENCLAW_CONFIG_PATH", "/tmp/custom-openclaw.json", 1)
+        setenv("OPENCLAW_STATE_DIR", "/tmp/openclaw-state", 1)
+        defer {
+            unsetenv("OPENCLAW_CONFIG_PATH")
+            unsetenv("OPENCLAW_STATE_DIR")
+        }
+
+        let plist = LaunchAgentManager.plistContents(bundlePath: "/Applications/OpenClaw.app")
+        let data = try #require(plist.data(using: .utf8))
+        let object = try #require(
+            PropertyListSerialization.propertyList(from: data, format: nil) as? [String: Any])
+
+        let environment = try #require(object["EnvironmentVariables"] as? [String: String])
+        #expect(environment["OPENCLAW_CONFIG_PATH"] == "/tmp/custom-openclaw.json")
+        #expect(environment["OPENCLAW_STATE_DIR"] == "/tmp/openclaw-state")
+        #expect(environment["PATH"]?.isEmpty == false)
+    }
 }

--- a/apps/macos/Tests/OpenClawIPCTests/LaunchAgentManagerTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/LaunchAgentManagerTests.swift
@@ -16,22 +16,42 @@ struct LaunchAgentManagerTests {
         #expect(args == ["/Applications/OpenClaw.app/Contents/MacOS/OpenClaw"])
     }
 
-    @Test func `launch at login plist preserves OpenClaw profile environment overrides`() throws {
-        setenv("OPENCLAW_CONFIG_PATH", "/tmp/custom-openclaw.json", 1)
-        setenv("OPENCLAW_STATE_DIR", "/tmp/openclaw-state", 1)
-        defer {
-            unsetenv("OPENCLAW_CONFIG_PATH")
-            unsetenv("OPENCLAW_STATE_DIR")
+    @MainActor
+    @Test func `launch at login plist preserves normalized profile environment once`() async throws {
+        try await TestIsolation.withEnvValues([
+            "OPENCLAW_CONFIG_PATH": "  /tmp/custom&<openclaw>\"'.json  ",
+            "OPENCLAW_STATE_DIR": "/tmp/openclaw-state",
+            "PATH": "/tmp/custom&<bin>",
+        ]) {
+            let plist = LaunchAgentManager.plistContents(bundlePath: "/Applications/OpenClaw.app")
+            let data = try #require(plist.data(using: .utf8))
+            let object = try #require(
+                PropertyListSerialization.propertyList(from: data, format: nil) as? [String: Any])
+
+            let environment = try #require(object["EnvironmentVariables"] as? [String: String])
+            #expect(environment["OPENCLAW_CONFIG_PATH"] == "/tmp/custom&<openclaw>\"'.json")
+            #expect(environment["OPENCLAW_STATE_DIR"] == "/tmp/openclaw-state")
+            #expect(environment["PATH"]?.contains("/tmp/custom&<bin>") == true)
+            #expect(plist.components(separatedBy: "<key>OPENCLAW_CONFIG_PATH</key>").count == 2)
+            #expect(plist.components(separatedBy: "<key>OPENCLAW_STATE_DIR</key>").count == 2)
         }
+    }
 
-        let plist = LaunchAgentManager.plistContents(bundlePath: "/Applications/OpenClaw.app")
-        let data = try #require(plist.data(using: .utf8))
-        let object = try #require(
-            PropertyListSerialization.propertyList(from: data, format: nil) as? [String: Any])
+    @MainActor
+    @Test func `launch at login plist omits unset and blank profile environment`() async throws {
+        try await TestIsolation.withEnvValues([
+            "OPENCLAW_CONFIG_PATH": nil,
+            "OPENCLAW_STATE_DIR": " \n ",
+        ]) {
+            let plist = LaunchAgentManager.plistContents(bundlePath: "/Applications/OpenClaw.app")
+            let data = try #require(plist.data(using: .utf8))
+            let object = try #require(
+                PropertyListSerialization.propertyList(from: data, format: nil) as? [String: Any])
 
-        let environment = try #require(object["EnvironmentVariables"] as? [String: String])
-        #expect(environment["OPENCLAW_CONFIG_PATH"] == "/tmp/custom-openclaw.json")
-        #expect(environment["OPENCLAW_STATE_DIR"] == "/tmp/openclaw-state")
-        #expect(environment["PATH"]?.isEmpty == false)
+            let environment = try #require(object["EnvironmentVariables"] as? [String: String])
+            #expect(environment.keys.sorted() == ["PATH"])
+            #expect(!plist.contains("OPENCLAW_CONFIG_PATH"))
+            #expect(!plist.contains("OPENCLAW_STATE_DIR"))
+        }
     }
 }

--- a/apps/macos/Tests/OpenClawIPCTests/LaunchAgentManagerTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/LaunchAgentManagerTests.swift
@@ -21,9 +21,10 @@ struct LaunchAgentManagerTests {
         try await TestIsolation.withEnvValues([
             "OPENCLAW_CONFIG_PATH": "  /tmp/custom&<openclaw>\"'.json  ",
             "OPENCLAW_STATE_DIR": "/tmp/openclaw-state",
-            "PATH": "/tmp/custom&<bin>",
         ]) {
-            let plist = LaunchAgentManager.plistContents(bundlePath: "/Applications/OpenClaw.app")
+            let plist = LaunchAgentManager.plistContents(
+                bundlePath: "/Applications/OpenClaw.app",
+                preferredPaths: ["/tmp/custom&<bin>", "/usr/bin"])
             let data = try #require(plist.data(using: .utf8))
             let object = try #require(
                 PropertyListSerialization.propertyList(from: data, format: nil) as? [String: Any])


### PR DESCRIPTION
Fixes #98594.

## What Problem This Solves

The macOS app reads `OPENCLAW_CONFIG_PATH` and `OPENCLAW_STATE_DIR` to select its active profile, but its launch-at-login plist preserved only `PATH`. After login, the relaunched app could therefore fall back to the default config and state directory.

## Why This Change Was Made

- Preserve the two existing non-empty profile path overrides alongside `PATH`.
- Reuse `OpenClawEnv.path` so foreground and login-launched processes share whitespace and empty-value normalization.
- Keep the existing plist renderer and lifecycle behavior instead of replacing the whole output path.
- XML-escape `PATH` and profile values, and test raw key uniqueness, special-character round trips, and blank omission under the shared Swift env lock.

Apple's current `launchd.plist(5)` contract defines `EnvironmentVariables` as a dictionary of string values. The real-behavior proof below uses the documented `launchctl bootstrap`/`bootout` path.

## User Impact

Enabling Launch at login from an app process started with explicit config/state paths now preserves that same profile on the next login. Users without those overrides keep the existing `PATH`-only behavior.

## Evidence

Exact head: `085fe7532ed3c6c75d879fa55f2148e34304ad23`

- Xcode 27 / Swift 6.4 isolated LaunchAgent suite: 3/3 passed.
- Synthetic current-main merge: LaunchAgent and Gateway LaunchAgent suites, 11/11 passed.
- After hosted parallel CI exposed process-wide `PATH` test pollution, the test now injects preferred paths directly. The four previously failing parallel suites plus both LaunchAgent suites pass together, 147/147.
- `plutil -lint`: generated populated and blank plists passed.
- Parsed populated plist preserved normalized `PATH`, `OPENCLAW_CONFIG_PATH`, and `OPENCLAW_STATE_DIR`; every raw key appeared exactly once. Blank/unset profile values produced only `PATH`.
- Real per-user launchd proof: a temporary redacted LaunchAgent bootstrapped successfully, remained running, and its spawned process received the exact normalized special-character `PATH`, config path, and state directory. The temporary service was booted out after inspection.
- SwiftFormat and `git diff --check` passed. Codex autoreview accepted and fixed one PATH-escaping regression, then confirmed both the final bundle at 0.96 confidence and the test-isolation repair at 0.98 confidence.

The contributor branch's old standalone dependency graph no longer builds under this machine's current Swift actor checks. Proof therefore runs against the synthetic merge users would actually receive, which carries current `main` dependency pins; exact-head hosted macOS CI remains the landing authority.
