### PR TITLE
refactor: consolidate abort primitives

### DIFF
--- a/src/agents/agent-hooks/compaction-safeguard.ts
+++ b/src/agents/agent-hooks/compaction-safeguard.ts
@@ -4,7 +4,7 @@ import path from "node:path";
 import { extractSections } from "../../auto-reply/reply/post-compaction-context.js";
 import { openRootFile } from "../../infra/boundary-file-read.js";
 import { formatErrorMessage } from "../../infra/errors.js";
-import { isAbortError } from "../../infra/unhandled-rejections.js";
+import { isAbortError } from "../../infra/abort-signal.js";
 import { createSubsystemLogger } from "../../logging/subsystem.js";
 import {
   getCompactionProvider,

--- a/src/agents/agent-tools.abort.ts
+++ b/src/agents/agent-tools.abort.ts
@@ -4,51 +4,13 @@
  * channel, and before_tool_call metadata on wrapped tools.
  */
 import { copyPluginToolMeta } from "../plugins/tools.js";
-import { bindAbortRelay } from "../utils/fetch-timeout.js";
+import { createAbortError, mergeAbortSignals } from "../infra/abort-signal.js";
 import type { AnyAgentTool } from "./agent-tools.types.js";
 import { copyBeforeToolCallHookMarker } from "./before-tool-call-metadata.js";
 import { copyChannelAgentToolMeta } from "./channel-tools.js";
 
 function throwAbortError(): never {
-  const err = new Error("Aborted");
-  err.name = "AbortError";
-  throw err;
-}
-
-/**
- * Checks if an object is a valid AbortSignal using structural typing.
- * This is more reliable than `instanceof` across different realms (VM, iframe, etc.)
- * where the AbortSignal constructor may differ.
- */
-function isAbortSignal(obj: unknown): obj is AbortSignal {
-  return obj instanceof AbortSignal;
-}
-
-function combineAbortSignals(a?: AbortSignal, b?: AbortSignal): AbortSignal | undefined {
-  if (!a && !b) {
-    return undefined;
-  }
-  if (a && !b) {
-    return a;
-  }
-  if (b && !a) {
-    return b;
-  }
-  if (a?.aborted) {
-    return a;
-  }
-  if (b?.aborted) {
-    return b;
-  }
-  if (typeof AbortSignal.any === "function" && isAbortSignal(a) && isAbortSignal(b)) {
-    return AbortSignal.any([a, b]);
-  }
-
-  const controller = new AbortController();
-  const onAbort = bindAbortRelay(controller);
-  a?.addEventListener("abort", onAbort, { once: true });
-  b?.addEventListener("abort", onAbort, { once: true });
-  return controller.signal;
+  throw createAbortError("Aborted");
 }
 
 /** Wrap a tool so every execute call observes the supplied run abort signal. */
@@ -66,11 +28,15 @@ export function wrapToolWithAbortSignal(
   const wrappedTool: AnyAgentTool = {
     ...tool,
     execute: async (toolCallId, params, signal, onUpdate) => {
-      const combined = combineAbortSignals(signal, abortSignal);
-      if (combined?.aborted) {
-        throwAbortError();
+      const combined = mergeAbortSignals([signal, abortSignal]);
+      try {
+        if (combined.signal?.aborted) {
+          throwAbortError();
+        }
+        return await execute(toolCallId, params, combined.signal, onUpdate);
+      } finally {
+        combined.dispose();
       }
-      return await execute(toolCallId, params, combined, onUpdate);
     },
   };
   copyPluginToolMeta(tool, wrappedTool);

--- a/src/agents/anthropic-transport-stream.ts
+++ b/src/agents/anthropic-transport-stream.ts
@@ -5,6 +5,7 @@
  */
 import { readResponseTextSnippet } from "@openclaw/media-core/read-response-with-limit";
 import { normalizeLowercaseStringOrEmpty } from "@openclaw/normalization-core/string-coerce";
+import { createAbortError as createNamedAbortError } from "../infra/abort-signal.js";
 import { toErrorObject } from "../infra/errors.js";
 import { getEnvApiKey } from "../llm/env-api-keys.js";
 import { calculateCost, clampThinkingLevel } from "../llm/model-utils.js";
@@ -634,12 +635,10 @@ function createAbortError(signal: AbortSignal): Error {
   if (reason instanceof Error) {
     return reason;
   }
-  const error =
-    reason === undefined
-      ? new Error("Request was aborted")
-      : new Error("Request was aborted", { cause: reason });
-  error.name = "AbortError";
-  return error;
+  return createNamedAbortError(
+    "Request was aborted",
+    reason === undefined ? undefined : { cause: reason },
+  );
 }
 
 function readAnthropicSseChunk(

--- a/src/agents/apply-patch.ts
+++ b/src/agents/apply-patch.ts
@@ -7,6 +7,7 @@ import syncFs from "node:fs";
 import fs from "node:fs/promises";
 import path from "node:path";
 import { Type } from "typebox";
+import { createAbortError } from "../infra/abort-signal.js";
 import { openRootFile, type RootFileOpenResult } from "../infra/boundary-file-read.js";
 import { root as fsRoot } from "../infra/fs-safe.js";
 import { PATH_ALIAS_POLICIES, type PathAliasPolicy } from "../infra/path-alias-guards.js";
@@ -117,9 +118,7 @@ export function createApplyPatchTool(
         throw new Error("Provide a patch input.");
       }
       if (signal?.aborted) {
-        const err = new Error("Aborted");
-        err.name = "AbortError";
-        throw err;
+        throw createAbortError("Aborted");
       }
 
       const result = await applyPatch(input, {
@@ -163,9 +162,7 @@ export async function applyPatch(
 
   for (const hunk of parsed.hunks) {
     if (options.signal?.aborted) {
-      const err = new Error("Aborted");
-      err.name = "AbortError";
-      throw err;
+      throw createAbortError("Aborted");
     }
 
     if (hunk.kind === "add") {

--- a/src/agents/bash-tools.process.ts
+++ b/src/agents/bash-tools.process.ts
@@ -3,6 +3,7 @@
  * Lists, polls, logs, writes to, sends keys to, pastes into, kills, clears,
  * and removes background exec sessions.
  */
+import { createAbortError as createNamedAbortError } from "../infra/abort-signal.js";
 import { formatDurationCompact } from "../infra/format-time/format-duration.ts";
 import { getDiagnosticSessionState } from "../logging/diagnostic-session-state.js";
 import { killProcessTree } from "../process/kill-tree.js";
@@ -149,9 +150,7 @@ function createAbortError(reason: unknown): Error {
   if (reason instanceof Error) {
     return reason;
   }
-  const error = new Error(typeof reason === "string" ? reason : "Aborted");
-  error.name = "AbortError";
-  return error;
+  return createNamedAbortError(typeof reason === "string" ? reason : "Aborted");
 }
 
 async function sleepPollInterval(ms: number, signal?: AbortSignal): Promise<void> {

--- a/src/agents/cli-runner/claude-live-session.ts
+++ b/src/agents/cli-runner/claude-live-session.ts
@@ -3,6 +3,7 @@
  */
 import crypto from "node:crypto";
 import { isRecord } from "@openclaw/normalization-core/record-coerce";
+import { createAbortError as createNamedAbortError } from "../../infra/abort-signal.js";
 import type { ReplyBackendHandle } from "../../auto-reply/reply/reply-run-registry.js";
 import type { CliBackendConfig } from "../../config/types.js";
 import {
@@ -354,9 +355,7 @@ function buildClaudeLiveFingerprint(params: {
 }
 
 function createAbortError(): Error {
-  const error = new Error("CLI run aborted");
-  error.name = "AbortError";
-  return error;
+  return createNamedAbortError("CLI run aborted");
 }
 
 function clearTurnTimers(turn: ClaudeLiveTurn): void {

--- a/src/agents/cli-runner/execute.ts
+++ b/src/agents/cli-runner/execute.ts
@@ -10,6 +10,7 @@ import {
   waitForMcpLoopbackToolCallCaptureIdle,
 } from "../../gateway/mcp-http.loopback-runtime.js";
 import { shouldLogVerbose } from "../../globals.js";
+import { createAbortError } from "../../infra/abort-signal.js";
 import {
   assertAgentRunLifecycleGenerationCurrent,
   emitAgentEvent,
@@ -247,9 +248,7 @@ export function setCliRunnerExecuteTestDeps(overrides: Partial<typeof executeDep
 }
 
 function createCliAbortError(): Error {
-  const error = new Error("CLI run aborted");
-  error.name = "AbortError";
-  return error;
+  return createAbortError("CLI run aborted");
 }
 
 function buildCliLogArgs(params: {

--- a/src/agents/compaction.ts
+++ b/src/agents/compaction.ts
@@ -4,7 +4,7 @@
 import type { AgentCompactionIdentifierPolicy } from "../config/types.agent-defaults.js";
 import { formatErrorMessage } from "../infra/errors.js";
 import { retryAsync } from "../infra/retry.js";
-import { isAbortError } from "../infra/unhandled-rejections.js";
+import { isAbortError } from "../infra/abort-signal.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
 import {
   buildOversizedFallbackPlanWithWorker,

--- a/src/agents/embedded-agent-runner/compaction-safety-timeout.ts
+++ b/src/agents/embedded-agent-runner/compaction-safety-timeout.ts
@@ -4,56 +4,17 @@
 import { finiteSecondsToTimerSafeMilliseconds } from "@openclaw/normalization-core/number-coercion";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import type { CompactResult, ContextEngine } from "../../context-engine/types.js";
+import { createAbortError, mergeAbortSignals } from "../../infra/abort-signal.js";
 import { withTimeout } from "../../node-host/with-timeout.js";
 
 const EMBEDDED_COMPACTION_TIMEOUT_MS = 180_000;
 
-function createAbortError(signal: AbortSignal): Error {
+function abortErrorFromSignal(signal: AbortSignal): Error {
   const reason = "reason" in signal ? signal.reason : undefined;
   if (reason instanceof Error) {
     return reason;
   }
-  const err = reason ? new Error("aborted", { cause: reason }) : new Error("aborted");
-  err.name = "AbortError";
-  return err;
-}
-
-function composeAbortSignals(...signals: Array<AbortSignal | undefined>): {
-  signal?: AbortSignal;
-  cleanup: () => void;
-} {
-  const activeSignals = signals.filter((signal): signal is AbortSignal => Boolean(signal));
-  if (activeSignals.length <= 1) {
-    return { signal: activeSignals[0], cleanup: () => {} };
-  }
-
-  const controller = new AbortController();
-  const removers: Array<() => void> = [];
-
-  const abortFrom = (signal: AbortSignal) => {
-    if (!controller.signal.aborted) {
-      controller.abort("reason" in signal ? signal.reason : undefined);
-    }
-  };
-
-  for (const signal of activeSignals) {
-    if (signal.aborted) {
-      abortFrom(signal);
-      break;
-    }
-    const onAbort = () => abortFrom(signal);
-    signal.addEventListener("abort", onAbort, { once: true });
-    removers.push(() => signal.removeEventListener("abort", onAbort));
-  }
-
-  return {
-    signal: controller.signal,
-    cleanup: () => {
-      for (const remove of removers) {
-        remove();
-      }
-    },
-  };
+  return createAbortError("aborted", reason ? { cause: reason } : undefined);
 }
 
 export function resolveCompactionTimeoutMs(cfg?: OpenClawConfig): number {
@@ -92,7 +53,7 @@ export async function compactWithSafetyTimeout<T>(
       let externalAbortListener: (() => void) | undefined;
       let externalAbortPromise: Promise<never> | undefined;
       const abortSignal = opts?.abortSignal;
-      const composedAbortSignal = composeAbortSignals(timeoutSignal, abortSignal);
+      const composedAbortSignal = mergeAbortSignals([timeoutSignal, abortSignal]);
 
       if (timeoutSignal) {
         timeoutListener = () => {
@@ -104,12 +65,12 @@ export async function compactWithSafetyTimeout<T>(
       if (abortSignal) {
         if (abortSignal.aborted) {
           cancel();
-          throw createAbortError(abortSignal);
+          throw abortErrorFromSignal(abortSignal);
         }
         externalAbortPromise = new Promise((_, reject) => {
           externalAbortListener = () => {
             cancel();
-            reject(createAbortError(abortSignal));
+            reject(abortErrorFromSignal(abortSignal));
           };
           abortSignal.addEventListener("abort", externalAbortListener, { once: true });
         });
@@ -122,7 +83,7 @@ export async function compactWithSafetyTimeout<T>(
         }
         return await compactPromise;
       } finally {
-        composedAbortSignal.cleanup();
+        composedAbortSignal.dispose();
         if (timeoutListener) {
           timeoutSignal?.removeEventListener("abort", timeoutListener);
         }

--- a/src/agents/embedded-agent-runner/run/attempt.async-tasks.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.async-tasks.ts
@@ -1,6 +1,7 @@
 /**
  * Waits for completion-required async tasks before finalizing an attempt.
  */
+import { createAbortError as createNamedAbortError } from "../../../infra/abort-signal.js";
 import { toErrorObject } from "../../../infra/errors.js";
 import { isCronRunSessionKey } from "../../../sessions/session-key-utils.js";
 import { isTerminalTaskStatus } from "../../../tasks/task-executor-policy.js";
@@ -42,11 +43,9 @@ function sleep(ms: number): Promise<void> {
 }
 
 function createAbortError(signal: AbortSignal): Error {
-  const err = new Error("aborted", {
+  return createNamedAbortError("aborted", {
     cause: "reason" in signal ? (signal as { reason?: unknown }).reason : undefined,
   });
-  err.name = "AbortError";
-  return err;
 }
 
 function throwIfAborted(signal: AbortSignal | undefined): void {

--- a/src/agents/sandbox/docker.ts
+++ b/src/agents/sandbox/docker.ts
@@ -4,6 +4,7 @@
  * Wraps Docker spawn, environment sanitization, container inspection, creation, and exec behavior.
  */
 import { spawn } from "node:child_process";
+import { createAbortError } from "../../infra/abort-signal.js";
 import { createSubsystemLogger } from "../../logging/subsystem.js";
 import {
   materializeWindowsSpawnProgram,
@@ -32,12 +33,6 @@ type ExecDockerRawError = Error & {
   stdout: Buffer;
   stderr: Buffer;
 };
-
-function createAbortError(): Error {
-  const err = new Error("Aborted");
-  err.name = "AbortError";
-  return err;
-}
 
 type DockerSpawnRuntime = {
   platform: NodeJS.Platform;
@@ -139,7 +134,7 @@ export function execDockerRaw(
       const stdout = Buffer.concat(stdoutChunks);
       const stderr = Buffer.concat(stderrChunks);
       if (aborted || signal?.aborted) {
-        reject(createAbortError());
+      reject(createAbortError("Aborted"));
         return;
       }
       const exitCode = code ?? 0;

--- a/src/agents/tools/message-tool.ts
+++ b/src/agents/tools/message-tool.ts
@@ -10,6 +10,7 @@ import {
 } from "@openclaw/normalization-core/string-coerce";
 import { sortUniqueStrings, uniqueValues } from "@openclaw/normalization-core/string-normalization";
 import { Type, type TSchema } from "typebox";
+import { createAbortError } from "../../infra/abort-signal.js";
 import {
   GATEWAY_CLIENT_IDS,
   GATEWAY_CLIENT_MODES,
@@ -1268,9 +1269,7 @@ export function createMessageTool(options?: MessageToolOptions): AnyAgentTool {
     parameters: schema,
     execute: async (toolCallId, args, signal) => {
       if (signal?.aborted) {
-        const err = new Error("Message send aborted");
-        err.name = "AbortError";
-        throw err;
+        throw createAbortError("Message send aborted");
       }
       // Shallow-copy so we don't mutate the original event args (used for logging/dedup).
       const params = { ...(args as Record<string, unknown>) };

--- a/src/auto-reply/reply/agent-runner-memory.ts
+++ b/src/auto-reply/reply/agent-runner-memory.ts
@@ -36,7 +36,7 @@ import { readSessionMessagesAsync } from "../../gateway/session-utils.fs.js";
 import { logVerbose } from "../../globals.js";
 import { emitAgentEvent, registerAgentRunContext } from "../../infra/agent-events.js";
 import { formatErrorMessage } from "../../infra/errors.js";
-import { isAbortError } from "../../infra/unhandled-rejections.js";
+import { isAbortError } from "../../infra/abort-signal.js";
 import { resolveMemoryFlushPlan } from "../../plugins/memory-state.js";
 import { CommandLane } from "../../process/lanes.js";
 import { createLazyImportLoader } from "../../shared/lazy-promise.js";

--- a/src/auto-reply/reply/dispatch-from-config.ts
+++ b/src/auto-reply/reply/dispatch-from-config.ts
@@ -66,7 +66,7 @@ import { isDiagnosticsEnabled } from "../../infra/diagnostic-events.js";
 import { measureDiagnosticsTimelineSpan } from "../../infra/diagnostics-timeline.js";
 import { formatErrorMessage } from "../../infra/errors.js";
 import { getSessionBindingService } from "../../infra/outbound/session-binding-service.js";
-import { isAbortError } from "../../infra/unhandled-rejections.js";
+import { isAbortError } from "../../infra/abort-signal.js";
 import type { StuckSessionRecoveryOutcome } from "../../logging/diagnostic-session-recovery.js";
 import {
   logMessageDispatchCompleted,

--- a/src/auto-reply/reply/reply-run-registry.ts
+++ b/src/auto-reply/reply/reply-run-registry.ts
@@ -1,5 +1,6 @@
 // Tracks active reply runs so stop, queue, and status commands can coordinate.
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
+import { createAbortError } from "../../infra/abort-signal.js";
 import {
   createAgentRunRestartAbortError,
   isAgentRunRestartAbortReason,
@@ -170,9 +171,7 @@ export class ReplyRunFollowupAdmissionBlockedError extends Error {
 }
 
 function createUserAbortError(): Error {
-  const err = new Error("Reply operation aborted by user");
-  err.name = "AbortError";
-  return err;
+  return createAbortError("Reply operation aborted by user");
 }
 
 function registerWaitSessionId(sessionKey: string, sessionId: string): void {

--- a/src/commands/agent-via-gateway.ts
+++ b/src/commands/agent-via-gateway.ts
@@ -17,6 +17,7 @@ import {
   readGatewayDispatchConfigWithShellEnvFallback,
 } from "../config/gateway-dispatch-config.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { createAbortError } from "../infra/abort-signal.js";
 import {
   callGateway,
   isGatewayCredentialsRequiredError,
@@ -454,9 +455,7 @@ function resolveAgentCliProcessLike(deps: AgentCliDeps | undefined): AgentCliPro
 }
 
 function createAbortDelayError(): Error {
-  const err = new Error("gateway agent retry aborted");
-  err.name = "AbortError";
-  return err;
+  return createAbortError("gateway agent retry aborted");
 }
 
 function delayMs(ms: number, signal?: AbortSignal): Promise<void> {

--- a/src/context-engine/registry.ts
+++ b/src/context-engine/registry.ts
@@ -1,6 +1,7 @@
 // Context-engine registry owns engine registration, resolution, compatibility, and quarantine.
 import { sanitizeForLog } from "../../packages/terminal-core/src/ansi.js";
 import type { OpenClawConfig } from "../config/types.js";
+import { createAbortError } from "../infra/abort-signal.js";
 import { defaultSlotIdForKey } from "../plugins/slots.js";
 import { resolveGlobalSingleton } from "../shared/global-singleton.js";
 import { isStringOption } from "../utils/string-readers.js";
@@ -737,11 +738,9 @@ function contextEngineAbortError(methodParams: unknown): Error | undefined {
   if (reason instanceof Error) {
     return reason;
   }
-  const error = new Error(
+  return createAbortError(
     typeof reason === "string" && reason ? reason : "Context engine operation aborted.",
   );
-  error.name = "AbortError";
-  return error;
 }
 
 function isContextEngineAbortRejection(error: unknown, methodParams: unknown): boolean {

--- a/src/gateway/call.ts
+++ b/src/gateway/call.ts
@@ -21,6 +21,7 @@ import {
   resolveStateDir as resolveStateDirFromPaths,
 } from "../config/paths.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { createAbortError } from "../infra/abort-signal.js";
 import { loadDeviceAuthToken } from "../infra/device-auth-store.js";
 import { loadOrCreateDeviceIdentity, type DeviceIdentity } from "../infra/device-identity.js";
 import { loadGatewayTlsRuntime } from "../infra/tls/gateway.js";
@@ -849,9 +850,7 @@ function createGatewayTimeoutTransportError(params: {
 }
 
 function createGatewayRequestAbortError(method: string): Error {
-  const err = new Error(`gateway request aborted for ${method}`);
-  err.name = "AbortError";
-  return err;
+  return createAbortError(`gateway request aborted for ${method}`);
 }
 
 function ensureGatewaySupportsRequiredMethods(params: {

--- a/src/gateway/server-methods/agent.ts
+++ b/src/gateway/server-methods/agent.ts
@@ -96,7 +96,7 @@ import {
 } from "../../infra/outbound/agent-delivery.js";
 import { shouldDowngradeDeliveryToSessionOnly } from "../../infra/outbound/best-effort-delivery.js";
 import { resolveMessageChannelSelection } from "../../infra/outbound/channel-selection.js";
-import { isAbortError } from "../../infra/unhandled-rejections.js";
+import { isAbortError } from "../../infra/abort-signal.js";
 import {
   loadVoiceWakeRoutingConfig,
   resolveVoiceWakeRouteByTrigger,

--- a/src/infra/abort-signal.test.ts
+++ b/src/infra/abort-signal.test.ts
@@ -1,6 +1,111 @@
 // Covers abort signal wait helpers.
 import { describe, expect, it } from "vitest";
-import { waitForAbortSignal } from "./abort-signal.js";
+import {
+  createAbortError,
+  isAbortError,
+  mergeAbortSignals,
+  waitForAbortSignal,
+} from "./abort-signal.js";
+
+describe("abort errors", () => {
+  it("creates a named error with an optional cause", () => {
+    const cause = { source: "caller" };
+    const error = createAbortError("stopped", { cause });
+
+    expect(error).toMatchObject({ name: "AbortError", message: "stopped", cause });
+  });
+
+  it("detects standard and legacy Node abort errors", () => {
+    expect(isAbortError(createAbortError("aborted"))).toBe(true);
+    expect(isAbortError({ name: "AbortError", message: "test" })).toBe(true);
+    expect(isAbortError(new Error("This operation was aborted"))).toBe(true);
+  });
+
+  it.each([
+    null,
+    undefined,
+    "string error",
+    42,
+    new Error("Operation aborted"),
+    new Error("aborted"),
+    new Error("Request was aborted"),
+  ])("rejects non-abort input %#", (value) => {
+    expect(isAbortError(value)).toBe(false);
+  });
+});
+
+describe("mergeAbortSignals", () => {
+  it("returns no signal or the single input without listeners", () => {
+    const controller = new AbortController();
+    expect(mergeAbortSignals([]).signal).toBeUndefined();
+    expect(mergeAbortSignals([undefined, controller.signal]).signal).toBe(controller.signal);
+  });
+
+  it("uses input order when multiple inputs are already aborted", () => {
+    const first = new AbortController();
+    const second = new AbortController();
+    first.abort("first");
+    second.abort("second");
+
+    const merged = mergeAbortSignals([first.signal, second.signal]);
+
+    expect(merged.signal?.aborted).toBe(true);
+    expect(merged.signal?.reason).toBe("first");
+  });
+
+  it("preserves the first later abort reason and releases every listener", () => {
+    const makeSignal = () => {
+      const listeners = new Set<() => void>();
+      const signal = {
+        aborted: false,
+        reason: undefined as unknown,
+        addEventListener: (_type: string, listener: () => void) => listeners.add(listener),
+        removeEventListener: (_type: string, listener: () => void) => listeners.delete(listener),
+      } as unknown as AbortSignal;
+      return {
+        signal,
+        listeners,
+        abort: (reason: unknown) => {
+          Object.assign(signal, { aborted: true, reason });
+          // Snapshot before callbacks remove themselves from the listener set.
+          for (const listener of Array.from(listeners)) {
+            listener();
+          }
+        },
+      };
+    };
+    const first = makeSignal();
+    const second = makeSignal();
+    const merged = mergeAbortSignals([first.signal, second.signal]);
+    const reason = new Error("second stopped");
+
+    second.abort(reason);
+
+    expect(merged.signal?.reason).toBe(reason);
+    expect(first.listeners.size).toBe(0);
+    expect(second.listeners.size).toBe(0);
+  });
+
+  it("releases listeners when disposed before an abort", () => {
+    const first = new AbortController();
+    const second = new AbortController();
+    const removed: AbortSignal[] = [];
+    for (const signal of [first.signal, second.signal]) {
+      const remove = signal.removeEventListener.bind(signal);
+      signal.removeEventListener = ((type: string, listener: EventListenerOrEventListenerObject) => {
+        removed.push(signal);
+        remove(type, listener);
+      }) as AbortSignal["removeEventListener"];
+    }
+
+    const merged = mergeAbortSignals([first.signal, second.signal]);
+    merged.dispose();
+    merged.dispose();
+
+    expect(removed).toEqual([first.signal, second.signal]);
+    expect(merged.signal?.aborted).toBe(false);
+  });
+});
 
 describe("waitForAbortSignal", () => {
   it("resolves immediately when signal is missing", async () => {

--- a/src/infra/abort-signal.ts
+++ b/src/infra/abort-signal.ts
@@ -1,3 +1,74 @@
+export function createAbortError(message: string, options?: ErrorOptions): Error {
+  const error = new Error(message, options);
+  error.name = "AbortError";
+  return error;
+}
+
+export function isAbortError(error: unknown): boolean {
+  if (!error || typeof error !== "object") {
+    return false;
+  }
+  const name = "name" in error ? String(error.name) : "";
+  if (name === "AbortError") {
+    return true;
+  }
+  const message = "message" in error && typeof error.message === "string" ? error.message : "";
+  return message === "This operation was aborted";
+}
+
+export function mergeAbortSignals(
+  signals: ReadonlyArray<AbortSignal | undefined>,
+): { signal?: AbortSignal; dispose: () => void } {
+  const activeSignals: AbortSignal[] = [];
+  for (const signal of signals) {
+    if (signal && !activeSignals.includes(signal)) {
+      activeSignals.push(signal);
+    }
+  }
+  if (activeSignals.length <= 1) {
+    return { signal: activeSignals[0], dispose: () => {} };
+  }
+
+  const controller = new AbortController();
+  const listeners = new Map<AbortSignal, () => void>();
+  let disposed = false;
+  const dispose = () => {
+    if (disposed) {
+      return;
+    }
+    disposed = true;
+    for (const [signal, listener] of listeners) {
+      signal.removeEventListener("abort", listener);
+    }
+    listeners.clear();
+  };
+  const abortFrom = (signal: AbortSignal) => {
+    if (controller.signal.aborted) {
+      return;
+    }
+    controller.abort(signal.reason);
+    dispose();
+  };
+
+  for (const signal of activeSignals) {
+    if (signal.aborted) {
+      abortFrom(signal);
+      break;
+    }
+    const listener = () => abortFrom(signal);
+    listeners.set(signal, listener);
+    signal.addEventListener("abort", listener, { once: true });
+    if (controller.signal.aborted || signal.aborted) {
+      if (!controller.signal.aborted) {
+        abortFrom(signal);
+      }
+      break;
+    }
+  }
+
+  return { signal: controller.signal, dispose };
+}
+
 /** Resolves when the signal aborts, or immediately when no wait is needed. */
 export async function waitForAbortSignal(signal?: AbortSignal): Promise<void> {
   if (!signal || signal.aborted) {

--- a/src/infra/agent-events.ts
+++ b/src/infra/agent-events.ts
@@ -2,6 +2,7 @@
 import { AsyncLocalStorage } from "node:async_hooks";
 import { randomUUID } from "node:crypto";
 import type { VerboseLevel } from "../auto-reply/thinking.js";
+import { createAbortError } from "./abort-signal.js";
 import { resolveGlobalSingleton } from "../shared/global-singleton.js";
 import { notifyListeners, registerListener } from "../shared/listeners.js";
 
@@ -194,9 +195,7 @@ export function assertAgentRunLifecycleGenerationCurrent(lifecycleGeneration: st
   if (lifecycleGeneration === getAgentEventState().lifecycleGeneration) {
     return;
   }
-  const error = new Error("Agent run belongs to a stale gateway lifecycle");
-  error.name = "AbortError";
-  throw error;
+  throw createAbortError("Agent run belongs to a stale gateway lifecycle");
 }
 
 /** Captures immutable lifecycle ownership for one admitted execution. */

--- a/src/infra/outbound/abort.ts
+++ b/src/infra/outbound/abort.ts
@@ -1,11 +1,11 @@
+import { createAbortError } from "../abort-signal.js";
+
 /**
  * Throws an AbortError if the given signal has been aborted.
  * Use at async checkpoints to support cancellation.
  */
 export function throwIfAborted(abortSignal?: AbortSignal): void {
   if (abortSignal?.aborted) {
-    const err = new Error("Operation aborted");
-    err.name = "AbortError";
-    throw err;
+    throw createAbortError("Operation aborted");
   }
 }

--- a/src/infra/unhandled-rejections.test.ts
+++ b/src/infra/unhandled-rejections.test.ts
@@ -1,55 +1,12 @@
 // Covers transient and benign unhandled rejection classifiers.
 import { describe, expect, it } from "vitest";
 import {
-  isAbortError,
   isBenignUncaughtExceptionError,
   isTransientFileWatchError,
   isTransientNetworkError,
   isTransientSqliteError,
   isTransientUnhandledRejectionError,
 } from "./unhandled-rejections.js";
-
-describe("isAbortError", () => {
-  it("returns true for error with name AbortError", () => {
-    const error = new Error("aborted");
-    error.name = "AbortError";
-    expect(isAbortError(error)).toBe(true);
-  });
-
-  it('returns true for error with "This operation was aborted" message', () => {
-    const error = new Error("This operation was aborted");
-    expect(isAbortError(error)).toBe(true);
-  });
-
-  it("returns true for undici-style AbortError", () => {
-    // Node's undici throws errors with this exact message
-    const error = Object.assign(new Error("This operation was aborted"), { name: "AbortError" });
-    expect(isAbortError(error)).toBe(true);
-  });
-
-  it("returns true for object with AbortError name", () => {
-    expect(isAbortError({ name: "AbortError", message: "test" })).toBe(true);
-  });
-
-  it("returns false for regular errors", () => {
-    expect(isAbortError(new Error("Something went wrong"))).toBe(false);
-    expect(isAbortError(new TypeError("Cannot read property"))).toBe(false);
-    expect(isAbortError(new RangeError("Invalid array length"))).toBe(false);
-  });
-
-  it("returns false for errors with similar but different messages", () => {
-    expect(isAbortError(new Error("Operation aborted"))).toBe(false);
-    expect(isAbortError(new Error("aborted"))).toBe(false);
-    expect(isAbortError(new Error("Request was aborted"))).toBe(false);
-  });
-
-  it.each([null, undefined, "string error", 42, { message: "plain object" }])(
-    "returns false for non-abort input %#",
-    (value) => {
-      expect(isAbortError(value)).toBe(false);
-    },
-  );
-});
 
 describe("isTransientNetworkError", () => {
   it("returns true for errors with transient network codes", () => {

--- a/src/infra/unhandled-rejections.ts
+++ b/src/infra/unhandled-rejections.ts
@@ -2,6 +2,7 @@
 import process from "node:process";
 import { normalizeLowercaseStringOrEmpty } from "@openclaw/normalization-core/string-coerce";
 import { restoreTerminalState } from "../../packages/terminal-core/src/restore.js";
+import { isAbortError } from "./abort-signal.js";
 import {
   collectErrorGraphCandidates,
   extractErrorCode,
@@ -234,26 +235,6 @@ function extractErrorCodeWithCause(err: unknown): string | undefined {
     return direct;
   }
   return extractErrorCode(getErrorCause(err));
-}
-
-/**
- * Checks if an error is an AbortError.
- * These are typically intentional cancellations (e.g., during shutdown) and shouldn't crash.
- */
-export function isAbortError(err: unknown): boolean {
-  if (!err || typeof err !== "object") {
-    return false;
-  }
-  const name = "name" in err ? String(err.name) : "";
-  if (name === "AbortError") {
-    return true;
-  }
-  // Check for "This operation was aborted" message from Node's undici
-  const message = "message" in err && typeof err.message === "string" ? err.message : "";
-  if (message === "This operation was aborted") {
-    return true;
-  }
-  return false;
 }
 
 function isFatalError(err: unknown): boolean {

--- a/src/media-understanding/attachments.cache.ts
+++ b/src/media-understanding/attachments.cache.ts
@@ -12,7 +12,7 @@ import { resolveStateDir } from "../config/paths.js";
 import { logVerbose, shouldLogVerbose } from "../globals.js";
 import { FsSafeError, openLocalFileSafely } from "../infra/fs-safe.js";
 import type { SsrFPolicy } from "../infra/net/ssrf.js";
-import { isAbortError } from "../infra/unhandled-rejections.js";
+import { isAbortError } from "../infra/abort-signal.js";
 import {
   readRemoteMediaBuffer,
   type MediaFetchRetryOptions,

--- a/src/media/fetch.ts
+++ b/src/media/fetch.ts
@@ -14,8 +14,9 @@ import {
   withTrustedExplicitProxyGuardedFetchMode,
 } from "../infra/net/fetch-guard.js";
 import type { LookupFn, PinnedDispatcherPolicy, SsrFPolicy } from "../infra/net/ssrf.js";
+import { isAbortError } from "../infra/abort-signal.js";
 import { retryAsync, type RetryOptions } from "../infra/retry.js";
-import { isAbortError, isTransientNetworkError } from "../infra/unhandled-rejections.js";
+import { isTransientNetworkError } from "../infra/unhandled-rejections.js";
 import { redactSensitiveText } from "../logging/redact.js";
 import { resolveTimerTimeoutMs } from "../shared/number-coercion.js";
 import { saveMediaBuffer, saveMediaStream, type SavedMedia } from "./store.js";


### PR DESCRIPTION
## What Problem This Solves

Abort cancellation mechanics were reimplemented across core runtime paths, including error creation, error detection, and reason-preserving signal composition. Those copies could drift on abort reasons and listener cleanup.

## Why This Change Was Made

`src/infra/abort-signal.ts` is the existing focused owner for abort primitives. This consolidates only matching contracts there while leaving timeout policy, provider/channel policy, lifecycle codes, and differing cancellation semantics with their callers.

## User Impact

No intended behavior change. Cancellation errors retain their existing messages and causes, and composed signals preserve first-abort precedence and reasons while releasing listeners deterministically.

## Evidence

- `node scripts/run-vitest.mjs src/infra/abort-signal.test.ts src/infra/unhandled-rejections.test.ts src/agents/tool-search.test.ts src/agents/embedded-agent-runner.compaction-safety-timeout.test.ts` — 141 tests passed on exact head `c14c7444214`.
- Blacksmith Testbox through Crabbox `tbx_01kwncjaw3ehc8kr0rgescr413` — exact-head `pnpm check:changed` passed; Actions run 28691067680.
- `.agents/skills/autoreview/scripts/autoreview --mode local --stream-engine-output` — clean, no accepted/actionable findings.
- Production diff is net -39 lines.
