### PR TITLE
refactor: consolidate policy-free deferred promises

### DIFF
--- a/extensions/acpx/src/runtime-turn.ts
+++ b/extensions/acpx/src/runtime-turn.ts
@@ -2,6 +2,7 @@
  * ACPX turn adapters. Modern runtimes can expose startTurn directly; legacy
  * runtimes that only stream runTurn events are adapted to the newer contract.
  */
+import { createDeferred } from "openclaw/plugin-sdk/extension-shared";
 import type {
   AcpRuntime,
   AcpRuntimeEvent,
@@ -9,16 +10,6 @@ import type {
   AcpRuntimeTurnInput,
   AcpRuntimeTurnResult,
 } from "../runtime-api.js";
-
-function createDeferredResult<T>() {
-  let resolve!: (value: T) => void;
-  let reject!: (error: unknown) => void;
-  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
-    resolve = resolvePromise;
-    reject = rejectPromise;
-  });
-  return { promise, resolve, reject };
-}
 
 class LegacyRunTurnEventQueue {
   private readonly items: AcpRuntimeEvent[] = [];
@@ -94,7 +85,7 @@ class LegacyRunTurnEventQueue {
 }
 
 function legacyRunTurnAsStartTurn(runtime: AcpRuntime, input: AcpRuntimeTurnInput): AcpRuntimeTurn {
-  const result = createDeferredResult<AcpRuntimeTurnResult>();
+  const result = createDeferred<AcpRuntimeTurnResult>();
   result.promise.catch(() => {});
   const queue = new LegacyRunTurnEventQueue();
   let resultSettled = false;

--- a/src/gateway/node-reapproval-coordinator.ts
+++ b/src/gateway/node-reapproval-coordinator.ts
@@ -8,6 +8,7 @@ import {
   type NodePairingSupersededRequest,
   type RequestNodePairingResult,
 } from "../infra/node-pairing.js";
+import { createDeferred, type Deferred } from "../shared/deferred.js";
 import {
   AUTH_RATE_LIMIT_SCOPE_NODE_REAPPROVAL,
   buildRateLimitIdentityKey,
@@ -22,11 +23,7 @@ type ReapprovalRequestParams = {
   baseDir?: string;
 };
 
-type DeferredResult = {
-  promise: Promise<RequestNodePairingResult | null>;
-  resolve: (result: RequestNodePairingResult | null) => void;
-  reject: (error: unknown) => void;
-};
+type DeferredResult = Deferred<RequestNodePairingResult | null>;
 
 type QueuedRequest = {
   fingerprint: string;
@@ -45,16 +42,6 @@ export type NodeReapprovalCoordinator = {
   finalizeCleanup: (claim: NodePairingCleanupClaim) => Promise<NodePairingSupersededRequest[]>;
   dispose: () => void;
 };
-
-function createDeferredResult(): DeferredResult {
-  let resolve!: DeferredResult["resolve"];
-  let reject!: DeferredResult["reject"];
-  const promise = new Promise<RequestNodePairingResult | null>((resolvePromise, rejectPromise) => {
-    resolve = resolvePromise;
-    reject = rejectPromise;
-  });
-  return { promise, resolve, reject };
-}
 
 function normalizeFingerprintList(value: string[] | undefined): string[] | undefined {
   return value
@@ -188,7 +175,7 @@ export function createNodeReapprovalCoordinator(
       const fingerprint = buildRequestFingerprint(params.input);
       const state = requestStates.get(nodeId);
       if (!state) {
-        const deferred = createDeferredResult();
+        const deferred = createDeferred<RequestNodePairingResult | null>();
         const nextState: NodeRequestState = { activeFingerprint: fingerprint };
         requestStates.set(nodeId, nextState);
         startFirstRequest(nodeId, nextState, {
@@ -200,13 +187,13 @@ export function createNodeReapprovalCoordinator(
         return deferred.promise;
       }
       if (state.queued?.fingerprint === fingerprint) {
-        const follower = createDeferredResult();
+        const follower = createDeferred<RequestNodePairingResult | null>();
         state.queued.params = params;
         state.queued.followers.push(follower);
         return follower.promise;
       }
 
-      const deferred = createDeferredResult();
+      const deferred = createDeferred<RequestNodePairingResult | null>();
       if (state.queued) {
         state.queued.deferred.resolve(null);
         for (const follower of state.queued.followers) {

--- a/src/plugin-sdk/extension-shared.ts
+++ b/src/plugin-sdk/extension-shared.ts
@@ -4,6 +4,7 @@ import type { z } from "zod";
 import type { OpenClawConfig } from "../config/config.js";
 import { resolveActiveManagedProxyTlsOptions } from "../infra/net/proxy/managed-proxy-undici.js";
 import { resolveDefaultSecretProviderAlias } from "../secrets/ref-contract.js";
+import { createDeferred as createSharedDeferred } from "../shared/deferred.js";
 import { runPassiveAccountLifecycle } from "./channel-lifecycle.core.js";
 import { createLoggerBackedRuntime } from "./runtime-logger.js";
 export { safeParseJsonWithSchema, safeParseWithSchema } from "../utils/zod-parse.js";
@@ -149,13 +150,7 @@ export function coerceStatusIssueAccountId(value: unknown): string | undefined {
 
 /** Creates a promise with externally controlled resolve/reject hooks for async handoff code. */
 export function createDeferred<T>() {
-  let resolve!: (value: T | PromiseLike<T>) => void;
-  let reject!: (reason?: unknown) => void;
-  const promise = new Promise<T>((res, rej) => {
-    resolve = res;
-    reject = rej;
-  });
-  return { promise, resolve, reject };
+  return createSharedDeferred<T>();
 }
 
 const DEFAULT_PACKAGE_JSON_VERSION_CANDIDATES = [

--- a/src/shared/deferred.test.ts
+++ b/src/shared/deferred.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from "vitest";
+import { createDeferred } from "./deferred.js";
+
+describe("createDeferred", () => {
+  it("adopts promise-like resolution values", async () => {
+    const deferred = createDeferred<number>();
+
+    deferred.resolve(Promise.resolve(42));
+
+    await expect(deferred.promise).resolves.toBe(42);
+  });
+
+  it("keeps the first settlement", async () => {
+    const deferred = createDeferred<string>();
+
+    deferred.resolve("first");
+    deferred.reject(new Error("late rejection"));
+    deferred.resolve("second");
+
+    await expect(deferred.promise).resolves.toBe("first");
+  });
+});

--- a/src/shared/deferred.ts
+++ b/src/shared/deferred.ts
@@ -1,0 +1,15 @@
+export type Deferred<T = void> = {
+  promise: Promise<T>;
+  resolve: (value: T | PromiseLike<T>) => void;
+  reject: (reason?: unknown) => void;
+};
+
+type PromiseConstructorWithResolvers = PromiseConstructor & {
+  withResolvers<T>(): Deferred<T>;
+};
+
+const promiseWithResolvers = Promise as PromiseConstructorWithResolvers;
+
+export function createDeferred<T = void>(): Deferred<T> {
+  return promiseWithResolvers.withResolvers<T>();
+}

--- a/src/test-utils/deferred.ts
+++ b/src/test-utils/deferred.ts
@@ -1,18 +1,1 @@
-export type Deferred<T = void> = {
-  promise: Promise<T>;
-  resolve: (value: T | PromiseLike<T>) => void;
-  reject: (reason?: unknown) => void;
-};
-
-export function createDeferred<T = void>(): Deferred<T> {
-  let resolve: ((value: T | PromiseLike<T>) => void) | undefined;
-  let reject: ((reason?: unknown) => void) | undefined;
-  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
-    resolve = resolvePromise;
-    reject = rejectPromise;
-  });
-  if (!resolve || !reject) {
-    throw new Error("Expected deferred callbacks to be initialized");
-  }
-  return { promise, resolve, reject };
-}
+export { createDeferred, type Deferred } from "../shared/deferred.js";

--- a/src/wizard/session.ts
+++ b/src/wizard/session.ts
@@ -1,5 +1,6 @@
 // Wizard session helpers track onboarding session ids and state.
 import { randomUUID } from "node:crypto";
+import { createDeferred, type Deferred } from "../shared/deferred.js";
 import { WizardCancelledError, type WizardProgress, type WizardPrompter } from "./prompts.js";
 
 // WizardSession exposes interactive setup as a step/answer protocol for remote
@@ -31,22 +32,6 @@ type WizardNextResult = {
   status: WizardSessionStatus;
   error?: string;
 };
-
-type Deferred<T> = {
-  promise: Promise<T>;
-  resolve: (value: T) => void;
-  reject: (err: unknown) => void;
-};
-
-function createDeferred<T>(): Deferred<T> {
-  let resolve!: (value: T) => void;
-  let reject!: (err: unknown) => void;
-  const promise = new Promise<T>((res, rej) => {
-    resolve = res;
-    reject = rej;
-  });
-  return { promise, resolve, reject };
-}
 
 class WizardSessionPrompter implements WizardPrompter {
   constructor(private session: WizardSession) {}


### PR DESCRIPTION
## What Problem This Solves

The repository had several policy-free deferred-promise factories that independently constructed the same `{ promise, resolve, reject }` contract. That duplicated low-level mechanics while sitting beside many owner-specific promise waiters whose lifecycle, timeout, cancellation, and settlement rules must remain local.

## Why This Change Was Made

This adds one native-backed internal deferred helper and migrates only the exact matching factories in wizard sessions, node reapproval coordination, the ACPX legacy turn adapter, and the existing test/plugin SDK facades. Queue, lifecycle, timeout, abort, and explicit settlement-tracking implementations remain with their owners. The public plugin SDK wrapper keeps its existing required generic type argument.

AI-assisted: implemented and reviewed with Codex. I understand the changed contracts and verified the affected callers.

## User Impact

No user-visible behavior changes. Maintainers get one canonical, native `Promise.withResolvers`-backed implementation with 22 fewer total lines and 45 fewer production lines across the migrated surface.

## Evidence

- Focused tests: `node scripts/run-vitest.mjs src/shared/deferred.test.ts src/wizard/session.test.ts src/gateway/node-reapproval-coordinator.test.ts extensions/acpx/src/service.test.ts src/plugin-sdk/extension-shared.test.ts` — 67 tests passed across 4 Vitest shards.
- Changed gate: Blacksmith Testbox `tbx_01kwnce4g6x59h35yhvem1txw6`, Actions run `28691011909` — passed typechecks, lint, import cycles, and changed guards.
- Full build: Blacksmith Testbox `tbx_01kwnd33rbe43azmz0vxsvxbm6`, Actions run `28691280739` — `pnpm build` passed.
- Structured autoreview: `.agents/skills/autoreview/scripts/autoreview --mode local --prompt-file /tmp/deferred-autoreview-context.md --stream-engine-output` — clean, no accepted/actionable findings, confidence 0.96.
- Search proof: AST inventory covered 16,798 TS/JS files and classified 835 stored/returned resolver sites; only the exact policy-free factory subset was migrated.
