### PR TITLE
refactor: consolidate free-port test helpers

### DIFF
--- a/src/commands/chutes-oauth.test.ts
+++ b/src/commands/chutes-oauth.test.ts
@@ -1,25 +1,9 @@
 // Chutes OAuth tests cover OAuth endpoints, local callback handling, and fetch preconnect behavior.
-import net from "node:net";
 import { describe, expect, it, vi } from "vitest";
 import { CHUTES_TOKEN_ENDPOINT, CHUTES_USERINFO_ENDPOINT } from "../agents/chutes-oauth.js";
 import { withFetchPreconnect } from "../test-utils/fetch-mock.js";
+import { getFreePort } from "../test-utils/ports.js";
 import { loginChutes } from "./chutes-oauth.js";
-
-async function getFreePort(): Promise<number> {
-  return await new Promise((resolve, reject) => {
-    const server = net.createServer();
-    server.once("error", reject);
-    server.listen(0, "127.0.0.1", () => {
-      const address = server.address();
-      if (!address || typeof address === "string") {
-        server.close(() => reject(new Error("No TCP address")));
-        return;
-      }
-      const port = address.port;
-      server.close((err) => (err ? reject(err) : resolve(port)));
-    });
-  });
-}
 
 const urlToString = (url: Request | URL | string): string => {
   if (typeof url === "string") {

--- a/src/gateway/gateway-models.profiles.live.test.ts
+++ b/src/gateway/gateway-models.profiles.live.test.ts
@@ -2,7 +2,6 @@
 import { randomBytes, randomUUID } from "node:crypto";
 import { writeSync } from "node:fs";
 import fs from "node:fs/promises";
-import { createServer } from "node:net";
 import os from "node:os";
 import path from "node:path";
 import {
@@ -60,6 +59,7 @@ import { DEFAULT_AGENT_ID } from "../routing/session-key.js";
 import { stripAssistantInternalScaffolding } from "../shared/text/assistant-visible-text.js";
 import { findFinalTagMatches, stripFinalTags } from "../shared/text/final-tags.js";
 import { deleteTestEnvValue, setTestEnvValue } from "../test-utils/env.js";
+import { getFreePort, isPortFree } from "../test-utils/ports.js";
 import { GATEWAY_CLIENT_MODES, GATEWAY_CLIENT_NAMES } from "../utils/message-channel.js";
 import { GatewayClient } from "./client.js";
 import {
@@ -1948,42 +1948,6 @@ function editDistance(a: string, b: string): number {
 
   return prev[bLen] ?? Number.POSITIVE_INFINITY;
 }
-async function getFreePort(): Promise<number> {
-  return await new Promise((resolve, reject) => {
-    const srv = createServer();
-    srv.on("error", reject);
-    srv.listen(0, "127.0.0.1", () => {
-      const addr = srv.address();
-      if (!addr || typeof addr === "string") {
-        srv.close();
-        reject(new Error("failed to acquire free port"));
-        return;
-      }
-      const port = addr.port;
-      srv.close((err) => {
-        if (err) {
-          reject(err);
-        } else {
-          resolve(port);
-        }
-      });
-    });
-  });
-}
-
-async function isPortFree(port: number): Promise<boolean> {
-  if (!Number.isFinite(port) || port <= 0 || port > 65535) {
-    return false;
-  }
-  return await new Promise((resolve) => {
-    const srv = createServer();
-    srv.once("error", () => resolve(false));
-    srv.listen(port, "127.0.0.1", () => {
-      srv.close(() => resolve(true));
-    });
-  });
-}
-
 async function getFreeGatewayPort(): Promise<number> {
   // Gateway uses derived ports (browser/canvas). Avoid flaky collisions by
   // ensuring the common derived offsets are free too.

--- a/src/plugin-sdk/provider-auth-runtime.test.ts
+++ b/src/plugin-sdk/provider-auth-runtime.test.ts
@@ -1,28 +1,12 @@
 // Provider auth runtime tests cover OAuth callback handling and provider auth flow helpers.
 import fs from "node:fs/promises";
-import { createServer } from "node:net";
 import os from "node:os";
 import path from "node:path";
 import { describe, expect, it, vi } from "vitest";
 import { saveAuthProfileStore } from "../agents/auth-profiles/store.js";
 import { MAX_TIMER_TIMEOUT_MS } from "../shared/number-coercion.js";
+import { getFreePort } from "../test-utils/ports.js";
 import * as providerAuthRuntime from "./provider-auth-runtime.js";
-
-async function getFreePort(): Promise<number> {
-  return await new Promise((resolve, reject) => {
-    const server = createServer();
-    server.once("error", reject);
-    server.listen(0, "127.0.0.1", () => {
-      const address = server.address();
-      if (!address || typeof address === "string") {
-        server.close(() => reject(new Error("Failed to allocate a local port")));
-        return;
-      }
-      const { port } = address;
-      server.close((err) => (err ? reject(err) : resolve(port)));
-    });
-  });
-}
 
 describe("plugin-sdk provider-auth-runtime", () => {
   it("exports the runtime-ready auth helper", () => {

--- a/src/test-utils/ports.ts
+++ b/src/test-utils/ports.ts
@@ -2,7 +2,7 @@
 import { createServer } from "node:net";
 import { isMainThread, threadId } from "node:worker_threads";
 
-async function isPortFree(port: number): Promise<boolean> {
+export async function isPortFree(port: number): Promise<boolean> {
   if (!Number.isFinite(port) || port <= 0 || port > 65535) {
     return false;
   }
@@ -15,7 +15,7 @@ async function isPortFree(port: number): Promise<boolean> {
   });
 }
 
-async function getOsFreePort(): Promise<number> {
+export async function getFreePort(): Promise<number> {
   return await new Promise((resolve, reject) => {
     const server = createServer();
     server.once("error", reject);
@@ -80,7 +80,7 @@ export async function getDeterministicFreePortBlock(params?: {
 
   // Fallback: let the OS pick a port block (best effort).
   for (let attempt = 0; attempt < 25; attempt += 1) {
-    const port = await getOsFreePort();
+    const port = await getFreePort();
     const ok = (await Promise.all(offsets.map((offset) => isPortFree(port + offset)))).every(
       Boolean,
     );

--- a/test/scripts/e2e-mock-config-limits.test.ts
+++ b/test/scripts/e2e-mock-config-limits.test.ts
@@ -2,11 +2,11 @@
 import { type ChildProcess, spawn, spawnSync } from "node:child_process";
 import { once } from "node:events";
 import { mkdtemp, rm } from "node:fs/promises";
-import net from "node:net";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { setTimeout as delay } from "node:timers/promises";
 import { describe, expect, it } from "vitest";
+import { getFreePort } from "../../src/test-utils/ports.js";
 
 const mockOpenAiPath = "scripts/e2e/mock-openai-server.mjs";
 const webSearchMockPath = "scripts/e2e/lib/openai-web-search-minimal/mock-server.mjs";
@@ -42,22 +42,6 @@ function runScript(scriptPath: string, env: Record<string, string>) {
     killSignal: "SIGKILL",
     timeout: 3_000,
   });
-}
-
-async function freePort() {
-  const server = net.createServer();
-  await new Promise<void>((resolve, reject) => {
-    server.once("error", reject);
-    server.listen(0, "127.0.0.1", resolve);
-  });
-  const address = server.address();
-  await new Promise<void>((resolve, reject) => {
-    server.close((error) => (error ? reject(error) : resolve()));
-  });
-  if (!address || typeof address === "string") {
-    throw new Error("failed to allocate a local port");
-  }
-  return address.port;
 }
 
 async function waitForListening(child: ChildProcess, port: number, output: () => string) {
@@ -127,7 +111,7 @@ async function withMockServer(
     },
   ) => Promise<void>,
 ) {
-  const port = await freePort();
+  const port = await getFreePort();
   let stderr = "";
   let stdout = "";
   const child = spawn(process.execPath, [scriptPath], {


### PR DESCRIPTION
## What Problem This Solves

Removes repeated TCP free-port discovery implementations from root-owned tests, where small cleanup and error-handling differences made the same test contract harder to audit and maintain.

## Why This Change Was Made

The existing `src/test-utils/ports.ts` owner now exports its IPv4-loopback TCP discovery and availability probes, and exact-contract callers reuse them. Helpers with different ownership or semantics remain local, including held-socket reservations, live server lifecycles, plugin/package/UI boundaries, preferred-port selection, and range scanning.

The shared helper binds port `0` on `127.0.0.1`, closes before returning, rejects listen/address/close failures, and returns a port number. It intentionally does not promise that the port remains reserved after return.

## User Impact

No user-visible product behavior changes. Test and tooling maintenance has one fewer duplicated free-port implementation path, with 84 net lines removed.

## Evidence

- `node scripts/run-vitest.mjs src/plugin-sdk/provider-auth-runtime.test.ts src/commands/chutes-oauth.test.ts test/scripts/e2e-mock-config-limits.test.ts` — 3 files / 23 tests passed.
- Blacksmith Testbox `tbx_01kwnf4dmknfx3bxhca58zt15j` — `check:changed` passed, including core/core-test/extension typechecks, lint, import cycles, and repository guards.
- Autoreview: clean; no accepted/actionable findings, overall correctness `patch is correct` (0.96 confidence).
- `git diff --check` — passed.
- Build not run because no runtime module, package, lazy-import, generated output, or published boundary changed.
