### PR TITLE
refactor(providers): table-drive paired catalogs

### DIFF
--- a/extensions/byteplus/index.ts
+++ b/extensions/byteplus/index.ts
@@ -4,8 +4,7 @@
 import { definePluginEntry } from "openclaw/plugin-sdk/plugin-entry";
 import { createProviderApiKeyAuthMethod } from "openclaw/plugin-sdk/provider-auth-api-key";
 import { ensureModelAllowlistEntry } from "openclaw/plugin-sdk/provider-onboard";
-import { BYTEPLUS_CODING_MODEL_CATALOG, BYTEPLUS_MODEL_CATALOG } from "./models.js";
-import { buildBytePlusCodingProvider, buildBytePlusProvider } from "./provider-catalog.js";
+import { BYTEPLUS_PROVIDER_CATALOG_ENTRIES } from "./provider-catalog.js";
 import { buildBytePlusVideoGenerationProvider } from "./video-generation-provider.js";
 
 const PROVIDER_ID = "byteplus";
@@ -55,32 +54,26 @@ export default definePluginEntry({
             return null;
           }
           return {
-            providers: {
-              byteplus: { ...buildBytePlusProvider(), apiKey },
-              "byteplus-plan": { ...buildBytePlusCodingProvider(), apiKey },
-            },
+            providers: Object.fromEntries(
+              BYTEPLUS_PROVIDER_CATALOG_ENTRIES.map(({ id, buildProvider }) => [
+                id,
+                { ...buildProvider(), apiKey },
+              ]),
+            ),
           };
         },
       },
-      augmentModelCatalog: () => {
-        const byteplusModels = BYTEPLUS_MODEL_CATALOG.map((entry) => ({
-          provider: "byteplus",
-          id: entry.id,
-          name: entry.name,
-          reasoning: entry.reasoning,
-          input: [...entry.input],
-          contextWindow: entry.contextWindow,
-        }));
-        const byteplusPlanModels = BYTEPLUS_CODING_MODEL_CATALOG.map((entry) => ({
-          provider: "byteplus-plan",
-          id: entry.id,
-          name: entry.name,
-          reasoning: entry.reasoning,
-          input: [...entry.input],
-          contextWindow: entry.contextWindow,
-        }));
-        return [...byteplusModels, ...byteplusPlanModels];
-      },
+      augmentModelCatalog: () =>
+        BYTEPLUS_PROVIDER_CATALOG_ENTRIES.flatMap(({ id: provider, models }) =>
+          models.map((entry) => ({
+            provider,
+            id: entry.id,
+            name: entry.name,
+            reasoning: entry.reasoning,
+            input: [...entry.input],
+            contextWindow: entry.contextWindow,
+          })),
+        ),
     });
     api.registerVideoGenerationProvider(buildBytePlusVideoGenerationProvider());
   },

--- a/extensions/byteplus/provider-catalog.ts
+++ b/extensions/byteplus/provider-catalog.ts
@@ -3,6 +3,7 @@
  */
 import { buildManifestModelProviderConfig } from "openclaw/plugin-sdk/provider-catalog-shared";
 import type { ModelProviderConfig } from "openclaw/plugin-sdk/provider-model-shared";
+import { BYTEPLUS_CODING_MODEL_CATALOG, BYTEPLUS_MODEL_CATALOG } from "./models.js";
 import manifest from "./openclaw.plugin.json" with { type: "json" };
 
 /** Builds the standard BytePlus model provider config. */
@@ -20,3 +21,18 @@ export function buildBytePlusCodingProvider(): ModelProviderConfig {
     catalog: manifest.modelCatalog.providers["byteplus-plan"],
   });
 }
+
+export const BYTEPLUS_PROVIDER_CATALOG_ENTRIES = [
+  {
+    id: "byteplus",
+    label: "BytePlus",
+    models: BYTEPLUS_MODEL_CATALOG,
+    buildProvider: buildBytePlusProvider,
+  },
+  {
+    id: "byteplus-plan",
+    label: "BytePlus Plan",
+    models: BYTEPLUS_CODING_MODEL_CATALOG,
+    buildProvider: buildBytePlusCodingProvider,
+  },
+] as const;

--- a/extensions/byteplus/provider-discovery.ts
+++ b/extensions/byteplus/provider-discovery.ts
@@ -2,33 +2,21 @@
  * Static provider discovery entries for BytePlus manifest-backed catalogs.
  */
 import type { ProviderPlugin } from "openclaw/plugin-sdk/provider-model-shared";
-import { buildBytePlusCodingProvider, buildBytePlusProvider } from "./provider-catalog.js";
+import { BYTEPLUS_PROVIDER_CATALOG_ENTRIES } from "./provider-catalog.js";
 
-const bytePlusProviderDiscovery: ProviderPlugin[] = [
-  {
-    id: "byteplus",
-    label: "BytePlus",
+const bytePlusProviderDiscovery: ProviderPlugin[] = BYTEPLUS_PROVIDER_CATALOG_ENTRIES.map(
+  ({ id, label, buildProvider }) => ({
+    id,
+    label,
     docsPath: "/providers/models",
     auth: [],
     staticCatalog: {
       order: "simple",
       run: async () => ({
-        provider: buildBytePlusProvider(),
+        provider: buildProvider(),
       }),
     },
-  },
-  {
-    id: "byteplus-plan",
-    label: "BytePlus Plan",
-    docsPath: "/providers/models",
-    auth: [],
-    staticCatalog: {
-      order: "simple",
-      run: async () => ({
-        provider: buildBytePlusCodingProvider(),
-      }),
-    },
-  },
-];
+  }),
+);
 
 export default bytePlusProviderDiscovery;

--- a/extensions/volcengine/index.ts
+++ b/extensions/volcengine/index.ts
@@ -3,8 +3,7 @@ import { definePluginEntry } from "openclaw/plugin-sdk/plugin-entry";
 import { createProviderApiKeyAuthMethod } from "openclaw/plugin-sdk/provider-auth-api-key";
 import { ensureModelAllowlistEntry } from "openclaw/plugin-sdk/provider-onboard";
 import { applyVolcengineToolSchemaCompat } from "./api.js";
-import { DOUBAO_CODING_MODEL_CATALOG, DOUBAO_MODEL_CATALOG } from "./models.js";
-import { buildDoubaoCodingProvider, buildDoubaoProvider } from "./provider-catalog.js";
+import { VOLCENGINE_PROVIDER_CATALOG_ENTRIES } from "./provider-catalog.js";
 import { buildVolcengineSpeechProvider } from "./speech-provider.js";
 
 const PROVIDER_ID = "volcengine";
@@ -55,32 +54,26 @@ export default definePluginEntry({
             return null;
           }
           return {
-            providers: {
-              volcengine: { ...buildDoubaoProvider(), apiKey },
-              "volcengine-plan": { ...buildDoubaoCodingProvider(), apiKey },
-            },
+            providers: Object.fromEntries(
+              VOLCENGINE_PROVIDER_CATALOG_ENTRIES.map(({ id, buildProvider }) => [
+                id,
+                { ...buildProvider(), apiKey },
+              ]),
+            ),
           };
         },
       },
-      augmentModelCatalog: () => {
-        const volcengineModels = DOUBAO_MODEL_CATALOG.map((entry) => ({
-          provider: "volcengine",
-          id: entry.id,
-          name: entry.name,
-          reasoning: entry.reasoning,
-          input: [...entry.input],
-          contextWindow: entry.contextWindow,
-        }));
-        const volcenginePlanModels = DOUBAO_CODING_MODEL_CATALOG.map((entry) => ({
-          provider: "volcengine-plan",
-          id: entry.id,
-          name: entry.name,
-          reasoning: entry.reasoning,
-          input: [...entry.input],
-          contextWindow: entry.contextWindow,
-        }));
-        return [...volcengineModels, ...volcenginePlanModels];
-      },
+      augmentModelCatalog: () =>
+        VOLCENGINE_PROVIDER_CATALOG_ENTRIES.flatMap(({ id: provider, models }) =>
+          models.map((entry) => ({
+            provider,
+            id: entry.id,
+            name: entry.name,
+            reasoning: entry.reasoning,
+            input: [...entry.input],
+            contextWindow: entry.contextWindow,
+          })),
+        ),
       normalizeResolvedModel: ({ model }) => applyVolcengineToolSchemaCompat(model),
     });
     api.registerSpeechProvider(buildVolcengineSpeechProvider());

--- a/extensions/volcengine/provider-catalog.ts
+++ b/extensions/volcengine/provider-catalog.ts
@@ -1,6 +1,7 @@
 // Volcengine provider module implements model/runtime integration.
 import { buildManifestModelProviderConfig } from "openclaw/plugin-sdk/provider-catalog-shared";
 import type { ModelProviderConfig } from "openclaw/plugin-sdk/provider-model-shared";
+import { DOUBAO_CODING_MODEL_CATALOG, DOUBAO_MODEL_CATALOG } from "./models.js";
 import manifest from "./openclaw.plugin.json" with { type: "json" };
 
 export function buildDoubaoProvider(): ModelProviderConfig {
@@ -16,3 +17,18 @@ export function buildDoubaoCodingProvider(): ModelProviderConfig {
     catalog: manifest.modelCatalog.providers["volcengine-plan"],
   });
 }
+
+export const VOLCENGINE_PROVIDER_CATALOG_ENTRIES = [
+  {
+    id: "volcengine",
+    label: "Volcengine",
+    models: DOUBAO_MODEL_CATALOG,
+    buildProvider: buildDoubaoProvider,
+  },
+  {
+    id: "volcengine-plan",
+    label: "Volcengine Plan",
+    models: DOUBAO_CODING_MODEL_CATALOG,
+    buildProvider: buildDoubaoCodingProvider,
+  },
+] as const;

--- a/extensions/volcengine/provider-discovery.ts
+++ b/extensions/volcengine/provider-discovery.ts
@@ -1,32 +1,20 @@
 // Volcengine provider module implements model/runtime integration.
 import type { ProviderPlugin } from "openclaw/plugin-sdk/provider-model-shared";
-import { buildDoubaoCodingProvider, buildDoubaoProvider } from "./provider-catalog.js";
+import { VOLCENGINE_PROVIDER_CATALOG_ENTRIES } from "./provider-catalog.js";
 
-const volcengineProviderDiscovery: ProviderPlugin[] = [
-  {
-    id: "volcengine",
-    label: "Volcengine",
+const volcengineProviderDiscovery: ProviderPlugin[] = VOLCENGINE_PROVIDER_CATALOG_ENTRIES.map(
+  ({ id, label, buildProvider }) => ({
+    id,
+    label,
     docsPath: "/providers/models",
     auth: [],
     staticCatalog: {
       order: "simple",
       run: async () => ({
-        provider: buildDoubaoProvider(),
+        provider: buildProvider(),
       }),
     },
-  },
-  {
-    id: "volcengine-plan",
-    label: "Volcengine Plan",
-    docsPath: "/providers/models",
-    auth: [],
-    staticCatalog: {
-      order: "simple",
-      run: async () => ({
-        provider: buildDoubaoCodingProvider(),
-      }),
-    },
-  },
-];
+  }),
+);
 
 export default volcengineProviderDiscovery;


### PR DESCRIPTION
## What Problem This Solves

BytePlus and Volcengine each repeated the same standard/plan provider pairing across runtime catalog construction, model-catalog augmentation, and static provider discovery. That duplicated provider IDs, labels, builders, model arrays, and ordering in three files per plugin, making those surfaces easy to drift independently.

## Why This Change Was Made

Add one plugin-local descriptor table for each provider owner and derive all three matching catalog surfaces from it. The refactor deliberately stays inside BytePlus and Volcengine: providers with different auth, endpoint, discovery, fallback, alias, or override semantics remain separate, and no core or Plugin SDK policy surface is added.

## User Impact

No user-visible behavior changes. Provider order, IDs, labels, API-key injection, model metadata, static discovery, and fresh provider construction remain unchanged while future catalog updates have one owner-local pairing to maintain.

## Evidence

- `node scripts/run-vitest.mjs extensions/byteplus/index.test.ts extensions/volcengine/index.test.ts` — 2 files, 7 tests passed.
- `node scripts/run-vitest.mjs src/plugins/provider-install-catalog.test.ts src/plugins/manifest-model-catalog.test.ts` — 2 files, 14 tests passed.
- Delegated Blacksmith Testbox `tbx_01kwng7b4x6gtkxhtf92a9n7rh` — `corepack pnpm check:changed` passed extension production/test typechecks, lint with 0 warnings/errors, repository guards, duplicate coverage, and import-cycle checks.
- `.agents/skills/autoreview/scripts/autoreview --mode local --prompt-file tmp/autoreview-context.md --stream-engine-output` — clean, no accepted/actionable findings; correctness confidence 0.98.
- `git diff --check origin/main...HEAD` — clean.
- Production diff: 84 insertions, 90 deletions (net -6 LOC).
