### PR TITLE
fix(telegram): restore preview tool progress callbacks

### DIFF
--- a/extensions/codex/src/app-server/event-projector.test.ts
+++ b/extensions/codex/src/app-server/event-projector.test.ts
@@ -1958,6 +1958,71 @@ describe("CodexAppServerEventProjector", () => {
     expect(toolResultContentItem.content).toBe("ok");
   });
 
+  it("awaits native tool progress consumers before completing tool start notifications", async () => {
+    let releaseProgress!: () => void;
+    const progressDelivered = new Promise<void>((resolve) => {
+      releaseProgress = resolve;
+    });
+    let progressResolved = false;
+    void progressDelivered.then(() => {
+      progressResolved = true;
+    });
+    const onAgentEvent = vi.fn((event) => {
+      const data = requireRecord(event.data, "agent event data");
+      if (event.stream === "tool" && data.phase === "start" && data.name === "bash") {
+        return progressDelivered;
+      }
+      return undefined;
+    });
+    const projector = await createProjector({
+      ...(await createParams()),
+      onAgentEvent,
+    });
+
+    let notificationResolved = false;
+    const pendingNotification = projector
+      .handleNotification(
+        forCurrentTurn("item/started", {
+          item: {
+            type: "commandExecution",
+            id: "cmd-awaited",
+            command: "pwd",
+            cwd: "/workspace",
+            processId: null,
+            source: "agent",
+            status: "inProgress",
+            commandActions: [],
+            aggregatedOutput: null,
+            exitCode: null,
+            durationMs: null,
+          },
+        }),
+      )
+      .then(() => {
+        notificationResolved = true;
+      });
+
+    await flushDiagnosticEvents();
+
+    const toolStart = findAgentEvent(onAgentEvent, {
+      stream: "tool",
+      phase: "start",
+      itemId: "cmd-awaited",
+      name: "bash",
+    }).data;
+    expect(toolStart.toolCallId).toBe("cmd-awaited");
+    expect(onAgentEvent.mock.results.some((result) => result.value === progressDelivered)).toBe(
+      true,
+    );
+    expect(progressResolved).toBe(false);
+    expect(notificationResolved).toBe(false);
+
+    releaseProgress();
+    await pendingNotification;
+
+    expect(notificationResolved).toBe(true);
+  });
+
   it("synthesizes native tool progress from turn completion snapshots", async () => {
     const onAgentEvent = vi.fn();
     const onToolResult = vi.fn();

--- a/extensions/codex/src/app-server/event-projector.ts
+++ b/extensions/codex/src/app-server/event-projector.ts
@@ -1364,7 +1364,7 @@ export class CodexAppServerEventProjector {
       }
       return;
     }
-    this.emitAgentEvent({
+    await this.emitAgentEventAwaited({
       stream: "tool",
       data: {
         phase: params.phase,
@@ -1920,6 +1920,12 @@ export class CodexAppServerEventProjector {
   private emitAgentEvent(
     event: Parameters<NonNullable<EmbeddedRunAttemptParams["onAgentEvent"]>>[0],
   ): void {
+    void this.emitAgentEventAwaited(event);
+  }
+
+  private async emitAgentEventAwaited(
+    event: Parameters<NonNullable<EmbeddedRunAttemptParams["onAgentEvent"]>>[0],
+  ): Promise<void> {
     try {
       emitGlobalAgentEvent({
         runId: this.params.runId,
@@ -1931,13 +1937,10 @@ export class CodexAppServerEventProjector {
       embeddedAgentLog.debug("codex app-server global agent event emit failed", { error });
     }
     try {
-      const maybePromise = this.params.onAgentEvent?.(event);
-      void Promise.resolve(maybePromise).catch((error: unknown) => {
-        embeddedAgentLog.debug("codex app-server agent event handler rejected", { error });
-      });
+      await this.params.onAgentEvent?.(event);
     } catch (error) {
       // Downstream event consumers must not corrupt the canonical Codex turn projection.
-      embeddedAgentLog.debug("codex app-server agent event handler threw", { error });
+      embeddedAgentLog.debug("codex app-server agent event handler failed", { error });
     }
   }
 

--- a/extensions/telegram/src/bot-message-dispatch.test.ts
+++ b/extensions/telegram/src/bot-message-dispatch.test.ts
@@ -4781,6 +4781,29 @@ describe("dispatchTelegramMessage draft streaming", () => {
     expect(dispatchParams.replyOptions?.reasoningPayloadsEnabled).toBe(false);
   });
 
+  it("opts partial preview tool progress into quiet tool lifecycle callbacks", async () => {
+    setupDraftStreams({ answerMessageId: 2001 });
+    dispatchReplyWithBufferedBlockDispatcher.mockResolvedValue({
+      queuedFinal: false,
+      counts: { block: 0, final: 0, tool: 0 },
+    });
+
+    await dispatchWithContext({
+      context: createContext(),
+      streamMode: "partial",
+      telegramCfg: { streaming: { mode: "partial", preview: { toolProgress: true } } },
+    });
+
+    const dispatchParams = mockCallArg(dispatchReplyWithBufferedBlockDispatcher) as {
+      replyOptions?: {
+        allowToolLifecycleWhenProgressHidden?: boolean;
+        suppressDefaultToolProgressMessages?: boolean;
+      };
+    };
+    expect(dispatchParams.replyOptions?.suppressDefaultToolProgressMessages).toBe(true);
+    expect(dispatchParams.replyOptions?.allowToolLifecycleWhenProgressHidden).toBe(true);
+  });
+
   it("opts shared dispatch into durable reasoning payload delivery when reasoning streams", async () => {
     setupDraftStreams({
       answerMessageId: 2001,

--- a/extensions/telegram/src/bot-message-dispatch.test.ts
+++ b/extensions/telegram/src/bot-message-dispatch.test.ts
@@ -4274,6 +4274,40 @@ describe("dispatchTelegramMessage draft streaming", () => {
     );
   });
 
+  it("renders Telegram commentary in partial preview tool progress", async () => {
+    const draftStream = createSequencedDraftStream(2001);
+    createTelegramDraftStream.mockReturnValue(draftStream);
+    dispatchReplyWithBufferedBlockDispatcher.mockImplementation(async ({ replyOptions }) => {
+      await replyOptions?.onReplyStart?.();
+      await replyOptions?.onItemEvent?.({
+        kind: "preamble",
+        itemId: "preamble-1",
+        progressText: "Checking current config",
+      });
+      await replyOptions?.onToolStart?.({ name: "exec", phase: "start" });
+      return { queuedFinal: false };
+    });
+
+    await dispatchWithContext({
+      context: createContext(),
+      streamMode: "partial",
+      telegramCfg: {
+        streaming: {
+          mode: "partial",
+          preview: { toolProgress: true },
+          progress: { label: false },
+        },
+      },
+    });
+
+    expect(draftStream.updatePreview).toHaveBeenCalledWith(
+      telegramProgressPreview(
+        "💬 Checking current config\n🛠️ Exec",
+        "💬 Checking current config\n<b>🛠️ Exec</b>",
+      ),
+    );
+  });
+
   it("suppresses Telegram preamble progress when commentary is disabled", async () => {
     const draftStream = createSequencedDraftStream(2001);
     createTelegramDraftStream.mockReturnValue(draftStream);
@@ -4797,11 +4831,13 @@ describe("dispatchTelegramMessage draft streaming", () => {
     const dispatchParams = mockCallArg(dispatchReplyWithBufferedBlockDispatcher) as {
       replyOptions?: {
         allowToolLifecycleWhenProgressHidden?: boolean;
+        commentaryProgressEnabled?: boolean;
         suppressDefaultToolProgressMessages?: boolean;
       };
     };
     expect(dispatchParams.replyOptions?.suppressDefaultToolProgressMessages).toBe(true);
     expect(dispatchParams.replyOptions?.allowToolLifecycleWhenProgressHidden).toBe(true);
+    expect(dispatchParams.replyOptions?.commentaryProgressEnabled).toBe(true);
   });
 
   it("opts shared dispatch into durable reasoning payload delivery when reasoning streams", async () => {

--- a/extensions/telegram/src/bot-message-dispatch.ts
+++ b/extensions/telegram/src/bot-message-dispatch.ts
@@ -2666,6 +2666,8 @@ export const dispatchTelegramMessage = async ({
                       },
                   suppressDefaultToolProgressMessages:
                     !streamDeliveryEnabled || Boolean(answerLane.stream),
+                  allowToolLifecycleWhenProgressHidden:
+                    answerLane.stream && streamToolProgressEnabled ? true : undefined,
                   forceToolResultProgress: streamMode === "progress" && streamToolProgressEnabled,
                   allowProgressCallbacksWhenSourceDeliverySuppressed:
                     !isRoomEvent && Boolean(answerLane.stream),

--- a/extensions/telegram/src/bot-message-dispatch.ts
+++ b/extensions/telegram/src/bot-message-dispatch.ts
@@ -1109,6 +1109,11 @@ export const dispatchTelegramMessage = async ({
       }
     },
   });
+  const streamCommentaryProgressEnabled = answerLane.stream
+    ? streamMode === "progress"
+      ? progressDraft.commentaryProgressEnabled
+      : streamToolProgressEnabled
+    : undefined;
   let finalAnswerDeliveryStarted = false;
   let finalAnswerDelivered = false;
   // While the durable verbose lane is active it owns EVERY progress surface
@@ -2674,8 +2679,7 @@ export const dispatchTelegramMessage = async ({
                   onVerboseProgressVisibility: (isActive) => {
                     verboseProgressActive = isActive;
                   },
-                  commentaryProgressEnabled:
-                    streamMode === "progress" ? progressDraft.commentaryProgressEnabled : undefined,
+                  commentaryProgressEnabled: streamCommentaryProgressEnabled,
                   reasoningPayloadsEnabled: durableReasoningPayloadsEnabled,
                   onToolStart: async (payload) => {
                     const toolName = payload.name?.trim();

--- a/src/agents/embedded-agent-subscribe.handlers.tools.test.ts
+++ b/src/agents/embedded-agent-subscribe.handlers.tools.test.ts
@@ -350,6 +350,43 @@ describe("handleToolExecutionStart read path checks", () => {
     expect(ctx.state.itemActiveIds.has("command:tool-await-flush")).toBe(true);
   });
 
+  it("awaits tool start progress callbacks before completing start handling", async () => {
+    const { ctx, onAgentEvent } = createTestContext();
+    let releaseProgress: (() => void) | undefined;
+    onAgentEvent.mockImplementation((event: CapturedAgentEvent) => {
+      if (event.stream !== "tool" || event.data?.phase !== "start") {
+        return undefined;
+      }
+      return new Promise<void>((resolve) => {
+        releaseProgress = resolve;
+      });
+    });
+
+    const evt: ToolExecutionStartEvent = {
+      type: "tool_execution_start",
+      toolName: "exec",
+      toolCallId: "tool-await-progress",
+      args: { command: "echo hi" },
+    };
+
+    let settled = false;
+    const pending = Promise.resolve(handleToolExecutionStart(ctx, evt)).then(() => {
+      settled = true;
+    });
+
+    await vi.waitFor(() => {
+      expect(releaseProgress).toBeTypeOf("function");
+    });
+    await Promise.resolve();
+
+    expect(settled).toBe(false);
+    releaseProgress?.();
+    await pending;
+
+    expect(settled).toBe(true);
+    expect(ctx.state.toolMetaById.has("tool-await-progress")).toBe(true);
+  });
+
   it("keeps processing tool start when progress callbacks throw", async () => {
     const { ctx, warn, onExecutionPhase, onAgentEvent } = createTestContext();
     onExecutionPhase.mockImplementation(() => {

--- a/src/agents/embedded-agent-subscribe.handlers.tools.ts
+++ b/src/agents/embedded-agent-subscribe.handlers.tools.ts
@@ -325,12 +325,17 @@ function emitAgentEventCallbackBestEffort(
   ctx: ToolHandlerContext,
   event: Parameters<NonNullable<ToolHandlerContext["params"]["onAgentEvent"]>>[0],
 ): void {
+  void emitAgentEventCallback(ctx, event);
+}
+
+async function emitAgentEventCallback(
+  ctx: ToolHandlerContext,
+  event: Parameters<NonNullable<ToolHandlerContext["params"]["onAgentEvent"]>>[0],
+): Promise<void> {
   try {
     const result = ctx.params.onAgentEvent?.(event);
     if (isPromiseLike<void>(result)) {
-      void Promise.resolve(result).catch((error: unknown) => {
-        warnBestEffortEventFailure(ctx, "tool agent event", error);
-      });
+      await result;
     }
   } catch (error) {
     warnBestEffortEventFailure(ctx, "tool agent event", error);
@@ -793,15 +798,12 @@ export function handleToolExecutionStart(
   const continueAfterBlockReplyFlush = (): void | Promise<void> => {
     const onBlockReplyFlushResult = ctx.params.onBlockReplyFlush?.();
     if (isPromiseLike<void>(onBlockReplyFlushResult)) {
-      return onBlockReplyFlushResult.then(() => {
-        continueToolExecutionStart();
-      });
+      return onBlockReplyFlushResult.then(() => continueToolExecutionStart());
     }
-    continueToolExecutionStart();
-    return undefined;
+    return continueToolExecutionStart();
   };
 
-  const continueToolExecutionStart = () => {
+  const continueToolExecutionStart = async () => {
     const rawToolName = evt.toolName;
     const toolName = normalizeToolName(rawToolName);
     const toolCallId = evt.toolCallId;
@@ -925,8 +927,9 @@ export function handleToolExecutionStart(
       startedAt,
     };
     emitTrackedItemEvent(ctx, itemData);
-    // Best-effort typing signal; do not block tool summaries on slow emitters.
-    emitAgentEventCallbackBestEffort(ctx, {
+    // Tool-start callbacks open channel preview windows. Await this boundary so
+    // fast embedded turns cannot finalize before the preview sees the tool.
+    await emitAgentEventCallback(ctx, {
       stream: "tool",
       data: {
         phase: "start",

--- a/src/channels/progress-draft-compositor.test.ts
+++ b/src/channels/progress-draft-compositor.test.ts
@@ -21,6 +21,95 @@ describe("createChannelProgressDraftCompositor", () => {
     expect(update).toHaveBeenCalledWith("Shelling", { flush: true, lines: [] });
   });
 
+  it("renders commentary in non-progress previews when preview tool progress is enabled", async () => {
+    const update = vi.fn();
+    const progress = createChannelProgressDraftCompositor({
+      entry: {
+        streaming: {
+          mode: "partial",
+          preview: { toolProgress: true },
+          progress: { label: false },
+        },
+      },
+      mode: "partial",
+      active: true,
+      seed: "test",
+      commentaryLinePrefix: "💬 ",
+      commentaryItalics: false,
+      update,
+    });
+
+    expect(progress.commentaryProgressEnabled).toBe(true);
+
+    await progress.pushCommentaryProgress("Checking the current config.", {
+      itemId: "commentary-1",
+    });
+
+    expect(update).toHaveBeenCalledWith("💬 Checking the current config.", {
+      flush: true,
+      lines: [
+        {
+          id: "commentary:commentary-1",
+          kind: "item",
+          label: "Commentary",
+          prefix: false,
+          text: "💬 Checking the current config.",
+        },
+      ],
+    });
+  });
+
+  it("clears retracted commentary from non-progress previews", async () => {
+    const update = vi.fn();
+    const deleteCurrent = vi.fn();
+    const progress = createChannelProgressDraftCompositor({
+      entry: {
+        streaming: {
+          mode: "partial",
+          preview: { toolProgress: true },
+          progress: { label: false },
+        },
+      },
+      mode: "partial",
+      active: true,
+      seed: "test",
+      commentaryLinePrefix: "💬 ",
+      commentaryItalics: false,
+      update,
+      deleteCurrent,
+    });
+
+    await progress.pushCommentaryProgress("Checking the current config.", {
+      itemId: "commentary-1",
+    });
+    await progress.pushCommentaryProgress("", { itemId: "commentary-1" });
+
+    expect(deleteCurrent).toHaveBeenCalledOnce();
+  });
+
+  it("does not render non-progress commentary after suppression", async () => {
+    const update = vi.fn();
+    const progress = createChannelProgressDraftCompositor({
+      entry: {
+        streaming: {
+          mode: "partial",
+          preview: { toolProgress: true },
+          progress: { label: false },
+        },
+      },
+      mode: "partial",
+      active: true,
+      seed: "test",
+      commentaryLinePrefix: "💬 ",
+      update,
+    });
+
+    progress.suppress();
+    await progress.pushCommentaryProgress("Late preamble", { itemId: "commentary-1" });
+
+    expect(update).not.toHaveBeenCalled();
+  });
+
   it("gates window thinking on its own flag, independent of tool progress", async () => {
     // thinking: false hides thoughts even though toolProgress stays on…
     const hiddenUpdate = vi.fn();

--- a/src/channels/progress-draft-compositor.ts
+++ b/src/channels/progress-draft-compositor.ts
@@ -61,7 +61,9 @@ export function createChannelProgressDraftCompositor(params: {
   const previewToolProgressEnabled =
     params.active && resolveChannelStreamingPreviewToolProgress(params.entry);
   const commentaryProgressEnabled =
-    params.active && resolveChannelStreamingProgressCommentary(params.entry);
+    params.active &&
+    (resolveChannelStreamingProgressCommentary(params.entry) ||
+      (params.mode !== "progress" && previewToolProgressEnabled));
   const thinkingProgressEnabled =
     params.active && (params.reasoningGate ?? previewToolProgressEnabled);
   const suppressDefaultToolProgressMessages =
@@ -95,7 +97,7 @@ export function createChannelProgressDraftCompositor(params: {
   };
 
   const render = async (options?: { flush?: boolean }): Promise<boolean> => {
-    if (!params.active || params.mode !== "progress" || finalReplyStarted || finalReplyDelivered) {
+    if (!params.active || finalReplyStarted || finalReplyDelivered) {
       return false;
     }
     const text = formatDraftText();
@@ -318,7 +320,7 @@ export function createChannelProgressDraftCompositor(params: {
       return false;
     },
     async pushCommentaryProgress(text?: string, options?: { itemId?: string }) {
-      if (!params.active || params.mode !== "progress" || !commentaryProgressEnabled) {
+      if (!params.active || progressSuppressed || !commentaryProgressEnabled) {
         return false;
       }
       if (finalReplyStarted || finalReplyDelivered) {


### PR DESCRIPTION
## What Problem This Solves

Fixes Telegram preview bubbles dropping tool-call progress even when the active config enables it, including the existing `streaming.mode: "partial"` + `streaming.preview.toolProgress: true` setup with raw command text.

## Why This Change Was Made

This was not a config-key change. The loaded host Telegram gateway config already opted into preview tool progress, but three runtime paths could still prevent a visible Telegram tool bubble:

- Telegram suppressed default durable tool summaries when its live preview owned tool progress, but did not opt into the shared dispatcher callback path that forwards quiet tool lifecycle events.
- The generic embedded tool-start handler emitted `stream: "tool"` callbacks without awaiting the async channel progress callback.
- Codex app-server native tool items, such as native `bash` command executions, used a separate projector path from OpenClaw dynamic tools and also emitted `stream: "tool"` callbacks fire-and-forget.

## User Impact

Telegram preview bubbles can show tool starts again under the existing partial-preview config. No new operator setting is required; this patch makes the current `preview.toolProgress` behavior reach the Telegram draft path reliably for both OpenClaw dynamic tools and Codex-native app-server tools.

## Evidence

### Summary

- Set `allowToolLifecycleWhenProgressHidden` for Telegram replies when an answer draft stream is active and preview tool progress is enabled.
- Await embedded tool-start progress callbacks before completing tool-start handling, while keeping callback failures best-effort so a bad progress surface does not break the turn.
- Await Codex app-server native tool progress events before the native item notification completes.
- Allow commentary/preamble progress in non-progress preview tool windows, with retraction and suppression guards so late commentary does not resurrect a suppressed answer lane.

### Root Cause

Live config inspection showed the active host Telegram gateway was using `streaming.mode: "partial"`, `streaming.preview.toolProgress: true`, and raw command text. A separate container gateway exists and has its own config, but the inspected Telegram traffic was on the host gateway; the config itself was not the reason tool bubbles were missing.

Code inspection found the first drop in `extensions/telegram/src/bot-message-dispatch.ts`: Telegram correctly set `suppressDefaultToolProgressMessages` when its preview owned tool progress, but the shared dispatcher only forwards quiet tool lifecycle callbacks when `allowToolLifecycleWhenProgressHidden` is also set. That meant default summaries were hidden and the Telegram preview callback could still be withheld.

After that first fix was present in the host dist, a redacted live private-topic repro still showed missing tool bubbles. The session transcript contained native Codex `bash` `toolCall`/`toolResult` rows, while gateway delivery logs showed only final answer delivery for that turn. That proved tools executed and were mirrored into the transcript, but Telegram never received a progress draft before final delivery.

The second drop was in `src/agents/embedded-agent-subscribe.handlers.tools.ts`: generic embedded tool-start events emitted `stream: "tool"` to the channel callback without awaiting the async callback. A fast embedded turn could deliver the final answer and close/finalize the Telegram draft before `onToolStart` finished opening the progress preview, so the late tool line was rejected by the draft lifecycle.

The remaining live repro used the Codex app-server native projector, not the generic dynamic-tool handler. `extensions/codex/src/app-server/event-projector.ts` synthesized native tool `stream: "tool"` events for items like `commandExecution`, but its per-run event callback was also fire-and-forget. This PR now awaits the native `stream: "tool"` event while preserving catch-and-log behavior for callback failures and leaving non-critical observational events nonblocking.

Upstream/open PR check: related open work was reviewed for overlap. #96214 clears stale terminal presentations after embedded tool completion, #81260 removes duplicate tool starts, #93249 rotates in-flight Telegram preambles at tool boundaries, #97671 addresses Telegram partial/block stream mode selection, and #78020 suppresses internal progress previews. None fixed the missing Codex-native app-server `stream: "tool"` callback ordering bug covered here.

Codex dependency proof checked directly in upstream source: `codex-rs/exec/src/exec_events.rs` defines native exec item lifecycle events, `codex-rs/protocol/src/protocol.rs` defines patch progress lifecycle events, and `codex-rs/app-server-protocol/schema/json/ServerNotification.json` plus `codex-rs/app-server-protocol/src/protocol/v2/mcp.rs` define app-server/MCP tool-call progress notifications. OpenClaw has to preserve those lifecycle/progress events through the channel callback ordering boundary.

### Real behavior proof

Before this patch, the Telegram unit tests exercised `replyOptions.onToolStart` directly inside the Telegram dispatch mock, bypassing the shared dispatcher wrapper that suppresses callbacks when tool summaries are hidden. The new and updated regressions check the real handoffs:

- `suppressDefaultToolProgressMessages` remains `true`, so default durable summaries stay suppressed.
- `allowToolLifecycleWhenProgressHidden` is now `true`, so the shared dispatcher forwards lifecycle starts to the Telegram preview.
- Generic embedded tool-start handling now waits for the async channel progress callback before the start handler settles.
- Codex-native app-server tool-start projection now waits for the async per-run event consumer before the native item notification settles.

Focused proof after the final patch:

```text
OPENCLAW_VITEST_FS_MODULE_CACHE_PATH=$(mktemp -d) node scripts/run-vitest.mjs extensions/codex/src/app-server/event-projector.test.ts -t "awaits native tool progress|synthesizes normalized tool progress|continues projecting turn completion" --reporter=verbose
Test Files  1 passed (1)
Tests  3 passed | 97 skipped (100)
```

```text
node scripts/run-vitest.mjs src/channels/progress-draft-compositor.test.ts --reporter=verbose
Test Files  1 passed (1)
Tests  16 passed (16)
```

```text
node scripts/run-vitest.mjs extensions/telegram/src/bot-message-dispatch.test.ts -t "partial preview|Telegram commentary|quiet tool lifecycle|tool progress visible" --reporter=verbose
Test Files  1 passed (1)
Tests  6 passed | 165 skipped (171)
```

```text
node scripts/run-vitest.mjs src/agents/embedded-agent-subscribe.handlers.tools.test.ts -t "tool start progress|tool lifecycle|read path checks" --reporter=verbose
Test Files  2 passed (2)
Tests  18 passed | 134 skipped (152)
```

```text
node scripts/run-vitest.mjs src/auto-reply/reply/dispatch-from-config.test.ts -t "tool lifecycle|channel-owned group progress callbacks|suppressed" --reporter=verbose
Test Files  1 passed (1)
Tests  13 passed | 227 skipped (240)
```

### Verification

```text
git diff --check
```

```text
.agents/skills/autoreview/scripts/autoreview --mode local
autoreview clean: no accepted/actionable findings reported
overall: patch is correct (0.86)
```

After this PR was updated, `oc-update` was run against the local host gateway install. Redacted result:

```text
oc-update
applied: #99783 fix(telegram): restore preview tool progress callbacks
build completed
first gateway health check hit transient 1006 during restart; attempt 2 succeeded
gateway service active/running
```

Installed source/dist spot checks after `oc-update` found:

```text
allowToolLifecycleWhenProgressHidden: answerLane.stream && streamToolProgressEnabled ? true : void 0
await emitAgentEventCallback(ctx, { stream: "tool", ... })
await this.emitAgentEventAwaited({ stream: "tool", ... })
params.mode !== "progress" && previewToolProgressEnabled
progressSuppressed || !commentaryProgressEnabled
```

`oc-update` also surfaced unrelated local doctor/security warnings, including legacy state migration leftovers, disabled plugin config entries, sandbox namespace policy, LAN gateway bind/security posture, and auth/tooling warnings. Those are not caused by this PR and were not changed here.

### What was not tested

- I have not attached a live Telegram Desktop/Crabbox screenshot or recording for the final patch. Live inspection was limited to redacted host gateway/config/runtime evidence plus focused code-path tests and the post-`oc-update` installed source/dist spot check.
- The separate container gateway was not reconfigured by this PR; it remains a separate runtime with separate config.
- Thought/preamble bubbles were not separately proven as broken in the final repro; this PR keeps that work limited to the already-tested commentary preview behavior.
- I did not run the full Telegram extension suite or full repository checks; validation stayed focused on the Telegram dispatch path, shared compositor, embedded/Codex tool-start ordering, and shared dispatcher callback wrapper.

AI-assisted: yes.
