### PR TITLE
refactor: consolidate unique string list helpers

### DIFF
--- a/src/infra/exec-authorization-plan.ts
+++ b/src/infra/exec-authorization-plan.ts
@@ -1,3 +1,4 @@
+import { uniqueStrings } from "@openclaw/normalization-core/string-normalization";
 import { explainShellCommand } from "./command-explainer/extract.js";
 import type {
   CommandExplanation,
@@ -204,7 +205,7 @@ function stepReasons(step: CommandStep, risks: readonly CommandRisk[]): string[]
       reasons.push(risk.kind);
     }
   }
-  return [...new Set(reasons)];
+  return uniqueStrings(reasons);
 }
 
 function nonReusableStepReasons(step: CommandStep, risks: readonly CommandRisk[]): string[] {
@@ -214,7 +215,7 @@ function nonReusableStepReasons(step: CommandStep, risks: readonly CommandRisk[]
       reasons.push(risk.kind);
     }
   }
-  return [...new Set(reasons)];
+  return uniqueStrings(reasons);
 }
 
 function isShellExpansionDynamicArgument(risk: CommandRisk): boolean {
@@ -266,7 +267,7 @@ function shellWrapperPreludeReasons(params: {
       (risk) => UNANALYZABLE_RISKS.has(risk.kind) && riskBeforeStepExecutable(risk, params.step),
     )
     .map((risk) => risk.kind);
-  return [...new Set(reasons)];
+  return uniqueStrings(reasons);
 }
 
 function isPathScopedExecutableToken(token: string): boolean {
@@ -417,9 +418,11 @@ function createCandidate(params: {
   if (hasCommandPrelude(params.step) && preludeReasons.length === 0) {
     preludeReasons.push(SHELL_WRAPPER_PRELUDE_REASON);
   }
-  const reasons = [
-    ...new Set([...stepPromptReasons, ...stepNonReusableReasons, ...preludeReasons]),
-  ];
+  const reasons = uniqueStrings([
+    ...stepPromptReasons,
+    ...stepNonReusableReasons,
+    ...preludeReasons,
+  ]);
   const trustMode: ExecAuthorizationTrustMode =
     params.segment.resolution?.policyBlocked === true
       ? "prompt-only"

--- a/src/plugins/capability-provider-runtime.ts
+++ b/src/plugins/capability-provider-runtime.ts
@@ -96,10 +96,6 @@ function shouldSkipCapabilityResolution(params: {
   );
 }
 
-function uniqueSorted(values: Iterable<string>): string[] {
-  return sortUniqueStrings(values);
-}
-
 /** Loads the manifest snapshot used to resolve capability-provider ownership. */
 export function loadCapabilityManifestSnapshot(params: {
   cfg?: OpenClawConfig;
@@ -127,7 +123,7 @@ function resolveCapabilityPluginIds(params: {
     }),
   );
   return {
-    runtimePluginIds: uniqueSorted(
+    runtimePluginIds: sortUniqueStrings(
       contractPlugins
         .filter((plugin) =>
           isManifestPluginAvailableForControlPlane({
@@ -138,7 +134,7 @@ function resolveCapabilityPluginIds(params: {
         )
         .map((plugin) => plugin.id),
     ),
-    bundledCompatPluginIds: uniqueSorted(
+    bundledCompatPluginIds: sortUniqueStrings(
       contractPlugins.filter((plugin) => plugin.origin === "bundled").map((plugin) => plugin.id),
     ),
   };
@@ -173,7 +169,7 @@ export function resolveBundledCapabilityProviderIds(params: {
 }): string[] {
   const contractKey = CAPABILITY_CONTRACT_KEY[params.key];
   const snapshot = loadCapabilityManifestSnapshot(params);
-  return uniqueSorted(
+  return sortUniqueStrings(
     snapshot.plugins.flatMap((plugin) =>
       plugin.origin === "bundled" ? (plugin.contracts?.[contractKey] ?? []) : [],
     ),
@@ -464,8 +460,8 @@ function resolveRequestedCapabilityPluginIds(params: {
   }
   return runtimePluginIds.size > 0
     ? {
-        runtimePluginIds: uniqueSorted(runtimePluginIds),
-        bundledCompatPluginIds: uniqueSorted(bundledCompatPluginIds),
+        runtimePluginIds: sortUniqueStrings(runtimePluginIds),
+        bundledCompatPluginIds: sortUniqueStrings(bundledCompatPluginIds),
       }
     : undefined;
 }

--- a/src/plugins/providers.runtime.ts
+++ b/src/plugins/providers.runtime.ts
@@ -32,10 +32,6 @@ import {
 } from "./runtime/load-context.js";
 import type { ProviderPlugin } from "./types.js";
 
-function dedupeSortedPluginIds(values: Iterable<string>): string[] {
-  return sortUniqueStrings(values);
-}
-
 function resolveExplicitProviderOwnerPluginIds(
   params: {
     providerRefs: readonly string[];
@@ -45,7 +41,7 @@ function resolveExplicitProviderOwnerPluginIds(
   },
   snapshot: PluginMetadataRegistryView,
 ): string[] {
-  return dedupeSortedPluginIds(
+  return sortUniqueStrings(
     params.providerRefs.flatMap((provider) => {
       const plannedPluginIds = resolveManifestActivationPluginIds({
         trigger: {
@@ -99,7 +95,7 @@ function mergeExplicitOwnerPluginIds(
   if (explicitOwnerPluginIds.length === 0) {
     return [...providerPluginIds];
   }
-  return dedupeSortedPluginIds([...providerPluginIds, ...explicitOwnerPluginIds]);
+  return sortUniqueStrings([...providerPluginIds, ...explicitOwnerPluginIds]);
 }
 
 function resolvePluginProviderLoadBase(
@@ -141,13 +137,13 @@ function resolvePluginProviderLoadBase(
     params.modelRefs?.length ||
     providerOwnedPluginIds.length > 0 ||
     modelOwnedPluginIds.length > 0
-      ? dedupeSortedPluginIds([
+      ? sortUniqueStrings([
           ...(params.onlyPluginIds ?? []),
           ...providerOwnedPluginIds,
           ...modelOwnedPluginIds,
         ])
       : undefined;
-  const explicitOwnerPluginIds = dedupeSortedPluginIds([
+  const explicitOwnerPluginIds = sortUniqueStrings([
     ...providerOwnedPluginIds,
     ...modelOwnedPluginIds,
   ]);
@@ -246,7 +242,7 @@ function resolveRuntimeProviderPluginLoadState(
   });
   const runtimeRequestedPluginIds =
     base.requestedPluginIds !== undefined
-      ? dedupeSortedPluginIds([...(params.onlyPluginIds ?? []), ...explicitOwnerPluginIds])
+      ? sortUniqueStrings([...(params.onlyPluginIds ?? []), ...explicitOwnerPluginIds])
       : undefined;
   const requestConfig = withActivatedPluginIds({
     config: base.rawConfig,

--- a/src/plugins/providers.ts
+++ b/src/plugins/providers.ts
@@ -518,10 +518,6 @@ function resolveModelSupportMatchKind(
   return undefined;
 }
 
-function dedupeSortedPluginIds(values: Iterable<string>): string[] {
-  return sortUniqueStrings(values);
-}
-
 function classifyProviderRefOwnership(pluginIds: string[] | undefined): ProviderRefOwnership {
   if (!pluginIds || pluginIds.length === 0) {
     return { status: "unowned" };
@@ -542,7 +538,7 @@ function listNormalizedOwnerMapPluginIds(
       matched.push(...pluginIds);
     }
   }
-  return dedupeSortedPluginIds(matched);
+  return sortUniqueStrings(matched);
 }
 
 function resolveOwningPluginIdsForProviderFromSnapshot(
@@ -560,7 +556,7 @@ function resolveOwningPluginIdsForProviderFromSnapshot(
     const plugin = snapshot.byPluginId.get(pluginId);
     return plugin ? pluginOwnsProviderRef(plugin, normalizedProvider) : false;
   });
-  const pluginIds = dedupeSortedPluginIds([...directOwners, ...aliasOwners]);
+  const pluginIds = sortUniqueStrings([...directOwners, ...aliasOwners]);
   return pluginIds.length > 0 ? pluginIds : undefined;
 }
 
@@ -571,7 +567,7 @@ function resolvePreferredManifestPluginIds(
   if (matchedPluginIds.length === 0) {
     return undefined;
   }
-  const uniquePluginIds = dedupeSortedPluginIds(matchedPluginIds);
+  const uniquePluginIds = sortUniqueStrings(matchedPluginIds);
   if (uniquePluginIds.length <= 1) {
     return uniquePluginIds;
   }
@@ -691,7 +687,7 @@ function resolveOwningPluginIdsForCliBackend(params: {
     )
     .map((plugin) => plugin.id);
 
-  const deduped = dedupeSortedPluginIds(pluginIds);
+  const deduped = sortUniqueStrings(pluginIds);
   return deduped.length > 0 ? deduped : undefined;
 }
 
@@ -804,7 +800,7 @@ export function resolveOwningPluginIdsForModelRefs(params: {
 }): string[] {
   const registry = params.manifestRegistry ? undefined : loadProviderRegistrySnapshot(params);
   const manifestRegistry = params.manifestRegistry;
-  return dedupeSortedPluginIds(
+  return sortUniqueStrings(
     params.models.flatMap(
       (model) =>
         resolveOwningPluginIdsForModelRef({
@@ -854,6 +850,6 @@ export function resolveCatalogHookProviderPluginIds(params: {
     ...params,
     manifestRegistry,
   }).filter((pluginId) => runtimeAugmentPluginIds.has(pluginId));
-  return dedupeSortedPluginIds([...enabledProviderPluginIds, ...bundledCompatPluginIds]);
+  return sortUniqueStrings([...enabledProviderPluginIds, ...bundledCompatPluginIds]);
 }
 export { testing as __testing };


### PR DESCRIPTION
## What Problem This Solves

OpenClaw had several local wrappers and raw `Set` conversions that duplicated the shared stable-order string dedupe helpers, making the same policy-free mechanics appear to have multiple owners.

## Why This Change Was Made

This AI-assisted refactor removes three exact aliases of `sortUniqueStrings` in provider resolution and routes exec authorization reason-list dedupe through `uniqueStrings`. Sorting, trimming, casing, validation, precedence, source priority, and domain defaults remain local and unchanged.

## User Impact

No user-visible behavior changes. Maintainers get one canonical implementation for these exact unique-list mechanics and nine fewer production lines.

## Evidence

- `node scripts/run-vitest.mjs src/infra/exec-authorization-plan.test.ts src/plugins/capability-provider-runtime.test.ts src/plugins/providers.test.ts src/plugins/providers.runtime.consult-current-snapshot.test.ts` — 146 tests passed across 2 shards.
- Blacksmith Testbox through Crabbox changed gate — `tbx_01kwnhjbqsc6hgt2eb4c8m4y93`, Actions run `28693064957`, exit 0.
- `.agents/skills/autoreview/scripts/autoreview --mode local --stream-engine-output` — clean, 0 accepted/actionable findings, correctness confidence 0.99.
- `git diff --check` — passed.
- Build not required: no exports, package boundaries, or lazy imports changed.
