### PR TITLE
refactor: reuse shared number clamp

### DIFF
--- a/src/agents/agent-tools.read.ts
+++ b/src/agents/agent-tools.read.ts
@@ -23,6 +23,7 @@ import {
   resolveMediaReferenceSandboxPath,
 } from "../media/media-reference.js";
 import { sniffMimeFromBase64 } from "../media/sniff-mime-from-base64.js";
+import { clampNumber } from "../utils.js";
 import {
   REQUIRED_PARAM_GROUPS,
   assertRequiredParams,
@@ -75,10 +76,6 @@ const READ_CONTINUATION_NOTICE_RE =
   /\n\n\[(?:Showing lines [^\]]*?Use offset=\d+ to continue\.|\d+ more lines in file\. Use offset=\d+ to continue\.)\]\s*$/;
 const DAILY_MEMORY_PATH_RE = /^memory\/\d{4}-\d{2}-\d{2}\.md$/;
 
-function clamp(value: number, min: number, max: number): number {
-  return Math.max(min, Math.min(max, value));
-}
-
 function resolveAdaptiveReadMaxBytes(options?: OpenClawReadToolOptions): number {
   const contextWindowTokens = options?.modelContextWindowTokens;
   if (
@@ -91,7 +88,7 @@ function resolveAdaptiveReadMaxBytes(options?: OpenClawReadToolOptions): number 
   const fromContext = Math.floor(
     contextWindowTokens * CHARS_PER_TOKEN_ESTIMATE * ADAPTIVE_READ_CONTEXT_SHARE,
   );
-  return clamp(fromContext, DEFAULT_READ_PAGE_MAX_BYTES, MAX_ADAPTIVE_READ_MAX_BYTES);
+  return clampNumber(fromContext, DEFAULT_READ_PAGE_MAX_BYTES, MAX_ADAPTIVE_READ_MAX_BYTES);
 }
 
 function malformedXmlArgValuePathError(key: string): Error {

--- a/src/agents/code-mode.ts
+++ b/src/agents/code-mode.ts
@@ -15,6 +15,7 @@ import { uniqueValues } from "@openclaw/normalization-core/string-normalization"
 import { Type } from "typebox";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { createLazyPromiseLoader } from "../shared/lazy-runtime.js";
+import { clampNumber } from "../utils.js";
 import { resolveAgentConfig } from "./agent-scope-config.js";
 import type { HookContext } from "./agent-tools.before-tool-call.js";
 import {
@@ -186,10 +187,6 @@ function readPositiveInteger(value: unknown, fallback: number): number {
   return typeof value === "number" && Number.isInteger(value) && value > 0 ? value : fallback;
 }
 
-function clampInteger(value: number, min: number, max: number): number {
-  return Math.max(min, Math.min(max, value));
-}
-
 function readLanguages(value: unknown): CodeModeLanguage[] {
   if (!Array.isArray(value)) {
     return ["javascript", "typescript"];
@@ -203,7 +200,7 @@ function readLanguages(value: unknown): CodeModeLanguage[] {
 /** Resolves Code Mode runtime limits and language support from config. */
 export function resolveCodeModeConfig(config?: OpenClawConfig, agentId?: string): CodeModeConfig {
   const raw = readCodeModeRawConfig(config, agentId);
-  const maxSearchLimit = clampInteger(
+  const maxSearchLimit = clampNumber(
     readPositiveInteger(raw.maxSearchLimit, DEFAULT_MAX_SEARCH_LIMIT),
     1,
     DEFAULT_MAX_SEARCH_LIMIT,
@@ -213,33 +210,33 @@ export function resolveCodeModeConfig(config?: OpenClawConfig, agentId?: string)
     runtime: "quickjs-wasi",
     mode: "only",
     languages: readLanguages(raw.languages),
-    timeoutMs: clampInteger(readPositiveInteger(raw.timeoutMs, DEFAULT_TIMEOUT_MS), 100, 60_000),
-    memoryLimitBytes: clampInteger(
+    timeoutMs: clampNumber(readPositiveInteger(raw.timeoutMs, DEFAULT_TIMEOUT_MS), 100, 60_000),
+    memoryLimitBytes: clampNumber(
       readPositiveInteger(raw.memoryLimitBytes, DEFAULT_MEMORY_LIMIT_BYTES),
       1024 * 1024,
       1024 * 1024 * 1024,
     ),
-    maxOutputBytes: clampInteger(
+    maxOutputBytes: clampNumber(
       readPositiveInteger(raw.maxOutputBytes, DEFAULT_MAX_OUTPUT_BYTES),
       1024,
       10 * 1024 * 1024,
     ),
-    maxSnapshotBytes: clampInteger(
+    maxSnapshotBytes: clampNumber(
       readPositiveInteger(raw.maxSnapshotBytes, DEFAULT_MAX_SNAPSHOT_BYTES),
       1024,
       256 * 1024 * 1024,
     ),
-    maxPendingToolCalls: clampInteger(
+    maxPendingToolCalls: clampNumber(
       readPositiveInteger(raw.maxPendingToolCalls, DEFAULT_MAX_PENDING_TOOL_CALLS),
       1,
       128,
     ),
-    snapshotTtlSeconds: clampInteger(
+    snapshotTtlSeconds: clampNumber(
       readPositiveInteger(raw.snapshotTtlSeconds, DEFAULT_SNAPSHOT_TTL_SECONDS),
       1,
       24 * 60 * 60,
     ),
-    searchDefaultLimit: clampInteger(
+    searchDefaultLimit: clampNumber(
       readPositiveInteger(raw.searchDefaultLimit, DEFAULT_SEARCH_LIMIT),
       1,
       maxSearchLimit,


### PR DESCRIPTION
## What Problem This Solves

Two agent modules carried exact local copies of the repository's existing generic inclusive number clamp.

## Why This Change Was Made

An architecture audit of current `main`, packages, core source, Control UI, plugin SDK barrels, and helper history found that `src/utils.ts` has owned the exact generic `clampNumber` contract since January 2026. The compatible agent callers now import that established helper.

The audit intentionally leaves other numeric helpers unchanged:

- normalization-core finite/range helpers reject invalid or out-of-range input instead of clamping;
- integer option helpers add flooring and fallback policy and differ for reversed bounds;
- retry helpers add finite/fallback policy;
- the Control UI placement helper keeps its browser-local reversed-bound behavior;
- units, defaults, domain bounds, error policy, and semantic sentinels remain local.

No normalization-core or plugin SDK surface changes remain in this PR.

## User Impact

No intended user-visible behavior change. The two removed helpers and `src/utils.ts` use the same inclusive expression, including existing `NaN`, infinity, and reversed-bound behavior. The final production diff is net negative: 11 additions and 17 deletions across two files.

## Evidence

- Focused tests: `node scripts/run-vitest.mjs src/utils.test.ts src/agents/code-mode.test.ts src/agents/agent-tools.create-openclaw-coding-tools.adds-claude-style-aliases-schemas-without-dropping-g.test.ts`
  - Result: 3 files, 86 tests passed across 2 Vitest shards.
- Testbox-through-Crabbox: `tbx_01kwq4n4az2rs6cpss510pebp8`, Actions run `28714907327`, exit 0.
  - `pnpm check:changed` passed core production/test typechecks, lint with zero warnings/errors, guards, duplicate coverage, and import-cycle checks.
  - Full `pnpm build` passed, including plugin SDK export validation and Control UI build.
- Fresh committed-branch autoreview: clean, no accepted/actionable findings; correctness confidence 0.99.
- `git diff --check` passed.
