### PR TITLE
fix(huggingface): bound model discovery response body size with readProviderJsonResponse

### DIFF
--- a/extensions/huggingface/models.test.ts
+++ b/extensions/huggingface/models.test.ts
@@ -108,6 +108,48 @@ describe("huggingface models", () => {
     expect(timeoutSpy).toHaveBeenCalledWith(MAX_TIMER_TIMEOUT_MS);
   });
 
+  it("reads and parses model discovery response via readProviderJsonResponse", async () => {
+    process.env.VITEST = "false";
+    process.env.NODE_ENV = "development";
+    stubAbortSignalTimeout();
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(
+        async () =>
+          new Response(
+            JSON.stringify({ data: [{ id: "custom-model-a" }, { id: "custom-model-b" }] }),
+            { status: 200, headers: { "Content-Type": "application/json" } },
+          ),
+      ),
+    );
+
+    const models = await discoverHuggingfaceModels("hf_test_token");
+    expect(models).toHaveLength(2);
+    expect(models[0].id).toBe("custom-model-a");
+    expect(models[1].id).toBe("custom-model-b");
+  });
+
+  it("falls back to static catalog on malformed JSON response", async () => {
+    process.env.VITEST = "false";
+    process.env.NODE_ENV = "development";
+    stubAbortSignalTimeout();
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(
+        async () =>
+          new Response("not-json-at-all", {
+            status: 200,
+            headers: { "Content-Type": "application/json" },
+          }),
+      ),
+    );
+
+    const result = await discoverHuggingfaceModels("hf_test_token");
+    // readProviderJsonResponse throws "malformed JSON" -> outer catch returns static catalog
+    expect(result).toHaveLength(HUGGINGFACE_MODEL_CATALOG.length);
+    expect(result.map((m) => m.id)).toEqual(HUGGINGFACE_MODEL_CATALOG.map((m) => m.id));
+  });
+
   describe("isHuggingfacePolicyLocked", () => {
     it("returns true for :cheapest and :fastest refs", () => {
       expect(isHuggingfacePolicyLocked("huggingface/deepseek-ai/DeepSeek-R1:cheapest")).toBe(true);

--- a/extensions/huggingface/models.ts
+++ b/extensions/huggingface/models.ts
@@ -6,6 +6,7 @@ import {
   ssrfPolicyFromHttpBaseUrlAllowedHostname,
 } from "openclaw/plugin-sdk/ssrf-runtime";
 import { normalizeLowercaseStringOrEmpty } from "openclaw/plugin-sdk/string-coerce-runtime";
+import { readProviderJsonResponse } from "openclaw/plugin-sdk/provider-http";
 import { isHuggingfaceModelDiscoveryTestEnvironment } from "./model-discovery-env.js";
 
 export const HUGGINGFACE_BASE_URL = "https://router.huggingface.co/v1";
@@ -165,7 +166,10 @@ export async function discoverHuggingfaceModels(
         return HUGGINGFACE_MODEL_CATALOG.map(buildHuggingfaceModelDefinition);
       }
 
-      const body = (await response.json()) as OpenAIListModelsResponse;
+      const body = await readProviderJsonResponse<OpenAIListModelsResponse>(
+        response,
+        "huggingface-model-discovery",
+      );
       const data = body?.data;
       if (!Array.isArray(data) || data.length === 0) {
         return HUGGINGFACE_MODEL_CATALOG.map(buildHuggingfaceModelDefinition);


### PR DESCRIPTION
## Summary

HuggingFace model discovery (`/v1/models`) parses the response body with `response.json()` and no size limit, risking OOM from a compromised or misconfigured upstream endpoint.

- Problem: `response.json()` buffers the entire body before parsing; a multi-GB response exhausts process memory.
- Solution: Replace with `readProviderJsonResponse` from plugin-sdk, which enforces a 16 MiB cap and cancels the stream on overflow.
- What changed: `extensions/huggingface/models.ts` (1 call site), `extensions/huggingface/models.test.ts` (2 new tests)
- What did NOT change: Error-path behavior (already uses bounded reader); other `response.json()` call sites in extensions; test environment guard; static catalog fallback.

## Change Type

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [x] Security hardening
- [ ] Chore/infra

## Scope

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- N/A — no existing issue for this hardening gap

## Motivation

Same pattern already merged across 8 other provider response paths (PR #96321–#96620). HuggingFace was the only remaining unbounded `response.json()` success-path read in bundled extensions.

## Real behavior proof

- Behavior addressed: Unbounded `response.json()` in HuggingFace model discovery, OOM risk from huge API responses.
- Real environment tested: Linux x86_64, Node v22, branch `fix/huggingface-models-response-limit`.
- Exact steps or command run after this patch:

```bash
pnpm test extensions/huggingface/models.test.ts
```

- Evidence after fix:

```console
$ pnpm test extensions/huggingface/models.test.ts

 RUN  v4.1.8

 Test Files  1 passed (1)
      Tests  10 passed (10)
```

- Observed result after fix:
  - Valid JSON response → models parsed correctly (happy path test)
  - Malformed JSON response → graceful fallback to static catalog
  - All 8 original tests still pass (timeout handling, env guards, policy locking)

- What was not tested: Live HuggingFace network endpoint; response > 16 MiB (capped by `readProviderJsonResponse`'s default limit).

## User-visible / Behavior Changes

None for well-formed responses. Malformed or oversized responses now gracefully fall back to the static bundled catalog instead of crashing the process.

## Security Impact

- [x] New permissions/capabilities? No
- [x] Secrets/tokens handling changed? No
- [x] New/changed network calls? No
- [x] Command/tool execution surface changed? No
- [x] Data access scope changed? No

## Human Verification

- Verified scenarios: Valid JSON parse succeeds, malformed JSON falls back, existing tests unaffected.
- Edge cases checked: Empty response body (already handled by existing `!response.ok` branch), malformed JSON (new test), non-2xx response (existing path).
- What you did NOT verify: Live HuggingFace endpoint.

## Compatibility / Migration

- [x] Backward compatible? Yes
- [x] Config/env changes? No
- [x] Migration needed? No

## Best-fix Verdict

- **Best fix**: Yes — uses the same `readProviderJsonResponse` helper already used by other provider discovery paths (Mantle in #96480).
- **Refactor needed**: No.
- **Alternative considered**: Inline `readResponseWithLimit` (more verbose, duplicates error handling already in `readProviderJsonResponse`).

## AI Assistance

- **AI-assisted**: Yes
- **AI model**: DeepSeek V4
- **Human confirmed understanding of code changes**: Yes

## Risks and Mitigations

- **Highest-risk area**: A legitimate response > 16 MiB would fall back to static catalog instead of parsing live. Realistic `/v1/models` responses are well under this threshold.
- **Mitigation**: Uses the same 16 MiB cap already approved in 8 merged PRs. The static catalog is actively maintained and always used as fallback for other failure modes.
- **Compatibility impact**: None — well-formed responses pass through unchanged.
