### PR TITLE
fix(media-understanding): video auto-selection runs without a model

### DIFF
--- a/src/media-understanding/runner.ts
+++ b/src/media-understanding/runner.ts
@@ -632,8 +632,15 @@ async function resolveKeyEntry(params: {
             explicitModel: model,
             workspaceDir,
           })
-        : model;
-    if (capability === "image" && !resolvedModel) {
+        : capability === "video"
+          ? (model ??
+            resolveDefaultMediaModelFromRegistry({
+              providerId,
+              capability: "video",
+              providerRegistry,
+            }))
+          : model;
+    if ((capability === "image" || capability === "video") && !resolvedModel) {
       return null;
     }
     return { type: "provider" as const, provider: providerId, model: resolvedModel };
@@ -907,9 +914,15 @@ async function resolveActiveModelEntry(params: {
       providerRegistry: params.providerRegistry,
     });
   } else {
-    model = params.activeModel?.model;
+    model =
+      params.activeModel?.model ??
+      resolveDefaultMediaModelFromRegistry({
+        providerId,
+        capability: "video",
+        providerRegistry: params.providerRegistry,
+      });
   }
-  if ((params.capability === "image" || params.capability === "audio") && !model) {
+  if ((params.capability === "image" || params.capability === "video") && !model) {
     return null;
   }
   return {

--- a/src/media-understanding/runner.ts
+++ b/src/media-understanding/runner.ts
@@ -640,7 +640,7 @@ async function resolveKeyEntry(params: {
               providerRegistry,
             }))
           : model;
-    if ((capability === "image" || capability === "video") && !resolvedModel) {
+    if (capability === "image" && !resolvedModel) {
       return null;
     }
     return { type: "provider" as const, provider: providerId, model: resolvedModel };
@@ -922,7 +922,7 @@ async function resolveActiveModelEntry(params: {
         providerRegistry: params.providerRegistry,
       });
   }
-  if ((params.capability === "image" || params.capability === "video") && !model) {
+  if ((params.capability === "image" || params.capability === "audio") && !model) {
     return null;
   }
   return {

--- a/src/media-understanding/runner.video.test.ts
+++ b/src/media-understanding/runner.video.test.ts
@@ -6,6 +6,7 @@ import { withTempDir } from "../test-helpers/temp-dir.js";
 import { withEnvAsync } from "../test-utils/env.js";
 import { runCapability } from "./runner.js";
 import { withVideoFixture } from "./runner.test-utils.js";
+import type { MediaUnderstandingProvider } from "./types.js";
 
 vi.mock("../media/channel-inbound-roots.js", () => ({
   resolveChannelInboundAttachmentRoots: () => undefined,
@@ -84,7 +85,7 @@ describe("runCapability video provider wiring", () => {
           agentDir: isolatedAgentDir,
           attachments: cache,
           media,
-          providerRegistry: new Map([
+          providerRegistry: new Map<string, MediaUnderstandingProvider>([
             [
               "moonshot",
               {
@@ -150,7 +151,7 @@ describe("runCapability video provider wiring", () => {
               agentDir: isolatedAgentDir,
               attachments: cache,
               media,
-              providerRegistry: new Map([
+              providerRegistry: new Map<string, MediaUnderstandingProvider>([
                 [
                   "google",
                   {
@@ -212,7 +213,7 @@ describe("runCapability video provider wiring", () => {
           agentDir: isolatedAgentDir,
           attachments: cache,
           media,
-          providerRegistry: new Map([
+          providerRegistry: new Map<string, MediaUnderstandingProvider>([
             [
               "moonshot",
               {
@@ -236,6 +237,65 @@ describe("runCapability video provider wiring", () => {
         expect(seenModel).toBe("kimi-k2.5");
       });
     });
+  });
+
+  it("skips video providers without a resolvable default model", async () => {
+    let describeCalls = 0;
+
+    await withTempDir(
+      { prefix: "openclaw-video-no-default-provider-" },
+      async (isolatedAgentDir) => {
+        await withVideoFixture("openclaw-video-no-default", async ({ ctx, media, cache }) => {
+          const cfg = {
+            models: {
+              providers: {
+                moonshot: {
+                  auth: "api-key",
+                  apiKey: "moonshot-key", // pragma: allowlist secret
+                  models: [],
+                },
+              },
+            },
+            tools: {
+              media: {
+                video: {
+                  enabled: true,
+                },
+              },
+            },
+          } as unknown as OpenClawConfig;
+
+          const result = await runCapability({
+            capability: "video",
+            cfg,
+            ctx,
+            agentDir: isolatedAgentDir,
+            attachments: cache,
+            media,
+            providerRegistry: new Map<string, MediaUnderstandingProvider>([
+              [
+                "moonshot",
+                {
+                  id: "moonshot",
+                  capabilities: ["video"],
+                  describeVideo: async () => {
+                    describeCalls += 1;
+                    return { text: "moonshot" };
+                  },
+                },
+              ],
+            ]),
+            activeModel: { provider: "moonshot" },
+          });
+
+          expect(result.outputs).toHaveLength(0);
+          expect(result.decision.outcome).toBe("skipped");
+          expect(result.decision.attachments).toHaveLength(1);
+          expect(result.decision.attachments[0]?.attempts).toHaveLength(0);
+          expect(describeCalls).toBe(0);
+        });
+      },
+    );
   });
 
   it("does not use provider api config as video auth modelApi", async () => {
@@ -272,7 +332,7 @@ describe("runCapability video provider wiring", () => {
           agentDir: isolatedAgentDir,
           attachments: cache,
           media,
-          providerRegistry: new Map([
+          providerRegistry: new Map<string, MediaUnderstandingProvider>([
             [
               "openai",
               {

--- a/src/media-understanding/runner.video.test.ts
+++ b/src/media-understanding/runner.video.test.ts
@@ -164,7 +164,8 @@ describe("runCapability video provider wiring", () => {
                   {
                     id: "moonshot",
                     capabilities: ["video"],
-                    describeVideo: async () => ({ text: "moonshot", model: "kimi-k2.5" }),
+                    defaultModels: { video: "kimi-k2.5" },
+                    describeVideo: async (req) => ({ text: "moonshot", model: req.model }),
                   },
                 ],
               ]),
@@ -177,6 +178,63 @@ describe("runCapability video provider wiring", () => {
           });
         },
       );
+    });
+  });
+
+  it("uses the provider video default when the active provider has no model", async () => {
+    let seenModel: string | undefined;
+
+    await withTempDir({ prefix: "openclaw-video-active-provider-" }, async (isolatedAgentDir) => {
+      await withVideoFixture("openclaw-video-active-default", async ({ ctx, media, cache }) => {
+        const cfg = {
+          models: {
+            providers: {
+              moonshot: {
+                auth: "api-key",
+                apiKey: "moonshot-key", // pragma: allowlist secret
+                models: [],
+              },
+            },
+          },
+          tools: {
+            media: {
+              video: {
+                enabled: true,
+              },
+            },
+          },
+        } as unknown as OpenClawConfig;
+
+        const result = await runCapability({
+          capability: "video",
+          cfg,
+          ctx,
+          agentDir: isolatedAgentDir,
+          attachments: cache,
+          media,
+          providerRegistry: new Map([
+            [
+              "moonshot",
+              {
+                id: "moonshot",
+                capabilities: ["video"],
+                defaultModels: { video: "kimi-k2.5" },
+                describeVideo: async (req) => {
+                  seenModel = req.model;
+                  return { text: "moonshot", model: req.model };
+                },
+              },
+            ],
+          ]),
+          activeModel: { provider: "moonshot" },
+        });
+
+        expect(result.decision.outcome).toBe("success");
+        const output = requireCapabilityOutput(result, 0);
+        expect(output.provider).toBe("moonshot");
+        expect(output.model).toBe("kimi-k2.5");
+        expect(seenModel).toBe("kimi-k2.5");
+      });
     });
   });
 

--- a/src/media-understanding/runner.video.test.ts
+++ b/src/media-understanding/runner.video.test.ts
@@ -239,8 +239,8 @@ describe("runCapability video provider wiring", () => {
     });
   });
 
-  it("skips video providers without a resolvable default model", async () => {
-    let describeCalls = 0;
+  it("preserves self-defaulting video providers without registry model metadata", async () => {
+    let seenModel: string | undefined;
 
     await withTempDir(
       { prefix: "openclaw-video-no-default-provider-" },
@@ -278,9 +278,9 @@ describe("runCapability video provider wiring", () => {
                 {
                   id: "moonshot",
                   capabilities: ["video"],
-                  describeVideo: async () => {
-                    describeCalls += 1;
-                    return { text: "moonshot" };
+                  describeVideo: async (req) => {
+                    seenModel = req.model;
+                    return { text: "moonshot", model: "provider-default" };
                   },
                 },
               ],
@@ -288,11 +288,11 @@ describe("runCapability video provider wiring", () => {
             activeModel: { provider: "moonshot" },
           });
 
-          expect(result.outputs).toHaveLength(0);
-          expect(result.decision.outcome).toBe("skipped");
-          expect(result.decision.attachments).toHaveLength(1);
-          expect(result.decision.attachments[0]?.attempts).toHaveLength(0);
-          expect(describeCalls).toBe(0);
+          expect(result.decision.outcome).toBe("success");
+          const output = requireCapabilityOutput(result, 0);
+          expect(output.provider).toBe("moonshot");
+          expect(output.model).toBe("provider-default");
+          expect(seenModel).toBeUndefined();
         });
       },
     );


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users relying on automatic video media understanding could select a video-capable provider without forwarding that provider's declared default video model.

## Why This Change Was Made

Video auto-selection now resolves `defaultModels.video` for both active and key-selected providers when no explicit model is configured. Providers without default-model metadata retain the existing optional-model contract and can continue to choose their own default inside `describeVideo`.

The change stays within media-understanding provider entry resolution. It does not change provider metadata, authentication, explicit model precedence, schemas, or provider catalog defaults.

## User Impact

Video attachments can be described through auto-selected providers such as Moonshot with the provider's declared default model. Existing explicit video model configuration still wins, and custom self-defaulting video providers remain eligible with `model` unset.

## Evidence

- Focused regression suite:

  ```text
  node scripts/run-vitest.mjs \
    src/media-understanding/runner.video.test.ts \
    src/media-understanding/runner.auto-audio.test.ts

  Test Files  2 passed (2)
  Tests       14 passed (14)
  ```

- The regression coverage proves:
  - active video providers receive `defaultModels.video`;
  - key-selected video providers receive `defaultModels.video`;
  - explicit video models retain precedence;
  - providers without model metadata are invoked with `model: undefined` and may self-default;
  - adjacent audio model gating remains unchanged.

- Focused formatting and patch checks passed:

  ```text
  node_modules/.bin/oxfmt --check \
    src/media-understanding/runner.ts \
    src/media-understanding/runner.video.test.ts
  git diff --check
  ```

- Fresh branch autoreview against current `origin/main` found no actionable issues.
