### PR TITLE
test: migrate diagnostics-timeline to createSuiteTempRootTracker

### DIFF
--- a/src/infra/diagnostics-timeline.test.ts
+++ b/src/infra/diagnostics-timeline.test.ts
@@ -1,9 +1,9 @@
 // Covers diagnostics timeline event writing and spans.
-import { mkdtemp, readFile, rm } from "node:fs/promises";
-import { tmpdir } from "node:os";
+import { readFile } from "node:fs/promises";
 import { join } from "node:path";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { createSuiteTempRootTracker } from "../test-helpers/temp-dir.js";
 import {
   emitDiagnosticsTimelineEvent,
   isDiagnosticsTimelineEnabled,
@@ -11,11 +11,10 @@ import {
   measureDiagnosticsTimelineSpanSync,
 } from "./diagnostics-timeline.js";
 
-const tempDirs: string[] = [];
+const suiteTracker = createSuiteTempRootTracker({ prefix: "openclaw-diagnostics-timeline-" });
 
 async function createTimelineEnv() {
-  const dir = await mkdtemp(join(tmpdir(), "openclaw-diagnostics-timeline-"));
-  tempDirs.push(dir);
+  const dir = await suiteTracker.make("timeline");
   return {
     env: {
       OPENCLAW_DIAGNOSTICS: "timeline",
@@ -54,8 +53,12 @@ function attributesRecord(event: Record<string, unknown>): Record<string, unknow
   return event.attributes as Record<string, unknown>;
 }
 
-afterEach(async () => {
-  await Promise.all(tempDirs.splice(0).map((dir) => rm(dir, { recursive: true, force: true })));
+beforeAll(async () => {
+  await suiteTracker.setup();
+});
+
+afterAll(async () => {
+  await suiteTracker.cleanup();
 });
 
 describe("diagnostics timeline", () => {


### PR DESCRIPTION
## What Problem This Solves

`src/infra/diagnostics-timeline.test.ts` maintains a module-level `tempDirs: string[]` plus an `afterEach` drain to clean up ad-hoc `fs.mkdtemp` allocations. Five sibling test-migration PRs (#98893, #98965, #98987, #98993, #99074) already replaced the same pattern with `createSuiteTempRootTracker` from `src/test-helpers/temp-dir.js`. The diagnostics-timeline file is the next candidate in that consolidation sweep: the manual array tracking adds cleanup logic to the test setup/teardown surface that is exactly what `createSuiteTempRootTracker` is built to centralize. After this PR, every shared-prefix temp dir in `src/infra/diagnostics-timeline.test.ts` flows through the same suite-level lifecycle (setup / make / cleanup) used by `src/infra/update-runner.test.ts`, `src/infra/session-cost-usage.test.ts`, `src/infra/install-package-dir.test.ts`, `src/infra/node-pairing.test.ts`, `src/infra/provider-usage.auth.normalizes-keys.test.ts`, and `src/infra/device-pairing.test.ts`.

This consolidation keeps the `beforeAll/afterAll` lifecycle close to the production code, removes the chance of a forgotten `tempDirs.push`/`splice(0)` pair, and lets new tests in this file opt in to one line (`tracker.make("timeline")`) instead of re-deriving the temp-root setup.

## Changes

- `src/infra/diagnostics-timeline.test.ts`: replace module-level `tempDirs: string[]` and the `afterEach` drain with `createSuiteTempRootTracker({ prefix: "openclaw-diagnostics-timeline-" })`. `setup()` runs in `beforeAll`, `cleanup()` runs in `afterAll`. `createTimelineEnv()` now calls `suiteTracker.make("timeline")` instead of `fs.mkdtemp` + manual array push. Removed `mkdtemp`, `rm`, and `tmpdir` imports (no longer needed).

## Real behavior proof

- **Behavior addressed**: ad-hoc `fs.mkdtemp` + module-level temp-dirs array + `afterEach` drain replaced by `createSuiteTempRootTracker` setup/make/cleanup lifecycle. Test bodies are unchanged; assertions and behavior are identical.
- **Real environment tested**: local `pnpm vitest` on Linux Node 22, `node scripts/run-vitest.mjs src/infra/diagnostics-timeline.test.ts --run`.
- **Exact steps or command run after this patch**:
  ```bash
  node scripts/run-vitest.mjs src/infra/diagnostics-timeline.test.ts --run
  ```
- **Evidence after fix**:
  ```
  Test Files  1 passed (1)
       Tests  9 passed (9)
    Start at  11:43:10
    Duration  1.43s (transform 1.18s, setup 884ms, import 87ms, tests 226ms, environment 0ms)
  ```
- **Observed result after fix**: all 9 existing tests pass with no test-body changes. The temp-root setup runs once in `beforeAll` (`tracker.setup()`), each `createTimelineEnv()` call allocates `timeline-N` under the shared root, and `afterAll` removes the whole root via `tracker.cleanup()`. Same behavior, less surface.
- **What was not tested**: no new tests added — this is a behavior-preserving refactor. Did not run the full `pnpm test` or CI matrix; verification is scoped to the single test file plus pre-flight lint/tsgo below.

## Out of scope

- `src/infra/push-web.test.ts` also uses ad-hoc `fs.mkdtemp`, but its `vi.mock("../config/paths.js", () => ({ resolveStateDir: () => tmpDir }))` factory closes over the module-level `tmpDir` variable at import time, so wrapping it in a callback-style helper would silently leak the previous test's directory into the next. Migration would require restructuring the mock factory, which is out of scope for this narrow consolidation.
- `extensions/` test files (out of contributor scope).
- The five test-migration sibling PRs (#98893, #98965, #98987, #98993, #99074) already in the maintainer queue.

## Risk

- Low. Pure test-file change, zero production-code blast radius. `createSuiteTempRootTracker.setup()` runs once in `beforeAll` and `cleanup()` runs once in `afterAll`, so a forgotten `cleanup()` on test failure would leak only the single shared suite root (already handled by `cleanupSessionStateForTest`-style catch in the helper). All 9 existing tests pass with no assertion changes.