### PR TITLE
fix(agents): acquire compaction session lock re-entrantly to avoid self-deadlock

### DIFF
--- a/src/agents/embedded-agent-runner/compact.ts
+++ b/src/agents/embedded-agent-runner/compact.ts
@@ -1224,6 +1224,12 @@ async function compactEmbeddedAgentSessionDirectOnce(
           timeoutMs: compactionTimeoutMs,
         }),
       }),
+      // The overflow-recovery path already holds this session's write lock when
+      // it invokes compaction in-process. Acquire re-entrantly so the nested
+      // acquire does not self-deadlock until the acquire timeout elapses. The
+      // matching release below only decrements the count; the outer holder
+      // keeps the lock. See #97747.
+      allowReentrant: true,
     });
     try {
       await repairSessionFileIfNeeded({

--- a/src/agents/session-write-lock.test.ts
+++ b/src/agents/session-write-lock.test.ts
@@ -244,6 +244,37 @@ describe("acquireSessionWriteLock", () => {
     });
   });
 
+  it("re-enters an in-process-held session lock without self-deadlock when allowReentrant is set (#97747)", async () => {
+    await withTempSessionLockFile(async ({ sessionFile }) => {
+      // The overflow-recovery compaction path already holds the session write
+      // lock when it re-acquires it in-process. Without allowReentrant the
+      // nested acquire waits out the full timeout then throws (the self-deadlock
+      // in #97747). With allowReentrant it must resolve promptly, well inside a
+      // short timeout, and releasing the nested holder must leave the outer
+      // holder's lock in place.
+      const outer = await acquireSessionWriteLock({
+        sessionFile,
+        timeoutMs: 30_000,
+        allowReentrant: true,
+      });
+      const nested = await acquireSessionWriteLock({
+        sessionFile,
+        timeoutMs: 200,
+        allowReentrant: true,
+      });
+
+      // Releasing the nested holder only decrements the reentrant count; the
+      // outer holder still owns the lock, so a default re-acquire keeps failing
+      // fast instead of the lock being dropped prematurely.
+      await nested.release();
+      await expect(
+        acquireSessionWriteLock({ sessionFile, timeoutMs: 5, staleMs: 60_000 }),
+      ).rejects.toThrow(/session file locked/);
+
+      await outer.release();
+    });
+  });
+
   it("does not reenter locks by default through symlinked session paths", async () => {
     await withSymlinkedSessionPaths(async ({ sessionReal, sessionLink }) => {
       const lock = await acquireSessionWriteLock({ sessionFile: sessionReal, timeoutMs: 500 });


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where context-overflow recovery wedged a session. During overflow compaction the embedded run loop already held the session write lock, but `compactEmbeddedAgentSessionDirect` re-acquired the SAME session's lock without `allowReentrant`, so the nested acquire self-deadlocked for the full acquire timeout (~60s) and then threw `SessionWriteLockTimeoutError (pid=self)`. Each fallback model repeated the cycle, so every turn on that session failed with "session file locked" for several minutes until recovery.

## Why This Change Was Made

Pass `allowReentrant: true` to the compaction session-lock acquire, matching `src/plugin-sdk/file-lock.ts`, which already sets it for the same fs-safe lock manager. The manager handles reentrancy with a per-process count (`held.count`): the nested acquire bumps the count and the matching release in the existing `finally` only decrements it, so the outer holder keeps the lock until its own release. No lock-file or release-sequence changes.

## User Impact

Overflow-recovery compaction no longer self-deadlocks the session. Sessions that exceed the context window recover promptly instead of failing every turn with "session file locked" until the timeout watchdog eventually clears the stuck state.

## Evidence

- New regression test in `src/agents/session-write-lock.test.ts`: an in-process-held session lock is re-acquired with `allowReentrant: true` and a short 200ms timeout, asserting it resolves promptly (no self-deadlock wait); releasing the nested holder leaves the outer holder's lock in place (a default re-acquire still throws "session file locked"). The lock-level reentrant contract is also covered by the existing "keeps the lock file until the last release" and "does not reenter locks by default in the same process" tests.
- Release path is balanced: one acquire paired with one release in a `finally` that always runs, so the reentrant count is always decremented.
- `node scripts/test-projects.mjs src/agents/session-write-lock.test.ts`: the new test passes (50 passed). The 4 failures are pre-existing Windows `SessionWriteLockStaleError` flakes in payload-less-lock tests (lines 552–644); the lock module is unmodified by this change.

🤖 AI-assisted. Generated with [Claude Code](https://claude.com/claude-code).

Closes #97747