### PR TITLE
test: migrate doctor-session-snapshots and doctor-volatile-fs to shared temp-dir helpers

### DIFF
--- a/src/commands/doctor-session-snapshots.test.ts
+++ b/src/commands/doctor-session-snapshots.test.ts
@@ -1,12 +1,12 @@
 // Doctor session snapshot tests cover session snapshot validation and repair guidance.
 import fs from "node:fs/promises";
-import os from "node:os";
 import path from "node:path";
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { saveSessionStore } from "../config/sessions/store.js";
 import type { SessionEntry } from "../config/sessions/types.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import type { Skill } from "../skills/loading/skill-contract.js";
+import { createSuiteTempRootTracker } from "../test-helpers/temp-dir.js";
 
 const note = vi.hoisted(() => vi.fn());
 
@@ -87,19 +87,26 @@ function readMainSkillsSnapshot(raw: string): NonNullable<SessionEntry["skillsSn
 }
 
 describe("doctor session snapshot stale runtime metadata", () => {
+  const suiteTracker = createSuiteTempRootTracker({
+    prefix: "openclaw-doctor-session-snapshots-",
+  });
   let root = "";
   let bundledSkillsDir = "";
 
+  beforeAll(async () => {
+    await suiteTracker.setup();
+  });
+
+  afterAll(async () => {
+    await suiteTracker.cleanup();
+  });
+
   beforeEach(async () => {
     note.mockClear();
-    root = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-doctor-session-snapshots-"));
+    root = await suiteTracker.make("snapshot");
     bundledSkillsDir = path.join(root, "current", "skills");
     await fs.mkdir(path.join(bundledSkillsDir, "doctor"), { recursive: true });
     await fs.writeFile(path.join(bundledSkillsDir, "doctor", "SKILL.md"), "# Doctor\n");
-  });
-
-  afterEach(async () => {
-    await fs.rm(root, { recursive: true, force: true });
   });
 
   it("flags cached bundled skill locations from inactive and temp-backed runtime roots", () => {
@@ -485,19 +492,24 @@ describe("doctor session snapshot stale runtime metadata", () => {
 });
 
 describe("doctor session snapshot repair (shouldRepair)", () => {
+  const suiteTracker = createSuiteTempRootTracker({ prefix: "openclaw-doctor-repair-" });
   let root = "";
   let bundledSkillsDir = "";
 
+  beforeAll(async () => {
+    await suiteTracker.setup();
+  });
+
+  afterAll(async () => {
+    await suiteTracker.cleanup();
+  });
+
   beforeEach(async () => {
     note.mockClear();
-    root = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-doctor-repair-"));
+    root = await suiteTracker.make("snapshot");
     bundledSkillsDir = path.join(root, "current", "skills");
     await fs.mkdir(path.join(bundledSkillsDir, "doctor"), { recursive: true });
     await fs.writeFile(path.join(bundledSkillsDir, "doctor", "SKILL.md"), "# Doctor\n");
-  });
-
-  afterEach(async () => {
-    await fs.rm(root, { recursive: true, force: true });
   });
 
   it("repairs stale inline prompt paths", async () => {

--- a/src/commands/doctor-volatile-fs.test.ts
+++ b/src/commands/doctor-volatile-fs.test.ts
@@ -1,7 +1,7 @@
 import fs from "node:fs";
-import os from "node:os";
 import path from "node:path";
 import { describe, expect, it } from "vitest";
+import { withTempDirSync } from "../test-helpers/temp-dir.js";
 import {
   detectLinuxVolatileStateDir,
   formatLinuxVolatileStateDirWarning,
@@ -59,8 +59,7 @@ describe("detectLinuxVolatileStateDir", () => {
   });
 
   it("detects a missing state directory through an existing symlink", () => {
-    const root = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-doctor-volatile-"));
-    try {
+    withTempDirSync({ prefix: "openclaw-doctor-volatile-" }, (root) => {
       const volatileMount = path.join(root, "volatile");
       const stateLink = path.join(root, "state");
       fs.mkdirSync(volatileMount);
@@ -80,9 +79,7 @@ describe("detectLinuxVolatileStateDir", () => {
         mountPoint: resolvedVolatileMount,
         fsType: "tmpfs",
       });
-    } finally {
-      fs.rmSync(root, { recursive: true, force: true });
-    }
+    });
   });
 
   it.each([


### PR DESCRIPTION
## What Problem This Solves

Five sibling test-migration PRs (#98893, #98965, #98987, #98993, #99074) plus #99796 (just opened) already replaced ad-hoc `fs.mkdtemp` + manual cleanup with `createSuiteTempRootTracker` and `withTempDirSync` from `src/test-helpers/temp-dir.js`. This PR continues the same consolidation sweep into `src/commands/`:

- `doctor-session-snapshots.test.ts` has two `describe` blocks (`stale runtime metadata` and `shouldRepair`). Each block keeps a module-level `let root = ""; let bundledSkillsDir = "";` pair plus its own `beforeEach/afterEach` that does `fs.mkdtemp` + populate + `fs.rm` per test. That's two copies of the same ad-hoc setup.
- `doctor-volatile-fs.test.ts` has one site that does `fs.mkdtempSync` + try/finally with `fs.rmSync` inline inside an `it()` body.

Both files use the same isolated temp-root pattern as the already-shipped sibling PRs. After this PR, every shared-prefix temp dir in these two files flows through the same suite-level lifecycle (setup / make / cleanup) that `src/infra/update-runner.test.ts`, `src/infra/session-cost-usage.test.ts`, `src/infra/install-package-dir.test.ts`, `src/infra/node-pairing.test.ts`, `src/infra/provider-usage.auth.normalizes-keys.test.ts`, and `src/infra/device-pairing.test.ts` already use.

This consolidation keeps the `beforeAll/afterAll` lifecycle next to the production code, removes the chance of a forgotten `fs.rm(root, ...)` after a failed assertion, and lets new tests in these files opt in to one line (`tracker.make("snapshot")`) instead of re-deriving the temp-root setup.

## Changes

- `src/commands/doctor-session-snapshots.test.ts`: each of the two `describe` blocks now creates a `createSuiteTempRootTracker` with its own prefix (`openclaw-doctor-session-snapshots-` and `openclaw-doctor-repair-`). `setup()` runs in `beforeAll`, `cleanup()` runs in `afterAll`. `beforeEach` calls `tracker.make("snapshot")` instead of `fs.mkdtemp`. The two `afterEach` cleanup blocks are removed (suite-level cleanup is sufficient). Removed `os` import (no longer needed).
- `src/commands/doctor-volatile-fs.test.ts`: the one sync `fs.mkdtempSync` site is replaced with `withTempDirSync({ prefix: "openclaw-doctor-volatile-" }, (root) => { ... })`. The inline `try/finally` + `fs.rmSync` cleanup is removed (the helper handles it). Removed `os` import (no longer needed).

## Real behavior proof

- **Behavior addressed**: ad-hoc `fs.mkdtemp` / `fs.mkdtempSync` + per-test cleanup replaced with shared `createSuiteTempRootTracker` (session-snapshots) and `withTempDirSync` (volatile-fs). Test bodies are unchanged; assertions and behavior are identical.
- **Real environment tested**: local `pnpm vitest` on Linux Node 22.
- **Exact steps or command run after this patch**:
  ```bash
  node scripts/run-vitest.mjs src/commands/doctor-session-snapshots.test.ts --run
  node scripts/run-vitest.mjs src/commands/doctor-volatile-fs.test.ts --run
  ```
- **Evidence after fix**:
  ```
  doctor-session-snapshots: Test Files  1 passed (1) | Tests  19 passed (19) | Duration  4.63s
  doctor-volatile-fs:       Test Files  1 passed (1) | Tests   9 passed  (9) | Duration 32.43s
  ```
- **Observed result after fix**: 19 + 9 = 28 existing tests pass with no test-body changes. Suite-level `setup()` runs once per `describe` block, each `beforeEach` allocates a fresh `snapshot-N` subdir under the shared root, and `afterAll` removes the whole root via `tracker.cleanup()`. The volatile-fs sync test now wraps its body in `withTempDirSync`, which guarantees cleanup via the helper's `finally` block (with `maxRetries` for cross-platform robustness).
- **What was not tested**: no new tests added — this is a behavior-preserving refactor. Did not run the full `pnpm test` or CI matrix; verification is scoped to the two affected files plus pre-flight lint/tsgo below.

## Out of scope

- `src/infra/push-web.test.ts` was excluded from the consolidation sweep because its `vi.mock("../config/paths.js", () => ({ resolveStateDir: () => tmpDir }))` factory closes over the module-level `tmpDir` variable at import time; wrapping that in a callback-style helper would silently leak the previous test's directory into the next.
- `extensions/` test files (out of contributor scope).
- The six test-migration sibling PRs already in the maintainer queue (#98893, #98965, #98987, #98993, #99074, #99796).

## Risk

- Low. Pure test-file change, zero production-code blast radius. Each describe block uses its own `createSuiteTempRootTracker`, so a forgotten `cleanup()` on test failure would leak only that describe's single shared suite root. The volatile-fs sync test cleanup is centralized in `withTempDirSync`'s `finally` block. All 28 existing tests pass with no assertion changes.