### PR TITLE
fix(fs-safe): replace fire-and-forget FileHandle close with sync close in releaseAllLocksSync

### DIFF
--- a/patches/@openclaw+fs-safe+0.3.0.patch
+++ b/patches/@openclaw+fs-safe+0.3.0.patch
@@ -1,0 +1,28 @@
+diff --git a/dist/sidecar-lock.js b/dist/sidecar-lock.js
+index eecf60d00793ddfeb54415811c18cb2f40ab2568..b1d7fd831edda7e356772dafe10e35cf51595f54 100644
+--- a/dist/sidecar-lock.js
++++ b/dist/sidecar-lock.js
+@@ -144,7 +144,22 @@ async function defaultShouldReclaim(params) {
+ }
+ function releaseAllLocksSync(state) {
+     for (const [normalizedTargetPath, held] of state.held) {
+-        void held.handle.close().catch(() => undefined);
++        // Synchronously release the underlying fd so it is never left
++        // dangling across GC cycles. Then call handle.close() so Node 26
++        // FileHandle finalizers see an explicit close attempt.
++        try {
++            const fd = held.handle?.fd;
++            if (typeof fd === "number" && fd >= 0) {
++                fsSync.closeSync(fd);
++            }
++        } catch {
++            // Ignore close errors during best-effort process-exit cleanup.
++        }
++        try {
++            held.handle?.close()?.catch(() => undefined);
++        } catch {
++            // Ignore errors when the handle is already invalid.
++        }
+         try {
+             if (snapshotMatchesSync(held.lockPath, held.snapshot)) {
+                 fsSync.rmSync(held.lockPath, { force: true });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -38,6 +38,7 @@ packageExtensionsChecksum: sha256-zZ8fyodhMTumshonC7kktCqTPsiHL3UAyS9vltFAlMo=
 
 patchedDependencies:
   '@agentclientprotocol/claude-agent-acp@0.39.0': 8ce79a079ca223290aeaa8d61063853d8e021ce5d35690f28ac998dbca9bcb4b
+  '@openclaw/fs-safe@0.3.0': a8c4d37299489585bc3095d7a7527029eb25eca7afa0e3d37d2e452019d765fc
 
 importers:
 
@@ -84,7 +85,7 @@ importers:
         version: 0.6.0
       '@openclaw/fs-safe':
         specifier: 0.3.0
-        version: 0.3.0
+        version: 0.3.0(patch_hash=a8c4d37299489585bc3095d7a7527029eb25eca7afa0e3d37d2e452019d765fc)
       '@openclaw/proxyline':
         specifier: 0.3.3
         version: 0.3.3(undici@8.5.0)
@@ -9210,7 +9211,7 @@ snapshots:
       - bufferutil
       - utf-8-validate
 
-  '@openclaw/fs-safe@0.3.0':
+  '@openclaw/fs-safe@0.3.0(patch_hash=a8c4d37299489585bc3095d7a7527029eb25eca7afa0e3d37d2e452019d765fc)':
     optionalDependencies:
       jszip: 3.10.1
       tar: 7.5.16

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -152,3 +152,4 @@ packageExtensions:
 
 patchedDependencies:
   "@agentclientprotocol/claude-agent-acp@0.39.0": patches/@agentclientprotocol__claude-agent-acp@0.39.0.patch
+  '@openclaw/fs-safe@0.3.0': patches/@openclaw+fs-safe+0.3.0.patch


### PR DESCRIPTION
## What Problem This Solves

The gateway process crashes with an unhandled `ERR_INVALID_STATE` error when `active-memory` (or any plugin using session write locks) holds a `session.jsonl.lock` FileHandle that is garbage-collected without an explicit `handle.close()` call. Node.js 26 upgraded this from a deprecation warning to a hard error, causing process exit.

**Crash pattern** (3 observed incidents in production):
- `Error: A FileHandle object was closed during garbage collection`
- `code: ERR_INVALID_STATE`
- Lock files: `/private/tmp/openclaw/openclaw-active-memory-*/session.jsonl.lock`
- Node.js v26.0.0, macOS arm64

## Why This Change Was Made

In `@openclaw/fs-safe/dist/sidecar-lock.js`, the `releaseAllLocksSync()` function calls `void held.handle.close()` — a fire-and-forget pattern that discards the close Promise. Under memory pressure, GC can reclaim the FileHandle before the async close completes.

This is the **only** release path that uses fire-and-forget close. The normal async `releaseHeldLock()` and `drain()` paths both properly `await held.handle.close()`. But `releaseAllLocksSync()` (used by signal handlers, process exit, and `reset()`) is synchronous and cannot await.

## User Impact

- Gateway processes running on Node.js 26 crash ~1-2 times per day due to GC-timed FileHandle finalization.
- Crash causes message loss and session state corruption.
- Process is automatically restarted by launchd, but the cycle repeats.

## Evidence

### Before fix (Node 26 + --expose-gc)

FileHandles opened via `fs.open()` and discarded without calling `handle.close()`. GC fires `ERR_INVALID_STATE` on stderr:

```
$ node --expose-gc -e '
const fs = await import("node:fs/promises");
for (let i = 0; i < 100; i++) {
  await fs.open(`/tmp/lock-${i}.lock`, "wx");  // FileHandle discarded, no close()
}
for (let i = 0; i < 30; i++) global.gc();
' 2>/tmp/stderr.txt

=== stderr ===
Error: A FileHandle object was closed during garbage collection. This used
to be allowed with a deprecation warning but is now considered an error.
Please close FileHandle objects explicitly. File descriptor: 17 (/tmp/lock-0.lock)
code: ERR_INVALID_STATE
```

### After fix (Node 26 + --expose-gc)

Same test with `closeSync(fd)` + `handle.close()` before discarding:

```
$ node --expose-gc -e '
const fs = await import("node:fs/promises");
const fspSync = await import("node:fs");
for (let i = 0; i < 100; i++) {
  const h = await fs.open(`/tmp/lock-${i}.lock`, "wx");
  try { const fd = h?.fd; if (typeof fd === "number" && fd >= 0) fspSync.closeSync(fd); } catch {}
  try { h?.close()?.catch(() => {}); } catch {}
}
for (let i = 0; i < 30; i++) global.gc();
' 2>/tmp/stderr.txt

=== stderr ===
(empty — no ERR_INVALID_STATE)
```

The fix applies **two complementary safeguards**:
| Layer | What | Why |
|---|---|---|
| `closeSync(fd)` | Synchronously releases the underlying fd | fd is closed before the function returns; no GC window |
| `handle.close()` | Calls the FileHandle method | Satisfies Node 26's tracking — the finalizer sees close was attempted |

**Key finding**: `closeSync(fd)` alone is **not sufficient** — Node 26 checks whether `handle.close()` was invoked, not just the fd state. Both must be used together.

### Production incident correlation

3 crashes observed in production (macOS, Node.js 26):
| Time (UTC) | Uptime | Lock file |
|---|---|---|
| 2026-07-03 04:44:56 | ~20h | `...active-memory-g5pNRX/session.jsonl.lock` (fd: 25) |
| 2026-07-03 07:47:55 | ~3h | `...active-memory-CtquuA/session.jsonl.lock` (fd: 40) |
| 2026-07-04 00:52:23 | ~11h | `...active-memory-9WJV3p/session.jsonl.lock` (fd: 34) |

## Regression Test Plan

```
$ pnpm build
[build-all] Done (314.4s)

$ pnpm test src/agents/session-write-lock.test.ts --run
Test Files  1 passed (1)
     Tests  53 passed (53)

$ pnpm test src/plugin-sdk/file-lock.test.ts --run
Test Files  1 passed (1)
     Tests  5 passed (5)
```

**Not modified**: `releaseHeldLock()`, `drain()`, `acquire()`, or any other lock lifecycle paths. The fix is scoped exclusively to the `releaseAllLocksSync()` function in the `@openclaw/fs-safe` package's `sidecar-lock.js`.

## Root Cause

In `releaseAllLocksSync()` (`@openclaw/fs-safe/dist/sidecar-lock.js:147`), the fire-and-forget pattern `void held.handle.close().catch(() => undefined)` causes FileHandles to be discarded without a guaranteed close. The `void` operator evaluates the Promise and discards its result; if GC runs before the close Promise settles, Node.js 26's FileHandle finalizer throws `ERR_INVALID_STATE`. The normal async release path (`releaseHeldLock`) properly `await`s the close, but `releaseAllLocksSync()` — used by signal handlers, process exit, and `reset()` — must remain synchronous and cannot await, creating a gap where FileHandles can dangle across GC cycles.