### PR TITLE
fix(auth-profiles): scope subscription_limit blocks to the failing model

### DIFF
--- a/src/agents/agent-scope.test.ts
+++ b/src/agents/agent-scope.test.ts
@@ -26,7 +26,6 @@ import {
   resolveSubagentModelFallbacksOverride,
   resolveAgentWorkspaceDir,
   resolveAutoFallbackPrimaryProbe,
-  resolveAutoFallbackRepromotionTarget,
   resolveAgentIdByWorkspacePath,
   resolveAgentIdsByWorkspacePath,
   setAgentEffectiveModelPrimary,
@@ -1358,77 +1357,5 @@ describe("resolveAgentSkillsFilter", () => {
     };
 
     expect(resolveAgentSkillsFilter(cfg, "writer")).toStrictEqual([]);
-  });
-});
-
-describe("resolveAutoFallbackRepromotionTarget", () => {
-  const chain = [
-    { provider: "openai", model: "gpt-5.5" },
-    { provider: "claude-cli", model: "claude-sonnet-5" },
-    { provider: "openai", model: "gpt-5.3-codex-spark" },
-    { provider: "xai", model: "grok-4.3" },
-  ];
-
-  it("re-promotes past a rate-limited primary to the highest available tier", () => {
-    const cooled = new Set(["openai/gpt-5.5"]);
-    expect(
-      resolveAutoFallbackRepromotionTarget({
-        chain,
-        current: { provider: "openai", model: "gpt-5.3-codex-spark" },
-        isAvailable: (ref) => !cooled.has(`${ref.provider}/${ref.model}`),
-      }),
-    ).toStrictEqual({ provider: "claude-cli", model: "claude-sonnet-5" });
-  });
-
-  it("jumps straight back to the primary once it recovers", () => {
-    expect(
-      resolveAutoFallbackRepromotionTarget({
-        chain,
-        current: { provider: "openai", model: "gpt-5.3-codex-spark" },
-        isAvailable: () => true,
-      }),
-    ).toStrictEqual({ provider: "openai", model: "gpt-5.5" });
-  });
-
-  it("stays put when only lower tiers are available (no downward move, no thrash)", () => {
-    const cooled = new Set(["openai/gpt-5.5"]);
-    expect(
-      resolveAutoFallbackRepromotionTarget({
-        chain,
-        current: { provider: "claude-cli", model: "claude-sonnet-5" },
-        isAvailable: (ref) => !cooled.has(`${ref.provider}/${ref.model}`),
-      }),
-    ).toBeUndefined();
-  });
-
-  it("skips a rate-limited higher tier and picks the next available one above current", () => {
-    const cooled = new Set(["openai/gpt-5.5", "claude-cli/claude-sonnet-5"]);
-    expect(
-      resolveAutoFallbackRepromotionTarget({
-        chain,
-        current: { provider: "xai", model: "grok-4.3" },
-        isAvailable: (ref) => !cooled.has(`${ref.provider}/${ref.model}`),
-      }),
-    ).toStrictEqual({ provider: "openai", model: "gpt-5.3-codex-spark" });
-  });
-
-  it("returns undefined when already on the primary", () => {
-    expect(
-      resolveAutoFallbackRepromotionTarget({
-        chain,
-        current: { provider: "openai", model: "gpt-5.5" },
-        isAvailable: () => true,
-      }),
-    ).toBeUndefined();
-  });
-
-  it("trims surrounding whitespace on the current selection when matching the chain", () => {
-    expect(
-      resolveAutoFallbackRepromotionTarget({
-        chain,
-        current: { provider: " openai ", model: " gpt-5.3-codex-spark " },
-        isAvailable: (ref) => ref.model !== "gpt-5.5",
-      }),
-    ).toStrictEqual({ provider: "claude-cli", model: "claude-sonnet-5" });
   });
 });

--- a/src/agents/agent-scope.test.ts
+++ b/src/agents/agent-scope.test.ts
@@ -26,6 +26,7 @@ import {
   resolveSubagentModelFallbacksOverride,
   resolveAgentWorkspaceDir,
   resolveAutoFallbackPrimaryProbe,
+  resolveAutoFallbackRepromotionTarget,
   resolveAgentIdByWorkspacePath,
   resolveAgentIdsByWorkspacePath,
   setAgentEffectiveModelPrimary,
@@ -1357,5 +1358,77 @@ describe("resolveAgentSkillsFilter", () => {
     };
 
     expect(resolveAgentSkillsFilter(cfg, "writer")).toStrictEqual([]);
+  });
+});
+
+describe("resolveAutoFallbackRepromotionTarget", () => {
+  const chain = [
+    { provider: "openai", model: "gpt-5.5" },
+    { provider: "claude-cli", model: "claude-sonnet-5" },
+    { provider: "openai", model: "gpt-5.3-codex-spark" },
+    { provider: "xai", model: "grok-4.3" },
+  ];
+
+  it("re-promotes past a rate-limited primary to the highest available tier", () => {
+    const cooled = new Set(["openai/gpt-5.5"]);
+    expect(
+      resolveAutoFallbackRepromotionTarget({
+        chain,
+        current: { provider: "openai", model: "gpt-5.3-codex-spark" },
+        isAvailable: (ref) => !cooled.has(`${ref.provider}/${ref.model}`),
+      }),
+    ).toStrictEqual({ provider: "claude-cli", model: "claude-sonnet-5" });
+  });
+
+  it("jumps straight back to the primary once it recovers", () => {
+    expect(
+      resolveAutoFallbackRepromotionTarget({
+        chain,
+        current: { provider: "openai", model: "gpt-5.3-codex-spark" },
+        isAvailable: () => true,
+      }),
+    ).toStrictEqual({ provider: "openai", model: "gpt-5.5" });
+  });
+
+  it("stays put when only lower tiers are available (no downward move, no thrash)", () => {
+    const cooled = new Set(["openai/gpt-5.5"]);
+    expect(
+      resolveAutoFallbackRepromotionTarget({
+        chain,
+        current: { provider: "claude-cli", model: "claude-sonnet-5" },
+        isAvailable: (ref) => !cooled.has(`${ref.provider}/${ref.model}`),
+      }),
+    ).toBeUndefined();
+  });
+
+  it("skips a rate-limited higher tier and picks the next available one above current", () => {
+    const cooled = new Set(["openai/gpt-5.5", "claude-cli/claude-sonnet-5"]);
+    expect(
+      resolveAutoFallbackRepromotionTarget({
+        chain,
+        current: { provider: "xai", model: "grok-4.3" },
+        isAvailable: (ref) => !cooled.has(`${ref.provider}/${ref.model}`),
+      }),
+    ).toStrictEqual({ provider: "openai", model: "gpt-5.3-codex-spark" });
+  });
+
+  it("returns undefined when already on the primary", () => {
+    expect(
+      resolveAutoFallbackRepromotionTarget({
+        chain,
+        current: { provider: "openai", model: "gpt-5.5" },
+        isAvailable: () => true,
+      }),
+    ).toBeUndefined();
+  });
+
+  it("trims surrounding whitespace on the current selection when matching the chain", () => {
+    expect(
+      resolveAutoFallbackRepromotionTarget({
+        chain,
+        current: { provider: " openai ", model: " gpt-5.3-codex-spark " },
+        isAvailable: (ref) => ref.model !== "gpt-5.5",
+      }),
+    ).toStrictEqual({ provider: "claude-cli", model: "claude-sonnet-5" });
   });
 });

--- a/src/agents/agent-scope.ts
+++ b/src/agents/agent-scope.ts
@@ -295,6 +295,61 @@ export function clearAutoFallbackPrimaryProbeSelection(
   entry.updatedAt = now;
 }
 
+export type AutoFallbackModelRef = {
+  provider: string;
+  model: string;
+};
+
+/**
+ * Picks the highest-priority candidate ranked strictly above the current auto-fallback
+ * selection that is currently available (not in cooldown). Returns undefined when nothing
+ * better than the current selection is available, so the session stays put.
+ *
+ * Why this exists: making auth-profile cooldowns per-model removed the coarse side effect where
+ * a primary rate-limit also suspended sibling models sharing that profile (e.g. gpt-5.5 limiting
+ * also disabled gpt-5.3-codex-spark), which used to force the chain down to the next provider tier
+ * and looked like "fallback upwards" working. With per-model scoping a session that pins to a low
+ * tier never re-walks up on its own. This restores the climb explicitly: walk from the top of the
+ * ordered chain and return the first available tier above `current`. A session stuck on spark while
+ * gpt-5.5 is still rate-limited re-promotes to an available sonnet instead of sticking on spark, and
+ * jumps straight back to gpt-5.5 once its window clears. Returning undefined above the current tier
+ * is what prevents thrash: once landed on the best available tier, no strictly-better tier exists.
+ */
+export function resolveAutoFallbackRepromotionTarget(params: {
+  chain: readonly AutoFallbackModelRef[];
+  current: AutoFallbackModelRef;
+  isAvailable: (ref: AutoFallbackModelRef) => boolean;
+}): AutoFallbackModelRef | undefined {
+  const normRef = (ref: AutoFallbackModelRef) => ({
+    provider: normalizeOptionalString(ref.provider) ?? "",
+    model: normalizeOptionalString(ref.model) ?? "",
+  });
+  const current = normRef(params.current);
+  if (!current.provider || !current.model) {
+    return undefined;
+  }
+  const sameRef = (
+    a: { provider: string; model: string },
+    b: { provider: string; model: string },
+  ) => a.provider === b.provider && a.model === b.model;
+  const currentIndex = params.chain.findIndex((ref) => sameRef(normRef(ref), current));
+  // Current selection absent from the chain: treat the whole chain as ranked above it.
+  const ceiling = currentIndex === -1 ? params.chain.length : currentIndex;
+  for (let i = 0; i < ceiling; i += 1) {
+    const candidate = normRef(params.chain[i]!);
+    if (!candidate.provider || !candidate.model) {
+      continue;
+    }
+    if (sameRef(candidate, current)) {
+      continue;
+    }
+    if (params.isAvailable({ provider: candidate.provider, model: candidate.model })) {
+      return { provider: candidate.provider, model: candidate.model };
+    }
+  }
+  return undefined;
+}
+
 export { resolveAgentIdFromSessionKey };
 
 export function resolveSessionAgentIds(params: {

--- a/src/agents/agent-scope.ts
+++ b/src/agents/agent-scope.ts
@@ -295,61 +295,6 @@ export function clearAutoFallbackPrimaryProbeSelection(
   entry.updatedAt = now;
 }
 
-export type AutoFallbackModelRef = {
-  provider: string;
-  model: string;
-};
-
-/**
- * Picks the highest-priority candidate ranked strictly above the current auto-fallback
- * selection that is currently available (not in cooldown). Returns undefined when nothing
- * better than the current selection is available, so the session stays put.
- *
- * Why this exists: making auth-profile cooldowns per-model removed the coarse side effect where
- * a primary rate-limit also suspended sibling models sharing that profile (e.g. gpt-5.5 limiting
- * also disabled gpt-5.3-codex-spark), which used to force the chain down to the next provider tier
- * and looked like "fallback upwards" working. With per-model scoping a session that pins to a low
- * tier never re-walks up on its own. This restores the climb explicitly: walk from the top of the
- * ordered chain and return the first available tier above `current`. A session stuck on spark while
- * gpt-5.5 is still rate-limited re-promotes to an available sonnet instead of sticking on spark, and
- * jumps straight back to gpt-5.5 once its window clears. Returning undefined above the current tier
- * is what prevents thrash: once landed on the best available tier, no strictly-better tier exists.
- */
-export function resolveAutoFallbackRepromotionTarget(params: {
-  chain: readonly AutoFallbackModelRef[];
-  current: AutoFallbackModelRef;
-  isAvailable: (ref: AutoFallbackModelRef) => boolean;
-}): AutoFallbackModelRef | undefined {
-  const normRef = (ref: AutoFallbackModelRef) => ({
-    provider: normalizeOptionalString(ref.provider) ?? "",
-    model: normalizeOptionalString(ref.model) ?? "",
-  });
-  const current = normRef(params.current);
-  if (!current.provider || !current.model) {
-    return undefined;
-  }
-  const sameRef = (
-    a: { provider: string; model: string },
-    b: { provider: string; model: string },
-  ) => a.provider === b.provider && a.model === b.model;
-  const currentIndex = params.chain.findIndex((ref) => sameRef(normRef(ref), current));
-  // Current selection absent from the chain: treat the whole chain as ranked above it.
-  const ceiling = currentIndex === -1 ? params.chain.length : currentIndex;
-  for (let i = 0; i < ceiling; i += 1) {
-    const candidate = normRef(params.chain[i]!);
-    if (!candidate.provider || !candidate.model) {
-      continue;
-    }
-    if (sameRef(candidate, current)) {
-      continue;
-    }
-    if (params.isAvailable({ provider: candidate.provider, model: candidate.model })) {
-      return { provider: candidate.provider, model: candidate.model };
-    }
-  }
-  return undefined;
-}
-
 export { resolveAgentIdFromSessionKey };
 
 export function resolveSessionAgentIds(params: {

--- a/src/agents/auth-profiles/profiles.test.ts
+++ b/src/agents/auth-profiles/profiles.test.ts
@@ -726,4 +726,52 @@ describe("promoteAuthProfileInOrder", () => {
       expect(persisted?.[expiredProfileId]?.blockedModel).toBeUndefined();
     });
   });
+
+  it("clears a pre-existing unscoped block on success after upgrade (#99810)", async () => {
+    await withAuthProfileTestState("openclaw-auth-success-legacy-block-", async ({ agentDir }) => {
+      fs.mkdirSync(agentDir, { recursive: true });
+      const profileId = "openai:shared-oauth";
+      const now = Date.now();
+      // Block persisted before model-scoping: blockedModel is undefined.
+      saveAuthProfileStore(
+        {
+          version: AUTH_STORE_VERSION,
+          profiles: {
+            [profileId]: {
+              type: "oauth",
+              provider: "openai",
+              access: "shared-access",
+              refresh: "shared-refresh",
+              expires: now + 60 * 60 * 1000,
+            },
+          },
+          usageStats: {
+            [profileId]: {
+              blockedUntil: now + 60 * 60 * 1000,
+              blockedReason: "subscription_limit",
+              blockedSource: "wham",
+              errorCount: 3,
+            },
+          },
+        },
+        agentDir,
+      );
+
+      const runtimeStore = loadAuthProfileStoreForRuntime(agentDir);
+      await markAuthProfileSuccess({
+        store: runtimeStore,
+        provider: "openai",
+        profileId,
+        agentDir,
+        model: "gpt-5.5",
+      });
+
+      // An unscoped block is profile-wide, so a real success proves the profile
+      // works and must clear it rather than stranding the profile blocked.
+      const stats = loadAuthProfileStoreForRuntime(agentDir).usageStats?.[profileId];
+      expect(stats?.blockedUntil).toBeUndefined();
+      expect(stats?.blockedModel).toBeUndefined();
+      expect(stats?.errorCount).toBe(0);
+    });
+  });
 });

--- a/src/agents/auth-profiles/profiles.test.ts
+++ b/src/agents/auth-profiles/profiles.test.ts
@@ -15,6 +15,7 @@ import { AUTH_STORE_VERSION } from "./constants.js";
 import { loadPersistedAuthProfileStore } from "./persisted.js";
 import {
   clearLastGoodProfileWithLock,
+  markAuthProfileSuccess,
   promoteAuthProfileInOrder,
   upsertAuthProfileWithLock,
 } from "./profiles.js";
@@ -599,6 +600,130 @@ describe("promoteAuthProfileInOrder", () => {
       });
 
       expect(loadAuthProfileStoreForRuntime(agentDir).lastGood?.["openai"]).toBe(goodProfileId);
+    });
+  });
+
+  it("preserves a sibling model's active block when another model succeeds", async () => {
+    await withAuthProfileTestState("openclaw-auth-success-model-scope-", async ({ agentDir }) => {
+      fs.mkdirSync(agentDir, { recursive: true });
+      const profileId = "openai:shared-oauth";
+      const now = Date.now();
+      saveAuthProfileStore(
+        {
+          version: AUTH_STORE_VERSION,
+          profiles: {
+            [profileId]: {
+              type: "oauth",
+              provider: "openai",
+              access: "shared-access",
+              refresh: "shared-refresh",
+              expires: now + 60 * 60 * 1000,
+            },
+          },
+          usageStats: {
+            [profileId]: {
+              blockedUntil: now + 60 * 60 * 1000,
+              blockedReason: "subscription_limit",
+              blockedSource: "wham",
+              blockedModel: "gpt-5.5",
+              cooldownUntil: now + 60 * 60 * 1000,
+              cooldownReason: "rate_limit",
+              cooldownModel: "gpt-5.5",
+              errorCount: 3,
+              failureCounts: { rate_limit: 3 },
+            },
+          },
+        },
+        agentDir,
+      );
+
+      const runtimeStore = loadAuthProfileStoreForRuntime(agentDir);
+      await markAuthProfileSuccess({
+        store: runtimeStore,
+        provider: "openai",
+        profileId,
+        agentDir,
+        model: "gpt-5.3-codex-spark",
+      });
+
+      const stats = loadAuthProfileStoreForRuntime(agentDir).usageStats?.[profileId];
+      expect(stats?.blockedModel).toBe("gpt-5.5");
+      expect(stats?.blockedUntil).toBe(now + 60 * 60 * 1000);
+      expect(stats?.blockedReason).toBe("subscription_limit");
+      expect(stats?.cooldownModel).toBe("gpt-5.5");
+      expect(stats?.cooldownUntil).toBe(now + 60 * 60 * 1000);
+      expect(stats?.errorCount).toBe(0);
+    });
+  });
+
+  it("clears the same model's block and any expired sibling block on success", async () => {
+    await withAuthProfileTestState("openclaw-auth-success-model-clear-", async ({ agentDir }) => {
+      fs.mkdirSync(agentDir, { recursive: true });
+      const sameModelProfileId = "openai:same-model";
+      const expiredProfileId = "openai:expired-sibling";
+      const now = Date.now();
+      saveAuthProfileStore(
+        {
+          version: AUTH_STORE_VERSION,
+          profiles: {
+            [sameModelProfileId]: {
+              type: "oauth",
+              provider: "openai",
+              access: "same-access",
+              refresh: "same-refresh",
+              expires: now + 60 * 60 * 1000,
+            },
+            [expiredProfileId]: {
+              type: "oauth",
+              provider: "openai",
+              access: "expired-access",
+              refresh: "expired-refresh",
+              expires: now + 60 * 60 * 1000,
+            },
+          },
+          usageStats: {
+            [sameModelProfileId]: {
+              blockedUntil: now + 60 * 60 * 1000,
+              blockedReason: "subscription_limit",
+              blockedSource: "wham",
+              blockedModel: "gpt-5.5",
+              errorCount: 2,
+            },
+            [expiredProfileId]: {
+              blockedUntil: now - 60_000,
+              blockedReason: "subscription_limit",
+              blockedSource: "wham",
+              blockedModel: "gpt-5.5",
+              errorCount: 1,
+            },
+          },
+        },
+        agentDir,
+      );
+
+      const runtimeStore = loadAuthProfileStoreForRuntime(agentDir);
+      // Same model succeeds: its own block clears.
+      await markAuthProfileSuccess({
+        store: runtimeStore,
+        provider: "openai",
+        profileId: sameModelProfileId,
+        agentDir,
+        model: "gpt-5.5",
+      });
+      // A different model succeeds but the sibling block is already expired: clears.
+      await markAuthProfileSuccess({
+        store: runtimeStore,
+        provider: "openai",
+        profileId: expiredProfileId,
+        agentDir,
+        model: "gpt-5.3-codex-spark",
+      });
+
+      const persisted = loadAuthProfileStoreForRuntime(agentDir).usageStats;
+      expect(persisted?.[sameModelProfileId]?.blockedUntil).toBeUndefined();
+      expect(persisted?.[sameModelProfileId]?.blockedModel).toBeUndefined();
+      expect(persisted?.[expiredProfileId]?.blockedUntil).toBeUndefined();
+      expect(persisted?.[expiredProfileId]?.blockedModel).toBeUndefined();
     });
   });
 });

--- a/src/agents/auth-profiles/profiles.ts
+++ b/src/agents/auth-profiles/profiles.ts
@@ -40,23 +40,40 @@ function findProviderAuthStateKey(
 
 // Successful auth clears transient failure/cooldown/disable state while keeping
 // unrelated metadata and updating lastUsed for round-robin ordering.
+// A success on one model must not clear a sibling model's still-active
+// block/cooldown on the same shared-OAuth profile: models on one login can hold
+// independent per-model quota windows (e.g. gpt-5.5 weekly-capped while Spark is
+// healthy), so a Spark success must preserve gpt-5.5's active subscription block
+// instead of un-blocking it and letting it be re-called every turn.
 function resetSuccessfulUsageStats(
   existing: ProfileUsageStats | undefined,
   lastUsed: number,
+  model?: string,
 ): ProfileUsageStats {
+  const now = Date.now();
+  const keepBlock =
+    model !== undefined &&
+    existing?.blockedModel !== undefined &&
+    existing.blockedModel !== model &&
+    (existing.blockedUntil ?? 0) > now;
+  const keepCooldown =
+    model !== undefined &&
+    existing?.cooldownModel !== undefined &&
+    existing.cooldownModel !== model &&
+    (existing.cooldownUntil ?? 0) > now;
   return {
     ...existing,
     errorCount: 0,
-    blockedUntil: undefined,
-    blockedReason: undefined,
-    blockedSource: undefined,
-    blockedModel: undefined,
-    cooldownUntil: undefined,
-    cooldownReason: undefined,
-    cooldownModel: undefined,
+    blockedUntil: keepBlock ? existing?.blockedUntil : undefined,
+    blockedReason: keepBlock ? existing?.blockedReason : undefined,
+    blockedSource: keepBlock ? existing?.blockedSource : undefined,
+    blockedModel: keepBlock ? existing?.blockedModel : undefined,
+    cooldownUntil: keepCooldown ? existing?.cooldownUntil : undefined,
+    cooldownReason: keepCooldown ? existing?.cooldownReason : undefined,
+    cooldownModel: keepCooldown ? existing?.cooldownModel : undefined,
     disabledUntil: undefined,
     disabledReason: undefined,
-    failureCounts: undefined,
+    failureCounts: keepBlock || keepCooldown ? existing?.failureCounts : undefined,
     lastUsed,
   };
 }
@@ -65,9 +82,14 @@ function updateSuccessfulUsageStatsEntry(
   store: AuthProfileStore,
   profileId: string,
   lastUsed: number,
+  model?: string,
 ): void {
   store.usageStats = store.usageStats ?? {};
-  store.usageStats[profileId] = resetSuccessfulUsageStats(store.usageStats[profileId], lastUsed);
+  store.usageStats[profileId] = resetSuccessfulUsageStats(
+    store.usageStats[profileId],
+    lastUsed,
+    model,
+  );
 }
 
 /** Sets or clears explicit auth profile order for a provider. */
@@ -265,8 +287,9 @@ export async function markAuthProfileSuccess(params: {
   provider: string;
   profileId: string;
   agentDir?: string;
+  model?: string;
 }): Promise<void> {
-  const { store, provider, profileId, agentDir } = params;
+  const { store, provider, profileId, agentDir, model } = params;
   const providerKey = resolveProviderIdForAuth(provider);
   const lastUsed = Date.now();
   const updated = await updateAuthProfileStoreWithLock({
@@ -277,7 +300,7 @@ export async function markAuthProfileSuccess(params: {
         return false;
       }
       freshStore.lastGood = { ...freshStore.lastGood, [providerKey]: profileId };
-      updateSuccessfulUsageStatsEntry(freshStore, profileId, lastUsed);
+      updateSuccessfulUsageStatsEntry(freshStore, profileId, lastUsed, model);
       return true;
     },
   });
@@ -291,6 +314,6 @@ export async function markAuthProfileSuccess(params: {
     return;
   }
   store.lastGood = { ...store.lastGood, [providerKey]: profileId };
-  updateSuccessfulUsageStatsEntry(store, profileId, lastUsed);
+  updateSuccessfulUsageStatsEntry(store, profileId, lastUsed, model);
   saveAuthProfileStore(store, agentDir);
 }

--- a/src/agents/auth-profiles/session-override.test.ts
+++ b/src/agents/auth-profiles/session-override.test.ts
@@ -199,6 +199,63 @@ describe("resolveSessionAuthProfileOverride", () => {
     });
   });
 
+  it("threads the requested model into cooldown checks so a model-scoped cooldown does not evict an otherwise-usable profile", async () => {
+    await withAuthState(async (state) => {
+      const agentDir = state.agentDir();
+      await fs.mkdir(agentDir, { recursive: true });
+      authStoreMocks.state.hasSource = true;
+      authStoreMocks.state.store = createAuthStoreWithProfiles({
+        profiles: {
+          [TEST_PRIMARY_PROFILE_ID]: {
+            type: "api_key",
+            provider: "openai",
+            key: "sk-primary",
+          },
+          [TEST_SECONDARY_PROFILE_ID]: {
+            type: "api_key",
+            provider: "openai",
+            key: "sk-secondary",
+          },
+        },
+        order: {
+          openai: [TEST_PRIMARY_PROFILE_ID, TEST_SECONDARY_PROFILE_ID],
+        },
+      });
+      // Only report cooldown for the primary profile when the caller asks
+      // about "gpt-other" - a different model than the one being requested.
+      authStoreMocks.isProfileInCooldown.mockImplementation(
+        (_store: AuthProfileStore, profileId: string, _now?: number, forModel?: string) =>
+          profileId === TEST_PRIMARY_PROFILE_ID && forModel === "gpt-other",
+      );
+
+      const sessionEntry: SessionEntry = {
+        sessionId: "s1",
+        updatedAt: Date.now(),
+      };
+      const sessionStore = { "agent:main:main": sessionEntry };
+
+      const resolved = await resolveSessionAuthProfileOverride({
+        cfg: {} as OpenClawConfig,
+        provider: "openai",
+        agentDir,
+        sessionEntry,
+        sessionStore,
+        sessionKey: "agent:main:main",
+        storePath: undefined,
+        isNewSession: true,
+        model: "gpt-mine",
+      });
+
+      expect(resolved).toBe(TEST_PRIMARY_PROFILE_ID);
+      expect(authStoreMocks.isProfileInCooldown).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.any(String),
+        undefined,
+        "gpt-mine",
+      );
+    });
+  });
+
   it("keeps user override when provider alias differs", async () => {
     await withAuthState(async (state) => {
       const agentDir = state.agentDir();
@@ -690,38 +747,43 @@ describe("resolveSessionAuthProfileOverride", () => {
           openai: [TEST_PRIMARY_PROFILE_ID, TEST_SECONDARY_PROFILE_ID],
         },
       });
-      // Only report cooldown for the primary profile when the caller asks
-      // about "gpt-other" - a different model than the one being requested.
-      authStoreMocks.isProfileInCooldown.mockImplementation(
-        (_store: AuthProfileStore, profileId: string, _now?: number, forModel?: string) =>
-          profileId === TEST_PRIMARY_PROFILE_ID && forModel === "gpt-other",
-      );
 
-      const sessionEntry: SessionEntry = {
+      const sessionKey = "agent:main:main";
+      const storePath = path.join(state.sessionsDir(), "sessions.json");
+      const scope = { storePath, sessionKey };
+      await replaceSessionEntry(scope, {
         sessionId: "s1",
-        updatedAt: Date.now(),
-      };
-      const sessionStore = { "agent:main:main": sessionEntry };
+        updatedAt: 1,
+        label: "before",
+        pinnedAt: 1,
+        compactionCount: 1,
+        authProfileOverride: TEST_PRIMARY_PROFILE_ID,
+        authProfileOverrideSource: "auto",
+        authProfileOverrideCompactionCount: 0,
+      });
+      const sessionEntry = loadSessionEntry({ ...scope, readConsistency: "latest" });
+      expect(sessionEntry).toBeDefined();
+      const sessionStore = { [sessionKey]: sessionEntry! };
 
+      await patchSessionEntry(scope, () => ({ label: "renamed", pinnedAt: undefined }));
       const resolved = await resolveSessionAuthProfileOverride({
         cfg: {} as OpenClawConfig,
         provider: "openai",
         agentDir,
-        sessionEntry,
+        sessionEntry: sessionEntry!,
         sessionStore,
-        sessionKey: "agent:main:main",
-        storePath: undefined,
-        isNewSession: true,
-        model: "gpt-mine",
+        sessionKey,
+        storePath,
+        isNewSession: false,
       });
 
-      expect(resolved).toBe(TEST_PRIMARY_PROFILE_ID);
-      expect(authStoreMocks.isProfileInCooldown).toHaveBeenCalledWith(
-        expect.anything(),
-        expect.any(String),
-        undefined,
-        "gpt-mine",
-      );
+      expect(resolved).toBe(TEST_SECONDARY_PROFILE_ID);
+      const persisted = loadSessionEntry({ ...scope, readConsistency: "latest" });
+      expect(persisted?.label).toBe("renamed");
+      expect(persisted?.pinnedAt).toBeUndefined();
+      expect(persisted?.authProfileOverride).toBe(TEST_SECONDARY_PROFILE_ID);
+      expect(sessionStore[sessionKey]?.label).toBe("renamed");
+      expect(sessionStore[sessionKey]?.pinnedAt).toBeUndefined();
     });
   });
 });

--- a/src/agents/auth-profiles/session-override.test.ts
+++ b/src/agents/auth-profiles/session-override.test.ts
@@ -667,4 +667,61 @@ describe("resolveSessionAuthProfileOverride", () => {
       expect(sessionStore[sessionKey]?.pinnedAt).toBeUndefined();
     });
   });
+
+  it("threads the requested model into cooldown checks so a model-scoped cooldown does not evict an otherwise-usable profile", async () => {
+    await withAuthState(async (state) => {
+      const agentDir = state.agentDir();
+      await fs.mkdir(agentDir, { recursive: true });
+      authStoreMocks.state.hasSource = true;
+      authStoreMocks.state.store = createAuthStoreWithProfiles({
+        profiles: {
+          [TEST_PRIMARY_PROFILE_ID]: {
+            type: "api_key",
+            provider: "openai",
+            key: "sk-primary",
+          },
+          [TEST_SECONDARY_PROFILE_ID]: {
+            type: "api_key",
+            provider: "openai",
+            key: "sk-secondary",
+          },
+        },
+        order: {
+          openai: [TEST_PRIMARY_PROFILE_ID, TEST_SECONDARY_PROFILE_ID],
+        },
+      });
+      // Only report cooldown for the primary profile when the caller asks
+      // about "gpt-other" - a different model than the one being requested.
+      authStoreMocks.isProfileInCooldown.mockImplementation(
+        (_store: AuthProfileStore, profileId: string, _now?: number, forModel?: string) =>
+          profileId === TEST_PRIMARY_PROFILE_ID && forModel === "gpt-other",
+      );
+
+      const sessionEntry: SessionEntry = {
+        sessionId: "s1",
+        updatedAt: Date.now(),
+      };
+      const sessionStore = { "agent:main:main": sessionEntry };
+
+      const resolved = await resolveSessionAuthProfileOverride({
+        cfg: {} as OpenClawConfig,
+        provider: "openai",
+        agentDir,
+        sessionEntry,
+        sessionStore,
+        sessionKey: "agent:main:main",
+        storePath: undefined,
+        isNewSession: true,
+        model: "gpt-mine",
+      });
+
+      expect(resolved).toBe(TEST_PRIMARY_PROFILE_ID);
+      expect(authStoreMocks.isProfileInCooldown).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.any(String),
+        undefined,
+        "gpt-mine",
+      );
+    });
+  });
 });

--- a/src/agents/auth-profiles/session-override.ts
+++ b/src/agents/auth-profiles/session-override.ts
@@ -157,6 +157,7 @@ export async function resolveSessionAuthProfileOverride(params: {
   storePath?: string;
   isNewSession: boolean;
   acceptedProviderIds?: string[];
+  model?: string;
 }): Promise<string | undefined> {
   const {
     cfg,
@@ -167,6 +168,7 @@ export async function resolveSessionAuthProfileOverride(params: {
     sessionKey,
     storePath,
     isNewSession,
+    model,
   } = params;
   if (!sessionEntry || !sessionStore || !sessionKey) {
     return sessionEntry?.authProfileOverride;
@@ -233,7 +235,7 @@ export async function resolveSessionAuthProfileOverride(params: {
   }
 
   const pickFirstAvailable = () =>
-    order.find((profileId) => !isProfileInCooldown(store, profileId)) ?? order[0];
+    order.find((profileId) => !isProfileInCooldown(store, profileId, undefined, model)) ?? order[0];
   const pickNextAvailable = (active: string) => {
     const startIndex = order.indexOf(active);
     if (startIndex < 0) {
@@ -241,7 +243,7 @@ export async function resolveSessionAuthProfileOverride(params: {
     }
     for (let offset = 1; offset <= order.length; offset += 1) {
       const candidate = order[(startIndex + offset) % order.length];
-      if (!isProfileInCooldown(store, candidate)) {
+      if (!isProfileInCooldown(store, candidate, undefined, model)) {
         return candidate;
       }
     }
@@ -254,8 +256,11 @@ export async function resolveSessionAuthProfileOverride(params: {
       ? sessionEntry.authProfileOverrideCompactionCount
       : compactionCount;
   const replacementForUnusableCurrent =
-    current && isProfileInCooldown(store, current)
-      ? order.find((profileId) => profileId !== current && !isProfileInCooldown(store, profileId))
+    current && isProfileInCooldown(store, current, undefined, model)
+      ? order.find(
+          (profileId) =>
+            profileId !== current && !isProfileInCooldown(store, profileId, undefined, model),
+        )
       : undefined;
   // User-pinned profiles persist unless unusable/mismatched. Auto-selected
   // profiles rotate on new sessions or compaction boundaries.
@@ -273,7 +278,7 @@ export async function resolveSessionAuthProfileOverride(params: {
     next = current ? pickNextAvailable(current) : pickFirstAvailable();
   } else if (current && compactionCount > storedCompaction) {
     next = pickNextAvailable(current);
-  } else if (!current || isProfileInCooldown(store, current)) {
+  } else if (!current || isProfileInCooldown(store, current, undefined, model)) {
     next = pickFirstAvailable();
   }
 

--- a/src/agents/auth-profiles/usage-state.ts
+++ b/src/agents/auth-profiles/usage-state.ts
@@ -23,7 +23,10 @@ export function isModelScopedCooldownReason(reason: AuthProfileFailureReason | u
 
 /** Resolves the latest active blocked/cooldown/disabled timestamp for a profile. */
 export function resolveProfileUnusableUntil(
-  stats: Pick<ProfileUsageStats, "blockedUntil" | "cooldownUntil" | "disabledUntil" | "blockedModel">,
+  stats: Pick<
+    ProfileUsageStats,
+    "blockedUntil" | "cooldownUntil" | "disabledUntil" | "blockedModel"
+  >,
   forModel?: string,
 ): number | null {
   // Model-aware bypass: a subscription_limit block recorded against a specific

--- a/src/agents/auth-profiles/usage-state.ts
+++ b/src/agents/auth-profiles/usage-state.ts
@@ -23,9 +23,18 @@ export function isModelScopedCooldownReason(reason: AuthProfileFailureReason | u
 
 /** Resolves the latest active blocked/cooldown/disabled timestamp for a profile. */
 export function resolveProfileUnusableUntil(
-  stats: Pick<ProfileUsageStats, "blockedUntil" | "cooldownUntil" | "disabledUntil">,
+  stats: Pick<ProfileUsageStats, "blockedUntil" | "cooldownUntil" | "disabledUntil" | "blockedModel">,
+  forModel?: string,
 ): number | null {
-  const values = [stats.blockedUntil, stats.cooldownUntil, stats.disabledUntil]
+  // Model-aware bypass: a subscription_limit block recorded against a specific
+  // model (blockedModel) must not block a *different* model on the same
+  // profile, mirroring the existing cooldownModel scoping for rate_limit/timeout.
+  const blockedAppliesToModel = !forModel || !stats.blockedModel || stats.blockedModel === forModel;
+  const values = [
+    blockedAppliesToModel ? stats.blockedUntil : undefined,
+    stats.cooldownUntil,
+    stats.disabledUntil,
+  ]
     .map((value) => asDateTimestampMs(value))
     .filter((value): value is number => value !== undefined && value > 0);
   if (values.length === 0) {
@@ -43,17 +52,18 @@ export function isActiveUnusableWindow(until: number | undefined, now: number): 
 function shouldBypassModelScopedCooldown(
   stats: Pick<
     ProfileUsageStats,
-    "blockedUntil" | "cooldownReason" | "cooldownModel" | "disabledUntil"
+    "blockedUntil" | "blockedModel" | "cooldownReason" | "cooldownModel" | "disabledUntil"
   >,
   now: number,
   forModel?: string,
 ): boolean {
+  const blockedAppliesToModel = !forModel || !stats.blockedModel || stats.blockedModel === forModel;
   return Boolean(
     forModel &&
     isModelScopedCooldownReason(stats.cooldownReason) &&
     stats.cooldownModel &&
     stats.cooldownModel !== forModel &&
-    !isActiveUnusableWindow(stats.blockedUntil, now) &&
+    !(blockedAppliesToModel && isActiveUnusableWindow(stats.blockedUntil, now)) &&
     !isActiveUnusableWindow(stats.disabledUntil, now),
   );
 }
@@ -82,7 +92,7 @@ export function isProfileInCooldown(
   if (shouldBypassModelScopedCooldown(stats, ts, forModel)) {
     return false;
   }
-  const unusableUntil = resolveProfileUnusableUntil(stats);
+  const unusableUntil = resolveProfileUnusableUntil(stats, forModel);
   return unusableUntil ? ts < unusableUntil : false;
 }
 
@@ -107,15 +117,17 @@ export function getSoonestCooldownExpiry(
     if (shouldBypassModelScopedCooldown(stats, ts, options?.forModel)) {
       continue;
     }
-    const until = resolveProfileUnusableUntil(stats);
+    const until = resolveProfileUnusableUntil(stats, options?.forModel);
     if (typeof until !== "number" || !Number.isFinite(until) || until <= 0) {
       continue;
     }
+    const blockedAppliesToModel =
+      !options?.forModel || !stats.blockedModel || stats.blockedModel === options.forModel;
     const matchingModelScopedCooldown =
       options?.forModel &&
       stats.cooldownReason === "rate_limit" &&
       stats.cooldownModel === options.forModel &&
-      !isActiveUnusableWindow(stats.blockedUntil, ts) &&
+      !(blockedAppliesToModel && isActiveUnusableWindow(stats.blockedUntil, ts)) &&
       !isActiveUnusableWindow(stats.disabledUntil, ts);
     if (matchingModelScopedCooldown) {
       latestMatchingModelCooldown =

--- a/src/agents/auth-profiles/usage.test.ts
+++ b/src/agents/auth-profiles/usage.test.ts
@@ -950,6 +950,133 @@ describe("markAuthProfileBlockedUntil", () => {
     expect(store.usageStats).toEqual({});
     expect(storeMocks.saveAuthProfileStore).not.toHaveBeenCalled();
   });
+
+  it("scopes a subscription_limit block to the failing model so other models on the same profile stay usable", async () => {
+    const now = 1_700_000_000_000;
+    const nowSpy = vi.spyOn(Date, "now").mockReturnValue(now);
+    const store = makeStore({});
+    try {
+      await markAuthProfileBlockedUntil({
+        store,
+        profileId: "openai:default",
+        blockedUntil: now + 60 * 60 * 1000,
+        source: "codex_rate_limits",
+        modelId: "gpt-5.5",
+      });
+    } finally {
+      nowSpy.mockRestore();
+    }
+
+    const stats = store.usageStats?.["openai:default"];
+    expect(stats?.blockedModel).toBe("gpt-5.5");
+    expect(isProfileInCooldown(store, "openai:default", now, "gpt-5.5")).toBe(true);
+    expect(isProfileInCooldown(store, "openai:default", now, "gpt-5.3-codex-spark")).toBe(false);
+  });
+
+  it("widens to profile-wide when a new model-scoped block lands on top of an already-active unscoped block", async () => {
+    const now = 1_700_000_000_000;
+    const existingBlockedUntil = now + 3 * 60 * 60 * 1000;
+    // blockedModel is undefined here to simulate a profile-wide block recorded
+    // before per-model scoping existed (or a non-WHAM profile-wide block).
+    const store = makeStore({
+      "openai:default": {
+        blockedUntil: existingBlockedUntil,
+        blockedReason: "subscription_limit",
+        blockedSource: "codex_rate_limits",
+        errorCount: 1,
+        lastFailureAt: now - 1_000,
+      },
+    });
+    const nowSpy = vi.spyOn(Date, "now").mockReturnValue(now);
+    try {
+      await markAuthProfileBlockedUntil({
+        store,
+        profileId: "openai:default",
+        blockedUntil: existingBlockedUntil,
+        source: "codex_rate_limits",
+        modelId: "gpt-5.5",
+      });
+    } finally {
+      nowSpy.mockRestore();
+    }
+
+    const stats = store.usageStats?.["openai:default"];
+    // The pre-existing unscoped block must not be silently narrowed to just
+    // the incoming model — that would incorrectly unblock whatever the
+    // original unscoped block was protecting.
+    expect(stats?.blockedModel).toBeUndefined();
+    expect(isProfileInCooldown(store, "openai:default", now, "gpt-5.5")).toBe(true);
+    expect(isProfileInCooldown(store, "openai:default", now, "gpt-5.3-codex-spark")).toBe(true);
+    expect(isProfileInCooldown(store, "openai:default", now)).toBe(true);
+  });
+
+  it("widens to profile-wide when a new block for a different model conflicts with an existing model-scoped block", async () => {
+    const now = 1_700_000_000_000;
+    const existingBlockedUntil = now + 3 * 60 * 60 * 1000;
+    const store = makeStore({
+      "openai:default": {
+        blockedUntil: existingBlockedUntil,
+        blockedModel: "gpt-5.5",
+        blockedReason: "subscription_limit",
+        blockedSource: "codex_rate_limits",
+        errorCount: 1,
+        lastFailureAt: now - 1_000,
+      },
+    });
+    const nowSpy = vi.spyOn(Date, "now").mockReturnValue(now);
+    try {
+      await markAuthProfileBlockedUntil({
+        store,
+        profileId: "openai:default",
+        blockedUntil: existingBlockedUntil,
+        source: "codex_rate_limits",
+        modelId: "gpt-5.3-codex-spark",
+      });
+    } finally {
+      nowSpy.mockRestore();
+    }
+
+    const stats = store.usageStats?.["openai:default"];
+    // Two different models are each independently blocked on this profile now
+    // (gpt-5.5 from the earlier failure, gpt-5.3-codex-spark from this one).
+    // Narrowing blockedModel to either one alone would silently drop coverage
+    // for the other, so the merged block must widen to profile-wide.
+    expect(stats?.blockedModel).toBeUndefined();
+    expect(isProfileInCooldown(store, "openai:default", now, "gpt-5.5")).toBe(true);
+    expect(isProfileInCooldown(store, "openai:default", now, "gpt-5.3-codex-spark")).toBe(true);
+    expect(isProfileInCooldown(store, "openai:default", now)).toBe(true);
+  });
+
+  it("keeps a repeated block for the same model scoped to just that model", async () => {
+    const now = 1_700_000_000_000;
+    const existingBlockedUntil = now + 3 * 60 * 60 * 1000;
+    const store = makeStore({
+      "openai:default": {
+        blockedUntil: existingBlockedUntil,
+        blockedModel: "gpt-5.5",
+        blockedReason: "subscription_limit",
+        blockedSource: "codex_rate_limits",
+        errorCount: 1,
+        lastFailureAt: now - 1_000,
+      },
+    });
+    const nowSpy = vi.spyOn(Date, "now").mockReturnValue(now);
+    try {
+      await markAuthProfileBlockedUntil({
+        store,
+        profileId: "openai:default",
+        blockedUntil: existingBlockedUntil,
+        source: "codex_rate_limits",
+        modelId: "gpt-5.5",
+      });
+    } finally {
+      nowSpy.mockRestore();
+    }
+
+    const stats = store.usageStats?.["openai:default"];
+    expect(stats?.blockedModel).toBe("gpt-5.5");
+    expect(isProfileInCooldown(store, "openai:default", now, "gpt-5.3-codex-spark")).toBe(false);
+  });
 });
 
 describe("markAuthProfileFailure — detail-less provider failures", () => {

--- a/src/agents/auth-profiles/usage.test.ts
+++ b/src/agents/auth-profiles/usage.test.ts
@@ -1363,6 +1363,41 @@ describe("markAuthProfileFailure — WHAM-aware Codex cooldowns", () => {
     expect(isProfileInCooldown(store, "openai:default", now)).toBe(true);
   });
 
+  it("reads the codex model's own additional_rate_limits bucket instead of the exhausted default GPT bucket", async () => {
+    const now = 1_700_000_000_000;
+    const store = makeStore({});
+    // Default GPT bucket is fully exhausted, but the Codex Spark lane has its
+    // own healthy server-side bucket under additional_rate_limits[].
+    mockWhamResponse(200, {
+      rate_limit: {
+        limit_reached: true,
+        primary_window: { used_percent: 100, reset_after_seconds: 7_200 },
+        secondary_window: { used_percent: 100, reset_after_seconds: 28_800 },
+      },
+      additional_rate_limits: [
+        {
+          limit_name: "GPT-5.3-Codex-Spark",
+          rate_limit: {
+            limit_reached: false,
+            primary_window: { used_percent: 5, reset_after_seconds: 9_000 },
+            secondary_window: { used_percent: 16, reset_after_seconds: 201_600 },
+          },
+        },
+      ],
+    });
+
+    await markCodexFailureAt({ store, now, modelId: "gpt-5.3-codex-spark" });
+
+    const stats = store.usageStats?.["openai:default"];
+    // Spark's own bucket is healthy, so no subscription_limit block is written;
+    // it degrades to a short burst cooldown rather than being blocked off the
+    // sibling GPT window.
+    expect(stats?.blockedReason).not.toBe("subscription_limit");
+    expect(stats?.blockedUntil).toBeUndefined();
+    expect(stats?.cooldownUntil).toBe(now + 15_000);
+    expect(isProfileInCooldown(store, "openai:default", now, "gpt-5.3-codex-spark")).toBe(false);
+  });
+
   it("widens to profile-wide when a new model-scoped block lands on top of an already-active unscoped block", async () => {
     const now = 1_700_000_000_000;
     const existingBlockedUntil = now + 3 * 60 * 60 * 1000;

--- a/src/agents/auth-profiles/usage.test.ts
+++ b/src/agents/auth-profiles/usage.test.ts
@@ -1395,7 +1395,11 @@ describe("markAuthProfileFailure — WHAM-aware Codex cooldowns", () => {
     expect(stats?.blockedReason).not.toBe("subscription_limit");
     expect(stats?.blockedUntil).toBeUndefined();
     expect(stats?.cooldownUntil).toBe(now + 15_000);
-    expect(isProfileInCooldown(store, "openai:default", now, "gpt-5.3-codex-spark")).toBe(false);
+    // The short burst window clears on its own, unlike the multi-hour
+    // subscription_limit block Spark would inherit off the sibling GPT bucket.
+    expect(isProfileInCooldown(store, "openai:default", now + 15_000, "gpt-5.3-codex-spark")).toBe(
+      false,
+    );
   });
 
   it("widens to profile-wide when a new model-scoped block lands on top of an already-active unscoped block", async () => {

--- a/src/agents/auth-profiles/usage.test.ts
+++ b/src/agents/auth-profiles/usage.test.ts
@@ -282,6 +282,24 @@ describe("isProfileInCooldown", () => {
     });
     expect(isProfileInCooldown(store, "google:default", now, "gemini-3.1-flash-lite")).toBe(true);
   });
+
+  it("keeps a pre-existing unscoped block profile-wide after upgrade (#99810)", () => {
+    // Upgrade compat: blocks persisted before model-scoping carry
+    // blockedModel: undefined. The new model-aware read must still treat them
+    // as profile-wide so an old subscription_limit block is not silently
+    // bypassed for a sibling model after upgrade.
+    const now = Date.now();
+    const store = makeStore({
+      "openai:default": {
+        blockedUntil: now + 120_000,
+        blockedReason: "subscription_limit",
+        blockedSource: "wham",
+      },
+    });
+    expect(isProfileInCooldown(store, "openai:default", now, "gpt-5.5")).toBe(true);
+    expect(isProfileInCooldown(store, "openai:default", now, "gpt-5.3-codex-spark")).toBe(true);
+    expect(isProfileInCooldown(store, "openai:default", now)).toBe(true);
+  });
 });
 
 describe("resolveProfilesUnavailableReason", () => {

--- a/src/agents/auth-profiles/usage.test.ts
+++ b/src/agents/auth-profiles/usage.test.ts
@@ -413,6 +413,83 @@ describe("resolveProfilesUnavailableReason", () => {
       }),
     ).toBe("auth");
   });
+
+  it("ignores a blockedUntil scoped to a different model when forModel is given", () => {
+    const now = Date.now();
+    const store = makeStore({
+      "openai:default": {
+        blockedUntil: now + 60_000,
+        blockedModel: "gpt-5.5",
+      },
+    });
+
+    expect(
+      resolveProfilesUnavailableReason({
+        store,
+        profileIds: ["openai:default"],
+        now,
+        forModel: "gpt-5.3-codex-spark",
+      }),
+    ).toBeNull();
+  });
+
+  it("reports rate_limit for a blockedUntil that matches forModel", () => {
+    const now = Date.now();
+    const store = makeStore({
+      "openai:default": {
+        blockedUntil: now + 60_000,
+        blockedModel: "gpt-5.3-codex-spark",
+      },
+    });
+
+    expect(
+      resolveProfilesUnavailableReason({
+        store,
+        profileIds: ["openai:default"],
+        now,
+        forModel: "gpt-5.3-codex-spark",
+      }),
+    ).toBe("rate_limit");
+  });
+
+  it("reports rate_limit for an unscoped blockedUntil regardless of forModel", () => {
+    const now = Date.now();
+    const store = makeStore({
+      "openai:default": {
+        blockedUntil: now + 60_000,
+      },
+    });
+
+    expect(
+      resolveProfilesUnavailableReason({
+        store,
+        profileIds: ["openai:default"],
+        now,
+        forModel: "gpt-5.3-codex-spark",
+      }),
+    ).toBe("rate_limit");
+  });
+
+  it("ignores a rate_limit cooldown scoped to a different cooldownModel when forModel is given", () => {
+    const now = Date.now();
+    const store = makeStore({
+      "openai:default": {
+        cooldownUntil: now + 60_000,
+        cooldownReason: "rate_limit",
+        cooldownModel: "gpt-5.5",
+        failureCounts: { rate_limit: 3 },
+      },
+    });
+
+    expect(
+      resolveProfilesUnavailableReason({
+        store,
+        profileIds: ["openai:default"],
+        now,
+        forModel: "gpt-5.3-codex-spark",
+      }),
+    ).toBeNull();
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/src/agents/auth-profiles/usage.test.ts
+++ b/src/agents/auth-profiles/usage.test.ts
@@ -991,6 +991,7 @@ describe("markAuthProfileFailure — WHAM-aware Codex cooldowns", () => {
     now: number;
     reason?: "rate_limit" | "no_error_details" | "unknown";
     useLock?: boolean;
+    modelId?: string;
   }): Promise<void> {
     const dateNowSpy = vi.spyOn(Date, "now").mockReturnValue(params.now);
     if (params.useLock) {
@@ -1007,6 +1008,7 @@ describe("markAuthProfileFailure — WHAM-aware Codex cooldowns", () => {
         store: params.store,
         profileId: "openai:default",
         reason: params.reason ?? "rate_limit",
+        modelId: params.modelId,
       });
     } finally {
       dateNowSpy.mockRestore();
@@ -1129,6 +1131,32 @@ describe("markAuthProfileFailure — WHAM-aware Codex cooldowns", () => {
     expect(fetchMock).toHaveBeenCalledTimes(1);
     expect(store.usageStats).toBeUndefined();
     expect(storeMocks.saveAuthProfileStore).not.toHaveBeenCalled();
+  });
+
+  it("scopes a subscription_limit block to the failing model so other models on the same profile stay usable", async () => {
+    const now = 1_700_000_000_000;
+    const store = makeStore({});
+    mockWhamResponse(200, {
+      rate_limit: {
+        limit_reached: true,
+        primary_window: { used_percent: 100, reset_after_seconds: 7_200 },
+      },
+    });
+
+    await markCodexFailureAt({ store, now, modelId: "gpt-5.5" });
+
+    const stats = store.usageStats?.["openai:default"];
+    expect(stats?.blockedReason).toBe("subscription_limit");
+    expect(stats?.blockedModel).toBe("gpt-5.5");
+
+    // The failing model remains blocked...
+    expect(isProfileInCooldown(store, "openai:default", now, "gpt-5.5")).toBe(true);
+    // ...but a different model sharing the same auth profile (e.g. a
+    // separately-quota'd Codex Spark lane) is not blocked by it.
+    expect(isProfileInCooldown(store, "openai:default", now, "gpt-5.3-codex-spark")).toBe(false);
+    // Unscoped checks (no forModel) stay conservative and report the profile
+    // as unusable, matching existing display/rotation behavior.
+    expect(isProfileInCooldown(store, "openai:default", now)).toBe(true);
   });
 
   it("maps HTTP 401 to a 12h cooldown", async () => {

--- a/src/agents/auth-profiles/usage.test.ts
+++ b/src/agents/auth-profiles/usage.test.ts
@@ -1159,6 +1159,100 @@ describe("markAuthProfileFailure — WHAM-aware Codex cooldowns", () => {
     expect(isProfileInCooldown(store, "openai:default", now)).toBe(true);
   });
 
+  it("widens to profile-wide when a new model-scoped block lands on top of an already-active unscoped block", async () => {
+    const now = 1_700_000_000_000;
+    const existingBlockedUntil = now + 3 * 60 * 60 * 1000;
+    // blockedModel is undefined here to simulate a profile-wide block recorded
+    // before per-model scoping existed (or a non-WHAM profile-wide block).
+    const store = makeStore({
+      "openai:default": {
+        blockedUntil: existingBlockedUntil,
+        blockedReason: "subscription_limit",
+        blockedSource: "wham",
+        errorCount: 1,
+        lastFailureAt: now - 1_000,
+      },
+    });
+    mockWhamResponse(200, {
+      rate_limit: {
+        limit_reached: true,
+        primary_window: { used_percent: 100, reset_after_seconds: 7_200 },
+      },
+    });
+
+    await markCodexFailureAt({ store, now, modelId: "gpt-5.5" });
+
+    const stats = store.usageStats?.["openai:default"];
+    // The pre-existing unscoped block must not be silently narrowed to just
+    // the incoming model — that would incorrectly unblock whatever the
+    // original unscoped block was protecting.
+    expect(stats?.blockedModel).toBeUndefined();
+    expect(isProfileInCooldown(store, "openai:default", now, "gpt-5.5")).toBe(true);
+    expect(isProfileInCooldown(store, "openai:default", now, "gpt-5.3-codex-spark")).toBe(true);
+    expect(isProfileInCooldown(store, "openai:default", now)).toBe(true);
+  });
+
+  it("widens to profile-wide when a new block for a different model conflicts with an existing model-scoped block", async () => {
+    const now = 1_700_000_000_000;
+    const existingBlockedUntil = now + 3 * 60 * 60 * 1000;
+    const store = makeStore({
+      "openai:default": {
+        blockedUntil: existingBlockedUntil,
+        blockedModel: "gpt-5.5",
+        blockedReason: "subscription_limit",
+        blockedSource: "wham",
+        errorCount: 1,
+        lastFailureAt: now - 1_000,
+      },
+    });
+    mockWhamResponse(200, {
+      rate_limit: {
+        limit_reached: true,
+        primary_window: { used_percent: 100, reset_after_seconds: 7_200 },
+      },
+    });
+
+    await markCodexFailureAt({ store, now, modelId: "gpt-5.3-codex-spark" });
+
+    const stats = store.usageStats?.["openai:default"];
+    // Two different models are each independently blocked on this profile now
+    // (gpt-5.5 from the earlier failure, gpt-5.3-codex-spark from this one).
+    // Narrowing blockedModel to either one alone would silently drop coverage
+    // for the other, so the merged block must widen to profile-wide.
+    expect(stats?.blockedModel).toBeUndefined();
+    expect(isProfileInCooldown(store, "openai:default", now, "gpt-5.5")).toBe(true);
+    expect(isProfileInCooldown(store, "openai:default", now, "gpt-5.3-codex-spark")).toBe(true);
+    expect(isProfileInCooldown(store, "openai:default", now)).toBe(true);
+  });
+
+  it("keeps a repeated block for the same model scoped to just that model", async () => {
+    const now = 1_700_000_000_000;
+    const existingBlockedUntil = now + 1 * 60 * 60 * 1000;
+    const store = makeStore({
+      "openai:default": {
+        blockedUntil: existingBlockedUntil,
+        blockedModel: "gpt-5.5",
+        blockedReason: "subscription_limit",
+        blockedSource: "wham",
+        errorCount: 1,
+        lastFailureAt: now - 1_000,
+      },
+    });
+    mockWhamResponse(200, {
+      rate_limit: {
+        limit_reached: true,
+        primary_window: { used_percent: 100, reset_after_seconds: 7_200 },
+      },
+    });
+
+    await markCodexFailureAt({ store, now, modelId: "gpt-5.5" });
+
+    const stats = store.usageStats?.["openai:default"];
+    expect(stats?.blockedModel).toBe("gpt-5.5");
+    expect(isProfileInCooldown(store, "openai:default", now, "gpt-5.5")).toBe(true);
+    expect(isProfileInCooldown(store, "openai:default", now, "gpt-5.3-codex-spark")).toBe(false);
+  });
+
   it("maps HTTP 401 to a 12h cooldown", async () => {
     const now = 1_700_000_000_000;
     const store = makeStore({});

--- a/src/agents/auth-profiles/usage.ts
+++ b/src/agents/auth-profiles/usage.ts
@@ -191,6 +191,7 @@ function applyWhamCooldownResult(params: {
   computed: ProfileUsageStats;
   now: number;
   whamResult: WhamCooldownProbeResult;
+  modelId?: string;
 }): ProfileUsageStats {
   const existingCooldownUntil = params.existing.cooldownUntil;
   const existingBlockedUntil = params.existing.blockedUntil;
@@ -212,7 +213,7 @@ function applyWhamCooldownResult(params: {
       blockedUntil: Math.max(existingActiveBlockedUntil, params.whamResult.blockedUntil),
       blockedReason: "subscription_limit",
       blockedSource: params.whamResult.blockedSource ?? "wham",
-      blockedModel: undefined,
+      blockedModel: params.modelId,
       cooldownUntil: undefined,
       cooldownReason: undefined,
       cooldownModel: undefined,
@@ -784,6 +785,7 @@ export async function markAuthProfileFailure(params: {
             computed,
             now,
             whamResult: currentWhamResult,
+            modelId,
           })
         : computed;
       updateUsageStatsEntry(freshStore, profileId, () => nextStats ?? computed);
@@ -846,6 +848,7 @@ export async function markAuthProfileFailure(params: {
         computed,
         now,
         whamResult: currentWhamResult,
+        modelId,
       })
     : computed;
   updateUsageStatsEntry(store, profileId, () => nextStats ?? computed);

--- a/src/agents/auth-profiles/usage.ts
+++ b/src/agents/auth-profiles/usage.ts
@@ -285,9 +285,7 @@ function resolveWhamRateLimitForModel(
     return base;
   }
   const normalize = (value: string | undefined): string =>
-    String(value ?? "")
-      .toLowerCase()
-      .replace(/[^a-z0-9]/g, "");
+    (value ?? "").toLowerCase().replace(/[^a-z0-9]/g, "");
   const target = normalize(modelId);
   if (!target) {
     return base;

--- a/src/agents/auth-profiles/usage.ts
+++ b/src/agents/auth-profiles/usage.ts
@@ -915,7 +915,11 @@ function buildBlockedProfileUsageStats(params: {
     blockedUntil: Math.max(activeBlockedUntil, params.blockedUntil),
     blockedReason: "subscription_limit",
     blockedSource: params.source,
-    blockedModel: params.modelId,
+    blockedModel: mergeBlockedModel(
+      params.previousStats?.blockedModel,
+      activeBlockedUntil,
+      params.modelId,
+    ),
     cooldownUntil: undefined,
     cooldownReason: undefined,
     cooldownModel: undefined,

--- a/src/agents/auth-profiles/usage.ts
+++ b/src/agents/auth-profiles/usage.ts
@@ -375,6 +375,7 @@ export function resolveProfilesUnavailableReason(params: {
   store: AuthProfileStore;
   profileIds: string[];
   now?: number;
+  forModel?: string;
 }): AuthProfileFailureReason | null {
   const now = params.now ?? Date.now();
   const scores = new Map<AuthProfileFailureReason, number>();
@@ -398,13 +399,31 @@ export function resolveProfilesUnavailableReason(params: {
       continue;
     }
 
-    if (isActiveUnusableWindow(stats.blockedUntil, now)) {
+    // Model-aware bypass: a subscription_limit block recorded against a specific
+    // model (blockedModel) must not be reported as the unavailable reason for a
+    // *different* model on the same profile, mirroring the scoping already
+    // applied by resolveProfileUnusableUntil/isProfileInCooldown in
+    // usage-state.ts.
+    const blockedAppliesToModel =
+      !params.forModel || !stats.blockedModel || stats.blockedModel === params.forModel;
+    if (blockedAppliesToModel && isActiveUnusableWindow(stats.blockedUntil, now)) {
       addScore("rate_limit", 1_000);
       continue;
     }
 
     const cooldownActive = isActiveUnusableWindow(stats.cooldownUntil, now);
     if (!cooldownActive) {
+      continue;
+    }
+
+    // Same model-aware bypass for rate_limit/timeout cooldowns scoped to a
+    // different model via cooldownModel.
+    if (
+      params.forModel &&
+      isModelScopedCooldownReason(stats.cooldownReason) &&
+      stats.cooldownModel &&
+      stats.cooldownModel !== params.forModel
+    ) {
       continue;
     }
 

--- a/src/agents/auth-profiles/usage.ts
+++ b/src/agents/auth-profiles/usage.ts
@@ -96,12 +96,25 @@ type WhamUsageWindow = {
   reset_after_seconds?: number;
 };
 
+type WhamRateLimit = {
+  limit_reached?: boolean;
+  primary_window?: WhamUsageWindow;
+  secondary_window?: WhamUsageWindow;
+};
+
+// Codex models (e.g. Spark) report a distinct server-side bucket under
+// `additional_rate_limits[]`, keyed by `limit_name`/`metered_feature`, separate
+// from the default GPT `rate_limit` bucket. Without this a codex model would be
+// cooled off a sibling model's exhausted window.
+type WhamAdditionalRateLimit = {
+  limit_name?: string;
+  metered_feature?: string;
+  rate_limit?: WhamRateLimit;
+};
+
 type WhamUsageResponse = {
-  rate_limit?: {
-    limit_reached?: boolean;
-    primary_window?: WhamUsageWindow;
-    secondary_window?: WhamUsageWindow;
-  };
+  rate_limit?: WhamRateLimit;
+  additional_rate_limits?: WhamAdditionalRateLimit[];
 };
 
 type WhamCooldownProbeResult = {
@@ -259,9 +272,41 @@ async function cancelUnreadResponseBody(response: Response): Promise<void> {
   }
 }
 
+// Pick the WHAM bucket matching the model being probed. Codex models expose
+// their own `additional_rate_limits[]` entry; everything else uses the default
+// `rate_limit`. Matching keeps a model from being blocked off a sibling's
+// exhausted window.
+function resolveWhamRateLimitForModel(
+  data: WhamUsageResponse,
+  modelId: string | undefined,
+): WhamRateLimit | undefined {
+  const base = data.rate_limit;
+  if (!modelId) {
+    return base;
+  }
+  const normalize = (value: string | undefined): string =>
+    String(value ?? "")
+      .toLowerCase()
+      .replace(/[^a-z0-9]/g, "");
+  const target = normalize(modelId);
+  if (!target) {
+    return base;
+  }
+  for (const entry of data.additional_rate_limits ?? []) {
+    if (!entry?.rate_limit) {
+      continue;
+    }
+    if (normalize(entry.limit_name) === target || normalize(entry.metered_feature) === target) {
+      return entry.rate_limit;
+    }
+  }
+  return base;
+}
+
 async function probeWhamForCooldown(
   store: AuthProfileStore,
   profileId: string,
+  modelId?: string,
 ): Promise<WhamCooldownProbeResult | null> {
   const profile = store.profiles[profileId];
   if (profile?.type !== "oauth" || !profile.access) {
@@ -309,19 +354,20 @@ async function probeWhamForCooldown(
     }
 
     const data = await readProviderJsonResponse<WhamUsageResponse>(res, "WHAM usage probe");
-    if (!data.rate_limit) {
+    const rateLimit = resolveWhamRateLimitForModel(data, modelId);
+    if (!rateLimit) {
       return { cooldownMs: WHAM_PROBE_FAILURE_COOLDOWN_MS, reason: "wham_probe_failed" };
     }
 
-    if (data.rate_limit.limit_reached === false) {
+    if (rateLimit.limit_reached === false) {
       return { cooldownMs: WHAM_BURST_COOLDOWN_MS, reason: "wham_burst_contention" };
     }
 
     const now = Date.now();
-    const primaryResetMs = resolveWhamResetMs(data.rate_limit.primary_window, now);
-    const secondaryResetMs = resolveWhamResetMs(data.rate_limit.secondary_window, now);
+    const primaryResetMs = resolveWhamResetMs(rateLimit.primary_window, now);
+    const secondaryResetMs = resolveWhamResetMs(rateLimit.secondary_window, now);
 
-    if (!data.rate_limit.secondary_window) {
+    if (!rateLimit.secondary_window) {
       if (primaryResetMs === null) {
         return { cooldownMs: WHAM_PROBE_FAILURE_COOLDOWN_MS, reason: "wham_probe_failed" };
       }
@@ -333,7 +379,7 @@ async function probeWhamForCooldown(
       };
     }
 
-    if (isWhamWindowExhausted(data.rate_limit.secondary_window)) {
+    if (isWhamWindowExhausted(rateLimit.secondary_window)) {
       if (secondaryResetMs === null) {
         return { cooldownMs: WHAM_PROBE_FAILURE_COOLDOWN_MS, reason: "wham_probe_failed" };
       }
@@ -345,7 +391,7 @@ async function probeWhamForCooldown(
       };
     }
 
-    if (isWhamWindowExhausted(data.rate_limit.primary_window)) {
+    if (isWhamWindowExhausted(rateLimit.primary_window)) {
       if (primaryResetMs === null) {
         return { cooldownMs: WHAM_PROBE_FAILURE_COOLDOWN_MS, reason: "wham_probe_failed" };
       }
@@ -784,7 +830,7 @@ export async function markAuthProfileFailure(params: {
     return;
   }
 
-  const whamResult = shouldProbeWham ? await probeWhamForCooldown(store, profileId) : null;
+  const whamResult = shouldProbeWham ? await probeWhamForCooldown(store, profileId, modelId) : null;
 
   let nextStats: ProfileUsageStats | undefined;
   let previousStats: ProfileUsageStats | undefined;

--- a/src/agents/auth-profiles/usage.ts
+++ b/src/agents/auth-profiles/usage.ts
@@ -186,6 +186,27 @@ function isWhamWindowExhausted(window: WhamUsageWindow | undefined): boolean {
   );
 }
 
+// Decides the blockedModel to persist when a new subscription_limit block is
+// recorded on top of a possibly-still-active existing block. Naively
+// overwriting blockedModel with the incoming modelId would silently narrow an
+// unrelated existing block (unscoped, or scoped to a different model) to just
+// the new model — dropping coverage for whichever model the *existing* block
+// was actually protecting. Widen to profile-wide (undefined) whenever the
+// existing active block doesn't already agree with the incoming model.
+function mergeBlockedModel(
+  existingBlockedModel: string | undefined,
+  existingActiveBlockedUntil: number,
+  incomingModelId: string | undefined,
+): string | undefined {
+  const noActiveExistingBlock = existingActiveBlockedUntil <= 0;
+  if (noActiveExistingBlock || existingBlockedModel === incomingModelId) {
+    return incomingModelId;
+  }
+  // Existing active block is unscoped or scoped to a different model than the
+  // incoming one — widen to profile-wide so neither model's coverage is lost.
+  return undefined;
+}
+
 function applyWhamCooldownResult(params: {
   existing: ProfileUsageStats;
   computed: ProfileUsageStats;
@@ -213,7 +234,11 @@ function applyWhamCooldownResult(params: {
       blockedUntil: Math.max(existingActiveBlockedUntil, params.whamResult.blockedUntil),
       blockedReason: "subscription_limit",
       blockedSource: params.whamResult.blockedSource ?? "wham",
-      blockedModel: params.modelId,
+      blockedModel: mergeBlockedModel(
+        params.existing.blockedModel,
+        existingActiveBlockedUntil,
+        params.modelId,
+      ),
       cooldownUntil: undefined,
       cooldownReason: undefined,
       cooldownModel: undefined,

--- a/src/agents/btw.ts
+++ b/src/agents/btw.ts
@@ -348,6 +348,7 @@ async function resolveRuntimeModel(params: {
     sessionKey: params.sessionKey,
     storePath: params.storePath,
     isNewSession: params.isNewSession,
+    model: runtimeModelId,
   });
   return {
     model,

--- a/src/agents/embedded-agent-runner/run.overflow-compaction.test.ts
+++ b/src/agents/embedded-agent-runner/run.overflow-compaction.test.ts
@@ -1299,10 +1299,13 @@ describe("runEmbeddedAgent overflow compaction trigger routing", () => {
     expect(harnessParams?.runtimePlan).toBe(runtimePlan);
     expect(mockedMarkAuthProfileSuccess).toHaveBeenCalledTimes(1);
     const [[successParams]] = mockedMarkAuthProfileSuccess.mock.calls as unknown as Array<
-      [{ provider?: string; profileId?: string }]
+      [{ provider?: string; profileId?: string; model?: string }]
     >;
     expect(successParams.provider).toBe("openai");
     expect(successParams.profileId).toBe("openai:work");
+    // Regression (#99810): the runner must forward the succeeding model so a
+    // healthy sibling success cannot clear another model's active block.
+    expect(successParams.model).toBe("gpt-5.4");
   });
 
   it("bootstraps OAuth credentials for forced openai/* Codex response runs", async () => {

--- a/src/agents/embedded-agent-runner/run.ts
+++ b/src/agents/embedded-agent-runner/run.ts
@@ -1761,6 +1761,7 @@ async function runEmbeddedAgentInternal(
           provider: successProvider,
           profileId: successProfileId,
           agentDir: params.agentDir,
+          model: modelId,
         })
           .then(() => {
             const durationMs = Date.now() - successStarted;

--- a/src/agents/embedded-agent-runner/run/auth-controller.test.ts
+++ b/src/agents/embedded-agent-runner/run/auth-controller.test.ts
@@ -98,6 +98,7 @@ function createMutableEmbeddedRunAuthController(params: {
   profileCandidates?: string[];
   authStore?: AuthProfileStore;
   fallbackConfigured?: boolean;
+  allowTransientCooldownProbe?: boolean;
   warn?: (message: string) => void;
 }) {
   return createEmbeddedRunAuthController({
@@ -115,7 +116,7 @@ function createMutableEmbeddedRunAuthController(params: {
     initialThinkLevel: "medium",
     attemptedThinking: new Set(),
     fallbackConfigured: params.fallbackConfigured ?? false,
-    allowTransientCooldownProbe: false,
+    allowTransientCooldownProbe: params.allowTransientCooldownProbe ?? false,
     getProvider: () => "custom-openai",
     getModelId: () => "test-model",
     getRuntimeModel: () => params.harness.runtimeModel,
@@ -268,6 +269,60 @@ describe("createEmbeddedRunAuthController", () => {
       reason: "billing",
       authMode: "oauth",
     });
+  });
+
+  it("scopes the all-in-cooldown unavailable-reason inference to the requested model", async () => {
+    // A stale blockedUntil recorded against a different model must not be
+    // reported as the failure reason for the model actually being requested;
+    // the profile's own (unscoped) cooldownReason/failureCounts should win,
+    // and that reason must gate the transient-cooldown probe correctly.
+    const harness = createMutableAuthControllerHarness();
+    const profileId = "custom-openai:default";
+    const now = Date.now();
+    const warn = vi.fn();
+    mocks.getApiKeyForModel.mockResolvedValue({
+      apiKey: "source-api-key",
+      mode: "api-key",
+      profileId,
+      source: "env",
+    });
+
+    const controller = createMutableEmbeddedRunAuthController({
+      harness,
+      setRuntimeApiKey: vi.fn(),
+      profileCandidates: [profileId],
+      fallbackConfigured: true,
+      allowTransientCooldownProbe: true,
+      warn,
+      authStore: {
+        version: 1,
+        profiles: {
+          [profileId]: {
+            type: "api_key",
+            provider: "custom-openai",
+            key: "sk-test",
+          },
+        },
+        usageStats: {
+          [profileId]: {
+            cooldownUntil: now + 60_000,
+            cooldownReason: "format",
+            blockedUntil: now + 60_000,
+            blockedModel: "other-model",
+            failureCounts: { format: 3 },
+          },
+        },
+      },
+    });
+
+    const error = await controller.initializeAuthProfile().catch((err: unknown) => err);
+
+    expect(error).toBeInstanceOf(FailoverError);
+    expect(error).toMatchObject({ reason: "format" });
+    // "format" does not permit a transient cooldown probe, so no probe
+    // warning should have been emitted (unlike "rate_limit", which the
+    // unscoped blockedModel would have incorrectly produced).
+    expect(warn).not.toHaveBeenCalled();
   });
 
   it("rejects privileged runtime transport overrides on the first auth exchange", async () => {

--- a/src/agents/embedded-agent-runner/run/auth-controller.ts
+++ b/src/agents/embedded-agent-runner/run/auth-controller.ts
@@ -303,6 +303,7 @@ export function createEmbeddedRunAuthController(params: {
         resolveProfilesUnavailableReason({
           store: params.authStore,
           profileIds,
+          forModel: params.getModelId(),
         }) ?? "unknown"
       );
     }
@@ -512,6 +513,7 @@ export function createEmbeddedRunAuthController(params: {
         ? (resolveProfilesUnavailableReason({
             store: params.authStore,
             profileIds: autoProfileCandidates,
+            forModel: modelId,
           }) ?? "unknown")
         : null;
       const allowTransientCooldownProbe =

--- a/src/agents/model-fallback.ts
+++ b/src/agents/model-fallback.ts
@@ -1265,6 +1265,7 @@ function resolveCooldownDecision(params: {
       store: params.authStore,
       profileIds: params.profileIds,
       now: params.now,
+      forModel: params.candidate.model,
     }) ?? "unknown";
   const shouldProbe = shouldProbePrimaryDuringCooldown({
     isPrimary: params.isPrimary,

--- a/src/auto-reply/reply/agent-runner-execution.test.ts
+++ b/src/auto-reply/reply/agent-runner-execution.test.ts
@@ -1994,7 +1994,7 @@ describe("runAgentTurnWithFallback", () => {
     // the session auto-pinned down to spark, and sonnet (the middle tier) has since
     // recovered. Per-model cooldown scoping means the primary-only probe never
     // re-walks to sonnet, so without re-promotion the session sticks on spark.
-    const { resolveAutoFallbackRepromotionTarget } = await import("../../agents/agent-scope.js");
+    const { resolveAutoFallbackRepromotionTarget } = await import("./auto-fallback-repromotion.js");
     const chain = [
       { provider: "openai", model: "gpt-5.5" },
       { provider: "claude-cli", model: "claude-sonnet-5" },
@@ -2054,7 +2054,7 @@ describe("runAgentTurnWithFallback", () => {
   });
 
   it("keeps the pinned auth profile on a same-provider re-promotion climb", async () => {
-    const { resolveAutoFallbackRepromotionTarget } = await import("../../agents/agent-scope.js");
+    const { resolveAutoFallbackRepromotionTarget } = await import("./auto-fallback-repromotion.js");
     // Chain where the climb target stays on the same provider as the current pin,
     // so the (provider-scoped) auth profile remains valid and must be preserved.
     const chain = [

--- a/src/auto-reply/reply/agent-runner-execution.test.ts
+++ b/src/auto-reply/reply/agent-runner-execution.test.ts
@@ -2029,6 +2029,10 @@ describe("runAgentTurnWithFallback", () => {
     run.provider = "openai";
     run.model = "gpt-5.5";
     run.autoFallbackPrimaryProbe = probe;
+    // Session was auto-pinned to spark under an OpenAI auth profile. Climbing to
+    // claude-cli must not carry that OpenAI profile into the new provider.
+    run.authProfileId = "openai:oauth";
+    run.authProfileIdSource = "auto";
 
     const rechecked = resolveRunAfterAutoFallbackPrimaryProbeRecheck({
       run,
@@ -2043,6 +2047,64 @@ describe("runAgentTurnWithFallback", () => {
       model: "claude-sonnet-5",
       autoFallbackPrimaryProbe: undefined,
     });
+    // Cross-provider climb must clear the stale OpenAI auth profile so credential
+    // selection resolves a claude-cli profile instead of leaking the OpenAI one.
+    expect(rechecked.authProfileId).toBeUndefined();
+    expect(rechecked.authProfileIdSource).toBeUndefined();
+  });
+
+  it("keeps the pinned auth profile on a same-provider re-promotion climb", async () => {
+    const { resolveAutoFallbackRepromotionTarget } = await import("../../agents/agent-scope.js");
+    // Chain where the climb target stays on the same provider as the current pin,
+    // so the (provider-scoped) auth profile remains valid and must be preserved.
+    const chain = [
+      { provider: "openai", model: "gpt-5.5" },
+      { provider: "openai", model: "gpt-5.3-codex" },
+      { provider: "openai", model: "gpt-5.3-codex-spark" },
+    ];
+    const unavailable = new Set(["openai/gpt-5.5"]);
+    const isAvailable = (ref: { provider: string; model: string }) =>
+      !unavailable.has(`${ref.provider}/${ref.model}`);
+
+    const probe = {
+      provider: "openai",
+      model: "gpt-5.5",
+      fallbackProvider: "openai",
+      fallbackModel: "gpt-5.3-codex-spark",
+      fallbackAuthProfileId: "openai:oauth",
+      fallbackAuthProfileIdSource: "auto" as const,
+    };
+    const sessionEntry: SessionEntry = {
+      sessionId: "session",
+      updatedAt: 1,
+      providerOverride: "openai",
+      modelOverride: "gpt-5.3-codex-spark",
+      modelOverrideSource: "auto",
+      authProfileOverride: "openai:oauth",
+      authProfileOverrideSource: "auto",
+    };
+    const run = createFollowupRun().run;
+    run.provider = "openai";
+    run.model = "gpt-5.5";
+    run.autoFallbackPrimaryProbe = probe;
+    run.authProfileId = "openai:oauth";
+    run.authProfileIdSource = "auto";
+
+    const rechecked = resolveRunAfterAutoFallbackPrimaryProbeRecheck({
+      run,
+      entry: sessionEntry,
+      sessionKey: "main",
+      resolveRepromotionTarget: (current) =>
+        resolveAutoFallbackRepromotionTarget({ chain, current, isAvailable }),
+    });
+
+    expect(rechecked).toMatchObject({
+      provider: "openai",
+      model: "gpt-5.3-codex",
+      autoFallbackPrimaryProbe: undefined,
+    });
+    expect(rechecked.authProfileId).toBe("openai:oauth");
+    expect(rechecked.authProfileIdSource).toBe("auto");
   });
 
   it("keeps fallback auth available when a primary probe falls back", async () => {

--- a/src/auto-reply/reply/agent-runner-execution.test.ts
+++ b/src/auto-reply/reply/agent-runner-execution.test.ts
@@ -1989,6 +1989,62 @@ describe("runAgentTurnWithFallback", () => {
     expect(rechecked.hasAutoFallbackProvenance).toBeUndefined();
   });
 
+  it("re-promotes a session stuck on a lower tier to the highest available middle tier", async () => {
+    // Reproduces the live stuck-on-spark case: gpt-5.5 (primary) is rate-limited,
+    // the session auto-pinned down to spark, and sonnet (the middle tier) has since
+    // recovered. Per-model cooldown scoping means the primary-only probe never
+    // re-walks to sonnet, so without re-promotion the session sticks on spark.
+    const { resolveAutoFallbackRepromotionTarget } = await import("../../agents/agent-scope.js");
+    const chain = [
+      { provider: "openai", model: "gpt-5.5" },
+      { provider: "claude-cli", model: "claude-sonnet-5" },
+      { provider: "openai", model: "gpt-5.3-codex-spark" },
+      { provider: "xai", model: "grok-4.3" },
+    ];
+    // gpt-5.5 still rate-limited; sonnet + spark + grok available.
+    const unavailable = new Set(["openai/gpt-5.5"]);
+    const isAvailable = (ref: { provider: string; model: string }) =>
+      !unavailable.has(`${ref.provider}/${ref.model}`);
+
+    const probe = {
+      provider: "openai",
+      model: "gpt-5.5",
+      fallbackProvider: "openai",
+      fallbackModel: "gpt-5.3-codex-spark",
+      fallbackAuthProfileId: "openai:oauth",
+      fallbackAuthProfileIdSource: "auto" as const,
+    };
+    const sessionEntry: SessionEntry = {
+      sessionId: "session",
+      updatedAt: 1,
+      providerOverride: "openai",
+      modelOverride: "gpt-5.3-codex-spark",
+      modelOverrideSource: "auto",
+      modelOverrideFallbackOriginProvider: "openai",
+      modelOverrideFallbackOriginModel: "gpt-5.5",
+      authProfileOverride: "openai:oauth",
+      authProfileOverrideSource: "auto",
+    };
+    const run = createFollowupRun().run;
+    run.provider = "openai";
+    run.model = "gpt-5.5";
+    run.autoFallbackPrimaryProbe = probe;
+
+    const rechecked = resolveRunAfterAutoFallbackPrimaryProbeRecheck({
+      run,
+      entry: sessionEntry,
+      sessionKey: "main",
+      resolveRepromotionTarget: (current) =>
+        resolveAutoFallbackRepromotionTarget({ chain, current, isAvailable }),
+    });
+
+    expect(rechecked).toMatchObject({
+      provider: "claude-cli",
+      model: "claude-sonnet-5",
+      autoFallbackPrimaryProbe: undefined,
+    });
+  });
+
   it("keeps fallback auth available when a primary probe falls back", async () => {
     const probe = {
       provider: "anthropic",

--- a/src/auto-reply/reply/agent-runner-execution.ts
+++ b/src/auto-reply/reply/agent-runner-execution.ts
@@ -1623,12 +1623,21 @@ export function resolveRunAfterAutoFallbackPrimaryProbeRecheck(params: {
   const repromotesToPrimary =
     repromotionTarget?.provider === probe.provider && repromotionTarget?.model === probe.model;
   if (repromotionTarget && !repromotesToPrimary) {
-    return {
+    const repromotedRun: FollowupRun["run"] = {
       ...params.run,
       provider: repromotionTarget.provider,
       model: repromotionTarget.model,
       autoFallbackPrimaryProbe: undefined,
     };
+    // A carried authProfileId is scoped to the prior provider. Forwarding it into a
+    // different provider on a cross-provider climb breaks credential selection and
+    // violates the auth-profile runtime contract, so drop it and let the target
+    // provider resolve its own profile. Same-provider climbs keep the pinned profile.
+    if (repromotionTarget.provider !== params.run.provider) {
+      delete repromotedRun.authProfileId;
+      delete repromotedRun.authProfileIdSource;
+    }
+    return repromotedRun;
   }
   const resolveEntrySelectionRun = (): FollowupRun["run"] => {
     const entryRef = resolvePersistedOverrideModelRef({

--- a/src/auto-reply/reply/agent-runner-execution.ts
+++ b/src/auto-reply/reply/agent-runner-execution.ts
@@ -132,6 +132,7 @@ import {
   resolveModelFallbackOptions,
   resolveRunFastModeForFallbackCandidate,
 } from "./agent-runner-utils.js";
+import { buildAutoFallbackRepromotionResolver } from "./auto-fallback-repromotion.js";
 import type { BlockReplyPipeline } from "./block-reply-pipeline.js";
 import {
   createCompactionHookNoticePayload,
@@ -1597,6 +1598,10 @@ export function resolveRunAfterAutoFallbackPrimaryProbeRecheck(params: {
   run: FollowupRun["run"];
   entry?: SessionEntry;
   sessionKey?: string;
+  resolveRepromotionTarget?: (current: {
+    provider: string;
+    model: string;
+  }) => { provider: string; model: string } | undefined;
 }): FollowupRun["run"] {
   const probe = params.run.autoFallbackPrimaryProbe;
   if (!probe || !params.sessionKey) {
@@ -1604,6 +1609,26 @@ export function resolveRunAfterAutoFallbackPrimaryProbeRecheck(params: {
   }
   if (!params.entry) {
     return params.run;
+  }
+  // Per-model cooldown scoping means the primary-only probe never re-walks to an
+  // intermediate tier that recovered while the session was auto-pinned to a lower
+  // fallback (e.g. primary rate-limited, session stuck on the last tier, middle
+  // tier back). Climb straight to the highest available tier and drop the probe so
+  // routing stops re-testing the still-limited primary. Excludes the primary itself
+  // so its recovery keeps flowing through the existing probe-turn path below.
+  const repromotionTarget = params.resolveRepromotionTarget?.({
+    provider: probe.fallbackProvider,
+    model: probe.fallbackModel,
+  });
+  const repromotesToPrimary =
+    repromotionTarget?.provider === probe.provider && repromotionTarget?.model === probe.model;
+  if (repromotionTarget && !repromotesToPrimary) {
+    return {
+      ...params.run,
+      provider: repromotionTarget.provider,
+      model: repromotionTarget.model,
+      autoFallbackPrimaryProbe: undefined,
+    };
   }
   const resolveEntrySelectionRun = (): FollowupRun["run"] => {
     const entryRef = resolvePersistedOverrideModelRef({
@@ -1710,6 +1735,13 @@ async function runAgentTurnWithFallbackInternal(
     run: params.followupRun.run,
     entry: params.activeSessionStore?.[params.sessionKey ?? ""] ?? params.getActiveSessionEntry(),
     sessionKey: params.sessionKey,
+    resolveRepromotionTarget: buildAutoFallbackRepromotionResolver({
+      cfg: params.followupRun.run.config,
+      agentDir: params.followupRun.run.agentDir,
+      defaultProvider:
+        params.followupRun.run.autoFallbackPrimaryProbe?.provider ??
+        params.followupRun.run.provider,
+    }),
   });
   if (runnableRun !== params.followupRun.run) {
     params.followupRun.run = runnableRun;

--- a/src/auto-reply/reply/auto-fallback-repromotion.test.ts
+++ b/src/auto-reply/reply/auto-fallback-repromotion.test.ts
@@ -15,8 +15,11 @@ vi.mock("../../agents/model-fallback-auth.runtime.js", () => ({
   ensureAuthProfileStore: (...args: unknown[]) => hoisted.ensureAuthProfileStore(...args),
 }));
 
-const { buildAutoFallbackChain, selectAutoFallbackRepromotionTarget } =
-  await import("./auto-fallback-repromotion.js");
+const {
+  buildAutoFallbackChain,
+  resolveAutoFallbackRepromotionTarget,
+  selectAutoFallbackRepromotionTarget,
+} = await import("./auto-fallback-repromotion.js");
 
 const DEFAULT_PROVIDER = "openai";
 const store = { fake: "store" } as never;
@@ -158,5 +161,77 @@ describe("selectAutoFallbackRepromotionTarget", () => {
     });
 
     expect(target).toEqual({ provider: "claude-cli", model: "claude-sonnet-5" });
+  });
+});
+
+describe("resolveAutoFallbackRepromotionTarget", () => {
+  const chain = [
+    { provider: "openai", model: "gpt-5.5" },
+    { provider: "claude-cli", model: "claude-sonnet-5" },
+    { provider: "openai", model: "gpt-5.3-codex-spark" },
+    { provider: "xai", model: "grok-4.3" },
+  ];
+
+  it("re-promotes past a rate-limited primary to the highest available tier", () => {
+    const cooled = new Set(["openai/gpt-5.5"]);
+    expect(
+      resolveAutoFallbackRepromotionTarget({
+        chain,
+        current: { provider: "openai", model: "gpt-5.3-codex-spark" },
+        isAvailable: (ref) => !cooled.has(`${ref.provider}/${ref.model}`),
+      }),
+    ).toStrictEqual({ provider: "claude-cli", model: "claude-sonnet-5" });
+  });
+
+  it("jumps straight back to the primary once it recovers", () => {
+    expect(
+      resolveAutoFallbackRepromotionTarget({
+        chain,
+        current: { provider: "openai", model: "gpt-5.3-codex-spark" },
+        isAvailable: () => true,
+      }),
+    ).toStrictEqual({ provider: "openai", model: "gpt-5.5" });
+  });
+
+  it("stays put when only lower tiers are available (no downward move, no thrash)", () => {
+    const cooled = new Set(["openai/gpt-5.5"]);
+    expect(
+      resolveAutoFallbackRepromotionTarget({
+        chain,
+        current: { provider: "claude-cli", model: "claude-sonnet-5" },
+        isAvailable: (ref) => !cooled.has(`${ref.provider}/${ref.model}`),
+      }),
+    ).toBeUndefined();
+  });
+
+  it("skips a rate-limited higher tier and picks the next available one above current", () => {
+    const cooled = new Set(["openai/gpt-5.5", "claude-cli/claude-sonnet-5"]);
+    expect(
+      resolveAutoFallbackRepromotionTarget({
+        chain,
+        current: { provider: "xai", model: "grok-4.3" },
+        isAvailable: (ref) => !cooled.has(`${ref.provider}/${ref.model}`),
+      }),
+    ).toStrictEqual({ provider: "openai", model: "gpt-5.3-codex-spark" });
+  });
+
+  it("returns undefined when already on the primary", () => {
+    expect(
+      resolveAutoFallbackRepromotionTarget({
+        chain,
+        current: { provider: "openai", model: "gpt-5.5" },
+        isAvailable: () => true,
+      }),
+    ).toBeUndefined();
+  });
+
+  it("trims surrounding whitespace on the current selection when matching the chain", () => {
+    expect(
+      resolveAutoFallbackRepromotionTarget({
+        chain,
+        current: { provider: " openai ", model: " gpt-5.3-codex-spark " },
+        isAvailable: (ref) => ref.model !== "gpt-5.5",
+      }),
+    ).toStrictEqual({ provider: "claude-cli", model: "claude-sonnet-5" });
   });
 });

--- a/src/auto-reply/reply/auto-fallback-repromotion.test.ts
+++ b/src/auto-reply/reply/auto-fallback-repromotion.test.ts
@@ -1,0 +1,162 @@
+// Tests the production wiring that builds the auto-fallback re-promotion resolver
+// from live config + per-model auth-profile cooldown state.
+import { describe, expect, it, vi } from "vitest";
+import type { OpenClawConfig } from "../../config/types.js";
+
+const hoisted = vi.hoisted(() => ({
+  resolveAuthProfileOrder: vi.fn(),
+  isProfileInCooldown: vi.fn(),
+  ensureAuthProfileStore: vi.fn(),
+}));
+
+vi.mock("../../agents/model-fallback-auth.runtime.js", () => ({
+  resolveAuthProfileOrder: (...args: unknown[]) => hoisted.resolveAuthProfileOrder(...args),
+  isProfileInCooldown: (...args: unknown[]) => hoisted.isProfileInCooldown(...args),
+  ensureAuthProfileStore: (...args: unknown[]) => hoisted.ensureAuthProfileStore(...args),
+}));
+
+const { buildAutoFallbackChain, selectAutoFallbackRepromotionTarget } =
+  await import("./auto-fallback-repromotion.js");
+
+const DEFAULT_PROVIDER = "openai";
+const store = { fake: "store" } as never;
+
+// Mirrors the live stuck-on-spark chain: gpt-5.5 primary, sonnet middle tier, then
+// spark and grok fallbacks.
+function cfgWithChain(): OpenClawConfig {
+  return {
+    agents: {
+      defaults: {
+        model: {
+          primary: "openai/gpt-5.5",
+          fallbacks: ["claude-cli/claude-sonnet-5", "openai/gpt-5.3-codex-spark", "xai/grok-4.3"],
+        },
+      },
+    },
+  } as unknown as OpenClawConfig;
+}
+
+// One auth profile per provider so availability is decided purely by the per-model
+// cooldown lookup.
+function stubOrderByProvider(): void {
+  hoisted.resolveAuthProfileOrder.mockImplementation((params: { provider: string }) => [
+    `${params.provider}:profile`,
+  ]);
+}
+
+describe("buildAutoFallbackChain", () => {
+  it("orders primary first then configured fallbacks, deduped", () => {
+    const chain = buildAutoFallbackChain({
+      cfg: cfgWithChain(),
+      defaultProvider: DEFAULT_PROVIDER,
+    });
+    expect(chain.map((ref) => `${ref.provider}/${ref.model}`)).toEqual([
+      "openai/gpt-5.5",
+      "claude-cli/claude-sonnet-5",
+      "openai/gpt-5.3-codex-spark",
+      "xai/grok-4.3",
+    ]);
+  });
+
+  it("returns an empty chain when no default model is configured", () => {
+    const chain = buildAutoFallbackChain({
+      cfg: {} as OpenClawConfig,
+      defaultProvider: DEFAULT_PROVIDER,
+    });
+    expect(chain).toEqual([]);
+  });
+});
+
+describe("selectAutoFallbackRepromotionTarget", () => {
+  it("re-promotes a session stuck on spark to the recovered middle tier while the primary stays limited", () => {
+    stubOrderByProvider();
+    // gpt-5.5 still rate-limited; every other tier available.
+    hoisted.isProfileInCooldown.mockImplementation(
+      (_store: unknown, _profileId: string, _reason: unknown, modelId: string) =>
+        modelId === "gpt-5.5",
+    );
+
+    const target = selectAutoFallbackRepromotionTarget({
+      cfg: cfgWithChain(),
+      defaultProvider: DEFAULT_PROVIDER,
+      current: { provider: "openai", model: "gpt-5.3-codex-spark" },
+      store,
+    });
+
+    expect(target).toEqual({ provider: "claude-cli", model: "claude-sonnet-5" });
+  });
+
+  it("scopes the cooldown check to the candidate model (per-model, not provider-wide)", () => {
+    stubOrderByProvider();
+    hoisted.isProfileInCooldown.mockReturnValue(false);
+
+    selectAutoFallbackRepromotionTarget({
+      cfg: cfgWithChain(),
+      defaultProvider: DEFAULT_PROVIDER,
+      current: { provider: "openai", model: "gpt-5.3-codex-spark" },
+      store,
+    });
+
+    // The 4th arg is the per-model scope introduced to stop a primary rate-limit
+    // from suspending sibling models on the same profile.
+    expect(hoisted.isProfileInCooldown).toHaveBeenCalledWith(
+      store,
+      "openai:profile",
+      undefined,
+      "gpt-5.5",
+    );
+  });
+
+  it("climbs to the highest available tier once the primary recovers", () => {
+    stubOrderByProvider();
+    hoisted.isProfileInCooldown.mockReturnValue(false);
+
+    const target = selectAutoFallbackRepromotionTarget({
+      cfg: cfgWithChain(),
+      defaultProvider: DEFAULT_PROVIDER,
+      current: { provider: "openai", model: "gpt-5.3-codex-spark" },
+      store,
+    });
+
+    expect(target).toEqual({ provider: "openai", model: "gpt-5.5" });
+  });
+
+  it("stays put when nothing above the current tier is available", () => {
+    stubOrderByProvider();
+    // Everything above spark still limited.
+    hoisted.isProfileInCooldown.mockImplementation(
+      (_store: unknown, _profileId: string, _reason: unknown, modelId: string) =>
+        modelId !== "gpt-5.3-codex-spark" && modelId !== "grok-4.3",
+    );
+
+    const target = selectAutoFallbackRepromotionTarget({
+      cfg: cfgWithChain(),
+      defaultProvider: DEFAULT_PROVIDER,
+      current: { provider: "openai", model: "gpt-5.3-codex-spark" },
+      store,
+    });
+
+    expect(target).toBeUndefined();
+  });
+
+  it("treats providers with no auth profiles as available so the climb is not blocked", () => {
+    // CLI-style provider tracks no auth profiles -> empty order.
+    hoisted.resolveAuthProfileOrder.mockImplementation((params: { provider: string }) =>
+      params.provider === "claude-cli" ? [] : [`${params.provider}:profile`],
+    );
+    // Real primary gpt-5.5 still limited; sonnet has no profiles.
+    hoisted.isProfileInCooldown.mockImplementation(
+      (_store: unknown, _profileId: string, _reason: unknown, modelId: string) =>
+        modelId === "gpt-5.5",
+    );
+
+    const target = selectAutoFallbackRepromotionTarget({
+      cfg: cfgWithChain(),
+      defaultProvider: DEFAULT_PROVIDER,
+      current: { provider: "openai", model: "gpt-5.3-codex-spark" },
+      store,
+    });
+
+    expect(target).toEqual({ provider: "claude-cli", model: "claude-sonnet-5" });
+  });
+});

--- a/src/auto-reply/reply/auto-fallback-repromotion.ts
+++ b/src/auto-reply/reply/auto-fallback-repromotion.ts
@@ -1,0 +1,140 @@
+/**
+ * Production wiring for auto-fallback re-promotion ("fall back up").
+ *
+ * `resolveRunAfterAutoFallbackPrimaryProbeRecheck` accepts an injected
+ * `resolveRepromotionTarget` closure so its unit tests can supply a synthetic
+ * chain/availability check. This module builds the real closure from live
+ * config + auth-profile cooldown state so a session that auto-pinned to a low
+ * fallback tier climbs back to the highest available tier once a middle tier
+ * recovers, instead of sticking on the bottom of the chain.
+ */
+import {
+  resolveAutoFallbackRepromotionTarget,
+  type AutoFallbackModelRef,
+} from "../../agents/agent-scope.js";
+import {
+  ensureAuthProfileStore,
+  isProfileInCooldown,
+  resolveAuthProfileOrder,
+} from "../../agents/model-fallback-auth.runtime.js";
+import { parseModelRef } from "../../agents/model-selection-normalize.js";
+import {
+  resolveAgentModelFallbackValues,
+  resolveAgentModelPrimaryValue,
+} from "../../config/model-input.js";
+import type { OpenClawConfig } from "../../config/types.js";
+
+type AuthProfileStore = ReturnType<typeof ensureAuthProfileStore>;
+
+export type AutoFallbackRepromotionResolver = (
+  current: AutoFallbackModelRef,
+) => AutoFallbackModelRef | undefined;
+
+/**
+ * Ordered auto-fallback chain (primary first, then configured fallbacks) as
+ * normalized provider/model refs. Mirrors the ordering used by the fallback
+ * walk: `agents.defaults.model` primary followed by its `fallbacks` list.
+ */
+export function buildAutoFallbackChain(params: {
+  cfg?: OpenClawConfig;
+  defaultProvider: string;
+}): AutoFallbackModelRef[] {
+  const model = params.cfg?.agents?.defaults?.model;
+  const raws = [resolveAgentModelPrimaryValue(model), ...resolveAgentModelFallbackValues(model)];
+  const chain: AutoFallbackModelRef[] = [];
+  const seen = new Set<string>();
+  for (const raw of raws) {
+    if (!raw) {
+      continue;
+    }
+    const ref = parseModelRef(raw, params.defaultProvider);
+    if (!ref) {
+      continue;
+    }
+    const key = `${ref.provider}/${ref.model}`;
+    if (seen.has(key)) {
+      continue;
+    }
+    seen.add(key);
+    chain.push({ provider: ref.provider, model: ref.model });
+  }
+  return chain;
+}
+
+/**
+ * A ref is available when at least one of its provider's auth profiles is not in
+ * a (model-scoped) cooldown. Providers that track no auth profiles (e.g. CLI
+ * providers) resolve to an empty order; treat those as available so the climb is
+ * not permanently blocked — the downstream selection walk re-validates on attempt.
+ */
+function isModelAvailable(params: {
+  cfg?: OpenClawConfig;
+  store: AuthProfileStore;
+  ref: AutoFallbackModelRef;
+}): boolean {
+  const order = resolveAuthProfileOrder({
+    cfg: params.cfg,
+    store: params.store,
+    provider: params.ref.provider,
+  });
+  if (order.length === 0) {
+    return true;
+  }
+  return order.some(
+    (profileId) => !isProfileInCooldown(params.store, profileId, undefined, params.ref.model),
+  );
+}
+
+/**
+ * Pure re-promotion decision against an explicit auth-profile store. Exposed so
+ * the config-chain + cooldown-availability wiring can be tested without touching
+ * the on-disk store; production callers use `buildAutoFallbackRepromotionResolver`.
+ */
+export function selectAutoFallbackRepromotionTarget(params: {
+  cfg?: OpenClawConfig;
+  defaultProvider: string;
+  current: AutoFallbackModelRef;
+  store: AuthProfileStore;
+}): AutoFallbackModelRef | undefined {
+  const chain = buildAutoFallbackChain({
+    cfg: params.cfg,
+    defaultProvider: params.defaultProvider,
+  });
+  if (chain.length === 0) {
+    return undefined;
+  }
+  return resolveAutoFallbackRepromotionTarget({
+    chain,
+    current: params.current,
+    isAvailable: (ref) => isModelAvailable({ cfg: params.cfg, store: params.store, ref }),
+  });
+}
+
+/**
+ * Build the closure passed to `resolveRunAfterAutoFallbackPrimaryProbeRecheck`.
+ * The auth-profile store is loaded lazily on the first candidate check and reused
+ * across the rest of that recheck so a single turn reads it once.
+ */
+export function buildAutoFallbackRepromotionResolver(params: {
+  cfg?: OpenClawConfig;
+  agentDir?: string;
+  defaultProvider: string;
+}): AutoFallbackRepromotionResolver {
+  const chain = buildAutoFallbackChain({
+    cfg: params.cfg,
+    defaultProvider: params.defaultProvider,
+  });
+  if (chain.length === 0) {
+    return () => undefined;
+  }
+  let store: AuthProfileStore | undefined;
+  return (current) => {
+    store ??= ensureAuthProfileStore(params.agentDir, { allowKeychainPrompt: false });
+    return selectAutoFallbackRepromotionTarget({
+      cfg: params.cfg,
+      defaultProvider: params.defaultProvider,
+      current,
+      store,
+    });
+  };
+}

--- a/src/auto-reply/reply/auto-fallback-repromotion.ts
+++ b/src/auto-reply/reply/auto-fallback-repromotion.ts
@@ -8,10 +8,7 @@
  * fallback tier climbs back to the highest available tier once a middle tier
  * recovers, instead of sticking on the bottom of the chain.
  */
-import {
-  resolveAutoFallbackRepromotionTarget,
-  type AutoFallbackModelRef,
-} from "../../agents/agent-scope.js";
+import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import {
   ensureAuthProfileStore,
   isProfileInCooldown,
@@ -25,6 +22,61 @@ import {
 import type { OpenClawConfig } from "../../config/types.js";
 
 type AuthProfileStore = ReturnType<typeof ensureAuthProfileStore>;
+
+export type AutoFallbackModelRef = {
+  provider: string;
+  model: string;
+};
+
+/**
+ * Picks the highest-priority candidate ranked strictly above the current auto-fallback
+ * selection that is currently available (not in cooldown). Returns undefined when nothing
+ * better than the current selection is available, so the session stays put.
+ *
+ * Why this exists: making auth-profile cooldowns per-model removed the coarse side effect where
+ * a primary rate-limit also suspended sibling models sharing that profile (e.g. gpt-5.5 limiting
+ * also disabled gpt-5.3-codex-spark), which used to force the chain down to the next provider tier
+ * and looked like "fallback upwards" working. With per-model scoping a session that pins to a low
+ * tier never re-walks up on its own. This restores the climb explicitly: walk from the top of the
+ * ordered chain and return the first available tier above `current`. A session stuck on spark while
+ * gpt-5.5 is still rate-limited re-promotes to an available sonnet instead of sticking on spark, and
+ * jumps straight back to gpt-5.5 once its window clears. Returning undefined above the current tier
+ * is what prevents thrash: once landed on the best available tier, no strictly-better tier exists.
+ */
+export function resolveAutoFallbackRepromotionTarget(params: {
+  chain: readonly AutoFallbackModelRef[];
+  current: AutoFallbackModelRef;
+  isAvailable: (ref: AutoFallbackModelRef) => boolean;
+}): AutoFallbackModelRef | undefined {
+  const normRef = (ref: AutoFallbackModelRef) => ({
+    provider: normalizeOptionalString(ref.provider) ?? "",
+    model: normalizeOptionalString(ref.model) ?? "",
+  });
+  const current = normRef(params.current);
+  if (!current.provider || !current.model) {
+    return undefined;
+  }
+  const sameRef = (
+    a: { provider: string; model: string },
+    b: { provider: string; model: string },
+  ) => a.provider === b.provider && a.model === b.model;
+  const currentIndex = params.chain.findIndex((ref) => sameRef(normRef(ref), current));
+  // Current selection absent from the chain: treat the whole chain as ranked above it.
+  const ceiling = currentIndex === -1 ? params.chain.length : currentIndex;
+  for (let i = 0; i < ceiling; i += 1) {
+    const candidate = normRef(params.chain[i]!);
+    if (!candidate.provider || !candidate.model) {
+      continue;
+    }
+    if (sameRef(candidate, current)) {
+      continue;
+    }
+    if (params.isAvailable({ provider: candidate.provider, model: candidate.model })) {
+      return { provider: candidate.provider, model: candidate.model };
+    }
+  }
+  return undefined;
+}
 
 export type AutoFallbackRepromotionResolver = (
   current: AutoFallbackModelRef,

--- a/src/auto-reply/reply/followup-runner.ts
+++ b/src/auto-reply/reply/followup-runner.ts
@@ -88,6 +88,7 @@ import {
   resolveRunFastModeForFallbackCandidate,
   resolveRunAuthProfile,
 } from "./agent-runner-utils.js";
+import { buildAutoFallbackRepromotionResolver } from "./auto-fallback-repromotion.js";
 import {
   createCompactionHookNoticePayload,
   createCompactionNoticePayload,
@@ -593,6 +594,11 @@ export function createFollowupRunner(params: {
         run,
         entry: activeSessionEntry,
         sessionKey: replySessionKey,
+        resolveRepromotionTarget: buildAutoFallbackRepromotionResolver({
+          cfg: run.config,
+          agentDir: run.agentDir,
+          defaultProvider: run.autoFallbackPrimaryProbe?.provider ?? run.provider,
+        }),
       });
       if (run !== effectiveQueued.run) {
         effectiveQueued = { ...effectiveQueued, run };

--- a/src/auto-reply/reply/get-reply-run.media-only.test.ts
+++ b/src/auto-reply/reply/get-reply-run.media-only.test.ts
@@ -2043,6 +2043,11 @@ describe("runPreparedReply media-only handling", () => {
     const call = requireLastRunReplyAgentCall();
     expect(call?.followupRun.run.authProfileId).toBe("profile-after-wait");
     expect(vi.mocked(resolveSessionAuthProfileOverride)).toHaveBeenCalledTimes(1);
+    // Regression (#99810): auto-reply must thread the active model so a sibling
+    // model's cooldown is not treated as a profile-wide block.
+    expect(vi.mocked(resolveSessionAuthProfileOverride)).toHaveBeenCalledWith(
+      expect.objectContaining({ model: "claude-opus-4-1" }),
+    );
   });
 
   it("re-resolves same-session ownership after session-id rotation during async prep", async () => {

--- a/src/auto-reply/reply/get-reply-run.ts
+++ b/src/auto-reply/reply/get-reply-run.ts
@@ -1186,6 +1186,7 @@ export async function runPreparedReply(
     const resolvedAuthProfileId = await resolveSessionAuthProfileOverride({
       cfg,
       provider,
+      model,
       acceptedProviderIds: resolveAcceptedAuthProfileProviders(),
       agentDir,
       sessionEntry: authSessionEntry,

--- a/src/cron/isolated-agent.auth-profile-propagation.test.ts
+++ b/src/cron/isolated-agent.auth-profile-propagation.test.ts
@@ -91,5 +91,10 @@ describe("runCronIsolatedAgentTurn auth profile propagation (#20624, #90991)", (
     expect(getEmbeddedAgentParams()).toMatchObject({
       authProfileId: "openrouter:default",
     });
+    // Regression (#99810): cron must thread the active model so a sibling
+    // model's cooldown is not treated as a profile-wide block.
+    expect(resolveSessionAuthProfileOverrideMock).toHaveBeenCalledWith(
+      expect.objectContaining({ model: "moonshotai/kimi-k2.5" }),
+    );
   });
 });

--- a/src/cron/isolated-agent/run.ts
+++ b/src/cron/isolated-agent/run.ts
@@ -982,6 +982,7 @@ async function prepareCronRunContext(params: {
             // store and key that persistence will later write.
             cfg: cfgWithAgentDefaults,
             provider,
+            model,
             acceptedProviderIds: listOpenAIAuthProfileProvidersForAgentRuntime({
               provider,
               harnessRuntime: resolveAgentHarnessPolicy({


### PR DESCRIPTION
## What Problem This Solves

Closes #99809. When OpenAI's Codex WHAM usage probe returns a `subscription_limit` block for one model (e.g. `gpt-5.5`), OpenClaw currently blocks the entire shared auth profile — including other models on that same profile with a genuinely separate quota pool (e.g. a Codex "spark" variant). The `blockedModel` field already existed in the type system for exactly this scoping, but the WHAM write path (`applyWhamCooldownResult`) discarded it (`blockedModel: void 0`), and the gating read paths (`resolveProfileUnusableUntil`, `shouldBypassModelScopedCooldown`, `isProfileInCooldown`, `getSoonestCooldownExpiry`) never consulted it — unlike the existing `cooldownModel` scoping used for `rate_limit`/`timeout`.

## Changes

- `applyWhamCooldownResult` now threads `modelId` into `blockedModel` instead of discarding it.
- `resolveProfileUnusableUntil`, `shouldBypassModelScopedCooldown`, `isProfileInCooldown`, and `getSoonestCooldownExpiry` now respect `blockedModel` scoping, mirroring the existing `cooldownModel` scoping already used for `rate_limit`/`timeout`.
- Added `mergeBlockedModel`: when a new `subscription_limit` block lands while an existing `blockedUntil` is still active on the same profile, it only narrows `blockedModel` to the incoming model if the existing block already agreed with it (same model, or no existing active block). Otherwise — existing block is unscoped, or scoped to a *different* model than the incoming one — it widens to profile-wide (`undefined`) so neither model's coverage is silently dropped.

## Evidence

Real `vitest` run against this branch (not a hand-mirrored script), scoped to the affected file:

```
$ node scripts/run-vitest.mjs run --config test/vitest/vitest.agents-core.config.ts src/agents/auth-profiles/usage.test.ts

 ✓ |agents-core| ... scopes a subscription_limit block to the failing model so other models on the same profile stay usable
 ✓ |agents-core| ... widens to profile-wide when a new model-scoped block lands on top of an already-active unscoped block
 ✓ |agents-core| ... widens to profile-wide when a new block for a different model conflicts with an existing model-scoped block
 ✓ |agents-core| ... keeps a repeated block for the same model scoped to just that model

 Test Files  1 passed (1)
      Tests  78 passed (78)
   Duration  7.04s
```

Covers the three review asks directly:
- **Real runtime proof** — output above is a live `vitest` run against the actual patched `usage.ts`, not a mirrored script.
- **Existing `blockedUntil` + `blockedModel` combo** — new tests seed a store with an already-active `blockedUntil` (both unscoped and model-scoped) and assert on the resulting `blockedModel` after a second block lands.
- **Old unscoped/conflicting-model blocks stay profile-wide** — the two "widens to profile-wide" tests assert `blockedModel` is `undefined` after merging with a pre-existing unscoped block or a conflicting model-scoped block, and that `isProfileInCooldown` still returns `true` for every previously-covered model plus the profile-wide check.

