### PR TITLE
fix(google): bound OAuth response reads to prevent OOM

### DIFF
--- a/extensions/google/oauth.project.ts
+++ b/extensions/google/oauth.project.ts
@@ -1,4 +1,5 @@
 // Google plugin module implements oauth.project behavior.
+import { readProviderJsonResponse } from "openclaw/plugin-sdk/provider-http";
 import { fetchWithTimeout } from "./oauth.http.js";
 import {
   CODE_ASSIST_ENDPOINT_PROD,
@@ -21,7 +22,10 @@ async function getUserEmail(accessToken: string): Promise<string | undefined> {
       headers: { Authorization: `Bearer ${accessToken}` },
     });
     if (response.ok) {
-      const data = (await response.json()) as { email?: string };
+      const data = await readProviderJsonResponse<{ email?: string }>(
+        response,
+        "Google OAuth userinfo",
+      );
       return data.email;
     }
   } catch {
@@ -74,10 +78,10 @@ async function pollOperation(
     if (!response.ok) {
       continue;
     }
-    const data = (await response.json()) as {
+    const data = await readProviderJsonResponse<{
       done?: boolean;
       response?: { cloudaicompanionProject?: { id?: string } };
-    };
+    }>(response, "Google OAuth pollOperation");
     if (data.done) {
       return data;
     }
@@ -135,7 +139,10 @@ async function discoverProject(accessToken: string): Promise<string> {
       });
 
       if (!response.ok) {
-        const errorPayload = await response.json().catch(() => null);
+        const errorPayload = await readProviderJsonResponse<unknown>(
+          response,
+          "Google OAuth loadCodeAssist",
+        ).catch(() => null);
         if (isVpcScAffected(errorPayload)) {
           data = { currentTier: { id: TIER_STANDARD } };
           activeEndpoint = endpoint;
@@ -146,7 +153,7 @@ async function discoverProject(accessToken: string): Promise<string> {
         continue;
       }
 
-      data = (await response.json()) as typeof data;
+      data = await readProviderJsonResponse<typeof data>(response, "Google OAuth loadCodeAssist");
       activeEndpoint = endpoint;
       loadError = undefined;
       break;
@@ -211,11 +218,11 @@ async function discoverProject(accessToken: string): Promise<string> {
     throw new Error(`onboardUser failed: ${onboardResponse.status} ${onboardResponse.statusText}`);
   }
 
-  let lro = (await onboardResponse.json()) as {
+  let lro = await readProviderJsonResponse<{
     done?: boolean;
     name?: string;
     response?: { cloudaicompanionProject?: { id?: string } };
-  };
+  }>(onboardResponse, "Google OAuth onboardUser");
 
   if (!lro.done && lro.name) {
     lro = await pollOperation(activeEndpoint, lro.name, headers);

--- a/extensions/google/oauth.token.ts
+++ b/extensions/google/oauth.token.ts
@@ -3,7 +3,10 @@ import {
   asDateTimestampMs,
   resolveExpiresAtMsFromDurationSeconds,
 } from "openclaw/plugin-sdk/number-runtime";
-import { readResponseTextLimited } from "openclaw/plugin-sdk/provider-http";
+import {
+  readProviderJsonResponse,
+  readResponseTextLimited,
+} from "openclaw/plugin-sdk/provider-http";
 import { resolveOAuthClientConfig } from "./oauth.credentials.js";
 import { fetchWithTimeout } from "./oauth.http.js";
 import { resolveGoogleOAuthIdentity, resolveGooglePersonalOAuthIdentity } from "./oauth.project.js";
@@ -36,11 +39,11 @@ async function requestTokenGrant(body: URLSearchParams): Promise<{
     throw new Error(`Token exchange failed: ${errorText}`);
   }
 
-  return (await response.json()) as {
+  return await readProviderJsonResponse<{
     access_token?: string;
     refresh_token?: string;
     expires_in?: unknown;
-  };
+  }>(response, "Google OAuth token grant");
 }
 
 function resolveExpiredTokenTimestampMs(nowMs: number): number {

--- a/extensions/google/vertex-adc.ts
+++ b/extensions/google/vertex-adc.ts
@@ -9,6 +9,7 @@ import {
   resolveExpiresAtMsFromDurationMs,
   resolveExpiresAtMsFromDurationSeconds,
 } from "openclaw/plugin-sdk/number-runtime";
+import { readResponseWithLimit } from "openclaw/plugin-sdk/response-limit-runtime";
 import { normalizeOptionalString } from "openclaw/plugin-sdk/string-coerce-runtime";
 
 type GoogleAuthorizedUserCredentials = {
@@ -46,6 +47,7 @@ const GOOGLE_VERTEX_OAUTH_SCOPE = "https://www.googleapis.com/auth/cloud-platfor
 const GOOGLE_VERTEX_TOKEN_EXPIRY_BUFFER_MS = 60_000;
 const GOOGLE_VERTEX_DEFAULT_TOKEN_LIFETIME_SECONDS = 3600;
 const GOOGLE_VERTEX_AUTHLIB_TOKEN_CACHE_MS = 5 * 60_000;
+const GOOGLE_OAUTH_TOKEN_RESPONSE_MAX_BYTES = 1024 * 1024;
 
 let cachedGoogleVertexAuthorizedUserToken: GoogleVertexAuthorizedUserToken | undefined;
 let cachedGoogleAuthClient:
@@ -277,7 +279,10 @@ async function refreshGoogleVertexAuthorizedUserAccessToken(params: {
 async function readGoogleOauthTokenResponsePayload(
   response: Response,
 ): Promise<GoogleOauthTokenResponsePayload | undefined> {
-  const bytes = Buffer.from(await response.arrayBuffer());
+  const bytes = await readResponseWithLimit(response, GOOGLE_OAUTH_TOKEN_RESPONSE_MAX_BYTES, {
+    onOverflow: ({ maxBytes }) =>
+      new Error(`Google OAuth token response exceeds ${maxBytes} bytes`),
+  });
   const text = decodeGoogleOauthTokenResponseBody(bytes, response.headers.get("content-encoding"));
   if (!text.trim()) {
     return undefined;

--- a/extensions/google/vertex-adc.ts
+++ b/extensions/google/vertex-adc.ts
@@ -297,7 +297,9 @@ async function readGoogleOauthTokenResponsePayload(
 function decodeGoogleOauthTokenResponseBody(bytes: Buffer, contentEncoding: string | null): string {
   if (shouldGunzipGoogleOauthTokenResponse(bytes, contentEncoding)) {
     try {
-      return gunzipSync(bytes).toString("utf8");
+      return gunzipSync(bytes, { maxOutputLength: GOOGLE_OAUTH_TOKEN_RESPONSE_MAX_BYTES }).toString(
+        "utf8",
+      );
     } catch {
       return bytes.toString("utf8");
     }


### PR DESCRIPTION
## Summary

**Problem**: Three Google OAuth modules read HTTP response bodies without size limits, creating OOM risk when upstream services return oversized or malicious payloads. Additionally, `gunzipSync` in the Vertex ADC parser lacks a decompressed-output cap, so a small compressed payload can still inflate past the wire limit.

**Solution**: Replace all unbounded `response.arrayBuffer()`, `.json()` calls with bounded SDK helpers (`readResponseWithLimit`, `readProviderJsonResponse`). Add `maxOutputLength` to `gunzipSync` to cap decompressed output at the same 1 MB bound.

**What changed**: `extensions/google/vertex-adc.ts`, `extensions/google/oauth.token.ts`, `extensions/google/oauth.project.ts` — 3 files, +27/-12 lines.
- Wire reads bounded via SDK helpers (7 call sites)
- `gunzipSync` bounded via `maxOutputLength: GOOGLE_OAUTH_TOKEN_RESPONSE_MAX_BYTES`
- Token, project, and onboarding response paths all covered

**What did NOT change**: No behavior change for well-formed responses under the size limits. No API or config surface changes. No dependency additions.

## What Problem This Solves

7 call sites across 3 files consume unbounded HTTP response bodies. This is the same unbounded-read class fixed across 30+ providers via the Plugin SDK, but the Google OAuth paths were missed.

Additionally, the Vertex ADC gzip decoder could amplify a small compressed payload (under the 1 MB wire cap) into an arbitrarily large decompressed buffer, leaving an OOM path open even after the wire cap.

## Why This Change Was Made

The existing `readProviderJsonResponse` and `readResponseWithLimit` helpers already ship in the Plugin SDK with a default 16 MB cap. Using them here aligns with the established bounded-read pattern. The `maxOutputLength` option on `gunzipSync` (Node 15+) closes the decompression amplification path that the wire cap alone cannot address.

## Real behavior proof

**Behavior addressed**: Bounded HTTP response reads and bounded gzip decompression for Google OAuth HTTP paths.

**BEFORE FIX — unbounded `response.arrayBuffer()` reads entire body into memory:**
```typescript
const bytes = Buffer.from(await response.arrayBuffer());
```

**AFTER FIX — bounded read with 1 MB cap and overflow error:**
```typescript
const bytes = await readResponseWithLimit(response, GOOGLE_OAUTH_TOKEN_RESPONSE_MAX_BYTES, {
  onOverflow: ({ maxBytes }) =>
    new Error(`Google OAuth token response exceeds ${maxBytes} bytes`),
});
```

**BEFORE FIX — unbounded `gunzipSync` allocates full decompressed output:**
```typescript
return gunzipSync(bytes).toString("utf8");
```

**AFTER FIX — bounded decompression with `maxOutputLength`:**
```typescript
return gunzipSync(bytes, { maxOutputLength: GOOGLE_OAUTH_TOKEN_RESPONSE_MAX_BYTES }).toString("utf8");
```

**Real environment tested**: Linux x86_64, Node v24.13.1.

**Exact steps or command run after this patch**:
```bash
# Unit tests
pnpm test extensions/google -- --reporter verbose
pnpm test:changed

# L2 proof: bounded gzip prevents decompression bomb
node evidence/pr-99812/bounded-gzip-proof.mjs

# L2 proof: loopback HTTP shows oversized response rejection
node evidence/pr-99812/bounded-http-proof.mjs
```

**After-fix evidence**: L2 runtime proof with loopback HTTP server and decompression bomb:
```terminal_output
=== Bounded gzip decompression proof ===
Normal token response: 76 bytes uncompressed
  ✓ bounded: decompressed 76 bytes, parsed OK
Decompression bomb: 2068 bytes compressed → 2097153 bytes uncompressed
  unbounded gunzipSync: allocated 2097153 bytes (OOM risk)
  bounded gunzipSync: rejected — Cannot create a Buffer larger than 1048576 bytes

=== Bounded HTTP read proof ===
Normal response: 46 bytes — ✓ bounded read OK, parsed
Oversized response: caught — Response exceeds 1048576 bytes
  ✓ bounded read correctly rejected the oversized response
```

**Unit tests**:
```terminal_output
 ✓ |extension-providers| extensions/google/... (28 test files, 378 tests passed)
 ✓ |extension-providers| test:changed (15 test files, 228 tests passed)
```

**Observed result after the fix**: All tests pass. Both loopback proof scripts confirm oversized responses and decompression bombs are safely rejected at the 1 MB boundary. Normal-sized responses pass through unchanged.

**What was not tested**: Actual Google OAuth HTTP round-trips (requires live credentials). The SDK helpers `readResponseWithLimit` and `readProviderJsonResponse` are integration-tested in `src/agents/provider-http-errors.test.ts` and `packages/media-core/src/read-response-with-limit.test.ts`. This PR only swaps the call sites and adds a `maxOutputLength` option, preserving all existing error handling and test seams.

## Risk checklist

merge-risk: Low

- [x] Low risk — bounded-read wrapper replaces unbounded call with same return type and compatible error semantics
- [x] Decompression bomb path closed via `maxOutputLength` on `gunzipSync`
- [x] No behavior change for normal-sized responses under the cap
- [x] No API, config, or dependency changes
- [x] L2 runtime proof with loopback HTTP server (oversized response rejection) and decompression bomb (gzip amplification blocked)
- [x] Existing tests green (28 test files, 378 tests; 15 test:changed files, 228 tests)
