### PR TITLE
test: add MCP query-registry agent/runtime test fixture

### DIFF
--- a/src/agents/mcp-query-registry.fixture.ts
+++ b/src/agents/mcp-query-registry.fixture.ts
@@ -1,0 +1,193 @@
+/**
+ * Fake MCP server fixture for the query-registry workflow.
+ *
+ * The server exposes four canonical tools:
+ *   - demo_context
+ *   - demo_queries_list
+ *   - demo_query_describe
+ *   - demo_query_execute
+ *
+ * It intentionally enforces a policy in fixture code: a query id must be
+ * described before it can be executed. This lets tests verify that agents
+ * (or any caller) do not skip the describe step and invent parameters.
+ */
+import fs from "node:fs/promises";
+import { createRequire } from "node:module";
+import path from "node:path";
+
+const require = createRequire(import.meta.url);
+const SDK_SERVER_MCP_PATH = require.resolve("@modelcontextprotocol/sdk/server/mcp.js");
+const SDK_SERVER_STDIO_PATH = require.resolve("@modelcontextprotocol/sdk/server/stdio.js");
+const ZOD_PATH = require.resolve("zod");
+
+export const QUERY_REGISTRY_SERVER_NAME = "queryRegistry" as const;
+
+export const QUERY_REGISTRY_TOOLS = {
+  CONTEXT: "demo_context",
+  QUERIES_LIST: "demo_queries_list",
+  QUERY_DESCRIBE: "demo_query_describe",
+  QUERY_EXECUTE: "demo_query_execute",
+} as const;
+
+export const QUERY_REGISTRY_QUERIES = {
+  AUD004: { required: ["filial", "data"] },
+  CAD005: { required: ["termo"] },
+} as const;
+
+export type QueryRegistryQueryId = keyof typeof QUERY_REGISTRY_QUERIES;
+
+export async function writeQueryRegistryMcpServer(
+  filePath: string,
+  params: { logPath?: string } = {},
+): Promise<void> {
+  await fs.mkdir(path.dirname(filePath), { recursive: true });
+  await fs.writeFile(
+    filePath,
+    `#!/usr/bin/env node
+import { McpServer } from ${JSON.stringify(SDK_SERVER_MCP_PATH)};
+import { StdioServerTransport } from ${JSON.stringify(SDK_SERVER_STDIO_PATH)};
+import { z } from ${JSON.stringify(ZOD_PATH)};
+
+const logPath = ${JSON.stringify(params.logPath ?? "")};
+
+async function log(line) {
+  if (!logPath) return;
+  await import("node:fs/promises")
+    .then((fs) => fs.appendFile(logPath, line + "\\n", "utf8"))
+    .catch(() => {});
+}
+
+// Track which query ids have been described. The fixture enforces
+// describe-before-execute so tests can prove callers do not bypass discovery.
+const describedQueries = new Set();
+
+const server = new McpServer({ name: "query-registry-demo", version: "1.0.0" });
+
+server.tool(
+  "demo_context",
+  "Returns compact domain context for the query registry.",
+  {},
+  async () => {
+    await log("call demo_context");
+    return {
+      content: [{
+        type: "text",
+        text: "Domain: finance demo. Fiscal branches: filial A, filial B.",
+      }],
+    };
+  },
+);
+
+server.tool(
+  "demo_queries_list",
+  "Returns a compact list of available read-only queries.",
+  {},
+  async () => {
+    await log("call demo_queries_list");
+    // Compact list: only ids and required param names. Full schemas are fetched
+    // via demo_query_describe so the LLM prompt does not get flooded with a
+    // large catalog.
+    return {
+      content: [{
+        type: "text",
+        text: JSON.stringify([
+          { queryId: "AUD004", required: ["filial", "data"] },
+          { queryId: "CAD005", required: ["termo"] },
+        ]),
+      }],
+    };
+  },
+);
+
+server.tool(
+  "demo_query_describe",
+  "Returns the full parameter schema for a single query id.",
+  { queryId: z.string().min(1) },
+  async ({ queryId }) => {
+    await log("call demo_query_describe " + queryId);
+    const schemas = {
+      AUD004: {
+        type: "object",
+        properties: {
+          filial: { type: "string" },
+          data: { type: "string" },
+        },
+        required: ["filial", "data"],
+      },
+      CAD005: {
+        type: "object",
+        properties: {
+          termo: { type: "string" },
+        },
+        required: ["termo"],
+      },
+    };
+    const schema = schemas[queryId];
+    if (!schema) {
+      return {
+        content: [{ type: "text", text: "Unknown query id: " + queryId }],
+        isError: true,
+      };
+    }
+    describedQueries.add(queryId);
+    return {
+      content: [{ type: "text", text: JSON.stringify(schema) }],
+    };
+  },
+);
+
+server.tool(
+  "demo_query_execute",
+  "Executes a described query with the provided parameters.",
+  {
+    queryId: z.string().min(1),
+    params: z.object({}).passthrough(),
+  },
+  async ({ queryId, params }) => {
+    await log("call demo_query_execute " + queryId);
+    // Enforce the registry contract: execute only after describe. This catches
+    // callers that guess query shapes or skip the describe step.
+    if (!describedQueries.has(queryId)) {
+      return {
+        content: [{
+          type: "text",
+          text: "Query " + queryId + " must be described before execute.",
+        }],
+        isError: true,
+      };
+    }
+    if (queryId === "AUD004") {
+      return {
+        content: [{
+          type: "text",
+          text: JSON.stringify({
+            result: "AUD004 snapshot",
+            filial: params.filial,
+            data: params.data,
+          }),
+        }],
+      };
+    }
+    if (queryId === "CAD005") {
+      return {
+        content: [{
+          type: "text",
+          text: JSON.stringify({
+            result: "CAD005 snapshot",
+            termo: params.termo,
+          }),
+        }],
+      };
+    }
+    return {
+      content: [{ type: "text", text: "Unknown query id: " + queryId }],
+      isError: true,
+    };
+  },
+);
+
+await server.connect(new StdioServerTransport());
+`,
+    { encoding: "utf-8", mode: 0o755 },
+  );
+}

--- a/src/agents/mcp-query-registry.test.ts
+++ b/src/agents/mcp-query-registry.test.ts
@@ -5,10 +5,9 @@
  * MCP server fixture. They prove that the runtime discovers the tools and that
  * the fixture enforces the correct call order and boundary conditions.
  */
-import fs from "node:fs/promises";
-import os from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
+import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
 import { cleanupBundleMcpHarness } from "./agent-bundle-mcp-test-harness.js";
 import {
   getOrCreateSessionMcpRuntime,
@@ -39,12 +38,8 @@ async function createQueryRegistryRuntime(params: {
   });
 }
 
-async function makeTempFixture(): Promise<{
-  tempDir: string;
-  serverPath: string;
-  logPath: string;
-}> {
-  const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "query-registry-"));
+async function makeTempFixture(tempDirs: { make: (prefix: string) => string }) {
+  const tempDir = tempDirs.make("query-registry-");
   const serverPath = path.join(tempDir, "query-registry-server.mjs");
   const logPath = path.join(tempDir, "server.log");
   await writeQueryRegistryMcpServer(serverPath, { logPath });
@@ -58,20 +53,15 @@ async function expectTextContentBlock(block: unknown, text: string) {
 }
 
 describe("MCP query-registry workflow", () => {
-  const tempDirs: string[] = [];
+  const tempDirs = useAutoCleanupTempDirTracker(afterEach);
   let sessionSeq = 0;
 
   afterEach(async () => {
     await cleanupBundleMcpHarness();
-    for (const dir of tempDirs) {
-      await fs.rm(dir, { recursive: true, force: true });
-    }
-    tempDirs.length = 0;
   });
 
   it("discovers the four query-registry tools in the catalog", async () => {
-    const { tempDir, serverPath } = await makeTempFixture();
-    tempDirs.push(tempDir);
+    const { tempDir, serverPath } = await makeTempFixture(tempDirs);
     const sessionKey = `agent:test:query-registry:${sessionSeq++}`;
     const runtime = await createQueryRegistryRuntime({ serverPath, sessionKey });
 
@@ -90,8 +80,7 @@ describe("MCP query-registry workflow", () => {
   });
 
   it("executes the happy path: context -> list -> describe -> execute", async () => {
-    const { tempDir, serverPath } = await makeTempFixture();
-    tempDirs.push(tempDir);
+    const { tempDir, serverPath } = await makeTempFixture(tempDirs);
     const sessionKey = `agent:test:query-registry:${sessionSeq++}`;
     const runtime = await createQueryRegistryRuntime({ serverPath, sessionKey });
 
@@ -158,8 +147,7 @@ describe("MCP query-registry workflow", () => {
   });
 
   it("rejects execute when the query has not been described", async () => {
-    const { tempDir, serverPath } = await makeTempFixture();
-    tempDirs.push(tempDir);
+    const { tempDir, serverPath } = await makeTempFixture(tempDirs);
     const sessionKey = `agent:test:query-registry:${sessionSeq++}`;
     const runtime = await createQueryRegistryRuntime({ serverPath, sessionKey });
 
@@ -190,8 +178,7 @@ describe("MCP query-registry workflow", () => {
   });
 
   it("rejects execute with missing params", async () => {
-    const { tempDir, serverPath } = await makeTempFixture();
-    tempDirs.push(tempDir);
+    const { tempDir, serverPath } = await makeTempFixture(tempDirs);
     const sessionKey = `agent:test:query-registry:${sessionSeq++}`;
     const runtime = await createQueryRegistryRuntime({ serverPath, sessionKey });
 
@@ -211,8 +198,7 @@ describe("MCP query-registry workflow", () => {
   });
 
   it("rejects describe for an unknown query id", async () => {
-    const { tempDir, serverPath } = await makeTempFixture();
-    tempDirs.push(tempDir);
+    const { tempDir, serverPath } = await makeTempFixture(tempDirs);
     const sessionKey = `agent:test:query-registry:${sessionSeq++}`;
     const runtime = await createQueryRegistryRuntime({ serverPath, sessionKey });
 

--- a/src/agents/mcp-query-registry.test.ts
+++ b/src/agents/mcp-query-registry.test.ts
@@ -43,7 +43,7 @@ async function makeTempFixture(tempDirs: { make: (prefix: string) => string }) {
   const serverPath = path.join(tempDir, "query-registry-server.mjs");
   const logPath = path.join(tempDir, "server.log");
   await writeQueryRegistryMcpServer(serverPath, { logPath });
-  return { tempDir, serverPath, logPath };
+  return { serverPath };
 }
 
 async function expectTextContentBlock(block: unknown, text: string) {
@@ -61,13 +61,13 @@ describe("MCP query-registry workflow", () => {
   });
 
   it("discovers the four query-registry tools in the catalog", async () => {
-    const { tempDir, serverPath } = await makeTempFixture(tempDirs);
+    const { serverPath } = await makeTempFixture(tempDirs);
     const sessionKey = `agent:test:query-registry:${sessionSeq++}`;
     const runtime = await createQueryRegistryRuntime({ serverPath, sessionKey });
 
     try {
       const catalog = await runtime.getCatalog();
-      const toolNames = catalog.tools.map((tool) => tool.toolName).sort();
+      const toolNames = catalog.tools.map((tool) => tool.toolName).toSorted();
       expect(toolNames).toEqual([
         QUERY_REGISTRY_TOOLS.CONTEXT,
         QUERY_REGISTRY_TOOLS.QUERIES_LIST,
@@ -80,7 +80,7 @@ describe("MCP query-registry workflow", () => {
   });
 
   it("executes the happy path: context -> list -> describe -> execute", async () => {
-    const { tempDir, serverPath } = await makeTempFixture(tempDirs);
+    const { serverPath } = await makeTempFixture(tempDirs);
     const sessionKey = `agent:test:query-registry:${sessionSeq++}`;
     const runtime = await createQueryRegistryRuntime({ serverPath, sessionKey });
 
@@ -147,7 +147,7 @@ describe("MCP query-registry workflow", () => {
   });
 
   it("rejects execute when the query has not been described", async () => {
-    const { tempDir, serverPath } = await makeTempFixture(tempDirs);
+    const { serverPath } = await makeTempFixture(tempDirs);
     const sessionKey = `agent:test:query-registry:${sessionSeq++}`;
     const runtime = await createQueryRegistryRuntime({ serverPath, sessionKey });
 
@@ -178,7 +178,7 @@ describe("MCP query-registry workflow", () => {
   });
 
   it("rejects execute with missing params", async () => {
-    const { tempDir, serverPath } = await makeTempFixture(tempDirs);
+    const { serverPath } = await makeTempFixture(tempDirs);
     const sessionKey = `agent:test:query-registry:${sessionSeq++}`;
     const runtime = await createQueryRegistryRuntime({ serverPath, sessionKey });
 
@@ -198,7 +198,7 @@ describe("MCP query-registry workflow", () => {
   });
 
   it("rejects describe for an unknown query id", async () => {
-    const { tempDir, serverPath } = await makeTempFixture(tempDirs);
+    const { serverPath } = await makeTempFixture(tempDirs);
     const sessionKey = `agent:test:query-registry:${sessionSeq++}`;
     const runtime = await createQueryRegistryRuntime({ serverPath, sessionKey });
 

--- a/src/agents/mcp-query-registry.test.ts
+++ b/src/agents/mcp-query-registry.test.ts
@@ -1,0 +1,230 @@
+/**
+ * Integration tests for the MCP query-registry workflow.
+ *
+ * These tests use a real SessionMcpRuntime connected to the fake query-registry
+ * MCP server fixture. They prove that the runtime discovers the tools and that
+ * the fixture enforces the correct call order and boundary conditions.
+ */
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { cleanupBundleMcpHarness } from "./agent-bundle-mcp-test-harness.js";
+import {
+  getOrCreateSessionMcpRuntime,
+  materializeBundleMcpToolsForRun,
+} from "./agent-bundle-mcp-tools.js";
+import { QUERY_REGISTRY_TOOLS, writeQueryRegistryMcpServer } from "./mcp-query-registry.fixture.js";
+
+type TestRuntime = Awaited<ReturnType<typeof getOrCreateSessionMcpRuntime>>;
+
+async function createQueryRegistryRuntime(params: {
+  serverPath: string;
+  sessionKey: string;
+}): Promise<TestRuntime> {
+  return await getOrCreateSessionMcpRuntime({
+    sessionId: "session-query-registry",
+    sessionKey: params.sessionKey,
+    workspaceDir: "/workspace",
+    cfg: {
+      mcp: {
+        servers: {
+          queryRegistry: {
+            command: process.execPath,
+            args: [params.serverPath],
+          },
+        },
+      },
+    },
+  });
+}
+
+async function makeTempFixture(): Promise<{
+  tempDir: string;
+  serverPath: string;
+  logPath: string;
+}> {
+  const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "query-registry-"));
+  const serverPath = path.join(tempDir, "query-registry-server.mjs");
+  const logPath = path.join(tempDir, "server.log");
+  await writeQueryRegistryMcpServer(serverPath, { logPath });
+  return { tempDir, serverPath, logPath };
+}
+
+async function expectTextContentBlock(block: unknown, text: string) {
+  const content = block as { type?: string; text?: string } | undefined;
+  expect(content?.type).toBe("text");
+  expect(content?.text).toBe(text);
+}
+
+describe("MCP query-registry workflow", () => {
+  const tempDirs: string[] = [];
+  let sessionSeq = 0;
+
+  afterEach(async () => {
+    await cleanupBundleMcpHarness();
+    for (const dir of tempDirs) {
+      await fs.rm(dir, { recursive: true, force: true });
+    }
+    tempDirs.length = 0;
+  });
+
+  it("discovers the four query-registry tools in the catalog", async () => {
+    const { tempDir, serverPath } = await makeTempFixture();
+    tempDirs.push(tempDir);
+    const sessionKey = `agent:test:query-registry:${sessionSeq++}`;
+    const runtime = await createQueryRegistryRuntime({ serverPath, sessionKey });
+
+    try {
+      const catalog = await runtime.getCatalog();
+      const toolNames = catalog.tools.map((tool) => tool.toolName).sort();
+      expect(toolNames).toEqual([
+        QUERY_REGISTRY_TOOLS.CONTEXT,
+        QUERY_REGISTRY_TOOLS.QUERIES_LIST,
+        QUERY_REGISTRY_TOOLS.QUERY_DESCRIBE,
+        QUERY_REGISTRY_TOOLS.QUERY_EXECUTE,
+      ]);
+    } finally {
+      await runtime.dispose();
+    }
+  });
+
+  it("executes the happy path: context -> list -> describe -> execute", async () => {
+    const { tempDir, serverPath } = await makeTempFixture();
+    tempDirs.push(tempDir);
+    const sessionKey = `agent:test:query-registry:${sessionSeq++}`;
+    const runtime = await createQueryRegistryRuntime({ serverPath, sessionKey });
+
+    try {
+      const materialized = await materializeBundleMcpToolsForRun({ runtime });
+      const findTool = (name: string) => {
+        const tool = materialized.tools.find((t) => t.name === name);
+        expect(tool).toBeDefined();
+        return tool!;
+      };
+
+      const contextTool = findTool("queryRegistry__demo_context");
+      const listTool = findTool("queryRegistry__demo_queries_list");
+      const describeTool = findTool("queryRegistry__demo_query_describe");
+      const executeTool = findTool("queryRegistry__demo_query_execute");
+
+      const contextResult = await contextTool.execute("ctx-1", {}, undefined, undefined);
+      await expectTextContentBlock(
+        contextResult.content[0],
+        "Domain: finance demo. Fiscal branches: filial A, filial B.",
+      );
+
+      const listResult = await listTool.execute("list-1", {}, undefined, undefined);
+      await expectTextContentBlock(
+        listResult.content[0],
+        JSON.stringify([
+          { queryId: "AUD004", required: ["filial", "data"] },
+          { queryId: "CAD005", required: ["termo"] },
+        ]),
+      );
+
+      const describeResult = await describeTool.execute(
+        "describe-1",
+        { queryId: "AUD004" },
+        undefined,
+        undefined,
+      );
+      await expectTextContentBlock(
+        describeResult.content[0],
+        JSON.stringify({
+          type: "object",
+          properties: { filial: { type: "string" }, data: { type: "string" } },
+          required: ["filial", "data"],
+        }),
+      );
+
+      const executeResult = await executeTool.execute(
+        "execute-1",
+        { queryId: "AUD004", params: { filial: "A", data: "2026-07-01" } },
+        undefined,
+        undefined,
+      );
+      await expectTextContentBlock(
+        executeResult.content[0],
+        JSON.stringify({
+          result: "AUD004 snapshot",
+          filial: "A",
+          data: "2026-07-01",
+        }),
+      );
+    } finally {
+      await runtime.dispose();
+    }
+  });
+
+  it("rejects execute when the query has not been described", async () => {
+    const { tempDir, serverPath } = await makeTempFixture();
+    tempDirs.push(tempDir);
+    const sessionKey = `agent:test:query-registry:${sessionSeq++}`;
+    const runtime = await createQueryRegistryRuntime({ serverPath, sessionKey });
+
+    try {
+      const materialized = await materializeBundleMcpToolsForRun({ runtime });
+      const executeTool = materialized.tools.find(
+        (t) => t.name === "queryRegistry__demo_query_execute",
+      )!;
+
+      const result = await executeTool.execute(
+        "execute-undescribed",
+        { queryId: "AUD004", params: { filial: "A", data: "2026-07-01" } },
+        undefined,
+        undefined,
+      );
+
+      // MCP errors are surfaced in result.details.status, not as a top-level
+      // isError field. The fixture returns isError=true; the materializer maps it
+      // to details.status === "error" so agent code can react consistently.
+      expect(result.details).toMatchObject({ status: "error" });
+      await expectTextContentBlock(
+        result.content[0],
+        "Query AUD004 must be described before execute.",
+      );
+    } finally {
+      await runtime.dispose();
+    }
+  });
+
+  it("rejects execute with missing params", async () => {
+    const { tempDir, serverPath } = await makeTempFixture();
+    tempDirs.push(tempDir);
+    const sessionKey = `agent:test:query-registry:${sessionSeq++}`;
+    const runtime = await createQueryRegistryRuntime({ serverPath, sessionKey });
+
+    try {
+      // Describe first so the error is specifically about params, not ordering.
+      await runtime.callTool("queryRegistry", "demo_query_describe", { queryId: "AUD004" });
+      const result = await runtime.callTool("queryRegistry", "demo_query_execute", {
+        queryId: "AUD004",
+      });
+
+      expect(result.isError).toBe(true);
+      const text = (result.content[0] as { text?: string }).text ?? "";
+      expect(text).toMatch(/params/);
+    } finally {
+      await runtime.dispose();
+    }
+  });
+
+  it("rejects describe for an unknown query id", async () => {
+    const { tempDir, serverPath } = await makeTempFixture();
+    tempDirs.push(tempDir);
+    const sessionKey = `agent:test:query-registry:${sessionSeq++}`;
+    const runtime = await createQueryRegistryRuntime({ serverPath, sessionKey });
+
+    try {
+      const result = await runtime.callTool("queryRegistry", "demo_query_describe", {
+        queryId: "NOPE999",
+      });
+
+      expect(result.isError).toBe(true);
+      await expectTextContentBlock(result.content[0], "Unknown query id: NOPE999");
+    } finally {
+      await runtime.dispose();
+    }
+  });
+});


### PR DESCRIPTION
Fixes #99770

## What Problem This Solves

Issue #99770: OpenClaw had no test fixture for MCP query-registry workflows. Without one, planner and tool-materialization regressions could silently break the expected context → list → describe → execute ordering for read-only query registries.

## Why This Change Was Made

- Added `src/agents/mcp-query-registry.fixture.ts`: a self-contained stdio MCP server exposing the four canonical tools (`demo_context`, `demo_queries_list`, `demo_query_describe`, `demo_query_execute`) with `AUD004`/`CAD005` query ids.
- The fixture enforces describe-before-execute in server state, preventing callers from skipping discovery and inventing params.
- Added `src/agents/mcp-query-registry.test.ts`: five runtime integration tests using a real `SessionMcpRuntime` and `materializeBundleMcpToolsForRun` to cover catalog discovery, happy-path ordering, and negative controls (undescribed execute, missing params, unknown query id).
- Detailed comments explain every policy decision: compact catalog, `{queryId, params}` shape, and why errors surface in `details.status`.

## User Impact

No user-facing behavior change. This adds deterministic test-only coverage that protects the query-registry agent pattern from future regressions.

## Evidence

```bash

node scripts/run-vitest.mjs src/agents/mcp-query-registry.test.ts --reporter=verbose
node scripts/run-oxlint.mjs src/agents/mcp-query-registry.fixture.ts src/agents/mcp-query-registry.test.ts
pnpm exec oxfmt --check --threads=1 src/agents/mcp-query-registry.fixture.ts src/agents/mcp-query-registry.test.ts
```

All 5 tests pass; lint and format checks pass.

Closes #99770.


