### PR TITLE
fix(agents): derive conversation scope from trusted group facts

### DIFF
--- a/src/agents/agent-tools.policy.ts
+++ b/src/agents/agent-tools.policy.ts
@@ -307,6 +307,11 @@ export function resolveTrustedGroupId(params: {
   });
 }
 
+/** True when a server-derived session key names a group/channel conversation. */
+export function sessionKeyNamesGroupConversation(sessionKey?: string | null): boolean {
+  return (resolveGroupContextFromSessionKey(sessionKey).groupIds?.length ?? 0) > 0;
+}
+
 function resolveExplicitProfileAlsoAllow(tools?: OpenClawConfig["tools"]): string[] | undefined {
   return Array.isArray(tools?.alsoAllow) ? tools.alsoAllow : undefined;
 }

--- a/src/agents/conversation-capability-profile.test.ts
+++ b/src/agents/conversation-capability-profile.test.ts
@@ -81,4 +81,58 @@ describe("resolveConversationCapabilityProfile", () => {
     expect(profile.policy.groupPolicy).toEqual({ allow: ["read", "exec"] });
     expect(profile.policy.explicitToolAllowlist).toEqual(["read", "exec"]);
   });
+
+  it("does not classify the conversation as shared from a dropped caller group id", () => {
+    // Non-group session key cannot vouch for the caller-supplied group facts:
+    // the trust check drops them, so scope must stay unknown instead of
+    // reflecting untrusted input that the profile itself publishes as null.
+    const profile = resolveConversationCapabilityProfile({
+      sessionKey: "agent:main:discord:dm:guest",
+      agentId: "main",
+      messageProvider: "discord",
+      groupId: "team",
+      groupChannel: "#general",
+      groupSpace: "guild-1",
+      senderId: "guest",
+    });
+
+    expect(profile.policy.trustedGroup).toEqual({ groupId: null, dropped: true });
+    expect(profile.conversation.groupId).toBeNull();
+    expect(profile.conversation.groupChannel).toBeNull();
+    expect(profile.conversation.groupSpace).toBeNull();
+    expect(profile.conversation.scope).toBe("unknown");
+  });
+
+  it("classifies group-scoped session keys as shared without a live chat type", () => {
+    const profile = resolveConversationCapabilityProfile({
+      sessionKey: "agent:main:whatsapp:group:team",
+      agentId: "main",
+      messageProvider: "whatsapp",
+    });
+
+    expect(profile.conversation.scope).toBe("shared");
+  });
+
+  it("classifies shared scope from the live run session key behind a sandbox policy key", () => {
+    const profile = resolveConversationCapabilityProfile({
+      sessionKey: "agent:main:main",
+      runSessionKey: "agent:main:telegram:group:ops",
+      agentId: "main",
+      messageProvider: "telegram",
+    });
+
+    expect(profile.conversation.scope).toBe("shared");
+  });
+
+  it("keeps trusted caller group facts shared when the session key vouches for them", () => {
+    const profile = resolveConversationCapabilityProfile({
+      sessionKey: "agent:main:whatsapp:group:team",
+      agentId: "main",
+      messageProvider: "whatsapp",
+      groupId: "team",
+    });
+
+    expect(profile.policy.trustedGroup).toEqual({ groupId: "team", dropped: false });
+    expect(profile.conversation.scope).toBe("shared");
+  });
 });

--- a/src/agents/conversation-capability-profile.ts
+++ b/src/agents/conversation-capability-profile.ts
@@ -13,6 +13,7 @@ import {
   resolveInheritedToolPolicyForSession,
   resolveSubagentToolPolicyForSession,
   resolveTrustedGroupId,
+  sessionKeyNamesGroupConversation,
 } from "./agent-tools.policy.js";
 import type { SandboxToolPolicy } from "./sandbox/types.js";
 import { resolveSenderToolPolicy } from "./sender-tool-policy.js";
@@ -185,14 +186,18 @@ export function resolveConversationCapabilityProfile(
     spawnedBy: params.spawnedBy,
     groupId: params.groupId,
   });
+  // Group channel/space labels have no session-bound counterpart to verify
+  // against; mask them whenever the trust check dropped the caller group id.
+  const trustedGroupChannel = trustedGroup.dropped ? null : params.groupChannel;
+  const trustedGroupSpace = trustedGroup.dropped ? null : params.groupSpace;
   const groupPolicy = resolveGroupToolPolicy({
     config: params.config,
     sessionKey: params.sessionKey,
     spawnedBy: params.spawnedBy,
     messageProvider: messageProvider ?? undefined,
     groupId: trustedGroup.groupId,
-    groupChannel: trustedGroup.dropped ? null : params.groupChannel,
-    groupSpace: trustedGroup.dropped ? null : params.groupSpace,
+    groupChannel: trustedGroupChannel,
+    groupSpace: trustedGroupSpace,
     accountId: params.agentAccountId,
     senderId: params.senderId,
     senderName: params.senderName,
@@ -263,7 +268,14 @@ export function resolveConversationCapabilityProfile(
       hasVision: params.modelHasVision,
     },
     conversation: {
-      scope: resolveConversationScope(params),
+      scope: resolveConversationScope({
+        chatType: params.chatType,
+        sessionKey: params.sessionKey,
+        runSessionKey: params.runSessionKey,
+        trustedGroup,
+        groupChannel: trustedGroupChannel,
+        groupSpace: trustedGroupSpace,
+      }),
       chatType: normalizeChatType(params.chatType),
       sessionKey: params.runSessionKey ?? params.sessionKey,
       policySessionKey: params.sessionKey,
@@ -278,8 +290,8 @@ export function resolveConversationCapabilityProfile(
       currentThreadTs: params.currentThreadTs,
       currentMessageId: params.currentMessageId,
       groupId: trustedGroup.groupId,
-      groupChannel: trustedGroup.dropped ? null : params.groupChannel,
-      groupSpace: trustedGroup.dropped ? null : params.groupSpace,
+      groupChannel: trustedGroupChannel,
+      groupSpace: trustedGroupSpace,
       memberRoleIds: params.memberRoleIds,
       spawnedBy: params.spawnedBy,
     },
@@ -338,12 +350,14 @@ export function resolveConversationCapabilityProfile(
   };
 }
 
-function resolveConversationScope(
-  params: Pick<
-    ConversationCapabilityProfileParams,
-    "chatType" | "groupId" | "groupChannel" | "groupSpace"
-  >,
-): ConversationCapabilityScope {
+function resolveConversationScope(params: {
+  chatType?: string;
+  sessionKey?: string;
+  runSessionKey?: string;
+  trustedGroup: { groupId: string | null | undefined; dropped: boolean };
+  groupChannel?: string | null;
+  groupSpace?: string | null;
+}): ConversationCapabilityScope {
   const chatType = normalizeChatType(params.chatType);
   if (chatType === "direct") {
     return "direct";
@@ -351,7 +365,23 @@ function resolveConversationScope(
   if (chatType === "group" || chatType === "channel") {
     return "shared";
   }
-  return params.groupId?.trim() || params.groupChannel?.trim() || params.groupSpace?.trim()
+  // Without a live chat type, classify only from server-derived session keys
+  // and trust-checked group facts. A caller-supplied group id that
+  // resolveTrustedGroupId dropped must not flip an unknown-audience
+  // conversation to "shared": downstream audience and credential decisions
+  // read this field, and the profile already publishes that group as null.
+  if (
+    sessionKeyNamesGroupConversation(params.runSessionKey) ||
+    sessionKeyNamesGroupConversation(params.sessionKey)
+  ) {
+    return "shared";
+  }
+  if (params.trustedGroup.dropped) {
+    return "unknown";
+  }
+  return params.trustedGroup.groupId?.trim() ||
+    params.groupChannel?.trim() ||
+    params.groupSpace?.trim()
     ? "shared"
     : "unknown";
 }


### PR DESCRIPTION
## Summary

`ResolvedConversationCapabilityProfile.conversation.scope` now classifies the conversation audience exclusively from server-verified or trust-checked inputs, in this precedence:

1. Live chat type: `direct` -> `direct`; `group`/`channel` -> `shared`.
2. Server-derived session keys: when `runSessionKey` or `sessionKey` names a group/channel conversation (new `sessionKeyNamesGroupConversation` helper in `src/agents/agent-tools.policy.ts`), scope is `shared` even without a live chat type. This also covers runs whose policy key is a sandbox alias while the live run session is a group.
3. Trust-checked group facts: caller group facts count only when `resolveTrustedGroupId` vouched for them. When the trust check dropped the caller group id, scope resolves `unknown` instead of `shared`.

Previously the fallback branch (no usable chat type) read the raw caller-supplied `groupId`/`groupChannel`/`groupSpace` params, while the same profile published those fields trust-checked (`null` when dropped). An unvouched caller-controlled group value could therefore classify an unknown-audience conversation as `shared` in the exact field that conversation identity modes (#98542) and scoped brokered credentials (#98549 / #98707) are specified to consume for audience and credential decisions. The profile also now computes the masked `groupChannel`/`groupSpace` once and reuses them for group-policy resolution, the published conversation fields, and scope, so the three can no longer diverge.

`conversation.scope` has zero consumers on current main (verified by grep across `src/`, `extensions/`, `packages/`), so the semantics change is contract-safe now and becomes the guaranteed baseline before the first consumers land.

## Proof (local)

- `pnpm tsgo` clean.
- `pnpm vitest run src/agents/conversation-capability-profile.test.ts` — 6 passed, including new regressions:
  - dropped caller group facts -> `scope: "unknown"`, published group fields `null`;
  - group-scoped session key without live chat type -> `shared`;
  - live run session key behind a sandbox policy key -> `shared`;
  - session-vouched caller group -> `shared`, `dropped: false`.
- `oxfmt --check` clean on touched files.

## Non-goals

- No change to group tool-policy resolution or `resolveTrustedGroupId` semantics; only scope classification and shared computation of the already-masked fields.
- No new config or public API surface. `sessionKeyNamesGroupConversation` is an internal helper.
