### PR TITLE
refactor(agents): require one resolved capability profile per run

### DIFF
--- a/src/agents/agent-bundle-mcp-tools.request-boundary.test.ts
+++ b/src/agents/agent-bundle-mcp-tools.request-boundary.test.ts
@@ -6,6 +6,7 @@ import {
   materializeBundleMcpToolsForRun,
 } from "./agent-bundle-mcp-materialize.js";
 import type { McpCatalogTool, SessionMcpRuntime } from "./agent-bundle-mcp-types.js";
+import { resolveConversationCapabilityProfile } from "./conversation-capability-profile.js";
 import { applyFinalEffectiveToolPolicy } from "./embedded-agent-runner/effective-tool-policy.js";
 import { splitSdkTools } from "./embedded-agent-runner/tool-split.js";
 
@@ -87,6 +88,7 @@ async function buildConfiguredMcpToolNamesAtRequestBoundary(params: {
   const filtered = applyFinalEffectiveToolPolicy({
     bundledTools: runtime.tools,
     config: params.cfg,
+    conversationCapabilityProfile: resolveConversationCapabilityProfile({ config: params.cfg }),
     warn: () => {},
   });
   const { customTools } = splitSdkTools({ tools: filtered, sandboxEnabled: false });
@@ -172,9 +174,11 @@ describe("configured MCP tools reach the request boundary (#76063)", () => {
         toolNames: ["zeta_tool", "alpha_tool", "mu_tool"],
       }),
     });
+    const cfg: OpenClawConfig = { tools: { profile: "coding" } };
     const filtered = applyFinalEffectiveToolPolicy({
       bundledTools: runtime.tools,
-      config: { tools: { profile: "coding" } },
+      config: cfg,
+      conversationCapabilityProfile: resolveConversationCapabilityProfile({ config: cfg }),
       warn: () => {},
     });
     const { customTools } = splitSdkTools({ tools: filtered, sandboxEnabled: false });

--- a/src/agents/embedded-agent-runner/compact.ts
+++ b/src/agents/embedded-agent-runner/compact.ts
@@ -992,27 +992,9 @@ async function compactEmbeddedAgentSessionDirectOnce(
     const filteredBundledTools = applyFinalEffectiveToolPolicy({
       bundledTools: [...(bundleMcpRuntime?.tools ?? []), ...(bundleLspRuntime?.tools ?? [])],
       config: params.config,
-      sandboxToolPolicy: sandbox?.tools,
-      sessionKey: sandboxSessionKey,
-      // Intentionally omit explicit agentId: the core tools just built with
-      // createOpenClawCodingTools(...) also omit it, so both paths resolve
-      // agentId the same way via resolveAgentIdFromSessionKey(sessionKey).
-      // Passing effectiveSkillAgentId here would diverge from the core-tool
-      // policy for legacy/non-agent session keys where the two sources fall
-      // back to different ids.
-      modelProvider: model.provider,
-      modelId,
-      messageProvider: resolvedMessageProvider,
-      agentAccountId: params.agentAccountId,
-      groupId: params.groupId,
-      groupChannel: params.groupChannel,
-      groupSpace: params.groupSpace,
-      spawnedBy: params.spawnedBy,
-      senderId: params.senderId,
-      senderName: params.senderName,
-      senderUsername: params.senderUsername,
-      senderE164: params.senderE164,
-      senderIsOwner: params.senderIsOwner,
+      // The same profile constructed the core tool set above, so core and
+      // bundled tools cannot disagree about policy inputs (agentId included:
+      // both resolve it from the session key inside the profile).
       conversationCapabilityProfile: runtimeCapabilityProfile,
       warn: (message) => log.warn(message),
     });

--- a/src/agents/embedded-agent-runner/effective-tool-policy.test.ts
+++ b/src/agents/embedded-agent-runner/effective-tool-policy.test.ts
@@ -3,7 +3,12 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { describe, expect, it } from "vitest";
+import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { setPluginToolMeta } from "../../plugins/tools.js";
+import {
+  type ConversationCapabilityProfileParams,
+  resolveConversationCapabilityProfile,
+} from "../conversation-capability-profile.js";
 import type { AnyAgentTool } from "../tools/common.js";
 import { applyFinalEffectiveToolPolicy } from "./effective-tool-policy.js";
 
@@ -19,9 +24,33 @@ function makeTool(name: string): AnyAgentTool {
   };
 }
 
+// Mirrors the production composition: resolve the conversation capability
+// profile from server-verified inputs, then apply the final bundled pass.
+function applyFinalPolicy(
+  params: {
+    bundledTools: AnyAgentTool[];
+    config?: OpenClawConfig;
+    warn?: (message: string) => void;
+  } & Pick<
+    ConversationCapabilityProfileParams,
+    "sessionKey" | "messageProvider" | "senderId" | "groupId" | "groupChannel"
+  >,
+): AnyAgentTool[] {
+  const { bundledTools, config, warn, ...profileParams } = params;
+  return applyFinalEffectiveToolPolicy({
+    bundledTools,
+    config,
+    conversationCapabilityProfile: resolveConversationCapabilityProfile({
+      config,
+      ...profileParams,
+    }),
+    warn: warn ?? (() => {}),
+  });
+}
+
 describe("applyFinalEffectiveToolPolicy", () => {
   it("filters bundled tools through the configured allowlist", () => {
-    const filtered = applyFinalEffectiveToolPolicy({
+    const filtered = applyFinalPolicy({
       bundledTools: [makeTool("mcp__bundle__fs_delete"), makeTool("mcp__bundle__fs_read")],
       config: { tools: { allow: ["mcp__bundle__fs_read"] } },
       warn: () => {},
@@ -55,7 +84,7 @@ describe("applyFinalEffectiveToolPolicy", () => {
       "utf-8",
     );
 
-    const filtered = applyFinalEffectiveToolPolicy({
+    const filtered = applyFinalPolicy({
       bundledTools: [makeTool("mcp__bundle__fs_delete"), makeTool("mcp__bundle__fs_read")],
       config: {
         session: {
@@ -96,7 +125,7 @@ describe("applyFinalEffectiveToolPolicy", () => {
     setPluginToolMeta(deniedTool, { pluginId: "bundle-mcp", optional: false });
     setPluginToolMeta(allowedTool, { pluginId: "bundle-mcp", optional: false });
 
-    const filtered = applyFinalEffectiveToolPolicy({
+    const filtered = applyFinalPolicy({
       bundledTools: [deniedTool, allowedTool],
       config: {
         session: {
@@ -120,7 +149,7 @@ describe("applyFinalEffectiveToolPolicy", () => {
   it("applies channel-normalized per-sender policy to bundled tools", () => {
     // Teams normalizes to msteams in policy keys, which must happen before
     // sender-specific deny rules are applied.
-    const filtered = applyFinalEffectiveToolPolicy({
+    const filtered = applyFinalPolicy({
       bundledTools: [makeTool("mcp__bundle__exec"), makeTool("mcp__bundle__read")],
       config: {
         tools: {
@@ -138,7 +167,7 @@ describe("applyFinalEffectiveToolPolicy", () => {
   });
 
   it("returns the empty array unchanged when there are no bundled tools", () => {
-    const filtered = applyFinalEffectiveToolPolicy({
+    const filtered = applyFinalPolicy({
       bundledTools: [],
       config: { tools: { allow: ["message"] } },
       warn: () => {},
@@ -149,7 +178,7 @@ describe("applyFinalEffectiveToolPolicy", () => {
 
   it("drops caller-provided groupId when it disagrees with session-derived group context", () => {
     const warnings: string[] = [];
-    applyFinalEffectiveToolPolicy({
+    applyFinalPolicy({
       bundledTools: [makeTool("mcp__bundle__read")],
       // Session key encodes a concrete group (discord room 111); caller tries
       // to override with a different group id so a more permissive group
@@ -167,7 +196,7 @@ describe("applyFinalEffectiveToolPolicy", () => {
 
   it("drops caller-provided groupId when session encodes no group context (fail-closed)", () => {
     const warnings: string[] = [];
-    applyFinalEffectiveToolPolicy({
+    applyFinalPolicy({
       bundledTools: [makeTool("mcp__bundle__read")],
       // Direct/non-group session key: no session-derived group ids. A caller
       // supplying a groupId here has no server-verified ground truth; it
@@ -185,7 +214,7 @@ describe("applyFinalEffectiveToolPolicy", () => {
 
   it("leaves groupId untouched when caller did not supply one", () => {
     const warnings: string[] = [];
-    applyFinalEffectiveToolPolicy({
+    applyFinalPolicy({
       bundledTools: [makeTool("mcp__bundle__read")],
       sessionKey: "agent:alice:main",
       warn: (message) => warnings.push(message),
@@ -198,7 +227,7 @@ describe("applyFinalEffectiveToolPolicy", () => {
 
   it("does not emit unknown-entry warnings for core tool allowlists in the bundled pass", () => {
     const warnings: string[] = [];
-    applyFinalEffectiveToolPolicy({
+    applyFinalPolicy({
       bundledTools: [makeTool("mcp__bundle__read")],
       // Core tool names like `read` and `exec` are not in the bundled-only
       // input here, but they are valid core tools resolved by the first
@@ -212,7 +241,7 @@ describe("applyFinalEffectiveToolPolicy", () => {
 
   it("still warns on genuinely unknown entries in the bundled pass", () => {
     const warnings: string[] = [];
-    applyFinalEffectiveToolPolicy({
+    applyFinalPolicy({
       bundledTools: [makeTool("mcp__bundle__read")],
       config: { tools: { allow: ["mcp__bundle__read", "totally-made-up-tool"] } },
       warn: (message) => warnings.push(message),
@@ -225,7 +254,7 @@ describe("applyFinalEffectiveToolPolicy", () => {
     const mcpTool = makeTool("bundleProbe__bundle_probe");
     setPluginToolMeta(mcpTool, { pluginId: "bundle-mcp", optional: false });
 
-    const filtered = applyFinalEffectiveToolPolicy({
+    const filtered = applyFinalPolicy({
       bundledTools: [mcpTool],
       config: { tools: { profile: "coding" } },
       warn: () => {},
@@ -238,7 +267,7 @@ describe("applyFinalEffectiveToolPolicy", () => {
     const mcpTool = makeTool("bundleProbe__bundle_probe");
     setPluginToolMeta(mcpTool, { pluginId: "bundle-mcp", optional: false });
 
-    const filtered = applyFinalEffectiveToolPolicy({
+    const filtered = applyFinalPolicy({
       bundledTools: [mcpTool],
       config: { tools: { profile: "coding", deny: ["bundle-mcp"] } },
       warn: () => {},

--- a/src/agents/embedded-agent-runner/effective-tool-policy.ts
+++ b/src/agents/embedded-agent-runner/effective-tool-policy.ts
@@ -3,10 +3,7 @@
  */
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { getPluginToolMeta } from "../../plugins/tools.js";
-import {
-  resolveConversationCapabilityProfile,
-  type ResolvedConversationCapabilityProfile,
-} from "../conversation-capability-profile.js";
+import type { ResolvedConversationCapabilityProfile } from "../conversation-capability-profile.js";
 import { buildDeclaredToolAllowlistContext } from "../tool-policy-declared-context.js";
 import {
   applyToolPolicyPipeline,
@@ -17,14 +14,12 @@ import { collectExplicitDenylist, mergeAlsoAllowPolicy } from "../tool-policy.js
 import type { AnyAgentTool } from "../tools/common.js";
 
 /**
- * Identity inputs used by `resolveGroupToolPolicy` to look up channel/group
- * tool policy. These fields are an authorization signal (they can widen
- * bundled-tool availability via a group-scoped allowlist), so callers MUST
- * pass values derived from server-verified session metadata (session key,
- * inbound transport event), not from tool-call or model-controlled input.
- * The helper cross-checks caller-provided `groupId` against session-derived
- * group ids and drops the caller value when they disagree, but it cannot
- * detect drift on fields that have no session-bound counterpart.
+ * The capability profile is an authorization signal (group/sender policies can
+ * widen bundled-tool availability), so callers MUST resolve it from
+ * server-verified session metadata (session key, inbound transport event),
+ * never from tool-call or model-controlled input. Passing the same profile
+ * that constructed the core tool set keeps this final bundled-tool pass and
+ * tool construction from ever disagreeing about policy inputs.
  */
 type FinalEffectiveToolPolicyParams = {
   // Tools appended to the core tool set after `createOpenClawCodingTools()`
@@ -34,23 +29,7 @@ type FinalEffectiveToolPolicyParams = {
   // metadata no longer survives core-tool wrapping/normalization.
   bundledTools: AnyAgentTool[];
   config?: OpenClawConfig;
-  sandboxToolPolicy?: { allow?: string[]; deny?: string[] };
-  sessionKey?: string;
-  agentId?: string;
-  modelProvider?: string;
-  modelId?: string;
-  messageProvider?: string;
-  agentAccountId?: string | null;
-  groupId?: string | null;
-  groupChannel?: string | null;
-  groupSpace?: string | null;
-  spawnedBy?: string | null;
-  senderId?: string | null;
-  senderName?: string | null;
-  senderUsername?: string | null;
-  senderE164?: string | null;
-  senderIsOwner?: boolean;
-  conversationCapabilityProfile?: ResolvedConversationCapabilityProfile;
+  conversationCapabilityProfile: ResolvedConversationCapabilityProfile;
   warn: (message: string) => void;
   toolPolicyAuditLogLevel?: "info" | "debug";
 };
@@ -61,27 +40,7 @@ export function applyFinalEffectiveToolPolicy(
   if (params.bundledTools.length === 0) {
     return params.bundledTools;
   }
-  const capabilityProfile =
-    params.conversationCapabilityProfile ??
-    resolveConversationCapabilityProfile({
-      config: params.config,
-      sessionKey: params.sessionKey,
-      agentId: params.agentId,
-      agentAccountId: params.agentAccountId,
-      messageProvider: params.messageProvider,
-      groupId: params.groupId,
-      groupChannel: params.groupChannel,
-      groupSpace: params.groupSpace,
-      spawnedBy: params.spawnedBy,
-      senderId: params.senderId,
-      senderName: params.senderName,
-      senderUsername: params.senderUsername,
-      senderE164: params.senderE164,
-      senderIsOwner: params.senderIsOwner,
-      modelProvider: params.modelProvider,
-      modelId: params.modelId,
-      sandboxToolPolicy: params.sandboxToolPolicy,
-    });
+  const capabilityProfile = params.conversationCapabilityProfile;
   const { trustedGroup } = capabilityProfile.policy;
   // Resolve here for warnings and to strip caller-only group metadata before
   // this pass; resolveGroupToolPolicy re-checks internally for all callers.
@@ -104,6 +63,7 @@ export function applyFinalEffectiveToolPolicy(
     providerProfileAlsoAllow,
     groupPolicy,
     senderPolicy,
+    sandboxPolicy,
     subagentPolicy,
     inheritedToolPolicy,
   } = capabilityProfile.policy;
@@ -138,7 +98,7 @@ export function applyFinalEffectiveToolPolicy(
       senderPolicy,
       agentId,
     }),
-    { policy: params.sandboxToolPolicy, label: "sandbox tools.allow" },
+    { policy: sandboxPolicy, label: "sandbox tools.allow" },
     { policy: subagentPolicy, label: "subagent tools.allow" },
     { policy: inheritedToolPolicy, label: "inherited tools" },
   ].map((step) => Object.assign({}, step, { suppressUnavailableCoreToolWarning: true }));

--- a/src/agents/embedded-agent-runner/run/attempt.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.ts
@@ -719,48 +719,12 @@ function removeTrailingMidTurnPrecheckAssistantError(params: {
 }
 
 function collectAttemptExplicitToolAllowlistSources(params: {
-  config?: EmbeddedRunAttemptParams["config"];
-  sessionKey?: string;
-  sandboxSessionKey?: string;
-  agentId?: string;
-  modelProvider?: string;
-  modelId?: string;
-  messageProvider?: string;
-  agentAccountId?: string | null;
-  groupId?: string | null;
-  groupChannel?: string | null;
-  groupSpace?: string | null;
-  spawnedBy?: string | null;
-  senderId?: string | null;
-  senderName?: string | null;
-  senderUsername?: string | null;
-  senderE164?: string | null;
-  sandboxToolPolicy?: { allow?: string[]; deny?: string[] };
+  // The attempt's single resolved profile: keeps these allowlist *sources*
+  // in lockstep with the policy that actually constructed and filtered the
+  // run's tools, instead of re-resolving with divergent session inputs.
+  capabilityProfile: ResolvedConversationCapabilityProfile;
   toolsAllow?: string[];
-  conversationCapabilityProfile?: ResolvedConversationCapabilityProfile;
 }) {
-  const capabilityProfile =
-    params.conversationCapabilityProfile ??
-    resolveConversationCapabilityProfile({
-      config: params.config,
-      sessionKey: params.sessionKey,
-      sandboxSessionKey: params.sandboxSessionKey,
-      agentId: params.agentId,
-      modelProvider: params.modelProvider,
-      modelId: params.modelId,
-      messageProvider: params.messageProvider,
-      agentAccountId: params.agentAccountId,
-      groupId: params.groupId,
-      groupChannel: params.groupChannel,
-      groupSpace: params.groupSpace,
-      spawnedBy: params.spawnedBy,
-      senderId: params.senderId,
-      senderName: params.senderName,
-      senderUsername: params.senderUsername,
-      senderE164: params.senderE164,
-      sandboxToolPolicy: params.sandboxToolPolicy,
-      runtimeToolAllowlist: params.toolsAllow,
-    });
   const {
     agentId,
     globalPolicy,
@@ -768,9 +732,10 @@ function collectAttemptExplicitToolAllowlistSources(params: {
     agentPolicy,
     agentProviderPolicy,
     groupPolicy,
+    sandboxPolicy,
     subagentPolicy,
     inheritedToolPolicy,
-  } = capabilityProfile.policy;
+  } = params.capabilityProfile.policy;
   return collectExplicitToolAllowlistSources([
     { label: "tools.allow", allow: globalPolicy?.allow },
     { label: "tools.byProvider.allow", allow: globalProviderPolicy?.allow },
@@ -783,7 +748,7 @@ function collectAttemptExplicitToolAllowlistSources(params: {
       allow: agentProviderPolicy?.allow,
     },
     { label: "group tools.allow", allow: groupPolicy?.allow },
-    { label: "sandbox tools.allow", allow: params.sandboxToolPolicy?.allow },
+    { label: "sandbox tools.allow", allow: sandboxPolicy?.allow },
     { label: "subagent tools.allow", allow: subagentPolicy?.allow },
     { label: "inherited tools.allow", allow: inheritedToolPolicy?.allow },
     { label: "runtime toolsAllow", allow: params.toolsAllow, enforceWhenToolsDisabled: true },
@@ -1626,22 +1591,6 @@ export async function runEmbeddedAttempt(
     const filteredBundledTools = applyFinalEffectiveToolPolicy({
       bundledTools: allowedBundledTools,
       config: params.config,
-      sandboxToolPolicy: sandbox?.tools,
-      sessionKey: sandboxSessionKey,
-      agentId: sessionAgentId,
-      modelProvider: params.provider,
-      modelId: params.modelId,
-      messageProvider: resolveAttemptToolPolicyMessageProvider(params),
-      agentAccountId: params.agentAccountId,
-      groupId: params.groupId,
-      groupChannel: params.groupChannel,
-      groupSpace: params.groupSpace,
-      spawnedBy: params.spawnedBy,
-      senderId: params.senderId,
-      senderName: params.senderName,
-      senderUsername: params.senderUsername,
-      senderE164: params.senderE164,
-      senderIsOwner: params.senderIsOwner,
       conversationCapabilityProfile: runtimeCapabilityProfile,
       warn: (message) => log.warn(message),
     });
@@ -1815,23 +1764,7 @@ export async function runEmbeddedAttempt(
       toolSearch.catalogRegistered;
     prepStages.mark("bundle-tools");
     const explicitToolAllowlistSources = collectAttemptExplicitToolAllowlistSources({
-      config: params.config,
-      sessionKey: params.sessionKey,
-      sandboxSessionKey,
-      agentId: sessionAgentId,
-      modelProvider: params.provider,
-      modelId: params.modelId,
-      messageProvider: resolveAttemptToolPolicyMessageProvider(params),
-      agentAccountId: params.agentAccountId,
-      groupId: params.groupId,
-      groupChannel: params.groupChannel,
-      groupSpace: params.groupSpace,
-      spawnedBy: params.spawnedBy,
-      senderId: params.senderId,
-      senderName: params.senderName,
-      senderUsername: params.senderUsername,
-      senderE164: params.senderE164,
-      sandboxToolPolicy: sandbox?.tools,
+      capabilityProfile: runtimeCapabilityProfile,
       toolsAllow: params.toolsAllow,
     });
     const toolSearchRunPlan = buildToolSearchRunPlan({

--- a/src/flows/doctor-core-checks.runtime.ts
+++ b/src/flows/doctor-core-checks.runtime.ts
@@ -14,6 +14,7 @@ import {
 } from "../agents/agent-scope.js";
 import { createOpenClawCodingTools } from "../agents/agent-tools.js";
 import { resolveEffectiveToolPolicy } from "../agents/agent-tools.policy.js";
+import { resolveConversationCapabilityProfile } from "../agents/conversation-capability-profile.js";
 import { DEFAULT_MODEL, DEFAULT_PROVIDER } from "../agents/defaults.js";
 import { applyFinalEffectiveToolPolicy } from "../agents/embedded-agent-runner/effective-tool-policy.js";
 import { shouldCreateBundleMcpRuntimeForAttempt } from "../agents/embedded-agent-runner/run/attempt-tool-construction-plan.js";
@@ -792,9 +793,12 @@ function collectBundleMcpRuntimeToolSchemaFindings(params: {
   const activeBundleTools = applyFinalEffectiveToolPolicy({
     bundledTools: params.bundleRuntime.tools,
     config: params.cfg,
-    agentId: params.agentId,
-    modelProvider: params.modelRef.provider,
-    modelId: params.modelRef.model,
+    conversationCapabilityProfile: resolveConversationCapabilityProfile({
+      config: params.cfg,
+      agentId: params.agentId,
+      modelProvider: params.modelRef.provider,
+      modelId: params.modelRef.model,
+    }),
     warn: () => {},
     toolPolicyAuditLogLevel: "debug",
   });
@@ -1002,9 +1006,12 @@ function shouldReportBundleMcpRuntimeDiagnostic(params: {
     applyFinalEffectiveToolPolicy({
       bundledTools: collectBundleMcpDiagnosticSentinels(params),
       config: params.cfg,
-      agentId: params.agentId,
-      modelProvider: params.modelRef.provider,
-      modelId: params.modelRef.model,
+      conversationCapabilityProfile: resolveConversationCapabilityProfile({
+        config: params.cfg,
+        agentId: params.agentId,
+        modelProvider: params.modelRef.provider,
+        modelId: params.modelRef.model,
+      }),
       warn: () => {},
       toolPolicyAuditLogLevel: "debug",
     }).length > 0

--- a/src/gateway/server-methods/tools-effective.ts
+++ b/src/gateway/server-methods/tools-effective.ts
@@ -7,6 +7,7 @@ import {
   formatValidationErrors,
   validateToolsEffectiveParams,
 } from "../../../packages/gateway-protocol/src/index.js";
+import { resolveConversationCapabilityProfile } from "../../agents/conversation-capability-profile.js";
 import { buildEffectiveToolInventoryGroups } from "../../agents/tools-effective-inventory-groups.js";
 import type {
   EffectiveToolInventoryNotice,
@@ -377,16 +378,19 @@ function filterMcpTools(params: {
   return applyFinalEffectiveToolPolicy({
     bundledTools: params.mcpTools,
     config: params.context.cfg,
-    sessionKey: params.context.sessionKey,
-    agentId: params.context.agentId,
-    modelProvider: params.context.modelProvider,
-    modelId: params.context.modelId,
-    messageProvider: params.context.messageProvider,
-    agentAccountId: params.context.accountId,
-    groupId: params.context.groupId,
-    groupChannel: params.context.groupChannel,
-    groupSpace: params.context.groupSpace,
-    spawnedBy: params.context.spawnedBy,
+    conversationCapabilityProfile: resolveConversationCapabilityProfile({
+      config: params.context.cfg,
+      sessionKey: params.context.sessionKey,
+      agentId: params.context.agentId,
+      modelProvider: params.context.modelProvider,
+      modelId: params.context.modelId,
+      messageProvider: params.context.messageProvider,
+      agentAccountId: params.context.accountId,
+      groupId: params.context.groupId,
+      groupChannel: params.context.groupChannel,
+      groupSpace: params.context.groupSpace,
+      spawnedBy: params.context.spawnedBy,
+    }),
     warn: logWarn,
   });
 }


### PR DESCRIPTION
## Summary

The final bundled-tool policy pass and the attempt allowlist-source readout now consume the run's single resolved conversation capability profile instead of optionally re-resolving their own.

- `applyFinalEffectiveToolPolicy` (`src/agents/embedded-agent-runner/effective-tool-policy.ts`): `conversationCapabilityProfile` is required; the ~15 raw identity params (`sessionKey`, `agentId`, group/sender fields, model refs, `sandboxToolPolicy`) and the silent fallback re-resolution are deleted. The sandbox pipeline step reads `policy.sandboxPolicy` from the profile.
- `collectAttemptExplicitToolAllowlistSources` (`src/agents/embedded-agent-runner/run/attempt.ts`): same contract; it now reports allowlist sources from the profile that actually constructed and filtered the run's tools. Previously the callsite omitted the profile, so the fallback resolved a second full profile per attempt with divergent inputs — policy/group trust keyed off the live session key while tool construction used the sandbox policy session key. Where those keys differ, the reported sources could disagree with enforcement; they can no longer.
- Embedded attempt and compaction thread one `runtimeCapabilityProfile` into tool construction, the final bundled pass, and allowlist sources; the redundant raw-param forwarding blocks at those callsites are gone.
- Doctor runtime checks (`src/flows/doctor-core-checks.runtime.ts`) and gateway `tools.effective` (`src/gateway/server-methods/tools-effective.ts`) resolve their config-scope profile explicitly at the callsite — same inputs as before, resolution now visible instead of implicit.
- `createOpenClawCodingTools` keeps its optional profile param and self-resolve: it is public plugin-SDK surface (`src/plugin-sdk/agent-harness.ts`). `applyFinalEffectiveToolPolicy` is not SDK-exported (verified), so its signature change is internal.

Net: one canonical profile resolution per embedded run, enforced by the type system rather than by convention; +95/-176.

## Proof (local)

- `pnpm tsgo` clean.
- `pnpm vitest run` on `effective-tool-policy.test.ts`, `agent-bundle-mcp-tools.request-boundary.test.ts`, gateway `tools-effective` suites, `tool-allowlist-guard.test.ts`, doctor runtime suites, attempt tool-plan suites — all green (77 + 44 + 33 across batches; suite tests updated to the resolve-then-apply composition mirroring production).
- `oxfmt --check` clean on touched files.

## Non-goals

- No behavior change to policy pipeline ordering, tool filtering semantics, or the SDK surface.
- Harness selection (`src/agents/harness/selection.ts`) still resolves per entry point; threading the attempt profile there needs the `btw.ts` call-chain reshaped and is left as follow-up.
