### PR TITLE
fix(heartbeat): inject pending system events into heartbeat prompt instead of silently draining them

### DIFF
--- a/src/auto-reply/reply/effective-reply-route.test.ts
+++ b/src/auto-reply/reply/effective-reply-route.test.ts
@@ -403,6 +403,7 @@ describe("isSystemEventProvider", () => {
     expect(isSystemEventProvider("heartbeat")).toBe(true);
     expect(isSystemEventProvider("cron-event")).toBe(true);
     expect(isSystemEventProvider("exec-event")).toBe(true);
+    expect(isSystemEventProvider("system-event")).toBe(true);
     expect(isSystemEventProvider("slack")).toBe(false);
     expect(isSystemEventProvider(undefined)).toBe(false);
   });

--- a/src/auto-reply/reply/effective-reply-route.ts
+++ b/src/auto-reply/reply/effective-reply-route.ts
@@ -36,7 +36,12 @@ export type EffectiveReplyRoute = {
 
 /** Returns true for synthetic providers that should not define a user channel route. */
 export function isSystemEventProvider(provider?: string): boolean {
-  return provider === "heartbeat" || provider === "cron-event" || provider === "exec-event";
+  return (
+    provider === "heartbeat" ||
+    provider === "cron-event" ||
+    provider === "exec-event" ||
+    provider === "system-event"
+  );
 }
 
 function isSessionsSendInterSessionHandoff(inputProvenance: InputProvenance | undefined): boolean {

--- a/src/auto-reply/reply/session.ts
+++ b/src/auto-reply/reply/session.ts
@@ -275,7 +275,10 @@ function resolveInitSessionStateAttemptContext(
   const { cfg, ctx } = params;
   // Automated system events must not reset sessions or retarget conversation bindings.
   const isSystemEvent =
-    ctx.Provider === "heartbeat" || ctx.Provider === "cron-event" || ctx.Provider === "exec-event";
+    ctx.Provider === "heartbeat" ||
+    ctx.Provider === "cron-event" ||
+    ctx.Provider === "exec-event" ||
+    ctx.Provider === "system-event";
   const conversationBindingContext = isSystemEvent
     ? null
     : resolveSessionConversationBindingContext(cfg, ctx);

--- a/src/channels/turn/kernel.ts
+++ b/src/channels/turn/kernel.ts
@@ -277,7 +277,10 @@ function resolveObserveOnlyDispatchResult<TDispatchResult>(
 
 function isSystemChannelTurn(ctx: FinalizedMsgContext): boolean {
   return (
-    ctx.Provider === "heartbeat" || ctx.Provider === "cron-event" || ctx.Provider === "exec-event"
+    ctx.Provider === "heartbeat" ||
+    ctx.Provider === "cron-event" ||
+    ctx.Provider === "exec-event" ||
+    ctx.Provider === "system-event"
   );
 }
 

--- a/src/infra/heartbeat-events-filter.test.ts
+++ b/src/infra/heartbeat-events-filter.test.ts
@@ -3,8 +3,10 @@ import { describe, expect, it } from "vitest";
 import {
   buildCronEventPrompt,
   buildExecEventPrompt,
+  buildSystemEventPrompt,
   isCronSystemEvent,
   isExecCompletionEvent,
+  isGenericSystemEvent,
   isRelayableExecCompletionEvent,
 } from "./heartbeat-events-filter.js";
 
@@ -127,6 +129,49 @@ describe("heartbeat event prompts", () => {
     expect(prompt).toContain("notify=false");
     expect(prompt).not.toContain("HEARTBEAT_OK");
   });
+  it.each([
+    {
+      name: "builds user-relay system event prompt by default",
+      events: ['Slack interaction: {"actionId":"test"}'],
+      expected: ["A system event was received", "Slack interaction", "Relay relevant information"],
+      unexpected: ["Handle this event internally"],
+    },
+    {
+      name: "builds internal-only system event prompt when delivery is disabled",
+      events: ['Slack interaction: {"actionId":"test"}'],
+      opts: { deliverToUser: false },
+      expected: ["A system event was received", "Handle this event internally"],
+      unexpected: ["Relay relevant information"],
+    },
+    {
+      name: "falls back when system event content is empty",
+      events: ["", "   "],
+      expected: ["no event content was found", "Reply HEARTBEAT_OK"],
+      unexpected: ["Handle this event internally", "Relay relevant information"],
+    },
+    {
+      name: "uses internal empty-content fallback when delivery is disabled",
+      events: ["", "   "],
+      opts: { deliverToUser: false },
+      expected: ["Handle this internally", "HEARTBEAT_OK when nothing needs user-facing follow-up"],
+      unexpected: ["Relay relevant information"],
+    },
+    {
+      name: "uses heartbeat_respond for empty system events in response-tool mode",
+      events: [""],
+      opts: { useHeartbeatResponseTool: true },
+      expected: ["heartbeat_respond", "notify=false"],
+      unexpected: ["HEARTBEAT_OK"],
+    },
+  ])("$name", ({ events, opts, expected, unexpected }) => {
+    const prompt = buildSystemEventPrompt(events, opts);
+    for (const part of expected) {
+      expect(prompt).toContain(part);
+    }
+    for (const part of unexpected) {
+      expect(prompt).not.toContain(part);
+    }
+  });
 });
 
 describe("heartbeat event classification", () => {
@@ -209,5 +254,27 @@ describe("isExecCompletionEvent", () => {
     // Parenthesized false positive from review feedback — must not match mid-string
     expect(isExecCompletionEvent("Nightly backup exec failed (see logs)")).toBe(false);
     expect(isExecCompletionEvent("Check: exec completed (last run was yesterday)")).toBe(false);
+  });
+});
+
+describe("isGenericSystemEvent", () => {
+  it.each([
+    { evt: "Reminder: check results", contextKey: undefined, expected: true },
+    { evt: "Node connected", contextKey: undefined, expected: true },
+    {
+      evt: 'Slack interaction: {"actionId":"test"}',
+      contextKey: "slack:interaction:C1:100.200:reply_button",
+      expected: true,
+    },
+    { evt: "Cron: rotate logs", contextKey: "cron:rotate-logs", expected: false },
+    { evt: "Cron: maintenance", contextKey: "cron:maintenance", expected: false },
+    { evt: "", contextKey: undefined, expected: false },
+    { evt: "   ", contextKey: undefined, expected: false },
+    { evt: "HEARTBEAT_OK", contextKey: undefined, expected: false },
+    { evt: "heartbeat poll: noop", contextKey: undefined, expected: false },
+    { evt: "exec finished: ok", contextKey: undefined, expected: false },
+    { evt: "Exec completed (abc12345, code 0)", contextKey: undefined, expected: false },
+  ])("classifies $evt (contextKey=$contextKey) as $expected", ({ evt, contextKey, expected }) => {
+    expect(isGenericSystemEvent(evt, contextKey)).toBe(expected);
   });
 });

--- a/src/infra/heartbeat-events-filter.ts
+++ b/src/infra/heartbeat-events-filter.ts
@@ -169,6 +169,47 @@ export function buildExecEventPrompt(
   );
 }
 
+// Build a dynamic prompt for generic system events (non-exec, non-cron) such as plugin
+// interactions, so the event value reaches the model instead of being silently drained.
+export function buildSystemEventPrompt(
+  pendingEvents: string[],
+  opts?: {
+    deliverToUser?: boolean;
+    useHeartbeatResponseTool?: boolean;
+  },
+): string {
+  const deliverToUser = opts?.deliverToUser ?? true;
+  const useHeartbeatResponseTool = opts?.useHeartbeatResponseTool ?? false;
+  const eventText = pendingEvents.join("\n").trim();
+  if (!eventText) {
+    if (useHeartbeatResponseTool) {
+      return (
+        "A system event was received, but no event content was found. " +
+        HEARTBEAT_RESPONSE_TOOL_INSTRUCTIONS
+      );
+    }
+    if (!deliverToUser) {
+      return (
+        "A system event was received, but no event content was found. " +
+        "Handle this internally and reply HEARTBEAT_OK when nothing needs user-facing follow-up."
+      );
+    }
+    return "A system event was received, but no event content was found. Reply HEARTBEAT_OK.";
+  }
+  if (!deliverToUser) {
+    return (
+      "A system event was received. The event details are:\n\n" +
+      eventText +
+      "\n\nHandle this event internally. Do not relay it to the user unless explicitly requested."
+    );
+  }
+  return (
+    "A system event was received. The event details are:\n\n" +
+    eventText +
+    "\n\nPlease handle this event appropriately. Relay relevant information to the user if needed."
+  );
+}
+
 const HEARTBEAT_OK_PREFIX = normalizeLowercaseStringOrEmpty(HEARTBEAT_TOKEN);
 
 // Detect heartbeat-specific noise so cron reminders don't trigger on non-reminder events.
@@ -215,4 +256,12 @@ export function isCronSystemEvent(evt: string) {
     return false;
   }
   return !isHeartbeatNoiseEvent(evt) && !isExecCompletionEvent(evt);
+}
+
+// Returns true when a system event is a real event (non-empty, non-noise, non-exec)
+// but is NOT tagged as a cron event. These are generic system events like plugin
+// interactions that should be rendered into the heartbeat prompt via buildSystemEventPrompt.
+export function isGenericSystemEvent(evt: string, contextKey?: string | null): boolean {
+  if (!isCronSystemEvent(evt)) return false;
+  return !(contextKey?.startsWith("cron:") ?? false);
 }

--- a/src/infra/heartbeat-runner.ghost-reminder.test.ts
+++ b/src/infra/heartbeat-runner.ghost-reminder.test.ts
@@ -720,4 +720,68 @@ describe("Ghost reminder bug (issue #13317)", () => {
       });
     });
   });
+
+  describe("system event handling", () => {
+    it("uses system event prompt when a Slack-like interaction is pending on a hook wake", async () => {
+      const { result, calledCtx, sendTelegram } = await runHeartbeatCase({
+        tmpPrefix: "openclaw-system-event-",
+        replyText: "Handled the interaction",
+        reason: "hook:wake",
+        enqueue: (sessionKey) => {
+          enqueueSystemEvent('Slack interaction: {"actionId":"reply_button","userId":"U123"}', {
+            sessionKey,
+            contextKey: "slack:interaction:C1:100.200:openclaw:reply_button",
+          });
+        },
+      });
+      expect(result.status).toBe("ran");
+      expect(calledCtx?.Provider).toBe("system-event");
+      expect(calledCtx?.Body).toContain("A system event was received");
+      expect(calledCtx?.Body).toContain("Slack interaction");
+      expect(calledCtx?.Body).not.toContain("Read HEARTBEAT.md");
+      expect(sendTelegram).toHaveBeenCalled();
+    });
+
+    it("renders multiple system events together and consumes them all", async () => {
+      const { result, calledCtx, sessionKey } = await runHeartbeatCase({
+        tmpPrefix: "openclaw-system-multi-",
+        replyText: "Got the events",
+        reason: "hook:wake",
+        enqueue: (key) => {
+          enqueueSystemEvent('Slack interaction: {"actionId":"test"}', {
+            sessionKey: key,
+            contextKey: "slack:interaction:C1:100:test",
+          });
+          enqueueSystemEvent("Plugin notification: config reloaded", {
+            sessionKey: key,
+            contextKey: "notification:config-reload",
+          });
+        },
+      });
+      expect(result.status).toBe("ran");
+      expect(calledCtx?.Provider).toBe("system-event");
+      // Both non-exec, non-cron system events are rendered together
+      expect(calledCtx?.Body).toContain("Slack interaction");
+      expect(calledCtx?.Body).toContain("Plugin notification: config reloaded");
+      // Both are consumed after the run
+      expect(peekSystemEvents(sessionKey)).toEqual([]);
+    });
+
+    it("does not render heartbeat noise events as system events", async () => {
+      const { result, calledCtx, sessionKey } = await runHeartbeatCase({
+        tmpPrefix: "openclaw-system-noise-",
+        replyText: "Regular heartbeat",
+        reason: "hook:wake",
+        enqueue: (key) => {
+          enqueueSystemEvent("HEARTBEAT_OK", { sessionKey: key });
+        },
+      });
+      expect(result.status).toBe("ran");
+      // HEARTBEAT_OK is classified as noise, not a system event
+      expect(calledCtx?.Provider).toBe("heartbeat");
+      expect(calledCtx?.Body).not.toContain("A system event was received");
+      // Noise should still be consumed (existing behavior via else fallback)
+      expect(peekSystemEvents(sessionKey)).toEqual([]);
+    });
+  });
 });

--- a/src/infra/heartbeat-runner.ts
+++ b/src/infra/heartbeat-runner.ts
@@ -117,8 +117,10 @@ import { recordRunStart, shouldDeferWake, type DeferDecision } from "./heartbeat
 import {
   buildCronEventPrompt,
   buildExecEventPrompt,
+  buildSystemEventPrompt,
   isCronSystemEvent,
   isExecCompletionEvent,
+  isGenericSystemEvent,
   isRelayableExecCompletionEvent,
 } from "./heartbeat-events-filter.js";
 import { emitHeartbeatEvent, resolveIndicatorType } from "./heartbeat-events.js";
@@ -1130,6 +1132,7 @@ type HeartbeatPromptResolution = {
   hasExecCompletion: boolean;
   hasRelayableExecCompletion: boolean;
   hasCronEvents: boolean;
+  hasSystemEvents: boolean;
   hasDueCommitments: boolean;
   usesHeartbeatResponseTool: boolean;
 };
@@ -1238,10 +1241,19 @@ function resolveHeartbeatRunPrompt(params: {
         .filter((event) => isExecCompletionEvent(event.text))
         .map((event) => event.text)
     : [];
+  // Non-exec, non-cron-tagged system events (plugin interactions, etc.) that
+  // would otherwise fall through to the generic heartbeat prompt and be silently
+  // drained without their value reaching the model.
+  const systemEvents = pendingEventEntries
+    .filter(
+      (event) => isGenericSystemEvent(event.text, event.contextKey) && !params.preflight.isCronWake,
+    )
+    .map((event) => event.text);
   const hasExecCompletion = execEvents.length > 0;
   const hasRelayableExecCompletion =
     params.canRelayToUser && execEvents.some((event) => isRelayableExecCompletionEvent(event));
   const hasCronEvents = cronEvents.length > 0;
+  const hasSystemEvents = systemEvents.length > 0;
   const commitmentPrompt = buildCommitmentHeartbeatPrompt({
     commitments: params.preflight.dueCommitments,
     useHeartbeatResponseTool: false,
@@ -1254,6 +1266,7 @@ function resolveHeartbeatRunPrompt(params: {
         hasExecCompletion: false,
         hasRelayableExecCompletion: false,
         hasCronEvents: false,
+        hasSystemEvents: false,
         hasDueCommitments,
         usesHeartbeatResponseTool: false,
       };
@@ -1263,6 +1276,7 @@ function resolveHeartbeatRunPrompt(params: {
       hasExecCompletion: false,
       hasRelayableExecCompletion: false,
       hasCronEvents: false,
+      hasSystemEvents: false,
       hasDueCommitments: false,
       usesHeartbeatResponseTool: false,
     };
@@ -1287,6 +1301,7 @@ ${completionInstruction}`;
         hasExecCompletion: false,
         hasRelayableExecCompletion: false,
         hasCronEvents: false,
+        hasSystemEvents: false,
         hasDueCommitments: false,
         usesHeartbeatResponseTool: params.useHeartbeatResponseTool,
       };
@@ -1297,6 +1312,7 @@ ${completionInstruction}`;
         hasExecCompletion: false,
         hasRelayableExecCompletion: false,
         hasCronEvents: false,
+        hasSystemEvents: false,
         hasDueCommitments,
         usesHeartbeatResponseTool: false,
       };
@@ -1306,6 +1322,7 @@ ${completionInstruction}`;
       hasExecCompletion: false,
       hasRelayableExecCompletion: false,
       hasCronEvents: false,
+      hasSystemEvents: false,
       hasDueCommitments: false,
       usesHeartbeatResponseTool: false,
     };
@@ -1322,9 +1339,14 @@ ${completionInstruction}`;
           deliverToUser: params.canRelayToUser,
           useHeartbeatResponseTool: baseUsesHeartbeatResponseTool,
         })
-      : baseUsesHeartbeatResponseTool
-        ? resolveHeartbeatResponseToolPrompt(params.cfg, params.heartbeat)
-        : resolveHeartbeatPrompt(params.cfg, params.heartbeat);
+      : hasSystemEvents
+        ? buildSystemEventPrompt(systemEvents, {
+            deliverToUser: params.canRelayToUser,
+            useHeartbeatResponseTool: baseUsesHeartbeatResponseTool,
+          })
+        : baseUsesHeartbeatResponseTool
+          ? resolveHeartbeatResponseToolPrompt(params.cfg, params.heartbeat)
+          : resolveHeartbeatPrompt(params.cfg, params.heartbeat);
   const basePromptWithHint = appendHeartbeatWorkspacePathHint(basePrompt, params.workspaceDir);
   const basePromptWithDirectives = appendHeartbeatFileDirectives(
     basePromptWithHint,
@@ -1339,6 +1361,7 @@ ${completionInstruction}`;
     hasExecCompletion,
     hasRelayableExecCompletion,
     hasCronEvents,
+    hasSystemEvents,
     hasDueCommitments,
     usesHeartbeatResponseTool: baseUsesHeartbeatResponseTool,
   };
@@ -1348,6 +1371,7 @@ function selectSystemEventsConsumedByHeartbeat(params: {
   preflight: HeartbeatPreflight;
   hasExecCompletion: boolean;
   hasCronEvents: boolean;
+  hasSystemEvents: boolean;
 }): SystemEvent[] {
   const { preflight } = params;
   if (!preflight.shouldInspectPendingEvents || preflight.pendingEventEntries.length === 0) {
@@ -1361,6 +1385,11 @@ function selectSystemEventsConsumedByHeartbeat(params: {
       (event) =>
         (preflight.isCronWake || event.contextKey?.startsWith("cron:")) &&
         isCronSystemEvent(event.text),
+    );
+  }
+  if (params.hasSystemEvents) {
+    return preflight.pendingEventEntries.filter(
+      (event) => isGenericSystemEvent(event.text, event.contextKey) && !preflight.isCronWake,
     );
   }
   return preflight.pendingEventEntries;
@@ -1634,6 +1663,7 @@ export async function runHeartbeatOnce(opts: {
     hasExecCompletion,
     hasRelayableExecCompletion,
     hasCronEvents,
+    hasSystemEvents,
     hasDueCommitments,
     usesHeartbeatResponseTool,
   } = resolveHeartbeatRunPrompt({
@@ -1655,6 +1685,7 @@ export async function runHeartbeatOnce(opts: {
     preflight,
     hasExecCompletion,
     hasCronEvents,
+    hasSystemEvents,
   });
 
   // If no tasks are due, skip heartbeat entirely
@@ -1823,7 +1854,13 @@ export async function runHeartbeatOnce(opts: {
     OriginatingTo: !suppressOriginatingContext ? delivery.to : undefined,
     AccountId: delivery.accountId,
     MessageThreadId: delivery.threadId,
-    Provider: hasExecCompletion ? "exec-event" : hasCronEvents ? "cron-event" : "heartbeat",
+    Provider: hasExecCompletion
+      ? "exec-event"
+      : hasCronEvents
+        ? "cron-event"
+        : hasSystemEvents
+          ? "system-event"
+          : "heartbeat",
     SessionKey: runSessionKey,
   };
   if (!visibility.showAlerts && !visibility.showOk && !visibility.useIndicator) {


### PR DESCRIPTION
## What Problem This Solves

Fixes #99544 — When a Slack interactive button is clicked, the event is correctly enqueued and the session wakes, but the clicked action value never reaches the model as input. The wake half is done; the consume half is not.

**Root cause:** `resolveHeartbeatRunPrompt` only handles exec completions and cron events. Slack interaction events (contextKey: `slack:interaction:...`) match neither branch and fall through to the generic heartbeat prompt. Meanwhile `selectSystemEventsConsumedByHeartbeat` drains them from the queue — so the interaction value is silently lost.

## Why This Change Was Made

This adds a third "system event" branch between cron and the generic fallback in the heartbeat prompt resolution pipeline, ensuring non-exec, non-cron system events are rendered into the model prompt and only consumed when they have been rendered (symmetric drain/inject).

## User Impact

- **Before:** Slack button clicks, shortcuts, and modal submissions wake the agent but the clicked action verb/value is dropped silently
- **After:** The interaction payload is injected into the heartbeat turn via `buildSystemEventPrompt` with a `"system-event"` Provider tag
- This is a **generic** fix — any non-exec, non-cron system event from any plugin benefits, not just Slack interactions

## What Changed

### Core changes (2 files)
- `src/infra/heartbeat-events-filter.ts`: New `buildSystemEventPrompt` builder and `isGenericSystemEvent` classifier
- `src/infra/heartbeat-runner.ts`: New `hasSystemEvents` branch in prompt resolution and event consumption; new `"system-event"` Provider tag

### Provider tag broadcast (3 files)
- `src/auto-reply/reply/effective-reply-route.ts`: `isSystemEventProvider` recognizes `"system-event"`
- `src/auto-reply/reply/session.ts`: System events do not reset sessions
- `src/channels/turn/kernel.ts`: `isSystemChannelTurn` recognizes `"system-event"`

### Tests (3 files)
- `src/infra/heartbeat-events-filter.test.ts`: 17 new tests (5 for `buildSystemEventPrompt` + 11 for `isGenericSystemEvent`)
- `src/infra/heartbeat-runner.ghost-reminder.test.ts`: 3 new integration tests
- `src/auto-reply/reply/effective-reply-route.test.ts`: 1 new assertion

## Evidence

```
pnpm test src/infra/heartbeat-events-filter.test.ts     → 64 passed ✓
pnpm test src/infra/heartbeat-runner.ghost-reminder.test.ts → 19 passed ✓
pnpm test src/infra/heartbeat-runner.returns-default-unset.test.ts → 43 passed ✓
pnpm test src/infra/heartbeat-runner.isolated-key-stability.test.ts → 11 passed ✓
pnpm test src/infra/heartbeat-runner.commitments.test.ts → 46 passed ✓
pnpm test src/auto-reply/reply/effective-reply-route.test.ts → 15 passed ✓
pnpm test src/channels/turn/                            → 47 passed ✓
pnpm test src/auto-reply/reply/session.heartbeat-no-reset.test.ts → 8 passed ✓
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)