### PR TITLE
feat(codex): share native threads across Codex clients

### DIFF
--- a/.agents/skills/openclaw-changelog-update/scripts/verify-release-notes.mjs
+++ b/.agents/skills/openclaw-changelog-update/scripts/verify-release-notes.mjs
@@ -19,7 +19,7 @@ const nonEditorialTypes = new Set([
 const nonEditorialTitlePattern =
   /(?:^|[\s:([{\-])(docs?|documentation|tests?|testing|qa|quality assurance|refactor(?:ing)?|ci|continuous integration|build|chore|style|lint|format)(?:$|[\s:)\]}\-])/i;
 const editorialTitlePattern =
-  /^\s*(?:\[[^\]]+\]\s*)?(?:#\d+:\s*)?(?:add|allow|block|enable|expose|fail|fix|harden|honor|improve|keep|migrate|move|persist|preserve|prevent|propagate|rate[- ]?limit|restore|revert|ship|support|treat|validate)\b|^\s*#\d+:/i;
+  /^\s*(?:\[[^\]]+\]\s*)?(?:#\d+:\s*)?(?:add|allow|block|enable|expose|fail|fix|harden|honor|improve|keep|migrate|move|persist|polish|preserve|prevent|propagate|rate[- ]?limit|restore|revert|ship|support|treat|validate)\b|^\s*#\d+:/i;
 const genericDirectCommitTerms = new Set([
   "add",
   "allow",
@@ -656,9 +656,12 @@ function resolveAssociatedPullRequests(commitHashes, targetTimestamp) {
     const pullRequests = pullRequestsByCommit.get(commitHash) ?? [];
     const seen = new Set(pullRequests);
     for (const pullRequest of connection?.nodes ?? []) {
+      // GitHub's mergedAt can trail the merge commit timestamp by a second.
+      // Keep an exact merge-commit association so a release ending there does not drop its PR.
+      const isExactMergeCommit = pullRequest.mergeCommit?.oid === commitHash;
       if (
         pullRequest.mergedAt &&
-        mergedByTarget(pullRequest.mergedAt, targetTimestamp) &&
+        (isExactMergeCommit || mergedByTarget(pullRequest.mergedAt, targetTimestamp)) &&
         !seen.has(pullRequest.number)
       ) {
         pullRequests.push(pullRequest.number);
@@ -682,6 +685,7 @@ function resolveAssociatedPullRequests(commitHashes, targetTimestamp) {
                   nodes {
                     number
                     mergedAt
+                    mergeCommit { oid }
                   }
                   pageInfo { hasNextPage endCursor }
                 }
@@ -707,6 +711,7 @@ function resolveAssociatedPullRequests(commitHashes, targetTimestamp) {
                   nodes {
                     number
                     mergedAt
+                    mergeCommit { oid }
                   }
                   pageInfo { hasNextPage endCursor }
                 }
@@ -1191,7 +1196,7 @@ function ledgerFor(
     (entry) =>
       entry.type === "PullRequest" &&
       entry.mergedAt &&
-      mergedByTarget(entry.mergedAt, targetTimestamp) &&
+      (sourcePullRequests.has(entry.number) || mergedByTarget(entry.mergedAt, targetTimestamp)) &&
       recordedPullRequests.has(entry.number) &&
       !revertedReferences.has(entry.number),
   );
@@ -1514,7 +1519,7 @@ function main() {
     return (
       node?.__typename !== "PullRequest" ||
       !node.mergedAt ||
-      !mergedByTarget(node.mergedAt, source.targetTimestamp)
+      (!source.pullRequests.has(number) && !mergedByTarget(node.mergedAt, source.targetTimestamp))
     );
   });
   if (!options.writeLedger && invalidRecordedPullRequests.length > 0) {

--- a/.github/codeql/openclaw-boundary/queries/raw-socket-callsite-classification.ql
+++ b/.github/codeql/openclaw-boundary/queries/raw-socket-callsite-classification.ql
@@ -64,7 +64,7 @@ predicate allowedRawSocketClientCall(Expr call) {
   or
   allowedOwnerScope(call, "src/infra/gateway-lock.ts", "checkPortFree")
   or
-  allowedOwnerScope(call, "src/infra/jsonl-socket.ts", "requestJsonlSocket")
+  allowedOwnerScope(call, "src/infra/jsonl-socket.ts", "requestJsonlSocketWithMaxLineBytes")
   or
   allowedOwnerScope(call, "src/infra/net/http-connect-tunnel.ts", "connectToProxy")
   or

--- a/.github/workflows/control-ui-locale-refresh.yml
+++ b/.github/workflows/control-ui-locale-refresh.yml
@@ -200,31 +200,86 @@ jobs:
 
           run_openai_refresh
 
-      - name: Commit and push locale updates
+      - name: Prepare locale artifact
         env:
           LOCALE: ${{ matrix.locale }}
+        run: |
+          set -euo pipefail
+          artifact_dir="${RUNNER_TEMP}/control-ui-locale-${LOCALE}"
+          mkdir -p "${artifact_dir}"
+          git add -A ui/src/i18n
+          git diff --cached --binary --full-index -- ui/src/i18n > "${artifact_dir}/${LOCALE}.patch"
+
+      - name: Upload locale artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: control-ui-locale-${{ matrix.locale }}
+          path: ${{ runner.temp }}/control-ui-locale-${{ matrix.locale }}/${{ matrix.locale }}.patch
+          if-no-files-found: error
+          retention-days: 1
+
+  finalize:
+    name: Commit control UI locale refresh
+    needs: refresh
+    if: needs.refresh.result == 'success'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          fetch-depth: 0
+          persist-credentials: true
+          submodules: false
+
+      - name: Download locale artifacts
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          pattern: control-ui-locale-*
+          path: ${{ runner.temp }}/control-ui-locale-artifacts
+          merge-multiple: true
+
+      - name: Apply locale artifacts
+        run: |
+          set -euo pipefail
+          while IFS= read -r patch; do
+            if [ -s "${patch}" ]; then
+              git apply "${patch}"
+            fi
+          done < <(find "${RUNNER_TEMP}/control-ui-locale-artifacts" -type f -name '*.patch' | sort)
+
+      - name: Setup Node environment
+        uses: ./.github/actions/setup-node-env
+        with:
+          install-bun: "false"
+
+      - name: Validate control UI locale refresh
+        run: node --import tsx scripts/control-ui-i18n.ts check
+
+      - name: Commit and push aggregate locale refresh
+        env:
           TARGET_BRANCH: ${{ github.event.repository.default_branch }}
         run: |
           set -euo pipefail
-          if git diff --quiet -- ui/src/i18n; then
-            echo "No control UI locale changes for ${LOCALE}."
+          if ! git status --porcelain -- ui/src/i18n | grep -q .; then
+            echo "No control UI locale changes."
             exit 0
           fi
 
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git add -A ui/src/i18n
-          git commit --no-verify -m "chore(ui): refresh ${LOCALE} control ui locale"
+          git commit --no-verify -m "chore(ui): refresh control ui locales"
 
           for attempt in 1 2 3 4 5; do
             git fetch origin "${TARGET_BRANCH}"
-            git rebase --autostash "origin/${TARGET_BRANCH}"
+            git rebase "origin/${TARGET_BRANCH}"
             if git push origin HEAD:"${TARGET_BRANCH}"; then
               exit 0
             fi
-            echo "Push attempt ${attempt} for ${LOCALE} failed; retrying."
+            git rebase --abort >/dev/null 2>&1 || true
+            echo "Aggregate push attempt ${attempt} failed; retrying."
             sleep $((attempt * 2))
           done
 
-          echo "Failed to push ${LOCALE} locale update after retries."
+          echo "Failed to push aggregate control UI locale update after retries."
           exit 1

--- a/.github/workflows/native-app-locale-refresh.yml
+++ b/.github/workflows/native-app-locale-refresh.yml
@@ -147,31 +147,91 @@ jobs:
 
           run_openai_refresh
 
-      - name: Commit and push locale artifact
+      - name: Prepare locale artifact
         env:
           LOCALE: ${{ matrix.locale }}
+        run: |
+          set -euo pipefail
+          artifact_dir="${RUNNER_TEMP}/native-locale-${LOCALE}"
+          mkdir -p "${artifact_dir}"
+          git add -A apps/.i18n/native
+          git diff --cached --binary --full-index -- apps/.i18n/native > "${artifact_dir}/${LOCALE}.patch"
+
+      - name: Upload locale artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: native-locale-${{ matrix.locale }}
+          path: ${{ runner.temp }}/native-locale-${{ matrix.locale }}/${{ matrix.locale }}.patch
+          if-no-files-found: error
+          retention-days: 1
+
+  finalize:
+    name: Commit native locale refresh
+    needs: refresh
+    if: needs.refresh.result == 'success'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          fetch-depth: 0
+          persist-credentials: true
+          submodules: false
+
+      - name: Download locale artifacts
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          pattern: native-locale-*
+          path: ${{ runner.temp }}/native-locale-artifacts
+          merge-multiple: true
+
+      - name: Apply locale artifacts
+        run: |
+          set -euo pipefail
+          while IFS= read -r patch; do
+            if [ -s "${patch}" ]; then
+              git apply "${patch}"
+            fi
+          done < <(find "${RUNNER_TEMP}/native-locale-artifacts" -type f -name '*.patch' | sort)
+
+      - name: Setup Node environment
+        uses: ./.github/actions/setup-node-env
+        with:
+          install-bun: "false"
+
+      # Every worker observes the same source inventory. Generate it once here
+      # so locale patches remain independent and can be applied sequentially.
+      - name: Refresh shared native inventory
+        run: node --import tsx scripts/native-app-i18n.ts sync --write
+
+      - name: Validate native locale refresh
+        run: node --import tsx scripts/native-app-i18n.ts check
+
+      - name: Commit and push aggregate locale refresh
+        env:
           TARGET_BRANCH: ${{ github.event.repository.default_branch }}
         run: |
           set -euo pipefail
           if ! git status --porcelain -- apps/.i18n/native apps/.i18n/native-source.json | grep -q .; then
-            echo "No native locale changes for ${LOCALE}."
+            echo "No native locale changes."
             exit 0
           fi
 
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git add -A apps/.i18n/native apps/.i18n/native-source.json
-          git commit --no-verify -m "chore(i18n): refresh native ${LOCALE} locale"
+          git commit --no-verify -m "chore(i18n): refresh native locales"
 
           for attempt in 1 2 3 4 5; do
             git fetch origin "${TARGET_BRANCH}"
-            git rebase --autostash "origin/${TARGET_BRANCH}"
+            git rebase "origin/${TARGET_BRANCH}"
             if git push origin HEAD:"${TARGET_BRANCH}"; then
               exit 0
             fi
-            echo "Push attempt ${attempt} for ${LOCALE} failed; retrying."
+            git rebase --abort >/dev/null 2>&1 || true
+            echo "Aggregate push attempt ${attempt} failed; retrying."
             sleep $((attempt * 2))
           done
 
-          echo "Failed to push ${LOCALE} native locale update after retries."
+          echo "Failed to push aggregate native locale update after retries."
           exit 1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,43 +10,47 @@ Docs: https://docs.openclaw.ai
 - **External harness attachment:** `openclaw attach` launches an external harness against an existing Gateway session, making interactive Codex-style workflows easier to resume and inspect. (#96454) Thanks @anagnorisis2peripeteia and @obviyus.
 - **Telegram Codex workflows:** Telegram can now start Codex pairing with `/login`, steer active Codex runs, and recover final replies across transient API failures. (#98006, #98126, #98786) Thanks @100yenadmin, @Kyzcreig, and @obviyus.
 - **Event-driven cron runs:** the new `on-exit` schedule kind wakes an agent when a watched command exits, while session-targeted runs can detach cleanly. (#92037, #98755) Thanks @anagnorisis2peripeteia, @obviyus, and @EthanSK.
-- **Native app refresh:** iOS adopts the iOS 26 visual system with clearer Chat, Talk, and onboarding flows, while native app localization expands across Apple and Android surfaces. (#98452, #98736, #97110, #97111, #97112, #97113) Thanks @vincentkoc.
+- **Native app refresh:** iOS adopts the iOS 26 visual system with clearer Chat, Talk, onboarding, and reconnect flows, while native app localization expands across Apple and Android surfaces. (#98452, #98736, #99243, #97110, #97111, #97112, #97113) Thanks @jcooley8 and @vincentkoc.
 - **Richer messaging:** iMessage gains native poll creation, reading, and voting, and built-in usage footers provide clearer per-turn accounting in chat. (#98421, #92657, #92877) Thanks @omarshahine, @lobster, and @Marvinthebored.
 - **Safer scoped conversations:** capability profiles prepare per-conversation tool and access boundaries without weakening the existing default profile. (#98536)
+- **Mac local Gateway setup:** the macOS app can now install and start its local Gateway automatically, reducing the manual setup needed before first use. (#99767)
+- **Control UI navigation:** a session-first sidebar, compact context meter, warm light theme, reasoning-effort slider, streamlined composer, and slash-command picker make active conversations and commands easier to reach. (#99289, #99426, #99838) Thanks @VicZhang6 and @Solvely-Colin.
 
 ### Changes
 
 - **ClawRouter routing and quotas:** add the bundled ClawRouter provider plugin with credential-scoped dynamic model discovery, OpenAI-compatible and native Anthropic/Gemini transports, and managed budget reporting across OpenClaw usage surfaces. (#99658)
 - **Model and provider coverage:** add GPT-5.6 support, use Nemotron Super's 1M context window, and preserve explicit OpenRouter authentication headers. (#98333, #98726, #98187) Thanks @steipete-oai, @eleqtrizit, @sunlit-deng, and @laurencebrown.
-- **CLI and node workflows:** add `openclaw attach`, node context-path support, actionable device-approval recovery guidance, and clearer plugin install exit diagnostics. (#96454, #97679, #98115, #98146, #98497) Thanks @anagnorisis2peripeteia, @obviyus, @wm0018, @welfo-beo, @RomneyDa, @Sanjays2402, and @vincentkoc.
+- **CLI and node workflows:** add `openclaw attach`, node context-path support, actionable device-approval recovery guidance, soft-resume CLI sessions when prompt metadata changes, and clearer plugin install exit diagnostics. (#96454, #97679, #98115, #98146, #98497, #99822) Thanks @anagnorisis2peripeteia, @obviyus, @wm0018, @welfo-beo, @RomneyDa, @Sanjays2402, and @vincentkoc.
 - **Cron and usage:** add exit-triggered schedules, detached session-targeted runs, an in-flight job doctor warning, and a built-in full usage footer. (#92037, #98755, #98620, #92657, #92877) Thanks @anagnorisis2peripeteia, @obviyus, @EthanSK, @masatohoshino, and @Marvinthebored.
-- **Native apps and localization:** modernize iOS presentation and Talk controls, add Gateway speech providers, improve QR onboarding and protocol recovery, localize core Apple and Android surfaces, and add Swedish mobile localization. (#98452, #98736, #98376, #98302, #98385, #97110, #97111, #97112, #97113, #98043) Thanks @Tony-ooo, @joelnishanth, @cursoragent, @joshavant, @vincentkoc, and @yeager.
-- **Messaging capabilities:** add native iMessage polls and Telegram Codex pairing and steering flows. (#98421, #98006, #98126) Thanks @omarshahine, @lobster, @100yenadmin, and @Kyzcreig.
+- **Native apps and localization:** modernize iOS presentation, Chat, Talk, onboarding, and reconnect flows; add Gateway speech providers; improve QR onboarding and protocol recovery; install the local Gateway from macOS; localize core Apple and Android surfaces; and add Swedish mobile localization. (#98452, #98736, #99243, #98376, #98302, #98385, #99767, #97110, #97111, #97112, #97113, #98043) Thanks @jcooley8, @Tony-ooo, @joelnishanth, @cursoragent, @joshavant, @vincentkoc, and @yeager.
+- **Messaging capabilities:** add native iMessage polls, Telegram Codex pairing and steering, Telegram multi-lane progress summaries, and Signal target aliases. (#98421, #98006, #98126, #98907, #95738) Thanks @omarshahine, @lobster, @100yenadmin, @Kyzcreig, @Marvinthebored, and @jesse-merhi.
+- **Local inference and chat controls:** auto-discover Ollama inference nodes, add Control UI session-first navigation, reasoning controls, and command picking, and keep OpenClaw control tools available when deferred tool search selects the wrong tool family. (#99234, #99289, #99426, #99838, #99561) Thanks @100yenadmin, @joshavant, @VicZhang6, and @Solvely-Colin.
 - **Doctor and diagnostics:** expose auth-profile, workspace, device-pairing, channel-plugin, memory-provider, systemd exhaustion, and Windows LAN firewall findings. (#97125, #97358, #97366, #97496, #97968, #98291, #98666) Thanks @giodl73-repo, @masatohoshino, and @joshavant.
 - **Conversation and review controls:** prepare scoped conversation capability profiles and add Cursor Agent as an autoreview engine. (#98536, #97348) Thanks @hxy91819.
 
 ### Fixes
 
 - **ClawRouter auth profiles:** resolve credential-scoped catalog models during agent runs when the proxy key is stored in an auth profile, and document plugin and model allowlists.
-- **Telegram durability:** recover stalled ingress claims, retry restart-dropped media, survive transient polling errors, dead-letter poison updates, preserve forwarded rich text, route plugin callbacks correctly, and fall back safely when rich final replies are rejected. (#97118, #98102, #98735, #98775, #98776, #97174, #98786) Thanks @vincentkoc, @luoyanglang, @DaveArcher18, @obviyus, and @goldmar.
-- **Agent and context reliability:** preserve runtime overrides and steered subagent tasks, improve harness-aware context estimation and compaction prechecks, time out silent local streams, recover mid-stream failures, and cap Gateway run-cache growth. (#92237, #77539, #97928, #97861, #98525, #95430, #77973) Thanks @sercada, @amittell, @liuhao1024, @yetval, @osolmaz, @lzyyzznl, @vincentkoc, @alexelgier, and @fede-kamel.
+- **Telegram durability:** recover stalled ingress claims, retry restart-dropped media, survive transient polling errors, dead-letter poison updates, preserve forwarded rich text, route plugin callbacks correctly, keep progress updates in one stable multi-line window, and fall back safely when Telegram rejects rich final replies. (#97118, #98102, #98735, #98775, #98776, #97174, #98907, #98786) Thanks @vincentkoc, @luoyanglang, @DaveArcher18, @obviyus, @goldmar, @Marvinthebored, and @shakkernerd.
+- **Agent and context reliability:** preserve runtime overrides, steered subagent tasks, fallback tool-call hints, and legacy reseed attachments; soft-resume CLI sessions across prompt-only drift; improve harness-aware context estimation and compaction prechecks; time out silent local streams; recover mid-stream failures; and cap Gateway run-cache growth. (#92237, #77539, #99851, #99839, #99822, #97928, #97861, #98525, #95430, #77973) Thanks @sercada, @amittell, @obviyus, @liuhao1024, @yetval, @osolmaz, @lzyyzznl, @vincentkoc, @alexelgier, and @fede-kamel.
 - **Provider and network safety:** bound oversized or malformed responses across Moonshot, MiniMax, Anthropic OAuth, Discord, Matrix, SMS, browser, update, embeddings, Tlön, and Inworld paths. (#96502, #96322, #96644, #97693, #97662, #97999, #98455, #98508, #98554, #98496, #98660) Thanks @hugenshen, @cursoragent, @lsr911, @solodmd, @Alix-007, @wings1029, @lzyyzznl, @sunlit-deng, @vincentkoc, and @Pandah97.
-- **Channel delivery and routing:** keep Slack replies in the active thread, preserve account-bound delivery routes, apply response prefixes, suppress internal traces and unwanted fallback replies, and retain WeChat session routing for opaque account ids. (#97168, #98240, #89949, #93639, #97989, #80928, #93686) Thanks @LiuwqGit, @gorkem2020, @yetval, @wangwllu, @ZengWen-DT, @alexuser, @UnClouded77, @zhangguiping-xydt, and @htkillermax-gif.
+- **Channel delivery and routing:** keep Slack replies in the active thread, preserve account-bound delivery routes, apply response prefixes, suppress internal traces and unwanted fallback replies, and retain WeChat session routing for opaque account ids. (#97168, #98240, #89949, #93639, #97989, #80928, #93686) Thanks @LiuwqGit, @gorkem2020, @yetval, @wangwllu, @ZengWen-DT, @alexuser, @UnClouded77, @zhangguiping-xydt, @htkillermax-gif, and @vincentkoc.
 - **Cron correctness:** preserve provider and model selections on timeouts, retain startup catch-up deferrals, keep action-required output, clear blank thinking overrides, and preserve provider-owned daily-reset sessions. (#95943, #94022, #93810, #96393, #96293, #98356) Thanks @ZengWen-DT, @cursoragent, @luke-renjoy, @RichChen01, @vincentkoc, @yetval, @snowzlmbot, @nz365guy, and @takamasa-aiso.
 - **Memory and session recovery:** detect unindexed transcripts, preserve notes through transient reads, avoid cross-directory resumes, disambiguate reserved wiki index pages, and skip empty QMD sync work. (#97857, #98360, #97785, #94326, #90030) Thanks @zw-xysk, @CHE10X, @qingminglong, @yetval, @vincentkoc, @sahibzada-allahyar, and @ruben2000de.
 - **Windows and execution:** bind allowlisted execution to the validated Windows path, propagate `PATHEXT`, normalize inbound paths case-insensitively, and prevent cleanup crashes on Windows. (#98260, #98093, #97630, #97901) Thanks @eleqtrizit, @wendy-chsy, @VectorPeak, and @paulcam206.
-- **Mobile and UI stability:** preserve iOS chat line breaks and final replies, improve Android pairing and TLS recovery, hide expired pairing cards, and keep workspace file rails scrollable. (#98304, #98117, #98366, #98439, #98483, #98049, #98646, #98611) Thanks @joshavant, @Jabato01, @ooiuuii, @wuqxuan, @645648406-max, and @zw-xysk.
+- **Mobile and UI stability:** preserve iOS chat line breaks and final replies, improve Android pairing and TLS recovery, hide expired pairing cards, keep workspace file rails scrollable, restore copy-path over plain HTTP, and stop rubber-band scrolling in the Mac app Control UI. (#98304, #98117, #98366, #98439, #98483, #98049, #98646, #98611, #98764, #99830) Thanks @joshavant, @Jabato01, @ooiuuii, @wuqxuan, @645648406-max, @zw-xysk, @ZengWen-DT, and @adinballew.
 - **Codex and approval flows:** report ChatGPT authentication correctly, rename destructive approval mode to `ask`, classify dynamic goal and session tool results accurately, and derive terminal-idle timeouts from the explicit run deadline. (#91240, #98501, #98659, #96856, #85296) Thanks @849261680, @ukstem, @kevinslin, @yetval, @nxmxbbd, @alkor2000, and @vincentkoc.
-- **Configuration and plugin health:** surface unloadable channel plugins, preserve defaulted provider base URLs during patches, validate bundled plugin updates by manifest contract, and retain legacy ClawHub families where required. (#96397, #98396, #98010, #98249) Thanks @849261680, @momothemage, @weltmaister, @LiLan0125, @herove, and @Patrick-Erichsen.
-- **QQBot media delivery:** scope sandbox-generated media sends to the active session's workspace so `/workspace/...` and relative generated-file paths resolve safely across QQBot media tags, structured payloads, and streaming delivery. (#92872) Thanks @zhangguiping-xydt.
+- **Configuration and plugin health:** restrict config traversal to owned properties, preserve config-health recovery state, surface unloadable channel plugins, preserve defaulted provider base URLs during patches, validate bundled plugin updates by manifest contract, resolve public artifacts from installed plugin roots, and retain legacy ClawHub families where required. (#99846, #99728, #96397, #98396, #98010, #98819, #98249) Thanks @vincentkoc, @zenglingbiao, @joshavant, @jalehman, @ccbridle, @849261680, @momothemage, @weltmaister, @LiLan0125, @herove, @amknight, @KelTech-Services, and @Patrick-Erichsen.
+- **Runtime process safety:** prevent unhandled child-stream errors in SSH tunnels, supervisors, and MCP stdio transports; keep auto-replies from waiting on transcript mirroring; and avoid splitting Unicode characters in approval previews and LINE outbound fields. (#99800, #99802, #99803, #99549, #99566, #98994) Thanks @cxbAsDev, @vincentkoc, @Shagrat2, @mikasa0818, and @LEXES7.
+- **Node runtime compatibility:** installers, the CLI launcher, doctor, and the macOS app now reject incompatible Node 23 runtimes and guide users toward supported Node 22 or 24 releases. (#99832) Thanks @vincentkoc and @fuller-stack-dev.
+- **QQBot media delivery:** scope sandbox-generated media sends to the active session's workspace so `/workspace/...` and relative generated-file paths resolve safely across QQBot media tags, structured payloads, and streaming delivery. (#92872) Thanks @zhangguiping-xydt and @sliverp.
 
 ### Complete contribution record
 
-This audited record covers the complete 66e676d29b92d040716376a75aca32bad655cfac..3e50f41dd6ea3446b5c98a2f19ec70982ac908e6 history: 212 merged PRs. The generation manifest also supplies direct commits as editorial input; the grouped notes above prioritize user impact.
+This audited record covers the complete 66e676d29b92d040716376a75aca32bad655cfac..1e20f15581f9fe9132768379bd80cc74c047b8cc history: 455 merged PRs. The generation manifest also supplies direct commits as editorial input; the grouped notes above prioritize user impact.
 
 #### Pull requests
 
-- **PR #92872** fix(qqbot): allow scoped sandbox media sends. Thanks @zhangguiping-xydt.
 - **PR #96502** fix(moonshot): bound video description JSON response reads. Thanks @hugenshen and @cursoragent.
 - **PR #98249** Preserve legacy ClawHub family for selected plugins. Thanks @Patrick-Erichsen.
 - **PR #93767** fix(reasoning-tags): strip MiniMax `mm:` namespaced reasoning tags. Thanks @DrHack1.
@@ -165,7 +169,7 @@ This audited record covers the complete 66e676d29b92d040716376a75aca32bad655cfac
 - **PR #98318** docs(matrix): document missing streaming.progress mode, progress sub-fields, and mentionPatterns config. Thanks @wm0018 and @vincentkoc.
 - **PR #97753** docs(onboard): document 11 missing non-interactive CLI flags. Thanks @wm0018 and @vincentkoc.
 - **PR #97851** fix(mattermost): bound null-body error response reads. Thanks @Pick-cat.
-- **PR #98360** fix(memory-wiki): preserve notes after transient page reads. Related #98345. Thanks @qingminglong and @yetval.
+- **PR #98360** fix(memory-wiki): preserve notes after transient page reads. Related #98345. Thanks @qingminglong and @vincentkoc and @yetval.
 - **PR #98551** test: fix stale core test type failures. Thanks @RomneyDa.
 - **PR #98455** fix(browser): bound error body read in fetchHttpJson to prevent OOM. Thanks @wings1029.
 - **PR #95906** fix(code-mode): surface QuickJS error name and message to the model. Thanks @ZengWen-DT and @vincentkoc.
@@ -257,8 +261,251 @@ This audited record covers the complete 66e676d29b92d040716376a75aca32bad655cfac
 - **PR #97496** Doctor: expose channel plugin blocker findings. Thanks @giodl73-repo.
 - **PR #98792** fix(ci): restore docs and test type checks.
 - **PR #98736** improve(ios): simplify Talk controls and composer alignment.
+- **PR #98183** fix(gateway): distinguish reachable gateway from failed status probe. Thanks @masatohoshino.
+- **PR #98808** docs(telegram): move maintainer decisions into scoped AGENTS.md with reliability invariants. Thanks @obviyus.
+- **PR #98138** fix: guard setDeep against empty keys array in Chrome profile decoration. Thanks @zhangLei99586.
+- **PR #92283** fix(agents): don't inject A2A turns into isolated-cron sessions_send (#92257). Thanks @harjothkhara and @vincentkoc and @nailujac.
+- **PR #98812** fix(codex): preserve plugin app approvals in side conversations.
+- **PR #97889** fix(discord): guard JSON.parse against malformed API response bodies. Thanks @lsr911.
+- **PR #98689** fix(wizard): reject loose gateway port input. Related #98681. Thanks @qingminglong.
+- **PR #98720** fix(nostr): clear per-relay publish timeout timer to prevent dangling handles. Related #98463. Thanks @wangmiao0668000666 and @zhangLei99586.
+- **PR #98787** fix(memory-wiki): retry transient existing-page reads in wiki_apply and chatgpt import. Thanks @yetval and @vincentkoc.
+- **PR #98818** fix(ci): recover incomplete Swift build caches.
+- **PR #98811** feat(ios): modernize navigation and settings. Related #98803.
+- **PR #98843** docs: update mobile app release messaging. Thanks @joshavant.
+- **PR #93209** test: prefer auto-cleaning temp dir helper. Thanks @hxy91819.
+- **PR #98789** fix(telegram): sends and actions without an account id ignore the configured defaultAccount. Thanks @yetval.
+- **PR #98806** fix(telegram): webhook updates survive crashes and restarts via durable spooling. Related #98777. Thanks @obviyus.
+- **PR #98688** fix(fal): route grok-imagine and nano-banana-2-lite edits to correct endpoints. Thanks @davenicoll and @vincentkoc.
+- **PR #98891** fix(agents): normalize non-array tool-result content at transcript ingest. Related #98825. Thanks @obviyus and @snowzlmbot.
+- **PR #98781** fix(imessage): poll render vote-cue, cross-run echo suppression, and comment fold. Thanks @omarshahine.
+- **PR #97500** Doctor: expose tool result cap findings. Thanks @giodl73-repo.
+- **PR #98769** fix: Telegram replies duplicate recent context after sent replies. Related #98767. Thanks @rabsef-bicrym.
+- **PR #98933** fix(agents): stop gateway crash from wedged claude-cli turns and persist heartbeat session bindings. Related #98894, #98895. Thanks @obviyus.
+- **PR #98934** fix(agents): recover claude-cli context-overflow sessions and keep retry artifacts alive. Related #98897. Thanks @obviyus.
+- **PR #98908** refactor(agents): fold assistant string normalization into transcript ingest. Thanks @obviyus.
+- **PR #98738** fix(agents): fail fast with attributable reason after MCP stdio session dies mid-run. Thanks @masatohoshino and @vincentkoc.
+- **PR #98879** fix: backup skips volatile cache paths. Related #98865. Thanks @ZengWen-DT and @vincentkoc and @carterstebbins23-spec.
+- **PR #98942** fix(agents): unify claude-cli output classification across live and one-shot paths. Related #98896. Thanks @obviyus.
+- **PR #98932** fix(anthropic): restore Fable 5 Vertex simple completions.
+- **PR #98947** fix(cron): restore persistent session targets.
+- **PR #96523** fix(agents): preserve embedded OpenAI completions usage. Thanks @ly85206559 and @vincentkoc.
+- **PR #98758** perf(build): reduce plugin SDK declaration package size. Related #98757. Thanks @RomneyDa.
+- **PR #98877** fix(mattermost): include later team members in peer directory. Related #98871. Thanks @qingminglong.
+- **PR #98953** feat(ios): refine the chat experience. Related #98929.
+- **PR #98876** fix(terminal): preserve sibling home-prefix paths. Related #98872. Thanks @qingminglong.
+- **PR #98930** feat(ios): PR1 brand color palette overhaul. Thanks @joelnishanth.
+- **PR #94566** fix(android): make offline chat actionable. Thanks @Tosko4.
+- **PR #98955** fix(agents): preserve fresh tool result text under aggregate cap. Related #98874. Thanks @momothemage and @lamkan0210.
+- **PR #98059** [codex] Support Android selected photo access. Thanks @NianJiuZst.
+- **PR #98914** fix(android): return settings details to their originating tab on Back. Thanks @Lokimorty.
+- **PR #98898** fix(ios): back from settings details returns to the originating screen. Thanks @Lokimorty.
+- **PR #98235** fix(feishu): include video upload duration. Thanks @areslp.
+- **PR #98966** fix(discord): gate guild metadata reads [AI]. Thanks @pgondhi987.
+- **PR #98985** fix: clean up iOS About page copy. Related #98943. Thanks @sahilsatralkar.
+- **PR #98856** fix(ios): gateway error shows twice on the Settings Gateway page. Thanks @Lokimorty.
+- **PR #98936** fix: Control row icons use inconsistent row styling (iOS). Related #98916. Thanks @sahilsatralkar.
+- **PR #98040** [codex] Fix Android camera snap cleanup. Thanks @NianJiuZst.
+- **PR #99039** fix(macos): stop runtime config-health sidecar access. Related #98917. Thanks @momothemage and @P51moustache.
+- **PR #92667** ci: add process exec CodeQL security shard. Thanks @hxy91819.
+- **PR #98055** [codex] Gate Android Talk capture starts in background. Thanks @NianJiuZst.
+- **PR #98067** [codex] Cancel Android gateway pending RPCs on close. Thanks @NianJiuZst.
+- **PR #98698** fix(android): show specific gateway auth-recovery reason instead of generic label. Related #98046. Thanks @masatohoshino and @ccaprani.
+- **PR #83826** test(android): poll for stale TLS probe cleanup in auth test. Thanks @NeatGuyCoding.
+- **PR #98983** fix(agents): handle variadic claude --mcp-config and serialize gemini credential staging. Related #98944, #98945. Thanks @obviyus.
+- **PR #99145** fix(auto-reply): suppress room-event notice leaks. Thanks @obviyus.
+- **PR #99144** fix(auto-reply): default room events to silence. Thanks @obviyus.
+- **PR #98608** fix: Mattermost fails to load after configured plugin repair. Related #98564. Thanks @jacobtomlinson.
+- **PR #99143** fix(telegram): keep group history always on. Related #99142. Thanks @obviyus.
+- **PR #99159** fix(agents): claude-cli lifecycle cleanup — loopback fail-loud, exit-0 failover, bounded reseed, image sweep, one prepare cleanup owner. Related #98946. Thanks @obviyus.
+- **PR #98391** Expose disk space doctor lint findings. Thanks @giodl73-repo.
+- **PR #98835** fix(config/sessions): narrow reply-session initialization revision to identity fields. Related #98672. Thanks @moguangyu5-design and @jalehman and @AaronFaby.
+- **PR #99123** fix(android): ignore chat events with missing assistant role in voice text extraction. Thanks @ly85206559 and @cursoragent.
+- **PR #99147** fix(android): preserve split SMS permission grants. Thanks @NianJiuZst.
+- **PR #99107** fix(android): bracket IPv6 hosts in manual gateway URL composition. Thanks @ly85206559 and @cursoragent.
+- **PR #99158** fix: require Android contact and calendar write permissions in onboarding. Thanks @NianJiuZst.
+- **PR #99110** fix(android): strip ws scheme prefix from manual gateway host input. Related #87216. Thanks @ly85206559 and @cursoragent and @ruben2000de.
+- **PR #99212** fix(ci): session concurrency test flakes during child handshake.
+- **PR #94385** fix(feishu): preserve button command values in fallback text and add Feishu comment guidance with callback privacy. Related #69754. Thanks @xialonglee and @1yihui.
+- **PR #98563** fix: route iOS OpenAI realtime Talk through WebRTC. Thanks @PollyBot13.
+- **PR #99204** fix: require Android contact and calendar write permissions. Thanks @NianJiuZst.
+- **PR #99134** fix: OAuth refresh failures report reauth instead of stale success. Related #99120. Thanks @100yenadmin.
+- **PR #99153** fix: clean up Android camera clips on cancellation. Thanks @NianJiuZst.
+- **PR #99118** [codex] fix(memory-lancedb): align apache arrow peer dependency. Related #90295. Thanks @allenhurff and @joshavant.
+- **PR #98066** fix: keep iOS LAN QR pairing authenticated after bootstrap. Related #98064. Thanks @ooiuuii.
+- **PR #99155** fix: stop iOS screen recording after cancellation. Thanks @NianJiuZst.
+- **PR #95973** fix(telegram): explain disabled plugin approval failures. Related #95800. Thanks @MonkeyLeeT and @ChrisBot2026.
+- **PR #99233** fix: ignore test-only network CI guard lines. Thanks @joshavant.
+- **PR #98951** fix: strict guarded fetch fails before managed proxy DNS. Related #98925. Thanks @momothemage and @sandl99.
+- **PR #99137** fix: prevent Voice Wake crash after Talk audio capture. Thanks @PollyBot13.
+- **PR #99052** fix: Update Dark/Light mode UI control appearance. Related #98995. Thanks @sahilsatralkar.
+- **PR #99245** fix(ios): return chat to originating control detail. Thanks @Solvely-Colin.
+- **PR #92602** fix(android): queue node events until gateway connect. Related #79552. Thanks @ashishpatel26 and @hectorrp13.
+- **PR #98277** fix: keep Android gateway settings save idempotent. Thanks @Solvely-Colin.
+- **PR #99256** fix(auto-reply): single canonical group history and deduped turn metadata. Related #99218. Thanks @obviyus.
+- **PR #99259** fix(android): use Bluetooth microphones for voice capture. Related #96241. Thanks @gwtaylor.
+- **PR #98751** test(qa): prove native command targeting across QA transports. Thanks @RomneyDa.
+- **PR #98779** test(qa): cover expanded Crabline bindings. Thanks @RomneyDa.
+- **PR #99262** test(qa): cover Crabline Signal sends. Thanks @RomneyDa.
+- **PR #99261** refactor(shared): establish lazy runtime loader foundation. Thanks @RomneyDa.
+- **PR #99264** test(qa): cover Crabline Mattermost sends. Thanks @RomneyDa.
+- **PR #99265** test(qa): cover Crabline Matrix sends. Thanks @RomneyDa.
+- **PR #98400** Expose heartbeat template doctor lint findings. Thanks @giodl73-repo.
+- **PR #98695** Expose legacy plugin manifest doctor lint findings. Thanks @giodl73-repo.
+- **PR #99278** refactor(shared): consolidate core leaf lazy loaders. Thanks @RomneyDa.
+- **PR #99274** fix(zalo): match native bot identity fields. Thanks @RomneyDa.
+- **PR #99126** test(discord): clarify and guardrail gateway proxy selection. Related #98266. Thanks @svuppala2006 and @joshavant and @sallyom.
+- **PR #99290** feat(ios): add licenses settings screen. Thanks @joshavant.
+- **PR #98907** fix(telegram): distinguish and render streamed reasoning/commentary progress lanes. Thanks @Marvinthebored.
+- **PR #99294** fix(qa): stagger isolated worker startup. Thanks @RomneyDa.
+- **PR #99276** fix(memory-wiki): source imports crash on unreadable pages. Thanks @obviyus.
+- **PR #99296** refactor(shared): consolidate gateway and stateful runtime lazy loaders. Thanks @RomneyDa.
+- **PR #98768** Allow alternate Zalo Bot API roots. Thanks @RomneyDa.
+- **PR #99298** refactor(shared): consolidate Discord Slack and Telegram lazy loaders. Thanks @RomneyDa.
+- **PR #99307** fix(memory-wiki): avoid implicit error coercion. Thanks @RomneyDa.
+- **PR #99306** feat(auto-reply): persist ambient room events as transcript rows. Related #99257. Thanks @obviyus.
+- **PR #99302** refactor(shared): consolidate remaining channel lazy loaders. Thanks @RomneyDa.
+- **PR #99303** test(qa): cover Crabline Zalo transport. Thanks @RomneyDa.
+- **PR #99299** feat(android): add licenses settings screen. Thanks @joshavant.
+- **PR #99220** fix(ios): onboarding Retry Connection does nothing after editing gateway details. Related #99219. Thanks @abdullahtas0.
+- **PR #98749** refactor(shared): consolidate provider and utility lazy loaders. Thanks @RomneyDa.
+- **PR #99355** fix(ci): restore Telegram and plugin SDK guard checks. Thanks @RomneyDa.
+- **PR #88899** fix(android): render chat content through Markdown. Related #88014. Thanks @Pluviobyte and @Iman-Sharif.
+- **PR #99310** test(qa): migrate channel streaming evidence to transport flow. Thanks @RomneyDa.
+- **PR #99350** fix(ios): add Photos permission controls. Related #99046. Thanks @Tony-ooo.
+- **PR #99361** refactor(plugins): consolidate record guards. Thanks @RomneyDa.
+- **PR #99359** refactor(shared): consolidate core record guards. Thanks @RomneyDa.
+- **PR #97208** fix: avoid DeepSeek-native thinking on OpenRouter V4. Related #97196. Thanks @NianJiuZst and @patelmm79.
+- **PR #99385** fix(sessions): scope ambient transcript watermark to session id. Related #99373. Thanks @obviyus.
+- **PR #99389** fix(auto-reply): restore per-turn message-tool delivery contract. Related #99371. Thanks @obviyus.
+- **PR #98269** fix(android): derive Voice readiness from Gateway catalog. Related #98268. Thanks @Solvely-Colin.
+- **PR #92872** fix(qqbot): allow scoped sandbox media sends. Thanks @zhangguiping-xydt and @sliverp.
+- **PR #99414** fix(android): expose exact gateway recovery actions. Related #98045, #98046. Thanks @ccaprani.
+- **PR #99289** feat: session-first sidebar, compact context ring, and warm light theme for the Control UI. Related #99288.
+- **PR #99234** feat(nodes): add auto-discovered Ollama inference. Related #99228.
+- **PR #97095** fix: memory_search honors generic embedding providers. Thanks @849261680.
+- **PR #98841** fix(gateway): include session label in deriveSessionTitle fallback chain. Related #98742. Thanks @SunnyShu0925 and @BSG2000.
+- **PR #99301** fix(feishu): catch unhandled promise rejection in streaming card flush timer. Thanks @lwy-2.
+- **PR #99391** fix(compaction): count nested tool result content. Related #99375. Thanks @LZY3538 and @imchloe92.
+- **PR #99407** fix(daemon): avoid loading full gateway logs during diagnostics. Thanks @sunlit-deng.
+- **PR #99291** Fix/issue 98958 gateway lock fd leak. Related #98958. Thanks @chenyangjun-xy and @zhangLei99586.
+- **PR #99475** fix(ios): contacts.add crashes the app via unfetched CNContactFormatter keys. Thanks @abdullahtas0.
+- **PR #98003** fix(anthropic): wire buildGuardedModelFetch into the Cloudflare createClient branch. Thanks @wangmiao0668000666.
+- **PR #99425** fix: strip conda env marker from host tool runs. Related #99424. Thanks @ooiuuii and @krissding.
+- **PR #99398** fix(cli): reject unsafe sessions tail counts. Thanks @qingminglong.
+- **PR #98855** fix: chat.send no reply when thinking metadata is set. Thanks @jesse-merhi.
+- **PR #98752** Rework Android gateway onboarding setup. Thanks @jesse-merhi.
+- **PR #99446** fix(agents): preserve fd find failures. Thanks @zhangguiping-xydt.
+- **PR #99152** fix(config): use Object.hasOwn instead of in operator in restoreOriginalValueOrThrow. Thanks @zenglingbiao.
+- **PR #99460** fix: redact dotted API key activity previews. Related #99459. Thanks @ooiuuii.
+- **PR #99455** fix: long mobile media recordings time out. Thanks @NianJiuZst.
+- **PR #99410** fix(subagents): match requesterSessionKey when controllerSessionKey differs in list filter. Related #75593. Thanks @sheyanmin and @aaajiao.
+- **PR #98791** feat(signal): show status reactions during inbound replies. Thanks @jesse-merhi.
+- **PR #98683** fix(ui): keep landscape composer compact. Related #98615. Thanks @qingminglong and @jin-li.
+- **PR #99428** fix(logging): redact Telegram bot tokens from timeout URLs. Related #96982. Thanks @xialonglee and @liuhaiyang14.
+- **PR #99217** Preserve Codex output after missing turn completion. Thanks @100yenadmin and @Sedrak-Hovhannisyan and @fuller-stack-dev.
+- **PR #99520** fix(gateway): declare the dev agent required by the gateway e2e session key. Related #99513. Thanks @masatohoshino.
+- **PR #95738** feat(signal): add target aliases. Thanks @jesse-merhi.
+- **PR #98258** improve: make native chat scrolling reader-managed. Related #98255. Thanks @christopheraaronhogg.
+- **PR #99506** fix: keep always-on group fallback messages in dispatch. Related #99457. Thanks @LZY3538 and @zqchris.
+- **PR #89671** fix(google-meet): force English Meet UI via hl=en so automation works on any locale. Thanks @Unayung.
+- **PR #98130** fix(infra): bound jsonl-socket response buffer to prevent OOM. Thanks @Pick-cat.
+- **PR #99526** fix(agents): preserve primitive tool result output. Related #99523. Thanks @snowzlm.
+- **PR #99525** fix(imessage): recognize bare hex group chat identifiers as chat targets. Related #89235. Thanks @MatthewDelprado.
+- **PR #99098** fix: harden native i18n identifier filtering. Thanks @hxy91819.
+- **PR #99099** fix: harden docs map heading rendering. Thanks @hxy91819.
+- **PR #98725** Expose legacy plugin dependency doctor lint findings. Thanks @giodl73-repo.
+- **PR #99595** fix(agents): keep cli session binding facts session-stable. Related #99372. Thanks @obviyus.
+- **PR #90152** fix(telegram): stop duplicate fallback when dispatch fails after final reply. Thanks @zhangguiping-xydt.
+- **PR #98729** Expose stale plugin runtime symlink doctor lint findings. Thanks @giodl73-repo.
+- **PR #99591** fix(android): preserve numeric invoke error codes. Thanks @ly85206559.
+- **PR #98406** Expose WhatsApp responsiveness doctor lint findings. Thanks @giodl73-repo.
+- **PR #99570** fix(android): reject IPv6 zone IDs in gateway endpoint URLs. Thanks @ly85206559 and @cursoragent.
+- **PR #99557** fix(android): filter device and internal sessions from thread picker. Thanks @ly85206559 and @cursoragent.
+- **PR #99568** fix(android): block self-package notification forwarding in allowlist mode. Thanks @ly85206559 and @cursoragent.
+- **PR #99592** fix(android): parse talk directive aliases case-insensitively. Thanks @ly85206559.
+- **PR #99477** fix: avoid iOS node permission prompts. Thanks @NianJiuZst.
+- **PR #99374** improve(qa): standardize script evidence output. Thanks @RomneyDa.
+- **PR #99468** improve: tighten iOS Control row density. Related #99439. Thanks @sahilsatralkar.
+- **PR #99642** test: avoid cross-OS socket close event race. Thanks @RomneyDa.
+- **PR #89967** fix(macos): LaunchAgent starts gateway on external home volumes. Related #87199. Thanks @zhangguiping-xydt and @joshdaynard.
+- **PR #98613** fix(media): guard ffprobe JSON parse against malformed output. Thanks @Pick-cat.
+- **PR #97839** fix: log terminal session persistence failures. Related #97795. Thanks @LZY3538 and @aniruddhaadak80.
+- **PR #99247** feat: clarify iOS Location Always permission flow. Thanks @PollyBot13.
+- **PR #98224** fix(auto-reply): strip stray punctuation before silent-reply token detection. Thanks @SunnyShu0925.
+- **PR #97328** fix(google): rotate Gemini API keys for LLM requests. Thanks @MonkeyLeeT.
+- **PR #99661** fix(macos): remote mode fails with managed SSH aliases.
+- **PR #99649** fix(qa): defer partial Crabline recorder rows. Related #99648. Thanks @RomneyDa.
+- **PR #99211** Expose legacy cron store doctor lint findings. Thanks @giodl73-repo.
+- **PR #99629** test(qa): redact script evidence diagnostics. Thanks @RomneyDa.
+- **PR #99647** Fix Slack retry for session init conflicts. Thanks @steipete-oai.
+- **PR #99628** improve: enforce canonical QA scenario ownership. Related #99627. Thanks @RomneyDa.
+- **PR #99632** refactor(qa): simplify transport adapter contracts. Related #99622. Thanks @RomneyDa.
+- **PR #99656** test(qa): use full-turn budget for native stop recovery. Related #99655. Thanks @RomneyDa.
+- **PR #99605** fix(google): bound OAuth token error response reads. Thanks @mushuiyu886.
+- **PR #99679** fix(qa): consume Crabline events without recorder polling. Related #99664. Thanks @RomneyDa.
+- **PR #99687** refactor(infra): consolidate SHA-256 digest helpers. Related #99675. Thanks @RomneyDa.
+- **PR #98796** [AI-assisted] feat(android): add chat command controls. Thanks @IWhatsskill.
+- **PR #99671** refactor: consolidate number coercion callers. Related #99667. Thanks @RomneyDa.
+- **PR #99640** fix: CLI agent session resume churns when owner and non-owner alternate in a group. Related #99633. Thanks @obviyus.
+- **PR #99682** refactor(models): consolidate catalog ref parsing. Related #99674. Thanks @RomneyDa.
+- **PR #99566** fix(exec): avoid splitting surrogate pairs in approval display. Thanks @mikasa0818.
+- **PR #99702** refactor: remove redundant unique-list aliases. Related #99697. Thanks @RomneyDa.
+- **PR #99246** feat(ios): implement branded typography design system. Thanks @joelnishanth and @cursoragent.
+- **PR #99710** fix(build): Docker package preparation misses plugin SDK declarations. Thanks @RomneyDa.
+- **PR #99715** refactor: consolidate image data URL formatting. Thanks @RomneyDa.
+- **PR #98764** fix(ui): copy workspace file paths over plain HTTP. Related #98759. Thanks @ZengWen-DT and @adinballew.
+- **PR #99678** fix(build): forward default exports through stable runtime aliases. Related #99677. Thanks @headbouyJB and @vincentkoc.
+- **PR #99370** fix(file-transfer): don't inline zero-byte files as image content blocks. Thanks @2loch-ness6 and @vincentkoc.
+- **PR #99540** fix(doctor): shell completion install fails doctor when profile is read-only. Related #99237. Thanks @rballiance and @hunglp6d.
+- **PR #99718** refactor(text): consolidate cleanup owners. Thanks @RomneyDa.
+- **PR #98819** fix(plugins): resolve public artifacts from installed plugin roots. Related #98740. Thanks @amknight and @KelTech-Services.
+- **PR #99721** refactor: consolidate async timing helpers. Thanks @RomneyDa.
+- **PR #99722** fix: group agent session resume churns when messages toggle between @-mention and plain. Related #99696. Thanks @obviyus.
+- **PR #99676** refactor: consolidate string reader mechanics. Related #99663. Thanks @RomneyDa.
+- **PR #99705** improve(qa): execute runtime scenarios through Docker. Thanks @RomneyDa.
+- **PR #99231** improve: native iOS look with stock SwiftUI navigation, forms, chat, and talk visualizer. Related #99195. Thanks @marvkr.
+- **PR #99549** fix(auto-reply): don't block reply completion on transcript mirror. Thanks @Shagrat2.
+- **PR #99736** fix(qa): prevent smoke gateways from losing built files. Related #99734. Thanks @RomneyDa.
+- **PR #99658** feat(providers): add ClawRouter routing and quotas. Related #99657.
+- **PR #99238** Expose channel preview warning doctor findings. Thanks @giodl73-repo.
+- **PR #99759** fix(providers): resolve ClawRouter auth-profile models.
+- **PR #99561** fix: keep OpenClaw control tools available when tool_search misroutes. Related #99464. Thanks @100yenadmin and @joshavant.
+- **PR #99750** refactor: consolidate exact boolean coercion. Thanks @RomneyDa.
+- **PR #99753** refactor: consolidate abort primitives. Thanks @RomneyDa.
+- **PR #99426** feat: add slash command picker in chat composer. Thanks @VicZhang6 and @Solvely-Colin.
+- **PR #99771** refactor: consolidate free-port test helpers. Thanks @RomneyDa.
+- **PR #99755** refactor: consolidate policy-free deferred promises. Thanks @RomneyDa.
+- **PR #99719** refactor(net): consolidate URL protocol predicates. Thanks @RomneyDa.
+- **PR #99743** fix: avoid native command QA timeout under CI contention. Thanks @RomneyDa.
+- **PR #99368** fix(qa): prevent qa smoke ci timeouts under gateway concurrency. Thanks @RomneyDa.
+- **PR #99778** refactor(scripts): share regexp literal escaping. Thanks @RomneyDa.
+- **PR #99737** test: add executable runtime fixture canaries. Thanks @RomneyDa.
+- **PR #99735** test(qa): exercise Gateway and MCP scenarios over real transports. Thanks @RomneyDa.
+- **PR #99784** fix(qa): stabilize primary smoke runtime evidence. Thanks @RomneyDa.
+- **PR #99726** fix(onboard): skip unavailable skill installers via lifecycle readiness preflight. Thanks @fuller-stack-dev and @Sedrak-Hovhannisyan.
+- **PR #99793** ci: reuse one package in QA smoke.
+- **PR #99767** feat(macos): install and run the local Gateway automatically. Related #99764.
+- **PR #99820** ci: increase artifact Testbox memory.
+- **PR #99822** feat: soft-resume CLI sessions on prompt drift instead of hard invalidation. Related #99729. Thanks @obviyus.
+- **PR #99129** fix(markdown-core): use Object.hasOwn instead of in operator in parseFrontmatterBlock. Thanks @zenglingbiao and @vincentkoc.
+- **PR #99803** fix(mcp): suppress unhandled error on stderr pipe in stdio transport. Thanks @cxbAsDev and @vincentkoc.
+- **PR #99802** fix(supervisor): suppress unhandled stream errors on child stdout/stderr. Thanks @cxbAsDev and @vincentkoc.
+- **PR #99800** fix(ssh-tunnel): handle spawn error to prevent unhandled rejection crash. Thanks @cxbAsDev and @vincentkoc.
+- **PR #99653** fix(cli): hide synthetic Claude reseed prompts. Related #99646. Thanks @ZOOWH and @vincentkoc and @Jeehut.
+- **PR #99728** fix(config): preserve recovery state during config-health migration. Related #99280. Thanks @joshavant and @jalehman and @ccbridle.
+- **PR #99839** fix(gateway): preserve legacy reseed attachments. Thanks @vincentkoc.
+- **PR #99830** fix: stop rubber-band bounce of the Control UI shell in the Mac app web view.
+- **PR #99851** fix(agents): preserve fallback tool-call hints. Thanks @vincentkoc.
+- **PR #98994** fix(line): truncate outbound altText, location, menu, and code fields on code point boundaries. Thanks @LEXES7 and @vincentkoc.
+- **PR #99846** fix(config): restrict config paths to own properties. Thanks @vincentkoc and @zenglingbiao.
+- **PR #99861** fix(telegram): one outbound rich-HTML normalizer and one rich-to-plain fallback policy. Related #99833. Thanks @obviyus.
+- **PR #99866** fix(telegram): classify inbound events from the canonical mention decision so direct mentions stop lurking. Related #99854. Thanks @obviyus.
+- **PR #99832** fix: reject incompatible Node 23 runtimes. Thanks @fuller-stack-dev.
+- **PR #99243** Polish iOS onboarding and chat critique fixes. Thanks @jcooley8.
+- **PR #99714** perf(usage): shrink durable usage cache entries. Related #99511. Thanks @dexhunter and @wayne524.
+- **PR #99838** feat: declutter the Control UI shell — reasoning effort slider, borderless composer controls, version out of the sidebar. Related #99837.
 - **PR #93686** fix(weixin): startAccount preserves session routing. Related #93556. Thanks @zhangguiping-xydt and @htkillermax-gif.
-
 ## 2026.6.11
 
 We heard the feedback. v2026.6.11 focuses on the rough edges that make OpenClaw feel less dependable, with fixes for misplaced replies, stuck sends, reconnects, model setup failures, and safer admin defaults.

--- a/apps/.i18n/native-source.json
+++ b/apps/.i18n/native-source.json
@@ -5859,7 +5859,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 303,
+      "line": 308,
       "path": "apps/ios/Sources/Chat/AppleReviewDemoChatTransport.swift",
       "source": "\\\"\\(trimmed)\\\"",
       "surface": "apple",
@@ -5867,7 +5867,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 303,
+      "line": 308,
       "path": "apps/ios/Sources/Chat/AppleReviewDemoChatTransport.swift",
       "source": "that request",
       "surface": "apple",
@@ -7202,8 +7202,16 @@
       "id": "native.apple.a97cdae7c8e13f0e"
     },
     {
+      "kind": "ui-localized-call",
+      "line": 100,
+      "path": "apps/ios/Sources/Design/ChatProTab.swift",
+      "source": "What would you like to work on?",
+      "surface": "apple",
+      "id": "native.apple.202b97e93b938049"
+    },
+    {
       "kind": "ui-call",
-      "line": 109,
+      "line": 111,
       "path": "apps/ios/Sources/Design/ChatProTab.swift",
       "source": "The session attaches once the gateway is ready.",
       "surface": "apple",
@@ -7211,7 +7219,7 @@
     },
     {
       "kind": "ui-modifier",
-      "line": 185,
+      "line": 187,
       "path": "apps/ios/Sources/Design/ChatProTab.swift",
       "source": "Opens Settings / Gateway",
       "surface": "apple",
@@ -7219,7 +7227,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 235,
+      "line": 237,
       "path": "apps/ios/Sources/Design/ChatProTab.swift",
       "source": "Connected",
       "surface": "apple",
@@ -7227,7 +7235,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 235,
+      "line": 237,
       "path": "apps/ios/Sources/Design/ChatProTab.swift",
       "source": "Unavailable",
       "surface": "apple",
@@ -7235,7 +7243,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 246,
+      "line": 248,
       "path": "apps/ios/Sources/Design/ChatProTab.swift",
       "source": "Connect to a gateway",
       "surface": "apple",
@@ -7243,11 +7251,59 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 246,
+      "line": 248,
       "path": "apps/ios/Sources/Design/ChatProTab.swift",
       "source": "Message \\(self.agentDisplayName)...",
       "surface": "apple",
       "id": "native.apple.e8173c7d24457256"
+    },
+    {
+      "kind": "ui-localized-call",
+      "line": 298,
+      "path": "apps/ios/Sources/Design/ChatProTab.swift",
+      "source": "Check OpenClaw status",
+      "surface": "apple",
+      "id": "native.apple.14492e334b87e4f2"
+    },
+    {
+      "kind": "ui-localized-call",
+      "line": 299,
+      "path": "apps/ios/Sources/Design/ChatProTab.swift",
+      "source": "Summarize the current OpenClaw status and tell me what needs attention.",
+      "surface": "apple",
+      "id": "native.apple.bbf7bd23da1e7865"
+    },
+    {
+      "kind": "ui-localized-call",
+      "line": 302,
+      "path": "apps/ios/Sources/Design/ChatProTab.swift",
+      "source": "What can I control here?",
+      "surface": "apple",
+      "id": "native.apple.ea8cbb1b4230c652"
+    },
+    {
+      "kind": "ui-localized-call",
+      "line": 303,
+      "path": "apps/ios/Sources/Design/ChatProTab.swift",
+      "source": "Show me which phone controls and device capabilities are available right now.",
+      "surface": "apple",
+      "id": "native.apple.451d25bdb3130ed0"
+    },
+    {
+      "kind": "ui-localized-call",
+      "line": 306,
+      "path": "apps/ios/Sources/Design/ChatProTab.swift",
+      "source": "Help me start voice chat",
+      "surface": "apple",
+      "id": "native.apple.503ec402d08bd43a"
+    },
+    {
+      "kind": "ui-localized-call",
+      "line": 307,
+      "path": "apps/ios/Sources/Design/ChatProTab.swift",
+      "source": "Help me start a realtime voice session from this phone.",
+      "surface": "apple",
+      "id": "native.apple.65e462758be96174"
     },
     {
       "kind": "ui-call",
@@ -10987,7 +11043,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 24,
+      "line": 25,
       "path": "apps/ios/Sources/Onboarding/OnboardingWizardSteps.swift",
       "source": "Welcome to OpenClaw",
       "surface": "apple",
@@ -10995,7 +11051,7 @@
     },
     {
       "kind": "ui-call-concatenated",
-      "line": 36,
+      "line": 37,
       "path": "apps/ios/Sources/Onboarding/OnboardingWizardSteps.swift",
       "source": "The connected agent can use capabilities you enable, including camera, microphone, photos, contacts, calendar, and location. Continue only if you trust the gateway and agent.",
       "surface": "apple",
@@ -11003,7 +11059,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 44,
+      "line": 45,
       "path": "apps/ios/Sources/Onboarding/OnboardingWizardSteps.swift",
       "source": "Security",
       "surface": "apple",
@@ -11011,7 +11067,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 57,
+      "line": 58,
       "path": "apps/ios/Sources/Onboarding/OnboardingWizardSteps.swift",
       "source": "You can change permissions later in Settings.",
       "surface": "apple",
@@ -11019,7 +11075,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 63,
+      "line": 64,
       "path": "apps/ios/Sources/Onboarding/OnboardingWizardSteps.swift",
       "source": "Continue",
       "surface": "apple",
@@ -11027,7 +11083,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 143,
+      "line": 146,
       "path": "apps/ios/Sources/Onboarding/OnboardingWizardSteps.swift",
       "source": "Connect Gateway",
       "surface": "apple",
@@ -11035,15 +11091,47 @@
     },
     {
       "kind": "ui-call",
-      "line": 147,
+      "line": 151,
       "path": "apps/ios/Sources/Onboarding/OnboardingWizardSteps.swift",
       "source": "/pair qr",
       "surface": "apple",
       "id": "native.apple.9f65b2eadb6aee92"
     },
     {
+      "kind": "conditional-branch",
+      "line": 161,
+      "path": "apps/ios/Sources/Onboarding/OnboardingWizardSteps.swift",
+      "source": "Copied",
+      "surface": "apple",
+      "id": "native.apple.fe3269c93d6f8524"
+    },
+    {
+      "kind": "conditional-branch",
+      "line": 161,
+      "path": "apps/ios/Sources/Onboarding/OnboardingWizardSteps.swift",
+      "source": "Copy",
+      "surface": "apple",
+      "id": "native.apple.bad4a8110ca864e1"
+    },
+    {
+      "kind": "conditional-branch",
+      "line": 169,
+      "path": "apps/ios/Sources/Onboarding/OnboardingWizardSteps.swift",
+      "source": "Copy pair command",
+      "surface": "apple",
+      "id": "native.apple.b6f3f5c300b28f17"
+    },
+    {
+      "kind": "conditional-branch",
+      "line": 169,
+      "path": "apps/ios/Sources/Onboarding/OnboardingWizardSteps.swift",
+      "source": "Pair command copied",
+      "surface": "apple",
+      "id": "native.apple.7308cbcb1e40d70e"
+    },
+    {
       "kind": "ui-call",
-      "line": 150,
+      "line": 174,
       "path": "apps/ios/Sources/Onboarding/OnboardingWizardSteps.swift",
       "source": "Run this in your OpenClaw chat, then scan the code.",
       "surface": "apple",
@@ -11051,7 +11139,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 162,
+      "line": 186,
       "path": "apps/ios/Sources/Onboarding/OnboardingWizardSteps.swift",
       "source": "Scan QR Code",
       "surface": "apple",
@@ -11059,7 +11147,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 171,
+      "line": 195,
       "path": "apps/ios/Sources/Onboarding/OnboardingWizardSteps.swift",
       "source": "Set Up Manually",
       "surface": "apple",
@@ -11115,7 +11203,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 144,
+      "line": 147,
       "path": "apps/ios/Sources/Onboarding/OnboardingWizardView.swift",
       "source": "Back",
       "surface": "apple",
@@ -11123,7 +11211,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 152,
+      "line": 155,
       "path": "apps/ios/Sources/Onboarding/OnboardingWizardView.swift",
       "source": "Close",
       "surface": "apple",
@@ -11131,7 +11219,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 167,
+      "line": 170,
       "path": "apps/ios/Sources/Onboarding/OnboardingWizardView.swift",
       "source": "Done",
       "surface": "apple",
@@ -11139,7 +11227,7 @@
     },
     {
       "kind": "ui-modifier",
-      "line": 175,
+      "line": 178,
       "path": "apps/ios/Sources/Onboarding/OnboardingWizardView.swift",
       "source": "QR Scanner Unavailable",
       "surface": "apple",
@@ -11147,7 +11235,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 180,
+      "line": 183,
       "path": "apps/ios/Sources/Onboarding/OnboardingWizardView.swift",
       "source": "OK",
       "surface": "apple",
@@ -11155,7 +11243,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 209,
+      "line": 212,
       "path": "apps/ios/Sources/Onboarding/OnboardingWizardView.swift",
       "source": "Scan QR Code",
       "surface": "apple",
@@ -11163,7 +11251,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 216,
+      "line": 219,
       "path": "apps/ios/Sources/Onboarding/OnboardingWizardView.swift",
       "source": "Cancel",
       "surface": "apple",
@@ -11171,7 +11259,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 223,
+      "line": 226,
       "path": "apps/ios/Sources/Onboarding/OnboardingWizardView.swift",
       "source": "Photos",
       "surface": "apple",
@@ -11179,7 +11267,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 347,
+      "line": 350,
       "path": "apps/ios/Sources/Onboarding/OnboardingWizardView.swift",
       "source": "LAN or Tailscale host",
       "surface": "apple",
@@ -11187,7 +11275,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 355,
+      "line": 358,
       "path": "apps/ios/Sources/Onboarding/OnboardingWizardView.swift",
       "source": "VPS with domain",
       "surface": "apple",
@@ -11195,7 +11283,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 366,
+      "line": 369,
       "path": "apps/ios/Sources/Onboarding/OnboardingWizardView.swift",
       "source": "For local iOS app development",
       "surface": "apple",
@@ -11203,7 +11291,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 381,
+      "line": 384,
       "path": "apps/ios/Sources/Onboarding/OnboardingWizardView.swift",
       "source": "Continue",
       "surface": "apple",
@@ -11211,7 +11299,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 390,
+      "line": 393,
       "path": "apps/ios/Sources/Onboarding/OnboardingWizardView.swift",
       "source": "Developer mode",
       "surface": "apple",
@@ -11219,7 +11307,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 418,
+      "line": 421,
       "path": "apps/ios/Sources/Onboarding/OnboardingWizardView.swift",
       "source": "Off",
       "surface": "apple",
@@ -11227,7 +11315,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 418,
+      "line": 421,
       "path": "apps/ios/Sources/Onboarding/OnboardingWizardView.swift",
       "source": "On",
       "surface": "apple",
@@ -11235,7 +11323,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 425,
+      "line": 428,
       "path": "apps/ios/Sources/Onboarding/OnboardingWizardView.swift",
       "source": "Mode",
       "surface": "apple",
@@ -11243,7 +11331,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 426,
+      "line": 429,
       "path": "apps/ios/Sources/Onboarding/OnboardingWizardView.swift",
       "source": "Discovery",
       "surface": "apple",
@@ -11251,7 +11339,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 428,
+      "line": 431,
       "path": "apps/ios/Sources/Onboarding/OnboardingWizardView.swift",
       "source": "Progress",
       "surface": "apple",
@@ -11259,7 +11347,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 430,
+      "line": 433,
       "path": "apps/ios/Sources/Onboarding/OnboardingWizardView.swift",
       "source": "Status",
       "surface": "apple",
@@ -11267,7 +11355,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 449,
+      "line": 452,
       "path": "apps/ios/Sources/Onboarding/OnboardingWizardView.swift",
       "source": "Choose a mode first.",
       "surface": "apple",
@@ -11275,7 +11363,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 454,
+      "line": 457,
       "path": "apps/ios/Sources/Onboarding/OnboardingWizardView.swift",
       "source": "Back to Mode Selection",
       "surface": "apple",
@@ -11283,7 +11371,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 466,
+      "line": 469,
       "path": "apps/ios/Sources/Onboarding/OnboardingWizardView.swift",
       "source": "No gateways found yet.",
       "surface": "apple",
@@ -11291,7 +11379,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 491,
+      "line": 494,
       "path": "apps/ios/Sources/Onboarding/OnboardingWizardView.swift",
       "source": "Resolving…",
       "surface": "apple",
@@ -11299,7 +11387,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 507,
+      "line": 510,
       "path": "apps/ios/Sources/Onboarding/OnboardingWizardView.swift",
       "source": "Restart Discovery",
       "surface": "apple",
@@ -11307,7 +11395,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 513,
+      "line": 516,
       "path": "apps/ios/Sources/Onboarding/OnboardingWizardView.swift",
       "source": "Discovered Gateways",
       "surface": "apple",
@@ -11315,7 +11403,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 517,
+      "line": 520,
       "path": "apps/ios/Sources/Onboarding/OnboardingWizardView.swift",
       "source": "Manual Fallback",
       "surface": "apple",
@@ -11323,7 +11411,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 522,
+      "line": 525,
       "path": "apps/ios/Sources/Onboarding/OnboardingWizardView.swift",
       "source": "Domain Settings",
       "surface": "apple",
@@ -11331,7 +11419,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 537,
+      "line": 540,
       "path": "apps/ios/Sources/Onboarding/OnboardingWizardView.swift",
       "source": "Developer Local",
       "surface": "apple",
@@ -11339,7 +11427,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 540,
+      "line": 543,
       "path": "apps/ios/Sources/Onboarding/OnboardingWizardView.swift",
       "source": "Default host is localhost. Use your Mac LAN IP if simulator networking requires it.",
       "surface": "apple",
@@ -11347,7 +11435,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 564,
+      "line": 567,
       "path": "apps/ios/Sources/Onboarding/OnboardingWizardView.swift",
       "source": "Gateway rejected credentials. Scan a fresh QR code or update token/password.",
       "surface": "apple",
@@ -11355,7 +11443,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 568,
+      "line": 571,
       "path": "apps/ios/Sources/Onboarding/OnboardingWizardView.swift",
       "source": "Auth token looks valid.",
       "surface": "apple",
@@ -11363,7 +11451,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 582,
+      "line": 585,
       "path": "apps/ios/Sources/Onboarding/OnboardingWizardView.swift",
       "source": "Resume After Approval",
       "surface": "apple",
@@ -11371,7 +11459,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 588,
+      "line": 591,
       "path": "apps/ios/Sources/Onboarding/OnboardingWizardView.swift",
       "source": "Pairing Approval",
       "surface": "apple",
@@ -11379,7 +11467,7 @@
     },
     {
       "kind": "ui-call-concatenated",
-      "line": 598,
+      "line": 601,
       "path": "apps/ios/Sources/Onboarding/OnboardingWizardView.swift",
       "source": "Approve this device on the gateway.\n1) `\\(commandLine)`\n2) `/pair approve` in your OpenClaw chat\n\\(requestLine)\nOpenClaw will also retry automatically when you return to this app.",
       "surface": "apple",
@@ -11387,7 +11475,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 612,
+      "line": 615,
       "path": "apps/ios/Sources/Onboarding/OnboardingWizardView.swift",
       "source": "Scan QR Code Again",
       "surface": "apple",
@@ -11395,7 +11483,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 625,
+      "line": 628,
       "path": "apps/ios/Sources/Onboarding/OnboardingWizardView.swift",
       "source": "Retry Connection",
       "surface": "apple",
@@ -11403,15 +11491,15 @@
     },
     {
       "kind": "ui-call",
-      "line": 666,
+      "line": 661,
       "path": "apps/ios/Sources/Onboarding/OnboardingWizardView.swift",
-      "source": "Open OpenClaw",
+      "source": "Go to Chat",
       "surface": "apple",
-      "id": "native.apple.f50052c1d760ec10"
+      "id": "native.apple.e674edbcb002aec6"
     },
     {
       "kind": "ui-call",
-      "line": 680,
+      "line": 675,
       "path": "apps/ios/Sources/Onboarding/OnboardingWizardView.swift",
       "source": "Paste setup code",
       "surface": "apple",
@@ -11419,7 +11507,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 695,
+      "line": 690,
       "path": "apps/ios/Sources/Onboarding/OnboardingWizardView.swift",
       "source": "Applying...",
       "surface": "apple",
@@ -11427,7 +11515,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 699,
+      "line": 694,
       "path": "apps/ios/Sources/Onboarding/OnboardingWizardView.swift",
       "source": "Apply Setup Code",
       "surface": "apple",
@@ -11435,7 +11523,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 714,
+      "line": 709,
       "path": "apps/ios/Sources/Onboarding/OnboardingWizardView.swift",
       "source": "Setup Code",
       "surface": "apple",
@@ -11443,7 +11531,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 717,
+      "line": 712,
       "path": "apps/ios/Sources/Onboarding/OnboardingWizardView.swift",
       "source": "Use this if you received a setup code instead of a QR code.",
       "surface": "apple",
@@ -11451,7 +11539,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 724,
+      "line": 719,
       "path": "apps/ios/Sources/Onboarding/OnboardingWizardView.swift",
       "source": "Host",
       "surface": "apple",
@@ -11459,7 +11547,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 728,
+      "line": 723,
       "path": "apps/ios/Sources/Onboarding/OnboardingWizardView.swift",
       "source": "Port",
       "surface": "apple",
@@ -11467,7 +11555,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 731,
+      "line": 726,
       "path": "apps/ios/Sources/Onboarding/OnboardingWizardView.swift",
       "source": "Use TLS",
       "surface": "apple",
@@ -11475,7 +11563,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 732,
+      "line": 727,
       "path": "apps/ios/Sources/Onboarding/OnboardingWizardView.swift",
       "source": "Discovery Domain (optional)",
       "surface": "apple",
@@ -11483,7 +11571,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 737,
+      "line": 732,
       "path": "apps/ios/Sources/Onboarding/OnboardingWizardView.swift",
       "source": "Gateway Auth Token",
       "surface": "apple",
@@ -11491,7 +11579,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 740,
+      "line": 735,
       "path": "apps/ios/Sources/Onboarding/OnboardingWizardView.swift",
       "source": "Gateway Password",
       "surface": "apple",
@@ -11499,7 +11587,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 784,
+      "line": 779,
       "path": "apps/ios/Sources/Onboarding/OnboardingWizardView.swift",
       "source": "Connecting…",
       "surface": "apple",
@@ -11659,7 +11747,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 990,
+      "line": 994,
       "path": "apps/ios/Sources/RootTabs.swift",
       "source": "Gateway needs attention",
       "surface": "apple",
@@ -11667,7 +11755,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 990,
+      "line": 994,
       "path": "apps/ios/Sources/RootTabs.swift",
       "source": "OpenClaw iOS",
       "surface": "apple",
@@ -11675,7 +11763,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1026,
+      "line": 1030,
       "path": "apps/ios/Sources/RootTabs.swift",
       "source": "Available",
       "surface": "apple",
@@ -11683,7 +11771,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1026,
+      "line": 1030,
       "path": "apps/ios/Sources/RootTabs.swift",
       "source": "Gateway default",
       "surface": "apple",
@@ -19731,7 +19819,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 404,
+      "line": 425,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatView.swift",
       "source": "Jump to latest",
       "surface": "apple",
@@ -19739,7 +19827,7 @@
     },
     {
       "kind": "ui-modifier",
-      "line": 415,
+      "line": 436,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatView.swift",
       "source": "Jump to latest reply",
       "surface": "apple",
@@ -19747,7 +19835,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 435,
+      "line": 456,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatView.swift",
       "source": "Refresh",
       "surface": "apple",
@@ -19755,7 +19843,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 832,
+      "line": 881,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatView.swift",
       "source": "Loading chat",
       "surface": "apple",
@@ -19763,7 +19851,7 @@
     },
     {
       "kind": "ui-modifier",
-      "line": 912,
+      "line": 961,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatView.swift",
       "source": "Dismiss",
       "surface": "apple",

--- a/apps/.i18n/native/ar.json
+++ b/apps/.i18n/native/ar.json
@@ -4504,6 +4504,11 @@
       "translated": "جاهز"
     },
     {
+      "id": "native.apple.202b97e93b938049",
+      "source": "What would you like to work on?",
+      "translated": "ما الذي ترغب في العمل عليه؟"
+    },
+    {
       "id": "native.apple.32179ce0b6d4543f",
       "source": "The session attaches once the gateway is ready.",
       "translated": "يتم إرفاق الجلسة بمجرد أن يصبح Gateway جاهزًا."
@@ -4532,6 +4537,36 @@
       "id": "native.apple.e8173c7d24457256",
       "source": "Message \\(self.agentDisplayName)...",
       "translated": "راسل \\(self.agentDisplayName)..."
+    },
+    {
+      "id": "native.apple.14492e334b87e4f2",
+      "source": "Check OpenClaw status",
+      "translated": "تحقق من حالة OpenClaw"
+    },
+    {
+      "id": "native.apple.bbf7bd23da1e7865",
+      "source": "Summarize the current OpenClaw status and tell me what needs attention.",
+      "translated": "لخّص حالة OpenClaw الحالية وأخبرني بما يحتاج إلى اهتمام."
+    },
+    {
+      "id": "native.apple.ea8cbb1b4230c652",
+      "source": "What can I control here?",
+      "translated": "ما الذي يمكنني التحكم فيه هنا؟"
+    },
+    {
+      "id": "native.apple.451d25bdb3130ed0",
+      "source": "Show me which phone controls and device capabilities are available right now.",
+      "translated": "اعرض لي عناصر التحكم في الهاتف وإمكانات الجهاز المتاحة الآن."
+    },
+    {
+      "id": "native.apple.503ec402d08bd43a",
+      "source": "Help me start voice chat",
+      "translated": "ساعدني في بدء محادثة صوتية"
+    },
+    {
+      "id": "native.apple.65e462758be96174",
+      "source": "Help me start a realtime voice session from this phone.",
+      "translated": "ساعدني في بدء جلسة صوتية فورية من هذا الهاتف."
     },
     {
       "id": "native.apple.e8018adcccaa2a4d",
@@ -6904,6 +6939,26 @@
       "translated": "/pair qr"
     },
     {
+      "id": "native.apple.fe3269c93d6f8524",
+      "source": "Copied",
+      "translated": "تم النسخ"
+    },
+    {
+      "id": "native.apple.bad4a8110ca864e1",
+      "source": "Copy",
+      "translated": "نسخ"
+    },
+    {
+      "id": "native.apple.b6f3f5c300b28f17",
+      "source": "Copy pair command",
+      "translated": "نسخ أمر الاقتران"
+    },
+    {
+      "id": "native.apple.7308cbcb1e40d70e",
+      "source": "Pair command copied",
+      "translated": "تم نسخ أمر الاقتران"
+    },
+    {
       "id": "native.apple.b727174424127618",
       "source": "Run this in your OpenClaw chat, then scan the code.",
       "translated": "شغّل هذا في دردشة OpenClaw لديك، ثم امسح الرمز ضوئيًا."
@@ -7129,9 +7184,9 @@
       "translated": "إعادة محاولة الاتصال"
     },
     {
-      "id": "native.apple.f50052c1d760ec10",
-      "source": "Open OpenClaw",
-      "translated": "فتح OpenClaw"
+      "id": "native.apple.e674edbcb002aec6",
+      "source": "Go to Chat",
+      "translated": "الانتقال إلى الدردشة"
     },
     {
       "id": "native.apple.4679e949156e07e3",

--- a/apps/.i18n/native/de.json
+++ b/apps/.i18n/native/de.json
@@ -4504,6 +4504,11 @@
       "translated": "Bereit"
     },
     {
+      "id": "native.apple.202b97e93b938049",
+      "source": "What would you like to work on?",
+      "translated": "Woran möchten Sie arbeiten?"
+    },
+    {
       "id": "native.apple.32179ce0b6d4543f",
       "source": "The session attaches once the gateway is ready.",
       "translated": "Die Sitzung wird angehängt, sobald die Gateway bereit ist."
@@ -4532,6 +4537,36 @@
       "id": "native.apple.e8173c7d24457256",
       "source": "Message \\(self.agentDisplayName)...",
       "translated": "Nachricht an \\(self.agentDisplayName)..."
+    },
+    {
+      "id": "native.apple.14492e334b87e4f2",
+      "source": "Check OpenClaw status",
+      "translated": "OpenClaw-Status prüfen"
+    },
+    {
+      "id": "native.apple.bbf7bd23da1e7865",
+      "source": "Summarize the current OpenClaw status and tell me what needs attention.",
+      "translated": "Fassen Sie den aktuellen OpenClaw-Status zusammen und sagen Sie mir, was Aufmerksamkeit erfordert."
+    },
+    {
+      "id": "native.apple.ea8cbb1b4230c652",
+      "source": "What can I control here?",
+      "translated": "Was kann ich hier steuern?"
+    },
+    {
+      "id": "native.apple.451d25bdb3130ed0",
+      "source": "Show me which phone controls and device capabilities are available right now.",
+      "translated": "Zeigen Sie mir, welche Telefonsteuerungen und Gerätefunktionen derzeit verfügbar sind."
+    },
+    {
+      "id": "native.apple.503ec402d08bd43a",
+      "source": "Help me start voice chat",
+      "translated": "Helfen Sie mir, den Voice-Chat zu starten"
+    },
+    {
+      "id": "native.apple.65e462758be96174",
+      "source": "Help me start a realtime voice session from this phone.",
+      "translated": "Helfen Sie mir, von diesem Telefon aus eine Echtzeit-Sprachsitzung zu starten."
     },
     {
       "id": "native.apple.e8018adcccaa2a4d",
@@ -6904,6 +6939,26 @@
       "translated": "/pair qr"
     },
     {
+      "id": "native.apple.fe3269c93d6f8524",
+      "source": "Copied",
+      "translated": "Kopiert"
+    },
+    {
+      "id": "native.apple.bad4a8110ca864e1",
+      "source": "Copy",
+      "translated": "Kopieren"
+    },
+    {
+      "id": "native.apple.b6f3f5c300b28f17",
+      "source": "Copy pair command",
+      "translated": "Kopplungsbefehl kopieren"
+    },
+    {
+      "id": "native.apple.7308cbcb1e40d70e",
+      "source": "Pair command copied",
+      "translated": "Kopplungsbefehl kopiert"
+    },
+    {
       "id": "native.apple.b727174424127618",
       "source": "Run this in your OpenClaw chat, then scan the code.",
       "translated": "Führen Sie dies in Ihrem OpenClaw-Chat aus und scannen Sie dann den Code."
@@ -7129,9 +7184,9 @@
       "translated": "Verbindung erneut versuchen"
     },
     {
-      "id": "native.apple.f50052c1d760ec10",
-      "source": "Open OpenClaw",
-      "translated": "OpenClaw öffnen"
+      "id": "native.apple.e674edbcb002aec6",
+      "source": "Go to Chat",
+      "translated": "Zum Chat"
     },
     {
       "id": "native.apple.4679e949156e07e3",

--- a/apps/.i18n/native/es.json
+++ b/apps/.i18n/native/es.json
@@ -4504,6 +4504,11 @@
       "translated": "Listo"
     },
     {
+      "id": "native.apple.202b97e93b938049",
+      "source": "What would you like to work on?",
+      "translated": "¿En qué te gustaría trabajar?"
+    },
+    {
       "id": "native.apple.32179ce0b6d4543f",
       "source": "The session attaches once the gateway is ready.",
       "translated": "La sesión se adjunta una vez que el gateway esté listo."
@@ -4532,6 +4537,36 @@
       "id": "native.apple.e8173c7d24457256",
       "source": "Message \\(self.agentDisplayName)...",
       "translated": "Mensaje para \\(self.agentDisplayName)..."
+    },
+    {
+      "id": "native.apple.14492e334b87e4f2",
+      "source": "Check OpenClaw status",
+      "translated": "Comprobar el estado de OpenClaw"
+    },
+    {
+      "id": "native.apple.bbf7bd23da1e7865",
+      "source": "Summarize the current OpenClaw status and tell me what needs attention.",
+      "translated": "Resume el estado actual de OpenClaw y dime qué necesita atención."
+    },
+    {
+      "id": "native.apple.ea8cbb1b4230c652",
+      "source": "What can I control here?",
+      "translated": "¿Qué puedo controlar aquí?"
+    },
+    {
+      "id": "native.apple.451d25bdb3130ed0",
+      "source": "Show me which phone controls and device capabilities are available right now.",
+      "translated": "Muéstrame qué controles del teléfono y capacidades del dispositivo están disponibles ahora mismo."
+    },
+    {
+      "id": "native.apple.503ec402d08bd43a",
+      "source": "Help me start voice chat",
+      "translated": "Ayúdame a iniciar el chat de voz"
+    },
+    {
+      "id": "native.apple.65e462758be96174",
+      "source": "Help me start a realtime voice session from this phone.",
+      "translated": "Ayúdame a iniciar una sesión de voz en tiempo real desde este teléfono."
     },
     {
       "id": "native.apple.e8018adcccaa2a4d",
@@ -6904,6 +6939,26 @@
       "translated": "/pair qr"
     },
     {
+      "id": "native.apple.fe3269c93d6f8524",
+      "source": "Copied",
+      "translated": "Copiado"
+    },
+    {
+      "id": "native.apple.bad4a8110ca864e1",
+      "source": "Copy",
+      "translated": "Copiar"
+    },
+    {
+      "id": "native.apple.b6f3f5c300b28f17",
+      "source": "Copy pair command",
+      "translated": "Copiar comando de emparejamiento"
+    },
+    {
+      "id": "native.apple.7308cbcb1e40d70e",
+      "source": "Pair command copied",
+      "translated": "Comando de emparejamiento copiado"
+    },
+    {
       "id": "native.apple.b727174424127618",
       "source": "Run this in your OpenClaw chat, then scan the code.",
       "translated": "Ejecuta esto en tu chat de OpenClaw y luego escanea el código."
@@ -7129,9 +7184,9 @@
       "translated": "Reintentar conexión"
     },
     {
-      "id": "native.apple.f50052c1d760ec10",
-      "source": "Open OpenClaw",
-      "translated": "Abrir OpenClaw"
+      "id": "native.apple.e674edbcb002aec6",
+      "source": "Go to Chat",
+      "translated": "Ir al chat"
     },
     {
       "id": "native.apple.4679e949156e07e3",

--- a/apps/.i18n/native/fa.json
+++ b/apps/.i18n/native/fa.json
@@ -4504,6 +4504,11 @@
       "translated": "آماده"
     },
     {
+      "id": "native.apple.202b97e93b938049",
+      "source": "What would you like to work on?",
+      "translated": "دوست دارید روی چه چیزی کار کنید؟"
+    },
+    {
       "id": "native.apple.32179ce0b6d4543f",
       "source": "The session attaches once the gateway is ready.",
       "translated": "پس از آماده شدن Gateway، نشست متصل می‌شود."
@@ -4532,6 +4537,36 @@
       "id": "native.apple.e8173c7d24457256",
       "source": "Message \\(self.agentDisplayName)...",
       "translated": "پیام به \\(self.agentDisplayName)..."
+    },
+    {
+      "id": "native.apple.14492e334b87e4f2",
+      "source": "Check OpenClaw status",
+      "translated": "بررسی وضعیت OpenClaw"
+    },
+    {
+      "id": "native.apple.bbf7bd23da1e7865",
+      "source": "Summarize the current OpenClaw status and tell me what needs attention.",
+      "translated": "وضعیت فعلی OpenClaw را خلاصه کن و بگو چه چیزهایی نیاز به توجه دارد."
+    },
+    {
+      "id": "native.apple.ea8cbb1b4230c652",
+      "source": "What can I control here?",
+      "translated": "اینجا چه چیزهایی را می‌توانم کنترل کنم؟"
+    },
+    {
+      "id": "native.apple.451d25bdb3130ed0",
+      "source": "Show me which phone controls and device capabilities are available right now.",
+      "translated": "به من نشان بده در حال حاضر کدام کنترل‌های تلفن و قابلیت‌های دستگاه در دسترس هستند."
+    },
+    {
+      "id": "native.apple.503ec402d08bd43a",
+      "source": "Help me start voice chat",
+      "translated": "برای شروع گفت‌وگوی صوتی به من کمک کن"
+    },
+    {
+      "id": "native.apple.65e462758be96174",
+      "source": "Help me start a realtime voice session from this phone.",
+      "translated": "به من کمک کن از این تلفن یک جلسه صوتی بلادرنگ شروع کنم."
     },
     {
       "id": "native.apple.e8018adcccaa2a4d",
@@ -6904,6 +6939,26 @@
       "translated": "/pair qr"
     },
     {
+      "id": "native.apple.fe3269c93d6f8524",
+      "source": "Copied",
+      "translated": "کپی شد"
+    },
+    {
+      "id": "native.apple.bad4a8110ca864e1",
+      "source": "Copy",
+      "translated": "کپی"
+    },
+    {
+      "id": "native.apple.b6f3f5c300b28f17",
+      "source": "Copy pair command",
+      "translated": "کپی کردن فرمان جفت‌سازی"
+    },
+    {
+      "id": "native.apple.7308cbcb1e40d70e",
+      "source": "Pair command copied",
+      "translated": "فرمان جفت‌سازی کپی شد"
+    },
+    {
       "id": "native.apple.b727174424127618",
       "source": "Run this in your OpenClaw chat, then scan the code.",
       "translated": "این را در چت OpenClaw خود اجرا کنید، سپس کد را اسکن کنید."
@@ -7129,9 +7184,9 @@
       "translated": "تلاش دوباره برای اتصال"
     },
     {
-      "id": "native.apple.f50052c1d760ec10",
-      "source": "Open OpenClaw",
-      "translated": "باز کردن OpenClaw"
+      "id": "native.apple.e674edbcb002aec6",
+      "source": "Go to Chat",
+      "translated": "رفتن به چت"
     },
     {
       "id": "native.apple.4679e949156e07e3",

--- a/apps/.i18n/native/fr.json
+++ b/apps/.i18n/native/fr.json
@@ -4504,6 +4504,11 @@
       "translated": "Prêt"
     },
     {
+      "id": "native.apple.202b97e93b938049",
+      "source": "What would you like to work on?",
+      "translated": "Sur quoi souhaitez-vous travailler ?"
+    },
+    {
       "id": "native.apple.32179ce0b6d4543f",
       "source": "The session attaches once the gateway is ready.",
       "translated": "La session se connecte une fois que le gateway est prêt."
@@ -4532,6 +4537,36 @@
       "id": "native.apple.e8173c7d24457256",
       "source": "Message \\(self.agentDisplayName)...",
       "translated": "Message à \\(self.agentDisplayName)..."
+    },
+    {
+      "id": "native.apple.14492e334b87e4f2",
+      "source": "Check OpenClaw status",
+      "translated": "Vérifier l’état d’OpenClaw"
+    },
+    {
+      "id": "native.apple.bbf7bd23da1e7865",
+      "source": "Summarize the current OpenClaw status and tell me what needs attention.",
+      "translated": "Résume l’état actuel d’OpenClaw et indique-moi ce qui nécessite une attention."
+    },
+    {
+      "id": "native.apple.ea8cbb1b4230c652",
+      "source": "What can I control here?",
+      "translated": "Que puis-je contrôler ici ?"
+    },
+    {
+      "id": "native.apple.451d25bdb3130ed0",
+      "source": "Show me which phone controls and device capabilities are available right now.",
+      "translated": "Montre-moi les contrôles du téléphone et les fonctionnalités de l’appareil actuellement disponibles."
+    },
+    {
+      "id": "native.apple.503ec402d08bd43a",
+      "source": "Help me start voice chat",
+      "translated": "Aidez-moi à démarrer le chat vocal"
+    },
+    {
+      "id": "native.apple.65e462758be96174",
+      "source": "Help me start a realtime voice session from this phone.",
+      "translated": "Aidez-moi à démarrer une session vocale en temps réel depuis ce téléphone."
     },
     {
       "id": "native.apple.e8018adcccaa2a4d",
@@ -6904,6 +6939,26 @@
       "translated": "/pair qr"
     },
     {
+      "id": "native.apple.fe3269c93d6f8524",
+      "source": "Copied",
+      "translated": "Copié"
+    },
+    {
+      "id": "native.apple.bad4a8110ca864e1",
+      "source": "Copy",
+      "translated": "Copier"
+    },
+    {
+      "id": "native.apple.b6f3f5c300b28f17",
+      "source": "Copy pair command",
+      "translated": "Copier la commande d’appairage"
+    },
+    {
+      "id": "native.apple.7308cbcb1e40d70e",
+      "source": "Pair command copied",
+      "translated": "Commande d’appairage copiée"
+    },
+    {
       "id": "native.apple.b727174424127618",
       "source": "Run this in your OpenClaw chat, then scan the code.",
       "translated": "Exécutez ceci dans votre chat OpenClaw, puis scannez le code."
@@ -7129,9 +7184,9 @@
       "translated": "Réessayer la connexion"
     },
     {
-      "id": "native.apple.f50052c1d760ec10",
-      "source": "Open OpenClaw",
-      "translated": "Ouvrir OpenClaw"
+      "id": "native.apple.e674edbcb002aec6",
+      "source": "Go to Chat",
+      "translated": "Aller au chat"
     },
     {
       "id": "native.apple.4679e949156e07e3",

--- a/apps/.i18n/native/hi.json
+++ b/apps/.i18n/native/hi.json
@@ -4504,6 +4504,11 @@
       "translated": "तैयार"
     },
     {
+      "id": "native.apple.202b97e93b938049",
+      "source": "What would you like to work on?",
+      "translated": "आप किस पर काम करना चाहेंगे?"
+    },
+    {
       "id": "native.apple.32179ce0b6d4543f",
       "source": "The session attaches once the gateway is ready.",
       "translated": "Gateway तैयार होने के बाद सेशन अटैच हो जाता है।"
@@ -4532,6 +4537,36 @@
       "id": "native.apple.e8173c7d24457256",
       "source": "Message \\(self.agentDisplayName)...",
       "translated": "\\(self.agentDisplayName) को संदेश भेजें..."
+    },
+    {
+      "id": "native.apple.14492e334b87e4f2",
+      "source": "Check OpenClaw status",
+      "translated": "OpenClaw स्थिति जांचें"
+    },
+    {
+      "id": "native.apple.bbf7bd23da1e7865",
+      "source": "Summarize the current OpenClaw status and tell me what needs attention.",
+      "translated": "वर्तमान OpenClaw स्थिति का सारांश दें और मुझे बताएं कि किस पर ध्यान देने की आवश्यकता है।"
+    },
+    {
+      "id": "native.apple.ea8cbb1b4230c652",
+      "source": "What can I control here?",
+      "translated": "मैं यहां क्या नियंत्रित कर सकता/सकती हूं?"
+    },
+    {
+      "id": "native.apple.451d25bdb3130ed0",
+      "source": "Show me which phone controls and device capabilities are available right now.",
+      "translated": "मुझे दिखाएं कि अभी कौन-से फ़ोन नियंत्रण और डिवाइस क्षमताएं उपलब्ध हैं।"
+    },
+    {
+      "id": "native.apple.503ec402d08bd43a",
+      "source": "Help me start voice chat",
+      "translated": "वॉइस चैट शुरू करने में मेरी मदद करें"
+    },
+    {
+      "id": "native.apple.65e462758be96174",
+      "source": "Help me start a realtime voice session from this phone.",
+      "translated": "इस फ़ोन से रीयलटाइम वॉइस सेशन शुरू करने में मेरी मदद करें।"
     },
     {
       "id": "native.apple.e8018adcccaa2a4d",
@@ -6904,6 +6939,26 @@
       "translated": "/pair qr"
     },
     {
+      "id": "native.apple.fe3269c93d6f8524",
+      "source": "Copied",
+      "translated": "कॉपी किया गया"
+    },
+    {
+      "id": "native.apple.bad4a8110ca864e1",
+      "source": "Copy",
+      "translated": "कॉपी करें"
+    },
+    {
+      "id": "native.apple.b6f3f5c300b28f17",
+      "source": "Copy pair command",
+      "translated": "पेयर कमांड कॉपी करें"
+    },
+    {
+      "id": "native.apple.7308cbcb1e40d70e",
+      "source": "Pair command copied",
+      "translated": "पेयर कमांड कॉपी किया गया"
+    },
+    {
       "id": "native.apple.b727174424127618",
       "source": "Run this in your OpenClaw chat, then scan the code.",
       "translated": "इसे अपनी OpenClaw चैट में चलाएँ, फिर कोड स्कैन करें।"
@@ -7129,9 +7184,9 @@
       "translated": "कनेक्शन फिर से प्रयास करें"
     },
     {
-      "id": "native.apple.f50052c1d760ec10",
-      "source": "Open OpenClaw",
-      "translated": "OpenClaw खोलें"
+      "id": "native.apple.e674edbcb002aec6",
+      "source": "Go to Chat",
+      "translated": "Chat पर जाएं"
     },
     {
       "id": "native.apple.4679e949156e07e3",

--- a/apps/.i18n/native/id.json
+++ b/apps/.i18n/native/id.json
@@ -4504,6 +4504,11 @@
       "translated": "Siap"
     },
     {
+      "id": "native.apple.202b97e93b938049",
+      "source": "What would you like to work on?",
+      "translated": "Apa yang ingin Anda kerjakan?"
+    },
+    {
       "id": "native.apple.32179ce0b6d4543f",
       "source": "The session attaches once the gateway is ready.",
       "translated": "Sesi terhubung setelah gateway siap."
@@ -4532,6 +4537,36 @@
       "id": "native.apple.e8173c7d24457256",
       "source": "Message \\(self.agentDisplayName)...",
       "translated": "Pesan \\(self.agentDisplayName)..."
+    },
+    {
+      "id": "native.apple.14492e334b87e4f2",
+      "source": "Check OpenClaw status",
+      "translated": "Periksa status OpenClaw"
+    },
+    {
+      "id": "native.apple.bbf7bd23da1e7865",
+      "source": "Summarize the current OpenClaw status and tell me what needs attention.",
+      "translated": "Ringkas status OpenClaw saat ini dan beri tahu saya apa yang perlu diperhatikan."
+    },
+    {
+      "id": "native.apple.ea8cbb1b4230c652",
+      "source": "What can I control here?",
+      "translated": "Apa yang bisa saya kendalikan di sini?"
+    },
+    {
+      "id": "native.apple.451d25bdb3130ed0",
+      "source": "Show me which phone controls and device capabilities are available right now.",
+      "translated": "Tampilkan kontrol ponsel dan kemampuan perangkat yang tersedia saat ini."
+    },
+    {
+      "id": "native.apple.503ec402d08bd43a",
+      "source": "Help me start voice chat",
+      "translated": "Bantu saya memulai obrolan suara"
+    },
+    {
+      "id": "native.apple.65e462758be96174",
+      "source": "Help me start a realtime voice session from this phone.",
+      "translated": "Bantu saya memulai sesi suara realtime dari ponsel ini."
     },
     {
       "id": "native.apple.e8018adcccaa2a4d",
@@ -6904,6 +6939,26 @@
       "translated": "/pair qr"
     },
     {
+      "id": "native.apple.fe3269c93d6f8524",
+      "source": "Copied",
+      "translated": "Disalin"
+    },
+    {
+      "id": "native.apple.bad4a8110ca864e1",
+      "source": "Copy",
+      "translated": "Salin"
+    },
+    {
+      "id": "native.apple.b6f3f5c300b28f17",
+      "source": "Copy pair command",
+      "translated": "Salin perintah pemasangan"
+    },
+    {
+      "id": "native.apple.7308cbcb1e40d70e",
+      "source": "Pair command copied",
+      "translated": "Perintah pemasangan disalin"
+    },
+    {
       "id": "native.apple.b727174424127618",
       "source": "Run this in your OpenClaw chat, then scan the code.",
       "translated": "Jalankan ini di chat OpenClaw Anda, lalu pindai kodenya."
@@ -7129,9 +7184,9 @@
       "translated": "Coba Ulang Koneksi"
     },
     {
-      "id": "native.apple.f50052c1d760ec10",
-      "source": "Open OpenClaw",
-      "translated": "Buka OpenClaw"
+      "id": "native.apple.e674edbcb002aec6",
+      "source": "Go to Chat",
+      "translated": "Buka Obrolan"
     },
     {
       "id": "native.apple.4679e949156e07e3",

--- a/apps/.i18n/native/it.json
+++ b/apps/.i18n/native/it.json
@@ -4504,6 +4504,11 @@
       "translated": "Pronto"
     },
     {
+      "id": "native.apple.202b97e93b938049",
+      "source": "What would you like to work on?",
+      "translated": "Su cosa vorresti lavorare?"
+    },
+    {
       "id": "native.apple.32179ce0b6d4543f",
       "source": "The session attaches once the gateway is ready.",
       "translated": "La sessione si collega quando il Gateway è pronto."
@@ -4532,6 +4537,36 @@
       "id": "native.apple.e8173c7d24457256",
       "source": "Message \\(self.agentDisplayName)...",
       "translated": "Messaggio a \\(self.agentDisplayName)..."
+    },
+    {
+      "id": "native.apple.14492e334b87e4f2",
+      "source": "Check OpenClaw status",
+      "translated": "Controlla lo stato di OpenClaw"
+    },
+    {
+      "id": "native.apple.bbf7bd23da1e7865",
+      "source": "Summarize the current OpenClaw status and tell me what needs attention.",
+      "translated": "Riassumi lo stato attuale di OpenClaw e dimmi cosa richiede attenzione."
+    },
+    {
+      "id": "native.apple.ea8cbb1b4230c652",
+      "source": "What can I control here?",
+      "translated": "Cosa posso controllare qui?"
+    },
+    {
+      "id": "native.apple.451d25bdb3130ed0",
+      "source": "Show me which phone controls and device capabilities are available right now.",
+      "translated": "Mostrami quali controlli del telefono e funzionalità del dispositivo sono disponibili in questo momento."
+    },
+    {
+      "id": "native.apple.503ec402d08bd43a",
+      "source": "Help me start voice chat",
+      "translated": "Aiutami ad avviare la chat vocale"
+    },
+    {
+      "id": "native.apple.65e462758be96174",
+      "source": "Help me start a realtime voice session from this phone.",
+      "translated": "Aiutami ad avviare una sessione vocale in tempo reale da questo telefono."
     },
     {
       "id": "native.apple.e8018adcccaa2a4d",
@@ -6904,6 +6939,26 @@
       "translated": "/pair qr"
     },
     {
+      "id": "native.apple.fe3269c93d6f8524",
+      "source": "Copied",
+      "translated": "Copiato"
+    },
+    {
+      "id": "native.apple.bad4a8110ca864e1",
+      "source": "Copy",
+      "translated": "Copia"
+    },
+    {
+      "id": "native.apple.b6f3f5c300b28f17",
+      "source": "Copy pair command",
+      "translated": "Copia comando di associazione"
+    },
+    {
+      "id": "native.apple.7308cbcb1e40d70e",
+      "source": "Pair command copied",
+      "translated": "Comando di associazione copiato"
+    },
+    {
       "id": "native.apple.b727174424127618",
       "source": "Run this in your OpenClaw chat, then scan the code.",
       "translated": "Esegui questo nella chat di OpenClaw, quindi scansiona il codice."
@@ -7129,9 +7184,9 @@
       "translated": "Riprova connessione"
     },
     {
-      "id": "native.apple.f50052c1d760ec10",
-      "source": "Open OpenClaw",
-      "translated": "Apri OpenClaw"
+      "id": "native.apple.e674edbcb002aec6",
+      "source": "Go to Chat",
+      "translated": "Vai alla chat"
     },
     {
       "id": "native.apple.4679e949156e07e3",

--- a/apps/.i18n/native/ja-JP.json
+++ b/apps/.i18n/native/ja-JP.json
@@ -4504,6 +4504,11 @@
       "translated": "準備完了"
     },
     {
+      "id": "native.apple.202b97e93b938049",
+      "source": "What would you like to work on?",
+      "translated": "何に取り組みますか？"
+    },
+    {
       "id": "native.apple.32179ce0b6d4543f",
       "source": "The session attaches once the gateway is ready.",
       "translated": "Gateway の準備ができると、セッションが接続されます。"
@@ -4532,6 +4537,36 @@
       "id": "native.apple.e8173c7d24457256",
       "source": "Message \\(self.agentDisplayName)...",
       "translated": "\\(self.agentDisplayName) にメッセージ..."
+    },
+    {
+      "id": "native.apple.14492e334b87e4f2",
+      "source": "Check OpenClaw status",
+      "translated": "OpenClaw のステータスを確認"
+    },
+    {
+      "id": "native.apple.bbf7bd23da1e7865",
+      "source": "Summarize the current OpenClaw status and tell me what needs attention.",
+      "translated": "現在の OpenClaw のステータスを要約し、注意が必要な項目を教えてください。"
+    },
+    {
+      "id": "native.apple.ea8cbb1b4230c652",
+      "source": "What can I control here?",
+      "translated": "ここで何を制御できますか？"
+    },
+    {
+      "id": "native.apple.451d25bdb3130ed0",
+      "source": "Show me which phone controls and device capabilities are available right now.",
+      "translated": "現在利用可能な電話の制御機能とデバイス機能を表示してください。"
+    },
+    {
+      "id": "native.apple.503ec402d08bd43a",
+      "source": "Help me start voice chat",
+      "translated": "音声チャットの開始を手伝ってください"
+    },
+    {
+      "id": "native.apple.65e462758be96174",
+      "source": "Help me start a realtime voice session from this phone.",
+      "translated": "この電話からリアルタイム音声セッションを開始するのを手伝ってください。"
     },
     {
       "id": "native.apple.e8018adcccaa2a4d",
@@ -6904,6 +6939,26 @@
       "translated": "/pair qr"
     },
     {
+      "id": "native.apple.fe3269c93d6f8524",
+      "source": "Copied",
+      "translated": "コピーしました"
+    },
+    {
+      "id": "native.apple.bad4a8110ca864e1",
+      "source": "Copy",
+      "translated": "コピー"
+    },
+    {
+      "id": "native.apple.b6f3f5c300b28f17",
+      "source": "Copy pair command",
+      "translated": "ペアリングコマンドをコピー"
+    },
+    {
+      "id": "native.apple.7308cbcb1e40d70e",
+      "source": "Pair command copied",
+      "translated": "ペアリングコマンドをコピーしました"
+    },
+    {
       "id": "native.apple.b727174424127618",
       "source": "Run this in your OpenClaw chat, then scan the code.",
       "translated": "OpenClawチャットでこれを実行してから、コードをスキャンしてください。"
@@ -7129,9 +7184,9 @@
       "translated": "接続を再試行"
     },
     {
-      "id": "native.apple.f50052c1d760ec10",
-      "source": "Open OpenClaw",
-      "translated": "OpenClaw を開く"
+      "id": "native.apple.e674edbcb002aec6",
+      "source": "Go to Chat",
+      "translated": "チャットへ移動"
     },
     {
       "id": "native.apple.4679e949156e07e3",

--- a/apps/.i18n/native/ko.json
+++ b/apps/.i18n/native/ko.json
@@ -4504,6 +4504,11 @@
       "translated": "준비됨"
     },
     {
+      "id": "native.apple.202b97e93b938049",
+      "source": "What would you like to work on?",
+      "translated": "무엇을 작업하시겠어요?"
+    },
+    {
       "id": "native.apple.32179ce0b6d4543f",
       "source": "The session attaches once the gateway is ready.",
       "translated": "Gateway가 준비되면 세션이 연결됩니다."
@@ -4532,6 +4537,36 @@
       "id": "native.apple.e8173c7d24457256",
       "source": "Message \\(self.agentDisplayName)...",
       "translated": "\\(self.agentDisplayName)에게 메시지 보내기..."
+    },
+    {
+      "id": "native.apple.14492e334b87e4f2",
+      "source": "Check OpenClaw status",
+      "translated": "OpenClaw 상태 확인"
+    },
+    {
+      "id": "native.apple.bbf7bd23da1e7865",
+      "source": "Summarize the current OpenClaw status and tell me what needs attention.",
+      "translated": "현재 OpenClaw 상태를 요약하고 주의가 필요한 항목을 알려주세요."
+    },
+    {
+      "id": "native.apple.ea8cbb1b4230c652",
+      "source": "What can I control here?",
+      "translated": "여기서 무엇을 제어할 수 있나요?"
+    },
+    {
+      "id": "native.apple.451d25bdb3130ed0",
+      "source": "Show me which phone controls and device capabilities are available right now.",
+      "translated": "현재 사용할 수 있는 휴대폰 제어 기능과 기기 기능을 보여주세요."
+    },
+    {
+      "id": "native.apple.503ec402d08bd43a",
+      "source": "Help me start voice chat",
+      "translated": "음성 채팅 시작 도와주기"
+    },
+    {
+      "id": "native.apple.65e462758be96174",
+      "source": "Help me start a realtime voice session from this phone.",
+      "translated": "이 휴대폰에서 실시간 음성 세션을 시작하도록 도와주세요."
     },
     {
       "id": "native.apple.e8018adcccaa2a4d",
@@ -6904,6 +6939,26 @@
       "translated": "/pair qr"
     },
     {
+      "id": "native.apple.fe3269c93d6f8524",
+      "source": "Copied",
+      "translated": "복사됨"
+    },
+    {
+      "id": "native.apple.bad4a8110ca864e1",
+      "source": "Copy",
+      "translated": "복사"
+    },
+    {
+      "id": "native.apple.b6f3f5c300b28f17",
+      "source": "Copy pair command",
+      "translated": "페어링 명령 복사"
+    },
+    {
+      "id": "native.apple.7308cbcb1e40d70e",
+      "source": "Pair command copied",
+      "translated": "페어링 명령이 복사되었습니다"
+    },
+    {
       "id": "native.apple.b727174424127618",
       "source": "Run this in your OpenClaw chat, then scan the code.",
       "translated": "OpenClaw 채팅에서 이를 실행한 다음 코드를 스캔하세요."
@@ -7129,9 +7184,9 @@
       "translated": "연결 다시 시도"
     },
     {
-      "id": "native.apple.f50052c1d760ec10",
-      "source": "Open OpenClaw",
-      "translated": "OpenClaw 열기"
+      "id": "native.apple.e674edbcb002aec6",
+      "source": "Go to Chat",
+      "translated": "채팅으로 이동"
     },
     {
       "id": "native.apple.4679e949156e07e3",

--- a/apps/.i18n/native/nl.json
+++ b/apps/.i18n/native/nl.json
@@ -4504,6 +4504,11 @@
       "translated": "Gereed"
     },
     {
+      "id": "native.apple.202b97e93b938049",
+      "source": "What would you like to work on?",
+      "translated": "Waar wilt u aan werken?"
+    },
+    {
       "id": "native.apple.32179ce0b6d4543f",
       "source": "The session attaches once the gateway is ready.",
       "translated": "De sessie wordt gekoppeld zodra de Gateway gereed is."
@@ -4532,6 +4537,36 @@
       "id": "native.apple.e8173c7d24457256",
       "source": "Message \\(self.agentDisplayName)...",
       "translated": "Bericht \\(self.agentDisplayName)..."
+    },
+    {
+      "id": "native.apple.14492e334b87e4f2",
+      "source": "Check OpenClaw status",
+      "translated": "OpenClaw-status controleren"
+    },
+    {
+      "id": "native.apple.bbf7bd23da1e7865",
+      "source": "Summarize the current OpenClaw status and tell me what needs attention.",
+      "translated": "Vat de huidige OpenClaw-status samen en vertel me wat aandacht nodig heeft."
+    },
+    {
+      "id": "native.apple.ea8cbb1b4230c652",
+      "source": "What can I control here?",
+      "translated": "Wat kan ik hier bedienen?"
+    },
+    {
+      "id": "native.apple.451d25bdb3130ed0",
+      "source": "Show me which phone controls and device capabilities are available right now.",
+      "translated": "Laat me zien welke telefoonbediening en apparaatmogelijkheden nu beschikbaar zijn."
+    },
+    {
+      "id": "native.apple.503ec402d08bd43a",
+      "source": "Help me start voice chat",
+      "translated": "Help me een voicechat te starten"
+    },
+    {
+      "id": "native.apple.65e462758be96174",
+      "source": "Help me start a realtime voice session from this phone.",
+      "translated": "Help me een realtime spraaksessie vanaf deze telefoon te starten."
     },
     {
       "id": "native.apple.e8018adcccaa2a4d",
@@ -6904,6 +6939,26 @@
       "translated": "/pair qr"
     },
     {
+      "id": "native.apple.fe3269c93d6f8524",
+      "source": "Copied",
+      "translated": "Gekopieerd"
+    },
+    {
+      "id": "native.apple.bad4a8110ca864e1",
+      "source": "Copy",
+      "translated": "Kopiëren"
+    },
+    {
+      "id": "native.apple.b6f3f5c300b28f17",
+      "source": "Copy pair command",
+      "translated": "Koppelopdracht kopiëren"
+    },
+    {
+      "id": "native.apple.7308cbcb1e40d70e",
+      "source": "Pair command copied",
+      "translated": "Koppelopdracht gekopieerd"
+    },
+    {
       "id": "native.apple.b727174424127618",
       "source": "Run this in your OpenClaw chat, then scan the code.",
       "translated": "Voer dit uit in je OpenClaw-chat en scan vervolgens de code."
@@ -7129,9 +7184,9 @@
       "translated": "Verbinding opnieuw proberen"
     },
     {
-      "id": "native.apple.f50052c1d760ec10",
-      "source": "Open OpenClaw",
-      "translated": "Open OpenClaw"
+      "id": "native.apple.e674edbcb002aec6",
+      "source": "Go to Chat",
+      "translated": "Ga naar Chat"
     },
     {
       "id": "native.apple.4679e949156e07e3",

--- a/apps/.i18n/native/pl.json
+++ b/apps/.i18n/native/pl.json
@@ -4504,6 +4504,11 @@
       "translated": "Gotowe"
     },
     {
+      "id": "native.apple.202b97e93b938049",
+      "source": "What would you like to work on?",
+      "translated": "Nad czym chcesz popracować?"
+    },
+    {
       "id": "native.apple.32179ce0b6d4543f",
       "source": "The session attaches once the gateway is ready.",
       "translated": "Sesja zostanie dołączona, gdy Gateway będzie gotowy."
@@ -4532,6 +4537,36 @@
       "id": "native.apple.e8173c7d24457256",
       "source": "Message \\(self.agentDisplayName)...",
       "translated": "Wiadomość do \\(self.agentDisplayName)..."
+    },
+    {
+      "id": "native.apple.14492e334b87e4f2",
+      "source": "Check OpenClaw status",
+      "translated": "Sprawdź status OpenClaw"
+    },
+    {
+      "id": "native.apple.bbf7bd23da1e7865",
+      "source": "Summarize the current OpenClaw status and tell me what needs attention.",
+      "translated": "Podsumuj bieżący status OpenClaw i powiedz mi, co wymaga uwagi."
+    },
+    {
+      "id": "native.apple.ea8cbb1b4230c652",
+      "source": "What can I control here?",
+      "translated": "Czym mogę tutaj sterować?"
+    },
+    {
+      "id": "native.apple.451d25bdb3130ed0",
+      "source": "Show me which phone controls and device capabilities are available right now.",
+      "translated": "Pokaż mi, które elementy sterowania telefonu i możliwości urządzenia są teraz dostępne."
+    },
+    {
+      "id": "native.apple.503ec402d08bd43a",
+      "source": "Help me start voice chat",
+      "translated": "Pomóż mi rozpocząć czat głosowy"
+    },
+    {
+      "id": "native.apple.65e462758be96174",
+      "source": "Help me start a realtime voice session from this phone.",
+      "translated": "Pomóż mi rozpocząć sesję głosową w czasie rzeczywistym z tego telefonu."
     },
     {
       "id": "native.apple.e8018adcccaa2a4d",
@@ -6904,6 +6939,26 @@
       "translated": "/pair qr"
     },
     {
+      "id": "native.apple.fe3269c93d6f8524",
+      "source": "Copied",
+      "translated": "Skopiowano"
+    },
+    {
+      "id": "native.apple.bad4a8110ca864e1",
+      "source": "Copy",
+      "translated": "Kopiuj"
+    },
+    {
+      "id": "native.apple.b6f3f5c300b28f17",
+      "source": "Copy pair command",
+      "translated": "Kopiuj polecenie parowania"
+    },
+    {
+      "id": "native.apple.7308cbcb1e40d70e",
+      "source": "Pair command copied",
+      "translated": "Polecenie parowania skopiowane"
+    },
+    {
       "id": "native.apple.b727174424127618",
       "source": "Run this in your OpenClaw chat, then scan the code.",
       "translated": "Uruchom to w czacie OpenClaw, a następnie zeskanuj kod."
@@ -7129,9 +7184,9 @@
       "translated": "Ponów połączenie"
     },
     {
-      "id": "native.apple.f50052c1d760ec10",
-      "source": "Open OpenClaw",
-      "translated": "Otwórz OpenClaw"
+      "id": "native.apple.e674edbcb002aec6",
+      "source": "Go to Chat",
+      "translated": "Przejdź do czatu"
     },
     {
       "id": "native.apple.4679e949156e07e3",

--- a/apps/.i18n/native/pt-BR.json
+++ b/apps/.i18n/native/pt-BR.json
@@ -4504,6 +4504,11 @@
       "translated": "Pronto"
     },
     {
+      "id": "native.apple.202b97e93b938049",
+      "source": "What would you like to work on?",
+      "translated": "Em que você gostaria de trabalhar?"
+    },
+    {
       "id": "native.apple.32179ce0b6d4543f",
       "source": "The session attaches once the gateway is ready.",
       "translated": "A sessão será anexada assim que o Gateway estiver pronto."
@@ -4532,6 +4537,36 @@
       "id": "native.apple.e8173c7d24457256",
       "source": "Message \\(self.agentDisplayName)...",
       "translated": "Mensagem para \\(self.agentDisplayName)..."
+    },
+    {
+      "id": "native.apple.14492e334b87e4f2",
+      "source": "Check OpenClaw status",
+      "translated": "Verificar status do OpenClaw"
+    },
+    {
+      "id": "native.apple.bbf7bd23da1e7865",
+      "source": "Summarize the current OpenClaw status and tell me what needs attention.",
+      "translated": "Resuma o status atual do OpenClaw e me diga o que precisa de atenção."
+    },
+    {
+      "id": "native.apple.ea8cbb1b4230c652",
+      "source": "What can I control here?",
+      "translated": "O que posso controlar aqui?"
+    },
+    {
+      "id": "native.apple.451d25bdb3130ed0",
+      "source": "Show me which phone controls and device capabilities are available right now.",
+      "translated": "Mostre quais controles do telefone e recursos do dispositivo estão disponíveis agora."
+    },
+    {
+      "id": "native.apple.503ec402d08bd43a",
+      "source": "Help me start voice chat",
+      "translated": "Ajude-me a iniciar o chat por voz"
+    },
+    {
+      "id": "native.apple.65e462758be96174",
+      "source": "Help me start a realtime voice session from this phone.",
+      "translated": "Ajude-me a iniciar uma sessão de voz em tempo real a partir deste telefone."
     },
     {
       "id": "native.apple.e8018adcccaa2a4d",
@@ -6904,6 +6939,26 @@
       "translated": "/pair qr"
     },
     {
+      "id": "native.apple.fe3269c93d6f8524",
+      "source": "Copied",
+      "translated": "Copiado"
+    },
+    {
+      "id": "native.apple.bad4a8110ca864e1",
+      "source": "Copy",
+      "translated": "Copiar"
+    },
+    {
+      "id": "native.apple.b6f3f5c300b28f17",
+      "source": "Copy pair command",
+      "translated": "Copiar comando de pareamento"
+    },
+    {
+      "id": "native.apple.7308cbcb1e40d70e",
+      "source": "Pair command copied",
+      "translated": "Comando de pareamento copiado"
+    },
+    {
       "id": "native.apple.b727174424127618",
       "source": "Run this in your OpenClaw chat, then scan the code.",
       "translated": "Execute isto no seu chat do OpenClaw e, em seguida, escaneie o código."
@@ -7129,9 +7184,9 @@
       "translated": "Tentar conexão novamente"
     },
     {
-      "id": "native.apple.f50052c1d760ec10",
-      "source": "Open OpenClaw",
-      "translated": "Abrir OpenClaw"
+      "id": "native.apple.e674edbcb002aec6",
+      "source": "Go to Chat",
+      "translated": "Ir para o Chat"
     },
     {
       "id": "native.apple.4679e949156e07e3",

--- a/apps/.i18n/native/ru.json
+++ b/apps/.i18n/native/ru.json
@@ -4504,6 +4504,11 @@
       "translated": "Готово"
     },
     {
+      "id": "native.apple.202b97e93b938049",
+      "source": "What would you like to work on?",
+      "translated": "Над чем вы хотите поработать?"
+    },
+    {
       "id": "native.apple.32179ce0b6d4543f",
       "source": "The session attaches once the gateway is ready.",
       "translated": "Сеанс подключится, когда Gateway будет готов."
@@ -4532,6 +4537,36 @@
       "id": "native.apple.e8173c7d24457256",
       "source": "Message \\(self.agentDisplayName)...",
       "translated": "Сообщение \\(self.agentDisplayName)..."
+    },
+    {
+      "id": "native.apple.14492e334b87e4f2",
+      "source": "Check OpenClaw status",
+      "translated": "Проверить статус OpenClaw"
+    },
+    {
+      "id": "native.apple.bbf7bd23da1e7865",
+      "source": "Summarize the current OpenClaw status and tell me what needs attention.",
+      "translated": "Сводка текущего статуса OpenClaw и что требует внимания."
+    },
+    {
+      "id": "native.apple.ea8cbb1b4230c652",
+      "source": "What can I control here?",
+      "translated": "Чем я могу здесь управлять?"
+    },
+    {
+      "id": "native.apple.451d25bdb3130ed0",
+      "source": "Show me which phone controls and device capabilities are available right now.",
+      "translated": "Покажите, какие элементы управления телефоном и возможности устройства доступны прямо сейчас."
+    },
+    {
+      "id": "native.apple.503ec402d08bd43a",
+      "source": "Help me start voice chat",
+      "translated": "Помогите начать голосовой чат"
+    },
+    {
+      "id": "native.apple.65e462758be96174",
+      "source": "Help me start a realtime voice session from this phone.",
+      "translated": "Помогите начать сеанс голосовой связи в реальном времени с этого телефона."
     },
     {
       "id": "native.apple.e8018adcccaa2a4d",
@@ -6904,6 +6939,26 @@
       "translated": "/pair qr"
     },
     {
+      "id": "native.apple.fe3269c93d6f8524",
+      "source": "Copied",
+      "translated": "Скопировано"
+    },
+    {
+      "id": "native.apple.bad4a8110ca864e1",
+      "source": "Copy",
+      "translated": "Копировать"
+    },
+    {
+      "id": "native.apple.b6f3f5c300b28f17",
+      "source": "Copy pair command",
+      "translated": "Копировать команду сопряжения"
+    },
+    {
+      "id": "native.apple.7308cbcb1e40d70e",
+      "source": "Pair command copied",
+      "translated": "Команда сопряжения скопирована"
+    },
+    {
       "id": "native.apple.b727174424127618",
       "source": "Run this in your OpenClaw chat, then scan the code.",
       "translated": "Выполните это в чате OpenClaw, затем отсканируйте код."
@@ -7129,9 +7184,9 @@
       "translated": "Повторить подключение"
     },
     {
-      "id": "native.apple.f50052c1d760ec10",
-      "source": "Open OpenClaw",
-      "translated": "Открыть OpenClaw"
+      "id": "native.apple.e674edbcb002aec6",
+      "source": "Go to Chat",
+      "translated": "Перейти в чат"
     },
     {
       "id": "native.apple.4679e949156e07e3",

--- a/apps/.i18n/native/sv.json
+++ b/apps/.i18n/native/sv.json
@@ -4504,6 +4504,11 @@
       "translated": "Redo"
     },
     {
+      "id": "native.apple.202b97e93b938049",
+      "source": "What would you like to work on?",
+      "translated": "Vad vill du arbeta med?"
+    },
+    {
       "id": "native.apple.32179ce0b6d4543f",
       "source": "The session attaches once the gateway is ready.",
       "translated": "Sessionen ansluter när Gateway är redo."
@@ -4532,6 +4537,36 @@
       "id": "native.apple.e8173c7d24457256",
       "source": "Message \\(self.agentDisplayName)...",
       "translated": "Meddela \\(self.agentDisplayName)..."
+    },
+    {
+      "id": "native.apple.14492e334b87e4f2",
+      "source": "Check OpenClaw status",
+      "translated": "Kontrollera OpenClaw-status"
+    },
+    {
+      "id": "native.apple.bbf7bd23da1e7865",
+      "source": "Summarize the current OpenClaw status and tell me what needs attention.",
+      "translated": "Sammanfatta aktuell OpenClaw-status och berätta vad som behöver uppmärksamhet."
+    },
+    {
+      "id": "native.apple.ea8cbb1b4230c652",
+      "source": "What can I control here?",
+      "translated": "Vad kan jag styra här?"
+    },
+    {
+      "id": "native.apple.451d25bdb3130ed0",
+      "source": "Show me which phone controls and device capabilities are available right now.",
+      "translated": "Visa vilka telefonkontroller och enhetsfunktioner som är tillgängliga just nu."
+    },
+    {
+      "id": "native.apple.503ec402d08bd43a",
+      "source": "Help me start voice chat",
+      "translated": "Hjälp mig att starta röstchatt"
+    },
+    {
+      "id": "native.apple.65e462758be96174",
+      "source": "Help me start a realtime voice session from this phone.",
+      "translated": "Hjälp mig att starta en röstsessions i realtid från den här telefonen."
     },
     {
       "id": "native.apple.e8018adcccaa2a4d",
@@ -6904,6 +6939,26 @@
       "translated": "/pair qr"
     },
     {
+      "id": "native.apple.fe3269c93d6f8524",
+      "source": "Copied",
+      "translated": "Kopierat"
+    },
+    {
+      "id": "native.apple.bad4a8110ca864e1",
+      "source": "Copy",
+      "translated": "Kopiera"
+    },
+    {
+      "id": "native.apple.b6f3f5c300b28f17",
+      "source": "Copy pair command",
+      "translated": "Kopiera parkopplingskommandot"
+    },
+    {
+      "id": "native.apple.7308cbcb1e40d70e",
+      "source": "Pair command copied",
+      "translated": "Parkopplingskommandot kopierat"
+    },
+    {
       "id": "native.apple.b727174424127618",
       "source": "Run this in your OpenClaw chat, then scan the code.",
       "translated": "Kör detta i din OpenClaw-chatt och skanna sedan koden."
@@ -7129,9 +7184,9 @@
       "translated": "Försök ansluta igen"
     },
     {
-      "id": "native.apple.f50052c1d760ec10",
-      "source": "Open OpenClaw",
-      "translated": "Öppna OpenClaw"
+      "id": "native.apple.e674edbcb002aec6",
+      "source": "Go to Chat",
+      "translated": "Gå till chatten"
     },
     {
       "id": "native.apple.4679e949156e07e3",

--- a/apps/.i18n/native/th.json
+++ b/apps/.i18n/native/th.json
@@ -4504,6 +4504,11 @@
       "translated": "พร้อม"
     },
     {
+      "id": "native.apple.202b97e93b938049",
+      "source": "What would you like to work on?",
+      "translated": "คุณต้องการทำงานอะไร?"
+    },
+    {
       "id": "native.apple.32179ce0b6d4543f",
       "source": "The session attaches once the gateway is ready.",
       "translated": "เซสชันจะเชื่อมต่อเมื่อ gateway พร้อมใช้งาน"
@@ -4532,6 +4537,36 @@
       "id": "native.apple.e8173c7d24457256",
       "source": "Message \\(self.agentDisplayName)...",
       "translated": "ส่งข้อความถึง \\(self.agentDisplayName)..."
+    },
+    {
+      "id": "native.apple.14492e334b87e4f2",
+      "source": "Check OpenClaw status",
+      "translated": "ตรวจสอบสถานะ OpenClaw"
+    },
+    {
+      "id": "native.apple.bbf7bd23da1e7865",
+      "source": "Summarize the current OpenClaw status and tell me what needs attention.",
+      "translated": "สรุปสถานะ OpenClaw ปัจจุบันและบอกฉันว่ามีอะไรที่ต้องให้ความสนใจ"
+    },
+    {
+      "id": "native.apple.ea8cbb1b4230c652",
+      "source": "What can I control here?",
+      "translated": "ฉันควบคุมอะไรได้บ้างที่นี่?"
+    },
+    {
+      "id": "native.apple.451d25bdb3130ed0",
+      "source": "Show me which phone controls and device capabilities are available right now.",
+      "translated": "แสดงให้ฉันดูว่าการควบคุมโทรศัพท์และความสามารถของอุปกรณ์ใดที่พร้อมใช้งานในตอนนี้"
+    },
+    {
+      "id": "native.apple.503ec402d08bd43a",
+      "source": "Help me start voice chat",
+      "translated": "ช่วยฉันเริ่มแชทด้วยเสียง"
+    },
+    {
+      "id": "native.apple.65e462758be96174",
+      "source": "Help me start a realtime voice session from this phone.",
+      "translated": "ช่วยฉันเริ่มเซสชันเสียงแบบเรียลไทม์จากโทรศัพท์เครื่องนี้"
     },
     {
       "id": "native.apple.e8018adcccaa2a4d",
@@ -6904,6 +6939,26 @@
       "translated": "/pair qr"
     },
     {
+      "id": "native.apple.fe3269c93d6f8524",
+      "source": "Copied",
+      "translated": "คัดลอกแล้ว"
+    },
+    {
+      "id": "native.apple.bad4a8110ca864e1",
+      "source": "Copy",
+      "translated": "คัดลอก"
+    },
+    {
+      "id": "native.apple.b6f3f5c300b28f17",
+      "source": "Copy pair command",
+      "translated": "คัดลอกคำสั่งจับคู่"
+    },
+    {
+      "id": "native.apple.7308cbcb1e40d70e",
+      "source": "Pair command copied",
+      "translated": "คัดลอกคำสั่งจับคู่แล้ว"
+    },
+    {
       "id": "native.apple.b727174424127618",
       "source": "Run this in your OpenClaw chat, then scan the code.",
       "translated": "เรียกใช้สิ่งนี้ในแชท OpenClaw ของคุณ จากนั้นสแกนโค้ด"
@@ -7129,9 +7184,9 @@
       "translated": "ลองเชื่อมต่ออีกครั้ง"
     },
     {
-      "id": "native.apple.f50052c1d760ec10",
-      "source": "Open OpenClaw",
-      "translated": "เปิด OpenClaw"
+      "id": "native.apple.e674edbcb002aec6",
+      "source": "Go to Chat",
+      "translated": "ไปที่แชท"
     },
     {
       "id": "native.apple.4679e949156e07e3",

--- a/apps/.i18n/native/tr.json
+++ b/apps/.i18n/native/tr.json
@@ -4504,6 +4504,11 @@
       "translated": "Hazır"
     },
     {
+      "id": "native.apple.202b97e93b938049",
+      "source": "What would you like to work on?",
+      "translated": "Ne üzerinde çalışmak istersiniz?"
+    },
+    {
       "id": "native.apple.32179ce0b6d4543f",
       "source": "The session attaches once the gateway is ready.",
       "translated": "Gateway hazır olduğunda oturum bağlanır."
@@ -4532,6 +4537,36 @@
       "id": "native.apple.e8173c7d24457256",
       "source": "Message \\(self.agentDisplayName)...",
       "translated": "\\(self.agentDisplayName) ile mesajlaş..."
+    },
+    {
+      "id": "native.apple.14492e334b87e4f2",
+      "source": "Check OpenClaw status",
+      "translated": "OpenClaw durumunu kontrol et"
+    },
+    {
+      "id": "native.apple.bbf7bd23da1e7865",
+      "source": "Summarize the current OpenClaw status and tell me what needs attention.",
+      "translated": "Mevcut OpenClaw durumunu özetle ve nelere dikkat edilmesi gerektiğini söyle."
+    },
+    {
+      "id": "native.apple.ea8cbb1b4230c652",
+      "source": "What can I control here?",
+      "translated": "Burada neleri kontrol edebilirim?"
+    },
+    {
+      "id": "native.apple.451d25bdb3130ed0",
+      "source": "Show me which phone controls and device capabilities are available right now.",
+      "translated": "Şu anda hangi telefon kontrollerinin ve cihaz özelliklerinin kullanılabilir olduğunu göster."
+    },
+    {
+      "id": "native.apple.503ec402d08bd43a",
+      "source": "Help me start voice chat",
+      "translated": "Sesli sohbet başlatmama yardım et"
+    },
+    {
+      "id": "native.apple.65e462758be96174",
+      "source": "Help me start a realtime voice session from this phone.",
+      "translated": "Bu telefondan gerçek zamanlı bir sesli oturum başlatmama yardım et."
     },
     {
       "id": "native.apple.e8018adcccaa2a4d",
@@ -6904,6 +6939,26 @@
       "translated": "/pair qr"
     },
     {
+      "id": "native.apple.fe3269c93d6f8524",
+      "source": "Copied",
+      "translated": "Kopyalandı"
+    },
+    {
+      "id": "native.apple.bad4a8110ca864e1",
+      "source": "Copy",
+      "translated": "Kopyala"
+    },
+    {
+      "id": "native.apple.b6f3f5c300b28f17",
+      "source": "Copy pair command",
+      "translated": "Eşleştirme komutunu kopyala"
+    },
+    {
+      "id": "native.apple.7308cbcb1e40d70e",
+      "source": "Pair command copied",
+      "translated": "Eşleştirme komutu kopyalandı"
+    },
+    {
       "id": "native.apple.b727174424127618",
       "source": "Run this in your OpenClaw chat, then scan the code.",
       "translated": "Bunu OpenClaw sohbetinizde çalıştırın, ardından kodu tarayın."
@@ -7129,9 +7184,9 @@
       "translated": "Bağlantıyı Yeniden Dene"
     },
     {
-      "id": "native.apple.f50052c1d760ec10",
-      "source": "Open OpenClaw",
-      "translated": "OpenClaw'ı Aç"
+      "id": "native.apple.e674edbcb002aec6",
+      "source": "Go to Chat",
+      "translated": "Sohbete Git"
     },
     {
       "id": "native.apple.4679e949156e07e3",

--- a/apps/.i18n/native/uk.json
+++ b/apps/.i18n/native/uk.json
@@ -4504,6 +4504,11 @@
       "translated": "Готово"
     },
     {
+      "id": "native.apple.202b97e93b938049",
+      "source": "What would you like to work on?",
+      "translated": "Над чим ви хотіли б попрацювати?"
+    },
+    {
       "id": "native.apple.32179ce0b6d4543f",
       "source": "The session attaches once the gateway is ready.",
       "translated": "Сеанс під’єднається, щойно Gateway буде готовий."
@@ -4532,6 +4537,36 @@
       "id": "native.apple.e8173c7d24457256",
       "source": "Message \\(self.agentDisplayName)...",
       "translated": "Повідомлення \\(self.agentDisplayName)..."
+    },
+    {
+      "id": "native.apple.14492e334b87e4f2",
+      "source": "Check OpenClaw status",
+      "translated": "Перевірити статус OpenClaw"
+    },
+    {
+      "id": "native.apple.bbf7bd23da1e7865",
+      "source": "Summarize the current OpenClaw status and tell me what needs attention.",
+      "translated": "Підсумуй поточний статус OpenClaw і скажи, що потребує уваги."
+    },
+    {
+      "id": "native.apple.ea8cbb1b4230c652",
+      "source": "What can I control here?",
+      "translated": "Чим я можу тут керувати?"
+    },
+    {
+      "id": "native.apple.451d25bdb3130ed0",
+      "source": "Show me which phone controls and device capabilities are available right now.",
+      "translated": "Покажи, які елементи керування телефоном і можливості пристрою доступні зараз."
+    },
+    {
+      "id": "native.apple.503ec402d08bd43a",
+      "source": "Help me start voice chat",
+      "translated": "Допоможіть мені почати голосовий чат"
+    },
+    {
+      "id": "native.apple.65e462758be96174",
+      "source": "Help me start a realtime voice session from this phone.",
+      "translated": "Допоможіть мені почати голосову сесію в реальному часі з цього телефона."
     },
     {
       "id": "native.apple.e8018adcccaa2a4d",
@@ -6904,6 +6939,26 @@
       "translated": "/pair qr"
     },
     {
+      "id": "native.apple.fe3269c93d6f8524",
+      "source": "Copied",
+      "translated": "Скопійовано"
+    },
+    {
+      "id": "native.apple.bad4a8110ca864e1",
+      "source": "Copy",
+      "translated": "Копіювати"
+    },
+    {
+      "id": "native.apple.b6f3f5c300b28f17",
+      "source": "Copy pair command",
+      "translated": "Копіювати команду сполучення"
+    },
+    {
+      "id": "native.apple.7308cbcb1e40d70e",
+      "source": "Pair command copied",
+      "translated": "Команду сполучення скопійовано"
+    },
+    {
       "id": "native.apple.b727174424127618",
       "source": "Run this in your OpenClaw chat, then scan the code.",
       "translated": "Виконайте це в чаті OpenClaw, а потім відскануйте код."
@@ -7129,9 +7184,9 @@
       "translated": "Повторити підключення"
     },
     {
-      "id": "native.apple.f50052c1d760ec10",
-      "source": "Open OpenClaw",
-      "translated": "Відкрити OpenClaw"
+      "id": "native.apple.e674edbcb002aec6",
+      "source": "Go to Chat",
+      "translated": "Перейти до чату"
     },
     {
       "id": "native.apple.4679e949156e07e3",

--- a/apps/.i18n/native/vi.json
+++ b/apps/.i18n/native/vi.json
@@ -4504,6 +4504,11 @@
       "translated": "Sẵn sàng"
     },
     {
+      "id": "native.apple.202b97e93b938049",
+      "source": "What would you like to work on?",
+      "translated": "Bạn muốn làm việc gì?"
+    },
+    {
       "id": "native.apple.32179ce0b6d4543f",
       "source": "The session attaches once the gateway is ready.",
       "translated": "Phiên sẽ được đính kèm khi gateway sẵn sàng."
@@ -4532,6 +4537,36 @@
       "id": "native.apple.e8173c7d24457256",
       "source": "Message \\(self.agentDisplayName)...",
       "translated": "Nhắn tin cho \\(self.agentDisplayName)..."
+    },
+    {
+      "id": "native.apple.14492e334b87e4f2",
+      "source": "Check OpenClaw status",
+      "translated": "Kiểm tra trạng thái OpenClaw"
+    },
+    {
+      "id": "native.apple.bbf7bd23da1e7865",
+      "source": "Summarize the current OpenClaw status and tell me what needs attention.",
+      "translated": "Tóm tắt trạng thái OpenClaw hiện tại và cho tôi biết những gì cần chú ý."
+    },
+    {
+      "id": "native.apple.ea8cbb1b4230c652",
+      "source": "What can I control here?",
+      "translated": "Tôi có thể điều khiển gì ở đây?"
+    },
+    {
+      "id": "native.apple.451d25bdb3130ed0",
+      "source": "Show me which phone controls and device capabilities are available right now.",
+      "translated": "Cho tôi xem các điều khiển điện thoại và khả năng thiết bị hiện có ngay bây giờ."
+    },
+    {
+      "id": "native.apple.503ec402d08bd43a",
+      "source": "Help me start voice chat",
+      "translated": "Giúp tôi bắt đầu trò chuyện thoại"
+    },
+    {
+      "id": "native.apple.65e462758be96174",
+      "source": "Help me start a realtime voice session from this phone.",
+      "translated": "Giúp tôi bắt đầu một phiên thoại thời gian thực từ điện thoại này."
     },
     {
       "id": "native.apple.e8018adcccaa2a4d",
@@ -6904,6 +6939,26 @@
       "translated": "/pair qr"
     },
     {
+      "id": "native.apple.fe3269c93d6f8524",
+      "source": "Copied",
+      "translated": "Đã sao chép"
+    },
+    {
+      "id": "native.apple.bad4a8110ca864e1",
+      "source": "Copy",
+      "translated": "Sao chép"
+    },
+    {
+      "id": "native.apple.b6f3f5c300b28f17",
+      "source": "Copy pair command",
+      "translated": "Sao chép lệnh ghép đôi"
+    },
+    {
+      "id": "native.apple.7308cbcb1e40d70e",
+      "source": "Pair command copied",
+      "translated": "Đã sao chép lệnh ghép đôi"
+    },
+    {
       "id": "native.apple.b727174424127618",
       "source": "Run this in your OpenClaw chat, then scan the code.",
       "translated": "Chạy lệnh này trong cuộc trò chuyện OpenClaw của bạn, sau đó quét mã."
@@ -7129,9 +7184,9 @@
       "translated": "Thử kết nối lại"
     },
     {
-      "id": "native.apple.f50052c1d760ec10",
-      "source": "Open OpenClaw",
-      "translated": "Mở OpenClaw"
+      "id": "native.apple.e674edbcb002aec6",
+      "source": "Go to Chat",
+      "translated": "Đi tới Chat"
     },
     {
       "id": "native.apple.4679e949156e07e3",

--- a/apps/.i18n/native/zh-CN.json
+++ b/apps/.i18n/native/zh-CN.json
@@ -4504,6 +4504,11 @@
       "translated": "就绪"
     },
     {
+      "id": "native.apple.202b97e93b938049",
+      "source": "What would you like to work on?",
+      "translated": "你想处理什么？"
+    },
+    {
       "id": "native.apple.32179ce0b6d4543f",
       "source": "The session attaches once the gateway is ready.",
       "translated": "Gateway 准备就绪后，会话将会附加。"
@@ -4532,6 +4537,36 @@
       "id": "native.apple.e8173c7d24457256",
       "source": "Message \\(self.agentDisplayName)...",
       "translated": "向 \\(self.agentDisplayName) 发送消息..."
+    },
+    {
+      "id": "native.apple.14492e334b87e4f2",
+      "source": "Check OpenClaw status",
+      "translated": "检查 OpenClaw 状态"
+    },
+    {
+      "id": "native.apple.bbf7bd23da1e7865",
+      "source": "Summarize the current OpenClaw status and tell me what needs attention.",
+      "translated": "总结当前 OpenClaw 状态，并告诉我哪些事项需要关注。"
+    },
+    {
+      "id": "native.apple.ea8cbb1b4230c652",
+      "source": "What can I control here?",
+      "translated": "我可以在这里控制什么？"
+    },
+    {
+      "id": "native.apple.451d25bdb3130ed0",
+      "source": "Show me which phone controls and device capabilities are available right now.",
+      "translated": "显示当前可用的手机控制项和设备功能。"
+    },
+    {
+      "id": "native.apple.503ec402d08bd43a",
+      "source": "Help me start voice chat",
+      "translated": "帮我开始语音聊天"
+    },
+    {
+      "id": "native.apple.65e462758be96174",
+      "source": "Help me start a realtime voice session from this phone.",
+      "translated": "帮我从这部手机开始实时语音会话。"
     },
     {
       "id": "native.apple.e8018adcccaa2a4d",
@@ -6904,6 +6939,26 @@
       "translated": "/pair qr"
     },
     {
+      "id": "native.apple.fe3269c93d6f8524",
+      "source": "Copied",
+      "translated": "已复制"
+    },
+    {
+      "id": "native.apple.bad4a8110ca864e1",
+      "source": "Copy",
+      "translated": "复制"
+    },
+    {
+      "id": "native.apple.b6f3f5c300b28f17",
+      "source": "Copy pair command",
+      "translated": "复制配对命令"
+    },
+    {
+      "id": "native.apple.7308cbcb1e40d70e",
+      "source": "Pair command copied",
+      "translated": "配对命令已复制"
+    },
+    {
       "id": "native.apple.b727174424127618",
       "source": "Run this in your OpenClaw chat, then scan the code.",
       "translated": "在你的 OpenClaw 聊天中运行此项，然后扫描代码。"
@@ -7129,9 +7184,9 @@
       "translated": "重试连接"
     },
     {
-      "id": "native.apple.f50052c1d760ec10",
-      "source": "Open OpenClaw",
-      "translated": "打开 OpenClaw"
+      "id": "native.apple.e674edbcb002aec6",
+      "source": "Go to Chat",
+      "translated": "前往聊天"
     },
     {
       "id": "native.apple.4679e949156e07e3",

--- a/apps/.i18n/native/zh-TW.json
+++ b/apps/.i18n/native/zh-TW.json
@@ -4504,6 +4504,11 @@
       "translated": "就緒"
     },
     {
+      "id": "native.apple.202b97e93b938049",
+      "source": "What would you like to work on?",
+      "translated": "你想要處理什麼？"
+    },
+    {
       "id": "native.apple.32179ce0b6d4543f",
       "source": "The session attaches once the gateway is ready.",
       "translated": "Gateway 準備就緒後，工作階段會連接。"
@@ -4532,6 +4537,36 @@
       "id": "native.apple.e8173c7d24457256",
       "source": "Message \\(self.agentDisplayName)...",
       "translated": "傳訊給 \\(self.agentDisplayName)…"
+    },
+    {
+      "id": "native.apple.14492e334b87e4f2",
+      "source": "Check OpenClaw status",
+      "translated": "檢查 OpenClaw 狀態"
+    },
+    {
+      "id": "native.apple.bbf7bd23da1e7865",
+      "source": "Summarize the current OpenClaw status and tell me what needs attention.",
+      "translated": "摘要目前的 OpenClaw 狀態，並告訴我哪些事項需要注意。"
+    },
+    {
+      "id": "native.apple.ea8cbb1b4230c652",
+      "source": "What can I control here?",
+      "translated": "我可以在這裡控制什麼？"
+    },
+    {
+      "id": "native.apple.451d25bdb3130ed0",
+      "source": "Show me which phone controls and device capabilities are available right now.",
+      "translated": "顯示目前可用的手機控制項目和裝置功能。"
+    },
+    {
+      "id": "native.apple.503ec402d08bd43a",
+      "source": "Help me start voice chat",
+      "translated": "協助我開始語音聊天"
+    },
+    {
+      "id": "native.apple.65e462758be96174",
+      "source": "Help me start a realtime voice session from this phone.",
+      "translated": "協助我從這支手機開始即時語音工作階段。"
     },
     {
       "id": "native.apple.e8018adcccaa2a4d",
@@ -6904,6 +6939,26 @@
       "translated": "/pair qr"
     },
     {
+      "id": "native.apple.fe3269c93d6f8524",
+      "source": "Copied",
+      "translated": "已複製"
+    },
+    {
+      "id": "native.apple.bad4a8110ca864e1",
+      "source": "Copy",
+      "translated": "複製"
+    },
+    {
+      "id": "native.apple.b6f3f5c300b28f17",
+      "source": "Copy pair command",
+      "translated": "複製配對指令"
+    },
+    {
+      "id": "native.apple.7308cbcb1e40d70e",
+      "source": "Pair command copied",
+      "translated": "已複製配對指令"
+    },
+    {
       "id": "native.apple.b727174424127618",
       "source": "Run this in your OpenClaw chat, then scan the code.",
       "translated": "在你的 OpenClaw 聊天中執行此操作，然後掃描代碼。"
@@ -7129,9 +7184,9 @@
       "translated": "重試連線"
     },
     {
-      "id": "native.apple.f50052c1d760ec10",
-      "source": "Open OpenClaw",
-      "translated": "開啟 OpenClaw"
+      "id": "native.apple.e674edbcb002aec6",
+      "source": "Go to Chat",
+      "translated": "前往聊天"
     },
     {
       "id": "native.apple.4679e949156e07e3",

--- a/apps/ios/Resources/Localizable.xcstrings
+++ b/apps/ios/Resources/Localizable.xcstrings
@@ -681,6 +681,142 @@
         }
       }
     },
+    "Check OpenClaw status": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Check OpenClaw status"
+          }
+        },
+        "zh-CN": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "检查 OpenClaw 状态"
+          }
+        },
+        "zh-TW": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "檢查 OpenClaw 狀態"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Verificar status do OpenClaw"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "OpenClaw-Status prüfen"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Comprobar el estado de OpenClaw"
+          }
+        },
+        "ja-JP": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "OpenClawのステータスを確認"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "OpenClaw 상태 확인"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Vérifier l’état d’OpenClaw"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "OpenClaw की स्थिति जाँचें"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "التحقق من حالة OpenClaw"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Controlla lo stato di OpenClaw"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "OpenClaw durumunu kontrol et"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Перевірити стан OpenClaw"
+          }
+        },
+        "id": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Periksa status OpenClaw"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sprawdź stan OpenClaw"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ตรวจสอบสถานะ OpenClaw"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Kiểm tra trạng thái OpenClaw"
+          }
+        },
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "OpenClaw-status controleren"
+          }
+        },
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "بررسی وضعیت OpenClaw"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Проверить состояние OpenClaw"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Kontrollera OpenClaw-status"
+          }
+        }
+      }
+    },
     "Close": {
       "localizations": {
         "en": {
@@ -2173,6 +2309,278 @@
           "stringUnit": {
             "state": "translated",
             "value": "Första TLS-anslutningen.\n\nVerifiera detta SHA-256-fingeravtryck via en annan kanal innan du litar på det:\n%@"
+          }
+        }
+      }
+    },
+    "Help me start a realtime voice session from this phone.": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Help me start a realtime voice session from this phone."
+          }
+        },
+        "zh-CN": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "帮我从这部手机开始实时语音会话。"
+          }
+        },
+        "zh-TW": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "幫我從這支手機開始即時語音工作階段。"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ajude-me a iniciar uma sessão de voz em tempo real neste telefone."
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Hilf mir, auf diesem Telefon eine Echtzeit-Sprachsitzung zu starten."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ayúdame a iniciar una sesión de voz en tiempo real desde este teléfono."
+          }
+        },
+        "ja-JP": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "このスマートフォンからリアルタイム音声セッションを開始するのを手伝ってください。"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "이 휴대전화에서 실시간 음성 세션을 시작하도록 도와주세요."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aidez-moi à démarrer une session vocale en temps réel depuis ce téléphone."
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "इस फ़ोन से रीयल-टाइम वॉइस सत्र शुरू करने में मेरी मदद करें।"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ساعدني في بدء جلسة صوتية في الوقت الفعلي من هذا الهاتف."
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aiutami ad avviare una sessione vocale in tempo reale da questo telefono."
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bu telefondan gerçek zamanlı bir sesli oturum başlatmama yardım et."
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Допоможи мені почати голосовий сеанс у реальному часі з цього телефона."
+          }
+        },
+        "id": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bantu saya memulai sesi suara waktu nyata dari ponsel ini."
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pomóż mi rozpocząć sesję głosową w czasie rzeczywistym na tym telefonie."
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ช่วยฉันเริ่มเซสชันเสียงแบบเรียลไทม์จากโทรศัพท์เครื่องนี้"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Giúp tôi bắt đầu một phiên thoại theo thời gian thực từ điện thoại này."
+          }
+        },
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Help me vanaf deze telefoon een realtime spraaksessie te starten."
+          }
+        },
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "به من کمک کن از این تلفن یک جلسه صوتی بلادرنگ را شروع کنم."
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Помоги мне начать голосовой сеанс в реальном времени с этого телефона."
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Hjälp mig att starta en röstsession i realtid från den här telefonen."
+          }
+        }
+      }
+    },
+    "Help me start voice chat": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Help me start voice chat"
+          }
+        },
+        "zh-CN": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "帮我开始语音聊天"
+          }
+        },
+        "zh-TW": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "幫我開始語音聊天"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ajude-me a iniciar um chat por voz"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Hilf mir, einen Sprachchat zu starten"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ayúdame a iniciar un chat de voz"
+          }
+        },
+        "ja-JP": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "音声チャットの開始を手伝って"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "음성 채팅 시작 도와줘"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aidez-moi à démarrer un chat vocal"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "वॉइस चैट शुरू करने में मेरी मदद करें"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ساعدني في بدء محادثة صوتية"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aiutami ad avviare una chat vocale"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sesli sohbet başlatmama yardım et"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Допоможи мені почати голосовий чат"
+          }
+        },
+        "id": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bantu saya memulai chat suara"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pomóż mi rozpocząć czat głosowy"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ช่วยฉันเริ่มแชทด้วยเสียง"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Giúp tôi bắt đầu trò chuyện thoại"
+          }
+        },
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Help me een spraakchat te starten"
+          }
+        },
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "به من کمک کن گفت‌وگوی صوتی را شروع کنم"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Помоги мне начать голосовой чат"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Hjälp mig att starta en röstchatt"
           }
         }
       }
@@ -4761,6 +5169,278 @@
         }
       }
     },
+    "Show me which phone controls and device capabilities are available right now.": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Show me which phone controls and device capabilities are available right now."
+          }
+        },
+        "zh-CN": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "告诉我目前可以使用哪些手机控制功能和设备能力。"
+          }
+        },
+        "zh-TW": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "告訴我目前可以使用哪些手機控制功能和裝置能力。"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mostre quais controles do telefone e recursos do dispositivo estão disponíveis agora."
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Zeige mir, welche Telefonsteuerungen und Gerätefunktionen gerade verfügbar sind."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Muéstrame qué controles del teléfono y funciones del dispositivo están disponibles ahora."
+          }
+        },
+        "ja-JP": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "現在利用できるスマートフォンの操作機能とデバイス機能を教えてください。"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "지금 사용할 수 있는 휴대전화 제어 기능과 기기 기능을 보여 주세요."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Montrez-moi les commandes du téléphone et les fonctionnalités de l’appareil actuellement disponibles."
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "मुझे दिखाएं कि अभी कौन-से फ़ोन नियंत्रण और डिवाइस क्षमताएं उपलब्ध हैं।"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "اعرض لي عناصر التحكم في الهاتف وإمكانات الجهاز المتاحة الآن."
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mostrami quali controlli del telefono e funzionalità del dispositivo sono disponibili ora."
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Şu anda hangi telefon kontrollerinin ve cihaz özelliklerinin kullanılabildiğini göster."
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Покажи, які елементи керування телефоном і можливості пристрою доступні зараз."
+          }
+        },
+        "id": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tunjukkan kontrol ponsel dan kemampuan perangkat yang tersedia saat ini."
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pokaż mi, które funkcje sterowania telefonem i możliwości urządzenia są teraz dostępne."
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "แสดงให้ฉันเห็นว่าตอนนี้มีการควบคุมโทรศัพท์และความสามารถของอุปกรณ์ใดบ้าง"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cho tôi biết hiện có những tính năng điều khiển điện thoại và khả năng thiết bị nào."
+          }
+        },
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Laat me zien welke telefoonbediening en apparaatfuncties nu beschikbaar zijn."
+          }
+        },
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "نشان بده اکنون کدام کنترل‌های تلفن و قابلیت‌های دستگاه در دسترس هستند."
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Покажи, какие элементы управления телефоном и возможности устройства сейчас доступны."
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Visa vilka telefonkontroller och enhetsfunktioner som är tillgängliga just nu."
+          }
+        }
+      }
+    },
+    "Summarize the current OpenClaw status and tell me what needs attention.": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Summarize the current OpenClaw status and tell me what needs attention."
+          }
+        },
+        "zh-CN": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "总结当前的 OpenClaw 状态，并告诉我哪些方面需要注意。"
+          }
+        },
+        "zh-TW": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "總結目前的 OpenClaw 狀態，並告訴我哪些方面需要注意。"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Resuma o status atual do OpenClaw e diga o que precisa de atenção."
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Fasse den aktuellen OpenClaw-Status zusammen und sage mir, was Aufmerksamkeit erfordert."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Resume el estado actual de OpenClaw y dime qué necesita atención."
+          }
+        },
+        "ja-JP": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "現在のOpenClawの状態を要約し、注意が必要な点を教えてください。"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "현재 OpenClaw 상태를 요약하고 주의가 필요한 항목을 알려 주세요."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Résumez l’état actuel d’OpenClaw et indiquez-moi ce qui nécessite mon attention."
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "OpenClaw की मौजूदा स्थिति का सारांश दें और बताएं कि किन चीज़ों पर ध्यान देने की ज़रूरत है।"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "لخّص حالة OpenClaw الحالية وأخبرني بما يحتاج إلى الاهتمام."
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Riassumi lo stato attuale di OpenClaw e dimmi cosa richiede attenzione."
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mevcut OpenClaw durumunu özetle ve nelerin ilgilenilmesi gerektiğini söyle."
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Підсумуй поточний стан OpenClaw і скажи, що потребує уваги."
+          }
+        },
+        "id": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ringkas status OpenClaw saat ini dan beri tahu saya apa yang perlu diperhatikan."
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Podsumuj bieżący stan OpenClaw i powiedz mi, co wymaga uwagi."
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "สรุปสถานะ OpenClaw ปัจจุบันและบอกฉันว่ามีอะไรที่ต้องตรวจสอบ"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tóm tắt trạng thái OpenClaw hiện tại và cho tôi biết những gì cần chú ý."
+          }
+        },
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Vat de huidige OpenClaw-status samen en vertel me wat aandacht nodig heeft."
+          }
+        },
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "وضعیت فعلی OpenClaw را خلاصه کن و بگو چه چیزهایی نیاز به توجه دارند."
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Подведи итог текущего состояния OpenClaw и скажи, что требует внимания."
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sammanfatta aktuell OpenClaw-status och berätta vad som behöver uppmärksammas."
+          }
+        }
+      }
+    },
     "Talk": {
       "localizations": {
         "en": {
@@ -5437,6 +6117,278 @@
           "stringUnit": {
             "state": "translated",
             "value": "Lita på denna gateway?"
+          }
+        }
+      }
+    },
+    "What can I control here?": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "What can I control here?"
+          }
+        },
+        "zh-CN": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "我可以在这里控制什么？"
+          }
+        },
+        "zh-TW": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "我可以在這裡控制什麼？"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "O que posso controlar aqui?"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Was kann ich hier steuern?"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "¿Qué puedo controlar aquí?"
+          }
+        },
+        "ja-JP": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ここでは何を操作できますか？"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "여기서 무엇을 제어할 수 있나요?"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Que puis-je contrôler ici ?"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "मैं यहाँ क्या नियंत्रित कर सकता हूँ?"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ما الذي يمكنني التحكم فيه هنا؟"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cosa posso controllare qui?"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Burada neleri kontrol edebilirim?"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Чим я можу керувати тут?"
+          }
+        },
+        "id": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Apa yang dapat saya kontrol di sini?"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Czym mogę tutaj sterować?"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ฉันควบคุมอะไรที่นี่ได้บ้าง"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tôi có thể điều khiển gì ở đây?"
+          }
+        },
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wat kan ik hier bedienen?"
+          }
+        },
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "اینجا چه چیزهایی را می‌توانم کنترل کنم؟"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Чем я могу управлять здесь?"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Vad kan jag styra här?"
+          }
+        }
+      }
+    },
+    "What would you like to work on?": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "What would you like to work on?"
+          }
+        },
+        "zh-CN": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "你想处理什么？"
+          }
+        },
+        "zh-TW": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "你想處理什麼？"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Em que você gostaria de trabalhar?"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Woran möchtest du arbeiten?"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "¿En qué te gustaría trabajar?"
+          }
+        },
+        "ja-JP": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "何に取り組みますか？"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "무엇을 진행하고 싶으신가요?"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sur quoi souhaitez-vous travailler ?"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "आप किस पर काम करना चाहेंगे?"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ما الذي تود العمل عليه؟"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Su cosa vuoi lavorare?"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ne üzerinde çalışmak istersiniz?"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Над чим ви хочете попрацювати?"
+          }
+        },
+        "id": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Apa yang ingin Anda kerjakan?"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nad czym chcesz popracować?"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "คุณอยากทำอะไร"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bạn muốn làm việc gì?"
+          }
+        },
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Waaraan wil je werken?"
+          }
+        },
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "می‌خواهید روی چه چیزی کار کنید؟"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Над чем вы хотите поработать?"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Vad vill du arbeta med?"
           }
         }
       }

--- a/apps/ios/Sources/Chat/AppleReviewDemoChatTransport.swift
+++ b/apps/ios/Sources/Chat/AppleReviewDemoChatTransport.swift
@@ -80,9 +80,9 @@ struct LocalChatFixture {
         modelID: "gpt-5.5",
         modelName: "GPT-5.5",
         responsePrefix: "OpenClaw is connected to your gateway.",
-        seedMessages: [
-            "Ready when you are. I can check a project, coordinate an agent, or prepare the next step.",
-        ],
+        seedMessages: ProcessInfo.processInfo.arguments.contains("--openclaw-empty-chat-fixture")
+            ? []
+            : ["Ready when you are. I can check a project, coordinate an agent, or prepare the next step."],
         agents: [
             AgentSummary(
                 id: "main",
@@ -298,7 +298,12 @@ private actor LocalFixtureChatStore {
 
     func sendMessage(sessionKey _: String, message: String, runId: String) throws -> OpenClawChatSendResponse {
         let now = Date().timeIntervalSince1970 * 1000
-        self.messages.append(Self.message(role: "user", text: message, timestamp: now))
+        self.messages.append(
+            Self.message(
+                role: "user",
+                text: message,
+                timestamp: now,
+                idempotencyKey: "\(runId):user"))
         let trimmed = message.trimmingCharacters(in: .whitespacesAndNewlines)
         let subject = trimmed.isEmpty ? "that request" : "\"\(trimmed)\""
         self.messages.append(
@@ -377,7 +382,12 @@ private actor LocalFixtureChatStore {
         }
     }
 
-    private static func message(role: String, text: String, timestamp: Double) -> OpenClawChatMessage {
+    private static func message(
+        role: String,
+        text: String,
+        timestamp: Double,
+        idempotencyKey: String? = nil) -> OpenClawChatMessage
+    {
         OpenClawChatMessage(
             role: role,
             content: [
@@ -388,7 +398,8 @@ private actor LocalFixtureChatStore {
                     fileName: nil,
                     content: nil),
             ],
-            timestamp: timestamp)
+            timestamp: timestamp,
+            idempotencyKey: idempotencyKey)
     }
 
     private static func normalizedSessionKey(_ value: String, fallback: String) -> String {

--- a/apps/ios/Sources/Design/ChatProTab.swift
+++ b/apps/ios/Sources/Design/ChatProTab.swift
@@ -97,6 +97,8 @@ struct ChatProTab: View {
                 composerChrome: .clean,
                 isComposerEnabled: self.gatewayConnected,
                 messagePlaceholder: self.messagePlaceholder,
+                emptyAssistantIntro: String(localized: "What would you like to work on?"),
+                emptyAssistantPrompts: Self.emptyAssistantPrompts,
                 talkControl: self.talkControl)
                 // iMessage-style grey bubbles for agent replies in the clean chrome.
                     .environment(\.openClawAssistantBubblesInCleanChrome, true)
@@ -270,7 +272,7 @@ struct ChatProTab: View {
     private var agentBadge: String {
         if let identity = activeAgent?.identity,
            let emoji = identity["emoji"]?.value as? String,
-           let normalizedEmoji = normalized(emoji)
+           let normalizedEmoji = Self.normalizedBadgeEmoji(emoji)
         {
             return normalizedEmoji
         }
@@ -283,6 +285,27 @@ struct ChatProTab: View {
         }
         return "OC"
     }
+
+    nonisolated static func normalizedBadgeEmoji(_ value: String?) -> String? {
+        guard let value else { return nil }
+        let normalized = value.trimmingCharacters(in: .whitespacesAndNewlines)
+        return normalized.isEmpty || normalized == "?" ? nil : normalized
+    }
+
+    nonisolated static let emptyAssistantPrompts: [OpenClawChatView.StarterPrompt] = [
+        OpenClawChatView.StarterPrompt(
+            id: "summarize-status",
+            title: String(localized: "Check OpenClaw status"),
+            prompt: String(localized: "Summarize the current OpenClaw status and tell me what needs attention.")),
+        OpenClawChatView.StarterPrompt(
+            id: "show-controls",
+            title: String(localized: "What can I control here?"),
+            prompt: String(localized: "Show me which phone controls and device capabilities are available right now.")),
+        OpenClawChatView.StarterPrompt(
+            id: "start-voice",
+            title: String(localized: "Help me start voice chat"),
+            prompt: String(localized: "Help me start a realtime voice session from this phone.")),
+    ]
 
     private func normalized(_ value: String?) -> String? {
         guard let value else { return nil }

--- a/apps/ios/Sources/Onboarding/OnboardingWizardSteps.swift
+++ b/apps/ios/Sources/Onboarding/OnboardingWizardSteps.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import UIKit
 
 private enum OnboardingLayout {
     static let contentMaxWidth: CGFloat = 680
@@ -131,6 +132,8 @@ struct OnboardingWelcomeStep: View {
     let onScanQRCode: () -> Void
     let onManualSetup: () -> Void
 
+    @State private var pairCommandCopied = false
+
     var body: some View {
         VStack(spacing: 0) {
             Spacer()
@@ -144,8 +147,29 @@ struct OnboardingWelcomeStep: View {
                 .font(OpenClawType.title1)
                 .padding(.bottom, 12)
 
-            KeycapText("/pair qr")
-                .padding(.bottom, 10)
+            HStack(spacing: 8) {
+                KeycapText("/pair qr")
+                Button {
+                    var transaction = Transaction()
+                    transaction.disablesAnimations = true
+                    withTransaction(transaction) {
+                        UIPasteboard.general.string = "/pair qr"
+                        self.pairCommandCopied = true
+                    }
+                } label: {
+                    Label(
+                        self.pairCommandCopied ? "Copied" : "Copy",
+                        systemImage: self.pairCommandCopied ? "checkmark" : "doc.on.doc")
+                        .font(OpenClawType.captionSemiBold)
+                }
+                .buttonStyle(.bordered)
+                .controlSize(.small)
+                .tint(.primary)
+                .animation(nil, value: self.pairCommandCopied)
+                .accessibilityLabel(self.pairCommandCopied ? "Pair command copied" : "Copy pair command")
+                .accessibilityIdentifier("onboarding-copy-pair-command")
+            }
+            .padding(.bottom, 10)
 
             Text("Run this in your OpenClaw chat, then scan the code.")
                 .font(OpenClawType.subhead)

--- a/apps/ios/Sources/Onboarding/OnboardingWizardView.swift
+++ b/apps/ios/Sources/Onboarding/OnboardingWizardView.swift
@@ -75,15 +75,18 @@ struct OnboardingWizardView: View {
     let allowSkip: Bool
     let onRequestLocalNetworkAccess: (String) -> Void
     let onClose: () -> Void
+    let onComplete: () -> Void
 
     init(
         allowSkip: Bool,
         onRequestLocalNetworkAccess: @escaping (String) -> Void,
-        onClose: @escaping () -> Void)
+        onClose: @escaping () -> Void,
+        onComplete: @escaping () -> Void)
     {
         self.allowSkip = allowSkip
         self.onRequestLocalNetworkAccess = onRequestLocalNetworkAccess
         self.onClose = onClose
+        self.onComplete = onComplete
         _step = State(
             initialValue: OnboardingStateStore.shouldPresentFirstRunIntro() ? .intro : .welcome)
     }
@@ -646,24 +649,16 @@ struct OnboardingWizardView: View {
                 .foregroundStyle(OpenClawBrand.textPrimary)
                 .padding(.bottom, 8)
 
-            let server = self.appModel.gatewayServerName ?? "gateway"
-            Text(server)
+            Text(self.successEndpoint)
                 .font(OpenClawType.subhead)
                 .foregroundStyle(.secondary)
-                .padding(.bottom, 4)
-
-            if let addr = self.appModel.gatewayRemoteAddress {
-                Text(addr)
-                    .font(OpenClawType.subhead)
-                    .foregroundStyle(.secondary)
-            }
 
             Spacer()
 
             Button {
-                self.onClose()
+                self.onComplete()
             } label: {
-                Text("Open OpenClaw")
+                Label("Go to Chat", systemImage: "bubble.left.and.bubble.right.fill")
                     .font(OpenClawType.headline)
             }
             .font(OpenClawType.headline)
@@ -995,6 +990,15 @@ extension OnboardingWizardView {
     private var canConnectManual: Bool {
         let host = self.manualHost.trimmingCharacters(in: .whitespacesAndNewlines)
         return !host.isEmpty && self.manualPort > 0 && self.manualPort <= 65535
+    }
+
+    private var successEndpoint: String {
+        let serverName = self.appModel.gatewayServerName?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        if !serverName.isEmpty {
+            return serverName
+        }
+        let remoteAddress = self.appModel.gatewayRemoteAddress?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        return remoteAddress.isEmpty ? "gateway" : remoteAddress
     }
 
     private func initializeState() {

--- a/apps/ios/Sources/RootTabs.swift
+++ b/apps/ios/Sources/RootTabs.swift
@@ -900,6 +900,10 @@ struct RootTabs: View {
                     },
                     onClose: {
                         self.showOnboarding = false
+                    },
+                    onComplete: {
+                        self.selectSidebarDestination(.chat)
+                        self.showOnboarding = false
                     })
                     .environment(self.appModel)
                     .environment(self.voiceWake)

--- a/apps/ios/Tests/GatewayStatusBuilderTests.swift
+++ b/apps/ios/Tests/GatewayStatusBuilderTests.swift
@@ -41,4 +41,16 @@ import Testing
         #expect(ChatProTab.gatewayPillTitle(state: .connected, isGatewayUsable: true) == "Connected")
         #expect(ChatProTab.gatewayPillTitle(state: .connected, isGatewayUsable: false) == "Unavailable")
     }
+
+    @Test func `chat agent badge rejects placeholder question mark`() {
+        #expect(ChatProTab.normalizedBadgeEmoji(" 🦞 ") == "🦞")
+        #expect(ChatProTab.normalizedBadgeEmoji("?") == nil)
+        #expect(ChatProTab.normalizedBadgeEmoji("   ") == nil)
+        #expect(ChatProTab.normalizedBadgeEmoji(nil) == nil)
+    }
+
+    @Test func `chat starter prompts stay stable and actionable`() {
+        #expect(ChatProTab.emptyAssistantPrompts.map(\.id) == ["summarize-status", "show-controls", "start-voice"])
+        #expect(ChatProTab.emptyAssistantPrompts.allSatisfy { !$0.title.isEmpty && !$0.prompt.isEmpty })
+    }
 }

--- a/apps/ios/Tests/IOSGatewayChatTransportTests.swift
+++ b/apps/ios/Tests/IOSGatewayChatTransportTests.swift
@@ -1,4 +1,5 @@
 import Foundation
+import OpenClawChatUI
 import OpenClawKit
 import OpenClawProtocol
 import Testing
@@ -173,5 +174,25 @@ import Testing
             stateversion: nil)
         let mapped = IOSGatewayChatTransport.mapEventFrame(frame)
         #expect(mapped == nil)
+    }
+}
+
+@Suite struct LocalFixtureChatTransportTests {
+    @Test func sentUserTurnCarriesGatewayIdempotencyMetadata() async throws {
+        let transport = LocalFixtureChatTransport(fixture: .appleReviewDemo)
+
+        _ = try await transport.sendMessage(
+            sessionKey: "main",
+            message: "hello",
+            thinking: "auto",
+            idempotencyKey: "fixture-run",
+            attachments: [])
+        let history = try await transport.requestHistory(sessionKey: "main")
+        let decoded = try #require(history.messages).compactMap { payload -> OpenClawChatMessage? in
+            guard let data = try? JSONEncoder().encode(payload) else { return nil }
+            return try? JSONDecoder().decode(OpenClawChatMessage.self, from: data)
+        }
+
+        #expect(decoded.last(where: { $0.role == "user" })?.idempotencyKey == "fixture-run:user")
     }
 }

--- a/apps/ios/UITests/OpenClawSnapshotUITests.swift
+++ b/apps/ios/UITests/OpenClawSnapshotUITests.swift
@@ -293,6 +293,103 @@ final class OpenClawSnapshotUITests: XCTestCase {
         self.attachScreenshot(named: "chat-light")
     }
 
+    func testEmptyChatStarterPromptSendsMessage() throws {
+        self.launchApp(
+            for: ScreenshotTarget(
+                initialTab: "chat",
+                initialDestination: "chat",
+                name: "chat-empty-starters"),
+            additionalArguments: ["--openclaw-empty-chat-fixture"])
+
+        let starter = try XCTUnwrap(self.app?.buttons["chat-starter-summarize-status"])
+        XCTAssertTrue(starter.waitForExistence(timeout: 8))
+        XCTAssertTrue(self.app?.staticTexts["What would you like to work on?"].exists == true)
+        self.attachScreenshot(named: "chat-empty-starters")
+
+        starter.tap()
+        let sentText = "Summarize the current OpenClaw status and tell me what needs attention."
+        let sentRows = self.app?.staticTexts.matching(NSPredicate(format: "label == %@", sentText))
+        XCTAssertTrue(sentRows?.firstMatch.waitForExistence(timeout: 5) == true)
+        XCTAssertEqual(sentRows?.count, 1)
+        XCTAssertTrue(
+            self.app?.staticTexts.matching(NSPredicate(format: "label CONTAINS %@", "I can help with"))
+                .firstMatch.waitForExistence(timeout: 5) == true)
+        self.attachScreenshot(named: "chat-starter-response")
+    }
+
+    func testEmptyChatStarterPromptsLocalizeInGerman() throws {
+        self.launchApp(
+            for: ScreenshotTarget(
+                initialTab: "chat",
+                initialDestination: "chat",
+                name: "chat-empty-starters-german"),
+            additionalArguments: [
+                "--openclaw-empty-chat-fixture",
+                "-AppleLanguages",
+                "(de)",
+                "-AppleLocale",
+                "de_DE",
+            ])
+
+        XCTAssertTrue(self.app?.staticTexts["Woran möchtest du arbeiten?"].waitForExistence(timeout: 8) == true)
+        let starter = try XCTUnwrap(self.app?.buttons["OpenClaw-Status prüfen"])
+        XCTAssertTrue(starter.exists)
+        starter.tap()
+        XCTAssertTrue(
+            self.app?.staticTexts[
+                "Fasse den aktuellen OpenClaw-Status zusammen und sage mir, was Aufmerksamkeit erfordert."
+            ].waitForExistence(timeout: 5) == true)
+        self.attachScreenshot(named: "chat-empty-starters-german")
+    }
+
+    func testOnboardingPairCommandAndCompletionOpenChat() throws {
+        try XCTSkipIf(UIDevice.current.userInterfaceIdiom != .phone, "Phone onboarding proof only")
+        self.addUIInterruptionMonitor(withDescription: "Local network access") { alert in
+            guard alert.buttons["Allow"].exists else { return false }
+            alert.buttons["Allow"].tap()
+            return true
+        }
+
+        let app = XCUIApplication()
+        setupSnapshot(app)
+        app.launchArguments += [
+            "--openclaw-reset-onboarding",
+            "--openclaw-initial-tab",
+            "settings",
+            "--openclaw-initial-destination",
+            "settings",
+        ]
+        app.launch()
+        self.app = app
+
+        XCTAssertTrue(app.buttons["Continue"].waitForExistence(timeout: 8))
+        app.buttons["Continue"].tap()
+        app.tap()
+
+        let copyPairCommand = app.buttons["onboarding-copy-pair-command"]
+        XCTAssertTrue(copyPairCommand.waitForExistence(timeout: 8))
+        copyPairCommand.tap()
+        XCTAssertEqual(copyPairCommand.label, "Pair command copied")
+        self.attachScreenshot(named: "onboarding-copy-pair-command")
+
+        app.buttons["Set Up Manually"].tap()
+        let setupCode = app.textFields["Paste setup code"]
+        XCTAssertTrue(setupCode.waitForExistence(timeout: 5))
+        setupCode.tap()
+        setupCode.typeText("APPLE-REVIEW-DEMO")
+        app.buttons["Done"].tap()
+        app.buttons["Apply Setup Code"].tap()
+
+        XCTAssertTrue(app.staticTexts["Connected"].waitForExistence(timeout: 8))
+        XCTAssertTrue(app.staticTexts["Apple Review Demo Gateway"].exists)
+        XCTAssertFalse(app.staticTexts["Local demo mode"].exists)
+        self.attachScreenshot(named: "onboarding-connected-go-to-chat")
+
+        app.buttons["Go to Chat"].tap()
+        XCTAssertTrue(app.tabBars.buttons["Chat"].waitForExistence(timeout: 5))
+        XCTAssertTrue(app.tabBars.buttons["Chat"].isSelected)
+    }
+
     func testTalkUsesNativeControls() throws {
         try XCTSkipIf(UIDevice.current.userInterfaceIdiom != .phone, "Phone Talk controls only")
         self.launchApp(for: ScreenshotTarget(
@@ -602,7 +699,8 @@ final class OpenClawSnapshotUITests: XCTestCase {
     private func launchApp(
         for target: ScreenshotTarget,
         appearance: String? = "dark",
-        screenshotMode: Bool = true)
+        screenshotMode: Bool = true,
+        additionalArguments: [String] = [])
     {
         self.app?.terminate()
 
@@ -619,6 +717,7 @@ final class OpenClawSnapshotUITests: XCTestCase {
         if screenshotMode {
             app.launchArguments.append("--openclaw-screenshot-mode")
         }
+        app.launchArguments += additionalArguments
         if let appearance {
             app.launchArguments += ["--openclaw-appearance", appearance]
         }
@@ -684,7 +783,7 @@ final class OpenClawSnapshotUITests: XCTestCase {
         app.buttons["Apply Setup Code"].tap()
 
         XCTAssertTrue(app.staticTexts["Connected"].waitForExistence(timeout: 45))
-        app.buttons["Open OpenClaw"].tap()
+        app.buttons["Go to Chat"].tap()
         return app
     }
 

--- a/apps/ios/project.yml
+++ b/apps/ios/project.yml
@@ -65,8 +65,8 @@ targets:
         buildPhase: resources
       - path: Sources/Fonts
         buildPhase: resources
-    resources:
       - path: Resources/Localizable.xcstrings
+        buildPhase: resources
     dependencies:
       - target: OpenClawShareExtension
         embed: true
@@ -201,8 +201,8 @@ targets:
       Release: Signing.xcconfig
     sources:
       - path: ShareExtension
-    resources:
       - path: Resources/Localizable.xcstrings
+        buildPhase: resources
     dependencies:
       - package: OpenClawKit
       - sdk: AppIntents.framework
@@ -247,8 +247,8 @@ targets:
       - path: Sources/LiveActivity/OpenClawActivityAttributes.swift
       - path: Sources/Fonts
         buildPhase: resources
-    resources:
       - path: Resources/Localizable.xcstrings
+        buildPhase: resources
     dependencies:
       - sdk: WidgetKit.framework
       - sdk: ActivityKit.framework
@@ -290,8 +290,8 @@ targets:
           - Info.plist
       - path: Sources/Fonts
         buildPhase: resources
-    resources:
       - path: Resources/Localizable.xcstrings
+        buildPhase: resources
     dependencies:
       - sdk: AppIntents.framework
       - sdk: WatchConnectivity.framework

--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatModels.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatModels.swift
@@ -183,10 +183,15 @@ public struct OpenClawChatMessageContent: Codable, Hashable, Sendable {
 }
 
 public struct OpenClawChatMessage: Codable, Hashable, Identifiable, Sendable {
+    private struct OpenClawMetadata: Codable {
+        let idempotencyKey: String?
+    }
+
     public var id: UUID = .init()
     public let role: String
     public let content: [OpenClawChatMessageContent]
     public let timestamp: Double?
+    public let idempotencyKey: String?
     public let toolCallId: String?
     public let toolName: String?
     public let usage: OpenClawChatUsage?
@@ -197,6 +202,8 @@ public struct OpenClawChatMessage: Codable, Hashable, Identifiable, Sendable {
         case role
         case content
         case timestamp
+        case idempotencyKey
+        case openClaw = "__openclaw"
         case toolCallId
         case tool_call_id
         case toolName
@@ -211,6 +218,7 @@ public struct OpenClawChatMessage: Codable, Hashable, Identifiable, Sendable {
         role: String,
         content: [OpenClawChatMessageContent],
         timestamp: Double?,
+        idempotencyKey: String? = nil,
         toolCallId: String? = nil,
         toolName: String? = nil,
         usage: OpenClawChatUsage? = nil,
@@ -221,6 +229,7 @@ public struct OpenClawChatMessage: Codable, Hashable, Identifiable, Sendable {
         self.role = role
         self.content = content
         self.timestamp = timestamp
+        self.idempotencyKey = idempotencyKey
         self.toolCallId = toolCallId
         self.toolName = toolName
         self.usage = usage
@@ -232,6 +241,9 @@ public struct OpenClawChatMessage: Codable, Hashable, Identifiable, Sendable {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         let decodedRole = try container.decode(String.self, forKey: .role)
         let decodedTimestamp = try container.decodeIfPresent(Double.self, forKey: .timestamp)
+        let decodedOpenClaw = try container.decodeIfPresent(OpenClawMetadata.self, forKey: .openClaw)
+        let decodedIdempotencyKey = try decodedOpenClaw?.idempotencyKey ??
+            container.decodeIfPresent(String.self, forKey: .idempotencyKey)
         let decodedToolCallId =
             try container.decodeIfPresent(String.self, forKey: .toolCallId) ??
             container.decodeIfPresent(String.self, forKey: .tool_call_id)
@@ -244,6 +256,7 @@ public struct OpenClawChatMessage: Codable, Hashable, Identifiable, Sendable {
 
         self.role = decodedRole
         self.timestamp = decodedTimestamp
+        self.idempotencyKey = decodedIdempotencyKey
         self.toolCallId = decodedToolCallId
         self.toolName = decodedToolName
         self.usage = decodedUsage
@@ -315,6 +328,7 @@ public struct OpenClawChatMessage: Codable, Hashable, Identifiable, Sendable {
         var container = encoder.container(keyedBy: CodingKeys.self)
         try container.encode(self.role, forKey: .role)
         try container.encodeIfPresent(self.timestamp, forKey: .timestamp)
+        try container.encodeIfPresent(self.idempotencyKey, forKey: .idempotencyKey)
         try container.encodeIfPresent(self.toolCallId, forKey: .toolCallId)
         try container.encodeIfPresent(self.toolName, forKey: .toolName)
         try container.encodeIfPresent(self.usage, forKey: .usage)

--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatView.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatView.swift
@@ -44,6 +44,18 @@ public struct OpenClawChatView: View {
         case clean
     }
 
+    public struct StarterPrompt: Hashable, Identifiable, Sendable {
+        public let id: String
+        public let title: String
+        public let prompt: String
+
+        public init(id: String, title: String, prompt: String) {
+            self.id = id
+            self.title = title
+            self.prompt = prompt
+        }
+    }
+
     @State private var viewModel: OpenClawChatViewModel
     @Environment(\.scenePhase) private var scenePhase
     @State private var scrollerBottomID = UUID()
@@ -69,6 +81,7 @@ public struct OpenClawChatView: View {
     private let isComposerEnabled: Bool
     private let messagePlaceholder: String?
     private let emptyAssistantIntro: String?
+    private let emptyAssistantPrompts: [StarterPrompt]
     private let talkControl: OpenClawChatTalkControl?
 
     private enum ScrollFollowTarget: Equatable {
@@ -118,6 +131,7 @@ public struct OpenClawChatView: View {
         isComposerEnabled: Bool = true,
         messagePlaceholder: String? = nil,
         emptyAssistantIntro: String? = nil,
+        emptyAssistantPrompts: [StarterPrompt] = [],
         talkControl: OpenClawChatTalkControl? = nil)
     {
         _viewModel = State(initialValue: viewModel)
@@ -135,6 +149,7 @@ public struct OpenClawChatView: View {
         self.isComposerEnabled = isComposerEnabled
         self.messagePlaceholder = messagePlaceholder
         self.emptyAssistantIntro = emptyAssistantIntro
+        self.emptyAssistantPrompts = emptyAssistantPrompts
         self.talkControl = talkControl
     }
 
@@ -299,7 +314,13 @@ public struct OpenClawChatView: View {
     @ViewBuilder
     private var messageListRows: some View {
         if let introText = visibleEmptyAssistantIntro {
-            ChatAssistantIntroCard(text: introText)
+            ChatAssistantIntroCard(
+                text: introText,
+                prompts: self.emptyAssistantPrompts,
+                onPrompt: { prompt in
+                    self.viewModel.input = prompt.prompt
+                    self.viewModel.send()
+                })
                 .frame(maxWidth: .infinity, alignment: .leading)
         }
 
@@ -692,6 +713,7 @@ public struct OpenClawChatView: View {
                 role: last.role,
                 content: content,
                 timestamp: last.timestamp,
+                idempotencyKey: last.idempotencyKey,
                 toolCallId: last.toolCallId,
                 toolName: last.toolName,
                 usage: last.usage,
@@ -805,22 +827,49 @@ public struct OpenClawChatView: View {
 
 private struct ChatAssistantIntroCard: View {
     let text: String
+    let prompts: [OpenClawChatView.StarterPrompt]
+    let onPrompt: (OpenClawChatView.StarterPrompt) -> Void
 
     var body: some View {
-        // Rendered as a grey assistant bubble so the greeting reads like the
-        // agent's first message, matching the in-conversation bubble style.
-        Text(self.text)
-            .font(OpenClawChatTypography.body)
-            .foregroundStyle(OpenClawChatTheme.assistantText)
-            .multilineTextAlignment(.leading)
-            .padding(.vertical, 10)
-            .padding(.horizontal, 14)
-            .background(
-                RoundedRectangle(cornerRadius: 18, style: .continuous)
-                    .fill(OpenClawChatTheme.assistantBubble))
-            .frame(maxWidth: 320, alignment: .leading)
-            .padding(.top, 8)
-            .frame(maxWidth: .infinity, alignment: .leading)
+        VStack(alignment: .leading, spacing: 10) {
+            // Rendered as a grey assistant bubble so the greeting reads like the
+            // agent's first message, matching the in-conversation bubble style.
+            Text(self.text)
+                .font(OpenClawChatTypography.body)
+                .foregroundStyle(OpenClawChatTheme.assistantText)
+                .multilineTextAlignment(.leading)
+                .padding(.vertical, 10)
+                .padding(.horizontal, 14)
+                .background(
+                    RoundedRectangle(cornerRadius: 18, style: .continuous)
+                        .fill(OpenClawChatTheme.assistantBubble))
+
+            ForEach(self.prompts) { prompt in
+                Button {
+                    self.onPrompt(prompt)
+                } label: {
+                    HStack(spacing: 8) {
+                        Text(prompt.title)
+                            .font(OpenClawChatTypography.body(size: 15, weight: .semibold, relativeTo: .callout))
+                            .multilineTextAlignment(.leading)
+                        Spacer(minLength: 8)
+                        Image(systemName: "arrow.up.right")
+                            .font(OpenClawChatTypography.captionSemiBold)
+                            .foregroundStyle(.secondary)
+                    }
+                    .padding(.horizontal, 12)
+                    .padding(.vertical, 10)
+                    .background(
+                        RoundedRectangle(cornerRadius: 14, style: .continuous)
+                            .fill(OpenClawChatTheme.subtleCard))
+                }
+                .buttonStyle(.plain)
+                .accessibilityIdentifier("chat-starter-\(prompt.id)")
+            }
+        }
+        .frame(maxWidth: 340, alignment: .leading)
+        .padding(.top, 8)
+        .frame(maxWidth: .infinity, alignment: .leading)
     }
 }
 

--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatViewModel.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatViewModel.swift
@@ -133,6 +133,7 @@ public final class OpenClawChatViewModel {
     }
 
     private struct LatestUserTurn {
+        var idempotencyKey: String?
         var refreshKey: String?
         var occurrence: Int
         var timestamp: Double?
@@ -459,6 +460,7 @@ public final class OpenClawChatViewModel {
         }
         self.replaceMessages(nextMessages)
         self.prunePendingLocalUserEchoMessageIDs()
+        self.clearProvisionalFinalMarkersAdoptedByHistory(incoming)
         self.pruneProvisionalFinalMessages()
         self.pruneRunMessageScopes()
         self.sessionId = payload.sessionId
@@ -610,6 +612,7 @@ public final class OpenClawChatViewModel {
             role: message.role,
             content: sanitizedContent,
             timestamp: message.timestamp,
+            idempotencyKey: message.idempotencyKey,
             toolCallId: message.toolCallId,
             toolName: message.toolName,
             usage: message.usage,
@@ -639,6 +642,12 @@ public final class OpenClawChatViewModel {
     private static func messageIdentityKey(for message: OpenClawChatMessage) -> String? {
         let role = message.role.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
         guard !role.isEmpty else { return nil }
+
+        // The gateway persists this key with the canonical user row. Prefer it
+        // so a server timestamp change cannot replace the optimistic row's ID.
+        if let idempotencyKey = Self.normalizedIdempotencyKey(message.idempotencyKey) {
+            return [role, "idempotency", idempotencyKey].joined(separator: "|")
+        }
 
         let timestamp: String = {
             guard let value = message.timestamp, value.isFinite else { return "" }
@@ -672,8 +681,8 @@ public final class OpenClawChatViewModel {
         guard role == "assistant" else { return nil }
 
         // chat.final and session.message can serialize the same final row with
-        // different timestamps/content ids; the run user-turn scope owns safety
-        // for repeated same-text replies across turns.
+        // different timestamps/content ids. Reconciliation prefers the durable
+        // gateway run key, with user-turn scope as a legacy fallback.
         let contentFingerprint = Self.finalMessageContentFingerprint(for: message)
         let toolCallId = (message.toolCallId ?? "").trimmingCharacters(in: .whitespacesAndNewlines)
         let toolName = (message.toolName ?? "").trimmingCharacters(in: .whitespacesAndNewlines)
@@ -686,6 +695,28 @@ public final class OpenClawChatViewModel {
     private static func normalizedRunID(_ runId: String?) -> String? {
         let trimmed = runId?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
         return trimmed.isEmpty ? nil : trimmed
+    }
+
+    private static func normalizedIdempotencyKey(_ key: String?) -> String? {
+        let trimmed = key?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        return trimmed.isEmpty ? nil : trimmed
+    }
+
+    private static func adoptingCanonicalMessage(
+        _ incoming: OpenClawChatMessage,
+        over existing: OpenClawChatMessage) -> OpenClawChatMessage
+    {
+        OpenClawChatMessage(
+            id: existing.id,
+            role: incoming.role,
+            content: incoming.content,
+            timestamp: incoming.timestamp ?? existing.timestamp,
+            idempotencyKey: incoming.idempotencyKey,
+            toolCallId: incoming.toolCallId,
+            toolName: incoming.toolName,
+            usage: incoming.usage,
+            stopReason: incoming.stopReason,
+            errorMessage: incoming.errorMessage)
     }
 
     private func currentRunMessageScope() -> RunMessageScope {
@@ -709,6 +740,9 @@ public final class OpenClawChatViewModel {
         case (nil, nil):
             return true
         case let (lhs?, rhs?):
+            if lhs.idempotencyKey != nil || rhs.idempotencyKey != nil {
+                return lhs.idempotencyKey == rhs.idempotencyKey
+            }
             if let lhsKey = lhs.refreshKey, let rhsKey = rhs.refreshKey {
                 return lhsKey == rhsKey && lhs.occurrence == rhs.occurrence
             }
@@ -727,7 +761,14 @@ public final class OpenClawChatViewModel {
         -> [OpenClawChatMessage].Index
     {
         guard let latestUserTurn else { return messages.startIndex }
-        if let refreshKey = latestUserTurn.refreshKey {
+        if let idempotencyKey = latestUserTurn.idempotencyKey,
+           let index = messages.lastIndex(where: { message in
+               message.role.trimmingCharacters(in: .whitespacesAndNewlines).lowercased() == "user" &&
+                   Self.normalizedIdempotencyKey(message.idempotencyKey) == idempotencyKey
+           })
+        {
+            return messages.index(after: index)
+        } else if let refreshKey = latestUserTurn.refreshKey {
             var occurrence = 0
             for index in messages.indices {
                 guard self.userRefreshIdentityKey(for: messages[index]) == refreshKey else { continue }
@@ -750,16 +791,39 @@ public final class OpenClawChatViewModel {
         }).map { messages.index(after: $0) } ?? messages.startIndex
     }
 
+    private static func messageRange(
+        after latestUserTurn: LatestUserTurn?,
+        in messages: [OpenClawChatMessage]) -> Range<[OpenClawChatMessage].Index>
+    {
+        let start = self.indexAfterLatestUserTurn(latestUserTurn, in: messages)
+        guard latestUserTurn != nil, start < messages.endIndex else {
+            return start..<messages.endIndex
+        }
+        // Without an exact assistant run key, any user row is a turn boundary.
+        // Steering and channel-originated turns are both metadata-free, so
+        // widening this range would make distinct replies indistinguishable.
+        let end = messages[start...].firstIndex { message in
+            message.role.trimmingCharacters(in: .whitespacesAndNewlines).lowercased() == "user"
+        } ?? messages.endIndex
+        return start..<end
+    }
+
     private func hasCanonicalFinalMessageMatching(
         _ message: OpenClawChatMessage,
         scope: RunMessageScope) -> Bool
     {
         guard let key = Self.finalMessageReconciliationKey(for: message) else { return false }
         guard self.isCurrentSession(scope.session) else { return false }
-        let searchStart = Self.indexAfterLatestUserTurn(scope.latestUserTurn, in: self.messages)
-        guard searchStart < self.messages.endIndex else { return false }
+        if let runId = Self.normalizedIdempotencyKey(message.idempotencyKey) {
+            return self.messages.contains { existing in
+                self.provisionalFinalMessagesByID[existing.id] == nil &&
+                    Self.normalizedIdempotencyKey(existing.idempotencyKey) == runId
+            }
+        }
+        let searchRange = Self.messageRange(after: scope.latestUserTurn, in: self.messages)
+        guard !searchRange.isEmpty else { return false }
 
-        return self.messages[searchStart...].contains { existing in
+        return self.messages[searchRange].contains { existing in
             self.provisionalFinalMessagesByID[existing.id] == nil &&
                 Self.finalMessageReconciliationKey(for: existing) == key
         }
@@ -781,6 +845,24 @@ public final class OpenClawChatViewModel {
         }
     }
 
+    private func clearProvisionalFinalMarkersAdoptedByHistory(_ incoming: [OpenClawChatMessage]) {
+        let canonicalRunIds = Set<String>(incoming.compactMap { message in
+            guard Self.isAssistantMessage(message) else { return nil }
+            return Self.normalizedIdempotencyKey(message.idempotencyKey)
+        })
+        guard !canonicalRunIds.isEmpty else { return }
+        self.provisionalFinalMessagesByID = self.provisionalFinalMessagesByID.filter { messageID, provisional in
+            guard let runId = provisional.runId,
+                  canonicalRunIds.contains(runId),
+                  let visible = self.messages.first(where: { $0.id == messageID }),
+                  Self.normalizedIdempotencyKey(visible.idempotencyKey) == runId
+            else {
+                return true
+            }
+            return false
+        }
+    }
+
     private func pruneRunMessageScopes() {
         self.runMessageScopesByRunID = self.runMessageScopesByRunID.filter { entry in
             self.isCurrentSession(entry.value.session)
@@ -793,12 +875,19 @@ public final class OpenClawChatViewModel {
         }
     }
 
-    private func adoptPendingLocalUserEcho(incoming: OpenClawChatMessage) -> Bool {
-        guard let incomingKey = Self.userRefreshIdentityKey(for: incoming) else { return false }
-        guard let matchIndex = messages.lastIndex(where: { existing in
-            self.pendingLocalUserEchoMessageIDsByRunID.values.contains(existing.id)
-                && Self.userRefreshIdentityKey(for: existing) == incomingKey
-        }) else {
+    private func adoptCorrelatedUserMessage(incoming: OpenClawChatMessage) -> Bool {
+        guard incoming.role.trimmingCharacters(in: .whitespacesAndNewlines).lowercased() == "user" else {
+            return false
+        }
+        // The final event can clear pending bookkeeping before session.message
+        // arrives. The persisted key still identifies the exact user turn, so
+        // adopt the durable row without losing the optimistic row's UI identity.
+        guard let incomingKey = Self.normalizedIdempotencyKey(incoming.idempotencyKey) else { return false }
+        let matchIndex = self.messages.lastIndex { existing in
+            existing.role.trimmingCharacters(in: .whitespacesAndNewlines).lowercased() == "user" &&
+                Self.normalizedIdempotencyKey(existing.idempotencyKey) == incomingKey
+        }
+        guard let matchIndex else {
             return false
         }
 
@@ -807,31 +896,89 @@ public final class OpenClawChatViewModel {
             $0.value != existing.id
         }
         var updated = self.messages
-        updated[matchIndex] = OpenClawChatMessage(
-            id: existing.id,
-            role: incoming.role,
-            content: incoming.content,
-            timestamp: incoming.timestamp ?? existing.timestamp,
-            toolCallId: incoming.toolCallId,
-            toolName: incoming.toolName,
-            usage: incoming.usage,
-            stopReason: incoming.stopReason,
-            errorMessage: incoming.errorMessage)
+        updated[matchIndex] = Self.adoptingCanonicalMessage(incoming, over: existing)
         self.replaceMessages(Self.dedupeMessages(updated))
         self.prunePendingLocalUserEchoMessageIDs()
         return true
     }
 
-    private func adoptProvisionalFinalMessage(incoming: OpenClawChatMessage) -> Bool {
-        guard let incomingKey = Self.finalMessageReconciliationKey(for: incoming) else { return false }
-        let canonicalScope = self.currentRunMessageScope()
-        let searchStart = Self.indexAfterLatestUserTurn(canonicalScope.latestUserTurn, in: self.messages)
-        guard searchStart < self.messages.endIndex else { return false }
+    private func rekeyLocalUserEcho(
+        messageID: UUID?,
+        runId: String) -> (pendingMessageID: UUID?, scope: RunMessageScope)?
+    {
+        guard let messageID, let matchIndex = self.messages.firstIndex(where: { $0.id == messageID }) else {
+            return nil
+        }
+        let existing = self.messages[matchIndex]
+        let remoteKey = "\(runId):user"
+        let canonical = self.messages.last { message in
+            message.id != messageID &&
+                message.role.trimmingCharacters(in: .whitespacesAndNewlines).lowercased() == "user" &&
+                Self.normalizedIdempotencyKey(message.idempotencyKey) == remoteKey
+        }
+        var updated = self.messages
+        updated[matchIndex] = if let canonical {
+            Self.adoptingCanonicalMessage(canonical, over: existing)
+        } else {
+            OpenClawChatMessage(
+                id: existing.id,
+                role: existing.role,
+                content: existing.content,
+                timestamp: existing.timestamp,
+                idempotencyKey: remoteKey,
+                toolCallId: existing.toolCallId,
+                toolName: existing.toolName,
+                usage: existing.usage,
+                stopReason: existing.stopReason,
+                errorMessage: existing.errorMessage)
+        }
+        self.replaceMessages(Self.dedupeMessages(updated))
+        guard let survivingIndex = self.messages.firstIndex(where: { message in
+            message.role.trimmingCharacters(in: .whitespacesAndNewlines).lowercased() == "user" &&
+                Self.normalizedIdempotencyKey(message.idempotencyKey) == remoteKey
+        }) else {
+            return nil
+        }
+        let survivingMessage = self.messages[survivingIndex]
+        let scope = RunMessageScope(
+            session: self.currentSessionSnapshot(),
+            latestUserTurn: Self.userTurn(at: survivingIndex, in: self.messages))
+        let pendingMessageID = survivingMessage.id == messageID ? messageID : nil
+        return (pendingMessageID, scope)
+    }
 
-        guard let matchIndex = messages[searchStart...].lastIndex(where: { existing in
+    private func rescopeProvisionalFinalMessages(runId: String, scope: RunMessageScope) {
+        let matchingMessageIDs = self.provisionalFinalMessagesByID.compactMap { messageID, provisional in
+            provisional.runId == runId ? messageID : nil
+        }
+        for messageID in matchingMessageIDs {
+            self.provisionalFinalMessagesByID[messageID]?.scope = scope
+        }
+    }
+
+    private func hasRecordedFinalMessage(runId: String) -> Bool {
+        if self.provisionalFinalMessagesByID.values.contains(where: { $0.runId == runId }) {
+            return true
+        }
+        return self.messages.contains { message in
+            Self.isAssistantMessage(message) &&
+                Self.normalizedIdempotencyKey(message.idempotencyKey) == runId
+        }
+    }
+
+    private func adoptProvisionalFinalMessage(incoming: OpenClawChatMessage) -> Bool {
+        let incomingRunId = Self.normalizedIdempotencyKey(incoming.idempotencyKey)
+        let incomingKey = Self.finalMessageReconciliationKey(for: incoming)
+        guard incomingRunId != nil || incomingKey != nil else { return false }
+        let canonicalUserTurn = self.currentRunMessageScope().latestUserTurn
+        guard let matchIndex = messages.indices.last(where: { index in
+            let existing = self.messages[index]
             guard let provisional = self.provisionalFinalMessagesByID[existing.id] else { return false }
+            if let incomingRunId {
+                return provisional.runId == incomingRunId
+            }
             return provisional.reconciliationKey == incomingKey &&
-                Self.isSameUserTurnBoundary(provisional.scope.latestUserTurn, canonicalScope.latestUserTurn)
+                Self.isSameUserTurnBoundary(provisional.scope.latestUserTurn, canonicalUserTurn)
         }) else {
             return false
         }
@@ -839,16 +986,11 @@ public final class OpenClawChatViewModel {
         let existing = self.messages[matchIndex]
         let provisional = self.provisionalFinalMessagesByID[existing.id]
         var updated = self.messages
-        updated[matchIndex] = OpenClawChatMessage(
-            id: existing.id,
-            role: incoming.role,
-            content: incoming.content,
-            timestamp: incoming.timestamp ?? existing.timestamp,
-            toolCallId: incoming.toolCallId,
-            toolName: incoming.toolName,
-            usage: incoming.usage,
-            stopReason: incoming.stopReason,
-            errorMessage: incoming.errorMessage)
+        updated.remove(at: matchIndex)
+        // The durable session.message arrives at its transcript position. A
+        // steering row may have been delivered after chat.final, so append the
+        // adopted row here while retaining the provisional UUID.
+        updated.append(Self.adoptingCanonicalMessage(incoming, over: existing))
         self.provisionalFinalMessagesByID.removeValue(forKey: existing.id)
         if let runId = provisional?.runId {
             self.runMessageScopesByRunID.removeValue(forKey: runId)
@@ -865,36 +1007,27 @@ public final class OpenClawChatViewModel {
     {
         guard !previous.isEmpty, !incoming.isEmpty else { return incoming }
 
-        var idsByKey: [String: [UUID]] = [:]
+        var previousMessagesByKey: [String: [OpenClawChatMessage]] = [:]
         for message in previous {
             guard let key = Self.messageIdentityKey(for: message) else { continue }
-            idsByKey[key, default: []].append(message.id)
+            previousMessagesByKey[key, default: []].append(message)
         }
 
         return incoming.map { message in
             guard let key = Self.messageIdentityKey(for: message),
-                  var ids = idsByKey[key],
-                  let reusedId = ids.first
+                  var matches = previousMessagesByKey[key],
+                  let existing = matches.first
             else {
                 return message
             }
-            ids.removeFirst()
-            if ids.isEmpty {
-                idsByKey.removeValue(forKey: key)
+            matches.removeFirst()
+            if matches.isEmpty {
+                previousMessagesByKey.removeValue(forKey: key)
             } else {
-                idsByKey[key] = ids
+                previousMessagesByKey[key] = matches
             }
-            guard reusedId != message.id else { return message }
-            return OpenClawChatMessage(
-                id: reusedId,
-                role: message.role,
-                content: message.content,
-                timestamp: message.timestamp,
-                toolCallId: message.toolCallId,
-                toolName: message.toolName,
-                usage: message.usage,
-                stopReason: message.stopReason,
-                errorMessage: message.errorMessage)
+            guard existing.id != message.id else { return message }
+            return Self.adoptingCanonicalMessage(message, over: existing)
         }
     }
 
@@ -913,6 +1046,9 @@ public final class OpenClawChatViewModel {
         }
 
         var reconciled = Self.reconcileMessageIDs(previous: previous, incoming: incoming)
+        let incomingIdempotencyKeys = Set(reconciled.compactMap { message in
+            Self.normalizedIdempotencyKey(message.idempotencyKey)
+        })
         let incomingIdentityKeys = Set(reconciled.compactMap(Self.messageIdentityKey(for:)))
         var remainingIncomingUserRefreshCounts = countKeys(
             reconciled.compactMap(Self.userRefreshIdentityKey(for:)))
@@ -931,6 +1067,24 @@ public final class OpenClawChatViewModel {
             remainingIncomingUserRefreshCounts[userKey] = remaining - 1
         }
 
+        // Exact client correlation owns pending-send adoption. A metadata-free
+        // row is ambiguous across clients, so retain both rather than lose a turn.
+        let pendingLocalUsers = previous.filter { message in
+            guard message.role.lowercased() == "user", pendingLocalUserEchoIDs.contains(message.id) else {
+                return false
+            }
+            let matched = Self.normalizedIdempotencyKey(message.idempotencyKey)
+                .map(incomingIdempotencyKeys.contains) ?? false
+            guard matched else { return true }
+            if let userKey = Self.userRefreshIdentityKey(for: message),
+               let remaining = remainingIncomingUserRefreshCounts[userKey],
+               remaining > 0
+            {
+                remainingIncomingUserRefreshCounts[userKey] = remaining - 1
+            }
+            return false
+        }
+
         let lastCanonicalPreviousIndex = previous.lastIndex { message in
             guard let identityKey = Self.messageIdentityKey(for: message) else { return false }
             return incomingIdentityKeys.contains(identityKey)
@@ -939,11 +1093,9 @@ public final class OpenClawChatViewModel {
             previous[previous.index(after: index)...]
         } ?? []
 
-        let pendingLocalUsers = previous.filter { message in
-            message.role.lowercased() == "user" && pendingLocalUserEchoIDs.contains(message.id)
-        }
         let trailingLocalUsers = trailingLocalCandidates.filter { message in
             guard message.role.lowercased() == "user" else { return false }
+            guard !pendingLocalUserEchoIDs.contains(message.id) else { return false }
             guard let identityKey = Self.messageIdentityKey(for: message) else { return true }
             guard !incomingIdentityKeys.contains(identityKey) else { return false }
             guard let userKey = Self.userRefreshIdentityKey(for: message) else { return true }
@@ -995,6 +1147,9 @@ public final class OpenClawChatViewModel {
     }
 
     private static func dedupeKey(for message: OpenClawChatMessage) -> String? {
+        if let idempotencyKey = normalizedIdempotencyKey(message.idempotencyKey) {
+            return "\(message.role)|idempotency|\(idempotencyKey)"
+        }
         guard let timestamp = message.timestamp else { return nil }
         let text = message.content.compactMap(\.text).joined(separator: "\n")
             .trimmingCharacters(in: .whitespacesAndNewlines)
@@ -1311,7 +1466,8 @@ public final class OpenClawChatViewModel {
                 id: userMessageID,
                 role: "user",
                 content: userContent,
-                timestamp: userMessageTimestamp))
+                timestamp: userMessageTimestamp,
+                idempotencyKey: "\(runId):user"))
         self.pendingLocalUserEchoMessageIDsByRunID[runId] = userMessageID
         self.runMessageScopesByRunID[runId] = self.currentRunMessageScope()
 
@@ -1335,21 +1491,39 @@ public final class OpenClawChatViewModel {
             self.logDiagnostic(
                 "chat.ui transport send accepted sessionKey=\(sessionKey) "
                     + "localRunId=\(runId) remoteRunId=\(response.runId)")
+            var reusedRunAlreadyFinal = false
             if response.runId != runId {
                 let pendingUserMessageID = self.pendingLocalUserEchoMessageIDsByRunID.removeValue(forKey: runId)
-                let runScope = self.runMessageScopesByRunID.removeValue(forKey: runId)
+                let localRunScope = self.runMessageScopesByRunID.removeValue(forKey: runId)
                 self.clearPendingRun(runId)
                 self.pendingRuns.insert(response.runId)
-                self.pendingLocalUserEchoMessageIDsByRunID[response.runId] = pendingUserMessageID
-                self.runMessageScopesByRunID[response.runId] = runScope
-                self.armPendingRunTimeout(runId: response.runId)
+                // The gateway can reuse an identical active run without writing
+                // this second turn. Move the optimistic row onto that durable
+                // identity, collapsing it if the canonical row is already here.
+                let rekeyedUserEcho = self.rekeyLocalUserEcho(
+                    messageID: pendingUserMessageID,
+                    runId: response.runId)
+                self.pendingLocalUserEchoMessageIDsByRunID[response.runId] = rekeyedUserEcho?.pendingMessageID
+                let remoteRunScope = rekeyedUserEcho?.scope ?? localRunScope ?? self.currentRunMessageScope()
+                self.runMessageScopesByRunID[response.runId] = remoteRunScope
+                self.rescopeProvisionalFinalMessages(runId: response.runId, scope: remoteRunScope)
+                reusedRunAlreadyFinal = self.hasRecordedFinalMessage(runId: response.runId)
+                if reusedRunAlreadyFinal {
+                    self.clearPendingRun(response.runId)
+                    self.pendingToolCallsById = [:]
+                    self.updateStreamingAssistantText(nil)
+                } else {
+                    self.armPendingRunTimeout(runId: response.runId)
+                }
             }
             if response.status == "ok" {
                 let historyContext = self.beginHistoryRequest(for: sessionSnapshot)
                 await self.refreshHistoryAfterRun(historyRequest: historyContext)
                 guard self.isCurrentSession(sessionSnapshot) else { return }
                 self.finishPendingRunAfterTerminalOkSendAck(response)
-            } else if !self.finishPendingRunIfTerminalSendAck(response) {
+            } else if !self.finishPendingRunIfTerminalSendAck(response),
+                      !reusedRunAlreadyFinal
+            {
                 let historyContext = self.beginHistoryRequest(for: sessionSnapshot)
                 await self.refreshHistoryAfterRun(historyRequest: historyContext)
                 guard self.isCurrentSession(sessionSnapshot) else { return }
@@ -1999,9 +2173,10 @@ public final class OpenClawChatViewModel {
         // just sent. performSend already appended an optimistic row carrying a
         // local client timestamp, while the echo carries a server timestamp, so
         // the timestamp-keyed identity/dedupe paths below never collapse them.
-        // Adopt the server record only onto a still-visible row created by this
-        // client's pending send; same-content user turns from other clients must append.
-        if self.adoptPendingLocalUserEcho(incoming: sanitized) {
+        // Adopt the server record onto the exactly correlated row even when the
+        // run's final event already cleared pending state. Same-content turns
+        // without this key remain distinct.
+        if self.adoptCorrelatedUserMessage(incoming: sanitized) {
             return
         }
         if self.adoptProvisionalFinalMessage(incoming: sanitized) {
@@ -2133,6 +2308,7 @@ public final class OpenClawChatViewModel {
             role: message.role,
             content: message.content,
             timestamp: Date().timeIntervalSince1970 * 1000,
+            idempotencyKey: message.idempotencyKey,
             toolCallId: message.toolCallId,
             toolName: message.toolName,
             usage: message.usage,
@@ -2362,20 +2538,34 @@ public final class OpenClawChatViewModel {
         guard let lastUserIndex = messages.lastIndex(where: { $0.role.lowercased() == "user" }) else {
             return nil
         }
-        guard let refreshKey = userRefreshIdentityKey(for: messages[lastUserIndex]) else {
+        return self.userTurn(at: lastUserIndex, in: messages)
+    }
+
+    private static func userTurn(
+        at userIndex: [OpenClawChatMessage].Index,
+        in messages: [OpenClawChatMessage]) -> LatestUserTurn?
+    {
+        guard messages.indices.contains(userIndex),
+              messages[userIndex].role.trimmingCharacters(in: .whitespacesAndNewlines).lowercased() == "user"
+        else {
+            return nil
+        }
+        guard let refreshKey = userRefreshIdentityKey(for: messages[userIndex]) else {
             return LatestUserTurn(
+                idempotencyKey: self.normalizedIdempotencyKey(messages[userIndex].idempotencyKey),
                 refreshKey: nil,
                 occurrence: 0,
-                timestamp: messages[lastUserIndex].timestamp)
+                timestamp: messages[userIndex].timestamp)
         }
-        let occurrence = messages[...lastUserIndex].reduce(into: 0) { count, message in
+        let occurrence = messages[...userIndex].reduce(into: 0) { count, message in
             guard self.userRefreshIdentityKey(for: message) == refreshKey else { return }
             count += 1
         }
         return LatestUserTurn(
+            idempotencyKey: Self.normalizedIdempotencyKey(messages[userIndex].idempotencyKey),
             refreshKey: refreshKey,
             occurrence: occurrence,
-            timestamp: messages[lastUserIndex].timestamp)
+            timestamp: messages[userIndex].timestamp)
     }
 
     private static func hasAnsweredUser(
@@ -2383,6 +2573,17 @@ public final class OpenClawChatViewModel {
         in messages: [OpenClawChatMessage])
         -> Bool
     {
+        // Hooks may transform persisted user content while preserving this key.
+        // Prefer the durable turn identity so a completed refresh rejects older history.
+        if let idempotencyKey = user.idempotencyKey {
+            guard let userIndex = messages.lastIndex(where: { message in
+                message.role.trimmingCharacters(in: .whitespacesAndNewlines).lowercased() == "user" &&
+                    self.normalizedIdempotencyKey(message.idempotencyKey) == idempotencyKey
+            }) else {
+                return false
+            }
+            return self.hasAssistantMessage(after: userIndex, in: messages)
+        }
         guard let refreshKey = user.refreshKey else { return false }
         var occurrence = 0
         var latestMatchingUserIndex: [OpenClawChatMessage].Index?
@@ -2391,14 +2592,7 @@ public final class OpenClawChatViewModel {
             occurrence += 1
             latestMatchingUserIndex = index
             guard occurrence == user.occurrence else { continue }
-            let nextIndex = messages.index(after: index)
-            guard nextIndex < messages.endIndex else { return false }
-            return messages[nextIndex...].contains { message in
-                guard message.role.lowercased() == "assistant" else { return false }
-                let text = message.content.compactMap(\.text).joined(separator: "\n")
-                    .trimmingCharacters(in: .whitespacesAndNewlines)
-                return !text.isEmpty || message.errorMessage != nil
-            }
+            return self.hasAssistantMessage(after: index, in: messages)
         }
         guard let latestMatchingUserIndex,
               messages.lastIndex(where: { $0.role.lowercased() == "user" }) == latestMatchingUserIndex
@@ -2411,7 +2605,14 @@ public final class OpenClawChatViewModel {
         {
             return false
         }
-        let nextIndex = messages.index(after: latestMatchingUserIndex)
+        return self.hasAssistantMessage(after: latestMatchingUserIndex, in: messages)
+    }
+
+    private static func hasAssistantMessage(
+        after userIndex: [OpenClawChatMessage].Index,
+        in messages: [OpenClawChatMessage]) -> Bool
+    {
+        let nextIndex = messages.index(after: userIndex)
         guard nextIndex < messages.endIndex else { return false }
         return messages[nextIndex...].contains { message in
             guard message.role.lowercased() == "assistant" else { return false }

--- a/apps/shared/OpenClawKit/Tests/OpenClawKitTests/ChatViewModelTests.swift
+++ b/apps/shared/OpenClawKit/Tests/OpenClawKitTests/ChatViewModelTests.swift
@@ -3,19 +3,34 @@ import OpenClawKit
 import Testing
 @testable import OpenClawChatUI
 
-private func chatTextMessage(role: String, text: String, timestamp: Double, contentId: String? = nil) -> AnyCodable {
+private func chatTextMessage(
+    role: String,
+    text: String,
+    timestamp: Double,
+    contentId: String? = nil,
+    idempotencyKey: String? = nil) -> AnyCodable
+{
     var content: [String: Any] = ["type": "text", "text": text]
     if let contentId {
         content["id"] = contentId
     }
-    return AnyCodable([
+    var message: [String: Any] = [
         "role": role,
         "content": [content],
         "timestamp": timestamp,
-    ])
+    ]
+    if let idempotencyKey {
+        message["__openclaw"] = ["idempotencyKey": idempotencyKey]
+    }
+    return AnyCodable(message)
 }
 
-private func chatTextModelMessage(role: String, text: String, timestamp: Double) -> OpenClawChatMessage {
+private func chatTextModelMessage(
+    role: String,
+    text: String,
+    timestamp: Double,
+    idempotencyKey: String? = nil) -> OpenClawChatMessage
+{
     OpenClawChatMessage(
         role: role,
         content: [
@@ -26,7 +41,8 @@ private func chatTextModelMessage(role: String, text: String, timestamp: Double)
                 fileName: nil,
                 content: nil),
         ],
-        timestamp: timestamp)
+        timestamp: timestamp,
+        idempotencyKey: idempotencyKey)
 }
 
 private func chatErrorMessage(role: String, errorMessage: String, timestamp: Double) -> AnyCodable {
@@ -39,8 +55,8 @@ private func chatErrorMessage(role: String, errorMessage: String, timestamp: Dou
     ])
 }
 
-fileprivate extension Array where Element == OpenClawChatMessage {
-    func containsUserText(_ text: String) -> Bool {
+extension [OpenClawChatMessage] {
+    fileprivate func containsUserText(_ text: String) -> Bool {
         self.contains { message in
             message.role == "user" &&
                 message.content.contains { $0.text == text }
@@ -142,6 +158,7 @@ private func makeViewModel(
     modelResponses: [[OpenClawChatModelChoice]] = [],
     commandResponses: [[OpenClawChatCommandChoice]] = [],
     requestHistoryHook: (@Sendable (String) async throws -> Void)? = nil,
+    historyResponseHook: (@Sendable (String, Int, [String]) async throws -> OpenClawChatHistoryPayload?)? = nil,
     setActiveSessionHook: (@Sendable (String) async throws -> Void)? = nil,
     createSessionHook: (@Sendable (String, String?) async throws -> Void)? = nil,
     resetSessionHook: (@Sendable (String) async throws -> Void)? = nil,
@@ -149,6 +166,7 @@ private func makeViewModel(
     setSessionModelHook: (@Sendable (String?) async throws -> Void)? = nil,
     setSessionThinkingHook: (@Sendable (String) async throws -> Void)? = nil,
     sendMessageHook: (@Sendable (String) async throws -> OpenClawChatSendResponse)? = nil,
+    sendMessageStatus: String = "ok",
     waitForRunCompletionHook: (@Sendable (String, Int) async -> Bool)? = nil,
     healthResponses: [Bool] = [true],
     initialThinkingLevel: String? = nil,
@@ -162,6 +180,7 @@ private func makeViewModel(
         modelResponses: modelResponses,
         commandResponses: commandResponses,
         requestHistoryHook: requestHistoryHook,
+        historyResponseHook: historyResponseHook,
         setActiveSessionHook: setActiveSessionHook,
         createSessionHook: createSessionHook,
         resetSessionHook: resetSessionHook,
@@ -169,6 +188,7 @@ private func makeViewModel(
         setSessionModelHook: setSessionModelHook,
         setSessionThinkingHook: setSessionThinkingHook,
         sendMessageHook: sendMessageHook,
+        sendMessageStatus: sendMessageStatus,
         waitForRunCompletionHook: waitForRunCompletionHook,
         healthResponses: healthResponses)
     let vm = await MainActor.run {
@@ -315,14 +335,17 @@ private final class CallbackBox {
 
 private actor AsyncGate {
     private var continuation: CheckedContinuation<Void, Never>?
+    private var isOpen = false
 
     func wait() async {
+        guard !self.isOpen else { return }
         await withCheckedContinuation { continuation in
             self.continuation = continuation
         }
     }
 
     func open() {
+        self.isOpen = true
         self.continuation?.resume()
         self.continuation = nil
     }
@@ -392,6 +415,8 @@ private final class TestChatTransport: @unchecked Sendable, OpenClawChatTranspor
     private let modelResponses: [[OpenClawChatModelChoice]]
     private let commandResponses: [[OpenClawChatCommandChoice]]
     private let requestHistoryHook: (@Sendable (String) async throws -> Void)?
+    private let historyResponseHook:
+        (@Sendable (String, Int, [String]) async throws -> OpenClawChatHistoryPayload?)?
     private let setActiveSessionHook: (@Sendable (String) async throws -> Void)?
     private let createSessionHook: (@Sendable (String, String?) async throws -> Void)?
     private let resetSessionHook: (@Sendable (String) async throws -> Void)?
@@ -399,6 +424,7 @@ private final class TestChatTransport: @unchecked Sendable, OpenClawChatTranspor
     private let setSessionModelHook: (@Sendable (String?) async throws -> Void)?
     private let setSessionThinkingHook: (@Sendable (String) async throws -> Void)?
     private let sendMessageHook: (@Sendable (String) async throws -> OpenClawChatSendResponse)?
+    private let sendMessageStatus: String
     private let waitForRunCompletionHook: (@Sendable (String, Int) async -> Bool)?
     private let healthResponses: [Bool]
 
@@ -411,6 +437,7 @@ private final class TestChatTransport: @unchecked Sendable, OpenClawChatTranspor
         modelResponses: [[OpenClawChatModelChoice]] = [],
         commandResponses: [[OpenClawChatCommandChoice]] = [],
         requestHistoryHook: (@Sendable (String) async throws -> Void)? = nil,
+        historyResponseHook: (@Sendable (String, Int, [String]) async throws -> OpenClawChatHistoryPayload?)? = nil,
         setActiveSessionHook: (@Sendable (String) async throws -> Void)? = nil,
         createSessionHook: (@Sendable (String, String?) async throws -> Void)? = nil,
         resetSessionHook: (@Sendable (String) async throws -> Void)? = nil,
@@ -418,6 +445,7 @@ private final class TestChatTransport: @unchecked Sendable, OpenClawChatTranspor
         setSessionModelHook: (@Sendable (String?) async throws -> Void)? = nil,
         setSessionThinkingHook: (@Sendable (String) async throws -> Void)? = nil,
         sendMessageHook: (@Sendable (String) async throws -> OpenClawChatSendResponse)? = nil,
+        sendMessageStatus: String = "ok",
         waitForRunCompletionHook: (@Sendable (String, Int) async -> Bool)? = nil,
         healthResponses: [Bool] = [true])
     {
@@ -426,6 +454,7 @@ private final class TestChatTransport: @unchecked Sendable, OpenClawChatTranspor
         self.modelResponses = modelResponses
         self.commandResponses = commandResponses
         self.requestHistoryHook = requestHistoryHook
+        self.historyResponseHook = historyResponseHook
         self.setActiveSessionHook = setActiveSessionHook
         self.createSessionHook = createSessionHook
         self.resetSessionHook = resetSessionHook
@@ -433,6 +462,7 @@ private final class TestChatTransport: @unchecked Sendable, OpenClawChatTranspor
         self.setSessionModelHook = setSessionModelHook
         self.setSessionThinkingHook = setSessionThinkingHook
         self.sendMessageHook = sendMessageHook
+        self.sendMessageStatus = sendMessageStatus
         self.waitForRunCompletionHook = waitForRunCompletionHook
         self.healthResponses = healthResponses
         var cont: AsyncStream<OpenClawChatTransportEvent>.Continuation!
@@ -471,6 +501,12 @@ private final class TestChatTransport: @unchecked Sendable, OpenClawChatTranspor
         if let requestHistoryHook {
             try await requestHistoryHook(sessionKey)
         }
+        if let historyResponseHook {
+            let sentRunIds = await self.sentRunIds()
+            if let response = try await historyResponseHook(sessionKey, idx, sentRunIds) {
+                return response
+            }
+        }
         if idx < self.historyResponses.count {
             return self.historyResponses[idx]
         }
@@ -495,7 +531,7 @@ private final class TestChatTransport: @unchecked Sendable, OpenClawChatTranspor
         if let sendMessageHook {
             return try await sendMessageHook(idempotencyKey)
         }
-        return OpenClawChatSendResponse(runId: idempotencyKey, status: "ok")
+        return OpenClawChatSendResponse(runId: idempotencyKey, status: self.sendMessageStatus)
     }
 
     func abortRun(sessionKey _: String, runId: String) async throws {
@@ -623,6 +659,10 @@ private final class TestChatTransport: @unchecked Sendable, OpenClawChatTranspor
         await self.state.patchedThinkingLevels
     }
 
+    func healthCallCount() async -> Int {
+        await self.state.healthCallCount
+    }
+
     func resetSessionKeys() async -> [String] {
         await self.state.resetSessionKeys
     }
@@ -728,6 +768,27 @@ extension TestChatTransportState {
 }
 
 struct ChatViewModelTests {
+    @Test func `keeps distinct idempotent user turns with identical timestamps and content`() async throws {
+        let history = historyPayload(
+            messages: [
+                chatTextMessage(
+                    role: "user",
+                    text: "same words",
+                    timestamp: 1,
+                    idempotencyKey: "client-a:user"),
+                chatTextMessage(
+                    role: "user",
+                    text: "same words",
+                    timestamp: 1,
+                    idempotencyKey: "client-b:user"),
+            ])
+        let (_, vm) = await makeViewModel(historyResponses: [history])
+
+        try await loadAndWaitBootstrap(vm: vm)
+
+        #expect(await MainActor.run { vm.messages.count } == 2)
+    }
+
     @Test func `timeline revision advances when visible history changes`() async throws {
         let history = historyPayload(
             sessionId: "revision-session",
@@ -840,7 +901,9 @@ struct ChatViewModelTests {
                     timestamp: Date().timeIntervalSince1970 * 1000),
             ])
 
-        let (transport, vm) = await makeViewModel(historyResponses: [history1, history2])
+        let (transport, vm) = await makeViewModel(
+            historyResponses: [history1, history2],
+            sendMessageStatus: "pending")
         try await loadAndWaitBootstrap(vm: vm, sessionId: sessionId)
         await sendUserMessage(vm)
         try await waitUntil("pending run starts") { await MainActor.run { vm.pendingRunCount == 1 } }
@@ -876,7 +939,9 @@ struct ChatViewModelTests {
     @Test func `renders final chat event message when history is stale`() async throws {
         let sessionId = "sess-main"
         let history = historyPayload(sessionId: sessionId)
-        let (transport, vm) = await makeViewModel(historyResponses: [history, history])
+        let (transport, vm) = await makeViewModel(
+            historyResponses: [history, history],
+            sendMessageStatus: "pending")
         try await loadAndWaitBootstrap(vm: vm, sessionId: sessionId)
 
         await sendUserMessage(vm, text: "hello")
@@ -919,7 +984,8 @@ struct ChatViewModelTests {
                 if count == 2 {
                     await finalRefreshGate.wait()
                 }
-            })
+            },
+            sendMessageStatus: "pending")
         try await loadAndWaitBootstrap(vm: vm, sessionId: sessionId)
 
         await sendUserMessage(vm, text: "hello")
@@ -980,7 +1046,8 @@ struct ChatViewModelTests {
                 if count == 2 {
                     await finalRefreshGate.wait()
                 }
-            })
+            },
+            sendMessageStatus: "pending")
         try await loadAndWaitBootstrap(vm: vm, sessionId: sessionId)
 
         await sendUserMessage(vm, text: "hello")
@@ -1090,6 +1157,7 @@ struct ChatViewModelTests {
             ])
         let (transport, vm) = await makeViewModel(
             historyResponses: [history1, history2, history3],
+            sendMessageStatus: "pending",
             waitForRunCompletionHook: { _, _ in true })
         try await loadAndWaitBootstrap(vm: vm, sessionId: sessionId)
 
@@ -1124,7 +1192,9 @@ struct ChatViewModelTests {
                     text: "completed from lifecycle",
                     timestamp: now + 60000),
             ])
-        let (transport, vm) = await makeViewModel(historyResponses: [history1, history2, history3])
+        let (transport, vm) = await makeViewModel(
+            historyResponses: [history1, history2, history3],
+            sendMessageStatus: "pending")
         try await loadAndWaitBootstrap(vm: vm, sessionId: sessionId)
 
         await sendUserMessage(vm, text: "hello")
@@ -1151,7 +1221,9 @@ struct ChatViewModelTests {
     @Test func `pending run blocks second main send`() async throws {
         let sessionId = "sess-main"
         let history = historyPayload(sessionId: sessionId, messages: [])
-        let (transport, vm) = await makeViewModel(historyResponses: [history, history])
+        let (transport, vm) = await makeViewModel(
+            historyResponses: [history, history],
+            sendMessageStatus: "pending")
         try await loadAndWaitBootstrap(vm: vm, sessionId: sessionId)
 
         await sendUserMessage(vm, text: "first")
@@ -1173,7 +1245,7 @@ struct ChatViewModelTests {
         #expect(await MainActor.run { vm.input } == "second")
     }
 
-    @Test func terminalOkSendAckClearsPendingRunWithoutWaitingForCompletion() async throws {
+    @Test func `terminal ok send ack clears pending run without waiting for completion`() async throws {
         let sessionId = "sess-main"
         let history = historyPayload(sessionId: sessionId, messages: [])
         let (transport, vm) = await makeViewModel(historyResponses: [history, history])
@@ -1189,7 +1261,742 @@ struct ChatViewModelTests {
         #expect(await MainActor.run { vm.messages.containsUserText("cached") })
     }
 
-    @Test func terminalTimeoutSendAckSurfacesErrorAndAllowsNextSend() async throws {
+    @Test func `rekeys optimistic user message when gateway reuses active run`() async throws {
+        let sessionId = "sess-main"
+        let remoteRunId = "existing-active-run"
+        let now = Date().timeIntervalSince1970 * 1000
+        let responseGate = AsyncGate()
+        let (_, vm) = await makeViewModel(
+            historyResponses: [historyPayload(sessionId: sessionId)],
+            historyResponseHook: { _, index, _ in
+                guard index == 1 else { return nil }
+                return historyPayload(
+                    sessionId: sessionId,
+                    messages: [
+                        chatTextMessage(
+                            role: "user",
+                            text: "same active request",
+                            timestamp: now + 5000,
+                            idempotencyKey: "\(remoteRunId):user"),
+                    ])
+            },
+            sendMessageHook: { _ in
+                await responseGate.wait()
+                return OpenClawChatSendResponse(runId: remoteRunId, status: "in_flight")
+            })
+        try await loadAndWaitBootstrap(vm: vm, sessionId: sessionId)
+
+        await sendUserMessage(vm, text: "same active request")
+        let optimisticID = try await MainActor.run {
+            try #require(vm.messages.last(where: { $0.role == "user" })?.id)
+        }
+        await responseGate.open()
+
+        try await waitUntil("reused run adopts one canonical user row") {
+            await MainActor.run {
+                vm.messages.count(where: { $0.role == "user" }) == 1 &&
+                    vm.messages.contains(where: { message in
+                        message.id == optimisticID &&
+                            message.timestamp == now + 5000 &&
+                            message.idempotencyKey == "\(remoteRunId):user"
+                    })
+            }
+        }
+    }
+
+    @Test func `reused run preserves canonical event received before acknowledgement`() async throws {
+        let sessionId = "sess-main"
+        let remoteRunId = "existing-active-run"
+        let now = Date().timeIntervalSince1970 * 1000
+        let responseGate = AsyncGate()
+        let (transport, vm) = await makeViewModel(
+            historyResponses: [
+                historyPayload(sessionId: sessionId),
+                historyPayload(sessionId: sessionId, messages: []),
+            ],
+            sendMessageHook: { _ in
+                await responseGate.wait()
+                return OpenClawChatSendResponse(runId: remoteRunId, status: "in_flight")
+            })
+        try await loadAndWaitBootstrap(vm: vm, sessionId: sessionId)
+
+        await sendUserMessage(vm, text: "same active request")
+        let optimisticID = try await MainActor.run {
+            try #require(vm.messages.last(where: { $0.role == "user" })?.id)
+        }
+        let canonicalTimestamp = now + 5000
+        transport.emit(
+            .sessionMessage(
+                OpenClawSessionMessageEventPayload(
+                    sessionKey: "agent:main:main",
+                    message: OpenClawChatMessage(
+                        role: "user",
+                        content: [
+                            OpenClawChatMessageContent(
+                                type: "text",
+                                text: "canonical active request",
+                                mimeType: nil,
+                                fileName: nil,
+                                content: nil),
+                        ],
+                        timestamp: canonicalTimestamp,
+                        idempotencyKey: "\(remoteRunId):user"),
+                    messageId: "srv-reused-run-user",
+                    messageSeq: 1)))
+        try await waitUntil("canonical event arrives before send acknowledgement") {
+            await MainActor.run { vm.messages.count(where: { $0.role == "user" }) == 2 }
+        }
+        await responseGate.open()
+
+        try await waitUntil("reused run preserves canonical event data") {
+            await MainActor.run {
+                vm.messages.count(where: { $0.role == "user" }) == 1 &&
+                    vm.messages.contains(where: { message in
+                        message.id == optimisticID &&
+                            message.content.first?.text == "canonical active request" &&
+                            message.timestamp == canonicalTimestamp &&
+                            message.idempotencyKey == "\(remoteRunId):user"
+                    })
+            }
+        }
+    }
+
+    @Test func `reused run final stays scoped to surviving canonical user turn`() async throws {
+        let sessionId = "sess-main"
+        let remoteRunId = "existing-active-run"
+        let now = Date().timeIntervalSince1970 * 1000
+        let activeUser = chatTextMessage(
+            role: "user",
+            text: "same active request",
+            timestamp: now + 1,
+            idempotencyKey: "\(remoteRunId):user")
+        let activeReply = chatTextMessage(
+            role: "assistant",
+            text: "active reply",
+            timestamp: now + 2,
+            idempotencyKey: remoteRunId)
+        let newerUser = chatTextMessage(
+            role: "user",
+            text: "newer request from another client",
+            timestamp: now + 3,
+            idempotencyKey: "other-client-run:user")
+        let initialHistory = historyPayload(sessionId: sessionId, messages: [activeUser])
+        let canonicalHistory = historyPayload(
+            sessionId: sessionId,
+            messages: [activeUser, activeReply, newerUser])
+        let responseGate = AsyncGate()
+        let (transport, vm) = await makeViewModel(
+            historyResponses: [initialHistory, canonicalHistory, canonicalHistory],
+            sendMessageHook: { _ in
+                await responseGate.wait()
+                return OpenClawChatSendResponse(runId: remoteRunId, status: "in_flight")
+            })
+        try await loadAndWaitBootstrap(vm: vm, sessionId: sessionId)
+
+        await sendUserMessage(vm, text: "same active request")
+        transport.emit(
+            .sessionMessage(
+                OpenClawSessionMessageEventPayload(
+                    sessionKey: "agent:main:main",
+                    message: chatTextModelMessage(
+                        role: "assistant",
+                        text: "active reply",
+                        timestamp: now + 2,
+                        idempotencyKey: remoteRunId),
+                    messageId: "srv-active-reply",
+                    messageSeq: 2)))
+        transport.emit(
+            .sessionMessage(
+                OpenClawSessionMessageEventPayload(
+                    sessionKey: "agent:main:main",
+                    message: chatTextModelMessage(
+                        role: "user",
+                        text: "newer request from another client",
+                        timestamp: now + 3,
+                        idempotencyKey: "other-client-run:user"),
+                    messageId: "srv-newer-user",
+                    messageSeq: 3)))
+        try await waitUntil("newer user arrives before reused-run acknowledgement") {
+            await MainActor.run { vm.messages.containsUserText("newer request from another client") }
+        }
+        await responseGate.open()
+        try await waitUntil("reused run collapses onto earlier canonical user") {
+            await MainActor.run {
+                vm.messages.count(where: { $0.role == "user" && $0.content.first?.text == "same active request" }) == 1
+            }
+        }
+
+        transport.emit(
+            .chat(
+                OpenClawChatEventPayload(
+                    runId: remoteRunId,
+                    sessionKey: "main",
+                    state: "final",
+                    message: activeReply,
+                    errorMessage: nil)))
+
+        try await waitUntil("reused final does not duplicate earlier canonical reply") {
+            await MainActor.run {
+                vm.pendingRunCount == 0 &&
+                    vm.messages
+                    .count(where: { $0.role == "assistant" && $0.content.first?.text == "active reply" }) == 1
+            }
+        }
+    }
+
+    @Test func `newer identical reply does not suppress reused run final`() async throws {
+        let sessionId = "sess-main"
+        let remoteRunId = "existing-active-run"
+        let now = Date().timeIntervalSince1970 * 1000
+        let responseGate = AsyncGate()
+        let finalRefreshGate = SessionSubscribeGate()
+        let historyCount = AsyncCounter()
+        let history = historyPayload(
+            sessionId: sessionId,
+            messages: [
+                chatTextMessage(
+                    role: "user",
+                    text: "same active request",
+                    timestamp: now - 3000,
+                    idempotencyKey: "\(remoteRunId):user"),
+                chatTextMessage(
+                    role: "user",
+                    text: "newer request from another client",
+                    timestamp: now - 2000,
+                    idempotencyKey: "other-client-run:user"),
+                chatTextMessage(
+                    role: "assistant",
+                    text: "OK",
+                    timestamp: now - 1000),
+            ])
+        let (transport, vm) = await makeViewModel(
+            historyResponses: [history, history],
+            requestHistoryHook: { _ in
+                let count = await historyCount.increment()
+                if count == 3 {
+                    await finalRefreshGate.wait()
+                }
+            },
+            sendMessageHook: { _ in
+                await responseGate.wait()
+                return OpenClawChatSendResponse(runId: remoteRunId, status: "in_flight")
+            })
+        try await loadAndWaitBootstrap(vm: vm, sessionId: sessionId)
+
+        await sendUserMessage(vm, text: "same active request")
+        try await waitUntil("duplicate request is optimistic") {
+            await MainActor.run {
+                vm.messages.count(where: { $0.role == "user" && $0.content.first?.text == "same active request" }) == 2
+            }
+        }
+        await responseGate.open()
+        try await waitUntil("duplicate request collapses onto older active user") {
+            guard await historyCount.current() >= 2 else { return false }
+            return await MainActor.run {
+                vm.messages.count(where: {
+                    $0.role == "user" && $0.content.first?.text == "same active request"
+                }) == 1
+            }
+        }
+
+        transport.emit(
+            .chat(
+                OpenClawChatEventPayload(
+                    runId: remoteRunId,
+                    sessionKey: "main",
+                    state: "final",
+                    message: chatTextMessage(
+                        role: "assistant",
+                        text: "OK",
+                        timestamp: now + 4,
+                        idempotencyKey: remoteRunId),
+                    errorMessage: nil)))
+
+        try await waitUntil("reused final remains distinct from newer turn reply") {
+            await MainActor.run {
+                vm.pendingRunCount == 0 &&
+                    vm.messages.count(where: { $0.role == "assistant" && $0.content.first?.text == "OK" }) == 2
+            }
+        }
+        await finalRefreshGate.release()
+    }
+
+    @Test func `correlated reply after metadata free steering suppresses reused final duplicate`() async throws {
+        let sessionId = "sess-main"
+        let remoteRunId = "existing-active-run"
+        let now = Date().timeIntervalSince1970 * 1000
+        let responseGate = AsyncGate()
+        let history = historyPayload(
+            sessionId: sessionId,
+            messages: [
+                chatTextMessage(
+                    role: "user",
+                    text: "same active request",
+                    timestamp: now - 3000,
+                    idempotencyKey: "\(remoteRunId):user"),
+                chatTextMessage(
+                    role: "user",
+                    text: "steer the active run",
+                    timestamp: now - 2000),
+                chatTextMessage(
+                    role: "assistant",
+                    text: "steered reply",
+                    timestamp: now - 1000,
+                    idempotencyKey: remoteRunId),
+            ])
+        let (transport, vm) = await makeViewModel(
+            historyResponses: [history, history],
+            sendMessageHook: { _ in
+                await responseGate.wait()
+                return OpenClawChatSendResponse(runId: remoteRunId, status: "in_flight")
+            })
+        try await loadAndWaitBootstrap(vm: vm, sessionId: sessionId)
+
+        await sendUserMessage(vm, text: "same active request")
+        try await waitUntil("steered duplicate request is optimistic") {
+            await MainActor.run {
+                vm.messages.count(where: { $0.role == "user" && $0.content.first?.text == "same active request" }) == 2
+            }
+        }
+        await responseGate.open()
+        try await waitUntil("steered duplicate request collapses onto active user") {
+            await MainActor.run {
+                vm.messages.count(where: {
+                    $0.role == "user" && $0.content.first?.text == "same active request"
+                }) == 1
+            }
+        }
+
+        transport.emit(
+            .chat(
+                OpenClawChatEventPayload(
+                    runId: remoteRunId,
+                    sessionKey: "main",
+                    state: "final",
+                    message: chatTextMessage(
+                        role: "assistant",
+                        text: "steered reply",
+                        timestamp: now + 1,
+                        idempotencyKey: remoteRunId),
+                    errorMessage: nil)))
+
+        try await waitUntil("steering row remains inside reused run scope") {
+            await MainActor.run {
+                vm.pendingRunCount == 0 &&
+                    vm.messages.count(where: {
+                        $0.role == "assistant" && $0.content.first?.text == "steered reply"
+                    }) == 1
+            }
+        }
+    }
+
+    @Test func `canonical projected reply after steering adopts reused provisional final`() async throws {
+        let sessionId = "sess-main"
+        let remoteRunId = "existing-active-run"
+        let now = Date().timeIntervalSince1970 * 1000
+        let finalRefreshGate = SessionSubscribeGate()
+        let historyCount = AsyncCounter()
+        let history = historyPayload(
+            sessionId: sessionId,
+            messages: [
+                chatTextMessage(
+                    role: "user",
+                    text: "same active request",
+                    timestamp: now - 1000,
+                    idempotencyKey: "\(remoteRunId):user"),
+            ])
+        let (transport, vm) = await makeViewModel(
+            historyResponses: [history, history],
+            requestHistoryHook: { _ in
+                let count = await historyCount.increment()
+                if count == 3 {
+                    await finalRefreshGate.wait()
+                }
+            },
+            sendMessageHook: { _ in
+                OpenClawChatSendResponse(runId: remoteRunId, status: "in_flight")
+            })
+        try await loadAndWaitBootstrap(vm: vm, sessionId: sessionId)
+
+        await sendUserMessage(vm, text: "same active request")
+        try await waitUntil("steering adoption send refresh completes") {
+            await historyCount.current() >= 2
+        }
+        transport.emit(
+            .chat(
+                OpenClawChatEventPayload(
+                    runId: remoteRunId,
+                    sessionKey: "main",
+                    state: "final",
+                    message: chatTextMessage(
+                        role: "assistant",
+                        text: "steered reply",
+                        timestamp: now + 1,
+                        idempotencyKey: remoteRunId),
+                    errorMessage: nil)))
+        try await waitUntil("provisional reply precedes steering row") {
+            await MainActor.run {
+                vm.messages.contains { $0.role == "assistant" && $0.content.first?.text == "steered reply" }
+            }
+        }
+        let provisionalID = try await MainActor.run {
+            try #require(vm.messages.first(where: {
+                $0.role == "assistant" && $0.content.first?.text == "steered reply"
+            })?.id)
+        }
+
+        transport.emit(
+            .sessionMessage(
+                OpenClawSessionMessageEventPayload(
+                    sessionKey: "agent:main:main",
+                    message: chatTextModelMessage(
+                        role: "user",
+                        text: "steer the active run",
+                        timestamp: now + 2),
+                    messageId: "srv-steering-user",
+                    messageSeq: 2)))
+        transport.emit(
+            .sessionMessage(
+                OpenClawSessionMessageEventPayload(
+                    sessionKey: "agent:main:main",
+                    message: chatTextModelMessage(
+                        role: "assistant",
+                        text: "canonical steered reply",
+                        timestamp: now + 3,
+                        idempotencyKey: remoteRunId),
+                    messageId: "srv-steered-reply",
+                    messageSeq: 3)))
+
+        try await waitUntil("canonical reply after steering adopts provisional row") {
+            await MainActor.run {
+                guard vm.messages.count(where: { $0.role == "assistant" }) == 1,
+                      let reply = vm.messages.first(where: { $0.id == provisionalID }),
+                      reply.content.first?.text == "canonical steered reply",
+                      reply.timestamp == now + 3,
+                      let steeringIndex = vm.messages.firstIndex(where: {
+                          $0.role == "user" && $0.content.first?.text == "steer the active run"
+                      }),
+                      let replyIndex = vm.messages.firstIndex(where: { $0.id == provisionalID })
+                else {
+                    return false
+                }
+                return steeringIndex < replyIndex
+            }
+        }
+        await finalRefreshGate.release()
+    }
+
+    @Test func `metadata free channel turn does not adopt reused provisional final`() async throws {
+        let sessionId = "sess-main"
+        let remoteRunId = "existing-active-run"
+        let now = Date().timeIntervalSince1970 * 1000
+        let finalRefreshGate = SessionSubscribeGate()
+        let historyCount = AsyncCounter()
+        let history = historyPayload(
+            sessionId: sessionId,
+            messages: [
+                chatTextMessage(
+                    role: "user",
+                    text: "same active request",
+                    timestamp: now - 1000,
+                    idempotencyKey: "\(remoteRunId):user"),
+            ])
+        let (transport, vm) = await makeViewModel(
+            historyResponses: [history, history],
+            requestHistoryHook: { _ in
+                let count = await historyCount.increment()
+                if count == 3 {
+                    await finalRefreshGate.wait()
+                }
+            },
+            sendMessageHook: { _ in
+                OpenClawChatSendResponse(runId: remoteRunId, status: "in_flight")
+            })
+        try await loadAndWaitBootstrap(vm: vm, sessionId: sessionId)
+
+        await sendUserMessage(vm, text: "same active request")
+        try await waitUntil("channel boundary send refresh completes") {
+            await historyCount.current() >= 2
+        }
+        transport.emit(
+            .chat(
+                OpenClawChatEventPayload(
+                    runId: remoteRunId,
+                    sessionKey: "main",
+                    state: "final",
+                    message: chatTextMessage(
+                        role: "assistant",
+                        text: "same reply",
+                        timestamp: now + 1,
+                        idempotencyKey: remoteRunId),
+                    errorMessage: nil)))
+        try await waitUntil("reused provisional reply is visible") {
+            await MainActor.run {
+                vm.messages.contains { $0.role == "assistant" && $0.content.first?.text == "same reply" }
+            }
+        }
+        let provisionalID = try await MainActor.run {
+            try #require(vm.messages.first(where: {
+                $0.role == "assistant" && $0.content.first?.text == "same reply"
+            })?.id)
+        }
+
+        transport.emit(
+            .sessionMessage(
+                OpenClawSessionMessageEventPayload(
+                    sessionKey: "agent:main:main",
+                    message: chatTextModelMessage(
+                        role: "user",
+                        text: "independent channel request",
+                        timestamp: now + 2),
+                    messageId: "srv-channel-user",
+                    messageSeq: 2)))
+        transport.emit(
+            .sessionMessage(
+                OpenClawSessionMessageEventPayload(
+                    sessionKey: "agent:main:main",
+                    message: chatTextModelMessage(
+                        role: "assistant",
+                        text: "same reply",
+                        timestamp: now + 3),
+                    messageId: "srv-channel-reply",
+                    messageSeq: 3)))
+
+        try await waitUntil("independent channel reply remains distinct") {
+            await MainActor.run {
+                let replies = vm.messages.filter {
+                    $0.role == "assistant" && $0.content.first?.text == "same reply"
+                }
+                guard replies.count == 2, replies.first?.id == provisionalID else { return false }
+                guard let userIndex = vm.messages.firstIndex(where: {
+                    $0.role == "user" && $0.content.first?.text == "independent channel request"
+                }),
+                    let canonicalIndex = vm.messages.firstIndex(where: { $0.id == replies[1].id })
+                else {
+                    return false
+                }
+                return userIndex < canonicalIndex
+            }
+        }
+        await finalRefreshGate.release()
+    }
+
+    @Test func `late transformed canonical user keeps reused run final scope`() async throws {
+        let sessionId = "sess-main"
+        let remoteRunId = "existing-active-run"
+        let now = Date().timeIntervalSince1970 * 1000
+        let responseGate = AsyncGate()
+        let finalRefreshGate = SessionSubscribeGate()
+        let historyCount = AsyncCounter()
+        let emptyHistory = historyPayload(sessionId: sessionId)
+        let (transport, vm) = await makeViewModel(
+            historyResponses: [emptyHistory, emptyHistory],
+            requestHistoryHook: { _ in
+                let count = await historyCount.increment()
+                if count == 3 {
+                    await finalRefreshGate.wait()
+                }
+            },
+            sendMessageHook: { _ in
+                await responseGate.wait()
+                return OpenClawChatSendResponse(runId: remoteRunId, status: "in_flight")
+            })
+        try await loadAndWaitBootstrap(vm: vm, sessionId: sessionId)
+
+        await sendUserMessage(vm, text: "same active request")
+        await responseGate.open()
+        try await waitUntil("optimistic user adopts reused run identity") {
+            await MainActor.run {
+                vm.messages.contains(where: { message in
+                    message.role == "user" && message.idempotencyKey == "\(remoteRunId):user"
+                })
+            }
+        }
+        try await waitUntil("post-ack history refresh completes") {
+            await historyCount.current() >= 2
+        }
+
+        transport.emit(
+            .sessionMessage(
+                OpenClawSessionMessageEventPayload(
+                    sessionKey: "agent:main:main",
+                    message: chatTextModelMessage(
+                        role: "user",
+                        text: "canonical redacted request",
+                        timestamp: now + 1,
+                        idempotencyKey: "\(remoteRunId):user"),
+                    messageId: "srv-transformed-user",
+                    messageSeq: 1)))
+        transport.emit(
+            .sessionMessage(
+                OpenClawSessionMessageEventPayload(
+                    sessionKey: "agent:main:main",
+                    message: chatTextModelMessage(
+                        role: "assistant",
+                        text: "active reply",
+                        timestamp: now + 2,
+                        idempotencyKey: remoteRunId),
+                    messageId: "srv-active-reply",
+                    messageSeq: 2)))
+        transport.emit(
+            .sessionMessage(
+                OpenClawSessionMessageEventPayload(
+                    sessionKey: "agent:main:main",
+                    message: chatTextModelMessage(
+                        role: "user",
+                        text: "newer request from another client",
+                        timestamp: now + 3,
+                        idempotencyKey: "other-client-run:user"),
+                    messageId: "srv-newer-user",
+                    messageSeq: 3)))
+        try await waitUntil("canonical user transformation and newer turn arrive") {
+            await MainActor.run {
+                vm.messages.containsUserText("canonical redacted request") &&
+                    vm.messages.containsUserText("newer request from another client")
+            }
+        }
+
+        transport.emit(
+            .chat(
+                OpenClawChatEventPayload(
+                    runId: remoteRunId,
+                    sessionKey: "main",
+                    state: "final",
+                    message: chatTextMessage(
+                        role: "assistant",
+                        text: "active reply",
+                        timestamp: now + 4,
+                        idempotencyKey: remoteRunId),
+                    errorMessage: nil)))
+
+        try await waitUntil("late canonical adoption does not duplicate reused final") {
+            await MainActor.run {
+                vm.pendingRunCount == 0 &&
+                    vm.messages
+                    .count(where: { $0.role == "assistant" && $0.content.first?.text == "active reply" }) == 1
+            }
+        }
+        await finalRefreshGate.release()
+    }
+
+    @Test func `history reconciled early final stays in canonical order after delayed event`() async throws {
+        let sessionId = "sess-main"
+        let remoteRunId = "existing-active-run"
+        let now = Date().timeIntervalSince1970 * 1000
+        let responseGate = AsyncGate()
+        let historyGate = AsyncGate()
+        let emptyHistory = historyPayload(sessionId: sessionId)
+        let canonicalHistory = historyPayload(
+            sessionId: sessionId,
+            messages: [
+                chatTextMessage(
+                    role: "user",
+                    text: "same active request",
+                    timestamp: now,
+                    idempotencyKey: "\(remoteRunId):user"),
+                chatTextMessage(
+                    role: "assistant",
+                    text: "early final reply",
+                    timestamp: now + 2,
+                    idempotencyKey: remoteRunId),
+                chatTextMessage(
+                    role: "user",
+                    text: "newer channel request",
+                    timestamp: now + 3),
+            ])
+        let (transport, vm) = await makeViewModel(
+            historyResponses: [emptyHistory, canonicalHistory],
+            historyResponseHook: { _, index, _ in
+                guard index == 1 else { return nil }
+                await historyGate.wait()
+                return canonicalHistory
+            },
+            sendMessageHook: { _ in
+                await responseGate.wait()
+                return OpenClawChatSendResponse(runId: remoteRunId, status: "in_flight")
+            })
+        try await loadAndWaitBootstrap(vm: vm, sessionId: sessionId)
+
+        await sendUserMessage(vm, text: "same active request")
+        transport.emit(
+            .chat(
+                OpenClawChatEventPayload(
+                    runId: remoteRunId,
+                    sessionKey: "main",
+                    state: "final",
+                    message: chatTextMessage(
+                        role: "assistant",
+                        text: "early final reply",
+                        timestamp: now + 1,
+                        idempotencyKey: remoteRunId),
+                    errorMessage: nil)))
+        try await waitUntil("early final is visible before acknowledgement") {
+            await MainActor.run {
+                vm.messages.contains {
+                    $0.role == "assistant" && $0.content.first?.text == "early final reply"
+                }
+            }
+        }
+        let provisionalID = try await MainActor.run {
+            try #require(vm.messages.first(where: {
+                $0.role == "assistant" && $0.content.first?.text == "early final reply"
+            })?.id)
+        }
+
+        await historyGate.open()
+        try await waitUntil("history adopts early final before newer user") {
+            await MainActor.run {
+                guard let replyIndex = vm.messages.firstIndex(where: { $0.id == provisionalID }),
+                      let newerUserIndex = vm.messages.firstIndex(where: {
+                          $0.role == "user" && $0.content.first?.text == "newer channel request"
+                      })
+                else {
+                    return false
+                }
+                return replyIndex < newerUserIndex && vm.messages[replyIndex].timestamp == now + 2
+            }
+        }
+
+        await responseGate.open()
+        try await waitUntil("early final run acknowledgement rekeys optimistic user") {
+            await MainActor.run {
+                vm.pendingRunCount == 0 &&
+                    vm.messages.count(where: {
+                        $0.role == "user" && $0.idempotencyKey == "\(remoteRunId):user"
+                    }) == 1
+            }
+        }
+
+        transport.emit(
+            .sessionMessage(
+                OpenClawSessionMessageEventPayload(
+                    sessionKey: "agent:main:main",
+                    message: chatTextModelMessage(
+                        role: "assistant",
+                        text: "early final reply",
+                        timestamp: now + 4,
+                        idempotencyKey: remoteRunId),
+                    messageId: "srv-early-final-reply",
+                    messageSeq: 2)))
+
+        try await waitUntil("delayed canonical event preserves history order") {
+            await MainActor.run {
+                guard vm.messages.count(where: {
+                    $0.role == "assistant" && $0.idempotencyKey == remoteRunId
+                }) == 1,
+                    let replyIndex = vm.messages.firstIndex(where: { $0.id == provisionalID }),
+                    let newerUserIndex = vm.messages.firstIndex(where: {
+                        $0.role == "user" && $0.content.first?.text == "newer channel request"
+                    })
+                else {
+                    return false
+                }
+                return replyIndex < newerUserIndex && vm.messages[replyIndex].timestamp == now + 2
+            }
+        }
+    }
+
+    @Test func `terminal timeout send ack surfaces error and allows next send`() async throws {
         let sessionId = "sess-main"
         let history = historyPayload(sessionId: sessionId, messages: [])
         let sendCount = AsyncCounter()
@@ -1230,7 +2037,9 @@ struct ChatViewModelTests {
                     timestamp: now + 1),
             ])
 
-        let (transport, vm) = await makeViewModel(historyResponses: [history1, history2])
+        let (transport, vm) = await makeViewModel(
+            historyResponses: [history1, history2],
+            sendMessageStatus: "pending")
         try await loadAndWaitBootstrap(vm: vm, sessionId: sessionId)
         try await sendMessageAndEmitFinal(
             transport: transport,
@@ -1253,7 +2062,9 @@ struct ChatViewModelTests {
         let history1 = historyPayload(sessionId: sessionId)
         let history2 = historyPayload(sessionId: sessionId, messages: [])
 
-        let (transport, vm) = await makeViewModel(historyResponses: [history1, history2])
+        let (transport, vm) = await makeViewModel(
+            historyResponses: [history1, history2],
+            sendMessageStatus: "pending")
         try await loadAndWaitBootstrap(vm: vm, sessionId: sessionId)
         try await sendMessageAndEmitFinal(
             transport: transport,
@@ -1273,28 +2084,52 @@ struct ChatViewModelTests {
     @Test func `does not duplicate user message when refresh returns canonical timestamp`() async throws {
         let sessionId = "sess-main"
         let now = Date().timeIntervalSince1970 * 1000
-        let history1 = historyPayload(sessionId: sessionId)
-        let history2 = historyPayload(
+        let refreshGate = AsyncGate()
+        let historyCallCount = AsyncCounter()
+        let history1 = historyPayload(
             sessionId: sessionId,
             messages: [
                 chatTextMessage(
-                    role: "user",
-                    text: "hello from mac webchat",
-                    timestamp: now + 5000),
-                chatTextMessage(
                     role: "assistant",
-                    text: "final answer",
-                    timestamp: now + 6000),
+                    text: "earlier answer",
+                    timestamp: now + 1000),
             ])
-
-        let (transport, vm) = await makeViewModel(historyResponses: [history1, history2])
+        let (_, vm) = await makeViewModel(
+            historyResponses: [history1],
+            requestHistoryHook: { _ in
+                if await historyCallCount.increment() == 2 {
+                    await refreshGate.wait()
+                }
+            },
+            historyResponseHook: { _, index, sentRunIds in
+                guard index == 1, let runId = sentRunIds.last else { return nil }
+                return historyPayload(
+                    sessionId: sessionId,
+                    messages: [
+                        chatTextMessage(
+                            role: "assistant",
+                            text: "earlier answer",
+                            timestamp: now + 1000),
+                        chatTextMessage(
+                            role: "user",
+                            text: "hello from mac webchat",
+                            timestamp: now + 5000,
+                            idempotencyKey: "\(runId):user"),
+                        chatTextMessage(
+                            role: "assistant",
+                            text: "final answer",
+                            timestamp: now + 6000),
+                    ])
+            })
         try await loadAndWaitBootstrap(vm: vm, sessionId: sessionId)
-        try await sendMessageAndEmitFinal(
-            transport: transport,
-            vm: vm,
-            text: "hello from mac webchat")
+        await sendUserMessage(vm, text: "hello from mac webchat")
+        try await waitUntil("canonical refresh starts") { await historyCallCount.current() == 2 }
+        let optimisticID = try await MainActor.run {
+            try #require(vm.messages.last(where: { $0.role == "user" })?.id)
+        }
+        await refreshGate.open()
 
-        try await waitUntil("canonical refresh keeps one user message") {
+        try await waitUntil("send acknowledgement refresh keeps one user message") {
             await MainActor.run {
                 let userMessages = vm.messages.filter { message in
                     message.role == "user" &&
@@ -1307,26 +2142,116 @@ struct ChatViewModelTests {
                 return hasAssistant && userMessages.count == 1
             }
         }
+        #expect(await MainActor.run { vm.messages.last(where: { $0.role == "user" })?.id } == optimisticID)
+    }
+
+    @Test func `metadata free canonical refresh keeps ambiguous user turns distinct`() async throws {
+        let sessionId = "sess-main"
+        let now = Date().timeIntervalSince1970 * 1000
+        let refreshGate = AsyncGate()
+        let historyCallCount = AsyncCounter()
+        let (_, vm) = await makeViewModel(
+            historyResponses: [historyPayload(sessionId: sessionId)],
+            requestHistoryHook: { _ in
+                if await historyCallCount.increment() == 2 {
+                    await refreshGate.wait()
+                }
+            },
+            historyResponseHook: { _, index, _ in
+                guard index == 1 else { return nil }
+                return historyPayload(
+                    sessionId: sessionId,
+                    messages: [
+                        chatTextMessage(
+                            role: "user",
+                            text: "legacy echo",
+                            timestamp: now + 5000),
+                        chatTextMessage(
+                            role: "assistant",
+                            text: "legacy answer",
+                            timestamp: now + 6000),
+                    ])
+            })
+        try await loadAndWaitBootstrap(vm: vm, sessionId: sessionId)
+        await sendUserMessage(vm, text: "legacy echo")
+        try await waitUntil("legacy refresh starts") { await historyCallCount.current() == 2 }
+        let optimisticID = try await MainActor.run {
+            try #require(vm.messages.last(where: { $0.role == "user" })?.id)
+        }
+        await refreshGate.open()
+
+        try await waitUntil("metadata free canonical refresh preserves both user rows") {
+            await MainActor.run {
+                vm.messages.count(where: { message in
+                    message.role == "user" &&
+                        message.content.compactMap(\.text).joined(separator: "\n") == "legacy echo"
+                }) == 2 && vm.messages.contains(where: { message in
+                    message.role == "assistant" &&
+                        message.content.compactMap(\.text).joined(separator: "\n") == "legacy answer"
+                })
+            }
+        }
+        #expect(await MainActor.run { vm.messages.contains(where: { $0.id == optimisticID }) })
+    }
+
+    @Test func `preserves local echo when another client sends identical text during refresh`() async throws {
+        let sessionId = "sess-main"
+        let now = Date().timeIntervalSince1970 * 1000
+        let (transport, vm) = await makeViewModel(
+            historyResponses: [historyPayload(sessionId: sessionId)],
+            historyResponseHook: { _, index, _ in
+                guard index == 1 else { return nil }
+                return historyPayload(
+                    sessionId: sessionId,
+                    messages: [
+                        chatTextMessage(
+                            role: "user",
+                            text: "same words",
+                            timestamp: now + 5000,
+                            idempotencyKey: "other-client:user"),
+                        chatTextMessage(
+                            role: "assistant",
+                            text: "other client's answer",
+                            timestamp: now + 6000),
+                    ])
+            })
+        try await loadAndWaitBootstrap(vm: vm, sessionId: sessionId)
+        await sendUserMessage(vm, text: "same words")
+
+        try await waitUntil("foreign identical turn and local echo both survive") {
+            await MainActor.run {
+                vm.pendingRunCount == 0 &&
+                    vm.messages.count(where: { message in
+                        message.role == "user" &&
+                            message.content.compactMap(\.text).joined(separator: "\n") == "same words"
+                    }) == 2
+            }
+        }
+        #expect(await transport.sentRunIds().count == 1)
     }
 
     @Test func `preserves repeated optimistic user messages with identical content during refresh`() async throws {
         let sessionId = "sess-main"
         let now = Date().timeIntervalSince1970 * 1000
         let history1 = historyPayload(sessionId: sessionId)
-        let history2 = historyPayload(
-            sessionId: sessionId,
-            messages: [
-                chatTextMessage(
-                    role: "user",
-                    text: "retry",
-                    timestamp: now + 5000),
-                chatTextMessage(
-                    role: "assistant",
-                    text: "first answer",
-                    timestamp: now + 6000),
-            ])
-
-        let (transport, vm) = await makeViewModel(historyResponses: [history1, history2, history2])
+        let (transport, vm) = await makeViewModel(
+            historyResponses: [history1],
+            historyResponseHook: { _, index, sentRunIds in
+                guard index > 0, let firstRunId = sentRunIds.first else { return nil }
+                return historyPayload(
+                    sessionId: sessionId,
+                    messages: [
+                        chatTextMessage(
+                            role: "user",
+                            text: "retry",
+                            timestamp: now + 5000,
+                            idempotencyKey: "\(firstRunId):user"),
+                        chatTextMessage(
+                            role: "assistant",
+                            text: "first answer",
+                            timestamp: now + 6000),
+                    ])
+            })
         try await loadAndWaitBootstrap(vm: vm, sessionId: sessionId)
         try await sendMessageAndEmitFinal(
             transport: transport,
@@ -1454,6 +2379,72 @@ struct ChatViewModelTests {
         })
     }
 
+    @Test @MainActor func `transformed canonical reply invalidates older stale refresh`() async throws {
+        let staleRefreshGate = SessionSubscribeGate()
+        let historyCount = AsyncCounter()
+        let now = Date().timeIntervalSince1970 * 1000
+        let staleTurn = [
+            chatTextMessage(role: "user", text: "older question", timestamp: now - 2),
+            chatTextMessage(role: "assistant", text: "older answer", timestamp: now - 1),
+        ]
+        let (transport, vm) = await makeViewModel(
+            historyResponses: [
+                historyPayload(sessionId: "sess-bootstrap", messages: staleTurn),
+                historyPayload(sessionId: "sess-stale", messages: staleTurn),
+            ],
+            requestHistoryHook: { sessionKey in
+                guard sessionKey == "main" else { return }
+                let count = await historyCount.increment()
+                if count == 2 {
+                    await staleRefreshGate.wait()
+                }
+            },
+            historyResponseHook: { _, index, sentRunIds in
+                guard index == 2, let runId = sentRunIds.first else { return nil }
+                return historyPayload(
+                    sessionId: "sess-canonical",
+                    messages: [
+                        chatTextMessage(
+                            role: "user",
+                            text: "canonical redacted request",
+                            timestamp: now,
+                            idempotencyKey: "\(runId):user"),
+                        chatTextMessage(
+                            role: "assistant",
+                            text: "canonical answer",
+                            timestamp: now + 1,
+                            idempotencyKey: runId),
+                    ])
+            })
+        try await loadAndWaitBootstrap(vm: vm, sessionId: "sess-bootstrap")
+
+        transport.emit(OpenClawChatTransportEvent.seqGap)
+        try await waitUntil("stale transformed refresh is in flight") {
+            await historyCount.current() == 2
+        }
+
+        vm.input = "original request"
+        vm.send()
+        _ = try await waitForLastSentRunId(transport)
+        try await waitUntil("transformed canonical answer applies") {
+            await MainActor.run {
+                vm.sessionId == "sess-canonical" &&
+                    vm.messages.containsUserText("canonical redacted request") &&
+                    vm.messages.contains { $0.content.contains { $0.text == "canonical answer" } }
+            }
+        }
+
+        let healthCallsBeforeRelease = await transport.healthCallCount()
+        await staleRefreshGate.release()
+        try await waitUntil("older transformed refresh completes") {
+            await transport.healthCallCount() > healthCallsBeforeRelease
+        }
+
+        #expect(vm.sessionId == "sess-canonical")
+        #expect(vm.messages.containsUserText("canonical redacted request"))
+        #expect(vm.messages.contains { $0.content.contains { $0.text == "canonical answer" } })
+    }
+
     @Test func `accepts canonical session key events for own pending run`() async throws {
         let history1 = historyPayload()
         let history2 = historyPayload(
@@ -1464,7 +2455,9 @@ struct ChatViewModelTests {
                     timestamp: Date().timeIntervalSince1970 * 1000),
             ])
 
-        let (transport, vm) = await makeViewModel(historyResponses: [history1, history2])
+        let (transport, vm) = await makeViewModel(
+            historyResponses: [history1, history2],
+            sendMessageStatus: "pending")
         try await loadAndWaitBootstrap(vm: vm)
         await sendUserMessage(vm)
         try await waitUntil("pending run starts") { await MainActor.run { vm.pendingRunCount == 1 } }
@@ -1496,7 +2489,9 @@ struct ChatViewModelTests {
                     timestamp: now),
             ])
 
-        let (transport, vm) = await makeViewModel(historyResponses: [history1, history2])
+        let (transport, vm) = await makeViewModel(
+            historyResponses: [history1, history2],
+            sendMessageStatus: "pending")
         try await loadAndWaitBootstrap(vm: vm)
 
         await sendUserMessage(vm)
@@ -1694,7 +2689,9 @@ struct ChatViewModelTests {
 
     @Test func `appends external session assistant message while run pending`() async throws {
         let now = Date().timeIntervalSince1970 * 1000
-        let (transport, vm) = await makeViewModel(historyResponses: [historyPayload()])
+        let (transport, vm) = await makeViewModel(
+            historyResponses: [historyPayload()],
+            sendMessageStatus: "pending")
 
         await MainActor.run { vm.load() }
         try await waitUntil("bootstrap history loaded") { await MainActor.run { vm.messages.isEmpty } }
@@ -1741,6 +2738,7 @@ struct ChatViewModelTests {
         try await waitUntil("bootstrap history loaded") { await MainActor.run { vm.messages.isEmpty } }
 
         await sendUserMessage(vm, text: "echo me")
+        let runId = try await waitForLastSentRunId(transport)
         try await waitUntil("optimistic user message visible") {
             await MainActor.run {
                 vm.messages.count == 1 && vm.messages.first?.content.first?.text == "echo me"
@@ -1763,7 +2761,8 @@ struct ChatViewModelTests {
                                 fileName: nil,
                                 content: nil),
                         ],
-                        timestamp: Date().timeIntervalSince1970 * 1000 + 5000),
+                        timestamp: Date().timeIntervalSince1970 * 1000 + 5000,
+                        idempotencyKey: "\(runId):user"),
                     messageId: "srv-echo-1",
                     messageSeq: 1)))
 
@@ -1773,6 +2772,141 @@ struct ChatViewModelTests {
                 msg.role == "user" && msg.content.first?.text == "echo me"
             }) == 1
         })
+    }
+
+    @Test func `late correlated user echo replaces optimistic row after final`() async throws {
+        let history = historyPayload()
+        let (transport, vm) = await makeViewModel(
+            historyResponses: [history, history],
+            sendMessageStatus: "pending")
+
+        await MainActor.run { vm.load() }
+        try await waitUntil("bootstrap history loaded") { await MainActor.run { vm.messages.isEmpty } }
+
+        await sendUserMessage(vm, text: "sensitive draft")
+        let runId = try await waitForLastSentRunId(transport)
+        let optimisticID = try await MainActor.run {
+            try #require(vm.messages.last(where: { $0.role == "user" })?.id)
+        }
+
+        transport.emit(
+            .chat(
+                OpenClawChatEventPayload(
+                    runId: runId,
+                    sessionKey: "main",
+                    state: "final",
+                    message: nil,
+                    errorMessage: nil)))
+        try await waitUntil("final clears pending correlation bookkeeping") {
+            await MainActor.run { vm.pendingRunCount == 0 }
+        }
+
+        let canonicalTimestamp = Date().timeIntervalSince1970 * 1000 + 5000
+        transport.emit(
+            .sessionMessage(
+                OpenClawSessionMessageEventPayload(
+                    sessionKey: "agent:main:main",
+                    message: OpenClawChatMessage(
+                        role: "user",
+                        content: [
+                            OpenClawChatMessageContent(
+                                type: "text",
+                                text: "redacted canonical text",
+                                mimeType: nil,
+                                fileName: nil,
+                                content: nil),
+                        ],
+                        timestamp: canonicalTimestamp,
+                        idempotencyKey: "\(runId):user"),
+                    messageId: "srv-late-user-echo",
+                    messageSeq: 2)))
+
+        try await waitUntil("late canonical echo replaces optimistic row") {
+            await MainActor.run {
+                vm.messages.count(where: { $0.role == "user" }) == 1 &&
+                    vm.messages.contains(where: { message in
+                        message.id == optimisticID &&
+                            message.content.first?.text == "redacted canonical text" &&
+                            message.timestamp == canonicalTimestamp
+                    })
+            }
+        }
+    }
+
+    @Test func `metadata free same text event cannot consume pending local identity`() async throws {
+        let (transport, vm) = await makeViewModel(
+            historyResponses: [historyPayload()],
+            sendMessageStatus: "pending")
+
+        await MainActor.run { vm.load() }
+        try await waitUntil("bootstrap history loaded") { await MainActor.run { vm.messages.isEmpty } }
+
+        await sendUserMessage(vm, text: "legacy echo")
+        let runId = try await waitForLastSentRunId(transport)
+        let optimisticID = try await MainActor.run {
+            try #require(vm.messages.last(where: { $0.role == "user" })?.id)
+        }
+        let canonicalTimestamp = Date().timeIntervalSince1970 * 1000 + 5000
+
+        transport.emit(
+            .sessionMessage(
+                OpenClawSessionMessageEventPayload(
+                    sessionKey: "agent:main:main",
+                    message: OpenClawChatMessage(
+                        role: "user",
+                        content: [
+                            OpenClawChatMessageContent(
+                                type: "text",
+                                text: "legacy echo",
+                                mimeType: nil,
+                                fileName: nil,
+                                content: nil),
+                        ],
+                        timestamp: canonicalTimestamp),
+                    messageId: "srv-legacy-echo-1",
+                    messageSeq: 1)))
+
+        try await waitUntil("ambiguous metadata free event remains distinct") {
+            await MainActor.run {
+                vm.messages.count(where: { message in
+                    message.role == "user" && message.content.first?.text == "legacy echo"
+                }) == 2
+            }
+        }
+
+        let localCanonicalTimestamp = canonicalTimestamp + 1000
+        transport.emit(
+            .sessionMessage(
+                OpenClawSessionMessageEventPayload(
+                    sessionKey: "agent:main:main",
+                    message: OpenClawChatMessage(
+                        role: "user",
+                        content: [
+                            OpenClawChatMessageContent(
+                                type: "text",
+                                text: "legacy echo",
+                                mimeType: nil,
+                                fileName: nil,
+                                content: nil),
+                        ],
+                        timestamp: localCanonicalTimestamp,
+                        idempotencyKey: "\(runId):user"),
+                    messageId: "srv-local-echo-1",
+                    messageSeq: 2)))
+
+        try await waitUntil("later correlated local echo adopts only the optimistic row") {
+            await MainActor.run {
+                vm.messages.count(where: { message in
+                    message.role == "user" && message.content.first?.text == "legacy echo"
+                }) == 2 && vm.messages.contains(where: { message in
+                    message.id == optimisticID &&
+                        message.timestamp == localCanonicalTimestamp &&
+                        message.idempotencyKey == "\(runId):user"
+                }) && vm.messages.contains(where: { message in
+                    message.timestamp == canonicalTimestamp && message.idempotencyKey == nil
+                })
+            }
+        }
     }
 
     @Test func `appends same content user transcript when it is not local echo`() async throws {
@@ -1895,7 +3029,9 @@ struct ChatViewModelTests {
             text: "resynced after gap",
             timestamp: now)])
 
-        let (transport, vm) = await makeViewModel(historyResponses: [history1, history2])
+        let (transport, vm) = await makeViewModel(
+            historyResponses: [history1, history2],
+            sendMessageStatus: "pending")
 
         try await loadAndWaitBootstrap(vm: vm)
 
@@ -3441,7 +4577,8 @@ struct ChatViewModelTests {
                     await staleFallbackGate.wait()
                     _ = await staleFallbackReleasedCount.increment()
                 }
-            })
+            },
+            sendMessageStatus: "pending")
 
         try await loadAndWaitBootstrap(vm: vm, sessionId: "sess-main")
 
@@ -4331,7 +5468,9 @@ struct ChatViewModelTests {
     @Test func `abort requests do not clear pending until aborted event`() async throws {
         let sessionId = "sess-main"
         let history = historyPayload(sessionId: sessionId)
-        let (transport, vm) = await makeViewModel(historyResponses: [history, history])
+        let (transport, vm) = await makeViewModel(
+            historyResponses: [history, history],
+            sendMessageStatus: "pending")
         try await loadAndWaitBootstrap(vm: vm, sessionId: sessionId)
 
         await sendUserMessage(vm)

--- a/docs/docs_map.md
+++ b/docs/docs_map.md
@@ -5417,6 +5417,7 @@ Do not edit it by hand; run `pnpm docs:map:gen`.
 - Headings:
   - H2: Requirements
   - H2: Quickstart
+  - H2: Share threads with Codex Desktop and CLI
   - H2: Configuration
   - H2: Verify Codex runtime
   - H2: Routing and model selection

--- a/docs/gateway/security/index.md
+++ b/docs/gateway/security/index.md
@@ -261,7 +261,11 @@ Use this when auditing access or deciding what to back up:
   - `~/.openclaw/credentials/<channel>-allowFrom.json` (default account)
   - `~/.openclaw/credentials/<channel>-<accountId>-allowFrom.json` (non-default accounts)
 - **Model auth profiles**: `~/.openclaw/agents/<agentId>/agent/auth-profiles.json`
-- **Codex runtime state**: `~/.openclaw/agents/<agentId>/agent/codex-home/`
+- **Codex runtime state (default)**: `~/.openclaw/agents/<agentId>/agent/codex-home/`
+- **Shared Codex runtime state (opt-in)**: `$CODEX_HOME` or `~/.codex` when
+  `plugins.entries.codex.config.appServer.homeScope` is `"user"`. This mode uses
+  the native Codex account, config, plugins, and thread store; enable it only for
+  an owner-controlled local Gateway. See [Codex harness](/plugins/codex-harness#share-threads-with-codex-desktop-and-cli).
 - **File-backed secrets payload (optional)**: `~/.openclaw/secrets.json`
 - **Legacy OAuth import**: `~/.openclaw/credentials/oauth.json`
 
@@ -998,7 +1002,11 @@ Assume anything under `~/.openclaw/` (or `$OPENCLAW_STATE_DIR/`) may contain sec
 - `openclaw.json`: config may include tokens (gateway, remote gateway), provider settings, and allowlists.
 - `credentials/**`: channel credentials (example: WhatsApp creds), pairing allowlists, legacy OAuth imports.
 - `agents/<agentId>/agent/auth-profiles.json`: API keys, token profiles, OAuth tokens, and optional `keyRef`/`tokenRef`.
-- `agents/<agentId>/agent/codex-home/**`: per-agent Codex app-server account, config, skills, plugins, native thread state, and diagnostics.
+- `agents/<agentId>/agent/codex-home/**`: per-agent Codex app-server account, config, skills, plugins, native thread state, and diagnostics (the default).
+- `$CODEX_HOME/**` or `~/.codex/**`: when the Codex plugin explicitly uses
+  `appServer.homeScope: "user"`, the Gateway can read and update the native Codex
+  account, config, plugins, and threads. Treat this as privileged owner access;
+  the mode is local-stdio-only and native thread management is owner-only.
 - `secrets.json` (optional): file-backed secret payload used by `file` SecretRef providers (`secrets.providers`).
 - `agents/<agentId>/agent/auth.json`: legacy compatibility file. Static `api_key` entries are scrubbed when discovered.
 - `agents/<agentId>/sessions/**`: session transcripts (`*.jsonl`) + routing metadata (`sessions.json`) that can contain private messages and tool output.

--- a/docs/plugins/codex-harness-reference.md
+++ b/docs/plugins/codex-harness-reference.md
@@ -88,6 +88,7 @@ Supported `appServer` fields:
 | Field                                         | Default                                                | Meaning                                                                                                                                                                                                                                                                                                                                                                                         |
 | --------------------------------------------- | ------------------------------------------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `transport`                                   | `"stdio"`                                              | `"stdio"` spawns Codex; `"websocket"` connects to `url`.                                                                                                                                                                                                                                                                                                                                        |
+| `homeScope`                                   | `"agent"`                                              | `"agent"` isolates Codex state per OpenClaw agent. `"user"` shares the native `$CODEX_HOME` or `~/.codex`, uses native auth, and enables owner-only thread management. User scope requires stdio.                                                                                                                                                                                               |
 | `command`                                     | managed Codex binary                                   | Executable for stdio transport. Leave unset to use the managed binary.                                                                                                                                                                                                                                                                                                                          |
 | `args`                                        | `["app-server", "--listen", "stdio://"]`               | Arguments for stdio transport.                                                                                                                                                                                                                                                                                                                                                                  |
 | `url`                                         | unset                                                  | WebSocket app-server URL.                                                                                                                                                                                                                                                                                                                                                                       |
@@ -265,7 +266,7 @@ that combination.
 
 ## Auth and environment isolation
 
-Auth is selected in this order:
+In the default per-agent home, auth is selected in this order:
 
 1. An explicit OpenClaw Codex auth profile for the agent.
 2. The app-server's existing account in that agent's Codex home.
@@ -289,6 +290,14 @@ per-agent directory under that agent's OpenClaw state. That keeps Codex config,
 accounts, plugin cache/data, and thread state scoped to the OpenClaw agent
 instead of leaking in from the operator's personal `~/.codex` home.
 
+Set `appServer.homeScope: "user"` to share native Codex state with Codex
+Desktop and the CLI. This local-stdio-only mode uses `$CODEX_HOME` when set and
+`~/.codex` otherwise, including native auth, config, plugins, and threads.
+OpenClaw skips its auth-profile bridge for the app-server. Verified owner turns
+can use `codex_threads` to list, search, read, fork, rename, archive, and restore
+those threads. Fork a thread before continuing it in OpenClaw; independent
+Codex processes do not coordinate concurrent writers for the same thread.
+
 OpenClaw does not rewrite `HOME` for normal local app-server launches. Codex-run
 subprocesses such as `openclaw`, `gh`, `git`, cloud CLIs, and shell commands see
 the normal process home and can find user-home config and tokens. Codex may also
@@ -296,10 +305,11 @@ discover `$HOME/.agents/skills` and `$HOME/.agents/plugins/marketplace.json`;
 that `.agents` discovery is intentionally shared with the operator home and is
 separate from isolated `~/.codex` state.
 
-OpenClaw plugins and OpenClaw skill snapshots still flow through OpenClaw's own
-plugin registry and skill loader. Personal Codex `~/.codex` assets do not. If
-you have useful Codex CLI skills or plugins from a Codex home that should become
-part of an OpenClaw agent, inventory them explicitly:
+In the default agent scope, OpenClaw plugins and OpenClaw skill snapshots still
+flow through OpenClaw's own plugin registry and skill loader; personal Codex
+`~/.codex` assets do not. If you have useful Codex CLI skills or plugins from a
+Codex home that should become part of an isolated OpenClaw agent, inventory
+them explicitly:
 
 ```bash
 openclaw migrate codex --dry-run
@@ -328,8 +338,8 @@ If a deployment needs additional environment isolation, add those variables to
 
 `appServer.clearEnv` only affects the spawned Codex app-server child process.
 OpenClaw removes `CODEX_HOME` and `HOME` from this list during local launch
-normalization: `CODEX_HOME` stays per-agent, and `HOME` stays inherited so
-subprocesses can use normal user-home state.
+normalization: `CODEX_HOME` stays pointed at the selected agent or user scope,
+and `HOME` stays inherited so subprocesses can use normal user-home state.
 
 ## Dynamic tools
 

--- a/docs/plugins/codex-harness.md
+++ b/docs/plugins/codex-harness.md
@@ -103,6 +103,46 @@ Restart the gateway after changing plugin config. If an existing chat already
 has a session, use `/new` or `/reset` before testing runtime changes so the next
 turn resolves the harness from current config.
 
+## Share threads with Codex Desktop and CLI
+
+The default `appServer.homeScope: "agent"` keeps each OpenClaw agent isolated
+from the operator's native Codex state. To let an owner ask OpenClaw to inspect
+and manage the same native threads shown by Codex Desktop and the Codex CLI,
+opt into the user Codex home:
+
+```json5
+{
+  plugins: {
+    entries: {
+      codex: {
+        enabled: true,
+        config: {
+          appServer: {
+            homeScope: "user",
+          },
+        },
+      },
+    },
+  },
+}
+```
+
+User-home mode is available only with local stdio transport. It uses
+`$CODEX_HOME` when set and `~/.codex` otherwise, including that home's native
+Codex auth, config, plugins, and thread store. OpenClaw does not inject an
+OpenClaw auth profile into this app-server.
+
+Owner turns gain the `codex_threads` tool. It can list, search, read, fork,
+rename, archive, and restore native threads. Ask the agent to fork a thread when
+you want to continue it in OpenClaw; the fork is attached to the current
+OpenClaw session and remains visible to other native Codex clients. Archive
+requires explicit confirmation that the thread is closed elsewhere.
+
+Do not resume or write the same thread concurrently from OpenClaw and another
+Codex client. Codex coordinates live writers inside one app-server process, not
+across independent Desktop, CLI, and OpenClaw processes. Forking creates a
+separate continuation and is the safe coexistence path.
+
 ## Configuration
 
 The quickstart config is the minimum viable Codex harness config. Set Codex
@@ -451,7 +491,7 @@ Get the thread id from the completed `/diagnostics` reply, `/codex binding`, or
 For upload mechanics and runtime-level diagnostics boundaries, see
 [Codex harness runtime](/plugins/codex-harness-runtime#codex-feedback-upload).
 
-Auth is selected in this order:
+In the default per-agent home, auth is selected in this order:
 
 1. Ordered OpenAI auth profiles for the agent, preferably under
    `auth.order.openai`. Run `openclaw doctor --fix` to migrate older
@@ -490,6 +530,8 @@ thread state do not read or write the operator's personal `~/.codex` by
 default. OpenClaw preserves the normal process `HOME`; Codex-run subprocesses
 can still find user-home config and tokens, and Codex may discover shared
 `$HOME/.agents/skills` and `$HOME/.agents/plugins/marketplace.json` entries.
+With `appServer.homeScope: "user"`, OpenClaw instead uses the native user Codex
+home and its existing account without injecting an OpenClaw auth profile.
 
 If a deployment needs additional environment isolation, add those variables to
 `appServer.clearEnv`:
@@ -513,8 +555,8 @@ If a deployment needs additional environment isolation, add those variables to
 
 `appServer.clearEnv` only affects the spawned Codex app-server child process.
 OpenClaw removes `CODEX_HOME` and `HOME` from this list during local launch
-normalization: `CODEX_HOME` stays per-agent, and `HOME` stays inherited so
-subprocesses can use normal user-home state.
+normalization: `CODEX_HOME` stays pointed at the selected agent or user scope,
+and `HOME` stays inherited so subprocesses can use normal user-home state.
 
 Codex dynamic tools default to `searchable` loading. OpenClaw does not expose
 dynamic tools that duplicate Codex-native workspace operations: `read`, `write`,
@@ -561,12 +603,13 @@ Supported `appServer` fields:
 | Field                                         | Default                                                | Meaning                                                                                                                                                                                                                                                                                                                                                                                         |
 | --------------------------------------------- | ------------------------------------------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `transport`                                   | `"stdio"`                                              | `"stdio"` spawns Codex; `"websocket"` connects to `url`.                                                                                                                                                                                                                                                                                                                                        |
+| `homeScope`                                   | `"agent"`                                              | `"agent"` isolates Codex state per OpenClaw agent. `"user"` shares the native `$CODEX_HOME` or `~/.codex`, uses native auth, and enables owner-only thread management. User scope requires stdio.                                                                                                                                                                                               |
 | `command`                                     | managed Codex binary                                   | Executable for stdio transport. Leave unset to use the managed binary; set it only for an explicit override.                                                                                                                                                                                                                                                                                    |
 | `args`                                        | `["app-server", "--listen", "stdio://"]`               | Arguments for stdio transport.                                                                                                                                                                                                                                                                                                                                                                  |
 | `url`                                         | unset                                                  | WebSocket app-server URL.                                                                                                                                                                                                                                                                                                                                                                       |
 | `authToken`                                   | unset                                                  | Bearer token for WebSocket transport. Accepts a literal string or SecretInput such as `${CODEX_APP_SERVER_TOKEN}`.                                                                                                                                                                                                                                                                              |
 | `headers`                                     | `{}`                                                   | Extra WebSocket headers. Header values accept literal strings or SecretInput values, for example `x-codex-client-session-token: "${CODEX_CLIENT_SESSION_TOKEN}"`.                                                                                                                                                                                                                               |
-| `clearEnv`                                    | `[]`                                                   | Extra environment variable names removed from the spawned stdio app-server process after OpenClaw builds its inherited environment. OpenClaw keeps per-agent `CODEX_HOME` and inherited `HOME` for local launches.                                                                                                                                                                              |
+| `clearEnv`                                    | `[]`                                                   | Extra environment variable names removed from the spawned stdio app-server process after OpenClaw builds its inherited environment. OpenClaw keeps the selected `CODEX_HOME` and inherited `HOME` for local launches.                                                                                                                                                                           |
 | `codeModeOnly`                                | `false`                                                | Opt into Codex's code-mode-only tool surface. OpenClaw dynamic tools remain registered with Codex so nested `tools.*` calls return through the app-server `item/tool/call` bridge.                                                                                                                                                                                                              |
 | `remoteWorkspaceRoot`                         | unset                                                  | Remote Codex app-server workspace root. When set, OpenClaw infers the local workspace root from the resolved OpenClaw workspace, preserves the current cwd suffix under this remote root, and sends only the final app-server cwd to Codex. If the cwd is outside the resolved OpenClaw workspace root, OpenClaw fails closed instead of sending a gateway-local path to the remote app-server. |
 | `requestTimeoutMs`                            | `60000`                                                | Timeout for app-server control-plane calls.                                                                                                                                                                                                                                                                                                                                                     |

--- a/extensions/codex/index.test.ts
+++ b/extensions/codex/index.test.ts
@@ -32,12 +32,14 @@ describe("codex plugin", () => {
     expect(manifest.enabledByDefault).toBeUndefined();
   });
 
-  it("registers the codex provider, agent harness, and hosted web search", () => {
+  it("registers the codex provider, agent harness, native thread tool, and hosted web search", () => {
     const registerAgentHarness = vi.fn();
     const registerCommand = vi.fn();
     const registerMediaUnderstandingProvider = vi.fn();
     const registerMigrationProvider = vi.fn();
     const registerProvider = vi.fn();
+    const registerTool = vi.fn();
+    const registerToolMetadata = vi.fn();
     const registerWebSearchProvider = vi.fn();
     const on = vi.fn();
     const onConversationBindingResolved = vi.fn();
@@ -55,6 +57,8 @@ describe("codex plugin", () => {
         registerMediaUnderstandingProvider,
         registerMigrationProvider,
         registerProvider,
+        registerTool,
+        registerToolMetadata,
         registerWebSearchProvider,
         on,
         onConversationBindingResolved,
@@ -101,6 +105,10 @@ describe("codex plugin", () => {
       | undefined;
     expect(migrationRegistration?.id).toBe("codex");
     expect(migrationRegistration?.label).toBe("Codex");
+    expect(registerTool).toHaveBeenCalledWith(expect.any(Function), { name: "codex_threads" });
+    expect(registerToolMetadata).toHaveBeenCalledWith(
+      expect.objectContaining({ toolName: "codex_threads", risk: "high" }),
+    );
     expect(inboundClaimRegistration?.[0]).toBe("inbound_claim");
     expect(typeof inboundClaimRegistration?.[1]).toBe("function");
     expect(typeof bindingResolvedRegistration?.[0]).toBe("function");

--- a/extensions/codex/index.ts
+++ b/extensions/codex/index.ts
@@ -16,6 +16,7 @@ import {
   handleCodexConversationInboundClaim,
 } from "./src/conversation-binding.js";
 import { buildCodexMigrationProvider } from "./src/migration/provider.js";
+import { createCodexThreadsTool } from "./src/native-thread-tool.js";
 import {
   createCodexCliSessionNodeHostCommands,
   createCodexCliSessionNodeInvokePolicies,
@@ -51,6 +52,22 @@ export default definePluginEntry({
       createCodexWebSearchProvider({ resolvePluginConfig: resolveCurrentPluginConfig }),
     );
     api.registerMigrationProvider(buildCodexMigrationProvider({ runtime: api.runtime }));
+    api.registerTool(
+      (context) =>
+        createCodexThreadsTool({
+          context,
+          runtime: api.runtime,
+          getPluginConfig: resolveCurrentPluginConfig,
+        }),
+      { name: "codex_threads" },
+    );
+    api.registerToolMetadata({
+      toolName: "codex_threads",
+      displayName: "Codex Threads",
+      description: "Manage native Codex threads in the shared user Codex home.",
+      risk: "high",
+      tags: ["codex", "sessions"],
+    });
     for (const command of createCodexCliSessionNodeHostCommands()) {
       api.registerNodeHostCommand(command);
     }

--- a/extensions/codex/openclaw.plugin.json
+++ b/extensions/codex/openclaw.plugin.json
@@ -6,6 +6,7 @@
   "contracts": {
     "mediaUnderstandingProviders": ["codex"],
     "migrationProviders": ["codex"],
+    "tools": ["codex_threads"],
     "webSearchProviders": ["codex"]
   },
   "mediaUnderstandingProviderMetadata": {
@@ -140,6 +141,11 @@
             "type": "string",
             "enum": ["stdio", "websocket"],
             "default": "stdio"
+          },
+          "homeScope": {
+            "type": "string",
+            "enum": ["agent", "user"],
+            "default": "agent"
           },
           "command": { "type": "string" },
           "args": {
@@ -364,6 +370,11 @@
     "appServer.transport": {
       "label": "Transport",
       "help": "Use stdio to spawn Codex locally, or websocket to connect to an already-running app-server.",
+      "advanced": true
+    },
+    "appServer.homeScope": {
+      "label": "Codex Home Scope",
+      "help": "Use agent for isolated Codex state, or user to share native Codex threads, config, and authentication with Codex Desktop and the CLI.",
       "advanced": true
     },
     "appServer.command": {

--- a/extensions/codex/src/app-server/auth-bridge.test.ts
+++ b/extensions/codex/src/app-server/auth-bridge.test.ts
@@ -8,8 +8,8 @@ import {
   replaceRuntimeAuthProfileStoreSnapshots,
 } from "openclaw/plugin-sdk/agent-runtime";
 import { upsertAuthProfile } from "openclaw/plugin-sdk/provider-auth";
+import { withTempDir } from "openclaw/plugin-sdk/test-env";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { useAutoCleanupTempDirTracker } from "../../../../test/helpers/temp-dir.js";
 import {
   applyCodexAppServerAuthProfile,
   bridgeCodexAppServerStartOptions,
@@ -43,8 +43,6 @@ const providerRuntimeMocks = vi.hoisted(() => ({
     },
   ),
 }));
-
-const tempDirs = useAutoCleanupTempDirTracker(afterEach);
 
 vi.mock("openclaw/plugin-sdk/agent-runtime", async (importOriginal) => {
   const actual = await importOriginal<typeof import("openclaw/plugin-sdk/agent-runtime")>();
@@ -244,12 +242,11 @@ describe("bridgeCodexAppServerStartOptions", () => {
   });
 
   it("uses the native user Codex home for coexistence mode", async () => {
-    const root = tempDirs.make("openclaw-codex-user-home-");
-    const agentDir = path.join(root, "agent");
-    const codexHome = path.join(root, "user-codex-home");
-    vi.stubEnv("CODEX_HOME", codexHome);
-    const startOptions = createStartOptions({ homeScope: "user" });
-    try {
+    await withTempDir("openclaw-codex-user-home-", async (root) => {
+      const agentDir = path.join(root, "agent");
+      const codexHome = path.join(root, "user-codex-home");
+      vi.stubEnv("CODEX_HOME", codexHome);
+      const startOptions = createStartOptions({ homeScope: "user" });
       await expect(
         bridgeCodexAppServerStartOptions({ startOptions, agentDir, authProfileId: null }),
       ).resolves.toEqual({
@@ -258,9 +255,7 @@ describe("bridgeCodexAppServerStartOptions", () => {
       });
       await expect(fs.access(codexHome)).resolves.toBeUndefined();
       await expectPathMissing(resolveCodexAppServerHomeDir(agentDir));
-    } finally {
-      await fs.rm(root, { recursive: true, force: true });
-    }
+    });
   });
 
   it("preserves inherited HOME when clearEnv asks to clear app-server isolation vars", async () => {

--- a/extensions/codex/src/app-server/auth-bridge.test.ts
+++ b/extensions/codex/src/app-server/auth-bridge.test.ts
@@ -9,6 +9,7 @@ import {
 } from "openclaw/plugin-sdk/agent-runtime";
 import { upsertAuthProfile } from "openclaw/plugin-sdk/provider-auth";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { useAutoCleanupTempDirTracker } from "../../../../test/helpers/temp-dir.js";
 import {
   applyCodexAppServerAuthProfile,
   bridgeCodexAppServerStartOptions,
@@ -42,6 +43,8 @@ const providerRuntimeMocks = vi.hoisted(() => ({
     },
   ),
 }));
+
+const tempDirs = useAutoCleanupTempDirTracker(afterEach);
 
 vi.mock("openclaw/plugin-sdk/agent-runtime", async (importOriginal) => {
   const actual = await importOriginal<typeof import("openclaw/plugin-sdk/agent-runtime")>();
@@ -241,7 +244,7 @@ describe("bridgeCodexAppServerStartOptions", () => {
   });
 
   it("uses the native user Codex home for coexistence mode", async () => {
-    const root = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-codex-user-home-"));
+    const root = tempDirs.make("openclaw-codex-user-home-");
     const agentDir = path.join(root, "agent");
     const codexHome = path.join(root, "user-codex-home");
     vi.stubEnv("CODEX_HOME", codexHome);

--- a/extensions/codex/src/app-server/auth-bridge.test.ts
+++ b/extensions/codex/src/app-server/auth-bridge.test.ts
@@ -240,6 +240,26 @@ describe("bridgeCodexAppServerStartOptions", () => {
     }
   });
 
+  it("uses the native user Codex home for coexistence mode", async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-codex-user-home-"));
+    const agentDir = path.join(root, "agent");
+    const codexHome = path.join(root, "user-codex-home");
+    vi.stubEnv("CODEX_HOME", codexHome);
+    const startOptions = createStartOptions({ homeScope: "user" });
+    try {
+      await expect(
+        bridgeCodexAppServerStartOptions({ startOptions, agentDir, authProfileId: null }),
+      ).resolves.toEqual({
+        ...startOptions,
+        env: { CODEX_HOME: codexHome },
+      });
+      await expect(fs.access(codexHome)).resolves.toBeUndefined();
+      await expectPathMissing(resolveCodexAppServerHomeDir(agentDir));
+    } finally {
+      await fs.rm(root, { recursive: true, force: true });
+    }
+  });
+
   it("preserves inherited HOME when clearEnv asks to clear app-server isolation vars", async () => {
     const agentDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-codex-app-server-"));
     const startOptions = createStartOptions({

--- a/extensions/codex/src/app-server/auth-bridge.ts
+++ b/extensions/codex/src/app-server/auth-bridge.ts
@@ -21,7 +21,7 @@ import {
 } from "openclaw/plugin-sdk/agent-runtime";
 import { hasUsableOAuthCredential } from "openclaw/plugin-sdk/provider-auth";
 import type { CodexAppServerClient } from "./client.js";
-import type { CodexAppServerStartOptions } from "./config.js";
+import { resolveCodexAppServerUserHomeDir, type CodexAppServerStartOptions } from "./config.js";
 import type {
   CodexChatgptAuthTokensRefreshResponse,
   CodexGetAccountResponse,
@@ -65,12 +65,9 @@ export async function bridgeCodexAppServerStartOptions(params: {
   if (params.startOptions.transport !== "stdio") {
     return params.startOptions;
   }
-  const isolatedStartOptions = await withAgentCodexHomeEnvironment(
-    params.startOptions,
-    params.agentDir,
-  );
+  const scopedStartOptions = await withCodexHomeEnvironment(params.startOptions, params.agentDir);
   if (params.authProfileId === null) {
-    return isolatedStartOptions;
+    return scopedStartOptions;
   }
   const store = resolveCodexAppServerAuthProfileStore({
     agentDir: params.agentDir,
@@ -89,8 +86,8 @@ export async function bridgeCodexAppServerStartOptions(params: {
     config: params.config,
   });
   return shouldClearInheritedOpenAiApiKey
-    ? withClearedEnvironmentVariables(isolatedStartOptions, CODEX_APP_SERVER_API_KEY_ENV_VARS)
-    : isolatedStartOptions;
+    ? withClearedEnvironmentVariables(scopedStartOptions, CODEX_APP_SERVER_API_KEY_ENV_VARS)
+    : scopedStartOptions;
 }
 
 export function resolveCodexAppServerAuthProfileId(params: {
@@ -333,13 +330,15 @@ export function resolveCodexAppServerNativeHomeDir(agentDir: string): string {
   return path.join(resolveCodexAppServerHomeDir(agentDir), CODEX_APP_SERVER_NATIVE_HOME_DIRNAME);
 }
 
-async function withAgentCodexHomeEnvironment(
+async function withCodexHomeEnvironment(
   startOptions: CodexAppServerStartOptions,
   agentDir: string,
 ): Promise<CodexAppServerStartOptions> {
   const codexHome = startOptions.env?.[CODEX_HOME_ENV_VAR]?.trim()
     ? startOptions.env[CODEX_HOME_ENV_VAR]
-    : resolveCodexAppServerHomeDir(agentDir);
+    : startOptions.homeScope === "user"
+      ? resolveCodexAppServerUserHomeDir(process.env)
+      : resolveCodexAppServerHomeDir(agentDir);
   const nativeHome = startOptions.env?.[HOME_ENV_VAR]?.trim()
     ? startOptions.env[HOME_ENV_VAR]
     : undefined;

--- a/extensions/codex/src/app-server/capabilities.ts
+++ b/extensions/codex/src/app-server/capabilities.ts
@@ -8,12 +8,17 @@ export const CODEX_CONTROL_METHODS = {
   account: "account/read",
   compact: "thread/compact/start",
   feedback: "feedback/upload",
+  forkThread: "thread/fork",
   listMcpServers: "mcpServerStatus/list",
   listSkills: "skills/list",
   listThreads: "thread/list",
+  readThread: "thread/read",
   rateLimits: "account/rateLimits/read",
+  archiveThread: "thread/archive",
+  renameThread: "thread/name/set",
   resumeThread: "thread/resume",
   review: "review/start",
+  unarchiveThread: "thread/unarchive",
 } as const;
 
 type CodexControlName = keyof typeof CODEX_CONTROL_METHODS;

--- a/extensions/codex/src/app-server/config.test.ts
+++ b/extensions/codex/src/app-server/config.test.ts
@@ -1,10 +1,9 @@
 // Codex tests cover config plugin behavior.
 import fs from "node:fs/promises";
-import os from "node:os";
 import path from "node:path";
 import { MAX_TIMER_TIMEOUT_MS } from "openclaw/plugin-sdk/number-runtime";
-import { afterEach, describe, expect, it, vi } from "vitest";
-import { useAutoCleanupTempDirTracker } from "../../../../test/helpers/temp-dir.js";
+import { withTempDir } from "openclaw/plugin-sdk/test-env";
+import { describe, expect, it, vi } from "vitest";
 import {
   CODEX_APP_SERVER_CONFIG_KEYS,
   CODEX_APP_SERVER_EXPERIMENTAL_CONFIG_KEYS,
@@ -27,8 +26,6 @@ import {
 } from "./config.js";
 
 type RuntimeOptionsParams = NonNullable<Parameters<typeof resolveCodexAppServerRuntimeOptions>[0]>;
-
-const tempDirs = useAutoCleanupTempDirTracker(afterEach);
 
 function resolveRuntimeForTest(params: RuntimeOptionsParams = {}) {
   return resolveCodexAppServerRuntimeOptions({ env: {}, requirementsToml: null, ...params });
@@ -561,8 +558,7 @@ describe("Codex app-server config", () => {
   });
 
   it("checks shared user config before enabling model-backed approval review", async () => {
-    const codexHome = tempDirs.make("openclaw-codex-user-home-");
-    try {
+    await withTempDir("openclaw-codex-user-home-", async (codexHome) => {
       await fs.writeFile(
         path.join(codexHome, "config.toml"),
         'openai_base_url = "http://localhost:8080/v1"\n',
@@ -576,9 +572,7 @@ describe("Codex app-server config", () => {
           homeScope: "user",
         }),
       ).toBe(false);
-    } finally {
-      await fs.rm(codexHome, { recursive: true, force: true });
-    }
+    });
   });
 
   it("treats only explicit OpenAI model context as safe for Codex-backed auto-review", () => {

--- a/extensions/codex/src/app-server/config.test.ts
+++ b/extensions/codex/src/app-server/config.test.ts
@@ -3,7 +3,8 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { MAX_TIMER_TIMEOUT_MS } from "openclaw/plugin-sdk/number-runtime";
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { useAutoCleanupTempDirTracker } from "../../../../test/helpers/temp-dir.js";
 import {
   CODEX_APP_SERVER_CONFIG_KEYS,
   CODEX_APP_SERVER_EXPERIMENTAL_CONFIG_KEYS,
@@ -26,6 +27,8 @@ import {
 } from "./config.js";
 
 type RuntimeOptionsParams = NonNullable<Parameters<typeof resolveCodexAppServerRuntimeOptions>[0]>;
+
+const tempDirs = useAutoCleanupTempDirTracker(afterEach);
 
 function resolveRuntimeForTest(params: RuntimeOptionsParams = {}) {
   return resolveCodexAppServerRuntimeOptions({ env: {}, requirementsToml: null, ...params });
@@ -558,7 +561,7 @@ describe("Codex app-server config", () => {
   });
 
   it("checks shared user config before enabling model-backed approval review", async () => {
-    const codexHome = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-codex-user-home-"));
+    const codexHome = tempDirs.make("openclaw-codex-user-home-");
     try {
       await fs.writeFile(
         path.join(codexHome, "config.toml"),

--- a/extensions/codex/src/app-server/config.test.ts
+++ b/extensions/codex/src/app-server/config.test.ts
@@ -1,5 +1,7 @@
 // Codex tests cover config plugin behavior.
 import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
 import { MAX_TIMER_TIMEOUT_MS } from "openclaw/plugin-sdk/number-runtime";
 import { describe, expect, it, vi } from "vitest";
 import {
@@ -13,6 +15,7 @@ import {
   fingerprintCodexAppServerNetworkProxyConfigPatch,
   readCodexPluginConfig,
   resolveCodexAppServerRuntimeOptions,
+  resolveCodexAppServerUserHomeDir,
   resolveCodexComputerUseConfig,
   resolveCodexModelBackedReviewerPolicyContext,
   resolveOpenClawExecModeForCodexAppServer,
@@ -520,7 +523,59 @@ describe("Codex app-server config", () => {
     expectFields(runtime.start, "runtime start", {
       command: "codex",
       commandSource: "managed",
+      homeScope: "agent",
     });
+  });
+
+  it("resolves opt-in user-home coexistence only for local stdio", () => {
+    const runtime = resolveRuntimeForTest({
+      pluginConfig: { appServer: { homeScope: "user" } },
+    });
+
+    expect(runtime.start.homeScope).toBe("user");
+    expect(() =>
+      resolveRuntimeForTest({
+        pluginConfig: {
+          appServer: {
+            transport: "websocket",
+            url: "ws://127.0.0.1:39175",
+            homeScope: "user",
+          },
+        },
+      }),
+    ).toThrow(
+      "plugins.entries.codex.config.appServer.homeScope=user requires appServer.transport=stdio",
+    );
+  });
+
+  it("resolves the native user Codex home from CODEX_HOME or the OS home", () => {
+    expect(resolveCodexAppServerUserHomeDir({ CODEX_HOME: "/tmp/custom-codex" })).toBe(
+      "/tmp/custom-codex",
+    );
+    expect(resolveCodexAppServerUserHomeDir({}, () => "/Users/tester")).toBe(
+      "/Users/tester/.codex",
+    );
+  });
+
+  it("checks shared user config before enabling model-backed approval review", async () => {
+    const codexHome = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-codex-user-home-"));
+    try {
+      await fs.writeFile(
+        path.join(codexHome, "config.toml"),
+        'openai_base_url = "http://localhost:8080/v1"\n',
+      );
+
+      expect(
+        canUseCodexModelBackedApprovalsReviewerForModel({
+          modelProvider: "openai",
+          model: "gpt-5.5",
+          env: { CODEX_HOME: codexHome },
+          homeScope: "user",
+        }),
+      ).toBe(false);
+    } finally {
+      await fs.rm(codexHome, { recursive: true, force: true });
+    }
   });
 
   it("treats only explicit OpenAI model context as safe for Codex-backed auto-review", () => {
@@ -942,8 +997,8 @@ allowed_sandbox_modes = ["read-only", "workspace-write"]
       env: {},
       modelProvider: "openai",
       requirementsPath: "/custom/codex/requirements.toml",
-      readRequirementsFile: (path) => {
-        readPaths.push(path);
+      readRequirementsFile: (requirementsPath) => {
+        readPaths.push(requirementsPath);
         return 'allowed_sandbox_modes = ["read-only", "workspace-write"]\n';
       },
     });
@@ -963,8 +1018,8 @@ allowed_sandbox_modes = ["read-only", "workspace-write"]
       env: { ProgramData: "D:\\ManagedData" },
       modelProvider: "openai",
       platform: "win32",
-      readRequirementsFile: (path) => {
-        readPaths.push(path);
+      readRequirementsFile: (requirementsPath) => {
+        readPaths.push(requirementsPath);
         return 'allowed_sandbox_modes = ["read-only", "workspace-write"]\n';
       },
     });
@@ -1826,6 +1881,7 @@ allowed_sandbox_modes = ["read-only", "workspace-write"]
         commandSource: "config",
         args: ["app-server", "--listen", "stdio://"],
         headers: {},
+        homeScope: "agent",
       },
     });
   });

--- a/extensions/codex/src/app-server/config.ts
+++ b/extensions/codex/src/app-server/config.ts
@@ -1,7 +1,7 @@
 // Codex helper module supports config behavior.
 import { createHash, createHmac, randomBytes } from "node:crypto";
 import { readFileSync } from "node:fs";
-import { hostname as readHostName } from "node:os";
+import { homedir as readHomeDir, hostname as readHostName } from "node:os";
 import path from "node:path";
 import {
   resolveProviderIdForAuth,
@@ -32,6 +32,7 @@ const CODEX_CONFIG_TOML_FILENAME = "config.toml";
 const PLAIN_DECIMAL_NUMBER_RE = /^[+-]?(?:(?:\d+\.?\d*)|(?:\.\d+))$/;
 
 type CodexAppServerTransportMode = "stdio" | "websocket";
+export type CodexAppServerHomeScope = "agent" | "user";
 type CodexAppServerPolicyMode = "yolo" | "guardian";
 export type CodexAppServerConnectionClass = "local-loopback" | "remote";
 export type CodexAppServerRemoteAppsSubstrate = "preconfigured";
@@ -165,6 +166,7 @@ export type ResolvedCodexPluginsPolicy = {
 
 export type CodexAppServerStartOptions = {
   transport: CodexAppServerTransportMode;
+  homeScope?: CodexAppServerHomeScope;
   command: string;
   commandSource?: CodexAppServerCommandSource;
   managedFallbackCommandPaths?: string[];
@@ -200,6 +202,7 @@ export type CodexModelBackedReviewerContext = {
   env?: NodeJS.ProcessEnv;
   agentDir?: string;
   codexConfigToml?: string | null;
+  homeScope?: CodexAppServerHomeScope;
 };
 
 export type CodexPluginConfig = {
@@ -214,6 +217,7 @@ export type CodexPluginConfig = {
   appServer?: {
     mode?: CodexAppServerPolicyMode;
     transport?: CodexAppServerTransportMode;
+    homeScope?: CodexAppServerHomeScope;
     command?: string;
     args?: string[] | string;
     url?: string;
@@ -248,6 +252,7 @@ export function shouldAutoApproveCodexAppServerApprovals(
 export const CODEX_APP_SERVER_CONFIG_KEYS = [
   "mode",
   "transport",
+  "homeScope",
   "command",
   "args",
   "url",
@@ -300,6 +305,7 @@ const DEFAULT_CODEX_COMPUTER_USE_MARKETPLACE_DISCOVERY_TIMEOUT_MS = 60_000;
 const DEFAULT_CODEX_APP_SERVER_NETWORK_PROXY_PROFILE_PREFIX = "openclaw-network";
 
 const codexAppServerTransportSchema = z.enum(["stdio", "websocket"]);
+const codexAppServerHomeScopeSchema = z.enum(["agent", "user"]);
 const SecretInputSchema = buildSecretInputSchema();
 const codexAppServerPolicyModeSchema = z.enum(["yolo", "guardian"]);
 const codexAppServerApprovalPolicySchema = z.enum([
@@ -397,6 +403,7 @@ const codexPluginConfigSchema = z
       .object({
         mode: codexAppServerPolicyModeSchema.optional(),
         transport: codexAppServerTransportSchema.optional(),
+        homeScope: codexAppServerHomeScopeSchema.optional(),
         command: z.string().optional(),
         args: z.union([z.array(z.string()), z.string()]).optional(),
         url: z.string().optional(),
@@ -530,6 +537,7 @@ export function resolveCodexAppServerRuntimeOptions(
   const env = params.env ?? process.env;
   const config = readCodexPluginConfig(params.pluginConfig).appServer ?? {};
   const transport = resolveTransport(config.transport);
+  const homeScope: CodexAppServerHomeScope = config.homeScope === "user" ? "user" : "agent";
   const configCommand = readNonEmptyString(config.command);
   const envCommand = readNonEmptyString(env.OPENCLAW_CODEX_APP_SERVER_BIN);
   const command = configCommand ?? envCommand ?? "codex";
@@ -572,6 +580,7 @@ export function resolveCodexAppServerRuntimeOptions(
     env,
     agentDir: params.agentDir,
     codexConfigToml: params.codexConfigToml,
+    homeScope,
   });
   const explicitModelBackedReviewer =
     explicitApprovalsReviewer === "auto_review" ||
@@ -644,6 +653,11 @@ export function resolveCodexAppServerRuntimeOptions(
       "plugins.entries.codex.config.appServer.url is required when appServer.transport is websocket",
     );
   }
+  if (transport === "websocket" && homeScope === "user") {
+    throw new Error(
+      "plugins.entries.codex.config.appServer.homeScope=user requires appServer.transport=stdio",
+    );
+  }
   assertCodexAppServerConnectionClassConfig({
     connectionClass,
     authToken,
@@ -668,6 +682,7 @@ export function resolveCodexAppServerRuntimeOptions(
   return {
     start: {
       transport,
+      homeScope,
       command,
       commandSource,
       args: args.length > 0 ? args : ["app-server", "--listen", "stdio://"],
@@ -748,6 +763,7 @@ export function isTrustedCodexModelBackedOpenAIProvider(params: {
   model?: string;
   agentDir?: string;
   codexConfigToml?: string | null;
+  homeScope?: CodexAppServerHomeScope;
 }): boolean {
   if (!openAIBaseUrlEnvOverridesAreTrustedForModelBackedReview(params.env)) {
     return false;
@@ -1542,12 +1558,16 @@ function isTrustedCodexModelBackedApprovalsReviewerProvider(
       model: params.model,
       agentDir: params.agentDir,
       codexConfigToml: params.codexConfigToml,
+      homeScope: params.homeScope,
     })
   );
 }
 
 function readCodexBaseUrlOverridesForModelBackedReview(
-  params: Pick<CodexModelBackedReviewerContext, "agentDir" | "codexConfigToml">,
+  params: Pick<
+    CodexModelBackedReviewerContext,
+    "agentDir" | "codexConfigToml" | "env" | "homeScope"
+  >,
 ): { openAI: string[]; chatGPT: string[] } | false {
   const configToml = readCodexAppServerConfigToml(params);
   if (configToml === false) {
@@ -1577,7 +1597,10 @@ function readCodexBaseUrlOverridesForModelBackedReview(
 }
 
 function readCodexAppServerConfigToml(
-  params: Pick<CodexModelBackedReviewerContext, "agentDir" | "codexConfigToml">,
+  params: Pick<
+    CodexModelBackedReviewerContext,
+    "agentDir" | "codexConfigToml" | "env" | "homeScope"
+  >,
 ): string | undefined | false {
   if (params.codexConfigToml !== undefined) {
     return params.codexConfigToml ?? undefined;
@@ -1594,13 +1617,25 @@ function readCodexAppServerConfigToml(
 }
 
 function resolveCodexAppServerConfigPath(
-  params: Pick<CodexModelBackedReviewerContext, "agentDir">,
+  params: Pick<CodexModelBackedReviewerContext, "agentDir" | "env" | "homeScope">,
 ): string | undefined {
+  if (params.homeScope === "user") {
+    return path.join(resolveCodexAppServerUserHomeDir(params.env), CODEX_CONFIG_TOML_FILENAME);
+  }
   const agentDir = readNonEmptyString(params.agentDir);
   const codexHome = agentDir
     ? path.join(path.resolve(agentDir), CODEX_APP_SERVER_HOME_DIRNAME)
     : undefined;
   return codexHome ? path.join(codexHome, CODEX_CONFIG_TOML_FILENAME) : undefined;
+}
+
+/** Resolves the native user Codex home used by Desktop and the CLI. */
+export function resolveCodexAppServerUserHomeDir(
+  env: NodeJS.ProcessEnv = process.env,
+  homedir: () => string = readHomeDir,
+): string {
+  const configured = readNonEmptyString(env.CODEX_HOME);
+  return path.resolve(configured ?? path.join(homedir(), ".codex"));
 }
 
 function readErrorCode(error: unknown): string | undefined {

--- a/extensions/codex/src/app-server/dynamic-tool-build.test.ts
+++ b/extensions/codex/src/app-server/dynamic-tool-build.test.ts
@@ -939,6 +939,24 @@ describe("Codex app-server dynamic tool build", () => {
     );
   });
 
+  it("passes owner identity into Codex dynamic tool construction", async () => {
+    const sessionFile = path.join(tempDir, "session.jsonl");
+    const workspaceDir = path.join(tempDir, "workspace");
+    const params = createParams(sessionFile, workspaceDir);
+    params.disableTools = false;
+    params.senderIsOwner = true;
+    params.runtimePlan = createCodexRuntimePlanFixture();
+    const factoryOptions: unknown[] = [];
+    setOpenClawCodingToolsFactoryForTests((options) => {
+      factoryOptions.push(options);
+      return [];
+    });
+
+    await buildDynamicToolsForTest(params, workspaceDir, { sandbox: null as never });
+
+    expect(factoryOptions[0]).toMatchObject({ senderIsOwner: true });
+  });
+
   it("passes native and routable channel targets into Codex dynamic tools", async () => {
     const sessionFile = path.join(tempDir, "session.jsonl");
     const workspaceDir = path.join(tempDir, "workspace");

--- a/extensions/codex/src/app-server/dynamic-tool-build.ts
+++ b/extensions/codex/src/app-server/dynamic-tool-build.ts
@@ -252,6 +252,7 @@ export async function buildDynamicTools(input: DynamicToolBuildParams) {
     senderName: params.senderName,
     senderUsername: params.senderUsername,
     senderE164: params.senderE164,
+    senderIsOwner: params.senderIsOwner,
     allowGatewaySubagentBinding:
       params.allowGatewaySubagentBinding || isForcedPrivateQaCodexRuntime(),
     ...sessionKeys,

--- a/extensions/codex/src/app-server/protocol.ts
+++ b/extensions/codex/src/app-server/protocol.ts
@@ -159,6 +159,58 @@ export type CodexThreadForkParams = CodexThreadStartParams & {
 
 export type CodexThreadForkResponse = CodexThreadStartResponse;
 
+export const CODEX_INTERACTIVE_THREAD_SOURCE_KINDS = ["cli", "vscode"] as const;
+
+export type CodexThreadSourceKind =
+  | (typeof CODEX_INTERACTIVE_THREAD_SOURCE_KINDS)[number]
+  | "exec"
+  | "appServer"
+  | "subAgent"
+  | "subAgentReview"
+  | "subAgentCompact"
+  | "subAgentThreadSpawn"
+  | "subAgentOther"
+  | "unknown";
+
+export type CodexThreadListParams = JsonObject & {
+  cursor?: string | null;
+  limit?: number | null;
+  modelProviders?: string[] | null;
+  sortKey?: "created_at" | "updated_at" | "recency_at" | null;
+  sortDirection?: "asc" | "desc" | null;
+  archived?: boolean | null;
+  searchTerm?: string | null;
+  sourceKinds?: CodexThreadSourceKind[] | null;
+};
+
+export type CodexThreadListResponse = {
+  data: CodexThread[];
+  nextCursor?: string | null;
+  backwardsCursor?: string | null;
+};
+
+export type CodexThreadReadParams = JsonObject & {
+  threadId: string;
+  includeTurns?: boolean;
+};
+
+export type CodexThreadReadResponse = {
+  thread: CodexThread;
+};
+
+export type CodexThreadSetNameParams = JsonObject & {
+  threadId: string;
+  name: string;
+};
+
+export type CodexThreadArchiveParams = JsonObject & {
+  threadId: string;
+};
+
+export type CodexThreadUnarchiveResponse = {
+  thread: CodexThread;
+};
+
 export type CodexThreadResumeResponse = {
   thread: CodexThread;
   model: string;
@@ -229,6 +281,7 @@ export type CodexThread = {
   threadSource?: string | null;
   agentNickname?: string | null;
   agentRole?: string | null;
+  turns?: CodexTurn[];
 };
 
 export type CodexThreadStatus =
@@ -564,8 +617,13 @@ export declare namespace v2 {
 type CodexAppServerRequestParamsOverride = {
   "environment/add": { environmentId: string; execServerUrl: string };
   "thread/fork": CodexThreadForkParams;
+  "thread/archive": CodexThreadArchiveParams;
   "thread/inject_items": CodexThreadInjectItemsParams;
+  "thread/list": CodexThreadListParams;
+  "thread/name/set": CodexThreadSetNameParams;
+  "thread/read": CodexThreadReadParams;
   "thread/start": CodexThreadStartParams;
+  "thread/unarchive": CodexThreadArchiveParams;
   "thread/unsubscribe": CodexThreadUnsubscribeParams;
   "turn/interrupt": CodexTurnInterruptParams;
 };
@@ -592,11 +650,15 @@ type CodexAppServerRequestResultMap = {
   "review/start": JsonValue;
   "skills/list": CodexSkillsListResponse;
   "thread/compact/start": JsonValue;
+  "thread/archive": JsonValue;
   "thread/fork": CodexThreadForkResponse;
   "thread/inject_items": JsonValue;
-  "thread/list": JsonValue;
+  "thread/list": CodexThreadListResponse;
+  "thread/name/set": JsonValue;
+  "thread/read": CodexThreadReadResponse;
   "thread/resume": CodexThreadResumeResponse;
   "thread/start": CodexThreadStartResponse;
+  "thread/unarchive": CodexThreadUnarchiveResponse;
   "thread/unsubscribe": JsonValue;
   "turn/interrupt": JsonValue;
   "turn/start": CodexTurnStartResponse;

--- a/extensions/codex/src/app-server/request.test.ts
+++ b/extensions/codex/src/app-server/request.test.ts
@@ -68,6 +68,27 @@ describe("requestCodexAppServerJson sandbox guard", () => {
     expect(request).toHaveBeenCalledWith("thread/list", { limit: 10 }, { timeoutMs: 60_000 });
   });
 
+  it("allows current native thread management methods in sandboxed sessions", async () => {
+    const request = vi.fn(async () => ({ ok: true }));
+    sharedClientMocks.getSharedCodexAppServerClient.mockResolvedValue({ request });
+
+    for (const method of ["thread/name/set", "thread/archive", "thread/unarchive"] as const) {
+      await expect(
+        requestCodexAppServerJson({
+          method,
+          requestParams:
+            method === "thread/name/set"
+              ? { threadId: "thread-1", name: "Shared thread" }
+              : { threadId: "thread-1" },
+          config: { agents: { defaults: { sandbox: { mode: "all" } } } },
+          sessionKey: "sandboxed-session",
+        }),
+      ).resolves.toEqual({ ok: true });
+    }
+
+    expect(request).toHaveBeenCalledTimes(3);
+  });
+
   it("fails closed for config-level exec host=node even without a session key", async () => {
     await expect(
       requestCodexAppServerJson({

--- a/extensions/codex/src/app-server/sandbox-guard.ts
+++ b/extensions/codex/src/app-server/sandbox-guard.ts
@@ -37,7 +37,7 @@ const DIRECT_METHOD_POLICIES = new Map<string, DirectMethodPolicy>([
   ["thread/inject_items", "allowed-control-plane"],
   ["thread/list", "allowed-control-plane"],
   ["thread/metadata/update", "allowed-control-plane"],
-  ["thread/name/update", "allowed-control-plane"],
+  ["thread/name/set", "allowed-control-plane"],
   ["thread/read", "allowed-control-plane"],
   ["thread/rollback", "allowed-control-plane"],
   ["thread/start", "requires-openclaw-environment"],

--- a/extensions/codex/src/app-server/session-history.test.ts
+++ b/extensions/codex/src/app-server/session-history.test.ts
@@ -32,6 +32,9 @@ async function writeSession(records: unknown[]): Promise<string> {
   return sessionFile;
 }
 
+// Fixtures keep legacy string content on purpose: session ingest normalizes
+// assistant strings into [{ type: "text" }] blocks, so expectations below
+// assert the canonical block-array shape for assistant rows.
 function messageEntry(params: {
   id: string;
   parentId: string | null;
@@ -87,7 +90,7 @@ describe("readCodexMirroredSessionHistoryMessages", () => {
       readCodexMirroredSessionHistoryMessages(mirroredTarget(sessionFile)),
     ).resolves.toMatchObject([
       { role: "user", content: "root prompt" },
-      { role: "assistant", content: "active answer" },
+      { role: "assistant", content: [{ type: "text", text: "active answer" }] },
     ]);
   });
 
@@ -141,7 +144,7 @@ describe("readCodexMirroredSessionHistoryMessages", () => {
       readCodexMirroredSessionHistoryMessages(mirroredTarget(sessionFile)),
     ).resolves.toMatchObject([
       { role: "user", content: "visible prompt" },
-      { role: "assistant", content: "continued answer" },
+      { role: "assistant", content: [{ type: "text", text: "continued answer" }] },
     ]);
   });
 
@@ -172,7 +175,7 @@ describe("readCodexMirroredSessionHistoryMessages", () => {
       readCodexMirroredSessionHistoryMessages(mirroredTarget(sessionFile)),
     ).resolves.toMatchObject([
       { role: "user", content: "visible prompt" },
-      { role: "assistant", content: "continued answer" },
+      { role: "assistant", content: [{ type: "text", text: "continued answer" }] },
     ]);
   });
 });

--- a/extensions/codex/src/app-server/shared-client.test.ts
+++ b/extensions/codex/src/app-server/shared-client.test.ts
@@ -407,6 +407,29 @@ describe("shared Codex app-server client", () => {
     expect(applyCall.config).toBe(config);
   });
 
+  it("uses native auth automatically for shared user-home clients", async () => {
+    const harness = createClientHarness();
+    vi.spyOn(CodexAppServerClient, "start").mockReturnValue(harness.client);
+
+    const clientPromise = createIsolatedCodexAppServerClient({
+      timeoutMs: 1000,
+      authProfileId: "openai:target",
+      startOptions: {
+        transport: "stdio",
+        homeScope: "user",
+        command: "codex",
+        args: ["app-server"],
+        headers: {},
+      },
+    });
+    await sendInitializeResult(harness, "openclaw/0.125.0 (macOS; test)");
+
+    await expect(clientPromise).resolves.toBe(harness.client);
+    expect(mocks.resolveCodexAppServerAuthProfileIdForAgent).not.toHaveBeenCalled();
+    expect(bridgeStartOptionsCall().authProfileId).toBeNull();
+    expect(applyAuthProfileCall().authProfileId).toBeNull();
+  });
+
   it("resolves the configured implicit auth profile before sharing a client", async () => {
     const harness = createClientHarness();
     vi.spyOn(CodexAppServerClient, "start").mockReturnValue(harness.client);

--- a/extensions/codex/src/app-server/shared-client.ts
+++ b/extensions/codex/src/app-server/shared-client.ts
@@ -131,7 +131,10 @@ async function resolveCodexAppServerClientStartContext(
   options?: IsolatedCodexAppServerClientOptions,
 ): Promise<ResolvedCodexAppServerClientStartContext> {
   const agentDir = options?.agentDir ?? resolveDefaultAgentDir(options?.config ?? {});
-  const usesNativeAuth = options?.authProfileId === null;
+  const requestedStartOptions =
+    options?.startOptions ?? resolveCodexAppServerRuntimeOptions().start;
+  const usesNativeAuth =
+    options?.authProfileId === null || requestedStartOptions.homeScope === "user";
   const requestedAuthProfileId =
     options?.authProfileId === null ? undefined : options?.authProfileId;
   const authProfileStore =
@@ -151,8 +154,6 @@ async function resolveCodexAppServerClientStartContext(
         config: options?.config,
         ...(authProfileStore ? { authProfileStore } : {}),
       });
-  const requestedStartOptions =
-    options?.startOptions ?? resolveCodexAppServerRuntimeOptions().start;
   const managedStartOptions = await resolveManagedCodexAppServerStartOptions(requestedStartOptions);
   const startOptions = await bridgeCodexAppServerStartOptions({
     startOptions: managedStartOptions,

--- a/extensions/codex/src/command-rpc.ts
+++ b/extensions/codex/src/command-rpc.ts
@@ -63,7 +63,7 @@ export async function codexControlRequest(
   method: CodexControlMethod,
   requestParams?: unknown,
   options: CodexControlRequestOptions = {},
-) {
+): Promise<unknown> {
   const runtime = resolveCodexAppServerRuntimeOptions({ pluginConfig });
   return await requestCodexAppServerJson({
     method,
@@ -96,7 +96,7 @@ export async function safeCodexControlRequest(
   method: CodexControlMethod,
   requestParams?: unknown,
   options: CodexControlRequestOptions = {},
-) {
+): Promise<SafeValue<unknown>> {
   return await safeValue(
     async () =>
       await codexControlRequest(pluginConfig, method, requestParams as JsonValue, options),

--- a/extensions/codex/src/native-thread-coexistence.live.test.ts
+++ b/extensions/codex/src/native-thread-coexistence.live.test.ts
@@ -1,8 +1,8 @@
 import fs from "node:fs/promises";
-import os from "node:os";
 import path from "node:path";
 import { setTimeout as delay } from "node:timers/promises";
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it } from "vitest";
+import { useAutoCleanupTempDirTracker } from "../../../test/helpers/temp-dir.js";
 import type { CodexAppServerClient } from "./app-server/client.js";
 import { resolveCodexAppServerRuntimeOptions } from "./app-server/config.js";
 import { CODEX_INTERACTIVE_THREAD_SOURCE_KINDS } from "./app-server/protocol.js";
@@ -12,6 +12,7 @@ const LIVE =
   process.env.OPENCLAW_LIVE_TEST === "1" &&
   process.env.OPENCLAW_LIVE_CODEX_THREAD_COEXISTENCE === "1";
 const describeLive = LIVE ? describe : describe.skip;
+const tempDirs = useAutoCleanupTempDirTracker(afterEach);
 
 async function withClient<T>(
   options: Parameters<typeof createIsolatedCodexAppServerClient>[0],
@@ -27,7 +28,7 @@ async function withClient<T>(
 
 describeLive("native Codex thread coexistence", () => {
   it("shares thread storage across independent app-server processes", async () => {
-    const root = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-codex-coexistence-"));
+    const root = tempDirs.make("openclaw-codex-coexistence-");
     const codexHome = path.join(root, "codex-home");
     const agentDir = path.join(root, "agent");
     const workspace = path.join(root, "workspace");

--- a/extensions/codex/src/native-thread-coexistence.live.test.ts
+++ b/extensions/codex/src/native-thread-coexistence.live.test.ts
@@ -1,8 +1,8 @@
 import fs from "node:fs/promises";
 import path from "node:path";
 import { setTimeout as delay } from "node:timers/promises";
-import { afterEach, describe, expect, it } from "vitest";
-import { useAutoCleanupTempDirTracker } from "../../../test/helpers/temp-dir.js";
+import { withTempDir } from "openclaw/plugin-sdk/test-env";
+import { describe, expect, it } from "vitest";
 import type { CodexAppServerClient } from "./app-server/client.js";
 import { resolveCodexAppServerRuntimeOptions } from "./app-server/config.js";
 import { CODEX_INTERACTIVE_THREAD_SOURCE_KINDS } from "./app-server/protocol.js";
@@ -12,7 +12,6 @@ const LIVE =
   process.env.OPENCLAW_LIVE_TEST === "1" &&
   process.env.OPENCLAW_LIVE_CODEX_THREAD_COEXISTENCE === "1";
 const describeLive = LIVE ? describe : describe.skip;
-const tempDirs = useAutoCleanupTempDirTracker(afterEach);
 
 async function withClient<T>(
   options: Parameters<typeof createIsolatedCodexAppServerClient>[0],
@@ -28,101 +27,158 @@ async function withClient<T>(
 
 describeLive("native Codex thread coexistence", () => {
   it("shares thread storage across independent app-server processes", async () => {
-    const root = tempDirs.make("openclaw-codex-coexistence-");
-    const codexHome = path.join(root, "codex-home");
-    const agentDir = path.join(root, "agent");
-    const workspace = path.join(root, "workspace");
-    await fs.mkdir(workspace, { recursive: true });
-    const runtime = resolveCodexAppServerRuntimeOptions({
-      pluginConfig: { appServer: { homeScope: "user" } },
-      env: {},
-    });
-    const startOptions = {
-      ...runtime.start,
-      env: { CODEX_HOME: codexHome },
-      clearEnv: ["CODEX_API_KEY", "OPENAI_API_KEY"],
-    };
-    const clientOptions = {
-      startOptions,
-      agentDir,
-      authProfileId: null,
-      timeoutMs: 60_000,
-    };
+    await withTempDir("openclaw-codex-coexistence-", async (root) => {
+      try {
+        const codexHome = path.join(root, "codex-home");
+        const agentDir = path.join(root, "agent");
+        const workspace = path.join(root, "workspace");
+        await fs.mkdir(workspace, { recursive: true });
+        const runtime = resolveCodexAppServerRuntimeOptions({
+          pluginConfig: { appServer: { homeScope: "user" } },
+          env: {},
+        });
+        const startOptions = {
+          ...runtime.start,
+          env: { CODEX_HOME: codexHome },
+          clearEnv: ["CODEX_API_KEY", "OPENAI_API_KEY"],
+        };
+        const clientOptions = {
+          startOptions,
+          agentDir,
+          authProfileId: null,
+          timeoutMs: 60_000,
+        };
 
-    try {
-      const started = await withClient(clientOptions, async (first) => {
-        const response = await first.request(
-          "thread/start",
-          {
-            cwd: workspace,
-            approvalPolicy: "never",
-            sandbox: "danger-full-access",
-            threadSource: "user",
-          },
-          { timeoutMs: 60_000 },
-        );
-        const turn = await first.request(
-          "turn/start",
-          {
-            threadId: response.thread.id,
-            input: [{ type: "text", text: "Cross-client visibility probe" }],
-          },
-          { timeoutMs: 60_000 },
-        );
-        let materialized = false;
-        for (let attempt = 0; attempt < 50; attempt += 1) {
-          const listed = await first.request(
-            "thread/list",
+        const started = await withClient(clientOptions, async (first) => {
+          const response = await first.request(
+            "thread/start",
             {
-              archived: false,
-              limit: 100,
-              modelProviders: [],
-              sortKey: "recency_at",
-              sortDirection: "desc",
-              sourceKinds: [...CODEX_INTERACTIVE_THREAD_SOURCE_KINDS],
+              cwd: workspace,
+              approvalPolicy: "never",
+              sandbox: "danger-full-access",
+              threadSource: "user",
             },
             { timeoutMs: 60_000 },
           );
-          materialized = listed.data.some((thread) => thread.id === response.thread.id);
-          if (materialized) {
-            break;
+          const turn = await first.request(
+            "turn/start",
+            {
+              threadId: response.thread.id,
+              input: [{ type: "text", text: "Cross-client visibility probe" }],
+            },
+            { timeoutMs: 60_000 },
+          );
+          let materialized = false;
+          for (let attempt = 0; attempt < 50; attempt += 1) {
+            const listed = await first.request(
+              "thread/list",
+              {
+                archived: false,
+                limit: 100,
+                modelProviders: [],
+                sortKey: "recency_at",
+                sortDirection: "desc",
+                sourceKinds: [...CODEX_INTERACTIVE_THREAD_SOURCE_KINDS],
+              },
+              { timeoutMs: 60_000 },
+            );
+            materialized = listed.data.some((thread) => thread.id === response.thread.id);
+            if (materialized) {
+              break;
+            }
+            await delay(100);
           }
-          await delay(100);
-        }
-        if (!materialized) {
-          throw new Error("user turn did not materialize shared thread");
-        }
-        try {
+          if (!materialized) {
+            throw new Error("user turn did not materialize shared thread");
+          }
+          try {
+            await first.request(
+              "turn/interrupt",
+              { threadId: response.thread.id, turnId: turn.turn.id },
+              { timeoutMs: 60_000 },
+            );
+          } catch (error) {
+            if (
+              !(error instanceof Error) ||
+              !error.message.includes("no active turn to interrupt")
+            ) {
+              throw error;
+            }
+          }
           await first.request(
-            "turn/interrupt",
-            { threadId: response.thread.id, turnId: turn.turn.id },
+            "thread/name/set",
+            { threadId: response.thread.id, name: "OpenClaw coexistence source" },
             { timeoutMs: 60_000 },
           );
-        } catch (error) {
-          if (!(error instanceof Error) || !error.message.includes("no active turn to interrupt")) {
-            throw error;
+          return response;
+        });
+
+        const forked = await withClient(clientOptions, async (second) => {
+          const read = await second.request(
+            "thread/read",
+            { threadId: started.thread.id, includeTurns: true },
+            { timeoutMs: 60_000 },
+          );
+          expect(read.thread.id).toBe(started.thread.id);
+
+          let listedSource;
+          let listedThreads: Array<{ id: string; source?: unknown }> = [];
+          for (let attempt = 0; attempt < 50; attempt += 1) {
+            const listed = await second.request(
+              "thread/list",
+              {
+                archived: false,
+                limit: 100,
+                modelProviders: [],
+                sortKey: "recency_at",
+                sortDirection: "desc",
+                sourceKinds: [...CODEX_INTERACTIVE_THREAD_SOURCE_KINDS],
+              },
+              { timeoutMs: 60_000 },
+            );
+            listedThreads = listed.data;
+            listedSource = listed.data.find((thread) => thread.id === started.thread.id);
+            if (listedSource) {
+              break;
+            }
+            await delay(100);
           }
-        }
-        await first.request(
-          "thread/name/set",
-          { threadId: response.thread.id, name: "OpenClaw coexistence source" },
-          { timeoutMs: 60_000 },
-        );
-        return response;
-      });
+          if (!listedSource) {
+            throw new Error(
+              `shared thread missing from list: ${JSON.stringify({
+                threadId: started.thread.id,
+                readSource: read.thread.source,
+                listed: listedThreads.map((thread) => ({ id: thread.id, source: thread.source })),
+              })}`,
+            );
+          }
 
-      const forked = await withClient(clientOptions, async (second) => {
-        const read = await second.request(
-          "thread/read",
-          { threadId: started.thread.id, includeTurns: true },
-          { timeoutMs: 60_000 },
-        );
-        expect(read.thread.id).toBe(started.thread.id);
+          const response = await second.request(
+            "thread/fork",
+            { threadId: started.thread.id, threadSource: "user" },
+            { timeoutMs: 60_000 },
+          );
+          expect(response.thread.id).not.toBe(started.thread.id);
+          await second.request(
+            "thread/name/set",
+            { threadId: response.thread.id, name: "OpenClaw coexistence fork" },
+            { timeoutMs: 60_000 },
+          );
+          await second.request(
+            "thread/archive",
+            { threadId: response.thread.id },
+            { timeoutMs: 60_000 },
+          );
+          await second.request(
+            "thread/unarchive",
+            { threadId: response.thread.id },
+            { timeoutMs: 60_000 },
+          );
+          return response;
+        });
 
-        let listedSource;
-        let listedThreads: Array<{ id: string; source?: unknown }> = [];
-        for (let attempt = 0; attempt < 50; attempt += 1) {
-          const listed = await second.request(
+        await withClient(clientOptions, async (third) => {
+          const finalList = await third.request(
             "thread/list",
             {
               archived: false,
@@ -134,71 +190,18 @@ describeLive("native Codex thread coexistence", () => {
             },
             { timeoutMs: 60_000 },
           );
-          listedThreads = listed.data;
-          listedSource = listed.data.find((thread) => thread.id === started.thread.id);
-          if (listedSource) {
-            break;
-          }
-          await delay(100);
-        }
-        if (!listedSource) {
-          throw new Error(
-            `shared thread missing from list: ${JSON.stringify({
-              threadId: started.thread.id,
-              readSource: read.thread.source,
-              listed: listedThreads.map((thread) => ({ id: thread.id, source: thread.source })),
-            })}`,
+          expect(finalList.data).toEqual(
+            expect.arrayContaining([
+              expect.objectContaining({
+                id: forked.thread.id,
+                name: "OpenClaw coexistence fork",
+              }),
+            ]),
           );
-        }
-
-        const response = await second.request(
-          "thread/fork",
-          { threadId: started.thread.id, threadSource: "user" },
-          { timeoutMs: 60_000 },
-        );
-        expect(response.thread.id).not.toBe(started.thread.id);
-        await second.request(
-          "thread/name/set",
-          { threadId: response.thread.id, name: "OpenClaw coexistence fork" },
-          { timeoutMs: 60_000 },
-        );
-        await second.request(
-          "thread/archive",
-          { threadId: response.thread.id },
-          { timeoutMs: 60_000 },
-        );
-        await second.request(
-          "thread/unarchive",
-          { threadId: response.thread.id },
-          { timeoutMs: 60_000 },
-        );
-        return response;
-      });
-
-      await withClient(clientOptions, async (third) => {
-        const finalList = await third.request(
-          "thread/list",
-          {
-            archived: false,
-            limit: 100,
-            modelProviders: [],
-            sortKey: "recency_at",
-            sortDirection: "desc",
-            sourceKinds: [...CODEX_INTERACTIVE_THREAD_SOURCE_KINDS],
-          },
-          { timeoutMs: 60_000 },
-        );
-        expect(finalList.data).toEqual(
-          expect.arrayContaining([
-            expect.objectContaining({
-              id: forked.thread.id,
-              name: "OpenClaw coexistence fork",
-            }),
-          ]),
-        );
-      });
-    } finally {
-      await fs.rm(root, { recursive: true, force: true, maxRetries: 20, retryDelay: 100 });
-    }
+        });
+      } finally {
+        await fs.rm(root, { recursive: true, force: true, maxRetries: 20, retryDelay: 100 });
+      }
+    });
   }, 120_000);
 });

--- a/extensions/codex/src/native-thread-coexistence.live.test.ts
+++ b/extensions/codex/src/native-thread-coexistence.live.test.ts
@@ -1,0 +1,203 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { setTimeout as delay } from "node:timers/promises";
+import { describe, expect, it } from "vitest";
+import type { CodexAppServerClient } from "./app-server/client.js";
+import { resolveCodexAppServerRuntimeOptions } from "./app-server/config.js";
+import { CODEX_INTERACTIVE_THREAD_SOURCE_KINDS } from "./app-server/protocol.js";
+import { createIsolatedCodexAppServerClient } from "./app-server/shared-client.js";
+
+const LIVE =
+  process.env.OPENCLAW_LIVE_TEST === "1" &&
+  process.env.OPENCLAW_LIVE_CODEX_THREAD_COEXISTENCE === "1";
+const describeLive = LIVE ? describe : describe.skip;
+
+async function withClient<T>(
+  options: Parameters<typeof createIsolatedCodexAppServerClient>[0],
+  run: (client: CodexAppServerClient) => Promise<T>,
+): Promise<T> {
+  const client = await createIsolatedCodexAppServerClient(options);
+  try {
+    return await run(client);
+  } finally {
+    await client.closeAndWait();
+  }
+}
+
+describeLive("native Codex thread coexistence", () => {
+  it("shares thread storage across independent app-server processes", async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-codex-coexistence-"));
+    const codexHome = path.join(root, "codex-home");
+    const agentDir = path.join(root, "agent");
+    const workspace = path.join(root, "workspace");
+    await fs.mkdir(workspace, { recursive: true });
+    const runtime = resolveCodexAppServerRuntimeOptions({
+      pluginConfig: { appServer: { homeScope: "user" } },
+      env: {},
+    });
+    const startOptions = {
+      ...runtime.start,
+      env: { CODEX_HOME: codexHome },
+      clearEnv: ["CODEX_API_KEY", "OPENAI_API_KEY"],
+    };
+    const clientOptions = {
+      startOptions,
+      agentDir,
+      authProfileId: null,
+      timeoutMs: 60_000,
+    };
+
+    try {
+      const started = await withClient(clientOptions, async (first) => {
+        const response = await first.request(
+          "thread/start",
+          {
+            cwd: workspace,
+            approvalPolicy: "never",
+            sandbox: "danger-full-access",
+            threadSource: "user",
+          },
+          { timeoutMs: 60_000 },
+        );
+        const turn = await first.request(
+          "turn/start",
+          {
+            threadId: response.thread.id,
+            input: [{ type: "text", text: "Cross-client visibility probe" }],
+          },
+          { timeoutMs: 60_000 },
+        );
+        let materialized = false;
+        for (let attempt = 0; attempt < 50; attempt += 1) {
+          const listed = await first.request(
+            "thread/list",
+            {
+              archived: false,
+              limit: 100,
+              modelProviders: [],
+              sortKey: "recency_at",
+              sortDirection: "desc",
+              sourceKinds: [...CODEX_INTERACTIVE_THREAD_SOURCE_KINDS],
+            },
+            { timeoutMs: 60_000 },
+          );
+          materialized = listed.data.some((thread) => thread.id === response.thread.id);
+          if (materialized) {
+            break;
+          }
+          await delay(100);
+        }
+        if (!materialized) {
+          throw new Error("user turn did not materialize shared thread");
+        }
+        try {
+          await first.request(
+            "turn/interrupt",
+            { threadId: response.thread.id, turnId: turn.turn.id },
+            { timeoutMs: 60_000 },
+          );
+        } catch (error) {
+          if (!(error instanceof Error) || !error.message.includes("no active turn to interrupt")) {
+            throw error;
+          }
+        }
+        await first.request(
+          "thread/name/set",
+          { threadId: response.thread.id, name: "OpenClaw coexistence source" },
+          { timeoutMs: 60_000 },
+        );
+        return response;
+      });
+
+      const forked = await withClient(clientOptions, async (second) => {
+        const read = await second.request(
+          "thread/read",
+          { threadId: started.thread.id, includeTurns: true },
+          { timeoutMs: 60_000 },
+        );
+        expect(read.thread.id).toBe(started.thread.id);
+
+        let listedSource;
+        let listedThreads: Array<{ id: string; source?: unknown }> = [];
+        for (let attempt = 0; attempt < 50; attempt += 1) {
+          const listed = await second.request(
+            "thread/list",
+            {
+              archived: false,
+              limit: 100,
+              modelProviders: [],
+              sortKey: "recency_at",
+              sortDirection: "desc",
+              sourceKinds: [...CODEX_INTERACTIVE_THREAD_SOURCE_KINDS],
+            },
+            { timeoutMs: 60_000 },
+          );
+          listedThreads = listed.data;
+          listedSource = listed.data.find((thread) => thread.id === started.thread.id);
+          if (listedSource) {
+            break;
+          }
+          await delay(100);
+        }
+        if (!listedSource) {
+          throw new Error(
+            `shared thread missing from list: ${JSON.stringify({
+              threadId: started.thread.id,
+              readSource: read.thread.source,
+              listed: listedThreads.map((thread) => ({ id: thread.id, source: thread.source })),
+            })}`,
+          );
+        }
+
+        const response = await second.request(
+          "thread/fork",
+          { threadId: started.thread.id, threadSource: "user" },
+          { timeoutMs: 60_000 },
+        );
+        expect(response.thread.id).not.toBe(started.thread.id);
+        await second.request(
+          "thread/name/set",
+          { threadId: response.thread.id, name: "OpenClaw coexistence fork" },
+          { timeoutMs: 60_000 },
+        );
+        await second.request(
+          "thread/archive",
+          { threadId: response.thread.id },
+          { timeoutMs: 60_000 },
+        );
+        await second.request(
+          "thread/unarchive",
+          { threadId: response.thread.id },
+          { timeoutMs: 60_000 },
+        );
+        return response;
+      });
+
+      await withClient(clientOptions, async (third) => {
+        const finalList = await third.request(
+          "thread/list",
+          {
+            archived: false,
+            limit: 100,
+            modelProviders: [],
+            sortKey: "recency_at",
+            sortDirection: "desc",
+            sourceKinds: [...CODEX_INTERACTIVE_THREAD_SOURCE_KINDS],
+          },
+          { timeoutMs: 60_000 },
+        );
+        expect(finalList.data).toEqual(
+          expect.arrayContaining([
+            expect.objectContaining({
+              id: forked.thread.id,
+              name: "OpenClaw coexistence fork",
+            }),
+          ]),
+        );
+      });
+    } finally {
+      await fs.rm(root, { recursive: true, force: true, maxRetries: 20, retryDelay: 100 });
+    }
+  }, 120_000);
+});

--- a/extensions/codex/src/native-thread-tool.test.ts
+++ b/extensions/codex/src/native-thread-tool.test.ts
@@ -2,8 +2,8 @@ import fs from "node:fs/promises";
 import path from "node:path";
 import type { OpenClawPluginToolContext } from "openclaw/plugin-sdk/plugin-entry";
 import { createPluginRuntimeMock } from "openclaw/plugin-sdk/plugin-test-runtime";
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { useAutoCleanupTempDirTracker } from "../../../test/helpers/temp-dir.js";
+import { withTempDir } from "openclaw/plugin-sdk/test-env";
+import { describe, expect, it, vi } from "vitest";
 import { CODEX_CONTROL_METHODS } from "./app-server/capabilities.js";
 import { CODEX_INTERACTIVE_THREAD_SOURCE_KINDS } from "./app-server/protocol.js";
 import {
@@ -13,22 +13,19 @@ import {
 } from "./app-server/session-binding.js";
 import { createCodexThreadsTool } from "./native-thread-tool.js";
 
-const tempDirs = useAutoCleanupTempDirTracker(afterEach);
-
 describe("native Codex thread tool", () => {
   let root: string;
   let sessionFile: string;
 
-  beforeEach(async () => {
-    root = tempDirs.make("openclaw-codex-threads-");
-    sessionFile = path.join(root, "sessions", "session-id.jsonl");
-    await fs.mkdir(path.dirname(sessionFile), { recursive: true });
-    await fs.writeFile(sessionFile, "");
-  });
-
-  afterEach(async () => {
-    await fs.rm(root, { recursive: true, force: true });
-  });
+  async function withFixture(run: () => void | Promise<void>): Promise<void> {
+    await withTempDir("openclaw-codex-threads-", async (tempRoot) => {
+      root = tempRoot;
+      sessionFile = path.join(root, "sessions", "session-id.jsonl");
+      await fs.mkdir(path.dirname(sessionFile), { recursive: true });
+      await fs.writeFile(sessionFile, "");
+      await run();
+    });
+  }
 
   function createTool(params?: {
     owner?: boolean;
@@ -61,137 +58,142 @@ describe("native Codex thread tool", () => {
     });
   }
 
-  it("materializes only for owner turns in shared user-home mode", () => {
-    expect(createTool()).not.toBeNull();
-    expect(createTool({ owner: false })).toBeNull();
-    expect(createTool({ homeScope: "agent" })).toBeNull();
-  });
+  it("materializes only for owner turns in shared user-home mode", () =>
+    withFixture(() => {
+      expect(createTool()).not.toBeNull();
+      expect(createTool({ owner: false })).toBeNull();
+      expect(createTool({ homeScope: "agent" })).toBeNull();
+    }));
 
-  it("lists native threads with bounded deterministic parameters", async () => {
-    const response = { data: [{ id: "thread-1", status: { type: "idle" } }] };
-    const request = vi.fn(async () => response);
-    const tool = createTool({ request });
+  it("lists native threads with bounded deterministic parameters", () =>
+    withFixture(async () => {
+      const response = { data: [{ id: "thread-1", status: { type: "idle" } }] };
+      const request = vi.fn(async () => response);
+      const tool = createTool({ request });
 
-    const result = await tool?.execute("call-1", {
-      action: "list",
-      archived: true,
-      cursor: "next-page",
-      limit: 12,
-      search: "coexistence",
-    });
-
-    expect(request).toHaveBeenCalledWith(
-      { appServer: { homeScope: "user" } },
-      CODEX_CONTROL_METHODS.listThreads,
-      {
+      const result = await tool?.execute("call-1", {
+        action: "list",
         archived: true,
         cursor: "next-page",
         limit: 12,
-        modelProviders: [],
-        searchTerm: "coexistence",
-        sortKey: "recency_at",
-        sortDirection: "desc",
-        sourceKinds: [...CODEX_INTERACTIVE_THREAD_SOURCE_KINDS],
-      },
-      expect.objectContaining({
-        sessionId: "session-id",
-        sessionKey: "agent:main:telegram:direct:owner",
-      }),
-    );
-    expect(result?.details).toEqual(response);
-  });
+        search: "coexistence",
+      });
 
-  it("forks a native thread and attaches the fork to the OpenClaw session", async () => {
-    const request = vi.fn(async () => ({
-      thread: { id: "forked-thread", cwd: "/tmp/project", status: { type: "idle" } },
-      model: "gpt-5.5",
-      modelProvider: "openai",
+      expect(request).toHaveBeenCalledWith(
+        { appServer: { homeScope: "user" } },
+        CODEX_CONTROL_METHODS.listThreads,
+        {
+          archived: true,
+          cursor: "next-page",
+          limit: 12,
+          modelProviders: [],
+          searchTerm: "coexistence",
+          sortKey: "recency_at",
+          sortDirection: "desc",
+          sourceKinds: [...CODEX_INTERACTIVE_THREAD_SOURCE_KINDS],
+        },
+        expect.objectContaining({
+          sessionId: "session-id",
+          sessionKey: "agent:main:telegram:direct:owner",
+        }),
+      );
+      expect(result?.details).toEqual(response);
     }));
-    const tool = createTool({ request });
 
-    const result = await tool?.execute("call-2", {
-      action: "fork",
-      thread_id: "source-thread",
-    });
+  it("forks a native thread and attaches the fork to the OpenClaw session", () =>
+    withFixture(async () => {
+      const request = vi.fn(async () => ({
+        thread: { id: "forked-thread", cwd: "/tmp/project", status: { type: "idle" } },
+        model: "gpt-5.5",
+        modelProvider: "openai",
+      }));
+      const tool = createTool({ request });
 
-    expect(request).toHaveBeenCalledWith(
-      { appServer: { homeScope: "user" } },
-      CODEX_CONTROL_METHODS.forkThread,
-      { threadId: "source-thread", threadSource: "user" },
-      expect.any(Object),
-    );
-    await expect(
-      readCodexAppServerBinding(sessionFile, { agentDir: path.join(root, "agent") }),
-    ).resolves.toMatchObject({
-      threadId: "forked-thread",
-      cwd: "/tmp/project",
-      model: "gpt-5.5",
-      modelProvider: "openai",
-    });
-    expect(result?.details).toMatchObject({
-      action: "fork",
-      sourceThreadId: "source-thread",
-      attached: true,
-    });
-  });
+      const result = await tool?.execute("call-2", {
+        action: "fork",
+        thread_id: "source-thread",
+      });
 
-  it("refuses to archive the active thread bound to this OpenClaw session", async () => {
-    await writeCodexAppServerBinding(sessionFile, {
-      threadId: "active-thread",
-      cwd: "/tmp/project",
-    });
-    const request = vi.fn(async (_config, method: string) => {
-      if (method === CODEX_CONTROL_METHODS.readThread) {
-        return { thread: { id: "active-thread", status: { type: "active" } } };
-      }
-      return {};
-    });
-    const tool = createTool({ request });
+      expect(request).toHaveBeenCalledWith(
+        { appServer: { homeScope: "user" } },
+        CODEX_CONTROL_METHODS.forkThread,
+        { threadId: "source-thread", threadSource: "user" },
+        expect.any(Object),
+      );
+      await expect(
+        readCodexAppServerBinding(sessionFile, { agentDir: path.join(root, "agent") }),
+      ).resolves.toMatchObject({
+        threadId: "forked-thread",
+        cwd: "/tmp/project",
+        model: "gpt-5.5",
+        modelProvider: "openai",
+      });
+      expect(result?.details).toMatchObject({
+        action: "fork",
+        sourceThreadId: "source-thread",
+        attached: true,
+      });
+    }));
 
-    await expect(
-      tool?.execute("call-3", {
+  it("refuses to archive the active thread bound to this OpenClaw session", () =>
+    withFixture(async () => {
+      await writeCodexAppServerBinding(sessionFile, {
+        threadId: "active-thread",
+        cwd: "/tmp/project",
+      });
+      const request = vi.fn(async (_config, method: string) => {
+        if (method === CODEX_CONTROL_METHODS.readThread) {
+          return { thread: { id: "active-thread", status: { type: "active" } } };
+        }
+        return {};
+      });
+      const tool = createTool({ request });
+
+      await expect(
+        tool?.execute("call-3", {
+          action: "archive",
+          thread_id: "active-thread",
+          confirm: true,
+        }),
+      ).rejects.toThrow("cannot archive the Codex thread active in this OpenClaw session");
+      expect(request).not.toHaveBeenCalledWith(
+        expect.anything(),
+        CODEX_CONTROL_METHODS.archiveThread,
+        expect.anything(),
+        expect.anything(),
+      );
+    }));
+
+  it("archives an idle bound thread and clears its attachment", () =>
+    withFixture(async () => {
+      await writeCodexAppServerBinding(sessionFile, {
+        threadId: "idle-thread",
+        cwd: "/tmp/project",
+      });
+      const request = vi.fn(async (_config, method: string) => {
+        if (method === CODEX_CONTROL_METHODS.readThread) {
+          return { thread: { id: "idle-thread", status: { type: "idle" } } };
+        }
+        return {};
+      });
+      const tool = createTool({ request });
+
+      await tool?.execute("call-4", {
         action: "archive",
-        thread_id: "active-thread",
+        thread_id: "idle-thread",
         confirm: true,
-      }),
-    ).rejects.toThrow("cannot archive the Codex thread active in this OpenClaw session");
-    expect(request).not.toHaveBeenCalledWith(
-      expect.anything(),
-      CODEX_CONTROL_METHODS.archiveThread,
-      expect.anything(),
-      expect.anything(),
-    );
-  });
+      });
 
-  it("archives an idle bound thread and clears its attachment", async () => {
-    await writeCodexAppServerBinding(sessionFile, {
-      threadId: "idle-thread",
-      cwd: "/tmp/project",
-    });
-    const request = vi.fn(async (_config, method: string) => {
-      if (method === CODEX_CONTROL_METHODS.readThread) {
-        return { thread: { id: "idle-thread", status: { type: "idle" } } };
-      }
-      return {};
-    });
-    const tool = createTool({ request });
-
-    await tool?.execute("call-4", {
-      action: "archive",
-      thread_id: "idle-thread",
-      confirm: true,
-    });
-
-    expect(request).toHaveBeenCalledWith(
-      { appServer: { homeScope: "user" } },
-      CODEX_CONTROL_METHODS.archiveThread,
-      { threadId: "idle-thread" },
-      expect.any(Object),
-    );
-    await expect(fs.access(resolveCodexAppServerBindingPath(sessionFile))).rejects.toMatchObject({
-      code: "ENOENT",
-    });
-  });
+      expect(request).toHaveBeenCalledWith(
+        { appServer: { homeScope: "user" } },
+        CODEX_CONTROL_METHODS.archiveThread,
+        { threadId: "idle-thread" },
+        expect.any(Object),
+      );
+      await expect(fs.access(resolveCodexAppServerBindingPath(sessionFile))).rejects.toMatchObject({
+        code: "ENOENT",
+      });
+    }));
 
   it.each([
     {
@@ -212,9 +214,8 @@ describe("native Codex thread tool", () => {
       method: CODEX_CONTROL_METHODS.unarchiveThread,
       requestParams: { threadId: "thread-1" },
     },
-  ])(
-    "routes $action through the typed Codex control method",
-    async ({ params, method, requestParams }) => {
+  ])("routes $action through the typed Codex control method", ({ params, method, requestParams }) =>
+    withFixture(async () => {
       const request = vi.fn(async () => ({ thread: { id: "thread-1" } }));
       const tool = createTool({ request });
 
@@ -226,6 +227,6 @@ describe("native Codex thread tool", () => {
         requestParams,
         expect.any(Object),
       );
-    },
+    }),
   );
 });

--- a/extensions/codex/src/native-thread-tool.test.ts
+++ b/extensions/codex/src/native-thread-tool.test.ts
@@ -1,9 +1,9 @@
 import fs from "node:fs/promises";
-import os from "node:os";
 import path from "node:path";
 import type { OpenClawPluginToolContext } from "openclaw/plugin-sdk/plugin-entry";
 import { createPluginRuntimeMock } from "openclaw/plugin-sdk/plugin-test-runtime";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { useAutoCleanupTempDirTracker } from "../../../test/helpers/temp-dir.js";
 import { CODEX_CONTROL_METHODS } from "./app-server/capabilities.js";
 import { CODEX_INTERACTIVE_THREAD_SOURCE_KINDS } from "./app-server/protocol.js";
 import {
@@ -13,12 +13,14 @@ import {
 } from "./app-server/session-binding.js";
 import { createCodexThreadsTool } from "./native-thread-tool.js";
 
+const tempDirs = useAutoCleanupTempDirTracker(afterEach);
+
 describe("native Codex thread tool", () => {
   let root: string;
   let sessionFile: string;
 
   beforeEach(async () => {
-    root = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-codex-threads-"));
+    root = tempDirs.make("openclaw-codex-threads-");
     sessionFile = path.join(root, "sessions", "session-id.jsonl");
     await fs.mkdir(path.dirname(sessionFile), { recursive: true });
     await fs.writeFile(sessionFile, "");

--- a/extensions/codex/src/native-thread-tool.test.ts
+++ b/extensions/codex/src/native-thread-tool.test.ts
@@ -117,7 +117,7 @@ describe("native Codex thread tool", () => {
     expect(request).toHaveBeenCalledWith(
       { appServer: { homeScope: "user" } },
       CODEX_CONTROL_METHODS.forkThread,
-      { threadId: "source-thread" },
+      { threadId: "source-thread", threadSource: "user" },
       expect.any(Object),
     );
     await expect(

--- a/extensions/codex/src/native-thread-tool.test.ts
+++ b/extensions/codex/src/native-thread-tool.test.ts
@@ -1,0 +1,229 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import type { OpenClawPluginToolContext } from "openclaw/plugin-sdk/plugin-entry";
+import { createPluginRuntimeMock } from "openclaw/plugin-sdk/plugin-test-runtime";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { CODEX_CONTROL_METHODS } from "./app-server/capabilities.js";
+import { CODEX_INTERACTIVE_THREAD_SOURCE_KINDS } from "./app-server/protocol.js";
+import {
+  readCodexAppServerBinding,
+  resolveCodexAppServerBindingPath,
+  writeCodexAppServerBinding,
+} from "./app-server/session-binding.js";
+import { createCodexThreadsTool } from "./native-thread-tool.js";
+
+describe("native Codex thread tool", () => {
+  let root: string;
+  let sessionFile: string;
+
+  beforeEach(async () => {
+    root = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-codex-threads-"));
+    sessionFile = path.join(root, "sessions", "session-id.jsonl");
+    await fs.mkdir(path.dirname(sessionFile), { recursive: true });
+    await fs.writeFile(sessionFile, "");
+  });
+
+  afterEach(async () => {
+    await fs.rm(root, { recursive: true, force: true });
+  });
+
+  function createTool(params?: {
+    owner?: boolean;
+    homeScope?: "agent" | "user";
+    request?: ReturnType<typeof vi.fn>;
+  }) {
+    const context: OpenClawPluginToolContext = {
+      config: {},
+      agentId: "main",
+      agentDir: path.join(root, "agent"),
+      workspaceDir: path.join(root, "workspace"),
+      sessionKey: "agent:main:telegram:direct:owner",
+      sessionId: "session-id",
+      senderIsOwner: params?.owner ?? true,
+    };
+    const runtime = createPluginRuntimeMock({
+      agent: {
+        session: {
+          getSessionEntry: () => ({ sessionId: "session-id", sessionFile, updatedAt: Date.now() }),
+          resolveStorePath: () => path.join(root, "sessions", "sessions.json"),
+          resolveSessionFilePath: () => sessionFile,
+        },
+      },
+    });
+    return createCodexThreadsTool({
+      context,
+      runtime,
+      getPluginConfig: () => ({ appServer: { homeScope: params?.homeScope ?? "user" } }),
+      request: params?.request as never,
+    });
+  }
+
+  it("materializes only for owner turns in shared user-home mode", () => {
+    expect(createTool()).not.toBeNull();
+    expect(createTool({ owner: false })).toBeNull();
+    expect(createTool({ homeScope: "agent" })).toBeNull();
+  });
+
+  it("lists native threads with bounded deterministic parameters", async () => {
+    const response = { data: [{ id: "thread-1", status: { type: "idle" } }] };
+    const request = vi.fn(async () => response);
+    const tool = createTool({ request });
+
+    const result = await tool?.execute("call-1", {
+      action: "list",
+      archived: true,
+      cursor: "next-page",
+      limit: 12,
+      search: "coexistence",
+    });
+
+    expect(request).toHaveBeenCalledWith(
+      { appServer: { homeScope: "user" } },
+      CODEX_CONTROL_METHODS.listThreads,
+      {
+        archived: true,
+        cursor: "next-page",
+        limit: 12,
+        modelProviders: [],
+        searchTerm: "coexistence",
+        sortKey: "recency_at",
+        sortDirection: "desc",
+        sourceKinds: [...CODEX_INTERACTIVE_THREAD_SOURCE_KINDS],
+      },
+      expect.objectContaining({
+        sessionId: "session-id",
+        sessionKey: "agent:main:telegram:direct:owner",
+      }),
+    );
+    expect(result?.details).toEqual(response);
+  });
+
+  it("forks a native thread and attaches the fork to the OpenClaw session", async () => {
+    const request = vi.fn(async () => ({
+      thread: { id: "forked-thread", cwd: "/tmp/project", status: { type: "idle" } },
+      model: "gpt-5.5",
+      modelProvider: "openai",
+    }));
+    const tool = createTool({ request });
+
+    const result = await tool?.execute("call-2", {
+      action: "fork",
+      thread_id: "source-thread",
+    });
+
+    expect(request).toHaveBeenCalledWith(
+      { appServer: { homeScope: "user" } },
+      CODEX_CONTROL_METHODS.forkThread,
+      { threadId: "source-thread" },
+      expect.any(Object),
+    );
+    await expect(
+      readCodexAppServerBinding(sessionFile, { agentDir: path.join(root, "agent") }),
+    ).resolves.toMatchObject({
+      threadId: "forked-thread",
+      cwd: "/tmp/project",
+      model: "gpt-5.5",
+      modelProvider: "openai",
+    });
+    expect(result?.details).toMatchObject({
+      action: "fork",
+      sourceThreadId: "source-thread",
+      attached: true,
+    });
+  });
+
+  it("refuses to archive the active thread bound to this OpenClaw session", async () => {
+    await writeCodexAppServerBinding(sessionFile, {
+      threadId: "active-thread",
+      cwd: "/tmp/project",
+    });
+    const request = vi.fn(async (_config, method: string) => {
+      if (method === CODEX_CONTROL_METHODS.readThread) {
+        return { thread: { id: "active-thread", status: { type: "active" } } };
+      }
+      return {};
+    });
+    const tool = createTool({ request });
+
+    await expect(
+      tool?.execute("call-3", {
+        action: "archive",
+        thread_id: "active-thread",
+        confirm: true,
+      }),
+    ).rejects.toThrow("cannot archive the Codex thread active in this OpenClaw session");
+    expect(request).not.toHaveBeenCalledWith(
+      expect.anything(),
+      CODEX_CONTROL_METHODS.archiveThread,
+      expect.anything(),
+      expect.anything(),
+    );
+  });
+
+  it("archives an idle bound thread and clears its attachment", async () => {
+    await writeCodexAppServerBinding(sessionFile, {
+      threadId: "idle-thread",
+      cwd: "/tmp/project",
+    });
+    const request = vi.fn(async (_config, method: string) => {
+      if (method === CODEX_CONTROL_METHODS.readThread) {
+        return { thread: { id: "idle-thread", status: { type: "idle" } } };
+      }
+      return {};
+    });
+    const tool = createTool({ request });
+
+    await tool?.execute("call-4", {
+      action: "archive",
+      thread_id: "idle-thread",
+      confirm: true,
+    });
+
+    expect(request).toHaveBeenCalledWith(
+      { appServer: { homeScope: "user" } },
+      CODEX_CONTROL_METHODS.archiveThread,
+      { threadId: "idle-thread" },
+      expect.any(Object),
+    );
+    await expect(fs.access(resolveCodexAppServerBindingPath(sessionFile))).rejects.toMatchObject({
+      code: "ENOENT",
+    });
+  });
+
+  it.each([
+    {
+      action: "read" as const,
+      params: { action: "read", thread_id: "thread-1", include_turns: true },
+      method: CODEX_CONTROL_METHODS.readThread,
+      requestParams: { threadId: "thread-1", includeTurns: true },
+    },
+    {
+      action: "rename" as const,
+      params: { action: "rename", thread_id: "thread-1", name: "Shared thread" },
+      method: CODEX_CONTROL_METHODS.renameThread,
+      requestParams: { threadId: "thread-1", name: "Shared thread" },
+    },
+    {
+      action: "unarchive" as const,
+      params: { action: "unarchive", thread_id: "thread-1" },
+      method: CODEX_CONTROL_METHODS.unarchiveThread,
+      requestParams: { threadId: "thread-1" },
+    },
+  ])(
+    "routes $action through the typed Codex control method",
+    async ({ params, method, requestParams }) => {
+      const request = vi.fn(async () => ({ thread: { id: "thread-1" } }));
+      const tool = createTool({ request });
+
+      await tool?.execute("call-5", params);
+
+      expect(request).toHaveBeenCalledWith(
+        { appServer: { homeScope: "user" } },
+        method,
+        requestParams,
+        expect.any(Object),
+      );
+    },
+  );
+});

--- a/extensions/codex/src/native-thread-tool.ts
+++ b/extensions/codex/src/native-thread-tool.ts
@@ -290,7 +290,7 @@ export function createCodexThreadsTool(options: CodexThreadsToolOptions): AnyAge
       const response = await request(
         pluginConfig,
         CODEX_CONTROL_METHODS.forkThread,
-        { threadId },
+        { threadId, threadSource: "user" },
         requestOptions(),
       );
       if (!isJsonObject(response) || !isJsonObject(response.thread)) {

--- a/extensions/codex/src/native-thread-tool.ts
+++ b/extensions/codex/src/native-thread-tool.ts
@@ -1,0 +1,326 @@
+/**
+ * Owner-only access to native Codex threads stored in the user's Codex home.
+ */
+import path from "node:path";
+import {
+  jsonResult,
+  readStringParam,
+  type AnyAgentTool,
+  type PluginRuntime,
+} from "openclaw/plugin-sdk/core";
+import type { OpenClawPluginToolContext } from "openclaw/plugin-sdk/plugin-entry";
+import { Type } from "typebox";
+import { CODEX_CONTROL_METHODS } from "./app-server/capabilities.js";
+import { readCodexPluginConfig } from "./app-server/config.js";
+import { CODEX_INTERACTIVE_THREAD_SOURCE_KINDS, isJsonObject } from "./app-server/protocol.js";
+import {
+  clearCodexAppServerBinding,
+  readCodexAppServerBinding,
+  writeCodexAppServerBinding,
+} from "./app-server/session-binding.js";
+import { codexControlRequest, type CodexControlRequestOptions } from "./command-rpc.js";
+
+const ListParamsSchema = Type.Object(
+  {
+    action: Type.Literal("list"),
+    archived: Type.Optional(Type.Boolean()),
+    cursor: Type.Optional(Type.String()),
+    limit: Type.Optional(Type.Integer({ minimum: 1, maximum: 100 })),
+    search: Type.Optional(Type.String()),
+  },
+  { additionalProperties: false },
+);
+
+const ReadParamsSchema = Type.Object(
+  {
+    action: Type.Literal("read"),
+    thread_id: Type.String(),
+    include_turns: Type.Optional(Type.Boolean()),
+  },
+  { additionalProperties: false },
+);
+
+const ForkParamsSchema = Type.Object(
+  {
+    action: Type.Literal("fork"),
+    thread_id: Type.String(),
+    attach: Type.Optional(
+      Type.Boolean({
+        default: true,
+        description: "Attach the fork to this OpenClaw session for its next turn.",
+      }),
+    ),
+  },
+  { additionalProperties: false },
+);
+
+const RenameParamsSchema = Type.Object(
+  {
+    action: Type.Literal("rename"),
+    thread_id: Type.String(),
+    name: Type.String(),
+  },
+  { additionalProperties: false },
+);
+
+const ArchiveParamsSchema = Type.Object(
+  {
+    action: Type.Literal("archive"),
+    thread_id: Type.String(),
+    confirm: Type.Literal(true, {
+      description: "Required acknowledgement that the thread is closed in other Codex clients.",
+    }),
+  },
+  { additionalProperties: false },
+);
+
+const UnarchiveParamsSchema = Type.Object(
+  {
+    action: Type.Literal("unarchive"),
+    thread_id: Type.String(),
+  },
+  { additionalProperties: false },
+);
+
+const CodexThreadsParamsSchema = Type.Union([
+  ListParamsSchema,
+  ReadParamsSchema,
+  ForkParamsSchema,
+  RenameParamsSchema,
+  ArchiveParamsSchema,
+  UnarchiveParamsSchema,
+]);
+
+type CodexThreadsToolOptions = {
+  context: OpenClawPluginToolContext;
+  runtime: PluginRuntime;
+  getPluginConfig: () => unknown;
+  request?: typeof codexControlRequest;
+};
+
+function asRecord(value: unknown): Record<string, unknown> {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : {};
+}
+
+function readBoolean(value: unknown, fallback = false): boolean {
+  return typeof value === "boolean" ? value : fallback;
+}
+
+function readLimit(value: unknown): number | undefined {
+  return typeof value === "number" && Number.isInteger(value) && value >= 1 && value <= 100
+    ? value
+    : undefined;
+}
+
+function resolveSessionFile(
+  context: OpenClawPluginToolContext,
+  runtime: PluginRuntime,
+): string | undefined {
+  const sessionKey = context.sessionKey?.trim();
+  if (!sessionKey) {
+    return undefined;
+  }
+  const entry = runtime.agent.session.getSessionEntry({
+    agentId: context.agentId,
+    sessionKey,
+    readConsistency: "latest",
+  });
+  const sessionId = context.sessionId?.trim() || entry?.sessionId?.trim();
+  if (!sessionId) {
+    return undefined;
+  }
+  const storePath = runtime.agent.session.resolveStorePath(undefined, {
+    agentId: context.agentId,
+  });
+  return runtime.agent.session.resolveSessionFilePath(sessionId, entry, {
+    agentId: context.agentId,
+    sessionsDir: path.dirname(storePath),
+  });
+}
+
+function readThreadId(params: Record<string, unknown>): string {
+  return readStringParam(params, "thread_id", { required: true, label: "thread_id" });
+}
+
+function readThreadStatusType(value: unknown): string | undefined {
+  if (!isJsonObject(value) || !isJsonObject(value.thread) || !isJsonObject(value.thread.status)) {
+    return undefined;
+  }
+  return typeof value.thread.status.type === "string" ? value.thread.status.type : undefined;
+}
+
+/** Builds the native Codex thread tool only for owner runs in shared-user-home mode. */
+export function createCodexThreadsTool(options: CodexThreadsToolOptions): AnyAgentTool | null {
+  if (options.context.senderIsOwner !== true) {
+    return null;
+  }
+  if (readCodexPluginConfig(options.getPluginConfig()).appServer?.homeScope !== "user") {
+    return null;
+  }
+  const request = options.request ?? codexControlRequest;
+  const requestOptions = (): CodexControlRequestOptions => ({
+    agentDir: options.context.agentDir,
+    config:
+      options.context.getRuntimeConfig?.() ??
+      options.context.runtimeConfig ??
+      options.context.config,
+    sessionId: options.context.sessionId,
+    sessionKey: options.context.sessionKey,
+  });
+  const currentSessionFile = () => resolveSessionFile(options.context, options.runtime);
+  const currentBinding = async (sessionFile: string | undefined) =>
+    sessionFile
+      ? await readCodexAppServerBinding(sessionFile, {
+          agentDir: options.context.agentDir,
+          config: requestOptions().config,
+        })
+      : undefined;
+
+  return {
+    name: "codex_threads",
+    label: "Codex Threads",
+    description:
+      "List, read, fork, rename, archive, or restore native Codex threads. Fork to continue a thread safely across Codex clients; do not resume the same thread from two clients.",
+    parameters: CodexThreadsParamsSchema,
+    async execute(_toolCallId, rawParams) {
+      const params = asRecord(rawParams);
+      const action = readStringParam(params, "action", { required: true, label: "action" });
+      const pluginConfig = options.getPluginConfig();
+
+      if (action === "list") {
+        const cursor = readStringParam(params, "cursor");
+        const searchTerm = readStringParam(params, "search");
+        const response = await request(
+          pluginConfig,
+          CODEX_CONTROL_METHODS.listThreads,
+          {
+            archived: readBoolean(params.archived),
+            limit: readLimit(params.limit) ?? 20,
+            modelProviders: [],
+            sortKey: "recency_at",
+            sortDirection: "desc",
+            sourceKinds: [...CODEX_INTERACTIVE_THREAD_SOURCE_KINDS],
+            ...(cursor ? { cursor } : {}),
+            ...(searchTerm ? { searchTerm } : {}),
+          },
+          requestOptions(),
+        );
+        return jsonResult(response);
+      }
+
+      const threadId = readThreadId(params);
+      if (action === "read") {
+        const response = await request(
+          pluginConfig,
+          CODEX_CONTROL_METHODS.readThread,
+          { threadId, includeTurns: readBoolean(params.include_turns) },
+          requestOptions(),
+        );
+        return jsonResult(response);
+      }
+      if (action === "rename") {
+        const name = readStringParam(params, "name", { required: true, label: "name" });
+        await request(
+          pluginConfig,
+          CODEX_CONTROL_METHODS.renameThread,
+          { threadId, name },
+          requestOptions(),
+        );
+        return jsonResult({ action, threadId, name });
+      }
+      if (action === "unarchive") {
+        const response = await request(
+          pluginConfig,
+          CODEX_CONTROL_METHODS.unarchiveThread,
+          { threadId },
+          requestOptions(),
+        );
+        return jsonResult(response);
+      }
+
+      const sessionFile = currentSessionFile();
+      const binding = await currentBinding(sessionFile);
+      if (action === "archive") {
+        if (params.confirm !== true) {
+          throw new Error("confirm=true is required to archive a native Codex thread");
+        }
+        if (binding?.threadId === threadId) {
+          const current = await request(
+            pluginConfig,
+            CODEX_CONTROL_METHODS.readThread,
+            { threadId, includeTurns: false },
+            requestOptions(),
+          );
+          if (readThreadStatusType(current) === "active") {
+            throw new Error("cannot archive the Codex thread active in this OpenClaw session");
+          }
+        }
+        await request(
+          pluginConfig,
+          CODEX_CONTROL_METHODS.archiveThread,
+          { threadId },
+          requestOptions(),
+        );
+        if (sessionFile && binding?.threadId === threadId) {
+          await clearCodexAppServerBinding(sessionFile);
+        }
+        return jsonResult({ action, threadId });
+      }
+      if (action !== "fork") {
+        throw new Error(`unsupported codex_threads action: ${action}`);
+      }
+
+      const attach = readBoolean(params.attach, true);
+      if (attach && !sessionFile) {
+        throw new Error("cannot attach a Codex fork without an active OpenClaw session");
+      }
+      if (attach && binding?.threadId === threadId) {
+        const current = await request(
+          pluginConfig,
+          CODEX_CONTROL_METHODS.readThread,
+          { threadId, includeTurns: false },
+          requestOptions(),
+        );
+        if (readThreadStatusType(current) === "active") {
+          throw new Error("cannot replace the Codex thread active in this OpenClaw turn");
+        }
+      }
+      const response = await request(
+        pluginConfig,
+        CODEX_CONTROL_METHODS.forkThread,
+        { threadId },
+        requestOptions(),
+      );
+      if (!isJsonObject(response) || !isJsonObject(response.thread)) {
+        throw new Error("Codex app-server returned an invalid thread/fork response");
+      }
+      const forkThreadId =
+        typeof response.thread.id === "string" && response.thread.id.trim()
+          ? response.thread.id
+          : undefined;
+      if (!forkThreadId) {
+        throw new Error("Codex app-server thread/fork response did not include a thread id");
+      }
+      if (attach && sessionFile) {
+        await writeCodexAppServerBinding(sessionFile, {
+          threadId: forkThreadId,
+          cwd:
+            typeof response.thread.cwd === "string"
+              ? response.thread.cwd
+              : (options.context.workspaceDir ?? ""),
+          model: typeof response.model === "string" ? response.model : undefined,
+          modelProvider:
+            typeof response.modelProvider === "string" ? response.modelProvider : undefined,
+        });
+      }
+      return jsonResult({
+        action,
+        sourceThreadId: threadId,
+        thread: response.thread,
+        attached: attach,
+      });
+    },
+  };
+}

--- a/extensions/discord/src/outbound-adapter.test.ts
+++ b/extensions/discord/src/outbound-adapter.test.ts
@@ -309,6 +309,16 @@ describe("discordOutbound", () => {
   });
 
   it("routes audioAsVoice payloads through the Discord voice send helper", async () => {
+    const onDeliveryResult = vi.fn();
+    hoisted.sendMessageDiscordMock.mockImplementation(
+      async (_to: unknown, _text: unknown, options: unknown) => {
+        const deliveryResult = { messageId: "msg-1", channelId: "ch-1" };
+        const onProgress = (options as { onDeliveryResult?: (result: unknown) => Promise<void> })
+          .onDeliveryResult;
+        await onProgress?.(deliveryResult);
+        return deliveryResult;
+      },
+    );
     const result = await discordOutbound.sendPayload?.({
       cfg: {},
       to: "channel:123456",
@@ -321,6 +331,7 @@ describe("discordOutbound", () => {
       accountId: "default",
       replyToId: "reply-1",
       replyToMode: "first",
+      onDeliveryResult,
     });
 
     const voiceCall = mockCall(hoisted.sendVoiceMessageDiscordMock, "sendVoiceMessageDiscord");
@@ -359,6 +370,11 @@ describe("discordOutbound", () => {
       messageId: "msg-1",
       channelId: "ch-1",
     });
+    expect(onDeliveryResult.mock.calls.map((call) => call[0]?.messageId)).toEqual([
+      "voice-1",
+      "msg-1",
+      "msg-1",
+    ]);
   });
 
   it("keeps captured replyTo on audioAsVoice sends when replyToMode is batched", async () => {

--- a/extensions/discord/src/outbound-adapter.ts
+++ b/extensions/discord/src/outbound-adapter.ts
@@ -2,6 +2,7 @@
 import type { OutboundIdentity } from "openclaw/plugin-sdk/channel-outbound";
 import { resolveOutboundSendDep } from "openclaw/plugin-sdk/channel-outbound";
 import {
+  attachChannelToResult,
   type ChannelOutboundAdapter,
   createAttachedChannelResultAdapter,
 } from "openclaw/plugin-sdk/channel-send-result";
@@ -174,6 +175,7 @@ export const discordOutbound: ChannelOutboundAdapter = {
       identity,
       silent,
       formatting,
+      onDeliveryResult,
     }) => {
       if (!silent) {
         const webhookResult = await maybeSendDiscordWebhookText({
@@ -202,6 +204,11 @@ export const discordOutbound: ChannelOutboundAdapter = {
             silent: silent ?? undefined,
             cfg,
             ...resolveDiscordFormattingOptions({ formatting }),
+            onDeliveryResult: onDeliveryResult
+              ? async (result) => {
+                  await onDeliveryResult(attachChannelToResult("discord", result));
+                }
+              : undefined,
           }),
       });
     },
@@ -220,6 +227,7 @@ export const discordOutbound: ChannelOutboundAdapter = {
       threadId,
       silent,
       formatting,
+      onDeliveryResult,
     }) => {
       const send =
         resolveOutboundSendDep<DiscordSendFn>(deps, "discord") ??
@@ -254,6 +262,11 @@ export const discordOutbound: ChannelOutboundAdapter = {
               silent: silent ?? undefined,
               cfg,
               ...formattingOptions,
+              onDeliveryResult: onDeliveryResult
+                ? async (result) => {
+                    await onDeliveryResult(attachChannelToResult("discord", result));
+                  }
+                : undefined,
             }),
         });
         return await withDiscordDeliveryRetry({
@@ -270,6 +283,11 @@ export const discordOutbound: ChannelOutboundAdapter = {
               silent: silent ?? undefined,
               cfg,
               ...formattingOptions,
+              onDeliveryResult: onDeliveryResult
+                ? async (result) => {
+                    await onDeliveryResult(attachChannelToResult("discord", result));
+                  }
+                : undefined,
             }),
         });
       }
@@ -288,6 +306,11 @@ export const discordOutbound: ChannelOutboundAdapter = {
             silent: silent ?? undefined,
             cfg,
             ...formattingOptions,
+            onDeliveryResult: onDeliveryResult
+              ? async (result) => {
+                  await onDeliveryResult(attachChannelToResult("discord", result));
+                }
+              : undefined,
           }),
       });
     },

--- a/extensions/discord/src/outbound-payload.ts
+++ b/extensions/discord/src/outbound-payload.ts
@@ -23,6 +23,14 @@ type DiscordOutboundPayloadContext = Parameters<
 >[0];
 type DiscordPayloadSendContext = Awaited<ReturnType<typeof createDiscordPayloadSendContext>>;
 
+function resolveDiscordDeliveryProgress(ctx: DiscordOutboundPayloadContext) {
+  return ctx.onDeliveryResult
+    ? async (result: Awaited<ReturnType<DiscordPayloadSendContext["send"]>>) => {
+        await ctx.onDeliveryResult?.(attachChannelToResult("discord", result));
+      }
+    : undefined;
+}
+
 function createDiscordUnknownPayloadResult(target: string) {
   return {
     messageId: "",
@@ -94,6 +102,7 @@ export async function sendDiscordOutboundPayload(params: {
           replyTo: voiceReplyTo,
         }),
     );
+    await ctx.onDeliveryResult?.(attachChannelToResult("discord", lastResult));
     if (payload.text?.trim()) {
       lastResult = await sendContext.withRetry(
         async () =>
@@ -101,6 +110,7 @@ export async function sendDiscordOutboundPayload(params: {
             verbose: false,
             ...resolveDiscordFormattedDeliveryOptions(ctx, sendContext),
             replyTo: voiceReplyTo,
+            onDeliveryResult: resolveDiscordDeliveryProgress(ctx),
           }),
       );
     }
@@ -111,6 +121,7 @@ export async function sendDiscordOutboundPayload(params: {
             verbose: false,
             ...resolveDiscordMediaDeliveryOptions(ctx, sendContext, mediaUrl),
             replyTo: voiceReplyTo,
+            onDeliveryResult: resolveDiscordDeliveryProgress(ctx),
           }),
       );
     }
@@ -146,6 +157,7 @@ export async function sendDiscordOutboundPayload(params: {
                 embeds,
                 filename,
                 ...resolveDiscordFormattedDeliveryOptions(ctx, sendContext),
+                onDeliveryResult: resolveDiscordDeliveryProgress(ctx),
               }),
           ),
         send: async ({ text, mediaUrl, isFirst }) =>
@@ -157,6 +169,7 @@ export async function sendDiscordOutboundPayload(params: {
                 components: isFirst ? nativeComponents : undefined,
                 embeds: isFirst ? embeds : undefined,
                 filename: isFirst ? filename : undefined,
+                onDeliveryResult: resolveDiscordDeliveryProgress(ctx),
               }),
           ),
       });
@@ -176,19 +189,22 @@ export async function sendDiscordOutboundPayload(params: {
     text: payload.text ?? "",
     mediaUrls,
     fallbackResult: createDiscordUnknownPayloadResult(sendContext.target),
-    sendNoMedia: async () =>
-      await sendContext.withRetry(
+    sendNoMedia: async () => {
+      return await sendContext.withRetry(
         async () =>
           await sendDiscordComponentMessageLazy(sendContext.target, componentSpec, {
             ...resolveDiscordFormattedDeliveryOptions(ctx, sendContext),
+            onDeliveryResult: resolveDiscordDeliveryProgress(ctx),
           }),
-      ),
+      );
+    },
     send: async ({ text, mediaUrl, isFirst }) => {
       if (isFirst) {
         return await sendContext.withRetry(
           async () =>
             await sendDiscordComponentMessageLazy(sendContext.target, componentSpec, {
               ...resolveDiscordMediaDeliveryOptions(ctx, sendContext, mediaUrl),
+              onDeliveryResult: resolveDiscordDeliveryProgress(ctx),
             }),
         );
       }
@@ -197,6 +213,7 @@ export async function sendDiscordOutboundPayload(params: {
           await sendContext.send(sendContext.target, text, {
             verbose: false,
             ...resolveDiscordMediaDeliveryOptions(ctx, sendContext, mediaUrl),
+            onDeliveryResult: resolveDiscordDeliveryProgress(ctx),
           }),
       );
     },

--- a/extensions/discord/src/send.components.test.ts
+++ b/extensions/discord/src/send.components.test.ts
@@ -130,6 +130,27 @@ describe("sendDiscordComponentMessage", () => {
     );
   });
 
+  it("reports the platform send before component registry bookkeeping", async () => {
+    const { rest, postMock, getMock } = makeDiscordRest();
+    getMock.mockResolvedValueOnce({ type: ChannelType.GuildText, id: "chan-1" });
+    postMock.mockResolvedValueOnce({ id: "msg-progress", channel_id: "chan-1" });
+    registerMock.mockImplementationOnce(() => {
+      throw new Error("registry write failed");
+    });
+    const onDeliveryResult = vi.fn();
+
+    await expect(
+      sendDiscordComponentMessage(
+        "channel:chan-1",
+        { blocks: [{ type: "actions", buttons: [{ label: "Tap" }] }] },
+        { cfg: DISCORD_TEST_CFG, rest, token: "t", onDeliveryResult },
+      ),
+    ).rejects.toThrow("registry write failed");
+
+    expect(onDeliveryResult).toHaveBeenCalledOnce();
+    expect(onDeliveryResult.mock.calls[0]?.[0]?.messageId).toBe("msg-progress");
+  });
+
   it("edits component messages and refreshes component registry entries", async () => {
     const { rest, patchMock, getMock } = makeDiscordRest();
     getMock.mockResolvedValueOnce({
@@ -263,6 +284,7 @@ describe("sendDiscordComponentMessage classic message downgrade", () => {
   it("forwards mediaReadFile and mediaAccess to sendMessageDiscord", async () => {
     const readFileMock = vi.fn().mockResolvedValue(Buffer.from("pdf"));
     const mediaAccess = { localRoots: ["/tmp"], readFile: readFileMock };
+    const onDeliveryResult = vi.fn();
 
     await sendDiscordComponentMessage(
       "channel:chan-1",
@@ -273,6 +295,7 @@ describe("sendDiscordComponentMessage classic message downgrade", () => {
         mediaUrl: "https://example.com/report.pdf",
         mediaReadFile: readFileMock,
         mediaAccess,
+        onDeliveryResult,
       },
     );
 
@@ -296,6 +319,7 @@ describe("sendDiscordComponentMessage classic message downgrade", () => {
         maxLinesPerMessage: undefined,
         tableMode: undefined,
         chunkMode: undefined,
+        onDeliveryResult,
       },
     ]);
   });

--- a/extensions/discord/src/send.components.ts
+++ b/extensions/discord/src/send.components.ts
@@ -167,6 +167,8 @@ type DiscordComponentSendOpts = {
   tableMode?: MarkdownTableMode;
   chunkMode?: ChunkMode;
   suppressEmbeds?: boolean;
+  /** Persist the concrete platform send before component bookkeeping can fail. */
+  onDeliveryResult?: (result: DiscordSendResult) => Promise<void> | void;
 };
 
 export function registerBuiltDiscordComponentMessage(params: {
@@ -285,6 +287,7 @@ export async function sendDiscordComponentMessage(
       maxLinesPerMessage: opts.maxLinesPerMessage,
       tableMode: opts.tableMode,
       chunkMode: opts.chunkMode,
+      onDeliveryResult: opts.onDeliveryResult,
       ...(opts.suppressEmbeds === undefined ? {} : { suppressEmbeds: opts.suppressEmbeds }),
     });
   }
@@ -326,6 +329,14 @@ export async function sendDiscordComponentMessage(
     });
   }
 
+  const deliveryResult = createDiscordSendResult({
+    result,
+    fallbackChannelId: channelId,
+    kind: "card",
+    ...(opts.replyTo ? { replyToId: opts.replyTo } : {}),
+  });
+  await opts.onDeliveryResult?.(deliveryResult);
+
   registerBuiltDiscordComponentMessage({
     buildResult,
     messageId: result.id,
@@ -338,12 +349,7 @@ export async function sendDiscordComponentMessage(
     direction: "outbound",
   });
 
-  return createDiscordSendResult({
-    result,
-    fallbackChannelId: channelId,
-    kind: "card",
-    ...(opts.replyTo ? { replyToId: opts.replyTo } : {}),
-  });
+  return deliveryResult;
 }
 
 export async function editDiscordComponentMessage(

--- a/extensions/discord/src/send.outbound.ts
+++ b/extensions/discord/src/send.outbound.ts
@@ -29,6 +29,7 @@ import {
   resolveDiscordSendEmbeds,
   sendDiscordMedia,
   sendDiscordText,
+  type DiscordSendProgress,
   type DiscordSendComponents,
   type DiscordSendEmbeds,
 } from "./send.shared.js";
@@ -54,6 +55,8 @@ type DiscordSendOpts = {
   embeds?: DiscordSendEmbeds;
   silent?: boolean;
   suppressEmbeds?: boolean;
+  /** Persist each concrete platform send before any later chunk can fail. */
+  onDeliveryResult?: (result: DiscordSendResult) => Promise<void> | void;
 };
 
 type DiscordClientRequest = ReturnType<typeof createDiscordClient>["request"];
@@ -72,6 +75,7 @@ async function sendDiscordThreadTextChunks(params: {
   maxChars?: number;
   silent?: boolean;
   suppressEmbeds?: boolean;
+  onResult?: DiscordSendProgress;
 }): Promise<void> {
   for (const chunk of params.chunks) {
     await sendDiscordText(
@@ -87,6 +91,7 @@ async function sendDiscordThreadTextChunks(params: {
       params.silent,
       params.suppressEmbeds,
       params.maxChars,
+      params.onResult,
     );
   }
 }
@@ -245,6 +250,19 @@ export async function sendMessageDiscord(
     const messageId = threadRes.message?.id ?? threadId;
     const resultChannelId = threadRes.message?.channel_id ?? threadId;
     const remainingChunks = chunks.slice(1);
+    await opts.onDeliveryResult?.(
+      toDiscordSendResult(
+        {
+          id: messageId,
+          channel_id: resultChannelId,
+        },
+        channelId,
+        { kind: "text", threadId },
+      ),
+    );
+    const reportThreadResult: DiscordSendProgress = async (result, kind) => {
+      await opts.onDeliveryResult?.(toDiscordSendResult(result, threadId, { kind, threadId }));
+    };
 
     try {
       if (opts.mediaUrl) {
@@ -268,6 +286,7 @@ export async function sendMessageDiscord(
           opts.silent,
           suppressEmbeds,
           textLimit,
+          reportThreadResult,
         );
         await sendDiscordThreadTextChunks({
           rest,
@@ -279,6 +298,7 @@ export async function sendMessageDiscord(
           maxChars: textLimit,
           silent: opts.silent,
           suppressEmbeds,
+          onResult: reportThreadResult,
         });
       } else {
         await sendDiscordThreadTextChunks({
@@ -291,6 +311,7 @@ export async function sendMessageDiscord(
           maxChars: textLimit,
           silent: opts.silent,
           suppressEmbeds,
+          onResult: reportThreadResult,
         });
       }
     } catch (err) {
@@ -319,6 +340,14 @@ export async function sendMessageDiscord(
   }
 
   let result: DiscordChannelMessageResult;
+  const reportResult: DiscordSendProgress = async (progressResult, kind) => {
+    await opts.onDeliveryResult?.(
+      toDiscordSendResult(progressResult, channelId, {
+        kind,
+        replyToId: opts.replyTo,
+      }),
+    );
+  };
   try {
     if (opts.mediaUrl) {
       result = await sendDiscordMedia(
@@ -340,6 +369,7 @@ export async function sendMessageDiscord(
         opts.silent,
         suppressEmbeds,
         textLimit,
+        reportResult,
       );
     } else {
       result = await sendDiscordText(
@@ -355,6 +385,7 @@ export async function sendMessageDiscord(
         opts.silent,
         suppressEmbeds,
         textLimit,
+        reportResult,
       );
     }
   } catch (err) {

--- a/extensions/discord/src/send.sends-basic-channel-messages.test.ts
+++ b/extensions/discord/src/send.sends-basic-channel-messages.test.ts
@@ -219,6 +219,26 @@ describe("sendMessageDiscord", () => {
     expect(requireRestBody(postMock).flags).toBe(MessageFlags.SuppressEmbeds);
   });
 
+  it("reports the first Discord chunk before a later chunk fails", async () => {
+    const { rest, postMock, getMock } = makeDiscordRest();
+    getMock.mockResolvedValueOnce({ type: ChannelType.GuildText });
+    postMock
+      .mockResolvedValueOnce({ id: "msg1", channel_id: "789" })
+      .mockRejectedValueOnce(new Error("second chunk failed"));
+    const onDeliveryResult = vi.fn();
+
+    await expect(
+      sendMessageDiscord("channel:789", "a".repeat(2500), {
+        rest,
+        token: "t",
+        cfg: DISCORD_TEST_CFG,
+        onDeliveryResult,
+      }),
+    ).rejects.toThrow("second chunk failed");
+
+    expect(onDeliveryResult.mock.calls.map((call) => call[0]?.messageId)).toEqual(["msg1"]);
+  });
+
   it("allows Discord link embeds when suppressEmbeds is disabled", async () => {
     const { rest, postMock, getMock } = makeDiscordRest();
     getMock.mockResolvedValueOnce({ type: ChannelType.GuildText });

--- a/extensions/discord/src/send.shared.ts
+++ b/extensions/discord/src/send.shared.ts
@@ -294,6 +294,11 @@ export function toDiscordFileBlob(data: Blob | Uint8Array): Blob {
   return new Blob([arrayBuffer]);
 }
 
+export type DiscordSendProgress = (
+  result: { id: string; channel_id: string },
+  kind: "text" | "media",
+) => Promise<void> | void;
+
 async function sendDiscordText(
   rest: RequestClient,
   channelId: string,
@@ -307,6 +312,7 @@ async function sendDiscordText(
   silent?: boolean,
   suppressEmbeds?: boolean,
   maxChars?: number,
+  onResult?: DiscordSendProgress,
 ) {
   if (!text.trim()) {
     throw new Error("Message must be non-empty for Discord sends");
@@ -337,12 +343,14 @@ async function sendDiscordText(
   };
   if (chunks.length === 1) {
     const result = await sendChunk(chunks[0], true);
+    await onResult?.(result, "text");
     return { ...result, platformMessageIds: result.id ? [result.id] : [] };
   }
   const platformMessageIds: string[] = [];
   let last: { id: string; channel_id: string } | null = null;
   for (const [index, chunk] of chunks.entries()) {
     last = await sendChunk(chunk, index === 0);
+    await onResult?.(last, "text");
     if (last.id) {
       platformMessageIds.push(last.id);
     }
@@ -372,6 +380,7 @@ async function sendDiscordMedia(
   silent?: boolean,
   suppressEmbeds?: boolean,
   maxChars?: number,
+  onResult?: DiscordSendProgress,
 ) {
   const media = await loadWebMedia(
     mediaUrl,
@@ -415,6 +424,7 @@ async function sendDiscordMedia(
     () => createChannelMessage<{ id: string; channel_id: string }>(rest, channelId, { body }),
     "media",
   )) as { id: string; channel_id: string };
+  await onResult?.(res, "media");
   const platformMessageIds = res.id ? [res.id] : [];
   for (const chunk of chunks.slice(1)) {
     if (!chunk.trim()) {
@@ -433,6 +443,7 @@ async function sendDiscordMedia(
       silent,
       suppressEmbeds,
       maxChars,
+      onResult,
     );
     for (const id of followup.platformMessageIds) {
       if (id) {

--- a/extensions/feishu/src/channel.ts
+++ b/extensions/feishu/src/channel.ts
@@ -183,7 +183,18 @@ const feishuMessageAdapter = defineChannelMessageAdapter({
       if (!sendText) {
         throw new Error("Feishu text sending is not available.");
       }
-      return toFeishuMessageSendResult(await sendText(ctx), "text");
+      const { onDeliveryResult, ...outboundCtx } = ctx;
+      const result = await sendText({
+        ...outboundCtx,
+        ...(onDeliveryResult
+          ? {
+              onDeliveryResult: async (progress) => {
+                await onDeliveryResult(toFeishuMessageSendResult(progress, "text"));
+              },
+            }
+          : {}),
+      });
+      return toFeishuMessageSendResult(result, "text");
     },
     media: async (ctx) => {
       const runtime = await loadFeishuChannelRuntime();
@@ -191,7 +202,18 @@ const feishuMessageAdapter = defineChannelMessageAdapter({
       if (!sendMedia) {
         throw new Error("Feishu media sending is not available.");
       }
-      return toFeishuMessageSendResult(await sendMedia(ctx), "media");
+      const { onDeliveryResult, ...outboundCtx } = ctx;
+      const result = await sendMedia({
+        ...outboundCtx,
+        ...(onDeliveryResult
+          ? {
+              onDeliveryResult: async (progress) => {
+                await onDeliveryResult(toFeishuMessageSendResult(progress, "media"));
+              },
+            }
+          : {}),
+      });
+      return toFeishuMessageSendResult(result, "media");
     },
   },
 });

--- a/extensions/feishu/src/outbound.test.ts
+++ b/extensions/feishu/src/outbound.test.ts
@@ -250,17 +250,22 @@ describe("feishuOutbound.sendText local-image auto-convert", () => {
           expect(result.receipt.platformMessageIds).toEqual(["feishu-text-1"]);
         },
         media: async () => {
+          const onDeliveryResult = vi.fn();
           const result = await adapterSendMedia({
             cfg: emptyConfig,
             to: "chat:chat-1",
             text: "",
             mediaUrl: "https://example.com/image.png",
             accountId: "default",
+            onDeliveryResult,
           });
           expect(sendMediaCall()?.to).toBe("chat:chat-1");
           expect(sendMediaCall()?.mediaUrl).toBe("https://example.com/image.png");
           expect(sendMediaCall()?.accountId).toBe("default");
           expect(result.receipt.platformMessageIds).toEqual(["feishu-media-1"]);
+          expect(onDeliveryResult.mock.calls[0]?.[0]?.receipt.platformMessageIds).toEqual([
+            "feishu-media-1",
+          ]);
         },
       },
     });
@@ -1319,6 +1324,58 @@ describe("feishuOutbound.sendMedia replyToId forwarding", () => {
 
     expect(sendMessageCall()?.text).toBe("caption text");
     expect(sendMediaCall()?.mediaUrl).toBe("https://example.com/song.mp3");
+  });
+
+  it("reports a sent caption before media failure and avoids repeating it in fallback", async () => {
+    sendMessageFeishuMock
+      .mockResolvedValueOnce({ messageId: "caption_msg" })
+      .mockResolvedValueOnce({ messageId: "fallback_msg" });
+    sendMediaFeishuMock.mockRejectedValueOnce(new Error("upload failed"));
+    const onDeliveryResult = vi.fn();
+
+    const result = await feishuOutbound.sendMedia?.({
+      cfg: emptyConfig,
+      to: "chat_1",
+      text: "caption text",
+      mediaUrl: "https://example.com/image.png",
+      accountId: "main",
+      onDeliveryResult,
+    });
+
+    expect(sendMessageCall(0)?.text).toBe("caption text");
+    expect(sendMessageCall(1)?.text).toBe("📎 https://example.com/image.png");
+    expect(onDeliveryResult.mock.calls.map((call) => call[0]?.messageId)).toEqual([
+      "caption_msg",
+      "fallback_msg",
+    ]);
+    expectFeishuResult(result, "fallback_msg");
+  });
+
+  it("does not resend successful media when delivery progress persistence fails", async () => {
+    sendMessageFeishuMock.mockResolvedValueOnce({ messageId: "caption_msg" });
+    sendMediaFeishuMock.mockResolvedValueOnce({ messageId: "media_msg" });
+    const onDeliveryResult = vi
+      .fn()
+      .mockResolvedValueOnce(undefined)
+      .mockRejectedValueOnce(new Error("progress write failed"));
+
+    await expect(
+      feishuOutbound.sendMedia?.({
+        cfg: emptyConfig,
+        to: "chat_1",
+        text: "caption text",
+        mediaUrl: "https://example.com/image.png",
+        accountId: "main",
+        onDeliveryResult,
+      }),
+    ).rejects.toThrow("progress write failed");
+
+    expect(sendMediaFeishuMock).toHaveBeenCalledOnce();
+    expect(sendMessageFeishuMock).toHaveBeenCalledOnce();
+    expect(onDeliveryResult.mock.calls.map((call) => call[0]?.messageId)).toEqual([
+      "caption_msg",
+      "media_msg",
+    ]);
   });
 
   it("keeps skipped voice text in the upload failure fallback", async () => {

--- a/extensions/feishu/src/outbound.ts
+++ b/extensions/feishu/src/outbound.ts
@@ -29,7 +29,11 @@ import { cleanupAmbientCommentTypingReaction } from "./comment-reaction.js";
 import { parseFeishuCommentTarget } from "./comment-target.js";
 import { deliverCommentThreadText } from "./drive.js";
 import { resolveFeishuIdentityHeaderTitle } from "./identity-header.js";
-import { sendMediaFeishu, shouldSuppressFeishuTextForVoiceMedia } from "./media.js";
+import {
+  sendMediaFeishu,
+  shouldSuppressFeishuTextForVoiceMedia,
+  type SendMediaResult,
+} from "./media.js";
 import { chunkTextForOutbound, type ChannelOutboundAdapter } from "./outbound-runtime-api.js";
 import { buildFeishuPresentationCardElements } from "./presentation-card.js";
 import {
@@ -568,9 +572,15 @@ export const feishuOutbound: ChannelOutboundAdapter = {
     const mediaUrls = normalizeStringEntries(resolvePayloadMediaUrls(ctx.payload));
     return attachChannelToResult(
       "feishu",
-      await sendPayloadMediaSequenceAndFinalize({
+      await sendPayloadMediaSequenceAndFinalize<
+        SendMediaResult,
+        Awaited<ReturnType<typeof sendCardFeishu>>
+      >({
         text: ctx.payload.text ?? "",
         mediaUrls,
+        onResult: async (deliveryResult) => {
+          await ctx.onDeliveryResult?.(attachChannelToResult("feishu", deliveryResult));
+        },
         send: async ({ mediaUrl }) =>
           await sendMediaFeishu({
             cfg: ctx.cfg,
@@ -682,6 +692,7 @@ export const feishuOutbound: ChannelOutboundAdapter = {
       mediaLocalRoots,
       replyToId,
       threadId,
+      onDeliveryResult,
     }) => {
       const { replyToMessageId, replyInThread } = resolveFeishuMediaReplyMode({
         replyToId,
@@ -706,10 +717,14 @@ export const feishuOutbound: ChannelOutboundAdapter = {
           mediaUrl,
           audioAsVoice,
         });
+      const reportDelivery = async (result: Awaited<ReturnType<typeof sendOutboundText>>) => {
+        await onDeliveryResult?.(attachChannelToResult("feishu", result));
+      };
+      let textSent = false;
 
       // Send text first if provided, except for Feishu native voice bubbles.
       if (text?.trim() && !suppressTextForVoiceMedia) {
-        await sendOutboundText({
+        const textResult = await sendOutboundText({
           cfg,
           to,
           text,
@@ -717,12 +732,15 @@ export const feishuOutbound: ChannelOutboundAdapter = {
           replyToMessageId,
           replyInThread,
         });
+        textSent = true;
+        await reportDelivery(textResult);
       }
 
       // Upload and send media if URL or local path provided
       if (mediaUrl) {
+        let mediaResult: Awaited<ReturnType<typeof sendMediaFeishu>>;
         try {
-          const result = await sendMediaFeishu({
+          mediaResult = await sendMediaFeishu({
             cfg,
             to,
             mediaUrl,
@@ -732,23 +750,14 @@ export const feishuOutbound: ChannelOutboundAdapter = {
             replyInThread,
             ...(audioAsVoice === true ? { audioAsVoice: true } : {}),
           });
-          if (result.voiceIntentDegradedToFile && text?.trim()) {
-            await sendOutboundText({
-              cfg,
-              to,
-              text,
-              accountId: accountId ?? undefined,
-              replyToMessageId,
-              replyInThread,
-            });
-          }
-          return result;
         } catch (err) {
           // Log the error for debugging
           console.error(`[feishu] sendMediaFeishu failed:`, err);
           // Fallback to URL link if upload fails
-          const fallbackText = [text?.trim(), `📎 ${mediaUrl}`].filter(Boolean).join("\n\n");
-          return await sendOutboundText({
+          const fallbackText = [textSent ? undefined : text?.trim(), `📎 ${mediaUrl}`]
+            .filter(Boolean)
+            .join("\n\n");
+          const fallbackResult = await sendOutboundText({
             cfg,
             to,
             text: fallbackText,
@@ -756,7 +765,25 @@ export const feishuOutbound: ChannelOutboundAdapter = {
             replyToMessageId,
             replyInThread,
           });
+          await reportDelivery(fallbackResult);
+          return fallbackResult;
         }
+
+        // Upload fallback applies only to the platform send. Persistence and
+        // follow-up failures must not resend an attachment already accepted by Feishu.
+        await onDeliveryResult?.(attachChannelToResult("feishu", mediaResult));
+        if (mediaResult.voiceIntentDegradedToFile && text?.trim()) {
+          const textResult = await sendOutboundText({
+            cfg,
+            to,
+            text,
+            accountId: accountId ?? undefined,
+            replyToMessageId,
+            replyInThread,
+          });
+          await reportDelivery(textResult);
+        }
+        return mediaResult;
       }
 
       // No media URL, just return text result

--- a/extensions/line/src/channel.sendPayload.test.ts
+++ b/extensions/line/src/channel.sendPayload.test.ts
@@ -161,6 +161,31 @@ describe("line outbound sendPayload", () => {
     });
   });
 
+  it("reports each platform result for text and media payloads", async () => {
+    const { runtime } = createRuntime();
+    setLineRuntime(runtime);
+    const cfg = { channels: { line: {} } } as OpenClawConfig;
+    const onDeliveryResult = vi.fn();
+
+    await lineOutboundAdapter.sendPayload!({
+      to: "line:user:progress",
+      text: "Hello",
+      payload: {
+        text: "Hello",
+        mediaUrl: "https://example.com/image.jpg",
+      },
+      accountId: "default",
+      cfg,
+      onDeliveryResult,
+    });
+
+    expect(onDeliveryResult).toHaveBeenCalledTimes(2);
+    expect(onDeliveryResult.mock.calls.map(([result]) => result.messageId)).toEqual([
+      "m-text",
+      "m-media",
+    ]);
+  });
+
   it("sends template message without dropping text", async () => {
     const { runtime, mocks } = createRuntime();
     setLineRuntime(runtime);

--- a/extensions/line/src/outbound.ts
+++ b/extensions/line/src/outbound.ts
@@ -82,7 +82,7 @@ export const lineOutboundAdapter: NonNullable<ChannelPlugin<ResolvedLineAccount>
   deliveryMode: "direct",
   chunker: (text, limit) => getLineRuntime().channel.text.chunkMarkdownText(text, limit),
   textChunkLimit: 5000,
-  sendPayload: async ({ to, payload, accountId, cfg }) => {
+  sendPayload: async ({ to, payload, accountId, cfg, onDeliveryResult }) => {
     const runtime = getLineRuntime();
     const outboundRuntime = await loadLineOutboundRuntime();
     const lineData = (payload.channelData?.line as LineChannelDataWithMedia | undefined) ?? {};
@@ -100,6 +100,14 @@ export const lineOutboundAdapter: NonNullable<ChannelPlugin<ResolvedLineAccount>
       outboundRuntime.buildTemplateMessageFromPayload;
 
     let lastResult: LineSendResult | null = null;
+    const recordResult = async (
+      resultPromise: Promise<LineSendResult>,
+    ): Promise<LineSendResult> => {
+      const result = await resultPromise;
+      lastResult = result;
+      await onDeliveryResult?.(createEmptyChannelResult("line", { ...result }));
+      return result;
+    };
     const quickReplies = lineData.quickReplies ?? [];
     const hasQuickReplies = quickReplies.length > 0;
     const quickReply = hasQuickReplies
@@ -113,12 +121,13 @@ export const lineOutboundAdapter: NonNullable<ChannelPlugin<ResolvedLineAccount>
       }
       for (let i = 0; i < messages.length; i += 5) {
         const batch = messages.slice(i, i + 5) as unknown as Parameters<typeof sendBatch>[1];
-        const result = await sendBatch(to, batch, {
-          verbose: false,
-          cfg,
-          accountId: accountId ?? undefined,
-        });
-        lastResult = result;
+        await recordResult(
+          sendBatch(to, batch, {
+            verbose: false,
+            cfg,
+            accountId: accountId ?? undefined,
+          }),
+        );
       }
     };
 
@@ -144,15 +153,13 @@ export const lineOutboundAdapter: NonNullable<ChannelPlugin<ResolvedLineAccount>
           continue;
         }
         if (!useLineSpecificMedia) {
-          lastResult = await (lineRuntime?.sendMessageLine ?? outboundRuntime.sendMessageLine)(
-            to,
-            "",
-            {
+          await recordResult(
+            (lineRuntime?.sendMessageLine ?? outboundRuntime.sendMessageLine)(to, "", {
               verbose: false,
               mediaUrl: trimmed,
               cfg,
               accountId: accountId ?? undefined,
-            },
+            }),
           );
           continue;
         }
@@ -162,10 +169,8 @@ export const lineOutboundAdapter: NonNullable<ChannelPlugin<ResolvedLineAccount>
           durationMs: lineData.durationMs,
           trackingId: lineData.trackingId,
         });
-        lastResult = await (lineRuntime?.sendMessageLine ?? outboundRuntime.sendMessageLine)(
-          to,
-          "",
-          {
+        await recordResult(
+          (lineRuntime?.sendMessageLine ?? outboundRuntime.sendMessageLine)(to, "", {
             verbose: false,
             mediaUrl: resolved.mediaUrl,
             mediaKind: resolved.mediaKind,
@@ -174,7 +179,7 @@ export const lineOutboundAdapter: NonNullable<ChannelPlugin<ResolvedLineAccount>
             trackingId: resolved.trackingId,
             cfg,
             accountId: accountId ?? undefined,
-          },
+          }),
         );
       }
     };
@@ -182,39 +187,47 @@ export const lineOutboundAdapter: NonNullable<ChannelPlugin<ResolvedLineAccount>
     if (!shouldSendQuickRepliesInline) {
       if (lineData.flexMessage) {
         const flexContents = lineData.flexMessage.contents as Parameters<typeof sendFlex>[2];
-        lastResult = await sendFlex(to, lineData.flexMessage.altText, flexContents, {
-          verbose: false,
-          cfg,
-          accountId: accountId ?? undefined,
-        });
+        await recordResult(
+          sendFlex(to, lineData.flexMessage.altText, flexContents, {
+            verbose: false,
+            cfg,
+            accountId: accountId ?? undefined,
+          }),
+        );
       }
 
       if (lineData.templateMessage) {
         const template = buildTemplate(lineData.templateMessage);
         if (template) {
-          lastResult = await sendTemplate(to, template, {
-            verbose: false,
-            cfg,
-            accountId: accountId ?? undefined,
-          });
+          await recordResult(
+            sendTemplate(to, template, {
+              verbose: false,
+              cfg,
+              accountId: accountId ?? undefined,
+            }),
+          );
         }
       }
 
       if (lineData.location) {
-        lastResult = await sendLocation(to, lineData.location, {
-          verbose: false,
-          cfg,
-          accountId: accountId ?? undefined,
-        });
+        await recordResult(
+          sendLocation(to, lineData.location, {
+            verbose: false,
+            cfg,
+            accountId: accountId ?? undefined,
+          }),
+        );
       }
 
       for (const flexMsg of processed.flexMessages) {
         const flexContents = flexMsg.contents;
-        lastResult = await sendFlex(to, flexMsg.altText, flexContents, {
-          verbose: false,
-          cfg,
-          accountId: accountId ?? undefined,
-        });
+        await recordResult(
+          sendFlex(to, flexMsg.altText, flexContents, {
+            verbose: false,
+            cfg,
+            accountId: accountId ?? undefined,
+          }),
+        );
       }
     }
 
@@ -227,17 +240,21 @@ export const lineOutboundAdapter: NonNullable<ChannelPlugin<ResolvedLineAccount>
       for (let i = 0; i < chunks.length; i += 1) {
         const isLast = i === chunks.length - 1;
         if (isLast && hasQuickReplies) {
-          lastResult = await sendQuickReplies(to, chunks[i], quickReplies, {
-            verbose: false,
-            cfg,
-            accountId: accountId ?? undefined,
-          });
+          await recordResult(
+            sendQuickReplies(to, chunks[i], quickReplies, {
+              verbose: false,
+              cfg,
+              accountId: accountId ?? undefined,
+            }),
+          );
         } else {
-          lastResult = await sendText(to, chunks[i], {
-            verbose: false,
-            cfg,
-            accountId: accountId ?? undefined,
-          });
+          await recordResult(
+            sendText(to, chunks[i], {
+              verbose: false,
+              cfg,
+              accountId: accountId ?? undefined,
+            }),
+          );
         }
       }
     } else if (shouldSendQuickRepliesInline) {
@@ -302,15 +319,12 @@ export const lineOutboundAdapter: NonNullable<ChannelPlugin<ResolvedLineAccount>
         };
         await sendMessageBatch(quickReplyMessages);
       } else if (quickReply) {
-        lastResult = await sendQuickReplies(
-          to,
-          buildLineQuickReplyFallbackText(quickReplies),
-          quickReplies,
-          {
+        await recordResult(
+          sendQuickReplies(to, buildLineQuickReplyFallbackText(quickReplies), quickReplies, {
             verbose: false,
             cfg,
             accountId: accountId ?? undefined,
-          },
+          }),
         );
       }
     }
@@ -319,8 +333,9 @@ export const lineOutboundAdapter: NonNullable<ChannelPlugin<ResolvedLineAccount>
       await sendMediaMessages();
     }
 
-    if (lastResult) {
-      return createEmptyChannelResult("line", { ...lastResult });
+    const completedResult = lastResult as LineSendResult | null;
+    if (completedResult) {
+      return createEmptyChannelResult("line", { ...completedResult });
     }
     return createEmptyChannelResult("line", { messageId: "empty", chatId: to });
   },
@@ -400,17 +415,20 @@ export const lineMessageAdapter = defineChannelMessageAdapter({
     },
   },
   send: {
-    text: async ({ cfg, to, text, accountId }) => {
+    text: async ({ cfg, to, text, accountId, onDeliveryResult }) => {
       const result = await lineOutboundAdapter.sendPayload!({
         cfg,
         to,
         text,
         accountId,
         payload: { text },
+        onDeliveryResult: async (deliveryResult) => {
+          await onDeliveryResult?.(toLineMessageSendResult(deliveryResult, "text"));
+        },
       });
       return toLineMessageSendResult(result, "text");
     },
-    media: async ({ cfg, to, text, mediaUrl, accountId }) => {
+    media: async ({ cfg, to, text, mediaUrl, accountId, onDeliveryResult }) => {
       const result = await lineOutboundAdapter.sendPayload!({
         cfg,
         to,
@@ -418,6 +436,9 @@ export const lineMessageAdapter = defineChannelMessageAdapter({
         mediaUrl,
         accountId,
         payload: { text, mediaUrl },
+        onDeliveryResult: async (deliveryResult) => {
+          await onDeliveryResult?.(toLineMessageSendResult(deliveryResult, "media"));
+        },
       });
       return toLineMessageSendResult(result, "media");
     },

--- a/extensions/matrix/src/matrix/send.test.ts
+++ b/extensions/matrix/src/matrix/send.test.ts
@@ -685,6 +685,27 @@ describe("sendMessageMatrix threads", () => {
     expectTextReceiptPart(parts[2], "$m3");
   });
 
+  it("reports the first Matrix event before a later event fails", async () => {
+    const { client, sendMessage } = makeClient();
+    sendMessage
+      .mockReset()
+      .mockResolvedValueOnce("$m1")
+      .mockRejectedValueOnce(new Error("second event failed"));
+    convertMarkdownTablesMock.mockImplementation(() => "part1|part2");
+    chunkMarkdownTextWithModeMock.mockImplementation((text: string) => text.split("|"));
+    const onDeliveryResult = vi.fn();
+
+    await expect(
+      sendMessageMatrix("room:!room:example", "ignored", {
+        client,
+        cfg: {} as never,
+        onDeliveryResult,
+      }),
+    ).rejects.toThrow("second event failed");
+
+    expect(onDeliveryResult.mock.calls.map((call) => call[0]?.messageId)).toEqual(["$m1"]);
+  });
+
   it("merges extra content into only the first chunked text event", async () => {
     const { client, sendMessage } = makeClient();
     convertMarkdownTablesMock.mockImplementation(() => "first|second|third");

--- a/extensions/matrix/src/matrix/send.ts
+++ b/extensions/matrix/src/matrix/send.ts
@@ -259,10 +259,24 @@ export async function sendMessageMatrix(
         ? buildThreadRelation(threadId, opts.replyToId)
         : buildReplyRelation(opts.replyToId);
       let pendingExtraContent = opts.extraContent;
-      const sendContent = async (content: MatrixOutboundContent) => {
+      const sendContent = async (content: MatrixOutboundContent, kind: MessageReceiptPartKind) => {
         const contentWithExtra = withMatrixExtraContentFields(content, pendingExtraContent);
         pendingExtraContent = undefined;
         const eventId = await client.sendMessage(roomId, contentWithExtra);
+        if (eventId) {
+          await opts.onDeliveryResult?.({
+            messageId: eventId,
+            roomId,
+            primaryMessageId: eventId,
+            receipt: createMatrixSendReceipt({
+              roomId,
+              platformMessageIds: [eventId],
+              kind,
+              replyToId: opts.replyToId,
+              threadId,
+            }),
+          });
+        }
         return eventId;
       };
 
@@ -324,7 +338,7 @@ export async function sendMessageMatrix(
           content,
           markdown: captionMarkdown,
         });
-        const eventId = await sendContent(content);
+        const eventId = await sendContent(content, receiptKind);
         lastMessageId = eventId ?? lastMessageId;
         if (eventId) {
           platformMessageIds.push(eventId);
@@ -344,7 +358,7 @@ export async function sendMessageMatrix(
             content: followup,
             markdown: text,
           });
-          const followupEventId = await sendContent(followup);
+          const followupEventId = await sendContent(followup, "text");
           lastMessageId = followupEventId ?? lastMessageId;
           if (followupEventId) {
             platformMessageIds.push(followupEventId);
@@ -362,7 +376,7 @@ export async function sendMessageMatrix(
             content,
             markdown: text,
           });
-          const eventId = await sendContent(content);
+          const eventId = await sendContent(content, "text");
           lastMessageId = eventId ?? lastMessageId;
           if (eventId) {
             platformMessageIds.push(eventId);

--- a/extensions/matrix/src/matrix/send/types.ts
+++ b/extensions/matrix/src/matrix/send/types.ts
@@ -102,6 +102,8 @@ export type MatrixSendOpts = {
   extraContent?: MatrixExtraContentFields;
   /** Send audio as voice message instead of audio file. Defaults to false. */
   audioAsVoice?: boolean;
+  /** Persist each concrete platform send before any later event can fail. */
+  onDeliveryResult?: (result: MatrixSendResult) => Promise<void> | void;
 };
 
 export type MatrixMediaMsgType =

--- a/extensions/matrix/src/outbound.ts
+++ b/extensions/matrix/src/outbound.ts
@@ -94,6 +94,18 @@ function resolveMatrixExtraContent(payload: ReplyPayload): MatrixExtraContentFie
   return presentation ? { [MATRIX_OPENCLAW_PRESENTATION_KEY]: presentation } : undefined;
 }
 
+function resolveMatrixDeliveryProgress(
+  onDeliveryResult: Parameters<
+    NonNullable<ChannelOutboundAdapter["sendText"]>
+  >[0]["onDeliveryResult"],
+) {
+  return onDeliveryResult
+    ? async (result: Awaited<ReturnType<typeof sendMessageMatrix>>) => {
+        await onDeliveryResult({ channel: "matrix", ...result });
+      }
+    : undefined;
+}
+
 export const matrixOutbound: ChannelOutboundAdapter = {
   deliveryMode: "direct",
   chunker: chunkTextForOutbound,
@@ -128,6 +140,7 @@ export const matrixOutbound: ChannelOutboundAdapter = {
     threadId,
     accountId,
     audioAsVoice,
+    onDeliveryResult,
   }) => {
     const send =
       resolveOutboundSendDep<typeof sendMessageMatrix>(deps, "matrix") ?? sendMessageMatrix;
@@ -155,6 +168,7 @@ export const matrixOutbound: ChannelOutboundAdapter = {
           accountId: accountId ?? undefined,
           audioAsVoice: payload.audioAsVoice ?? audioAsVoice,
           extraContent: isFirst ? resolveMatrixExtraContent(payload) : undefined,
+          onDeliveryResult: resolveMatrixDeliveryProgress(onDeliveryResult),
         });
       }
       return {
@@ -174,6 +188,7 @@ export const matrixOutbound: ChannelOutboundAdapter = {
       accountId: accountId ?? undefined,
       audioAsVoice: payload.audioAsVoice ?? audioAsVoice,
       extraContent: resolveMatrixExtraContent(payload),
+      onDeliveryResult: resolveMatrixDeliveryProgress(onDeliveryResult),
     });
     return {
       channel: "matrix",
@@ -181,7 +196,17 @@ export const matrixOutbound: ChannelOutboundAdapter = {
       roomId: result.roomId,
     };
   },
-  sendText: async ({ cfg, to, text, deps, replyToId, threadId, accountId, audioAsVoice }) => {
+  sendText: async ({
+    cfg,
+    to,
+    text,
+    deps,
+    replyToId,
+    threadId,
+    accountId,
+    audioAsVoice,
+    onDeliveryResult,
+  }) => {
     const send =
       resolveOutboundSendDep<typeof sendMessageMatrix>(deps, "matrix") ?? sendMessageMatrix;
     const resolvedThreadId =
@@ -192,6 +217,7 @@ export const matrixOutbound: ChannelOutboundAdapter = {
       threadId: resolvedThreadId,
       accountId: accountId ?? undefined,
       audioAsVoice,
+      onDeliveryResult: resolveMatrixDeliveryProgress(onDeliveryResult),
     });
     return {
       channel: "matrix",
@@ -211,6 +237,7 @@ export const matrixOutbound: ChannelOutboundAdapter = {
     threadId,
     accountId,
     audioAsVoice,
+    onDeliveryResult,
   }) => {
     const send =
       resolveOutboundSendDep<typeof sendMessageMatrix>(deps, "matrix") ?? sendMessageMatrix;
@@ -225,6 +252,7 @@ export const matrixOutbound: ChannelOutboundAdapter = {
       threadId: resolvedThreadId,
       accountId: accountId ?? undefined,
       audioAsVoice,
+      onDeliveryResult: resolveMatrixDeliveryProgress(onDeliveryResult),
     });
     return {
       channel: "matrix",

--- a/extensions/msteams/src/outbound.ts
+++ b/extensions/msteams/src/outbound.ts
@@ -115,6 +115,7 @@ export const msteamsOutbound: ChannelOutboundAdapter = {
     mediaReadFile,
     payload,
     deps,
+    onDeliveryResult,
   }) => {
     const msteamsData = asObjectRecord(payload.channelData?.msteams);
     const presentationCard = msteamsData?.presentationCard;
@@ -138,9 +139,12 @@ export const msteamsOutbound: ChannelOutboundAdapter = {
     );
     if (mediaUrls.length > 0) {
       const send = resolveMSTeamsMediaSend({ cfg, deps });
-      const result = await sendPayloadMediaSequence({
+      const result = await sendPayloadMediaSequence<MSTeamsSendResult>({
         text,
         mediaUrls,
+        onResult: async (deliveryResult) => {
+          await onDeliveryResult?.(attachChannelToResult("msteams", deliveryResult));
+        },
         send: async ({ text: textLocal, mediaUrl: mediaUrlLocal }) =>
           await send(to, textLocal, { mediaUrl: mediaUrlLocal, mediaLocalRoots, mediaReadFile }),
       });
@@ -157,6 +161,7 @@ export const msteamsOutbound: ChannelOutboundAdapter = {
       let result: Awaited<ReturnType<MSTeamsTextSendFn>>;
       for (const chunk of chunks) {
         result = await send(to, chunk);
+        await onDeliveryResult?.(attachChannelToResult("msteams", result));
       }
       return attachChannelToResult("msteams", result!);
     }

--- a/extensions/signal/src/channel.ts
+++ b/extensions/signal/src/channel.ts
@@ -6,10 +6,7 @@ import { createChatChannelPlugin, type ChannelPlugin } from "openclaw/plugin-sdk
 import { defineChannelMessageAdapter } from "openclaw/plugin-sdk/channel-outbound";
 import { resolveOutboundSendDep } from "openclaw/plugin-sdk/channel-outbound";
 import { createPairingPrefixStripper } from "openclaw/plugin-sdk/channel-pairing";
-import {
-  attachChannelToResult,
-  attachChannelToResults,
-} from "openclaw/plugin-sdk/channel-send-result";
+import { attachChannelToResult } from "openclaw/plugin-sdk/channel-send-result";
 import { PAIRING_APPROVED_MESSAGE } from "openclaw/plugin-sdk/channel-status";
 import { createLazyRuntimeModule } from "openclaw/plugin-sdk/lazy-runtime";
 import { resolveMarkdownTableMode } from "openclaw/plugin-sdk/markdown-table-runtime";
@@ -219,6 +216,9 @@ async function sendFormattedSignalText(ctx: {
   accountId?: string | null;
   deps?: { [channelId: string]: unknown };
   abortSignal?: AbortSignal;
+  onDeliveryResult?: Parameters<
+    NonNullable<ChannelOutboundAdapter["sendFormattedText"]>
+  >[0]["onDeliveryResult"];
 }) {
   const { send, maxBytes } = await resolveSignalSendContext({
     cfg: ctx.cfg,
@@ -255,9 +255,14 @@ async function sendFormattedSignalText(ctx: {
       textMode: "plain",
       textStyles: chunk.styles,
     });
-    results.push(attachSignalVisibleText(result, chunk.text));
+    const deliveryResult = attachChannelToResult(
+      "signal",
+      attachSignalVisibleText(result, chunk.text),
+    );
+    results.push(deliveryResult);
+    await ctx.onDeliveryResult?.(deliveryResult);
   }
-  return attachChannelToResults("signal", results);
+  return results;
 }
 
 async function sendFormattedSignalMedia(ctx: {
@@ -549,7 +554,15 @@ export const signalPlugin: ChannelPlugin<ResolvedSignalAccount, SignalProbe> =
         afterDeliverPayload: async (params) =>
           await registerDeliveredSignalApprovalPayloadForReactions(params),
         renderPresentation: async (params) => await renderSignalApprovalPayloadForReactions(params),
-        sendFormattedText: async ({ cfg, to, text, accountId, deps, abortSignal }) =>
+        sendFormattedText: async ({
+          cfg,
+          to,
+          text,
+          accountId,
+          deps,
+          abortSignal,
+          onDeliveryResult,
+        }) =>
           await sendFormattedSignalText({
             cfg,
             to,
@@ -557,6 +570,7 @@ export const signalPlugin: ChannelPlugin<ResolvedSignalAccount, SignalProbe> =
             accountId,
             deps,
             abortSignal,
+            onDeliveryResult,
           }),
         sendFormattedMedia: async ({
           cfg,

--- a/extensions/signal/src/core.test.ts
+++ b/extensions/signal/src/core.test.ts
@@ -342,6 +342,30 @@ describe("signal outbound", () => {
     );
   });
 
+  it("reports a formatted Signal chunk before a later chunk fails", async () => {
+    const send = vi
+      .fn()
+      .mockResolvedValueOnce({ messageId: "signal-1" })
+      .mockRejectedValueOnce(new Error("second Signal chunk failed"));
+    const onDeliveryResult = vi.fn();
+
+    await expect(
+      signalPlugin.outbound?.sendFormattedText?.({
+        cfg: {} as OpenClawConfig,
+        to: "+15551234567",
+        text: "a".repeat(5000),
+        deps: { signal: send },
+        onDeliveryResult,
+      }),
+    ).rejects.toThrow("second Signal chunk failed");
+
+    expect(send).toHaveBeenCalledTimes(2);
+    expect(onDeliveryResult).toHaveBeenCalledTimes(1);
+    expect(onDeliveryResult).toHaveBeenCalledWith(
+      expect.objectContaining({ channel: "signal", messageId: "signal-1" }),
+    );
+  });
+
   it("resolves aliases before formatted Signal media sends", async () => {
     const send = vi.fn(async () => ({
       messageId: "signal-1",

--- a/extensions/slack/src/channel.test.ts
+++ b/extensions/slack/src/channel.test.ts
@@ -695,6 +695,34 @@ describe("slackPlugin outbound", () => {
     expect(result).toEqual({ channel: "slack", messageId: "m-text" });
   });
 
+  it("forwards partial-send progress through the registered Slack sender", async () => {
+    const sendSlack = vi.fn(async (...args: unknown[]) => {
+      const options = args[2] as {
+        onDeliveryResult?: (result: { messageId: string }) => Promise<void>;
+      };
+      await options.onDeliveryResult?.({ messageId: "m-first" });
+      throw new Error("later Slack chunk failed");
+    });
+    const onDeliveryResult = vi.fn();
+    const sendText = requireSlackSendText();
+
+    await expect(
+      sendText({
+        cfg,
+        to: "C123",
+        text: "long message",
+        accountId: "default",
+        deps: { sendSlack },
+        onDeliveryResult,
+      }),
+    ).rejects.toThrow("later Slack chunk failed");
+
+    expect(onDeliveryResult).toHaveBeenCalledWith({
+      channel: "slack",
+      messageId: "m-first",
+    });
+  });
+
   it("prefers replyToId over threadId for sendMedia", async () => {
     const sendSlack = vi.fn().mockResolvedValue({ messageId: "m-media" });
     const sendMedia = requireSlackSendMedia();

--- a/extensions/slack/src/channel.ts
+++ b/extensions/slack/src/channel.ts
@@ -13,6 +13,7 @@ import { createChannelMessageAdapterFromOutbound } from "openclaw/plugin-sdk/cha
 import { resolveOutboundSendDep } from "openclaw/plugin-sdk/channel-outbound";
 import { createPairingPrefixStripper } from "openclaw/plugin-sdk/channel-pairing";
 import {
+  attachChannelToResult,
   createAttachedChannelResultAdapter,
   type ChannelOutboundAdapter,
 } from "openclaw/plugin-sdk/channel-send-result";
@@ -454,7 +455,7 @@ const slackChannelOutbound: ChannelOutboundAdapter = {
   },
   ...createAttachedChannelResultAdapter({
     channel: "slack",
-    sendText: async ({ to, text, accountId, deps, replyToId, threadId, cfg }) => {
+    sendText: async ({ to, text, accountId, deps, replyToId, threadId, cfg, onDeliveryResult }) => {
       const { send, threadTsValue, tokenOverride } = await resolveSlackSendContext({
         cfg,
         accountId: accountId ?? undefined,
@@ -466,6 +467,11 @@ const slackChannelOutbound: ChannelOutboundAdapter = {
         cfg,
         threadTs: threadTsValue,
         accountId: accountId ?? undefined,
+        onDeliveryResult: onDeliveryResult
+          ? async (result) => {
+              await onDeliveryResult(attachChannelToResult("slack", result));
+            }
+          : undefined,
         ...(tokenOverride ? { token: tokenOverride } : {}),
       });
     },
@@ -479,6 +485,7 @@ const slackChannelOutbound: ChannelOutboundAdapter = {
       replyToId,
       threadId,
       cfg,
+      onDeliveryResult,
     }) => {
       const { send, threadTsValue, tokenOverride } = await resolveSlackSendContext({
         cfg,
@@ -493,6 +500,11 @@ const slackChannelOutbound: ChannelOutboundAdapter = {
         mediaLocalRoots,
         threadTs: threadTsValue,
         accountId: accountId ?? undefined,
+        onDeliveryResult: onDeliveryResult
+          ? async (result) => {
+              await onDeliveryResult(attachChannelToResult("slack", result));
+            }
+          : undefined,
         ...(tokenOverride ? { token: tokenOverride } : {}),
       });
     },

--- a/extensions/slack/src/outbound-adapter.ts
+++ b/extensions/slack/src/outbound-adapter.ts
@@ -80,6 +80,9 @@ async function sendSlackOutboundMessage(params: {
   replyToId?: string | null;
   threadId?: string | number | null;
   identity?: OutboundIdentity;
+  onDeliveryResult?: Parameters<
+    NonNullable<ChannelOutboundAdapter["sendText"]>
+  >[0]["onDeliveryResult"];
 }) {
   const send =
     resolveOutboundSendDep<SlackSendFn>(params.deps, "slack") ??
@@ -103,6 +106,11 @@ async function sendSlackOutboundMessage(params: {
       : {}),
     ...(params.blocks ? { blocks: params.blocks } : {}),
     ...(slackIdentity ? { identity: slackIdentity } : {}),
+    onDeliveryResult: params.onDeliveryResult
+      ? async (progress) => {
+          await params.onDeliveryResult?.(attachChannelToResult("slack", progress));
+        }
+      : undefined,
   });
   return result;
 }
@@ -228,6 +236,7 @@ export const slackOutbound: ChannelOutboundAdapter = {
             replyToId: ctx.replyToId,
             threadId: ctx.threadId,
             identity: ctx.identity,
+            onDeliveryResult: ctx.onDeliveryResult,
           }),
         finalize: async () =>
           await sendSlackOutboundMessage({
@@ -243,13 +252,24 @@ export const slackOutbound: ChannelOutboundAdapter = {
             replyToId: ctx.replyToId,
             threadId: ctx.threadId,
             identity: ctx.identity,
+            onDeliveryResult: ctx.onDeliveryResult,
           }),
       }),
     );
   },
   ...createAttachedChannelResultAdapter({
     channel: "slack",
-    sendText: async ({ cfg, to, text, accountId, deps, replyToId, threadId, identity }) =>
+    sendText: async ({
+      cfg,
+      to,
+      text,
+      accountId,
+      deps,
+      replyToId,
+      threadId,
+      identity,
+      onDeliveryResult,
+    }) =>
       await sendSlackOutboundMessage({
         cfg,
         to,
@@ -259,6 +279,7 @@ export const slackOutbound: ChannelOutboundAdapter = {
         replyToId,
         threadId,
         identity,
+        onDeliveryResult,
       }),
     sendMedia: async ({
       cfg,
@@ -273,6 +294,7 @@ export const slackOutbound: ChannelOutboundAdapter = {
       replyToId,
       threadId,
       identity,
+      onDeliveryResult,
     }) =>
       await sendSlackOutboundMessage({
         cfg,
@@ -287,6 +309,7 @@ export const slackOutbound: ChannelOutboundAdapter = {
         replyToId,
         threadId,
         identity,
+        onDeliveryResult,
       }),
   }),
 };

--- a/extensions/slack/src/send.blocks.test.ts
+++ b/extensions/slack/src/send.blocks.test.ts
@@ -1,5 +1,5 @@
 // Slack tests cover send.blocks plugin behavior.
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { createSlackSendTestClient } from "./blocks.test-helpers.js";
 import {
   clearSlackThreadParticipationCache,
@@ -201,6 +201,25 @@ describe("sendMessageSlack chunking", () => {
         .filter((text) => text.length === null || text.length > 8000),
     ).toStrictEqual([]);
     expect(postedTexts.join("")).toBe(message);
+  });
+
+  it("reports the first Slack chunk before a later chunk fails", async () => {
+    const client = createSlackSendTestClient();
+    client.chat.postMessage
+      .mockResolvedValueOnce({ ts: "m1", channel: "C123" })
+      .mockRejectedValueOnce(new Error("second chunk failed"));
+    const onDeliveryResult = vi.fn();
+
+    await expect(
+      sendMessageSlack("channel:C123", "a".repeat(8500), {
+        token: "xoxb-test",
+        cfg: SLACK_TEST_CFG,
+        client,
+        onDeliveryResult,
+      }),
+    ).rejects.toThrow("second chunk failed");
+
+    expect(onDeliveryResult.mock.calls.map((call) => call[0]?.messageId)).toEqual(["m1"]);
   });
 
   it("preserves the first canonical response thread across chunked sends", async () => {

--- a/extensions/slack/src/send.ts
+++ b/extensions/slack/src/send.ts
@@ -114,6 +114,8 @@ type SlackSendOpts = {
   identity?: SlackSendIdentity;
   blocks?: (Block | KnownBlock)[];
   metadata?: MessageMetadata;
+  /** Persist each concrete platform send before any later chunk can fail. */
+  onDeliveryResult?: (result: SlackSendResult) => Promise<void> | void;
 };
 
 type SlackWebApiErrorData = {
@@ -773,6 +775,10 @@ async function sendMessageSlackQueuedInner(params: {
         accountId: account.accountId,
         token,
       });
+  const reportDelivery = async (result: SlackSendResult) => {
+    await opts.onDeliveryResult?.(result);
+    return result;
+  };
   if (blocks) {
     if (opts.mediaUrl) {
       throw new Error("Slack send does not support blocks with mediaUrl");
@@ -796,7 +802,7 @@ async function sendMessageSlackQueuedInner(params: {
     const deliveredChannelId = resolvePostedMessageChannelId(response, channelId);
     const deliveredThreadTs =
       resolvePostedMessageThreadTs(response) ?? normalizeSlackThreadTsCandidate(opts.threadTs);
-    return {
+    return await reportDelivery({
       messageId,
       channelId: deliveredChannelId,
       threadTs: deliveredThreadTs,
@@ -806,7 +812,7 @@ async function sendMessageSlackQueuedInner(params: {
         kind: "card",
         threadTs: deliveredThreadTs,
       }),
-    };
+    });
   }
   const textLimit = resolveTextChunkLimit(cfg, "slack", account.accountId, {
     fallbackLimit: SLACK_TEXT_LIMIT,
@@ -852,6 +858,17 @@ async function sendMessageSlackQueuedInner(params: {
       maxBytes: mediaMaxBytes,
     });
     sentMessageIds.push(lastMessageId);
+    await reportDelivery({
+      messageId: lastMessageId,
+      channelId,
+      threadTs: normalizeSlackThreadTsCandidate(opts.threadTs),
+      receipt: createSlackSendReceipt({
+        platformMessageIds: [lastMessageId],
+        channelId,
+        kind: "media",
+        threadTs: normalizeSlackThreadTsCandidate(opts.threadTs),
+      }),
+    });
     chunksToPost = rest;
   } else {
     chunksToPost = resolvedChunks.length ? resolvedChunks : [""];
@@ -873,6 +890,20 @@ async function sendMessageSlackQueuedInner(params: {
     canonicalDeliveredThreadTs ??= resolvePostedMessageThreadTs(response);
     if (response.ts) {
       sentMessageIds.push(response.ts);
+      await reportDelivery({
+        messageId: response.ts,
+        channelId: deliveredChannelId,
+        threadTs:
+          resolvePostedMessageThreadTs(response) ?? normalizeSlackThreadTsCandidate(opts.threadTs),
+        receipt: createSlackSendReceipt({
+          platformMessageIds: [response.ts],
+          channelId: deliveredChannelId,
+          kind: "text",
+          threadTs:
+            resolvePostedMessageThreadTs(response) ??
+            normalizeSlackThreadTsCandidate(opts.threadTs),
+        }),
+      });
     }
   }
 

--- a/extensions/telegram/src/bot-message-context.dm-threads.test.ts
+++ b/extensions/telegram/src/bot-message-context.dm-threads.test.ts
@@ -3,6 +3,7 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { TelegramInboundBodyResult } from "./bot-message-context.body.js";
 import { resetTopicNameCacheForTest } from "./topic-name-cache.js";
 
 type SessionRuntimeModule = typeof import("./bot-message-context.session.runtime.js");
@@ -10,7 +11,7 @@ type RecordInboundSessionFn = SessionRuntimeModule["recordInboundSession"];
 type ResolveStorePathFn = SessionRuntimeModule["resolveStorePath"];
 
 const { inboundBodyResult, recordInboundSessionMock, resolveStorePathMock } = vi.hoisted(() => {
-  const createInboundBodyResult = () => ({
+  const createInboundBodyResult = (): TelegramInboundBodyResult => ({
     bodyText: "hello",
     rawBody: "hello",
     historyKey: undefined,

--- a/extensions/telegram/src/outbound-adapter.ts
+++ b/extensions/telegram/src/outbound-adapter.ts
@@ -68,6 +68,9 @@ async function resolveTelegramSendContext(params: {
   formatting?: OutboundDeliveryFormattingOptions;
   silent?: boolean;
   gatewayClientScopes?: readonly string[];
+  onDeliveryResult?: Parameters<
+    NonNullable<ChannelOutboundAdapter["sendText"]>
+  >[0]["onDeliveryResult"];
   resolveSend: ResolveTelegramSendFn;
 }): Promise<{
   send: TelegramSendFn;
@@ -83,6 +86,7 @@ async function resolveTelegramSendContext(params: {
     accountId?: string;
     silent?: boolean;
     gatewayClientScopes?: readonly string[];
+    onDeliveryResult?: TelegramSendOpts["onDeliveryResult"];
   };
 }> {
   const send = await params.resolveSend(params.deps);
@@ -98,6 +102,11 @@ async function resolveTelegramSendContext(params: {
       accountId: params.accountId ?? undefined,
       silent: params.silent,
       gatewayClientScopes: params.gatewayClientScopes,
+      onDeliveryResult: params.onDeliveryResult
+        ? async (result) => {
+            await params.onDeliveryResult?.(attachChannelToResult("telegram", result));
+          }
+        : undefined,
       ...(params.formatting?.parseMode === "HTML" ? { textMode: "html" as const } : {}),
       tableMode: params.formatting?.tableMode,
     },

--- a/extensions/telegram/src/send.test.ts
+++ b/extensions/telegram/src/send.test.ts
@@ -1479,6 +1479,24 @@ describe("sendMessageTelegram", () => {
     expect(chunks.every((chunk) => chunk.length <= 4000)).toBe(true);
   });
 
+  it("reports the first Telegram chunk before a later chunk fails", async () => {
+    botApi.sendMessage
+      .mockResolvedValueOnce({ message_id: 54, chat: { id: "123" } })
+      .mockRejectedValueOnce(new Error("second chunk failed"));
+    const onDeliveryResult = vi.fn();
+    const markdown = `# Long\n\n${"**section** with _style_ and `code`\n".repeat(3000)}`;
+
+    await expect(
+      sendMessageTelegram("123", markdown, {
+        cfg: TELEGRAM_TEST_CFG,
+        token: "tok",
+        onDeliveryResult,
+      }),
+    ).rejects.toThrow("second chunk failed");
+
+    expect(onDeliveryResult.mock.calls.map((call) => call[0]?.messageId)).toEqual(["54"]);
+  });
+
   it("chunks long inline markdown through the HTML text path", async () => {
     botApi.sendMessage.mockResolvedValue({ message_id: 52, chat: { id: "123" } });
     const markdown = `**${"A".repeat(70_000)}**`;

--- a/extensions/telegram/src/send.ts
+++ b/extensions/telegram/src/send.ts
@@ -144,6 +144,8 @@ type TelegramSendOpts = {
   buttons?: TelegramInlineButtons;
   /** Send image as document to avoid Telegram compression. Defaults to false. */
   forceDocument?: boolean;
+  /** Persist each concrete platform send before any later chunk can fail. */
+  onDeliveryResult?: (result: TelegramSendResult) => Promise<void> | void;
 };
 
 type TelegramSendResult = {
@@ -715,6 +717,12 @@ export async function sendMessageTelegram(
     verbose: opts.verbose,
     gatewayClientScopes: opts.gatewayClientScopes,
   });
+  const reportDelivery = async (messageId: string | number, deliveredChatId: string | number) => {
+    await opts.onDeliveryResult?.({
+      messageId: String(messageId),
+      chatId: String(deliveredChatId),
+    });
+  };
   const mediaUrl = opts.mediaUrl?.trim();
   const mediaMaxBytes =
     opts.maxBytes ??
@@ -892,6 +900,7 @@ export async function sendMessageTelegram(
       );
       const messageId = resolveTelegramMessageIdOrThrow(res, context);
       recordSentMessage(chatId, messageId, cfg);
+      await reportDelivery(messageId, res?.chat?.id ?? chatId);
       await recordOutboundMessageForPromptContext({
         cfg,
         account,
@@ -1072,6 +1081,7 @@ export async function sendMessageTelegram(
           );
           const fallbackMessageId = resolveTelegramMessageIdOrThrow(plainResult.result, context);
           recordSentMessage(chatId, fallbackMessageId, cfg);
+          await reportDelivery(fallbackMessageId, plainResult.result?.chat?.id ?? chatId);
           await recordOutboundMessageForPromptContext({
             cfg,
             account,
@@ -1095,6 +1105,7 @@ export async function sendMessageTelegram(
       }
       const messageId = resolveTelegramMessageIdOrThrow(result, context);
       recordSentMessage(chatId, messageId, cfg);
+      await reportDelivery(messageId, result?.chat?.id ?? chatId);
       await recordOutboundMessageForPromptContext({
         cfg,
         account,
@@ -1350,6 +1361,7 @@ export async function sendMessageTelegram(
     const mediaMessageId = resolveTelegramMessageIdOrThrow(result, "media send");
     const resolvedChatId = String(result?.chat?.id ?? chatId);
     recordSentMessage(chatId, mediaMessageId, cfg);
+    await reportDelivery(mediaMessageId, resolvedChatId);
     await recordOutboundMessageForPromptContext({
       cfg,
       account,

--- a/extensions/twitch/src/outbound.test.ts
+++ b/extensions/twitch/src/outbound.test.ts
@@ -228,6 +228,40 @@ describe("outbound", () => {
         { capability: "afterCommit", status: "not_declared" },
       ]);
     });
+
+    it("adapts outbound progress into message receipts", async () => {
+      const progress = {
+        channel: "twitch",
+        messageId: "twitch-progress-1",
+        receipt: twitchTestReceipt("twitch-progress-1"),
+      };
+      const sendText = twitchOutbound.sendText;
+      if (!sendText) {
+        throw new Error("Twitch text sending is not available.");
+      }
+      const sendSpy = vi.spyOn(twitchOutbound, "sendText").mockImplementationOnce(async (ctx) => {
+        await ctx.onDeliveryResult?.(progress);
+        return progress;
+      });
+      const onDeliveryResult = vi.fn();
+
+      try {
+        await twitchMessageAdapter.send?.text?.({
+          cfg: mockConfig,
+          to: "#testchannel",
+          text: "Hello Twitch!",
+          accountId: "default",
+          onDeliveryResult,
+        });
+      } finally {
+        sendSpy.mockRestore();
+      }
+
+      expect(onDeliveryResult).toHaveBeenCalledOnce();
+      expect(onDeliveryResult.mock.calls[0]?.[0]?.receipt.platformMessageIds).toEqual([
+        "twitch-progress-1",
+      ]);
+    });
   });
 
   describe("resolveTarget", () => {

--- a/extensions/twitch/src/outbound.ts
+++ b/extensions/twitch/src/outbound.ts
@@ -229,13 +229,35 @@ export const twitchMessageAdapter = defineChannelMessageAdapter({
       if (!twitchOutbound.sendText) {
         throw new Error("Twitch text sending is not available.");
       }
-      return toTwitchMessageSendResult(await twitchOutbound.sendText(ctx), "text");
+      const { onDeliveryResult, ...outboundCtx } = ctx;
+      const result = await twitchOutbound.sendText({
+        ...outboundCtx,
+        ...(onDeliveryResult
+          ? {
+              onDeliveryResult: async (progress) => {
+                await onDeliveryResult(toTwitchMessageSendResult(progress, "text"));
+              },
+            }
+          : {}),
+      });
+      return toTwitchMessageSendResult(result, "text");
     },
     media: async (ctx) => {
       if (!twitchOutbound.sendMedia) {
         throw new Error("Twitch media sending is not available.");
       }
-      return toTwitchMessageSendResult(await twitchOutbound.sendMedia(ctx), "media");
+      const { onDeliveryResult, ...outboundCtx } = ctx;
+      const result = await twitchOutbound.sendMedia({
+        ...outboundCtx,
+        ...(onDeliveryResult
+          ? {
+              onDeliveryResult: async (progress) => {
+                await onDeliveryResult(toTwitchMessageSendResult(progress, "media"));
+              },
+            }
+          : {}),
+      });
+      return toTwitchMessageSendResult(result, "media");
     },
   },
 });

--- a/extensions/whatsapp/src/channel-outbound.test.ts
+++ b/extensions/whatsapp/src/channel-outbound.test.ts
@@ -203,6 +203,7 @@ describe("whatsappChannelOutbound", () => {
       cfg: {},
       accountId: undefined,
       gifPlayback: undefined,
+      onDeliveryResult: expect.any(Function),
       preserveLeadingWhitespace: true,
     });
   });

--- a/extensions/whatsapp/src/channel-outbound.ts
+++ b/extensions/whatsapp/src/channel-outbound.ts
@@ -77,12 +77,16 @@ export const whatsappMessageAdapter = defineChannelMessageAdapter({
     },
   },
   send: {
-    text: async (ctx) =>
-      toWhatsAppMessageSendResult(
-        await whatsappChannelOutbound.sendText!({
-          ...ctx,
-        }),
-        ctx.replyToId,
-      ),
+    text: async ({ onDeliveryResult, ...ctx }) => {
+      const result = await whatsappChannelOutbound.sendText!({
+        ...ctx,
+        onDeliveryResult: onDeliveryResult
+          ? async (progress) => {
+              await onDeliveryResult(toWhatsAppMessageSendResult(progress, ctx.replyToId));
+            }
+          : undefined,
+      });
+      return toWhatsAppMessageSendResult(result, ctx.replyToId);
+    },
   },
 });

--- a/extensions/whatsapp/src/outbound-base.test.ts
+++ b/extensions/whatsapp/src/outbound-base.test.ts
@@ -106,6 +106,41 @@ describe("createWhatsAppOutboundBase", () => {
     expect(options.accountId).toBe("default");
   });
 
+  it("forwards internal send progress with channel identity", async () => {
+    const sendMessageWhatsApp = vi.fn(async (_to, _text, options) => {
+      await options.onDeliveryResult?.({
+        messageId: "msg-voice",
+        toJid: "15551234567@s.whatsapp.net",
+      });
+      return {
+        messageId: "msg-caption",
+        toJid: "15551234567@s.whatsapp.net",
+      };
+    });
+    const outbound = createWhatsAppOutboundBase({
+      chunker: (text) => [text],
+      sendMessageWhatsApp,
+      sendPollWhatsApp: vi.fn(),
+      shouldLogVerbose: () => false,
+      resolveTarget: ({ to }) => ({ ok: true as const, to: to ?? "" }),
+    });
+    const onDeliveryResult = vi.fn();
+
+    await outbound.sendMedia!({
+      cfg: {} as never,
+      to: "whatsapp:+15551234567",
+      text: "voice",
+      mediaUrl: "/tmp/voice.ogg",
+      onDeliveryResult,
+    });
+
+    expect(onDeliveryResult).toHaveBeenCalledWith({
+      channel: "whatsapp",
+      messageId: "msg-voice",
+      toJid: "15551234567@s.whatsapp.net",
+    });
+  });
+
   it("uses the configured default account for quote metadata lookup when accountId is omitted", async () => {
     cacheInboundMessageMeta("work", "15551234567@s.whatsapp.net", "reply-1", {
       participant: "111@s.whatsapp.net",

--- a/extensions/whatsapp/src/outbound-base.ts
+++ b/extensions/whatsapp/src/outbound-base.ts
@@ -7,6 +7,7 @@ import {
 } from "openclaw/plugin-sdk/account-core";
 import { resolveOutboundSendDep } from "openclaw/plugin-sdk/channel-outbound";
 import {
+  attachChannelToResult,
   createAttachedChannelResultAdapter,
   type ChannelOutboundAdapter,
 } from "openclaw/plugin-sdk/channel-send-result";
@@ -43,6 +44,8 @@ type WhatsAppSendTextOptions = {
     messageText?: string;
   };
   preserveLeadingWhitespace?: boolean;
+  /** Report each accepted internal platform send before the next fallible send. */
+  onDeliveryResult?: (result: { messageId: string; toJid: string }) => Promise<void> | void;
 };
 type WhatsAppSendMessage = (
   to: string,
@@ -159,7 +162,16 @@ export function createWhatsAppOutboundBase({
     resolveTarget,
     ...createAttachedChannelResultAdapter({
       channel: "whatsapp",
-      sendText: async ({ cfg, to, text, accountId, deps, gifPlayback, replyToId }) => {
+      sendText: async ({
+        cfg,
+        to,
+        text,
+        accountId,
+        deps,
+        gifPlayback,
+        replyToId,
+        onDeliveryResult,
+      }) => {
         const normalizedText = normalizeText(text);
         if (skipEmptyText && !normalizedText) {
           return { messageId: "" };
@@ -180,7 +192,14 @@ export function createWhatsAppOutboundBase({
           cfg,
           accountId: accountId ?? undefined,
           gifPlayback,
-          quotedMessageKey,
+          ...(quotedMessageKey ? { quotedMessageKey } : {}),
+          ...(onDeliveryResult
+            ? {
+                onDeliveryResult: async (result) => {
+                  await onDeliveryResult(attachChannelToResult("whatsapp", result));
+                },
+              }
+            : {}),
         });
       },
       sendMedia: async ({
@@ -197,6 +216,7 @@ export function createWhatsAppOutboundBase({
         gifPlayback,
         forceDocument,
         replyToId,
+        onDeliveryResult,
       }) => {
         const lookupAccountId = resolveQuoteLookupAccountId(cfg, accountId);
         const quotedMessageKey = resolveQuotedMessageKey({
@@ -220,7 +240,14 @@ export function createWhatsAppOutboundBase({
           accountId: accountId ?? undefined,
           gifPlayback,
           forceDocument,
-          quotedMessageKey,
+          ...(quotedMessageKey ? { quotedMessageKey } : {}),
+          ...(onDeliveryResult
+            ? {
+                onDeliveryResult: async (result) => {
+                  await onDeliveryResult(attachChannelToResult("whatsapp", result));
+                },
+              }
+            : {}),
         });
       },
       sendPoll: async ({ cfg, to, poll, accountId }) =>

--- a/extensions/whatsapp/src/send.test.ts
+++ b/extensions/whatsapp/src/send.test.ts
@@ -299,6 +299,33 @@ describe("web outbound", () => {
     expect(sendMessage).toHaveBeenNthCalledWith(2, "+1555", "voice note", undefined, undefined);
   });
 
+  it("reports the accepted voice send before a caption failure", async () => {
+    const buf = Buffer.from("audio");
+    loadWebMediaMock.mockResolvedValueOnce({
+      buffer: buf,
+      contentType: "audio/ogg",
+      kind: "audio",
+    });
+    sendMessage
+      .mockResolvedValueOnce(createAcceptedWhatsAppSendResult("media", "voice-accepted"))
+      .mockRejectedValueOnce(new Error("caption failed"));
+    const onDeliveryResult = vi.fn();
+
+    await expect(
+      sendMessageWhatsApp("+1555", "voice note", {
+        verbose: false,
+        cfg: WHATSAPP_TEST_CFG,
+        mediaUrl: "/tmp/voice.ogg",
+        onDeliveryResult,
+      }),
+    ).rejects.toThrow("caption failed");
+
+    expect(onDeliveryResult).toHaveBeenCalledOnce();
+    expect(onDeliveryResult).toHaveBeenCalledWith(
+      expect.objectContaining({ messageId: "voice-accepted" }),
+    );
+  });
+
   it.each([
     { name: "mp3", contentType: "audio/mpeg", fileName: "voice.mp3" },
     { name: "webm", contentType: "audio/webm", fileName: "voice.webm" },

--- a/extensions/whatsapp/src/send.ts
+++ b/extensions/whatsapp/src/send.ts
@@ -150,6 +150,8 @@ export async function sendMessageWhatsApp(
       messageText?: string;
     };
     preserveLeadingWhitespace?: boolean;
+    /** Report each accepted internal platform send before the next fallible send. */
+    onDeliveryResult?: (result: { messageId: string; toJid: string }) => Promise<void> | void;
   },
 ): Promise<{ messageId: string; toJid: string }> {
   let text = options.preserveLeadingWhitespace ? body : normalizeWhatsAppPayloadText(body);
@@ -244,15 +246,20 @@ export async function sendMessageWhatsApp(
     const result = sendOptions
       ? await active.sendMessage(to, text, mediaBuffer, mediaType, sendOptions)
       : await active.sendMessage(to, text, mediaBuffer, mediaType);
-    if (visibleTextAfterVoice) {
-      if (sendOptions) {
-        await active.sendMessage(to, visibleTextAfterVoice, undefined, undefined, sendOptions);
-      } else {
-        await active.sendMessage(to, visibleTextAfterVoice, undefined, undefined);
-      }
-    }
     const messageId = (result as { messageId?: string })?.messageId ?? "unknown";
     const sentRemoteJid = resolveActualSentRemoteJid(result, jid);
+    if (visibleTextAfterVoice) {
+      // Voice captions require a second platform send. Persist the accepted voice
+      // first so a caption failure cannot make recovery replay the voice note.
+      await options.onDeliveryResult?.({ messageId, toJid: sentRemoteJid });
+      const captionResult = sendOptions
+        ? await active.sendMessage(to, visibleTextAfterVoice, undefined, undefined, sendOptions)
+        : await active.sendMessage(to, visibleTextAfterVoice, undefined, undefined);
+      await options.onDeliveryResult?.({
+        messageId: (captionResult as { messageId?: string })?.messageId ?? "unknown",
+        toJid: resolveActualSentRemoteJid(captionResult, jid),
+      });
+    }
     if (messageId && messageId !== "unknown" && text) {
       registerWhatsAppApprovalReactionTargetForOutboundMessage({
         accountId: resolvedAccountId,

--- a/extensions/zalo/src/channel.ts
+++ b/extensions/zalo/src/channel.ts
@@ -304,6 +304,7 @@ export const zaloPlugin: ChannelPlugin<ResolvedZaloAccount, ZaloProbeResult> =
           sendText: (nextCtx) => zaloRawSendResultAdapter.sendText!(nextCtx),
           sendMedia: (nextCtx) => zaloRawSendResultAdapter.sendMedia!(nextCtx),
           emptyResult: createEmptyChannelResult("zalo"),
+          onResult: ctx.onDeliveryResult,
         }),
       ...zaloRawSendResultAdapter,
     },

--- a/extensions/zalouser/src/channel.adapters.ts
+++ b/extensions/zalouser/src/channel.adapters.ts
@@ -1,10 +1,14 @@
 // Zalouser plugin module implements channel.adapters behavior.
 import { createScopedDmSecurityResolver } from "openclaw/plugin-sdk/channel-config-helpers";
-import { defineChannelMessageAdapter } from "openclaw/plugin-sdk/channel-outbound";
+import {
+  defineChannelMessageAdapter,
+  type ChannelMessageSendResult,
+} from "openclaw/plugin-sdk/channel-outbound";
 import { createPairingPrefixStripper } from "openclaw/plugin-sdk/channel-pairing";
 import {
   createEmptyChannelResult,
-  createRawChannelSendResultAdapter,
+  type ChannelOutboundAdapter,
+  type OutboundDeliveryResult,
 } from "openclaw/plugin-sdk/channel-send-result";
 import { createStaticReplyToModeResolver } from "openclaw/plugin-sdk/conversation-runtime";
 import { createLazyRuntimeModule } from "openclaw/plugin-sdk/lazy-runtime";
@@ -40,6 +44,7 @@ import {
   parseZalouserOutboundTarget,
   resolveZalouserOutboundSessionRoute,
 } from "./session-route.js";
+import type { ZaloSendResult } from "./types.js";
 
 const loadZalouserChannelRuntime = createLazyRuntimeModule(() => import("./channel.runtime.js"));
 
@@ -50,6 +55,7 @@ type ZalouserSendTextContext = {
   text: string;
   accountId?: string | null;
   cfg: OpenClawConfig;
+  onDeliveryResult?: (result: ChannelMessageSendResult) => Promise<void> | void;
 };
 
 type ZalouserSendMediaContext = ZalouserSendTextContext & {
@@ -74,6 +80,13 @@ function resolveZalouserOutboundTextChunkLimit(cfg: OpenClawConfig, accountId?: 
   return getZalouserRuntime().channel.text.resolveTextChunkLimit(cfg, "zalouser", accountId, {
     fallbackLimit: ZALOUSER_TEXT_CHUNK_LIMIT,
   });
+}
+
+function toZalouserMessageSendResult(result: ZaloSendResult): ChannelMessageSendResult {
+  return {
+    messageId: result.messageId,
+    receipt: result.receipt,
+  };
 }
 
 function resolveZalouserGroupPolicyEntry(params: ChannelGroupContext) {
@@ -107,17 +120,27 @@ function resolveZalouserRequireMention(params: ChannelGroupContext): boolean {
   return true;
 }
 
-async function sendZalouserTextFromContext({ to, text, accountId, cfg }: ZalouserSendTextContext) {
+async function sendZalouserTextFromContext({
+  to,
+  text,
+  accountId,
+  cfg,
+  onDeliveryResult,
+}: ZalouserSendTextContext) {
   const { sendMessageZalouser } = await loadZalouserChannelRuntime();
   const account = resolveZalouserAccountSync({ cfg, accountId });
   const target = parseZalouserOutboundTarget(to);
-  return await sendMessageZalouser(target.threadId, text, {
+  const result = await sendMessageZalouser(target.threadId, text, {
     profile: account.profile,
     isGroup: target.isGroup,
     textMode: "markdown",
     textChunkMode: resolveZalouserOutboundChunkMode(cfg, account.accountId),
     textChunkLimit: resolveZalouserOutboundTextChunkLimit(cfg, account.accountId),
+    onDeliveryResult: async (progress) => {
+      await onDeliveryResult?.(toZalouserMessageSendResult(progress));
+    },
   });
+  return toZalouserMessageSendResult(result);
 }
 
 async function sendZalouserMediaFromContext({
@@ -128,11 +151,12 @@ async function sendZalouserMediaFromContext({
   cfg,
   mediaLocalRoots,
   mediaReadFile,
+  onDeliveryResult,
 }: ZalouserSendMediaContext) {
   const { sendMessageZalouser } = await loadZalouserChannelRuntime();
   const account = resolveZalouserAccountSync({ cfg, accountId });
   const target = parseZalouserOutboundTarget(to);
-  return await sendMessageZalouser(target.threadId, text, {
+  const result = await sendMessageZalouser(target.threadId, text, {
     profile: account.profile,
     isGroup: target.isGroup,
     mediaUrl,
@@ -141,14 +165,51 @@ async function sendZalouserMediaFromContext({
     textMode: "markdown",
     textChunkMode: resolveZalouserOutboundChunkMode(cfg, account.accountId),
     textChunkLimit: resolveZalouserOutboundTextChunkLimit(cfg, account.accountId),
+    onDeliveryResult: async (progress) => {
+      await onDeliveryResult?.(toZalouserMessageSendResult(progress));
+    },
+  });
+  return toZalouserMessageSendResult(result);
+}
+
+function adaptZalouserOutboundProgress(
+  onDeliveryResult: ((result: OutboundDeliveryResult) => Promise<void> | void) | undefined,
+) {
+  return onDeliveryResult
+    ? async (result: ChannelMessageSendResult) => {
+        await onDeliveryResult(toZalouserOutboundDeliveryResult(result));
+      }
+    : undefined;
+}
+
+function toZalouserOutboundDeliveryResult(
+  result: ChannelMessageSendResult,
+): OutboundDeliveryResult {
+  return createEmptyChannelResult("zalouser", {
+    messageId:
+      result.messageId ??
+      result.receipt.primaryPlatformMessageId ??
+      result.receipt.platformMessageIds[0],
+    receipt: result.receipt,
   });
 }
 
-const zalouserRawSendResultAdapter = createRawChannelSendResultAdapter({
-  channel: "zalouser",
-  sendText: sendZalouserTextFromContext,
-  sendMedia: sendZalouserMediaFromContext,
-});
+const zalouserRawSendResultAdapter: Pick<ChannelOutboundAdapter, "sendText" | "sendMedia"> = {
+  sendText: async ({ onDeliveryResult, ...ctx }) =>
+    toZalouserOutboundDeliveryResult(
+      await sendZalouserTextFromContext({
+        ...ctx,
+        onDeliveryResult: adaptZalouserOutboundProgress(onDeliveryResult),
+      }),
+    ),
+  sendMedia: async ({ onDeliveryResult, ...ctx }) =>
+    toZalouserOutboundDeliveryResult(
+      await sendZalouserMediaFromContext({
+        ...ctx,
+        onDeliveryResult: adaptZalouserOutboundProgress(onDeliveryResult),
+      }),
+    ),
+};
 
 export const zalouserMessageAdapter = defineChannelMessageAdapter({
   id: "zalouser",

--- a/extensions/zalouser/src/channel.sendpayload.test.ts
+++ b/extensions/zalouser/src/channel.sendpayload.test.ts
@@ -193,6 +193,59 @@ describe("zalouserPlugin outbound sendPayload", () => {
     expect(result.messageId).toBe("zlu-code");
   });
 
+  it("forwards internal chunk progress through the outbound adapter", async () => {
+    mockedSend.mockImplementationOnce(async (_threadId, _text, options) => {
+      const onDeliveryResult = options?.onDeliveryResult;
+      if (!onDeliveryResult) {
+        throw new Error("missing progress callback");
+      }
+      await onDeliveryResult({ ok: true, messageId: "zlu-part-1" } as never);
+      await onDeliveryResult({ ok: true, messageId: "zlu-part-2" } as never);
+      return { ok: true, messageId: "zlu-part-2" } as never;
+    });
+    const onDeliveryResult = vi.fn();
+    const sendPayload = requireZalouserSendPayload();
+
+    await sendPayload({
+      ...baseCtx({ text: "chunked internally" }),
+      to: "987654321",
+      onDeliveryResult,
+    });
+
+    expect(onDeliveryResult.mock.calls.map((call) => call[0]?.messageId)).toEqual([
+      "zlu-part-1",
+      "zlu-part-2",
+    ]);
+  });
+
+  it("forwards internal chunk progress through the message adapter", async () => {
+    const receipt = createMessageReceiptFromOutboundResults({
+      results: [{ channel: "zalouser", messageId: "zlu-message-part" }],
+      kind: "text",
+    });
+    mockedSend.mockImplementationOnce(async (_threadId, _text, options) => {
+      const onDeliveryResult = options?.onDeliveryResult;
+      if (!onDeliveryResult) {
+        throw new Error("missing progress callback");
+      }
+      await onDeliveryResult({ ok: true, messageId: "zlu-message-part", receipt } as never);
+      return { ok: true, messageId: "zlu-message-part", receipt } as never;
+    });
+    const onDeliveryResult = vi.fn();
+    const sendText = requireZalouserTextSender(requireZalouserMessageAdapter());
+
+    await sendText({
+      cfg: {},
+      to: "user:987654321",
+      text: "chunked internally",
+      onDeliveryResult,
+    });
+
+    expect(onDeliveryResult).toHaveBeenCalledOnce();
+    expect(onDeliveryResult.mock.calls[0]?.[0]?.messageId).toBe("zlu-message-part");
+    expect(onDeliveryResult.mock.calls[0]?.[0]?.receipt).toBe(receipt);
+  });
+
   it("declares message adapter durable text and media with receipt proofs", async () => {
     mockedSend.mockImplementation(async (_threadId, _text, opts: { mediaUrl?: string } = {}) =>
       opts.mediaUrl

--- a/extensions/zalouser/src/send.test.ts
+++ b/extensions/zalouser/src/send.test.ts
@@ -208,6 +208,26 @@ describe("zalouser send helpers", () => {
     expectResultFields(result, { ok: true, messageId: "mid-2c-2" });
   });
 
+  it("reports each completed internal chunk before a later chunk fails", async () => {
+    const firstResult = sendResult("mid-progress-1", "thread-progress");
+    mockSendText
+      .mockResolvedValueOnce(firstResult)
+      .mockResolvedValueOnce(sendFailure("second chunk failed", "thread-progress"));
+    const onDeliveryResult = vi.fn();
+
+    await expect(
+      sendMessageZalouser("thread-progress", "a".repeat(2001), {
+        textChunkLimit: 2000,
+        onDeliveryResult,
+      }),
+    ).rejects.toThrow("second chunk failed");
+
+    expect(mockSendText).toHaveBeenCalledTimes(2);
+    expect(onDeliveryResult).toHaveBeenCalledOnce();
+    expect(onDeliveryResult).toHaveBeenCalledWith(firstResult);
+    expect(requireSendTextOptions(0)).not.toHaveProperty("onDeliveryResult");
+  });
+
   it("preserves text styles when splitting long formatted markdown", async () => {
     const text = `**${"a".repeat(2501)}**`;
     mockSendText

--- a/extensions/zalouser/src/send.ts
+++ b/extensions/zalouser/src/send.ts
@@ -12,7 +12,10 @@ import {
 } from "./zalo-js.js";
 import { TextStyle } from "./zca-constants.js";
 
-type ZalouserSendOptions = ZaloSendOptions;
+type ZalouserSendOptions = ZaloSendOptions & {
+  /** Persist each concrete platform send before the next internal chunk starts. */
+  onDeliveryResult?: (result: ZaloSendResult) => Promise<void> | void;
+};
 type ZalouserSendResult = ZaloSendResult;
 
 const ZALO_TEXT_LIMIT = 2000;
@@ -30,25 +33,26 @@ export async function sendMessageZalouser(
   text: string,
   options: ZalouserSendOptions = {},
 ): Promise<ZalouserSendResult> {
+  const { onDeliveryResult, ...transportOptions } = options;
   const prepared =
-    options.textMode === "markdown"
+    transportOptions.textMode === "markdown"
       ? parseZalouserTextStyles(text)
-      : { text, styles: options.textStyles };
-  const textChunkLimit = options.textChunkLimit ?? ZALO_TEXT_LIMIT;
+      : { text, styles: transportOptions.textStyles };
+  const textChunkLimit = transportOptions.textChunkLimit ?? ZALO_TEXT_LIMIT;
   const chunks = splitStyledText(
     prepared.text,
     (prepared.styles?.length ?? 0) > 0 ? prepared.styles : undefined,
     textChunkLimit,
-    options.textChunkMode,
+    transportOptions.textChunkMode,
   );
 
   let lastResult: ZalouserSendResult | null = null;
   for (const [index, chunk] of chunks.entries()) {
     const chunkOptions =
       index === 0
-        ? { ...options, textStyles: chunk.styles }
+        ? { ...transportOptions, textStyles: chunk.styles }
         : {
-            ...options,
+            ...transportOptions,
             caption: undefined,
             mediaLocalRoots: undefined,
             mediaUrl: undefined,
@@ -56,8 +60,9 @@ export async function sendMessageZalouser(
           };
     const result = await sendZaloTextMessage(threadId, chunk.text, chunkOptions);
     if (!result.ok) {
-      return result;
+      throw new Error(result.error || "Failed to send Zalouser message");
     }
+    await onDeliveryResult?.(result);
     lastResult = result;
   }
 

--- a/scripts/apple-app-i18n.ts
+++ b/scripts/apple-app-i18n.ts
@@ -42,6 +42,15 @@ const CATALOGS = [
         "Sent to OpenClaw.",
       ],
       "apps/ios/Sources/Design/SettingsChannelsDestination.swift": ["Logout"],
+      "apps/ios/Sources/Design/ChatProTab.swift": [
+        "Check OpenClaw status",
+        "Help me start a realtime voice session from this phone.",
+        "Help me start voice chat",
+        "Show me which phone controls and device capabilities are available right now.",
+        "Summarize the current OpenClaw status and tell me what needs attention.",
+        "What can I control here?",
+        "What would you like to work on?",
+      ],
       "apps/ios/Sources/Gateway/GatewayProblemView.swift": ["Done"],
       "apps/ios/Sources/Gateway/GatewayQuickSetupSheet.swift": [
         "Close",

--- a/scripts/native-app-i18n.ts
+++ b/scripts/native-app-i18n.ts
@@ -76,6 +76,8 @@ const APPLE_EXTENSIONS = new Set([".swift", ".plist"]);
 const NATIVE_FORMAT_RE = /%(?:\d+\$)?[@a-z]/giu;
 const APPLE_UI_MULTILINE_CALLS =
   /(?:Text|Label|Button|TextField|SecureField|Picker|Section|LabeledContent|Toggle|Menu|ShareLink|Link|TextEditor|ProgressView|Gauge|DisclosureGroup|ControlGroup|DatePicker|Stepper)\s*\(\s*"""([\s\S]*?)"""/gu;
+const APPLE_LOCALIZED_STRING_CALLS =
+  /\b(?:String\s*\(\s*localized:|LocalizedStringResource\s*\()\s*"((?:\\.|[^"\\])*)"/gu;
 const APPLE_CALL_START = /\b([A-Za-z_][A-Za-z0-9_]*)\s*\(\s*/gu;
 const APPLE_MODIFIER_CALLS =
   /\.(?:navigationTitle|accessibilityLabel|accessibilityHint|help|alert|confirmationDialog)\s*\(\s*"((?:\\.|[^"\\])*)"/gu;
@@ -626,6 +628,7 @@ function extractCandidates(
     surface === "apple"
       ? [
           [APPLE_UI_MULTILINE_CALLS, "ui-call-multiline"],
+          [APPLE_LOCALIZED_STRING_CALLS, "ui-localized-call"],
           [APPLE_MODIFIER_CALLS, "ui-modifier"],
           [APPLE_MODIFIER_MULTILINE_CALLS, "ui-modifier-multiline"],
           ...CONDITIONAL_BRANCHES.map((pattern) => [pattern, "conditional-branch"] as const),

--- a/src/agents/agent-command.ts
+++ b/src/agents/agent-command.ts
@@ -1865,6 +1865,7 @@ async function agentCommandInternal(
         });
 
         let fallbackAttemptIndex = 0;
+        const fallbackRuntimeState: { originRuntime?: "cli" | "embedded" } = {};
         attemptLifecycleState.currentTurnUserMessagePersisted = false;
         const fallbackResult = await runWithModelFallback<AgentAttemptResult>({
           cfg,
@@ -1981,6 +1982,7 @@ async function agentCommandInternal(
               sessionHasHistory:
                 !isNewSession ||
                 (await attemptExecutionRuntime.sessionFileHasContent(attemptSessionFile)),
+              fallbackRuntimeState,
               suppressPromptPersistenceOnRetry:
                 suppressUserTurnPersistence ||
                 userTurnTranscriptRecorder.hasPersisted() ||

--- a/src/agents/agent-tools.create-openclaw-coding-tools.test.ts
+++ b/src/agents/agent-tools.create-openclaw-coding-tools.test.ts
@@ -620,6 +620,33 @@ describe("createOpenClawCodingTools", () => {
     }
   });
 
+  it("forwards owner identity to plugin-only tool construction", () => {
+    const resolvePluginToolsSpy = vi
+      .spyOn(openClawPluginTools, "resolveOpenClawPluginToolsForOptions")
+      .mockReturnValue([]);
+
+    try {
+      createOpenClawCodingTools({
+        config: testConfig,
+        includeCoreTools: false,
+        runtimeToolAllowlist: ["codex_threads"],
+        senderIsOwner: true,
+        toolConstructionPlan: {
+          includeBaseCodingTools: false,
+          includeShellTools: false,
+          includeChannelTools: false,
+          includeOpenClawTools: false,
+          includePluginTools: true,
+        },
+      });
+
+      expect(resolvePluginToolsSpy).toHaveBeenCalledTimes(1);
+      expect(resolvePluginToolsSpy.mock.calls[0]?.[0].options?.senderIsOwner).toBe(true);
+    } finally {
+      resolvePluginToolsSpy.mockRestore();
+    }
+  });
+
   it("forwards auth profiles to plugin-only tool construction", () => {
     const createOpenClawToolsMock = vi.mocked(createOpenClawTools);
     createOpenClawToolsMock.mockClear();

--- a/src/agents/agent-tools.ts
+++ b/src/agents/agent-tools.ts
@@ -519,7 +519,7 @@ export function createOpenClawCodingTools(options?: {
   toolSearchCatalogRef?: ToolSearchCatalogRef;
   /** Limits which tool families are materialized before the shared policy pipeline runs. */
   toolConstructionPlan?: OpenClawCodingToolConstructionPlan;
-  /** Trusted sender identity bit for command/channel-action auth; does not filter model tools. */
+  /** Trusted sender identity bit for command/channel-action auth and owner-gated plugin tools. */
   senderIsOwner?: boolean;
   /** Auth profiles already loaded for this run; used for prompt-time tool availability. */
   authProfileStore?: AuthProfileStore;

--- a/src/agents/agent-tools.ts
+++ b/src/agents/agent-tools.ts
@@ -904,6 +904,7 @@ export function createOpenClawCodingTools(options?: {
             config: options?.config,
             fsPolicy,
             requesterSenderId: options?.senderId,
+            senderIsOwner: options?.senderIsOwner,
             sessionId: options?.sessionId,
             oneShotCliRun: options?.oneShotCliRun,
             sandboxBrowserBridgeUrl: sandbox?.browser?.bridgeUrl,

--- a/src/agents/command/attempt-execution.cli.test.ts
+++ b/src/agents/command/attempt-execution.cli.test.ts
@@ -217,6 +217,10 @@ describe("CLI attempt execution", () => {
     runId?: string;
     body?: string;
     transcriptBody?: string;
+    providerOverride?: string;
+    modelOverride?: string;
+    isFallbackRetry?: boolean;
+    fallbackRuntimeState?: RunAgentAttemptParams["fallbackRuntimeState"];
     userTurnTranscriptRecorder?: RunAgentAttemptParams["userTurnTranscriptRecorder"];
   }) {
     const runId = overrides?.runId ?? "run-embedded-live-stream-gate";
@@ -230,11 +234,12 @@ describe("CLI attempt execution", () => {
     runEmbeddedAgentMock.mockResolvedValueOnce({
       meta: { durationMs: 1 },
     } satisfies EmbeddedAgentRunResult);
+    const providerOverride = overrides?.providerOverride ?? "openai";
 
     await runAgentAttempt({
-      providerOverride: "openai",
+      providerOverride,
       originalProvider: "openai",
-      modelOverride: "gpt-5.4",
+      modelOverride: overrides?.modelOverride ?? "gpt-5.4",
       cfg: {} as OpenClawConfig,
       sessionEntry,
       sessionId: sessionEntry.sessionId,
@@ -244,7 +249,8 @@ describe("CLI attempt execution", () => {
       workspaceDir: tmpDir,
       body: overrides?.body ?? "stream gate",
       transcriptBody: overrides?.transcriptBody,
-      isFallbackRetry: false,
+      isFallbackRetry: overrides?.isFallbackRetry ?? false,
+      fallbackRuntimeState: overrides?.fallbackRuntimeState,
       resolvedThinkLevel: "medium",
       timeoutMs: 1_000,
       runId,
@@ -259,14 +265,14 @@ describe("CLI attempt execution", () => {
       resolvedVerboseLevel: undefined,
       agentDir: tmpDir,
       onAgentEvent: vi.fn(),
-      authProfileProvider: "openai",
+      authProfileProvider: providerOverride,
       sessionStore,
       storePath,
       sessionHasHistory: false,
       userTurnTranscriptRecorder: overrides?.userTurnTranscriptRecorder,
     });
 
-    return firstEmbeddedAgentArg();
+    return firstEmbeddedAgentArg(runEmbeddedAgentMock.mock.calls.length - 1);
   }
 
   beforeEach(async () => {
@@ -2016,7 +2022,6 @@ describe("CLI attempt execution", () => {
         cwd: tmpDir,
       },
     });
-
     await runAgentAttempt({
       providerOverride: "claude-cli",
       originalProvider: "claude-cli",
@@ -2066,6 +2071,7 @@ describe("CLI attempt execution", () => {
     const sessionStore: Record<string, SessionEntry> = { [sessionKey]: sessionEntry };
     await fs.writeFile(storePath, JSON.stringify(sessionStore, null, 2), "utf-8");
     runCliAgentMock.mockResolvedValueOnce(makeCliResult("canonical cli"));
+    const fallbackRuntimeState: NonNullable<RunAgentAttemptParams["fallbackRuntimeState"]> = {};
 
     await runAgentAttempt({
       providerOverride: "anthropic",
@@ -2103,6 +2109,7 @@ describe("CLI attempt execution", () => {
       sessionStore,
       storePath,
       sessionHasHistory: false,
+      fallbackRuntimeState,
     });
 
     expect(runEmbeddedAgentMock).not.toHaveBeenCalled();
@@ -2110,6 +2117,16 @@ describe("CLI attempt execution", () => {
       provider: "claude-cli",
       model: "claude-opus-4-7",
     });
+    expect(fallbackRuntimeState.originRuntime).toBe("cli");
+
+    const images = [{ type: "image" as const, data: "aGVsbG8=", mimeType: "image/png" }];
+    const fallbackArg = await runOpenClawEmbeddedAttemptForTest({
+      runId: "run-canonical-claude-cli-fallback",
+      isFallbackRetry: true,
+      fallbackRuntimeState,
+      opts: { images },
+    });
+    expect(fallbackArg.images).toEqual(images);
   });
 
   it("routes provider-qualified Anthropic shorthand through the configured Claude CLI runtime", async () => {
@@ -2295,6 +2312,52 @@ describe("CLI attempt execution", () => {
       userTurnTranscriptRecorder: recorder,
       suppressNextUserMessagePersistence: false,
     });
+  });
+
+  it.each([
+    { originRuntime: undefined, retry: false, expectedImages: true },
+    { originRuntime: "cli" as const, retry: true, expectedImages: true },
+    { originRuntime: "embedded" as const, retry: true, expectedImages: false },
+  ])(
+    "forwards embedded images for originRuntime=$originRuntime retry=$retry",
+    async ({ originRuntime, retry, expectedImages }) => {
+      const images = [{ type: "image" as const, data: "aGVsbG8=", mimeType: "image/png" }];
+      const imageOrder = ["inline" as const];
+      const embeddedArg = await runOpenClawEmbeddedAttemptForTest({
+        runId: `embedded-image-fallback-${originRuntime ?? "unset"}-${retry}`,
+        isFallbackRetry: retry,
+        fallbackRuntimeState: originRuntime === undefined ? undefined : { originRuntime },
+        opts: { images, imageOrder },
+      });
+
+      expect(embeddedArg.images).toEqual(expectedImages ? images : undefined);
+      expect(embeddedArg.imageOrder).toEqual(expectedImages ? imageOrder : undefined);
+    },
+  );
+
+  it("records raw CLI-shaped model runs as embedded origins", async () => {
+    const images = [{ type: "image" as const, data: "aGVsbG8=", mimeType: "image/png" }];
+    const fallbackRuntimeState: NonNullable<RunAgentAttemptParams["fallbackRuntimeState"]> = {};
+
+    const firstArg = await runOpenClawEmbeddedAttemptForTest({
+      runId: "raw-cli-shaped-origin",
+      providerOverride: "claude-cli",
+      modelOverride: "claude-opus-4-7",
+      fallbackRuntimeState,
+      opts: { modelRun: true, images },
+    });
+    expect(fallbackRuntimeState.originRuntime).toBe("embedded");
+    expect(firstArg.images).toEqual(images);
+
+    const retryArg = await runOpenClawEmbeddedAttemptForTest({
+      runId: "raw-cli-shaped-origin-retry",
+      providerOverride: "claude-cli",
+      modelOverride: "claude-opus-4-7",
+      isFallbackRetry: true,
+      fallbackRuntimeState,
+      opts: { modelRun: true, images },
+    });
+    expect(retryArg.images).toBeUndefined();
   });
 
   it("forwards selected auth profiles through metadata-scoped provider aliases", async () => {

--- a/src/agents/command/attempt-execution.ts
+++ b/src/agents/command/attempt-execution.ts
@@ -514,6 +514,7 @@ export function runAgentAttempt(params: {
   allowTransientCooldownProbe?: boolean;
   modelFallbacksOverride?: string[];
   sessionHasHistory?: boolean;
+  fallbackRuntimeState?: { originRuntime?: "cli" | "embedded" };
   suppressPromptPersistenceOnRetry?: boolean;
   userTurnTranscriptRecorder?: UserTurnTranscriptRecorder;
   onUserMessagePersisted?: (message: Extract<AgentMessage, { role: "user" }>) => void;
@@ -554,6 +555,12 @@ export function runAgentAttempt(params: {
         authProfileId: params.sessionEntry?.authProfileOverride,
       }) ?? params.providerOverride);
   const isCliExecutionProvider = isCliProvider(cliExecutionProvider, params.cfg);
+  if (params.fallbackRuntimeState && params.fallbackRuntimeState.originRuntime === undefined) {
+    params.fallbackRuntimeState.originRuntime =
+      !isRawModelRun && isCliExecutionProvider ? "cli" : "embedded";
+  }
+  const shouldForwardImagesToEmbedded =
+    !params.isFallbackRetry || params.fallbackRuntimeState?.originRuntime === "cli";
   const allowCliAuthProfileForwarding =
     isCliExecutionProvider &&
     cliBackendAcceptsAuthProfileForwarding({
@@ -698,6 +705,8 @@ export function runAgentAttempt(params: {
         authProfileId,
         bootstrapPromptWarningSignaturesSeen,
         bootstrapPromptWarningSignature,
+        // CLI retries may reuse native session history. Their image replay
+        // decision must be made per process invocation inside the CLI runner.
         images: params.isFallbackRetry ? undefined : params.opts.images,
         imageOrder: params.isFallbackRetry ? undefined : params.opts.imageOrder,
         skillsSnapshot: params.skillsSnapshot,
@@ -797,8 +806,10 @@ export function runAgentAttempt(params: {
     skillsSnapshot: params.skillsSnapshot,
     prompt: effectivePrompt,
     transcriptPrompt: params.transcriptBody,
-    images: params.isFallbackRetry ? undefined : params.opts.images,
-    imageOrder: params.isFallbackRetry ? undefined : params.opts.imageOrder,
+    // CLI-origin retries cannot rely on transcript replay: orphan-user repair
+    // removes the persisted CLI turn before the embedded prompt is submitted.
+    images: shouldForwardImagesToEmbedded ? params.opts.images : undefined,
+    imageOrder: shouldForwardImagesToEmbedded ? params.opts.imageOrder : undefined,
     clientTools: params.opts.clientTools,
     provider: embeddedAgentProvider,
     model: params.modelOverride,

--- a/src/agents/embedded-agent-runner/run.overflow-compaction.test.ts
+++ b/src/agents/embedded-agent-runner/run.overflow-compaction.test.ts
@@ -73,6 +73,7 @@ function makeForwardingCase(internalEvents: AgentInternalEvent[]) {
       forceMessageTool: true,
       requireExplicitMessageTarget: true,
       chatType: "channel",
+      senderIsOwner: true,
       internalEvents,
       onAgentToolResult,
     },
@@ -84,6 +85,7 @@ function makeForwardingCase(internalEvents: AgentInternalEvent[]) {
       forceMessageTool: true,
       requireExplicitMessageTarget: true,
       chatType: "channel",
+      senderIsOwner: true,
       onAgentToolResult,
     },
   } satisfies {

--- a/src/agents/embedded-agent-runner/run.ts
+++ b/src/agents/embedded-agent-runner/run.ts
@@ -2124,6 +2124,7 @@ async function runEmbeddedAgentInternal(
             senderName: params.senderName,
             senderUsername: params.senderUsername,
             senderE164: params.senderE164,
+            senderIsOwner: params.senderIsOwner,
             approvalReviewerDeviceId: params.approvalReviewerDeviceId,
             currentChannelId: params.currentChannelId,
             chatId: params.chatId,

--- a/src/agents/openclaw-tools.plugin-context.test.ts
+++ b/src/agents/openclaw-tools.plugin-context.test.ts
@@ -20,6 +20,17 @@ describe("openclaw plugin tool context", () => {
     expect(result.context.requesterSenderId).toBe("trusted-sender");
   });
 
+  it("forwards the trusted owner bit", () => {
+    const result = resolveOpenClawPluginToolInputs({
+      options: {
+        config: {} as never,
+        senderIsOwner: true,
+      },
+    });
+
+    expect(result.context.senderIsOwner).toBe(true);
+  });
+
   it("forwards fs policy for plugin tool sandbox enforcement", () => {
     const result = resolveOpenClawPluginToolInputs({
       options: {

--- a/src/agents/openclaw-tools.plugin-context.ts
+++ b/src/agents/openclaw-tools.plugin-context.ts
@@ -25,6 +25,7 @@ export type OpenClawPluginToolOptions = {
   modelProvider?: string;
   modelId?: string;
   requesterSenderId?: string | null;
+  senderIsOwner?: boolean;
   requesterAgentIdOverride?: string;
   sessionId?: string;
   /**
@@ -95,6 +96,7 @@ export function resolveOpenClawPluginToolInputs(params: {
       agentAccountId: options?.agentAccountId,
       deliveryContext,
       requesterSenderId: options?.requesterSenderId ?? undefined,
+      senderIsOwner: options?.senderIsOwner,
       sandboxed: options?.sandboxed,
       oneShotCliRun: options?.oneShotCliRun,
     },

--- a/src/channels/message/outbound-bridge.test.ts
+++ b/src/channels/message/outbound-bridge.test.ts
@@ -1,7 +1,10 @@
 // Outbound bridge tests cover channel message handoff from core to outbound adapters.
 import { describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
-import { createChannelMessageAdapterFromOutbound } from "./outbound-bridge.js";
+import {
+  createChannelMessageAdapterFromOutbound,
+  type ChannelMessageOutboundBridgeResult,
+} from "./outbound-bridge.js";
 import type {
   ChannelMessageSendPayloadContext,
   ChannelMessageSendPollContext,
@@ -77,6 +80,35 @@ describe("createChannelMessageAdapterFromOutbound", () => {
         replyToId: "parent-1",
       },
     ]);
+  });
+
+  it("normalizes outbound progress results before forwarding them to message callers", async () => {
+    const sendText = vi.fn(
+      async (request: {
+        onDeliveryResult?: (result: ChannelMessageOutboundBridgeResult) => Promise<void> | void;
+      }) => {
+        await request.onDeliveryResult?.({ channel: "demo", messageId: "chunk-1" });
+        return { channel: "demo", messageId: "chunk-2" };
+      },
+    );
+    const onDeliveryResult = vi.fn();
+    const adapter = createChannelMessageAdapterFromOutbound({ outbound: { sendText } });
+
+    await adapter.send?.text?.({
+      cfg,
+      to: "room-1",
+      text: "hello",
+      onDeliveryResult,
+    });
+
+    expect(onDeliveryResult).toHaveBeenCalledTimes(1);
+    expect(onDeliveryResult).toHaveBeenCalledWith({
+      messageId: "chunk-1",
+      receipt: expect.objectContaining({
+        primaryPlatformMessageId: "chunk-1",
+        platformMessageIds: ["chunk-1"],
+      }),
+    });
   });
 
   it("preserves an outbound receipt instead of rebuilding it", async () => {

--- a/src/channels/message/outbound-bridge.ts
+++ b/src/channels/message/outbound-bridge.ts
@@ -30,22 +30,26 @@ export type ChannelMessageOutboundBridgeResult = MessageReceiptSourceResult & {
   messageId?: string;
 };
 
+type ChannelMessageOutboundBridgeContext<TContext> = Omit<TContext, "onDeliveryResult"> & {
+  onDeliveryResult?: (result: ChannelMessageOutboundBridgeResult) => Promise<void> | void;
+};
+
 /** Legacy outbound adapter shape bridged into the channel message adapter contract. */
 export type ChannelMessageOutboundBridgeAdapter<TConfig = unknown> = {
   deliveryCapabilities?: {
     durableFinal?: DurableFinalDeliveryRequirementMap;
   };
   sendText?: (
-    ctx: ChannelMessageSendTextContext<TConfig>,
+    ctx: ChannelMessageOutboundBridgeContext<ChannelMessageSendTextContext<TConfig>>,
   ) => Promise<ChannelMessageOutboundBridgeResult>;
   sendMedia?: (
-    ctx: ChannelMessageSendMediaContext<TConfig>,
+    ctx: ChannelMessageOutboundBridgeContext<ChannelMessageSendMediaContext<TConfig>>,
   ) => Promise<ChannelMessageOutboundBridgeResult>;
   sendPayload?: (
-    ctx: ChannelMessageSendPayloadContext<TConfig>,
+    ctx: ChannelMessageOutboundBridgeContext<ChannelMessageSendPayloadContext<TConfig>>,
   ) => Promise<ChannelMessageOutboundBridgeResult>;
   sendPoll?: (
-    ctx: ChannelMessageSendPollContext<TConfig>,
+    ctx: ChannelMessageOutboundBridgeContext<ChannelMessageSendPollContext<TConfig>>,
   ) => Promise<ChannelMessageOutboundBridgeResult>;
 };
 
@@ -72,14 +76,16 @@ function resolveResultMessageId(result: ChannelMessageOutboundBridgeResult): str
   );
 }
 
+type MessageSendResultParams = {
+  kind: MessageReceiptPartKind;
+  normalizeReceiptKind?: boolean;
+  threadId?: string | number | null;
+  replyToId?: string | null;
+};
+
 function toMessageSendResult(
   result: ChannelMessageOutboundBridgeResult,
-  params: {
-    kind: MessageReceiptPartKind;
-    normalizeReceiptKind?: boolean;
-    threadId?: string | number | null;
-    replyToId?: string | null;
-  },
+  params: MessageSendResultParams,
 ): ChannelMessageSendResult {
   const receipt = result.receipt
     ? params.normalizeReceiptKind
@@ -99,6 +105,27 @@ function toMessageSendResult(
     ...(resolveResultMessageId({ ...result, receipt })
       ? {
           messageId: resolveResultMessageId({ ...result, receipt }),
+        }
+      : {}),
+  };
+}
+
+function adaptOutboundBridgeContext<
+  TContext extends {
+    onDeliveryResult?: (result: ChannelMessageSendResult) => Promise<void> | void;
+  },
+>(
+  ctx: TContext,
+  resultParams: MessageSendResultParams,
+): ChannelMessageOutboundBridgeContext<TContext> {
+  const { onDeliveryResult, ...outboundCtx } = ctx;
+  return {
+    ...outboundCtx,
+    ...(onDeliveryResult
+      ? {
+          onDeliveryResult: async (result: ChannelMessageOutboundBridgeResult) => {
+            await onDeliveryResult(toMessageSendResult(result, resultParams));
+          },
         }
       : {}),
   };
@@ -131,37 +158,57 @@ export function createChannelMessageAdapterFromOutbound<TConfig = unknown>(
 ): ChannelMessageAdapterShape<TConfig> {
   const send: NonNullable<ChannelMessageAdapterShape<TConfig>["send"]> = {};
   if (params.outbound.sendText) {
-    send.text = async (ctx) =>
-      toMessageSendResult(await params.outbound.sendText!(ctx), {
+    send.text = async (ctx) => {
+      const resultParams = {
         kind: "text",
         threadId: ctx.threadId,
         replyToId: ctx.replyToId,
-      });
+      } satisfies MessageSendResultParams;
+      return toMessageSendResult(
+        await params.outbound.sendText!(adaptOutboundBridgeContext(ctx, resultParams)),
+        resultParams,
+      );
+    };
   }
   if (params.outbound.sendMedia) {
-    send.media = async (ctx) =>
-      toMessageSendResult(await params.outbound.sendMedia!(ctx), {
+    send.media = async (ctx) => {
+      const resultParams = {
         kind: ctx.audioAsVoice ? "voice" : "media",
         threadId: ctx.threadId,
         replyToId: ctx.replyToId,
-      });
+      } satisfies MessageSendResultParams;
+      return toMessageSendResult(
+        await params.outbound.sendMedia!(adaptOutboundBridgeContext(ctx, resultParams)),
+        resultParams,
+      );
+    };
   }
   if (params.outbound.sendPayload) {
-    send.payload = async (ctx) =>
-      toMessageSendResult(await params.outbound.sendPayload!(ctx), {
+    send.payload = async (ctx) => {
+      const resultParams = {
         kind: resolvePayloadReceiptKind(ctx as ChannelMessageSendPayloadContext<unknown>),
         threadId: ctx.threadId,
         replyToId: ctx.replyToId,
-      });
+      } satisfies MessageSendResultParams;
+      return toMessageSendResult(
+        await params.outbound.sendPayload!(adaptOutboundBridgeContext(ctx, resultParams)),
+        resultParams,
+      );
+    };
   }
   if (params.outbound.sendPoll) {
-    send.poll = async (ctx) =>
-      toMessageSendResult(await params.outbound.sendPoll!(ctx), {
+    send.poll = async (ctx) => {
+      const resultParams = {
         kind: "poll",
         normalizeReceiptKind: true,
         threadId: ctx.threadId,
         replyToId: ctx.replyToId,
-      });
+      } satisfies MessageSendResultParams;
+      return toMessageSendResult(
+        await params.outbound.sendPoll!(adaptOutboundBridgeContext(ctx, resultParams)),
+        resultParams,
+      );
+    };
   }
 
   return {

--- a/src/channels/message/types.ts
+++ b/src/channels/message/types.ts
@@ -179,6 +179,8 @@ export type ChannelMessageSendTextContext<TConfig = OpenClawConfig> = {
   silent?: boolean;
   signal?: AbortSignal;
   gatewayClientScopes?: readonly string[];
+  /** @internal Report each completed platform sub-send before another fallible step. */
+  onDeliveryResult?: (result: ChannelMessageSendResult) => Promise<void> | void;
 };
 
 /** Media send context with validated access hooks and media presentation hints. */

--- a/src/channels/plugins/outbound.types.ts
+++ b/src/channels/plugins/outbound.types.ts
@@ -40,6 +40,8 @@ export type ChannelOutboundContext = {
   deps?: OutboundSendDeps;
   silent?: boolean;
   gatewayClientScopes?: readonly string[];
+  /** @internal Report each completed platform sub-send before starting another fallible step. */
+  onDeliveryResult?: (result: OutboundDeliveryResult) => Promise<void> | void;
 };
 
 export type ChannelOutboundPayloadContext = ChannelOutboundContext & {

--- a/src/infra/heartbeat-runner.respects-ackmaxchars-heartbeat-acks.test.ts
+++ b/src/infra/heartbeat-runner.respects-ackmaxchars-heartbeat-acks.test.ts
@@ -116,6 +116,7 @@ describe("runHeartbeatOnce ack handling", () => {
           mediaAccess: {},
           mediaLocalRoots: undefined,
           mediaReadFile: undefined,
+          onDeliveryResult: expect.any(Function),
           replyToIdSource: undefined,
           replyToMode: undefined,
           silent: undefined,

--- a/src/infra/outbound/deliver.queue-integration.test.ts
+++ b/src/infra/outbound/deliver.queue-integration.test.ts
@@ -57,7 +57,7 @@ async function drainMatrixReconnect(opts: { deliver: DeliverFn; stateDir: string
     log: createRecoveryLog(),
     stateDir: opts.stateDir,
     deliver: opts.deliver,
-    selectEntry: (entry) => ({ match: entry.channel === "matrix" }),
+    selectEntry: (entry) => ({ match: entry.channel === "matrix", bypassBackoff: true }),
   });
 }
 
@@ -109,16 +109,26 @@ describe("deliverOutboundPayloads queue integration: mid-batch failure with send
   });
 
   it("advances queued entry to unknown_after_send when a later payload fails after an earlier one succeeded", async () => {
-    const sendMatrix = createPartialSendFailure();
+    let sendCount = 0;
+    let stateBeforeSecondSend: string | undefined;
+    const sendMatrix = vi.fn(async () => {
+      sendCount += 1;
+      if (sendCount === 1) {
+        return { messageId: "m1" };
+      }
+      stateBeforeSecondSend = (await loadPendingDeliveries(tmpDir))[0]?.recoveryState;
+      throw new Error("second payload send failed");
+    });
 
     await deliverPartialMatrixBatch(sendMatrix, tmpDir);
 
+    expect(stateBeforeSecondSend).toBe("unknown_after_send");
     const entries = await loadPendingDeliveries(tmpDir);
     expect(entries).toHaveLength(1);
     const entry = entries[0];
     expect(entry.recoveryState).toBe("unknown_after_send");
-    expect(entry.retryCount).toBe(0);
-    expect(entry.lastError).toBeUndefined();
+    expect(entry.retryCount).toBe(1);
+    expect(entry.lastError).toContain("second payload send failed");
     expect(sendMatrix).toHaveBeenCalledTimes(2);
   });
 
@@ -137,7 +147,7 @@ describe("deliverOutboundPayloads queue integration: mid-batch failure with send
     expect(await loadPendingDeliveries(tmpDir)).toHaveLength(0);
   });
 
-  it("leaves entry for retry in send_attempt_started when no send evidence exists", async () => {
+  it("retains retryable send-attempt state when an adapter fails before returning a result", async () => {
     process.env.OPENCLAW_STATE_DIR = tmpDir;
     const sendMatrix = vi.fn().mockRejectedValueOnce(new Error("first payload send failed"));
 

--- a/src/infra/outbound/deliver.test.ts
+++ b/src/infra/outbound/deliver.test.ts
@@ -4,6 +4,7 @@ import path from "node:path";
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { chunkText } from "../../auto-reply/chunk.js";
 import { createMessageReceiptFromOutboundResults } from "../../channels/message/receipt.js";
+import type { ChannelMessageSendTextContext } from "../../channels/message/types.js";
 import type { ChannelOutboundAdapter } from "../../channels/plugins/types.js";
 import type { OpenClawConfig } from "../../config/config.js";
 import type { SessionTranscriptAppendResult } from "../../config/sessions/transcript.js";
@@ -55,6 +56,7 @@ const queueMocks = vi.hoisted(() => ({
   enqueueDelivery: vi.fn(async () => "mock-queue-id"),
   ackDelivery: vi.fn(async () => {}),
   failDelivery: vi.fn(async () => {}),
+  failDeliveryAfterPlatformSend: vi.fn(async () => {}),
   markDeliveryPlatformOutcomeUnknown: vi.fn(async () => {}),
   markDeliveryPlatformSendAttemptStarted: vi.fn(async () => {}),
   withActiveDeliveryClaim: vi.fn<
@@ -97,6 +99,7 @@ vi.mock("./delivery-queue.js", () => ({
   enqueueDelivery: queueMocks.enqueueDelivery,
   ackDelivery: queueMocks.ackDelivery,
   failDelivery: queueMocks.failDelivery,
+  failDeliveryAfterPlatformSend: queueMocks.failDeliveryAfterPlatformSend,
   markDeliveryPlatformOutcomeUnknown: queueMocks.markDeliveryPlatformOutcomeUnknown,
   markDeliveryPlatformSendAttemptStarted: queueMocks.markDeliveryPlatformSendAttemptStarted,
   withActiveDeliveryClaim: queueMocks.withActiveDeliveryClaim,
@@ -319,6 +322,8 @@ describe("deliverOutboundPayloads", () => {
     queueMocks.ackDelivery.mockResolvedValue(undefined);
     queueMocks.failDelivery.mockClear();
     queueMocks.failDelivery.mockResolvedValue(undefined);
+    queueMocks.failDeliveryAfterPlatformSend.mockClear();
+    queueMocks.failDeliveryAfterPlatformSend.mockResolvedValue(undefined);
     queueMocks.markDeliveryPlatformOutcomeUnknown.mockClear();
     queueMocks.markDeliveryPlatformOutcomeUnknown.mockResolvedValue(undefined);
     queueMocks.markDeliveryPlatformSendAttemptStarted.mockClear();
@@ -638,9 +643,6 @@ describe("deliverOutboundPayloads", () => {
     queueMocks.ackDelivery.mockImplementationOnce(async () => {
       order.push("ack");
     });
-    queueMocks.markDeliveryPlatformSendAttemptStarted.mockImplementationOnce(async () => {
-      order.push("mark-started");
-    });
     queueMocks.markDeliveryPlatformOutcomeUnknown.mockImplementationOnce(async () => {
       order.push("mark-unknown");
     });
@@ -707,7 +709,6 @@ describe("deliverOutboundPayloads", () => {
     expect(order).toEqual([
       "queue",
       "before",
-      "mark-started",
       "send",
       "after:pending-1:message-adapter-1",
       "mark-unknown",
@@ -757,9 +758,38 @@ describe("deliverOutboundPayloads", () => {
 
     expect(results).toStrictEqual([]);
     expect(sendMatrix).not.toHaveBeenCalled();
-    expect(queueMocks.markDeliveryPlatformSendAttemptStarted).not.toHaveBeenCalled();
     expect(queueMocks.markDeliveryPlatformOutcomeUnknown).not.toHaveBeenCalled();
     expect(queueMocks.ackDelivery).toHaveBeenCalledWith("mock-queue-id");
+  });
+
+  it("keeps a canceled zero-result delivery retryable when queue ack fails", async () => {
+    hookMocks.runner.hasHooks.mockImplementation(
+      (hookName?: string) => hookName === "message_sending",
+    );
+    hookMocks.runner.runMessageSending.mockResolvedValueOnce({
+      cancel: true,
+      content: "blocked",
+    });
+    queueMocks.ackDelivery.mockRejectedValueOnce(new Error("ack offline"));
+    const sendMatrix = vi.fn();
+
+    const results = await deliverOutboundPayloads({
+      cfg: {},
+      channel: "matrix",
+      to: "!room:example",
+      payloads: [{ text: "hello" }],
+      deps: { matrix: sendMatrix },
+      queuePolicy: "best_effort",
+    });
+
+    expect(results).toStrictEqual([]);
+    expect(sendMatrix).not.toHaveBeenCalled();
+    expect(queueMocks.failDelivery).toHaveBeenCalledWith(
+      "mock-queue-id",
+      expect.stringContaining("failed to ack unsent delivery"),
+    );
+    expect(queueMocks.failDeliveryAfterPlatformSend).not.toHaveBeenCalled();
+    expect(queueMocks.markDeliveryPlatformOutcomeUnknown).not.toHaveBeenCalled();
   });
 
   it("runs message adapter failure cleanup for failed sends with pending attempt tokens", async () => {
@@ -1020,31 +1050,6 @@ describe("deliverOutboundPayloads", () => {
     expect(queueMocks.ackDelivery).not.toHaveBeenCalled();
   });
 
-  it("requires the platform-send attempt marker before required durable platform I/O", async () => {
-    queueMocks.markDeliveryPlatformSendAttemptStarted.mockRejectedValueOnce(
-      new Error("marker offline"),
-    );
-    const sendMatrix = vi.fn().mockResolvedValue({ messageId: "m1" });
-
-    await expect(
-      deliverOutboundPayloads({
-        cfg: {},
-        channel: "matrix",
-        to: "!room:example",
-        payloads: [{ text: "hi" }],
-        deps: { matrix: sendMatrix },
-        queuePolicy: "required",
-      }),
-    ).rejects.toThrow("marker offline");
-
-    expect(queueMocks.markDeliveryPlatformSendAttemptStarted).toHaveBeenCalledWith("mock-queue-id");
-    expect(sendMatrix).not.toHaveBeenCalled();
-    const failDeliveryCall = requireMockCall(queueMocks.failDelivery, "failDelivery");
-    expect(failDeliveryCall[0]).toBe("mock-queue-id");
-    expect(String(failDeliveryCall[1])).toContain("marker offline");
-    expect(queueMocks.ackDelivery).not.toHaveBeenCalled();
-  });
-
   it("marks queued delivery as unknown-after-send (not failed) when a later payload fails after an earlier one succeeded", async () => {
     const sendMatrix = vi
       .fn()
@@ -1068,7 +1073,7 @@ describe("deliverOutboundPayloads", () => {
     expect(queueMocks.ackDelivery).not.toHaveBeenCalled();
   });
 
-  it("still calls failDelivery when a payload fails before any send succeeded", async () => {
+  it("retains retryable send-attempt state when the first platform call fails without a result", async () => {
     const sendMatrix = vi.fn().mockRejectedValueOnce(new Error("first payload send failed"));
 
     await expect(
@@ -1082,33 +1087,105 @@ describe("deliverOutboundPayloads", () => {
       }),
     ).rejects.toThrow("first payload send failed");
 
-    expect(queueMocks.failDelivery).toHaveBeenCalledWith(
+    expect(queueMocks.markDeliveryPlatformSendAttemptStarted).toHaveBeenCalledWith(
       "mock-queue-id",
-      expect.stringContaining("first payload send failed"),
+      undefined,
     );
     expect(queueMocks.markDeliveryPlatformOutcomeUnknown).not.toHaveBeenCalled();
+    expect(queueMocks.failDelivery).toHaveBeenCalledWith(
+      "mock-queue-id",
+      "first payload send failed",
+    );
     expect(queueMocks.ackDelivery).not.toHaveBeenCalled();
   });
 
-  it("fails required delivery when the post-send unknown marker cannot be written", async () => {
+  it("directly acks a sent delivery when the post-send unknown marker cannot be written", async () => {
     queueMocks.markDeliveryPlatformOutcomeUnknown.mockRejectedValueOnce(
       new Error("unknown marker offline"),
     );
     const sendMatrix = vi.fn().mockResolvedValue({ messageId: "m1" });
 
-    await expect(
-      deliverOutboundPayloads({
-        cfg: {},
-        channel: "matrix",
-        to: "!room:example",
-        payloads: [{ text: "hi" }],
-        deps: { matrix: sendMatrix },
-        queuePolicy: "required",
-      }),
-    ).rejects.toThrow("unknown marker offline");
+    await deliverOutboundPayloads({
+      cfg: {},
+      channel: "matrix",
+      to: "!room:example",
+      payloads: [{ text: "hi" }],
+      deps: { matrix: sendMatrix },
+      queuePolicy: "required",
+    });
 
     expect(sendMatrix).toHaveBeenCalled();
-    expect(queueMocks.ackDelivery).not.toHaveBeenCalled();
+    expect(queueMocks.ackDelivery).toHaveBeenCalledWith("mock-queue-id");
+    expect(queueMocks.failDelivery).not.toHaveBeenCalled();
+  });
+
+  it("runs sent-result commit hooks when marker fallback ack precedes a partial failure", async () => {
+    queueMocks.markDeliveryPlatformOutcomeUnknown.mockRejectedValueOnce(
+      new Error("unknown marker offline"),
+    );
+    const afterCommit = vi.fn();
+    const messageSendText = vi
+      .fn()
+      .mockResolvedValueOnce({
+        messageId: "message-adapter-1",
+        receipt: createMessageReceiptFromOutboundResults({
+          results: [{ channel: "matrix", messageId: "message-adapter-1" }],
+          kind: "text",
+        }),
+      })
+      .mockRejectedValueOnce(new Error("second send failed"));
+    setActivePluginRegistry(
+      createTestRegistry([
+        {
+          pluginId: "matrix",
+          source: "test",
+          plugin: {
+            id: "matrix",
+            message: {
+              id: "matrix",
+              durableFinal: { capabilities: { text: true, afterCommit: true } },
+              send: { lifecycle: { afterCommit }, text: messageSendText },
+            },
+          },
+        },
+      ]),
+    );
+
+    const results = await deliverOutboundPayloads({
+      cfg: {},
+      channel: "matrix",
+      to: "!room:example",
+      payloads: [{ text: "first" }, { text: "second" }],
+      bestEffort: true,
+      queuePolicy: "required",
+    });
+
+    expect(results).toHaveLength(1);
+    expect(queueMocks.ackDelivery).toHaveBeenCalledTimes(1);
+    expect(afterCommit).toHaveBeenCalledTimes(1);
+    expect(queueMocks.failDelivery).not.toHaveBeenCalled();
+  });
+
+  it("retains unknown-after-send evidence when both the marker and direct ack fail", async () => {
+    queueMocks.markDeliveryPlatformOutcomeUnknown.mockRejectedValueOnce(
+      new Error("unknown marker offline"),
+    );
+    queueMocks.ackDelivery.mockRejectedValueOnce(new Error("ack offline"));
+    const sendMatrix = vi.fn().mockResolvedValue({ messageId: "m1" });
+
+    await deliverOutboundPayloads({
+      cfg: {},
+      channel: "matrix",
+      to: "!room:example",
+      payloads: [{ text: "hi" }],
+      deps: { matrix: sendMatrix },
+      queuePolicy: "required",
+    });
+
+    expect(queueMocks.failDeliveryAfterPlatformSend).toHaveBeenCalledWith(
+      "mock-queue-id",
+      expect.stringContaining("marker=unknown marker offline; ack=ack offline"),
+    );
     expect(queueMocks.failDelivery).not.toHaveBeenCalled();
   });
 
@@ -1129,6 +1206,10 @@ describe("deliverOutboundPayloads", () => {
 
     expect(sendMatrix).toHaveBeenCalled();
     expect(queueMocks.markDeliveryPlatformOutcomeUnknown).toHaveBeenCalledWith("mock-queue-id");
+    expect(queueMocks.failDeliveryAfterPlatformSend).toHaveBeenCalledWith(
+      "mock-queue-id",
+      expect.stringContaining("failed to ack sent delivery: ack offline"),
+    );
     expect(queueMocks.failDelivery).not.toHaveBeenCalled();
   });
 
@@ -2154,6 +2235,276 @@ describe("deliverOutboundPayloads", () => {
     expect(sendMedia).not.toHaveBeenCalled();
   });
 
+  it("persists formatted sub-send results before a later adapter chunk fails", async () => {
+    const firstResult = { channel: "line" as const, messageId: "fmt-1" };
+    const sendFormattedText = vi.fn(
+      async (ctx: { onDeliveryResult?: (result: typeof firstResult) => Promise<void> | void }) => {
+        await ctx.onDeliveryResult?.(firstResult);
+        throw new Error("second formatted chunk failed");
+      },
+    );
+    setActivePluginRegistry(
+      createTestRegistry([
+        {
+          pluginId: "line",
+          source: "test",
+          plugin: createOutboundTestPlugin({
+            id: "line",
+            outbound: {
+              deliveryMode: "direct",
+              sendText: async () => firstResult,
+              sendFormattedText,
+            },
+          }),
+        },
+      ]),
+    );
+
+    await expect(
+      deliverOutboundPayloads({
+        cfg: {},
+        channel: "line",
+        to: "U123",
+        payloads: [{ text: "two chunks" }],
+        queuePolicy: "required",
+      }),
+    ).rejects.toThrow("second formatted chunk failed");
+
+    expect(queueMocks.markDeliveryPlatformOutcomeUnknown).toHaveBeenCalledWith("mock-queue-id");
+    expect(queueMocks.failDelivery).not.toHaveBeenCalled();
+    expect(queueMocks.ackDelivery).not.toHaveBeenCalled();
+  });
+
+  it("preserves repeated platform identities across separate adapter invocations", async () => {
+    const sendFormattedText = vi.fn(
+      async (ctx: {
+        onDeliveryResult?: (result: { channel: "line"; messageId: string }) => Promise<void> | void;
+      }) => {
+        const result = { channel: "line" as const, messageId: "push" };
+        await ctx.onDeliveryResult?.(result);
+        return [result];
+      },
+    );
+    setActivePluginRegistry(
+      createTestRegistry([
+        {
+          pluginId: "line",
+          source: "test",
+          plugin: createOutboundTestPlugin({
+            id: "line",
+            outbound: {
+              deliveryMode: "direct",
+              sendText: async () => ({ channel: "line", messageId: "push" }),
+              sendFormattedText,
+            },
+          }),
+        },
+      ]),
+    );
+
+    const results = await deliverOutboundPayloads({
+      cfg: {},
+      channel: "line",
+      to: "U123",
+      payloads: [{ text: "first" }, { text: "second" }],
+      queuePolicy: "required",
+    });
+
+    expect(sendFormattedText).toHaveBeenCalledTimes(2);
+    expect(results.map((result) => result.messageId)).toEqual(["push", "push"]);
+  });
+
+  it("preserves repeated receipt IDs within one adapter invocation", async () => {
+    const receipt = createMessageReceiptFromOutboundResults({
+      results: [{ channel: "line", messageId: "push" }],
+      kind: "text",
+    });
+    const sendPayload = vi.fn(
+      async (ctx: {
+        onDeliveryResult?: (result: {
+          channel: "line";
+          messageId: string;
+          receipt: typeof receipt;
+        }) => Promise<void> | void;
+      }) => {
+        const result = { channel: "line" as const, messageId: "push", receipt };
+        await ctx.onDeliveryResult?.(result);
+        await ctx.onDeliveryResult?.(result);
+        return result;
+      },
+    );
+    setActivePluginRegistry(
+      createTestRegistry([
+        {
+          pluginId: "line",
+          source: "test",
+          plugin: createOutboundTestPlugin({
+            id: "line",
+            outbound: {
+              deliveryMode: "direct",
+              sendText: async () => ({ channel: "line", messageId: "unused" }),
+              sendPayload,
+            },
+          }),
+        },
+      ]),
+    );
+
+    const results = await deliverOutboundPayloads({
+      cfg: {},
+      channel: "line",
+      to: "U123",
+      payloads: [{ text: "text plus media", channelData: { line: { mode: "custom" } } }],
+      queuePolicy: "required",
+    });
+
+    expect(sendPayload).toHaveBeenCalledTimes(1);
+    expect(results.map((result) => result.messageId)).toEqual(["push", "push"]);
+  });
+
+  it("replaces repeated progress IDs covered by aggregate receipt parts", async () => {
+    const aggregateReceipt = createMessageReceiptFromOutboundResults({
+      results: [
+        { channel: "line", messageId: "push" },
+        { channel: "line", messageId: "push" },
+      ],
+      kind: "text",
+    });
+    const sendPayload = vi.fn(
+      async (ctx: {
+        onDeliveryResult?: (result: { channel: "line"; messageId: string }) => Promise<void> | void;
+      }) => {
+        await ctx.onDeliveryResult?.({ channel: "line", messageId: "push" });
+        await ctx.onDeliveryResult?.({ channel: "line", messageId: "push" });
+        return { channel: "line" as const, messageId: "push", receipt: aggregateReceipt };
+      },
+    );
+    setActivePluginRegistry(
+      createTestRegistry([
+        {
+          pluginId: "line",
+          source: "test",
+          plugin: createOutboundTestPlugin({
+            id: "line",
+            outbound: {
+              deliveryMode: "direct",
+              sendText: async () => ({ channel: "line", messageId: "unused" }),
+              sendPayload,
+            },
+          }),
+        },
+      ]),
+    );
+
+    const results = await deliverOutboundPayloads({
+      cfg: {},
+      channel: "line",
+      to: "U123",
+      payloads: [{ text: "two pushes", channelData: { line: { mode: "custom" } } }],
+      queuePolicy: "required",
+    });
+
+    expect(results).toHaveLength(1);
+    expect(results[0]?.receipt?.parts.map((part) => part.platformMessageId)).toEqual([
+      "push",
+      "push",
+    ]);
+  });
+
+  it("replaces per-message progress with one aggregate final receipt", async () => {
+    const aggregateReceipt = createMessageReceiptFromOutboundResults({
+      results: [
+        { channel: "line", messageId: "m1" },
+        { channel: "line", messageId: "m2" },
+      ],
+      kind: "text",
+    });
+    const sendFormattedText = vi.fn(
+      async (ctx: {
+        onDeliveryResult?: (result: { channel: "line"; messageId: string }) => Promise<void> | void;
+      }) => {
+        await ctx.onDeliveryResult?.({ channel: "line", messageId: "m1" });
+        await ctx.onDeliveryResult?.({ channel: "line", messageId: "m2" });
+        return [
+          {
+            channel: "line" as const,
+            messageId: "m2",
+            receipt: aggregateReceipt,
+          },
+        ];
+      },
+    );
+    setActivePluginRegistry(
+      createTestRegistry([
+        {
+          pluginId: "line",
+          source: "test",
+          plugin: createOutboundTestPlugin({
+            id: "line",
+            outbound: {
+              deliveryMode: "direct",
+              sendText: async () => ({ channel: "line", messageId: "unused" }),
+              sendFormattedText,
+            },
+          }),
+        },
+      ]),
+    );
+
+    const results = await deliverOutboundPayloads({
+      cfg: {},
+      channel: "line",
+      to: "U123",
+      payloads: [{ text: "two chunks" }],
+      queuePolicy: "required",
+    });
+
+    expect(results).toHaveLength(1);
+    expect(results[0]?.receipt?.parts.map((part) => part.platformMessageId)).toEqual(["m1", "m2"]);
+  });
+
+  it("keeps commit hooks attached to a final result that replaces progress evidence", async () => {
+    const afterCommit = vi.fn();
+    const receipt = createMessageReceiptFromOutboundResults({
+      results: [{ channel: "matrix", messageId: "message-adapter-1" }],
+      kind: "text",
+    });
+    setActivePluginRegistry(
+      createTestRegistry([
+        {
+          pluginId: "matrix",
+          source: "test",
+          plugin: {
+            id: "matrix",
+            message: {
+              id: "matrix",
+              durableFinal: { capabilities: { text: true, afterCommit: true } },
+              send: {
+                lifecycle: { afterCommit },
+                text: async (ctx: ChannelMessageSendTextContext) => {
+                  const result = { messageId: "message-adapter-1", receipt };
+                  await ctx.onDeliveryResult?.(result);
+                  return result;
+                },
+              },
+            },
+          },
+        },
+      ]),
+    );
+
+    const results = await deliverOutboundPayloads({
+      cfg: {},
+      channel: "matrix",
+      to: "!room:example",
+      payloads: [{ text: "hello" }],
+      queuePolicy: "required",
+    });
+
+    expect(results).toHaveLength(1);
+    expect(afterCommit).toHaveBeenCalledTimes(1);
+  });
+
   it("includes OpenClaw tmp root in plugin mediaLocalRoots", async () => {
     const sendMatrix = vi.fn().mockResolvedValue({ messageId: "m-media", roomId: "!room" });
 
@@ -2820,6 +3171,30 @@ describe("deliverOutboundPayloads", () => {
     );
   });
 
+  it("records an all-failed bestEffort batch as a retryable attempt", async () => {
+    const sendMatrix = vi
+      .fn()
+      .mockRejectedValueOnce(new Error("first failed"))
+      .mockRejectedValueOnce(new Error("second failed"));
+
+    const results = await deliverOutboundPayloads({
+      cfg: {},
+      channel: "matrix",
+      to: "!room:example",
+      payloads: [{ text: "first" }, { text: "second" }],
+      deps: { matrix: sendMatrix },
+      bestEffort: true,
+    });
+
+    expect(results).toStrictEqual([]);
+    expect(queueMocks.failDelivery).toHaveBeenCalledWith(
+      "mock-queue-id",
+      "partial delivery failure (bestEffort)",
+    );
+    expect(queueMocks.ackDelivery).not.toHaveBeenCalled();
+    expect(queueMocks.markDeliveryPlatformOutcomeUnknown).not.toHaveBeenCalled();
+  });
+
   it("calls failDelivery instead of ackDelivery on bestEffort partial failure without onError", async () => {
     await runBestEffortPartialFailureDelivery({ onError: false });
 
@@ -2848,6 +3223,9 @@ describe("deliverOutboundPayloads", () => {
 
   it("logs a warning when failDelivery rejects in the error handler (#83113)", async () => {
     const sendMatrix = vi.fn().mockRejectedValue(new Error("native send failed"));
+    queueMocks.markDeliveryPlatformSendAttemptStarted.mockRejectedValueOnce(
+      new Error("pre-send marker offline"),
+    );
     queueMocks.failDelivery.mockRejectedValueOnce(new Error("db connection lost"));
 
     await expect(
@@ -2859,9 +3237,10 @@ describe("deliverOutboundPayloads", () => {
         deps: { matrix: sendMatrix },
         queuePolicy: "required",
       }),
-    ).rejects.toThrow("native send failed");
+    ).rejects.toThrow("pre-send marker offline");
 
     expect(queueMocks.failDelivery).toHaveBeenCalledWith("mock-queue-id", expect.any(String));
+    expect(sendMatrix).not.toHaveBeenCalled();
     const warnCall = requireMockCall(logMocks.warn, "warn");
     const warnMessage = String(warnCall[0]);
     expect(warnMessage).toContain("failed to mark queued delivery");
@@ -3171,6 +3550,50 @@ describe("deliverOutboundPayloads", () => {
     expect(appendOptions?.text).toBe("report.pdf");
     expect(appendOptions?.idempotencyKey).toBe("idem-deliver-1");
     expect(appendOptions?.config).toBe(cfg);
+  });
+
+  it("does not mirror a full payload when only an internal sub-send succeeded", async () => {
+    const partialResult = { channel: "line" as const, messageId: "partial-1" };
+    const sendFormattedText = vi.fn(
+      async (ctx: {
+        onDeliveryResult?: (result: typeof partialResult) => Promise<void> | void;
+      }) => {
+        await ctx.onDeliveryResult?.(partialResult);
+        throw new Error("second internal send failed");
+      },
+    );
+    setActivePluginRegistry(
+      createTestRegistry([
+        {
+          pluginId: "line",
+          source: "test",
+          plugin: createOutboundTestPlugin({
+            id: "line",
+            outbound: {
+              deliveryMode: "direct",
+              sendText: async () => partialResult,
+              sendFormattedText,
+            },
+          }),
+        },
+      ]),
+    );
+    mocks.appendAssistantMessageToSessionTranscript.mockClear();
+
+    const results = await deliverOutboundPayloads({
+      cfg: {},
+      channel: "line",
+      to: "U123",
+      payloads: [{ text: "first part and unsent second part" }],
+      bestEffort: true,
+      mirror: {
+        sessionKey: "agent:main:main",
+        text: "first part and unsent second part",
+      },
+    });
+
+    expect(results).toEqual([partialResult]);
+    expect(mocks.appendAssistantMessageToSessionTranscript).not.toHaveBeenCalled();
   });
 
   it("does not fail the channel send when the post-delivery transcript mirror throws", async () => {

--- a/src/infra/outbound/deliver.ts
+++ b/src/infra/outbound/deliver.ts
@@ -66,6 +66,7 @@ import {
   ackDelivery,
   enqueueDelivery,
   failDelivery,
+  failDeliveryAfterPlatformSend,
   markDeliveryPlatformOutcomeUnknown,
   markDeliveryPlatformSendAttemptStarted,
   type QueuedReplyPayloadSendingHook,
@@ -203,6 +204,7 @@ type ChannelHandlerParams = {
   mediaAccess?: OutboundMediaAccess;
   gatewayClientScopes?: readonly string[];
   onPlatformSendStart?: () => Promise<void>;
+  onDeliveryResult?: (result: OutboundDeliveryResult) => Promise<void> | void;
 };
 
 // Channel docking: outbound delivery delegates to plugin.outbound adapters.
@@ -345,6 +347,11 @@ function createPluginHandler(
   const sendMedia = outbound?.sendMedia;
   const chunker = outbound?.chunker ?? null;
   const chunkerMode = outbound?.chunkerMode;
+  const onMessageDeliveryResult = params.onDeliveryResult
+    ? async (result: ChannelMessageSendResult): Promise<void> => {
+        await params.onDeliveryResult?.(normalizeChannelMessageSendResult(params.channel, result));
+      }
+    : undefined;
   const resolveCtx = (overrides?: {
     replyToId?: string | null;
     replyToIdSource?: "explicit" | "implicit";
@@ -452,12 +459,16 @@ function createPluginHandler(
               payload,
             };
             if (messagePayload) {
+              const messagePayloadCtx = {
+                ...payloadCtx,
+                onDeliveryResult: onMessageDeliveryResult,
+              };
               const sent = await runChannelMessageSendWithLifecycle({
                 lifecycle: messageLifecycle,
-                ctx: payloadCtx,
+                ctx: messagePayloadCtx,
                 send: async () => {
                   await params.onPlatformSendStart?.();
-                  return await messagePayload(payloadCtx);
+                  return await messagePayload(messagePayloadCtx);
                 },
               });
               return attachOutboundDeliveryCommitHook(
@@ -495,12 +506,13 @@ function createPluginHandler(
         text,
       };
       if (messageText) {
+        const messageTextCtx = { ...textCtx, onDeliveryResult: onMessageDeliveryResult };
         const sent = await runChannelMessageSendWithLifecycle({
           lifecycle: messageLifecycle,
-          ctx: textCtx,
+          ctx: messageTextCtx,
           send: async () => {
             await params.onPlatformSendStart?.();
-            return await messageText(textCtx);
+            return await messageText(messageTextCtx);
           },
         });
         return attachOutboundDeliveryCommitHook(
@@ -520,12 +532,13 @@ function createPluginHandler(
         mediaUrl,
       };
       if (messageMedia) {
+        const messageMediaCtx = { ...mediaCtx, onDeliveryResult: onMessageDeliveryResult };
         const sent = await runChannelMessageSendWithLifecycle({
           lifecycle: messageLifecycle,
-          ctx: mediaCtx,
+          ctx: messageMediaCtx,
           send: async () => {
             await params.onPlatformSendStart?.();
-            return await messageMedia(mediaCtx);
+            return await messageMedia(messageMediaCtx);
           },
         });
         return attachOutboundDeliveryCommitHook(
@@ -580,6 +593,7 @@ function createChannelOutboundContextBase(
     mediaLocalRoots: params.mediaAccess?.localRoots,
     mediaReadFile: params.mediaAccess?.readFile,
     gatewayClientScopes: params.gatewayClientScopes,
+    onDeliveryResult: params.onDeliveryResult,
   };
 }
 
@@ -590,37 +604,55 @@ const isDeliveryAbortError = (err: unknown): boolean =>
   (err instanceof OutboundDeliveryError &&
     isAbortError((err as Error & { cause?: unknown }).cause));
 
-async function markQueuedPlatformSendAttemptStarted(params: {
+type QueuedPostSendState = "marked" | "acked" | "failed";
+
+type QueuedPreSendState = "marked" | "acked";
+
+async function persistQueuedPreSendState(params: {
   queueId: string;
   queuePolicy: OutboundDeliveryQueuePolicy;
-}): Promise<boolean> {
+  stateDir?: string;
+}): Promise<QueuedPreSendState> {
   try {
-    await markDeliveryPlatformSendAttemptStarted(params.queueId);
-    return true;
-  } catch (err: unknown) {
+    await markDeliveryPlatformSendAttemptStarted(params.queueId, params.stateDir);
+    return "marked";
+  } catch (markErr: unknown) {
     if (params.queuePolicy === "required") {
-      throw err;
+      throw markErr;
     }
     log.warn(
-      `failed to mark queued delivery ${params.queueId} as platform-send-attempt-started; continuing best-effort delivery: ${formatErrorMessage(err)}`,
+      `failed to mark queued delivery ${params.queueId} as platform-send-attempt-started; removing replay intent before best-effort send: ${formatErrorMessage(markErr)}`,
     );
-    return false;
+    // If the pre-send marker is unavailable, remove the intent before crossing
+    // the platform boundary. An ack failure aborts the send, leaving safe retry state.
+    await ackDelivery(params.queueId, params.stateDir);
+    return "acked";
   }
 }
 
-async function markQueuedPlatformOutcomeUnknown(params: {
+async function persistQueuedPostSendState(params: {
   queueId: string;
   queuePolicy: OutboundDeliveryQueuePolicy;
-}): Promise<void> {
+}): Promise<QueuedPostSendState> {
   try {
     await markDeliveryPlatformOutcomeUnknown(params.queueId);
-  } catch (err: unknown) {
-    if (params.queuePolicy === "required") {
-      throw err;
-    }
+    return "marked";
+  } catch (markErr: unknown) {
     log.warn(
-      `failed to mark queued delivery ${params.queueId} as platform-outcome-unknown; continuing best-effort delivery: ${formatErrorMessage(err)}`,
+      `failed to mark queued delivery ${params.queueId} as platform-outcome-unknown; falling back to direct ack (${params.queuePolicy}): ${formatErrorMessage(markErr)}`,
     );
+    try {
+      // The platform already returned a result. If state marking is unavailable,
+      // deleting the intent is safer than leaving it replayable.
+      await ackDelivery(params.queueId);
+      return "acked";
+    } catch (ackErr: unknown) {
+      const error = `post-send state persistence failed: marker=${formatErrorMessage(markErr)}; ack=${formatErrorMessage(ackErr)}`;
+      // Keep the evidence in the same canonical row if both primary state
+      // transitions fail; a generic failure update would make it replayable.
+      await failDeliveryAfterPlatformSend(params.queueId, error);
+      return "failed";
+    }
   }
 }
 
@@ -645,15 +677,15 @@ type DeliverOutboundPayloadsCoreParams = {
   onError?: (err: unknown, payload: NormalizedOutboundPayload) => void;
   onPayload?: (payload: NormalizedOutboundPayload) => void;
   onPayloadDeliveryOutcome?: (outcome: OutboundPayloadDeliveryOutcome) => void;
+  /** @internal Runs after each identified platform result, before further fallible work. */
+  onDeliveryResult?: (result: OutboundDeliveryResult) => Promise<void> | void;
+  /** @internal Persists ambiguous-send state immediately before platform I/O. */
+  onPlatformSendStart?: () => Promise<void>;
   /** Session/agent context used for hooks and media local-root scoping. */
   session?: OutboundSessionContext;
   mirror?: DeliveryMirror;
   silent?: boolean;
   gatewayClientScopes?: readonly string[];
-};
-
-type DeliverOutboundPayloadsCoreRuntimeParams = DeliverOutboundPayloadsCoreParams & {
-  onPlatformSendStart?: () => Promise<void>;
 };
 
 /**
@@ -666,6 +698,10 @@ type DeliverOutboundPayloadsCoreRuntimeParams = DeliverOutboundPayloadsCoreParam
 export type DeliverOutboundPayloadsParams = DeliverOutboundPayloadsCoreParams & {
   /** @internal Skip write-ahead queue (used by crash-recovery to avoid re-enqueueing). */
   skipQueue?: boolean;
+  /** @internal Existing recovery queue entry to mark when the platform send begins. */
+  deliveryQueueId?: string;
+  /** @internal State directory that owns the existing recovery queue entry. */
+  deliveryQueueStateDir?: string;
   /** @internal Let recovery run commit hooks after it has acked the recovered queue entry. */
   deferCommitHooks?: boolean;
   queuePolicy?: OutboundDeliveryQueuePolicy;
@@ -858,23 +894,6 @@ function hasDeliveryResultIdentity(result: OutboundDeliveryResult): boolean {
     result.toJid ||
     result.pollId,
   );
-}
-
-function pushIdentifiedDeliveryResult(
-  results: OutboundDeliveryResult[],
-  delivery: OutboundDeliveryResult,
-): boolean {
-  if (!hasDeliveryResultIdentity(delivery)) {
-    return false;
-  }
-  results.push(delivery);
-  return true;
-}
-
-function filterIdentifiedDeliveryResults(
-  results: readonly OutboundDeliveryResult[],
-): OutboundDeliveryResult[] {
-  return results.filter((result) => hasDeliveryResultIdentity(result));
 }
 
 function normalizeDeliveryPin(payload: ReplyPayload): ReplyPayloadDeliveryPin | undefined {
@@ -1326,34 +1345,61 @@ async function deliverOutboundPayloadsWithQueueCleanup(
   // without throwing — so the outer try/catch never fires. We track whether any
   // payload failed so we can call failDelivery instead of ackDelivery.
   let hadPartialFailure = false;
-  const wrappedParams = {
+  let lastPayloadError: unknown;
+  const queuePolicy = params.queuePolicy ?? "best_effort";
+  const platformQueueId = queueId ?? params.deliveryQueueId;
+  const platformQueuePolicy = queueId ? queuePolicy : "required";
+  const platformQueueStateDir = queueId ? undefined : params.deliveryQueueStateDir;
+  let queuedPreSendState: QueuedPreSendState | undefined;
+  let queuedPostSendState: QueuedPostSendState | undefined;
+  let deliveredResults: OutboundDeliveryResult[] = [];
+  let commitHooksRun = false;
+  const runCommitHooksAfterAck = async (): Promise<void> => {
+    if (
+      queuedPostSendState !== "acked" ||
+      params.deferCommitHooks ||
+      commitHooksRun ||
+      deliveredResults.length === 0
+    ) {
+      return;
+    }
+    commitHooksRun = true;
+    await runOutboundDeliveryCommitHooks(deliveredResults);
+  };
+  const wrappedParams: DeliverOutboundPayloadsParams = {
     ...params,
+    onPlatformSendStart: async () => {
+      if (platformQueueId && queuedPreSendState === undefined) {
+        queuedPreSendState = await persistQueuedPreSendState({
+          queueId: platformQueueId,
+          queuePolicy: platformQueuePolicy,
+          stateDir: platformQueueStateDir,
+        });
+        if (queueId && queuedPreSendState === "acked") {
+          queuedPostSendState = "acked";
+        }
+      }
+      await params.onPlatformSendStart?.();
+    },
     onError: (err: unknown, payload: NormalizedOutboundPayload) => {
       hadPartialFailure = true;
+      lastPayloadError = err;
       params.onError?.(err, payload);
     },
+    onDeliveryResult: async (result) => {
+      deliveredResults.push(result);
+      if (queueId && queuedPostSendState === undefined) {
+        queuedPostSendState = await persistQueuedPostSendState({ queueId, queuePolicy });
+      }
+      await params.onDeliveryResult?.(result);
+    },
   };
-  const queuePolicy = params.queuePolicy ?? "best_effort";
   let platformResultsReturned = false;
-  let platformSendStarted = false;
 
   try {
-    const results = await deliverOutboundPayloadsCore({
-      ...wrappedParams,
-      ...(queueId
-        ? {
-            onPlatformSendStart: async () => {
-              if (platformSendStarted) {
-                return;
-              }
-              platformSendStarted = await markQueuedPlatformSendAttemptStarted({
-                queueId,
-                queuePolicy,
-              });
-            },
-          }
-        : {}),
-    });
+    const results = await deliverOutboundPayloadsCore(wrappedParams);
+    // Core reconciles adapter progress objects with hook-bearing final results.
+    deliveredResults = results;
     platformResultsReturned = true;
     if (!queueId) {
       if (!params.deferCommitHooks) {
@@ -1363,58 +1409,108 @@ async function deliverOutboundPayloadsWithQueueCleanup(
     }
     if (queueId) {
       if (hadPartialFailure) {
-        await failDelivery(queueId, "partial delivery failure (bestEffort)").catch(
-          (err: unknown) => {
+        const partialSendEvidence =
+          results.length > 0 ||
+          (lastPayloadError instanceof OutboundDeliveryError && lastPayloadError.sentBeforeError);
+        const postSendState =
+          queuedPostSendState ??
+          (partialSendEvidence
+            ? await persistQueuedPostSendState({ queueId, queuePolicy })
+            : undefined);
+        const error = "partial delivery failure (bestEffort)";
+        if (postSendState === undefined || postSendState === "marked") {
+          await failDelivery(queueId, error).catch((err: unknown) => {
             log.warn(
               `failed to mark queued delivery ${queueId} as failed after partial failure; continuing best-effort delivery: ${formatErrorMessage(err)}`,
             );
-          },
-        );
-      } else {
-        if (platformSendStarted) {
-          await markQueuedPlatformOutcomeUnknown({
-            queueId,
-            queuePolicy,
           });
+        } else if (postSendState === "acked") {
+          // Direct ack is the fallback when the post-send marker cannot be
+          // written. Once the row is gone, recovery cannot run these hooks.
+          await runCommitHooksAfterAck();
         }
-        const acked = await ackDelivery(queueId)
-          .then(() => true)
-          .catch((err: unknown) => {
-            if (queuePolicy === "required") {
-              throw err;
-            }
-            log.warn(
-              `failed to ack queued delivery ${queueId}; continuing best-effort delivery: ${formatErrorMessage(err)}`,
-            );
-            return false;
-          });
+      } else {
+        const postSendState =
+          queuedPostSendState ??
+          (results.length > 0 || queuedPreSendState === "marked"
+            ? await persistQueuedPostSendState({ queueId, queuePolicy })
+            : queuedPreSendState === "acked"
+              ? "acked"
+              : undefined);
+        const acked =
+          postSendState === "acked"
+            ? true
+            : postSendState === "failed"
+              ? false
+              : await ackDelivery(queueId)
+                  .then(() => true)
+                  .catch(async (err: unknown) => {
+                    const hasSendEvidence =
+                      deliveredResults.length > 0 || queuedPreSendState !== undefined;
+                    try {
+                      if (hasSendEvidence) {
+                        await failDeliveryAfterPlatformSend(
+                          queueId,
+                          `failed to ack sent delivery: ${formatErrorMessage(err)}`,
+                        );
+                        queuedPostSendState = "failed";
+                      } else {
+                        await failDelivery(
+                          queueId,
+                          `failed to ack unsent delivery: ${formatErrorMessage(err)}`,
+                        );
+                      }
+                    } catch (persistErr: unknown) {
+                      log.warn(
+                        `failed to preserve queued delivery ${queueId} after ack failure: ${formatErrorMessage(persistErr)}`,
+                      );
+                    }
+                    if (queuePolicy === "required") {
+                      throw err;
+                    }
+                    log.warn(
+                      hasSendEvidence
+                        ? `failed to ack queued delivery ${queueId}; preserved unknown-after-send state: ${formatErrorMessage(err)}`
+                        : `failed to ack unsent queued delivery ${queueId}; retained it for retry: ${formatErrorMessage(err)}`,
+                    );
+                    return false;
+                  });
         if (acked) {
-          await runOutboundDeliveryCommitHooks(results);
+          queuedPostSendState = "acked";
+          await runCommitHooksAfterAck();
         }
       }
     }
     return results;
   } catch (err) {
+    if (err instanceof OutboundDeliveryError && err.results.length > 0) {
+      deliveredResults = err.results;
+    }
     if (queueId) {
       if (isDeliveryAbortError(err)) {
         await ackDelivery(queueId).catch(() => {});
       } else if (!platformResultsReturned) {
         const sendEvidence =
-          platformSendStarted && err instanceof OutboundDeliveryError && err.sentBeforeError;
+          deliveredResults.length > 0 ||
+          (err instanceof OutboundDeliveryError && err.sentBeforeError);
         if (sendEvidence) {
-          await markQueuedPlatformOutcomeUnknown({
-            queueId,
-            queuePolicy,
-          }).catch((markErr: unknown) => {
-            log.warn(
-              `failed to mark queued delivery ${queueId} as platform-outcome-unknown after mid-send error; falling back to fail: ${formatErrorMessage(markErr)}`,
-            );
-            return failDelivery(queueId, formatErrorMessage(err)).catch((failErr: unknown) => {
-              log.warn(
-                `failed to mark queued delivery ${queueId} as failed: ${formatErrorMessage(failErr)}`,
-              );
+          try {
+            queuedPostSendState ??= await persistQueuedPostSendState({
+              queueId,
+              queuePolicy,
             });
-          });
+            if (queuedPostSendState === "marked") {
+              await failDeliveryAfterPlatformSend(queueId, formatErrorMessage(err));
+              queuedPostSendState = "failed";
+            }
+          } catch (persistErr: unknown) {
+            // Do not convert concrete send evidence back into a generic retry.
+            // All canonical state transitions failed, so retain the original row.
+            log.warn(
+              `failed to preserve queued delivery ${queueId} post-send evidence: ${formatErrorMessage(persistErr)}`,
+            );
+          }
+          await runCommitHooksAfterAck();
         } else {
           await failDelivery(queueId, formatErrorMessage(err)).catch((failErr: unknown) => {
             log.warn(
@@ -1430,7 +1526,7 @@ async function deliverOutboundPayloadsWithQueueCleanup(
 
 /** Core delivery logic (extracted for queue wrapper). */
 async function deliverOutboundPayloadsCore(
-  params: DeliverOutboundPayloadsCoreRuntimeParams,
+  params: DeliverOutboundPayloadsCoreParams,
 ): Promise<OutboundDeliveryResult[]> {
   const { cfg, channel, to, payloads } = params;
   const directiveOptions = await resolveChannelOutboundDirectiveOptions({ cfg, channel });
@@ -1444,6 +1540,164 @@ async function deliverOutboundPayloadsCore(
   const accountId = params.accountId;
   const deps = params.deps;
   const abortSignal = params.abortSignal;
+  const results: OutboundDeliveryResult[] = [];
+  let reportedResults: Array<{ identityKey: string; resultIndex: number }> = [];
+  const resultIdentityKey = (delivery: OutboundDeliveryResult): string =>
+    JSON.stringify([
+      delivery.channel,
+      delivery.messageId,
+      delivery.chatId,
+      delivery.channelId,
+      delivery.roomId,
+      delivery.conversationId,
+      delivery.timestamp,
+      delivery.toJid,
+      delivery.pollId,
+    ]);
+  const resultPlatformIds = (
+    delivery: OutboundDeliveryResult,
+    options?: { receiptOnly?: boolean },
+  ): Set<string> => {
+    const ids = new Set<string>();
+    const add = (value: string | undefined) => {
+      const id = value?.trim();
+      if (id && id !== "unknown" && id !== "suppressed") {
+        ids.add(id);
+      }
+    };
+    if (!options?.receiptOnly) {
+      add(delivery.messageId);
+    }
+    add(delivery.receipt?.primaryPlatformMessageId);
+    for (const id of delivery.receipt?.platformMessageIds ?? []) {
+      add(id);
+    }
+    for (const part of delivery.receipt?.parts ?? []) {
+      add(part.platformMessageId);
+    }
+    return ids;
+  };
+  const reportIdentifiedDeliveryResult = async (
+    delivery: OutboundDeliveryResult,
+  ): Promise<void> => {
+    if (!hasDeliveryResultIdentity(delivery)) {
+      return;
+    }
+    const resultIndex = results.length;
+    results.push(delivery);
+    reportedResults.push({ identityKey: resultIdentityKey(delivery), resultIndex });
+    // Persist concrete platform evidence before pinning, hooks, mirroring, or
+    // another send can fail or the process can stop.
+    await params.onDeliveryResult?.(delivery);
+  };
+  const recordIdentifiedDeliveryResults = async (
+    deliveries: readonly OutboundDeliveryResult[],
+    options?: { finalResultIsLastReported?: boolean },
+  ): Promise<boolean[]> => {
+    const reportedByIdentity = new Map<string, number[]>();
+    for (const reported of reportedResults) {
+      const matches = reportedByIdentity.get(reported.identityKey) ?? [];
+      matches.push(reported.resultIndex);
+      reportedByIdentity.set(reported.identityKey, matches);
+    }
+    try {
+      const recorded: boolean[] = [];
+      const availableReportedIndices = new Set(
+        reportedResults.map((reported) => reported.resultIndex),
+      );
+      const replacements = new Map<number, OutboundDeliveryResult>();
+      const removals = new Set<number>();
+      const appendResults: OutboundDeliveryResult[] = [];
+      for (const delivery of deliveries) {
+        if (!hasDeliveryResultIdentity(delivery)) {
+          recorded.push(false);
+          continue;
+        }
+        const receiptPartIds = (delivery.receipt?.parts ?? [])
+          .map((part) => part.platformMessageId?.trim())
+          .filter((id): id is string => Boolean(id && id !== "unknown" && id !== "suppressed"));
+        const receiptIds =
+          receiptPartIds.length > 0
+            ? receiptPartIds
+            : [...resultPlatformIds(delivery, { receiptOnly: true })];
+        const coveredIndices: number[] = [];
+        for (const receiptId of receiptIds) {
+          const matchingIndices = reportedResults
+            .filter(
+              (reported) =>
+                availableReportedIndices.has(reported.resultIndex) &&
+                !coveredIndices.includes(reported.resultIndex) &&
+                results[reported.resultIndex]?.channel === delivery.channel &&
+                resultPlatformIds(results[reported.resultIndex]).has(receiptId),
+            )
+            .map((reported) => reported.resultIndex);
+          // One receipt part covers one progress result. Repeated parts preserve
+          // aggregate multiplicity, while one constant platform ID cannot erase
+          // other successful sends that the final receipt does not aggregate.
+          const matchingIndex = options?.finalResultIsLastReported
+            ? matchingIndices.at(-1)
+            : matchingIndices[0];
+          if (matchingIndex !== undefined && !coveredIndices.includes(matchingIndex)) {
+            coveredIndices.push(matchingIndex);
+          }
+        }
+        let reportedIndex: number | undefined;
+        if (coveredIndices.length > 0) {
+          reportedIndex = Math.min(...coveredIndices);
+          for (const coveredIndex of coveredIndices) {
+            availableReportedIndices.delete(coveredIndex);
+            if (coveredIndex !== reportedIndex) {
+              removals.add(coveredIndex);
+            }
+          }
+        } else {
+          const reportedMatches = (
+            reportedByIdentity.get(resultIdentityKey(delivery)) ?? []
+          ).filter((index) => availableReportedIndices.has(index));
+          reportedIndex = options?.finalResultIsLastReported
+            ? reportedMatches.at(-1)
+            : reportedMatches[0];
+          if (reportedIndex !== undefined) {
+            availableReportedIndices.delete(reportedIndex);
+          }
+        }
+        if (reportedIndex !== undefined) {
+          // Replace all progress covered by an aggregate receipt with the final
+          // hook-bearing object, avoiding duplicate receipt parts.
+          replacements.set(reportedIndex, delivery);
+        } else {
+          appendResults.push(delivery);
+        }
+        recorded.push(true);
+      }
+      if (replacements.size > 0 || removals.size > 0) {
+        const reconciled = results.flatMap((result, index) => {
+          if (removals.has(index)) {
+            return [];
+          }
+          return [replacements.get(index) ?? result];
+        });
+        results.splice(0, results.length, ...reconciled);
+      }
+      for (const delivery of appendResults) {
+        results.push(delivery);
+        await params.onDeliveryResult?.(delivery);
+      }
+      return recorded;
+    } finally {
+      // Progress matching is scoped to exactly one adapter invocation. IDs such
+      // as LINE's constant "push" value can legitimately repeat later.
+      reportedResults = [];
+    }
+  };
+  const recordIdentifiedDeliveryResult = async (
+    delivery: OutboundDeliveryResult,
+  ): Promise<boolean> =>
+    (
+      await recordIdentifiedDeliveryResults([delivery], {
+        finalResultIsLastReported: true,
+      })
+    )[0] ?? false;
   const resolveMediaAccess = (mediaSources: readonly string[]): OutboundMediaAccess =>
     mediaSources.length > 0
       ? resolveAgentScopedOutboundMediaAccess({
@@ -1477,7 +1731,8 @@ async function deliverOutboundPayloadsCore(
       silent: params.silent,
       mediaAccess: resolveMediaAccess(mediaSources),
       gatewayClientScopes: params.gatewayClientScopes,
-      ...(params.onPlatformSendStart ? { onPlatformSendStart: params.onPlatformSendStart } : {}),
+      onPlatformSendStart: params.onPlatformSendStart,
+      onDeliveryResult: reportIdentifiedDeliveryResult,
     });
   const baseHandler = await createHandler([]);
   const handlerByMediaSources = new Map<string, Promise<ChannelHandler>>();
@@ -1494,7 +1749,6 @@ async function deliverOutboundPayloadsCore(
     handlerByMediaSources.set(key, created);
     return created;
   };
-  const results: OutboundDeliveryResult[] = [];
   const handler = baseHandler;
   const configuredTextLimit = handler.chunker
     ? resolveTextChunkLimit(cfg, channel, accountId, {
@@ -1538,7 +1792,7 @@ async function deliverOutboundPayloadsCore(
         continue;
       }
       throwIfAborted(abortSignal);
-      pushIdentifiedDeliveryResult(results, await sendHandler.sendText(unit.text, unit.overrides));
+      await recordIdentifiedDeliveryResult(await sendHandler.sendText(unit.text, unit.overrides));
     }
   };
   const normalizedPayloads = normalizePayloadsForChannelDelivery(outboundPayloadPlan, handler);
@@ -1557,7 +1811,7 @@ async function deliverOutboundPayloadsCore(
     payloadSummary: NormalizedOutboundPayload,
     deliveredResults: readonly OutboundDeliveryResult[],
   ): void => {
-    if (!params.mirror || !params.replyPayloadSendingHook || deliveredResults.length === 0) {
+    if (!params.mirror || deliveredResults.length === 0) {
       return;
     }
     deliveredMirrorPayloads.push(payloadSummary);
@@ -1750,11 +2004,14 @@ async function deliverOutboundPayloadsCore(
           }) ||
           effectivePayload.audioAsVoice === true)
       ) {
+        const beforeCount = results.length;
         const delivery = await deliveryHandler.sendPayload(
           effectivePayload,
           applySendReplyToConsumption(sendOverrides),
         );
-        if (!hasDeliveryResultIdentity(delivery)) {
+        await recordIdentifiedDeliveryResult(delivery);
+        const deliveredResults = results.slice(beforeCount);
+        if (deliveredResults.length === 0) {
           completeDeliveryDiagnostics(0);
           recordPayloadOutcome(
             suppressedPayloadOutcome({
@@ -1764,39 +2021,36 @@ async function deliverOutboundPayloadsCore(
           );
           continue;
         }
-        results.push(delivery);
-        recordPayloadOutcome({ index: payloadIndex, status: "sent", results: [delivery] });
-        recordDeliveredMirrorPayload(payloadSummary, [delivery]);
+        recordPayloadOutcome({ index: payloadIndex, status: "sent", results: deliveredResults });
+        recordDeliveredMirrorPayload(payloadSummary, deliveredResults);
         await maybePinDeliveredMessage({
           handler: deliveryHandler,
           payload: effectivePayload,
           target: deliveryTarget,
-          messageId: delivery.messageId,
+          messageId: deliveredResults.find((entry) => entry.messageId)?.messageId,
           gatewayClientScopes: params.gatewayClientScopes,
         });
         await maybeNotifyAfterDeliveredPayload({
           handler: deliveryHandler,
           payload: effectivePayload,
           target: deliveryTarget,
-          results: [delivery],
+          results: deliveredResults,
         });
-        completeDeliveryDiagnostics(1);
+        completeDeliveryDiagnostics(deliveredResults.length);
         emitMessageSent({
           success: true,
           content: payloadSummary.hookContent ?? payloadSummary.text,
-          messageId: delivery.messageId,
+          messageId: deliveredResults.at(-1)?.messageId,
         });
         continue;
       }
       if (payloadSummary.mediaUrls.length === 0) {
         const beforeCount = results.length;
         if (deliveryHandler.sendFormattedText) {
-          results.push(
-            ...filterIdentifiedDeliveryResults(
-              await deliveryHandler.sendFormattedText(
-                payloadSummary.text,
-                applySendReplyToConsumption(sendOverrides),
-              ),
+          await recordIdentifiedDeliveryResults(
+            await deliveryHandler.sendFormattedText(
+              payloadSummary.text,
+              applySendReplyToConsumption(sendOverrides),
             ),
           );
         } else {
@@ -1920,7 +2174,7 @@ async function deliverOutboundPayloadsCore(
               unit.overrides,
             )
           : await deliveryHandler.sendMedia(unit.caption ?? "", unit.mediaUrl, unit.overrides);
-        if (pushIdentifiedDeliveryResult(results, delivery)) {
+        if (await recordIdentifiedDeliveryResult(delivery)) {
           firstMessageId ??= delivery.messageId;
           lastMessageId = delivery.messageId;
         }
@@ -1961,6 +2215,9 @@ async function deliverOutboundPayloadsCore(
         messageId: lastMessageId,
       });
     } catch (err) {
+      // A rejected adapter has no final return to reconcile with its progress
+      // results. Keep the results, but never match them to a later payload.
+      reportedResults = [];
       recordPayloadOutcome({
         index: payloadIndex,
         status: "failed",
@@ -1985,17 +2242,14 @@ async function deliverOutboundPayloadsCore(
       params.onError?.(err, payloadSummary);
     }
   }
-  if (params.mirror && results.length > 0) {
-    const deliveredMirror =
-      deliveredMirrorPayloads.length > 0
-        ? {
-            text: deliveredMirrorPayloads
-              .map((payload) => payload.hookContent ?? payload.text)
-              .filter((text) => text.trim())
-              .join("\n"),
-            mediaUrls: deliveredMirrorPayloads.flatMap((payload) => payload.mediaUrls),
-          }
-        : params.mirror;
+  if (params.mirror && deliveredMirrorPayloads.length > 0) {
+    const deliveredMirror = {
+      text: deliveredMirrorPayloads
+        .map((payload) => payload.hookContent ?? payload.text)
+        .filter((text) => text.trim())
+        .join("\n"),
+      mediaUrls: deliveredMirrorPayloads.flatMap((payload) => payload.mediaUrls),
+    };
     const mirrorText = resolveMirroredTranscriptText({
       text: deliveredMirror.text,
       mediaUrls: deliveredMirror.mediaUrls,

--- a/src/infra/outbound/delivery-queue-recovery.ts
+++ b/src/infra/outbound/delivery-queue-recovery.ts
@@ -17,7 +17,11 @@ import {
 } from "../delivery-recovery.shared.js";
 import { formatErrorMessage } from "../errors.js";
 import { resolveOutboundChannelMessageAdapter } from "./channel-resolution.js";
-import type { OutboundDeliveryResult } from "./deliver-types.js";
+import {
+  isOutboundDeliveryError,
+  type OutboundDeliveryResult,
+  type OutboundPayloadDeliveryOutcome,
+} from "./deliver-types.js";
 import {
   isOutboundDeliveryResultArray,
   runOutboundDeliveryCommitHooks,
@@ -25,8 +29,10 @@ import {
 import {
   ackDelivery,
   failDelivery,
+  failDeliveryAfterPlatformSend,
   loadPendingDelivery,
   loadPendingDeliveries,
+  markDeliveryPlatformOutcomeUnknown,
   moveToFailed,
   type QueuedDelivery,
   type QueuedDeliveryPayload,
@@ -49,6 +55,8 @@ export type DeliverFn = (
       deliveryQueueStateDir?: string;
       skipQueue?: boolean;
       deferCommitHooks?: boolean;
+      onPayloadDeliveryOutcome?: (outcome: OutboundPayloadDeliveryOutcome) => void;
+      onDeliveryResult?: (result: OutboundDeliveryResult) => Promise<void> | void;
     },
 ) => Promise<unknown>;
 
@@ -338,6 +346,31 @@ export function isPermanentDeliveryError(error: string): boolean {
   return PERMANENT_ERROR_PATTERNS.some((re) => re.test(error));
 }
 
+async function persistRecoveredPostSendState(opts: {
+  entry: QueuedDelivery;
+  log: RecoveryLogger;
+  stateDir?: string;
+}): Promise<"marked" | "acked" | "failed"> {
+  try {
+    await markDeliveryPlatformOutcomeUnknown(opts.entry.id, opts.stateDir);
+    return "marked";
+  } catch (markErr) {
+    // A result proves at least one send completed. If the intermediate marker
+    // is unavailable, direct ack still removes the replayable intent.
+    opts.log.warn(
+      `Delivery entry ${opts.entry.id} failed to persist post-send state; falling back to direct ack: ${formatErrorMessage(markErr)}`,
+    );
+    try {
+      await ackDelivery(opts.entry.id, opts.stateDir);
+      return "acked";
+    } catch (ackErr) {
+      const error = `post-send state persistence failed: marker=${formatErrorMessage(markErr)}; ack=${formatErrorMessage(ackErr)}`;
+      await failDeliveryAfterPlatformSend(opts.entry.id, error, opts.stateDir);
+      return "failed";
+    }
+  }
+}
+
 async function drainQueuedEntry(opts: {
   entry: QueuedDelivery;
   cfg: OpenClawConfig;
@@ -426,17 +459,125 @@ async function drainQueuedEntry(opts: {
       return "failed";
     }
   }
-  try {
-    const result = await opts.deliver(buildRecoveryDeliverParams(entry, opts.cfg, opts.stateDir));
-    await ackDelivery(entry.id, opts.stateDir);
-    if (isOutboundDeliveryResultArray(result)) {
-      await runOutboundDeliveryCommitHooks(result);
+  const payloadOutcomes: OutboundPayloadDeliveryOutcome[] = [];
+  let postSendState: "marked" | "acked" | "failed" | undefined;
+  let deliveredResults: OutboundDeliveryResult[] = [];
+  let commitHooksRun = false;
+  const collectResults = (results: readonly OutboundDeliveryResult[]): void => {
+    for (const result of results) {
+      if (!deliveredResults.includes(result)) {
+        deliveredResults.push(result);
+      }
     }
+  };
+  const runCommitHooksAfterAck = async (): Promise<void> => {
+    if (postSendState !== "acked" || commitHooksRun || deliveredResults.length === 0) {
+      return;
+    }
+    commitHooksRun = true;
+    await runOutboundDeliveryCommitHooks(deliveredResults);
+  };
+  try {
+    const result = await opts.deliver({
+      ...buildRecoveryDeliverParams(entry, opts.cfg, opts.stateDir),
+      onPayloadDeliveryOutcome: (outcome) => payloadOutcomes.push(outcome),
+      onDeliveryResult: async (deliveryResult) => {
+        collectResults([deliveryResult]);
+        postSendState ??= await persistRecoveredPostSendState({
+          entry,
+          log: opts.log,
+          stateDir: opts.stateDir,
+        });
+      },
+    });
+    const results = isOutboundDeliveryResultArray(result) ? result : [];
+    if (results.length > 0) {
+      deliveredResults = [...results];
+    }
+    const failedOutcome = payloadOutcomes.find((outcome) => outcome.status === "failed");
+    if (failedOutcome) {
+      const errMsg = formatErrorMessage(failedOutcome.error);
+      opts.onFailed?.(entry, errMsg);
+      if (results.length > 0 || failedOutcome.sentBeforeError) {
+        postSendState ??= await persistRecoveredPostSendState({
+          entry,
+          log: opts.log,
+          stateDir: opts.stateDir,
+        });
+        opts.log.warn(
+          `Delivery entry ${entry.id} partially sent before best-effort recovery failed; preserving unknown_after_send`,
+        );
+        if (postSendState === "acked") {
+          await runCommitHooksAfterAck();
+        }
+      } else {
+        await failDelivery(entry.id, errMsg, opts.stateDir);
+      }
+      return "failed";
+    }
+    postSendState ??=
+      results.length > 0
+        ? await persistRecoveredPostSendState({ entry, log: opts.log, stateDir: opts.stateDir })
+        : undefined;
+    if (postSendState === "failed") {
+      const errMsg = "recovered send completed but queue finalization failed";
+      opts.onFailed?.(entry, errMsg);
+      opts.log.warn(`Delivery entry ${entry.id} ${errMsg}; preserving unknown_after_send`);
+      return "failed";
+    }
+    if (postSendState !== "acked") {
+      try {
+        await ackDelivery(entry.id, opts.stateDir);
+        postSendState = "acked";
+      } catch (ackErr) {
+        const ackError = `failed to ack recovered delivery: ${formatErrorMessage(ackErr)}`;
+        if (results.length > 0) {
+          await failDeliveryAfterPlatformSend(entry.id, ackError, opts.stateDir);
+          postSendState = "failed";
+        } else {
+          await failDelivery(entry.id, ackError, opts.stateDir);
+        }
+        opts.onFailed?.(entry, ackError);
+        opts.log.warn(`Delivery entry ${entry.id} ${ackError}`);
+        return "failed";
+      }
+    }
+    await runCommitHooksAfterAck();
     opts.onRecovered?.(entry);
     return "recovered";
   } catch (err) {
     const errMsg = formatErrorMessage(err);
     opts.onFailed?.(entry, errMsg);
+    if (isOutboundDeliveryError(err) && err.results.length > 0) {
+      deliveredResults = [...err.results];
+    }
+    const hasSendEvidence =
+      deliveredResults.length > 0 ||
+      postSendState !== undefined ||
+      (isOutboundDeliveryError(err) && err.sentBeforeError);
+    if (hasSendEvidence) {
+      // A rejected batch can still contain successful earlier sends. Preserve
+      // that concrete evidence so reconnect recovery never replays the batch.
+      try {
+        postSendState ??= await persistRecoveredPostSendState({
+          entry,
+          log: opts.log,
+          stateDir: opts.stateDir,
+        });
+      } catch (persistErr) {
+        // Never overwrite concrete send evidence with a generic retry state.
+        opts.log.error(
+          `Delivery entry ${entry.id} could not persist post-send evidence: ${formatErrorMessage(persistErr)}`,
+        );
+      }
+      if (postSendState === "acked") {
+        await runCommitHooksAfterAck();
+      }
+      opts.log.warn(
+        `Delivery entry ${entry.id} partially sent before recovery failed; preserving unknown_after_send`,
+      );
+      return "failed";
+    }
     if (isPermanentDeliveryError(errMsg)) {
       try {
         await moveToFailed(entry.id, opts.stateDir);

--- a/src/infra/outbound/delivery-queue-storage.ts
+++ b/src/infra/outbound/delivery-queue-storage.ts
@@ -145,6 +145,22 @@ export async function failDelivery(id: string, error: string, stateDir?: string)
   }));
 }
 
+/** Record a failed attempt without losing evidence that platform delivery may have completed. */
+export async function failDeliveryAfterPlatformSend(
+  id: string,
+  error: string,
+  stateDir?: string,
+): Promise<void> {
+  updateQueuedDelivery(id, stateDir, (entry) => ({
+    ...entry,
+    retryCount: entry.retryCount + 1,
+    lastAttemptAt: Date.now(),
+    lastError: error,
+    platformSendStartedAt: entry.platformSendStartedAt ?? Date.now(),
+    recoveryState: "unknown_after_send",
+  }));
+}
+
 function updateQueuedDelivery(
   id: string,
   stateDir: string | undefined,

--- a/src/infra/outbound/delivery-queue.recovery.test.ts
+++ b/src/infra/outbound/delivery-queue.recovery.test.ts
@@ -3,6 +3,7 @@
 import { MAX_DATE_TIMESTAMP_MS } from "@openclaw/normalization-core/number-coercion";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { openOpenClawStateDatabase } from "../../state/openclaw-state-db.js";
+import { OutboundDeliveryError, type OutboundPayloadDeliveryOutcome } from "./deliver-types.js";
 import { attachOutboundDeliveryCommitHook } from "./delivery-commit-hooks.js";
 import {
   enqueueDelivery,
@@ -133,6 +134,113 @@ describe("delivery-queue recovery", () => {
     expect(entries).toHaveLength(1);
     expect(entries[0]?.retryCount).toBe(1);
     expect(entries[0]?.lastError).toBe("network down");
+  });
+
+  it("does not replay a recovery batch that rejected after an earlier send succeeded", async () => {
+    const id = await enqueueDelivery(
+      {
+        channel: "demo-channel-c",
+        to: "#ch",
+        payloads: [{ text: "first" }, { text: "second" }],
+      },
+      tmpDir(),
+    );
+    const partialFailure = new OutboundDeliveryError("second send failed", {
+      cause: new Error("network down"),
+      results: [{ channel: "demo-channel-c", messageId: "m1" }],
+    });
+
+    const { result } = await runRecovery({
+      deliver: vi.fn().mockRejectedValue(partialFailure),
+    });
+
+    expect(result).toMatchObject({ recovered: 0, failed: 1 });
+    const entries = await loadPendingDeliveries(tmpDir());
+    expect(entries).toHaveLength(1);
+    expect(entries[0]?.id).toBe(id);
+    expect(entries[0]?.recoveryState).toBe("unknown_after_send");
+    expect(entries[0]?.retryCount).toBe(0);
+
+    const replay = vi.fn();
+    await runRecovery({ deliver: replay });
+    expect(replay).not.toHaveBeenCalled();
+    expect(await loadPendingDeliveries(tmpDir())).toHaveLength(0);
+    expect(readOutboundQueueStatus(tmpDir(), id)).toBe("failed");
+  });
+
+  it("keeps a best-effort recovery failure retryable when no payload was sent", async () => {
+    await enqueueDelivery(
+      {
+        channel: "demo-channel-c",
+        to: "#ch",
+        payloads: [{ text: "first" }],
+        bestEffort: true,
+      },
+      tmpDir(),
+    );
+    const deliver = vi.fn(
+      async (params: {
+        onPayloadDeliveryOutcome?: (outcome: OutboundPayloadDeliveryOutcome) => void;
+      }) => {
+        params.onPayloadDeliveryOutcome?.({
+          index: 0,
+          status: "failed",
+          error: new Error("network down"),
+          sentBeforeError: false,
+          stage: "platform_send",
+        });
+        return [];
+      },
+    );
+
+    const { result } = await runRecovery({ deliver });
+
+    expect(result).toMatchObject({ recovered: 0, failed: 1 });
+    const entries = await loadPendingDeliveries(tmpDir());
+    expect(entries).toHaveLength(1);
+    expect(entries[0]?.recoveryState).toBeUndefined();
+    expect(entries[0]?.retryCount).toBe(1);
+    expect(entries[0]?.lastError).toBe("network down");
+  });
+
+  it("does not ack a partially sent best-effort recovery batch", async () => {
+    const id = await enqueueDelivery(
+      {
+        channel: "demo-channel-c",
+        to: "#ch",
+        payloads: [{ text: "first" }, { text: "second" }],
+        bestEffort: true,
+      },
+      tmpDir(),
+    );
+    const deliver = vi.fn(
+      async (params: {
+        onPayloadDeliveryOutcome?: (outcome: OutboundPayloadDeliveryOutcome) => void;
+      }) => {
+        params.onPayloadDeliveryOutcome?.({
+          index: 1,
+          status: "failed",
+          error: new Error("second send failed"),
+          sentBeforeError: true,
+          stage: "platform_send",
+        });
+        return [{ channel: "demo-channel-c", messageId: "m1" }];
+      },
+    );
+
+    const { result } = await runRecovery({ deliver });
+
+    expect(result).toMatchObject({ recovered: 0, failed: 1 });
+    const entries = await loadPendingDeliveries(tmpDir());
+    expect(entries).toHaveLength(1);
+    expect(entries[0]?.id).toBe(id);
+    expect(entries[0]?.recoveryState).toBe("unknown_after_send");
+    expect(entries[0]?.retryCount).toBe(0);
+
+    const replay = vi.fn();
+    await runRecovery({ deliver: replay });
+    expect(replay).not.toHaveBeenCalled();
+    expect(readOutboundQueueStatus(tmpDir(), id)).toBe("failed");
   });
 
   it("moves entries abandoned after platform send may have started to failed without reconciliation", async () => {
@@ -465,7 +573,7 @@ describe("delivery-queue recovery", () => {
   });
 
   it("passes skipQueue: true to prevent re-enqueueing during recovery", async () => {
-    const id = await enqueueDelivery(
+    await enqueueDelivery(
       { channel: "demo-channel-a", to: "+1", payloads: [{ text: "a" }] },
       tmpDir(),
     );
@@ -473,13 +581,7 @@ describe("delivery-queue recovery", () => {
     const deliver = vi.fn().mockResolvedValue([]);
     await runRecovery({ deliver });
 
-    const deliverInput = mockCallArg(deliver) as {
-      deliveryQueueId?: string;
-      deliveryQueueStateDir?: string;
-      skipQueue?: boolean;
-    };
-    expect(deliverInput.deliveryQueueId).toBe(id);
-    expect(deliverInput.deliveryQueueStateDir).toBe(tmpDir());
+    const deliverInput = mockCallArg(deliver) as { skipQueue?: boolean };
     expect(deliverInput.skipQueue).toBe(true);
   });
 
@@ -530,6 +632,281 @@ describe("delivery-queue recovery", () => {
     expect(order).toEqual(["deliver", "commit-after-ack"]);
     expect(await loadPendingDeliveries(tmpDir())).toHaveLength(0);
     expect(readOutboundQueueStatus(tmpDir(), id)).toBeUndefined();
+  });
+
+  it("does not restore an acked entry when a recovered send commit hook fails", async () => {
+    const id = await enqueueDelivery(
+      { channel: "demo-channel-a", to: "+1", payloads: [{ text: "a" }] },
+      tmpDir(),
+    );
+    const result = attachOutboundDeliveryCommitHook(
+      { channel: "demo-channel-a", messageId: "m1" },
+      async () => {
+        throw new Error("commit hook offline");
+      },
+    );
+    const deliver = vi.fn().mockResolvedValue([result]);
+
+    const { result: summary } = await runRecovery({ deliver });
+
+    expect(summary).toEqual({
+      recovered: 1,
+      failed: 0,
+      skippedMaxRetries: 0,
+      deferredBackoff: 0,
+    });
+    expect(await loadPendingDeliveries(tmpDir())).toHaveLength(0);
+    expect(readOutboundQueueStatus(tmpDir(), id)).toBeUndefined();
+  });
+
+  it("marks a recovered send unknown before ack so ack failure cannot make it replayable", async () => {
+    const id = await enqueueDelivery(
+      { channel: "demo-channel-a", to: "+1", payloads: [{ text: "a" }] },
+      tmpDir(),
+    );
+    let recoveryStateAtAck: string | undefined;
+    vi.resetModules();
+    vi.doMock("./delivery-queue-storage.js", async () => {
+      const actual = await vi.importActual<typeof import("./delivery-queue-storage.js")>(
+        "./delivery-queue-storage.js",
+      );
+      return {
+        ...actual,
+        ackDelivery: vi.fn(async (entryId: string, stateDir?: string) => {
+          recoveryStateAtAck = (await actual.loadPendingDelivery(entryId, stateDir))?.recoveryState;
+          throw new Error("ack state db locked");
+        }),
+      };
+    });
+
+    try {
+      const { recoverPendingDeliveries: recoverWithAckFailure } =
+        await import("./delivery-queue-recovery.js");
+      const summary = await recoverWithAckFailure({
+        deliver: asDeliverFn(
+          vi.fn().mockResolvedValue([{ channel: "demo-channel-a", messageId: "m1" }]),
+        ),
+        log: createRecoveryLog(),
+        cfg: baseCfg,
+        stateDir: tmpDir(),
+      });
+
+      expect(summary).toEqual({
+        recovered: 0,
+        failed: 1,
+        skippedMaxRetries: 0,
+        deferredBackoff: 0,
+      });
+      expect(recoveryStateAtAck).toBe("unknown_after_send");
+      const pending = await loadPendingDeliveries(tmpDir());
+      expect(pending).toHaveLength(1);
+      expect(pending[0]?.id).toBe(id);
+      expect(pending[0]?.recoveryState).toBe("unknown_after_send");
+      expect(pending[0]?.lastError).toContain("ack state db locked");
+    } finally {
+      vi.doUnmock("./delivery-queue-storage.js");
+      vi.resetModules();
+    }
+  });
+
+  it("keeps a recovered zero-result delivery retryable when ack fails", async () => {
+    const id = await enqueueDelivery(
+      { channel: "demo-channel-a", to: "+1", payloads: [{ text: "a" }] },
+      tmpDir(),
+    );
+    vi.resetModules();
+    vi.doMock("./delivery-queue-storage.js", async () => {
+      const actual = await vi.importActual<typeof import("./delivery-queue-storage.js")>(
+        "./delivery-queue-storage.js",
+      );
+      return {
+        ...actual,
+        ackDelivery: vi.fn(async () => {
+          throw new Error("ack state db locked");
+        }),
+      };
+    });
+
+    try {
+      const { recoverPendingDeliveries: recoverWithAckFailure } =
+        await import("./delivery-queue-recovery.js");
+      const summary = await recoverWithAckFailure({
+        deliver: asDeliverFn(vi.fn().mockResolvedValue([])),
+        log: createRecoveryLog(),
+        cfg: baseCfg,
+        stateDir: tmpDir(),
+      });
+
+      expect(summary).toMatchObject({ recovered: 0, failed: 1 });
+      const pending = await loadPendingDeliveries(tmpDir());
+      expect(pending).toHaveLength(1);
+      expect(pending[0]?.id).toBe(id);
+      expect(pending[0]?.recoveryState).toBeUndefined();
+      expect(pending[0]?.retryCount).toBe(1);
+      expect(pending[0]?.lastError).toContain("ack state db locked");
+    } finally {
+      vi.doUnmock("./delivery-queue-storage.js");
+      vi.resetModules();
+    }
+  });
+
+  it("directly acks a recovered send when its post-send marker fails", async () => {
+    const id = await enqueueDelivery(
+      { channel: "demo-channel-a", to: "+1", payloads: [{ text: "a" }] },
+      tmpDir(),
+    );
+    vi.resetModules();
+    vi.doMock("./delivery-queue-storage.js", async () => {
+      const actual = await vi.importActual<typeof import("./delivery-queue-storage.js")>(
+        "./delivery-queue-storage.js",
+      );
+      return {
+        ...actual,
+        markDeliveryPlatformOutcomeUnknown: vi.fn(async () => {
+          throw new Error("post-send state db locked");
+        }),
+      };
+    });
+
+    try {
+      const { recoverPendingDeliveries: recoverWithMarkFailure } =
+        await import("./delivery-queue-recovery.js");
+      const log = createRecoveryLog();
+      const summary = await recoverWithMarkFailure({
+        deliver: asDeliverFn(
+          vi.fn().mockResolvedValue([{ channel: "demo-channel-a", messageId: "m1" }]),
+        ),
+        cfg: baseCfg,
+        stateDir: tmpDir(),
+        log,
+      });
+
+      expect(summary).toEqual({
+        recovered: 1,
+        failed: 0,
+        skippedMaxRetries: 0,
+        deferredBackoff: 0,
+      });
+      expect(await loadPendingDeliveries(tmpDir())).toHaveLength(0);
+      expect(readOutboundQueueStatus(tmpDir(), id)).toBeUndefined();
+      expectMockMessageContaining(log.warn, "falling back to direct ack");
+    } finally {
+      vi.doUnmock("./delivery-queue-storage.js");
+      vi.resetModules();
+    }
+  });
+
+  it("runs recovered commit hooks when marker fallback ack precedes a partial failure", async () => {
+    await enqueueDelivery(
+      {
+        channel: "demo-channel-a",
+        to: "+1",
+        payloads: [{ text: "first" }, { text: "second" }],
+        bestEffort: true,
+      },
+      tmpDir(),
+    );
+    const afterCommit = vi.fn();
+    vi.resetModules();
+    vi.doMock("./delivery-queue-storage.js", async () => {
+      const actual = await vi.importActual<typeof import("./delivery-queue-storage.js")>(
+        "./delivery-queue-storage.js",
+      );
+      return {
+        ...actual,
+        markDeliveryPlatformOutcomeUnknown: vi.fn(async () => {
+          throw new Error("post-send state db locked");
+        }),
+      };
+    });
+
+    try {
+      const { recoverPendingDeliveries: recoverWithMarkFailure } =
+        await import("./delivery-queue-recovery.js");
+      const { attachOutboundDeliveryCommitHook: attachHookAfterReset } =
+        await import("./delivery-commit-hooks.js");
+      const result = attachHookAfterReset(
+        { channel: "demo-channel-a", messageId: "m1" },
+        afterCommit,
+      );
+      const summary = await recoverWithMarkFailure({
+        deliver: asDeliverFn(
+          vi.fn(
+            async (params: {
+              onDeliveryResult?: (deliveryResult: typeof result) => Promise<void> | void;
+              onPayloadDeliveryOutcome?: (outcome: OutboundPayloadDeliveryOutcome) => void;
+            }) => {
+              await params.onDeliveryResult?.(result);
+              params.onPayloadDeliveryOutcome?.({
+                index: 1,
+                status: "failed",
+                error: new Error("second send failed"),
+                sentBeforeError: false,
+                stage: "platform_send",
+              });
+              return [result];
+            },
+          ),
+        ),
+        cfg: baseCfg,
+        stateDir: tmpDir(),
+        log: createRecoveryLog(),
+      });
+
+      expect(summary).toMatchObject({ recovered: 0, failed: 1 });
+      expect(afterCommit).toHaveBeenCalledTimes(1);
+      expect(await loadPendingDeliveries(tmpDir())).toHaveLength(0);
+    } finally {
+      vi.doUnmock("./delivery-queue-storage.js");
+      vi.resetModules();
+    }
+  });
+
+  it("retains unknown-after-send when recovered-send marking and ack both fail", async () => {
+    const id = await enqueueDelivery(
+      { channel: "demo-channel-a", to: "+1", payloads: [{ text: "a" }] },
+      tmpDir(),
+    );
+    vi.resetModules();
+    vi.doMock("./delivery-queue-storage.js", async () => {
+      const actual = await vi.importActual<typeof import("./delivery-queue-storage.js")>(
+        "./delivery-queue-storage.js",
+      );
+      return {
+        ...actual,
+        markDeliveryPlatformOutcomeUnknown: vi.fn(async () => {
+          throw new Error("post-send state db locked");
+        }),
+        ackDelivery: vi.fn(async () => {
+          throw new Error("ack state db locked");
+        }),
+      };
+    });
+
+    try {
+      const { recoverPendingDeliveries: recoverWithStateFailures } =
+        await import("./delivery-queue-recovery.js");
+      const summary = await recoverWithStateFailures({
+        deliver: asDeliverFn(
+          vi.fn().mockResolvedValue([{ channel: "demo-channel-a", messageId: "m1" }]),
+        ),
+        cfg: baseCfg,
+        stateDir: tmpDir(),
+        log: createRecoveryLog(),
+      });
+
+      expect(summary).toMatchObject({ recovered: 0, failed: 1 });
+      const entries = await loadPendingDeliveries(tmpDir());
+      expect(entries).toHaveLength(1);
+      expect(entries[0]?.id).toBe(id);
+      expect(entries[0]?.recoveryState).toBe("unknown_after_send");
+      expect(entries[0]?.retryCount).toBe(1);
+      expect(entries[0]?.lastError).toContain("marker=post-send state db locked");
+      expect(entries[0]?.lastError).toContain("ack=ack state db locked");
+    } finally {
+      vi.doUnmock("./delivery-queue-storage.js");
+      vi.resetModules();
+    }
   });
 
   it("replays stored delivery options during recovery", async () => {

--- a/src/infra/outbound/delivery-queue.storage.test.ts
+++ b/src/infra/outbound/delivery-queue.storage.test.ts
@@ -7,6 +7,7 @@ import {
   ackDelivery,
   enqueueDelivery,
   failDelivery,
+  failDeliveryAfterPlatformSend,
   loadPendingDeliveries,
   markDeliveryPlatformOutcomeUnknown,
   markDeliveryPlatformSendAttemptStarted,
@@ -175,6 +176,22 @@ describe("delivery-queue storage", () => {
       expect(typeof entry.lastAttemptAt).toBe("number");
       expect((entry.lastAttemptAt as number) > 0).toBe(true);
       expect(entry.lastError).toBe("connection refused");
+    });
+
+    it("keeps post-send failure evidence while recording the retry failure", async () => {
+      const id = await enqueueTextDelivery({
+        channel: "forum",
+        to: "123",
+        payloads: [{ text: "test" }],
+      });
+
+      await failDeliveryAfterPlatformSend(id, "state update failed", tmpDir());
+
+      const entry = readQueuedEntry(tmpDir(), id);
+      expect(entry.retryCount).toBe(1);
+      expect(entry.lastError).toBe("state update failed");
+      expect(entry.recoveryState).toBe("unknown_after_send");
+      expect(typeof entry.platformSendStartedAt).toBe("number");
     });
   });
 

--- a/src/infra/outbound/delivery-queue.ts
+++ b/src/infra/outbound/delivery-queue.ts
@@ -3,6 +3,7 @@ export {
   ackDelivery,
   enqueueDelivery,
   failDelivery,
+  failDeliveryAfterPlatformSend,
   loadPendingDelivery,
   loadPendingDeliveries,
   markDeliveryPlatformOutcomeUnknown,

--- a/src/infra/session-cost-usage.test.ts
+++ b/src/infra/session-cost-usage.test.ts
@@ -529,7 +529,7 @@ describe("session cost usage", () => {
       await refreshCostUsageCache({ sessionFiles: [sessionFile] });
       const cachePath = path.join(sessionsDir, ".usage-cost-cache.json");
       const cache = JSON.parse(await fs.readFile(cachePath, "utf-8")) as { version: number };
-      cache.version = 4;
+      cache.version = 5;
       await fs.writeFile(cachePath, `${JSON.stringify(cache)}\n`, "utf-8");
 
       // The pre-upgrade cache must be treated as stale (not served), forcing a rebuild
@@ -1102,6 +1102,15 @@ describe("session cost usage", () => {
 
     await withStateDir(root, async () => {
       await refreshCostUsageCache({ config: configFor(1, 1) });
+      const cachePath = path.join(sessionsDir, ".usage-cost-cache.json");
+      const cache = JSON.parse(await fs.readFile(cachePath, "utf-8")) as {
+        pricingFingerprint?: unknown;
+        files: Record<string, Record<string, unknown>>;
+      };
+      expect(typeof cache.pricingFingerprint).toBe("string");
+      expect(cache.files[sessionFile]).not.toHaveProperty("pricingFingerprint");
+      expect(cache.files[sessionFile]).not.toHaveProperty("filePath");
+      expect(cache.files[sessionFile]).not.toHaveProperty("sessionId");
 
       const stale = await loadCostUsageSummaryFromCache({
         startMs: Date.UTC(2026, 1, 5),

--- a/src/infra/session-cost-usage.ts
+++ b/src/infra/session-cost-usage.ts
@@ -74,11 +74,9 @@ export type {
   UsageCacheStatus,
 } from "./session-cost-usage.types.js";
 
-// Bump when the *meaning* of cached totals changes (not just their inputs), so durable
-// caches written by older builds are rebuilt instead of served stale. Bumped to 5:
-// recorded zero costs for known-priced token usage are recomputed, and unpriced
-// zero-cost usage counts toward missingCostEntries.
-const USAGE_COST_CACHE_VERSION = 5;
+// Bump when the durable cache schema or the meaning of cached totals changes, so
+// older builds are rebuilt instead of served stale.
+const USAGE_COST_CACHE_VERSION = 6;
 const USAGE_COST_CACHE_FILE = ".usage-cost-cache.json";
 const USAGE_COST_CACHE_LOCK_WRITE_GRACE_MS = 10_000;
 const USAGE_COST_CACHE_TEMP_FILE_GRACE_MS = USAGE_COST_CACHE_LOCK_WRITE_GRACE_MS;
@@ -124,23 +122,21 @@ type UsageCostCachedTranscriptEntry = {
 };
 
 type UsageCostCacheFileEntry = {
-  filePath: string;
   size: number;
   mtimeMs: number;
-  pricingFingerprint: string;
   scannedAt: number;
   parsedRecords: number;
   countedRecords: number;
   usageEntries: UsageCostCachedUsageEntry[];
   transcriptEntries?: UsageCostCachedTranscriptEntry[];
   totals: CostUsageTotals;
-  sessionId?: string;
   sessionSummary?: SessionCostSummary;
 };
 
 type UsageCostCacheFile = {
   version: number;
   updatedAt: number;
+  pricingFingerprint: string;
   files: Record<string, UsageCostCacheFileEntry>;
 };
 
@@ -304,31 +300,41 @@ async function acquireUsageCostCacheRefreshLock(cachePath: string): Promise<{
   }
 }
 
-function normalizeUsageCostCache(raw: unknown): UsageCostCacheFile {
+function createEmptyUsageCostCache(pricingFingerprint: string): UsageCostCacheFile {
+  return { version: USAGE_COST_CACHE_VERSION, updatedAt: 0, pricingFingerprint, files: {} };
+}
+
+function normalizeUsageCostCache(raw: unknown, pricingFingerprint: string): UsageCostCacheFile {
   if (!raw || typeof raw !== "object") {
-    return { version: USAGE_COST_CACHE_VERSION, updatedAt: 0, files: {} };
+    return createEmptyUsageCostCache(pricingFingerprint);
   }
   const record = raw as Record<string, unknown>;
   if (
     record.version !== USAGE_COST_CACHE_VERSION ||
+    typeof record.pricingFingerprint !== "string" ||
+    record.pricingFingerprint !== pricingFingerprint ||
     !record.files ||
     typeof record.files !== "object"
   ) {
-    return { version: USAGE_COST_CACHE_VERSION, updatedAt: 0, files: {} };
+    return createEmptyUsageCostCache(pricingFingerprint);
   }
   return {
     version: USAGE_COST_CACHE_VERSION,
     updatedAt: asFiniteNumber(record.updatedAt) ?? 0,
+    pricingFingerprint: record.pricingFingerprint,
     files: record.files as Record<string, UsageCostCacheFileEntry>,
   };
 }
 
-async function readUsageCostCache(cachePath: string): Promise<UsageCostCacheFile> {
+async function readUsageCostCache(
+  cachePath: string,
+  pricingFingerprint: string,
+): Promise<UsageCostCacheFile> {
   try {
     const raw = await fs.promises.readFile(cachePath, "utf-8");
-    return normalizeUsageCostCache(JSON.parse(raw));
+    return normalizeUsageCostCache(JSON.parse(raw), pricingFingerprint);
   } catch {
-    return { version: USAGE_COST_CACHE_VERSION, updatedAt: 0, files: {} };
+    return createEmptyUsageCostCache(pricingFingerprint);
   }
 }
 
@@ -402,14 +408,12 @@ async function listUsageCountedTranscriptFiles(
 function isUsageCostCacheEntryFresh(params: {
   entry: UsageCostCacheFileEntry | undefined;
   file: UsageCostTranscriptFile;
-  pricingFingerprint: string;
   requireSessionSummary?: boolean;
 }): boolean {
   return Boolean(
     params.entry &&
     params.entry.size === params.file.size &&
     params.entry.mtimeMs === params.file.mtimeMs &&
-    params.entry.pricingFingerprint === params.pricingFingerprint &&
     (!params.requireSessionSummary || params.entry.sessionSummary),
   );
 }
@@ -417,24 +421,20 @@ function isUsageCostCacheEntryFresh(params: {
 function canUseUsageCostCacheEntryForPartial(params: {
   entry: UsageCostCacheFileEntry | undefined;
   file: UsageCostTranscriptFile;
-  pricingFingerprint: string;
 }): params is {
   entry: UsageCostCacheFileEntry;
   file: UsageCostTranscriptFile;
-  pricingFingerprint: string;
 } {
   return Boolean(
     params.entry &&
     params.entry.size <= params.file.size &&
-    params.entry.mtimeMs <= params.file.mtimeMs &&
-    params.entry.pricingFingerprint === params.pricingFingerprint,
+    params.entry.mtimeMs <= params.file.mtimeMs,
   );
 }
 
 function getUsageCostStaleFiles(params: {
   cache: UsageCostCacheFile;
   files: UsageCostTranscriptFile[];
-  pricingFingerprint: string;
   sessionSummaryFiles?: Set<string>;
 }): UsageCostTranscriptFile[] {
   const sessionSummaryFiles = params.sessionSummaryFiles ?? new Set<string>();
@@ -443,7 +443,6 @@ function getUsageCostStaleFiles(params: {
       !isUsageCostCacheEntryFresh({
         entry: params.cache.files[file.filePath],
         file,
-        pricingFingerprint: params.pricingFingerprint,
         requireSessionSummary: sessionSummaryFiles.has(file.filePath),
       }),
   );
@@ -452,7 +451,6 @@ function getUsageCostStaleFiles(params: {
 function countUsableUsageCostCacheFiles(params: {
   cache: UsageCostCacheFile;
   files: UsageCostTranscriptFile[];
-  pricingFingerprint: string;
 }): number {
   const filesByPath = new Map(params.files.map((file) => [file.filePath, file]));
   let cachedFiles = 0;
@@ -463,7 +461,6 @@ function countUsableUsageCostCacheFiles(params: {
       canUseUsageCostCacheEntryForPartial({
         entry,
         file,
-        pricingFingerprint: params.pricingFingerprint,
       })
     ) {
       cachedFiles += 1;
@@ -477,7 +474,6 @@ function buildCostUsageSummaryFromCache(params: {
   files: UsageCostTranscriptFile[];
   startMs: number;
   endMs: number;
-  pricingFingerprint: string;
   refreshing: boolean;
 }): CostUsageSummary {
   const dailyMap = new Map<string, CostUsageTotals>();
@@ -486,12 +482,10 @@ function buildCostUsageSummaryFromCache(params: {
   const staleFiles = getUsageCostStaleFiles({
     cache: params.cache,
     files: params.files,
-    pricingFingerprint: params.pricingFingerprint,
   });
   const cachedFiles = countUsableUsageCostCacheFiles({
     cache: params.cache,
     files: params.files,
-    pricingFingerprint: params.pricingFingerprint,
   });
 
   for (const [filePath, entry] of Object.entries(params.cache.files)) {
@@ -501,7 +495,6 @@ function buildCostUsageSummaryFromCache(params: {
       !canUseUsageCostCacheEntryForPartial({
         entry,
         file,
-        pricingFingerprint: params.pricingFingerprint,
       })
     ) {
       continue;
@@ -1496,13 +1489,10 @@ async function scanUsageFileForCache(params: {
   previous?: UsageCostCacheFileEntry;
   includeSessionSummary?: boolean;
 }): Promise<UsageCostCacheFileEntry> {
-  const pricingFingerprint = resolveUsageCostPricingFingerprint(params.config);
   const appendOnlyPreviousCandidate =
     params.previous &&
-    params.previous.filePath === params.file.filePath &&
     params.previous.size > 0 &&
     params.previous.size < params.file.size &&
-    params.previous.pricingFingerprint === pricingFingerprint &&
     params.previous.mtimeMs <= params.file.mtimeMs
       ? params.previous
       : undefined;
@@ -1584,17 +1574,14 @@ async function scanUsageFileForCache(params: {
     (params.includeSessionSummary || appendOnlyPrevious?.sessionSummary)
       ? (buildSessionCostSummaryFromCacheEntry({
           entry: {
-            filePath: params.file.filePath,
             size: params.file.size,
             mtimeMs: params.file.mtimeMs,
-            pricingFingerprint,
             scannedAt: Date.now(),
             parsedRecords,
             countedRecords,
             usageEntries,
             transcriptEntries: combinedTranscriptEntries,
             totals,
-            sessionId,
           },
           sessionId,
           sessionFile: params.file.filePath,
@@ -1610,7 +1597,6 @@ async function scanUsageFileForCache(params: {
       ...appendOnlyPrevious,
       size: params.file.size,
       mtimeMs: params.file.mtimeMs,
-      pricingFingerprint,
       scannedAt: Date.now(),
       parsedRecords: appendOnlyPrevious.parsedRecords + parsedRecords,
       countedRecords: appendOnlyPrevious.countedRecords + countedRecords,
@@ -1622,17 +1608,14 @@ async function scanUsageFileForCache(params: {
   }
 
   return {
-    filePath: params.file.filePath,
     size: params.file.size,
     mtimeMs: params.file.mtimeMs,
-    pricingFingerprint,
     scannedAt: Date.now(),
     parsedRecords,
     countedRecords,
     usageEntries,
     transcriptEntries: combinedTranscriptEntries,
     totals,
-    sessionId,
     sessionSummary,
   };
 }
@@ -1654,10 +1637,13 @@ async function refreshCostUsageCacheForPath(params?: {
   try {
     await cleanupStaleUsageCostCacheTempFiles(cachePath);
     const pricingFingerprint = resolveUsageCostPricingFingerprint(params?.config);
-    const cache = await readUsageCostCache(cachePath);
+    const cache = await readUsageCostCache(cachePath, pricingFingerprint);
     const files = await listUsageCountedTranscriptFiles(params?.agentId, {
       sessionsDir: params?.sessionsDir,
     });
+    // Empty caches come from missing/corrupt files and version/pricing mismatches.
+    // Persist the empty current-shape cache even when this refresh scans no files.
+    let cacheMutated = cache.updatedAt === 0;
     const sessionSummaryFiles = new Set(params?.sessionFiles ?? []);
     const refreshStartMs = params?.startMs;
     const refreshFiles =
@@ -1667,7 +1653,6 @@ async function refreshCostUsageCacheForPath(params?: {
           ? files
           : files.filter((file) => file.mtimeMs >= refreshStartMs);
     const livePaths = new Set(files.map((file) => file.filePath));
-    let cacheMutated = false;
     for (const filePath of Object.keys(cache.files)) {
       if (!livePaths.has(filePath)) {
         delete cache.files[filePath];
@@ -1682,7 +1667,6 @@ async function refreshCostUsageCacheForPath(params?: {
     const staleFiles = getUsageCostStaleFiles({
       cache,
       files: refreshFiles,
-      pricingFingerprint,
       sessionSummaryFiles,
     })
       .toSorted((a, b) => {
@@ -1754,19 +1738,17 @@ export async function loadCostUsageSummaryFromCache(params: {
   const cachePath = resolveUsageCostCachePath(params.agentId);
   const pricingFingerprint = resolveUsageCostPricingFingerprint(params.config);
   let [cache, files] = await Promise.all([
-    readUsageCostCache(cachePath),
+    readUsageCostCache(cachePath, pricingFingerprint),
     listUsageCountedTranscriptFiles(params.agentId),
   ]);
   const staleFiles = getUsageCostStaleFiles({
     cache,
     files,
-    pricingFingerprint,
   });
   if (params.requestRefresh !== false && staleFiles.length > 0) {
     const cachedFiles = countUsableUsageCostCacheFiles({
       cache,
       files,
-      pricingFingerprint,
     });
     if (params.refreshMode === "sync-when-empty" && cachedFiles === 0) {
       const result = await refreshCostUsageCache({
@@ -1775,14 +1757,13 @@ export async function loadCostUsageSummaryFromCache(params: {
         startMs: params.startMs,
       });
       [cache, files] = await Promise.all([
-        readUsageCostCache(cachePath),
+        readUsageCostCache(cachePath, pricingFingerprint),
         listUsageCountedTranscriptFiles(params.agentId),
       ]);
       if (result === "refreshed") {
         const remainingStaleFiles = getUsageCostStaleFiles({
           cache,
           files,
-          pricingFingerprint,
         });
         if (remainingStaleFiles.length > 0) {
           requestCostUsageCacheRefresh({ config: params.config, agentId: params.agentId });
@@ -1798,7 +1779,6 @@ export async function loadCostUsageSummaryFromCache(params: {
     files,
     startMs: params.startMs,
     endMs: params.endMs,
-    pricingFingerprint,
     refreshing: usageCostRefreshes.has(cachePath) || refreshRunning,
   });
 }
@@ -1817,7 +1797,7 @@ export async function loadSessionCostSummaryFromCache(params: {
   const cachePath = resolveUsageCostCachePath(params.agentId);
   const pricingFingerprint = resolveUsageCostPricingFingerprint(params.config);
   let [cache, stats] = await Promise.all([
-    readUsageCostCache(cachePath),
+    readUsageCostCache(cachePath, pricingFingerprint),
     fs.promises.stat(params.sessionFile).catch(() => null),
   ]);
   let file = stats
@@ -1829,7 +1809,6 @@ export async function loadSessionCostSummaryFromCache(params: {
     !isUsageCostCacheEntryFresh({
       entry,
       file,
-      pricingFingerprint,
       requireSessionSummary: true,
     });
   let refreshRequested = false;
@@ -1842,7 +1821,7 @@ export async function loadSessionCostSummaryFromCache(params: {
       });
       if (result === "refreshed") {
         [cache, stats] = await Promise.all([
-          readUsageCostCache(cachePath),
+          readUsageCostCache(cachePath, pricingFingerprint),
           fs.promises.stat(params.sessionFile).catch(() => null),
         ]);
         file = stats
@@ -1854,7 +1833,6 @@ export async function loadSessionCostSummaryFromCache(params: {
           !isUsageCostCacheEntryFresh({
             entry,
             file,
-            pricingFingerprint,
             requireSessionSummary: true,
           });
       } else {
@@ -1950,7 +1928,7 @@ export async function loadSessionCostSummariesFromCache(params: {
     limit: USAGE_COST_TRANSCRIPT_STAT_CONCURRENCY,
   }).then(({ results }) => results);
   const [cache, stats, refreshRunning] = await Promise.all([
-    readUsageCostCache(cachePath),
+    readUsageCostCache(cachePath, pricingFingerprint),
     statsPromise,
     isUsageCostCacheRefreshRunning(cachePath),
   ]);
@@ -1967,7 +1945,6 @@ export async function loadSessionCostSummariesFromCache(params: {
       !isUsageCostCacheEntryFresh({
         entry,
         file,
-        pricingFingerprint,
         requireSessionSummary: true,
       });
     if (stale) {

--- a/src/plugin-sdk/reply-payload.test.ts
+++ b/src/plugin-sdk/reply-payload.test.ts
@@ -116,6 +116,83 @@ describe("sendPayloadWithChunkedTextAndMedia", () => {
 });
 
 describe("sendTextMediaPayload", () => {
+  it("reports each completed text chunk before a later chunk fails", async () => {
+    const sendText = vi
+      .fn()
+      .mockResolvedValueOnce({ channel: "test", messageId: "ab" })
+      .mockRejectedValueOnce(new Error("second chunk failed"));
+    const onDeliveryResult = vi.fn();
+
+    await expect(
+      sendTextMediaPayload({
+        channel: "test",
+        ctx: {
+          cfg: {},
+          to: "target",
+          text: "",
+          payload: { text: "abcd" },
+          onDeliveryResult,
+        },
+        adapter: {
+          textChunkLimit: 2,
+          chunker: () => ["ab", "cd"],
+          sendText,
+        },
+      }),
+    ).rejects.toThrow("second chunk failed");
+
+    expect(onDeliveryResult).toHaveBeenCalledTimes(1);
+    expect(onDeliveryResult).toHaveBeenCalledWith({ channel: "test", messageId: "ab" });
+  });
+
+  it("does not report callback-aware text sends twice", async () => {
+    const onDeliveryResult = vi.fn();
+    const result = { channel: "test", messageId: "m1" };
+
+    await sendTextMediaPayload({
+      channel: "test",
+      ctx: {
+        cfg: {},
+        to: "target",
+        text: "",
+        payload: { text: "hello" },
+        onDeliveryResult,
+      },
+      adapter: {
+        sendText: async (ctx) => {
+          await ctx.onDeliveryResult?.(result);
+          return result;
+        },
+      },
+    });
+
+    expect(onDeliveryResult).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not report callback-aware media sends twice", async () => {
+    const onDeliveryResult = vi.fn();
+    const result = { channel: "test", messageId: "m1" };
+
+    await sendTextMediaPayload({
+      channel: "test",
+      ctx: {
+        cfg: {},
+        to: "target",
+        text: "",
+        payload: { mediaUrl: "https://example.com/a.png" },
+        onDeliveryResult,
+      },
+      adapter: {
+        sendMedia: async (ctx) => {
+          await ctx.onDeliveryResult?.(result);
+          return result;
+        },
+      },
+    });
+
+    expect(onDeliveryResult).toHaveBeenCalledTimes(1);
+  });
+
   it("uses an implicit single-use reply only for the first text chunk", async () => {
     const sendText = vi.fn(async ({ text }) => ({ channel: "test", messageId: text }));
 

--- a/src/plugin-sdk/reply-payload.ts
+++ b/src/plugin-sdk/reply-payload.ts
@@ -226,6 +226,8 @@ export async function sendPayloadWithChunkedTextAndMedia<
   sendMedia: (ctx: TContext & { text: string; mediaUrl: string }) => Promise<TResult>;
   /** Result returned when payload has neither text nor media. */
   emptyResult: TResult;
+  /** Host callback that persists each completed sub-send before the next one starts. */
+  onResult?: (result: TResult) => Promise<void> | void;
 }): Promise<TResult> {
   const payload = params.ctx.payload as { text?: string; mediaUrls?: string[]; mediaUrl?: string };
   const text = payload.text ?? "";
@@ -241,12 +243,14 @@ export async function sendPayloadWithChunkedTextAndMedia<
       text,
       mediaUrl: urls[0],
     });
+    await params.onResult?.(lastResult);
     for (let i = 1; i < urls.length; i++) {
       lastResult = await params.sendMedia({
         ...params.ctx,
         text: "",
         mediaUrl: urls[i],
       });
+      await params.onResult?.(lastResult);
     }
     return lastResult;
   }
@@ -255,6 +259,7 @@ export async function sendPayloadWithChunkedTextAndMedia<
   let lastResult: TResult;
   for (const chunk of chunks) {
     lastResult = await params.sendText({ ...params.ctx, text: chunk });
+    await params.onResult?.(lastResult);
   }
   return lastResult!;
 }
@@ -275,6 +280,8 @@ export async function sendPayloadMediaSequence<TResult>(params: {
     /** Whether this is the first media entry in the original sequence. */
     isFirst: boolean;
   }) => Promise<TResult>;
+  /** Called after each successful media send and before the next send starts. */
+  onResult?: (result: TResult) => Promise<void> | void;
 }): Promise<TResult | undefined> {
   let lastResult: TResult | undefined;
   for (let i = 0; i < params.mediaUrls.length; i += 1) {
@@ -288,6 +295,7 @@ export async function sendPayloadMediaSequence<TResult>(params: {
       index: i,
       isFirst: i === 0,
     });
+    await params.onResult?.(lastResult);
   }
   return lastResult;
 }
@@ -304,6 +312,7 @@ export async function sendPayloadMediaSequenceOrFallback<TResult>(params: {
     index: number;
     isFirst: boolean;
   }) => Promise<TResult>;
+  onResult?: (result: TResult) => Promise<void> | void;
   /** Result returned when no media result is available. */
   fallbackResult: TResult;
   /** Optional callback used instead of `fallbackResult` when there are no media URLs. */
@@ -327,6 +336,7 @@ export async function sendPayloadMediaSequenceAndFinalize<TMediaResult, TResult>
     index: number;
     isFirst: boolean;
   }) => Promise<TMediaResult>;
+  onResult?: (result: TMediaResult) => Promise<void> | void;
   /** Final callback whose result is returned after optional media sends. */
   finalize: () => Promise<TResult>;
 }): Promise<TResult> {
@@ -358,14 +368,24 @@ export async function sendTextMediaPayload(params: {
     const lastResult = await sendPayloadMediaSequence({
       text,
       mediaUrls: urls,
-      send: async ({ text: textLocal, mediaUrl }) =>
-        await params.adapter.sendMedia!({
+      send: async ({ text: textLocal, mediaUrl }) => {
+        let childReported = false;
+        const result = await params.adapter.sendMedia!({
           ...params.ctx,
           text: textLocal,
           mediaUrl,
           ...(audioAsVoice === undefined ? {} : { audioAsVoice }),
           replyToId: nextReplyToId(),
-        }),
+          onDeliveryResult: async (deliveryResult) => {
+            childReported = true;
+            await params.ctx.onDeliveryResult?.(deliveryResult);
+          },
+        });
+        if (!childReported) {
+          await params.ctx.onDeliveryResult?.(result);
+        }
+        return result;
+      },
     });
     return lastResult ?? { channel: params.channel, messageId: "" };
   }
@@ -376,11 +396,19 @@ export async function sendTextMediaPayload(params: {
       : [text];
   let lastResult: Awaited<ReturnType<NonNullable<typeof params.adapter.sendText>>>;
   for (const chunk of chunks) {
+    let childReported = false;
     lastResult = await params.adapter.sendText!({
       ...params.ctx,
       text: chunk,
       replyToId: nextReplyToId(),
+      onDeliveryResult: async (deliveryResult) => {
+        childReported = true;
+        await params.ctx.onDeliveryResult?.(deliveryResult);
+      },
     });
+    if (!childReported) {
+      await params.ctx.onDeliveryResult?.(lastResult);
+    }
   }
   return lastResult!;
 }

--- a/src/plugins/tool-descriptor-cache.test.ts
+++ b/src/plugins/tool-descriptor-cache.test.ts
@@ -124,6 +124,29 @@ describe("plugin tool descriptor cache keys", () => {
     expect(firstKey).not.toBe(secondKey);
   });
 
+  it("varies descriptor keys by trusted owner state", () => {
+    const base = {
+      pluginId: "demo",
+      source: "/tmp/demo.js",
+      contractToolNames: ["owner_tool"],
+      ctx: {
+        workspaceDir: "/tmp/workspace",
+        agentId: "main",
+      },
+    };
+
+    const ownerKey = buildPluginToolDescriptorCacheKey({
+      ...base,
+      ctx: { ...base.ctx, senderIsOwner: true },
+    });
+    const nonOwnerKey = buildPluginToolDescriptorCacheKey({
+      ...base,
+      ctx: { ...base.ctx, senderIsOwner: false },
+    });
+
+    expect(ownerKey).not.toBe(nonOwnerKey);
+  });
+
   it("keeps descriptor keys stable across config bookkeeping writes", () => {
     const firstConfig = {
       id: "runtime",

--- a/src/plugins/tool-descriptor-cache.ts
+++ b/src/plugins/tool-descriptor-cache.ts
@@ -112,6 +112,7 @@ function buildDescriptorContextCacheKey(params: {
     agentAccountId: ctx.agentAccountId ?? null,
     deliveryContext: ctx.deliveryContext ?? null,
     requesterSenderId: ctx.requesterSenderId ?? null,
+    senderIsOwner: ctx.senderIsOwner ?? null,
     sandboxed: ctx.sandboxed ?? null,
   });
 }

--- a/src/plugins/tool-types.ts
+++ b/src/plugins/tool-types.ts
@@ -46,6 +46,8 @@ export type OpenClawPluginToolContext = {
   deliveryContext?: DeliveryContext;
   /** Trusted sender id from inbound context (runtime-provided, not tool args). */
   requesterSenderId?: string;
+  /** Trusted owner bit from inbound context (runtime-provided, not tool args). */
+  senderIsOwner?: boolean;
   sandboxed?: boolean;
   /**
    * True for explicit one-shot local CLI runs that must release plugin-owned

--- a/test/scripts/ci-workflow-guards.test.ts
+++ b/test/scripts/ci-workflow-guards.test.ts
@@ -7,6 +7,7 @@ import { parse } from "yaml";
 const CHECKOUT_V6 = "actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10";
 const CACHE_V5 = "actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae";
 const UPLOAD_ARTIFACT_V7 = "actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a";
+const DOWNLOAD_ARTIFACT_V8 = "actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c";
 const OPENGREP_PR_DIFF_WORKFLOW = ".github/workflows/opengrep-precise.yml";
 const OPENGREP_FULL_WORKFLOW = ".github/workflows/opengrep-precise-full.yml";
 const CONTROL_UI_LOCALE_REFRESH_WORKFLOW = ".github/workflows/control-ui-locale-refresh.yml";
@@ -124,16 +125,20 @@ describe("ci workflow guards", () => {
     expect(findUnpinnedExternalActions()).toEqual([]);
   });
 
-  it("keeps locale refresh bots from cancelling active refresh matrices", () => {
+  it("keeps locale refresh matrices alive and commits each aggregate once", () => {
     const controlUiWorkflow = parse(readFileSync(CONTROL_UI_LOCALE_REFRESH_WORKFLOW, "utf8"));
-    const source = readFileSync(NATIVE_APP_LOCALE_REFRESH_WORKFLOW, "utf8");
-    const workflow = parse(source);
+    const workflow = parse(readFileSync(NATIVE_APP_LOCALE_REFRESH_WORKFLOW, "utf8"));
     const refresh = workflow.jobs.refresh;
-    const commitStep = refresh.steps.find(
-      (step: { name?: string }) => step.name === "Commit and push locale artifact",
-    );
+    const nativeFinalize = workflow.jobs.finalize;
+    const controlUiFinalize = controlUiWorkflow.jobs.finalize;
     const refreshStep = refresh.steps.find(
       (step: { name?: string }) => step.name === "Refresh native locale artifact",
+    );
+    const nativeArtifactStep = refresh.steps.find(
+      (step: { name?: string }) => step.name === "Prepare locale artifact",
+    );
+    const nativeInventoryStep = nativeFinalize.steps.find(
+      (step: { name?: string }) => step.name === "Refresh shared native inventory",
     );
     const controlUiRefreshStep = controlUiWorkflow.jobs.refresh.steps.find(
       (step: { name?: string }) => step.name === "Refresh control UI locale files",
@@ -156,6 +161,11 @@ describe("ci workflow guards", () => {
       "${{ secrets.OPENCLAW_DOCS_I18N_OPENAI_API_KEY }}",
     );
     expect(refreshStep.env.OPENAI_API_KEY).toBe("${{ secrets.OPENAI_API_KEY }}");
+    expect(nativeArtifactStep.run).toContain("git add -A apps/.i18n/native");
+    expect(nativeArtifactStep.run).not.toContain("native-source.json");
+    expect(nativeInventoryStep.run).toBe(
+      "node --import tsx scripts/native-app-i18n.ts sync --write",
+    );
     expect(controlUiRefreshStep.run).toContain("run_refresh anthropic");
     expect(controlUiRefreshStep.run).toContain("retrying with OpenAI");
     expect(controlUiRefreshStep.run).toContain("run_openai_refresh");
@@ -165,10 +175,38 @@ describe("ci workflow guards", () => {
     );
     expect(controlUiRefreshStep.env.OPENAI_API_KEY).toBe("${{ secrets.OPENAI_API_KEY }}");
     expect(controlUiRefreshStep.env.OPENCLAW_CONTROL_UI_I18N_AUTH_OPTIONAL).toBe("0");
-    expect(commitStep.run).toContain("for attempt in 1 2 3 4 5");
-    expect(commitStep.run).toContain('git fetch origin "${TARGET_BRANCH}"');
-    expect(commitStep.run).toContain('git rebase --autostash "origin/${TARGET_BRANCH}"');
-    expect(commitStep.run).toContain('git push origin HEAD:"${TARGET_BRANCH}"');
+
+    for (const [refreshJob, finalizeJob, artifactPattern, commitMessage] of [
+      [refresh, nativeFinalize, "native-locale-*", "chore(i18n): refresh native locales"],
+      [
+        controlUiWorkflow.jobs.refresh,
+        controlUiFinalize,
+        "control-ui-locale-*",
+        "chore(ui): refresh control ui locales",
+      ],
+    ] as const) {
+      const uploadStep = refreshJob.steps.find(
+        (step: { name?: string }) => step.name === "Upload locale artifact",
+      );
+      const downloadStep = finalizeJob.steps.find(
+        (step: { name?: string }) => step.name === "Download locale artifacts",
+      );
+      const commitStep = finalizeJob.steps.find(
+        (step: { name?: string }) => step.name === "Commit and push aggregate locale refresh",
+      );
+
+      expect(finalizeJob.needs).toBe("refresh");
+      expect(finalizeJob.if).toBe("needs.refresh.result == 'success'");
+      expect(uploadStep.uses).toBe(UPLOAD_ARTIFACT_V7);
+      expect(downloadStep.uses).toBe(DOWNLOAD_ARTIFACT_V8);
+      expect(downloadStep.with.pattern).toBe(artifactPattern);
+      expect(downloadStep.with["merge-multiple"]).toBe(true);
+      expect(commitStep.run).toContain(`git commit --no-verify -m "${commitMessage}"`);
+      expect(commitStep.run).toContain("for attempt in 1 2 3 4 5");
+      expect(commitStep.run).toContain('git fetch origin "${TARGET_BRANCH}"');
+      expect(commitStep.run).toContain('git rebase "origin/${TARGET_BRANCH}"');
+      expect(commitStep.run).toContain('git push origin HEAD:"${TARGET_BRANCH}"');
+    }
   });
 
   it("fails OpenGrep SARIF artifact uploads when reports are missing", () => {

--- a/test/scripts/native-app-i18n.test.ts
+++ b/test/scripts/native-app-i18n.test.ts
@@ -74,6 +74,29 @@ describe("native app i18n inventory", () => {
     expect(entries.some((entry) => entry.source === "Searching…")).toBe(true);
     expect(entries.some((entry) => entry.source === "Run now")).toBe(true);
     expect(entries.some((entry) => entry.source === "Loading chat")).toBe(true);
+    expect(entries.some((entry) => entry.source === "What would you like to work on?")).toBe(true);
+    expect(entries.some((entry) => entry.source === "Check OpenClaw status")).toBe(true);
+    expect(entries.some((entry) => entry.source === "What can I control here?")).toBe(true);
+    expect(entries.some((entry) => entry.source === "Help me start voice chat")).toBe(true);
+    expect(
+      entries.some(
+        (entry) =>
+          entry.source ===
+          "Summarize the current OpenClaw status and tell me what needs attention.",
+      ),
+    ).toBe(true);
+    expect(
+      entries.some(
+        (entry) =>
+          entry.source ===
+          "Show me which phone controls and device capabilities are available right now.",
+      ),
+    ).toBe(true);
+    expect(
+      entries.some(
+        (entry) => entry.source === "Help me start a realtime voice session from this phone.",
+      ),
+    ).toBe(true);
     expect(entries.some((entry) => entry.source === "DIARY")).toBe(true);
     expect(entries.some((entry) => entry.source === "ask OpenClaw $prompt")).toBe(true);
     expect(entries.some((entry) => entry.source === "OpenClaw is paused")).toBe(true);

--- a/ui/src/i18n/.i18n/raw-copy-baseline.json
+++ b/ui/src/i18n/.i18n/raw-copy-baseline.json
@@ -307,6 +307,13 @@
       "kind": "html-text",
       "name": "text",
       "path": "ui/src/ui/chat/session-controls.ts",
+      "text": "Faster"
+    },
+    {
+      "count": 1,
+      "kind": "html-text",
+      "name": "text",
+      "path": "ui/src/ui/chat/session-controls.ts",
       "text": "Model"
     },
     {
@@ -315,6 +322,13 @@
       "name": "text",
       "path": "ui/src/ui/chat/session-controls.ts",
       "text": "Reasoning"
+    },
+    {
+      "count": 1,
+      "kind": "html-text",
+      "name": "text",
+      "path": "ui/src/ui/chat/session-controls.ts",
+      "text": "Smarter"
     },
     {
       "count": 1,

--- a/ui/src/styles/chat/layout.css
+++ b/ui/src/styles/chat/layout.css
@@ -1517,6 +1517,13 @@
     min-width: 0;
   }
 
+  /* The borderless trigger is 30px on desktop; keep a >=40px touch target
+     inside the mobile composer grid. */
+  .agent-chat__composer-controls .chat-controls__inline-select-trigger {
+    height: 40px;
+    min-height: 40px;
+  }
+
   /* Desktop restores the quota pill in the composer flex row (#93041); the mobile composer is a
      fixed 2-col grid (model | settings), so the pill would push the settings chip to a new row. */
   .agent-chat__composer-controls .chat-controls__quota {
@@ -2182,19 +2189,21 @@
   display: none;
 }
 
+/* Composer controls are quiet text controls: no borders/fills at rest so the
+   composer frame stays the only chrome; hover/open get a soft wash. */
 .chat-controls__inline-select-trigger {
   box-sizing: border-box;
   display: flex;
   align-items: center;
   justify-content: space-between;
-  gap: 8px;
+  gap: 6px;
   width: 100%;
-  height: 36px;
-  min-height: 36px;
-  padding: 0 10px 0 12px;
-  border: 1px solid color-mix(in srgb, var(--input) 88%, transparent);
-  border-radius: var(--radius-lg);
-  background: color-mix(in srgb, var(--card) 92%, var(--bg-elevated) 8%);
+  height: 30px;
+  min-height: 30px;
+  padding: 0 6px 0 8px;
+  border: none;
+  border-radius: var(--radius-sm);
+  background: transparent;
   color: var(--text);
   font-size: 13px;
   line-height: 1.35;
@@ -2203,9 +2212,10 @@
   user-select: none;
 }
 
-.chat-controls__inline-select-trigger:hover {
-  border-color: color-mix(in srgb, var(--text) 18%, var(--input));
-  background: color-mix(in srgb, var(--card) 82%, var(--bg-elevated) 18%);
+.chat-controls__inline-select-trigger:hover,
+.chat-controls__inline-select[open] > .chat-controls__inline-select-trigger {
+  background: color-mix(in srgb, var(--text) 7%, transparent);
+  color: var(--text-strong);
 }
 
 .chat-controls__inline-select-trigger:focus-visible {
@@ -2357,6 +2367,175 @@
   transform: translateX(0);
 }
 
+.chat-controls__reasoning-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  min-width: 0;
+}
+
+.chat-controls__reasoning-value {
+  padding-right: 8px;
+  overflow: hidden;
+  color: var(--text-strong);
+  font-size: 12px;
+  font-weight: 600;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+}
+
+/* Discrete effort slider: native range input for keyboard/a11y, decorative
+   stop dots layered underneath (pointer-events: none). Dot inset must track
+   half the thumb width so dots align with the thumb's travel. */
+.chat-controls__reasoning-slider {
+  position: relative;
+  display: flex;
+  align-items: center;
+  height: 26px;
+  margin: 2px 8px 0;
+}
+
+.chat-controls__reasoning-dots {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0 5px;
+  pointer-events: none;
+}
+
+.chat-controls__reasoning-dot {
+  width: 4px;
+  height: 4px;
+  border-radius: var(--radius-full);
+  background: color-mix(in srgb, var(--text) 28%, transparent);
+}
+
+.chat-controls__reasoning-dot--default {
+  background: color-mix(in srgb, var(--text) 55%, transparent);
+}
+
+.chat-controls__reasoning-range {
+  -webkit-appearance: none;
+  appearance: none;
+  position: relative;
+  z-index: 1;
+  width: 100%;
+  height: 26px;
+  margin: 0;
+  padding: 0;
+  background: transparent;
+  cursor: pointer;
+}
+
+.chat-controls__reasoning-range:disabled {
+  cursor: not-allowed;
+  opacity: 0.5;
+}
+
+.chat-controls__reasoning-range:focus-visible {
+  outline: none;
+}
+
+/* --reasoning-fill is set inline (and live-updated on drag) so the filled
+   segment tracks the thumb; pseudo-elements inherit the custom property. */
+.chat-controls__reasoning-range::-webkit-slider-runnable-track {
+  height: 3px;
+  border-radius: var(--radius-full);
+  background: linear-gradient(
+    90deg,
+    color-mix(in srgb, var(--text) 45%, transparent) var(--reasoning-fill, 0%),
+    color-mix(in srgb, var(--text) 14%, transparent) var(--reasoning-fill, 0%)
+  );
+}
+
+.chat-controls__reasoning-range::-webkit-slider-thumb {
+  -webkit-appearance: none;
+  width: 14px;
+  height: 14px;
+  margin-top: -5.5px;
+  border: none;
+  border-radius: var(--radius-full);
+  background: var(--text-strong);
+  box-shadow: 0 1px 4px rgba(0, 0, 0, 0.35);
+}
+
+.chat-controls__reasoning-range:focus-visible::-webkit-slider-thumb {
+  box-shadow: var(--focus-ring);
+}
+
+/* Inherited default (no override): hollow-looking muted thumb. */
+.chat-controls__reasoning-range--inherit::-webkit-slider-thumb {
+  background: var(--muted);
+}
+
+/* Inherited default that is not on the offered scale (e.g. "adaptive"):
+   ghost the parked thumb so its position does not read as the default. */
+.chat-controls__reasoning-range--unanchored::-webkit-slider-thumb {
+  opacity: 0.35;
+}
+
+.chat-controls__reasoning-range::-moz-range-track {
+  height: 3px;
+  border-radius: var(--radius-full);
+  background: color-mix(in srgb, var(--text) 14%, transparent);
+}
+
+.chat-controls__reasoning-range::-moz-range-progress {
+  height: 3px;
+  border-radius: var(--radius-full);
+  background: color-mix(in srgb, var(--text) 45%, transparent);
+}
+
+.chat-controls__reasoning-range::-moz-range-thumb {
+  width: 14px;
+  height: 14px;
+  border: none;
+  border-radius: var(--radius-full);
+  background: var(--text-strong);
+  box-shadow: 0 1px 4px rgba(0, 0, 0, 0.35);
+}
+
+.chat-controls__reasoning-range--inherit::-moz-range-thumb {
+  background: var(--muted);
+}
+
+.chat-controls__reasoning-range--unanchored::-moz-range-thumb {
+  opacity: 0.35;
+}
+
+.chat-controls__reasoning-scale {
+  display: flex;
+  justify-content: space-between;
+  margin: 0 8px;
+  color: var(--muted);
+  font-size: 11px;
+}
+
+.chat-controls__reasoning-reset {
+  margin: 2px 8px 0;
+  padding: 0;
+  border: none;
+  background: none;
+  color: var(--muted);
+  font: inherit;
+  font-size: 11px;
+  text-align: left;
+  cursor: pointer;
+}
+
+.chat-controls__reasoning-reset:hover:not(:disabled) {
+  color: var(--text);
+  text-decoration: underline;
+}
+
+.chat-controls__reasoning-reset:disabled {
+  cursor: not-allowed;
+  opacity: 0.55;
+}
+
 .chat-controls__reasoning-options {
   display: grid;
   grid-template-columns: minmax(0, 1fr);
@@ -2420,12 +2599,12 @@
   justify-content: center;
   gap: 4px;
   box-sizing: border-box;
-  min-width: 104px;
-  height: 36px;
-  padding: 0 10px;
-  border: 1px solid color-mix(in srgb, var(--border) 80%, transparent);
-  border-radius: var(--radius-lg);
-  background: color-mix(in srgb, var(--card) 86%, var(--bg-elevated) 14%);
+  min-width: 0;
+  height: 30px;
+  padding: 0 8px;
+  border: none;
+  border-radius: var(--radius-sm);
+  background: transparent;
   color: var(--fg);
   font-size: 12px;
   font-weight: 650;
@@ -2435,8 +2614,7 @@
 }
 
 .chat-controls__quota:hover {
-  border-color: color-mix(in srgb, var(--accent) 44%, var(--border));
-  background: color-mix(in srgb, var(--accent-subtle) 28%, var(--card));
+  background: color-mix(in srgb, var(--text) 7%, transparent);
 }
 
 .chat-controls__quota-label {

--- a/ui/src/styles/layout.css
+++ b/ui/src/styles/layout.css
@@ -1180,56 +1180,34 @@
   min-height: 42px;
 }
 
-.sidebar-version {
+/* Borderless status line: the sidebar footer signals connectivity only;
+   the gateway version moved into Settings (Quick Settings footer). */
+.sidebar-status {
   display: flex;
   align-items: center;
-  justify-content: space-between;
-  gap: 10px;
-  min-height: 40px;
+  gap: 8px;
+  min-height: 28px;
   padding: 0 12px;
-  border-radius: var(--radius-lg);
-  background: color-mix(in srgb, var(--bg-elevated) 72%, transparent);
-  border: 1px solid color-mix(in srgb, var(--border) 72%, transparent);
 }
 
-.sidebar-version__label {
-  font-size: 12px; /* was 11px */
-  font-weight: 600;
-  color: var(--muted);
-  text-transform: uppercase;
-  letter-spacing: 0.06em;
-}
-
-.sidebar-version__text {
+.sidebar-status__text {
   font-size: 12px;
-  color: var(--text);
-  font-weight: 600;
+  color: var(--muted);
 }
 
-.sidebar-version__dot {
-  width: 8px;
-  height: 8px;
-  border-radius: var(--radius-full);
-  background: color-mix(in srgb, var(--accent) 78%, white 22%);
-  box-shadow: 0 0 0 4px color-mix(in srgb, var(--accent) 14%, transparent);
-  opacity: 1;
-  margin: 0 auto;
-}
-
-.sidebar-version__status {
+.sidebar-status__dot {
   width: 8px;
   height: 8px;
   border-radius: var(--radius-full);
   flex-shrink: 0;
-  margin-left: auto;
 }
 
-.sidebar-version__status.sidebar-connection-status--online {
+.sidebar-status__dot.sidebar-connection-status--online {
   background: var(--ok);
   box-shadow: 0 0 0 4px color-mix(in srgb, var(--ok) 14%, transparent);
 }
 
-.sidebar-version__status.sidebar-connection-status--offline {
+.sidebar-status__dot.sidebar-connection-status--offline {
   background: var(--danger);
   box-shadow: 0 0 0 4px color-mix(in srgb, var(--danger) 14%, transparent);
 }
@@ -1243,16 +1221,11 @@
   gap: 6px;
 }
 
-.sidebar--collapsed .sidebar-version {
+.sidebar--collapsed .sidebar-status {
   width: 44px;
-  min-height: 44px;
+  min-height: 36px;
   padding: 0;
   justify-content: center;
-  border-radius: var(--radius-lg);
-}
-
-.sidebar--collapsed .sidebar-version__status {
-  margin-left: 0;
 }
 
 /* Mode switch in sidebar — hidden on desktop, shown on mobile */

--- a/ui/src/styles/layout.mobile.css
+++ b/ui/src/styles/layout.mobile.css
@@ -279,9 +279,9 @@
     padding: 12px 8px 0;
   }
 
-  .sidebar--collapsed .sidebar-version {
+  .sidebar--collapsed .sidebar-status {
     width: auto;
-    min-height: 40px;
+    min-height: 32px;
     padding: 0 12px;
   }
 
@@ -289,9 +289,9 @@
     padding: 8px 0 2px;
   }
 
-  .shell--nav-collapsed:not(.shell--nav-drawer-open) .sidebar--collapsed .sidebar-version {
+  .shell--nav-collapsed:not(.shell--nav-drawer-open) .sidebar--collapsed .sidebar-status {
     width: 44px;
-    min-height: 44px;
+    min-height: 36px;
     padding: 0;
     justify-content: center;
   }

--- a/ui/src/ui/app-lifecycle-connect.node.test.ts
+++ b/ui/src/ui/app-lifecycle-connect.node.test.ts
@@ -2,12 +2,20 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { ChatQueueItem } from "./ui-types.ts";
 
-const { applySettingsFromUrlMock, connectGatewayMock, loadBootstrapMock, restoreComposerMock } =
-  vi.hoisted(() => ({
+const {
+  applySettingsFromUrlMock,
+  connectGatewayMock,
+  loadBootstrapMock,
+  restoreComposerMock,
+  scheduleChatScrollMock,
+  startNodesPollingMock,
+} = vi.hoisted(() => ({
     applySettingsFromUrlMock: vi.fn(),
     connectGatewayMock: vi.fn(),
     loadBootstrapMock: vi.fn(),
     restoreComposerMock: vi.fn<(...args: unknown[]) => boolean>(() => false),
+    scheduleChatScrollMock: vi.fn(),
+    startNodesPollingMock: vi.fn(),
   }));
 
 vi.mock("./app-gateway.ts", () => ({
@@ -34,7 +42,7 @@ vi.mock("./app-settings.ts", () => ({
 
 vi.mock("./app-polling.ts", () => ({
   startLogsPolling: vi.fn(),
-  startNodesPolling: vi.fn(),
+  startNodesPolling: startNodesPollingMock,
   stopLogsPolling: vi.fn(),
   stopNodesPolling: vi.fn(),
   startDebugPolling: vi.fn(),
@@ -43,16 +51,12 @@ vi.mock("./app-polling.ts", () => ({
 
 vi.mock("./app-scroll.ts", () => ({
   observeTopbar: vi.fn(),
-  scheduleChatScroll: vi.fn(),
+  scheduleChatScroll: scheduleChatScrollMock,
   scheduleLogsScroll: vi.fn(),
 }));
 
-import { handleConnected, handleUpdated } from "./app-lifecycle.ts";
-import { startNodesPolling } from "./app-polling.ts";
-import { scheduleChatScroll } from "./app-scroll.ts";
-
-const startNodesPollingMock = vi.mocked(startNodesPolling);
-const scheduleChatScrollMock = vi.mocked(scheduleChatScroll);
+let handleConnected: typeof import("./app-lifecycle.ts").handleConnected;
+let handleUpdated: typeof import("./app-lifecycle.ts").handleUpdated;
 
 function createDeferred() {
   let resolve: (() => void) | undefined;
@@ -100,7 +104,8 @@ function createHost() {
 }
 
 describe("handleConnected", () => {
-  beforeEach(() => {
+  beforeEach(async () => {
+    vi.resetModules();
     applySettingsFromUrlMock.mockReset();
     connectGatewayMock.mockReset();
     loadBootstrapMock.mockReset();
@@ -111,6 +116,7 @@ describe("handleConnected", () => {
     vi.stubGlobal("window", {
       addEventListener: vi.fn(),
     });
+    ({ handleConnected, handleUpdated } = await import("./app-lifecycle.ts"));
   });
 
   it("starts the first gateway connect without waiting for bootstrap", async () => {

--- a/ui/src/ui/app-render.helpers.ts
+++ b/ui/src/ui/app-render.helpers.ts
@@ -920,6 +920,11 @@ export function renderTopbarThemeModeToggle(state: AppViewState) {
   `;
 }
 
+/**
+ * Sidebar footer status dot. The footer intentionally shows only live
+ * connection state; the gateway version lives in Settings (Quick Settings
+ * footer) instead of persistent chrome.
+ */
 export function renderSidebarConnectionStatus(state: AppViewState) {
   const label = state.connected ? t("common.online") : t("common.offline");
   const toneClass = state.connected
@@ -928,7 +933,7 @@ export function renderSidebarConnectionStatus(state: AppViewState) {
 
   return html`
     <span
-      class="sidebar-version__status ${toneClass}"
+      class="sidebar-status__dot ${toneClass}"
       role="img"
       aria-live="polite"
       aria-label=${t("chat.gatewayStatus", { status: label })}

--- a/ui/src/ui/app-render.ts
+++ b/ui/src/ui/app-render.ts
@@ -2732,22 +2732,14 @@ export function renderApp(state: AppViewState) {
                     : nothing}
                 </a>
                 <div class="sidebar-mode-switch">${renderTopbarThemeModeToggle(state)}</div>
-                ${(() => {
-                  const version = state.hello?.server?.version ?? "";
-                  return version
-                    ? html`
-                        <div class="sidebar-version" title=${`v${version}`}>
-                          ${!navCollapsed
-                            ? html`
-                                <span class="sidebar-version__label">${t("common.version")}</span>
-                                <span class="sidebar-version__text">v${version}</span>
-                                ${renderSidebarConnectionStatus(state)}
-                              `
-                            : html` ${renderSidebarConnectionStatus(state)} `}
-                        </div>
-                      `
-                    : nothing;
-                })()}
+                <div class="sidebar-status">
+                  ${renderSidebarConnectionStatus(state)}
+                  ${navCollapsed
+                    ? nothing
+                    : html`<span class="sidebar-status__text"
+                        >${state.connected ? t("common.online") : t("common.offline")}</span
+                      >`}
+                </div>
               </div>
             </div>
           </div>

--- a/ui/src/ui/chat/grouped-render.test.ts
+++ b/ui/src/ui/chat/grouped-render.test.ts
@@ -31,12 +31,15 @@ vi.mock("../../local-storage.ts", () => ({
   }),
 }));
 
-vi.mock("../markdown.ts", () => ({
-  isMarkdownBlockArtText: () => false,
-  toSanitizedMarkdownHtml: markdownRenderMock,
-  toStreamingMarkdownHtml: streamingMarkdownRenderMock,
-  toStreamingPlainTextHtml: streamingTextRenderMock,
-}));
+vi.mock("../markdown.ts", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../markdown.ts")>();
+  return {
+    ...actual,
+    toSanitizedMarkdownHtml: markdownRenderMock,
+    toStreamingMarkdownHtml: streamingMarkdownRenderMock,
+    toStreamingPlainTextHtml: streamingTextRenderMock,
+  };
+});
 
 vi.mock("../icons.ts", () => ({
   icons: {},
@@ -112,11 +115,18 @@ vi.mock("../tool-display.ts", () => ({
   formatToolDetail: () => undefined,
   resolveToolDisplay: ({ name, args }: { name: string; args?: unknown }) => ({
     name,
-    label: name,
+    label:
+      {
+        sessions_spawn: "Sub-agent",
+        skill_workshop: "Skill Workshop",
+        web_search: "Web Search",
+      }[name] ?? name,
     icon: "zap",
     detail:
       args && typeof args === "object" && "detail" in args
         ? String((args as { detail: unknown }).detail)
+        : args && typeof args === "object" && name === "skill_workshop" && "action" in args
+          ? String((args as { action: unknown }).action)
         : undefined,
   }),
 }));
@@ -1228,7 +1238,7 @@ describe("grouped chat rendering", () => {
     expectElement(container, ".chat-bubble--tool-shell", HTMLElement);
     const summary = container.querySelector<HTMLElement>(".chat-tool-msg-summary");
     expect(summary?.querySelector(".chat-tool-msg-summary__label")?.textContent).toBe(
-      "sessions_spawn",
+      "Sub-agent",
     );
     expect(container.querySelector(".chat-tool-msg-body")).toBeNull();
 
@@ -1433,7 +1443,7 @@ describe("grouped chat rendering", () => {
     expect(summary.classList.contains("chat-tool-msg-summary--error")).toBe(true);
     expect(summary.querySelector(".chat-tool-msg-summary__label")?.textContent).toBe("Tool error");
     expect(summary.querySelector(".chat-tool-msg-summary__names")?.textContent).toBe(
-      "sessions_spawn",
+      "Sub-agent",
     );
     expect(summary.querySelector(".chat-tool-msg-summary__error-badge")).not.toBeNull();
 

--- a/ui/src/ui/chat/session-controls.ts
+++ b/ui/src/ui/chat/session-controls.ts
@@ -941,6 +941,7 @@ export function renderChatModelSelect(state: AppViewState) {
     selectedThinkingLabel,
     selectedThinkingValue: thinking.currentOverride,
     fastMode,
+    thinkingDefaultValue: thinking.defaultValue,
     thinkingDisabled,
     thinkingOptions: [{ value: "", label: thinking.defaultLabel }, ...thinking.options],
     onModelSelect: (next) => switchChatModel(state, next),
@@ -957,6 +958,8 @@ type ChatThinkingSelectOption = {
 type ChatThinkingSelectState = {
   currentOverride: string;
   defaultLabel: string;
+  /** Normalized default level id so the slider can mark the inherited stop. */
+  defaultValue: string;
   options: ChatThinkingSelectOption[];
 };
 
@@ -1142,6 +1145,7 @@ export function resolveChatThinkingSelectState(state: AppViewState): ChatThinkin
   return {
     currentOverride: effectiveOverride,
     defaultLabel: formatInheritedThinkingLabel(defaultLevel),
+    defaultValue: normalizeThinkingOptionValue(defaultLevel),
     options: buildThinkingOptions(levels, effectiveOverride),
   };
 }
@@ -1164,10 +1168,6 @@ function formatCombinedPickerThinkingLabel(label: string): string {
   return label.replace(/^Inherited:\s*/u, "");
 }
 
-function formatCombinedPickerThinkingOptionLabel(option: ChatInlineSelectOption): string {
-  return option.value === "" ? "Default" : formatCombinedPickerThinkingLabel(option.label);
-}
-
 function renderChatModelReasoningSelect(params: {
   fastMode: ChatFastModeSelectState;
   disabled: boolean;
@@ -1176,6 +1176,7 @@ function renderChatModelReasoningSelect(params: {
   selectedModelValue: string;
   selectedThinkingLabel: string;
   selectedThinkingValue: string;
+  thinkingDefaultValue: string;
   thinkingDisabled: boolean;
   thinkingOptions: ChatInlineSelectOption[];
   onFastModeSelect: (value: "" | "on" | "off" | "auto") => Promise<unknown>;
@@ -1190,6 +1191,7 @@ function renderChatModelReasoningSelect(params: {
     selectedModelValue,
     selectedThinkingLabel,
     selectedThinkingValue,
+    thinkingDefaultValue,
     thinkingDisabled,
     thinkingOptions,
     onFastModeSelect,
@@ -1198,7 +1200,53 @@ function renderChatModelReasoningSelect(params: {
   } = params;
   const triggerModel = formatCombinedPickerModelLabel(selectedModelLabel);
   const triggerThinking = formatCombinedPickerThinkingLabel(selectedThinkingLabel);
-  const triggerLabel = `${triggerModel} · ${triggerThinking}`;
+  const triggerTitle = `${triggerModel} · ${triggerThinking}`;
+  // The visible trigger stays minimal: the inherited default level is noise,
+  // so reasoning only appears when overridden. Title/aria keep the full pair.
+  const triggerLabel =
+    selectedThinkingValue === "" ? triggerModel : `${triggerModel} · ${triggerThinking}`;
+  // Reasoning renders as a discrete slider over the ordered level list the
+  // gateway offers (faster -> smarter). "" (inherit default) is not a stop:
+  // the thumb parks on the default level until the user sets an override.
+  const sliderStops = thinkingOptions.filter((option) => option.value !== "");
+  const defaultStopIndex = sliderStops.findIndex((option) => option.value === thinkingDefaultValue);
+  const hasThinkingOverride = selectedThinkingValue !== "";
+  const overrideStopIndex = sliderStops.findIndex(
+    (option) => option.value === selectedThinkingValue,
+  );
+  const sliderIndex = Math.max(hasThinkingOverride ? overrideStopIndex : defaultStopIndex, 0);
+  // Inherited defaults like "adaptive" may not exist on the offered scale.
+  // The value label stays truthful ("Default (Adaptive)"); the thumb gets an
+  // unanchored style so its parked position does not read as the default.
+  const sliderUnanchored = !hasThinkingOverride && defaultStopIndex < 0;
+  const sliderFillPercent = (index: number) =>
+    sliderStops.length > 1 ? (index / (sliderStops.length - 1)) * 100 : 0;
+  const reasoningValueLabel = hasThinkingOverride
+    ? triggerThinking
+    : `Default (${triggerThinking})`;
+  const defaultLevelLabel = formatThinkingOverrideLabel(thinkingDefaultValue);
+  // Keep the filled track segment glued to the thumb while dragging; the
+  // sessions.patch commit happens on release (change), not per input tick.
+  const onSliderDrag = (event: Event) => {
+    const input = event.currentTarget as HTMLInputElement;
+    input.style.setProperty("--reasoning-fill", `${sliderFillPercent(Number(input.value))}%`);
+  };
+  const onSliderCommit = async (event: Event) => {
+    if (thinkingDisabled) {
+      return;
+    }
+    const input = event.currentTarget as HTMLInputElement;
+    const stop = sliderStops[Number(input.value)];
+    if (!stop || stop.value === selectedThinkingValue) {
+      return;
+    }
+    await onThinkingSelect(stop.value);
+  };
+  const showReasoning = sliderStops.length > 0;
+  // A one-entry scale is not a slider, but the lone level must stay
+  // selectable from the inherited default (regression guard vs the old list).
+  const onlyStop = sliderStops.length === 1 ? sliderStops[0] : undefined;
+  const showReasoningPanel = showReasoning || fastMode.supported;
   return html`
     <details class="chat-controls__session chat-controls__inline-select chat-controls__model">
       <summary
@@ -1210,9 +1258,9 @@ function renderChatModelReasoningSelect(params: {
         data-chat-select-value=${selectedModelValue}
         data-chat-thinking-value=${selectedThinkingValue}
         data-chat-thinking-disabled=${thinkingDisabled ? "true" : "false"}
-        aria-label=${`${t("chat.selectors.model")}, ${t("chat.selectors.thinkingLevel")}: ${triggerLabel}`}
+        aria-label=${`${t("chat.selectors.model")}, ${t("chat.selectors.thinkingLevel")}: ${triggerTitle}`}
         aria-disabled=${disabled ? "true" : "false"}
-        title=${triggerLabel}
+        title=${triggerTitle}
         @click=${(event: MouseEvent) => {
           if (disabled) {
             event.preventDefault();
@@ -1272,100 +1320,162 @@ function renderChatModelReasoningSelect(params: {
             },
           )}
         </div>
-        <div
-          class="chat-controls__reasoning-panel"
-          role="listbox"
-          aria-label=${t("chat.selectors.thinkingLevel")}
-        >
-          <div class="chat-controls__inline-select-section-label">Reasoning</div>
-          <div class="chat-controls__reasoning-options">
-            ${repeat(
-              thinkingOptions,
-              (thinking) => thinking.value,
-              (thinking) => {
-                const thinkingSelected = thinking.value === selectedThinkingValue;
-                return html`
-                  <button
-                    class="chat-controls__reasoning-option ${thinkingSelected
-                      ? "chat-controls__reasoning-option--selected"
-                      : ""}"
-                    data-chat-thinking-option=${thinking.value}
-                    role="option"
-                    aria-selected=${thinkingSelected ? "true" : "false"}
-                    type="button"
-                    ?disabled=${thinkingDisabled}
-                    @click=${async (event: MouseEvent) => {
-                      event.stopPropagation();
-                      if (thinkingDisabled) {
-                        event.preventDefault();
-                        return;
-                      }
-                      (event.currentTarget as HTMLElement)
-                        .closest("details")
-                        ?.removeAttribute("open");
-                      await onThinkingSelect(thinking.value);
-                    }}
-                  >
-                    <span>${formatCombinedPickerThinkingOptionLabel(thinking)}</span>
-                    ${thinkingSelected
-                      ? html`<span class="chat-controls__inline-select-check" aria-hidden="true">
-                          ${icons.check}
-                        </span>`
-                      : ""}
-                  </button>
-                `;
-              },
-            )}
-          </div>
-          ${fastMode.supported
-            ? html`
-                <div class="chat-controls__inline-select-section-label">Speed</div>
-                <div class="chat-controls__reasoning-options" role="listbox">
-                  ${repeat(
-                    fastMode.options,
-                    (speed) => speed.value,
-                    (speed) => {
-                      const speedValue = speed.value as "" | "on" | "off" | "auto";
-                      const speedSelected = speedValue === fastMode.currentOverride;
-                      return html`
-                        <button
-                          class="chat-controls__reasoning-option ${speedSelected
-                            ? "chat-controls__reasoning-option--selected"
-                            : ""}"
-                          data-chat-speed-option=${speed.value}
-                          role="option"
-                          aria-selected=${speedSelected ? "true" : "false"}
-                          type="button"
-                          ?disabled=${fastMode.disabled}
-                          @click=${async (event: MouseEvent) => {
-                            event.stopPropagation();
-                            if (fastMode.disabled) {
-                              event.preventDefault();
-                              return;
-                            }
-                            (event.currentTarget as HTMLElement)
-                              .closest("details")
-                              ?.removeAttribute("open");
-                            await onFastModeSelect(speedValue);
-                          }}
-                        >
-                          <span>${speed.label}</span>
-                          ${speedSelected
-                            ? html`<span
-                                class="chat-controls__inline-select-check"
-                                aria-hidden="true"
+        ${showReasoningPanel
+          ? html`
+              <div class="chat-controls__reasoning-panel">
+                ${showReasoning
+                  ? html`
+                      <div class="chat-controls__reasoning-head">
+                        <span class="chat-controls__inline-select-section-label">Reasoning</span>
+                        <span class="chat-controls__reasoning-value">${reasoningValueLabel}</span>
+                      </div>
+                      ${sliderStops.length > 1
+                        ? html`
+                            <div class="chat-controls__reasoning-slider">
+                              <div class="chat-controls__reasoning-dots" aria-hidden="true">
+                                ${sliderStops.map(
+                                  (stop, index) =>
+                                    html`<span
+                                      class="chat-controls__reasoning-dot ${index ===
+                                      defaultStopIndex
+                                        ? "chat-controls__reasoning-dot--default"
+                                        : ""}"
+                                      data-stop=${stop.value}
+                                    ></span>`,
+                                )}
+                              </div>
+                              <input
+                                class="chat-controls__reasoning-range ${hasThinkingOverride
+                                  ? ""
+                                  : "chat-controls__reasoning-range--inherit"} ${sliderUnanchored
+                                  ? "chat-controls__reasoning-range--unanchored"
+                                  : ""}"
+                                type="range"
+                                min="0"
+                                max=${sliderStops.length - 1}
+                                step="1"
+                                .value=${String(sliderIndex)}
+                                style=${`--reasoning-fill: ${sliderFillPercent(sliderIndex)}%`}
+                                data-chat-thinking-slider="true"
+                                data-chat-thinking-values=${sliderStops
+                                  .map((stop) => stop.value)
+                                  .join(",")}
+                                aria-label=${t("chat.selectors.thinkingLevel")}
+                                aria-valuetext=${reasoningValueLabel}
+                                ?disabled=${thinkingDisabled}
+                                @input=${onSliderDrag}
+                                @change=${onSliderCommit}
+                              />
+                            </div>
+                            <div class="chat-controls__reasoning-scale" aria-hidden="true">
+                              <span>Faster</span>
+                              <span>Smarter</span>
+                            </div>
+                          `
+                        : onlyStop
+                          ? html`
+                              <button
+                                class="chat-controls__reasoning-option ${hasThinkingOverride
+                                  ? "chat-controls__reasoning-option--selected"
+                                  : ""}"
+                                data-chat-thinking-option=${onlyStop.value}
+                                type="button"
+                                aria-pressed=${hasThinkingOverride ? "true" : "false"}
+                                ?disabled=${thinkingDisabled}
+                                @click=${async (event: MouseEvent) => {
+                                  event.stopPropagation();
+                                  if (thinkingDisabled || hasThinkingOverride) {
+                                    event.preventDefault();
+                                    return;
+                                  }
+                                  await onThinkingSelect(onlyStop.value);
+                                }}
                               >
-                                ${icons.check}
-                              </span>`
-                            : ""}
-                        </button>
-                      `;
-                    },
-                  )}
-                </div>
-              `
-            : ""}
-        </div>
+                                <span>${onlyStop.label}</span>
+                                ${hasThinkingOverride
+                                  ? html`<span
+                                      class="chat-controls__inline-select-check"
+                                      aria-hidden="true"
+                                    >
+                                      ${icons.check}
+                                    </span>`
+                                  : ""}
+                              </button>
+                            `
+                          : ""}
+                      ${hasThinkingOverride
+                        ? html`
+                            <button
+                              class="chat-controls__reasoning-reset"
+                              data-chat-thinking-option=""
+                              type="button"
+                              ?disabled=${thinkingDisabled}
+                              @click=${async (event: MouseEvent) => {
+                                event.stopPropagation();
+                                if (thinkingDisabled) {
+                                  event.preventDefault();
+                                  return;
+                                }
+                                await onThinkingSelect("");
+                              }}
+                            >
+                              Use default (${defaultLevelLabel})
+                            </button>
+                          `
+                        : ""}
+                    `
+                  : ""}
+                ${fastMode.supported
+                  ? html`
+                      <div class="chat-controls__inline-select-section-label">Speed</div>
+                      <div class="chat-controls__reasoning-options" role="listbox">
+                        ${repeat(
+                          fastMode.options,
+                          (speed) => speed.value,
+                          (speed) => {
+                            const speedValue = speed.value as "" | "on" | "off" | "auto";
+                            const speedSelected = speedValue === fastMode.currentOverride;
+                            return html`
+                              <button
+                                class="chat-controls__reasoning-option ${speedSelected
+                                  ? "chat-controls__reasoning-option--selected"
+                                  : ""}"
+                                data-chat-speed-option=${speed.value}
+                                role="option"
+                                aria-selected=${speedSelected ? "true" : "false"}
+                                type="button"
+                                ?disabled=${fastMode.disabled}
+                                @click=${async (event: MouseEvent) => {
+                                  event.stopPropagation();
+                                  if (fastMode.disabled) {
+                                    event.preventDefault();
+                                    return;
+                                  }
+                                  (event.currentTarget as HTMLElement)
+                                    .closest("details")
+                                    ?.removeAttribute("open");
+                                  await onFastModeSelect(speedValue);
+                                }}
+                              >
+                                <span>${speed.label}</span>
+                                ${speedSelected
+                                  ? html`<span
+                                      class="chat-controls__inline-select-check"
+                                      aria-hidden="true"
+                                    >
+                                      ${icons.check}
+                                    </span>`
+                                  : ""}
+                              </button>
+                            `;
+                          },
+                        )}
+                      </div>
+                    `
+                  : ""}
+              </div>
+            `
+          : ""}
       </div>
     </details>
   `;

--- a/ui/src/ui/chat/tool-cards.node.test.ts
+++ b/ui/src/ui/chat/tool-cards.node.test.ts
@@ -11,10 +11,16 @@ vi.mock("../tool-display.ts", () => ({
   formatToolDetail: () => undefined,
   resolveToolDisplay: ({ name }: { name: string }) => ({
     name,
-    label: name
-      .split(/[._-]/g)
-      .map((part) => (part ? part[0].toUpperCase() + part.slice(1) : part))
-      .join(" "),
+    label:
+      {
+        sessions_spawn: "Sub-agent",
+        skill_workshop: "Skill Workshop",
+        web_search: "Web Search",
+      }[name] ??
+      name
+        .split(/[._-]/g)
+        .map((part) => (part ? part[0].toUpperCase() + part.slice(1) : part))
+        .join(" "),
     icon: "zap",
   }),
 }));

--- a/ui/src/ui/chat/tool-cards.test.ts
+++ b/ui/src/ui/chat/tool-cards.test.ts
@@ -2,6 +2,38 @@
 
 import { render } from "lit";
 import { describe, expect, it, vi } from "vitest";
+
+vi.mock("../markdown.ts", async (importOriginal) => await importOriginal());
+vi.mock("../tool-display.ts", () => ({
+  formatToolDetail: (display: { detail?: string }) => display.detail,
+  resolveToolDisplay: ({
+    name,
+    args,
+  }: {
+    name: string;
+    args?: unknown;
+  }) => {
+    const labels: Record<string, string> = {
+      sessions_spawn: "Sub-agent",
+      skill_workshop: "Skill Workshop",
+      web_search: "Web Search",
+    };
+    const detail =
+      name === "skill_workshop" &&
+      args &&
+      typeof args === "object" &&
+      typeof (args as { action?: unknown }).action === "string"
+        ? (args as { action: string }).action
+        : undefined;
+    return {
+      name,
+      label: labels[name] ?? name,
+      icon: "zap",
+      detail,
+    };
+  },
+}));
+
 import {
   formatCollapsedToolPreviewText,
   formatCollapsedToolSummaryText,

--- a/ui/src/ui/navigation.browser.test.ts
+++ b/ui/src/ui/navigation.browser.test.ts
@@ -369,14 +369,18 @@ describe("control UI routing", () => {
     app.requestUpdate();
     await app.updateComplete;
 
-    expectElement(app, ".sidebar-version", HTMLElement);
-    const statusDot = expectElement(app, ".sidebar-version__status", HTMLElement);
+    const status = expectElement(app, ".sidebar-status", HTMLElement);
+    const statusDot = expectElement(app, ".sidebar-status__dot", HTMLElement);
     expect(statusDot.getAttribute("aria-label")).toBe("Gateway status: Online");
     expect(statusDot.getAttribute("title")).toBe("Gateway status: Online");
     expect([...statusDot.classList]).toEqual([
-      "sidebar-version__status",
+      "sidebar-status__dot",
       "sidebar-connection-status--online",
     ]);
+    // The gateway version intentionally stays out of the persistent sidebar;
+    // it lives in Settings (Quick Settings footer).
+    expect(status.textContent).not.toContain("1.2.3");
+    expect(app.querySelector(".sidebar-version")).toBeNull();
 
     app.applySettings({ ...app.settings, navWidth: 360 });
     await app.updateComplete;

--- a/ui/src/ui/views/chat.test.ts
+++ b/ui/src/ui/views/chat.test.ts
@@ -174,10 +174,13 @@ vi.mock("../chat/grouped-render.ts", () => ({
   },
 }));
 
-vi.mock("../markdown.ts", () => ({
-  isMarkdownBlockArtText: () => false,
-  toSanitizedMarkdownHtml: (value: string) => value,
-}));
+vi.mock("../markdown.ts", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../markdown.ts")>();
+  return {
+    ...actual,
+    toSanitizedMarkdownHtml: (value: string) => value,
+  };
+});
 
 vi.mock("../chat/tool-expansion-state.ts", () => ({
   getExpandedToolCards: () => new Map<string, boolean>(),
@@ -482,8 +485,34 @@ function getThinkingSelect(container: Element): HTMLElement {
   return select;
 }
 
-function getThinkingOptions(container: Element): HTMLButtonElement[] {
-  return Array.from(container.querySelectorAll<HTMLButtonElement>("[data-chat-thinking-option]"));
+function getThinkingSlider(container: Element): HTMLInputElement | null {
+  return container.querySelector<HTMLInputElement>('[data-chat-thinking-slider="true"]');
+}
+
+function getThinkingSliderValues(container: Element): string[] {
+  const values = getThinkingSlider(container)?.dataset.chatThinkingValues ?? "";
+  return values ? values.split(",") : [];
+}
+
+function setThinkingSliderLevel(container: Element, value: string) {
+  const slider = getThinkingSlider(container);
+  expect(slider).toBeInstanceOf(HTMLInputElement);
+  if (!slider) {
+    return;
+  }
+  const index = getThinkingSliderValues(container).indexOf(value);
+  expect(index).toBeGreaterThanOrEqual(0);
+  slider.value = String(index);
+  slider.dispatchEvent(new Event("change", { bubbles: true }));
+}
+
+function getThinkingReasoningValueLabel(container: Element): string {
+  return container.querySelector(".chat-controls__reasoning-value")?.textContent?.trim() ?? "";
+}
+
+/** The "" (use default) reset button; the only remaining [data-chat-thinking-option]. */
+function getThinkingResetButton(container: Element): HTMLButtonElement | null {
+  return container.querySelector<HTMLButtonElement>('[data-chat-thinking-option=""]');
 }
 
 function requireElement(container: Element, selector: string, label: string): Element {
@@ -4147,11 +4176,8 @@ describe("chat session controls", () => {
     const container = document.createElement("div");
     render(renderChatSessionSelect(state), container);
 
-    const adaptive = getThinkingOptions(container).find(
-      (option) => option.dataset.chatThinkingOption === "adaptive",
-    );
-    expect(adaptive).toBeInstanceOf(HTMLButtonElement);
-    adaptive?.click();
+    expect(getThinkingSliderValues(container)).toEqual(["off", "adaptive"]);
+    setThinkingSliderLevel(container, "adaptive");
 
     expect(request).toHaveBeenCalledWith("sessions.patch", {
       key: "global",
@@ -4299,22 +4325,9 @@ describe("chat session controls", () => {
     const container = document.createElement("div");
     render(renderChatSessionSelect(state), container);
 
-    const thinkingOptions = getThinkingOptions(container);
-
-    expect(thinkingOptions.map((option) => option.dataset.chatThinkingOption)).toEqual([
-      "",
-      "off",
-      "adaptive",
-      "xhigh",
-      "max",
-    ]);
-    expect(thinkingOptions.map((option) => option.textContent?.trim())).toEqual([
-      "Default",
-      "Off",
-      "Adaptive",
-      "Extra high",
-      "Maximum",
-    ]);
+    expect(getThinkingSliderValues(container)).toEqual(["off", "adaptive", "xhigh", "max"]);
+    // No override -> inherit state: no reset affordance.
+    expect(getThinkingResetButton(container)).toBeNull();
   });
 
   it("labels chat thinking default from the active session row", () => {
@@ -4327,11 +4340,61 @@ describe("chat session controls", () => {
     render(renderChatSessionSelect(state), container);
 
     const thinkingSelect = getThinkingSelect(container);
-    const thinkingOptions = getThinkingOptions(container);
 
     expect(getChatThinkingValue(thinkingSelect)).toBe("");
-    expect(thinkingOptions[0]?.textContent?.trim()).toBe("Default");
+    expect(getThinkingReasoningValueLabel(container)).toBe("Default (Adaptive)");
     expect(thinkingSelect.title).toContain("Adaptive");
+    // "adaptive" is not one of the offered stops, so the parked thumb must
+    // render as unanchored instead of pretending the default is "off".
+    expect(getThinkingSliderValues(container)).not.toContain("adaptive");
+    expect(
+      getThinkingSlider(container)?.classList.contains(
+        "chat-controls__reasoning-range--unanchored",
+      ),
+    ).toBe(true);
+  });
+
+  it("anchors the slider thumb on the inherited default when it is a stop", () => {
+    const { state } = createChatHeaderState({
+      model: "gpt-5.5",
+      modelProvider: "openai",
+      thinkingDefault: "medium",
+    });
+    const container = document.createElement("div");
+    render(renderChatSessionSelect(state), container);
+
+    const slider = getThinkingSlider(container);
+    expect(slider?.classList.contains("chat-controls__reasoning-range--unanchored")).toBe(false);
+    expect(slider?.value).toBe(String(getThinkingSliderValues(container).indexOf("medium")));
+  });
+
+  it("keeps a single available thinking level selectable without a slider", async () => {
+    const { state, request } = createChatHeaderState();
+    state.sessionsResult = createSessionsResultFromRows([
+      {
+        key: "main",
+        kind: "direct",
+        modelProvider: "openai",
+        model: "gpt-5",
+        thinkingLevels: [{ id: "adaptive", label: "adaptive" }],
+        updatedAt: 1,
+      },
+    ]);
+    const container = document.createElement("div");
+    render(renderChatSessionSelect(state), container);
+
+    expect(getThinkingSlider(container)).toBeNull();
+    const only = container.querySelector<HTMLButtonElement>(
+      '[data-chat-thinking-option="adaptive"]',
+    );
+    expect(only).toBeInstanceOf(HTMLButtonElement);
+    expect(only?.getAttribute("aria-pressed")).toBe("false");
+    only?.click();
+
+    expect(request).toHaveBeenCalledWith("sessions.patch", {
+      key: "main",
+      thinkingLevel: "adaptive",
+    });
   });
 
   it("disables thinking for known non-reasoning models without duplicate off options", () => {
@@ -4366,11 +4429,11 @@ describe("chat session controls", () => {
     render(renderChatSessionSelect(state), container);
 
     const thinkingSelect = getThinkingSelect(container);
-    const thinkingOptions = getThinkingOptions(container);
 
     expect(thinkingSelect.dataset.chatThinkingDisabled).toBe("true");
-    expect(thinkingOptions.map((option) => option.dataset.chatThinkingOption)).toEqual([""]);
-    expect(thinkingOptions.map((option) => option.textContent?.trim())).toEqual(["Default"]);
+    // No reasoning levels -> no slider and no reset control at all.
+    expect(getThinkingSlider(container)).toBeNull();
+    expect(getThinkingResetButton(container)).toBeNull();
   });
 
   it("does not label a non-default chat model from global thinking defaults", () => {
@@ -4397,9 +4460,9 @@ describe("chat session controls", () => {
     const container = document.createElement("div");
     render(renderChatSessionSelect(state), container);
 
-    const thinkingOptions = getThinkingOptions(container);
-
-    expect(thinkingOptions[0]?.textContent?.trim()).toBe("Default");
+    // The session model is reasoning-capable, so the inherited default must
+    // come from the model (low), not the unrelated global session default (off).
+    expect(getThinkingReasoningValueLabel(container)).toBe("Default (Low)");
   });
 
   it("always renders full thinking labels", () => {
@@ -4424,19 +4487,12 @@ describe("chat session controls", () => {
     render(renderChatSessionSelect(state), container);
 
     const thinkingSelect = getThinkingSelect(container);
-    const thinkingOptions = getThinkingOptions(container);
 
     expect(container.querySelector('[data-chat-thinking-select-compact="true"]')).toBeNull();
     expect(getChatThinkingValue(thinkingSelect)).toBe("");
     expect(thinkingSelect.title).toContain("High");
-    expect(thinkingOptions.map((option) => option.textContent?.trim())).toEqual([
-      "Default",
-      "Off",
-      "Low",
-      "Medium",
-      "High",
-      "Extra high",
-    ]);
+    expect(getThinkingSliderValues(container)).toEqual(["off", "low", "medium", "high", "xhigh"]);
+    expect(getThinkingReasoningValueLabel(container)).toBe("Default (High)");
   });
 
   it("labels chat thinking default from session defaults when the row is absent", () => {
@@ -4448,10 +4504,9 @@ describe("chat session controls", () => {
     render(renderChatSessionSelect(state), container);
 
     const thinkingSelect = getThinkingSelect(container);
-    const thinkingOptions = getThinkingOptions(container);
 
     expect(getChatThinkingValue(thinkingSelect)).toBe("");
-    expect(thinkingOptions[0]?.textContent?.trim()).toBe("Default");
+    expect(getThinkingReasoningValueLabel(container)).toBe("Default (Adaptive)");
     expect(thinkingSelect.title).toContain("Adaptive");
   });
 });


### PR DESCRIPTION
Closes #99781

## What Problem This Solves

OpenClaw's Codex harness isolates each agent in a private Codex home, so threads created in Codex Desktop or the CLI are invisible to OpenClaw, and OpenClaw-created threads are invisible to native Codex clients.

## Why This Change Was Made

Adds an opt-in `appServer.homeScope: "user"` mode that connects the stdio app-server to the native user Codex home and authentication. An owner-only `codex_threads` tool lists, reads, forks, renames, archives, and restores native threads; continuation is fork-first so two clients never write the same thread concurrently.

The existing per-agent isolated home remains the default. Shared-user-home mode is intentionally rejected for remote WebSocket transports.

## User Impact

Operators can opt a Codex-backed OpenClaw agent into the same thread store used by Codex Desktop and the CLI, inspect and manage those native threads from OpenClaw, and attach a safe native fork to the current OpenClaw session.

## Evidence

- Live cross-process proof: three independent bundled Codex app-server processes create/list/read/fork/rename/archive/unarchive through one shared native home (`OPENCLAW_LIVE_TEST=1 OPENCLAW_LIVE_CODEX_THREAD_COEXISTENCE=1 node scripts/test-live.mjs -- extensions/codex/src/native-thread-coexistence.live.test.ts`).
- Focused Vitest proof: 239 tests passed across the Codex extension, plugin context, and descriptor cache shards.
- Testbox changed-surface gate: core/extensions typechecks, lint, import cycles, database-first guards, and architecture checks passed.
- Full Testbox production build passed (`corepack pnpm build`).
- Fresh Codex autoreview accepted one fork-source finding; the fix and regression test were added, and the final rerun reported no actionable findings.
