### PR TITLE
feat: soft-resume CLI sessions on prompt drift instead of hard invalidation

### DIFF
--- a/src/agents/cli-runner.before-agent-reply-cron.test.ts
+++ b/src/agents/cli-runner.before-agent-reply-cron.test.ts
@@ -89,7 +89,7 @@ function makeStubContext(params: typeof baseRunParams & { trigger?: string }) {
     authEpochVersion: 0,
     backendResolved: {},
     preparedBackend: {},
-    reusableCliSession: {},
+    reusableCliSession: { mode: "none" },
   } as unknown;
 }
 

--- a/src/agents/cli-runner.bundle-mcp.e2e.test.ts
+++ b/src/agents/cli-runner.bundle-mcp.e2e.test.ts
@@ -181,7 +181,7 @@ async function prepareBundleMcpExecutionContext(params: {
       bundleMcpMode: "claude-config-file",
     },
     preparedBackend,
-    reusableCliSession: {},
+    reusableCliSession: { mode: "none" },
     hadSessionFile: false,
     contextEngineConfig: params.config,
     modelId: params.model,

--- a/src/agents/cli-runner.context-engine.test.ts
+++ b/src/agents/cli-runner.context-engine.test.ts
@@ -103,6 +103,7 @@ function buildPreparedContext(contextEngine: ContextEngine): PreparedCliRunConte
       env: {},
     },
     reusableCliSession: {
+      mode: "reuse",
       sessionId: "existing-external-cli-session",
     },
     hadSessionFile: true,

--- a/src/agents/cli-runner.reliability.test.ts
+++ b/src/agents/cli-runner.reliability.test.ts
@@ -207,7 +207,9 @@ function buildPreparedContext(params?: {
       backend,
       env: {},
     },
-    reusableCliSession: params?.cliSessionId ? { sessionId: params.cliSessionId } : {},
+    reusableCliSession: params?.cliSessionId
+      ? { mode: "reuse", sessionId: params.cliSessionId }
+      : { mode: "none" },
     hadSessionFile: false,
     contextEngineConfig: {},
     modelId: model,
@@ -666,6 +668,71 @@ describe("runCliAgent reliability", () => {
     expect(supervisorSpawnMock).toHaveBeenCalledTimes(1);
   });
 
+  it("clears a soft-resumed binding after confirmed message send followed by failure", async () => {
+    supervisorSpawnMock.mockClear();
+    supervisorSpawnMock.mockImplementationOnce(async (...args: unknown[]) => {
+      const input = args[0] as Parameters<ReturnType<typeof getProcessSupervisor>["spawn"]>[0];
+      const captureHandle = markMcpLoopbackToolCallStarted({
+        captureKey: input.env?.OPENCLAW_MCP_CLI_CAPTURE_KEY ?? "",
+        toolName: "message",
+        args: {
+          action: "send",
+          channel: "telegram",
+          target: "chat123",
+          message: "sent before failure",
+        },
+      });
+      if (!captureHandle) {
+        throw new Error("Expected message delivery capture");
+      }
+      recordMcpLoopbackToolCallResult({
+        captureHandle,
+        toolName: "message",
+        args: {
+          action: "send",
+          channel: "telegram",
+          target: "chat123",
+          message: "sent before failure",
+        },
+        result: { status: "sent" },
+        isError: false,
+      });
+      markMcpLoopbackToolCallFinished(captureHandle);
+      return createManagedRun({
+        reason: "exit",
+        exitCode: 1,
+        exitSignal: null,
+        durationMs: 150,
+        stdout: "",
+        stderr: "failed after delivery",
+        timedOut: false,
+        noOutputTimedOut: false,
+      });
+    });
+    const context = buildPreparedContext({
+      sessionKey: "agent:main:soft-drift-delivered-failure",
+      runId: "run-soft-drift-delivered-failure",
+      cliSessionId: "soft-cli-session",
+      provider: "claude-cli",
+      model: "opus",
+      openClawHistoryPrompt: CLI_RESEED_PROMPT,
+    });
+    context.reusableCliSession = {
+      mode: "reuse-with-drift",
+      sessionId: "soft-cli-session",
+      drift: { reasons: ["system-prompt"] },
+    };
+    context.mcpDeliveryCapture = true;
+
+    const result = await runPreparedCliAgent(context);
+
+    expect(result.payloads).toBeUndefined();
+    expect(result.didSendViaMessagingTool).toBe(true);
+    expect(result.messagingToolSentTexts).toEqual(["sent before failure"]);
+    expect(result.meta.agentMeta?.clearCliSessionBinding).toBe(true);
+    expect(supervisorSpawnMock).toHaveBeenCalledTimes(1);
+  });
+
   it("does not retry context overflow after a confirmed message send", async () => {
     supervisorSpawnMock.mockClear();
     supervisorSpawnMock.mockImplementationOnce(async (...args: unknown[]) => {
@@ -799,6 +866,43 @@ describe("runCliAgent reliability", () => {
     expect(result.meta.agentMeta?.sessionId).toBe("");
     expect(result.meta.agentMeta?.clearCliSessionBinding).toBeUndefined();
     expect(supervisorSpawnMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("refreshes soft-resumed binding hashes without clearing the stored binding", async () => {
+    supervisorSpawnMock.mockClear();
+    supervisorSpawnMock.mockResolvedValueOnce(
+      createManagedRun({
+        reason: "exit",
+        exitCode: 0,
+        exitSignal: null,
+        durationMs: 50,
+        stdout: "ok",
+        stderr: "",
+        timedOut: false,
+        noOutputTimedOut: false,
+      }),
+    );
+    const context = buildPreparedContext({
+      sessionKey: "agent:main:soft-drift-refresh",
+      runId: "run-soft-drift-refresh",
+      cliSessionId: "soft-cli-session",
+      provider: "codex-cli",
+      model: "gpt-5.4",
+    });
+    context.reusableCliSession = {
+      mode: "reuse-with-drift",
+      sessionId: "soft-cli-session",
+      drift: { reasons: ["system-prompt"] },
+    };
+    context.extraSystemPromptHash = "new-system-prompt-hash";
+
+    const result = await runPreparedCliAgent(context);
+
+    expect(result.meta.agentMeta?.clearCliSessionBinding).toBeUndefined();
+    expect(result.meta.agentMeta?.cliSessionBinding).toMatchObject({
+      sessionId: "soft-cli-session",
+      extraSystemPromptHash: "new-system-prompt-hash",
+    });
   });
 
   it("returns only the source-reply mirror after a successful CLI turn", async () => {

--- a/src/agents/cli-runner.spawn.test.ts
+++ b/src/agents/cli-runner.spawn.test.ts
@@ -210,7 +210,7 @@ function buildPreparedCliRunContext(params: {
       env: params.preparedEnv ?? {},
       ...(params.mcpConfigHash ? { mcpConfigHash: params.mcpConfigHash } : {}),
     },
-    reusableCliSession: {},
+    reusableCliSession: { mode: "none" },
     hadSessionFile: false,
     contextEngineConfig: {},
     modelId: params.model,
@@ -328,7 +328,7 @@ describe("runCliAgent spawn path", () => {
       useResume: true,
       cliSessionId: "claude-session-secret",
       resolvedSessionId: "claude-session-secret",
-      reusableSessionId: "claude-session-secret",
+      reusableSession: { mode: "reuse", sessionId: "claude-session-secret" },
       hasHistoryPrompt: false,
     });
 
@@ -337,6 +337,27 @@ describe("runCliAgent spawn path", () => {
     expect(logLine).toContain("session=present");
     expect(logLine).toContain("reuse=reusable");
     expect(logLine).toContain("historyPrompt=none");
+    expect(logLine).not.toContain("claude-session-secret");
+  });
+
+  it("formats soft-resume drift in CLI resume diagnostics", () => {
+    const logLine = buildCliExecLogLine({
+      provider: "claude-cli",
+      model: "claude-opus-4-7",
+      promptChars: 42,
+      trigger: "user",
+      useResume: true,
+      cliSessionId: "claude-session-secret",
+      resolvedSessionId: "claude-session-secret",
+      reusableSession: {
+        mode: "reuse-with-drift",
+        sessionId: "claude-session-secret",
+        drift: { reasons: ["system-prompt"] },
+      },
+      hasHistoryPrompt: false,
+    });
+
+    expect(logLine).toContain("reuse=reusable-drift:system-prompt");
     expect(logLine).not.toContain("claude-session-secret");
   });
 
@@ -389,7 +410,7 @@ describe("runCliAgent spawn path", () => {
         backend: backendConfig,
         env: {},
       },
-      reusableCliSession: {},
+      reusableCliSession: { mode: "none" },
       hadSessionFile: false,
       contextEngineConfig: {},
       modelId: "sonnet",
@@ -490,6 +511,49 @@ describe("runCliAgent spawn path", () => {
     );
 
     await expectPathMissing(systemPromptPath);
+  });
+
+  it("resends system prompts through a file for soft-resumed prompt-tool drift", async () => {
+    const writeSoftResumeSystemPromptFile = vi.fn(async () => ({
+      filePath: "/tmp/openclaw-soft-resume-system-prompt.md",
+      cleanup: async () => {},
+    }));
+    setCliRunnerExecuteTestDeps({
+      writeCliSystemPromptFile: writeSoftResumeSystemPromptFile,
+    });
+    supervisorSpawnMock.mockImplementationOnce(async (...args: unknown[]) => {
+      const input = (args[0] ?? {}) as { argv?: string[] };
+      expect(input.argv).toContain("resume");
+      expect(input.argv).toContain("soft-cli-session");
+      expect(input.argv?.join(" ")).toContain("/tmp/openclaw-soft-resume-system-prompt.md");
+      return createManagedRun({
+        reason: "exit",
+        exitCode: 0,
+        exitSignal: null,
+        durationMs: 50,
+        stdout: "ok",
+        stderr: "",
+        timedOut: false,
+        noOutputTimedOut: false,
+      });
+    });
+    const context = buildPreparedCliRunContext({
+      provider: "codex-cli",
+      model: "gpt-5.4",
+      runId: "run-soft-resume-system-prompt-file",
+    });
+    context.reusableCliSession = {
+      mode: "reuse-with-drift",
+      sessionId: "soft-cli-session",
+      drift: { reasons: ["prompt-tools"] },
+    };
+
+    await executePreparedCliRun(context, "soft-cli-session");
+
+    expect(writeSoftResumeSystemPromptFile).toHaveBeenCalledWith({
+      backend: context.preparedBackend.backend,
+      systemPrompt: "You are a helpful assistant.",
+    });
   });
 
   it("passes --session-id for new Claude sessions", async () => {
@@ -742,7 +806,7 @@ describe("runCliAgent spawn path", () => {
       model: "gpt-5.4",
       runId: "run-1",
     });
-    context.reusableCliSession = { sessionId: "thread-123" };
+    context.reusableCliSession = { mode: "reuse", sessionId: "thread-123" };
 
     try {
       const result = await executePreparedCliRun(context, "thread-123");
@@ -3936,7 +4000,7 @@ ${JSON.stringify({
       model: "gpt-5.4",
       runId: "run-warning",
     });
-    context.reusableCliSession = { sessionId: "thread-123" };
+    context.reusableCliSession = { mode: "reuse", sessionId: "thread-123" };
     context.bootstrapPromptWarningLines = [
       "[Bootstrap truncation warning]",
       "- AGENTS.md: 200 raw -> 20 injected",

--- a/src/agents/cli-runner.ts
+++ b/src/agents/cli-runner.ts
@@ -29,7 +29,11 @@ import {
   loadCliSessionContextEngineMessages,
   loadCliSessionHistoryMessages,
 } from "./cli-runner/session-history.js";
-import type { PreparedCliRunContext, RunCliAgentParams } from "./cli-runner/types.js";
+import type {
+  CliReusableSession,
+  PreparedCliRunContext,
+  RunCliAgentParams,
+} from "./cli-runner/types.js";
 import { claudeCliSessionTranscriptHasContent as claudeCliSessionTranscriptHasContentImpl } from "./command/attempt-execution.helpers.js";
 import { classifyFailoverReason, isFailoverErrorMessage } from "./embedded-agent-helpers.js";
 import type { EmbeddedAgentRunResult } from "./embedded-agent-runner.js";
@@ -84,6 +88,12 @@ export function restoreCliRunnerTestDeps(): void {
 
 function isClaudeCliProvider(provider: string): boolean {
   return provider.trim().toLowerCase() === "claude-cli";
+}
+
+function resolveReusableCliSessionId(reusableCliSession: CliReusableSession): string | undefined {
+  return reusableCliSession.mode === "reuse" || reusableCliSession.mode === "reuse-with-drift"
+    ? reusableCliSession.sessionId
+    : undefined;
 }
 
 function shouldRetryFreshCliSessionAfterFailover(params: {
@@ -727,7 +737,9 @@ export async function runPreparedCliAgent(
           sessionId: "",
           provider: params.provider,
           model: context.modelId,
-          ...(context.reusableCliSession.sessionId ? { clearCliSessionBinding: true } : {}),
+          ...(resolveReusableCliSessionId(context.reusableCliSession)
+            ? { clearCliSessionBinding: true }
+            : {}),
         },
       },
       didSendViaMessagingTool: true,
@@ -1158,10 +1170,11 @@ export async function runPreparedCliAgent(
       ctx: hookContext,
       hookRunner,
     });
+    const reusableCliSessionId = resolveReusableCliSessionId(context.reusableCliSession);
     try {
       return await finishCliAttempt(
-        await executeCliAttempt(context.reusableCliSession.sessionId),
-        context.reusableCliSession.sessionId,
+        await executeCliAttempt(reusableCliSessionId),
+        reusableCliSessionId,
       );
     } catch (err) {
       const deliveredFailure = await finishDeliveredFailure(err);
@@ -1169,7 +1182,7 @@ export async function runPreparedCliAgent(
         return deliveredFailure;
       }
       if (isFailoverError(err)) {
-        const retryableSessionId = context.reusableCliSession.sessionId;
+        const retryableSessionId = reusableCliSessionId;
         if (
           shouldRetryFreshCliSessionAfterFailover({
             error: err,

--- a/src/agents/cli-runner/execute.supervisor-capture.test.ts
+++ b/src/agents/cli-runner/execute.supervisor-capture.test.ts
@@ -92,7 +92,7 @@ function buildPreparedCliRunContext(params: {
       env: {},
       ...(params.beforeExecution ? { beforeExecution: params.beforeExecution } : {}),
     },
-    reusableCliSession: {},
+    reusableCliSession: { mode: "none" },
     hadSessionFile: false,
     contextEngineConfig: {},
     modelId: "model",

--- a/src/agents/cli-runner/execute.ts
+++ b/src/agents/cli-runner/execute.ts
@@ -90,7 +90,7 @@ import {
   formatCliBackendOutputDigest,
   LEGACY_CLAUDE_CLI_LOG_OUTPUT_ENV,
 } from "./log.js";
-import type { PreparedCliRunContext } from "./types.js";
+import type { CliReusableSession, PreparedCliRunContext } from "./types.js";
 
 const executeDeps = {
   getProcessSupervisor: getProcessSupervisorImpl,
@@ -377,6 +377,21 @@ function fingerprintCliSessionId(sessionId?: string): string {
   return crypto.createHash("sha256").update(trimmed).digest("hex").slice(0, 12);
 }
 
+function formatCliSessionReuseLogState(reusableSession: CliReusableSession): string {
+  switch (reusableSession.mode) {
+    case "reuse":
+      return "reusable";
+    case "reuse-with-drift":
+      return `reusable-drift:${reusableSession.drift.reasons.join(",")}`;
+    case "invalidate":
+      return `invalidated:${reusableSession.invalidatedReason}`;
+    case "none":
+      return "none";
+  }
+  const exhaustive: never = reusableSession;
+  return exhaustive;
+}
+
 /** Builds the compact execution summary logged before a CLI backend run. */
 export function buildCliExecLogLine(params: {
   provider: string;
@@ -386,15 +401,9 @@ export function buildCliExecLogLine(params: {
   useResume: boolean;
   cliSessionId?: string;
   resolvedSessionId?: string;
-  reusableSessionId?: string;
-  invalidatedReason?: string;
+  reusableSession: CliReusableSession;
   hasHistoryPrompt: boolean;
 }): string {
-  const reuseState = params.reusableSessionId
-    ? "reusable"
-    : params.invalidatedReason
-      ? `invalidated:${params.invalidatedReason}`
-      : "none";
   return [
     `cli exec: provider=${params.provider}`,
     `model=${params.model}`,
@@ -403,7 +412,7 @@ export function buildCliExecLogLine(params: {
     `useResume=${params.useResume ? "true" : "false"}`,
     `session=${params.cliSessionId ? "present" : "none"}`,
     `resumeSession=${params.useResume ? fingerprintCliSessionId(params.resolvedSessionId) : "none"}`,
-    `reuse=${reuseState}`,
+    `reuse=${formatCliSessionReuseLogState(params.reusableSession)}`,
     `historyPrompt=${params.hasHistoryPrompt ? "present" : "none"}`,
   ].join(" ");
 }
@@ -445,13 +454,15 @@ export async function executePreparedCliRun(
   const useResume = Boolean(
     cliSessionIdToUse && resolvedSessionId && backend.resumeArgs && backend.resumeArgs.length > 0,
   );
+  const resendSystemPromptForSoftResume = context.reusableCliSession.mode === "reuse-with-drift";
   const systemPromptArg = resolveSystemPromptUsage({
     backend,
-    isNewSession: isNew,
+    isNewSession: isNew || resendSystemPromptForSoftResume,
     systemPrompt: context.systemPrompt,
   });
   const systemPromptFile =
-    systemPromptArg && (!useResume || backend.systemPromptWhen === "always")
+    systemPromptArg &&
+    (!useResume || backend.systemPromptWhen === "always" || resendSystemPromptForSoftResume)
       ? await executeDeps.writeCliSystemPromptFile({
           backend,
           systemPrompt: systemPromptArg,
@@ -522,6 +533,7 @@ export async function executePreparedCliRun(
     imagePaths,
     promptArg: argsPrompt,
     useResume,
+    sendSystemPromptOnResume: resendSystemPromptForSoftResume,
   });
 
   const claudeOwnerKey = buildClaudeOwnerKey({
@@ -662,8 +674,7 @@ export async function executePreparedCliRun(
             useResume,
             cliSessionId: cliSessionIdToUse,
             resolvedSessionId,
-            reusableSessionId: context.reusableCliSession.sessionId,
-            invalidatedReason: context.reusableCliSession.invalidatedReason,
+            reusableSession: context.reusableCliSession,
             hasHistoryPrompt: Boolean(context.openClawHistoryPrompt),
           }),
         );

--- a/src/agents/cli-runner/helpers.system-prompt-resume.test.ts
+++ b/src/agents/cli-runner/helpers.system-prompt-resume.test.ts
@@ -136,6 +136,21 @@ describe("buildCliArgs — issue #80374", () => {
     expect(args).not.toContain(PROMPT_FILE);
   });
 
+  it("soft system-prompt drift includes --append-system-prompt-file on legacy resume", () => {
+    const args = buildCliArgs({
+      backend: BACKEND_FIRST as CliBackendConfig,
+      baseArgs: BASE_ARGS,
+      modelId: "claude-haiku-4-5",
+      sessionId: "test-session-id",
+      systemPrompt: SYSTEM_PROMPT,
+      systemPromptFilePath: PROMPT_FILE,
+      useResume: true,
+      sendSystemPromptOnResume: true,
+    });
+    expect(args).toContain("--append-system-prompt-file");
+    expect(args).toContain(PROMPT_FILE);
+  });
+
   it("new 'always': includes --append-system-prompt-file on resume (issue #80374)", () => {
     const args = buildCliArgs({
       backend: BACKEND_ALWAYS as CliBackendConfig,

--- a/src/agents/cli-runner/helpers.ts
+++ b/src/agents/cli-runner/helpers.ts
@@ -497,20 +497,25 @@ export function buildCliArgs(params: {
   imagePaths?: string[];
   promptArg?: string;
   useResume: boolean;
+  sendSystemPromptOnResume?: boolean;
 }): string[] {
   const args: string[] = [...params.baseArgs];
+  const shouldSendSystemPrompt =
+    !params.useResume ||
+    params.backend.systemPromptWhen === "always" ||
+    params.sendSystemPromptOnResume;
   if (params.backend.modelArg && params.modelId) {
     args.push(params.backend.modelArg, params.modelId);
   }
   if (
-    (!params.useResume || params.backend.systemPromptWhen === "always") &&
+    shouldSendSystemPrompt &&
     params.systemPrompt &&
     params.systemPromptFilePath &&
     params.backend.systemPromptFileArg
   ) {
     args.push(params.backend.systemPromptFileArg, params.systemPromptFilePath);
   } else if (
-    (!params.useResume || params.backend.systemPromptWhen === "always") &&
+    shouldSendSystemPrompt &&
     params.systemPrompt &&
     params.systemPromptFilePath &&
     params.backend.systemPromptFileConfigKey
@@ -522,11 +527,7 @@ export function buildCliArgs(params: {
         params.systemPromptFilePath,
       ),
     );
-  } else if (
-    (!params.useResume || params.backend.systemPromptWhen === "always") &&
-    params.systemPrompt &&
-    params.backend.systemPromptArg
-  ) {
+  } else if (shouldSendSystemPrompt && params.systemPrompt && params.backend.systemPromptArg) {
     args.push(params.backend.systemPromptArg, stripSystemPromptCacheBoundary(params.systemPrompt));
   }
   if (!params.useResume && params.sessionId) {

--- a/src/agents/cli-runner/prepare.test.ts
+++ b/src/agents/cli-runner/prepare.test.ts
@@ -2053,7 +2053,6 @@ describe("shouldSkipLocalCliCredentialEpoch", () => {
         "OpenClaw resumed this CLI session after prompt content changed.",
       );
       expect(context.params.prompt).toContain("changed=system-prompt");
-      expect(context.params.prompt).toContain("Current session context:\nnew stable prompt");
       expect(context.params.prompt).toContain("latest ask");
     } finally {
       fs.rmSync(dir, { recursive: true, force: true });

--- a/src/agents/cli-runner/prepare.test.ts
+++ b/src/agents/cli-runner/prepare.test.ts
@@ -148,6 +148,7 @@ function createCliBackendConfig(
   params: {
     bundleMcp?: boolean;
     reseedFromRawTranscriptWhenUncompacted?: boolean;
+    systemPromptWhen?: "first" | "always" | "never";
   } = {},
 ): OpenClawConfig {
   return {
@@ -158,7 +159,7 @@ function createCliBackendConfig(
             command: "test-cli",
             args: ["--print"],
             systemPromptArg: "--system-prompt",
-            systemPromptWhen: "first",
+            systemPromptWhen: params.systemPromptWhen ?? "first",
             sessionMode: "existing",
             output: "text",
             input: "arg",
@@ -1397,7 +1398,7 @@ describe("shouldSkipLocalCliCredentialEpoch", () => {
         }),
       });
 
-      expect(context.reusableCliSession).toEqual({ sessionId: "cli-session" });
+      expect(context.reusableCliSession).toEqual({ mode: "reuse", sessionId: "cli-session" });
       expect(context.params.prompt).toBe("Current event:\nBob: yes\n\n[OpenClaw room event]");
       expect(context.openClawHistoryPrompt).toContain("Room context:\nAlice: lunch?");
       expect(context.openClawHistoryPrompt).toContain("Current event:\nBob: yes");
@@ -1848,7 +1849,7 @@ describe("shouldSkipLocalCliCredentialEpoch", () => {
 
       expect(context.systemPrompt).toContain("## Inbound Context\nchannel=telegram");
       expect(context.extraSystemPromptHash).toBeUndefined();
-      expect(context.reusableCliSession).toEqual({ sessionId: "cli-session" });
+      expect(context.reusableCliSession).toEqual({ mode: "reuse", sessionId: "cli-session" });
     } finally {
       fs.rmSync(dir, { recursive: true, force: true });
     }
@@ -1881,7 +1882,10 @@ describe("shouldSkipLocalCliCredentialEpoch", () => {
       });
 
       expect(context.messageToolPolicyHash).toBeDefined();
-      expect(context.reusableCliSession).toEqual({ invalidatedReason: "system-prompt" });
+      expect(context.reusableCliSession).toEqual({
+        mode: "invalidate",
+        invalidatedReason: "message-policy",
+      });
     } finally {
       fs.rmSync(dir, { recursive: true, force: true });
     }
@@ -2007,7 +2011,84 @@ describe("shouldSkipLocalCliCredentialEpoch", () => {
       });
 
       expect(context.extraSystemPromptHash).toBe(hashCliSessionText(staticPrompt));
-      expect(context.reusableCliSession).toEqual({ sessionId: "cli-session" });
+      expect(context.reusableCliSession).toEqual({ mode: "reuse", sessionId: "cli-session" });
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("soft-resumes content drift and surfaces a per-turn drift note", async () => {
+    const { dir, sessionFile } = createSessionFile();
+    try {
+      const context = await prepareCliRunContext({
+        sessionId: "session-test",
+        sessionKey: "agent:main:test",
+        sessionFile,
+        workspaceDir: dir,
+        prompt: "latest ask",
+        currentInboundContext: {
+          text: "Conversation info (untrusted metadata):\nchannel=telegram",
+        },
+        provider: "test-cli",
+        model: "test-model",
+        timeoutMs: 1_000,
+        runId: "run-test-soft-resume-drift-note",
+        extraSystemPrompt: "new stable prompt",
+        extraSystemPromptStatic: "new stable prompt",
+        cliSessionBinding: {
+          sessionId: "cli-session",
+          extraSystemPromptHash: hashCliSessionText("old stable prompt"),
+          cwdHash: hashCliSessionText(dir),
+        },
+        config: createCliBackendConfig(),
+      });
+
+      expect(context.reusableCliSession).toEqual({
+        mode: "reuse-with-drift",
+        sessionId: "cli-session",
+        drift: { reasons: ["system-prompt"] },
+      });
+      expect(context.openClawHistoryPrompt).toBeUndefined();
+      expect(context.params.prompt).toContain(
+        "OpenClaw resumed this CLI session after prompt content changed.",
+      );
+      expect(context.params.prompt).toContain("changed=system-prompt");
+      expect(context.params.prompt).toContain("Current session context:\nnew stable prompt");
+      expect(context.params.prompt).toContain("latest ask");
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("invalidates content drift when the backend cannot receive a resumed system prompt", async () => {
+    const { dir, sessionFile } = createSessionFile();
+    try {
+      const context = await prepareCliRunContext({
+        sessionId: "session-test",
+        sessionFile,
+        workspaceDir: dir,
+        prompt: "latest ask",
+        provider: "test-cli",
+        model: "test-model",
+        timeoutMs: 1_000,
+        runId: "run-test-soft-resume-unsupported-backend",
+        extraSystemPrompt: "new stable prompt",
+        extraSystemPromptStatic: "new stable prompt",
+        cliSessionBinding: {
+          sessionId: "cli-session",
+          extraSystemPromptHash: hashCliSessionText("old stable prompt"),
+          cwdHash: hashCliSessionText(dir),
+        },
+        config: createCliBackendConfig({ systemPromptWhen: "never" }),
+      });
+
+      expect(context.reusableCliSession).toEqual({
+        mode: "invalidate",
+        invalidatedReason: "system-prompt",
+      });
+      expect(context.params.prompt).not.toContain(
+        "OpenClaw resumed this CLI session after prompt content changed.",
+      );
     } finally {
       fs.rmSync(dir, { recursive: true, force: true });
     }
@@ -2111,7 +2192,7 @@ describe("shouldSkipLocalCliCredentialEpoch", () => {
             "if current-turn context says final text stays private, use `message(action=send)`",
           );
         }
-        expect(second.reusableCliSession).toEqual({ sessionId: "cli-session" });
+        expect(second.reusableCliSession).toEqual({ mode: "reuse", sessionId: "cli-session" });
       } finally {
         fs.rmSync(dir, { recursive: true, force: true });
       }
@@ -2203,7 +2284,7 @@ describe("shouldSkipLocalCliCredentialEpoch", () => {
       });
 
       expect(second.extraSystemPromptHash).toBe(first.extraSystemPromptHash);
-      expect(second.reusableCliSession).toEqual({ sessionId: "cli-session" });
+      expect(second.reusableCliSession).toEqual({ mode: "reuse", sessionId: "cli-session" });
     } finally {
       fs.rmSync(dir, { recursive: true, force: true });
     }
@@ -2328,7 +2409,7 @@ describe("shouldSkipLocalCliCredentialEpoch", () => {
         }),
       );
       expect(second.promptToolNamesHash).toBe(first.promptToolNamesHash);
-      expect(second.reusableCliSession).toEqual({ sessionId: "cli-session" });
+      expect(second.reusableCliSession).toEqual({ mode: "reuse", sessionId: "cli-session" });
     } finally {
       fs.rmSync(dir, { recursive: true, force: true });
     }
@@ -2368,7 +2449,11 @@ describe("shouldSkipLocalCliCredentialEpoch", () => {
         }),
       });
 
-      expect(context.reusableCliSession).toEqual({ invalidatedReason: "system-prompt" });
+      expect(context.reusableCliSession).toEqual({
+        mode: "reuse-with-drift",
+        sessionId: "cli-session",
+        drift: { reasons: ["system-prompt"] },
+      });
       expect(context.openClawHistoryPrompt).toContain("prior no-compaction ask");
       expect(context.openClawHistoryPrompt).toContain("latest ask");
     } finally {
@@ -2408,7 +2493,7 @@ describe("shouldSkipLocalCliCredentialEpoch", () => {
         }),
       });
 
-      expect(context.reusableCliSession).toEqual({ sessionId: "cli-session" });
+      expect(context.reusableCliSession).toEqual({ mode: "reuse", sessionId: "cli-session" });
       expect(context.openClawHistoryPrompt).toContain("prior resumable ask");
       expect(context.openClawHistoryPrompt).toContain("latest ask");
     } finally {
@@ -2556,6 +2641,18 @@ describe("shouldSkipLocalCliCredentialEpoch", () => {
           },
         ],
       });
+      const baselineContext = await prepareCliRunContext({
+        sessionId: "session-test",
+        sessionKey: "agent:main:test",
+        sessionFile,
+        workspaceDir: dir,
+        prompt: "latest ask",
+        provider: "native-cli",
+        model: "test-model",
+        timeoutMs: 1_000,
+        runId: "run-test-loopback-prompt-tools-baseline",
+        config: createCliBackendConfig({ bundleMcp: true }),
+      });
       const context = await prepareCliRunContext({
         sessionId: "session-test",
         sessionKey: "agent:main:test",
@@ -2570,6 +2667,12 @@ describe("shouldSkipLocalCliCredentialEpoch", () => {
         cliSessionBinding: {
           sessionId: "cli-session",
           promptToolNamesHash: "old-tool-surface",
+          ...(baselineContext.preparedBackend.mcpConfigHash
+            ? { mcpConfigHash: baselineContext.preparedBackend.mcpConfigHash }
+            : {}),
+          ...(baselineContext.preparedBackend.mcpResumeHash
+            ? { mcpResumeHash: baselineContext.preparedBackend.mcpResumeHash }
+            : {}),
         },
       });
 
@@ -2595,7 +2698,11 @@ describe("shouldSkipLocalCliCredentialEpoch", () => {
       expect(context.promptToolNamesHash).toBe(
         hashCliSessionText(JSON.stringify(["memory_search"])),
       );
-      expect(context.reusableCliSession).toEqual({ invalidatedReason: "system-prompt" });
+      expect(context.reusableCliSession).toEqual({
+        mode: "reuse-with-drift",
+        sessionId: "cli-session",
+        drift: { reasons: ["prompt-tools"] },
+      });
     } finally {
       fs.rmSync(dir, { recursive: true, force: true });
     }
@@ -2944,7 +3051,10 @@ describe("shouldSkipLocalCliCredentialEpoch", () => {
         workspaceDir: dir,
       });
       expect(orphanCheck).not.toHaveBeenCalled();
-      expect(context.reusableCliSession).toEqual({ invalidatedReason: "missing-transcript" });
+      expect(context.reusableCliSession).toEqual({
+        mode: "invalidate",
+        invalidatedReason: "missing-transcript",
+      });
     } finally {
       fs.rmSync(dir, { recursive: true, force: true });
     }
@@ -2988,7 +3098,10 @@ describe("shouldSkipLocalCliCredentialEpoch", () => {
         sessionId: "orphaned-claude-sid",
         workspaceDir: dir,
       });
-      expect(context.reusableCliSession).toEqual({ invalidatedReason: "orphaned-tool-use" });
+      expect(context.reusableCliSession).toEqual({
+        mode: "invalidate",
+        invalidatedReason: "orphaned-tool-use",
+      });
     } finally {
       fs.rmSync(dir, { recursive: true, force: true });
     }
@@ -3027,7 +3140,10 @@ describe("shouldSkipLocalCliCredentialEpoch", () => {
 
       expect(transcriptCheck).not.toHaveBeenCalled();
       expect(orphanCheck).not.toHaveBeenCalled();
-      expect(context.reusableCliSession).toEqual({ invalidatedReason: "auth-profile" });
+      expect(context.reusableCliSession).toEqual({
+        mode: "invalidate",
+        invalidatedReason: "auth-profile",
+      });
     } finally {
       fs.rmSync(dir, { recursive: true, force: true });
     }
@@ -3067,7 +3183,10 @@ describe("shouldSkipLocalCliCredentialEpoch", () => {
         sessionId: "live-claude-sid",
         workspaceDir: dir,
       });
-      expect(context.reusableCliSession).toEqual({ sessionId: "live-claude-sid" });
+      expect(context.reusableCliSession).toEqual({
+        mode: "reuse",
+        sessionId: "live-claude-sid",
+      });
     } finally {
       fs.rmSync(dir, { recursive: true, force: true });
     }
@@ -3121,7 +3240,10 @@ describe("shouldSkipLocalCliCredentialEpoch", () => {
         sessionId: "live-claude-sid",
         workspaceDir: taskDir,
       });
-      expect(context.reusableCliSession).toEqual({ sessionId: "live-claude-sid" });
+      expect(context.reusableCliSession).toEqual({
+        mode: "reuse",
+        sessionId: "live-claude-sid",
+      });
     } finally {
       fs.rmSync(dir, { recursive: true, force: true });
     }
@@ -3502,7 +3624,7 @@ describe("shouldSkipLocalCliCredentialEpoch", () => {
       });
 
       expect(transcriptCheck).not.toHaveBeenCalled();
-      expect(context.reusableCliSession).toEqual({ sessionId: "test-cli-sid" });
+      expect(context.reusableCliSession).toEqual({ mode: "reuse", sessionId: "test-cli-sid" });
     } finally {
       fs.rmSync(dir, { recursive: true, force: true });
     }
@@ -3716,7 +3838,7 @@ describe("shouldSkipLocalCliCredentialEpoch", () => {
         config: createCliBackendConfig(),
       });
 
-      expect(context.reusableCliSession).toEqual({ sessionId: "cli-session" });
+      expect(context.reusableCliSession).toEqual({ mode: "reuse", sessionId: "cli-session" });
       expect(context.openClawHistoryPrompt).toBeDefined();
       expect(context.openClawHistoryPrompt).toContain(recentMarker);
       expect(context.openClawHistoryPrompt).toContain("EARLIEST_USER");

--- a/src/agents/cli-runner/prepare.ts
+++ b/src/agents/cli-runner/prepare.ts
@@ -134,43 +134,20 @@ function canApplySystemPromptOnResume(backend: CliBackendConfig): boolean {
   );
 }
 
-function buildCliSessionDriftUserContext(params: {
-  reusableCliSession: CliReusableSession;
-  extraSystemPrompt: string;
-  promptToolNames: string[];
-}): string | undefined {
-  const { reusableCliSession } = params;
+function buildCliSessionDriftUserContext(
+  reusableCliSession: CliReusableSession,
+): string | undefined {
   if (reusableCliSession.mode !== "reuse-with-drift") {
     return undefined;
   }
-  const lines = [
-    `OpenClaw resumed this CLI session after prompt content changed. Follow the current turn's instructions; changed=${reusableCliSession.drift.reasons.join(",")}.`,
-  ];
-  if (reusableCliSession.drift.reasons.includes("system-prompt") && params.extraSystemPrompt) {
-    lines.push(`Current session context:\n${params.extraSystemPrompt}`);
-  }
-  if (reusableCliSession.drift.reasons.includes("prompt-tools")) {
-    lines.push(
-      `Current prompt tool surface: ${
-        params.promptToolNames.length > 0 ? params.promptToolNames.join(", ") : "none"
-      }`,
-    );
-  }
-  return lines.join("\n\n");
+  return `OpenClaw resumed this CLI session after prompt content changed. Follow the current turn's instructions; changed=${reusableCliSession.drift.reasons.join(",")}.`;
 }
 
 function prependCliSessionDriftUserContext(
   context: RunCliAgentParams["currentInboundContext"],
   reusableCliSession: CliReusableSession,
-  driftContext: {
-    extraSystemPrompt: string;
-    promptToolNames: string[];
-  },
 ): RunCliAgentParams["currentInboundContext"] {
-  const note = buildCliSessionDriftUserContext({
-    reusableCliSession,
-    ...driftContext,
-  });
+  const note = buildCliSessionDriftUserContext(reusableCliSession);
   if (!note) {
     return context;
   }
@@ -889,10 +866,6 @@ export async function prepareCliRunContext(
       const currentInboundContext = prependCliSessionDriftUserContext(
         params.currentInboundContext,
         reusableCliSession,
-        {
-          extraSystemPrompt,
-          promptToolNames: promptTools.map((tool) => tool.name).toSorted(),
-        },
       );
       const fullCurrentInboundPrompt = buildCurrentInboundPrompt({
         context: currentInboundContext,

--- a/src/agents/cli-runner/prepare.ts
+++ b/src/agents/cli-runner/prepare.ts
@@ -4,6 +4,7 @@
  */
 import { uniqueStrings } from "@openclaw/normalization-core/string-normalization";
 import { getRuntimeConfig } from "../../config/config.js";
+import type { CliBackendConfig } from "../../config/types.agent-defaults.js";
 import {
   assertContextEngineHostSupport,
   buildGenericCliContextEngineHostSupport,
@@ -109,6 +110,79 @@ const prepareDeps = {
   claudeCliSessionTranscriptHasOrphanedToolUse,
   resolveApiKeyForProfile,
 };
+
+function resolveReusableCliSessionId(reusableCliSession: CliReusableSession): string | undefined {
+  return reusableCliSession.mode === "reuse" || reusableCliSession.mode === "reuse-with-drift"
+    ? reusableCliSession.sessionId
+    : undefined;
+}
+
+function resolveCliSessionInvalidatedReason(
+  reusableCliSession: CliReusableSession,
+): Extract<CliReusableSession, { mode: "invalidate" }>["invalidatedReason"] | undefined {
+  return reusableCliSession.mode === "invalidate"
+    ? reusableCliSession.invalidatedReason
+    : undefined;
+}
+
+function canApplySystemPromptOnResume(backend: CliBackendConfig): boolean {
+  return (
+    backend.systemPromptWhen !== "never" &&
+    Boolean(
+      backend.systemPromptArg || backend.systemPromptFileArg || backend.systemPromptFileConfigKey,
+    )
+  );
+}
+
+function buildCliSessionDriftUserContext(params: {
+  reusableCliSession: CliReusableSession;
+  extraSystemPrompt: string;
+  promptToolNames: string[];
+}): string | undefined {
+  const { reusableCliSession } = params;
+  if (reusableCliSession.mode !== "reuse-with-drift") {
+    return undefined;
+  }
+  const lines = [
+    `OpenClaw resumed this CLI session after prompt content changed. Follow the current turn's instructions; changed=${reusableCliSession.drift.reasons.join(",")}.`,
+  ];
+  if (reusableCliSession.drift.reasons.includes("system-prompt") && params.extraSystemPrompt) {
+    lines.push(`Current session context:\n${params.extraSystemPrompt}`);
+  }
+  if (reusableCliSession.drift.reasons.includes("prompt-tools")) {
+    lines.push(
+      `Current prompt tool surface: ${
+        params.promptToolNames.length > 0 ? params.promptToolNames.join(", ") : "none"
+      }`,
+    );
+  }
+  return lines.join("\n\n");
+}
+
+function prependCliSessionDriftUserContext(
+  context: RunCliAgentParams["currentInboundContext"],
+  reusableCliSession: CliReusableSession,
+  driftContext: {
+    extraSystemPrompt: string;
+    promptToolNames: string[];
+  },
+): RunCliAgentParams["currentInboundContext"] {
+  const note = buildCliSessionDriftUserContext({
+    reusableCliSession,
+    ...driftContext,
+  });
+  if (!note) {
+    return context;
+  }
+  if (!context) {
+    return { text: note };
+  }
+  return {
+    ...context,
+    text: [note, context.text].join("\n\n"),
+    ...(context.resumableText ? { resumableText: [note, context.resumableText].join("\n\n") } : {}),
+  };
+}
 
 async function resolveCliSkillsPrompt(params: {
   agentId: string;
@@ -618,7 +692,7 @@ export async function prepareCliRunContext(
         ? hashCliSessionText(JSON.stringify(promptTools.map((tool) => tool.name).toSorted()))
         : undefined;
     const reusableCliSessionCandidate: CliReusableSession = isSideQuestion
-      ? {}
+      ? { mode: "none" }
       : params.cliSessionBinding
         ? resolveCliSessionReuse({
             binding: params.cliSessionBinding,
@@ -633,9 +707,15 @@ export async function prepareCliRunContext(
             mcpResumeHash: preparedBackendFinal.mcpResumeHash,
           })
         : params.cliSessionId
-          ? { sessionId: params.cliSessionId }
-          : {};
-    const candidateClaudeCliSessionId = reusableCliSessionCandidate.sessionId?.trim() || undefined;
+          ? { mode: "reuse", sessionId: params.cliSessionId }
+          : { mode: "none" };
+    const backendReusableCliSession: CliReusableSession =
+      reusableCliSessionCandidate.mode === "reuse-with-drift" &&
+      !canApplySystemPromptOnResume(preparedBackendFinal.backend)
+        ? { mode: "invalidate", invalidatedReason: "system-prompt" }
+        : reusableCliSessionCandidate;
+    const candidateClaudeCliSessionId =
+      resolveReusableCliSessionId(backendReusableCliSession)?.trim() || undefined;
     const hasClaudeCliCandidate =
       candidateClaudeCliSessionId !== undefined && isClaudeCliProvider(params.provider);
     const claudeCliTranscriptMissing =
@@ -651,18 +731,20 @@ export async function prepareCliRunContext(
         sessionId: candidateClaudeCliSessionId,
         workspaceDir: cwd,
       }));
-    const claudeCliInvalidatedReason: CliReusableSession["invalidatedReason"] | undefined =
+    const claudeCliInvalidatedReason: "missing-transcript" | "orphaned-tool-use" | undefined =
       claudeCliTranscriptMissing
         ? "missing-transcript"
         : claudeCliTranscriptOrphanedToolUse
           ? "orphaned-tool-use"
           : undefined;
     const reusableCliSession: CliReusableSession = claudeCliInvalidatedReason
-      ? { invalidatedReason: claudeCliInvalidatedReason }
-      : reusableCliSessionCandidate;
-    if (reusableCliSession.invalidatedReason) {
+      ? { mode: "invalidate", invalidatedReason: claudeCliInvalidatedReason }
+      : backendReusableCliSession;
+    const reusableCliSessionId = resolveReusableCliSessionId(reusableCliSession);
+    const invalidatedReason = resolveCliSessionInvalidatedReason(reusableCliSession);
+    if (invalidatedReason) {
       cliBackendLog.info(
-        `cli session reset: provider=${params.provider} reason=${reusableCliSession.invalidatedReason}`,
+        `cli session reset: provider=${params.provider} reason=${invalidatedReason}`,
       );
     }
     let openClawHistoryMessages: unknown[] | undefined;
@@ -804,15 +886,23 @@ export async function prepareCliRunContext(
     }
     let historyPromptCurrentTurn = preparedPrompt;
     if (!isSideQuestion) {
+      const currentInboundContext = prependCliSessionDriftUserContext(
+        params.currentInboundContext,
+        reusableCliSession,
+        {
+          extraSystemPrompt,
+          promptToolNames: promptTools.map((tool) => tool.name).toSorted(),
+        },
+      );
       const fullCurrentInboundPrompt = buildCurrentInboundPrompt({
-        context: params.currentInboundContext,
+        context: currentInboundContext,
         prompt: preparedPrompt,
       });
       const runCurrentInboundPrompt = buildCurrentInboundPrompt({
-        context: params.currentInboundContext,
+        context: currentInboundContext,
         prompt: preparedPrompt,
         preferResumableText:
-          params.currentInboundEventKind === "room_event" && Boolean(reusableCliSession.sessionId),
+          params.currentInboundEventKind === "room_event" && Boolean(reusableCliSessionId),
       });
       historyPromptCurrentTurn = annotateInterSessionPromptText(
         fullCurrentInboundPrompt,
@@ -825,11 +915,9 @@ export async function prepareCliRunContext(
     }
     const allowRawTranscriptReseed =
       backendResolved.config.reseedFromRawTranscriptWhenUncompacted === true;
-    const rawTranscriptReseedReason = reusableCliSession.sessionId
-      ? "session-expired"
-      : reusableCliSession.invalidatedReason;
+    const rawTranscriptReseedReason = reusableCliSessionId ? "session-expired" : invalidatedReason;
     const shouldPrepareOpenClawHistoryPrompt =
-      !isSideQuestion && (!reusableCliSession.sessionId || allowRawTranscriptReseed);
+      !isSideQuestion && (!reusableCliSessionId || allowRawTranscriptReseed);
     const openClawHistoryPrompt = shouldPrepareOpenClawHistoryPrompt
       ? buildCliSessionHistoryPrompt({
           messages: await loadCliSessionReseedMessages({

--- a/src/agents/cli-runner/session-history.ts
+++ b/src/agents/cli-runner/session-history.ts
@@ -59,6 +59,7 @@ type HistoryEntry = {
 type RawTranscriptReseedReason =
   | "auth-profile"
   | "auth-epoch"
+  | "message-policy"
   | "system-prompt"
   | "cwd"
   | "mcp"
@@ -69,6 +70,7 @@ type RawTranscriptReseedReason =
 const RAW_TRANSCRIPT_RESEED_ALLOWED_REASONS = new Set<RawTranscriptReseedReason>([
   "missing-transcript",
   "orphaned-tool-use",
+  "message-policy",
   "system-prompt",
   "cwd",
   "mcp",

--- a/src/agents/cli-runner/types.ts
+++ b/src/agents/cli-runner/types.ts
@@ -24,6 +24,7 @@ import type { SkillSnapshot } from "../../skills/types.js";
 import type { BootstrapContextMode } from "../bootstrap-files.js";
 import type { BootstrapContextRunKind } from "../bootstrap-mode.js";
 import type { ResolvedCliBackend } from "../cli-backends.js";
+import type { CliSessionReuseResult } from "../cli-session.js";
 import type { ContextWindowInfo } from "../context-window-guard.js";
 import type { FailoverReason } from "../embedded-agent-helpers.js";
 import type { EmbeddedAgentExecutionPhase } from "../embedded-agent-runner/execution-phase.js";
@@ -167,18 +168,13 @@ export type CliPreparedBackend = {
   env?: Record<string, string>;
 };
 
-/** Reusable CLI session id and the reason it was rejected, when any. */
-export type CliReusableSession = {
-  sessionId?: string;
-  invalidatedReason?:
-    | "auth-profile"
-    | "auth-epoch"
-    | "system-prompt"
-    | "cwd"
-    | "mcp"
-    | "missing-transcript"
-    | "orphaned-tool-use";
-};
+/** Reusable CLI session id, soft content drift, or hard invalidation. */
+export type CliReusableSession =
+  | CliSessionReuseResult
+  | {
+      mode: "invalidate";
+      invalidatedReason: "system-prompt" | "missing-transcript" | "orphaned-tool-use";
+    };
 
 export type CliSessionBindingFacts = {
   extraSystemPromptStatic?: string;

--- a/src/agents/cli-session.test.ts
+++ b/src/agents/cli-session.test.ts
@@ -73,7 +73,7 @@ describe("cli-session helpers", () => {
         mcpConfigHash: "mcp-config-b",
         mcpResumeHash: "mcp-resume-b",
       }),
-    ).toEqual({ sessionId: "cli-session-1" });
+    ).toEqual({ mode: "reuse", sessionId: "cli-session-1" });
   });
 
   it("keeps legacy bindings reusable until richer metadata is persisted", () => {
@@ -90,10 +90,10 @@ describe("cli-session helpers", () => {
         authEpochVersion: 2,
         cwdHash: hashCliSessionText("/work/repo"),
       }),
-    ).toEqual({ sessionId: "legacy-session" });
+    ).toEqual({ mode: "reuse", sessionId: "legacy-session" });
   });
 
-  it("invalidates legacy bindings when auth, prompt, or MCP state changes", () => {
+  it("invalidates legacy bindings on mechanical changes and resumes on content drift", () => {
     const entry: SessionEntry = {
       sessionId: "openclaw-session",
       updatedAt: Date.now(),
@@ -108,21 +108,25 @@ describe("cli-session helpers", () => {
         authEpochVersion: 2,
         authProfileId: "anthropic:work",
       }),
-    ).toEqual({ invalidatedReason: "auth-profile" });
+    ).toEqual({ mode: "invalidate", invalidatedReason: "auth-profile" });
     expect(
       resolveCliSessionReuse({
         binding,
         authEpochVersion: 2,
         extraSystemPromptHash: "prompt-hash",
       }),
-    ).toEqual({ invalidatedReason: "system-prompt" });
+    ).toEqual({
+      mode: "reuse-with-drift",
+      sessionId: "legacy-session",
+      drift: { reasons: ["system-prompt"] },
+    });
     expect(
       resolveCliSessionReuse({
         binding,
         authEpochVersion: 2,
         mcpConfigHash: "mcp-hash",
       }),
-    ).toEqual({ invalidatedReason: "mcp" });
+    ).toEqual({ mode: "invalidate", invalidatedReason: "mcp" });
   });
 
   it("invalidates reuse when stored auth profile or prompt shape changes", () => {
@@ -144,7 +148,7 @@ describe("cli-session helpers", () => {
         extraSystemPromptHash: "prompt-a",
         mcpConfigHash: "mcp-a",
       }),
-    ).toEqual({ invalidatedReason: "auth-profile" });
+    ).toEqual({ mode: "invalidate", invalidatedReason: "auth-profile" });
     expect(
       resolveCliSessionReuse({
         binding,
@@ -154,7 +158,7 @@ describe("cli-session helpers", () => {
         extraSystemPromptHash: "prompt-a",
         mcpConfigHash: "mcp-a",
       }),
-    ).toEqual({ invalidatedReason: "auth-epoch" });
+    ).toEqual({ mode: "invalidate", invalidatedReason: "auth-epoch" });
     expect(
       resolveCliSessionReuse({
         binding,
@@ -164,7 +168,11 @@ describe("cli-session helpers", () => {
         extraSystemPromptHash: "prompt-b",
         mcpConfigHash: "mcp-a",
       }),
-    ).toEqual({ invalidatedReason: "system-prompt" });
+    ).toEqual({
+      mode: "reuse-with-drift",
+      sessionId: "cli-session-1",
+      drift: { reasons: ["system-prompt"] },
+    });
     expect(
       resolveCliSessionReuse({
         binding,
@@ -175,7 +183,11 @@ describe("cli-session helpers", () => {
         promptToolNamesHash: "prompt-tools-b",
         mcpConfigHash: "mcp-a",
       }),
-    ).toEqual({ invalidatedReason: "system-prompt" });
+    ).toEqual({
+      mode: "reuse-with-drift",
+      sessionId: "cli-session-1",
+      drift: { reasons: ["prompt-tools"] },
+    });
     expect(
       resolveCliSessionReuse({
         binding,
@@ -185,7 +197,39 @@ describe("cli-session helpers", () => {
         extraSystemPromptHash: "prompt-a",
         mcpConfigHash: "mcp-b",
       }),
-    ).toEqual({ invalidatedReason: "mcp" });
+    ).toEqual({ mode: "invalidate", invalidatedReason: "mcp" });
+  });
+
+  it("keeps content-drift bindings reusable for queued turns until hashes refresh", () => {
+    const binding = {
+      sessionId: "cli-session-1",
+      authEpochVersion: 2,
+      extraSystemPromptHash: "prompt-a",
+      mcpConfigHash: "mcp-a",
+    };
+    const current = {
+      binding,
+      authEpochVersion: 2,
+      extraSystemPromptHash: "prompt-b",
+      mcpConfigHash: "mcp-a",
+    };
+
+    expect(resolveCliSessionReuse(current)).toEqual({
+      mode: "reuse-with-drift",
+      sessionId: "cli-session-1",
+      drift: { reasons: ["system-prompt"] },
+    });
+    expect(resolveCliSessionReuse(current)).toEqual({
+      mode: "reuse-with-drift",
+      sessionId: "cli-session-1",
+      drift: { reasons: ["system-prompt"] },
+    });
+    expect(
+      resolveCliSessionReuse({
+        ...current,
+        binding: { ...binding, extraSystemPromptHash: "prompt-b" },
+      }),
+    ).toEqual({ mode: "reuse", sessionId: "cli-session-1" });
   });
 
   it("invalidates reuse when message-tool prompt policy changes", () => {
@@ -201,14 +245,14 @@ describe("cli-session helpers", () => {
         authEpochVersion: 2,
         messageToolPolicyHash: "message-policy-b",
       }),
-    ).toEqual({ invalidatedReason: "system-prompt" });
+    ).toEqual({ mode: "invalidate", invalidatedReason: "message-policy" });
     expect(
       resolveCliSessionReuse({
         binding,
         authEpochVersion: 2,
         messageToolPolicyHash: "message-policy-a",
       }),
-    ).toEqual({ sessionId: "cli-session-1" });
+    ).toEqual({ mode: "reuse", sessionId: "cli-session-1" });
   });
 
   it("invalidates reuse when the task cwd changes", () => {
@@ -224,14 +268,14 @@ describe("cli-session helpers", () => {
         authEpochVersion: 2,
         cwdHash: hashCliSessionText("/work/repo-b"),
       }),
-    ).toEqual({ invalidatedReason: "cwd" });
+    ).toEqual({ mode: "invalidate", invalidatedReason: "cwd" });
     expect(
       resolveCliSessionReuse({
         binding,
         authEpochVersion: 2,
         cwdHash: hashCliSessionText("/work/repo-a"),
       }),
-    ).toEqual({ sessionId: "cli-session-1" });
+    ).toEqual({ mode: "reuse", sessionId: "cli-session-1" });
   });
 
   it("does not invalidate legacy metadata before cwd hash backfill", () => {
@@ -241,7 +285,7 @@ describe("cli-session helpers", () => {
         authEpochVersion: 2,
         cwdHash: hashCliSessionText("/work/repo-a"),
       }),
-    ).toEqual({ sessionId: "cli-session-1" });
+    ).toEqual({ mode: "reuse", sessionId: "cli-session-1" });
   });
 
   it("reuses when auth profile ids rotate but the versioned auth epoch is stable", () => {
@@ -263,7 +307,7 @@ describe("cli-session helpers", () => {
         extraSystemPromptHash: "prompt-a",
         mcpConfigHash: "mcp-a",
       }),
-    ).toEqual({ sessionId: "cli-session-1" });
+    ).toEqual({ mode: "reuse", sessionId: "cli-session-1" });
   });
 
   it("accepts unversioned auth epochs for binding upgrades", () => {
@@ -284,7 +328,7 @@ describe("cli-session helpers", () => {
         extraSystemPromptHash: "prompt-a",
         mcpConfigHash: "mcp-a",
       }),
-    ).toEqual({ sessionId: "cli-session-1" });
+    ).toEqual({ mode: "reuse", sessionId: "cli-session-1" });
   });
 
   it("accepts older auth epoch versions for binding upgrades", () => {
@@ -306,7 +350,7 @@ describe("cli-session helpers", () => {
         extraSystemPromptHash: "prompt-a",
         mcpConfigHash: "mcp-a",
       }),
-    ).toEqual({ sessionId: "cli-session-1" });
+    ).toEqual({ mode: "reuse", sessionId: "cli-session-1" });
   });
 
   it("accepts v3 bindings without authEpoch as binding upgrades to v4", () => {
@@ -333,7 +377,7 @@ describe("cli-session helpers", () => {
         extraSystemPromptHash: "prompt-a",
         mcpConfigHash: "mcp-a",
       }),
-    ).toEqual({ sessionId: "cli-session-1" });
+    ).toEqual({ mode: "reuse", sessionId: "cli-session-1" });
   });
 
   it("does not treat model changes as a session mismatch", () => {
@@ -355,7 +399,7 @@ describe("cli-session helpers", () => {
         extraSystemPromptHash: "prompt-a",
         mcpConfigHash: "mcp-a",
       }),
-    ).toEqual({ sessionId: "cli-session-1" });
+    ).toEqual({ mode: "reuse", sessionId: "cli-session-1" });
   });
 
   it("prefers the stable MCP resume hash over the raw MCP config hash", () => {
@@ -379,7 +423,7 @@ describe("cli-session helpers", () => {
         mcpConfigHash: "mcp-config-b",
         mcpResumeHash: "mcp-resume-a",
       }),
-    ).toEqual({ sessionId: "cli-session-1" });
+    ).toEqual({ mode: "reuse", sessionId: "cli-session-1" });
     expect(
       resolveCliSessionReuse({
         binding,
@@ -390,7 +434,7 @@ describe("cli-session helpers", () => {
         mcpConfigHash: "mcp-config-a",
         mcpResumeHash: "mcp-resume-b",
       }),
-    ).toEqual({ invalidatedReason: "mcp" });
+    ).toEqual({ mode: "invalidate", invalidatedReason: "mcp" });
   });
 
   it("falls back to legacy MCP config hashes when stored resume hashes are absent", () => {
@@ -413,7 +457,7 @@ describe("cli-session helpers", () => {
         mcpConfigHash: "mcp-config-a",
         mcpResumeHash: "mcp-resume-a",
       }),
-    ).toEqual({ sessionId: "cli-session-1" });
+    ).toEqual({ mode: "reuse", sessionId: "cli-session-1" });
     expect(
       resolveCliSessionReuse({
         binding,
@@ -424,7 +468,7 @@ describe("cli-session helpers", () => {
         mcpConfigHash: "mcp-config-b",
         mcpResumeHash: "mcp-resume-a",
       }),
-    ).toEqual({ invalidatedReason: "mcp" });
+    ).toEqual({ mode: "invalidate", invalidatedReason: "mcp" });
   });
 
   it("clears provider-scoped and global CLI session state", () => {

--- a/src/agents/cli-session.ts
+++ b/src/agents/cli-session.ts
@@ -106,6 +106,25 @@ export function clearAllCliSessions(entry: Partial<MutableCliSessionFields>): vo
   entry.claudeCliSessionId = undefined;
 }
 
+export type CliSessionInvalidatedReason =
+  | "auth-profile"
+  | "auth-epoch"
+  | "message-policy"
+  | "cwd"
+  | "mcp";
+
+export type CliSessionContentDriftReason = "system-prompt" | "prompt-tools";
+
+export type CliSessionReuseResult =
+  | { mode: "none" }
+  | { mode: "reuse"; sessionId: string }
+  | {
+      mode: "reuse-with-drift";
+      sessionId: string;
+      drift: { reasons: CliSessionContentDriftReason[] };
+    }
+  | { mode: "invalidate"; invalidatedReason: CliSessionInvalidatedReason };
+
 /** Decide whether a stored CLI session can be reused for the current auth/prompt/cwd/MCP state. */
 export function resolveCliSessionReuse(params: {
   binding?: CliSessionBinding;
@@ -118,17 +137,14 @@ export function resolveCliSessionReuse(params: {
   cwdHash?: string;
   mcpConfigHash?: string;
   mcpResumeHash?: string;
-}): {
-  sessionId?: string;
-  invalidatedReason?: "auth-profile" | "auth-epoch" | "system-prompt" | "cwd" | "mcp";
-} {
+}): CliSessionReuseResult {
   const binding = params.binding;
   const sessionId = normalizeOptionalString(binding?.sessionId);
   if (!sessionId) {
-    return {};
+    return { mode: "none" };
   }
   if (binding?.forceReuse === true) {
-    return { sessionId };
+    return { mode: "reuse", sessionId };
   }
   const currentAuthProfileId = normalizeOptionalString(params.authProfileId);
   const currentAuthEpoch = normalizeOptionalString(params.authEpoch);
@@ -147,43 +163,50 @@ export function resolveCliSessionReuse(params: {
     storedAuthEpoch === currentAuthEpoch;
   if (storedAuthProfileId !== currentAuthProfileId) {
     if (!hasMatchingVersionedAuthEpoch) {
-      return { invalidatedReason: "auth-profile" };
+      return { mode: "invalidate", invalidatedReason: "auth-profile" };
     }
   }
   if (
     binding?.authEpochVersion === params.authEpochVersion &&
     storedAuthEpoch !== currentAuthEpoch
   ) {
-    return { invalidatedReason: "auth-epoch" };
-  }
-  const storedExtraSystemPromptHash = normalizeOptionalString(binding?.extraSystemPromptHash);
-  if (storedExtraSystemPromptHash !== currentExtraSystemPromptHash) {
-    return { invalidatedReason: "system-prompt" };
+    return { mode: "invalidate", invalidatedReason: "auth-epoch" };
   }
   const storedMessageToolPolicyHash = normalizeOptionalString(binding?.messageToolPolicyHash);
   if (storedMessageToolPolicyHash !== currentMessageToolPolicyHash) {
-    return { invalidatedReason: "system-prompt" };
-  }
-  const storedPromptToolNamesHash = normalizeOptionalString(binding?.promptToolNamesHash);
-  if (storedPromptToolNamesHash !== currentPromptToolNamesHash) {
-    return { invalidatedReason: "system-prompt" };
+    return { mode: "invalidate", invalidatedReason: "message-policy" };
   }
   const storedCwdHash = normalizeOptionalString(binding?.cwdHash);
   if (storedCwdHash !== undefined && storedCwdHash !== currentCwdHash) {
-    return { invalidatedReason: "cwd" };
+    return { mode: "invalidate", invalidatedReason: "cwd" };
   }
   const storedMcpResumeHash = normalizeOptionalString(binding?.mcpResumeHash);
   if (storedMcpResumeHash && currentMcpResumeHash) {
     // Resume hashes are stricter than raw MCP config hashes: a match proves the
     // exact resumed CLI tool topology still belongs to this session.
     if (storedMcpResumeHash !== currentMcpResumeHash) {
-      return { invalidatedReason: "mcp" };
+      return { mode: "invalidate", invalidatedReason: "mcp" };
     }
-    return { sessionId };
+  } else {
+    const storedMcpConfigHash = normalizeOptionalString(binding?.mcpConfigHash);
+    if (storedMcpConfigHash !== currentMcpConfigHash) {
+      return { mode: "invalidate", invalidatedReason: "mcp" };
+    }
   }
-  const storedMcpConfigHash = normalizeOptionalString(binding?.mcpConfigHash);
-  if (storedMcpConfigHash !== currentMcpConfigHash) {
-    return { invalidatedReason: "mcp" };
+
+  const driftReasons: CliSessionContentDriftReason[] = [];
+  const storedExtraSystemPromptHash = normalizeOptionalString(binding?.extraSystemPromptHash);
+  if (storedExtraSystemPromptHash !== currentExtraSystemPromptHash) {
+    driftReasons.push("system-prompt");
   }
-  return { sessionId };
+  const storedPromptToolNamesHash = normalizeOptionalString(binding?.promptToolNamesHash);
+  if (storedPromptToolNamesHash !== currentPromptToolNamesHash) {
+    driftReasons.push("prompt-tools");
+  }
+  if (driftReasons.length > 0) {
+    // Content drift resumes by contract (#99729): the transcript remains usable.
+    // Deleting this binding here makes queued turns spawn without session history.
+    return { mode: "reuse-with-drift", sessionId, drift: { reasons: driftReasons } };
+  }
+  return { mode: "reuse", sessionId };
 }


### PR DESCRIPTION
Closes #99729
Related: #99640, #99722, #99595, #99372

## What Problem This Solves

Resolves a structural problem where any change to prompt-building code could silently start killing resumed CLI agent sessions. Four production bugs in one cycle (#99372, #99595, #99633, #99696) shared the same mechanism: a per-turn fact leaked into the session reuse fingerprint, and every mismatch hard-invalidated the session — dropping continuity and re-paying full bootstrap cost (~10x prompt payload per turn, measured in #99722). It also fixes the cascade defect where turns queued during an invalidation ran with no history at all (`reuse=none`, `historyPrompt=none`, observed in production).

## Why This Change Was Made

`resolveCliSessionReuse` now returns a closed result (`none | reuse | reuse-with-drift | invalidate`) that classifies fingerprint mismatches by what they mean:

- **Mechanical** (auth profile/epoch, cwd, MCP topology, message-tool delivery policy) — resume cannot work or delivery semantics would silently change: hard invalidate, fresh session, binding deleted. Delivery policy stays mechanical deliberately: a mid-session `message_tool_only` flip changes whether final text is visible, which is a session contract, not content drift.
- **Content drift** (extra system prompt, prompt tool list) — resume anyway: the session is kept, the binding is NOT deleted (this removes the queued-turn history-loss cascade), the executor resends the current system prompt on the drift turn (bundled claude-cli runs `systemPromptWhen: "always"` since #80374, so the resumed turn executes under the *new* instructions with the old transcript — no staleness), and a one-line note in the per-turn context tells the model why instructions shifted. Stored hashes refresh on the next successful run, so drift is reported once. Backends that cannot receive a system prompt on resume (`systemPromptWhen: "never"` / no prompt-arg mechanism) keep the old hard-invalidate behavior via a capability gate.

`invalidatedReason` also stops collapsing message-policy changes into `"system-prompt"` — logs now attribute `message-policy`, `cwd`, `mcp`, auth reasons distinctly, and drift turns log `reuse=reusable-drift:<reasons>`.

## User Impact

CLI-backed agents keep one warm session across prompt-content changes (config tweaks, prompt-builder changes, tool-list changes) instead of restarting; a whole class of future churn regressions becomes impossible to reintroduce via prompt code. Turns queued during a genuine invalidation no longer run history-less. Operators get precise `reuse=` attribution in logs. Mechanical changes (auth, workspace, MCP topology, delivery mode) behave exactly as before.

## Evidence

- Design + production motivation: #99729 (four-bug family, 10.1x prompt-cost table from live deployment).
- Fail-confirmed regression tests: content drift → same session reused, binding preserved, drift note present, hashes refreshed after success; mechanical change → hard invalidate + binding deleted; queued-turn simulation → no history-less spawn on content drift; unsupported-backend → hard invalidate.
- #99640 and #99722 regression tests pass unmodified (hash stability remains the first line of defense; soft resume is the structural backstop).
- Local validation: `pnpm tsgo` 0, `pnpm check:test-types` 0, affected-test sweep 0, `prompt:snapshots:check` 0 (current), oxlint 0, `git diff --check` 0, autoreview clean; re-validated after rebase onto latest main.
- Landed on maintainer instruction without pre-merge canary/CI wait; post-rebase focused validation: cli-session + prepare suites 60/60 green. Live drift-resume observation will follow on the next production deployment.
