### PR TITLE
fix(auto-reply): surface empty interactive completions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ Docs: https://docs.openclaw.ai
 - **Control UI tool-result images:** render direct image content blocks from Gateway history and make the delayed-send scroll E2E setup deterministic. (#100295) Thanks @lzyyzznl.
 - **Plugin approval diagnostics:** surface Gateway validation rejection reasons while keeping transport and availability failures fail-closed. (#100337) Thanks @tzy-17.
 - **IRC Unicode messages:** split outbound PRIVMSG payloads on UTF-16 code-point boundaries so emoji cannot be cut into lone surrogates. (#96572) Thanks @llagy009.
+- **Interactive empty replies:** surface a visible recovery error when direct or queued interactive turns finish without a reply, while preserving intentional silence after message-tool delivery, durable side effects, or compaction progress. (#99824) Thanks @mushuiyu886.
 - **OpenAI realtime voice greetings:** prevent server VAD from creating a second outbound greeting while an explicit greeting response owns the turn, without disabling caller interruption. (#86285) Thanks @giodl73-repo.
 - **iOS Voice Wake cleanup:** avoid initializing the microphone audio pipeline while disabling inactive Voice Wake, preventing simulator launch aborts and unnecessary audio setup.
 - **Cron duration validation:** reject positive durations that truncate below one millisecond instead of silently scheduling a zero-duration interval. (#100311) Thanks @qingminglong.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ Docs: https://docs.openclaw.ai
 - **Control UI tool-result images:** render direct image content blocks from Gateway history and make the delayed-send scroll E2E setup deterministic. (#100295) Thanks @lzyyzznl.
 - **Plugin approval diagnostics:** surface Gateway validation rejection reasons while keeping transport and availability failures fail-closed. (#100337) Thanks @tzy-17.
 - **IRC Unicode messages:** split outbound PRIVMSG payloads on UTF-16 code-point boundaries so emoji cannot be cut into lone surrogates. (#96572) Thanks @llagy009.
-- **Interactive empty replies:** surface a visible recovery error when direct or queued interactive turns finish without a reply, while preserving intentional silence after message-tool delivery, durable side effects, or delivered compaction notices and honoring queued send policies. (#99824) Thanks @mushuiyu886.
+- **Interactive empty replies:** surface a visible recovery error when direct or queued interactive turns finish without a reply, while preserving intentional silence after message-tool delivery or durable side effects, treating compaction notices as progress, and honoring queued send policies. (#99824) Thanks @mushuiyu886.
 - **OpenAI realtime voice greetings:** prevent server VAD from creating a second outbound greeting while an explicit greeting response owns the turn, without disabling caller interruption. (#86285) Thanks @giodl73-repo.
 - **iOS Voice Wake cleanup:** avoid initializing the microphone audio pipeline while disabling inactive Voice Wake, preventing simulator launch aborts and unnecessary audio setup.
 - **Cron duration validation:** reject positive durations that truncate below one millisecond instead of silently scheduling a zero-duration interval. (#100311) Thanks @qingminglong.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ Docs: https://docs.openclaw.ai
 - **Control UI tool-result images:** render direct image content blocks from Gateway history and make the delayed-send scroll E2E setup deterministic. (#100295) Thanks @lzyyzznl.
 - **Plugin approval diagnostics:** surface Gateway validation rejection reasons while keeping transport and availability failures fail-closed. (#100337) Thanks @tzy-17.
 - **IRC Unicode messages:** split outbound PRIVMSG payloads on UTF-16 code-point boundaries so emoji cannot be cut into lone surrogates. (#96572) Thanks @llagy009.
-- **Interactive empty replies:** surface a visible recovery error when direct or queued interactive turns finish without a reply, while preserving intentional silence after message-tool delivery, durable side effects, or compaction progress. (#99824) Thanks @mushuiyu886.
+- **Interactive empty replies:** surface a visible recovery error when direct or queued interactive turns finish without a reply, while preserving intentional silence after message-tool delivery, durable side effects, or delivered compaction notices and honoring queued send policies. (#99824) Thanks @mushuiyu886.
 - **OpenAI realtime voice greetings:** prevent server VAD from creating a second outbound greeting while an explicit greeting response owns the turn, without disabling caller interruption. (#86285) Thanks @giodl73-repo.
 - **iOS Voice Wake cleanup:** avoid initializing the microphone audio pipeline while disabling inactive Voice Wake, preventing simulator launch aborts and unnecessary audio setup.
 - **Cron duration validation:** reject positive durations that truncate below one millisecond instead of silently scheduling a zero-duration interval. (#100311) Thanks @qingminglong.

--- a/src/agents/embedded-agent-runner/delivery-evidence.ts
+++ b/src/agents/embedded-agent-runner/delivery-evidence.ts
@@ -42,6 +42,11 @@ type AgentDeliveryEvidence = {
   };
 };
 
+type SourceReplyDeliveryEvidence = {
+  didDeliverSourceReplyViaMessageTool?: unknown;
+  messagingToolSourceReplyPayloads?: unknown;
+};
+
 function hasNonEmptyString(value: unknown): value is string {
   return typeof value === "string" && value.trim().length > 0;
 }
@@ -52,6 +57,17 @@ function hasNonEmptyArray(value: unknown): boolean {
 
 function hasNonEmptyStringArray(value: unknown): boolean {
   return Array.isArray(value) && value.some(hasNonEmptyString);
+}
+
+function hasVisibleMessagingToolTarget(value: unknown): boolean {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return false;
+  }
+  const target = value as { text?: unknown; mediaUrls?: unknown };
+  if ("text" in target || "mediaUrls" in target) {
+    return hasNonEmptyString(target.text) || hasNonEmptyStringArray(target.mediaUrls);
+  }
+  return true;
 }
 
 function hasVisibleAttachmentReference(value: unknown): boolean {
@@ -224,6 +240,42 @@ export function hasCommittedMessagingToolDeliveryEvidence(
     hasNonEmptyStringArray(result.messagingToolSentTexts) ||
     hasNonEmptyStringArray(result.messagingToolSentMediaUrls) ||
     hasNonEmptyArray(result.messagingToolSentTargets)
+  );
+}
+
+/** Returns whether messaging-tool metadata proves a user-visible committed delivery. */
+export function hasVisibleCommittedMessagingToolDeliveryEvidence(
+  result: Pick<
+    AgentDeliveryEvidence,
+    "messagingToolSentTexts" | "messagingToolSentMediaUrls" | "messagingToolSentTargets"
+  >,
+): boolean {
+  return (
+    hasNonEmptyStringArray(result.messagingToolSentTexts) ||
+    hasNonEmptyStringArray(result.messagingToolSentMediaUrls) ||
+    (Array.isArray(result.messagingToolSentTargets) &&
+      result.messagingToolSentTargets.some(hasVisibleMessagingToolTarget))
+  );
+}
+
+/** Returns whether a source reply was visibly delivered through the message tool. */
+export function hasCommittedSourceReplyDeliveryEvidence(
+  result: SourceReplyDeliveryEvidence,
+): boolean {
+  return (
+    result.didDeliverSourceReplyViaMessageTool === true ||
+    hasVisibleAgentPayload({ payloads: result.messagingToolSourceReplyPayloads })
+  );
+}
+
+/** Returns whether outbound metadata proves a visible message, spawn, or cron side effect. */
+export function hasVisibleOutboundDeliveryEvidence(result: AgentDeliveryEvidence): boolean {
+  return (
+    result.didSendViaMessagingTool === true ||
+    hasVisibleCommittedMessagingToolDeliveryEvidence(result) ||
+    (Array.isArray(result.acceptedSessionSpawns) &&
+      hasAcceptedSessionSpawn(result.acceptedSessionSpawns)) ||
+    hasPositiveNumber(result.successfulCronAdds)
   );
 }
 

--- a/src/auto-reply/reply/agent-runner-execution.ts
+++ b/src/auto-reply/reply/agent-runner-execution.ts
@@ -2142,6 +2142,8 @@ async function runAgentTurnWithFallbackInternal(
             applyReplyToMode: params.applyReplyToMode,
             normalizeMediaPaths: replyMediaContext.normalizePayload,
             typingSignals: params.typingSignals,
+            reasoningPayloadsEnabled: params.opts?.reasoningPayloadsEnabled,
+            commentaryPayloadsEnabled: params.opts?.commentaryPayloadsEnabled,
             blockStreamingEnabled: params.blockStreamingEnabled,
             blockReplyPipeline,
             directlySentBlockKeys,

--- a/src/auto-reply/reply/agent-runner-execution.ts
+++ b/src/auto-reply/reply/agent-runner-execution.ts
@@ -423,6 +423,7 @@ export type AgentRunLoopResult =
       fallbackAttempts: RuntimeFallbackAttempt[];
       didLogHeartbeatStrip: boolean;
       autoCompactionCount: number;
+      didDeliverCompactionNotice: boolean;
       /** Payload keys sent directly (not via pipeline) during tool flush. */
       directlySentBlockKeys?: Set<string>;
       /** Payloads successfully sent directly during tool flush. */
@@ -1800,13 +1801,17 @@ async function runAgentTurnWithFallbackInternal(
   };
   const currentMessageId = params.sessionCtx.MessageSidFull ?? params.sessionCtx.MessageSid;
   const notifyUserAboutCompaction = shouldNotifyUserAboutCompaction(runtimeConfig);
+  let didDeliverCompactionNotice = false;
   const deliverCompactionNoticePayload = async (noticePayload: ReplyPayload, label: string) => {
+    const deliver = params.opts?.onBlockReply ?? params.onCompactionNoticePayload;
+    if (!deliver) {
+      return;
+    }
     try {
-      if (params.opts?.onBlockReply) {
-        await params.opts.onBlockReply(noticePayload);
-        return;
-      }
-      await params.onCompactionNoticePayload?.(noticePayload);
+      await deliver(noticePayload);
+      // Empty-reply recovery must only treat a notice as visible after its
+      // delivery callback resolves; failed or unwired notices remain invisible.
+      didDeliverCompactionNotice = true;
     } catch (err) {
       // Non-critical notice delivery failure should not bubble out of the
       // fire-and-forget event handler.
@@ -3552,6 +3557,7 @@ async function runAgentTurnWithFallbackInternal(
     fallbackAttempts,
     didLogHeartbeatStrip,
     autoCompactionCount,
+    didDeliverCompactionNotice,
     directlySentBlockKeys: directlySentBlockKeys.size > 0 ? directlySentBlockKeys : undefined,
     directlySentBlockPayloads: directlySentBlockPayloads.filter(
       (payload): payload is ReplyPayload => payload !== undefined,

--- a/src/auto-reply/reply/agent-runner-execution.ts
+++ b/src/auto-reply/reply/agent-runner-execution.ts
@@ -423,7 +423,6 @@ export type AgentRunLoopResult =
       fallbackAttempts: RuntimeFallbackAttempt[];
       didLogHeartbeatStrip: boolean;
       autoCompactionCount: number;
-      didDeliverCompactionNotice: boolean;
       /** Payload keys sent directly (not via pipeline) during tool flush. */
       directlySentBlockKeys?: Set<string>;
       /** Payloads successfully sent directly during tool flush. */
@@ -1801,7 +1800,6 @@ async function runAgentTurnWithFallbackInternal(
   };
   const currentMessageId = params.sessionCtx.MessageSidFull ?? params.sessionCtx.MessageSid;
   const notifyUserAboutCompaction = shouldNotifyUserAboutCompaction(runtimeConfig);
-  let didDeliverCompactionNotice = false;
   const deliverCompactionNoticePayload = async (noticePayload: ReplyPayload, label: string) => {
     const deliver = params.opts?.onBlockReply ?? params.onCompactionNoticePayload;
     if (!deliver) {
@@ -1809,9 +1807,6 @@ async function runAgentTurnWithFallbackInternal(
     }
     try {
       await deliver(noticePayload);
-      // Empty-reply recovery must only treat a notice as visible after its
-      // delivery callback resolves; failed or unwired notices remain invisible.
-      didDeliverCompactionNotice = true;
     } catch (err) {
       // Non-critical notice delivery failure should not bubble out of the
       // fire-and-forget event handler.
@@ -3559,7 +3554,6 @@ async function runAgentTurnWithFallbackInternal(
     fallbackAttempts,
     didLogHeartbeatStrip,
     autoCompactionCount,
-    didDeliverCompactionNotice,
     directlySentBlockKeys: directlySentBlockKeys.size > 0 ? directlySentBlockKeys : undefined,
     directlySentBlockPayloads: directlySentBlockPayloads.filter(
       (payload): payload is ReplyPayload => payload !== undefined,

--- a/src/auto-reply/reply/agent-runner.misc.runreplyagent.test.ts
+++ b/src/auto-reply/reply/agent-runner.misc.runreplyagent.test.ts
@@ -503,6 +503,106 @@ describe("runReplyAgent auto-compaction token update", () => {
     expectReplyText(result, "⚠️ Gateway is restarting. Please wait a few seconds and try again.");
   });
 
+  it("surfaces empty interactive direct replies as visible failures", async () => {
+    const sessionKey = "main";
+    const sessionEntry = {
+      sessionId: "session",
+      updatedAt: Date.now(),
+      totalTokens: 50_000,
+    };
+    runEmbeddedAgentMock.mockResolvedValueOnce({
+      payloads: [],
+      meta: {
+        agentMeta: {
+          provider: "anthropic",
+          model: "claude",
+        },
+        finalAssistantVisibleText: "",
+      },
+    });
+
+    const { typing, sessionCtx, resolvedQueue, followupRun } = createBaseRun({
+      storePath: "",
+      sessionEntry,
+    });
+    const result = await runReplyAgent({
+      commandBody: "hello",
+      followupRun,
+      queueKey: sessionKey,
+      resolvedQueue,
+      shouldSteer: false,
+      shouldFollowup: false,
+      isActive: false,
+      isStreaming: false,
+      typing,
+      sessionCtx,
+      sessionEntry,
+      sessionStore: { [sessionKey]: sessionEntry },
+      sessionKey,
+      defaultModel: "anthropic/claude-opus-4-6",
+      agentCfgContextTokens: 200_000,
+      resolvedVerboseLevel: "off",
+      isNewSession: false,
+      blockStreamingEnabled: false,
+      resolvedBlockStreamingBreak: "message_end",
+      shouldInjectGroupIntro: false,
+      typingMode: "instant",
+    });
+
+    const payload = expectRecordFields(result, { isError: true }, "empty interactive fallback");
+    expect(payload.text).toContain("did not produce a visible reply");
+  });
+
+  it("keeps spawn-only empty direct replies silent", async () => {
+    const sessionKey = "main";
+    const sessionEntry = {
+      sessionId: "session",
+      updatedAt: Date.now(),
+      totalTokens: 50_000,
+    };
+    runEmbeddedAgentMock.mockResolvedValueOnce({
+      payloads: [],
+      acceptedSessionSpawns: [{ runId: "child-run", childSessionKey: "agent:main:child" }],
+      meta: {
+        agentMeta: {
+          provider: "anthropic",
+          model: "claude",
+        },
+        finalAssistantVisibleText: "",
+      },
+    });
+
+    const { typing, sessionCtx, resolvedQueue, followupRun } = createBaseRun({
+      storePath: "",
+      sessionEntry,
+    });
+    const result = await runReplyAgent({
+      commandBody: "hello",
+      followupRun,
+      queueKey: sessionKey,
+      resolvedQueue,
+      shouldSteer: false,
+      shouldFollowup: false,
+      isActive: false,
+      isStreaming: false,
+      typing,
+      sessionCtx,
+      sessionEntry,
+      sessionStore: { [sessionKey]: sessionEntry },
+      sessionKey,
+      defaultModel: "anthropic/claude-opus-4-6",
+      agentCfgContextTokens: 200_000,
+      resolvedVerboseLevel: "off",
+      isNewSession: false,
+      blockStreamingEnabled: false,
+      resolvedBlockStreamingBreak: "message_end",
+      shouldInjectGroupIntro: false,
+      typingMode: "instant",
+    });
+
+    expect(result).toBeUndefined();
+  });
+
   it("starts queued followup drain only after clearing the active reply operation", async () => {
     const sessionKey = "main";
     const sessionEntry = {

--- a/src/auto-reply/reply/agent-runner.misc.runreplyagent.test.ts
+++ b/src/auto-reply/reply/agent-runner.misc.runreplyagent.test.ts
@@ -584,6 +584,16 @@ describe("runReplyAgent auto-compaction token update", () => {
     },
   );
 
+  it("threads the empty interactive direct fallback through normal final preparation", async () => {
+    const result = await runEmptyDirectReply(
+      { meta: { agentMeta: {} } },
+      { config: { channels: { whatsapp: { replyToMode: "first" } } } },
+    );
+
+    const payload = expectRecordFields(result, { isError: true }, "empty interactive fallback");
+    expect(payload.replyToId).toBe("msg");
+  });
+
   it("keeps spawn-only empty direct replies silent", async () => {
     expect(
       await runEmptyDirectReply({

--- a/src/auto-reply/reply/agent-runner.misc.runreplyagent.test.ts
+++ b/src/auto-reply/reply/agent-runner.misc.runreplyagent.test.ts
@@ -376,10 +376,8 @@ describe("runReplyAgent auto-compaction token update", () => {
       updatedAt: Date.now(),
       totalTokens: 50_000,
     };
-    const agentMeta = requireRecord(
-      requireRecord(agentResult.meta, "agent result meta").agentMeta,
-      "agent result agent meta",
-    );
+    const resultMeta = requireRecord(agentResult.meta, "agent result meta");
+    const agentMeta = requireRecord(resultMeta.agentMeta, "agent result agent meta");
     runEmbeddedAgentMock.mockImplementationOnce(async (params) => {
       const onAgentEvent = requireRecord(params, "embedded agent params").onAgentEvent;
       if (typeof onAgentEvent === "function") {
@@ -391,6 +389,7 @@ describe("runReplyAgent auto-compaction token update", () => {
         payloads: [],
         ...agentResult,
         meta: {
+          ...resultMeta,
           agentMeta: {
             provider: "anthropic",
             model: "claude",
@@ -594,10 +593,15 @@ describe("runReplyAgent auto-compaction token update", () => {
     ).toBeUndefined();
   });
 
-  it("keeps empty direct replies silent after delivering runtime compaction notices", async () => {
+  it("keeps terminal direct failures silent after delivering runtime compaction notices", async () => {
     const onBlockReply = vi.fn();
     const result = await runEmptyDirectReply(
-      { meta: { agentMeta: {} } },
+      {
+        meta: {
+          agentMeta: {},
+          error: { kind: "tool_result_mismatch", message: "terminal failure after notice" },
+        },
+      },
       {
         agentEvents: [
           { stream: "compaction", data: { phase: "start" } },

--- a/src/auto-reply/reply/agent-runner.misc.runreplyagent.test.ts
+++ b/src/auto-reply/reply/agent-runner.misc.runreplyagent.test.ts
@@ -362,6 +362,59 @@ describe("runReplyAgent auto-compaction token update", () => {
     return { typing, sessionCtx, resolvedQueue, followupRun };
   }
 
+  async function runEmptyDirectReply(agentResult: Record<string, unknown>) {
+    const sessionKey = "main";
+    const sessionEntry = {
+      sessionId: "session",
+      updatedAt: Date.now(),
+      totalTokens: 50_000,
+    };
+    const agentMeta = requireRecord(
+      requireRecord(agentResult.meta, "agent result meta").agentMeta,
+      "agent result agent meta",
+    );
+    runEmbeddedAgentMock.mockResolvedValueOnce({
+      payloads: [],
+      ...agentResult,
+      meta: {
+        agentMeta: {
+          provider: "anthropic",
+          model: "claude",
+          ...agentMeta,
+        },
+        finalAssistantVisibleText: "",
+      },
+    });
+
+    const { typing, sessionCtx, resolvedQueue, followupRun } = createBaseRun({
+      storePath: "",
+      sessionEntry,
+    });
+    return runReplyAgent({
+      commandBody: "hello",
+      followupRun,
+      queueKey: sessionKey,
+      resolvedQueue,
+      shouldSteer: false,
+      shouldFollowup: false,
+      isActive: false,
+      isStreaming: false,
+      typing,
+      sessionCtx,
+      sessionEntry,
+      sessionStore: { [sessionKey]: sessionEntry },
+      sessionKey,
+      defaultModel: "anthropic/claude-opus-4-6",
+      agentCfgContextTokens: 200_000,
+      resolvedVerboseLevel: "off",
+      isNewSession: false,
+      blockStreamingEnabled: false,
+      resolvedBlockStreamingBreak: "message_end",
+      shouldInjectGroupIntro: false,
+      typingMode: "instant",
+    });
+  }
+
   async function runBaseReplyWithAgentMeta(params: {
     agentMeta: Record<string, unknown>;
     collectDiagnostics?: boolean;
@@ -503,104 +556,25 @@ describe("runReplyAgent auto-compaction token update", () => {
     expectReplyText(result, "⚠️ Gateway is restarting. Please wait a few seconds and try again.");
   });
 
-  it("surfaces empty interactive direct replies as visible failures", async () => {
-    const sessionKey = "main";
-    const sessionEntry = {
-      sessionId: "session",
-      updatedAt: Date.now(),
-      totalTokens: 50_000,
-    };
-    runEmbeddedAgentMock.mockResolvedValueOnce({
-      payloads: [],
-      meta: {
-        agentMeta: {
-          provider: "anthropic",
-          model: "claude",
-        },
-        finalAssistantVisibleText: "",
-      },
-    });
-
-    const { typing, sessionCtx, resolvedQueue, followupRun } = createBaseRun({
-      storePath: "",
-      sessionEntry,
-    });
-    const result = await runReplyAgent({
-      commandBody: "hello",
-      followupRun,
-      queueKey: sessionKey,
-      resolvedQueue,
-      shouldSteer: false,
-      shouldFollowup: false,
-      isActive: false,
-      isStreaming: false,
-      typing,
-      sessionCtx,
-      sessionEntry,
-      sessionStore: { [sessionKey]: sessionEntry },
-      sessionKey,
-      defaultModel: "anthropic/claude-opus-4-6",
-      agentCfgContextTokens: 200_000,
-      resolvedVerboseLevel: "off",
-      isNewSession: false,
-      blockStreamingEnabled: false,
-      resolvedBlockStreamingBreak: "message_end",
-      shouldInjectGroupIntro: false,
-      typingMode: "instant",
-    });
-
-    const payload = expectRecordFields(result, { isError: true }, "empty interactive fallback");
-    expect(payload.text).toContain("did not produce a visible reply");
-  });
+  it.each([
+    ["without side effects", { meta: { agentMeta: {} } }],
+    ["after hidden compaction", { meta: { agentMeta: { compactionCount: 1 } } }],
+  ] satisfies Array<[string, Record<string, unknown>]>)(
+    "surfaces empty interactive direct replies %s",
+    async (_label, agentResult) => {
+      const result = await runEmptyDirectReply(agentResult);
+      const payload = expectRecordFields(result, { isError: true }, "empty interactive fallback");
+      expect(payload.text).toContain("did not produce a visible reply");
+    },
+  );
 
   it("keeps spawn-only empty direct replies silent", async () => {
-    const sessionKey = "main";
-    const sessionEntry = {
-      sessionId: "session",
-      updatedAt: Date.now(),
-      totalTokens: 50_000,
-    };
-    runEmbeddedAgentMock.mockResolvedValueOnce({
-      payloads: [],
-      acceptedSessionSpawns: [{ runId: "child-run", childSessionKey: "agent:main:child" }],
-      meta: {
-        agentMeta: {
-          provider: "anthropic",
-          model: "claude",
-        },
-        finalAssistantVisibleText: "",
-      },
-    });
-
-    const { typing, sessionCtx, resolvedQueue, followupRun } = createBaseRun({
-      storePath: "",
-      sessionEntry,
-    });
-    const result = await runReplyAgent({
-      commandBody: "hello",
-      followupRun,
-      queueKey: sessionKey,
-      resolvedQueue,
-      shouldSteer: false,
-      shouldFollowup: false,
-      isActive: false,
-      isStreaming: false,
-      typing,
-      sessionCtx,
-      sessionEntry,
-      sessionStore: { [sessionKey]: sessionEntry },
-      sessionKey,
-      defaultModel: "anthropic/claude-opus-4-6",
-      agentCfgContextTokens: 200_000,
-      resolvedVerboseLevel: "off",
-      isNewSession: false,
-      blockStreamingEnabled: false,
-      resolvedBlockStreamingBreak: "message_end",
-      shouldInjectGroupIntro: false,
-      typingMode: "instant",
-    });
-
-    expect(result).toBeUndefined();
+    expect(
+      await runEmptyDirectReply({
+        acceptedSessionSpawns: [{ runId: "child-run", childSessionKey: "agent:main:child" }],
+        meta: { agentMeta: {} },
+      }),
+    ).toBeUndefined();
   });
 
   it("starts queued followup drain only after clearing the active reply operation", async () => {

--- a/src/auto-reply/reply/agent-runner.misc.runreplyagent.test.ts
+++ b/src/auto-reply/reply/agent-runner.misc.runreplyagent.test.ts
@@ -594,6 +594,24 @@ describe("runReplyAgent auto-compaction token update", () => {
     expect(payload.replyToId).toBe("msg");
   });
 
+  it.each([
+    ["reasoning", { text: "internal reasoning", isReasoning: true }],
+    ["commentary", { text: "internal commentary", isCommentary: true }],
+  ])("surfaces a fallback for disabled %s-only direct output", async (_label, payload) => {
+    const onBlockReply = vi.fn();
+    const result = await runEmptyDirectReply(
+      {
+        payloads: [payload],
+        meta: { agentMeta: {} },
+      },
+      { onBlockReply },
+    );
+
+    const fallback = expectRecordFields(result, { isError: true }, "empty interactive fallback");
+    expect(fallback.text).toContain("did not produce a visible reply");
+    expect(onBlockReply).not.toHaveBeenCalled();
+  });
+
   it("keeps spawn-only empty direct replies silent", async () => {
     expect(
       await runEmptyDirectReply({

--- a/src/auto-reply/reply/agent-runner.misc.runreplyagent.test.ts
+++ b/src/auto-reply/reply/agent-runner.misc.runreplyagent.test.ts
@@ -621,7 +621,7 @@ describe("runReplyAgent auto-compaction token update", () => {
     ).toBeUndefined();
   });
 
-  it("keeps terminal direct failures silent after delivering runtime compaction notices", async () => {
+  it("surfaces terminal direct failures after runtime compaction progress", async () => {
     const onBlockReply = vi.fn();
     const result = await runEmptyDirectReply(
       {
@@ -643,7 +643,7 @@ describe("runReplyAgent auto-compaction token update", () => {
     );
 
     expect(onBlockReply).toHaveBeenCalledTimes(2);
-    expect(result).toBeUndefined();
+    expectRecordFields(result, { isError: true }, "terminal failure");
   });
 
   it("surfaces empty direct replies when runtime compaction notice delivery fails", async () => {

--- a/src/auto-reply/reply/agent-runner.misc.runreplyagent.test.ts
+++ b/src/auto-reply/reply/agent-runner.misc.runreplyagent.test.ts
@@ -362,7 +362,14 @@ describe("runReplyAgent auto-compaction token update", () => {
     return { typing, sessionCtx, resolvedQueue, followupRun };
   }
 
-  async function runEmptyDirectReply(agentResult: Record<string, unknown>) {
+  async function runEmptyDirectReply(
+    agentResult: Record<string, unknown>,
+    options?: {
+      agentEvents?: Array<{ stream: string; data: Record<string, unknown> }>;
+      config?: OpenClawConfig;
+      onBlockReply?: (payload: unknown) => Promise<void> | void;
+    },
+  ) {
     const sessionKey = "main";
     const sessionEntry = {
       sessionId: "session",
@@ -373,22 +380,31 @@ describe("runReplyAgent auto-compaction token update", () => {
       requireRecord(agentResult.meta, "agent result meta").agentMeta,
       "agent result agent meta",
     );
-    runEmbeddedAgentMock.mockResolvedValueOnce({
-      payloads: [],
-      ...agentResult,
-      meta: {
-        agentMeta: {
-          provider: "anthropic",
-          model: "claude",
-          ...agentMeta,
+    runEmbeddedAgentMock.mockImplementationOnce(async (params) => {
+      const onAgentEvent = requireRecord(params, "embedded agent params").onAgentEvent;
+      if (typeof onAgentEvent === "function") {
+        for (const event of options?.agentEvents ?? []) {
+          await onAgentEvent(event);
+        }
+      }
+      return {
+        payloads: [],
+        ...agentResult,
+        meta: {
+          agentMeta: {
+            provider: "anthropic",
+            model: "claude",
+            ...agentMeta,
+          },
+          finalAssistantVisibleText: "",
         },
-        finalAssistantVisibleText: "",
-      },
+      };
     });
 
     const { typing, sessionCtx, resolvedQueue, followupRun } = createBaseRun({
       storePath: "",
       sessionEntry,
+      config: options?.config,
     });
     return runReplyAgent({
       commandBody: "hello",
@@ -399,6 +415,7 @@ describe("runReplyAgent auto-compaction token update", () => {
       shouldFollowup: false,
       isActive: false,
       isStreaming: false,
+      opts: options?.onBlockReply ? { onBlockReply: options.onBlockReply } : undefined,
       typing,
       sessionCtx,
       sessionEntry,
@@ -575,6 +592,42 @@ describe("runReplyAgent auto-compaction token update", () => {
         meta: { agentMeta: {} },
       }),
     ).toBeUndefined();
+  });
+
+  it("keeps empty direct replies silent after delivering runtime compaction notices", async () => {
+    const onBlockReply = vi.fn();
+    const result = await runEmptyDirectReply(
+      { meta: { agentMeta: {} } },
+      {
+        agentEvents: [
+          { stream: "compaction", data: { phase: "start" } },
+          { stream: "compaction", data: { phase: "end", completed: true } },
+        ],
+        config: {
+          agents: { defaults: { compaction: { notifyUser: true } } },
+        },
+        onBlockReply,
+      },
+    );
+
+    expect(onBlockReply).toHaveBeenCalledTimes(2);
+    expect(result).toBeUndefined();
+  });
+
+  it("surfaces empty direct replies when runtime compaction notice delivery fails", async () => {
+    const result = await runEmptyDirectReply(
+      { meta: { agentMeta: {} } },
+      {
+        agentEvents: [{ stream: "compaction", data: { phase: "start" } }],
+        config: {
+          agents: { defaults: { compaction: { notifyUser: true } } },
+        },
+        onBlockReply: vi.fn().mockRejectedValue(new Error("delivery failed")),
+      },
+    );
+
+    const payload = expectRecordFields(result, { isError: true }, "empty interactive fallback");
+    expect(payload.text).toContain("did not produce a visible reply");
   });
 
   it("starts queued followup drain only after clearing the active reply operation", async () => {

--- a/src/auto-reply/reply/agent-runner.ts
+++ b/src/auto-reply/reply/agent-runner.ts
@@ -1963,6 +1963,67 @@ export async function runReplyAgent(params: {
     ) {
       await opts.onObservedReplyDelivery?.();
     }
+    const currentMessageId = sessionCtx.MessageSidFull ?? sessionCtx.MessageSid;
+    // A terminal fallback is built separately after normal payload filtering.
+    // Share this state across deliverable lanes so replyToMode=first still threads
+    // at most one visible payload without hidden reasoning/commentary consuming it.
+    const applyDeliveredReplyToMode = createReplyToModeFilterForChannel(
+      replyToMode,
+      replyToChannel,
+    );
+    const applyFinalReplyToMode = (payload: ReplyPayload) => {
+      const isDisabledReasoningLane =
+        payload.isReasoning === true && opts?.reasoningPayloadsEnabled !== true;
+      const isDisabledCommentaryLane =
+        payload.isCommentary === true && opts?.commentaryPayloadsEnabled !== true;
+      const isFilteredPayload =
+        normalizeReplyPayload(payload, { applyChannelTransforms: false }) === null;
+      return isDisabledReasoningLane || isDisabledCommentaryLane || isFilteredPayload
+        ? payload
+        : applyDeliveredReplyToMode(payload);
+    };
+    const buildFinalPayloads = (payloads: ReplyPayload[]) =>
+      buildReplyPayloads({
+        config: cfg,
+        payloads,
+        isHeartbeat,
+        didLogHeartbeatStrip,
+        silentExpected: followupRun.run.silentExpected,
+        blockStreamingEnabled,
+        blockReplyPipeline,
+        directlySentBlockKeys,
+        directlySentBlockPayloads,
+        replyToMode,
+        replyToChannel,
+        currentMessageId,
+        replyThreading: replyThreadingOverride ?? sessionCtx.ReplyThreading,
+        applyReplyToMode: applyFinalReplyToMode,
+        messageProvider: followupRun.run.messageProvider,
+        messagingToolSentTexts: runResult.messagingToolSentTexts,
+        messagingToolSentMediaUrls: runResult.messagingToolSentMediaUrls,
+        messagingToolSentTargets: runResult.messagingToolSentTargets,
+        originatingChannel: sessionCtx.OriginatingChannel,
+        originatingChatType: sessionCtx.ChatType,
+        originatingTo: resolveOriginMessageTo({
+          originatingTo: sessionCtx.OriginatingTo,
+          to: sessionCtx.To,
+        }),
+        originatingThreadId: replyRouteThreadId,
+        accountId: sessionCtx.AccountId,
+        normalizeMediaPaths: replyMediaContext.normalizePayload,
+      });
+    const returnPreparedFallbackPayload = async (
+      payload: ReplyPayload,
+    ): Promise<ReplyPayload | undefined> => {
+      const result = await buildFinalPayloads([payload]);
+      didLogHeartbeatStrip = result.didLogHeartbeatStrip;
+      const preparedPayload = result.replyPayloads[0];
+      if (!preparedPayload) {
+        return undefined;
+      }
+      await signalTypingIfNeeded([preparedPayload], typingSignals);
+      return returnWithQueuedFollowupDrain(preparedPayload);
+    };
     const returnSilentFallbackFailureIfNeeded = async (): Promise<ReplyPayload | undefined> => {
       const silentFallbackFailurePayload = buildSilentFallbackFailurePayload({
         fallbackTransition,
@@ -1982,8 +2043,7 @@ export async function runReplyAgent(params: {
           `configured model backend ${fallbackTransition.selectedModelRef} failed and fallback ${fallbackTransition.activeModelRef} produced no visible reply`,
         ),
       );
-      await signalTypingIfNeeded([silentFallbackFailurePayload], typingSignals);
-      return returnWithQueuedFollowupDrain(silentFallbackFailurePayload);
+      return returnPreparedFallbackPayload(silentFallbackFailurePayload);
     };
     const returnEmptyInteractiveReplyIfNeeded = async (): Promise<ReplyPayload | undefined> => {
       const emptyInteractiveReplyPayload = buildEmptyInteractiveReplyFallbackPayload({
@@ -2001,8 +2061,7 @@ export async function runReplyAgent(params: {
         "run_failed",
         new Error("empty interactive reply produced no visible payload"),
       );
-      await signalTypingIfNeeded([emptyInteractiveReplyPayload], typingSignals);
-      return returnWithQueuedFollowupDrain(emptyInteractiveReplyPayload);
+      return returnPreparedFallbackPayload(emptyInteractiveReplyPayload);
     };
 
     const fallbackNoticePayloads: ReplyPayload[] = [];
@@ -2092,55 +2151,6 @@ export async function runReplyAgent(params: {
       return returnWithQueuedFollowupDrain(undefined);
     }
 
-    const currentMessageId = sessionCtx.MessageSidFull ?? sessionCtx.MessageSid;
-    // A terminal fallback is built separately after normal payload filtering.
-    // Share this state across deliverable lanes so replyToMode=first still threads
-    // at most one visible payload without hidden reasoning/commentary consuming it.
-    const applyDeliveredReplyToMode = createReplyToModeFilterForChannel(
-      replyToMode,
-      replyToChannel,
-    );
-    const applyFinalReplyToMode = (payload: ReplyPayload) => {
-      const isDisabledReasoningLane =
-        payload.isReasoning === true && opts?.reasoningPayloadsEnabled !== true;
-      const isDisabledCommentaryLane =
-        payload.isCommentary === true && opts?.commentaryPayloadsEnabled !== true;
-      const isFilteredPayload =
-        normalizeReplyPayload(payload, { applyChannelTransforms: false }) === null;
-      return isDisabledReasoningLane || isDisabledCommentaryLane || isFilteredPayload
-        ? payload
-        : applyDeliveredReplyToMode(payload);
-    };
-    const buildFinalPayloads = (payloads: ReplyPayload[]) =>
-      buildReplyPayloads({
-        config: cfg,
-        payloads,
-        isHeartbeat,
-        didLogHeartbeatStrip,
-        silentExpected: followupRun.run.silentExpected,
-        blockStreamingEnabled,
-        blockReplyPipeline,
-        directlySentBlockKeys,
-        directlySentBlockPayloads,
-        replyToMode,
-        replyToChannel,
-        currentMessageId,
-        replyThreading: replyThreadingOverride ?? sessionCtx.ReplyThreading,
-        applyReplyToMode: applyFinalReplyToMode,
-        messageProvider: followupRun.run.messageProvider,
-        messagingToolSentTexts: runResult.messagingToolSentTexts,
-        messagingToolSentMediaUrls: runResult.messagingToolSentMediaUrls,
-        messagingToolSentTargets: runResult.messagingToolSentTargets,
-        originatingChannel: sessionCtx.OriginatingChannel,
-        originatingChatType: sessionCtx.ChatType,
-        originatingTo: resolveOriginMessageTo({
-          originatingTo: sessionCtx.OriginatingTo,
-          to: sessionCtx.To,
-        }),
-        originatingThreadId: replyRouteThreadId,
-        accountId: sessionCtx.AccountId,
-        normalizeMediaPaths: replyMediaContext.normalizePayload,
-      });
     const payloadCandidates =
       fallbackNoticePayloads.length > 0
         ? [...fallbackNoticePayloads, ...payloadArray]

--- a/src/auto-reply/reply/agent-runner.ts
+++ b/src/auto-reply/reply/agent-runner.ts
@@ -1356,6 +1356,7 @@ export async function runReplyAgent(params: {
     requesterSenderE164: followupRun.run.senderE164,
   });
   const compactionNoticeMessageId = sessionCtx.MessageSidFull ?? sessionCtx.MessageSid;
+  let didSendDirectCompactionNoticePayload = false;
   const sendDirectCompactionNotice = shouldNotifyUserAboutCompaction(cfg)
     ? async (phase: CompactionNoticePhase) => {
         if (!opts?.onBlockReply) {
@@ -1368,6 +1369,7 @@ export async function runReplyAgent(params: {
         });
         try {
           await opts.onBlockReply(noticePayload);
+          didSendDirectCompactionNoticePayload = true;
         } catch (err) {
           logVerbose(`preflightCompaction notice delivery failed: ${String(err)}`);
         }
@@ -1945,6 +1947,7 @@ export async function runReplyAgent(params: {
     const committedMessagingToolSourceReplyDelivery =
       hasCommittedSourceReplyDeliveryEvidence(runResult);
     const successfulSideEffectDelivery =
+      didSendDirectCompactionNoticePayload ||
       successfulSourceReplyDelivery ||
       committedMessagingToolSourceReplyDelivery ||
       hasVisibleOutboundDeliveryEvidence(runResult) ||

--- a/src/auto-reply/reply/agent-runner.ts
+++ b/src/auto-reply/reply/agent-runner.ts
@@ -2171,8 +2171,12 @@ export async function runReplyAgent(params: {
       didLogHeartbeatStrip = terminalPayloadResult.didLogHeartbeatStrip;
     }
 
-    const hasReplyPayloadBeyondFallbackNotice = replyPayloads.some(
-      (payload) => !isReplyPayloadStatusNotice(payload),
+    const hasVisibleReplyPayload = replyPayloads.some(
+      (payload) =>
+        !isReplyPayloadStatusNotice(payload) &&
+        (payload.isReasoning !== true || opts?.reasoningPayloadsEnabled === true) &&
+        (payload.isCommentary !== true || opts?.commentaryPayloadsEnabled === true) &&
+        normalizeReplyPayload(payload, { applyChannelTransforms: false }) !== null,
     );
     const hasDeliveredBlockStream = Boolean(
       blockReplyPipeline?.didStream() && !blockReplyPipeline.isAborted(),
@@ -2181,7 +2185,7 @@ export async function runReplyAgent(params: {
       hasDeliveredBlockStream || successfulSideEffectDelivery;
     if (
       replyPayloads.length === 0 ||
-      (!hasReplyPayloadBeyondFallbackNotice && !canDeliverStandaloneFallbackNotice)
+      (!hasVisibleReplyPayload && !canDeliverStandaloneFallbackNotice)
     ) {
       const silentFallbackFailurePayload = await returnSilentFallbackFailureIfNeeded();
       if (silentFallbackFailurePayload) {

--- a/src/auto-reply/reply/agent-runner.ts
+++ b/src/auto-reply/reply/agent-runner.ts
@@ -1737,6 +1737,7 @@ export async function runReplyAgent(params: {
       fallbackModel,
       fallbackExhausted,
       fallbackAttempts,
+      didDeliverCompactionNotice,
       directlySentBlockKeys,
       directlySentBlockPayloads,
       terminalFailurePayload,
@@ -1948,6 +1949,7 @@ export async function runReplyAgent(params: {
       hasCommittedSourceReplyDeliveryEvidence(runResult);
     const successfulSideEffectDelivery =
       didSendDirectCompactionNoticePayload ||
+      didDeliverCompactionNotice ||
       successfulSourceReplyDelivery ||
       committedMessagingToolSourceReplyDelivery ||
       hasVisibleOutboundDeliveryEvidence(runResult) ||

--- a/src/auto-reply/reply/agent-runner.ts
+++ b/src/auto-reply/reply/agent-runner.ts
@@ -2,7 +2,6 @@
 import crypto from "node:crypto";
 import fs from "node:fs/promises";
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
-import { hasAcceptedSessionSpawn } from "../../agents/accepted-session-spawn.js";
 import {
   hasSessionAutoModelFallbackProvenance,
   hasConfiguredModelFallbacks,
@@ -11,7 +10,11 @@ import {
 } from "../../agents/agent-scope.js";
 import { resolveContextTokensForModel } from "../../agents/context.js";
 import { DEFAULT_CONTEXT_TOKENS } from "../../agents/defaults.js";
-import { hasVisibleAgentPayload } from "../../agents/embedded-agent-runner/delivery-evidence.js";
+import {
+  hasCommittedSourceReplyDeliveryEvidence,
+  hasVisibleCommittedMessagingToolDeliveryEvidence,
+  hasVisibleOutboundDeliveryEvidence,
+} from "../../agents/embedded-agent-runner/delivery-evidence.js";
 import {
   formatEmbeddedAgentQueueFailureSummary,
   queueEmbeddedAgentMessageWithOutcomeAsync,
@@ -240,49 +243,6 @@ function resolveReplyRunDeliveryContext(params: {
   });
 }
 
-function hasNonEmptyStringArray(value: unknown): boolean {
-  return Array.isArray(value) && value.some((entry) => typeof entry === "string" && entry.trim());
-}
-
-function hasCommittedMessagingTargetDeliveryEvidence(value: unknown): boolean {
-  if (!Array.isArray(value)) {
-    return false;
-  }
-  return value.some((entry) => {
-    if (!entry || typeof entry !== "object") {
-      return false;
-    }
-    const record = entry as { text?: unknown; mediaUrls?: unknown };
-    if ("text" in record || "mediaUrls" in record) {
-      return (
-        (typeof record.text === "string" && record.text.trim().length > 0) ||
-        hasNonEmptyStringArray(record.mediaUrls)
-      );
-    }
-    return true;
-  });
-}
-
-function hasSuccessfulSideEffectDelivery(params: {
-  blockReplyPipeline: { didStream: () => boolean; isAborted: () => boolean } | null;
-  directlySentBlockKeys?: Set<string>;
-  messagingToolSentTexts?: string[];
-  messagingToolSentMediaUrls?: string[];
-  messagingToolSentTargets?: unknown[];
-  didSendViaMessagingTool?: boolean;
-  acceptedSessionSpawns?: readonly unknown[];
-  successfulCronAdds?: number;
-  didSendDeterministicApprovalPrompt?: boolean;
-}): boolean {
-  return (
-    params.didSendViaMessagingTool === true ||
-    hasSuccessfulSourceReplyDelivery(params) ||
-    hasAcceptedSessionSpawn(params.acceptedSessionSpawns) ||
-    (params.successfulCronAdds ?? 0) > 0 ||
-    params.didSendDeterministicApprovalPrompt === true
-  );
-}
-
 function hasSuccessfulSourceReplyDelivery(params: {
   blockReplyPipeline: { didStream: () => boolean; isAborted: () => boolean } | null;
   directlySentBlockKeys?: Set<string>;
@@ -293,9 +253,7 @@ function hasSuccessfulSourceReplyDelivery(params: {
   return (
     (params.blockReplyPipeline?.didStream() && !params.blockReplyPipeline.isAborted()) ||
     (params.directlySentBlockKeys?.size ?? 0) > 0 ||
-    hasNonEmptyStringArray(params.messagingToolSentTexts) ||
-    hasNonEmptyStringArray(params.messagingToolSentMediaUrls) ||
-    hasCommittedMessagingTargetDeliveryEvidence(params.messagingToolSentTargets)
+    hasVisibleCommittedMessagingToolDeliveryEvidence(params)
   );
 }
 
@@ -1977,17 +1935,6 @@ export async function runReplyAgent(params: {
       preserveFreshTotalTokensOnStaleUsage: preflightCompactionApplied,
     });
 
-    const successfulSideEffectDelivery = hasSuccessfulSideEffectDelivery({
-      blockReplyPipeline,
-      directlySentBlockKeys,
-      messagingToolSentTexts: runResult.messagingToolSentTexts,
-      messagingToolSentMediaUrls: runResult.messagingToolSentMediaUrls,
-      messagingToolSentTargets: runResult.messagingToolSentTargets,
-      didSendViaMessagingTool: runResult.didSendViaMessagingTool,
-      acceptedSessionSpawns: runResult.acceptedSessionSpawns,
-      successfulCronAdds: runResult.successfulCronAdds,
-      didSendDeterministicApprovalPrompt: runResult.didSendDeterministicApprovalPrompt,
-    });
     const successfulSourceReplyDelivery = hasSuccessfulSourceReplyDelivery({
       blockReplyPipeline,
       directlySentBlockKeys,
@@ -1996,12 +1943,14 @@ export async function runReplyAgent(params: {
       messagingToolSentTargets: runResult.messagingToolSentTargets,
     });
     const committedMessagingToolSourceReplyDelivery =
-      runResult.didDeliverSourceReplyViaMessageTool === true ||
-      hasVisibleAgentPayload({ payloads: runResult.messagingToolSourceReplyPayloads });
+      hasCommittedSourceReplyDeliveryEvidence(runResult);
+    const successfulSideEffectDelivery =
+      successfulSourceReplyDelivery ||
+      committedMessagingToolSourceReplyDelivery ||
+      hasVisibleOutboundDeliveryEvidence(runResult) ||
+      runResult.didSendDeterministicApprovalPrompt === true;
     const shouldDeliverTerminalFailure = Boolean(
-      terminalFailurePayload &&
-      !successfulSideEffectDelivery &&
-      !committedMessagingToolSourceReplyDelivery,
+      terminalFailurePayload && !successfulSideEffectDelivery,
     );
     if (
       opts?.sourceReplyDeliveryMode === "message_tool_only" &&
@@ -2034,8 +1983,7 @@ export async function runReplyAgent(params: {
     const returnEmptyInteractiveReplyIfNeeded = async (): Promise<ReplyPayload | undefined> => {
       const emptyInteractiveReplyPayload = buildEmptyInteractiveReplyFallbackPayload({
         isHeartbeat,
-        hasSuccessfulSideEffectDelivery:
-          successfulSideEffectDelivery || committedMessagingToolSourceReplyDelivery,
+        hasSuccessfulSideEffectDelivery: successfulSideEffectDelivery,
         allowEmptyAssistantReplyAsSilent: followupRun.run.allowEmptyAssistantReplyAsSilent,
         silentExpected: followupRun.run.silentExpected,
         sourceReplyDeliveryMode:

--- a/src/auto-reply/reply/agent-runner.ts
+++ b/src/auto-reply/reply/agent-runner.ts
@@ -2,6 +2,7 @@
 import crypto from "node:crypto";
 import fs from "node:fs/promises";
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
+import { hasAcceptedSessionSpawn } from "../../agents/accepted-session-spawn.js";
 import {
   hasSessionAutoModelFallbackProvenance,
   hasConfiguredModelFallbacks,
@@ -94,6 +95,7 @@ import {
   type CompactionNoticePhase,
 } from "./compaction-notice.js";
 import { resolveEffectiveReplyRoute } from "./effective-reply-route.js";
+import { buildEmptyInteractiveReplyFallbackPayload } from "./empty-interactive-reply.js";
 import { createFollowupRunner } from "./followup-runner.js";
 import { REPLY_RUN_STILL_SHUTTING_DOWN_TEXT } from "./get-reply-run-queue.js";
 import { normalizeReplyPayload } from "./normalize-reply.js";
@@ -268,12 +270,14 @@ function hasSuccessfulSideEffectDelivery(params: {
   messagingToolSentMediaUrls?: string[];
   messagingToolSentTargets?: unknown[];
   didSendViaMessagingTool?: boolean;
+  acceptedSessionSpawns?: readonly unknown[];
   successfulCronAdds?: number;
   didSendDeterministicApprovalPrompt?: boolean;
 }): boolean {
   return (
     params.didSendViaMessagingTool === true ||
     hasSuccessfulSourceReplyDelivery(params) ||
+    hasAcceptedSessionSpawn(params.acceptedSessionSpawns) ||
     (params.successfulCronAdds ?? 0) > 0 ||
     params.didSendDeterministicApprovalPrompt === true
   );
@@ -1980,6 +1984,7 @@ export async function runReplyAgent(params: {
       messagingToolSentMediaUrls: runResult.messagingToolSentMediaUrls,
       messagingToolSentTargets: runResult.messagingToolSentTargets,
       didSendViaMessagingTool: runResult.didSendViaMessagingTool,
+      acceptedSessionSpawns: runResult.acceptedSessionSpawns,
       successfulCronAdds: runResult.successfulCronAdds,
       didSendDeterministicApprovalPrompt: runResult.didSendDeterministicApprovalPrompt,
     });
@@ -2025,6 +2030,26 @@ export async function runReplyAgent(params: {
       );
       await signalTypingIfNeeded([silentFallbackFailurePayload], typingSignals);
       return returnWithQueuedFollowupDrain(silentFallbackFailurePayload);
+    };
+    const returnEmptyInteractiveReplyIfNeeded = async (): Promise<ReplyPayload | undefined> => {
+      const emptyInteractiveReplyPayload = buildEmptyInteractiveReplyFallbackPayload({
+        isHeartbeat,
+        hasSuccessfulSideEffectDelivery:
+          successfulSideEffectDelivery || committedMessagingToolSourceReplyDelivery,
+        allowEmptyAssistantReplyAsSilent: followupRun.run.allowEmptyAssistantReplyAsSilent,
+        silentExpected: followupRun.run.silentExpected,
+        sourceReplyDeliveryMode:
+          opts?.sourceReplyDeliveryMode ?? followupRun.run.sourceReplyDeliveryMode,
+      });
+      if (!emptyInteractiveReplyPayload) {
+        return undefined;
+      }
+      replyOperation.fail(
+        "run_failed",
+        new Error("empty interactive reply produced no visible payload"),
+      );
+      await signalTypingIfNeeded([emptyInteractiveReplyPayload], typingSignals);
+      return returnWithQueuedFollowupDrain(emptyInteractiveReplyPayload);
     };
 
     const fallbackNoticePayloads: ReplyPayload[] = [];
@@ -2106,6 +2131,10 @@ export async function runReplyAgent(params: {
       const silentFallbackFailurePayload = await returnSilentFallbackFailureIfNeeded();
       if (silentFallbackFailurePayload) {
         return silentFallbackFailurePayload;
+      }
+      const emptyInteractiveReplyPayload = await returnEmptyInteractiveReplyIfNeeded();
+      if (emptyInteractiveReplyPayload) {
+        return emptyInteractiveReplyPayload;
       }
       return returnWithQueuedFollowupDrain(undefined);
     }
@@ -2194,6 +2223,10 @@ export async function runReplyAgent(params: {
       const silentFallbackFailurePayload = await returnSilentFallbackFailureIfNeeded();
       if (silentFallbackFailurePayload) {
         return silentFallbackFailurePayload;
+      }
+      const emptyInteractiveReplyPayload = await returnEmptyInteractiveReplyIfNeeded();
+      if (emptyInteractiveReplyPayload) {
+        return emptyInteractiveReplyPayload;
       }
       return returnWithQueuedFollowupDrain(undefined);
     }

--- a/src/auto-reply/reply/agent-runner.ts
+++ b/src/auto-reply/reply/agent-runner.ts
@@ -1356,7 +1356,6 @@ export async function runReplyAgent(params: {
     requesterSenderE164: followupRun.run.senderE164,
   });
   const compactionNoticeMessageId = sessionCtx.MessageSidFull ?? sessionCtx.MessageSid;
-  let didSendDirectCompactionNoticePayload = false;
   const sendDirectCompactionNotice = shouldNotifyUserAboutCompaction(cfg)
     ? async (phase: CompactionNoticePhase) => {
         if (!opts?.onBlockReply) {
@@ -1369,7 +1368,6 @@ export async function runReplyAgent(params: {
         });
         try {
           await opts.onBlockReply(noticePayload);
-          didSendDirectCompactionNoticePayload = true;
         } catch (err) {
           logVerbose(`preflightCompaction notice delivery failed: ${String(err)}`);
         }
@@ -1737,7 +1735,6 @@ export async function runReplyAgent(params: {
       fallbackModel,
       fallbackExhausted,
       fallbackAttempts,
-      didDeliverCompactionNotice,
       directlySentBlockKeys,
       directlySentBlockPayloads,
       terminalFailurePayload,
@@ -1948,12 +1945,12 @@ export async function runReplyAgent(params: {
     const committedMessagingToolSourceReplyDelivery =
       hasCommittedSourceReplyDeliveryEvidence(runResult);
     const successfulSideEffectDelivery =
-      didSendDirectCompactionNoticePayload ||
-      didDeliverCompactionNotice ||
       successfulSourceReplyDelivery ||
       committedMessagingToolSourceReplyDelivery ||
       hasVisibleOutboundDeliveryEvidence(runResult) ||
       runResult.didSendDeterministicApprovalPrompt === true;
+    // Compaction notices are progress, not a terminal reply. Dispatcher-backed
+    // delivery settles after this run returns, so it cannot prove turn completion here.
     const shouldDeliverTerminalFailure = Boolean(
       terminalFailurePayload && !successfulSideEffectDelivery,
     );

--- a/src/auto-reply/reply/empty-interactive-reply.ts
+++ b/src/auto-reply/reply/empty-interactive-reply.ts
@@ -1,0 +1,74 @@
+import { hasVisibleAgentPayload } from "../../agents/embedded-agent-runner/delivery-evidence.js";
+import { markReplyPayloadForSourceSuppressionDelivery } from "../reply-payload.js";
+import type { ReplyPayload } from "../types.js";
+
+export const EMPTY_INTERACTIVE_REPLY_FALLBACK_TEXT =
+  "I finished the turn, but it did not produce a visible reply. Please try again, or start a new session if this keeps happening.";
+
+function hasNonEmptyStringArray(value: unknown): boolean {
+  return Array.isArray(value) && value.some((entry) => typeof entry === "string" && entry.trim());
+}
+
+function hasCommittedMessagingTargetDeliveryEvidence(value: unknown): boolean {
+  if (!Array.isArray(value)) {
+    return false;
+  }
+  return value.some((entry) => {
+    if (!entry || typeof entry !== "object") {
+      return false;
+    }
+    const record = entry as { text?: unknown; mediaUrls?: unknown };
+    if ("text" in record || "mediaUrls" in record) {
+      return (
+        (typeof record.text === "string" && record.text.trim().length > 0) ||
+        hasNonEmptyStringArray(record.mediaUrls)
+      );
+    }
+    return true;
+  });
+}
+
+export function hasCommittedSourceReplyDeliveryEvidence(params: {
+  didSendViaMessagingTool?: boolean;
+  didDeliverSourceReplyViaMessageTool?: boolean;
+  messagingToolSentTexts?: string[];
+  messagingToolSentMediaUrls?: string[];
+  messagingToolSentTargets?: unknown[];
+  messagingToolSourceReplyPayloads?: ReplyPayload[];
+}): boolean {
+  return (
+    params.didSendViaMessagingTool === true ||
+    params.didDeliverSourceReplyViaMessageTool === true ||
+    hasNonEmptyStringArray(params.messagingToolSentTexts) ||
+    hasNonEmptyStringArray(params.messagingToolSentMediaUrls) ||
+    hasCommittedMessagingTargetDeliveryEvidence(params.messagingToolSentTargets) ||
+    hasVisibleAgentPayload({ payloads: params.messagingToolSourceReplyPayloads })
+  );
+}
+
+export function buildEmptyInteractiveReplyFallbackPayload(params: {
+  isHeartbeat?: boolean;
+  silentExpected?: boolean;
+  allowEmptyAssistantReplyAsSilent?: boolean;
+  sourceReplyDeliveryMode?: string;
+  hasSuccessfulSideEffectDelivery?: boolean;
+  successfulCronAdds?: number;
+  didSendDeterministicApprovalPrompt?: boolean;
+}): ReplyPayload | undefined {
+  if (
+    params.isHeartbeat === true ||
+    params.silentExpected === true ||
+    params.allowEmptyAssistantReplyAsSilent === true ||
+    params.sourceReplyDeliveryMode === "message_tool_only" ||
+    params.hasSuccessfulSideEffectDelivery === true ||
+    (params.successfulCronAdds ?? 0) > 0 ||
+    params.didSendDeterministicApprovalPrompt === true
+  ) {
+    return undefined;
+  }
+
+  return markReplyPayloadForSourceSuppressionDelivery({
+    text: EMPTY_INTERACTIVE_REPLY_FALLBACK_TEXT,
+    isError: true,
+  });
+}

--- a/src/auto-reply/reply/empty-interactive-reply.ts
+++ b/src/auto-reply/reply/empty-interactive-reply.ts
@@ -1,68 +1,23 @@
-import { hasVisibleAgentPayload } from "../../agents/embedded-agent-runner/delivery-evidence.js";
+import type { SourceReplyDeliveryMode } from "../get-reply-options.types.js";
 import { markReplyPayloadForSourceSuppressionDelivery } from "../reply-payload.js";
 import type { ReplyPayload } from "../types.js";
 
 export const EMPTY_INTERACTIVE_REPLY_FALLBACK_TEXT =
   "I finished the turn, but it did not produce a visible reply. Please try again, or start a new session if this keeps happening.";
 
-function hasNonEmptyStringArray(value: unknown): boolean {
-  return Array.isArray(value) && value.some((entry) => typeof entry === "string" && entry.trim());
-}
-
-function hasCommittedMessagingTargetDeliveryEvidence(value: unknown): boolean {
-  if (!Array.isArray(value)) {
-    return false;
-  }
-  return value.some((entry) => {
-    if (!entry || typeof entry !== "object") {
-      return false;
-    }
-    const record = entry as { text?: unknown; mediaUrls?: unknown };
-    if ("text" in record || "mediaUrls" in record) {
-      return (
-        (typeof record.text === "string" && record.text.trim().length > 0) ||
-        hasNonEmptyStringArray(record.mediaUrls)
-      );
-    }
-    return true;
-  });
-}
-
-export function hasCommittedSourceReplyDeliveryEvidence(params: {
-  didSendViaMessagingTool?: boolean;
-  didDeliverSourceReplyViaMessageTool?: boolean;
-  messagingToolSentTexts?: string[];
-  messagingToolSentMediaUrls?: string[];
-  messagingToolSentTargets?: unknown[];
-  messagingToolSourceReplyPayloads?: ReplyPayload[];
-}): boolean {
-  return (
-    params.didSendViaMessagingTool === true ||
-    params.didDeliverSourceReplyViaMessageTool === true ||
-    hasNonEmptyStringArray(params.messagingToolSentTexts) ||
-    hasNonEmptyStringArray(params.messagingToolSentMediaUrls) ||
-    hasCommittedMessagingTargetDeliveryEvidence(params.messagingToolSentTargets) ||
-    hasVisibleAgentPayload({ payloads: params.messagingToolSourceReplyPayloads })
-  );
-}
-
 export function buildEmptyInteractiveReplyFallbackPayload(params: {
   isHeartbeat?: boolean;
   silentExpected?: boolean;
   allowEmptyAssistantReplyAsSilent?: boolean;
-  sourceReplyDeliveryMode?: string;
+  sourceReplyDeliveryMode?: SourceReplyDeliveryMode;
   hasSuccessfulSideEffectDelivery?: boolean;
-  successfulCronAdds?: number;
-  didSendDeterministicApprovalPrompt?: boolean;
 }): ReplyPayload | undefined {
   if (
     params.isHeartbeat === true ||
     params.silentExpected === true ||
     params.allowEmptyAssistantReplyAsSilent === true ||
     params.sourceReplyDeliveryMode === "message_tool_only" ||
-    params.hasSuccessfulSideEffectDelivery === true ||
-    (params.successfulCronAdds ?? 0) > 0 ||
-    params.didSendDeterministicApprovalPrompt === true
+    params.hasSuccessfulSideEffectDelivery === true
   ) {
     return undefined;
   }

--- a/src/auto-reply/reply/followup-delivery.test.ts
+++ b/src/auto-reply/reply/followup-delivery.test.ts
@@ -48,6 +48,18 @@ describe("resolveFollowupDeliveryPayloads", () => {
     ).toEqual([{ text: "internal reasoning", isReasoning: true }, { text: "final answer" }]);
   });
 
+  it("drops commentary unless its delivery lane is enabled", () => {
+    const payload = { text: "internal commentary", isCommentary: true };
+    expect(resolveFollowupDeliveryPayloads({ cfg: baseConfig, payloads: [payload] })).toEqual([]);
+    expect(
+      resolveFollowupDeliveryPayloads({
+        cfg: baseConfig,
+        payloads: [payload],
+        commentaryPayloadsEnabled: true,
+      }),
+    ).toMatchObject([payload]);
+  });
+
   it("drops heartbeat ack payloads without media", () => {
     expect(
       resolveFollowupDeliveryPayloads({

--- a/src/auto-reply/reply/followup-delivery.test.ts
+++ b/src/auto-reply/reply/followup-delivery.test.ts
@@ -11,14 +11,29 @@ vi.mock("../../channels/plugins/index.js", () => ({
 const baseConfig = {} as OpenClawConfig;
 
 describe("resolveFollowupDeliveryPayloads", () => {
+  it("drops payloads without visible content", () => {
+    expect(
+      resolveFollowupDeliveryPayloads({
+        cfg: baseConfig,
+        payloads: [{ text: " \t\n " }, { text: "", mediaUrls: [" "] }],
+      }),
+    ).toEqual([]);
+  });
+
+  it("keeps rich content when text is blank", () => {
+    expect(
+      resolveFollowupDeliveryPayloads({
+        cfg: baseConfig,
+        payloads: [{ text: " ", mediaUrl: "file:///tmp/reply.png" }],
+      }),
+    ).toMatchObject([{ text: " ", mediaUrl: "file:///tmp/reply.png" }]);
+  });
+
   it("drops a durable reasoning payload when reasoningPayloadsEnabled is not set", () => {
     expect(
       resolveFollowupDeliveryPayloads({
         cfg: baseConfig,
-        payloads: [
-          { text: "internal reasoning", isReasoning: true },
-          { text: "final answer" },
-        ],
+        payloads: [{ text: "internal reasoning", isReasoning: true }, { text: "final answer" }],
       }),
     ).toEqual([{ text: "final answer" }]);
   });
@@ -27,10 +42,7 @@ describe("resolveFollowupDeliveryPayloads", () => {
     expect(
       resolveFollowupDeliveryPayloads({
         cfg: baseConfig,
-        payloads: [
-          { text: "internal reasoning", isReasoning: true },
-          { text: "final answer" },
-        ],
+        payloads: [{ text: "internal reasoning", isReasoning: true }, { text: "final answer" }],
         reasoningPayloadsEnabled: true,
       }),
     ).toEqual([{ text: "internal reasoning", isReasoning: true }, { text: "final answer" }]);

--- a/src/auto-reply/reply/followup-delivery.ts
+++ b/src/auto-reply/reply/followup-delivery.ts
@@ -1,4 +1,5 @@
 /** Prepares queued follow-up payloads for source-channel delivery. */
+import { hasOutboundReplyContent } from "openclaw/plugin-sdk/reply-payload";
 import type { MessagingToolSend } from "../../agents/embedded-agent-messaging.types.js";
 import type { ReplyToMode } from "../../config/types.base.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
@@ -23,14 +24,7 @@ import {
 } from "./reply-payloads.js";
 import { createReplyDeliveryContext, resolveReplyToMode } from "./reply-threading.js";
 
-function hasReplyPayloadMedia(payload: ReplyPayload): boolean {
-  if (typeof payload.mediaUrl === "string" && payload.mediaUrl.trim().length > 0) {
-    return true;
-  }
-  return Array.isArray(payload.mediaUrls) && payload.mediaUrls.some((url) => url.trim().length > 0);
-}
-
-/** Strips heartbeat tokens, applies threading, and dedupes message-tool sends. */
+/** Strips empty/heartbeat payloads, applies threading, and dedupes message-tool sends. */
 export function resolveFollowupDeliveryPayloads(params: {
   cfg: OpenClawConfig;
   payloads: ReplyPayload[];
@@ -75,16 +69,18 @@ export function resolveFollowupDeliveryPayloads(params: {
   const sanitizedPayloads: ReplyPayload[] = [];
   for (const payload of deliverablePayloads) {
     const text = payload.text;
-    if (!text || !text.includes("HEARTBEAT_OK")) {
-      sanitizedPayloads.push(payload);
-      continue;
+    const sanitized =
+      text?.includes("HEARTBEAT_OK") === true
+        ? copyReplyPayloadMetadata(payload, {
+            ...payload,
+            text: stripHeartbeatToken(text, { mode: "message" }).text,
+          })
+        : payload;
+    // Normalize before callers decide whether the run was empty. Otherwise a
+    // whitespace-only model payload can suppress the interactive fallback.
+    if (hasOutboundReplyContent(sanitized, { trimText: true })) {
+      sanitizedPayloads.push(sanitized);
     }
-    const stripped = stripHeartbeatToken(text, { mode: "message" });
-    const hasMedia = hasReplyPayloadMedia(payload);
-    if (stripped.shouldSkip && !hasMedia) {
-      continue;
-    }
-    sanitizedPayloads.push(copyReplyPayloadMetadata(payload, { ...payload, text: stripped.text }));
   }
   const replyTaggedPayloads = applyReplyThreading({
     payloads: sanitizedPayloads,

--- a/src/auto-reply/reply/followup-delivery.ts
+++ b/src/auto-reply/reply/followup-delivery.ts
@@ -36,6 +36,7 @@ export function resolveFollowupDeliveryPayloads(params: {
   originatingTo?: string;
   originatingThreadId?: string | number;
   reasoningPayloadsEnabled?: boolean;
+  commentaryPayloadsEnabled?: boolean;
   sentMediaUrls?: string[];
   sentTargets?: MessagingToolSend[];
   sentTexts?: string[];
@@ -64,7 +65,9 @@ export function resolveFollowupDeliveryPayloads(params: {
       }
     : undefined;
   const deliverablePayloads = params.payloads.filter(
-    (payload) => !(payload.isReasoning === true && params.reasoningPayloadsEnabled !== true),
+    (payload) =>
+      !(payload.isReasoning === true && params.reasoningPayloadsEnabled !== true) &&
+      !(payload.isCommentary === true && params.commentaryPayloadsEnabled !== true),
   );
   const sanitizedPayloads: ReplyPayload[] = [];
   for (const payload of deliverablePayloads) {

--- a/src/auto-reply/reply/followup-runner.test.ts
+++ b/src/auto-reply/reply/followup-runner.test.ts
@@ -12,6 +12,7 @@ import {
   createUserTurnTranscriptRecorder,
   type PersistedUserTurnMessage,
 } from "../../sessions/user-turn-transcript.js";
+import type { GetReplyOptions } from "../types.js";
 import type { FollowupRun, QueueSettings } from "./queue.js";
 
 const runEmbeddedAgentMock = vi.fn();
@@ -4329,13 +4330,14 @@ describe("createFollowupRunner messaging delivery and dedupe", () => {
       sessionStore: Record<string, SessionEntry>;
       sessionKey: string;
       storePath: string;
+      opts: GetReplyOptions;
     }> = {},
   ) {
     if (overrides.storePath && overrides.sessionStore) {
       registerFollowupTestSessionStore(overrides.storePath, overrides.sessionStore);
     }
     return createFollowupRunner({
-      opts: { onBlockReply },
+      opts: { ...overrides.opts, onBlockReply },
       typing: createMockTypingController(),
       typingMode: "instant",
       defaultModel: "anthropic/claude-opus-4-6",
@@ -4354,13 +4356,27 @@ describe("createFollowupRunner messaging delivery and dedupe", () => {
       sessionStore: Record<string, SessionEntry>;
       sessionKey: string;
       storePath: string;
+      opts: GetReplyOptions;
     }>;
+    agentEvent?: { stream: string; data: Record<string, unknown> };
   }) {
     const onBlockReply = createAsyncReplySpy();
-    runEmbeddedAgentMock.mockResolvedValueOnce({
+    const agentResult = {
       meta: {},
       ...params.agentResult,
-    });
+    };
+    if (params.agentEvent) {
+      runEmbeddedAgentMock.mockImplementationOnce(async (runParams: unknown) => {
+        const onAgentEvent = requireRecord(runParams, "embedded run params").onAgentEvent;
+        if (typeof onAgentEvent !== "function") {
+          throw new Error("expected embedded run onAgentEvent callback");
+        }
+        await onAgentEvent(params.agentEvent);
+        return agentResult;
+      });
+    } else {
+      runEmbeddedAgentMock.mockResolvedValueOnce(agentResult);
+    }
     const runner = createMessagingDedupeRunner(onBlockReply, params.runnerOverrides);
     await runner(params.queued ?? baseQueuedRun());
     return { onBlockReply };
@@ -4914,6 +4930,61 @@ describe("createFollowupRunner messaging delivery and dedupe", () => {
     expect(routeReplyMock).toHaveBeenCalledTimes(1);
     const routed = requireMockCallArg(routeReplyMock, 0);
     expect(requireRecord(routed.payload, "fallback payload")).toMatchObject({ isError: true });
+  });
+
+  it("routes the fallback after a hidden compaction retry", async () => {
+    await runMessagingCase({
+      agentResult: { payloads: [] },
+      agentEvent: {
+        stream: "compaction",
+        data: { phase: "end", completed: true, willRetry: true },
+      },
+      queued: {
+        ...baseQueuedRun("discord"),
+        originatingChannel: "discord",
+        originatingTo: "channel:C1",
+      } as FollowupRun,
+    });
+
+    expect(routeReplyMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("honors sendPolicy deny for queued origin delivery", async () => {
+    const onItemEvent = vi.fn();
+    const staleSessionEntry: SessionEntry = {
+      sessionId: "session",
+      updatedAt: Date.now(),
+      sendPolicy: "allow",
+    };
+    const persistedSessionEntry: SessionEntry = {
+      ...staleSessionEntry,
+      sendPolicy: "deny",
+    };
+    const storePath = path.join(tmpdir(), "openclaw-followup-send-policy.json");
+    registerFollowupTestSessionStore(storePath, { main: persistedSessionEntry });
+    const { onBlockReply } = await runMessagingCase({
+      agentResult: { payloads: [{ text: "must stay private" }] },
+      agentEvent: {
+        stream: "item",
+        data: { kind: "preamble", progressText: "also private" },
+      },
+      queued: {
+        ...baseQueuedRun("discord"),
+        originatingChannel: "discord",
+        originatingTo: "channel:C1",
+        run: { ...baseQueuedRun("discord").run, verboseLevel: "on" },
+      } as FollowupRun,
+      runnerOverrides: {
+        sessionEntry: staleSessionEntry,
+        sessionKey: "main",
+        storePath,
+        opts: { onItemEvent },
+      },
+    });
+
+    expect(routeReplyMock).not.toHaveBeenCalled();
+    expect(onBlockReply).not.toHaveBeenCalled();
+    expect(onItemEvent).not.toHaveBeenCalled();
   });
 
   it("keeps empty message-tool-only followup completions silent", async () => {

--- a/src/auto-reply/reply/followup-runner.test.ts
+++ b/src/auto-reply/reply/followup-runner.test.ts
@@ -4958,6 +4958,39 @@ describe("createFollowupRunner messaging delivery and dedupe", () => {
     expect(routeReplyMock).toHaveBeenCalledTimes(1);
   });
 
+  it.each([
+    ["fails", { ok: false, error: "forced route failure" }],
+    ["is hook-suppressed", { ok: true, suppressed: true }],
+  ])("routes the fallback when a compaction notice %s", async (_label, noticeResult) => {
+    routeReplyMock.mockResolvedValueOnce(noticeResult).mockResolvedValue({ ok: true });
+    runEmbeddedAgentMock.mockImplementationOnce(async (runParams: unknown) => {
+      const onAgentEvent = requireRecord(runParams, "embedded run params").onAgentEvent;
+      if (typeof onAgentEvent !== "function") {
+        throw new Error("expected embedded run onAgentEvent callback");
+      }
+      await onAgentEvent({ stream: "compaction", data: { phase: "start" } });
+      return { payloads: [], meta: {} };
+    });
+    const queued = baseQueuedRun("discord");
+    const runner = createFollowupRunner({
+      typing: createMockTypingController(),
+      typingMode: "instant",
+      defaultModel: "anthropic/claude-opus-4-6",
+    });
+
+    await runner({
+      ...queued,
+      originatingChannel: "discord",
+      originatingTo: "channel:C1",
+      run: {
+        ...queued.run,
+        config: { agents: { defaults: { compaction: { notifyUser: true } } } },
+      },
+    });
+
+    expect(routeReplyMock).toHaveBeenCalledTimes(2);
+  });
+
   it("honors sendPolicy deny for queued origin delivery", async () => {
     const onItemEvent = vi.fn();
     const staleSessionEntry: SessionEntry = {

--- a/src/auto-reply/reply/followup-runner.test.ts
+++ b/src/auto-reply/reply/followup-runner.test.ts
@@ -5337,9 +5337,10 @@ describe("createFollowupRunner messaging delivery and dedupe", () => {
 
     await runner(queued);
 
-    expect(routeReplyMock).toHaveBeenCalledTimes(2);
+    expect(routeReplyMock).toHaveBeenCalledTimes(3);
     const startRoute = requireMockCallArg(routeReplyMock, 0);
     const endRoute = requireMockCallArg(routeReplyMock, 1);
+    const fallbackRoute = requireMockCallArg(routeReplyMock, 2);
     expect(startRoute).toMatchObject({
       channel: "discord",
       to: "channel:C1",
@@ -5361,6 +5362,10 @@ describe("createFollowupRunner messaging delivery and dedupe", () => {
       replyToId: "current-msg-1",
       replyToCurrent: true,
       isCompactionNotice: true,
+    });
+    expect(fallbackRoute.replyKind).toBe("final");
+    expect(requireRecord(fallbackRoute.payload, "fallback payload")).toMatchObject({
+      isError: true,
     });
   });
 
@@ -5442,7 +5447,7 @@ describe("createFollowupRunner messaging delivery and dedupe", () => {
       }),
     );
 
-    expect(routeReplyMock).toHaveBeenCalledTimes(4);
+    expect(routeReplyMock).toHaveBeenCalledTimes(5);
     expect(
       requireRecord(requireMockCallArg(routeReplyMock, 0).payload, "hook start"),
     ).toMatchObject({
@@ -5472,6 +5477,11 @@ describe("createFollowupRunner messaging delivery and dedupe", () => {
       replyToId: "current-msg-1",
       replyToCurrent: true,
       isCompactionNotice: true,
+    });
+    const fallbackRoute = requireMockCallArg(routeReplyMock, 4);
+    expect(fallbackRoute.replyKind).toBe("final");
+    expect(requireRecord(fallbackRoute.payload, "fallback payload")).toMatchObject({
+      isError: true,
     });
   });
 
@@ -5510,13 +5520,18 @@ describe("createFollowupRunner messaging delivery and dedupe", () => {
       }),
     );
 
-    expect(routeReplyMock).toHaveBeenCalledTimes(1);
+    expect(routeReplyMock).toHaveBeenCalledTimes(2);
     const payload = requireRecord(requireMockCallArg(routeReplyMock, 0).payload, "notice payload");
     expect(payload).toMatchObject({
       text: "🧹 Compacting context...",
       isCompactionNotice: true,
     });
     expect(payload.replyToId).toBeUndefined();
+    const fallbackRoute = requireMockCallArg(routeReplyMock, 1);
+    expect(fallbackRoute.replyKind).toBe("final");
+    const fallbackPayload = requireRecord(fallbackRoute.payload, "fallback payload");
+    expect(fallbackPayload).toMatchObject({ isError: true });
+    expect(fallbackPayload.replyToId).toBeUndefined();
   });
 
   it("plans queued compaction notices with the active fallback candidate", async () => {

--- a/src/auto-reply/reply/followup-runner.test.ts
+++ b/src/auto-reply/reply/followup-runner.test.ts
@@ -4956,6 +4956,21 @@ describe("createFollowupRunner messaging delivery and dedupe", () => {
     expect(requireRecord(routed.payload, "fallback payload")).toMatchObject({ isError: true });
   });
 
+  it("routes the fallback for disabled commentary-only output", async () => {
+    await runMessagingCase({
+      agentResult: { payloads: [{ text: "internal commentary", isCommentary: true }] },
+      queued: {
+        ...baseQueuedRun("discord"),
+        originatingChannel: "discord",
+        originatingTo: "channel:C1",
+      } as FollowupRun,
+    });
+
+    expect(routeReplyMock).toHaveBeenCalledTimes(1);
+    const routed = requireMockCallArg(routeReplyMock, 0);
+    expect(requireRecord(routed.payload, "fallback payload")).toMatchObject({ isError: true });
+  });
+
   it("routes the fallback after a hidden compaction retry", async () => {
     await runMessagingCase({
       agentResult: { payloads: [] },
@@ -4974,9 +4989,10 @@ describe("createFollowupRunner messaging delivery and dedupe", () => {
   });
 
   it.each([
+    ["succeeds", { ok: true }],
     ["fails", { ok: false, error: "forced route failure" }],
     ["is hook-suppressed", { ok: true, suppressed: true }],
-  ])("routes the fallback when a compaction notice %s", async (_label, noticeResult) => {
+  ])("routes the fallback after compaction progress that %s", async (_label, noticeResult) => {
     routeReplyMock.mockResolvedValueOnce(noticeResult).mockResolvedValue({ ok: true });
     runEmbeddedAgentMock.mockImplementationOnce(async (runParams: unknown) => {
       const onAgentEvent = requireRecord(runParams, "embedded run params").onAgentEvent;

--- a/src/auto-reply/reply/followup-runner.test.ts
+++ b/src/auto-reply/reply/followup-runner.test.ts
@@ -5574,7 +5574,13 @@ describe("createFollowupRunner messaging delivery and dedupe", () => {
       }),
     );
 
-    expect(routeReplyMock).not.toHaveBeenCalled();
+    expect(routeReplyMock).toHaveBeenCalledTimes(1);
+    const routed = requireMockCallArg(routeReplyMock, 0);
+    expect(routed.replyKind).toBe("final");
+    const payload = requireRecord(routed.payload, "fallback payload");
+    expect(payload).toMatchObject({ isError: true });
+    expect(payload.isCompactionNotice).not.toBe(true);
+    expect(String(payload.text)).toContain("did not produce a visible reply");
   });
 });
 

--- a/src/auto-reply/reply/followup-runner.test.ts
+++ b/src/auto-reply/reply/followup-runner.test.ts
@@ -4941,6 +4941,21 @@ describe("createFollowupRunner messaging delivery and dedupe", () => {
     expect(requireRecord(routed.payload, "fallback payload")).toMatchObject({ isError: true });
   });
 
+  it("routes the fallback for a whitespace-only assistant payload", async () => {
+    await runMessagingCase({
+      agentResult: { payloads: [{ text: " \t\n " }] },
+      queued: {
+        ...baseQueuedRun("discord"),
+        originatingChannel: "discord",
+        originatingTo: "channel:C1",
+      } as FollowupRun,
+    });
+
+    expect(routeReplyMock).toHaveBeenCalledTimes(1);
+    const routed = requireMockCallArg(routeReplyMock, 0);
+    expect(requireRecord(routed.payload, "fallback payload")).toMatchObject({ isError: true });
+  });
+
   it("routes the fallback after a hidden compaction retry", async () => {
     await runMessagingCase({
       agentResult: { payloads: [] },

--- a/src/auto-reply/reply/followup-runner.test.ts
+++ b/src/auto-reply/reply/followup-runner.test.ts
@@ -4919,6 +4919,51 @@ describe("createFollowupRunner messaging delivery and dedupe", () => {
     });
   });
 
+  it("retains reply-lane ownership until empty fallback delivery settles", async () => {
+    let releaseDelivery = () => {};
+    const deliveryStarted = new Promise<void>((resolveStarted) => {
+      routeReplyMock.mockImplementationOnce(
+        async () =>
+          await new Promise<{ ok: true }>((resolveDelivery) => {
+            releaseDelivery = () => resolveDelivery({ ok: true });
+            resolveStarted();
+          }),
+      );
+    });
+    runEmbeddedAgentMock.mockResolvedValueOnce({ payloads: [], meta: {} });
+    const runner = createFollowupRunner({
+      typing: createMockTypingController(),
+      typingMode: "instant",
+      sessionKey: "main",
+      defaultModel: "openai/gpt-5.5",
+    });
+
+    const pending = runner(
+      createQueuedRun({
+        originatingChannel: "discord",
+        originatingTo: "channel:C1",
+        run: { sessionKey: "main", sessionId: "active-session", messageProvider: "discord" },
+      }),
+    );
+    await deliveryStarted;
+
+    expect(replyRunRegistryForTest.get("main")?.result).toMatchObject({
+      kind: "failed",
+      code: "run_failed",
+    });
+    expect(() =>
+      createReplyOperationForTest({
+        sessionKey: "main",
+        sessionId: "next-session",
+        resetTriggered: false,
+      }),
+    ).toThrow();
+
+    releaseDelivery();
+    await pending;
+    expect(replyRunRegistryForTest.get("main")).toBeUndefined();
+  });
+
   it("routes the fallback for whitespace-only messaging evidence", async () => {
     await runMessagingCase({
       agentResult: {

--- a/src/auto-reply/reply/followup-runner.test.ts
+++ b/src/auto-reply/reply/followup-runner.test.ts
@@ -46,6 +46,7 @@ let replyRunRegistryForTest: typeof import("./reply-run-registry.js").replyRunRe
 let replyRunTestingForTest: typeof import("./reply-run-registry.js").testing;
 let cliBackendsTestingForTest: typeof import("../../agents/cli-backends.js").testing;
 let setReplyPayloadMetadataForTest: typeof import("../reply-payload.js").setReplyPayloadMetadata;
+let getReplyPayloadMetadataForTest: typeof import("../reply-payload.js").getReplyPayloadMetadata;
 const FOLLOWUP_DEBUG = process.env.OPENCLAW_DEBUG_FOLLOWUP_RUNNER_TEST === "1";
 const FOLLOWUP_TEST_QUEUES = new Map<
   string,
@@ -479,8 +480,10 @@ async function loadFreshFollowupRunnerModuleForTest() {
     replyRunRegistry: replyRunRegistryForTest,
     testing: replyRunTestingForTest,
   } = await import("./reply-run-registry.js"));
-  ({ setReplyPayloadMetadata: setReplyPayloadMetadataForTest } =
-    await import("../reply-payload.js"));
+  ({
+    getReplyPayloadMetadata: getReplyPayloadMetadataForTest,
+    setReplyPayloadMetadata: setReplyPayloadMetadataForTest,
+  } = await import("../reply-payload.js"));
 }
 
 function setFastFollowupCliBackendDeps(): void {
@@ -4891,6 +4894,8 @@ describe("createFollowupRunner messaging delivery and dedupe", () => {
         ...baseQueuedRun("discord"),
         originatingChannel: "discord",
         originatingTo: "channel:C1",
+        originatingChatType: "direct",
+        originatingReplyToMode: "off",
       } as FollowupRun,
     });
 
@@ -4908,6 +4913,10 @@ describe("createFollowupRunner messaging delivery and dedupe", () => {
     expect(String(requireRecord(routed.payload, "fallback payload").text)).toContain(
       "did not produce a visible reply",
     );
+    expect(getReplyPayloadMetadataForTest(routed.payload as never)).toMatchObject({
+      replyDelivery: { chatType: "direct", replyToMode: "off" },
+      replyDeliverySource: { channel: "discord" },
+    });
   });
 
   it("routes the fallback for whitespace-only messaging evidence", async () => {

--- a/src/auto-reply/reply/followup-runner.test.ts
+++ b/src/auto-reply/reply/followup-runner.test.ts
@@ -4894,6 +4894,28 @@ describe("createFollowupRunner messaging delivery and dedupe", () => {
     );
   });
 
+  it("routes the fallback for whitespace-only messaging evidence", async () => {
+    await runMessagingCase({
+      agentResult: {
+        payloads: [],
+        messagingToolSentTexts: ["  "],
+        messagingToolSentMediaUrls: ["\t"],
+        messagingToolSentTargets: [
+          { tool: "message", provider: "discord", to: "channel:C1", text: "  " },
+        ],
+      },
+      queued: {
+        ...baseQueuedRun("discord"),
+        originatingChannel: "discord",
+        originatingTo: "channel:C1",
+      } as FollowupRun,
+    });
+
+    expect(routeReplyMock).toHaveBeenCalledTimes(1);
+    const routed = requireMockCallArg(routeReplyMock, 0);
+    expect(requireRecord(routed.payload, "fallback payload")).toMatchObject({ isError: true });
+  });
+
   it("keeps empty message-tool-only followup completions silent", async () => {
     const queued = baseQueuedRun("discord");
     const { onBlockReply } = await runMessagingCase({
@@ -4913,73 +4935,35 @@ describe("createFollowupRunner messaging delivery and dedupe", () => {
     expect(onBlockReply).not.toHaveBeenCalled();
   });
 
-  it("keeps empty followup completions silent after source delivery", async () => {
-    const { onBlockReply } = await runMessagingCase({
-      agentResult: {
-        payloads: [],
-        didDeliverSourceReplyViaMessageTool: true,
-      },
-      queued: {
-        ...baseQueuedRun("discord"),
-        originatingChannel: "discord",
-        originatingTo: "channel:C1",
-      } as FollowupRun,
-    });
+  it.each([
+    ["source delivery", { didDeliverSourceReplyViaMessageTool: true }],
+    ["source reply payload", { messagingToolSourceReplyPayloads: [{ text: "sent" }] }],
+    [
+      "committed messaging target",
+      { messagingToolSentTargets: [{ tool: "message", provider: "discord", to: "channel:C1" }] },
+    ],
+    [
+      "accepted child-session spawn",
+      { acceptedSessionSpawns: [{ runId: "child-run", childSessionKey: "agent:main:child" }] },
+    ],
+    ["cron side effect", { successfulCronAdds: 1 }],
+    ["deterministic approval prompt", { didSendDeterministicApprovalPrompt: true }],
+  ] satisfies Array<[string, Record<string, unknown>]>)(
+    "keeps empty followup completions silent after %s",
+    async (_label, sideEffectEvidence) => {
+      const { onBlockReply } = await runMessagingCase({
+        agentResult: { payloads: [], ...sideEffectEvidence },
+        queued: {
+          ...baseQueuedRun("discord"),
+          originatingChannel: "discord",
+          originatingTo: "channel:C1",
+        } as FollowupRun,
+      });
 
-    expect(routeReplyMock).not.toHaveBeenCalled();
-    expect(onBlockReply).not.toHaveBeenCalled();
-  });
-
-  it("keeps spawn-only empty followup completions silent", async () => {
-    const { onBlockReply } = await runMessagingCase({
-      agentResult: {
-        payloads: [],
-        acceptedSessionSpawns: [{ runId: "child-run", childSessionKey: "agent:main:child" }],
-      },
-      queued: {
-        ...baseQueuedRun("discord"),
-        originatingChannel: "discord",
-        originatingTo: "channel:C1",
-      } as FollowupRun,
-    });
-
-    expect(routeReplyMock).not.toHaveBeenCalled();
-    expect(onBlockReply).not.toHaveBeenCalled();
-  });
-
-  it("keeps empty followup completions silent after cron side effects", async () => {
-    const { onBlockReply } = await runMessagingCase({
-      agentResult: {
-        payloads: [],
-        successfulCronAdds: 1,
-      },
-      queued: {
-        ...baseQueuedRun("discord"),
-        originatingChannel: "discord",
-        originatingTo: "channel:C1",
-      } as FollowupRun,
-    });
-
-    expect(routeReplyMock).not.toHaveBeenCalled();
-    expect(onBlockReply).not.toHaveBeenCalled();
-  });
-
-  it("keeps empty followup completions silent after deterministic approval prompts", async () => {
-    const { onBlockReply } = await runMessagingCase({
-      agentResult: {
-        payloads: [],
-        didSendDeterministicApprovalPrompt: true,
-      },
-      queued: {
-        ...baseQueuedRun("discord"),
-        originatingChannel: "discord",
-        originatingTo: "channel:C1",
-      } as FollowupRun,
-    });
-
-    expect(routeReplyMock).not.toHaveBeenCalled();
-    expect(onBlockReply).not.toHaveBeenCalled();
-  });
+      expect(routeReplyMock).not.toHaveBeenCalled();
+      expect(onBlockReply).not.toHaveBeenCalled();
+    },
+  );
 
   it("keeps message-tool-only queued followup finals private", async () => {
     const queued = baseQueuedRun("discord");

--- a/src/auto-reply/reply/followup-runner.test.ts
+++ b/src/auto-reply/reply/followup-runner.test.ts
@@ -4868,6 +4868,119 @@ describe("createFollowupRunner messaging delivery and dedupe", () => {
     expectBlockReplyText(onBlockReply, "hello world!");
   });
 
+  it("routes a visible fallback when an interactive followup completes empty", async () => {
+    const { onBlockReply } = await runMessagingCase({
+      agentResult: { payloads: [] },
+      queued: {
+        ...baseQueuedRun("discord"),
+        originatingChannel: "discord",
+        originatingTo: "channel:C1",
+      } as FollowupRun,
+    });
+
+    expect(onBlockReply).not.toHaveBeenCalled();
+    expect(routeReplyMock).toHaveBeenCalledTimes(1);
+    const routed = requireMockCallArg(routeReplyMock, 0);
+    expect(routed).toMatchObject({
+      channel: "discord",
+      to: "channel:C1",
+      replyKind: "final",
+      payload: {
+        isError: true,
+      },
+    });
+    expect(String(requireRecord(routed.payload, "fallback payload").text)).toContain(
+      "did not produce a visible reply",
+    );
+  });
+
+  it("keeps empty message-tool-only followup completions silent", async () => {
+    const queued = baseQueuedRun("discord");
+    const { onBlockReply } = await runMessagingCase({
+      agentResult: { payloads: [] },
+      queued: {
+        ...queued,
+        originatingChannel: "discord",
+        originatingTo: "channel:C1",
+        run: {
+          ...queued.run,
+          sourceReplyDeliveryMode: "message_tool_only",
+        },
+      } as FollowupRun,
+    });
+
+    expect(routeReplyMock).not.toHaveBeenCalled();
+    expect(onBlockReply).not.toHaveBeenCalled();
+  });
+
+  it("keeps empty followup completions silent after source delivery", async () => {
+    const { onBlockReply } = await runMessagingCase({
+      agentResult: {
+        payloads: [],
+        didDeliverSourceReplyViaMessageTool: true,
+      },
+      queued: {
+        ...baseQueuedRun("discord"),
+        originatingChannel: "discord",
+        originatingTo: "channel:C1",
+      } as FollowupRun,
+    });
+
+    expect(routeReplyMock).not.toHaveBeenCalled();
+    expect(onBlockReply).not.toHaveBeenCalled();
+  });
+
+  it("keeps spawn-only empty followup completions silent", async () => {
+    const { onBlockReply } = await runMessagingCase({
+      agentResult: {
+        payloads: [],
+        acceptedSessionSpawns: [{ runId: "child-run", childSessionKey: "agent:main:child" }],
+      },
+      queued: {
+        ...baseQueuedRun("discord"),
+        originatingChannel: "discord",
+        originatingTo: "channel:C1",
+      } as FollowupRun,
+    });
+
+    expect(routeReplyMock).not.toHaveBeenCalled();
+    expect(onBlockReply).not.toHaveBeenCalled();
+  });
+
+  it("keeps empty followup completions silent after cron side effects", async () => {
+    const { onBlockReply } = await runMessagingCase({
+      agentResult: {
+        payloads: [],
+        successfulCronAdds: 1,
+      },
+      queued: {
+        ...baseQueuedRun("discord"),
+        originatingChannel: "discord",
+        originatingTo: "channel:C1",
+      } as FollowupRun,
+    });
+
+    expect(routeReplyMock).not.toHaveBeenCalled();
+    expect(onBlockReply).not.toHaveBeenCalled();
+  });
+
+  it("keeps empty followup completions silent after deterministic approval prompts", async () => {
+    const { onBlockReply } = await runMessagingCase({
+      agentResult: {
+        payloads: [],
+        didSendDeterministicApprovalPrompt: true,
+      },
+      queued: {
+        ...baseQueuedRun("discord"),
+        originatingChannel: "discord",
+        originatingTo: "channel:C1",
+      } as FollowupRun,
+    });
+
+    expect(routeReplyMock).not.toHaveBeenCalled();
+    expect(onBlockReply).not.toHaveBeenCalled();
+  });
+
   it("keeps message-tool-only queued followup finals private", async () => {
     const queued = baseQueuedRun("discord");
     const { onBlockReply } = await runMessagingCase({

--- a/src/auto-reply/reply/followup-runner.ts
+++ b/src/auto-reply/reply/followup-runner.ts
@@ -1464,8 +1464,19 @@ export function createFollowupRunner(params: {
           "run_failed",
           new Error("empty interactive follow-up produced no visible payload"),
         );
+        const deliveryPayloads = resolveFollowupDeliveryPayloads({
+          cfg: runtimeConfig,
+          payloads: [payload],
+          messageProvider: run.messageProvider,
+          originatingAccountId: queued.originatingAccountId ?? run.agentAccountId,
+          originatingChannel: queued.originatingChannel,
+          originatingChatType: queued.originatingChatType,
+          originatingReplyToMode: queued.originatingReplyToMode,
+          originatingTo: queued.originatingTo,
+          originatingThreadId: queued.originatingThreadId,
+        });
         await sendRunPayloads(
-          [payload],
+          deliveryPayloads,
           effectiveQueued,
           {
             provider: providerUsed,

--- a/src/auto-reply/reply/followup-runner.ts
+++ b/src/auto-reply/reply/followup-runner.ts
@@ -44,6 +44,7 @@ import {
 import { formatErrorMessage } from "../../infra/errors.js";
 import { defaultRuntime } from "../../runtime.js";
 import { shouldPreserveUserFacingSessionStateForInputProvenance } from "../../sessions/input-provenance.js";
+import { resolveSendPolicy } from "../../sessions/send-policy.js";
 import { isInternalMessageChannel } from "../../utils/message-channel.js";
 import {
   getReplyPayloadMetadata,
@@ -640,23 +641,38 @@ export function createFollowupRunner(params: {
       if (replyOperation.sessionId !== run.sessionId) {
         run = { ...run, sessionId: replyOperation.sessionId };
         effectiveQueued = { ...effectiveQueued, run };
-        const admittedSessionEntry = replySessionKey
-          ? (sessionStore?.[replySessionKey] ??
-            (storePath
-              ? loadSessionEntry({
-                  storePath,
-                  sessionKey: replySessionKey,
-                })
-              : undefined))
-          : undefined;
-        if (admittedSessionEntry?.sessionId === replyOperation.sessionId) {
-          activeSessionEntry = admittedSessionEntry;
-          if (admittedSessionEntry.sessionFile) {
-            run = { ...run, sessionFile: admittedSessionEntry.sessionFile };
-            effectiveQueued = { ...effectiveQueued, run };
-          }
+      }
+      // Admission may wait while session policy changes. Reload persisted state before any
+      // delivery decision; the enqueue-time in-memory snapshot is not authoritative here.
+      const admittedSessionEntry = replySessionKey
+        ? storePath
+          ? loadSessionEntry({ storePath, sessionKey: replySessionKey })
+          : sessionStore?.[replySessionKey]
+        : undefined;
+      if (admittedSessionEntry?.sessionId === replyOperation.sessionId) {
+        activeSessionEntry = admittedSessionEntry;
+        if (admittedSessionEntry.sessionFile) {
+          run = { ...run, sessionFile: admittedSessionEntry.sessionFile };
+          effectiveQueued = { ...effectiveQueued, run };
         }
       }
+      const sendPolicyDenied =
+        resolveSendPolicy({
+          cfg: runtimeConfig,
+          entry: activeSessionEntry,
+          sessionKey: run.runtimePolicySessionKey ?? replySessionKey,
+          channel: queued.originatingChannel ?? run.messageProvider,
+          chatType: run.chatType ?? activeSessionEntry?.chatType,
+        }) === "deny";
+      const progressOpts = sendPolicyDenied ? undefined : opts;
+      // Carry the admission-time policy through every queued delivery path; direct origin routing
+      // bypasses the outer dispatcher that normally enforces sendPolicy.
+      const sendRunPayloads: typeof sendFollowupPayloads = async (...args) => {
+        if (sendPolicyDenied) {
+          return;
+        }
+        await sendFollowupPayloads(...args);
+      };
       const runId = crypto.randomUUID();
       const shouldSurfaceToControlUi = isInternalMessageChannel(
         resolveOriginMessageProvider({
@@ -665,7 +681,6 @@ export function createFollowupRunner(params: {
         }),
       );
       let autoCompactionCount = 0;
-      let didObserveCompactionRetry = false;
       let runResult: Awaited<ReturnType<typeof runEmbeddedAgent>>;
       let fallbackProvider = run.provider;
       let fallbackModel = run.model;
@@ -702,7 +717,7 @@ export function createFollowupRunner(params: {
         if (noticePayloads.length === 0) {
           return;
         }
-        await sendFollowupPayloads(noticePayloads, effectiveQueued, resolvedRun, {
+        await sendRunPayloads(noticePayloads, effectiveQueued, resolvedRun, {
           kind: "block",
           mirror: false,
           runId,
@@ -762,7 +777,7 @@ export function createFollowupRunner(params: {
             );
             return;
           }
-          await sendFollowupPayloads(
+          await sendRunPayloads(
             [
               markReplyPayloadForSourceSuppressionDelivery({
                 text: preflightCompactionFailureText,
@@ -986,7 +1001,7 @@ export function createFollowupRunner(params: {
                 ) {
                   return;
                 }
-                await sendFollowupPayloads(
+                await sendRunPayloads(
                   [payload],
                   effectiveQueued,
                   {
@@ -1031,9 +1046,9 @@ export function createFollowupRunner(params: {
                   emitLifecycleTerminal: false,
                   onAgentRunStart: () => opts?.onAgentRunStart?.(runId),
                   suppressAssistantBridge: run.silentExpected,
-                  onReasoningText: createCliReasoningStreamBridge(opts?.onReasoningStream),
+                  onReasoningText: createCliReasoningStreamBridge(progressOpts?.onReasoningStream),
                   onReasoningProgress: async (payload) => {
-                    await opts?.onReasoningProgress?.(payload);
+                    await progressOpts?.onReasoningProgress?.(payload);
                   },
                   onToolEvent: async (payload) => {
                     await cliToolSummaryTracker.noteToolEvent(payload);
@@ -1045,20 +1060,20 @@ export function createFollowupRunner(params: {
                         stream: "tool",
                         data: { name: payload.name, phase: payload.phase, args: payload.args },
                       },
-                      opts,
+                      opts: progressOpts,
                       detailMode: toolProgressDetail,
                       emitChannelProgress: shouldEmitToolResultProgress(),
                     });
                   },
                   onCommentaryText:
-                    opts?.commentaryProgressEnabled === true && opts.onItemEvent
+                    progressOpts?.commentaryProgressEnabled === true && progressOpts.onItemEvent
                       ? async ({ text, itemId }) => {
                           await forwardFollowupProgressEvent({
                             evt: {
                               stream: "item",
                               data: { kind: "preamble", progressText: text, itemId },
                             },
-                            opts,
+                            opts: progressOpts,
                             detailMode: toolProgressDetail,
                           });
                         }
@@ -1070,7 +1085,7 @@ export function createFollowupRunner(params: {
                       if (isRoomEventFollowup()) {
                         return;
                       }
-                      await sendFollowupPayloads(
+                      await sendRunPayloads(
                         [payload],
                         effectiveQueued,
                         {
@@ -1284,18 +1299,10 @@ export function createFollowupRunner(params: {
                 onToolResult: deliverFollowupToolSummary,
                 onAgentEvent: (evt) => {
                   lifecycleBackstop.note(evt);
-                  if (
-                    evt.stream === "compaction" &&
-                    evt.data?.phase === "end" &&
-                    evt.data?.completed === true &&
-                    evt.data?.willRetry === true
-                  ) {
-                    didObserveCompactionRetry = true;
-                  }
                   return enqueueProgressDelivery(async () => {
                     await forwardFollowupProgressEvent({
                       evt,
-                      opts,
+                      opts: progressOpts,
                       detailMode: toolProgressDetail,
                       emitChannelProgress: shouldEmitToolResultProgress(),
                       onCompactionComplete: () => {
@@ -1308,7 +1315,7 @@ export function createFollowupRunner(params: {
                     });
                     if (
                       hasFailedFollowupProgressEvent(evt) &&
-                      canForwardFailedFollowupProgressEvent(evt, opts)
+                      canForwardFailedFollowupProgressEvent(evt, progressOpts)
                     ) {
                       markVisibleToolErrorProgress();
                     }
@@ -1443,10 +1450,9 @@ export function createFollowupRunner(params: {
           allowEmptyAssistantReplyAsSilent: run.allowEmptyAssistantReplyAsSilent,
           sourceReplyDeliveryMode: run.sourceReplyDeliveryMode,
           hasSuccessfulSideEffectDelivery:
-            // Compaction progress already gave the user a visible response or continued the turn;
-            // adding an empty-reply error afterward would contradict that lifecycle state.
+            // A delivered compaction notice is already a visible response; adding an empty-reply
+            // error afterward would contradict that lifecycle state.
             didSendCompactionNoticePayload ||
-            didObserveCompactionRetry ||
             hasVisibleOutboundDeliveryEvidence(runResult) ||
             hasCommittedSourceReplyDeliveryEvidence(runResult) ||
             runResult.didSendDeterministicApprovalPrompt === true,
@@ -1458,7 +1464,7 @@ export function createFollowupRunner(params: {
           "run_failed",
           new Error("empty interactive follow-up produced no visible payload"),
         );
-        await sendFollowupPayloads(
+        await sendRunPayloads(
           [payload],
           effectiveQueued,
           {
@@ -1630,7 +1636,7 @@ export function createFollowupRunner(params: {
         return;
       }
 
-      await sendFollowupPayloads(
+      await sendRunPayloads(
         deliveryPayloads,
         effectiveQueued,
         {

--- a/src/auto-reply/reply/followup-runner.ts
+++ b/src/auto-reply/reply/followup-runner.ts
@@ -640,6 +640,9 @@ export function createFollowupRunner(params: {
         return;
       }
       replyOperation = admission.operation;
+      // Failure paths may still drain progress or route a recovery payload. Keep lane ownership
+      // until finally completes so the next turn cannot overtake that asynchronous delivery.
+      replyOperation.retainFailureUntilComplete();
       // Multi-source collected turns become atomic at reply-lane admission.
       // Their queue owner uses this boundary to retire source cancellation ids.
       effectiveQueued.queuedLifecycle?.onAdmitted?.();
@@ -1398,12 +1401,10 @@ export function createFollowupRunner(params: {
             ...terminalMetadata,
             fallbackExhaustedFailure: true,
           });
-          replyOperation.retainFailureUntilComplete();
           replyOperation.fail("run_failed", exhaustionError);
         } else if (deferredLifecycleError || runResult.meta?.error) {
           const terminalError = new Error(terminalErrorMessage ?? "Agent run failed");
           emitSettledLifecycleError(terminalError, terminalMetadata);
-          replyOperation.retainFailureUntilComplete();
           replyOperation.fail("run_failed", terminalError);
         } else {
           settledLifecycleTerminal?.emit("end", runResult);

--- a/src/auto-reply/reply/followup-runner.ts
+++ b/src/auto-reply/reply/followup-runner.ts
@@ -696,7 +696,6 @@ export function createFollowupRunner(params: {
           ? queued.originatingReplyToId
           : queued.messageId;
       const compactionNoticeReplyToId = resolveFollowupCurrentMessageId();
-      let didSendCompactionNoticePayload = false;
       const sendCompactionNoticePayload = async (
         payload: ReplyPayload,
         resolvedRun: { provider: string; modelId: string } = {
@@ -718,16 +717,16 @@ export function createFollowupRunner(params: {
           originatingReplyToMode: queued.originatingReplyToMode,
           originatingTo: queued.originatingTo,
           reasoningPayloadsEnabled: opts?.reasoningPayloadsEnabled === true,
+          commentaryPayloadsEnabled: opts?.commentaryPayloadsEnabled === true,
         });
         if (noticePayloads.length === 0) {
           return;
         }
-        didSendCompactionNoticePayload =
-          (await sendRunPayloads(noticePayloads, effectiveQueued, resolvedRun, {
-            kind: "block",
-            mirror: false,
-            runId,
-          })) || didSendCompactionNoticePayload;
+        await sendRunPayloads(noticePayloads, effectiveQueued, resolvedRun, {
+          kind: "block",
+          mirror: false,
+          runId,
+        });
       };
       const notifyPreflightCompaction = shouldNotifyUserAboutCompaction(runtimeConfig)
         ? async (phase: CompactionNoticePhase) => {
@@ -1455,9 +1454,6 @@ export function createFollowupRunner(params: {
           allowEmptyAssistantReplyAsSilent: run.allowEmptyAssistantReplyAsSilent,
           sourceReplyDeliveryMode: run.sourceReplyDeliveryMode,
           hasSuccessfulSideEffectDelivery:
-            // A delivered compaction notice is already a visible response; adding an empty-reply
-            // error afterward would contradict that lifecycle state.
-            didSendCompactionNoticePayload ||
             hasVisibleOutboundDeliveryEvidence(runResult) ||
             hasCommittedSourceReplyDeliveryEvidence(runResult) ||
             runResult.didSendDeterministicApprovalPrompt === true,
@@ -1541,6 +1537,7 @@ export function createFollowupRunner(params: {
         originatingTo: queued.originatingTo,
         originatingThreadId: queued.originatingThreadId,
         reasoningPayloadsEnabled: opts?.reasoningPayloadsEnabled === true,
+        commentaryPayloadsEnabled: opts?.commentaryPayloadsEnabled === true,
         sentMediaUrls: runResult.messagingToolSentMediaUrls,
         sentTargets: runResult.messagingToolSentTargets,
         sentTexts: runResult.messagingToolSentTexts,

--- a/src/auto-reply/reply/followup-runner.ts
+++ b/src/auto-reply/reply/followup-runner.ts
@@ -2,7 +2,6 @@
 import crypto from "node:crypto";
 import { readStringValue } from "@openclaw/normalization-core/string-coerce";
 import { hasOutboundReplyContent } from "openclaw/plugin-sdk/reply-payload";
-import { hasAcceptedSessionSpawn } from "../../agents/accepted-session-spawn.js";
 import {
   clearAutoFallbackPrimaryProbeSelection,
   entryMatchesAutoFallbackPrimaryProbe,
@@ -12,6 +11,10 @@ import { resolveBootstrapWarningSignaturesSeen } from "../../agents/bootstrap-bu
 import { getCliSessionBinding } from "../../agents/cli-session.js";
 import { resolveContextTokensForModel } from "../../agents/context.js";
 import { DEFAULT_CONTEXT_TOKENS } from "../../agents/defaults.js";
+import {
+  hasCommittedSourceReplyDeliveryEvidence,
+  hasVisibleOutboundDeliveryEvidence,
+} from "../../agents/embedded-agent-runner/delivery-evidence.js";
 import { mergeEmbeddedAgentRunResultForModelFallbackExhaustion } from "../../agents/embedded-agent-runner/result-fallback-classifier.js";
 import { runEmbeddedAgent } from "../../agents/embedded-agent.js";
 import type { FastModeAutoProgressState } from "../../agents/fast-mode.js";
@@ -81,10 +84,7 @@ import {
   shouldNotifyUserAboutCompaction,
   type CompactionNoticePhase,
 } from "./compaction-notice.js";
-import {
-  buildEmptyInteractiveReplyFallbackPayload,
-  hasCommittedSourceReplyDeliveryEvidence,
-} from "./empty-interactive-reply.js";
+import { buildEmptyInteractiveReplyFallbackPayload } from "./empty-interactive-reply.js";
 import { resolveFollowupDeliveryPayloads } from "./followup-delivery.js";
 import { resolveOriginMessageProvider } from "./origin-routing.js";
 import {
@@ -1436,29 +1436,23 @@ export function createFollowupRunner(params: {
       const modelUsed = runResult.meta?.agentMeta?.model ?? fallbackModel ?? defaultModel;
       const providerUsed =
         runResult.meta?.agentMeta?.provider ?? fallbackProvider ?? queued.run.provider;
-      const sendEmptyInteractiveFallbackIfNeeded = async (): Promise<boolean> => {
+      const sendEmptyInteractiveFallbackIfNeeded = async (): Promise<void> => {
         const payload = buildEmptyInteractiveReplyFallbackPayload({
           isHeartbeat: opts?.isHeartbeat === true,
           silentExpected: run.silentExpected,
           allowEmptyAssistantReplyAsSilent: run.allowEmptyAssistantReplyAsSilent,
           sourceReplyDeliveryMode: run.sourceReplyDeliveryMode,
           hasSuccessfulSideEffectDelivery:
+            // Compaction progress already gave the user a visible response or continued the turn;
+            // adding an empty-reply error afterward would contradict that lifecycle state.
             didSendCompactionNoticePayload ||
             didObserveCompactionRetry ||
-            hasAcceptedSessionSpawn(runResult.acceptedSessionSpawns) ||
-            hasCommittedSourceReplyDeliveryEvidence({
-              didSendViaMessagingTool: runResult.didSendViaMessagingTool,
-              didDeliverSourceReplyViaMessageTool: runResult.didDeliverSourceReplyViaMessageTool,
-              messagingToolSentTexts: runResult.messagingToolSentTexts,
-              messagingToolSentMediaUrls: runResult.messagingToolSentMediaUrls,
-              messagingToolSentTargets: runResult.messagingToolSentTargets,
-              messagingToolSourceReplyPayloads: runResult.messagingToolSourceReplyPayloads,
-            }),
-          successfulCronAdds: runResult.successfulCronAdds,
-          didSendDeterministicApprovalPrompt: runResult.didSendDeterministicApprovalPrompt,
+            hasVisibleOutboundDeliveryEvidence(runResult) ||
+            hasCommittedSourceReplyDeliveryEvidence(runResult) ||
+            runResult.didSendDeterministicApprovalPrompt === true,
         });
         if (!payload) {
-          return false;
+          return;
         }
         replyOperation?.fail(
           "run_failed",
@@ -1473,7 +1467,6 @@ export function createFollowupRunner(params: {
           },
           { runId },
         );
-        return true;
       };
       const usedCliProvider = isCliProvider(providerUsed, runtimeConfig);
       const contextTokensUsed =

--- a/src/auto-reply/reply/followup-runner.ts
+++ b/src/auto-reply/reply/followup-runner.ts
@@ -373,7 +373,7 @@ export function createFollowupRunner(params: {
     queued: FollowupRun,
     resolvedRun: { provider: string; modelId: string },
     options: { kind?: ReplyDispatchKind; mirror?: boolean; runId?: string } = {},
-  ) => {
+  ): Promise<boolean> => {
     // Check if we should route to originating channel.
     const { originatingChannel, originatingTo } = queued;
     const runtimeConfig = resolveQueuedReplyRuntimeConfig(queued.run.config);
@@ -392,27 +392,29 @@ export function createFollowupRunner(params: {
     );
 
     if (sendablePayloads.length === 0) {
-      return;
+      return false;
     }
 
     if (!shouldRouteToOriginating && !opts?.onBlockReply) {
       defaultRuntime.error?.(
         "followup queue: completed with payloads but no origin route or visible dispatcher is available",
       );
-      return;
+      return false;
     }
 
+    let deliveredAnyPayload = false;
     let crossChannelRouteFailureNeedsNotice = false;
     let routedAnyCrossChannelPayloadToOrigin = false;
     const replyKind = options.kind ?? "final";
-    const sendDispatcherPayload = async (payload: ReplyPayload) => {
+    const sendDispatcherPayload = async (payload: ReplyPayload): Promise<boolean> => {
       if (!opts?.onBlockReply) {
-        return;
+        return false;
       }
       if (deliveryPlan.isSilentPayload(payload)) {
-        return;
+        return false;
       }
       await opts.onBlockReply(payload);
+      return true;
     };
     for (const payload of sendablePayloads) {
       const providerRoute = deliveryPlan.resolveFollowupRoute({
@@ -473,14 +475,15 @@ export function createFollowupRunner(params: {
           });
           if (opts?.onBlockReply) {
             if (origin && origin === provider) {
-              await sendDispatcherPayload(payload);
+              deliveredAnyPayload = (await sendDispatcherPayload(payload)) || deliveredAnyPayload;
             } else {
               crossChannelRouteFailureNeedsNotice = true;
             }
           } else {
             defaultRuntime.error?.(`followup queue: route-reply failed: ${errorMsg}`);
           }
-        } else {
+        } else if (!result.suppressed) {
+          deliveredAnyPayload = true;
           const provider = resolveOriginMessageProvider({
             provider: queued.run.messageProvider,
           });
@@ -492,7 +495,7 @@ export function createFollowupRunner(params: {
           }
         }
       } else if (deliveryRoute === "dispatcher") {
-        await sendDispatcherPayload(payload);
+        deliveredAnyPayload = (await sendDispatcherPayload(payload)) || deliveredAnyPayload;
       }
     }
     if (
@@ -502,16 +505,18 @@ export function createFollowupRunner(params: {
     ) {
       if (queued.currentInboundEventKind === "room_event") {
         logVerbose("followup queue: cross-channel failure notice suppressed for room_event");
-        return;
+        return deliveredAnyPayload;
       }
-      await sendDispatcherPayload({
-        text:
-          "Follow-up completed, but OpenClaw could not deliver it to the originating " +
-          "channel. The reply content was not forwarded to this channel to avoid " +
-          "cross-channel misdelivery.",
-        isError: true,
-      });
+      deliveredAnyPayload =
+        (await sendDispatcherPayload({
+          text:
+            "Follow-up completed, but OpenClaw could not deliver it to the originating " +
+            "channel. The reply content was not forwarded to this channel to avoid " +
+            "cross-channel misdelivery.",
+          isError: true,
+        })) || deliveredAnyPayload;
     }
+    return deliveredAnyPayload;
   };
 
   return async (queued: FollowupRun) => {
@@ -669,9 +674,9 @@ export function createFollowupRunner(params: {
       // bypasses the outer dispatcher that normally enforces sendPolicy.
       const sendRunPayloads: typeof sendFollowupPayloads = async (...args) => {
         if (sendPolicyDenied) {
-          return;
+          return false;
         }
-        await sendFollowupPayloads(...args);
+        return sendFollowupPayloads(...args);
       };
       const runId = crypto.randomUUID();
       const shouldSurfaceToControlUi = isInternalMessageChannel(
@@ -717,12 +722,12 @@ export function createFollowupRunner(params: {
         if (noticePayloads.length === 0) {
           return;
         }
-        await sendRunPayloads(noticePayloads, effectiveQueued, resolvedRun, {
-          kind: "block",
-          mirror: false,
-          runId,
-        });
-        didSendCompactionNoticePayload = true;
+        didSendCompactionNoticePayload =
+          (await sendRunPayloads(noticePayloads, effectiveQueued, resolvedRun, {
+            kind: "block",
+            mirror: false,
+            runId,
+          })) || didSendCompactionNoticePayload;
       };
       const notifyPreflightCompaction = shouldNotifyUserAboutCompaction(runtimeConfig)
         ? async (phase: CompactionNoticePhase) => {

--- a/src/auto-reply/reply/followup-runner.ts
+++ b/src/auto-reply/reply/followup-runner.ts
@@ -2,6 +2,7 @@
 import crypto from "node:crypto";
 import { readStringValue } from "@openclaw/normalization-core/string-coerce";
 import { hasOutboundReplyContent } from "openclaw/plugin-sdk/reply-payload";
+import { hasAcceptedSessionSpawn } from "../../agents/accepted-session-spawn.js";
 import {
   clearAutoFallbackPrimaryProbeSelection,
   entryMatchesAutoFallbackPrimaryProbe,
@@ -80,6 +81,10 @@ import {
   shouldNotifyUserAboutCompaction,
   type CompactionNoticePhase,
 } from "./compaction-notice.js";
+import {
+  buildEmptyInteractiveReplyFallbackPayload,
+  hasCommittedSourceReplyDeliveryEvidence,
+} from "./empty-interactive-reply.js";
 import { resolveFollowupDeliveryPayloads } from "./followup-delivery.js";
 import { resolveOriginMessageProvider } from "./origin-routing.js";
 import {
@@ -660,6 +665,7 @@ export function createFollowupRunner(params: {
         }),
       );
       let autoCompactionCount = 0;
+      let didObserveCompactionRetry = false;
       let runResult: Awaited<ReturnType<typeof runEmbeddedAgent>>;
       let fallbackProvider = run.provider;
       let fallbackModel = run.model;
@@ -670,6 +676,7 @@ export function createFollowupRunner(params: {
           ? queued.originatingReplyToId
           : queued.messageId;
       const compactionNoticeReplyToId = resolveFollowupCurrentMessageId();
+      let didSendCompactionNoticePayload = false;
       const sendCompactionNoticePayload = async (
         payload: ReplyPayload,
         resolvedRun: { provider: string; modelId: string } = {
@@ -700,6 +707,7 @@ export function createFollowupRunner(params: {
           mirror: false,
           runId,
         });
+        didSendCompactionNoticePayload = true;
       };
       const notifyPreflightCompaction = shouldNotifyUserAboutCompaction(runtimeConfig)
         ? async (phase: CompactionNoticePhase) => {
@@ -1276,6 +1284,14 @@ export function createFollowupRunner(params: {
                 onToolResult: deliverFollowupToolSummary,
                 onAgentEvent: (evt) => {
                   lifecycleBackstop.note(evt);
+                  if (
+                    evt.stream === "compaction" &&
+                    evt.data?.phase === "end" &&
+                    evt.data?.completed === true &&
+                    evt.data?.willRetry === true
+                  ) {
+                    didObserveCompactionRetry = true;
+                  }
                   return enqueueProgressDelivery(async () => {
                     await forwardFollowupProgressEvent({
                       evt,
@@ -1420,6 +1436,45 @@ export function createFollowupRunner(params: {
       const modelUsed = runResult.meta?.agentMeta?.model ?? fallbackModel ?? defaultModel;
       const providerUsed =
         runResult.meta?.agentMeta?.provider ?? fallbackProvider ?? queued.run.provider;
+      const sendEmptyInteractiveFallbackIfNeeded = async (): Promise<boolean> => {
+        const payload = buildEmptyInteractiveReplyFallbackPayload({
+          isHeartbeat: opts?.isHeartbeat === true,
+          silentExpected: run.silentExpected,
+          allowEmptyAssistantReplyAsSilent: run.allowEmptyAssistantReplyAsSilent,
+          sourceReplyDeliveryMode: run.sourceReplyDeliveryMode,
+          hasSuccessfulSideEffectDelivery:
+            didSendCompactionNoticePayload ||
+            didObserveCompactionRetry ||
+            hasAcceptedSessionSpawn(runResult.acceptedSessionSpawns) ||
+            hasCommittedSourceReplyDeliveryEvidence({
+              didSendViaMessagingTool: runResult.didSendViaMessagingTool,
+              didDeliverSourceReplyViaMessageTool: runResult.didDeliverSourceReplyViaMessageTool,
+              messagingToolSentTexts: runResult.messagingToolSentTexts,
+              messagingToolSentMediaUrls: runResult.messagingToolSentMediaUrls,
+              messagingToolSentTargets: runResult.messagingToolSentTargets,
+              messagingToolSourceReplyPayloads: runResult.messagingToolSourceReplyPayloads,
+            }),
+          successfulCronAdds: runResult.successfulCronAdds,
+          didSendDeterministicApprovalPrompt: runResult.didSendDeterministicApprovalPrompt,
+        });
+        if (!payload) {
+          return false;
+        }
+        replyOperation?.fail(
+          "run_failed",
+          new Error("empty interactive follow-up produced no visible payload"),
+        );
+        await sendFollowupPayloads(
+          [payload],
+          effectiveQueued,
+          {
+            provider: providerUsed,
+            modelId: modelUsed,
+          },
+          { runId },
+        );
+        return true;
+      };
       const usedCliProvider = isCliProvider(providerUsed, runtimeConfig);
       const contextTokensUsed =
         resolveContextTokensForModel({
@@ -1457,6 +1512,7 @@ export function createFollowupRunner(params: {
 
       const payloadArray = runResult.payloads ?? [];
       if (payloadArray.length === 0) {
+        await sendEmptyInteractiveFallbackIfNeeded();
         return;
       }
       const finalPayloads = resolveFollowupDeliveryPayloads({
@@ -1476,6 +1532,7 @@ export function createFollowupRunner(params: {
       });
 
       if (finalPayloads.length === 0) {
+        await sendEmptyInteractiveFallbackIfNeeded();
         return;
       }
 

--- a/src/auto-reply/reply/reply-delivery.test.ts
+++ b/src/auto-reply/reply/reply-delivery.test.ts
@@ -15,6 +15,36 @@ type BlockReplyPipelineLike = NonNullable<
 >;
 
 describe("createBlockReplyDeliveryHandler", () => {
+  it.each([
+    ["reasoning", { text: "internal reasoning", isReasoning: true }, "reasoningPayloadsEnabled"],
+    [
+      "commentary",
+      { text: "internal commentary", isCommentary: true },
+      "commentaryPayloadsEnabled",
+    ],
+  ] as const)("gates %s before delivery bookkeeping", async (_label, payload, enabledFlag) => {
+    const onBlockReply = vi.fn(async () => {});
+    const enqueue = vi.fn();
+    const baseParams = {
+      onBlockReply,
+      normalizeStreamingText: (reply: ReplyPayload) => ({ text: reply.text, skip: false }),
+      applyReplyToMode: (reply: ReplyPayload) => reply,
+      typingSignals: {
+        signalTextDelta: vi.fn(async () => {}),
+      } as unknown as TypingSignaler,
+      blockStreamingEnabled: true,
+      blockReplyPipeline: { enqueue } as unknown as BlockReplyPipelineLike,
+      directlySentBlockKeys: new Set<string>(),
+      directlySentBlockPayloads: [],
+    };
+
+    await createBlockReplyDeliveryHandler(baseParams)(payload);
+    expect(enqueue).not.toHaveBeenCalled();
+
+    await createBlockReplyDeliveryHandler({ ...baseParams, [enabledFlag]: true })(payload);
+    expect(enqueue).toHaveBeenCalledTimes(1);
+  });
+
   it("sends captioned media-bearing block replies when block streaming is disabled", async () => {
     const onBlockReply = vi.fn(async () => {});
     const normalizeStreamingText = vi.fn((payload: { text?: string }) => ({

--- a/src/auto-reply/reply/reply-delivery.ts
+++ b/src/auto-reply/reply/reply-delivery.ts
@@ -96,12 +96,22 @@ export function createBlockReplyDeliveryHandler(params: {
   applyReplyToMode: (payload: ReplyPayload) => ReplyPayload;
   normalizeMediaPaths?: (payload: ReplyPayload) => Promise<ReplyPayload>;
   typingSignals: TypingSignaler;
+  reasoningPayloadsEnabled?: boolean;
+  commentaryPayloadsEnabled?: boolean;
   blockStreamingEnabled: boolean;
   blockReplyPipeline: BlockReplyPipeline | null;
   directlySentBlockKeys: Set<string>;
   directlySentBlockPayloads: Array<ReplyPayload | undefined>;
 }): (payload: ReplyPayload) => Promise<void> {
   return async (payload) => {
+    // Suppressed display lanes must not enter delivery bookkeeping: callers use
+    // that evidence to decide whether an otherwise empty turn needs a fallback.
+    if (
+      (payload.isReasoning === true && params.reasoningPayloadsEnabled !== true) ||
+      (payload.isCommentary === true && params.commentaryPayloadsEnabled !== true)
+    ) {
+      return;
+    }
     const { text, skip } = params.normalizeStreamingText(payload);
     if (skip && !hasOutboundReplyContent({ ...payload, text: undefined })) {
       return;
@@ -185,9 +195,8 @@ export function createBlockReplyDeliveryHandler(params: {
       blockPayload.isReasoning === true ||
       blockPayload.isCommentary === true
     ) {
-      // Reasoning and commentary are separate display lanes that never merge into
-      // the assistant's final text, so they must be delivered directly even when
-      // block streaming is off; presentation gating stays downstream (dispatch gate).
+      // Enabled display lanes never merge into final text, so deliver them directly
+      // even when block streaming is off.
       await sendDirectBlockReply({
         onBlockReply: params.onBlockReply,
         directlySentBlockKeys: params.directlySentBlockKeys,


### PR DESCRIPTION
## What Problem This Solves

Closes #99712.

An interactive agent turn could complete successfully but leave no deliverable final reply after directive stripping, reasoning/commentary filtering, model-fallback exhaustion, queued follow-up routing, or block-stream dedupe. The user then saw a completed turn with no explanation.

## Why This Change Was Made

This rewrite keeps the policy at the reply-delivery owner boundary instead of teaching the TUI or individual providers about empty results:

- direct and queued follow-up paths share safe failure copy and conversation-silence policy;
- terminal delivery evidence is distinct from reasoning, commentary, status notices, and empty voice markers;
- explicit `NO_REPLY`, heartbeats, pending continuations, message-tool-only runs, room/internal events, and committed side effects remain silent;
- fallback exhaustion without a preserved result still routes through the normal safe terminal-failure path;
- model fallback preserves only the non-visible follow-up results needed by that owner path.

## User Impact

Interactive users now receive a visible, sanitized failure when a completed turn produced no deliverable reply. Existing deliberate-silence and side-effect contracts are unchanged.

## Evidence

- Focused Testbox: 236/236 tests passed across direct reply, queued follow-up, and block-stream suites — https://github.com/openclaw/openclaw/actions/runs/28754109271
- Exact changed gate: typecheck, lint, focused tests, and changed-surface checks — https://github.com/openclaw/openclaw/actions/runs/28754110416
- Source-blind real Gateway + TUI PTY: visible failure, raw directive absent, next turn completed, clean exit — https://github.com/openclaw/openclaw/actions/runs/28753546491
- Upstream Codex contract checked at `be33f80bc65159c094ecd06bf155afa3061ce23d`: `codex-rs/app-server/src/bespoke_event_handling.rs:1348-1369` emits an empty item list for completed turns; `codex-rs/app-server-protocol/src/protocol/v2/thread_data.rs:231-263` defines `NotLoaded` as intentionally empty.
- Fresh Codex autoreview: no actionable findings after accepted fixes.
