### PR TITLE
fix(config): use Object.hasOwn instead of in operator in unsetConfigValueAtPath

### DIFF
--- a/src/config/config-paths.test.ts
+++ b/src/config/config-paths.test.ts
@@ -2,7 +2,7 @@
 // preventing prototype-named keys (toString, constructor, valueOf) from being falsely
 // reported as "found and deleted" when they don't exist as own properties.
 import { describe, expect, it } from "vitest";
-import { setConfigValueAtPath, unsetConfigValueAtPath } from "./config-paths.js";
+import { unsetConfigValueAtPath } from "./config-paths.js";
 
 describe("unsetConfigValueAtPath — prototype pollution", () => {
   const PROTOTYPE_KEYS = ["toString", "constructor", "valueOf", "hasOwnProperty"];

--- a/src/config/config-paths.test.ts
+++ b/src/config/config-paths.test.ts
@@ -1,0 +1,33 @@
+// Regression test: unsetConfigValueAtPath uses Object.hasOwn instead of in operator,
+// preventing prototype-named keys (toString, constructor, valueOf) from being falsely
+// reported as "found and deleted" when they don't exist as own properties.
+import { describe, expect, it } from "vitest";
+import { setConfigValueAtPath, unsetConfigValueAtPath } from "./config-paths.js";
+
+describe("unsetConfigValueAtPath — prototype pollution", () => {
+  const PROTOTYPE_KEYS = ["toString", "constructor", "valueOf", "hasOwnProperty"];
+
+  for (const key of PROTOTYPE_KEYS) {
+    it(`returns false when "${key}" is not an own property`, () => {
+      const root = { foo: { bar: "value" } };
+      const result = unsetConfigValueAtPath(root, ["foo", key]);
+      expect(result).toBe(false);
+      expect(Object.hasOwn(root.foo, key)).toBe(false);
+    });
+  }
+
+  it("correctly deletes an existing prototype-named key", () => {
+    const root = { foo: { bar: "value", toString: "myVal" } };
+    const result = unsetConfigValueAtPath(root, ["foo", "toString"]);
+    expect(result).toBe(true);
+    expect(Object.hasOwn(root.foo, "toString")).toBe(false);
+    expect(root.foo.bar).toBe("value"); // sibling unaffected
+  });
+
+  it("does not incorrectly prune parent when deletion is a no-op", () => {
+    const root = { foo: { bar: "value" } };
+    unsetConfigValueAtPath(root, ["foo", "toString"]);
+    expect(Object.hasOwn(root, "foo")).toBe(true);
+    expect(root.foo.bar).toBe("value");
+  });
+});

--- a/src/config/config-paths.ts
+++ b/src/config/config-paths.ts
@@ -1,6 +1,6 @@
+import { isBlockedObjectKey } from "../infra/prototype-keys.js";
 // Resolves and classifies config paths for reads, writes, and metadata.
 import { isPlainObject } from "../utils.js";
-import { isBlockedObjectKey } from "../infra/prototype-keys.js";
 
 type PathNode = Record<string, unknown>;
 
@@ -60,7 +60,7 @@ export function unsetConfigValueAtPath(root: PathNode, path: string[]): boolean 
     cursor = next;
   }
   const leafKey = path[path.length - 1];
-  if (!(leafKey in cursor)) {
+  if (!Object.hasOwn(cursor, leafKey)) {
     return false;
   }
   delete cursor[leafKey];


### PR DESCRIPTION
## Summary
Use `Object.hasOwn()` instead of the `in` operator in `unsetConfigValueAtPath()` to prevent prototype chain pollution when checking whether a config key exists before deletion.

## What Problem This Solves
When calling `unsetConfigValueAtPath(root, ["foo", "toString"])` on a config object that does **not** have a `toString` key, the function returns `true` (claiming success) because `"toString" in cursor` matches `Object.prototype.toString`.

**The function lies to its caller** — it reports "key found and deleted" when the key never existed. This can cause config management tools (CLI `config unset`, config merge logic) to silently skip error handling for non-existent keys.

**Code evidence**: In `src/config/config-paths.ts:63`, `if (!(leafKey in cursor))` checks the prototype chain. `cursor` is a plain `PathNode` object (`Record<string, unknown>`), and `leafKey` comes from user-provided dot-notation paths like `foo.toString`.

## Root Cause
- The `in` operator checks the entire prototype chain, not just own properties
- `Object.hasOwn()` (ES2022+) correctly checks only the object's own properties
- `Object.hasOwn` is already used 15+ times across the codebase — this was a missed instance

## Why This Fix
- **Minimal**: 1-line change, same pattern as #99129
- **Consistent**: matches existing `Object.hasOwn` usage in the codebase
- **Regression-safe**: normal keys pass unchanged; only prototype keys are affected

## Evidence
- **Before**: `/config unset foo.toString` reports "Config value unset" even though `toString` never existed as a config key — the `in` operator finds `Object.prototype.toString`
- **After**: `/config unset foo.toString` correctly reports "No config value found"
- **Root cause**: `if (!(leafKey in cursor))` at `config-paths.ts:63` traverses the prototype chain; `"toString" in {}` is `true`
- All 4 prototype keys tested: toString, constructor, valueOf, hasOwnProperty — all correctly return false
- Existing own-key deletion and parent pruning: unaffected

## Real Behavior Proof

### Before (on main)
```bash
$ node --import tsx proof.mjs
FAIL non-existent "toString" returns false (got: true, owns "toString": false)
FAIL non-existent "constructor" returns false (got: true, owns "constructor": false)
FAIL non-existent "valueOf" returns false (got: true, owns "valueOf": false)
FAIL non-existent "hasOwnProperty" returns false (got: true, owns "hasOwnProperty": false)
PASS existing "toString" deleted successfully
PASS "toString" no longer own property
PASS sibling key "bar" preserved
PASS parent "foo" preserved after no-op unset
PASS sibling "bar" preserved after no-op unset

4 FAILED
```

### After (with fix)
```bash
$ node --import tsx proof.mjs
PASS non-existent "toString" returns false (got: false, owns "toString": false)
PASS non-existent "constructor" returns false (got: false, owns "constructor": false)
PASS non-existent "valueOf" returns false (got: false, owns "valueOf": false)
PASS non-existent "hasOwnProperty" returns false (got: false, owns "hasOwnProperty": false)
PASS existing "toString" deleted successfully
PASS "toString" no longer own property
PASS sibling key "bar" preserved
PASS parent "foo" preserved after no-op unset
PASS sibling "bar" preserved after no-op unset

ALL PASS
```

## Tests and Validation
- Regression test added: `src/config/config-paths.test.ts` covers 4 prototype keys + own-key deletion + parent pruning
- Fix verified with standalone `node --import tsx` proof script (see above)
- Focused vitest proof: `node scripts/run-vitest.mjs src/config/config-paths.test.ts` — 1 file, 6 tests passed
- Diff: 1 line changed in source + regression test
- Proof: 4 prototype keys (toString/constructor/valueOf/hasOwnProperty) all change from FAIL → PASS, regression tests pass
