### PR TITLE
fix: stop rubber-band bounce of the Control UI shell in the Mac app web view

### DIFF
--- a/ui/src/styles/base.css
+++ b/ui/src/styles/base.css
@@ -499,6 +499,10 @@
 html,
 body {
   height: 100%;
+  /* App shell: inner panes scroll, the root never should. Without this the
+     macOS WKWebView (Mac app) and Safari rubber-band the whole window, even
+     when nothing overflows. */
+  overscroll-behavior: none;
 }
 
 body {
@@ -563,7 +567,6 @@ openclaw-app {
     width: 100%;
     height: 100%;
     overflow: hidden;
-    overscroll-behavior: none;
   }
 
   @supports (height: 100dvh) {


### PR DESCRIPTION
## What Problem This Solves

Opening the Control UI in the macOS app's dashboard window (a WKWebView) lets the whole page rubber-band vertically — even when the content fits the viewport with nothing to scroll. The entire shell shifts up and down on trackpad scroll, which feels broken for an app shell. Desktop Safari shows the same bounce.

## Why This Change Was Made

The root scroller of the Control UI is never supposed to scroll — the shell is a fixed grid and inner panes (chat thread, lists) own scrolling. `overscroll-behavior: none` was only applied in `@media (display-mode: standalone)` (installed PWA), so plain browser contexts — which is what WKWebView is — kept WebKit's default elastic bounce. The fix applies the rule to `html, body` globally and removes the now-redundant standalone-mode declaration. Inner scrollers keep their native elasticity; only chaining/bouncing of the root is suppressed. Safari has supported `overscroll-behavior` since 16; the macOS app targets macOS 15 (Safari 18+ WebKit).

## User Impact

The Mac app's dashboard window (and the Control UI in any browser) no longer bounces the whole UI when there is nothing to scroll. Inner panes scroll exactly as before.

## Evidence

Computed-style probe (Playwright + the repo's mock-gateway e2e harness, non-standalone context, `/chat`):

- `main` (before): `{"html":"auto","body":"auto","standaloneMediaMatches":false}` — root bounces
- this branch (after): `{"html":"none","body":"none","standaloneMediaMatches":false}` — root bounce disabled

Diff is CSS-only (+4/−1 in `ui/src/styles/base.css`).
