### PR TITLE
fix(slack): keep colons inside interactive-reply button labels (#99823)

### DIFF
--- a/extensions/slack/src/interactive-replies.test.ts
+++ b/extensions/slack/src/interactive-replies.test.ts
@@ -94,4 +94,46 @@ describe("compileSlackInteractiveReplies", () => {
     );
     expect(result.interactive).toBeUndefined();
   });
+
+  it("keeps colons inside button labels (e.g. times) with the label, not the value", () => {
+    const result = compileSlackInteractiveReplies({
+      text: "[[slack_buttons: Fr 10.07. 9:00:slot_fr_0900, Mo 13.07. 10:45:slot_mo_1045]]",
+    });
+
+    const buttonsBlock = result.interactive?.blocks.find((block) => block.type === "buttons");
+    expect(buttonsBlock).toEqual({
+      type: "buttons",
+      buttons: [
+        { label: "Fr 10.07. 9:00", value: "slot_fr_0900" },
+        { label: "Mo 13.07. 10:45", value: "slot_mo_1045" },
+      ],
+    });
+  });
+
+  it("still strips a trailing :style suffix on labeled buttons, including colon labels", () => {
+    const result = compileSlackInteractiveReplies({
+      text: "[[slack_buttons: Retry:retry:primary, Slot 9:00:slot_0900:danger]]",
+    });
+
+    const buttonsBlock = result.interactive?.blocks.find((block) => block.type === "buttons");
+    expect(buttonsBlock).toEqual({
+      type: "buttons",
+      buttons: [
+        { label: "Retry", value: "retry", style: "primary" },
+        { label: "Slot 9:00", value: "slot_0900", style: "danger" },
+      ],
+    });
+  });
+
+  it("does not treat a single-colon label:style entry as a styled button", () => {
+    const result = compileSlackInteractiveReplies({
+      text: "[[slack_buttons: Approve:primary]]",
+    });
+
+    const buttonsBlock = result.interactive?.blocks.find((block) => block.type === "buttons");
+    expect(buttonsBlock).toEqual({
+      type: "buttons",
+      buttons: [{ label: "Approve", value: "primary" }],
+    });
+  });
 });

--- a/extensions/slack/src/interactive-replies.ts
+++ b/extensions/slack/src/interactive-replies.ts
@@ -26,36 +26,40 @@ function parseChoice(raw: string, options?: { allowStyle?: boolean }): SlackChoi
   if (!trimmed) {
     return null;
   }
-  const delimiter = trimmed.indexOf(":");
-  if (delimiter === -1) {
-    return {
-      label: trimmed,
-      value: trimmed,
-    };
-  }
-  const label = trimmed.slice(0, delimiter).trim();
-  let value = trimmed.slice(delimiter + 1).trim();
-  if (!label || !value) {
-    return null;
-  }
+  // Strip an optional trailing `:style` suffix before splitting label/value, but
+  // only when a label:value colon still remains after it. A bare `label:style`
+  // (single colon) is a plain value today, not a styled button. (#99823)
+  let working = trimmed;
   let style: SlackChoice["style"];
   if (options?.allowStyle) {
-    const styleDelimiter = value.lastIndexOf(":");
-    if (styleDelimiter !== -1) {
-      const maybeStyle = normalizeLowercaseStringOrEmpty(value.slice(styleDelimiter + 1));
+    const styleDelimiter = working.lastIndexOf(":");
+    if (styleDelimiter !== -1 && working.slice(0, styleDelimiter).includes(":")) {
+      const maybeStyle = normalizeLowercaseStringOrEmpty(working.slice(styleDelimiter + 1));
       if (
         maybeStyle === "primary" ||
         maybeStyle === "secondary" ||
         maybeStyle === "success" ||
         maybeStyle === "danger"
       ) {
-        const unstyledValue = value.slice(0, styleDelimiter).trim();
-        if (unstyledValue) {
-          value = unstyledValue;
+        const unstyled = working.slice(0, styleDelimiter).trim();
+        if (unstyled) {
+          working = unstyled;
           style = maybeStyle;
         }
       }
     }
+  }
+  // Split label/value at the LAST remaining colon so colons inside the label
+  // (e.g. a time like "9:00") stay with the label and only the trailing token
+  // becomes the value. Single-colon entries are unaffected. (#99823)
+  const delimiter = working.lastIndexOf(":");
+  if (delimiter === -1) {
+    return { label: working, value: working };
+  }
+  const label = working.slice(0, delimiter).trim();
+  const value = working.slice(delimiter + 1).trim();
+  if (!label || !value) {
+    return null;
   }
   return style ? { label, value, style } : { label, value };
 }


### PR DESCRIPTION
## Summary

Fixes #99823. `parseChoice()` in `extensions/slack/src/interactive-replies.ts` split each `Label:value` interactive-reply entry at the **first** colon. Any label that itself contains a colon — most commonly a time of day (`9:00`) — was truncated, and the remainder leaked into the button `value`. Proposing meeting slots is a primary use case for reply buttons, so this hit the most common usage and produced values the agent never defined (breaking interaction-payload mapping).

**Fix (order matters, per the issue):**
1. Strip the optional trailing `:style` suffix first (`primary|secondary|success|danger`), but only when a `label:value` colon still remains after it — so a bare single-colon `label:style` stays a plain value exactly as today.
2. Split label/value at the **last** remaining colon, so colons inside the label stay with the label and only the trailing token becomes the value.
3. Entries without a colon keep the `label === value` fallback.

Behavior only changes for entries with two or more colons — exactly the currently-broken case. Single-colon entries parse identically to today. The same `parseChoice` is used for `slack_select`, so select options with colon labels are fixed too.

Net diff: source +15/-14; tests +46.

## Real behavior proof

- **Behavior addressed:** Slack `[[slack_buttons:]]` labels containing a colon (e.g. meeting times) are split at the first colon, corrupting both label and value.
- **Real environment tested:** OpenClaw source checkout on latest `main`, macOS, Node v22.22.3. The regression test runs the **real** `compileSlackInteractiveReplies()` on the exact input from the issue (no mocks of the parser).
- **Exact input exercised:** `[[slack_buttons: Fr 10.07. 9:00:slot_fr_0900, Mo 13.07. 10:45:slot_mo_1045]]`
- **Evidence — BEFORE the fix** (ran the new tests against pre-fix `parseChoice`, source stashed): the real compile output was the corrupted
  ```json
  [ { "label": "Fr 10.07. 9",  "value": "00:slot_fr_0900" },
    { "label": "Mo 13.07. 10", "value": "45:slot_mo_1045" } ]
  ```
  → 2 tests failed (`keeps colons inside button labels…`, `still strips a trailing :style suffix…`). The single-colon guardrail test passed on the old code, confirming today's single-colon behavior is preserved.
- **Observed result AFTER the fix:**
  ```json
  [ { "label": "Fr 10.07. 9:00",  "value": "slot_fr_0900" },
    { "label": "Mo 13.07. 10:45", "value": "slot_mo_1045" } ]
  ```
  → `Test Files 1 passed`, `Tests 7 passed (7)` (4 pre-existing + 3 new). Styled colon-labels (`Slot 9:00:slot_0900:danger` → `{label:"Slot 9:00", value:"slot_0900", style:"danger"}`) and single-colon `Approve:primary` (→ `{label:"Approve", value:"primary"}`, unstyled) both verified.
- **Observed result after fix:** correct label/value split for colon-bearing labels; no change for single-colon or no-colon entries.
- **What was not tested:** no live Slack workspace round-trip (the parser is pure/deterministic and exercised directly); no local structured autoreview (no review-engine CLI installed on this machine).

## Verification

```
node scripts/run-vitest.mjs extensions/slack/src/interactive-replies.test.ts
# Test Files 1 passed (1) / Tests 7 passed (7)
# pre-fix parseChoice (source stashed) → 2 of the 3 new tests fail (red)
oxfmt --check  # clean
```
