### PR TITLE
feat: declutter the Control UI shell — reasoning effort slider, borderless composer controls, version out of the sidebar

### DIFF
--- a/ui/src/i18n/.i18n/raw-copy-baseline.json
+++ b/ui/src/i18n/.i18n/raw-copy-baseline.json
@@ -307,6 +307,13 @@
       "kind": "html-text",
       "name": "text",
       "path": "ui/src/ui/chat/session-controls.ts",
+      "text": "Faster"
+    },
+    {
+      "count": 1,
+      "kind": "html-text",
+      "name": "text",
+      "path": "ui/src/ui/chat/session-controls.ts",
       "text": "Model"
     },
     {
@@ -315,6 +322,13 @@
       "name": "text",
       "path": "ui/src/ui/chat/session-controls.ts",
       "text": "Reasoning"
+    },
+    {
+      "count": 1,
+      "kind": "html-text",
+      "name": "text",
+      "path": "ui/src/ui/chat/session-controls.ts",
+      "text": "Smarter"
     },
     {
       "count": 1,

--- a/ui/src/styles/chat/layout.css
+++ b/ui/src/styles/chat/layout.css
@@ -2182,19 +2182,21 @@
   display: none;
 }
 
+/* Composer controls are quiet text controls: no borders/fills at rest so the
+   composer frame stays the only chrome; hover/open get a soft wash. */
 .chat-controls__inline-select-trigger {
   box-sizing: border-box;
   display: flex;
   align-items: center;
   justify-content: space-between;
-  gap: 8px;
+  gap: 6px;
   width: 100%;
-  height: 36px;
-  min-height: 36px;
-  padding: 0 10px 0 12px;
-  border: 1px solid color-mix(in srgb, var(--input) 88%, transparent);
-  border-radius: var(--radius-lg);
-  background: color-mix(in srgb, var(--card) 92%, var(--bg-elevated) 8%);
+  height: 30px;
+  min-height: 30px;
+  padding: 0 6px 0 8px;
+  border: none;
+  border-radius: var(--radius-sm);
+  background: transparent;
   color: var(--text);
   font-size: 13px;
   line-height: 1.35;
@@ -2203,9 +2205,10 @@
   user-select: none;
 }
 
-.chat-controls__inline-select-trigger:hover {
-  border-color: color-mix(in srgb, var(--text) 18%, var(--input));
-  background: color-mix(in srgb, var(--card) 82%, var(--bg-elevated) 18%);
+.chat-controls__inline-select-trigger:hover,
+.chat-controls__inline-select[open] > .chat-controls__inline-select-trigger {
+  background: color-mix(in srgb, var(--text) 7%, transparent);
+  color: var(--text-strong);
 }
 
 .chat-controls__inline-select-trigger:focus-visible {
@@ -2357,6 +2360,165 @@
   transform: translateX(0);
 }
 
+.chat-controls__reasoning-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  min-width: 0;
+}
+
+.chat-controls__reasoning-value {
+  padding-right: 8px;
+  overflow: hidden;
+  color: var(--text-strong);
+  font-size: 12px;
+  font-weight: 600;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+}
+
+/* Discrete effort slider: native range input for keyboard/a11y, decorative
+   stop dots layered underneath (pointer-events: none). Dot inset must track
+   half the thumb width so dots align with the thumb's travel. */
+.chat-controls__reasoning-slider {
+  position: relative;
+  display: flex;
+  align-items: center;
+  height: 26px;
+  margin: 2px 8px 0;
+}
+
+.chat-controls__reasoning-dots {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0 5px;
+  pointer-events: none;
+}
+
+.chat-controls__reasoning-dot {
+  width: 4px;
+  height: 4px;
+  border-radius: var(--radius-full);
+  background: color-mix(in srgb, var(--text) 28%, transparent);
+}
+
+.chat-controls__reasoning-dot--default {
+  background: color-mix(in srgb, var(--text) 55%, transparent);
+}
+
+.chat-controls__reasoning-range {
+  -webkit-appearance: none;
+  appearance: none;
+  position: relative;
+  z-index: 1;
+  width: 100%;
+  height: 26px;
+  margin: 0;
+  padding: 0;
+  background: transparent;
+  cursor: pointer;
+}
+
+.chat-controls__reasoning-range:disabled {
+  cursor: not-allowed;
+  opacity: 0.5;
+}
+
+.chat-controls__reasoning-range:focus-visible {
+  outline: none;
+}
+
+/* --reasoning-fill is set inline (and live-updated on drag) so the filled
+   segment tracks the thumb; pseudo-elements inherit the custom property. */
+.chat-controls__reasoning-range::-webkit-slider-runnable-track {
+  height: 3px;
+  border-radius: var(--radius-full);
+  background: linear-gradient(
+    90deg,
+    color-mix(in srgb, var(--text) 45%, transparent) var(--reasoning-fill, 0%),
+    color-mix(in srgb, var(--text) 14%, transparent) var(--reasoning-fill, 0%)
+  );
+}
+
+.chat-controls__reasoning-range::-webkit-slider-thumb {
+  -webkit-appearance: none;
+  width: 14px;
+  height: 14px;
+  margin-top: -5.5px;
+  border: none;
+  border-radius: var(--radius-full);
+  background: var(--text-strong);
+  box-shadow: 0 1px 4px rgba(0, 0, 0, 0.35);
+}
+
+.chat-controls__reasoning-range:focus-visible::-webkit-slider-thumb {
+  box-shadow: var(--focus-ring);
+}
+
+/* Inherited default (no override): hollow-looking muted thumb. */
+.chat-controls__reasoning-range--inherit::-webkit-slider-thumb {
+  background: var(--muted);
+}
+
+.chat-controls__reasoning-range::-moz-range-track {
+  height: 3px;
+  border-radius: var(--radius-full);
+  background: color-mix(in srgb, var(--text) 14%, transparent);
+}
+
+.chat-controls__reasoning-range::-moz-range-progress {
+  height: 3px;
+  border-radius: var(--radius-full);
+  background: color-mix(in srgb, var(--text) 45%, transparent);
+}
+
+.chat-controls__reasoning-range::-moz-range-thumb {
+  width: 14px;
+  height: 14px;
+  border: none;
+  border-radius: var(--radius-full);
+  background: var(--text-strong);
+  box-shadow: 0 1px 4px rgba(0, 0, 0, 0.35);
+}
+
+.chat-controls__reasoning-range--inherit::-moz-range-thumb {
+  background: var(--muted);
+}
+
+.chat-controls__reasoning-scale {
+  display: flex;
+  justify-content: space-between;
+  margin: 0 8px;
+  color: var(--muted);
+  font-size: 11px;
+}
+
+.chat-controls__reasoning-reset {
+  margin: 2px 8px 0;
+  padding: 0;
+  border: none;
+  background: none;
+  color: var(--muted);
+  font: inherit;
+  font-size: 11px;
+  text-align: left;
+  cursor: pointer;
+}
+
+.chat-controls__reasoning-reset:hover:not(:disabled) {
+  color: var(--text);
+  text-decoration: underline;
+}
+
+.chat-controls__reasoning-reset:disabled {
+  cursor: not-allowed;
+  opacity: 0.55;
+}
+
 .chat-controls__reasoning-options {
   display: grid;
   grid-template-columns: minmax(0, 1fr);
@@ -2420,12 +2582,12 @@
   justify-content: center;
   gap: 4px;
   box-sizing: border-box;
-  min-width: 104px;
-  height: 36px;
-  padding: 0 10px;
-  border: 1px solid color-mix(in srgb, var(--border) 80%, transparent);
-  border-radius: var(--radius-lg);
-  background: color-mix(in srgb, var(--card) 86%, var(--bg-elevated) 14%);
+  min-width: 0;
+  height: 30px;
+  padding: 0 8px;
+  border: none;
+  border-radius: var(--radius-sm);
+  background: transparent;
   color: var(--fg);
   font-size: 12px;
   font-weight: 650;
@@ -2435,8 +2597,7 @@
 }
 
 .chat-controls__quota:hover {
-  border-color: color-mix(in srgb, var(--accent) 44%, var(--border));
-  background: color-mix(in srgb, var(--accent-subtle) 28%, var(--card));
+  background: color-mix(in srgb, var(--text) 7%, transparent);
 }
 
 .chat-controls__quota-label {

--- a/ui/src/styles/chat/layout.css
+++ b/ui/src/styles/chat/layout.css
@@ -1517,6 +1517,13 @@
     min-width: 0;
   }
 
+  /* The borderless trigger is 30px on desktop; keep a >=40px touch target
+     inside the mobile composer grid. */
+  .agent-chat__composer-controls .chat-controls__inline-select-trigger {
+    height: 40px;
+    min-height: 40px;
+  }
+
   /* Desktop restores the quota pill in the composer flex row (#93041); the mobile composer is a
      fixed 2-col grid (model | settings), so the pill would push the settings chip to a new row. */
   .agent-chat__composer-controls .chat-controls__quota {

--- a/ui/src/styles/chat/layout.css
+++ b/ui/src/styles/chat/layout.css
@@ -2471,6 +2471,12 @@
   background: var(--muted);
 }
 
+/* Inherited default that is not on the offered scale (e.g. "adaptive"):
+   ghost the parked thumb so its position does not read as the default. */
+.chat-controls__reasoning-range--unanchored::-webkit-slider-thumb {
+  opacity: 0.35;
+}
+
 .chat-controls__reasoning-range::-moz-range-track {
   height: 3px;
   border-radius: var(--radius-full);
@@ -2494,6 +2500,10 @@
 
 .chat-controls__reasoning-range--inherit::-moz-range-thumb {
   background: var(--muted);
+}
+
+.chat-controls__reasoning-range--unanchored::-moz-range-thumb {
+  opacity: 0.35;
 }
 
 .chat-controls__reasoning-scale {

--- a/ui/src/styles/layout.css
+++ b/ui/src/styles/layout.css
@@ -1180,56 +1180,34 @@
   min-height: 42px;
 }
 
-.sidebar-version {
+/* Borderless status line: the sidebar footer signals connectivity only;
+   the gateway version moved into Settings (Quick Settings footer). */
+.sidebar-status {
   display: flex;
   align-items: center;
-  justify-content: space-between;
-  gap: 10px;
-  min-height: 40px;
+  gap: 8px;
+  min-height: 28px;
   padding: 0 12px;
-  border-radius: var(--radius-lg);
-  background: color-mix(in srgb, var(--bg-elevated) 72%, transparent);
-  border: 1px solid color-mix(in srgb, var(--border) 72%, transparent);
 }
 
-.sidebar-version__label {
-  font-size: 12px; /* was 11px */
-  font-weight: 600;
-  color: var(--muted);
-  text-transform: uppercase;
-  letter-spacing: 0.06em;
-}
-
-.sidebar-version__text {
+.sidebar-status__text {
   font-size: 12px;
-  color: var(--text);
-  font-weight: 600;
+  color: var(--muted);
 }
 
-.sidebar-version__dot {
-  width: 8px;
-  height: 8px;
-  border-radius: var(--radius-full);
-  background: color-mix(in srgb, var(--accent) 78%, white 22%);
-  box-shadow: 0 0 0 4px color-mix(in srgb, var(--accent) 14%, transparent);
-  opacity: 1;
-  margin: 0 auto;
-}
-
-.sidebar-version__status {
+.sidebar-status__dot {
   width: 8px;
   height: 8px;
   border-radius: var(--radius-full);
   flex-shrink: 0;
-  margin-left: auto;
 }
 
-.sidebar-version__status.sidebar-connection-status--online {
+.sidebar-status__dot.sidebar-connection-status--online {
   background: var(--ok);
   box-shadow: 0 0 0 4px color-mix(in srgb, var(--ok) 14%, transparent);
 }
 
-.sidebar-version__status.sidebar-connection-status--offline {
+.sidebar-status__dot.sidebar-connection-status--offline {
   background: var(--danger);
   box-shadow: 0 0 0 4px color-mix(in srgb, var(--danger) 14%, transparent);
 }
@@ -1243,16 +1221,11 @@
   gap: 6px;
 }
 
-.sidebar--collapsed .sidebar-version {
+.sidebar--collapsed .sidebar-status {
   width: 44px;
-  min-height: 44px;
+  min-height: 36px;
   padding: 0;
   justify-content: center;
-  border-radius: var(--radius-lg);
-}
-
-.sidebar--collapsed .sidebar-version__status {
-  margin-left: 0;
 }
 
 /* Mode switch in sidebar — hidden on desktop, shown on mobile */

--- a/ui/src/styles/layout.mobile.css
+++ b/ui/src/styles/layout.mobile.css
@@ -279,9 +279,9 @@
     padding: 12px 8px 0;
   }
 
-  .sidebar--collapsed .sidebar-version {
+  .sidebar--collapsed .sidebar-status {
     width: auto;
-    min-height: 40px;
+    min-height: 32px;
     padding: 0 12px;
   }
 
@@ -289,9 +289,9 @@
     padding: 8px 0 2px;
   }
 
-  .shell--nav-collapsed:not(.shell--nav-drawer-open) .sidebar--collapsed .sidebar-version {
+  .shell--nav-collapsed:not(.shell--nav-drawer-open) .sidebar--collapsed .sidebar-status {
     width: 44px;
-    min-height: 44px;
+    min-height: 36px;
     padding: 0;
     justify-content: center;
   }

--- a/ui/src/ui/app-render.helpers.ts
+++ b/ui/src/ui/app-render.helpers.ts
@@ -920,6 +920,11 @@ export function renderTopbarThemeModeToggle(state: AppViewState) {
   `;
 }
 
+/**
+ * Sidebar footer status dot. The footer intentionally shows only live
+ * connection state; the gateway version lives in Settings (Quick Settings
+ * footer) instead of persistent chrome.
+ */
 export function renderSidebarConnectionStatus(state: AppViewState) {
   const label = state.connected ? t("common.online") : t("common.offline");
   const toneClass = state.connected
@@ -928,7 +933,7 @@ export function renderSidebarConnectionStatus(state: AppViewState) {
 
   return html`
     <span
-      class="sidebar-version__status ${toneClass}"
+      class="sidebar-status__dot ${toneClass}"
       role="img"
       aria-live="polite"
       aria-label=${t("chat.gatewayStatus", { status: label })}

--- a/ui/src/ui/app-render.ts
+++ b/ui/src/ui/app-render.ts
@@ -2732,22 +2732,14 @@ export function renderApp(state: AppViewState) {
                     : nothing}
                 </a>
                 <div class="sidebar-mode-switch">${renderTopbarThemeModeToggle(state)}</div>
-                ${(() => {
-                  const version = state.hello?.server?.version ?? "";
-                  return version
-                    ? html`
-                        <div class="sidebar-version" title=${`v${version}`}>
-                          ${!navCollapsed
-                            ? html`
-                                <span class="sidebar-version__label">${t("common.version")}</span>
-                                <span class="sidebar-version__text">v${version}</span>
-                                ${renderSidebarConnectionStatus(state)}
-                              `
-                            : html` ${renderSidebarConnectionStatus(state)} `}
-                        </div>
-                      `
-                    : nothing;
-                })()}
+                <div class="sidebar-status">
+                  ${renderSidebarConnectionStatus(state)}
+                  ${navCollapsed
+                    ? nothing
+                    : html`<span class="sidebar-status__text"
+                        >${state.connected ? t("common.online") : t("common.offline")}</span
+                      >`}
+                </div>
               </div>
             </div>
           </div>

--- a/ui/src/ui/chat/session-controls.ts
+++ b/ui/src/ui/chat/session-controls.ts
@@ -941,6 +941,7 @@ export function renderChatModelSelect(state: AppViewState) {
     selectedThinkingLabel,
     selectedThinkingValue: thinking.currentOverride,
     fastMode,
+    thinkingDefaultValue: thinking.defaultValue,
     thinkingDisabled,
     thinkingOptions: [{ value: "", label: thinking.defaultLabel }, ...thinking.options],
     onModelSelect: (next) => switchChatModel(state, next),
@@ -957,6 +958,8 @@ type ChatThinkingSelectOption = {
 type ChatThinkingSelectState = {
   currentOverride: string;
   defaultLabel: string;
+  /** Normalized default level id so the slider can mark the inherited stop. */
+  defaultValue: string;
   options: ChatThinkingSelectOption[];
 };
 
@@ -1142,6 +1145,7 @@ export function resolveChatThinkingSelectState(state: AppViewState): ChatThinkin
   return {
     currentOverride: effectiveOverride,
     defaultLabel: formatInheritedThinkingLabel(defaultLevel),
+    defaultValue: normalizeThinkingOptionValue(defaultLevel),
     options: buildThinkingOptions(levels, effectiveOverride),
   };
 }
@@ -1164,10 +1168,6 @@ function formatCombinedPickerThinkingLabel(label: string): string {
   return label.replace(/^Inherited:\s*/u, "");
 }
 
-function formatCombinedPickerThinkingOptionLabel(option: ChatInlineSelectOption): string {
-  return option.value === "" ? "Default" : formatCombinedPickerThinkingLabel(option.label);
-}
-
 function renderChatModelReasoningSelect(params: {
   fastMode: ChatFastModeSelectState;
   disabled: boolean;
@@ -1176,6 +1176,7 @@ function renderChatModelReasoningSelect(params: {
   selectedModelValue: string;
   selectedThinkingLabel: string;
   selectedThinkingValue: string;
+  thinkingDefaultValue: string;
   thinkingDisabled: boolean;
   thinkingOptions: ChatInlineSelectOption[];
   onFastModeSelect: (value: "" | "on" | "off" | "auto") => Promise<unknown>;
@@ -1190,6 +1191,7 @@ function renderChatModelReasoningSelect(params: {
     selectedModelValue,
     selectedThinkingLabel,
     selectedThinkingValue,
+    thinkingDefaultValue,
     thinkingDisabled,
     thinkingOptions,
     onFastModeSelect,
@@ -1198,7 +1200,46 @@ function renderChatModelReasoningSelect(params: {
   } = params;
   const triggerModel = formatCombinedPickerModelLabel(selectedModelLabel);
   const triggerThinking = formatCombinedPickerThinkingLabel(selectedThinkingLabel);
-  const triggerLabel = `${triggerModel} · ${triggerThinking}`;
+  const triggerTitle = `${triggerModel} · ${triggerThinking}`;
+  // The visible trigger stays minimal: the inherited default level is noise,
+  // so reasoning only appears when overridden. Title/aria keep the full pair.
+  const triggerLabel =
+    selectedThinkingValue === "" ? triggerModel : `${triggerModel} · ${triggerThinking}`;
+  // Reasoning renders as a discrete slider over the ordered level list the
+  // gateway offers (faster -> smarter). "" (inherit default) is not a stop:
+  // the thumb parks on the default level until the user sets an override.
+  const sliderStops = thinkingOptions.filter((option) => option.value !== "");
+  const defaultStopIndex = sliderStops.findIndex((option) => option.value === thinkingDefaultValue);
+  const hasThinkingOverride = selectedThinkingValue !== "";
+  const overrideStopIndex = sliderStops.findIndex(
+    (option) => option.value === selectedThinkingValue,
+  );
+  const sliderIndex = Math.max(hasThinkingOverride ? overrideStopIndex : defaultStopIndex, 0);
+  const sliderFillPercent = (index: number) =>
+    sliderStops.length > 1 ? (index / (sliderStops.length - 1)) * 100 : 0;
+  const reasoningValueLabel = hasThinkingOverride
+    ? triggerThinking
+    : `Default (${triggerThinking})`;
+  const defaultLevelLabel = formatThinkingOverrideLabel(thinkingDefaultValue);
+  // Keep the filled track segment glued to the thumb while dragging; the
+  // sessions.patch commit happens on release (change), not per input tick.
+  const onSliderDrag = (event: Event) => {
+    const input = event.currentTarget as HTMLInputElement;
+    input.style.setProperty("--reasoning-fill", `${sliderFillPercent(Number(input.value))}%`);
+  };
+  const onSliderCommit = async (event: Event) => {
+    if (thinkingDisabled) {
+      return;
+    }
+    const input = event.currentTarget as HTMLInputElement;
+    const stop = sliderStops[Number(input.value)];
+    if (!stop || stop.value === selectedThinkingValue) {
+      return;
+    }
+    await onThinkingSelect(stop.value);
+  };
+  const showReasoning = sliderStops.length > 0;
+  const showReasoningPanel = showReasoning || fastMode.supported;
   return html`
     <details class="chat-controls__session chat-controls__inline-select chat-controls__model">
       <summary
@@ -1210,9 +1251,9 @@ function renderChatModelReasoningSelect(params: {
         data-chat-select-value=${selectedModelValue}
         data-chat-thinking-value=${selectedThinkingValue}
         data-chat-thinking-disabled=${thinkingDisabled ? "true" : "false"}
-        aria-label=${`${t("chat.selectors.model")}, ${t("chat.selectors.thinkingLevel")}: ${triggerLabel}`}
+        aria-label=${`${t("chat.selectors.model")}, ${t("chat.selectors.thinkingLevel")}: ${triggerTitle}`}
         aria-disabled=${disabled ? "true" : "false"}
-        title=${triggerLabel}
+        title=${triggerTitle}
         @click=${(event: MouseEvent) => {
           if (disabled) {
             event.preventDefault();
@@ -1272,100 +1313,130 @@ function renderChatModelReasoningSelect(params: {
             },
           )}
         </div>
-        <div
-          class="chat-controls__reasoning-panel"
-          role="listbox"
-          aria-label=${t("chat.selectors.thinkingLevel")}
-        >
-          <div class="chat-controls__inline-select-section-label">Reasoning</div>
-          <div class="chat-controls__reasoning-options">
-            ${repeat(
-              thinkingOptions,
-              (thinking) => thinking.value,
-              (thinking) => {
-                const thinkingSelected = thinking.value === selectedThinkingValue;
-                return html`
-                  <button
-                    class="chat-controls__reasoning-option ${thinkingSelected
-                      ? "chat-controls__reasoning-option--selected"
-                      : ""}"
-                    data-chat-thinking-option=${thinking.value}
-                    role="option"
-                    aria-selected=${thinkingSelected ? "true" : "false"}
-                    type="button"
-                    ?disabled=${thinkingDisabled}
-                    @click=${async (event: MouseEvent) => {
-                      event.stopPropagation();
-                      if (thinkingDisabled) {
-                        event.preventDefault();
-                        return;
-                      }
-                      (event.currentTarget as HTMLElement)
-                        .closest("details")
-                        ?.removeAttribute("open");
-                      await onThinkingSelect(thinking.value);
-                    }}
-                  >
-                    <span>${formatCombinedPickerThinkingOptionLabel(thinking)}</span>
-                    ${thinkingSelected
-                      ? html`<span class="chat-controls__inline-select-check" aria-hidden="true">
-                          ${icons.check}
-                        </span>`
-                      : ""}
-                  </button>
-                `;
-              },
-            )}
-          </div>
-          ${fastMode.supported
-            ? html`
-                <div class="chat-controls__inline-select-section-label">Speed</div>
-                <div class="chat-controls__reasoning-options" role="listbox">
-                  ${repeat(
-                    fastMode.options,
-                    (speed) => speed.value,
-                    (speed) => {
-                      const speedValue = speed.value as "" | "on" | "off" | "auto";
-                      const speedSelected = speedValue === fastMode.currentOverride;
-                      return html`
-                        <button
-                          class="chat-controls__reasoning-option ${speedSelected
-                            ? "chat-controls__reasoning-option--selected"
-                            : ""}"
-                          data-chat-speed-option=${speed.value}
-                          role="option"
-                          aria-selected=${speedSelected ? "true" : "false"}
-                          type="button"
-                          ?disabled=${fastMode.disabled}
-                          @click=${async (event: MouseEvent) => {
-                            event.stopPropagation();
-                            if (fastMode.disabled) {
-                              event.preventDefault();
-                              return;
-                            }
-                            (event.currentTarget as HTMLElement)
-                              .closest("details")
-                              ?.removeAttribute("open");
-                            await onFastModeSelect(speedValue);
-                          }}
-                        >
-                          <span>${speed.label}</span>
-                          ${speedSelected
-                            ? html`<span
-                                class="chat-controls__inline-select-check"
-                                aria-hidden="true"
+        ${showReasoningPanel
+          ? html`
+              <div class="chat-controls__reasoning-panel">
+                ${showReasoning
+                  ? html`
+                      <div class="chat-controls__reasoning-head">
+                        <span class="chat-controls__inline-select-section-label">Reasoning</span>
+                        <span class="chat-controls__reasoning-value">${reasoningValueLabel}</span>
+                      </div>
+                      ${sliderStops.length > 1
+                        ? html`
+                            <div class="chat-controls__reasoning-slider">
+                              <div class="chat-controls__reasoning-dots" aria-hidden="true">
+                                ${sliderStops.map(
+                                  (stop, index) =>
+                                    html`<span
+                                      class="chat-controls__reasoning-dot ${index ===
+                                      defaultStopIndex
+                                        ? "chat-controls__reasoning-dot--default"
+                                        : ""}"
+                                      data-stop=${stop.value}
+                                    ></span>`,
+                                )}
+                              </div>
+                              <input
+                                class="chat-controls__reasoning-range ${hasThinkingOverride
+                                  ? ""
+                                  : "chat-controls__reasoning-range--inherit"}"
+                                type="range"
+                                min="0"
+                                max=${sliderStops.length - 1}
+                                step="1"
+                                .value=${String(sliderIndex)}
+                                style=${`--reasoning-fill: ${sliderFillPercent(sliderIndex)}%`}
+                                data-chat-thinking-slider="true"
+                                data-chat-thinking-values=${sliderStops
+                                  .map((stop) => stop.value)
+                                  .join(",")}
+                                aria-label=${t("chat.selectors.thinkingLevel")}
+                                aria-valuetext=${reasoningValueLabel}
+                                ?disabled=${thinkingDisabled}
+                                @input=${onSliderDrag}
+                                @change=${onSliderCommit}
+                              />
+                            </div>
+                            <div class="chat-controls__reasoning-scale" aria-hidden="true">
+                              <span>Faster</span>
+                              <span>Smarter</span>
+                            </div>
+                          `
+                        : ""}
+                      ${hasThinkingOverride
+                        ? html`
+                            <button
+                              class="chat-controls__reasoning-reset"
+                              data-chat-thinking-option=""
+                              type="button"
+                              ?disabled=${thinkingDisabled}
+                              @click=${async (event: MouseEvent) => {
+                                event.stopPropagation();
+                                if (thinkingDisabled) {
+                                  event.preventDefault();
+                                  return;
+                                }
+                                await onThinkingSelect("");
+                              }}
+                            >
+                              Use default (${defaultLevelLabel})
+                            </button>
+                          `
+                        : ""}
+                    `
+                  : ""}
+                ${fastMode.supported
+                  ? html`
+                      <div class="chat-controls__inline-select-section-label">Speed</div>
+                      <div class="chat-controls__reasoning-options" role="listbox">
+                        ${repeat(
+                          fastMode.options,
+                          (speed) => speed.value,
+                          (speed) => {
+                            const speedValue = speed.value as "" | "on" | "off" | "auto";
+                            const speedSelected = speedValue === fastMode.currentOverride;
+                            return html`
+                              <button
+                                class="chat-controls__reasoning-option ${speedSelected
+                                  ? "chat-controls__reasoning-option--selected"
+                                  : ""}"
+                                data-chat-speed-option=${speed.value}
+                                role="option"
+                                aria-selected=${speedSelected ? "true" : "false"}
+                                type="button"
+                                ?disabled=${fastMode.disabled}
+                                @click=${async (event: MouseEvent) => {
+                                  event.stopPropagation();
+                                  if (fastMode.disabled) {
+                                    event.preventDefault();
+                                    return;
+                                  }
+                                  (event.currentTarget as HTMLElement)
+                                    .closest("details")
+                                    ?.removeAttribute("open");
+                                  await onFastModeSelect(speedValue);
+                                }}
                               >
-                                ${icons.check}
-                              </span>`
-                            : ""}
-                        </button>
-                      `;
-                    },
-                  )}
-                </div>
-              `
-            : ""}
-        </div>
+                                <span>${speed.label}</span>
+                                ${speedSelected
+                                  ? html`<span
+                                      class="chat-controls__inline-select-check"
+                                      aria-hidden="true"
+                                    >
+                                      ${icons.check}
+                                    </span>`
+                                  : ""}
+                              </button>
+                            `;
+                          },
+                        )}
+                      </div>
+                    `
+                  : ""}
+              </div>
+            `
+          : ""}
       </div>
     </details>
   `;

--- a/ui/src/ui/chat/session-controls.ts
+++ b/ui/src/ui/chat/session-controls.ts
@@ -1239,6 +1239,9 @@ function renderChatModelReasoningSelect(params: {
     await onThinkingSelect(stop.value);
   };
   const showReasoning = sliderStops.length > 0;
+  // A one-entry scale is not a slider, but the lone level must stay
+  // selectable from the inherited default (regression guard vs the old list).
+  const onlyStop = sliderStops.length === 1 ? sliderStops[0] : undefined;
   const showReasoningPanel = showReasoning || fastMode.supported;
   return html`
     <details class="chat-controls__session chat-controls__inline-select chat-controls__model">
@@ -1363,7 +1366,37 @@ function renderChatModelReasoningSelect(params: {
                               <span>Smarter</span>
                             </div>
                           `
-                        : ""}
+                        : onlyStop
+                          ? html`
+                              <button
+                                class="chat-controls__reasoning-option ${hasThinkingOverride
+                                  ? "chat-controls__reasoning-option--selected"
+                                  : ""}"
+                                data-chat-thinking-option=${onlyStop.value}
+                                type="button"
+                                aria-pressed=${hasThinkingOverride ? "true" : "false"}
+                                ?disabled=${thinkingDisabled}
+                                @click=${async (event: MouseEvent) => {
+                                  event.stopPropagation();
+                                  if (thinkingDisabled || hasThinkingOverride) {
+                                    event.preventDefault();
+                                    return;
+                                  }
+                                  await onThinkingSelect(onlyStop.value);
+                                }}
+                              >
+                                <span>${onlyStop.label}</span>
+                                ${hasThinkingOverride
+                                  ? html`<span
+                                      class="chat-controls__inline-select-check"
+                                      aria-hidden="true"
+                                    >
+                                      ${icons.check}
+                                    </span>`
+                                  : ""}
+                              </button>
+                            `
+                          : ""}
                       ${hasThinkingOverride
                         ? html`
                             <button

--- a/ui/src/ui/chat/session-controls.ts
+++ b/ui/src/ui/chat/session-controls.ts
@@ -1215,6 +1215,10 @@ function renderChatModelReasoningSelect(params: {
     (option) => option.value === selectedThinkingValue,
   );
   const sliderIndex = Math.max(hasThinkingOverride ? overrideStopIndex : defaultStopIndex, 0);
+  // Inherited defaults like "adaptive" may not exist on the offered scale.
+  // The value label stays truthful ("Default (Adaptive)"); the thumb gets an
+  // unanchored style so its parked position does not read as the default.
+  const sliderUnanchored = !hasThinkingOverride && defaultStopIndex < 0;
   const sliderFillPercent = (index: number) =>
     sliderStops.length > 1 ? (index / (sliderStops.length - 1)) * 100 : 0;
   const reasoningValueLabel = hasThinkingOverride
@@ -1343,7 +1347,9 @@ function renderChatModelReasoningSelect(params: {
                               <input
                                 class="chat-controls__reasoning-range ${hasThinkingOverride
                                   ? ""
-                                  : "chat-controls__reasoning-range--inherit"}"
+                                  : "chat-controls__reasoning-range--inherit"} ${sliderUnanchored
+                                  ? "chat-controls__reasoning-range--unanchored"
+                                  : ""}"
                                 type="range"
                                 min="0"
                                 max=${sliderStops.length - 1}

--- a/ui/src/ui/navigation.browser.test.ts
+++ b/ui/src/ui/navigation.browser.test.ts
@@ -369,14 +369,18 @@ describe("control UI routing", () => {
     app.requestUpdate();
     await app.updateComplete;
 
-    expectElement(app, ".sidebar-version", HTMLElement);
-    const statusDot = expectElement(app, ".sidebar-version__status", HTMLElement);
+    const status = expectElement(app, ".sidebar-status", HTMLElement);
+    const statusDot = expectElement(app, ".sidebar-status__dot", HTMLElement);
     expect(statusDot.getAttribute("aria-label")).toBe("Gateway status: Online");
     expect(statusDot.getAttribute("title")).toBe("Gateway status: Online");
     expect([...statusDot.classList]).toEqual([
-      "sidebar-version__status",
+      "sidebar-status__dot",
       "sidebar-connection-status--online",
     ]);
+    // The gateway version intentionally stays out of the persistent sidebar;
+    // it lives in Settings (Quick Settings footer).
+    expect(status.textContent).not.toContain("1.2.3");
+    expect(app.querySelector(".sidebar-version")).toBeNull();
 
     app.applySettings({ ...app.settings, navWidth: 360 });
     await app.updateComplete;

--- a/ui/src/ui/views/chat.test.ts
+++ b/ui/src/ui/views/chat.test.ts
@@ -4343,6 +4343,35 @@ describe("chat session controls", () => {
     expect(thinkingSelect.title).toContain("Adaptive");
   });
 
+  it("keeps a single available thinking level selectable without a slider", async () => {
+    const { state, request } = createChatHeaderState();
+    state.sessionsResult = createSessionsResultFromRows([
+      {
+        key: "main",
+        kind: "direct",
+        modelProvider: "openai",
+        model: "gpt-5",
+        thinkingLevels: [{ id: "adaptive", label: "adaptive" }],
+        updatedAt: 1,
+      },
+    ]);
+    const container = document.createElement("div");
+    render(renderChatSessionSelect(state), container);
+
+    expect(getThinkingSlider(container)).toBeNull();
+    const only = container.querySelector<HTMLButtonElement>(
+      '[data-chat-thinking-option="adaptive"]',
+    );
+    expect(only).toBeInstanceOf(HTMLButtonElement);
+    expect(only?.getAttribute("aria-pressed")).toBe("false");
+    only?.click();
+
+    expect(request).toHaveBeenCalledWith("sessions.patch", {
+      key: "main",
+      thinkingLevel: "adaptive",
+    });
+  });
+
   it("disables thinking for known non-reasoning models without duplicate off options", () => {
     const { state } = createChatHeaderState({
       model: "mistral:v0.3",

--- a/ui/src/ui/views/chat.test.ts
+++ b/ui/src/ui/views/chat.test.ts
@@ -482,8 +482,34 @@ function getThinkingSelect(container: Element): HTMLElement {
   return select;
 }
 
-function getThinkingOptions(container: Element): HTMLButtonElement[] {
-  return Array.from(container.querySelectorAll<HTMLButtonElement>("[data-chat-thinking-option]"));
+function getThinkingSlider(container: Element): HTMLInputElement | null {
+  return container.querySelector<HTMLInputElement>('[data-chat-thinking-slider="true"]');
+}
+
+function getThinkingSliderValues(container: Element): string[] {
+  const values = getThinkingSlider(container)?.dataset.chatThinkingValues ?? "";
+  return values ? values.split(",") : [];
+}
+
+function setThinkingSliderLevel(container: Element, value: string) {
+  const slider = getThinkingSlider(container);
+  expect(slider).toBeInstanceOf(HTMLInputElement);
+  if (!slider) {
+    return;
+  }
+  const index = getThinkingSliderValues(container).indexOf(value);
+  expect(index).toBeGreaterThanOrEqual(0);
+  slider.value = String(index);
+  slider.dispatchEvent(new Event("change", { bubbles: true }));
+}
+
+function getThinkingReasoningValueLabel(container: Element): string {
+  return container.querySelector(".chat-controls__reasoning-value")?.textContent?.trim() ?? "";
+}
+
+/** The "" (use default) reset button; the only remaining [data-chat-thinking-option]. */
+function getThinkingResetButton(container: Element): HTMLButtonElement | null {
+  return container.querySelector<HTMLButtonElement>('[data-chat-thinking-option=""]');
 }
 
 function requireElement(container: Element, selector: string, label: string): Element {
@@ -4147,11 +4173,8 @@ describe("chat session controls", () => {
     const container = document.createElement("div");
     render(renderChatSessionSelect(state), container);
 
-    const adaptive = getThinkingOptions(container).find(
-      (option) => option.dataset.chatThinkingOption === "adaptive",
-    );
-    expect(adaptive).toBeInstanceOf(HTMLButtonElement);
-    adaptive?.click();
+    expect(getThinkingSliderValues(container)).toEqual(["off", "adaptive"]);
+    setThinkingSliderLevel(container, "adaptive");
 
     expect(request).toHaveBeenCalledWith("sessions.patch", {
       key: "global",
@@ -4299,22 +4322,9 @@ describe("chat session controls", () => {
     const container = document.createElement("div");
     render(renderChatSessionSelect(state), container);
 
-    const thinkingOptions = getThinkingOptions(container);
-
-    expect(thinkingOptions.map((option) => option.dataset.chatThinkingOption)).toEqual([
-      "",
-      "off",
-      "adaptive",
-      "xhigh",
-      "max",
-    ]);
-    expect(thinkingOptions.map((option) => option.textContent?.trim())).toEqual([
-      "Default",
-      "Off",
-      "Adaptive",
-      "Extra high",
-      "Maximum",
-    ]);
+    expect(getThinkingSliderValues(container)).toEqual(["off", "adaptive", "xhigh", "max"]);
+    // No override -> inherit state: no reset affordance.
+    expect(getThinkingResetButton(container)).toBeNull();
   });
 
   it("labels chat thinking default from the active session row", () => {
@@ -4327,10 +4337,9 @@ describe("chat session controls", () => {
     render(renderChatSessionSelect(state), container);
 
     const thinkingSelect = getThinkingSelect(container);
-    const thinkingOptions = getThinkingOptions(container);
 
     expect(getChatThinkingValue(thinkingSelect)).toBe("");
-    expect(thinkingOptions[0]?.textContent?.trim()).toBe("Default");
+    expect(getThinkingReasoningValueLabel(container)).toBe("Default (Adaptive)");
     expect(thinkingSelect.title).toContain("Adaptive");
   });
 
@@ -4366,11 +4375,11 @@ describe("chat session controls", () => {
     render(renderChatSessionSelect(state), container);
 
     const thinkingSelect = getThinkingSelect(container);
-    const thinkingOptions = getThinkingOptions(container);
 
     expect(thinkingSelect.dataset.chatThinkingDisabled).toBe("true");
-    expect(thinkingOptions.map((option) => option.dataset.chatThinkingOption)).toEqual([""]);
-    expect(thinkingOptions.map((option) => option.textContent?.trim())).toEqual(["Default"]);
+    // No reasoning levels -> no slider and no reset control at all.
+    expect(getThinkingSlider(container)).toBeNull();
+    expect(getThinkingResetButton(container)).toBeNull();
   });
 
   it("does not label a non-default chat model from global thinking defaults", () => {
@@ -4397,9 +4406,9 @@ describe("chat session controls", () => {
     const container = document.createElement("div");
     render(renderChatSessionSelect(state), container);
 
-    const thinkingOptions = getThinkingOptions(container);
-
-    expect(thinkingOptions[0]?.textContent?.trim()).toBe("Default");
+    // The session model is reasoning-capable, so the inherited default must
+    // come from the model (low), not the unrelated global session default (off).
+    expect(getThinkingReasoningValueLabel(container)).toBe("Default (Low)");
   });
 
   it("always renders full thinking labels", () => {
@@ -4424,19 +4433,12 @@ describe("chat session controls", () => {
     render(renderChatSessionSelect(state), container);
 
     const thinkingSelect = getThinkingSelect(container);
-    const thinkingOptions = getThinkingOptions(container);
 
     expect(container.querySelector('[data-chat-thinking-select-compact="true"]')).toBeNull();
     expect(getChatThinkingValue(thinkingSelect)).toBe("");
     expect(thinkingSelect.title).toContain("High");
-    expect(thinkingOptions.map((option) => option.textContent?.trim())).toEqual([
-      "Default",
-      "Off",
-      "Low",
-      "Medium",
-      "High",
-      "Extra high",
-    ]);
+    expect(getThinkingSliderValues(container)).toEqual(["off", "low", "medium", "high", "xhigh"]);
+    expect(getThinkingReasoningValueLabel(container)).toBe("Default (High)");
   });
 
   it("labels chat thinking default from session defaults when the row is absent", () => {
@@ -4448,10 +4450,9 @@ describe("chat session controls", () => {
     render(renderChatSessionSelect(state), container);
 
     const thinkingSelect = getThinkingSelect(container);
-    const thinkingOptions = getThinkingOptions(container);
 
     expect(getChatThinkingValue(thinkingSelect)).toBe("");
-    expect(thinkingOptions[0]?.textContent?.trim()).toBe("Default");
+    expect(getThinkingReasoningValueLabel(container)).toBe("Default (Adaptive)");
     expect(thinkingSelect.title).toContain("Adaptive");
   });
 });

--- a/ui/src/ui/views/chat.test.ts
+++ b/ui/src/ui/views/chat.test.ts
@@ -4341,6 +4341,28 @@ describe("chat session controls", () => {
     expect(getChatThinkingValue(thinkingSelect)).toBe("");
     expect(getThinkingReasoningValueLabel(container)).toBe("Default (Adaptive)");
     expect(thinkingSelect.title).toContain("Adaptive");
+    // "adaptive" is not one of the offered stops, so the parked thumb must
+    // render as unanchored instead of pretending the default is "off".
+    expect(getThinkingSliderValues(container)).not.toContain("adaptive");
+    expect(
+      getThinkingSlider(container)?.classList.contains(
+        "chat-controls__reasoning-range--unanchored",
+      ),
+    ).toBe(true);
+  });
+
+  it("anchors the slider thumb on the inherited default when it is a stop", () => {
+    const { state } = createChatHeaderState({
+      model: "gpt-5.5",
+      modelProvider: "openai",
+      thinkingDefault: "medium",
+    });
+    const container = document.createElement("div");
+    render(renderChatSessionSelect(state), container);
+
+    const slider = getThinkingSlider(container);
+    expect(slider?.classList.contains("chat-controls__reasoning-range--unanchored")).toBe(false);
+    expect(slider?.value).toBe(String(getThinkingSliderValues(container).indexOf("medium")));
   });
 
   it("keeps a single available thinking level selectable without a slider", async () => {


### PR DESCRIPTION
Closes #99837

## What Problem This Solves

The Control UI chat surface carries chrome that competes with the content. The model picker and provider-usage pill are bordered, filled buttons sitting inside the already-framed composer; the reasoning level is a seven-item text-button list in a flyout; and the sidebar permanently shows a boxed `VERSION vYYYY.M.P` pill for metadata nobody needs at a glance. The overall effect is a busy shell where sessions and the conversation should dominate.

## Why This Change Was Made

Three scoped moves, modeled on minimal agent composers (Cursor's Effort slider being the reference):

- **Composer controls become quiet text controls.** `.chat-controls__inline-select-trigger` and `.chat-controls__quota` lose border/fill at rest and get a soft hover/open wash. The trigger shows just the model name unless a reasoning override is active (title/aria keep the full `model · level` pair).
- **Reasoning becomes a discrete Faster ↔ Smarter slider** over the ordered levels the gateway offers, rendered as a native `<input type="range">` (keyboard/a11y for free) with stop dots, a filled track segment glued to the thumb, the inherited default marked on the track, a live value label (`High` / `Default (Medium)`), and a one-click `Use default (…)` reset. Commits happen on release (`change`), not per drag tick. A one-entry level list renders as a single toggle button instead of a slider so the lone level stays selectable. Models without reasoning levels now show no dead "Default"-only list at all.
- **The sidebar version pill becomes a slim status line** (connection dot + Online/Offline). The gateway version stays visible where it belongs: Settings → Quick Settings connection footer, which already renders `Connected · <assistant> · v<version>`.

Deliberate non-goal: reducing the sidebar nav IA itself — that is a separate product decision (noted in #99837).

## User Impact

The chat surface reads much closer to a minimal editor composer: one framed input, plain text controls, and a reasoning scale you can drag instead of a list you parse. The persistent version badge is gone from every screen; connectivity stays visible at a glance, and the version remains one click away in Settings.

## Evidence

All captures come from the repo's mock-gateway e2e harness (deterministic fabricated demo data, 1440×900@2x, dark theme), before = `main`, after = this branch.

### Composer (closed)

| Before | After |
| --- | --- |
| <img src="https://github.com/steipete/openclaw-pr-assets/releases/download/control-ui-declutter/before-composer.png" width="470" alt="Composer before: bordered model and usage pills" /> | <img src="https://github.com/steipete/openclaw-pr-assets/releases/download/control-ui-declutter/after-composer.png" width="470" alt="Composer after: borderless text controls" /> |

### Model picker + reasoning

| Before | After |
| --- | --- |
| <img src="https://github.com/steipete/openclaw-pr-assets/releases/download/control-ui-declutter/before-picker-open.png" width="470" alt="Picker before: reasoning as a text-button list" /> | <img src="https://github.com/steipete/openclaw-pr-assets/releases/download/control-ui-declutter/after-picker-open.png" width="470" alt="Picker after: Faster–Smarter effort slider with default marker and reset" /> |

### Sidebar footer

| Before | After |
| --- | --- |
| <img src="https://github.com/steipete/openclaw-pr-assets/releases/download/control-ui-declutter/before-sidebar-footer.png" width="470" alt="Sidebar footer before: boxed VERSION pill" /> | <img src="https://github.com/steipete/openclaw-pr-assets/releases/download/control-ui-declutter/after-sidebar-footer.png" width="470" alt="Sidebar footer after: slim connection status line" /> |

### Full chat view

| Before | After |
| --- | --- |
| <img src="https://github.com/steipete/openclaw-pr-assets/releases/download/control-ui-declutter/before-chat.png" width="470" alt="Chat before" /> | <img src="https://github.com/steipete/openclaw-pr-assets/releases/download/control-ui-declutter/after-chat.png" width="470" alt="Chat after" /> |

### Version still visible in Settings

<img src="https://github.com/steipete/openclaw-pr-assets/releases/download/control-ui-declutter/after-settings.png" width="700" alt="Settings Quick Settings footer showing Connected · OpenClaw · v2026.7.2" />

### Validation

- `node scripts/run-vitest.mjs ui/src/ui/views/chat.test.ts ui/src/ui/chat-model-select-state.test.ts ui/src/ui/app-chat.test.ts ui/src/ui/navigation.browser.test.ts ui/src/ui/app-render.helpers.browser.test.ts ui/src/ui/chat/chat-responsive.browser.test.ts` — 258 tests pass, including new coverage: slider drives `sessions.patch` with the selected level, singleton level renders as a selectable toggle, no-reasoning models render no dead control, sidebar shows no version text.
- `tsgo` core lane, `oxfmt --check`, `oxlint`, and `control-ui-i18n check` all clean; the two new visible strings (`Faster`, `Smarter`) are registered in the raw-copy baseline via the documented `control-ui-i18n sync --write` flow, matching how this picker's existing labels (Model/Reasoning/Speed/Default) are handled.
- Codex autoreview (gpt-5.5): one accepted finding — singleton level lists lost their only control — fixed in `fix(ui): keep a single available thinking level selectable` with a regression test; one rejected finding (claimed i18n drift for `Use default (`) disproven by running the actual checker, which exits clean because mixed text+interpolation nodes are not raw-copy chunks.
- Net diff is +~250 LOC, dominated by cross-browser slider CSS (`::-webkit-slider-*`, `::-moz-range-*`) for the genuinely new control; the sidebar/status and picker markup shrink.

Tests-only DOM contract change: thinking options moved from `[data-chat-thinking-option]` buttons to a `[data-chat-thinking-slider]` range input carrying `data-chat-thinking-values`; the `""` reset keeps the old attribute so default-reset flows stay covered.
