### PR TITLE
fix(gateway): preserve legacy reseed attachments

### DIFF
--- a/src/gateway/cli-session-history.claude.ts
+++ b/src/gateway/cli-session-history.claude.ts
@@ -102,6 +102,12 @@ function cloneJsonValue<T>(value: T): T {
   return structuredClone(value);
 }
 
+function removeContentBlock<T>(content: T[], blockIndex: number): T[] | null {
+  const nextContent = cloneJsonValue(content);
+  nextContent.splice(blockIndex, 1);
+  return nextContent.length > 0 ? nextContent : null;
+}
+
 function normalizeClaudeCliContent(
   content: string | unknown[],
   toolNameRegistry: ToolNameRegistry,
@@ -305,9 +311,8 @@ function parseClaudeCliHistoryEntry(
           }
           // The receipt proves only the matching text block is synthetic.
           // Preserve sibling images or other native content that has no local duplicate proof.
-          const nextContent = cloneJsonValue(content);
-          nextContent.splice(candidate.blockIndex, 1);
-          if (nextContent.length === 0) {
+          const nextContent = removeContentBlock(content, candidate.blockIndex);
+          if (!nextContent) {
             return null;
           }
           content = nextContent;
@@ -316,12 +321,20 @@ function parseClaudeCliHistoryEntry(
         for (const candidate of promptTextCandidates) {
           const reseedPrompt = parseCliReseedPrompt(candidate.text);
           if (reseedPrompt.kind === "legacy") {
-            if (!reseedPrompt.userMessage) {
-              return null;
-            }
             if (candidate.blockIndex === undefined) {
+              if (!reseedPrompt.userMessage) {
+                return null;
+              }
               content = reseedPrompt.userMessage;
             } else if (Array.isArray(content)) {
+              if (!reseedPrompt.userMessage) {
+                const contentWithoutReseed = removeContentBlock(content, candidate.blockIndex);
+                if (!contentWithoutReseed) {
+                  return null;
+                }
+                content = contentWithoutReseed;
+                break;
+              }
               const nextContent = cloneJsonValue(content);
               const block = nextContent[candidate.blockIndex];
               if (block && typeof block === "object") {

--- a/src/gateway/cli-session-history.test.ts
+++ b/src/gateway/cli-session-history.test.ts
@@ -609,6 +609,60 @@ describe("cli session history", () => {
     });
   });
 
+  it("drops empty legacy reseed text while preserving sibling native content", async () => {
+    await withClaudeProjectsDir(async ({ homeDir, sessionId, filePath }) => {
+      const caption = { type: "text", text: "real caption" };
+      const image = {
+        type: "image",
+        source: { type: "base64", media_type: "image/png", data: "x" },
+      };
+      const document = { type: "document", source: { type: "text", data: "notes" } };
+      await fs.writeFile(
+        filePath,
+        `${JSON.stringify({
+          type: "user",
+          uuid: "legacy-empty-reseed",
+          message: {
+            role: "user",
+            content: [
+              caption,
+              { type: "text", text: buildLegacyReseedPrompt("") },
+              image,
+              document,
+            ],
+          },
+        })}\n`,
+        "utf-8",
+      );
+
+      const messages = readClaudeCliSessionMessages({ cliSessionId: sessionId, homeDir });
+
+      expect(messages).toHaveLength(1);
+      expect(readRecord(messages[0]).content).toEqual([caption, image, document]);
+    });
+  });
+
+  it.each([
+    ["string", buildLegacyReseedPrompt("")],
+    ["single text block", [{ type: "text", text: buildLegacyReseedPrompt("") }]],
+  ])("drops empty legacy reseed rows in %s form", async (_label, content) => {
+    await withClaudeProjectsDir(async ({ homeDir, sessionId, filePath }) => {
+      await fs.writeFile(
+        filePath,
+        `${JSON.stringify({
+          type: "user",
+          uuid: "legacy-empty-reseed",
+          message: { role: "user", content },
+        })}\n`,
+        "utf-8",
+      );
+
+      const messages = readClaudeCliSessionMessages({ cliSessionId: sessionId, homeDir });
+
+      expect(messages).toEqual([]);
+    });
+  });
+
   it("fails open when the first user row does not match the reseed receipt", async () => {
     await withClaudeProjectsDir(async ({ homeDir, sessionId, filePath }) => {
       const expectedPrompt = "expected synthetic prompt";


### PR DESCRIPTION
Follow-up to #99653.

## What Problem This Solves

Legacy Claude CLI reseed rows can contain an empty `<next_user_message>` text block alongside an image, document, or other native user content. The importer returned `null` for the whole row, hiding those sibling blocks from visible OpenClaw history.

## Why This Change Was Made

The importer now applies one invariant to receipt-backed and legacy reseed rows: remove only the proven synthetic text block, and drop the row only when no content remains.

Scalar and single-text-block empty reseeds keep their existing suppression behavior. Mixed native content preserves sibling order and bytes.

## User Impact

Image-only and attachment-bearing legacy Claude turns remain visible after reseed import instead of disappearing with the empty synthetic wrapper.

## Evidence

- `node scripts/run-vitest.mjs src/gateway/cli-session-history.test.ts`
  - 4 files, 148 tests passed
- `oxfmt --check` and `oxlint --deny-warnings` passed for both changed files
- `git diff --check` passed
- Autoreview: clean, no actionable findings, confidence 0.97
- Blacksmith Testbox `tbx_01kwnvp27dr9wa2xhv78wkqgzc`
  - `pnpm check:changed` passed for core and core-tests
  - hydration run: https://github.com/openclaw/openclaw/actions/runs/28697153121
