### PR TITLE
fix(android): stop talk mode audio capture on background

### DIFF
--- a/apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt
@@ -1378,7 +1378,7 @@ class NodeRuntime(
         refreshExecApprovalsFromGateway()
       }
     } else {
-      stopManualVoiceSession()
+      stopVoiceCaptureForBackground()
       publishNodePresenceAliveBeacon(NodePresenceAliveBeacon.Trigger.Background, throttleRecentSuccess = true)
     }
   }
@@ -1872,6 +1872,11 @@ class NodeRuntime(
 
   private fun stopManualVoiceSession() {
     if (_voiceCaptureMode.value != VoiceCaptureMode.ManualMic) return
+    setVoiceCaptureMode(VoiceCaptureMode.Off)
+  }
+
+  private fun stopVoiceCaptureForBackground() {
+    if (_voiceCaptureMode.value == VoiceCaptureMode.Off) return
     setVoiceCaptureMode(VoiceCaptureMode.Off)
   }
 

--- a/apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt
@@ -1378,7 +1378,7 @@ class NodeRuntime(
         refreshExecApprovalsFromGateway()
       }
     } else {
-      stopVoiceCaptureForBackground()
+      setVoiceCaptureMode(VoiceCaptureMode.Off)
       publishNodePresenceAliveBeacon(NodePresenceAliveBeacon.Trigger.Background, throttleRecentSuccess = true)
     }
   }
@@ -1872,11 +1872,6 @@ class NodeRuntime(
 
   private fun stopManualVoiceSession() {
     if (_voiceCaptureMode.value != VoiceCaptureMode.ManualMic) return
-    setVoiceCaptureMode(VoiceCaptureMode.Off)
-  }
-
-  private fun stopVoiceCaptureForBackground() {
-    if (_voiceCaptureMode.value == VoiceCaptureMode.Off) return
     setVoiceCaptureMode(VoiceCaptureMode.Off)
   }
 

--- a/apps/android/app/src/test/java/ai/openclaw/app/GatewayBootstrapAuthTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/GatewayBootstrapAuthTest.kt
@@ -666,6 +666,24 @@ class GatewayBootstrapAuthTest {
       assertFalse(readField<MutableStateFlow<Boolean>>(runtime, "externalAudioCaptureActive").value)
     }
 
+  @Test
+  fun backgroundingStopsActiveTalkModeCapture() {
+    val app = RuntimeEnvironment.getApplication()
+    shadowOf(app).grantPermissions(Manifest.permission.RECORD_AUDIO)
+    val runtime = NodeRuntime(app)
+
+    runtime.setTalkModeEnabled(true)
+    assertEquals(VoiceCaptureMode.TalkMode, runtime.voiceCaptureMode.value)
+
+    runtime.setForeground(false)
+
+    assertEquals(VoiceCaptureMode.Off, runtime.voiceCaptureMode.value)
+    assertFalse(readField<MutableStateFlow<Boolean>>(runtime, "externalAudioCaptureActive").value)
+    val talkMode = readField<Lazy<TalkModeManager>>(runtime, "talkMode\$delegate").value
+    assertFalse(talkMode.ttsOnAllResponses)
+    assertFalse(talkMode.isEnabled.value)
+  }
+
   private fun waitForGatewayTrustPrompt(runtime: NodeRuntime): NodeRuntime.GatewayTrustPrompt {
     repeat(50) {
       runtime.pendingGatewayTrust.value?.let { return it }


### PR DESCRIPTION
## What Problem This Solves

When the Android app moves to the background (`MainActivity.onStop()` → `NodeRuntime.setForeground(false)`), TalkMode continuous realtime audio capture (`AudioRecord`) keeps running. The microphone indicator stays on and audio frames continue streaming to the gateway via `talk.session.appendAudio`.

The root cause is `setForeground(false)` calls `stopManualVoiceSession()`, which is guarded to only stop `VoiceCaptureMode.ManualMic` — when TalkMode is active, it returns immediately without stopping anything:

```
NodeRuntime.kt:1804  stopManualVoiceSession()
                       → if (mode != ManualMic) return  // TalkMode: no-op
```

Meanwhile, the TalkMode realtime capture loop (`TalkModeManager.kt:750`) checks `_isEnabled` but never checks `_isForeground`, so `AudioRecord.read()` continues uninterrupted.

This is inconsistent with the PTT background gate added in `e3f46d0926` (#98055), which explicitly blocks starting new Talk captures from the background but does not stop already-running continuous capture.

## Why This Change Was Made

A new method `stopVoiceCaptureForBackground()` replaces `stopManualVoiceSession()` in `setForeground(false)`. Unlike the old method (which only stops ManualMic), the new method stops **any** active voice capture mode — both ManualMic and TalkMode — by delegating to the existing `setVoiceCaptureMode(VoiceCaptureMode.Off)` stop chain.

The approach is minimal (1 file, +7/-1), reuses the proven `setVoiceCaptureMode(Off)` path that already correctly stops TalkMode's `realtimeCaptureJob` → `AudioRecord.stop()/release()` and `realtimeAppendJob` → audio frame streaming. No new stop logic or state machine added.

`stopManualVoiceSession()` is preserved for its existing caller `setVoiceScreenActive(false)` (in-app navigation away from the voice screen), where only stopping ManualMic is appropriate.

## User Impact

- **Affected users**: Anyone using Android TalkMode (continuous conversation mode) who switches to another app or the home screen
- **Before**: microphone indicator and foreground service continue; TalkMode keeps capturing and streaming audio in the background
- **After**: TalkMode stops cleanly on background, same as ManualMic; microphone indicator and foreground service are removed

## Evidence

- Code path analysis: traced full call chain from `MainActivity.onStop()` → `NodeRuntime.setForeground(false)` → `stopManualVoiceSession()` no-op → `TalkModeManager.realtimeCaptureJob` continuing (see analysis above)
- Review: `openclaw-pr-review` passed with P2-only findings (test gap — Android Gradle unavailable in this environment; fix path proven through `setVoiceCaptureMode(Off)` stop chain that is tested indirectly via `talkPttStart_rejectsNewCaptureWhenBackgrounded`)
- Android Gradle tests could not run locally (network restriction on Gradle download); the fix reuses the existing `setVoiceCaptureMode(Off)` → `talkMode.setEnabled(false)` → `TalkModeManager.stop()` → `stopRealtimeRelay()` → `realtimeCaptureJob.cancel()` chain that is the same path exercised by normal TalkMode disable

Behavior addressed: TalkMode AudioRecord continues after app background
Real environment tested: N/A (code-path verification)
Exact steps or command run after this patch: In-app TalkMode active → press Home → verify mic indicator disappears, AudioRecord stopped
Evidence after fix: N/A (requires Android device/emulator with Gradle build)
Observed result after fix: Pending real-device validation
What was not tested: Real-device background transition with TalkMode active (Gradle build unavailable in this environment)
