### PR TITLE
fix(agents): preserve fallback tool-call hints

### DIFF
--- a/src/agents/command/attempt-execution.helpers.ts
+++ b/src/agents/command/attempt-execution.helpers.ts
@@ -12,7 +12,11 @@ import {
   startsWithSilentToken,
   stripLeadingSilentToken,
 } from "../../auto-reply/tokens.js";
-import { resolveToolUseId, type ToolContentBlock } from "../../chat/tool-content.js";
+import {
+  isToolCallBlock,
+  resolveToolUseId,
+  type ToolContentBlock,
+} from "../../chat/tool-content.js";
 import {
   type ClaudeCliFallbackSeed,
   readClaudeCliFallbackSeed,
@@ -320,7 +324,7 @@ function extractFallbackTurnText(message: FallbackTurnLikeMessage): string {
     // Tool calls: render as a compact "(tool: name)" hint so the fallback
     // model sees the conversation flow without the full tool argument blob,
     // which is rarely useful out of context and chews through char budget.
-    if (rec.type === "tool_use" && typeof rec.name === "string") {
+    if (isToolCallBlock(rec) && typeof rec.name === "string") {
       parts.push(`(tool call: ${rec.name})`);
       continue;
     }

--- a/src/agents/command/attempt-execution.test.ts
+++ b/src/agents/command/attempt-execution.test.ts
@@ -166,7 +166,7 @@ describe("formatClaudeCliFallbackPrelude", () => {
           role: "assistant",
           content: [
             { type: "text", text: "Earlier assistant reply" },
-            { type: "tool_use", name: "Bash" },
+            { type: "toolcall", name: "Bash" },
           ],
         },
         {
@@ -269,7 +269,10 @@ describe("buildClaudeCliFallbackContextPrelude", () => {
           message: {
             role: "assistant",
             model: "claude-sonnet-4-6",
-            content: [{ type: "text", text: "prior answer about blue-green" }],
+            content: [
+              { type: "text", text: "prior answer about blue-green" },
+              { type: "tool_use", id: "toolu_1", name: "Bash", input: { command: "pwd" } },
+            ],
           },
         },
       ];
@@ -285,6 +288,7 @@ describe("buildClaudeCliFallbackContextPrelude", () => {
       expect(prelude).toContain("## Prior session context (from claude-cli)");
       expect(prelude).toContain("user: prior question about deploys");
       expect(prelude).toContain("assistant: prior answer about blue-green");
+      expect(prelude).toContain("(tool call: Bash)");
     } finally {
       await fs.rm(tmpHome, { recursive: true, force: true });
     }


### PR DESCRIPTION
Follow-up to #99653.

## What Problem This Solves

Claude CLI history import normalizes native `tool_use` blocks to OpenClaw's provider-neutral `toolcall` shape. Cross-provider fallback formatting still checked only for raw `tool_use`, so tool-call hints disappeared from the fallback context while tool results remained.

## Why This Change Was Made

The fallback formatter now uses the shared `isToolCallBlock` contract instead of duplicating one provider spelling.

Tests cover both sides of the boundary:

- the formatter receives canonical `toolcall`;
- a real Claude JSONL fixture starts with native `tool_use`, passes through importer normalization, and still renders the compact tool-call hint.

## User Impact

When Claude CLI falls back to another model, the replacement model retains the prior tool-call sequence instead of seeing missing calls or orphaned results.

## Evidence

- `node scripts/run-vitest.mjs src/agents/command/attempt-execution.test.ts`
  - 1 file, 58 tests passed
- Changed-file `oxfmt`, `oxlint --deny-warnings`, and `git diff --check` passed
- Autoreview: clean, no actionable findings, confidence 0.98
- Three independent best-fix/security/parser reviews: clean
- Blacksmith Testbox `tbx_01kwnwx0qgqrsmkyagjw77f6af`
  - `pnpm check:changed` passed for core and core-tests
  - hydration run: https://github.com/openclaw/openclaw/actions/runs/28697669175
