### PR TITLE
fix(acpx): handle MCP proxy stdio pipe errors

### DIFF
--- a/extensions/acpx/src/runtime-internals/mcp-proxy.mjs
+++ b/extensions/acpx/src/runtime-internals/mcp-proxy.mjs
@@ -104,21 +104,48 @@ function main() {
   }
 
   const input = createInterface({ input: process.stdin });
+  let exiting = false;
+
+  const exitWithError = (error) => {
+    if (exiting) {
+      return;
+    }
+    exiting = true;
+    input.close();
+    child.kill();
+    process.stderr.write(`${formatErrorMessage(error)}\n`);
+    process.exit(1);
+  };
+
+  child.stdin.on("error", exitWithError);
+  child.stdout.on("error", exitWithError);
+
   input.on("line", (line) => {
-    child.stdin.write(`${rewriteLine(line, mcpServers)}\n`);
+    if (exiting) {
+      return;
+    }
+    child.stdin.write(`${rewriteLine(line, mcpServers)}\n`, (error) => {
+      if (error) {
+        exitWithError(error);
+      }
+    });
   });
   input.on("close", () => {
+    if (exiting || child.stdin.destroyed || child.stdin.writableEnded) {
+      return;
+    }
     child.stdin.end();
   });
 
   child.stdout.pipe(process.stdout);
 
-  child.on("error", (error) => {
-    process.stderr.write(`${formatErrorMessage(error)}\n`);
-    process.exit(1);
-  });
+  child.on("error", exitWithError);
 
   child.on("close", (code, signal) => {
+    if (exiting) {
+      return;
+    }
+    exiting = true;
     if (signal) {
       process.kill(process.pid, signal);
       return;

--- a/extensions/acpx/src/runtime-internals/mcp-proxy.mjs
+++ b/extensions/acpx/src/runtime-internals/mcp-proxy.mjs
@@ -118,7 +118,7 @@ function main() {
   };
 
   child.stdin.on("error", exitWithError);
-  child.stdout.on("error", exitWithError);
+  process.stdout.on("error", exitWithError);
 
   input.on("line", (line) => {
     if (exiting) {

--- a/extensions/acpx/src/runtime-internals/mcp-proxy.test.ts
+++ b/extensions/acpx/src/runtime-internals/mcp-proxy.test.ts
@@ -10,6 +10,10 @@ import { afterEach, describe, expect, it } from "vitest";
 const tempDirs: string[] = [];
 const proxyPath = path.resolve(bundledPluginFile("acpx", "src/runtime-internals/mcp-proxy.mjs"));
 
+function encodePayload(payload: Record<string, unknown>): string {
+  return Buffer.from(JSON.stringify(payload), "utf8").toString("base64url");
+}
+
 async function makeTempScript(name: string, content: string): Promise<string> {
   const dir = await mkdtemp(path.join(os.tmpdir(), "openclaw-acpx-mcp-proxy-"));
   tempDirs.push(dir);
@@ -55,20 +59,17 @@ rl.on("line", (line) => process.stdout.write(line + "\n"));
 `,
     );
 
-    const payload = Buffer.from(
-      JSON.stringify({
-        targetCommand: `${process.execPath} ${echoServerPath}`,
-        mcpServers: [
-          {
-            name: "canva",
-            command: "npx",
-            args: ["-y", "mcp-remote@latest", "https://mcp.canva.com/mcp"],
-            env: [{ name: "CANVA_TOKEN", value: "secret" }],
-          },
-        ],
-      }),
-      "utf8",
-    ).toString("base64url");
+    const payload = encodePayload({
+      targetCommand: `${process.execPath} ${echoServerPath}`,
+      mcpServers: [
+        {
+          name: "canva",
+          command: "npx",
+          args: ["-y", "mcp-remote@latest", "https://mcp.canva.com/mcp"],
+          env: [{ name: "CANVA_TOKEN", value: "secret" }],
+        },
+      ],
+    });
 
     const child = spawn(process.execPath, [proxyPath, "--payload", payload], {
       stdio: ["pipe", "pipe", "inherit"],
@@ -127,5 +128,60 @@ rl.on("line", (line) => process.stdout.write(line + "\n"));
     expect(lines[1].params.mcpServers).toEqual(lines[0].params.mcpServers);
     expect(lines[2].method).toBe("session/prompt");
     expect(lines[2].params.mcpServers).toBeUndefined();
+  });
+
+  it("reports target stdin pipe failures without an unhandled stream error", async () => {
+    const closedStdinServerPath = await makeTempScript(
+      "closed-stdin-server.cjs",
+      String.raw`#!/usr/bin/env node
+const fs = require("node:fs");
+fs.closeSync(0);
+process.stdout.write("ready\n");
+setTimeout(() => {}, 30_000);
+`,
+    );
+
+    const payload = encodePayload({
+      targetCommand: `${process.execPath} ${closedStdinServerPath}`,
+      mcpServers: [],
+    });
+
+    const child = spawn(process.execPath, [proxyPath, "--payload", payload], {
+      stdio: ["pipe", "pipe", "pipe"],
+      cwd: process.cwd(),
+    });
+
+    let stdout = "";
+    let stderr = "";
+    const ready = new Promise<void>((resolve) => {
+      child.stdout.on("data", (chunk) => {
+        stdout += String(chunk);
+        if (stdout.includes("ready\n")) {
+          resolve();
+        }
+      });
+    });
+    child.stderr.on("data", (chunk) => {
+      stderr += String(chunk);
+    });
+
+    await ready;
+    child.stdin.write(
+      `${JSON.stringify({
+        jsonrpc: "2.0",
+        id: 1,
+        method: "session/new",
+        params: { cwd: process.cwd(), mcpServers: [] },
+      })}\n`,
+    );
+    child.stdin.end();
+
+    const exitCode = await new Promise<number | null>((resolve) => {
+      child.once("close", (code) => resolve(code));
+    });
+
+    expect(exitCode).toBe(1);
+    expect(stderr).toMatch(/EPIPE|write/i);
+    expect(stderr).not.toContain("Unhandled 'error' event");
   });
 });

--- a/extensions/acpx/src/runtime-internals/mcp-proxy.test.ts
+++ b/extensions/acpx/src/runtime-internals/mcp-proxy.test.ts
@@ -184,4 +184,58 @@ setTimeout(() => {}, 30_000);
     expect(stderr).toMatch(/EPIPE|write/i);
     expect(stderr).not.toContain("Unhandled 'error' event");
   });
+
+  it("reports proxy stdout pipe failures without an unhandled stream error", async () => {
+    const outputServerPath = await makeTempScript(
+      "output-server.cjs",
+      String.raw`#!/usr/bin/env node
+const { createInterface } = require("node:readline");
+process.stderr.write("ready\n");
+createInterface({ input: process.stdin }).once("line", () => {
+  process.stdout.write("x".repeat(1024 * 1024));
+});
+setTimeout(() => {}, 30_000);
+`,
+    );
+
+    const payload = encodePayload({
+      targetCommand: `${process.execPath} ${outputServerPath}`,
+      mcpServers: [],
+    });
+
+    const child = spawn(process.execPath, [proxyPath, "--payload", payload], {
+      stdio: ["pipe", "pipe", "pipe"],
+      cwd: process.cwd(),
+    });
+
+    let stderr = "";
+    const ready = new Promise<void>((resolve) => {
+      child.stderr.on("data", (chunk) => {
+        stderr += String(chunk);
+        if (stderr.includes("ready\n")) {
+          resolve();
+        }
+      });
+    });
+
+    await ready;
+    child.stdout.destroy();
+    child.stdin.write(
+      `${JSON.stringify({
+        jsonrpc: "2.0",
+        id: 1,
+        method: "session/new",
+        params: { cwd: process.cwd(), mcpServers: [] },
+      })}\n`,
+    );
+    child.stdin.end();
+
+    const exitCode = await new Promise<number | null>((resolve) => {
+      child.once("close", (code) => resolve(code));
+    });
+
+    expect(exitCode).toBe(1);
+    expect(stderr).toMatch(/EPIPE|write/i);
+    expect(stderr).not.toContain("Unhandled 'error' event");
+  });
 });


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where ACPX MCP proxy sessions could crash with an unhandled stream error when the proxied MCP target closed its stdio pipe while OpenClaw was still forwarding input.

## Why This Change Was Made

The proxy now treats child `stdin` and `stdout` stream failures as controlled process failures, and checks the `stdin.write` callback so pipe errors are reported once instead of bubbling as uncaught Node stream errors. Normal request rewriting and target exit propagation stay unchanged.

## User Impact

Operators get a clear proxy failure instead of an unhandled exception when a target MCP process closes its stdio unexpectedly.

## Evidence

- `node scripts/run-vitest.mjs extensions/acpx/src/runtime-internals/mcp-proxy.test.ts`: 1 file passed, 3 tests passed.
- `pnpm exec oxfmt --check extensions/acpx/src/runtime-internals/mcp-proxy.mjs extensions/acpx/src/runtime-internals/mcp-proxy.test.ts`: all matched files use the correct format.
- `git diff --check`: no whitespace errors.

```text
$ node scripts/run-vitest.mjs extensions/acpx/src/runtime-internals/mcp-proxy.test.ts
Test Files  1 passed (1)
Tests       3 passed (3)
```

- Live closed-stdio proxy run against a temporary target that closes fd 0: controlled `write EPIPE`, exit code 1, and no unhandled stream error.

```text
$ node live closed-stdio MCP proxy proof
proxy=extensions/acpx/src/runtime-internals/mcp-proxy.mjs
target=temporary Node MCP target that closes fd 0 before proxy writes
stdout="target-ready"
stderr="write EPIPE"
exitCode=1
signal=none
unhandledError=no
```

AI-assisted: built with Codex

