### PR TITLE
fix(ios): reject loopback-prefix hosts for auth retry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,6 +71,7 @@ Docs: https://docs.openclaw.ai
 - **TUI new-session hooks:** create `/new` sessions through the shared Gateway lifecycle so command and session hooks receive the completed parent transcript in both Gateway and embedded modes, while preventing rollover during an active turn. (#100241, #49918) Thanks @BingqingLyu.
 - **TUI abort diagnostics:** show sanitized tool argument-validation summaries for aborted runs in both Gateway and local TUI modes without exposing raw model arguments. (#91002) Thanks @wsyjh8.
 - **iOS Watch replies:** persist queued quick replies in the gateway-scoped chat outbox and submit them through idempotent chat delivery, preventing losses, duplicates, and cross-gateway sends after reconnects. (#100031) Thanks @NianJiuZst.
+- **iOS Gateway auth retry:** restrict stored device-token retry to parsed loopback hosts and reject wildcard bind addresses, preventing remote lookalike hostnames from receiving trusted retry credentials. (#99859) Thanks @ly85206559.
 
 ## 2026.7.1
 

--- a/apps/shared/OpenClawKit/Sources/OpenClawKit/GatewayChannel.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawKit/GatewayChannel.swift
@@ -1200,7 +1200,7 @@ public actor GatewayChannelActor {
         else {
             return false
         }
-        if host == "localhost" || host == "::1" || host == "127.0.0.1" || host.hasPrefix("127.") {
+        if LoopbackHost.isLoopbackHost(host) {
             return true
         }
         if self.url.scheme?.lowercased() == "wss",

--- a/apps/shared/OpenClawKit/Sources/OpenClawKit/GatewayChannel.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawKit/GatewayChannel.swift
@@ -1200,7 +1200,7 @@ public actor GatewayChannelActor {
         else {
             return false
         }
-        if LoopbackHost.isLoopbackHost(host) {
+        if Self.isTrustedDeviceRetryLoopbackHost(host) {
             return true
         }
         if self.url.scheme?.lowercased() == "wss",
@@ -1209,6 +1209,14 @@ public actor GatewayChannelActor {
             return trust.allowsDeviceTokenRetryAuth
         }
         return false
+    }
+
+    private static func isTrustedDeviceRetryLoopbackHost(_ host: String) -> Bool {
+        let normalized = LoopbackHost.normalizedHost(host)
+        if normalized == "0.0.0.0" || normalized == "::" {
+            return false
+        }
+        return LoopbackHost.isLoopbackHost(normalized)
     }
 
     private nonisolated func sleepUnlessCancelled(nanoseconds: UInt64) async -> Bool {

--- a/apps/shared/OpenClawKit/Tests/OpenClawKitTests/GatewayNodeSessionTests.swift
+++ b/apps/shared/OpenClawKit/Tests/OpenClawKitTests/GatewayNodeSessionTests.swift
@@ -1357,8 +1357,8 @@ struct GatewayNodeSessionTests {
         await gateway.disconnect()
     }
 
-    @Test
-    func `token mismatch does not retry stored device token for untrusted local hosts`() async throws {
+    @Test(.stateDirectoryIsolated)
+    func `token mismatch retries stored device token only for trusted loopback hosts`() async throws {
         let tempDir = FileManager.default.temporaryDirectory
             .appendingPathComponent(UUID().uuidString, isDirectory: true)
         try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
@@ -1398,11 +1398,7 @@ struct GatewayNodeSessionTests {
             ],
         ]
 
-        for rawURL in [
-            "ws://127.attacker.example:18789",
-            "ws://0.0.0.0:18789",
-            "ws://[::]:18789",
-        ] {
+        func retryAuth(for rawURL: String) async throws -> [String: Any] {
             let session = FakeGatewayWebSocketSession(connectError: connectError)
             let gateway = GatewayNodeSession()
             let url = try #require(URL(string: rawURL))
@@ -1428,10 +1424,28 @@ struct GatewayNodeSessionTests {
             }
 
             let retryAuth = try #require(session.latestTask()?.latestConnectAuth())
+            await gateway.disconnect()
+            return retryAuth
+        }
+
+        for rawURL in [
+            "ws://127.attacker.example:18789",
+            "ws://0.0.0.0:18789",
+            "ws://[::]:18789",
+        ] {
+            let retryAuth = try await retryAuth(for: rawURL)
             #expect(retryAuth["token"] as? String == "shared-gateway-token")
             #expect(retryAuth["deviceToken"] == nil)
+        }
 
-            await gateway.disconnect()
+        for rawURL in [
+            "ws://localhost:18789",
+            "ws://127.0.0.2:18789",
+            "ws://[::1]:18789",
+        ] {
+            let retryAuth = try await retryAuth(for: rawURL)
+            #expect(retryAuth["token"] as? String == "shared-gateway-token")
+            #expect(retryAuth["deviceToken"] as? String == "stored-device-token")
         }
     }
 

--- a/apps/shared/OpenClawKit/Tests/OpenClawKitTests/GatewayNodeSessionTests.swift
+++ b/apps/shared/OpenClawKit/Tests/OpenClawKitTests/GatewayNodeSessionTests.swift
@@ -1358,7 +1358,7 @@ struct GatewayNodeSessionTests {
     }
 
     @Test
-    func `token mismatch does not retry stored device token for loopback prefix hostname`() async throws {
+    func `token mismatch does not retry stored device token for untrusted local hosts`() async throws {
         let tempDir = FileManager.default.temporaryDirectory
             .appendingPathComponent(UUID().uuidString, isDirectory: true)
         try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
@@ -1379,15 +1379,6 @@ struct GatewayNodeSessionTests {
             role: "operator",
             token: "stored-device-token")
 
-        let connectError: [String: Any] = [
-            "code": GatewayConnectAuthDetailCode.authTokenMismatch.rawValue,
-            "message": "token mismatch",
-            "details": [
-                "canRetryWithDeviceToken": true,
-            ],
-        ]
-        let session = FakeGatewayWebSocketSession(connectError: connectError)
-        let gateway = GatewayNodeSession()
         let options = GatewayConnectOptions(
             role: "operator",
             scopes: ["operator.read"],
@@ -1399,33 +1390,49 @@ struct GatewayNodeSessionTests {
             clientDisplayName: "iOS Test",
             includeDeviceIdentity: true)
 
-        let url = try #require(URL(string: "ws://127.attacker.example:18789"))
+        let connectError: [String: Any] = [
+            "code": GatewayConnectAuthDetailCode.authTokenMismatch.rawValue,
+            "message": "token mismatch",
+            "details": [
+                "canRetryWithDeviceToken": true,
+            ],
+        ]
 
-        for _ in 0..<2 {
-            do {
-                try await gateway.connect(
-                    url: url,
-                    token: "shared-gateway-token",
-                    bootstrapToken: nil,
-                    password: nil,
-                    connectOptions: options,
-                    sessionBox: WebSocketSessionBox(session: session),
-                    onConnected: {},
-                    onDisconnected: { _ in },
-                    onInvoke: { req in
-                        BridgeInvokeResponse(id: req.id, ok: true, payloadJSON: nil, error: nil)
-                    })
-                Issue.record("connect unexpectedly succeeded")
-            } catch let error as GatewayConnectAuthError {
-                #expect(error.detail == .authTokenMismatch)
+        for rawURL in [
+            "ws://127.attacker.example:18789",
+            "ws://0.0.0.0:18789",
+            "ws://[::]:18789",
+        ] {
+            let session = FakeGatewayWebSocketSession(connectError: connectError)
+            let gateway = GatewayNodeSession()
+            let url = try #require(URL(string: rawURL))
+
+            for _ in 0..<2 {
+                do {
+                    try await gateway.connect(
+                        url: url,
+                        token: "shared-gateway-token",
+                        bootstrapToken: nil,
+                        password: nil,
+                        connectOptions: options,
+                        sessionBox: WebSocketSessionBox(session: session),
+                        onConnected: {},
+                        onDisconnected: { _ in },
+                        onInvoke: { req in
+                            BridgeInvokeResponse(id: req.id, ok: true, payloadJSON: nil, error: nil)
+                        })
+                    Issue.record("connect unexpectedly succeeded")
+                } catch let error as GatewayConnectAuthError {
+                    #expect(error.detail == .authTokenMismatch)
+                }
             }
+
+            let retryAuth = try #require(session.latestTask()?.latestConnectAuth())
+            #expect(retryAuth["token"] as? String == "shared-gateway-token")
+            #expect(retryAuth["deviceToken"] == nil)
+
+            await gateway.disconnect()
         }
-
-        let retryAuth = try #require(session.latestTask()?.latestConnectAuth())
-        #expect(retryAuth["token"] as? String == "shared-gateway-token")
-        #expect(retryAuth["deviceToken"] == nil)
-
-        await gateway.disconnect()
     }
 
     @Test

--- a/apps/shared/OpenClawKit/Tests/OpenClawKitTests/GatewayNodeSessionTests.swift
+++ b/apps/shared/OpenClawKit/Tests/OpenClawKitTests/GatewayNodeSessionTests.swift
@@ -1358,6 +1358,77 @@ struct GatewayNodeSessionTests {
     }
 
     @Test
+    func `token mismatch does not retry stored device token for loopback prefix hostname`() async throws {
+        let tempDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+        let previousStateDir = ProcessInfo.processInfo.environment["OPENCLAW_STATE_DIR"]
+        setenv("OPENCLAW_STATE_DIR", tempDir.path, 1)
+        defer {
+            if let previousStateDir {
+                setenv("OPENCLAW_STATE_DIR", previousStateDir, 1)
+            } else {
+                unsetenv("OPENCLAW_STATE_DIR")
+            }
+            try? FileManager.default.removeItem(at: tempDir)
+        }
+
+        let identity = DeviceIdentityStore.loadOrCreate()
+        _ = DeviceAuthStore.storeToken(
+            deviceId: identity.deviceId,
+            role: "operator",
+            token: "stored-device-token")
+
+        let connectError: [String: Any] = [
+            "code": GatewayConnectAuthDetailCode.authTokenMismatch.rawValue,
+            "message": "token mismatch",
+            "details": [
+                "canRetryWithDeviceToken": true,
+            ],
+        ]
+        let session = FakeGatewayWebSocketSession(connectError: connectError)
+        let gateway = GatewayNodeSession()
+        let options = GatewayConnectOptions(
+            role: "operator",
+            scopes: ["operator.read"],
+            caps: [],
+            commands: [],
+            permissions: [:],
+            clientId: "openclaw-ios-test",
+            clientMode: "ui",
+            clientDisplayName: "iOS Test",
+            includeDeviceIdentity: true)
+
+        let url = try #require(URL(string: "ws://127.attacker.example:18789"))
+
+        for _ in 0..<2 {
+            do {
+                try await gateway.connect(
+                    url: url,
+                    token: "shared-gateway-token",
+                    bootstrapToken: nil,
+                    password: nil,
+                    connectOptions: options,
+                    sessionBox: WebSocketSessionBox(session: session),
+                    onConnected: {},
+                    onDisconnected: { _ in },
+                    onInvoke: { req in
+                        BridgeInvokeResponse(id: req.id, ok: true, payloadJSON: nil, error: nil)
+                    })
+                Issue.record("connect unexpectedly succeeded")
+            } catch let error as GatewayConnectAuthError {
+                #expect(error.detail == .authTokenMismatch)
+            }
+        }
+
+        let retryAuth = try #require(session.latestTask()?.latestConnectAuth())
+        #expect(retryAuth["token"] as? String == "shared-gateway-token")
+        #expect(retryAuth["deviceToken"] == nil)
+
+        await gateway.disconnect()
+    }
+
+    @Test
     func `normalize canvas host url preserves explicit secure canvas port`() throws {
         let normalized = try canonicalizeCanvasHostUrl(
             raw: "https://canvas.example.com:9443/__openclaw__/cap/token",


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where iOS/shared Gateway auth retry could treat a remote hostname such as `127.attacker.example` as loopback during token-mismatch recovery. In that case, a stale shared gateway token plus a stored device token could cause the client to attempt device-token retry for a hostname that only looks loopback by prefix.

## Why This Change Was Made

The retry trust gate now uses the existing structured loopback parser instead of a string prefix check, but keeps a retry-specific boundary that rejects unspecified bind hosts such as `0.0.0.0` and `::`. This keeps the auth-retry decision aligned with sibling retry behavior: real loopback endpoints remain eligible, prefix-bypass hostnames and wildcard bind addresses do not.

## User Impact

Users keep the intended local-device retry behavior for real loopback Gateway connections, while misleading remote hostnames and unspecified local bind addresses are no longer eligible for the more trusted device-token retry path. This is a narrow iOS/shared Gateway hardening fix with no new configuration or migration.

## Evidence

- `git diff --check origin/main...HEAD`
- `python .agents\skills\autoreview\scripts\autoreview --mode local --base origin/main` -> clean, no accepted/actionable findings
- Added focused Swift regression coverage for `ws://127.attacker.example:18789`, `ws://0.0.0.0:18789`, and `ws://[::]:18789`, verifying a second auth attempt keeps the shared token and does not attach the stored device token.
- GitHub CI on `92c27f3309524eb1006a8c2153cf17789aa15749`: `macos-swift`, `ios-build`, `Real behavior proof`, `security-fast`, and `preflight` passed.
- Local Swift execution is blocked on this Windows worktree because `swift` is not installed: `swift : The term 'swift' is not recognized...`.
- Remote Testbox/Crabbox focused Swift proof was attempted but blocked before dispatch because the local `crabbox` binary failed wrapper sanity checks: `[crabbox] selected binary failed basic --version/--help sanity checks`.