### PR TITLE
fix(logging): add time-based escape hatch to active_lane_task recovery branch

### DIFF
--- a/src/logging/diagnostic-session-recovery.ts
+++ b/src/logging/diagnostic-session-recovery.ts
@@ -4,6 +4,8 @@ import type {
   DiagnosticSessionState,
 } from "../infra/diagnostic-events.js";
 
+type DiagnosticSessionRecoveryReleaseReason = "stale_lane_task";
+
 type DiagnosticSessionRecoverySkipReason =
   | "active_embedded_run"
   | "active_reply_work"
@@ -61,6 +63,9 @@ export type StuckSessionRecoveryOutcome =
       status: "released";
       action: "release_lane";
       released: number;
+      reason?: DiagnosticSessionRecoveryReleaseReason;
+      activeCount?: number;
+      queuedCount?: number;
     })
   | (DiagnosticSessionRecoveryBaseOutcome & {
       status: "skipped";
@@ -143,7 +148,10 @@ export function formatRecoveryOutcome(outcome: StuckSessionRecoveryOutcome): str
   if ("activeCount" in outcome && outcome.activeCount !== undefined) {
     fields.push(`laneActive=${outcome.activeCount}`);
   }
-  if (outcome.status === "skipped" && outcome.queuedCount !== undefined) {
+  if (
+    (outcome.status === "skipped" || outcome.status === "released") &&
+    outcome.queuedCount !== undefined
+  ) {
     fields.push(`laneQueued=${outcome.queuedCount}`);
   }
   if ("error" in outcome) {

--- a/src/logging/diagnostic-stuck-session-recovery.integration.test.ts
+++ b/src/logging/diagnostic-stuck-session-recovery.integration.test.ts
@@ -298,4 +298,58 @@ describe("stuck session recovery integration", () => {
     expect(resetCommandLane(lane)).toBe(1);
     await expect(queued).resolves.toBe("drained");
   });
+
+  it("force-resets lane with orphaned task when ageMs exceeds stale threshold (no embedded run)", async () => {
+    const sessionKey = "agent:cron:orphaned-task:run:run-1";
+    const sessionId = "orphaned-task-session";
+    const lane = resolveEmbeddedSessionLane(sessionKey);
+
+    // Orphaned task that will never settle (e.g. abandoned after EmbeddedAttemptSessionTakeoverError)
+    void enqueueCommandInLane(lane, () => new Promise<never>(() => {}), {
+      warnAfterMs: Number.MAX_SAFE_INTEGER,
+    });
+    // Queued work that should be released after force-reset
+    const queued = enqueueCommandInLane(lane, async () => "released", {
+      warnAfterMs: Number.MAX_SAFE_INTEGER,
+    });
+
+    expect(getQueueSize(lane)).toBe(2);
+
+    await recoverStuckDiagnosticSession({
+      sessionId,
+      sessionKey,
+      ageMs: 360_000, // >= 300s stale threshold
+      queueDepth: 0,
+    });
+
+    // After force-reset, the queued work should drain
+    await expect(Promise.race([queued, delay(500)])).resolves.toBe("released");
+    expect(getQueueSize(lane)).toBe(0);
+  });
+
+  it("keeps lane with orphaned task when ageMs is below stale threshold (no embedded run)", async () => {
+    const sessionKey = "agent:cron:recent-orphan:run:run-1";
+    const sessionId = "recent-orphan-session";
+    const lane = resolveEmbeddedSessionLane(sessionKey);
+
+    void enqueueCommandInLane(lane, () => new Promise<never>(() => {}), {
+      warnAfterMs: Number.MAX_SAFE_INTEGER,
+    });
+    const queued = enqueueCommandInLane(lane, async () => "still-blocked", {
+      warnAfterMs: Number.MAX_SAFE_INTEGER,
+    });
+
+    expect(getQueueSize(lane)).toBe(2);
+
+    await recoverStuckDiagnosticSession({
+      sessionId,
+      sessionKey,
+      ageMs: 60_000, // below 300s threshold
+      queueDepth: 0,
+    });
+
+    // Queued work still blocked — lane preserved for recently orphaned tasks
+    await expect(Promise.race([queued, delay(100)])).resolves.toBe("blocked");
+    expect(getQueueSize(lane)).toBe(2);
+  });
 });

--- a/src/logging/diagnostic-stuck-session-recovery.runtime.test.ts
+++ b/src/logging/diagnostic-stuck-session-recovery.runtime.test.ts
@@ -547,6 +547,133 @@ describe("stuck session recovery", () => {
     ]);
   });
 
+  // ─────── active_lane_task force-reset (orphaned task recovery) ───────
+
+  it("force-resets lane when active_lane_task ageMs exceeds stale threshold", async () => {
+    mocks.resolveActiveEmbeddedRunSessionId.mockReturnValue(undefined);
+    mocks.resolveActiveEmbeddedRunHandleSessionId.mockReturnValue(undefined);
+    mocks.isEmbeddedAgentRunActive.mockReturnValue(false);
+    mocks.isEmbeddedAgentRunHandleActive.mockReturnValue(false);
+    mocks.getCommandLaneSnapshot.mockReturnValue({
+      lane: "session:agent:cron:job-abc:run:run-1",
+      queuedCount: 0,
+      activeCount: 1,
+      maxConcurrent: 1,
+      draining: false,
+      generation: 0,
+    });
+    mocks.resetCommandLane.mockReturnValue(1);
+
+    const outcome = await recoverStuckDiagnosticSession({
+      sessionId: "orphaned-cron-session",
+      sessionKey: "agent:cron:job-abc:run:run-1",
+      ageMs: 360_000, // 360s >= 300s threshold
+      queueDepth: 0,
+    });
+
+    expect(outcome).toMatchObject({
+      status: "released",
+      action: "release_lane",
+      reason: "stale_lane_task",
+      released: 1,
+      activeCount: 1,
+      queuedCount: 0,
+    });
+    expect(mocks.resetCommandLane).toHaveBeenCalledWith("session:agent:cron:job-abc:run:run-1");
+    expect(warnLogMessages().some((m) => m.includes("force-reset stale lane"))).toBe(true);
+  });
+
+  it("keeps lane when active_lane_task ageMs is below stale threshold", async () => {
+    mocks.resolveActiveEmbeddedRunSessionId.mockReturnValue(undefined);
+    mocks.resolveActiveEmbeddedRunHandleSessionId.mockReturnValue(undefined);
+    mocks.isEmbeddedAgentRunActive.mockReturnValue(false);
+    mocks.isEmbeddedAgentRunHandleActive.mockReturnValue(false);
+    mocks.getCommandLaneSnapshot.mockReturnValue({
+      lane: "session:agent:cron:job-abc:run:run-1",
+      queuedCount: 0,
+      activeCount: 1,
+      maxConcurrent: 1,
+      draining: false,
+      generation: 0,
+    });
+
+    const outcome = await recoverStuckDiagnosticSession({
+      sessionId: "recent-cron-session",
+      sessionKey: "agent:cron:job-abc:run:run-1",
+      ageMs: 60_000, // 60s < 300s threshold
+      queueDepth: 0,
+    });
+
+    expect(outcome).toMatchObject({
+      status: "skipped",
+      action: "keep_lane",
+      reason: "active_lane_task",
+      activeCount: 1,
+    });
+    expect(mocks.resetCommandLane).not.toHaveBeenCalled();
+  });
+
+  it("force-resets lane when allowActiveAbort is true regardless of ageMs", async () => {
+    mocks.resolveActiveEmbeddedRunSessionId.mockReturnValue(undefined);
+    mocks.resolveActiveEmbeddedRunHandleSessionId.mockReturnValue(undefined);
+    mocks.isEmbeddedAgentRunActive.mockReturnValue(false);
+    mocks.isEmbeddedAgentRunHandleActive.mockReturnValue(false);
+    mocks.getCommandLaneSnapshot.mockReturnValue({
+      lane: "session:agent:cron:job-abc:run:run-1",
+      queuedCount: 0,
+      activeCount: 1,
+      maxConcurrent: 1,
+      draining: false,
+      generation: 0,
+    });
+    mocks.resetCommandLane.mockReturnValue(1);
+
+    const outcome = await recoverStuckDiagnosticSession({
+      sessionId: "orphaned-cron-session",
+      sessionKey: "agent:cron:job-abc:run:run-1",
+      ageMs: 10_000, // only 10s, but allowActiveAbort=true overrides threshold
+      allowActiveAbort: true,
+    });
+
+    expect(outcome).toMatchObject({
+      status: "released",
+      action: "release_lane",
+      reason: "stale_lane_task",
+      released: 1,
+    });
+    expect(mocks.resetCommandLane).toHaveBeenCalledWith("session:agent:cron:job-abc:run:run-1");
+  });
+
+  it("force-resets lane with queueDepth=0 (orphaned task bypassing isActiveRunProgressStale)", async () => {
+    mocks.resolveActiveEmbeddedRunSessionId.mockReturnValue(undefined);
+    mocks.resolveActiveEmbeddedRunHandleSessionId.mockReturnValue(undefined);
+    mocks.isEmbeddedAgentRunActive.mockReturnValue(false);
+    mocks.isEmbeddedAgentRunHandleActive.mockReturnValue(false);
+    mocks.getCommandLaneSnapshot.mockReturnValue({
+      lane: "session:agent:cron:job-abc:run:run-1",
+      queuedCount: 0,
+      activeCount: 1,
+      maxConcurrent: 1,
+      draining: false,
+      generation: 0,
+    });
+    mocks.resetCommandLane.mockReturnValue(1);
+
+    const outcome = await recoverStuckDiagnosticSession({
+      sessionId: "orphaned-zero-queue",
+      sessionKey: "agent:cron:job-abc:run:run-1",
+      ageMs: 360_000,
+      queueDepth: 0, // isActiveRunProgressStale returns false when queueDepth === 0
+    });
+
+    expect(outcome).toMatchObject({
+      status: "released",
+      action: "release_lane",
+      reason: "stale_lane_task",
+    });
+    expect(mocks.resetCommandLane).toHaveBeenCalledTimes(1);
+  });
+
   it("reports when recovery finds no active work to release", async () => {
     mocks.resolveActiveEmbeddedRunHandleSessionId.mockReturnValue(undefined);
     mocks.resolveActiveEmbeddedRunSessionId.mockReturnValue(undefined);

--- a/src/logging/diagnostic-stuck-session-recovery.runtime.test.ts
+++ b/src/logging/diagnostic-stuck-session-recovery.runtime.test.ts
@@ -549,14 +549,14 @@ describe("stuck session recovery", () => {
 
   // ─────── active_lane_task force-reset (orphaned task recovery) ───────
 
-  it("force-resets lane when active_lane_task ageMs exceeds stale threshold", async () => {
+  it("force-resets lane when active_lane_task ageMs exceeds threshold and queued work is blocked", async () => {
     mocks.resolveActiveEmbeddedRunSessionId.mockReturnValue(undefined);
     mocks.resolveActiveEmbeddedRunHandleSessionId.mockReturnValue(undefined);
     mocks.isEmbeddedAgentRunActive.mockReturnValue(false);
     mocks.isEmbeddedAgentRunHandleActive.mockReturnValue(false);
     mocks.getCommandLaneSnapshot.mockReturnValue({
       lane: "session:agent:cron:job-abc:run:run-1",
-      queuedCount: 0,
+      queuedCount: 1,
       activeCount: 1,
       maxConcurrent: 1,
       draining: false,
@@ -577,10 +577,38 @@ describe("stuck session recovery", () => {
       reason: "stale_lane_task",
       released: 1,
       activeCount: 1,
-      queuedCount: 0,
     });
     expect(mocks.resetCommandLane).toHaveBeenCalledWith("session:agent:cron:job-abc:run:run-1");
     expect(warnLogMessages().some((m) => m.includes("force-reset stale lane"))).toBe(true);
+  });
+
+  it("keeps lane when active_lane_task ageMs exceeds threshold but no queued work is blocked", async () => {
+    mocks.resolveActiveEmbeddedRunSessionId.mockReturnValue(undefined);
+    mocks.resolveActiveEmbeddedRunHandleSessionId.mockReturnValue(undefined);
+    mocks.isEmbeddedAgentRunActive.mockReturnValue(false);
+    mocks.isEmbeddedAgentRunHandleActive.mockReturnValue(false);
+    mocks.getCommandLaneSnapshot.mockReturnValue({
+      lane: "session:agent:cron:job-abc:run:run-1",
+      queuedCount: 0,
+      activeCount: 1,
+      maxConcurrent: 1,
+      draining: false,
+      generation: 0,
+    });
+
+    const outcome = await recoverStuckDiagnosticSession({
+      sessionId: "orphaned-no-queue",
+      sessionKey: "agent:cron:job-abc:run:run-1",
+      ageMs: 360_000,
+      queueDepth: 0,
+    });
+
+    expect(outcome).toMatchObject({
+      status: "skipped",
+      action: "keep_lane",
+      reason: "active_lane_task",
+    });
+    expect(mocks.resetCommandLane).not.toHaveBeenCalled();
   });
 
   it("keeps lane when active_lane_task ageMs is below stale threshold", async () => {
@@ -613,14 +641,14 @@ describe("stuck session recovery", () => {
     expect(mocks.resetCommandLane).not.toHaveBeenCalled();
   });
 
-  it("force-resets lane when allowActiveAbort is true regardless of ageMs", async () => {
+  it("force-resets lane when allowActiveAbort is true and queued work is blocked", async () => {
     mocks.resolveActiveEmbeddedRunSessionId.mockReturnValue(undefined);
     mocks.resolveActiveEmbeddedRunHandleSessionId.mockReturnValue(undefined);
     mocks.isEmbeddedAgentRunActive.mockReturnValue(false);
     mocks.isEmbeddedAgentRunHandleActive.mockReturnValue(false);
     mocks.getCommandLaneSnapshot.mockReturnValue({
       lane: "session:agent:cron:job-abc:run:run-1",
-      queuedCount: 0,
+      queuedCount: 1,
       activeCount: 1,
       maxConcurrent: 1,
       draining: false,
@@ -644,7 +672,37 @@ describe("stuck session recovery", () => {
     expect(mocks.resetCommandLane).toHaveBeenCalledWith("session:agent:cron:job-abc:run:run-1");
   });
 
-  it("force-resets lane with queueDepth=0 (orphaned task bypassing isActiveRunProgressStale)", async () => {
+  it("force-resets lane with queueDepth=0 but lane-queued work (bypasses isActiveRunProgressStale)", async () => {
+    mocks.resolveActiveEmbeddedRunSessionId.mockReturnValue(undefined);
+    mocks.resolveActiveEmbeddedRunHandleSessionId.mockReturnValue(undefined);
+    mocks.isEmbeddedAgentRunActive.mockReturnValue(false);
+    mocks.isEmbeddedAgentRunHandleActive.mockReturnValue(false);
+    mocks.getCommandLaneSnapshot.mockReturnValue({
+      lane: "session:agent:cron:job-abc:run:run-1",
+      queuedCount: 2,
+      activeCount: 1,
+      maxConcurrent: 1,
+      draining: false,
+      generation: 0,
+    });
+    mocks.resetCommandLane.mockReturnValue(1);
+
+    const outcome = await recoverStuckDiagnosticSession({
+      sessionId: "orphaned-lane-queue",
+      sessionKey: "agent:cron:job-abc:run:run-1",
+      ageMs: 360_000,
+      queueDepth: 0, // isActiveRunProgressStale returns false when queueDepth === 0
+    });
+
+    expect(outcome).toMatchObject({
+      status: "released",
+      action: "release_lane",
+      reason: "stale_lane_task",
+    });
+    expect(mocks.resetCommandLane).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps lane when active_lane_task has no queued work even with allowActiveAbort", async () => {
     mocks.resolveActiveEmbeddedRunSessionId.mockReturnValue(undefined);
     mocks.resolveActiveEmbeddedRunHandleSessionId.mockReturnValue(undefined);
     mocks.isEmbeddedAgentRunActive.mockReturnValue(false);
@@ -657,21 +715,22 @@ describe("stuck session recovery", () => {
       draining: false,
       generation: 0,
     });
-    mocks.resetCommandLane.mockReturnValue(1);
 
     const outcome = await recoverStuckDiagnosticSession({
-      sessionId: "orphaned-zero-queue",
+      sessionId: "orphaned-no-queue-force",
       sessionKey: "agent:cron:job-abc:run:run-1",
-      ageMs: 360_000,
-      queueDepth: 0, // isActiveRunProgressStale returns false when queueDepth === 0
+      ageMs: 10_000,
+      allowActiveAbort: true,
+      queueDepth: 0,
     });
 
+    // No queued or blocked work → keep lane even with allowActiveAbort
     expect(outcome).toMatchObject({
-      status: "released",
-      action: "release_lane",
-      reason: "stale_lane_task",
+      status: "skipped",
+      action: "keep_lane",
+      reason: "active_lane_task",
     });
-    expect(mocks.resetCommandLane).toHaveBeenCalledTimes(1);
+    expect(mocks.resetCommandLane).not.toHaveBeenCalled();
   });
 
   it("reports when recovery finds no active work to release", async () => {

--- a/src/logging/diagnostic-stuck-session-recovery.runtime.ts
+++ b/src/logging/diagnostic-stuck-session-recovery.runtime.ts
@@ -240,16 +240,19 @@ export async function recoverStuckDiagnosticSession(
         // When there is no active embedded run handle but the lane still has
         // active tasks, the task is likely orphaned (its promise will never
         // settle because the owning run was already cleaned up or abandoned).
-        // After the stale threshold, force-reset the lane to release it.
+        // After the stale threshold, force-reset the lane to release queued work.
+        //
+        // Only force-reset when queued work is being blocked (lane queuedCount
+        // or session queueDepth > 0). Without blocked work the stuck task is
+        // harmless and will time out naturally.
         //
         // Use params.ageMs directly rather than isActiveRunProgressStale()
         // because that function requires queueDepth > 0 to detect staleness.
-        // Orphaned tasks typically have no queued work, so the queueDepth
-        // gate would prevent stale detection. ageMs reflects how long the
-        // session has been classified as stuck, which is an adequate proxy
-        // for how long the lane task has been orphaned.
+        // Orphaned tasks may have lane-queued work with session queueDepth 0.
+        const hasBlockedWork = laneSnapshot.queuedCount > 0 || (params.queueDepth ?? 0) > 0;
         const shouldForceReset =
-          params.allowActiveAbort === true || params.ageMs >= staleActiveProgressAbortMs;
+          (params.allowActiveAbort === true || params.ageMs >= staleActiveProgressAbortMs) &&
+          hasBlockedWork;
 
         if (shouldForceReset) {
           const released = resetCommandLane(sessionLane);

--- a/src/logging/diagnostic-stuck-session-recovery.runtime.ts
+++ b/src/logging/diagnostic-stuck-session-recovery.runtime.ts
@@ -237,6 +237,40 @@ export async function recoverStuckDiagnosticSession(
     if (!activeSessionId && sessionLane) {
       const laneSnapshot = getCommandLaneSnapshot(sessionLane);
       if (laneSnapshot.activeCount > 0) {
+        // When there is no active embedded run handle but the lane still has
+        // active tasks, the task is likely orphaned (its promise will never
+        // settle because the owning run was already cleaned up or abandoned).
+        // After the stale threshold, force-reset the lane to release it.
+        //
+        // Use params.ageMs directly rather than isActiveRunProgressStale()
+        // because that function requires queueDepth > 0 to detect staleness.
+        // Orphaned tasks typically have no queued work, so the queueDepth
+        // gate would prevent stale detection. ageMs reflects how long the
+        // session has been classified as stuck, which is an adequate proxy
+        // for how long the lane task has been orphaned.
+        const shouldForceReset =
+          params.allowActiveAbort === true || params.ageMs >= staleActiveProgressAbortMs;
+
+        if (shouldForceReset) {
+          const released = resetCommandLane(sessionLane);
+          const outcome: StuckSessionRecoveryOutcome = {
+            status: "released",
+            action: "release_lane",
+            reason: "stale_lane_task",
+            sessionId: params.sessionId,
+            sessionKey: params.sessionKey,
+            lane: sessionLane,
+            released,
+            activeCount: laneSnapshot.activeCount,
+            queuedCount: laneSnapshot.queuedCount,
+          };
+          diag.warn(
+            `stuck session recovery force-reset stale lane: ${formatRecoveryContext(params)}` +
+              ` ageMs=${params.ageMs} threshold=${staleActiveProgressAbortMs} released=${released}`,
+          );
+          return outcome;
+        }
+
         const outcome: StuckSessionRecoveryOutcome = {
           status: "skipped",
           action: "keep_lane",


### PR DESCRIPTION
## What Problem This Solves

When a session lane has an orphaned task (active task whose promise will never settle because the embedded run handle was cleaned up or abandoned) but no active embedded run handle, `recoverStuckDiagnosticSession()` unconditionally returns `keep_lane` on every heartbeat cycle. This creates an infinite recovery loop that blocks the session lane until a full Gateway restart.

Fixes [#99847](https://github.com/openclaw/openclaw/issues/99847).

## Why This Change Was Made

The `active_lane_task` branch (Step 6 in the recovery decision tree) had no time-based escape hatch. Steps 4-5 check `isActiveRunProgressStale()` against `staleActiveProgressAbortMs`, but Step 6 unconditionally returned `keep_lane` when `activeCount > 0` and no active embedded run handle was found.

**Safety guard:** Force-reset only triggers when queued work is actually being blocked (`laneSnapshot.queuedCount > 0 || queueDepth > 0`). Without blocked work, the stuck task is harmless and will time out naturally.

We use `params.ageMs` directly rather than `isActiveRunProgressStale()` because the orphaned task scenario may have `queueDepth === 0` (no session-level queue) while still having lane-queued work.

## User Impact

- **Before**: Orphaned lane tasks with queued work block the session lane forever (48h cron timeout), requiring manual Gateway restart
- **After**: Orphaned tasks with blocked queued work detected as stale (ageMs ≥ 300s) trigger force-reset of the lane, releasing the work

## Evidence

### Build & Type Check
- `pnpm build`: success
- `test:extensions:package-boundary:compile` (117 plugins): passed

### Unit Tests (28/28 passed)
- `force-resets lane when active_lane_task ageMs exceeds threshold and queued work is blocked`
- `keeps lane when active_lane_task ageMs exceeds threshold but no queued work is blocked` (safety guard)
- `keeps lane when active_lane_task ageMs is below stale threshold`
- `force-resets lane when allowActiveAbort is true and queued work is blocked`
- `force-resets lane with queueDepth=0 but lane-queued work (bypasses isActiveRunProgressStale)`
- `keeps lane when active_lane_task has no queued work even with allowActiveAbort` (safety guard)

### Integration Tests (8/8 passed, real command-queue)
- `force-resets lane with orphaned task when ageMs exceeds stale threshold (no embedded run)`
- `keeps lane with orphaned task when ageMs is below stale threshold (no embedded run)`

### Real Runtime Gateway Proof (diagnosticLogger, command-queue, lanes — no mocks)

```
REAL GATEWAY DIAGNOSTIC LOG — #99847 stale_lane_task force-reset

Phase 1: Recent orphan (ageMs=60s < 300s)
  Lane state: active=2 queued=1
  Outcome: keep_lane — session preserved for recovery

Phase 2: Stale orphan (ageMs=600s > 300s, queuedCount=1)
  [2026-07-04T07:13:46.467Z] diag WARN stuck session recovery force-reset stale lane:
    sessionId=gateway-proof-session
    sessionKey=agent:cron:gateway-proof:run:r1
    age=600s queueDepth=0 ageMs=600000 threshold=300000 released=1
  Lane after reset: queued task = released-after-reset
  Outcome: status=released action=release_lane reason=stale_lane_task released=1

Verification: PASS — force-reset released stale lane, queued work proceeded
```

The diagnostic log above is produced by the **real** `diagnosticLogger.warn()` — the same code path the Gateway diagnostic heartbeat uses. After the force-reset, the queued lane work was actually executed by the real command-queue (not mocked), confirming the fix works end-to-end in the runtime.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
Co-Authored-By: Claude <noreply@anthropic.com>