### PR TITLE
fix(compaction): exclude turn-aggregated cache fields from context token fallback

### DIFF
--- a/packages/agent-core/src/harness/compaction/compaction.test.ts
+++ b/packages/agent-core/src/harness/compaction/compaction.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it, vi } from "vitest";
 import { createAssistantMessageEventStream } from "../../llm.js";
-import type { AssistantMessage, Model, StreamFn } from "../../llm.js";
-import { generateSummary } from "./compaction.js";
+import type { AssistantMessage, Model, StreamFn, Usage } from "../../llm.js";
+import { calculateContextTokens, generateSummary } from "./compaction.js";
 
 describe("generateSummary thinking options", () => {
   it("maps explicit Fable off to low effort for compaction", async () => {
@@ -58,5 +58,64 @@ describe("generateSummary thinking options", () => {
 
     expect(result).toEqual({ ok: true, value: "summary" });
     expect(streamFn).toHaveBeenCalledOnce();
+  });
+});
+
+function makeUsage(overrides: Partial<Usage> = {}): Usage {
+  return {
+    input: 0,
+    output: 0,
+    cacheRead: 0,
+    cacheWrite: 0,
+    totalTokens: 0,
+    cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+    ...overrides,
+  };
+}
+
+describe("calculateContextTokens", () => {
+  it("returns totalTokens when non-zero", () => {
+    const usage = makeUsage({ totalTokens: 163_978 });
+    expect(calculateContextTokens(usage)).toBe(163_978);
+  });
+
+  it("falls back to input + output when totalTokens is 0", () => {
+    const usage = makeUsage({ input: 12, output: 15_104, totalTokens: 0 });
+    expect(calculateContextTokens(usage)).toBe(15_116);
+  });
+
+  it("excludes turn-aggregated cacheRead/cacheWrite from fallback (regression #99843)", () => {
+    // Simulates the exact scenario from #99843: a multi-call tool-loop turn
+    // where cacheRead is aggregated across ~12 API calls but totalTokens is
+    // missing (0). The fallback must not sum cacheRead/cacheWrite, or it
+    // would report 927,907 instead of the correct ~15,116.
+    const usage = makeUsage({
+      input: 12,
+      output: 15_104,
+      cacheRead: 819_661,
+      cacheWrite: 93_130,
+      totalTokens: 0,
+    });
+    const result = calculateContextTokens(usage);
+    // Must NOT include cacheRead/cacheWrite in the fallback.
+    expect(result).toBe(15_116);
+    // Must be far below the inflated sum that the old formula produced.
+    expect(result).toBeLessThan(100_000);
+  });
+
+  it("returns 0 when all fields are 0", () => {
+    const usage = makeUsage();
+    expect(calculateContextTokens(usage)).toBe(0);
+  });
+
+  it("returns totalTokens even when other fields are large", () => {
+    const usage = makeUsage({
+      input: 1000,
+      output: 500,
+      cacheRead: 999_999,
+      cacheWrite: 500_000,
+      totalTokens: 1_500,
+    });
+    expect(calculateContextTokens(usage)).toBe(1_500);
   });
 });

--- a/packages/agent-core/src/harness/compaction/compaction.ts
+++ b/packages/agent-core/src/harness/compaction/compaction.ts
@@ -146,9 +146,17 @@ export const DEFAULT_COMPACTION_SETTINGS: CompactionSettings = {
   keepRecentTokens: 20000,
 };
 
-/** Calculate total context tokens from provider usage. */
+/**
+ * Calculate total context tokens from provider usage.
+ *
+ * Prefer `totalTokens` as the canonical per-call context size. The fallback
+ * intentionally excludes `cacheRead`/`cacheWrite` because those fields can be
+ * turn-aggregated across multiple API calls in a single tool-loop turn with
+ * prompt caching, which would inflate the estimate and trigger premature
+ * compaction (see #99843).
+ */
 export function calculateContextTokens(usage: Usage): number {
-  return usage.totalTokens || usage.input + usage.output + usage.cacheRead + usage.cacheWrite;
+  return usage.totalTokens || usage.input + usage.output;
 }
 function getAssistantUsage(msg: AgentMessage): Usage | undefined {
   if (msg.role === "assistant" && "usage" in msg) {


### PR DESCRIPTION
## What Problem This Solves

Fixes #99843 — Auto-compaction can fire far below the configured trigger when `calculateContextTokens` falls back to summing `input + output + cacheRead + cacheWrite` because `cacheRead`/`cacheWrite` can be turn-aggregated across multiple API calls in a single tool-loop turn with prompt caching.

In the reported case, compaction fired at **~164k real context** on a session configured to trigger at 180k (300k window, reserveTokens: 120000), because the estimator computed **931,132** — a ~5.7x inflation.

## Why This Change Was Made

The fallback formula `input + output + cacheRead + cacheWrite` is correct for **cost accounting** but wrong for **context estimation**:
- `cacheRead` and `cacheWrite` accumulate across all API calls in a turn (12 calls × ~150k cached tokens each = 819k+ aggregated)
- `totalTokens` is the canonical per-call context size
- When `totalTokens` is 0/missing, only `input + output` should be used — cache fields must not be summed because they multiply-count the same cached context

## User Impact

- Sessions doing long multi-call turns (agentic tool loops with prompt caching) will no longer compact prematurely
- The compaction banner will display accurate token estimates
- No behavior change when `totalTokens` is present (the normal case)

## Evidence

- **Source-level reproduction**: The exact token values from the issue report (input=12, output=15104, cacheRead=819661, cacheWrite=93130, totalTokens=0) reproduce the inflated 927,907 estimate with the old formula
- **Regression test**: Added 5 test cases covering the exact #99843 scenario
- **Test results**: `packages/agent-core` compaction tests (6 passed), `src/agents` compaction tests (17 passed)
- **Zero existing test impact**: No existing tests assert the old cache-inclusive fallback behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)