### PR TITLE
feat(xai): stream TTS over native websocket

### DIFF
--- a/docs/providers/xai.md
+++ b/docs/providers/xai.md
@@ -141,28 +141,27 @@ workloads unless you explicitly need a Grok 4.20 beta alias.
 
 The bundled plugin maps xAI's current public API surface onto OpenClaw's shared
 provider and tool contracts. Capabilities that don't fit the shared contract
-(for example streaming TTS and realtime voice) are not exposed - see the table
-below.
+(for example realtime voice) are not exposed - see the table below.
 
-| xAI capability             | OpenClaw surface                          | Status                                                              |
-| -------------------------- | ----------------------------------------- | ------------------------------------------------------------------- |
-| Chat / Responses           | `xai/<model>` model provider              | Yes                                                                 |
-| Server-side web search     | `web_search` provider `grok`              | Yes                                                                 |
-| Server-side X search       | `x_search` tool                           | Yes                                                                 |
-| Server-side code execution | `code_execution` tool                     | Yes                                                                 |
-| Images                     | `image_generate`                          | Yes                                                                 |
-| Videos                     | `video_generate`                          | Yes                                                                 |
-| Batch text-to-speech       | `messages.tts.provider: "xai"` / `tts`    | Yes                                                                 |
-| Streaming TTS              | -                                         | Not exposed; OpenClaw's TTS contract returns complete audio buffers |
-| Batch speech-to-text       | `tools.media.audio` / media understanding | Yes                                                                 |
-| Streaming speech-to-text   | Voice Call `streaming.provider: "xai"`    | Yes                                                                 |
-| Realtime voice             | -                                         | Not exposed yet; different session/WebSocket contract               |
-| Files / batches            | Generic model API compatibility only      | Not a first-class OpenClaw tool                                     |
+| xAI capability             | OpenClaw surface                          | Status                                                |
+| -------------------------- | ----------------------------------------- | ----------------------------------------------------- |
+| Chat / Responses           | `xai/<model>` model provider              | Yes                                                   |
+| Server-side web search     | `web_search` provider `grok`              | Yes                                                   |
+| Server-side X search       | `x_search` tool                           | Yes                                                   |
+| Server-side code execution | `code_execution` tool                     | Yes                                                   |
+| Images                     | `image_generate`                          | Yes                                                   |
+| Videos                     | `video_generate`                          | Yes                                                   |
+| Batch text-to-speech       | `messages.tts.provider: "xai"` / `tts`    | Yes                                                   |
+| Streaming TTS              | `textToSpeechStream` callers              | Yes, native xAI WebSocket only                        |
+| Batch speech-to-text       | `tools.media.audio` / media understanding | Yes                                                   |
+| Streaming speech-to-text   | Voice Call `streaming.provider: "xai"`    | Yes                                                   |
+| Realtime voice             | -                                         | Not exposed yet; different session/WebSocket contract |
+| Files / batches            | Generic model API compatibility only      | Not a first-class OpenClaw tool                       |
 
 <Note>
 OpenClaw uses xAI's REST image/video/TTS/STT APIs for media generation,
-speech, and batch transcription, xAI's streaming STT WebSocket for live
-voice-call transcription, and the Responses API for model, search, and
+speech, and batch transcription, xAI's streaming TTS/STT WebSockets for shared
+speech streaming contracts, and the Responses API for model, search, and
 code-execution tools. Features that need different OpenClaw contracts, such as
 Realtime voice sessions, are documented here as upstream capabilities rather
 than hidden plugin behavior.
@@ -322,9 +321,13 @@ Legacy aliases still normalize to the canonical bundled ids:
     ```
 
     <Note>
-    OpenClaw uses xAI's batch `/v1/tts` endpoint. xAI also offers streaming TTS
-    over WebSocket, but the OpenClaw speech provider contract currently expects
-    a complete audio buffer before reply delivery.
+    OpenClaw keeps normal attachments and `talk.speak` on xAI's batch
+    `/v1/tts` endpoint. Streaming playback callers use xAI's native
+    `wss://api.x.ai/v1/tts` WebSocket contract with `text.delta` and
+    `text.done` input events and `audio.delta` audio chunks until
+    `audio.done`. That WebSocket path is restricted to the native xAI host so
+    REST-compatible proxy base URLs are not silently treated as xAI streaming
+    endpoints.
     </Note>
 
   </Accordion>
@@ -501,8 +504,8 @@ Legacy aliases still normalize to the canonical bundled ids:
       client-side or custom tools used by OpenClaw's shared agent loop. See the
       [xAI multi-agent limitations](https://docs.x.ai/developers/model-capabilities/text/multi-agent#limitations).
     - xAI Realtime voice is not registered as an OpenClaw provider yet. It
-      needs a different bidirectional voice session contract than batch STT or
-      streaming transcription.
+      needs a different bidirectional voice session contract than streaming
+      TTS, batch STT, or streaming transcription.
     - xAI image `quality`, image `mask`, and extra native-only aspect ratios are
       not exposed until the shared `image_generate` tool has corresponding
       cross-provider controls.

--- a/extensions/xai/package.json
+++ b/extensions/xai/package.json
@@ -5,11 +5,11 @@
   "description": "OpenClaw xAI plugin",
   "type": "module",
   "dependencies": {
-    "typebox": "1.1.39"
+    "typebox": "1.1.39",
+    "ws": "8.21.0"
   },
   "devDependencies": {
-    "@openclaw/plugin-sdk": "workspace:*",
-    "ws": "8.21.0"
+    "@openclaw/plugin-sdk": "workspace:*"
   },
   "openclaw": {
     "extensions": [

--- a/extensions/xai/speech-provider.test.ts
+++ b/extensions/xai/speech-provider.test.ts
@@ -2,14 +2,27 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { buildXaiSpeechProvider } from "./speech-provider.js";
 
-const { xaiTTSMock, isProviderAuthProfileConfiguredMock, resolveApiKeyForProviderMock } =
-  vi.hoisted(() => ({
-    xaiTTSMock: vi.fn(async () => Buffer.from("audio-bytes")),
-    isProviderAuthProfileConfiguredMock: vi.fn(() => false),
-    resolveApiKeyForProviderMock: vi.fn(
-      async (): Promise<{ apiKey: string | undefined }> => ({ apiKey: undefined }),
-    ),
-  }));
+const {
+  xaiTTSMock,
+  xaiTTSStreamMock,
+  isProviderAuthProfileConfiguredMock,
+  resolveApiKeyForProviderMock,
+} = vi.hoisted(() => ({
+  xaiTTSMock: vi.fn(async () => Buffer.from("audio-bytes")),
+  xaiTTSStreamMock: vi.fn(async () => ({
+    audioStream: new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(new Uint8Array([1, 2, 3]));
+        controller.close();
+      },
+    }),
+    release: vi.fn(async () => {}),
+  })),
+  isProviderAuthProfileConfiguredMock: vi.fn(() => false),
+  resolveApiKeyForProviderMock: vi.fn(
+    async (): Promise<{ apiKey: string | undefined }> => ({ apiKey: undefined }),
+  ),
+}));
 
 vi.mock("./tts.js", () => ({
   XAI_BASE_URL: "https://api.x.ai/v1",
@@ -20,6 +33,7 @@ vi.mock("./tts.js", () => ({
   normalizeXaiTtsBaseUrl: (baseUrl?: string) =>
     baseUrl?.trim().replace(/\/+$/, "") || "https://api.x.ai/v1",
   xaiTTS: xaiTTSMock,
+  xaiTTSStream: xaiTTSStreamMock,
 }));
 
 vi.mock("openclaw/plugin-sdk/provider-auth", () => ({
@@ -58,8 +72,36 @@ function requireLastTtsCall(): {
   return params;
 }
 
+function requireLastTtsStreamCall(): {
+  text?: string;
+  apiKey?: string;
+  baseUrl?: string;
+  voiceId?: string;
+  language?: string;
+  speed?: number;
+  responseFormat?: string;
+} {
+  const params = (xaiTTSStreamMock.mock.calls as unknown as Array<[unknown]>).at(-1)?.[0] as
+    | {
+        text?: string;
+        apiKey?: string;
+        baseUrl?: string;
+        voiceId?: string;
+        language?: string;
+        speed?: number;
+        responseFormat?: string;
+      }
+    | undefined;
+  if (!params) {
+    throw new Error("Expected xaiTTSStream call");
+  }
+  return params;
+}
+
 describe("xai speech provider", () => {
   afterEach(() => {
+    xaiTTSMock.mockClear();
+    xaiTTSStreamMock.mockClear();
     isProviderAuthProfileConfiguredMock.mockReset();
     isProviderAuthProfileConfiguredMock.mockReturnValue(false);
     resolveApiKeyForProviderMock.mockReset();
@@ -115,6 +157,45 @@ describe("xai speech provider", () => {
     expect(result.outputFormat).toBe("wav");
     expect(result.fileExtension).toBe(".wav");
     expect(requireLastTtsCall().responseFormat).toBe("wav");
+  });
+
+  it("streams audio through the native xAI TTS helper", async () => {
+    const provider = buildXaiSpeechProvider();
+    const result = await provider.streamSynthesize?.({
+      text: "hello",
+      cfg: {},
+      providerConfig: {
+        apiKey: "xai-key",
+        baseUrl: "https://api.x.ai/v1",
+        voiceId: "eve",
+        language: "en",
+        speed: 1,
+        responseFormat: "wav",
+      },
+      providerOverrides: {
+        voice: "ara",
+        language: "es",
+        speed: 1.2,
+      },
+      target: "audio-file",
+      timeoutMs: 5_000,
+    });
+
+    expect(result?.outputFormat).toBe("wav");
+    expect(result?.fileExtension).toBe(".wav");
+    expect(result?.voiceCompatible).toBe(false);
+    expect(result?.audioStream).toBeInstanceOf(ReadableStream);
+    expect(result?.release).toBeDefined();
+    expect(requireLastTtsStreamCall()).toMatchObject({
+      text: "hello",
+      apiKey: "xai-key",
+      baseUrl: "https://api.x.ai/v1",
+      voiceId: "ara",
+      language: "es",
+      speed: 1.2,
+      responseFormat: "wav",
+    });
+    expect(xaiTTSMock).not.toHaveBeenCalled();
   });
 
   it("honors voice, language, and speed overrides for telephony output", async () => {

--- a/extensions/xai/speech-provider.ts
+++ b/extensions/xai/speech-provider.ts
@@ -24,6 +24,7 @@ import {
   XAI_BASE_URL,
   XAI_TTS_VOICES,
   xaiTTS,
+  xaiTTSStream,
 } from "./tts.js";
 
 const XAI_SPEECH_RESPONSE_FORMATS = ["mp3", "wav", "pcm", "mulaw", "alaw"] as const;
@@ -250,6 +251,29 @@ export function buildXaiSpeechProvider(): SpeechProviderPlugin {
         outputFormat: responseFormat,
         fileExtension: responseFormatToFileExtension(responseFormat),
         voiceCompatible: false,
+      };
+    },
+    streamSynthesize: async (req) => {
+      const config = readXaiProviderConfig(req.providerConfig);
+      const overrides = readXaiOverrides(req.providerOverrides);
+      const apiKey = await resolveXaiAudioApiKey(config.apiKey, req.cfg);
+      const responseFormat = resolveSpeechResponseFormat(req.target, config.responseFormat);
+      const stream = await xaiTTSStream({
+        text: req.text,
+        apiKey,
+        baseUrl: config.baseUrl,
+        voiceId: overrides.voiceId ?? config.voiceId,
+        language: overrides.language ?? config.language,
+        speed: overrides.speed ?? config.speed,
+        responseFormat,
+        timeoutMs: req.timeoutMs,
+      });
+      return {
+        audioStream: stream.audioStream,
+        outputFormat: responseFormat,
+        fileExtension: responseFormatToFileExtension(responseFormat),
+        voiceCompatible: false,
+        release: stream.release,
       };
     },
     synthesizeTelephony: async (req) => {

--- a/extensions/xai/tts.test.ts
+++ b/extensions/xai/tts.test.ts
@@ -1,7 +1,38 @@
 // Xai tests cover tts plugin behavior.
+import { EventEmitter } from "node:events";
 import { mockPinnedHostnameResolution } from "openclaw/plugin-sdk/test-env";
 import { beforeEach, afterEach, describe, expect, it, vi } from "vitest";
-import { isValidXaiTtsVoice, XAI_BASE_URL, XAI_TTS_VOICES, xaiTTS } from "./tts.js";
+import { isValidXaiTtsVoice, XAI_BASE_URL, XAI_TTS_VOICES, xaiTTS, xaiTTSStream } from "./tts.js";
+
+type XaiTtsStreamOptions = Parameters<typeof xaiTTSStream>[0];
+type XaiTtsWebSocketFactory = NonNullable<XaiTtsStreamOptions["websocketFactory"]>;
+
+class FakeTtsWebSocket extends EventEmitter {
+  static readonly CONNECTING = 0;
+  static readonly OPEN = 1;
+  readyState = FakeTtsWebSocket.CONNECTING;
+  readonly sent: string[] = [];
+  close = vi.fn(() => {
+    this.readyState = 3;
+    this.emit("close");
+  });
+  terminate = vi.fn(() => {
+    this.readyState = 3;
+  });
+
+  send(data: string) {
+    this.sent.push(data);
+  }
+
+  open() {
+    this.readyState = FakeTtsWebSocket.OPEN;
+    this.emit("open");
+  }
+
+  message(event: Record<string, unknown>) {
+    this.emit("message", JSON.stringify(event));
+  }
+}
 
 function createStreamingAudioResponse(params: {
   chunkCount: number;
@@ -171,6 +202,143 @@ describe("xai tts", () => {
           timeoutMs: 5_000,
         }),
       ).rejects.toThrow("xAI TTS API error (503): temporary upstream outage");
+    });
+  });
+
+  describe("xaiTTSStream", () => {
+    function createSocketHarness() {
+      const sockets: FakeTtsWebSocket[] = [];
+      const factory: ReturnType<typeof vi.fn<XaiTtsWebSocketFactory>> = vi.fn(() => {
+        const socket = new FakeTtsWebSocket();
+        sockets.push(socket);
+        return socket as ReturnType<XaiTtsWebSocketFactory>;
+      });
+      return { sockets, factory };
+    }
+
+    async function readAll(stream: ReadableStream<Uint8Array>): Promise<Buffer> {
+      const reader = stream.getReader();
+      const chunks: Uint8Array[] = [];
+      while (true) {
+        const next = await reader.read();
+        if (next.done) {
+          break;
+        }
+        chunks.push(next.value);
+      }
+      return Buffer.concat(chunks);
+    }
+
+    it("uses the native xAI TTS WebSocket URL and sends text.delta before text.done", async () => {
+      vi.stubEnv("OPENCLAW_VERSION", "2026.3.22");
+      const { sockets, factory } = createSocketHarness();
+      const resultPromise = xaiTTSStream({
+        text: "hello stream",
+        apiKey: "ok-key",
+        baseUrl: XAI_BASE_URL,
+        voiceId: "eve",
+        language: "auto",
+        speed: 1.2,
+        responseFormat: "pcm",
+        timeoutMs: 5_000,
+        websocketFactory: factory,
+      });
+
+      sockets[0]?.open();
+      const result = await resultPromise;
+      sockets[0]?.message({
+        type: "audio.delta",
+        delta: Buffer.from([1, 2, 3]).toString("base64"),
+      });
+      sockets[0]?.message({ type: "audio.done" });
+
+      const url = new URL(factory.mock.calls[0]?.[0] ?? "");
+      expect(url.toString()).toBe(
+        "wss://api.x.ai/v1/tts?language=auto&voice=eve&codec=pcm&speed=1.2",
+      );
+      expect(factory.mock.calls[0]?.[1]).toMatchObject({
+        headers: {
+          Authorization: "Bearer ok-key",
+          "User-Agent": "openclaw/2026.3.22",
+        },
+        handshakeTimeout: 5_000,
+      });
+      expect(sockets[0]?.sent.map((data) => JSON.parse(data) as unknown)).toEqual([
+        { type: "text.delta", delta: "hello stream" },
+        { type: "text.done" },
+      ]);
+      await expect(readAll(result.audioStream)).resolves.toEqual(Buffer.from([1, 2, 3]));
+      vi.unstubAllEnvs();
+    });
+
+    it("rejects non-native base URLs for streaming TTS", async () => {
+      await expect(
+        xaiTTSStream({
+          text: "hello",
+          apiKey: "ok-key",
+          baseUrl: "https://proxy.example.test/v1",
+          voiceId: "eve",
+          timeoutMs: 5_000,
+          websocketFactory: vi.fn(),
+        }),
+      ).rejects.toThrow("xAI streaming TTS requires native xAI baseUrl https://api.x.ai/v1");
+    });
+
+    it("errors the audio stream when the connection closes before audio.done", async () => {
+      const { sockets, factory } = createSocketHarness();
+      const resultPromise = xaiTTSStream({
+        text: "hello",
+        apiKey: "ok-key",
+        baseUrl: XAI_BASE_URL,
+        voiceId: "eve",
+        timeoutMs: 5_000,
+        websocketFactory: factory,
+      });
+      sockets[0]?.open();
+      const result = await resultPromise;
+      sockets[0]?.emit("close");
+
+      await expect(readAll(result.audioStream)).rejects.toThrow(
+        "xAI streaming TTS connection closed before audio.done",
+      );
+    });
+
+    it("times out connection setup and releases the socket", async () => {
+      vi.useFakeTimers();
+      const { sockets, factory } = createSocketHarness();
+      const resultPromise = xaiTTSStream({
+        text: "hello",
+        apiKey: "ok-key",
+        baseUrl: XAI_BASE_URL,
+        voiceId: "eve",
+        timeoutMs: 50,
+        websocketFactory: factory,
+      });
+      const expectation = expect(resultPromise).rejects.toThrow("xAI streaming TTS timed out");
+
+      await vi.advanceTimersByTimeAsync(50);
+
+      await expectation;
+      expect(sockets[0]?.close).toHaveBeenCalled();
+      vi.useRealTimers();
+    });
+
+    it("closes the socket when the caller releases the stream", async () => {
+      const { sockets, factory } = createSocketHarness();
+      const resultPromise = xaiTTSStream({
+        text: "hello",
+        apiKey: "ok-key",
+        baseUrl: XAI_BASE_URL,
+        voiceId: "eve",
+        timeoutMs: 5_000,
+        websocketFactory: factory,
+      });
+      sockets[0]?.open();
+      const result = await resultPromise;
+
+      await result.release();
+
+      expect(sockets[0]?.close).toHaveBeenCalledWith(1000, "tts complete");
     });
   });
 });

--- a/extensions/xai/tts.ts
+++ b/extensions/xai/tts.ts
@@ -1,15 +1,31 @@
-// Xai plugin module implements tts behavior.
 import { assertOkOrThrowProviderError, postJsonRequest } from "openclaw/plugin-sdk/provider-http";
 import { readResponseWithLimit } from "openclaw/plugin-sdk/response-limit-runtime";
 import { trimToUndefined } from "openclaw/plugin-sdk/speech";
+// Xai plugin module implements tts behavior.
+import WebSocket, { type RawData } from "ws";
 import { XAI_BASE_URL } from "./api.js";
 import { xaiUserAgentHeaderFor } from "./src/xai-user-agent.js";
 export { XAI_BASE_URL };
 
 const DEFAULT_TTS_MAX_BYTES = 16 * 1024 * 1024;
 export const XAI_TTS_VOICES = ["eve", "ara", "rex", "sal", "leo", "una"] as const;
+const XAI_NATIVE_TTS_WS_URL = "wss://api.x.ai/v1/tts";
+const XAI_TTS_CLOSE_TIMEOUT_MS = 1_000;
 
 type XaiTtsVoice = (typeof XAI_TTS_VOICES)[number];
+type XaiTtsResponseFormat = "mp3" | "wav" | "pcm" | "mulaw" | "alaw";
+type XaiTtsWebSocket = {
+  readyState: number;
+  close: (code?: number, reason?: string) => void;
+  on: (event: "message", listener: (data: RawData) => void) => XaiTtsWebSocket;
+  once: (
+    event: "open" | "error" | "close",
+    listener: (...args: unknown[]) => void,
+  ) => XaiTtsWebSocket;
+  send: (data: string) => void;
+  terminate?: WebSocket["terminate"];
+};
+type XaiTtsWebSocketFactory = (url: string, options: WebSocket.ClientOptions) => XaiTtsWebSocket;
 
 export function normalizeXaiTtsBaseUrl(baseUrl?: string): string {
   const trimmed = baseUrl?.trim();
@@ -17,6 +33,11 @@ export function normalizeXaiTtsBaseUrl(baseUrl?: string): string {
     return XAI_BASE_URL;
   }
   return trimmed.replace(/\/+$/, "");
+}
+
+function isNativeXaiTtsBaseUrl(baseUrl: string): boolean {
+  const url = new URL(normalizeXaiTtsBaseUrl(baseUrl));
+  return url.protocol === "https:" && url.hostname === "api.x.ai" && url.pathname === "/v1";
 }
 
 export function isValidXaiTtsVoice(voice: string, baseUrl?: string): voice is XaiTtsVoice {
@@ -50,7 +71,7 @@ export async function xaiTTS(params: {
   voiceId: string;
   language?: string;
   speed?: number;
-  responseFormat?: "mp3" | "wav" | "pcm" | "mulaw" | "alaw";
+  responseFormat?: XaiTtsResponseFormat;
   timeoutMs: number;
   maxBytes?: number;
 }): Promise<Buffer> {
@@ -101,5 +122,234 @@ export async function xaiTTS(params: {
     });
   } finally {
     await release();
+  }
+}
+
+function createXaiTtsAbortError(message: string): Error {
+  const err = new Error(message);
+  err.name = "AbortError";
+  return err;
+}
+
+function rawDataToString(data: RawData): string {
+  return Array.isArray(data)
+    ? Buffer.concat(data).toString("utf8")
+    : Buffer.from(data as Uint8Array).toString("utf8");
+}
+
+function readXaiTtsErrorMessage(value: unknown): string {
+  if (typeof value === "string" && value.trim()) {
+    return value.trim();
+  }
+  if (value && typeof value === "object") {
+    const record = value as Record<string, unknown>;
+    if (typeof record.message === "string" && record.message.trim()) {
+      return record.message.trim();
+    }
+    if (typeof record.error === "string" && record.error.trim()) {
+      return record.error.trim();
+    }
+  }
+  return "xAI streaming TTS error";
+}
+
+function buildXaiTtsStreamingUrl(params: {
+  baseUrl: string;
+  voiceId: string;
+  language?: string;
+  speed?: number;
+  responseFormat?: XaiTtsResponseFormat;
+}): string {
+  if (!isNativeXaiTtsBaseUrl(params.baseUrl)) {
+    throw new Error("xAI streaming TTS requires native xAI baseUrl https://api.x.ai/v1");
+  }
+  const language = normalizeXaiLanguageCode(params.language) ?? "en";
+  const url = new URL(XAI_NATIVE_TTS_WS_URL);
+  url.searchParams.set("language", language);
+  url.searchParams.set("voice", params.voiceId);
+  url.searchParams.set("codec", params.responseFormat ?? "mp3");
+  if (params.speed != null) {
+    url.searchParams.set("speed", String(params.speed));
+  }
+  return url.toString();
+}
+
+export async function xaiTTSStream(params: {
+  text: string;
+  apiKey: string;
+  baseUrl: string;
+  voiceId: string;
+  language?: string;
+  speed?: number;
+  responseFormat?: XaiTtsResponseFormat;
+  timeoutMs: number;
+  websocketFactory?: XaiTtsWebSocketFactory;
+}): Promise<{
+  audioStream: ReadableStream<Uint8Array>;
+  release: () => Promise<void>;
+}> {
+  const { text, apiKey, baseUrl, voiceId, responseFormat = "mp3", timeoutMs } = params;
+
+  if (!isValidXaiTtsVoice(voiceId, baseUrl)) {
+    throw new Error(`Invalid voice: ${voiceId}`);
+  }
+
+  const url = buildXaiTtsStreamingUrl({
+    baseUrl,
+    voiceId,
+    language: params.language,
+    speed: params.speed,
+    responseFormat,
+  });
+
+  const headers = {
+    Authorization: `Bearer ${apiKey}`,
+    ...xaiUserAgentHeaderFor(XAI_BASE_URL),
+  };
+  const websocketFactory =
+    params.websocketFactory ?? ((wsUrl, options) => new WebSocket(wsUrl, options));
+  const ws = websocketFactory(url, {
+    headers,
+    handshakeTimeout: timeoutMs,
+  });
+
+  let controller: ReadableStreamDefaultController<Uint8Array> | undefined;
+  let handoffComplete = false;
+  let streamClosed = false;
+  let released = false;
+  let closeTimer: NodeJS.Timeout | undefined;
+  let timeout: NodeJS.Timeout | undefined;
+
+  const clearTimeouts = () => {
+    if (timeout) {
+      clearTimeout(timeout);
+      timeout = undefined;
+    }
+    if (closeTimer) {
+      clearTimeout(closeTimer);
+      closeTimer = undefined;
+    }
+  };
+
+  const closeSocket = () => {
+    if (ws.readyState === WebSocket.OPEN || ws.readyState === WebSocket.CONNECTING) {
+      ws.close(1000, "tts complete");
+      if (ws.readyState !== WebSocket.CLOSED) {
+        closeTimer = setTimeout(() => ws.terminate?.(), XAI_TTS_CLOSE_TIMEOUT_MS);
+      }
+    }
+  };
+
+  const failStream = (err: Error) => {
+    clearTimeouts();
+    if (!streamClosed) {
+      streamClosed = true;
+      controller?.error(err);
+    }
+    closeSocket();
+  };
+
+  const release = async () => {
+    released = true;
+    clearTimeouts();
+    if (!streamClosed) {
+      streamClosed = true;
+      controller?.close();
+    }
+    closeSocket();
+  };
+
+  const audioStream = new ReadableStream<Uint8Array>({
+    start(nextController) {
+      controller = nextController;
+    },
+    cancel() {
+      return release();
+    },
+  });
+
+  const openPromise = new Promise<void>((resolve, reject) => {
+    timeout = setTimeout(() => {
+      const err = createXaiTtsAbortError("xAI streaming TTS timed out");
+      if (!handoffComplete) {
+        reject(err);
+      }
+      failStream(err);
+    }, timeoutMs);
+
+    ws.once("open", () => {
+      try {
+        ws.send(JSON.stringify({ type: "text.delta", delta: text }));
+        ws.send(JSON.stringify({ type: "text.done" }));
+        handoffComplete = true;
+        resolve();
+      } catch (err) {
+        reject(err);
+        failStream(err instanceof Error ? err : new Error(String(err)));
+      }
+    });
+    ws.once("error", (err) => {
+      if (!handoffComplete) {
+        reject(err);
+        return;
+      }
+      failStream(err instanceof Error ? err : new Error(String(err)));
+    });
+    ws.once("close", () => {
+      if (closeTimer) {
+        clearTimeout(closeTimer);
+        closeTimer = undefined;
+      }
+      if (!handoffComplete) {
+        reject(new Error("xAI streaming TTS connection closed before ready"));
+        return;
+      }
+      if (!streamClosed && !released) {
+        failStream(new Error("xAI streaming TTS connection closed before audio.done"));
+      }
+    });
+  });
+
+  ws.on("message", (data) => {
+    if (streamClosed) {
+      return;
+    }
+    let event: Record<string, unknown>;
+    try {
+      event = JSON.parse(rawDataToString(data)) as Record<string, unknown>;
+    } catch {
+      failStream(new Error("xAI streaming TTS returned malformed JSON"));
+      return;
+    }
+    switch (event.type) {
+      case "audio.delta": {
+        if (typeof event.delta !== "string") {
+          failStream(new Error("xAI streaming TTS audio.delta missing base64 payload"));
+          return;
+        }
+        controller?.enqueue(Buffer.from(event.delta, "base64"));
+        return;
+      }
+      case "audio.done":
+        clearTimeouts();
+        if (!streamClosed) {
+          streamClosed = true;
+          controller?.close();
+        }
+        closeSocket();
+        return;
+      case "error":
+        failStream(new Error(readXaiTtsErrorMessage(event.message ?? event.error)));
+        return;
+      default:
+    }
+  });
+
+  try {
+    await openPromise;
+    return { audioStream, release };
+  } catch (err) {
+    await release();
+    throw err;
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1768,13 +1768,13 @@ importers:
       typebox:
         specifier: 1.1.39
         version: 1.1.39
+      ws:
+        specifier: 8.21.0
+        version: 8.21.0
     devDependencies:
       '@openclaw/plugin-sdk':
         specifier: workspace:*
         version: link:../../packages/plugin-sdk
-      ws:
-        specifier: 8.21.0
-        version: 8.21.0
 
   extensions/xiaomi:
     devDependencies:


### PR DESCRIPTION
Closes #99660

## What Problem This Solves

Fixes an issue where xAI could be used for buffered OpenClaw TTS, but streaming playback callers could not use xAI's native lower-latency streaming TTS WebSocket contract.

## Why This Change Was Made

The xAI speech provider now exposes `streamSynthesize` through the documented native `wss://api.x.ai/v1/tts` WebSocket flow while leaving existing buffered `synthesize` and telephony paths on REST `/v1/tts`. The streaming path uses Node's native WebSocket client and is restricted to the native xAI host so REST-compatible proxy base URLs are not silently treated as xAI WebSocket endpoints.

## User Impact

Streaming TTS callers can receive xAI audio chunks as they arrive instead of waiting for a complete buffered audio response, while existing normal TTS attachment and telephony behavior remains unchanged.

## Evidence

- Claim proved: xAI streaming TTS uses the native WebSocket endpoint, sends `text.delta` then `text.done`, consumes `audio.delta` chunks until `audio.done`, and is wired through the speech provider streaming contract.
- Commands / artifacts:
  - Branch head SHA: 0dbfb2f7b8e0dc5d84ab18b3d770ee16cd91e533
  - `node scripts/run-vitest.mjs extensions/xai/tts.test.ts extensions/xai/speech-provider.test.ts` passed: 2 files, 21 tests.
  - `node scripts/run-vitest.mjs test/scripts/plugin-package-dependencies.test.ts` passed: 1 file, 3 tests.
  - `git diff --check` passed.
  - Official xAI Text-to-Speech docs checked for the native streaming endpoint and event protocol: https://docs.x.ai/developers/model-capabilities/audio/text-to-speech
- Observed result: focused tests cover URL/query shape, WebSocket headers, text event ordering, audio chunk decoding, early close, connection error, timeout, release behavior, provider integration, and package dependency ownership.
- Not tested / proof gaps: no live xAI credential smoke was run, so there is no real-service audio proof. `pnpm docs:list` was attempted but local pnpm aborted with `ERR_PNPM_ABORTED_REMOVE_MODULES_DIR_NO_TTY` in this worktree.