### PR TITLE
fix(reply): surface empty interactive completions

### DIFF
--- a/src/auto-reply/reply/agent-runner.misc.runreplyagent.test.ts
+++ b/src/auto-reply/reply/agent-runner.misc.runreplyagent.test.ts
@@ -321,6 +321,7 @@ describe("runReplyAgent auto-compaction token update", () => {
     storePath: string;
     sessionEntry: Record<string, unknown>;
     config?: Record<string, unknown>;
+    run?: Record<string, unknown>;
     sessionFile?: string;
     workspaceDir?: string;
   }) {
@@ -355,10 +356,102 @@ describe("runReplyAgent auto-compaction token update", () => {
         bashElevated: { enabled: false, allowed: false, defaultLevel: "off" },
         timeoutMs: 1_000,
         blockReplyBreak: "message_end",
+        ...params.run,
       },
     } as unknown as FollowupRun;
     return { typing, sessionCtx, resolvedQueue, followupRun };
   }
+
+  it("surfaces empty interactive completions as visible failures", async () => {
+    const sessionKey = "main";
+    const sessionEntry = {
+      sessionId: "session",
+      updatedAt: Date.now(),
+      totalTokens: 50_000,
+    };
+    runEmbeddedAgentMock.mockResolvedValue({
+      payloads: [],
+      meta: { agentMeta: {} },
+    });
+
+    const { typing, sessionCtx, resolvedQueue, followupRun } = createBaseRun({
+      storePath: "",
+      sessionEntry,
+    });
+
+    const result = await runReplyAgent({
+      commandBody: "hello",
+      followupRun,
+      queueKey: sessionKey,
+      resolvedQueue,
+      shouldSteer: false,
+      shouldFollowup: false,
+      isActive: false,
+      isStreaming: false,
+      typing,
+      sessionCtx,
+      sessionEntry,
+      sessionStore: { [sessionKey]: sessionEntry },
+      sessionKey,
+      defaultModel: "anthropic/claude-opus-4-6",
+      agentCfgContextTokens: 200_000,
+      resolvedVerboseLevel: "off",
+      isNewSession: false,
+      blockStreamingEnabled: false,
+      resolvedBlockStreamingBreak: "message_end",
+      shouldInjectGroupIntro: false,
+      typingMode: "instant",
+    });
+
+    const reply = requireRecord(result, "empty interactive reply result");
+    expect(reply.text).toContain("did not produce a visible reply");
+    expect(reply.isError).toBe(true);
+  });
+
+  it("keeps resolved message-tool-only empty completions silent", async () => {
+    const sessionKey = "main";
+    const sessionEntry = {
+      sessionId: "session",
+      updatedAt: Date.now(),
+      totalTokens: 50_000,
+    };
+    runEmbeddedAgentMock.mockResolvedValue({
+      payloads: [],
+      meta: { agentMeta: {} },
+    });
+
+    const { typing, sessionCtx, resolvedQueue, followupRun } = createBaseRun({
+      storePath: "",
+      sessionEntry,
+      run: { sourceReplyDeliveryMode: "message_tool_only" },
+    });
+
+    const result = await runReplyAgent({
+      commandBody: "hello",
+      followupRun,
+      queueKey: sessionKey,
+      resolvedQueue,
+      shouldSteer: false,
+      shouldFollowup: false,
+      isActive: false,
+      isStreaming: false,
+      typing,
+      sessionCtx,
+      sessionEntry,
+      sessionStore: { [sessionKey]: sessionEntry },
+      sessionKey,
+      defaultModel: "anthropic/claude-opus-4-6",
+      agentCfgContextTokens: 200_000,
+      resolvedVerboseLevel: "off",
+      isNewSession: false,
+      blockStreamingEnabled: false,
+      resolvedBlockStreamingBreak: "message_end",
+      shouldInjectGroupIntro: false,
+      typingMode: "instant",
+    });
+
+    expect(result).toBeUndefined();
+  });
 
   async function runBaseReplyWithAgentMeta(params: {
     agentMeta: Record<string, unknown>;

--- a/src/auto-reply/reply/agent-runner.ts
+++ b/src/auto-reply/reply/agent-runner.ts
@@ -94,6 +94,7 @@ import {
   type CompactionNoticePhase,
 } from "./compaction-notice.js";
 import { resolveEffectiveReplyRoute } from "./effective-reply-route.js";
+import { buildEmptyInteractiveReplyPayload } from "./empty-interactive-reply.js";
 import { createFollowupRunner } from "./followup-runner.js";
 import { REPLY_RUN_STILL_SHUTTING_DOWN_TEXT } from "./get-reply-run-queue.js";
 import { resolveOriginMessageProvider, resolveOriginMessageTo } from "./origin-routing.js";
@@ -2017,6 +2018,25 @@ export async function runReplyAgent(params: {
       await signalTypingIfNeeded([silentFallbackFailurePayload], typingSignals);
       return returnWithQueuedFollowupDrain(silentFallbackFailurePayload);
     };
+    const returnEmptyInteractiveReplyIfNeeded = async (): Promise<ReplyPayload | undefined> => {
+      const emptyInteractiveReplyPayload = buildEmptyInteractiveReplyPayload({
+        isHeartbeat,
+        hasSuccessfulSideEffectDelivery: successfulSideEffectDelivery,
+        allowEmptyAssistantReplyAsSilent: followupRun.run.allowEmptyAssistantReplyAsSilent,
+        silentExpected: followupRun.run.silentExpected,
+        sourceReplyDeliveryMode:
+          followupRun.run.sourceReplyDeliveryMode ?? opts?.sourceReplyDeliveryMode,
+      });
+      if (!emptyInteractiveReplyPayload) {
+        return undefined;
+      }
+      replyOperation.fail(
+        "run_failed",
+        new Error("interactive reply completed without a visible payload"),
+      );
+      await signalTypingIfNeeded([emptyInteractiveReplyPayload], typingSignals);
+      return returnWithQueuedFollowupDrain(emptyInteractiveReplyPayload);
+    };
 
     const fallbackNoticePayloads: ReplyPayload[] = [];
     if (
@@ -2094,6 +2114,10 @@ export async function runReplyAgent(params: {
       if (silentFallbackFailurePayload) {
         return silentFallbackFailurePayload;
       }
+      const emptyInteractiveReplyPayload = await returnEmptyInteractiveReplyIfNeeded();
+      if (emptyInteractiveReplyPayload) {
+        return emptyInteractiveReplyPayload;
+      }
       return returnWithQueuedFollowupDrain(undefined);
     }
 
@@ -2147,6 +2171,10 @@ export async function runReplyAgent(params: {
       const silentFallbackFailurePayload = await returnSilentFallbackFailureIfNeeded();
       if (silentFallbackFailurePayload) {
         return silentFallbackFailurePayload;
+      }
+      const emptyInteractiveReplyPayload = await returnEmptyInteractiveReplyIfNeeded();
+      if (emptyInteractiveReplyPayload) {
+        return emptyInteractiveReplyPayload;
       }
       return returnWithQueuedFollowupDrain(undefined);
     }

--- a/src/auto-reply/reply/empty-interactive-reply.ts
+++ b/src/auto-reply/reply/empty-interactive-reply.ts
@@ -1,0 +1,27 @@
+import { markReplyPayloadForSourceSuppressionDelivery } from "../reply-payload.js";
+import type { ReplyPayload } from "../types.js";
+
+const EMPTY_INTERACTIVE_REPLY_TEXT =
+  "I finished the turn, but it did not produce a visible reply. Please try again, or start a new session if this keeps happening.";
+
+export function buildEmptyInteractiveReplyPayload(params: {
+  isHeartbeat?: boolean;
+  hasSuccessfulSideEffectDelivery?: boolean;
+  allowEmptyAssistantReplyAsSilent?: boolean;
+  silentExpected?: boolean;
+  sourceReplyDeliveryMode?: "automatic" | "message_tool_only";
+}): ReplyPayload | undefined {
+  if (
+    params.isHeartbeat === true ||
+    params.allowEmptyAssistantReplyAsSilent === true ||
+    params.silentExpected === true ||
+    params.sourceReplyDeliveryMode === "message_tool_only" ||
+    params.hasSuccessfulSideEffectDelivery === true
+  ) {
+    return undefined;
+  }
+  return markReplyPayloadForSourceSuppressionDelivery({
+    text: EMPTY_INTERACTIVE_REPLY_TEXT,
+    isError: true,
+  });
+}

--- a/src/auto-reply/reply/followup-runner.test.ts
+++ b/src/auto-reply/reply/followup-runner.test.ts
@@ -4048,6 +4048,27 @@ describe("createFollowupRunner messaging delivery and dedupe", () => {
     return { onBlockReply };
   }
 
+  async function runEmptyInteractiveCase(
+    params: {
+      agentResult?: Record<string, unknown>;
+      queued?: FollowupRun;
+    } = {},
+  ) {
+    return await runMessagingCase({
+      agentResult: {
+        payloads: [],
+        ...params.agentResult,
+      },
+      queued:
+        params.queued ??
+        ({
+          ...baseQueuedRun("discord"),
+          originatingChannel: "discord",
+          originatingTo: "channel:C1",
+        } as FollowupRun),
+    });
+  }
+
   function makeTextReplyDedupeResult(overrides?: Record<string, unknown>) {
     return {
       payloads: [{ text: "hello world!" }],
@@ -4055,6 +4076,60 @@ describe("createFollowupRunner messaging delivery and dedupe", () => {
       ...overrides,
     };
   }
+
+  it("routes a visible fallback when an interactive followup completes empty", async () => {
+    const { onBlockReply } = await runEmptyInteractiveCase();
+
+    expect(routeReplyMock).toHaveBeenCalledTimes(1);
+    expect(onBlockReply).not.toHaveBeenCalled();
+    const payload = requireRecord(requireMockCallArg(routeReplyMock, 0).payload, "routed payload");
+    expect(payload.text).toContain("did not produce a visible reply");
+    expect(payload.isError).toBe(true);
+  });
+
+  it("keeps message-tool-only empty followup completions silent", async () => {
+    const queued = baseQueuedRun("discord");
+    const { onBlockReply } = await runEmptyInteractiveCase({
+      queued: {
+        ...queued,
+        originatingChannel: "discord",
+        originatingTo: "channel:C1",
+        run: {
+          ...queued.run,
+          sourceReplyDeliveryMode: "message_tool_only",
+        },
+      } as FollowupRun,
+    });
+
+    expect(routeReplyMock).not.toHaveBeenCalled();
+    expect(onBlockReply).not.toHaveBeenCalled();
+  });
+
+  it("keeps source-delivered empty followup completions silent", async () => {
+    const { onBlockReply } = await runEmptyInteractiveCase({
+      agentResult: {
+        didDeliverSourceReplyViaMessageTool: true,
+      },
+    });
+
+    expect(routeReplyMock).not.toHaveBeenCalled();
+    expect(onBlockReply).not.toHaveBeenCalled();
+  });
+
+  it("keeps cron and approval side-effect followups silent", async () => {
+    await runEmptyInteractiveCase({
+      agentResult: {
+        successfulCronAdds: 1,
+      },
+    });
+    await runEmptyInteractiveCase({
+      agentResult: {
+        didSendDeterministicApprovalPrompt: true,
+      },
+    });
+
+    expect(routeReplyMock).not.toHaveBeenCalled();
+  });
 
   it("persists usage even when replies are suppressed", async () => {
     const storePath = "/tmp/openclaw-followup-usage.json";
@@ -4775,9 +4850,10 @@ describe("createFollowupRunner messaging delivery and dedupe", () => {
 
     await runner(queued);
 
-    expect(routeReplyMock).toHaveBeenCalledTimes(2);
+    expect(routeReplyMock).toHaveBeenCalledTimes(3);
     const startRoute = requireMockCallArg(routeReplyMock, 0);
     const endRoute = requireMockCallArg(routeReplyMock, 1);
+    const finalRoute = requireMockCallArg(routeReplyMock, 2);
     expect(startRoute).toMatchObject({
       channel: "discord",
       to: "channel:C1",
@@ -4794,6 +4870,10 @@ describe("createFollowupRunner messaging delivery and dedupe", () => {
     });
     expect(endRoute.replyKind).toBe("block");
     expect(endRoute.mirror).toBe(false);
+    expect(finalRoute.replyKind).toBe("final");
+    expect(requireRecord(finalRoute.payload, "final payload").text).toContain(
+      "did not produce a visible reply",
+    );
     expect(requireRecord(endRoute.payload, "end payload")).toMatchObject({
       text: "🧹 Compaction complete",
       replyToId: "current-msg-1",
@@ -4880,7 +4960,7 @@ describe("createFollowupRunner messaging delivery and dedupe", () => {
       }),
     );
 
-    expect(routeReplyMock).toHaveBeenCalledTimes(4);
+    expect(routeReplyMock).toHaveBeenCalledTimes(5);
     expect(
       requireRecord(requireMockCallArg(routeReplyMock, 0).payload, "hook start"),
     ).toMatchObject({
@@ -4911,6 +4991,9 @@ describe("createFollowupRunner messaging delivery and dedupe", () => {
       replyToCurrent: true,
       isCompactionNotice: true,
     });
+    expect(
+      requireRecord(requireMockCallArg(routeReplyMock, 4).payload, "final payload").text,
+    ).toContain("did not produce a visible reply");
   });
 
   it("applies reply-to mode filtering to queued compaction notices", async () => {
@@ -4948,13 +5031,16 @@ describe("createFollowupRunner messaging delivery and dedupe", () => {
       }),
     );
 
-    expect(routeReplyMock).toHaveBeenCalledTimes(1);
+    expect(routeReplyMock).toHaveBeenCalledTimes(2);
     const payload = requireRecord(requireMockCallArg(routeReplyMock, 0).payload, "notice payload");
     expect(payload).toMatchObject({
       text: "🧹 Compacting context...",
       isCompactionNotice: true,
     });
     expect(payload.replyToId).toBeUndefined();
+    expect(
+      requireRecord(requireMockCallArg(routeReplyMock, 1).payload, "final payload").text,
+    ).toContain("did not produce a visible reply");
   });
 
   it("plans queued compaction notices with the active fallback candidate", async () => {
@@ -5005,7 +5091,7 @@ describe("createFollowupRunner messaging delivery and dedupe", () => {
     });
   });
 
-  it("suppresses queued compaction completion notices while compaction will retry", async () => {
+  it("routes empty fallback after retrying compaction still completes empty", async () => {
     runEmbeddedAgentMock.mockImplementationOnce(
       async (args: {
         onAgentEvent?: (evt: { stream: string; data: Record<string, unknown> }) => Promise<void>;
@@ -5043,7 +5129,10 @@ describe("createFollowupRunner messaging delivery and dedupe", () => {
       }),
     );
 
-    expect(routeReplyMock).not.toHaveBeenCalled();
+    expect(routeReplyMock).toHaveBeenCalledTimes(1);
+    const payload = requireRecord(requireMockCallArg(routeReplyMock, 0).payload, "routed payload");
+    expect(payload.text).toContain("did not produce a visible reply");
+    expect(payload.isError).toBe(true);
   });
 });
 

--- a/src/auto-reply/reply/followup-runner.ts
+++ b/src/auto-reply/reply/followup-runner.ts
@@ -79,6 +79,7 @@ import {
   shouldNotifyUserAboutCompaction,
   type CompactionNoticePhase,
 } from "./compaction-notice.js";
+import { buildEmptyInteractiveReplyPayload } from "./empty-interactive-reply.js";
 import { resolveFollowupDeliveryPayloads } from "./followup-delivery.js";
 import { resolveOriginMessageProvider } from "./origin-routing.js";
 import {
@@ -109,6 +110,29 @@ function filterStringArray(value: unknown): string[] | undefined {
   return Array.isArray(value)
     ? value.filter((entry): entry is string => typeof entry === "string")
     : undefined;
+}
+
+function hasNonEmptyStringArray(value: unknown): boolean {
+  return Array.isArray(value) && value.some((entry) => typeof entry === "string" && entry.trim());
+}
+
+function hasCommittedMessagingTargetDeliveryEvidence(value: unknown): boolean {
+  if (!Array.isArray(value)) {
+    return false;
+  }
+  return value.some((entry) => {
+    if (!entry || typeof entry !== "object") {
+      return false;
+    }
+    const record = entry as { text?: unknown; mediaUrls?: unknown };
+    if ("text" in record || "mediaUrls" in record) {
+      return (
+        (typeof record.text === "string" && record.text.trim().length > 0) ||
+        hasNonEmptyStringArray(record.mediaUrls)
+      );
+    }
+    return true;
+  });
 }
 
 function hasFailedFollowupProgressEvent(evt: FollowupAgentEvent): boolean {
@@ -1432,7 +1456,42 @@ export function createFollowupRunner(params: {
       }
 
       const payloadArray = runResult.payloads ?? [];
+      const buildEmptyInteractiveFollowupPayload = () =>
+        buildEmptyInteractiveReplyPayload({
+          isHeartbeat: opts?.isHeartbeat,
+          hasSuccessfulSideEffectDelivery:
+            runResult.didSendViaMessagingTool === true ||
+            runResult.didDeliverSourceReplyViaMessageTool === true ||
+            hasNonEmptyStringArray(runResult.messagingToolSentTexts) ||
+            hasNonEmptyStringArray(runResult.messagingToolSentMediaUrls) ||
+            hasCommittedMessagingTargetDeliveryEvidence(runResult.messagingToolSentTargets) ||
+            (runResult.successfulCronAdds ?? 0) > 0 ||
+            runResult.didSendDeterministicApprovalPrompt === true,
+          allowEmptyAssistantReplyAsSilent: run.allowEmptyAssistantReplyAsSilent,
+          silentExpected: run.silentExpected,
+          sourceReplyDeliveryMode: run.sourceReplyDeliveryMode,
+        });
+      const routeEmptyInteractiveFollowupIfNeeded = async () => {
+        const emptyInteractiveReplyPayload = buildEmptyInteractiveFollowupPayload();
+        if (!emptyInteractiveReplyPayload) {
+          return;
+        }
+        replyOperation?.fail(
+          "run_failed",
+          new Error("interactive follow-up completed without a visible payload"),
+        );
+        await sendFollowupPayloads(
+          [emptyInteractiveReplyPayload],
+          effectiveQueued,
+          {
+            provider: providerUsed,
+            modelId: modelUsed,
+          },
+          { runId },
+        );
+      };
       if (payloadArray.length === 0) {
+        await routeEmptyInteractiveFollowupIfNeeded();
         return;
       }
       const finalPayloads = resolveFollowupDeliveryPayloads({
@@ -1451,6 +1510,7 @@ export function createFollowupRunner(params: {
       });
 
       if (finalPayloads.length === 0) {
+        await routeEmptyInteractiveFollowupIfNeeded();
         return;
       }
 


### PR DESCRIPTION
Closes #99712

## What Problem This Solves

Fixes an issue where an interactive direct turn could finish successfully with no assistant payload and no committed source reply, causing the user-facing channel turn to silently complete without any visible deliverable.

## Why This Change Was Made

Direct reply and queued follow-up delivery now share a bounded empty-interactive fallback that emits a visible error payload only when the run otherwise has no visible output. Existing silent paths remain silent for heartbeats, explicitly silent runs, message-tool-only delivery, and runs that already committed a message-tool, cron, approval, media, or other side-effect delivery.

## User Impact

Users get a visible failure message when an interactive channel turn produces no deliverable output, instead of seeing the turn disappear. Message-tool-only and known side-effect flows continue to avoid duplicate automatic replies.

## Evidence

- Claim proved: empty direct and follow-up interactive completions route a visible fallback while preserving silent/side-effect/message-tool-only exceptions.
- Commands / artifacts:
  - Head SHA: 167c0625323a5843828e7e241d0bfcb11d3bfb76
  - `node scripts/run-vitest.mjs src/auto-reply/reply/agent-runner.misc.runreplyagent.test.ts src/auto-reply/reply/followup-runner.test.ts` passed: 2 files, 149 tests.
  - `git diff --check` passed.
  - `python .agents\skills\autoreview\scripts\autoreview --mode local` passed after fixes with no accepted/actionable findings.
- Observed result: focused tests cover main-run empty output, resolved `message_tool_only` suppression, follow-up empty fallback routing, source-delivered suppression, cron/approval suppression, and compaction/progress paths that still finish with no visible final payload.
- Not tested / proof gaps: no live Telegram or other real channel proof was run. This PR intentionally claims focused source/runtime path coverage, not live Telegram-visible proof.