### PR TITLE
fix(slack): preserve time colons in interactive labels

### DIFF
--- a/extensions/slack/src/interactive-replies.test.ts
+++ b/extensions/slack/src/interactive-replies.test.ts
@@ -94,4 +94,99 @@ describe("compileSlackInteractiveReplies", () => {
     );
     expect(result.interactive).toBeUndefined();
   });
+
+  it("keeps time-style colons in Slack button labels", () => {
+    const result = compileSlackInteractiveReplies({
+      text: "[[slack_buttons: Fr 10.07. 9:00:slot_fr_0900, Mo 13.07. 10:45:slot_mo_1045, Today 11:30:ticket:123]]",
+    });
+
+    expect(result.interactive).toEqual({
+      blocks: [
+        {
+          type: "buttons",
+          buttons: [
+            { label: "Fr 10.07. 9:00", value: "slot_fr_0900" },
+            { label: "Mo 13.07. 10:45", value: "slot_mo_1045" },
+            { label: "Today 11:30", value: "ticket:123" },
+          ],
+        },
+      ],
+    });
+  });
+
+  it("keeps button style suffixes after time-style labels", () => {
+    const result = compileSlackInteractiveReplies({
+      text: "[[slack_buttons: Fr 10.07. 9:00:slot_fr_0900:primary, Later 10:45:slot_later:danger]]",
+    });
+
+    expect(result.interactive).toEqual({
+      blocks: [
+        {
+          type: "buttons",
+          buttons: [
+            { label: "Fr 10.07. 9:00", value: "slot_fr_0900", style: "primary" },
+            { label: "Later 10:45", value: "slot_later", style: "danger" },
+          ],
+        },
+      ],
+    });
+  });
+
+  it("preserves colon-containing Slack callback values", () => {
+    const result = compileSlackInteractiveReplies({
+      text: "[[slack_buttons: Open:ticket:123, Timed:ticket:9:00:id, Allow:pluginbind:approval-123:o, Deny:/approve plugin:approval-123 deny]]",
+    });
+
+    expect(result.interactive).toEqual({
+      blocks: [
+        {
+          type: "buttons",
+          buttons: [
+            { label: "Open", value: "ticket:123" },
+            { label: "Timed", value: "ticket:9:00:id" },
+            { label: "Allow", value: "pluginbind:approval-123:o" },
+            { label: "Deny", value: "/approve plugin:approval-123 deny" },
+          ],
+        },
+      ],
+    });
+  });
+
+  it("keeps single-colon button entries unchanged when the value matches a style name", () => {
+    const result = compileSlackInteractiveReplies({
+      text: "[[slack_buttons: Primary:primary, Danger:danger, Fr 10.07. 9:00:primary]]",
+    });
+
+    expect(result.interactive).toEqual({
+      blocks: [
+        {
+          type: "buttons",
+          buttons: [
+            { label: "Primary", value: "primary" },
+            { label: "Danger", value: "danger" },
+            { label: "Fr 10.07. 9:00", value: "primary" },
+          ],
+        },
+      ],
+    });
+  });
+
+  it("keeps time-style colons in Slack select option labels", () => {
+    const result = compileSlackInteractiveReplies({
+      text: "[[slack_select: Pick a time | Fr 10.07. 9:00:slot_fr_0900, Mo 13.07. 10:45:slot_mo_1045]]",
+    });
+
+    expect(result.interactive).toEqual({
+      blocks: [
+        {
+          type: "select",
+          placeholder: "Pick a time",
+          options: [
+            { label: "Fr 10.07. 9:00", value: "slot_fr_0900" },
+            { label: "Mo 13.07. 10:45", value: "slot_mo_1045" },
+          ],
+        },
+      ],
+    });
+  });
 });

--- a/extensions/slack/src/interactive-replies.ts
+++ b/extensions/slack/src/interactive-replies.ts
@@ -21,41 +21,60 @@ type SlackChoice = {
   style?: "primary" | "secondary" | "success" | "danger";
 };
 
+function resolveChoiceDelimiter(value: string): number {
+  const firstDelimiter = value.indexOf(":");
+  if (firstDelimiter === -1) {
+    return -1;
+  }
+  const prefix = value.slice(0, firstDelimiter);
+  const suffix = value.slice(firstDelimiter + 1);
+  if (/\b\d{1,2}$/.test(prefix) && /^\d{2}:/.test(suffix)) {
+    return firstDelimiter + 3;
+  }
+  if (/\b\d{1,2}$/.test(prefix) && /^\d{2}$/.test(suffix)) {
+    return -1;
+  }
+  return firstDelimiter;
+}
+
 function parseChoice(raw: string, options?: { allowStyle?: boolean }): SlackChoice | null {
   const trimmed = raw.trim();
   if (!trimmed) {
     return null;
   }
-  const delimiter = trimmed.indexOf(":");
-  if (delimiter === -1) {
-    return {
-      label: trimmed,
-      value: trimmed,
-    };
-  }
-  const label = trimmed.slice(0, delimiter).trim();
-  let value = trimmed.slice(delimiter + 1).trim();
-  if (!label || !value) {
-    return null;
-  }
+  let working = trimmed;
   let style: SlackChoice["style"];
   if (options?.allowStyle) {
-    const styleDelimiter = value.lastIndexOf(":");
+    const styleDelimiter = working.lastIndexOf(":");
     if (styleDelimiter !== -1) {
-      const maybeStyle = normalizeLowercaseStringOrEmpty(value.slice(styleDelimiter + 1));
+      const maybeStyle = normalizeLowercaseStringOrEmpty(working.slice(styleDelimiter + 1));
       if (
         maybeStyle === "primary" ||
         maybeStyle === "secondary" ||
         maybeStyle === "success" ||
         maybeStyle === "danger"
       ) {
-        const unstyledValue = value.slice(0, styleDelimiter).trim();
-        if (unstyledValue) {
-          value = unstyledValue;
+        const withoutStyle = working.slice(0, styleDelimiter).trim();
+        const delimiterBeforeStyle = resolveChoiceDelimiter(withoutStyle);
+        if (
+          delimiterBeforeStyle !== -1 &&
+          withoutStyle.slice(0, delimiterBeforeStyle).trim() &&
+          withoutStyle.slice(delimiterBeforeStyle + 1).trim()
+        ) {
+          working = withoutStyle;
           style = maybeStyle;
         }
       }
     }
+  }
+  const delimiter = resolveChoiceDelimiter(working);
+  if (delimiter === -1) {
+    return style ? { label: working, value: working, style } : { label: working, value: working };
+  }
+  const label = working.slice(0, delimiter).trim();
+  const value = working.slice(delimiter + 1).trim();
+  if (!label || !value) {
+    return null;
   }
   return style ? { label, value, style } : { label, value };
 }


### PR DESCRIPTION
Closes #99823

## What Problem This Solves

Fixes an issue where Slack users choosing `[[slack_buttons:]]` or `[[slack_select:]]` options with time-like labels such as `9:00` would have the label/value split at the time colon instead of the intended action delimiter.

## Why This Change Was Made

Slack interactive reply parsing now treats `H:MM` and `HH:MM` tokens as part of the label while preserving the existing first-delimiter behavior for callback values that legitimately contain colons. Button style suffixes are still recognized only when a real label/value delimiter exists before the style token.

## User Impact

Slack buttons and selects can show time labels like `Fr 10.07. 9:00` while still sending the intended callback value, including values such as `ticket:123` or `/approve plugin:approval-123 deny`.

## Evidence

- Claim proved: Slack interactive choice parsing preserves time-style label colons without breaking colon-containing callback values or style suffixes.
- Commands / artifacts:
  - Head SHA: 4a0d3b5fbf88e226237734a80bea7125e82f17d2
  - `node scripts/run-vitest.mjs extensions/slack/src/interactive-replies.test.ts` passed: 1 file, 9 tests.
  - `git diff --check` passed.
  - `python .agents\skills\autoreview\scripts\autoreview --mode local` passed before commit with no accepted/actionable findings.
- Observed result: focused tests cover time labels, select labels, style suffixes, style-named values, and colon-containing Slack callback values.
- Not tested / proof gaps: no live Slack workspace/API proof and no broad CI/full lint/typecheck were run locally.