### PR TITLE
fix(android): accept case-insensitive assistant roles in voice chat text

### DIFF
--- a/apps/android/app/src/main/java/ai/openclaw/app/voice/ChatEventText.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/voice/ChatEventText.kt
@@ -12,8 +12,10 @@ internal object ChatEventText {
   /** Extracts text from assistant messages while ignoring non-assistant roles. */
   fun assistantTextFromMessage(messageEl: JsonElement?): String? {
     val message = messageEl.asObjectOrNull() ?: return null
-    val role = message["role"].asStringOrNull()
-    if (role != "assistant") return null
+    val role = message["role"].asStringOrNull()?.trim()
+    // Voice stays fail-closed on missing roles (#99123); only canonical assistant roles speak.
+    if (role.isNullOrEmpty()) return null
+    if (!role.equals("assistant", ignoreCase = true)) return null
     return textFromContent(message["content"])
   }
 

--- a/apps/android/app/src/main/java/ai/openclaw/app/voice/ChatEventText.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/voice/ChatEventText.kt
@@ -13,7 +13,7 @@ internal object ChatEventText {
   fun assistantTextFromMessage(messageEl: JsonElement?): String? {
     val message = messageEl.asObjectOrNull() ?: return null
     val role = message["role"].asStringOrNull()?.trim()
-    // Voice stays fail-closed on missing roles (#99123); only canonical assistant roles speak.
+    // Voice stays fail-closed on missing roles; only canonical assistant roles speak.
     if (role.isNullOrEmpty()) return null
     if (!role.equals("assistant", ignoreCase = true)) return null
     return textFromContent(message["content"])

--- a/apps/android/app/src/main/java/ai/openclaw/app/voice/ChatEventText.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/voice/ChatEventText.kt
@@ -12,11 +12,14 @@ internal object ChatEventText {
   /** Extracts text from assistant messages while ignoring non-assistant roles. */
   fun assistantTextFromMessage(messageEl: JsonElement?): String? {
     val message = messageEl.asObjectOrNull() ?: return null
-    val role = message["role"].asStringOrNull()?.trim()
-    // Voice stays fail-closed on missing roles; only canonical assistant roles speak.
-    if (role.isNullOrEmpty()) return null
-    if (!role.equals("assistant", ignoreCase = true)) return null
+    if (!isAssistantRole(message["role"].asStringOrNull())) return null
     return textFromContent(message["content"])
+  }
+
+  fun isAssistantRole(role: String?): Boolean {
+    val normalized = role?.trim()
+    if (normalized.isNullOrEmpty()) return false
+    return normalized.equals("assistant", ignoreCase = true)
   }
 
   private fun textFromContent(content: JsonElement?): String? =

--- a/apps/android/app/src/main/java/ai/openclaw/app/voice/TalkModeManager.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/voice/TalkModeManager.kt
@@ -1813,7 +1813,7 @@ class TalkModeManager internal constructor(
     val messages = root["messages"] as? JsonArray ?: return null
     for (item in messages.reversed()) {
       val obj = item.asObjectOrNull() ?: continue
-      if (obj["role"].asStringOrNull() != "assistant") continue
+      if (!ChatEventText.isAssistantRole(obj["role"].asStringOrNull())) continue
       if (sinceSeconds != null) {
         val timestamp = obj["timestamp"].asDoubleOrNull()
         if (timestamp != null && !TalkModeRuntime.isMessageTimestampAfter(timestamp, sinceSeconds)) continue

--- a/apps/android/app/src/test/java/ai/openclaw/app/voice/ChatEventTextTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/voice/ChatEventTextTest.kt
@@ -84,7 +84,7 @@ class ChatEventTextTest {
   }
 
   @Test
-  fun ignoresNonCanonicalAssistantRoles() {
+  fun acceptsCaseInsensitiveAssistantRoles() {
     for (role in listOf("ASSISTANT", " assistant ")) {
       val payload =
         payload(
@@ -92,13 +92,13 @@ class ChatEventTextTest {
           {
             "message": {
               "role": "$role",
-              "content": "do not speak"
+              "content": "speak this"
             }
           }
           """,
         )
 
-      assertNull(ChatEventText.assistantTextFromPayload(payload))
+      assertEquals("speak this", ChatEventText.assistantTextFromPayload(payload))
     }
   }
 


### PR DESCRIPTION
## What Problem This Solves

Android voice text extraction rejected assistant chat events when the gateway sent a non-lowercase or padded `role` value (for example `ASSISTANT` or `" assistant "`). Shared kit chat UI accepts those roles case-insensitively after trimming, so Talk mode could stay silent while the chat UI showed the reply.

## Why This Change Was Made

Align Android Talk-mode role handling with `OpenClawChatEventText`: trim whitespace and compare `assistant` case-insensitively. The same helper is now used by the direct chat-event path and the `chat.history` fallback path, so mixed-case/padded assistant roles behave consistently across both voice extraction paths.

Voice intentionally stays fail-closed on missing/empty roles; this change only fixes canonical assistant roles that differ by case or surrounding whitespace.

## User Impact

Talk/voice playback now speaks assistant replies when the gateway emits mixed-case or padded assistant roles, matching shared chat UI behavior. User-role and missing-role events remain ignored for voice.

## Evidence

Shared kit parity source:

- `apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatEventText.swift` trims role text and compares `assistant` case-insensitively.

Local checks:

- `git diff --check origin/main...HEAD`

Earlier Android CI on this PR passed the relevant lanes before the latest fallback normalization commit:

- `preflight`
- `android-test-play`
- `android-test-third-party`
- `android-build-play`
- `Real behavior proof`
- `security-fast`

### Live proof (local Android emulator)

Environment: Windows, Android Studio JBR, AVD `Medium_Phone` (API 17), `emulator-5554`.

Unit (PR branch):

```text
./gradlew :app:testPlayDebugUnitTest --tests ai.openclaw.app.voice.ChatEventTextTest
→ BUILD SUCCESSFUL
```

Device (debug APK + local debug `chatRole` injector, not part of PR diff): injected terminal `chat` events into TalkMode.

| Injected role | Extracted `assistantText` | Result |
|---|---|---|
| `ASSISTANT` | `OpenClaw live proof uppercase` | PASS |
| `" assistant "` | `OpenClaw live proof padded` | PASS |

Redacted logcat: `TalkMode: gateway event: chat`; `VoiceE2E PASS` for both roles with expected `assistantText`. TTS playback skipped without gateway (`not connected`); proof target is role normalization + extraction.

Repro: `scripts/repro/android-chat-role-live-proof.ps1` (local). Details: https://github.com/openclaw/openclaw/pull/99871#issuecomment-4886525872

Changed files:

- `apps/android/app/src/main/java/ai/openclaw/app/voice/ChatEventText.kt`
- `apps/android/app/src/main/java/ai/openclaw/app/voice/TalkModeManager.kt`
- `apps/android/app/src/test/java/ai/openclaw/app/voice/ChatEventTextTest.kt`
