### PR TITLE
fix(android): accept boolean flag aliases in node invoke params

### DIFF
--- a/apps/android/app/src/main/java/ai/openclaw/app/node/CameraHandler.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/node/CameraHandler.kt
@@ -8,11 +8,9 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.withContext
-import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonPrimitive
 import kotlinx.serialization.json.buildJsonArray
 import kotlinx.serialization.json.buildJsonObject
-import kotlinx.serialization.json.contentOrNull
 import kotlinx.serialization.json.put
 
 internal const val CAMERA_CLIP_MAX_RAW_BYTES: Long = 18L * 1024L * 1024L
@@ -178,23 +176,6 @@ class CameraHandler(
     }
   }
 
-  private fun parseIncludeAudio(paramsJson: String?): Boolean? {
-    if (paramsJson.isNullOrBlank()) return null
-    val root =
-      try {
-        Json.parseToJsonElement(paramsJson).asObjectOrNull()
-      } catch (_: Throwable) {
-        null
-      } ?: return null
-    val value =
-      (root["includeAudio"] as? JsonPrimitive)
-        ?.contentOrNull
-        ?.trim()
-        ?.lowercase()
-    return when (value) {
-      "true" -> true
-      "false" -> false
-      else -> null
-    }
-  }
+  private fun parseIncludeAudio(paramsJson: String?): Boolean? =
+    parseJsonBooleanFlag(parseJsonParamsObject(paramsJson), "includeAudio")
 }

--- a/apps/android/app/src/main/java/ai/openclaw/app/node/NodeUtils.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/node/NodeUtils.kt
@@ -66,15 +66,15 @@ fun parseJsonString(
   key: String,
 ): String? = readJsonPrimitive(params, key)?.contentOrNull
 
-/** Parses strict true/false flags from string-like JSON primitives. */
+/** Parses true/false flags from JSON primitives, including common string aliases. */
 fun parseJsonBooleanFlag(
   params: JsonObject?,
   key: String,
 ): Boolean? {
   val value = readJsonPrimitive(params, key)?.contentOrNull?.trim()?.lowercase() ?: return null
   return when (value) {
-    "true" -> true
-    "false" -> false
+    "true", "yes", "1" -> true
+    "false", "no", "0" -> false
     else -> null
   }
 }

--- a/apps/android/app/src/test/java/ai/openclaw/app/node/NodeUtilsTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/node/NodeUtilsTest.kt
@@ -47,4 +47,18 @@ class NodeUtilsTest {
     assertNull(parseJsonBooleanFlag(params, "enabled"))
     assertNull(parseJsonBooleanFlag(params, "missing"))
   }
+
+  @Test
+  fun parseJsonBooleanFlag_parsesIncludeAudioAliasesForCameraClip() {
+    val cases =
+      linkedMapOf(
+        """{"includeAudio":"no"}""" to false,
+        """{"includeAudio":"0"}""" to false,
+        """{"includeAudio":"yes"}""" to true,
+      )
+    for ((source, expected) in cases) {
+      val params = json.parseToJsonElement(source) as JsonObject
+      assertEquals(source, expected, parseJsonBooleanFlag(params, "includeAudio"))
+    }
+  }
 }

--- a/apps/android/app/src/test/java/ai/openclaw/app/node/NodeUtilsTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/node/NodeUtilsTest.kt
@@ -1,0 +1,50 @@
+package ai.openclaw.app.node
+
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.put
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class NodeUtilsTest {
+  private val json = Json { ignoreUnknownKeys = true }
+
+  @Test
+  fun parseJsonBooleanFlag_acceptsCommonStringAliases() {
+    val cases =
+      linkedMapOf(
+        """{"enabled":"true"}""" to true,
+        """{"enabled":"false"}""" to false,
+        """{"enabled":"yes"}""" to true,
+        """{"enabled":"no"}""" to false,
+        """{"enabled":"1"}""" to true,
+        """{"enabled":"0"}""" to false,
+        """{"enabled":" YES "}""" to true,
+      )
+    for ((source, expected) in cases) {
+      val params = json.parseToJsonElement(source) as JsonObject
+      assertEquals(source, expected, parseJsonBooleanFlag(params, "enabled"))
+    }
+  }
+
+  @Test
+  fun parseJsonBooleanFlag_acceptsJsonBooleanLiterals() {
+    val params = buildJsonObject {
+      put("enabled", true)
+      put("disabled", false)
+    }
+
+    assertEquals(true, parseJsonBooleanFlag(params, "enabled"))
+    assertEquals(false, parseJsonBooleanFlag(params, "disabled"))
+  }
+
+  @Test
+  fun parseJsonBooleanFlag_returnsNullForUnknownValues() {
+    val params = json.parseToJsonElement("""{"enabled":"maybe"}""") as JsonObject
+
+    assertNull(parseJsonBooleanFlag(params, "enabled"))
+    assertNull(parseJsonBooleanFlag(params, "missing"))
+  }
+}


### PR DESCRIPTION
## What Problem This Solves

Android node invoke handlers use `parseJsonBooleanFlag` for flags such as `includeSystem`, `includeDisabled`, `includeNonLaunchable`, `includeAudio`, and presence beacon `ok`/`handled`. That helper only accepted `"true"` / `"false"` string literals, while nearby Android voice parsers already accept common dictated/config-style aliases like `yes`/`no`/`1`/`0`.

Agent/tool params using those aliases were silently treated as unset and fell back to defaults.

For `camera.clip`, the mismatch was worse: `CameraCaptureManager` read `includeAudio` through the shared helper, but `CameraHandler.handleClip` kept a duplicate strict parser. An alias such as `includeAudio: "no"` could record without audio while the wrapper still marked external audio capture as active.

## Why This Change Was Made

Extend `parseJsonBooleanFlag` to match the existing Android alias set used by the voice parsing paths, and route `CameraHandler` `includeAudio` through the same helper so both camera paths agree on alias semantics.

Unknown strings such as `"maybe"` still return `null` and fall through to existing caller defaults.

## User Impact

Node invoke commands that pass boolean flags as `yes`, `no`, `1`, or `0` now behave as operators expect—for example device app listing filters and camera `includeAudio`. Strict JSON boolean literals continue to work.

## Evidence

Sibling parser contract checked:

- `apps/android/app/src/main/java/ai/openclaw/app/voice/TalkDirectiveParser.kt` (`asBooleanOrNull` accepts `true`/`false`/`yes`/`no`/`1`/`0`)
- `apps/android/app/src/main/java/ai/openclaw/app/voice/TalkModeManager.kt` (same alias set)

ClawSweeper follow-up addressed:

- `CameraHandler.parseIncludeAudio` now delegates to `parseJsonBooleanFlag(parseJsonParamsObject(...), "includeAudio")`, matching `CameraCaptureManager`.

Local Gradle unit proof on Windows / Android Studio JBR:

```powershell
cd apps/android
$env:JAVA_HOME = "F:\Program Files\Android\Android Studio\jbr"
$env:ANDROID_HOME = "F:\Android\Sdk"
$env:ANDROID_SDK_ROOT = "F:\Android\Sdk"
.\gradlew.bat :app:testPlayDebugUnitTest --tests "ai.openclaw.app.node.NodeUtilsTest"
.\gradlew.bat :app:testThirdPartyDebugUnitTest --tests "ai.openclaw.app.node.NodeUtilsTest"
```

Result: **BUILD SUCCESSFUL** (4 tests).

CI: `android-test-play`, `android-test-third-party`, and `preflight` are green on the latest push.

Changed files:

- `apps/android/app/src/main/java/ai/openclaw/app/node/NodeUtils.kt`
- `apps/android/app/src/main/java/ai/openclaw/app/node/CameraHandler.kt`
- `apps/android/app/src/test/java/ai/openclaw/app/node/NodeUtilsTest.kt`

On-device instrumented proof (Android emulator, real PackageManager path):

Ran `DeviceHandler.handleDeviceApps` on a booted Android emulator via `am instrument`, exercising the real `parseJsonBooleanFlag` -> device `PackageManager` path (no Robolectric). The `device.apps` response echoes the parsed `includeSystem` boolean, so the alias resolution is visible in the response itself:

```text
$ adb shell am instrument -w -e class ai.openclaw.app.node.DeviceAppsBooleanAliasProofTest ai.openclaw.app.test/androidx.test.runner.AndroidJUnitRunner
ai.openclaw.app.node.DeviceAppsBooleanAliasProofTest:..
Time: 0.27
OK (2 tests)
```

```text
I openclaw.proof: alias=yes params={"includeSystem":"yes","limit":200} payload={"count":20,...,"includeSystem":true,...}
I openclaw.proof: alias=no  params={"includeSystem":"no","limit":200}  payload={"count":1,...,"includeSystem":false,...}
I openclaw.proof: alias=1   params={"includeSystem":"1","limit":200}   payload={"count":20,...,"includeSystem":true,...}
I openclaw.proof: alias=0   params={"includeSystem":"0","limit":200}   payload={"count":1,...,"includeSystem":false,...}
I openclaw.proof: RESULT yes(flag=true,count=20) no(flag=false,count=1)
I openclaw.proof: RESULT 1(flag=true) 0(flag=false)
```

Interpretation: `includeSystem: "yes"` / `"1"` resolve to `true` and return all 20 installed apps (19 system + OpenClaw Node); `"no"` / `"0"` resolve to `false` and return only the 1 non-system app. On `main`/v2026.6.11 these aliases are unknown to `parseJsonBooleanFlag`, so `"yes"` would fall back to the default `false` — the `true` result here proves the alias now flows through the real app path after the fix.
