### PR TITLE
fix(amazon-bedrock): enable prompt caching and resolve context window for claude-sonnet-5

### DIFF
--- a/extensions/amazon-bedrock/bedrock-options.ts
+++ b/extensions/amazon-bedrock/bedrock-options.ts
@@ -50,5 +50,8 @@ export function supportsBedrockPromptCaching(modelId: string, modelName?: string
   if (candidates.some((s) => s.includes("claude-3-5-haiku"))) {
     return true;
   }
+  if (candidates.some((s) => s.includes("claude-sonnet-5"))) {
+    return true;
+  }
   return false;
 }

--- a/extensions/amazon-bedrock/discovery.test.ts
+++ b/extensions/amazon-bedrock/discovery.test.ts
@@ -255,6 +255,31 @@ describe("bedrock discovery", () => {
     });
   });
 
+  it("resolves 200K context window for Claude Sonnet 5 foundation model", async () => {
+    sendMock
+      .mockResolvedValueOnce({
+        modelSummaries: [
+          {
+            modelId: "anthropic.claude-sonnet-5",
+            modelName: "Claude Sonnet 5",
+            providerName: "Anthropic",
+            inputModalities: ["TEXT"],
+            outputModalities: ["TEXT"],
+            responseStreamingSupported: true,
+            modelLifecycle: { status: "ACTIVE" },
+          },
+        ],
+      })
+      .mockResolvedValueOnce({ inferenceProfileSummaries: [] });
+
+    const models = await discoverBedrockModels({ region: "us-east-1", clientFactory });
+    expect(models).toHaveLength(1);
+    expectModelFields(models[0], {
+      id: "anthropic.claude-sonnet-5",
+      contextWindow: 200_000,
+    });
+  });
+
   it("uses 1M context window for dotted Claude Opus 4.8 Bedrock refs", async () => {
     sendMock
       .mockResolvedValueOnce({

--- a/extensions/amazon-bedrock/discovery.ts
+++ b/extensions/amazon-bedrock/discovery.ts
@@ -69,6 +69,7 @@ const KNOWN_CONTEXT_WINDOWS: Record<string, number> = {
   "anthropic.claude-sonnet-4-6-v1:0": 1_000_000,
   "anthropic.claude-sonnet-4-5-20250929-v1:0": 200_000,
   "anthropic.claude-sonnet-4-20250514-v1:0": 200_000,
+  "anthropic.claude-sonnet-5": 200_000,
   "anthropic.claude-opus-4-5-20251101-v1:0": 200_000,
   "anthropic.claude-opus-4-1-20250805-v1:0": 200_000,
   "anthropic.claude-haiku-4-5-20251001-v1:0": 200_000,

--- a/extensions/amazon-bedrock/index.test.ts
+++ b/extensions/amazon-bedrock/index.test.ts
@@ -418,6 +418,12 @@ describe("amazon-bedrock provider plugin", () => {
     expect(supportsBedrockPromptCaching("us.anthropic.claude-fable-5")).toBe(true);
   });
 
+  it("recognizes Claude Sonnet 5 refs as prompt-cache eligible", () => {
+    expect(supportsBedrockPromptCaching("global.anthropic.claude-sonnet-5")).toBe(true);
+    expect(supportsBedrockPromptCaching("anthropic.claude-sonnet-5")).toBe(true);
+    expect(supportsBedrockPromptCaching("us.anthropic.claude-sonnet-5")).toBe(true);
+  });
+
   it("owns Anthropic-style replay policy for Claude Bedrock models", async () => {
     const provider = await registerSingleProviderPlugin(amazonBedrockPlugin);
 


### PR DESCRIPTION
**Fixes #99305.**

## Summary
Enables prompt caching support for the Bedrock `global.anthropic.claude-sonnet-5` model, which previously resulted in zero cache hits. Also resolves the correct context window capacity of 200K tokens instead of falling back to the 32K default.

## Changes
- **bedrock-options.ts**: Added `claude-sonnet-5` to prompt caching eligibility list.
- **discovery.ts**: Map `anthropic.claude-sonnet-5` context window to 200,000 tokens.
- **index.test.ts**: Added tests to check `supportsBedrockPromptCaching` returns true for Claude Sonnet 5 variants.
- **discovery.test.ts**: Added test to check context window resolution for Claude Sonnet 5.
