### PR TITLE
fix(slack): preserve time colons in interactive labels

### DIFF
--- a/extensions/slack/src/interactive-replies.test.ts
+++ b/extensions/slack/src/interactive-replies.test.ts
@@ -97,7 +97,7 @@ describe("compileSlackInteractiveReplies", () => {
 
   it("keeps time-style colons in Slack button labels", () => {
     const result = compileSlackInteractiveReplies({
-      text: "[[slack_buttons: Fr 10.07. 9:00:slot_fr_0900, Mo 13.07. 10:45:slot_mo_1045, Today 11:30:ticket:123]]",
+      text: "[[slack_buttons: Fr 10.07. 9:00:slot_fr_0900, Mo 13.07. 10:45:slot_mo_1045, Today 11:30:ticket:123, Mon 14:30-16:00:slot_range]]",
     });
 
     expect(result.interactive).toEqual({
@@ -108,6 +108,7 @@ describe("compileSlackInteractiveReplies", () => {
             { label: "Fr 10.07. 9:00", value: "slot_fr_0900" },
             { label: "Mo 13.07. 10:45", value: "slot_mo_1045" },
             { label: "Today 11:30", value: "ticket:123" },
+            { label: "Mon 14:30-16:00", value: "slot_range" },
           ],
         },
       ],
@@ -134,7 +135,7 @@ describe("compileSlackInteractiveReplies", () => {
 
   it("preserves colon-containing Slack callback values", () => {
     const result = compileSlackInteractiveReplies({
-      text: "[[slack_buttons: Open:ticket:123, Timed:ticket:9:00:id, Allow:pluginbind:approval-123:o, Deny:/approve plugin:approval-123 deny]]",
+      text: "[[slack_buttons: Model v2:01:open, Step 2:30-day:open, Timed:ticket:9:00:id, Today 11:30:12:34:id, Deny:/approve plugin:approval-123 deny]]",
     });
 
     expect(result.interactive).toEqual({
@@ -142,9 +143,10 @@ describe("compileSlackInteractiveReplies", () => {
         {
           type: "buttons",
           buttons: [
-            { label: "Open", value: "ticket:123" },
+            { label: "Model v2", value: "01:open" },
+            { label: "Step 2", value: "30-day:open" },
             { label: "Timed", value: "ticket:9:00:id" },
-            { label: "Allow", value: "pluginbind:approval-123:o" },
+            { label: "Today 11:30", value: "12:34:id" },
             { label: "Deny", value: "/approve plugin:approval-123 deny" },
           ],
         },

--- a/extensions/slack/src/interactive-replies.test.ts
+++ b/extensions/slack/src/interactive-replies.test.ts
@@ -94,4 +94,99 @@ describe("compileSlackInteractiveReplies", () => {
     );
     expect(result.interactive).toBeUndefined();
   });
+
+  it("keeps time-style colons in Slack button labels", () => {
+    const result = compileSlackInteractiveReplies({
+      text: "[[slack_buttons: Fr 10.07. 9:00:slot_fr_0900, Mo 13.07. 10:45:slot_mo_1045, Today 11:30:ticket:123]]",
+    });
+
+    expect(result.interactive).toEqual({
+      blocks: [
+        {
+          type: "buttons",
+          buttons: [
+            { label: "Fr 10.07. 9:00", value: "slot_fr_0900" },
+            { label: "Mo 13.07. 10:45", value: "slot_mo_1045" },
+            { label: "Today 11:30", value: "ticket:123" },
+          ],
+        },
+      ],
+    });
+  });
+
+  it("keeps button style suffixes after time-style labels", () => {
+    const result = compileSlackInteractiveReplies({
+      text: "[[slack_buttons: Fr 10.07. 9:00:slot_fr_0900:primary, Later 10:45:slot_later:danger]]",
+    });
+
+    expect(result.interactive).toEqual({
+      blocks: [
+        {
+          type: "buttons",
+          buttons: [
+            { label: "Fr 10.07. 9:00", value: "slot_fr_0900", style: "primary" },
+            { label: "Later 10:45", value: "slot_later", style: "danger" },
+          ],
+        },
+      ],
+    });
+  });
+
+  it("preserves colon-containing Slack callback values", () => {
+    const result = compileSlackInteractiveReplies({
+      text: "[[slack_buttons: Open:ticket:123, Timed:ticket:9:00:id, Allow:pluginbind:approval-123:o, Deny:/approve plugin:approval-123 deny]]",
+    });
+
+    expect(result.interactive).toEqual({
+      blocks: [
+        {
+          type: "buttons",
+          buttons: [
+            { label: "Open", value: "ticket:123" },
+            { label: "Timed", value: "ticket:9:00:id" },
+            { label: "Allow", value: "pluginbind:approval-123:o" },
+            { label: "Deny", value: "/approve plugin:approval-123 deny" },
+          ],
+        },
+      ],
+    });
+  });
+
+  it("keeps single-colon button entries unchanged when the value matches a style name", () => {
+    const result = compileSlackInteractiveReplies({
+      text: "[[slack_buttons: Primary:primary, Danger:danger, Fr 10.07. 9:00:primary]]",
+    });
+
+    expect(result.interactive).toEqual({
+      blocks: [
+        {
+          type: "buttons",
+          buttons: [
+            { label: "Primary", value: "primary" },
+            { label: "Danger", value: "danger" },
+            { label: "Fr 10.07. 9:00", value: "primary" },
+          ],
+        },
+      ],
+    });
+  });
+
+  it("keeps time-style colons in Slack select option labels", () => {
+    const result = compileSlackInteractiveReplies({
+      text: "[[slack_select: Pick a time | Fr 10.07. 9:00:slot_fr_0900, Mo 13.07. 10:45:slot_mo_1045]]",
+    });
+
+    expect(result.interactive).toEqual({
+      blocks: [
+        {
+          type: "select",
+          placeholder: "Pick a time",
+          options: [
+            { label: "Fr 10.07. 9:00", value: "slot_fr_0900" },
+            { label: "Mo 13.07. 10:45", value: "slot_mo_1045" },
+          ],
+        },
+      ],
+    });
+  });
 });

--- a/extensions/slack/src/interactive-replies.ts
+++ b/extensions/slack/src/interactive-replies.ts
@@ -28,13 +28,21 @@ function resolveChoiceDelimiter(value: string): number {
   }
   const prefix = value.slice(0, firstDelimiter);
   const suffix = value.slice(firstDelimiter + 1);
-  if (/\b\d{1,2}$/.test(prefix) && /^\d{2}:/.test(suffix)) {
-    return firstDelimiter + 3;
+  const startsWithClockLabel = /\b(?:[01]?\d|2[0-3])$/.test(prefix) && /^[0-5]\d/.test(suffix);
+  if (!startsWithClockLabel) {
+    return firstDelimiter;
   }
-  if (/\b\d{1,2}$/.test(prefix) && /^\d{2}$/.test(suffix)) {
-    return -1;
+
+  // Legacy syntax makes label and callback colons ambiguous. Recognize only a
+  // complete clock or dash-separated range followed by the real separator/end.
+  const clockEnd = firstDelimiter + 3;
+  const labelSuffix =
+    value.slice(clockEnd).match(/^(?:\s*[-–—]\s*(?:[01]?\d|2[0-3]):[0-5]\d)*\s*/)?.[0] ?? "";
+  const delimiter = clockEnd + labelSuffix.length;
+  if (value[delimiter] === ":") {
+    return delimiter;
   }
-  return firstDelimiter;
+  return delimiter === value.length ? -1 : firstDelimiter;
 }
 
 function parseChoice(raw: string, options?: { allowStyle?: boolean }): SlackChoice | null {
@@ -42,39 +50,36 @@ function parseChoice(raw: string, options?: { allowStyle?: boolean }): SlackChoi
   if (!trimmed) {
     return null;
   }
-  let working = trimmed;
+  const delimiter = resolveChoiceDelimiter(trimmed);
+  if (delimiter === -1) {
+    return {
+      label: trimmed,
+      value: trimmed,
+    };
+  }
+  const label = trimmed.slice(0, delimiter).trim();
+  let value = trimmed.slice(delimiter + 1).trim();
+  if (!label || !value) {
+    return null;
+  }
   let style: SlackChoice["style"];
   if (options?.allowStyle) {
-    const styleDelimiter = working.lastIndexOf(":");
+    const styleDelimiter = value.lastIndexOf(":");
     if (styleDelimiter !== -1) {
-      const maybeStyle = normalizeLowercaseStringOrEmpty(working.slice(styleDelimiter + 1));
+      const maybeStyle = normalizeLowercaseStringOrEmpty(value.slice(styleDelimiter + 1));
       if (
         maybeStyle === "primary" ||
         maybeStyle === "secondary" ||
         maybeStyle === "success" ||
         maybeStyle === "danger"
       ) {
-        const withoutStyle = working.slice(0, styleDelimiter).trim();
-        const delimiterBeforeStyle = resolveChoiceDelimiter(withoutStyle);
-        if (
-          delimiterBeforeStyle !== -1 &&
-          withoutStyle.slice(0, delimiterBeforeStyle).trim() &&
-          withoutStyle.slice(delimiterBeforeStyle + 1).trim()
-        ) {
-          working = withoutStyle;
+        const unstyledValue = value.slice(0, styleDelimiter).trim();
+        if (unstyledValue) {
+          value = unstyledValue;
           style = maybeStyle;
         }
       }
     }
-  }
-  const delimiter = resolveChoiceDelimiter(working);
-  if (delimiter === -1) {
-    return style ? { label: working, value: working, style } : { label: working, value: working };
-  }
-  const label = working.slice(0, delimiter).trim();
-  const value = working.slice(delimiter + 1).trim();
-  if (!label || !value) {
-    return null;
   }
   return style ? { label, value, style } : { label, value };
 }

--- a/extensions/slack/src/interactive-replies.ts
+++ b/extensions/slack/src/interactive-replies.ts
@@ -21,41 +21,60 @@ type SlackChoice = {
   style?: "primary" | "secondary" | "success" | "danger";
 };
 
+function resolveChoiceDelimiter(value: string): number {
+  const firstDelimiter = value.indexOf(":");
+  if (firstDelimiter === -1) {
+    return -1;
+  }
+  const prefix = value.slice(0, firstDelimiter);
+  const suffix = value.slice(firstDelimiter + 1);
+  if (/\b\d{1,2}$/.test(prefix) && /^\d{2}:/.test(suffix)) {
+    return firstDelimiter + 3;
+  }
+  if (/\b\d{1,2}$/.test(prefix) && /^\d{2}$/.test(suffix)) {
+    return -1;
+  }
+  return firstDelimiter;
+}
+
 function parseChoice(raw: string, options?: { allowStyle?: boolean }): SlackChoice | null {
   const trimmed = raw.trim();
   if (!trimmed) {
     return null;
   }
-  const delimiter = trimmed.indexOf(":");
-  if (delimiter === -1) {
-    return {
-      label: trimmed,
-      value: trimmed,
-    };
-  }
-  const label = trimmed.slice(0, delimiter).trim();
-  let value = trimmed.slice(delimiter + 1).trim();
-  if (!label || !value) {
-    return null;
-  }
+  let working = trimmed;
   let style: SlackChoice["style"];
   if (options?.allowStyle) {
-    const styleDelimiter = value.lastIndexOf(":");
+    const styleDelimiter = working.lastIndexOf(":");
     if (styleDelimiter !== -1) {
-      const maybeStyle = normalizeLowercaseStringOrEmpty(value.slice(styleDelimiter + 1));
+      const maybeStyle = normalizeLowercaseStringOrEmpty(working.slice(styleDelimiter + 1));
       if (
         maybeStyle === "primary" ||
         maybeStyle === "secondary" ||
         maybeStyle === "success" ||
         maybeStyle === "danger"
       ) {
-        const unstyledValue = value.slice(0, styleDelimiter).trim();
-        if (unstyledValue) {
-          value = unstyledValue;
+        const withoutStyle = working.slice(0, styleDelimiter).trim();
+        const delimiterBeforeStyle = resolveChoiceDelimiter(withoutStyle);
+        if (
+          delimiterBeforeStyle !== -1 &&
+          withoutStyle.slice(0, delimiterBeforeStyle).trim() &&
+          withoutStyle.slice(delimiterBeforeStyle + 1).trim()
+        ) {
+          working = withoutStyle;
           style = maybeStyle;
         }
       }
     }
+  }
+  const delimiter = resolveChoiceDelimiter(working);
+  if (delimiter === -1) {
+    return style ? { label: working, value: working, style } : { label: working, value: working };
+  }
+  const label = working.slice(0, delimiter).trim();
+  const value = working.slice(delimiter + 1).trim();
+  if (!label || !value) {
+    return null;
   }
   return style ? { label, value, style } : { label, value };
 }


### PR DESCRIPTION
Closes #99823

## What Problem This Solves

Fixes an issue where Slack users choosing `[[slack_buttons:]]` or `[[slack_select:]]` options with time-like labels such as `9:00` would have the label/value split at the time colon instead of the intended action delimiter.

## Why This Change Was Made

Slack interactive reply parsing now treats `H:MM` and `HH:MM` tokens as part of the label while preserving the existing first-delimiter behavior for callback values that legitimately contain colons. Button style suffixes are still recognized only when a real label/value delimiter exists before the style token.

This PR intentionally keeps the existing single-colon `Label:value` directive contract instead of switching to the alternate last-colon approaches in #99828 / #99836. The last-colon shape fixes time labels but would reinterpret currently valid callback values that contain colons. The H:MM heuristic is narrower: it fixes the reported meeting-slot pattern while preserving values such as `ticket:123` and `/approve plugin:approval-123 deny`.

## User Impact

Slack buttons and selects can show time labels like `Fr 10.07. 9:00` while still sending the intended callback value, including values such as `ticket:123` or `/approve plugin:approval-123 deny`.

## Evidence

- Claim proved: Slack interactive choice parsing preserves time-style label colons without breaking colon-containing callback values or style suffixes.
- Commands / artifacts:
  - Head SHA: 4a0d3b5fbf88e226237734a80bea7125e82f17d2
  - `node scripts/run-vitest.mjs extensions/slack/src/interactive-replies.test.ts --reporter=verbose` passed: 1 file, 9 tests.
  - `node --import tsx --input-type=module` direct runtime proof against `extensions/slack/interactive-replies-api.ts` passed with this input:

    ```js
    import { compileSlackInteractiveReplies } from "./extensions/slack/interactive-replies-api.ts";

    const out = compileSlackInteractiveReplies({
      text: "[[slack_buttons: Fr 10.07. 9:00:slot_fr_0900, Mo 13.07. 10:45:slot_mo_1045, Today 11:30:ticket:123, Deny:/approve plugin:approval-123 deny]]",
    });
    console.log(JSON.stringify(out.interactive?.blocks?.find((block) => block.type === "buttons")?.buttons, null, 2));
    ```

    Observed output:

    ```json
    [
      { "label": "Fr 10.07. 9:00", "value": "slot_fr_0900" },
      { "label": "Mo 13.07. 10:45", "value": "slot_mo_1045" },
      { "label": "Today 11:30", "value": "ticket:123" },
      { "label": "Deny", "value": "/approve plugin:approval-123 deny" }
    ]
    ```

  - `git diff --check upstream/main...HEAD` passed.
  - `python .agents\skills\autoreview\scripts\autoreview --mode local` passed before commit with no accepted/actionable findings.
- Observed result: focused tests cover time labels, select labels, style suffixes, style-named values, and colon-containing Slack callback values; the direct runtime proof exercises the public Slack interactive-replies API entrypoint.
- Not tested / proof gaps: no live Slack workspace transcript and no broad local full lint/typecheck were run locally; GitHub CI is green on the current head.