### PR TITLE
fix(opencode-go): register thinking profile to enable xhigh/max support

### DIFF
--- a/extensions/opencode-go/index.ts
+++ b/extensions/opencode-go/index.ts
@@ -13,6 +13,7 @@ import {
   resolveOpencodeGoModel,
 } from "./provider-catalog.js";
 import { createOpencodeGoWrapper } from "./stream.js";
+import { resolveOpencodeGoDeepSeekV4ThinkingProfile } from "./thinking.js";
 
 const PROVIDER_ID = "opencode-go";
 const OPENCODE_SHARED_PROFILE_IDS = ["opencode:default", "opencode-go:default"] as const;
@@ -137,6 +138,8 @@ export default definePluginEntry({
       augmentModelCatalog: () => listOpencodeGoModelCatalogEntries(),
       ...PASSTHROUGH_GEMINI_REPLAY_HOOKS,
       wrapStreamFn: (ctx) => createOpencodeGoWrapper(ctx.streamFn, ctx.thinkingLevel),
+      resolveThinkingProfile: ({ modelId }) =>
+        resolveOpencodeGoDeepSeekV4ThinkingProfile(modelId),
       isModernModelRef: () => true,
     });
     api.registerMediaUnderstandingProvider(opencodeGoMediaUnderstandingProvider);

--- a/extensions/opencode-go/thinking.ts
+++ b/extensions/opencode-go/thinking.ts
@@ -1,0 +1,25 @@
+import type { ProviderThinkingProfile } from "openclaw/plugin-sdk/plugin-entry";
+
+const V4_THINKING_LEVEL_IDS = ["off", "minimal", "low", "medium", "high", "xhigh", "max"] as const;
+
+function buildV4ThinkingLevel(id: (typeof V4_THINKING_LEVEL_IDS)[number]) {
+  return { id };
+}
+
+const OPENCODE_GO_DEEPSEEK_V4_THINKING_PROFILE = {
+  levels: V4_THINKING_LEVEL_IDS.map(buildV4ThinkingLevel),
+  defaultLevel: "high",
+} satisfies ProviderThinkingProfile;
+
+function isOpencodeGoDeepSeekV4ModelId(modelId: string): boolean {
+  const id = modelId.trim().toLowerCase();
+  return id === "deepseek-v4-pro" || id === "deepseek-v4-flash";
+}
+
+export function resolveOpencodeGoDeepSeekV4ThinkingProfile(
+  modelId: string,
+): ProviderThinkingProfile | undefined {
+  return isOpencodeGoDeepSeekV4ModelId(modelId)
+    ? OPENCODE_GO_DEEPSEEK_V4_THINKING_PROFILE
+    : undefined;
+}


### PR DESCRIPTION
## Summary

Fixes: #99617

### Problem

Opencode-go DeepSeek V4 models (`deepseek-v4-pro`, `deepseek-v4-flash`) have `supportsReasoningEffort: true` but lack a `resolveThinkingProfile` hook. Without one, the gateway falls back to the base thinking profile (off~high), so `xhigh` and `max` never appear in the UI even though the stream wrapper (`createDeepSeekV4OpenAICompatibleThinkingWrapper`) already handles them correctly on the wire.

PR #99618 attempted to fix this by adding `thinkingLevelMap` to the model entries, but that approach has two problems:

1. `thinkingLevelMap` only affects the stream wrapper — it does **not** influence `resolveThinkingProfile()`, so the UI/gateway still filters out xhigh/max.
2. It mapped `high → "max"`, silently changing existing `/think high` behavior from `reasoning_effort: "high"` to `"max"`, which affects cost and latency.

### Changes

- **`extensions/opencode-go/thinking.ts`** (new) — Define a thinking profile identical to the deepseek extensions pattern, exposing the full level range: `off, minimal, low, medium, high, xhigh, max` with `defaultLevel: "high"`.
- **`extensions/opencode-go/index.ts`** (+3 lines) — Register `resolveThinkingProfile` hook pointing at the new profile.
- **`stream.ts` / `provider-catalog.ts`** — Unchanged. The shared `createDeepSeekV4OpenAICompatibleThinkingWrapper` already maps thinking levels to reasoning_effort correctly.

### Real API Verification

All three tests conducted against `https://opencode.ai/zen/go/v1` with `deepseek-v4-pro`:

**Test 1: reasoning_effort: "max"**
```bash
curl -s -X POST https://opencode.ai/zen/go/v1/chat/completions \
  -H "Authorization: Bearer $OPENCODE_API_KEY" \
  -H "Content-Type: application/json" \
  -d '{"model":"deepseek-v4-pro","messages":[{"role":"user","content":"请用中文思考 1+1=？给出推理过程"}],"reasoning_effort":"max","max_tokens":500}'
```
Result: HTTP 200 ✅ — Response contains `reasoning_content` (134 reasoning tokens), full chain-of-thought reasoning in Chinese.

**Test 2: reasoning_effort: "high"**
```bash
curl -s -X POST https://opencode.ai/zen/go/v1/chat/completions \
  -H "Authorization: Bearer $OPENCODE_API_KEY" \
  -H "Content-Type: application/json" \
  -d '{"model":"deepseek-v4-pro","messages":[{"role":"user","content":"请用中文回答 2+2=？"}],"reasoning_effort":"high","max_tokens":500}'
```
Result: HTTP 200 ✅ — Contains `reasoning_content` (119 reasoning tokens), shorter than "max" as expected.

**Test 3: thinking disabled**
```bash
curl -s -X POST https://opencode.ai/zen/go/v1/chat/completions \
  -H "Authorization: Bearer $OPENCODE_API_KEY" \
  -H "Content-Type: application/json" \
  -d '{"model":"deepseek-v4-pro","messages":[{"role":"user","content":"请用中文回答 3+3=？"}],"thinking":{"type":"disabled"},"max_tokens":500}'
```
Result: HTTP 200 ✅ — No `reasoning_content`, direct 6-token answer, reasoning fully disabled.

### Verification

- TypeScript type check: `npx tsc -p extensions/opencode-go/tsconfig.json --noEmit`
- Backward compatible: non-DeepSeek-V4 models unaffected; models without thinking profile continue using base profile
