### PR TITLE
fix(web-shared): bound response.text() fallback to honor maxBytes

### DIFF
--- a/src/agents/tools/web-fetch.cf-markdown.test.ts
+++ b/src/agents/tools/web-fetch.cf-markdown.test.ts
@@ -6,7 +6,7 @@ import * as logger from "../../logger.js";
 import { withFetchPreconnect } from "../../test-utils/fetch-mock.js";
 import "./web-fetch.test-mocks.js";
 import { createWebFetchTool } from "./web-fetch.js";
-import { createBaseWebFetchToolConfig, makeFetchHeaders } from "./web-fetch.test-harness.js";
+import { createBaseWebFetchToolConfig } from "./web-fetch.test-harness.js";
 
 const lookupMock = vi.fn();
 const baseToolConfig = createBaseWebFetchToolConfig({
@@ -14,24 +14,20 @@ const baseToolConfig = createBaseWebFetchToolConfig({
 });
 
 function markdownResponse(body: string, extraHeaders: Record<string, string> = {}): Response {
-  return {
-    ok: true,
+  return new Response(body, {
     status: 200,
-    headers: makeFetchHeaders({
+    headers: {
       "content-type": "text/markdown; charset=utf-8",
       ...extraHeaders,
-    }),
-    text: async () => body,
-  } as Response;
+    },
+  });
 }
 
 function htmlResponse(body: string): Response {
-  return {
-    ok: true,
+  return new Response(body, {
     status: 200,
-    headers: makeFetchHeaders({ "content-type": "text/html; charset=utf-8" }),
-    text: async () => body,
-  } as Response;
+    headers: { "content-type": "text/html; charset=utf-8" },
+  });
 }
 
 describe("web_fetch Cloudflare Markdown for Agents", () => {

--- a/src/agents/tools/web-shared.test.ts
+++ b/src/agents/tools/web-shared.test.ts
@@ -147,12 +147,15 @@ describe("readResponseText", () => {
     expect(releaseLock).toHaveBeenCalledTimes(1);
   });
 
-  it("refuses to call unbounded .text() when maxBytes is set", async () => {
-    // Foreign Response without a body stream or arrayBuffer — the only way
-    // to read is .text() which buffers the full body before any check.
-    // When maxBytes is set the caller expects bounded memory, so we must
-    // fail-closed rather than call .text() unbounded.
-    const longText = "x".repeat(10_000);
+  it("truncates text-only fallback at byte boundaries when maxBytes is set", async () => {
+    // Foreign Response without a body stream or arrayBuffer — only .text()
+    // is available.  Truncation must be byte-accurate so multi-byte UTF-8
+    // content is not corrupted (naive text.slice would cut mid-codepoint).
+    const prefix = "x".repeat(50) + "中文";
+    const longText = prefix + "🔥" + "y".repeat(50);
+    const fullBytes = new TextEncoder().encode(longText);
+    const CAP = new TextEncoder().encode(prefix).byteLength; // clean codepoint boundary
+    expect(fullBytes.byteLength).toBeGreaterThan(CAP);
     const response = {
       body: null as unknown,
       headers: new Headers(),
@@ -161,13 +164,15 @@ describe("readResponseText", () => {
       },
     } as unknown as Response;
 
-    // With maxBytes → rejected (no bounded byte source available)
-    const capped = await readResponseText(response, { maxBytes: 100 });
+    // With maxBytes → byte-level truncation
+    const capped = await readResponseText(response, { maxBytes: CAP });
     expect(capped.truncated).toBe(true);
-    expect(capped.bytesRead).toBe(0);
-    expect(capped.text).toBe("");
+    expect(capped.bytesRead).toBe(CAP);
+    const expected = new TextDecoder().decode(fullBytes.slice(0, CAP));
+    expect(capped.text).toBe(expected);
+    expect(capped.text).not.toContain("�");
 
-    // Without maxBytes → .text() is safe (caller accepts full allocation)
+    // Without maxBytes → passes through (regression)
     const noCapResponse = {
       body: null as unknown,
       headers: new Headers(),
@@ -178,6 +183,6 @@ describe("readResponseText", () => {
     const full = await readResponseText(noCapResponse);
     expect(full.text).toBe(longText);
     expect(full.truncated).toBe(false);
-    expect(full.bytesRead).toBe(new TextEncoder().encode(longText).byteLength);
+    expect(full.bytesRead).toBe(fullBytes.byteLength);
   });
 });

--- a/src/agents/tools/web-shared.test.ts
+++ b/src/agents/tools/web-shared.test.ts
@@ -146,4 +146,35 @@ describe("readResponseText", () => {
     expect(cancel).toHaveBeenCalledTimes(1);
     expect(releaseLock).toHaveBeenCalledTimes(1);
   });
+
+  it("truncates text-only fallback responses when maxBytes is set", async () => {
+    // Foreign Response without a body stream (no getReader) — the .text()
+    // fallback path must still honor maxBytes.
+    const longText = "y".repeat(10_000);
+    const response = {
+      body: null as unknown,
+      headers: new Headers(),
+      async text() {
+        return longText;
+      },
+    } as unknown as Response;
+
+    // With maxBytes → truncated
+    const capped = await readResponseText(response, { maxBytes: 100 });
+    expect(capped.text).toBe("y".repeat(100));
+    expect(capped.truncated).toBe(true);
+    expect(capped.bytesRead).toBe(100);
+
+    // Without maxBytes → passes through (regression)
+    const noCapResponse = {
+      body: null as unknown,
+      headers: new Headers(),
+      async text() {
+        return longText;
+      },
+    } as unknown as Response;
+    const full = await readResponseText(noCapResponse);
+    expect(full.text).toBe(longText);
+    expect(full.truncated).toBe(false);
+  });
 });

--- a/src/agents/tools/web-shared.test.ts
+++ b/src/agents/tools/web-shared.test.ts
@@ -147,10 +147,15 @@ describe("readResponseText", () => {
     expect(releaseLock).toHaveBeenCalledTimes(1);
   });
 
-  it("truncates text-only fallback responses when maxBytes is set", async () => {
+  it("truncates text-only fallback responses at byte boundaries when maxBytes is set", async () => {
     // Foreign Response without a body stream (no getReader) — the .text()
-    // fallback path must still honor maxBytes.
-    const longText = "y".repeat(10_000);
+    // fallback path must still honor maxBytes at byte-level granularity.
+    // Use multi-byte UTF-8: "中" = 3 bytes, "🔥" = 4 bytes.
+    // 50 x's (50 bytes) + "中文" (6 bytes) + "🔥" (4 bytes) + 50 y's (50 bytes)
+    const longText = "x".repeat(50) + "中文🔥" + "y".repeat(50);
+    const bytes = new TextEncoder().encode(longText);
+    const CAP = 53; // lands at clean boundary after 50 x's + "中" (3 bytes)
+    expect(bytes.byteLength).toBeGreaterThan(CAP);
     const response = {
       body: null as unknown,
       headers: new Headers(),
@@ -159,11 +164,15 @@ describe("readResponseText", () => {
       },
     } as unknown as Response;
 
-    // With maxBytes → truncated
-    const capped = await readResponseText(response, { maxBytes: 100 });
-    expect(capped.text).toBe("y".repeat(100));
+    // With maxBytes → byte-truncated
+    const capped = await readResponseText(response, { maxBytes: CAP });
     expect(capped.truncated).toBe(true);
-    expect(capped.bytesRead).toBe(100);
+    expect(capped.bytesRead).toBe(CAP);
+    // Verify truncation is byte-accurate: decode the expected prefix
+    const expected = new TextDecoder().decode(bytes.slice(0, CAP));
+    expect(capped.text).toBe(expected);
+    // Verify truncation preserves valid UTF-8 (no replacement characters)
+    expect(capped.text).not.toContain("�");
 
     // Without maxBytes → passes through (regression)
     const noCapResponse = {
@@ -176,5 +185,6 @@ describe("readResponseText", () => {
     const full = await readResponseText(noCapResponse);
     expect(full.text).toBe(longText);
     expect(full.truncated).toBe(false);
+    expect(full.bytesRead).toBe(bytes.byteLength);
   });
 });

--- a/src/agents/tools/web-shared.test.ts
+++ b/src/agents/tools/web-shared.test.ts
@@ -147,42 +147,47 @@ describe("readResponseText", () => {
     expect(releaseLock).toHaveBeenCalledTimes(1);
   });
 
-  it("truncates text-only fallback at byte boundaries when maxBytes is set", async () => {
-    // Foreign Response without a body stream or arrayBuffer — only .text()
-    // is available.  Truncation must be byte-accurate so multi-byte UTF-8
-    // content is not corrupted (naive text.slice would cut mid-codepoint).
-    const prefix = "x".repeat(50) + "中文";
-    const longText = prefix + "🔥" + "y".repeat(50);
-    const fullBytes = new TextEncoder().encode(longText);
-    const CAP = new TextEncoder().encode(prefix).byteLength; // clean codepoint boundary
-    expect(fullBytes.byteLength).toBeGreaterThan(CAP);
+  it("does not invoke whole-body fallbacks when maxBytes is set", async () => {
+    const arrayBuffer = vi.fn(async () => new TextEncoder().encode("hello").buffer);
+    const text = vi.fn(async () => "hello");
     const response = {
-      body: null as unknown,
+      arrayBuffer,
       headers: new Headers(),
-      async text() {
-        return longText;
-      },
+      text,
     } as unknown as Response;
 
-    // With maxBytes → byte-level truncation
-    const capped = await readResponseText(response, { maxBytes: CAP });
-    expect(capped.truncated).toBe(true);
-    expect(capped.bytesRead).toBe(CAP);
-    const expected = new TextDecoder().decode(fullBytes.slice(0, CAP));
-    expect(capped.text).toBe(expected);
-    expect(capped.text).not.toContain("�");
+    await expect(readResponseText(response, { maxBytes: 4 })).resolves.toEqual({
+      text: "",
+      truncated: true,
+      bytesRead: 0,
+    });
+    expect(arrayBuffer).not.toHaveBeenCalled();
+    expect(text).not.toHaveBeenCalled();
+  });
 
-    // Without maxBytes → passes through (regression)
-    const noCapResponse = {
-      body: null as unknown,
+  it("treats a native bodyless response as empty when maxBytes is set", async () => {
+    await expect(
+      readResponseText(new Response(null, { status: 204 }), { maxBytes: 4 }),
+    ).resolves.toEqual({
+      text: "",
+      truncated: false,
+      bytesRead: 0,
+    });
+  });
+
+  it("preserves uncapped text-only fallback byte accounting", async () => {
+    const value = "中文🔥";
+    const text = vi.fn(async () => value);
+    const response = {
       headers: new Headers(),
-      async text() {
-        return longText;
-      },
+      text,
     } as unknown as Response;
-    const full = await readResponseText(noCapResponse);
-    expect(full.text).toBe(longText);
-    expect(full.truncated).toBe(false);
-    expect(full.bytesRead).toBe(fullBytes.byteLength);
+
+    await expect(readResponseText(response)).resolves.toEqual({
+      text: value,
+      truncated: false,
+      bytesRead: new TextEncoder().encode(value).byteLength,
+    });
+    expect(text).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/agents/tools/web-shared.test.ts
+++ b/src/agents/tools/web-shared.test.ts
@@ -147,15 +147,12 @@ describe("readResponseText", () => {
     expect(releaseLock).toHaveBeenCalledTimes(1);
   });
 
-  it("truncates text-only fallback responses at byte boundaries when maxBytes is set", async () => {
-    // Foreign Response without a body stream (no getReader) — the .text()
-    // fallback path must still honor maxBytes at byte-level granularity.
-    // Use multi-byte UTF-8: "中" = 3 bytes, "🔥" = 4 bytes.
-    // 50 x's (50 bytes) + "中文" (6 bytes) + "🔥" (4 bytes) + 50 y's (50 bytes)
-    const longText = "x".repeat(50) + "中文🔥" + "y".repeat(50);
-    const bytes = new TextEncoder().encode(longText);
-    const CAP = 53; // lands at clean boundary after 50 x's + "中" (3 bytes)
-    expect(bytes.byteLength).toBeGreaterThan(CAP);
+  it("refuses to call unbounded .text() when maxBytes is set", async () => {
+    // Foreign Response without a body stream or arrayBuffer — the only way
+    // to read is .text() which buffers the full body before any check.
+    // When maxBytes is set the caller expects bounded memory, so we must
+    // fail-closed rather than call .text() unbounded.
+    const longText = "x".repeat(10_000);
     const response = {
       body: null as unknown,
       headers: new Headers(),
@@ -164,17 +161,13 @@ describe("readResponseText", () => {
       },
     } as unknown as Response;
 
-    // With maxBytes → byte-truncated
-    const capped = await readResponseText(response, { maxBytes: CAP });
+    // With maxBytes → rejected (no bounded byte source available)
+    const capped = await readResponseText(response, { maxBytes: 100 });
     expect(capped.truncated).toBe(true);
-    expect(capped.bytesRead).toBe(CAP);
-    // Verify truncation is byte-accurate: decode the expected prefix
-    const expected = new TextDecoder().decode(bytes.slice(0, CAP));
-    expect(capped.text).toBe(expected);
-    // Verify truncation preserves valid UTF-8 (no replacement characters)
-    expect(capped.text).not.toContain("�");
+    expect(capped.bytesRead).toBe(0);
+    expect(capped.text).toBe("");
 
-    // Without maxBytes → passes through (regression)
+    // Without maxBytes → .text() is safe (caller accepts full allocation)
     const noCapResponse = {
       body: null as unknown,
       headers: new Headers(),
@@ -185,6 +178,6 @@ describe("readResponseText", () => {
     const full = await readResponseText(noCapResponse);
     expect(full.text).toBe(longText);
     expect(full.truncated).toBe(false);
-    expect(full.bytesRead).toBe(bytes.byteLength);
+    expect(full.bytesRead).toBe(new TextEncoder().encode(longText).byteLength);
   });
 });

--- a/src/agents/tools/web-shared.ts
+++ b/src/agents/tools/web-shared.ts
@@ -313,6 +313,9 @@ export async function readResponseText(
 
   try {
     const text = await res.text();
+    if (maxBytes !== undefined && text.length > maxBytes) {
+      return { text: text.slice(0, maxBytes), truncated: true, bytesRead: maxBytes };
+    }
     return { text, truncated: false, bytesRead: text.length };
   } catch {
     return { text: "", truncated: false, bytesRead: 0 };

--- a/src/agents/tools/web-shared.ts
+++ b/src/agents/tools/web-shared.ts
@@ -313,10 +313,12 @@ export async function readResponseText(
 
   try {
     const text = await res.text();
-    if (maxBytes !== undefined && text.length > maxBytes) {
-      return { text: text.slice(0, maxBytes), truncated: true, bytesRead: maxBytes };
+    const bytes = new TextEncoder().encode(text);
+    if (maxBytes !== undefined && bytes.byteLength > maxBytes) {
+      const truncated = new TextDecoder().decode(bytes.slice(0, maxBytes));
+      return { text: truncated, truncated: true, bytesRead: maxBytes };
     }
-    return { text, truncated: false, bytesRead: text.length };
+    return { text, truncated: false, bytesRead: bytes.byteLength };
   } catch {
     return { text: "", truncated: false, bytesRead: 0 };
   }

--- a/src/agents/tools/web-shared.ts
+++ b/src/agents/tools/web-shared.ts
@@ -297,6 +297,15 @@ export async function readResponseText(
     return { text: decodeResponseBytes(res, bytes), truncated, bytesRead };
   }
 
+  if (maxBytes) {
+    if (res instanceof Response && res.body === null) {
+      return { text: "", truncated: false, bytesRead: 0 };
+    }
+    // Whole-body fallbacks allocate before returning, so they cannot honor a byte cap.
+    // Fail closed instead of making maxBytes a returned-text limit only.
+    return { text: "", truncated: true, bytesRead: 0 };
+  }
+
   const readBytes = (res as { arrayBuffer?: () => Promise<ArrayBuffer> }).arrayBuffer;
   if (typeof readBytes === "function") {
     try {
@@ -314,10 +323,6 @@ export async function readResponseText(
   try {
     const text = await res.text();
     const bytes = new TextEncoder().encode(text);
-    if (maxBytes !== undefined && bytes.byteLength > maxBytes) {
-      const truncated = new TextDecoder().decode(bytes.slice(0, maxBytes));
-      return { text: truncated, truncated: true, bytesRead: maxBytes };
-    }
     return { text, truncated: false, bytesRead: bytes.byteLength };
   } catch {
     return { text: "", truncated: false, bytesRead: 0 };

--- a/src/agents/tools/web-shared.ts
+++ b/src/agents/tools/web-shared.ts
@@ -311,16 +311,14 @@ export async function readResponseText(
     }
   }
 
-  // Only arrive here when the response has neither a readable body stream
-  // nor an arrayBuffer() method.  When maxBytes is set the caller expects
-  // bounded memory — calling .text() would buffer the full body unbounded
-  // before the post-read check, defeating the cap.
-  if (maxBytes !== undefined) {
-    return { text: "", truncated: true, bytesRead: 0 };
-  }
   try {
     const text = await res.text();
-    return { text, truncated: false, bytesRead: new TextEncoder().encode(text).byteLength };
+    const bytes = new TextEncoder().encode(text);
+    if (maxBytes !== undefined && bytes.byteLength > maxBytes) {
+      const truncated = new TextDecoder().decode(bytes.slice(0, maxBytes));
+      return { text: truncated, truncated: true, bytesRead: maxBytes };
+    }
+    return { text, truncated: false, bytesRead: bytes.byteLength };
   } catch {
     return { text: "", truncated: false, bytesRead: 0 };
   }

--- a/src/agents/tools/web-shared.ts
+++ b/src/agents/tools/web-shared.ts
@@ -311,14 +311,16 @@ export async function readResponseText(
     }
   }
 
+  // Only arrive here when the response has neither a readable body stream
+  // nor an arrayBuffer() method.  When maxBytes is set the caller expects
+  // bounded memory — calling .text() would buffer the full body unbounded
+  // before the post-read check, defeating the cap.
+  if (maxBytes !== undefined) {
+    return { text: "", truncated: true, bytesRead: 0 };
+  }
   try {
     const text = await res.text();
-    const bytes = new TextEncoder().encode(text);
-    if (maxBytes !== undefined && bytes.byteLength > maxBytes) {
-      const truncated = new TextDecoder().decode(bytes.slice(0, maxBytes));
-      return { text: truncated, truncated: true, bytesRead: maxBytes };
-    }
-    return { text, truncated: false, bytesRead: bytes.byteLength };
+    return { text, truncated: false, bytesRead: new TextEncoder().encode(text).byteLength };
   } catch {
     return { text: "", truncated: false, bytesRead: 0 };
   }

--- a/src/agents/tools/web-tools.fetch.test.ts
+++ b/src/agents/tools/web-tools.fetch.test.ts
@@ -6,7 +6,6 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { LookupFn } from "../../infra/net/ssrf.js";
 import { resolveRequestUrl } from "../../plugin-sdk/request-url.js";
 import { withFetchPreconnect } from "../../test-utils/fetch-mock.js";
-import { makeFetchHeaders } from "./web-fetch.test-harness.js";
 const { extractReadableContentMock, resolveWebFetchDefinitionMock } = vi.hoisted(() => ({
   extractReadableContentMock: vi.fn(),
   resolveWebFetchDefinitionMock: vi.fn(),
@@ -29,37 +28,36 @@ import { WEB_FETCH_SPILL_MAX_CHARS } from "./web-fetch.js";
 
 const lookupMock = vi.fn();
 
-type MockResponse = {
-  ok: boolean;
-  status: number;
-  url?: string;
-  headers?: { get: (key: string) => string | null };
-  text?: () => Promise<string>;
-  json?: () => Promise<unknown>;
-};
+function responseWithUrl(body: BodyInit, init: ResponseInit, url: string): Response {
+  const response = new Response(body, init);
+  Object.defineProperty(response, "url", { value: url });
+  return response;
+}
 
-function htmlResponse(html: string, url = "https://example.com/"): MockResponse {
-  return {
-    ok: true,
-    status: 200,
+function htmlResponse(html: string, url = "https://example.com/"): Response {
+  return responseWithUrl(
+    html,
+    {
+      status: 200,
+      headers: { "content-type": "text/html; charset=utf-8" },
+    },
     url,
-    headers: makeFetchHeaders({ "content-type": "text/html; charset=utf-8" }),
-    text: async () => html,
-  };
+  );
 }
 
 function textResponse(
   text: string,
   url = "https://example.com/",
   contentType = "text/plain; charset=utf-8",
-): MockResponse {
-  return {
-    ok: true,
-    status: 200,
+): Response {
+  return responseWithUrl(
+    text,
+    {
+      status: 200,
+      headers: { "content-type": contentType },
+    },
     url,
-    headers: makeFetchHeaders({ "content-type": contentType }),
-    text: async () => text,
-  };
+  );
 }
 
 function errorHtmlResponse(
@@ -67,14 +65,16 @@ function errorHtmlResponse(
   status = 404,
   url = "https://example.com/",
   contentType: string | null = "text/html; charset=utf-8",
-): MockResponse {
-  return {
-    ok: false,
-    status,
+): Response {
+  const body = contentType ? html : new TextEncoder().encode(html);
+  return responseWithUrl(
+    body,
+    {
+      status,
+      headers: contentType ? { "content-type": contentType } : undefined,
+    },
     url,
-    headers: contentType ? makeFetchHeaders({ "content-type": contentType }) : makeFetchHeaders({}),
-    text: async () => html,
-  };
+  );
 }
 function installMockFetch(
   impl: (input: RequestInfo | URL, init?: RequestInit) => Promise<Response>,
@@ -111,13 +111,7 @@ function createFetchTool(fetchOverrides: Record<string, unknown> = {}) {
 
 function installPlainTextFetch(text: string) {
   installMockFetch((input: RequestInfo | URL) =>
-    Promise.resolve({
-      ok: true,
-      status: 200,
-      headers: makeFetchHeaders({ "content-type": "text/plain" }),
-      text: async () => text,
-      url: resolveRequestUrl(input),
-    } as Response),
+    Promise.resolve(textResponse(text, resolveRequestUrl(input))),
   );
 }
 
@@ -415,13 +409,7 @@ describe("web_fetch extraction fallbacks", () => {
   it("enforces maxChars after wrapping", async () => {
     const longText = "x".repeat(5_000);
     installMockFetch((input: RequestInfo | URL) =>
-      Promise.resolve({
-        ok: true,
-        status: 200,
-        headers: makeFetchHeaders({ "content-type": "text/plain" }),
-        text: async () => longText,
-        url: resolveRequestUrl(input),
-      } as Response),
+      Promise.resolve(textResponse(longText, resolveRequestUrl(input))),
     );
 
     const tool = createFetchTool({
@@ -655,13 +643,7 @@ describe("web_fetch extraction fallbacks", () => {
   it("keeps DNS pinning for web_fetch by default even when HTTP_PROXY is configured", async () => {
     vi.stubEnv("HTTP_PROXY", "http://127.0.0.1:7890");
     const mockFetch = installMockFetch((input: RequestInfo | URL) =>
-      Promise.resolve({
-        ok: true,
-        status: 200,
-        headers: makeFetchHeaders({ "content-type": "text/plain" }),
-        text: async () => "proxy body",
-        url: resolveRequestUrl(input),
-      } as Response),
+      Promise.resolve(textResponse("proxy body", resolveRequestUrl(input))),
     );
     const tool = createFetchTool({ firecrawl: { enabled: false } });
 
@@ -678,13 +660,7 @@ describe("web_fetch extraction fallbacks", () => {
   it("uses env proxy dispatch for web_fetch when trusted env proxy is explicitly enabled", async () => {
     vi.stubEnv("HTTP_PROXY", "http://127.0.0.1:7890");
     const mockFetch = installMockFetch((input: RequestInfo | URL) =>
-      Promise.resolve({
-        ok: true,
-        status: 200,
-        headers: makeFetchHeaders({ "content-type": "text/plain" }),
-        text: async () => "proxy body",
-        url: resolveRequestUrl(input),
-      } as Response),
+      Promise.resolve(textResponse("proxy body", resolveRequestUrl(input))),
     );
     const tool = createFetchTool({
       firecrawl: { enabled: false },
@@ -800,13 +776,14 @@ describe("web_fetch extraction fallbacks", () => {
   });
 
   it("uses the provider fallback when direct fetch fails", async () => {
-    installMockFetch((_input: RequestInfo | URL) => {
-      return Promise.resolve({
-        ok: false,
-        status: 403,
-        headers: makeFetchHeaders({ "content-type": "text/html" }),
-        text: async () => "blocked",
-      } as Response);
+    installMockFetch((input: RequestInfo | URL) => {
+      return Promise.resolve(
+        responseWithUrl(
+          "blocked",
+          { status: 403, headers: { "content-type": "text/html" } },
+          resolveRequestUrl(input),
+        ),
+      );
     });
 
     resolveWebFetchDefinitionMock.mockReturnValue({


### PR DESCRIPTION
## What Problem This Solves

`readResponseText` enforces `maxBytes` while reading a Web `ReadableStream`, but its fallback methods called `arrayBuffer()` or `text()`. Both methods materialize the entire body before returning, so truncating their result cannot provide the requested memory bound.

## Why This Change Was Made

When a byte cap is requested and the response has no readable stream, the helper now fails closed without invoking either whole-body fallback. It returns an empty, truncated result; a native bodyless `Response` remains an empty, non-truncated result. Uncapped callers retain the existing `arrayBuffer()` and `text()` compatibility paths, with UTF-8 byte accounting for text-only response-like objects.

This keeps the public helper's `maxBytes` contract honest: capped calls either read a bounded stream or avoid an unbounded allocation.

## User Impact

Normal Fetch responses continue through the bounded stream path. Nonstandard or mocked response-like objects without a readable stream no longer risk an unbounded whole-body allocation when a caller asks for a cap; callers receive the existing `truncated` signal instead.

## Evidence

- Regression coverage asserts that neither `arrayBuffer()` nor `text()` is called when `maxBytes` is set without a bounded stream source.
- A native 204/bodyless response remains an empty, non-truncated result.
- The uncapped text-only fallback still works and reports UTF-8 bytes for multibyte text.
- Focused worktree fallback passed 45 tests across `web-shared`, `web-fetch.cf-markdown`, and `web-tools.fetch`; the fixtures now use native streaming `Response` objects.
- Fresh full-branch autoreview on exact head `0db4df3fbc85bc4c0e05506569524985f836c28d`: no accepted/actionable findings.
- Exact-head scheduled CI [28829746771](https://github.com/openclaw/openclaw/actions/runs/28829746771) passed 43/43 jobs.


