### PR TITLE
fix: default TLS gateway deep links to port 443 when port is omitted

### DIFF
--- a/apps/.i18n/native-source.json
+++ b/apps/.i18n/native-source.json
@@ -8699,7 +8699,7 @@
     },
     {
       "kind": "ui-modifier",
-      "line": 222,
+      "line": 215,
       "path": "apps/ios/Sources/Design/SettingsProTab.swift",
       "source": "Scan QR Code",
       "surface": "apple",
@@ -8707,7 +8707,7 @@
     },
     {
       "kind": "ui-modifier",
-      "line": 243,
+      "line": 236,
       "path": "apps/ios/Sources/Design/SettingsProTab.swift",
       "source": "Reset Onboarding?",
       "surface": "apple",
@@ -8715,7 +8715,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 247,
+      "line": 240,
       "path": "apps/ios/Sources/Design/SettingsProTab.swift",
       "source": "Reset",
       "surface": "apple",
@@ -8723,7 +8723,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 251,
+      "line": 244,
       "path": "apps/ios/Sources/Design/SettingsProTab.swift",
       "source": "Cancel",
       "surface": "apple",
@@ -8731,7 +8731,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 255,
+      "line": 248,
       "path": "apps/ios/Sources/Design/SettingsProTab.swift",
       "source": "This disconnects, clears saved gateway credentials, and reopens onboarding.",
       "surface": "apple",
@@ -8739,7 +8739,7 @@
     },
     {
       "kind": "ui-modifier",
-      "line": 258,
+      "line": 251,
       "path": "apps/ios/Sources/Design/SettingsProTab.swift",
       "source": "QR Scanner Unavailable",
       "surface": "apple",
@@ -8747,7 +8747,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 265,
+      "line": 258,
       "path": "apps/ios/Sources/Design/SettingsProTab.swift",
       "source": "OK",
       "surface": "apple",
@@ -8755,7 +8755,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 313,
+      "line": 306,
       "path": "apps/ios/Sources/Design/SettingsProTab.swift",
       "source": "Enable OpenClaw Hosted Push Relay?",
       "surface": "apple",
@@ -8763,7 +8763,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 327,
+      "line": 320,
       "path": "apps/ios/Sources/Design/SettingsProTab.swift",
       "source": "Continue",
       "surface": "apple",
@@ -8771,7 +8771,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 335,
+      "line": 328,
       "path": "apps/ios/Sources/Design/SettingsProTab.swift",
       "source": "Not Now",
       "surface": "apple",

--- a/apps/.i18n/native-source.json
+++ b/apps/.i18n/native-source.json
@@ -8691,7 +8691,7 @@
     },
     {
       "kind": "ui-modifier",
-      "line": 120,
+      "line": 123,
       "path": "apps/ios/Sources/Design/SettingsProTab.swift",
       "source": "Settings",
       "surface": "apple",
@@ -8699,7 +8699,7 @@
     },
     {
       "kind": "ui-modifier",
-      "line": 213,
+      "line": 215,
       "path": "apps/ios/Sources/Design/SettingsProTab.swift",
       "source": "Scan QR Code",
       "surface": "apple",
@@ -8707,7 +8707,7 @@
     },
     {
       "kind": "ui-modifier",
-      "line": 234,
+      "line": 236,
       "path": "apps/ios/Sources/Design/SettingsProTab.swift",
       "source": "Reset Onboarding?",
       "surface": "apple",
@@ -8715,7 +8715,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 238,
+      "line": 240,
       "path": "apps/ios/Sources/Design/SettingsProTab.swift",
       "source": "Reset",
       "surface": "apple",
@@ -8723,7 +8723,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 242,
+      "line": 244,
       "path": "apps/ios/Sources/Design/SettingsProTab.swift",
       "source": "Cancel",
       "surface": "apple",
@@ -8731,7 +8731,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 246,
+      "line": 248,
       "path": "apps/ios/Sources/Design/SettingsProTab.swift",
       "source": "This disconnects, clears saved gateway credentials, and reopens onboarding.",
       "surface": "apple",
@@ -8739,7 +8739,7 @@
     },
     {
       "kind": "ui-modifier",
-      "line": 249,
+      "line": 251,
       "path": "apps/ios/Sources/Design/SettingsProTab.swift",
       "source": "QR Scanner Unavailable",
       "surface": "apple",
@@ -8747,7 +8747,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 256,
+      "line": 258,
       "path": "apps/ios/Sources/Design/SettingsProTab.swift",
       "source": "OK",
       "surface": "apple",
@@ -8755,7 +8755,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 304,
+      "line": 306,
       "path": "apps/ios/Sources/Design/SettingsProTab.swift",
       "source": "Enable OpenClaw Hosted Push Relay?",
       "surface": "apple",
@@ -8763,7 +8763,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 318,
+      "line": 320,
       "path": "apps/ios/Sources/Design/SettingsProTab.swift",
       "source": "Continue",
       "surface": "apple",
@@ -8771,7 +8771,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 326,
+      "line": 328,
       "path": "apps/ios/Sources/Design/SettingsProTab.swift",
       "source": "Not Now",
       "surface": "apple",
@@ -11659,7 +11659,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 207,
+      "line": 208,
       "path": "apps/ios/Sources/RootTabs.swift",
       "source": "Settings",
       "surface": "apple",
@@ -11667,7 +11667,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 306,
+      "line": 307,
       "path": "apps/ios/Sources/RootTabs.swift",
       "source": "OpenClaw",
       "surface": "apple",
@@ -11675,7 +11675,7 @@
     },
     {
       "kind": "ui-modifier",
-      "line": 336,
+      "line": 337,
       "path": "apps/ios/Sources/RootTabs.swift",
       "source": "OpenClaw \\(self.sidebarGatewayStatusTitle)",
       "surface": "apple",
@@ -11683,7 +11683,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 341,
+      "line": 342,
       "path": "apps/ios/Sources/RootTabs.swift",
       "source": "Online",
       "surface": "apple",
@@ -11691,7 +11691,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 343,
+      "line": 344,
       "path": "apps/ios/Sources/RootTabs.swift",
       "source": "Connecting",
       "surface": "apple",
@@ -11699,7 +11699,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 345,
+      "line": 346,
       "path": "apps/ios/Sources/RootTabs.swift",
       "source": "Needs attention",
       "surface": "apple",
@@ -11707,7 +11707,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 347,
+      "line": 348,
       "path": "apps/ios/Sources/RootTabs.swift",
       "source": "Offline",
       "surface": "apple",
@@ -11715,7 +11715,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 427,
+      "line": 428,
       "path": "apps/ios/Sources/RootTabs.swift",
       "source": "Chat",
       "surface": "apple",
@@ -11723,7 +11723,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 440,
+      "line": 441,
       "path": "apps/ios/Sources/RootTabs.swift",
       "source": "Overview",
       "surface": "apple",
@@ -11731,7 +11731,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 464,
+      "line": 465,
       "path": "apps/ios/Sources/RootTabs.swift",
       "source": "Agents",
       "surface": "apple",
@@ -11739,7 +11739,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 471,
+      "line": 472,
       "path": "apps/ios/Sources/RootTabs.swift",
       "source": "Instances",
       "surface": "apple",
@@ -11747,7 +11747,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 482,
+      "line": 483,
       "path": "apps/ios/Sources/RootTabs.swift",
       "source": "Dreaming",
       "surface": "apple",
@@ -11755,7 +11755,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 489,
+      "line": 490,
       "path": "apps/ios/Sources/RootTabs.swift",
       "source": "Usage",
       "surface": "apple",
@@ -11763,7 +11763,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 496,
+      "line": 497,
       "path": "apps/ios/Sources/RootTabs.swift",
       "source": "Cron Jobs",
       "surface": "apple",
@@ -11771,7 +11771,7 @@
     },
     {
       "kind": "ui-modifier",
-      "line": 622,
+      "line": 626,
       "path": "apps/ios/Sources/RootTabs.swift",
       "source": "Hide Sidebar",
       "surface": "apple",
@@ -11779,7 +11779,7 @@
     },
     {
       "kind": "ui-modifier",
-      "line": 749,
+      "line": 753,
       "path": "apps/ios/Sources/RootTabs.swift",
       "source": "Close canvas",
       "surface": "apple",
@@ -11787,7 +11787,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 998,
+      "line": 1002,
       "path": "apps/ios/Sources/RootTabs.swift",
       "source": "Gateway needs attention",
       "surface": "apple",
@@ -11795,7 +11795,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 998,
+      "line": 1002,
       "path": "apps/ios/Sources/RootTabs.swift",
       "source": "OpenClaw iOS",
       "surface": "apple",
@@ -11803,7 +11803,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1034,
+      "line": 1038,
       "path": "apps/ios/Sources/RootTabs.swift",
       "source": "Available",
       "surface": "apple",
@@ -11811,7 +11811,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1034,
+      "line": 1038,
       "path": "apps/ios/Sources/RootTabs.swift",
       "source": "Gateway default",
       "surface": "apple",

--- a/apps/.i18n/native-source.json
+++ b/apps/.i18n/native-source.json
@@ -8699,7 +8699,7 @@
     },
     {
       "kind": "ui-modifier",
-      "line": 215,
+      "line": 222,
       "path": "apps/ios/Sources/Design/SettingsProTab.swift",
       "source": "Scan QR Code",
       "surface": "apple",
@@ -8707,7 +8707,7 @@
     },
     {
       "kind": "ui-modifier",
-      "line": 236,
+      "line": 243,
       "path": "apps/ios/Sources/Design/SettingsProTab.swift",
       "source": "Reset Onboarding?",
       "surface": "apple",
@@ -8715,7 +8715,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 240,
+      "line": 247,
       "path": "apps/ios/Sources/Design/SettingsProTab.swift",
       "source": "Reset",
       "surface": "apple",
@@ -8723,7 +8723,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 244,
+      "line": 251,
       "path": "apps/ios/Sources/Design/SettingsProTab.swift",
       "source": "Cancel",
       "surface": "apple",
@@ -8731,7 +8731,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 248,
+      "line": 255,
       "path": "apps/ios/Sources/Design/SettingsProTab.swift",
       "source": "This disconnects, clears saved gateway credentials, and reopens onboarding.",
       "surface": "apple",
@@ -8739,7 +8739,7 @@
     },
     {
       "kind": "ui-modifier",
-      "line": 251,
+      "line": 258,
       "path": "apps/ios/Sources/Design/SettingsProTab.swift",
       "source": "QR Scanner Unavailable",
       "surface": "apple",
@@ -8747,7 +8747,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 258,
+      "line": 265,
       "path": "apps/ios/Sources/Design/SettingsProTab.swift",
       "source": "OK",
       "surface": "apple",
@@ -8755,7 +8755,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 306,
+      "line": 313,
       "path": "apps/ios/Sources/Design/SettingsProTab.swift",
       "source": "Enable OpenClaw Hosted Push Relay?",
       "surface": "apple",
@@ -8763,7 +8763,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 320,
+      "line": 327,
       "path": "apps/ios/Sources/Design/SettingsProTab.swift",
       "source": "Continue",
       "surface": "apple",
@@ -8771,7 +8771,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 328,
+      "line": 335,
       "path": "apps/ios/Sources/Design/SettingsProTab.swift",
       "source": "Not Now",
       "surface": "apple",

--- a/apps/.i18n/native-source.json
+++ b/apps/.i18n/native-source.json
@@ -8691,7 +8691,7 @@
     },
     {
       "kind": "ui-modifier",
-      "line": 123,
+      "line": 131,
       "path": "apps/ios/Sources/Design/SettingsProTab.swift",
       "source": "Settings",
       "surface": "apple",
@@ -8699,7 +8699,7 @@
     },
     {
       "kind": "ui-modifier",
-      "line": 215,
+      "line": 224,
       "path": "apps/ios/Sources/Design/SettingsProTab.swift",
       "source": "Scan QR Code",
       "surface": "apple",
@@ -8707,7 +8707,7 @@
     },
     {
       "kind": "ui-modifier",
-      "line": 236,
+      "line": 245,
       "path": "apps/ios/Sources/Design/SettingsProTab.swift",
       "source": "Reset Onboarding?",
       "surface": "apple",
@@ -8715,7 +8715,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 240,
+      "line": 249,
       "path": "apps/ios/Sources/Design/SettingsProTab.swift",
       "source": "Reset",
       "surface": "apple",
@@ -8723,7 +8723,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 244,
+      "line": 253,
       "path": "apps/ios/Sources/Design/SettingsProTab.swift",
       "source": "Cancel",
       "surface": "apple",
@@ -8731,7 +8731,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 248,
+      "line": 257,
       "path": "apps/ios/Sources/Design/SettingsProTab.swift",
       "source": "This disconnects, clears saved gateway credentials, and reopens onboarding.",
       "surface": "apple",
@@ -8739,7 +8739,7 @@
     },
     {
       "kind": "ui-modifier",
-      "line": 251,
+      "line": 260,
       "path": "apps/ios/Sources/Design/SettingsProTab.swift",
       "source": "QR Scanner Unavailable",
       "surface": "apple",
@@ -8747,7 +8747,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 258,
+      "line": 267,
       "path": "apps/ios/Sources/Design/SettingsProTab.swift",
       "source": "OK",
       "surface": "apple",
@@ -8755,7 +8755,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 306,
+      "line": 321,
       "path": "apps/ios/Sources/Design/SettingsProTab.swift",
       "source": "Enable OpenClaw Hosted Push Relay?",
       "surface": "apple",
@@ -8763,7 +8763,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 320,
+      "line": 335,
       "path": "apps/ios/Sources/Design/SettingsProTab.swift",
       "source": "Continue",
       "surface": "apple",
@@ -8771,7 +8771,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 328,
+      "line": 343,
       "path": "apps/ios/Sources/Design/SettingsProTab.swift",
       "source": "Not Now",
       "surface": "apple",
@@ -8859,7 +8859,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 634,
+      "line": 633,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "Configured",
       "surface": "apple",
@@ -8867,7 +8867,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 634,
+      "line": 633,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "Not configured",
       "surface": "apple",
@@ -8875,7 +8875,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 699,
+      "line": 698,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "Connect to the gateway.",
       "surface": "apple",
@@ -8883,7 +8883,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 699,
+      "line": 698,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "Gateway requests will appear here.",
       "surface": "apple",
@@ -8891,7 +8891,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 746,
+      "line": 745,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "High",
       "surface": "apple",
@@ -8899,7 +8899,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 746,
+      "line": 745,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "Resolving",
       "surface": "apple",
@@ -8907,7 +8907,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 751,
+      "line": 750,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "One-time approval",
       "surface": "apple",
@@ -8915,7 +8915,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 751,
+      "line": 750,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "Permission can be saved",
       "surface": "apple",
@@ -8923,7 +8923,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 753,
+      "line": 752,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "Medium",
       "surface": "apple",
@@ -8931,7 +8931,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 753,
+      "line": 752,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "Review",
       "surface": "apple",
@@ -8939,7 +8939,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 774,
+      "line": 773,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "\\(diagnosticsIssueCount)",
       "surface": "apple",
@@ -8947,7 +8947,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 785,
+      "line": 784,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "Location off",
       "surface": "apple",
@@ -8955,7 +8955,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 787,
+      "line": 786,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "Location While Using",
       "surface": "apple",
@@ -8963,7 +8963,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 789,
+      "line": 788,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "Location While Using, effective Off",
       "surface": "apple",
@@ -8971,7 +8971,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 791,
+      "line": 790,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "Location While Using, effective Always",
       "surface": "apple",
@@ -8979,7 +8979,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 793,
+      "line": 792,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "Location Always",
       "surface": "apple",
@@ -8987,7 +8987,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 795,
+      "line": 794,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "Location Always, effective While Using",
       "surface": "apple",
@@ -8995,7 +8995,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 797,
+      "line": 796,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "Location Always, effective Off",
       "surface": "apple",
@@ -9003,7 +9003,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 825,
+      "line": 824,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "Checking iOS notification permission.",
       "surface": "apple",
@@ -9011,7 +9011,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 827,
+      "line": 826,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "OpenClaw can show approval prompts and event alerts when the app is not active.",
       "surface": "apple",
@@ -9019,7 +9019,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 829,
+      "line": 828,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "Notifications have been denied. Enable them in iOS Settings.",
       "surface": "apple",
@@ -9027,7 +9027,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 831,
+      "line": 830,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "Enable notifications to receive approval prompts and event alerts outside the app.",
       "surface": "apple",
@@ -9035,7 +9035,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 833,
+      "line": 832,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "OpenClaw cannot determine the current notification permission state.",
       "surface": "apple",
@@ -11659,7 +11659,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 208,
+      "line": 209,
       "path": "apps/ios/Sources/RootTabs.swift",
       "source": "Settings",
       "surface": "apple",
@@ -11667,7 +11667,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 307,
+      "line": 308,
       "path": "apps/ios/Sources/RootTabs.swift",
       "source": "OpenClaw",
       "surface": "apple",
@@ -11675,7 +11675,7 @@
     },
     {
       "kind": "ui-modifier",
-      "line": 337,
+      "line": 338,
       "path": "apps/ios/Sources/RootTabs.swift",
       "source": "OpenClaw \\(self.sidebarGatewayStatusTitle)",
       "surface": "apple",
@@ -11683,7 +11683,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 342,
+      "line": 343,
       "path": "apps/ios/Sources/RootTabs.swift",
       "source": "Online",
       "surface": "apple",
@@ -11691,7 +11691,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 344,
+      "line": 345,
       "path": "apps/ios/Sources/RootTabs.swift",
       "source": "Connecting",
       "surface": "apple",
@@ -11699,7 +11699,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 346,
+      "line": 347,
       "path": "apps/ios/Sources/RootTabs.swift",
       "source": "Needs attention",
       "surface": "apple",
@@ -11707,7 +11707,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 348,
+      "line": 349,
       "path": "apps/ios/Sources/RootTabs.swift",
       "source": "Offline",
       "surface": "apple",
@@ -11715,7 +11715,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 428,
+      "line": 429,
       "path": "apps/ios/Sources/RootTabs.swift",
       "source": "Chat",
       "surface": "apple",
@@ -11723,7 +11723,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 441,
+      "line": 442,
       "path": "apps/ios/Sources/RootTabs.swift",
       "source": "Overview",
       "surface": "apple",
@@ -11731,7 +11731,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 465,
+      "line": 466,
       "path": "apps/ios/Sources/RootTabs.swift",
       "source": "Agents",
       "surface": "apple",
@@ -11739,7 +11739,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 472,
+      "line": 473,
       "path": "apps/ios/Sources/RootTabs.swift",
       "source": "Instances",
       "surface": "apple",
@@ -11747,7 +11747,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 483,
+      "line": 484,
       "path": "apps/ios/Sources/RootTabs.swift",
       "source": "Dreaming",
       "surface": "apple",
@@ -11755,7 +11755,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 490,
+      "line": 491,
       "path": "apps/ios/Sources/RootTabs.swift",
       "source": "Usage",
       "surface": "apple",
@@ -11763,7 +11763,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 497,
+      "line": 498,
       "path": "apps/ios/Sources/RootTabs.swift",
       "source": "Cron Jobs",
       "surface": "apple",
@@ -11771,7 +11771,7 @@
     },
     {
       "kind": "ui-modifier",
-      "line": 626,
+      "line": 630,
       "path": "apps/ios/Sources/RootTabs.swift",
       "source": "Hide Sidebar",
       "surface": "apple",
@@ -11779,7 +11779,7 @@
     },
     {
       "kind": "ui-modifier",
-      "line": 753,
+      "line": 757,
       "path": "apps/ios/Sources/RootTabs.swift",
       "source": "Close canvas",
       "surface": "apple",
@@ -11787,7 +11787,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1002,
+      "line": 1006,
       "path": "apps/ios/Sources/RootTabs.swift",
       "source": "Gateway needs attention",
       "surface": "apple",
@@ -11795,7 +11795,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1002,
+      "line": 1006,
       "path": "apps/ios/Sources/RootTabs.swift",
       "source": "OpenClaw iOS",
       "surface": "apple",
@@ -11803,7 +11803,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1038,
+      "line": 1042,
       "path": "apps/ios/Sources/RootTabs.swift",
       "source": "Available",
       "surface": "apple",
@@ -11811,7 +11811,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1038,
+      "line": 1042,
       "path": "apps/ios/Sources/RootTabs.swift",
       "source": "Gateway default",
       "surface": "apple",

--- a/apps/ios/Sources/Design/SettingsProTab.swift
+++ b/apps/ios/Sources/Design/SettingsProTab.swift
@@ -69,6 +69,7 @@ struct SettingsProTab: View {
     let ownsNavigationStack: Bool
     let navigateToRoute: ((SettingsRoute) -> Void)?
     let onRouteChange: ((SettingsRoute?) -> Void)?
+    let handlesGatewaySetupRequests: Bool
 
     init(
         initialRoute: SettingsRoute? = nil,
@@ -76,7 +77,8 @@ struct SettingsProTab: View {
         headerLeadingAction: OpenClawSidebarHeaderAction? = nil,
         ownsNavigationStack: Bool = true,
         navigateToRoute: ((SettingsRoute) -> Void)? = nil,
-        onRouteChange: ((SettingsRoute?) -> Void)? = nil)
+        onRouteChange: ((SettingsRoute?) -> Void)? = nil,
+        handlesGatewaySetupRequests: Bool = false)
     {
         self.initialRoute = initialRoute
         self.directRoute = directRoute
@@ -84,6 +86,7 @@ struct SettingsProTab: View {
         self.ownsNavigationStack = ownsNavigationStack
         self.navigateToRoute = navigateToRoute
         self.onRouteChange = onRouteChange
+        self.handlesGatewaySetupRequests = handlesGatewaySetupRequests
     }
 
     var body: some View {
@@ -136,7 +139,9 @@ struct SettingsProTab: View {
                 self.previousLocationModeRaw = self.locationModeRaw
                 self.syncSettingsState()
                 self.refreshNotificationSettings()
-                self.applyPendingGatewaySetupLinkIfNeeded()
+                if self.handlesGatewaySetupRequests {
+                    self.applyPendingGatewaySetupLinkIfNeeded()
+                }
                 self.applyInitialRouteIfNeeded()
                 self.notifyRouteChange()
             }
@@ -171,9 +176,6 @@ struct SettingsProTab: View {
             }
             .onChange(of: self.defaultShareInstruction) { _, newValue in
                 ShareToAgentSettings.saveDefaultInstruction(newValue)
-            }
-            .onChange(of: self.appModel.gatewaySetupRequestID) { _, _ in
-                self.applyPendingGatewaySetupLinkIfNeeded()
             }
             .onChange(of: self.onboardingRequestID) { _, _ in
                 // Root-owned resets leave Settings mounted behind onboarding.

--- a/apps/ios/Sources/Design/SettingsProTab.swift
+++ b/apps/ios/Sources/Design/SettingsProTab.swift
@@ -69,7 +69,7 @@ struct SettingsProTab: View {
     let ownsNavigationStack: Bool
     let navigateToRoute: ((SettingsRoute) -> Void)?
     let onRouteChange: ((SettingsRoute?) -> Void)?
-    let handlesGatewaySetupRequests: Bool
+    let gatewaySetupRequestID: Int
 
     init(
         initialRoute: SettingsRoute? = nil,
@@ -78,7 +78,7 @@ struct SettingsProTab: View {
         ownsNavigationStack: Bool = true,
         navigateToRoute: ((SettingsRoute) -> Void)? = nil,
         onRouteChange: ((SettingsRoute?) -> Void)? = nil,
-        handlesGatewaySetupRequests: Bool = false)
+        gatewaySetupRequestID: Int = 0)
     {
         self.initialRoute = initialRoute
         self.directRoute = directRoute
@@ -86,7 +86,7 @@ struct SettingsProTab: View {
         self.ownsNavigationStack = ownsNavigationStack
         self.navigateToRoute = navigateToRoute
         self.onRouteChange = onRouteChange
-        self.handlesGatewaySetupRequests = handlesGatewaySetupRequests
+        self.gatewaySetupRequestID = gatewaySetupRequestID
     }
 
     var body: some View {
@@ -135,11 +135,11 @@ struct SettingsProTab: View {
 
     private func settingsLifecycle(_ content: some View) -> some View {
         content
-            .task {
+            .task(id: self.gatewaySetupRequestID) {
                 self.previousLocationModeRaw = self.locationModeRaw
                 self.syncSettingsState()
                 self.refreshNotificationSettings()
-                if self.handlesGatewaySetupRequests {
+                if self.gatewaySetupRequestID != 0 {
                     self.applyPendingGatewaySetupLinkIfNeeded()
                 }
                 self.applyInitialRouteIfNeeded()
@@ -176,13 +176,6 @@ struct SettingsProTab: View {
             }
             .onChange(of: self.defaultShareInstruction) { _, newValue in
                 ShareToAgentSettings.saveDefaultInstruction(newValue)
-            }
-            .onChange(of: self.appModel.gatewaySetupRequestID) { _, _ in
-                guard self.handlesGatewaySetupRequests else { return }
-                // A non-gateway sidebar Settings view is replaced during routing; its replacement
-                // consumes in `.task` so staged state cannot disappear with the old view.
-                guard self.ownsNavigationStack || self.directRoute == .gateway else { return }
-                self.applyPendingGatewaySetupLinkIfNeeded()
             }
             .onChange(of: self.onboardingRequestID) { _, _ in
                 // Root-owned resets leave Settings mounted behind onboarding.

--- a/apps/ios/Sources/Design/SettingsProTab.swift
+++ b/apps/ios/Sources/Design/SettingsProTab.swift
@@ -177,6 +177,13 @@ struct SettingsProTab: View {
             .onChange(of: self.defaultShareInstruction) { _, newValue in
                 ShareToAgentSettings.saveDefaultInstruction(newValue)
             }
+            .onChange(of: self.appModel.gatewaySetupRequestID) { _, _ in
+                guard self.handlesGatewaySetupRequests else { return }
+                // A non-gateway sidebar Settings view is replaced during routing; its replacement
+                // consumes in `.task` so staged state cannot disappear with the old view.
+                guard self.ownsNavigationStack || self.directRoute == .gateway else { return }
+                self.applyPendingGatewaySetupLinkIfNeeded()
+            }
             .onChange(of: self.onboardingRequestID) { _, _ in
                 // Root-owned resets leave Settings mounted behind onboarding.
                 // Reload cleared credentials before the view can persist stale state.

--- a/apps/ios/Sources/Design/SettingsProTab.swift
+++ b/apps/ios/Sources/Design/SettingsProTab.swift
@@ -1,6 +1,11 @@
 import OpenClawKit
 import SwiftUI
 
+struct GatewaySetupRequest {
+    let id: Int
+    let link: GatewayConnectDeepLink
+}
+
 struct SettingsProTab: View {
     @Environment(NodeAppModel.self) var appModel
     @Environment(VoiceWakeManager.self) var voiceWake
@@ -69,7 +74,8 @@ struct SettingsProTab: View {
     let ownsNavigationStack: Bool
     let navigateToRoute: ((SettingsRoute) -> Void)?
     let onRouteChange: ((SettingsRoute?) -> Void)?
-    let gatewaySetupRequestID: Int
+    let gatewaySetupRequest: GatewaySetupRequest?
+    let onGatewaySetupRequestHandled: ((Int) -> Void)?
 
     init(
         initialRoute: SettingsRoute? = nil,
@@ -78,7 +84,8 @@ struct SettingsProTab: View {
         ownsNavigationStack: Bool = true,
         navigateToRoute: ((SettingsRoute) -> Void)? = nil,
         onRouteChange: ((SettingsRoute?) -> Void)? = nil,
-        gatewaySetupRequestID: Int = 0)
+        gatewaySetupRequest: GatewaySetupRequest? = nil,
+        onGatewaySetupRequestHandled: ((Int) -> Void)? = nil)
     {
         self.initialRoute = initialRoute
         self.directRoute = directRoute
@@ -86,7 +93,8 @@ struct SettingsProTab: View {
         self.ownsNavigationStack = ownsNavigationStack
         self.navigateToRoute = navigateToRoute
         self.onRouteChange = onRouteChange
-        self.gatewaySetupRequestID = gatewaySetupRequestID
+        self.gatewaySetupRequest = gatewaySetupRequest
+        self.onGatewaySetupRequestHandled = onGatewaySetupRequestHandled
     }
 
     var body: some View {
@@ -135,15 +143,16 @@ struct SettingsProTab: View {
 
     private func settingsLifecycle(_ content: some View) -> some View {
         content
-            .task(id: self.gatewaySetupRequestID) {
+            .task {
                 self.previousLocationModeRaw = self.locationModeRaw
                 self.syncSettingsState()
                 self.refreshNotificationSettings()
-                if self.gatewaySetupRequestID != 0 {
-                    self.applyPendingGatewaySetupLinkIfNeeded()
-                }
+                self.applyGatewaySetupRequestIfNeeded()
                 self.applyInitialRouteIfNeeded()
                 self.notifyRouteChange()
+            }
+            .onChange(of: self.gatewaySetupRequest?.id) { _, _ in
+                self.applyGatewaySetupRequestIfNeeded()
             }
             .onChange(of: self.scenePhase) { _, phase in
                 if phase == .active {
@@ -262,6 +271,12 @@ struct SettingsProTab: View {
                 Text(self.scannerError ?? "")
                     .font(OpenClawType.subhead)
             }
+    }
+
+    private func applyGatewaySetupRequestIfNeeded() {
+        guard let gatewaySetupRequest else { return }
+        self.applyGatewaySetupLink(gatewaySetupRequest.link)
+        self.onGatewaySetupRequestHandled?(gatewaySetupRequest.id)
     }
 
     func openNotificationsRouteFromApprovals() {

--- a/apps/ios/Sources/Design/SettingsProTabActions.swift
+++ b/apps/ios/Sources/Design/SettingsProTabActions.swift
@@ -222,8 +222,7 @@ extension SettingsProTab {
         await self.connectManual()
     }
 
-    func applyPendingGatewaySetupLinkIfNeeded() {
-        guard let link = self.appModel.consumePendingGatewaySetupLink() else { return }
+    func applyGatewaySetupLink(_ link: GatewayConnectDeepLink) {
         self.setupCode = ""
         self.setupStatusText = nil
         self.stagedGatewaySetupLink = link

--- a/apps/ios/Sources/RootTabs.swift
+++ b/apps/ios/Sources/RootTabs.swift
@@ -202,7 +202,8 @@ struct RootTabs: View {
 
             SettingsProTab(
                 initialRoute: self.selectedSettingsRoute,
-                onRouteChange: self.handleSettingsRouteChange)
+                onRouteChange: self.handleSettingsRouteChange,
+                handlesGatewaySetupRequests: true)
                 .id(self.settingsTabViewID)
                 .tabItem { Label("Settings", systemImage: "gearshape.fill") }
                 .tag(AppTab.settings)
@@ -511,13 +512,15 @@ struct RootTabs: View {
                     headerLeadingAction: self.sidebarHeaderLeadingAction,
                     ownsNavigationStack: false,
                     navigateToRoute: self.pushSidebarSettingsRoute,
-                    onRouteChange: self.handleSettingsRouteChange)
+                    onRouteChange: self.handleSettingsRouteChange,
+                    handlesGatewaySetupRequests: true)
             } else {
                 SettingsProTab(
                     headerLeadingAction: self.sidebarHeaderLeadingAction,
                     ownsNavigationStack: false,
                     navigateToRoute: self.pushSidebarSettingsRoute,
-                    onRouteChange: self.handleSettingsRouteChange)
+                    onRouteChange: self.handleSettingsRouteChange,
+                    handlesGatewaySetupRequests: true)
             }
         case .gateway:
             SettingsProTab(
@@ -525,7 +528,8 @@ struct RootTabs: View {
                 headerLeadingAction: self.sidebarHeaderLeadingAction,
                 ownsNavigationStack: false,
                 navigateToRoute: self.pushSidebarSettingsRoute,
-                onRouteChange: self.handleSettingsRouteChange)
+                onRouteChange: self.handleSettingsRouteChange,
+                handlesGatewaySetupRequests: true)
         }
     }
 
@@ -1296,6 +1300,8 @@ extension RootTabs {
         self.showOnboarding = false
         self.presentedSheet = nil
         self.didAutoOpenSettings = true
+        // Rebuild the canonical Settings owner before it consumes this request.
+        self.selectedSettingsRouteRequestID &+= 1
         self.selectSidebarDestination(.gateway)
         self.requestLocalNetworkAccess(reason: "gateway_setup_deeplink")
     }

--- a/apps/ios/Sources/RootTabs.swift
+++ b/apps/ios/Sources/RootTabs.swift
@@ -51,7 +51,7 @@ struct RootTabs: View {
     @State private var didEvaluateOnboarding: Bool = false
     @State private var didAutoOpenSettings: Bool = false
     @State private var didApplyInitialChatSession: Bool = false
-    @State private var handledGatewaySetupRequestID: Int = 0
+    @State private var gatewaySetupRequest: GatewaySetupRequest?
     @State private var suppressedExecApprovalPromptIDForNotificationSettings: String?
 
     private static var initialTab: AppTab {
@@ -203,7 +203,8 @@ struct RootTabs: View {
             SettingsProTab(
                 initialRoute: self.selectedSettingsRoute,
                 onRouteChange: self.handleSettingsRouteChange,
-                gatewaySetupRequestID: self.handledGatewaySetupRequestID)
+                gatewaySetupRequest: self.gatewaySetupRequest,
+                onGatewaySetupRequestHandled: self.handleGatewaySetupRequest)
                 .id(self.settingsTabViewID)
                 .tabItem { Label("Settings", systemImage: "gearshape.fill") }
                 .tag(AppTab.settings)
@@ -513,14 +514,16 @@ struct RootTabs: View {
                     ownsNavigationStack: false,
                     navigateToRoute: self.pushSidebarSettingsRoute,
                     onRouteChange: self.handleSettingsRouteChange,
-                    gatewaySetupRequestID: self.handledGatewaySetupRequestID)
+                    gatewaySetupRequest: self.gatewaySetupRequest,
+                    onGatewaySetupRequestHandled: self.handleGatewaySetupRequest)
             } else {
                 SettingsProTab(
                     headerLeadingAction: self.sidebarHeaderLeadingAction,
                     ownsNavigationStack: false,
                     navigateToRoute: self.pushSidebarSettingsRoute,
                     onRouteChange: self.handleSettingsRouteChange,
-                    gatewaySetupRequestID: self.handledGatewaySetupRequestID)
+                    gatewaySetupRequest: self.gatewaySetupRequest,
+                    onGatewaySetupRequestHandled: self.handleGatewaySetupRequest)
             }
         case .gateway:
             SettingsProTab(
@@ -529,7 +532,8 @@ struct RootTabs: View {
                 ownsNavigationStack: false,
                 navigateToRoute: self.pushSidebarSettingsRoute,
                 onRouteChange: self.handleSettingsRouteChange,
-                gatewaySetupRequestID: self.handledGatewaySetupRequestID)
+                gatewaySetupRequest: self.gatewaySetupRequest,
+                onGatewaySetupRequestHandled: self.handleGatewaySetupRequest)
         }
     }
 
@@ -1295,14 +1299,20 @@ extension RootTabs {
 
     private func maybeOpenSettingsForGatewaySetup() {
         let requestID = self.appModel.gatewaySetupRequestID
-        guard requestID != 0, requestID != self.handledGatewaySetupRequestID else { return }
+        guard requestID != 0, requestID != self.gatewaySetupRequest?.id else { return }
+        guard let link = self.appModel.consumePendingGatewaySetupLink() else { return }
         self.showOnboarding = false
         self.presentedSheet = nil
         self.didAutoOpenSettings = true
         self.selectSidebarDestination(.gateway)
-        // Publish only to the routed canonical Settings view; embedded Settings views keep ID 0.
-        self.handledGatewaySetupRequestID = requestID
+        // Root owns delivery so embedded Settings views cannot consume the one-shot link.
+        self.gatewaySetupRequest = GatewaySetupRequest(id: requestID, link: link)
         self.requestLocalNetworkAccess(reason: "gateway_setup_deeplink")
+    }
+
+    private func handleGatewaySetupRequest(_ requestID: Int) {
+        guard self.gatewaySetupRequest?.id == requestID else { return }
+        self.gatewaySetupRequest = nil
     }
 
     private func maybeRequestLocalNetworkAccess(reason: String) {

--- a/apps/ios/Sources/RootTabs.swift
+++ b/apps/ios/Sources/RootTabs.swift
@@ -203,7 +203,7 @@ struct RootTabs: View {
             SettingsProTab(
                 initialRoute: self.selectedSettingsRoute,
                 onRouteChange: self.handleSettingsRouteChange,
-                handlesGatewaySetupRequests: true)
+                gatewaySetupRequestID: self.handledGatewaySetupRequestID)
                 .id(self.settingsTabViewID)
                 .tabItem { Label("Settings", systemImage: "gearshape.fill") }
                 .tag(AppTab.settings)
@@ -513,14 +513,14 @@ struct RootTabs: View {
                     ownsNavigationStack: false,
                     navigateToRoute: self.pushSidebarSettingsRoute,
                     onRouteChange: self.handleSettingsRouteChange,
-                    handlesGatewaySetupRequests: true)
+                    gatewaySetupRequestID: self.handledGatewaySetupRequestID)
             } else {
                 SettingsProTab(
                     headerLeadingAction: self.sidebarHeaderLeadingAction,
                     ownsNavigationStack: false,
                     navigateToRoute: self.pushSidebarSettingsRoute,
                     onRouteChange: self.handleSettingsRouteChange,
-                    handlesGatewaySetupRequests: true)
+                    gatewaySetupRequestID: self.handledGatewaySetupRequestID)
             }
         case .gateway:
             SettingsProTab(
@@ -529,7 +529,7 @@ struct RootTabs: View {
                 ownsNavigationStack: false,
                 navigateToRoute: self.pushSidebarSettingsRoute,
                 onRouteChange: self.handleSettingsRouteChange,
-                handlesGatewaySetupRequests: true)
+                gatewaySetupRequestID: self.handledGatewaySetupRequestID)
         }
     }
 
@@ -1296,11 +1296,12 @@ extension RootTabs {
     private func maybeOpenSettingsForGatewaySetup() {
         let requestID = self.appModel.gatewaySetupRequestID
         guard requestID != 0, requestID != self.handledGatewaySetupRequestID else { return }
-        self.handledGatewaySetupRequestID = requestID
         self.showOnboarding = false
         self.presentedSheet = nil
         self.didAutoOpenSettings = true
         self.selectSidebarDestination(.gateway)
+        // Publish only to the routed canonical Settings view; embedded Settings views keep ID 0.
+        self.handledGatewaySetupRequestID = requestID
         self.requestLocalNetworkAccess(reason: "gateway_setup_deeplink")
     }
 

--- a/apps/ios/Sources/RootTabs.swift
+++ b/apps/ios/Sources/RootTabs.swift
@@ -1300,8 +1300,6 @@ extension RootTabs {
         self.showOnboarding = false
         self.presentedSheet = nil
         self.didAutoOpenSettings = true
-        // Rebuild the canonical Settings owner before it consumes this request.
-        self.selectedSettingsRouteRequestID &+= 1
         self.selectSidebarDestination(.gateway)
         self.requestLocalNetworkAccess(reason: "gateway_setup_deeplink")
     }

--- a/apps/ios/Sources/Terminal/TerminalHubScreen.swift
+++ b/apps/ios/Sources/Terminal/TerminalHubScreen.swift
@@ -151,10 +151,6 @@ struct TerminalHubScreen: View {
 
     /// Identity for the embedded web view: recreate it only when the gateway
     /// endpoint or credentials actually change.
-    static func webContentIdentity(config: GatewayConnectConfig?) -> Int {
-        self.webContentIdentity(config: config, storedOperatorToken: self.storedOperatorToken())
-    }
-
     static func webContentIdentity(config: GatewayConnectConfig?, storedOperatorToken: String?) -> Int {
         var hasher = Hasher()
         hasher.combine(config?.url)

--- a/apps/shared/OpenClawKit/Sources/OpenClawKit/DeepLinks.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawKit/DeepLinks.swift
@@ -1,5 +1,9 @@
 import Foundation
 
+private func defaultGatewayPort(tls: Bool) -> Int {
+    tls ? 443 : 18789
+}
+
 public enum DeepLinkRoute: Sendable, Equatable {
     case agent(AgentDeepLink)
     case gateway(GatewayConnectDeepLink)
@@ -122,7 +126,7 @@ public struct GatewayConnectDeepLink: Codable, Sendable, Equatable {
         }
         return GatewayConnectDeepLink(
             host: host,
-            port: payload.port ?? (tls ? 443 : 18789),
+            port: payload.port ?? defaultGatewayPort(tls: tls),
             tls: tls,
             bootstrapToken: payload.bootstrapToken,
             token: payload.token,
@@ -149,7 +153,7 @@ public struct GatewayConnectDeepLink: Codable, Sendable, Equatable {
         }
         return GatewayConnectDeepLink(
             host: hostname,
-            port: parsed.port ?? (tls ? 443 : 18789),
+            port: parsed.port ?? defaultGatewayPort(tls: tls),
             tls: tls,
             bootstrapToken: bootstrapToken,
             token: token,
@@ -254,7 +258,7 @@ public enum DeepLinkParser {
                 return nil
             }
             let tls = (query["tls"] as NSString?)?.boolValue ?? false
-            let port = query["port"].flatMap { Int($0) } ?? (tls ? 443 : 18789)
+            let port = query["port"].flatMap { Int($0) } ?? defaultGatewayPort(tls: tls)
             if !tls, !LoopbackHost.isLocalNetworkHost(hostParam) {
                 return nil
             }

--- a/apps/shared/OpenClawKit/Sources/OpenClawKit/DeepLinks.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawKit/DeepLinks.swift
@@ -253,8 +253,8 @@ public enum DeepLinkParser {
             else {
                 return nil
             }
-            let port = query["port"].flatMap { Int($0) } ?? 18789
             let tls = (query["tls"] as NSString?)?.boolValue ?? false
+            let port = query["port"].flatMap { Int($0) } ?? (tls ? 443 : 18789)
             if !tls, !LoopbackHost.isLocalNetworkHost(hostParam) {
                 return nil
             }

--- a/apps/shared/OpenClawKit/Tests/OpenClawKitTests/DeepLinksSecurityTests.swift
+++ b/apps/shared/OpenClawKit/Tests/OpenClawKitTests/DeepLinksSecurityTests.swift
@@ -10,6 +10,13 @@ private func setupCode(from payload: String) -> String {
         .replacingOccurrences(of: "=", with: "")
 }
 
+private func gatewayLink(from raw: String) -> GatewayConnectDeepLink? {
+    guard let url = URL(string: raw),
+          case let .gateway(link)? = DeepLinkParser.parse(url)
+    else { return nil }
+    return link
+}
+
 @Suite struct DeepLinksSecurityTests {
     @Test func dashboardDeepLinkParses() {
         let url = URL(string: "openclaw://dashboard")!
@@ -21,46 +28,22 @@ private func setupCode(from payload: String) -> String {
         #expect(DeepLinkParser.parse(url) == .dashboard)
     }
 
-    @Test func gatewayDeepLinkUsesTlsDefaultPortWhenPortMissing() throws {
-        let url = try #require(URL(
-            string: "openclaw://gateway?host=gateway.example.com&tls=1&token=abc"))
-        #expect(
-            DeepLinkParser.parse(url) == .gateway(
-                .init(
-                    host: "gateway.example.com",
-                    port: 443,
-                    tls: true,
-                    bootstrapToken: nil,
-                    token: "abc",
-                    password: nil)))
+    @Test func gatewayDeepLinkUsesTlsDefaultPortWhenPortMissing() {
+        let link = gatewayLink(from: "openclaw://gateway?host=gateway.example.com&tls=1")
+        #expect(link?.port == 443)
+        #expect(link?.tls == true)
     }
 
-    @Test func gatewayDeepLinkUsesPlaintextDefaultPortWhenPortMissing() throws {
-        let url = try #require(URL(
-            string: "openclaw://gateway?host=127.0.0.1&tls=0&token=abc"))
-        #expect(
-            DeepLinkParser.parse(url) == .gateway(
-                .init(
-                    host: "127.0.0.1",
-                    port: 18789,
-                    tls: false,
-                    bootstrapToken: nil,
-                    token: "abc",
-                    password: nil)))
+    @Test func gatewayDeepLinkUsesPlaintextDefaultPortWhenPortMissing() {
+        let link = gatewayLink(from: "openclaw://gateway?host=127.0.0.1&tls=0")
+        #expect(link?.port == 18789)
+        #expect(link?.tls == false)
     }
 
-    @Test func gatewayDeepLinkPreservesExplicitTlsPort() throws {
-        let url = try #require(URL(
-            string: "openclaw://gateway?host=gateway.example.com&port=18789&tls=1&token=abc"))
-        #expect(
-            DeepLinkParser.parse(url) == .gateway(
-                .init(
-                    host: "gateway.example.com",
-                    port: 18789,
-                    tls: true,
-                    bootstrapToken: nil,
-                    token: "abc",
-                    password: nil)))
+    @Test func gatewayDeepLinkPreservesExplicitTlsPort() {
+        let link = gatewayLink(from: "openclaw://gateway?host=gateway.example.com&port=18789&tls=1")
+        #expect(link?.port == 18789)
+        #expect(link?.tls == true)
     }
 
     @Test func gatewayDeepLinkRejectsInsecureNonLoopbackWs() {

--- a/apps/shared/OpenClawKit/Tests/OpenClawKitTests/DeepLinksSecurityTests.swift
+++ b/apps/shared/OpenClawKit/Tests/OpenClawKitTests/DeepLinksSecurityTests.swift
@@ -21,6 +21,33 @@ private func setupCode(from payload: String) -> String {
         #expect(DeepLinkParser.parse(url) == .dashboard)
     }
 
+    @Test func gatewayDeepLinkUsesTlsDefaultPortWhenPortMissing() {
+        let url = URL(string: "openclaw://gateway?host=gateway.example.com&tls=1&token=abc")!
+        #expect(
+            DeepLinkParser.parse(url) == .gateway(
+                .init(
+                    host: "gateway.example.com",
+                    port: 443,
+                    tls: true,
+                    bootstrapToken: nil,
+                    token: "abc",
+                    password: nil)))
+    }
+
+    @Test func gatewayDeepLinkPreservesExplicitTlsPort() {
+        let url = URL(
+            string: "openclaw://gateway?host=gateway.example.com&port=18789&tls=1&token=abc")!
+        #expect(
+            DeepLinkParser.parse(url) == .gateway(
+                .init(
+                    host: "gateway.example.com",
+                    port: 18789,
+                    tls: true,
+                    bootstrapToken: nil,
+                    token: "abc",
+                    password: nil)))
+    }
+
     @Test func gatewayDeepLinkRejectsInsecureNonLoopbackWs() {
         let url = URL(
             string: "openclaw://gateway?host=attacker.example&port=18789&tls=0&token=abc")!

--- a/apps/shared/OpenClawKit/Tests/OpenClawKitTests/DeepLinksSecurityTests.swift
+++ b/apps/shared/OpenClawKit/Tests/OpenClawKitTests/DeepLinksSecurityTests.swift
@@ -21,8 +21,9 @@ private func setupCode(from payload: String) -> String {
         #expect(DeepLinkParser.parse(url) == .dashboard)
     }
 
-    @Test func gatewayDeepLinkUsesTlsDefaultPortWhenPortMissing() {
-        let url = URL(string: "openclaw://gateway?host=gateway.example.com&tls=1&token=abc")!
+    @Test func gatewayDeepLinkUsesTlsDefaultPortWhenPortMissing() throws {
+        let url = try #require(URL(
+            string: "openclaw://gateway?host=gateway.example.com&tls=1&token=abc"))
         #expect(
             DeepLinkParser.parse(url) == .gateway(
                 .init(
@@ -34,9 +35,23 @@ private func setupCode(from payload: String) -> String {
                     password: nil)))
     }
 
-    @Test func gatewayDeepLinkPreservesExplicitTlsPort() {
-        let url = URL(
-            string: "openclaw://gateway?host=gateway.example.com&port=18789&tls=1&token=abc")!
+    @Test func gatewayDeepLinkUsesPlaintextDefaultPortWhenPortMissing() throws {
+        let url = try #require(URL(
+            string: "openclaw://gateway?host=127.0.0.1&tls=0&token=abc"))
+        #expect(
+            DeepLinkParser.parse(url) == .gateway(
+                .init(
+                    host: "127.0.0.1",
+                    port: 18789,
+                    tls: false,
+                    bootstrapToken: nil,
+                    token: "abc",
+                    password: nil)))
+    }
+
+    @Test func gatewayDeepLinkPreservesExplicitTlsPort() throws {
+        let url = try #require(URL(
+            string: "openclaw://gateway?host=gateway.example.com&port=18789&tls=1&token=abc"))
         #expect(
             DeepLinkParser.parse(url) == .gateway(
                 .init(


### PR DESCRIPTION
## What Problem This Solves

Fixes two coupled iOS gateway setup failures:

- A gateway deep link with TLS enabled and no explicit port parsed to port **18789** instead of the standard TLS port **443**.
- Any mounted Settings view could consume the pending setup request before the routed, canonical Settings screen appeared.

Setup codes and raw gateway URL parsing in OpenClawKit already default omitted TLS/WSS ports to 443; the `openclaw://gateway` query parser did not.

## Why This Change Was Made

Centralize the TLS default-port rule in `DeepLinks.swift` (`tls ? 443 : 18789`) and use it for setup payloads, raw URLs, and gateway deep links.

Make gateway setup request ownership explicit: `RootTabs` consumes the model's one-shot link, selects the gateway route, and passes one typed request only to the canonical phone or iPad Settings surface. Settings acknowledges the request after staging it, preventing both hidden-view consumption and replay after navigation.

The change preserves explicit ports, so existing links such as `openclaw://gateway?...&port=18789&tls=1` still parse to 18789.

## User Impact

TLS gateway deep links from QR codes or shared links now stage the expected HTTPS/WSS endpoint without requiring an explicit `port=443` parameter. This works on both phone and iPad layouts even when another Settings surface is already mounted. Explicit ports remain unchanged, and omitted plaintext ports still default to 18789.

## Evidence

Parser regression proof:

- `swift test --package-path apps/shared/OpenClawKit --filter DeepLinksSecurityTests`
- 21 tests passed, covering omitted TLS and plaintext ports plus explicit TLS ports.

Build proof:

- Fresh generated iOS project, Debug simulator build: `** BUILD SUCCEEDED **`
- SwiftFormat and SwiftLint build phases passed.
- Native app localization inventory regenerated and `native-app-i18n.ts check` passes.

Live end-to-end proof using the exact built app:

- iPhone 17 simulator: opened and applied two consecutive unique TLS links without ports. Each Connect replaced the previous host and applied port `443` with TLS.
- iPad Pro 13-inch simulator: repeated the same two-link matrix in canonical sidebar Settings. The second request replaced the first and retained port `443` with TLS.

Review and related-work check:

- Fresh exact-head autoreview: no findings, confidence 0.90.
- No exact duplicate found. #98265 (setup short codes) and #98189 (onboarding tests) are related but non-overlapping.
- No UI layout or styling change, so there is no meaningful before/after visual delta.
