### PR TITLE
fix(macos): onboarding connection check stops local gateway before remote mode is chosen

### DIFF
--- a/apps/macos/Sources/OpenClaw/AppState.swift
+++ b/apps/macos/Sources/OpenClaw/AppState.swift
@@ -247,6 +247,9 @@ final class AppState {
     /// Tracks whether the Canvas panel is currently visible (not persisted).
     var canvasPanelVisible: Bool = false
 
+    /// Skips ConnectionModeCoordinator while onboarding probes remote without committing mode.
+    var suppressConnectionModeCoordinator = false
+
     var peekabooBridgeEnabled: Bool {
         didSet {
             self.ifNotPreview {

--- a/apps/macos/Sources/OpenClaw/MenuBar.swift
+++ b/apps/macos/Sources/OpenClaw/MenuBar.swift
@@ -87,6 +87,7 @@ struct OpenClawApp: App {
             self.applyStatusItemAppearance(paused: self.state.isPaused, sleeping: self.isGatewaySleeping)
         }
         .onChange(of: self.state.connectionMode) { _, mode in
+            guard !self.state.suppressConnectionModeCoordinator else { return }
             Task { await ConnectionModeCoordinator.shared.apply(mode: mode, paused: self.state.isPaused) }
             CLIInstallPrompter.shared.checkAndPromptIfNeeded(reason: "connection-mode")
         }

--- a/apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift
+++ b/apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift
@@ -469,31 +469,43 @@ extension OnboardingView {
 
     @MainActor
     private func probeRemoteConnection() async {
-        let originalMode = self.state.connectionMode
-        let shouldRestoreMode = originalMode != .remote
-        if shouldRestoreMode {
-            // Reuse the shared remote endpoint stack for probing without committing the user's mode choice.
-            self.state.connectionMode = .remote
-        }
-        self.remoteProbeState = .checking
-        self.remoteAuthIssue = nil
-        defer {
+        await Self.withSuppressedConnectionModeCoordinator(state: self.state) {
+            let originalMode = self.state.connectionMode
+            let shouldRestoreMode = originalMode != .remote
             if shouldRestoreMode {
-                self.suppressRemoteProbeReset = true
-                self.state.connectionMode = originalMode
-                self.suppressRemoteProbeReset = false
+                // Reuse the shared remote endpoint stack for probing without committing the user's mode choice.
+                self.state.connectionMode = .remote
+            }
+            self.remoteProbeState = .checking
+            self.remoteAuthIssue = nil
+            defer {
+                if shouldRestoreMode {
+                    self.suppressRemoteProbeReset = true
+                    self.state.connectionMode = originalMode
+                    self.suppressRemoteProbeReset = false
+                }
+            }
+
+            switch await RemoteGatewayProbe.run() {
+            case let .ready(success):
+                self.remoteProbeState = .ok(success)
+            case let .authIssue(issue):
+                self.remoteAuthIssue = issue
+                self.remoteProbeState = .failed(issue.statusMessage)
+            case let .failed(message):
+                self.remoteProbeState = .failed(message)
             }
         }
+    }
 
-        switch await RemoteGatewayProbe.run() {
-        case let .ready(success):
-            self.remoteProbeState = .ok(success)
-        case let .authIssue(issue):
-            self.remoteAuthIssue = issue
-            self.remoteProbeState = .failed(issue.statusMessage)
-        case let .failed(message):
-            self.remoteProbeState = .failed(message)
-        }
+    @MainActor
+    static func withSuppressedConnectionModeCoordinator(
+        state: AppState,
+        perform: () async -> Void) async
+    {
+        state.suppressConnectionModeCoordinator = true
+        defer { state.suppressConnectionModeCoordinator = false }
+        await perform()
     }
 
     private func resetRemoteProbeFeedback() {

--- a/apps/macos/Tests/OpenClawIPCTests/OnboardingRemoteAuthPromptTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/OnboardingRemoteAuthPromptTests.swift
@@ -139,4 +139,13 @@ struct OnboardingRemoteAuthPromptTests {
         #expect(OnboardingView.shouldResetRemoteProbeFeedback(for: .remote, suppressReset: false) == false)
         #expect(OnboardingView.shouldResetRemoteProbeFeedback(for: .local, suppressReset: true) == false)
     }
+
+    @Test @MainActor func `remote probe suppresses connection mode coordinator`() async {
+        let state = AppState(preview: true)
+        #expect(state.suppressConnectionModeCoordinator == false)
+        await OnboardingView.withSuppressedConnectionModeCoordinator(state: state) {
+            #expect(state.suppressConnectionModeCoordinator)
+        }
+        #expect(state.suppressConnectionModeCoordinator == false)
+    }
 }


### PR DESCRIPTION
Related: #99767

## What Problem This Solves

Fixes an issue where macOS users testing remote connectivity from onboarding's **Check connection** while still setting up a local gateway would see the local gateway stop mid-onboarding, even though they had not chosen remote mode yet.

## Why This Change Was Made

Suppress `ConnectionModeCoordinator` during the transient remote probe window while keeping the existing temporary connection-mode flip needed for endpoint health checks.

## User Impact

Local gateway onboarding can probe remote settings without tearing down the gateway install that onboarding just started.

## Evidence

- `OnboardingRemoteAuthPromptTests`: remote probe suppression helper restores coordinator behavior.
- macOS IPC test target: `OnboardingRemoteAuthPromptTests`.
