### PR TITLE
fix(plugins): wrap self-hosted discovery JSON parse in try/catch

### DIFF
--- a/scripts/proof/provider-self-hosted-json-parse.mts
+++ b/scripts/proof/provider-self-hosted-json-parse.mts
@@ -1,0 +1,41 @@
+// Real behavior proof: malformed self-hosted provider discovery JSON.
+// Starts a local HTTP server that returns invalid JSON on /v1/models, then runs
+// OpenClaw's discovery helper against it and captures the labeled warning.
+
+import { createServer } from "node:http";
+import { discoverOpenAICompatibleLocalModels } from "../../src/plugins/provider-self-hosted-setup.js";
+
+const HOST = "127.0.0.1";
+const PORT = 0; // let the OS assign a free port
+
+const server = createServer((req, res) => {
+  if (req.url === "/v1/models") {
+    res.writeHead(200, { "Content-Type": "application/json" });
+    res.end("not valid json {");
+    return;
+  }
+  res.writeHead(404);
+  res.end("not found");
+});
+
+await new Promise<void>((resolve) => server.listen(PORT, HOST, resolve));
+const address = server.address();
+if (address === null || typeof address === "string") {
+  throw new Error("server did not bind to a TCP port");
+}
+const baseUrl = `http://${HOST}:${address.port}/v1`;
+
+console.log("=== Proof: self-hosted provider malformed discovery JSON ===\n");
+console.log(`Endpoint: ${baseUrl}/models`);
+console.log("Response body: not valid json {\n");
+
+const models = await discoverOpenAICompatibleLocalModels({
+  baseUrl,
+  label: "malformed-test",
+  env: {}, // avoid VITEST early-return so real discovery runs
+});
+
+console.log(`Discovered models: ${JSON.stringify(models)}`);
+console.log("\nPASS: malformed discovery JSON is caught and discovery returns an empty list.");
+
+server.close();

--- a/scripts/proof/provider-self-hosted-json-parse.mts
+++ b/scripts/proof/provider-self-hosted-json-parse.mts
@@ -18,7 +18,9 @@ const server = createServer((req, res) => {
   res.end("not found");
 });
 
-await new Promise<void>((resolve) => server.listen(PORT, HOST, resolve));
+await new Promise<void>((resolve) => {
+  server.listen(PORT, HOST, resolve);
+});
 const address = server.address();
 if (address === null || typeof address === "string") {
   throw new Error("server did not bind to a TCP port");

--- a/src/plugins/provider-self-hosted-setup.test.ts
+++ b/src/plugins/provider-self-hosted-setup.test.ts
@@ -6,9 +6,16 @@ import {
 } from "./provider-self-hosted-setup.js";
 import type { ProviderAuthMethodNonInteractiveContext } from "./types.js";
 
-const { fetchWithSsrFGuardMock, upsertAuthProfileWithLock } = vi.hoisted(() => ({
+const { fetchWithSsrFGuardMock, upsertAuthProfileWithLock, mockedLogger } = vi.hoisted(() => ({
   fetchWithSsrFGuardMock: vi.fn(),
   upsertAuthProfileWithLock: vi.fn(async () => null),
+  mockedLogger: {
+    info: vi.fn<(msg: string) => void>(),
+    warn: vi.fn<(msg: string) => void>(),
+    error: vi.fn<(msg: string) => void>(),
+    debug: vi.fn<(msg: string) => void>(),
+    child: vi.fn(() => mockedLogger),
+  },
 }));
 
 vi.mock("../infra/net/fetch-guard.js", () => ({
@@ -17,6 +24,10 @@ vi.mock("../infra/net/fetch-guard.js", () => ({
 
 vi.mock("../agents/auth-profiles/upsert-with-lock.js", () => ({
   upsertAuthProfileWithLock,
+}));
+
+vi.mock("../logging/subsystem.js", () => ({
+  createSubsystemLogger: () => mockedLogger,
 }));
 
 beforeEach(() => {
@@ -655,5 +666,9 @@ describe("configureOpenAICompatibleSelfHostedProviderNonInteractive", () => {
 
     // Malformed JSON is caught and a warning is logged; discovery returns an empty list.
     expect(models).toEqual([]);
+    expect(mockedLogger.warn).toHaveBeenCalledTimes(1);
+    expect(mockedLogger.warn).toHaveBeenLastCalledWith(
+      expect.stringContaining("malformed-test discovery response is not valid JSON"),
+    );
   });
 });

--- a/src/plugins/provider-self-hosted-setup.test.ts
+++ b/src/plugins/provider-self-hosted-setup.test.ts
@@ -636,4 +636,24 @@ describe("configureOpenAICompatibleSelfHostedProviderNonInteractive", () => {
     expect(ctx.resolveApiKey).not.toHaveBeenCalled();
     expect(upsertAuthProfileWithLock).not.toHaveBeenCalled();
   });
+
+  it("wraps malformed discovery JSON with a descriptive error", async () => {
+    fetchWithSsrFGuardMock.mockResolvedValueOnce({
+      response: new Response("not valid json {", {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      }),
+      finalUrl: "http://127.0.0.1:8080/v1/models",
+      release: vi.fn(async () => undefined),
+    });
+
+    const models = await discoverOpenAICompatibleLocalModels({
+      baseUrl: "http://127.0.0.1:8080/v1",
+      label: "malformed-test",
+      env: {},
+    });
+
+    // Malformed JSON is caught and a warning is logged; discovery returns an empty list.
+    expect(models).toEqual([]);
+  });
 });

--- a/src/plugins/provider-self-hosted-setup.ts
+++ b/src/plugins/provider-self-hosted-setup.ts
@@ -105,7 +105,11 @@ async function readSelfHostedDiscoveryJson(response: Response, label: string): P
         `${label} discovery response body too large: ${size} bytes (limit: ${maxBytes} bytes)`,
       ),
   });
-  return JSON.parse(new TextDecoder().decode(bytes));
+  try {
+    return JSON.parse(new TextDecoder().decode(bytes)) as unknown;
+  } catch (cause) {
+    throw new Error(`${label} discovery response is not valid JSON`, { cause });
+  }
 }
 
 async function cancelUnreadResponseBody(response: Response): Promise<void> {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where a self-hosted provider discovery endpoint returning malformed JSON would produce a raw `SyntaxError` without identifying which endpoint failed. This made it hard for operators and developers to diagnose which local or self-hosted provider returned bad data during setup or model discovery.

## Why This Change Was Made

Wrapped `JSON.parse` inside `readSelfHostedDiscoveryJson` with a `try/catch` that rethrows an `Error` carrying the endpoint label (e.g. `ollama discovery response is not valid JSON`) and the original parse failure as `cause`. The change is scoped to the shared discovery helper so both `/models` and llama.cpp `/props` discovery benefit from the same diagnostic.

## User Impact

When a self-hosted provider returns non-JSON or malformed JSON during discovery, the resulting warning/error now names the provider endpoint instead of surfacing only a bare `SyntaxError`, speeding up diagnosis.

## Evidence

**Real environment tested**: Linux, Node 22, branch `fix/provider-self-hosted-setup-json-parse`

**Proof command**:
```bash
node_modules/.bin/tsx scripts/proof/provider-self-hosted-json-parse.mts
```

**Proof output**:
```
=== Proof: self-hosted provider malformed discovery JSON ===

Endpoint: http://127.0.0.1:44995/v1/models
Response body: not valid json {

[plugins/self-hosted-provider-setup] Failed to discover malformed-test models: Error: malformed-test discovery response is not valid JSON
Discovered models: []

PASS: malformed discovery JSON is caught and discovery returns an empty list.
```

**Regression test**:
```bash
node scripts/run-vitest.mjs src/plugins/provider-self-hosted-setup.test.ts
```

```
 Test Files  1 passed (1)
      Tests  13 passed (13)
```

The regression test "wraps malformed discovery JSON with a descriptive error" asserts that the logged warning contains `malformed-test discovery response is not valid JSON`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
Co-Authored-By: Claude <noreply@anthropic.com>
