### PR TITLE
fix(gateway): wrap live-probe JSON.parse calls in try/catch

### DIFF
--- a/scripts/proof/live-probe-json-parse.mts
+++ b/scripts/proof/live-probe-json-parse.mts
@@ -16,7 +16,9 @@ const server = createServer((_request, response) => {
   response.end("not valid json {");
 });
 
-await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+await new Promise<void>((resolve) => {
+  server.listen(0, "127.0.0.1", resolve);
+});
 const address = server.address();
 if (address === null || typeof address === "string") {
   throw new Error("server did not bind to a TCP port");

--- a/scripts/proof/live-probe-json-parse.mts
+++ b/scripts/proof/live-probe-json-parse.mts
@@ -1,0 +1,56 @@
+// Real behavior proof: malformed MCP loopback JSON-RPC response handling.
+// Starts a local HTTP server that returns invalid JSON on /mcp, then runs
+// OpenClaw's live-probe helper against it and captures the contextual error.
+
+import { createServer } from "node:http";
+import {
+  clearActiveMcpLoopbackRuntimeByOwnerToken,
+  setActiveMcpLoopbackRuntime,
+} from "../../src/gateway/mcp-http.loopback-runtime.js";
+import { verifyCliCronMcpLoopbackPreflight } from "../../src/gateway/gateway-cli-backend.live-probe-helpers.js";
+
+const ownerToken = "proof-owner-token";
+
+const server = createServer((_request, response) => {
+  response.writeHead(200, { "content-type": "application/json" });
+  response.end("not valid json {");
+});
+
+await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+const address = server.address();
+if (address === null || typeof address === "string") {
+  throw new Error("server did not bind to a TCP port");
+}
+
+setActiveMcpLoopbackRuntime({
+  port: address.port,
+  ownerToken,
+  nonOwnerToken: "proof-non-owner-token",
+});
+
+console.log("=== Proof: live-probe helpers JSON.parse hardening ===\n");
+console.log(`Loopback endpoint: http://127.0.0.1:${address.port}/mcp`);
+console.log("Response body: not valid json {\n");
+
+try {
+  await verifyCliCronMcpLoopbackPreflight({
+    sessionKey: "proof-session-key",
+    port: address.port,
+    token: "proof-gateway-token",
+    env: {},
+  });
+  console.log("FAIL: expected verifyCliCronMcpLoopbackPreflight to throw");
+  process.exitCode = 1;
+} catch (error) {
+  const message = error instanceof Error ? error.message : String(error);
+  if (message.includes("mcp loopback returned malformed JSON")) {
+    console.log(`Caught expected error: ${message}`);
+    console.log("\nPASS: malformed loopback JSON produces contextual error.");
+  } else {
+    console.log(`FAIL: unexpected error: ${message}`);
+    process.exitCode = 1;
+  }
+} finally {
+  clearActiveMcpLoopbackRuntimeByOwnerToken(ownerToken);
+  server.close();
+}

--- a/src/gateway/gateway-cli-backend.live-probe-helpers.test.ts
+++ b/src/gateway/gateway-cli-backend.live-probe-helpers.test.ts
@@ -148,4 +148,20 @@ describe("gateway CLI backend live probe helpers", () => {
       server.close();
     }
   });
+
+  it("wraps malformed loopback JSON-RPC responses with a contextual error", async () => {
+    const server = createHttpServer((_request, response) => {
+      response.writeHead(200, { "content-type": "application/json" });
+      response.end("not valid json {");
+    });
+    const port = await listen(server);
+    activateLoopbackRuntime(port);
+    try {
+      await expect(verifyCliCronMcpLoopbackPreflight(preflightParams())).rejects.toThrow(
+        "mcp loopback returned malformed JSON",
+      );
+    } finally {
+      server.close();
+    }
+  });
 });

--- a/src/gateway/gateway-cli-backend.live-probe-helpers.ts
+++ b/src/gateway/gateway-cli-backend.live-probe-helpers.ts
@@ -234,7 +234,12 @@ async function callLoopbackJsonRpc(params: {
   if (!text.trim()) {
     return {};
   }
-  const parsed = JSON.parse(text) as LoopbackJsonRpcResponse;
+  let parsed: LoopbackJsonRpcResponse;
+  try {
+    parsed = JSON.parse(text) as LoopbackJsonRpcResponse;
+  } catch (cause) {
+    throw new Error("mcp loopback returned malformed JSON", { cause });
+  }
   if (parsed.error?.message) {
     throw new Error(`mcp loopback json-rpc error: ${parsed.error.message}`);
   }
@@ -261,6 +266,14 @@ async function readBoundedResponseText(response: Response, byteLimit: number): P
     chunks.push(Buffer.from(value));
   }
   return Buffer.concat(chunks, totalBytes).toString("utf8");
+}
+
+function parseCronProbeArgs(raw: string): Record<string, unknown> {
+  try {
+    return JSON.parse(raw) as Record<string, unknown>;
+  } catch (cause) {
+    throw new Error("cron probe argsJson is not valid JSON", { cause });
+  }
 }
 
 export async function verifyCliCronMcpLoopbackPreflight(params: {
@@ -333,7 +346,7 @@ export async function verifyCliCronMcpLoopbackPreflight(params: {
       method: "tools/call",
       params: {
         name: "cron",
-        arguments: JSON.parse(cronProbe.argsJson) as Record<string, unknown>,
+        arguments: parseCronProbeArgs(cronProbe.argsJson),
       },
     },
   });


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where gateway live-probe helpers parsed MCP loopback JSON-RPC responses and cron probe `argsJson` with bare `JSON.parse`, so malformed data produced a raw `SyntaxError` without identifying which probe path failed. This made gateway live-preflight failures harder to diagnose.

## Why This Change Was Made

Wrapped both JSON.parse sites in `src/gateway/gateway-cli-backend.live-probe-helpers.ts` with `try/catch` blocks that throw contextual errors (`mcp loopback returned malformed JSON` and `cron probe argsJson is not valid JSON`) while preserving the original parse error as `cause`.

## User Impact

Operators running gateway live probes now get clear, path-specific diagnostics when a probe response or cron argument payload is malformed, instead of an unlabeled `SyntaxError`.

## Evidence

**Real environment tested**: Linux, Node 22, branch `fix/live-probe-helpers-json-parse`

**Proof command** (malformed MCP loopback response):
```bash
node_modules/.bin/tsx scripts/proof/live-probe-json-parse.mts
```

**Proof output**:
```
=== Proof: live-probe helpers JSON.parse hardening ===

Loopback endpoint: http://127.0.0.1:46299/mcp
Response body: not valid json {

Caught expected error: mcp loopback returned malformed JSON

PASS: malformed loopback JSON produces contextual error.
```

The proof starts a real local HTTP server, registers it as the active MCP loopback runtime, and calls `verifyCliCronMcpLoopbackPreflight`, which rejects with the contextual error above.

**Regression test**:
```bash
node scripts/run-vitest.mjs src/gateway/gateway-cli-backend.live-probe-helpers.test.ts
```

```
 Test Files  3 passed (3)
      Tests  12 passed (12)
```

New test "wraps malformed loopback JSON-RPC responses with a contextual error" verifies the malformed response path raises `mcp loopback returned malformed JSON`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
Co-Authored-By: Claude <noreply@anthropic.com>
