### PR TITLE
fix(plugins): stage git plugin clone on target filesystem to avoid EXDEV

### DIFF
--- a/src/infra/install-source-utils.ts
+++ b/src/infra/install-source-utils.ts
@@ -135,12 +135,23 @@ export type NpmIntegrityDrift = {
   actualIntegrity: string;
 };
 
-/** Runs a callback in a private temp directory and removes it afterward. */
+/**
+ * Runs a callback in a private temp directory and removes it afterward.
+ *
+ * By default the temp directory is created under `os.tmpdir()`. Callers that
+ * later move the staged result into a persistent location with an atomic
+ * `rename()` should pass `rootDir` pointing at (a directory on) the same
+ * filesystem as that destination. Otherwise the rename can fail with `EXDEV`
+ * ("cross-device link not permitted") when `/tmp` and the destination live on
+ * different mounts — common in containers with bind-mounted state dirs.
+ */
 export async function withTempDir<T>(
   prefix: string,
   fn: (tmpDir: string) => Promise<T>,
+  options?: { rootDir?: string },
 ): Promise<T> {
-  return await withTempWorkspace({ rootDir: os.tmpdir(), prefix }, async (tmp) => fn(tmp.dir));
+  const rootDir = options?.rootDir ?? os.tmpdir();
+  return await withTempWorkspace({ rootDir, prefix }, async (tmp) => fn(tmp.dir));
 }
 
 /** Resolves and validates a user-supplied archive path before extraction. */

--- a/src/infra/install-source-utils.ts
+++ b/src/infra/install-source-utils.ts
@@ -135,16 +135,7 @@ export type NpmIntegrityDrift = {
   actualIntegrity: string;
 };
 
-/**
- * Runs a callback in a private temp directory and removes it afterward.
- *
- * By default the temp directory is created under `os.tmpdir()`. Callers that
- * later move the staged result into a persistent location with an atomic
- * `rename()` should pass `rootDir` pointing at (a directory on) the same
- * filesystem as that destination. Otherwise the rename can fail with `EXDEV`
- * ("cross-device link not permitted") when `/tmp` and the destination live on
- * different mounts — common in containers with bind-mounted state dirs.
- */
+/** Runs a callback in a private temp directory and removes it afterward. */
 export async function withTempDir<T>(
   prefix: string,
   fn: (tmpDir: string) => Promise<T>,

--- a/src/plugins/git-install.test.ts
+++ b/src/plugins/git-install.test.ts
@@ -486,6 +486,47 @@ describe("installPluginFromGitSpec", () => {
     }
   });
 
+  it("stages the clone under the managed git dir so replacement never crosses filesystems (#99885)", async () => {
+    const gitDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-git-install-stage-"));
+    try {
+      runCommandWithTimeoutMock
+        .mockResolvedValueOnce({ code: 0, stdout: "", stderr: "" })
+        .mockResolvedValueOnce({ code: 0, stdout: "abc123\n", stderr: "" })
+        .mockResolvedValueOnce({ code: 0, stdout: "", stderr: "" });
+      installPluginFromInstalledPackageDirMock.mockImplementation(
+        async (params: { packageDir: string }) => {
+          await fs.mkdir(params.packageDir, { recursive: true });
+          return {
+            ok: true,
+            pluginId: "demo",
+            targetDir: params.packageDir,
+            version: "1.2.3",
+            extensions: ["index.js"],
+          };
+        },
+      );
+
+      const result = await installPluginFromGitSpec({
+        spec: "git:github.com/acme/demo",
+        gitDir,
+      });
+      expect(result.ok).toBe(true);
+      if (!result.ok) {
+        throw new Error(result.error);
+      }
+
+      // The clone destination must live under the resolved managed git dir, not
+      // os.tmpdir(). Staging elsewhere makes the final atomic rename into the
+      // persistent repo cross filesystems and fail with EXDEV in containers.
+      const cloneArgv = commandArgvAt(0);
+      const cloneDest = cloneArgv[cloneArgv.length - 1];
+      const resolvedGitDir = path.resolve(gitDir);
+      expect(path.resolve(cloneDest).startsWith(resolvedGitDir)).toBe(true);
+    } finally {
+      await fs.rm(gitDir, { recursive: true, force: true });
+    }
+  });
+
   it("uses a credential-free managed repo path for authenticated git URLs", async () => {
     const gitDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-git-install-path-"));
     try {

--- a/src/plugins/git-install.test.ts
+++ b/src/plugins/git-install.test.ts
@@ -5,6 +5,7 @@ import os from "node:os";
 import path from "node:path";
 import { redactSensitiveUrlLikeString } from "@openclaw/net-policy/redact-sensitive-url";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
 import type { DiagnosticSecurityEvent } from "../infra/diagnostic-events.js";
 
 const runCommandWithTimeoutMock = vi.fn();
@@ -145,6 +146,7 @@ describe("isImmutableGitCommitRef", () => {
 
 describe("installPluginFromGitSpec", () => {
   const tempDirs: string[] = [];
+  const trackedTempDirs = useAutoCleanupTempDirTracker(afterEach);
 
   beforeEach(async () => {
     runCommandWithTimeoutMock.mockReset();
@@ -486,8 +488,8 @@ describe("installPluginFromGitSpec", () => {
     }
   });
 
-  it("stages the clone under the managed git dir so replacement never crosses filesystems (#99885)", async () => {
-    const gitDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-git-install-stage-"));
+  it("stages the clone beside the managed repo so replacement stays on one filesystem (#99885)", async () => {
+    const gitDir = trackedTempDirs.make("openclaw-git-install-stage-");
     try {
       runCommandWithTimeoutMock
         .mockResolvedValueOnce({ code: 0, stdout: "", stderr: "" })
@@ -515,15 +517,94 @@ describe("installPluginFromGitSpec", () => {
         throw new Error(result.error);
       }
 
-      // The clone destination must live under the resolved managed git dir, not
-      // os.tmpdir(). Staging elsewhere makes the final atomic rename into the
-      // persistent repo cross filesystems and fail with EXDEV in containers.
       const cloneArgv = commandArgvAt(0);
       const cloneDest = cloneArgv[cloneArgv.length - 1];
-      const resolvedGitDir = path.resolve(gitDir);
-      expect(path.resolve(cloneDest).startsWith(resolvedGitDir)).toBe(true);
+      const persistentRepoDir = expectedGitRepoDir({
+        gitDir,
+        normalizedSpec: "git:https://github.com/acme/demo.git",
+      });
+      const cloneParent = await fs.realpath(path.dirname(path.dirname(path.resolve(cloneDest))));
+      const targetParent = await fs.realpath(path.dirname(persistentRepoDir));
+      expect(cloneParent).toBe(targetParent);
     } finally {
       await fs.rm(gitDir, { recursive: true, force: true });
+    }
+  });
+
+  it("falls back to OS temp when target workspace creation fails", async () => {
+    const gitDir = trackedTempDirs.make("openclaw-git-install-stage-fallback-");
+    runCommandWithTimeoutMock
+      .mockResolvedValueOnce({ code: 0, stdout: "", stderr: "" })
+      .mockResolvedValueOnce({ code: 0, stdout: "abc123\n", stderr: "" })
+      .mockResolvedValueOnce({ code: 0, stdout: "", stderr: "" });
+    installPluginFromInstalledPackageDirMock.mockImplementation(
+      async (params: { packageDir: string }) => {
+        await fs.mkdir(params.packageDir, { recursive: true });
+        return {
+          ok: true,
+          pluginId: "demo",
+          targetDir: params.packageDir,
+          version: "1.2.3",
+          extensions: ["index.js"],
+        };
+      },
+    );
+    const mkdtempSpy = vi
+      .spyOn(fs, "mkdtemp")
+      .mockRejectedValueOnce(Object.assign(new Error("read-only filesystem"), { code: "EROFS" }));
+
+    try {
+      const result = await installPluginFromGitSpec({
+        spec: "git:github.com/acme/demo",
+        gitDir,
+      });
+
+      expect(result.ok).toBe(true);
+      expect(mkdtempSpy).toHaveBeenCalledTimes(2);
+      const targetPrefix = mkdtempSpy.mock.calls[0]?.[0];
+      const fallbackPrefix = mkdtempSpy.mock.calls[1]?.[0];
+      const persistentRepoDir = expectedGitRepoDir({
+        gitDir,
+        normalizedSpec: "git:https://github.com/acme/demo.git",
+      });
+      expect(path.dirname(targetPrefix)).toBe(await fs.realpath(path.dirname(persistentRepoDir)));
+      expect(path.dirname(fallbackPrefix)).toBe(await fs.realpath(os.tmpdir()));
+      expect(runCommandWithTimeoutMock).toHaveBeenCalledTimes(3);
+    } finally {
+      mkdtempSpy.mockRestore();
+    }
+  });
+
+  it("keeps dry-run clone staging out of managed state", async () => {
+    const caseDir = trackedTempDirs.make("openclaw-git-dry-run-stage-");
+    const gitDir = path.join(caseDir, "git");
+    try {
+      runCommandWithTimeoutMock
+        .mockResolvedValueOnce({ code: 0, stdout: "", stderr: "" })
+        .mockResolvedValueOnce({ code: 0, stdout: "abc123\n", stderr: "" });
+      installPluginFromInstalledPackageDirMock.mockImplementation(
+        async (params: { packageDir: string }) => ({
+          ok: true,
+          pluginId: "demo",
+          targetDir: params.packageDir,
+          version: "1.2.3",
+          extensions: ["index.js"],
+        }),
+      );
+
+      const result = await installPluginFromGitSpec({
+        spec: "git:github.com/acme/demo",
+        gitDir,
+        dryRun: true,
+      });
+
+      expect(result.ok).toBe(true);
+      const cloneArgv = commandArgvAt(0);
+      const cloneDest = path.resolve(cloneArgv[cloneArgv.length - 1]);
+      expect(path.relative(gitDir, cloneDest).split(path.sep)[0]).toBe("..");
+      await expect(fs.access(gitDir)).rejects.toThrow();
+    } finally {
+      await fs.rm(caseDir, { recursive: true, force: true });
     }
   });
 

--- a/src/plugins/git-install.ts
+++ b/src/plugins/git-install.ts
@@ -242,21 +242,37 @@ function resolveGitInstallRepoDir(params: {
   return path.join(gitRoot, `git-${sha256HexPrefix(redactedSpec, 16)}`, "repo");
 }
 
-/**
- * Chooses a staging root for the transient clone. Prefers the managed git root
- * (the parent of `git-<hash>/repo`) so the final atomic rename into the
- * persistent repo stays on the same filesystem — otherwise a `/tmp` vs
- * `~/.openclaw` mount split surfaces as EXDEV on rename (#99885). Falls back to
- * the OS temp dir if the managed root cannot be prepared, preserving the prior
- * behavior instead of failing the install outright.
- */
-async function resolveGitStagingRoot(persistentRepoDir: string): Promise<string | undefined> {
-  const managedRoot = path.dirname(path.dirname(persistentRepoDir));
+async function withGitStagingDir<T>(
+  persistentRepoDir: string | undefined,
+  fn: (tmpDir: string) => Promise<T>,
+): Promise<T> {
+  if (!persistentRepoDir) {
+    return await withTempDir("openclaw-git-plugin-", fn);
+  }
+  const targetParent = path.dirname(persistentRepoDir);
   try {
-    await fs.mkdir(managedRoot, { recursive: true });
-    return managedRoot;
+    await fs.mkdir(targetParent, { recursive: true });
   } catch {
-    return undefined;
+    return await withTempDir("openclaw-git-plugin-", fn);
+  }
+
+  let callbackStarted = false;
+  try {
+    return await withTempDir(
+      "openclaw-git-plugin-",
+      async (tmpDir) => {
+        callbackStarted = true;
+        return await fn(tmpDir);
+      },
+      { rootDir: targetParent },
+    );
+  } catch (err) {
+    // Workspace creation can fail on read-only mounts. Never retry after the
+    // callback starts, because that could clone or install dependencies twice.
+    if (callbackStarted) {
+      throw err;
+    }
+    return await withTempDir("openclaw-git-plugin-", fn);
   }
 }
 
@@ -354,162 +370,154 @@ export async function installPluginFromGitSpec(
   const persistentRepoDir = resolveGitInstallRepoDir({ gitDir: params.gitDir, source: parsed });
   const effectiveMode =
     params.mode === "update" && (await pathExists(persistentRepoDir)) ? "update" : "install";
-  // Stage the clone under the managed git root (parent of `git-<hash>/repo`) so
-  // that the final atomic rename into `persistentRepoDir` stays on the same
-  // filesystem. Using `os.tmpdir()` here breaks in containers where `/tmp` and
-  // `~/.openclaw` are separate mounts, surfacing as EXDEV on rename (#99885).
-  const stagingRoot = await resolveGitStagingRoot(persistentRepoDir);
-  return await withTempDir(
-    "openclaw-git-plugin-",
-    async (tmpDir) => {
-      const repoDir = path.join(tmpDir, "repo");
-      params.logger?.info?.(
-        `Cloning ${sanitizeForLog(redactSensitiveUrlLikeString(parsed.label))}...`,
-      );
-      const cloneArgs = parsed.ref
-        ? ["git", "clone", parsed.url, repoDir]
-        : ["git", "clone", "--depth", "1", parsed.url, repoDir];
-      const clone = await runGitCommand({
-        argv: cloneArgs,
-        action: "clone",
-        source: parsed,
-        timeoutMs: params.timeoutMs,
-      });
-      if (!clone.ok) {
-        return clone;
-      }
+  const stagingRepoDir = params.dryRun ? undefined : persistentRepoDir;
+  return await withGitStagingDir(stagingRepoDir, async (tmpDir) => {
+    const repoDir = path.join(tmpDir, "repo");
+    params.logger?.info?.(
+      `Cloning ${sanitizeForLog(redactSensitiveUrlLikeString(parsed.label))}...`,
+    );
+    const cloneArgs = parsed.ref
+      ? ["git", "clone", parsed.url, repoDir]
+      : ["git", "clone", "--depth", "1", parsed.url, repoDir];
+    const clone = await runGitCommand({
+      argv: cloneArgs,
+      action: "clone",
+      source: parsed,
+      timeoutMs: params.timeoutMs,
+    });
+    if (!clone.ok) {
+      return clone;
+    }
 
-      if (parsed.ref) {
-        const checkout = await runGitCommand({
-          argv: ["git", "switch", "--detach", "--", parsed.ref],
-          action: `checkout ${parsed.ref}`,
-          source: parsed,
-          cwd: repoDir,
-          timeoutMs: params.timeoutMs,
-        });
-        if (!checkout.ok) {
-          return checkout;
-        }
-      }
-
-      const rev = await runGitCommand({
-        argv: ["git", "rev-parse", "HEAD"],
-        action: "resolve commit for",
+    if (parsed.ref) {
+      const checkout = await runGitCommand({
+        argv: ["git", "switch", "--detach", "--", parsed.ref],
+        action: `checkout ${parsed.ref}`,
         source: parsed,
         cwd: repoDir,
         timeoutMs: params.timeoutMs,
       });
-      if (!rev.ok) {
-        return rev;
+      if (!checkout.ok) {
+        return checkout;
       }
+    }
 
-      const installPolicyRequest = {
-        kind: "plugin-git" as const,
-        requestedSpecifier: parsed.input,
-        source: {
-          kind: "git" as const,
-          authority: "third-party" as const,
-          mutable: !isImmutableGitCommitRef(parsed.ref),
-          network: true,
-        },
-      };
-      const preflight = await preflightPluginGitInstallPolicy({
-        config: params.config,
-        logger: params.logger ?? {},
+    const rev = await runGitCommand({
+      argv: ["git", "rev-parse", "HEAD"],
+      action: "resolve commit for",
+      source: parsed,
+      cwd: repoDir,
+      timeoutMs: params.timeoutMs,
+    });
+    if (!rev.ok) {
+      return rev;
+    }
+
+    const installPolicyRequest = {
+      kind: "plugin-git" as const,
+      requestedSpecifier: parsed.input,
+      source: {
+        kind: "git" as const,
+        authority: "third-party" as const,
+        mutable: !isImmutableGitCommitRef(parsed.ref),
+        network: true,
+      },
+    };
+    const preflight = await preflightPluginGitInstallPolicy({
+      config: params.config,
+      logger: params.logger ?? {},
+      mode: effectiveMode,
+      pluginId: params.expectedPluginId ?? parsed.label,
+      requestedSpecifier: parsed.input,
+      source: installPolicyRequest.source,
+      sourcePath: repoDir,
+    });
+    if (preflight?.blocked) {
+      const reason =
+        preflight.blocked.code === "security_scan_failed"
+          ? "security_scan_failed"
+          : "security_scan_blocked";
+      emitPluginAuditSecurityEvent({
+        outcome: pluginAuditOutcomeForReason(reason),
+        reason,
+        pluginId: params.expectedPluginId,
         mode: effectiveMode,
-        pluginId: params.expectedPluginId ?? parsed.label,
-        requestedSpecifier: parsed.input,
-        source: installPolicyRequest.source,
-        sourcePath: repoDir,
+        sourceFamily: "git",
       });
-      if (preflight?.blocked) {
-        const reason =
-          preflight.blocked.code === "security_scan_failed"
-            ? "security_scan_failed"
-            : "security_scan_blocked";
-        emitPluginAuditSecurityEvent({
-          outcome: pluginAuditOutcomeForReason(reason),
-          reason,
-          pluginId: params.expectedPluginId,
-          mode: effectiveMode,
-          sourceFamily: "git",
-        });
-        return buildBlockedGitInstallResult({ blocked: preflight.blocked });
-      }
+      return buildBlockedGitInstallResult({ blocked: preflight.blocked });
+    }
 
-      if (!params.dryRun) {
-        params.logger?.info?.("Installing plugin dependencies with npm…");
-        const install = await runCommandWithTimeout(
-          [
-            "npm",
-            ...createSafeNpmInstallArgs({
-              omitDev: true,
-              loglevel: "error",
-              noAudit: true,
-              noFund: true,
-            }),
-          ],
-          {
-            cwd: repoDir,
-            timeoutMs: Math.max(params.timeoutMs ?? DEFAULT_GIT_TIMEOUT_MS, 300_000),
-            env: createSafeNpmInstallEnv(process.env, {
-              npmConfigCwd: repoDir,
-              packageLock: true,
-              quiet: true,
-            }),
-          },
-        );
-        if (install.code !== 0) {
-          return {
-            ok: false,
-            error: `npm install failed: ${install.stderr.trim() || install.stdout.trim()}`,
-          };
-        }
-      }
-
-      const result = await installPluginFromInstalledPackageDir({
-        dangerouslyForceUnsafeInstall: params.dangerouslyForceUnsafeInstall,
-        config: params.config,
-        packageDir: repoDir,
-        dryRun: params.dryRun,
-        expectedPluginId: params.expectedPluginId,
-        logger: params.logger,
-        mode: effectiveMode,
-        emitSuccessSecurityEvent: false,
-        installPolicyRequest,
-      });
-      if (!result.ok) {
-        return result;
-      }
-      if (!params.dryRun) {
-        const replaceResult = await replaceManagedGitRepo({
-          stagedRepoDir: repoDir,
-          persistentRepoDir,
-        });
-        if (!replaceResult.ok) {
-          return replaceResult;
-        }
-        emitPluginInstallSecurityEvent({
-          pluginId: result.pluginId,
-          mode: effectiveMode,
-          sourceFamily: "git",
-          extensionCount: result.extensions.length,
-          hasVersion: Boolean(result.version),
-          trustedSourceLinkedOfficialInstall: params.trustedSourceLinkedOfficialInstall,
-        });
-      }
-
-      return {
-        ...result,
-        targetDir: params.dryRun ? result.targetDir : persistentRepoDir,
-        git: {
-          url: parsed.url,
-          ref: parsed.ref,
-          commit: normalizeOptionalString(rev.stdout),
-          resolvedAt: new Date().toISOString(),
+    if (!params.dryRun) {
+      params.logger?.info?.("Installing plugin dependencies with npm…");
+      const install = await runCommandWithTimeout(
+        [
+          "npm",
+          ...createSafeNpmInstallArgs({
+            omitDev: true,
+            loglevel: "error",
+            noAudit: true,
+            noFund: true,
+          }),
+        ],
+        {
+          cwd: repoDir,
+          timeoutMs: Math.max(params.timeoutMs ?? DEFAULT_GIT_TIMEOUT_MS, 300_000),
+          env: createSafeNpmInstallEnv(process.env, {
+            npmConfigCwd: repoDir,
+            packageLock: true,
+            quiet: true,
+          }),
         },
-      };
-    },
-    stagingRoot ? { rootDir: stagingRoot } : undefined,
-  );
+      );
+      if (install.code !== 0) {
+        return {
+          ok: false,
+          error: `npm install failed: ${install.stderr.trim() || install.stdout.trim()}`,
+        };
+      }
+    }
+
+    const result = await installPluginFromInstalledPackageDir({
+      dangerouslyForceUnsafeInstall: params.dangerouslyForceUnsafeInstall,
+      config: params.config,
+      packageDir: repoDir,
+      dryRun: params.dryRun,
+      expectedPluginId: params.expectedPluginId,
+      logger: params.logger,
+      mode: effectiveMode,
+      emitSuccessSecurityEvent: false,
+      installPolicyRequest,
+    });
+    if (!result.ok) {
+      return result;
+    }
+    if (!params.dryRun) {
+      const replaceResult = await replaceManagedGitRepo({
+        stagedRepoDir: repoDir,
+        persistentRepoDir,
+      });
+      if (!replaceResult.ok) {
+        return replaceResult;
+      }
+      emitPluginInstallSecurityEvent({
+        pluginId: result.pluginId,
+        mode: effectiveMode,
+        sourceFamily: "git",
+        extensionCount: result.extensions.length,
+        hasVersion: Boolean(result.version),
+        trustedSourceLinkedOfficialInstall: params.trustedSourceLinkedOfficialInstall,
+      });
+    }
+
+    return {
+      ...result,
+      targetDir: params.dryRun ? result.targetDir : persistentRepoDir,
+      git: {
+        url: parsed.url,
+        ref: parsed.ref,
+        commit: normalizeOptionalString(rev.stdout),
+        resolvedAt: new Date().toISOString(),
+      },
+    };
+  });
 }

--- a/src/plugins/git-install.ts
+++ b/src/plugins/git-install.ts
@@ -1,5 +1,6 @@
 /** Parses, clones, verifies, and installs plugin packages from Git specs. */
 import "../infra/fs-safe-defaults.js";
+import fs from "node:fs/promises";
 import path from "node:path";
 import { redactSensitiveUrlLikeString } from "@openclaw/net-policy/redact-sensitive-url";
 import { hasHttpUrlPrefix } from "@openclaw/net-policy/url-protocol";
@@ -241,6 +242,24 @@ function resolveGitInstallRepoDir(params: {
   return path.join(gitRoot, `git-${sha256HexPrefix(redactedSpec, 16)}`, "repo");
 }
 
+/**
+ * Chooses a staging root for the transient clone. Prefers the managed git root
+ * (the parent of `git-<hash>/repo`) so the final atomic rename into the
+ * persistent repo stays on the same filesystem — otherwise a `/tmp` vs
+ * `~/.openclaw` mount split surfaces as EXDEV on rename (#99885). Falls back to
+ * the OS temp dir if the managed root cannot be prepared, preserving the prior
+ * behavior instead of failing the install outright.
+ */
+async function resolveGitStagingRoot(persistentRepoDir: string): Promise<string | undefined> {
+  const managedRoot = path.dirname(path.dirname(persistentRepoDir));
+  try {
+    await fs.mkdir(managedRoot, { recursive: true });
+    return managedRoot;
+  } catch {
+    return undefined;
+  }
+}
+
 async function replaceManagedGitRepo(params: {
   stagedRepoDir: string;
   persistentRepoDir: string;
@@ -335,153 +354,162 @@ export async function installPluginFromGitSpec(
   const persistentRepoDir = resolveGitInstallRepoDir({ gitDir: params.gitDir, source: parsed });
   const effectiveMode =
     params.mode === "update" && (await pathExists(persistentRepoDir)) ? "update" : "install";
-  return await withTempDir("openclaw-git-plugin-", async (tmpDir) => {
-    const repoDir = path.join(tmpDir, "repo");
-    params.logger?.info?.(
-      `Cloning ${sanitizeForLog(redactSensitiveUrlLikeString(parsed.label))}...`,
-    );
-    const cloneArgs = parsed.ref
-      ? ["git", "clone", parsed.url, repoDir]
-      : ["git", "clone", "--depth", "1", parsed.url, repoDir];
-    const clone = await runGitCommand({
-      argv: cloneArgs,
-      action: "clone",
-      source: parsed,
-      timeoutMs: params.timeoutMs,
-    });
-    if (!clone.ok) {
-      return clone;
-    }
+  // Stage the clone under the managed git root (parent of `git-<hash>/repo`) so
+  // that the final atomic rename into `persistentRepoDir` stays on the same
+  // filesystem. Using `os.tmpdir()` here breaks in containers where `/tmp` and
+  // `~/.openclaw` are separate mounts, surfacing as EXDEV on rename (#99885).
+  const stagingRoot = await resolveGitStagingRoot(persistentRepoDir);
+  return await withTempDir(
+    "openclaw-git-plugin-",
+    async (tmpDir) => {
+      const repoDir = path.join(tmpDir, "repo");
+      params.logger?.info?.(
+        `Cloning ${sanitizeForLog(redactSensitiveUrlLikeString(parsed.label))}...`,
+      );
+      const cloneArgs = parsed.ref
+        ? ["git", "clone", parsed.url, repoDir]
+        : ["git", "clone", "--depth", "1", parsed.url, repoDir];
+      const clone = await runGitCommand({
+        argv: cloneArgs,
+        action: "clone",
+        source: parsed,
+        timeoutMs: params.timeoutMs,
+      });
+      if (!clone.ok) {
+        return clone;
+      }
 
-    if (parsed.ref) {
-      const checkout = await runGitCommand({
-        argv: ["git", "switch", "--detach", "--", parsed.ref],
-        action: `checkout ${parsed.ref}`,
+      if (parsed.ref) {
+        const checkout = await runGitCommand({
+          argv: ["git", "switch", "--detach", "--", parsed.ref],
+          action: `checkout ${parsed.ref}`,
+          source: parsed,
+          cwd: repoDir,
+          timeoutMs: params.timeoutMs,
+        });
+        if (!checkout.ok) {
+          return checkout;
+        }
+      }
+
+      const rev = await runGitCommand({
+        argv: ["git", "rev-parse", "HEAD"],
+        action: "resolve commit for",
         source: parsed,
         cwd: repoDir,
         timeoutMs: params.timeoutMs,
       });
-      if (!checkout.ok) {
-        return checkout;
+      if (!rev.ok) {
+        return rev;
       }
-    }
 
-    const rev = await runGitCommand({
-      argv: ["git", "rev-parse", "HEAD"],
-      action: "resolve commit for",
-      source: parsed,
-      cwd: repoDir,
-      timeoutMs: params.timeoutMs,
-    });
-    if (!rev.ok) {
-      return rev;
-    }
-
-    const installPolicyRequest = {
-      kind: "plugin-git" as const,
-      requestedSpecifier: parsed.input,
-      source: {
-        kind: "git" as const,
-        authority: "third-party" as const,
-        mutable: !isImmutableGitCommitRef(parsed.ref),
-        network: true,
-      },
-    };
-    const preflight = await preflightPluginGitInstallPolicy({
-      config: params.config,
-      logger: params.logger ?? {},
-      mode: effectiveMode,
-      pluginId: params.expectedPluginId ?? parsed.label,
-      requestedSpecifier: parsed.input,
-      source: installPolicyRequest.source,
-      sourcePath: repoDir,
-    });
-    if (preflight?.blocked) {
-      const reason =
-        preflight.blocked.code === "security_scan_failed"
-          ? "security_scan_failed"
-          : "security_scan_blocked";
-      emitPluginAuditSecurityEvent({
-        outcome: pluginAuditOutcomeForReason(reason),
-        reason,
-        pluginId: params.expectedPluginId,
-        mode: effectiveMode,
-        sourceFamily: "git",
-      });
-      return buildBlockedGitInstallResult({ blocked: preflight.blocked });
-    }
-
-    if (!params.dryRun) {
-      params.logger?.info?.("Installing plugin dependencies with npm…");
-      const install = await runCommandWithTimeout(
-        [
-          "npm",
-          ...createSafeNpmInstallArgs({
-            omitDev: true,
-            loglevel: "error",
-            noAudit: true,
-            noFund: true,
-          }),
-        ],
-        {
-          cwd: repoDir,
-          timeoutMs: Math.max(params.timeoutMs ?? DEFAULT_GIT_TIMEOUT_MS, 300_000),
-          env: createSafeNpmInstallEnv(process.env, {
-            npmConfigCwd: repoDir,
-            packageLock: true,
-            quiet: true,
-          }),
+      const installPolicyRequest = {
+        kind: "plugin-git" as const,
+        requestedSpecifier: parsed.input,
+        source: {
+          kind: "git" as const,
+          authority: "third-party" as const,
+          mutable: !isImmutableGitCommitRef(parsed.ref),
+          network: true,
         },
-      );
-      if (install.code !== 0) {
-        return {
-          ok: false,
-          error: `npm install failed: ${install.stderr.trim() || install.stdout.trim()}`,
-        };
-      }
-    }
-
-    const result = await installPluginFromInstalledPackageDir({
-      dangerouslyForceUnsafeInstall: params.dangerouslyForceUnsafeInstall,
-      config: params.config,
-      packageDir: repoDir,
-      dryRun: params.dryRun,
-      expectedPluginId: params.expectedPluginId,
-      logger: params.logger,
-      mode: effectiveMode,
-      emitSuccessSecurityEvent: false,
-      installPolicyRequest,
-    });
-    if (!result.ok) {
-      return result;
-    }
-    if (!params.dryRun) {
-      const replaceResult = await replaceManagedGitRepo({
-        stagedRepoDir: repoDir,
-        persistentRepoDir,
-      });
-      if (!replaceResult.ok) {
-        return replaceResult;
-      }
-      emitPluginInstallSecurityEvent({
-        pluginId: result.pluginId,
+      };
+      const preflight = await preflightPluginGitInstallPolicy({
+        config: params.config,
+        logger: params.logger ?? {},
         mode: effectiveMode,
-        sourceFamily: "git",
-        extensionCount: result.extensions.length,
-        hasVersion: Boolean(result.version),
-        trustedSourceLinkedOfficialInstall: params.trustedSourceLinkedOfficialInstall,
+        pluginId: params.expectedPluginId ?? parsed.label,
+        requestedSpecifier: parsed.input,
+        source: installPolicyRequest.source,
+        sourcePath: repoDir,
       });
-    }
+      if (preflight?.blocked) {
+        const reason =
+          preflight.blocked.code === "security_scan_failed"
+            ? "security_scan_failed"
+            : "security_scan_blocked";
+        emitPluginAuditSecurityEvent({
+          outcome: pluginAuditOutcomeForReason(reason),
+          reason,
+          pluginId: params.expectedPluginId,
+          mode: effectiveMode,
+          sourceFamily: "git",
+        });
+        return buildBlockedGitInstallResult({ blocked: preflight.blocked });
+      }
 
-    return {
-      ...result,
-      targetDir: params.dryRun ? result.targetDir : persistentRepoDir,
-      git: {
-        url: parsed.url,
-        ref: parsed.ref,
-        commit: normalizeOptionalString(rev.stdout),
-        resolvedAt: new Date().toISOString(),
-      },
-    };
-  });
+      if (!params.dryRun) {
+        params.logger?.info?.("Installing plugin dependencies with npm…");
+        const install = await runCommandWithTimeout(
+          [
+            "npm",
+            ...createSafeNpmInstallArgs({
+              omitDev: true,
+              loglevel: "error",
+              noAudit: true,
+              noFund: true,
+            }),
+          ],
+          {
+            cwd: repoDir,
+            timeoutMs: Math.max(params.timeoutMs ?? DEFAULT_GIT_TIMEOUT_MS, 300_000),
+            env: createSafeNpmInstallEnv(process.env, {
+              npmConfigCwd: repoDir,
+              packageLock: true,
+              quiet: true,
+            }),
+          },
+        );
+        if (install.code !== 0) {
+          return {
+            ok: false,
+            error: `npm install failed: ${install.stderr.trim() || install.stdout.trim()}`,
+          };
+        }
+      }
+
+      const result = await installPluginFromInstalledPackageDir({
+        dangerouslyForceUnsafeInstall: params.dangerouslyForceUnsafeInstall,
+        config: params.config,
+        packageDir: repoDir,
+        dryRun: params.dryRun,
+        expectedPluginId: params.expectedPluginId,
+        logger: params.logger,
+        mode: effectiveMode,
+        emitSuccessSecurityEvent: false,
+        installPolicyRequest,
+      });
+      if (!result.ok) {
+        return result;
+      }
+      if (!params.dryRun) {
+        const replaceResult = await replaceManagedGitRepo({
+          stagedRepoDir: repoDir,
+          persistentRepoDir,
+        });
+        if (!replaceResult.ok) {
+          return replaceResult;
+        }
+        emitPluginInstallSecurityEvent({
+          pluginId: result.pluginId,
+          mode: effectiveMode,
+          sourceFamily: "git",
+          extensionCount: result.extensions.length,
+          hasVersion: Boolean(result.version),
+          trustedSourceLinkedOfficialInstall: params.trustedSourceLinkedOfficialInstall,
+        });
+      }
+
+      return {
+        ...result,
+        targetDir: params.dryRun ? result.targetDir : persistentRepoDir,
+        git: {
+          url: parsed.url,
+          ref: parsed.ref,
+          commit: normalizeOptionalString(rev.stdout),
+          resolvedAt: new Date().toISOString(),
+        },
+      };
+    },
+    stagingRoot ? { rootDir: stagingRoot } : undefined,
+  );
 }

--- a/src/scripts/test-projects.test.ts
+++ b/src/scripts/test-projects.test.ts
@@ -996,6 +996,12 @@ describe("test-projects args", () => {
         watchMode: false,
       },
       {
+        config: "test/vitest/vitest.plugins.config.ts",
+        forwardedArgs: [],
+        includePatterns: ["src/plugins/git-install.test.ts"],
+        watchMode: false,
+      },
+      {
         config: "test/vitest/vitest.e2e.config.ts",
         forwardedArgs: [
           "test/e2e/qa-lab/plugins/plugin-lifecycle-probe.e2e.test.ts",


### PR DESCRIPTION
## What Problem This Solves

Git-backed plugin installs cloned into `os.tmpdir()` and then published the
managed repository with an atomic rename into the OpenClaw state directory.
When those paths were on different filesystems, the rename failed with
`EXDEV: cross-device link not permitted` and the install aborted.

Fixes #99885.

## Why This Change Was Made

Non-dry-run clones now use a private temporary workspace beside the exact
managed `git-<hash>/repo` target. The staged clone and the rename target
therefore share a filesystem, preserving atomic replacement without adding a
copy fallback to the shared filesystem primitive.

`withTempDir` accepts an optional root for this owner-controlled staging path.
Dry runs deliberately keep the default OS temp workspace so validation remains
ephemeral and does not create managed state. If the target parent cannot be
prepared, the existing structured managed-repository replacement error path is
preserved. Workspace initialization fallback happens only before the clone
callback starts, so clone and dependency-install side effects are never retried.

## User Impact

`openclaw plugins install git:<repo>` and git-backed plugin updates now work
when the OpenClaw state directory is mounted separately from `/tmp`, including
common container and bind-mount layouts. Existing install policy, dependency
scan, URL redaction, and atomic replacement behavior are unchanged.

## Evidence

- Focused Testbox serial run: 208 tests passed across git install, install
  source, install directory, replace file, and CLI install.
- Path-scoped Testbox `pnpm check:changed` passed core/core-test typecheck,
  lint, import cycles, and policy guards.
- The test-project routing contract passes with the plugin test registered as a
  temp-helper importer (83 tooling tests).
- Real CLI install passed with the source on device `64768` and OpenClaw state
  plus the managed clone on device `21`.
- Dry-run regression coverage proves the managed git root remains absent.
- Fresh branch autoreview reported no accepted/actionable findings.
