### PR TITLE
fix(tui): suppress unhandled rejection from async agent event handler

### DIFF
--- a/src/tui/embedded-backend.ts
+++ b/src/tui/embedded-backend.ts
@@ -322,7 +322,7 @@ export class EmbeddedTuiBackend implements TuiBackend {
     defaultRuntime.log = silentRuntime.log;
     defaultRuntime.error = silentRuntime.error;
     this.unsubscribe = onAgentEvent((evt) => {
-      void this.handleAgentEvent(evt);
+      void this.handleAgentEvent(evt).catch(() => {});
     });
     // Local mode never runs gateway startup; canonicalize orphaned keys once here.
     this.ready = (async () => {

--- a/src/tui/embedded-backend.ts
+++ b/src/tui/embedded-backend.ts
@@ -322,7 +322,9 @@ export class EmbeddedTuiBackend implements TuiBackend {
     defaultRuntime.log = silentRuntime.log;
     defaultRuntime.error = silentRuntime.error;
     this.unsubscribe = onAgentEvent((evt) => {
-      void this.handleAgentEvent(evt).catch(() => {});
+      void this.handleAgentEvent(evt).catch((err: unknown) => {
+        logWarn(`embedded-backend: agent event handler failed: ${String(err)}`, silentRuntime);
+      });
     });
     // Local mode never runs gateway startup; canonicalize orphaned keys once here.
     this.ready = (async () => {


### PR DESCRIPTION
## Summary

Add .catch() with logWarn diagnostic to the TUI embedded backend onAgentEvent callback. Rejection now logged instead of crashing the TUI process with unhandledRejection.

## Real behavior proof (required for external PRs)

**Behavior addressed**: void this.handleAgentEvent(evt) without .catch() → rejection → unhandledRejection → TUI crash

**Real environment tested**: Linux, Node 22, OpenClaw main

**Before**: void this.handleAgentEvent(evt) — crash on rejection
**After**: void this.handleAgentEvent(evt).catch((err) => logWarn(...)) — logged via existing logWarn import

**What was not tested**: Live TUI rejection in handleAgentEvent

## Risk

Low. Errors logged for observability via existing logWarn.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
Co-Authored-By: Claude <noreply@anthropic.com>