### PR TITLE
fix(agents): preserve mixed image attachment order

### DIFF
--- a/src/auto-reply/reply/current-turn-images.test.ts
+++ b/src/auto-reply/reply/current-turn-images.test.ts
@@ -61,6 +61,59 @@ describe("resolveCurrentTurnImages", () => {
     });
   });
 
+  it("preserves the full order when only inline image payloads are present", async () => {
+    const inlineImage = {
+      type: "image" as const,
+      data: Buffer.from("inline").toString("base64"),
+      mimeType: "image/png",
+    };
+
+    const result = await resolveCurrentTurnImages({
+      ctx: { Body: "compare these" } satisfies MsgContext,
+      cfg: {} as OpenClawConfig,
+      images: [inlineImage],
+      imageOrder: ["offloaded", "inline", "offloaded"],
+    });
+
+    expect(result).toEqual({
+      images: [inlineImage],
+      imageOrder: ["offloaded", "inline", "offloaded"],
+    });
+  });
+
+  it("preserves all-offloaded image order without inline payloads", async () => {
+    const result = await resolveCurrentTurnImages({
+      ctx: { Body: "compare these" } satisfies MsgContext,
+      cfg: {} as OpenClawConfig,
+      images: [],
+      imageOrder: ["offloaded", "offloaded"],
+    });
+
+    expect(result).toEqual({
+      imageOrder: ["offloaded", "offloaded"],
+    });
+  });
+
+  it("preserves interleaved offloaded slots around inline image payloads", async () => {
+    const inlineImages = ["first", "second"].map((data) => ({
+      type: "image" as const,
+      data: Buffer.from(data).toString("base64"),
+      mimeType: "image/png",
+    }));
+
+    const result = await resolveCurrentTurnImages({
+      ctx: { Body: "compare these" } satisfies MsgContext,
+      cfg: {} as OpenClawConfig,
+      images: inlineImages,
+      imageOrder: ["inline", "offloaded", "inline"],
+    });
+
+    expect(result).toEqual({
+      images: inlineImages,
+      imageOrder: ["inline", "offloaded", "inline"],
+    });
+  });
+
   it("appends extracted PDF page images without dropping current image attachments", async () => {
     await withTempDir({ prefix: "openclaw-current-turn-pdf-images-" }, async (base) => {
       const imagePath = path.join(base, "photo.png");

--- a/src/auto-reply/reply/current-turn-images.ts
+++ b/src/auto-reply/reply/current-turn-images.ts
@@ -20,7 +20,7 @@ type CurrentImageAttachment = {
 };
 
 type OrderedTurnImage = {
-  image: ImageContent;
+  image?: ImageContent;
   imageOrder: PromptImageOrderEntry;
   sourceIndex?: number;
   sequence: number;
@@ -105,13 +105,32 @@ function appendOrderedImages(params: {
   imageOrder?: PromptImageOrderEntry[];
   sourceIndex?: number;
 }) {
-  if (!params.images || params.images.length === 0) {
+  const images = params.images ?? [];
+  if (!params.imageOrder || params.imageOrder.length === 0) {
+    for (const image of images) {
+      params.entries.push({
+        image,
+        imageOrder: "inline",
+        sourceIndex: params.sourceIndex,
+        sequence: params.entries.length,
+      });
+    }
     return;
   }
-  for (const [index, image] of params.images.entries()) {
+
+  let inlineIndex = 0;
+  for (const imageOrder of params.imageOrder) {
     params.entries.push({
-      image,
-      imageOrder: params.imageOrder?.[index] ?? "inline",
+      image: imageOrder === "inline" ? images[inlineIndex++] : undefined,
+      imageOrder,
+      sourceIndex: params.sourceIndex,
+      sequence: params.entries.length,
+    });
+  }
+  while (inlineIndex < images.length) {
+    params.entries.push({
+      image: images[inlineIndex++],
+      imageOrder: "inline",
       sourceIndex: params.sourceIndex,
       sequence: params.entries.length,
     });
@@ -134,8 +153,9 @@ function resolveMergedTurnImages(entries: OrderedTurnImage[]): {
     }
     return left.sequence - right.sequence;
   });
+  const images = merged.flatMap((entry) => (entry.image ? [entry.image] : []));
   return {
-    images: merged.map((entry) => entry.image),
+    ...(images.length > 0 ? { images } : {}),
     imageOrder: merged.map((entry) => entry.imageOrder),
   };
 }


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users sending a mix of inline and offloaded image attachments could have the attachment order truncated before the model run.

## Why This Change Was Made

The reply image resolver now preserves every inline/offloaded order slot while associating concrete payloads only with inline slots. This restores the producer contract expected by the shared prompt-image merger.

## User Impact

Mixed image attachments keep their original order instead of losing offloaded slots when only inline images have in-memory payloads.

## Evidence

- `node scripts/run-vitest.mjs src/auto-reply/reply/current-turn-images.test.ts` passed 6 tests.
- Scoped `oxfmt` and `oxlint` passed.
- Autoreview passed with no accepted/actionable findings.
- After rebasing onto `main` at `be95bb72d459`, `check:changed` passed on Blacksmith Testbox `tbx_01kwp69wbwd2pc7y8cfv7w0pek` (exit 0).
