### PR TITLE
fix: reject plugin npm packages without manifests

### DIFF
--- a/scripts/verify-plugin-npm-published-runtime.mjs
+++ b/scripts/verify-plugin-npm-published-runtime.mjs
@@ -129,6 +129,10 @@ export function collectPluginNpmPublishedRuntimeErrors(params) {
   if (errors.length > 0) {
     return errors;
   }
+  if (!hasPackedFile(packageFiles, "openclaw.plugin.json")) {
+    errors.push(`${packageLabel} plugin npm package must include openclaw.plugin.json`);
+    return errors;
+  }
   const extensions = extensionsResult.entries;
   const runtimeExtensions = runtimeExtensionsResult.entries;
   const setupEntry = setupEntryResult.entry;

--- a/test/scripts/verify-plugin-npm-published-runtime.test.ts
+++ b/test/scripts/verify-plugin-npm-published-runtime.test.ts
@@ -139,7 +139,7 @@ describe("collectPluginNpmPublishedRuntimeErrors", () => {
             extensions: ["./index.ts"],
           },
         },
-        files: ["package.json", "index.ts"],
+        files: ["package.json", "openclaw.plugin.json", "index.ts"],
       }),
     ).toEqual([
       "@openclaw/discord@2026.5.2 requires compiled runtime output for TypeScript entry ./index.ts: expected ./dist/index.js, ./dist/index.mjs, ./dist/index.cjs, ./index.js, ./index.mjs, ./index.cjs",
@@ -157,9 +157,42 @@ describe("collectPluginNpmPublishedRuntimeErrors", () => {
             runtimeExtensions: ["./dist/index.js"],
           },
         },
-        files: ["package.json", "index.ts", "dist/index.js"],
+        files: ["package.json", "openclaw.plugin.json", "index.ts", "dist/index.js"],
       }),
     ).toStrictEqual([]);
+  });
+
+  it("flags plugin npm packages without an OpenClaw plugin manifest", () => {
+    expect(
+      collectPluginNpmPublishedRuntimeErrors({
+        packageJson: {
+          name: "@openclaw/searxng-plugin",
+          version: "2026.6.11",
+          openclaw: {
+            extensions: ["./index.ts"],
+            runtimeExtensions: ["./dist/index.js"],
+          },
+        },
+        files: ["package.json", "dist/index.js"],
+      }),
+    ).toEqual([
+      "@openclaw/searxng-plugin@2026.6.11 plugin npm package must include openclaw.plugin.json",
+    ]);
+  });
+
+  it("flags reservation packages before they can pass plugin runtime verification", () => {
+    expect(
+      collectPluginNpmPublishedRuntimeErrors({
+        packageJson: {
+          name: "@openclaw/tavily-plugin",
+          version: "0.0.0",
+          description: "Bootstrap reservation",
+        },
+        files: ["package.json", "README.md"],
+      }),
+    ).toEqual([
+      "@openclaw/tavily-plugin@0.0.0 plugin npm package must include openclaw.plugin.json",
+    ]);
   });
 
   it("flags missing explicit runtimeExtensions outputs", () => {
@@ -173,7 +206,7 @@ describe("collectPluginNpmPublishedRuntimeErrors", () => {
             runtimeExtensions: ["./dist/index.js"],
           },
         },
-        files: ["package.json", "src/index.ts"],
+        files: ["package.json", "openclaw.plugin.json", "src/index.ts"],
       }),
     ).toEqual(["@openclaw/line@2026.5.3 runtime extension entry not found: ./dist/index.js"]);
   });
@@ -189,7 +222,7 @@ describe("collectPluginNpmPublishedRuntimeErrors", () => {
             runtimeExtensions: ["./dist/index.js"],
           },
         },
-        files: ["package.json", "dist/index.js"],
+        files: ["package.json", "openclaw.plugin.json", "dist/index.js"],
       }),
     ).toEqual([
       "@openclaw/acpx@2026.5.3 package.json openclaw.runtimeExtensions length (1) must match openclaw.extensions length (2)",
@@ -207,7 +240,7 @@ describe("collectPluginNpmPublishedRuntimeErrors", () => {
             runtimeExtensions: [" "],
           },
         },
-        files: ["package.json", "src/index.ts", "dist/index.js"],
+        files: ["package.json", "openclaw.plugin.json", "src/index.ts", "dist/index.js"],
       }),
     ).toEqual([
       "@openclaw/whatsapp@2026.5.3 package.json openclaw.runtimeExtensions[0] must be a non-empty string",
@@ -226,7 +259,13 @@ describe("collectPluginNpmPublishedRuntimeErrors", () => {
             setupEntry: "./setup-entry.ts",
           },
         },
-        files: ["package.json", "index.ts", "dist/index.js", "setup-entry.ts"],
+        files: [
+          "package.json",
+          "openclaw.plugin.json",
+          "index.ts",
+          "dist/index.js",
+          "setup-entry.ts",
+        ],
       }),
     ).toEqual([
       "@openclaw/line@2026.5.3 requires compiled runtime output for TypeScript entry ./setup-entry.ts: expected ./dist/setup-entry.js, ./dist/setup-entry.mjs, ./dist/setup-entry.cjs, ./setup-entry.js, ./setup-entry.mjs, ./setup-entry.cjs",
@@ -246,7 +285,7 @@ describe("collectPluginNpmPublishedRuntimeErrors", () => {
             runtimeSetupEntry: "./dist/setup-entry.js",
           },
         },
-        files: ["package.json", "dist/index.js", "dist/setup-entry.js"],
+        files: ["package.json", "openclaw.plugin.json", "dist/index.js", "dist/setup-entry.js"],
       }),
     ).toStrictEqual([]);
   });
@@ -264,7 +303,7 @@ describe("collectPluginNpmPublishedRuntimeErrors", () => {
             runtimeSetupEntry: "./dist/setup-entry.js",
           },
         },
-        files: ["package.json", "dist/index.js"],
+        files: ["package.json", "openclaw.plugin.json", "dist/index.js"],
       }),
     ).toEqual(["@openclaw/matrix@2026.5.3 runtime setup entry not found: ./dist/setup-entry.js"]);
   });
@@ -281,7 +320,7 @@ describe("collectPluginNpmPublishedRuntimeErrors", () => {
             runtimeSetupEntry: "./dist/setup-entry.js",
           },
         },
-        files: ["package.json", "dist/index.js", "dist/setup-entry.js"],
+        files: ["package.json", "openclaw.plugin.json", "dist/index.js", "dist/setup-entry.js"],
       }),
     ).toEqual([
       "@openclaw/twitch@2026.5.3 package.json openclaw.runtimeSetupEntry requires openclaw.setupEntry",


### PR DESCRIPTION
Closes #96878

AI-assisted with Codex.

## What Problem This Solves

Fixes an issue where users trying to recover SearXNG or Tavily web_search after upgrade could be directed to official npm plugin packages that did not contain an OpenClaw plugin manifest, causing install validation to fail instead of restoring the provider.

## Why This Change Was Made

The current live `@openclaw/searxng-plugin@2026.6.11` and `@openclaw/tavily-plugin@2026.6.11` packages now contain the expected manifests and install successfully. This change adds the missing release verifier gate so plugin npm packages without a root `openclaw.plugin.json`, including 0.0.0 reservation packages, fail plugin runtime verification before they can be treated as valid published plugin artifacts.

## User Impact

Users get a working official npm recovery path for SearXNG and Tavily, and release managers get a direct guard against publishing or accepting plugin npm packages that would later fail with `plugin id mismatch` or hook-pack fallback errors.

## Evidence

- `node scripts/run-vitest.mjs test/scripts/verify-plugin-npm-published-runtime.test.ts -- --reporter verbose`
- `pnpm format:check scripts/verify-plugin-npm-published-runtime.mjs test/scripts/verify-plugin-npm-published-runtime.test.ts`
- `./node_modules/.bin/oxlint --tsconfig config/tsconfig/oxlint.scripts.json scripts/verify-plugin-npm-published-runtime.mjs`
- `./node_modules/.bin/oxlint test/scripts/verify-plugin-npm-published-runtime.test.ts`
- `OPENCLAW_PLUGIN_NPM_VERIFY_ATTEMPTS=1 OPENCLAW_PLUGIN_NPM_README_VERIFY_ATTEMPTS=1 node scripts/verify-plugin-npm-published-runtime.mjs @openclaw/searxng-plugin@2026.6.11`
- `OPENCLAW_PLUGIN_NPM_VERIFY_ATTEMPTS=1 OPENCLAW_PLUGIN_NPM_README_VERIFY_ATTEMPTS=1 node scripts/verify-plugin-npm-published-runtime.mjs @openclaw/tavily-plugin@2026.6.11`
- `OPENCLAW_HOME=$(mktemp -d) pnpm openclaw plugins install npm:@openclaw/searxng-plugin`
- `OPENCLAW_HOME=$(mktemp -d) pnpm openclaw plugins install npm:@openclaw/tavily-plugin`
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base upstream/main` -> clean, no accepted/actionable findings

Redacted terminal proof:

```text
$ node scripts/run-vitest.mjs test/scripts/verify-plugin-npm-published-runtime.test.ts -- --reporter verbose
✓ collectPluginNpmPublishedRuntimeErrors > flags plugin npm packages without an OpenClaw plugin manifest
✓ collectPluginNpmPublishedRuntimeErrors > flags reservation packages before they can pass plugin runtime verification
Test Files  1 passed (1)
Tests  24 passed (24)
[test] passed 1 Vitest shard in 57.82s
```

```text
$ OPENCLAW_PLUGIN_NPM_VERIFY_ATTEMPTS=1 OPENCLAW_PLUGIN_NPM_README_VERIFY_ATTEMPTS=1 node scripts/verify-plugin-npm-published-runtime.mjs @openclaw/searxng-plugin@2026.6.11
plugin-npm-published-runtime-check: @openclaw/searxng-plugin@2026.6.11 OK (8 files, 284 readme chars)
npm readme metadata for @openclaw/searxng-plugin@2026.6.11 was unavailable; verified README from published tarball instead.

$ OPENCLAW_PLUGIN_NPM_VERIFY_ATTEMPTS=1 OPENCLAW_PLUGIN_NPM_README_VERIFY_ATTEMPTS=1 node scripts/verify-plugin-npm-published-runtime.mjs @openclaw/tavily-plugin@2026.6.11
plugin-npm-published-runtime-check: @openclaw/tavily-plugin@2026.6.11 OK (1395 files, 265 readme chars)
npm readme metadata for @openclaw/tavily-plugin@2026.6.11 was unavailable; verified README from published tarball instead.
```

```text
$ OPENCLAW_HOME=$(mktemp -d) pnpm openclaw plugins install npm:@openclaw/searxng-plugin
Installing @openclaw/searxng-plugin into <tmp-home>/.openclaw/npm/projects/openclaw-searxng-plugin-<hash>...
Linked peerDependency "openclaw" -> <repo>
Plugin manifest id "searxng" differs from npm package name "@openclaw/searxng-plugin"; using manifest id as the config key.
Installed plugin: searxng
Restart the gateway to load plugins.

$ OPENCLAW_HOME=$(mktemp -d) pnpm openclaw plugins install npm:@openclaw/tavily-plugin
Installing @openclaw/tavily-plugin into <tmp-home>/.openclaw/npm/projects/openclaw-tavily-plugin-<hash>...
Linked peerDependency "openclaw" -> <repo>
Plugin manifest id "tavily" differs from npm package name "@openclaw/tavily-plugin"; using manifest id as the config key.
Installed plugin: tavily
Restart the gateway to load plugins.
```
