### PR TITLE
fix: notify requester when sessions_send delivery later fails

### DIFF
--- a/src/agents/tools/sessions-send-tool.a2a.test.ts
+++ b/src/agents/tools/sessions-send-tool.a2a.test.ts
@@ -15,13 +15,17 @@ vi.mock("../../gateway/call.js", () => ({
   callGateway: (opts: unknown) => callGatewayMock(opts),
 }));
 
-vi.mock("../run-wait.js", () => ({
-  waitForAgentRun: vi.fn().mockResolvedValue({ status: "ok" }),
-  readLatestAssistantReplySnapshot: vi.fn().mockResolvedValue({
-    text: "Test announce reply",
-    fingerprint: "test-announce-reply",
-  }),
-}));
+vi.mock("../run-wait.js", async (importOriginal) => {
+  const { isRecoverableAgentWaitError } = await importOriginal<typeof import("../run-wait.js")>();
+  return {
+    isRecoverableAgentWaitError,
+    waitForAgentRun: vi.fn().mockResolvedValue({ status: "ok" }),
+    readLatestAssistantReplySnapshot: vi.fn().mockResolvedValue({
+      text: "Test announce reply",
+      fingerprint: "test-announce-reply",
+    }),
+  };
+});
 
 vi.mock("./agent-step.js", () => ({
   runAgentStep: vi.fn().mockResolvedValue("Test announce reply"),
@@ -335,6 +339,114 @@ describe("runSessionsSendA2AFlow announce delivery", () => {
       firstMockArg(vi.mocked(readLatestAssistantReplySnapshot), "assistant reply snapshot")
         .sessionKey,
     ).toBe("agent:main:discord:group:dev");
+    expect(runAgentStep).not.toHaveBeenCalled();
+    expect(gatewayCalls.find((call) => call.method === "send")).toBeUndefined();
+  });
+
+  it("notifies the requester when delayed target delivery fails after acceptance", async () => {
+    vi.mocked(waitForAgentRun).mockResolvedValueOnce({
+      status: "timeout",
+      error:
+        "SessionWriteLockTimeoutError: session file locked (timeout 60000ms): pid=43 alive=true",
+      pendingError: true,
+    });
+
+    await runSessionsSendA2AFlow({
+      targetSessionKey: "agent:worker:discord:group:dev",
+      displayKey: "agent:worker:discord:group:dev",
+      message: "Test message",
+      announceTimeoutMs: 10_000,
+      maxPingPongTurns: 2,
+      requesterSessionKey: "agent:main:discord:group:req",
+      requesterChannel: "discord",
+      notifyRequesterOnWaitFailure: true,
+      baseline: {
+        text: "previous reply",
+        fingerprint: "previous-reply",
+      },
+      waitRunId: "run-lock-timeout",
+    });
+
+    expect(readLatestAssistantReplySnapshot).not.toHaveBeenCalled();
+    expect(runAgentStep).toHaveBeenCalledOnce();
+    expect(firstMockArg(vi.mocked(runAgentStep), "agent step")).toMatchObject({
+      sessionKey: "agent:main:discord:group:req",
+      sourceSessionKey: "agent:worker:discord:group:dev",
+      sourceTool: "sessions_send",
+    });
+    const stepInput = firstMockArg(vi.mocked(runAgentStep), "agent step");
+    expect(stepInput.message).toContain("sessions_send delivery to");
+    expect(stepInput.message).toContain("SessionWriteLockTimeoutError");
+    expect(gatewayCalls.find((call) => call.method === "send")).toBeUndefined();
+  });
+
+  it("does not notify the requester for waited sends that already returned the error inline", async () => {
+    vi.mocked(waitForAgentRun).mockResolvedValueOnce({
+      status: "timeout",
+      error:
+        "SessionWriteLockTimeoutError: session file locked (timeout 60000ms): pid=43 alive=true",
+      pendingError: true,
+    });
+
+    await runSessionsSendA2AFlow({
+      targetSessionKey: "agent:worker:discord:group:dev",
+      displayKey: "agent:worker:discord:group:dev",
+      message: "Test message",
+      announceTimeoutMs: 10_000,
+      maxPingPongTurns: 2,
+      requesterSessionKey: "agent:main:discord:group:req",
+      requesterChannel: "discord",
+      waitRunId: "run-lock-timeout-inline",
+    });
+
+    expect(readLatestAssistantReplySnapshot).not.toHaveBeenCalled();
+    expect(runAgentStep).not.toHaveBeenCalled();
+    expect(gatewayCalls.find((call) => call.method === "send")).toBeUndefined();
+  });
+
+  it("keeps ordinary delayed target timeouts silent", async () => {
+    vi.mocked(waitForAgentRun).mockResolvedValueOnce({
+      status: "timeout",
+      timeoutPhase: "provider",
+      providerStarted: true,
+    });
+
+    await runSessionsSendA2AFlow({
+      targetSessionKey: "agent:worker:discord:group:dev",
+      displayKey: "agent:worker:discord:group:dev",
+      message: "Test message",
+      announceTimeoutMs: 10_000,
+      maxPingPongTurns: 2,
+      requesterSessionKey: "agent:main:discord:group:req",
+      requesterChannel: "discord",
+      notifyRequesterOnWaitFailure: true,
+      waitRunId: "run-still-working",
+    });
+
+    expect(readLatestAssistantReplySnapshot).not.toHaveBeenCalled();
+    expect(runAgentStep).not.toHaveBeenCalled();
+    expect(gatewayCalls.find((call) => call.method === "send")).toBeUndefined();
+  });
+
+  it("keeps recoverable delayed wait errors silent", async () => {
+    vi.mocked(waitForAgentRun).mockResolvedValueOnce({
+      status: "error",
+      error: "gateway closed (1006)",
+    });
+
+    await runSessionsSendA2AFlow({
+      targetSessionKey: "agent:worker:discord:group:dev",
+      displayKey: "agent:worker:discord:group:dev",
+      message: "Test message",
+      announceTimeoutMs: 10_000,
+      maxPingPongTurns: 2,
+      requesterSessionKey: "agent:main:discord:group:req",
+      requesterChannel: "discord",
+      notifyRequesterOnWaitFailure: true,
+      waitRunId: "run-wait-interrupted",
+    });
+
+    expect(readLatestAssistantReplySnapshot).not.toHaveBeenCalled();
     expect(runAgentStep).not.toHaveBeenCalled();
     expect(gatewayCalls.find((call) => call.method === "send")).toBeUndefined();
   });

--- a/src/agents/tools/sessions-send-tool.a2a.ts
+++ b/src/agents/tools/sessions-send-tool.a2a.ts
@@ -10,7 +10,9 @@ import { createSubsystemLogger } from "../../logging/subsystem.js";
 import type { GatewayMessageChannel } from "../../utils/message-channel.js";
 import { resolveNestedAgentLaneForSession } from "../lanes.js";
 import {
+  type AgentWaitResult,
   type AssistantReplySnapshot,
+  isRecoverableAgentWaitError,
   readLatestAssistantReplySnapshot,
   waitForAgentRun,
 } from "../run-wait.js";
@@ -39,6 +41,13 @@ const defaultSessionsSendA2ADeps = {
 let sessionsSendA2ADeps: {
   callGateway: GatewayCaller;
 } = defaultSessionsSendA2ADeps;
+
+function isDeliveryFailureWait(wait: AgentWaitResult): boolean {
+  return (
+    (wait.status === "error" && !isRecoverableAgentWaitError(wait.error)) ||
+    (wait.status === "timeout" && wait.pendingError === true)
+  );
+}
 
 async function deliverAnnounceReply(params: {
   announceTarget: AnnounceTarget;
@@ -83,6 +92,7 @@ export async function runSessionsSendA2AFlow(params: {
   baseline?: AssistantReplySnapshot;
   roundOneReply?: string;
   waitRunId?: string;
+  notifyRequesterOnWaitFailure?: boolean;
 }) {
   const runContextId = params.waitRunId ?? "unknown";
   try {
@@ -106,6 +116,28 @@ export async function runSessionsSendA2AFlow(params: {
             ? latestSnapshot.text
             : undefined;
         latestReply = primaryReply;
+      } else {
+        if (
+          params.notifyRequesterOnWaitFailure === true &&
+          params.requesterSessionKey &&
+          isDeliveryFailureWait(wait)
+        ) {
+          const error =
+            typeof wait.error === "string" && wait.error.trim() ? `: ${wait.error.trim()}` : "";
+          await runAgentStep({
+            sessionKey: params.requesterSessionKey,
+            message:
+              `sessions_send delivery to ${params.displayKey} failed${error}. ` +
+              "The target may not have received the message; retry or report the failure instead of assuming delivery succeeded.",
+            extraSystemPrompt:
+              "A previous sessions_send delivery failed after it was accepted. Decide whether to retry, use another route, or report the failure. Do not assume the target received the message.",
+            timeoutMs: params.announceTimeoutMs,
+            lane: resolveNestedAgentLaneForSession(params.requesterSessionKey),
+            sourceSessionKey: params.targetSessionKey,
+            sourceTool: "sessions_send",
+          });
+        }
+        return;
       }
     }
     if (!latestReply) {

--- a/src/agents/tools/sessions-send-tool.ts
+++ b/src/agents/tools/sessions-send-tool.ts
@@ -665,6 +665,7 @@ export function createSessionsSendTool(opts?: {
         waitRunId?: string,
         flowTargetSessionKey = resolvedKey,
         flowDisplayKey = displayKey,
+        notifyRequesterOnWaitFailure = false,
       ) => {
         if (skipA2AFlow) {
           return;
@@ -684,6 +685,7 @@ export function createSessionsSendTool(opts?: {
           baseline: flowBaseline,
           roundOneReply,
           waitRunId,
+          notifyRequesterOnWaitFailure,
         });
       };
 
@@ -701,7 +703,7 @@ export function createSessionsSendTool(opts?: {
         }
         runId = start.runId;
         if (!start.activeRunQueue) {
-          startA2AFlow(undefined, runId, start.a2aSessionKey, start.a2aDisplayKey);
+          startA2AFlow(undefined, runId, start.a2aSessionKey, start.a2aDisplayKey, true);
         }
         return jsonResult({
           runId,
@@ -744,7 +746,7 @@ export function createSessionsSendTool(opts?: {
           });
         }
         if (!isTerminalAgentWaitTimeout(result)) {
-          startA2AFlow(undefined, runId);
+          startA2AFlow(undefined, runId, resolvedKey, displayKey, true);
           return jsonResult({
             runId,
             status: "accepted",


### PR DESCRIPTION
Closes #98415

AI-assisted by Codex.

## What Problem This Solves

Fixes an issue where users sending agent-to-agent messages with `sessions_send` could receive `accepted` with pending delivery, then never learn that the target run later failed while waiting on the target session file lock.

When the later wait failure was a `SessionWriteLockTimeoutError`, the background A2A flow only logged the failure, so the requester agent had no retry or fallback signal.

## Why This Change Was Made

The change keeps the existing fire-and-forget `accepted/pending` contract, but lets the existing background A2A flow notify the requester when a delayed target wait reports a concrete delivery failure after acceptance.

The notification is deliberately scoped to paths where the requester only saw `accepted/pending`; waited sends that already returned the error inline do not get a duplicate requester turn, and recoverable wait interruptions such as gateway disconnects remain silent because delivery is unknown.

## User Impact

Requester agents now get an actionable follow-up when a previously accepted `sessions_send` later fails due to target delivery/persistence errors, so they can retry, use another route, or report the failure instead of assuming the target received the message.

There is no new model-facing parameter, config option, storage surface, or public API change.

## Evidence

- `node scripts/run-vitest.mjs src/agents/tools/sessions-send-tool.a2a.test.ts` (22 tests passed)
- `node scripts/run-vitest.mjs src/agents/openclaw-tools.sessions.test.ts` (35 tests passed)
- `pnpm format:check -- src/agents/tools/sessions-send-tool.ts src/agents/tools/sessions-send-tool.a2a.ts src/agents/tools/sessions-send-tool.a2a.test.ts`
- `pnpm exec oxlint src/agents/tools/sessions-send-tool.ts src/agents/tools/sessions-send-tool.a2a.ts src/agents/tools/sessions-send-tool.a2a.test.ts`
- `git diff --check`
- `.agents/skills/autoreview/scripts/autoreview --mode local` -> clean, no accepted/actionable findings

Redacted local behavior proof using the real `createSessionsSendTool` entrypoint, real A2A flow, real `runAgentStep`, and real `run-wait` helper with a controlled local Gateway RPC stub for the delayed target wait:

```text
initial sessions_send result {
  status: 'accepted',
  runId: 'run-target-accepted',
  delivery: { status: 'pending', mode: 'announce' }
}
target accepted call { method: 'agent', sessionKey: 'agent:worker:discord:group:dev' }
delayed target wait {
  method: 'agent.wait',
  runId: 'run-target-accepted',
  simulatedError: 'SessionWriteLockTimeoutError',
  pendingError: true
}
requester notification {
  method: 'agent',
  sessionKey: 'agent:main:discord:group:req',
  sourceSessionKey: 'agent:worker:discord:group:dev',
  messageIncludesLockTimeout: true
}
```
