### PR TITLE
fix(cron): retry fallback on empty embedded cron results

### DIFF
--- a/src/cron/isolated-agent/run-executor.ts
+++ b/src/cron/isolated-agent/run-executor.ts
@@ -2,6 +2,10 @@
 import { createHash } from "node:crypto";
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import type { BootstrapContextMode } from "../../agents/bootstrap-files.js";
+import {
+  classifyEmbeddedAgentRunResultForModelFallback,
+  mergeEmbeddedAgentRunResultForModelFallbackExhaustion,
+} from "../../agents/embedded-agent-runner/result-fallback-classifier.js";
 import type { FastModeAutoProgressState } from "../../agents/fast-mode.js";
 import { runAgentHarnessBeforeMessageWriteHook } from "../../agents/harness/hook-helpers.js";
 import { resolveCliRuntimeExecutionProvider } from "../../agents/model-runtime-aliases.js";
@@ -294,6 +298,22 @@ export function createCronPromptExecutor(params: {
         recorder: UserTurnTranscriptRecorder;
       }
     | undefined;
+  // CLI providers surface their own terminal classification. Embedded cron
+  // results can return fallback-safe incomplete/empty payloads, so the fallback
+  // classifier must agree with the branch that produced the result.
+  const resolveCronExecutionProvider = (provider: string, model: string) => {
+    const executionProvider =
+      resolveCliRuntimeExecutionProvider({
+        provider,
+        cfg: params.cfgWithAgentDefaults,
+        agentId: params.agentId,
+        modelId: model,
+      }) ?? provider;
+    return {
+      executionProvider,
+      isCli: isCliProvider(executionProvider, params.cfgWithAgentDefaults),
+    };
+  };
 
   const runPrompt = async (promptText: string) => {
     const userTurnTranscriptRecorder =
@@ -339,22 +359,24 @@ export function createCronPromptExecutor(params: {
         });
       },
       fallbacksOverride: cronFallbacksOverride,
+      classifyResult: ({ provider, model, result }) =>
+        resolveCronExecutionProvider(provider, model).isCli
+          ? null
+          : classifyEmbeddedAgentRunResultForModelFallback({ provider, model, result }),
+      mergeExhaustedResult: mergeEmbeddedAgentRunResultForModelFallbackExhaustion,
       run: async (providerOverride, modelOverride, runOptions) => {
         if (params.abortSignal?.aborted) {
           throw new Error(params.abortReason());
         }
-        const executionProvider =
-          resolveCliRuntimeExecutionProvider({
-            provider: providerOverride,
-            cfg: params.cfgWithAgentDefaults,
-            agentId: params.agentId,
-            modelId: modelOverride,
-          }) ?? providerOverride;
+        const { executionProvider, isCli } = resolveCronExecutionProvider(
+          providerOverride,
+          modelOverride,
+        );
         const bootstrapPromptWarningSignature =
           bootstrapPromptWarningSignaturesSeen[bootstrapPromptWarningSignaturesSeen.length - 1];
         // CLI providers can resume provider-native sessions; embedded providers
         // use OpenClaw's transcript/session file plus prompt-cache affinity.
-        if (isCliProvider(executionProvider, params.cfgWithAgentDefaults)) {
+        if (isCli) {
           const cliSessionBinding = params.cronSession.isNewSession
             ? undefined
             : await getCliSessionBinding(params.cronSession.sessionEntry, executionProvider);

--- a/src/cron/isolated-agent/run.result-fallback-gap.test.ts
+++ b/src/cron/isolated-agent/run.result-fallback-gap.test.ts
@@ -1,0 +1,149 @@
+import { describe, expect, it } from "vitest";
+import { mergeEmbeddedAgentRunResultForModelFallbackExhaustion } from "../../agents/embedded-agent-runner/result-fallback-classifier.js";
+import { makeIsolatedAgentJobFixture, makeIsolatedAgentParamsFixture } from "./job-fixtures.js";
+import { setupRunCronIsolatedAgentTurnSuite } from "./run.suite-helpers.js";
+import {
+  isCliProviderMock,
+  loadRunCronIsolatedAgentTurn,
+  mockRunCronFallbackPassthrough,
+  runEmbeddedAgentMock,
+  runWithModelFallbackMock,
+} from "./run.test-harness.js";
+
+const runCronIsolatedAgentTurn = await loadRunCronIsolatedAgentTurn();
+
+function makeReasoningOnlyIncompleteResult() {
+  return {
+    payloads: [{ text: "Agent couldn't generate a response.", isError: true }],
+    meta: {
+      agentMeta: {},
+      agentHarnessResultClassification: "reasoning-only",
+      error: {
+        kind: "incomplete_turn",
+        message: "Agent couldn't generate a response.",
+        fallbackSafe: true,
+        terminalPresentation: false,
+      },
+    },
+  };
+}
+
+function makeHealthyFallbackResult() {
+  return {
+    payloads: [{ text: "Workspace cleaned up: removed 12 stale files." }],
+    meta: {
+      agentMeta: {},
+      finalAssistantVisibleText: "Workspace cleaned up: removed 12 stale files.",
+    },
+  };
+}
+
+function installFaithfulFallbackLoop(): void {
+  runWithModelFallbackMock.mockImplementation(
+    async ({ provider, model, run, fallbacksOverride, classifyResult, mergeExhaustedResult }) => {
+      const candidates = [
+        { provider, model },
+        ...((fallbacksOverride ?? []) as string[]).map((ref) => {
+          const slash = ref.indexOf("/");
+          return { provider: ref.slice(0, slash), model: ref.slice(slash + 1) };
+        }),
+      ];
+      let latest = { result: undefined as unknown, provider, model };
+      for (let index = 0; index < candidates.length; index += 1) {
+        const candidate = candidates[index];
+        const result = await run(candidate.provider, candidate.model, {
+          isFinalFallbackAttempt: index === candidates.length - 1,
+        });
+        const classification = await classifyResult?.({
+          result,
+          provider: candidate.provider,
+          model: candidate.model,
+          attempt: index + 1,
+          total: candidates.length,
+        });
+        if (!classification) {
+          return { result, provider: candidate.provider, model: candidate.model, attempts: [] };
+        }
+        latest = { result, provider: candidate.provider, model: candidate.model };
+      }
+      const merged = mergeExhaustedResult
+        ? mergeExhaustedResult({ latestResult: latest.result, preferredResult: latest.result })
+        : latest.result;
+      return { result: merged, provider: latest.provider, model: latest.model, attempts: [] };
+    },
+  );
+}
+
+describe("runCronIsolatedAgentTurn result-level fallback wiring", () => {
+  setupRunCronIsolatedAgentTurnSuite({ fast: true });
+
+  it("engages the configured fallback when the primary returns a reasoning-only incomplete result", async () => {
+    installFaithfulFallbackLoop();
+    runEmbeddedAgentMock.mockReset();
+    runEmbeddedAgentMock
+      .mockResolvedValueOnce(makeReasoningOnlyIncompleteResult())
+      .mockResolvedValueOnce(makeHealthyFallbackResult());
+
+    const result = await runCronIsolatedAgentTurn(
+      makeIsolatedAgentParamsFixture({
+        job: makeIsolatedAgentJobFixture({
+          payload: {
+            kind: "agentTurn",
+            message: "test",
+            fallbacks: ["anthropic/claude-sonnet-4-6"],
+          },
+        }),
+      }),
+    );
+
+    expect(runEmbeddedAgentMock).toHaveBeenCalledTimes(2);
+    expect(runEmbeddedAgentMock.mock.calls[1]?.[0]).toMatchObject({
+      provider: "anthropic",
+      model: "claude-sonnet-4-6",
+    });
+    expect(result.status).toBe("ok");
+  });
+
+  it("passes the embedded classifier and merge helper only for embedded results", async () => {
+    mockRunCronFallbackPassthrough();
+
+    await runCronIsolatedAgentTurn(makeIsolatedAgentParamsFixture());
+
+    const request = runWithModelFallbackMock.mock.calls[0]?.[0] as {
+      classifyResult?: (input: {
+        result: unknown;
+        provider: string;
+        model: string;
+        attempt: number;
+        total: number;
+      }) => unknown;
+      mergeExhaustedResult?: unknown;
+    };
+    expect(typeof request?.classifyResult).toBe("function");
+    expect(request?.mergeExhaustedResult).toBe(
+      mergeEmbeddedAgentRunResultForModelFallbackExhaustion,
+    );
+
+    const reasoningOnly = makeReasoningOnlyIncompleteResult();
+    expect(
+      await request.classifyResult?.({
+        result: reasoningOnly,
+        provider: "openai",
+        model: "gpt-5.4",
+        attempt: 1,
+        total: 2,
+      }),
+    ).toBeTruthy();
+
+    isCliProviderMock.mockImplementation((provider: string) => provider === "claude-cli");
+    expect(
+      await request.classifyResult?.({
+        result: reasoningOnly,
+        provider: "claude-cli",
+        model: "claude-sonnet-4-6",
+        attempt: 1,
+        total: 2,
+      }),
+    ).toBeNull();
+  });
+});


### PR DESCRIPTION
Related: #97115

## What Problem This Solves

Fixes an issue where isolated cron `agentTurn` jobs with configured model fallbacks could stop on an embedded primary model that returned a fallback-safe incomplete result, such as reasoning-only or empty visible output, instead of trying the next configured fallback model.

This covers the returned-result / zero-token failure mode reported in #97115. The separate shared AbortController timeout claim is a distinct terminal-timeout contract and is intentionally left out of this narrow PR.

## Why This Change Was Made

The isolated cron embedded path now passes the existing embedded result fallback classifier and exhausted-result merge helper into `runWithModelFallback`, matching the already-supported embedded fallback contract. The classifier is scoped away from CLI-backed execution providers so CLI runtimes continue to own their own terminal classification.

## User Impact

Scheduled embedded cron runs can now recover through the configured fallback chain when the primary candidate returns a fallback-safe incomplete result. Users should get the healthy fallback model's answer instead of a recurring generic "Agent couldn't generate a response" cron failure for that returned-result case.

AI-assisted.

## Evidence

Loopback behavior proof:

- Command: `OPENCLAW_LOG_LEVEL=error node --import tsx --input-type=module` with a temporary stdin script importing the production `runWithModelFallback` helper and production embedded result classifier from this checkout.
- Setup: local loopback endpoint returned a fallback-safe embedded `incomplete_turn` / `reasoning-only` result for `openai/primary-empty`, then returned visible assistant text for `anthropic/fallback-winner`.
- Redaction: loopback port, local paths, account details, endpoints, and secrets were redacted. No real API keys or external provider accounts were used.

```text
loopback endpoint http://127.0.0.1:<redacted-port>/agent-run
without_cron_classifier summary {"outcome":"completed","winner":"openai/primary-empty","visibleText":null,"firstPayload":"Agent couldn't generate a response.","attempts":[],"loopbackHits":[{"provider":"openai","model":"primary-empty","final":false}]}
with_cron_classifier summary {"outcome":"completed","winner":"anthropic/fallback-winner","visibleText":"fallback winner: cron delivered a visible assistant reply","firstPayload":"fallback winner: cron delivered a visible assistant reply","attempts":[{"provider":"openai","model":"primary-empty","reason":"format","code":"incomplete_result"}],"loopbackHits":[{"provider":"openai","model":"primary-empty","final":false},{"provider":"anthropic","model":"fallback-winner","final":true}]}
```

Focused validation:

```text
node scripts/run-vitest.mjs src/cron/isolated-agent/run.result-fallback-gap.test.ts
Test Files  1 passed (1)
Tests  2 passed (2)

node scripts/run-vitest.mjs src/cron/isolated-agent/run*.test.ts src/agents/outcome-fallback-runtime-contract.test.ts src/agents/model-fallback.test.ts
Test Files  22 passed (22)
Tests  199 passed (199)
Test Files  2 passed (2)
Tests  100 passed (100)

node_modules/.bin/oxfmt --check src/cron/isolated-agent/run-executor.ts src/cron/isolated-agent/run.result-fallback-gap.test.ts
All matched files use the correct format.

git diff --check
passed

node scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.core.json src/cron/isolated-agent/run-executor.ts src/cron/isolated-agent/run.result-fallback-gap.test.ts
passed

node scripts/run-tsgo.mjs -p tsconfig.core.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/core.tsbuildinfo
passed

node scripts/run-tsgo.mjs -p test/tsconfig/tsconfig.core.test.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/core-test.tsbuildinfo
passed

.agents/skills/autoreview/scripts/autoreview --mode local
autoreview clean: no accepted/actionable findings reported
```
