### PR TITLE
fix #97115: classify isolated cron fallback results

### DIFF
--- a/src/cron/isolated-agent/run-execution.runtime.ts
+++ b/src/cron/isolated-agent/run-execution.runtime.ts
@@ -8,6 +8,10 @@ export { resolveCronAgentLane } from "../../agents/lanes.js";
 export { ensureSelectedAgentHarnessPlugin } from "../../agents/harness/runtime-plugin.js";
 export { LiveSessionModelSwitchError } from "../../agents/live-model-switch-error.js";
 export { runWithModelFallback } from "../../agents/model-fallback.js";
+export {
+  classifyEmbeddedAgentRunResultForModelFallback,
+  mergeEmbeddedAgentRunResultForModelFallbackExhaustion,
+} from "../../agents/embedded-agent-runner/result-fallback-classifier.js";
 export { isCliProvider } from "../../agents/model-selection-cli.js";
 export { normalizeVerboseLevel } from "../../auto-reply/thinking.shared.js";
 export { resolveSessionTranscriptPath } from "../../config/sessions/paths.js";

--- a/src/cron/isolated-agent/run-executor.ts
+++ b/src/cron/isolated-agent/run-executor.ts
@@ -29,7 +29,9 @@ import {
   getCliSessionBinding,
   isCliProvider,
   LiveSessionModelSwitchError,
+  classifyEmbeddedAgentRunResultForModelFallback,
   logWarn,
+  mergeEmbeddedAgentRunResultForModelFallbackExhaustion,
   normalizeVerboseLevel,
   registerAgentRunContext,
   resolveBootstrapWarningSignaturesSeen,
@@ -339,6 +341,13 @@ export function createCronPromptExecutor(params: {
         });
       },
       fallbacksOverride: cronFallbacksOverride,
+      classifyResult: ({ provider, model, result }) =>
+        classifyEmbeddedAgentRunResultForModelFallback({
+          provider,
+          model,
+          result,
+        }),
+      mergeExhaustedResult: mergeEmbeddedAgentRunResultForModelFallbackExhaustion,
       run: async (providerOverride, modelOverride, runOptions) => {
         if (params.abortSignal?.aborted) {
           throw new Error(params.abortReason());

--- a/src/cron/isolated-agent/run.payload-fallbacks.test.ts
+++ b/src/cron/isolated-agent/run.payload-fallbacks.test.ts
@@ -3,8 +3,10 @@ import { describe, expect, it } from "vitest";
 import { makeIsolatedAgentJobFixture, makeIsolatedAgentParamsFixture } from "./job-fixtures.js";
 import { setupRunCronIsolatedAgentTurnSuite } from "./run.suite-helpers.js";
 import {
+  classifyEmbeddedAgentRunResultForModelFallbackMock,
   isCliProviderMock,
   loadRunCronIsolatedAgentTurn,
+  mergeEmbeddedAgentRunResultForModelFallbackExhaustionMock,
   mockRunCronFallbackPassthrough,
   resolveConfiguredModelRefMock,
   resolveCliRuntimeExecutionProviderMock,
@@ -17,13 +19,20 @@ import {
 const runCronIsolatedAgentTurn = await loadRunCronIsolatedAgentTurn();
 
 function requireModelFallbackRequest(): {
+  classifyResult?: (params: { provider: string; model: string; result: unknown }) => unknown;
   fallbacksOverride?: string[];
+  mergeExhaustedResult?: (params: { latestResult: unknown; preferredResult: unknown }) => unknown;
   provider?: string;
   model?: string;
 } {
   const request = runWithModelFallbackMock.mock.calls[0]?.[0] as
     | {
+        classifyResult?: (params: { provider: string; model: string; result: unknown }) => unknown;
         fallbacksOverride?: string[];
+        mergeExhaustedResult?: (params: {
+          latestResult: unknown;
+          preferredResult: unknown;
+        }) => unknown;
         provider?: string;
         model?: string;
       }
@@ -97,6 +106,61 @@ describe("runCronIsolatedAgentTurn — payload.fallbacks", () => {
     expect(result.status).toBe("ok");
     expect(runWithModelFallbackMock).toHaveBeenCalledOnce();
     expect(requireModelFallbackRequest().fallbacksOverride).toEqual(expectedFallbacks);
+  });
+
+  it("passes embedded result fallback classification into cron model failover", async () => {
+    const classified = {
+      code: "empty_result",
+      message: "embedded agent returned no payloads",
+      retryable: true,
+    };
+    classifyEmbeddedAgentRunResultForModelFallbackMock.mockReturnValue(classified);
+
+    const result = await runCronIsolatedAgentTurn(
+      makeIsolatedAgentParamsFixture({
+        job: makeIsolatedAgentJobFixture({
+          payload: { kind: "agentTurn", message: "test" },
+        }),
+      }),
+    );
+
+    expect(result.status).toBe("ok");
+    expect(runWithModelFallbackMock).toHaveBeenCalledOnce();
+    const fallbackRequest = requireModelFallbackRequest();
+    const embeddedResult = {
+      payloads: [],
+      meta: {
+        agentMeta: {},
+        agentHarnessResultClassification: "empty_result",
+      },
+    };
+    expect(
+      fallbackRequest.classifyResult?.({
+        provider: "anthropic",
+        model: "claude-sonnet-4-6",
+        result: embeddedResult,
+      }),
+    ).toBe(classified);
+    expect(classifyEmbeddedAgentRunResultForModelFallbackMock).toHaveBeenCalledWith({
+      provider: "anthropic",
+      model: "claude-sonnet-4-6",
+      result: embeddedResult,
+    });
+    expect(fallbackRequest.mergeExhaustedResult).toBe(
+      mergeEmbeddedAgentRunResultForModelFallbackExhaustionMock,
+    );
+    const latestResult = { payloads: [{ text: "latest visible summary" }] };
+    const preferredResult = { payloads: [{ text: "preferred fallback summary" }] };
+    expect(
+      fallbackRequest.mergeExhaustedResult?.({
+        latestResult,
+        preferredResult,
+      }),
+    ).toBe(latestResult);
+    expect(mergeEmbeddedAgentRunResultForModelFallbackExhaustionMock).toHaveBeenCalledWith({
+      latestResult,
+      preferredResult,
+    });
   });
 
   it("plans Anthropic fallbacks canonically while executing compatible attempts through Claude CLI", async () => {

--- a/src/cron/isolated-agent/run.test-harness.ts
+++ b/src/cron/isolated-agent/run.test-harness.ts
@@ -84,6 +84,8 @@ export const callGatewayMock = createMock();
 export const ensureRuntimePluginsLoadedMock = createMock();
 export const listWebSearchProvidersMock = createMock();
 export const resolveWebSearchProviderIdMock = createMock();
+export const classifyEmbeddedAgentRunResultForModelFallbackMock = createMock();
+export const mergeEmbeddedAgentRunResultForModelFallbackExhaustionMock = createMock();
 
 const resolveBootstrapWarningSignaturesSeenMock = createMock();
 const resolveCronStyleNowMock = createMock();
@@ -256,6 +258,10 @@ vi.mock("./run-execution.runtime.js", () => ({
   resolveSessionTranscriptPath: resolveSessionTranscriptPathMock,
   registerAgentRunContext: registerAgentRunContextMock,
   logWarn: (...args: unknown[]) => logWarnMock(...args),
+  classifyEmbeddedAgentRunResultForModelFallback:
+    classifyEmbeddedAgentRunResultForModelFallbackMock,
+  mergeEmbeddedAgentRunResultForModelFallbackExhaustion:
+    mergeEmbeddedAgentRunResultForModelFallbackExhaustionMock,
 }));
 
 vi.mock("../../agents/model-runtime-aliases.js", () => ({
@@ -517,6 +523,12 @@ function resetRunExecutionMocks(): void {
   registerAgentRunContextMock.mockReturnValue(undefined);
   runWithModelFallbackMock.mockReset();
   runWithModelFallbackMock.mockResolvedValue(makeDefaultModelFallbackResult());
+  classifyEmbeddedAgentRunResultForModelFallbackMock.mockReset();
+  classifyEmbeddedAgentRunResultForModelFallbackMock.mockReturnValue(null);
+  mergeEmbeddedAgentRunResultForModelFallbackExhaustionMock.mockReset();
+  mergeEmbeddedAgentRunResultForModelFallbackExhaustionMock.mockImplementation(
+    (params: { latestResult: unknown }) => params.latestResult,
+  );
   runEmbeddedAgentMock.mockReset();
   runEmbeddedAgentMock.mockResolvedValue(makeDefaultEmbeddedResult());
   runCliAgentMock.mockReset();


### PR DESCRIPTION
## What Problem This Solves

Fixes #97115.

Isolated cron runs already use `runWithModelFallback`, but they did not pass the embedded runner's result fallback classifier or exhausted-result merge helper. That meant zero-token/empty terminal "success" results could be treated as successful cron turns instead of moving to the configured fallback chain, and exhausted fallback summaries could lose the richer embedded result.

## Why This Change Was Made

The embedded agent path already has the canonical fallback classifier and exhausted-result merge behavior. This change wires those same helpers through the isolated cron runtime boundary into `createCronPromptExecutor` so cron fallback behavior matches normal embedded agent fallback behavior without adding a second classifier.

## User Impact

Cron agent runs that receive empty/reasoning-only/planning-only terminal results can now continue to configured fallback models instead of silently completing with no useful message. When every fallback is exhausted, cron keeps the embedded runner's richer terminal summary instead of replacing it with a weaker generic result.

## Evidence

- `node scripts/run-vitest.mjs src/cron/isolated-agent/run.payload-fallbacks.test.ts --reporter=verbose` — 7 passed
- `node scripts/run-vitest.mjs src/cron/isolated-agent/run*.test.ts --reporter=verbose` — 21 files / 198 tests passed
- `node scripts/run-vitest.mjs src/agents/outcome-fallback-runtime-contract.test.ts --reporter=verbose` — 10 passed
- `node scripts/run-vitest.mjs src/agents/model-fallback.test.ts --reporter=verbose` — 90 passed
- `node scripts/run-oxlint.mjs src/cron/isolated-agent/run-execution.runtime.ts src/cron/isolated-agent/run-executor.ts src/cron/isolated-agent/run.test-harness.ts src/cron/isolated-agent/run.payload-fallbacks.test.ts`
- `git diff --check`

## Real Behavior Proof

Loopback cron fallback proof was run locally with the PR applied. It uses real `runWithModelFallback`, `classifyEmbeddedAgentRunResultForModelFallback`, and `mergeEmbeddedAgentRunResultForModelFallbackExhaustion`, with a loopback cron-shaped run function. No external provider, API key, account id, phone number, endpoint, or private path is used. Synthetic run/session identifiers are redacted.

Command:

```sh
node_modules/.bin/tsx /tmp/openclaw-97115-loopback-proof.mjs
```

Observed output:

```text
OpenClaw #97115 loopback cron fallback proof
No external provider, API key, account id, phone number, endpoint, or private path is used.
Private runtime identifiers are redacted in the synthetic run/session ids.
This exercises the same classifier and exhaustion merge helpers wired into isolated cron in PR #99913.

[baseline without cron result hooks]
outcome=completed
winner=openai/gpt-5-loopback-primary
visibleText=""
runCalls=[{"provider":"openai","model":"gpt-5-loopback-primary","isFinalFallbackAttempt":false}]
classifications=[]
fallbackAttempts=[]

[model-fallback/decision] model fallback decision: decision=candidate_failed requested=openai/gpt-5-loopback-primary candidate=openai/gpt-5-loopback-primary reason=format next=anthropic/claude-sonnet-loopback-fallback detail=openai/gpt-5-loopback-primary ended without a visible assistant reply
[model-fallback/decision] model fallback decision: decision=candidate_succeeded requested=openai/gpt-5-loopback-primary candidate=anthropic/claude-sonnet-loopback-fallback reason=unknown next=none

[after PR hook wiring]
outcome=completed
winner=anthropic/claude-sonnet-loopback-fallback
visibleText="fallback winner delivered visible cron response"
runCalls=[{"provider":"openai","model":"gpt-5-loopback-primary","isFinalFallbackAttempt":false},{"provider":"anthropic","model":"claude-sonnet-loopback-fallback","isFinalFallbackAttempt":true}]
classifications=[{"provider":"openai","model":"gpt-5-loopback-primary","code":"empty_result","reason":"format"},{"provider":"anthropic","model":"claude-sonnet-loopback-fallback","code":null,"reason":null}]
fallbackAttempts=[{"provider":"openai","model":"gpt-5-loopback-primary","reason":"format","code":"empty_result"}]
```
