### PR TITLE
fix(commands): guard shortenText against non-positive maxLen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- **Command output truncation:** return an empty string for non-positive shortening limits instead of emitting an over-budget ellipsis. (#99917) Thanks @Super-Cabbage.
 - **Agent helper downloads:** bound fd and ripgrep archive downloads and extraction with declared and streamed byte caps, extraction limits, timeouts, traversal-safe unpacking, and partial-file cleanup. (#98988) Thanks @LeonidasLux.
 - **Control UI cron actions:** localize the overflow-menu label and due-only run action across all supported locales.
 - **OpenAI Realtime Codex auth:** reuse external Codex OAuth profiles for Realtime voice sessions when no explicit OpenAI API key is configured.

--- a/src/commands/text-format.test.ts
+++ b/src/commands/text-format.test.ts
@@ -11,6 +11,11 @@ describe("shortenText", () => {
     expect(shortenText("openclaw-status-output", 10)).toBe("openclaw-…");
   });
 
+  it("returns an empty string for non-positive limits", () => {
+    expect(shortenText("openclaw", 0)).toBe("");
+    expect(shortenText("openclaw", -1)).toBe("");
+  });
+
   it("counts multi-byte characters correctly", () => {
     expect(shortenText("hello🙂world", 7)).toBe("hello🙂…");
   });

--- a/src/commands/text-format.ts
+++ b/src/commands/text-format.ts
@@ -3,6 +3,9 @@
 
 /** Shortens text to maxLen code points, appending an ellipsis when truncated. */
 export const shortenText = (value: string, maxLen: number) => {
+  if (maxLen <= 0) {
+    return "";
+  }
   const chars = Array.from(value);
   if (chars.length <= maxLen) {
     return value;


### PR DESCRIPTION
## What Problem This Solves

`shortenText()` in `text-format.ts` does not guard against `maxLen` values of 0 or less. When `maxLen = 0`, the function returns `"..."` (3 characters) which exceeds the stated limit of 0 characters:

```text
shortenText("abc", 0) → "..."  (wrong: "...".length = 3 > maxLen 0)
```

Expected behavior: non-positive `maxLen` should return an empty string.

## Real behavior proof

- **Behavior or issue addressed**: `shortenText` edge case when `maxLen <= 0` returns text exceeding the limit
- **Real environment tested**: Node 22.22, Linux x86_64, local dev checkout
- **Exact steps or command run after this patch**:

  ```bash
  node --import tsx -e "
  import { shortenText } from './src/commands/text-format.js';
  console.log('shortenText(\"abc\", 0)  →', JSON.stringify(shortenText('abc', 0)));
  console.log('shortenText(\"abc\", 3)  →', JSON.stringify(shortenText('abc', 3)));
  console.log('shortenText(\"abcde\", 3) →', JSON.stringify(shortenText('abcde', 3)));
  console.log('shortenText(\"\", 0)     →', JSON.stringify(shortenText('', 0)));
  console.log('shortenText(\"abc\", -1) →', JSON.stringify(shortenText('abc', -1)));
  "
  ```
- **Evidence after fix**:

  ```text
  shortenText("abc", 0)  → ""
  shortenText("abc", 3)  → "abc"
  shortenText("abcde", 3) → "ab…"
  shortenText("", 0)     → ""
  shortenText("abc", -1) → ""
  ```
- **Observed result after fix**: Non-positive `maxLen` returns empty string; existing behavior for positive `maxLen` is unchanged.
- **What was not tested**: Full test suite for all callers (no behavior change for positive maxLen)

## Files Changed

| File | Change |
|---|---|
| `src/commands/text-format.ts` | Added `if (maxLen <= 0) return "";` guard before truncation logic |

Generated with Claude Code