### PR TITLE
fix(lsp): suppress unhandled spawn error on LSP child process

### DIFF
--- a/src/agents/agent-bundle-lsp-runtime.test.ts
+++ b/src/agents/agent-bundle-lsp-runtime.test.ts
@@ -122,6 +122,21 @@ describe("bundle LSP runtime", () => {
     expect(killProcessTreeMock).toHaveBeenCalledWith(4321, { graceMs: 1000 });
   });
 
+  it("suppresses spawn errors on LSP child process to prevent unhandled error crash", async () => {
+    const child = new MockChildProcess();
+    spawnMock.mockReturnValue(child);
+
+    const { spawnLspServerProcess } = await import("./agent-bundle-lsp-runtime.js");
+    const result = spawnLspServerProcess({
+      command: "typescript-language-server",
+      args: ["--stdio"],
+    });
+
+    // The returned child must have an error handler installed.
+    // Emitting error on a ChildProcess without a handler throws ERR_UNHANDLED_ERROR.
+    expect(() => result.emit("error", new Error("spawn ENOENT"))).not.toThrow();
+  });
+
   it("keeps LSP framing aligned after multibyte messages in the same chunk", async () => {
     configureSingleLspServer();
     const prefix = encodeLspMessage({

--- a/src/agents/agent-bundle-lsp-runtime.ts
+++ b/src/agents/agent-bundle-lsp-runtime.ts
@@ -80,7 +80,7 @@ export function spawnLspServerProcess(config: StdioMcpServerLaunchConfig): Child
     allowShellFallback: true,
   });
   const invocation = materializeWindowsSpawnProgram(program, config.args ?? []);
-  return spawn(invocation.command, invocation.argv, {
+  const child = spawn(invocation.command, invocation.argv, {
     stdio: ["pipe", "pipe", "pipe"],
     env: mergedEnv,
     cwd: config.cwd,
@@ -88,6 +88,8 @@ export function spawnLspServerProcess(config: StdioMcpServerLaunchConfig): Child
     windowsHide: invocation.windowsHide ?? process.platform === "win32",
     shell: invocation.shell,
   });
+  child.on("error", () => {});
+  return child;
 }
 
 function createLspSession(serverName: string, child: ChildProcess): LspSession {


### PR DESCRIPTION
## What Problem This Solves

spawnLspServerProcess returns a bare ChildProcess without an error handler. Missing LSP binary (ENOENT) emits unhandled error event that crashes the gateway.

## Why This Change Was Made

Add child.on("error", () => {}) before returning, matching the pattern in supervisor child adapter (#99802) and MCP stdio transport (#99803).

## User Impact

Missing or unstartable LSP servers no longer crash the gateway. Existing LSP initialization failure path provides diagnostics.

## Evidence

Live proof: spawnLspServerProcess with nonexistent binary, NO extra handlers. Process survives. Regression test: 4 passed.

## Risk

Low. One-line noop handler. Same pattern merged in #99800, #99802, #99803.