### PR TITLE
fix(plugins): publish git installs across devices

### DIFF
--- a/src/plugins/git-install.test.ts
+++ b/src/plugins/git-install.test.ts
@@ -49,6 +49,17 @@ function expectedGitRepoDir(params: { gitDir: string; normalizedSpec: string }):
   return path.join(params.gitDir, `git-${hash}`, "repo");
 }
 
+function createFsError(code: string, message = code): NodeJS.ErrnoException {
+  return Object.assign(new Error(message), { code });
+}
+
+function normalizeComparablePath(filePath: string): string {
+  const resolved = path.resolve(filePath);
+  const basename =
+    process.platform === "win32" ? path.basename(resolved).toLowerCase() : path.basename(resolved);
+  return path.join(path.dirname(resolved), basename);
+}
+
 function expectParsedGitSpec(spec: string) {
   const parsed = parseGitPluginSpec(spec);
   if (!parsed) {
@@ -207,7 +218,7 @@ describe("installPluginFromGitSpec", () => {
     expect(result.git.commit).toBe("abc123");
     const cloneArgv = commandArgvAt(0);
     expect(cloneArgv.slice(0, 3)).toEqual(["git", "clone", "https://github.com/acme/demo.git"]);
-    expect(cloneArgv[3]).toContain("/repo");
+    expect(path.basename(cloneArgv[3] ?? "")).toBe("repo");
     expect(commandArgvAt(1)).toEqual(["git", "switch", "--detach", "--", "v1.2.3"]);
     expect(commandArgvAt(3)).toEqual([
       "npm",
@@ -220,7 +231,7 @@ describe("installPluginFromGitSpec", () => {
     ]);
     const installOptions = firstInstallOptions();
     expect(installOptions?.expectedPluginId).toBe("demo");
-    expect(installOptions?.packageDir).toContain("/repo");
+    expect(path.basename(installOptions?.packageDir ?? "")).toBe("repo");
     expect(installOptions?.installPolicyRequest?.kind).toBe("plugin-git");
     expect(installOptions?.installPolicyRequest?.requestedSpecifier).toBe(
       "git:github.com/acme/demo@v1.2.3",
@@ -285,6 +296,75 @@ describe("installPluginFromGitSpec", () => {
     }
   });
 
+  it("publishes the managed repo through copy fallback when the final rename crosses devices", async () => {
+    const gitDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-git-install-exdev-"));
+    const normalizedSpec = "git:https://github.com/acme/demo.git";
+    const expectedRepoDir = expectedGitRepoDir({ gitDir, normalizedSpec });
+    try {
+      runCommandWithTimeoutMock
+        .mockResolvedValueOnce({ code: 0, stdout: "", stderr: "" })
+        .mockResolvedValueOnce({ code: 0, stdout: "abc123\n", stderr: "" })
+        .mockResolvedValueOnce({ code: 0, stdout: "", stderr: "" });
+      installPluginFromInstalledPackageDirMock.mockImplementation(
+        async (params: { packageDir: string }) => {
+          await fs.mkdir(params.packageDir, { recursive: true });
+          await fs.writeFile(path.join(params.packageDir, "package.json"), "{}", "utf8");
+          await fs.writeFile(path.join(params.packageDir, "marker.txt"), "published", "utf8");
+          return {
+            ok: true,
+            pluginId: "demo",
+            targetDir: params.packageDir,
+            version: "1.2.3",
+            extensions: ["index.js"],
+          };
+        },
+      );
+      const realRename = fs.rename.bind(fs);
+      let exdevMoves = 0;
+      vi.spyOn(fs, "rename").mockImplementation(async (...args: Parameters<typeof fs.rename>) => {
+        const [from, to] = args;
+        if (
+          exdevMoves === 0 &&
+          path.basename(String(from)) === "repo" &&
+          normalizeComparablePath(String(to)) === normalizeComparablePath(expectedRepoDir)
+        ) {
+          exdevMoves += 1;
+          throw createFsError("EXDEV", "cross-device link not permitted");
+        }
+        return await realRename(...args);
+      });
+      const captured = captureSecurityEvents();
+
+      let result: Awaited<ReturnType<typeof installPluginFromGitSpec>>;
+      try {
+        result = await installPluginFromGitSpec({
+          spec: "git:https://github.com/acme/demo.git",
+          gitDir,
+        });
+      } finally {
+        captured.stop();
+      }
+
+      expect(result.ok).toBe(true);
+      if (!result.ok) {
+        throw new Error(result.error);
+      }
+      expect(exdevMoves).toBe(1);
+      expect(result.targetDir).toBe(expectedRepoDir);
+      await expect(fs.readFile(path.join(expectedRepoDir, "marker.txt"), "utf8")).resolves.toBe(
+        "published",
+      );
+      expect(captured.events).toHaveLength(1);
+      expect(captured.events[0]).toMatchObject({
+        action: "plugin.installed",
+        outcome: "success",
+        target: { kind: "plugin", name: "demo" },
+      });
+    } finally {
+      await fs.rm(gitDir, { recursive: true, force: true });
+    }
+  });
+
   it("uses a shallow clone when no ref is requested", async () => {
     runCommandWithTimeoutMock
       .mockResolvedValueOnce({ code: 0, stdout: "", stderr: "" })
@@ -317,7 +397,7 @@ describe("installPluginFromGitSpec", () => {
       "1",
       "https://github.com/acme/demo.git",
     ]);
-    expect(cloneArgv[5]).toContain("/repo");
+    expect(path.basename(cloneArgv[5] ?? "")).toBe("repo");
   });
 
   it("runs install policy preflight before npm installs git dependencies", async () => {
@@ -360,7 +440,7 @@ describe("installPluginFromGitSpec", () => {
         pluginId: "demo",
         requestedSpecifier: "git:github.com/acme/demo",
         source: { kind: "git", authority: "third-party", mutable: true, network: true },
-        sourcePath: expect.stringContaining("/repo"),
+        sourcePath: expect.stringMatching(new RegExp(`${path.sep === "\\" ? "\\\\" : "/"}repo$`)),
       }),
     );
     expect(installPluginFromInstalledPackageDirMock).not.toHaveBeenCalled();

--- a/src/plugins/git-install.ts
+++ b/src/plugins/git-install.ts
@@ -1,6 +1,7 @@
 /** Parses, clones, verifies, and installs plugin packages from Git specs. */
 import "../infra/fs-safe-defaults.js";
 import { createHash } from "node:crypto";
+import fs from "node:fs/promises";
 import path from "node:path";
 import { redactSensitiveUrlLikeString } from "@openclaw/net-policy/redact-sensitive-url";
 import { hasHttpUrlPrefix } from "@openclaw/net-policy/url-protocol";
@@ -8,7 +9,7 @@ import { normalizeOptionalString } from "@openclaw/normalization-core/string-coe
 import { sanitizeForLog } from "../../packages/terminal-core/src/ansi.js";
 import { pathExists } from "../infra/fs-safe.js";
 import { withTempDir } from "../infra/install-source-utils.js";
-import { replaceDirectoryAtomic } from "../infra/replace-file.js";
+import { movePathWithCopyFallback } from "../infra/replace-file.js";
 import {
   createSafeNpmInstallArgs,
   createSafeNpmInstallEnv,
@@ -247,11 +248,35 @@ async function replaceManagedGitRepo(params: {
   persistentRepoDir: string;
 }): Promise<{ ok: true } | { ok: false; error: string }> {
   try {
-    await replaceDirectoryAtomic({
-      stagedDir: params.stagedRepoDir,
-      targetDir: params.persistentRepoDir,
-      backupPrefix: ".repo-backup-",
-    });
+    const targetDir = path.resolve(params.persistentRepoDir);
+    const stagedDir = path.resolve(params.stagedRepoDir);
+    const parentDir = path.dirname(targetDir);
+    const backupDir = path.join(parentDir, `.repo-backup-${process.pid}-${Date.now()}`);
+    let backupCreated = false;
+
+    await fs.mkdir(parentDir, { recursive: true });
+    try {
+      await movePathWithCopyFallback({ from: targetDir, to: backupDir });
+      backupCreated = true;
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code !== "ENOENT") {
+        throw err;
+      }
+    }
+
+    try {
+      await movePathWithCopyFallback({ from: stagedDir, to: targetDir });
+    } catch (err) {
+      if (backupCreated) {
+        await movePathWithCopyFallback({ from: backupDir, to: targetDir }).catch(() => undefined);
+        backupCreated = false;
+      }
+      throw err;
+    }
+
+    if (backupCreated) {
+      await fs.rm(backupDir, { recursive: true, force: true });
+    }
     return { ok: true };
   } catch (err) {
     return {


### PR DESCRIPTION
Closes #99885

## What Problem This Solves

Fixes an issue where users installing git-backed plugins in Docker or other split-filesystem setups would hit `EXDEV: cross-device link not permitted` when OpenClaw tried to publish the cloned repository from the process temp directory into the managed git plugin directory.

## Why This Change Was Made

The managed git repo publish step now keeps the existing backup/restore behavior but uses the existing cross-device-safe move helper for both backup and final publish moves. That preserves the previous rollback semantics while allowing the final staged clone to be copied through the helper when a direct rename cannot cross filesystems.

## User Impact

Users can install `git:` plugins when `/tmp` and the OpenClaw state directory live on different mounts, such as Docker containers with bind-mounted home or state directories. Existing install failure behavior and security success events remain unchanged when publishing fails.

## Evidence

- Claim proved: git plugin install publishing falls back successfully when the final managed repo rename raises `EXDEV`, while still emitting the install success event only after the repo is published.
- Commands / artifacts:
  - `node scripts/run-vitest.mjs src/plugins/git-install.test.ts` -> 21 tests passed.
  - `node scripts/run-vitest.mjs src/plugins/git-install.test.ts src/infra/install-package-dir.test.ts src/infra/replace-file.test.ts` -> 2 Vitest shards passed; `src/infra/install-package-dir.test.ts` and `src/infra/replace-file.test.ts` covered the shared copy-fallback helper behavior, with platform-specific hardlink cases skipped on Windows as expected.
  - `.\node_modules\.bin\oxfmt.CMD --check --threads=1 src/plugins/git-install.ts src/plugins/git-install.test.ts` -> all matched files use the correct format.
  - `.\node_modules\.bin\oxlint.CMD --tsconfig config/tsconfig/oxlint.core.json src/plugins/git-install.ts src/plugins/git-install.test.ts` -> no issues reported.
  - `git diff --check` -> passed.
- Observed result: the focused regression test forces the final `repo -> managed git repo` rename to throw `EXDEV`, then verifies the install succeeds and the managed repo contains the staged marker file.
- Not tested / proof gaps: I did not run a live Docker bind-mount install; the proof is a source-level regression test against the exact publish boundary plus the existing infra fallback tests.