### PR TITLE
fix(slack): warn when bot token authenticates as user

### DIFF
--- a/extensions/slack/src/channel.test.ts
+++ b/extensions/slack/src/channel.test.ts
@@ -433,12 +433,16 @@ describe("slackPlugin status", () => {
     const cfg = {
       channels: {
         slack: {
-          botToken: "xoxb-test",
-          appToken: "xapp-test",
+          accounts: {
+            work: {
+              botToken: "xoxb-work",
+              appToken: "xapp-work",
+            },
+          },
         },
       },
     } as OpenClawConfig;
-    const account = slackPlugin.config.resolveAccount(cfg, "default");
+    const account = slackPlugin.config.resolveAccount(cfg, "work");
 
     const result = await slackPlugin.status!.probeAccount!({
       account,
@@ -446,13 +450,33 @@ describe("slackPlugin status", () => {
       cfg,
     });
 
-    expect(probeSpy).toHaveBeenCalledWith("xoxb-test", 2500);
+    expect(probeSpy).toHaveBeenCalledWith("xoxb-work", 2500, { accountId: "work" });
     expect(result).toEqual({
       ok: true,
       status: 200,
       bot: { id: "B1", name: "openclaw-bot" },
       team: { id: "T1", name: "OpenClaw" },
     });
+  });
+
+  it("renders Slack probe token warnings in capabilities output", () => {
+    const lines = slackPlugin.status?.formatCapabilitiesProbe?.({
+      probe: {
+        ok: true,
+        warning: "Slack bot token is a user token",
+        bot: { id: "UUSER", name: "human-installer" },
+        team: { id: "T1", name: "OpenClaw" },
+      },
+    });
+
+    expect(lines).toStrictEqual([
+      {
+        text: "Warning: Slack bot token is a user token",
+        tone: "warn",
+      },
+      { text: "Bot: @human-installer" },
+      { text: "Team: OpenClaw (T1)" },
+    ]);
   });
 
   it("recovers thread routing from mixed-case Slack session keys", async () => {

--- a/extensions/slack/src/channel.ts
+++ b/extensions/slack/src/channel.ts
@@ -687,11 +687,18 @@ export const slackPlugin: ChannelPlugin<ResolvedSlackAccount, SlackProbe> = crea
         if (!token) {
           return { ok: false, error: "missing token" };
         }
-        return await (await loadSlackProbeModule()).probeSlack(token, timeoutMs);
+        return await (
+          await loadSlackProbeModule()
+        ).probeSlack(token, timeoutMs, {
+          accountId: account.accountId,
+        });
       },
       formatCapabilitiesProbe: ({ probe }) => {
         const slackProbe = probe as SlackProbe | undefined;
         const lines = [];
+        if (slackProbe?.warning) {
+          lines.push({ text: `Warning: ${slackProbe.warning}`, tone: "warn" } as const);
+        }
         if (slackProbe?.bot?.name) {
           lines.push({ text: `Bot: @${slackProbe.bot.name}` });
         }

--- a/extensions/slack/src/monitor.test-helpers.ts
+++ b/extensions/slack/src/monitor.test-helpers.ts
@@ -1,5 +1,6 @@
 // Slack helper module supports monitor helpers behavior.
 import type { ChannelRuntimeSurface } from "openclaw/plugin-sdk/channel-contract";
+import type { RuntimeEnv } from "openclaw/plugin-sdk/runtime-env";
 import { vi } from "vitest";
 import type { Mock } from "vitest";
 import { clearSlackInboundDeliveryStateForTest } from "./monitor/inbound-delivery-state.js";
@@ -12,6 +13,7 @@ type SlackProviderMonitor = (params: {
   abortSignal: AbortSignal;
   config?: Record<string, unknown>;
   channelRuntime?: ChannelRuntimeSurface;
+  runtime?: RuntimeEnv;
 }) => Promise<unknown>;
 
 type SlackTestState = {
@@ -86,7 +88,7 @@ function ensureSlackTestRuntime(): {
   }
   if (!globalState["__slackClient"]) {
     globalState["__slackClient"] = {
-      auth: { test: vi.fn().mockResolvedValue({ user_id: "bot-user" }) },
+      auth: { test: vi.fn().mockResolvedValue({ user_id: "bot-user", bot_id: "bot-id" }) },
       conversations: {
         info: vi.fn().mockResolvedValue({
           channel: { name: "dm", is_im: true },
@@ -138,7 +140,12 @@ async function waitForSlackEvent(name: string) {
 
 export function startSlackMonitor(
   monitorSlackProvider: SlackProviderMonitor,
-  opts?: { botToken?: string; appToken?: string; channelRuntime?: ChannelRuntimeSurface },
+  opts?: {
+    botToken?: string;
+    appToken?: string;
+    channelRuntime?: ChannelRuntimeSurface;
+    runtime?: RuntimeEnv;
+  },
 ) {
   const controller = new AbortController();
   const run = monitorSlackProvider({
@@ -147,6 +154,7 @@ export function startSlackMonitor(
     abortSignal: controller.signal,
     config: slackTestState.config,
     channelRuntime: opts?.channelRuntime,
+    runtime: opts?.runtime,
   });
   return { controller, run };
 }
@@ -225,7 +233,7 @@ export function resetSlackTestState(config: Record<string, unknown> = defaultSla
       entries.map((input) => ({ input, resolved: false })),
     );
   const client = getSlackClient();
-  client.auth.test.mockReset().mockResolvedValue({ user_id: "bot-user" });
+  client.auth.test.mockReset().mockResolvedValue({ user_id: "bot-user", bot_id: "bot-id" });
   client.conversations.info.mockReset().mockResolvedValue({
     channel: { name: "dm", is_im: true },
   });

--- a/extensions/slack/src/monitor/provider.auth-test-token.test.ts
+++ b/extensions/slack/src/monitor/provider.auth-test-token.test.ts
@@ -1,5 +1,5 @@
 // Slack tests cover auth.test token handling during provider boot.
-import { beforeEach, describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
   getSlackClient,
   resetSlackTestState,
@@ -27,5 +27,33 @@ describe("auth.test boot call", () => {
     if (firstArg != null) {
       expect(firstArg).not.toHaveProperty("token");
     }
+  });
+
+  it("warns when auth.test returns a user id without bot_id", async () => {
+    const runtimeLog = vi.fn();
+    const client = getSlackClient();
+    client.auth.test.mockResolvedValueOnce({
+      user_id: "UUSER",
+      user: "human-installer",
+      team_id: "T1",
+      team: "OpenClaw",
+    });
+
+    const monitor = startSlackMonitor(monitorSlackProvider, {
+      botToken: "xoxp-user-token",
+      runtime: {
+        log: runtimeLog,
+        error: vi.fn(),
+        exit: vi.fn(),
+      },
+    });
+    await stopSlackMonitor(monitor);
+
+    expect(runtimeLog).toHaveBeenCalledWith(
+      expect.stringContaining("channels.slack.accounts.default.botToken"),
+    );
+    expect(runtimeLog).toHaveBeenCalledWith(
+      expect.stringContaining("replace it with a Bot User OAuth Token"),
+    );
   });
 });

--- a/extensions/slack/src/monitor/provider.ts
+++ b/extensions/slack/src/monitor/provider.ts
@@ -38,7 +38,11 @@ import { normalizeSlackWebhookPath, registerSlackHttpHandler } from "../http/ind
 import { SLACK_TEXT_LIMIT } from "../limits.js";
 import { resolveSlackChannelAllowlist } from "../resolve-channels.js";
 import { resolveSlackUserAllowlist, type SlackUserResolution } from "../resolve-users.js";
-import { resolveSlackAppToken, resolveSlackBotToken } from "../token.js";
+import {
+  formatSlackBotTokenIdentityWarning,
+  resolveSlackAppToken,
+  resolveSlackBotToken,
+} from "../token.js";
 import { normalizeAllowList } from "./allow-list.js";
 import { resolveSlackSlashCommandConfig } from "./commands.js";
 import {
@@ -339,12 +343,17 @@ export async function monitorSlackProvider(opts: MonitorSlackOpts = {}) {
     slackMode === "socket" ? parseApiAppIdFromAppToken(appToken) : undefined;
   let authTestFailed = false;
   let authTestError: string | undefined;
+  let authIdentityWarning: string | undefined;
   try {
     const auth = await app.client.auth.test();
     botUserId = auth.user_id ?? "";
     botId = (auth as { bot_id?: string }).bot_id ?? "";
     teamId = auth.team_id ?? "";
     apiAppId = (auth as { api_app_id?: string }).api_app_id ?? "";
+    authIdentityWarning = formatSlackBotTokenIdentityWarning({
+      auth,
+      accountId: account.accountId,
+    });
     if (!botUserId) {
       authTestFailed = true;
       authTestError = "auth.test returned no user_id";
@@ -360,6 +369,9 @@ export async function monitorSlackProvider(opts: MonitorSlackOpts = {}) {
           "explicit bot-mention detection will be disabled until restart with a valid bot token",
       ),
     );
+  }
+  if (authIdentityWarning) {
+    runtime.log?.(warn(authIdentityWarning));
   }
 
   if (apiAppId && expectedApiAppIdFromAppToken && apiAppId !== expectedApiAppIdFromAppToken) {

--- a/extensions/slack/src/probe.test.ts
+++ b/extensions/slack/src/probe.test.ts
@@ -41,6 +41,7 @@ describe("probeSlack", () => {
     authTestMock.mockResolvedValue({
       ok: true,
       user_id: "U123",
+      bot_id: "B123",
       user: "openclaw-bot",
       team_id: "T123",
       team: "OpenClaw",
@@ -58,6 +59,25 @@ describe("probeSlack", () => {
     const [promise, timeoutMs] = requireFirstTimeoutCall();
     expect(promise).toBeInstanceOf(Promise);
     expect(timeoutMs).toBe(2500);
+  });
+
+  it("warns when auth.test looks like a user token in the bot token slot", async () => {
+    vi.spyOn(Date, "now").mockReturnValueOnce(100).mockReturnValueOnce(145);
+    authTestMock.mockResolvedValue({
+      ok: true,
+      user_id: "UUSER",
+      user: "human-installer",
+      team_id: "T123",
+      team: "OpenClaw",
+    });
+
+    await expect(probeSlack("xoxp-user-token", 2500, { accountId: "work" })).resolves.toMatchObject(
+      {
+        ok: true,
+        warning:
+          'Slack auth.test identified account "work" as user UUSER without bot_id. channels.slack.accounts.work.botToken appears to contain a user token; replace it with a Bot User OAuth Token. Until replaced, OpenClaw can mistake mentions of that user for bot mentions.',
+      },
+    );
   });
 
   it("keeps optional auth metadata fields undefined when Slack omits them", async () => {

--- a/extensions/slack/src/probe.ts
+++ b/extensions/slack/src/probe.ts
@@ -3,15 +3,21 @@ import type { BaseProbeResult } from "openclaw/plugin-sdk/channel-contract";
 import { withTimeout } from "openclaw/plugin-sdk/text-utility-runtime";
 import { createSlackWebClient } from "./client.js";
 import { formatSlackError } from "./errors.js";
+import { formatSlackBotTokenIdentityWarning } from "./token.js";
 
 export type SlackProbe = BaseProbeResult & {
   status?: number | null;
   elapsedMs?: number | null;
   bot?: { id?: string; name?: string };
   team?: { id?: string; name?: string };
+  warning?: string;
 };
 
-export async function probeSlack(token: string, timeoutMs = 2500): Promise<SlackProbe> {
+export async function probeSlack(
+  token: string,
+  timeoutMs = 2500,
+  opts?: { accountId?: string | null },
+): Promise<SlackProbe> {
   const client = createSlackWebClient(token);
   const start = Date.now();
   try {
@@ -24,12 +30,17 @@ export async function probeSlack(token: string, timeoutMs = 2500): Promise<Slack
         elapsedMs: Date.now() - start,
       };
     }
+    const warning = formatSlackBotTokenIdentityWarning({
+      auth: result,
+      accountId: opts?.accountId,
+    });
     return {
       ok: true,
       status: 200,
       elapsedMs: Date.now() - start,
       bot: { id: result.user_id, name: result.user },
       team: { id: result.team_id, name: result.team },
+      ...(warning ? { warning } : {}),
     };
   } catch (err) {
     const message = formatSlackError(err);

--- a/extensions/slack/src/token.ts
+++ b/extensions/slack/src/token.ts
@@ -1,5 +1,25 @@
 // Slack plugin module implements token behavior.
+import type { AuthTestResponse } from "@slack/web-api";
 import { normalizeResolvedSecretInputString } from "openclaw/plugin-sdk/secret-input";
+
+export function formatSlackBotTokenIdentityWarning(params: {
+  auth: Pick<AuthTestResponse, "bot_id" | "user_id">;
+  accountId?: string | null;
+}): string | undefined {
+  const userId = params.auth.user_id?.trim();
+  const botId = params.auth.bot_id?.trim();
+  // Slack documents bot_id only for bot-token auth.test responses. Use response identity,
+  // not token prefixes, so rotated bot and user tokens stay supported.
+  if (!userId || botId) {
+    return undefined;
+  }
+  const accountId = params.accountId?.trim() || "default";
+  const tokenPath =
+    accountId === "default"
+      ? "channels.slack.botToken, channels.slack.accounts.default.botToken, or SLACK_BOT_TOKEN"
+      : `channels.slack.accounts.${accountId}.botToken`;
+  return `Slack auth.test identified account "${accountId}" as user ${userId} without bot_id. ${tokenPath} appears to contain a user token; replace it with a Bot User OAuth Token. Until replaced, OpenClaw can mistake mentions of that user for bot mentions.`;
+}
 
 export function resolveSlackBotToken(
   raw?: unknown,


### PR DESCRIPTION
Closes #98357
Supersedes #98358 because the contributor fork branch could not be updated across current `main` without GitHub's `workflow` OAuth scope.

AI-assisted maintainer follow-through; original implementation credited via commit co-authorship.

## What Problem This Solves

Fixes an issue where Slack operators could put a user OAuth token in the bot-token slot and still see startup and account probing succeed without any indication that OpenClaw had authenticated as a human workspace member.

That misconfiguration is especially confusing because Slack mention and self-author handling uses the authenticated identity.

## Why This Change Was Made

Slack's documented `auth.test` response includes `bot_id` for bot tokens and omits it for user tokens. The Slack plugin now uses that response identity to emit one non-fatal warning from provider startup and account capabilities probing, while preserving normal startup, token precedence, and correctly configured bot-token behavior.

The check deliberately does not parse token prefixes, so Slack's rotated `xoxe` token forms remain supported. Default-account remediation covers top-level config, `accounts.default`, and environment fallback; named accounts receive their exact config path.

## User Impact

Slack operators now get a precise warning and replacement guidance when the configured bot-token credential authenticates as a user. Existing valid Slack bot-token setups have no new output or behavior change.

## Evidence

- Slack contract: official `auth.test` documentation shows user-token success with `user_id` and no `bot_id`, and bot-token success with both fields. Installed `@slack/web-api@7.16.0` exposes both optional response fields.
- Contributor live proof: a disposable Slack app exercised the changed `probeSlack()` path against Slack's real `auth.test`; a user token produced the warning, while the bot-token control did not. Token, user, and workspace details were redacted and the disposable app was removed.
- Focused tests: `node scripts/run-vitest.mjs extensions/slack/src/probe.test.ts extensions/slack/src/channel.test.ts extensions/slack/src/monitor/provider.auth-test-token.test.ts` — 3 files, 52 tests passed.
- Fresh autoreview after maintainer refinement: clean, correctness 0.97.
- Maintainer refinement: added the supported `channels.slack.accounts.default.botToken` remediation path, switched to the SDK response type, documented the rotation-safe dependency contract, and removed 73 net lines of duplicate/overfit tests.
- Exact head `9e497b167a53a151eb70e5622ae5de1f344387ef`: [CI run 28703706649](https://github.com/openclaw/openclaw/actions/runs/28703706649) passed with 44 successful jobs and 10 intentional skips. CodeQL Critical Quality, Workflow Sanity, OpenGrep, and iOS Periphery also passed; `scripts/pr prepare-run 99931` accepted the exact-head hosted CI/Testbox gates.

Contributor credit: @ooiuuii / luyifan.
