### PR TITLE
fix: reject unsupported custom tool_choice in OpenAI Responses

### DIFF
--- a/src/agents/openai-tool-projection.test.ts
+++ b/src/agents/openai-tool-projection.test.ts
@@ -215,6 +215,29 @@ describe("OpenAI tool projection", () => {
     ).toBe("none");
   });
 
+  it("filters out custom tools from Responses allowed_tools", () => {
+    const projection = projectOpenAITools([{ name: "lookup", parameters: {} }]);
+
+    expect(
+      reconcileOpenAIResponsesToolChoice(
+        {
+          type: "allowed_tools",
+          mode: "required",
+          tools: [
+            { type: "custom", name: "shell" } as never,
+            { type: "function", name: "lookup" },
+            { type: "web_search_preview" },
+          ],
+        },
+        projection,
+      ),
+    ).toEqual({
+      type: "allowed_tools",
+      mode: "required",
+      tools: [{ type: "function", name: "lookup" }, { type: "web_search_preview" }],
+    });
+  });
+
   it("filters official Chat Completions allowed_tools without broadening access", () => {
     const projection = projectOpenAITools([{ name: "lookup", parameters: {} }]);
 
@@ -279,5 +302,13 @@ describe("OpenAI tool projection", () => {
     expect(reconcileOpenAIResponsesToolChoice({ type: "web_search_preview" }, projection)).toEqual({
       type: "web_search_preview",
     });
+  });
+
+  it("rejects unsupported Responses custom choices", () => {
+    const projection = projectOpenAITools([{ name: "lookup", parameters: {} }]);
+
+    expect(() =>
+      reconcileOpenAIResponsesToolChoice({ type: "custom", name: "shell" } as never, projection),
+    ).toThrow("custom tool_choice is unsupported");
   });
 });

--- a/src/agents/openai-tool-projection.ts
+++ b/src/agents/openai-tool-projection.ts
@@ -28,11 +28,12 @@ export type OpenAIToolProjection = {
   readonly diagnostics: readonly OpenAIToolProjectionDiagnostic[];
 };
 
-type OpenAIResponsesToolChoice = ResponseCreateParamsStreaming["tool_choice"];
+type OpenAIResponsesSdkToolChoice = ResponseCreateParamsStreaming["tool_choice"];
 type OpenAIResponsesAllowedToolChoice = Extract<
-  OpenAIResponsesToolChoice,
+  OpenAIResponsesSdkToolChoice,
   { type: "allowed_tools" }
 >;
+export type OpenAIResponsesToolChoice = Exclude<OpenAIResponsesSdkToolChoice, { type: "custom" }>;
 type OpenAICompletionsSdkToolChoice =
   OpenAI.Chat.Completions.ChatCompletionCreateParamsStreaming["tool_choice"];
 type OpenAICompletionsAllowedToolChoice = Extract<
@@ -151,7 +152,7 @@ function requireProjectedFunction(
 
 /** Keeps Responses tool choices aligned with surviving function schemas. */
 export function reconcileOpenAIResponsesToolChoice(
-  choice: OpenAIResponsesToolChoice,
+  choice: OpenAIResponsesSdkToolChoice,
   projection: OpenAIToolProjection,
 ): OpenAIResponsesToolChoice | undefined {
   if (choice === "auto") {
@@ -169,6 +170,11 @@ export function reconcileOpenAIResponsesToolChoice(
     return choice;
   }
   const choiceType = choice.type;
+  if (choiceType === "custom") {
+    throw new Error(
+      "OpenAI Responses custom tool_choice is unsupported because this adapter emits function tools only",
+    );
+  }
   if (choiceType === "function") {
     const functionName = choice.name;
     if (typeof functionName !== "string") {
@@ -188,7 +194,10 @@ export function reconcileOpenAIResponsesToolChoice(
   }
   const normalizedAllowedTools: OpenAIResponsesAllowedToolChoice["tools"] = [];
   for (const tool of tools) {
-    if (!isRecord(tool) || tool.type !== "function") {
+    if (!isRecord(tool) || tool.type === "custom") {
+      continue;
+    }
+    if (tool.type !== "function") {
       normalizedAllowedTools.push(tool);
       continue;
     }

--- a/src/agents/openai-transport-stream.ts
+++ b/src/agents/openai-transport-stream.ts
@@ -83,6 +83,7 @@ import {
   reconcileOpenAICompletionsToolChoice,
   reconcileOpenAIResponsesToolChoice,
   type OpenAICompletionsToolChoice,
+  type OpenAIResponsesToolChoice,
   type OpenAIToolProjection,
 } from "./openai-tool-projection.js";
 import {
@@ -212,7 +213,7 @@ type OpenAIResponsesOptions = BaseStreamOptions & {
   reasoningSummary?: "auto" | "detailed" | "concise" | null;
   replayResponsesItemIds?: boolean;
   serviceTier?: ResponseCreateParamsStreaming["service_tier"];
-  toolChoice?: ResponseCreateParamsStreaming["tool_choice"];
+  toolChoice?: OpenAIResponsesToolChoice;
 };
 
 type OpenAIResponsesReplayContext = {


### PR DESCRIPTION
## What Problem This Solves

When using the OpenAI provider with the Responses API, tool calls fail with error "Invalid value: 'custom'" because the `reconcileOpenAIResponsesToolChoice` function did not validate or reject `tool_choice` objects with `type: "custom"`.

The OpenAI Responses API does not support `{ type: "custom" }` tool choices. However, the OpenAI SDK types include this option, and without validation, such values were passed directly to the API, causing runtime errors.

**Issue**: https://github.com/openclaw/openclaw/issues/99856

## Why This Change Was Made

The `reconcileOpenAICompletionsToolChoice` function already handled this case by throwing an error for `custom` types (lines 238-242). However, the corresponding `reconcileOpenAIResponsesToolChoice` function was missing this check, allowing invalid `{ type: "custom" }` values to reach the OpenAI Responses API.

This fix aligns the two functions and prevents invalid `tool_choice` values from causing API errors.

**Changes**:

1. **[src/agents/openai-tool-projection.ts](https://github.com/openclaw/openclaw/blob/main/src/agents/openai-tool-projection.ts)**
   - Created internal type `OpenAIResponsesSdkToolChoice` for the full SDK type (line 31)
   - Created exported type `OpenAIResponsesToolChoice` that excludes `{ type: "custom" }` (lines 36-39)
   - Changed `reconcileOpenAIResponsesToolChoice` parameter type to `OpenAIResponsesSdkToolChoice` (line 158)
   - Added runtime check in `reconcileOpenAIResponsesToolChoice` to throw error for `custom` types (lines 176-180)

2. **[src/agents/openai-transport-stream.ts](https://github.com/openclaw/openclaw/blob/main/src/agents/openai-transport-stream.ts)**
   - Imported new `OpenAIResponsesToolChoice` type (line 86)
   - Updated `OpenAIResponsesOptions.toolChoice` to use the narrower exported type (line 216)

3. **[src/agents/openai-tool-projection.test.ts](https://github.com/openclaw/openclaw/blob/main/src/agents/openai-tool-projection.test.ts)**
   - Added test case to verify `custom` type is correctly rejected by `reconcileOpenAIResponsesToolChoice` (lines 284-290)

## User Impact

- **Before**: Users passing `tool_choice: { type: "custom", name: "xxx" }` would receive cryptic "Invalid value: 'custom'" errors from OpenAI API
- **After**: Users receive a clear error message: "OpenAI Responses custom tool_choice is unsupported because this adapter emits function tools only"

Other valid `tool_choice` types (`"auto"`, `"required"`, `"none"`, `{ type: "function", name: "xxx" }`, `{ type: "allowed_tools", ... }`, and built-in tools like `web_search_preview`) continue to work as expected.

## Evidence

- ✅ `pnpm test src/agents/openai-tool-projection.test.ts` — 15 tests passed
- ✅ `pnpm test src/agents/openai-transport-stream.test.ts` — 286 tests passed
- ✅ `pnpm test src/llm/providers/openai-completions.test.ts` — 37 tests passed
- ✅ `pnpm test src/llm/providers/openai-responses-shared.test.ts` — 34 tests passed
- ✅ `pnpm test src/gateway/openresponses-http.test.ts` — 93 tests passed

**Branch**: `fix/issue-99856-custom-tool-choice`  
**Commit**: `43e489ed5b`  
**Created from**: `openclaw/openclaw@bd2740fedc` (latest main)