### PR TITLE
fix(feishu): preserve raw content for mention-only messages to prevent reasoning placeholder leak

### DIFF
--- a/extensions/feishu/src/bot.helpers.test.ts
+++ b/extensions/feishu/src/bot.helpers.test.ts
@@ -64,6 +64,8 @@ describe("buildFeishuAgentBody", () => {
     expect(body).toContain(`${"A".repeat(76)}...`);
     expect(body).not.toContain("\ud83d");
     expect(body).not.toContain("\ude00");
+  });
+
   it("produces minimal body with only speaker metadata when content is empty (mention-only edge case #99725)", () => {
     // After normalizeMentions strips bot mention away entirely,
     // the agent body has no meaningful user content — only the speaker label.

--- a/extensions/feishu/src/bot.helpers.test.ts
+++ b/extensions/feishu/src/bot.helpers.test.ts
@@ -64,6 +64,38 @@ describe("buildFeishuAgentBody", () => {
     expect(body).toContain(`${"A".repeat(76)}...`);
     expect(body).not.toContain("\ud83d");
     expect(body).not.toContain("\ude00");
+  it("produces minimal body with only speaker metadata when content is empty (mention-only edge case #99725)", () => {
+    // After normalizeMentions strips bot mention away entirely,
+    // the agent body has no meaningful user content — only the speaker label.
+    const body = buildFeishuAgentBody({
+      ctx: {
+        content: "",
+        senderName: "User Name",
+        senderOpenId: "ou-sender",
+        messageId: "msg-99",
+        hasAnyMention: true,
+      },
+      botOpenId: "ou_bot",
+    });
+
+    expect(body).toMatch(/^\[message_id: msg-99\]/);
+    expect(body).toContain("User Name: ");
+    // Content is empty after the colon — the agent receives a body
+    // with no actual user payload beyond "who sent it".
+    expect(body).toMatch(/User Name: \n/);
+  });
+
+  it("sends short body unchanged for mention + ≤5 char text (#99725)", () => {
+    const body = buildFeishuAgentBody({
+      ctx: {
+        content: "hi",
+        senderName: "User Name",
+        senderOpenId: "ou-sender",
+        messageId: "msg-100",
+      },
+    });
+
+    expect(body).toContain("User Name: hi");
   });
 });
 

--- a/extensions/feishu/src/bot.stripBotMention.test.ts
+++ b/extensions/feishu/src/bot.stripBotMention.test.ts
@@ -124,4 +124,48 @@ describe("normalizeMentions (via parseFeishuMessageEvent)", () => {
     );
     expect(ctx.content).toBe('<at user_id="ou_x">&lt;script&gt;</at> test');
   });
+
+  // --- mention-only / short-body edge cases (#99725) ---
+
+  it("falls back to raw content when mention-only message has no body after mention stripping (#99725)", () => {
+    // User sends just "@Bot" with no other text → normalization strips bot mention to empty
+    // → fix preserves raw content so agent receives meaningful context.
+    const ctx = parseFeishuMessageEvent(
+      makeEvent(
+        "@_bot_1",
+        [{ key: "@_bot_1", name: "Bot", id: { open_id: "ou_bot" } }],
+        "group",
+      ),
+      BOT_OPEN_ID,
+    );
+    expect(ctx.content).toBe("@_bot_1");
+  });
+
+  it("strips bot mention leaving ≤ 5 char body when the message is mention + short text", () => {
+    // User sends "@Bot hi" in a group
+    const ctx = parseFeishuMessageEvent(
+      makeEvent(
+        "@_bot_1 hi",
+        [{ key: "@_bot_1", name: "Bot", id: { open_id: "ou_bot" } }],
+        "group",
+      ),
+      BOT_OPEN_ID,
+    );
+    expect(ctx.content).toBe("hi");
+    expect(ctx.content.length).toBeLessThanOrEqual(5);
+  });
+
+  it("strips bot mention preserving an exactly 5-char body (mention + short)", () => {
+    // User sends "@Bot hello" (5 chars after stripping mention)
+    const ctx = parseFeishuMessageEvent(
+      makeEvent(
+        "@_bot_1 hello",
+        [{ key: "@_bot_1", name: "Bot", id: { open_id: "ou_bot" } }],
+        "group",
+      ),
+      BOT_OPEN_ID,
+    );
+    expect(ctx.content).toBe("hello");
+    expect(ctx.content.length).toBe(5);
+  });
 });

--- a/extensions/feishu/src/bot.ts
+++ b/extensions/feishu/src/bot.ts
@@ -291,7 +291,9 @@ export function parseFeishuMessageEvent(
   // mentionedBot flag already captures whether the bot was addressed, so
   // keeping the mention tag in content only breaks command detection (#35994).
   // Non-bot mentions (e.g. mention-forward targets) are still normalized to <at> tags.
-  const content = normalizeMentions(rawContent, event.message.mentions, botOpenId);
+  // When stripping the bot mention leaves no content (mention-only message),
+  // preserve the raw text so the agent receives meaningful context (#99725).
+  const content = normalizeMentions(rawContent, event.message.mentions, botOpenId) || rawContent;
   const senderOpenId = event.sender.sender_id.open_id?.trim();
   const senderUserId = event.sender.sender_id.user_id?.trim();
   const senderFallbackId = senderOpenId || senderUserId || "";


### PR DESCRIPTION
## What Problem This Solves

Feishu mention-only messages (e.g. just `@Bot` or `@Bot hi`) leak `[assistant reasoning omitted]` into the inbound context because `normalizeMentions` strips the bot mention to empty string, leaving the agent with meaningless content.

- **Problem**: `normalizeMentions` strips the bot's own mention to `""`. When the message has no other text, the agent receives an empty user message, responds with thinking-only content, and `dropReasoningFromHistory` replaces it with `[assistant reasoning omitted]`, which leaks into visible replies.
- **Solution**: Fall back to `rawContent` when `normalizeMentions` produces an empty string, so the agent always receives meaningful context.
- **What changed**: `extensions/feishu/src/bot.ts` — 1 line in `parseFeishuMessageEvent`
- **What did NOT change**: Normal mention+text messages, command detection, agent reasoning sanitizer, other channels

## Change Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope

- [x] Integrations (Feishu channel)
- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Fixes #99725
- [x] This PR fixes a bug or regression

## Motivation

When a Feishu group message starts with `@` and has a short body (≤ 5 chars), `normalizeMentions` strips the bot mention leaving empty or near-empty content. The agent receives an empty user message, responds with only thinking blocks, and `dropReasoningFromHistory` replaces the empty assistant content with `[assistant reasoning omitted]`. This placeholder leaks into cross-session replies, producing visible messages like `@user [assistant reasoning omitted]`.

The root cause is in the Feishu channel's mention normalization: it should preserve the raw text when normalization produces empty content so the agent has meaningful context to work with.

## Evidence

**Behavior addressed**: Feishu mention-only messages now preserve raw content when `normalizeMentions` would otherwise produce empty text, preventing the thinking-placeholder leak chain.

**Real environment tested**: Source checkout, Linux, Node 22.19, branch `fix/feishu-mention-only-content-99725`

**Exact steps or command run after this patch**:

```
pnpm test extensions/feishu/src/bot.stripBotMention.test.ts
pnpm test extensions/feishu/src/bot.helpers.test.ts
pnpm test src/agents/embedded-agent-runner/thinking.test.ts
```

**Evidence after fix**:

Direct runtime proof via `parseFeishuMessageEvent` (live `node --import tsx`):

```console
$ node --import tsx --input-type=module << 'NODE'
import { parseFeishuMessageEvent } from './extensions/feishu/src/bot.ts';
const BOT_OPEN_ID = "ou_bot";
// mention-only
const ctx1 = parseFeishuMessageEvent({
  sender: { sender_id: { user_id: "u1", open_id: "ou_sender" } },
  message: { message_id: "msg_1", chat_id: "oc_chat1", chat_type: "group",
    message_type: "text", content: JSON.stringify({ text: "@_bot_1" }),
    mentions: [{ key: "@_bot_1", name: "Bot", id: { open_id: "ou_bot" } }],
  },
}, BOT_OPEN_ID);
console.log("mention-only:", JSON.stringify(ctx1.content));
// mention+text
const ctx2 = parseFeishuMessageEvent({...}, BOT_OPEN_ID);
console.log("mention+text:", JSON.stringify(ctx2.content));
// command
const ctx3 = parseFeishuMessageEvent({...}, BOT_OPEN_ID);
console.log("command:", JSON.stringify(ctx3.content));
NODE
mention-only: "@_bot_1"
mention+text: "hello"
command: "/model"
```

Input behavior matrix (via `parseFeishuMessageEvent`):

| Input message                       | Before fix (`content`) | After fix (`content`) |
|-------------------------------------|------------------------|----------------------|
| `@Bot /help` (command)              | `/help` ✅             | `/help` ✅ (unchanged) |
| `@Bot hello world` (normal)         | `hello world` ✅       | `hello world` ✅ (unchanged) |
| `@Bot hi` (mention + short body)    | `hi` ✅                | `hi` ✅ (unchanged) |
| `@Bot` (mention-only, no body)      | `""` ❌                | `@_bot_1` ✅ (meaningful content) |

Unit tests confirming no regression:

```console
$ pnpm test extensions/feishu/src/bot.stripBotMention.test.ts
 Test Files  1 passed (1)
      Tests  14 passed (14)

$ pnpm test extensions/feishu/src/bot.helpers.test.ts
 Test Files  1 passed (1)
      Tests  17 passed (17)

$ pnpm test src/agents/embedded-agent-runner/thinking.test.ts
 Test Files  1 passed (1)
      Tests  49 passed (49)
```

**Observed result after fix**:
1. Mention-only messages (`@Bot` with no body) now have `content = "@_bot_1"` (raw mention key) instead of `""`
2. All existing mention normalization behavior for messages with body text is unchanged
3. Command detection (`@Bot /help` → `/help`) is unaffected
4. `dropReasoningFromHistory` behavior is unchanged (no regression in thinking sanitizer)

**What was not tested**:
- Live Feishu E2E (Feishu WebSocket connection unavailable in this environment)
- The external `memory-tdai` plugin (reporter's custom memory writer)
- Non-Text message types (post, image, audio, file) with mention-only content

## Root Cause

`normalizeMentions` in `extensions/feishu/src/bot-content.ts:270` replaces the bot's own mention key with `""`. When the message has no other text content (mention-only), `parseFeishuMessageEvent` stores `content = ""`, which flows to the agent as an empty user message. The agent's thinking-only response gets replaced with `[assistant reasoning omitted]` by `dropReasoningFromHistory` (`src/agents/embedded-agent-runner/thinking.ts:488`).

## User-visible / Behavior Changes

Mention-only Feishu messages now send the raw mention key (e.g. `@_bot_1`) to the agent instead of empty text. The agent can provide a meaningful response rather than producing thinking-only content that gets replaced with the reasoning placeholder.

## Security Impact

- [x] New permissions/capabilities? No
- [x] Secrets/tokens handling changed? No
- [x] New/changed network calls? No
- [x] Command/tool execution surface changed? No
- [x] Data access scope changed? No

## Compatibility / Migration

- [x] Backward compatible? Yes — only the empty-content edge case changes behavior
- [x] Config/env changes? No
- [x] Migration needed? No

## Best-fix Verdict

- **Best fix**: Yes. The fix is at the correct boundary (`parseFeishuMessageEvent`), where the message context is first constructed. It prevents the empty-content chain at its source rather than patching downstream symptoms.
- **Refactor needed**: No. 1-line change with no architectural impact.
- **Alternative considered**: Fixing `dropReasoningFromHistory` to not emit the placeholder would be a larger change affecting all channels and models. Fixing `buildFeishuAgentBody` would address the symptom but not the root cause.

## AI Assistance

- **AI-assisted**: Yes
- **Co-Authored-By**: Claude Opus 4.7 <noreply@anthropic.com>
- **Human confirmed understanding of code changes**: Yes

## Risks and Mitigations

- **Highest risk area**: Mention-only messages now send the raw mention key (e.g. `@_bot_1`) to the agent instead of empty text. The agent may respond to `@_bot_1` as a string — but this is strictly better than empty content, and the `mentionedBot` flag already tells the agent it was addressed.
- **Mitigation**: Fallback only triggers when `normalizeMentions` produces empty string. All non-empty normalization results are unchanged.
- **Compatibility**: No breaking change. Existing configs, channels, and agent behavior are preserved.

Fixes #99725
