### PR TITLE
fix(clawrouter): prevent oversized usage responses from exhausting memory

### DIFF
--- a/extensions/clawrouter/usage.test.ts
+++ b/extensions/clawrouter/usage.test.ts
@@ -1,6 +1,34 @@
 import { describe, expect, it, vi } from "vitest";
 import { fetchClawRouterUsage } from "./usage.js";
 
+function oversizedJsonResponse(): {
+  response: Response;
+  state: { canceled: boolean; enqueuedBytes: number };
+} {
+  const state = { canceled: false, enqueuedBytes: 0 };
+  const chunk = 1024 * 1024;
+  const maxChunks = 64;
+  let emitted = 0;
+  const response = new Response(
+    new ReadableStream({
+      pull(controller) {
+        if (emitted >= maxChunks) {
+          controller.close();
+          return;
+        }
+        emitted += 1;
+        state.enqueuedBytes += chunk;
+        controller.enqueue(new Uint8Array(chunk));
+      },
+      cancel() {
+        state.canceled = true;
+      },
+    }),
+    { headers: { "content-type": "application/json" } },
+  );
+  return { response, state };
+}
+
 describe("ClawRouter usage", () => {
   it("maps the managed monthly budget and usage totals", async () => {
     const fetchFn = vi.fn(async () =>
@@ -69,6 +97,20 @@ describe("ClawRouter usage", () => {
     expect(snapshot.windows).toEqual([]);
     expect(snapshot.summary).toBe("0 requests · 0 tokens · $0.00 used");
     expect(snapshot.plan).toBe("Unmetered proxy key");
+  });
+
+  it("rejects oversized successful JSON responses before buffering the whole body", async () => {
+    const { response, state } = oversizedJsonResponse();
+
+    await expect(
+      fetchClawRouterUsage({
+        token: "proxy-key",
+        timeoutMs: 5000,
+        fetchFn: vi.fn(async () => response) as unknown as typeof fetch,
+      }),
+    ).rejects.toThrow("ClawRouter usage: JSON response exceeds 16777216 bytes");
+    expect(state.canceled).toBe(true);
+    expect(state.enqueuedBytes).toBeLessThan(64 * 1024 * 1024);
   });
 
   it("does not expose an upstream error body", async () => {

--- a/extensions/clawrouter/usage.ts
+++ b/extensions/clawrouter/usage.ts
@@ -1,3 +1,4 @@
+import { readProviderJsonResponse } from "openclaw/plugin-sdk/provider-http";
 import type { ProviderUsageSnapshot } from "openclaw/plugin-sdk/provider-usage";
 import { normalizeClawRouterRootUrl } from "./provider-catalog.js";
 
@@ -78,7 +79,10 @@ export async function fetchClawRouterUsage(params: {
   if (!response.ok) {
     throw new Error(`ClawRouter usage request failed (HTTP ${response.status})`);
   }
-  const payload = (await response.json()) as ClawRouterUsagePayload;
+  const payload = await readProviderJsonResponse<ClawRouterUsagePayload>(
+    response,
+    "ClawRouter usage",
+  );
   const budget = payload.budget;
   const limitMicros = nonNegativeNumber(budget?.limitMicros);
   const spentMicros = nonNegativeNumber(budget?.spentMicros);


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where ClawRouter usage/quota probes could buffer an unexpectedly large successful JSON response when the remote usage API returned an oversized body. The request already had a timeout, but the success-path JSON body read was not byte-bounded, so a malformed or hostile upstream response could amplify memory and CPU use before failing.

## Why This Change Was Made

The ClawRouter usage fetch now reads successful usage JSON through the shared provider HTTP JSON reader, which applies the established provider JSON byte cap and cancels oversized streams. This keeps the fix scoped to ClawRouter usage response parsing; it does not change ClawRouter request routing, auth, budgets, or non-2xx error body handling.

## User Impact

Users and operators can keep ClawRouter usage/status surfaces enabled with a bounded failure mode if the usage endpoint returns an abnormal success body. Normal ClawRouter usage summaries and budget windows continue to parse as before.

## Evidence

- Regression coverage: oversized streaming success JSON now fails before buffering the whole body, cancels the stream, and the existing ClawRouter usage mapping tests still pass.

  ```text
  [test] starting test/vitest/vitest.extensions.config.ts
  
   RUN  v4.1.8 [local path redacted]
  
   Test Files  1 passed (1)
        Tests  4 passed (4)
     Start at  18:42:19
     Duration  2.39s (transform 1.14s, setup 447ms, import 1.45s, tests 198ms, environment 0ms)
  
  [test] passed 1 Vitest shard in 12.04s
  ```

- Extension package-boundary compile verifies the new plugin-sdk provider HTTP import remains valid for bundled extensions.

  ```text
  $ node scripts/check-extension-package-tsc-boundary.mjs --mode=compile
  preparing plugin-sdk boundary artifacts for 117 plugins
  compile concurrency 4
  [15/117] clawrouter
  extension package boundary check passed
  mode: compile
  compiled plugins: 117
  canary plugins: 0
  ```
