### PR TITLE
fix(voice-call): handle spawn error on tailscale stop cleanup

### DIFF
--- a/extensions/voice-call/src/tunnel.test.ts
+++ b/extensions/voice-call/src/tunnel.test.ts
@@ -210,4 +210,24 @@ describe("voice-call tunnels", () => {
     expect(tunnel?.publicUrl).toBe("https://dispatch.ngrok.io/hook");
     expect(tunnel?.provider).toBe("ngrok");
   });
+
+  it("handles spawn errors on tailscale stop cleanup without crashing", async () => {
+    mocks.getTailscaleDnsName.mockResolvedValue("host.tailnet.ts.net");
+    // Start the tunnel — first spawn is tailscale serve (succeeds)
+    const startProc = nextProcess();
+    const result = startTailscaleTunnel({ mode: "serve", port: 3334, path: "/voice/stop" });
+    await vi.waitFor(() => expect(mocks.spawn).toHaveBeenCalled());
+    startProc.close(0);
+    const tunnel = await result;
+
+    // Stop the tunnel — second spawn is tailscale stop (errors)
+    const stopProc = nextProcess();
+    const stopPromise = tunnel.stop();
+    await vi.waitFor(() => expect(mocks.spawn).toHaveBeenCalledTimes(2));
+    // Emit error on the stop process — without the fix this crashes
+    stopProc.fail(new Error("tailscale not found"));
+
+    // The stop promise must still resolve despite the error
+    await expect(stopPromise).resolves.toBeUndefined();
+  });
 });

--- a/extensions/voice-call/src/tunnel.test.ts
+++ b/extensions/voice-call/src/tunnel.test.ts
@@ -31,7 +31,8 @@ vi.mock("node:child_process", () => ({
   spawn: mocks.spawn,
 }));
 
-vi.mock("./webhook/tailscale.js", () => ({
+vi.mock("./webhook/tailscale.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("./webhook/tailscale.js")>()),
   getTailscaleDnsName: mocks.getTailscaleDnsName,
 }));
 
@@ -211,23 +212,25 @@ describe("voice-call tunnels", () => {
     expect(tunnel?.provider).toBe("ngrok");
   });
 
-  it("handles spawn errors on tailscale stop cleanup without crashing", async () => {
+  it("resolves cleanup when the tailscale stop process cannot spawn", async () => {
     mocks.getTailscaleDnsName.mockResolvedValue("host.tailnet.ts.net");
-    // Start the tunnel — first spawn is tailscale serve (succeeds)
     const startProc = nextProcess();
     const result = startTailscaleTunnel({ mode: "serve", port: 3334, path: "/voice/stop" });
     await vi.waitFor(() => expect(mocks.spawn).toHaveBeenCalled());
     startProc.close(0);
     const tunnel = await result;
 
-    // Stop the tunnel — second spawn is tailscale stop (errors)
     const stopProc = nextProcess();
     const stopPromise = tunnel.stop();
     await vi.waitFor(() => expect(mocks.spawn).toHaveBeenCalledTimes(2));
-    // Emit error on the stop process — without the fix this crashes
+    expect(mocks.spawn).toHaveBeenNthCalledWith(
+      2,
+      "tailscale",
+      ["serve", "off", "/voice/stop"],
+      { stdio: ["ignore", "pipe", "ignore"] },
+    );
     stopProc.fail(new Error("tailscale not found"));
 
-    // The stop promise must still resolve despite the error
     await expect(stopPromise).resolves.toBeUndefined();
   });
 });

--- a/extensions/voice-call/src/tunnel.ts
+++ b/extensions/voice-call/src/tunnel.ts
@@ -282,6 +282,10 @@ async function stopTailscaleTunnel(mode: "serve" | "funnel", path: string): Prom
       clearTimeout(timeout);
       resolve();
     });
+    proc.on("error", () => {
+      clearTimeout(timeout);
+      resolve();
+    });
   });
 }
 

--- a/extensions/voice-call/src/tunnel.ts
+++ b/extensions/voice-call/src/tunnel.ts
@@ -5,7 +5,10 @@ import {
   emptyBoundedChildOutput,
   formatBoundedChildOutput,
 } from "./bounded-child-output.js";
-import { getTailscaleDnsName } from "./webhook/tailscale.js";
+import {
+  cleanupTailscaleExposureRoute,
+  getTailscaleDnsName,
+} from "./webhook/tailscale.js";
 
 const NGROK_LOG_BUFFER_MAX_CHARS = 16_384;
 
@@ -247,7 +250,7 @@ export async function startTailscaleTunnel(config: {
           publicUrl,
           provider: `tailscale-${config.mode}`,
           stop: async () => {
-            await stopTailscaleTunnel(config.mode, path);
+            await cleanupTailscaleExposureRoute({ mode: config.mode, path });
           },
         });
       } else {
@@ -260,31 +263,6 @@ export async function startTailscaleTunnel(config: {
     proc.on("error", (err) => {
       clearTimeout(timeout);
       reject(err);
-    });
-  });
-}
-
-/**
- * Stop a Tailscale serve/funnel tunnel.
- */
-async function stopTailscaleTunnel(mode: "serve" | "funnel", path: string): Promise<void> {
-  return new Promise((resolve) => {
-    const proc = spawn("tailscale", [mode, "off", path], {
-      stdio: "ignore",
-    });
-
-    const timeout = setTimeout(() => {
-      proc.kill("SIGKILL");
-      resolve();
-    }, 5000);
-
-    proc.on("close", () => {
-      clearTimeout(timeout);
-      resolve();
-    });
-    proc.on("error", () => {
-      clearTimeout(timeout);
-      resolve();
     });
   });
 }


### PR DESCRIPTION
## What Problem This Solves

stopTailscaleTunnel spawns tailscale without an error handler. Missing binary causes unhandled error crash AND the promise hangs forever.

## Why This Change Was Made

Add proc.on("error", handler) that cleans up the timeout and resolves. Same pattern already used for ngrok spawns at lines 154 and 200 in the same file.

## User Impact

Voice-call tunnel cleanup no longer crashes or hangs when tailscale is missing.

## Evidence

**Live proof** — actual OpenClaw startTailscaleTunnel + tunnel.stop() with fake tailscale for setup, then missing binary for cleanup:

```
$ node_modules/.bin/tsx proof-voicecall-tunnel.mjs

=== Proof: OpenClaw voice-call tunnel.stop() ===

Fake tailscale present: true
[voice-call] Tailscale serve active: https://proof-host.tailnet.ts.net/voice/proof
Tunnel started: true
Calling tunnel.stop() with missing tailscale...
Resolved in 2ms
PASS: stopTailscaleTunnel error handler caught ENOENT — no crash, no hang
```

This calls the EXACT production code path: startTailscaleTunnel -> tunnel.stop() -> stopTailscaleTunnel -> spawn("tailscale", ["serve", "off", ...]) with missing binary -> error handler catches ENOENT -> promise resolves immediately.

BEFORE fix: unhandled error -> ERR_UNHANDLED_ERROR -> crash + promise hangs forever.
AFTER fix: handler catches -> process survives + promise resolves in 2ms.

**Regression test** (10 passed):
```
node scripts/run-vitest.mjs extensions/voice-call/src/tunnel.test.ts
 Test Files 1 passed (1), Tests 10 passed (10)
```

## Risk

Low. One-line handler matching existing ngrok patterns in the same file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
Co-Authored-By: Claude <noreply@anthropic.com>