### PR TITLE
improve: speed up plugin SDK surface checks

### DIFF
--- a/scripts/plugin-sdk-surface-report.mjs
+++ b/scripts/plugin-sdk-surface-report.mjs
@@ -282,27 +282,29 @@ function countWildcardReexports(entrypoints) {
   return { count, matches };
 }
 
+// All three inventories overlap. Reuse one module graph so reporting subsets
+// does not triple TypeScript compiler time and heap usage.
+const exportStatsProgram = ts.createProgram(pluginSdkEntrypoints.map(entrypointPath), {
+  allowJs: false,
+  declaration: true,
+  emitDeclarationOnly: true,
+  module: ts.ModuleKind.ESNext,
+  moduleResolution: ts.ModuleResolutionKind.Bundler,
+  noEmit: true,
+  skipLibCheck: true,
+  strict: false,
+  target: ts.ScriptTarget.ES2022,
+  types: [],
+});
+const exportStatsChecker = exportStatsProgram.getTypeChecker();
+
 function collectExportStats(entrypoints) {
-  const files = entrypoints.map(entrypointPath);
-  const program = ts.createProgram(files, {
-    allowJs: false,
-    declaration: true,
-    emitDeclarationOnly: true,
-    module: ts.ModuleKind.ESNext,
-    moduleResolution: ts.ModuleResolutionKind.Bundler,
-    noEmit: true,
-    skipLibCheck: true,
-    strict: false,
-    target: ts.ScriptTarget.ES2022,
-    types: [],
-  });
-  const checker = program.getTypeChecker();
   const byEntrypoint = new Map();
   const uniqueNames = new Set();
   const uniqueCallableNames = new Set();
 
   for (const entrypoint of entrypoints) {
-    const sourceFile = program.getSourceFile(entrypointPath(entrypoint));
+    const sourceFile = exportStatsProgram.getSourceFile(entrypointPath(entrypoint));
     if (!sourceFile) {
       byEntrypoint.set(entrypoint, {
         exports: 0,
@@ -312,8 +314,8 @@ function collectExportStats(entrypoints) {
       });
       continue;
     }
-    const moduleSymbol = checker.getSymbolAtLocation(sourceFile);
-    const symbols = moduleSymbol ? checker.getExportsOfModule(moduleSymbol) : [];
+    const moduleSymbol = exportStatsChecker.getSymbolAtLocation(sourceFile);
+    const symbols = moduleSymbol ? exportStatsChecker.getExportsOfModule(moduleSymbol) : [];
     let callableExports = 0;
     let deprecatedExports = 0;
     let deprecatedCallableExports = 0;
@@ -321,11 +323,11 @@ function collectExportStats(entrypoints) {
     for (const symbol of symbols) {
       const exportName = `${entrypoint}:${symbol.getName()}`;
       uniqueNames.add(exportName);
-      const callable = isCallableExport(checker, symbol, sourceFile);
+      const callable = isCallableExport(exportStatsChecker, symbol, sourceFile);
       const deprecated =
         deprecatedEntrypoint ||
         hasDeprecatedTag(symbol) ||
-        hasDeprecatedTag(unwrapAlias(checker, symbol));
+        hasDeprecatedTag(unwrapAlias(exportStatsChecker, symbol));
       if (callable) {
         callableExports += 1;
         uniqueCallableNames.add(exportName);

--- a/test/scripts/plugin-sdk-surface-report.test.ts
+++ b/test/scripts/plugin-sdk-surface-report.test.ts
@@ -38,8 +38,8 @@ function readDefaultPublicSurfaceBudgets(): PublicSurfaceCounts {
   };
 }
 
-function readCurrentPublicSurfaceCounts(): PublicSurfaceCounts {
-  const result = runSurfaceReport({});
+function readCurrentPublicSurfaceCounts(env: Record<string, string>): PublicSurfaceCounts {
+  const result = runSurfaceReport(env);
   expect(result.status).toBe(0);
   expect(result.stderr).toBe("");
 
@@ -123,27 +123,12 @@ describe("plugin SDK surface report", () => {
     expect(result.stderr).not.toContain("at ");
   });
 
-  it("accepts exact deprecated export budget overrides by public entrypoint", () => {
-    const result = runSurfaceReport({
+  it("pins default surface counts and accepts exact entrypoint budgets", () => {
+    const counts = readCurrentPublicSurfaceCounts({
       OPENCLAW_PLUGIN_SDK_MAX_PUBLIC_DEPRECATED_EXPORTS_BY_ENTRYPOINT: JSON.stringify({ core: 2 }),
     });
 
-    expect(result.status).toBe(0);
-    expect(result.stderr).toBe("");
-  });
-
-  it("keeps default public surface budgets pinned to current source counts", () => {
-    expect(readDefaultPublicSurfaceBudgets()).toEqual(readCurrentPublicSurfaceCounts());
-  });
-
-  it("keeps generated package declarations out of source surface counts", () => {
-    const budget = readDefaultPublicSurfaceBudgets().callableExports;
-    const result = runSurfaceReport({
-      OPENCLAW_PLUGIN_SDK_MAX_PUBLIC_FUNCTION_EXPORTS: String(budget - 1),
-    });
-
-    expect(result.status).toBe(1);
-    expect(result.stderr).toContain(`public callable exports ${budget} > ${budget - 1}`);
+    expect(readDefaultPublicSurfaceBudgets()).toEqual(counts);
   });
 
   it("rejects deprecated export growth by public entrypoint", () => {


### PR DESCRIPTION
Related: #57266

## What Problem This Solves

The plugin SDK surface-report test file repeatedly rebuilt overlapping TypeScript compiler graphs, making six useful contract checks wait behind four 17–19 second repository-wide scans. A focused run took 75.7 seconds and peaked at 3.8 GB RSS locally.

## Why This Change Was Made

The report now builds one TypeScript Program from the complete SDK entrypoint inventory and projects all, public, and local-only counts from that shared checker. The tests fold exact entrypoint-budget acceptance into the pinned-count scan and remove a duplicate case that reasserted the same callable count without independently exercising generated declarations.

## User Impact

Developers get materially faster and lighter plugin SDK surface checks. Report output, source counts, budget failures, and CLI validation behavior are unchanged.

## Evidence

- Focused macOS: 75.721s -> 16.326s wall (-78.4%); 3,806.4 -> 1,950.7 MB peak RSS (-48.7%); 72.962s -> 13.821s file time (-81.1%).
- Focused Linux: 52.219s -> 10.016s file time (-80.8%).
- Tests: 8 -> 6; all six retained cases cover distinct help, argument-validation, exact-count, or growth-budget behavior.
- Standalone `plugin-sdk-surface-report.mjs --check`: identical visible counts/output; 18.72s -> 7.14s locally.
- `pnpm test:changed`: 1 file, 6/6 passing.
- Testbox-through-Crabbox changed gate: passed on `tbx_01kwpcf0byn0txjvgq42f2s8hm`; https://github.com/openclaw/openclaw/actions/runs/28704025763
- Autoreview: clean, no findings, correctness confidence 0.98.
