### PR TITLE
fix: restore Voice Wake after failed iOS PTT start

### DIFF
--- a/apps/ios/Sources/Model/NodeAppModel.swift
+++ b/apps/ios/Sources/Model/NodeAppModel.swift
@@ -1696,7 +1696,15 @@ final class NodeAppModel {
         switch req.command {
         case OpenClawTalkCommand.pttStart.rawValue:
             self.pttVoiceWakeSuspended = self.voiceWake.suspendForExternalAudioCapture()
+            var didStart = false
+            defer {
+                if !didStart {
+                    self.voiceWake.resumeAfterExternalAudioCapture(wasSuspended: self.pttVoiceWakeSuspended)
+                    self.pttVoiceWakeSuspended = false
+                }
+            }
             let payload = try await self.talkMode.beginPushToTalk()
+            didStart = true
             let json = try Self.encodePayload(payload)
             return BridgeInvokeResponse(id: req.id, ok: true, payloadJSON: json)
         case OpenClawTalkCommand.pttStop.rawValue:

--- a/apps/ios/Sources/Voice/VoiceWakeManager.swift
+++ b/apps/ios/Sources/Voice/VoiceWakeManager.swift
@@ -545,6 +545,10 @@ extension VoiceWakeManager {
         self.isStarting = isStarting
     }
 
+    func _test_isSuspendedForExternalAudio() -> Bool {
+        self.isSuspendedForExternalAudio
+    }
+
     func _test_waitForScheduledStart() async {
         let task = self.scheduledStartTask
         await task?.value

--- a/apps/ios/Tests/NodeAppModelInvokeTests.swift
+++ b/apps/ios/Tests/NodeAppModelInvokeTests.swift
@@ -687,6 +687,22 @@ private final class MockBootstrapNotificationCenter: NotificationCentering, @unc
         #expect(watchService.lastSentAppSnapshot?.talkEnabled == false)
     }
 
+    @Test @MainActor func handleInvokePTTStartRestoresVoiceWakeWhenStartFails() async {
+        let talkMode = TalkModeManager(allowSimulatorCapture: true)
+        let appModel = NodeAppModel(talkMode: talkMode)
+        appModel.voiceWake.isEnabled = true
+        appModel.voiceWake.isListening = true
+        appModel.voiceWake.statusText = "Listening"
+
+        let req = BridgeInvokeRequest(id: "ptt-start", command: OpenClawTalkCommand.pttStart.rawValue)
+        let res = await appModel._test_handleInvoke(req)
+
+        #expect(res.ok == false)
+        #expect(res.error?.message.contains("Gateway not connected") == true)
+        #expect(appModel.voiceWake._test_isSuspendedForExternalAudio() == false)
+        appModel.voiceWake.stop()
+    }
+
     @Test @MainActor func watchAppCommandOpensChatSessionOnPhoneModel() async {
         let watchService = MockWatchMessagingService()
         let appModel = NodeAppModel(watchMessagingService: watchService)


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where iOS users who had Voice Wake listening could trigger push-to-talk start, hit an early start failure such as a disconnected gateway, and leave Voice Wake paused for external audio capture even though no push-to-talk recording was active.

AI-assisted: yes.

## Why This Change Was Made

`talk.pttStart` now restores the Voice Wake external-audio suspension when `beginPushToTalk()` throws before capture starts, while preserving the existing successful-start behavior where `talk.pttStop` or `talk.pttCancel` performs the resume. A focused invoke test covers the offline-gateway failure path.

## User Impact

Voice Wake can recover after failed iOS push-to-talk starts instead of staying silently paused until the user toggles it or restarts the app.

## Evidence

- `git diff --check upstream/main...HEAD`
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base upstream/main` -> clean, no accepted/actionable findings
- `pnpm ios:gen` attempted for focused iOS test setup, but this machine is missing `xcodegen` (`bash: xcodegen: command not found`), so Xcode test execution is blocked locally.
