### PR TITLE
test: skip real restart waits in update CLI tests

### DIFF
--- a/src/cli/update-cli.test.ts
+++ b/src/cli/update-cli.test.ts
@@ -229,6 +229,7 @@ vi.mock("../utils.js", async (importOriginal) => {
       typeof value === "object" && value !== null && !Array.isArray(value),
     pathExists: (...args: unknown[]) => pathExists(...args),
     resolveConfigDir: () => "/tmp/openclaw-config",
+    sleep: vi.fn(async () => undefined),
   };
 });
 


### PR DESCRIPTION
## What Problem This Solves

`src/cli/update-cli.test.ts` spent about 60 seconds waiting through the production restart-health retry delay in one managed-service failure case. The higher-level test needs to prove update orchestration and terminal reporting, while retry cadence and timeout behavior are already covered directly in `src/cli/daemon-cli/restart-health.test.ts`.

Related: #57266

## Why This Change Was Made

Mock `sleep` in the update CLI test harness, matching the existing deterministic restart-health tests. This keeps all 163 update CLI cases and their assertions while removing real wall-clock delay.

## User Impact

No runtime behavior changes. The focused update CLI test file is substantially faster and uses less peak memory.

## Evidence

- Full case audit: 163 retained; no duplicate or tautological cases found.
- Local focused report: 69.022s to 7.893s wall, 63.635s to 4.809s file time, 632.4MB to 530.7MB max RSS; 163 to 163 tests.
- Linux Testbox focused report: 62.403s to 1.622s file time; 163 to 163 tests. Testbox `tbx_01kwpfade88h831n60p756vh9h`, Actions run 28705236854.
- `pnpm format:check -- src/cli/update-cli.test.ts`
- `pnpm test:changed`
- Testbox `pnpm check:changed`: `tbx_01kwpfck8a1z03mcf8p53fnyq3`, Actions run 28705263577.
- Autoreview: clean, no accepted or actionable findings (0.99).
