### PR TITLE
[codex] fix(copilot): preserve BYOK bearer auth through proxy

### DIFF
--- a/extensions/copilot/src/byok-proxy.test.ts
+++ b/extensions/copilot/src/byok-proxy.test.ts
@@ -82,6 +82,50 @@ describe("createCopilotByokProxy", () => {
     }
   });
 
+  it("injects resolved bearer auth when the SDK request omits Authorization", async () => {
+    ssrfRuntimeMock.fetchWithSsrFGuard.mockResolvedValue({
+      response: new Response("ok", { status: 200 }),
+      release: vi.fn(async () => undefined),
+    });
+    const resolvedProvider = resolveCopilotProvider({
+      model: {
+        provider: "tencent-tokenplan",
+        api: "openai-completions",
+        id: "hy3",
+        baseUrl: "https://tokenplan.example/v1",
+        authHeader: true,
+      },
+      resolvedApiKey: "tokenplan-secret",
+    });
+
+    const proxy = await createCopilotByokProxy(resolvedProvider);
+
+    try {
+      const response = await fetch(`${proxy?.provider.provider?.baseUrl}/chat/completions`, {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+        },
+        body: JSON.stringify({ model: "hy3" }),
+      });
+
+      expect(response.status).toBe(200);
+      expect(ssrfRuntimeMock.fetchWithSsrFGuard).toHaveBeenCalledWith(
+        expect.objectContaining({
+          url: "https://tokenplan.example/v1/chat/completions",
+          init: expect.objectContaining({
+            headers: expect.objectContaining({
+              authorization: "Bearer tokenplan-secret",
+              "content-type": "application/json",
+            }),
+          }),
+        }),
+      );
+    } finally {
+      await proxy?.close();
+    }
+  });
+
   it("aborts in-flight upstream fetches when the proxy closes", async () => {
     let upstreamSignal: AbortSignal | undefined;
     ssrfRuntimeMock.fetchWithSsrFGuard.mockImplementation(async ({ init }: any) => {
@@ -160,6 +204,40 @@ describe("createCopilotByokProxy", () => {
           }),
         }),
       );
+    } finally {
+      await proxy?.close();
+    }
+  });
+
+  it("does not inject bearer auth on nonce-less Azure SDK paths", async () => {
+    ssrfRuntimeMock.fetchWithSsrFGuard.mockResolvedValue({
+      response: new Response("azure-ok", { status: 200 }),
+      release: vi.fn(async () => undefined),
+    });
+    const resolvedProvider = resolveCopilotProvider({
+      model: {
+        provider: "custom-azure",
+        api: "azure-openai-responses",
+        id: "deployment-gpt",
+        baseUrl: "https://example.openai.azure.com/openai/v1",
+        authHeader: true,
+      },
+      resolvedApiKey: "azure-bearer",
+    });
+
+    const proxy = await createCopilotByokProxy(resolvedProvider);
+
+    try {
+      const response = await fetch(`${proxy?.provider.provider?.baseUrl}/openai/v1/responses`, {
+        method: "POST",
+        body: JSON.stringify({ model: "deployment-gpt" }),
+      });
+
+      expect(response.status).toBe(200);
+      const call = ssrfRuntimeMock.fetchWithSsrFGuard.mock.calls[0]?.[0] as
+        | { init?: { headers?: Record<string, string> } }
+        | undefined;
+      expect(call?.init?.headers).not.toHaveProperty("authorization");
     } finally {
       await proxy?.close();
     }

--- a/extensions/copilot/src/byok-proxy.ts
+++ b/extensions/copilot/src/byok-proxy.ts
@@ -15,6 +15,7 @@ export type CopilotByokProxyHandle = {
 };
 
 type HeaderValue = string | number | string[] | undefined;
+type ProviderConfig = NonNullable<ResolvedCopilotProvider["provider"]>;
 
 export async function createCopilotByokProxy(
   resolvedProvider: ResolvedCopilotProvider,
@@ -32,6 +33,7 @@ export async function createCopilotByokProxy(
   const targetPathPrefix = trimTrailingSlash(targetBaseUrl.pathname);
   const proxyPathPrefix = `/${nonce}${targetPathPrefix}`;
   const acceptsAzureSdkPaths = providerConfig.type === "azure";
+  const upstreamBearerAuthorization = resolveUpstreamBearerAuthorization(providerConfig);
   const activeFetches = new Set<AbortController>();
   const server = createServer((req, res) => {
     void handleProxyRequest(req, res, {
@@ -40,6 +42,7 @@ export async function createCopilotByokProxy(
       proxyPathPrefix,
       targetBaseUrl,
       targetPathPrefix,
+      upstreamBearerAuthorization,
     });
   });
 
@@ -88,6 +91,7 @@ async function handleProxyRequest(
     proxyPathPrefix: string;
     targetBaseUrl: URL;
     targetPathPrefix: string;
+    upstreamBearerAuthorization: string | undefined;
   },
 ): Promise<void> {
   let guarded: Awaited<ReturnType<typeof fetchWithSsrFGuard>> | undefined;
@@ -101,6 +105,7 @@ async function handleProxyRequest(
     }
   });
   try {
+    const canInjectBearerAuthorization = isNonceProtectedProxyRequest(req, params.proxyPathPrefix);
     const url = resolveTargetUrl(req, params);
     if (!url) {
       res.writeHead(404);
@@ -112,7 +117,11 @@ async function handleProxyRequest(
       url: url.toString(),
       init: {
         method: req.method,
-        headers: normalizeProxyRequestHeaders(req.headers),
+        headers: buildProxyRequestHeaders(req.headers, {
+          upstreamBearerAuthorization: canInjectBearerAuthorization
+            ? params.upstreamBearerAuthorization
+            : undefined,
+        }),
         signal: upstreamAbort.signal,
         ...(body ? { body: toFetchBody(body) } : {}),
       },
@@ -129,9 +138,9 @@ async function handleProxyRequest(
       return;
     }
     await finished(
-      Readable.fromWeb(
-        guarded.response.body as unknown as NodeReadableStream<Uint8Array>,
-      ).pipe(res),
+      Readable.fromWeb(guarded.response.body as unknown as NodeReadableStream<Uint8Array>).pipe(
+        res,
+      ),
     );
   } catch (error) {
     if (res.destroyed || res.writableEnded) {
@@ -190,6 +199,14 @@ function isAzureSdkProxyPath(pathname: string): boolean {
   return pathname === "/openai" || pathname.startsWith("/openai/");
 }
 
+function isNonceProtectedProxyRequest(req: IncomingMessage, proxyPathPrefix: string): boolean {
+  const incomingUrl = new URL(req.url ?? "/", `http://${LOOPBACK_HOST}`);
+  return (
+    incomingUrl.pathname === proxyPathPrefix ||
+    incomingUrl.pathname.startsWith(`${proxyPathPrefix}/`)
+  );
+}
+
 async function readBody(req: IncomingMessage): Promise<Buffer | undefined> {
   const chunks: Buffer[] = [];
   for await (const chunk of req) {
@@ -219,6 +236,25 @@ function normalizeProxyRequestHeaders(headers: IncomingMessage["headers"]): Reco
   return out;
 }
 
+function buildProxyRequestHeaders(
+  headers: IncomingMessage["headers"],
+  params: { upstreamBearerAuthorization: string | undefined },
+): Record<string, string> {
+  const out = normalizeProxyRequestHeaders(headers);
+  if (params.upstreamBearerAuthorization && !hasHeader(out, "authorization")) {
+    // The SDK declares bearerToken as Authorization auth, but some BYOK
+    // adapter paths can omit it before reaching our loopback proxy. The proxy
+    // owns the final guarded hop, so inject only when the SDK left it absent.
+    out["authorization"] = params.upstreamBearerAuthorization;
+  }
+  return out;
+}
+
+function resolveUpstreamBearerAuthorization(providerConfig: ProviderConfig): string | undefined {
+  const bearerToken = providerConfig.bearerToken?.trim();
+  return bearerToken ? `Bearer ${bearerToken}` : undefined;
+}
+
 function normalizeProxyResponseHeaders(headers: Headers): Record<string, string> {
   const out: Record<string, string> = {};
   headers.forEach((value, key) => {
@@ -234,6 +270,10 @@ function normalizeHeaderValue(value: HeaderValue): string | undefined {
     return undefined;
   }
   return Array.isArray(value) ? value.join(", ") : String(value);
+}
+
+function hasHeader(headers: Record<string, string>, target: string): boolean {
+  return Object.keys(headers).some((key) => key.toLowerCase() === target);
 }
 
 function isHopByHopHeader(key: string): boolean {

--- a/extensions/copilot/src/provider-bridge.test.ts
+++ b/extensions/copilot/src/provider-bridge.test.ts
@@ -73,6 +73,28 @@ describe("resolveCopilotProvider", () => {
     expect(supportsCopilotByokProviderShape({ baseUrl: "https://proxy.example/v1" })).toBe(true);
   });
 
+  it("maps OpenAI Chat Completions BYOK bearer auth with the provider-local model id", () => {
+    const result = resolveCopilotProvider({
+      model: {
+        provider: "tencent-tokenplan",
+        api: "openai-completions",
+        id: "hy3",
+        baseUrl: "https://tokenplan.example/v1",
+        authHeader: true,
+      },
+      resolvedApiKey: "secret-key",
+    });
+
+    expect(result.provider).toMatchObject({
+      type: "openai",
+      wireApi: "completions",
+      baseUrl: "https://tokenplan.example/v1",
+      modelId: "hy3",
+      wireModel: "hy3",
+      bearerToken: "secret-key",
+    });
+  });
+
   it("changes the BYOK compatibility fingerprint when token limits change", () => {
     const base = {
       provider: "custom-proxy",


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users routing OpenAI-compatible BYOK providers through the GitHub Copilot harness could hit upstream 401s when the Copilot SDK/runtime omitted the resolved bearer `Authorization` header before the loopback proxy forwarded the request.

This was reproduced with Tencent TokenPlan/TokenHub-shaped Chat Completions providers: direct OpenClaw provider calls succeeded, while the same provider/model through Copilot BYOK could fail at the upstream auth hop.

AI-assisted: yes.

## Why This Change Was Made

The Copilot BYOK proxy now carries OpenClaw's resolved bearer auth intent to the final SSRF-guarded upstream hop, but only for nonce-protected proxy requests and only when the SDK did not already send `authorization`. Azure SDK nonce-less `/openai/...` proxy paths remain excluded so discovering the loopback port cannot turn the proxy into a bearer-token relay.

The package install proof also confirms the existing `@github/copilot-sdk` production dependency resolves the Copilot CLI package transitively, so this PR does not change the plugin dependency graph.

## User Impact

Users can run Tencent TokenPlan/TokenHub and Ollama Cloud OpenAI-compatible BYOK models through the Copilot harness without losing bearer auth at the proxy hop. The PR does not change the plugin dependency graph; the existing SDK dependency continues to resolve the Copilot CLI package in production installs.

## Evidence

Focused local tests:

- `node scripts/run-vitest.mjs extensions/copilot/src/byok-proxy.test.ts extensions/copilot/src/provider-bridge.test.ts test/scripts/plugin-package-dependencies.test.ts test/plugin-npm-package-manifest.test.ts`
  - Passed: 4 files / 31 tests.
- `pnpm exec oxfmt --check --threads=1 extensions/copilot/src/byok-proxy.ts extensions/copilot/src/byok-proxy.test.ts extensions/copilot/src/provider-bridge.test.ts my_docs/04-cases/2026-07-04-copilot-byok-tencent-harness-bug/00-case.md`
  - Passed.
- `git diff --check`
  - Passed.
- `pnpm deadcode:dependencies`
  - Passed after keeping `@github/copilot` as an SDK transitive dependency instead of a direct plugin dependency.
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main`
  - Passed: `autoreview clean: no accepted/actionable findings reported`.

Package/install proof:

- `npm pack --pack-destination /tmp` for `extensions/copilot`.
- Inspected the tarball:
  - `package/package.json` keeps `@github/copilot-sdk: 1.0.0-beta.9` as the direct runtime dependency.
  - `package/dist/...` contains the proxy bearer fix symbols `upstreamBearerAuthorization` and `isNonceProtectedProxyRequest`.
- Installed the tarball in a temporary npm project with `npm install --package-lock-only --omit=dev --ignore-scripts <tgz>` and confirmed `node_modules/@github/copilot` still resolves from `@github/copilot-sdk`'s production dependency graph without adding a direct plugin dependency.

Live openclaw2 proof with real provider keys, redacted/no secret values printed:

- Installed the final package through the trusted official path:
  - `openclaw plugins install npm-pack:/tmp/openclaw-copilot-byok-final-20260704.tgz --force`
  - Restarted gateway.
  - Confirmed loaded dist contains `upstreamBearerAuthorization`.
- Gateway status after final install:
  - OpenClaw `2026.7.4 (80b40a8)`.
  - Gateway loopback `127.0.0.1:28443`.
  - Connectivity probe: ok.

Final live model probes, all using:

```bash
openclaw infer model run --gateway --model <provider/model> \
  --prompt "Reply with exactly OK-LIVE-PROBE" --thinking off --json
```

Results:

- `custom-tokenplan-hy3/hy3` through Copilot BYOK: returned `OK-LIVE-PROBE`.
- `custom-tokenhub-hy3/hy3` through Copilot BYOK: returned `OK-LIVE-PROBE`.
- `ollama-cloud/deepseek-v4-flash` direct gateway path: returned `OK-LIVE-PROBE`.
- Temporary `custom-ollama-cloud-copilot/deepseek-v4-flash` through Copilot BYOK: returned `OK-LIVE-PROBE`.

Cleanup proof:

- The temporary Ollama Copilot BYOK provider and `agents.defaults.models["custom-ollama-cloud-copilot/deepseek-v4-flash"]` allowlist entry were removed after the live probe.
- `openclaw config validate` passed after cleanup.
- Gateway was restarted and remained healthy.
- Confirmed `hasTempProvider=false` and `hasTempAllowlist=false`.

Known unrelated environment noise on openclaw2:

- `Plugin version drift: 6 active official plugins not on gateway 2026.7.4`.
- Existing legacy state migration warning for memory index conflicts.
- Neither affected the package install, gateway connectivity, config validation, or live provider probes above.

