### PR TITLE
fix(codex): warn when routes use stale embedded binaries

### DIFF
--- a/docs/plugins/codex-harness-reference.md
+++ b/docs/plugins/codex-harness-reference.md
@@ -441,9 +441,9 @@ If discovery fails or times out, OpenClaw uses a bundled fallback catalog for:
 - GPT-5.5
 - GPT-5.4 mini
 
-The current bundled harness is `@openai/codex` `0.142.4`. A `model/list` probe
-against that bundled app-server in a GPT-5.6-enabled workspace returned these
-public picker rows:
+The current bundled harness is `@openai/codex` `0.142.5`. The fallback snapshot
+below was captured from a bundled app-server in a GPT-5.6-enabled workspace and
+is not a substitute for `/codex models` on the live gateway/account:
 
 | Model id              | Input modalities | Reasoning efforts                    |
 | --------------------- | ---------------- | ------------------------------------ |

--- a/extensions/codex/npm-shrinkwrap.json
+++ b/extensions/codex/npm-shrinkwrap.json
@@ -8,16 +8,16 @@
       "name": "@openclaw/codex",
       "version": "2026.6.11",
       "dependencies": {
-        "@openai/codex": "0.142.4",
+        "@openai/codex": "0.142.5",
         "typebox": "1.1.39",
         "ws": "8.21.0",
         "zod": "4.4.3"
       }
     },
     "node_modules/@openai/codex": {
-      "version": "0.142.4",
-      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.142.4.tgz",
-      "integrity": "sha512-BW9+3Cs7tChgkc0QhUsZIDm6XgpSDSeJkljRSHhJZqDwlaxDnNVhRP/sZwhgrTn3f2jPn3jc4WTKfLOTk+g5pA==",
+      "version": "0.142.5",
+      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.142.5.tgz",
+      "integrity": "sha512-WQEpD7l3k68eIAP0aq28EdR18ENBAf8DyprzFhzNwCOQJSv4nHzpwT8Fl30IJacprko2ZCmUBZjM2u941l2yLw==",
       "license": "Apache-2.0",
       "bin": {
         "codex": "bin/codex.js"
@@ -26,19 +26,19 @@
         "node": ">=16"
       },
       "optionalDependencies": {
-        "@openai/codex-darwin-arm64": "npm:@openai/codex@0.142.4-darwin-arm64",
-        "@openai/codex-darwin-x64": "npm:@openai/codex@0.142.4-darwin-x64",
-        "@openai/codex-linux-arm64": "npm:@openai/codex@0.142.4-linux-arm64",
-        "@openai/codex-linux-x64": "npm:@openai/codex@0.142.4-linux-x64",
-        "@openai/codex-win32-arm64": "npm:@openai/codex@0.142.4-win32-arm64",
-        "@openai/codex-win32-x64": "npm:@openai/codex@0.142.4-win32-x64"
+        "@openai/codex-darwin-arm64": "npm:@openai/codex@0.142.5-darwin-arm64",
+        "@openai/codex-darwin-x64": "npm:@openai/codex@0.142.5-darwin-x64",
+        "@openai/codex-linux-arm64": "npm:@openai/codex@0.142.5-linux-arm64",
+        "@openai/codex-linux-x64": "npm:@openai/codex@0.142.5-linux-x64",
+        "@openai/codex-win32-arm64": "npm:@openai/codex@0.142.5-win32-arm64",
+        "@openai/codex-win32-x64": "npm:@openai/codex@0.142.5-win32-x64"
       }
     },
     "node_modules/@openai/codex-darwin-arm64": {
       "name": "@openai/codex",
-      "version": "0.142.4-darwin-arm64",
-      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.142.4-darwin-arm64.tgz",
-      "integrity": "sha512-CfXp5jilBOxD8zLuG6Nk7w5ZPP3roE3s1rsr60za9PQKI7kaJ/5G+oP3Z0N1CoB4mpy+5JHkMLTZAZZPGFlSgQ==",
+      "version": "0.142.5-darwin-arm64",
+      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.142.5-darwin-arm64.tgz",
+      "integrity": "sha512-l43p8xv+Z/2/b6fCUc7/FmcQZsaPB7RFizLponGwHAnFOWe3i9Vky69p+up3BUam9AetoQQUv7Mo+2KdaFEqhA==",
       "cpu": [
         "arm64"
       ],
@@ -53,9 +53,9 @@
     },
     "node_modules/@openai/codex-darwin-x64": {
       "name": "@openai/codex",
-      "version": "0.142.4-darwin-x64",
-      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.142.4-darwin-x64.tgz",
-      "integrity": "sha512-H9ia31pkJFtBk+UrREAfJiTUfcvgactKbG4W4SF2LFfJOTRsrsJZGtscHQ8/lLGeKEfOk/psrbSOPDyrZnxvnQ==",
+      "version": "0.142.5-darwin-x64",
+      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.142.5-darwin-x64.tgz",
+      "integrity": "sha512-yk6A06/VmW7NFsa48OVPaj//g/zeSpd79wjuqfXZwW8ZKRYQm3+wCd3hWjPl79F3QnXvDvM2j3JMIBL3m3GXXg==",
       "cpu": [
         "x64"
       ],
@@ -70,9 +70,9 @@
     },
     "node_modules/@openai/codex-linux-arm64": {
       "name": "@openai/codex",
-      "version": "0.142.4-linux-arm64",
-      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.142.4-linux-arm64.tgz",
-      "integrity": "sha512-/bBcEm+OKmlGHH0c88jrVgYMRyaNC/hGOW/znP/PiHQEeIf4UdsUGQ7x4FAZm648140cgaeKYIBoRBbHizS+5w==",
+      "version": "0.142.5-linux-arm64",
+      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.142.5-linux-arm64.tgz",
+      "integrity": "sha512-77ka5PSnm5HdxdBT99IwntCasmbqevlS0eiC0AtEb6ZXCLkim2gm0AWm+jNYy0EhbssvNK+KghayWo34HMgXeA==",
       "cpu": [
         "arm64"
       ],
@@ -87,9 +87,9 @@
     },
     "node_modules/@openai/codex-linux-x64": {
       "name": "@openai/codex",
-      "version": "0.142.4-linux-x64",
-      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.142.4-linux-x64.tgz",
-      "integrity": "sha512-t3tNOkDdiO5/gRqkTmuMcAj5JjCbeWotOJzxV7pPkD2u2KvzVRrk7jPAjuy+85wPc12lsIupYgxHlK7CkVLOjA==",
+      "version": "0.142.5-linux-x64",
+      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.142.5-linux-x64.tgz",
+      "integrity": "sha512-pxY+d3NgNE57Y/MApD3/TZUAygxJN6I9h3ZeDUwe67mxWjUxsuapxMRFTKSznCalYbRAeZp752+AAXmUbmguEg==",
       "cpu": [
         "x64"
       ],
@@ -104,9 +104,9 @@
     },
     "node_modules/@openai/codex-win32-arm64": {
       "name": "@openai/codex",
-      "version": "0.142.4-win32-arm64",
-      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.142.4-win32-arm64.tgz",
-      "integrity": "sha512-QBGeoYk3pmVscVIxeW21cvPJIjsnmD5dOTqMAzypXGik5soNIKHbps2Kj1LBKOjVbbx5qoDEbTwDfYmnjfqgdQ==",
+      "version": "0.142.5-win32-arm64",
+      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.142.5-win32-arm64.tgz",
+      "integrity": "sha512-65BEqGbUZ7r0ayunIHdBjo5crwgbwKX/6puOcO+VCswUw/dXvDsN2IGcbXB52+bS9U5+FxP783cUHfTT6m40DQ==",
       "cpu": [
         "arm64"
       ],
@@ -121,9 +121,9 @@
     },
     "node_modules/@openai/codex-win32-x64": {
       "name": "@openai/codex",
-      "version": "0.142.4-win32-x64",
-      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.142.4-win32-x64.tgz",
-      "integrity": "sha512-W0rSPT0t7FnKlJYNu9/HpHzaSOutuSSYjIVunKorYmrScXk9pQxBEhEuyn16JOtywc/2nX8nHEmWsuj2sd8suw==",
+      "version": "0.142.5-win32-x64",
+      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.142.5-win32-x64.tgz",
+      "integrity": "sha512-a+wI4PEx9a2fg6V5ueTTDkOkr1XpEvA5RFXIbo/L2hOfzMmGtyRnbG24bCGu5Q2RSgVxSQV0aLkdb3vdYMNH9A==",
       "cpu": [
         "x64"
       ],

--- a/extensions/codex/package.json
+++ b/extensions/codex/package.json
@@ -8,7 +8,7 @@
   },
   "type": "module",
   "dependencies": {
-    "@openai/codex": "0.142.4",
+    "@openai/codex": "0.142.5",
     "typebox": "1.1.39",
     "ws": "8.21.0",
     "zod": "4.4.3"

--- a/extensions/codex/src/app-server/version.ts
+++ b/extensions/codex/src/app-server/version.ts
@@ -9,4 +9,4 @@ export const MIN_CODEX_SANDBOX_EXEC_SERVER_APP_SERVER_VERSION = "0.132.0";
 export const MANAGED_CODEX_APP_SERVER_PACKAGE = "@openai/codex";
 // Keep this in sync with the Codex CLI live-test package pin.
 /** Managed Codex app-server package version installed by OpenClaw. */
-export const MANAGED_CODEX_APP_SERVER_PACKAGE_VERSION = "0.142.4";
+export const MANAGED_CODEX_APP_SERVER_PACKAGE_VERSION = "0.142.5";

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -519,8 +519,8 @@ importers:
   extensions/codex:
     dependencies:
       '@openai/codex':
-        specifier: 0.142.4
-        version: 0.142.4
+        specifier: 0.142.5
+        version: 0.142.5
       typebox:
         specifier: 1.1.39
         version: 1.1.39
@@ -3130,43 +3130,43 @@ packages:
     resolution: {integrity: sha512-gOBg5YHMfZy+TfHArfVogwgfBeQnKbbGo3pSUyK/gSI0AVu+pEiDVcKlQb0D8Mg1LNRZILZ6XG8I5dJ4KuAd9Q==}
     engines: {node: ^20.17.0 || >=22.9.0}
 
-  '@openai/codex@0.142.4':
-    resolution: {integrity: sha512-BW9+3Cs7tChgkc0QhUsZIDm6XgpSDSeJkljRSHhJZqDwlaxDnNVhRP/sZwhgrTn3f2jPn3jc4WTKfLOTk+g5pA==}
+  '@openai/codex@0.142.5':
+    resolution: {integrity: sha512-WQEpD7l3k68eIAP0aq28EdR18ENBAf8DyprzFhzNwCOQJSv4nHzpwT8Fl30IJacprko2ZCmUBZjM2u941l2yLw==}
     engines: {node: '>=16'}
     hasBin: true
 
-  '@openai/codex@0.142.4-darwin-arm64':
-    resolution: {integrity: sha512-CfXp5jilBOxD8zLuG6Nk7w5ZPP3roE3s1rsr60za9PQKI7kaJ/5G+oP3Z0N1CoB4mpy+5JHkMLTZAZZPGFlSgQ==}
+  '@openai/codex@0.142.5-darwin-arm64':
+    resolution: {integrity: sha512-l43p8xv+Z/2/b6fCUc7/FmcQZsaPB7RFizLponGwHAnFOWe3i9Vky69p+up3BUam9AetoQQUv7Mo+2KdaFEqhA==}
     engines: {node: '>=16'}
     cpu: [arm64]
     os: [darwin]
 
-  '@openai/codex@0.142.4-darwin-x64':
-    resolution: {integrity: sha512-H9ia31pkJFtBk+UrREAfJiTUfcvgactKbG4W4SF2LFfJOTRsrsJZGtscHQ8/lLGeKEfOk/psrbSOPDyrZnxvnQ==}
+  '@openai/codex@0.142.5-darwin-x64':
+    resolution: {integrity: sha512-yk6A06/VmW7NFsa48OVPaj//g/zeSpd79wjuqfXZwW8ZKRYQm3+wCd3hWjPl79F3QnXvDvM2j3JMIBL3m3GXXg==}
     engines: {node: '>=16'}
     cpu: [x64]
     os: [darwin]
 
-  '@openai/codex@0.142.4-linux-arm64':
-    resolution: {integrity: sha512-/bBcEm+OKmlGHH0c88jrVgYMRyaNC/hGOW/znP/PiHQEeIf4UdsUGQ7x4FAZm648140cgaeKYIBoRBbHizS+5w==}
+  '@openai/codex@0.142.5-linux-arm64':
+    resolution: {integrity: sha512-77ka5PSnm5HdxdBT99IwntCasmbqevlS0eiC0AtEb6ZXCLkim2gm0AWm+jNYy0EhbssvNK+KghayWo34HMgXeA==}
     engines: {node: '>=16'}
     cpu: [arm64]
     os: [linux]
 
-  '@openai/codex@0.142.4-linux-x64':
-    resolution: {integrity: sha512-t3tNOkDdiO5/gRqkTmuMcAj5JjCbeWotOJzxV7pPkD2u2KvzVRrk7jPAjuy+85wPc12lsIupYgxHlK7CkVLOjA==}
+  '@openai/codex@0.142.5-linux-x64':
+    resolution: {integrity: sha512-pxY+d3NgNE57Y/MApD3/TZUAygxJN6I9h3ZeDUwe67mxWjUxsuapxMRFTKSznCalYbRAeZp752+AAXmUbmguEg==}
     engines: {node: '>=16'}
     cpu: [x64]
     os: [linux]
 
-  '@openai/codex@0.142.4-win32-arm64':
-    resolution: {integrity: sha512-QBGeoYk3pmVscVIxeW21cvPJIjsnmD5dOTqMAzypXGik5soNIKHbps2Kj1LBKOjVbbx5qoDEbTwDfYmnjfqgdQ==}
+  '@openai/codex@0.142.5-win32-arm64':
+    resolution: {integrity: sha512-65BEqGbUZ7r0ayunIHdBjo5crwgbwKX/6puOcO+VCswUw/dXvDsN2IGcbXB52+bS9U5+FxP783cUHfTT6m40DQ==}
     engines: {node: '>=16'}
     cpu: [arm64]
     os: [win32]
 
-  '@openai/codex@0.142.4-win32-x64':
-    resolution: {integrity: sha512-W0rSPT0t7FnKlJYNu9/HpHzaSOutuSSYjIVunKorYmrScXk9pQxBEhEuyn16JOtywc/2nX8nHEmWsuj2sd8suw==}
+  '@openai/codex@0.142.5-win32-x64':
+    resolution: {integrity: sha512-a+wI4PEx9a2fg6V5ueTTDkOkr1XpEvA5RFXIbo/L2hOfzMmGtyRnbG24bCGu5Q2RSgVxSQV0aLkdb3vdYMNH9A==}
     engines: {node: '>=16'}
     cpu: [x64]
     os: [win32]
@@ -9177,31 +9177,31 @@ snapshots:
 
   '@npmcli/redact@4.0.0': {}
 
-  '@openai/codex@0.142.4':
+  '@openai/codex@0.142.5':
     optionalDependencies:
-      '@openai/codex-darwin-arm64': '@openai/codex@0.142.4-darwin-arm64'
-      '@openai/codex-darwin-x64': '@openai/codex@0.142.4-darwin-x64'
-      '@openai/codex-linux-arm64': '@openai/codex@0.142.4-linux-arm64'
-      '@openai/codex-linux-x64': '@openai/codex@0.142.4-linux-x64'
-      '@openai/codex-win32-arm64': '@openai/codex@0.142.4-win32-arm64'
-      '@openai/codex-win32-x64': '@openai/codex@0.142.4-win32-x64'
+      '@openai/codex-darwin-arm64': '@openai/codex@0.142.5-darwin-arm64'
+      '@openai/codex-darwin-x64': '@openai/codex@0.142.5-darwin-x64'
+      '@openai/codex-linux-arm64': '@openai/codex@0.142.5-linux-arm64'
+      '@openai/codex-linux-x64': '@openai/codex@0.142.5-linux-x64'
+      '@openai/codex-win32-arm64': '@openai/codex@0.142.5-win32-arm64'
+      '@openai/codex-win32-x64': '@openai/codex@0.142.5-win32-x64'
 
-  '@openai/codex@0.142.4-darwin-arm64':
+  '@openai/codex@0.142.5-darwin-arm64':
     optional: true
 
-  '@openai/codex@0.142.4-darwin-x64':
+  '@openai/codex@0.142.5-darwin-x64':
     optional: true
 
-  '@openai/codex@0.142.4-linux-arm64':
+  '@openai/codex@0.142.5-linux-arm64':
     optional: true
 
-  '@openai/codex@0.142.4-linux-x64':
+  '@openai/codex@0.142.5-linux-x64':
     optional: true
 
-  '@openai/codex@0.142.4-win32-arm64':
+  '@openai/codex@0.142.5-win32-arm64':
     optional: true
 
-  '@openai/codex@0.142.4-win32-x64':
+  '@openai/codex@0.142.5-win32-x64':
     optional: true
 
   '@openclaw/crabline@0.1.9':

--- a/scripts/lib/plugin-npm-release.ts
+++ b/scripts/lib/plugin-npm-release.ts
@@ -112,9 +112,9 @@ function readOptionalTextFile(path: string): string | undefined {
   }
 }
 
-function readOptionalJsonFile<TValue>(path: string): TValue | undefined {
+function readOptionalJsonFile(path: string): unknown {
   try {
-    return JSON.parse(readFileSync(path, "utf8")) as TValue;
+    return JSON.parse(readFileSync(path, "utf8")) as unknown;
   } catch {
     return undefined;
   }
@@ -122,6 +122,10 @@ function readOptionalJsonFile<TValue>(path: string): TValue | undefined {
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return Boolean(value && typeof value === "object" && !Array.isArray(value));
+}
+
+function optionalString(value: unknown): string | undefined {
+  return typeof value === "string" ? value : undefined;
 }
 
 function collectCodexRouteRuntimePackageErrors(
@@ -156,25 +160,25 @@ function collectCodexRouteRuntimePackageErrors(
     );
   }
 
-  const shrinkwrap = readOptionalJsonFile<{
-    packages?: Record<string, unknown>;
-  }>(join(candidate.packageDir, "npm-shrinkwrap.json"));
-  if (!shrinkwrap) {
+  const shrinkwrap = readOptionalJsonFile(join(candidate.packageDir, "npm-shrinkwrap.json"));
+  if (!isRecord(shrinkwrap)) {
     errors.push(
       `${CODEX_ROUTE_PLUGIN_PACKAGE_NAME} npm-shrinkwrap.json is required so npm publishes the approved ${CODEX_ROUTE_RUNTIME_DEPENDENCY_NAME} route binary.`,
     );
     return errors;
   }
 
-  const packages = shrinkwrap.packages;
+  const packages = isRecord(shrinkwrap.packages) ? shrinkwrap.packages : {};
   const rootPackage = isRecord(packages?.[""]) ? packages[""] : undefined;
   const rootDependencies = isRecord(rootPackage?.dependencies)
     ? rootPackage.dependencies
     : undefined;
-  const shrinkwrapRootVersion = rootDependencies?.[CODEX_ROUTE_RUNTIME_DEPENDENCY_NAME];
+  const shrinkwrapRootVersion = optionalString(
+    rootDependencies?.[CODEX_ROUTE_RUNTIME_DEPENDENCY_NAME],
+  );
   if (shrinkwrapRootVersion !== expectedVersion) {
     errors.push(
-      `${CODEX_ROUTE_PLUGIN_PACKAGE_NAME} npm-shrinkwrap root dependency ${CODEX_ROUTE_RUNTIME_DEPENDENCY_NAME} must be ${expectedVersion}; found "${String(shrinkwrapRootVersion ?? "<missing>")}".`,
+      `${CODEX_ROUTE_PLUGIN_PACKAGE_NAME} npm-shrinkwrap root dependency ${CODEX_ROUTE_RUNTIME_DEPENDENCY_NAME} must be ${expectedVersion}; found "${shrinkwrapRootVersion ?? "<missing>"}".`,
     );
   }
 
@@ -182,9 +186,10 @@ function collectCodexRouteRuntimePackageErrors(
   const runtimePackage = isRecord(packages?.[runtimePackageKey])
     ? packages[runtimePackageKey]
     : undefined;
-  if (runtimePackage?.version !== expectedVersion) {
+  const runtimePackageVersion = optionalString(runtimePackage?.version);
+  if (runtimePackageVersion !== expectedVersion) {
     errors.push(
-      `${CODEX_ROUTE_PLUGIN_PACKAGE_NAME} npm-shrinkwrap ${runtimePackageKey}.version must be ${expectedVersion}; found "${String(runtimePackage?.version ?? "<missing>")}".`,
+      `${CODEX_ROUTE_PLUGIN_PACKAGE_NAME} npm-shrinkwrap ${runtimePackageKey}.version must be ${expectedVersion}; found "${runtimePackageVersion ?? "<missing>"}".`,
     );
   }
   const optionalDependencies = isRecord(runtimePackage?.optionalDependencies)
@@ -193,9 +198,10 @@ function collectCodexRouteRuntimePackageErrors(
   for (const platformPackage of CODEX_ROUTE_RUNTIME_PLATFORM_PACKAGES) {
     const platformSuffix = platformPackage.slice(`${CODEX_ROUTE_RUNTIME_DEPENDENCY_NAME}-`.length);
     const expectedAlias = `npm:${CODEX_ROUTE_RUNTIME_DEPENDENCY_NAME}@${expectedVersion}-${platformSuffix}`;
-    if (optionalDependencies[platformPackage] !== expectedAlias) {
+    const actualAlias = optionalString(optionalDependencies[platformPackage]);
+    if (actualAlias !== expectedAlias) {
       errors.push(
-        `${CODEX_ROUTE_PLUGIN_PACKAGE_NAME} npm-shrinkwrap ${runtimePackageKey}.optionalDependencies["${platformPackage}"] must be "${expectedAlias}"; found "${String(optionalDependencies[platformPackage] ?? "<missing>")}".`,
+        `${CODEX_ROUTE_PLUGIN_PACKAGE_NAME} npm-shrinkwrap ${runtimePackageKey}.optionalDependencies["${platformPackage}"] must be "${expectedAlias}"; found "${actualAlias ?? "<missing>"}".`,
       );
     }
     const platformPackageKey = `node_modules/${platformPackage}`;
@@ -203,9 +209,10 @@ function collectCodexRouteRuntimePackageErrors(
       ? packages[platformPackageKey]
       : undefined;
     const expectedPlatformVersion = `${expectedVersion}-${platformSuffix}`;
-    if (lockedPlatformPackage?.version !== expectedPlatformVersion) {
+    const lockedPlatformPackageVersion = optionalString(lockedPlatformPackage?.version);
+    if (lockedPlatformPackageVersion !== expectedPlatformVersion) {
       errors.push(
-        `${CODEX_ROUTE_PLUGIN_PACKAGE_NAME} npm-shrinkwrap ${platformPackageKey}.version must be ${expectedPlatformVersion}; found "${String(lockedPlatformPackage?.version ?? "<missing>")}".`,
+        `${CODEX_ROUTE_PLUGIN_PACKAGE_NAME} npm-shrinkwrap ${platformPackageKey}.version must be ${expectedPlatformVersion}; found "${lockedPlatformPackageVersion ?? "<missing>"}".`,
       );
     }
   }

--- a/scripts/lib/plugin-npm-release.ts
+++ b/scripts/lib/plugin-npm-release.ts
@@ -13,6 +13,8 @@ export type PluginPackageJson = {
   version?: string;
   type?: string;
   private?: boolean;
+  dependencies?: Record<string, string>;
+  optionalDependencies?: Record<string, string>;
   repository?:
     | string
     | {
@@ -25,6 +27,7 @@ export type PluginPackageJson = {
       defaultChoice?: string;
       minHostVersion?: string;
       npmSpec?: string;
+      requiredPlatformPackages?: string[];
     };
     compat?: {
       pluginApi?: string;
@@ -85,6 +88,17 @@ export type PublishablePluginPackageCandidate<
 };
 
 export const OPENCLAW_PLUGIN_NPM_REPOSITORY_URL = "https://github.com/openclaw/openclaw";
+const CODEX_ROUTE_PLUGIN_PACKAGE_NAME = "@openclaw/codex";
+const CODEX_ROUTE_RUNTIME_DEPENDENCY_NAME = "@openai/codex";
+const CODEX_ROUTE_RUNTIME_PLATFORM_PACKAGES = [
+  "@openai/codex-linux-x64",
+  "@openai/codex-linux-arm64",
+  "@openai/codex-darwin-x64",
+  "@openai/codex-darwin-arm64",
+  "@openai/codex-win32-x64",
+  "@openai/codex-win32-arm64",
+] as const;
+const EXACT_NPM_VERSION_PATTERN = /^\d+\.\d+\.\d+(?:[-+][0-9A-Za-z.-]+)?$/u;
 
 function readPluginPackageJson(path: string): unknown {
   return JSON.parse(readFileSync(path, "utf8"));
@@ -96,6 +110,107 @@ function readOptionalTextFile(path: string): string | undefined {
   } catch {
     return undefined;
   }
+}
+
+function readOptionalJsonFile<TValue>(path: string): TValue | undefined {
+  try {
+    return JSON.parse(readFileSync(path, "utf8")) as TValue;
+  } catch {
+    return undefined;
+  }
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value && typeof value === "object" && !Array.isArray(value));
+}
+
+function collectCodexRouteRuntimePackageErrors(
+  candidate: PublishablePluginPackageCandidate,
+): string[] {
+  if (candidate.packageJson.name !== CODEX_ROUTE_PLUGIN_PACKAGE_NAME) {
+    return [];
+  }
+  const errors: string[] = [];
+  const expectedVersion =
+    candidate.packageJson.dependencies?.[CODEX_ROUTE_RUNTIME_DEPENDENCY_NAME]?.trim() ?? "";
+  const requiredPlatformPackages =
+    candidate.packageJson.openclaw?.install?.requiredPlatformPackages;
+
+  if (!expectedVersion) {
+    errors.push(
+      `${CODEX_ROUTE_PLUGIN_PACKAGE_NAME} must declare dependencies["${CODEX_ROUTE_RUNTIME_DEPENDENCY_NAME}"] so route binary drift can be checked before publish.`,
+    );
+    return errors;
+  }
+  if (!EXACT_NPM_VERSION_PATTERN.test(expectedVersion)) {
+    errors.push(
+      `${CODEX_ROUTE_PLUGIN_PACKAGE_NAME} must pin ${CODEX_ROUTE_RUNTIME_DEPENDENCY_NAME} to an exact version; found "${expectedVersion}".`,
+    );
+  }
+  if (
+    !Array.isArray(requiredPlatformPackages) ||
+    CODEX_ROUTE_RUNTIME_PLATFORM_PACKAGES.some((pkg) => !requiredPlatformPackages.includes(pkg))
+  ) {
+    errors.push(
+      `${CODEX_ROUTE_PLUGIN_PACKAGE_NAME} openclaw.install.requiredPlatformPackages must include every ${CODEX_ROUTE_RUNTIME_DEPENDENCY_NAME} platform package.`,
+    );
+  }
+
+  const shrinkwrap = readOptionalJsonFile<{
+    packages?: Record<string, unknown>;
+  }>(join(candidate.packageDir, "npm-shrinkwrap.json"));
+  if (!shrinkwrap) {
+    errors.push(
+      `${CODEX_ROUTE_PLUGIN_PACKAGE_NAME} npm-shrinkwrap.json is required so npm publishes the approved ${CODEX_ROUTE_RUNTIME_DEPENDENCY_NAME} route binary.`,
+    );
+    return errors;
+  }
+
+  const packages = shrinkwrap.packages;
+  const rootPackage = isRecord(packages?.[""]) ? packages[""] : undefined;
+  const rootDependencies = isRecord(rootPackage?.dependencies)
+    ? rootPackage.dependencies
+    : undefined;
+  const shrinkwrapRootVersion = rootDependencies?.[CODEX_ROUTE_RUNTIME_DEPENDENCY_NAME];
+  if (shrinkwrapRootVersion !== expectedVersion) {
+    errors.push(
+      `${CODEX_ROUTE_PLUGIN_PACKAGE_NAME} npm-shrinkwrap root dependency ${CODEX_ROUTE_RUNTIME_DEPENDENCY_NAME} must be ${expectedVersion}; found "${String(shrinkwrapRootVersion ?? "<missing>")}".`,
+    );
+  }
+
+  const runtimePackageKey = `node_modules/${CODEX_ROUTE_RUNTIME_DEPENDENCY_NAME}`;
+  const runtimePackage = isRecord(packages?.[runtimePackageKey])
+    ? packages[runtimePackageKey]
+    : undefined;
+  if (runtimePackage?.version !== expectedVersion) {
+    errors.push(
+      `${CODEX_ROUTE_PLUGIN_PACKAGE_NAME} npm-shrinkwrap ${runtimePackageKey}.version must be ${expectedVersion}; found "${String(runtimePackage?.version ?? "<missing>")}".`,
+    );
+  }
+  const optionalDependencies = isRecord(runtimePackage?.optionalDependencies)
+    ? runtimePackage.optionalDependencies
+    : {};
+  for (const platformPackage of CODEX_ROUTE_RUNTIME_PLATFORM_PACKAGES) {
+    const platformSuffix = platformPackage.slice(`${CODEX_ROUTE_RUNTIME_DEPENDENCY_NAME}-`.length);
+    const expectedAlias = `npm:${CODEX_ROUTE_RUNTIME_DEPENDENCY_NAME}@${expectedVersion}-${platformSuffix}`;
+    if (optionalDependencies[platformPackage] !== expectedAlias) {
+      errors.push(
+        `${CODEX_ROUTE_PLUGIN_PACKAGE_NAME} npm-shrinkwrap ${runtimePackageKey}.optionalDependencies["${platformPackage}"] must be "${expectedAlias}"; found "${String(optionalDependencies[platformPackage] ?? "<missing>")}".`,
+      );
+    }
+    const platformPackageKey = `node_modules/${platformPackage}`;
+    const lockedPlatformPackage = isRecord(packages?.[platformPackageKey])
+      ? packages[platformPackageKey]
+      : undefined;
+    const expectedPlatformVersion = `${expectedVersion}-${platformSuffix}`;
+    if (lockedPlatformPackage?.version !== expectedPlatformVersion) {
+      errors.push(
+        `${CODEX_ROUTE_PLUGIN_PACKAGE_NAME} npm-shrinkwrap ${platformPackageKey}.version must be ${expectedPlatformVersion}; found "${String(lockedPlatformPackage?.version ?? "<missing>")}".`,
+      );
+    }
+  }
+
+  return errors;
 }
 
 export function collectExtensionPackageJsonCandidates<
@@ -298,6 +413,7 @@ export function collectPublishablePluginPackageErrors(
   errors.push(
     ...validateExternalCodePluginPackageJson(packageJson).issues.map((issue) => issue.message),
   );
+  errors.push(...collectCodexRouteRuntimePackageErrors(candidate));
 
   return errors;
 }

--- a/src/cli/daemon-cli/status.print.test.ts
+++ b/src/cli/daemon-cli/status.print.test.ts
@@ -681,6 +681,7 @@ describe("printDaemonStatus", () => {
         },
         pluginVersionDrift: {
           gatewayVersion: "2026.5.4",
+          runtimeDependencyDrifts: [],
           drifts: [
             {
               pluginId: "whatsapp",
@@ -712,6 +713,7 @@ describe("printDaemonStatus", () => {
         },
         pluginVersionDrift: {
           gatewayVersion: "2026.5.4",
+          runtimeDependencyDrifts: [],
           drifts: [
             {
               pluginId: "whatsapp",
@@ -731,6 +733,44 @@ describe("printDaemonStatus", () => {
     expectMockLineContains(runtime.log, "openclaw gateway restart");
   });
 
+  it("prints detailed plugin route runtime dependency drift entries in deep mode", () => {
+    printDaemonStatus(
+      {
+        service: {
+          label: "LaunchAgent",
+          loaded: true,
+          loadedText: "loaded",
+          notLoadedText: "not loaded",
+          runtime: { status: "running", pid: 8000 },
+        },
+        pluginVersionDrift: {
+          gatewayVersion: "2026.6.11",
+          drifts: [],
+          runtimeDependencyDrifts: [
+            {
+              pluginId: "codex",
+              dependencyName: "@openai/codex",
+              expectedVersion: "0.142.5",
+              source: "npm",
+              installedVersion: "2026.6.11",
+              installedDependencyVersion: "0.139.0",
+              installPath:
+                "/home/eva/.openclaw/npm/projects/openclaw-codex/node_modules/@openclaw/codex",
+            },
+          ],
+        },
+        extraServices: [],
+      },
+      { json: false, deep: true },
+    );
+
+    expectMockLineContains(runtime.log, "route runtime dependency");
+    expectMockLineContains(runtime.log, "- codex in 2026.6.11: @openai/codex 0.139.0");
+    expectMockLineContains(runtime.log, "expected 0.142.5");
+    expectMockLineContains(runtime.log, "openclaw plugins update codex");
+    expectMockLineContains(runtime.log, "openclaw gateway restart");
+  });
+
   it("prints exact package update commands for pinned npm plugin drift in deep mode", () => {
     printDaemonStatus(
       {
@@ -743,6 +783,7 @@ describe("printDaemonStatus", () => {
         },
         pluginVersionDrift: {
           gatewayVersion: "2026.6.10-beta.1",
+          runtimeDependencyDrifts: [],
           drifts: [
             {
               pluginId: "brave",

--- a/src/cli/daemon-cli/status.print.ts
+++ b/src/cli/daemon-cli/status.print.ts
@@ -19,7 +19,10 @@ import { classifySystemdUnavailableDetail } from "../../daemon/systemd-unavailab
 import { resolveControlUiLinks } from "../../gateway/control-ui-links.js";
 import { formatGatewayRestartHandoffDiagnostic } from "../../infra/restart-handoff.js";
 import { isWSLEnv } from "../../infra/wsl.js";
-import { resolvePluginVersionDriftUpdateCommand } from "../../plugins/plugin-version-drift.js";
+import {
+  resolvePluginRuntimeDependencyDriftUpdateCommand,
+  resolvePluginVersionDriftUpdateCommand,
+} from "../../plugins/plugin-version-drift.js";
 import { defaultRuntime } from "../../runtime.js";
 import { shortenHomePath } from "../../utils.js";
 import { formatCliCommand } from "../command-format.js";
@@ -506,14 +509,20 @@ export function printDaemonStatus(status: DaemonStatus, opts: { json: boolean; d
   }
 
   const drift = status.pluginVersionDrift;
-  if (drift && drift.drifts.length > 0) {
-    defaultRuntime.log(
-      warnText(
-        `Plugin version drift: ${drift.drifts.length} active official plugin${
-          drift.drifts.length === 1 ? "" : "s"
-        } not on gateway ${drift.gatewayVersion}`,
-      ),
-    );
+  if (drift && (drift.drifts.length > 0 || drift.runtimeDependencyDrifts.length > 0)) {
+    const driftParts = [
+      drift.drifts.length > 0
+        ? `${drift.drifts.length} active official plugin${
+            drift.drifts.length === 1 ? "" : "s"
+          } not on gateway ${drift.gatewayVersion}`
+        : null,
+      drift.runtimeDependencyDrifts.length > 0
+        ? `${drift.runtimeDependencyDrifts.length} route runtime dependenc${
+            drift.runtimeDependencyDrifts.length === 1 ? "y" : "ies"
+          } not on the approved release version`
+        : null,
+    ].filter((line): line is string => Boolean(line));
+    defaultRuntime.log(warnText(`Plugin version drift: ${driftParts.join("; ")}`));
     if (opts.deep) {
       for (const entry of drift.drifts) {
         const sourceLabel = entry.source === "clawhub" ? "clawhub" : "npm";
@@ -521,16 +530,35 @@ export function printDaemonStatus(status: DaemonStatus, opts: { json: boolean; d
           `- ${warnText(entry.pluginId)}: ${entry.installedVersion} (${sourceLabel}) → expected ${drift.gatewayVersion}`,
         );
       }
-      const updateCommands = drift.drifts.map((entry) =>
-        formatCliCommand(resolvePluginVersionDriftUpdateCommand(entry)),
-      );
-      if (updateCommands.length === 1) {
+      for (const entry of drift.runtimeDependencyDrifts) {
+        const sourceLabel = entry.source === "clawhub" ? "clawhub" : "npm";
+        const installed = entry.installedDependencyVersion ?? "<missing>";
+        const pluginVersion = entry.installedVersion ? ` in ${entry.installedVersion}` : "";
         defaultRuntime.log(
-          `${label("Fix:")} ${updateCommands[0]} && ${formatCliCommand("openclaw gateway restart")}.`,
+          `- ${warnText(entry.pluginId)}${pluginVersion}: ${entry.dependencyName} ${installed} (${sourceLabel}) → expected ${entry.expectedVersion}`,
+        );
+        if (entry.installPath) {
+          defaultRuntime.log(
+            `  ${label("Plugin root:")} ${infoText(shortenHomePath(entry.installPath))}`,
+          );
+        }
+      }
+      const updateCommands = [
+        ...drift.drifts.map((entry) =>
+          formatCliCommand(resolvePluginVersionDriftUpdateCommand(entry)),
+        ),
+        ...drift.runtimeDependencyDrifts.map((entry) =>
+          formatCliCommand(resolvePluginRuntimeDependencyDriftUpdateCommand(entry)),
+        ),
+      ];
+      const uniqueUpdateCommands = [...new Set(updateCommands)];
+      if (uniqueUpdateCommands.length === 1) {
+        defaultRuntime.log(
+          `${label("Fix:")} ${uniqueUpdateCommands[0]} && ${formatCliCommand("openclaw gateway restart")}.`,
         );
       } else {
         defaultRuntime.log(`${label("Fix:")} update each drifted plugin:`);
-        for (const command of updateCommands) {
+        for (const command of uniqueUpdateCommands) {
           defaultRuntime.log(`- ${command}`);
         }
         defaultRuntime.log(`Then run ${formatCliCommand("openclaw gateway restart")}.`);

--- a/src/cli/daemon-cli/status.print.ts
+++ b/src/cli/daemon-cli/status.print.ts
@@ -533,13 +533,22 @@ export function printDaemonStatus(status: DaemonStatus, opts: { json: boolean; d
       for (const entry of drift.runtimeDependencyDrifts) {
         const sourceLabel = entry.source === "clawhub" ? "clawhub" : "npm";
         const installed = entry.installedDependencyVersion ?? "<missing>";
+        const installedLabel =
+          entry.declaredDependencyVersion && entry.declaredDependencyVersion !== installed
+            ? `${installed} (declared ${entry.declaredDependencyVersion}, ${sourceLabel})`
+            : `${installed} (${sourceLabel})`;
         const pluginVersion = entry.installedVersion ? ` in ${entry.installedVersion}` : "";
         defaultRuntime.log(
-          `- ${warnText(entry.pluginId)}${pluginVersion}: ${entry.dependencyName} ${installed} (${sourceLabel}) → expected ${entry.expectedVersion}`,
+          `- ${warnText(entry.pluginId)}${pluginVersion}: ${entry.dependencyName} ${installedLabel} → expected ${entry.expectedVersion}`,
         );
         if (entry.installPath) {
           defaultRuntime.log(
             `  ${label("Plugin root:")} ${infoText(shortenHomePath(entry.installPath))}`,
+          );
+        }
+        if (entry.dependencyPackageJsonPath) {
+          defaultRuntime.log(
+            `  ${label("Runtime package:")} ${infoText(shortenHomePath(entry.dependencyPackageJsonPath))}`,
           );
         }
       }

--- a/src/commands/doctor-workspace-status.test.ts
+++ b/src/commands/doctor-workspace-status.test.ts
@@ -178,6 +178,7 @@ describe("noteWorkspaceStatus", () => {
       {
         pluginVersionDrift: {
           gatewayVersion: "2026.6.1",
+          runtimeDependencyDrifts: [],
           drifts: [
             {
               pluginId: "codex",
@@ -198,6 +199,51 @@ describe("noteWorkspaceStatus", () => {
         target: "codex",
         requirement: "plugin-version-drift",
         message: expect.stringContaining("2026.5.30-beta.1"),
+        fixHint: expect.stringContaining("openclaw plugins update codex"),
+      }),
+    ]);
+  });
+
+  it("collects Codex route runtime dependency drift as a structured finding", async () => {
+    mocks.resolveDefaultAgentId.mockReturnValue("default");
+    mocks.resolveAgentWorkspaceDir.mockReturnValue("/workspace");
+    mocks.buildPluginRegistrySnapshotReport.mockReturnValue({
+      workspaceDir: "/workspace",
+      ...createPluginLoadResult({ plugins: [] }),
+    });
+    mocks.buildPluginCompatibilityWarnings.mockReturnValue([]);
+    mocks.listTaskFlowRecords.mockReturnValue([]);
+
+    const findings = collectWorkspaceStatusHealthFindings(
+      {
+        plugins: { entries: { codex: { enabled: true } } },
+      },
+      {
+        pluginVersionDrift: {
+          gatewayVersion: "2026.6.11",
+          drifts: [],
+          runtimeDependencyDrifts: [
+            {
+              pluginId: "codex",
+              dependencyName: "@openai/codex",
+              expectedVersion: "0.142.5",
+              source: "npm",
+              installedVersion: "2026.6.11",
+              installedDependencyVersion: "0.139.0",
+            },
+          ],
+        },
+      },
+    );
+
+    expect(findings).toEqual([
+      expect.objectContaining({
+        checkId: "core/doctor/workspace-status",
+        severity: "warning",
+        path: "plugins.entries.codex",
+        target: "codex",
+        requirement: "plugin-runtime-dependency-drift",
+        message: expect.stringContaining("@openai/codex 0.139.0"),
         fixHint: expect.stringContaining("openclaw plugins update codex"),
       }),
     ]);
@@ -288,6 +334,7 @@ describe("noteWorkspaceStatus", () => {
         },
         pluginVersionDrift: {
           gatewayVersion: "2026.6.1",
+          runtimeDependencyDrifts: [],
           drifts: [
             {
               pluginId: "codex",
@@ -303,7 +350,7 @@ describe("noteWorkspaceStatus", () => {
       const driftCalls = noteSpy.mock.calls.filter(([, title]) => title === "Plugin version drift");
       expect(driftCalls).toHaveLength(1);
       const [[body]] = driftCalls;
-      expect(body).toContain("1 active official plugin not on OpenClaw 2026.6.1");
+      expect(body).toContain("1 active official plugin drift found for OpenClaw 2026.6.1");
       expect(body).toContain("codex: 2026.5.30-beta.1 (npm) -> expected 2026.6.1");
       expect(body).toContain("openclaw plugins update codex");
       expect(body).toContain("openclaw gateway restart");
@@ -335,6 +382,7 @@ describe("noteWorkspaceStatus", () => {
         },
         pluginVersionDrift: {
           gatewayVersion: "2026.6.10-beta.1",
+          runtimeDependencyDrifts: [],
           drifts: [
             {
               pluginId: "brave",
@@ -354,6 +402,56 @@ describe("noteWorkspaceStatus", () => {
       const [[body]] = driftCalls;
       expect(body).toContain("openclaw plugins update @openclaw/brave-plugin@2026.6.10-beta.1");
       expect(body).not.toContain("openclaw plugins update brave");
+      expect(body).toContain("openclaw gateway restart");
+    } finally {
+      noteSpy.mockRestore();
+    }
+  });
+
+  it("surfaces Codex route runtime dependency drift in workspace notes", async () => {
+    const noteSpy = await runNoteWorkspaceStatusForTest(
+      createPluginLoadResult({
+        plugins: [
+          createPluginRecord({
+            id: "codex",
+            name: "Codex",
+            origin: "global",
+            source: "/tmp/codex/index.js",
+          }),
+        ],
+      }),
+      [],
+      {
+        cfg: {
+          plugins: {
+            entries: {
+              codex: { enabled: true },
+            },
+          },
+        },
+        pluginVersionDrift: {
+          gatewayVersion: "2026.6.11",
+          drifts: [],
+          runtimeDependencyDrifts: [
+            {
+              pluginId: "codex",
+              dependencyName: "@openai/codex",
+              expectedVersion: "0.142.5",
+              source: "npm",
+              installedVersion: "2026.6.11",
+              installedDependencyVersion: "0.139.0",
+            },
+          ],
+        },
+      },
+    );
+    try {
+      const driftCalls = noteSpy.mock.calls.filter(([, title]) => title === "Plugin version drift");
+      expect(driftCalls).toHaveLength(1);
+      const [[body]] = driftCalls;
+      expect(body).toContain("1 active official plugin drift found for OpenClaw 2026.6.11");
+      expect(body).toContain("codex 2026.6.11: @openai/codex 0.139.0 (npm) -> expected 0.142.5");
+      expect(body).toContain("openclaw plugins update codex");
       expect(body).toContain("openclaw gateway restart");
     } finally {
       noteSpy.mockRestore();

--- a/src/commands/doctor-workspace-status.ts
+++ b/src/commands/doctor-workspace-status.ts
@@ -5,6 +5,7 @@ import { formatCliCommand } from "../cli/command-format.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import type { HealthFinding } from "../flows/health-checks.js";
 import {
+  resolvePluginRuntimeDependencyDriftUpdateCommand,
   resolvePluginVersionDriftUpdateCommand,
   type PluginVersionDriftReport,
 } from "../plugins/plugin-version-drift.js";
@@ -77,21 +78,39 @@ function noteFlowRecoveryHints() {
 function pluginVersionDriftToHealthFindings(
   drift: PluginVersionDriftReport | undefined,
 ): HealthFinding[] {
-  if (!drift || drift.drifts.length === 0) {
+  if (!drift || (drift.drifts.length === 0 && drift.runtimeDependencyDrifts.length === 0)) {
     return [];
   }
-  return drift.drifts.map((entry) => {
-    const updateCommand = formatCliCommand(resolvePluginVersionDriftUpdateCommand(entry));
-    return {
-      checkId: WORKSPACE_STATUS_CHECK_ID,
-      severity: "warning",
-      message: `Plugin ${entry.pluginId} is ${entry.installedVersion}, but the Gateway is ${drift.gatewayVersion}.`,
-      path: `plugins.entries.${entry.pluginId}`,
-      target: entry.pluginId,
-      requirement: "plugin-version-drift",
-      fixHint: `${updateCommand} && ${formatCliCommand("openclaw gateway restart")}`,
-    };
-  });
+  return [
+    ...drift.drifts.map((entry) => {
+      const updateCommand = formatCliCommand(resolvePluginVersionDriftUpdateCommand(entry));
+      return {
+        checkId: WORKSPACE_STATUS_CHECK_ID,
+        severity: "warning" as const,
+        message: `Plugin ${entry.pluginId} is ${entry.installedVersion}, but the Gateway is ${drift.gatewayVersion}.`,
+        path: `plugins.entries.${entry.pluginId}`,
+        target: entry.pluginId,
+        requirement: "plugin-version-drift",
+        fixHint: `${updateCommand} && ${formatCliCommand("openclaw gateway restart")}`,
+      };
+    }),
+    ...drift.runtimeDependencyDrifts.map((entry) => {
+      const updateCommand = formatCliCommand(
+        resolvePluginRuntimeDependencyDriftUpdateCommand(entry),
+      );
+      const installed = entry.installedDependencyVersion ?? "<missing>";
+      const pluginVersion = entry.installedVersion ? ` ${entry.installedVersion}` : "";
+      return {
+        checkId: WORKSPACE_STATUS_CHECK_ID,
+        severity: "warning" as const,
+        message: `Plugin ${entry.pluginId}${pluginVersion} embeds ${entry.dependencyName} ${installed}, but this OpenClaw release expects ${entry.expectedVersion} for route runtime execution.`,
+        path: `plugins.entries.${entry.pluginId}`,
+        target: entry.pluginId,
+        requirement: "plugin-runtime-dependency-drift",
+        fixHint: `${updateCommand} && ${formatCliCommand("openclaw gateway restart")}`,
+      };
+    }),
+  ];
 }
 
 function pluginCompatibilityWarningToHealthFinding(message: string): HealthFinding {
@@ -158,26 +177,34 @@ export function collectWorkspaceStatusHealthFindings(
 }
 
 function notePluginVersionDrift(drift: PluginVersionDriftReport | undefined) {
-  if (!drift || drift.drifts.length === 0) {
+  if (!drift || (drift.drifts.length === 0 && drift.runtimeDependencyDrifts.length === 0)) {
     return;
   }
-  const singleDrift = drift.drifts.length === 1 ? drift.drifts[0] : undefined;
-  const updateCommands = drift.drifts.map((entry) =>
-    formatCliCommand(resolvePluginVersionDriftUpdateCommand(entry)),
-  );
+  const totalDrifts = drift.drifts.length + drift.runtimeDependencyDrifts.length;
+  const updateCommands = [
+    ...drift.drifts.map((entry) => formatCliCommand(resolvePluginVersionDriftUpdateCommand(entry))),
+    ...drift.runtimeDependencyDrifts.map((entry) =>
+      formatCliCommand(resolvePluginRuntimeDependencyDriftUpdateCommand(entry)),
+    ),
+  ];
+  const uniqueUpdateCommands = [...new Set(updateCommands)];
   const lines = [
-    `${drift.drifts.length} active official plugin${
-      drift.drifts.length === 1 ? "" : "s"
-    } not on OpenClaw ${drift.gatewayVersion}`,
+    `${totalDrifts} active official plugin drift${totalDrifts === 1 ? "" : "s"} found for OpenClaw ${drift.gatewayVersion}`,
     ...drift.drifts.map((entry) => {
       const sourceLabel = entry.source === "clawhub" ? "clawhub" : "npm";
       return `- ${entry.pluginId}: ${entry.installedVersion} (${sourceLabel}) -> expected ${drift.gatewayVersion}`;
     }),
-    singleDrift
-      ? `Fix: ${updateCommands[0]} && ${formatCliCommand("openclaw gateway restart")}.`
+    ...drift.runtimeDependencyDrifts.map((entry) => {
+      const sourceLabel = entry.source === "clawhub" ? "clawhub" : "npm";
+      const installed = entry.installedDependencyVersion ?? "<missing>";
+      const pluginVersion = entry.installedVersion ? ` ${entry.installedVersion}` : "";
+      return `- ${entry.pluginId}${pluginVersion}: ${entry.dependencyName} ${installed} (${sourceLabel}) -> expected ${entry.expectedVersion}`;
+    }),
+    uniqueUpdateCommands.length === 1
+      ? `Fix: ${uniqueUpdateCommands[0]} && ${formatCliCommand("openclaw gateway restart")}.`
       : [
           "Fix each drifted plugin:",
-          ...updateCommands.map((command) => `- ${command}`),
+          ...uniqueUpdateCommands.map((command) => `- ${command}`),
           `Then run ${formatCliCommand("openclaw gateway restart")}.`,
         ].join("\n"),
   ];

--- a/src/commands/doctor-workspace-status.ts
+++ b/src/commands/doctor-workspace-status.ts
@@ -99,11 +99,15 @@ function pluginVersionDriftToHealthFindings(
         resolvePluginRuntimeDependencyDriftUpdateCommand(entry),
       );
       const installed = entry.installedDependencyVersion ?? "<missing>";
+      const installedDetail =
+        entry.declaredDependencyVersion && entry.declaredDependencyVersion !== installed
+          ? `${installed} (declared ${entry.declaredDependencyVersion})`
+          : installed;
       const pluginVersion = entry.installedVersion ? ` ${entry.installedVersion}` : "";
       return {
         checkId: WORKSPACE_STATUS_CHECK_ID,
         severity: "warning" as const,
-        message: `Plugin ${entry.pluginId}${pluginVersion} embeds ${entry.dependencyName} ${installed}, but this OpenClaw release expects ${entry.expectedVersion} for route runtime execution.`,
+        message: `Plugin ${entry.pluginId}${pluginVersion} embeds ${entry.dependencyName} ${installedDetail}, but this OpenClaw release expects ${entry.expectedVersion} for route runtime execution.`,
         path: `plugins.entries.${entry.pluginId}`,
         target: entry.pluginId,
         requirement: "plugin-runtime-dependency-drift",
@@ -197,8 +201,12 @@ function notePluginVersionDrift(drift: PluginVersionDriftReport | undefined) {
     ...drift.runtimeDependencyDrifts.map((entry) => {
       const sourceLabel = entry.source === "clawhub" ? "clawhub" : "npm";
       const installed = entry.installedDependencyVersion ?? "<missing>";
+      const installedDetail =
+        entry.declaredDependencyVersion && entry.declaredDependencyVersion !== installed
+          ? `${installed} (declared ${entry.declaredDependencyVersion})`
+          : installed;
       const pluginVersion = entry.installedVersion ? ` ${entry.installedVersion}` : "";
-      return `- ${entry.pluginId}${pluginVersion}: ${entry.dependencyName} ${installed} (${sourceLabel}) -> expected ${entry.expectedVersion}`;
+      return `- ${entry.pluginId}${pluginVersion}: ${entry.dependencyName} ${installedDetail} (${sourceLabel}) -> expected ${entry.expectedVersion}`;
     }),
     uniqueUpdateCommands.length === 1
       ? `Fix: ${uniqueUpdateCommands[0]} && ${formatCliCommand("openclaw gateway restart")}.`

--- a/src/plugins/plugin-version-drift.test.ts
+++ b/src/plugins/plugin-version-drift.test.ts
@@ -543,4 +543,19 @@ describe("resolvePluginRuntimeDependencyDriftUpdateCommand", () => {
       }),
     ).toBe("openclaw plugins update codex");
   });
+
+  it("uses the package name for exact pinned stale route runtime dependencies", () => {
+    expect(
+      resolvePluginRuntimeDependencyDriftUpdateCommand({
+        pluginId: "codex",
+        dependencyName: "@openai/codex",
+        expectedVersion: "0.142.5",
+        source: "npm",
+        installedVersion: "2026.6.11",
+        installedDependencyVersion: "0.139.0",
+        packageName: "@openclaw/codex",
+        spec: "@openclaw/codex@2026.6.11",
+      }),
+    ).toBe("openclaw plugins update @openclaw/codex");
+  });
 });

--- a/src/plugins/plugin-version-drift.test.ts
+++ b/src/plugins/plugin-version-drift.test.ts
@@ -1,5 +1,5 @@
 /** Tests plugin version drift detection between package, manifest, and install records. */
-import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { describe, expect, it } from "vitest";
@@ -41,6 +41,7 @@ function clawhubRecord(
 function withPackageJson(
   dependencies: Record<string, string>,
   callback: (installPath: string) => void,
+  installedDependencies: Record<string, string> = dependencies,
 ): void {
   const installPath = mkdtempSync(join(tmpdir(), "openclaw-plugin-drift-"));
   try {
@@ -48,6 +49,14 @@ function withPackageJson(
       join(installPath, "package.json"),
       JSON.stringify({ name: "@openclaw/codex", dependencies }, null, 2),
     );
+    for (const [dependencyName, version] of Object.entries(installedDependencies)) {
+      const dependencyDir = join(installPath, "node_modules", ...dependencyName.split("/"));
+      mkdirSync(dependencyDir, { recursive: true });
+      writeFileSync(
+        join(dependencyDir, "package.json"),
+        JSON.stringify({ name: dependencyName, version }, null, 2),
+      );
+    }
     callback(installPath);
   } finally {
     rmSync(installPath, { recursive: true, force: true });
@@ -369,10 +378,18 @@ describe("detectPluginVersionDrift", () => {
           expectedVersion: "0.142.5",
           source: "npm",
           installedVersion: "2026.6.11",
+          declaredDependencyVersion: "0.139.0",
           installedDependencyVersion: "0.139.0",
           packageName: "@openclaw/codex",
           spec: "@openclaw/codex",
           installPath,
+          dependencyPackageJsonPath: join(
+            installPath,
+            "node_modules",
+            "@openai",
+            "codex",
+            "package.json",
+          ),
         },
       ]);
     });
@@ -402,10 +419,45 @@ describe("detectPluginVersionDrift", () => {
       expect(result.runtimeDependencyDrifts).toHaveLength(1);
       expect(result.runtimeDependencyDrifts[0]).toMatchObject({
         pluginId: "codex",
+        declaredDependencyVersion: "0.139.0",
         installedDependencyVersion: "0.139.0",
         expectedVersion: "0.142.5",
       });
     });
+  });
+
+  it("reports Codex route runtime drift when the declaration is current but the nested runtime is stale", () => {
+    withPackageJson(
+      { "@openai/codex": "0.142.5" },
+      (installPath) => {
+        const result = detectPluginVersionDrift({
+          gatewayVersion: "2026.6.11",
+          installRecords: {
+            codex: npmRecord("2026.6.11", {
+              resolvedName: "@openclaw/codex",
+              spec: "@openclaw/codex",
+              installPath,
+            }),
+          },
+          runtimeDependencyExpectations: [
+            {
+              pluginId: "codex",
+              dependencyName: "@openai/codex",
+              expectedVersion: "0.142.5",
+            },
+          ],
+        });
+
+        expect(result.runtimeDependencyDrifts).toHaveLength(1);
+        expect(result.runtimeDependencyDrifts[0]).toMatchObject({
+          pluginId: "codex",
+          declaredDependencyVersion: "0.142.5",
+          installedDependencyVersion: "0.139.0",
+          expectedVersion: "0.142.5",
+        });
+      },
+      { "@openai/codex": "0.139.0" },
+    );
   });
 
   it("does not report Codex route runtime dependency drift when the embedded dependency matches", () => {
@@ -459,6 +511,7 @@ describe("detectPluginVersionDrift", () => {
           expectedVersion: "0.142.5",
         }),
       ]);
+      expect(result.runtimeDependencyDrifts[0]).not.toHaveProperty("declaredDependencyVersion");
       expect(result.runtimeDependencyDrifts[0]).not.toHaveProperty("installedDependencyVersion");
     });
   });

--- a/src/plugins/plugin-version-drift.test.ts
+++ b/src/plugins/plugin-version-drift.test.ts
@@ -1,9 +1,13 @@
 /** Tests plugin version drift detection between package, manifest, and install records. */
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { describe, expect, it } from "vitest";
 import type { OpenClawConfig } from "../config/types.js";
 import type { PluginInstallRecord } from "../config/types.plugins.js";
 import {
   detectPluginVersionDrift,
+  resolvePluginRuntimeDependencyDriftUpdateCommand,
   resolvePluginVersionDriftUpdateCommand,
 } from "./plugin-version-drift.js";
 
@@ -32,6 +36,22 @@ function clawhubRecord(
     resolvedVersion: version,
     ...overrides,
   };
+}
+
+function withPackageJson(
+  dependencies: Record<string, string>,
+  callback: (installPath: string) => void,
+): void {
+  const installPath = mkdtempSync(join(tmpdir(), "openclaw-plugin-drift-"));
+  try {
+    writeFileSync(
+      join(installPath, "package.json"),
+      JSON.stringify({ name: "@openclaw/codex", dependencies }, null, 2),
+    );
+    callback(installPath);
+  } finally {
+    rmSync(installPath, { recursive: true, force: true });
+  }
 }
 
 describe("detectPluginVersionDrift", () => {
@@ -320,6 +340,128 @@ describe("detectPluginVersionDrift", () => {
 
     expect(result.drifts.map((d) => d.pluginId)).toEqual(["discord", "matrix", "whatsapp"]);
   });
+
+  it("reports stale Codex route runtime dependencies even when the plugin version matches the gateway", () => {
+    withPackageJson({ "@openai/codex": "0.139.0" }, (installPath) => {
+      const result = detectPluginVersionDrift({
+        gatewayVersion: "2026.6.11",
+        installRecords: {
+          codex: npmRecord("2026.6.11", {
+            resolvedName: "@openclaw/codex",
+            spec: "@openclaw/codex",
+            installPath,
+          }),
+        },
+        runtimeDependencyExpectations: [
+          {
+            pluginId: "codex",
+            dependencyName: "@openai/codex",
+            expectedVersion: "0.142.5",
+          },
+        ],
+      });
+
+      expect(result.drifts).toEqual([]);
+      expect(result.runtimeDependencyDrifts).toEqual([
+        {
+          pluginId: "codex",
+          dependencyName: "@openai/codex",
+          expectedVersion: "0.142.5",
+          source: "npm",
+          installedVersion: "2026.6.11",
+          installedDependencyVersion: "0.139.0",
+          packageName: "@openclaw/codex",
+          spec: "@openclaw/codex",
+          installPath,
+        },
+      ]);
+    });
+  });
+
+  it("checks exact pinned official Codex plugin installs for route runtime dependency drift", () => {
+    withPackageJson({ "@openai/codex": "0.139.0" }, (installPath) => {
+      const result = detectPluginVersionDrift({
+        gatewayVersion: "2026.6.11",
+        installRecords: {
+          codex: npmRecord("2026.6.11", {
+            resolvedName: "@openclaw/codex",
+            spec: "@openclaw/codex@2026.6.11",
+            installPath,
+          }),
+        },
+        runtimeDependencyExpectations: [
+          {
+            pluginId: "codex",
+            dependencyName: "@openai/codex",
+            expectedVersion: "0.142.5",
+          },
+        ],
+      });
+
+      expect(result.drifts).toEqual([]);
+      expect(result.runtimeDependencyDrifts).toHaveLength(1);
+      expect(result.runtimeDependencyDrifts[0]).toMatchObject({
+        pluginId: "codex",
+        installedDependencyVersion: "0.139.0",
+        expectedVersion: "0.142.5",
+      });
+    });
+  });
+
+  it("does not report Codex route runtime dependency drift when the embedded dependency matches", () => {
+    withPackageJson({ "@openai/codex": "0.142.5" }, (installPath) => {
+      const result = detectPluginVersionDrift({
+        gatewayVersion: "2026.6.11",
+        installRecords: {
+          codex: npmRecord("2026.6.11", {
+            resolvedName: "@openclaw/codex",
+            spec: "@openclaw/codex",
+            installPath,
+          }),
+        },
+        runtimeDependencyExpectations: [
+          {
+            pluginId: "codex",
+            dependencyName: "@openai/codex",
+            expectedVersion: "0.142.5",
+          },
+        ],
+      });
+
+      expect(result.runtimeDependencyDrifts).toEqual([]);
+    });
+  });
+
+  it("reports missing Codex route runtime dependencies", () => {
+    withPackageJson({}, (installPath) => {
+      const result = detectPluginVersionDrift({
+        gatewayVersion: "2026.6.11",
+        installRecords: {
+          codex: npmRecord("2026.6.11", {
+            resolvedName: "@openclaw/codex",
+            spec: "@openclaw/codex",
+            installPath,
+          }),
+        },
+        runtimeDependencyExpectations: [
+          {
+            pluginId: "codex",
+            dependencyName: "@openai/codex",
+            expectedVersion: "0.142.5",
+          },
+        ],
+      });
+
+      expect(result.runtimeDependencyDrifts).toEqual([
+        expect.objectContaining({
+          pluginId: "codex",
+          dependencyName: "@openai/codex",
+          expectedVersion: "0.142.5",
+        }),
+      ]);
+      expect(result.runtimeDependencyDrifts[0]).not.toHaveProperty("installedDependencyVersion");
+    });
+  });
 });
 
 describe("resolvePluginVersionDriftUpdateCommand", () => {
@@ -385,5 +527,20 @@ describe("resolvePluginVersionDriftUpdateCommand", () => {
         spec: "@openclaw/brave-plugin@2026.6.9",
       }),
     ).toBe("openclaw plugins update brave");
+  });
+});
+
+describe("resolvePluginRuntimeDependencyDriftUpdateCommand", () => {
+  it("updates the plugin id for stale embedded route runtime dependencies", () => {
+    expect(
+      resolvePluginRuntimeDependencyDriftUpdateCommand({
+        pluginId: "codex",
+        dependencyName: "@openai/codex",
+        expectedVersion: "0.142.5",
+        source: "npm",
+        installedVersion: "2026.6.11",
+        installedDependencyVersion: "0.139.0",
+      }),
+    ).toBe("openclaw plugins update codex");
   });
 });

--- a/src/plugins/plugin-version-drift.ts
+++ b/src/plugins/plugin-version-drift.ts
@@ -1,4 +1,6 @@
 // Detects plugin version drift between config, manifests, and installs.
+import { existsSync, readFileSync } from "node:fs";
+import { join } from "node:path";
 import type { OpenClawConfig } from "../config/types.js";
 import type { PluginInstallRecord } from "../config/types.plugins.js";
 import { parseClawHubPluginSpec } from "../infra/clawhub-spec.js";
@@ -18,10 +20,38 @@ export type PluginVersionDriftEntry = {
   spec?: string;
 };
 
+export type PluginRuntimeDependencyExpectation = {
+  pluginId: string;
+  dependencyName: string;
+  expectedVersion: string;
+};
+
+export type PluginRuntimeDependencyDriftEntry = {
+  pluginId: string;
+  dependencyName: string;
+  expectedVersion: string;
+  source: PluginInstallRecord["source"];
+  installedVersion?: string;
+  installedDependencyVersion?: string;
+  packageName?: string;
+  spec?: string;
+  installPath?: string;
+};
+
 export type PluginVersionDriftReport = {
   gatewayVersion: string;
   drifts: PluginVersionDriftEntry[];
+  runtimeDependencyDrifts: PluginRuntimeDependencyDriftEntry[];
 };
+
+export const DEFAULT_PLUGIN_RUNTIME_DEPENDENCY_EXPECTATIONS: readonly PluginRuntimeDependencyExpectation[] =
+  [
+    {
+      pluginId: "codex",
+      dependencyName: "@openai/codex",
+      expectedVersion: "0.142.5",
+    },
+  ];
 
 function resolveExactNpmPinPackageName(entry: PluginVersionDriftEntry): string | undefined {
   if (entry.source !== "npm" || !entry.spec) {
@@ -43,6 +73,12 @@ export function resolvePluginVersionDriftUpdateCommand(entry: PluginVersionDrift
       return `openclaw plugins update ${exactNpmTarget}`;
     }
   }
+  return `openclaw plugins update ${entry.pluginId}`;
+}
+
+export function resolvePluginRuntimeDependencyDriftUpdateCommand(
+  entry: PluginRuntimeDependencyDriftEntry,
+): string {
   return `openclaw plugins update ${entry.pluginId}`;
 }
 
@@ -85,6 +121,115 @@ function shouldCompareOfficialInstallToGateway(params: {
   return false;
 }
 
+function isTrustedSourceLinkedOfficialInstall(params: {
+  pluginId: string;
+  record: PluginInstallRecord;
+}): boolean {
+  return Boolean(
+    resolveTrustedSourceLinkedOfficialNpmSpec(params) ||
+    resolveTrustedSourceLinkedOfficialClawHubInstall(params),
+  );
+}
+
+function readPackageJsonDependencies(packageDir: string): {
+  dependencies: Record<string, string>;
+  optionalDependencies: Record<string, string>;
+} | null {
+  const packageJsonPath = join(packageDir, "package.json");
+  if (!existsSync(packageJsonPath)) {
+    return null;
+  }
+  try {
+    const parsed = JSON.parse(readFileSync(packageJsonPath, "utf8")) as {
+      dependencies?: unknown;
+      optionalDependencies?: unknown;
+    };
+    const dependencies =
+      parsed.dependencies &&
+      typeof parsed.dependencies === "object" &&
+      !Array.isArray(parsed.dependencies)
+        ? (parsed.dependencies as Record<string, string>)
+        : {};
+    const optionalDependencies =
+      parsed.optionalDependencies &&
+      typeof parsed.optionalDependencies === "object" &&
+      !Array.isArray(parsed.optionalDependencies)
+        ? (parsed.optionalDependencies as Record<string, string>)
+        : {};
+    return { dependencies, optionalDependencies };
+  } catch {
+    return null;
+  }
+}
+
+function buildRuntimeDependencyExpectationMap(
+  expectations: readonly PluginRuntimeDependencyExpectation[],
+): Map<string, PluginRuntimeDependencyExpectation[]> {
+  const byPluginId = new Map<string, PluginRuntimeDependencyExpectation[]>();
+  for (const expectation of expectations) {
+    const current = byPluginId.get(expectation.pluginId) ?? [];
+    current.push(expectation);
+    byPluginId.set(expectation.pluginId, current);
+  }
+  return byPluginId;
+}
+
+function collectRuntimeDependencyDrifts(params: {
+  installRecords: Record<string, PluginInstallRecord>;
+  config?: OpenClawConfig;
+  expectations: readonly PluginRuntimeDependencyExpectation[];
+}): PluginRuntimeDependencyDriftEntry[] {
+  const expectationsByPluginId = buildRuntimeDependencyExpectationMap(params.expectations);
+  const drifts: PluginRuntimeDependencyDriftEntry[] = [];
+
+  for (const [pluginId, record] of Object.entries(params.installRecords)) {
+    if (!record || !isPluginEnabled(params.config, pluginId)) {
+      continue;
+    }
+    const expectations = expectationsByPluginId.get(pluginId);
+    if (!expectations?.length) {
+      continue;
+    }
+    if (!isTrustedSourceLinkedOfficialInstall({ pluginId, record })) {
+      continue;
+    }
+    if (!record.installPath) {
+      continue;
+    }
+    const packageDependencies = readPackageJsonDependencies(record.installPath);
+    if (!packageDependencies) {
+      continue;
+    }
+    const installedVersion = record.resolvedVersion ?? record.version;
+    for (const expectation of expectations) {
+      const installedDependencyVersion =
+        packageDependencies.dependencies[expectation.dependencyName] ??
+        packageDependencies.optionalDependencies[expectation.dependencyName];
+      if (installedDependencyVersion === expectation.expectedVersion) {
+        continue;
+      }
+      drifts.push({
+        pluginId,
+        dependencyName: expectation.dependencyName,
+        expectedVersion: expectation.expectedVersion,
+        source: record.source,
+        ...(installedVersion ? { installedVersion } : {}),
+        ...(installedDependencyVersion ? { installedDependencyVersion } : {}),
+        ...(record.resolvedName ? { packageName: record.resolvedName } : {}),
+        ...(record.spec ? { spec: record.spec } : {}),
+        installPath: record.installPath,
+      });
+    }
+  }
+
+  drifts.sort((a, b) => {
+    const byPlugin = a.pluginId.localeCompare(b.pluginId);
+    return byPlugin === 0 ? a.dependencyName.localeCompare(b.dependencyName) : byPlugin;
+  });
+
+  return drifts;
+}
+
 /**
  * Compare active official external plugin installs against the running gateway
  * version and return any mismatches.
@@ -95,13 +240,18 @@ function shouldCompareOfficialInstallToGateway(params: {
  *   produced by `loadInstalledPluginIndexInstallRecords`).
  * @param params.config The merged daemon-side OpenClawConfig (optional).
  *   Plugins inactive under the effective activation policy are skipped.
+ * @param params.runtimeDependencyExpectations Optional package-level runtime
+ *   dependency contracts for official plugins. These catch cases where the
+ *   plugin package version matches OpenClaw, but the route binary embedded
+ *   inside that plugin is older than the release expects.
  *
- * The returned `drifts` list is sorted by `pluginId` for stable output.
+ * The returned drift lists are sorted for stable output.
  */
 export function detectPluginVersionDrift(params: {
   gatewayVersion: string;
   installRecords: Record<string, PluginInstallRecord>;
   config?: OpenClawConfig;
+  runtimeDependencyExpectations?: readonly PluginRuntimeDependencyExpectation[];
 }): PluginVersionDriftReport {
   const { gatewayVersion, installRecords, config } = params;
   const normalizedGateway = normalizeVersion(gatewayVersion);
@@ -147,5 +297,11 @@ export function detectPluginVersionDrift(params: {
   return {
     gatewayVersion,
     drifts,
+    runtimeDependencyDrifts: collectRuntimeDependencyDrifts({
+      installRecords,
+      config,
+      expectations:
+        params.runtimeDependencyExpectations ?? DEFAULT_PLUGIN_RUNTIME_DEPENDENCY_EXPECTATIONS,
+    }),
   };
 }

--- a/src/plugins/plugin-version-drift.ts
+++ b/src/plugins/plugin-version-drift.ts
@@ -32,10 +32,12 @@ export type PluginRuntimeDependencyDriftEntry = {
   expectedVersion: string;
   source: PluginInstallRecord["source"];
   installedVersion?: string;
+  declaredDependencyVersion?: string;
   installedDependencyVersion?: string;
   packageName?: string;
   spec?: string;
   installPath?: string;
+  dependencyPackageJsonPath?: string;
 };
 
 export type PluginVersionDriftReport = {
@@ -169,6 +171,28 @@ function readPackageJsonDependencies(packageDir: string): {
   }
 }
 
+function dependencyPackageJsonPath(packageDir: string, dependencyName: string): string {
+  return join(packageDir, "node_modules", ...dependencyName.split("/"), "package.json");
+}
+
+function readInstalledDependencyPackageVersion(
+  packageDir: string,
+  dependencyName: string,
+): { version: string; packageJsonPath: string } | null {
+  const packageJsonPath = dependencyPackageJsonPath(packageDir, dependencyName);
+  if (!existsSync(packageJsonPath)) {
+    return null;
+  }
+  try {
+    const parsed = JSON.parse(readFileSync(packageJsonPath, "utf8")) as {
+      version?: unknown;
+    };
+    return typeof parsed.version === "string" ? { version: parsed.version, packageJsonPath } : null;
+  } catch {
+    return null;
+  }
+}
+
 function buildRuntimeDependencyExpectationMap(
   expectations: readonly PluginRuntimeDependencyExpectation[],
 ): Map<string, PluginRuntimeDependencyExpectation[]> {
@@ -209,10 +233,14 @@ function collectRuntimeDependencyDrifts(params: {
     }
     const installedVersion = record.resolvedVersion ?? record.version;
     for (const expectation of expectations) {
-      const installedDependencyVersion =
+      const declaredDependencyVersion =
         packageDependencies.dependencies[expectation.dependencyName] ??
         packageDependencies.optionalDependencies[expectation.dependencyName];
-      if (installedDependencyVersion === expectation.expectedVersion) {
+      const installedDependency = readInstalledDependencyPackageVersion(
+        record.installPath,
+        expectation.dependencyName,
+      );
+      if (installedDependency?.version === expectation.expectedVersion) {
         continue;
       }
       drifts.push({
@@ -221,10 +249,16 @@ function collectRuntimeDependencyDrifts(params: {
         expectedVersion: expectation.expectedVersion,
         source: record.source,
         ...(installedVersion ? { installedVersion } : {}),
-        ...(installedDependencyVersion ? { installedDependencyVersion } : {}),
+        ...(declaredDependencyVersion ? { declaredDependencyVersion } : {}),
+        ...(installedDependency?.version
+          ? { installedDependencyVersion: installedDependency.version }
+          : {}),
         ...(record.resolvedName ? { packageName: record.resolvedName } : {}),
         ...(record.spec ? { spec: record.spec } : {}),
         installPath: record.installPath,
+        ...(installedDependency?.packageJsonPath
+          ? { dependencyPackageJsonPath: installedDependency.packageJsonPath }
+          : {}),
       });
     }
   }

--- a/src/plugins/plugin-version-drift.ts
+++ b/src/plugins/plugin-version-drift.ts
@@ -53,7 +53,10 @@ export const DEFAULT_PLUGIN_RUNTIME_DEPENDENCY_EXPECTATIONS: readonly PluginRunt
     },
   ];
 
-function resolveExactNpmPinPackageName(entry: PluginVersionDriftEntry): string | undefined {
+function resolveExactNpmPinPackageName(entry: {
+  source: PluginInstallRecord["source"];
+  spec?: string;
+}): string | undefined {
   if (entry.source !== "npm" || !entry.spec) {
     return undefined;
   }
@@ -79,6 +82,10 @@ export function resolvePluginVersionDriftUpdateCommand(entry: PluginVersionDrift
 export function resolvePluginRuntimeDependencyDriftUpdateCommand(
   entry: PluginRuntimeDependencyDriftEntry,
 ): string {
+  const exactNpmPackageName = resolveExactNpmPinPackageName(entry);
+  if (exactNpmPackageName) {
+    return `openclaw plugins update ${exactNpmPackageName}`;
+  }
   return `openclaw plugins update ${entry.pluginId}`;
 }
 

--- a/test/plugin-npm-release.test.ts
+++ b/test/plugin-npm-release.test.ts
@@ -124,6 +124,81 @@ function writePluginReadme(repoDir: string, extensionId: string): void {
   writeFileSync(join(packageDir, "README.md"), `# ${extensionId}\n`);
 }
 
+function codexPackageJson(codexVersion = "0.142.5") {
+  return {
+    name: "@openclaw/codex",
+    version: "2026.6.11",
+    type: "module",
+    repository: {
+      type: "git",
+      url: OPENCLAW_PLUGIN_NPM_REPOSITORY_URL,
+    },
+    dependencies: {
+      "@openai/codex": codexVersion,
+    },
+    openclaw: {
+      extensions: ["./index.ts"],
+      install: {
+        npmSpec: "@openclaw/codex",
+        requiredPlatformPackages: [
+          "@openai/codex-linux-x64",
+          "@openai/codex-linux-arm64",
+          "@openai/codex-darwin-x64",
+          "@openai/codex-darwin-arm64",
+          "@openai/codex-win32-x64",
+          "@openai/codex-win32-arm64",
+        ],
+      },
+      ...externalPluginContract("2026.6.11"),
+      release: {
+        publishToNpm: true,
+      },
+    },
+  };
+}
+
+function writeCodexShrinkwrap(packageDir: string, codexVersion = "0.142.5"): void {
+  const platformPackages = [
+    "@openai/codex-linux-x64",
+    "@openai/codex-linux-arm64",
+    "@openai/codex-darwin-x64",
+    "@openai/codex-darwin-arm64",
+    "@openai/codex-win32-x64",
+    "@openai/codex-win32-arm64",
+  ];
+  const packages: Record<string, unknown> = {
+    "": {
+      name: "@openclaw/codex",
+      version: "2026.6.11",
+      dependencies: {
+        "@openai/codex": codexVersion,
+      },
+    },
+    "node_modules/@openai/codex": {
+      version: codexVersion,
+      optionalDependencies: Object.fromEntries(
+        platformPackages.map((name) => {
+          const suffix = name.slice("@openai/codex-".length);
+          return [name, `npm:@openai/codex@${codexVersion}-${suffix}`];
+        }),
+      ),
+    },
+  };
+  for (const name of platformPackages) {
+    const suffix = name.slice("@openai/codex-".length);
+    packages[`node_modules/${name}`] = {
+      name: "@openai/codex",
+      version: `${codexVersion}-${suffix}`,
+    };
+  }
+  writeJsonFile(join(packageDir, "npm-shrinkwrap.json"), {
+    name: "@openclaw/codex",
+    version: "2026.6.11",
+    lockfileVersion: 3,
+    packages,
+  });
+}
+
 describe("collectPublishablePluginPackageErrors", () => {
   it("accepts a valid publishable plugin package candidate", () => {
     expect(
@@ -298,6 +373,44 @@ describe("collectPublishablePluginPackageErrors", () => {
         },
       }),
     ).toEqual(["README.md must exist and contain package documentation."]);
+  });
+
+  it("accepts the Codex route runtime package contract when package and shrinkwrap agree", () => {
+    const repoDir = makeTempRepoRoot(tempDirs, "openclaw-codex-plugin-release-");
+    const packageDir = join(repoDir, "extensions", "codex");
+    mkdirSync(packageDir, { recursive: true });
+    writeCodexShrinkwrap(packageDir, "0.142.5");
+
+    expect(
+      collectPublishablePluginPackageErrors({
+        extensionId: "codex",
+        packageDir,
+        readmeText: "# Codex\n",
+        packageJson: codexPackageJson("0.142.5"),
+      }),
+    ).toStrictEqual([]);
+  });
+
+  it("blocks Codex route runtime package drift before publishing", () => {
+    const repoDir = makeTempRepoRoot(tempDirs, "openclaw-codex-plugin-release-");
+    const packageDir = join(repoDir, "extensions", "codex");
+    mkdirSync(packageDir, { recursive: true });
+    writeCodexShrinkwrap(packageDir, "0.139.0");
+
+    expect(
+      collectPublishablePluginPackageErrors({
+        extensionId: "codex",
+        packageDir,
+        readmeText: "# Codex\n",
+        packageJson: codexPackageJson("0.142.5"),
+      }),
+    ).toEqual(
+      expect.arrayContaining([
+        '@openclaw/codex npm-shrinkwrap root dependency @openai/codex must be 0.142.5; found "0.139.0".',
+        '@openclaw/codex npm-shrinkwrap node_modules/@openai/codex.version must be 0.142.5; found "0.139.0".',
+        '@openclaw/codex npm-shrinkwrap node_modules/@openai/codex-linux-x64.version must be 0.142.5-linux-x64; found "0.139.0-linux-x64".',
+      ]),
+    );
   });
 });
 


### PR DESCRIPTION
## What Problem This Solves

OpenClaw can look current while `/codex` routes still spawn the stale `@openai/codex` bundled inside the active `@openclaw/codex` plugin. Fleet evidence in #99951 shows one customer VM and one reference VM running `@openclaw/codex@2026.6.11` with nested `@openai/codex@0.139.0`, even though the host/global `codex` CLI is newer and `openclaw plugins update codex --dry-run` reports the plugin current.

This is a stable-channel false green, not a beta-only problem. Read-only npm checks on 2026-07-04 showed:

```text
@openclaw/codex@2026.6.5          -> @openai/codex 0.135.0
@openclaw/codex@2026.6.6          -> @openai/codex 0.139.0
@openclaw/codex@2026.6.8          -> @openai/codex 0.139.0
@openclaw/codex@2026.6.9          -> @openai/codex 0.139.0
@openclaw/codex@2026.6.10         -> @openai/codex 0.139.0
@openclaw/codex@2026.6.11-beta.2  -> @openai/codex 0.139.0
@openclaw/codex@2026.6.11         -> @openai/codex 0.139.0
@openclaw/codex@2026.7.1-beta.1   -> @openai/codex 0.142.4
@openai/codex@latest              -> 0.142.5
```

So normal stable/customer updates can keep the primary Codex provider route on the old app-server runtime even while beta has moved forward.

## Why This Change Was Made

`codex --version` on the host is not route health proof. Upstream Codex launches its platform binary from the installed `@openai/codex` package tree, so OpenClaw’s `/codex` route truth must come from the active plugin package root and its vendored runtime dependency.

The missed Codex release surface between `0.139.0` and `0.142.5` includes changes that overlap with OpenClaw's embedded app-server route path:

- `0.142.5`: trace/logging safety fix preventing full Responses WebSocket request payloads from being written to trace logs.
- `0.142.2`: MCP tool-search behavior, remote plugin catalog fixes, remote stdio cwd handling, remote image validation, PowerShell safety approval handling, and patched bundled dependencies.
- `0.141.x` / `0.140.x`: app-server/session/state/auth/reliability changes, exec-server and shell behavior fixes, plugin/MCP reliability improvements, and thread/session durability fixes.

This PR does not claim every Codex route symptom is caused by the stale binary. It closes the release-gate gap that allowed OpenClaw to report current while running a stale primary-provider route runtime.

This PR:

- bumps the Codex provider runtime dependency to `@openai/codex@0.142.5`;
- reports plugin version, declared runtime dependency, installed runtime dependency, and plugin root in status/doctor drift surfaces;
- warns/fails when active `@openclaw/codex` embeds a stale or missing `@openai/codex` route runtime;
- makes exact-pinned stale route-runtime remediation suggest `openclaw plugins update @openclaw/codex` instead of an id-only update that can preserve the stale pin;
- adds plugin publish/pretag guards so packed `@openclaw/codex` shrinkwrap/platform aliases must match the approved route runtime dependency.

## User Impact

Operators get a visible release-blocking warning when OpenClaw’s Codex provider route would run an older embedded Codex binary than the approved release expects. This does not claim customer fleets are remediated; it proves detection/blocking and requires a later approved rollout to fix customer VMs.

## Evidence

Issue/evidence:

- Release blocker issue: #99951
- OpenAI Codex changelog: https://developers.openai.com/codex/changelog
- `@openai/codex` npm: https://www.npmjs.com/package/%40openai/codex
- `@openclaw/codex` npm: https://www.npmjs.com/package/%40openclaw/codex
- Evidence packet: `internal redacted evidence packet (private; available to maintainers on request)`
- Dependency report: `/Volumes/LEXAR/Codex/codex-openclaw-route-version-checks/pr-99956/dependency-changes.md`
- Redacted stale-route status proof: `/Volumes/LEXAR/Codex/codex-openclaw-route-version-checks/pr-99956/status-deep-stale-route-runtime-proof.txt`

Real npm-installed stale route package proof (registry install, lifecycle scripts disabled):

```json
{
  "source": "npm install --ignore-scripts --omit=dev @openclaw/codex@2026.6.11",
  "plugin": {
    "name": "@openclaw/codex",
    "version": "2026.6.11",
    "declaredOpenAiCodex": "0.139.0"
  },
  "nestedRuntime": {
    "name": "@openai/codex",
    "version": "0.139.0",
    "bin": {
      "codex": "bin/codex.js"
    }
  }
}
```

Redacted `openclaw status --deep` renderer proof against that npm-installed `@openclaw/codex@2026.6.11` package root:

```text
Service: openclaw-gateway (loaded)

Gateway version: 2026.6.11

Connectivity probe: ok

Plugin version drift: 1 route runtime dependency not on the approved release version
- codex in 2026.6.11: @openai/codex 0.139.0 (npm) → expected 0.142.5
  Plugin root: <lexar-evidence-root>/real-npm-stale-install/node_modules/@openclaw/codex
  Runtime package: <lexar-evidence-root>/real-npm-stale-install/node_modules/@openclaw/codex/node_modules/@openai/codex/package.json
Fix: openclaw plugins update @openclaw/codex && openclaw gateway restart.

Troubles: run openclaw status
Troubleshooting: https://docs.openclaw.ai/troubleshooting
```

Focused local validation:

- `pnpm install --lockfile-only --ignore-scripts`
- `pnpm exec node scripts/generate-npm-shrinkwrap.mjs --package-dir extensions/codex`
- `node scripts/generate-npm-shrinkwrap.mjs --package-dir extensions/codex --check`
- `pnpm exec oxfmt --check --threads=1 ...`
- `node scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.scripts.json scripts/lib/plugin-npm-release.ts`
- `node scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.core.json src/plugins/plugin-version-drift.ts src/plugins/plugin-version-drift.test.ts src/cli/daemon-cli/status.print.ts src/commands/doctor-workspace-status.ts`
- `node scripts/run-vitest.mjs src/plugins/plugin-version-drift.test.ts src/cli/daemon-cli/status.print.test.ts src/commands/doctor-workspace-status.test.ts extensions/codex/src/manifest.test.ts test/plugin-npm-release.test.ts`
- `pnpm tsgo:test:src`
- `git diff --check`

Dependency-guard boundary:

- This PR intentionally changes `extensions/codex/package.json`, `extensions/codex/npm-shrinkwrap.json`, and `pnpm-lock.yaml` for the `@openai/codex` family from `0.142.4` to `0.142.5`.
- Dependency guard is expected to remain blocked until a repository admin or `@openclaw/openclaw-secops` approves the current head with `/allow-dependencies-change`, or maintainers move the dependency bump to a maintainer-owned branch.

