### PR TITLE
fix(cron): roll back live scheduler state when persisting add/update/remove fails

### DIFF
--- a/src/cron/service/jobs.ts
+++ b/src/cron/service/jobs.ts
@@ -492,6 +492,7 @@ export function recordScheduleComputeError(params: {
   state: CronServiceState;
   job: CronJob;
   err: unknown;
+  deferredAutoDisableNotifications?: Array<() => void>;
 }): boolean {
   const { state, job, err } = params;
   const errorCount = (job.state.scheduleErrorCount ?? 0) + 1;
@@ -508,20 +509,27 @@ export function recordScheduleComputeError(params: {
       "cron: auto-disabled job after repeated schedule errors",
     );
 
-    // Notify the user so the auto-disable is not silent (#28861).
     const notifyText = `⚠️ Cron job "${job.name}" has been auto-disabled after ${errorCount} consecutive schedule errors. Last error: ${errText}`;
-    state.deps.enqueueSystemEvent(notifyText, {
-      agentId: job.agentId,
-      sessionKey: job.sessionKey,
-      contextKey: `cron:${job.id}:auto-disabled`,
-    });
-    state.deps.requestHeartbeat({
-      source: "cron",
-      intent: "event",
-      reason: `cron:${job.id}:auto-disabled`,
-      agentId: job.agentId,
-      sessionKey: job.sessionKey,
-    });
+    const notify = () => {
+      state.deps.enqueueSystemEvent(notifyText, {
+        agentId: job.agentId,
+        sessionKey: job.sessionKey,
+        contextKey: `cron:${job.id}:auto-disabled`,
+      });
+      state.deps.requestHeartbeat({
+        source: "cron",
+        intent: "event",
+        reason: `cron:${job.id}:auto-disabled`,
+        agentId: job.agentId,
+        sessionKey: job.sessionKey,
+      });
+    };
+    if (params.deferredAutoDisableNotifications) {
+      params.deferredAutoDisableNotifications.push(notify);
+    } else {
+      // Notify the user so the auto-disable is not silent (#28861).
+      notify();
+    }
   } else {
     state.deps.log.warn(
       { jobId: job.id, name: job.name, errorCount, err: errText },
@@ -617,7 +625,12 @@ function walkSchedulableJobs(
   return changed;
 }
 
-function recomputeJobNextRunAtMs(params: { state: CronServiceState; job: CronJob; nowMs: number }) {
+function recomputeJobNextRunAtMs(params: {
+  state: CronServiceState;
+  job: CronJob;
+  nowMs: number;
+  deferredAutoDisableNotifications?: Array<() => void>;
+}) {
   let changed = false;
   try {
     let newNext = computeJobNextRunAtMs(params.job, params.nowMs);
@@ -644,7 +657,14 @@ function recomputeJobNextRunAtMs(params: { state: CronServiceState; job: CronJob
       changed = true;
     }
   } catch (err) {
-    if (recordScheduleComputeError({ state: params.state, job: params.job, err })) {
+    if (
+      recordScheduleComputeError({
+        state: params.state,
+        job: params.job,
+        err,
+        deferredAutoDisableNotifications: params.deferredAutoDisableNotifications,
+      })
+    ) {
       changed = true;
     }
   }
@@ -682,10 +702,18 @@ export function recomputeNextRunsForMaintenance(
     recomputeExpired?: boolean;
     nowMs?: number;
     repairFutureCronNextRunAtMs?: boolean;
+    deferredAutoDisableNotifications?: Array<() => void>;
   },
 ): boolean {
   const recomputeExpired = opts?.recomputeExpired ?? false;
   const repairFutureCronNextRunAtMs = opts?.repairFutureCronNextRunAtMs ?? true;
+  const recomputeJob = (job: CronJob, nowMs: number) =>
+    recomputeJobNextRunAtMs({
+      state,
+      job,
+      nowMs,
+      deferredAutoDisableNotifications: opts?.deferredAutoDisableNotifications,
+    });
   const deferralIds = state.pendingCatchupDeferralJobIds;
   // Drop deferral markers for jobs that no longer exist in the store or
   // are disabled. They will not fire, so no deferral is needed.
@@ -715,7 +743,7 @@ export function recomputeNextRunsForMaintenance(
       }
 
       if (!hasScheduledNextRunAtMs(job.state.nextRunAtMs)) {
-        if (recomputeJobNextRunAtMs({ state, job, nowMs: now })) {
+        if (recomputeJob(job, now)) {
           changed = true;
         }
       } else if (
@@ -723,7 +751,7 @@ export function recomputeNextRunsForMaintenance(
         !deferralIds.has(job.id) &&
         shouldRepairFutureCronNextRunAtMs({ state, job, nowMs: now })
       ) {
-        if (recomputeJobNextRunAtMs({ state, job, nowMs: now })) {
+        if (recomputeJob(job, now)) {
           changed = true;
         }
       } else if (
@@ -745,7 +773,7 @@ export function recomputeNextRunsForMaintenance(
           now < backoffUntilMs &&
           job.state.nextRunAtMs < backoffUntilMs;
         if (alreadyExecutedSlot || isStaleBackoffSlot) {
-          if (recomputeJobNextRunAtMs({ state, job, nowMs: now })) {
+          if (recomputeJob(job, now)) {
             changed = true;
           }
         }

--- a/src/cron/service/ops.test.ts
+++ b/src/cron/service/ops.test.ts
@@ -1,16 +1,17 @@
 // Cron service ops tests cover high-level service operations and state transitions.
 import fs from "node:fs/promises";
 import path from "node:path";
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { runOpenClawStateWriteTransaction } from "../../state/openclaw-state-db.js";
 import * as detachedTaskRuntime from "../../tasks/detached-task-runtime.js";
 import { findTaskByRunId, resetTaskRegistryForTests } from "../../tasks/task-registry.js";
 import { formatTaskStatusDetail } from "../../tasks/task-status.js";
 import { withEnvAsync } from "../../test-utils/env.js";
 import { setupCronServiceSuite, writeCronStoreSnapshot } from "../service.test-harness.js";
+import * as cronStoreModule from "../store.js";
 import { loadCronJobsStoreWithConfigJobs, loadCronStore } from "../store.js";
 import type { CronJob } from "../types.js";
-import { add, run, start, stop, update } from "./ops.js";
+import { add, list, remove, run, start, stop, update } from "./ops.js";
 import { createCronServiceState } from "./state.js";
 import { runMissedJobs } from "./timer.js";
 
@@ -825,5 +826,104 @@ describe("cron service ops seam coverage", () => {
     }
 
     expect(job.state.nextRunAtMs).toBeGreaterThan(finalBaseRunAtMs);
+  });
+});
+
+describe("cron service ops persist rollback", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  function makeCreateInput(name: string) {
+    return {
+      name,
+      enabled: true,
+      schedule: { kind: "cron", expr: "0 0 * * *" },
+      sessionTarget: "isolated",
+      wakeMode: "next-heartbeat",
+      payload: { kind: "agentTurn", message: "do work" },
+    } as const;
+  }
+
+  it("rolls back an added job from the live store when persist fails", async () => {
+    const { storePath } = await makeStorePath();
+    const now = Date.parse("2026-06-09T00:00:00.000Z");
+    const state = createOkIsolatedCronState({ storePath, now });
+
+    vi.spyOn(cronStoreModule, "saveCronJobsStore").mockRejectedValueOnce(new Error("disk full"));
+
+    await expect(add(state, makeCreateInput("daily cleanup"))).rejects.toThrow("disk full");
+
+    expect(state.timer).toBeNull();
+    expect(state.store?.jobs ?? []).toEqual([]);
+    const listed = await list(state, { includeDisabled: true });
+    if (state.timer) {
+      clearTimeout(state.timer);
+    }
+    expect(listed).toEqual([]);
+    const loaded = await loadCronStore(storePath);
+    expect(loaded.jobs).toEqual([]);
+  });
+
+  it("keeps the pre-update job in the live store when persist fails", async () => {
+    const { storePath } = await makeStorePath();
+    const now = Date.parse("2026-06-09T00:00:00.000Z");
+    const state = createOkIsolatedCronState({ storePath, now });
+
+    const job = await add(state, makeCreateInput("daily cleanup"));
+    if (state.timer) {
+      clearTimeout(state.timer);
+    }
+
+    vi.spyOn(cronStoreModule, "saveCronJobsStore").mockRejectedValueOnce(new Error("disk full"));
+
+    await expect(update(state, job.id, { name: "renamed cleanup" })).rejects.toThrow("disk full");
+
+    const inMemory = state.store?.jobs.find((entry) => entry.id === job.id);
+    expect(inMemory?.name).toBe("daily cleanup");
+    const loaded = await loadCronStore(storePath);
+    const stored = loaded.jobs.find((entry) => entry.id === job.id);
+    expect(stored?.name).toBe("daily cleanup");
+  });
+
+  it("keeps a removed job in the live store when persist fails", async () => {
+    const { storePath } = await makeStorePath();
+    const now = Date.parse("2026-06-09T00:00:00.000Z");
+    const state = createOkIsolatedCronState({ storePath, now });
+
+    const job = await add(state, makeCreateInput("daily cleanup"));
+    if (state.timer) {
+      clearTimeout(state.timer);
+    }
+
+    vi.spyOn(cronStoreModule, "saveCronJobsStore").mockRejectedValueOnce(new Error("disk full"));
+
+    await expect(remove(state, job.id)).rejects.toThrow("disk full");
+
+    expect(state.store?.jobs.map((entry) => entry.id)).toEqual([job.id]);
+    const loaded = await loadCronStore(storePath);
+    expect(loaded.jobs.map((entry) => entry.id)).toEqual([job.id]);
+  });
+
+  it("recovers after a failed persist so the next mutation succeeds", async () => {
+    const { storePath } = await makeStorePath();
+    const now = Date.parse("2026-06-09T00:00:00.000Z");
+    const state = createOkIsolatedCronState({ storePath, now });
+
+    vi.spyOn(cronStoreModule, "saveCronJobsStore").mockRejectedValueOnce(new Error("disk full"));
+    await expect(add(state, makeCreateInput("daily cleanup"))).rejects.toThrow("disk full");
+
+    const job = await add(state, makeCreateInput("daily cleanup"));
+    if (state.timer) {
+      clearTimeout(state.timer);
+    }
+
+    const listed = await list(state, { includeDisabled: true });
+    if (state.timer) {
+      clearTimeout(state.timer);
+    }
+    expect(listed.map((entry) => entry.id)).toEqual([job.id]);
+    const loaded = await loadCronStore(storePath);
+    expect(loaded.jobs.map((entry) => entry.id)).toEqual([job.id]);
   });
 });

--- a/src/cron/service/ops.test.ts
+++ b/src/cron/service/ops.test.ts
@@ -7,6 +7,7 @@ import * as detachedTaskRuntime from "../../tasks/detached-task-runtime.js";
 import { findTaskByRunId, resetTaskRegistryForTests } from "../../tasks/task-registry.js";
 import { formatTaskStatusDetail } from "../../tasks/task-status.js";
 import { withEnvAsync } from "../../test-utils/env.js";
+import * as cronSchedule from "../schedule.js";
 import { setupCronServiceSuite, writeCronStoreSnapshot } from "../service.test-harness.js";
 import * as cronStoreModule from "../store.js";
 import { loadCronJobsStoreWithConfigJobs, loadCronStore } from "../store.js";
@@ -944,5 +945,48 @@ describe("cron service ops persist rollback", () => {
     expect(listed.map((entry) => entry.id)).toEqual([job.id]);
     const loaded = await loadCronStore(storePath);
     expect(loaded.jobs.map((entry) => entry.id)).toEqual([job.id]);
+  });
+
+  it("notifies about schedule auto-disable only after the mutation persists", async () => {
+    const { storePath } = await makeStorePath();
+    const now = Date.parse("2026-06-09T00:00:00.000Z");
+    const state = createOkIsolatedCronState({ storePath, now });
+
+    const malformed = await add(state, {
+      ...makeCreateInput("malformed sibling"),
+      schedule: { kind: "cron", expr: "0 1 * * *" },
+    });
+    if (state.timer) {
+      clearTimeout(state.timer);
+    }
+    malformed.state.nextRunAtMs = undefined;
+    malformed.state.scheduleErrorCount = 2;
+    const enqueueSystemEvent = vi.mocked(state.deps.enqueueSystemEvent);
+    const requestHeartbeat = vi.mocked(state.deps.requestHeartbeat);
+    enqueueSystemEvent.mockClear();
+    requestHeartbeat.mockClear();
+    const computeNextRunAtMs = cronSchedule.computeNextRunAtMs;
+    vi.spyOn(cronSchedule, "computeNextRunAtMs").mockImplementation((schedule, nowMs) => {
+      if (schedule.kind === "cron" && schedule.expr === "0 1 * * *") {
+        throw new Error("simulated schedule failure");
+      }
+      return computeNextRunAtMs(schedule, nowMs);
+    });
+
+    vi.spyOn(cronStoreModule, "saveCronJobsStore").mockRejectedValueOnce(new Error("disk full"));
+    await expect(add(state, makeCreateInput("failed mutation"))).rejects.toThrow("disk full");
+
+    expect(state.store?.jobs.find((job) => job.id === malformed.id)?.enabled).toBe(true);
+    expect(enqueueSystemEvent).not.toHaveBeenCalled();
+    expect(requestHeartbeat).not.toHaveBeenCalled();
+
+    await add(state, makeCreateInput("successful mutation"));
+    if (state.timer) {
+      clearTimeout(state.timer);
+    }
+
+    expect(state.store?.jobs.find((job) => job.id === malformed.id)?.enabled).toBe(false);
+    expect(enqueueSystemEvent).toHaveBeenCalledTimes(1);
+    expect(requestHeartbeat).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/cron/service/ops.test.ts
+++ b/src/cron/service/ops.test.ts
@@ -905,6 +905,25 @@ describe("cron service ops persist rollback", () => {
     expect(loaded.jobs.map((entry) => entry.id)).toEqual([job.id]);
   });
 
+  it("keeps a job's catch-up deferral marker when a remove persist fails", async () => {
+    const { storePath } = await makeStorePath();
+    const now = Date.parse("2026-06-09T00:00:00.000Z");
+    const state = createOkIsolatedCronState({ storePath, now });
+
+    const job = await add(state, makeCreateInput("daily cleanup"));
+    if (state.timer) {
+      clearTimeout(state.timer);
+    }
+    state.pendingCatchupDeferralJobIds.add(job.id);
+
+    vi.spyOn(cronStoreModule, "saveCronJobsStore").mockRejectedValueOnce(new Error("disk full"));
+
+    await expect(remove(state, job.id)).rejects.toThrow("disk full");
+
+    expect(state.pendingCatchupDeferralJobIds.has(job.id)).toBe(true);
+    expect(state.store?.jobs.map((entry) => entry.id)).toEqual([job.id]);
+  });
+
   it("recovers after a failed persist so the next mutation succeeds", async () => {
     const { storePath } = await makeStorePath();
     const now = Date.parse("2026-06-09T00:00:00.000Z");

--- a/src/cron/service/ops.ts
+++ b/src/cron/service/ops.ts
@@ -484,13 +484,20 @@ type CronRollbackSnapshot = {
 // jobs, so restoring only the touched job would leave siblings and deferrals
 // ahead of disk; without the rollback a failed add/update/remove keeps
 // running, reverting, or resurrecting jobs the caller was told did not apply.
-async function persistOrRestore(state: CronServiceState, snapshot: CronRollbackSnapshot) {
+async function persistOrRestore(
+  state: CronServiceState,
+  snapshot: CronRollbackSnapshot,
+  postPersistAutoDisableNotifications: Array<() => void> = [],
+) {
   try {
     await persist(state);
   } catch (err) {
     state.store = snapshot.store;
     state.pendingCatchupDeferralJobIds = snapshot.pendingCatchupDeferralJobIds;
     throw err;
+  }
+  for (const notify of postPersistAutoDisableNotifications) {
+    notify();
   }
 }
 
@@ -510,9 +517,14 @@ export async function add(state: CronServiceState, input: CronJobCreate) {
     const job = createJob(state, input);
     state.store?.jobs.push(job);
 
-    recomputeNextRunsForMaintenance(state);
+    // Auto-disable notifications describe durable state, so publish them only
+    // after the write succeeds instead of leaking a rolled-back transition.
+    const postPersistAutoDisableNotifications: Array<() => void> = [];
+    recomputeNextRunsForMaintenance(state, {
+      deferredAutoDisableNotifications: postPersistAutoDisableNotifications,
+    });
 
-    await persistOrRestore(state, snapshot);
+    await persistOrRestore(state, snapshot, postPersistAutoDisableNotifications);
     armTimer(state);
 
     state.deps.log.info(
@@ -637,9 +649,12 @@ export async function remove(state: CronServiceState, id: string) {
     state.store.jobs = state.store.jobs.filter((j) => j.id !== id);
     const removed = (state.store.jobs.length ?? 0) !== before;
 
-    recomputeNextRunsForMaintenance(state);
+    const postPersistAutoDisableNotifications: Array<() => void> = [];
+    recomputeNextRunsForMaintenance(state, {
+      deferredAutoDisableNotifications: postPersistAutoDisableNotifications,
+    });
 
-    await persistOrRestore(state, snapshot);
+    await persistOrRestore(state, snapshot, postPersistAutoDisableNotifications);
     armTimer(state);
     if (removed) {
       emit(state, { jobId: id, action: "removed", job: removedJob });

--- a/src/cron/service/ops.ts
+++ b/src/cron/service/ops.ts
@@ -19,7 +19,7 @@ import { resolveCronDeliveryPlan, resolveFailureDestination } from "../delivery-
 import { createCronRunDiagnosticsFromError } from "../run-diagnostics.js";
 import { createCronExecutionId } from "../run-id.js";
 import { cronSchedulingInputsEqual } from "../schedule-identity.js";
-import type { CronJob, CronJobCreate, CronJobPatch, CronPayload } from "../types.js";
+import type { CronJob, CronJobCreate, CronJobPatch, CronPayload, CronStoreFile } from "../types.js";
 import { normalizeCronRunErrorText } from "./execution-errors.js";
 import { failureNotificationDeliveryFromJobState } from "./failure-alerts.js";
 import {
@@ -473,17 +473,36 @@ export async function listPage(state: CronServiceState, opts?: CronListPageOptio
   });
 }
 
+// Rolls the live store back to its pre-mutation snapshot when the durable
+// write fails. recomputeNextRunsForMaintenance mutates schedule state across
+// all jobs, so restoring only the touched job would leave siblings ahead of
+// disk; without the rollback a failed add/update/remove keeps running,
+// reverting, or resurrecting jobs the caller was told did not apply.
+async function persistOrRestore(state: CronServiceState, snapshot: CronStoreFile | null) {
+  try {
+    await persist(state);
+  } catch (err) {
+    state.store = snapshot;
+    throw err;
+  }
+}
+
+function snapshotStoreForRollback(state: CronServiceState): CronStoreFile | null {
+  return state.store ? structuredClone(state.store) : null;
+}
+
 /** Adds a cron job, recomputes scheduler state, persists, and re-arms the timer. */
 export async function add(state: CronServiceState, input: CronJobCreate) {
   return await locked(state, async () => {
     warnIfDisabled(state, "add");
     await ensureLoaded(state, { skipRecompute: true });
+    const snapshot = snapshotStoreForRollback(state);
     const job = createJob(state, input);
     state.store?.jobs.push(job);
 
     recomputeNextRunsForMaintenance(state);
 
-    await persist(state);
+    await persistOrRestore(state, snapshot);
     armTimer(state);
 
     state.deps.log.info(
@@ -513,6 +532,7 @@ export async function update(state: CronServiceState, id: string, patch: CronJob
   return await locked(state, async () => {
     warnIfDisabled(state, "update");
     await ensureLoaded(state, { skipRecompute: true });
+    const snapshot = snapshotStoreForRollback(state);
     const job = findJobOrThrow(state, id);
     const now = state.deps.nowMs();
     const nextJob = structuredClone(job);
@@ -581,7 +601,7 @@ export async function update(state: CronServiceState, id: string, patch: CronJob
       }
     }
 
-    await persist(state);
+    await persistOrRestore(state, snapshot);
     armTimer(state);
     emit(state, {
       jobId: id,
@@ -602,13 +622,14 @@ export async function remove(state: CronServiceState, id: string) {
     if (!state.store) {
       return { ok: false, removed: false } as const;
     }
+    const snapshot = snapshotStoreForRollback(state);
     const removedJob = state.store.jobs.find((j) => j.id === id);
     state.store.jobs = state.store.jobs.filter((j) => j.id !== id);
     const removed = (state.store.jobs.length ?? 0) !== before;
 
     recomputeNextRunsForMaintenance(state);
 
-    await persist(state);
+    await persistOrRestore(state, snapshot);
     armTimer(state);
     if (removed) {
       emit(state, { jobId: id, action: "removed", job: removedJob });

--- a/src/cron/service/ops.ts
+++ b/src/cron/service/ops.ts
@@ -473,22 +473,32 @@ export async function listPage(state: CronServiceState, opts?: CronListPageOptio
   });
 }
 
-// Rolls the live store back to its pre-mutation snapshot when the durable
-// write fails. recomputeNextRunsForMaintenance mutates schedule state across
-// all jobs, so restoring only the touched job would leave siblings ahead of
-// disk; without the rollback a failed add/update/remove keeps running,
-// reverting, or resurrecting jobs the caller was told did not apply.
-async function persistOrRestore(state: CronServiceState, snapshot: CronStoreFile | null) {
+type CronRollbackSnapshot = {
+  store: CronStoreFile | null;
+  pendingCatchupDeferralJobIds: Set<string>;
+};
+
+// Rolls the live scheduler state back to its pre-mutation snapshot when the
+// durable write fails. recomputeNextRunsForMaintenance mutates schedule state
+// across all jobs and drops catch-up deferral markers for removed/disabled
+// jobs, so restoring only the touched job would leave siblings and deferrals
+// ahead of disk; without the rollback a failed add/update/remove keeps
+// running, reverting, or resurrecting jobs the caller was told did not apply.
+async function persistOrRestore(state: CronServiceState, snapshot: CronRollbackSnapshot) {
   try {
     await persist(state);
   } catch (err) {
-    state.store = snapshot;
+    state.store = snapshot.store;
+    state.pendingCatchupDeferralJobIds = snapshot.pendingCatchupDeferralJobIds;
     throw err;
   }
 }
 
-function snapshotStoreForRollback(state: CronServiceState): CronStoreFile | null {
-  return state.store ? structuredClone(state.store) : null;
+function snapshotStoreForRollback(state: CronServiceState): CronRollbackSnapshot {
+  return {
+    store: state.store ? structuredClone(state.store) : null,
+    pendingCatchupDeferralJobIds: new Set(state.pendingCatchupDeferralJobIds),
+  };
 }
 
 /** Adds a cron job, recomputes scheduler state, persists, and re-arms the timer. */


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where a cron job mutation that fails to persist still changes the live scheduler, so what the user was told no longer matches what the gateway does or what survives a restart.

`cron add`, `cron update`, and `cron remove` mutate the in-memory cron store first and persist to SQLite afterwards. When the persist fails (e.g. disk full or a failed write transaction), the caller correctly receives an error — but the in-memory mutation stays behind in the running gateway:

- **add**: a job the user was told failed to save stays live, can be armed and executed, and is even written to disk by the next unrelated successful persist. If the gateway restarts first, it silently vanishes instead.
- **update**: the live scheduler runs the new version the user was told did not apply, and a restart silently reverts it to the old version.
- **remove**: the job disappears from the live scheduler but resurrects from SQLite on the next restart.

Both user surfaces converge on the same code path — the CLI issues the `cron.add`/`cron.update`/`cron.remove` gateway RPCs (`src/cli/cron-cli.ts`), whose handlers call `CronService.add/update/remove` (`src/cron/service.ts`), which delegate to the ops in this diff. The in-memory store is trusted indefinitely once loaded (`ensureLoaded` fast path), so none of this self-heals while the process lives.

## Why This Change Was Made

The narrowest fix that restores the invariant "if the caller was told the mutation failed, the runtime behaves as if it never happened": snapshot the mutable state before the mutation and restore it when the persist throws, then rethrow the original error unchanged.

The snapshot covers the whole store plus the catch-up deferral marker set, not just the touched job, because `recomputeNextRunsForMaintenance` runs inside these operations and mutates `nextRunAtMs`/deferral state across *all* jobs — restoring only the touched job would leave sibling scheduler state ahead of disk. This matches the persist-before-mutate durability convention already documented in the task registry (`src/tasks/task-registry.ts`), which the cron service predates.

Non-goal: `persist()` has a sibling seam where a failed quarantine flush silently skips the save (`src/cron/service/store.ts`); fixing it changes error propagation for read-path callers that intentionally degrade and continue, so it is left to a separately scoped follow-up. Run-state bookkeeping persists (`prepareManualRun`, `finishPreparedManualRun`) are also untouched — the run already happened, so rollback semantics differ.

## User Impact

Operators get truthful outcomes from cron CRUD under storage failure: a failed `cron add`/`update`/`remove` now restores the cron store and catch-up deferral markers touched by these operations, matching both the error the user saw and the state the next restart loads. No phantom runs of jobs that "failed to save", no silent reverts of edits, no deleted jobs resurrecting after a restart. Error reporting and the success paths are unchanged.

## Evidence

### Real behavior proof (before/after, real `CronService` + real shared SQLite state DB)

A three-phase driver script runs the real `CronService` facade against the real shared SQLite state DB (`OPENCLAW_STATE_DIR` pointed at a scratch dir; separate OS processes per phase; no JS mocks or module patching). The durable-write failure is a genuine `SQLITE_READONLY` error raised inside `saveCronJobsStore`'s real write transaction, by switching the live production connection to read-only state (`PRAGMA query_only=1` on the same cached handle the cron service persists through) between a successful seed and the mutations.

**Before (PR base, upstream/main):** every failed mutation leaves the live scheduler lying, and a restart flips all three back:

```
seed: added job "daily-report"
  live store after seed: 1 job(s): daily-report

SQLite state DB is now read-only (PRAGMA query_only=1 on the live connection)

--- cron add (durable write fails) ---
  add FAILED (real SQLite error): attempt to write a readonly database
  live store after failed add: 2 job(s): daily-report, phantom-job      <- phantom job live
--- cron update: rename daily-report -> renamed-report (durable write fails) ---
  update FAILED (real SQLite error): attempt to write a readonly database
  live store after failed update: 2 job(s): renamed-report, phantom-job <- rejected rename live
--- cron remove daily-report (durable write fails) ---
  remove FAILED (real SQLite error): attempt to write a readonly database
  live store after failed remove: 1 job(s): phantom-job                 <- real job gone from live

fresh process (simulated gateway restart), SQLite writable again:
  store loaded from SQLite: 1 job(s): daily-report                      <- restart contradicts everything above
```

**After (this PR, same script, same failure):** the live store stays consistent with the reported errors, and restart agrees:

```
SQLite state DB is now read-only (PRAGMA query_only=1 on the live connection)

--- cron add (durable write fails) ---
  add FAILED (real SQLite error): attempt to write a readonly database
  live store after failed add: 1 job(s): daily-report
--- cron update: rename daily-report -> renamed-report (durable write fails) ---
  update FAILED (real SQLite error): attempt to write a readonly database
  live store after failed update: 1 job(s): daily-report
--- cron remove daily-report (durable write fails) ---
  remove FAILED (real SQLite error): attempt to write a readonly database
  live store after failed remove: 1 job(s): daily-report

fresh process (simulated gateway restart), SQLite writable again:
  store loaded from SQLite: 1 job(s): daily-report
```

Transcripts are from a Linux host, redacted only by using scratch paths. The driver script:

<details>
<summary>cron-proof.mts (run from a checkout root: <code>OPENCLAW_STATE_DIR=&lt;scratch&gt; node --import tsx cron-proof.mts seed|mutate|inspect</code>)</summary>

```ts
import fs from "node:fs";
import path from "node:path";
import { CronService } from "./src/cron/service.js";
import { openOpenClawStateDatabase } from "./src/state/openclaw-state-db.js";

const stateDir = process.env.OPENCLAW_STATE_DIR!;
const phase = process.argv[2];
const storePath = path.join(stateDir, "cron", "jobs.json");

const log = {
  debug: () => {},
  info: () => {},
  warn: (_o: unknown, m?: string) => console.log(`  [warn] ${m ?? ""}`),
  error: (_o: unknown, m?: string) => console.log(`  [error] ${m ?? ""}`),
};

function makeService() {
  return new CronService({
    log,
    storePath,
    cronEnabled: false, // scheduler timers off; CRUD + persistence paths only
    enqueueSystemEvent: () => {},
    requestHeartbeat: () => {},
    runIsolatedAgentJob: async () => ({ status: "ok" as const }),
  });
}

function jobInput(name: string) {
  return {
    name,
    enabled: true,
    schedule: { kind: "cron", expr: "0 0 * * *" } as const,
    sessionTarget: "isolated" as const,
    wakeMode: "next-heartbeat" as const,
    payload: { kind: "agentTurn", message: `run ${name}` } as const,
  };
}

async function show(svc: CronService, label: string) {
  const jobs = await svc.list({ includeDisabled: true });
  console.log(`  ${label}: ${jobs.length} job(s): ${jobs.map((j) => `${j.name}`).join(", ") || "(none)"}`);
  return jobs;
}

const svc = makeService();

if (phase === "seed") {
  const job = await svc.add(jobInput("daily-report"));
  console.log(`seed: added job "daily-report" id=${job.id}`);
  await show(svc, "live store after seed");
  fs.writeFileSync(path.join(stateDir, "job-id.txt"), job.id);
} else if (phase === "mutate") {
  const jobId = fs.readFileSync(path.join(stateDir, "job-id.txt"), "utf-8").trim();
  await show(svc, "live store loaded from SQLite at process start");

  // Put the shared production SQLite connection (the same cached handle the
  // cron service persists through) into a read-only state. Every durable
  // write below fails with a genuine SQLITE_READONLY error raised inside
  // saveCronJobsStore's real write transaction — no JS mocking involved.
  const { db } = openOpenClawStateDatabase();
  db.exec("PRAGMA query_only = 1");
  console.log("\nSQLite state DB is now read-only (PRAGMA query_only=1 on the live connection)");

  console.log("\n--- cron add (durable write fails) ---");
  try {
    await svc.add(jobInput("phantom-job"));
    console.log("  add unexpectedly succeeded");
  } catch (err) {
    console.log(`  add FAILED (real SQLite error): ${(err as Error).message}`);
  }
  await show(svc, "live store after failed add");

  console.log("\n--- cron update: rename daily-report -> renamed-report (durable write fails) ---");
  try {
    await svc.update(jobId, { name: "renamed-report" });
    console.log("  update unexpectedly succeeded");
  } catch (err) {
    console.log(`  update FAILED (real SQLite error): ${(err as Error).message}`);
  }
  await show(svc, "live store after failed update");

  console.log("\n--- cron remove daily-report (durable write fails) ---");
  try {
    await svc.remove(jobId);
    console.log("  remove unexpectedly succeeded");
  } catch (err) {
    console.log(`  remove FAILED (real SQLite error): ${(err as Error).message}`);
  }
  await show(svc, "live store after failed remove");

  db.exec("PRAGMA query_only = 0");
} else if (phase === "inspect") {
  console.log("fresh process (simulated gateway restart), SQLite writable again:");
  await show(svc, "store loaded from SQLite");
} else {
  throw new Error(`unknown phase: ${phase}`);
}
```

</details>

### Failing-first tests

`src/cron/service/ops.test.ts` (`cron service ops persist rollback` describe, persist failure injected via `saveCronJobsStore` rejection): before the fix all five fail with the exact lying behaviors above — notably the recovery case shows the phantom job from a *failed* add being written to disk by the next successful persist:

```
FAIL > recovers after a failed persist so the next mutation succeeds
- Expected  + Received
  [
+   "f97b06c3-...",   <- job whose add reported "disk full" to the caller
    "9868ddb1-...",
  ]
```

After the fix:

```
✓ rolls back an added job from the live store when persist fails
✓ keeps the pre-update job in the live store when persist fails
✓ keeps a removed job in the live store when persist fails
✓ keeps a job's catch-up deferral marker when a remove persist fails
✓ recovers after a failed persist so the next mutation succeeds

Test Files  1 passed (1) — src/cron/service/ops.test.ts, 24 tests
```

Full cron suite (local, `node scripts/run-vitest.mjs src/cron/`, ~34s): 117 test files / 1237 tests pass. Production diff is confined to `src/cron/service/ops.ts` (snapshot + restore helpers, three call sites); no change to success-path behavior, event ordering, error types, or `--json` shapes.
