### PR TITLE
fix(telegram): show typing for accepted topic messages

### DIFF
--- a/extensions/telegram/src/bot-message-context.ts
+++ b/extensions/telegram/src/bot-message-context.ts
@@ -481,12 +481,12 @@ export const buildTelegramMessageContext = async ({
     return null;
   }
 
-  // Direct chats are now reply-eligible; send the first typing cue before
-  // expensive context/session construction without showing typing for dropped turns.
-  if (!isGroup) {
+  // Send the first typing cue before expensive context/session construction,
+  // but only after intake has accepted the message as a non-room-event turn.
+  if (bodyResult.inboundEventKind !== "room_event") {
     initialTypingCueSent = true;
     void sendTyping().catch((err: unknown) => {
-      logVerbose(`telegram early direct typing cue failed for chat ${chatId}: ${String(err)}`);
+      logVerbose(`telegram early typing cue failed for chat ${chatId}: ${String(err)}`);
     });
   }
 

--- a/extensions/telegram/src/bot-message-context.typing.test.ts
+++ b/extensions/telegram/src/bot-message-context.typing.test.ts
@@ -82,4 +82,87 @@ describe("buildTelegramMessageContext typing", () => {
 
     expect(sendChatActionHandler.sendChatAction).not.toHaveBeenCalled();
   });
+
+  it("sends forum topic typing after accepted user-request classification and before context construction", async () => {
+    const buildInboundContext = vi.fn(
+      (params: Parameters<typeof buildChannelInboundEventContext>[0]) =>
+        buildChannelInboundEventContext(params as never),
+    );
+    const sendChatActionHandler = createSendChatActionHandler();
+
+    const ctx = await buildTelegramMessageContextForTest({
+      message: {
+        chat: { id: -1001234567890, type: "supergroup", title: "Forum", is_forum: true },
+        from: { id: 42, first_name: "Pat" },
+        message_thread_id: 99,
+        text: "hello topic",
+      },
+      resolveGroupRequireMention: () => false,
+      resolveTelegramGroupConfig: () => ({
+        groupConfig: { requireMention: false },
+        topicConfig: undefined,
+      }),
+      sendChatActionHandler,
+      sessionRuntime: {
+        buildChannelInboundEventContext:
+          buildInboundContext as unknown as typeof buildChannelInboundEventContext,
+      },
+    });
+
+    expect(ctx?.ctxPayload.InboundEventKind).toBe("user_request");
+    expect(ctx?.initialTypingCueSent).toBe(true);
+    expect(sendChatActionHandler.sendChatAction).toHaveBeenCalledWith(-1001234567890, "typing", {
+      message_thread_id: 99,
+    });
+    expect(sendChatActionHandler.sendChatAction.mock.invocationCallOrder[0]).toBeLessThan(
+      buildInboundContext.mock.invocationCallOrder[0],
+    );
+  });
+
+  it("does not send forum topic typing for room events", async () => {
+    const sendChatActionHandler = createSendChatActionHandler();
+
+    const ctx = await buildTelegramMessageContextForTest({
+      cfg: { messages: { groupChat: { unmentionedInbound: "room_event", mentionPatterns: [] } } },
+      message: {
+        chat: { id: -1001234567890, type: "supergroup", title: "Forum", is_forum: true },
+        from: { id: 42, first_name: "Pat" },
+        message_thread_id: 99,
+        text: "ambient chatter",
+      },
+      resolveGroupRequireMention: () => false,
+      resolveTelegramGroupConfig: () => ({
+        groupConfig: { requireMention: false },
+        topicConfig: undefined,
+      }),
+      sendChatActionHandler,
+    });
+
+    expect(ctx?.ctxPayload.InboundEventKind).toBe("room_event");
+    expect(ctx?.initialTypingCueSent).toBe(false);
+    expect(sendChatActionHandler.sendChatAction).not.toHaveBeenCalled();
+  });
+
+  it("does not send forum topic typing for unaddressed require-mention messages", async () => {
+    const sendChatActionHandler = createSendChatActionHandler();
+
+    await expect(
+      buildTelegramMessageContextForTest({
+        message: {
+          chat: { id: -1001234567890, type: "supergroup", title: "Forum", is_forum: true },
+          from: { id: 42, first_name: "Pat" },
+          message_thread_id: 99,
+          text: "ambient chatter",
+        },
+        resolveGroupRequireMention: () => true,
+        resolveTelegramGroupConfig: () => ({
+          groupConfig: { requireMention: true },
+          topicConfig: undefined,
+        }),
+        sendChatActionHandler,
+      }),
+    ).resolves.toBeNull();
+
+    expect(sendChatActionHandler.sendChatAction).not.toHaveBeenCalled();
+  });
 });


### PR DESCRIPTION
Related: #92287

## What Problem This Solves

Accepted Telegram forum-topic messages can spend noticeable time in context and session construction before the existing typing cue runs. During that window, an addressed message looks dropped even though OpenClaw accepted it.

## Why This Change Was Made

Telegram direct chats already send the first native typing cue after access and body validation but before expensive context construction. This extends that same timing to accepted non-`room_event` group/topic turns.

The cue still runs only after authorization, mention gating, body classification, and configured-binding readiness. Ambient room events and unaddressed require-mention messages remain quiet. The later fallback in `bot-message.ts` still covers any accepted path that did not send this early cue.

This is complementary to #92287, which covers queued follow-up and dispatch typing policy.

## User Impact

Users in Telegram forum topics get prompt native typing feedback for messages OpenClaw has accepted. Dropped, ambient, and unaddressed group traffic does not produce a false acceptance signal.

## Evidence

- Prepared head: `76dfef13052c72f8672f2cf737a0f7d53a895a6e`.
- The unrelated skip-log metadata from the submitted branch was removed; Moeed Ahmed remains the commit author.
- `node scripts/run-vitest.mjs extensions/telegram/src/bot-message-context.typing.test.ts extensions/telegram/src/bot-message-context.require-mention.test.ts extensions/telegram/src/bot-message.test.ts` - 3 files, 33 tests passed after rebasing onto current `main`.
- Fresh branch AutoReview reported no findings and rated the patch correct with 0.86 confidence.
- Exact-head CI run `28761749596` completed successfully.
- Native Telegram Desktop run `28707408543` proved forum-topic typing delivery on the prior candidate. The exact-order follow-up moves that same cue before context construction and is covered by the invocation-order test.
- Exact-head proof attempt `28759453474` did not produce a behavioral verdict: its manifest skipped both baseline and candidate because the recorded previews lost the proof chat framing. No product assertion failed.
