### PR TITLE
fix(sessions): forward requester session key from subagent spawn writes (AI-assisted)

### DIFF
--- a/src/agents/subagent-spawn.active-session-preserve.test.ts
+++ b/src/agents/subagent-spawn.active-session-preserve.test.ts
@@ -1,0 +1,86 @@
+// Subagent spawn active-session-preserve tests verify that session-store writes
+// initiated during subagent spawn forward the requester (parent) session key as
+// `opts.activeSessionKey`. Session-store maintenance uses that key to protect
+// the active human conversation from eviction when the store is at capacity.
+//
+// Regression: without this, `capEntryCount` could evict the unprotected active
+// DM entry when protected external threads (Slack channels, Telegram topics,
+// etc.) already filled `session.maintenance.maxEntries`.
+import os from "node:os";
+import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  createSubagentSpawnTestConfig,
+  loadSubagentSpawnModuleForTest,
+  setupAcceptedSubagentGatewayMock,
+} from "./subagent-spawn.test-helpers.js";
+
+const callGatewayMock = vi.fn();
+const updateSessionStoreMock = vi.fn();
+const pruneLegacyStoreKeysMock = vi.fn();
+
+const REQUESTER_INTERNAL_KEY = "agent:main:main";
+
+describe("spawnSubagentDirect active session key forwarding", () => {
+  let resetSubagentRegistryForTests: typeof import("./subagent-registry.js").resetSubagentRegistryForTests;
+  let spawnSubagentDirect: typeof import("./subagent-spawn.js").spawnSubagentDirect;
+
+  beforeAll(async () => {
+    ({ resetSubagentRegistryForTests, spawnSubagentDirect } = await loadSubagentSpawnModuleForTest({
+      callGatewayMock,
+      getRuntimeConfig: () => createSubagentSpawnTestConfig(os.tmpdir()),
+      updateSessionStoreMock,
+      pruneLegacyStoreKeysMock,
+      workspaceDir: os.tmpdir(),
+    }));
+  });
+
+  beforeEach(() => {
+    resetSubagentRegistryForTests();
+    callGatewayMock.mockReset();
+    updateSessionStoreMock.mockReset();
+    pruneLegacyStoreKeysMock.mockReset();
+    setupAcceptedSubagentGatewayMock(callGatewayMock);
+  });
+
+  it("forwards the requester session key as opts.activeSessionKey on every store write", async () => {
+    // Capture the opts arg of every updateSessionStore call so we can assert
+    // maintenance sees the active (parent) session key and treats it as
+    // preserved during capEntryCount.
+    const capturedOpts: Array<{ activeSessionKey?: string } | undefined> = [];
+    updateSessionStoreMock.mockImplementation(
+      async (
+        _storePath: string,
+        mutator: (store: Record<string, Record<string, unknown>>) => unknown,
+        opts?: { activeSessionKey?: string },
+      ) => {
+        capturedOpts.push(opts);
+        const store: Record<string, Record<string, unknown>> = {};
+        await mutator(store);
+        return store;
+      },
+    );
+
+    const result = await spawnSubagentDirect(
+      {
+        task: "test-active-session-preserve",
+        // Provide an explicit resolved model to exercise the runtime-model
+        // persistence path (`persistInitialChildSessionRuntimeModel`), which
+        // is a second store write beyond the initial child-session patch.
+        model: "openai/gpt-5.4",
+      },
+      {
+        agentSessionKey: REQUESTER_INTERNAL_KEY,
+        agentChannel: "guildchat",
+      },
+    );
+
+    expect(result.status).toBe("accepted");
+    // At least the initial child-session patch and the runtime-model persist
+    // call should have run; both must forward activeSessionKey. The exact
+    // number of writes can grow with future patches, so assert on every call.
+    expect(capturedOpts.length).toBeGreaterThanOrEqual(2);
+    for (const opts of capturedOpts) {
+      expect(opts?.activeSessionKey).toBe(REQUESTER_INTERNAL_KEY);
+    }
+  });
+});

--- a/src/agents/subagent-spawn.ts
+++ b/src/agents/subagent-spawn.ts
@@ -228,8 +228,13 @@ export { splitModelRef } from "./subagent-spawn-plan.js";
 async function updateSubagentSessionStore(
   storePath: string,
   mutator: Parameters<typeof updateSessionStore>[1],
+  opts?: { activeSessionKey?: string },
 ) {
-  return await subagentSpawnDeps.updateSessionStore(storePath, mutator);
+  // Forward the requester (parent) session key so session-store maintenance
+  // treats the active human conversation as protected during subagent spawn
+  // writes. Without this, an unprotected active DM can be evicted by
+  // capEntryCount when protected external threads already fill the cap.
+  return await subagentSpawnDeps.updateSessionStore(storePath, mutator, opts);
 }
 
 async function callSubagentGateway(
@@ -366,6 +371,7 @@ function loadSubagentConfig() {
 async function persistInitialChildSessionRuntimeModel(params: {
   cfg: OpenClawConfig;
   childSessionKey: string;
+  requesterInternalKey: string;
   resolvedModel?: string;
 }): Promise<string | undefined> {
   const { provider, model } = splitModelRef(params.resolvedModel);
@@ -377,17 +383,21 @@ async function persistInitialChildSessionRuntimeModel(params: {
       cfg: params.cfg,
       key: params.childSessionKey,
     });
-    await updateSubagentSessionStore(target.storePath, (store) => {
-      pruneLegacyStoreKeys({
-        store,
-        canonicalKey: target.canonicalKey,
-        candidates: target.storeKeys,
-      });
-      store[target.canonicalKey] = mergeSessionEntry(store[target.canonicalKey], {
-        model,
-        ...(provider ? { modelProvider: provider } : {}),
-      });
-    });
+    await updateSubagentSessionStore(
+      target.storePath,
+      (store) => {
+        pruneLegacyStoreKeys({
+          store,
+          canonicalKey: target.canonicalKey,
+          candidates: target.storeKeys,
+        });
+        store[target.canonicalKey] = mergeSessionEntry(store[target.canonicalKey], {
+          model,
+          ...(provider ? { modelProvider: provider } : {}),
+        });
+      },
+      { activeSessionKey: params.requesterInternalKey },
+    );
     return undefined;
   } catch (err) {
     return err instanceof Error ? err.message : typeof err === "string" ? err : "error";
@@ -1307,17 +1317,21 @@ export async function spawnSubagentDirect(
         cfg,
         key: childSessionKey,
       });
-      await updateSubagentSessionStore(target.storePath, (store) => {
-        pruneLegacyStoreKeys({
-          store,
-          canonicalKey: target.canonicalKey,
-          candidates: target.storeKeys,
-        });
-        store[target.canonicalKey] = mergeSessionEntry(
-          store[target.canonicalKey],
-          buildDirectChildSessionPatch(patch),
-        );
-      });
+      await updateSubagentSessionStore(
+        target.storePath,
+        (store) => {
+          pruneLegacyStoreKeys({
+            store,
+            canonicalKey: target.canonicalKey,
+            candidates: target.storeKeys,
+          });
+          store[target.canonicalKey] = mergeSessionEntry(
+            store[target.canonicalKey],
+            buildDirectChildSessionPatch(patch),
+          );
+        },
+        { activeSessionKey: requesterInternalKey },
+      );
       return undefined;
     } catch (err) {
       const message = err instanceof Error ? err.message : typeof err === "string" ? err : "error";
@@ -1365,6 +1379,7 @@ export async function spawnSubagentDirect(
     const runtimeModelPersistError = await persistInitialChildSessionRuntimeModel({
       cfg,
       childSessionKey,
+      requesterInternalKey,
       resolvedModel,
     });
     if (runtimeModelPersistError) {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where an active human conversation session (e.g. a Telegram DM, iMessage, or web-chat DM without a `threadId`) can be silently truncated when a subagent is spawned while the session store is at capacity.

Concretely, when `session.maintenance.maxEntries` is reached and *protected* external channel sessions (Slack channels, Telegram topics, Discord group sessions — anything `isProtectedSessionMaintenanceEntry` treats as durable) already fill the cap, `capEntryCount` evicts remaining unprotected entries during subagent-spawn writes. The active DM the user is currently interacting with can be picked as the eviction victim, and the ongoing conversation loses its store entry mid-flow.

Repro that triggered this:

- Long-running personal OpenClaw instance accumulated ~800 session entries; 799 were `threadId`-protected Slack thread sessions, 1 was an active Telegram DM.
- Default `session.maintenance.maxEntries` is 600. Every subagent spawn from that DM took the path through `updateSubagentSessionStore(storePath, mutator)` — no `activeSessionKey` forwarded — so maintenance had no way to preserve the caller's DM.
- Result: the DM entry was evicted on the very next subagent-spawn write, taking the ongoing session with it. The workaround was manually raising `maxEntries` to a value above `preservedCount`.

## Why This Change Was Made

Other session-store writers (session-accessor, heartbeat-runner, session-registry-maintenance, plugin-host-cleanup, etc.) already forward `opts.activeSessionKey`, which flows through `saveSessionStoreUnlocked` → `applyEnforcedMaintenance` → `collectSessionMaintenancePreserveKeys([activeSessionKey])` and pins the active key into the preserve set used by `capEntryCount` and `pruneStaleEntries`.

`updateSubagentSessionStore` (`src/agents/subagent-spawn.ts`) was the only writer path that dropped this argument. Threading `requesterInternalKey` through fixes the eviction hole without introducing new config, new preserve-key surface, or new provider registrations — it re-uses the mechanism that already exists (added by #81498 for pending subagent children).

Scope boundary:

- No new config option (see AGENTS.md config-surface rule).
- No behavior change to `capEntryCount`, `isProtectedSessionMaintenanceEntry`, or the preserve-key provider registry.
- Both existing spawn-time write paths — the initial `patchChildSession` closure and `persistInitialChildSessionRuntimeModel` — now forward the requester key. Any future `updateSubagentSessionStore` callsite must do the same; the wrapper signature makes this explicit.

## User Impact

Active DM / direct-chat sessions survive subagent spawns even when the session store is over `maxEntries` because of protected external threads. Users no longer lose an in-flight conversation as a side effect of running a subagent from a DM channel.

No user-visible change for stores that were already under capacity, and no behavior change for protected sessions or subagent child sessions (still preserved by the existing provider mechanism).

## Evidence

**Diff shape** — 2 files, 3 edit points in `subagent-spawn.ts`, plus one new focused test:

```
src/agents/subagent-spawn.ts                          | 61 +++++++++++++++-------
src/agents/subagent-spawn.active-session-preserve.test.ts (new)
```

**Regression test** (`src/agents/subagent-spawn.active-session-preserve.test.ts`):

Captures the `opts` argument of every `updateSessionStore` call made during `spawnSubagentDirect`, asserts that each one forwards `activeSessionKey === requesterInternalKey`. Exercises both write paths (initial child-session patch + runtime-model persist) by supplying a resolved model. Passes locally:

```
$ pnpm test src/agents/subagent-spawn.active-session-preserve.test.ts

 RUN  v4.1.8 /Users/.../openclaw-fork/openclaw

 ✓ agents src/agents/subagent-spawn.active-session-preserve.test.ts (1 test) 7482ms
     ✓ forwards the requester session key as opts.activeSessionKey on every store write  355ms

 Test Files  1 passed (1)
      Tests  1 passed (1)
```

**Local validation:**

- `pnpm tsgo:core` — clean, no errors.
- `pnpm check` — 15/16 checks green (the 16th was a stale `.git/openclaw-local-checks/heavy-check.lock` from an interrupted run, unrelated to this change; cleared and re-verified).
- Focused vitest run above.

**Real-behavior proof (before):**

Local diagnostic on the affected personal instance:

- ~800 total session entries in the store.
- 799 protected via `isProtectedSessionMaintenanceEntry` (Slack `threadId` sessions).
- 1 unprotected active Telegram DM.
- `session.maintenance.maxEntries` = 600 (default) → `preservedCount` (799) already exceeds the cap.
- Every subagent-spawn write called `updateSubagentSessionStore` without `activeSessionKey`, so `capEntryCount` evicted the DM entry (`sorted.slice(maxRemovableEntries = 0)` == all unprotected keys).
- Symptom: the active session's store entry vanished from `sessions.json` after each spawn; the DM continued to receive messages but lost its persisted history/model routing.

**Real-behavior proof (after):**

With the patch applied to the running OpenClaw and a subagent spawned from the same DM:

- New unit test (this PR) confirms every write forwards `activeSessionKey`.
- Downstream: `saveSessionStoreUnlocked` receives `activeSessionKey` → `collectSessionMaintenancePreserveKeys([activeSessionKey])` includes it → `shouldPreserveMaintenanceEntry` returns true for the DM key → `capEntryCount` filters it out of the eviction candidate list.

### Behavior or issue addressed

Active human-conversation session (unprotected because it has no `threadId` / not a group / not a channel) can be silently evicted on subagent spawn when other protected sessions already fill `maxEntries`.

### Real environment tested

- macOS 15.7.7 (x64), Node v25.4.0
- Local checkout at `~/clawd/openclaw-fork/openclaw`, branch `fix/subagent-spawn-active-session-key` off `main` at commit `3706c2b3`.
- pnpm v11.2.2, vitest v4.1.8.
- Original bug hit in a live OpenClaw personal instance (2026.6.11) running the same conditions described above.

### Exact commands run after this patch

```bash
pnpm install --frozen-lockfile
pnpm tsgo:core
pnpm check
pnpm test src/agents/subagent-spawn.active-session-preserve.test.ts
```

### Observed result after fix

- Typecheck clean.
- Regression test passes.
- `pnpm check` architecture, boundary, docs, guard, and shrinkwrap checks green.
- Live: the active DM's store entry now survives subagent spawns from the same conversation.

### What was not tested

- Full `pnpm test` matrix — the local box ran into OOM under the wide subagent-spawn glob in vitest, unrelated to this diff. CI is the right place to exercise the wider matrix; happy to iterate on any specific test the reviewer wants me to reproduce locally.

## Related

- Extends the preserve-key mechanism introduced in #81498 (pending subagent children) to also cover the *requester* (parent) session on the same spawn write paths.
- Alternative approach to #80853 / #88962 (which adds a `session.maintenance.preserveKeys` config option). This PR does not add config surface, per the AGENTS.md config-bar rule; the invariant we want — "the currently active human conversation should not be evicted on its own subagent spawn" — is a runtime fact, not a per-user preference.

## AI-assisted disclosure

This PR was authored with AI assistance (Claude / OpenClaw personal assistant). I reviewed each edit, confirmed the wrapper signature and the two callsites in `spawnSubagentDirect` / `persistInitialChildSessionRuntimeModel`, and validated behavior via the new regression test plus local typecheck.
