### PR TITLE
Fix Android realtime tool completion synchronization

### DIFF
--- a/apps/android/app/src/main/java/ai/openclaw/app/voice/TalkModeManager.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/voice/TalkModeManager.kt
@@ -94,6 +94,12 @@ private data class RealtimeToolCompletion(
   val messageEl: JsonElement?,
 )
 
+private data class RealtimeToolCompletionDispatch(
+  val toolRun: RealtimeToolRun,
+  val state: String,
+  val messageEl: JsonElement?,
+)
+
 class TalkModeManager internal constructor(
   private val context: Context,
   private val scope: CoroutineScope,
@@ -170,6 +176,7 @@ class TalkModeManager internal constructor(
   private var realtimeAppendJob: Job? = null
 
   // Realtime tool calls can complete before their chat final arrives; cache by call/run id until both sides meet.
+  private val realtimeToolLock = Any()
   private val realtimeToolRuns = LinkedHashMap<String, RealtimeToolRun>()
   private val pendingRealtimeToolCalls = LinkedHashSet<String>()
   private val pendingRealtimeToolCompletions = LinkedHashMap<String, RealtimeToolCompletion>()
@@ -1028,9 +1035,11 @@ class TalkModeManager internal constructor(
     }
     realtimeCaptureJob = null
     realtimeAppendJob = null
-    realtimeToolRuns.clear()
-    pendingRealtimeToolCalls.clear()
-    pendingRealtimeToolCompletions.clear()
+    synchronized(realtimeToolLock) {
+      realtimeToolRuns.clear()
+      pendingRealtimeToolCalls.clear()
+      pendingRealtimeToolCompletions.clear()
+    }
     realtimeUserEntryId = null
     realtimeUserEntryAwaitingFinal = false
     realtimeUserEntryAwaitingFinalStartedAtMs = null
@@ -1065,7 +1074,9 @@ class TalkModeManager internal constructor(
     forced: Boolean = false,
   ) {
     val relaySessionId = realtimeSessionId ?: return
-    pendingRealtimeToolCalls.add(callId)
+    synchronized(realtimeToolLock) {
+      pendingRealtimeToolCalls.add(callId)
+    }
     scope.launch {
       try {
         if (name == REALTIME_AGENT_CONTROL_TOOL) {
@@ -1088,15 +1099,34 @@ class TalkModeManager internal constructor(
         val runId = parseRunId(response)
         if (!runId.isNullOrBlank()) {
           if (realtimeSessionId != relaySessionId) return@launch
-          realtimeToolRuns[runId] =
-            RealtimeToolRun(callId = callId, relaySessionId = relaySessionId)
-          val completion = pendingRealtimeToolCompletions.remove(runId)
-          if (completion != null) {
-            maybeCompleteRealtimeToolCall(
-              runId = runId,
-              state = completion.state,
-              messageEl = completion.messageEl,
-            )
+          var dispatch: RealtimeToolCompletionDispatch? = null
+          var sessionStillActive = true
+          val hasCachedCompletion =
+            synchronized(realtimeToolLock) {
+              if (realtimeSessionId != relaySessionId) {
+                sessionStillActive = false
+                return@synchronized false
+              }
+              val toolRun = RealtimeToolRun(callId = callId, relaySessionId = relaySessionId)
+              realtimeToolRuns[runId] =
+                toolRun
+              val completion = pendingRealtimeToolCompletions.remove(runId)
+              if (completion != null) {
+                realtimeToolRuns.remove(runId)
+                dispatch =
+                  RealtimeToolCompletionDispatch(
+                    toolRun = toolRun,
+                    state = completion.state,
+                    messageEl = completion.messageEl,
+                  )
+                true
+              } else {
+                false
+              }
+            }
+          if (!sessionStillActive) return@launch
+          if (hasCachedCompletion) {
+            dispatch?.let(::dispatchRealtimeToolCompletion)
           } else {
             _statusText.value = "Thinking…"
           }
@@ -1108,7 +1138,9 @@ class TalkModeManager internal constructor(
         Log.w(tag, "realtime toolCall failed: ${err.message ?: err::class.simpleName}")
         submitRealtimeToolError(callId, err.message ?: "tool call failed", relaySessionId)
       } finally {
-        pendingRealtimeToolCalls.remove(callId)
+        synchronized(realtimeToolLock) {
+          pendingRealtimeToolCalls.remove(callId)
+        }
       }
     }
   }
@@ -1118,11 +1150,35 @@ class TalkModeManager internal constructor(
     state: String,
     messageEl: JsonElement?,
   ): Boolean {
-    if (realtimeSessionId == null || pendingRealtimeToolCalls.isEmpty()) return false
     if (state != "final" && state != "aborted" && state != "error") return false
-    pendingRealtimeToolCompletions[runId] =
-      RealtimeToolCompletion(state = state, messageEl = messageEl)
-    return true
+    var dispatch: RealtimeToolCompletionDispatch? = null
+    val handled =
+      synchronized(realtimeToolLock) {
+        val toolRun = realtimeToolRuns[runId]
+        if (toolRun != null) {
+          realtimeToolRuns.remove(runId)
+          if (toolRun.relaySessionId == realtimeSessionId) {
+            dispatch =
+              RealtimeToolCompletionDispatch(
+                toolRun = toolRun,
+                state = state,
+                messageEl = messageEl,
+              )
+          }
+          return@synchronized true
+        }
+        if (realtimeSessionId == null || pendingRealtimeToolCalls.isEmpty()) return@synchronized false
+        pendingRealtimeToolCompletions[runId] =
+          RealtimeToolCompletion(state = state, messageEl = messageEl)
+        while (pendingRealtimeToolCompletions.size > maxCachedRunCompletions) {
+          pendingRealtimeToolCompletions.entries.firstOrNull()?.let {
+            pendingRealtimeToolCompletions.remove(it.key)
+          }
+        }
+        true
+      }
+    dispatch?.let(::dispatchRealtimeToolCompletion)
+    return handled
   }
 
   private fun maybeCompleteRealtimeToolCall(
@@ -1130,15 +1186,49 @@ class TalkModeManager internal constructor(
     state: String,
     messageEl: JsonElement?,
   ): Boolean {
-    val toolRun = realtimeToolRuns[runId] ?: return false
-    if (toolRun.relaySessionId != realtimeSessionId) {
-      realtimeToolRuns.remove(runId)
-      return true
-    }
-    when (state) {
+    var dispatch: RealtimeToolCompletionDispatch? = null
+    val handled =
+      synchronized(realtimeToolLock) {
+        val toolRun = realtimeToolRuns[runId] ?: return@synchronized false
+        if (toolRun.relaySessionId != realtimeSessionId) {
+          realtimeToolRuns.remove(runId)
+          return@synchronized true
+        }
+        when (state) {
+          "final" -> {
+            realtimeToolRuns.remove(runId)
+            dispatch =
+              RealtimeToolCompletionDispatch(
+                toolRun = toolRun,
+                state = state,
+                messageEl = messageEl,
+              )
+            true
+          }
+          "aborted", "error" -> {
+            realtimeToolRuns.remove(runId)
+            dispatch =
+              RealtimeToolCompletionDispatch(
+                toolRun = toolRun,
+                state = state,
+                messageEl = messageEl,
+              )
+            true
+          }
+          else -> false
+        }
+      }
+    if (!handled) return false
+
+    dispatch?.let(::dispatchRealtimeToolCompletion)
+    return true
+  }
+
+  private fun dispatchRealtimeToolCompletion(dispatch: RealtimeToolCompletionDispatch) {
+    when (dispatch.state) {
       "final" -> {
-        realtimeToolRuns.remove(runId)
-        val text = extractTextFromChatEventMessage(messageEl).orEmpty()
+        val text = extractTextFromChatEventMessage(dispatch.messageEl).orEmpty()
+        val toolRun = dispatch.toolRun
         scope.launch {
           submitRealtimeToolResult(
             callId = toolRun.callId,
@@ -1146,17 +1236,15 @@ class TalkModeManager internal constructor(
             sessionId = toolRun.relaySessionId,
           )
         }
-        return true
       }
       "aborted", "error" -> {
-        realtimeToolRuns.remove(runId)
+        val toolRun = dispatch.toolRun
+        val state = dispatch.state
         scope.launch {
           submitRealtimeToolError(toolRun.callId, state, toolRun.relaySessionId)
         }
-        return true
       }
     }
-    return false
   }
 
   private suspend fun submitRealtimeToolError(

--- a/apps/android/app/src/test/java/ai/openclaw/app/voice/TalkModeManagerTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/voice/TalkModeManagerTest.kt
@@ -136,6 +136,20 @@ class TalkModeManagerTest {
   }
 
   @Test
+  fun realtimeToolFinalBeforeRunMetadataIsHeldForToolCompletion() {
+    val manager = createManager()
+
+    manager.ttsOnAllResponses = true
+    setPrivateField(manager, "realtimeSessionId", "relay-1")
+    pendingRealtimeToolCalls(manager).add("call-1")
+
+    manager.handleGatewayEvent("chat", chatFinalPayload(runId = "run-tool", text = "tool result"))
+
+    assertEquals(0L, playbackGeneration(manager).get())
+    assertTrue(pendingRealtimeToolCompletions(manager).containsKey("run-tool"))
+  }
+
+  @Test
   fun realtimeCloseErrorDisablesTalkButKeepsFailureStatus() {
     var stoppedByRelay = false
     val manager = createManager(onStoppedByRelay = { stoppedByRelay = true })
@@ -545,6 +559,12 @@ class TalkModeManagerTest {
 
   @Suppress("UNCHECKED_CAST")
   private fun realtimeToolRuns(manager: TalkModeManager) = readPrivateField(manager, "realtimeToolRuns") as MutableMap<String, RealtimeToolRun>
+
+  @Suppress("UNCHECKED_CAST")
+  private fun pendingRealtimeToolCalls(manager: TalkModeManager) = readPrivateField(manager, "pendingRealtimeToolCalls") as MutableSet<String>
+
+  @Suppress("UNCHECKED_CAST")
+  private fun pendingRealtimeToolCompletions(manager: TalkModeManager) = readPrivateField(manager, "pendingRealtimeToolCompletions") as MutableMap<String, Any>
 
   private fun setPrivateField(
     target: Any,


### PR DESCRIPTION
## What Problem This Solves

Android Talk Mode realtime tool calls tracked `realtimeToolRuns`, `pendingRealtimeToolCalls`, and `pendingRealtimeToolCompletions` in unsynchronized `LinkedHashMap`/`LinkedHashSet` state. Gateway chat events and `talk.client.toolCall` responses both run on `Dispatchers.IO`, so a terminal chat event could race run registration and leave an `openclaw_agent_consult` result stranded instead of submitting `talk.session.submitToolResult`.

## Why This Change Was Made

This change puts the realtime tool state transitions behind a dedicated `realtimeToolLock`. Run registration, pending terminal completion caching, cached completion consumption, stale-session checks, and run removal are now decided under the same lock. The actual gateway result/error submission still happens after releasing the lock, so the lock does not cover network I/O.

The patch also bounds cached realtime completions with the same cache cap used elsewhere in Talk Mode and adds a regression test for a final chat event arriving before run metadata exists.

## User Impact

Realtime Talk Mode should no longer hang on `openclaw_agent_consult` when the agent answer and tool-call RPC response arrive concurrently. Users should get the voice reply instead of staying stuck in `Thinking...` until the provider times out.

## Evidence

- `env JAVA_HOME=/opt/homebrew/opt/openjdk/libexec/openjdk.jdk/Contents/Home GRADLE_OPTS='-Dorg.gradle.java.home=/opt/homebrew/opt/openjdk/libexec/openjdk.jdk/Contents/Home' node scripts/run-android-gradle.mjs :app:testPlayDebugUnitTest --tests ai.openclaw.app.voice.TalkModeManagerTest` - passed
- `env JAVA_HOME=/opt/homebrew/opt/openjdk/libexec/openjdk.jdk/Contents/Home GRADLE_OPTS='-Dorg.gradle.java.home=/opt/homebrew/opt/openjdk/libexec/openjdk.jdk/Contents/Home' node scripts/run-android-gradle.mjs :app:runKtlintCheckOverMainSourceSet` - passed
- `env JAVA_HOME=/opt/homebrew/opt/openjdk/libexec/openjdk.jdk/Contents/Home GRADLE_OPTS='-Dorg.gradle.java.home=/opt/homebrew/opt/openjdk/libexec/openjdk.jdk/Contents/Home' node scripts/run-android-gradle.mjs :app:runKtlintCheckOverTestSourceSet` - passed
- `.agents/skills/autoreview/scripts/autoreview --mode local ...` - clean after addressing three accepted concurrency findings
- `git diff --check` - passed

Note: full `:app:ktlintCheck` still reports pre-existing style violations in unrelated Android files such as `ChatController.kt`, `NodeRuntime.kt`, and `ChatControllerCommandControlsTest.kt`; the touched main/test source-set checks above pass after this patch.
