### PR TITLE
fix(control-ui): add missing action buttons to workboard card detail drawer

### DIFF
--- a/ui/src/styles/workboard.css
+++ b/ui/src/styles/workboard.css
@@ -1501,6 +1501,18 @@
   justify-content: center;
 }
 
+.workboard-detail__actions-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+
+.workboard-detail__actions-row .btn {
+  flex: 0 0 auto;
+  justify-content: center;
+  min-width: 0;
+}
+
 @media (max-width: 860px) {
   .workboard-modal {
     padding: 0;

--- a/ui/src/ui/views/workboard.test.ts
+++ b/ui/src/ui/views/workboard.test.ts
@@ -1639,6 +1639,162 @@ describe("renderWorkboard", () => {
     }
   });
 
+  it("renders action buttons in the detail drawer for writable cards", async () => {
+    const host = {};
+    const state = getWorkboardState(host);
+    state.loaded = true;
+    state.cards = [
+      {
+        id: "card-1",
+        title: "Test action buttons",
+        status: "todo",
+        priority: "normal",
+        labels: [],
+        position: 1000,
+        createdAt: 1,
+        updatedAt: 1,
+      },
+    ];
+    const container = document.createElement("div");
+    document.body.append(container);
+    const props: WorkboardRenderProps = {
+      host,
+      client: null,
+      connected: true,
+      pluginEnabled: true,
+      agentsList: null,
+      sessions: [],
+      onOpenSession: () => undefined,
+      onRequestUpdate: () => renderInto(container, props),
+    };
+
+    try {
+      renderInto(container, props);
+      const launcher = container.querySelector<HTMLButtonElement>(
+        "button[aria-label='View details']",
+      );
+      expect(launcher).toBeInstanceOf(HTMLButtonElement);
+      launcher?.click();
+      await nextFrame();
+
+      expect(container.querySelector(".workboard-detail-drawer")).toBeInstanceOf(HTMLElement);
+      expect(
+        container.querySelector<HTMLButtonElement>('button[title="Edit card"]'),
+      ).toBeInstanceOf(HTMLButtonElement);
+      expect(
+        container.querySelector<HTMLButtonElement>('button[title="Archive card"]'),
+      ).toBeInstanceOf(HTMLButtonElement);
+      expect(
+        container.querySelector<HTMLButtonElement>('button[title="Delete card"]'),
+      ).toBeInstanceOf(HTMLButtonElement);
+    } finally {
+      render(nothing, container);
+      container.remove();
+    }
+  });
+
+  it("hides action buttons in the detail drawer for read-only cards", async () => {
+    const host = {};
+    const state = getWorkboardState(host);
+    state.loaded = true;
+    state.cards = [
+      {
+        id: "card-1",
+        title: "Read-only card",
+        status: "todo",
+        priority: "normal",
+        labels: [],
+        position: 1000,
+        createdAt: 1,
+        updatedAt: 1,
+      },
+    ];
+    const container = document.createElement("div");
+    document.body.append(container);
+    const props: WorkboardRenderProps = {
+      host,
+      client: null,
+      connected: true,
+      pluginEnabled: true,
+      agentsList: null,
+      sessions: [],
+      canWrite: false,
+      onOpenSession: () => undefined,
+      onRequestUpdate: () => renderInto(container, props),
+    };
+
+    try {
+      renderInto(container, props);
+      const launcher = container.querySelector<HTMLButtonElement>(
+        "button[aria-label='View details']",
+      );
+      launcher?.click();
+      await nextFrame();
+
+      expect(container.querySelector(".workboard-detail-drawer")).toBeInstanceOf(HTMLElement);
+      expect(container.querySelector<HTMLButtonElement>('button[title="Edit card"]')).toBeNull();
+      expect(container.querySelector<HTMLButtonElement>('button[title="Archive card"]')).toBeNull();
+      expect(container.querySelector<HTMLButtonElement>('button[title="Delete card"]')).toBeNull();
+    } finally {
+      render(nothing, container);
+      container.remove();
+    }
+  });
+
+  it("hides the edit button and shows unarchive for archived cards in the detail drawer", async () => {
+    const host = {};
+    const state = getWorkboardState(host);
+    state.loaded = true;
+    state.showArchived = true;
+    state.cards = [
+      {
+        id: "card-1",
+        title: "Archived card",
+        status: "done",
+        priority: "normal",
+        labels: [],
+        position: 1000,
+        createdAt: 1,
+        updatedAt: 1,
+        metadata: { archivedAt: Date.now() },
+      },
+    ];
+    const container = document.createElement("div");
+    document.body.append(container);
+    const props: WorkboardRenderProps = {
+      host,
+      client: null,
+      connected: true,
+      pluginEnabled: true,
+      agentsList: null,
+      sessions: [],
+      onOpenSession: () => undefined,
+      onRequestUpdate: () => renderInto(container, props),
+    };
+
+    try {
+      renderInto(container, props);
+      const launcher = container.querySelector<HTMLButtonElement>(
+        "button[aria-label='View details']",
+      );
+      launcher?.click();
+      await nextFrame();
+
+      expect(container.querySelector(".workboard-detail-drawer")).toBeInstanceOf(HTMLElement);
+      expect(container.querySelector<HTMLButtonElement>('button[title="Edit card"]')).toBeNull();
+      expect(
+        container.querySelector<HTMLButtonElement>('button[title="Restore from archive"]'),
+      ).toBeInstanceOf(HTMLButtonElement);
+      expect(container.querySelector<HTMLButtonElement>('button[title="Archive card"]')).toBeNull();
+      expect(
+        container.querySelector<HTMLButtonElement>('button[title="Delete card"]'),
+      ).toBeInstanceOf(HTMLButtonElement);
+    } finally {
+      render(nothing, container);
+      container.remove();
+    }
+  });
+
   it("does not restore focus to a disconnected modal opener", async () => {
     const host = {};
     const state = getWorkboardState(host);

--- a/ui/src/ui/views/workboard.ts
+++ b/ui/src/ui/views/workboard.ts
@@ -1883,6 +1883,14 @@ function renderCardDetailsPanel(props: WorkboardProps) {
   const events = (card.events ?? []).slice(-6).toReversed();
   const busy = state.busyCardIds.has(card.id) || state.dispatching;
   const showStartControls = writable && cardCanStart(state, props.sessions, card);
+  const session = findWorkboardSession(card, props.sessions);
+  const activeTask = cardHasActiveOrRunningUnresolvedTask(card, task, state.missingTaskIds);
+  const live =
+    activeTask ||
+    cardHasUnresolvedStartedRun(card) ||
+    session?.hasActiveRun === true ||
+    (session?.hasActiveRun !== false && session?.status === "running");
+  const archived = Boolean(card.metadata?.archivedAt);
   const dependencies = getWorkboardDependencyState(card, state.cards);
   return html`
     <aside
@@ -2085,6 +2093,92 @@ function renderCardDetailsPanel(props: WorkboardProps) {
         </section>
 
         <div class="workboard-detail__actions">
+          ${writable ? renderCardMoveControl(props, card, busy) : nothing}
+          <div class="workboard-detail__actions-row">
+            ${writable && (linkedSessionKey ? live : activeTask)
+              ? html`
+                  <button
+                    class="btn btn--icon"
+                    type="button"
+                    title=${t("workboard.stopSession")}
+                    aria-label=${t("workboard.stopSession")}
+                    ?disabled=${busy || !props.connected}
+                    @click=${() =>
+                      stopWorkboardCard({
+                        host: props.host,
+                        client: props.client,
+                        card,
+                        requestUpdate: props.onRequestUpdate,
+                      })}
+                  >
+                    ${icons.stop}<span>${t("workboard.stopSession")}</span>
+                  </button>
+                `
+              : nothing}
+            ${writable && !archived
+              ? html`
+                  <button
+                    class="btn btn--icon"
+                    type="button"
+                    title=${t("workboard.editCard")}
+                    aria-label=${t("workboard.editCard")}
+                    ?disabled=${state.dispatching}
+                    @click=${(event: MouseEvent) => {
+                      rememberWorkboardReturnFocus(event.currentTarget);
+                      openEditModal(state, card);
+                      props.onRequestUpdate?.();
+                    }}
+                  >
+                    ${icons.edit}<span>${t("workboard.editCard")}</span>
+                  </button>
+                `
+              : nothing}
+            ${writable
+              ? html`
+                  <button
+                    class="btn btn--icon"
+                    type="button"
+                    title=${archived ? t("workboard.unarchiveCard") : t("workboard.archiveCard")}
+                    aria-label=${archived
+                      ? t("workboard.unarchiveCard")
+                      : t("workboard.archiveCard")}
+                    ?disabled=${busy}
+                    @click=${() =>
+                      archiveWorkboardCard({
+                        host: props.host,
+                        client: props.client,
+                        cardId: card.id,
+                        archived: !archived,
+                        requestUpdate: props.onRequestUpdate,
+                      })}
+                  >
+                    ${archived ? icons.archiveRestore : icons.archive}<span
+                      >${archived ? t("workboard.unarchiveCard") : t("workboard.archiveCard")}</span
+                    >
+                  </button>
+                `
+              : nothing}
+            ${writable
+              ? html`
+                  <button
+                    class="btn btn--icon workboard-card__delete"
+                    type="button"
+                    title=${t("workboard.deleteCard")}
+                    aria-label=${t("workboard.deleteCard")}
+                    ?disabled=${busy}
+                    @click=${() =>
+                      deleteWorkboardCard({
+                        host: props.host,
+                        client: props.client,
+                        cardId: card.id,
+                        requestUpdate: props.onRequestUpdate,
+                      })}
+                  >
+                    ${icons.trash}<span>${t("workboard.deleteCard")}</span>
+                  </button>
+                `
+              : nothing}
+          </div>
           ${linkedSessionKey
             ? html`
                 <button


### PR DESCRIPTION
## Summary

**Problem**: The workboard card detail drawer (expanded view) is missing action buttons that are available in the compact card view: edit, delete, archive/unarchive, stop, and status change.

**Solution**: Added the missing action buttons to the `renderCardDetailsPanel` function in the workboard view, matching the conditions and behavior of the compact card view.

**What changed**: Added 4 variables (session, activeTask, live, archived) and 5 action controls (status dropdown, stop, edit, archive/unarchive, delete) to the detail drawer in `ui/src/ui/views/workboard.ts`; added `.workboard-detail__actions-row` flex CSS in `ui/src/styles/workboard.css`; added 3 rendering tests in `ui/src/ui/views/workboard.test.ts`.

**What did NOT change**: No changes to controller logic, compact card view, i18n keys, or dependencies.

Fixes #99957

## What Problem This Solves

When opening a workboard card's detail drawer (expanded view), users previously had no access to edit, delete, archive, stop, or change card status. These actions were only available in the compact card view on the board, requiring users to close the drawer and interact with the compact card instead -- creating unnecessary friction.

## Root Cause

The `renderCardDetailsPanel` function was implemented as a read-only information display and never included the action button layer that `renderCard` provides. Only "Open Session" and "Start execution" controls were available.

## Real behavior proof

**Behavior addressed**: Workboard card detail drawer now includes edit, delete, archive/unarchive, stop, and status change buttons.

**Real environment tested**: Linux x86_64, Node v24.1.0, OpenClaw Gateway (local mode), Chrome browser via Playwright

**Exact steps or command run after this patch**:
1. `pnpm ui:build` to build the modified UI
2. `pnpm dev gateway` to start the local Gateway
3. Opened http://localhost:18789/workboard in Chrome via Playwright
4. Created a new workboard card with Bugfix template
5. Opened the card detail drawer (expanded view)
6. Captured screenshots of the action buttons

**After-fix evidence**:

Full page screenshot showing the workboard with the card detail drawer open:
![Workboard detail drawer - full page](https://raw.githubusercontent.com/LeonidasLux/my-pr-image-evidences/master/2026/07/04/PR-99970/pr-99970-detail-drawer-full.png)

Close-up of the detail drawer action buttons (status dropdown, edit, archive, delete):
![Workboard action buttons close-up](https://raw.githubusercontent.com/LeonidasLux/my-pr-image-evidences/master/2026/07/04/PR-99970/pr-99970-detail-drawer-actions.png)

**Observed result after the fix**: The detail drawer footer now shows the status dropdown, Edit, Archive, and Delete buttons alongside the existing Start controls. All 78 tests pass (75 existing + 3 new) covering writable, read-only, and archived card states.

```text
$ pnpm test -- ui/src/ui/views/workboard.test.ts
 Test Files  1 passed (1)
      Tests  78 passed (78)
```

**What was not tested**: Read-only and archived card detail drawer states in the browser (the test suite covers these via unit tests with identical helper variables). The stop button requires an active running session to appear, which needs a real agent session to be started -- not tested in this screenshot run.

## Risk checklist

merge-risk: Low

- [x] Low risk declaration -- Only additive changes to the detail drawer, not modifying any existing logic
- [x] All existing tests pass (78/78)
- [x] Build passes (pnpm build:ci-artifacts)
- [x] No new dependencies or i18n strings
- [x] Buttons follow identical conditions to the compact card view
- [x] Visual proof screenshots provided (real browser, real Gateway, real Workboard)