### PR TITLE
fix(watch): defer restart when dist/entry.js is missing mid-rebuild

### DIFF
--- a/scripts/watch-node.mjs
+++ b/scripts/watch-node.mjs
@@ -1,14 +1,21 @@
 #!/usr/bin/env node
 // Watches dev source paths and restarts scripts/run-node.mjs when relevant
 // files change.
-import { spawn } from "node:child_process";
+import { spawn, spawnSync } from "node:child_process";
 import { createHash } from "node:crypto";
 import fs from "node:fs";
 import path from "node:path";
 import process from "node:process";
 import { pathToFileURL } from "node:url";
+import { BUILD_STAMP_FILE, RUNTIME_POSTBUILD_STAMP_FILE } from "./lib/local-build-metadata.mjs";
 import { sleep } from "./lib/sleep.mjs";
-import { isRestartRelevantRunNodePath, runNodeWatchedPaths } from "./run-node-watch-paths.mjs";
+import {
+  isRestartRelevantRunNodePath,
+  runNodeConfigFiles,
+  runNodeSourceRoots,
+  runNodeWatchedPaths,
+} from "./run-node-watch-paths.mjs";
+import { resolveBuildRequirement, resolveRuntimePostBuildRequirement } from "./run-node.mjs";
 
 const WATCH_NODE_RUNNER = "scripts/run-node.mjs";
 const WATCH_RESTART_SIGNAL = "SIGTERM";
@@ -19,6 +26,8 @@ const WATCH_LOCK_WAIT_MS = 5_000;
 const WATCH_LOCK_POLL_MS = 100;
 const WATCH_SHUTDOWN_KILL_GRACE_MS = 5_000;
 const WATCH_LOCK_DIR = path.join(".local", "watch-node");
+const WATCH_BUILD_READY_POLL_MS = 200;
+const WATCH_BUILD_READY_TIMEOUT_MS = 5 * 60 * 1000;
 const AUTO_DOCTOR_DISABLE_VALUES = new Set(["0", "false", "no", "off"]);
 // The source watcher cannot import the TypeScript owner; keep this literal
 // aligned with src/commands/doctor-invocation.ts.
@@ -27,6 +36,72 @@ const DOCTOR_DISABLE_CROSS_STATE_DIR_IMPORTS_ENV =
 
 const buildRunnerArgs = (args) => [WATCH_NODE_RUNNER, ...args];
 const buildDoctorRunnerArgs = () => [WATCH_NODE_RUNNER, "doctor", "--fix", "--non-interactive"];
+
+/**
+ * Reason codes from resolveBuildRequirement / resolveRuntimePostBuildRequirement
+ * that indicate the dist/ is physically broken — the child process cannot start.
+ * Soft-staleness reasons (source_mtime_newer, git_head_changed, dirty_watched_tree,
+ * config_newer, build_stamp_missing_head, build_stamp_newer, etc.) are handled by
+ * run-node rebuilding on the next start, so the guard does NOT defer on them.
+ */
+const HARD_BUILD_FAILURES = new Set([
+  "missing_dist_entry",
+  "missing_bundled_plugin_dist_entry",
+  "missing_private_qa_dist",
+]);
+
+const HARD_RUNTIME_FAILURES = new Set(["missing_runtime_postbuild_output"]);
+
+/**
+ * Checks if the build output is ready for restart by delegating to run-node's
+ * canonical readiness contract. Only defers on hard failures where the child
+ * process physically cannot start (missing files). Soft staleness (source drift,
+ * git HEAD change, dirty tree) is handled by run-node rebuilding on start.
+ */
+const isBuildReadyForRestart = (cwd, env, fsImpl = fs) => {
+  try {
+    const distRoot = path.join(cwd, "dist");
+    const distEntry = path.join(distRoot, "entry.js");
+    const buildDeps = {
+      cwd,
+      fs: fsImpl,
+      spawnSync,
+      env,
+      distRoot,
+      distEntry,
+      buildStampPath: path.join(distRoot, BUILD_STAMP_FILE),
+      runtimePostBuildStampPath: path.join(distRoot, RUNTIME_POSTBUILD_STAMP_FILE),
+      sourceRoots: runNodeSourceRoots.map((name) => ({
+        name,
+        path: path.join(cwd, name),
+      })),
+      configFiles: runNodeConfigFiles.map((filePath) => path.join(cwd, filePath)),
+    };
+    const buildReq = resolveBuildRequirement(buildDeps);
+    if (buildReq.shouldBuild) {
+      if (HARD_BUILD_FAILURES.has(buildReq.reason)) {
+        return false;
+      }
+      // resolveBuildRequirement checks missing_build_stamp before
+      // missing_dist_entry. When both stamp and entry are absent the
+      // reason is missing_build_stamp (soft) even though the entry is
+      // also gone (hard failure). Verify entry existence directly.
+      if (buildReq.reason === "missing_build_stamp") {
+        try {
+          if (!fsImpl.existsSync(distEntry)) {
+            return false;
+          }
+        } catch {
+          return false;
+        }
+      }
+    }
+    const runtimeReq = resolveRuntimePostBuildRequirement(buildDeps);
+    return !(runtimeReq.shouldSync && HARD_RUNTIME_FAILURES.has(runtimeReq.reason));
+  } catch {
+    return false;
+  }
+};
 
 const normalizePath = (filePath) =>
   String(filePath ?? "")
@@ -271,6 +346,7 @@ export async function runWatchMain(params = {}) {
     cwd: params.cwd ?? process.cwd(),
     args: params.args ?? process.argv.slice(2),
     env: params.env ? { ...params.env } : { ...process.env },
+    fs: params.fs ?? fs,
     now: params.now ?? Date.now,
     sleep: params.sleep ?? sleep,
     signalProcess: params.signalProcess ?? ((pid, signal) => process.kill(pid, signal)),
@@ -400,6 +476,38 @@ export async function runWatchMain(params = {}) {
         if (restartRequested || shouldRestartAfterChildExit(exitCode, exitSignal)) {
           forceKillWatchProcessGroup(exitedProcess);
           restartRequested = false;
+          // #99603: when the child exited during a deferred restart (build
+          // not ready), wait for build readiness instead of restarting
+          // immediately into a potentially broken dist.
+          // Skip in test mode to preserve existing test behavior.
+          const isTestMode = deps.env.OPENCLAW_WATCH_MODE === "test";
+          if (!isTestMode && !isBuildReadyForRestart(deps.cwd, deps.env, deps.fs)) {
+            logWatcher(
+              "Child exited during deferred restart but build output is not ready; waiting.",
+              deps,
+            );
+            const startedAt = deps.now();
+            const pollAfterChildExit = async () => {
+              while (!isBuildReadyForRestart(deps.cwd, deps.env, deps.fs)) {
+                if (deps.now() - startedAt > WATCH_BUILD_READY_TIMEOUT_MS) {
+                  logWatcher(
+                    `Build output still not ready after ${WATCH_BUILD_READY_TIMEOUT_MS}ms ` +
+                      "after child exit; restarting anyway (bounded recovery).",
+                    deps,
+                  );
+                  startRunner();
+                  return;
+                }
+                await deps.sleep(WATCH_BUILD_READY_POLL_MS);
+              }
+              logWatcher("Build output ready after child exit; restarting.", deps);
+              startRunner();
+            };
+            pollAfterChildExit().catch(() => {
+              startRunner();
+            });
+            return;
+          }
           startRunner();
           return;
         }
@@ -498,6 +606,52 @@ export async function runWatchMain(params = {}) {
         return;
       }
       restartRequested = true;
+
+      // #99603 fix: Check if build output exists before restarting.
+      // If dist/entry.js is missing (mid-rebuild state), wait for it to appear
+      // before sending SIGTERM to avoid crash-loop.
+      // Skip this check in test mode to preserve existing test behavior.
+      const isTestMode = deps.env.OPENCLAW_WATCH_MODE === "test";
+      if (!isTestMode && !isBuildReadyForRestart(deps.cwd, deps.env, deps.fs)) {
+        logWatcher(
+          "Build output not ready (dist/entry.js missing or stale); waiting before restart.",
+          deps,
+        );
+        // Poll until build is ready, then restart. Times out after
+        // WATCH_BUILD_READY_TIMEOUT_MS to avoid polling forever when the build
+        // never completes (e.g. build error); the current process keeps running.
+        const startedAt = deps.now();
+        const pollBuildReady = async () => {
+          while (!isBuildReadyForRestart(deps.cwd, deps.env, deps.fs)) {
+            if (deps.now() - startedAt > WATCH_BUILD_READY_TIMEOUT_MS) {
+              restartRequested = false;
+              logWatcher(
+                `Build output still not ready after ${WATCH_BUILD_READY_TIMEOUT_MS}ms; giving up. ` +
+                  "The current process is still running. A future file change will retry the restart.",
+                deps,
+              );
+              return;
+            }
+            await deps.sleep(WATCH_BUILD_READY_POLL_MS);
+          }
+          logWatcher("Build output ready; proceeding with restart.", deps);
+          // Only kill if we are still the active restart request. If the
+          // child exited on its own during deferral, the exit handler will
+          // have reset restartRequested and started a new child already.
+          if (restartRequested && watchProcess && typeof watchProcess.kill === "function") {
+            signalWatchProcess(watchProcess, WATCH_RESTART_SIGNAL);
+          } else if (!restartRequested) {
+            logWatcher("Restart already handled by exit handler; skipping duplicate kill.", deps);
+          }
+        };
+        // oxlint-disable-next-line typescript/use-unknown-in-catch-callback-variable
+        pollBuildReady().catch((err) => {
+          restartRequested = false;
+          logWatcher(`Error polling build readiness: ${err?.message ?? String(err)}`, deps);
+        });
+        return;
+      }
+
       if (typeof watchProcess.kill === "function") {
         signalWatchProcess(watchProcess, WATCH_RESTART_SIGNAL);
       }

--- a/scripts/watch-node.mjs
+++ b/scripts/watch-node.mjs
@@ -1,21 +1,14 @@
 #!/usr/bin/env node
 // Watches dev source paths and restarts scripts/run-node.mjs when relevant
 // files change.
-import { spawn, spawnSync } from "node:child_process";
+import { spawn } from "node:child_process";
 import { createHash } from "node:crypto";
 import fs from "node:fs";
 import path from "node:path";
 import process from "node:process";
 import { pathToFileURL } from "node:url";
-import { BUILD_STAMP_FILE, RUNTIME_POSTBUILD_STAMP_FILE } from "./lib/local-build-metadata.mjs";
 import { sleep } from "./lib/sleep.mjs";
-import {
-  isRestartRelevantRunNodePath,
-  runNodeConfigFiles,
-  runNodeSourceRoots,
-  runNodeWatchedPaths,
-} from "./run-node-watch-paths.mjs";
-import { resolveBuildRequirement, resolveRuntimePostBuildRequirement } from "./run-node.mjs";
+import { isRestartRelevantRunNodePath, runNodeWatchedPaths } from "./run-node-watch-paths.mjs";
 
 const WATCH_NODE_RUNNER = "scripts/run-node.mjs";
 const WATCH_RESTART_SIGNAL = "SIGTERM";
@@ -26,8 +19,8 @@ const WATCH_LOCK_WAIT_MS = 5_000;
 const WATCH_LOCK_POLL_MS = 100;
 const WATCH_SHUTDOWN_KILL_GRACE_MS = 5_000;
 const WATCH_LOCK_DIR = path.join(".local", "watch-node");
-const WATCH_BUILD_READY_POLL_MS = 200;
-const WATCH_BUILD_READY_TIMEOUT_MS = 5 * 60 * 1000;
+const WATCH_DIST_ENTRY_POLL_MS = 1_000;
+const WATCH_DIST_ENTRY_TIMEOUT_MS = 5 * 60 * 1_000;
 const AUTO_DOCTOR_DISABLE_VALUES = new Set(["0", "false", "no", "off"]);
 // The source watcher cannot import the TypeScript owner; keep this literal
 // aligned with src/commands/doctor-invocation.ts.
@@ -36,72 +29,6 @@ const DOCTOR_DISABLE_CROSS_STATE_DIR_IMPORTS_ENV =
 
 const buildRunnerArgs = (args) => [WATCH_NODE_RUNNER, ...args];
 const buildDoctorRunnerArgs = () => [WATCH_NODE_RUNNER, "doctor", "--fix", "--non-interactive"];
-
-/**
- * Reason codes from resolveBuildRequirement / resolveRuntimePostBuildRequirement
- * that indicate the dist/ is physically broken — the child process cannot start.
- * Soft-staleness reasons (source_mtime_newer, git_head_changed, dirty_watched_tree,
- * config_newer, build_stamp_missing_head, build_stamp_newer, etc.) are handled by
- * run-node rebuilding on the next start, so the guard does NOT defer on them.
- */
-const HARD_BUILD_FAILURES = new Set([
-  "missing_dist_entry",
-  "missing_bundled_plugin_dist_entry",
-  "missing_private_qa_dist",
-]);
-
-const HARD_RUNTIME_FAILURES = new Set(["missing_runtime_postbuild_output"]);
-
-/**
- * Checks if the build output is ready for restart by delegating to run-node's
- * canonical readiness contract. Only defers on hard failures where the child
- * process physically cannot start (missing files). Soft staleness (source drift,
- * git HEAD change, dirty tree) is handled by run-node rebuilding on start.
- */
-const isBuildReadyForRestart = (cwd, env, fsImpl = fs) => {
-  try {
-    const distRoot = path.join(cwd, "dist");
-    const distEntry = path.join(distRoot, "entry.js");
-    const buildDeps = {
-      cwd,
-      fs: fsImpl,
-      spawnSync,
-      env,
-      distRoot,
-      distEntry,
-      buildStampPath: path.join(distRoot, BUILD_STAMP_FILE),
-      runtimePostBuildStampPath: path.join(distRoot, RUNTIME_POSTBUILD_STAMP_FILE),
-      sourceRoots: runNodeSourceRoots.map((name) => ({
-        name,
-        path: path.join(cwd, name),
-      })),
-      configFiles: runNodeConfigFiles.map((filePath) => path.join(cwd, filePath)),
-    };
-    const buildReq = resolveBuildRequirement(buildDeps);
-    if (buildReq.shouldBuild) {
-      if (HARD_BUILD_FAILURES.has(buildReq.reason)) {
-        return false;
-      }
-      // resolveBuildRequirement checks missing_build_stamp before
-      // missing_dist_entry. When both stamp and entry are absent the
-      // reason is missing_build_stamp (soft) even though the entry is
-      // also gone (hard failure). Verify entry existence directly.
-      if (buildReq.reason === "missing_build_stamp") {
-        try {
-          if (!fsImpl.existsSync(distEntry)) {
-            return false;
-          }
-        } catch {
-          return false;
-        }
-      }
-    }
-    const runtimeReq = resolveRuntimePostBuildRequirement(buildDeps);
-    return !(runtimeReq.shouldSync && HARD_RUNTIME_FAILURES.has(runtimeReq.reason));
-  } catch {
-    return false;
-  }
-};
 
 const normalizePath = (filePath) =>
   String(filePath ?? "")
@@ -325,6 +252,7 @@ const releaseWatchLock = (lockHandle) => {
  *   cwd?: string;
  *   args?: string[];
  *   env?: NodeJS.ProcessEnv;
+ *   fs?: Pick<typeof fs, "existsSync">;
  *   now?: () => number;
  *   sleep?: (ms: number) => Promise<void>;
  *   signalProcess?: (pid: number, signal: string | number) => void;
@@ -372,6 +300,7 @@ export async function runWatchMain(params = {}) {
     let settled = false;
     let shuttingDown = false;
     let restartRequested = false;
+    let deferredRestartGeneration = 0;
     let deferredRestartActive = false;
     let watchProcess = null;
     let watcher = null;
@@ -477,31 +406,26 @@ export async function runWatchMain(params = {}) {
         if (restartRequested || shouldRestartAfterChildExit(exitCode, exitSignal)) {
           forceKillWatchProcessGroup(exitedProcess);
           restartRequested = false;
-          // #99603: when the child exited during a deferred restart (build
-          // not ready), wait for build readiness instead of restarting
-          // immediately into a potentially broken dist.
-          // Skip in test mode to preserve existing test behavior.
-          const isTestMode = deps.env.OPENCLAW_WATCH_MODE === "test";
-          if (!isTestMode && !isBuildReadyForRestart(deps.cwd, deps.env, deps.fs)) {
-            logWatcher(
-              "Child exited during deferred restart but build output is not ready; waiting.",
-              deps,
-            );
-            deferUntilBuildReady(
-              () => {
-                logWatcher("Build output ready after child exit; restarting.", deps);
-                startRunner();
+          deferredRestartGeneration += 1;
+          deferredRestartActive = false;
+          if (!hasDistEntry()) {
+            deferredRestartActive = true;
+            const generation = deferredRestartGeneration;
+            logWatcher("Watcher child exited mid-build; waiting for the build entry.", deps);
+            deferRestartUntilDistEntryExists({
+              generation,
+              targetProcess: null,
+              onReady: () => {
+                if (!watchProcess) {
+                  startRunner();
+                }
               },
-              () => {
-                logWatcher(
-                  `Build output still not ready after ${WATCH_BUILD_READY_TIMEOUT_MS}ms ` +
-                    "after child exit; restarting anyway (bounded recovery).",
-                  deps,
-                );
-                startRunner();
+              onTimeout: () => {
+                logWatcher("Build entry wait timed out; starting run-node recovery.", deps);
+                if (!watchProcess) {
+                  startRunner();
+                }
               },
-            ).catch(() => {
-              startRunner();
             });
             return;
           }
@@ -594,20 +518,46 @@ export async function runWatchMain(params = {}) {
       });
     };
 
-    // Shared readiness polling loop for both the requestRestart and
-    // child-exit deferral paths. Calls onReady when the build is ready,
-    // onTimeout after WATCH_BUILD_READY_TIMEOUT_MS. Errors fall through
-    // to the caller's catch handler.
-    const deferUntilBuildReady = async (onReady, onTimeout) => {
-      const startedAt = deps.now();
-      while (!isBuildReadyForRestart(deps.cwd, deps.env, deps.fs)) {
-        if (deps.now() - startedAt > WATCH_BUILD_READY_TIMEOUT_MS) {
-          onTimeout();
-          return;
+    const hasDistEntry = () => deps.fs.existsSync(path.join(deps.cwd, "dist", "entry.js"));
+
+    const deferRestartUntilDistEntryExists = ({
+      generation,
+      targetProcess,
+      onReady,
+      onTimeout,
+    }) => {
+      void (async () => {
+        const deadline = deps.now() + WATCH_DIST_ENTRY_TIMEOUT_MS;
+        while (true) {
+          if (
+            generation !== deferredRestartGeneration ||
+            settled ||
+            shuttingDown ||
+            (targetProcess && (!restartRequested || watchProcess !== targetProcess))
+          ) {
+            return;
+          }
+          await deps.sleep(WATCH_DIST_ENTRY_POLL_MS);
+          if (
+            generation !== deferredRestartGeneration ||
+            settled ||
+            shuttingDown ||
+            (targetProcess && (!restartRequested || watchProcess !== targetProcess))
+          ) {
+            return;
+          }
+          if (hasDistEntry()) {
+            deferredRestartActive = false;
+            onReady();
+            return;
+          }
+          if (deps.now() >= deadline) {
+            deferredRestartActive = false;
+            onTimeout();
+            return;
+          }
         }
-        await deps.sleep(WATCH_BUILD_READY_POLL_MS);
-      }
-      onReady();
+      })();
     };
 
     const requestRestart = (changedPath) => {
@@ -615,54 +565,35 @@ export async function runWatchMain(params = {}) {
         return;
       }
       if (!watchProcess) {
+        if (deferredRestartActive) {
+          return;
+        }
         startRunner();
         return;
       }
       restartRequested = true;
 
-      // #99603 fix: Check if build output exists before restarting.
-      // If dist/entry.js is missing (mid-rebuild state), wait for it to appear
-      // before sending SIGTERM to avoid crash-loop.
-      // Skip this check in test mode to preserve existing test behavior.
-      const isTestMode = deps.env.OPENCLAW_WATCH_MODE === "test";
-      if (!isTestMode && !isBuildReadyForRestart(deps.cwd, deps.env, deps.fs)) {
-        // Single-flight: only one deferral loop runs at a time. Additional
-        // change events during deferral are coalesced into the active loop.
-        if (deferredRestartActive) {
-          return;
+      // A separate build can temporarily remove dist while this healthy child is
+      // still serving. Keep it alive until run-node can take ownership safely.
+      if (!hasDistEntry()) {
+        if (!deferredRestartActive) {
+          deferredRestartActive = true;
+          deferredRestartGeneration += 1;
+          logWatcher("Build entry missing; keeping watcher child alive until it returns.", deps);
+          const targetProcess = watchProcess;
+          deferRestartUntilDistEntryExists({
+            generation: deferredRestartGeneration,
+            targetProcess,
+            onReady: () => {
+              logWatcher("Build entry restored; restarting watcher child.", deps);
+              signalWatchProcess(targetProcess, WATCH_RESTART_SIGNAL);
+            },
+            onTimeout: () => {
+              restartRequested = false;
+              logWatcher("Build entry wait timed out; keeping the healthy watcher child.", deps);
+            },
+          });
         }
-        deferredRestartActive = true;
-        logWatcher(
-          "Build output not ready (dist/entry.js missing or stale); waiting before restart.",
-          deps,
-        );
-        const clearDeferral = () => {
-          deferredRestartActive = false;
-        };
-        deferUntilBuildReady(
-          () => {
-            clearDeferral();
-            logWatcher("Build output ready; proceeding with restart.", deps);
-            if (restartRequested && watchProcess && typeof watchProcess.kill === "function") {
-              signalWatchProcess(watchProcess, WATCH_RESTART_SIGNAL);
-            } else if (!restartRequested) {
-              logWatcher("Restart already handled by exit handler; skipping duplicate kill.", deps);
-            }
-          },
-          () => {
-            clearDeferral();
-            restartRequested = false;
-            logWatcher(
-              `Build output still not ready after ${WATCH_BUILD_READY_TIMEOUT_MS}ms; giving up. ` +
-                "The current process is still running. A future file change will retry the restart.",
-              deps,
-            );
-          },
-        ).catch(() => {
-          clearDeferral();
-          restartRequested = false;
-          logWatcher("Error polling build readiness; giving up.", deps);
-        });
         return;
       }
 

--- a/scripts/watch-node.mjs
+++ b/scripts/watch-node.mjs
@@ -372,6 +372,7 @@ export async function runWatchMain(params = {}) {
     let settled = false;
     let shuttingDown = false;
     let restartRequested = false;
+    let deferredRestartActive = false;
     let watchProcess = null;
     let watcher = null;
     let lockHandle = null;
@@ -486,24 +487,20 @@ export async function runWatchMain(params = {}) {
               "Child exited during deferred restart but build output is not ready; waiting.",
               deps,
             );
-            const startedAt = deps.now();
-            const pollAfterChildExit = async () => {
-              while (!isBuildReadyForRestart(deps.cwd, deps.env, deps.fs)) {
-                if (deps.now() - startedAt > WATCH_BUILD_READY_TIMEOUT_MS) {
-                  logWatcher(
-                    `Build output still not ready after ${WATCH_BUILD_READY_TIMEOUT_MS}ms ` +
-                      "after child exit; restarting anyway (bounded recovery).",
-                    deps,
-                  );
-                  startRunner();
-                  return;
-                }
-                await deps.sleep(WATCH_BUILD_READY_POLL_MS);
-              }
-              logWatcher("Build output ready after child exit; restarting.", deps);
-              startRunner();
-            };
-            pollAfterChildExit().catch(() => {
+            deferUntilBuildReady(
+              () => {
+                logWatcher("Build output ready after child exit; restarting.", deps);
+                startRunner();
+              },
+              () => {
+                logWatcher(
+                  `Build output still not ready after ${WATCH_BUILD_READY_TIMEOUT_MS}ms ` +
+                    "after child exit; restarting anyway (bounded recovery).",
+                  deps,
+                );
+                startRunner();
+              },
+            ).catch(() => {
               startRunner();
             });
             return;
@@ -597,6 +594,22 @@ export async function runWatchMain(params = {}) {
       });
     };
 
+    // Shared readiness polling loop for both the requestRestart and
+    // child-exit deferral paths. Calls onReady when the build is ready,
+    // onTimeout after WATCH_BUILD_READY_TIMEOUT_MS. Errors fall through
+    // to the caller's catch handler.
+    const deferUntilBuildReady = async (onReady, onTimeout) => {
+      const startedAt = deps.now();
+      while (!isBuildReadyForRestart(deps.cwd, deps.env, deps.fs)) {
+        if (deps.now() - startedAt > WATCH_BUILD_READY_TIMEOUT_MS) {
+          onTimeout();
+          return;
+        }
+        await deps.sleep(WATCH_BUILD_READY_POLL_MS);
+      }
+      onReady();
+    };
+
     const requestRestart = (changedPath) => {
       if (shuttingDown || isIgnoredWatchPath(changedPath, deps.cwd, deps.watchPaths)) {
         return;
@@ -613,41 +626,42 @@ export async function runWatchMain(params = {}) {
       // Skip this check in test mode to preserve existing test behavior.
       const isTestMode = deps.env.OPENCLAW_WATCH_MODE === "test";
       if (!isTestMode && !isBuildReadyForRestart(deps.cwd, deps.env, deps.fs)) {
+        // Single-flight: only one deferral loop runs at a time. Additional
+        // change events during deferral are coalesced into the active loop.
+        if (deferredRestartActive) {
+          return;
+        }
+        deferredRestartActive = true;
         logWatcher(
           "Build output not ready (dist/entry.js missing or stale); waiting before restart.",
           deps,
         );
-        // Poll until build is ready, then restart. Times out after
-        // WATCH_BUILD_READY_TIMEOUT_MS to avoid polling forever when the build
-        // never completes (e.g. build error); the current process keeps running.
-        const startedAt = deps.now();
-        const pollBuildReady = async () => {
-          while (!isBuildReadyForRestart(deps.cwd, deps.env, deps.fs)) {
-            if (deps.now() - startedAt > WATCH_BUILD_READY_TIMEOUT_MS) {
-              restartRequested = false;
-              logWatcher(
-                `Build output still not ready after ${WATCH_BUILD_READY_TIMEOUT_MS}ms; giving up. ` +
-                  "The current process is still running. A future file change will retry the restart.",
-                deps,
-              );
-              return;
-            }
-            await deps.sleep(WATCH_BUILD_READY_POLL_MS);
-          }
-          logWatcher("Build output ready; proceeding with restart.", deps);
-          // Only kill if we are still the active restart request. If the
-          // child exited on its own during deferral, the exit handler will
-          // have reset restartRequested and started a new child already.
-          if (restartRequested && watchProcess && typeof watchProcess.kill === "function") {
-            signalWatchProcess(watchProcess, WATCH_RESTART_SIGNAL);
-          } else if (!restartRequested) {
-            logWatcher("Restart already handled by exit handler; skipping duplicate kill.", deps);
-          }
+        const clearDeferral = () => {
+          deferredRestartActive = false;
         };
-        // oxlint-disable-next-line typescript/use-unknown-in-catch-callback-variable
-        pollBuildReady().catch((err) => {
+        deferUntilBuildReady(
+          () => {
+            clearDeferral();
+            logWatcher("Build output ready; proceeding with restart.", deps);
+            if (restartRequested && watchProcess && typeof watchProcess.kill === "function") {
+              signalWatchProcess(watchProcess, WATCH_RESTART_SIGNAL);
+            } else if (!restartRequested) {
+              logWatcher("Restart already handled by exit handler; skipping duplicate kill.", deps);
+            }
+          },
+          () => {
+            clearDeferral();
+            restartRequested = false;
+            logWatcher(
+              `Build output still not ready after ${WATCH_BUILD_READY_TIMEOUT_MS}ms; giving up. ` +
+                "The current process is still running. A future file change will retry the restart.",
+              deps,
+            );
+          },
+        ).catch(() => {
+          clearDeferral();
           restartRequested = false;
-          logWatcher(`Error polling build readiness: ${err?.message ?? String(err)}`, deps);
+          logWatcher("Error polling build readiness; giving up.", deps);
         });
         return;
       }

--- a/src/infra/scripts-modules.d.ts
+++ b/src/infra/scripts-modules.d.ts
@@ -12,6 +12,7 @@ declare module "../../scripts/watch-node.mjs" {
     cwd?: string;
     args?: string[];
     env?: NodeJS.ProcessEnv;
+    fs?: { existsSync: (path: string) => boolean };
     now?: () => number;
     sleep?: (ms: number) => Promise<void>;
     signalProcess?: (pid: number, signal: NodeJS.Signals | 0) => void;

--- a/src/infra/watch-node.test.ts
+++ b/src/infra/watch-node.test.ts
@@ -4,10 +4,23 @@ import { EventEmitter } from "node:events";
 import fs from "node:fs";
 import path from "node:path";
 import { bundledPluginFile } from "openclaw/plugin-sdk/test-fixtures";
-import { describe, expect, it, vi } from "vitest";
-import { runNodeWatchedPaths } from "../../scripts/run-node.mjs";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  resolveBuildRequirement,
+  resolveRuntimePostBuildRequirement,
+  runNodeWatchedPaths,
+} from "../../scripts/run-node.mjs";
 import { runWatchMain } from "../../scripts/watch-node.mjs";
 import { withTempDir } from "../test-helpers/temp-dir.js";
+
+vi.mock("../../scripts/run-node.mjs", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../scripts/run-node.mjs")>();
+  return {
+    ...actual,
+    resolveBuildRequirement: vi.fn(() => ({ shouldBuild: false, reason: "clean" })),
+    resolveRuntimePostBuildRequirement: vi.fn(() => ({ shouldSync: false, reason: "clean" })),
+  };
+});
 
 const VOICE_CALL_README = bundledPluginFile("voice-call", "README.md");
 const VOICE_CALL_MANIFEST = bundledPluginFile("voice-call", "openclaw.plugin.json");
@@ -84,7 +97,8 @@ const startWatchRun = ({
   const runPromise = runWatch({
     args,
     createWatcher,
-    env,
+    // Default to test mode to skip dist/entry.js checks in tests
+    env: env ? { ...env, OPENCLAW_WATCH_MODE: "test" } : { OPENCLAW_WATCH_MODE: "test" },
     lockDisabled: true,
     process: fakeProcess,
     spawn,
@@ -610,6 +624,385 @@ describe("watch-node script", () => {
     } finally {
       errorSpy.mockRestore();
     }
+  });
+
+  describe("build readiness guard (#99603)", () => {
+    function fakeProcessWithStderr() {
+      const proc = createFakeProcess();
+      const stderrWrite = vi.fn();
+      Object.defineProperty(proc, "stderr", {
+        value: { write: stderrWrite, isTTY: false },
+        writable: true,
+        configurable: true,
+      });
+      return { proc, stderrWrite };
+    }
+
+    const mockResolveBuild = vi.mocked(resolveBuildRequirement);
+    const mockResolveRuntime = vi.mocked(resolveRuntimePostBuildRequirement);
+
+    beforeEach(() => {
+      mockResolveBuild.mockReturnValue({ shouldBuild: false, reason: "clean" });
+      mockResolveRuntime.mockReturnValue({ shouldSync: false, reason: "clean" });
+    });
+
+    afterEach(() => {
+      vi.clearAllMocks();
+    });
+
+    // Hard failures: dist/ is physically broken, child CANNOT start → defer.
+    const HARD_FAILURES = [
+      "missing_dist_entry",
+      "missing_bundled_plugin_dist_entry",
+      "missing_private_qa_dist",
+    ] as const;
+
+    // Soft staleness: dist/ exists but is stale, run-node will rebuild → allow restart.
+    // Soft staleness: dist/ exists but is stale, run-node will rebuild → allow restart.
+    // Includes missing_build_stamp: usable dist/entry.js exists, stamp is metadata only.
+    // Soft staleness: dist/ exists but is stale, run-node will rebuild → allow restart.
+    const SOFT_STALENESS = [
+      "missing_build_stamp",
+      "git_head_changed",
+      "dirty_watched_tree",
+      "config_newer",
+      "build_stamp_missing_head",
+      "source_mtime_newer",
+    ] as const;
+
+    for (const reason of HARD_FAILURES) {
+      it(`defers restart on hard failure: ${reason}`, async () => {
+        const { child, spawn, watcher, createWatcher } = createWatchHarness();
+        const { proc: fakeProcess, stderrWrite } = fakeProcessWithStderr();
+
+        mockResolveBuild.mockReturnValue({ shouldBuild: true, reason });
+        mockResolveRuntime.mockReturnValue({ shouldSync: false, reason: "clean" });
+
+        const runPromise = runWatch({
+          args: ["gateway", "--force"],
+          cwd: "/repo/openclaw",
+          createWatcher,
+          env: { PATH: "/usr/bin" },
+          lockDisabled: true,
+          process: fakeProcess,
+          spawn,
+        } as WatchRunParams);
+
+        watcher.emit("change", "src/infra/something.ts");
+        await new Promise((resolve) => {
+          setImmediate(resolve);
+        });
+
+        expect(child.kill).not.toHaveBeenCalled();
+        const stderrOutput = stderrWrite.mock.calls.map((c: unknown[]) => String(c[0])).join("");
+        expect(stderrOutput).toContain("Build output not ready");
+
+        fakeProcess.emit("SIGINT");
+        await runPromise;
+        expect(watcher.close).toHaveBeenCalledTimes(1);
+      });
+    }
+
+    it("defers on runtime hard failure: missing_runtime_postbuild_output", async () => {
+      const { child, spawn, watcher, createWatcher } = createWatchHarness();
+      const { proc: fakeProcess, stderrWrite } = fakeProcessWithStderr();
+
+      mockResolveBuild.mockReturnValue({ shouldBuild: false, reason: "clean" });
+      mockResolveRuntime.mockReturnValue({
+        shouldSync: true,
+        reason: "missing_runtime_postbuild_output",
+      });
+
+      const runPromise = runWatch({
+        args: ["gateway", "--force"],
+        cwd: "/repo/openclaw",
+        createWatcher,
+        env: { PATH: "/usr/bin" },
+        lockDisabled: true,
+        process: fakeProcess,
+        spawn,
+      } as WatchRunParams);
+
+      watcher.emit("change", "src/infra/something.ts");
+      await new Promise((resolve) => {
+        setImmediate(resolve);
+      });
+
+      expect(child.kill).not.toHaveBeenCalled();
+      expect(stderrWrite.mock.calls.map((c: unknown[]) => String(c[0])).join("")).toContain(
+        "Build output not ready",
+      );
+
+      fakeProcess.emit("SIGINT");
+      await runPromise;
+    });
+
+    for (const reason of SOFT_STALENESS) {
+      it(`allows restart on soft staleness: ${reason} (run-node will rebuild)`, async () => {
+        const childA = createKillableChild();
+        const childB = createKillableChild();
+        const spawn = vi.fn().mockReturnValueOnce(childA).mockReturnValueOnce(childB);
+        const watcher = Object.assign(new EventEmitter(), {
+          close: vi.fn(async () => {}),
+        });
+        const createWatcher = vi.fn(() => watcher);
+        const fakeProcess = createFakeProcess();
+
+        mockResolveBuild.mockReturnValue({ shouldBuild: true, reason });
+        mockResolveRuntime.mockReturnValue({ shouldSync: false, reason: "clean" });
+
+        // missing_build_stamp triggers a direct dist/entry.js existence check.
+        // Provide a mock fs where entry.js exists so the guard proceeds normally.
+        const extraParams: Record<string, unknown> = {};
+        if (reason === "missing_build_stamp") {
+          const distEntry = path.join("/repo/openclaw", "dist", "entry.js");
+          extraParams.fs = {
+            existsSync: vi.fn((filePath: string) => filePath === distEntry),
+          } as unknown as typeof fs;
+        }
+
+        const runPromise = runWatch({
+          args: ["gateway", "--force"],
+          cwd: "/repo/openclaw",
+          createWatcher,
+          env: { PATH: "/usr/bin" },
+          lockDisabled: true,
+          process: fakeProcess,
+          spawn,
+          ...extraParams,
+        } as WatchRunParams);
+
+        watcher.emit("change", "src/infra/something.ts");
+        await new Promise((resolve) => {
+          setImmediate(resolve);
+        });
+
+        // Soft staleness → guard does NOT defer → child IS killed
+        expect(childA.kill).toHaveBeenCalledWith("SIGTERM");
+        expect(spawn).toHaveBeenCalledTimes(2);
+
+        fakeProcess.emit("SIGINT");
+        await runPromise;
+        expect(watcher.close).toHaveBeenCalledTimes(1);
+      });
+    }
+
+    it("defers when both stamp and entry are missing (masked missing_dist_entry)", async () => {
+      const { child, spawn, watcher, createWatcher } = createWatchHarness();
+      const { proc: fakeProcess, stderrWrite } = fakeProcessWithStderr();
+
+      // resolveBuildRequirement checks missing_build_stamp before missing_dist_entry.
+      // When both are absent the reason is missing_build_stamp (soft), but dist/entry.js
+      // is also gone — the direct entry check in isBuildReadyForRestart must catch this.
+      mockResolveBuild.mockReturnValue({ shouldBuild: true, reason: "missing_build_stamp" });
+      mockResolveRuntime.mockReturnValue({ shouldSync: false, reason: "clean" });
+
+      // Simulate entry.js missing via fs mock: the direct fs.existsSync check fails
+      const distEntry = path.join("/repo/openclaw", "dist", "entry.js");
+      const mockFs = {
+        existsSync: vi.fn((filePath: string) => filePath !== distEntry),
+      };
+
+      const runPromise = runWatch({
+        args: ["gateway", "--force"],
+        cwd: "/repo/openclaw",
+        createWatcher,
+        env: { PATH: "/usr/bin" },
+        fs: mockFs as unknown as typeof fs,
+        lockDisabled: true,
+        process: fakeProcess,
+        spawn,
+      } as WatchRunParams);
+
+      watcher.emit("change", "src/infra/something.ts");
+      await new Promise((resolve) => {
+        setImmediate(resolve);
+      });
+
+      // Both missing → hard failure → defer, child NOT killed
+      expect(child.kill).not.toHaveBeenCalled();
+      const stderrOutput = stderrWrite.mock.calls.map((c: unknown[]) => String(c[0])).join("");
+      expect(stderrOutput).toContain("Build output not ready");
+
+      fakeProcess.emit("SIGINT");
+      await runPromise;
+      expect(watcher.close).toHaveBeenCalledTimes(1);
+    });
+    it("kills child normally when full readiness contract passes", async () => {
+      const childA = createKillableChild();
+      const childB = createKillableChild();
+      const spawn = vi.fn().mockReturnValueOnce(childA).mockReturnValueOnce(childB);
+      const watcher = Object.assign(new EventEmitter(), {
+        close: vi.fn(async () => {}),
+      });
+      const createWatcher = vi.fn(() => watcher);
+      const fakeProcess = createFakeProcess();
+
+      mockResolveBuild.mockReturnValue({ shouldBuild: false, reason: "clean" });
+      mockResolveRuntime.mockReturnValue({ shouldSync: false, reason: "clean" });
+
+      const runPromise = runWatch({
+        args: ["gateway", "--force"],
+        cwd: "/repo/openclaw",
+        createWatcher,
+        env: { PATH: "/usr/bin" },
+        lockDisabled: true,
+        process: fakeProcess,
+        spawn,
+      } as WatchRunParams);
+
+      watcher.emit("change", "src/infra/something.ts");
+      await new Promise((resolve) => {
+        setImmediate(resolve);
+      });
+
+      expect(childA.kill).toHaveBeenCalledWith("SIGTERM");
+      expect(spawn).toHaveBeenCalledTimes(2);
+
+      fakeProcess.emit("SIGINT");
+      await runPromise;
+      expect(watcher.close).toHaveBeenCalledTimes(1);
+    });
+
+    it("gives up after timeout when hard failure never recovers", async () => {
+      const { child, spawn, watcher, createWatcher } = createWatchHarness();
+      const { proc: fakeProcess, stderrWrite } = fakeProcessWithStderr();
+
+      mockResolveBuild.mockReturnValue({ shouldBuild: true, reason: "missing_dist_entry" });
+      mockResolveRuntime.mockReturnValue({ shouldSync: false, reason: "clean" });
+
+      let currentTime = 0;
+      const mockNow = vi.fn(() => currentTime);
+      const mockSleep = vi.fn(async (ms: number) => {
+        currentTime += ms;
+      });
+
+      const runPromise = runWatch({
+        args: ["gateway", "--force"],
+        cwd: "/repo/openclaw",
+        createWatcher,
+        env: { PATH: "/usr/bin" },
+        lockDisabled: true,
+        now: mockNow,
+        process: fakeProcess,
+        sleep: mockSleep,
+        spawn,
+      } as WatchRunParams);
+
+      watcher.emit("change", "src/infra/something.ts");
+      await new Promise((resolve) => {
+        setImmediate(resolve);
+      });
+
+      expect(child.kill).not.toHaveBeenCalled();
+
+      await mockSleep(5 * 60 * 1000 + 100);
+      await new Promise((resolve) => {
+        setImmediate(resolve);
+      });
+
+      expect(child.kill).not.toHaveBeenCalled();
+      const stderrOutput = stderrWrite.mock.calls.map((c: unknown[]) => String(c[0])).join("");
+      expect(stderrOutput).toContain("giving up");
+
+      fakeProcess.emit("SIGINT");
+      await runPromise;
+      expect(watcher.close).toHaveBeenCalledTimes(1);
+    });
+
+    it("clears stale restartRequested after timeout so later child exit proceeds normally", async () => {
+      const { child, spawn, watcher, createWatcher } = createWatchHarness();
+      const { proc: fakeProcess } = fakeProcessWithStderr();
+
+      mockResolveBuild.mockReturnValue({ shouldBuild: true, reason: "missing_dist_entry" });
+      mockResolveRuntime.mockReturnValue({ shouldSync: false, reason: "clean" });
+
+      let currentTime = 0;
+      const mockNow = vi.fn(() => currentTime);
+      const mockSleep = vi.fn(async (ms: number) => {
+        currentTime += ms;
+      });
+
+      const runPromise = runWatch({
+        args: ["gateway", "--force"],
+        cwd: "/repo/openclaw",
+        createWatcher,
+        env: { PATH: "/usr/bin", OPENCLAW_GATEWAY_WATCH_AUTO_DOCTOR: "0" },
+        lockDisabled: true,
+        now: mockNow,
+        process: fakeProcess,
+        sleep: mockSleep,
+        spawn,
+      } as WatchRunParams);
+
+      // Trigger restart → hard failure → defer → poll starts, restartRequested=true
+      watcher.emit("change", "src/infra/something.ts");
+      await new Promise((resolve) => {
+        setImmediate(resolve);
+      });
+      expect(child.kill).not.toHaveBeenCalled();
+
+      // Timeout → restartRequested cleared by timeout path
+      await mockSleep(5 * 60 * 1000 + 100);
+      await new Promise((resolve) => {
+        setImmediate(resolve);
+      });
+
+      // Now mock readiness as clean so normal child exit proceeds
+      mockResolveBuild.mockReturnValue({ shouldBuild: false, reason: "clean" });
+
+      // Child exits with non-SIGTERM code (e.g. 1). If restartRequested were
+      // still stale, exit handler would enter the restart branch and call
+      // startRunner. With restartRequested cleared and auto-doctor disabled,
+      // exit handler proceeds to settle (the non-zero code is not restartable).
+      child.emit("exit", 1, null);
+      await new Promise((resolve) => {
+        setImmediate(resolve);
+      });
+
+      // Should NOT have restarted — staleness cleared, exit code 1 is not restartable
+      expect(spawn).toHaveBeenCalledTimes(1);
+
+      fakeProcess.emit("SIGINT");
+      await runPromise;
+      expect(watcher.close).toHaveBeenCalledTimes(1);
+    });
+
+    it("defers child-exit restart on hard failure", async () => {
+      const { child, spawn, watcher, createWatcher, fakeProcess } = createWatchHarness();
+
+      mockResolveBuild.mockReturnValue({ shouldBuild: true, reason: "missing_dist_entry" });
+      mockResolveRuntime.mockReturnValue({ shouldSync: false, reason: "clean" });
+
+      const runPromise = runWatch({
+        args: ["gateway", "--force"],
+        createWatcher,
+        env: { PATH: "/usr/bin" },
+        lockDisabled: true,
+        process: fakeProcess,
+        spawn,
+      } as WatchRunParams);
+
+      child.emit("exit", 143, null);
+      await new Promise((resolve) => {
+        setImmediate(resolve);
+      });
+
+      // Hard failure → guard deferred
+      expect(spawn).toHaveBeenCalledTimes(1);
+
+      // Now recovery: readiness passes
+      mockResolveBuild.mockReturnValue({ shouldBuild: false, reason: "clean" });
+      await new Promise((resolve) => {
+        setTimeout(resolve, 500);
+      });
+
+      expect(spawn).toHaveBeenCalledTimes(2);
+
+      fakeProcess.emit("SIGINT");
+      await runPromise;
+      expect(watcher.close).toHaveBeenCalledTimes(1);
+    });
   });
 
   it("replaces an existing watcher lock holder before starting", async () => {

--- a/src/infra/watch-node.test.ts
+++ b/src/infra/watch-node.test.ts
@@ -4,23 +4,10 @@ import { EventEmitter } from "node:events";
 import fs from "node:fs";
 import path from "node:path";
 import { bundledPluginFile } from "openclaw/plugin-sdk/test-fixtures";
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import {
-  resolveBuildRequirement,
-  resolveRuntimePostBuildRequirement,
-  runNodeWatchedPaths,
-} from "../../scripts/run-node.mjs";
+import { describe, expect, it, vi } from "vitest";
+import { runNodeWatchedPaths } from "../../scripts/run-node.mjs";
 import { runWatchMain } from "../../scripts/watch-node.mjs";
 import { withTempDir } from "../test-helpers/temp-dir.js";
-
-vi.mock("../../scripts/run-node.mjs", async (importOriginal) => {
-  const actual = await importOriginal<typeof import("../../scripts/run-node.mjs")>();
-  return {
-    ...actual,
-    resolveBuildRequirement: vi.fn(() => ({ shouldBuild: false, reason: "clean" })),
-    resolveRuntimePostBuildRequirement: vi.fn(() => ({ shouldSync: false, reason: "clean" })),
-  };
-});
 
 const VOICE_CALL_README = bundledPluginFile("voice-call", "README.md");
 const VOICE_CALL_MANIFEST = bundledPluginFile("voice-call", "openclaw.plugin.json");
@@ -28,6 +15,7 @@ const VOICE_CALL_PACKAGE = bundledPluginFile("voice-call", "package.json");
 const VOICE_CALL_INDEX = bundledPluginFile("voice-call", "index.ts");
 const VOICE_CALL_RUNTIME = bundledPluginFile("voice-call", "src/runtime.ts");
 type WatchRunParams = NonNullable<Parameters<typeof runWatchMain>[0]> & {
+  fs?: { existsSync: (path: string) => boolean };
   lockDisabled?: boolean;
   signalProcess?: (pid: number, signal: NodeJS.Signals | 0) => void;
   sleep?: (ms: number) => Promise<void>;
@@ -97,8 +85,8 @@ const startWatchRun = ({
   const runPromise = runWatch({
     args,
     createWatcher,
-    // Default to test mode to skip dist/entry.js checks in tests
-    env: env ? { ...env, OPENCLAW_WATCH_MODE: "test" } : { OPENCLAW_WATCH_MODE: "test" },
+    env,
+    fs: { existsSync: () => true },
     lockDisabled: true,
     process: fakeProcess,
     spawn,
@@ -534,6 +522,121 @@ describe("watch-node script", () => {
     expect(exitCode).toBe(130);
   });
 
+  it("keeps the healthy child alive until a concurrently rebuilt dist entry returns", async () => {
+    const childA = createKillableChild();
+    const childB = createKillableChild();
+    const spawn = vi.fn().mockReturnValueOnce(childA).mockReturnValueOnce(childB);
+    const watcher = Object.assign(new EventEmitter(), {
+      close: vi.fn(async () => {}),
+    });
+    const fakeProcess = createFakeProcess();
+    let distEntryExists = false;
+    let resumePoll: (() => void) | undefined;
+    const sleep = vi.fn(
+      () =>
+        new Promise<void>((resolve) => {
+          resumePoll = resolve;
+        }),
+    );
+    const runPromise = runWatch({
+      args: ["gateway", "--force"],
+      createWatcher: () => watcher,
+      fs: { existsSync: () => distEntryExists },
+      lockDisabled: true,
+      process: fakeProcess,
+      sleep,
+      spawn,
+    });
+
+    watcher.emit("change", "src/infra/restart.ts");
+    watcher.emit("change", "src/infra/restart.ts");
+    expect(childA.kill).not.toHaveBeenCalled();
+    expect(sleep).toHaveBeenCalledTimes(1);
+
+    distEntryExists = true;
+    resumePoll?.();
+    await new Promise<void>((resolve) => {
+      setImmediate(resolve);
+    });
+    expect(childA.kill).toHaveBeenCalledWith("SIGTERM");
+    expect(spawn).toHaveBeenCalledTimes(2);
+
+    fakeProcess.emit("SIGINT");
+    expect(await runPromise).toBe(130);
+  });
+
+  it("does not resurrect a deferred child after watcher shutdown", async () => {
+    const child = createKillableChild();
+    const spawn = vi.fn(() => child);
+    const watcher = Object.assign(new EventEmitter(), {
+      close: vi.fn(async () => {}),
+    });
+    const fakeProcess = createFakeProcess();
+    let resumePoll: (() => void) | undefined;
+    const runPromise = runWatch({
+      args: ["gateway", "--force"],
+      createWatcher: () => watcher,
+      fs: { existsSync: () => false },
+      lockDisabled: true,
+      process: fakeProcess,
+      sleep: () =>
+        new Promise<void>((resolve) => {
+          resumePoll = resolve;
+        }),
+      spawn,
+    });
+
+    watcher.emit("change", "src/infra/restart.ts");
+    fakeProcess.emit("SIGINT");
+    expect(await runPromise).toBe(130);
+    resumePoll?.();
+    await new Promise<void>((resolve) => {
+      setImmediate(resolve);
+    });
+    expect(spawn).toHaveBeenCalledTimes(1);
+  });
+
+  it("waits for the build entry when the healthy child exits during deferral", async () => {
+    const childA = Object.assign(new EventEmitter(), { kill: vi.fn() });
+    const childB = createKillableChild();
+    const spawn = vi.fn().mockReturnValueOnce(childA).mockReturnValueOnce(childB);
+    const watcher = Object.assign(new EventEmitter(), {
+      close: vi.fn(async () => {}),
+    });
+    const fakeProcess = createFakeProcess();
+    let distEntryExists = false;
+    const resumePolls: Array<() => void> = [];
+    const runPromise = runWatch({
+      args: ["gateway", "--force"],
+      createWatcher: () => watcher,
+      fs: { existsSync: () => distEntryExists },
+      lockDisabled: true,
+      process: fakeProcess,
+      sleep: () =>
+        new Promise<void>((resolve) => {
+          resumePolls.push(resolve);
+        }),
+      spawn,
+    });
+
+    watcher.emit("change", "src/infra/restart.ts");
+    childA.emit("exit", 1, null);
+    watcher.emit("change", "src/infra/restart.ts");
+    expect(spawn).toHaveBeenCalledTimes(1);
+
+    distEntryExists = true;
+    for (const resume of resumePolls) {
+      resume();
+    }
+    await new Promise<void>((resolve) => {
+      setImmediate(resolve);
+    });
+    expect(spawn).toHaveBeenCalledTimes(2);
+
+    fakeProcess.emit("SIGINT");
+    expect(await runPromise).toBe(130);
+  });
+
   it("kills child and exits when watcher emits an error", async () => {
     const { child, spawn, watcher, createWatcher, fakeProcess } = createWatchHarness();
 
@@ -624,472 +727,6 @@ describe("watch-node script", () => {
     } finally {
       errorSpy.mockRestore();
     }
-  });
-
-  describe("build readiness guard (#99603)", () => {
-    function fakeProcessWithStderr() {
-      const proc = createFakeProcess();
-      const stderrWrite = vi.fn();
-      Object.defineProperty(proc, "stderr", {
-        value: { write: stderrWrite, isTTY: false },
-        writable: true,
-        configurable: true,
-      });
-      return { proc, stderrWrite };
-    }
-
-    const mockResolveBuild = vi.mocked(resolveBuildRequirement);
-    const mockResolveRuntime = vi.mocked(resolveRuntimePostBuildRequirement);
-
-    beforeEach(() => {
-      mockResolveBuild.mockReturnValue({ shouldBuild: false, reason: "clean" });
-      mockResolveRuntime.mockReturnValue({ shouldSync: false, reason: "clean" });
-    });
-
-    afterEach(() => {
-      vi.clearAllMocks();
-    });
-
-    // Hard failures: dist/ is physically broken, child CANNOT start → defer.
-    const HARD_FAILURES = [
-      "missing_dist_entry",
-      "missing_bundled_plugin_dist_entry",
-      "missing_private_qa_dist",
-    ] as const;
-
-    // Soft staleness: dist/ exists but is stale, run-node will rebuild → allow restart.
-    // Soft staleness: dist/ exists but is stale, run-node will rebuild → allow restart.
-    // Includes missing_build_stamp: usable dist/entry.js exists, stamp is metadata only.
-    // Soft staleness: dist/ exists but is stale, run-node will rebuild → allow restart.
-    const SOFT_STALENESS = [
-      "missing_build_stamp",
-      "git_head_changed",
-      "dirty_watched_tree",
-      "config_newer",
-      "build_stamp_missing_head",
-      "source_mtime_newer",
-    ] as const;
-
-    for (const reason of HARD_FAILURES) {
-      it(`defers restart on hard failure: ${reason}`, async () => {
-        const { child, spawn, watcher, createWatcher } = createWatchHarness();
-        const { proc: fakeProcess, stderrWrite } = fakeProcessWithStderr();
-
-        mockResolveBuild.mockReturnValue({ shouldBuild: true, reason });
-        mockResolveRuntime.mockReturnValue({ shouldSync: false, reason: "clean" });
-
-        const runPromise = runWatch({
-          args: ["gateway", "--force"],
-          cwd: "/repo/openclaw",
-          createWatcher,
-          env: { PATH: "/usr/bin" },
-          lockDisabled: true,
-          process: fakeProcess,
-          spawn,
-        } as WatchRunParams);
-
-        watcher.emit("change", "src/infra/something.ts");
-        await new Promise((resolve) => {
-          setImmediate(resolve);
-        });
-
-        expect(child.kill).not.toHaveBeenCalled();
-        const stderrOutput = stderrWrite.mock.calls.map((c: unknown[]) => String(c[0])).join("");
-        expect(stderrOutput).toContain("Build output not ready");
-
-        fakeProcess.emit("SIGINT");
-        await runPromise;
-        expect(watcher.close).toHaveBeenCalledTimes(1);
-      });
-    }
-
-    it("defers on runtime hard failure: missing_runtime_postbuild_output", async () => {
-      const { child, spawn, watcher, createWatcher } = createWatchHarness();
-      const { proc: fakeProcess, stderrWrite } = fakeProcessWithStderr();
-
-      mockResolveBuild.mockReturnValue({ shouldBuild: false, reason: "clean" });
-      mockResolveRuntime.mockReturnValue({
-        shouldSync: true,
-        reason: "missing_runtime_postbuild_output",
-      });
-
-      const runPromise = runWatch({
-        args: ["gateway", "--force"],
-        cwd: "/repo/openclaw",
-        createWatcher,
-        env: { PATH: "/usr/bin" },
-        lockDisabled: true,
-        process: fakeProcess,
-        spawn,
-      } as WatchRunParams);
-
-      watcher.emit("change", "src/infra/something.ts");
-      await new Promise((resolve) => {
-        setImmediate(resolve);
-      });
-
-      expect(child.kill).not.toHaveBeenCalled();
-      expect(stderrWrite.mock.calls.map((c: unknown[]) => String(c[0])).join("")).toContain(
-        "Build output not ready",
-      );
-
-      fakeProcess.emit("SIGINT");
-      await runPromise;
-    });
-
-    for (const reason of SOFT_STALENESS) {
-      it(`allows restart on soft staleness: ${reason} (run-node will rebuild)`, async () => {
-        const childA = createKillableChild();
-        const childB = createKillableChild();
-        const spawn = vi.fn().mockReturnValueOnce(childA).mockReturnValueOnce(childB);
-        const watcher = Object.assign(new EventEmitter(), {
-          close: vi.fn(async () => {}),
-        });
-        const createWatcher = vi.fn(() => watcher);
-        const fakeProcess = createFakeProcess();
-
-        mockResolveBuild.mockReturnValue({ shouldBuild: true, reason });
-        mockResolveRuntime.mockReturnValue({ shouldSync: false, reason: "clean" });
-
-        // missing_build_stamp triggers a direct dist/entry.js existence check.
-        // Provide a mock fs where entry.js exists so the guard proceeds normally.
-        const extraParams: Record<string, unknown> = {};
-        if (reason === "missing_build_stamp") {
-          const distEntry = path.join("/repo/openclaw", "dist", "entry.js");
-          extraParams.fs = {
-            existsSync: vi.fn((filePath: string) => filePath === distEntry),
-          } as unknown as typeof fs;
-        }
-
-        const runPromise = runWatch({
-          args: ["gateway", "--force"],
-          cwd: "/repo/openclaw",
-          createWatcher,
-          env: { PATH: "/usr/bin" },
-          lockDisabled: true,
-          process: fakeProcess,
-          spawn,
-          ...extraParams,
-        } as WatchRunParams);
-
-        watcher.emit("change", "src/infra/something.ts");
-        await new Promise((resolve) => {
-          setImmediate(resolve);
-        });
-
-        // Soft staleness → guard does NOT defer → child IS killed
-        expect(childA.kill).toHaveBeenCalledWith("SIGTERM");
-        expect(spawn).toHaveBeenCalledTimes(2);
-
-        fakeProcess.emit("SIGINT");
-        await runPromise;
-        expect(watcher.close).toHaveBeenCalledTimes(1);
-      });
-    }
-
-    it("defers when both stamp and entry are missing (masked missing_dist_entry)", async () => {
-      const { child, spawn, watcher, createWatcher } = createWatchHarness();
-      const { proc: fakeProcess, stderrWrite } = fakeProcessWithStderr();
-
-      // resolveBuildRequirement checks missing_build_stamp before missing_dist_entry.
-      // When both are absent the reason is missing_build_stamp (soft), but dist/entry.js
-      // is also gone — the direct entry check in isBuildReadyForRestart must catch this.
-      mockResolveBuild.mockReturnValue({ shouldBuild: true, reason: "missing_build_stamp" });
-      mockResolveRuntime.mockReturnValue({ shouldSync: false, reason: "clean" });
-
-      // Simulate entry.js missing via fs mock: the direct fs.existsSync check fails
-      const distEntry = path.join("/repo/openclaw", "dist", "entry.js");
-      const mockFs = {
-        existsSync: vi.fn((filePath: string) => filePath !== distEntry),
-      };
-
-      const runPromise = runWatch({
-        args: ["gateway", "--force"],
-        cwd: "/repo/openclaw",
-        createWatcher,
-        env: { PATH: "/usr/bin" },
-        fs: mockFs as unknown as typeof fs,
-        lockDisabled: true,
-        process: fakeProcess,
-        spawn,
-      } as WatchRunParams);
-
-      watcher.emit("change", "src/infra/something.ts");
-      await new Promise((resolve) => {
-        setImmediate(resolve);
-      });
-
-      // Both missing → hard failure → defer, child NOT killed
-      expect(child.kill).not.toHaveBeenCalled();
-      const stderrOutput = stderrWrite.mock.calls.map((c: unknown[]) => String(c[0])).join("");
-      expect(stderrOutput).toContain("Build output not ready");
-
-      fakeProcess.emit("SIGINT");
-      await runPromise;
-      expect(watcher.close).toHaveBeenCalledTimes(1);
-    });
-    it("kills child normally when full readiness contract passes", async () => {
-      const childA = createKillableChild();
-      const childB = createKillableChild();
-      const spawn = vi.fn().mockReturnValueOnce(childA).mockReturnValueOnce(childB);
-      const watcher = Object.assign(new EventEmitter(), {
-        close: vi.fn(async () => {}),
-      });
-      const createWatcher = vi.fn(() => watcher);
-      const fakeProcess = createFakeProcess();
-
-      mockResolveBuild.mockReturnValue({ shouldBuild: false, reason: "clean" });
-      mockResolveRuntime.mockReturnValue({ shouldSync: false, reason: "clean" });
-
-      const runPromise = runWatch({
-        args: ["gateway", "--force"],
-        cwd: "/repo/openclaw",
-        createWatcher,
-        env: { PATH: "/usr/bin" },
-        lockDisabled: true,
-        process: fakeProcess,
-        spawn,
-      } as WatchRunParams);
-
-      watcher.emit("change", "src/infra/something.ts");
-      await new Promise((resolve) => {
-        setImmediate(resolve);
-      });
-
-      expect(childA.kill).toHaveBeenCalledWith("SIGTERM");
-      expect(spawn).toHaveBeenCalledTimes(2);
-
-      fakeProcess.emit("SIGINT");
-      await runPromise;
-      expect(watcher.close).toHaveBeenCalledTimes(1);
-    });
-
-    it("gives up after timeout when hard failure never recovers", async () => {
-      const { child, spawn, watcher, createWatcher } = createWatchHarness();
-      const { proc: fakeProcess, stderrWrite } = fakeProcessWithStderr();
-
-      mockResolveBuild.mockReturnValue({ shouldBuild: true, reason: "missing_dist_entry" });
-      mockResolveRuntime.mockReturnValue({ shouldSync: false, reason: "clean" });
-
-      let currentTime = 0;
-      const mockNow = vi.fn(() => currentTime);
-      const mockSleep = vi.fn(async (ms: number) => {
-        currentTime += ms;
-      });
-
-      const runPromise = runWatch({
-        args: ["gateway", "--force"],
-        cwd: "/repo/openclaw",
-        createWatcher,
-        env: { PATH: "/usr/bin" },
-        lockDisabled: true,
-        now: mockNow,
-        process: fakeProcess,
-        sleep: mockSleep,
-        spawn,
-      } as WatchRunParams);
-
-      watcher.emit("change", "src/infra/something.ts");
-      await new Promise((resolve) => {
-        setImmediate(resolve);
-      });
-
-      expect(child.kill).not.toHaveBeenCalled();
-
-      await mockSleep(5 * 60 * 1000 + 100);
-      await new Promise((resolve) => {
-        setImmediate(resolve);
-      });
-
-      expect(child.kill).not.toHaveBeenCalled();
-      const stderrOutput = stderrWrite.mock.calls.map((c: unknown[]) => String(c[0])).join("");
-      expect(stderrOutput).toContain("giving up");
-
-      fakeProcess.emit("SIGINT");
-      await runPromise;
-      expect(watcher.close).toHaveBeenCalledTimes(1);
-    });
-
-    it("clears stale restartRequested after timeout so later child exit proceeds normally", async () => {
-      const { child, spawn, watcher, createWatcher } = createWatchHarness();
-      const { proc: fakeProcess } = fakeProcessWithStderr();
-
-      mockResolveBuild.mockReturnValue({ shouldBuild: true, reason: "missing_dist_entry" });
-      mockResolveRuntime.mockReturnValue({ shouldSync: false, reason: "clean" });
-
-      let currentTime = 0;
-      const mockNow = vi.fn(() => currentTime);
-      const mockSleep = vi.fn(async (ms: number) => {
-        currentTime += ms;
-      });
-
-      const runPromise = runWatch({
-        args: ["gateway", "--force"],
-        cwd: "/repo/openclaw",
-        createWatcher,
-        env: { PATH: "/usr/bin", OPENCLAW_GATEWAY_WATCH_AUTO_DOCTOR: "0" },
-        lockDisabled: true,
-        now: mockNow,
-        process: fakeProcess,
-        sleep: mockSleep,
-        spawn,
-      } as WatchRunParams);
-
-      // Trigger restart → hard failure → defer → poll starts, restartRequested=true
-      watcher.emit("change", "src/infra/something.ts");
-      await new Promise((resolve) => {
-        setImmediate(resolve);
-      });
-      expect(child.kill).not.toHaveBeenCalled();
-
-      // Timeout → restartRequested cleared by timeout path
-      await mockSleep(5 * 60 * 1000 + 100);
-      await new Promise((resolve) => {
-        setImmediate(resolve);
-      });
-
-      // Now mock readiness as clean so normal child exit proceeds
-      mockResolveBuild.mockReturnValue({ shouldBuild: false, reason: "clean" });
-
-      // Child exits with non-SIGTERM code (e.g. 1). If restartRequested were
-      // still stale, exit handler would enter the restart branch and call
-      // startRunner. With restartRequested cleared and auto-doctor disabled,
-      // exit handler proceeds to settle (the non-zero code is not restartable).
-      child.emit("exit", 1, null);
-      await new Promise((resolve) => {
-        setImmediate(resolve);
-      });
-
-      // Should NOT have restarted — staleness cleared, exit code 1 is not restartable
-      expect(spawn).toHaveBeenCalledTimes(1);
-
-      fakeProcess.emit("SIGINT");
-      await runPromise;
-      expect(watcher.close).toHaveBeenCalledTimes(1);
-    });
-
-    it("defers child-exit restart on hard failure", async () => {
-      const { child, spawn, watcher, createWatcher, fakeProcess } = createWatchHarness();
-
-      mockResolveBuild.mockReturnValue({ shouldBuild: true, reason: "missing_dist_entry" });
-      mockResolveRuntime.mockReturnValue({ shouldSync: false, reason: "clean" });
-
-      const runPromise = runWatch({
-        args: ["gateway", "--force"],
-        createWatcher,
-        env: { PATH: "/usr/bin" },
-        lockDisabled: true,
-        process: fakeProcess,
-        spawn,
-      } as WatchRunParams);
-
-      child.emit("exit", 143, null);
-      await new Promise((resolve) => {
-        setImmediate(resolve);
-      });
-
-      // Hard failure → guard deferred
-      expect(spawn).toHaveBeenCalledTimes(1);
-
-      // Now recovery: readiness passes
-      mockResolveBuild.mockReturnValue({ shouldBuild: false, reason: "clean" });
-      await new Promise((resolve) => {
-        setTimeout(resolve, 500);
-      });
-
-      expect(spawn).toHaveBeenCalledTimes(2);
-
-      fakeProcess.emit("SIGINT");
-      await runPromise;
-      expect(watcher.close).toHaveBeenCalledTimes(1);
-    });
-
-    it("coalesces multiple file changes into single deferral loop", async () => {
-      const { child, spawn, watcher, createWatcher } = createWatchHarness();
-      const { proc: fakeProcess } = fakeProcessWithStderr();
-
-      mockResolveBuild.mockReturnValue({ shouldBuild: true, reason: "missing_dist_entry" });
-      mockResolveRuntime.mockReturnValue({ shouldSync: false, reason: "clean" });
-
-      const runPromise = runWatch({
-        args: ["gateway", "--force"],
-        cwd: "/repo/openclaw",
-        createWatcher,
-        env: { PATH: "/usr/bin" },
-        lockDisabled: true,
-        process: fakeProcess,
-        spawn,
-      } as WatchRunParams);
-
-      // First change → deferral starts
-      watcher.emit("change", "src/infra/a.ts");
-      await new Promise((resolve) => {
-        setImmediate(resolve);
-      });
-      expect(child.kill).not.toHaveBeenCalled();
-
-      // Second change during deferral → single-flight guard, no new loop
-      watcher.emit("change", "src/infra/b.ts");
-      await new Promise((resolve) => {
-        setImmediate(resolve);
-      });
-      expect(child.kill).not.toHaveBeenCalled();
-
-      // Build becomes ready → child killed exactly once
-      mockResolveBuild.mockReturnValue({ shouldBuild: false, reason: "clean" });
-      await new Promise((resolve) => {
-        setTimeout(resolve, 500);
-      });
-      expect(child.kill).toHaveBeenCalledTimes(1);
-      expect(child.kill).toHaveBeenCalledWith("SIGTERM");
-
-      fakeProcess.emit("SIGINT");
-      await runPromise;
-      expect(watcher.close).toHaveBeenCalledTimes(1);
-    });
-
-    it("recovers requestRestart when entry reappears then sends SIGTERM", async () => {
-      const childA = createKillableChild();
-      const childB = createKillableChild();
-      const spawn = vi.fn().mockReturnValueOnce(childA).mockReturnValueOnce(childB);
-      const watcher = Object.assign(new EventEmitter(), {
-        close: vi.fn(async () => {}),
-      });
-      const createWatcher = vi.fn(() => watcher);
-      const fakeProcess = createFakeProcess();
-
-      mockResolveBuild.mockReturnValue({ shouldBuild: true, reason: "missing_dist_entry" });
-      mockResolveRuntime.mockReturnValue({ shouldSync: false, reason: "clean" });
-
-      const runPromise = runWatch({
-        args: ["gateway", "--force"],
-        cwd: "/repo/openclaw",
-        createWatcher,
-        env: { PATH: "/usr/bin" },
-        lockDisabled: true,
-        process: fakeProcess,
-        spawn,
-      } as WatchRunParams);
-
-      watcher.emit("change", "src/infra/something.ts");
-      await new Promise((resolve) => {
-        setImmediate(resolve);
-      });
-      // Deferred: child NOT killed yet
-      expect(childA.kill).not.toHaveBeenCalled();
-
-      // Build becomes ready → guard passes → kill child → exit handler restarts
-      mockResolveBuild.mockReturnValue({ shouldBuild: false, reason: "clean" });
-      await new Promise((resolve) => {
-        setTimeout(resolve, 500);
-      });
-      expect(childA.kill).toHaveBeenCalledWith("SIGTERM");
-      expect(spawn).toHaveBeenCalledTimes(2);
-
-      fakeProcess.emit("SIGINT");
-      await runPromise;
-      expect(watcher.close).toHaveBeenCalledTimes(1);
-    });
   });
 
   it("replaces an existing watcher lock holder before starting", async () => {

--- a/src/infra/watch-node.test.ts
+++ b/src/infra/watch-node.test.ts
@@ -1003,6 +1003,93 @@ describe("watch-node script", () => {
       await runPromise;
       expect(watcher.close).toHaveBeenCalledTimes(1);
     });
+
+    it("coalesces multiple file changes into single deferral loop", async () => {
+      const { child, spawn, watcher, createWatcher } = createWatchHarness();
+      const { proc: fakeProcess } = fakeProcessWithStderr();
+
+      mockResolveBuild.mockReturnValue({ shouldBuild: true, reason: "missing_dist_entry" });
+      mockResolveRuntime.mockReturnValue({ shouldSync: false, reason: "clean" });
+
+      const runPromise = runWatch({
+        args: ["gateway", "--force"],
+        cwd: "/repo/openclaw",
+        createWatcher,
+        env: { PATH: "/usr/bin" },
+        lockDisabled: true,
+        process: fakeProcess,
+        spawn,
+      } as WatchRunParams);
+
+      // First change → deferral starts
+      watcher.emit("change", "src/infra/a.ts");
+      await new Promise((resolve) => {
+        setImmediate(resolve);
+      });
+      expect(child.kill).not.toHaveBeenCalled();
+
+      // Second change during deferral → single-flight guard, no new loop
+      watcher.emit("change", "src/infra/b.ts");
+      await new Promise((resolve) => {
+        setImmediate(resolve);
+      });
+      expect(child.kill).not.toHaveBeenCalled();
+
+      // Build becomes ready → child killed exactly once
+      mockResolveBuild.mockReturnValue({ shouldBuild: false, reason: "clean" });
+      await new Promise((resolve) => {
+        setTimeout(resolve, 500);
+      });
+      expect(child.kill).toHaveBeenCalledTimes(1);
+      expect(child.kill).toHaveBeenCalledWith("SIGTERM");
+
+      fakeProcess.emit("SIGINT");
+      await runPromise;
+      expect(watcher.close).toHaveBeenCalledTimes(1);
+    });
+
+    it("recovers requestRestart when entry reappears then sends SIGTERM", async () => {
+      const childA = createKillableChild();
+      const childB = createKillableChild();
+      const spawn = vi.fn().mockReturnValueOnce(childA).mockReturnValueOnce(childB);
+      const watcher = Object.assign(new EventEmitter(), {
+        close: vi.fn(async () => {}),
+      });
+      const createWatcher = vi.fn(() => watcher);
+      const fakeProcess = createFakeProcess();
+
+      mockResolveBuild.mockReturnValue({ shouldBuild: true, reason: "missing_dist_entry" });
+      mockResolveRuntime.mockReturnValue({ shouldSync: false, reason: "clean" });
+
+      const runPromise = runWatch({
+        args: ["gateway", "--force"],
+        cwd: "/repo/openclaw",
+        createWatcher,
+        env: { PATH: "/usr/bin" },
+        lockDisabled: true,
+        process: fakeProcess,
+        spawn,
+      } as WatchRunParams);
+
+      watcher.emit("change", "src/infra/something.ts");
+      await new Promise((resolve) => {
+        setImmediate(resolve);
+      });
+      // Deferred: child NOT killed yet
+      expect(childA.kill).not.toHaveBeenCalled();
+
+      // Build becomes ready → guard passes → kill child → exit handler restarts
+      mockResolveBuild.mockReturnValue({ shouldBuild: false, reason: "clean" });
+      await new Promise((resolve) => {
+        setTimeout(resolve, 500);
+      });
+      expect(childA.kill).toHaveBeenCalledWith("SIGTERM");
+      expect(spawn).toHaveBeenCalledTimes(2);
+
+      fakeProcess.emit("SIGINT");
+      await runPromise;
+      expect(watcher.close).toHaveBeenCalledTimes(1);
+    });
   });
 
   it("replaces an existing watcher lock holder before starting", async () => {

--- a/test/scripts/lint-suppressions.test.ts
+++ b/test/scripts/lint-suppressions.test.ts
@@ -194,7 +194,6 @@ describe("production lint suppressions", () => {
         "extensions/feishu/src/bitable.ts|typescript/no-unnecessary-type-parameters|1",
         "extensions/matrix/src/onboarding.test-harness.ts|typescript/no-unnecessary-type-parameters|1",
         "extensions/slack/src/monitor/provider-support.ts|typescript/no-unnecessary-type-parameters|1",
-        "scripts/watch-node.mjs|typescript/use-unknown-in-catch-callback-variable|1",
         "src/agents/agent-bundle-mcp-runtime.ts|unicorn/prefer-add-event-listener|1",
         "src/audit/audit-event-writer.ts|unicorn/require-post-message-target-origin|2",
         "src/channels/plugins/channel-runtime-surface.types.ts|typescript/no-unnecessary-type-parameters|1",

--- a/test/scripts/lint-suppressions.test.ts
+++ b/test/scripts/lint-suppressions.test.ts
@@ -194,6 +194,7 @@ describe("production lint suppressions", () => {
         "extensions/feishu/src/bitable.ts|typescript/no-unnecessary-type-parameters|1",
         "extensions/matrix/src/onboarding.test-harness.ts|typescript/no-unnecessary-type-parameters|1",
         "extensions/slack/src/monitor/provider-support.ts|typescript/no-unnecessary-type-parameters|1",
+        "scripts/watch-node.mjs|typescript/use-unknown-in-catch-callback-variable|1",
         "src/agents/agent-bundle-mcp-runtime.ts|unicorn/prefer-add-event-listener|1",
         "src/audit/audit-event-writer.ts|unicorn/require-post-message-target-origin|2",
         "src/channels/plugins/channel-runtime-surface.types.ts|typescript/no-unnecessary-type-parameters|1",


### PR DESCRIPTION
## What Problem This Solves

When another source operation temporarily removes `dist/entry.js`, the watch process used to terminate a healthy Gateway child immediately. The replacement then started against incomplete build output and could enter a restart loop.

Fixes #99603.

## Why This Change Was Made

The watch process now treats the root `dist/entry.js` as the minimum restart boundary. If it is absent, a healthy child remains online while one bounded, generation-aware poll waits for the entry to return. New changes coalesce into that poll, shutdown cancels it, and stale polls cannot signal a replacement child.

If the child exits while output is incomplete, the same bounded wait owns recovery. `run-node.mjs` remains the canonical owner of full freshness checks and build locking; the watcher only prevents an avoidable handoff into physically missing output.

This replaces the contributor branch's synchronous Git/build-readiness polling and duplicate restart paths with a smaller owner-boundary fix.

## User Impact

- Before: a concurrent build could turn a healthy source Gateway into a crash loop.
- After: the healthy Gateway stays available until its replacement can at least load the built entry point.
- Normal source changes retain the existing immediate restart behavior.

## Evidence

- `corepack pnpm test src/infra/watch-node.test.ts` — 18 passed on Blacksmith Testbox `tbx_01kx84w2gwdynjzq74j91aga2b`.
- `corepack pnpm check:changed -- scripts/watch-node.mjs src/infra/scripts-modules.d.ts src/infra/watch-node.test.ts` — passed on the same Testbox.
- Fresh autoreview: no accepted or actionable findings.
- Live reproduction on `clawmac`: `dist/entry.js` disappeared during a source update while the managed Gateway was serving; the CLI reported the missing entry and the Gateway required recovery after the build completed. The fixed watcher covers the unsafe child handoff exposed by that incident.

Tests cover healthy-child preservation, event coalescing, restored-entry restart, shutdown cancellation, child exit during deferral, and stale-generation cancellation.

## Changes

- `scripts/watch-node.mjs`: bounded single-flight restart deferral around missing `dist/entry.js`.
- `src/infra/watch-node.test.ts`: focused race and lifecycle regression coverage.
- `src/infra/scripts-modules.d.ts`: injectable filesystem dependency used by the tests.
