### PR TITLE
docs: sync plugin package snippets

### DIFF
--- a/docs/plugins/sdk-setup.md
+++ b/docs/plugins/sdk-setup.md
@@ -43,6 +43,12 @@ Your `package.json` needs an `openclaw` field that tells the plugin system what 
       "name": "@myorg/openclaw-my-plugin",
       "version": "1.0.0",
       "type": "module",
+      "dependencies": {
+        "typebox": "1.1.39"
+      },
+      "peerDependencies": {
+        "openclaw": ">=2026.3.24-beta.2"
+      },
       "openclaw": {
         "extensions": ["./index.ts"],
         "compat": {

--- a/docs/snippets/plugin-publish/minimal-package.json
+++ b/docs/snippets/plugin-publish/minimal-package.json
@@ -2,6 +2,12 @@
   "name": "@myorg/openclaw-my-plugin",
   "version": "1.0.0",
   "type": "module",
+  "dependencies": {
+    "typebox": "1.1.39"
+  },
+  "peerDependencies": {
+    "openclaw": ">=2026.3.24-beta.2"
+  },
   "openclaw": {
     "extensions": ["./index.ts"],
     "compat": {


### PR DESCRIPTION
## What Problem This Solves

PR #99962 expanded the primary plugin quickstart `package.json` with the runtime `typebox` dependency and `openclaw` peer dependency, but left the canonical publish snippet and SDK setup copy unchanged. That made `src/docs/clawhub-plugin-docs.test.ts` fail on current `main` and presented conflicting package metadata across the plugin docs.

## Why This Change Was Made

Update the canonical snippet and the SDK setup copy to match the primary quickstart. The additions reflect the quickstart source imports: `typebox` is a runtime dependency, while `openclaw/plugin-sdk/*` is provided by the OpenClaw peer.

## User Impact

Plugin authors now see one consistent, installable package shape across the quickstart, SDK setup reference, and canonical publish snippet.

## Evidence

- `pnpm test src/docs/clawhub-plugin-docs.test.ts --run` — 3/3 pass
- `pnpm docs:check-mdx` — pass (690 files)
- `pnpm format:docs:check` — pass (674 files)
- `git diff --check` — pass
- Fresh autoreview — clean, 0.99 confidence
- Reproduced failure on PR #99969 exact-head CI after syncing current `main`: https://github.com/openclaw/openclaw/actions/runs/28708136201/job/85137144813

Related: #99962
