### PR TITLE
fix(discord): keep voice log previews UTF-16 safe

### DIFF
--- a/extensions/discord/src/voice/log-preview.test.ts
+++ b/extensions/discord/src/voice/log-preview.test.ts
@@ -10,4 +10,10 @@ describe("formatVoiceLogPreview", () => {
     const preview = formatVoiceLogPreview("x".repeat(501));
     expect(preview).toBe(`${"x".repeat(500)}...`);
   });
+
+  it("does not split emoji when the preview limit lands inside a surrogate pair", () => {
+    const preview = formatVoiceLogPreview(`${"x".repeat(499)}😀tail`);
+    expect(preview).toBe(`${"x".repeat(499)}...`);
+    expect(preview).not.toMatch(/[\uD800-\uDFFF]/u);
+  });
 });

--- a/extensions/discord/src/voice/log-preview.ts
+++ b/extensions/discord/src/voice/log-preview.ts
@@ -1,3 +1,5 @@
+import { truncateUtf16Safe } from "openclaw/plugin-sdk/text-utility-runtime";
+
 const DISCORD_VOICE_LOG_PREVIEW_CHARS = 500;
 
 export function formatVoiceLogPreview(text: string): string {
@@ -5,5 +7,5 @@ export function formatVoiceLogPreview(text: string): string {
   if (oneLine.length <= DISCORD_VOICE_LOG_PREVIEW_CHARS) {
     return oneLine;
   }
-  return `${oneLine.slice(0, DISCORD_VOICE_LOG_PREVIEW_CHARS)}...`;
+  return `${truncateUtf16Safe(oneLine, DISCORD_VOICE_LOG_PREVIEW_CHARS)}...`;
 }


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where Discord voice diagnostics could show a broken preview character when a long transcript or response was truncated exactly inside an emoji.

## Why This Change Was Made

Voice log previews now reuse the shared UTF-16-safe truncation helper while preserving the existing 500-character preview budget and ellipsis behavior.

## User Impact

Operators reading Discord voice logs get stable previews without lone surrogate characters at truncation boundaries.

## Evidence

- `node scripts/run-vitest.mjs extensions/discord/src/voice/log-preview.test.ts --reporter=verbose`: 1 file / 3 tests passed.
- Direct runtime proof against `formatVoiceLogPreview` showed the old raw slice shape leaves a lone surrogate while the patched preview does not.

```text
$ node --import tsx --input-type=module
{
  "inputLength": 505,
  "rawSliceHasLoneSurrogate": true,
  "safePreviewHasLoneSurrogate": false,
  "safePreviewLength": 502,
  "safePreviewTail": "xxxxx..."
}
```

AI-assisted: built with Codex
