### PR TITLE
fix(sessions): reuse successful main sessions after completed runs

### DIFF
--- a/src/auto-reply/reply/session.test.ts
+++ b/src/auto-reply/reply/session.test.ts
@@ -2141,12 +2141,22 @@ describe("initSessionState reset policy", () => {
       expectNewSession: false,
     },
     {
-      name: "main terminal rows rotate when transcript is newer than updatedAt",
+      name: "interrupted main terminal rows rotate when transcript is newer than updatedAt",
       sessionKey: "agent:main:main",
+      status: "killed" as const,
       updatedAtOffsetMs: -10_000,
       endedAtOffsetMs: -11_000,
       transcriptMtimeOffsetMs: 0,
       expectNewSession: true,
+    },
+    {
+      name: "successful main terminal rows reuse when transcript is newer than updatedAt",
+      sessionKey: "agent:main:main",
+      status: "done" as const,
+      updatedAtOffsetMs: -10_000,
+      endedAtOffsetMs: -11_000,
+      transcriptMtimeOffsetMs: 0,
+      expectNewSession: false,
     },
     {
       name: "main endedAt-only rows rotate when transcript is newer than updatedAt",

--- a/src/commands/agent.session.test.ts
+++ b/src/commands/agent.session.test.ts
@@ -149,20 +149,25 @@ describe("agent session resolution", () => {
     });
   });
 
-  it("rotates stale terminal main sessions whose transcript is newer than the registry", async () => {
+  it("rotates interrupted terminal main sessions whose transcript is newer than the registry", async () => {
     const scenarios = [
       {
         label: "canonical main",
         mainKey: "main",
         sessionKey: "agent:main:main",
-        status: "done" as const,
+        status: "killed" as const,
       },
-      { label: "raw main alias", mainKey: "main", sessionKey: "main", status: "done" as const },
+      {
+        label: "raw main alias",
+        mainKey: "main",
+        sessionKey: "main",
+        status: "killed" as const,
+      },
       {
         label: "custom main alias",
         mainKey: "work",
         sessionKey: "agent:main:main",
-        status: "done" as const,
+        status: "killed" as const,
       },
       { label: "endedAt-only main", mainKey: "main", sessionKey: "agent:main:main" },
     ];

--- a/src/config/sessions/lifecycle.ts
+++ b/src/config/sessions/lifecycle.ts
@@ -165,6 +165,11 @@ export function resolveTerminalMainSessionTranscriptRegistryCheck(
   if (!hasTerminalLifecycle) {
     return undefined;
   }
+  if (params.entry.status === "done") {
+    // Successful main runs stay reusable; updatedAt can lag healthy transcript writes.
+    // Interrupted/endedAt-only rows still use this guard for recovery rollover.
+    return undefined;
+  }
   if (params.entry.status === "failed") {
     // Failed rows with a present transcript stay reusable for retry/recovery.
     // Callers already rotate failed rows when the transcript is missing.

--- a/src/gateway/server-methods/agent.test.ts
+++ b/src/gateway/server-methods/agent.test.ts
@@ -823,75 +823,130 @@ describe("gateway agent handler", () => {
     expect(capturedEntry?.sessionFile).toBeUndefined();
   });
 
-  it.each([
-    { name: "status terminal row", status: "done" as const },
-    { name: "endedAt-only terminal row" },
-  ])(
-    "rotates a terminal main session from a $name when its transcript is newer",
-    async (scenario) => {
-      const now = Date.parse("2026-05-18T09:47:00.000Z");
-      vi.useFakeTimers({ toFake: ["Date"] });
-      dateOnlyFakeClockActive = true;
-      vi.setSystemTime(now);
+  it("rotates an endedAt-only terminal main session when its transcript is newer", async () => {
+    const now = Date.parse("2026-05-18T09:47:00.000Z");
+    vi.useFakeTimers({ toFake: ["Date"] });
+    dateOnlyFakeClockActive = true;
+    vi.setSystemTime(now);
 
-      await withTempDir(
-        { prefix: "openclaw-gateway-terminal-main-newer-transcript-" },
-        async (root) => {
-          const sessionsDir = `${root}/sessions`;
-          await fs.mkdir(sessionsDir, { recursive: true });
-          const sessionFile = "terminal-main-session.jsonl";
-          const transcriptPath = `${sessionsDir}/${sessionFile}`;
-          await fs.writeFile(
-            transcriptPath,
-            `${JSON.stringify({ type: "session", id: "terminal-main-session" })}\n`,
-            "utf8",
-          );
-          await fs.utimes(transcriptPath, new Date(now - 1_000), new Date(now - 1_000));
-          mocks.loadSessionEntry.mockReturnValue({
-            cfg: {},
-            storePath: `${sessionsDir}/sessions.json`,
-            entry: {
-              sessionId: "terminal-main-session",
-              sessionFile,
-              ...(scenario.status ? { status: scenario.status } : {}),
-              updatedAt: now - 10_000,
-              sessionStartedAt: now - 60_000,
-              lastInteractionAt: now - 10_000,
-              startedAt: now - 20_000,
-              endedAt: now - 15_000,
-              runtimeMs: 5_000,
-              cliSessionBindings: {
-                "claude-cli": { sessionId: "old-claude-cli-session" },
-                "codex-cli": { sessionId: "old-codex-cli-session" },
-              },
-              cliSessionIds: {
-                "claude-cli": "old-claude-cli-session",
-                "codex-cli": "old-codex-cli-session",
-              },
-              claudeCliSessionId: "old-claude-cli-session",
+    await withTempDir(
+      { prefix: "openclaw-gateway-terminal-main-newer-transcript-" },
+      async (root) => {
+        const sessionsDir = `${root}/sessions`;
+        await fs.mkdir(sessionsDir, { recursive: true });
+        const sessionFile = "terminal-main-session.jsonl";
+        const transcriptPath = `${sessionsDir}/${sessionFile}`;
+        await fs.writeFile(
+          transcriptPath,
+          `${JSON.stringify({ type: "session", id: "terminal-main-session" })}\n`,
+          "utf8",
+        );
+        await fs.utimes(transcriptPath, new Date(now - 1_000), new Date(now - 1_000));
+        mocks.loadSessionEntry.mockReturnValue({
+          cfg: {},
+          storePath: `${sessionsDir}/sessions.json`,
+          entry: {
+            sessionId: "terminal-main-session",
+            sessionFile,
+            updatedAt: now - 10_000,
+            sessionStartedAt: now - 60_000,
+            lastInteractionAt: now - 10_000,
+            startedAt: now - 20_000,
+            endedAt: now - 15_000,
+            runtimeMs: 5_000,
+            cliSessionBindings: {
+              "claude-cli": { sessionId: "old-claude-cli-session" },
+              "codex-cli": { sessionId: "old-codex-cli-session" },
             },
-            canonicalKey: "agent:main:main",
-          });
+            cliSessionIds: {
+              "claude-cli": "old-claude-cli-session",
+              "codex-cli": "old-codex-cli-session",
+            },
+            claudeCliSessionId: "old-claude-cli-session",
+          },
+          canonicalKey: "agent:main:main",
+        });
 
-          const capturedEntry = await runMainAgentAndCaptureEntry(
-            "test-idem-terminal-main-newer-transcript",
-          );
+        const capturedEntry = await runMainAgentAndCaptureEntry(
+          "test-idem-terminal-main-newer-transcript",
+        );
 
-          const call = await waitForAgentCommandCall<{ sessionId?: string }>();
-          expect(call.sessionId).not.toBe("terminal-main-session");
-          expect(capturedEntry?.sessionId).not.toBe("terminal-main-session");
-          expect(capturedEntry?.status).toBeUndefined();
-          expect(capturedEntry?.startedAt).toBeUndefined();
-          expect(capturedEntry?.endedAt).toBeUndefined();
-          expect(capturedEntry?.runtimeMs).toBeUndefined();
-          expect(capturedEntry?.sessionFile).toBeUndefined();
-          expect(capturedEntry?.cliSessionBindings).toBeUndefined();
-          expect(capturedEntry?.cliSessionIds).toBeUndefined();
-          expect(capturedEntry?.claudeCliSessionId).toBeUndefined();
-        },
-      );
-    },
-  );
+        const call = await waitForAgentCommandCall<{ sessionId?: string }>();
+        expect(call.sessionId).not.toBe("terminal-main-session");
+        expect(capturedEntry?.sessionId).not.toBe("terminal-main-session");
+        expect(capturedEntry?.status).toBeUndefined();
+        expect(capturedEntry?.startedAt).toBeUndefined();
+        expect(capturedEntry?.endedAt).toBeUndefined();
+        expect(capturedEntry?.runtimeMs).toBeUndefined();
+        expect(capturedEntry?.sessionFile).toBeUndefined();
+        expect(capturedEntry?.cliSessionBindings).toBeUndefined();
+        expect(capturedEntry?.cliSessionIds).toBeUndefined();
+        expect(capturedEntry?.claudeCliSessionId).toBeUndefined();
+      },
+    );
+  });
+
+  it("reuses a successful terminal main session when its transcript is newer", async () => {
+    const now = Date.parse("2026-05-18T09:47:15.000Z");
+    vi.useFakeTimers({ toFake: ["Date"] });
+    dateOnlyFakeClockActive = true;
+    vi.setSystemTime(now);
+
+    await withTempDir(
+      { prefix: "openclaw-gateway-terminal-main-done-newer-transcript-" },
+      async (root) => {
+        const sessionsDir = `${root}/sessions`;
+        await fs.mkdir(sessionsDir, { recursive: true });
+        const sessionFile = "terminal-main-session.jsonl";
+        const transcriptPath = `${sessionsDir}/${sessionFile}`;
+        await fs.writeFile(
+          transcriptPath,
+          `${JSON.stringify({ type: "session", id: "terminal-main-session" })}\n`,
+          "utf8",
+        );
+        await fs.utimes(transcriptPath, new Date(now - 1_000), new Date(now - 1_000));
+        mocks.loadSessionEntry.mockReturnValue({
+          cfg: {},
+          storePath: `${sessionsDir}/sessions.json`,
+          entry: {
+            sessionId: "terminal-main-session",
+            sessionFile,
+            status: "done",
+            updatedAt: now - 10_000,
+            sessionStartedAt: now - 60_000,
+            lastInteractionAt: now - 10_000,
+            startedAt: now - 20_000,
+            endedAt: now - 15_000,
+            runtimeMs: 5_000,
+            cliSessionBindings: {
+              "claude-cli": { sessionId: "old-claude-cli-session" },
+              "codex-cli": { sessionId: "old-codex-cli-session" },
+            },
+            cliSessionIds: {
+              "claude-cli": "old-claude-cli-session",
+              "codex-cli": "old-codex-cli-session",
+            },
+            claudeCliSessionId: "old-claude-cli-session",
+          },
+          canonicalKey: "agent:main:main",
+        });
+
+        const capturedEntry = await runMainAgentAndCaptureEntry(
+          "test-idem-terminal-main-done-newer-transcript",
+        );
+
+        const call = await waitForAgentCommandCall<{ sessionId?: string }>();
+        expect(call.sessionId).toBe("terminal-main-session");
+        expect(capturedEntry?.sessionId).toBe("terminal-main-session");
+        expect(capturedEntry?.sessionFile).toBe(sessionFile);
+        expect(capturedEntry?.cliSessionIds).toEqual({
+          "claude-cli": "old-claude-cli-session",
+          "codex-cli": "old-codex-cli-session",
+        });
+        expect(capturedEntry?.claudeCliSessionId).toBe("old-claude-cli-session");
+      },
+    );
+  });
 
   it("reuses terminal main sessions when the fresh store row has the transcript marker", async () => {
     const now = Date.parse("2026-05-18T09:47:30.000Z");


### PR DESCRIPTION
﻿Closes #99964

## What Problem This Solves

Fixes an issue where users could see the main agent unexpectedly roll into a new session after a successful completed run when the transcript file mtime was newer than `sessions.json.updatedAt`.

That made normal successful transcripts look like `.jsonl.reset.*` rollovers even when no manual reset, idle expiry, or daily reset should have happened.

## Why This Change Was Made

Successful `status: "done"` main sessions now stay reusable when the transcript freshness guard sees a newer transcript mtime. The terminal-main transcript guard still applies to unsafe recovery shapes such as endedAt-only rows and interrupted terminal statuses, so interrupted or ambiguous terminal state can still force rollover.

The fix lives at the session lifecycle guard owner so gateway, CLI command session resolution, and auto-reply admission all share the same decision instead of each caller special-casing successful runs.

## User Impact

Main-agent conversations keep their session id and transcript continuity after successful runs. Users should no longer get surprise reset archives solely because transcript persistence landed after the registry bookkeeping timestamp.

## Evidence

- Red proof before the fix: `node scripts/run-vitest.mjs run --config test/vitest/vitest.gateway.config.ts src/gateway/server-methods/agent.test.ts -t "terminal main" --maxWorkers=1 --reporter=dot` failed because `status: "done"` reused-session expectation received a new UUID.
- Green proof after the fix: same command passed with `12 passed | 336 skipped`.
- Real CLI session resolver proof on this branch, using a temp `OPENCLAW_STATE_DIR` with a completed main row whose transcript mtime is newer than `updatedAt`:

```json
{"scenario":"status:done","requestedSessionKey":"agent:main:main","resolvedSessionKey":"agent:main:main","registrySessionId":"proof-done-session","registryUpdatedAt":1783175167356,"transcriptMtimeGreaterThanUpdatedAt":true,"resolvedSessionId":"proof-done-session","reusedExistingSession":true,"isNewSession":false,"preservedSessionFile":true}
{"scenario":"endedAt-only:no-status","requestedSessionKey":"agent:main:main","resolvedSessionKey":"agent:main:main","registrySessionId":"proof-endedAt-only-session","registryUpdatedAt":1783175167356,"transcriptMtimeGreaterThanUpdatedAt":true,"resolvedSessionId":"30b4b44e-b719-4cc1-b4c0-b1eee5641c91","reusedExistingSession":false,"isNewSession":true,"preservedSessionFile":false}
```

- CLI command resolver shard: `node scripts/run-vitest.mjs run --config test/vitest/vitest.commands.config.ts src/commands/agent.session.test.ts --maxWorkers=1 --reporter=dot` passed with `7 passed`.
- Auto-reply admission shard: `node scripts/run-vitest.mjs run --config test/vitest/vitest.auto-reply-reply.config.ts src/auto-reply/reply/session.test.ts -t "terminal rows" --maxWorkers=1 --reporter=dot` passed with `7 passed | 120 skipped`.
- `node scripts/run-vitest.mjs run --config test/vitest/vitest.agents-support.config.ts src/agents/command/session-store.test.ts --maxWorkers=1 --reporter=dot` passed with `45 passed`.
- `pnpm exec oxfmt --check src/config/sessions/lifecycle.ts src/gateway/server-methods/agent.test.ts src/commands/agent.session.test.ts src/auto-reply/reply/session.test.ts` passed.
- `git diff --check -- src/config/sessions/lifecycle.ts src/gateway/server-methods/agent.test.ts src/commands/agent.session.test.ts src/auto-reply/reply/session.test.ts` passed.

Known local proof gap: the full `src/gateway/server-methods/agent.test.ts` file was attempted locally but exceeded the no-output window in this Windows worktree, so the PR relies on the focused terminal-main shard locally plus GitHub CI for the wider gateway matrix.
