### PR TITLE
fix(sessions): exclude done sessions from transcript freshness rollover guard

### DIFF
--- a/src/auto-reply/reply/session.test.ts
+++ b/src/auto-reply/reply/session.test.ts
@@ -2211,6 +2211,15 @@ describe("initSessionState reset policy", () => {
       expectNewSession: false,
     },
     {
+      name: "main killed terminal rows rotate when transcript is newer than updatedAt",
+      sessionKey: "agent:main:main",
+      status: "killed" as const,
+      updatedAtOffsetMs: -10_000,
+      endedAtOffsetMs: -11_000,
+      transcriptMtimeOffsetMs: 0,
+      expectNewSession: true,
+    },
+    {
       name: "main endedAt-only rows rotate when transcript is newer than updatedAt",
       sessionKey: "agent:main:main",
       updatedAtOffsetMs: -10_000,

--- a/src/auto-reply/reply/session.test.ts
+++ b/src/auto-reply/reply/session.test.ts
@@ -2203,12 +2203,12 @@ describe("initSessionState reset policy", () => {
       expectNewSession: false,
     },
     {
-      name: "main terminal rows rotate when transcript is newer than updatedAt",
+      name: "main status-done terminal rows reuse when transcript is newer than updatedAt",
       sessionKey: "agent:main:main",
       updatedAtOffsetMs: -10_000,
       endedAtOffsetMs: -11_000,
       transcriptMtimeOffsetMs: 0,
-      expectNewSession: true,
+      expectNewSession: false,
     },
     {
       name: "main endedAt-only rows rotate when transcript is newer than updatedAt",

--- a/src/commands/agent.session.test.ts
+++ b/src/commands/agent.session.test.ts
@@ -149,22 +149,44 @@ describe("agent session resolution", () => {
     });
   });
 
-  it("reuses status-done terminal main sessions whose transcript is newer than the registry", async () => {
+  it("handles terminal main sessions whose transcript is newer than the registry", async () => {
     const scenarios = [
       {
-        label: "canonical main",
+        label: "canonical done main",
         mainKey: "main",
         sessionKey: "agent:main:main",
         status: "done" as const,
+        expectNewSession: false,
       },
-      { label: "raw main alias", mainKey: "main", sessionKey: "main", status: "done" as const },
       {
-        label: "custom main alias",
+        label: "raw done main alias",
+        mainKey: "main",
+        sessionKey: "main",
+        status: "done" as const,
+        expectNewSession: false,
+      },
+      {
+        label: "custom done main alias",
         mainKey: "work",
         sessionKey: "agent:main:main",
         status: "done" as const,
+        expectNewSession: false,
       },
-    ];
+      {
+        label: "killed main",
+        mainKey: "main",
+        sessionKey: "agent:main:main",
+        status: "killed" as const,
+        expectNewSession: true,
+      },
+      {
+        label: "endedAt-only main",
+        mainKey: "main",
+        sessionKey: "agent:main:main",
+        status: undefined,
+        expectNewSession: true,
+      },
+    ] as const;
     for (const scenario of scenarios) {
       await withTempHome(async (home) => {
         const store = path.join(home, "sessions.json");
@@ -204,55 +226,11 @@ describe("agent session resolution", () => {
 
         const resolution = resolveSession({ cfg, sessionKey: scenario.sessionKey });
 
-        expect(resolution.isNewSession).toBe(false);
-        expect(resolution.sessionId).toBe(sessionId);
-      });
-    }
-  });
-
-  it("rotates endedAt-only terminal main sessions whose transcript is newer than the registry", async () => {
-    const scenarios = [
-      { label: "endedAt-only main", mainKey: "main", sessionKey: "agent:main:main" },
-    ] as const;
-    for (const scenario of scenarios) {
-      await withTempHome(async (home) => {
-        const store = path.join(home, "sessions.json");
-        const sessionFile = path.join(home, `session-${scenario.label.replaceAll(" ", "-")}.jsonl`);
-        const sessionId = `stale-terminal-${scenario.label.replaceAll(" ", "-")}`;
-        const registryUpdatedAt = Date.now() - 10_000;
-        fs.mkdirSync(path.dirname(sessionFile), { recursive: true });
-        fs.writeFileSync(sessionFile, JSON.stringify({ type: "session", id: sessionId }) + "\n");
-        fs.utimesSync(
-          sessionFile,
-          (registryUpdatedAt + 5_000) / 1000,
-          (registryUpdatedAt + 5_000) / 1000,
-        );
-        writeSessionStoreSeed(store, {
-          [scenario.sessionKey]: {
-            sessionId,
-            sessionFile,
-            updatedAt: registryUpdatedAt,
-            sessionStartedAt: registryUpdatedAt - 60_000,
-            lastInteractionAt: registryUpdatedAt - 30_000,
-            startedAt: registryUpdatedAt - 1_000,
-            endedAt: registryUpdatedAt - 100,
-            cliSessionBindings: {
-              "claude-cli": { sessionId: "old-claude-cli-session" },
-              "codex-cli": { sessionId: "old-codex-cli-session" },
-            },
-            cliSessionIds: {
-              "claude-cli": "old-claude-cli-session",
-              "codex-cli": "old-codex-cli-session",
-            },
-            claudeCliSessionId: "old-claude-cli-session",
-          },
-        });
-        const cfg = mockConfig(home, store);
-        cfg.session = { ...cfg.session, mainKey: scenario.mainKey };
-
-        const resolution = resolveSession({ cfg, sessionKey: scenario.sessionKey });
-
-        expect(resolution.isNewSession).toBe(true);
+        expect(resolution.isNewSession).toBe(scenario.expectNewSession);
+        if (!scenario.expectNewSession) {
+          expect(resolution.sessionId).toBe(sessionId);
+          return;
+        }
         expect(resolution.sessionId).not.toBe(sessionId);
         expect(resolution.sessionEntry?.sessionFile).toBeUndefined();
         expect(resolution.sessionEntry?.status).toBeUndefined();

--- a/src/commands/agent.session.test.ts
+++ b/src/commands/agent.session.test.ts
@@ -149,7 +149,7 @@ describe("agent session resolution", () => {
     });
   });
 
-  it("rotates stale terminal main sessions whose transcript is newer than the registry", async () => {
+  it("reuses status-done terminal main sessions whose transcript is newer than the registry", async () => {
     const scenarios = [
       {
         label: "canonical main",
@@ -164,6 +164,54 @@ describe("agent session resolution", () => {
         sessionKey: "agent:main:main",
         status: "done" as const,
       },
+    ];
+    for (const scenario of scenarios) {
+      await withTempHome(async (home) => {
+        const store = path.join(home, "sessions.json");
+        const sessionFile = path.join(home, `session-${scenario.label.replaceAll(" ", "-")}.jsonl`);
+        const sessionId = `stale-terminal-${scenario.label.replaceAll(" ", "-")}`;
+        const registryUpdatedAt = Date.now() - 10_000;
+        fs.mkdirSync(path.dirname(sessionFile), { recursive: true });
+        fs.writeFileSync(sessionFile, JSON.stringify({ type: "session", id: sessionId }) + "\n");
+        fs.utimesSync(
+          sessionFile,
+          (registryUpdatedAt + 5_000) / 1000,
+          (registryUpdatedAt + 5_000) / 1000,
+        );
+        writeSessionStoreSeed(store, {
+          [scenario.sessionKey]: {
+            sessionId,
+            sessionFile,
+            updatedAt: registryUpdatedAt,
+            ...(scenario.status ? { status: scenario.status } : {}),
+            sessionStartedAt: registryUpdatedAt - 60_000,
+            lastInteractionAt: registryUpdatedAt - 30_000,
+            startedAt: registryUpdatedAt - 1_000,
+            endedAt: registryUpdatedAt - 100,
+            cliSessionBindings: {
+              "claude-cli": { sessionId: "old-claude-cli-session" },
+              "codex-cli": { sessionId: "old-codex-cli-session" },
+            },
+            cliSessionIds: {
+              "claude-cli": "old-claude-cli-session",
+              "codex-cli": "old-codex-cli-session",
+            },
+            claudeCliSessionId: "old-claude-cli-session",
+          },
+        });
+        const cfg = mockConfig(home, store);
+        cfg.session = { ...cfg.session, mainKey: scenario.mainKey };
+
+        const resolution = resolveSession({ cfg, sessionKey: scenario.sessionKey });
+
+        expect(resolution.isNewSession).toBe(false);
+        expect(resolution.sessionId).toBe(sessionId);
+      });
+    }
+  });
+
+  it("rotates endedAt-only terminal main sessions whose transcript is newer than the registry", async () => {
+    const scenarios = [
       { label: "endedAt-only main", mainKey: "main", sessionKey: "agent:main:main" },
     ];
     for (const scenario of scenarios) {

--- a/src/commands/agent.session.test.ts
+++ b/src/commands/agent.session.test.ts
@@ -213,7 +213,7 @@ describe("agent session resolution", () => {
   it("rotates endedAt-only terminal main sessions whose transcript is newer than the registry", async () => {
     const scenarios = [
       { label: "endedAt-only main", mainKey: "main", sessionKey: "agent:main:main" },
-    ];
+    ] as const;
     for (const scenario of scenarios) {
       await withTempHome(async (home) => {
         const store = path.join(home, "sessions.json");
@@ -232,7 +232,6 @@ describe("agent session resolution", () => {
             sessionId,
             sessionFile,
             updatedAt: registryUpdatedAt,
-            ...(scenario.status ? { status: scenario.status } : {}),
             sessionStartedAt: registryUpdatedAt - 60_000,
             lastInteractionAt: registryUpdatedAt - 30_000,
             startedAt: registryUpdatedAt - 1_000,

--- a/src/config/sessions/lifecycle.ts
+++ b/src/config/sessions/lifecycle.ts
@@ -216,6 +216,7 @@ export function resolveTerminalMainSessionTranscriptRegistryCheck(
   if (params.entry.status === "failed" || params.entry.status === "done") {
     // Failed rows with a present transcript stay reusable for retry/recovery.
     // Callers already rotate failed rows when the transcript is missing.
+    //
     // Done rows stay reusable for continuation — transcript mtime may slightly
     // exceed registry updatedAt due to persistence ordering (the transcript
     // write can land after the registry update), so the guard is not needed

--- a/src/config/sessions/lifecycle.ts
+++ b/src/config/sessions/lifecycle.ts
@@ -213,9 +213,12 @@ export function resolveTerminalMainSessionTranscriptRegistryCheck(
   if (!hasTerminalLifecycle) {
     return undefined;
   }
-  if (params.entry.status === "failed") {
+  if (params.entry.status === "failed" || params.entry.status === "done") {
     // Failed rows with a present transcript stay reusable for retry/recovery.
     // Callers already rotate failed rows when the transcript is missing.
+    // Done rows stay reusable for continuation — transcript mtime may slightly
+    // trail registry updatedAt due to persistence ordering, and the guard is
+    // not needed for successful completions.
     return undefined;
   }
   // updatedAt is touched after managed transcript appends; endedAt can predate

--- a/src/config/sessions/lifecycle.ts
+++ b/src/config/sessions/lifecycle.ts
@@ -213,14 +213,14 @@ export function resolveTerminalMainSessionTranscriptRegistryCheck(
   if (!hasTerminalLifecycle) {
     return undefined;
   }
-  if (params.entry.status === "failed" || params.entry.status === "done") {
+  if (params.entry.status === "done") {
+    // Successful rows stay reusable: transcript writes can land after registry
+    // updates without making the session stale.
+    return undefined;
+  }
+  if (params.entry.status === "failed") {
     // Failed rows with a present transcript stay reusable for retry/recovery.
     // Callers already rotate failed rows when the transcript is missing.
-    //
-    // Done rows stay reusable for continuation — transcript mtime may slightly
-    // exceed registry updatedAt due to persistence ordering (the transcript
-    // write can land after the registry update), so the guard is not needed
-    // for successful completions.
     return undefined;
   }
   // updatedAt is touched after managed transcript appends; endedAt can predate

--- a/src/config/sessions/lifecycle.ts
+++ b/src/config/sessions/lifecycle.ts
@@ -217,8 +217,9 @@ export function resolveTerminalMainSessionTranscriptRegistryCheck(
     // Failed rows with a present transcript stay reusable for retry/recovery.
     // Callers already rotate failed rows when the transcript is missing.
     // Done rows stay reusable for continuation — transcript mtime may slightly
-    // trail registry updatedAt due to persistence ordering, and the guard is
-    // not needed for successful completions.
+    // exceed registry updatedAt due to persistence ordering (the transcript
+    // write can land after the registry update), so the guard is not needed
+    // for successful completions.
     return undefined;
   }
   // updatedAt is touched after managed transcript appends; endedAt can predate

--- a/src/gateway/server-methods/agent.test.ts
+++ b/src/gateway/server-methods/agent.test.ts
@@ -1285,15 +1285,19 @@ describe("gateway agent handler", () => {
     expect(capturedEntry?.sessionFile).toBeUndefined();
   });
 
-  it("rotates an endedAt-only terminal main session when its transcript is newer", async () => {
-    const now = Date.parse("2026-05-18T09:47:00.000Z");
-    vi.useFakeTimers({ toFake: ["Date"] });
-    dateOnlyFakeClockActive = true;
-    vi.setSystemTime(now);
+  it.each([
+    { name: "status-done row", status: "done" as const, expectReuse: true },
+    { name: "status-killed row", status: "killed" as const, expectReuse: false },
+    { name: "endedAt-only row", status: undefined, expectReuse: false },
+  ])(
+    "handles a terminal main session from a $name when its transcript is newer",
+    async (scenario) => {
+      const now = Date.parse("2026-05-18T09:47:00.000Z");
+      vi.useFakeTimers({ toFake: ["Date"] });
+      dateOnlyFakeClockActive = true;
+      vi.setSystemTime(now);
 
-    await withTempDir(
-      { prefix: "openclaw-gateway-terminal-main-newer-transcript-" },
-      async (root) => {
+      await withTempDir({ prefix: "openclaw-gateway-terminal-main-newer-" }, async (root) => {
         const sessionsDir = `${root}/sessions`;
         await fs.mkdir(sessionsDir, { recursive: true });
         const sessionFile = "terminal-main-session.jsonl";
@@ -1310,6 +1314,7 @@ describe("gateway agent handler", () => {
           entry: {
             sessionId: "terminal-main-session",
             sessionFile,
+            ...(scenario.status ? { status: scenario.status } : {}),
             updatedAt: now - 10_000,
             sessionStartedAt: now - 60_000,
             lastInteractionAt: now - 10_000,
@@ -1334,6 +1339,11 @@ describe("gateway agent handler", () => {
         );
 
         const call = await waitForAgentCommandCall<{ sessionId?: string }>();
+        if (scenario.expectReuse) {
+          expect(call.sessionId).toBe("terminal-main-session");
+          expect(capturedEntry?.sessionId).toBe("terminal-main-session");
+          return;
+        }
         expect(call.sessionId).not.toBe("terminal-main-session");
         expect(capturedEntry?.sessionId).not.toBe("terminal-main-session");
         expect(capturedEntry?.status).toBeUndefined();
@@ -1344,62 +1354,9 @@ describe("gateway agent handler", () => {
         expect(capturedEntry?.cliSessionBindings).toBeUndefined();
         expect(capturedEntry?.cliSessionIds).toBeUndefined();
         expect(capturedEntry?.claudeCliSessionId).toBeUndefined();
-      },
-    );
-  });
-
-  it("reuses a status-done terminal main session when its transcript is newer", async () => {
-    const now = Date.parse("2026-05-18T09:47:00.000Z");
-    vi.useFakeTimers({ toFake: ["Date"] });
-    dateOnlyFakeClockActive = true;
-    vi.setSystemTime(now);
-
-    await withTempDir({ prefix: "openclaw-gateway-terminal-main-done-reuse-" }, async (root) => {
-      const sessionsDir = `${root}/sessions`;
-      await fs.mkdir(sessionsDir, { recursive: true });
-      const sessionFile = "terminal-main-session.jsonl";
-      const transcriptPath = `${sessionsDir}/${sessionFile}`;
-      await fs.writeFile(
-        transcriptPath,
-        `${JSON.stringify({ type: "session", id: "terminal-main-session" })}\n`,
-        "utf8",
-      );
-      await fs.utimes(transcriptPath, new Date(now - 1_000), new Date(now - 1_000));
-      mocks.loadSessionEntry.mockReturnValue({
-        cfg: {},
-        storePath: `${sessionsDir}/sessions.json`,
-        entry: {
-          sessionId: "terminal-main-session",
-          sessionFile,
-          status: "done",
-          updatedAt: now - 10_000,
-          sessionStartedAt: now - 60_000,
-          lastInteractionAt: now - 10_000,
-          startedAt: now - 20_000,
-          endedAt: now - 15_000,
-          runtimeMs: 5_000,
-          cliSessionBindings: {
-            "claude-cli": { sessionId: "old-claude-cli-session" },
-            "codex-cli": { sessionId: "old-codex-cli-session" },
-          },
-          cliSessionIds: {
-            "claude-cli": "old-claude-cli-session",
-            "codex-cli": "old-codex-cli-session",
-          },
-          claudeCliSessionId: "old-claude-cli-session",
-        },
-        canonicalKey: "agent:main:main",
       });
-
-      const capturedEntry = await runMainAgentAndCaptureEntry(
-        "test-idem-terminal-main-newer-transcript",
-      );
-
-      const call = await waitForAgentCommandCall<{ sessionId?: string }>();
-      expect(call.sessionId).toBe("terminal-main-session");
-      expect(capturedEntry?.sessionId).toBe("terminal-main-session");
-    });
-  });
+    },
+  );
 
   it("reuses terminal main sessions when the fresh store row has the transcript marker", async () => {
     const now = Date.parse("2026-05-18T09:47:30.000Z");

--- a/src/gateway/server-methods/agent.test.ts
+++ b/src/gateway/server-methods/agent.test.ts
@@ -1285,75 +1285,121 @@ describe("gateway agent handler", () => {
     expect(capturedEntry?.sessionFile).toBeUndefined();
   });
 
-  it.each([
-    { name: "status terminal row", status: "done" as const },
-    { name: "endedAt-only terminal row" },
-  ])(
-    "rotates a terminal main session from a $name when its transcript is newer",
-    async (scenario) => {
-      const now = Date.parse("2026-05-18T09:47:00.000Z");
-      vi.useFakeTimers({ toFake: ["Date"] });
-      dateOnlyFakeClockActive = true;
-      vi.setSystemTime(now);
+  it("rotates an endedAt-only terminal main session when its transcript is newer", async () => {
+    const now = Date.parse("2026-05-18T09:47:00.000Z");
+    vi.useFakeTimers({ toFake: ["Date"] });
+    dateOnlyFakeClockActive = true;
+    vi.setSystemTime(now);
 
-      await withTempDir(
-        { prefix: "openclaw-gateway-terminal-main-newer-transcript-" },
-        async (root) => {
-          const sessionsDir = `${root}/sessions`;
-          await fs.mkdir(sessionsDir, { recursive: true });
-          const sessionFile = "terminal-main-session.jsonl";
-          const transcriptPath = `${sessionsDir}/${sessionFile}`;
-          await fs.writeFile(
-            transcriptPath,
-            `${JSON.stringify({ type: "session", id: "terminal-main-session" })}\n`,
-            "utf8",
-          );
-          await fs.utimes(transcriptPath, new Date(now - 1_000), new Date(now - 1_000));
-          mocks.loadSessionEntry.mockReturnValue({
-            cfg: {},
-            storePath: `${sessionsDir}/sessions.json`,
-            entry: {
-              sessionId: "terminal-main-session",
-              sessionFile,
-              ...(scenario.status ? { status: scenario.status } : {}),
-              updatedAt: now - 10_000,
-              sessionStartedAt: now - 60_000,
-              lastInteractionAt: now - 10_000,
-              startedAt: now - 20_000,
-              endedAt: now - 15_000,
-              runtimeMs: 5_000,
-              cliSessionBindings: {
-                "claude-cli": { sessionId: "old-claude-cli-session" },
-                "codex-cli": { sessionId: "old-codex-cli-session" },
-              },
-              cliSessionIds: {
-                "claude-cli": "old-claude-cli-session",
-                "codex-cli": "old-codex-cli-session",
-              },
-              claudeCliSessionId: "old-claude-cli-session",
+    await withTempDir(
+      { prefix: "openclaw-gateway-terminal-main-newer-transcript-" },
+      async (root) => {
+        const sessionsDir = `${root}/sessions`;
+        await fs.mkdir(sessionsDir, { recursive: true });
+        const sessionFile = "terminal-main-session.jsonl";
+        const transcriptPath = `${sessionsDir}/${sessionFile}`;
+        await fs.writeFile(
+          transcriptPath,
+          `${JSON.stringify({ type: "session", id: "terminal-main-session" })}\n`,
+          "utf8",
+        );
+        await fs.utimes(transcriptPath, new Date(now - 1_000), new Date(now - 1_000));
+        mocks.loadSessionEntry.mockReturnValue({
+          cfg: {},
+          storePath: `${sessionsDir}/sessions.json`,
+          entry: {
+            sessionId: "terminal-main-session",
+            sessionFile,
+            updatedAt: now - 10_000,
+            sessionStartedAt: now - 60_000,
+            lastInteractionAt: now - 10_000,
+            startedAt: now - 20_000,
+            endedAt: now - 15_000,
+            runtimeMs: 5_000,
+            cliSessionBindings: {
+              "claude-cli": { sessionId: "old-claude-cli-session" },
+              "codex-cli": { sessionId: "old-codex-cli-session" },
             },
-            canonicalKey: "agent:main:main",
-          });
+            cliSessionIds: {
+              "claude-cli": "old-claude-cli-session",
+              "codex-cli": "old-codex-cli-session",
+            },
+            claudeCliSessionId: "old-claude-cli-session",
+          },
+          canonicalKey: "agent:main:main",
+        });
 
-          const capturedEntry = await runMainAgentAndCaptureEntry(
-            "test-idem-terminal-main-newer-transcript",
-          );
+        const capturedEntry = await runMainAgentAndCaptureEntry(
+          "test-idem-terminal-main-newer-transcript",
+        );
 
-          const call = await waitForAgentCommandCall<{ sessionId?: string }>();
-          expect(call.sessionId).not.toBe("terminal-main-session");
-          expect(capturedEntry?.sessionId).not.toBe("terminal-main-session");
-          expect(capturedEntry?.status).toBeUndefined();
-          expect(capturedEntry?.startedAt).toBeUndefined();
-          expect(capturedEntry?.endedAt).toBeUndefined();
-          expect(capturedEntry?.runtimeMs).toBeUndefined();
-          expect(capturedEntry?.sessionFile).toBeUndefined();
-          expect(capturedEntry?.cliSessionBindings).toBeUndefined();
-          expect(capturedEntry?.cliSessionIds).toBeUndefined();
-          expect(capturedEntry?.claudeCliSessionId).toBeUndefined();
-        },
+        const call = await waitForAgentCommandCall<{ sessionId?: string }>();
+        expect(call.sessionId).not.toBe("terminal-main-session");
+        expect(capturedEntry?.sessionId).not.toBe("terminal-main-session");
+        expect(capturedEntry?.status).toBeUndefined();
+        expect(capturedEntry?.startedAt).toBeUndefined();
+        expect(capturedEntry?.endedAt).toBeUndefined();
+        expect(capturedEntry?.runtimeMs).toBeUndefined();
+        expect(capturedEntry?.sessionFile).toBeUndefined();
+        expect(capturedEntry?.cliSessionBindings).toBeUndefined();
+        expect(capturedEntry?.cliSessionIds).toBeUndefined();
+        expect(capturedEntry?.claudeCliSessionId).toBeUndefined();
+      },
+    );
+  });
+
+  it("reuses a status-done terminal main session when its transcript is newer", async () => {
+    const now = Date.parse("2026-05-18T09:47:00.000Z");
+    vi.useFakeTimers({ toFake: ["Date"] });
+    dateOnlyFakeClockActive = true;
+    vi.setSystemTime(now);
+
+    await withTempDir({ prefix: "openclaw-gateway-terminal-main-done-reuse-" }, async (root) => {
+      const sessionsDir = `${root}/sessions`;
+      await fs.mkdir(sessionsDir, { recursive: true });
+      const sessionFile = "terminal-main-session.jsonl";
+      const transcriptPath = `${sessionsDir}/${sessionFile}`;
+      await fs.writeFile(
+        transcriptPath,
+        `${JSON.stringify({ type: "session", id: "terminal-main-session" })}\n`,
+        "utf8",
       );
-    },
-  );
+      await fs.utimes(transcriptPath, new Date(now - 1_000), new Date(now - 1_000));
+      mocks.loadSessionEntry.mockReturnValue({
+        cfg: {},
+        storePath: `${sessionsDir}/sessions.json`,
+        entry: {
+          sessionId: "terminal-main-session",
+          sessionFile,
+          status: "done",
+          updatedAt: now - 10_000,
+          sessionStartedAt: now - 60_000,
+          lastInteractionAt: now - 10_000,
+          startedAt: now - 20_000,
+          endedAt: now - 15_000,
+          runtimeMs: 5_000,
+          cliSessionBindings: {
+            "claude-cli": { sessionId: "old-claude-cli-session" },
+            "codex-cli": { sessionId: "old-codex-cli-session" },
+          },
+          cliSessionIds: {
+            "claude-cli": "old-claude-cli-session",
+            "codex-cli": "old-codex-cli-session",
+          },
+          claudeCliSessionId: "old-claude-cli-session",
+        },
+        canonicalKey: "agent:main:main",
+      });
+
+      const capturedEntry = await runMainAgentAndCaptureEntry(
+        "test-idem-terminal-main-newer-transcript",
+      );
+
+      const call = await waitForAgentCommandCall<{ sessionId?: string }>();
+      expect(call.sessionId).toBe("terminal-main-session");
+      expect(capturedEntry?.sessionId).toBe("terminal-main-session");
+    });
+  });
 
   it("reuses terminal main sessions when the fresh store row has the transcript marker", async () => {
     const now = Date.parse("2026-05-18T09:47:30.000Z");


### PR DESCRIPTION
## What Problem This Solves

Successful main sessions (`status: "done"`) can roll over to new session IDs and archive transcript as `.jsonl.reset.*` when the transcript file mtime is slightly newer than the registry `updatedAt`, even though the session completed successfully.
- Problem: `resolveTerminalMainSessionTranscriptRegistryCheck` applies the transcript freshness guard to `status: "done"` rows, forcing unnecessary session rotation on the next inbound message.
- Solution: Exclude `status: "done"` from the guard alongside the already-excluded `status: "failed"`, so successful sessions stay reusable.
- What changed: One condition in `src/config/sessions/lifecycle.ts` (core fix), test expectations in 3 test files.
- What did NOT change: `killed`/`timeout` still guarded; `endedAt-only` terminal rows still guarded; no config/API/docs changes.

## Change Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Fixes #99964
- Related #99971 (alternative PR)
- [x] This PR fixes a bug or regression

## Motivation

After a main session completes successfully (`status: "done"`), the next user message should reuse the same session. However, when the transcript file's mtime is slightly newer than the session registry's `updatedAt` (which can happen due to filesystem I/O timing — the transcript write may land after the registry update), `hasTerminalMainSessionTranscriptNewerThanRegistry` returns `true`, causing `canReuseSession` to be `false`. This forces a new UUID session and archives the old transcript as `.jsonl.reset.*`.

Three call paths are affected:
1. Gateway agent session admission (`src/gateway/server-methods/agent.ts:1956-1970`)
2. CLI command session resolver (`src/agents/command/session.ts:379-389`)
3. Auto-reply session (`src/auto-reply/reply/session.ts:548`)

All three use the same shared guard function, so fixing it in one place covers all paths.

## Evidence

- Behavior addressed: `resolveTerminalMainSessionTranscriptRegistryCheck()` now returns `undefined` for `status: "done"` rows, preventing transcript-mtime-based rollover for successful completions.
- Real environment tested: Linux x86_64, Node 22.19, branch `fix/done-session-transcript-guard-99964`

- Exact steps or command run after this patch:

```
node --import tsx /media/vdb/code/github/contributions/pr-99964-evidence/full-chain-proof.ts
node scripts/run-vitest.mjs src/commands/agent.session.test.ts --run
node scripts/run-vitest.mjs src/auto-reply/reply/session.test.ts --run -t "terminal"
node scripts/run-vitest.mjs src/gateway/server-methods/agent.test.ts --run -t "terminal"
```

- Evidence after fix:

```
============================================================
  PR #99964 Full-Chain Live Proof
============================================================

  Session status: done | transcript mtime > registry: YES

  [Layer 1] Guard function (shared by Gateway + CLI + Auto-reply)
    hasTerminalMainSessionTranscriptNewerThanRegistrySync() = false
    => PASS: Guard skipped for done sessions (enables reuse)

  [Layer 2] CLI resolveSession() - proven by passing test
    Test: 'reuses status-done terminal main sessions'
    File: src/commands/agent.session.test.ts
    Assertions: isNewSession=false, sessionId matches original
    => PASS (test suite: 8/8 passed)

  [Layer 3] Gateway handler - proven by passing test
    Test: 'reuses a status-done terminal main session when its transcript is newer'
    File: src/gateway/server-methods/agent.test.ts
    => PASS (test suite: 20/20 terminal tests passed)

  [Layer 4] Auto-reply session - proven by passing test
    Test: 'main status-done terminal rows reuse when transcript is newer'
    File: src/auto-reply/reply/session.test.ts
    => PASS (6/6 terminal tests passed)

  [Behavior Matrix] All 3 call paths, all session states
  +----------------+--------+-------------+----------+-----------+
  | Status         | mtime  | Before fix  | After fix | Guard    |
  +----------------+--------+-------------+----------+---------+
  | done           | > reg  | Rotation    | Reuses   | false    |
  | failed         | > reg  | Reuses      | Reuses   | false    |
  | killed         | > reg  | Rotation    | Rotation | true     |
  | timeout        | > reg  | Rotation    | Rotation | true     |
  | endedAt-only   | > reg  | Rotation    | Rotation | true     |
  +----------------+--------+-------------+----------+---------+

  ALL LAYERS PASSED
```

| Test file | Result |
|-----------|--------|
| `src/commands/agent.session.test.ts` | 8 passed |
| `src/auto-reply/reply/session.test.ts` (terminal) | 6 passed, 108 skipped |
| `src/gateway/server-methods/agent.test.ts` (terminal) | 20 passed, 308 skipped |

- Observed result after fix:
  1. `status: "done"` sessions with newer transcript mtime no longer trigger session rollover
  2. `failed` sessions remain reusable (existing behavior preserved)
  3. `killed`/`timeout`/`endedAt-only` sessions remain guarded (existing behavior preserved)
  4. All existing tests updated and pass

- What was not tested: Full Gateway with a real remote model provider — the session reuse decision happens before any model call, so mocked model responses in the Gateway tests prove the same code path. All 4 layers (guard function, CLI resolveSession, Gateway handler, auto-reply) are covered.


## Root Cause

In `resolveTerminalMainSessionTranscriptRegistryCheck()` (`src/config/sessions/lifecycle.ts:162-184`):

```
const hasTerminalLifecycle =
    isTerminalSessionStatus(params.entry.status) ||  // "done" is terminal
    resolvePositiveTimestamp(params.entry.endedAt) !== undefined;
if (!hasTerminalLifecycle) { return undefined; }
if (params.entry.status === "failed") {
    // Only "failed" was excluded — "done" fell through to the guard
    return undefined;
}
```

`isTerminalSessionStatus()` includes `"done"`, `"failed"`, `"killed"`, `"timeout"` — but only `"failed"` was excluded from the mtime check, leaving `"done"` (successful completion) unprotected.

**Provenance**: Introduced in `af906225fa` (Fermin Quant, 2026-06-25) as part of PRs #0c9ac48d and #57bed6ae which added the terminal-main transcript freshness guard.

## Alternative Approach Considered

Two approaches were considered:

**Option A (chosen)**: Exclude `status: "done"` from the transcript freshness guard. Minimal change, low risk.

**Option B (not chosen)**: Fix the persistence ordering so transcript mtime never exceeds registry `updatedAt`. This addresses the root cause (filesystem I/O timing), but involves more code paths and complexity. The persistence ordering issue is a known technical debt that could be addressed as a follow-up for other terminal states.

Option A was chosen because:
- It directly fixes the user-facing bug with minimal risk
- It follows the established pattern of excluding `failure` (same exclusion approach)
- The guard remains active for abnormal terminal states (`killed`, `timeout`, `endedAt-only`) where transcript-continuity recovery logic is still important
- A follow-up fix for persistence ordering would benefit all terminal states uniformly

## User-visible / Behavior Changes

Successful main-agent sessions will no longer unexpectedly roll over to a new session ID when the transcript mtime is slightly newer than the registry `updatedAt`. The `.jsonl.reset.*` archive pattern will no longer appear for normal successful runs.

## Security Impact

- [x] New permissions/capabilities? No
- [x] Secrets/tokens handling changed? No
- [x] New/changed network calls? No
- [x] Command/tool execution surface changed? No
- [x] Data access scope changed? No

## Regression Test Plan

- Updated existing test expectation in `src/gateway/server-methods/agent.test.ts` for `status: "done"` case (now expects reuse instead of rotation)
- Updated existing test expectation in `src/commands/agent.session.test.ts` for `status: "done"` cases (now expects reuse)
- Updated existing test expectation in `src/auto-reply/reply/session.test.ts` for the default-done case
- `endedAt-only` test cases unchanged (still assert rotation — guard remains active)
- All 3 affected test suites pass

## Human Verification

- Verified scenarios: status-done with newer transcript (reuse), endedAt-only with newer transcript (rotation), failed with newer transcript (reuse, unchanged), killed/timeout with newer transcript (rotation, unchanged)
- Edge cases checked: main session aliases (canonical, raw, custom) with done status; explicit session-id resume still works
- What you did NOT verify: Full Gateway E2E; real agent run producing the mtime ordering race

## Compatibility / Migration

- [x] Backward compatible? Yes — only relaxes session reuse, never tightens
- [x] Config/env changes? No
- [x] Migration needed? No

## Best-fix Verdict

- **Best fix**: Yes. The shared guard function is the right boundary because all three affected call paths (gateway, CLI, auto-reply) already depend on it. Adding the condition inline is minimal and follows the existing `failed` exclusion pattern.
- **Refactor needed**: No. A follow-up to fix persistence ordering (Option B) could be filed separately.
- **Alternative considered**: Fix persistence ordering so `updatedAt >= transcript mtime`. This is a deeper fix but involves more risk and wasn't necessary for this bug.

## Risks and Mitigations

- **Lowest risk**: Only relaxes the guard for successful completions (`status: "done"`). Abnormal terminal states (`killed`, `timeout`, `endedAt-only`) remain fully guarded.
- **Familiar pattern**: Follows the exact same approach as the existing `failed` exclusion.
- **Test coverage**: All 3 call paths covered by existing tests, with updated expectations for the new behavior.

## AI Assistance

- **AI-assisted**: Yes
- **Co-Authored-By**: Claude Opus 4.8 <noreply@anthropic.com>
- **Human confirmed understanding of code changes**: Yes

Fixes #99964