### PR TITLE
fix(android): serialize PTT microphone ownership

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- **Android PTT microphone ownership:** pause realtime relay capture while push-to-talk owns the microphone, then resume only for the same completed capture. (#99986) Thanks @NianJiuZst.
 - **Small-context compaction:** cap the effective reserve against the known model context window so small local models do not enter compaction from the first token. (#100621) Thanks @vincentkoc.
 - **Plugin install diagnostics:** suppress the misleading hook-pack fallback after plugin install failures only when the hook manifest is absent, while preserving actionable malformed hook-pack errors. (#100554) Thanks @vincentkoc.
 - **Config validation diagnostics:** emit each unchanged sanitized validation-warning payload once per config path, reset deduplication after a clean validation, and preserve the warning fingerprint across transient invalid reads and failed refreshes. (#100569, #25574) Thanks @vincentkoc.

--- a/apps/android/app/src/main/java/ai/openclaw/app/voice/TalkModeManager.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/voice/TalkModeManager.kt
@@ -33,6 +33,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.NonCancellable
 import kotlinx.coroutines.TimeoutCancellationException
+import kotlinx.coroutines.cancelAndJoin
 import kotlinx.coroutines.channels.BufferOverflow
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.delay
@@ -205,6 +206,8 @@ class TalkModeManager internal constructor(
   @Volatile private var realtimeSessionId: String? = null
   private var realtimeCaptureJob: Job? = null
   private var realtimeAppendJob: Job? = null
+  private val realtimeCapturePauseLock = Any()
+  private var realtimeCapturePause: RealtimeCapturePause? = null
 
   // Realtime tool calls can complete before their chat final arrives; cache by call/run id until both sides meet.
   private val realtimeToolLock = Any()
@@ -315,6 +318,19 @@ class TalkModeManager internal constructor(
     val completion: CompletableDeferred<TalkPttStopPayload>?,
   )
 
+  private data class RealtimeCapturePause(
+    // Null while relay creation is still in flight. Keeping the PTT turn here
+    // prevents a late relay response from opening a second microphone capture.
+    val sessionId: String?,
+    val pttCaptureId: String,
+  )
+
+  private enum class RealtimeCaptureResume {
+    Skipped,
+    Resumed,
+    Disconnected,
+  }
+
   private suspend fun startPushToTalk(
     allowNewCapture: Boolean,
     canStartCapture: () -> Boolean,
@@ -373,6 +389,19 @@ class TalkModeManager internal constructor(
         activePttCaptureId = captureId
         pttCompletion = completion
         try {
+          // PTT owns the microphone until its turn finishes. Waiting here prevents
+          // SpeechRecognizer from racing the realtime AudioRecord teardown.
+          withContext(NonCancellable) {
+            pauseRealtimeCaptureForPushToTalk(captureId)
+          }
+          if (
+            activePttCaptureId != captureId ||
+              captureGeneration != startGeneration.get() ||
+              !canStartCapture() ||
+              stopRequested
+          ) {
+            throw IllegalStateException("NODE_BACKGROUND_UNAVAILABLE: command requires foreground")
+          }
           recognizer?.cancel()
           recognizer?.destroy()
           recognizer = SpeechRecognizer.createSpeechRecognizer(context).also { it.setRecognitionListener(listener) }
@@ -387,10 +416,8 @@ class TalkModeManager internal constructor(
           activePttCaptureId = null
           pttCompletion = null
           completion?.cancel()
+          resumeRealtimeCaptureAfterPushToTalk(captureId)
           _statusText.value = if (_isEnabled.value) "Listening" else "Ready"
-          if (_isEnabled.value) {
-            start()
-          }
           throw err
         }
         _statusText.value = "Listening (PTT)"
@@ -432,9 +459,7 @@ class TalkModeManager internal constructor(
 
       if (transcript.isEmpty()) {
         _statusText.value = if (_isEnabled.value) "Listening" else "Ready"
-        if (_isEnabled.value) {
-          start()
-        }
+        resumeRealtimeCaptureAfterPushToTalk(captureId)
         return@withContext finishPushToTalk(
           TalkPttStopPayload(captureId = captureId, transcript = null, status = "empty"),
           cleared.completion,
@@ -443,9 +468,7 @@ class TalkModeManager internal constructor(
 
       if (!isConnected()) {
         _statusText.value = "Gateway not connected"
-        if (_isEnabled.value) {
-          start()
-        }
+        resumeRealtimeCaptureAfterPushToTalk(captureId)
         return@withContext finishPushToTalk(
           TalkPttStopPayload(captureId = captureId, transcript = transcript, status = "offline"),
           cleared.completion,
@@ -454,7 +477,11 @@ class TalkModeManager internal constructor(
 
       _statusText.value = "Thinking…"
       scope.launch {
-        finalizeTranscript(transcript)
+        try {
+          finalizeTranscript(transcript)
+        } finally {
+          resumeRealtimeCaptureAfterPushToTalk(captureId)
+        }
       }
       finishPushToTalk(
         TalkPttStopPayload(captureId = captureId, transcript = transcript, status = "queued"),
@@ -474,9 +501,7 @@ class TalkModeManager internal constructor(
         clearPushToTalkRecognition(captureId)
           ?: return@withContext TalkPttStopPayload(captureId = captureId, transcript = null, status = "idle")
       _statusText.value = if (_isEnabled.value) "Listening" else "Ready"
-      if (_isEnabled.value) {
-        start()
-      }
+      resumeRealtimeCaptureAfterPushToTalk(captureId)
       finishPushToTalk(
         TalkPttStopPayload(captureId = captureId, transcript = null, status = "cancelled"),
         cleared.completion,
@@ -808,9 +833,11 @@ class TalkModeManager internal constructor(
     cancelActivePlayback()
     stopTextToSpeechPlayback()
     withContext(Dispatchers.Main) {
-      recognizer?.cancel()
-      recognizer?.destroy()
-      recognizer = null
+      if (activePttCaptureId == null) {
+        recognizer?.cancel()
+        recognizer?.destroy()
+        recognizer = null
+      }
     }
 
     _statusText.value = "Connecting…"
@@ -833,11 +860,27 @@ class TalkModeManager internal constructor(
       throw CancellationException("realtime talk stopped while connecting")
     }
 
-    realtimeSessionId = sessionId
     realtimeOutputSuppressed = false
-    _isListening.value = true
-    _statusText.value = "Listening"
-    startRealtimeCapture(sessionId)
+    val capturePaused =
+      synchronized(realtimeCapturePauseLock) {
+        // Session publication and capture installation are one transition. PTT
+        // therefore either blocks startup or detaches every installed capture job.
+        realtimeSessionId = sessionId
+        val pause = realtimeCapturePause
+        if (pause != null) {
+          realtimeCapturePause = pause.copy(sessionId = sessionId)
+          true
+        } else {
+          _isListening.value = true
+          _statusText.value = "Listening"
+          startRealtimeCaptureLocked(sessionId)
+          false
+        }
+      }
+    if (capturePaused) {
+      Log.d(tag, "realtime session ready; capture paused for PTT relaySessionId=$sessionId")
+      return
+    }
     Log.d(tag, "realtime session started relaySessionId=$sessionId")
   }
 
@@ -865,8 +908,9 @@ class TalkModeManager internal constructor(
       else -> "Talk failed: Realtime provider closed: $reason"
     }
 
+  /** Caller holds [realtimeCapturePauseLock] so PTT cannot miss newly installed jobs. */
   @SuppressLint("MissingPermission")
-  private fun startRealtimeCapture(sessionId: String) {
+  private fun startRealtimeCaptureLocked(sessionId: String) {
     realtimeCaptureJob?.cancel()
     realtimeAppendJob?.cancel()
     val audioFrames =
@@ -1180,17 +1224,23 @@ class TalkModeManager internal constructor(
     preserveStatus: Boolean = false,
   ) {
     val status = _statusText.value
-    val sessionId = realtimeSessionId
-    realtimeSessionId = null
+    val (sessionId, captureJobs) =
+      synchronized(realtimeCapturePauseLock) {
+        val currentSessionId = realtimeSessionId
+        val currentCaptureJobs = realtimeCaptureJob to realtimeAppendJob
+        realtimeSessionId = null
+        realtimeCaptureJob = null
+        realtimeAppendJob = null
+        realtimeCapturePause = null
+        currentSessionId to currentCaptureJobs
+      }
     realtimeOutputSuppressed = false
     if (cancelCapture) {
-      realtimeCaptureJob?.cancel()
+      captureJobs.first?.cancel()
     }
     if (cancelAppend) {
-      realtimeAppendJob?.cancel()
+      captureJobs.second?.cancel()
     }
-    realtimeCaptureJob = null
-    realtimeAppendJob = null
     synchronized(realtimeToolLock) {
       realtimeToolRuns.clear()
       pendingRealtimeToolCalls.clear()
@@ -1208,6 +1258,55 @@ class TalkModeManager internal constructor(
     if (closeSession && !sessionId.isNullOrBlank()) {
       scope.launch {
         closeRealtimeSession(sessionId)
+      }
+    }
+  }
+
+  internal suspend fun pauseRealtimeCaptureForPushToTalk(captureId: String) {
+    val captureJobs =
+      synchronized(realtimeCapturePauseLock) {
+        val currentSessionId = realtimeSessionId
+        val currentCaptureJobs = realtimeCaptureJob to realtimeAppendJob
+        realtimeCapturePause = RealtimeCapturePause(sessionId = currentSessionId, pttCaptureId = captureId)
+        realtimeCaptureJob = null
+        realtimeAppendJob = null
+        currentCaptureJobs
+      }
+    val (captureJob, appendJob) = captureJobs
+    captureJob?.cancelAndJoin()
+    appendJob?.cancelAndJoin()
+  }
+
+  internal fun resumeRealtimeCaptureAfterPushToTalk(captureId: String) {
+    val outcome =
+      synchronized(realtimeCapturePauseLock) {
+        val current = realtimeCapturePause ?: return@synchronized RealtimeCaptureResume.Skipped
+        if (current.pttCaptureId != captureId || activePttCaptureId != null) {
+          return@synchronized RealtimeCaptureResume.Skipped
+        }
+        val sessionId = current.sessionId
+        if (!_isEnabled.value || stopRequested || sessionId == null || realtimeSessionId != sessionId) {
+          realtimeCapturePause = null
+          return@synchronized RealtimeCaptureResume.Skipped
+        }
+        if (!isConnected()) return@synchronized RealtimeCaptureResume.Disconnected
+        if (realtimeCaptureJob?.isActive == true || realtimeAppendJob?.isActive == true) {
+          realtimeCapturePause = null
+          return@synchronized RealtimeCaptureResume.Skipped
+        }
+        realtimeCapturePause = null
+        _isListening.value = true
+        _statusText.value = "Listening"
+        startRealtimeCaptureLocked(sessionId)
+        RealtimeCaptureResume.Resumed
+      }
+    when (outcome) {
+      RealtimeCaptureResume.Skipped -> return
+      RealtimeCaptureResume.Resumed -> return
+      RealtimeCaptureResume.Disconnected -> {
+        _statusText.value = "Gateway not connected"
+        stopRealtimeRelay(preserveStatus = true)
+        disableRealtimeModeAndNotifyOwner()
       }
     }
   }

--- a/apps/android/app/src/test/java/ai/openclaw/app/voice/TalkModeManagerTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/voice/TalkModeManagerTest.kt
@@ -653,6 +653,103 @@ class TalkModeManagerTest {
   }
 
   @Test
+  fun pushToTalkPauseWaitsForRealtimeCaptureJobs() =
+    runTest {
+      val manager = createManager()
+      val captureJob = Job()
+      val appendJob = Job()
+      setPrivateField(manager, "realtimeSessionId", "relay-1")
+      setPrivateField(manager, "realtimeCaptureJob", captureJob)
+      setPrivateField(manager, "realtimeAppendJob", appendJob)
+      setMutableStateFlow(manager, "_isEnabled", true)
+
+      manager.pauseRealtimeCaptureForPushToTalk("capture-1")
+
+      assertTrue(captureJob.isCancelled)
+      assertTrue(appendJob.isCancelled)
+      assertNull(readPrivateField(manager, "realtimeCaptureJob"))
+      assertNull(readPrivateField(manager, "realtimeAppendJob"))
+      assertTrue(readPrivateField(manager, "realtimeCapturePause") != null)
+    }
+
+  @Test
+  fun stalePushToTalkCompletionCannotResumeNewerPause() =
+    runTest {
+      val manager = createManager()
+      setPrivateField(manager, "realtimeSessionId", "relay-1")
+      setMutableStateFlow(manager, "_isEnabled", true)
+      manager.pauseRealtimeCaptureForPushToTalk("capture-new")
+      setPrivateField(manager, "activePttCaptureId", "capture-new")
+
+      manager.resumeRealtimeCaptureAfterPushToTalk("capture-old")
+
+      assertTrue(readPrivateField(manager, "realtimeCapturePause") != null)
+      assertEquals("capture-new", readPrivateField(manager, "activePttCaptureId"))
+    }
+
+  @Test
+  fun pushToTalkPauseOutlivesRecognitionWhileRelayConnects() =
+    runTest {
+      val manager = createManager()
+
+      manager.pauseRealtimeCaptureForPushToTalk("capture-1")
+      setPrivateField(manager, "activePttCaptureId", null)
+
+      val pause = readPrivateField(manager, "realtimeCapturePause")
+      assertTrue(pause != null)
+      assertNull(readPrivateField(pause!!, "sessionId"))
+      assertEquals("capture-1", readPrivateField(pause, "pttCaptureId"))
+
+      manager.resumeRealtimeCaptureAfterPushToTalk("capture-1")
+
+      assertNull(readPrivateField(manager, "realtimeCapturePause"))
+    }
+
+  @Test
+  fun resumingRealtimeCaptureRestoresListeningState() =
+    runTest {
+      val manager = createManager(scope = this)
+      setPrivateField(manager, "realtimeSessionId", "relay-1")
+      setMutableStateFlow(manager, "_isEnabled", true)
+      manager.pauseRealtimeCaptureForPushToTalk("capture-1")
+      setMutableStateFlow(manager, "_isListening", false)
+      setMutableStateFlow(manager, "_statusText", "Thinking…")
+
+      manager.resumeRealtimeCaptureAfterPushToTalk("capture-1")
+
+      assertTrue(manager.isListening.value)
+      assertEquals("Listening", manager.statusText.value)
+      manager.stopAllCapture()
+    }
+
+  @Test
+  fun disconnectedRelayDoesNotResumeAfterPushToTalk() =
+    runTest {
+      var stoppedByRelay = false
+      val manager =
+        createManager(
+          scope = this,
+          isConnected = { false },
+          onStoppedByRelay = { stoppedByRelay = true },
+        )
+      setPrivateField(manager, "realtimeSessionId", "relay-1")
+      setMutableStateFlow(manager, "_isEnabled", true)
+      manager.pauseRealtimeCaptureForPushToTalk("capture-1")
+      setMutableStateFlow(manager, "_isListening", false)
+      setMutableStateFlow(manager, "_statusText", "Gateway not connected")
+
+      manager.resumeRealtimeCaptureAfterPushToTalk("capture-1")
+
+      assertFalse(manager.isListening.value)
+      assertFalse(manager.isEnabled.value)
+      assertTrue(stoppedByRelay)
+      assertEquals("Gateway not connected", manager.statusText.value)
+      assertNull(readPrivateField(manager, "realtimeSessionId"))
+      assertNull(readPrivateField(manager, "realtimeCaptureJob"))
+      assertNull(readPrivateField(manager, "realtimeAppendJob"))
+    }
+
+  @Test
   @OptIn(ExperimentalCoroutinesApi::class)
   fun chatFinalWaitUsesGatewayEventTimeout() =
     runTest {


### PR DESCRIPTION
## What Problem This Solves

Android Talk Mode could keep realtime relay microphone capture running while push-to-talk started Android `SpeechRecognizer`. The same speech could reach both the realtime relay and PTT paths, while `AudioRecord` and the system recognizer contended for the microphone.

## Why This Change Was Made

This change gives each PTT capture explicit ownership over the realtime capture lifecycle:

- PTT atomically detaches realtime capture and append jobs, then waits for both to finish before starting `SpeechRecognizer`.
- A relay that finishes connecting during PTT records its session under the existing pause instead of opening a second microphone capture.
- Completion resumes only when the same PTT capture still owns the pause and the same relay session remains enabled and connected.
- Stale completion, disconnect, stop, cancel, and empty/offline exits clear or preserve ownership deterministically.

The relay session remains open during a normal PTT turn; only local capture is paused.

## User Impact

Android Talk Mode no longer lets realtime relay capture overlap PTT recognition. A completed PTT turn resumes the correct relay capture, while stale turns cannot restart or tear down newer microphone ownership.

## Evidence

- Testbox Actions 28777723406: focused `TalkModeManagerTest` plus Android main/test ktlint, passed.
- Testbox Actions 28778176379: repository changed-surface gate, passed.
- Focused regression coverage: active relay pause/join, relay-ready-during-PTT, stale completion, normal resume, and disconnect cleanup.
- Fresh autoreview after the final state-machine rewrite: no actionable findings.
- `git diff --check`: passed.

No physical Android device was attached, so real microphone handoff remains an explicit proof gap; the concurrency and ownership transitions are covered by focused Robolectric tests.
