### PR TITLE
test: speed up Docker scheduler coverage

### DIFF
--- a/test/scripts/docker-all-scheduler.test.ts
+++ b/test/scripts/docker-all-scheduler.test.ts
@@ -519,8 +519,8 @@ postgres Created
       )}`,
       env: process.env,
       label: "oversized-capture-timeout",
-        timeoutKillGraceMs: Number.MAX_SAFE_INTEGER,
-        timeoutMs: Number.MAX_SAFE_INTEGER,
+      timeoutKillGraceMs: Number.MAX_SAFE_INTEGER,
+      timeoutMs: Number.MAX_SAFE_INTEGER,
     });
 
     expect(result).toMatchObject({
@@ -608,7 +608,7 @@ setInterval(() => {}, 1000);
       command: `exec ${JSON.stringify(process.execPath)} ${JSON.stringify(scriptPath)}`,
       env: process.env,
       label: "oversized-timeout-grace",
-        timeoutKillGraceMs: Number.MAX_SAFE_INTEGER,
+      timeoutKillGraceMs: Number.MAX_SAFE_INTEGER,
       timeoutMs: 500,
     });
 
@@ -730,12 +730,17 @@ setInterval(() => {}, 1000);
 `,
       "utf8",
     );
+    // Preserve the production 10s grace while accelerating only this spawned proof's clock.
     writeFileSync(
       runnerPath,
       `
-import { runShellCommand } from ${JSON.stringify(
+const realNow = Date.now.bind(Date);
+const startedAt = realNow();
+Date.now = () => startedAt + (realNow() - startedAt) * 100;
+
+const { runShellCommand } = await import(${JSON.stringify(
         new URL("../../scripts/test-docker-all.mjs", import.meta.url).href,
-      )};
+      )});
 
 await runShellCommand({
   command: ${JSON.stringify(`exec ${JSON.stringify(process.execPath)} ${JSON.stringify(leaderPath)}`)},


### PR DESCRIPTION
## What Problem This Solves

`test/scripts/docker-all-scheduler.test.ts` spent more than ten seconds of each run waiting through the production shutdown grace in one parent-signal proof. That made this 27-case file the second-slowest measured tooling test despite the behavior itself being deterministic.

## Why This Change Was Made

Scale `Date.now` only inside the disposable spawned proof process before it imports the real scheduler module. The production 10-second grace and implementation remain unchanged; the test still drives the real SIGTERM, grace polling, SIGKILL escalation, descendant cleanup, second-command suppression, and exit-143 path.

All 27 cases were audited. Each protects a distinct CLI, scheduler admission, artifact, log-bound, timer-clamp, process-tree, or operator-policy contract, so none were removed.

## User Impact

No runtime behavior changes. The focused test is 55.6% faster locally and 73.2% faster on Linux, with lower local peak RSS and identical behavioral coverage.

## Evidence

- Tests: 27 -> 27
- Local focused: 20.72s -> 9.21s wall; 15.47s -> 5.27s file time; 304.3MB -> 255.9MB max RSS
- Linux focused: 13.577s -> 3.643s file time
- Linux proof: Testbox `tbx_01kwpqmcbfszdwxzk18xae9t5e`, Actions run https://github.com/openclaw/openclaw/actions/runs/28708869458
- Remote `check:changed`: Testbox `tbx_01kwpqqf7cyvdh1rvtybhpz06q`, Actions run https://github.com/openclaw/openclaw/actions/runs/28708913375, exit 0
- `pnpm test:changed` — 27/27 pass
- `pnpm format:check test/scripts/docker-all-scheduler.test.ts` — pass
- `git diff --check` — pass
- Fresh autoreview — clean, 0.98 confidence

Related: #57266
