### PR TITLE
fix(signal): bound receive websocket payloads

### DIFF
--- a/extensions/signal/src/client-container.test.ts
+++ b/extensions/signal/src/client-container.test.ts
@@ -37,12 +37,14 @@ function bodyStream(text: string): { body: ReadableStream<Uint8Array> } {
 const wsMockState = vi.hoisted(() => ({
   behavior: "close" as "close" | "open" | "error" | "unexpected-response",
   urls: [] as string[],
+  options: [] as Array<{ maxPayload?: number } | undefined>,
 }));
 
 beforeEach(() => {
   vi.spyOn(fetchModule, "resolveFetch").mockReturnValue(mockFetch as unknown as typeof fetch);
   wsMockState.behavior = "close";
   wsMockState.urls = [];
+  wsMockState.options = [];
 });
 
 function requireFetchCall(index = 0): [RequestInfo | URL, RequestInit] {
@@ -84,8 +86,9 @@ vi.mock("ws", () => ({
   default: class MockWebSocket {
     private handlers = new Map<string, Array<(...args: unknown[]) => void>>();
 
-    constructor(url: string | URL) {
+    constructor(url: string | URL, options?: { maxPayload?: number }) {
       wsMockState.urls.push(String(url));
+      wsMockState.options.push(options);
       setTimeout(() => {
         if (wsMockState.behavior === "open") {
           this.emit("open");
@@ -202,6 +205,7 @@ describe("containerCheck", () => {
 
     expect(result).toEqual({ ok: true, status: 101, error: null });
     expect(wsMockState.urls).toEqual(["ws://localhost:8080/v1/receive/%2B14259798283"]);
+    expect(wsMockState.options).toEqual([{ maxPayload: 1024 * 1024 }]);
   });
 
   it("rejects container receive endpoints that do not upgrade to WebSocket", async () => {
@@ -945,6 +949,7 @@ describe("streamContainerEvents", () => {
     expect(log).toHaveBeenCalledWith(
       "[signal-ws] connecting to ws://localhost:8080/v1/receive/<redacted>",
     );
+    expect(wsMockState.options).toEqual([{ maxPayload: 1024 * 1024 }]);
     expectMockLogNotContains(log, "+14259798283");
     expectMockLogNotContains(log, "%2B14259798283");
   });

--- a/extensions/signal/src/client-container.ts
+++ b/extensions/signal/src/client-container.ts
@@ -54,6 +54,8 @@ export type ContainerWebSocketMessage = {
 
 const DEFAULT_TIMEOUT_MS = 10_000;
 const DEFAULT_ATTACHMENT_RESPONSE_MAX_BYTES = 1_048_576;
+// Receive envelopes contain JSON metadata; attachment bytes are fetched separately.
+// Keep the ws pre-buffer limit narrow so a container cannot force 100 MiB frames.
 const SIGNAL_CONTAINER_WS_MAX_PAYLOAD_BYTES = 1024 * 1024;
 const CONTAINER_TEXT_STYLE_MARKERS: Record<string, string> = {
   BOLD: "**",

--- a/extensions/signal/src/client-container.ts
+++ b/extensions/signal/src/client-container.ts
@@ -54,6 +54,7 @@ export type ContainerWebSocketMessage = {
 
 const DEFAULT_TIMEOUT_MS = 10_000;
 const DEFAULT_ATTACHMENT_RESPONSE_MAX_BYTES = 1_048_576;
+const SIGNAL_CONTAINER_WS_MAX_PAYLOAD_BYTES = 1024 * 1024;
 const CONTAINER_TEXT_STYLE_MARKERS: Record<string, string> = {
   BOLD: "**",
   ITALIC: "*",
@@ -176,7 +177,7 @@ function containerReceiveCheck(
       resolve(result);
     };
     try {
-      ws = new WebSocket(wsUrl);
+      ws = new WebSocket(wsUrl, { maxPayload: SIGNAL_CONTAINER_WS_MAX_PAYLOAD_BYTES });
     } catch (err) {
       settle({
         ok: false,
@@ -328,7 +329,7 @@ export async function streamContainerEvents(params: {
     };
 
     try {
-      ws = new WebSocket(wsUrl);
+      ws = new WebSocket(wsUrl, { maxPayload: SIGNAL_CONTAINER_WS_MAX_PAYLOAD_BYTES });
     } catch (err) {
       logError(
         `[signal-ws] failed to create WebSocket: ${err instanceof Error ? err.message : String(err)}`,


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where Signal container receive WebSocket connections could accept the upstream `ws` client default 100 MiB inbound message window for receive events.

## Why This Change Was Made

Signal container receive events are JSON envelopes, so both the health-check receive probe and the long-running receive stream now use a 1 MiB inbound WebSocket payload cap.

## User Impact

Signal container users keep normal receive events, while a buggy or hostile container can no longer make OpenClaw buffer oversized receive frames up to the broader `ws` default.

## Evidence

- Red test before the fix: `node scripts/run-vitest.mjs extensions/signal/src/client-container.test.ts --reporter=verbose` failed because both WebSocket constructors received `undefined` options instead of `{ maxPayload: 1048576 }`.
- `node scripts/run-vitest.mjs extensions/signal/src/client-container.test.ts --reporter=verbose`: 1 file / 53 tests passed.
- `node_modules/.bin/oxfmt --check extensions/signal/src/client-container.ts extensions/signal/src/client-container.test.ts`: passed.
- `git diff --check`: passed.
- Loopback proof with production `streamContainerEvents`: a normal Signal-shaped JSON event was received, then an oversized frame was rejected by the `ws` maxPayload path.

```text
$ node --import tsx --input-type=module
{
  "configuredMaxPayloadBytes": 1048576,
  "normalEvents": 1,
  "oversizedFrameBytes": 1048620,
  "clientRejectedOversized": true,
  "serverCloseCode": 1009,
  "redactedConnectLog": "[signal-ws] connecting to ws://127.0.0.1:51145/v1/receive/<redacted>"
}
```

AI-assisted: built with Codex
