### PR TITLE
fix(huggingface): bound model discovery JSON reads

### DIFF
--- a/extensions/huggingface/models.test.ts
+++ b/extensions/huggingface/models.test.ts
@@ -108,6 +108,42 @@ describe("huggingface models", () => {
     expect(timeoutSpy).toHaveBeenCalledWith(MAX_TIMER_TIMEOUT_MS);
   });
 
+  it("reads live discovery responses through the bounded JSON reader", async () => {
+    process.env.VITEST = "false";
+    process.env.NODE_ENV = "development";
+    stubAbortSignalTimeout();
+    const response = new Response(
+      JSON.stringify({
+        data: [
+          {
+            id: "test-org/Test-Model",
+            owned_by: "test-org",
+            providers: [{ context_length: 4096 }],
+          },
+        ],
+      }),
+      { status: 200, headers: { "Content-Type": "application/json" } },
+    );
+    const jsonSpy = vi
+      .spyOn(response, "json")
+      .mockRejectedValue(new Error("unbounded response.json should not be called"));
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => response),
+    );
+
+    const models = await discoverHuggingfaceModels("hf_test_token");
+
+    expect(jsonSpy).not.toHaveBeenCalled();
+    expect(models).toEqual([
+      expect.objectContaining({
+        id: "test-org/Test-Model",
+        name: "test-org/Test-Model",
+        contextWindow: 4096,
+      }),
+    ]);
+  });
+
   describe("isHuggingfacePolicyLocked", () => {
     it("returns true for :cheapest and :fastest refs", () => {
       expect(isHuggingfacePolicyLocked("huggingface/deepseek-ai/DeepSeek-R1:cheapest")).toBe(true);

--- a/extensions/huggingface/models.ts
+++ b/extensions/huggingface/models.ts
@@ -1,5 +1,6 @@
 // Huggingface plugin module implements models behavior.
 import { resolveTimerTimeoutMs } from "openclaw/plugin-sdk/number-runtime";
+import { readProviderJsonResponse } from "openclaw/plugin-sdk/provider-http";
 import type { ModelDefinitionConfig } from "openclaw/plugin-sdk/provider-model-types";
 import {
   fetchWithSsrFGuard,
@@ -165,7 +166,10 @@ export async function discoverHuggingfaceModels(
         return HUGGINGFACE_MODEL_CATALOG.map(buildHuggingfaceModelDefinition);
       }
 
-      const body = (await response.json()) as OpenAIListModelsResponse;
+      const body = await readProviderJsonResponse<OpenAIListModelsResponse>(
+        response,
+        "huggingface-model-discovery",
+      );
       const data = body?.data;
       if (!Array.isArray(data) || data.length === 0) {
         return HUGGINGFACE_MODEL_CATALOG.map(buildHuggingfaceModelDefinition);


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where Hugging Face model discovery could buffer an unbounded JSON response when the live `/models` endpoint returns a large or hostile body.

## Why This Change Was Made

Live discovery now uses the shared bounded provider JSON reader instead of native `Response.json()`. The fallback catalog behavior is unchanged when discovery fails or returns no usable models.

## User Impact

Users can keep live Hugging Face model discovery enabled without letting an oversized model-list response grow memory without the provider response cap.

## Evidence

- Red before fix: `node scripts/run-vitest.mjs extensions/huggingface/models.test.ts --reporter=verbose` failed because native `response.json()` was called.
- `node scripts/run-vitest.mjs extensions/huggingface/models.test.ts --reporter=verbose`: passed 1 file, 9 tests.
- `node_modules/.bin/oxfmt --check extensions/huggingface/models.ts extensions/huggingface/models.test.ts && git diff --check`: passed.

```text
✓ huggingface models > reads live discovery responses through the bounded JSON reader
Test Files  1 passed (1)
Tests  9 passed (9)
```

AI-assisted: built with Codex
