### PR TITLE
fix(queue): reserve foreground lane slot

### DIFF
--- a/docs/concepts/queue.md
+++ b/docs/concepts/queue.md
@@ -18,6 +18,7 @@ We serialize inbound auto-reply runs (all channels) through a tiny in-process qu
 - A lane-aware FIFO queue drains each lane with a configurable concurrency cap (default 1 for unconfigured lanes; main defaults to 4, subagent to 8).
 - `runEmbeddedAgent` enqueues by **session key** (lane `session:<key>`) to guarantee only one active run per session.
 - Each session run is then queued into a **global lane** (`main` by default) so overall parallelism is capped by `agents.defaults.maxConcurrent`.
+- Non-foreground runs on the `main` lane reserve one slot for foreground/manual work when `main` has more than one slot, so background cron, heartbeat, and detached work cannot consume every operator slot.
 - When verbose logging is enabled, queued runs emit a short notice if they waited more than ~2s before starting.
 - Typing indicators still fire immediately on enqueue (when supported by the channel) so user experience is unchanged while we wait our turn.
 
@@ -117,6 +118,7 @@ keys.
 
 - Applies to auto-reply agent runs across all inbound channels that use the gateway reply pipeline (WhatsApp web, Telegram, Slack, Discord, Signal, iMessage, webchat, etc.).
 - Default lane (`main`) is process-wide for inbound + main heartbeats; set `agents.defaults.maxConcurrent` to allow multiple sessions in parallel.
+- Non-foreground `main`-lane work can use at most `agents.defaults.maxConcurrent - 1` slots when the lane has spare capacity to reserve, preserving one slot for foreground/manual turns.
 - Additional lanes may exist (e.g. `cron`, `cron-nested`, `nested`, `subagent`) so background jobs can run in parallel without blocking inbound replies. Isolated cron agent turns hold a `cron` slot while their inner agent execution uses `cron-nested`; both use `cron.maxConcurrentRuns`. Shared non-cron `nested` flows keep their own lane behavior. These detached runs are tracked as [background tasks](/automation/tasks).
 - Per-session lanes guarantee that only one agent run touches a given session at a time.
 - No external dependencies or background worker threads; pure TypeScript + promises.

--- a/src/agents/embedded-agent-runner/run.overflow-compaction.harness.ts
+++ b/src/agents/embedded-agent-runner/run.overflow-compaction.harness.ts
@@ -285,6 +285,7 @@ export const mockedResolveAuthProfileOrder = vi.fn<(_params?: unknown) => string
 );
 export const mockedMarkAuthProfileSuccess = vi.fn(async () => {});
 export const mockedShouldPreferExplicitConfigApiKeyAuth = vi.fn(() => false);
+export const mockedResolveGlobalLane = vi.fn(() => "global-lane");
 
 export const overflowBaseRunParams = {
   sessionId: "test-session",
@@ -363,6 +364,8 @@ export function resetRunOverflowCompactionHarnessMocks(): void {
   mockedRunContextEngineMaintenance.mockResolvedValue(undefined);
   mockedWaitForDeferredTurnMaintenanceForSession.mockReset();
   mockedWaitForDeferredTurnMaintenanceForSession.mockResolvedValue(undefined);
+  mockedResolveGlobalLane.mockReset();
+  mockedResolveGlobalLane.mockReturnValue("global-lane");
   mockedSessionLikelyHasOversizedToolResults.mockReset();
   mockedSessionLikelyHasOversizedToolResults.mockReturnValue(false);
   mockedResolveLiveToolResultMaxChars.mockReset();
@@ -744,7 +747,7 @@ export async function loadRunOverflowCompactionHarness(): Promise<{
   vi.doMock("./lanes.js", () => ({
     resolveSessionLane: vi.fn((key: string) => `session:${key}`),
     resolveEmbeddedSessionLane: vi.fn((key: string) => `session:${key}`),
-    resolveGlobalLane: vi.fn(() => "global-lane"),
+    resolveGlobalLane: mockedResolveGlobalLane,
   }));
 
   vi.doMock("./logger.js", () => ({

--- a/src/agents/embedded-agent-runner/run.overflow-compaction.test.ts
+++ b/src/agents/embedded-agent-runner/run.overflow-compaction.test.ts
@@ -12,6 +12,7 @@ import {
   rotateAgentEventLifecycleGeneration,
   withAgentRunLifecycleGeneration,
 } from "../../infra/agent-events.js";
+import { CommandLane } from "../../process/lanes.js";
 import type { AgentHarness } from "../harness/types.js";
 import type { AgentInternalEvent } from "../internal-events.js";
 import type { AgentRuntimePlan } from "../runtime-plan/types.js";
@@ -42,6 +43,7 @@ import {
   mockedResolveAuthProfileOrder,
   mockedResolveContextWindowInfo,
   mockedResolveFailoverStatus,
+  mockedResolveGlobalLane,
   mockedResolveModelAsync,
   mockedRunContextEngineMaintenance,
   mockedRunEmbeddedAttempt,
@@ -1078,36 +1080,51 @@ describe("runEmbeddedAgent overflow compaction trigger routing", () => {
 
   it("marks user-triggered session queue work as foreground", async () => {
     mockedRunEmbeddedAttempt.mockResolvedValueOnce(makeAttemptResult({ promptError: null }));
-    const observedPriorities: unknown[] = [];
+    const observedOpts: unknown[] = [];
 
     await runEmbeddedAgent({
       ...overflowBaseRunParams,
       trigger: "user",
       runId: "run-user-session-priority",
       enqueue: async (task, opts) => {
-        observedPriorities.push(opts?.priority);
+        observedOpts.push(opts);
         return await task();
       },
     });
 
-    expect(observedPriorities[0]).toBe("foreground");
+    expect(observedOpts.map((opts) => (opts as { priority?: string })?.priority)).toEqual([
+      "foreground",
+      "foreground",
+    ]);
+    expect(
+      observedOpts.some((opts) =>
+        Boolean((opts as { reserveForPriority?: unknown })?.reserveForPriority),
+      ),
+    ).toBe(false);
   });
 
-  it("marks cron-triggered session queue work as background", async () => {
+  it("marks cron-triggered session queue work as background with a foreground reserve", async () => {
     mockedRunEmbeddedAttempt.mockResolvedValueOnce(makeAttemptResult({ promptError: null }));
-    const observedPriorities: unknown[] = [];
+    mockedResolveGlobalLane.mockReturnValue(CommandLane.Main);
+    const observedOpts: unknown[] = [];
 
     await runEmbeddedAgent({
       ...overflowBaseRunParams,
       trigger: "cron",
       runId: "run-cron-session-priority",
       enqueue: async (task, opts) => {
-        observedPriorities.push(opts?.priority);
+        observedOpts.push(opts);
         return await task();
       },
     });
 
-    expect(observedPriorities[0]).toBe("background");
+    expect(observedOpts.map((opts) => (opts as { priority?: string })?.priority)).toEqual([
+      "background",
+      "background",
+    ]);
+    expect(observedOpts[1]).toMatchObject({
+      reserveForPriority: { slots: 1, priority: "foreground" },
+    });
   });
 
   it("forwards explicit OpenAI Codex auth profiles to codex plugin harnesses", async () => {

--- a/src/agents/embedded-agent-runner/run.ts
+++ b/src/agents/embedded-agent-runner/run.ts
@@ -728,6 +728,9 @@ async function runEmbeddedAgentInternal(
     const globalOpts: CommandQueueEnqueueOptions = {
       ...opts,
       priority: sessionQueuePriority,
+      ...(globalLane === "main" && sessionQueuePriority !== "foreground"
+        ? { reserveForPriority: { slots: 1, priority: "foreground" } as const }
+        : {}),
     };
     const taskWithCurrentLifecycle = () => {
       params.onLaneWait?.({ waitMs: 0, queuedAhead: 0, waiting: false });

--- a/src/process/command-queue.test.ts
+++ b/src/process/command-queue.test.ts
@@ -219,6 +219,79 @@ describe("command queue", () => {
     expect(calls).toEqual(["first", "second"]);
   });
 
+  it("preserves reserved lane capacity for foreground work", async () => {
+    setCommandLaneConcurrency(CommandLane.Main, 3);
+    const releaseBackground = createDeferred();
+    const calls: string[] = [];
+    const backgroundOpts = {
+      priority: "background" as const,
+      reserveForPriority: { slots: 1, priority: "foreground" as const },
+    };
+
+    const background1 = enqueueCommandInLane(
+      CommandLane.Main,
+      async () => {
+        calls.push("background-1");
+        await releaseBackground.promise;
+      },
+      backgroundOpts,
+    );
+    const background2 = enqueueCommandInLane(
+      CommandLane.Main,
+      async () => {
+        calls.push("background-2");
+        await releaseBackground.promise;
+      },
+      backgroundOpts,
+    );
+    const background3 = enqueueCommandInLane(
+      CommandLane.Main,
+      async () => {
+        calls.push("background-3");
+      },
+      backgroundOpts,
+    );
+
+    await vi.waitFor(() => expect(calls).toEqual(["background-1", "background-2"]));
+    expectLaneSnapshotFields(CommandLane.Main, {
+      activeCount: 2,
+      queuedCount: 1,
+    });
+
+    const foreground = enqueueCommandInLane(
+      CommandLane.Main,
+      async () => {
+        calls.push("foreground");
+      },
+      { priority: "foreground" },
+    );
+
+    await foreground;
+    expect(calls).toEqual(["background-1", "background-2", "foreground"]);
+
+    releaseBackground.resolve();
+    await Promise.all([background1, background2, background3]);
+    expect(calls).toEqual(["background-1", "background-2", "foreground", "background-3"]);
+  });
+
+  it("does not reserve all capacity on a single-slot lane", async () => {
+    setCommandLaneConcurrency(CommandLane.Main, 1);
+    const calls: string[] = [];
+
+    await enqueueCommandInLane(
+      CommandLane.Main,
+      async () => {
+        calls.push("background");
+      },
+      {
+        priority: "background",
+        reserveForPriority: { slots: 1, priority: "foreground" },
+      },
+    );
+
+    expect(calls).toEqual(["background"]);
+  });
+
   it("reports queueAhead after priority insertion", async () => {
     vi.useFakeTimers();
     try {

--- a/src/process/command-queue.ts
+++ b/src/process/command-queue.ts
@@ -74,6 +74,10 @@ type QueueEntry = {
   taskTimeoutAbortGraceMs?: number;
   taskTimeoutReleaseSignal?: AbortSignal;
   onWait?: (waitMs: number, queuedAhead: number) => void;
+  reserveForPriority?: {
+    slots: number;
+    priority: number;
+  };
 };
 
 type LaneState = {
@@ -259,6 +263,37 @@ function resolveQueuePriority(priority: CommandQueueEnqueueOptions["priority"]):
   }
 }
 
+function normalizeReserveForPriority(
+  reserveForPriority: CommandQueueEnqueueOptions["reserveForPriority"],
+): QueueEntry["reserveForPriority"] {
+  if (!reserveForPriority) {
+    return undefined;
+  }
+  const slots = Math.floor(reserveForPriority.slots);
+  if (!Number.isFinite(slots) || slots <= 0) {
+    return undefined;
+  }
+  return {
+    slots,
+    priority: resolveQueuePriority(reserveForPriority.priority),
+  };
+}
+
+function canStartQueueEntry(state: LaneState, entry: QueueEntry): boolean {
+  const reserve = entry.reserveForPriority;
+  if (!reserve || entry.priority >= reserve.priority) {
+    return true;
+  }
+  if (state.maxConcurrent <= reserve.slots) {
+    return true;
+  }
+  const availableSlots = Math.max(0, state.maxConcurrent - state.activeTaskIds.size);
+  if (availableSlots <= reserve.slots) {
+    return false;
+  }
+  return true;
+}
+
 function enqueueLaneEntry(state: LaneState, entry: QueueEntry): void {
   const insertAt = state.queue.findIndex(
     (queued) =>
@@ -391,7 +426,11 @@ function drainLane(lane: string) {
   const pump = () => {
     try {
       while (state.activeTaskIds.size < state.maxConcurrent && state.queue.length > 0) {
-        const entry = state.queue.shift() as QueueEntry;
+        const entry = state.queue[0];
+        if (!canStartQueueEntry(state, entry)) {
+          return;
+        }
+        state.queue.shift();
         const waitedMs = Date.now() - entry.enqueuedAt;
         if (waitedMs >= entry.warnAfterMs) {
           try {
@@ -501,6 +540,7 @@ export function enqueueCommandInLane<T>(
       taskTimeoutAbortGraceMs: normalizeTaskTimeoutMs(opts?.taskTimeoutAbortGraceMs),
       taskTimeoutReleaseSignal: opts?.taskTimeoutReleaseSignal,
       onWait: opts?.onWait,
+      reserveForPriority: normalizeReserveForPriority(opts?.reserveForPriority),
     });
     logLaneEnqueue(cleaned, getLaneDepth(state));
     drainLane(cleaned);

--- a/src/process/command-queue.types.ts
+++ b/src/process/command-queue.types.ts
@@ -12,6 +12,16 @@ export type CommandQueueEnqueueOptions = {
   /** Ends the task after a caller-owned timeout cleanup grace has already elapsed. */
   taskTimeoutReleaseSignal?: AbortSignal;
   priority?: "foreground" | "normal" | "background";
+  /**
+   * Keep this many lane slots free for entries at or above the given priority.
+   *
+   * Example: `{ slots: 1, priority: "foreground" }` lets foreground work use
+   * the final lane slot while normal/background work waits.
+   */
+  reserveForPriority?: {
+    slots: number;
+    priority: "foreground" | "normal" | "background";
+  };
 };
 
 /** Minimal queue function contract used by code that only needs to schedule work. */


### PR DESCRIPTION
## Summary

Adds a foreground-reserve policy to OpenClaw command queues so non-foreground embedded work on the shared `main` lane cannot consume the last slot needed for an interactive/manual turn.

## What Problem This Solves

When multiple embedded/background runs saturate the `main` lane, a direct user turn can get stuck behind them and then trip session-lock retry/takeover failure paths. This patch keeps one `foreground` slot available for operator-facing work while preserving existing session serialization.

This is an admission/capacity reserve, not a full starvation-aging policy. It composes with the broader command-queue starvation work by preventing lower-priority work from filling the final active slot; aging can still decide ordering among queued entries later.

## Changes

- Add `reserveForPriority` to command queue enqueue options.
- Teach the queue pump to skip lower-priority work when starting it would consume reserved capacity.
- Guard against deadlock on single-slot lanes by applying reserves only when lane capacity exceeds reserve count.
- Apply `{ slots: 1, priority: "foreground" }` to non-foreground embedded-agent runs on `CommandLane.Main`.
- Leave user/manual foreground turns unreserved.
- Add regression coverage for reserved capacity, single-slot no-deadlock behavior, and embedded-agent main-lane reserve propagation.
- Document the queue guarantee.

## Evidence

- `corepack pnpm exec vitest run src/process/command-queue.test.ts`
  - `35 passed`
- `corepack pnpm exec vitest run src/agents/embedded-agent-runner/run.overflow-compaction.test.ts`
  - `98 passed`
- `corepack pnpm lint --threads=8`
  - passed
- `git diff --check origin/main...HEAD`
  - passed
- Rebased onto current `origin/main` commit `445976ed`.
- Head commit after lint cleanup: `225b79fe`.

### Reproducible Runtime Transcript

Local proof command, run against this PR's source without installing it into my live gateway:

```bash
corepack pnpm exec tsx .artifacts/foreground-reserve-proof.ts
```

The temporary proof script imports the real `src/process/command-queue.ts` module and enqueues three blocking background tasks plus one foreground task on `CommandLane.Main` with `maxConcurrent=3`.

Observed transcript, redacted to the scheduling fields:

```text
no-reserve:after-background-enqueue active=3 queued=0 started=[background-1, background-2, background-3]
no-reserve:after-foreground-enqueue active=3 queued=1 started=[background-1, background-2, background-3]
no-reserve:complete started=[background-1, background-2, background-3, foreground]

reserve:after-background-enqueue active=2 queued=1 started=[background-1, background-2]
reserve:after-foreground-enqueue active=3 queued=1 started=[background-1, background-2, foreground]
reserve:complete started=[background-1, background-2, foreground, background-3]

PROOF_PASS: without reserve, 3/3 background tasks consume the lane and foreground waits; with reserve, 2/3 background tasks run, one background waits, and foreground starts in reserved slot.
```

Full local JSONL transcript was saved on my machine at:

```text
/root/.openclaw/workspace/artifacts/openclaw-proofs/foreground-reserve-proof-20260704.jsonl
```

## Throughput Tradeoff

The reduced saturated background throughput is intentional and acceptable for `main` lane embedded work: when `maxConcurrent=3`, non-foreground `main`-lane work may use 2 slots while one slot remains available for foreground/manual turns. This only applies when the lane has more slots than the reserve count, so single-slot lanes do not deadlock or lose all background capacity.

## Runtime Note

This is source-only. I have not applied it to my live installed OpenClaw gateway.
