### PR TITLE
perf: defer realtime smoke live imports

### DIFF
--- a/scripts/dev/realtime-talk-live-smoke.ts
+++ b/scripts/dev/realtime-talk-live-smoke.ts
@@ -3,10 +3,6 @@ import { mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { pathToFileURL } from "node:url";
-import { GoogleGenAI, Modality } from "@google/genai";
-import { chromium, type Browser } from "playwright";
-import { createServer } from "vite";
-import { buildOpenAIRealtimeVoiceProvider } from "../../extensions/openai/realtime-voice-provider.ts";
 import { readBoundedResponseText } from "../lib/bounded-response.ts";
 import {
   parseStrictIntegerOption,
@@ -29,6 +25,10 @@ const GOOGLE_LIVE_WS_URL =
 type RealtimeSmokeCliOptions = {
   help: boolean;
 };
+
+// Keep live stacks behind their owning smoke paths so help and safety helpers stay lightweight.
+type Browser = import("playwright").Browser;
+type ViteDevServer = Awaited<ReturnType<(typeof import("vite"))["createServer"]>>;
 
 type SmokeResult = {
   name: string;
@@ -269,6 +269,8 @@ async function createOpenAIClientSecret(
 }
 
 async function smokeOpenAIBackendBridge(apiKey: string): Promise<SmokeResult> {
+  const { buildOpenAIRealtimeVoiceProvider } =
+    await import("../../extensions/openai/realtime-voice-provider.ts");
   const provider = buildOpenAIRealtimeVoiceProvider();
   const events: string[] = [];
   const bridge = provider.createBridge({
@@ -445,6 +447,7 @@ async function smokeOpenAIWebRtc(browser: Browser, apiKey: string): Promise<Smok
 }
 
 async function createGoogleLiveToken(apiKey: string): Promise<string> {
+  const { GoogleGenAI, Modality } = await import("@google/genai");
   const ai = new GoogleGenAI({
     apiKey,
     httpOptions: { apiVersion: "v1alpha" },
@@ -574,9 +577,10 @@ async function smokeGoogleLiveBrowserWs(browser: Browser, apiKey: string): Promi
 }
 
 async function smokeGatewayRelayBrowser(browser: Browser): Promise<SmokeResult> {
-  let server: Awaited<ReturnType<typeof createServer>> | undefined;
+  let server: ViteDevServer | undefined;
   const dir = await mkdtemp(path.join(tmpdir(), "openclaw-realtime-talk-"));
   try {
+    const { createServer } = await import("vite");
     const repoRoot = process.cwd().replaceAll("\\", "/");
     const relayModulePath = JSON.stringify(
       `/@fs/${repoRoot}/ui/src/ui/chat/realtime-talk-gateway-relay.ts`,
@@ -766,6 +770,7 @@ async function main(argv = process.argv.slice(2)): Promise<void> {
     console.log(usage());
     return;
   }
+  const { chromium } = await import("playwright");
   const openAIKey = getEnv("OPENAI_API_KEY");
   const googleKey = getEnv("GEMINI_API_KEY") ?? getEnv("GOOGLE_API_KEY");
   const browser = await chromium.launch({


### PR DESCRIPTION
## What Problem This Solves

`test/scripts/dev-tooling-safety.test.ts` eagerly loaded Playwright, Vite, Google GenAI, and the OpenAI realtime provider through `realtime-talk-live-smoke.ts`, even when tests imported only lightweight safety helpers or the CLI exited for `--help`/invalid arguments. This inflated tooling test time and memory.

## Why This Change Was Made

Move each existing heavy dependency behind the live smoke path that owns it:

- OpenAI provider runtime inside the backend bridge smoke
- Google GenAI inside token creation
- Vite inside the Gateway relay browser smoke
- Playwright after CLI argument/help validation

The live workflow, dependency versions, and public options are unchanged. Installed dependency source/types and a runtime namespace probe confirm the same named ESM exports. All 58 tests were audited; each protects a distinct redaction, parsing, network-bound, process-tree, platform, CLI, or log-lifecycle contract, so none were removed.

## User Impact

Developer smoke `--help`, argument errors, and imported helper checks no longer initialize unused live stacks. The focused test is 48.6% faster locally with 24.5% lower peak RSS, and 31.1% faster on Linux. Live smoke behavior is unchanged.

## Evidence

- Tests: 58 -> 58
- Local focused: 26.54s -> 13.65s wall; 17.31s -> 8.58s file time; 684.8MB -> 517.2MB max RSS
- Linux focused: 9.081s -> 6.261s file time
- Focused Linux + full build + `check:changed`: Testbox `tbx_01kwpsgt14gkvnn96fensnny9d`, Actions run https://github.com/openclaw/openclaw/actions/runs/28709734929, exit 0
- Build emitted no `[INEFFECTIVE_DYNAMIC_IMPORT]` warning
- Full remote `test:changed`: 285 files, 4,516 passed, 15 skipped; Testbox `tbx_01kwpt6t12bpqdjwkzgb3a5w7j`, Actions run https://github.com/openclaw/openclaw/actions/runs/28710040961, exit 0
- `pnpm format:check scripts/dev/realtime-talk-live-smoke.ts` — pass
- `git diff --check` — pass
- Fresh autoreview — clean, 0.97 confidence

Related: #57266
