### PR TITLE
fix(infra): report exact ss listener ports

### DIFF
--- a/src/infra/ports-inspect.ts
+++ b/src/infra/ports-inspect.ts
@@ -351,7 +351,7 @@ function parseSsListeners(output: string, port: number): PortListener[] {
       continue;
     }
     const parts = line.split(/\s+/);
-    const localAddress = parts.find((part) => part.includes(`:${port}`));
+    const localAddress = parts.find((part) => parseTcpEndpoint(part)?.port === port);
     if (!localAddress) {
       continue;
     }

--- a/src/infra/ports.test.ts
+++ b/src/infra/ports.test.ts
@@ -219,6 +219,30 @@ describeUnix("inspectPortUsage", () => {
     }
   });
 
+  it("does not match ss listener ports by substring", async () => {
+    runCommandWithTimeoutMock.mockImplementation(async (argv: string[]) => {
+      const command = argv[0];
+      if (typeof command !== "string") {
+        return { stdout: "", stderr: "", code: 1 };
+      }
+      if (command.includes("lsof")) {
+        throw Object.assign(new Error("spawn lsof ENOENT"), { code: "ENOENT" });
+      }
+      if (command === "ss") {
+        return {
+          stdout: 'LISTEN 0 4096 127.0.0.1:18789 0.0.0.0:* users:(("openclaw",pid=123,fd=12))',
+          stderr: "",
+          code: 0,
+        };
+      }
+      return { stdout: "", stderr: "", code: 1 };
+    });
+
+    const result = await inspectPortUsage(1878);
+
+    expect(result.listeners).toEqual([]);
+  });
+
   it("reports established gateway client connections from lsof", async () => {
     runCommandWithTimeoutMock.mockImplementation(async (argv: string[]) => {
       const command = argv[0];


### PR DESCRIPTION
Closes #99977

## What Problem This Solves

Fixes an issue where Linux gateway port diagnostics could report the wrong listener process when the requested port is a prefix of another listener port, such as inspecting 1878 while ss output contains 127.0.0.1:18789.

AI-assisted. I understand the change: it keeps the Linux ss fallback parser on the existing port-diagnostics path, but changes its listener row match from substring search to exact parsed TCP endpoint port equality.

## Why This Change Was Made

The Linux ss parser was the only listener parser in this module still selecting the local address column with a substring match. This reuses the existing parseTcpEndpoint helper, matching the sibling netstat parser behavior without changing lsof, Windows, process enrichment, or probe fallback behavior.

## User Impact

Operators running OpenClaw gateway diagnostics on Linux get more reliable process ownership reports and are less likely to stop an unrelated process when troubleshooting a busy gateway port.

## Evidence

- Focused test with Node 24: node scripts/run-vitest.mjs src/infra/ports.test.ts
  - Result: 1 file passed, 15 tests passed.
- Whitespace check: git diff --check
  - Result: passed.
- Autoreview: .agents/skills/autoreview/scripts/autoreview --mode local
  - Result: clean, no accepted/actionable findings reported.
