### PR TITLE
fix: roll rounded durations into seconds

### DIFF
--- a/src/infra/format-time/format-duration.ts
+++ b/src/infra/format-time/format-duration.ts
@@ -33,8 +33,9 @@ export function formatDurationPrecise(
   if (!Number.isFinite(ms)) {
     return "unknown";
   }
-  if (ms < 1000) {
-    return `${Math.max(0, Math.round(ms))}ms`;
+  const roundedMs = Math.max(0, Math.round(ms));
+  if (roundedMs < 1000) {
+    return `${roundedMs}ms`;
   }
   return formatDurationSeconds(ms, {
     decimals: options.decimals ?? 2,
@@ -55,8 +56,9 @@ export function formatDurationCompact(
   if (ms == null || !Number.isFinite(ms) || ms <= 0) {
     return undefined;
   }
-  if (ms < 1000) {
-    return `${Math.round(ms)}ms`;
+  const roundedMs = Math.round(ms);
+  if (roundedMs < 1000) {
+    return `${roundedMs}ms`;
   }
   const sep = options?.spaced ? " " : "";
   const totalSeconds = Math.round(ms / 1000);
@@ -85,8 +87,9 @@ export function formatDurationHuman(ms?: number | null, fallback = "n/a"): strin
   if (ms == null || !Number.isFinite(ms) || ms < 0) {
     return fallback;
   }
-  if (ms < 1000) {
-    return `${Math.round(ms)}ms`;
+  const roundedMs = Math.round(ms);
+  if (roundedMs < 1000) {
+    return `${roundedMs}ms`;
   }
   const sec = Math.round(ms / 1000);
   if (sec < 60) {

--- a/src/infra/format-time/format-time.test.ts
+++ b/src/infra/format-time/format-time.test.ts
@@ -34,6 +34,7 @@ describe("format-duration", () => {
       expectFormatterCases(formatDurationCompact, [
         { input: 500, expected: "500ms" },
         { input: 999, expected: "999ms" },
+        { input: 999.6, expected: "1s" },
         { input: 1000, expected: "1s" },
         { input: 45000, expected: "45s" },
         { input: 59000, expected: "59s" },
@@ -71,6 +72,7 @@ describe("format-duration", () => {
     it("formats single-unit outputs and day threshold behavior", () => {
       expectFormatterCases(formatDurationHuman, [
         { input: 500, expected: "500ms" },
+        { input: 999.6, expected: "1s" },
         { input: 5000, expected: "5s" },
         { input: 180000, expected: "3m" },
         { input: 7200000, expected: "2h" },
@@ -88,7 +90,7 @@ describe("format-duration", () => {
       { input: 999, expected: "999ms" },
       { input: -1, expected: "0ms" },
       { input: -500, expected: "0ms" },
-      { input: 999.6, expected: "1000ms" },
+      { input: 999.6, expected: "1s" },
       { input: 1000, expected: "1s" },
       { input: 1500, expected: "1.5s" },
       { input: 1234, expected: "1.23s" },


### PR DESCRIPTION
Closes #99978

## What Problem This Solves

Fixes an issue where users reading duration output could see `1000ms` when a sub-second value such as 999.6ms rounded up to the next unit boundary.

## Why This Change Was Made

The duration helpers now decide whether to stay in milliseconds after calculating the rounded millisecond value, so values that round to 1000ms flow through the existing seconds formatting path. This keeps the fix limited to the shared formatter behavior and adds regression coverage for all three affected duration displays.

## User Impact

Timing text now stays in the expected unit scheme: rounded sub-second durations display as `1s` instead of the confusing `1000ms` edge case.

## Evidence

- Claim proved: `formatDurationPrecise`, `formatDurationCompact`, and `formatDurationHuman` return `1s` for 999.6ms.
- Commands / artifacts:
  - `git diff --check` passed.
  - `node scripts/run-vitest.mjs src/infra/format-time/format-time.test.ts --reporter=verbose` passed: 1 file, 60 tests.
  - `node --import tsx -e "const m=await import('./src/infra/format-time/format-duration.ts'); console.log(JSON.stringify({precise:m.formatDurationPrecise(999.6),compact:m.formatDurationCompact(999.6),human:m.formatDurationHuman(999.6)}))"` printed `{"precise":"1s","compact":"1s","human":"1s"}`.
  - `python .agents\skills\autoreview\scripts\autoreview --mode local` passed with no accepted/actionable findings.
- Observed result: all affected duration helpers roll rounded 1000ms values into the existing seconds display path.
- Not tested / proof gaps:
  - No broad suite or full typecheck run; this is a two-file formatter fix and the focused formatter test covers the changed behavior.
  - First focused test attempt failed because the fresh isolated worktree had no `node_modules` (`OPENCLAW_MISSING_VITEST`); `corepack pnpm install --frozen-lockfile` completed successfully and the same focused test passed afterward.

AI-assisted with Codex.