### PR TITLE
improve: speed up package candidate safety tests

### DIFF
--- a/test/scripts/resolve-openclaw-package-candidate.test.ts
+++ b/test/scripts/resolve-openclaw-package-candidate.test.ts
@@ -219,7 +219,14 @@ describe("resolve-openclaw-package-candidate", () => {
       ["--package-sha256", [...requiredArgs, "--package-sha256", "", "--package-sha256", "abc123"]],
       [
         "--source",
-        ["--source", "npm", "--source", "artifact", "--output-dir", ".artifacts/docker-e2e-package"],
+        [
+          "--source",
+          "npm",
+          "--source",
+          "artifact",
+          "--output-dir",
+          ".artifacts/docker-e2e-package",
+        ],
       ],
       [
         "--trusted-source-id",
@@ -227,7 +234,13 @@ describe("resolve-openclaw-package-candidate", () => {
       ],
       [
         "--trusted-source-policy",
-        [...requiredArgs, "--trusted-source-policy", "one.json", "--trusted-source-policy", "two.json"],
+        [
+          ...requiredArgs,
+          "--trusted-source-policy",
+          "one.json",
+          "--trusted-source-policy",
+          "two.json",
+        ],
       ],
     ] satisfies Array<[string, string[]]>;
 
@@ -616,8 +629,12 @@ describe("resolve-openclaw-package-candidate", () => {
         "fs.writeFileSync(process.env.OPENCLAW_TEST_CHILD_PID, String(child.pid));",
         "setInterval(() => {}, 1000);",
       ].join("");
+      // Accelerate only the module-level 5s forwarded-signal failsafe in this disposable runner.
       const runnerScript = [
-        `import { runCommandForTest } from ${JSON.stringify(scriptUrl)};`,
+        "const realSetTimeout = globalThis.setTimeout;",
+        "globalThis.setTimeout = (callback, delay, ...args) =>",
+        "  realSetTimeout(callback, delay === 5000 ? 25 : delay, ...args);",
+        `const { runCommandForTest } = await import(${JSON.stringify(scriptUrl)});`,
         `await runCommandForTest(process.execPath, ['-e', ${JSON.stringify(parentScript)}], { timeoutMs: 60000 });`,
       ].join("\n");
       const runner = spawn(process.execPath, ["--input-type=module", "-e", runnerScript], {
@@ -1336,8 +1353,17 @@ describe("resolve-openclaw-package-candidate", () => {
     const dir = await mkdtemp(path.join(tmpdir(), "openclaw-package-artifact-scan-"));
     tempDirs.push(dir);
 
-    for (let index = 0; index <= ARTIFACT_TARBALL_SCAN_MAX_ENTRIES; index += 1) {
-      await writeFile(path.join(dir, `not-a-package-${index}.txt`), "x");
+    // Keep the real 10,001-entry proof while avoiding serial filesystem setup.
+    const indexes = Array.from(
+      { length: ARTIFACT_TARBALL_SCAN_MAX_ENTRIES + 1 },
+      (_, index) => index,
+    );
+    for (let start = 0; start < indexes.length; start += 128) {
+      await Promise.all(
+        indexes
+          .slice(start, start + 128)
+          .map((index) => writeFile(path.join(dir, `not-a-package-${index}.txt`), "x")),
+      );
     }
 
     await expect(findSingleTarballForTest(dir)).rejects.toThrow(


### PR DESCRIPTION
## What Problem This Solves

The package-candidate safety test file spent five real seconds proving its forwarded-signal force-kill path and created 10,001 scan fixtures serially. This made a 45-test tooling file take 9.078 seconds of test time.

## Why This Change Was Made

Accelerate only the disposable runner's existing five-second forwarded-signal failsafe while preserving the production timeout value and full process-tree behavior. Create the same 10,001 filesystem entries in bounded batches, retaining the real scan-limit proof.

## User Impact

No product behavior changes. Maintainers get faster package-candidate safety validation with the same behavioral coverage.

## Evidence

- Audited all 45 declared cases; all cover distinct parsing, filesystem, process, download, integrity, or security contracts and remain.
- Local focused: 45/45 passing.
- Wall time: 13.06s -> 7.58s (42.0% faster).
- Vitest file time: 9.078s -> 3.637s (59.9% faster).
- External-termination case: 5.117s -> 0.135s.
- Autoreview: clean, 0.98 confidence.
- Focused Linux Testbox: 45/45 passing, 6.16s wrapper wall, 617,488 KB max RSS; `tbx_01kwpxnn548kezvm71c62p7e7v`, Actions https://github.com/openclaw/openclaw/actions/runs/28711677712.
- Remote `check:changed`: green; `tbx_01kwpxnqd660rgb32mt9se2ys6`, Actions https://github.com/openclaw/openclaw/actions/runs/28711678728.
- `pnpm exec oxfmt --check test/scripts/resolve-openclaw-package-candidate.test.ts`
- `git diff --check`
