### PR TITLE
fix: detect localized Windows netstat listeners

### DIFF
--- a/qa/scenarios/channels/native-command-session-target.yaml
+++ b/qa/scenarios/channels/native-command-session-target.yaml
@@ -72,12 +72,6 @@ flow:
                 expr: "env.gateway.call('sessions.list', {}).then((result) => result.sessions?.find((session) => session.hasActiveRun === true))"
             - expr: liveTurnTimeoutMs(env, 15000)
             - 100
-        - set: activeSessionKey
-          value:
-            expr: activeSession.key
-        - set: activeSessionLockPath
-          value:
-            expr: "path.join(env.gateway.tempRoot, 'state', 'agents', 'qa', 'sessions', `${activeSession.sessionId}.jsonl.lock`)"
         - set: startIndex
           value:
             expr: "state.getSnapshot().messages.filter((message) => message.direction === 'outbound').length"
@@ -101,31 +95,6 @@ flow:
               expr: config.abortReplyNeedle
             timeoutMs: 15000
           saveAs: abortReply
-        - call: waitForCondition
-          saveAs: clearedSession
-          args:
-            - lambda:
-                async: true
-                expr: "env.gateway.call('sessions.list', {}).then((result) => { const session = result.sessions?.find((entry) => entry.key === activeSessionKey); return session && session.hasActiveRun !== true ? session : undefined; })"
-            - expr: liveTurnTimeoutMs(env, 90000)
-            - 250
-        - call: waitForCondition
-          args:
-            - lambda:
-                async: true
-                expr: "env.mock ? (await fetchJson(`${env.mock.baseUrl}/debug/inflight-requests`)).every((request) => !String(request.allInputText ?? request.prompt ?? '').includes(config.delayedPrompt)) : true"
-            - expr: liveTurnTimeoutMs(env, 90000)
-            - 250
-        - call: waitForCondition
-          args:
-            - lambda:
-                async: true
-                expr: "fs.access(activeSessionLockPath).then(() => undefined, (error) => error?.code === 'ENOENT' ? true : undefined)"
-            - expr: liveTurnTimeoutMs(env, 90000)
-            - 250
-        - set: recoveryStartIndex
-          value:
-            expr: "state.getSnapshot().messages.filter((message) => message.direction === 'outbound').length"
         - sendInbound:
             conversation:
               id:
@@ -142,10 +111,10 @@ flow:
                 expr: config.conversationId
               kind: direct
             sinceIndex:
-              ref: recoveryStartIndex
+              ref: startIndex
             textIncludes:
               expr: config.recoveryMarker
             timeoutMs:
-              expr: liveTurnTimeoutMs(env, 90000)
+              expr: liveTurnTimeoutMs(env, 60000)
           saveAs: recoveryReply
       detailsExpr: "`native command reply=${abortReply.text}; recovery reply=${recoveryReply.text}`"

--- a/qa/scenarios/channels/native-command-session-target.yaml
+++ b/qa/scenarios/channels/native-command-session-target.yaml
@@ -115,6 +115,6 @@ flow:
             textIncludes:
               expr: config.recoveryMarker
             timeoutMs:
-              expr: liveTurnTimeoutMs(env, 60000)
+              expr: liveTurnTimeoutMs(env, 90000)
           saveAs: recoveryReply
       detailsExpr: "`native command reply=${abortReply.text}; recovery reply=${recoveryReply.text}`"

--- a/qa/scenarios/channels/native-command-session-target.yaml
+++ b/qa/scenarios/channels/native-command-session-target.yaml
@@ -72,6 +72,12 @@ flow:
                 expr: "env.gateway.call('sessions.list', {}).then((result) => result.sessions?.find((session) => session.hasActiveRun === true))"
             - expr: liveTurnTimeoutMs(env, 15000)
             - 100
+        - set: activeSessionKey
+          value:
+            expr: activeSession.key
+        - set: activeSessionLockPath
+          value:
+            expr: "path.join(env.gateway.tempRoot, 'state', 'agents', 'qa', 'sessions', `${activeSession.sessionId}.jsonl.lock`)"
         - set: startIndex
           value:
             expr: "state.getSnapshot().messages.filter((message) => message.direction === 'outbound').length"
@@ -95,6 +101,31 @@ flow:
               expr: config.abortReplyNeedle
             timeoutMs: 15000
           saveAs: abortReply
+        - call: waitForCondition
+          saveAs: clearedSession
+          args:
+            - lambda:
+                async: true
+                expr: "env.gateway.call('sessions.list', {}).then((result) => { const session = result.sessions?.find((entry) => entry.key === activeSessionKey); return session && session.hasActiveRun !== true ? session : undefined; })"
+            - expr: liveTurnTimeoutMs(env, 90000)
+            - 250
+        - call: waitForCondition
+          args:
+            - lambda:
+                async: true
+                expr: "env.mock ? (await fetchJson(`${env.mock.baseUrl}/debug/inflight-requests`)).every((request) => !String(request.allInputText ?? request.prompt ?? '').includes(config.delayedPrompt)) : true"
+            - expr: liveTurnTimeoutMs(env, 90000)
+            - 250
+        - call: waitForCondition
+          args:
+            - lambda:
+                async: true
+                expr: "fs.access(activeSessionLockPath).then(() => undefined, (error) => error?.code === 'ENOENT' ? true : undefined)"
+            - expr: liveTurnTimeoutMs(env, 90000)
+            - 250
+        - set: recoveryStartIndex
+          value:
+            expr: "state.getSnapshot().messages.filter((message) => message.direction === 'outbound').length"
         - sendInbound:
             conversation:
               id:
@@ -111,7 +142,7 @@ flow:
                 expr: config.conversationId
               kind: direct
             sinceIndex:
-              ref: startIndex
+              ref: recoveryStartIndex
             textIncludes:
               expr: config.recoveryMarker
             timeoutMs:

--- a/src/cli/ports.ts
+++ b/src/cli/ports.ts
@@ -3,6 +3,7 @@ import { execFileSync } from "node:child_process";
 import { createServer } from "node:net";
 import { formatErrorMessage } from "../infra/errors.js";
 import { resolveLsofCommandSync } from "../infra/ports-lsof.js";
+import { parseWindowsNetstatListeners } from "../infra/ports-netstat.js";
 import { probePortUsage } from "../infra/ports-probe.js";
 import { getWindowsSystem32ExePath } from "../infra/windows-install-roots.js";
 import { resolvePositiveTimerTimeoutMs, resolveTimerTimeoutMs } from "../shared/number-coercion.js";
@@ -166,22 +167,15 @@ export function listPortListeners(port: number): PortProcess[] {
       const out = execFileSync(getWindowsSystem32ExePath("netstat.exe"), ["-ano", "-p", "TCP"], {
         encoding: "utf-8",
       });
-      const lines = out.split(/\r?\n/).filter(Boolean);
+      const listeners = parseWindowsNetstatListeners(out, port);
+      const seenPids = new Set<number>();
       const results: PortProcess[] = [];
-      for (const line of lines) {
-        const parts = line.trim().split(/\s+/);
-        if (parts.length >= 5 && parts[3] === "LISTENING") {
-          const localAddress = parts[1];
-          const addressPort = localAddress.split(":").pop();
-          if (addressPort === String(port)) {
-            const pid = Number.parseInt(parts[4], 10);
-            if (!Number.isNaN(pid) && pid > 0) {
-              if (!results.some((p) => p.pid === pid)) {
-                results.push({ pid });
-              }
-            }
-          }
+      for (const listener of listeners) {
+        if (seenPids.has(listener.pid)) {
+          continue;
         }
+        seenPids.add(listener.pid);
+        results.push({ pid: listener.pid });
       }
       return results;
     } catch (err: unknown) {

--- a/src/cli/ports.ts
+++ b/src/cli/ports.ts
@@ -164,7 +164,7 @@ export function parseLsofOutput(output: string): PortProcess[] {
 export function listPortListeners(port: number): PortProcess[] {
   if (process.platform === "win32") {
     try {
-      const out = execFileSync(getWindowsSystem32ExePath("netstat.exe"), ["-ano", "-p", "TCP"], {
+      const out = execFileSync(getWindowsSystem32ExePath("netstat.exe"), ["-ano"], {
         encoding: "utf-8",
       });
       const listeners = parseWindowsNetstatListeners(out, port);

--- a/src/cli/program.force.test.ts
+++ b/src/cli/program.force.test.ts
@@ -320,6 +320,14 @@ describe("gateway --force helpers (Windows netstat path)", () => {
       ),
     ].join("\r\n");
 
+  const makeLocalizedNetstatOutput = () =>
+    [
+      "Proto  Local Address          Foreign Address        State           PID",
+      "  TCP    0.0.0.0:18789        0.0.0.0:0              ABHOEREN        42",
+      "  TCP    [::1]:18789          [::]:0                 ABHOEREN        99",
+      "  TCP    127.0.0.1:18789      127.0.0.1:50123        ESTABLISHED     123",
+    ].join("\r\n");
+
   it("returns empty list when netstat finds no listeners on the port", () => {
     (execFileSync as unknown as Mock).mockReturnValue(makeNetstatOutput(9999, 42));
     expect(listPortListeners(18789)).toStrictEqual([]);
@@ -333,6 +341,11 @@ describe("gateway --force helpers (Windows netstat path)", () => {
       ["-ano", "-p", "TCP"],
       { encoding: "utf-8" },
     );
+  });
+
+  it("parses localized Windows listener rows without depending on the state text", () => {
+    (execFileSync as unknown as Mock).mockReturnValue(makeLocalizedNetstatOutput());
+    expect(listPortListeners(18789)).toEqual<PortProcess[]>([{ pid: 42 }, { pid: 99 }]);
   });
 
   it("does not incorrectly match a port that is a substring (e.g. 80 vs 8080)", () => {

--- a/src/cli/program.force.test.ts
+++ b/src/cli/program.force.test.ts
@@ -325,7 +325,9 @@ describe("gateway --force helpers (Windows netstat path)", () => {
       "Proto  Local Address          Foreign Address        State           PID",
       "  TCP    0.0.0.0:18789        0.0.0.0:0              ABHOEREN        42",
       "  TCP    [::1]:18789          [::]:0                 ABHOEREN        99",
+      "  TCP    127.0.0.1:18789      127.0.0.1:0            ABHOEREN        122",
       "  TCP    127.0.0.1:18789      127.0.0.1:50123        ESTABLISHED     123",
+      "  TCP    127.0.0.1:18789      0.0.0.0:0                              124",
     ].join("\r\n");
 
   it("returns empty list when netstat finds no listeners on the port", () => {
@@ -336,11 +338,9 @@ describe("gateway --force helpers (Windows netstat path)", () => {
   it("parses PIDs from netstat output correctly", () => {
     (execFileSync as unknown as Mock).mockReturnValue(makeNetstatOutput(18789, 42, 99));
     expect(listPortListeners(18789)).toEqual<PortProcess[]>([{ pid: 42 }, { pid: 99 }]);
-    expect(execFileSync).toHaveBeenCalledWith(
-      getWindowsSystem32ExePath("netstat.exe"),
-      ["-ano", "-p", "TCP"],
-      { encoding: "utf-8" },
-    );
+    expect(execFileSync).toHaveBeenCalledWith(getWindowsSystem32ExePath("netstat.exe"), ["-ano"], {
+      encoding: "utf-8",
+    });
   });
 
   it("parses localized Windows listener rows without depending on the state text", () => {

--- a/src/infra/gateway-processes.test.ts
+++ b/src/infra/gateway-processes.test.ts
@@ -217,7 +217,9 @@ describe("gateway-processes", () => {
         status: 0,
         stdout: [
           "Proto  Local Address          Foreign Address        State           PID",
-          "TCP    0.0.0.0:18789         0.0.0.0:0              LISTENING       200",
+          "TCP    127.0.0.1:18789       127.0.0.1:54321        HERGESTELLT    999",
+          "TCP    0.0.0.0:18789         0.0.0.0:0              ABHOEREN       200",
+          "TCP    [::]:18789            [::]:0                 ABHOEREN       200",
         ].join("\r\n"),
       })
       .mockReturnValueOnce({

--- a/src/infra/gateway-processes.test.ts
+++ b/src/infra/gateway-processes.test.ts
@@ -217,6 +217,7 @@ describe("gateway-processes", () => {
         status: 0,
         stdout: [
           "Proto  Local Address          Foreign Address        State           PID",
+          "TCP    127.0.0.1:18789       127.0.0.1:0            ABHOEREN       998",
           "TCP    127.0.0.1:18789       127.0.0.1:54321        HERGESTELLT    999",
           "TCP    0.0.0.0:18789         0.0.0.0:0              ABHOEREN       200",
           "TCP    [::]:18789            [::]:0                 ABHOEREN       200",
@@ -233,6 +234,7 @@ describe("gateway-processes", () => {
     expect(findVerifiedGatewayListenerPidsOnPortSync(18789)).toEqual([200]);
     expect(spawnSyncMock.mock.calls[0]?.[0]).toBe(getWindowsPowerShellExePath());
     expect(spawnSyncMock.mock.calls[1]?.[0]).toBe(getWindowsSystem32ExePath("netstat.exe"));
+    expect(spawnSyncMock.mock.calls[1]?.[1]).toEqual(["-ano"]);
     expect(spawnSyncMock.mock.calls[2]?.[0]).toBe(getWindowsPowerShellExePath());
   });
 

--- a/src/infra/ports-inspect.ts
+++ b/src/infra/ports-inspect.ts
@@ -5,6 +5,7 @@ import { runCommandWithTimeout } from "../process/exec.js";
 import { parseStrictPositiveInteger } from "./parse-finite-number.js";
 import { buildPortHints } from "./ports-format.js";
 import { resolveLsofCommand } from "./ports-lsof.js";
+import { parseTcpEndpoint, parseWindowsNetstatListeners } from "./ports-netstat.js";
 import { probePortUsage } from "./ports-probe.js";
 import type {
   PortConnection,
@@ -74,37 +75,6 @@ function dedupePortListeners(listeners: PortListener[]): PortListener[] {
     seen.add(key);
     return true;
   });
-}
-
-function normalizeTcpHost(host: string): string {
-  const normalized = host.toLowerCase();
-  return normalized.startsWith("::ffff:") ? normalized.slice("::ffff:".length) : normalized;
-}
-
-function parseTcpPort(raw: string | undefined): number | null {
-  if (!raw || !/^\d+$/.test(raw)) {
-    return null;
-  }
-  const port = Number(raw);
-  return Number.isSafeInteger(port) && port >= 0 && port <= 65_535 ? port : null;
-}
-
-function parseTcpEndpoint(raw: string): { host: string; port: number } | null {
-  const endpoint = raw.trim();
-  const bracketMatch = endpoint.match(/^\[([^\]]+)\]:(\d+)$/);
-  if (bracketMatch) {
-    const port = parseTcpPort(bracketMatch[2]);
-    return port === null ? null : { host: normalizeTcpHost(bracketMatch[1]), port };
-  }
-  const lastColon = endpoint.lastIndexOf(":");
-  if (lastColon <= 0 || lastColon >= endpoint.length - 1) {
-    return null;
-  }
-  const port = parseTcpPort(endpoint.slice(lastColon + 1));
-  if (port === null) {
-    return null;
-  }
-  return { host: normalizeTcpHost(endpoint.slice(0, lastColon)), port };
 }
 
 function parseLsofTcpConnectionAddress(
@@ -434,33 +404,7 @@ async function readUnixListeners(
 }
 
 function parseNetstatListeners(output: string, port: number): PortListener[] {
-  const listeners: PortListener[] = [];
-  for (const rawLine of output.split(/\r?\n/)) {
-    const line = rawLine.trim();
-    if (!line) {
-      continue;
-    }
-    if (!normalizeLowercaseStringOrEmpty(line).includes("listen")) {
-      continue;
-    }
-    const parts = line.split(/\s+/);
-    if (parts.length < 4) {
-      continue;
-    }
-    const localAddr = parts[1];
-    if (!localAddr || parseTcpEndpoint(localAddr)?.port !== port) {
-      continue;
-    }
-    const pidRaw = parts.at(-1);
-    const pid = parseStrictPositiveInteger(pidRaw);
-    const listener: PortListener = {};
-    if (pid !== undefined) {
-      listener.pid = pid;
-    }
-    listener.address = localAddr;
-    listeners.push(listener);
-  }
-  return listeners;
+  return parseWindowsNetstatListeners(output, port);
 }
 
 function parseNetstatConnections(output: string, port: number): PortConnection[] {

--- a/src/infra/ports-inspect.ts
+++ b/src/infra/ports-inspect.ts
@@ -506,7 +506,7 @@ async function readWindowsNetstatEntries<T extends PortListener>(
   parse: (output: string, port: number) => T[],
 ): Promise<{ entries: T[]; detail?: string; errors: string[] }> {
   const errors: string[] = [];
-  const res = await runCommandSafe([getWindowsSystem32ExePath("netstat.exe"), "-ano", "-p", "tcp"]);
+  const res = await runCommandSafe([getWindowsSystem32ExePath("netstat.exe"), "-ano"]);
   if (res.code !== 0) {
     if (res.error) {
       errors.push(res.error);

--- a/src/infra/ports-netstat.ts
+++ b/src/infra/ports-netstat.ts
@@ -1,0 +1,74 @@
+import { parseStrictPositiveInteger } from "./parse-finite-number.js";
+import type { PortListener } from "./ports-types.js";
+
+export type WindowsNetstatListener = PortListener & { pid: number; address: string };
+
+function normalizeTcpHost(host: string): string {
+  const normalized = host.toLowerCase();
+  return normalized.startsWith("::ffff:") ? normalized.slice("::ffff:".length) : normalized;
+}
+
+function parseTcpPort(raw: string | undefined): number | null {
+  if (!raw || !/^\d+$/.test(raw)) {
+    return null;
+  }
+  const port = Number(raw);
+  return Number.isSafeInteger(port) && port >= 0 && port <= 65_535 ? port : null;
+}
+
+export function parseTcpEndpoint(raw: string): { host: string; port: number } | null {
+  const endpoint = raw.trim();
+  const bracketMatch = endpoint.match(/^\[([^\]]+)\]:(\d+)$/);
+  if (bracketMatch) {
+    const port = parseTcpPort(bracketMatch[2]);
+    return port === null ? null : { host: normalizeTcpHost(bracketMatch[1]), port };
+  }
+  const lastColon = endpoint.lastIndexOf(":");
+  if (lastColon <= 0 || lastColon >= endpoint.length - 1) {
+    return null;
+  }
+  const port = parseTcpPort(endpoint.slice(lastColon + 1));
+  if (port === null) {
+    return null;
+  }
+  return { host: normalizeTcpHost(endpoint.slice(0, lastColon)), port };
+}
+
+function isWildcardEndpoint(raw: string | undefined): boolean {
+  const endpoint = raw?.trim();
+  if (!endpoint || endpoint === "*:*") {
+    return true;
+  }
+  const parsed = parseTcpEndpoint(endpoint);
+  if (!parsed) {
+    return false;
+  }
+  return parsed.port === 0;
+}
+
+export function parseWindowsNetstatListeners(
+  output: string,
+  port: number,
+): WindowsNetstatListener[] {
+  const listeners: WindowsNetstatListener[] = [];
+  for (const rawLine of output.split(/\r?\n/)) {
+    const parts = rawLine.trim().split(/\s+/);
+    if (parts.length < 4 || parts[0]?.toUpperCase() !== "TCP") {
+      continue;
+    }
+    const localAddress = parts[1];
+    const remoteAddress = parts[2];
+    if (!localAddress || parseTcpEndpoint(localAddress)?.port !== port) {
+      continue;
+    }
+    if (!isWildcardEndpoint(remoteAddress)) {
+      continue;
+    }
+    const pid = parseStrictPositiveInteger(parts.at(-1));
+    if (pid === undefined) {
+      continue;
+    }
+    listeners.push({ pid, address: localAddress });
+  }
+  return listeners;
+}

--- a/src/infra/ports-netstat.ts
+++ b/src/infra/ports-netstat.ts
@@ -43,7 +43,9 @@ function isWildcardEndpoint(raw: string | undefined): boolean {
   if (!parsed) {
     return false;
   }
-  return parsed.port === 0;
+  // Windows localizes the TCP state text, so the wildcard peer is the stable
+  // listener signal. Be strict here because force paths can kill the returned PID.
+  return parsed.port === 0 && ["0.0.0.0", "::", "*"].includes(parsed.host);
 }
 
 export function parseWindowsNetstatListeners(
@@ -53,7 +55,7 @@ export function parseWindowsNetstatListeners(
   const listeners: WindowsNetstatListener[] = [];
   for (const rawLine of output.split(/\r?\n/)) {
     const parts = rawLine.trim().split(/\s+/);
-    if (parts.length < 4 || parts[0]?.toUpperCase() !== "TCP") {
+    if (parts.length < 5 || parts[0]?.toUpperCase() !== "TCP") {
       continue;
     }
     const localAddress = parts[1];

--- a/src/infra/ports.test.ts
+++ b/src/infra/ports.test.ts
@@ -497,6 +497,39 @@ describe("inspectPortUsage on Windows", () => {
     );
   });
 
+  it("reports localized Windows listener rows without requiring English state text", async () => {
+    setPlatform("win32");
+    runCommandWithTimeoutMock.mockImplementation(async (argv: string[]) => {
+      const [command] = argv;
+      if (command === getWindowsSystem32ExePath("netstat.exe")) {
+        return {
+          stdout:
+            "  TCP    127.0.0.1:18789    0.0.0.0:0        ABHOEREN       4242\r\n" +
+            "  TCP    [::1]:18789        [::]:0           ABHOEREN       4243\r\n" +
+            "  TCP    127.0.0.1:18789    127.0.0.1:50123  HERGESTELLT    9000\r\n",
+          stderr: "",
+          code: 0,
+        };
+      }
+      if (command === getWindowsSystem32ExePath("tasklist.exe")) {
+        return { stdout: "Image Name: node.exe\r\n", stderr: "", code: 0 };
+      }
+      if (command === getWindowsPowerShellExePath()) {
+        return {
+          stdout: "node.exe C:\\openclaw\\dist\\index.js gateway run\r\n",
+          stderr: "",
+          code: 0,
+        };
+      }
+      return { stdout: "", stderr: "", code: 1 };
+    });
+
+    const result = await inspectPortUsage(18789);
+
+    expect(result.status).toBe("busy");
+    expect(result.listeners.map((listener) => listener.pid)).toEqual([4242, 4243]);
+  });
+
   it("does not match Windows listener ports by substring", async () => {
     setPlatform("win32");
     runCommandWithTimeoutMock.mockImplementation(async (argv: string[]) => {

--- a/src/infra/ports.test.ts
+++ b/src/infra/ports.test.ts
@@ -506,6 +506,7 @@ describe("inspectPortUsage on Windows", () => {
           stdout:
             "  TCP    127.0.0.1:18789    0.0.0.0:0        ABHOEREN       4242\r\n" +
             "  TCP    [::1]:18789        [::]:0           ABHOEREN       4243\r\n" +
+            "  TCP    127.0.0.1:18789    127.0.0.1:0      ABHOEREN       8999\r\n" +
             "  TCP    127.0.0.1:18789    127.0.0.1:50123  HERGESTELLT    9000\r\n",
           stderr: "",
           code: 0,
@@ -528,6 +529,10 @@ describe("inspectPortUsage on Windows", () => {
 
     expect(result.status).toBe("busy");
     expect(result.listeners.map((listener) => listener.pid)).toEqual([4242, 4243]);
+    expect(runCommandWithTimeoutMock).toHaveBeenCalledWith(
+      [getWindowsSystem32ExePath("netstat.exe"), "-ano"],
+      expect.anything(),
+    );
   });
 
   it("does not match Windows listener ports by substring", async () => {

--- a/src/infra/windows-port-pids.ts
+++ b/src/infra/windows-port-pids.ts
@@ -4,6 +4,7 @@ import { normalizeLowercaseStringOrEmpty } from "@openclaw/normalization-core/st
 import { normalizeStringEntries } from "@openclaw/normalization-core/string-normalization";
 import { parseCmdScriptCommandLine } from "../daemon/cmd-argv.js";
 import { parseStrictPositiveInteger } from "./parse-finite-number.js";
+import { parseWindowsNetstatListeners } from "./ports-netstat.js";
 import {
   getWindowsPowerShellExePath,
   getWindowsSystem32ExePath,
@@ -45,19 +46,7 @@ function readListeningPidsViaPowerShell(port: number, timeoutMs: number): number
 }
 
 function parseListeningPidsFromNetstat(stdout: string, port: number): number[] {
-  const pids = new Set<number>();
-  for (const line of stdout.split(/\r?\n/)) {
-    const match = line.match(/^\s*TCP\s+(\S+):(\d+)\s+\S+\s+LISTENING\s+(\d+)\s*$/i);
-    if (!match) {
-      continue;
-    }
-    const parsedPort = Number.parseInt(match[2] ?? "", 10);
-    const pid = Number.parseInt(match[3] ?? "", 10);
-    if (parsedPort === port && Number.isFinite(pid) && pid > 0) {
-      pids.add(pid);
-    }
-  }
-  return [...pids];
+  return [...new Set(parseWindowsNetstatListeners(stdout, port).map((listener) => listener.pid))];
 }
 
 export function readWindowsListeningPidsOnPortSync(

--- a/src/infra/windows-port-pids.ts
+++ b/src/infra/windows-port-pids.ts
@@ -65,7 +65,7 @@ export function readWindowsListeningPidsResultSync(
   if (powershellPids != null) {
     return { ok: true, pids: powershellPids };
   }
-  const netstat = spawnSync(getWindowsSystem32ExePath("netstat.exe"), ["-ano", "-p", "tcp"], {
+  const netstat = spawnSync(getWindowsSystem32ExePath("netstat.exe"), ["-ano"], {
     encoding: "utf8",
     timeout: timeoutMs,
     windowsHide: true,


### PR DESCRIPTION
Closes #99984

## What Problem This Solves

Fixes an issue where localized Windows installs could miss an active TCP listener during gateway `--force`, port diagnostics, or stale gateway cleanup because `netstat` did not print the English `LISTENING` state.

## Why This Change Was Made

The CLI force-free path, port diagnostics, and Windows listening-PID fallback now share one endpoint-based parser. It identifies listeners by complete TCP row shape, exact local port, wildcard remote endpoint, and positive PID instead of localized state text.

The netstat calls use `-ano` without a protocol filter so IPv4 and IPv6 listeners are both included. Non-wildcard port-zero peers, established connections, malformed rows, UDP rows, and invalid PIDs are ignored. Unrelated QA scenario changes were removed from the branch.

## User Impact

Windows users with non-English system output get reliable IPv4 and IPv6 port-conflict detection and cleanup. Existing connections on the target port are not mistaken for listeners.

## Evidence

- Exact head: `4de6d305ed301133869328a595d5b2ac757d88c2`
- Focused tests:
  - `node scripts/run-vitest.mjs src/cli/program.force.test.ts src/infra/ports.test.ts src/infra/gateway-processes.test.ts`
  - Result: 46/46 passed on the final rebased head.
- Changed gate:
  - Blacksmith Testbox through Crabbox: `tbx_01kwqqajxsz3b9n3cmvpmxn8q4`
  - Result: `pnpm check:changed` passed; provider `blacksmith-testbox`, exit code 0.
- Native Windows proof:
  - Azure Crabbox lease `cbx_836847c36168`, run `run_75d72e8afb34`.
  - Live IPv4 and IPv6 `TcpListener` sockets were reported with the same owning PID by `Get-NetTCPConnection`.
  - `netstat -ano` reported both listeners.
  - `netstat -ano -p tcp` reported IPv4 but omitted IPv6, confirming the protocol filter could clip valid listeners.
- Review and static checks:
  - `git diff --check`
  - touched-file `oxfmt --check`
  - branch autoreview against `origin/main`: clean, no accepted/actionable findings.
- Exact-head CI: https://github.com/openclaw/openclaw/actions/runs/28723005786
