### PR TITLE
fix: keep subagent truncation within max length

### DIFF
--- a/src/agents/subagent-list.test.ts
+++ b/src/agents/subagent-list.test.ts
@@ -74,10 +74,8 @@ describe("buildSubagentList", () => {
       recentMinutes: 30,
       taskMaxChars: 110,
     });
-    expect(list.active[0]?.line).toContain(
-      "This is a deliberately long task description used to verify that subagent list output keeps the full task text",
-    );
-    expect(list.active[0]?.line).toContain("...");
+    expect(list.active[0]?.task).toHaveLength(110);
+    expect(list.active[0]?.task).toMatch(/\.\.\.$/);
     expect(list.active[0]?.line).not.toContain("after a short hard cutoff.");
   });
 

--- a/src/shared/subagents-format.test.ts
+++ b/src/shared/subagents-format.test.ts
@@ -37,21 +37,34 @@ describe("shared/subagents-format", () => {
 
   it("truncates lines only when needed", () => {
     expect(truncateLine("short", 10)).toBe("short");
-    expect(truncateLine("trim me   ", 7)).toBe("trim me...");
+    expect(truncateLine("abc   ", 5)).toBe("abc");
+    expect(truncateLine("trim me   ", 7)).toBe("trim me");
+    expect(truncateLine("abcdefghij", 5)).toBe("ab...");
+  });
+
+  it("keeps truncated lines within the requested max length", () => {
+    for (const maxLength of [0, 1, 2, 3, 4, 5, 7, 12]) {
+      const result = truncateLine("abcdefghij", maxLength);
+      expect(result.length).toBeLessThanOrEqual(maxLength);
+    }
+    expect(truncateLine("abcdefghij", 0)).toBe("");
+    expect(truncateLine("abcdefghij", 1)).toBe(".");
+    expect(truncateLine("abcdefghij", 2)).toBe("..");
+    expect(truncateLine("abcdefghij", 3)).toBe("...");
   });
 
   it("truncates without breaking surrogate pairs", () => {
     // Emoji at the cut point: the surrogate pair must not be split.
-    expect(truncateLine("AB🤖CD", 3)).toBe("AB...");
+    expect(truncateLine("AB🤖CDEF", 6)).toBe("AB...");
     // Cut point in the middle of a 3-emoji string.
-    expect(truncateLine("🤖🤖🤖", 5)).toBe("🤖🤖...");
+    expect(truncateLine("🤖🤖🤖", 5)).toBe("🤖...");
     // CJK Extension B (surrogate pair) at boundary: character stays intact.
-    expect(truncateLine("AB𠮷CD", 5)).toBe("AB𠮷C...");
+    expect(truncateLine("AB𠮷CDEF", 7)).toBe("AB𠮷...");
     // No broken surrogates in output.
     for (const result of [
-      truncateLine("AB🤖CD", 3),
+      truncateLine("AB🤖CDEF", 6),
       truncateLine("🤖🤖🤖", 5),
-      truncateLine("AB𠮷CD", 5),
+      truncateLine("AB𠮷CDEF", 7),
     ]) {
       expect(result).not.toMatch(
         /[\uD800-\uDBFF](?![\uDC00-\uDFFF])|(?<![\uD800-\uDBFF])[\uDC00-\uDFFF]/,

--- a/src/shared/subagents-format.ts
+++ b/src/shared/subagents-format.ts
@@ -27,10 +27,16 @@ export function formatTokenShort(value?: number) {
 
 /** Truncates a single-line display string without preserving trailing whitespace. */
 export function truncateLine(value: string, maxLength: number) {
-  if (value.length <= maxLength) {
-    return value;
+  const limit = Math.max(0, Math.floor(maxLength));
+  const trimmed = value.trimEnd();
+  if (trimmed.length <= limit) {
+    return trimmed;
   }
-  return `${truncateUtf16Safe(value, maxLength).trimEnd()}...`;
+  const marker = "...";
+  if (limit <= marker.length) {
+    return marker.slice(0, limit);
+  }
+  return `${truncateUtf16Safe(trimmed, limit - marker.length).trimEnd()}${marker}`;
 }
 
 type TokenUsageLike = {


### PR DESCRIPTION
Closes #99979

## What Problem This Solves

Fixes an issue where users viewing compact subagent lists could see truncated labels or task text exceed the requested display budget because `truncateLine` appended `...` after slicing to `maxLength`.

## Why This Change Was Made

`truncateLine` now trims trailing whitespace before deciding whether truncation is needed, reserves room for the ellipsis marker when truncating, and keeps tiny limits within the caller-provided budget. The existing UTF-16-safe slicing path remains in place so truncation still avoids dangling surrogate halves.

## User Impact

Subagent list/status columns now stay within the configured label and task widths when truncation applies, preserving compact alignment without losing surrogate-pair safety.

## Evidence

- Current head: `8bc4652fe2af7ce27181161a5f74c581e875f4b9`.
- Claim proved: `truncateLine` returns strings no longer than `maxLength`, and the real `subagents` list tool path renders long task text inside the default `taskMaxChars` budget instead of overflowing after appending `...`.
- Commands / artifacts:
  - `node --import tsx --eval "... createSubagentsTool({ agentSessionKey: 'agent:main:main' }).execute('proof-call-100013', { action: 'list' }) ..."` - passed against a seeded in-memory subagent run on the current PR head.
  - `node scripts/run-vitest.mjs src/shared/subagents-format.test.ts src/agents/subagent-list.test.ts` - passed 2 Vitest shards, 15 tests.
  - `git diff --check` - passed.
  - `PYTHONUTF8=1 python .agents/skills/autoreview/scripts/autoreview --mode local` - clean, no accepted/actionable findings.
- Observed real behavior proof from the `subagents` tool path:

```text
head=8bc4652fe2af7ce27181161a5f74c581e875f4b9
tool=createSubagentsTool(action=list)
activeCount=1
taskLength=72
taskMaxChars=72
taskWithinBudget=true
taskEndsWithEllipsis=true
lineContainsOverflowTail=false
text=
active subagents:
1. Proof worker (gpt-5.5, 1s) running - This is a deliberately long task description used to prove that the r...

recent (last 30m):
(none)
```

- Not tested / proof gaps: no full suite was run locally. GitHub CI is green on the current PR head, and the added real-path proof exercises the user-visible `subagents` list formatting path without live provider credentials.