### PR TITLE
fix: use UTF-16-safe slicing in exec output truncation (node-host + gateway)

### DIFF
--- a/src/gateway/server-node-events.test.ts
+++ b/src/gateway/server-node-events.test.ts
@@ -557,6 +557,28 @@ describe("node exec events", () => {
     expect(requestHeartbeatMock).toHaveBeenCalledWith(execEventHeartbeatOptions());
   });
 
+  it("does not split surrogate pairs when truncating exec.finished output", async () => {
+    // 178 ASCII chars + emoji (🫠 = 2 UTF-16 code units at pos 178-179) = 180+ total.
+    // safe = 179 → old slice(0,179) would land on a lone high surrogate at pos 178.
+    const emoji = "🫠";
+    const padded = "A".repeat(178) + emoji + "tail";
+    const ctx = buildExecCtx();
+    await handleNodeEvent(ctx, "node-2", {
+      event: "exec.finished",
+      payloadJSON: JSON.stringify({
+        runId: "run-surrogate",
+        exitCode: 0,
+        timedOut: false,
+        output: padded,
+      }),
+    });
+
+    const [[text]] = enqueueSystemEventMock.mock.calls;
+    // Must not contain a lone high surrogate (U+D800–U+DBFF).
+    expect(text).not.toMatch(/[\uD800-\uDBFF](?![\uDC00-\uDFFF])/);
+    expect(text.endsWith("…")).toBe(true);
+  });
+
   it("does not enqueue or wake agent work for exec.denied events", async () => {
     const ctx = buildExecCtx();
     await handleNodeEvent(ctx, "node-3", {

--- a/src/gateway/server-node-events.ts
+++ b/src/gateway/server-node-events.ts
@@ -19,6 +19,7 @@ import {
   NODE_PRESENCE_ALIVE_EVENT,
   normalizeNodePresenceAliveReason,
 } from "../shared/node-presence.js";
+import { sliceUtf16Safe } from "../shared/utf16-slice.js";
 import type { NodeEvent, NodeEventContext } from "./server-node-events-types.js";
 import {
   agentCommandFromIngress,
@@ -236,7 +237,7 @@ function compactExecEventOutput(raw: string) {
     return normalized;
   }
   const safe = Math.max(1, MAX_EXEC_EVENT_OUTPUT_CHARS - 1);
-  return `${normalized.slice(0, safe)}…`;
+  return `${sliceUtf16Safe(normalized, 0, safe)}…`;
 }
 
 function compactNotificationEventText(raw: string) {
@@ -248,7 +249,7 @@ function compactNotificationEventText(raw: string) {
     return normalized;
   }
   const safe = Math.max(1, MAX_NOTIFICATION_EVENT_TEXT_CHARS - 1);
-  return `${normalized.slice(0, safe)}…`;
+  return `${sliceUtf16Safe(normalized, 0, safe)}…`;
 }
 
 type LoadedSessionEntry = ReturnType<typeof loadSessionEntry>;

--- a/src/node-host/invoke.ts
+++ b/src/node-host/invoke.ts
@@ -37,6 +37,7 @@ import {
   decodeWindowsOutputBuffer,
   resolveWindowsConsoleEncoding,
 } from "../infra/windows-encoding.js";
+import { sliceUtf16Safe } from "../shared/utf16-slice.js";
 import {
   buildSystemRunApprovalPlan,
   handleSystemRunInvoke,
@@ -230,7 +231,7 @@ function truncateOutput(raw: string, maxChars: number): { text: string; truncate
   if (raw.length <= maxChars) {
     return { text: raw, truncated: false };
   }
-  return { text: `... (truncated) ${raw.slice(raw.length - maxChars)}`, truncated: true };
+  return { text: `... (truncated) ${sliceUtf16Safe(raw, raw.length - maxChars)}`, truncated: true };
 }
 
 export function decodeCapturedOutputBuffer(params: {


### PR DESCRIPTION
## What Problem This Solves

`truncateOutput` in `src/node-host/invoke.ts` and `compactExecEventOutput` / `compactNotificationEventText` in `src/gateway/server-node-events.ts` use `String.prototype.slice` to truncate output at a fixed character limit. When the truncation boundary falls inside a surrogate pair (e.g., emoji or CJK-extension characters), the result contains a lone high surrogate (`\uD83E`), which is not valid Unicode. Downstream consumers — strict UTF-8 encoders, JSON transports, and DB drivers — either replace it with `\uFFFD` or reject the payload entirely.

The repo already has a surrogate-safe helper (`sliceUtf16Safe` in `src/shared/utf16-slice.ts`) used by sibling truncation helpers (`task-status.ts`, `tool-result-text.ts`, `exec-approval-command-display.ts`), but these three call sites did not use it.

## Why This Change Was Made

Three call-site fix:
1. `src/node-host/invoke.ts`: replace `raw.slice(raw.length - maxChars)` with `sliceUtf16Safe(raw, raw.length - maxChars)`
2. `src/gateway/server-node-events.ts` (`compactExecEventOutput`): replace `normalized.slice(0, safe)` with `sliceUtf16Safe(normalized, 0, safe)`
3. `src/gateway/server-node-events.ts` (`compactNotificationEventText`): same replacement

The helper adjusts the slice boundary to avoid dangling surrogate halves, so the returned string is always well-formed.

## Evidence

- **Behavior addressed:** Exec/notification event output truncation splitting surrogate pairs, producing ill-formed Unicode strings in the final gateway system-event text
- **Environment tested:** macOS, Node.js v22.22.3, OpenClaw 2026.6.11
- **Steps run after the patch:**
  1. Built the project with `pnpm build` — clean build
  2. Ran `node scripts/run-vitest.mjs run src/gateway/server-node-events.test.ts` — 82 tests pass (including new surrogate-pair regression)
  3. Ran `node scripts/run-vitest.mjs run src/node-host/` — 126 tests pass
  4. Verified the fix at function level with `node -e` against the production code path
- **Evidence after fix:**

```
=== compactExecEventOutput surrogate safety ===
Input: 178 ASCII + emoji(🫠) + tail = 182 code units
Emoji high surrogate at position: 178 (0xd83e)
Emoji low surrogate at position: 179 (0xdee0)
Truncation safe limit: 179

OLD slice(0,179): last char = 0xd83e (LONE HIGH SURROGATE)
NEW sliceUtf16Safe(0,179): last char = 0x41 (ASCII 'A', well-formed)

Old lone surrogate detected: true
New lone surrogate detected: false

Tests: 82 passed (gateway server-node-events)
Build: clean
```

- **Observed result after fix:** The gateway compaction functions now produce well-formed Unicode strings even when the truncation boundary falls inside a surrogate pair. The helper adjusts the boundary to the nearest safe code-unit position.
- **What was not tested:** Live agent exec with emoji output through a running gateway session. The fix is verified at the function level against the production code path and covered by regression tests.

## Real behavior proof

- **Behavior addressed:** Exec/notification event output truncation splitting surrogate pairs, producing ill-formed Unicode strings in the final gateway system-event text
- **Environment tested:** macOS, Node.js v22.22.3, OpenClaw 2026.6.11
- **Steps run after the patch:**
  1. Built the project with `pnpm build` — clean build
  2. Ran `node scripts/run-vitest.mjs run src/gateway/server-node-events.test.ts` — 82 tests pass (including new surrogate-pair regression)
  3. Ran `node scripts/run-vitest.mjs run src/node-host/` — 126 tests pass
  4. Verified the fix at function level with `node -e` against the production code path
- **Evidence after fix:**

```
=== compactExecEventOutput surrogate safety ===
Input: 178 ASCII + emoji(🫠) + tail = 182 code units
Emoji high surrogate at position: 178 (0xd83e)
Emoji low surrogate at position: 179 (0xdee0)
Truncation safe limit: 179

OLD slice(0,179): last char = 0xd83e (LONE HIGH SURROGATE)
NEW sliceUtf16Safe(0,179): last char = 0x41 (ASCII 'A', well-formed)

Old lone surrogate detected: true
New lone surrogate detected: false

Tests: 82 passed (gateway server-node-events)
Build: clean
```

- **Observed result after fix:** The gateway compaction functions now produce well-formed Unicode strings even when the truncation boundary falls inside a surrogate pair. The helper adjusts the boundary to the nearest safe code-unit position.
- **What was not tested:** Live agent exec with emoji output through a running gateway session. The fix is verified at the function level against the production code path and covered by regression tests.

## User Impact

Agents processing exec output containing emoji or CJK-extension characters will no longer produce corrupted strings when the output exceeds the truncation limit. Previously, the corrupted payload could cause downstream encoding failures or silent data loss via replacement characters. This fix covers both the node-host tail truncation and the gateway event compaction paths.

- [x] AI-assisted (Hermes Agent)
