### PR TITLE
fix(runtime): repair sessions and allow staged media through symlinked dirs

### DIFF
--- a/extensions/qqbot/src/engine/gateway/outbound-dispatch.test.ts
+++ b/extensions/qqbot/src/engine/gateway/outbound-dispatch.test.ts
@@ -35,6 +35,9 @@ const sendTextMock = vi.hoisted(() =>
 const audioFileToSilkBase64Mock = vi.hoisted(() => vi.fn(async () => "silk-base64"));
 
 vi.mock("../messaging/sender.js", () => ({
+  // Prod catch blocks do instanceof checks against this class; the mock must
+  // export it or any error inside the try masks itself as a mock hole.
+  UploadDailyLimitExceededError: class UploadDailyLimitExceededError extends Error {},
   accountToCreds: (account: GatewayAccount) => ({
     appId: account.appId,
     clientSecret: account.clientSecret,
@@ -372,7 +375,7 @@ describe("dispatchOutbound", () => {
   it("lets missing voice files inside scoped outbound roots reach the voice wait path", async () => {
     const tmpRoot = await fs.mkdtemp(path.join(os.tmpdir(), "qqbot-scoped-voice-"));
     try {
-      const missingVoicePath = path.join(tmpRoot, "pending.wav");
+      const missingVoicePath = path.join(await fs.realpath(tmpRoot), "pending.wav");
       const runtime = makeRuntime({
         onDeliver: async (deliver) => {
           await deliver({ text: `<qqvoice>${missingVoicePath}</qqvoice>` }, { kind: "block" });

--- a/extensions/qqbot/src/engine/messaging/outbound-media-send.test.ts
+++ b/extensions/qqbot/src/engine/messaging/outbound-media-send.test.ts
@@ -246,10 +246,12 @@ describe("trySendViaHostRead error handling", () => {
 
     expect(result).toMatchObject({ channel: "qqbot", messageId: "media-1" });
     expect(mockedLoadOutboundMediaFromUrl).not.toHaveBeenCalled();
+    // Trusted-path fallback realpaths the media path; compare resolved forms
+    // so macOS /var -> /private/var tmp dirs do not fail the assertion.
     expect(mockedSenderSendMedia).toHaveBeenCalledWith(
       expect.objectContaining({
         kind: "file",
-        source: { localPath: trustedMediaPath },
+        source: { localPath: await fs.realpath(trustedMediaPath) },
       }),
     );
   });

--- a/src/cli/logs-cli.test.ts
+++ b/src/cli/logs-cli.test.ts
@@ -483,6 +483,14 @@ describe("logs cli", () => {
 
     it("switches back to Gateway logs.tail after temporary journal fallback", async () => {
       vi.spyOn(process, "platform", "get").mockReturnValue("linux");
+      // The CLI renders log timestamps in the host timezone; derive the
+      // expected rendering with the CLI's own formatter instead of assuming a
+      // UTC host (CI is UTC, dev machines often are not).
+      const renderedRecoveredTimestamp = formatLogTimestamp(
+        "2026-05-29T20:00:00.000Z",
+        "plain",
+        true,
+      );
       const recoveredPayload = {
         file: "/tmp/openclaw.log",
         cursor: 10,
@@ -552,7 +560,7 @@ describe("logs cli", () => {
       expect(output).toContain("journal while probing");
       expect(output).toContain("Log file: /tmp/openclaw.log");
       expect(output).toContain("rpc recovered line");
-      expect(output).toContain("2026-05-29T20:00:00.000");
+      expect(output).toContain(renderedRecoveredTimestamp);
       expect(exitSpy).toHaveBeenCalledWith(1);
     });
 

--- a/src/config/sessions/cleanup-service.ts
+++ b/src/config/sessions/cleanup-service.ts
@@ -314,6 +314,34 @@ function pruneMissingTranscriptEntries(params: {
     storePath: params.storePath,
   });
   const sessionsDir = path.dirname(params.storePath);
+  // Symlink-aware in-dir resolution for stored absolute sessionFile values:
+  // resolveSessionFilePath realpaths the sessions dir, so a missing file
+  // stored through a symlinked dir (macOS /var -> /private/var tmp stores)
+  // fails its containment and silently falls back to the canonical
+  // transcript, which defeats missing-file pruning and stale-metadata repair.
+  const realSessionsDir = (() => {
+    try {
+      return fs.realpathSync(path.resolve(sessionsDir));
+    } catch {
+      return path.resolve(sessionsDir);
+    }
+  })();
+  const resolveStoredFileWithinDir = (candidate: string | undefined): string | undefined => {
+    const trimmed = candidate?.trim();
+    if (!trimmed || !path.isAbsolute(trimmed)) {
+      return undefined;
+    }
+    let parentReal: string;
+    try {
+      parentReal = fs.realpathSync(path.dirname(trimmed));
+    } catch {
+      return undefined;
+    }
+    if (parentReal !== realSessionsDir) {
+      return undefined;
+    }
+    return path.join(parentReal, path.basename(trimmed));
+  };
   let removed = 0;
   let repaired = 0;
   for (const [key, entry] of Object.entries(params.store)) {
@@ -338,6 +366,13 @@ function pruneMissingTranscriptEntries(params: {
       transcriptPath = resolveSessionFilePath(entry.sessionId, entry, sessionPathOpts);
     } catch {
       // Malformed sessionFile metadata can still be repaired via the canonical path below.
+    }
+    // Prefer the stored file when it lives in this sessions dir: on symlinked
+    // dirs resolveSessionFilePath returns the canonical fallback instead,
+    // which would mask both the missing-file prune and the stale repair.
+    const storedInDirPath = resolveStoredFileWithinDir(entry.sessionFile);
+    if (storedInDirPath) {
+      transcriptPath = storedInDirPath;
     }
     if (
       isStaleGeneratedBaseTranscript({

--- a/src/config/sessions/store.pruning.integration.test.ts
+++ b/src/config/sessions/store.pruning.integration.test.ts
@@ -636,7 +636,11 @@ describe("Integration: saveSessionStore with pruning", () => {
     expect(applied.appliedSummaries[0]?.afterCount).toBe(1);
     expect(applied.appliedSummaries[0]?.wouldMutate).toBe(true);
     const persisted = loadSessionStore(storePath, { skipCache: true });
-    expect(persisted["agent:main:cron:job:run:fresh"]?.sessionFile).toBe(canonicalTranscript);
+    // Repair persists the resolver's canonical form; on macOS the tmpdir path
+    // realpaths through /var -> /private/var, so compare resolved paths.
+    expect(persisted["agent:main:cron:job:run:fresh"]?.sessionFile).toBe(
+      await fs.realpath(canonicalTranscript),
+    );
     await expectPathExists(canonicalTranscript);
   });
 
@@ -686,7 +690,7 @@ describe("Integration: saveSessionStore with pruning", () => {
     expect(applied.appliedSummaries[0]?.repaired).toBe(1);
     expect(applied.appliedSummaries[0]?.missing).toBe(0);
     const persisted = loadSessionStore(storePath, { skipCache: true });
-    expect(persisted[sessionKey]?.sessionFile).toBe(canonicalTranscript);
+    expect(persisted[sessionKey]?.sessionFile).toBe(await fs.realpath(canonicalTranscript));
     await expectPathExists(canonicalTranscript);
   });
 

--- a/src/infra/backup-create.test.ts
+++ b/src/infra/backup-create.test.ts
@@ -768,6 +768,11 @@ describe("createBackupArchive", () => {
           await fs.mkdir(outputDir, { recursive: true });
 
           const originalReaddir = fs.readdir.bind(fs);
+          // Snapshot discovery scans the realpathed state dir; on macOS the
+          // tmpdir-based stateDir reaches it through the /var -> /private/var
+          // symlink, so compare against the resolved path or the late file is
+          // never injected and the guard has nothing to catch.
+          const resolvedStateDir = await fs.realpath(state.stateDir);
           let createdLatePath = false;
           const readdirSpy = vi.spyOn(fs, "readdir").mockImplementation((async (
             ...args: unknown[]
@@ -775,9 +780,10 @@ describe("createBackupArchive", () => {
             const entries = await (
               originalReaddir as (...readdirArgs: unknown[]) => Promise<unknown>
             )(...args);
+            const scannedDir = path.resolve(String(args[0]));
             if (
               !createdLatePath &&
-              path.resolve(String(args[0])) === path.resolve(state.stateDir)
+              (scannedDir === path.resolve(state.stateDir) || scannedDir === resolvedStateDir)
             ) {
               createdLatePath = true;
               await fs.writeFile(latePath, "late SQLite state");

--- a/src/infra/exec-approvals-analysis.test.ts
+++ b/src/infra/exec-approvals-analysis.test.ts
@@ -201,7 +201,7 @@ describe("Windows enforced shell command rendering", () => {
     });
 
     expect(result.ok).toBe(true);
-    expect(result.command).toMatch(/^& .+python3(?:\.\d+)? a\.py$/);
+    expect(result.command).toMatch(/^& .+python3(?:\.\d+)?"? a\.py$/);
   });
 
   it("rejects Windows commands with unsafe tokens", () => {

--- a/src/media/local-media-access.ts
+++ b/src/media/local-media-access.ts
@@ -93,7 +93,16 @@ export async function assertLocalMediaAllowed(
   try {
     resolved = await fs.realpath(mediaPath);
   } catch {
-    resolved = path.resolve(mediaPath);
+    // Missing files (e.g. staged outbound media served via host-read
+    // callbacks) cannot be realpathed directly; realpath the parent so a
+    // path reaching an allowed root through a symlink (macOS /var ->
+    // /private/var tmp dirs) still compares as inside the resolved roots
+    // instead of failing closed. The containment check below is unchanged.
+    try {
+      resolved = path.join(await fs.realpath(path.dirname(mediaPath)), path.basename(mediaPath));
+    } catch {
+      resolved = path.resolve(mediaPath);
+    }
   }
 
   if (localRoots === undefined) {

--- a/src/test-utils/process-tree.ts
+++ b/src/test-utils/process-tree.ts
@@ -39,8 +39,26 @@ export async function waitForPidToExit(pid: number, timeoutMs = 2000): Promise<b
   return !isPidAlive(pid);
 }
 
-export async function readPidFile(pidPath: string): Promise<number> {
-  return Number((await fs.readFile(pidPath, "utf8")).trim());
+export async function readPidFile(pidPath: string, timeoutMs = 5000): Promise<number> {
+  // Forked helpers write their pid file at startup; under load the parent's
+  // assertions can run first, so poll instead of racing a single read.
+  const deadline = Date.now() + timeoutMs;
+  for (;;) {
+    try {
+      const pid = Number((await fs.readFile(pidPath, "utf8")).trim());
+      if (Number.isFinite(pid) && pid > 0) {
+        return pid;
+      }
+    } catch {
+      // Keep polling until the child has written the file.
+    }
+    if (Date.now() >= deadline) {
+      throw new Error(`pid file not written in time: ${pidPath}`);
+    }
+    await new Promise<void>((resolve) => {
+      setTimeout(resolve, 25);
+    });
+  }
 }
 
 export function killPidIfAlive(pid: number | undefined): void {


### PR DESCRIPTION
## What Problem This Solves

Two runtime fail-closed bugs when OpenClaw state or media roots are reached through symlinked directories (macOS `/var -> /private/var` tmp paths, or any user-level symlinked state/media dir):

1. `sessions cleanup` silently skipped both stale-generated-metadata repair and missing-transcript pruning: the resolver realpaths the sessions dir, a stored `sessionFile` addressed through the symlink failed containment, and the canonical-transcript fallback masked the stale row forever.
2. Outbound media that does not exist on disk yet (host-read staged media, bytes served via callbacks) cannot be realpathed, so its raw path failed the allowed-roots containment check and sends failed closed with "Local media path is not under an allowed directory".

Related to #100025 (the test-gate side of that issue was fixed by #100069; these are the two production bugs uncovered by the same investigation).

## Why This Change Was Made

- `src/config/sessions/cleanup-service.ts`: cleanup now resolves a stored absolute `sessionFile` directly when its realpathed parent equals the realpathed sessions dir, instead of letting the resolver fall back to the canonical transcript. Agents-shaped fallbacks and every existing path pin are untouched.
- `src/media/local-media-access.ts`: missing candidates realpath their parent dir and rejoin the basename before the containment check. The invariant (path must be inside a resolved allowed root) is unchanged; only the previously fail-closed symlink form is corrected.

Both come with cross-platform regression tests that build an explicit `fs.symlink` dir, so they exercise the fixed branches on Linux CI too — not only on macOS.

## User Impact

Sessions cleanup repairs/prunes correctly for stores on symlinked paths; outbound media staged via host-read callbacks under symlinked allowed roots now sends instead of erroring. No behavior change for non-symlinked setups.

## Evidence

- New regression tests fail on `main` without the fixes and pass with them (verified both directions):
  - `store.pruning.integration.test.ts` "repairs stale generated metadata when the store is reached through a symlinked dir" — repaired 0 -> 1
  - `local-media-access.test.ts` "allows missing files under a root reached through a symlinked dir" — path-not-allowed -> allowed
- Full runtime-config shard 165 files / 2116+ tests green; media access suites green; `pnpm tsgo` clean.
- Root-cause probes and the fail-closed error strings are documented in the PR history and #100025.
