### PR TITLE
fix: normalize Android all-day calendar events

### DIFF
--- a/apps/android/app/src/main/java/ai/openclaw/app/node/CalendarHandler.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/node/CalendarHandler.kt
@@ -37,10 +37,16 @@ internal data class CalendarAddRequest(
   val startMs: Long,
   val endMs: Long,
   val isAllDay: Boolean,
+  val timeZoneId: String,
   val location: String?,
   val notes: String?,
   val calendarId: Long?,
   val calendarTitle: String?,
+)
+
+private data class CalendarAddRange(
+  val start: Instant,
+  val end: Instant,
 )
 
 /**
@@ -148,7 +154,7 @@ private object SystemCalendarDataSource : CalendarDataSource {
         put(CalendarContract.Events.DTSTART, request.startMs)
         put(CalendarContract.Events.DTEND, request.endMs)
         put(CalendarContract.Events.ALL_DAY, if (request.isAllDay) 1 else 0)
-        put(CalendarContract.Events.EVENT_TIMEZONE, TimeZone.getDefault().id)
+        put(CalendarContract.Events.EVENT_TIMEZONE, request.timeZoneId)
         request.location?.let { put(CalendarContract.Events.EVENT_LOCATION, it) }
         request.notes?.let { put(CalendarContract.Events.DESCRIPTION, it) }
       }
@@ -393,15 +399,33 @@ class CalendarHandler private constructor(
     val end =
       parseISO((params["endISO"] as? JsonPrimitive)?.content)
         ?: return null
+    val isAllDay = (params["isAllDay"] as? JsonPrimitive)?.content?.toBooleanStrictOrNull() ?: false
+    val addRange = normalizeAddRange(start, end, isAllDay)
     return CalendarAddRequest(
       title = (params["title"] as? JsonPrimitive)?.content?.trim().orEmpty(),
-      startMs = start.toEpochMilli(),
-      endMs = end.toEpochMilli(),
-      isAllDay = (params["isAllDay"] as? JsonPrimitive)?.content?.toBooleanStrictOrNull() ?: false,
+      startMs = addRange.start.toEpochMilli(),
+      endMs = addRange.end.toEpochMilli(),
+      isAllDay = isAllDay,
+      timeZoneId = if (isAllDay) "UTC" else TimeZone.getDefault().id,
       location = (params["location"] as? JsonPrimitive)?.content?.trim()?.ifEmpty { null },
       notes = (params["notes"] as? JsonPrimitive)?.content?.trim()?.ifEmpty { null },
       calendarId = (params["calendarId"] as? JsonPrimitive)?.content?.toLongOrNull(),
       calendarTitle = (params["calendarTitle"] as? JsonPrimitive)?.content?.trim()?.ifEmpty { null },
+    )
+  }
+
+  private fun normalizeAddRange(
+    start: Instant,
+    end: Instant,
+    isAllDay: Boolean,
+  ): CalendarAddRange {
+    if (!isAllDay) return CalendarAddRange(start = start, end = end)
+    if (end <= start) return CalendarAddRange(start = start, end = end)
+    val dayStart = start.truncatedTo(ChronoUnit.DAYS)
+    val dayEnd = end.truncatedTo(ChronoUnit.DAYS)
+    return CalendarAddRange(
+      start = dayStart,
+      end = if (dayEnd > dayStart) dayEnd else dayStart.plus(1, ChronoUnit.DAYS),
     )
   }
 

--- a/apps/android/app/src/test/java/ai/openclaw/app/node/CalendarHandlerTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/node/CalendarHandlerTest.kt
@@ -9,6 +9,7 @@ import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Test
+import java.time.Instant
 
 class CalendarHandlerTest : NodeHandlerRobolectricTest() {
   @Test
@@ -86,6 +87,24 @@ class CalendarHandlerTest : NodeHandlerRobolectricTest() {
     assertFalse(result.ok)
     assertEquals("CALENDAR_NOT_FOUND", result.error?.code)
   }
+
+  @Test
+  fun handleCalendarAdd_normalizesAllDayEventForAndroidProvider() {
+    val source = FakeCalendarDataSource(canRead = true, canWrite = true)
+    val handler = CalendarHandler.forTesting(appContext(), source)
+
+    val result =
+      handler.handleCalendarAdd(
+        """{"title":"X","startISO":"2026-07-05T09:00:00Z","endISO":"2026-07-06T09:00:00Z","isAllDay":true}""",
+      )
+
+    assertTrue(result.ok)
+    val request = source.addedRequest ?: error("missing add request")
+    assertTrue(request.isAllDay)
+    assertEquals("UTC", request.timeZoneId)
+    assertEquals(Instant.parse("2026-07-05T00:00:00Z").toEpochMilli(), request.startMs)
+    assertEquals(Instant.parse("2026-07-06T00:00:00Z").toEpochMilli(), request.endMs)
+  }
 }
 
 private class FakeCalendarDataSource(
@@ -104,6 +123,9 @@ private class FakeCalendarDataSource(
     ),
   private val addError: Throwable? = null,
 ) : CalendarDataSource {
+  var addedRequest: CalendarAddRequest? = null
+    private set
+
   override fun hasReadPermission(context: Context): Boolean = canRead
 
   override fun hasWritePermission(context: Context): Boolean = canWrite
@@ -118,6 +140,7 @@ private class FakeCalendarDataSource(
     request: CalendarAddRequest,
   ): CalendarEventRecord {
     addError?.let { throw it }
+    addedRequest = request
     return addResult
   }
 }


### PR DESCRIPTION
## What Problem This Solves

Fixes Android `calendar.add` all-day events being written with the device timezone and caller-provided instants instead of Android provider-compatible UTC all-day rows.

## Why This Change Was Made

Android `CalendarContract` all-day events need UTC timezone metadata and UTC-midnight `DTSTART`/`DTEND` values. This change normalizes only the all-day path to UTC day boundaries and keeps timed events on the existing device-timezone path.

## User Impact

`calendar.add` requests with `isAllDay: true` now create stable all-day Android calendar events instead of depending on OEM provider tolerance for invalid all-day rows that may be rejected or stored on the wrong date.

## Evidence

- `node scripts/run-android-gradle.mjs :app:testPlayDebugUnitTest --tests ai.openclaw.app.node.CalendarHandlerTest`
- `git diff --check`
- `node scripts/run-android-gradle.mjs :app:ktlintCheck` was attempted and failed on pre-existing unrelated ktlint violations in `apps/android/app/src/test/java/ai/openclaw/app/chat/ChatControllerCommandControlsTest.kt`, `apps/android/app/src/test/java/ai/openclaw/app/gateway/InvokeErrorParserTest.kt`, and `apps/android/app/src/test/java/ai/openclaw/app/ui/GatewayConfigResolverTest.kt`.
- Autoreview skipped at requester direction for this round.
