### PR TITLE
[codex] Avoid rereading compacted transcript history

### DIFF
--- a/src/agents/embedded-agent-runner/compaction-successor-transcript.test.ts
+++ b/src/agents/embedded-agent-runner/compaction-successor-transcript.test.ts
@@ -20,6 +20,7 @@ async function createTmpDir(): Promise<string> {
 }
 
 afterEach(async () => {
+  vi.restoreAllMocks();
   if (tmpDir) {
     await fs.rm(tmpDir, { recursive: true, force: true }).catch(() => undefined);
     tmpDir = undefined;
@@ -85,6 +86,19 @@ function requireEntryByType<T extends TranscriptEntry["type"]>(
     throw new Error(`expected ${label}`);
   }
   return entry as Extract<TranscriptEntry, { type: T }>;
+}
+
+function readUserTexts(entries: readonly TranscriptEntry[]): string[] {
+  return entries
+    .filter((entry) => entry.type === "message" && entry.message.role === "user")
+    .map((entry) => {
+      if (entry.type !== "message" || entry.message.role !== "user") {
+        return "";
+      }
+      return typeof entry.message.content === "string"
+        ? entry.message.content
+        : JSON.stringify(entry.message.content);
+    });
 }
 
 function createCompactedSession(sessionDir: string): {
@@ -183,6 +197,78 @@ describe("rotateTranscriptAfterCompaction", () => {
         content: [{ type: "text", text: "post assistant" }],
         timestamp: 6,
       },
+    ]);
+  });
+
+  it("rotates a long file-backed transcript without rereading compacted history", async () => {
+    const dir = await createTmpDir();
+    const manager = SessionManager.create(dir, dir);
+
+    for (let index = 0; index < 900; index += 1) {
+      manager.appendMessage({
+        role: "user",
+        content: `historical prompt ${index} ${"x".repeat(900)}`,
+        timestamp: index * 2 + 1,
+      });
+      manager.appendMessage(
+        makeAssistant(`historical answer ${index} ${"y".repeat(900)}`, index * 2 + 2),
+      );
+    }
+
+    manager.appendModelChange("anthropic", "claude-opus-4-8");
+    manager.appendThinkingLevelChange("medium");
+    manager.appendMessage({ role: "user", content: "pre kept request", timestamp: 5_000 });
+    manager.appendMessage(makeAssistant("preserved assistant before kept tail", 5_001));
+    const firstKeptId = manager.appendMessage({
+      role: "user",
+      content: "kept deployment prompt",
+      timestamp: 5_002,
+    });
+    manager.appendLabelChange(firstKeptId, "kept bookmark");
+    manager.appendMessage(makeAssistant("kept deployment answer", 5_003));
+    manager.appendCompaction("Summary of the long historical transcript.", firstKeptId, 200_000);
+    manager.appendMessage({
+      role: "user",
+      content: "post compaction followup",
+      timestamp: 5_004,
+    });
+    manager.appendMessage(makeAssistant("post compaction answer", 5_005));
+
+    const sessionFile = requireString(manager.getSessionFile(), "source session file");
+    const sourcePath = path.resolve(sessionFile);
+    const sourceBytes = (await fs.stat(sourcePath)).size;
+    const readFileSpy = vi.spyOn(fs, "readFile");
+
+    const result = await rotateTranscriptFileAfterCompaction({
+      sessionFile: sourcePath,
+      now: () => new Date("2026-07-04T16:30:00.000Z"),
+    });
+
+    expect(result.rotated).toBe(true);
+    expect(sourceBytes).toBeGreaterThan(1024 * 1024);
+    expect(readFileSpy.mock.calls.some(([file]) => path.resolve(String(file)) === sourcePath)).toBe(
+      false,
+    );
+    const successor = SessionManager.open(requireString(result.sessionFile, "successor file"));
+    const successorEntries = successor.getEntries();
+    const serializedSuccessor = JSON.stringify(successorEntries);
+    expect(serializedSuccessor).toContain("Summary of the long historical transcript.");
+    expect(serializedSuccessor).toContain("preserved assistant before kept tail");
+    expect(serializedSuccessor).toContain("kept deployment prompt");
+    expect(serializedSuccessor).toContain("post compaction followup");
+    expect(serializedSuccessor).not.toContain("historical prompt 100");
+    expect(readUserTexts(successorEntries)).toEqual([
+      "kept deployment prompt",
+      "post compaction followup",
+    ]);
+    expect(successor.getLabel(firstKeptId)).toBe("kept bookmark");
+    expect(successor.buildSessionContext().messages.map((message) => message.role)).toEqual([
+      "compactionSummary",
+      "assistant",
+      "user",
+      "assistant",
+      "user",
+      "assistant",
     ]);
   });
 

--- a/src/agents/embedded-agent-runner/compaction-successor-transcript.ts
+++ b/src/agents/embedded-agent-runner/compaction-successor-transcript.ts
@@ -11,6 +11,7 @@ import { collectDuplicateUserMessageEntryIdsForCompaction } from "./compaction-d
 import { stripThinkingSignaturesFromMessage } from "./thinking.js";
 import {
   readTranscriptFileState,
+  readTranscriptFileStateForSuccessorRotation,
   TranscriptFileState,
   writeTranscriptFileAtomic,
 } from "./transcript-file-state.js";
@@ -91,12 +92,42 @@ export async function rotateTranscriptFileAfterCompaction(params: {
   sessionFile: string;
   now?: () => Date;
 }): Promise<CompactionTranscriptRotation> {
-  const state = await readTranscriptFileState(params.sessionFile);
+  const state = await readTranscriptFileStateForSuccessorRotation(params.sessionFile);
+  const sessionManager = isCompleteSuccessorRotationState(state)
+    ? state
+    : await readTranscriptFileState(params.sessionFile);
   return rotateTranscriptAfterCompaction({
-    sessionManager: state,
+    sessionManager,
     sessionFile: params.sessionFile,
     ...(params.now ? { now: params.now } : {}),
   });
+}
+
+function isCompleteSuccessorRotationState(state: ReadonlySessionManagerForRotation): boolean {
+  const branch = state.getBranch();
+  const latestCompactionIndex = findLatestCompactionIndex(branch);
+  if (latestCompactionIndex < 0) {
+    return false;
+  }
+
+  const compaction = branch[latestCompactionIndex] as CompactionEntry;
+  if (compaction.firstKeptEntryId === compaction.id) {
+    return true;
+  }
+  if (!compaction.firstKeptEntryId) {
+    return false;
+  }
+
+  const firstKeptIndex = branch.findIndex((entry) => entry.id === compaction.firstKeptEntryId);
+  if (firstKeptIndex <= 0) {
+    return false;
+  }
+
+  // File-only rotation can skip compacted middle rows only when the tail proves
+  // the assistant turn that rotation intentionally preserves is present.
+  return branch
+    .slice(0, firstKeptIndex)
+    .some((entry) => entry.type === "message" && entry.message.role === "assistant");
 }
 
 function findLatestCompactionIndex(entries: SessionEntry[]): number {

--- a/src/agents/embedded-agent-runner/transcript-file-state.ts
+++ b/src/agents/embedded-agent-runner/transcript-file-state.ts
@@ -43,6 +43,11 @@ type TranscriptLeafControlEntry = {
 
 export type TranscriptPersistedEntry = SessionEntry | TranscriptLeafControlEntry;
 
+const SUCCESSOR_ROTATION_HEAD_BYTES = 32 * 1024;
+const SUCCESSOR_ROTATION_TAIL_BYTES = 512 * 1024;
+const SUCCESSOR_ROTATION_SMALL_FILE_BYTES =
+  SUCCESSOR_ROTATION_HEAD_BYTES + SUCCESSOR_ROTATION_TAIL_BYTES;
+
 const sessionEntryTypes = new Set<string>([
   "branch_summary",
   "compaction",
@@ -936,6 +941,84 @@ export class TranscriptFileState {
 export async function readTranscriptFileState(sessionFile: string): Promise<TranscriptFileState> {
   const raw = await fs.readFile(sessionFile, "utf-8");
   const fileEntries = (parseSessionEntries(raw) as unknown[]).map(fileEntryOrMigrationSlot);
+  return buildTranscriptFileState(fileEntries);
+}
+
+/** Read only the transcript slices needed to attempt successor rotation. */
+export async function readTranscriptFileStateForSuccessorRotation(
+  sessionFile: string,
+): Promise<TranscriptFileState> {
+  const partialEntries = await readSuccessorRotationFileEntries(sessionFile);
+  if (!partialEntries) {
+    return readTranscriptFileState(sessionFile);
+  }
+  return buildTranscriptFileState(partialEntries);
+}
+
+async function readSuccessorRotationFileEntries(sessionFile: string): Promise<FileEntry[] | null> {
+  const handle = await fs.open(sessionFile, "r");
+  try {
+    const { size } = await handle.stat();
+    if (size <= SUCCESSOR_ROTATION_SMALL_FILE_BYTES) {
+      return null;
+    }
+
+    const headBytes = Math.min(size, SUCCESSOR_ROTATION_HEAD_BYTES);
+    const headBuffer = Buffer.allocUnsafe(headBytes);
+    const headRead = await handle.read(headBuffer, 0, headBytes, 0);
+    const headRecords = parseCompleteJsonlRecords(
+      headBuffer.toString("utf-8", 0, headRead.bytesRead),
+      { dropLeadingPartial: false, dropTrailingPartial: headRead.bytesRead < size },
+    );
+    const header = headRecords.find((entry) => entry.type === "session");
+    if (!header) {
+      return null;
+    }
+
+    const tailStart = Math.max(0, size - SUCCESSOR_ROTATION_TAIL_BYTES);
+    if (tailStart <= headRead.bytesRead) {
+      return null;
+    }
+    const tailBytes = size - tailStart;
+    const tailBuffer = Buffer.allocUnsafe(tailBytes);
+    const tailRead = await handle.read(tailBuffer, 0, tailBytes, tailStart);
+    const tailRecords = parseCompleteJsonlRecords(
+      tailBuffer.toString("utf-8", 0, tailRead.bytesRead),
+      { dropLeadingPartial: tailStart > 0, dropTrailingPartial: false },
+    );
+
+    return [header, ...tailRecords].map(fileEntryOrMigrationSlot);
+  } finally {
+    await handle.close();
+  }
+}
+
+function parseCompleteJsonlRecords(
+  raw: string,
+  options: { dropLeadingPartial: boolean; dropTrailingPartial: boolean },
+): Record<string, unknown>[] {
+  const lines = raw.split("\n");
+  if (options.dropLeadingPartial) {
+    lines.shift();
+  }
+  if (options.dropTrailingPartial) {
+    lines.pop();
+  }
+  const records: unknown[] = [];
+  for (const line of lines) {
+    if (!line.trim()) {
+      continue;
+    }
+    try {
+      records.push(JSON.parse(line));
+    } catch {
+      continue;
+    }
+  }
+  return records.filter(isRecord);
+}
+
+function buildTranscriptFileState(fileEntries: FileEntry[]): TranscriptFileState {
   const headerBeforeMigration =
     fileEntries.find((entry): entry is SessionHeader => entry.type === "session") ?? null;
   const headerVersionBeforeMigration = sessionHeaderVersion(headerBeforeMigration);


### PR DESCRIPTION
## What Problem This Solves

Issue #99190 tracks long-session paths that reread full JSONL transcript files even after older history has already been compacted. The file-backed post-compaction successor rotation path still parsed the entire original transcript before writing the successor file.

In the reproduced long-session fixture, rotating after compaction read the full `3,374,701` byte source transcript even though the successor only needs the session header and the active tail around the latest compaction.

## Root Cause

`rotateTranscriptFileAfterCompaction` always called the generic full transcript reader. That reader is still the right default for repair and mutation paths, but successor rotation has a narrower data need: it must build a valid successor from the latest compaction, preserved assistant context, labels/state in the active tail, and post-compaction entries.

## Changes

- add `readTranscriptFileStateForSuccessorRotation`, a rotation-specific reader that samples a small session header window plus the recent transcript tail
- fall back to the existing full reader when the sampled state is missing the latest compaction, `firstKeptEntryId`, or the assistant turn that successor rotation intentionally preserves
- keep the existing full transcript reader unchanged for normal parsing, repair, and mutation behavior
- add a long-transcript regression test proving the source transcript is not reread, summarized historical prompts do not leak into the successor, labels survive, and context roles stay valid

## Safety

The optimization is only used by the file-backed successor rotation entrypoint. If the bounded sample cannot prove it has the complete active rotation state, the code falls back to the full transcript parse before rotating.

## Evidence

Measured on the long-transcript regression fixture:

```text
baseline original transcript read bytes: 3374701
optimized original transcript read bytes: 557056
readFileBytes: 0
bounded source reads: 2
```

Focused validation passed:

- successor transcript and transcript file-state Vitest suite: 4 files, 40 tests
- formatting check for the changed TypeScript files
- whitespace check
- core TypeScript typecheck
- agent test TypeScript typecheck

Fixes #99190