### PR TITLE
fix(agents): replay images across cli fallback

### DIFF
--- a/src/agents/cli-runner.helpers.test.ts
+++ b/src/agents/cli-runner.helpers.test.ts
@@ -1,5 +1,6 @@
 /** Tests CLI runner prompt/image/system-prompt helper utilities. */
 import fs from "node:fs/promises";
+import os from "node:os";
 import path from "node:path";
 import { MAX_IMAGE_BYTES } from "@openclaw/media-core/constants";
 import type { ImageContent } from "openclaw/plugin-sdk/llm";
@@ -7,6 +8,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import { createSolidPngBuffer } from "../../test/helpers/image-fixtures.js";
 import { resolvePreferredOpenClawTmpDir } from "../infra/tmp-openclaw-dir.js";
 import { escapeRegExp } from "../shared/regexp.js";
+import { captureEnv, setTestEnvValue } from "../test-utils/env.js";
 import {
   buildCliArgs,
   buildClaudeOwnerKey,
@@ -494,6 +496,55 @@ describe("writeCliImages", () => {
       await prepared.cleanupImages?.();
     } finally {
       await fs.rm(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it("merges inline payloads with offloaded refs in attachment order", async () => {
+    const stateDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-cli-mixed-images-"));
+    const workspaceDir = path.join(stateDir, "workspace");
+    const inboundDir = path.join(stateDir, "media", "inbound");
+    const mediaId = "offloaded.png";
+    const historyImagePath = path.join(workspaceDir, "history.png");
+    const offloadedImage = createSolidPngBuffer(1, 1, { r: 255, g: 0, b: 0 });
+    const inlineImage = createSolidPngBuffer(1, 1, { r: 0, g: 0, b: 255 });
+    const historyImage = createSolidPngBuffer(1, 1, { r: 0, g: 255, b: 0 });
+    await fs.mkdir(workspaceDir, { recursive: true });
+    await fs.mkdir(inboundDir, { recursive: true });
+    await fs.writeFile(path.join(inboundDir, mediaId), offloadedImage);
+    await fs.writeFile(historyImagePath, historyImage);
+    const envSnapshot = captureEnv(["OPENCLAW_STATE_DIR"]);
+    setTestEnvValue("OPENCLAW_STATE_DIR", stateDir);
+    const currentTurn = `compare these\n[media attached: media://inbound/${mediaId}]`;
+
+    try {
+      const prepared = await prepareCliPromptImagePayload({
+        backend: {
+          command: "codex",
+          imageArg: "--image",
+          imageMode: "repeat",
+          input: "arg",
+        },
+        prompt: `[Earlier history: ${historyImagePath}]\n\n[Retry after failure]\n\n${currentTurn}`,
+        imagePrompt: currentTurn,
+        workspaceDir,
+        images: [
+          {
+            type: "image",
+            data: inlineImage.toString("base64"),
+            mimeType: "image/png",
+          },
+        ],
+        imageOrder: ["offloaded", "inline"],
+      });
+
+      expect(prepared.imagePaths).toHaveLength(2);
+      await expect(fs.readFile(prepared.imagePaths?.[0] ?? "")).resolves.toEqual(offloadedImage);
+      await expect(fs.readFile(prepared.imagePaths?.[1] ?? "")).resolves.toEqual(inlineImage);
+
+      await prepared.cleanupImages?.();
+    } finally {
+      envSnapshot.restore();
+      await fs.rm(stateDir, { recursive: true, force: true });
     }
   });
 });

--- a/src/agents/cli-runner.reliability.test.ts
+++ b/src/agents/cli-runner.reliability.test.ts
@@ -3,6 +3,7 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { createSolidPngBuffer } from "../../test/helpers/image-fixtures.js";
 import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
 import { getReplyPayloadMetadata } from "../auto-reply/reply-payload.js";
 import {
@@ -597,11 +598,60 @@ describe("runCliAgent reliability", () => {
       model: "opus",
       openClawHistoryPrompt: CLI_RESEED_PROMPT,
     });
+    context.preparedBackend.backend = {
+      ...context.preparedBackend.backend,
+      resumeArgs: ["exec", "resume", "{sessionId}", "--json"],
+      imageArg: "--image",
+      imageMode: "repeat",
+    };
+    const stateDir = autoCleanupTempDirs.make("openclaw-cli-retry-images-");
+    const workspaceDir = path.join(stateDir, "workspace");
+    const inboundDir = path.join(stateDir, "media", "inbound");
+    const mediaId = "offloaded.png";
+    const offloadedImage = createSolidPngBuffer(1, 1, { r: 255, g: 0, b: 0 });
+    const inlineImage = createSolidPngBuffer(1, 1, { r: 0, g: 0, b: 255 });
+    fs.mkdirSync(workspaceDir, { recursive: true });
+    fs.mkdirSync(inboundDir, { recursive: true });
+    fs.writeFileSync(path.join(inboundDir, mediaId), offloadedImage);
+    vi.stubEnv("OPENCLAW_STATE_DIR", stateDir);
+    const currentTurn = `compare these\n[media attached: media://inbound/${mediaId}]`;
+    context.workspaceDir = workspaceDir;
+    context.params = {
+      ...context.params,
+      workspaceDir,
+      prompt: `[Retry after failure]\n\n${currentTurn}`,
+      imagePrompt: currentTurn,
+      images: [
+        {
+          type: "image",
+          data: inlineImage.toString("base64"),
+          mimeType: "image/png",
+        },
+      ],
+      imageOrder: ["offloaded", "inline"],
+    };
 
     const result = await runPreparedCliAgent(context);
 
     expect(result.payloads).toEqual([{ text: "hello from fresh cli" }]);
     expect(supervisorSpawnMock).toHaveBeenCalledTimes(2);
+    for (const [index, label] of ["resumed", "fresh"].entries()) {
+      const spawn = requireRecord(
+        callArg(supervisorSpawnMock, index, 0, `${label} image CLI spawn`),
+        `${label} image CLI spawn`,
+      );
+      const argv = requireArray(spawn.argv, `${label} image CLI argv`);
+      const imagePaths = argv.flatMap((arg, argIndex) =>
+        arg === "--image" && typeof argv[argIndex + 1] === "string"
+          ? [argv[argIndex + 1] as string]
+          : [],
+      );
+      expect(imagePaths).toHaveLength(2);
+      expect(fs.readFileSync(imagePaths[0])).toEqual(offloadedImage);
+      expect(fs.readFileSync(imagePaths[1])).toEqual(inlineImage);
+      expect(argv.includes("resume")).toBe(index === 0);
+      expect(argv.includes("stale-cli-session")).toBe(index === 0);
+    }
   });
 
   it("does not retry or fail over after a confirmed message send", async () => {

--- a/src/agents/cli-runner/execute.ts
+++ b/src/agents/cli-runner/execute.ts
@@ -485,8 +485,10 @@ export async function executePreparedCliRun(
   } = await prepareCliPromptImagePayload({
     backend,
     prompt,
+    imagePrompt: params.imagePrompt,
     workspaceDir: context.workspaceDir,
     images: params.images,
+    imageOrder: params.imageOrder,
   });
   prompt = promptWithImages;
 

--- a/src/agents/cli-runner/helpers.ts
+++ b/src/agents/cli-runner/helpers.ts
@@ -24,9 +24,14 @@ import { privateFileStore } from "../../infra/private-file-store.js";
 import { tempWorkspace } from "../../infra/private-temp-workspace.js";
 import { resolvePreferredOpenClawTmpDir } from "../../infra/tmp-openclaw-dir.js";
 import type { ImageContent } from "../../llm/types.js";
+import type { PromptImageOrderEntry } from "../../media/prompt-image-order.js";
 import { listRegisteredPluginAgentPromptGuidance } from "../../plugins/command-registry-state.js";
 import type { EmbeddedContextFile } from "../embedded-agent-helpers.js";
-import { detectImageReferences, loadImageFromRef } from "../embedded-agent-runner/run/images.js";
+import {
+  detectAndLoadPromptImages,
+  detectImageReferences,
+  loadImageFromRef,
+} from "../embedded-agent-runner/run/images.js";
 import { resolveDefaultModelForAgent } from "../model-selection.js";
 import type { AgentTool } from "../runtime/index.js";
 import type { SandboxFsBridge } from "../sandbox/fs-bridge.js";
@@ -447,8 +452,10 @@ export async function writeCliSystemPromptFile(params: {
 export async function prepareCliPromptImagePayload(params: {
   backend: CliBackendConfig;
   prompt: string;
+  imagePrompt?: string;
   workspaceDir: string;
   images?: ImageContent[];
+  imageOrder?: PromptImageOrderEntry[];
 }): Promise<{
   prompt: string;
   imagePaths?: string[];
@@ -456,9 +463,20 @@ export async function prepareCliPromptImagePayload(params: {
 }> {
   let prompt = params.prompt;
   const resolvedImages =
-    params.images && params.images.length > 0
-      ? params.images
-      : await loadPromptRefImages({ prompt, workspaceDir: params.workspaceDir });
+    params.imagePrompt !== undefined
+      ? (
+          await detectAndLoadPromptImages({
+            prompt: params.imagePrompt,
+            workspaceDir: params.workspaceDir,
+            model: { input: ["text", "image"] },
+            existingImages: params.images,
+            imageOrder: params.imageOrder,
+            maxBytes: MAX_IMAGE_BYTES,
+          })
+        ).images
+      : params.images && params.images.length > 0
+        ? params.images
+        : await loadPromptRefImages({ prompt, workspaceDir: params.workspaceDir });
   if (resolvedImages.length === 0) {
     return { prompt };
   }

--- a/src/agents/cli-runner/types.ts
+++ b/src/agents/cli-runner/types.ts
@@ -49,6 +49,8 @@ export type RunCliAgentParams = {
   config?: OpenClawConfig;
   prompt: string;
   transcriptPrompt?: string;
+  /** Undecorated current-turn prompt used to merge inline and offloaded images. */
+  imagePrompt?: string;
   /**
    * Execution mode for the generic CLI runner. Side questions are one-shot
    * background answers and must not reuse or mutate normal agent sessions.

--- a/src/agents/command/attempt-execution.cli.test.ts
+++ b/src/agents/command/attempt-execution.cli.test.ts
@@ -2057,6 +2057,7 @@ describe("CLI attempt execution", () => {
     expectMockArgFields(runCliAgentMock, {
       prompt: "[Wed 2024-06-05 15:30 UTC] what time is it?",
       transcriptPrompt: "canonical timestamp question",
+      imagePrompt: "what time is it?",
       userTurnTranscriptRecorder,
       suppressNextUserMessagePersistence: false,
     });
@@ -2072,6 +2073,8 @@ describe("CLI attempt execution", () => {
     await fs.writeFile(storePath, JSON.stringify(sessionStore, null, 2), "utf-8");
     runCliAgentMock.mockResolvedValueOnce(makeCliResult("canonical cli"));
     const fallbackRuntimeState: NonNullable<RunAgentAttemptParams["fallbackRuntimeState"]> = {};
+    const images = [{ type: "image" as const, data: "aGVsbG8=", mimeType: "image/png" }];
+    const imageOrder = ["inline" as const];
 
     await runAgentAttempt({
       providerOverride: "anthropic",
@@ -2093,11 +2096,11 @@ describe("CLI attempt execution", () => {
       sessionFile: path.join(tmpDir, "session.jsonl"),
       workspaceDir: tmpDir,
       body: "route this",
-      isFallbackRetry: false,
+      isFallbackRetry: true,
       resolvedThinkLevel: "medium",
       timeoutMs: 1_000,
       runId: "run-canonical-claude-cli",
-      opts: {} as Parameters<typeof runAgentAttempt>[0]["opts"],
+      opts: { images, imageOrder } as Parameters<typeof runAgentAttempt>[0]["opts"],
       runContext: {} as Parameters<typeof runAgentAttempt>[0]["runContext"],
       spawnedBy: undefined,
       messageChannel: "telegram",
@@ -2116,10 +2119,12 @@ describe("CLI attempt execution", () => {
     expectMockArgFields(runCliAgentMock, {
       provider: "claude-cli",
       model: "claude-opus-4-7",
+      imagePrompt: "route this",
+      images,
+      imageOrder,
     });
     expect(fallbackRuntimeState.originRuntime).toBe("cli");
 
-    const images = [{ type: "image" as const, data: "aGVsbG8=", mimeType: "image/png" }];
     const fallbackArg = await runOpenClawEmbeddedAttemptForTest({
       runId: "run-canonical-claude-cli-fallback",
       isFallbackRetry: true,

--- a/src/agents/command/attempt-execution.ts
+++ b/src/agents/command/attempt-execution.ts
@@ -705,10 +705,12 @@ export function runAgentAttempt(params: {
         authProfileId,
         bootstrapPromptWarningSignaturesSeen,
         bootstrapPromptWarningSignature,
-        // CLI retries may reuse native session history. Their image replay
-        // decision must be made per process invocation inside the CLI runner.
-        images: params.isFallbackRetry ? undefined : params.opts.images,
-        imageOrder: params.isFallbackRetry ? undefined : params.opts.imageOrder,
+        // Image discovery must use the original turn, before retry/history decoration.
+        imagePrompt: params.body,
+        // Fallback prompts repeat the current task, so prompt-local images must
+        // accompany every CLI process. Native dedupe requires a runtime receipt.
+        images: params.opts.images,
+        imageOrder: params.opts.imageOrder,
         skillsSnapshot: params.skillsSnapshot,
         messageChannel: params.messageChannel,
         streamParams: params.opts.streamParams,


### PR DESCRIPTION
Related: https://github.com/openclaw/openclaw/pull/99891
Related: https://github.com/openclaw/openclaw/pull/99902

## What Problem This Solves

Fixes an issue where users whose embedded agent attempt fell back to a CLI provider could lose inline or offloaded images, or replay a stale image reference from retry/history prompt decoration.

## Why This Change Was Made

The fallback path now passes the undecorated current turn into the CLI image preparation seam and forwards the canonical attachment order. The CLI runner reuses the existing prompt image detector to merge inline payloads, offloaded claim-check references, and explicit current-turn image references without scanning retry or history decoration.

This is intentionally limited to `runAgentAttempt` fallback execution. Defining a canonical current-turn image prompt for normal auto-reply queue collection remains separate work because collected turns need per-item attachment boundaries.

## User Impact

CLI fallback attempts now receive the same current-turn images, in the same order, across both resumed and fresh CLI processes. Text-only fallback turns no longer attach image paths found only in prior history or retry context.

## Evidence

- Rebased head: `72503d339a9b13134ddd3596f5acac146b966ed7`
- Focused Vitest: 6 files passed, 8 tests passed, 308 skipped.
- `oxfmt --check` passed for all 7 changed files.
- Scoped Oxlint passed with 0 warnings and 0 errors.
- Branch autoreview against `origin/main`: clean, no actionable findings, confidence 0.91.
- Testbox-through-Crabbox `pnpm check:changed`: passed, provider `blacksmith-testbox`, ID `tbx_01kwq38v4hcd9tny25r5n9twtp`, exit code 0.
