### PR TITLE
fix(gateway): keep close reasons valid UTF-8

### DIFF
--- a/src/gateway/server/close-reason.test.ts
+++ b/src/gateway/server/close-reason.test.ts
@@ -1,0 +1,36 @@
+import { Buffer } from "node:buffer";
+import { describe, expect, test } from "vitest";
+import { truncateCloseReason } from "./close-reason.js";
+
+describe("truncateCloseReason", () => {
+  const multibyte = "\u{1f600}";
+
+  test("returns the fallback for an empty reason", () => {
+    expect(truncateCloseReason("")).toBe("invalid handshake");
+  });
+
+  test("keeps close reasons that are already within the byte limit", () => {
+    expect(truncateCloseReason("invalid connect params")).toBe("invalid connect params");
+  });
+
+  test("keeps a complete multibyte character when it fits at the byte limit", () => {
+    const reason = `${"x".repeat(116)}${multibyte} trailing text`;
+    const truncated = truncateCloseReason(reason);
+
+    expect(truncated).toBe(`${"x".repeat(116)}${multibyte}`);
+    expect(Buffer.byteLength(truncated)).toBe(120);
+  });
+
+  test("backs up before a split multibyte character", () => {
+    const reason = `${"x".repeat(118)}${multibyte} trailing text`;
+    const truncated = truncateCloseReason(reason);
+
+    expect(truncated).toBe("x".repeat(118));
+    expect(Buffer.byteLength(truncated)).toBeLessThanOrEqual(120);
+    expect(truncated).not.toContain("\uFFFD");
+  });
+
+  test("returns an empty reason when the byte limit cannot fit one character", () => {
+    expect(truncateCloseReason(multibyte, 3)).toBe("");
+  });
+});

--- a/src/gateway/server/close-reason.ts
+++ b/src/gateway/server/close-reason.ts
@@ -15,5 +15,35 @@ export function truncateCloseReason(reason: string, maxBytes = CLOSE_REASON_MAX_
   if (buf.length <= maxBytes) {
     return reason;
   }
-  return buf.subarray(0, maxBytes).toString();
+  const end = utf8BoundaryAtOrBefore(buf, maxBytes);
+  return buf.subarray(0, end).toString();
+}
+
+function utf8BoundaryAtOrBefore(buf: Buffer, maxBytes: number): number {
+  const limit = Math.max(0, Math.min(Math.floor(maxBytes), buf.length));
+  let end = 0;
+
+  while (end < limit) {
+    const byte = buf[end];
+    const charBytes = utf8SequenceLength(byte);
+    if (end + charBytes > limit) {
+      break;
+    }
+    end += charBytes;
+  }
+
+  return end;
+}
+
+function utf8SequenceLength(byte: number): number {
+  if (byte < 0x80) {
+    return 1;
+  }
+  if (byte < 0xe0) {
+    return 2;
+  }
+  if (byte < 0xf0) {
+    return 3;
+  }
+  return 4;
 }


### PR DESCRIPTION
Closes #99976

## What Problem This Solves

Fixes a gateway close-reason truncation bug where a byte slice could split a multibyte UTF-8 character and decode into a replacement character. That replacement could garble the close reason and re-encode over the WebSocket close-frame byte budget.

## Why This Change Was Made

Gateway close-reason truncation now chooses a valid UTF-8 code point boundary at or before the byte limit before decoding the sliced buffer. The change keeps the existing fallback behavior for empty close reasons and preserves ASCII close reasons that already fit.

## User Impact

Non-ASCII gateway close reasons stay readable and remain within the RFC-safe byte limit.

## Evidence

- Before/after byte repro with `node --import tsx --input-type=module`, comparing the exact `origin/main` truncation expression with this branch's `truncateCloseReason`:
  - Split UTF-8 input: `136` bytes.
  - `origin/main` behavior: tail `xxxxxxx�`, `bytes: 121`, `containsReplacement: true`.
  - This branch, split-boundary case: tail `xxxxxxxx`, `bytes: 118`, `containsReplacement: false`.
  - This branch, exact-boundary case: tail `xxxxxx😀`, `bytes: 120`, `containsReplacement: false`.
  - Empty fallback remains `invalid handshake`.
- Runtime path checked:
  - `src/gateway/server/ws-connection/message-handler.ts:750`, `:886`, `:1003`, `:1546`, and `:1886` all pass gateway handshake/authorization close reasons through `truncateCloseReason`.
- `node scripts/run-vitest.mjs src/gateway/server/close-reason.test.ts`
  - Passed: `Test Files 4 passed (4)`, `Tests 20 passed (20)`.
- `node scripts/run-vitest.mjs src/gateway/server.auth.default-token.test.ts`
  - Passed full default auth-token gateway suite: `Test Files 2 passed (2)`, `Tests 38 passed (38)`.
- `node scripts/run-vitest.mjs src/gateway/client.test.ts -t "gateway rejects"`
  - Passed selected client rejection handling: `Test Files 2 passed (2)`, `Tests 4 passed | 118 skipped (122)`.
- `git diff --check origin/main...HEAD`
  - Passed with no whitespace errors.
- `.agents/skills/autoreview/scripts/autoreview --mode local`
  - Single draft-PR autoreview round run before commit; passed with `autoreview clean: no accepted/actionable findings reported` and `overall: patch is correct (0.93)`.
- Remote proof note:
  - GitHub `Real behavior proof` run `28715260183`, job `85155380858`, succeeded, but only verified PR problem/evidence text (`External PR includes problem context and evidence.`); it did not execute this PR's code, so it is not counted as behavioral proof.
  - Blacksmith Testbox-through-Crabbox changed gate was attempted but blocked locally because the `blacksmith` executable is not installed.
  - AWS Crabbox changed gate was attempted but blocked because this machine is not logged into the OpenClaw Crabbox broker.
