### PR TITLE
fix(android): synchronize realtime tool completions

### DIFF
--- a/apps/.i18n/native-source.json
+++ b/apps/.i18n/native-source.json
@@ -5587,7 +5587,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 346,
+      "line": 369,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/voice/TalkModeManager.kt",
       "source": "Listening",
       "surface": "android",
@@ -5595,7 +5595,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 346,
+      "line": 369,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/voice/TalkModeManager.kt",
       "source": "Ready",
       "surface": "android",
@@ -5603,7 +5603,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 706,
+      "line": 726,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/voice/TalkModeManager.kt",
       "source": "Off",
       "surface": "android",
@@ -5611,7 +5611,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 707,
+      "line": 727,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/voice/TalkModeManager.kt",
       "source": "Talk failed: Realtime provider closed unexpectedly.",
       "surface": "android",
@@ -5619,7 +5619,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 708,
+      "line": 728,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/voice/TalkModeManager.kt",
       "source": "Talk failed: Realtime provider closed: $reason",
       "surface": "android",
@@ -5627,7 +5627,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1617,
+      "line": 1675,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/voice/TalkModeManager.kt",
       "source": "Aborted",
       "surface": "android",
@@ -5635,7 +5635,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1617,
+      "line": 1675,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/voice/TalkModeManager.kt",
       "source": "Chat error",
       "surface": "android",

--- a/apps/android/app/src/main/java/ai/openclaw/app/voice/TalkModeManager.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/voice/TalkModeManager.kt
@@ -100,6 +100,22 @@ private data class RealtimeToolCompletionDispatch(
   val messageEl: JsonElement?,
 )
 
+private sealed interface RealtimeToolRegistration {
+  data object SessionEnded : RealtimeToolRegistration
+
+  data object AwaitingCompletion : RealtimeToolRegistration
+
+  data class Completed(val dispatch: RealtimeToolCompletionDispatch) : RealtimeToolRegistration
+}
+
+private sealed interface RealtimeToolCompletionDecision {
+  data object NotHandled : RealtimeToolCompletionDecision
+
+  data object Consumed : RealtimeToolCompletionDecision
+
+  data class Dispatch(val completion: RealtimeToolCompletionDispatch) : RealtimeToolCompletionDecision
+}
+
 class TalkModeManager internal constructor(
   private val context: Context,
   private val scope: CoroutineScope,
@@ -479,10 +495,7 @@ class TalkModeManager internal constructor(
     val activeSession = mainSessionKey.ifBlank { "main" }
     if (eventSession != null && eventSession != activeSession) return
 
-    if (maybeCompleteRealtimeToolCall(runId = runId, state = state, messageEl = obj["message"])) {
-      return
-    }
-    if (holdPendingRealtimeToolCompletion(runId = runId, state = state, messageEl = obj["message"])) {
+    if (handleRealtimeToolCompletion(runId = runId, state = state, messageEl = obj["message"])) {
       return
     }
 
@@ -1104,36 +1117,11 @@ class TalkModeManager internal constructor(
           session.request("talk.client.toolCall", params.toString(), timeoutMs = 15_000)
         val runId = parseRunId(response)
         if (!runId.isNullOrBlank()) {
-          if (realtimeSessionId != relaySessionId) return@launch
-          var dispatch: RealtimeToolCompletionDispatch? = null
-          var sessionStillActive = true
-          val hasCachedCompletion =
-            synchronized(realtimeToolLock) {
-              if (realtimeSessionId != relaySessionId) {
-                sessionStillActive = false
-                return@synchronized false
-              }
-              val toolRun = RealtimeToolRun(callId = callId, relaySessionId = relaySessionId)
-              realtimeToolRuns[runId] = toolRun
-              val completion = pendingRealtimeToolCompletions.remove(runId)
-              if (completion != null) {
-                realtimeToolRuns.remove(runId)
-                dispatch =
-                  RealtimeToolCompletionDispatch(
-                    toolRun = toolRun,
-                    state = completion.state,
-                    messageEl = completion.messageEl,
-                  )
-                true
-              } else {
-                false
-              }
-            }
-          if (!sessionStillActive) return@launch
-          if (hasCachedCompletion) {
-            dispatch?.let(::dispatchRealtimeToolCompletion)
-          } else {
-            _statusText.value = "Thinking…"
+          when (val registration = registerRealtimeToolRun(runId, callId, relaySessionId)) {
+            RealtimeToolRegistration.SessionEnded -> return@launch
+            RealtimeToolRegistration.AwaitingCompletion -> _statusText.value = "Thinking…"
+            is RealtimeToolRegistration.Completed ->
+              dispatchRealtimeToolCompletion(registration.dispatch)
           }
         } else {
           submitRealtimeToolError(callId, "tool call returned no run id", relaySessionId)
@@ -1150,83 +1138,66 @@ class TalkModeManager internal constructor(
     }
   }
 
-  private fun holdPendingRealtimeToolCompletion(
+  private fun registerRealtimeToolRun(
+    runId: String,
+    callId: String,
+    relaySessionId: String,
+  ): RealtimeToolRegistration =
+    synchronized(realtimeToolLock) {
+      if (realtimeSessionId != relaySessionId) {
+        return@synchronized RealtimeToolRegistration.SessionEnded
+      }
+      val toolRun = RealtimeToolRun(callId = callId, relaySessionId = relaySessionId)
+      val completion = pendingRealtimeToolCompletions.remove(runId)
+      if (completion == null) {
+        realtimeToolRuns[runId] = toolRun
+        RealtimeToolRegistration.AwaitingCompletion
+      } else {
+        RealtimeToolRegistration.Completed(
+          RealtimeToolCompletionDispatch(
+            toolRun = toolRun,
+            state = completion.state,
+            messageEl = completion.messageEl,
+          ),
+        )
+      }
+    }
+
+  private fun handleRealtimeToolCompletion(
     runId: String,
     state: String,
     messageEl: JsonElement?,
   ): Boolean {
     if (state != "final" && state != "aborted" && state != "error") return false
-    var dispatch: RealtimeToolCompletionDispatch? = null
-    val handled =
+    val decision =
       synchronized(realtimeToolLock) {
-        val toolRun = realtimeToolRuns[runId]
+        val toolRun = realtimeToolRuns.remove(runId)
         if (toolRun != null) {
-          realtimeToolRuns.remove(runId)
-          if (toolRun.relaySessionId == realtimeSessionId) {
-            dispatch =
-              RealtimeToolCompletionDispatch(
-                toolRun = toolRun,
-                state = state,
-                messageEl = messageEl,
-              )
+          if (toolRun.relaySessionId != realtimeSessionId) {
+            return@synchronized RealtimeToolCompletionDecision.Consumed
           }
-          return@synchronized true
+          return@synchronized RealtimeToolCompletionDecision.Dispatch(
+            RealtimeToolCompletionDispatch(toolRun = toolRun, state = state, messageEl = messageEl),
+          )
         }
-        if (realtimeSessionId == null || pendingRealtimeToolCalls.isEmpty()) return@synchronized false
+        if (realtimeSessionId == null || pendingRealtimeToolCalls.isEmpty()) {
+          return@synchronized RealtimeToolCompletionDecision.NotHandled
+        }
         pendingRealtimeToolCompletions[runId] =
           RealtimeToolCompletion(state = state, messageEl = messageEl)
         while (pendingRealtimeToolCompletions.size > maxCachedRunCompletions) {
-          pendingRealtimeToolCompletions.entries.firstOrNull()?.let {
-            pendingRealtimeToolCompletions.remove(it.key)
-          }
+          pendingRealtimeToolCompletions.remove(pendingRealtimeToolCompletions.keys.first())
         }
+        RealtimeToolCompletionDecision.Consumed
+      }
+    return when (decision) {
+      RealtimeToolCompletionDecision.NotHandled -> false
+      RealtimeToolCompletionDecision.Consumed -> true
+      is RealtimeToolCompletionDecision.Dispatch -> {
+        dispatchRealtimeToolCompletion(decision.completion)
         true
       }
-    dispatch?.let(::dispatchRealtimeToolCompletion)
-    return handled
-  }
-
-  private fun maybeCompleteRealtimeToolCall(
-    runId: String,
-    state: String,
-    messageEl: JsonElement?,
-  ): Boolean {
-    var dispatch: RealtimeToolCompletionDispatch? = null
-    val handled =
-      synchronized(realtimeToolLock) {
-        val toolRun = realtimeToolRuns[runId] ?: return@synchronized false
-        if (toolRun.relaySessionId != realtimeSessionId) {
-          realtimeToolRuns.remove(runId)
-          return@synchronized true
-        }
-        when (state) {
-          "final" -> {
-            realtimeToolRuns.remove(runId)
-            dispatch =
-              RealtimeToolCompletionDispatch(
-                toolRun = toolRun,
-                state = state,
-                messageEl = messageEl,
-              )
-            true
-          }
-          "aborted", "error" -> {
-            realtimeToolRuns.remove(runId)
-            dispatch =
-              RealtimeToolCompletionDispatch(
-                toolRun = toolRun,
-                state = state,
-                messageEl = messageEl,
-              )
-            true
-          }
-          else -> false
-        }
-      }
-    if (!handled) return false
-
-    dispatch?.let(::dispatchRealtimeToolCompletion)
-    return true
+    }
   }
 
   private fun dispatchRealtimeToolCompletion(dispatch: RealtimeToolCompletionDispatch) {

--- a/apps/android/app/src/main/java/ai/openclaw/app/voice/TalkModeManager.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/voice/TalkModeManager.kt
@@ -94,6 +94,12 @@ private data class RealtimeToolCompletion(
   val messageEl: JsonElement?,
 )
 
+private data class RealtimeToolCompletionDispatch(
+  val toolRun: RealtimeToolRun,
+  val state: String,
+  val messageEl: JsonElement?,
+)
+
 class TalkModeManager internal constructor(
   private val context: Context,
   private val scope: CoroutineScope,
@@ -170,6 +176,7 @@ class TalkModeManager internal constructor(
   private var realtimeAppendJob: Job? = null
 
   // Realtime tool calls can complete before their chat final arrives; cache by call/run id until both sides meet.
+  private val realtimeToolLock = Any()
   private val realtimeToolRuns = LinkedHashMap<String, RealtimeToolRun>()
   private val pendingRealtimeToolCalls = LinkedHashSet<String>()
   private val pendingRealtimeToolCompletions = LinkedHashMap<String, RealtimeToolCompletion>()
@@ -1034,9 +1041,11 @@ class TalkModeManager internal constructor(
     }
     realtimeCaptureJob = null
     realtimeAppendJob = null
-    realtimeToolRuns.clear()
-    pendingRealtimeToolCalls.clear()
-    pendingRealtimeToolCompletions.clear()
+    synchronized(realtimeToolLock) {
+      realtimeToolRuns.clear()
+      pendingRealtimeToolCalls.clear()
+      pendingRealtimeToolCompletions.clear()
+    }
     realtimeUserEntryId = null
     realtimeUserEntryAwaitingFinal = false
     realtimeUserEntryAwaitingFinalStartedAtMs = null
@@ -1071,7 +1080,9 @@ class TalkModeManager internal constructor(
     forced: Boolean = false,
   ) {
     val relaySessionId = realtimeSessionId ?: return
-    pendingRealtimeToolCalls.add(callId)
+    synchronized(realtimeToolLock) {
+      pendingRealtimeToolCalls.add(callId)
+    }
     scope.launch {
       try {
         if (name == REALTIME_AGENT_CONTROL_TOOL) {
@@ -1094,15 +1105,33 @@ class TalkModeManager internal constructor(
         val runId = parseRunId(response)
         if (!runId.isNullOrBlank()) {
           if (realtimeSessionId != relaySessionId) return@launch
-          realtimeToolRuns[runId] =
-            RealtimeToolRun(callId = callId, relaySessionId = relaySessionId)
-          val completion = pendingRealtimeToolCompletions.remove(runId)
-          if (completion != null) {
-            maybeCompleteRealtimeToolCall(
-              runId = runId,
-              state = completion.state,
-              messageEl = completion.messageEl,
-            )
+          var dispatch: RealtimeToolCompletionDispatch? = null
+          var sessionStillActive = true
+          val hasCachedCompletion =
+            synchronized(realtimeToolLock) {
+              if (realtimeSessionId != relaySessionId) {
+                sessionStillActive = false
+                return@synchronized false
+              }
+              val toolRun = RealtimeToolRun(callId = callId, relaySessionId = relaySessionId)
+              realtimeToolRuns[runId] = toolRun
+              val completion = pendingRealtimeToolCompletions.remove(runId)
+              if (completion != null) {
+                realtimeToolRuns.remove(runId)
+                dispatch =
+                  RealtimeToolCompletionDispatch(
+                    toolRun = toolRun,
+                    state = completion.state,
+                    messageEl = completion.messageEl,
+                  )
+                true
+              } else {
+                false
+              }
+            }
+          if (!sessionStillActive) return@launch
+          if (hasCachedCompletion) {
+            dispatch?.let(::dispatchRealtimeToolCompletion)
           } else {
             _statusText.value = "Thinking…"
           }
@@ -1114,7 +1143,9 @@ class TalkModeManager internal constructor(
         Log.w(tag, "realtime toolCall failed: ${err.message ?: err::class.simpleName}")
         submitRealtimeToolError(callId, err.message ?: "tool call failed", relaySessionId)
       } finally {
-        pendingRealtimeToolCalls.remove(callId)
+        synchronized(realtimeToolLock) {
+          pendingRealtimeToolCalls.remove(callId)
+        }
       }
     }
   }
@@ -1124,11 +1155,35 @@ class TalkModeManager internal constructor(
     state: String,
     messageEl: JsonElement?,
   ): Boolean {
-    if (realtimeSessionId == null || pendingRealtimeToolCalls.isEmpty()) return false
     if (state != "final" && state != "aborted" && state != "error") return false
-    pendingRealtimeToolCompletions[runId] =
-      RealtimeToolCompletion(state = state, messageEl = messageEl)
-    return true
+    var dispatch: RealtimeToolCompletionDispatch? = null
+    val handled =
+      synchronized(realtimeToolLock) {
+        val toolRun = realtimeToolRuns[runId]
+        if (toolRun != null) {
+          realtimeToolRuns.remove(runId)
+          if (toolRun.relaySessionId == realtimeSessionId) {
+            dispatch =
+              RealtimeToolCompletionDispatch(
+                toolRun = toolRun,
+                state = state,
+                messageEl = messageEl,
+              )
+          }
+          return@synchronized true
+        }
+        if (realtimeSessionId == null || pendingRealtimeToolCalls.isEmpty()) return@synchronized false
+        pendingRealtimeToolCompletions[runId] =
+          RealtimeToolCompletion(state = state, messageEl = messageEl)
+        while (pendingRealtimeToolCompletions.size > maxCachedRunCompletions) {
+          pendingRealtimeToolCompletions.entries.firstOrNull()?.let {
+            pendingRealtimeToolCompletions.remove(it.key)
+          }
+        }
+        true
+      }
+    dispatch?.let(::dispatchRealtimeToolCompletion)
+    return handled
   }
 
   private fun maybeCompleteRealtimeToolCall(
@@ -1136,15 +1191,49 @@ class TalkModeManager internal constructor(
     state: String,
     messageEl: JsonElement?,
   ): Boolean {
-    val toolRun = realtimeToolRuns[runId] ?: return false
-    if (toolRun.relaySessionId != realtimeSessionId) {
-      realtimeToolRuns.remove(runId)
-      return true
-    }
-    when (state) {
+    var dispatch: RealtimeToolCompletionDispatch? = null
+    val handled =
+      synchronized(realtimeToolLock) {
+        val toolRun = realtimeToolRuns[runId] ?: return@synchronized false
+        if (toolRun.relaySessionId != realtimeSessionId) {
+          realtimeToolRuns.remove(runId)
+          return@synchronized true
+        }
+        when (state) {
+          "final" -> {
+            realtimeToolRuns.remove(runId)
+            dispatch =
+              RealtimeToolCompletionDispatch(
+                toolRun = toolRun,
+                state = state,
+                messageEl = messageEl,
+              )
+            true
+          }
+          "aborted", "error" -> {
+            realtimeToolRuns.remove(runId)
+            dispatch =
+              RealtimeToolCompletionDispatch(
+                toolRun = toolRun,
+                state = state,
+                messageEl = messageEl,
+              )
+            true
+          }
+          else -> false
+        }
+      }
+    if (!handled) return false
+
+    dispatch?.let(::dispatchRealtimeToolCompletion)
+    return true
+  }
+
+  private fun dispatchRealtimeToolCompletion(dispatch: RealtimeToolCompletionDispatch) {
+    when (dispatch.state) {
       "final" -> {
-        realtimeToolRuns.remove(runId)
-        val text = extractTextFromChatEventMessage(messageEl).orEmpty()
+        val text = extractTextFromChatEventMessage(dispatch.messageEl).orEmpty()
+        val toolRun = dispatch.toolRun
         scope.launch {
           submitRealtimeToolResult(
             callId = toolRun.callId,
@@ -1152,17 +1241,15 @@ class TalkModeManager internal constructor(
             sessionId = toolRun.relaySessionId,
           )
         }
-        return true
       }
       "aborted", "error" -> {
-        realtimeToolRuns.remove(runId)
+        val toolRun = dispatch.toolRun
+        val state = dispatch.state
         scope.launch {
           submitRealtimeToolError(toolRun.callId, state, toolRun.relaySessionId)
         }
-        return true
       }
     }
-    return false
   }
 
   private suspend fun submitRealtimeToolError(

--- a/apps/android/app/src/test/java/ai/openclaw/app/voice/TalkModeManagerTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/voice/TalkModeManagerTest.kt
@@ -151,6 +151,20 @@ class TalkModeManagerTest {
   }
 
   @Test
+  fun realtimeToolFinalBeforeRunMetadataIsHeldForToolCompletion() {
+    val manager = createManager()
+
+    manager.ttsOnAllResponses = true
+    setPrivateField(manager, "realtimeSessionId", "relay-1")
+    pendingRealtimeToolCalls(manager).add("call-1")
+
+    manager.handleGatewayEvent("chat", chatFinalPayload(runId = "run-tool", text = "tool result"))
+
+    assertEquals(0L, playbackGeneration(manager).get())
+    assertTrue(pendingRealtimeToolCompletions(manager).containsKey("run-tool"))
+  }
+
+  @Test
   fun realtimeCloseErrorDisablesTalkButKeepsFailureStatus() {
     var stoppedByRelay = false
     val manager = createManager(onStoppedByRelay = { stoppedByRelay = true })
@@ -560,6 +574,12 @@ class TalkModeManagerTest {
 
   @Suppress("UNCHECKED_CAST")
   private fun realtimeToolRuns(manager: TalkModeManager) = readPrivateField(manager, "realtimeToolRuns") as MutableMap<String, RealtimeToolRun>
+
+  @Suppress("UNCHECKED_CAST")
+  private fun pendingRealtimeToolCalls(manager: TalkModeManager) = readPrivateField(manager, "pendingRealtimeToolCalls") as MutableSet<String>
+
+  @Suppress("UNCHECKED_CAST")
+  private fun pendingRealtimeToolCompletions(manager: TalkModeManager) = readPrivateField(manager, "pendingRealtimeToolCompletions") as MutableMap<String, Any>
 
   private fun setPrivateField(
     target: Any,


### PR DESCRIPTION
Related: #99968

## What Problem This Solves

Fixes an issue where Android Talk Mode realtime agent-consult replies could stay stuck in `Thinking...` when the Gateway chat final event arrived before Android finished registering the realtime tool-call run metadata.

## Why This Change Was Made

Android receives realtime talk events and Gateway chat events concurrently. This change protects the realtime tool run maps and pending completion cache with a dedicated lock, records final/error completions that arrive while a tool call is still pending, and dispatches the eventual `talk.session.submitToolResult` after leaving the lock so network I/O does not run inside the synchronized section.

Cached pending completions are bounded with the existing Talk Mode cache cap, and a regression test covers the final-before-run-metadata ordering.

## User Impact

Android realtime Talk Mode can complete agent consult tool calls reliably instead of losing the result when the tool-call RPC response and chat final event race.

## Evidence

- Current head: `b88ffe9fc8`.
- `git diff --check` - passed.
- `PYTHONUTF8=1 PYTHONIOENCODING=utf-8 python .agents\skills\autoreview\scripts\autoreview --mode commit --commit HEAD` - passed, `autoreview clean: no accepted/actionable findings reported`.
- `pnpm native:i18n:sync` refreshed `apps/.i18n/native-source.json` after the Android source line shifts.
- `pnpm native:i18n:check` - passed, `native-app-i18n: entries=2489 changed=false`.
- OPPO Reno15 / OPPO PLW110 / Android 16 ADB proof using the installed debug app and a local Gateway race harness:
  - Android connected as `OpenClawAndroid/2026.6.11-dev (Android 16; SDK 36)`.
  - `talk.session.create` started realtime session `relay-android-race-proof`.
  - Gateway sent realtime `talk.event` `type:"toolCall"` for `openclaw_agent_consult`.
  - Android sent `talk.client.toolCall` with `callId:"call-android-race-proof"`.
  - The harness delivered the chat final before returning the run id.
  - Android still submitted `talk.session.submitToolResult`:
    `{"sessionId":"relay-android-race-proof","callId":"call-android-race-proof","result":{"text":"Android realtime tool race proof ok"}}`
- Android debug result:
  `{"ok":true,"normal":null,"realtime":{"mode":"realtime","status":"Thinking...","userText":"Android realtime tool race proof user","assistantText":"Android realtime tool race proof ok"}}`
- Logcat included:
  - `TalkMode: realtime session started relaySessionId=relay-android-race-proof`
  - `VoiceE2E: PASS {"ok":true,"normal":null,"realtime":{"mode":"realtime","status":"Thinking...","userText":"Android realtime tool race proof user","assistantText":"Android realtime tool race proof ok"}}`
- Attempted `cmd /c gradlew.bat :app:testPlayDebugUnitTest --tests ai.openclaw.app.voice.TalkModeManagerTest`; it timed out after roughly 184s on this Windows host without reporting a test failure.
- Also attempted a live OpenAI Realtime gateway run with a user-provided `OPENAI_API_KEY`; Android timed out before `talk.session.create`, so that attempt is not used as proof for this PR.
