### PR TITLE
fix(session-maintenance): preserve zero-valued fields in warning dedupe key

### DIFF
--- a/src/infra/session-maintenance-warning.test.ts
+++ b/src/infra/session-maintenance-warning.test.ts
@@ -33,6 +33,7 @@ vi.mock("./outbound/deliver.js", () => ({
 type SessionMaintenanceWarningModule = typeof import("./session-maintenance-warning.js");
 
 let deliverSessionMaintenanceWarning: SessionMaintenanceWarningModule["deliverSessionMaintenanceWarning"];
+let buildWarningContextForTests: SessionMaintenanceWarningModule["testing"]["buildWarningContextForTests"];
 let resetSessionMaintenanceWarningForTests: SessionMaintenanceWarningModule["testing"]["resetSessionMaintenanceWarningForTests"];
 
 function createParams(
@@ -94,7 +95,7 @@ describe("deliverSessionMaintenanceWarning", () => {
     }));
     ({
       deliverSessionMaintenanceWarning,
-      testing: { resetSessionMaintenanceWarningForTests },
+      testing: { buildWarningContextForTests, resetSessionMaintenanceWarningForTests },
     } = await import("./session-maintenance-warning.js"));
   });
 
@@ -147,6 +148,22 @@ describe("deliverSessionMaintenanceWarning", () => {
     await deliverSessionMaintenanceWarning(params);
 
     expect(mocks.deliverOutboundPayloads).toHaveBeenCalledTimes(1);
+  });
+
+  it("preserves zero-valued warning fields in the dedupe context", () => {
+    const sessionKey = `agent:${randomUUID()}:main`;
+    const params = createParams({
+      sessionKey,
+      warning: {
+        activeSessionKey: sessionKey,
+        pruneAfterMs: 0,
+        maxEntries: 10,
+        wouldPrune: true,
+        wouldCap: false,
+      } as never,
+    });
+
+    expect(buildWarningContextForTests(params)).toBe(`${sessionKey}|0|10|prune|`);
   });
 
   it("falls back to a system event when the last target is not deliverable", async () => {

--- a/src/infra/session-maintenance-warning.ts
+++ b/src/infra/session-maintenance-warning.ts
@@ -31,6 +31,7 @@ function resetSessionMaintenanceWarningForTests() {
 }
 
 export const testing = {
+  buildWarningContextForTests: buildWarningContext,
   resetSessionMaintenanceWarningForTests,
 } as const;
 
@@ -44,13 +45,11 @@ function buildWarningContext(params: WarningParams): string {
   const { warning } = params;
   return [
     warning.activeSessionKey,
-    warning.pruneAfterMs,
-    warning.maxEntries,
+    String(warning.pruneAfterMs),
+    String(warning.maxEntries),
     warning.wouldPrune ? "prune" : "",
     warning.wouldCap ? "cap" : "",
-  ]
-    .filter(Boolean)
-    .join("|");
+  ].join("|");
 }
 
 function formatDuration(ms: number): string {


### PR DESCRIPTION
Closes #99983

## What Problem This Solves

Fixes an issue where a session-maintenance re-warning is silently suppressed after limits change between two configurations that each have a zero-valued field in a different slot position. `buildWarningContext` used `.filter(Boolean)` on the key array, which collapses numeric `0` alongside empty strings — so `pruneAfterMs=10, maxEntries=0` and `pruneAfterMs=0, maxEntries=10` both produce the same dedupe key, causing the second warning to be treated as a duplicate and never delivered.

## Why This Change Was Made

The key array has five positional slots: `[sessionKey, pruneAfterMs, maxEntries, wouldPrune, wouldCap]`. With `.filter(Boolean)`, any slot holding `0` or `""` is dropped and subsequent values shift left. This means two structurally different warnings can collapse to identical strings. The fix wraps the two numeric fields in `String()` and removes `.filter(Boolean)` — all five slots are always present, positions are stable, and `"0"` is a truthy non-empty string.

## User Impact

After this fix, a session in warn-only mode correctly receives a new warning whenever its effective maintenance limits change to include a zero-valued field — such as switching from `maxEntries=10` to `maxEntries=0` (or vice versa for `pruneAfterMs`). Previously, that re-warning was silently swallowed.

## Evidence

### Runtime delivery proof — bug reproduced on main, fix confirmed on this PR

The script below inlines both versions of the key encoder and simulates the full `warnedContexts` Map dedupe guard from `deliverSessionMaintenanceWarning`. No external dependencies. Source: `proof-99983.mjs` (runnable with `node proof-99983.mjs`).

**Collision scenario:** limits change from `{pruneAfterMs: 10, maxEntries: 0}` to `{pruneAfterMs: 0, maxEntries: 10}`. Both configs have one zero-valued field — in different positions. Under `.filter(Boolean)` both collapse to the same string; under `String()` they are distinct.

```
--------------------------------------------------------------------
  BEFORE FIX -- .filter(Boolean) on main
--------------------------------------------------------------------
  scan 1  pruneAfterMs=10 maxEntries=0   (initial warning)
    key    : "agent:abc-redacted:main|10|prune"
    result : OK WARNING DELIVERED
  scan 2  pruneAfterMs=0  maxEntries=10  (limits changed -> re-warn expected)
    key    : "agent:abc-redacted:main|10|prune"
    result : X  SUPPRESSED (duplicate key)   <-- BUG: zero dropped, slots collide
  scan 3  pruneAfterMs=0  maxEntries=10  (same limits -> suppress expected)
    key    : "agent:abc-redacted:main|10|prune"
    result : X  SUPPRESSED (duplicate key)

--------------------------------------------------------------------
  AFTER  FIX -- String() on PR #100050
--------------------------------------------------------------------
  scan 1  pruneAfterMs=10 maxEntries=0   (initial warning)
    key    : "agent:abc-redacted:main|10|0|prune|"
    result : OK WARNING DELIVERED
  scan 2  pruneAfterMs=0  maxEntries=10  (limits changed -> re-warn expected)
    key    : "agent:abc-redacted:main|0|10|prune|"
    result : OK WARNING DELIVERED            <-- FIXED: distinct keys, re-warn fires
  scan 3  pruneAfterMs=0  maxEntries=10  (same limits -> suppress expected)
    key    : "agent:abc-redacted:main|0|10|prune|"
    result : X  SUPPRESSED (duplicate key)   <-- correct dedup still works

====================================================================
  Collision proof
--------------------------------------------------------------------
  BUGGY key scan 1 : "agent:abc-redacted:main|10|prune"
  BUGGY key scan 2 : "agent:abc-redacted:main|10|prune"  <- SAME (zero dropped, slots collide)

  FIXED key scan 1 : "agent:abc-redacted:main|10|0|prune|"
  FIXED key scan 2 : "agent:abc-redacted:main|0|10|prune|"  <- DISTINCT

  Bug reproduced (scan 2 wrongly suppressed) : CONFIRMED
  Fix verified   (scan 2 delivers, scan 3 ok): CONFIRMED
====================================================================

exit:0
```

### Unit test run — all 6 pass including regression test

```
 RUN  v4.1.8 C:/tmp/openclaw-work

 ✔ |infra| src/infra/session-maintenance-warning.test.ts > deliverSessionMaintenanceWarning > forwards session context to outbound delivery 236ms
 ✔ |infra| src/infra/session-maintenance-warning.test.ts > deliverSessionMaintenanceWarning > suppresses duplicate warning contexts for the same session 1ms
 ✔ |infra| src/infra/session-maintenance-warning.test.ts > deliverSessionMaintenanceWarning > preserves zero-valued warning fields in the dedupe context 0ms
 ✔ |infra| src/infra/session-maintenance-warning.test.ts > deliverSessionMaintenanceWarning > falls back to a system event when the last target is not deliverable 0ms
 ✔ |infra| src/infra/session-maintenance-warning.test.ts > deliverSessionMaintenanceWarning > skips warning delivery in test mode 0ms
 ✔ |infra| src/infra/session-maintenance-warning.test.ts > deliverSessionMaintenanceWarning > enqueues a system event when outbound delivery fails 77ms

 Test Files  1 passed (1)
      Tests  6 passed (6)
   Start at  00:07:02
   Duration  1.33s (transform 988ms, setup 721ms, import 21ms, tests 361ms, environment 0ms)

EXIT:0
```

The regression test `preserves zero-valued warning fields in the dedupe context` directly asserts that `pruneAfterMs: 0` encodes as `"${sessionKey}|0|10|prune|"` — not collapsed.

### Migration / stored-state note

`warnedContexts` is an in-process `Map` never written to disk or SQLite. It is cleared on process restart. No migration or upgrade compatibility action is required.
