### PR TITLE
fix: tests in nested git worktrees load bundled plugins from the enclosing checkout

### DIFF
--- a/scripts/pr-lib/gates.sh
+++ b/scripts/pr-lib/gates.sh
@@ -23,6 +23,14 @@ run_hosted_prepare_gates() {
   run_quiet_logged "exact-head hosted CI/Testbox gates" ".local/gates-hosted-checks.log" node "${args[@]}"
 }
 
+pin_worktree_bundled_plugins_dir() {
+  # Nested .worktrees/<pr> checkouts resolve vitest tooling from the primary
+  # checkout's node_modules; pin bundled plugin discovery to this worktree so
+  # PR branches without the openclaw-root node_modules-boundary fix still test
+  # their own extensions instead of the primary checkout's stale trees.
+  export OPENCLAW_BUNDLED_PLUGINS_DIR="${OPENCLAW_BUNDLED_PLUGINS_DIR:-$PWD/extensions}"
+}
+
 run_prepare_push_retry_gates() {
   local docs_only="${1:-false}"
 
@@ -32,6 +40,7 @@ run_prepare_push_retry_gates() {
     return 1
   fi
 
+  pin_worktree_bundled_plugins_dir
   bootstrap_deps_if_needed
   run_quiet_logged "pnpm build (lease-retry)" ".local/lease-retry-build.log" pnpm build
   run_quiet_logged "pnpm check (lease-retry)" ".local/lease-retry-check.log" pnpm check
@@ -140,6 +149,7 @@ prepare_gates() {
     gates_mode="reused_docs_only"
     echo "Docs/changelog-only delta since last verified head $previous_last_verified_head; reusing prior gates."
   else
+    pin_worktree_bundled_plugins_dir
     bootstrap_deps_if_needed
     run_quiet_logged "pnpm build" ".local/gates-build.log" pnpm build
     run_quiet_logged "pnpm check" ".local/gates-check.log" pnpm check

--- a/src/infra/openclaw-root.test.ts
+++ b/src/infra/openclaw-root.test.ts
@@ -220,6 +220,35 @@ describe("resolveOpenClawPackageRoot", () => {
       },
     },
     {
+      name: "does not cross a node_modules boundary into an enclosing checkout",
+      setup: () => {
+        // Nested git worktrees resolve tooling (vitest, tinypool) from the
+        // enclosing checkout's node_modules; its root must never win.
+        const outerCheckout = fx("nested-worktree-outer");
+        setPackageRoot(outerCheckout);
+        setPackageRoot(path.join(outerCheckout, "node_modules", "vitest"), "vitest");
+        const argv1 = path.join(
+          outerCheckout,
+          "node_modules",
+          "vitest",
+          "dist",
+          "workers",
+          "threads.js",
+        );
+        return { opts: { argv1 }, expected: null };
+      },
+    },
+    {
+      name: "still resolves the openclaw package below a node_modules boundary",
+      setup: () => {
+        const project = fx("installed-below-boundary");
+        setPackageRoot(project);
+        const pkgRoot = path.join(project, "node_modules", "openclaw");
+        setPackageRoot(pkgRoot);
+        return { opts: { argv1: path.join(pkgRoot, "dist", "entry.js") }, expected: pkgRoot };
+      },
+    },
+    {
       name: "returns null when no package roots exist",
       setup: () => ({
         opts: { cwd: fx("missing") },

--- a/src/infra/openclaw-root.ts
+++ b/src/infra/openclaw-root.ts
@@ -67,6 +67,14 @@ function* iterAncestorDirs(startDir: string, maxDepth: number): Generator<string
   let current = path.resolve(startDir);
   for (let i = 0; i < maxDepth; i += 1) {
     yield current;
+    // Never walk above a node_modules boundary: a package.json up there belongs
+    // to the workspace that installed the tooling (for example an enclosing
+    // checkout hosting a nested git worktree), not to the package owning the
+    // running code. Crossing it made nested worktrees resolve the ancestor
+    // checkout and load its stale bundled plugin manifests.
+    if (path.basename(current) === "node_modules") {
+      break;
+    }
     const parent = path.dirname(current);
     if (parent === current) {
       break;

--- a/src/plugins/bundled-dir.test.ts
+++ b/src/plugins/bundled-dir.test.ts
@@ -360,7 +360,10 @@ describe("resolveBundledPluginsDir", () => {
 
     delete process.env.OPENCLAW_DISABLE_BUNDLED_PLUGINS;
     fs.mkdirSync(path.join(repoRoot, "node_modules", ".pnpm"), { recursive: true });
-    expect(resolveSourceCheckoutDependencyDiagnostic()).toBeNull();
+    // The diagnostic also scans the real checkout hosting this test run (via
+    // module-root resolution), which may itself lack node_modules in nested
+    // worktrees; only assert the satisfied fixture is no longer reported.
+    expect(resolveSourceCheckoutDependencyDiagnostic()?.source).not.toBe(repoRoot);
   });
 
   it("returns a stable empty bundled plugin directory when bundled plugins are disabled", () => {
@@ -499,6 +502,50 @@ describe("resolveBundledPluginsDir", () => {
 
     expect(fs.realpathSync(bundledDir ?? "")).toBe(
       fs.realpathSync(path.join(installedRoot, "dist", "extensions")),
+    );
+  });
+
+  it("ignores an enclosing checkout reached through node_modules tooling argv1", () => {
+    // Nested git worktrees (.worktrees/<pr>, .claude/worktrees/*) have no local
+    // node_modules, so vitest workers run with argv1 inside the enclosing
+    // checkout's node_modules. That checkout's (possibly stale) bundled plugin
+    // trees must never win discovery over the checkout under test.
+    const outerRoot = createOpenClawRoot({
+      prefix: "openclaw-bundled-dir-enclosing-",
+      hasExtensions: true,
+      hasSrc: true,
+      hasDistExtensions: true,
+      hasGitCheckout: true,
+      hasPnpmWorkspace: true,
+    });
+    seedBundledPluginTree(outerRoot, "extensions");
+    seedBundledPluginTree(outerRoot, path.join("dist", "extensions"));
+    const workerArgv1 = path.join(
+      outerRoot,
+      "node_modules",
+      "vitest",
+      "dist",
+      "workers",
+      "threads.js",
+    );
+    fs.mkdirSync(path.dirname(workerArgv1), { recursive: true });
+    fs.writeFileSync(workerArgv1, "", "utf8");
+    const nestedWorktree = path.join(outerRoot, ".worktrees", "pr-1234");
+    fs.mkdirSync(nestedWorktree, { recursive: true });
+
+    vi.spyOn(process, "cwd").mockReturnValue(nestedWorktree);
+    process.argv[1] = workerArgv1;
+    process.execArgv.length = 0;
+    delete process.env.OPENCLAW_BUNDLED_PLUGINS_DIR;
+    delete process.env.OPENCLAW_DISABLE_BUNDLED_PLUGINS;
+
+    const bundledDir = requireBundledDir(resolveBundledPluginsDir());
+
+    expect(fs.realpathSync(bundledDir)).not.toBe(
+      fs.realpathSync(path.join(outerRoot, "dist", "extensions")),
+    );
+    expect(fs.realpathSync(bundledDir)).not.toBe(
+      fs.realpathSync(path.join(outerRoot, "extensions")),
     );
   });
 


### PR DESCRIPTION
Closes #100052

## What Problem This Solves

Fixes an issue where developers running tests inside git worktrees nested under another checkout of this repo (`.worktrees/pr-NNNN`, `.claude/worktrees/*`) would test against the **enclosing** checkout's bundled plugin manifests instead of the worktree's own. With any manifest skew between the two checkouts (~12 shards affected: agents-core, extension-providers, infra, gateway-server, cli, plugin-sdk, tooling, unit-security, media-understanding, runtime-config, extension-imessage, extension-messaging), this produced false failures — e.g. 3 `supportsUsageInStreaming` failures in `src/agents/model-compat.test.ts` — and broke the `scripts/pr prepare-run` local `pnpm test` gate whenever the primary checkout sat on a release branch.

Root cause: nested worktrees have no local `node_modules`, so vitest workers run with `argv1` inside the enclosing checkout's `node_modules` (e.g. `<ancestor>/node_modules/vitest/dist/workers/threads.js`). `resolveOpenClawPackageRoot*` walked up from there, crossed **out of** `node_modules`, and matched the enclosing checkout's `package.json` as the openclaw package root; bundled plugin discovery tries that argv-derived root before the (correct) module root, so the ancestor's stale `extensions` / `dist/extensions` trees won.

## Why This Change Was Made

The package-root ancestor walk in `src/infra/openclaw-root.ts` now stops at any `node_modules` boundary: a `package.json` above `node_modules` belongs to the workspace that installed the tooling, never to the package owning the running code. This heals every `argv1`/`moduleUrl`/`cwd`-based caller (bundled plugins, plugin-sdk alias, channel catalogs, skills) at the single owning seam instead of reordering candidates per caller. Installed layouts (`node_modules/openclaw`, `.bin` shims, realpathed global installs) match at or below the boundary and are unaffected.

`scripts/pr-lib/gates.sh` additionally pins `OPENCLAW_BUNDLED_PLUGINS_DIR` to the gate worktree's own `extensions` as belt-and-suspenders, because the gates execute PR-branch code and open PRs cut before this fix would otherwise still discover the primary checkout's trees.

Non-goal (follow-up): `resolveLinkedSourceBundledPluginsEnv` in `scripts/run-vitest.mjs` papered over the symlinked-node_modules variant of this bug and is likely removable once this lands.

## User Impact

No runtime behavior change for installed or packaged layouts. Contributors and maintainers can run tests from nested worktrees (and `scripts/pr prepare-run` gates) and get results that match a plain clone, regardless of which branch the primary checkout has checked out.

## Evidence

Discovery probe inside a live nested worktree (`.claude/worktrees/*` with the primary checkout parked on `release/2026.6.5`), same environment before/after:

Before (broken — ancestor's stale June-4 dist build wins):

```json
{
  "argv1": ".../clawdbot/node_modules/vitest/dist/workers/threads.js",
  "argvRoot": "/Users/steipete/Projects/clawdbot",
  "moduleRoot": ".../clawdbot/.claude/worktrees/trusting-bartik-4742ac",
  "bundledDir": "/Users/steipete/Projects/clawdbot/dist/extensions"
}
```

After (anchored to the checkout under test):

```json
{
  "argv1": ".../clawdbot/node_modules/vitest/dist/workers/threads.js",
  "argvRoot": null,
  "moduleRoot": ".../clawdbot/.claude/worktrees/trusting-bartik-4742ac",
  "bundledDir": ".../clawdbot/.claude/worktrees/trusting-bartik-4742ac/extensions"
}
```

- New regression tests fail with the boundary check reverted (verified counterfactually) and pass with it: nested-checkout fixture in `src/plugins/bundled-dir.test.ts`, boundary semantics (poisoned tooling argv1 → null; installed `node_modules/openclaw` still resolves) in `src/infra/openclaw-root.test.ts`.
- `node scripts/run-vitest.mjs run --config test/vitest/vitest.agents-core.config.ts src/agents/model-compat.test.ts` → 57 passed inside the nested worktree.
- Resolver-consuming collateral: 408 tests green across infra, plugins, plugin-sdk, contracts-plugin, runtime-config shards (`control-ui-assets`, `update-startup`, `update-runner`, `install`, `install.npm-spec`, `plugin-sdk-root-alias`, `qa-runtime`, `qa-runner-runtime`, `npm-managed-root`, `plugin-peer-link`, `doc-baseline`, `sdk-alias`).
- `oxfmt --check` and `oxlint` clean on changed TS files; `shellcheck -s bash` clean on `gates.sh`; Codex autoreview clean ("no actionable defects").
- Known gap: `tsgo` typecheck not runnable in the dependency-less worktree used for development; covered by hosted CI on this PR.
