### PR TITLE
fix(gateway): read usage-cost cache once per agent in sessions.usage

### DIFF
--- a/src/gateway/server-methods/usage.sessions-usage.test.ts
+++ b/src/gateway/server-methods/usage.sessions-usage.test.ts
@@ -65,8 +65,8 @@ vi.mock("../../infra/session-cost-usage.js", async () => {
       }
       return [];
     }),
-    loadSessionCostSummaryFromCache: vi.fn(async () => ({
-      summary: {
+    loadSessionCostSummariesFromCache: vi.fn(async (params: { sessions: unknown[] }) => ({
+      summaries: params.sessions.map(() => ({
         input: 0,
         output: 0,
         cacheRead: 0,
@@ -78,16 +78,7 @@ vi.mock("../../infra/session-cost-usage.js", async () => {
         cacheReadCost: 0,
         cacheWriteCost: 0,
         missingCostEntries: 0,
-      },
-      cacheStatus: {
-        status: "fresh",
-        cachedFiles: 1,
-        pendingFiles: 0,
-        staleFiles: 0,
-      },
-    })),
-    loadSessionCostSummariesFromCache: vi.fn(async (params: { sessions: unknown[] }) => ({
-      summaries: params.sessions.map(() => null),
+      })),
       cacheStatus: {
         status: "fresh",
         cachedFiles: params.sessions.length,
@@ -105,7 +96,6 @@ vi.mock("../../infra/session-cost-usage.js", async () => {
 
 import {
   discoverAllSessions,
-  loadSessionCostSummaryFromCache,
   loadSessionCostSummariesFromCache,
   loadSessionLogs,
   loadSessionUsageTimeSeries,
@@ -284,7 +274,7 @@ describe("sessions.usage", () => {
     expect(sessions[0].agentId).toBe("opus");
   });
 
-  it("loads selected session summaries concurrently and reports cache refresh status", async () => {
+  it("loads selected session summaries in one batched cache read and reports refresh status", async () => {
     vi.mocked(discoverAllSessions).mockResolvedValueOnce([
       {
         sessionId: "s-a",
@@ -302,29 +292,10 @@ describe("sessions.usage", () => {
         mtime: 100,
       },
     ]);
-    const pending: Array<{
-      sessionId?: string;
-      resolve: (value: Awaited<ReturnType<typeof loadSessionCostSummaryFromCache>>) => void;
-    }> = [];
-    for (let i = 0; i < 3; i += 1) {
-      vi.mocked(loadSessionCostSummaryFromCache).mockImplementationOnce(
-        async ({ sessionId }) =>
-          await new Promise<Awaited<ReturnType<typeof loadSessionCostSummaryFromCache>>>(
-            (resolve) => {
-              pending.push({ sessionId, resolve });
-            },
-          ),
-      );
-    }
-
-    const respondPromise = runSessionsUsage({ ...BASE_USAGE_RANGE, limit: 3 });
-    await vi.waitFor(() =>
-      expect(vi.mocked(loadSessionCostSummaryFromCache)).toHaveBeenCalledTimes(3),
-    );
-    for (const item of pending) {
-      const tokens = item.sessionId === "s-a" ? 10 : item.sessionId === "s-b" ? 20 : 30;
-      item.resolve({
-        summary: {
+    vi.mocked(loadSessionCostSummariesFromCache).mockImplementation(async ({ sessions }) => ({
+      summaries: sessions.map((session) => {
+        const tokens = session.sessionId === "s-a" ? 10 : session.sessionId === "s-b" ? 20 : 30;
+        return {
           input: tokens,
           output: 0,
           cacheRead: 0,
@@ -336,17 +307,20 @@ describe("sessions.usage", () => {
           cacheReadCost: 0,
           cacheWriteCost: 0,
           missingCostEntries: 0,
-        },
-        cacheStatus: {
-          status: item.sessionId === "s-b" ? "refreshing" : "fresh",
-          cachedFiles: item.sessionId === "s-b" ? 0 : 1,
-          pendingFiles: item.sessionId === "s-b" ? 1 : 0,
-          staleFiles: item.sessionId === "s-b" ? 1 : 0,
-        },
-      });
-    }
+        };
+      }),
+      cacheStatus: {
+        status: "refreshing",
+        cachedFiles: 2,
+        pendingFiles: 1,
+        staleFiles: 1,
+      },
+    }));
 
-    const respond = await respondPromise;
+    const respond = await runSessionsUsage({ ...BASE_USAGE_RANGE, limit: 3 });
+
+    // All three sessions belong to one agent, so the whole cache is read exactly once.
+    expect(vi.mocked(loadSessionCostSummariesFromCache)).toHaveBeenCalledTimes(1);
     expect(respond).toHaveBeenCalledTimes(1);
     const result = mockArg(respond, 0, 1) as {
       cacheStatus?: { status: string };
@@ -395,10 +369,10 @@ describe("sessions.usage", () => {
     expect(sessions).toHaveLength(1);
     expect(sessions[0]?.key).toBe("agent:opus:s-opus");
     expect(sessions[0]?.agentId).toBe("opus");
-    expect(vi.mocked(loadSessionCostSummaryFromCache)).toHaveBeenCalledWith(
+    expect(vi.mocked(loadSessionCostSummariesFromCache)).toHaveBeenCalledWith(
       expect.objectContaining({
         agentId: "opus",
-        sessionId: "s-opus",
+        sessions: expect.arrayContaining([expect.objectContaining({ sessionId: "s-opus" })]),
       }),
     );
   });
@@ -428,11 +402,15 @@ describe("sessions.usage", () => {
       const sessions = expectSuccessfulSessionsUsage(respond);
       expect(sessions).toHaveLength(1);
       expect(sessions[0]?.key).toBe("agent:opus:main");
-      expect(vi.mocked(loadSessionCostSummaryFromCache)).toHaveBeenCalledWith(
+      expect(vi.mocked(loadSessionCostSummariesFromCache)).toHaveBeenCalledWith(
         expect.objectContaining({
           agentId: "opus",
-          sessionFile: fs.realpathSync(sessionFile),
-          sessionId: "main",
+          sessions: expect.arrayContaining([
+            expect.objectContaining({
+              sessionFile: fs.realpathSync(sessionFile),
+              sessionId: "main",
+            }),
+          ]),
         }),
       );
     });
@@ -475,12 +453,15 @@ describe("sessions.usage", () => {
       expect(sessions).toHaveLength(1);
       expect(sessions[0]?.key).toBe("global");
       expect(sessions[0]?.agentId).toBe("opus");
-      expect(vi.mocked(loadSessionCostSummaryFromCache)).toHaveBeenCalledWith(
+      expect(vi.mocked(loadSessionCostSummariesFromCache)).toHaveBeenCalledWith(
         expect.objectContaining({
           agentId: "opus",
-          sessionEntry,
-          sessionFile: fs.realpathSync(sessionFile),
-          sessionId: "current",
+          sessions: expect.arrayContaining([
+            expect.objectContaining({
+              sessionFile: fs.realpathSync(sessionFile),
+              sessionId: "current",
+            }),
+          ]),
         }),
       );
     });
@@ -512,12 +493,15 @@ describe("sessions.usage", () => {
       expect(sessions).toHaveLength(1);
       expect(sessions[0]?.key).toBe("agent:opus:shared");
       expect(sessions[0]?.agentId).toBe("opus");
-      expect(vi.mocked(loadSessionCostSummaryFromCache)).toHaveBeenCalledWith(
+      expect(vi.mocked(loadSessionCostSummariesFromCache)).toHaveBeenCalledWith(
         expect.objectContaining({
           agentId: "opus",
-          sessionEntry: undefined,
-          sessionFile: fs.realpathSync(sessionFile),
-          sessionId: "shared",
+          sessions: expect.arrayContaining([
+            expect.objectContaining({
+              sessionFile: fs.realpathSync(sessionFile),
+              sessionId: "shared",
+            }),
+          ]),
         }),
       );
     });
@@ -548,16 +532,11 @@ describe("sessions.usage", () => {
       const sessions = expectSuccessfulSessionsUsage(respond);
       expect(sessions).toHaveLength(1);
       expect(sessions[0]?.key).toBe(storeKey);
-      expect(vi.mocked(loadSessionCostSummaryFromCache)).toHaveBeenCalled();
+      expect(vi.mocked(loadSessionCostSummariesFromCache)).toHaveBeenCalled();
       expect(
         vi
-          .mocked(loadSessionCostSummaryFromCache)
+          .mocked(loadSessionCostSummariesFromCache)
           .mock.calls.some((call) => call[0]?.agentId === "opus"),
-      ).toBe(true);
-      expect(
-        vi
-          .mocked(loadSessionCostSummaryFromCache)
-          .mock.calls.every((call) => call[0]?.refreshMode === "background"),
       ).toBe(true);
     });
   });
@@ -581,15 +560,15 @@ describe("sessions.usage", () => {
           },
         },
       });
-      vi.mocked(loadSessionCostSummaryFromCache).mockImplementation(async ({ sessionId }) => ({
-        summary: {
-          input: sessionId === "old" ? 10 : 20,
+      vi.mocked(loadSessionCostSummariesFromCache).mockImplementation(async ({ sessions }) => ({
+        summaries: sessions.map((session) => ({
+          input: session.sessionId === "old" ? 10 : 20,
           output: 0,
           cacheRead: 0,
           cacheWrite: 0,
-          totalTokens: sessionId === "old" ? 10 : 20,
-          totalCost: sessionId === "old" ? 0.01 : 0.02,
-          inputCost: sessionId === "old" ? 0.01 : 0.02,
+          totalTokens: session.sessionId === "old" ? 10 : 20,
+          totalCost: session.sessionId === "old" ? 0.01 : 0.02,
+          inputCost: session.sessionId === "old" ? 0.01 : 0.02,
           outputCost: 0,
           cacheReadCost: 0,
           cacheWriteCost: 0,
@@ -602,10 +581,10 @@ describe("sessions.usage", () => {
             toolResults: 0,
             errors: 0,
           },
-        },
+        })),
         cacheStatus: {
           status: "fresh",
-          cachedFiles: 1,
+          cachedFiles: sessions.length,
           pendingFiles: 0,
           staleFiles: 0,
         },
@@ -764,10 +743,6 @@ describe("sessions.usage", () => {
         missingCostEntries: 0,
       };
     };
-    vi.mocked(loadSessionCostSummaryFromCache).mockImplementation(async ({ sessionId }) => ({
-      summary: buildUsage(sessionId),
-      cacheStatus: { status: "fresh", cachedFiles: 1, pendingFiles: 0, staleFiles: 0 },
-    }));
     vi.mocked(loadSessionCostSummariesFromCache).mockImplementation(async ({ sessions }) => {
       return {
         summaries: sessions.map((session) => buildUsage(session.sessionId)),
@@ -796,7 +771,8 @@ describe("sessions.usage", () => {
     // Only the most-recent session (s-a, mtime=300) appears in the page
     expect(result.sessions).toHaveLength(1);
     expect(result.sessions[0].key).toContain("s-a");
-    expect(vi.mocked(loadSessionCostSummaryFromCache)).toHaveBeenCalledTimes(1);
+    // Both visible and hidden sessions load through the same batched per-agent
+    // cache read, so the whole cache is parsed once per agent, not once per session.
     expect(vi.mocked(loadSessionCostSummariesFromCache)).toHaveBeenCalledTimes(1);
 
     // But aggregate totals must include all 3 sessions (0.08 + 0.04 + 0.02 = 0.14)

--- a/src/gateway/server-methods/usage.ts
+++ b/src/gateway/server-methods/usage.ts
@@ -31,7 +31,6 @@ import type {
 import {
   loadCostUsageSummaryFromCache,
   loadSessionLogs,
-  loadSessionCostSummaryFromCache,
   loadSessionCostSummariesFromCache,
   loadSessionUsageTimeSeries,
   discoverAllSessions,
@@ -65,7 +64,7 @@ import type { GatewayRequestHandlers, RespondFn } from "./types.js";
 
 const COST_USAGE_CACHE_TTL_MS = 30_000;
 const COST_USAGE_CACHE_MAX = 256;
-const SESSIONS_USAGE_CACHE_READ_CONCURRENCY = 12;
+const SESSIONS_USAGE_AGENT_LOAD_CONCURRENCY = 12;
 const DAY_MS = 24 * 60 * 60 * 1000;
 
 type DateRange = { startMs: number; endMs: number };
@@ -1143,8 +1142,6 @@ export const usageHandlers: GatewayRequestHandlers = {
     // Sort by most recent first
     mergedEntries.sort((a, b) => b.updatedAt - a.updatedAt);
 
-    const limitedEntries = mergedEntries.slice(0, limit);
-
     // Load usage for each session
     const sessions: SessionUsageEntry[] = [];
     const aggregateTotals = createEmptyCostUsageTotals();
@@ -1190,112 +1187,67 @@ export const usageHandlers: GatewayRequestHandlers = {
       { length: mergedEntries.length },
       () => null,
     );
-    const usageLoadTasks: Array<
-      () => Promise<{
-        entryIndex: number;
-        cacheStatus: UsageCacheStatus;
-        summary: SessionCostSummary | null;
-      }>
-    > = [];
 
-    for (const [entryIndex, merged] of limitedEntries.entries()) {
-      const includedSessionIds = merged.includedSessionIds ?? [merged.sessionId];
-      for (const includedSessionId of includedSessionIds) {
-        const isCurrentSession = includedSessionId === merged.sessionId;
-        const includedSessionFile = isCurrentSession
-          ? merged.sessionFile
-          : resolveExistingUsageSessionFile({
-              sessionId: includedSessionId,
-              agentId: merged.agentId,
-            });
-        if (!includedSessionFile) {
-          continue;
-        }
-        usageLoadTasks.push(async () => {
-          const cachedUsage = await loadSessionCostSummaryFromCache({
-            sessionId: includedSessionId,
-            sessionEntry: isCurrentSession ? merged.storeEntry : undefined,
-            sessionFile: includedSessionFile,
-            config,
-            agentId: merged.agentId,
-            startMs,
-            endMs,
-            refreshMode: "background",
-          });
-          return {
-            entryIndex,
-            cacheStatus: cachedUsage.cacheStatus,
-            summary: cachedUsage.summary,
-          };
-        });
-      }
-    }
-
-    const usageLoadResult = await runTasksWithConcurrency({
-      tasks: usageLoadTasks,
-      limit: SESSIONS_USAGE_CACHE_READ_CONCURRENCY,
-      errorMode: "stop",
-    });
-    if (usageLoadResult.hasError) {
-      throw usageLoadResult.firstError;
-    }
-    for (const loaded of usageLoadResult.results) {
-      cacheStatus = mergeUsageCacheStatus(cacheStatus, loaded.cacheStatus);
-      if (!loaded.summary) {
-        continue;
-      }
-      const merged = mergedEntries[loaded.entryIndex];
-      const usage = usageByEntryIndex[loaded.entryIndex] ?? createEmptySessionCostSummary();
-      usage.sessionId = merged.sessionId;
-      usage.sessionFile = merged.sessionFile;
-      mergeSessionUsageInto(usage, loaded.summary);
-      usageByEntryIndex[loaded.entryIndex] = usage;
-    }
-
-    const hiddenSessionsByAgent = new Map<
+    // Group every included session (visible + hidden) by agent so the usage-cost
+    // cache is read and parsed at most once per agent. Loading each session
+    // individually re-reads and re-parses the whole cache file, so RSS spikes
+    // in proportion to `limit` on every dashboard connect (issue #100041).
+    const sessionsByAgent = new Map<
       string | undefined,
       Array<{ entryIndex: number; sessionId: string; sessionFile: string }>
     >();
     for (const [entryIndex, merged] of mergedEntries.entries()) {
-      if (entryIndex < limitedEntries.length) {
-        continue;
-      }
-      const hiddenSessions = hiddenSessionsByAgent.get(merged.agentId) ?? [];
       for (const includedSessionId of merged.includedSessionIds ?? [merged.sessionId]) {
-        const sessionFile =
+        const includedSessionFile =
           includedSessionId === merged.sessionId
             ? merged.sessionFile
             : resolveExistingUsageSessionFile({
                 sessionId: includedSessionId,
                 agentId: merged.agentId,
               });
-        if (sessionFile) {
-          hiddenSessions.push({ entryIndex, sessionId: includedSessionId, sessionFile });
+        if (!includedSessionFile) {
+          continue;
         }
+        const agentSessions = sessionsByAgent.get(merged.agentId) ?? [];
+        agentSessions.push({
+          entryIndex,
+          sessionId: includedSessionId,
+          sessionFile: includedSessionFile,
+        });
+        sessionsByAgent.set(merged.agentId, agentSessions);
       }
-      hiddenSessionsByAgent.set(merged.agentId, hiddenSessions);
     }
-    for (const [agentId, hiddenSessions] of hiddenSessionsByAgent) {
-      const hiddenUsage = await loadSessionCostSummariesFromCache({
-        sessions: hiddenSessions,
-        config,
-        agentId,
-        startMs,
-        endMs,
-      });
-      cacheStatus = mergeUsageCacheStatus(cacheStatus, hiddenUsage.cacheStatus);
-      for (const [hiddenIndex, summary] of hiddenUsage.summaries.entries()) {
+
+    const agentLoadResult = await runTasksWithConcurrency({
+      tasks: Array.from(sessionsByAgent.entries()).map(([agentId, agentSessions]) => async () => ({
+        agentSessions,
+        loaded: await loadSessionCostSummariesFromCache({
+          sessions: agentSessions,
+          config,
+          agentId,
+          startMs,
+          endMs,
+        }),
+      })),
+      limit: SESSIONS_USAGE_AGENT_LOAD_CONCURRENCY,
+      errorMode: "stop",
+    });
+    if (agentLoadResult.hasError) {
+      throw agentLoadResult.firstError;
+    }
+    for (const { agentSessions, loaded } of agentLoadResult.results) {
+      cacheStatus = mergeUsageCacheStatus(cacheStatus, loaded.cacheStatus);
+      for (const [index, summary] of loaded.summaries.entries()) {
         if (!summary) {
           continue;
         }
-        const hiddenSession = hiddenSessions[hiddenIndex];
-        const merged = mergedEntries[hiddenSession.entryIndex];
-        const usage =
-          usageByEntryIndex[hiddenSession.entryIndex] ?? createEmptySessionCostSummary();
+        const session = agentSessions[index];
+        const merged = mergedEntries[session.entryIndex];
+        const usage = usageByEntryIndex[session.entryIndex] ?? createEmptySessionCostSummary();
         usage.sessionId = merged.sessionId;
         usage.sessionFile = merged.sessionFile;
         mergeSessionUsageInto(usage, summary);
-        usageByEntryIndex[hiddenSession.entryIndex] = usage;
+        usageByEntryIndex[session.entryIndex] = usage;
       }
     }
 


### PR DESCRIPTION
Closes #100041

## What Problem This Solves

Resolves an issue where operators running the openclaw-control-ui dashboard get chronic false-positive `memory pressure: level=warning reason=rss_growth` warnings that advise restarting the gateway when nothing is wrong. On every dashboard connect/reconnect, the bootstrap RPC batch calls `sessions.usage` (default `limit=50`), which spikes gateway RSS 200-600 MiB in a single ~30s window and trips the `rss_growth` diagnostic (threshold 512 MiB). GC reclaims it immediately, so it is a transient over-allocation, not a leak.

## Why This Change Was Made

The `sessions.usage` handler loaded each visible session's summary through `loadSessionCostSummaryFromCache`, and that function unconditionally does a full `fs.readFile` + `JSON.parse` of the entire `.usage-cost-cache.json` on every call with no request-scoped memoization. At `limit=50` that is ~50 full re-parses of the whole cache per connect — the burst tracks the `limit` parameter, not on-disk store size (the reporter confirmed `limit=1` → ~19 MiB vs `limit=50` → ~450 MiB on an identical store).

The hidden-session path already avoided this by using the batched `loadSessionCostSummariesFromCache`, which reads and parses the cache at most once per agent. This change unifies the visible and hidden session paths onto that batched loader, so the cache is read once per agent regardless of `limit`. The visible path already ran in `background` refresh mode, so no refresh semantics change.

## User Impact

A routine dashboard connect no longer allocates hundreds of MiB or trips the memory-pressure alarm. Cache read/parse cost for `sessions.usage` is now O(agents) instead of O(sessions requested), and no longer grows with the `limit` request parameter.

## Evidence

- `node scripts/run-vitest.mjs src/gateway/server-methods/usage.sessions-usage.test.ts` → 36 passed. Tests updated to assert the whole cache is read once per agent (`loadSessionCostSummariesFromCache` called once) rather than once per session.
- `pnpm tsgo:core` and `pnpm check:test-types` → clean.
- `git diff --numstat`: net -49 prod LOC (removes the duplicate per-session load path).
- Note: one pre-existing DST test (`fills every calendar day ... spring-forward`) fails on this macOS checkout at the base commit too, unrelated to this change (timezone/`Intl` environment dependent; CI truth is Linux Node 24).

## Maintainer Validation

- Blacksmith Testbox `tbx_01kwqd945cj8jmjdffd0j8g40t` (`jade-prawn`), exact base vs exact head with 50 real session transcripts and a ~20 MiB durable usage cache: base transient Gateway RSS growth `+1431.01 MiB`; head `+0.11 MiB`. Both RPC calls returned all 50 sessions; the head stays safely below the `512 MiB` `rss_growth` warning threshold.
- `corepack pnpm test:serial src/gateway/server-methods/usage.sessions-usage.test.ts` -> 36/36 passed.
- `corepack pnpm check:changed -- src/gateway/server-methods/usage.ts src/gateway/server-methods/usage.sessions-usage.test.ts` -> passed on the same Testbox.
- Fresh branch autoreview: no accepted or actionable findings.
