### PR TITLE
fix(cron): retry isolated setup watchdog stalls

### DIFF
--- a/src/cron/retry-hint.test.ts
+++ b/src/cron/retry-hint.test.ts
@@ -42,7 +42,11 @@ describe("resolveCronExecutionRetryHint", () => {
   });
 
   it("classifies cron pre-execution watchdog failures as timeout retries", () => {
-    for (const message of [setupTimeoutErrorMessage(), preExecutionTimeoutErrorMessage()]) {
+    for (const message of [
+      "cron: isolated agent setup stalled before runner start",
+      setupTimeoutErrorMessage(),
+      preExecutionTimeoutErrorMessage(),
+    ]) {
       expect(resolveCronExecutionRetryHint(message, ["timeout"])).toEqual({
         retryable: true,
         category: "timeout",

--- a/src/cron/retry-hint.ts
+++ b/src/cron/retry-hint.ts
@@ -18,6 +18,11 @@ export type CronRetryHint = {
 const SERVER_ERROR_PATTERN =
   /\b(?:https?|status(?:[ _]code)?|response(?:[ _]code)?|http(?:[ _]status)?)\b[\s:=#"']{0,4}5\d{2}\b|\b5\d{2}\b[\s:)\].,-]*(?:internal server error|server error|bad gateway|service unavailable|gateway time-?out)\b|\binternal server error\b|\bbad gateway\b|\bservice unavailable\b|\bgateway time-?out\b|\b5xx\b|^\s*5\d{2}\s*$/i;
 
+// Cron setup/pre-execution watchdogs can emit runner-start stall prose that
+// does not include terse timeout tokens or ETIMEDOUT codes.
+const TIMEOUT_PATTERN =
+  /(timeout|timed out|isolated agent setup stalled before runner start|stalled before execution start|etimedout)/i;
+
 const TRANSIENT_PATTERNS: Record<CronRetryOn, RegExp> = {
   rate_limit:
     /(rate[_ ]limit|too many requests|429|resource has been exhausted|cloudflare|tokens per day)/i,
@@ -25,7 +30,7 @@ const TRANSIENT_PATTERNS: Record<CronRetryOn, RegExp> = {
     /\b529\b|\boverloaded(?:_error)?\b|high demand|temporar(?:ily|y) overloaded|capacity exceeded/i,
   network:
     /(network|fetch failed|socket|econnreset|econnrefused|eai_again|enetdown|ehostunreach|ehostdown|enetreset|enetunreach|epipe)/i,
-  timeout: /(timeout|timed out|stalled before execution start|etimedout)/i,
+  timeout: TIMEOUT_PATTERN,
   server_error: SERVER_ERROR_PATTERN,
 };
 


### PR DESCRIPTION
## Summary

Fix cron retry classification for isolated-agent setup watchdog failures that stall before the runner starts.

## Root cause

Cron's retry policy is driven by `resolveCronExecutionRetryHint`, which classifies an error message against configured transient categories. The setup watchdog path can fail with prose like:

- `cron: isolated agent setup stalled before runner start`

That message is a transient setup timeout, but it did not contain the existing timeout tokens (`timeout`, `timed out`, `stalled before execution start`, `ETIMEDOUT`). As a result, cron jobs configured with `retryOn: ["timeout"]` did not treat this pre-runner setup stall as retryable, so Pablo task execution cron failures could stop instead of retrying.

## Fix

- Extracted the timeout regex into `TIMEOUT_PATTERN` for readability.
- Added the isolated setup watchdog text to timeout matching.
- Added regression coverage that verifies setup/pre-execution watchdog messages classify as `timeout` retries.

## Verification

- `node scripts/run-vitest.mjs run --config test/vitest/vitest.cron.config.ts src/cron/retry-hint.test.ts` passed: 1 file, 6 tests.
- `pnpm tsgo:core` passed.

Known local gate issues while validating:

- The requested command `node scripts/run-vitest.mjs run --config test/vitest/vitest.unit.config.ts src/cron/retry-hint.test.ts` exits with "No test files found" because `vitest.unit.config.ts` excludes `src/cron/**`; the cron shard command above is the matching config for this test.
- `pnpm format:check` currently reports existing formatting differences across many unrelated files.
- `pnpm lint` currently fails in the plugin-sdk boundary root shims generation step with `rolldown-plugin-dts` errors while building existing plugin SDK `.d.ts` entries; no lint finding points at the cron retry files.
