### PR TITLE
fix: retry isolated cron setup watchdog timeouts

### DIFF
--- a/src/cron/retry-hint.test.ts
+++ b/src/cron/retry-hint.test.ts
@@ -42,7 +42,11 @@ describe("resolveCronExecutionRetryHint", () => {
   });
 
   it("classifies cron pre-execution watchdog failures as timeout retries", () => {
-    for (const message of [setupTimeoutErrorMessage(), preExecutionTimeoutErrorMessage()]) {
+    for (const message of [
+      "cron: isolated agent setup stalled before runner start",
+      setupTimeoutErrorMessage(),
+      preExecutionTimeoutErrorMessage(),
+    ]) {
       expect(resolveCronExecutionRetryHint(message, ["timeout"])).toEqual({
         retryable: true,
         category: "timeout",

--- a/src/cron/retry-hint.ts
+++ b/src/cron/retry-hint.ts
@@ -18,6 +18,11 @@ export type CronRetryHint = {
 const SERVER_ERROR_PATTERN =
   /\b(?:https?|status(?:[ _]code)?|response(?:[ _]code)?|http(?:[ _]status)?)\b[\s:=#"']{0,4}5\d{2}\b|\b5\d{2}\b[\s:)\].,-]*(?:internal server error|server error|bad gateway|service unavailable|gateway time-?out)\b|\binternal server error\b|\bbad gateway\b|\bservice unavailable\b|\bgateway time-?out\b|\b5xx\b|^\s*5\d{2}\s*$/i;
 
+// Cron setup/pre-execution watchdogs can emit runner-start stall prose that
+// does not include terse timeout tokens or ETIMEDOUT codes.
+const TIMEOUT_PATTERN =
+  /(timeout|timed out|isolated agent setup stalled before runner start|stalled before execution start|etimedout)/i;
+
 const TRANSIENT_PATTERNS: Record<CronRetryOn, RegExp> = {
   rate_limit:
     /(rate[_ ]limit|too many requests|429|resource has been exhausted|cloudflare|tokens per day)/i,
@@ -25,7 +30,7 @@ const TRANSIENT_PATTERNS: Record<CronRetryOn, RegExp> = {
     /\b529\b|\boverloaded(?:_error)?\b|high demand|temporar(?:ily|y) overloaded|capacity exceeded/i,
   network:
     /(network|fetch failed|socket|econnreset|econnrefused|eai_again|enetdown|ehostunreach|ehostdown|enetreset|enetunreach|epipe)/i,
-  timeout: /(timeout|timed out|stalled before execution start|etimedout)/i,
+  timeout: TIMEOUT_PATTERN,
   server_error: SERVER_ERROR_PATTERN,
 };
 


### PR DESCRIPTION
## Root cause
The cron setup watchdog emits 'cron: isolated agent setup timed out before runner start' when an isolated agent run stalls before the runner starts, but the retry classifier on origin/main does not recognize the sibling phrasing 'isolated agent setup stalled before runner start' as retryable.

## Fix
Broadened the timeout classifier through a named TIMEOUT_PATTERN so setup/pre-execution watchdog prose is treated as timeout while leaving the scheduler, watchdog, and restart paths unchanged.

## Test
Updated src/cron/retry-hint.test.ts to assert setup/pre-execution watchdog failures classify as retryable timeout errors.

## Sibling occurrences
Grepped src/cron for related timeout/setup watchdog wording; the only uncovered sibling was 'isolated agent setup stalled before runner start', now covered.