### PR TITLE
refactor(plugin-sdk): remove broad HTTP body exports

### DIFF
--- a/scripts/plugin-sdk-surface-report.mjs
+++ b/scripts/plugin-sdk-surface-report.mjs
@@ -127,7 +127,7 @@ const defaultPublicDeprecatedExportsByEntrypointBudget = Object.freeze({
   "outbound-send-deps": 4,
   "outbound-runtime": 16,
   "file-access-runtime": 2,
-  "infra-runtime": 585,
+  "infra-runtime": 569,
   "ssrf-policy": 1,
   "ssrf-runtime": 1,
   "media-runtime": 2,
@@ -202,11 +202,11 @@ let publicDeprecatedExportsByEntrypointBudget;
 try {
   budgets = {
     publicEntrypoints: readBudgetEnv("OPENCLAW_PLUGIN_SDK_MAX_PUBLIC_ENTRYPOINTS", 323),
-    publicExports: readBudgetEnv("OPENCLAW_PLUGIN_SDK_MAX_PUBLIC_EXPORTS", 10425),
-    publicFunctionExports: readBudgetEnv("OPENCLAW_PLUGIN_SDK_MAX_PUBLIC_FUNCTION_EXPORTS", 5237),
+    publicExports: readBudgetEnv("OPENCLAW_PLUGIN_SDK_MAX_PUBLIC_EXPORTS", 10406),
+    publicFunctionExports: readBudgetEnv("OPENCLAW_PLUGIN_SDK_MAX_PUBLIC_FUNCTION_EXPORTS", 5229),
     publicDeprecatedExports: readBudgetEnv(
       "OPENCLAW_PLUGIN_SDK_MAX_PUBLIC_DEPRECATED_EXPORTS",
-      3261,
+      3245,
     ),
     publicWildcardReexports: readBudgetEnv(
       "OPENCLAW_PLUGIN_SDK_MAX_PUBLIC_WILDCARD_REEXPORTS",

--- a/src/agents/model-scan.ts
+++ b/src/agents/model-scan.ts
@@ -1,3 +1,6 @@
+/**
+ * Scans remote provider model catalogs for configured providers.
+ */
 import { normalizeProviderId } from "@openclaw/model-catalog-core/provider-id";
 import {
   asDateTimestampMs,
@@ -13,9 +16,6 @@ import {
 } from "@openclaw/normalization-core/string-normalization";
 import { Type } from "typebox";
 import { formatErrorMessage } from "../infra/errors.js";
-/**
- * Scans remote provider model catalogs for configured providers.
- */
 import { readResponseWithLimit } from "../infra/http-body.js";
 import { getEnvApiKey } from "../llm/env-api-keys.js";
 import type { OpenAICompletionsOptions } from "../llm/providers/openai-completions.js";

--- a/src/commands/docs.ts
+++ b/src/commands/docs.ts
@@ -1,7 +1,7 @@
+// Implements docs link/search output for `openclaw docs`.
 import { formatDocsLink } from "../../packages/terminal-core/src/links.js";
 import { isRich, theme } from "../../packages/terminal-core/src/theme.js";
 import { formatCliCommand } from "../cli/command-format.js";
-// Implements docs link/search output for `openclaw docs`.
 import { readResponseWithLimit } from "../infra/http-body.js";
 import type { RuntimeEnv } from "../runtime.js";
 

--- a/src/link-understanding/runner.ts
+++ b/src/link-understanding/runner.ts
@@ -1,9 +1,9 @@
+// Link-understanding runner fetches allowed URLs and invokes configured commands with bounded content.
 import type { MsgContext } from "../auto-reply/templating.js";
 import { applyTemplate } from "../auto-reply/templating.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import type { LinkModelConfig, LinkToolsConfig } from "../config/types.tools.js";
 import { logVerbose, shouldLogVerbose } from "../globals.js";
-// Link-understanding runner fetches allowed URLs and invokes configured commands with bounded content.
 import { readResponseWithLimit } from "../infra/http-body.js";
 import { fetchWithSsrFGuard, GUARDED_FETCH_MODE } from "../infra/net/fetch-guard.js";
 import { CLI_OUTPUT_MAX_BUFFER } from "../media-understanding/defaults.js";

--- a/src/plugin-sdk/infra-runtime.ts
+++ b/src/plugin-sdk/infra-runtime.ts
@@ -36,26 +36,6 @@ export * from "../infra/heartbeat-events.ts";
 export * from "../infra/heartbeat-summary.ts";
 export * from "../infra/heartbeat-visibility.ts";
 export * from "../infra/home-dir.js";
-// Keep this deprecated barrel pinned to its shipped request-body surface; new
-// response readers belong only to the focused response-limit/media entrypoints.
-export {
-  __test__,
-  DEFAULT_WEBHOOK_BODY_TIMEOUT_MS,
-  DEFAULT_WEBHOOK_MAX_BODY_BYTES,
-  installRequestBodyLimitGuard,
-  isRequestBodyLimitError,
-  readJsonBodyWithLimit,
-  readRequestBodyWithLimit,
-  requestBodyErrorToText,
-  RequestBodyLimitError,
-  testApi,
-  type ReadJsonBodyOptions,
-  type ReadJsonBodyResult,
-  type ReadRequestBodyOptions,
-  type RequestBodyLimitErrorCode,
-  type RequestBodyLimitGuard,
-  type RequestBodyLimitGuardOptions,
-} from "../infra/http-body.js";
 export * from "../infra/json-files.js";
 export * from "../infra/local-file-access.js";
 export * from "../infra/map-size.js";

--- a/src/plugin-sdk/media-runtime.ts
+++ b/src/plugin-sdk/media-runtime.ts
@@ -51,11 +51,6 @@ export * from "../media/png-encode.ts";
 export * from "../media/qr-image.ts";
 export * from "../media/qr-terminal.ts";
 export * from "@openclaw/media-core/read-byte-stream-with-limit";
-export {
-  readChunkWithIdleTimeout,
-  readResponseTextSnippet,
-  readResponseWithLimit,
-} from "../infra/http-body.js";
 export * from "../media/store.js";
 export * from "../media/temp-files.js";
 export { resolveChannelMediaMaxBytes } from "../channels/plugins/media-limits.js";

--- a/src/plugins/provider-self-hosted-setup.ts
+++ b/src/plugins/provider-self-hosted-setup.ts
@@ -1,3 +1,4 @@
+// Builds setup metadata for self-hosted provider plugins.
 import {
   findNormalizedProviderValue,
   normalizeProviderId,
@@ -17,7 +18,6 @@ import {
 } from "../agents/self-hosted-provider-defaults.js";
 import type { ModelDefinitionConfig } from "../config/types.models.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
-// Builds setup metadata for self-hosted provider plugins.
 import { readResponseWithLimit } from "../infra/http-body.js";
 import { fetchWithSsrFGuard } from "../infra/net/fetch-guard.js";
 import type { SsrFPolicy } from "../infra/net/ssrf.js";

--- a/src/video-generation/dashscope-compatible.ts
+++ b/src/video-generation/dashscope-compatible.ts
@@ -1,3 +1,4 @@
+// DashScope-compatible video provider adapts DashScope-style generation APIs.
 import { normalizeLowercaseStringOrEmpty } from "@openclaw/normalization-core/string-coerce";
 import { uniqueStrings } from "@openclaw/normalization-core/string-normalization";
 import {
@@ -12,7 +13,6 @@ import {
   waitProviderOperationPollInterval,
   type ProviderOperationTimeoutMs,
 } from "openclaw/plugin-sdk/provider-http";
-// DashScope-compatible video provider adapts DashScope-style generation APIs.
 import { readResponseWithLimit } from "../infra/http-body.js";
 import { resolveGeneratedMediaMaxBytes } from "../media/configured-max-bytes.js";
 import type {


### PR DESCRIPTION
Related: #99744

## What Problem This Solves

Removes HTTP-body helpers that were unnecessarily exposed through the deprecated `infra-runtime` compatibility barrel and the broad `media-runtime` barrel.

## Why This Change Was Made

The HTTP-body consolidation has focused Plugin SDK entrypoints for these contracts. This removes 16 request-body exports from `infra-runtime` and three response-reader exports from `media-runtime`, while retaining `response-limit-runtime` and the webhook request-body entrypoints. The SDK surface ratchets are reduced to prevent the broad exports from returning.

The five file-header comments displaced by the original consolidation are also restored to the top of their modules.

## User Impact

Plugin authors use the focused HTTP response and webhook entrypoints instead of broad compatibility barrels. Core and bundled plugin callers are unchanged.

## Evidence

- Repository search found no internal caller importing any removed symbol through `infra-runtime` or `media-runtime`.
- `node scripts/run-vitest.mjs test/scripts/plugin-sdk-surface-report.test.ts src/plugins/contracts/plugin-sdk-subpaths.test.ts src/plugins/sdk-alias.test.ts` — 3 shards, 100 tests passed.
- Blacksmith Testbox `tbx_01kwqa2rv1cfcf32n3m7zge18g` — `pnpm check:changed` and `pnpm build` passed: https://github.com/openclaw/openclaw/actions/runs/28717371519
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main --engine codex --thinking high --stream-engine-output` — clean, no accepted/actionable findings (0.99 confidence).
- SDK surface: 19 fewer public exports, 8 fewer callable exports, 16 fewer deprecated exports from `infra-runtime`.
- Production LOC: 11 additions, 36 deletions; net -25.
