### PR TITLE
fix(agents): scale aggregate tool-result budget with context window and compact on pressure

### DIFF
--- a/src/agents/embedded-agent-runner/run.ts
+++ b/src/agents/embedded-agent-runner/run.ts
@@ -2867,6 +2867,7 @@ async function runEmbeddedAgentInternal(
                     sessionKey: params.sessionKey,
                     agentId: sessionAgentId,
                     config: params.config,
+                    protectTrailingToolResults: true,
                   });
                   if (truncResult.truncated) {
                     log.info(
@@ -2930,6 +2931,7 @@ async function runEmbeddedAgentInternal(
                   sessionKey: params.sessionKey,
                   agentId: sessionAgentId,
                   config: params.config,
+                  protectTrailingToolResults: preflightRecovery?.route === "compact_then_truncate",
                 });
                 if (truncResult.truncated) {
                   log.info(

--- a/src/agents/embedded-agent-runner/run/attempt.spawn-workspace.context-engine.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.spawn-workspace.context-engine.test.ts
@@ -18,6 +18,7 @@ import {
   resetSubagentRegistryForTests,
 } from "../../subagent-registry.js";
 import type { SubagentRunRecord } from "../../subagent-registry.types.js";
+import { makeAgentAssistantMessage } from "../../test-helpers/agent-message-fixtures.js";
 import {
   type AttemptContextEngine,
   buildLoopPromptCacheInfo,
@@ -3160,5 +3161,96 @@ describe("runEmbeddedAttempt tool-result guard budget wiring", () => {
     expect(afterTurn).toHaveBeenCalledTimes(1);
     expect(sumToolResultTextChars(afterTurnMessages)).toBeGreaterThan(4_000);
     expect(JSON.stringify(afterTurnMessages)).not.toContain("truncated");
+  });
+
+  it("routes aggregate prompt-history truncation to compact-then-truncate before prompt submission", async () => {
+    let sawPrompt = false;
+    const sessionMessages: AgentMessage[] = [{ role: "user", content: "seed", timestamp: 1 }];
+    for (let index = 0; index < 5; index += 1) {
+      sessionMessages.push({
+        ...makeAgentAssistantMessage({
+          content: [{ type: "toolCall", id: `aggregate_${index}`, name: "read", arguments: {} }],
+          timestamp: 2 + index * 2,
+        }),
+      });
+      sessionMessages.push({
+        role: "toolResult",
+        toolCallId: `aggregate_${index}`,
+        toolName: "read",
+        content: [{ type: "text", text: `${index}: ${"aggregate output ".repeat(900)}` }],
+        isError: false,
+        timestamp: 3 + index * 2,
+      } as AgentMessage);
+    }
+    sessionMessages.push(
+      makeAgentAssistantMessage({
+        content: [{ type: "text", text: "old turn done" }],
+        timestamp: 20,
+      }),
+    );
+
+    const result = await createContextEngineAttemptRunner({
+      contextEngine: createContextEngineBootstrapAndAssemble(),
+      sessionKey,
+      tempPaths,
+      sessionMessages,
+      attemptOverrides: {
+        contextTokenBudget: 1_000,
+      },
+      sessionPrompt: async (session) => {
+        sawPrompt = true;
+        session.messages = [...session.messages, doneMessage];
+      },
+    });
+
+    expect(sawPrompt).toBe(false);
+    expect(result.promptErrorSource).toBe("precheck");
+    expect(result.preflightRecovery).toEqual({ route: "compact_then_truncate" });
+    expect(hoisted.preemptiveCompactionCalls).toHaveLength(0);
+  });
+
+  it("routes protected trailing aggregate pressure to compact-then-truncate", async () => {
+    let sawPrompt = false;
+    const sessionMessages: AgentMessage[] = [
+      { role: "user", content: "seed", timestamp: 1 },
+      makeAgentAssistantMessage({
+        content: Array.from({ length: 5 }, (_, index) => ({
+          type: "toolCall",
+          id: `fresh_${index}`,
+          name: "read",
+          arguments: {},
+        })),
+        timestamp: 2,
+      }),
+    ];
+    for (let index = 0; index < 5; index += 1) {
+      sessionMessages.push({
+        role: "toolResult",
+        toolCallId: `fresh_${index}`,
+        toolName: "read",
+        content: [{ type: "text", text: `${index}: ${"fresh output ".repeat(90)}` }],
+        isError: false,
+        timestamp: 3 + index,
+      } as AgentMessage);
+    }
+
+    const result = await createContextEngineAttemptRunner({
+      contextEngine: createContextEngineBootstrapAndAssemble(),
+      sessionKey,
+      tempPaths,
+      sessionMessages,
+      attemptOverrides: {
+        contextTokenBudget: 1_000,
+      },
+      sessionPrompt: async (session) => {
+        sawPrompt = true;
+        session.messages = [...session.messages, doneMessage];
+      },
+    });
+
+    expect(sawPrompt).toBe(false);
+    expect(result.promptErrorSource).toBe("precheck");
+    expect(result.preflightRecovery).toEqual({ route: "compact_then_truncate" });
+    expect(hoisted.preemptiveCompactionCalls).toHaveLength(0);
   });
 });

--- a/src/agents/embedded-agent-runner/run/attempt.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.ts
@@ -333,6 +333,7 @@ import {
 } from "../tool-result-context-guard.js";
 import {
   resolveLiveToolResultMaxChars,
+  resolveLiveToolResultAggregateMaxChars,
   createToolResultPromptProjectionState,
   truncateOversizedToolResultsInMessages,
   type ToolResultPromptProjectionState,
@@ -532,7 +533,7 @@ export {
 };
 
 const MAX_BTW_SNAPSHOT_MESSAGES = 100;
-const PROMPT_TOOL_RESULT_AGGREGATE_CAP_MULTIPLIER = 4;
+const aggregateToolResultPressureWarnings = new Set<string>();
 
 function pluginMetadataSnapshotCoversProvider(
   snapshot: PluginMetadataSnapshot | undefined,
@@ -4212,25 +4213,49 @@ export async function runEmbeddedAttempt(
             cfg: params.config,
             agentId: sessionAgentId,
           });
+          const promptToolResultAggregateMaxChars = resolveLiveToolResultAggregateMaxChars({
+            contextWindowTokens: contextTokenBudget,
+            perResultMaxChars: promptToolResultMaxChars,
+          });
           let promptHistoryMessages = activeSession.messages;
           const promptToolResultTruncation = truncateOversizedToolResultsInMessages(
             activeSession.messages,
             contextTokenBudget,
             promptToolResultMaxChars,
-            promptToolResultMaxChars * PROMPT_TOOL_RESULT_AGGREGATE_CAP_MULTIPLIER,
+            promptToolResultAggregateMaxChars,
             toolResultPromptProjectionState,
           );
-          if (promptToolResultTruncation.messages !== activeSession.messages) {
+          const promptHistoryChanged =
+            promptToolResultTruncation.messages !== activeSession.messages;
+          const { aggregatePressureEngaged } = promptToolResultTruncation;
+          if (promptHistoryChanged) {
             promptHistoryMessages = promptToolResultTruncation.messages;
-            log.info(
+          }
+          if (promptHistoryChanged || aggregatePressureEngaged) {
+            const sessionLogKey = params.sessionKey ?? params.sessionId ?? "unknown";
+            const truncationLog =
               `[tool-result-truncation] Truncated ${promptToolResultTruncation.truncatedCount} ` +
-                `tool result(s) for prompt history ` +
-                `(maxChars=${promptToolResultMaxChars} ` +
-                `aggregateBudgetChars=${
-                  promptToolResultMaxChars * PROMPT_TOOL_RESULT_AGGREGATE_CAP_MULTIPLIER
-                }) ` +
-                `sessionKey=${params.sessionKey ?? params.sessionId ?? "unknown"}`,
-            );
+              `tool result(s) for prompt history ` +
+              `(maxChars=${promptToolResultMaxChars} ` +
+              `aggregateBudgetChars=${promptToolResultAggregateMaxChars} ` +
+              `aggregate=${promptToolResultTruncation.aggregateTruncatedCount}) ` +
+              `sessionKey=${sessionLogKey}`;
+            if (aggregatePressureEngaged) {
+              if (!aggregateToolResultPressureWarnings.has(sessionLogKey)) {
+                aggregateToolResultPressureWarnings.add(sessionLogKey);
+                log.warn(
+                  `${truncationLog}; aggregate tool-result pressure detected, compaction has been requested; consider /compact or /new if pressure persists`,
+                );
+              }
+              // Compaction and aggregate truncation both target about half the window;
+              // compact-then-truncate prevents re-hitting the same cap on the next turn.
+              preflightRecovery = { route: "compact_then_truncate" };
+              promptError = new Error(PREEMPTIVE_OVERFLOW_ERROR_TEXT);
+              promptErrorSource = "precheck";
+              skipPromptSubmission = true;
+            } else {
+              log.info(truncationLog);
+            }
           }
 
           const promptSubmission = resolveRuntimeContextPromptParts({
@@ -4778,7 +4803,7 @@ export async function runEmbeddedAttempt(
                     messages,
                     contextTokenBudget,
                     promptToolResultMaxChars,
-                    promptToolResultMaxChars * PROMPT_TOOL_RESULT_AGGREGATE_CAP_MULTIPLIER,
+                    promptToolResultAggregateMaxChars,
                     toolResultPromptProjectionState,
                   );
                   return providerPromptHistoryTruncation.messages !== messages

--- a/src/agents/embedded-agent-runner/run/preemptive-compaction.test.ts
+++ b/src/agents/embedded-agent-runner/run/preemptive-compaction.test.ts
@@ -393,7 +393,7 @@ describe("preemptive-compaction", () => {
   });
 
   it("routes to compact then truncate when recent tool tails help but cannot fully cover the overflow", () => {
-    const medium = "alpha beta gamma delta epsilon ".repeat(220);
+    const medium = "alpha beta gamma delta epsilon ".repeat(600);
     const longHistory = "old discussion with substantial retained context and decisions ".repeat(
       5000,
     );
@@ -426,6 +426,8 @@ describe("preemptive-compaction", () => {
       makeToolResultMessage(oversized),
       makeToolResultMessage(medium),
       makeToolResultMessage(medium),
+      makeToolResultMessage(medium),
+      makeToolResultMessage(medium),
     ];
     const reserveTokens = 2_000;
     const estimatedPromptTokens = estimateLlmBoundaryTokenPressure({
@@ -435,7 +437,7 @@ describe("preemptive-compaction", () => {
     });
     const potential = estimateToolResultReductionPotential({
       messages,
-      contextWindowTokens: 128_000,
+      contextWindowTokens: 20_000,
     });
     const desiredOverflowTokens = 2_000;
     const result = shouldPreemptivelyCompactBeforePrompt({

--- a/src/agents/embedded-agent-runner/tool-result-truncation.test.ts
+++ b/src/agents/embedded-agent-runner/tool-result-truncation.test.ts
@@ -22,6 +22,7 @@ let sessionLikelyHasOversizedToolResults: typeof import("./tool-result-truncatio
 let estimateToolResultReductionPotential: typeof import("./tool-result-truncation.js").estimateToolResultReductionPotential;
 let DEFAULT_MAX_LIVE_TOOL_RESULT_CHARS: typeof import("./tool-result-truncation.js").DEFAULT_MAX_LIVE_TOOL_RESULT_CHARS;
 let resolveLiveToolResultMaxChars: typeof import("./tool-result-truncation.js").resolveLiveToolResultMaxChars;
+let resolveLiveToolResultAggregateMaxChars: typeof import("./tool-result-truncation.js").resolveLiveToolResultAggregateMaxChars;
 let createToolResultPromptProjectionState: typeof import("./tool-result-truncation.js").createToolResultPromptProjectionState;
 let tmpDir: string | undefined;
 
@@ -41,6 +42,7 @@ async function loadFreshToolResultTruncationModuleForTest() {
     estimateToolResultReductionPotential,
     DEFAULT_MAX_LIVE_TOOL_RESULT_CHARS,
     resolveLiveToolResultMaxChars,
+    resolveLiveToolResultAggregateMaxChars,
     createToolResultPromptProjectionState,
   } = await import("./tool-result-truncation.js"));
 }
@@ -298,6 +300,23 @@ describe("calculateMaxToolResultChars", () => {
     });
     expect(result).toBe(24_000);
   });
+
+  it.each([
+    { contextWindowTokens: 20_000, perResultMaxChars: 16_000, aggregateMaxChars: 64_000 },
+    { contextWindowTokens: 128_000, perResultMaxChars: 32_000, aggregateMaxChars: 256_000 },
+    { contextWindowTokens: 200_000, perResultMaxChars: 64_000, aggregateMaxChars: 400_000 },
+    { contextWindowTokens: 1_000_000, perResultMaxChars: 64_000, aggregateMaxChars: 2_000_000 },
+  ])(
+    "resolves aggregate live cap for $contextWindowTokens token windows",
+    ({ contextWindowTokens, perResultMaxChars, aggregateMaxChars }) => {
+      expect(
+        resolveLiveToolResultAggregateMaxChars({
+          contextWindowTokens,
+          perResultMaxChars,
+        }),
+      ).toBe(aggregateMaxChars);
+    },
+  );
 });
 
 describe("sessionLikelyHasOversizedToolResults", () => {
@@ -309,13 +328,16 @@ describe("sessionLikelyHasOversizedToolResults", () => {
   });
 
   it("returns true for aggregate medium tool results that exceed the shared budget", () => {
-    const medium = "alpha beta gamma delta epsilon ".repeat(600);
+    const medium = "alpha beta gamma delta epsilon ".repeat(500);
     const messages: AgentMessage[] = [
       makeToolResult(medium, "call_1"),
       makeToolResult(medium, "call_2"),
       makeToolResult(medium, "call_3"),
+      makeToolResult(medium, "call_4"),
+      makeToolResult(medium, "call_5"),
+      makeToolResult(medium, "call_6"),
     ];
-    expect(sessionLikelyHasOversizedToolResults({ messages, contextWindowTokens: 128_000 })).toBe(
+    expect(sessionLikelyHasOversizedToolResults({ messages, contextWindowTokens: 20_000 })).toBe(
       true,
     );
   });
@@ -340,14 +362,17 @@ describe("estimateToolResultReductionPotential", () => {
       makeToolResult(medium, "call_1"),
       makeToolResult(medium, "call_2"),
       makeToolResult(medium, "call_3"),
+      makeToolResult(medium, "call_4"),
+      makeToolResult(medium, "call_5"),
+      makeToolResult(medium, "call_6"),
     ];
 
     const estimate = estimateToolResultReductionPotential({
       messages,
-      contextWindowTokens: 128_000,
+      contextWindowTokens: 20_000,
     });
 
-    expect(estimate.toolResultCount).toBe(3);
+    expect(estimate.toolResultCount).toBe(6);
     expect(estimate.oversizedCount).toBe(0);
     expect(estimate.aggregateReducibleChars).toBeGreaterThan(0);
     expect(estimate.maxReducibleChars).toBe(estimate.aggregateReducibleChars);
@@ -365,6 +390,7 @@ describe("estimateToolResultReductionPotential", () => {
     const estimate = estimateToolResultReductionPotential({
       messages,
       contextWindowTokens: 128_000,
+      aggregateMaxCharsOverride: 50_000,
     });
 
     expect(estimate.oversizedCount).toBeGreaterThan(0);
@@ -375,7 +401,7 @@ describe("estimateToolResultReductionPotential", () => {
     );
   });
 
-  it("lets tiny caps drive aggregate recovery estimates without the old floor", () => {
+  it("lets explicit aggregate caps drive aggregate recovery estimates", () => {
     const medium = "alpha beta gamma delta epsilon ".repeat(600);
     const messages: AgentMessage[] = [
       makeToolResult(medium, "call_1"),
@@ -387,6 +413,7 @@ describe("estimateToolResultReductionPotential", () => {
       messages,
       contextWindowTokens: 128_000,
       maxCharsOverride: 120,
+      aggregateMaxCharsOverride: 120,
     });
 
     expect(estimate.maxChars).toBe(120);
@@ -521,14 +548,7 @@ describe("truncateOversizedToolResultsInMessages", () => {
     );
 
     expect(first.truncatedCount).toBe(4);
-    expect(second.truncatedCount).toBe(2);
-    expect(
-      second.messages.reduce(
-        (sum, message) =>
-          sum + (message.role === "toolResult" ? getToolResultTextLength(message) : 0),
-        0,
-      ),
-    ).toBeLessThanOrEqual(12_000);
+    expect(second.truncatedCount).toBe(1);
     expect(second.messages.every((message) => getToolResultTextLength(message) <= 12_000)).toBe(
       true,
     );
@@ -658,7 +678,7 @@ describe("truncateOversizedToolResultsInMessages", () => {
     expect(totalChars).toBeLessThanOrEqual(32_000);
   });
 
-  it("falls back to trimming fresh trailing batches that exceed the aggregate budget", () => {
+  it("leaves fresh trailing batches intact when only they exceed the aggregate budget", () => {
     const projectionState = createToolResultPromptProjectionState();
     const messages: AgentMessage[] = [makeUserMessage("run several tools")];
     for (let index = 0; index < 5; index++) {
@@ -678,8 +698,9 @@ describe("truncateOversizedToolResultsInMessages", () => {
       0,
     );
 
-    expect(result.truncatedCount).toBeGreaterThan(0);
-    expect(totalChars).toBeLessThanOrEqual(32_000);
+    expect(result.truncatedCount).toBe(0);
+    expect(result.aggregatePressureEngaged).toBe(true);
+    expect(totalChars).toBeGreaterThan(32_000);
     expect(toolResults.every((message) => getFirstToolResultText(message).length > 0)).toBe(true);
   });
 
@@ -857,6 +878,7 @@ describe("truncateOversizedToolResultsInSession", () => {
       sessionFile,
       contextWindowTokens: 128_000,
       maxCharsOverride: DEFAULT_MAX_LIVE_TOOL_RESULT_CHARS,
+      aggregateMaxCharsOverride: DEFAULT_MAX_LIVE_TOOL_RESULT_CHARS,
     });
 
     expect(result.truncated).toBe(true);
@@ -901,6 +923,36 @@ describe("truncateOversizedToolResultsInSession", () => {
     expect(text.length).toBeLessThan(2_000);
     expect(text).toContain("truncated");
   });
+
+  it("leaves protected trailing batches intact during persisted aggregate recovery", async () => {
+    const dir = await createTmpDir();
+    const sm = SessionManager.create(dir, dir);
+    const firstKeptEntryId = sm.appendMessage(makeUserMessage("hello"));
+    sm.appendMessage(makeAssistantMessage("calling tools"));
+    const beforeTexts = Array.from({ length: 5 }, (_, index) => String(index).repeat(8_000));
+    for (const [index, text] of beforeTexts.entries()) {
+      sm.appendMessage(makeToolResult(text, `fresh_${index}`));
+    }
+    sm.appendCompaction("summary", firstKeptEntryId, 10);
+    const sessionFile = sm.getSessionFile()!;
+
+    const result = await truncateOversizedToolResultsInSession({
+      sessionFile,
+      contextWindowTokens: 1_000_000,
+      maxCharsOverride: 8_000,
+      aggregateMaxCharsOverride: 32_000,
+      protectTrailingToolResults: true,
+    });
+
+    expect(result.truncated).toBe(false);
+    const afterBranch = SessionManager.open(sessionFile).getBranch();
+    const afterTexts = afterBranch
+      .filter((entry) => entry.type === "message" && entry.message.role === "toolResult")
+      .map((entry) => (entry.type === "message" ? getFirstToolResultText(entry.message) : ""));
+
+    expect(afterTexts).toEqual(beforeTexts);
+  });
+
   it("combines oversized and aggregate recovery truncation in the same session rewrite", async () => {
     const dir = await createTmpDir();
     const sm = SessionManager.create(dir, dir);
@@ -948,6 +1000,7 @@ describe("truncateOversizedToolResultsInSession", () => {
       sessionFile,
       contextWindowTokens: 128_000,
       maxCharsOverride: 120,
+      aggregateMaxCharsOverride: 120,
     });
 
     expect(result.truncated).toBe(true);

--- a/src/agents/embedded-agent-runner/tool-result-truncation.ts
+++ b/src/agents/embedded-agent-runner/tool-result-truncation.ts
@@ -45,6 +45,8 @@ const LARGE_CONTEXT_MAX_LIVE_TOOL_RESULT_CHARS = 32_000;
 const XL_CONTEXT_MAX_LIVE_TOOL_RESULT_CHARS = 64_000;
 const LARGE_CONTEXT_TOOL_RESULT_TOKENS = 100_000;
 const XL_CONTEXT_TOOL_RESULT_TOKENS = 200_000;
+const PROMPT_TOOL_RESULT_AGGREGATE_CAP_MULTIPLIER = 4;
+const AGGREGATE_TOOL_RESULT_CONTEXT_SHARE = 0.5;
 
 /**
  * Minimum characters to keep when truncating.
@@ -53,6 +55,7 @@ const XL_CONTEXT_TOOL_RESULT_TOKENS = 200_000;
  */
 const MIN_KEEP_CHARS = 2_000;
 const RECOVERY_MIN_KEEP_CHARS = 0;
+const aggregateToolResultRecoveryWarnings = new Set<string>();
 
 type ToolResultTruncationOptions = {
   suffix?: string | ((truncatedChars: number) => string);
@@ -65,6 +68,37 @@ const COMPACT_RECOVERY_SUFFIX = (truncatedChars: number) =>
   `[... ${Math.max(1, Math.floor(truncatedChars))} chars truncated; narrow args]`;
 const AGGREGATE_ELISION_MARKER =
   "[tool result elided: aggregate tool-result budget exceeded; rerun the command if the output is needed]";
+
+function logToolResultSessionTruncation(params: {
+  rewrittenEntries: number;
+  contextWindowTokens: number;
+  maxChars: number;
+  aggregateBudgetChars: number;
+  oversizedReplacementCount: number;
+  aggregateReplacementCount: number;
+  sessionKey?: string;
+  sessionId?: string;
+}): void {
+  const sessionLogKey = params.sessionKey ?? params.sessionId ?? "unknown";
+  const message =
+    `[tool-result-truncation] Truncated ${params.rewrittenEntries} tool result(s) in session ` +
+    `(contextWindow=${params.contextWindowTokens} maxChars=${params.maxChars} ` +
+    `aggregateBudgetChars=${params.aggregateBudgetChars} ` +
+    `oversized=${params.oversizedReplacementCount} aggregate=${params.aggregateReplacementCount}) ` +
+    `sessionKey=${sessionLogKey}`;
+  if (params.aggregateReplacementCount <= 0) {
+    log.info(message);
+    return;
+  }
+  if (aggregateToolResultRecoveryWarnings.has(sessionLogKey)) {
+    log.info(message);
+    return;
+  }
+  aggregateToolResultRecoveryWarnings.add(sessionLogKey);
+  log.warn(
+    `${message}; aggregate tool-result pressure detected; consider /compact or /new if pressure persists`,
+  );
+}
 
 function resolveSuffixFactory(
   suffix: ToolResultTruncationOptions["suffix"],
@@ -250,6 +284,38 @@ export function resolveLiveToolResultMaxChars(params: {
   return calculateMaxToolResultCharsWithCap(params.contextWindowTokens, cap);
 }
 
+export function resolveLiveToolResultAggregateMaxChars(params: {
+  contextWindowTokens: number;
+  perResultMaxChars?: number;
+  cfg?: OpenClawConfig;
+  agentId?: string | null;
+}): number {
+  const perResultMaxChars = Math.max(
+    1,
+    Math.floor(
+      params.perResultMaxChars ??
+        resolveLiveToolResultMaxChars({
+          contextWindowTokens: params.contextWindowTokens,
+          cfg: params.cfg,
+          agentId: params.agentId,
+        }),
+    ),
+  );
+  const contextWindowTokens = Number.isFinite(params.contextWindowTokens)
+    ? Math.max(1, Math.floor(params.contextWindowTokens))
+    : 1;
+  // Aggregate truncation shares the 0.5 history-pressure invariant used by
+  // safeguard compaction and the mid-turn single-result guard. If this drifts,
+  // truncation can hide pressure that compaction routing should see.
+  const contextShareChars = Math.floor(
+    contextWindowTokens * 4 * AGGREGATE_TOOL_RESULT_CONTEXT_SHARE,
+  );
+  return Math.max(
+    perResultMaxChars * PROMPT_TOOL_RESULT_AGGREGATE_CAP_MULTIPLIER,
+    contextShareChars,
+  );
+}
+
 /**
  * Get the total character count of text content blocks in a tool result message.
  */
@@ -358,7 +424,13 @@ export function truncateOversizedToolResultsInMessages(
   maxCharsOverride?: number,
   aggregateMaxCharsOverride?: number,
   projectionState?: ToolResultPromptProjectionState,
-): { messages: AgentMessage[]; truncatedCount: number } {
+): {
+  messages: AgentMessage[];
+  truncatedCount: number;
+  aggregateTruncatedCount: number;
+  aggregatePressureEngaged: boolean;
+  aggregateBudgetChars: number;
+} {
   const maxChars = Math.max(
     1,
     maxCharsOverride ?? calculateMaxToolResultChars(contextWindowTokens),
@@ -419,6 +491,9 @@ export function truncateOversizedToolResultsInMessages(
     return {
       messages: hasProjectedChanges ? projectedMessages : messages,
       truncatedCount: 0,
+      aggregateTruncatedCount: 0,
+      aggregatePressureEngaged: plan.aggregatePressureExceeded,
+      aggregateBudgetChars,
     };
   }
 
@@ -439,6 +514,9 @@ export function truncateOversizedToolResultsInMessages(
   return {
     messages: replacedBranch.map((entry) => entry.message as AgentMessage),
     truncatedCount: replacementIds.size,
+    aggregateTruncatedCount: plan.aggregateReplacementCount,
+    aggregatePressureEngaged: plan.aggregatePressureExceeded,
+    aggregateBudgetChars,
   };
 }
 
@@ -450,8 +528,10 @@ function calculateRecoveryAggregateToolResultChars(
   return Math.max(
     1,
     aggregateMaxCharsOverride ??
-      maxCharsOverride ??
-      calculateMaxToolResultChars(contextWindowTokens),
+      resolveLiveToolResultAggregateMaxChars({
+        contextWindowTokens,
+        perResultMaxChars: maxCharsOverride ?? calculateMaxToolResultChars(contextWindowTokens),
+      }),
   );
 }
 
@@ -600,7 +680,7 @@ function buildAggregateToolResultReplacements(params: {
   aggregateBudgetChars: number;
   minKeepChars?: number;
   protectTrailingToolResults?: boolean;
-}): ToolResultReplacement[] {
+}): { replacements: ToolResultReplacement[]; pressureExceeded: boolean } {
   const minKeepChars = params.minKeepChars ?? MIN_KEEP_CHARS;
   const protectedEntryIds = params.protectTrailingToolResults
     ? getTrailingToolResultEntryIds(params.branch)
@@ -629,7 +709,7 @@ function buildAggregateToolResultReplacements(params: {
     .filter((item) => item.textLength > 0);
 
   if (candidates.length < 2) {
-    return [];
+    return { replacements: [], pressureExceeded: false };
   }
 
   const suffixFactory =
@@ -641,7 +721,7 @@ function buildAggregateToolResultReplacements(params: {
 
   const totalChars = candidates.reduce((sum, item) => sum + item.textLength, 0);
   if (totalChars <= params.aggregateBudgetChars) {
-    return [];
+    return { replacements: [], pressureExceeded: false };
   }
 
   let remainingReduction = totalChars - params.aggregateBudgetChars;
@@ -658,16 +738,6 @@ function buildAggregateToolResultReplacements(params: {
     ...aggregateRecoveryCandidates.filter((item) => item.aggregateEligible),
     ...(protectedEntryIds.size > 0
       ? aggregateRecoveryCandidates.filter((item) => !item.aggregateEligible)
-      : []),
-    ...(protectedEntryIds.size > 0
-      ? candidates
-          .filter((item) => item.protectedFromAggregateRecovery)
-          .toSorted((a, b) => {
-            if (a.index !== b.index) {
-              return a.index - b.index;
-            }
-            return b.textLength - a.textLength;
-          })
       : []),
   ];
 
@@ -726,18 +796,22 @@ function buildAggregateToolResultReplacements(params: {
     }
   }
 
-  return replacements;
+  return { replacements, pressureExceeded: true };
 }
 
 function getTrailingToolResultEntryIds(branch: ToolResultBranchEntry[]): Set<string> {
   const ids = new Set<string>();
+  let sawMessage = false;
   for (let index = branch.length - 1; index >= 0; index--) {
     const entry = branch[index];
-    if (
-      entry?.type !== "message" ||
-      !entry.message ||
-      (entry.message as { role?: string }).role !== "toolResult"
-    ) {
+    if (entry?.type !== "message" || !entry.message) {
+      if (!sawMessage) {
+        continue;
+      }
+      break;
+    }
+    sawMessage = true;
+    if ((entry.message as { role?: string }).role !== "toolResult") {
       break;
     }
     ids.add(entry.id);
@@ -775,6 +849,7 @@ function buildOversizedToolResultReplacements(params: {
   branch: ToolResultBranchEntry[];
   maxChars: number;
   minKeepChars?: number;
+  protectedEntryIds?: Set<string>;
 }): ToolResultReplacement[] {
   const minKeepChars = params.minKeepChars ?? MIN_KEEP_CHARS;
   const replacements: ToolResultReplacement[] = [];
@@ -790,10 +865,13 @@ function buildOversizedToolResultReplacements(params: {
     if (getToolResultTextLength(msg) <= params.maxChars) {
       continue;
     }
+    const replacementMinKeepChars = params.protectedEntryIds?.has(entry.id)
+      ? Math.max(minKeepChars, MIN_KEEP_CHARS)
+      : minKeepChars;
     replacements.push({
       entryId: entry.id,
       message: truncateToolResultMessage(msg, params.maxChars, {
-        minKeepChars,
+        minKeepChars: replacementMinKeepChars,
       }),
     });
   }
@@ -857,14 +935,19 @@ function buildToolResultReplacementPlan(params: {
   replacements: ToolResultReplacement[];
   oversizedReplacementCount: number;
   aggregateReplacementCount: number;
+  aggregatePressureExceeded: boolean;
   oversizedReducibleChars: number;
   aggregateReducibleChars: number;
 } {
   const minKeepChars = params.minKeepChars ?? MIN_KEEP_CHARS;
+  const protectedEntryIds = params.protectTrailingToolResults
+    ? getTrailingToolResultEntryIds(params.branch)
+    : undefined;
   const oversizedReplacements = buildOversizedToolResultReplacements({
     branch: params.branch,
     maxChars: params.maxChars,
     minKeepChars,
+    protectedEntryIds,
   });
   const oversizedReducibleChars = calculateReplacementReduction(
     params.branch,
@@ -874,12 +957,13 @@ function buildToolResultReplacementPlan(params: {
     params.branch,
     oversizedReplacements,
   );
-  const aggregateReplacements = buildAggregateToolResultReplacements({
+  const aggregatePlan = buildAggregateToolResultReplacements({
     branch: oversizedTrimmedBranch,
     aggregateBudgetChars: params.aggregateBudgetChars,
     minKeepChars,
     protectTrailingToolResults: params.protectTrailingToolResults,
   });
+  const aggregateReplacements = aggregatePlan.replacements;
   const aggregateReducibleChars = calculateReplacementReduction(
     oversizedTrimmedBranch,
     aggregateReplacements,
@@ -889,6 +973,7 @@ function buildToolResultReplacementPlan(params: {
     replacements: [...oversizedReplacements, ...aggregateReplacements],
     oversizedReplacementCount: oversizedReplacements.length,
     aggregateReplacementCount: aggregateReplacements.length,
+    aggregatePressureExceeded: aggregatePlan.pressureExceeded,
     oversizedReducibleChars,
     aggregateReducibleChars,
   };
@@ -953,6 +1038,7 @@ function truncateOversizedToolResultsInExistingSessionManager(params: {
   contextWindowTokens: number;
   maxCharsOverride?: number;
   aggregateMaxCharsOverride?: number;
+  protectTrailingToolResults?: boolean;
   sessionFile?: string;
   sessionId?: string;
   sessionKey?: string;
@@ -979,6 +1065,7 @@ function truncateOversizedToolResultsInExistingSessionManager(params: {
     maxChars,
     aggregateBudgetChars,
     minKeepChars: RECOVERY_MIN_KEEP_CHARS,
+    protectTrailingToolResults: params.protectTrailingToolResults,
   });
   if (plan.replacements.length === 0) {
     return {
@@ -1008,12 +1095,16 @@ function truncateOversizedToolResultsInExistingSessionManager(params: {
     });
   }
 
-  log.info(
-    `[tool-result-truncation] Truncated ${rewriteResult.rewrittenEntries} tool result(s) in session ` +
-      `(contextWindow=${contextWindowTokens} maxChars=${maxChars} aggregateBudgetChars=${aggregateBudgetChars} ` +
-      `oversized=${plan.oversizedReplacementCount} aggregate=${plan.aggregateReplacementCount}) ` +
-      `sessionKey=${params.sessionKey ?? params.sessionId ?? "unknown"}`,
-  );
+  logToolResultSessionTruncation({
+    rewrittenEntries: rewriteResult.rewrittenEntries,
+    contextWindowTokens,
+    maxChars,
+    aggregateBudgetChars,
+    oversizedReplacementCount: plan.oversizedReplacementCount,
+    aggregateReplacementCount: plan.aggregateReplacementCount,
+    sessionKey: params.sessionKey,
+    sessionId: params.sessionId,
+  });
 
   return {
     truncated: rewriteResult.changed,
@@ -1028,6 +1119,7 @@ async function truncateOversizedToolResultsInTranscriptState(params: {
   contextWindowTokens: number;
   maxCharsOverride?: number;
   aggregateMaxCharsOverride?: number;
+  protectTrailingToolResults?: boolean;
   sessionId?: string;
   sessionKey?: string;
   agentId?: string;
@@ -1054,6 +1146,7 @@ async function truncateOversizedToolResultsInTranscriptState(params: {
     maxChars,
     aggregateBudgetChars,
     minKeepChars: RECOVERY_MIN_KEEP_CHARS,
+    protectTrailingToolResults: params.protectTrailingToolResults,
   });
   if (plan.replacements.length === 0) {
     return {
@@ -1088,12 +1181,16 @@ async function truncateOversizedToolResultsInTranscriptState(params: {
     });
   }
 
-  log.info(
-    `[tool-result-truncation] Truncated ${rewriteResult.rewrittenEntries} tool result(s) in session ` +
-      `(contextWindow=${contextWindowTokens} maxChars=${maxChars} aggregateBudgetChars=${aggregateBudgetChars} ` +
-      `oversized=${plan.oversizedReplacementCount} aggregate=${plan.aggregateReplacementCount}) ` +
-      `sessionKey=${params.sessionKey ?? params.sessionId ?? "unknown"}`,
-  );
+  logToolResultSessionTruncation({
+    rewrittenEntries: rewriteResult.rewrittenEntries,
+    contextWindowTokens,
+    maxChars,
+    aggregateBudgetChars,
+    oversizedReplacementCount: plan.oversizedReplacementCount,
+    aggregateReplacementCount: plan.aggregateReplacementCount,
+    sessionKey: params.sessionKey,
+    sessionId: params.sessionId,
+  });
 
   return {
     truncated: rewriteResult.changed,
@@ -1107,6 +1204,7 @@ export function truncateOversizedToolResultsInSessionManager(params: {
   contextWindowTokens: number;
   maxCharsOverride?: number;
   aggregateMaxCharsOverride?: number;
+  protectTrailingToolResults?: boolean;
   sessionFile?: string;
   sessionId?: string;
   sessionKey?: string;
@@ -1129,6 +1227,7 @@ export async function truncateOversizedToolResultsInSession(params: {
   contextWindowTokens: number;
   maxCharsOverride?: number;
   aggregateMaxCharsOverride?: number;
+  protectTrailingToolResults?: boolean;
   sessionId?: string;
   sessionKey?: string;
   agentId?: string;
@@ -1148,6 +1247,7 @@ export async function truncateOversizedToolResultsInSession(params: {
       contextWindowTokens,
       maxCharsOverride: params.maxCharsOverride,
       aggregateMaxCharsOverride: params.aggregateMaxCharsOverride,
+      protectTrailingToolResults: params.protectTrailingToolResults,
       sessionFile,
       sessionId: params.sessionId,
       sessionKey: params.sessionKey,


### PR DESCRIPTION
## What Problem This Solves

Fixes #100042.

OpenClaw had a unit mismatch between window-relative compaction and an absolute aggregate tool-result cap. Large `contextWindow` sessions could hit the 256k-char aggregate tool-result clamp on every model call long before window-relative compaction saw pressure, silently truncating even fresh tool output to empty content while only emitting an INFO-level signal.

## Why This Change Was Made

The aggregate tool-result budget now scales with the model context window: `max(perResultMaxChars * 4, floor(contextWindowTokens * 4 * 0.5))`. The 0.5 share mirrors safeguard compaction `maxHistoryShare` and `SINGLE_TOOL_RESULT_CONTEXT_SHARE`, while the 4x per-result floor preserves existing small-window behavior.

Trailing tool results are structurally excluded from aggregate clearing and protected with the 2000-char min-keep floor when truncation is still needed. Protected trailing aggregate pressure is reported separately from destructive replacements, so fresh output can request compaction without being erased.

Aggregate engagement is routed through the existing precheck overflow recovery as `compact_then_truncate`, so the session performs real compaction and then runs the persistent tool-result truncation backstop for forward progress. Failure mode is bounded: `MAX_OVERFLOW_COMPACTION_ATTEMPTS = 3`, then one persistent truncation attempt, then explicit give-up with the existing blocked context-overflow response; no unbounded compaction loop.

## User Impact

Large-`contextWindow` sessions no longer silently lose fresh tool output just because the absolute aggregate cap was hit. Operators get a once-per-session WARN with `/compact` and `/new` hints when aggregate pressure engages. Small-window behavior is unchanged because the old 4x aggregate floor is preserved.

## Evidence

Field evidence for the failure mode is documented in issue #100042.

Verification run after the final rebase:

- `pnpm tsgo` — passed, exit code 0.
- `node scripts/run-vitest.mjs src/agents/embedded-agent-runner/tool-result-truncation.test.ts` — passed, 47 tests.
- `node scripts/run-vitest.mjs src/agents/embedded-agent-runner/run/attempt.spawn-workspace.context-engine.test.ts` — passed, 69 tests.
- `git diff --check` — passed.
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main --prompt-file <issue-context>` — clean, no accepted/actionable findings.
