### PR TITLE
chore: update oxlint tsgolint

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -87,7 +87,7 @@
     "typescript/prefer-promise-reject-errors": "error",
     "typescript/restrict-plus-operands": "error",
     "typescript/no-unnecessary-qualifier": "error",
-    "typescript/no-unnecessary-type-assertion": "error",
+    "typescript/no-unnecessary-type-assertion": "off",
     "typescript/no-unnecessary-type-arguments": "error",
     "typescript/no-unnecessary-type-constraint": "error",
     "typescript/no-unnecessary-type-conversion": "error",

--- a/apps/shared/OpenClawKit/Sources/OpenClawKit/Resources/CanvasA2UI/a2ui.bundle.js
+++ b/apps/shared/OpenClawKit/Sources/OpenClawKit/Resources/CanvasA2UI/a2ui.bundle.js
@@ -656,11 +656,12 @@ var ZodType = class {
 			data,
 			parsedType: getParsedType(data)
 		};
-		return handleResult(ctx, this._parseSync({
+		const result = this._parseSync({
 			data,
 			path: ctx.path,
 			parent: ctx
-		}));
+		});
+		return handleResult(ctx, result);
 	}
 	"~validate"(data) {
 		const ctx = {
@@ -717,7 +718,8 @@ var ZodType = class {
 			path: ctx.path,
 			parent: ctx
 		});
-		return handleResult(ctx, await (isAsync(maybeAsyncResult) ? maybeAsyncResult : Promise.resolve(maybeAsyncResult)));
+		const result = await (isAsync(maybeAsyncResult) ? maybeAsyncResult : Promise.resolve(maybeAsyncResult));
+		return handleResult(ctx, result);
 	}
 	refine(check, message) {
 		const getIssueProperties = (val) => {
@@ -3270,7 +3272,8 @@ var ZodPromise = class extends ZodType {
 			});
 			return INVALID;
 		}
-		return OK((ctx.parsedType === ZodParsedType.promise ? ctx.data : Promise.resolve(ctx.data)).then((data) => {
+		const promisified = ctx.parsedType === ZodParsedType.promise ? ctx.data : Promise.resolve(ctx.data);
+		return OK(promisified.then((data) => {
 			return this._def.type.parseAsync(data, {
 				path: ctx.path,
 				errorMap: ctx.common.contextualErrorMap
@@ -3744,35 +3747,23 @@ const DataValueMapItemSchema = lazyType(() => objectType({
 		message: `Value map item must have exactly one value property (valueString, valueNumber, valueBoolean, valueMap), found ${count}.`
 	});
 }));
-const DataValueSchema = objectType({
-	key: stringType(),
-	valueString: stringType().optional(),
-	valueNumber: numberType().optional(),
-	valueBoolean: booleanType().optional(),
-	valueMap: arrayType(DataValueMapItemSchema).optional()
-}).strict().superRefine((val, ctx) => {
-	let count = 0;
-	if (val.valueString !== void 0) count++;
-	if (val.valueNumber !== void 0) count++;
-	if (val.valueBoolean !== void 0) count++;
-	if (val.valueMap !== void 0) count++;
-	if (count !== 1) ctx.addIssue({
-		code: ZodIssueCode.custom,
-		message: `Value must have exactly one value property (valueString, valueNumber, valueBoolean, valueMap), found ${count}.`
+function createDataValueSchema(options = {}) {
+	const maxDepth = options.maxDepth ?? 5;
+	return DataValueMapItemSchema.superRefine((val, ctx) => {
+		const checkDepth = (v, currentDepth) => {
+			if (currentDepth > maxDepth) {
+				ctx.addIssue({
+					code: ZodIssueCode.custom,
+					message: `valueMap recursion exceeded maximum depth of ${maxDepth}.`
+				});
+				return;
+			}
+			if (v.valueMap && Array.isArray(v.valueMap)) for (const item of v.valueMap) checkDepth(item, currentDepth + 1);
+		};
+		checkDepth(val, 1);
 	});
-}).superRefine((val, ctx) => {
-	const checkDepth = (v, currentDepth) => {
-		if (currentDepth > 5) {
-			ctx.addIssue({
-				code: ZodIssueCode.custom,
-				message: "valueMap recursion exceeded maximum depth of 5."
-			});
-			return;
-		}
-		if (v.valueMap && Array.isArray(v.valueMap)) for (const item of v.valueMap) checkDepth(item, currentDepth + 1);
-	};
-	checkDepth(val, 1);
-});
+}
+const DataValueSchema = createDataValueSchema();
 objectType({
 	path: stringType().optional(),
 	literalNumber: numberType().optional(),
@@ -5551,7 +5542,7 @@ var Signal;
 * (though, see deep.ts for nested / deep behavior)
 */
 const createStorage = (initial = null) => new Signal.State(initial, { equals: () => false });
-const ARRAY_GETTER_METHODS = new Set([
+const ARRAY_GETTER_METHODS = /* @__PURE__ */ new Set([
 	Symbol.iterator,
 	"concat",
 	"entries",
@@ -5574,7 +5565,7 @@ const ARRAY_GETTER_METHODS = new Set([
 	"some",
 	"values"
 ]);
-const ARRAY_WRITE_THEN_READ_METHODS = new Set([
+const ARRAY_WRITE_THEN_READ_METHODS = /* @__PURE__ */ new Set([
 	"fill",
 	"push",
 	"unshift"
@@ -6702,8 +6693,10 @@ var i$5 = class {
 * SPDX-License-Identifier: BSD-3-Clause
 */ const { I: t$2 } = j$1, i$4 = (o) => o, n$6 = (o) => null === o || "object" != typeof o && "function" != typeof o, r$4 = (o) => void 0 === o.strings, s$5 = () => document.createComment(""), v = (o, n, e) => {
 	const l = o._$AA.parentNode, d = void 0 === n ? o._$AB : n._$AA;
-	if (void 0 === e) e = new t$2(l.insertBefore(s$5(), d), l.insertBefore(s$5(), d), o, o.options);
-	else {
+	if (void 0 === e) {
+		const i = l.insertBefore(s$5(), d), n = l.insertBefore(s$5(), d);
+		e = new t$2(i, n, o, o.options);
+	} else {
 		const t = e._$AB.nextSibling, n = e._$AM, c = n !== o;
 		if (c) {
 			let t;
@@ -7313,7 +7306,8 @@ let Root = (() => {
 				if (this.#lightDomEffectDisposer) this.#lightDomEffectDisposer();
 				this.#lightDomEffectDisposer = effect(() => {
 					const allChildren = this.childComponents ?? null;
-					D(this.renderComponentTree(allChildren), this, { host: this });
+					const lightDomTemplate = this.renderComponentTree(allChildren);
+					D(lightDomTemplate, this, { host: this });
 				});
 			}
 		}
@@ -9259,8 +9253,9 @@ var __runInitializers$10 = function(thisArg, initializers, value) {
 			return b`(empty)`;
 		}
 		render() {
+			const classes = merge(this.theme.components.Image.all, this.usageHint ? this.theme.components.Image[this.usageHint] : {});
 			return b`<section
-      class=${e$2(merge(this.theme.components.Image.all, this.usageHint ? this.theme.components.Image[this.usageHint] : {}))}
+      class=${e$2(classes)}
       style=${o$2({
 				...this.theme.additionalStyles?.Image ?? {},
 				"--object-fit": this.fit ?? "fill"
@@ -9952,10 +9947,11 @@ var __runInitializers$8 = function(thisArg, initializers, value) {
         </div>
       `;
 			const count = currentSelections.length;
+			const headerText = count > 0 ? `${count} Selected` : this.description ?? "Select items";
 			return b`
       <div class="container">
         <div class="dropdown-header" @click=${() => this.isOpen = !this.isOpen}>
-          <span class="header-text">${count > 0 ? `${count} Selected` : this.description ?? "Select items"}</span>
+          <span class="header-text">${headerText}</span>
           <span class="chevron ${this.isOpen ? "open" : ""}">
             <svg
               xmlns="http://www.w3.org/2000/svg"
@@ -9974,9 +9970,10 @@ var __runInitializers$8 = function(thisArg, initializers, value) {
           <div class="options-scroll-container">
             ${filteredOptions.map((option) => {
 				const label = extractStringValue(option.label, this.component, this.processor, this.surfaceId);
+				const isSelected = currentSelections.includes(option.value);
 				return b`
                 <div
-                  class="option-item ${currentSelections.includes(option.value) ? "selected" : ""}"
+                  class="option-item ${isSelected ? "selected" : ""}"
                   @click=${(e) => {
 					e.stopPropagation();
 					this.toggleSelection(option.value);
@@ -11535,21 +11532,26 @@ const markdown$1 = e$6(class MarkdownDirective extends i$5 {
 	* if present. Otherwise, it returns the value wrapped in a span.
 	*/
 	render(value, markdownRenderer, markdownOptions) {
-		if (markdownRenderer) return m(markdownRenderer(value, markdownOptions).then((value) => {
-			return o(value);
-		}), b`<span class="no-markdown-renderer">${value}</span>`);
-		return m((async () => {
+		if (markdownRenderer) {
+			const rendered = markdownRenderer(value, markdownOptions).then((value) => {
+				return o(value);
+			});
+			return m(rendered, b`<span class="no-markdown-renderer">${value}</span>`);
+		}
+		const dynamicRendererPromise = (async () => {
 			try {
 				const { renderMarkdown } = await import("@a2ui/markdown-it");
-				return o(await renderMarkdown(value, markdownOptions));
-			} catch (e) {
+				const rendered = await renderMarkdown(value, markdownOptions);
+				return o(rendered);
+			} catch {
 				if (!MarkdownDirective.defaultMarkdownWarningLogged) {
 					console.warn("[MarkdownDirective] Failed to load optional `@a2ui/markdown-it` renderer. Using fallback regex.");
 					MarkdownDirective.defaultMarkdownWarningLogged = true;
 				}
 				return b`<span class="no-markdown-renderer">${value}</span>`;
 			}
-		})(), b`<span class="no-markdown-renderer">${value}</span>`);
+		})();
+		return m(dynamicRendererPromise, b`<span class="no-markdown-renderer">${value}</span>`);
 	}
 });
 /**
@@ -11778,8 +11780,9 @@ var __runInitializers$1 = function(thisArg, initializers, value) {
 			return additionalStyles;
 		}
 		render() {
+			const classes = merge(this.theme.components.Text.all, this.usageHint ? this.theme.components.Text[this.usageHint] : {});
 			return b`<section
-      class=${e$2(merge(this.theme.components.Text.all, this.usageHint ? this.theme.components.Text[this.usageHint] : {}))}
+      class=${e$2(classes)}
       style=${this.theme.additionalStyles?.Text ? o$2(this.#getAdditionalStyles()) : A}
     >
       ${this.#renderText()}

--- a/package.json
+++ b/package.json
@@ -2049,7 +2049,7 @@
     "lit": "3.3.3",
     "oxfmt": "0.57.0",
     "oxlint": "1.72.0",
-    "oxlint-tsgolint": "0.23.0",
+    "oxlint-tsgolint": "0.24.0",
     "shiki": "4.3.0",
     "signal-utils": "0.21.1",
     "sigstore": "4.1.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -277,10 +277,10 @@ importers:
         version: 0.57.0
       oxlint:
         specifier: 1.72.0
-        version: 1.72.0(oxlint-tsgolint@0.23.0)
+        version: 1.72.0(oxlint-tsgolint@0.24.0)
       oxlint-tsgolint:
-        specifier: 0.23.0
-        version: 0.23.0
+        specifier: 0.24.0
+        version: 0.24.0
       shiki:
         specifier: 4.3.0
         version: 4.3.0
@@ -3442,33 +3442,33 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@oxlint-tsgolint/darwin-arm64@0.23.0':
-    resolution: {integrity: sha512-gOs9PVr2wEg4ox9z0aJo+RKhhImW86YL5N6yav8BK/rgPsIrwN/igSZ+pbRr723NFvUNKde9fgMhRA6JrXAOZw==}
+  '@oxlint-tsgolint/darwin-arm64@0.24.0':
+    resolution: {integrity: sha512-C2uMmwK5Bc4ri4ysZ6sA8Rcu+A5zBQTp6ml2u0CLLbRZp4kMFPV3yWk8B5DK9Aw7y9bbjogIm75tUwGLFzlsYQ==}
     cpu: [arm64]
     os: [darwin]
 
-  '@oxlint-tsgolint/darwin-x64@0.23.0':
-    resolution: {integrity: sha512-kjJ8B+7n4tB9VJdxS5A9GdJt6/bYpzbu4lXp2uO1S3sRmCB5gDEABlGoiePNApRWaW+xqL4b4xgiE727jSLhuA==}
+  '@oxlint-tsgolint/darwin-x64@0.24.0':
+    resolution: {integrity: sha512-Wgvt/1lRbDxmoNqWQKKcL+UIiqLmdJ+EWLpQa1qzoNVAfNB0PJpa82/8dH1twT/3rSs4zrP5TXPWl4juB71WuQ==}
     cpu: [x64]
     os: [darwin]
 
-  '@oxlint-tsgolint/linux-arm64@0.23.0':
-    resolution: {integrity: sha512-6dCZuKNu135seMXilkRk9SpCx6i1XgmiipYGalLij5WVRX6ZYS8c4xI7preN/zv9fCXhsQclTIMDu2Y/cytTjw==}
+  '@oxlint-tsgolint/linux-arm64@0.24.0':
+    resolution: {integrity: sha512-PB1rxII7KV83+ASY4sSkXtqvpij6ME66+QCRL49uksi/ofs2Rf/UVboYr095n0Rkbl2wgvlsHGl6DHC361jQUQ==}
     cpu: [arm64]
     os: [linux]
 
-  '@oxlint-tsgolint/linux-x64@0.23.0':
-    resolution: {integrity: sha512-3bdilnyA7kmSTjK27rvjIjSxL5SIg3wt7vwNiRkouWB83ytssyKnuGvxSYJxgMEmFpSutzaBzcCUM2jDtPGcgA==}
+  '@oxlint-tsgolint/linux-x64@0.24.0':
+    resolution: {integrity: sha512-xcz3CxKmjTQLREtE/UShh+ruWmm9nAb7UM9zKcD65BStiuYgOakAKkPHl4YS5DztpVcDrE0+HqbOolTlRKYWmw==}
     cpu: [x64]
     os: [linux]
 
-  '@oxlint-tsgolint/win32-arm64@0.23.0':
-    resolution: {integrity: sha512-j+OEp44SVYiQ+ZD+uttsX7u6L9SvmbbQ77SO1pSFCcJlsVMeCk8qZsjhKfGKuT/jIA+ipOJMVs/+pqUfObBWNw==}
+  '@oxlint-tsgolint/win32-arm64@0.24.0':
+    resolution: {integrity: sha512-A2i6ZGBec3i20S7RaxkgHc6r3HYtD5Mn7j/mb22NkTz14u0JuudvTu6JggAnbGMcv8+dBKQI//EasxSPJLD8pw==}
     cpu: [arm64]
     os: [win32]
 
-  '@oxlint-tsgolint/win32-x64@0.23.0':
-    resolution: {integrity: sha512-5MyjFuqf+g8OUPJBSGWHJtmoWnzFJYyOg4To9WMQshZYEWig/vtu7JtJ03VWnzHv9LJkAUeApY0gVCOywFR/iQ==}
+  '@oxlint-tsgolint/win32-x64@0.24.0':
+    resolution: {integrity: sha512-0ZbGd9qRB6zs82moekaKdEvncRANq49EAwfNX62JpTS46feXUhKAuoyVDvZMj6Rywejylrmmu79Wo6faYCo4Ew==}
     cpu: [x64]
     os: [win32]
 
@@ -6356,8 +6356,8 @@ packages:
       vite-plus:
         optional: true
 
-  oxlint-tsgolint@0.23.0:
-    resolution: {integrity: sha512-3mBv3CoPbh8dFbzfDGIWa2ytZjn2v+3EX4aKRXjIhsoGFzG8GCjfRirz3rwZf1wYbZzsNLTSgpw8VjQuWdp/jA==}
+  oxlint-tsgolint@0.24.0:
+    resolution: {integrity: sha512-giCk5sEvG02d5tzPmFMX3hem8ndzEEu1xvGYS5OwNfO2WGl6ZVxt5LjE0yiMDoz94INI7XkXwgFAQiydPvVHDw==}
     hasBin: true
 
   oxlint@1.72.0:
@@ -9207,22 +9207,22 @@ snapshots:
   '@oxfmt/binding-win32-x64-msvc@0.57.0':
     optional: true
 
-  '@oxlint-tsgolint/darwin-arm64@0.23.0':
+  '@oxlint-tsgolint/darwin-arm64@0.24.0':
     optional: true
 
-  '@oxlint-tsgolint/darwin-x64@0.23.0':
+  '@oxlint-tsgolint/darwin-x64@0.24.0':
     optional: true
 
-  '@oxlint-tsgolint/linux-arm64@0.23.0':
+  '@oxlint-tsgolint/linux-arm64@0.24.0':
     optional: true
 
-  '@oxlint-tsgolint/linux-x64@0.23.0':
+  '@oxlint-tsgolint/linux-x64@0.24.0':
     optional: true
 
-  '@oxlint-tsgolint/win32-arm64@0.23.0':
+  '@oxlint-tsgolint/win32-arm64@0.24.0':
     optional: true
 
-  '@oxlint-tsgolint/win32-x64@0.23.0':
+  '@oxlint-tsgolint/win32-x64@0.24.0':
     optional: true
 
   '@oxlint/binding-android-arm-eabi@1.72.0':
@@ -12401,16 +12401,16 @@ snapshots:
       '@oxfmt/binding-win32-ia32-msvc': 0.57.0
       '@oxfmt/binding-win32-x64-msvc': 0.57.0
 
-  oxlint-tsgolint@0.23.0:
+  oxlint-tsgolint@0.24.0:
     optionalDependencies:
-      '@oxlint-tsgolint/darwin-arm64': 0.23.0
-      '@oxlint-tsgolint/darwin-x64': 0.23.0
-      '@oxlint-tsgolint/linux-arm64': 0.23.0
-      '@oxlint-tsgolint/linux-x64': 0.23.0
-      '@oxlint-tsgolint/win32-arm64': 0.23.0
-      '@oxlint-tsgolint/win32-x64': 0.23.0
+      '@oxlint-tsgolint/darwin-arm64': 0.24.0
+      '@oxlint-tsgolint/darwin-x64': 0.24.0
+      '@oxlint-tsgolint/linux-arm64': 0.24.0
+      '@oxlint-tsgolint/linux-x64': 0.24.0
+      '@oxlint-tsgolint/win32-arm64': 0.24.0
+      '@oxlint-tsgolint/win32-x64': 0.24.0
 
-  oxlint@1.72.0(oxlint-tsgolint@0.23.0):
+  oxlint@1.72.0(oxlint-tsgolint@0.24.0):
     optionalDependencies:
       '@oxlint/binding-android-arm-eabi': 1.72.0
       '@oxlint/binding-android-arm64': 1.72.0
@@ -12431,7 +12431,7 @@ snapshots:
       '@oxlint/binding-win32-arm64-msvc': 1.72.0
       '@oxlint/binding-win32-ia32-msvc': 1.72.0
       '@oxlint/binding-win32-x64-msvc': 1.72.0
-      oxlint-tsgolint: 0.23.0
+      oxlint-tsgolint: 0.24.0
 
   p-finally@1.0.0: {}
 


### PR DESCRIPTION
## What Problem This Solves

The dependency refresh landed in #100027 with `oxlint-tsgolint` held at 0.23.0 because 0.24.0 newly reports thousands of `typescript/no-unnecessary-type-assertion` findings. Applying its autofixes is unsafe: the repository-wide typecheck then fails because many assertions are load-bearing for inference and public/package boundary compilation.

Follow-up to #100027 and #99952.

## Why This Change Was Made

- Updates `oxlint-tsgolint` and all platform packages to 0.24.0.
- Temporarily disables only `typescript/no-unnecessary-type-assertion`; all other configured oxlint rules remain active.
- Preserves existing assertions instead of accepting type-breaking autofixes.
- Syncs the deterministic native Canvas A2UI bundle required by the all-lanes generated-resource gate.

The 0.24.0 rule regression is tracked upstream in [#1044](https://github.com/oxc-project/tsgolint/issues/1044), [#1047](https://github.com/oxc-project/tsgolint/issues/1047), and [#1053](https://github.com/oxc-project/tsgolint/issues/1053).

## User Impact

No runtime behavior change. Maintainers get the current tsgolint binary while lint stays clean and the typecheck remains sound. The affected assertion rule can be re-enabled after the upstream false positives are fixed.

## Evidence

- Blacksmith Testbox-through-Crabbox: `tbx_01kwqbxatqvhg4fmfkc5gwb0mn`
- [Actions hydration/proof run 28718184872](https://github.com/openclaw/openclaw/actions/runs/28718184872)
- `pnpm check:changed`: passed all selected lanes
- Full project typecheck: passed
- Oxlint: core 0 warnings/errors; extensions 0 warnings/errors; scripts 0 warnings/errors
- Runtime import cycles: 0
- Focused tooling tests: 39 passed
- Autoreview: clean, 0.98 confidence
