### PR TITLE
fix(tooling): accept pnpm separator in web fetch benchmark

### DIFF
--- a/scripts/bench-web-fetch.ts
+++ b/scripts/bench-web-fetch.ts
@@ -7,6 +7,7 @@ import { createWebFetchTool } from "../src/agents/tools/web-fetch.js";
 import type { OpenClawConfig } from "../src/config/types.openclaw.js";
 import type { LookupFn } from "../src/infra/net/ssrf.js";
 import { extractReadableContent } from "../src/web-fetch/content-extractors.runtime.js";
+import { stripLeadingPackageManagerSeparator } from "./lib/arg-utils.mjs";
 
 type BenchmarkCaseId =
   | "tool-create"
@@ -204,13 +205,14 @@ function parseFlagValue(flag: string, args: string[]): string | undefined {
 }
 
 function parseOptions(args = process.argv.slice(2)): Options {
-  validateArgs(args);
+  const normalizedArgs = stripLeadingPackageManagerSeparator(args);
+  validateArgs(normalizedArgs);
   return {
-    cases: parseCases(args),
-    json: args.includes("--json"),
-    output: parseFlagValue("--output", args),
-    runs: parsePositiveInteger("--runs", 20, args),
-    warmup: parseNonNegativeInteger("--warmup", 3, args),
+    cases: parseCases(normalizedArgs),
+    json: normalizedArgs.includes("--json"),
+    output: parseFlagValue("--output", normalizedArgs),
+    runs: parsePositiveInteger("--runs", 20, normalizedArgs),
+    warmup: parseNonNegativeInteger("--warmup", 3, normalizedArgs),
   };
 }
 

--- a/test/scripts/bench-web-fetch.test.ts
+++ b/test/scripts/bench-web-fetch.test.ts
@@ -1,0 +1,53 @@
+// Bench Web Fetch tests cover the offline benchmark CLI contract.
+import { spawnSync } from "node:child_process";
+import { describe, expect, it } from "vitest";
+
+const SCRIPT_PATH = "scripts/bench-web-fetch.ts";
+
+function runBenchWebFetch(...args: string[]) {
+  return spawnSync(process.execPath, ["--import", "tsx", SCRIPT_PATH, ...args], {
+    cwd: process.cwd(),
+    encoding: "utf8",
+    env: {
+      ...process.env,
+      FIRECRAWL_API_KEY: "test-firecrawl-key-that-should-be-ignored",
+      NODE_NO_WARNINGS: "1",
+    },
+  });
+}
+
+describe("web fetch benchmark script", () => {
+  it("accepts the package-manager separator documented for pnpm scripts", () => {
+    const result = runBenchWebFetch(
+      "--",
+      "--case",
+      "tool-create",
+      "--runs",
+      "1",
+      "--warmup",
+      "0",
+      "--json",
+    );
+
+    expect(result.status).toBe(0);
+    expect(result.stderr).toBe("");
+    const report = JSON.parse(result.stdout) as {
+      cases: Array<{ id: string; samplesMs: number[] }>;
+    };
+    expect(report.cases).toHaveLength(1);
+    expect(report.cases[0]).toMatchObject({
+      id: "tool-create",
+      samplesMs: expect.any(Array),
+    });
+    expect(report.cases[0]?.samplesMs).toHaveLength(1);
+  });
+
+  it("rejects duplicate singular flags without a stack trace", () => {
+    const result = runBenchWebFetch("--runs", "1", "--runs", "2");
+
+    expect(result.status).toBe(2);
+    expect(result.stdout).toBe("");
+    expect(result.stderr.trim()).toBe("--runs was provided more than once");
+    expect(result.stderr).not.toContain("\n    at ");
+  });
+});


### PR DESCRIPTION
Summary
- Accept the leading package-manager `--` separator in `scripts/bench-web-fetch.ts`, matching the documented `pnpm perf:web-fetch -- ...` usage.
- Add a focused process-level regression test for the separator path and duplicate singular flag errors.

Verification
- `git diff --check`
- Testbox `tbx_01kwqc7et5h0ayeyvb7nmbdag4`: `corepack pnpm test:serial test/scripts/bench-web-fetch.test.ts`; `corepack pnpm perf:web-fetch -- --runs 3 --warmup 1`; JSON output smoke; duplicate `--runs` exits 2.
- Testbox `tbx_01kwqc9r82drrxm5sgjm49gf9f`: clean JSON output smoke for `tool-create` and `extract-basic-shell`.
- Testbox `tbx_01kwqcdbafxebdedxps4ebs0ch`: `OPENCLAW_TESTBOX=1 corepack pnpm check:changed`.
- AWS macOS `run_4a9298a661da` / `cbx_d6c8035eee22` (`mac2.metal`, macOS 14.8.7): Node 22.22.0 + pnpm 11.2.2 install, `corepack pnpm build`, `node scripts/check-memory-fd-repro.mjs --files 96 ...`, `node scripts/check-gateway-watch-regression.mjs --skip-build ...`.
