### PR TITLE
[AI-assisted] fix(android): prevent gateway setup button clipping

### DIFF
--- a/apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt
@@ -975,9 +975,9 @@ private fun GatewaySettingsScreen(
       Column(verticalArrangement = Arrangement.spacedBy(10.dp)) {
         Text(text = "Pair New Gateway", style = ClawTheme.type.section, color = ClawTheme.colors.text)
         Text(text = "Clear this phone's saved gateway access and scan a fresh setup code.", style = ClawTheme.type.body, color = ClawTheme.colors.textMuted)
-        Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
-          ClawSecondaryButton(text = "Pair New Gateway", onClick = viewModel::pairNewGateway, modifier = Modifier.weight(1f), icon = Icons.Default.QrCode2)
-          ClawSecondaryButton(text = "Setup Code", onClick = { showSetupCodeHelp = !showSetupCodeHelp }, modifier = Modifier.weight(1f), icon = Icons.Default.Info)
+        Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+          ClawSecondaryButton(text = "Pair New Gateway", onClick = viewModel::pairNewGateway, modifier = Modifier.fillMaxWidth(), icon = Icons.Default.QrCode2)
+          ClawSecondaryButton(text = "Setup Code", onClick = { showSetupCodeHelp = !showSetupCodeHelp }, modifier = Modifier.fillMaxWidth(), icon = Icons.Default.Info)
         }
         if (showSetupCodeHelp) {
           Text(


### PR DESCRIPTION
## What Problem This Solves

The Android Gateway settings screen can clip the longer "Pair New Gateway" action label because it shares a narrow side-by-side button row with "Setup Code".

## Why This Change Was Made

This stacks the gateway setup actions as full-width buttons inside the existing panel, giving the longer label enough horizontal space without changing the action behavior.

## User Impact

Users can read and tap both gateway setup actions without truncated button text on the Android Gateway settings screen.

## Evidence

- Built the Android Play debug APK with `env -u ANDROID_PREFS_ROOT ./gradlew --no-daemon :app:assemblePlayDebug --console=plain`; build succeeded.
- Verified on the lane b API 36 Android emulator: before, the first setup button was clipped as "Pair New Gatew..."; after, "Pair New Gateway" and "Setup Code" render as stacked full-width buttons without clipping.
- Before:

<img width="360" alt="before-gateway-pair-buttons" src="https://github.com/user-attachments/assets/90587ebb-5701-45aa-a579-718cb8f82f1e" />

- After:

<img width="360" alt="after-gateway-pair-buttons" src="https://github.com/user-attachments/assets/16d15fa8-ee2c-4191-9e56-191f9d70e118" />
