### PR TITLE
Doctor: expose write-config blocker findings

### DIFF
--- a/src/flows/doctor-health-contributions.test.ts
+++ b/src/flows/doctor-health-contributions.test.ts
@@ -2783,8 +2783,28 @@ describe("doctor health contributions", () => {
       });
     });
 
-    it("reports an unwritable config directory when the config file is missing", async () => {
-      vi.spyOn(fs, "existsSync").mockReturnValue(false);
+    it("skips a missing config directory when an existing ancestor is writable", async () => {
+      vi.spyOn(fs, "existsSync").mockImplementation((path) => path === "/tmp");
+      const accessSpy = vi.spyOn(fs, "accessSync").mockImplementation(() => undefined);
+
+      await expect(
+        runDoctorLintChecks(
+          {
+            cfg: {},
+            mode: "lint" as const,
+            runtime: { log: vi.fn(), error: vi.fn(), exit: vi.fn() },
+            configPath: "/tmp/openclaw-home/openclaw.json",
+          },
+          { checks: [check], onlyIds: ["core/doctor/write-config"] },
+        ),
+      ).resolves.toMatchObject({
+        findings: [],
+      });
+      expect(accessSpy).toHaveBeenCalledWith("/tmp", fs.constants.W_OK);
+    });
+
+    it("reports an unwritable existing parent when the config file is missing", async () => {
+      vi.spyOn(fs, "existsSync").mockImplementation((path) => path === "/tmp");
       vi.spyOn(fs, "accessSync").mockImplementation(() => {
         throw new Error("EACCES");
       });
@@ -2803,7 +2823,8 @@ describe("doctor health contributions", () => {
         findings: [
           expect.objectContaining({
             checkId: "core/doctor/write-config",
-            path: "/tmp/openclaw-home",
+            path: "/tmp",
+            target: "/tmp/openclaw-home",
             requirement: "writable-config-directory",
           }),
         ],

--- a/src/flows/doctor-health-contributions.test.ts
+++ b/src/flows/doctor-health-contributions.test.ts
@@ -2887,6 +2887,42 @@ describe("doctor health contributions", () => {
       });
       expect(accessSpy).not.toHaveBeenCalled();
     });
+
+    it("reports a dangling symlink that blocks the config directory path", async () => {
+      vi.spyOn(fs, "existsSync").mockImplementation((path) => path === "/tmp");
+      vi.spyOn(fs, "lstatSync").mockImplementation((path) => {
+        if (path === "/tmp/openclaw-home") {
+          return { isDirectory: () => false } as fs.Stats;
+        }
+        throw Object.assign(new Error("ENOENT"), { code: "ENOENT" });
+      });
+      vi.spyOn(fs, "statSync").mockImplementation(() => {
+        throw Object.assign(new Error("ENOENT"), { code: "ENOENT" });
+      });
+      const accessSpy = vi.spyOn(fs, "accessSync").mockImplementation(() => undefined);
+
+      await expect(
+        runDoctorLintChecks(
+          {
+            cfg: {},
+            mode: "lint" as const,
+            runtime: { log: vi.fn(), error: vi.fn(), exit: vi.fn() },
+            configPath: "/tmp/openclaw-home/openclaw.json",
+          },
+          { checks: [check], onlyIds: ["core/doctor/write-config"] },
+        ),
+      ).resolves.toMatchObject({
+        findings: [
+          expect.objectContaining({
+            checkId: "core/doctor/write-config",
+            path: "/tmp/openclaw-home",
+            target: "/tmp/openclaw-home",
+            requirement: "config-directory-path",
+          }),
+        ],
+      });
+      expect(accessSpy).not.toHaveBeenCalled();
+    });
   });
 
   describe("config size drops during update", () => {

--- a/src/flows/doctor-health-contributions.test.ts
+++ b/src/flows/doctor-health-contributions.test.ts
@@ -2775,7 +2775,10 @@ describe("doctor health contributions", () => {
       ).resolves.toMatchObject({
         findings: [],
       });
-      expect(accessSpy).toHaveBeenCalledWith("/tmp/openclaw-home", fs.constants.W_OK);
+      expect(accessSpy).toHaveBeenCalledWith(
+        "/tmp/openclaw-home",
+        fs.constants.W_OK | fs.constants.X_OK,
+      );
     });
 
     it("reports an unwritable config directory for an existing config", async () => {
@@ -2827,13 +2830,43 @@ describe("doctor health contributions", () => {
       ).resolves.toMatchObject({
         findings: [],
       });
-      expect(accessSpy).toHaveBeenCalledWith("/tmp", fs.constants.W_OK);
+      expect(accessSpy).toHaveBeenCalledWith("/tmp", fs.constants.W_OK | fs.constants.X_OK);
     });
 
     it("reports an unwritable existing parent when the config file is missing", async () => {
       vi.spyOn(fs, "existsSync").mockImplementation((path) => path === "/tmp");
       vi.spyOn(fs, "accessSync").mockImplementation(() => {
         throw new Error("EACCES");
+      });
+
+      await expect(
+        runDoctorLintChecks(
+          {
+            cfg: {},
+            mode: "lint" as const,
+            runtime: { log: vi.fn(), error: vi.fn(), exit: vi.fn() },
+            configPath: "/tmp/openclaw-home/openclaw.json",
+          },
+          { checks: [check], onlyIds: ["core/doctor/write-config"] },
+        ),
+      ).resolves.toMatchObject({
+        findings: [
+          expect.objectContaining({
+            checkId: "core/doctor/write-config",
+            path: "/tmp",
+            target: "/tmp/openclaw-home",
+            requirement: "writable-config-directory",
+          }),
+        ],
+      });
+    });
+
+    it("reports an existing parent without search permission", async () => {
+      vi.spyOn(fs, "existsSync").mockImplementation((path) => path === "/tmp");
+      vi.spyOn(fs, "accessSync").mockImplementation((_path, mode) => {
+        if (mode === (fs.constants.W_OK | fs.constants.X_OK)) {
+          throw new Error("EACCES");
+        }
       });
 
       await expect(

--- a/src/flows/doctor-health-contributions.test.ts
+++ b/src/flows/doctor-health-contributions.test.ts
@@ -658,6 +658,7 @@ describe("doctor health contributions", () => {
   });
 
   afterEach(() => {
+    vi.unstubAllEnvs();
     vi.restoreAllMocks();
   });
 
@@ -2701,6 +2702,113 @@ describe("doctor health contributions", () => {
         },
       }),
     ).toBe(false);
+  });
+
+  describe("write-config lint findings", () => {
+    const writeConfigContribution = requireDoctorContribution("doctor:write-config");
+    const check = writeConfigContribution.healthChecks[0] as HealthCheck & {
+      defaultEnabled?: boolean;
+    };
+
+    it("keeps write-config lint opt-in for structured findings", async () => {
+      expect(writeConfigContribution.healthCheckIds).toEqual(["core/doctor/write-config"]);
+      expect(check.defaultEnabled).toBe(false);
+
+      const ctx = {
+        cfg: {},
+        mode: "lint" as const,
+        runtime: { log: vi.fn(), error: vi.fn(), exit: vi.fn() },
+        configPath: "/tmp/fake-openclaw.json",
+      };
+
+      await expect(runDoctorLintChecks(ctx, { checks: [check] })).resolves.toMatchObject({
+        checksRun: 0,
+        checksSkipped: 1,
+        findings: [],
+      });
+    });
+
+    it("reports Nix immutable config mode when selected", async () => {
+      vi.stubEnv("OPENCLAW_NIX_MODE", "1");
+
+      await expect(
+        runDoctorLintChecks(
+          {
+            cfg: {},
+            mode: "lint" as const,
+            runtime: { log: vi.fn(), error: vi.fn(), exit: vi.fn() },
+            configPath: "/tmp/fake-openclaw.json",
+          },
+          { checks: [check], onlyIds: ["core/doctor/write-config"] },
+        ),
+      ).resolves.toMatchObject({
+        checksRun: 1,
+        checksSkipped: 0,
+        findings: [
+          expect.objectContaining({
+            checkId: "core/doctor/write-config",
+            path: "/tmp/fake-openclaw.json",
+            requirement: "mutable-config-write-path",
+          }),
+        ],
+      });
+    });
+
+    it("reports an unwritable existing config when selected", async () => {
+      vi.spyOn(fs, "existsSync").mockReturnValue(true);
+      vi.spyOn(fs, "accessSync").mockImplementation((_path, mode) => {
+        if (mode === fs.constants.W_OK) {
+          throw new Error("EACCES");
+        }
+      });
+
+      await expect(
+        runDoctorLintChecks(
+          {
+            cfg: {},
+            mode: "lint" as const,
+            runtime: { log: vi.fn(), error: vi.fn(), exit: vi.fn() },
+            configPath: "/tmp/fake-openclaw.json",
+          },
+          { checks: [check], onlyIds: ["core/doctor/write-config"] },
+        ),
+      ).resolves.toMatchObject({
+        findings: [
+          expect.objectContaining({
+            checkId: "core/doctor/write-config",
+            path: "/tmp/fake-openclaw.json",
+            requirement: "writable-config-file",
+          }),
+        ],
+      });
+    });
+
+    it("reports an unwritable config directory when the config file is missing", async () => {
+      vi.spyOn(fs, "existsSync").mockReturnValue(false);
+      vi.spyOn(fs, "accessSync").mockImplementation(() => {
+        throw new Error("EACCES");
+      });
+
+      await expect(
+        runDoctorLintChecks(
+          {
+            cfg: {},
+            mode: "lint" as const,
+            runtime: { log: vi.fn(), error: vi.fn(), exit: vi.fn() },
+            configPath: "/tmp/openclaw-home/openclaw.json",
+          },
+          { checks: [check], onlyIds: ["core/doctor/write-config"] },
+        ),
+      ).resolves.toMatchObject({
+        findings: [
+          expect.objectContaining({
+            checkId: "core/doctor/write-config",
+            path: "/tmp/openclaw-home",
+            requirement: "writable-config-directory",
+          }),
+        ],
+      });
+    });
   });
 
   describe("config size drops during update", () => {

--- a/src/flows/doctor-health-contributions.test.ts
+++ b/src/flows/doctor-health-contributions.test.ts
@@ -2754,12 +2754,32 @@ describe("doctor health contributions", () => {
       });
     });
 
-    it("reports an unwritable existing config when selected", async () => {
-      vi.spyOn(fs, "existsSync").mockReturnValue(true);
-      vi.spyOn(fs, "accessSync").mockImplementation((_path, mode) => {
-        if (mode === fs.constants.W_OK) {
-          throw new Error("EACCES");
-        }
+    it("skips a read-only existing config when its directory is writable", async () => {
+      const configPath = "/tmp/openclaw-home/openclaw.json";
+      vi.spyOn(fs, "existsSync").mockImplementation((path) => path === configPath);
+      const accessSpy = vi.spyOn(fs, "accessSync").mockImplementation(() => undefined);
+
+      await expect(
+        runDoctorLintChecks(
+          {
+            cfg: {},
+            mode: "lint" as const,
+            runtime: { log: vi.fn(), error: vi.fn(), exit: vi.fn() },
+            configPath,
+          },
+          { checks: [check], onlyIds: ["core/doctor/write-config"] },
+        ),
+      ).resolves.toMatchObject({
+        findings: [],
+      });
+      expect(accessSpy).toHaveBeenCalledWith("/tmp/openclaw-home", fs.constants.W_OK);
+    });
+
+    it("reports an unwritable config directory for an existing config", async () => {
+      const configPath = "/tmp/openclaw-home/openclaw.json";
+      vi.spyOn(fs, "existsSync").mockImplementation((path) => path === configPath);
+      vi.spyOn(fs, "accessSync").mockImplementation(() => {
+        throw new Error("EACCES");
       });
 
       await expect(
@@ -2768,7 +2788,7 @@ describe("doctor health contributions", () => {
             cfg: {},
             mode: "lint" as const,
             runtime: { log: vi.fn(), error: vi.fn(), exit: vi.fn() },
-            configPath: "/tmp/fake-openclaw.json",
+            configPath,
           },
           { checks: [check], onlyIds: ["core/doctor/write-config"] },
         ),
@@ -2776,8 +2796,9 @@ describe("doctor health contributions", () => {
         findings: [
           expect.objectContaining({
             checkId: "core/doctor/write-config",
-            path: "/tmp/fake-openclaw.json",
-            requirement: "writable-config-file",
+            path: "/tmp/openclaw-home",
+            target: configPath,
+            requirement: "writable-config-directory",
           }),
         ],
       });

--- a/src/flows/doctor-health-contributions.test.ts
+++ b/src/flows/doctor-health-contributions.test.ts
@@ -2757,6 +2757,9 @@ describe("doctor health contributions", () => {
     it("skips a read-only existing config when its directory is writable", async () => {
       const configPath = "/tmp/openclaw-home/openclaw.json";
       vi.spyOn(fs, "existsSync").mockImplementation((path) => path === configPath);
+      vi.spyOn(fs, "statSync").mockReturnValue({
+        isDirectory: () => true,
+      } as fs.Stats);
       const accessSpy = vi.spyOn(fs, "accessSync").mockImplementation(() => undefined);
 
       await expect(
@@ -2778,6 +2781,9 @@ describe("doctor health contributions", () => {
     it("reports an unwritable config directory for an existing config", async () => {
       const configPath = "/tmp/openclaw-home/openclaw.json";
       vi.spyOn(fs, "existsSync").mockImplementation((path) => path === configPath);
+      vi.spyOn(fs, "statSync").mockReturnValue({
+        isDirectory: () => true,
+      } as fs.Stats);
       vi.spyOn(fs, "accessSync").mockImplementation(() => {
         throw new Error("EACCES");
       });
@@ -2850,6 +2856,36 @@ describe("doctor health contributions", () => {
           }),
         ],
       });
+    });
+
+    it("reports an existing file that blocks the config directory path", async () => {
+      vi.spyOn(fs, "existsSync").mockImplementation((path) => path === "/tmp/openclaw-home");
+      vi.spyOn(fs, "statSync").mockReturnValue({
+        isDirectory: () => false,
+      } as fs.Stats);
+      const accessSpy = vi.spyOn(fs, "accessSync").mockImplementation(() => undefined);
+
+      await expect(
+        runDoctorLintChecks(
+          {
+            cfg: {},
+            mode: "lint" as const,
+            runtime: { log: vi.fn(), error: vi.fn(), exit: vi.fn() },
+            configPath: "/tmp/openclaw-home/openclaw.json",
+          },
+          { checks: [check], onlyIds: ["core/doctor/write-config"] },
+        ),
+      ).resolves.toMatchObject({
+        findings: [
+          expect.objectContaining({
+            checkId: "core/doctor/write-config",
+            path: "/tmp/openclaw-home",
+            target: "/tmp/openclaw-home",
+            requirement: "config-directory-path",
+          }),
+        ],
+      });
+      expect(accessSpy).not.toHaveBeenCalled();
     });
   });
 

--- a/src/flows/doctor-health-contributions.ts
+++ b/src/flows/doctor-health-contributions.ts
@@ -1331,18 +1331,6 @@ async function collectWriteConfigHealthFindings(
   }
   if (fs.existsSync(configPath)) {
     try {
-      fs.accessSync(configPath, fs.constants.R_OK);
-    } catch {
-      findings.push({
-        checkId: "core/doctor/write-config",
-        severity: "warning",
-        message: "Doctor cannot safely write config because the current config file is unreadable.",
-        path: configPath,
-        requirement: "readable-config-before-write",
-        fixHint: "Restore read access to the config file before running doctor --fix.",
-      });
-    }
-    try {
       fs.accessSync(configPath, fs.constants.W_OK);
     } catch {
       findings.push({
@@ -1356,19 +1344,35 @@ async function collectWriteConfigHealthFindings(
     }
     return findings;
   }
+  const configDirectory = nodePath.dirname(configPath);
+  const existingParent = findNearestExistingParent(configDirectory);
   try {
-    fs.accessSync(nodePath.dirname(configPath), fs.constants.W_OK);
+    fs.accessSync(existingParent, fs.constants.W_OK);
   } catch {
     findings.push({
       checkId: "core/doctor/write-config",
       severity: "warning",
-      message: "Doctor cannot create the config file because its parent directory is not writable.",
-      path: nodePath.dirname(configPath),
+      message:
+        "Doctor cannot create the config directory because the nearest existing parent is not writable.",
+      path: existingParent,
+      target: configDirectory,
       requirement: "writable-config-directory",
-      fixHint: "Create or make the config directory writable before running doctor --fix.",
+      fixHint: "Make the existing parent directory writable before running doctor --fix.",
     });
   }
   return findings;
+}
+
+function findNearestExistingParent(path: string): string {
+  let candidate = path;
+  while (!fs.existsSync(candidate)) {
+    const parent = nodePath.dirname(candidate);
+    if (parent === candidate) {
+      return candidate;
+    }
+    candidate = parent;
+  }
+  return candidate;
 }
 
 async function runWorkspaceSuggestionsHealth(ctx: DoctorHealthFlowContext): Promise<void> {

--- a/src/flows/doctor-health-contributions.ts
+++ b/src/flows/doctor-health-contributions.ts
@@ -1347,7 +1347,7 @@ async function collectWriteConfigHealthFindings(
     return findings;
   }
   try {
-    fs.accessSync(existingParent, fs.constants.W_OK);
+    fs.accessSync(existingParent, fs.constants.W_OK | fs.constants.X_OK);
   } catch {
     findings.push({
       checkId: "core/doctor/write-config",

--- a/src/flows/doctor-health-contributions.ts
+++ b/src/flows/doctor-health-contributions.ts
@@ -1329,35 +1329,25 @@ async function collectWriteConfigHealthFindings(
   if (!configPath) {
     return findings;
   }
-  if (fs.existsSync(configPath)) {
-    try {
-      fs.accessSync(configPath, fs.constants.W_OK);
-    } catch {
-      findings.push({
-        checkId: "core/doctor/write-config",
-        severity: "warning",
-        message: "Doctor cannot write the current config file.",
-        path: configPath,
-        requirement: "writable-config-file",
-        fixHint: "Restore write access to the config file before running doctor --fix.",
-      });
-    }
-    return findings;
-  }
   const configDirectory = nodePath.dirname(configPath);
-  const existingParent = findNearestExistingParent(configDirectory);
+  const configPathExists = fs.existsSync(configPath);
+  const existingParent = configPathExists
+    ? configDirectory
+    : findNearestExistingParent(configDirectory);
   try {
     fs.accessSync(existingParent, fs.constants.W_OK);
   } catch {
     findings.push({
       checkId: "core/doctor/write-config",
       severity: "warning",
-      message:
-        "Doctor cannot create the config directory because the nearest existing parent is not writable.",
+      message: configPathExists
+        ? "Doctor cannot write config because the config directory is not writable."
+        : "Doctor cannot create the config directory because the nearest existing parent is not writable.",
       path: existingParent,
-      target: configDirectory,
+      target: configPathExists ? configPath : configDirectory,
       requirement: "writable-config-directory",
-      fixHint: "Make the existing parent directory writable before running doctor --fix.",
+      fixHint:
+        "Make the existing config directory or parent directory writable before running doctor --fix.",
     });
   }
   return findings;

--- a/src/flows/doctor-health-contributions.ts
+++ b/src/flows/doctor-health-contributions.ts
@@ -1334,6 +1334,18 @@ async function collectWriteConfigHealthFindings(
   const existingParent = configPathExists
     ? configDirectory
     : findNearestExistingParent(configDirectory);
+  if (!isDirectoryPath(existingParent)) {
+    findings.push({
+      checkId: "core/doctor/write-config",
+      severity: "warning",
+      message: "Doctor cannot create the config directory because a path component is a file.",
+      path: existingParent,
+      target: configDirectory,
+      requirement: "config-directory-path",
+      fixHint: "Move the file blocking the config directory path before running doctor --fix.",
+    });
+    return findings;
+  }
   try {
     fs.accessSync(existingParent, fs.constants.W_OK);
   } catch {
@@ -1363,6 +1375,14 @@ function findNearestExistingParent(path: string): string {
     candidate = parent;
   }
   return candidate;
+}
+
+function isDirectoryPath(path: string): boolean {
+  try {
+    return fs.statSync(path).isDirectory();
+  } catch {
+    return false;
+  }
 }
 
 async function runWorkspaceSuggestionsHealth(ctx: DoctorHealthFlowContext): Promise<void> {

--- a/src/flows/doctor-health-contributions.ts
+++ b/src/flows/doctor-health-contributions.ts
@@ -1367,7 +1367,7 @@ async function collectWriteConfigHealthFindings(
 
 function findNearestExistingParent(path: string): string {
   let candidate = path;
-  while (!fs.existsSync(candidate)) {
+  while (!pathEntryExists(candidate)) {
     const parent = nodePath.dirname(candidate);
     if (parent === candidate) {
       return candidate;
@@ -1375,6 +1375,18 @@ function findNearestExistingParent(path: string): string {
     candidate = parent;
   }
   return candidate;
+}
+
+function pathEntryExists(path: string): boolean {
+  if (fs.existsSync(path)) {
+    return true;
+  }
+  try {
+    fs.lstatSync(path);
+    return true;
+  } catch {
+    return false;
+  }
 }
 
 function isDirectoryPath(path: string): boolean {

--- a/src/flows/doctor-health-contributions.ts
+++ b/src/flows/doctor-health-contributions.ts
@@ -1,11 +1,13 @@
 // Doctor health contribution helpers collect health checks from plugin manifests.
 import fs from "node:fs";
+import nodePath from "node:path";
 import type { probeGatewayMemoryStatus } from "../commands/doctor-gateway-health.js";
 import type { DoctorOptions, DoctorPrompter } from "../commands/doctor-prompter.js";
 import {
   isLegacyParentWritableUpdateDoctorPass,
   UPDATE_PARENT_SUPPORTS_DOCTOR_CONFIG_WRITE_ENV,
 } from "../commands/doctor/shared/update-phase.js";
+import { resolveIsNixMode } from "../config/paths.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import type { buildGatewayConnectionDetails } from "../gateway/call.js";
 import type { UpdatePostInstallDoctorResult } from "../infra/update-doctor-result.js";
@@ -1308,6 +1310,67 @@ async function runWriteConfigHealth(ctx: DoctorHealthFlowContext): Promise<void>
   }
 }
 
+async function collectWriteConfigHealthFindings(
+  ctx: Parameters<HealthCheck["detect"]>[0],
+): Promise<readonly HealthFinding[]> {
+  const findings: HealthFinding[] = [];
+  const configPath = ctx.configPath;
+  if (resolveIsNixMode(process.env)) {
+    findings.push({
+      checkId: "core/doctor/write-config",
+      severity: "warning",
+      message: "Doctor config writes are disabled because OpenClaw is running in Nix mode.",
+      ...(configPath ? { path: configPath } : {}),
+      requirement: "mutable-config-write-path",
+      fixHint:
+        "Edit the Nix source for this install and rebuild; do not run doctor --fix against this config file.",
+    });
+  }
+  if (!configPath) {
+    return findings;
+  }
+  if (fs.existsSync(configPath)) {
+    try {
+      fs.accessSync(configPath, fs.constants.R_OK);
+    } catch {
+      findings.push({
+        checkId: "core/doctor/write-config",
+        severity: "warning",
+        message: "Doctor cannot safely write config because the current config file is unreadable.",
+        path: configPath,
+        requirement: "readable-config-before-write",
+        fixHint: "Restore read access to the config file before running doctor --fix.",
+      });
+    }
+    try {
+      fs.accessSync(configPath, fs.constants.W_OK);
+    } catch {
+      findings.push({
+        checkId: "core/doctor/write-config",
+        severity: "warning",
+        message: "Doctor cannot write the current config file.",
+        path: configPath,
+        requirement: "writable-config-file",
+        fixHint: "Restore write access to the config file before running doctor --fix.",
+      });
+    }
+    return findings;
+  }
+  try {
+    fs.accessSync(nodePath.dirname(configPath), fs.constants.W_OK);
+  } catch {
+    findings.push({
+      checkId: "core/doctor/write-config",
+      severity: "warning",
+      message: "Doctor cannot create the config file because its parent directory is not writable.",
+      path: nodePath.dirname(configPath),
+      requirement: "writable-config-directory",
+      fixHint: "Create or make the config directory writable before running doctor --fix.",
+    });
+  }
+  return findings;
+}
+
 async function runWorkspaceSuggestionsHealth(ctx: DoctorHealthFlowContext): Promise<void> {
   if (ctx.options.workspaceSuggestions === false) {
     return;
@@ -2042,6 +2105,12 @@ export function resolveDoctorHealthContributions(): DoctorHealthContribution[] {
     createDoctorHealthContribution({
       id: "doctor:write-config",
       label: "Write config",
+      healthChecks: {
+        id: "core/doctor/write-config",
+        description: "Config write blockers are findings before doctor repair writes.",
+        defaultEnabled: false,
+        detect: collectWriteConfigHealthFindings,
+      },
       run: runWriteConfigHealth,
     }),
     createDoctorHealthContribution({


### PR DESCRIPTION
## Summary
- add default-disabled `core/doctor/write-config` lint findings for config write blockers
- report Nix immutable config mode and unwritable config write directories/ancestors without attempting a write
- keep real config writes in the existing `doctor:write-config` run path; no CLI, SDK, plugin, or config contract change
- complete the tracked Doctor rule inventory: this is the 44th of 44 rule families with structured lint findings

## Validation
- `corepack pnpm exec vitest run src/flows/doctor-health-contributions.test.ts --maxWorkers 1 --no-fileParallelism` (81 tests)
- `corepack pnpm exec oxfmt --check src/flows/doctor-health-contributions.ts src/flows/doctor-health-contributions.test.ts`
- `corepack pnpm exec oxlint --tsconfig config/tsconfig/oxlint.core.json src/flows/doctor-health-contributions.ts src/flows/doctor-health-contributions.test.ts`
- `corepack pnpm tsgo:core`
- `git diff --check`

## Real behavior proof
Source lint entrypoint with isolated `OPENCLAW_CONFIG_PATH` / `OPENCLAW_STATE_DIR` and `OPENCLAW_NIX_MODE=1`:

- default `doctor --lint --json` path: `checksRun=23`, `checksSkipped=24`, no `core/doctor/write-config` finding emitted
- selected lint path: `--only core/doctor/write-config` equivalent ran `checksRun=1`, `checksSkipped=46`, emitted `core/doctor/write-config` with `requirement=mutable-config-write-path`

## Notes
- The new check is opt-in via `defaultEnabled: false`; default lint behavior is unchanged.
- This PR intentionally does not report "there is config normalization to write" as a lint finding. That remains separate from the write-path blocker diagnostics here.







