### PR TITLE
fix(infra): roll session warning durations across unit boundaries

### DIFF
--- a/src/infra/session-maintenance-warning.test.ts
+++ b/src/infra/session-maintenance-warning.test.ts
@@ -217,4 +217,19 @@ describe("deliverSessionMaintenanceWarning", () => {
       expect(firstSystemEventCall()?.[0]).toContain(`older than ${expected}`);
     },
   );
+
+  it.each([
+    [30_000, "30 seconds"],
+    [1_800_000, "30 minutes"],
+    [43_200_000, "12 hours"],
+  ])("formatDuration keeps %dms in its own unit as %s", async (pruneAfterMs, expected) => {
+    mocks.deliverOutboundPayloads.mockRejectedValueOnce(new Error("force system event"));
+    const params = createParams({
+      warning: { pruneAfterMs, wouldPrune: true, wouldCap: false, maxEntries: 100 } as never,
+    });
+
+    await deliverSessionMaintenanceWarning(params);
+
+    expect(firstSystemEventCall()?.[0]).toContain(`older than ${expected}`);
+  });
 });

--- a/src/infra/session-maintenance-warning.test.ts
+++ b/src/infra/session-maintenance-warning.test.ts
@@ -199,4 +199,22 @@ describe("deliverSessionMaintenanceWarning", () => {
       { sessionKey: params.sessionKey },
     ]);
   });
+
+  it.each([
+    [59_500, "60 seconds", "1 minute"],
+    [3_570_000, "60 minutes", "1 hour"],
+    [86_370_000, "24 hours", "1 day"],
+  ])(
+    "formatDuration rolls over %dms to next unit instead of %s",
+    async (pruneAfterMs, _buggyOutput, expected) => {
+      mocks.deliverOutboundPayloads.mockRejectedValueOnce(new Error("force system event"));
+      const params = createParams({
+        warning: { pruneAfterMs, wouldPrune: true, wouldCap: false, maxEntries: 100 } as never,
+      });
+
+      await deliverSessionMaintenanceWarning(params);
+
+      expect(firstSystemEventCall()?.[0]).toContain(`older than ${expected}`);
+    },
+  );
 });

--- a/src/infra/session-maintenance-warning.ts
+++ b/src/infra/session-maintenance-warning.ts
@@ -54,16 +54,16 @@ function buildWarningContext(params: WarningParams): string {
 }
 
 function formatDuration(ms: number): string {
-  if (ms >= 86_400_000) {
-    const days = Math.round(ms / 86_400_000);
+  const days = Math.round(ms / 86_400_000);
+  if (days >= 1) {
     return `${days} day${days === 1 ? "" : "s"}`;
   }
-  if (ms >= 3_600_000) {
-    const hours = Math.round(ms / 3_600_000);
+  const hours = Math.round(ms / 3_600_000);
+  if (hours >= 1) {
     return `${hours} hour${hours === 1 ? "" : "s"}`;
   }
-  if (ms >= 60_000) {
-    const mins = Math.round(ms / 60_000);
+  const mins = Math.round(ms / 60_000);
+  if (mins >= 1) {
     return `${mins} minute${mins === 1 ? "" : "s"}`;
   }
   const secs = Math.round(ms / 1000);

--- a/src/infra/session-maintenance-warning.ts
+++ b/src/infra/session-maintenance-warning.ts
@@ -32,7 +32,6 @@ function resetSessionMaintenanceWarningForTests() {
 
 export const testing = {
   resetSessionMaintenanceWarningForTests,
-  formatDuration,
 } as const;
 
 const loadDeliverRuntime = messageRuntimeLoader.load;

--- a/src/infra/session-maintenance-warning.ts
+++ b/src/infra/session-maintenance-warning.ts
@@ -54,20 +54,20 @@ function buildWarningContext(params: WarningParams): string {
 }
 
 function formatDuration(ms: number): string {
-  const days = Math.round(ms / 86_400_000);
-  if (days >= 1) {
-    return `${days} day${days === 1 ? "" : "s"}`;
+  const secs = Math.round(ms / 1000);
+  if (secs < 60) {
+    return `${secs} second${secs === 1 ? "" : "s"}`;
   }
-  const hours = Math.round(ms / 3_600_000);
-  if (hours >= 1) {
-    return `${hours} hour${hours === 1 ? "" : "s"}`;
-  }
-  const mins = Math.round(ms / 60_000);
-  if (mins >= 1) {
+  const mins = Math.round(secs / 60);
+  if (mins < 60) {
     return `${mins} minute${mins === 1 ? "" : "s"}`;
   }
-  const secs = Math.round(ms / 1000);
-  return `${secs} second${secs === 1 ? "" : "s"}`;
+  const hours = Math.round(mins / 60);
+  if (hours < 24) {
+    return `${hours} hour${hours === 1 ? "" : "s"}`;
+  }
+  const days = Math.round(hours / 24);
+  return `${days} day${days === 1 ? "" : "s"}`;
 }
 
 function buildWarningText(warning: SessionMaintenanceWarning): string {

--- a/src/infra/session-maintenance-warning.ts
+++ b/src/infra/session-maintenance-warning.ts
@@ -32,6 +32,7 @@ function resetSessionMaintenanceWarningForTests() {
 
 export const testing = {
   resetSessionMaintenanceWarningForTests,
+  formatDuration,
 } as const;
 
 const loadDeliverRuntime = messageRuntimeLoader.load;


### PR DESCRIPTION
## What Problem This Solves

Session maintenance warnings could display rounded durations as `60 seconds`, `60 minutes`, or `24 hours` instead of promoting them to `1 minute`, `1 hour`, or `1 day`.

## Why This Change Was Made

The warning formatter selected a unit from the raw millisecond value and rounded only afterward. It now rounds progressively from seconds through days, matching the rollover semantics used by the shared duration formatter while preserving the warning text's spelled-out unit labels.

## User Impact

Warn-only session maintenance messages now use natural duration boundaries without changing cleanup behavior or configuration.

## Evidence

- Regression cases cover 59.5 seconds, 59.5 minutes, and 23 hours 59.5 minutes.
- Guard cases cover 30 seconds, 30 minutes, and 12 hours to ensure values are not promoted early.
- Focused tests and the changed-file gate will be rerun against the final rebased head before merge.
