### PR TITLE
fix: keep undici terminated exceptions non-fatal

### DIFF
--- a/src/infra/unhandled-rejections.test.ts
+++ b/src/infra/unhandled-rejections.test.ts
@@ -364,6 +364,10 @@ describe("isTransientUnhandledRejectionError", () => {
     const wrappedWsPreHandshakeClose = Object.assign(new Error("feishu reconnect failed"), {
       cause: wsPreHandshakeClose,
     });
+    const undiciTerminated = new TypeError("terminated");
+    const wrappedUndiciTerminated = Object.assign(new Error("model fetch failed"), {
+      cause: undiciTerminated,
+    });
     const generic = new Error("boom");
 
     expect(isBenignUncaughtExceptionError(epipe)).toBe(true);
@@ -380,6 +384,10 @@ describe("isTransientUnhandledRejectionError", () => {
     expect(isBenignUncaughtExceptionError(new Error("ERR_HTTP2_INVALID_SESSION"))).toBe(true);
     expect(isBenignUncaughtExceptionError(wsPreHandshakeClose)).toBe(true);
     expect(isBenignUncaughtExceptionError(wrappedWsPreHandshakeClose)).toBe(true);
+    expect(isBenignUncaughtExceptionError(undiciTerminated)).toBe(true);
+    expect(isBenignUncaughtExceptionError(wrappedUndiciTerminated)).toBe(true);
+    expect(isBenignUncaughtExceptionError(new Error("terminated"))).toBe(false);
+    expect(isBenignUncaughtExceptionError(new TypeError("terminated unexpectedly"))).toBe(false);
     expect(
       isBenignUncaughtExceptionError(
         new Error("WebSocket error: WebSocket was closed before the connection was established"),

--- a/src/infra/unhandled-rejections.ts
+++ b/src/infra/unhandled-rejections.ts
@@ -114,6 +114,7 @@ const TRANSIENT_NETWORK_MESSAGE_CODE_RE =
 const BENIGN_UNCAUGHT_EXCEPTION_NETWORK_MESSAGE_CODE_RE =
   /\b(ECONNREFUSED|ENETDOWN|EHOSTUNREACH|ENETUNREACH|EADDRNOTAVAIL|EAI_AGAIN|ENOTFOUND|ETIMEDOUT|UND_ERR_CONNECT_TIMEOUT|UND_ERR_DNS_RESOLVE_FAILED|UND_ERR_CONNECT|ERR_HTTP2_INVALID_SESSION)\b/i;
 const WS_PRE_HANDSHAKE_CLOSE_MESSAGE = "websocket was closed before the connection was established";
+const UNDICI_TERMINATED_TYPE_ERROR_MESSAGE = "terminated";
 
 const TRANSIENT_SQLITE_MESSAGE_CODE_RE =
   /\b(SQLITE_BUSY|SQLITE_CANTOPEN|SQLITE_IOERR|SQLITE_LOCKED)\b/i;
@@ -422,6 +423,15 @@ export function isTransientUnhandledRejectionError(err: unknown): boolean {
 
 function isBenignUncaughtNetworkException(err: unknown): boolean {
   for (const candidate of collectNestedUnhandledErrorCandidates(err)) {
+    // Undici emits this bare TypeError when a response body aborts after request start.
+    // Keep the shape exact so unrelated "terminated" errors still take the fatal path.
+    if (
+      candidate instanceof TypeError &&
+      normalizeLowercaseStringOrEmpty(candidate.message) === UNDICI_TERMINATED_TYPE_ERROR_MESSAGE
+    ) {
+      return true;
+    }
+
     const code = extractErrorCodeOrErrno(candidate);
     if (code && BENIGN_UNCAUGHT_EXCEPTION_NETWORK_CODES.has(code)) {
       return true;


### PR DESCRIPTION
## What Problem This Solves

Fixes #100094.

Bare undici response-body aborts can surface as `TypeError("terminated")`. The shared uncaught-exception classifier already handles several transient network shapes, but that bare undici shape was still routed through the fatal uncaught-exception path.

## Why This Change Was Made

This adds a narrow match for an actual `TypeError` instance whose normalized message is exactly `terminated`, inside the existing benign network uncaught-exception classifier. The existing error graph traversal covers wrapped causes, while the exact type/message guard keeps generic `Error("terminated")` and broader `"terminated ..."` messages on the fatal path.

## User Impact

Gateway processes can continue after this specific transient undici abort instead of exiting or restarting. Other uncaught exceptions keep the existing fatal behavior.

## Evidence

- `node scripts/run-vitest.mjs src/infra/unhandled-rejections.test.ts src/infra/unhandled-rejections.fatal-detection.test.ts`
- `git diff --check`
- Local autoreview: clean, no accepted/actionable findings

AI assistance: drafted and validated by Codex in the OpenClaw OSS sweep.
