### PR TITLE
fix(msteams): paginate channel thread replies so newest replies aren't dropped

### DIFF
--- a/extensions/msteams/src/graph-thread.test.ts
+++ b/extensions/msteams/src/graph-thread.test.ts
@@ -197,6 +197,19 @@ describe("fetchThreadReplies", () => {
     expect(result.at(-1)?.id).toBe("reply-60");
   });
 
+  it("selects the newest replies by createdDateTime regardless of page order", async () => {
+    const items = [
+      { id: "c", createdDateTime: "2026-01-03T00:00:00Z" },
+      { id: "a", createdDateTime: "2026-01-01T00:00:00Z" },
+      { id: "b", createdDateTime: "2026-01-02T00:00:00Z" },
+    ];
+    vi.mocked(fetchAllGraphPages).mockResolvedValueOnce({ items, truncated: false } as never);
+
+    const result = await fetchThreadReplies("tok", "g", "c", "m", 2);
+
+    expect(result.map((r) => r.id)).toStrictEqual(["b", "c"]);
+  });
+
   it("clamps per-page $top to 50 maximum", async () => {
     vi.mocked(fetchAllGraphPages).mockResolvedValueOnce({ items: [], truncated: false } as never);
 

--- a/extensions/msteams/src/graph-thread.test.ts
+++ b/extensions/msteams/src/graph-thread.test.ts
@@ -8,19 +8,12 @@ import {
   resolveTeamGroupId,
   stripHtmlFromTeamsMessage,
 } from "./graph-thread.js";
-import { fetchGraphJson } from "./graph.js";
+import { fetchAllGraphPages, fetchGraphJson } from "./graph.js";
 
 vi.mock("./graph.js", () => ({
   fetchGraphJson: vi.fn(),
+  fetchAllGraphPages: vi.fn(),
 }));
-
-const firstGraphPath = () => {
-  const [call] = vi.mocked(fetchGraphJson).mock.calls;
-  if (!call) {
-    throw new Error("expected Graph fetch call");
-  }
-  return call[0].path;
-};
 
 describe("stripHtmlFromTeamsMessage", () => {
   it("preserves @mention display names from <at> tags", () => {
@@ -163,41 +156,65 @@ describe("fetchChannelMessage", () => {
 
 describe("fetchThreadReplies", () => {
   beforeEach(() => {
-    vi.mocked(fetchGraphJson).mockReset();
+    vi.mocked(fetchAllGraphPages).mockReset();
   });
 
+  const firstPagesPath = () => {
+    const [call] = vi.mocked(fetchAllGraphPages).mock.calls;
+    if (!call) {
+      throw new Error("expected Graph pages call");
+    }
+    return (call[0] as { path: string }).path;
+  };
+
   it("fetches replies with correct path and default limit", async () => {
-    vi.mocked(fetchGraphJson).mockResolvedValueOnce({
-      value: [{ id: "reply-1" }, { id: "reply-2" }],
+    vi.mocked(fetchAllGraphPages).mockResolvedValueOnce({
+      items: [{ id: "reply-1" }, { id: "reply-2" }],
+      truncated: false,
     } as never);
 
     const result = await fetchThreadReplies("tok", "group-1", "channel-1", "msg-1");
 
     expect(result).toHaveLength(2);
-    expect(fetchGraphJson).toHaveBeenCalledWith({
+    expect(fetchAllGraphPages).toHaveBeenCalledWith({
       token: "tok",
       path: "/teams/group-1/channels/channel-1/messages/msg-1/replies?$top=50&$select=id,from,body,createdDateTime",
+      maxPages: 50,
     });
   });
 
-  it("clamps limit to 50 maximum", async () => {
-    vi.mocked(fetchGraphJson).mockResolvedValueOnce({ value: [] } as never);
+  it("follows pagination and keeps the newest replies (Graph returns oldest-first)", async () => {
+    const replies = Array.from({ length: 60 }, (_, i) => ({ id: `reply-${i + 1}` }));
+    vi.mocked(fetchAllGraphPages).mockResolvedValueOnce({
+      items: replies,
+      truncated: false,
+    } as never);
+
+    const result = await fetchThreadReplies("tok", "g", "c", "m", 50);
+
+    expect(result).toHaveLength(50);
+    expect(result[0]?.id).toBe("reply-11");
+    expect(result.at(-1)?.id).toBe("reply-60");
+  });
+
+  it("clamps per-page $top to 50 maximum", async () => {
+    vi.mocked(fetchAllGraphPages).mockResolvedValueOnce({ items: [], truncated: false } as never);
 
     await fetchThreadReplies("tok", "g", "c", "m", 200);
 
-    expect(firstGraphPath()).toContain("$top=50");
+    expect(firstPagesPath()).toContain("$top=50");
   });
 
-  it("clamps limit to 1 minimum", async () => {
-    vi.mocked(fetchGraphJson).mockResolvedValueOnce({ value: [] } as never);
+  it("clamps per-page $top to 1 minimum", async () => {
+    vi.mocked(fetchAllGraphPages).mockResolvedValueOnce({ items: [], truncated: false } as never);
 
     await fetchThreadReplies("tok", "g", "c", "m", 0);
 
-    expect(firstGraphPath()).toContain("$top=1");
+    expect(firstPagesPath()).toContain("$top=1");
   });
 
-  it("returns empty array when value is missing", async () => {
-    vi.mocked(fetchGraphJson).mockResolvedValueOnce({} as never);
+  it("returns empty array when there are no replies", async () => {
+    vi.mocked(fetchAllGraphPages).mockResolvedValueOnce({ items: [], truncated: false } as never);
 
     const result = await fetchThreadReplies("tok", "g", "c", "m");
     expect(result).toStrictEqual([]);

--- a/extensions/msteams/src/graph-thread.ts
+++ b/extensions/msteams/src/graph-thread.ts
@@ -3,7 +3,7 @@ import {
   asDateTimestampMs,
   resolveExpiresAtMsFromDurationMs,
 } from "openclaw/plugin-sdk/number-runtime";
-import { fetchGraphJson, type GraphResponse } from "./graph.js";
+import { fetchAllGraphPages, fetchGraphJson } from "./graph.js";
 
 export type GraphThreadMessage = {
   id?: string;
@@ -115,12 +115,11 @@ export async function fetchChannelMessage(
 /**
  * Fetch thread replies for a channel message, ordered chronologically.
  *
- * **Limitation:** The Graph API replies endpoint (`/messages/{id}/replies`) does not
- * support `$orderby`, so results are always returned in ascending (oldest-first) order.
- * Combined with the `$top` cap of 50, this means only the **oldest 50 replies** are
- * returned for long threads — newer replies are silently omitted. There is currently no
- * Graph API workaround for this; pagination via `@odata.nextLink` can retrieve more
- * replies but still in ascending order only.
+ * The Graph replies endpoint (`/messages/{id}/replies`) returns replies ascending
+ * (oldest-first), does not support `$orderby`, and caps `$top` at 50. Fetching a single
+ * page therefore dropped the newest (usually most relevant) replies on long threads.
+ * This follows `@odata.nextLink` to page through the thread and returns the newest
+ * `limit` replies. Pagination is bounded by `maxPages`.
  */
 export async function fetchThreadReplies(
   token: string,
@@ -129,13 +128,12 @@ export async function fetchThreadReplies(
   messageId: string,
   limit = 50,
 ): Promise<GraphThreadMessage[]> {
-  const top = Math.min(Math.max(limit, 1), 50);
-  // NOTE: Graph replies endpoint returns oldest-first and does not support $orderby.
-  // For threads with >50 replies, only the oldest 50 are returned. The most recent
-  // replies (often the most relevant context) may be truncated.
+  const want = Math.max(limit, 1);
+  const top = Math.min(want, 50);
   const path = `/teams/${encodeURIComponent(groupId)}/channels/${encodeURIComponent(channelId)}/messages/${encodeURIComponent(messageId)}/replies?$top=${top}&$select=id,from,body,createdDateTime`;
-  const res = await fetchGraphJson<GraphResponse<GraphThreadMessage>>({ token, path });
-  return res.value ?? [];
+  const { items } = await fetchAllGraphPages<GraphThreadMessage>({ token, path, maxPages: 50 });
+  // Replies come back oldest-first, so the newest `want` are at the end of the list.
+  return items.slice(-want);
 }
 
 /**

--- a/extensions/msteams/src/graph-thread.ts
+++ b/extensions/msteams/src/graph-thread.ts
@@ -142,7 +142,7 @@ export async function fetchThreadReplies(
   // back to arrival order (Graph returns oldest-first) when any timestamp is missing.
   const allTimestamped = items.every((m) => Number.isFinite(Date.parse(m.createdDateTime ?? "")));
   const ordered = allTimestamped
-    ? [...items].sort((a, b) => Date.parse(a.createdDateTime ?? "") - Date.parse(b.createdDateTime ?? ""))
+    ? items.toSorted((a, b) => Date.parse(a.createdDateTime ?? "") - Date.parse(b.createdDateTime ?? ""))
     : items;
   return ordered.slice(-want);
 }

--- a/extensions/msteams/src/graph-thread.ts
+++ b/extensions/msteams/src/graph-thread.ts
@@ -112,14 +112,20 @@ export async function fetchChannelMessage(
   }
 }
 
+// Getting the newest replies means walking the whole thread, because the Graph replies
+// endpoint is oldest-first with no `$orderby`. Bound the walk so a very long thread
+// cannot issue an unbounded number of sequential Graph reads on the inbound context path
+// (50 pages x $top 50 = up to 2500 replies scanned).
+const MAX_REPLY_PAGES = 50;
+
 /**
- * Fetch thread replies for a channel message, ordered chronologically.
+ * Fetch thread replies for a channel message, returning the newest `limit`.
  *
- * The Graph replies endpoint (`/messages/{id}/replies`) returns replies ascending
- * (oldest-first), does not support `$orderby`, and caps `$top` at 50. Fetching a single
- * page therefore dropped the newest (usually most relevant) replies on long threads.
- * This follows `@odata.nextLink` to page through the thread and returns the newest
- * `limit` replies. Pagination is bounded by `maxPages`.
+ * The Graph replies endpoint (`/messages/{id}/replies`) returns replies oldest-first,
+ * does not support `$orderby`, and caps `$top` at 50, so fetching a single page dropped
+ * the newest (usually most relevant) replies on long threads. This pages through the
+ * thread via `@odata.nextLink` (bounded by `MAX_REPLY_PAGES`) and selects the newest
+ * `limit` by `createdDateTime`, falling back to arrival order when timestamps are absent.
  */
 export async function fetchThreadReplies(
   token: string,
@@ -131,9 +137,14 @@ export async function fetchThreadReplies(
   const want = Math.max(limit, 1);
   const top = Math.min(want, 50);
   const path = `/teams/${encodeURIComponent(groupId)}/channels/${encodeURIComponent(channelId)}/messages/${encodeURIComponent(messageId)}/replies?$top=${top}&$select=id,from,body,createdDateTime`;
-  const { items } = await fetchAllGraphPages<GraphThreadMessage>({ token, path, maxPages: 50 });
-  // Replies come back oldest-first, so the newest `want` are at the end of the list.
-  return items.slice(-want);
+  const { items } = await fetchAllGraphPages<GraphThreadMessage>({ token, path, maxPages: MAX_REPLY_PAGES });
+  // Order by createdDateTime so the newest window does not depend on page order. Fall
+  // back to arrival order (Graph returns oldest-first) when any timestamp is missing.
+  const allTimestamped = items.every((m) => Number.isFinite(Date.parse(m.createdDateTime ?? "")));
+  const ordered = allTimestamped
+    ? [...items].sort((a, b) => Date.parse(a.createdDateTime ?? "") - Date.parse(b.createdDateTime ?? ""))
+    : items;
+  return ordered.slice(-want);
 }
 
 /**


### PR DESCRIPTION
Closes #98870

## What Problem This Solves

Fixes an issue where the Teams channel thread context an agent sees is missing the newest replies on any thread with more than 50 replies. `fetchThreadReplies` requested a single page of `/messages/{id}/replies`, and since Graph caps `$top` at 50 and returns replies oldest-first, long threads exposed only the oldest 50 replies to the agent and silently dropped the most recent, usually most relevant, messages.

## Why This Change Was Made

`fetchThreadReplies` now pages through the thread with `fetchAllGraphPages` (the helper this module already uses for `listChannelsForTeam` and `listTeamsByName`, which follows `@odata.nextLink`) and returns the newest `limit` replies. Newest selection is by `createdDateTime` with a fallback to arrival order, so it no longer depends on undocumented page ordering. Per-page `$top` clamping is unchanged, so short threads behave exactly as before.

Because the replies endpoint is oldest-first with no `$orderby`, reaching the newest replies means walking the whole thread. The walk is bounded by a named `MAX_REPLY_PAGES = 50` (up to 2500 replies scanned). Open question for maintainers: happy to lower that cap if the extra sequential Graph reads on the inbound context path are a concern, though a lower cap means very long threads fall back to fewer of the newest replies.

## User Impact

On Teams channel threads with more than 50 replies, the agent now gets the most recent replies as context instead of only the oldest 50, so its responses reflect the current state of the conversation.

## Evidence

- Reuses `fetchAllGraphPages`, which already handles `@odata.nextLink` pagination and is covered in `graph.test.ts`, so there is no new Graph interaction here, just the existing helper applied to replies.
- Unit tests in `graph-thread.test.ts` (run in CI): newest 50 selected from 60 paginated replies, newest window by `createdDateTime` regardless of page order, plus the path, `$top` clamp, and empty-thread cases on the paginated helper.
- I do not have a live Teams tenant, so I could not add live long-thread proof. Validation here is the unit tests and CI. If a maintainer with a tenant can capture a redacted over-50-reply run, or is comfortable accepting on the patch plus the reused helper, that would clear the proof gate.
