### PR TITLE
Fix nodejs installation logic on Debian-based systems

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -627,10 +627,6 @@ is_arch_linux() {
             return 0
         fi
     fi
-    # Fallback: check for pacman
-    if command -v pacman &> /dev/null; then
-        return 0
-    fi
     return 1
 }
 
@@ -677,7 +673,7 @@ install_build_tools_linux() {
         return 0
     fi
 
-    if command -v pacman &> /dev/null || is_arch_linux; then
+    if command -v pacman &> /dev/null && is_arch_linux; then
         if is_root; then
             run_quiet_step "Installing build tools" pacman -Sy --noconfirm base-devel python make cmake gcc
         else
@@ -1922,7 +1918,7 @@ install_git() {
         elif command -v apt-get &> /dev/null; then
             run_quiet_step "Updating package index" apt_get_update
             run_quiet_step "Installing Git" apt_get_install git
-        elif command -v pacman &> /dev/null || is_arch_linux; then
+        elif command -v pacman &> /dev/null && is_arch_linux; then
             if is_root; then
                 run_quiet_step "Installing Git" pacman -Sy --noconfirm git
             else

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1814,7 +1814,7 @@ install_node() {
         fi
 
         # Arch-based distros: use pacman with official repos
-        if command -v pacman &> /dev/null || is_arch_linux; then
+        if command -v pacman &> /dev/null && is_arch_linux; then
             ui_info "Installing Node.js via pacman (Arch-based distribution detected)"
             if is_root; then
                 run_required_step "Installing Node.js" pacman -Sy --noconfirm nodejs npm


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where non-Arch Linux systems (such as Debian, Ubuntu, Mint, etc.) that happen to have a `pacman` executable present in their `PATH` were incorrectly routed into Arch-based installer branches.  
This caused the installer to attempt `pacman -Sy` operations on systems that do not use pacman as a package manager, breaking build-tool installation, Git installation, and the Node.js install path.

The root cause was that the Arch detection logic treated the presence of any `pacman` binary as proof of an Arch-based distribution.

## Why This Change Was Made

The previous logic relied on:

```
command -v pacman || is_arch_linux
```

Additionally, `is_arch_linux` itself included a fallback that returned success if `pacman` existed in `PATH`.  
This produced false positives whenever any package or program named `pacman` was installed on non-Arch systems.

To correct this:

1. **Removed the pacman fallback from `is_arch_linux()`**  
   The function now identifies Arch-based systems only via `/etc/os-release` or `/etc/arch-release`.

2. **Switched installer conditions from `||` to `&&`**  
   The installer now requires:
   - a system that is *actually* Arch-based  
   - and a real pacman package manager available  
   before using pacman installation paths.

This prevents unrelated binaries named `pacman` from triggering Arch-specific routes.

## User Impact

- Debian/Ubuntu/Mint users who have any program named `pacman` on their system (e.g., games or custom tools) will no longer be misdetected as Arch.
- Installer routes for build tools, Git, and Node.js now reliably use `apt`/NodeSource on Debian-based systems.
- Arch and Arch-like distributions continue to install packages via pacman normally.
- This change improves reliability and prevents package‑manager confusion in multi-distro setups and development environments.

## Evidence

(You will add your real logs + test outputs here as soon as you run the PR-proof steps.)

---

## Follow-up (optional)

Dear maintainers,  
If you agree, I can submit a separate PR to add distro‑specific helpers such as `is_debian_linux()` and `is_fedora_linux()` to reduce repeated `command -v apt-get` / `command -v dnf` checks and improve installer routing clarity across the codebase.

