### PR TITLE
fix: bound silent deferred maintenance failures

### DIFF
--- a/src/agents/embedded-agent-runner/context-engine-maintenance.test.ts
+++ b/src/agents/embedded-agent-runner/context-engine-maintenance.test.ts
@@ -770,6 +770,76 @@ describe("runContextEngineMaintenance", () => {
     });
   });
 
+  it("fails and surfaces deferred maintenance that never settles", async () => {
+    await withStateDirEnv("openclaw-turn-maintenance-timeout-", async () => {
+      vi.useFakeTimers();
+      try {
+        resetCommandQueueStateForTest();
+        resetTaskRegistryForTests({ persist: false });
+        resetTaskFlowRegistryForTests({ persist: false });
+
+        const sessionKey = "agent:main:session-timeout";
+        const maintain = vi.fn(
+          async () =>
+            await new Promise<never>(() => {
+              // Intentionally never settles; timeout handling owns completion.
+            }),
+        );
+        const backgroundEngine = {
+          info: {
+            id: "test",
+            name: "Test Engine",
+            turnMaintenanceMode: "background" as const,
+          },
+          ingest: async () => ({ ingested: true }),
+          assemble: async ({ messages }: { messages: unknown[] }) => ({
+            messages,
+            estimatedTokens: 0,
+          }),
+          compact: async () => ({ ok: true, compacted: false }),
+          maintain,
+        } as NonNullable<Parameters<typeof runContextEngineMaintenance>[0]["contextEngine"]>;
+        let deferredPromise: Promise<void> | undefined;
+
+        await runContextEngineMaintenance({
+          contextEngine: backgroundEngine,
+          sessionId: "session-timeout",
+          sessionKey,
+          sessionFile: "/tmp/session-timeout.jsonl",
+          reason: "turn",
+          onDeferredMaintenance: (promise) => {
+            deferredPromise = promise;
+          },
+        });
+
+        await waitForAssertion(() => expect(maintain).toHaveBeenCalledTimes(1));
+        await vi.advanceTimersByTimeAsync(10_000);
+        await waitForAssertion(() => {
+          const task = listTasksForOwnerKey(sessionKey).find(
+            (candidate) => candidate.taskKind === TURN_MAINTENANCE_TASK_KIND,
+          );
+          expect(task?.notifyPolicy).toBe("state_changes");
+          expect(task?.progressSummary).toContain("still running");
+        });
+
+        await vi.advanceTimersByTimeAsync(300_000);
+        if (!deferredPromise) {
+          throw new Error("expected deferred maintenance promise");
+        }
+        await deferredPromise;
+
+        const task = listTasksForOwnerKey(sessionKey).find(
+          (candidate) => candidate.taskKind === TURN_MAINTENANCE_TASK_KIND,
+        );
+        expect(task?.status).toBe("failed");
+        expect(task?.notifyPolicy).toBe("state_changes");
+        expect(String(task?.error)).toContain("deferred context engine maintenance timed out");
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+  });
+
   it("queues a follow-up maintenance run when a new turn finishes during an active deferred run", async () => {
     await withStateDirEnv("openclaw-turn-maintenance-rerun-", async () => {
       vi.useFakeTimers();

--- a/src/agents/embedded-agent-runner/context-engine-maintenance.ts
+++ b/src/agents/embedded-agent-runner/context-engine-maintenance.ts
@@ -43,6 +43,7 @@ const TURN_MAINTENANCE_TASK_LABEL = "Context engine turn maintenance";
 const TURN_MAINTENANCE_TASK_TASK = "Deferred context-engine maintenance after turn.";
 const TURN_MAINTENANCE_LANE_PREFIX = "context-engine-turn-maintenance:";
 const TURN_MAINTENANCE_LONG_WAIT_MS = 10_000;
+const TURN_MAINTENANCE_STALE_TIMEOUT_MS = 300_000;
 const DEFERRED_TURN_MAINTENANCE_ABORT_STATE_KEY = Symbol.for(
   "openclaw.contextEngineTurnMaintenanceAbortState",
 );
@@ -401,6 +402,28 @@ async function executeContextEngineMaintenance(params: {
   return result;
 }
 
+async function runDeferredTurnMaintenanceWithTimeout<T>(work: Promise<T>): Promise<T> {
+  let timeout: ReturnType<typeof setTimeout> | undefined;
+  try {
+    return await Promise.race([
+      work,
+      new Promise<never>((_, reject) => {
+        timeout = setTimeout(() => {
+          reject(
+            new Error(
+              `deferred context engine maintenance timed out after ${TURN_MAINTENANCE_STALE_TIMEOUT_MS}ms`,
+            ),
+          );
+        }, TURN_MAINTENANCE_STALE_TIMEOUT_MS);
+      }),
+    ]);
+  } finally {
+    if (timeout) {
+      clearTimeout(timeout);
+    }
+  }
+}
+
 async function runDeferredTurnMaintenanceWorker(params: {
   contextEngine: ContextEngine;
   sessionId: string;
@@ -456,19 +479,21 @@ async function runDeferredTurnMaintenanceWorker(params: {
       }
     }, TURN_MAINTENANCE_LONG_WAIT_MS);
 
-    const result = await executeContextEngineMaintenance({
-      contextEngine: params.contextEngine,
-      sessionId: params.sessionId,
-      sessionKey: params.sessionKey,
-      sessionFile: params.sessionFile,
-      reason: "turn",
-      sessionManager: params.sessionManager,
-      runtimeContext: params.runtimeContext,
-      runtimeSettings: params.runtimeSettings,
-      agentId: params.agentId,
-      config: params.config,
-      executionMode: "background",
-    });
+    const result = await runDeferredTurnMaintenanceWithTimeout(
+      executeContextEngineMaintenance({
+        contextEngine: params.contextEngine,
+        sessionId: params.sessionId,
+        sessionKey: params.sessionKey,
+        sessionFile: params.sessionFile,
+        reason: "turn",
+        sessionManager: params.sessionManager,
+        runtimeContext: params.runtimeContext,
+        runtimeSettings: params.runtimeSettings,
+        agentId: params.agentId,
+        config: params.config,
+        executionMode: "background",
+      }),
+    );
     if (longRunningTimer) {
       clearTimeout(longRunningTimer);
       longRunningTimer = null;


### PR DESCRIPTION
## What Problem This Solves

Deferred context-engine turn maintenance can currently remain running indefinitely when the engine's maintenance promise never settles. Because these tasks begin with silent notification policy, that can leave the session/task surface stuck without a terminal visible failure.

## Why This Change Was Made

This bounds deferred turn maintenance with a 5-minute timeout. If a maintenance run is still active after the existing long-running threshold, it is promoted to `state_changes`; if it never settles, it now fails the task with a readable timeout instead of staying silent forever.

## User Impact

Users get a visible stuck-maintenance failure instead of a silent running task when background maintenance wedges. Normal completed maintenance remains unchanged.

## Evidence

- `node scripts/run-vitest.mjs src/agents/embedded-agent-runner/context-engine-maintenance.test.ts`
- `pnpm exec oxfmt --check --threads=1 src/agents/embedded-agent-runner/context-engine-maintenance.ts src/agents/embedded-agent-runner/context-engine-maintenance.test.ts`
- `node scripts/run-oxlint.mjs src/agents/embedded-agent-runner/context-engine-maintenance.ts src/agents/embedded-agent-runner/context-engine-maintenance.test.ts`
