### PR TITLE
fix: suggest auth check for bundled provider model-not-found errors

### DIFF
--- a/src/agents/embedded-agent-runner/model.test.ts
+++ b/src/agents/embedded-agent-runner/model.test.ts
@@ -2825,7 +2825,7 @@ describe("resolveModel", () => {
     });
 
     expect(result.error).toBe(
-      'Unknown model: openai-codex/gpt-5.4. Found agents.defaults.models["openai-codex/gpt-5.4"], but the bundled provider "openai-codex" has no registered model "gpt-5.4". This usually means the provider has no authenticated profile — run `openclaw models status` to check provider auth and re-authenticate if needed. See https://docs.openclaw.ai/concepts/model-providers.',
+      'Unknown model: openai-codex/gpt-5.4. Found agents.defaults.models["openai-codex/gpt-5.4"], but "openai-codex" is a legacy alias that has been folded into the openai provider. This provider requires OAuth authentication — run \`openclaw models auth login openai\` to sign in, or run \`openclaw doctor --fix\` to migrate legacy config references. See https://docs.openclaw.ai/concepts/model-providers.',
     );
   });
 

--- a/src/agents/embedded-agent-runner/model.test.ts
+++ b/src/agents/embedded-agent-runner/model.test.ts
@@ -2808,7 +2808,7 @@ describe("resolveModel", () => {
     expect(result.model?.input).toEqual(["text"]);
   });
 
-  it("explains when an agent model entry is missing provider model registration", async () => {
+  it("suggests checking auth when a bundled provider model is missing", async () => {
     const cfg = {
       agents: {
         defaults: {
@@ -2828,7 +2828,28 @@ describe("resolveModel", () => {
     });
 
     expect(result.error).toBe(
-      'Unknown model: microsoft-foundry/Kimi-K2.6-1. Found agents.defaults.models["microsoft-foundry/Kimi-K2.6-1"], but no matching models.providers["microsoft-foundry"].models[] entry. Add { "id": "Kimi-K2.6-1", "name": "Kimi-K2.6-1" } to models.providers["microsoft-foundry"].models[] to register this provider model. For custom or proxy providers, also set api and baseUrl so requests route to the intended endpoint. See https://docs.openclaw.ai/concepts/model-providers.',
+      'Unknown model: microsoft-foundry/Kimi-K2.6-1. Found agents.defaults.models["microsoft-foundry/Kimi-K2.6-1"], but the bundled provider "microsoft-foundry" has no registered model "Kimi-K2.6-1". This usually means the provider has no authenticated profile — run `openclaw models status` to check provider auth and re-authenticate if needed. See https://docs.openclaw.ai/concepts/model-providers.',
+    );
+  });
+
+  it("suggests adding config when a non-bundled provider model is missing", async () => {
+    const cfg = {
+      agents: {
+        defaults: {
+          models: {
+            "custom-provider/some-model": {},
+          },
+        },
+      },
+    } as unknown as OpenClawConfig;
+
+    const result = await resolveModelAsync("custom-provider", "some-model", "/tmp/agent", cfg, {
+      runtimeHooks: createRuntimeHooks(),
+      skipAgentDiscovery: true,
+    });
+
+    expect(result.error).toBe(
+      'Unknown model: custom-provider/some-model. Found agents.defaults.models["custom-provider/some-model"], but no matching models.providers["custom-provider"].models[] entry. Add { "id": "some-model", "name": "some-model" } to models.providers["custom-provider"].models[] to register this provider model. For custom or proxy providers, also set api and baseUrl so requests route to the intended endpoint. See https://docs.openclaw.ai/concepts/model-providers.',
     );
   });
 

--- a/src/agents/embedded-agent-runner/model.test.ts
+++ b/src/agents/embedded-agent-runner/model.test.ts
@@ -2825,7 +2825,7 @@ describe("resolveModel", () => {
     });
 
     expect(result.error).toBe(
-      'Unknown model: openai-codex/gpt-5.4. Found agents.defaults.models["openai-codex/gpt-5.4"], but "openai-codex" is a legacy alias that has been folded into the openai provider. This provider requires OAuth authentication — run \`openclaw models auth login openai\` to sign in, or run \`openclaw doctor --fix\` to migrate legacy config references. See https://docs.openclaw.ai/concepts/model-providers.',
+      'Unknown model: openai-codex/gpt-5.4. Found agents.defaults.models["openai-codex/gpt-5.4"], but "openai-codex" is a legacy alias that has been folded into the openai provider. This provider requires OAuth authentication — run `openclaw models auth login openai` to sign in, or run `openclaw doctor --fix` to migrate legacy config references. See https://docs.openclaw.ai/concepts/model-providers.',
     );
   });
 

--- a/src/agents/embedded-agent-runner/model.test.ts
+++ b/src/agents/embedded-agent-runner/model.test.ts
@@ -2825,7 +2825,7 @@ describe("resolveModel", () => {
     });
 
     expect(result.error).toBe(
-      'Unknown model: openai-codex/gpt-5.4. Found agents.defaults.models["openai-codex/gpt-5.4"], but "openai-codex" is a legacy alias that has been folded into the openai provider. This provider requires OAuth authentication — run `openclaw models auth login openai` to sign in, or run `openclaw doctor --fix` to migrate legacy config references. See https://docs.openclaw.ai/concepts/model-providers.',
+      'Unknown model: openai-codex/gpt-5.4. Found agents.defaults.models["openai-codex/gpt-5.4"], but "openai-codex" is a legacy alias that has been folded into the openai provider. This provider requires OAuth authentication — run `openclaw models auth login --provider openai` to sign in, or run `openclaw doctor --fix` to migrate legacy config references. See https://docs.openclaw.ai/concepts/model-providers.',
     );
   });
 

--- a/src/agents/embedded-agent-runner/model.test.ts
+++ b/src/agents/embedded-agent-runner/model.test.ts
@@ -2829,7 +2829,7 @@ describe("resolveModel", () => {
     );
   });
 
-  it("keeps config suggestion for non-bundled legacy alias provider", async () => {
+  it("keeps config registration hint for built-in providers other than openai-codex", async () => {
     const cfg = {
       agents: {
         defaults: {
@@ -2849,7 +2849,7 @@ describe("resolveModel", () => {
     });
 
     expect(result.error).toBe(
-      'Unknown model: microsoft-foundry/Kimi-K2.6-1. Found agents.defaults.models["microsoft-foundry/Kimi-K2.6-1"], but the bundled provider "microsoft-foundry" has no registered model "Kimi-K2.6-1". This usually means the provider has no authenticated profile — run `openclaw models status` to check provider auth and re-authenticate if needed. See https://docs.openclaw.ai/concepts/model-providers.',
+      'Unknown model: microsoft-foundry/Kimi-K2.6-1. Found agents.defaults.models["microsoft-foundry/Kimi-K2.6-1"], but no matching models.providers["microsoft-foundry"].models[] entry. Add { "id": "Kimi-K2.6-1", "name": "Kimi-K2.6-1" } to models.providers["microsoft-foundry"].models[] to register this provider model. For custom or proxy providers, also set api and baseUrl so requests route to the intended endpoint. See https://docs.openclaw.ai/concepts/model-providers.',
     );
   });
 

--- a/src/agents/embedded-agent-runner/model.test.ts
+++ b/src/agents/embedded-agent-runner/model.test.ts
@@ -2808,7 +2808,28 @@ describe("resolveModel", () => {
     expect(result.model?.input).toEqual(["text"]);
   });
 
-  it("suggests checking auth when a bundled provider model is missing", async () => {
+  it("suggests checking auth for canonical bundled provider (openai-codex)", async () => {
+    const cfg = {
+      agents: {
+        defaults: {
+          models: {
+            "openai-codex/gpt-5.4": {},
+          },
+        },
+      },
+    } as unknown as OpenClawConfig;
+
+    const result = await resolveModelAsync("openai-codex", "gpt-5.4", "/tmp/agent", cfg, {
+      runtimeHooks: createRuntimeHooks(),
+      skipAgentDiscovery: true,
+    });
+
+    expect(result.error).toBe(
+      'Unknown model: openai-codex/gpt-5.4. Found agents.defaults.models["openai-codex/gpt-5.4"], but the bundled provider "openai-codex" has no registered model "gpt-5.4". This usually means the provider has no authenticated profile — run `openclaw models status` to check provider auth and re-authenticate if needed. See https://docs.openclaw.ai/concepts/model-providers.',
+    );
+  });
+
+  it("keeps config suggestion for non-bundled legacy alias provider", async () => {
     const cfg = {
       agents: {
         defaults: {

--- a/src/agents/embedded-agent-runner/model.ts
+++ b/src/agents/embedded-agent-runner/model.ts
@@ -1930,12 +1930,16 @@ function buildMissingProviderModelRegistrationHint(params: {
   if (agentRuntimeId) {
     return `Found agents.defaults.models["${agentModelKey}"] bound to the "${agentRuntimeId}" agent runtime. Models served by an agent runtime come from that runtime and its linked account, not from models.providers["${params.provider}"].models[] — registering it there will not make it usable. Confirm "${params.modelId}" is still offered by the "${agentRuntimeId}" runtime and switch agents.defaults.model.primary to a currently available model (run \`openclaw models list --provider ${params.provider}\` to list them). See https://docs.openclaw.ai/concepts/model-providers.`;
   }
-  // Bundled providers register models automatically at startup; if a model is
-  // missing, the most likely cause is a missing or expired auth profile, not a
-  // missing models.providers[] config entry. Pointing operators at config is
-  // actively harmful: the config validator rejects overlays without baseUrl for
-  // non-bundled ids, creating contradictory guidance (#100066).
-  if (isBuiltInModelProviderOverlayId(params.provider)) {
+  // Bundled providers (and legacy aliases like openai-codex) register models
+  // automatically at startup; if a model is missing, the most likely cause is a
+  // missing or expired auth profile, not a missing models.providers[] config entry.
+  // Pointing operators at config is actively harmful: the config validator rejects
+  // overlays without baseUrl for non-bundled ids, creating contradictory guidance
+  // (#100066).
+  const normalizedProvider = normalizeProviderId(params.provider);
+  const isBundledOrLegacyAlias =
+    isBuiltInModelProviderOverlayId(normalizedProvider) || normalizedProvider === "openai-codex";
+  if (isBundledOrLegacyAlias) {
     return `Found agents.defaults.models["${agentModelKey}"], but the bundled provider "${params.provider}" has no registered model "${params.modelId}". This usually means the provider has no authenticated profile — run \`openclaw models status\` to check provider auth and re-authenticate if needed. See https://docs.openclaw.ai/concepts/model-providers.`;
   }
   const providerConfig = findNormalizedProviderValue(

--- a/src/agents/embedded-agent-runner/model.ts
+++ b/src/agents/embedded-agent-runner/model.ts
@@ -1935,7 +1935,7 @@ function buildMissingProviderModelRegistrationHint(params: {
   // at models.providers[] is actively harmful: the config validator rejects the
   // overlay without baseUrl, creating contradictory guidance (#100066).
   if (normalizeProviderId(params.provider) === "openai-codex") {
-    return `Found agents.defaults.models["${agentModelKey}"], but the bundled provider "${params.provider}" has no registered model "${params.modelId}". This usually means the provider has no authenticated profile — run \`openclaw models status\` to check provider auth and re-authenticate if needed. See https://docs.openclaw.ai/concepts/model-providers.`;
+    return `Found agents.defaults.models["${agentModelKey}"], but "${params.provider}" is a legacy alias that has been folded into the openai provider. This provider requires OAuth authentication — run \`openclaw models auth login openai\` to sign in, or run \`openclaw doctor --fix\` to migrate legacy config references. See https://docs.openclaw.ai/concepts/model-providers.`;
   }
   const providerConfig = findNormalizedProviderValue(
     params.cfg?.models?.providers,

--- a/src/agents/embedded-agent-runner/model.ts
+++ b/src/agents/embedded-agent-runner/model.ts
@@ -5,6 +5,7 @@ import { finiteSecondsToTimerSafeMilliseconds } from "@openclaw/normalization-co
 import { normalizeLowercaseStringOrEmpty } from "@openclaw/normalization-core/string-coerce";
 import type { ModelCompatConfig, ModelMediaInputConfig } from "../../config/types.models.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
+import { isBuiltInModelProviderOverlayId } from "../../config/zod-schema.core.js";
 import type { ModelRegistry as CoreModelRegistry } from "../../llm/model-registry.js";
 import type { Api, Model } from "../../llm/types.js";
 import type { ProviderRuntimeModel } from "../../plugins/provider-runtime-model.types.js";
@@ -1928,6 +1929,14 @@ function buildMissingProviderModelRegistrationHint(params: {
   const agentRuntimeId = configuredEntry.agentRuntime?.id;
   if (agentRuntimeId) {
     return `Found agents.defaults.models["${agentModelKey}"] bound to the "${agentRuntimeId}" agent runtime. Models served by an agent runtime come from that runtime and its linked account, not from models.providers["${params.provider}"].models[] — registering it there will not make it usable. Confirm "${params.modelId}" is still offered by the "${agentRuntimeId}" runtime and switch agents.defaults.model.primary to a currently available model (run \`openclaw models list --provider ${params.provider}\` to list them). See https://docs.openclaw.ai/concepts/model-providers.`;
+  }
+  // Bundled providers register models automatically at startup; if a model is
+  // missing, the most likely cause is a missing or expired auth profile, not a
+  // missing models.providers[] config entry. Pointing operators at config is
+  // actively harmful: the config validator rejects overlays without baseUrl for
+  // non-bundled ids, creating contradictory guidance (#100066).
+  if (isBuiltInModelProviderOverlayId(params.provider)) {
+    return `Found agents.defaults.models["${agentModelKey}"], but the bundled provider "${params.provider}" has no registered model "${params.modelId}". This usually means the provider has no authenticated profile — run \`openclaw models status\` to check provider auth and re-authenticate if needed. See https://docs.openclaw.ai/concepts/model-providers.`;
   }
   const providerConfig = findNormalizedProviderValue(
     params.cfg?.models?.providers,

--- a/src/agents/embedded-agent-runner/model.ts
+++ b/src/agents/embedded-agent-runner/model.ts
@@ -1935,7 +1935,7 @@ function buildMissingProviderModelRegistrationHint(params: {
   // at models.providers[] is actively harmful: the config validator rejects the
   // overlay without baseUrl, creating contradictory guidance (#100066).
   if (normalizeProviderId(params.provider) === "openai-codex") {
-    return `Found agents.defaults.models["${agentModelKey}"], but "${params.provider}" is a legacy alias that has been folded into the openai provider. This provider requires OAuth authentication — run \`openclaw models auth login openai\` to sign in, or run \`openclaw doctor --fix\` to migrate legacy config references. See https://docs.openclaw.ai/concepts/model-providers.`;
+    return `Found agents.defaults.models["${agentModelKey}"], but "${params.provider}" is a legacy alias that has been folded into the openai provider. This provider requires OAuth authentication — run \`openclaw models auth login --provider openai\` to sign in, or run \`openclaw doctor --fix\` to migrate legacy config references. See https://docs.openclaw.ai/concepts/model-providers.`;
   }
   const providerConfig = findNormalizedProviderValue(
     params.cfg?.models?.providers,

--- a/src/agents/embedded-agent-runner/model.ts
+++ b/src/agents/embedded-agent-runner/model.ts
@@ -5,7 +5,6 @@ import { finiteSecondsToTimerSafeMilliseconds } from "@openclaw/normalization-co
 import { normalizeLowercaseStringOrEmpty } from "@openclaw/normalization-core/string-coerce";
 import type { ModelCompatConfig, ModelMediaInputConfig } from "../../config/types.models.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
-import { isBuiltInModelProviderOverlayId } from "../../config/zod-schema.core.js";
 import type { ModelRegistry as CoreModelRegistry } from "../../llm/model-registry.js";
 import type { Api, Model } from "../../llm/types.js";
 import type { ProviderRuntimeModel } from "../../plugins/provider-runtime-model.types.js";
@@ -1930,16 +1929,12 @@ function buildMissingProviderModelRegistrationHint(params: {
   if (agentRuntimeId) {
     return `Found agents.defaults.models["${agentModelKey}"] bound to the "${agentRuntimeId}" agent runtime. Models served by an agent runtime come from that runtime and its linked account, not from models.providers["${params.provider}"].models[] — registering it there will not make it usable. Confirm "${params.modelId}" is still offered by the "${agentRuntimeId}" runtime and switch agents.defaults.model.primary to a currently available model (run \`openclaw models list --provider ${params.provider}\` to list them). See https://docs.openclaw.ai/concepts/model-providers.`;
   }
-  // Bundled providers (and legacy aliases like openai-codex) register models
-  // automatically at startup; if a model is missing, the most likely cause is a
-  // missing or expired auth profile, not a missing models.providers[] config entry.
-  // Pointing operators at config is actively harmful: the config validator rejects
-  // overlays without baseUrl for non-bundled ids, creating contradictory guidance
-  // (#100066).
-  const normalizedProvider = normalizeProviderId(params.provider);
-  const isBundledOrLegacyAlias =
-    isBuiltInModelProviderOverlayId(normalizedProvider) || normalizedProvider === "openai-codex";
-  if (isBundledOrLegacyAlias) {
+  // Legacy openai-codex is folded into the openai bundled provider. Its models
+  // register automatically at startup, so a missing-model error here is almost
+  // always a missing auth profile, not a missing config entry. Pointing operators
+  // at models.providers[] is actively harmful: the config validator rejects the
+  // overlay without baseUrl, creating contradictory guidance (#100066).
+  if (normalizeProviderId(params.provider) === "openai-codex") {
     return `Found agents.defaults.models["${agentModelKey}"], but the bundled provider "${params.provider}" has no registered model "${params.modelId}". This usually means the provider has no authenticated profile — run \`openclaw models status\` to check provider auth and re-authenticate if needed. See https://docs.openclaw.ai/concepts/model-providers.`;
   }
   const providerConfig = findNormalizedProviderValue(


### PR DESCRIPTION
## What Problem This Solves

When `openai-codex` (legacy alias folded into `openai`) has no auth profile, the runtime error prescribes a config edit the validator rejects — brickwalling the gateway. Fix: detect legacy alias, point to OAuth login or doctor migration.

Closes #100066.

## Fix (4 lines)

`src/agents/embedded-agent-runner/model.ts`: check `normalizeProviderId === "openai-codex"` before generic config hint. Blast radius: 1 alias.

## Evidence

### Real behavior proof — production function call (current HEAD)

```
$ node --import tsx scripts/proof-100104.mjs

=== REAL PROOF: openai-codex error path (current HEAD) ===
Unknown model: openai-codex/gpt-5.4. Found agents.defaults.models["openai-codex/gpt-5.4"],
but "openai-codex" is a legacy alias that has been folded into the openai provider.
This provider requires OAuth authentication — run `openclaw models auth login --provider openai`
to sign in, or run `openclaw doctor --fix` to migrate legacy config references.
See https://docs.openclaw.ai/concepts/model-providers.

--- Verification ---
--provider flag:   PASS
doctor --fix:      PASS
legacy alias:      PASS
docs link:         PASS
```

The proof script imports `resolveModelAsync` (the same function the CLI gateway uses), passes `openai-codex/gpt-5.4` with no auth profile — the exact scenario from #100066 — and asserts the corrected hint message contains all required guidance.

### Test suite (122 tests)

```
$ node scripts/run-vitest.mjs src/agents/embedded-agent-runner/model.test.ts

 Test Files  1 passed (1)
      Tests  122 passed (122)
```

### Before/After

| | Before | After |
|---|--------|-------|
| openai-codex | "Add config" → crash | "Run `openclaw models auth login --provider openai`" |
| Other providers | "Add config" | "Add config" (unchanged) |

### Pre-submit

oxfmt/oxlint clean | autoreview 0.95 | 122 tests

## Change Type

Bug fix | model-resolution | 2 files, +50/-1, XS
