### PR TITLE
docs: tailor imsg skill for OpenClaw agents

### DIFF
--- a/skills/imsg/SKILL.md
+++ b/skills/imsg/SKILL.md
@@ -205,14 +205,11 @@ Use `send-rich --reply-to <message-guid>` for threaded replies. Confirm the refe
 
 Native Apple Messages polls require the bridge. Creation needs at least two `--option` values. Voting requires one of `--option-id`, `--option-index`, or `--option`.
 
-Messages renders only the options on a poll balloon — the poll title is never shown to recipients. So `poll send` automatically echoes `--question` as a reply comment on the poll (a text whose `reply_to` is the poll guid, exactly what the native "comment or Send" field produces). Just set `--question` and the visible caption appears for free — no extra step. Use `--comment` only to make the visible caption differ from the stored title.
+Messages renders only the options on a poll balloon; the `--question` title is not shown to recipients. Set `--question` (required) plus at least two `--option` values.
 
 ```bash
 imsg poll send --chat 'iMessage;-;+15551234567' \
   --question "Dinner?" --option "Pizza" --option "Sushi"
-# --comment overrides the echoed caption when it should differ from --question:
-imsg poll send --chat 'iMessage;-;+15551234567' \
-  --question "Dinner?" --comment "Vote by 5pm 🍽️" --option "Pizza" --option "Sushi"
 imsg poll send --chat 'iMessage;+;chat0000' --reply-to <message-guid> \
   --question "Approve?" --option "Yes" --option "No"
 imsg poll vote --chat 'iMessage;+;chat0000' \
@@ -226,8 +223,6 @@ imsg history --chat-id 42 --limit 20 --json | jq -s '.[] | select(.poll != null)
 ```
 
 Poll vote rows are `poll` events, not tapbacks; `watch --reactions` is not required to see them.
-
-Inbound native polls carry no title of their own, so imsg backfills the poll's `question` from its caption (the reply-to-the-poll message) — a native poll read back from history/watch shows the real question, not an empty one.
 
 ## Watch and Long-Running Agents
 

--- a/skills/imsg/SKILL.md
+++ b/skills/imsg/SKILL.md
@@ -205,9 +205,14 @@ Use `send-rich --reply-to <message-guid>` for threaded replies. Confirm the refe
 
 Native Apple Messages polls require the bridge. Creation needs at least two `--option` values. Voting requires one of `--option-id`, `--option-index`, or `--option`.
 
+Messages renders only the options on a poll balloon — the poll title is never shown to recipients. So `poll send` automatically echoes `--question` as a reply comment on the poll (a text whose `reply_to` is the poll guid, exactly what the native "comment or Send" field produces). Just set `--question` and the visible caption appears for free — no extra step. Use `--comment` only to make the visible caption differ from the stored title.
+
 ```bash
 imsg poll send --chat 'iMessage;-;+15551234567' \
   --question "Dinner?" --option "Pizza" --option "Sushi"
+# --comment overrides the echoed caption when it should differ from --question:
+imsg poll send --chat 'iMessage;-;+15551234567' \
+  --question "Dinner?" --comment "Vote by 5pm 🍽️" --option "Pizza" --option "Sushi"
 imsg poll send --chat 'iMessage;+;chat0000' --reply-to <message-guid> \
   --question "Approve?" --option "Yes" --option "No"
 imsg poll vote --chat 'iMessage;+;chat0000' \

--- a/skills/imsg/SKILL.md
+++ b/skills/imsg/SKILL.md
@@ -227,6 +227,8 @@ imsg history --chat-id 42 --limit 20 --json | jq -s '.[] | select(.poll != null)
 
 Poll vote rows are `poll` events, not tapbacks; `watch --reactions` is not required to see them.
 
+Inbound native polls carry no title of their own, so imsg backfills the poll's `question` from its caption (the reply-to-the-poll message) — a native poll read back from history/watch shows the real question, not an empty one.
+
 ## Watch and Long-Running Agents
 
 For a short one-off wait, use `watch`:

--- a/skills/imsg/SKILL.md
+++ b/skills/imsg/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: imsg
-description: "iMessage/SMS CLI for listing chats, history, and sending messages via Messages.app."
+description: "Use the imsg CLI from OpenClaw agents for iMessage/SMS DMs, groups, replies, reactions, polls, watching, and private-API actions."
 homepage: https://imsg.to
 metadata:
   {
@@ -25,98 +25,223 @@ metadata:
 
 # imsg
 
-Use `imsg` to read and send iMessage/SMS via macOS Messages.app.
+Use `imsg` when an OpenClaw agent must act through the user's local macOS Messages.app account: inspect iMessage/SMS history, choose the correct DM or group, send messages/files, reply, react, vote in polls, or use private-API iMessage features.
 
-## When to Use
+Do not use this skill for Telegram, Signal, WhatsApp, Discord, Slack, or for replying inside the current OpenClaw conversation when the configured channel already routes the reply.
 
-Use when:
+## Agent Flow
 
-- User explicitly asks to send iMessage or SMS
-- Reading iMessage conversation history
-- Checking recent Messages.app chats
-- Sending to phone numbers or Apple IDs
+1. Resolve the conversation first.
+2. Choose DM, existing group, or new group.
+3. Pick the lowest-capability command that can do the requested action.
+4. Confirm any send or visible state change unless the user already gave exact recipient, content, and action.
+5. Execute with stable identifiers: prefer `--chat-id` for normal sends/watch/history and `--chat` chat GUID for bridge actions.
 
-## When NOT to Use
+Never infer a recipient from a casual name alone when several chats or handles could match. Show the matched display name, handle(s), group participants, and message text/action before sending.
 
-Do not use when:
+## Host Requirements
 
-- Telegram messages -> use `message` tool with `channel:telegram`
-- Signal messages -> use Signal channel if configured
-- WhatsApp messages -> use WhatsApp channel if configured
-- Discord messages -> use `message` tool with `channel:discord`
-- Slack messages -> use `slack` skill
-- Group chat management (adding/removing members) -> not supported
-- Bulk/mass messaging -> always confirm with user first
-- Replying in current conversation -> just reply normally (OpenClaw routes automatically)
+- macOS 14+ with Messages.app signed in for send/react/bridge actions.
+- Full Disk Access for the process context that runs `imsg` or OpenClaw; reads fail without Messages DB access.
+- Automation permission for Messages.app when using public `send`.
+- Accessibility permission for the process context that runs public `imsg react`; it uses System Events UI automation. Bridge `tapback` uses private API instead.
+- Optional Contacts permission for contact-name resolution.
+- SMS sends require Text Message Forwarding from the user's iPhone to this Mac.
+- Linux reads a copied `chat.db` only; it cannot send, react, launch Messages.app, mark read, or type.
 
-## Requirements
+## Resolve Targets
 
-- macOS with Messages.app signed in
-- Full Disk Access for terminal
-- Automation permission for Messages.app (for sending)
-
-## Common Commands
-
-### List Chats
+Use `--json` reads. Output is newline-delimited JSON; use `jq -s` when `jq` is available, or consume one object per line directly.
 
 ```bash
-imsg chats --limit 10 --json
+imsg chats --limit 25 --json | jq -s
+imsg search --query "dinner" --match contains --json | jq -s
+imsg history --chat-id 42 --limit 20 --attachments --json | jq -s
+imsg group --chat-id 42 --json
 ```
 
-### View History
+Target rules:
+
+- DM to a phone/email: use `imsg send --to` when the user gave an exact handle, or after a single unambiguous chat match.
+- Existing DM thread: `imsg send --chat-id <id>` is safer than re-resolving a name.
+- Existing group: inspect with `imsg group --chat-id <id> --json`; send with `--chat-id`, bridge with the chat GUID from `group`.
+- New group: use `chat-create` only when the user explicitly asked to create a group or no existing group matches.
+- Ambiguous group names: confirm participants, not just display name.
+- SMS: use `--service sms` only when requested or when iMessage fallback is not desired. SMS relay requires Text Message Forwarding.
+
+Do not make `jq` a hard prerequisite for the skill; it is only a convenient formatter for examples.
+
+## Capability Choice
+
+Use public Messages automation when enough:
+
+- Read/list/search/watch: `chats`, `group`, `history`, `search`, `watch`
+- Basic text/file send: `send`
+- Standard tapback to most recent incoming message in a chat: `react`
+
+Use the private API bridge only for features public automation cannot do:
+
+- Rich replies, text formatting, effects, subjects, multipart sends
+- Native Apple Messages polls and poll votes
+- Tapback by message GUID or tapback removal
+- Edit, unsend, delete, notify anyways
+- Read receipts, typing indicators, bridge event watch
+- Group create/name/photo/member/leave/delete/mark actions
+- Account, whois, nickname checks
+
+Before bridge actions, check:
 
 ```bash
-# By chat ID
-imsg history --chat-id 1 --limit 20 --json
-
-# With attachments info
-imsg history --chat-id 1 --limit 20 --attachments --json
+imsg status --json
 ```
 
-### Watch for New Messages
+If the host supports bridge actions but Messages is not injected yet, ask before running `imsg launch`. It kills and relaunches Messages.app to inject the bridge, so treat it as a visible state change:
 
 ```bash
-imsg watch --chat-id 1 --attachments
+imsg launch
+imsg status --json
 ```
 
-### Send Messages
+If SIP, library validation, private entitlement checks, or missing selectors still block the capability, do not ask the user to disable SIP casually. Explain that the requested private-API action is unavailable on this host and offer the closest non-bridge action, if one exists.
+
+## DM Scenarios
+
+Exact handle, basic send:
 
 ```bash
-# Text only
-imsg send --to "+14155551212" --text "Hello!"
-
-# With attachment
-imsg send --to "+14155551212" --text "Check this out" --file /path/to/image.jpg
-
-# Specify service
-imsg send --to "+14155551212" --text "Hi" --service imessage
-imsg send --to "+14155551212" --text "Hi" --service sms
+imsg send --to "+14155551212" --text "On my way" --service auto
 ```
 
-## Service Options
+Known DM thread:
 
-- `--service imessage` - Force iMessage (requires recipient has iMessage)
-- `--service sms` - Force SMS (green bubble)
-- `--service auto` - Let Messages.app decide (default)
+```bash
+imsg send --chat-id 42 --text "On my way"
+imsg send --chat-id 42 --file /path/to/photo.jpg
+```
+
+Force channel only when the user asks:
+
+```bash
+imsg send --to "+14155551212" --text "green bubble" --service sms
+imsg send --to "+14155551212" --text "iMessage only" --service imessage --no-sms-fallback
+```
+
+Threaded reply, formatting, effects, or attachment reply:
+
+```bash
+imsg send-rich --chat 'iMessage;-;+15551234567' \
+  --reply-to <message-guid> --text "reply text"
+imsg send-rich --chat 'iMessage;-;+15551234567' --text 'hello world' \
+  --format '[{"start":0,"length":5,"styles":["bold"]}]'
+imsg send-rich --chat 'iMessage;-;+15551234567' --text "boom" --effect impact
+imsg send-attachment --chat 'iMessage;-;+15551234567' \
+  --reply-to <message-guid> --file /path/to/file.jpg
+```
+
+Formatting ranges are UTF-16 positions. Supported styles include `bold`, `italic`, `underline`, and `strikethrough`; use `--format-file` for generated JSON.
+
+## Group Scenarios
+
+Inspect before acting:
+
+```bash
+imsg group --chat-id 42 --json
+imsg history --chat-id 42 --limit 20 --json | jq -s
+```
+
+Send to an existing group:
+
+```bash
+imsg send --chat-id 42 --text "Works for me"
+```
+
+Bridge reply or poll in an existing group:
+
+```bash
+imsg send-rich --chat 'iMessage;+;chat0000' \
+  --reply-to <message-guid> --text "replying in thread"
+imsg poll send --chat 'iMessage;+;chat0000' \
+  --question "Dinner?" --option "Pizza" --option "Sushi"
+```
+
+Create or mutate groups only on explicit request:
+
+```bash
+imsg chat-create --addresses '+15551111111,+15552222222' --name 'Crew' --text 'gm'
+imsg chat-name --chat 'iMessage;+;chat0000' --name 'Renamed'
+imsg chat-photo --chat 'iMessage;+;chat0000' --file /path/to/group.jpg
+imsg chat-add-member --chat 'iMessage;+;chat0000' --address +15553333333
+imsg chat-remove-member --chat 'iMessage;+;chat0000' --address +15553333333
+imsg chat-leave --chat 'iMessage;+;chat0000'
+imsg chat-delete --chat 'iMessage;+;chat0000'
+imsg chat-mark --chat 'iMessage;+;chat0000' --read
+```
+
+Group mutations are highly visible. Confirm the exact group and participant list before changing membership, name, photo, read state, leaving, or deleting.
+
+## Reactions and Replies
+
+Public `react` is limited: it reacts to the most recent incoming message in the chat.
+
+```bash
+imsg react --chat-id 42 --reaction like
+imsg react --chat-id 42 --reaction love
+imsg react --chat-id 42 --reaction dislike
+imsg react --chat-id 42 --reaction laugh
+imsg react --chat-id 42 --reaction emphasis
+imsg react --chat-id 42 --reaction question
+```
+
+For a specific message GUID or removal, use bridge `tapback`:
+
+```bash
+imsg tapback --chat 'iMessage;-;+15551234567' --message <message-guid> --kind love
+imsg tapback --chat 'iMessage;-;+15551234567' --message <message-guid> --kind love --remove
+```
+
+Use `send-rich --reply-to <message-guid>` for threaded replies. Confirm the referenced message if the user says "that" or "the previous one".
+
+## Polls
+
+Native Apple Messages polls require the bridge. Creation needs at least two `--option` values. Voting requires one of `--option-id`, `--option-index`, or `--option`.
+
+```bash
+imsg poll send --chat 'iMessage;-;+15551234567' \
+  --question "Dinner?" --option "Pizza" --option "Sushi"
+imsg poll send --chat 'iMessage;+;chat0000' --reply-to <message-guid> \
+  --question "Approve?" --option "Yes" --option "No"
+imsg poll vote --chat 'iMessage;+;chat0000' \
+  --poll <poll-message-guid> --option-id <option-id>
+```
+
+Find poll IDs and options with:
+
+```bash
+imsg history --chat-id 42 --limit 20 --json | jq -s '.[] | select(.poll != null) | {guid, poll}'
+```
+
+Poll vote rows are `poll` events, not tapbacks; `watch --reactions` is not required to see them.
+
+## Watch and Long-Running Agents
+
+For a short one-off wait, use `watch`:
+
+```bash
+imsg watch --chat-id 42 --since-rowid 9000 --json
+imsg watch --chat-id 42 --attachments --convert-attachments --json
+imsg watch --chat-id 42 --reactions --json
+imsg watch --chat-id 42 --bb-events --json
+```
+
+`--since-rowid` is exclusive. Without it, `watch` starts at the newest row. `watch` uses filesystem events plus a low-frequency polling fallback, so it can catch up after missed SQLite sidecar events. Poll objects appear without `--reactions`.
+
+For a daemon or multi-chat integration, use `imsg rpc`. It speaks JSON-RPC 2.0 over stdin/stdout. Inspect `imsg status --json` for `rpc_methods` before using newer bridge or poll methods.
 
 ## Safety Rules
 
-1. **Always confirm recipient and message content** before sending
-2. **Never send to unknown numbers** without explicit user approval
-3. **Be careful with attachments** - confirm file path exists
-4. **Rate limit yourself** - don't spam
-
-## Example Workflow
-
-User: "Text mom that I'll be late"
-
-```bash
-# 1. Find mom's chat
-imsg chats --limit 20 --json | jq '.[] | select(.displayName | contains("Mom"))'
-
-# 2. Confirm with user
-# "Found Mom at +1555123456. Send 'I'll be late' via iMessage?"
-
-# 3. Send after confirmation
-imsg send --to "+1555123456" --text "I'll be late"
-```
+- Confirm recipient, chat, and content before every send unless the user's request already contains exact values.
+- Confirm visible state changes: read receipts, typing indicators, edits, unsends, deletes, poll votes, tapbacks, group membership, group name/photo, leaving/deleting chats.
+- Never send to unknown numbers or ambiguous contact-name matches without approval.
+- Confirm attachments exist and are the intended files.
+- Prefer E.164 phone numbers; use `--region US` or another region only when needed for local formats.
+- Do not use bridge actions just because they are available; use them only when the requested behavior needs them.


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where the bundled `imsg` skill read like a generic CLI reference and did not guide OpenClaw agents through DM vs group targeting, bridge-only features, or safety-sensitive iMessage actions.

## Why This Change Was Made

The skill now starts from the agent workflow: resolve the conversation, choose DM/existing group/new group, pick the lowest-capability command, confirm sends and visible state changes, and then execute with stable identifiers. It also documents current `imsg` surfaces for replies, formatting, reactions, polls, watch, long-running RPC, and private API actions while keeping public AppleScript permissions separate from bridge-backed IMCore behavior.

## User Impact

OpenClaw agents get clearer guidance for using `imsg` correctly across direct messages and group chats. They should be less likely to send to ambiguous recipients, mutate groups accidentally, confuse public `react` with bridge `tapback`, or run `imsg launch` without user approval.

## Evidence

Documented commands verified against the installed **imsg 0.12.2** on macOS 26 (this is a docs change, so proof = the documented surface matches the real CLI):

```console
$ imsg --version
0.12.2

# Poll surface the skill documents — --question/--option/--reply-to/vote flags exist,
# and there is deliberately NO --comment (that lives in openclaw/imsg#155, not shipped):
$ imsg poll --help | grep -E '^\s+--'
  --chat <value>        chat guid or rowid
  --chat-id <value>     chat rowid
  --question <value>    poll question
  --reply-to <value>    guid of message to reply to
  --option <value>      poll option text; pass at least twice
  --poll <value>        vote: guid of the poll message to vote on
  --option-id <value>   vote: UUID of the option to select
  --option-index <value>  vote: 1-based option number to select

# Capability keys the skill tells agents to gate on:
$ imsg status --json | jq '{bridge_version, v2_ready, basic_features, advanced_features}'
{ "bridge_version": 2, "v2_ready": true, "basic_features": true, "advanced_features": true }

# The documented poll-read jq filter returns real poll objects from history:
$ imsg history --chat-id <id> --limit 40 --json \
    | jq -s '[.[] | select(.poll != null) | {kind: .poll.kind}] | group_by(.kind) | map({(.[0].kind): length}) | add'
{ "created": 5, "vote": 3 }
```

Also: `git diff --check -- skills/imsg/SKILL.md` clean; `pnpm docs:list` used to identify relevant iMessage docs context.

**Scope note:** an earlier revision documented the poll caption echo, `--comment` override, and inbound question backfill; those live in openclaw/imsg#155, not shipped imsg 0.12.2, and were removed in 01e9c38 so this skill documents only shipped behavior (see the `poll --help` proof above). They'll be re-added once a release ships #155.

