### PR TITLE
fix(ui): repair router refactor regressions

### DIFF
--- a/ui/src/app-navigation.test.ts
+++ b/ui/src/app-navigation.test.ts
@@ -200,6 +200,11 @@ describe("routeIdFromPath", () => {
     expect(routeIdFromPath("/apps/openclaw/sessions", "/apps/openclaw")).toBe("sessions");
   });
 
+  it("rejects route-shaped paths outside the configured base path", () => {
+    expect(routeIdFromPath("/xx/chat", "/ui")).toBeNull();
+    expect(routeIdFromPath("/other/sessions", "/apps/openclaw")).toBeNull();
+  });
+
   it("returns null for unknown path", () => {
     expect(routeIdFromPath("/unknown")).toBeNull();
   });

--- a/ui/src/app-route-paths.ts
+++ b/ui/src/app-route-paths.ts
@@ -51,6 +51,13 @@ export function pathForRoute(routeId: RouteId, basePath = ""): string {
 export function routeIdFromPath(pathname: string, basePath = ""): RouteId | null {
   const normalizedPath = normalizePath(pathname);
   const normalizedBasePath = normalizeBasePath(basePath);
+  const isWithinBasePath =
+    !normalizedBasePath ||
+    normalizedPath === normalizedBasePath ||
+    normalizedPath.startsWith(`${normalizedBasePath}/`);
+  if (!isWithinBasePath) {
+    return null;
+  }
   const routePath = normalizedBasePath
     ? normalizedPath.slice(normalizedBasePath.length) || "/"
     : normalizedPath;

--- a/ui/src/app/app-host.ts
+++ b/ui/src/app/app-host.ts
@@ -624,7 +624,12 @@ class OpenClawShell extends LitElement {
               isRouteId(routeId) ? context.preload(routeId) : Promise.resolve()}
           ></openclaw-app-sidebar>
         </div>
-        <main class="content ${activeRoute === "chat" ? "content--chat" : ""}">
+        <main
+          class="content ${activeRoute === "chat" ? "content--chat" : ""} ${activeRoute ===
+          "workboard"
+            ? "content--workboard"
+            : ""}"
+        >
           <openclaw-update-banner
             .props=${{
               statusBanner: this.overlaySnapshot.updateStatusBanner,

--- a/ui/src/components/terminal/terminal-panel.test.ts
+++ b/ui/src/components/terminal/terminal-panel.test.ts
@@ -49,7 +49,7 @@ describe("OpenClawTerminalPanel", () => {
       },
       addEventListener: () => () => {},
     };
-    const panel = new OpenClawTerminalPanel();
+    const panel = document.createElement("openclaw-terminal-panel") as OpenClawTerminalPanel;
     panel.client = client;
     panel.agentId = "ops";
     panel.available = true;

--- a/ui/src/lib/agents/index.test.ts
+++ b/ui/src/lib/agents/index.test.ts
@@ -1,12 +1,6 @@
 // Control UI tests cover agents behavior.
 import { describe, expect, it, vi } from "vitest";
-import {
-  loadAgents,
-  loadToolsCatalog,
-  loadToolsEffective,
-  saveAgentsConfig,
-  setDefaultAgent,
-} from "./index.ts";
+import { loadAgents, loadToolsCatalog, loadToolsEffective, setDefaultAgent } from "./index.ts";
 import type { AgentsConfigCapability, AgentsState } from "./index.ts";
 
 type TestRequest = (method: string, payload?: unknown) => Promise<unknown>;
@@ -346,50 +340,10 @@ describe("loadToolsEffective", () => {
   });
 });
 
-describe("saveAgentsConfig", () => {
-  it("restores the pre-save agent after reload when it still exists", async () => {
-    const { state, config, request } = createSaveState();
-    state.agentsSelectedId = "kimi";
-    request.mockImplementationOnce(async () => {
-      state.agentsSelectedId = null;
-      return {
-        defaultId: "main",
-        mainKey: "main",
-        scope: "per-sender",
-        agents: [
-          { id: "main", name: "main" },
-          { id: "kimi", name: "kimi" },
-        ],
-      };
-    });
-
-    await saveAgentsConfig(state, config);
-
-    expect(config.save).toHaveBeenCalledTimes(1);
-    expect(request).toHaveBeenNthCalledWith(1, "agents.list", {});
-    expect(state.agentsSelectedId).toBe("kimi");
-  });
-
-  it("falls back to the default agent when the saved agent disappears", async () => {
-    const { state, config, request } = createSaveState();
-    state.agentsSelectedId = "kimi";
-    request.mockResolvedValueOnce({
-      defaultId: "main",
-      mainKey: "main",
-      scope: "per-sender",
-      agents: [{ id: "main", name: "main" }],
-    });
-
-    await saveAgentsConfig(state, config);
-
-    expect(config.save).toHaveBeenCalledTimes(1);
-    expect(state.agentsSelectedId).toBe("main");
-  });
-});
-
 describe("setDefaultAgent", () => {
   it("stages the default agent and persists a clean draft", async () => {
-    const { state, config, request } = createSaveState();
+    const { config } = createSaveState();
+    const refreshAgents = vi.fn(async () => null);
     config.state.configForm = { agents: { list: [{ id: "main" }, { id: "kimi" }] } };
     config.state.configFormOriginal = { agents: { list: [{ id: "main" }, { id: "kimi" }] } };
     config.state.configFormDirty = false;
@@ -397,37 +351,29 @@ describe("setDefaultAgent", () => {
       config.state.configFormDirty = true;
       return true;
     });
-    request.mockResolvedValueOnce({
-      defaultId: "kimi",
-      mainKey: "main",
-      scope: "per-sender",
-      agents: [
-        { id: "main", name: "main" },
-        { id: "kimi", name: "kimi" },
-      ],
-    });
-
-    await setDefaultAgent(state, config, "kimi");
+    await setDefaultAgent(config, "kimi", refreshAgents);
 
     expect(config.stageDefaultAgent).toHaveBeenCalledWith("kimi");
     expect(config.save).toHaveBeenCalledTimes(1);
-    expect(request).toHaveBeenCalledWith("agents.list", {});
+    expect(refreshAgents).toHaveBeenCalledTimes(1);
   });
 
   it("does not persist when the agent is absent from the config list", async () => {
-    const { state, config, request } = createSaveState();
+    const { config } = createSaveState();
+    const refreshAgents = vi.fn(async () => null);
     config.state.configForm = { agents: { list: [{ id: "main" }] } };
     vi.mocked(config.stageDefaultAgent).mockReturnValue(false);
 
-    await setDefaultAgent(state, config, "ghost");
+    await setDefaultAgent(config, "ghost", refreshAgents);
 
     expect(config.stageDefaultAgent).toHaveBeenCalledWith("ghost");
     expect(config.save).not.toHaveBeenCalled();
-    expect(request).not.toHaveBeenCalled();
+    expect(refreshAgents).not.toHaveBeenCalled();
   });
 
   it("does not persist unrelated dirty agent config drafts", async () => {
-    const { state, config, request } = createSaveState();
+    const { config } = createSaveState();
+    const refreshAgents = vi.fn(async () => null);
     config.state.configFormDirty = true;
     config.state.configFormOriginal = { agents: { list: [{ id: "main" }, { id: "kimi" }] } };
     config.state.configForm = {
@@ -448,11 +394,11 @@ describe("setDefaultAgent", () => {
       return true;
     });
 
-    await setDefaultAgent(state, config, "kimi");
+    await setDefaultAgent(config, "kimi", refreshAgents);
 
     expect(config.stageDefaultAgent).toHaveBeenCalledWith("kimi");
     expect(config.save).not.toHaveBeenCalled();
-    expect(request).not.toHaveBeenCalled();
+    expect(refreshAgents).not.toHaveBeenCalled();
     expect(config.state.configForm).toEqual({
       agents: {
         list: [
@@ -462,5 +408,20 @@ describe("setDefaultAgent", () => {
       },
     });
     expect(config.state.configFormDirty).toBe(true);
+  });
+
+  it("keeps the shared agent cache unchanged when saving fails", async () => {
+    const { config } = createSaveState();
+    const refreshAgents = vi.fn(async () => null);
+    config.state.configFormDirty = false;
+    vi.mocked(config.stageDefaultAgent).mockImplementation(() => {
+      config.state.configFormDirty = true;
+      return true;
+    });
+    vi.mocked(config.save).mockResolvedValue(false);
+
+    await setDefaultAgent(config, "kimi", refreshAgents);
+
+    expect(refreshAgents).not.toHaveBeenCalled();
   });
 });

--- a/ui/src/lib/agents/index.ts
+++ b/ui/src/lib/agents/index.ts
@@ -191,24 +191,18 @@ export async function loadToolsEffective(
   });
 }
 
-export async function saveAgentsConfig(state: AgentsState, config: AgentsConfigCapability) {
-  const selectedBefore = state.agentsSelectedId;
-  await config.save();
-  await loadAgents(state);
-  if (selectedBefore && state.agentsList?.agents.some((entry) => entry.id === selectedBefore)) {
-    state.agentsSelectedId = selectedBefore;
-  }
-}
-
 export async function setDefaultAgent(
-  state: AgentsState,
   config: AgentsConfigCapability,
   agentId: string,
+  refreshAgents: () => Promise<unknown>,
 ): Promise<void> {
   const hadPendingConfigDraft = config.state.configFormDirty;
   if (config.stageDefaultAgent(agentId)) {
     if (!hadPendingConfigDraft && config.state.configFormDirty) {
-      await saveAgentsConfig(state, config);
+      const saved = await config.save();
+      if (saved) {
+        await refreshAgents();
+      }
     }
   }
 }

--- a/ui/src/lib/cron-status.test.ts
+++ b/ui/src/lib/cron-status.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from "vitest";
+import type { CronJob } from "../api/types.ts";
+import { isCronJobActiveFailure } from "./cron-status.ts";
+
+function failedJob(enabled: boolean): CronJob {
+  return {
+    enabled,
+    state: { lastRunStatus: "error" },
+  } as CronJob;
+}
+
+describe("isCronJobActiveFailure", () => {
+  it("reports only enabled failed jobs as actionable", () => {
+    expect(isCronJobActiveFailure(failedJob(true))).toBe(true);
+    expect(isCronJobActiveFailure(failedJob(false))).toBe(false);
+  });
+});

--- a/ui/src/pages/agents/agents-page.ts
+++ b/ui/src/pages/agents/agents-page.ts
@@ -25,6 +25,7 @@ import {
   buildToolsEffectiveRequestKey,
   refreshVisibleToolsEffectiveForCurrentSession,
   resetToolsEffectiveState,
+  setDefaultAgent,
   type AgentsPanel,
   type AgentsState,
 } from "../../lib/agents/index.ts";
@@ -265,6 +266,12 @@ export class AgentsPage extends LitElement implements AgentsState {
   private ensureInitialData() {
     if (!this.connected || !this.client || !this.routeDataInitialized) {
       return;
+    }
+    if (
+      !this.context.runtimeConfig.state.configSnapshot &&
+      !this.context.runtimeConfig.state.configLoading
+    ) {
+      void this.context.runtimeConfig.ensureLoaded();
     }
     if (!this.agentsList && !this.agentsLoading) {
       void this.loadAgentsAndCommit();
@@ -726,12 +733,12 @@ export class AgentsPage extends LitElement implements AgentsState {
             }
           },
           onSetDefault: (agentId) => {
-            const hadPendingConfigDraft = this.context.runtimeConfig.state.configFormDirty;
-            if (this.context.runtimeConfig.stageDefaultAgent(agentId)) {
-              if (!hadPendingConfigDraft && this.context.runtimeConfig.state.configFormDirty) {
-                this.saveAgentConfig();
-              }
-            }
+            void (async () => {
+              await this.context.runtimeConfig.ensureLoaded();
+              await setDefaultAgent(this.context.runtimeConfig, agentId, () =>
+                this.context.agents.refreshList(),
+              );
+            })();
           },
         }),
         "agents",

--- a/ui/src/pages/chat/chat-state.test.ts
+++ b/ui/src/pages/chat/chat-state.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it, vi } from "vitest";
+import { resolveChatAvatarUrl, type ChatPageHost } from "./chat-state.ts";
+
+vi.mock("../../app/assistant-identity.ts", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../../app/assistant-identity.ts")>()),
+  loadLocalAssistantIdentity: () => ({ avatar: "data:image/png;base64,bG9jYWw=" }),
+}));
+
+describe("resolveChatAvatarUrl", () => {
+  it("prefers the authenticated avatar blob over persisted and protected URLs", () => {
+    const state = {
+      sessionKey: "agent:main:main",
+      chatAvatarUrl: "blob:authenticated-avatar",
+      assistantAvatar: "/avatar/main",
+      assistantAgentId: "main",
+    } as unknown as ChatPageHost;
+
+    expect(resolveChatAvatarUrl(state)).toBe("blob:authenticated-avatar");
+  });
+});

--- a/ui/src/pages/chat/chat-state.ts
+++ b/ui/src/pages/chat/chat-state.ts
@@ -391,6 +391,9 @@ export function resolveChatAvatarUrl(
   >,
 ): string | null {
   const agentId = resolveChatAgentId(state);
+  if (state.chatAvatarUrl) {
+    return state.chatAvatarUrl;
+  }
   const localAvatar = loadLocalAssistantIdentity({ agentId }).avatar;
   if (localAvatar) {
     return localAvatar;
@@ -403,9 +406,6 @@ export function resolveChatAvatarUrl(
     if (state.assistantAgentId === agentId) {
       return assistantAvatar;
     }
-  }
-  if (state.chatAvatarUrl) {
-    return state.chatAvatarUrl;
   }
   const agent = state.agentsList?.agents?.find((candidate) => candidate.id === agentId) as
     | { identity?: { avatar?: string; avatarUrl?: string } }

--- a/ui/src/pages/overview/overview-page.ts
+++ b/ui/src/pages/overview/overview-page.ts
@@ -19,7 +19,7 @@ import {
   type UiSettings,
 } from "../../app/settings.ts";
 import { I18nController, t } from "../../i18n/index.ts";
-import { resolveCronJobLastRunStatus } from "../../lib/cron-status.ts";
+import { isCronJobActiveFailure } from "../../lib/cron-status.ts";
 import { createInitialCronState, loadCronJobsPage, loadCronStatus } from "../../lib/cron/index.ts";
 import { isMonitoredAuthProvider, loadModelAuthStatus } from "../../lib/model-auth.ts";
 import { requestSessionUsage } from "../../lib/sessions/index.ts";
@@ -326,9 +326,7 @@ export class OverviewPage extends LitElement {
       `${blocked.length} skill${blocked.length === 1 ? "" : "s"} blocked`,
     );
 
-    const failedCron = this.cron.cronJobs.filter(
-      (job) => resolveCronJobLastRunStatus(job) === "error",
-    );
+    const failedCron = this.cron.cronJobs.filter(isCronJobActiveFailure);
     addNamedAttention(
       items,
       failedCron,

--- a/ui/src/pages/workboard/workboard.e2e.test.ts
+++ b/ui/src/pages/workboard/workboard.e2e.test.ts
@@ -469,7 +469,7 @@ describeControlUiE2e("Control UI Workboard mocked Gateway E2E", () => {
       await writableGateway.resolveDeferred("workboard.cards.update", { card: reviewedCard });
       const reviewedCardSurface = cardInColumn(writable.page, "Review", editedCard.title);
       await reviewedCardSurface.waitFor({ state: "visible" });
-      await reviewedCardSurface.getByTitle("View details").click();
+      await reviewedCardSurface.getByRole("button", { name: "View details", exact: true }).click();
       await writable.page.locator(".workboard-detail").getByText("Moved to Review").waitFor({
         state: "visible",
       });

--- a/ui/src/styles/layout.css
+++ b/ui/src/styles/layout.css
@@ -1277,6 +1277,29 @@
   min-height: 0;
 }
 
+.content--workboard {
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+  padding-bottom: 16px;
+}
+
+.content--workboard > * + * {
+  margin-top: 14px;
+}
+
+.content--workboard > openclaw-router-outlet,
+.content--workboard openclaw-workboard-page {
+  display: flex;
+  flex: 1 1 0;
+  flex-direction: column;
+  min-height: 0;
+}
+
+.content--workboard openclaw-workboard-page {
+  gap: 14px;
+}
+
 :root[data-theme-mode="light"] .content {
   background: var(--bg-content);
 }


### PR DESCRIPTION
## What Problem This Solves

Follow-up to #100024. The route-module refactor landed with several regressions that its focused proof did not exercise:

- route-shaped URLs outside the configured base path could resolve as valid routes;
- Agents could render before runtime config was loaded, making **Set Default** a silent no-op;
- a successful default-agent save could leave application-wide agent state stale;
- authenticated avatar blobs lost precedence to persisted or protected avatar URLs;
- disabled cron jobs with historical failures appeared as active Overview errors;
- the Workboard lost its bounded route layout, so columns no longer scrolled;
- one Workboard E2E selector and one terminal custom-element test were incompatible with the refactored component boundaries.

## Why This Change Was Made

The fixes keep ownership at the new route/capability boundaries: validate mount containment before matching, load config from the connected Agents page lifecycle, refresh the shared agents capability after a successful save, restore the route-specific Workboard layout through its router wrappers, and reuse the canonical actionable-cron predicate. The obsolete page-state agent save helper was removed.

## User Impact

- Deep links respect the configured Control UI mount.
- **Set Default** persists reliably and updates all agent consumers.
- Authenticated avatars render instead of stale/protected fallbacks.
- Disabled cron jobs no longer raise false active-failure alerts.
- Workboard columns scroll again at constrained heights.

## Evidence

- `OPENCLAW_VITEST_MAX_WORKERS=2 node scripts/run-vitest.mjs run --config test/vitest/vitest.ui.config.ts --reporter=dot` — 120 files, 1,942 tests passed.
- `OPENCLAW_VITEST_MAX_WORKERS=2 node scripts/run-vitest.mjs run --config test/vitest/vitest.ui-e2e.config.ts --reporter=dot` — 10 files, 31 scenarios passed.
- `pnpm tsgo:core`
- `pnpm tsgo:test:ui`
- touched-file type-aware `oxlint` — passed.
- `pnpm check:architecture` — passed.
- `env -u OPENAI_API_KEY -u ANTHROPIC_API_KEY pnpm ui:i18n:check` — 20 locales clean.
- `pnpm ui:build`
- Fresh autoreview after fixes — no actionable findings.

Supersedes the duplicate refactor follow-up in #100095.
