### PR TITLE
Preserve provider settings during onboarding updates

### DIFF
--- a/extensions/minimax/onboard.test.ts
+++ b/extensions/minimax/onboard.test.ts
@@ -107,6 +107,7 @@ describe("minimax onboard", () => {
           MiniMax: {
             baseUrl: "https://api.minimax.io/anthropic",
             api: "anthropic-messages",
+            apiKey: { source: "env", provider: "default", id: "MINIMAX_API_KEY" },
             timeoutSeconds: 900,
             models: [buildMinimaxApiModelDefinition("MiniMax-M2.7")],
           },
@@ -115,6 +116,11 @@ describe("minimax onboard", () => {
     });
 
     expect(Object.keys(cfg.models?.providers ?? {})).toEqual(["minimax"]);
+    expect(cfg.models?.providers?.minimax?.apiKey).toEqual({
+      source: "env",
+      provider: "default",
+      id: "MINIMAX_API_KEY",
+    });
     expect(cfg.models?.providers?.minimax?.timeoutSeconds).toBe(900);
     expect(cfg.models?.providers?.minimax?.models.map((model) => model.id)).toEqual([
       "MiniMax-M2.7",

--- a/extensions/minimax/onboard.test.ts
+++ b/extensions/minimax/onboard.test.ts
@@ -77,6 +77,29 @@ describe("minimax onboard", () => {
     expect(provider?.models.map((m) => m.id)).toEqual(["old-model", "MiniMax-M3"]);
   });
 
+  it("drops placeholder apiKey while preserving provider timeout", () => {
+    const cfg = applyMinimaxApiConfig({
+      models: {
+        providers: {
+          minimax: {
+            baseUrl: "https://api.minimax.io/anthropic",
+            apiKey: "minimax",
+            api: "anthropic-messages",
+            timeoutSeconds: 900,
+            models: [buildMinimaxApiModelDefinition("MiniMax-M2.7")],
+          },
+        },
+      },
+    });
+
+    expect(cfg.models?.providers?.minimax?.apiKey).toBeUndefined();
+    expect(cfg.models?.providers?.minimax?.timeoutSeconds).toBe(900);
+    expect(cfg.models?.providers?.minimax?.models.map((m) => m.id)).toEqual([
+      "MiniMax-M2.7",
+      "MiniMax-M3",
+    ]);
+  });
+
   it("preserves other providers when adding minimax", () => {
     const cfg = applyMinimaxApiConfig({
       models: {

--- a/extensions/minimax/onboard.test.ts
+++ b/extensions/minimax/onboard.test.ts
@@ -100,6 +100,28 @@ describe("minimax onboard", () => {
     ]);
   });
 
+  it("preserves models from a non-canonical provider key", () => {
+    const cfg = applyMinimaxApiConfig({
+      models: {
+        providers: {
+          MiniMax: {
+            baseUrl: "https://api.minimax.io/anthropic",
+            api: "anthropic-messages",
+            timeoutSeconds: 900,
+            models: [buildMinimaxApiModelDefinition("MiniMax-M2.7")],
+          },
+        },
+      },
+    });
+
+    expect(Object.keys(cfg.models?.providers ?? {})).toEqual(["minimax"]);
+    expect(cfg.models?.providers?.minimax?.timeoutSeconds).toBe(900);
+    expect(cfg.models?.providers?.minimax?.models.map((model) => model.id)).toEqual([
+      "MiniMax-M2.7",
+      "MiniMax-M3",
+    ]);
+  });
+
   it("preserves other providers when adding minimax", () => {
     const cfg = applyMinimaxApiConfig({
       models: {

--- a/extensions/minimax/onboard.ts
+++ b/extensions/minimax/onboard.ts
@@ -39,14 +39,18 @@ function applyMinimaxApiProviderConfigWithBaseUrl(
     baseUrl: params.baseUrl,
     models: [],
   };
-  const resolvedApiKey = typeof existingApiKey === "string" ? existingApiKey : undefined;
-  const normalizedApiKey = resolvedApiKey?.trim() === "minimax" ? "" : resolvedApiKey;
+  const preservedApiKey =
+    typeof existingApiKey === "string"
+      ? existingApiKey.trim() === "" || existingApiKey.trim() === "minimax"
+        ? undefined
+        : existingApiKey
+      : existingApiKey;
   providers[params.providerId] = {
     ...existingProviderRest,
     baseUrl: params.baseUrl,
     api: "anthropic-messages",
     authHeader: true,
-    ...(normalizedApiKey?.trim() ? { apiKey: normalizedApiKey } : {}),
+    ...(preservedApiKey ? { apiKey: preservedApiKey } : {}),
     models: mergedModels.length > 0 ? mergedModels : [apiModel],
   };
 

--- a/extensions/minimax/onboard.ts
+++ b/extensions/minimax/onboard.ts
@@ -1,4 +1,6 @@
 // Minimax setup module handles plugin onboarding behavior.
+
+import { normalizeProviderId } from "openclaw/plugin-sdk/provider-model-shared";
 import {
   applyAgentDefaultModelPrimary,
   applyOnboardAuthAgentModelsAndProviders,
@@ -23,7 +25,12 @@ function applyMinimaxApiProviderConfigWithBaseUrl(
   params: MinimaxApiProviderConfigParams,
 ): OpenClawConfig {
   const providers = { ...cfg.models?.providers } as Record<string, ModelProviderConfig>;
-  const existingProvider = providers[params.providerId];
+  const normalizedProviderId = normalizeProviderId(params.providerId);
+  const existingProvider =
+    providers[params.providerId] ??
+    Object.entries(providers).find(
+      ([providerId]) => normalizeProviderId(providerId) === normalizedProviderId,
+    )?.[1];
   const existingModels = existingProvider?.models ?? [];
   const apiModel = buildMinimaxApiModelDefinition(params.modelId);
   const hasApiModel = existingModels.some((model) => model.id === params.modelId);

--- a/src/commands/onboard-auth.config-shared.test.ts
+++ b/src/commands/onboard-auth.config-shared.test.ts
@@ -111,7 +111,13 @@ describe("onboard auth provider config merges", () => {
               baseUrl: "https://old.example.com/v1",
               apiKey: "stale-key",
               auth: "api-key",
+              authHeader: true,
               headers: { authorization: "stale-header" },
+              request: {
+                allowPrivateNetwork: true,
+                auth: { mode: "authorization-bearer", token: "stale-token" },
+                headers: { "x-stale-auth": "stale-request-header" },
+              },
               timeoutSeconds: 900,
               models: [makeModel("model-a")],
             },
@@ -132,7 +138,9 @@ describe("onboard auth provider config merges", () => {
 
     expect(next.models?.providers?.custom?.apiKey).toBeUndefined();
     expect(next.models?.providers?.custom?.auth).toBeUndefined();
+    expect(next.models?.providers?.custom?.authHeader).toBeUndefined();
     expect(next.models?.providers?.custom?.headers).toBeUndefined();
+    expect(next.models?.providers?.custom?.request).toEqual({ allowPrivateNetwork: true });
     expect(next.models?.providers?.custom?.timeoutSeconds).toBe(900);
   });
 

--- a/src/commands/onboard-auth.config-shared.test.ts
+++ b/src/commands/onboard-auth.config-shared.test.ts
@@ -101,6 +101,36 @@ describe("onboard auth provider config merges", () => {
     expect(next.models?.providers?.other?.timeoutSeconds).toBe(300);
   });
 
+  it("preserves settings without resurrecting a non-canonical provider key", () => {
+    const next = applyOnboardAuthAgentModelsAndProviders(
+      {
+        models: {
+          providers: {
+            Custom: {
+              api: "openai-completions",
+              baseUrl: "https://old.example.com/v1",
+              timeoutSeconds: 900,
+              models: [makeModel("model-a")],
+            },
+          },
+        },
+      },
+      {
+        agentModels,
+        providers: {
+          custom: {
+            api: "openai-completions",
+            baseUrl: "https://new.example.com/v1",
+            models: [makeModel("model-b")],
+          },
+        },
+      },
+    );
+
+    expect(Object.keys(next.models?.providers ?? {})).toEqual(["custom"]);
+    expect(next.models?.providers?.custom?.timeoutSeconds).toBe(900);
+  });
+
   it("lets onboarding provider patches clear omitted auth fields", () => {
     const next = applyOnboardAuthAgentModelsAndProviders(
       {

--- a/src/commands/onboard-auth.config-shared.test.ts
+++ b/src/commands/onboard-auth.config-shared.test.ts
@@ -5,6 +5,7 @@ import type { AgentModelEntryConfig } from "../config/types.agent-defaults.js";
 import type { ModelDefinitionConfig } from "../config/types.models.js";
 import {
   applyAgentDefaultModelPrimary,
+  applyOnboardAuthAgentModelsAndProviders,
   applyProviderConfigWithDefaultModelPreset,
   applyProviderConfigWithModelCatalogPreset,
   applyProviderConfigWithDefaultModel,
@@ -59,6 +60,80 @@ describe("onboard auth provider config merges", () => {
     ]);
     expect(next.models?.providers?.custom?.apiKey).toBe("test-key");
     expect(next.agents?.defaults?.models).toEqual(agentModels);
+  });
+
+  it("preserves provider-level settings when applying onboarding provider patches", () => {
+    const next = applyOnboardAuthAgentModelsAndProviders(
+      {
+        models: {
+          mode: "merge",
+          providers: {
+            custom: {
+              api: "openai-completions",
+              baseUrl: "https://old.example.com/v1",
+              timeoutSeconds: 900,
+              models: [makeModel("model-a")],
+            },
+            other: {
+              api: "openai-responses",
+              baseUrl: "https://other.example.com/v1",
+              timeoutSeconds: 300,
+              models: [makeModel("other-a")],
+            },
+          },
+        },
+      },
+      {
+        agentModels,
+        providers: {
+          custom: {
+            api: "openai-completions",
+            baseUrl: "https://new.example.com/v1",
+            models: [makeModel("model-b")],
+          },
+        },
+      },
+    );
+
+    expect(next.models?.providers?.custom?.timeoutSeconds).toBe(900);
+    expect(next.models?.providers?.custom?.baseUrl).toBe("https://new.example.com/v1");
+    expect(next.models?.providers?.custom?.models?.map((m) => m.id)).toEqual(["model-b"]);
+    expect(next.models?.providers?.other?.timeoutSeconds).toBe(300);
+  });
+
+  it("lets onboarding provider patches clear omitted auth fields", () => {
+    const next = applyOnboardAuthAgentModelsAndProviders(
+      {
+        models: {
+          providers: {
+            custom: {
+              api: "anthropic-messages",
+              baseUrl: "https://old.example.com/v1",
+              apiKey: "stale-key",
+              auth: "api-key",
+              headers: { authorization: "stale-header" },
+              timeoutSeconds: 900,
+              models: [makeModel("model-a")],
+            },
+          },
+        },
+      },
+      {
+        agentModels,
+        providers: {
+          custom: {
+            api: "anthropic-messages",
+            baseUrl: "https://new.example.com/v1",
+            models: [makeModel("model-b")],
+          },
+        },
+      },
+    );
+
+    expect(next.models?.providers?.custom?.apiKey).toBeUndefined();
+    expect(next.models?.providers?.custom?.auth).toBeUndefined();
+    expect(next.models?.providers?.custom?.headers).toBeUndefined();
+    expect(next.models?.providers?.custom?.timeoutSeconds).toBe(900);
   });
 
   it("preserves existing agent model entries when adding provider models", () => {

--- a/src/commands/onboard-auth.config-shared.test.ts
+++ b/src/commands/onboard-auth.config-shared.test.ts
@@ -131,6 +131,93 @@ describe("onboard auth provider config merges", () => {
     expect(next.models?.providers?.custom?.timeoutSeconds).toBe(900);
   });
 
+  it("prefers canonical settings and removes every non-canonical provider key", () => {
+    const next = applyOnboardAuthAgentModelsAndProviders(
+      {
+        models: {
+          providers: {
+            Custom: {
+              api: "openai-completions",
+              baseUrl: "https://stale.example.com/v1",
+              timeoutSeconds: 300,
+              models: [makeModel("stale-a")],
+            },
+            custom: {
+              api: "openai-completions",
+              baseUrl: "https://canonical.example.com/v1",
+              timeoutSeconds: 900,
+              models: [makeModel("canonical-a")],
+            },
+            CUSTOM: {
+              api: "openai-completions",
+              baseUrl: "https://older.example.com/v1",
+              timeoutSeconds: 600,
+              models: [makeModel("older-a")],
+            },
+          },
+        },
+      },
+      {
+        agentModels,
+        providers: {
+          custom: {
+            api: "openai-completions",
+            baseUrl: "https://new.example.com/v1",
+            models: [makeModel("model-b")],
+          },
+        },
+      },
+    );
+
+    expect(Object.keys(next.models?.providers ?? {})).toEqual(["custom"]);
+    expect(next.models?.providers?.custom?.timeoutSeconds).toBe(900);
+    expect(next.models?.providers?.custom?.baseUrl).toBe("https://new.example.com/v1");
+  });
+
+  it("collapses duplicate provider keys when applying a provider preset", () => {
+    const next = applyProviderConfigWithDefaultModels(
+      {
+        models: {
+          providers: {
+            Custom: {
+              api: "openai-completions",
+              baseUrl: "https://stale.example.com/v1",
+              timeoutSeconds: 300,
+              models: [makeModel("stale-a")],
+            },
+            custom: {
+              api: "openai-completions",
+              baseUrl: "https://canonical.example.com/v1",
+              timeoutSeconds: 900,
+              models: [makeModel("canonical-a")],
+            },
+            CUSTOM: {
+              api: "openai-completions",
+              baseUrl: "https://older.example.com/v1",
+              timeoutSeconds: 600,
+              models: [makeModel("older-a")],
+            },
+          },
+        },
+      },
+      {
+        agentModels,
+        providerId: "custom",
+        api: "openai-completions",
+        baseUrl: "https://new.example.com/v1",
+        defaultModels: [makeModel("model-b")],
+        defaultModelId: "model-b",
+      },
+    );
+
+    expect(Object.keys(next.models?.providers ?? {})).toEqual(["custom"]);
+    expect(next.models?.providers?.custom?.timeoutSeconds).toBe(900);
+    expect(next.models?.providers?.custom?.models?.map((model) => model.id)).toEqual([
+      "canonical-a",
+      "model-b",
+    ]);
+  });
+
   it("lets onboarding provider patches clear omitted auth fields", () => {
     const next = applyOnboardAuthAgentModelsAndProviders(
       {

--- a/src/plugin-sdk/provider-onboard.ts
+++ b/src/plugin-sdk/provider-onboard.ts
@@ -289,7 +289,15 @@ function mergeOnboardProviderConfigs(
 ): Record<string, ModelProviderConfig> {
   const merged: Record<string, ModelProviderConfig> = { ...existingProviders };
   for (const [providerId, providerConfig] of Object.entries(patchProviders)) {
-    const existingProvider = existingProviders?.[providerId];
+    const existingProviderKey = findNormalizedProviderKey(existingProviders ?? {}, providerId);
+    const existingProvider = existingProviderKey
+      ? existingProviders?.[existingProviderKey]
+      : undefined;
+    if (existingProviderKey && existingProviderKey !== providerId) {
+      // The patch owns the canonical key; retaining its old case variant would
+      // leave two runtime candidates with conflicting auth and endpoint state.
+      delete merged[existingProviderKey];
+    }
     if (
       !isMergeableProviderConfig(existingProvider) ||
       !isMergeableProviderConfig(providerConfig)

--- a/src/plugin-sdk/provider-onboard.ts
+++ b/src/plugin-sdk/provider-onboard.ts
@@ -258,6 +258,38 @@ export function withAgentModelAliases(
   return next;
 }
 
+function isMergeableProviderConfig(
+  value: ModelProviderConfig | undefined,
+): value is ModelProviderConfig {
+  return Boolean(value && typeof value === "object" && !Array.isArray(value));
+}
+
+function mergeOnboardProviderConfigs(
+  existingProviders: Record<string, ModelProviderConfig> | undefined,
+  patchProviders: Record<string, ModelProviderConfig>,
+): Record<string, ModelProviderConfig> {
+  const merged: Record<string, ModelProviderConfig> = { ...existingProviders };
+  for (const [providerId, providerConfig] of Object.entries(patchProviders)) {
+    const existingProvider = existingProviders?.[providerId];
+    if (!isMergeableProviderConfig(existingProvider) || !isMergeableProviderConfig(providerConfig)) {
+      merged[providerId] = providerConfig;
+      continue;
+    }
+    const nextProvider = { ...existingProvider, ...providerConfig };
+    if (!("apiKey" in providerConfig)) {
+      delete nextProvider.apiKey;
+    }
+    if (!("auth" in providerConfig)) {
+      delete nextProvider.auth;
+    }
+    if (!("headers" in providerConfig)) {
+      delete nextProvider.headers;
+    }
+    merged[providerId] = nextProvider;
+  }
+  return merged;
+}
+
 /** Write onboarding-auth model aliases and provider configs into the canonical config sections. */
 export function applyOnboardAuthAgentModelsAndProviders(
   cfg: OpenClawConfig,
@@ -270,6 +302,7 @@ export function applyOnboardAuthAgentModelsAndProviders(
     ...cfg.agents?.defaults?.models,
     ...params.agentModels,
   });
+  const mergedProviders = mergeOnboardProviderConfigs(cfg.models?.providers, params.providers);
   return {
     ...cfg,
     agents: {
@@ -280,8 +313,9 @@ export function applyOnboardAuthAgentModelsAndProviders(
       },
     },
     models: {
+      ...cfg.models,
       mode: cfg.models?.mode ?? "merge",
-      providers: params.providers,
+      providers: mergedProviders,
     },
   };
 }

--- a/src/plugin-sdk/provider-onboard.ts
+++ b/src/plugin-sdk/provider-onboard.ts
@@ -264,6 +264,25 @@ function isMergeableProviderConfig(
   return Boolean(value && typeof value === "object" && !Array.isArray(value));
 }
 
+function mergeOnboardProviderRequest(
+  existing: ModelProviderConfig["request"],
+  patch: ModelProviderConfig["request"],
+): ModelProviderConfig["request"] {
+  if (!existing) {
+    return patch;
+  }
+  const merged = { ...existing, ...patch };
+  // Keep operator transport policy, but never resurrect nested credentials
+  // that the onboarding owner intentionally omitted from its patch.
+  if (!patch || !("auth" in patch)) {
+    delete merged.auth;
+  }
+  if (!patch || !("headers" in patch)) {
+    delete merged.headers;
+  }
+  return Object.keys(merged).length > 0 ? merged : undefined;
+}
+
 function mergeOnboardProviderConfigs(
   existingProviders: Record<string, ModelProviderConfig> | undefined,
   patchProviders: Record<string, ModelProviderConfig>,
@@ -271,19 +290,24 @@ function mergeOnboardProviderConfigs(
   const merged: Record<string, ModelProviderConfig> = { ...existingProviders };
   for (const [providerId, providerConfig] of Object.entries(patchProviders)) {
     const existingProvider = existingProviders?.[providerId];
-    if (!isMergeableProviderConfig(existingProvider) || !isMergeableProviderConfig(providerConfig)) {
+    if (
+      !isMergeableProviderConfig(existingProvider) ||
+      !isMergeableProviderConfig(providerConfig)
+    ) {
       merged[providerId] = providerConfig;
       continue;
     }
     const nextProvider = { ...existingProvider, ...providerConfig };
-    if (!("apiKey" in providerConfig)) {
-      delete nextProvider.apiKey;
+    for (const key of ["apiKey", "auth", "authHeader", "headers"] as const) {
+      if (!(key in providerConfig)) {
+        delete nextProvider[key];
+      }
     }
-    if (!("auth" in providerConfig)) {
-      delete nextProvider.auth;
-    }
-    if (!("headers" in providerConfig)) {
-      delete nextProvider.headers;
+    if (!("request" in providerConfig) || providerConfig.request) {
+      nextProvider.request = mergeOnboardProviderRequest(
+        existingProvider.request,
+        providerConfig.request,
+      );
     }
     merged[providerId] = nextProvider;
   }

--- a/src/plugin-sdk/provider-onboard.ts
+++ b/src/plugin-sdk/provider-onboard.ts
@@ -1,7 +1,10 @@
 // Keep provider onboarding helpers dependency-light so bundled provider plugins
 // do not pull heavyweight runtime graphs at activation time.
 
-import { findNormalizedProviderKey } from "@openclaw/model-catalog-core/provider-id";
+import {
+  findNormalizedProviderKey,
+  normalizeProviderId,
+} from "@openclaw/model-catalog-core/provider-id";
 import { resolvePrimaryStringValue } from "../../packages/normalization-core/src/string-coerce.js";
 import { ensureStaticModelAllowlistEntry } from "../agents/model-allowlist-entry.js";
 import { normalizeConfiguredProviderCatalogModelId } from "../agents/model-ref-shared.js";
@@ -140,7 +143,9 @@ function resolveProviderModelMergeState(
   providerId: string,
 ): ProviderModelMergeState {
   const providers = { ...cfg.models?.providers } as Record<string, ModelProviderConfig>;
-  const existingProviderKey = findNormalizedProviderKey(providers, providerId);
+  const existingProviderKey = Object.hasOwn(providers, providerId)
+    ? providerId
+    : findNormalizedProviderKey(providers, providerId);
   const existingProvider =
     existingProviderKey !== undefined
       ? (providers[existingProviderKey] as ModelProviderConfig | undefined)
@@ -150,8 +155,11 @@ function resolveProviderModelMergeState(
     : [];
   // Collapse case/alias variants into the canonical provider key before writing,
   // otherwise onboarding can leave two provider blocks for the same backend.
-  if (existingProviderKey && existingProviderKey !== providerId) {
-    delete providers[existingProviderKey];
+  const normalizedProviderId = normalizeProviderId(providerId);
+  for (const key of Object.keys(providers)) {
+    if (key !== providerId && normalizeProviderId(key) === normalizedProviderId) {
+      delete providers[key];
+    }
   }
   return {
     providers,
@@ -289,14 +297,23 @@ function mergeOnboardProviderConfigs(
 ): Record<string, ModelProviderConfig> {
   const merged: Record<string, ModelProviderConfig> = { ...existingProviders };
   for (const [providerId, providerConfig] of Object.entries(patchProviders)) {
+    const normalizedProviderId = normalizeProviderId(providerId);
+    const patchProviderKey = Object.hasOwn(patchProviders, normalizedProviderId)
+      ? normalizedProviderId
+      : findNormalizedProviderKey(patchProviders, providerId);
+    if (providerId !== patchProviderKey) {
+      continue;
+    }
     const existingProviderKey = findNormalizedProviderKey(existingProviders ?? {}, providerId);
-    const existingProvider = existingProviderKey
-      ? existingProviders?.[existingProviderKey]
-      : undefined;
-    if (existingProviderKey && existingProviderKey !== providerId) {
+    const existingProvider =
+      existingProviders?.[providerId] ??
+      (existingProviderKey ? existingProviders?.[existingProviderKey] : undefined);
+    for (const key of Object.keys(existingProviders ?? {})) {
       // The patch owns the canonical key; retaining its old case variant would
       // leave two runtime candidates with conflicting auth and endpoint state.
-      delete merged[existingProviderKey];
+      if (key !== providerId && normalizeProviderId(key) === normalizedProviderId) {
+        delete merged[key];
+      }
     }
     if (
       !isMergeableProviderConfig(existingProvider) ||


### PR DESCRIPTION
## What Problem This Solves

Provider onboarding can refresh a provider's model catalog/config and accidentally drop provider-level settings that are not repeated in the new provider patch. In the observed OMLX/iMessage failure, losing `models.providers.omlx.timeoutSeconds` made long-running local/VLM work fall back to the implicit short provider watchdog after model/provider refreshes.

The first version of this PR preserved those fields with a shallow merge, but ClawSweeper correctly flagged that as too additive for auth-bearing fields. Some provider onboarding paths, including MiniMax, intentionally omit stale/placeholder auth fields such as `apiKey` so runtime auth discovery can take over. This revision preserves non-auth provider settings like `timeoutSeconds` while letting provider-owned auth fields (`apiKey`, `auth`, `headers`) be cleared when omitted from the patch.

## Summary

- Preserve existing non-auth provider-level settings when onboarding refreshes provider model configs.
- Keep untouched provider entries when applying onboarding provider patches.
- Allow onboarding patches to intentionally clear omitted auth-bearing fields.
- Add regression coverage for both timeout preservation and MiniMax placeholder `apiKey` removal.

## Evidence

### Field Evidence

This PR came from a live OMLX/iMessage regression on a local VLM provider.

Observed broken state:

- `agents.defaults.timeoutSeconds` was still configured high, but `models.providers.omlx.timeoutSeconds` had been dropped from the provider entry after provider/model config refresh.
- OMLX requests then logged with no provider timeout applied:
  - `[model-fetch] start provider=omlx api=openai-completions model=Agents-A1-oQ6-fp16 ... timeoutMs=undefined`
- User-visible failure:
  - `LLM request failed. | Request timed out before a response was generated. Please try again, or increase agents.defaults.timeoutSeconds in your config.`

After restoring the provider timeout and applying this merge behavior locally, the same OMLX provider path preserved and used the provider-level timeout:

- Config values verified:
  - `models.providers.omlx.timeoutSeconds = 1200`
  - OMLX provider: `baseUrl=http://127.0.0.1:8000/v1`, `api=openai-completions`
  - Model row retained `input: ["text", "image"]`
- Runtime log showed the provider timeout was actually applied:
  - `[model-fetch] start provider=omlx api=openai-completions model=Agents-A1-oQ6-fp16 method=POST url=http://127.0.0.1:8000/v1/chat/completions timeoutMs=1200000 proxy=none policy=custom`
  - `[model-fetch] response provider=omlx api=openai-completions model=Agents-A1-oQ6-fp16 status=200 ... contentType=text/event-stream; charset=utf-8`

Follow-up observation, intentionally out of scope for this PR:

- Once provider timeout preservation was fixed, a separate hard run ceiling was exposed: `agents.defaults.timeoutSeconds=1200` can still abort an active, streaming local-model run at 20 minutes.
- The diagnostic log showed active stream progress shortly before that abort:
  - `activeWorkKind=model_call lastProgress=model_call:stream_progress lastProgressAge=33s`
  - followed by `embedded run timeout ... timeoutMs=1200000`
- Locally, that was mitigated by making the agent hard-run ceiling much larger while keeping the OMLX provider timeout provider-owned. This PR does not try to change run-lifetime semantics; it only prevents provider-owned timeout settings from being erased during onboarding/provider refresh.

### Test Evidence

- Added shared onboarding regression coverage in `src/commands/onboard-auth.config-shared.test.ts`:
  - `preserves provider-level settings when applying onboarding provider patches` proves a provider patch keeps `timeoutSeconds` and untouched providers.
  - `lets onboarding provider patches clear omitted auth fields` proves omitted `apiKey`, `auth`, and `headers` are removed while `timeoutSeconds` is retained.
- Added MiniMax-specific regression coverage in `extensions/minimax/onboard.test.ts`:
  - `drops placeholder apiKey while preserving provider timeout` proves the MiniMax sentinel/placeholder `apiKey` path does not restore stale auth and still preserves `timeoutSeconds`.
- Ran `git diff --check` locally; it passed.
- Focused local Vitest execution was attempted, but this fresh checkout had no `node_modules`; dependency hydration required registry access and was stopped after DNS/network failures in the sandbox. The PR branch is pushed so repository CI can run the authored regression tests in the normal environment.

## CI Notes

- `Real behavior proof` is passing on the current PR revision.
- The remaining failing check observed during review is `QA Smoke CI`. Its failed run is broad smoke coverage, not the proof gate, and reported `passed=19 failed=6 total=25` in unrelated end-to-end scenarios such as memory fallback and telemetry/runtime smoke flows. I did not find evidence that those failures are caused by the provider-onboarding merge change in this PR.
