### PR TITLE
test(ui): stabilize Control UI suite routing

### DIFF
--- a/ui/src/pages/chat/chat-avatar.test.ts
+++ b/ui/src/pages/chat/chat-avatar.test.ts
@@ -1,8 +1,10 @@
 /* @vitest-environment jsdom */
 
 import { render } from "lit";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { renderChatAvatar } from "./chat-avatar.ts";
+
+vi.unmock("../../lib/agents/display.ts");
 
 function renderAvatar(params: Parameters<typeof renderChatAvatar>) {
   const container = document.createElement("div");

--- a/ui/src/pages/chat/chat-composer.test.ts
+++ b/ui/src/pages/chat/chat-composer.test.ts
@@ -384,9 +384,7 @@ describe("context notice", () => {
     expect(notice).toBeInstanceOf(HTMLElement);
     expect(notice!.textContent?.replace(/\s+/gu, " ").trim()).toBe("95%");
     expect([...notice!.classList]).toEqual(["context-ring", "context-ring--warning"]);
-    expect(notice!.getAttribute("aria-label")).toBe(
-      "Session context usage: 190k / 200k (95%)",
-    );
+    expect(notice!.getAttribute("aria-label")).toBe("Session context usage: 190k / 200k (95%)");
     expect(notice!.style.getPropertyValue("--ctx-color")).toBe("rgb(4, 5, 6)");
     expect(notice!.style.getPropertyValue("--ctx-bg")).toBe("rgba(4, 5, 6, 0.15999999999999998)");
 
@@ -457,9 +455,12 @@ describe("side result render", () => {
     expect(sideResult!.querySelector(".chat-side-result__question")?.textContent).toBe(
       "what changed?",
     );
-    expect(sideResult!.querySelector(".chat-side-result__body")?.textContent?.trim()).toBe(
-      "The web UI now renders **BTW** separately.",
-    );
+    expect(
+      sideResult!
+        .querySelector(".chat-side-result__body")
+        ?.textContent?.trim()
+        .replaceAll("**", ""),
+    ).toBe("The web UI now renders BTW separately.");
 
     const button = container.querySelector<HTMLButtonElement>(".chat-side-result__dismiss");
     expect(button).toBeInstanceOf(HTMLButtonElement);

--- a/ui/vitest.config.ts
+++ b/ui/vitest.config.ts
@@ -61,9 +61,9 @@ const sharedUiTestConfig = {
 } as const;
 const nodeDrivenBrowserLayoutTests = [
   "src/ui/chat/sidebar-session-picker.browser.test.ts",
-  "src/ui/chat/chat-responsive.browser.test.ts",
+  "src/pages/chat/chat-responsive.browser.test.ts",
   "src/components/form-controls.browser.test.ts",
-  "src/ui/views/sessions.browser.test.ts",
+  "src/pages/sessions/view.browser.test.ts",
 ] as const;
 const chromiumExecutableOverrideEnvKey = "PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH";
 const systemChromiumExecutableCandidates = [

--- a/ui/vitest.node.config.ts
+++ b/ui/vitest.node.config.ts
@@ -10,8 +10,8 @@ export default defineConfig({
     testTimeout: 120_000,
     include: [
       "src/**/*.node.test.ts",
-      "src/ui/chat/chat-responsive.browser.test.ts",
-      "src/ui/views/sessions.browser.test.ts",
+      "src/pages/chat/chat-responsive.browser.test.ts",
+      "src/pages/sessions/view.browser.test.ts",
     ],
     environment: "node",
   },


### PR DESCRIPTION
## Summary
- keep moved chat-responsive and sessions browser layout tests in both UI Vitest routing configs
- isolate the chat avatar test from suite-order module mocks
- assert BTW side-result visible copy independent of markdown-rendering order

## Verification
- `corepack pnpm format:check ui/src/pages/chat/chat-avatar.test.ts ui/src/pages/chat/chat-composer.test.ts ui/vitest.config.ts ui/vitest.node.config.ts && cd ui && node ../scripts/run-vitest.mjs run --config vitest.node.config.ts --configLoader runner src/pages/chat/chat-responsive.browser.test.ts src/pages/sessions/view.browser.test.ts && cd .. && corepack pnpm ui:build && corepack pnpm test:ui` via Testbox `tbx_01kwqq66mn6y5crbtzx3ca92r4`, Actions https://github.com/openclaw/openclaw/actions/runs/28722986679
- `OPENCLAW_CHECK_CHANGED_REMOTE_CHILD=1 OPENCLAW_CHANGED_LANES_RAW_SYNC=1 corepack pnpm check:changed` via Testbox `tbx_01kwqq6bdwhyfyqwst5qh783kr`, Actions https://github.com/openclaw/openclaw/actions/runs/28722989000
