### PR TITLE
feat(release): publish covered extended-stable candidates

### DIFF
--- a/.github/workflows/extended-stable-plugin-acceptance.yml
+++ b/.github/workflows/extended-stable-plugin-acceptance.yml
@@ -1,0 +1,71 @@
+name: Extended-Stable Plugin Acceptance
+
+on:
+  workflow_dispatch:
+    inputs:
+      release_version:
+        description: Exact final extended-stable version, for example 2026.6.33
+        required: true
+        type: string
+      plugin_package_name:
+        description: Covered plugin npm package name
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+concurrency:
+  group: extended-stable-plugin-acceptance-${{ inputs.release_version }}-${{ inputs.plugin_package_name }}
+  cancel-in-progress: false
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+  NODE_VERSION: "24.15.0"
+
+jobs:
+  accept:
+    name: Accept exact core and plugin pair
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    steps:
+      - name: Checkout protected main
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          ref: ${{ github.sha }}
+          fetch-depth: 1
+          persist-credentials: false
+
+      - name: Require protected workflow identity
+        env:
+          EXPECTED_SHA: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+          actual_sha="$(git rev-parse HEAD)"
+          if [[ "${GITHUB_REF}" != "refs/heads/main" || "${actual_sha}" != "${EXPECTED_SHA}" ]]; then
+            echo "Extended-stable plugin acceptance must run from the recorded protected-main SHA." >&2
+            exit 1
+          fi
+
+      - name: Setup Node environment
+        uses: ./.github/actions/setup-node-env
+        with:
+          install-bun: "false"
+
+      - name: Run exact package acceptance
+        env:
+          PLUGIN_PACKAGE_NAME: ${{ inputs.plugin_package_name }}
+          RELEASE_VERSION: ${{ inputs.release_version }}
+        run: |
+          node --import tsx scripts/run-extended-stable-plugin-acceptance.ts \
+            --release-version "${RELEASE_VERSION}" \
+            --plugin-package-name "${PLUGIN_PACKAGE_NAME}" \
+            --output "${RUNNER_TEMP}/extended-stable-plugin-acceptance/extended-stable-plugin-acceptance.json"
+
+      - name: Upload immutable acceptance result
+        if: ${{ always() }}
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: extended-stable-plugin-acceptance-${{ github.run_id }}-${{ github.run_attempt }}
+          path: ${{ runner.temp }}/extended-stable-plugin-acceptance/extended-stable-plugin-acceptance.json
+          if-no-files-found: error

--- a/.github/workflows/openclaw-npm-release.yml
+++ b/.github/workflows/openclaw-npm-release.yml
@@ -578,6 +578,7 @@ jobs:
           install-bun: "false"
 
       - name: Ensure version is not already published
+        if: ${{ inputs.npm_dist_tag != 'extended-stable' }}
         run: |
           set -euo pipefail
           PACKAGE_VERSION=$(node -p "require('./package.json').version")
@@ -792,13 +793,66 @@ jobs:
           NPM_WORKFLOW_REF: ${{ github.ref }}
         run: node scripts/openclaw-npm-extended-stable-release.mjs validate-request
 
-      - name: Capture previous extended-stable selector
-        id: previous_extended_stable
+      - name: Reconcile existing extended-stable candidate
+        id: extended_stable_candidate_state
         if: ${{ inputs.npm_dist_tag == 'extended-stable' }}
-        run: node scripts/openclaw-npm-extended-stable-release.mjs capture-selector
+        env:
+          EXPECTED_VERSION: ${{ inputs.tag }}
+        run: |
+          set -euo pipefail
+          release_version="${EXPECTED_VERSION#v}"
+          candidate_tag="$(EXPECTED_VERSION="${release_version}" node -e 'import("./scripts/openclaw-npm-extended-stable-release.mjs").then((module) => process.stdout.write(module.extendedStableCandidateTag(process.env.EXPECTED_VERSION)))')"
+          exact_version=""
+          candidate_version=""
+          for attempt in {1..12}; do
+            exact_error="$(mktemp)"
+            tags_error="$(mktemp)"
+            set +e
+            exact_json="$(npm view "openclaw@${release_version}" version --json 2>"${exact_error}")"
+            exact_status=$?
+            tags_json="$(npm view openclaw dist-tags --json 2>"${tags_error}")"
+            tags_status=$?
+            set -e
+            if [[ "${exact_status}" == "0" ]]; then
+              exact_version="$(jq -r '.' <<<"${exact_json}")"
+            elif grep -Eq 'E404|404 Not Found|is not in this registry' "${exact_error}"; then
+              exact_version="absent"
+            else
+              exact_version="query_failed"
+            fi
+            if [[ "${tags_status}" == "0" ]]; then
+              candidate_version="$(jq -r --arg tag "${candidate_tag}" '.[$tag] // "absent"' <<<"${tags_json}")"
+            else
+              candidate_version="query_failed"
+            fi
+            rm -f "${exact_error}" "${tags_error}"
+            if [[ "${exact_version}" != "query_failed" && "${candidate_version}" != "query_failed" ]]; then
+              break
+            fi
+            if [[ "${attempt}" != "12" ]]; then
+              sleep 5
+            fi
+          done
+          if [[ "${exact_version}" == "query_failed" || "${candidate_version}" == "query_failed" ]]; then
+            echo "Could not authoritatively query existing extended-stable candidate state." >&2
+            exit 1
+          fi
+          if [[ "${exact_version}" == "absent" && "${candidate_version}" == "absent" ]]; then
+            echo "already_published=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          if [[ "${exact_version}" == "${release_version}" && "${candidate_version}" == "${release_version}" ]]; then
+            echo "openclaw@${release_version} and ${candidate_tag} already exist; reusing immutable publication."
+            echo "already_published=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          echo "Existing extended-stable publication is not safely reusable (exact=${exact_version}, candidate=${candidate_version})." >&2
+          echo "The public OIDC workflow cannot repair dist-tags; use the protected private selector recovery path." >&2
+          exit 1
 
       - name: Publish
         id: publish
+        if: ${{ inputs.npm_dist_tag != 'extended-stable' || steps.extended_stable_candidate_state.outputs.already_published != 'true' }}
         env:
           BYPASS_EXTENDED_STABLE_GUARD: ${{ inputs.bypass_extended_stable_guard }}
           OPENCLAW_PREPACK_PREPARED: "1"
@@ -828,12 +882,31 @@ jobs:
           publish_if_missing "@openclaw/ai" "$(find preflight-tarball -type f -name 'openclaw-ai-*.tgz' -print | head -n 1)"
           bash scripts/openclaw-npm-publish.sh --publish "${publish_target}"
 
-      - name: Verify extended-stable registry readback
-        id: extended_stable_readback
+      - name: Verify extended-stable candidate readback
+        id: extended_stable_candidate_readback
         if: ${{ success() && inputs.npm_dist_tag == 'extended-stable' }}
         env:
           EXPECTED_VERSION: ${{ inputs.tag }}
-        run: node scripts/openclaw-npm-extended-stable-release.mjs verify-readback
+        run: node scripts/openclaw-npm-extended-stable-release.mjs verify-candidate-readback
+
+      - name: Write extended-stable core publication result
+        if: ${{ success() && inputs.npm_dist_tag == 'extended-stable' }}
+        env:
+          EXPECTED_VERSION: ${{ inputs.tag }}
+          PACKAGE_INTEGRITY: ${{ steps.extended_stable_candidate_readback.outputs.integrity }}
+        run: |
+          set -euo pipefail
+          SOURCE_SHA="$(git rev-parse HEAD)" \
+            node scripts/openclaw-npm-extended-stable-release.mjs write-publication-result \
+            > extended-stable-core-publication.json
+
+      - name: Upload extended-stable core publication result
+        if: ${{ success() && inputs.npm_dist_tag == 'extended-stable' }}
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: extended-stable-core-publication-${{ github.run_id }}-${{ github.run_attempt }}
+          path: extended-stable-core-publication.json
+          if-no-files-found: error
 
       - name: Summarize extended-stable npm publication
         if: ${{ always() && inputs.npm_dist_tag == 'extended-stable' }}
@@ -846,12 +919,12 @@ jobs:
           FULL_RELEASE_VALIDATION_RUN_ID: ${{ inputs.full_release_validation_run_id }}
           TARBALL_NAME: ${{ steps.preflight_provenance.outputs.tarball_name }}
           TARBALL_SHA256: ${{ steps.preflight_provenance.outputs.tarball_sha256 }}
-          SELECTOR_CAPTURE_OUTCOME: ${{ steps.previous_extended_stable.outcome }}
-          PREVIOUS_EXTENDED_STABLE: ${{ steps.previous_extended_stable.outputs.previous }}
           PUBLISH_OUTCOME: ${{ steps.publish.outcome }}
-          EXACT_READBACK: ${{ steps.extended_stable_readback.outputs.exact_version }}
-          SELECTOR_READBACK: ${{ steps.extended_stable_readback.outputs.extended_stable_selector }}
-          READBACK_OUTCOME: ${{ steps.extended_stable_readback.outcome }}
+          CANDIDATE_TAG: ${{ steps.extended_stable_candidate_readback.outputs.candidate_tag }}
+          EXACT_READBACK: ${{ steps.extended_stable_candidate_readback.outputs.exact_version }}
+          CANDIDATE_READBACK: ${{ steps.extended_stable_candidate_readback.outputs.candidate_version }}
+          PACKAGE_INTEGRITY: ${{ steps.extended_stable_candidate_readback.outputs.integrity }}
+          READBACK_OUTCOME: ${{ steps.extended_stable_candidate_readback.outcome }}
         run: |
           set -euo pipefail
           release_version="${RELEASE_TAG#v}"
@@ -866,15 +939,11 @@ jobs:
             echo "- Full Release Validation run: ${FULL_RELEASE_VALIDATION_RUN_ID}"
             echo "- Tarball: ${TARBALL_NAME:-unavailable}"
             echo "- Tarball SHA-256: ${TARBALL_SHA256:-unavailable}"
-            echo "- Previous openclaw@extended-stable: ${PREVIOUS_EXTENDED_STABLE:-unavailable}"
             echo "- npm publish outcome: ${PUBLISH_OUTCOME}"
             echo "- Exact-version readback: ${EXACT_READBACK:-unavailable}"
-            echo "- Extended-stable selector readback: ${SELECTOR_READBACK:-unavailable}"
-            echo "- Registry readback outcome: ${READBACK_OUTCOME}"
-            if [[ "$SELECTOR_CAPTURE_OUTCOME" != "success" ]]; then
-              echo "- Selector capture failed; npm publish did not run and no repair is required because npm was unchanged."
-            else
-              repair_command="$(EXPECTED_VERSION="$RELEASE_TAG" node scripts/openclaw-npm-extended-stable-release.mjs repair-command)"
-              echo "- Repair command: \`${repair_command}\`"
-            fi
+            echo "- Candidate tag: ${CANDIDATE_TAG:-unavailable}"
+            echo "- Candidate readback: ${CANDIDATE_READBACK:-unavailable}"
+            echo "- Package integrity: ${PACKAGE_INTEGRITY:-unavailable}"
+            echo "- Candidate readback outcome: ${READBACK_OUTCOME}"
+            echo "- Shared openclaw@extended-stable selector: unchanged (promoted by the private release orchestrator)"
           } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/openclaw-release-publish.yml
+++ b/.github/workflows/openclaw-release-publish.yml
@@ -139,11 +139,18 @@ jobs:
               echo "Extended-stable release orchestration requires publish_openclaw_npm=true." >&2
               exit 1
             fi
-            if [[ ! "${RELEASE_TAG}" =~ ^v([0-9]{4})\.([1-9][0-9]*)\.([3-9][0-9]|[1-9][0-9]{2,})$ ]]; then
+            if [[ ! "${RELEASE_TAG}" =~ ^v([0-9]{4})\.([1-9][0-9]*)\.([1-9][0-9]*)$ ]]; then
               echo "Extended-stable publish requires a final vYYYY.M.P tag with patch 33 or above." >&2
               exit 1
             fi
-            expected_extended_stable_ref="refs/heads/extended-stable/${BASH_REMATCH[1]}.${BASH_REMATCH[2]}.33"
+            extended_stable_year="${BASH_REMATCH[1]}"
+            extended_stable_month="${BASH_REMATCH[2]}"
+            extended_stable_patch="${BASH_REMATCH[3]}"
+            if (( 10#${extended_stable_patch} < 33 )); then
+              echo "Extended-stable publish requires patch 33 or above; got ${extended_stable_patch}." >&2
+              exit 1
+            fi
+            expected_extended_stable_ref="refs/heads/extended-stable/${extended_stable_year}.${extended_stable_month}.33"
             if [[ "${WORKFLOW_REF}" != "${expected_extended_stable_ref}" ]]; then
               echo "Extended-stable publish must run from ${expected_extended_stable_ref}; got ${WORKFLOW_REF}." >&2
               exit 1

--- a/.github/workflows/openclaw-release-publish.yml
+++ b/.github/workflows/openclaw-release-publish.yml
@@ -1543,13 +1543,18 @@ jobs:
       - name: Publish candidates and build protected-selector handoff
         env:
           GH_TOKEN: ${{ github.token }}
+          PREFLIGHT_RUN_ID: ${{ inputs.preflight_run_id }}
+          RELEASE_TAG: ${{ inputs.tag }}
+          SOURCE_SHA: ${{ needs.resolve_release_target.outputs.sha }}
+          VALIDATION_RUN_ID: ${{ inputs.full_release_validation_run_id }}
+          WORKFLOW_REF: ${{ github.ref_name }}
         run: |
           node --import tsx scripts/orchestrate-extended-stable-plugin-release.ts \
-            --release-tag "${{ inputs.tag }}" \
-            --source-sha "${{ needs.resolve_release_target.outputs.sha }}" \
-            --workflow-ref "${{ github.ref_name }}" \
-            --preflight-run-id "${{ inputs.preflight_run_id }}" \
-            --validation-run-id "${{ inputs.full_release_validation_run_id }}" \
+            --release-tag "${RELEASE_TAG}" \
+            --source-sha "${SOURCE_SHA}" \
+            --workflow-ref "${WORKFLOW_REF}" \
+            --preflight-run-id "${PREFLIGHT_RUN_ID}" \
+            --validation-run-id "${VALIDATION_RUN_ID}" \
             --output "${RUNNER_TEMP}/extended-stable-selector-handoff/extended-stable-selector-handoff.json"
 
       - name: Upload protected-selector handoff

--- a/.github/workflows/openclaw-release-publish.yml
+++ b/.github/workflows/openclaw-release-publish.yml
@@ -36,6 +36,7 @@ on:
           - alpha
           - beta
           - latest
+          - extended-stable
       plugin_publish_scope:
         description: Plugin publish scope to run before OpenClaw publish
         required: true
@@ -44,6 +45,7 @@ on:
         options:
           - selected
           - all-publishable
+          - extended-stable
       plugins:
         description: Comma-separated plugin package names when plugin_publish_scope=selected
         required: false
@@ -130,15 +132,32 @@ jobs:
           if [[ "${RELEASE_TAG}" == *"-alpha."* || "${RELEASE_TAG}" == *"-beta."* ]]; then
             stable_release=false
           fi
+          extended_stable_release=false
+          if [[ "${RELEASE_NPM_DIST_TAG}" == "extended-stable" ]]; then
+            extended_stable_release=true
+            if [[ "${PUBLISH_OPENCLAW_NPM}" != "true" ]]; then
+              echo "Extended-stable release orchestration requires publish_openclaw_npm=true." >&2
+              exit 1
+            fi
+            if [[ ! "${RELEASE_TAG}" =~ ^v([0-9]{4})\.([1-9][0-9]*)\.([3-9][0-9]|[1-9][0-9]{2,})$ ]]; then
+              echo "Extended-stable publish requires a final vYYYY.M.P tag with patch 33 or above." >&2
+              exit 1
+            fi
+            expected_extended_stable_ref="refs/heads/extended-stable/${BASH_REMATCH[1]}.${BASH_REMATCH[2]}.33"
+            if [[ "${WORKFLOW_REF}" != "${expected_extended_stable_ref}" ]]; then
+              echo "Extended-stable publish must run from ${expected_extended_stable_ref}; got ${WORKFLOW_REF}." >&2
+              exit 1
+            fi
+          fi
           if [[ -n "${WINDOWS_NODE_TAG}" && ! "${WINDOWS_NODE_TAG}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+([-.][0-9A-Za-z]+([.-][0-9A-Za-z]+)*)?$ ]]; then
             echo "windows_node_tag must be an explicit openclaw-windows-node release tag, not latest: ${WINDOWS_NODE_TAG}" >&2
             exit 1
           fi
-          if [[ "${PUBLISH_OPENCLAW_NPM}" == "true" && "${stable_release}" == "true" && -z "${WINDOWS_NODE_TAG}" ]]; then
+          if [[ "${PUBLISH_OPENCLAW_NPM}" == "true" && "${stable_release}" == "true" && "${extended_stable_release}" != "true" && -z "${WINDOWS_NODE_TAG}" ]]; then
             echo "Stable OpenClaw publish requires an explicit windows_node_tag." >&2
             exit 1
           fi
-          if [[ "${PUBLISH_OPENCLAW_NPM}" == "true" && "${stable_release}" == "true" && -z "${WINDOWS_NODE_INSTALLER_DIGESTS}" ]]; then
+          if [[ "${PUBLISH_OPENCLAW_NPM}" == "true" && "${stable_release}" == "true" && "${extended_stable_release}" != "true" && -z "${WINDOWS_NODE_INSTALLER_DIGESTS}" ]]; then
             echo "Stable OpenClaw publish requires candidate-approved windows_node_installer_digests." >&2
             exit 1
           fi
@@ -146,11 +165,15 @@ jobs:
           if [[ "${RELEASE_TAG}" == *"-alpha."* && "${RELEASE_NPM_DIST_TAG}" == "alpha" && "${WORKFLOW_REF}" =~ ^refs/heads/tideclaw/alpha/[0-9]{4}-[0-9]{2}-[0-9]{2}-[0-9]{4}Z$ ]]; then
             tideclaw_alpha_publish=true
           fi
-          if [[ "${PUBLISH_OPENCLAW_NPM}" == "true" && "${WORKFLOW_REF}" != "refs/heads/main" && ! "${WORKFLOW_REF}" =~ ^refs/heads/release/[0-9]{4}\.[1-9][0-9]*\.[1-9][0-9]*$ && "${tideclaw_alpha_publish}" != "true" ]]; then
-            echo "publish_openclaw_npm=true requires dispatching this workflow from main, release/YYYY.M.PATCH, or a Tideclaw alpha branch for alpha prereleases." >&2
+          if [[ "${PUBLISH_OPENCLAW_NPM}" == "true" && "${WORKFLOW_REF}" != "refs/heads/main" && ! "${WORKFLOW_REF}" =~ ^refs/heads/release/[0-9]{4}\.[1-9][0-9]*\.[1-9][0-9]*$ && "${tideclaw_alpha_publish}" != "true" && "${extended_stable_release}" != "true" ]]; then
+            echo "publish_openclaw_npm=true requires dispatching this workflow from main, release/YYYY.M.PATCH, extended-stable/YYYY.M.33, or a Tideclaw alpha branch for alpha prereleases." >&2
             exit 1
           fi
-          if [[ "${PUBLISH_OPENCLAW_NPM}" == "true" && "${PLUGIN_PUBLISH_SCOPE}" != "all-publishable" ]]; then
+          if [[ "${PUBLISH_OPENCLAW_NPM}" == "true" && "${extended_stable_release}" == "true" && "${PLUGIN_PUBLISH_SCOPE}" != "extended-stable" ]]; then
+            echo "Extended-stable publish requires plugin_publish_scope=extended-stable." >&2
+            exit 1
+          fi
+          if [[ "${PUBLISH_OPENCLAW_NPM}" == "true" && "${extended_stable_release}" != "true" && "${PLUGIN_PUBLISH_SCOPE}" != "all-publishable" ]]; then
             echo "publish_openclaw_npm=true requires plugin_publish_scope=all-publishable so every publishable official plugin is released with OpenClaw." >&2
             exit 1
           fi
@@ -160,6 +183,10 @@ jobs:
           fi
           if [[ "${PLUGIN_PUBLISH_SCOPE}" == "all-publishable" && -n "${PLUGINS}" ]]; then
             echo "plugin_publish_scope=all-publishable must not include plugins." >&2
+            exit 1
+          fi
+          if [[ "${PLUGIN_PUBLISH_SCOPE}" == "extended-stable" && -n "${PLUGINS}" ]]; then
+            echo "plugin_publish_scope=extended-stable derives the covered set and must not include plugins." >&2
             exit 1
           fi
           case "$RELEASE_PROFILE" in
@@ -172,7 +199,7 @@ jobs:
 
       - name: Validate stable Windows source release
         id: windows_source
-        if: ${{ inputs.publish_openclaw_npm }}
+        if: ${{ inputs.publish_openclaw_npm && inputs.npm_dist_tag != 'extended-stable' }}
         env:
           GH_TOKEN: ${{ github.token }}
           RELEASE_TAG: ${{ inputs.tag }}
@@ -414,7 +441,8 @@ jobs:
           set -euo pipefail
           git fetch --no-tags origin \
             +refs/heads/main:refs/remotes/origin/main \
-            '+refs/heads/release/*:refs/remotes/origin/release/*'
+            '+refs/heads/release/*:refs/remotes/origin/release/*' \
+            '+refs/heads/extended-stable/*:refs/remotes/origin/extended-stable/*'
           if git merge-base --is-ancestor HEAD origin/main; then
             exit 0
           fi
@@ -423,6 +451,10 @@ jobs:
               exit 0
             fi
           done < <(git for-each-ref --format='%(refname)' refs/remotes/origin/release)
+          if [[ "${WORKFLOW_REF_NAME}" =~ ^extended-stable/[0-9]{4}\.[1-9][0-9]*\.33$ ]] &&
+            git merge-base --is-ancestor HEAD "refs/remotes/origin/${WORKFLOW_REF_NAME}"; then
+            exit 0
+          fi
           if [[ "${RELEASE_TAG}" == *"-alpha."* ]]; then
             if [[ ! "${WORKFLOW_REF_NAME}" =~ ^tideclaw/alpha/[0-9]{4}-[0-9]{2}-[0-9]{2}-[0-9]{4}Z$ ]]; then
               echo "Alpha publish tags must be dispatched from tideclaw/alpha/YYYY-MM-DD-HHMMZ." >&2
@@ -461,6 +493,7 @@ jobs:
   publish:
     name: Publish plugins, then OpenClaw
     needs: [resolve_release_target]
+    if: ${{ inputs.npm_dist_tag != 'extended-stable' }}
     runs-on: ubuntu-latest
     timeout-minutes: 120
     environment: npm-release
@@ -801,7 +834,7 @@ jobs:
           }
 
           guard_openclaw_npm_not_already_published() {
-            local release_version release_url
+            local candidate_tag candidate_version release_version release_url
 
             if [[ "${PUBLISH_OPENCLAW_NPM}" != "true" ]]; then
               return 0
@@ -810,6 +843,20 @@ jobs:
             release_version="${RELEASE_TAG#v}"
             if ! npm view "openclaw@${release_version}" version >/dev/null 2>&1; then
               return 0
+            fi
+
+            if [[ "${RELEASE_NPM_DIST_TAG}" == "extended-stable" ]]; then
+              candidate_tag="extended-stable-candidate-${release_version//./-}"
+              candidate_version="$(npm view "openclaw@${candidate_tag}" version 2>/dev/null || true)"
+              if [[ "${candidate_version}" == "${release_version}" ]]; then
+                echo "Reusing existing immutable openclaw@${release_version} publication under ${candidate_tag}."
+                return 0
+              fi
+              {
+                echo "openclaw@${release_version} already exists, but ${candidate_tag} does not resolve to it."
+                echo "The public orchestrator cannot repair candidate dist-tags; use the protected private recovery path."
+              } >&2
+              exit 1
             fi
 
             release_url="https://github.com/${GITHUB_REPOSITORY}/releases/tag/${RELEASE_TAG}"
@@ -1471,4 +1518,43 @@ jobs:
         with:
           name: openclaw-release-postpublish-evidence-${{ inputs.tag }}
           path: ${{ runner.temp }}/openclaw-release-postpublish-evidence
+          if-no-files-found: error
+
+  publish_extended_stable_candidates:
+    name: Publish and accept extended-stable npm candidates
+    needs: [resolve_release_target]
+    if: ${{ inputs.npm_dist_tag == 'extended-stable' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 240
+    environment: npm-release
+    steps:
+      - name: Checkout release SHA
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          ref: ${{ needs.resolve_release_target.outputs.sha }}
+          fetch-depth: 1
+          persist-credentials: false
+
+      - name: Setup Node environment
+        uses: ./.github/actions/setup-node-env
+        with:
+          install-bun: "false"
+
+      - name: Publish candidates and build protected-selector handoff
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          node --import tsx scripts/orchestrate-extended-stable-plugin-release.ts \
+            --release-tag "${{ inputs.tag }}" \
+            --source-sha "${{ needs.resolve_release_target.outputs.sha }}" \
+            --workflow-ref "${{ github.ref_name }}" \
+            --preflight-run-id "${{ inputs.preflight_run_id }}" \
+            --validation-run-id "${{ inputs.full_release_validation_run_id }}" \
+            --output "${RUNNER_TEMP}/extended-stable-selector-handoff/extended-stable-selector-handoff.json"
+
+      - name: Upload protected-selector handoff
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: extended-stable-selector-handoff-${{ github.run_id }}-${{ github.run_attempt }}
+          path: ${{ runner.temp }}/extended-stable-selector-handoff/extended-stable-selector-handoff.json
           if-no-files-found: error

--- a/.github/workflows/plugin-npm-release.yml
+++ b/.github/workflows/plugin-npm-release.yml
@@ -103,11 +103,10 @@ jobs:
           branch_year="${BASH_REMATCH[1]}"
           branch_month="${BASH_REMATCH[2]}"
           root_version="$(node -p "require('./package.json').version")"
-          if [[ ! "${root_version}" =~ ^([0-9]{4})\.([1-9][0-9]*)\.([3-9][0-9]|[1-9][0-9]{2,})$ ]]; then
-            echo "Extended-stable plugin publication requires an exact final YYYY.M.P version with patch 33 or above." >&2
-            exit 1
-          fi
-          if [[ "${BASH_REMATCH[1]}" != "${branch_year}" || "${BASH_REMATCH[2]}" != "${branch_month}" ]]; then
+          ROOT_VERSION="${root_version}" node --import tsx --input-type=module -e \
+            'import { assertExtendedStableReleaseVersion } from "./scripts/lib/extended-stable-plugin-acceptance.ts"; assertExtendedStableReleaseVersion(process.env.ROOT_VERSION ?? "");'
+          IFS=. read -r root_year root_month _ <<< "${root_version}"
+          if [[ "${root_year}" != "${branch_year}" || "${root_month}" != "${branch_month}" ]]; then
             echo "Extended-stable plugin package month ${root_version} does not match ${WORKFLOW_REF}." >&2
             exit 1
           fi

--- a/.github/workflows/plugin-npm-release.yml
+++ b/.github/workflows/plugin-npm-release.yml
@@ -8,22 +8,26 @@ on:
       - ".github/workflows/plugin-npm-release.yml"
       - "extensions/**"
       - "package.json"
+      - "release/extended-stable-plugin-support.json"
       - "scripts/lib/plugin-npm-package-manifest.mjs"
+      - "scripts/lib/extended-stable-plugin-support.ts"
       - "scripts/lib/plugin-npm-release.ts"
       - "scripts/plugin-npm-publish.sh"
       - "scripts/plugin-npm-release-check.ts"
       - "scripts/plugin-npm-release-plan.ts"
+      - "scripts/plugin-npm-publication-result.ts"
       - "scripts/verify-plugin-npm-published-runtime.mjs"
   workflow_dispatch:
     inputs:
       publish_scope:
-        description: Publish the selected plugins or all publishable plugins from the ref
+        description: Publish selected, all publishable, or the fixed extended-stable plugin set
         required: true
         default: selected
         type: choice
         options:
           - selected
           - all-publishable
+          - extended-stable
       ref:
         description: Commit SHA on main, a release branch, or the matching Tideclaw alpha branch to publish from
         required: true
@@ -55,6 +59,7 @@ jobs:
       has_candidates: ${{ steps.plan.outputs.has_candidates }}
       candidate_count: ${{ steps.plan.outputs.candidate_count }}
       matrix: ${{ steps.plan.outputs.matrix }}
+      extended_stable: ${{ steps.plan.outputs.extended_stable }}
     steps:
       - name: Checkout
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
@@ -73,6 +78,40 @@ jobs:
         id: ref
         run: echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
 
+      - name: Bind extended-stable source to provenance SHA
+        if: github.event_name == 'workflow_dispatch' && inputs.publish_scope == 'extended-stable'
+        env:
+          PROVENANCE_SHA: ${{ github.sha }}
+          SOURCE_SHA: ${{ steps.ref.outputs.sha }}
+        run: |
+          if [[ "${SOURCE_SHA}" != "${PROVENANCE_SHA}" ]]; then
+            echo "Extended-stable plugin source ${SOURCE_SHA} must equal the workflow provenance SHA ${PROVENANCE_SHA}." >&2
+            echo "Dispatch this workflow on the exact release ref instead of publishing a different ref input." >&2
+            exit 1
+          fi
+
+      - name: Validate extended-stable release line
+        if: github.event_name == 'workflow_dispatch' && inputs.publish_scope == 'extended-stable'
+        env:
+          WORKFLOW_REF: ${{ github.ref }}
+        run: |
+          set -euo pipefail
+          if [[ ! "${WORKFLOW_REF}" =~ ^refs/heads/extended-stable/([0-9]{4})\.([1-9][0-9]*)\.33$ ]]; then
+            echo "Extended-stable plugin publication must run from extended-stable/YYYY.M.33." >&2
+            exit 1
+          fi
+          branch_year="${BASH_REMATCH[1]}"
+          branch_month="${BASH_REMATCH[2]}"
+          root_version="$(node -p "require('./package.json').version")"
+          if [[ ! "${root_version}" =~ ^([0-9]{4})\.([1-9][0-9]*)\.([3-9][0-9]|[1-9][0-9]{2,})$ ]]; then
+            echo "Extended-stable plugin publication requires an exact final YYYY.M.P version with patch 33 or above." >&2
+            exit 1
+          fi
+          if [[ "${BASH_REMATCH[1]}" != "${branch_year}" || "${BASH_REMATCH[2]}" != "${branch_month}" ]]; then
+            echo "Extended-stable plugin package month ${root_version} does not match ${WORKFLOW_REF}." >&2
+            exit 1
+          fi
+
       - name: Validate ref is on a trusted publish branch
         env:
           WORKFLOW_REF: ${{ github.ref }}
@@ -80,7 +119,8 @@ jobs:
           set -euo pipefail
           git fetch --no-tags origin \
             +refs/heads/main:refs/remotes/origin/main \
-            '+refs/heads/release/*:refs/remotes/origin/release/*'
+            '+refs/heads/release/*:refs/remotes/origin/release/*' \
+            '+refs/heads/extended-stable/*:refs/remotes/origin/extended-stable/*'
           if git merge-base --is-ancestor HEAD origin/main; then
             exit 0
           fi
@@ -89,6 +129,12 @@ jobs:
               exit 0
             fi
           done < <(git for-each-ref --format='%(refname)' refs/remotes/origin/release)
+          if [[ "${WORKFLOW_REF}" =~ ^refs/heads/extended-stable/[0-9]{4}\.[1-9][0-9]*\.33$ ]]; then
+            extended_stable_branch="${WORKFLOW_REF#refs/heads/}"
+            if git merge-base --is-ancestor HEAD "refs/remotes/origin/${extended_stable_branch}"; then
+              exit 0
+            fi
+          fi
           if [[ "${WORKFLOW_REF}" =~ ^refs/heads/tideclaw/alpha/[0-9]{4}-[0-9]{2}-[0-9]{2}-[0-9]{4}Z$ ]]; then
             alpha_branch="${WORKFLOW_REF#refs/heads/}"
             git fetch --no-tags origin "+refs/heads/${alpha_branch}:refs/remotes/origin/${alpha_branch}"
@@ -96,7 +142,7 @@ jobs:
               exit 0
             fi
           fi
-          echo "Plugin npm publishes must target a commit reachable from main, release/*, or the matching Tideclaw alpha branch." >&2
+          echo "Plugin npm publishes must target a commit reachable from main, release/*, extended-stable/YYYY.M.33, or the matching Tideclaw alpha branch." >&2
           exit 1
 
       - name: Validate publishable plugin metadata
@@ -143,21 +189,28 @@ jobs:
 
           cat .local/plugin-npm-release-plan.json
 
-          candidate_count="$(jq -r '.candidates | length' .local/plugin-npm-release-plan.json)"
+          matrix_selector='.candidates'
+          extended_stable="false"
+          if [[ "${PUBLISH_SCOPE}" == "extended-stable" ]]; then
+            matrix_selector='.all'
+            extended_stable="true"
+          fi
+          candidate_count="$(jq -r "${matrix_selector} | length" .local/plugin-npm-release-plan.json)"
           has_candidates="false"
           if [[ "${candidate_count}" != "0" ]]; then
             has_candidates="true"
           fi
-          matrix_json="$(jq -c '.candidates' .local/plugin-npm-release-plan.json)"
+          matrix_json="$(jq -c "${matrix_selector}" .local/plugin-npm-release-plan.json)"
 
           {
             echo "candidate_count=${candidate_count}"
             echo "has_candidates=${has_candidates}"
             echo "matrix=${matrix_json}"
+            echo "extended_stable=${extended_stable}"
           } >> "$GITHUB_OUTPUT"
 
           echo "Plugin release candidates:"
-          jq -r '.candidates[]? | "- \(.packageName)@\(.version) [\(.publishTag)] from \(.packageDir)"' .local/plugin-npm-release-plan.json
+          jq -r "${matrix_selector}[]? | \"- \\(.packageName)@\\(.version) [\\(.publishTag)] from \\(.packageDir)\"" .local/plugin-npm-release-plan.json
 
           echo "Already published / skipped:"
           jq -r '.skippedPublished[]? | "- \(.packageName)@\(.version)"' .local/plugin-npm-release-plan.json
@@ -237,10 +290,26 @@ jobs:
           install-bun: "false"
 
       - name: Preview publish command
-        run: bash scripts/plugin-npm-publish.sh --dry-run "${{ matrix.plugin.packageDir }}"
+        env:
+          CANDIDATE_TAG: ${{ matrix.plugin.candidateTag }}
+          PACKAGE_DIR: ${{ matrix.plugin.packageDir }}
+        run: |
+          args=(--dry-run)
+          if [[ -n "${CANDIDATE_TAG}" ]]; then
+            args+=(--candidate-tag "${CANDIDATE_TAG}")
+          fi
+          bash scripts/plugin-npm-publish.sh "${args[@]}" "${PACKAGE_DIR}"
 
       - name: Preview npm pack contents
-        run: bash scripts/plugin-npm-publish.sh --pack-dry-run "${{ matrix.plugin.packageDir }}"
+        env:
+          CANDIDATE_TAG: ${{ matrix.plugin.candidateTag }}
+          PACKAGE_DIR: ${{ matrix.plugin.packageDir }}
+        run: |
+          args=(--pack-dry-run)
+          if [[ -n "${CANDIDATE_TAG}" ]]; then
+            args+=(--candidate-tag "${CANDIDATE_TAG}")
+          fi
+          bash scripts/plugin-npm-publish.sh "${args[@]}" "${PACKAGE_DIR}"
 
   publish_plugins_npm:
     needs: [preview_plugins_npm, preview_plugin_pack, validate_release_publish_approval]
@@ -272,27 +341,221 @@ jobs:
       - name: Check npm package version
         id: npm_package_version
         env:
+          CANDIDATE_TAG: ${{ matrix.plugin.candidateTag }}
           PACKAGE_NAME: ${{ matrix.plugin.packageName }}
           PACKAGE_VERSION: ${{ matrix.plugin.version }}
         run: |
           set -euo pipefail
-          if npm view "${PACKAGE_NAME}@${PACKAGE_VERSION}" version >/dev/null 2>&1; then
+          if [[ -z "${CANDIDATE_TAG}" ]]; then
+            if npm view "${PACKAGE_NAME}@${PACKAGE_VERSION}" version >/dev/null 2>&1; then
+              echo "${PACKAGE_NAME}@${PACKAGE_VERSION} is already published on npm."
+              echo "already_published=true" >> "$GITHUB_OUTPUT"
+            else
+              echo "already_published=false" >> "$GITHUB_OUTPUT"
+            fi
+            exit 0
+          fi
+          query_error="$(mktemp)"
+          trap 'rm -f "${query_error}"' EXIT
+          set +e
+          published_version="$(npm view "${PACKAGE_NAME}@${PACKAGE_VERSION}" version --json 2>"${query_error}")"
+          query_status=$?
+          set -e
+          if [[ "${query_status}" == "0" ]]; then
+            if [[ "$(jq -r '.' <<<"${published_version}")" != "${PACKAGE_VERSION}" ]]; then
+              echo "npm returned an unexpected exact version for ${PACKAGE_NAME}@${PACKAGE_VERSION}." >&2
+              exit 1
+            fi
             echo "${PACKAGE_NAME}@${PACKAGE_VERSION} is already published on npm."
             echo "already_published=true" >> "$GITHUB_OUTPUT"
-          else
+          elif grep -Eq 'E404|404 Not Found|is not in this registry' "${query_error}"; then
+            echo "${PACKAGE_NAME}@${PACKAGE_VERSION} is authoritatively absent from npm."
             echo "already_published=false" >> "$GITHUB_OUTPUT"
+          else
+            cat "${query_error}" >&2
+            echo "Could not authoritatively query ${PACKAGE_NAME}@${PACKAGE_VERSION}; refusing publication." >&2
+            exit 1
           fi
 
-      - name: Publish
-        if: steps.npm_package_version.outputs.already_published != 'true'
+      - name: Publish regular plugin release
+        if: steps.npm_package_version.outputs.already_published != 'true' && matrix.plugin.candidateTag == ''
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
           OPENCLAW_NPM_PUBLISH_AUTH_MODE: trusted-publisher
         run: bash scripts/plugin-npm-publish.sh --publish "${{ matrix.plugin.packageDir }}"
 
+      - name: Publish extended-stable candidate
+        if: steps.npm_package_version.outputs.already_published != 'true' && matrix.plugin.candidateTag != ''
+        env:
+          OPENCLAW_NPM_PUBLISH_AUTH_MODE: trusted-publisher
+        run: >-
+          bash scripts/plugin-npm-publish.sh --publish
+          --candidate-tag "${{ matrix.plugin.candidateTag }}"
+          "${{ matrix.plugin.packageDir }}"
+
+      - name: Verify extended-stable candidate tag
+        if: matrix.plugin.candidateTag != ''
+        env:
+          ALREADY_PUBLISHED: ${{ steps.npm_package_version.outputs.already_published }}
+          PACKAGE_NAME: ${{ matrix.plugin.packageName }}
+          PACKAGE_VERSION: ${{ matrix.plugin.version }}
+          CANDIDATE_TAG: ${{ matrix.plugin.candidateTag }}
+        run: |
+          set -euo pipefail
+          authoritative_read=false
+          for attempt in {1..12}; do
+            query_error="$(mktemp)"
+            set +e
+            tags_json="$(npm view "${PACKAGE_NAME}" dist-tags --json 2>"${query_error}")"
+            query_status=$?
+            set -e
+            if [[ "${query_status}" != "0" ]]; then
+              cat "${query_error}" >&2
+              rm -f "${query_error}"
+              sleep 5
+              continue
+            fi
+            rm -f "${query_error}"
+            authoritative_read=true
+            resolved="$(jq -r --arg tag "${CANDIDATE_TAG}" '.[$tag] // empty' <<<"${tags_json:-{}}")"
+            if [[ "${resolved}" == "${PACKAGE_VERSION}" ]]; then
+              exit 0
+            fi
+            if [[ -n "${resolved}" ]]; then
+              echo "${PACKAGE_NAME} candidate tag ${CANDIDATE_TAG} points to ${resolved}, expected ${PACKAGE_VERSION}." >&2
+              exit 1
+            fi
+            sleep 5
+          done
+          if [[ "${authoritative_read}" != "true" ]]; then
+            echo "Could not authoritatively read npm dist-tags for ${PACKAGE_NAME}; refusing reconciliation." >&2
+            exit 1
+          fi
+          if [[ "${ALREADY_PUBLISHED}" == "true" ]]; then
+            echo "${PACKAGE_NAME}@${PACKAGE_VERSION} is immutable and already published, but ${CANDIDATE_TAG} is absent." >&2
+            echo "The public workflow has no dist-tag credential and will not republish or retag it; use the protected selector owner for separately approved recovery." >&2
+            exit 1
+          fi
+          echo "${PACKAGE_NAME} candidate tag ${CANDIDATE_TAG} did not resolve to ${PACKAGE_VERSION}." >&2
+          exit 1
+
       - name: Verify published runtime
         env:
           PACKAGE_NAME: ${{ matrix.plugin.packageName }}
           PACKAGE_VERSION: ${{ matrix.plugin.version }}
         run: node scripts/verify-plugin-npm-published-runtime.mjs "${PACKAGE_NAME}@${PACKAGE_VERSION}"
+
+      - name: Verify extended-stable npm provenance
+        if: matrix.plugin.candidateTag != ''
+        env:
+          PACKAGE_NAME: ${{ matrix.plugin.packageName }}
+          PACKAGE_VERSION: ${{ matrix.plugin.version }}
+        run: |
+          set -euo pipefail
+          provenance_predicate="$(npm view "${PACKAGE_NAME}@${PACKAGE_VERSION}" dist.attestations.provenance.predicateType)"
+          if [[ "${provenance_predicate}" != "https://slsa.dev/provenance/v1" ]]; then
+            echo "npm provenance metadata is missing for ${PACKAGE_NAME}@${PACKAGE_VERSION}." >&2
+            exit 1
+          fi
+          verification_dir="$(mktemp -d)"
+          trap 'rm -rf "${verification_dir}"' EXIT
+          (
+            cd "${verification_dir}"
+            npm init -y >/dev/null
+            npm install --ignore-scripts "${PACKAGE_NAME}@${PACKAGE_VERSION}"
+            npm audit signatures
+          )
+
+      - name: Write extended-stable publication record
+        if: matrix.plugin.candidateTag != ''
+        env:
+          PACKAGE_NAME: ${{ matrix.plugin.packageName }}
+          PACKAGE_VERSION: ${{ matrix.plugin.version }}
+          CANDIDATE_TAG: ${{ matrix.plugin.candidateTag }}
+          SOURCE_SHA: ${{ needs.preview_plugins_npm.outputs.ref_revision }}
+        run: |
+          set -euo pipefail
+          npm_integrity="$(npm view "${PACKAGE_NAME}@${PACKAGE_VERSION}" dist.integrity)"
+          if [[ "${npm_integrity}" != sha512-* ]]; then
+            echo "npm integrity missing for ${PACKAGE_NAME}@${PACKAGE_VERSION}." >&2
+            exit 1
+          fi
+          mkdir -p .local/plugin-publication-result
+          jq -n \
+            --arg packageName "${PACKAGE_NAME}" \
+            --arg version "${PACKAGE_VERSION}" \
+            --arg npmIntegrity "${npm_integrity}" \
+            --arg candidateTag "${CANDIDATE_TAG}" \
+            --arg sourceSha "${SOURCE_SHA}" \
+            --arg repository "${GITHUB_REPOSITORY}" \
+            --arg workflowPath ".github/workflows/plugin-npm-release.yml" \
+            --arg workflowRef "${GITHUB_REF}" \
+            --arg workflowSha "${GITHUB_WORKFLOW_SHA}" \
+            --arg runId "${GITHUB_RUN_ID}" \
+            --arg runAttempt "${GITHUB_RUN_ATTEMPT}" \
+            '{packageName:$packageName,version:$version,npmIntegrity:$npmIntegrity,candidateTag:$candidateTag,provenanceVerified:true,sourceSha:$sourceSha,repository:$repository,workflowPath:$workflowPath,workflowRef:$workflowRef,workflowSha:$workflowSha,runId:$runId,runAttempt:$runAttempt}' \
+            > ".local/plugin-publication-result/${{ matrix.plugin.extensionId }}.json"
+
+      - name: Upload extended-stable publication record
+        if: matrix.plugin.candidateTag != ''
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: extended-stable-plugin-publication-record-${{ github.run_attempt }}-${{ matrix.plugin.extensionId }}
+          path: .local/plugin-publication-result/${{ matrix.plugin.extensionId }}.json
+          if-no-files-found: error
+          retention-days: 14
+
+  aggregate_extended_stable_publication:
+    needs: [preview_plugins_npm, publish_plugins_npm]
+    if: github.event_name == 'workflow_dispatch' && needs.preview_plugins_npm.outputs.extended_stable == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          persist-credentials: false
+          ref: ${{ needs.preview_plugins_npm.outputs.ref_revision }}
+          fetch-depth: 1
+
+      - name: Setup Node environment
+        uses: ./.github/actions/setup-node-env
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          install-bun: "false"
+
+      - name: Download publication records
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          pattern: extended-stable-plugin-publication-record-${{ github.run_attempt }}-*
+          path: .local/plugin-publication-records
+          merge-multiple: true
+
+      - name: Close aggregate publication result
+        env:
+          SOURCE_SHA: ${{ needs.preview_plugins_npm.outputs.ref_revision }}
+        run: |
+          set -euo pipefail
+          mkdir -p .local/plugin-publication-aggregate
+          node --import tsx scripts/plugin-npm-publication-result.ts \
+            --results-dir .local/plugin-publication-records \
+            --output .local/plugin-publication-aggregate/extended-stable-plugin-publication.json \
+            --source-sha "${SOURCE_SHA}" \
+            --repository "${GITHUB_REPOSITORY}" \
+            --workflow-path ".github/workflows/plugin-npm-release.yml" \
+            --workflow-ref "${GITHUB_REF}" \
+            --workflow-sha "${GITHUB_WORKFLOW_SHA}" \
+            --run-id "${GITHUB_RUN_ID}" \
+            --run-attempt "${GITHUB_RUN_ATTEMPT}"
+          cat .local/plugin-publication-aggregate/extended-stable-plugin-publication.json
+
+      - name: Upload aggregate publication result
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: extended-stable-plugin-publication-${{ github.run_id }}-${{ github.run_attempt }}
+          path: .local/plugin-publication-aggregate/extended-stable-plugin-publication.json
+          if-no-files-found: error
+          retention-days: 90

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -142,12 +142,13 @@ gh workflow run full-release-validation.yml --ref main -f ref=<branch-or-sha>
 
 The monthly npm-only extended-stable path is the exception: dispatch both `OpenClaw NPM
 Release` preflight and `Full Release Validation` from the exact
-`extended-stable/YYYY.M.33` branch, preserve their run IDs, and pass both IDs to the
-direct npm publish run. See [Monthly npm-only extended-stable
+`extended-stable/YYYY.M.33` branch, preserve their run IDs, and pass both IDs to
+`OpenClaw Release Publish` with `plugin_publish_scope=extended-stable`. See [Monthly npm-only extended-stable
 publication](/reference/RELEASING#monthly-npm-only-extended-stable-publication) for
-the commands, exact identity requirements, registry readback, and selector
-repair procedure. This path does not dispatch plugin, macOS, Windows, GitHub
-Release, private dist-tag, or other platform publication.
+the commands, exact identity requirements, candidate verification, and
+protected-selector handoff. This path publishes only core plus the covered
+Codex, Discord, and Slack npm candidates; it skips ClawHub, macOS, Windows,
+GitHub Release, and other platform publication.
 
 ## Runners
 

--- a/docs/reference/RELEASING.md
+++ b/docs/reference/RELEASING.md
@@ -13,10 +13,11 @@ OpenClaw currently exposes three user-facing update channels:
 - beta: prerelease tags that publish to npm `beta`
 - dev: the moving head of `main`
 
-Separately, release operators can publish the trailing completed month's core
-package to npm `extended-stable`, beginning at patch `33`. The current-month
-regular final line continues on npm `latest`; this operator-side publication
-split does not by itself change CLI update-channel resolution.
+Separately, release operators can publish immutable candidates for the trailing
+completed month's core package and the covered Codex, Discord, and Slack plugin
+packages, beginning at patch `33`. The current-month regular final line continues
+on npm `latest`; this operator-side publication split does not by itself change
+CLI update-channel resolution.
 
 Tideclaw alpha builds are a separate internal prerelease track (npm dist-tag `alpha`), covered under [NPM workflow inputs](#npm-workflow-inputs) and [Release test boxes](#release-test-boxes).
 
@@ -34,7 +35,8 @@ Tideclaw alpha builds are a separate internal prerelease track (npm dist-tag `al
 - `latest` continues to follow the current regular/daily npm line; `beta` is the current beta install target
 - `extended-stable` means the supported trailing-month npm package, beginning at patch `33`; patch `34` and later are maintenance releases on that monthly line
 - Regular final and regular correction releases publish to npm `beta` by default; release operators can target `latest` explicitly, or promote a vetted beta build later
-- The dedicated monthly extended-stable path publishes only the core npm package. It does not publish plugins, macOS or Windows artifacts, a GitHub Release, private-repository dist-tags, Docker images, mobile artifacts, or website downloads.
+- The dedicated monthly extended-stable path publishes core plus the covered `@openclaw/codex`, `@openclaw/discord`, and `@openclaw/slack` npm candidates. It does not publish other plugins, macOS or Windows artifacts, a GitHub Release, private-repository dist-tags, Docker images, mobile artifacts, or website downloads.
+- Installing core does not automatically install every covered plugin. As with the regular channel, onboarding, configuration, or explicit plugin commands install the plugins a user actually enables.
 - Every regular final release ships the npm package, macOS app, and signed Windows Hub installers together. Beta releases normally validate and publish the npm/package path first, with native app build/sign/notarize/promote reserved for regular final unless explicitly requested.
 
 ## Release cadence
@@ -75,48 +77,58 @@ gh workflow run full-release-validation.yml \
 separate from the npm `extended-stable` dist-tag and is intentionally
 unchanged.
 
-After both runs succeed and the npm release environment is ready, promote the
-exact preflight tarball. Patch `P` must be `33` or greater:
+After both runs succeed and the npm release environment is ready, run the
+extended-stable release orchestrator. Patch `P` must be `33` or greater:
 
 ```bash
-gh workflow run openclaw-npm-release.yml \
+gh workflow run openclaw-release-publish.yml \
   --ref extended-stable/YYYY.M.33 \
   -f tag=vYYYY.M.P \
-  -f preflight_only=false \
   -f npm_dist_tag=extended-stable \
+  -f plugin_publish_scope=extended-stable \
+  -f publish_openclaw_npm=true \
+  -f release_profile=stable \
   -f preflight_run_id=<npm-preflight-run-id> \
   -f full_release_validation_run_id=<full-validation-run-id>
 ```
 
-For a fork or non-production rehearsal that intentionally cannot satisfy the
-monthly `.33` or protected-`main` month policy, add
-`-f bypass_extended_stable_guard=true` to both npm preflight and publish
-dispatches. The default is `false`. The bypass is accepted only with
-`npm_dist_tag=extended-stable` and is recorded in the workflow summary. It
-does not bypass the canonical `extended-stable/YYYY.M.33` workflow ref,
-branch-tip/tag/checkout equality, final-tag syntax, package/tag version
-equality, referenced run and manifest identity, tarball provenance,
-environment approval, registry readback, or selector repair evidence.
+For a fork or local core-only guard rehearsal, the lower-level
+`openclaw-npm-release.yml` workflow still accepts
+`bypass_extended_stable_guard=true`. The coordinated core-plus-plugin
+orchestrator does not accept that bypass: use a synthetic `.33+` version for
+an end-to-end rehearsal. The lower-level bypass never relaxes the canonical
+workflow ref, branch-tip/tag/checkout equality, referenced evidence, or
+candidate readback.
 
-The publish workflow verifies the referenced run identities, the prepared
-tarball digest, and both npm registry selectors. Independently confirm the
-result after the workflow succeeds:
+The public workflow publishes each immutable package under a derived,
+version-specific candidate tag, verifies exact versions, integrities,
+provenance, and package acceptance, proves both `latest` and shared
+`extended-stable` selectors remained unchanged, then uploads one closed
+plugin-first/core-last selector handoff.
+
+The protected `openclaw/releases` selector owner is a separate required phase.
+Until that workflow consumes the handoff and reports successful plugin-first,
+core-last promotion and candidate cleanup, the release is candidate-only and
+must not be announced as available on `extended-stable`. Do not repair shared
+selectors from this public repository or republish immutable versions.
+
+After protected promotion succeeds, independently confirm the result:
 
 ```bash
 npm view openclaw@YYYY.M.P version --userconfig "$(mktemp)"
 npm view openclaw@extended-stable version --userconfig "$(mktemp)"
+npm view @openclaw/codex@extended-stable version --userconfig "$(mktemp)"
+npm view @openclaw/discord@extended-stable version --userconfig "$(mktemp)"
+npm view @openclaw/slack@extended-stable version --userconfig "$(mktemp)"
 ```
 
-Both commands must return `YYYY.M.P`. If publish succeeds but selector
-readback fails, do not republish the immutable package version. Use the
-single `npm dist-tag add openclaw@YYYY.M.P extended-stable` repair command
-printed in the failed workflow's always-run summary, then repeat both
-independent readbacks. Rollback to the prior selector is a separate operator
-decision, not the readback repair path.
+Every command must return `YYYY.M.P`. If promotion or readback fails, do not
+republish. Use only the protected selector owner's guarded repair operation,
+with its captured prior state and terminal evidence.
 
 The regular checklist below continues to own beta, `latest`, GitHub Release,
-plugins, macOS, Windows, and other platform publication. Do not run those
-steps for this npm-only extended-stable path.
+uncovered plugins, macOS, Windows, and other platform publication. Do not run
+those steps for this npm-only extended-stable path.
 
 ## Regular release operator checklist
 

--- a/package.json
+++ b/package.json
@@ -177,6 +177,7 @@
     "scripts/lib/official-external-channel-catalog.json",
     "scripts/lib/official-external-plugin-catalog.json",
     "scripts/lib/official-external-provider-catalog.json",
+    "release/extended-stable-plugin-support.json",
     "scripts/lib/package-dist-imports.mjs",
     "scripts/postinstall-bundled-plugins.mjs",
     "scripts/windows-cmd-helpers.mjs"

--- a/release/extended-stable-plugin-support.json
+++ b/release/extended-stable-plugin-support.json
@@ -1,0 +1,23 @@
+{
+  "schemaVersion": 1,
+  "plugins": [
+    {
+      "pluginId": "codex",
+      "packageName": "@openclaw/codex",
+      "packageDir": "extensions/codex",
+      "acceptanceProfile": "codex-provider-v1"
+    },
+    {
+      "pluginId": "discord",
+      "packageName": "@openclaw/discord",
+      "packageDir": "extensions/discord",
+      "acceptanceProfile": "discord-channel-v1"
+    },
+    {
+      "pluginId": "slack",
+      "packageName": "@openclaw/slack",
+      "packageDir": "extensions/slack",
+      "acceptanceProfile": "slack-channel-v1"
+    }
+  ]
+}

--- a/scripts/lib/extended-stable-plugin-acceptance.ts
+++ b/scripts/lib/extended-stable-plugin-acceptance.ts
@@ -1,0 +1,255 @@
+import { createHash } from "node:crypto";
+import { readFileSync } from "node:fs";
+import { loadExtendedStablePluginSupport } from "./extended-stable-plugin-support.js";
+
+export const EXTENDED_STABLE_ACCEPTANCE_WORKFLOW_PATH =
+  ".github/workflows/extended-stable-plugin-acceptance.yml";
+
+export const COMMON_ACCEPTANCE_SCENARIOS = [
+  "install",
+  "production_loader",
+  "plugin_discovery",
+  "doctor",
+] as const;
+
+const PROFILE_SCENARIOS = {
+  "codex-provider-v1": "codex_contracts",
+  "discord-channel-v1": "discord_contracts",
+  "slack-channel-v1": "slack_contracts",
+} as const;
+
+export type AcceptanceScenarioStatus = "passed" | "failed" | "not_run";
+
+export type ExtendedStablePluginAcceptanceResult = {
+  schemaVersion: 1;
+  inputs: {
+    releaseVersion: string;
+    pluginPackageName: string;
+  };
+  resolved: {
+    coreVersion: string;
+    coreIntegrity: string;
+    pluginIntegrity: string;
+    acceptanceProfile: keyof typeof PROFILE_SCENARIOS;
+  };
+  workflow: {
+    repository: string;
+    path: typeof EXTENDED_STABLE_ACCEPTANCE_WORKFLOW_PATH;
+    ref: "refs/heads/main";
+    sha: string;
+    runId: number;
+    runAttempt: number;
+    event: "workflow_dispatch";
+  };
+  scenarios: Array<{
+    id: string;
+    status: AcceptanceScenarioStatus;
+  }>;
+  conclusion: "succeeded" | "failed";
+};
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function assertExactKeys(
+  value: Record<string, unknown>,
+  expectedKeys: readonly string[],
+  label: string,
+): void {
+  const actual = Object.keys(value).toSorted();
+  const expected = [...expectedKeys].toSorted();
+  if (JSON.stringify(actual) !== JSON.stringify(expected)) {
+    throw new Error(`${label} must contain exactly: ${expected.join(", ")}.`);
+  }
+}
+
+function requireRecord(value: unknown, label: string): Record<string, unknown> {
+  if (!isRecord(value)) {
+    throw new Error(`${label} must be an object.`);
+  }
+  return value;
+}
+
+function requireString(value: unknown, label: string): string {
+  if (typeof value !== "string" || value.length === 0 || value !== value.trim()) {
+    throw new Error(`${label} must be a non-empty, trimmed string.`);
+  }
+  return value;
+}
+
+function requirePositiveInteger(value: unknown, label: string): number {
+  if (!Number.isSafeInteger(value) || Number(value) <= 0) {
+    throw new Error(`${label} must be a positive integer.`);
+  }
+  return Number(value);
+}
+
+export function assertExtendedStableReleaseVersion(value: string): string {
+  if (!/^\d{4}\.[1-9]\d*\.[1-9]\d*$/u.test(value)) {
+    throw new Error(`releaseVersion must be an exact final YYYY.M.P version; got ${value}.`);
+  }
+  const patch = Number(value.split(".")[2]);
+  if (patch < 33) {
+    throw new Error(`extended-stable releaseVersion patch must be 33 or above; got ${value}.`);
+  }
+  return value;
+}
+
+export function acceptanceScenarioIds(profile: string): string[] {
+  const profileScenario = PROFILE_SCENARIOS[profile as keyof typeof PROFILE_SCENARIOS];
+  if (!profileScenario) {
+    throw new Error(`Unsupported extended-stable acceptance profile: ${profile}.`);
+  }
+  return [...COMMON_ACCEPTANCE_SCENARIOS, profileScenario];
+}
+
+export function resolveCoveredPlugin(rootDir: string, packageName: string) {
+  const support = loadExtendedStablePluginSupport(rootDir);
+  const plugin = support.plugins.find((entry) => entry.packageName === packageName);
+  if (!plugin) {
+    throw new Error(`${packageName} is not covered by extended-stable plugin support.`);
+  }
+  return plugin;
+}
+
+export function parseExtendedStablePluginAcceptanceResult(
+  value: unknown,
+): ExtendedStablePluginAcceptanceResult {
+  const root = requireRecord(value, "extended-stable plugin acceptance result");
+  assertExactKeys(
+    root,
+    ["schemaVersion", "inputs", "resolved", "workflow", "scenarios", "conclusion"],
+    "extended-stable plugin acceptance result",
+  );
+  if (root.schemaVersion !== 1) {
+    throw new Error("extended-stable plugin acceptance result schemaVersion must be 1.");
+  }
+
+  const inputs = requireRecord(root.inputs, "acceptance inputs");
+  assertExactKeys(inputs, ["releaseVersion", "pluginPackageName"], "acceptance inputs");
+  const releaseVersion = assertExtendedStableReleaseVersion(
+    requireString(inputs.releaseVersion, "acceptance inputs.releaseVersion"),
+  );
+  const pluginPackageName = requireString(
+    inputs.pluginPackageName,
+    "acceptance inputs.pluginPackageName",
+  );
+
+  const resolved = requireRecord(root.resolved, "acceptance resolved");
+  assertExactKeys(
+    resolved,
+    ["coreVersion", "coreIntegrity", "pluginIntegrity", "acceptanceProfile"],
+    "acceptance resolved",
+  );
+  const coreVersion = requireString(resolved.coreVersion, "acceptance resolved.coreVersion");
+  if (coreVersion !== releaseVersion) {
+    throw new Error("acceptance resolved.coreVersion must equal inputs.releaseVersion.");
+  }
+  const coreIntegrity = requireString(resolved.coreIntegrity, "acceptance resolved.coreIntegrity");
+  const pluginIntegrity = requireString(
+    resolved.pluginIntegrity,
+    "acceptance resolved.pluginIntegrity",
+  );
+  for (const [label, integrity] of [
+    ["coreIntegrity", coreIntegrity],
+    ["pluginIntegrity", pluginIntegrity],
+  ] as const) {
+    if (!/^sha512-[A-Za-z0-9+/]+={0,2}$/u.test(integrity)) {
+      throw new Error(`acceptance resolved.${label} must be an npm sha512 integrity.`);
+    }
+  }
+  const acceptanceProfile = requireString(
+    resolved.acceptanceProfile,
+    "acceptance resolved.acceptanceProfile",
+  ) as keyof typeof PROFILE_SCENARIOS;
+  const expectedScenarioIds = acceptanceScenarioIds(acceptanceProfile);
+
+  const workflow = requireRecord(root.workflow, "acceptance workflow");
+  assertExactKeys(
+    workflow,
+    ["repository", "path", "ref", "sha", "runId", "runAttempt", "event"],
+    "acceptance workflow",
+  );
+  const repository = requireString(workflow.repository, "acceptance workflow.repository");
+  const path = requireString(workflow.path, "acceptance workflow.path");
+  const ref = requireString(workflow.ref, "acceptance workflow.ref");
+  const sha = requireString(workflow.sha, "acceptance workflow.sha");
+  const event = requireString(workflow.event, "acceptance workflow.event");
+  if (path !== EXTENDED_STABLE_ACCEPTANCE_WORKFLOW_PATH) {
+    throw new Error(
+      `acceptance workflow.path must be ${EXTENDED_STABLE_ACCEPTANCE_WORKFLOW_PATH}.`,
+    );
+  }
+  if (ref !== "refs/heads/main") {
+    throw new Error("acceptance workflow.ref must be refs/heads/main.");
+  }
+  if (!/^[0-9a-f]{40}$/u.test(sha)) {
+    throw new Error("acceptance workflow.sha must be a full lowercase Git SHA.");
+  }
+  if (event !== "workflow_dispatch") {
+    throw new Error("acceptance workflow.event must be workflow_dispatch.");
+  }
+  const runId = requirePositiveInteger(workflow.runId, "acceptance workflow.runId");
+  const runAttempt = requirePositiveInteger(workflow.runAttempt, "acceptance workflow.runAttempt");
+
+  if (!Array.isArray(root.scenarios)) {
+    throw new Error("acceptance scenarios must be an array.");
+  }
+  const scenarios = root.scenarios.map((entry, index) => {
+    const scenario = requireRecord(entry, `acceptance scenarios[${index}]`);
+    assertExactKeys(scenario, ["id", "status"], `acceptance scenarios[${index}]`);
+    const id = requireString(scenario.id, `acceptance scenarios[${index}].id`);
+    const status = requireString(
+      scenario.status,
+      `acceptance scenarios[${index}].status`,
+    ) as AcceptanceScenarioStatus;
+    if (!(["passed", "failed", "not_run"] as const).includes(status)) {
+      throw new Error(`acceptance scenarios[${index}].status is invalid.`);
+    }
+    return { id, status };
+  });
+  if (JSON.stringify(scenarios.map((entry) => entry.id)) !== JSON.stringify(expectedScenarioIds)) {
+    throw new Error("acceptance scenarios must contain the profile scenarios in canonical order.");
+  }
+  const conclusion = requireString(root.conclusion, "acceptance conclusion");
+  if (conclusion !== "succeeded" && conclusion !== "failed") {
+    throw new Error("acceptance conclusion must be succeeded or failed.");
+  }
+  const allPassed = scenarios.every((scenario) => scenario.status === "passed");
+  if ((conclusion === "succeeded") !== allPassed) {
+    throw new Error("acceptance conclusion must be succeeded exactly when all scenarios passed.");
+  }
+
+  return {
+    schemaVersion: 1,
+    inputs: { releaseVersion, pluginPackageName },
+    resolved: {
+      coreVersion,
+      coreIntegrity,
+      pluginIntegrity,
+      acceptanceProfile,
+    },
+    workflow: {
+      repository,
+      path: EXTENDED_STABLE_ACCEPTANCE_WORKFLOW_PATH,
+      ref: "refs/heads/main",
+      sha,
+      runId,
+      runAttempt,
+      event: "workflow_dispatch",
+    },
+    scenarios,
+    conclusion,
+  };
+}
+
+export function readExtendedStablePluginAcceptanceResult(
+  path: string,
+): ExtendedStablePluginAcceptanceResult {
+  return parseExtendedStablePluginAcceptanceResult(JSON.parse(readFileSync(path, "utf8")));
+}
+
+export function sha256File(path: string): string {
+  return createHash("sha256").update(readFileSync(path)).digest("hex");
+}

--- a/scripts/lib/extended-stable-plugin-support.ts
+++ b/scripts/lib/extended-stable-plugin-support.ts
@@ -1,0 +1,159 @@
+// Extended-stable plugin support policy validation for release automation.
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+export const EXTENDED_STABLE_PLUGIN_SUPPORT_PATH = "release/extended-stable-plugin-support.json";
+
+export type ExtendedStablePluginSupportEntry = {
+  pluginId: string;
+  packageName: string;
+  packageDir: string;
+  acceptanceProfile: string;
+};
+
+export type ExtendedStablePluginSupport = {
+  schemaVersion: 1;
+  plugins: ExtendedStablePluginSupportEntry[];
+};
+
+const ACCEPTANCE_PROFILES = new Set([
+  "codex-provider-v1",
+  "discord-channel-v1",
+  "slack-channel-v1",
+]);
+
+const ROOT_KEYS = ["plugins", "schemaVersion"] as const;
+const ENTRY_KEYS = ["acceptanceProfile", "packageDir", "packageName", "pluginId"] as const;
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function assertExactKeys(
+  value: Record<string, unknown>,
+  expectedKeys: readonly string[],
+  label: string,
+) {
+  const actualKeys = Object.keys(value).toSorted();
+  const expected = [...expectedKeys].toSorted();
+  if (
+    actualKeys.length !== expected.length ||
+    actualKeys.some((key, index) => key !== expected[index])
+  ) {
+    throw new Error(`${label} must contain exactly: ${expected.join(", ")}.`);
+  }
+}
+
+function requireString(value: unknown, label: string): string {
+  if (typeof value !== "string" || value.length === 0 || value !== value.trim()) {
+    throw new Error(`${label} must be a non-empty, trimmed string.`);
+  }
+  return value;
+}
+
+function parseEntry(value: unknown, index: number): ExtendedStablePluginSupportEntry {
+  const label = `extended-stable plugin support entry ${index}`;
+  if (!isRecord(value)) {
+    throw new Error(`${label} must be an object.`);
+  }
+  assertExactKeys(value, ENTRY_KEYS, label);
+  const entry = {
+    pluginId: requireString(value.pluginId, `${label}.pluginId`),
+    packageName: requireString(value.packageName, `${label}.packageName`),
+    packageDir: requireString(value.packageDir, `${label}.packageDir`),
+    acceptanceProfile: requireString(value.acceptanceProfile, `${label}.acceptanceProfile`),
+  };
+  if (!/^[a-z0-9]+(?:-[a-z0-9]+)*$/u.test(entry.pluginId)) {
+    throw new Error(`${label}.pluginId must be a safe lowercase plugin id.`);
+  }
+  if (entry.packageName !== `@openclaw/${entry.pluginId}`) {
+    throw new Error(`${label}.packageName must match pluginId.`);
+  }
+  if (entry.packageDir !== `extensions/${entry.pluginId}`) {
+    throw new Error(`${label}.packageDir must match pluginId.`);
+  }
+  if (!ACCEPTANCE_PROFILES.has(entry.acceptanceProfile)) {
+    throw new Error(`${label}.acceptanceProfile is not registered.`);
+  }
+  return entry;
+}
+
+function assertUnique(
+  entries: readonly ExtendedStablePluginSupportEntry[],
+  key: keyof ExtendedStablePluginSupportEntry,
+) {
+  const values = entries.map((entry) => entry[key]);
+  if (new Set(values).size !== values.length) {
+    throw new Error(`extended-stable plugin support entries must have unique ${key} values.`);
+  }
+}
+
+export function parseExtendedStablePluginSupport(value: unknown): ExtendedStablePluginSupport {
+  if (!isRecord(value)) {
+    throw new Error("extended-stable plugin support policy must be an object.");
+  }
+  assertExactKeys(value, ROOT_KEYS, "extended-stable plugin support policy");
+  if (value.schemaVersion !== 1) {
+    throw new Error("extended-stable plugin support policy schemaVersion must be 1.");
+  }
+  if (!Array.isArray(value.plugins)) {
+    throw new Error("extended-stable plugin support policy plugins must be an array.");
+  }
+
+  const plugins = value.plugins.map(parseEntry);
+  for (const key of ["pluginId", "packageName", "packageDir"] as const) {
+    assertUnique(plugins, key);
+  }
+
+  const sortedPackageNames = plugins.map((entry) => entry.packageName).toSorted();
+  if (plugins.some((entry, index) => entry.packageName !== sortedPackageNames[index])) {
+    throw new Error("extended-stable plugin support entries must be sorted by packageName.");
+  }
+  return { schemaVersion: 1, plugins };
+}
+
+export function loadExtendedStablePluginSupport(rootDir: string): ExtendedStablePluginSupport {
+  const policyPath = join(rootDir, EXTENDED_STABLE_PLUGIN_SUPPORT_PATH);
+  let value: unknown;
+  try {
+    value = JSON.parse(readFileSync(policyPath, "utf8"));
+  } catch (error) {
+    throw new Error(`Could not read ${EXTENDED_STABLE_PLUGIN_SUPPORT_PATH}: ${String(error)}`, {
+      cause: error,
+    });
+  }
+  return parseExtendedStablePluginSupport(value);
+}
+
+export function validateExtendedStablePluginPackages(params: {
+  rootDir: string;
+  targetVersion: string;
+  support?: ExtendedStablePluginSupport;
+}): ExtendedStablePluginSupport {
+  const support = params.support ?? loadExtendedStablePluginSupport(params.rootDir);
+  for (const entry of support.plugins) {
+    const packagePath = join(params.rootDir, entry.packageDir, "package.json");
+    let packageJson: unknown;
+    try {
+      packageJson = JSON.parse(readFileSync(packagePath, "utf8"));
+    } catch (error) {
+      throw new Error(`Could not read covered plugin package ${packagePath}: ${String(error)}`, {
+        cause: error,
+      });
+    }
+    if (!isRecord(packageJson)) {
+      throw new Error(`Covered plugin package ${packagePath} must be a JSON object.`);
+    }
+    if (packageJson.name !== entry.packageName) {
+      throw new Error(
+        `Covered plugin ${entry.pluginId} package name must be ${entry.packageName}; found ${String(packageJson.name)}.`,
+      );
+    }
+    if (packageJson.version !== params.targetVersion) {
+      throw new Error(
+        `Covered plugin ${entry.packageName} version must match root version ${params.targetVersion}; found ${String(packageJson.version)}.`,
+      );
+    }
+  }
+  return support;
+}

--- a/scripts/lib/plugin-npm-release.ts
+++ b/scripts/lib/plugin-npm-release.ts
@@ -6,6 +6,7 @@ import { join, resolve } from "node:path";
 import { normalizeOptionalString } from "../../packages/normalization-core/src/string-coerce.js";
 import { validateExternalCodePluginPackageJson } from "../../packages/plugin-package-contract/src/index.ts";
 import { parseReleaseVersion } from "../openclaw-npm-release-check.ts";
+import { loadExtendedStablePluginSupport } from "./extended-stable-plugin-support.js";
 import { collectReleaseVersionFloorErrors, resolveNpmPublishPlan } from "./npm-publish-plan.mjs";
 
 export type PluginPackageJson = {
@@ -54,7 +55,9 @@ export type PublishablePluginPackage = {
   packageName: string;
   version: string;
   channel: "stable" | "alpha" | "beta";
-  publishTag: "latest" | "alpha" | "beta";
+  publishTag: string;
+  candidateTag?: string;
+  acceptanceProfile?: string;
   installNpmSpec?: string;
   requiredLatestDependencies?: RequiredLatestDependency[];
 };
@@ -69,7 +72,7 @@ export type PluginReleasePlan = {
   skippedPublished: PluginReleasePlanItem[];
 };
 
-export type PluginReleaseSelectionMode = "selected" | "all-publishable";
+export type PluginReleaseSelectionMode = "selected" | "all-publishable" | "extended-stable";
 
 export type GitRangeSelection = {
   baseRef: string;
@@ -159,6 +162,77 @@ function readOptionalTextFile(path: string): string | undefined {
   }
 }
 
+export function deriveExtendedStablePluginCandidateTag(params: {
+  pluginId: string;
+  version: string;
+}): string {
+  const parsed = parseReleaseVersion(params.version);
+  if (parsed === null || parsed.channel !== "stable" || parsed.correctionNumber !== undefined) {
+    throw new Error(
+      `Extended-stable plugin publication requires a stable YYYY.M.PATCH version; found "${params.version}".`,
+    );
+  }
+  if (!/^[a-z0-9]+(?:-[a-z0-9]+)*$/u.test(params.pluginId)) {
+    throw new Error(
+      `Extended-stable plugin id is not safe for an npm dist-tag: ${params.pluginId}.`,
+    );
+  }
+  return `extended-stable-plugin-candidate-${params.pluginId}-${parsed.year}-${parsed.month}-${parsed.patch}`;
+}
+
+export function collectExtendedStablePublishablePluginPackages(
+  rootDir = resolve("."),
+): PublishablePluginPackage[] {
+  const manifest = loadExtendedStablePluginSupport(rootDir);
+  const rootPackage = readPluginPackageJson(join(rootDir, "package.json")) as PluginPackageJson;
+  if (typeof rootPackage.version !== "string") {
+    throw new Error("Root package.json version must be a string.");
+  }
+  const rootVersion = rootPackage.version.trim();
+  const parsedRootVersion = parseReleaseVersion(rootVersion);
+  if (
+    parsedRootVersion === null ||
+    parsedRootVersion.channel !== "stable" ||
+    parsedRootVersion.correctionNumber !== undefined
+  ) {
+    throw new Error(
+      `Extended-stable plugin publication requires a stable root YYYY.M.PATCH version; found "${rootVersion}".`,
+    );
+  }
+
+  const publishable = collectPublishablePluginPackages(rootDir, {
+    packageNames: manifest.plugins.map((entry) => entry.packageName),
+  });
+  const byName = new Map(publishable.map((plugin) => [plugin.packageName, plugin]));
+  return manifest.plugins.map((entry) => {
+    const plugin = byName.get(entry.packageName);
+    if (
+      !plugin ||
+      plugin.extensionId !== entry.pluginId ||
+      plugin.packageDir !== entry.packageDir
+    ) {
+      throw new Error(
+        `${entry.packageName} must resolve to ${entry.packageDir} with plugin id ${entry.pluginId}.`,
+      );
+    }
+    if (plugin.version !== rootVersion) {
+      throw new Error(
+        `${entry.packageName} version must equal root release version ${rootVersion}; found ${plugin.version}.`,
+      );
+    }
+    const candidateTag = deriveExtendedStablePluginCandidateTag({
+      pluginId: entry.pluginId,
+      version: rootVersion,
+    });
+    return Object.assign({}, plugin, {
+      channel: "stable",
+      publishTag: candidateTag,
+      candidateTag,
+      acceptanceProfile: entry.acceptanceProfile,
+    });
+  });
+}
+
 export function collectExtensionPackageJsonCandidates<
   TPackageJson extends PluginPackageJson = PluginPackageJson,
 >(rootDir = resolve(".")): PublishablePluginPackageCandidate<TPackageJson>[] {
@@ -225,12 +299,12 @@ export function parsePluginReleaseSelection(value: string | undefined): string[]
 export function parsePluginReleaseSelectionMode(
   value: string | undefined,
 ): PluginReleaseSelectionMode {
-  if (value === "selected" || value === "all-publishable") {
+  if (value === "selected" || value === "all-publishable" || value === "extended-stable") {
     return value;
   }
 
   throw new Error(
-    `Unknown selection mode: ${value ?? "<missing>"}. Expected "selected" or "all-publishable".`,
+    `Unknown selection mode: ${value ?? "<missing>"}. Expected "selected", "all-publishable", or "extended-stable".`,
   );
 }
 
@@ -278,6 +352,11 @@ export function parsePluginReleaseArgs(argv: string[]): ParsedPluginReleaseArgs 
   }
   if (selectionMode === "all-publishable" && pluginsFlagProvided) {
     throw new Error("`--selection-mode all-publishable` must not be combined with `--plugins`.");
+  }
+  if (selectionMode === "extended-stable" && pluginsFlagProvided) {
+    throw new Error(
+      "`--selection-mode extended-stable` derives its package set from policy and must not be combined with `--plugins`.",
+    );
   }
   if (selection.length > 0 && (baseRef || headRef)) {
     throw new Error("Use either --plugins or --base-ref/--head-ref, not both.");
@@ -678,6 +757,22 @@ export function collectPluginReleasePlan(params?: {
   selectionMode?: PluginReleaseSelectionMode;
   gitRange?: GitRangeSelection;
 }): PluginReleasePlan {
+  if (params?.selectionMode === "extended-stable") {
+    const selectedPublishable = collectExtendedStablePublishablePluginPackages(params.rootDir);
+    assertPluginReleaseVersionFloors(selectedPublishable, "Plugin NPM release plan");
+    assertPluginReleaseDependencyFreshness(selectedPublishable, "Plugin NPM release plan");
+    const all = selectedPublishable.map((plugin) =>
+      Object.assign({}, plugin, {
+        alreadyPublished: isPluginVersionPublished(plugin.packageName, plugin.version),
+      }),
+    );
+    return {
+      all,
+      candidates: all.filter((plugin) => !plugin.alreadyPublished),
+      skippedPublished: all.filter((plugin) => plugin.alreadyPublished),
+    };
+  }
+
   const changedExtensionIds = params?.gitRange
     ? collectChangedExtensionIdsFromGitRange({
         rootDir: params.rootDir,

--- a/scripts/openclaw-npm-extended-stable-release.mjs
+++ b/scripts/openclaw-npm-extended-stable-release.mjs
@@ -306,8 +306,8 @@ function assertClosedObject(value, expectedKeys, label) {
   if (value === null || typeof value !== "object" || Array.isArray(value)) {
     throw new Error(`${label} must be a JSON object.`);
   }
-  const actualKeys = Object.keys(value).toSorted();
-  const sortedExpectedKeys = [...expectedKeys].toSorted();
+  const actualKeys = Object.keys(value).toSorted((left, right) => left.localeCompare(right));
+  const sortedExpectedKeys = [...expectedKeys].toSorted((left, right) => left.localeCompare(right));
   if (JSON.stringify(actualKeys) !== JSON.stringify(sortedExpectedKeys)) {
     throw new Error(`${label} has an unexpected field set.`);
   }

--- a/scripts/openclaw-npm-extended-stable-release.mjs
+++ b/scripts/openclaw-npm-extended-stable-release.mjs
@@ -69,6 +69,21 @@ export function validateNpmPublishBoundary(
   return parsed;
 }
 
+export function extendedStableCandidateTag(packageVersion) {
+  const parsed = parseReleaseVersion(packageVersion.replace(/^v/u, ""));
+  if (parsed === null || parsed.channel !== "stable" || parsed.correctionNumber !== undefined) {
+    throw new Error("Extended-stable candidate tags require an exact final YYYY.M.P version.");
+  }
+  return `extended-stable-candidate-${parsed.year}-${parsed.month}-${parsed.patch}`;
+}
+
+export function resolveNpmPublishTag(packageVersion, requestedTag, options = {}) {
+  validateNpmPublishBoundary(packageVersion, requestedTag, options);
+  return requestedTag === "extended-stable"
+    ? extendedStableCandidateTag(packageVersion)
+    : requestedTag;
+}
+
 export function validateExtendedStableNpmReleaseRequest(request) {
   const bypassExtendedStableGuard = request.bypassExtendedStableGuard ?? false;
   requireExtendedStableBypassTag(request.npmDistTag, bypassExtendedStableGuard);
@@ -209,70 +224,145 @@ export function validateFullReleaseValidationManifest({
   return manifest;
 }
 
-export function parsePriorExtendedStableSelector(stdout) {
-  let tags;
-  try {
-    tags = JSON.parse(stdout);
-  } catch (error) {
-    const message = error instanceof Error ? error.message : String(error);
-    throw new Error(`npm dist-tags query returned invalid JSON: ${message}`, {
-      cause: error,
-    });
-  }
-  if (tags === null || typeof tags !== "object" || Array.isArray(tags)) {
-    throw new Error("npm dist-tags query did not return a JSON object.");
-  }
-  if (!Object.hasOwn(tags, "extended-stable")) {
-    return "absent";
-  }
-  if (typeof tags["extended-stable"] !== "string" || tags["extended-stable"].trim() === "") {
-    throw new Error("npm extended-stable dist-tag was not a non-empty version string.");
-  }
-  return tags["extended-stable"];
-}
-
-export function capturePriorExtendedStableSelector({ query }) {
-  const result = query();
-  if (result.status !== 0) {
-    throw new Error(`npm dist-tags query failed with exit code ${result.status ?? "unknown"}.`);
-  }
-  return parsePriorExtendedStableSelector(result.stdout);
-}
-
-export async function verifyExtendedStableRegistryReadback({
+export async function verifyExtendedStableCandidateReadback({
   expectedVersion,
+  packageName = "openclaw",
   query,
   sleep,
   attempts = 12,
   delayMs = 10_000,
 }) {
+  const candidateTag = extendedStableCandidateTag(expectedVersion);
   let exactVersion = "missing";
-  let extendedStableSelector = "missing";
+  let candidateVersion = "missing";
+  let integrity = "missing";
   for (let attempt = 1; attempt <= attempts; attempt += 1) {
-    const exactResult = await query(`openclaw@${expectedVersion}`);
-    const extendedStableResult = await query("openclaw@extended-stable");
+    const [exactResult, candidateResult, integrityResult] = await Promise.all([
+      query(`${packageName}@${expectedVersion}`, "version"),
+      query(`${packageName}@${candidateTag}`, "version"),
+      query(`${packageName}@${expectedVersion}`, "dist.integrity"),
+    ]);
     exactVersion = exactResult.status === 0 ? exactResult.stdout.trim() : "missing";
-    extendedStableSelector =
-      extendedStableResult.status === 0 ? extendedStableResult.stdout.trim() : "missing";
-    if (exactVersion === expectedVersion && extendedStableSelector === expectedVersion) {
-      return { exactVersion, extendedStableSelector, attemptsUsed: attempt };
+    candidateVersion = candidateResult.status === 0 ? candidateResult.stdout.trim() : "missing";
+    integrity = integrityResult.status === 0 ? integrityResult.stdout.trim() : "missing";
+    if (
+      exactVersion === expectedVersion &&
+      candidateVersion === expectedVersion &&
+      integrity.startsWith("sha512-")
+    ) {
+      return { exactVersion, candidateVersion, candidateTag, integrity, attemptsUsed: attempt };
     }
     if (attempt < attempts) {
       await sleep(delayMs);
     }
   }
   throw new Error(
-    `npm registry did not converge to openclaw@${expectedVersion} and openclaw@extended-stable=${expectedVersion} after ${attempts} attempts (exact=${exactVersion}, extended-stable=${extendedStableSelector}).`,
+    `npm registry did not converge to ${packageName}@${expectedVersion} under ${candidateTag} after ${attempts} attempts (exact=${exactVersion}, candidate=${candidateVersion}, integrity=${integrity}).`,
   );
 }
 
-export function extendedStableSelectorRepairCommand(expectedVersion) {
-  const normalizedVersion = (expectedVersion ?? "").replace(/^v/u, "");
-  const parsed = parseReleaseVersion(normalizedVersion);
-  if (parsed === null || parsed.channel !== "stable" || parsed.correctionNumber !== undefined) {
-    throw new Error("Extended-stable selector repair requires an exact final YYYY.M.P version.");
+export function buildExtendedStableCorePublicationResult(input) {
+  const candidateTag = extendedStableCandidateTag(input.version);
+  const result = {
+    schemaVersion: 1,
+    package: {
+      name: "openclaw",
+      version: input.version,
+      integrity: input.integrity,
+      candidateTag,
+    },
+    source: {
+      repository: input.repository,
+      sha: input.sourceSha,
+    },
+    workflow: {
+      repository: input.repository,
+      path: ".github/workflows/openclaw-npm-release.yml",
+      ref: input.workflowRef,
+      runId: input.runId,
+      runAttempt: input.runAttempt,
+    },
+    conclusion: "succeeded",
+  };
+  if (!/^[0-9a-f]{40}$/u.test(result.source.sha)) {
+    throw new Error("Core publication source SHA must be 40 lowercase hex characters.");
   }
-  return `npm dist-tag add openclaw@${parsed.version} extended-stable`;
+  if (!result.package.integrity.startsWith("sha512-")) {
+    throw new Error("Core publication integrity must be an npm sha512 integrity.");
+  }
+  if (!result.workflow.ref.startsWith("refs/heads/")) {
+    throw new Error("Core publication workflow ref must be a branch ref.");
+  }
+  if (!Number.isSafeInteger(result.workflow.runId) || result.workflow.runId <= 0) {
+    throw new Error("Core publication run id must be a positive integer.");
+  }
+  if (!Number.isSafeInteger(result.workflow.runAttempt) || result.workflow.runAttempt <= 0) {
+    throw new Error("Core publication run attempt must be a positive integer.");
+  }
+  return result;
+}
+
+function assertClosedObject(value, expectedKeys, label) {
+  if (value === null || typeof value !== "object" || Array.isArray(value)) {
+    throw new Error(`${label} must be a JSON object.`);
+  }
+  const actualKeys = Object.keys(value).toSorted();
+  const sortedExpectedKeys = [...expectedKeys].toSorted();
+  if (JSON.stringify(actualKeys) !== JSON.stringify(sortedExpectedKeys)) {
+    throw new Error(`${label} has an unexpected field set.`);
+  }
+}
+
+export function verifyExtendedStableCorePublicationResult(value, expected) {
+  assertClosedObject(
+    value,
+    ["schemaVersion", "package", "source", "workflow", "conclusion"],
+    "Core publication result",
+  );
+  assertClosedObject(
+    value.package,
+    ["name", "version", "integrity", "candidateTag"],
+    "Core publication result package",
+  );
+  assertClosedObject(value.source, ["repository", "sha"], "Core publication result source");
+  assertClosedObject(
+    value.workflow,
+    ["repository", "path", "ref", "runId", "runAttempt"],
+    "Core publication result workflow",
+  );
+  const normalizedVersion = (expected.version ?? "").replace(/^v/u, "");
+  const checks = [
+    ["schemaVersion", value.schemaVersion, 1],
+    ["package.name", value.package.name, "openclaw"],
+    ["package.version", value.package.version, normalizedVersion],
+    [
+      "package.candidateTag",
+      value.package.candidateTag,
+      extendedStableCandidateTag(normalizedVersion),
+    ],
+    ["source.repository", value.source.repository, expected.repository],
+    ["source.sha", value.source.sha, expected.sourceSha],
+    ["workflow.repository", value.workflow.repository, expected.repository],
+    ["workflow.path", value.workflow.path, ".github/workflows/openclaw-npm-release.yml"],
+    ["workflow.ref", value.workflow.ref, expected.workflowRef],
+    ["workflow.runId", value.workflow.runId, expected.runId],
+    ["workflow.runAttempt", value.workflow.runAttempt, expected.runAttempt],
+    ["conclusion", value.conclusion, "succeeded"],
+  ];
+  for (const [label, actual, wanted] of checks) {
+    if (actual !== wanted) {
+      throw new Error(
+        `Core publication result ${label} mismatch: expected ${String(wanted)}, got ${String(actual)}.`,
+      );
+    }
+  }
+  if (
+    typeof value.package.integrity !== "string" ||
+    !value.package.integrity.startsWith("sha512-")
+  ) {
+    throw new Error("Core publication result package.integrity must be an npm sha512 integrity.");
+  }
+  return value;
 }
 
 function git(args) {
@@ -405,11 +495,16 @@ async function main() {
     const bypassExtendedStableGuard = parseExtendedStableGuardBypass(
       process.env.BYPASS_EXTENDED_STABLE_GUARD ?? "",
     );
-    const parsed = validateNpmPublishBoundary(process.env.PACKAGE_VERSION ?? "", npmDistTag, {
+    const packageVersion = process.env.PACKAGE_VERSION ?? "";
+    const parsed = validateNpmPublishBoundary(packageVersion, npmDistTag, {
       bypassExtendedStableGuard,
     });
     console.log(parsed.channel);
-    console.log(npmDistTag);
+    console.log(
+      resolveNpmPublishTag(packageVersion, npmDistTag, {
+        bypassExtendedStableGuard,
+      }),
+    );
     return;
   }
   if (command === "verify-run") {
@@ -434,19 +529,12 @@ async function main() {
     });
     return;
   }
-  if (command === "capture-selector") {
-    const previous = capturePriorExtendedStableSelector({
-      query: () =>
-        spawnSync("npm", ["view", "openclaw", "dist-tags", "--json"], { encoding: "utf8" }),
-    });
-    appendOutput({ previous });
-    return;
-  }
-  if (command === "verify-readback") {
+  if (command === "verify-candidate-readback") {
     const expectedVersion = (process.env.EXPECTED_VERSION ?? "").replace(/^v/u, "");
-    const result = await verifyExtendedStableRegistryReadback({
+    const result = await verifyExtendedStableCandidateReadback({
       expectedVersion,
-      query: (target) => spawnSync("npm", ["view", target, "version"], { encoding: "utf8" }),
+      packageName: process.env.NPM_PACKAGE_NAME ?? "openclaw",
+      query: (target, field) => spawnSync("npm", ["view", target, field], { encoding: "utf8" }),
       sleep: (delayMs) =>
         new Promise((resolve) => {
           setTimeout(resolve, delayMs);
@@ -454,12 +542,40 @@ async function main() {
     });
     appendOutput({
       exact_version: result.exactVersion,
-      extended_stable_selector: result.extendedStableSelector,
+      candidate_version: result.candidateVersion,
+      candidate_tag: result.candidateTag,
+      integrity: result.integrity,
     });
     return;
   }
-  if (command === "repair-command") {
-    console.log(extendedStableSelectorRepairCommand(process.env.EXPECTED_VERSION));
+  if (command === "write-publication-result") {
+    const result = buildExtendedStableCorePublicationResult({
+      version: (process.env.EXPECTED_VERSION ?? "").replace(/^v/u, ""),
+      integrity: process.env.PACKAGE_INTEGRITY ?? "",
+      repository: process.env.GITHUB_REPOSITORY ?? "",
+      sourceSha: process.env.SOURCE_SHA ?? process.env.GITHUB_SHA ?? "",
+      workflowRef: process.env.GITHUB_REF ?? "",
+      runId: Number(process.env.GITHUB_RUN_ID),
+      runAttempt: Number(process.env.GITHUB_RUN_ATTEMPT),
+    });
+    process.stdout.write(`${JSON.stringify(result, null, 2)}\n`);
+    return;
+  }
+  if (command === "verify-publication-result") {
+    const resultPath = process.env.CORE_PUBLICATION_RESULT_FILE ?? "";
+    if (!resultPath) {
+      throw new Error("CORE_PUBLICATION_RESULT_FILE is required.");
+    }
+    const result = JSON.parse(readFileSync(resultPath, "utf8"));
+    verifyExtendedStableCorePublicationResult(result, {
+      version: process.env.EXPECTED_VERSION ?? "",
+      repository: process.env.EXPECTED_REPOSITORY ?? process.env.GITHUB_REPOSITORY ?? "",
+      sourceSha: process.env.EXPECTED_SOURCE_SHA ?? "",
+      workflowRef: process.env.EXPECTED_WORKFLOW_REF ?? "",
+      runId: Number(process.env.EXPECTED_RUN_ID),
+      runAttempt: Number(process.env.EXPECTED_RUN_ATTEMPT),
+    });
+    console.log(`Verified core publication result for openclaw@${result.package.version}.`);
     return;
   }
   throw new Error(`Unknown extended-stable npm release command: ${command ?? "<missing>"}.`);

--- a/scripts/orchestrate-extended-stable-plugin-release.ts
+++ b/scripts/orchestrate-extended-stable-plugin-release.ts
@@ -29,7 +29,6 @@ type Run = {
   path: string;
   html_url: string;
   created_at: string;
-  actor?: { login?: string };
 };
 
 type Artifact = {
@@ -117,8 +116,7 @@ async function dispatchWorkflow(
         createdAt >= dispatchStartedAt &&
         run.event === "workflow_dispatch" &&
         run.head_branch === ref &&
-        (expectedHeadSha === undefined || run.head_sha === expectedHeadSha) &&
-        (!process.env.GITHUB_ACTOR || run.actor?.login === process.env.GITHUB_ACTOR)
+        (expectedHeadSha === undefined || run.head_sha === expectedHeadSha)
       );
     });
     if (matches.length > 1) {

--- a/scripts/orchestrate-extended-stable-plugin-release.ts
+++ b/scripts/orchestrate-extended-stable-plugin-release.ts
@@ -82,8 +82,8 @@ function command(
   });
 }
 
-function ghJson<T>(args: string[]): T {
-  return JSON.parse(String(command("gh", args))) as T;
+function ghJson(args: string[]): unknown {
+  return JSON.parse(String(command("gh", args))) as unknown;
 }
 
 async function dispatchWorkflow(
@@ -97,7 +97,7 @@ async function dispatchWorkflow(
   command("gh", ["workflow", "run", "--repo", repository, workflow, "--ref", ref, ...inputs]);
   const deadline = Date.now() + 2 * 60 * 1000;
   while (Date.now() < deadline) {
-    const response = ghJson<{ workflow_runs: Run[] }>([
+    const response = ghJson([
       "api",
       "--method",
       "GET",
@@ -108,7 +108,7 @@ async function dispatchWorkflow(
       `branch=${ref}`,
       "-f",
       "per_page=100",
-    ]);
+    ]) as { workflow_runs: Run[] };
     const matches = response.workflow_runs.filter((run) => {
       const createdAt = Date.parse(run.created_at);
       return (
@@ -138,12 +138,13 @@ async function approvePendingDeployments(repository: string, runId: number): Pro
     environment: { id: number; name: string };
   }>;
   try {
-    deployments = ghJson<
-      Array<{
-        current_user_can_approve: boolean;
-        environment: { id: number; name: string };
-      }>
-    >(["api", `repos/${repository}/actions/runs/${runId}/pending_deployments`]);
+    deployments = ghJson([
+      "api",
+      `repos/${repository}/actions/runs/${runId}/pending_deployments`,
+    ]) as Array<{
+      current_user_can_approve: boolean;
+      environment: { id: number; name: string };
+    }>;
   } catch {
     // A child without an environment gate can reject this endpoint while it starts.
     return;
@@ -171,7 +172,7 @@ async function approvePendingDeployments(repository: string, runId: number): Pro
 async function waitForRun(repository: string, runId: number): Promise<Run> {
   const deadline = Date.now() + 2 * 60 * 60 * 1000;
   while (Date.now() < deadline) {
-    const run = ghJson<Run>(["api", `repos/${repository}/actions/runs/${runId}`]);
+    const run = ghJson(["api", `repos/${repository}/actions/runs/${runId}`]) as Run;
     if (run.status === "completed") {
       if (run.conclusion !== "success") {
         throw new Error(`Actions run ${run.html_url} completed with ${run.conclusion}.`);
@@ -185,10 +186,10 @@ async function waitForRun(repository: string, runId: number): Promise<Run> {
 }
 
 function artifactForRun(repository: string, runId: number, expectedName: string): Artifact {
-  const response = ghJson<{ artifacts: Artifact[] }>([
+  const response = ghJson([
     "api",
     `repos/${repository}/actions/runs/${runId}/artifacts?per_page=100`,
-  ]);
+  ]) as { artifacts: Artifact[] };
   const matches = response.artifacts.filter(
     (artifact) => artifact.name === expectedName && !artifact.expired,
   );

--- a/scripts/orchestrate-extended-stable-plugin-release.ts
+++ b/scripts/orchestrate-extended-stable-plugin-release.ts
@@ -1,0 +1,507 @@
+#!/usr/bin/env -S node --import tsx
+
+import { execFileSync } from "node:child_process";
+import { createHash } from "node:crypto";
+import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { dirname, join, resolve } from "node:path";
+import { setTimeout as sleep } from "node:timers/promises";
+import { pathToFileURL } from "node:url";
+import { loadExtendedStablePluginSupport } from "./lib/extended-stable-plugin-support.js";
+import { verifySelectorHandoff } from "./verify-extended-stable-selector-handoff.js";
+
+type Args = {
+  releaseTag: string;
+  sourceSha: string;
+  workflowRef: string;
+  preflightRunId: string;
+  validationRunId: string;
+  output: string;
+};
+
+type Run = {
+  id: number;
+  run_attempt: number;
+  status: string;
+  conclusion: string | null;
+  event: string;
+  head_sha: string;
+  head_branch: string;
+  path: string;
+  html_url: string;
+  created_at: string;
+  actor?: { login?: string };
+};
+
+type Artifact = {
+  id: number;
+  name: string;
+  expired: boolean;
+  digest: string;
+};
+
+function parseArgs(argv: string[]): Args {
+  const values = new Map<string, string>();
+  for (let index = 0; index < argv.length; index += 2) {
+    const key = argv[index];
+    const value = argv[index + 1];
+    if (!key?.startsWith("--") || value === undefined || values.has(key)) {
+      throw new Error("Orchestrator requires unique --key value arguments.");
+    }
+    values.set(key, value);
+  }
+  const names = [
+    "release-tag",
+    "source-sha",
+    "workflow-ref",
+    "preflight-run-id",
+    "validation-run-id",
+    "output",
+  ];
+  if (values.size !== names.length || names.some((name) => !values.has(`--${name}`))) {
+    throw new Error(`Orchestrator requires exactly: ${names.join(", ")}.`);
+  }
+  return Object.fromEntries(
+    names.map((name) => [
+      name.replace(/-([a-z])/gu, (_, letter: string) => letter.toUpperCase()),
+      values.get(`--${name}`)!,
+    ]),
+  ) as Args;
+}
+
+function command(
+  executable: string,
+  args: string[],
+  options: { encoding?: null | "utf8"; env?: NodeJS.ProcessEnv } = {},
+): Buffer | string {
+  const encoding = Object.hasOwn(options, "encoding") ? options.encoding : "utf8";
+  return execFileSync(executable, args, {
+    encoding,
+    env: { ...process.env, ...options.env },
+    maxBuffer: 64 * 1024 * 1024,
+    stdio: ["ignore", "pipe", "pipe"],
+    timeout: 10 * 60 * 1000,
+  });
+}
+
+function ghJson<T>(args: string[]): T {
+  return JSON.parse(String(command("gh", args))) as T;
+}
+
+async function dispatchWorkflow(
+  repository: string,
+  workflow: string,
+  ref: string,
+  inputs: string[],
+  expectedHeadSha?: string,
+): Promise<number> {
+  const dispatchStartedAt = Date.now() - 1_000;
+  command("gh", ["workflow", "run", "--repo", repository, workflow, "--ref", ref, ...inputs]);
+  const deadline = Date.now() + 2 * 60 * 1000;
+  while (Date.now() < deadline) {
+    const response = ghJson<{ workflow_runs: Run[] }>([
+      "api",
+      "--method",
+      "GET",
+      `repos/${repository}/actions/workflows/${workflow}/runs`,
+      "-f",
+      "event=workflow_dispatch",
+      "-f",
+      `branch=${ref}`,
+      "-f",
+      "per_page=100",
+    ]);
+    const matches = response.workflow_runs.filter((run) => {
+      const createdAt = Date.parse(run.created_at);
+      return (
+        Number.isFinite(createdAt) &&
+        createdAt >= dispatchStartedAt &&
+        run.event === "workflow_dispatch" &&
+        run.head_branch === ref &&
+        (expectedHeadSha === undefined || run.head_sha === expectedHeadSha) &&
+        (!process.env.GITHUB_ACTOR || run.actor?.login === process.env.GITHUB_ACTOR)
+      );
+    });
+    if (matches.length > 1) {
+      throw new Error(`${workflow} dispatch matched multiple new runs; refusing to guess.`);
+    }
+    if (matches.length === 1) {
+      const run = matches[0]!;
+      console.log(`Dispatched ${workflow}: ${run.html_url}`);
+      return run.id;
+    }
+    await sleep(2_000);
+  }
+  throw new Error(`${workflow} dispatch could not be correlated to exactly one new run.`);
+}
+
+async function approvePendingDeployments(repository: string, runId: number): Promise<void> {
+  let deployments: Array<{
+    current_user_can_approve: boolean;
+    environment: { id: number; name: string };
+  }>;
+  try {
+    deployments = ghJson<
+      Array<{
+        current_user_can_approve: boolean;
+        environment: { id: number; name: string };
+      }>
+    >(["api", `repos/${repository}/actions/runs/${runId}/pending_deployments`]);
+  } catch {
+    // A child without an environment gate can reject this endpoint while it starts.
+    return;
+  }
+  for (const deployment of deployments) {
+    if (!deployment.current_user_can_approve) {
+      continue;
+    }
+    command("gh", [
+      "api",
+      "-X",
+      "POST",
+      `repos/${repository}/actions/runs/${runId}/pending_deployments`,
+      "-F",
+      `environment_ids[]=${deployment.environment.id}`,
+      "-f",
+      "state=approved",
+      "-f",
+      "comment=Approve child release gate after parent release approval",
+    ]);
+    console.log(`Approved ${deployment.environment.name} for run ${runId}.`);
+  }
+}
+
+async function waitForRun(repository: string, runId: number): Promise<Run> {
+  const deadline = Date.now() + 2 * 60 * 60 * 1000;
+  while (Date.now() < deadline) {
+    const run = ghJson<Run>(["api", `repos/${repository}/actions/runs/${runId}`]);
+    if (run.status === "completed") {
+      if (run.conclusion !== "success") {
+        throw new Error(`Actions run ${run.html_url} completed with ${run.conclusion}.`);
+      }
+      return run;
+    }
+    await approvePendingDeployments(repository, runId);
+    await sleep(15_000);
+  }
+  throw new Error(`Actions run ${runId} did not complete within two hours.`);
+}
+
+function artifactForRun(repository: string, runId: number, expectedName: string): Artifact {
+  const response = ghJson<{ artifacts: Artifact[] }>([
+    "api",
+    `repos/${repository}/actions/runs/${runId}/artifacts?per_page=100`,
+  ]);
+  const matches = response.artifacts.filter(
+    (artifact) => artifact.name === expectedName && !artifact.expired,
+  );
+  if (matches.length !== 1 || !/^sha256:[0-9a-f]{64}$/u.test(matches[0]!.digest)) {
+    throw new Error(`Run ${runId} must have one unexpired ${expectedName} artifact with a digest.`);
+  }
+  return matches[0]!;
+}
+
+function downloadVerifiedArtifact(
+  repository: string,
+  artifact: Artifact,
+  expectedFilename: string,
+  outputDir: string,
+): string {
+  mkdirSync(outputDir, { recursive: true });
+  const archive = command(
+    "gh",
+    ["api", `repos/${repository}/actions/artifacts/${artifact.id}/zip`],
+    { encoding: null },
+  ) as Buffer;
+  const digest = `sha256:${createHash("sha256").update(archive).digest("hex")}`;
+  if (digest !== artifact.digest) {
+    throw new Error(`Artifact ${artifact.name} bytes do not match its Actions API digest.`);
+  }
+  const archivePath = join(outputDir, "artifact.zip");
+  writeFileSync(archivePath, archive);
+  const listing = String(command("unzip", ["-Z1", archivePath]))
+    .split(/\r?\n/u)
+    .filter(Boolean);
+  if (listing.length !== 1 || listing[0] !== expectedFilename) {
+    throw new Error(`Artifact ${artifact.name} must contain exactly ${expectedFilename}.`);
+  }
+  const resultPath = join(outputDir, expectedFilename);
+  writeFileSync(
+    resultPath,
+    command("unzip", ["-p", archivePath, expectedFilename], { encoding: null }),
+  );
+  return resultPath;
+}
+
+function selectorSnapshot(packageName: string): {
+  latest: string | null;
+  extendedStable: string | null;
+} {
+  const value: unknown = JSON.parse(
+    String(
+      command("npm", [
+        "view",
+        packageName,
+        "dist-tags",
+        "--json",
+        "--registry=https://registry.npmjs.org/",
+      ]),
+    ),
+  );
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    throw new Error(`${packageName} dist-tag readback is invalid.`);
+  }
+  const tags = value as Record<string, unknown>;
+  const read = (tag: "latest" | "extended-stable"): string | null => {
+    const selected = tags[tag];
+    if (selected === undefined) {
+      return null;
+    }
+    if (typeof selected !== "string" || selected.length === 0) {
+      throw new Error(`${packageName} ${tag} selector readback is invalid.`);
+    }
+    return selected;
+  };
+  return {
+    latest: read("latest"),
+    extendedStable: read("extended-stable"),
+  };
+}
+
+function assertRunIdentity(run: Run, params: { path: string; sha?: string; event?: string }): void {
+  if (
+    !run.path.startsWith(params.path) ||
+    (params.sha !== undefined && run.head_sha !== params.sha) ||
+    (params.event !== undefined && run.event !== params.event)
+  ) {
+    throw new Error(`Actions run ${run.id} identity does not match ${params.path}.`);
+  }
+}
+
+function verifyJsonScript(script: string, args: string[], env?: NodeJS.ProcessEnv): unknown {
+  return JSON.parse(
+    String(command(process.execPath, ["--import", "tsx", script, ...args], { env })),
+  );
+}
+
+export async function orchestrate(args: Args, rootDir = resolve(".")): Promise<void> {
+  const repository = process.env.GITHUB_REPOSITORY;
+  const parentRunId = process.env.GITHUB_RUN_ID;
+  if (!repository || !parentRunId) {
+    throw new Error("GITHUB_REPOSITORY and GITHUB_RUN_ID are required.");
+  }
+  const releaseVersion = args.releaseTag.replace(/^v/u, "");
+  const support = loadExtendedStablePluginSupport(rootDir);
+  const packageNames = ["openclaw", ...support.plugins.map((plugin) => plugin.packageName)];
+  const selectorsBefore = Object.fromEntries(
+    packageNames.map((packageName) => [packageName, selectorSnapshot(packageName)]),
+  );
+
+  const pluginRunId = await dispatchWorkflow(
+    repository,
+    "plugin-npm-release.yml",
+    args.workflowRef,
+    [
+      "-f",
+      "publish_scope=extended-stable",
+      "-f",
+      `ref=${args.sourceSha}`,
+      "-f",
+      `release_publish_run_id=${parentRunId}`,
+    ],
+    args.sourceSha,
+  );
+  const pluginRun = await waitForRun(repository, pluginRunId);
+  assertRunIdentity(pluginRun, {
+    path: ".github/workflows/plugin-npm-release.yml",
+    sha: args.sourceSha,
+    event: "workflow_dispatch",
+  });
+  const pluginArtifact = artifactForRun(
+    repository,
+    pluginRunId,
+    `extended-stable-plugin-publication-${pluginRunId}-${pluginRun.run_attempt}`,
+  );
+  const pluginResultPath = downloadVerifiedArtifact(
+    repository,
+    pluginArtifact,
+    "extended-stable-plugin-publication.json",
+    join(dirname(args.output), "plugin-publication"),
+  );
+  const pluginProof = verifyJsonScript(
+    join(rootDir, "scripts/verify-extended-stable-plugin-publication.ts"),
+    [
+      "--result",
+      pluginResultPath,
+      "--root",
+      rootDir,
+      "--release-version",
+      releaseVersion,
+      "--source-sha",
+      args.sourceSha,
+      "--repository",
+      repository,
+      "--workflow-ref",
+      `refs/heads/${args.workflowRef}`,
+      "--run-id",
+      String(pluginRunId),
+      "--run-attempt",
+      String(pluginRun.run_attempt),
+      "--artifact-digest",
+      pluginArtifact.digest,
+    ],
+  ) as { plugins: Array<{ packageName: string; npmIntegrity: string; candidateTag: string }> };
+
+  const coreRunId = await dispatchWorkflow(
+    repository,
+    "openclaw-npm-release.yml",
+    args.workflowRef,
+    [
+      "-f",
+      `tag=${args.releaseTag}`,
+      "-f",
+      "preflight_only=false",
+      "-f",
+      `preflight_run_id=${args.preflightRunId}`,
+      "-f",
+      `full_release_validation_run_id=${args.validationRunId}`,
+      "-f",
+      `release_publish_run_id=${parentRunId}`,
+      "-f",
+      "npm_dist_tag=extended-stable",
+    ],
+    args.sourceSha,
+  );
+  const coreRun = await waitForRun(repository, coreRunId);
+  assertRunIdentity(coreRun, {
+    path: ".github/workflows/openclaw-npm-release.yml",
+    sha: args.sourceSha,
+    event: "workflow_dispatch",
+  });
+  const coreArtifact = artifactForRun(
+    repository,
+    coreRunId,
+    `extended-stable-core-publication-${coreRunId}-${coreRun.run_attempt}`,
+  );
+  const coreResultPath = downloadVerifiedArtifact(
+    repository,
+    coreArtifact,
+    "extended-stable-core-publication.json",
+    join(dirname(args.output), "core-publication"),
+  );
+  command(
+    process.execPath,
+    [
+      join(rootDir, "scripts/openclaw-npm-extended-stable-release.mjs"),
+      "verify-publication-result",
+    ],
+    {
+      env: {
+        CORE_PUBLICATION_RESULT_FILE: coreResultPath,
+        EXPECTED_VERSION: releaseVersion,
+        EXPECTED_SOURCE_SHA: args.sourceSha,
+        EXPECTED_WORKFLOW_REF: `refs/heads/${args.workflowRef}`,
+        EXPECTED_RUN_ID: String(coreRunId),
+        EXPECTED_RUN_ATTEMPT: String(coreRun.run_attempt),
+        EXPECTED_REPOSITORY: repository,
+      },
+    },
+  );
+  const coreResult = JSON.parse(readFileSync(coreResultPath, "utf8")) as {
+    package: { candidateTag: string; integrity: string; version: string };
+  };
+
+  const acceptanceProofs = [];
+  for (const plugin of support.plugins) {
+    const acceptanceRunId = await dispatchWorkflow(
+      repository,
+      "extended-stable-plugin-acceptance.yml",
+      "main",
+      [
+        "-f",
+        `release_version=${releaseVersion}`,
+        "-f",
+        `plugin_package_name=${plugin.packageName}`,
+      ],
+    );
+    const acceptanceRun = await waitForRun(repository, acceptanceRunId);
+    assertRunIdentity(acceptanceRun, {
+      path: ".github/workflows/extended-stable-plugin-acceptance.yml",
+      event: "workflow_dispatch",
+    });
+    const artifact = artifactForRun(
+      repository,
+      acceptanceRunId,
+      `extended-stable-plugin-acceptance-${acceptanceRunId}-${acceptanceRun.run_attempt}`,
+    );
+    const resultPath = downloadVerifiedArtifact(
+      repository,
+      artifact,
+      "extended-stable-plugin-acceptance.json",
+      join(dirname(args.output), `acceptance-${plugin.pluginId}`),
+    );
+    acceptanceProofs.push(
+      verifyJsonScript(join(rootDir, "scripts/verify-extended-stable-plugin-acceptance.ts"), [
+        "--result",
+        resultPath,
+        "--root",
+        rootDir,
+        "--release-version",
+        releaseVersion,
+        "--plugin-package-name",
+        plugin.packageName,
+        "--repository",
+        repository,
+        "--workflow-sha",
+        acceptanceRun.head_sha,
+        "--run-id",
+        String(acceptanceRunId),
+        "--run-attempt",
+        String(acceptanceRun.run_attempt),
+        "--artifact-digest",
+        artifact.digest,
+      ]),
+    );
+  }
+
+  const selectorsAfter = Object.fromEntries(
+    packageNames.map((packageName) => [packageName, selectorSnapshot(packageName)]),
+  );
+  if (JSON.stringify(selectorsAfter) !== JSON.stringify(selectorsBefore)) {
+    throw new Error("Candidate publication moved one or more shared selectors; refusing handoff.");
+  }
+
+  const handoff = {
+    schemaVersion: 1,
+    handoffId: `${repository}:${parentRunId}:${releaseVersion}`,
+    releaseVersion,
+    sourceSha: args.sourceSha,
+    core: {
+      publicationRunId: String(coreRunId),
+      publicationRunAttempt: String(coreRun.run_attempt),
+      publicationArtifactDigest: coreArtifact.digest,
+      version: coreResult.package.version,
+      npmIntegrity: coreResult.package.integrity,
+      candidateTag: coreResult.package.candidateTag,
+    },
+    pluginPublication: pluginProof,
+    acceptances: acceptanceProofs,
+    selectorsBefore,
+    selectorsAfter,
+    selectorOrder: ["plugins", "core"],
+    conclusion: "ready_for_protected_selector_promotion",
+  };
+  verifySelectorHandoff(handoff, rootDir);
+  mkdirSync(dirname(args.output), { recursive: true });
+  writeFileSync(args.output, `${JSON.stringify(handoff, null, 2)}\n`);
+}
+
+function isMain(): boolean {
+  return (
+    process.argv[1] !== undefined &&
+    import.meta.url === pathToFileURL(resolve(process.argv[1])).href
+  );
+}
+
+if (isMain()) {
+  await orchestrate(parseArgs(process.argv.slice(2)));
+}

--- a/scripts/plugin-npm-publication-result.ts
+++ b/scripts/plugin-npm-publication-result.ts
@@ -1,0 +1,216 @@
+#!/usr/bin/env -S node --import tsx
+// Plugin Npm Publication Result script closes extended-stable matrix evidence.
+
+import { readdirSync, readFileSync, writeFileSync } from "node:fs";
+import { join, resolve } from "node:path";
+import { pathToFileURL } from "node:url";
+import { loadExtendedStablePluginSupport } from "./lib/extended-stable-plugin-support.js";
+import { deriveExtendedStablePluginCandidateTag } from "./lib/plugin-npm-release.ts";
+
+type PublicationIdentity = {
+  repository: string;
+  workflowPath: string;
+  workflowRef: string;
+  workflowSha: string;
+  runId: string;
+  runAttempt: string;
+};
+
+export type ExtendedStablePluginPublicationRecord = PublicationIdentity & {
+  packageName: string;
+  version: string;
+  npmIntegrity: string;
+  candidateTag: string;
+  provenanceVerified: true;
+  sourceSha: string;
+};
+
+export type ExtendedStablePluginPublicationResult = {
+  schemaVersion: 1;
+  sourceSha: string;
+  workflow: PublicationIdentity;
+  plugins: Array<{
+    packageName: string;
+    version: string;
+    npmIntegrity: string;
+    candidateTag: string;
+    provenanceVerified: true;
+  }>;
+};
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function parseClosedRecord(value: unknown, label: string): ExtendedStablePluginPublicationRecord {
+  if (!isRecord(value)) {
+    throw new Error(`${label} must be a JSON object.`);
+  }
+  const expectedKeys = [
+    "candidateTag",
+    "npmIntegrity",
+    "packageName",
+    "provenanceVerified",
+    "repository",
+    "runAttempt",
+    "runId",
+    "sourceSha",
+    "version",
+    "workflowPath",
+    "workflowRef",
+    "workflowSha",
+  ];
+  if (JSON.stringify(Object.keys(value).toSorted()) !== JSON.stringify(expectedKeys)) {
+    throw new Error(`${label} has an unexpected field set.`);
+  }
+  for (const field of expectedKeys.filter((candidate) => candidate !== "provenanceVerified")) {
+    if (typeof value[field] !== "string" || !value[field].trim()) {
+      throw new Error(`${label}.${field} must be a non-empty string.`);
+    }
+  }
+  if (value.provenanceVerified !== true) {
+    throw new Error(`${label}.provenanceVerified must be true.`);
+  }
+  return value as ExtendedStablePluginPublicationRecord;
+}
+
+export function buildExtendedStablePluginPublicationResult(params: {
+  rootDir?: string;
+  records: unknown[];
+  sourceSha: string;
+  identity: PublicationIdentity;
+}): ExtendedStablePluginPublicationResult {
+  const rootDir = params.rootDir ?? resolve(".");
+  if (!/^[0-9a-f]{40}$/u.test(params.sourceSha)) {
+    throw new Error("sourceSha must be a full lowercase commit SHA.");
+  }
+  if (params.identity.repository !== "openclaw/openclaw") {
+    throw new Error("Publication repository must be openclaw/openclaw.");
+  }
+  if (params.identity.workflowPath !== ".github/workflows/plugin-npm-release.yml") {
+    throw new Error("Publication workflowPath must identify plugin-npm-release.yml.");
+  }
+  if (!/^[0-9a-f]{40}$/u.test(params.identity.workflowSha)) {
+    throw new Error("workflowSha must be a full lowercase commit SHA.");
+  }
+  if (params.identity.workflowSha !== params.sourceSha) {
+    throw new Error("workflowSha must equal the protected source SHA.");
+  }
+  if (!/^\d+$/u.test(params.identity.runId) || !/^\d+$/u.test(params.identity.runAttempt)) {
+    throw new Error("Publication runId and runAttempt must be decimal strings.");
+  }
+  const rootPackage = JSON.parse(readFileSync(join(rootDir, "package.json"), "utf8")) as {
+    version?: unknown;
+  };
+  if (typeof rootPackage.version !== "string" || !rootPackage.version.trim()) {
+    throw new Error("Root package.json version must be a non-empty string.");
+  }
+  const version = rootPackage.version.trim();
+  const manifest = loadExtendedStablePluginSupport(rootDir);
+  const records = params.records
+    .map((record, index) => parseClosedRecord(record, `publication record ${index}`))
+    .toSorted((left, right) => left.packageName.localeCompare(right.packageName));
+
+  const expectedNames = manifest.plugins.map((entry) => entry.packageName);
+  if (
+    JSON.stringify(records.map((record) => record.packageName)) !== JSON.stringify(expectedNames)
+  ) {
+    throw new Error(`Publication records must contain exactly: ${expectedNames.join(", ")}.`);
+  }
+  const manifestByName = new Map(manifest.plugins.map((entry) => [entry.packageName, entry]));
+  for (const record of records) {
+    const entry = manifestByName.get(record.packageName);
+    if (!entry) {
+      throw new Error(`Unexpected publication package: ${record.packageName}.`);
+    }
+    if (record.version !== version) {
+      throw new Error(
+        `${record.packageName} publication version must equal root version ${version}; found ${record.version}.`,
+      );
+    }
+    const expectedCandidateTag = deriveExtendedStablePluginCandidateTag({
+      pluginId: entry.pluginId,
+      version,
+    });
+    if (record.candidateTag !== expectedCandidateTag) {
+      throw new Error(
+        `${record.packageName} candidate tag must be ${expectedCandidateTag}; found ${record.candidateTag}.`,
+      );
+    }
+    if (!record.npmIntegrity.startsWith("sha512-")) {
+      throw new Error(`${record.packageName} npm integrity must be a sha512 digest.`);
+    }
+    for (const key of [
+      "repository",
+      "workflowPath",
+      "workflowRef",
+      "workflowSha",
+      "runId",
+      "runAttempt",
+    ] as const) {
+      if (record[key] !== params.identity[key]) {
+        throw new Error(`${record.packageName} ${key} does not match the publication run.`);
+      }
+    }
+    if (record.sourceSha !== params.sourceSha) {
+      throw new Error(`${record.packageName} sourceSha does not match the protected source SHA.`);
+    }
+  }
+
+  return {
+    schemaVersion: 1,
+    sourceSha: params.sourceSha,
+    workflow: params.identity,
+    plugins: records.map((record) => ({
+      packageName: record.packageName,
+      version: record.version,
+      npmIntegrity: record.npmIntegrity,
+      candidateTag: record.candidateTag,
+      provenanceVerified: true,
+    })),
+  };
+}
+
+function requiredArg(argv: string[], flag: string): string {
+  const index = argv.indexOf(flag);
+  const value = index >= 0 ? argv[index + 1]?.trim() : "";
+  if (!value || value.startsWith("--")) {
+    throw new Error(`${flag} is required.`);
+  }
+  return value;
+}
+
+function main(argv: string[]): void {
+  const resultsDir = requiredArg(argv, "--results-dir");
+  const output = requiredArg(argv, "--output");
+  const sourceSha = requiredArg(argv, "--source-sha");
+  const identity: PublicationIdentity = {
+    repository: requiredArg(argv, "--repository"),
+    workflowPath: requiredArg(argv, "--workflow-path"),
+    workflowRef: requiredArg(argv, "--workflow-ref"),
+    workflowSha: requiredArg(argv, "--workflow-sha"),
+    runId: requiredArg(argv, "--run-id"),
+    runAttempt: requiredArg(argv, "--run-attempt"),
+  };
+  const records = readdirSync(resultsDir)
+    .filter((name) => name.endsWith(".json"))
+    .toSorted()
+    .map((name) => JSON.parse(readFileSync(join(resultsDir, name), "utf8")) as unknown);
+  const result = buildExtendedStablePluginPublicationResult({
+    records,
+    sourceSha,
+    identity,
+  });
+  writeFileSync(output, `${JSON.stringify(result, null, 2)}\n`);
+}
+
+if (import.meta.url === pathToFileURL(process.argv[1] ?? "").href) {
+  try {
+    main(process.argv.slice(2));
+  } catch (error) {
+    console.error(
+      `plugin-npm-publication-result: ${error instanceof Error ? error.message : String(error)}`,
+    );
+    process.exitCode = 1;
+  }
+}

--- a/scripts/plugin-npm-publish.sh
+++ b/scripts/plugin-npm-publish.sh
@@ -3,7 +3,7 @@
 set -euo pipefail
 
 usage() {
-  echo "usage: bash scripts/plugin-npm-publish.sh [--dry-run|--pack-dry-run|--publish] <package-dir>"
+  echo "usage: bash scripts/plugin-npm-publish.sh [--dry-run|--pack-dry-run|--publish] [--candidate-tag <tag>] <package-dir>"
 }
 
 if [[ "${1:-}" == "--help" || "${1:-}" == "-h" ]]; then
@@ -18,8 +18,27 @@ if [[ "${mode}" != "--dry-run" && "${mode}" != "--pack-dry-run" && "${mode}" != 
 fi
 shift
 
-if [[ "${1:-}" == "--" ]]; then
-  shift
+candidate_tag=""
+while [[ "$#" -gt 0 ]]; do
+  case "$1" in
+    --candidate-tag)
+      candidate_tag="${2:-}"
+      if [[ -z "${candidate_tag}" || "${candidate_tag}" == -* ]]; then
+        echo "--candidate-tag requires a value" >&2
+        exit 2
+      fi
+      shift 2
+      ;;
+    --)
+      shift
+      break
+      ;;
+    *) break ;;
+  esac
+done
+if [[ -n "${candidate_tag}" && ! "${candidate_tag}" =~ ^extended-stable-plugin-candidate-[a-z0-9-]+-[0-9]{4}-[0-9]+-[0-9]+$ ]]; then
+  echo "invalid extended-stable plugin candidate tag: ${candidate_tag}" >&2
+  exit 2
 fi
 package_dir=""
 if [[ "$#" -gt 0 ]]; then
@@ -39,7 +58,18 @@ fi
 
 package_name="$(node -e 'const pkg = require(require("node:path").resolve(process.argv[1], "package.json")); console.log(pkg.name)' "${package_dir}")"
 package_version="$(node -e 'const pkg = require(require("node:path").resolve(process.argv[1], "package.json")); console.log(pkg.version)' "${package_dir}")"
-current_beta_version="$(npm view "${package_name}" dist-tags.beta 2>/dev/null || true)"
+if [[ -n "${candidate_tag}" ]]; then
+  plugin_id="$(basename "${package_dir}")"
+  expected_candidate_tag="extended-stable-plugin-candidate-${plugin_id}-${package_version//./-}"
+  if [[ "${candidate_tag}" != "${expected_candidate_tag}" ]]; then
+    echo "candidate tag mismatch: expected ${expected_candidate_tag}, found ${candidate_tag}" >&2
+    exit 1
+  fi
+fi
+current_beta_version=""
+if [[ -z "${candidate_tag}" ]]; then
+  current_beta_version="$(npm view "${package_name}" dist-tags.beta 2>/dev/null || true)"
+fi
 log() {
   if [[ "${mode}" == "--pack-dry-run" ]]; then
     printf '%s\n' "$*" >&2
@@ -48,17 +78,20 @@ log() {
   fi
 }
 publish_plan_output="$(
-  PACKAGE_VERSION="${package_version}" CURRENT_BETA_VERSION="${current_beta_version}" PUBLISH_MODE="${mode}" node --input-type=module <<'EOF'
+  PACKAGE_VERSION="${package_version}" CURRENT_BETA_VERSION="${current_beta_version}" PUBLISH_MODE="${mode}" CANDIDATE_TAG="${candidate_tag}" node --input-type=module <<'EOF'
 import {
   resolveNpmDistTagMirrorAuth,
   resolveNpmPublishPlan,
   shouldRequireNpmDistTagMirrorAuth,
 } from "./scripts/lib/npm-publish-plan.mjs";
 
-const plan = resolveNpmPublishPlan(
-  process.env.PACKAGE_VERSION ?? "",
-  process.env.CURRENT_BETA_VERSION,
-);
+const candidateTag = process.env.CANDIDATE_TAG ?? "";
+const plan = candidateTag
+  ? { channel: "extended-stable", publishTag: candidateTag, mirrorDistTags: [] }
+  : resolveNpmPublishPlan(
+      process.env.PACKAGE_VERSION ?? "",
+      process.env.CURRENT_BETA_VERSION,
+    );
 const auth = resolveNpmDistTagMirrorAuth({
   nodeAuthToken: process.env.NODE_AUTH_TOKEN,
   npmToken: process.env.NPM_TOKEN,
@@ -125,6 +158,20 @@ publish_auth_source="${mirror_auth_source}"
 if [[ "${OPENCLAW_NPM_PUBLISH_AUTH_MODE:-}" == "trusted-publisher" ]]; then
   publish_auth_token=""
   publish_auth_source="trusted-publisher"
+fi
+if [[ -n "${candidate_tag}" && "${mode}" == "--publish" ]]; then
+  if [[ "${OPENCLAW_NPM_PUBLISH_AUTH_MODE:-}" != "trusted-publisher" ]]; then
+    echo "extended-stable candidate publication requires GitHub OIDC trusted publishing." >&2
+    exit 1
+  fi
+  if [[ -n "${NODE_AUTH_TOKEN:-}" || -n "${NPM_TOKEN:-}" ]]; then
+    echo "extended-stable candidate publication must not receive an npm token." >&2
+    exit 1
+  fi
+  if [[ "${OPENCLAW_NPM_PUBLISH_PROVENANCE:-1}" == "0" || "${OPENCLAW_NPM_PUBLISH_PROVENANCE:-1}" == "false" ]]; then
+    echo "extended-stable candidate publication requires npm provenance." >&2
+    exit 1
+  fi
 fi
 publish_provenance="without provenance"
 if [[ " ${publish_cmd[*]} " == *" --provenance "* ]]; then

--- a/scripts/plugin-npm-release-check.ts
+++ b/scripts/plugin-npm-release-check.ts
@@ -6,6 +6,7 @@ import {
   assertPluginReleaseDependencyFreshness,
   assertPluginReleaseVersionFloors,
   collectChangedExtensionIdsFromGitRange,
+  collectExtendedStablePublishablePluginPackages,
   collectPublishablePluginPackages,
   parsePluginReleaseArgs,
   resolveChangedPublishablePluginPackages,
@@ -14,6 +15,17 @@ import {
 
 export function runPluginNpmReleaseCheck(argv: string[]) {
   const { selection, selectionMode, baseRef, headRef } = parsePluginReleaseArgs(argv);
+  if (selectionMode === "extended-stable") {
+    const selected = collectExtendedStablePublishablePluginPackages(".");
+    assertPluginReleaseVersionFloors(selected, "plugin-npm-release-check");
+    console.log("plugin-npm-release-check: extended-stable plugin metadata looks OK.");
+    for (const plugin of selected) {
+      console.log(
+        `  - ${plugin.packageName}@${plugin.version} (${plugin.candidateTag}, ${plugin.extensionId})`,
+      );
+    }
+    return;
+  }
   const changedExtensionIds =
     baseRef && headRef
       ? collectChangedExtensionIdsFromGitRange({

--- a/scripts/run-extended-stable-plugin-acceptance.ts
+++ b/scripts/run-extended-stable-plugin-acceptance.ts
@@ -151,7 +151,7 @@ function parsePluginList(output: string, pluginId: string, packageName: string):
   const errors = (list.diagnostics ?? []).filter(
     (entry) =>
       entry.level === "error" &&
-      (entry.pluginId === pluginId || String(entry.message ?? "").includes(pluginId)),
+      (entry.pluginId === pluginId || (entry.message ?? "").includes(pluginId)),
   );
   if (errors.length > 0) {
     throw new Error(`Plugin discovery reported errors: ${JSON.stringify(errors)}.`);

--- a/scripts/run-extended-stable-plugin-acceptance.ts
+++ b/scripts/run-extended-stable-plugin-acceptance.ts
@@ -1,0 +1,323 @@
+#!/usr/bin/env -S node --import tsx
+
+import { execFileSync } from "node:child_process";
+import { mkdirSync, mkdtempSync, readFileSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { pathToFileURL } from "node:url";
+import {
+  acceptanceScenarioIds,
+  assertExtendedStableReleaseVersion,
+  parseExtendedStablePluginAcceptanceResult,
+  resolveCoveredPlugin,
+  type AcceptanceScenarioStatus,
+} from "./lib/extended-stable-plugin-acceptance.js";
+
+const PROFILE_TESTS: Record<string, string[]> = {
+  "slack-channel-v1": [
+    "extensions/slack/src/config-schema.test.ts",
+    "extensions/slack/src/inbound-context.contract.test.ts",
+    "extensions/slack/src/outbound-payload.test.ts",
+    "extensions/slack/src/doctor.test.ts",
+  ],
+  "discord-channel-v1": [
+    "extensions/discord/src/config-schema.test.ts",
+    "extensions/discord/src/inbound-context.contract.test.ts",
+    "extensions/discord/src/outbound-payload.contract.test.ts",
+    "extensions/discord/src/doctor.test.ts",
+  ],
+  "codex-provider-v1": [
+    "extensions/codex/src/manifest.test.ts",
+    "extensions/codex/provider.test.ts",
+    "extensions/codex/src/app-server/plugin-inventory.test.ts",
+    "extensions/codex/doctor-contract-api.test.ts",
+  ],
+};
+
+type Args = {
+  releaseVersion: string;
+  pluginPackageName: string;
+  output: string;
+};
+
+function parseArgs(argv: string[]): Args {
+  const values = new Map<string, string>();
+  for (let index = 0; index < argv.length; index += 2) {
+    const key = argv[index];
+    const value = argv[index + 1];
+    if (!key?.startsWith("--") || value === undefined) {
+      throw new Error(
+        "Usage: run-extended-stable-plugin-acceptance.ts --release-version <version> --plugin-package-name <package> --output <path>",
+      );
+    }
+    if (values.has(key)) {
+      throw new Error(`Duplicate argument: ${key}.`);
+    }
+    values.set(key, value);
+  }
+  const allowed = new Set(["--release-version", "--plugin-package-name", "--output"]);
+  for (const key of values.keys()) {
+    if (!allowed.has(key)) {
+      throw new Error(`Unknown argument: ${key}.`);
+    }
+  }
+  const releaseVersion = values.get("--release-version");
+  const pluginPackageName = values.get("--plugin-package-name");
+  const output = values.get("--output");
+  if (!releaseVersion || !pluginPackageName || !output) {
+    throw new Error("release version, plugin package name, and output are required.");
+  }
+  return { releaseVersion, pluginPackageName, output };
+}
+
+function commandEnv(overrides: NodeJS.ProcessEnv = {}): NodeJS.ProcessEnv {
+  const env: NodeJS.ProcessEnv = {
+    ...process.env,
+    npm_config_registry: "https://registry.npmjs.org/",
+    ...overrides,
+  };
+  for (const name of [
+    "SLACK_APP_TOKEN",
+    "SLACK_BOT_TOKEN",
+    "SLACK_USER_TOKEN",
+    "DISCORD_BOT_TOKEN",
+    "OPENAI_API_KEY",
+    "CODEX_API_KEY",
+  ]) {
+    delete env[name];
+  }
+  return env;
+}
+
+function run(
+  command: string,
+  args: string[],
+  options: { cwd?: string; env?: NodeJS.ProcessEnv } = {},
+) {
+  return execFileSync(command, args, {
+    cwd: options.cwd,
+    env: commandEnv(options.env),
+    encoding: "utf8",
+    maxBuffer: 32 * 1024 * 1024,
+    stdio: ["ignore", "pipe", "pipe"],
+    timeout: 10 * 60 * 1000,
+  });
+}
+
+function npmIntegrity(spec: string): string {
+  const output = run("npm", ["view", spec, "dist.integrity", "--json"]);
+  const value: unknown = JSON.parse(output);
+  if (typeof value !== "string" || !/^sha512-[A-Za-z0-9+/]+={0,2}$/u.test(value)) {
+    throw new Error(`npm did not return a sha512 integrity for ${spec}.`);
+  }
+  return value;
+}
+
+function assertInstalledVersions(
+  projectDir: string,
+  releaseVersion: string,
+  pluginPackageName: string,
+): void {
+  const output = run("npm", ["ls", "--json", "--depth=0", "openclaw", pluginPackageName], {
+    cwd: projectDir,
+  });
+  const tree = JSON.parse(output) as {
+    dependencies?: Record<string, { invalid?: boolean; version?: string }>;
+  };
+  for (const packageName of ["openclaw", pluginPackageName]) {
+    const dependency = tree.dependencies?.[packageName];
+    if (dependency?.version !== releaseVersion || dependency.invalid === true) {
+      throw new Error(
+        `Expected ${packageName}@${releaseVersion} without an invalid dependency; got ${JSON.stringify(dependency)}.`,
+      );
+    }
+  }
+}
+
+function parsePluginList(output: string, pluginId: string, packageName: string): void {
+  const list = JSON.parse(output) as {
+    plugins?: Array<{ id?: string; packageName?: string; status?: string }>;
+    diagnostics?: Array<{ level?: string; message?: string; pluginId?: string }>;
+  };
+  const plugin = list.plugins?.find((entry) => entry.id === pluginId);
+  if (!plugin || plugin.status !== "loaded") {
+    throw new Error(`Expected loaded plugin ${pluginId}; got ${JSON.stringify(plugin)}.`);
+  }
+  if (plugin.packageName !== undefined && plugin.packageName !== packageName) {
+    throw new Error(
+      `Expected plugin ${pluginId} package ${packageName}; got ${plugin.packageName}.`,
+    );
+  }
+  const errors = (list.diagnostics ?? []).filter(
+    (entry) =>
+      entry.level === "error" &&
+      (entry.pluginId === pluginId || String(entry.message ?? "").includes(pluginId)),
+  );
+  if (errors.length > 0) {
+    throw new Error(`Plugin discovery reported errors: ${JSON.stringify(errors)}.`);
+  }
+}
+
+function assertDoctor(output: string, pluginId: string): void {
+  const relevantFailure = output
+    .split(/\r?\n/u)
+    .find(
+      (line) =>
+        line.toLowerCase().includes(pluginId.toLowerCase()) &&
+        /\b(missing|incompatible|failed|error)\b/iu.test(line),
+    );
+  if (relevantFailure) {
+    throw new Error(`Doctor reported a covered-plugin failure: ${relevantFailure}`);
+  }
+}
+
+export function runAcceptance(args: Args, rootDir = resolve(".")): void {
+  const releaseVersion = assertExtendedStableReleaseVersion(args.releaseVersion);
+  const plugin = resolveCoveredPlugin(rootDir, args.pluginPackageName);
+  const scenarioIds = acceptanceScenarioIds(plugin.acceptanceProfile);
+  const statuses = new Map<string, AcceptanceScenarioStatus>(
+    scenarioIds.map((id) => [id, "not_run"]),
+  );
+  const coreSpec = `openclaw@${releaseVersion}`;
+  const pluginSpec = `${plugin.packageName}@${releaseVersion}`;
+  const coreIntegrity = npmIntegrity(coreSpec);
+  const pluginIntegrity = npmIntegrity(pluginSpec);
+  const scratch = mkdtempSync(join(tmpdir(), "openclaw-extended-stable-plugin-acceptance-"));
+  const projectDir = join(scratch, "project");
+  const homeDir = join(scratch, "home");
+  mkdirSync(projectDir, { recursive: true });
+  mkdirSync(homeDir, { recursive: true });
+  writeFileSync(
+    join(projectDir, "package.json"),
+    `${JSON.stringify({ name: "extended-stable-plugin-acceptance", private: true }, null, 2)}\n`,
+  );
+
+  let failed = false;
+  const attempt = (id: string, action: () => void) => {
+    if (failed) {
+      return;
+    }
+    try {
+      action();
+      statuses.set(id, "passed");
+    } catch (error) {
+      statuses.set(id, "failed");
+      failed = true;
+      console.error(`${id}: ${error instanceof Error ? error.stack : String(error)}`);
+    }
+  };
+
+  attempt("install", () => {
+    run(
+      "npm",
+      [
+        "install",
+        "--ignore-scripts",
+        "--package-lock=false",
+        "--no-audit",
+        "--no-fund",
+        coreSpec,
+        pluginSpec,
+      ],
+      { cwd: projectDir },
+    );
+    assertInstalledVersions(projectDir, releaseVersion, plugin.packageName);
+  });
+  attempt("production_loader", () => {
+    run(process.execPath, [
+      join(rootDir, "scripts/verify-plugin-npm-published-runtime.mjs"),
+      pluginSpec,
+    ]);
+  });
+
+  const openclawEntry = join(projectDir, "node_modules/openclaw/openclaw.mjs");
+  const isolatedEnv = {
+    HOME: homeDir,
+    OPENCLAW_HOME: homeDir,
+    OPENCLAW_STATE_DIR: join(homeDir, ".openclaw"),
+    OPENCLAW_CONFIG_PATH: join(homeDir, ".openclaw/openclaw.json"),
+    OPENCLAW_ALLOW_ROOT: "1",
+    OPENCLAW_DISABLE_BONJOUR: "1",
+  };
+  attempt("plugin_discovery", () => {
+    run(process.execPath, [openclawEntry, "plugins", "install", `npm:${pluginSpec}`], {
+      cwd: projectDir,
+      env: isolatedEnv,
+    });
+    run(process.execPath, [openclawEntry, "plugins", "enable", plugin.pluginId], {
+      cwd: projectDir,
+      env: isolatedEnv,
+    });
+    const list = run(process.execPath, [openclawEntry, "plugins", "list", "--json"], {
+      cwd: projectDir,
+      env: isolatedEnv,
+    });
+    parsePluginList(list, plugin.pluginId, plugin.packageName);
+  });
+  attempt("doctor", () => {
+    const output = run(process.execPath, [openclawEntry, "doctor", "--non-interactive"], {
+      cwd: projectDir,
+      env: isolatedEnv,
+    });
+    assertDoctor(output, plugin.pluginId);
+  });
+
+  const profileScenario = scenarioIds.at(-1);
+  if (!profileScenario) {
+    throw new Error("Acceptance profile has no profile scenario.");
+  }
+  attempt(profileScenario, () => {
+    const tests = PROFILE_TESTS[plugin.acceptanceProfile];
+    if (!tests || tests.length === 0) {
+      throw new Error(`No hermetic tests registered for ${plugin.acceptanceProfile}.`);
+    }
+    for (const path of tests) {
+      readFileSync(join(rootDir, path));
+    }
+    run(process.execPath, [join(rootDir, "scripts/run-vitest.mjs"), ...tests], {
+      cwd: rootDir,
+      env: { CI: "true", OPENCLAW_LIVE_TEST: "0" },
+    });
+  });
+
+  const result = parseExtendedStablePluginAcceptanceResult({
+    schemaVersion: 1,
+    inputs: {
+      releaseVersion,
+      pluginPackageName: plugin.packageName,
+    },
+    resolved: {
+      coreVersion: releaseVersion,
+      coreIntegrity,
+      pluginIntegrity,
+      acceptanceProfile: plugin.acceptanceProfile,
+    },
+    workflow: {
+      repository: process.env.GITHUB_REPOSITORY,
+      path: ".github/workflows/extended-stable-plugin-acceptance.yml",
+      ref: process.env.GITHUB_REF,
+      sha: process.env.GITHUB_SHA,
+      runId: Number(process.env.GITHUB_RUN_ID),
+      runAttempt: Number(process.env.GITHUB_RUN_ATTEMPT),
+      event: process.env.GITHUB_EVENT_NAME,
+    },
+    scenarios: scenarioIds.map((id) => ({ id, status: statuses.get(id) })),
+    conclusion: failed ? "failed" : "succeeded",
+  });
+  mkdirSync(dirname(resolve(args.output)), { recursive: true });
+  writeFileSync(args.output, `${JSON.stringify(result, null, 2)}\n`);
+  if (failed) {
+    process.exitCode = 1;
+  }
+}
+
+function isMain(): boolean {
+  return (
+    process.argv[1] !== undefined &&
+    import.meta.url === pathToFileURL(resolve(process.argv[1])).href
+  );
+}
+
+if (isMain()) {
+  runAcceptance(parseArgs(process.argv.slice(2)));
+}

--- a/scripts/sync-plugin-versions.ts
+++ b/scripts/sync-plugin-versions.ts
@@ -193,14 +193,17 @@ export function syncPluginVersions(
 if (import.meta.main) {
   const check = process.argv.includes("--check");
   const summary = syncPluginVersions(resolve("."), { write: !check });
-  let supportValidationError: unknown;
+  let supportValidationError: Error | undefined;
   try {
     validateExtendedStablePluginPackages({
       rootDir: resolve("."),
       targetVersion: summary.targetVersion,
     });
   } catch (error) {
-    supportValidationError = error;
+    supportValidationError =
+      error instanceof Error
+        ? error
+        : new Error("Extended-stable plugin support validation failed.");
   }
   console.log(
     `Synced plugin versions to ${summary.targetVersion}. Updated: ${summary.updated.length}. Changelogged: ${summary.changelogged.length}. Skipped: ${summary.skipped.length}.`,
@@ -218,9 +221,7 @@ if (import.meta.main) {
       console.error(`  changelog entry required: ${packageName}`);
     }
     if (supportValidationError !== undefined) {
-      console.error(
-        `  extended-stable plugin support invalid: ${supportValidationError instanceof Error ? supportValidationError.message : String(supportValidationError)}`,
-      );
+      console.error(`  extended-stable plugin support invalid: ${supportValidationError.message}`);
     }
     console.error("Run `pnpm plugins:sync` and commit the plugin version alignment.");
     process.exit(1);

--- a/scripts/sync-plugin-versions.ts
+++ b/scripts/sync-plugin-versions.ts
@@ -1,6 +1,7 @@
 // Sync Plugin Versions script supports OpenClaw repository automation.
 import { existsSync, readdirSync, readFileSync, writeFileSync } from "node:fs";
 import { join, resolve } from "node:path";
+import { validateExtendedStablePluginPackages } from "./lib/extended-stable-plugin-support.js";
 
 type PackageJson = {
   name?: string;
@@ -192,17 +193,39 @@ export function syncPluginVersions(
 if (import.meta.main) {
   const check = process.argv.includes("--check");
   const summary = syncPluginVersions(resolve("."), { write: !check });
+  let supportValidationError: unknown;
+  try {
+    validateExtendedStablePluginPackages({
+      rootDir: resolve("."),
+      targetVersion: summary.targetVersion,
+    });
+  } catch (error) {
+    supportValidationError = error;
+  }
   console.log(
     `Synced plugin versions to ${summary.targetVersion}. Updated: ${summary.updated.length}. Changelogged: ${summary.changelogged.length}. Skipped: ${summary.skipped.length}.`,
   );
-  if (check && (summary.updated.length > 0 || summary.changelogged.length > 0)) {
+  if (
+    check &&
+    (summary.updated.length > 0 ||
+      summary.changelogged.length > 0 ||
+      supportValidationError !== undefined)
+  ) {
     for (const packageName of summary.updated) {
       console.error(`  update required: ${packageName}`);
     }
     for (const packageName of summary.changelogged) {
       console.error(`  changelog entry required: ${packageName}`);
     }
+    if (supportValidationError !== undefined) {
+      console.error(
+        `  extended-stable plugin support invalid: ${supportValidationError instanceof Error ? supportValidationError.message : String(supportValidationError)}`,
+      );
+    }
     console.error("Run `pnpm plugins:sync` and commit the plugin version alignment.");
     process.exit(1);
+  }
+  if (supportValidationError !== undefined) {
+    throw supportValidationError;
   }
 }

--- a/scripts/verify-extended-stable-plugin-acceptance.ts
+++ b/scripts/verify-extended-stable-plugin-acceptance.ts
@@ -1,0 +1,139 @@
+#!/usr/bin/env -S node --import tsx
+
+import { execFileSync } from "node:child_process";
+import { resolve } from "node:path";
+import { pathToFileURL } from "node:url";
+import {
+  readExtendedStablePluginAcceptanceResult,
+  resolveCoveredPlugin,
+  sha256File,
+} from "./lib/extended-stable-plugin-acceptance.js";
+
+type Args = {
+  result: string;
+  root: string;
+  releaseVersion: string;
+  pluginPackageName: string;
+  repository: string;
+  workflowSha: string;
+  runId: number;
+  runAttempt: number;
+  artifactDigest: string;
+};
+
+function parsePositiveInteger(value: string, label: string): number {
+  if (!/^\d+$/u.test(value) || Number(value) <= 0 || !Number.isSafeInteger(Number(value))) {
+    throw new Error(`${label} must be a positive integer.`);
+  }
+  return Number(value);
+}
+
+function parseArgs(argv: string[]): Args {
+  const values = new Map<string, string>();
+  for (let index = 0; index < argv.length; index += 2) {
+    const key = argv[index];
+    const value = argv[index + 1];
+    if (!key?.startsWith("--") || value === undefined || values.has(key)) {
+      throw new Error("Acceptance verifier requires unique --key value arguments.");
+    }
+    values.set(key, value);
+  }
+  const required = [
+    "--result",
+    "--root",
+    "--release-version",
+    "--plugin-package-name",
+    "--repository",
+    "--workflow-sha",
+    "--run-id",
+    "--run-attempt",
+    "--artifact-digest",
+  ];
+  if (values.size !== required.length || required.some((key) => !values.has(key))) {
+    throw new Error(`Acceptance verifier requires exactly: ${required.join(", ")}.`);
+  }
+  return {
+    result: values.get("--result")!,
+    root: values.get("--root")!,
+    releaseVersion: values.get("--release-version")!,
+    pluginPackageName: values.get("--plugin-package-name")!,
+    repository: values.get("--repository")!,
+    workflowSha: values.get("--workflow-sha")!,
+    runId: parsePositiveInteger(values.get("--run-id")!, "run id"),
+    runAttempt: parsePositiveInteger(values.get("--run-attempt")!, "run attempt"),
+    artifactDigest: values.get("--artifact-digest")!,
+  };
+}
+
+function npmIntegrity(spec: string): string {
+  const stdout = execFileSync(
+    "npm",
+    ["view", spec, "dist.integrity", "--json", "--registry=https://registry.npmjs.org/"],
+    {
+      encoding: "utf8",
+      maxBuffer: 4 * 1024 * 1024,
+      timeout: 2 * 60 * 1000,
+    },
+  );
+  const value: unknown = JSON.parse(stdout);
+  if (typeof value !== "string") {
+    throw new Error(`npm did not return an integrity for ${spec}.`);
+  }
+  return value;
+}
+
+export function verifyAcceptance(args: Args) {
+  const result = readExtendedStablePluginAcceptanceResult(args.result);
+  const plugin = resolveCoveredPlugin(args.root, args.pluginPackageName);
+  if (result.inputs.releaseVersion !== args.releaseVersion) {
+    throw new Error("Acceptance result release version does not match the requested release.");
+  }
+  if (result.inputs.pluginPackageName !== plugin.packageName) {
+    throw new Error("Acceptance result plugin package does not match the requested plugin.");
+  }
+  if (result.resolved.acceptanceProfile !== plugin.acceptanceProfile) {
+    throw new Error("Acceptance result profile does not match the checked-in support policy.");
+  }
+  if (
+    result.workflow.repository !== args.repository ||
+    result.workflow.sha !== args.workflowSha ||
+    result.workflow.runId !== args.runId ||
+    result.workflow.runAttempt !== args.runAttempt
+  ) {
+    throw new Error("Acceptance result workflow identity does not match its Actions run.");
+  }
+  if (result.conclusion !== "succeeded") {
+    throw new Error("Acceptance result did not succeed.");
+  }
+  if (!/^sha256:[0-9a-f]{64}$/u.test(args.artifactDigest)) {
+    throw new Error("Acceptance artifact API digest must be sha256:<lowercase hex>.");
+  }
+  const coreIntegrity = npmIntegrity(`openclaw@${args.releaseVersion}`);
+  const pluginIntegrity = npmIntegrity(`${plugin.packageName}@${args.releaseVersion}`);
+  if (
+    result.resolved.coreIntegrity !== coreIntegrity ||
+    result.resolved.pluginIntegrity !== pluginIntegrity
+  ) {
+    throw new Error("Acceptance result npm integrities do not match fresh registry readback.");
+  }
+  return {
+    packageName: plugin.packageName,
+    npmIntegrity: pluginIntegrity,
+    workflowSha: result.workflow.sha,
+    acceptanceRunId: result.workflow.runId,
+    acceptanceRunAttempt: result.workflow.runAttempt,
+    acceptanceArtifactDigest: args.artifactDigest,
+    acceptanceResultSha256: sha256File(args.result),
+  };
+}
+
+function isMain(): boolean {
+  return (
+    process.argv[1] !== undefined &&
+    import.meta.url === pathToFileURL(resolve(process.argv[1])).href
+  );
+}
+
+if (isMain()) {
+  process.stdout.write(`${JSON.stringify(verifyAcceptance(parseArgs(process.argv.slice(2))))}\n`);
+}

--- a/scripts/verify-extended-stable-plugin-publication.ts
+++ b/scripts/verify-extended-stable-plugin-publication.ts
@@ -1,0 +1,207 @@
+#!/usr/bin/env -S node --import tsx
+
+import { execFileSync } from "node:child_process";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { pathToFileURL } from "node:url";
+import {
+  assertExtendedStableReleaseVersion,
+  sha256File,
+} from "./lib/extended-stable-plugin-acceptance.js";
+import { loadExtendedStablePluginSupport } from "./lib/extended-stable-plugin-support.js";
+
+type Args = {
+  result: string;
+  root: string;
+  releaseVersion: string;
+  sourceSha: string;
+  repository: string;
+  workflowRef: string;
+  runId: string;
+  runAttempt: string;
+  artifactDigest: string;
+};
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function assertKeys(value: Record<string, unknown>, keys: string[], label: string): void {
+  if (JSON.stringify(Object.keys(value).toSorted()) !== JSON.stringify(keys.toSorted())) {
+    throw new Error(`${label} has unexpected or missing fields.`);
+  }
+}
+
+function string(value: unknown, label: string): string {
+  if (typeof value !== "string" || !value || value !== value.trim()) {
+    throw new Error(`${label} must be a non-empty trimmed string.`);
+  }
+  return value;
+}
+
+function parseArgs(argv: string[]): Args {
+  const values = new Map<string, string>();
+  for (let index = 0; index < argv.length; index += 2) {
+    const key = argv[index];
+    const value = argv[index + 1];
+    if (!key?.startsWith("--") || value === undefined || values.has(key)) {
+      throw new Error("Publication verifier requires unique --key value arguments.");
+    }
+    values.set(key, value);
+  }
+  const names = [
+    "result",
+    "root",
+    "release-version",
+    "source-sha",
+    "repository",
+    "workflow-ref",
+    "run-id",
+    "run-attempt",
+    "artifact-digest",
+  ];
+  if (values.size !== names.length || names.some((name) => !values.has(`--${name}`))) {
+    throw new Error(`Publication verifier requires exactly: ${names.join(", ")}.`);
+  }
+  return Object.fromEntries(
+    names.map((name) => [
+      name.replace(/-([a-z])/gu, (_, letter: string) => letter.toUpperCase()),
+      values.get(`--${name}`)!,
+    ]),
+  ) as Args;
+}
+
+function npmIntegrity(spec: string): string {
+  const output = execFileSync(
+    "npm",
+    ["view", spec, "dist.integrity", "--json", "--registry=https://registry.npmjs.org/"],
+    {
+      encoding: "utf8",
+      timeout: 2 * 60 * 1000,
+    },
+  );
+  const value: unknown = JSON.parse(output);
+  if (typeof value !== "string") {
+    throw new Error(`npm did not return an integrity for ${spec}.`);
+  }
+  return value;
+}
+
+function npmVersion(spec: string): string {
+  const output = execFileSync(
+    "npm",
+    ["view", spec, "version", "--json", "--registry=https://registry.npmjs.org/"],
+    {
+      encoding: "utf8",
+      timeout: 2 * 60 * 1000,
+    },
+  );
+  const value: unknown = JSON.parse(output);
+  if (typeof value !== "string") {
+    throw new Error(`npm did not return a version for ${spec}.`);
+  }
+  return value;
+}
+
+export function verifyPublication(args: Args) {
+  const releaseVersion = assertExtendedStableReleaseVersion(args.releaseVersion);
+  if (!/^[0-9a-f]{40}$/u.test(args.sourceSha)) {
+    throw new Error("source SHA must be a full lowercase Git SHA.");
+  }
+  if (!/^sha256:[0-9a-f]{64}$/u.test(args.artifactDigest)) {
+    throw new Error("Publication artifact API digest must be sha256:<lowercase hex>.");
+  }
+  const raw: unknown = JSON.parse(readFileSync(args.result, "utf8"));
+  if (!isRecord(raw)) {
+    throw new Error("Publication result must be an object.");
+  }
+  assertKeys(raw, ["schemaVersion", "sourceSha", "workflow", "plugins"], "publication result");
+  if (raw.schemaVersion !== 1 || raw.sourceSha !== args.sourceSha || !Array.isArray(raw.plugins)) {
+    throw new Error("Publication result version, source SHA, or plugins is invalid.");
+  }
+  if (!isRecord(raw.workflow)) {
+    throw new Error("Publication workflow must be an object.");
+  }
+  assertKeys(
+    raw.workflow,
+    ["repository", "workflowPath", "workflowRef", "workflowSha", "runId", "runAttempt"],
+    "publication workflow",
+  );
+  const workflow = {
+    repository: string(raw.workflow.repository, "workflow.repository"),
+    workflowPath: string(raw.workflow.workflowPath, "workflow.workflowPath"),
+    workflowRef: string(raw.workflow.workflowRef, "workflow.workflowRef"),
+    workflowSha: string(raw.workflow.workflowSha, "workflow.workflowSha"),
+    runId: string(raw.workflow.runId, "workflow.runId"),
+    runAttempt: string(raw.workflow.runAttempt, "workflow.runAttempt"),
+  };
+  if (
+    workflow.repository !== args.repository ||
+    workflow.workflowPath !== ".github/workflows/plugin-npm-release.yml" ||
+    workflow.workflowRef !== args.workflowRef ||
+    workflow.workflowSha !== args.sourceSha ||
+    workflow.runId !== args.runId ||
+    workflow.runAttempt !== args.runAttempt
+  ) {
+    throw new Error("Publication result workflow identity does not match its Actions run.");
+  }
+
+  const support = loadExtendedStablePluginSupport(args.root);
+  const expectedPackageNames = support.plugins.map((plugin) => plugin.packageName);
+  const entries = raw.plugins.map((value, index) => {
+    if (!isRecord(value)) {
+      throw new Error(`publication plugins[${index}] must be an object.`);
+    }
+    assertKeys(
+      value,
+      ["packageName", "version", "npmIntegrity", "candidateTag", "provenanceVerified"],
+      `publication plugins[${index}]`,
+    );
+    const packageName = string(value.packageName, `publication plugins[${index}].packageName`);
+    const plugin = support.plugins.find((candidate) => candidate.packageName === packageName);
+    if (!plugin) {
+      throw new Error(`Publication contains uncovered package ${packageName}.`);
+    }
+    const [year, month, patch] = releaseVersion.split(".");
+    const candidateTag = `extended-stable-plugin-candidate-${plugin.pluginId}-${year}-${month}-${patch}`;
+    const integrity = npmIntegrity(`${packageName}@${releaseVersion}`);
+    const candidateVersion = npmVersion(`${packageName}@${candidateTag}`);
+    if (
+      value.version !== releaseVersion ||
+      value.npmIntegrity !== integrity ||
+      value.candidateTag !== candidateTag ||
+      candidateVersion !== releaseVersion ||
+      value.provenanceVerified !== true
+    ) {
+      throw new Error(`Publication result is invalid for ${packageName}.`);
+    }
+    return { packageName, version: releaseVersion, npmIntegrity: integrity, candidateTag };
+  });
+  if (
+    JSON.stringify(entries.map((entry) => entry.packageName)) !==
+    JSON.stringify(expectedPackageNames)
+  ) {
+    throw new Error(
+      "Publication result must contain exactly the covered packages in package-name order.",
+    );
+  }
+  return {
+    sourceSha: args.sourceSha,
+    publicationRunId: args.runId,
+    publicationRunAttempt: args.runAttempt,
+    publicationArtifactDigest: args.artifactDigest,
+    publicationResultSha256: sha256File(args.result),
+    plugins: entries,
+  };
+}
+
+function isMain(): boolean {
+  return (
+    process.argv[1] !== undefined &&
+    import.meta.url === pathToFileURL(resolve(process.argv[1])).href
+  );
+}
+
+if (isMain()) {
+  process.stdout.write(`${JSON.stringify(verifyPublication(parseArgs(process.argv.slice(2))))}\n`);
+}

--- a/scripts/verify-extended-stable-selector-handoff.ts
+++ b/scripts/verify-extended-stable-selector-handoff.ts
@@ -1,0 +1,250 @@
+#!/usr/bin/env -S node --import tsx
+
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { pathToFileURL } from "node:url";
+import { assertExtendedStableReleaseVersion } from "./lib/extended-stable-plugin-acceptance.js";
+import { loadExtendedStablePluginSupport } from "./lib/extended-stable-plugin-support.js";
+
+function record(value: unknown, label: string): Record<string, unknown> {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    throw new Error(`${label} must be an object.`);
+  }
+  return value as Record<string, unknown>;
+}
+
+function keys(value: Record<string, unknown>, expected: string[], label: string): void {
+  if (JSON.stringify(Object.keys(value).toSorted()) !== JSON.stringify(expected.toSorted())) {
+    throw new Error(`${label} has unexpected or missing fields.`);
+  }
+}
+
+function text(value: unknown, label: string): string {
+  if (typeof value !== "string" || !value || value !== value.trim()) {
+    throw new Error(`${label} must be a non-empty trimmed string.`);
+  }
+  return value;
+}
+
+function sha256(value: unknown, label: string): string {
+  const parsed = text(value, label);
+  if (!/^[0-9a-f]{64}$/u.test(parsed)) {
+    throw new Error(`${label} must be a lowercase SHA-256 digest.`);
+  }
+  return parsed;
+}
+
+function artifactDigest(value: unknown, label: string): string {
+  const parsed = text(value, label);
+  if (!/^sha256:[0-9a-f]{64}$/u.test(parsed)) {
+    throw new Error(`${label} must be an Actions sha256:<lowercase hex> digest.`);
+  }
+  return parsed;
+}
+
+function positiveInteger(value: unknown, label: string): number {
+  const parsed = typeof value === "number" ? value : Number(text(value, label));
+  if (!Number.isSafeInteger(parsed) || parsed <= 0) {
+    throw new Error(`${label} must be a positive integer.`);
+  }
+  return parsed;
+}
+
+export function verifySelectorHandoff(value: unknown, rootDir = resolve(".")): void {
+  const handoff = record(value, "selector handoff");
+  keys(
+    handoff,
+    [
+      "schemaVersion",
+      "handoffId",
+      "releaseVersion",
+      "sourceSha",
+      "core",
+      "pluginPublication",
+      "acceptances",
+      "selectorsBefore",
+      "selectorsAfter",
+      "selectorOrder",
+      "conclusion",
+    ],
+    "selector handoff",
+  );
+  if (handoff.schemaVersion !== 1) {
+    throw new Error("selector handoff schemaVersion must be 1.");
+  }
+  text(handoff.handoffId, "selector handoff.handoffId");
+  const releaseVersion = assertExtendedStableReleaseVersion(
+    text(handoff.releaseVersion, "selector handoff.releaseVersion"),
+  );
+  const sourceSha = text(handoff.sourceSha, "selector handoff.sourceSha");
+  if (!/^[0-9a-f]{40}$/u.test(sourceSha)) {
+    throw new Error("selector handoff.sourceSha must be a full lowercase Git SHA.");
+  }
+  if (
+    handoff.conclusion !== "ready_for_protected_selector_promotion" ||
+    JSON.stringify(handoff.selectorOrder) !== JSON.stringify(["plugins", "core"])
+  ) {
+    throw new Error("selector handoff must be ready with plugin-first/core-last order.");
+  }
+
+  const core = record(handoff.core, "selector handoff.core");
+  keys(
+    core,
+    [
+      "publicationRunId",
+      "publicationRunAttempt",
+      "publicationArtifactDigest",
+      "version",
+      "npmIntegrity",
+      "candidateTag",
+    ],
+    "selector handoff.core",
+  );
+  if (core.version !== releaseVersion) {
+    throw new Error("selector handoff core version must match the release version.");
+  }
+  positiveInteger(core.publicationRunId, "selector handoff.core.publicationRunId");
+  positiveInteger(core.publicationRunAttempt, "selector handoff.core.publicationRunAttempt");
+  artifactDigest(core.publicationArtifactDigest, "selector handoff.core.publicationArtifactDigest");
+  const coreIntegrity = text(core.npmIntegrity, "selector handoff.core.npmIntegrity");
+  if (!coreIntegrity.startsWith("sha512-")) {
+    throw new Error("selector handoff core npmIntegrity must be sha512.");
+  }
+  const [year, month, patch] = releaseVersion.split(".");
+  if (core.candidateTag !== `extended-stable-candidate-${year}-${month}-${patch}`) {
+    throw new Error("selector handoff core candidate tag is invalid.");
+  }
+
+  const support = loadExtendedStablePluginSupport(rootDir);
+  const expectedPackages = support.plugins.map((plugin) => plugin.packageName);
+  const publication = record(handoff.pluginPublication, "selector handoff.pluginPublication");
+  keys(
+    publication,
+    [
+      "sourceSha",
+      "publicationRunId",
+      "publicationRunAttempt",
+      "publicationArtifactDigest",
+      "publicationResultSha256",
+      "plugins",
+    ],
+    "selector handoff.pluginPublication",
+  );
+  if (publication.sourceSha !== sourceSha || !Array.isArray(publication.plugins)) {
+    throw new Error("selector handoff plugin publication identity is invalid.");
+  }
+  positiveInteger(publication.publicationRunId, "plugin publication run id");
+  positiveInteger(publication.publicationRunAttempt, "plugin publication run attempt");
+  artifactDigest(publication.publicationArtifactDigest, "plugin publication artifact digest");
+  sha256(publication.publicationResultSha256, "plugin publication result SHA-256");
+  const publicationIntegrityByPackage = new Map<string, string>();
+  const publishedPackages = publication.plugins.map((entry, index) => {
+    const plugin = record(entry, `plugin publication plugins[${index}]`);
+    keys(
+      plugin,
+      ["packageName", "version", "npmIntegrity", "candidateTag"],
+      `plugin publication plugins[${index}]`,
+    );
+    if (plugin.version !== releaseVersion) {
+      throw new Error(`plugin publication plugins[${index}] has a mismatched version.`);
+    }
+    const packageName = text(
+      plugin.packageName,
+      `plugin publication plugins[${index}].packageName`,
+    );
+    const supportEntry = support.plugins.find((candidate) => candidate.packageName === packageName);
+    if (!supportEntry) {
+      throw new Error(`plugin publication plugins[${index}] is not covered.`);
+    }
+    const integrity = text(
+      plugin.npmIntegrity,
+      `plugin publication plugins[${index}].npmIntegrity`,
+    );
+    if (!integrity.startsWith("sha512-")) {
+      throw new Error(`plugin publication plugins[${index}] npmIntegrity must be sha512.`);
+    }
+    if (
+      plugin.candidateTag !==
+      `extended-stable-plugin-candidate-${supportEntry.pluginId}-${year}-${month}-${patch}`
+    ) {
+      throw new Error(`plugin publication plugins[${index}] candidate tag is invalid.`);
+    }
+    publicationIntegrityByPackage.set(packageName, integrity);
+    return packageName;
+  });
+  if (JSON.stringify(publishedPackages) !== JSON.stringify(expectedPackages)) {
+    throw new Error("selector handoff publication must contain exactly the covered packages.");
+  }
+
+  if (!Array.isArray(handoff.acceptances)) {
+    throw new Error("selector handoff.acceptances must be an array.");
+  }
+  const acceptedPackages = handoff.acceptances.map((entry, index) => {
+    const acceptance = record(entry, `selector handoff.acceptances[${index}]`);
+    keys(
+      acceptance,
+      [
+        "packageName",
+        "npmIntegrity",
+        "workflowSha",
+        "acceptanceRunId",
+        "acceptanceRunAttempt",
+        "acceptanceArtifactDigest",
+        "acceptanceResultSha256",
+      ],
+      `selector handoff.acceptances[${index}]`,
+    );
+    sha256(acceptance.acceptanceResultSha256, `acceptances[${index}] result SHA-256`);
+    artifactDigest(acceptance.acceptanceArtifactDigest, `acceptances[${index}] artifact digest`);
+    positiveInteger(acceptance.acceptanceRunId, `acceptances[${index}] run id`);
+    positiveInteger(acceptance.acceptanceRunAttempt, `acceptances[${index}] run attempt`);
+    const workflowSha = text(acceptance.workflowSha, `acceptances[${index}] workflow SHA`);
+    if (!/^[0-9a-f]{40}$/u.test(workflowSha)) {
+      throw new Error(`acceptances[${index}] workflow SHA must be full lowercase hex.`);
+    }
+    const packageName = text(acceptance.packageName, `acceptances[${index}].packageName`);
+    if (acceptance.npmIntegrity !== publicationIntegrityByPackage.get(packageName)) {
+      throw new Error(`acceptances[${index}] integrity does not match publication.`);
+    }
+    return packageName;
+  });
+  if (JSON.stringify(acceptedPackages) !== JSON.stringify(expectedPackages)) {
+    throw new Error("selector handoff acceptances must contain exactly the covered packages.");
+  }
+
+  for (const field of ["selectorsBefore", "selectorsAfter"] as const) {
+    const values = record(handoff[field], `selector handoff.${field}`);
+    const expectedSelectorKeys = ["openclaw", ...expectedPackages].toSorted();
+    if (JSON.stringify(Object.keys(values).toSorted()) !== JSON.stringify(expectedSelectorKeys)) {
+      throw new Error(`selector handoff.${field} must contain only core and covered plugins.`);
+    }
+    for (const [packageName, packageValue] of Object.entries(values)) {
+      const selectors = record(packageValue, `selector handoff.${field}.${packageName}`);
+      keys(selectors, ["latest", "extendedStable"], `selector handoff.${field}.${packageName}`);
+      for (const selectorValue of Object.values(selectors)) {
+        if (selectorValue !== null && (typeof selectorValue !== "string" || !selectorValue)) {
+          throw new Error(`selector handoff.${field}.${packageName} is invalid.`);
+        }
+      }
+    }
+  }
+  if (JSON.stringify(handoff.selectorsBefore) !== JSON.stringify(handoff.selectorsAfter)) {
+    throw new Error("selector handoff shared selectors changed during candidate publication.");
+  }
+}
+
+function isMain(): boolean {
+  return (
+    process.argv[1] !== undefined &&
+    import.meta.url === pathToFileURL(resolve(process.argv[1])).href
+  );
+}
+
+if (isMain()) {
+  const path = process.argv[2];
+  if (!path || process.argv.length !== 3) {
+    throw new Error("Usage: verify-extended-stable-selector-handoff.ts <handoff.json>");
+  }
+  verifySelectorHandoff(JSON.parse(readFileSync(path, "utf8")));
+  console.log("Extended-stable selector handoff verified.");
+}

--- a/src/scripts/extended-stable-plugin-support.test.ts
+++ b/src/scripts/extended-stable-plugin-support.test.ts
@@ -1,0 +1,123 @@
+import fs from "node:fs";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  loadExtendedStablePluginSupport,
+  parseExtendedStablePluginSupport,
+  validateExtendedStablePluginPackages,
+} from "../../scripts/lib/extended-stable-plugin-support.js";
+import { cleanupTempDirs, makeTempDir } from "../../test/helpers/temp-dir.js";
+
+const tempDirs: string[] = [];
+
+const validPolicy = {
+  schemaVersion: 1,
+  plugins: [
+    {
+      pluginId: "codex",
+      packageName: "@openclaw/codex",
+      packageDir: "extensions/codex",
+      acceptanceProfile: "codex-provider-v1",
+    },
+    {
+      pluginId: "discord",
+      packageName: "@openclaw/discord",
+      packageDir: "extensions/discord",
+      acceptanceProfile: "discord-channel-v1",
+    },
+    {
+      pluginId: "slack",
+      packageName: "@openclaw/slack",
+      packageDir: "extensions/slack",
+      acceptanceProfile: "slack-channel-v1",
+    },
+  ],
+} as const;
+
+function writeJson(filePath: string, value: unknown) {
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  fs.writeFileSync(filePath, `${JSON.stringify(value, null, 2)}\n`, "utf8");
+}
+
+function writeFixture(rootDir: string, version = "2026.7.33") {
+  writeJson(path.join(rootDir, "release/extended-stable-plugin-support.json"), validPolicy);
+  for (const plugin of validPolicy.plugins) {
+    writeJson(path.join(rootDir, plugin.packageDir, "package.json"), {
+      name: plugin.packageName,
+      version,
+    });
+  }
+}
+
+describe("extended-stable plugin support policy", () => {
+  afterEach(() => cleanupTempDirs(tempDirs));
+
+  it("loads the fixed Slack, Discord, and Codex support set", () => {
+    const rootDir = makeTempDir(tempDirs, "openclaw-extended-stable-support-");
+    writeFixture(rootDir);
+
+    const support = loadExtendedStablePluginSupport(rootDir);
+    expect(support.plugins.map((entry) => entry.packageName)).toEqual([
+      "@openclaw/codex",
+      "@openclaw/discord",
+      "@openclaw/slack",
+    ]);
+    expect(validateExtendedStablePluginPackages({ rootDir, targetVersion: "2026.7.33" })).toEqual(
+      support,
+    );
+  });
+
+  it("rejects unknown fields, unsafe identities, and unregistered profiles", () => {
+    expect(() => parseExtendedStablePluginSupport({ ...validPolicy, generatedAt: "now" })).toThrow(
+      /must contain exactly/u,
+    );
+
+    expect(() =>
+      parseExtendedStablePluginSupport({
+        ...validPolicy,
+        plugins: [validPolicy.plugins[1], validPolicy.plugins[0], validPolicy.plugins[2]],
+      }),
+    ).toThrow(/sorted by packageName/u);
+
+    expect(() =>
+      parseExtendedStablePluginSupport({
+        ...validPolicy,
+        plugins: [
+          ...validPolicy.plugins.slice(0, 2),
+          { ...validPolicy.plugins[2], packageDir: "../slack" },
+        ],
+      }),
+    ).toThrow(/packageDir must match pluginId/u);
+
+    expect(() =>
+      parseExtendedStablePluginSupport({
+        ...validPolicy,
+        plugins: [
+          ...validPolicy.plugins.slice(0, 2),
+          { ...validPolicy.plugins[2], acceptanceProfile: "unknown-v1" },
+        ],
+      }),
+    ).toThrow(/acceptanceProfile is not registered/u);
+  });
+
+  it("rejects package identity and root-version drift", () => {
+    const rootDir = makeTempDir(tempDirs, "openclaw-extended-stable-support-drift-");
+    writeFixture(rootDir);
+
+    writeJson(path.join(rootDir, "extensions/slack/package.json"), {
+      name: "@openclaw/not-slack",
+      version: "2026.7.33",
+    });
+    expect(() =>
+      validateExtendedStablePluginPackages({ rootDir, targetVersion: "2026.7.33" }),
+    ).toThrow(/package name must be @openclaw\/slack/u);
+
+    writeJson(path.join(rootDir, "extensions/slack/package.json"), {
+      name: "@openclaw/slack",
+      version: "2026.7.32",
+    });
+    expect(() =>
+      validateExtendedStablePluginPackages({ rootDir, targetVersion: "2026.7.33" }),
+    ).toThrow(/version must match root version 2026\.7\.33/u);
+  });
+});

--- a/test/plugin-npm-release.test.ts
+++ b/test/plugin-npm-release.test.ts
@@ -6,11 +6,13 @@ import { afterEach, describe, expect, it } from "vitest";
 import { collectClawHubPublishablePluginPackages } from "../scripts/lib/plugin-clawhub-release.ts";
 import {
   collectChangedExtensionIdsFromPaths,
+  collectExtendedStablePublishablePluginPackages,
   collectPluginReleaseDependencyFreshnessErrors,
   collectPluginReleaseVersionFloorErrors,
   collectPublishablePluginPackages,
   collectPublishablePluginPackageErrors,
   OPENCLAW_PLUGIN_NPM_REPOSITORY_URL,
+  deriveExtendedStablePluginCandidateTag,
   parsePluginReleaseArgs,
   parsePluginReleaseSelection,
   parsePluginReleaseSelectionMode,
@@ -44,11 +46,12 @@ describe("parsePluginReleaseSelectionMode", () => {
   it("accepts the supported explicit selection modes", () => {
     expect(parsePluginReleaseSelectionMode("selected")).toBe("selected");
     expect(parsePluginReleaseSelectionMode("all-publishable")).toBe("all-publishable");
+    expect(parsePluginReleaseSelectionMode("extended-stable")).toBe("extended-stable");
   });
 
   it("rejects unsupported selection modes", () => {
     expect(() => parsePluginReleaseSelectionMode("all")).toThrowError(
-      'Unknown selection mode: all. Expected "selected" or "all-publishable".',
+      'Unknown selection mode: all. Expected "selected", "all-publishable", or "extended-stable".',
     );
   });
 });
@@ -105,6 +108,47 @@ describe("parsePluginReleaseArgs", () => {
       selection: [],
       pluginsFlagProvided: false,
     });
+  });
+
+  it("rejects package overrides for the policy-derived extended-stable set", () => {
+    expect(() =>
+      parsePluginReleaseArgs([
+        "--selection-mode",
+        "extended-stable",
+        "--plugins",
+        "@openclaw/slack",
+      ]),
+    ).toThrowError(
+      "`--selection-mode extended-stable` derives its package set from policy and must not be combined with `--plugins`.",
+    );
+  });
+});
+
+describe("extended-stable plugin publication", () => {
+  it("derives the closed covered package set and immutable candidate tags", () => {
+    const rootVersion = (JSON.parse(readFileSync("package.json", "utf8")) as { version: string })
+      .version;
+    const plugins = collectExtendedStablePublishablePluginPackages();
+
+    expect(plugins.map((plugin) => plugin.packageName)).toEqual([
+      "@openclaw/codex",
+      "@openclaw/discord",
+      "@openclaw/slack",
+    ]);
+    expect(plugins.map((plugin) => plugin.version)).toEqual([
+      rootVersion,
+      rootVersion,
+      rootVersion,
+    ]);
+    expect(plugins.map((plugin) => plugin.candidateTag)).toEqual(
+      plugins.map((plugin) =>
+        deriveExtendedStablePluginCandidateTag({
+          pluginId: plugin.extensionId,
+          version: rootVersion,
+        }),
+      ),
+    );
+    expect(plugins.every((plugin) => plugin.publishTag === plugin.candidateTag)).toBe(true);
   });
 });
 

--- a/test/scripts/extended-stable-plugin-release.test.ts
+++ b/test/scripts/extended-stable-plugin-release.test.ts
@@ -1,0 +1,198 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+import { parse } from "yaml";
+import {
+  acceptanceScenarioIds,
+  parseExtendedStablePluginAcceptanceResult,
+} from "../../scripts/lib/extended-stable-plugin-acceptance.js";
+import { verifySelectorHandoff } from "../../scripts/verify-extended-stable-selector-handoff.js";
+
+const ACCEPTANCE_WORKFLOW = ".github/workflows/extended-stable-plugin-acceptance.yml";
+const RELEASE_WORKFLOW = ".github/workflows/openclaw-release-publish.yml";
+
+function validAcceptanceResult() {
+  return {
+    schemaVersion: 1,
+    inputs: {
+      releaseVersion: "2026.6.33",
+      pluginPackageName: "@openclaw/slack",
+    },
+    resolved: {
+      coreVersion: "2026.6.33",
+      coreIntegrity: `sha512-${"A".repeat(86)}==`,
+      pluginIntegrity: `sha512-${"B".repeat(86)}==`,
+      acceptanceProfile: "slack-channel-v1",
+    },
+    workflow: {
+      repository: "openclaw/openclaw",
+      path: ACCEPTANCE_WORKFLOW,
+      ref: "refs/heads/main",
+      sha: "a".repeat(40),
+      runId: 123,
+      runAttempt: 1,
+      event: "workflow_dispatch",
+    },
+    scenarios: acceptanceScenarioIds("slack-channel-v1").map((id) => ({
+      id,
+      status: "passed",
+    })),
+    conclusion: "succeeded",
+  };
+}
+
+function validSelectorHandoff() {
+  const packageNames = ["@openclaw/codex", "@openclaw/discord", "@openclaw/slack"];
+  const selectorState = Object.fromEntries(
+    ["openclaw", ...packageNames].map((packageName) => [
+      packageName,
+      { latest: "2026.7.2", extendedStable: "2026.6.32" },
+    ]),
+  );
+  return {
+    schemaVersion: 1,
+    handoffId: "openclaw/openclaw:123:2026.6.33",
+    releaseVersion: "2026.6.33",
+    sourceSha: "a".repeat(40),
+    core: {
+      publicationRunId: "100",
+      publicationRunAttempt: "1",
+      publicationArtifactDigest: `sha256:${"1".repeat(64)}`,
+      version: "2026.6.33",
+      npmIntegrity: "sha512-core",
+      candidateTag: "extended-stable-candidate-2026-6-33",
+    },
+    pluginPublication: {
+      sourceSha: "a".repeat(40),
+      publicationRunId: "101",
+      publicationRunAttempt: "1",
+      publicationArtifactDigest: `sha256:${"2".repeat(64)}`,
+      publicationResultSha256: "3".repeat(64),
+      plugins: packageNames.map((packageName) => {
+        const pluginId = packageName.slice("@openclaw/".length);
+        return {
+          packageName,
+          version: "2026.6.33",
+          npmIntegrity: `sha512-${pluginId}`,
+          candidateTag: `extended-stable-plugin-candidate-${pluginId}-2026-6-33`,
+        };
+      }),
+    },
+    acceptances: packageNames.map((packageName, index) => ({
+      packageName,
+      npmIntegrity: `sha512-${packageName.slice("@openclaw/".length)}`,
+      workflowSha: "b".repeat(40),
+      acceptanceRunId: 200 + index,
+      acceptanceRunAttempt: 1,
+      acceptanceArtifactDigest: `sha256:${String(index + 4).repeat(64)}`,
+      acceptanceResultSha256: String(index + 7).repeat(64),
+    })),
+    selectorsBefore: selectorState,
+    selectorsAfter: structuredClone(selectorState),
+    selectorOrder: ["plugins", "core"],
+    conclusion: "ready_for_protected_selector_promotion",
+  };
+}
+
+describe("extended-stable plugin release artifacts", () => {
+  it("accepts the closed successful acceptance schema", () => {
+    expect(parseExtendedStablePluginAcceptanceResult(validAcceptanceResult())).toEqual(
+      validAcceptanceResult(),
+    );
+  });
+
+  it("rejects extra fields and incomplete scenario results", () => {
+    expect(() =>
+      parseExtendedStablePluginAcceptanceResult({ ...validAcceptanceResult(), proof: true }),
+    ).toThrow("must contain exactly");
+
+    const incomplete = validAcceptanceResult();
+    incomplete.scenarios.pop();
+    expect(() => parseExtendedStablePluginAcceptanceResult(incomplete)).toThrow("canonical order");
+  });
+
+  it("binds candidate tags, package integrities, and unchanged shared selectors", () => {
+    const handoff = validSelectorHandoff();
+    expect(() => verifySelectorHandoff(handoff)).not.toThrow();
+
+    const mismatched = validSelectorHandoff();
+    mismatched.acceptances[0]!.npmIntegrity = "sha512-wrong";
+    expect(() => verifySelectorHandoff(mismatched)).toThrow(/integrity does not match/u);
+
+    const moved = validSelectorHandoff();
+    moved.selectorsAfter.openclaw!.extendedStable = "2026.6.33";
+    expect(() => verifySelectorHandoff(moved)).toThrow(/shared selectors changed/u);
+  });
+
+  it("keeps acceptance on protected main with two closed inputs and immutable evidence", () => {
+    const source = readFileSync(ACCEPTANCE_WORKFLOW, "utf8");
+    const workflow = parse(source) as {
+      on?: { workflow_dispatch?: { inputs?: Record<string, unknown> } };
+      jobs?: Record<
+        string,
+        {
+          if?: string;
+          steps?: Array<{
+            name?: string;
+            if?: string;
+            env?: Record<string, string>;
+            run?: string;
+          }>;
+        }
+      >;
+    };
+    expect(Object.keys(workflow.on?.workflow_dispatch?.inputs ?? {}).toSorted()).toEqual([
+      "plugin_package_name",
+      "release_version",
+    ]);
+    expect(workflow.jobs?.accept?.if).toBeUndefined();
+    expect(source).toContain("ref: ${{ github.sha }}");
+    expect(source).toContain('${GITHUB_REF}" != "refs/heads/main"');
+    expect(source).toContain("scripts/run-extended-stable-plugin-acceptance.ts");
+    const upload = workflow.jobs?.accept?.steps?.find(
+      (step) => step.name === "Upload immutable acceptance result",
+    );
+    expect(upload?.if).toContain("always()");
+    const acceptanceStep = workflow.jobs?.accept?.steps?.find(
+      (step) => step.name === "Run exact package acceptance",
+    );
+    expect(acceptanceStep?.env).toMatchObject({
+      PLUGIN_PACKAGE_NAME: "${{ inputs.plugin_package_name }}",
+      RELEASE_VERSION: "${{ inputs.release_version }}",
+    });
+    expect(acceptanceStep?.run).not.toContain("${{ inputs.");
+  });
+
+  it("routes extended-stable through candidate publication and a closed selector handoff", () => {
+    const source = readFileSync(RELEASE_WORKFLOW, "utf8");
+    expect(source).toContain("- extended-stable");
+    expect(source).toContain("plugin_publish_scope=extended-stable");
+    expect(source).toContain("scripts/orchestrate-extended-stable-plugin-release.ts");
+    expect(source).toContain("extended-stable-selector-handoff-${{ github.run_id }}");
+    expect(source).toContain("inputs.npm_dist_tag != 'extended-stable'");
+    expect(source).toContain("inputs.npm_dist_tag == 'extended-stable'");
+
+    const orchestrator = readFileSync(
+      "scripts/orchestrate-extended-stable-plugin-release.ts",
+      "utf8",
+    );
+    expect(orchestrator).toContain('"plugin-npm-release.yml"');
+    expect(orchestrator).toContain('"openclaw-npm-release.yml"');
+    expect(orchestrator).toContain('"extended-stable-plugin-acceptance.yml"');
+    expect(orchestrator).toContain('selectorOrder: ["plugins", "core"]');
+    expect(orchestrator).toContain('conclusion: "ready_for_protected_selector_promotion"');
+    expect(orchestrator).toContain("verifySelectorHandoff(handoff, rootDir)");
+    expect(orchestrator).toContain('extendedStable: read("extended-stable")');
+    expect(orchestrator).toContain("Candidate publication moved one or more shared selectors");
+    expect(orchestrator).toContain("actions/workflows/${workflow}/runs");
+    expect(orchestrator).toContain("matched multiple new runs; refusing to guess");
+    expect(orchestrator).not.toContain("dispatch did not return an Actions run URL");
+    expect(orchestrator).not.toContain("plugin-clawhub-release.yml");
+    expect(orchestrator).not.toContain("windows-node-release.yml");
+  });
+
+  it("allows the exact extended-stable branch in the plugin publisher", () => {
+    const source = readFileSync(".github/workflows/plugin-npm-release.yml", "utf8");
+    expect(source).toContain("+refs/heads/extended-stable/*:refs/remotes/origin/extended-stable/*");
+    expect(source).toContain("^refs/heads/extended-stable/");
+  });
+});

--- a/test/scripts/extended-stable-plugin-release.test.ts
+++ b/test/scripts/extended-stable-plugin-release.test.ts
@@ -185,9 +185,13 @@ describe("extended-stable plugin release artifacts", () => {
     expect(orchestrator).toContain("Candidate publication moved one or more shared selectors");
     expect(orchestrator).toContain("actions/workflows/${workflow}/runs");
     expect(orchestrator).toContain("matched multiple new runs; refusing to guess");
+    expect(orchestrator).not.toContain("run.actor?.login");
     expect(orchestrator).not.toContain("dispatch did not return an Actions run URL");
     expect(orchestrator).not.toContain("plugin-clawhub-release.yml");
     expect(orchestrator).not.toContain("windows-node-release.yml");
+
+    expect(source).toContain("10#${extended_stable_patch} < 33");
+    expect(source).not.toContain("[3-9][0-9]|[1-9][0-9]{2,}");
   });
 
   it("allows the exact extended-stable branch in the plugin publisher", () => {

--- a/test/scripts/openclaw-npm-extended-stable-release.test.ts
+++ b/test/scripts/openclaw-npm-extended-stable-release.test.ts
@@ -1,15 +1,15 @@
 import { spawnSync } from "node:child_process";
 import { describe, expect, it, vi } from "vitest";
 import {
-  capturePriorExtendedStableSelector,
-  extendedStableSelectorRepairCommand,
+  buildExtendedStableCorePublicationResult,
+  extendedStableCandidateTag,
   parseExtendedStableGuardBypass,
-  parsePriorExtendedStableSelector,
   validateFullReleaseValidationManifest,
   validateNpmPublishBoundary,
   validateExtendedStableNpmReleaseRequest,
   validateExtendedStableRunIdentity,
-  verifyExtendedStableRegistryReadback,
+  verifyExtendedStableCandidateReadback,
+  verifyExtendedStableCorePublicationResult,
 } from "../../scripts/openclaw-npm-extended-stable-release.mjs";
 
 const sha = "a".repeat(40);
@@ -72,7 +72,7 @@ describe("npm extended-stable publication boundary", () => {
       },
     );
     expect(result.status).toBe(0);
-    expect(result.stdout).toBe("stable\nextended-stable\n");
+    expect(result.stdout).toBe("stable\nextended-stable-candidate-2026-6-33\n");
     expect(result.stderr).toBe("");
   });
 
@@ -130,6 +130,94 @@ describe("npm extended-stable publication boundary", () => {
     );
     expect(result.status).not.toBe(0);
     expect(result.stderr).toMatch(error);
+  });
+});
+
+describe("extended-stable candidate publication", () => {
+  it("derives a unique candidate tag from an exact final release version", () => {
+    expect(extendedStableCandidateTag("v2026.6.33")).toBe("extended-stable-candidate-2026-6-33");
+    expect(() => extendedStableCandidateTag("2026.6.33-beta.1")).toThrow(/exact final YYYY\.M\.P/u);
+  });
+
+  it("accepts candidate exact-version, selector, and integrity convergence", async () => {
+    let attempt = 0;
+    const sleep = vi.fn(async () => {});
+    const result = await verifyExtendedStableCandidateReadback({
+      expectedVersion: "2026.6.33",
+      query: async (target: string, field: string) => {
+        if (target === "openclaw@2026.6.33" && field === "version") {
+          attempt += 1;
+          return { status: 0, stdout: "2026.6.33\n" };
+        }
+        if (field === "dist.integrity") {
+          return { status: 0, stdout: "sha512-proof\n" };
+        }
+        return { status: 0, stdout: attempt >= 2 ? "2026.6.33\n" : "2026.6.32\n" };
+      },
+      sleep,
+    });
+    expect(result).toEqual({
+      exactVersion: "2026.6.33",
+      candidateVersion: "2026.6.33",
+      candidateTag: "extended-stable-candidate-2026-6-33",
+      integrity: "sha512-proof",
+      attemptsUsed: 2,
+    });
+    expect(sleep).toHaveBeenCalledOnce();
+    expect(sleep).toHaveBeenCalledWith(10_000);
+  });
+
+  it("writes a closed core publication result for the private orchestrator", () => {
+    const result = buildExtendedStableCorePublicationResult({
+      version: "2026.6.33",
+      integrity: "sha512-proof",
+      repository: "openclaw/openclaw",
+      sourceSha: sha,
+      workflowRef: "refs/heads/extended-stable/2026.6.33",
+      runId: 123,
+      runAttempt: 2,
+    });
+    expect(result).toEqual({
+      schemaVersion: 1,
+      package: {
+        name: "openclaw",
+        version: "2026.6.33",
+        integrity: "sha512-proof",
+        candidateTag: "extended-stable-candidate-2026-6-33",
+      },
+      source: { repository: "openclaw/openclaw", sha },
+      workflow: {
+        repository: "openclaw/openclaw",
+        path: ".github/workflows/openclaw-npm-release.yml",
+        ref: "refs/heads/extended-stable/2026.6.33",
+        runId: 123,
+        runAttempt: 2,
+      },
+      conclusion: "succeeded",
+    });
+    expect(
+      verifyExtendedStableCorePublicationResult(result, {
+        version: "v2026.6.33",
+        repository: "openclaw/openclaw",
+        sourceSha: sha,
+        workflowRef: "refs/heads/extended-stable/2026.6.33",
+        runId: 123,
+        runAttempt: 2,
+      }),
+    ).toBe(result);
+    expect(() =>
+      verifyExtendedStableCorePublicationResult(
+        { ...result, unexpected: true },
+        {
+          version: "2026.6.33",
+          repository: "openclaw/openclaw",
+          sourceSha: sha,
+          workflowRef: "refs/heads/extended-stable/2026.6.33",
+          runId: 123,
+          runAttempt: 2,
+        },
+      ),
+    ).toThrow(/unexpected field set/u);
   });
 });
 
@@ -333,73 +421,4 @@ describe("Full Validation manifest identity", () => {
       }),
     ).toThrow();
   });
-});
-
-describe("extended-stable selector capture", () => {
-  it("distinguishes bootstrap absence from an existing selector", () => {
-    expect(parsePriorExtendedStableSelector('{"latest":"2026.7.1"}')).toBe("absent");
-    expect(parsePriorExtendedStableSelector('{"extended-stable":"2026.6.33"}')).toBe("2026.6.33");
-  });
-
-  it.each(["not json", "null", "[]", '"2026.6.33"'])("rejects invalid result %s", (value) => {
-    expect(() => parsePriorExtendedStableSelector(value)).toThrow();
-  });
-
-  it("rejects command failure rather than treating it as bootstrap", () => {
-    expect(() =>
-      capturePriorExtendedStableSelector({ query: () => ({ status: 1, stdout: "" }) }),
-    ).toThrow(/query failed/u);
-  });
-});
-
-describe("extended-stable registry readback", () => {
-  it("accepts eventual convergence and sleeps 10 seconds between attempts", async () => {
-    let attempt = 0;
-    const sleep = vi.fn(async () => {});
-    const result = await verifyExtendedStableRegistryReadback({
-      expectedVersion: "2026.6.33",
-      query: async (target: string) => {
-        if (target === "openclaw@2026.6.33") {
-          attempt += 1;
-        }
-        return { status: 0, stdout: attempt >= 2 ? "2026.6.33\n" : "2026.6.32\n" };
-      },
-      sleep,
-    });
-    expect(result).toEqual({
-      exactVersion: "2026.6.33",
-      extendedStableSelector: "2026.6.33",
-      attemptsUsed: 2,
-    });
-    expect(sleep).toHaveBeenCalledOnce();
-    expect(sleep).toHaveBeenCalledWith(10_000);
-  });
-
-  it("exhausts exactly 12 dual-query attempts on mismatch or failure", async () => {
-    const query = vi.fn(async () => ({ status: 1, stdout: "" }));
-    const sleep = vi.fn(async () => {});
-    await expect(
-      verifyExtendedStableRegistryReadback({ expectedVersion: "2026.6.33", query, sleep }),
-    ).rejects.toThrow(/after 12 attempts/u);
-    expect(query).toHaveBeenCalledTimes(24);
-    expect(sleep).toHaveBeenCalledTimes(11);
-    expect(sleep.mock.calls.every(([delay]) => delay === 10_000)).toBe(true);
-  });
-});
-
-describe("extended-stable selector repair", () => {
-  it("points the selector at the expected published version", () => {
-    expect(extendedStableSelectorRepairCommand("v2026.6.33")).toBe(
-      "npm dist-tag add openclaw@2026.6.33 extended-stable",
-    );
-  });
-
-  it.each([undefined, "absent", "2026.6.33-beta.1", "2026.6.33-1"])(
-    "rejects an invalid expected version: %s",
-    (expectedVersion) => {
-      expect(() => extendedStableSelectorRepairCommand(expectedVersion)).toThrow(
-        "Extended-stable selector repair requires an exact final YYYY.M.P version.",
-      );
-    },
-  );
 });

--- a/test/scripts/openclaw-npm-extended-stable-workflow.test.ts
+++ b/test/scripts/openclaw-npm-extended-stable-workflow.test.ts
@@ -115,18 +115,36 @@ describe("minimal npm extended-stable workflow", () => {
     expect(raw).toContain("openclaw-npm-extended-stable-release.mjs verify-manifest");
   });
 
-  it("captures selector fail closed, publishes extended-stable, retries, and summarizes", () => {
+  it("publishes to a candidate tag, emits a verified result, and leaves promotion private", () => {
     const parsed = workflow();
     const publish = parsed.jobs?.publish_openclaw_npm;
-    const capture = step(publish, "Capture previous extended-stable selector");
-    const readback = step(publish, "Verify extended-stable registry readback");
+    const reconcile = step(publish, "Reconcile existing extended-stable candidate");
+    const alreadyPublished = step(publish, "Ensure version is not already published");
+    const readback = step(publish, "Verify extended-stable candidate readback");
+    const writeResult = step(publish, "Write extended-stable core publication result");
+    const uploadResult = step(publish, "Upload extended-stable core publication result");
     const summary = step(publish, "Summarize extended-stable npm publication");
-    expect(capture.run).toContain("openclaw-npm-extended-stable-release.mjs capture-selector");
-    expect(step(publish, "Publish").run).toContain("openclaw-npm-publish.sh");
-    expect(readback.run).toContain("openclaw-npm-extended-stable-release.mjs verify-readback");
+    expect(reconcile.run).toContain("already_published=true");
+    expect(reconcile.run).toContain("Could not authoritatively query");
+    expect(reconcile.run).toContain("public OIDC workflow cannot repair dist-tags");
+    expect(alreadyPublished.if).toBe("${{ inputs.npm_dist_tag != 'extended-stable' }}");
+    const publishStep = step(publish, "Publish");
+    expect(publishStep.run).toContain("openclaw-npm-publish.sh");
+    expect(publishStep.if).toContain("already_published != 'true'");
+    expect(readback.run).toContain(
+      "openclaw-npm-extended-stable-release.mjs verify-candidate-readback",
+    );
+    expect(writeResult.run).toContain(
+      "openclaw-npm-extended-stable-release.mjs write-publication-result",
+    );
+    expect(uploadResult).toMatchObject({
+      if: "${{ success() && inputs.npm_dist_tag == 'extended-stable' }}",
+    });
     expect(summary.if).toContain("always()");
-    expect(summary.run).toContain("openclaw-npm-extended-stable-release.mjs repair-command");
-    expect(summary.run).toContain('EXPECTED_VERSION="$RELEASE_TAG"');
+    expect(summary.run).toContain("Shared openclaw@extended-stable selector: unchanged");
+    expect(publish?.steps?.map((candidate) => candidate.name)).not.toContain(
+      "Capture previous extended-stable selector",
+    );
     expect(publish?.environment).toBe("npm-release");
   });
 

--- a/test/scripts/openclaw-npm-publish.test.ts
+++ b/test/scripts/openclaw-npm-publish.test.ts
@@ -163,9 +163,9 @@ describe("openclaw npm publish wrapper", () => {
 
     expect(result.status).toBe(0);
     expect(readFileSync(npmLog, "utf8")).toContain(
-      "publish --access public --tag extended-stable --provenance",
+      "publish --access public --tag extended-stable-candidate-2026-6-11 --provenance",
     );
-    expect(result.stdout).toContain("Resolved publish tag: extended-stable");
+    expect(result.stdout).toContain("Resolved publish tag: extended-stable-candidate-2026-6-11");
   });
 
   it.each([

--- a/test/scripts/plugin-npm-publication-result.test.ts
+++ b/test/scripts/plugin-npm-publication-result.test.ts
@@ -1,0 +1,75 @@
+// Plugin npm publication result tests close extended-stable matrix evidence.
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+import { deriveExtendedStablePluginCandidateTag } from "../../scripts/lib/plugin-npm-release.js";
+import { buildExtendedStablePluginPublicationResult } from "../../scripts/plugin-npm-publication-result.js";
+
+const identity = {
+  repository: "openclaw/openclaw",
+  workflowPath: ".github/workflows/plugin-npm-release.yml",
+  workflowRef: "refs/heads/main",
+  workflowSha: "b".repeat(40),
+  runId: "123",
+  runAttempt: "2",
+};
+
+function records() {
+  const version = (JSON.parse(readFileSync("package.json", "utf8")) as { version: string }).version;
+  return ["slack", "codex", "discord"].map((pluginId) =>
+    Object.assign({}, identity, {
+      packageName: `@openclaw/${pluginId}`,
+      version,
+      npmIntegrity: `sha512-${pluginId}`,
+      candidateTag: deriveExtendedStablePluginCandidateTag({ pluginId, version }),
+      provenanceVerified: true,
+      sourceSha: "b".repeat(40),
+    }),
+  );
+}
+
+describe("extended-stable plugin publication result", () => {
+  it("sorts and closes exactly one record for every covered package", () => {
+    const result = buildExtendedStablePluginPublicationResult({
+      records: records(),
+      sourceSha: "b".repeat(40),
+      identity,
+    });
+
+    expect(result.plugins.map((plugin) => plugin.packageName)).toEqual([
+      "@openclaw/codex",
+      "@openclaw/discord",
+      "@openclaw/slack",
+    ]);
+    expect(result.workflow).toEqual(identity);
+  });
+
+  it("rejects missing packages, wrong tags, and unverified provenance", () => {
+    expect(() =>
+      buildExtendedStablePluginPublicationResult({
+        records: records().slice(1),
+        sourceSha: "b".repeat(40),
+        identity,
+      }),
+    ).toThrow(/must contain exactly/u);
+
+    const wrongTag = records();
+    wrongTag[0] = { ...wrongTag[0], candidateTag: "extended-stable" };
+    expect(() =>
+      buildExtendedStablePluginPublicationResult({
+        records: wrongTag,
+        sourceSha: "b".repeat(40),
+        identity,
+      }),
+    ).toThrow(/candidate tag must be/u);
+
+    const unverified = records();
+    unverified[0] = { ...unverified[0], provenanceVerified: false };
+    expect(() =>
+      buildExtendedStablePluginPublicationResult({
+        records: unverified,
+        sourceSha: "b".repeat(40),
+        identity,
+      }),
+    ).toThrow(/provenanceVerified must be true/u);
+  });
+});

--- a/test/scripts/plugin-npm-publish.test.ts
+++ b/test/scripts/plugin-npm-publish.test.ts
@@ -1,5 +1,6 @@
 // Plugin NPM Publish tests cover publish wrapper argument safety.
 import { spawnSync } from "node:child_process";
+import { readFileSync } from "node:fs";
 import { describe, expect, it } from "vitest";
 
 const scriptPath = "scripts/plugin-npm-publish.sh";
@@ -17,7 +18,7 @@ describe("plugin npm publish wrapper", () => {
 
     expect(result.status).toBe(0);
     expect(result.stdout.trim()).toBe(
-      "usage: bash scripts/plugin-npm-publish.sh [--dry-run|--pack-dry-run|--publish] <package-dir>",
+      "usage: bash scripts/plugin-npm-publish.sh [--dry-run|--pack-dry-run|--publish] [--candidate-tag <tag>] <package-dir>",
     );
     expect(result.stderr).toBe("");
   });
@@ -28,7 +29,7 @@ describe("plugin npm publish wrapper", () => {
     expect(result.status).toBe(2);
     expect(result.stdout).toBe("");
     expect(result.stderr.trim()).toBe(
-      "usage: bash scripts/plugin-npm-publish.sh [--dry-run|--pack-dry-run|--publish] <package-dir>",
+      "usage: bash scripts/plugin-npm-publish.sh [--dry-run|--pack-dry-run|--publish] [--candidate-tag <tag>] <package-dir>",
     );
   });
 
@@ -46,5 +47,45 @@ describe("plugin npm publish wrapper", () => {
     expect(result.status).toBe(2);
     expect(result.stdout).toBe("");
     expect(result.stderr.trim()).toBe("unexpected plugin npm publish argument: extra");
+  });
+
+  it("rejects a candidate tag not derived from plugin id and exact version", () => {
+    const result = runPluginPublishWrapper([
+      "--dry-run",
+      "--candidate-tag",
+      "extended-stable-plugin-candidate-slack-2000-1-33",
+      "extensions/slack",
+    ]);
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain("candidate tag mismatch: expected");
+  });
+
+  it("requires OIDC trusted publishing and no token for candidate publication", () => {
+    const version = (JSON.parse(readFileSync("package.json", "utf8")) as { version: string })
+      .version;
+    const result = spawnSync(
+      "bash",
+      [
+        scriptPath,
+        "--publish",
+        "--candidate-tag",
+        `extended-stable-plugin-candidate-slack-${version.replaceAll(".", "-")}`,
+        "extensions/slack",
+      ],
+      {
+        cwd: process.cwd(),
+        encoding: "utf8",
+        env: {
+          ...process.env,
+          NODE_AUTH_TOKEN: "",
+          NPM_TOKEN: "",
+          OPENCLAW_NPM_PUBLISH_AUTH_MODE: "",
+        },
+      },
+    );
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain("requires GitHub OIDC trusted publishing");
   });
 });

--- a/test/scripts/plugin-npm-release-workflow.test.ts
+++ b/test/scripts/plugin-npm-release-workflow.test.ts
@@ -1,0 +1,83 @@
+// Plugin npm release workflow tests protect extended-stable publication ownership.
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+import { parse } from "yaml";
+
+const workflowPath = ".github/workflows/plugin-npm-release.yml";
+
+type Step = { env?: Record<string, string>; if?: string; name?: string; run?: string };
+type Job = { permissions?: Record<string, string>; steps?: Step[] };
+type Workflow = {
+  on?: { workflow_dispatch?: { inputs?: { publish_scope?: { options?: string[] } } } };
+  jobs?: Record<string, Job>;
+};
+
+function workflow(): Workflow {
+  return parse(readFileSync(workflowPath, "utf8")) as Workflow;
+}
+
+function step(job: Job | undefined, name: string): Step {
+  const found = job?.steps?.find((candidate) => candidate.name === name);
+  if (!found) {
+    throw new Error(`Missing workflow step: ${name}`);
+  }
+  return found;
+}
+
+describe("plugin npm extended-stable publication", () => {
+  it("exposes the fixed policy mode and publishes candidates with OIDC only", () => {
+    const parsed = workflow();
+    expect(parsed.on?.workflow_dispatch?.inputs?.publish_scope?.options).toContain(
+      "extended-stable",
+    );
+    const publish = parsed.jobs?.publish_plugins_npm;
+    const sourceBinding = step(
+      parsed.jobs?.preview_plugins_npm,
+      "Bind extended-stable source to provenance SHA",
+    );
+    expect(sourceBinding.run).toContain('"${SOURCE_SHA}" != "${PROVENANCE_SHA}"');
+    const releaseLine = step(
+      parsed.jobs?.preview_plugins_npm,
+      "Validate extended-stable release line",
+    );
+    expect(releaseLine.run).toContain("extended-stable/([0-9]{4})");
+    expect(releaseLine.run).toContain("patch 33 or above");
+    expect(releaseLine.run).toContain('"${BASH_REMATCH[1]}" != "${branch_year}"');
+    expect(step(parsed.jobs?.preview_plugins_npm, "Resolve plugin release plan").run).toContain(
+      "matrix_selector='.all'",
+    );
+    expect(publish?.permissions?.["id-token"]).toBe("write");
+    const packageCheck = step(publish, "Check npm package version");
+    expect(packageCheck.run).toContain("Could not authoritatively query");
+    expect(packageCheck.run).toContain('if [[ -z "${CANDIDATE_TAG}" ]]');
+    expect(packageCheck.env?.CANDIDATE_TAG).toBe("${{ matrix.plugin.candidateTag }}");
+    const candidate = step(publish, "Publish extended-stable candidate");
+    expect(candidate.if).toContain("already_published != 'true'");
+    expect(candidate.env).toEqual({ OPENCLAW_NPM_PUBLISH_AUTH_MODE: "trusted-publisher" });
+    expect(candidate.run).toContain("--candidate-tag");
+    expect(candidate.run).not.toContain("NPM_TOKEN");
+    const reconcile = step(publish, "Verify extended-stable candidate tag");
+    expect(reconcile.env?.ALREADY_PUBLISHED).toContain("already_published");
+    expect(reconcile.run).toContain("is immutable and already published");
+    expect(reconcile.run).toContain("will not republish or retag it");
+    expect(reconcile.run).toContain("Could not authoritatively read npm dist-tags");
+    const provenance = step(publish, "Verify extended-stable npm provenance");
+    expect(provenance.run).toContain("dist.attestations.provenance.predicateType");
+    expect(provenance.run).toContain("npm audit signatures");
+  });
+
+  it("emits one closed aggregate without mutating shared dist-tags", () => {
+    const raw = readFileSync(workflowPath, "utf8");
+    const parsed = workflow();
+    const aggregate = parsed.jobs?.aggregate_extended_stable_publication;
+    expect(
+      step(aggregate, "Upload aggregate publication result").run ??
+        raw.includes(
+          "extended-stable-plugin-publication-${{ github.run_id }}-${{ github.run_attempt }}",
+        ),
+    ).toBeTruthy();
+    expect(raw).toContain("extended-stable-plugin-publication.json");
+    expect(raw).not.toContain("npm dist-tag add");
+    expect(raw).not.toContain("npm dist-tag rm");
+  });
+});

--- a/test/scripts/plugin-npm-release-workflow.test.ts
+++ b/test/scripts/plugin-npm-release-workflow.test.ts
@@ -2,6 +2,7 @@
 import { readFileSync } from "node:fs";
 import { describe, expect, it } from "vitest";
 import { parse } from "yaml";
+import { assertExtendedStableReleaseVersion } from "../../scripts/lib/extended-stable-plugin-acceptance.js";
 
 const workflowPath = ".github/workflows/plugin-npm-release.yml";
 
@@ -41,8 +42,9 @@ describe("plugin npm extended-stable publication", () => {
       "Validate extended-stable release line",
     );
     expect(releaseLine.run).toContain("extended-stable/([0-9]{4})");
-    expect(releaseLine.run).toContain("patch 33 or above");
-    expect(releaseLine.run).toContain('"${BASH_REMATCH[1]}" != "${branch_year}"');
+    expect(releaseLine.run).toContain("assertExtendedStableReleaseVersion");
+    expect(releaseLine.run).toContain('"${root_year}" != "${branch_year}"');
+    expect(releaseLine.run).not.toContain("[3-9][0-9]|[1-9][0-9]{2,}");
     expect(step(parsed.jobs?.preview_plugins_npm, "Resolve plugin release plan").run).toContain(
       "matrix_selector='.all'",
     );
@@ -64,6 +66,15 @@ describe("plugin npm extended-stable publication", () => {
     const provenance = step(publish, "Verify extended-stable npm provenance");
     expect(provenance.run).toContain("dist.attestations.provenance.predicateType");
     expect(provenance.run).toContain("npm audit signatures");
+  });
+
+  it("rejects patches 30-32 before accepting the extended-stable release line", () => {
+    for (const patch of [30, 31, 32]) {
+      expect(() => assertExtendedStableReleaseVersion(`2026.7.${patch}`)).toThrow(
+        "patch must be 33 or above",
+      );
+    }
+    expect(assertExtendedStableReleaseVersion("2026.7.33")).toBe("2026.7.33");
   });
 
   it("emits one closed aggregate without mutating shared dist-tags", () => {

--- a/test/scripts/test-projects.test.ts
+++ b/test/scripts/test-projects.test.ts
@@ -2004,6 +2004,10 @@ describe("scripts/test-projects changed-target routing", () => {
       ["scripts/plugin-npm-release-check.ts", ["test/scripts/release-wrapper-scripts.test.ts"]],
       ["scripts/plugin-npm-release-plan.ts", ["test/scripts/release-wrapper-scripts.test.ts"]],
       [
+        "scripts/plugin-npm-publication-result.ts",
+        ["test/scripts/plugin-npm-publication-result.test.ts"],
+      ],
+      [
         "scripts/plugin-release-pretag-pack-check.ts",
         ["test/scripts/plugin-release-pretag-pack-check.test.ts"],
       ],


### PR DESCRIPTION
## Summary

- adds the checked-in policy for the plugins covered by the net-new `extended-stable` channel: Codex, Discord, and Slack
- publishes immutable core and covered-plugin candidates under run-specific npm tags, without moving `latest`, `stable`, or the shared `extended-stable` selector
- runs exact-version acceptance for the core/plugin set and emits a validated selector-promotion handoff
- preserves regular release behavior and the existing plugin installation model: core installation does not automatically install every plugin; enabled plugins are installed by onboarding/config/plugin commands

## Release boundary

This PR implements the public candidate-publication and verification phase. It intentionally does not promote the shared `extended-stable` dist-tags. A protected owner in `openclaw/releases` must consume the validated handoff and promote covered plugin selectors first, then core last. Runtime selector convergence and backport planning remain separate work.

## Verification

- 393 focused tests passed during implementation; an independent final pass ran 320 focused tests with no failures
- changed TypeScript/JavaScript passed `oxlint --deny-warnings`
- all changed TypeScript, JavaScript, JSON, Markdown, and workflow files passed `oxfmt`
- shell syntax, Node syntax, JSON parsing, workflow-contract checks, and `git show --check` passed
- documentation MDX checks passed; link audit reported only unrelated pre-existing failures

### Verdaccio end-to-end canary

Proof: `/tmp/integ-claw-release-verdaccio.QIWdUO/proof.json`

- source SHA: `9d506c68ea73a7ff6631527e6612b8d9374721a8`
- installed core `2000.4.33`, then upgraded to `2000.4.34`
- `@openclaw/codex`, `@openclaw/discord`, and `@openclaw/slack` upgraded from `.33` to `.34`
- uncovered control plugin `@openclaw/matrix` remained at `.33`
- core selector moved absent -> `.33` -> `.34`
- published tarball identities and SHA-256 values matched the proof

The local canary does not exercise GitHub protected-environment approval, Actions OIDC, npm provenance, official npm publication, or the not-yet-landed private selector owner.
