### PR TITLE
fix(diagnostics-otel): preserve zero model-call usage

### DIFF
--- a/extensions/diagnostics-otel/src/service-genai-attributes.ts
+++ b/extensions/diagnostics-otel/src/service-genai-attributes.ts
@@ -51,6 +51,10 @@ export function positiveFiniteNumber(value: number | undefined): number | undefi
   return typeof value === "number" && Number.isFinite(value) && value > 0 ? value : undefined;
 }
 
+function nonNegativeFiniteNumber(value: number | undefined): number | undefined {
+  return typeof value === "number" && Number.isFinite(value) && value >= 0 ? value : undefined;
+}
+
 export function assignPositiveNumberAttr(
   attrs: Record<string, string | number | boolean>,
   key: string,
@@ -95,14 +99,17 @@ function modelCallPromptTokens(usage: {
   cacheRead?: number;
   cacheWrite?: number;
 }): number | undefined {
-  if (typeof usage.promptTokens === "number" && Number.isFinite(usage.promptTokens)) {
-    return usage.promptTokens;
+  const promptTokens = nonNegativeFiniteNumber(usage.promptTokens);
+  if (promptTokens !== undefined) {
+    return promptTokens;
   }
-  const input = usage.input ?? 0;
-  const cacheRead = usage.cacheRead ?? 0;
-  const cacheWrite = usage.cacheWrite ?? 0;
-  const total = input + cacheRead + cacheWrite;
-  return total > 0 ? total : undefined;
+  const input = nonNegativeFiniteNumber(usage.input);
+  const cacheRead = nonNegativeFiniteNumber(usage.cacheRead);
+  const cacheWrite = nonNegativeFiniteNumber(usage.cacheWrite);
+  if (input === undefined && cacheRead === undefined && cacheWrite === undefined) {
+    return undefined;
+  }
+  return (input ?? 0) + (cacheRead ?? 0) + (cacheWrite ?? 0);
 }
 
 export function assignModelCallPromptStatsAttrs(
@@ -147,7 +154,10 @@ export function assignModelCallUsageAttrs(
     ["gen_ai.usage.cache_read.input_tokens", usage.cacheRead],
     ["gen_ai.usage.cache_creation.input_tokens", usage.cacheWrite],
   ] as const) {
-    assignPositiveNumberAttr(attrs, key, value);
+    const normalized = nonNegativeFiniteNumber(value);
+    if (normalized !== undefined) {
+      attrs[key] = normalized;
+    }
   }
 }
 

--- a/extensions/diagnostics-otel/src/service.otlp-export.test.ts
+++ b/extensions/diagnostics-otel/src/service.otlp-export.test.ts
@@ -556,6 +556,42 @@ test("propagates the exported model span across two OTLP services with one roote
   }
 }, 30_000);
 
+test("preserves explicit zero model-call usage through OTLP protobuf export", async () => {
+  const receiver = startLocalOtlpReceiver();
+  const port = await receiver.listen();
+  releasePreloadedOtelGlobals();
+  const { service, ctx } = await startOtelService({
+    endpoint: `http://127.0.0.1:${port}`,
+    traces: true,
+  });
+
+  try {
+    emit({
+      type: "model.call.completed",
+      runId: "run-zero-usage",
+      callId: "call-zero-usage",
+      provider: "openai",
+      model: "gpt-5.6-luna",
+      durationMs: 1,
+      usage: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+    });
+    await waitForDiagnosticEventsDrained();
+    await service.stop?.(ctx);
+
+    expect(
+      receiver.capturedSpans.find((span) => span.name === "openclaw.model.call")?.attributes,
+    ).toMatchObject({
+      "openclaw.model_call.usage.input_tokens": 0,
+      "openclaw.model_call.usage.output_tokens": 0,
+      "openclaw.model_call.usage.prompt_tokens": 0,
+      "gen_ai.usage.input_tokens": 0,
+    });
+  } finally {
+    await service.stop?.(ctx);
+    await receiver.close();
+  }
+}, 30_000);
+
 test("uses the real preloaded model span as the mid-turn propagation root", async () => {
   const { service, ctx } = await startOtelService({ traces: true });
   const outboundTraceparent = runModelCallAndCaptureTraceparent({

--- a/extensions/diagnostics-otel/src/service.test.ts
+++ b/extensions/diagnostics-otel/src/service.test.ts
@@ -3616,14 +3616,26 @@ describe("diagnostics-otel service", () => {
     expect(JSON.stringify(failoverOptions?.attributes)).not.toContain("Agent:qa:otel-trace-smoke");
   });
 
-  test("maps model call APIs to GenAI operation names and error type", async () => {
+  test("maps model call APIs and preserves zero usage on terminal spans", async () => {
     await startOtelService({ traces: true, metrics: true });
+    const zeroUsage = {
+      input: 0,
+      output: 0,
+      cacheRead: 0,
+      cacheWrite: 0,
+      reasoningTokens: 0,
+      total: 0,
+    };
 
     emitDiagnosticEvent({
       type: "model.call.completed",
       ...MODEL_CALL_FIXTURE,
       api: "openai-completions",
       durationMs: 80,
+      requestPayloadBytes: 0,
+      responseStreamBytes: 0,
+      timeToFirstByteMs: 0,
+      usage: zeroUsage,
     });
     emitDiagnosticEvent({
       type: "model.call.completed",
@@ -3634,7 +3646,7 @@ describe("diagnostics-otel service", () => {
       api: "google-generative-ai",
       durationMs: 90,
     });
-    await emitAndFlush({
+    emitDiagnosticEvent({
       type: "model.call.error",
       runId: "run-1",
       callId: "call-3",
@@ -3642,12 +3654,20 @@ describe("diagnostics-otel service", () => {
       api: "openai-responses",
       durationMs: 40,
       errorCategory: "TimeoutError",
+      usage: zeroUsage,
+    });
+    await emitAndFlush({
+      type: "model.call.completed",
+      ...MODEL_CALL_FIXTURE,
+      callId: "call-cache-only",
+      durationMs: 30,
+      usage: { cacheWrite: 7 },
     });
 
     const modelCallAttrs = telemetryState.tracer.startSpan.mock.calls
       .filter((call) => call[0] === "openclaw.model.call")
       .map((call) => (call[1] as { attributes?: Record<string, unknown> }).attributes);
-    expect(modelCallAttrs).toHaveLength(3);
+    expect(modelCallAttrs).toHaveLength(4);
     expect(modelCallAttrs[0]?.["gen_ai.system"]).toBe("openai");
     expect(modelCallAttrs[0]?.["gen_ai.request.model"]).toBe("gpt-5.4");
     expect(modelCallAttrs[0]?.["gen_ai.operation.name"]).toBe("text_completion");
@@ -3658,6 +3678,40 @@ describe("diagnostics-otel service", () => {
     expect(modelCallAttrs[2]?.["gen_ai.request.model"]).toBe("gpt-5.4");
     expect(modelCallAttrs[2]?.["gen_ai.operation.name"]).toBe("chat");
     expect(modelCallAttrs[2]?.["error.type"]).toBe("TimeoutError");
+    for (const attrs of [modelCallAttrs[0], modelCallAttrs[2]]) {
+      expect(attrs).toMatchObject({
+        "openclaw.model_call.usage.input_tokens": 0,
+        "openclaw.model_call.usage.output_tokens": 0,
+        "openclaw.model_call.usage.cache_read_input_tokens": 0,
+        "openclaw.model_call.usage.cache_creation_input_tokens": 0,
+        "openclaw.model_call.usage.reasoning_output_tokens": 0,
+        "openclaw.model_call.usage.prompt_tokens": 0,
+        "openclaw.model_call.usage.total_tokens": 0,
+        "gen_ai.usage.input_tokens": 0,
+        "gen_ai.usage.output_tokens": 0,
+        "gen_ai.usage.cache_read.input_tokens": 0,
+        "gen_ai.usage.cache_creation.input_tokens": 0,
+      });
+    }
+    for (const key of [
+      "openclaw.model_call.request_bytes",
+      "openclaw.model_call.response_bytes",
+      "openclaw.model_call.time_to_first_byte_ms",
+    ]) {
+      expect(modelCallAttrs[0]).not.toHaveProperty(key);
+    }
+    expect(
+      Object.keys(modelCallAttrs[1] ?? {}).filter(
+        (key) => key.startsWith("openclaw.model_call.usage.") || key.startsWith("gen_ai.usage."),
+      ),
+    ).toEqual([]);
+    expect(modelCallAttrs[3]).toMatchObject({
+      "openclaw.model_call.usage.cache_creation_input_tokens": 7,
+      "openclaw.model_call.usage.prompt_tokens": 7,
+      "gen_ai.usage.input_tokens": 7,
+      "gen_ai.usage.cache_creation.input_tokens": 7,
+    });
+    expect(modelCallAttrs[3]).not.toHaveProperty("openclaw.model_call.usage.input_tokens");
   });
 
   test("uses latest GenAI request and agent span shapes only when semconv opt-in is set", async () => {


### PR DESCRIPTION
Fixes #100113.

## What Problem This Solves

Fixes an issue where diagnostics operators could not distinguish an explicit zero model-call usage value from missing usage telemetry. The OTEL attribute projection accepted only positive numbers, so valid zero token counts disappeared from completed and error model-call spans.

## Why This Change Was Made

Model-call usage attributes now preserve finite non-negative values, including zero, while timing and byte fields keep their existing positive-only behavior. Prompt totals also preserve zero when any prompt bucket was explicitly supplied, including cache-only usage; absent usage remains absent.

This stays inside the diagnostics OTEL projection owner boundary. It does not change aggregate `model.usage`, thresholds, recorder producers, CLI behavior, documentation, configuration, schema, environment variables, or public event contracts.

## User Impact

OTEL consumers can reliably tell a real zero-token model call from a call whose usage was not reported, without changing runtime behavior or telemetry contracts outside model-call span attributes.

## Evidence

- Exact base: `c37ba84f662aca1b2d384846ee59654e88ddfc50`.
- Exact pushed head: `af097c7c3f3834d3db7193fb563d5a2f014a76e4`.
- `node scripts/run-vitest.mjs extensions/diagnostics-otel/src/service.test.ts`: 157/157 passed.
- `node scripts/run-vitest.mjs extensions/diagnostics-otel/src/service.otlp-export.test.ts`: 83/83 passed, including a real OpenTelemetry SDK/OTLP serialization assertion for integer zero.
- `oxfmt`, targeted type-aware `oxlint`, and `git diff --check`: passed.
- Exact-head P0-P2 autoreview: clean, no accepted/actionable findings, correctness `0.97`.
- Production delta: `+18/-8` (net `+10`); test delta: `+93/-3` (net `+90`).
- Completed and error recorder paths cover explicit zero versus absent usage; cache-only positive usage and explicit prompt-total zero are covered.

Changed-gate caveat: pre-push Blacksmith Testbox proof was unavailable to this session, and the sanitized AWS Crabbox coordinator returned HTTP 500 before command execution; the task-owned lease was released. The local path-scoped fallback passed 15 guards before reaching an unchanged `packages/terminal-core/src/ansi.ts:194` TypeScript error. Exact-head required GitHub CI remains the merge gate.

Dependency inspection:

- OpenAI Codex `aac9f842473ac6a05d417dd76ce8b89bdb3b707d`:
  - `codex-rs/codex-api/src/sse/responses.rs:112-147,437-442,809-834,1158-1175` confirms nullable whole-response usage, zero-valued usage, and cache-write input tokens.
  - `codex-rs/protocol/src/protocol.rs:1820-1827,2055-2111,2260-2268` distinguishes exact raw per-response usage from accumulated usage and defines element-wise accumulation including cache-write input tokens.
  - `codex-rs/app-server-protocol/src/protocol/v2/thread.rs:1508-1518,1541-1569` preserves nullable raw usage and the camel-cased `cacheWriteInputTokens` field.
  - `codex-rs/app-server/src/bespoke_event_handling.rs:1066-1075` forwards nullable raw response usage without synthesizing values.
- Installed OpenTelemetry sources: API `1.9.1`, SDK trace `2.10.0`, OTLP exporter/transformer `0.221.0`.
  - `node_modules/@opentelemetry/sdk-trace/build/src/Span.js:80-103` accepts valid numeric attributes, including zero.
  - `node_modules/@opentelemetry/otlp-transformer/build/src/common/protobuf/common-serializer.js:95-120` serializes integer zero as an OTLP integer value.

AI-assisted with Codex; the maintainer inspected the implementation, callers, sibling dependency source, and proof directly.

<!-- agent-transcript:start -->
## Agent Transcript

<details>
<summary>Redacted Codex session transcript</summary>

```text
source: local Codex session
omitted: system/developer prompts, reasoning, raw tool output, secrets, auth data,
local paths, unrelated turns, and infrastructure identifiers

[user]
Repair PR #100115 from current main. Preserve explicit finite non-negative
model-call usage, including zero; preserve prompt total zero when a prompt
bucket was supplied; keep timing and byte fields positive-only. Cover completed
and error paths, zero versus absent, cache-only usage, and real OTLP output.

[assistant]
The invariant belongs in the diagnostics OTEL attribute projection. Both model
recorder terminal paths already converge there, so aggregate usage, producers,
contracts, config, and CLI behavior stay unchanged.

[assistant]
Implemented one non-negative usage normalizer plus focused recorder and OTLP
coverage. The two focused suites passed 157/157 and 83/83; formatting, targeted
type-aware lint, diff checks, and exact-head P0-P2 autoreview are clean.

[user]
Proceed with publication and landing. Rebase onto current origin/main, replace
the old self-owned branch only with force-with-lease against its exact head,
refresh the PR, request one exact-head ClawSweeper review, wait for CI, and use
the repo-native prepare and squash-merge flow.

[assistant]
Rebased conflict-free onto current main, reconfirmed the unchanged upstream
Codex usage contract, reran exact-head proof, verified the remote head, and
replaced it using the explicit force-with-lease guard.
```

</details>
<!-- agent-transcript:end -->
