### PR TITLE
fix(mcp): suppress unhandled rejection from async gateway event handler

### DIFF
--- a/src/mcp/channel-bridge.test.ts
+++ b/src/mcp/channel-bridge.test.ts
@@ -34,6 +34,10 @@ type BridgeInternals = {
     event: string;
     payload?: Record<string, unknown>;
   }) => Promise<void>;
+  dispatchGatewayEvent: (event: {
+    event: string;
+    payload?: Record<string, unknown>;
+  }) => Promise<void>;
   handleSessionMessageEvent: (payload: {
     sessionKey: string;
     senderIsOwner?: boolean;
@@ -298,6 +302,52 @@ describe("OpenClawChannelBridge — pendingClaudePermissions / pendingApprovals 
       expect(writes).toHaveLength(1);
       expect(writes[0]).toBe("openclaw mcp: notification channel/event failed\n");
       expect(writes[0]).not.toContain("transport closed");
+    } finally {
+      writeSpy.mockRestore();
+      await bridge.close();
+    }
+  });
+
+  test("a rejected gateway event still emits exactly one diagnostic record with verbose off", async () => {
+    const bridge = makeBridge(false);
+    const writes: string[] = [];
+    const writeSpy = vi
+      .spyOn(process.stderr, "write")
+      .mockImplementation((chunk: string | Uint8Array): boolean => {
+        writes.push(String(chunk));
+        return true;
+      });
+    vi.spyOn(bridge, "handleGatewayEvent").mockRejectedValue(new Error("handler boom"));
+    try {
+      await bridge.dispatchGatewayEvent({ event: "exec.approval.requested", payload: {} });
+
+      expect(writes).toHaveLength(1);
+      expect(writes[0]).toBe("openclaw mcp: gateway event exec.approval.requested failed\n");
+      expect(writes[0]).not.toContain("handler boom");
+    } finally {
+      writeSpy.mockRestore();
+      await bridge.close();
+    }
+  });
+
+  test("a rejected gateway event includes error detail with verbose on", async () => {
+    const bridge = makeBridge(true);
+    const writes: string[] = [];
+    const writeSpy = vi
+      .spyOn(process.stderr, "write")
+      .mockImplementation((chunk: string | Uint8Array): boolean => {
+        writes.push(String(chunk));
+        return true;
+      });
+    vi.spyOn(bridge, "handleGatewayEvent").mockRejectedValue(new Error("handler boom"));
+    try {
+      await bridge.dispatchGatewayEvent({ event: "exec.approval.requested", payload: {} });
+
+      expect(writes).toHaveLength(2);
+      expect(writes[0]).toBe("openclaw mcp: gateway event exec.approval.requested failed\n");
+      expect(writes[1]).toBe(
+        "openclaw mcp: gateway event exec.approval.requested error: Error: handler boom\n",
+      );
     } finally {
       writeSpy.mockRestore();
       await bridge.close();

--- a/src/mcp/channel-bridge.ts
+++ b/src/mcp/channel-bridge.ts
@@ -148,7 +148,7 @@ export class OpenClawChannelBridge {
       scopes: [READ_SCOPE, WRITE_SCOPE, APPROVALS_SCOPE],
       requestTimeoutMs: 180_000,
       onEvent: (event) => {
-        void this.handleGatewayEvent(event).catch(() => {});
+        void this.dispatchGatewayEvent(event);
       },
       onHelloOk: () => {
         this.retryingInitialConnect = false;
@@ -518,6 +518,21 @@ export class OpenClawChannelBridge {
     const id = normalizeApprovalId(payload.id);
     if (id) {
       this.pendingApprovals.delete(id);
+    }
+  }
+
+  private async dispatchGatewayEvent(event: EventFrame): Promise<void> {
+    try {
+      await this.handleGatewayEvent(event);
+    } catch (error) {
+      // Always surface a single low-noise record so swallowed gateway event
+      // failures remain observable; the spammy error detail stays behind --verbose.
+      process.stderr.write(`openclaw mcp: gateway event ${event.event} failed\n`);
+      if (this.verbose) {
+        process.stderr.write(
+          `openclaw mcp: gateway event ${event.event} error: ${String(error)}\n`,
+        );
+      }
     }
   }
 

--- a/src/mcp/channel-bridge.ts
+++ b/src/mcp/channel-bridge.ts
@@ -148,7 +148,7 @@ export class OpenClawChannelBridge {
       scopes: [READ_SCOPE, WRITE_SCOPE, APPROVALS_SCOPE],
       requestTimeoutMs: 180_000,
       onEvent: (event) => {
-        void this.handleGatewayEvent(event);
+        void this.handleGatewayEvent(event).catch(() => {});
       },
       onHelloOk: () => {
         this.retryingInitialConnect = false;


### PR DESCRIPTION
## What Problem This Solves

The `onEvent` callback in `OpenClawChannelBridge` calls `void this.handleGatewayEvent(event)` without observing the returned promise. Since `handleGatewayEvent` is async and can reject, this creates an unhandled promise rejection that crashes the MCP gateway process.

## Why This Change Was Made

Contain the async handler rejection and emit a low-noise diagnostic, matching the existing notification-failure observability pattern in the same bridge (`src/mcp/channel-bridge.ts:399`). Failed session or approval events are therefore visible to operators instead of disappearing silently.

## User Impact

Prevents the gateway from crashing when an MCP channel bridge event handler throws, while keeping failures observable.

## Evidence

### Behavior

The `onEvent` callback now delegates to `dispatchGatewayEvent`, which awaits `handleGatewayEvent` inside a `try/catch`. On rejection it writes exactly one stderr record (`openclaw mcp: gateway event <type> failed`), with the full error shown only when `--verbose` is on.

### Source

`src/mcp/channel-bridge.ts:150`
```ts
onEvent: (event) => {
  void this.dispatchGatewayEvent(event);
},
```

`src/mcp/channel-bridge.ts:524`
```ts
private async dispatchGatewayEvent(event: EventFrame): Promise<void> {
  try {
    await this.handleGatewayEvent(event);
  } catch (error) {
    // Always surface a single low-noise record so swallowed gateway event
    // failures remain observable; the spammy error detail stays behind --verbose.
    process.stderr.write(`openclaw mcp: gateway event ${event.event} failed\n`);
    if (this.verbose) {
      process.stderr.write(
        `openclaw mcp: gateway event ${event.event} error: ${String(error)}\n`,
      );
    }
  }
}
```

### Unit test output

```
$ pnpm test -- src/mcp/channel-bridge.test.ts --run
[test] starting test/vitest/vitest.unit.config.ts
 ✓ |unit| src/mcp/channel-bridge.test.ts (18 tests) 154ms

 Test Files  1 passed (1)
      Tests  18 passed (18)
   Duration  1.12s

[test] passed 1 Vitest shard in 10.50s
```

### Real runtime proof

I ran a real OpenClaw MCP bridge against the local gateway (`ws://127.0.0.1:18789`) and forced `handleGatewayEvent` to reject for `session.message` events. The bridge stayed alive and emitted the expected diagnostic on stderr:

```
openclaw mcp: gateway event session.message failed
openclaw mcp: gateway event session.message error: Error: injected proof rejection
openclaw mcp: gateway event session.message failed
openclaw mcp: gateway event session.message error: Error: injected proof rejection
openclaw mcp: gateway event session.message failed
openclaw mcp: gateway event session.message error: Error: injected proof rejection
```

The injection was removed before committing; the committed code only logs real failures.

### Regression coverage

- `a rejected gateway event still emits exactly one diagnostic record with verbose off`
- `a rejected gateway event includes error detail with verbose on`

Both tests force `handleGatewayEvent` to reject, call `dispatchGatewayEvent`, and assert the exact stderr output shape while confirming the error detail is redacted unless verbose is enabled.