### PR TITLE
fix(tui): isolate embedded event listener failures

### DIFF
--- a/src/tui/embedded-backend.test.ts
+++ b/src/tui/embedded-backend.test.ts
@@ -2,6 +2,7 @@
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { isEmbeddedMode, setEmbeddedMode } from "../infra/embedded-mode.js";
 import { defaultRuntime } from "../runtime.js";
+import { notifyListeners } from "../shared/listeners.js";
 import { withEnvAsync } from "../test-utils/env.js";
 
 const agentCommandFromIngressMock = vi.fn();
@@ -238,6 +239,12 @@ async function flushMicrotasks() {
   await Promise.resolve();
 }
 
+function emitRegisteredAgentEvent(evt: unknown) {
+  if (registeredListener) {
+    notifyListeners([registeredListener], evt);
+  }
+}
+
 describe("EmbeddedTuiBackend", () => {
   const originalRuntimeLog = defaultRuntime.log;
   const originalRuntimeError = defaultRuntime.error;
@@ -414,6 +421,40 @@ describe("EmbeddedTuiBackend", () => {
         },
       },
     ]);
+  });
+
+  it("isolates TUI event consumer failures in the agent event bus", async () => {
+    const { EmbeddedTuiBackend } = await import("./embedded-backend.js");
+    const pending = deferred<{
+      payloads: Array<{ text: string }>;
+      meta: Record<string, unknown>;
+    }>();
+    agentCommandFromIngressMock.mockReturnValueOnce(pending.promise);
+
+    const backend = new EmbeddedTuiBackend();
+    backend.onEvent = () => {
+      throw new Error("render failed");
+    };
+    backend.start();
+    await backend.sendChat({
+      sessionKey: "agent:main:main",
+      message: "hello",
+      runId: "run-listener-error",
+    });
+
+    expect(() =>
+      emitRegisteredAgentEvent({
+        runId: "run-listener-error",
+        stream: "assistant",
+        data: { text: "hello", delta: "hello" },
+      }),
+    ).not.toThrow();
+    await flushMicrotasks();
+
+    backend.onEvent = undefined;
+    pending.resolve({ payloads: [{ text: "hello" }], meta: {} });
+    await flushMicrotasks();
+    await backend.stop();
   });
 
   it("lists configured replace-mode models without loading the gateway catalog", async () => {

--- a/src/tui/embedded-backend.ts
+++ b/src/tui/embedded-backend.ts
@@ -322,7 +322,7 @@ export class EmbeddedTuiBackend implements TuiBackend {
     defaultRuntime.log = silentRuntime.log;
     defaultRuntime.error = silentRuntime.error;
     this.unsubscribe = onAgentEvent((evt) => {
-      void this.handleAgentEvent(evt);
+      void this.handleAgentEvent(evt).catch(() => {});
     });
     // Local mode never runs gateway startup; canonicalize orphaned keys once here.
     this.ready = (async () => {

--- a/src/tui/embedded-backend.ts
+++ b/src/tui/embedded-backend.ts
@@ -321,9 +321,8 @@ export class EmbeddedTuiBackend implements TuiBackend {
     this.previousRuntimeError = defaultRuntime.error;
     defaultRuntime.log = silentRuntime.log;
     defaultRuntime.error = silentRuntime.error;
-    this.unsubscribe = onAgentEvent((evt) => {
-      void this.handleAgentEvent(evt).catch(() => {});
-    });
+    // Keep this synchronous so the shared event bus can isolate listener failures.
+    this.unsubscribe = onAgentEvent((evt) => this.handleAgentEvent(evt));
     // Local mode never runs gateway startup; canonicalize orphaned keys once here.
     this.ready = (async () => {
       const { runSessionStartupMigration } =
@@ -1022,7 +1021,7 @@ export class EmbeddedTuiBackend implements TuiBackend {
     });
   }
 
-  private async handleAgentEvent(evt: AgentEventPayload) {
+  private handleAgentEvent(evt: AgentEventPayload) {
     const run = this.runs.get(evt.runId);
     if (!run) {
       return;


### PR DESCRIPTION
## What Problem This Solves

`EmbeddedTuiBackend.handleAgentEvent` was declared `async` even though it contains no asynchronous work. When a TUI event consumer threw synchronously, that unnecessary `async` boundary converted the error into a rejected promise; the fire-and-forget agent-event callback did not observe it, so Node could terminate the TUI for an unhandled rejection.

## Why This Change Was Made

Keep the embedded event handler synchronous and call it directly from `onAgentEvent`. This restores the existing shared event-bus contract: `notifyListeners` isolates synchronous listener failures while continuing to notify other consumers. A focused regression injects a throwing TUI consumer through the real shared listener helper.

This supersedes the original noop `.catch()` suggestion. Removing the redundant async boundary fixes the root cause, preserves event ordering, and reduces production code instead of adding a silent catch path.

## User Impact

Embedded/local TUI sessions no longer risk a process-level unhandled rejection when a TUI event consumer throws. Normal agent, chat, lifecycle, and local PTY behavior remains unchanged.

## Evidence

### Focused regression

```text
$ node scripts/run-vitest.mjs src/tui/embedded-backend.test.ts
Test Files  1 passed (1)
Tests       43 passed (43)
```

The new regression starts a local run, routes an assistant event through `notifyListeners`, injects a throwing `backend.onEvent` consumer, and verifies the event bus contains the failure.

### Local TUI PTY

```text
$ OPENCLAW_TUI_PTY_INCLUDE_LOCAL=1 node scripts/run-vitest.mjs run --config test/vitest/vitest.tui-pty.config.ts
Test Files  2 passed (2)
Tests       17 passed (17)
```

This includes the slower `tui --local` smoke, with only the external model endpoint mocked.

### Non-test runtime injection

Ran the real source backend and global agent-event bus outside Vitest with Node's strict unhandled-rejection mode. The harness installed an active embedded run, made `backend.onEvent` throw, emitted an assistant event through `emitAgentEvent`, waited one event-loop turn, and then stopped the backend.

```text
$ node --unhandled-rejections=strict --import tsx --input-type=module -e '<runtime injection>'
TUI_EVENT_FAILURE_CONTAINED process_alive=true
EXIT_CODE=0
```

Without the synchronous repair, the thrown consumer error crosses the unnecessary async boundary as a rejected promise and strict Node exits nonzero. With this branch, the process remains alive because `notifyListeners` contains the synchronous listener failure.

### Review

```text
$ .agents/skills/autoreview/scripts/autoreview --mode local --stream-engine-output
autoreview clean: no accepted/actionable findings reported
overall: patch is correct (0.97)
```

### Broad changed gate

Testbox-through-Crabbox provider `blacksmith-testbox`:

- Testbox: `tbx_01kwqyrrwwfn8tdnw4ajh48rd8`
- Actions: https://github.com/openclaw/openclaw/actions/runs/28725873865
- Command: `OPENCLAW_CHECK_CHANGED_REMOTE_CHILD=1 OPENCLAW_CHANGED_LANES_RAW_SYNC=1 pnpm check:changed`
- Result: core + coreTests typechecks, changed-file lint, import-cycle and repository guards passed; exit 0.

### Scope

- Production: `src/tui/embedded-backend.ts` (net -1 line)
- Regression: `src/tui/embedded-backend.test.ts`
- No config, protocol, dependency, storage, or public API changes.
