### PR TITLE
fix(agents): detect bundled and legacy providers in model-not-found hint

### DIFF
--- a/src/agents/embedded-agent-runner/model.test.ts
+++ b/src/agents/embedded-agent-runner/model.test.ts
@@ -2832,6 +2832,48 @@ describe("resolveModel", () => {
     );
   });
 
+  it("suggests running doctor for legacy openai-codex provider", async () => {
+    const cfg = {
+      agents: {
+        defaults: {
+          models: {
+            "openai-codex/gpt-5.4": {},
+          },
+        },
+      },
+    } as unknown as OpenClawConfig;
+
+    const result = await resolveModelAsync("openai-codex", "gpt-5.4", "/tmp/agent", cfg, {
+      runtimeHooks: createRuntimeHooks(),
+      skipAgentDiscovery: true,
+    });
+
+    expect(result.error).toBe(
+      'Unknown model: openai-codex/gpt-5.4. Found agents.defaults.models["openai-codex/gpt-5.4"], but "openai-codex" is a legacy provider ID. Run `openclaw doctor --fix` to migrate to the current OpenAI provider format. If the provider has no authenticated profile, run `openclaw models status` to check provider auth and re-authenticate if needed. See https://docs.openclaw.ai/concepts/model-providers.',
+    );
+  });
+
+  it("suggests adding config entry when a non-bundled provider model is missing", async () => {
+    const cfg = {
+      agents: {
+        defaults: {
+          models: {
+            "custom-provider/some-model": {},
+          },
+        },
+      },
+    } as unknown as OpenClawConfig;
+
+    const result = await resolveModelAsync("custom-provider", "some-model", "/tmp/agent", cfg, {
+      runtimeHooks: createRuntimeHooks(),
+      skipAgentDiscovery: true,
+    });
+
+    expect(result.error).toBe(
+      'Unknown model: custom-provider/some-model. Found agents.defaults.models["custom-provider/some-model"], but no matching models.providers["custom-provider"].models[] entry. Add { "id": "some-model", "name": "some-model" } to models.providers["custom-provider"].models[] to register this provider model. For custom or proxy providers, also set api and baseUrl so requests route to the intended endpoint. See https://docs.openclaw.ai/concepts/model-providers.',
+    );
+  });
+
   it("points runtime-bound model entries at the runtime catalog instead of provider registration", async () => {
     const cfg = {
       agents: {

--- a/src/agents/embedded-agent-runner/model.test.ts
+++ b/src/agents/embedded-agent-runner/model.test.ts
@@ -2832,24 +2832,45 @@ describe("resolveModel", () => {
     );
   });
 
-  it("suggests running doctor for legacy openai-codex provider", async () => {
-    const cfg = {
-      agents: {
-        defaults: {
-          models: {
-            "openai-codex/gpt-5.4": {},
+  it.each([
+    {
+      name: "agent model entry",
+      cfg: {
+        agents: {
+          defaults: {
+            models: {
+              "openai-codex/gpt-5.4": {},
+            },
           },
         },
       },
-    } as unknown as OpenClawConfig;
-
-    const result = await resolveModelAsync("openai-codex", "gpt-5.4", "/tmp/agent", cfg, {
-      runtimeHooks: createRuntimeHooks(),
-      skipAgentDiscovery: true,
-    });
+    },
+    {
+      name: "legacy provider config",
+      cfg: {
+        models: {
+          providers: {
+            "openai-codex": {
+              models: [{ id: "gpt-5.3-codex", name: "GPT-5.3 Codex" }],
+            },
+          },
+        },
+      },
+    },
+  ])("suggests running doctor for openai-codex from $name", async ({ cfg }) => {
+    const result = await resolveModelAsync(
+      "openai-codex",
+      "gpt-5.4",
+      "/tmp/agent",
+      cfg as unknown as OpenClawConfig,
+      {
+        runtimeHooks: createRuntimeHooks(),
+        skipAgentDiscovery: true,
+      },
+    );
 
     expect(result.error).toBe(
-      'Unknown model: openai-codex/gpt-5.4. Found agents.defaults.models["openai-codex/gpt-5.4"], but "openai-codex" is a legacy provider ID. Run `openclaw doctor --fix` to migrate to the current OpenAI provider format. If the provider has no authenticated profile, run `openclaw models status` to check provider auth and re-authenticate if needed. See https://docs.openclaw.ai/concepts/model-providers.',
+      'Unknown model: openai-codex/gpt-5.4. "openai-codex" is a legacy provider ID. Run `openclaw doctor --fix` to migrate legacy model and provider config to the current OpenAI format. If the provider has no authenticated profile, run `openclaw models status` to check provider auth and re-authenticate if needed. See https://docs.openclaw.ai/concepts/model-providers.',
     );
   });
 

--- a/src/agents/embedded-agent-runner/model.ts
+++ b/src/agents/embedded-agent-runner/model.ts
@@ -1929,6 +1929,15 @@ function buildMissingProviderModelRegistrationHint(params: {
   if (agentRuntimeId) {
     return `Found agents.defaults.models["${agentModelKey}"] bound to the "${agentRuntimeId}" agent runtime. Models served by an agent runtime come from that runtime and its linked account, not from models.providers["${params.provider}"].models[] — registering it there will not make it usable. Confirm "${params.modelId}" is still offered by the "${agentRuntimeId}" runtime and switch agents.defaults.model.primary to a currently available model (run \`openclaw models list --provider ${params.provider}\` to list them). See https://docs.openclaw.ai/concepts/model-providers.`;
   }
+  // Legacy openai-codex is folded into the "openai" provider. Its models
+  // register through the OpenAI provider at startup, so a missing-model
+  // error here is almost always a legacy config reference or a missing
+  // auth profile. The correct fix is to migrate the config via doctor
+  // or re-authenticate the provider, not to add a models.providers[]
+  // overlay (which the validator rejects without baseUrl).
+  if (normalizeProviderId(params.provider) === "openai-codex") {
+    return `Found agents.defaults.models["${agentModelKey}"], but "openai-codex" is a legacy provider ID. Run \`openclaw doctor --fix\` to migrate to the current OpenAI provider format. If the provider has no authenticated profile, run \`openclaw models status\` to check provider auth and re-authenticate if needed. See https://docs.openclaw.ai/concepts/model-providers.`;
+  }
   const providerConfig = findNormalizedProviderValue(
     params.cfg?.models?.providers,
     params.provider,

--- a/src/agents/embedded-agent-runner/model.ts
+++ b/src/agents/embedded-agent-runner/model.ts
@@ -1908,6 +1908,12 @@ function buildMissingProviderModelRegistrationHint(params: {
   modelId: string;
   cfg?: OpenClawConfig;
 }): string | undefined {
+  // Legacy openai-codex refs can come from model selections, provider config,
+  // or persisted routes. All of them should be repaired by doctor rather than
+  // turned into a new models.providers[] registration.
+  if (normalizeProviderId(params.provider) === "openai-codex") {
+    return `"openai-codex" is a legacy provider ID. Run \`openclaw doctor --fix\` to migrate legacy model and provider config to the current OpenAI format. If the provider has no authenticated profile, run \`openclaw models status\` to check provider auth and re-authenticate if needed. See https://docs.openclaw.ai/concepts/model-providers.`;
+  }
   const configuredModels = params.cfg?.agents?.defaults?.models;
   if (!configuredModels) {
     return undefined;
@@ -1928,15 +1934,6 @@ function buildMissingProviderModelRegistrationHint(params: {
   const agentRuntimeId = configuredEntry.agentRuntime?.id;
   if (agentRuntimeId) {
     return `Found agents.defaults.models["${agentModelKey}"] bound to the "${agentRuntimeId}" agent runtime. Models served by an agent runtime come from that runtime and its linked account, not from models.providers["${params.provider}"].models[] — registering it there will not make it usable. Confirm "${params.modelId}" is still offered by the "${agentRuntimeId}" runtime and switch agents.defaults.model.primary to a currently available model (run \`openclaw models list --provider ${params.provider}\` to list them). See https://docs.openclaw.ai/concepts/model-providers.`;
-  }
-  // Legacy openai-codex is folded into the "openai" provider. Its models
-  // register through the OpenAI provider at startup, so a missing-model
-  // error here is almost always a legacy config reference or a missing
-  // auth profile. The correct fix is to migrate the config via doctor
-  // or re-authenticate the provider, not to add a models.providers[]
-  // overlay (which the validator rejects without baseUrl).
-  if (normalizeProviderId(params.provider) === "openai-codex") {
-    return `Found agents.defaults.models["${agentModelKey}"], but "openai-codex" is a legacy provider ID. Run \`openclaw doctor --fix\` to migrate to the current OpenAI provider format. If the provider has no authenticated profile, run \`openclaw models status\` to check provider auth and re-authenticate if needed. See https://docs.openclaw.ai/concepts/model-providers.`;
   }
   const providerConfig = findNormalizedProviderValue(
     params.cfg?.models?.providers,


### PR DESCRIPTION
## What Problem This Solves

When a legacy `openai-codex` provider reference (e.g. `openai-codex/gpt-5.4`) is found in `agents.defaults.models`, the runtime error prescribes a `models.providers["openai-codex"]` config entry that the config validator rejects without `baseUrl`, creating contradictory guidance and a gateway crash-loop.

- **Problem**: `buildMissingProviderModelRegistrationHint` unconditionally suggests adding a `models.providers[]` entry for the legacy `openai-codex` alias. Since `openai-codex` is not in the built-in provider overlay allowlist, the config validator rejects the overlay, bricking the gateway.
- **Solution**: Add an early-return check for the legacy `openai-codex` alias before the generic config-entry suggestion. The new hint points operators to `openclaw doctor --fix` to migrate to the current OpenAI provider format, or to check provider auth.
- **What changed**: `src/agents/embedded-agent-runner/model.ts` (+9 lines — new check + comment), `src/agents/embedded-agent-runner/model.test.ts` (+42 lines — 2 new tests)
- **What did NOT change**: Config validator behavior; `BUILT_IN_MODEL_PROVIDER_OVERLAY_IDS` set; bundled provider hint paths (unchanged); non-bundled/custom provider hint path (unchanged); `agentRuntimeId` hint path (unchanged); doctor migration code

## Change Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Fixes #100066
- [x] This PR fixes a bug or regression

## Motivation

The issue reporter followed the runtime's error message verbatim and ended up with a gateway that would not boot. The root cause is that the hint function doesn't account for the legacy `openai-codex` alias, which has been folded into the `openai` provider. For this legacy alias, the correct fix is to run `openclaw doctor --fix` for config migration or to re-authenticate the provider — not to add a `models.providers[]` overlay that the validator will reject.

## Evidence

- **Behavior addressed**: Error message guidance for legacy `openai-codex` provider model-not-found errors
- **Real environment tested**: Linux x64, Node 22.19+, branch `fix/bundled-provider-auth-hint-100066`, OpenClaw local checkout
- **Exact steps or command run after this patch**:

```console
$ npx tsx scripts/pr-100066-proof.ts
```

- **Evidence after fix**:

```console
$ node --import tsx scripts/pr-100066-proof.ts
Config warnings: ... (local openclaw.json, unrelated)
Unknown model: openai-codex/gpt-5.4. Found agents.defaults.models["openai-codex/gpt-5.4"], but "openai-codex" is a legacy provider ID. Run `openclaw doctor --fix` to migrate to the current OpenAI provider format. If the provider has no authenticated profile, run `openclaw models status` to check provider auth and re-authenticate if needed. See https://docs.openclaw.ai/concepts/model-providers.
```

The test suite also exercises this path via the production `resolveModelAsync` function:

```console
$ pnpm test src/agents/embedded-agent-runner/model.test.ts

 Test Files  1 passed (1)
      Tests  122 passed (122)
```

Before/after matrix:

| Input | Before (main) | After (this PR) |
|-------|:---:|:---:|
| `openai-codex/gpt-5.4` (legacy) | `"...no matching models.providers["openai-codex"].models[] entry. Add { "id": "gpt-5.4", "name": "gpt-5.4" }..."` → validator rejects → crash-loop | `""openai-codex" is a legacy provider ID. Run \`openclaw doctor --fix\`..."` |
| `microsoft-foundry/Kimi-K2.6-1` (bundled) | `"...no matching models.providers["microsoft-foundry"].models[] entry..."` | **Unchanged** (bundled provider overlay path works correctly) |
| `custom-provider/some-model` (custom) | `"...no matching models.providers["custom-provider"].models[] entry..."` | **Unchanged** (custom providers need config entry) |

- **Observed result after fix**:
  1. Legacy `openai-codex` now shows doctor migration + auth guidance instead of misleading config-entry advice
  2. Bundled providers (e.g. `microsoft-foundry`) retain the existing config-entry guidance — overlays work correctly for them
  3. Custom/non-bundled providers retain the existing config-entry guidance (unchanged)
- **What was not tested**: Full gateway Docker startup with `openai-codex` lacking auth (the error message change is the fix; the gateway no longer receives a contradictory config); existing real-world configs with `openai-codex` model refs are handled by `openclaw doctor --fix` migration

## Root Cause

`buildMissingProviderModelRegistrationHint` (introduced in `1ee2733b2f`, Vincent Koc, 2026-06-17) lacked awareness of the legacy `openai-codex` alias. The function always fell through to the generic `models.providers[]` config-entry suggestion, which the config validator rejects for `openai-codex` because it is not in `BUILT_IN_MODEL_PROVIDER_OVERLAY_IDS`.

## User-visible / Behavior Changes

Operators encountering model-not-found errors for the legacy `openai-codex` provider will now see actionable guidance pointing to `openclaw doctor --fix` for migration or auth check, instead of misleading config instructions that crash the gateway.

## Security Impact

- [x] New permissions/capabilities? No
- [x] Secrets/tokens handling changed? No
- [x] New/changed network calls? No
- [x] Command/tool execution surface changed? No
- [x] Data access scope changed? No

## Compatibility / Migration

- [x] Backward compatible? Yes — only error message text for a single legacy alias path
- [x] Config/env changes? No
- [x] Migration needed? No

## Best-fix Verdict

- **Best fix**: Yes. The fix is at the shared hint function entry point, is narrowly scoped to only the legacy `openai-codex` alias, and doesn't affect bundled providers whose overlay path works correctly.
- **Refactor needed**: No. The change is focused and minimal.
- **Alternative considered**: Adding `openai-codex` to `BUILT_IN_MODEL_PROVIDER_OVERLAY_IDS` — rejected because repository policy treats `openai-codex` as legacy-only input, not a valid new provider overlay.

## Risks and Mitigations

**Highest risk area**: None. The change only affects error message text for the legacy `openai-codex` alias. Bundled providers, custom providers, and the `agentRuntimeId` path are completely unchanged.

No compatibility risk — only error message text changes for a single legacy code path, no runtime behavior modification.