### PR TITLE
fix(qqbot): channel status keeps reporting connected after the gateway websocket dies

### DIFF
--- a/extensions/qqbot/src/bridge/gateway.ts
+++ b/extensions/qqbot/src/bridge/gateway.ts
@@ -47,6 +47,7 @@ export interface GatewayContext {
   onReady?: (data: unknown) => void;
   onResumed?: (data: unknown) => void;
   onError?: (error: Error) => void;
+  onDisconnected?: (info: { reason?: string; fatal?: boolean }) => void;
   log?: {
     info: (msg: string) => void;
     error: (msg: string) => void;
@@ -143,6 +144,7 @@ export async function startGateway(ctx: GatewayContext): Promise<void> {
     onReady: ctx.onReady,
     onResumed: ctx.onResumed,
     onError: ctx.onError,
+    onDisconnected: ctx.onDisconnected,
     log: accountLogger,
     runtime,
     adapters: createEngineAdapters(),

--- a/extensions/qqbot/src/channel.gateway-status.test.ts
+++ b/extensions/qqbot/src/channel.gateway-status.test.ts
@@ -1,5 +1,5 @@
 // Qqbot tests cover channel gateway status truth on disconnect.
-import type { ChannelAccountSnapshot } from "openclaw/plugin-sdk";
+import type { ChannelAccountSnapshot } from "openclaw/plugin-sdk/channel-contract";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { qqbotPlugin } from "./channel.js";
 import type { ResolvedQQBotAccount } from "./types.js";

--- a/extensions/qqbot/src/channel.gateway-status.test.ts
+++ b/extensions/qqbot/src/channel.gateway-status.test.ts
@@ -1,0 +1,101 @@
+// Qqbot tests cover channel gateway status truth on disconnect.
+import type { ChannelAccountSnapshot } from "openclaw/plugin-sdk";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { qqbotPlugin } from "./channel.js";
+import type { ResolvedQQBotAccount } from "./types.js";
+
+const startGatewayMock = vi.hoisted(() => vi.fn());
+
+vi.mock("./bridge/gateway.js", () => ({
+  startGateway: startGatewayMock,
+}));
+
+type StartGatewayOptions = {
+  onReady?: (data: unknown) => void;
+  onResumed?: (data: unknown) => void;
+  onError?: (error: Error) => void;
+  onDisconnected?: (info: { reason?: string; fatal?: boolean }) => void;
+};
+
+async function startAccountAndCaptureGatewayOptions() {
+  startGatewayMock.mockImplementation(() => new Promise<void>(() => {}));
+  const statusWrites: ChannelAccountSnapshot[] = [];
+  let status: ChannelAccountSnapshot = {
+    accountId: "test-account",
+    running: true,
+    connected: false,
+    lastConnectedAt: null,
+    lastError: null,
+  };
+  const account = {
+    accountId: "test-account",
+    appId: "test-app",
+    clientSecret: "test-secret",
+    enabled: true,
+    markdownSupport: false,
+    config: {},
+    secretSource: "config",
+  } as unknown as ResolvedQQBotAccount;
+  const ctx = {
+    cfg: {},
+    accountId: "test-account",
+    account,
+    runtime: {},
+    abortSignal: new AbortController().signal,
+    getStatus: () => status,
+    setStatus: (next: ChannelAccountSnapshot) => {
+      status = next;
+      statusWrites.push(next);
+    },
+  };
+  const startAccount = qqbotPlugin.gateway?.startAccount;
+  expect(startAccount).toBeDefined();
+  void startAccount?.(ctx as Parameters<NonNullable<typeof startAccount>>[0]);
+  await vi.waitFor(() => {
+    expect(startGatewayMock).toHaveBeenCalled();
+  });
+  const options = startGatewayMock.mock.calls[0]?.[0] as StartGatewayOptions;
+  return { options, statusWrites, getStatus: () => status };
+}
+
+describe("qqbot channel gateway status", () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("marks the account disconnected when the gateway reports a disconnect", async () => {
+    const { options, getStatus } = await startAccountAndCaptureGatewayOptions();
+
+    options.onReady?.({});
+    expect(getStatus().connected).toBe(true);
+
+    expect(options.onDisconnected).toBeDefined();
+    options.onDisconnected?.({ reason: "close code 1006", fatal: false });
+    expect(getStatus().connected).toBe(false);
+    expect(getStatus().running).toBe(true);
+  });
+
+  it("records the close reason as lastError on a fatal disconnect", async () => {
+    const { options, getStatus } = await startAccountAndCaptureGatewayOptions();
+
+    options.onReady?.({});
+    options.onDisconnected?.({ reason: "banned", fatal: true });
+
+    expect(getStatus().connected).toBe(false);
+    // `running` is owned by the gateway lifecycle store: the account task
+    // stays held until an explicit stop/abort, so the plugin must not
+    // flip it here (a Start action would no-op against a held task).
+    expect(getStatus().running).toBe(true);
+    expect(getStatus().lastError).toBe("banned");
+  });
+
+  it("restores connected status when the gateway resumes after a disconnect", async () => {
+    const { options, getStatus } = await startAccountAndCaptureGatewayOptions();
+
+    options.onReady?.({});
+    options.onDisconnected?.({ reason: "close code 1006", fatal: false });
+    options.onResumed?.({});
+
+    expect(getStatus().connected).toBe(true);
+  });
+});

--- a/extensions/qqbot/src/channel.gateway-status.test.ts
+++ b/extensions/qqbot/src/channel.gateway-status.test.ts
@@ -55,7 +55,7 @@ async function startAccountAndCaptureGatewayOptions() {
     expect(startGatewayMock).toHaveBeenCalled();
   });
   const options = startGatewayMock.mock.calls[0]?.[0] as StartGatewayOptions;
-  return { options, statusWrites, getStatus: () => status };
+  return { account, options, statusWrites, getStatus: () => status };
 }
 
 describe("qqbot channel gateway status", () => {
@@ -76,26 +76,43 @@ describe("qqbot channel gateway status", () => {
   });
 
   it("records the close reason as lastError on a fatal disconnect", async () => {
-    const { options, getStatus } = await startAccountAndCaptureGatewayOptions();
+    const { account, options, getStatus } = await startAccountAndCaptureGatewayOptions();
 
     options.onReady?.({});
     options.onDisconnected?.({ reason: "banned", fatal: true });
 
-    expect(getStatus().connected).toBe(false);
+    // connected=false is the shared health monitor's recoverable-disconnect
+    // signal. Fatal closes clear the raw signal so they stay stopped.
+    expect(getStatus().connected).toBeUndefined();
     // `running` is owned by the gateway lifecycle store: the account task
     // stays held until an explicit stop/abort, so the plugin must not
     // flip it here (a Start action would no-op against a held task).
     expect(getStatus().running).toBe(true);
     expect(getStatus().lastError).toBe("banned");
+
+    const publicStatus = await qqbotPlugin.status?.buildAccountSnapshot?.({
+      account,
+      cfg: {},
+      runtime: getStatus(),
+    });
+    expect(publicStatus?.connected).toBe(false);
+    expect(publicStatus?.lastError).toBe("banned");
   });
 
-  it("restores connected status when the gateway resumes after a disconnect", async () => {
+  it("clears fatal errors when the gateway becomes ready or resumes", async () => {
     const { options, getStatus } = await startAccountAndCaptureGatewayOptions();
 
     options.onReady?.({});
-    options.onDisconnected?.({ reason: "close code 1006", fatal: false });
+    options.onDisconnected?.({ reason: "banned", fatal: true });
     options.onResumed?.({});
 
     expect(getStatus().connected).toBe(true);
+    expect(getStatus().lastError).toBeNull();
+
+    options.onDisconnected?.({ reason: "offline/sandbox-only", fatal: true });
+    options.onReady?.({});
+
+    expect(getStatus().connected).toBe(true);
+    expect(getStatus().lastError).toBeNull();
   });
 });

--- a/extensions/qqbot/src/channel.gateway-status.test.ts
+++ b/extensions/qqbot/src/channel.gateway-status.test.ts
@@ -75,15 +75,13 @@ describe("qqbot channel gateway status", () => {
     expect(getStatus().running).toBe(true);
   });
 
-  it("records the close reason as lastError on a fatal disconnect", async () => {
+  it("marks fatal disconnects unhealthy and records the close reason", async () => {
     const { account, options, getStatus } = await startAccountAndCaptureGatewayOptions();
 
     options.onReady?.({});
     options.onDisconnected?.({ reason: "banned", fatal: true });
 
-    // connected=false is the shared health monitor's recoverable-disconnect
-    // signal. Fatal closes clear the raw signal so they stay stopped.
-    expect(getStatus().connected).toBeUndefined();
+    expect(getStatus().connected).toBe(false);
     // `running` is owned by the gateway lifecycle store: the account task
     // stays held until an explicit stop/abort, so the plugin must not
     // flip it here (a Start action would no-op against a held task).

--- a/extensions/qqbot/src/channel.ts
+++ b/extensions/qqbot/src/channel.ts
@@ -362,6 +362,7 @@ export const qqbotPlugin: ChannelPlugin<ResolvedQQBotAccount> = {
             running: true,
             connected: true,
             lastConnectedAt: Date.now(),
+            lastError: null,
           });
           // Snapshot credentials so we can recover from the next hot
           // upgrade that might wipe openclaw.json mid-flight.
@@ -374,6 +375,7 @@ export const qqbotPlugin: ChannelPlugin<ResolvedQQBotAccount> = {
             running: true,
             connected: true,
             lastConnectedAt: Date.now(),
+            lastError: null,
           });
           persistAccountCredentialSnapshot(account);
         },
@@ -388,14 +390,12 @@ export const qqbotPlugin: ChannelPlugin<ResolvedQQBotAccount> = {
           log?.info(
             `[qqbot:${account.accountId}] Gateway disconnected${reason ? `: ${reason}` : ""}`,
           );
-          // Keep channel status honest: the websocket is down, so stop
-          // reporting connected. Fatal closes (banned / offline / retries
-          // exhausted) never reconnect, so surface the reason as lastError.
-          // `running` stays owned by the gateway lifecycle store — the
-          // account task is still held until an explicit stop/abort.
+          // Raw connected=false asks the shared health monitor to recover the
+          // channel. Fatal closes must not enter that restart loop; the status
+          // adapter still projects an absent connection state as disconnected.
           ctx.setStatus({
             ...ctx.getStatus(),
-            connected: false,
+            connected: fatal ? undefined : false,
             ...(fatal && reason ? { lastError: reason } : {}),
           });
         },

--- a/extensions/qqbot/src/channel.ts
+++ b/extensions/qqbot/src/channel.ts
@@ -384,6 +384,21 @@ export const qqbotPlugin: ChannelPlugin<ResolvedQQBotAccount> = {
             lastError: error.message,
           });
         },
+        onDisconnected: ({ reason, fatal }) => {
+          log?.info(
+            `[qqbot:${account.accountId}] Gateway disconnected${reason ? `: ${reason}` : ""}`,
+          );
+          // Keep channel status honest: the websocket is down, so stop
+          // reporting connected. Fatal closes (banned / offline / retries
+          // exhausted) never reconnect, so surface the reason as lastError.
+          // `running` stays owned by the gateway lifecycle store — the
+          // account task is still held until an explicit stop/abort.
+          ctx.setStatus({
+            ...ctx.getStatus(),
+            connected: false,
+            ...(fatal && reason ? { lastError: reason } : {}),
+          });
+        },
       });
     },
     logoutAccount: async ({ accountId, cfg }) => {

--- a/extensions/qqbot/src/channel.ts
+++ b/extensions/qqbot/src/channel.ts
@@ -390,12 +390,12 @@ export const qqbotPlugin: ChannelPlugin<ResolvedQQBotAccount> = {
           log?.info(
             `[qqbot:${account.accountId}] Gateway disconnected${reason ? `: ${reason}` : ""}`,
           );
-          // Raw connected=false asks the shared health monitor to recover the
-          // channel. Fatal closes must not enter that restart loop; the status
-          // adapter still projects an absent connection state as disconnected.
+          // Keep the raw lifecycle snapshot truthful so readiness and the shared
+          // health monitor see the failed transport. QQBot's fatal flag only
+          // suppresses its immediate reconnect policy.
           ctx.setStatus({
             ...ctx.getStatus(),
-            connected: fatal ? undefined : false,
+            connected: false,
             ...(fatal && reason ? { lastError: reason } : {}),
           });
         },

--- a/extensions/qqbot/src/engine/gateway/gateway-connection.test.ts
+++ b/extensions/qqbot/src/engine/gateway/gateway-connection.test.ts
@@ -170,6 +170,10 @@ describe("GatewayConnection disconnect status", () => {
     // replacement is scheduled, then becomes live.
     staleWs.emit("open");
     staleWs.emit("message", JSON.stringify({ op: 7 }));
+    expect(onDisconnected).toHaveBeenCalledWith({
+      reason: "server requested reconnect",
+      fatal: false,
+    });
     await vi.advanceTimersByTimeAsync(1_100);
     await vi.waitFor(() => {
       expect(createQQWSClientMock).toHaveBeenCalledTimes(2);
@@ -180,7 +184,7 @@ describe("GatewayConnection disconnect status", () => {
     // the live replacement's status.
     staleWs.emit("close", 1000, Buffer.from(""));
 
-    expect(onDisconnected).not.toHaveBeenCalled();
+    expect(onDisconnected).toHaveBeenCalledTimes(1);
     controller.abort();
     await started;
   });
@@ -207,12 +211,32 @@ describe("GatewayConnection disconnect status", () => {
 
     staleWs.emit("open");
     staleWs.emit("message", JSON.stringify({ op: 7 }));
+    expect(onDisconnected).toHaveBeenCalledWith({
+      reason: "server requested reconnect",
+      fatal: false,
+    });
     staleWs.emit("close", 1006, Buffer.from(""));
 
-    expect(onDisconnected).not.toHaveBeenCalled();
+    expect(onDisconnected).toHaveBeenCalledTimes(1);
     await vi.advanceTimersByTimeAsync(1_100);
     await vi.waitFor(() => {
       expect(createQQWSClientMock).toHaveBeenCalledTimes(2);
+    });
+
+    controller.abort();
+    await started;
+  });
+
+  it("reports a disconnect when the server invalidates the session", async () => {
+    const onDisconnected = vi.fn();
+    const { ws, controller, started } = await startConnection({ onDisconnected });
+
+    ws.emit("open");
+    ws.emit("message", JSON.stringify({ op: 9, d: false }));
+
+    expect(onDisconnected).toHaveBeenCalledWith({
+      reason: "session invalidated",
+      fatal: false,
     });
 
     controller.abort();

--- a/extensions/qqbot/src/engine/gateway/gateway-connection.test.ts
+++ b/extensions/qqbot/src/engine/gateway/gateway-connection.test.ts
@@ -79,6 +79,7 @@ async function startConnection(params: { onDisconnected?: (info: unknown) => voi
 describe("GatewayConnection disconnect status", () => {
   beforeEach(() => {
     vi.useFakeTimers();
+    createQQWSClientMock.mockReset();
   });
 
   afterEach(() => {
@@ -110,14 +111,32 @@ describe("GatewayConnection disconnect status", () => {
 
   it("reports a fatal disconnect when reconnect attempts are exhausted", async () => {
     const onDisconnected = vi.fn();
-    const { ws, controller, started } = await startConnection({ onDisconnected });
+    const sockets = Array.from({ length: MAX_RECONNECT_ATTEMPTS + 1 }, () => new FakeWebSocket());
+    let socketIndex = 0;
+    createQQWSClientMock.mockImplementation(async () => sockets[socketIndex++]);
+    const controller = new AbortController();
+    const connection = new GatewayConnection({
+      account: makeAccount(),
+      abortSignal: controller.signal,
+      cfg: {},
+      runtime: {} as GatewayPluginRuntime,
+      adapters: {} as EngineAdapters,
+      handleMessage: async () => {},
+      onDisconnected,
+    });
+    const started = connection.start();
+    await vi.waitFor(() => {
+      expect(createQQWSClientMock).toHaveBeenCalledTimes(1);
+    });
 
-    // Each close consumes one reconnect attempt without ever reconnecting
-    // (fake timers never fire the scheduled connect), so the attempt
-    // counter reaches the cap and the next close gives up permanently.
-    for (let attempt = 0; attempt <= MAX_RECONNECT_ATTEMPTS; attempt++) {
-      ws.emit("close", 1006, Buffer.from(""));
+    for (let attempt = 0; attempt < MAX_RECONNECT_ATTEMPTS; attempt++) {
+      sockets[attempt].emit("close", 1006, Buffer.from(""));
+      await vi.runOnlyPendingTimersAsync();
+      await vi.waitFor(() => {
+        expect(createQQWSClientMock).toHaveBeenCalledTimes(attempt + 2);
+      });
     }
+    sockets[MAX_RECONNECT_ATTEMPTS].emit("close", 1006, Buffer.from(""));
 
     expect(onDisconnected).toHaveBeenCalledWith({
       reason: "reconnect attempts exhausted",
@@ -162,6 +181,40 @@ describe("GatewayConnection disconnect status", () => {
     staleWs.emit("close", 1000, Buffer.from(""));
 
     expect(onDisconnected).not.toHaveBeenCalled();
+    controller.abort();
+    await started;
+  });
+
+  it("ignores a stale close while a server-driven reconnect is pending", async () => {
+    const onDisconnected = vi.fn();
+    const staleWs = new FakeWebSocket();
+    const replacementWs = new FakeWebSocket();
+    createQQWSClientMock.mockResolvedValueOnce(staleWs).mockResolvedValueOnce(replacementWs);
+    const controller = new AbortController();
+    const connection = new GatewayConnection({
+      account: makeAccount(),
+      abortSignal: controller.signal,
+      cfg: {},
+      runtime: {} as GatewayPluginRuntime,
+      adapters: {} as EngineAdapters,
+      handleMessage: async () => {},
+      onDisconnected,
+    });
+    const started = connection.start();
+    await vi.waitFor(() => {
+      expect(createQQWSClientMock).toHaveBeenCalledTimes(1);
+    });
+
+    staleWs.emit("open");
+    staleWs.emit("message", JSON.stringify({ op: 7 }));
+    staleWs.emit("close", 1006, Buffer.from(""));
+
+    expect(onDisconnected).not.toHaveBeenCalled();
+    await vi.advanceTimersByTimeAsync(1_100);
+    await vi.waitFor(() => {
+      expect(createQQWSClientMock).toHaveBeenCalledTimes(2);
+    });
+
     controller.abort();
     await started;
   });

--- a/extensions/qqbot/src/engine/gateway/gateway-connection.test.ts
+++ b/extensions/qqbot/src/engine/gateway/gateway-connection.test.ts
@@ -1,0 +1,140 @@
+// Qqbot tests cover gateway connection close/disconnect status behavior.
+import { EventEmitter } from "node:events";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { EngineAdapters } from "../adapter/index.js";
+import { MAX_RECONNECT_ATTEMPTS } from "./constants.js";
+import { GatewayConnection } from "./gateway-connection.js";
+import type { GatewayAccount, GatewayPluginRuntime } from "./types.js";
+
+const createQQWSClientMock = vi.hoisted(() => vi.fn());
+
+vi.mock("./ws-client.js", () => ({
+  createQQWSClient: createQQWSClientMock,
+}));
+
+vi.mock("../messaging/sender.js", () => ({
+  getAccessToken: vi.fn(async () => "test-token"),
+  getGatewayUrl: vi.fn(async () => "wss://mock-gateway"),
+  getPluginUserAgent: vi.fn(() => "test-agent"),
+  startBackgroundTokenRefresh: vi.fn(),
+  stopBackgroundTokenRefresh: vi.fn(),
+  clearTokenCache: vi.fn(),
+}));
+
+vi.mock("../session/session-store.js", () => ({
+  loadSession: vi.fn(() => undefined),
+  saveSession: vi.fn(),
+  clearSession: vi.fn(),
+}));
+
+vi.mock("../session/known-users.js", () => ({
+  recordKnownUser: vi.fn(),
+  flushKnownUsers: vi.fn(),
+}));
+
+vi.mock("../ref/store.js", () => ({
+  flushRefIndex: vi.fn(),
+}));
+
+vi.mock("../commands/slash-command-handler.js", () => ({
+  trySlashCommand: vi.fn(async () => "enqueue"),
+}));
+
+class FakeWebSocket extends EventEmitter {
+  readyState = 3; // CLOSED — keeps cleanup() from re-entering close()
+  close = vi.fn();
+  send = vi.fn();
+}
+
+function makeAccount(): GatewayAccount {
+  return {
+    accountId: "test-account",
+    appId: "test-app",
+    clientSecret: "test-secret",
+    markdownSupport: false,
+    config: {},
+  };
+}
+
+async function startConnection(params: { onDisconnected?: (info: unknown) => void }) {
+  const ws = new FakeWebSocket();
+  createQQWSClientMock.mockResolvedValue(ws);
+  const controller = new AbortController();
+  const connection = new GatewayConnection({
+    account: makeAccount(),
+    abortSignal: controller.signal,
+    cfg: {},
+    runtime: {} as GatewayPluginRuntime,
+    adapters: {} as EngineAdapters,
+    handleMessage: async () => {},
+    onDisconnected: params.onDisconnected,
+  });
+  const started = connection.start();
+  await vi.waitFor(() => {
+    expect(createQQWSClientMock).toHaveBeenCalled();
+  });
+  return { ws, controller, started };
+}
+
+describe("GatewayConnection disconnect status", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.clearAllMocks();
+  });
+
+  it("reports a fatal disconnect when the close code says the bot is banned", async () => {
+    const onDisconnected = vi.fn();
+    const { ws, controller, started } = await startConnection({ onDisconnected });
+
+    ws.emit("close", 4915, Buffer.from(""));
+
+    expect(onDisconnected).toHaveBeenCalledWith({ reason: "banned", fatal: true });
+    controller.abort();
+    await started;
+  });
+
+  it("reports a non-fatal disconnect on a transient close before reconnecting", async () => {
+    const onDisconnected = vi.fn();
+    const { ws, controller, started } = await startConnection({ onDisconnected });
+
+    ws.emit("close", 1006, Buffer.from(""));
+
+    expect(onDisconnected).toHaveBeenCalledWith({ reason: "close code 1006", fatal: false });
+    controller.abort();
+    await started;
+  });
+
+  it("reports a fatal disconnect when reconnect attempts are exhausted", async () => {
+    const onDisconnected = vi.fn();
+    const { ws, controller, started } = await startConnection({ onDisconnected });
+
+    // Each close consumes one reconnect attempt without ever reconnecting
+    // (fake timers never fire the scheduled connect), so the attempt
+    // counter reaches the cap and the next close gives up permanently.
+    for (let attempt = 0; attempt <= MAX_RECONNECT_ATTEMPTS; attempt++) {
+      ws.emit("close", 1006, Buffer.from(""));
+    }
+
+    expect(onDisconnected).toHaveBeenCalledWith({
+      reason: "reconnect attempts exhausted",
+      fatal: true,
+    });
+    controller.abort();
+    await started;
+  });
+
+  it("does not report a disconnect for the close caused by an intentional abort", async () => {
+    const onDisconnected = vi.fn();
+    const { ws, controller, started } = await startConnection({ onDisconnected });
+
+    controller.abort();
+    ws.emit("close", 1000, Buffer.from(""));
+
+    expect(onDisconnected).not.toHaveBeenCalled();
+    await started;
+  });
+});

--- a/extensions/qqbot/src/engine/gateway/gateway-connection.test.ts
+++ b/extensions/qqbot/src/engine/gateway/gateway-connection.test.ts
@@ -127,6 +127,45 @@ describe("GatewayConnection disconnect status", () => {
     await started;
   });
 
+  it("ignores a stale close from a superseded socket after a server-driven reconnect", async () => {
+    const onDisconnected = vi.fn();
+    const staleWs = new FakeWebSocket();
+    const replacementWs = new FakeWebSocket();
+    createQQWSClientMock.mockResolvedValueOnce(staleWs).mockResolvedValueOnce(replacementWs);
+    const controller = new AbortController();
+    const connection = new GatewayConnection({
+      account: makeAccount(),
+      abortSignal: controller.signal,
+      cfg: {},
+      runtime: {} as GatewayPluginRuntime,
+      adapters: {} as EngineAdapters,
+      handleMessage: async () => {},
+      onDisconnected,
+    });
+    const started = connection.start();
+    await vi.waitFor(() => {
+      expect(createQQWSClientMock).toHaveBeenCalledTimes(1);
+    });
+
+    // Server asks for a reconnect: the old socket is torn down and a
+    // replacement is scheduled, then becomes live.
+    staleWs.emit("open");
+    staleWs.emit("message", JSON.stringify({ op: 7 }));
+    await vi.advanceTimersByTimeAsync(1_100);
+    await vi.waitFor(() => {
+      expect(createQQWSClientMock).toHaveBeenCalledTimes(2);
+    });
+    replacementWs.emit("open");
+
+    // The superseded socket's close arrives late; it must not regress
+    // the live replacement's status.
+    staleWs.emit("close", 1000, Buffer.from(""));
+
+    expect(onDisconnected).not.toHaveBeenCalled();
+    controller.abort();
+    await started;
+  });
+
   it("does not report a disconnect for the close caused by an intentional abort", async () => {
     const onDisconnected = vi.fn();
     const { ws, controller, started } = await startConnection({ onDisconnected });

--- a/extensions/qqbot/src/engine/gateway/gateway-connection.ts
+++ b/extensions/qqbot/src/engine/gateway/gateway-connection.ts
@@ -279,6 +279,13 @@ export class GatewayConnection {
       // ---- WebSocket: close ----
       ws.on("close", (code, reason) => {
         log?.info(`WebSocket closed: ${code} ${reason.toString()}`);
+        // A superseded socket (torn down by a server-driven RECONNECT /
+        // INVALID_SESSION) can emit its close after the replacement is
+        // live; reacting again would tear down the new socket and
+        // regress the connected status.
+        if (this.currentWs !== null && this.currentWs !== ws) {
+          return;
+        }
         this.isConnecting = false;
         this.handleClose(code);
       });

--- a/extensions/qqbot/src/engine/gateway/gateway-connection.ts
+++ b/extensions/qqbot/src/engine/gateway/gateway-connection.ts
@@ -35,6 +35,7 @@ interface GatewayConnectionContext {
   onReady?: (data: unknown) => void;
   onResumed?: (data: unknown) => void;
   onError?: (error: Error) => void;
+  onDisconnected?: (info: { reason?: string; fatal?: boolean }) => void;
   handleMessage: (event: QueuedMessage) => Promise<void>;
   onInteraction?: (event: InteractionEvent) => void;
 }
@@ -132,6 +133,11 @@ export class GatewayConnection {
     const { account: _account, log } = this.ctx;
     if (this.isAborted || this.reconnect.isExhausted()) {
       log?.error(`Max reconnect attempts reached or aborted`);
+      // Exhaustion is a permanent give-up: report it as fatal so the
+      // channel status does not keep claiming a live connection.
+      if (!this.isAborted) {
+        this.ctx.onDisconnected?.({ reason: "reconnect attempts exhausted", fatal: true });
+      }
       return;
     }
     if (this.reconnectTimer) {
@@ -346,6 +352,13 @@ export class GatewayConnection {
     }
 
     this.cleanup();
+
+    // Publish the disconnect so channel status stops claiming a live
+    // connection; a fatal close (bot banned / offline) never reconnects.
+    // Abort-driven closes are an intentional stop, not a status change.
+    if (!this.isAborted) {
+      this.ctx.onDisconnected?.({ reason: action.reason, fatal: action.fatal });
+    }
 
     if (action.fatal) {
       return;

--- a/extensions/qqbot/src/engine/gateway/gateway-connection.ts
+++ b/extensions/qqbot/src/engine/gateway/gateway-connection.ts
@@ -279,11 +279,10 @@ export class GatewayConnection {
       // ---- WebSocket: close ----
       ws.on("close", (code, reason) => {
         log?.info(`WebSocket closed: ${code} ${reason.toString()}`);
-        // A superseded socket (torn down by a server-driven RECONNECT /
-        // INVALID_SESSION) can emit its close after the replacement is
-        // live; reacting again would tear down the new socket and
-        // regress the connected status.
-        if (this.currentWs !== null && this.currentWs !== ws) {
+        // cleanup() clears currentWs before a server-driven reconnect. Ignore
+        // the old socket's delayed close both during that gap and after the
+        // replacement is live, or it can reschedule reconnect handling.
+        if (this.currentWs !== ws) {
           return;
         }
         this.isConnecting = false;

--- a/extensions/qqbot/src/engine/gateway/gateway-connection.ts
+++ b/extensions/qqbot/src/engine/gateway/gateway-connection.ts
@@ -254,12 +254,20 @@ export class GatewayConnection {
               break;
 
             case GatewayOp.RECONNECT:
+              this.ctx.onDisconnected?.({
+                reason: "server requested reconnect",
+                fatal: false,
+              });
               this.cleanup();
               this.scheduleReconnect();
               break;
 
             case GatewayOp.INVALID_SESSION: {
               const canResume = d as boolean;
+              this.ctx.onDisconnected?.({
+                reason: canResume ? "session resume rejected" : "session invalidated",
+                fatal: false,
+              });
               if (!canResume) {
                 this.sessionId = null;
                 this.lastSeq = null;

--- a/extensions/qqbot/src/engine/gateway/gateway.ts
+++ b/extensions/qqbot/src/engine/gateway/gateway.ts
@@ -260,6 +260,7 @@ export async function startGateway(ctx: CoreGatewayContext): Promise<void> {
     onReady: ctx.onReady,
     onResumed: ctx.onResumed,
     onError: ctx.onError,
+    onDisconnected: ctx.onDisconnected,
     onInteraction: handleInteraction,
     handleMessage,
   });

--- a/extensions/qqbot/src/engine/gateway/types.ts
+++ b/extensions/qqbot/src/engine/gateway/types.ts
@@ -221,6 +221,12 @@ export interface CoreGatewayContext {
    */
   onResumed?: (data: unknown) => void;
   onError?: (error: Error) => void;
+  /**
+   * Invoked when the gateway websocket closes or permanently stops
+   * (fatal close code / reconnect attempts exhausted). Without this the
+   * channel status keeps reporting the last `connected: true` snapshot.
+   */
+  onDisconnected?: (info: { reason?: string; fatal?: boolean }) => void;
   log?: EngineLogger;
   /** PluginRuntime injected by the framework — same object in both versions. */
   runtime: GatewayPluginRuntime;


### PR DESCRIPTION
**Prompt request:** Make the QQBot channel report `connected: false` (with the close reason for permanent stops) whenever its gateway websocket closes, permanently stops, or exhausts reconnect attempts, while preserving the existing reconnect and lifecycle behavior.

**Proof target:** Show that after a fatal close the channel status flips to `connected: false` with the reason in `lastError`, and that READY and RESUMED still restore `connected: true`.

## What Problem This Solves

Fixes an issue where operators checking `openclaw channels status` (or any consumer of the gateway `channels.status` method) would see a QQBot account reported as `connected: true` even though the gateway websocket was down, including permanently dead states such as a banned or offline bot (close code 4915 = banned, 4914 = offline/sandbox-only) and exhausted reconnect attempts. Every real disconnect now gives readiness and health monitoring the expected `connected: false` failure signal.

## Why This Change Was Made

The QQBot channel only ever wrote `connected: true` (on READY and RESUMED); no close path updated the status. This change adds an `onDisconnected({ reason, fatal })` callback through the QQBot gateway boundary. It does not fire for an intentional stop, and delayed close events from superseded sockets are ignored both while replacement is pending and after it is live. All real closes write raw `connected: false`; fatal closes also record the terminal reason in `lastError`. READY and RESUMED restore `connected: true` and clear stale fatal errors. Server-requested reconnect and invalid-session opcodes publish one recoverable disconnect before retiring the socket; the delayed close is deduplicated. QQBot's fatal flag still suppresses its immediate reconnect policy, the shared monitor remains separately rate-limited, and `running` remains owned by the gateway lifecycle store.

## User Impact

Operators now see truthful QQBot connection state: `connected: false` during reconnect backoff and after a fatal close, with the reason (`banned`, `offline/sandbox-only`, `reconnect attempts exhausted`) surfaced as `lastError`. Readiness no longer reports a fatally disconnected account as healthy, and the shared health monitor can apply its bounded recovery policy.

## Evidence

Current head: `5ac9f1933eda7ddb175da152c78ee4043b7338e1`.

Real behavior proof: redacted `openclaw channels status` terminal output from a real gateway run. A full OpenClaw gateway (production channel manager, QQBot plugin, `channels.status` RPC, real CLI) runs from this branch in an isolated `OPENCLAW_STATE_DIR` with placeholder credentials; a local mock WebSocket server stands in for the QQ platform gateway and speaks the documented protocol frames (HELLO -> IDENTIFY -> READY -> RESUME -> RESUMED -> close codes), and the two QQ HTTP edge modules (token endpoint, REST gateway discovery) are stubbed at module load. Everything else, including the disconnect and status reporting path under review, is unmodified production code. Timeline: connect -> READY, transient close 4000 -> reconnect -> RESUMED, then fatal close 4914 with the mock platform refusing every subsequent session.

Before (base commit `bfffa950d7`), the status stays stale after the fatal close: the bot is permanently offline yet the channel still claims a live connection:

```text
--- channels status (after READY) ---
- QQ Bot default: enabled, configured, running, connected, token:config
--- channels status (after transient close + RESUMED) ---
- QQ Bot default: enabled, configured, running, connected, token:config
--- channels status (after fatal close 4914, mock platform refusing sessions) ---
- QQ Bot default: enabled, configured, running, connected, token:config
```

After (this change), the same timeline reports the truth: RESUMED restores `connected`, and the fatal close surfaces disconnected state plus the close reason:

```text
--- channels status (after READY) ---
- QQ Bot default: enabled, configured, running, connected, token:config
--- channels status (after transient close + RESUMED) ---
- QQ Bot default: enabled, configured, running, connected, token:config
--- channels status (after fatal close 4914, mock platform refusing sessions) ---
- QQ Bot default: enabled, configured, running, disconnected, token:config, health:disconnected, error:offline/sandbox-only
```

Gateway log lines from the same after-run show the new disconnect notifications on the production path (`[qqbot:default] Gateway disconnected: close code 4000`, `[qqbot:default] Gateway disconnected: offline/sandbox-only`). Both transient and fatal transport failures remain visible to raw health/readiness evaluation; QQBot itself only schedules immediate reconnects for recoverable failures.

Failing-first unit tests (fail on the base commit, where no disconnect signal exists; pass with this change):

- `extensions/qqbot/src/engine/gateway/gateway-connection.test.ts`: fatal close 4915 reports `{ reason: "banned", fatal: true }`; a transient close reports non-fatal; reconnect exhaustion reports `{ reason: "reconnect attempts exhausted", fatal: true }`; an intentional abort reports nothing; stale closes from superseded sockets are ignored; server-requested reconnect and invalid-session opcodes each publish exactly one recoverable disconnect.
- `extensions/qqbot/src/channel.gateway-status.test.ts`: transient and fatal raw status both flip to `connected: false`; fatal state records `lastError`; READY and RESUMED restore `connected: true` and clear the error.

Maintainer proof on Blacksmith Testbox `tbx_01kwrv0h5tzbcq6wwhezn9xc64`: full QQBot suite 74 files / 663 tests green; final-head focused status/connection proof 2 files / 10 tests green; path-scoped `pnpm check:changed` for all seven PR files green. Fresh branch autoreview on head `5ac9f1933eda7ddb175da152c78ee4043b7338e1`: no actionable findings. The generated Swift protocol drift that failed the earlier exact-head run was fixed independently on `main` by `1403c64799`, so that redundant repair was dropped during the final rebase.

Known limitation: the capture substitutes a local mock server for the live QQ platform edge (no live QQ credentials are used); close-code interpretation itself is the existing `ReconnectState.handleClose` mapping and is unchanged by this PR.
