### PR TITLE
fix(gateway): dispatch restart continuations after session reload

### DIFF
--- a/src/gateway/server-restart-sentinel.test.ts
+++ b/src/gateway/server-restart-sentinel.test.ts
@@ -2171,7 +2171,7 @@ describe("scheduleRestartSentinelWake", () => {
     expect(mocks.logWarn).not.toHaveBeenCalled();
   });
 
-  it("does not dispatch a queued agentTurn continuation after the session key changes", async () => {
+  it("dispatches a queued agentTurn continuation after the session id changes", async () => {
     const activeEntry: LoadedSessionEntry = {
       cfg: {},
       entry: {
@@ -2219,6 +2219,62 @@ describe("scheduleRestartSentinelWake", () => {
     await scheduleRestartSentinelWake({ deps: {} as never });
 
     expect(mocks.enqueueSessionDelivery).toHaveBeenCalledTimes(1);
+    expect(mocks.recordInboundSessionAndDispatchReply).toHaveBeenCalledTimes(1);
+    expectContinuationDispatchFields(
+      { routeSessionKey: "agent:main:main" },
+      { Body: "continue after restart" },
+    );
+    expect(mocks.enqueueSystemEvent).not.toHaveBeenCalled();
+    expect(mocks.requestHeartbeat).not.toHaveBeenCalled();
+    expect(mocks.logWarn).not.toHaveBeenCalledWith(
+      "restart continuation skipped: session changed",
+      expect.anything(),
+    );
+  });
+
+  it("falls back to a session wake when the queued continuation session disappears", async () => {
+    const activeEntry: LoadedSessionEntry = {
+      cfg: {},
+      entry: {
+        sessionId: "old-session-id",
+        updatedAt: Date.now(),
+      },
+      store: {},
+      storePath: "/tmp/sessions.json",
+      canonicalKey: "agent:main:main",
+      storeKeys: ["agent:main:main"],
+      legacyKey: undefined,
+    };
+    const missingEntry: LoadedSessionEntry = {
+      cfg: {},
+      entry: undefined,
+      store: {},
+      storePath: "/tmp/sessions.json",
+      canonicalKey: "agent:main:main",
+      storeKeys: ["agent:main:main"],
+      legacyKey: undefined,
+    };
+    mocks.readRestartSentinel.mockResolvedValue({
+      payload: {
+        sessionKey: "agent:main:main",
+        deliveryContext: {
+          channel: "whatsapp",
+          to: "+15550002",
+          accountId: "acct-2",
+        },
+        threadId: "thread-42",
+        ts: 123,
+        continuation: {
+          kind: "agentTurn",
+          message: "continue after restart",
+        },
+      },
+    } as Awaited<ReturnType<typeof mocks.readRestartSentinel>>);
+    mocks.loadSessionEntry.mockReturnValueOnce(activeEntry).mockReturnValue(missingEntry);
+
+    await scheduleRestartSentinelWake({ deps: {} as never });
+
+    expect(mocks.enqueueSessionDelivery).toHaveBeenCalledTimes(1);
     expect(mocks.recordInboundSessionAndDispatchReply).not.toHaveBeenCalled();
     expect(mocks.enqueueSystemEvent).toHaveBeenCalledWith("continue after restart", {
       sessionKey: "agent:main:main",
@@ -2235,11 +2291,11 @@ describe("scheduleRestartSentinelWake", () => {
       reason: "wake",
       sessionKey: "agent:main:main",
     });
-    expect(mocks.logWarn).toHaveBeenCalledWith("restart continuation skipped: session changed", {
+    expect(mocks.logWarn).toHaveBeenCalledWith("restart continuation skipped: session missing", {
       sessionKey: "agent:main:main",
       queueId: "session-delivery-1",
       expectedSessionId: "old-session-id",
-      actualSessionId: "new-session-id",
+      actualSessionId: null,
     });
   });
 

--- a/src/gateway/server-restart-sentinel.ts
+++ b/src/gateway/server-restart-sentinel.ts
@@ -261,15 +261,12 @@ export async function deliverQueuedSessionDelivery(params: {
     return;
   }
 
-  if (
-    params.entry.expectedSessionId &&
-    (!entry?.sessionId || entry.sessionId !== params.entry.expectedSessionId)
-  ) {
-    log.warn("restart continuation skipped: session changed", {
+  if (params.entry.expectedSessionId && !entry) {
+    log.warn("restart continuation skipped: session missing", {
       sessionKey: canonicalKey,
       queueId: params.entry.id,
       expectedSessionId: params.entry.expectedSessionId,
-      actualSessionId: entry?.sessionId ?? null,
+      actualSessionId: null,
     });
     enqueueRestartSentinelWake(params.entry.message, canonicalKey, queuedDeliveryContext);
     return;


### PR DESCRIPTION
## Bug
`gateway.restart` with `continuationMessage` restarts cleanly, but the typed one-shot continuation never fires afterward. Reproduced 3× on a live deployment (v2026.6.11): sentinel row consumed, no continuation turn in the calling session, and nothing ever reaches `delivery_queue_entries`.

## Root cause
`deliverQueuedSessionDelivery` in `src/gateway/server-restart-sentinel.ts` treated a same-session `sessionId` rotation during gateway reload as "session changed" and demoted every queued continuation to a heartbeat/system-event wake — which heartbeat rules then silently swallow. Since session ids rotate on reload as a matter of course, the skip path fired on effectively every restart.

## Fix
Narrow the skip to sessions whose mapping is actually missing: if the canonical `sessionKey` still resolves and a route exists, dispatch the continuation even when the opaque `sessionId` rotated. Route-less demotion and missing-session wake fallback are preserved.

## Testing
- New test `dispatches a queued agentTurn continuation after the session id changes` — failed before the fix (0 dispatch calls), passes after.
- Full pass: `server-restart-sentinel.test.ts`, `restart-sentinel.test.ts`, `session-delivery-queue.storage.test.ts`, `session-delivery-queue.recovery.test.ts`; typecheck clean on touched configs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)