### PR TITLE
ci: add coverage threshold gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -116,6 +116,7 @@ jobs:
       run_checks_node_core_dist: ${{ steps.manifest.outputs.run_checks_node_core_dist }}
       run_check: ${{ steps.manifest.outputs.run_check }}
       run_check_additional: ${{ steps.manifest.outputs.run_check_additional }}
+      run_coverage: ${{ steps.manifest.outputs.run_coverage }}
       run_check_docs: ${{ steps.manifest.outputs.run_check_docs }}
       run_format_check: ${{ steps.manifest.outputs.run_format_check }}
       compatibility_target: ${{ steps.manifest.outputs.compatibility_target }}
@@ -690,6 +691,7 @@ jobs:
             run_checks_node_core_dist: runNodeCoreDist,
             run_check: runNodeFull,
             run_check_additional: runNodeFull,
+            run_coverage: runNodeFull && eventName !== "pull_request",
             run_check_docs: docsChanged && eventName !== "push",
             run_format_check: runFormatCheck,
             run_control_ui_i18n: runControlUiI18n,
@@ -1921,6 +1923,35 @@ jobs:
             runner="${harness_root}/${runner}"
           fi
           node "$runner"
+
+  # Run the existing coverage-threshold script on trusted default validation.
+  coverage-threshold:
+    permissions:
+      contents: read
+    needs: [preflight]
+    if: needs.preflight.outputs.run_coverage == 'true'
+    runs-on: ${{ github.event_name == 'workflow_dispatch' && 'ubuntu-24.04' || (github.repository == 'openclaw/openclaw' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == 'openclaw/openclaw') && 'blacksmith-16vcpu-ubuntu-2404' || 'ubuntu-24.04') }}
+    timeout-minutes: 20
+    steps:
+      - *linux_node_checkout_step
+      - name: Setup Node environment
+        uses: ./.github/actions/setup-node-env
+        with:
+          install-bun: "false"
+
+      - name: Run coverage threshold gate
+        run: pnpm test:coverage
+
+      - name: Upload coverage report
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: coverage-threshold-report
+          path: |
+            coverage/lcov.info
+            coverage/coverage-final.json
+          if-no-files-found: ignore
+          retention-days: 7
 
   # Types, lint, and format check shards.
   check-shard:
@@ -3264,6 +3295,7 @@ jobs:
       - native-i18n
       - checks-ui
       - control-ui-i18n
+      - coverage-threshold
       - checks-fast-core
       - qa-smoke-ci-profile
       - checks-fast-plugin-contracts-shard
@@ -3296,6 +3328,7 @@ jobs:
             native-i18n=${{ needs.native-i18n.result }}
             checks-ui=${{ needs.checks-ui.result }}
             control-ui-i18n=${{ needs.control-ui-i18n.result }}
+            coverage-threshold=${{ needs.coverage-threshold.result }}
             checks-fast-core=${{ needs.checks-fast-core.result }}
             qa-smoke-ci-profile=${{ needs.qa-smoke-ci-profile.result }}
             checks-fast-plugin-contracts-shard=${{ needs.checks-fast-plugin-contracts-shard.result }}

--- a/test/scripts/ci-workflow-guards.test.ts
+++ b/test/scripts/ci-workflow-guards.test.ts
@@ -1693,6 +1693,33 @@ describe("ci workflow guards", () => {
     }
   });
 
+  it("keeps coverage thresholds on trusted default validation", () => {
+    const workflow = readCiWorkflow();
+    const source = readFileSync(".github/workflows/ci.yml", "utf8");
+    const coverageJob = workflow.jobs["coverage-threshold"];
+
+    expect(workflow.jobs.preflight.outputs.run_coverage).toBe(
+      "${{ steps.manifest.outputs.run_coverage }}",
+    );
+    expect(coverageJob.needs).toEqual(["preflight"]);
+    expect(coverageJob.if).toBe("needs.preflight.outputs.run_coverage == 'true'");
+    expect(
+      coverageJob.steps.some((step: { run?: string }) => step.run === "pnpm test:coverage"),
+    ).toBe(true);
+    expect(source).toContain('run_coverage: runNodeFull && eventName !== "pull_request"');
+
+    const uploadStep = coverageJob.steps.find(
+      (step: { name?: string }) => step.name === "Upload coverage report",
+    );
+    expect(uploadStep.uses).toBe(UPLOAD_ARTIFACT_V7);
+    expect(uploadStep.with).toMatchObject({
+      name: "coverage-threshold-report",
+      "if-no-files-found": "ignore",
+      "retention-days": 7,
+    });
+    expect(uploadStep.with.path).toContain("coverage/lcov.info");
+  });
+
   it("runs real behavior proof from the trusted workflow revision", () => {
     const workflow = readRealBehaviorProofWorkflow();
     const source = readFileSync(".github/workflows/real-behavior-proof.yml", "utf8");
@@ -4026,6 +4053,7 @@ printf '%s\n' "\${CURL_SUCCESS_IP:-203.0.113.7}"
       "native-i18n",
       "checks-ui",
       "control-ui-i18n",
+      "coverage-threshold",
       "checks-fast-core",
       "qa-smoke-ci-profile",
       "checks-fast-plugin-contracts-shard",


### PR DESCRIPTION
## What Problem This Solves

Fixes #90031.

OpenClaw already defines and documents `pnpm test:coverage`, but the trusted default validation graph did not run that V8 coverage-threshold gate. That lets normal validation stay green while the explicit coverage thresholds silently drift out of the default path.

## Why This Change Was Made

This adds a conservative trusted coverage lane for non-PR default validation first, so maintainers get coverage-threshold signal and artifacts without immediately making external PRs pay the extra wall time. The lane calls the existing package script instead of duplicating raw Vitest arguments in workflow YAML, keeping the threshold owner in `package.json` / Vitest config.

## User Impact

Maintainers get a visible `coverage-threshold` check on main/manual default validation for Node-relevant changes, plus downloadable `coverage/lcov.info` / `coverage-final.json` artifacts when produced. Contributors are not hit by the first rollout on pull_request events.

## Evidence

- `pnpm test test/scripts/ci-workflow-guards.test.ts` — passed, 34 tests.
- `pnpm exec oxfmt --check test/scripts/ci-workflow-guards.test.ts .github/workflows/ci.yml` — passed.
- `git diff --check` — passed.
- Diff secret scan — passed: no obvious secret patterns in diff.

## Changes

- Adds `run_coverage` to the CI preflight manifest for trusted non-PR Node validation.
- Adds a `coverage-threshold` job that runs `pnpm test:coverage` and uploads coverage artifacts.
- Adds a workflow guard test to prevent the coverage lane/package-script call from disappearing silently.

## Testing

See Evidence above.

Refs #90031.
