### PR TITLE
fix(agents): preserve spill-file pointers through elision and spill truncated web_fetch output

### DIFF
--- a/src/agents/embedded-agent-runner/tool-result-truncation.test.ts
+++ b/src/agents/embedded-agent-runner/tool-result-truncation.test.ts
@@ -8,6 +8,7 @@ import { SessionManager } from "openclaw/plugin-sdk/agent-sessions";
 import type { AssistantMessage, ToolResultMessage, UserMessage } from "openclaw/plugin-sdk/llm";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { onSessionTranscriptUpdate } from "../../sessions/transcript-events.js";
+import { formatFullOutputFooter } from "../sessions/tools/tool-contracts.js";
 import { makeAgentAssistantMessage } from "../test-helpers/agent-message-fixtures.js";
 
 let truncateToolResultText: typeof import("./tool-result-truncation.js").truncateToolResultText;
@@ -62,7 +63,7 @@ afterEach(async () => {
   }
 });
 
-function makeToolResult(text: string, toolCallId = "call_1"): ToolResultMessage {
+function makeToolResult(text: string, toolCallId = "call_1", details?: unknown): ToolResultMessage {
   // Tool-result fixtures use increasing timestamps so persisted branch rewrites
   // can preserve ordering while changing content.
   return {
@@ -71,8 +72,17 @@ function makeToolResult(text: string, toolCallId = "call_1"): ToolResultMessage 
     toolName: "read",
     content: [{ type: "text", text }],
     isError: false,
+    ...(details !== undefined ? { details } : {}),
     timestamp: nextTimestamp(),
   };
+}
+
+function textWithFullOutputFooter(text: string, fullOutputPath: string): string {
+  return `${text}\n\n[Showing truncated output. ${formatFullOutputFooter(fullOutputPath)}]`;
+}
+
+function realisticSpillPath(dir: string, name: string): string {
+  return path.join(dir, `${name}-${"segment-".repeat(8)}output.log`);
 }
 
 function makeUserMessage(text: string): UserMessage {
@@ -102,6 +112,11 @@ function getFirstToolResultText(message: AgentMessage | ToolResultMessage): stri
 
 async function createTmpDir(): Promise<string> {
   tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "tool-result-truncation-test-"));
+  return tmpDir;
+}
+
+async function createShortTmpDir(): Promise<string> {
+  tmpDir = await fs.mkdtemp(path.join(process.platform === "win32" ? os.tmpdir() : "/tmp", "oc-"));
   return tmpDir;
 }
 
@@ -720,6 +735,188 @@ describe("truncateOversizedToolResultsInMessages", () => {
 
     expect(result.truncatedCount).toBeGreaterThan(0);
     expect(totalChars).toBeLessThanOrEqual(8);
+  });
+
+  it("points aggregate elision at live spill files", async () => {
+    const spillPath = path.join(await createShortTmpDir(), "o");
+    await fs.writeFile(spillPath, "complete command output", { mode: 0o600 });
+    const messages: AgentMessage[] = [
+      makeToolResult(textWithFullOutputFooter("a".repeat(100), spillPath), "spill_1", {
+        fullOutputPath: spillPath,
+      }),
+      makeToolResult("b".repeat(100), "spill_2"),
+      makeToolResult("c".repeat(100), "spill_3"),
+    ];
+
+    const result = truncateOversizedToolResultsInMessages(messages, 128_000, 500, 100);
+    const text = getFirstToolResultText(result.messages[0] ?? makeToolResult(""));
+
+    expect(text).toContain("read");
+    expect(text).toContain(spillPath);
+    await fs.rm(spillPath, { force: true });
+  });
+
+  it("keeps capped spill markers distinct during aggregate elision", async () => {
+    const spillPath = path.join(await createShortTmpDir(), "p");
+    await fs.writeFile(spillPath, "partial web output", { mode: 0o600 });
+    const messages: AgentMessage[] = [
+      makeToolResult(textWithFullOutputFooter("a".repeat(100), spillPath), "partial_spill_1", {
+        fullOutputPath: spillPath,
+        spilledChars: 2_000_000,
+        spillTruncated: true,
+      }),
+      makeToolResult("b".repeat(100), "partial_spill_2"),
+      makeToolResult("c".repeat(100), "partial_spill_3"),
+    ];
+
+    const result = truncateOversizedToolResultsInMessages(messages, 128_000, 300, 100);
+    const text = getFirstToolResultText(result.messages[0] ?? makeToolResult(""));
+
+    expect(text).toContain("partial");
+    expect(text).toContain(spillPath);
+    expect(text).not.toContain("full output preserved");
+    await fs.rm(spillPath, { force: true });
+  });
+
+  it("detects spill footers escaped inside JSON tool results", async () => {
+    const spillPath = path.join(await createShortTmpDir(), "C:\\s");
+    await fs.writeFile(spillPath, "json wrapped output", { mode: 0o600 });
+    const messages: AgentMessage[] = [
+      makeToolResult(
+        JSON.stringify({ text: textWithFullOutputFooter("a".repeat(100), spillPath) }, null, 2),
+        "escaped_spill_1",
+        { fullOutputPath: spillPath },
+      ),
+      makeToolResult("b".repeat(100), "escaped_spill_2"),
+      makeToolResult("c".repeat(100), "escaped_spill_3"),
+    ];
+
+    const result = truncateOversizedToolResultsInMessages(messages, 128_000, 300, 100);
+    const text = getFirstToolResultText(result.messages[0] ?? makeToolResult(""));
+
+    expect(text).toContain("read");
+    expect(text).toContain(spillPath);
+    await fs.rm(spillPath, { force: true });
+  });
+
+  it("falls back to rerun guidance when the spill file is gone", async () => {
+    const dir = await createTmpDir();
+    const spillPath = path.join(dir, "deleted-output.log");
+    await fs.writeFile(spillPath, "complete command output", { mode: 0o600 });
+    await fs.rm(spillPath);
+    const messages: AgentMessage[] = [
+      makeToolResult(textWithFullOutputFooter("a".repeat(100), spillPath), "deleted_spill_1", {
+        fullOutputPath: spillPath,
+      }),
+      makeToolResult("b".repeat(100), "deleted_spill_2"),
+      makeToolResult("c".repeat(100), "deleted_spill_3"),
+    ];
+
+    const result = truncateOversizedToolResultsInMessages(messages, 128_000, 100, 100);
+    const text = getFirstToolResultText(result.messages[0] ?? makeToolResult(""));
+
+    expect(text).toContain("[tool result elided");
+    expect(text).not.toContain(spillPath);
+  });
+
+  it("keeps plain aggregate elision behavior without a spill pointer", () => {
+    const messages: AgentMessage[] = [
+      makeToolResult("a".repeat(100), "plain_1"),
+      makeToolResult("b".repeat(100), "plain_2"),
+      makeToolResult("c".repeat(100), "plain_3"),
+    ];
+
+    const result = truncateOversizedToolResultsInMessages(messages, 128_000, 100, 100);
+    const text = getFirstToolResultText(result.messages[0] ?? makeToolResult(""));
+
+    expect(text).toContain("[tool result elided");
+    expect(text).not.toContain("full output preserved at");
+  });
+
+  it("does not disclose details-only spill paths during aggregate elision", async () => {
+    const spillPath = path.join(await createTmpDir(), "private-output.log");
+    await fs.writeFile(spillPath, "private output", { mode: 0o600 });
+    const messages: AgentMessage[] = [
+      makeToolResult("a".repeat(100), "private_spill_1", { fullOutputPath: spillPath }),
+      makeToolResult("b".repeat(100), "private_spill_2"),
+      makeToolResult("c".repeat(100), "private_spill_3"),
+    ];
+
+    const result = truncateOversizedToolResultsInMessages(messages, 128_000, 100, 100);
+    const text = getFirstToolResultText(result.messages[0] ?? makeToolResult(""));
+
+    expect(text).toContain("[tool result elided");
+    expect(text).not.toContain(spillPath);
+    await fs.rm(spillPath, { force: true });
+  });
+
+  it("floors tiny aggregate elision budgets at compact spill markers", async () => {
+    const dir = await createTmpDir();
+    const spillPath = path.join(dir, "budget-output.log");
+    await fs.writeFile(spillPath, "complete command output", { mode: 0o600 });
+    const messages: AgentMessage[] = [
+      makeToolResult(textWithFullOutputFooter("a".repeat(100), spillPath), "budget_1", {
+        fullOutputPath: spillPath,
+      }),
+      makeToolResult("b".repeat(100), "budget_2"),
+      makeToolResult("c".repeat(100), "budget_3"),
+    ];
+
+    const result = truncateOversizedToolResultsInMessages(messages, 128_000, 1_000, 8);
+    const text = getFirstToolResultText(result.messages[0] ?? makeToolResult(""));
+
+    expect(text).toBe(`[read ${spillPath}]`);
+  });
+
+  it("keeps pointerless near-zero aggregate budgets sliced", () => {
+    const messages: AgentMessage[] = [
+      makeToolResult("a".repeat(100), "sliced_plain_1"),
+      makeToolResult("b".repeat(100), "sliced_plain_2"),
+      makeToolResult("c".repeat(100), "sliced_plain_3"),
+    ];
+
+    const result = truncateOversizedToolResultsInMessages(messages, 128_000, 1_000, 94);
+    const texts = result.messages.map((message) => getFirstToolResultText(message));
+
+    expect(
+      texts.some((text) => text.startsWith("[tool result elided:") && !text.includes("rerun")),
+    ).toBe(true);
+  });
+
+  it("keeps realistic spill pointers intact in near-zero aggregate elision budgets", async () => {
+    const dir = await createTmpDir();
+    const spillPath = realisticSpillPath(dir, "realistic");
+    await fs.writeFile(spillPath, "complete command output", { mode: 0o600 });
+    const messages: AgentMessage[] = [
+      makeToolResult(textWithFullOutputFooter("a".repeat(2_000), spillPath), "realistic_1", {
+        fullOutputPath: spillPath,
+      }),
+      makeToolResult("b".repeat(2_000), "realistic_2"),
+      makeToolResult("c".repeat(2_000), "realistic_3"),
+    ];
+
+    const result = truncateOversizedToolResultsInMessages(messages, 128_000, 5_000, 1);
+    const text = getFirstToolResultText(result.messages[0] ?? makeToolResult(""));
+
+    expect(text).toBe(`[read ${spillPath}]`);
+  });
+
+  it("uses spill-aware aggregate truncation suffixes with realistic paths", async () => {
+    const dir = await createTmpDir();
+    const spillPath = realisticSpillPath(dir, "suffix");
+    await fs.writeFile(spillPath, "complete command output", { mode: 0o600 });
+    const messages: AgentMessage[] = [
+      makeToolResult(textWithFullOutputFooter("a".repeat(5_000), spillPath), "suffix_1", {
+        fullOutputPath: spillPath,
+      }),
+      makeToolResult("b".repeat(5_000), "suffix_2"),
+    ];
+
+    const result = truncateOversizedToolResultsInMessages(messages, 128_000, 8_000, 9_000);
+    const text = getFirstToolResultText(result.messages[0] ?? makeToolResult(""));
+
+    expect(text).toContain(`full output at ${spillPath}`);
+    expect(text).not.toContain("narrow args");
   });
 
   it("does not restore filtered image blocks when reusing a projection", () => {

--- a/src/agents/embedded-agent-runner/tool-result-truncation.ts
+++ b/src/agents/embedded-agent-runner/tool-result-truncation.ts
@@ -1,6 +1,7 @@
 /**
  * Truncates oversized tool-result content in messages and transcripts.
  */
+import { existsSync } from "node:fs";
 import { normalizeLowercaseStringOrEmpty } from "@openclaw/normalization-core/string-coerce";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { formatErrorMessage } from "../../infra/errors.js";
@@ -14,6 +15,7 @@ import {
   resolveSessionWriteLockOptions,
 } from "../session-write-lock.js";
 import { SessionManager } from "../sessions/index.js";
+import { formatFullOutputFooter } from "../sessions/tools/tool-contracts.js";
 import { formatContextLimitTruncationNotice } from "./context-truncation-notice.js";
 import { log } from "./logger.js";
 import {
@@ -411,6 +413,109 @@ function isToolResultTextBlock(
   );
 }
 
+type ToolResultSpillDetails = {
+  fullOutputPath: string;
+  spillTruncated: boolean;
+  spilledChars?: number;
+};
+
+function getToolResultSpillDetails(message: AgentMessage): ToolResultSpillDetails | undefined {
+  const details = (message as { details?: unknown }).details;
+  if (!details || typeof details !== "object" || Array.isArray(details)) {
+    return undefined;
+  }
+  const fullOutputPath = (details as { fullOutputPath?: unknown }).fullOutputPath;
+  if (typeof fullOutputPath !== "string" || fullOutputPath.length === 0) {
+    return undefined;
+  }
+  const spillTruncated = (details as { spillTruncated?: unknown }).spillTruncated === true;
+  const spilledChars = (details as { spilledChars?: unknown }).spilledChars;
+  return {
+    fullOutputPath,
+    spillTruncated,
+    ...(typeof spilledChars === "number" && Number.isFinite(spilledChars)
+      ? { spilledChars: Math.max(0, Math.floor(spilledChars)) }
+      : {}),
+  };
+}
+
+function toolResultTextContainsFullOutputFooter(
+  message: AgentMessage,
+  fullOutputPath: string,
+): boolean {
+  const content = (message as { content?: unknown }).content;
+  if (!Array.isArray(content)) {
+    return false;
+  }
+  const footer = formatFullOutputFooter(fullOutputPath);
+  const escapedFooter = JSON.stringify(footer).slice(1, -1);
+  return content.some((block: unknown) => {
+    if (!isToolResultTextBlock(block)) {
+      return false;
+    }
+    return block.text.includes(footer) || block.text.includes(escapedFooter);
+  });
+}
+
+type AggregateElisionMarkers = {
+  full: string;
+  compact: string;
+  truncationSuffix: (truncatedChars: number) => string;
+};
+
+function resolveAggregateElisionMarkers(
+  message: AgentMessage,
+): AggregateElisionMarkers | undefined {
+  const spill = getToolResultSpillDetails(message);
+  if (!spill) {
+    return undefined;
+  }
+  // Details alone are not model-visible. Only preserve paths that already
+  // appeared in the original footer, so elision discloses nothing new.
+  if (!toolResultTextContainsFullOutputFooter(message, spill.fullOutputPath)) {
+    return undefined;
+  }
+  // Aggregate elision is a rare recovery path, not a request hot path; one
+  // existence check avoids pointing the model at already-deleted spill files.
+  if (!existsSync(spill.fullOutputPath)) {
+    return undefined;
+  }
+  // The path was already disclosed in the original tool footer; preserving it
+  // here adds no new disclosure and only keeps recovery possible.
+  if (spill.spillTruncated) {
+    const count =
+      spill.spilledChars === undefined ? "capped content" : `first ${spill.spilledChars} chars`;
+    return {
+      full: `[tool result elided: partial output preserved at ${spill.fullOutputPath} (${count}); read it if the output is needed]`,
+      compact: `[partial: ${spill.fullOutputPath}]`,
+      truncationSuffix: (truncatedChars) =>
+        `[... ${Math.max(1, Math.floor(truncatedChars))} chars truncated; partial output at ${spill.fullOutputPath}]`,
+    };
+  }
+  return {
+    full: `[tool result elided: full output preserved at ${spill.fullOutputPath}; read it if the output is needed]`,
+    compact: `[read ${spill.fullOutputPath}]`,
+    truncationSuffix: (truncatedChars) =>
+      `[... ${Math.max(1, Math.floor(truncatedChars))} chars truncated; full output at ${spill.fullOutputPath}]`,
+  };
+}
+
+function formatAggregateElisionText(
+  remainingTextBudget: number,
+  spillMarkers: AggregateElisionMarkers | undefined,
+): string {
+  if (remainingTextBudget <= 0) {
+    return "";
+  }
+  if (spillMarkers?.full && spillMarkers.full.length <= remainingTextBudget) {
+    return spillMarkers.full;
+  }
+  if (spillMarkers?.compact && spillMarkers.compact.length <= remainingTextBudget) {
+    return spillMarkers.compact;
+  }
+  return AGGREGATE_ELISION_MARKER.slice(0, remainingTextBudget);
+}
+
 /**
  * Truncate oversized tool results in an array of messages (in-memory).
  * Returns a new array with truncated messages.
@@ -677,6 +782,7 @@ function getToolResultTextBlocks(message: AgentMessage): string[] {
 
 function buildAggregateToolResultReplacements(params: {
   branch: ToolResultBranchEntry[];
+  spillSourceBranch?: ToolResultBranchEntry[];
   aggregateBudgetChars: number;
   minKeepChars?: number;
   protectTrailingToolResults?: boolean;
@@ -702,6 +808,7 @@ function buildAggregateToolResultReplacements(params: {
       index: item.index,
       entryId: item.entry.id,
       message: item.entry.message,
+      spillSourceMessage: params.spillSourceBranch?.[item.index]?.message ?? item.entry.message,
       textLength: getToolResultTextLength(item.entry.message),
       aggregateEligible: item.entry.aggregateEligible !== false,
       protectedFromAggregateRecovery: protectedEntryIds.has(item.entry.id),
@@ -753,9 +860,12 @@ function buildAggregateToolResultReplacements(params: {
 
     const requestedReduction = Math.min(reducibleChars, remainingReduction);
     const targetChars = Math.max(minTruncatedTextChars, candidate.textLength - requestedReduction);
-    const truncatedMessage = truncateToolResultMessage(candidate.message, targetChars, {
+    const spillMarkers = resolveAggregateElisionMarkers(candidate.spillSourceMessage);
+    const candidateSuffixFactory = spillMarkers?.truncationSuffix ?? suffixFactory;
+    const candidateTargetChars = Math.max(targetChars, candidateSuffixFactory(1).length);
+    const truncatedMessage = truncateToolResultMessage(candidate.message, candidateTargetChars, {
       minKeepChars,
-      suffix: suffixFactory,
+      suffix: candidateSuffixFactory,
     });
     const newLength = getToolResultTextLength(truncatedMessage);
     const actualReduction = Math.max(0, candidate.textLength - newLength);
@@ -778,9 +888,10 @@ function buildAggregateToolResultReplacements(params: {
       const baseMessage = existingReplacement?.message ?? candidate.message;
       const baseTextLength = getToolResultTextLength(baseMessage);
       const targetTextChars = Math.max(0, baseTextLength - remainingReduction);
-      const emptyMessage = clearToolResultText(baseMessage, targetTextChars);
+      const spillMarkers = resolveAggregateElisionMarkers(candidate.spillSourceMessage);
+      const emptyMessage = clearToolResultText(candidate.message, targetTextChars, spillMarkers);
       const actualReduction = Math.max(0, baseTextLength - getToolResultTextLength(emptyMessage));
-      if (actualReduction <= 0) {
+      if (actualReduction <= 0 && !spillMarkers) {
         continue;
       }
       const replacement = { entryId: candidate.entryId, message: emptyMessage };
@@ -822,20 +933,26 @@ function getTrailingToolResultEntryIds(branch: ToolResultBranchEntry[]): Set<str
 function clearToolResultText(
   message: AgentMessage,
   maxTextChars = Number.POSITIVE_INFINITY,
+  resolvedSpillMarkers?: AggregateElisionMarkers,
 ): AgentMessage {
   const content = (message as { content?: unknown }).content;
   if (!Array.isArray(content)) {
     return message;
   }
   let remainingTextBudget = Math.max(0, Math.floor(maxTextChars));
+  const spillMarkers = resolvedSpillMarkers ?? resolveAggregateElisionMarkers(message);
+  if (spillMarkers) {
+    // The pointer is what makes elision recoverable. ~130 chars per entry is
+    // negligible against the 64k+ aggregate floor, and accounting uses actual lengths.
+    remainingTextBudget = Math.max(remainingTextBudget, spillMarkers.compact.length);
+  }
   return {
     ...message,
     content: content.map((block) => {
       if (!isToolResultTextBlock(block)) {
         return block;
       }
-      const replacementText =
-        remainingTextBudget > 0 ? AGGREGATE_ELISION_MARKER.slice(0, remainingTextBudget) : "";
+      const replacementText = formatAggregateElisionText(remainingTextBudget, spillMarkers);
       remainingTextBudget = Math.max(0, remainingTextBudget - replacementText.length);
       return Object.assign({}, block, {
         text: replacementText,
@@ -868,10 +985,14 @@ function buildOversizedToolResultReplacements(params: {
     const replacementMinKeepChars = params.protectedEntryIds?.has(entry.id)
       ? Math.max(minKeepChars, MIN_KEEP_CHARS)
       : minKeepChars;
+    const spillMarkers = resolveAggregateElisionMarkers(msg);
+    const suffixFactory = spillMarkers?.truncationSuffix;
+    const maxChars = Math.max(params.maxChars, suffixFactory?.(1).length ?? 0);
     replacements.push({
       entryId: entry.id,
-      message: truncateToolResultMessage(msg, params.maxChars, {
+      message: truncateToolResultMessage(msg, maxChars, {
         minKeepChars: replacementMinKeepChars,
+        ...(suffixFactory ? { suffix: suffixFactory } : {}),
       }),
     });
   }
@@ -959,6 +1080,7 @@ function buildToolResultReplacementPlan(params: {
   );
   const aggregatePlan = buildAggregateToolResultReplacements({
     branch: oversizedTrimmedBranch,
+    spillSourceBranch: params.branch,
     aggregateBudgetChars: params.aggregateBudgetChars,
     minKeepChars,
     protectTrailingToolResults: params.protectTrailingToolResults,

--- a/src/agents/session-tool-result-guard.tool-result-persist-hook.test.ts
+++ b/src/agents/session-tool-result-guard.tool-result-persist-hook.test.ts
@@ -437,6 +437,8 @@ describe("tool_result_persist hook", () => {
         cwd: "/tmp/".concat("workspace/".repeat(400)),
         name: "oversized fallback command ".repeat(200),
         fullOutputPath: "/tmp/".concat("output/".repeat(400)),
+        spilledChars: 2_000_000,
+        spillTruncated: true,
         aggregated: "x".repeat(120_000),
         tail: "tail ".repeat(800),
         sessions: Array.from({ length: 10 }, (_, i) => ({
@@ -453,6 +455,8 @@ describe("tool_result_persist hook", () => {
     expect(details.persistedDetailsTruncated).toBe(true);
     expect(details.finalDetailsTruncated).toBe(true);
     expect(details.status?.token).toBe("***");
+    expect(details.spilledChars).toBe(2_000_000);
+    expect(details.spillTruncated).toBe(true);
     expect(serialized).not.toContain(tokenValue);
   });
 

--- a/src/agents/session-tool-result-guard.ts
+++ b/src/agents/session-tool-result-guard.ts
@@ -344,7 +344,17 @@ function buildPersistedDetailsFallback(
   }
   if (src) {
     fallback.originalDetailKeys = redactedOriginalDetailKeys(src, redactionConfig);
-    for (const key of ["status", "sessionId", "pid", "exitCode", "exitSignal", "truncated"]) {
+    for (const key of [
+      "status",
+      "sessionId",
+      "pid",
+      "exitCode",
+      "exitSignal",
+      "truncated",
+      "fullOutputPath",
+      "spilledChars",
+      "spillTruncated",
+    ]) {
       const field = src[key];
       if (field !== undefined) {
         fallback[key] = redactPersistedSummaryField(
@@ -470,6 +480,8 @@ function sanitizeToolResultDetailsForPersistence(
     "totalChars",
     "truncated",
     "fullOutputPath",
+    "spilledChars",
+    "spillTruncated",
     "truncation",
   ]) {
     const field = src[key];

--- a/src/agents/sessions/tools/bash.ts
+++ b/src/agents/sessions/tools/bash.ts
@@ -19,7 +19,7 @@ import type { ToolDefinition, ToolRenderResultOptions } from "../extensions/type
 import type { BashOperations } from "./bash-operations.js";
 import { OutputAccumulator } from "./output-accumulator.js";
 import { getTextOutput, invalidArgText, str } from "./render-utils.js";
-import type { BashToolDetails } from "./tool-contracts.js";
+import { formatFullOutputFooter, type BashToolDetails } from "./tool-contracts.js";
 import { wrapToolDefinition } from "./tool-definition-wrapper.js";
 import { DEFAULT_MAX_BYTES, DEFAULT_MAX_LINES, formatSize } from "./truncate.js";
 
@@ -254,7 +254,7 @@ function rebuildBashResultRenderComponent(
   if (truncation?.truncated || fullOutputPath) {
     const warnings: string[] = [];
     if (fullOutputPath) {
-      warnings.push(`Full output: ${fullOutputPath}`);
+      warnings.push(formatFullOutputFooter(fullOutputPath));
     }
     if (truncation?.truncated) {
       if (truncation.truncatedBy === "lines") {
@@ -379,16 +379,20 @@ export function createBashToolDefinition(
         let text = snapshot.content || emptyText;
         let details: BashToolDetails | undefined;
         if (truncation.truncated) {
-          details = { truncation, fullOutputPath: snapshot.fullOutputPath };
+          const fullOutputPath = snapshot.fullOutputPath;
+          if (!fullOutputPath) {
+            throw new Error("Missing full output path for truncated bash output");
+          }
+          details = { truncation, fullOutputPath };
           const startLine = truncation.totalLines - truncation.outputLines + 1;
           const endLine = truncation.totalLines;
           if (truncation.lastLinePartial) {
             const lastLineSize = formatSize(output.getLastLineBytes());
-            text += `\n\n[Showing last ${formatSize(truncation.outputBytes)} of line ${endLine} (line is ${lastLineSize}). Full output: ${snapshot.fullOutputPath}]`;
+            text += `\n\n[Showing last ${formatSize(truncation.outputBytes)} of line ${endLine} (line is ${lastLineSize}). ${formatFullOutputFooter(fullOutputPath)}]`;
           } else if (truncation.truncatedBy === "lines") {
-            text += `\n\n[Showing lines ${startLine}-${endLine} of ${truncation.totalLines}. Full output: ${snapshot.fullOutputPath}]`;
+            text += `\n\n[Showing lines ${startLine}-${endLine} of ${truncation.totalLines}. ${formatFullOutputFooter(fullOutputPath)}]`;
           } else {
-            text += `\n\n[Showing lines ${startLine}-${endLine} of ${truncation.totalLines} (${formatSize(DEFAULT_MAX_BYTES)} limit). Full output: ${snapshot.fullOutputPath}]`;
+            text += `\n\n[Showing lines ${startLine}-${endLine} of ${truncation.totalLines} (${formatSize(DEFAULT_MAX_BYTES)} limit). ${formatFullOutputFooter(fullOutputPath)}]`;
           }
         }
         return { text, details };

--- a/src/agents/sessions/tools/private-temp-file.ts
+++ b/src/agents/sessions/tools/private-temp-file.ts
@@ -5,6 +5,7 @@
  */
 import { randomBytes } from "node:crypto";
 import { createWriteStream, type WriteStream } from "node:fs";
+import { writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
@@ -13,10 +14,20 @@ export function createPrivateTempWriteStream(prefix: string): {
   path: string;
   stream: WriteStream;
 } {
-  const id = randomBytes(8).toString("hex");
-  const filePath = join(tmpdir(), `${prefix}-${id}.log`);
+  const filePath = createPrivateTempFilePath(prefix);
   return {
     path: filePath,
     stream: createWriteStream(filePath, { flags: "wx", mode: 0o600 }),
   };
+}
+
+export async function writePrivateTempFile(prefix: string, content: string): Promise<string> {
+  const filePath = createPrivateTempFilePath(prefix);
+  await writeFile(filePath, content, { flag: "wx", mode: 0o600 });
+  return filePath;
+}
+
+function createPrivateTempFilePath(prefix: string): string {
+  const id = randomBytes(8).toString("hex");
+  return join(tmpdir(), `${prefix}-${id}.log`);
 }

--- a/src/agents/sessions/tools/tool-contracts.ts
+++ b/src/agents/sessions/tools/tool-contracts.ts
@@ -16,6 +16,10 @@ export interface BashToolDetails {
   fullOutputPath?: string;
 }
 
+export function formatFullOutputFooter(path: string): string {
+  return `Full output: ${path}`;
+}
+
 export interface EditToolInput {
   path: string;
   edits: Edit[];

--- a/src/agents/tools/web-fetch.provider-fallback.test.ts
+++ b/src/agents/tools/web-fetch.provider-fallback.test.ts
@@ -1,5 +1,6 @@
 // Provider fallback tests verify web_fetch normalizes third-party fetch output
 // before exposing it to agents or cache entries.
+import { rm } from "node:fs/promises";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../../config/config.js";
 import { withFetchPreconnect } from "../../test-utils/fetch-mock.js";
@@ -89,13 +90,17 @@ describe("web_fetch provider fallback normalization", () => {
       contentType?: string;
       externalContent?: Record<string, unknown>;
       extractor?: string;
+      fullOutputPath?: string;
     };
 
     expect(details.extractor).toBe("custom-provider");
     expect(details.contentType).toBe("text/plain");
-    expect(details.text?.length).toBeLessThanOrEqual(800);
+    expect(
+      details.text?.split("\n\n[Showing truncated web_fetch content.")[0]?.length,
+    ).toBeLessThanOrEqual(800);
     expect(details.text).toContain("Ignore previous instructions");
     expect(details.text).toMatch(/<<<EXTERNAL_UNTRUSTED_CONTENT id="[a-f0-9]{16}">>>/);
+    expect(details.text).toContain(`Full output: ${details.fullOutputPath}`);
     expect(details.title).toContain("Provider Title");
     expect(details.warning).toContain("Provider Warning");
     expect(details.truncated).toBe(true);
@@ -103,6 +108,9 @@ describe("web_fetch provider fallback normalization", () => {
     expect(details.externalContent?.source).toBe("web_fetch");
     expect(details.externalContent?.wrapped).toBe(true);
     expect(details.externalContent?.provider).toBe("firecrawl");
+    if (details.fullOutputPath) {
+      await rm(details.fullOutputPath, { force: true });
+    }
   });
 
   it("keeps requested url and only accepts safe provider finalUrl values", async () => {
@@ -207,13 +215,20 @@ describe("web_fetch provider fallback normalization", () => {
       url: "https://example.com/fallback",
     });
     const details = result?.details as {
+      text?: string;
       wrappedLength?: number;
       externalContent?: Record<string, unknown>;
+      fullOutputPath?: string;
     };
 
     expect(details.wrappedLength).toBeGreaterThan(200);
-    expect(details.wrappedLength).toBeLessThanOrEqual(640);
+    expect(
+      details.text?.split("\n\n[Showing truncated web_fetch content.")[0]?.length,
+    ).toBeLessThanOrEqual(640);
     expect(details.externalContent?.provider).toBe("firecrawl");
+    if (details.fullOutputPath) {
+      await rm(details.fullOutputPath, { force: true });
+    }
     const definitionInput = resolveWebFetchDefinitionMock.mock.calls.at(0)?.[0] as
       | {
           config?: OpenClawConfig;

--- a/src/agents/tools/web-fetch.ts
+++ b/src/agents/tools/web-fetch.ts
@@ -20,6 +20,8 @@ import { createLazyImportLoader } from "../../shared/lazy-promise.js";
 import { isRecord } from "../../utils.js";
 import { extractReadableContent } from "../../web-fetch/content-extractors.runtime.js";
 import { stringEnum } from "../schema/string-enum.js";
+import { writePrivateTempFile } from "../sessions/tools/private-temp-file.js";
+import { formatFullOutputFooter } from "../sessions/tools/tool-contracts.js";
 import { setToolTerminalPresentation } from "../tool-terminal-presentation.js";
 import type { AnyAgentTool } from "./common.js";
 import {
@@ -59,6 +61,7 @@ const WEB_FETCH_PROGRESS_THRESHOLD_MS = 5_000;
 const WEB_FETCH_PROGRESS_TEXT = "Fetching page content...";
 const DEFAULT_ERROR_MAX_CHARS = 4_000;
 const DEFAULT_ERROR_MAX_BYTES = 64_000;
+export const WEB_FETCH_SPILL_MAX_CHARS = 2_000_000;
 const DEFAULT_FETCH_USER_AGENT =
   "Mozilla/5.0 (Macintosh; Intel Mac OS X 14_7_2) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/122.0.0.0 Safari/537.36";
 
@@ -247,15 +250,7 @@ function formatWebFetchTerminalPresentation(result: unknown): { text: string } |
   return { text: lines.join("\n") };
 }
 
-function wrapWebFetchContent(
-  value: string,
-  maxChars: number,
-): {
-  text: string;
-  truncated: boolean;
-  rawLength: number;
-  wrappedLength: number;
-} {
+function wrapWebFetchContent(value: string, maxChars: number): WebFetchWrappedContent {
   if (maxChars <= 0) {
     return { text: "", truncated: true, rawLength: 0, wrappedLength: 0 };
   }
@@ -295,6 +290,62 @@ function wrapWebFetchContent(
     truncated: truncated.truncated,
     rawLength: truncated.text.length,
     wrappedLength: wrappedText.length,
+  };
+}
+
+type WebFetchWrappedContent = {
+  text: string;
+  truncated: boolean;
+  rawLength: number;
+  wrappedLength: number;
+  fullOutputPath?: string;
+  spilledChars?: number;
+  spillTruncated?: boolean;
+};
+
+async function spillWebFetchContent(
+  value: string,
+  wrapped: WebFetchWrappedContent,
+  maxChars: number,
+  sourceTruncated = false,
+): Promise<WebFetchWrappedContent> {
+  if (!wrapped.truncated) {
+    return wrapped;
+  }
+  // maxChars/maxCharsCap bound the model-visible return text. Recoverable spill
+  // uses this fixed file cap so vanished pages can still be read after truncation.
+  const content = value.slice(0, WEB_FETCH_SPILL_MAX_CHARS);
+  const fullOutputPath = await writePrivateTempFile(
+    "openclaw-web-fetch",
+    wrapWebContent(content, "web_fetch"),
+  );
+  const spillCapped = value.length > WEB_FETCH_SPILL_MAX_CHARS;
+  const spillTruncated = sourceTruncated || spillCapped;
+  const spillNote = sourceTruncated
+    ? " Spilled available content from truncated response."
+    : spillCapped
+      ? ` Spilled first ${WEB_FETCH_SPILL_MAX_CHARS} chars.`
+      : "";
+  const fullOutputFooter = formatFullOutputFooter(fullOutputPath);
+  const footer = `\n\n[Showing truncated web_fetch content. ${fullOutputFooter}.${spillNote}]`;
+  const compactFooter = `[${fullOutputFooter}]`;
+  let visible = wrapped;
+  let text = wrapped.text;
+  if (footer.length <= maxChars) {
+    visible = wrapWebFetchContent(value, maxChars - footer.length);
+    text = `${visible.text}${footer}`;
+  } else if (compactFooter.length <= maxChars) {
+    visible = { ...wrapped, text: "", rawLength: 0, wrappedLength: 0 };
+    text = compactFooter;
+  }
+  return {
+    ...visible,
+    truncated: true,
+    text,
+    wrappedLength: text.length,
+    fullOutputPath,
+    spilledChars: content.length,
+    spillTruncated,
   };
 }
 
@@ -385,17 +436,22 @@ export function sanitizeWebFetchUrl(raw: string): string {
   return repaired.replace(/^(https?:\/\/[^/?#\s]+)\s+$/i, "$1");
 }
 
-function normalizeProviderWebFetchPayload(params: {
+async function normalizeProviderWebFetchPayload(params: {
   providerId: string;
   payload: unknown;
   requestedUrl: string;
   extractMode: ExtractMode;
   maxChars: number;
   tookMs: number;
-}): Record<string, unknown> {
+}): Promise<Record<string, unknown>> {
   const payload = isRecord(params.payload) ? params.payload : {};
   const rawText = typeof payload.text === "string" ? payload.text : "";
-  const wrapped = wrapWebFetchContent(rawText, params.maxChars);
+  const wrapped = await spillWebFetchContent(
+    rawText,
+    wrapWebFetchContent(rawText, params.maxChars),
+    params.maxChars,
+    payload.truncated === true,
+  );
   const url = params.requestedUrl;
   const finalUrl = normalizeProviderFinalUrl(payload.finalUrl) ?? url;
   const status =
@@ -430,6 +486,9 @@ function normalizeProviderWebFetchPayload(params: {
     length: wrapped.wrappedLength,
     rawLength: wrapped.rawLength,
     wrappedLength: wrapped.wrappedLength,
+    ...(wrapped.fullOutputPath ? { fullOutputPath: wrapped.fullOutputPath } : {}),
+    ...(wrapped.spilledChars !== undefined ? { spilledChars: wrapped.spilledChars } : {}),
+    ...(wrapped.spillTruncated ? { spillTruncated: true } : {}),
     fetchedAt:
       typeof payload.fetchedAt === "string" && payload.fetchedAt
         ? payload.fetchedAt
@@ -459,7 +518,7 @@ async function maybeFetchProviderWebFetchPayload(
     extractMode: params.extractMode,
     maxChars: params.maxChars,
   });
-  const payload = normalizeProviderWebFetchPayload({
+  const payload = await normalizeProviderWebFetchPayload({
     providerId: providerFallback.provider.id,
     payload: rawPayload,
     requestedUrl: params.url,
@@ -663,7 +722,13 @@ async function runWebFetch(params: WebFetchRuntimeParams): Promise<Record<string
       }
     }
 
-    const wrapped = wrapWebFetchContent(text, params.maxChars);
+    const wrapped = await spillWebFetchContent(
+      text,
+      wrapWebFetchContent(text, params.maxChars),
+      params.maxChars,
+      bodyResult.truncated,
+    );
+    throwIfFetchAborted(params.signal);
     const wrappedTitle = title ? wrapWebFetchField(title) : undefined;
     const wrappedWarning = wrapWebFetchField(responseTruncatedWarning);
     const payload = {
@@ -683,6 +748,9 @@ async function runWebFetch(params: WebFetchRuntimeParams): Promise<Record<string
       length: wrapped.wrappedLength,
       rawLength: wrapped.rawLength, // Actual content length, not wrapped
       wrappedLength: wrapped.wrappedLength,
+      ...(wrapped.fullOutputPath ? { fullOutputPath: wrapped.fullOutputPath } : {}),
+      ...(wrapped.spilledChars !== undefined ? { spilledChars: wrapped.spilledChars } : {}),
+      ...(wrapped.spillTruncated ? { spillTruncated: true } : {}),
       fetchedAt: new Date().toISOString(),
       tookMs: Date.now() - start,
       text: wrapped.text,

--- a/src/agents/tools/web-tools.fetch.test.ts
+++ b/src/agents/tools/web-tools.fetch.test.ts
@@ -1,5 +1,6 @@
 // web_fetch tool tests cover extraction fallbacks, progress events, provider
 // fallback behavior, and external-content wrapping.
+import { readFile, rm } from "node:fs/promises";
 import { EnvHttpProxyAgent } from "undici";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { LookupFn } from "../../infra/net/ssrf.js";
@@ -24,6 +25,7 @@ vi.mock("../../web-fetch/runtime.js", () => ({
   resolveWebFetchDefinition: resolveWebFetchDefinitionMock,
 }));
 import { createWebFetchTool } from "./web-fetch.js";
+import { WEB_FETCH_SPILL_MAX_CHARS } from "./web-fetch.js";
 
 const lookupMock = vi.fn();
 
@@ -144,6 +146,10 @@ async function captureToolErrorMessage(params: {
   } catch (error) {
     return (error as Error).message;
   }
+}
+
+function withoutSpillFooter(text: string | undefined): string {
+  return text?.split("\n\n[Showing truncated web_fetch content.")[0] ?? "";
 }
 
 describe("web_fetch extraction fallbacks", () => {
@@ -426,7 +432,7 @@ describe("web_fetch extraction fallbacks", () => {
     const result = await tool?.execute?.("call", { url: "https://example.com/long" });
     const details = result?.details as { text?: string; truncated?: boolean };
 
-    expect(details.text?.length).toBeLessThanOrEqual(2000);
+    expect(withoutSpillFooter(details.text).length).toBeLessThanOrEqual(2000);
     expect(details.truncated).toBe(true);
   });
 
@@ -441,8 +447,109 @@ describe("web_fetch extraction fallbacks", () => {
     const result = await tool?.execute?.("call", { url: "https://example.com/short" });
     const details = result?.details as { text?: string; truncated?: boolean };
 
-    expect(details.text?.length).toBeLessThanOrEqual(100);
+    expect(withoutSpillFooter(details.text).length).toBeLessThanOrEqual(100);
     expect(details.truncated).toBe(true);
+  });
+
+  it("spills truncated fetched text to a private temp file", async () => {
+    const fullText = "web fetch content ".repeat(400);
+    installPlainTextFetch(fullText);
+
+    const tool = createFetchTool({
+      firecrawl: { enabled: false },
+      maxChars: 500,
+    });
+
+    const result = await tool?.execute?.("call", { url: "https://example.com/spill" });
+    const details = result?.details as {
+      text?: string;
+      truncated?: boolean;
+      fullOutputPath?: string;
+      spilledChars?: number;
+      spillTruncated?: boolean;
+    };
+    if (!details.fullOutputPath) {
+      throw new Error("expected fullOutputPath");
+    }
+
+    expect(details.truncated).toBe(true);
+    expect(details.text).toContain(`Full output: ${details.fullOutputPath}`);
+    expect(details.text?.length).toBeLessThanOrEqual(500);
+    expect(details.spilledChars).toBe(fullText.length);
+    expect(details.spillTruncated).toBeUndefined();
+    const spilledText = await readFile(details.fullOutputPath, "utf8");
+    expect(spilledText).toContain("SECURITY NOTICE");
+    expect(spilledText).toContain(fullText);
+    await rm(details.fullOutputPath, { force: true });
+  });
+
+  it("caps oversized web_fetch spill files and says so in the footer", async () => {
+    const fullText = "x".repeat(WEB_FETCH_SPILL_MAX_CHARS + 123);
+    installPlainTextFetch(fullText);
+
+    const tool = createFetchTool({
+      firecrawl: { enabled: false },
+      maxChars: 500,
+      maxResponseBytes: WEB_FETCH_SPILL_MAX_CHARS + 1_000,
+    });
+
+    const result = await tool?.execute?.("call", { url: "https://example.com/spill-cap" });
+    const details = result?.details as {
+      text?: string;
+      fullOutputPath?: string;
+      spilledChars?: number;
+      spillTruncated?: boolean;
+    };
+    if (!details.fullOutputPath) {
+      throw new Error("expected fullOutputPath");
+    }
+
+    expect(details.text).toContain(`Spilled first ${WEB_FETCH_SPILL_MAX_CHARS} chars.`);
+    expect(details.text?.length).toBeLessThanOrEqual(500);
+    expect(details.spilledChars).toBe(WEB_FETCH_SPILL_MAX_CHARS);
+    expect(details.spillTruncated).toBe(true);
+    const spilledText = await readFile(details.fullOutputPath, "utf8");
+    expect(spilledText).toContain("SECURITY NOTICE");
+    expect(spilledText.length).toBeGreaterThan(WEB_FETCH_SPILL_MAX_CHARS);
+    expect(spilledText.length).toBeLessThan(WEB_FETCH_SPILL_MAX_CHARS + 1_000);
+    await rm(details.fullOutputPath, { force: true });
+  });
+
+  it("marks byte-capped web_fetch spills as partial", async () => {
+    const fullText = "z".repeat(40_000);
+    installMockFetch((input: RequestInfo | URL) => {
+      const response = new Response(fullText, {
+        status: 200,
+        headers: { "content-type": "text/plain" },
+      });
+      Object.defineProperty(response, "url", { value: resolveRequestUrl(input) });
+      return Promise.resolve(response);
+    });
+
+    const tool = createFetchTool({
+      firecrawl: { enabled: false },
+      maxChars: 500,
+      maxResponseBytes: 32_000,
+    });
+
+    const result = await tool?.execute?.("call", { url: "https://example.com/byte-cap" });
+    const details = result?.details as {
+      text?: string;
+      fullOutputPath?: string;
+      spilledChars?: number;
+      spillTruncated?: boolean;
+    };
+    if (!details.fullOutputPath) {
+      throw new Error("expected fullOutputPath");
+    }
+
+    expect(details.text).toContain("Spilled available content from truncated response.");
+    expect(details.spilledChars).toBe(32_000);
+    expect(details.spillTruncated).toBe(true);
+    const spilledText = await readFile(details.fullOutputPath, "utf8");
+    expect(spilledText).toContain("SECURITY NOTICE");
+    expect(spilledText).not.toContain(fullText);
+    await rm(details.fullOutputPath, { force: true });
   });
 
   it("decodes response bytes with a charset from Content-Type", async () => {
@@ -737,11 +844,20 @@ describe("web_fetch extraction fallbacks", () => {
       url: "https://example.com/large",
       maxChars: 200_000,
     });
-    const details = result?.details as { text?: string; length?: number; truncated?: boolean };
+    const details = result?.details as {
+      text?: string;
+      length?: number;
+      truncated?: boolean;
+      fullOutputPath?: string;
+    };
     expect(details.text).toMatch(/<<<EXTERNAL_UNTRUSTED_CONTENT id="[a-f0-9]{16}">>>/);
     expect(details.text).toContain("Source: Web Fetch");
-    expect(details.length).toBeLessThanOrEqual(10_000);
+    expect(withoutSpillFooter(details.text).length).toBeLessThanOrEqual(10_000);
+    expect(details.length).toBe(details.text?.length);
     expect(details.truncated).toBe(true);
+    if (details.fullOutputPath) {
+      await rm(details.fullOutputPath, { force: true });
+    }
   });
 
   it("rejects fractional maxChars before fetching", async () => {


### PR DESCRIPTION
## What Problem This Solves

Fixes #100112.

This is a follow-up to #100077/#100042. Truncation could destroy recoverable output: history elision discarded live exec spill-file pointers, and `web_fetch` discarded overflow at fetch time.

## Why This Change Was Made

This reuses the shipped spill seam. Elision markers preserve `details.fullOutputPath` when the file still exists, but only when the same `Full output: <path>` footer was already present in model-visible tool text.

That footer-visibility guard is enforced, not assumed: details-only paths are not surfaced, and JSON-escaped visible footers are detected so Windows-style paths stay recoverable without creating a new disclosure. Partial-spill honesty is preserved too: capped or source-truncated spills are labeled partial and are never claimed as full output.

`web_fetch` now spills truncated extracted content through owner-only private temp files, using the wrapped untrusted-content form rather than raw page text. Spills are capped at 2,000,000 chars, byte-capped/source-capped responses are marked partial, and the returned footer shares the exec footer contract through `formatFullOutputFooter`. Marker rendering degrades full -> compact -> plain rerun text, with a compact-pointer floor for valid spill pointers so recovery paths are not budget-starved.

The E2E scratch test initially caught that budget-starvation flaw: real temp paths were long enough that both aggregate clearing and recovery suffix truncation could drop the pointer. This revision treats the pointer as recovery-critical metadata while keeping pointerless results on the existing budget-sliced plain-marker behavior.

## User Impact

Models can recover full command output and fetched web content after truncation/elision instead of re-running expensive commands or losing vanished web content.

No config surface was added. Existing exec footers remain byte-identical.

## Evidence

Post-rebase onto current `origin/main`:

`pnpm tsgo`
Exit 0.

`pnpm check:test-types`
Exit 0.

`node scripts/run-vitest.mjs src/agents/embedded-agent-runner/tool-result-truncation.test.ts src/agents/tools/web-tools.fetch.test.ts src/agents/session-tool-result-guard.tool-result-persist-hook.test.ts`
Exit 0. Test Files: 3 passed. Tests: 104 passed.

Temporary production-path scratch E2E:
`node scripts/run-vitest.mjs src/agents/spill-recovery.scratch.test.ts --reporter=verbose`
Exit 0. Test Files: 1 passed. Tests: 1 passed. It exercised real bash capture, real `web_fetch` through a local HTTP proxy/server, aggregate elision, spill-file recovery, deleted-spill fallback, and details-without-visible-footer non-disclosure. The scratch file was deleted and was not committed.

Autoreview:
`.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main`
Final actionable finding was fixed with an abort recheck after web_fetch spill writes; rerun exited 0 with no accepted/actionable findings before the final no-conflict rebase. The required verification above was rerun after that final rebase.
