### PR TITLE
fix(chat): hide duplicate channel delivery mirrors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ Docs: https://docs.openclaw.ai
 ### Fixes
 
 - **Control UI terminal rendering:** adopt the shared `@openclaw/libterminal` browser lifecycle and add Nerd Font fallbacks so icon-enabled shell listings render their glyphs when a compatible local font is installed.
+- **Control UI chat history:** hide redundant channel-final delivery mirrors when the preceding app-server assistant reply already shows the same text.
 - **ClawRouter auth profiles:** resolve credential-scoped catalog models during agent runs when the proxy key is stored in an auth profile, and document plugin and model allowlists.
 - **Telegram durability:** recover stalled ingress claims, retry restart-dropped media, survive transient polling errors, dead-letter poison updates, preserve forwarded rich text, route plugin callbacks correctly, keep progress updates in one stable multi-line window, map self-hosted Bot API container paths through trusted host roots, and fall back safely when Telegram rejects rich final replies. (#97118, #98102, #98735, #98775, #98776, #97174, #98907, #91984, #98786) Thanks @vincentkoc, @luoyanglang, @DaveArcher18, @obviyus, @goldmar, @Marvinthebored, @Dizesales, and @shakkernerd.
 - **Cross-channel inbound media:** preserve captions and expose unavailable-attachment notices when WhatsApp, LINE, Signal, iMessage, Microsoft Teams, Feishu, Mattermost, or Zalo cannot materialize inbound media, instead of dispatching phantom placeholders or dropping media-only turns. (#100092)

--- a/src/gateway/chat-display-projection.ts
+++ b/src/gateway/chat-display-projection.ts
@@ -1494,6 +1494,38 @@ function isDuplicateAcpGatewayInjectedMessage(
   return Boolean(previousText && currentText && previousText === currentText);
 }
 
+function isDuplicateChannelFinalDeliveryMirror(
+  current: Record<string, unknown>,
+  previousVisible: Record<string, unknown> | undefined,
+): boolean {
+  if (!previousVisible || !isOpenClawDeliveryMirrorAssistantMessage(current)) {
+    return false;
+  }
+  const deliveryMirror = readRecord(current.openclawDeliveryMirror);
+  if (deliveryMirror?.kind !== "channel-final") {
+    return false;
+  }
+  if (asRoleContentMessage(previousVisible)?.role !== "assistant") {
+    return false;
+  }
+  if (isOpenClawDeliveryMirrorAssistantMessage(previousVisible)) {
+    return false;
+  }
+  if (isProjectedSessionsSendForwardedMessage(previousVisible)) {
+    return false;
+  }
+  const previousMeta = readRecord(previousVisible["__openclaw"]);
+  if (typeof previousMeta?.mirrorIdentity !== "string" || !previousMeta.mirrorIdentity.trim()) {
+    return false;
+  }
+  if (hasAssistantNonTextContent(previousVisible) || hasAssistantNonTextContent(current)) {
+    return false;
+  }
+  const previousText = displayTextForDuplicateCheck(previousVisible);
+  const currentText = displayTextForDuplicateCheck(current);
+  return Boolean(previousText && currentText && previousText === currentText);
+}
+
 function toProjectedMessages(messages: unknown[]): Array<Record<string, unknown>> {
   return messages.filter(
     (message): message is Record<string, unknown> =>
@@ -1532,7 +1564,10 @@ function filterVisibleProjectedHistoryMessages(
       changed = true;
       continue;
     }
-    if (isDuplicateAcpGatewayInjectedMessage(current, visible.at(-1))) {
+    if (
+      isDuplicateAcpGatewayInjectedMessage(current, visible.at(-1)) ||
+      isDuplicateChannelFinalDeliveryMirror(current, messages[i - 1])
+    ) {
       changed = true;
       continue;
     }

--- a/src/gateway/server-methods/server-methods.test.ts
+++ b/src/gateway/server-methods/server-methods.test.ts
@@ -1801,6 +1801,167 @@ describe("projectRecentChatDisplayMessages", () => {
     ]);
   });
 
+  it("drops channel-final delivery mirrors that duplicate the preceding assistant reply", () => {
+    const result = projectRecentChatDisplayMessages([
+      {
+        role: "user",
+        content: "yo big boy",
+        timestamp: 1,
+      },
+      {
+        role: "assistant",
+        provider: "openai",
+        model: "gpt-5.5",
+        content: [{ type: "text", text: "Yo Peter. I’m here." }],
+        __openclaw: { mirrorIdentity: "run-1:assistant" },
+        timestamp: 2,
+      },
+      {
+        role: "assistant",
+        provider: "openclaw",
+        model: "delivery-mirror",
+        content: [{ type: "text", text: "Yo Peter. I’m here." }],
+        idempotencyKey: "channel-final:message-1:0",
+        openclawDeliveryMirror: { kind: "channel-final", sourceMessageId: "message-1" },
+        timestamp: 3,
+      },
+    ]);
+
+    expect(result).toEqual([
+      {
+        role: "user",
+        content: "yo big boy",
+        timestamp: 1,
+      },
+      {
+        role: "assistant",
+        provider: "openai",
+        model: "gpt-5.5",
+        content: [{ type: "text", text: "Yo Peter. I’m here." }],
+        __openclaw: { mirrorIdentity: "run-1:assistant" },
+        timestamp: 2,
+      },
+    ]);
+  });
+
+  it("keeps a channel-final delivery mirror after a filtered user turn", () => {
+    const result = projectRecentChatDisplayMessages([
+      {
+        role: "assistant",
+        provider: "openai",
+        model: "gpt-5.5",
+        content: [{ type: "text", text: "Repeated reply" }],
+        __openclaw: { mirrorIdentity: "run-1:assistant" },
+        timestamp: 1,
+      },
+      {
+        role: "user",
+        content: "",
+        timestamp: 2,
+      },
+      {
+        role: "assistant",
+        provider: "openclaw",
+        model: "delivery-mirror",
+        content: [{ type: "text", text: "Repeated reply" }],
+        idempotencyKey: "channel-final:message-2:0",
+        openclawDeliveryMirror: { kind: "channel-final", sourceMessageId: "message-2" },
+        timestamp: 3,
+      },
+    ]);
+
+    expect(result).toHaveLength(2);
+    expect(result[1]).toEqual(
+      expect.objectContaining({
+        provider: "openclaw",
+        model: "delivery-mirror",
+      }),
+    );
+  });
+
+  it("keeps adjacent channel-final delivery mirrors from distinct sends", () => {
+    const deliveryMirror = (sourceMessageId: string, timestamp: number) => ({
+      role: "assistant",
+      provider: "openclaw",
+      model: "delivery-mirror",
+      content: [{ type: "text", text: "Repeated reply" }],
+      idempotencyKey: `channel-final:${sourceMessageId}:0`,
+      openclawDeliveryMirror: { kind: "channel-final", sourceMessageId },
+      timestamp,
+    });
+
+    const result = projectRecentChatDisplayMessages([
+      deliveryMirror("message-1", 1),
+      deliveryMirror("message-2", 2),
+    ]);
+
+    expect(result).toHaveLength(2);
+  });
+
+  it("keeps channel-final mirrors after unmarked assistant replies", () => {
+    const result = projectRecentChatDisplayMessages([
+      {
+        role: "assistant",
+        provider: "openai",
+        model: "gpt-5.5",
+        content: [{ type: "text", text: "Repeated reply" }],
+        timestamp: 1,
+      },
+      {
+        role: "assistant",
+        provider: "openclaw",
+        model: "delivery-mirror",
+        content: [{ type: "text", text: "Repeated reply" }],
+        idempotencyKey: "channel-final:message-unmarked:0",
+        openclawDeliveryMirror: { kind: "channel-final", sourceMessageId: "message-unmarked" },
+        timestamp: 2,
+      },
+    ]);
+
+    expect(result).toHaveLength(2);
+  });
+
+  it("keeps channel-final mirrors after forwarded sessions_send messages", () => {
+    const result = projectRecentChatDisplayMessages([
+      {
+        role: "user",
+        content: [{ type: "text", text: "Forwarded status" }],
+        provenance: {
+          kind: "inter_session",
+          sourceSessionKey: "agent:main:webchat:source",
+          sourceTool: "sessions_send",
+        },
+        timestamp: 1,
+      },
+      {
+        role: "assistant",
+        provider: "openclaw",
+        model: "delivery-mirror",
+        content: [{ type: "text", text: "Forwarded status" }],
+        idempotencyKey: "channel-final:message-forwarded:0",
+        openclawDeliveryMirror: {
+          kind: "channel-final",
+          sourceMessageId: "message-forwarded",
+        },
+        timestamp: 2,
+      },
+    ]);
+
+    expect(result).toHaveLength(2);
+    expect(result[0]).toEqual(
+      expect.objectContaining({
+        role: "assistant",
+        senderLabel: "Forwarded from main",
+      }),
+    );
+    expect(result[1]).toEqual(
+      expect.objectContaining({
+        provider: "openclaw",
+        model: "delivery-mirror",
+      }),
+    );
+  });
+
   it("keeps gateway-injected assistant replies when they are not duplicate ACP text", () => {
     const result = projectRecentChatDisplayMessages([
       {


### PR DESCRIPTION
## Summary

- hide an exact-text Slack channel-final delivery mirror when the immediately preceding app-server assistant reply already represents it
- preserve standalone delivery mirrors, hidden user-turn boundaries, structured replies, and distinct repeated channel sends
- add regression coverage for the live provider-output plus delivery-mirror transcript shape

## Testing

- focused gateway projection suite via `node scripts/test-projects.mjs src/gateway/server-methods/server-methods.test.ts` (167 passed)
- targeted type-aware Oxlint across all changed TypeScript files
- Oxfmt check across all changed files
