### PR TITLE
fix(codex): fail closed on unknown projector events

### DIFF
--- a/extensions/codex/src/app-server/event-projector.test.ts
+++ b/extensions/codex/src/app-server/event-projector.test.ts
@@ -1566,6 +1566,112 @@ describe("CodexAppServerEventProjector", () => {
     expect(result.lastAssistant).toBeUndefined();
   });
 
+  it("warns once for mismatched notifications it ignores", async () => {
+    const warn = vi.spyOn(embeddedAgentLog, "warn").mockImplementation(() => undefined);
+    const projector = await createProjector();
+
+    const notification = {
+      method: "item/agentMessage/delta",
+      params: { threadId: THREAD_ID, turnId: "turn-2", itemId: "msg-1", delta: "wrong" },
+    } satisfies ProjectorNotification;
+
+    await projector.handleNotification(notification);
+    await projector.handleNotification(notification);
+
+    expect(warn).toHaveBeenCalledTimes(1);
+    expect(warn).toHaveBeenCalledWith(
+      "codex app-server ignored mismatched notification",
+      expect.objectContaining({
+        reason: "turn-mismatch",
+        method: "item/agentMessage/delta",
+        activeThreadId: THREAD_ID,
+        activeTurnId: TURN_ID,
+        threadId: THREAD_ID,
+        turnId: "turn-2",
+        matchesActiveThread: true,
+        matchesActiveTurn: false,
+      }),
+    );
+  });
+
+  it("warns once for unknown notification methods instead of dropping them silently", async () => {
+    const warn = vi.spyOn(embeddedAgentLog, "warn").mockImplementation(() => undefined);
+    const projector = await createProjector();
+
+    const notification = forCurrentTurn("turn/progress" as ProjectorNotification["method"], {
+      phase: "streaming",
+    });
+
+    await projector.handleNotification(notification);
+    await projector.handleNotification(notification);
+
+    expect(warn).toHaveBeenCalledTimes(1);
+    expect(warn).toHaveBeenCalledWith(
+      "codex app-server ignored unknown notification method",
+      expect.objectContaining({
+        method: "turn/progress",
+        activeThreadId: THREAD_ID,
+        activeTurnId: TURN_ID,
+        threadId: THREAD_ID,
+        turnId: TURN_ID,
+        matchesActiveThread: true,
+        matchesActiveTurn: true,
+      }),
+    );
+  });
+
+  it("fails closed for unknown item statuses and logs a warning", async () => {
+    const warn = vi.spyOn(embeddedAgentLog, "warn").mockImplementation(() => undefined);
+    const onAgentEvent = vi.fn();
+    const projector = await createProjector({
+      ...(await createParams()),
+      verboseLevel: "full",
+      onAgentEvent,
+    });
+
+    await projector.handleNotification(
+      forCurrentTurn("item/completed", {
+        item: {
+          type: "commandExecution",
+          id: "tool-unknown-status",
+          command: "echo hi",
+          cwd: "/workspace",
+          processId: null,
+          source: "agent",
+          status: "cancelled",
+          commandActions: [],
+          aggregatedOutput: "Cancelled before completion",
+          exitCode: null,
+          durationMs: 12,
+        },
+      }),
+    );
+
+    const toolEvents = onAgentEvent.mock.calls
+      .map(([event]) => requireRecord(event, "agent event"))
+      .filter((event) => event.stream === "tool");
+    expect(toolEvents).toHaveLength(1);
+    expect(toolEvents[0]).toEqual(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          phase: "result",
+          itemId: "tool-unknown-status",
+          status: "failed",
+        }),
+      }),
+    );
+    expect(warn).toHaveBeenCalledWith(
+      "codex app-server projected unknown item status as failed",
+      expect.objectContaining({
+        itemId: "tool-unknown-status",
+        itemType: "commandExecution",
+        rawStatus: "cancelled",
+        threadId: THREAD_ID,
+        turnId: TURN_ID,
+      }),
+    );
+  });
+
   it("preserves sessions_yield detection in attempt results", () => {
     const projector = new CodexAppServerEventProjector(
       {

--- a/extensions/codex/src/app-server/event-projector.ts
+++ b/extensions/codex/src/app-server/event-projector.ts
@@ -27,6 +27,7 @@ import { saveMediaBuffer } from "openclaw/plugin-sdk/media-store";
 import { asDateTimestampMs } from "openclaw/plugin-sdk/number-runtime";
 import { resolveCodexLocalRuntimeAttribution } from "./local-runtime-attribution.js";
 import {
+  describeCodexNotificationCorrelation,
   readCodexNotificationThreadId,
   readCodexNotificationTurnId,
 } from "./notification-correlation.js";
@@ -200,6 +201,9 @@ export class CodexAppServerEventProjector {
   private readonly nativeGeneratedMediaUrlsByItemId = new Map<string, string>();
   private readonly diagnosticToolStartedAtByItem = new Map<string, number>();
   private readonly afterToolCallObservedItemIds = new Set<string>();
+  private readonly warnedUnknownNotificationMethods = new Set<string>();
+  private readonly warnedIgnoredNotificationCorrelations = new Set<string>();
+  private readonly warnedUnknownItemStatuses = new Set<string>();
   private assistantStarted = false;
   private reasoningStarted = false;
   private reasoningEnded = false;
@@ -307,9 +311,11 @@ export class CodexAppServerEventProjector {
     }
     if (isHookNotificationMethod(notification.method)) {
       if (!this.isHookNotificationForCurrentThread(params)) {
+        this.warnIgnoredNotification(notification, "thread-mismatch");
         return;
       }
     } else if (!this.isNotificationForTurn(params)) {
+      this.warnIgnoredNotification(notification, "turn-mismatch");
       return;
     }
 
@@ -364,6 +370,7 @@ export class CodexAppServerEventProjector {
         this.promptErrorSource = "prompt";
         break;
       default:
+        this.warnUnknownNotificationMethod(notification);
         break;
     }
   }
@@ -968,7 +975,7 @@ export class CodexAppServerEventProjector {
       !shouldSynthesizeToolProgressForItem(item) ||
       !this.isCurrentTurnSnapshotItem(item) ||
       this.completedItemIds.has(item.id) ||
-      itemStatus(item) === "running"
+      this.resolveItemStatus(item) === "running"
     ) {
       return;
     }
@@ -1329,7 +1336,7 @@ export class CodexAppServerEventProjector {
         phase: params.phase,
         kind,
         title: itemTitle(item),
-        status: params.phase === "start" ? "running" : itemStatus(item),
+        status: params.phase === "start" ? "running" : this.resolveItemStatus(item),
         ...(itemName(item) ? { name: itemName(item) } : {}),
         ...(meta ? { meta } : {}),
         ...(suppressChannelProgress ? { suppressChannelProgress: true } : {}),
@@ -1349,7 +1356,7 @@ export class CodexAppServerEventProjector {
     if (!name) {
       return;
     }
-    const status = params.phase === "result" ? itemStatus(item) : "running";
+    const status = params.phase === "result" ? this.resolveItemStatus(item) : "running";
     const args = itemToolArgs(item);
     const meta = itemMeta(item, this.toolProgressDetailMode());
     this.recordToolTrajectoryEvent({ phase: params.phase, item, name, args, status });
@@ -1536,7 +1543,7 @@ export class CodexAppServerEventProjector {
     if (!name) {
       return;
     }
-    const status = itemStatus(item);
+    const status = this.resolveItemStatus(item);
     if (status === "running") {
       return;
     }
@@ -1620,7 +1627,7 @@ export class CodexAppServerEventProjector {
       itemId,
       text: formatToolOutput(toolName, itemMeta(item, this.toolProgressDetailMode()), output),
       finalOutput: true,
-      isError: isNonSuccessItemStatus(itemStatus(item)),
+      isError: isNonSuccessItemStatus(this.resolveItemStatus(item)),
     });
   }
 
@@ -1717,7 +1724,7 @@ export class CodexAppServerEventProjector {
       id: item.id,
       name,
       text: itemTranscriptResultText(item, this.toolResultOutputTextByItem),
-      isError: isNonSuccessItemStatus(itemStatus(item)),
+      isError: isNonSuccessItemStatus(this.resolveItemStatus(item)),
     });
   }
 
@@ -2124,6 +2131,64 @@ export class CodexAppServerEventProjector {
     const turnId = params.turnId;
     return threadId === this.threadId && (turnId === this.turnId || turnId === null);
   }
+
+  private warnUnknownNotificationMethod(notification: CodexServerNotification): void {
+    if (this.warnedUnknownNotificationMethods.has(notification.method)) {
+      return;
+    }
+    this.warnedUnknownNotificationMethods.add(notification.method);
+    embeddedAgentLog.warn("codex app-server ignored unknown notification method", {
+      ...describeCodexNotificationCorrelation(notification, {
+        threadId: this.threadId,
+        turnId: this.turnId,
+      }),
+    });
+  }
+
+  private warnIgnoredNotification(
+    notification: CodexServerNotification,
+    reason: "thread-mismatch" | "turn-mismatch",
+  ): void {
+    const correlation = describeCodexNotificationCorrelation(notification, {
+      threadId: this.threadId,
+      turnId: this.turnId,
+    });
+    const dedupeKey = [
+      reason,
+      notification.method,
+      correlation.threadId ?? "",
+      correlation.turnId ?? "",
+      correlation.nestedTurnThreadId ?? "",
+      correlation.nestedTurnId ?? "",
+    ].join("|");
+    if (this.warnedIgnoredNotificationCorrelations.has(dedupeKey)) {
+      return;
+    }
+    this.warnedIgnoredNotificationCorrelations.add(dedupeKey);
+    embeddedAgentLog.warn("codex app-server ignored mismatched notification", {
+      reason,
+      ...correlation,
+    });
+  }
+
+  private resolveItemStatus(item: CodexThreadItem): "completed" | "failed" | "running" | "blocked" {
+    return itemStatus(item, (status) => this.warnUnknownItemStatus(status, item));
+  }
+
+  private warnUnknownItemStatus(status: string, item: CodexThreadItem): void {
+    const key = `${item.type}:${status}`;
+    if (this.warnedUnknownItemStatuses.has(key)) {
+      return;
+    }
+    this.warnedUnknownItemStatuses.add(key);
+    embeddedAgentLog.warn("codex app-server projected unknown item status as failed", {
+      itemId: item.id,
+      itemType: item.type,
+      rawStatus: status,
+      threadId: this.threadId,
+      turnId: this.turnId,
+    });
+  }
 }
 
 function isHookNotificationMethod(method: string): method is "hook/started" | "hook/completed" {
@@ -2408,8 +2473,14 @@ function itemTitle(item: CodexThreadItem): string {
   }
 }
 
-function itemStatus(item: CodexThreadItem): "completed" | "failed" | "running" | "blocked" {
+function itemStatus(
+  item: CodexThreadItem,
+  onUnknownStatus?: (status: string) => void,
+): "completed" | "failed" | "running" | "blocked" {
   const status = readItemString(item, "status");
+  if (status === undefined || status === "completed") {
+    return "completed";
+  }
   if (status === "failed") {
     return "failed";
   }
@@ -2419,7 +2490,8 @@ function itemStatus(item: CodexThreadItem): "completed" | "failed" | "running" |
   if (status === "inProgress" || status === "running") {
     return "running";
   }
-  return "completed";
+  onUnknownStatus?.(status);
+  return "failed";
 }
 
 function formatMissingToolResultError(params: { id: string; name: string }): string {


### PR DESCRIPTION
Closes #99269

## Summary
- fail closed for unknown Codex app-server item statuses instead of projecting them as successful completions
- log deduplicated warnings for ignored unknown notification methods and thread/turn correlation mismatches
- cover the new warning and fail-closed behavior with focused event projector tests

## Testing
- node scripts/run-vitest.mjs extensions/codex/src/app-server/event-projector.test.ts
