### PR TITLE
fix(agents): emit diagnostic when sessions_yield parks without continuation evidence

### DIFF
--- a/src/agents/embedded-agent-runner/run/incomplete-turn.ts
+++ b/src/agents/embedded-agent-runner/run/incomplete-turn.ts
@@ -376,8 +376,9 @@ function hasAsyncStartedToolActivity(toolMetas?: readonly { asyncStarted?: boole
   return (toolMetas ?? []).some((entry) => entry.asyncStarted === true);
 }
 
-/** Fields needed to determine whether a yielded turn has future continuation. */
+/** Fields needed to determine whether a yielded turn already delivered or can continue. */
 interface YieldContinuationAttempt {
+  clientToolCalls?: readonly unknown[];
   didSendDeterministicApprovalPrompt?: boolean;
   successfulCronAdds?: number;
   acceptedSessionSpawns?: readonly { runId: string; childSessionKey: string }[];
@@ -390,7 +391,8 @@ interface YieldContinuationAttempt {
 /** Continuation evidence for a yielded turn — sources that will produce future output. */
 export function hasYieldContinuationEvidence(attempt: YieldContinuationAttempt): boolean {
   return (
-    attempt.didSendDeterministicApprovalPrompt ||
+    (attempt.clientToolCalls?.length ?? 0) > 0 ||
+    attempt.didSendDeterministicApprovalPrompt === true ||
     hasCommittedMessagingToolDeliveryEvidence({
       messagingToolSentTexts: attempt.messagingToolSentTexts ?? [],
       messagingToolSentMediaUrls: attempt.messagingToolSentMediaUrls ?? [],

--- a/src/agents/embedded-agent-runner/run/incomplete-turn.ts
+++ b/src/agents/embedded-agent-runner/run/incomplete-turn.ts
@@ -10,6 +10,7 @@ import {
 } from "../../../auto-reply/tokens.js";
 import { hasAcceptedSessionSpawn } from "../../accepted-session-spawn.js";
 import { collectTextContentBlocks } from "../../content-blocks.js";
+import type { MessagingToolSend } from "../../embedded-agent-messaging.types.js";
 import {
   isStrictAgenticSupportedProviderModel,
   stripProviderPrefix,
@@ -371,9 +372,40 @@ function hasOnlySilentAssistantReply(assistantTexts?: readonly string[]): boolea
   );
 }
 
-function hasAsyncStartedToolActivity(toolMetas?: readonly { asyncStarted?: boolean }[]): boolean {
+export function hasAsyncStartedToolActivity(
+  toolMetas?: readonly { asyncStarted?: boolean }[],
+): boolean {
   return (toolMetas ?? []).some((entry) => entry.asyncStarted === true);
 }
+
+/** Fields needed to determine whether a yielded turn has future continuation. */
+interface YieldContinuationAttempt {
+  didSendDeterministicApprovalPrompt?: boolean;
+  successfulCronAdds?: number;
+  acceptedSessionSpawns?: readonly { runId: string; childSessionKey: string }[];
+  messagingToolSentTexts?: readonly string[];
+  messagingToolSentMediaUrls?: readonly string[];
+  messagingToolSentTargets?: readonly MessagingToolSend[];
+  toolMetas?: readonly { asyncStarted?: boolean }[];
+}
+
+/** Continuation evidence for a yielded turn — sources that will produce future output. */
+export function hasYieldContinuationEvidence(attempt: YieldContinuationAttempt): boolean {
+  return (
+    attempt.didSendDeterministicApprovalPrompt ||
+    hasCommittedMessagingToolDeliveryEvidence({
+      messagingToolSentTexts: attempt.messagingToolSentTexts ?? [],
+      messagingToolSentMediaUrls: attempt.messagingToolSentMediaUrls ?? [],
+      messagingToolSentTargets: attempt.messagingToolSentTargets ?? [],
+    }) ||
+    hasAcceptedSessionSpawn(attempt.acceptedSessionSpawns) ||
+    hasAsyncStartedToolActivity(attempt.toolMetas) ||
+    (attempt.successfulCronAdds ?? 0) > 0
+  );
+}
+
+export const YIELD_DIAGNOSTIC_TEXT =
+  "⚠️ Turn yielded without a continuation source. Send a message to resume.";
 
 function isToolResultRole(role: string): boolean {
   return role === "toolresult" || role === "tool_result" || role === "tool";

--- a/src/agents/embedded-agent-runner/run/incomplete-turn.ts
+++ b/src/agents/embedded-agent-runner/run/incomplete-turn.ts
@@ -372,9 +372,7 @@ function hasOnlySilentAssistantReply(assistantTexts?: readonly string[]): boolea
   );
 }
 
-export function hasAsyncStartedToolActivity(
-  toolMetas?: readonly { asyncStarted?: boolean }[],
-): boolean {
+function hasAsyncStartedToolActivity(toolMetas?: readonly { asyncStarted?: boolean }[]): boolean {
   return (toolMetas ?? []).some((entry) => entry.asyncStarted === true);
 }
 

--- a/src/agents/embedded-agent-runner/run/incomplete-turn.ts
+++ b/src/agents/embedded-agent-runner/run/incomplete-turn.ts
@@ -390,6 +390,8 @@ interface YieldContinuationAttempt {
 
 /** Continuation evidence for a yielded turn — sources that will produce future output. */
 export function hasYieldContinuationEvidence(attempt: YieldContinuationAttempt): boolean {
+  // Only same-attempt evidence is causal here. Session-wide active descendants may be
+  // stale or unrelated and must not suppress the diagnostic for this yielded turn.
   return (
     (attempt.clientToolCalls?.length ?? 0) > 0 ||
     attempt.didSendDeterministicApprovalPrompt === true ||

--- a/src/agents/embedded-agent-runner/run/terminal-resolution.ts
+++ b/src/agents/embedded-agent-runner/run/terminal-resolution.ts
@@ -469,6 +469,8 @@ function completeEmbeddedRun(
     : input.attempt.yieldDetected
       ? "end_turn"
       : (input.attemptAssistant?.stopReason as string | undefined);
+  // Existing visible payloads already avoid the silent-park symptom. The diagnostic
+  // fills only an otherwise empty yielded turn and must not duplicate visible output.
   const terminalPayloads = input.emptyAssistantReplyIsSilent
     ? [{ text: SILENT_REPLY_TOKEN }]
     : input.payloadsForTerminalPath?.length

--- a/src/agents/embedded-agent-runner/run/terminal-resolution.ts
+++ b/src/agents/embedded-agent-runner/run/terminal-resolution.ts
@@ -20,6 +20,7 @@ import {
 import type { EmbeddedRunContextRecoveryState } from "./context-recovery-state.js";
 import {
   hasAttemptTerminalState,
+  hasYieldContinuationEvidence,
   resolveAttemptReplayMetadata,
   resolveEmptyResponseRetryInstruction,
   resolveIncompleteTurnPayloadText,
@@ -29,6 +30,7 @@ import {
   resolveToolUseTerminalContinuationInstruction,
   shouldRetryMissingAssistantTurn,
   shouldTreatEmptyAssistantReplyAsSilent,
+  YIELD_DIAGNOSTIC_TEXT,
 } from "./incomplete-turn.js";
 import type { RunEmbeddedAgentParams } from "./params.js";
 import {
@@ -451,6 +453,8 @@ function completeEmbeddedRun(
     onSuccessfulAuthBinding: input.runParams.onSuccessfulAuthBinding,
   });
   const replayInvalid = input.resolveReplayInvalid(null);
+  const yieldHasContinuation =
+    input.attempt.yieldDetected && hasYieldContinuationEvidence(input.attempt);
   const livenessState = input.attempt.yieldDetected
     ? "paused"
     : resolveRunLivenessState({
@@ -467,7 +471,11 @@ function completeEmbeddedRun(
       : (input.attemptAssistant?.stopReason as string | undefined);
   const terminalPayloads = input.emptyAssistantReplyIsSilent
     ? [{ text: SILENT_REPLY_TOKEN }]
-    : input.payloadsForTerminalPath;
+    : input.payloadsForTerminalPath?.length
+      ? input.payloadsForTerminalPath
+      : input.attempt.yieldDetected && !yieldHasContinuation
+        ? [{ text: YIELD_DIAGNOSTIC_TEXT }]
+        : input.payloadsForTerminalPath;
   input.setTerminalLifecycleMeta({
     replayInvalid,
     livenessState,

--- a/src/agents/embedded-agent-runner/sessions-yield.orchestration.test.ts
+++ b/src/agents/embedded-agent-runner/sessions-yield.orchestration.test.ts
@@ -3,7 +3,6 @@
  * with no pending tool calls, so the parent session is idle when subagent
  * results arrive.
  */
-
 import { expectDefined } from "@openclaw/normalization-core";
 import { beforeAll, beforeEach, describe, expect, it } from "vitest";
 import { makeAttemptResult } from "./run.overflow-compaction.fixture.js";
@@ -12,6 +11,7 @@ import {
   mockedGlobalHookRunner,
   mockedRunEmbeddedAttempt,
   overflowBaseRunParams,
+  resetRunOverflowCompactionHarnessMocks,
   warmRunOverflowCompactionHarness,
 } from "./run.overflow-compaction.harness.js";
 import { isEmbeddedAgentRunActive, queueEmbeddedAgentMessageWithOutcome } from "./runs.js";
@@ -25,7 +25,7 @@ describe("sessions_yield orchestration", () => {
   });
 
   beforeEach(() => {
-    mockedRunEmbeddedAttempt.mockReset();
+    resetRunOverflowCompactionHarnessMocks();
     mockedGlobalHookRunner.hasHooks.mockImplementation(() => false);
   });
 
@@ -82,9 +82,9 @@ describe("sessions_yield orchestration", () => {
 
     // clientToolCalls wins — tool_calls stopReason, pendingToolCalls populated
     expect(result.meta.stopReason).toBe("tool_calls");
-    const pendingToolCalls = expectDefined(result.meta.pendingToolCalls, "pending tool calls");
-    expect(pendingToolCalls).toHaveLength(1);
-    expect(expectDefined(pendingToolCalls[0], "hosted tool call").name).toBe("hosted_tool");
+    expect(result.meta.pendingToolCalls).toHaveLength(1);
+    const hostedToolCall = expectDefined(result.meta.pendingToolCalls![0], "hosted tool call");
+    expect(hostedToolCall.name).toBe("hosted_tool");
   });
 
   it("preserves order across multiple client tool calls in one attempt (#52288)", async () => {
@@ -108,17 +108,67 @@ describe("sessions_yield orchestration", () => {
     });
 
     expect(result.meta.stopReason).toBe("tool_calls");
-    const pendingToolCalls = expectDefined(result.meta.pendingToolCalls, "pending tool calls");
-    expect(pendingToolCalls).toHaveLength(3);
-    expect(pendingToolCalls.map((c) => c.name)).toEqual([
+    expect(result.meta.pendingToolCalls).toHaveLength(3);
+    expect(result.meta.pendingToolCalls!.map((c) => c.name)).toEqual([
       "create_graph",
       "activate_graph",
       "get_status",
     ]);
-    expect(
-      JSON.parse(expectDefined(pendingToolCalls[0], "first pending tool call").arguments),
-    ).toEqual({
+    const firstCall = expectDefined(result.meta.pendingToolCalls![0], "first pending tool call");
+    expect(JSON.parse(firstCall.arguments)).toEqual({
       nodes: ["a", "b"],
+    });
+  });
+
+  describe("yield with continuation evidence", () => {
+    it("yield with accepted spawn — diagnostic suppressed", async () => {
+      // Pure test: runs in the outer harness where countActiveDescendantRuns
+      // returns 0, so suppression must come from the accepted spawn alone.
+      // Regression: a yielded turn with an accepted spawn must NOT emit the
+      // diagnostic — the spawned subagent will produce results.
+      mockedRunEmbeddedAttempt.mockResolvedValueOnce(
+        makeAttemptResult({
+          promptError: null,
+          yieldDetected: true,
+          assistantTexts: [],
+          clientToolCalls: undefined,
+          acceptedSessionSpawns: [{ runId: "child-run", childSessionKey: "child-key" }],
+        }),
+      );
+
+      const result = await runEmbeddedAgent({
+        ...overflowBaseRunParams,
+        runId: "run-yield-accepted-spawn-suppressed",
+      });
+
+      // Accepted spawn is continuation evidence → no diagnostic payload
+      expect(result.payloads).toBeUndefined();
+      expect(result.meta.stopReason).toBe("end_turn");
+      expect(result.meta.yielded).toBe(true);
+    });
+
+    it("yield with async started tool — diagnostic suppressed", async () => {
+      // Pure test: runs in the outer harness where countActiveDescendantRuns
+      // returns 0, so suppression must come from the async tool alone.
+      mockedRunEmbeddedAttempt.mockResolvedValueOnce(
+        makeAttemptResult({
+          promptError: null,
+          yieldDetected: true,
+          assistantTexts: [],
+          clientToolCalls: undefined,
+          toolMetas: [{ toolName: "my_async_tool", asyncStarted: true }],
+        }),
+      );
+
+      const result = await runEmbeddedAgent({
+        ...overflowBaseRunParams,
+        runId: "run-yield-async-tool-suppressed",
+      });
+
+      // Async tool activity is continuation evidence → no diagnostic payload
+      expect(result.payloads).toBeUndefined();
+      expect(result.meta.stopReason).toBe("end_turn");
+      expect(result.meta.yielded).toBe(true);
     });
   });
 
@@ -133,5 +183,82 @@ describe("sessions_yield orchestration", () => {
     // Neither clientToolCall nor yieldDetected → stopReason is undefined
     expect(result.meta.stopReason).toBeUndefined();
     expect(result.meta.pendingToolCalls).toBeUndefined();
+  });
+
+  it("emits diagnostic payload when yieldDetected has no continuation evidence", async () => {
+    mockedRunEmbeddedAttempt.mockResolvedValueOnce(
+      makeAttemptResult({
+        promptError: null,
+        yieldDetected: true,
+        assistantTexts: [],
+        clientToolCalls: undefined,
+      }),
+    );
+
+    const result = await runEmbeddedAgent({
+      ...overflowBaseRunParams,
+      runId: "run-yield-no-continuation",
+    });
+
+    // yieldDetected without any continuation source → diagnostic payload
+    expect(result.payloads).toHaveLength(1);
+    const diagnosticPayload = expectDefined(result.payloads![0], "diagnostic payload");
+    expect(diagnosticPayload.text).toBe(
+      "⚠️ Turn yielded without a continuation source. Send a message to resume.",
+    );
+    // stopReason is still end_turn (yield semantics preserved)
+    expect(result.meta.stopReason).toBe("end_turn");
+    // No pending tool calls
+    expect(result.meta.pendingToolCalls).toBeUndefined();
+  });
+
+  it("whitespace-only delivery text does not suppress diagnostic", async () => {
+    // Normalized helpers filter whitespace-only text — yield still parks
+    mockedRunEmbeddedAttempt.mockResolvedValueOnce(
+      makeAttemptResult({
+        promptError: null,
+        yieldDetected: true,
+        assistantTexts: [],
+        clientToolCalls: undefined,
+        didSendViaMessagingTool: true,
+        messagingToolSentTexts: ["   "],
+      }),
+    );
+
+    const result = await runEmbeddedAgent({
+      ...overflowBaseRunParams,
+      runId: "run-yield-whitespace-delivery",
+    });
+
+    // Whitespace-only delivery is not committed delivery → diagnostic emitted
+    expect(result.payloads).toHaveLength(1);
+    const wsPayload = expectDefined(result.payloads![0], "whitespace diagnostic payload");
+    expect(wsPayload.text).toBe(
+      "⚠️ Turn yielded without a continuation source. Send a message to resume.",
+    );
+  });
+
+  it("empty spawn array does not suppress diagnostic", async () => {
+    // An explicit empty spawn array is not a valid continuation
+    mockedRunEmbeddedAttempt.mockResolvedValueOnce(
+      makeAttemptResult({
+        promptError: null,
+        yieldDetected: true,
+        assistantTexts: [],
+        clientToolCalls: undefined,
+        acceptedSessionSpawns: [],
+      }),
+    );
+
+    const result = await runEmbeddedAgent({
+      ...overflowBaseRunParams,
+      runId: "run-yield-empty-spawn",
+    });
+
+    expect(result.payloads).toHaveLength(1);
+    const emptySpawnPayload = expectDefined(result.payloads![0], "empty spawn diagnostic payload");
+    expect(emptySpawnPayload.text).toBe(
+      "⚠️ Turn yielded without a continuation source. Send a message to resume.",
+    );
   });
 });

--- a/src/agents/embedded-agent-runner/sessions-yield.orchestration.test.ts
+++ b/src/agents/embedded-agent-runner/sessions-yield.orchestration.test.ts
@@ -85,6 +85,7 @@ describe("sessions_yield orchestration", () => {
     expect(result.meta.pendingToolCalls).toHaveLength(1);
     const hostedToolCall = expectDefined(result.meta.pendingToolCalls![0], "hosted tool call");
     expect(hostedToolCall.name).toBe("hosted_tool");
+    expect(result.payloads).toBeUndefined();
   });
 
   it("preserves order across multiple client tool calls in one attempt (#52288)", async () => {
@@ -122,8 +123,6 @@ describe("sessions_yield orchestration", () => {
 
   describe("yield with continuation evidence", () => {
     it("yield with accepted spawn — diagnostic suppressed", async () => {
-      // Pure test: runs in the outer harness where countActiveDescendantRuns
-      // returns 0, so suppression must come from the accepted spawn alone.
       // Regression: a yielded turn with an accepted spawn must NOT emit the
       // diagnostic — the spawned subagent will produce results.
       mockedRunEmbeddedAttempt.mockResolvedValueOnce(
@@ -131,7 +130,6 @@ describe("sessions_yield orchestration", () => {
           promptError: null,
           yieldDetected: true,
           assistantTexts: [],
-          clientToolCalls: undefined,
           acceptedSessionSpawns: [{ runId: "child-run", childSessionKey: "child-key" }],
         }),
       );
@@ -148,14 +146,11 @@ describe("sessions_yield orchestration", () => {
     });
 
     it("yield with async started tool — diagnostic suppressed", async () => {
-      // Pure test: runs in the outer harness where countActiveDescendantRuns
-      // returns 0, so suppression must come from the async tool alone.
       mockedRunEmbeddedAttempt.mockResolvedValueOnce(
         makeAttemptResult({
           promptError: null,
           yieldDetected: true,
           assistantTexts: [],
-          clientToolCalls: undefined,
           toolMetas: [{ toolName: "my_async_tool", asyncStarted: true }],
         }),
       );
@@ -191,7 +186,6 @@ describe("sessions_yield orchestration", () => {
         promptError: null,
         yieldDetected: true,
         assistantTexts: [],
-        clientToolCalls: undefined,
       }),
     );
 
@@ -219,7 +213,6 @@ describe("sessions_yield orchestration", () => {
         promptError: null,
         yieldDetected: true,
         assistantTexts: [],
-        clientToolCalls: undefined,
         didSendViaMessagingTool: true,
         messagingToolSentTexts: ["   "],
       }),
@@ -245,7 +238,6 @@ describe("sessions_yield orchestration", () => {
         promptError: null,
         yieldDetected: true,
         assistantTexts: [],
-        clientToolCalls: undefined,
         acceptedSessionSpawns: [],
       }),
     );


### PR DESCRIPTION
## What Problem This Solves

`sessions_yield` without a same-attempt continuation source can complete an interactive direct turn with `yieldDetected: true` and no payloads. The session is marked paused, but the user sees nothing and the agent appears hung.

Related to #100065.

## Why This Change Was Made

- Emit a visible diagnostic only when a yielded turn would otherwise return no terminal payload and has no same-attempt continuation evidence.
- Keep valid yield paths quiet when the attempt has accepted spawns, committed message delivery, async work, an approval prompt, cron work, or pending client tool calls.
- Preserve existing visible payloads without appending a duplicate warning.
- Keep yield acceptance, liveness classification, persisted state, and protocol shapes unchanged.
- Deliberately avoid session-wide active-descendant suppression: stale or unrelated descendants can exist and would recreate the reported silent park.

## User Impact

A bare `sessions_yield` now returns `⚠️ Turn yielded without a continuation source. Send a message to resume.` instead of silently parking the direct session. Legitimate same-attempt continuation and already-visible-output paths keep their existing behavior.

Contributor: SunnyShu (@SunnyShu0925). The contributor commits are preserved, and each maintainer repair commit includes `Co-authored-by: SunnyShu0925 <shu.zongyu@xydigit.com>`.

## Evidence

Exact pushed head: `faf26d9dac1f78b127189322c2368145cd85263a`

- `node scripts/run-vitest.mjs src/agents/embedded-agent-runner/run.incomplete-turn.test.ts src/agents/embedded-agent-runner/sessions-yield.orchestration.test.ts` — 148 tests passed.
- Node 24 `node scripts/check-changed.mjs -- <three changed files>` — core/core-test typecheck, targeted lint, formatting, dependency/boundary/import-cycle, and repository guards passed using the documented trusted-source local fallback after Blacksmith queue pressure in this maintainer lane.
- The temporary red-main dependency audit was repaired on the rebased base by `b7e17855b9b` (`@opentelemetry/sdk-node` to `0.220.0`, bringing `@opentelemetry/propagator-jaeger` to `2.9.0`) and `2396bd189b1` (`fast-uri` to `3.1.4`). This PR carries those repairs through its current `main` base; a local production audit now reports no high-or-higher advisories.
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main --stream-engine-output` — clean after documenting the approved same-attempt and silent-only scope; no accepted/actionable findings.
- Contributor live Gateway proof on the approved head showed a bare `sessions_yield` returning the diagnostic payload with `yielded: true`, `livenessState: "paused"`, and no tool failure.
- The focused orchestration coverage proves diagnostic emission for bare, blank-delivery, and empty-spawn yields, plus suppression for accepted spawns, async tools, and pending client tool calls.

## Compatibility

No config, environment, storage, migration, permission, or protocol change in this PR diff. The current base includes the red-main dependency audit repair noted above. No changelog edit; release-note context and contributor credit are recorded here.
