### PR TITLE
fix(control-ui): declutter Settings and make Simple/Advanced switch persistent

### DIFF
--- a/ui/src/pages/config/config-page.ts
+++ b/ui/src/pages/config/config-page.ts
@@ -1,5 +1,5 @@
 import { consume } from "@lit/context";
-import { html, LitElement } from "lit";
+import { html, LitElement, nothing } from "lit";
 import { property, state } from "lit/decorators.js";
 import type { FastMode } from "../../api/types.ts";
 import type { RouteId } from "../../app-route-paths.ts";
@@ -573,7 +573,6 @@ export class ConfigPage extends LitElement {
       excludeSections,
       includeVirtualSections: this.pageId === "communications" || this.pageId === "appearance",
       settingsLayout: this.pageId === "config" ? "accordion" : undefined,
-      onBackToQuick: this.pageId === "config" ? () => (this.settingsMode = "quick") : undefined,
       webPush: this.context.webPush.snapshot,
       onWebPushSubscribe: () => void this.context.webPush.enable(),
       onWebPushUnsubscribe: () => void this.context.webPush.disable(),
@@ -655,6 +654,10 @@ export class ConfigPage extends LitElement {
       version:
         appConfig.serverVersion ?? this.context.gateway.snapshot.hello?.server?.version ?? "",
       configObject,
+      savedConfigObject:
+        asConfigRecord(
+          runtimeConfig.state.configFormOriginal ?? runtimeConfig.state.configSnapshot?.config,
+        ) ?? {},
       configDirty: runtimeConfig.state.configFormDirty,
       configSaving: runtimeConfig.state.configSaving,
       configApplying: runtimeConfig.state.configApplying,
@@ -668,9 +671,6 @@ export class ConfigPage extends LitElement {
       onResetConfig: () => runtimeConfig.resetDraft(),
       onSaveConfig: () => void runtimeConfig.save(),
       onApplyConfig: () => void runtimeConfig.apply(),
-      onAdvancedSettings: () => {
-        this.settingsMode = "advanced";
-      },
       onThinkingChange: (level) =>
         runtimeConfig.patchForm(["agents", "defaults", "thinkingLevel"], level),
       onFastModeChange: (mode: FastMode) =>
@@ -698,6 +698,34 @@ export class ConfigPage extends LitElement {
     });
   }
 
+  private renderSettingsModeToggle() {
+    if (this.pageId !== "config") {
+      return nothing;
+    }
+    const modes = [
+      ["quick", "Simple"],
+      ["advanced", "Advanced"],
+    ] as const;
+    return html`
+      <div class="config-view-toggle qs-segmented" role="tablist" aria-label="Settings view">
+        ${modes.map(
+          ([mode, label]) => html`
+            <button
+              class="qs-segmented__btn ${this.settingsMode === mode
+                ? "qs-segmented__btn--active"
+                : ""}"
+              role="tab"
+              aria-selected=${this.settingsMode === mode}
+              @click=${() => (this.settingsMode = mode)}
+            >
+              ${label}
+            </button>
+          `,
+        )}
+      </div>
+    `;
+  }
+
   override render() {
     const configState = this.context.runtimeConfig.state;
     const configObject =
@@ -712,7 +740,11 @@ export class ConfigPage extends LitElement {
           <div class="page-title">${configPageTitle(this.pageId)}</div>
           <div class="page-sub">${configPageSubtitle(this.pageId)}</div>
         </div>
+        ${this.renderSettingsModeToggle()}
       </section>
+      ${this.pageId === "config"
+        ? html`<div class="config-view-toggle-row">${this.renderSettingsModeToggle()}</div>`
+        : nothing}
       ${renderSettingsWorkspace(
         this.context.basePath,
         body,

--- a/ui/src/pages/config/presets.ts
+++ b/ui/src/pages/config/presets.ts
@@ -19,8 +19,6 @@ export type ConfigPreset = {
   id: ConfigPresetId;
   label: string;
   description: string;
-  detail: string;
-  impact: string;
   icon: string;
   patch: ConfigPresetPatch;
 };
@@ -30,8 +28,6 @@ export const CONFIG_PRESETS: ConfigPreset[] = [
     id: "personal",
     label: "Personal Assistant",
     description: "Balanced default for daily use.",
-    detail: "Good fit for chat, docs, and light edits without a large coding budget.",
-    impact: "Injects bootstrap context every turn with a moderate prompt budget.",
     icon: "✨",
     patch: {
       agents: {
@@ -47,8 +43,6 @@ export const CONFIG_PRESETS: ConfigPreset[] = [
     id: "codeAgent",
     label: "Code Agent",
     description: "Highest context budget for repo work.",
-    detail: "Best for multi-file changes, long bootstrap docs, and code-heavy sessions.",
-    impact: "Uses the largest prompt budget and reinjects context every turn.",
     icon: "🛠️",
     patch: {
       agents: {
@@ -64,9 +58,6 @@ export const CONFIG_PRESETS: ConfigPreset[] = [
     id: "teamBot",
     label: "Team Bot",
     description: "Lean follow-ups for shared bots.",
-    detail:
-      "Best for multi-channel workflows where continuity matters more than large bootstrap payloads.",
-    impact: "Keeps follow-up turns smaller by skipping safe continuation reinjection.",
     icon: "👥",
     patch: {
       agents: {
@@ -82,8 +73,6 @@ export const CONFIG_PRESETS: ConfigPreset[] = [
     id: "minimal",
     label: "Minimal",
     description: "Smallest context budget and lowest cost.",
-    detail: "Best for quick utility turns, automations, and cost-sensitive workflows.",
-    impact: "Uses the smallest bootstrap budget and the leanest follow-up behavior.",
     icon: "⚡",
     patch: {
       agents: {

--- a/ui/src/pages/config/quick.test.ts
+++ b/ui/src/pages/config/quick.test.ts
@@ -74,7 +74,6 @@ function createProps(overrides: Partial<QuickSettingsProps> = {}): QuickSettings
     onUserAvatarChange: vi.fn(),
     configObject: {},
     onSelectPreset: vi.fn(),
-    onAdvancedSettings: vi.fn(),
     connected: true,
     gatewayUrl: "ws://localhost:18789",
     assistantName: "OpenClaw",
@@ -125,11 +124,10 @@ describe("renderQuickSettings", () => {
       "qs-card--model",
       "qs-card--channels",
       "qs-card--security",
-      "qs-card--personal",
       "qs-card--appearance",
+      "qs-card--personal",
       "qs-card--automations",
     ]);
-    expect(container.querySelectorAll(".qs-side-stack .qs-card")).toHaveLength(2);
     expect(container.querySelectorAll(".qs-card--span-all")).toHaveLength(1);
   });
 
@@ -138,13 +136,9 @@ describe("renderQuickSettings", () => {
 
     render(renderQuickSettings(createProps({ configObject: {} })), container);
 
-    const stat = Array.from(container.querySelectorAll<HTMLElement>(".qs-profile-stat")).find(
-      (candidate) =>
-        candidate.querySelector(".qs-profile-stat__label")?.textContent?.trim() ===
-        "Bootstrap Per File",
-    );
-    expect(stat?.querySelector(".qs-profile-stat__value")?.textContent?.trim()).toBe(
-      "20,000 chars",
+    const summary = container.querySelector(".qs-profiles__summary-values");
+    expect(summary?.textContent?.replace(/\s+/g, " ").trim()).toBe(
+      "20,000 chars per file · 60,000 chars total · Every turn",
     );
   });
 

--- a/ui/src/pages/config/quick.ts
+++ b/ui/src/pages/config/quick.ts
@@ -103,9 +103,6 @@ export type QuickSettingsProps = {
   onSaveConfig?: () => void;
   onApplyConfig?: () => void;
 
-  // Navigation
-  onAdvancedSettings?: () => void;
-
   // Connection
   connected: boolean;
   gatewayUrl: string;
@@ -364,33 +361,6 @@ function formatContextInjectionLabel(mode: ProfileSettings["contextInjection"]):
   return mode === "always" ? "Every turn" : "Skip safe follow-ups";
 }
 
-function describeContextInjection(mode: ProfileSettings["contextInjection"]): string {
-  return mode === "always"
-    ? "Reinject workspace bootstrap context on every turn."
-    : "Skip bootstrap reinjection after a completed safe follow-up.";
-}
-
-function renderProfileStat(params: {
-  label: string;
-  value: string;
-  previousValue: string;
-  note: string;
-}) {
-  const changed = params.value !== params.previousValue;
-  return html`
-    <div class="qs-profile-stat ${changed ? "qs-profile-stat--changed" : ""}">
-      <div class="qs-profile-stat__header">
-        <span class="qs-profile-stat__label">${params.label}</span>
-        <span class="qs-profile-stat__value">${params.value}</span>
-      </div>
-      <div class="qs-profile-stat__sub">
-        ${changed ? `Was ${params.previousValue}` : "Matches current default"}
-      </div>
-      <div class="qs-profile-stat__note muted">${params.note}</div>
-    </div>
-  `;
-}
-
 // ── Card renderers ──
 
 function renderCardHeader(icon: TemplateResult, title: string, action?: TemplateResult) {
@@ -576,7 +546,7 @@ function renderSecurityCard(props: QuickSettingsProps) {
             <span class="qs-toggle__hint muted">${browserEnabled ? "Enabled" : "Disabled"}</span>
           </label>
         </div>
-        <div class="qs-row qs-row--tool-profile">
+        <div class="qs-row qs-row--stacked">
           <span class="qs-row__label">${t("quickSettings.security.toolProfile")}</span>
           <div class="qs-segmented">
             ${toolProfiles.map(
@@ -618,8 +588,8 @@ function renderAppearanceCard(props: QuickSettingsProps) {
   return html`
     <div class="qs-card qs-card--appearance">
       ${renderCardHeader(icons.spark, "Appearance")}
-      <div class="qs-card__body">
-        <div class="qs-row">
+      <div class="qs-card__body qs-appearance">
+        <div class="qs-row qs-row--stacked">
           <span class="qs-row__label">Theme</span>
           <div class="qs-segmented">
             ${themeOptions.map(
@@ -646,7 +616,7 @@ function renderAppearanceCard(props: QuickSettingsProps) {
             )}
           </div>
         </div>
-        <div class="qs-row">
+        <div class="qs-row qs-row--stacked">
           <span class="qs-row__label">Mode</span>
           <div class="qs-segmented">
             ${(["light", "dark", "system"] as ThemeMode[]).map(
@@ -669,14 +639,13 @@ function renderAppearanceCard(props: QuickSettingsProps) {
             )}
           </div>
         </div>
-        <div class="qs-row">
+        <div class="qs-row qs-row--stacked">
           <span class="qs-row__label">Roundness</span>
           <div class="qs-segmented">
             ${BORDER_RADIUS_STOPS.map(
               (stop) => html`
                 <button
-                  class="qs-segmented__btn qs-segmented__btn--compact ${stop.value ===
-                  props.borderRadius
+                  class="qs-segmented__btn ${stop.value === props.borderRadius
                     ? "qs-segmented__btn--active"
                     : ""}"
                   @click=${() => props.setBorderRadius(stop.value)}
@@ -687,14 +656,13 @@ function renderAppearanceCard(props: QuickSettingsProps) {
             )}
           </div>
         </div>
-        <div class="qs-row">
+        <div class="qs-row qs-row--stacked">
           <span class="qs-row__label">Text size</span>
           <div class="qs-segmented">
             ${TEXT_SCALE_OPTIONS.map(
               (stop) => html`
                 <button
-                  class="qs-segmented__btn qs-segmented__btn--compact ${stop.value ===
-                  props.textScale
+                  class="qs-segmented__btn ${stop.value === props.textScale
                     ? "qs-segmented__btn--active"
                     : ""}"
                   title=${`${stop.value}%`}
@@ -752,7 +720,6 @@ function renderPersonalCard(props: QuickSettingsProps) {
             <div class="qs-identity-card__copy">
               <div class="qs-identity-card__eyebrow">User</div>
               <div class="qs-identity-card__title">${LOCAL_USER_LABEL}</div>
-              <div class="qs-identity-card__sub">Avatar is browser-local</div>
               <div class="qs-identity-card__repair">
                 <label class="qs-field">
                   <span class="qs-row__label">Avatar text / emoji</span>
@@ -884,55 +851,9 @@ function renderPresetsCard(props: QuickSettingsProps) {
     props.configReady === true &&
     props.configSaving !== true &&
     props.configApplying !== true;
-  const stateBanner = hasPendingProfileChange
-    ? html`
-        <div class="qs-profile-state qs-profile-state--pending" aria-live="polite">
-          <span class="qs-status-dot"></span>
-          <div class="qs-profile-state__text">
-            <span class="qs-profile-state__title"
-              >${selectedPreset?.label ?? "Custom"} is selected but not saved yet.</span
-            >
-            <span class="qs-profile-state__copy"
-              >Save Profile writes it as the default. Apply Now writes it and reloads the current
-              session.</span
-            >
-          </div>
-        </div>
-      `
-    : savedPreset
-      ? html`
-          <div class="qs-profile-state qs-profile-state--ok" aria-live="polite">
-            <span class="qs-status-dot qs-status-dot--ok"></span>
-            <div class="qs-profile-state__text">
-              <span class="qs-profile-state__title"
-                >${savedPreset.label} is your current default.</span
-              >
-              <span class="qs-profile-state__copy"
-                >Profiles only change bootstrap size and follow-up reinjection behavior.</span
-              >
-            </div>
-          </div>
-        `
-      : html`
-          <div class="qs-profile-state" aria-live="polite">
-            <span class="qs-status-dot"></span>
-            <div class="qs-profile-state__text">
-              <span class="qs-profile-state__title">Custom bootstrap settings are active.</span>
-              <span class="qs-profile-state__copy"
-                >Choose a built-in profile to replace the current custom values.</span
-              >
-            </div>
-          </div>
-        `;
-  const panelTitle = selectedPreset?.label ?? "Custom Configuration";
-  const panelDescription =
-    selectedPreset?.detail ?? "This config does not currently match one of the built-in profiles.";
-  const panelImpact =
-    selectedPreset?.impact ??
-    "Pick a profile to stage a focused change to bootstrap size and follow-up behavior.";
-  const commitCopy = hasPendingProfileChange
-    ? "Save Profile writes this as the default. Apply Now writes it and reloads the current session."
-    : "Other staged config edits are pending. Saving here will commit all staged config changes.";
+  const commitHint = hasPendingProfileChange
+    ? "Save writes this profile as the default. Apply Now also reloads the current session."
+    : "Staged config edits are pending. Saving commits all staged changes.";
 
   return html`
     <div class="qs-card qs-card--span-all">
@@ -946,131 +867,96 @@ function renderPresetsCard(props: QuickSettingsProps) {
             : html`<span class="qs-badge">Custom</span>`,
       )}
       <div class="qs-card__body qs-profiles">
-        <div class="qs-profiles__copy">
-          <div class="qs-profiles__eyebrow">Bootstrap Context</div>
-          <p class="qs-profiles__intro">
-            Choose how much workspace context OpenClaw injects into each run. These profiles do not
-            change your model, tools, channels, or theme.
-          </p>
-          ${stateBanner}
-          <div class="qs-presets-grid">
-            ${CONFIG_PRESETS.map((preset) => {
-              const presetDefaults = ((preset.patch.agents as Record<string, unknown> | undefined)
-                ?.defaults ?? {}) as Record<string, unknown>;
-              const presetContext =
-                presetDefaults.contextInjection === "continuation-skip"
-                  ? "continuation-skip"
-                  : "always";
-              return html`
-                <button
-                  type="button"
-                  class="qs-preset ${preset.id === selectedPresetId ? "qs-preset--active" : ""}"
-                  aria-pressed=${preset.id === selectedPresetId}
-                  @click=${() => props.onSelectPreset?.(preset.id)}
-                >
-                  <div class="qs-preset__head">
-                    <div class="qs-preset__identity">
-                      <span class="qs-preset__icon">${preset.icon}</span>
-                      <div class="qs-preset__identity-copy">
-                        <span class="qs-preset__label">${preset.label}</span>
-                        <span class="qs-preset__desc muted">${preset.description}</span>
-                      </div>
-                    </div>
-                    <div class="qs-preset__badges">
-                      ${preset.id === savedPresetId
-                        ? html`<span class="qs-badge qs-badge--ok">Current</span>`
-                        : nothing}
-                      ${hasPendingProfileChange && preset.id === selectedPresetId
-                        ? html`<span class="qs-badge qs-badge--warn">Selected</span>`
-                        : nothing}
+        <p class="qs-profiles__intro">
+          Choose how much workspace context OpenClaw injects into each run. Profiles only change
+          bootstrap size and follow-up reinjection — never your model, tools, channels, or theme.
+        </p>
+        <div class="qs-presets-grid">
+          ${CONFIG_PRESETS.map((preset) => {
+            const presetDefaults = ((preset.patch.agents as Record<string, unknown> | undefined)
+              ?.defaults ?? {}) as Record<string, unknown>;
+            const presetContext =
+              presetDefaults.contextInjection === "continuation-skip"
+                ? "continuation-skip"
+                : "always";
+            return html`
+              <button
+                type="button"
+                class="qs-preset ${preset.id === selectedPresetId ? "qs-preset--active" : ""}"
+                aria-pressed=${preset.id === selectedPresetId}
+                @click=${() => props.onSelectPreset?.(preset.id)}
+              >
+                <div class="qs-preset__head">
+                  <div class="qs-preset__identity">
+                    <span class="qs-preset__icon">${preset.icon}</span>
+                    <div class="qs-preset__identity-copy">
+                      <span class="qs-preset__label">${preset.label}</span>
+                      <span class="qs-preset__desc muted">${preset.description}</span>
                     </div>
                   </div>
-                  <div class="qs-preset__meta">
-                    <span
-                      >${formatCharBudget(Number(presetDefaults.bootstrapMaxChars ?? 0))} per
-                      file</span
-                    >
-                    <span
-                      >${formatCharBudget(Number(presetDefaults.bootstrapTotalMaxChars ?? 0))}
-                      total</span
-                    >
-                    <span>${formatContextInjectionLabel(presetContext)}</span>
+                  <div class="qs-preset__badges">
+                    ${preset.id === savedPresetId
+                      ? html`<span class="qs-badge qs-badge--ok">Current</span>`
+                      : nothing}
+                    ${hasPendingProfileChange && preset.id === selectedPresetId
+                      ? html`<span class="qs-badge qs-badge--warn">Selected</span>`
+                      : nothing}
                   </div>
-                </button>
-              `;
-            })}
-          </div>
+                </div>
+                <div class="qs-preset__meta">
+                  <span
+                    >${formatCharBudget(Number(presetDefaults.bootstrapMaxChars ?? 0))} per
+                    file</span
+                  >
+                  <span
+                    >${formatCharBudget(Number(presetDefaults.bootstrapTotalMaxChars ?? 0))}
+                    total</span
+                  >
+                  <span>${formatContextInjectionLabel(presetContext)}</span>
+                </div>
+              </button>
+            `;
+          })}
         </div>
-
-        <div class="qs-profile-panel">
-          <div class="qs-profile-panel__eyebrow">
-            ${selectedPreset ? "Selected Profile" : "Current Values"}
+        <div class="qs-profiles__footer" aria-live="polite">
+          <div class="qs-profiles__summary">
+            <span class="qs-profiles__summary-label"
+              >${selectedPreset?.label ?? "Custom values"}</span
+            >
+            <span class="qs-profiles__summary-values"
+              >${formatCharBudget(draftSettings.bootstrapMaxChars)} per file ·
+              ${formatCharBudget(draftSettings.bootstrapTotalMaxChars)} total ·
+              ${formatContextInjectionLabel(draftSettings.contextInjection)}</span
+            >
           </div>
-          <h4 class="qs-profile-panel__title">${panelTitle}</h4>
-          <p class="qs-profile-panel__copy">${panelDescription}</p>
-          <div class="qs-profile-panel__impact">${panelImpact}</div>
-
-          <div class="qs-profile-panel__stats">
-            ${renderProfileStat({
-              label: "Bootstrap Per File",
-              value: formatCharBudget(draftSettings.bootstrapMaxChars),
-              previousValue: formatCharBudget(savedSettings.bootstrapMaxChars),
-              note: "Maximum context injected from any single bootstrap file.",
-            })}
-            ${renderProfileStat({
-              label: "Bootstrap Total",
-              value: formatCharBudget(draftSettings.bootstrapTotalMaxChars),
-              previousValue: formatCharBudget(savedSettings.bootstrapTotalMaxChars),
-              note: "Total combined context allowed across all bootstrap files.",
-            })}
-            ${renderProfileStat({
-              label: "Follow-up Turns",
-              value: formatContextInjectionLabel(draftSettings.contextInjection),
-              previousValue: formatContextInjectionLabel(savedSettings.contextInjection),
-              note: describeContextInjection(draftSettings.contextInjection),
-            })}
-          </div>
-
           ${hasPendingConfigChange
             ? html`
-                <div class="qs-profile-panel__actions">
-                  <div class="qs-profile-panel__actions-copy muted">${commitCopy}</div>
-                  <div class="qs-profile-panel__actions-row">
-                    <button
-                      class="btn btn--sm"
-                      ?disabled=${props.configSaving === true || props.configApplying === true}
-                      @click=${props.onResetConfig}
-                    >
-                      Discard
-                    </button>
-                    <button
-                      class="btn btn--sm primary"
-                      ?disabled=${!canCommit}
-                      @click=${props.onSaveConfig}
-                    >
-                      ${props.configSaving === true
-                        ? "Saving…"
-                        : hasPendingProfileChange
-                          ? "Save Profile"
-                          : "Save Changes"}
-                    </button>
-                    <button
-                      class="btn btn--sm"
-                      ?disabled=${!canCommit}
-                      @click=${props.onApplyConfig}
-                    >
-                      ${props.configApplying === true ? "Applying…" : "Apply Now"}
-                    </button>
-                  </div>
+                <div class="qs-profiles__actions">
+                  <span class="qs-profiles__hint muted">${commitHint}</span>
+                  <button
+                    class="btn btn--sm"
+                    ?disabled=${props.configSaving === true || props.configApplying === true}
+                    @click=${props.onResetConfig}
+                  >
+                    Discard
+                  </button>
+                  <button
+                    class="btn btn--sm primary"
+                    ?disabled=${!canCommit}
+                    @click=${props.onSaveConfig}
+                  >
+                    ${props.configSaving === true
+                      ? "Saving…"
+                      : hasPendingProfileChange
+                        ? "Save Profile"
+                        : "Save Changes"}
+                  </button>
+                  <button class="btn btn--sm" ?disabled=${!canCommit} @click=${props.onApplyConfig}>
+                    ${props.configApplying === true ? "Applying…" : "Apply Now"}
+                  </button>
                 </div>
               `
-            : html`
-                <div class="qs-profile-panel__footer muted" aria-live="polite">
-                  ${savedPreset
-                    ? "Saved and ready. Choose another profile to stage a change."
-                    : "Current values are custom. Choose a profile to stage a change."}
-                </div>
-              `}
+            : nothing}
         </div>
       </div>
     </div>
@@ -1095,19 +981,9 @@ function renderConnectionFooter(props: QuickSettingsProps) {
 export function renderQuickSettings(props: QuickSettingsProps) {
   return html`
     <div class="qs-container">
-      <div class="qs-header">
-        <h2 class="qs-header__title">${icons.settings} Quick Settings</h2>
-        <button class="btn btn--sm" @click=${props.onAdvancedSettings}>
-          Advanced ${icons.chevronRight}
-        </button>
-      </div>
-
       <div class="qs-grid">
         ${renderModelCard(props)} ${renderChannelsCard(props)} ${renderSecurityCard(props)}
-        ${renderPersonalCard(props)}
-        <div class="qs-side-stack">
-          ${renderAppearanceCard(props)} ${renderAutomationsCard(props)}
-        </div>
+        ${renderAppearanceCard(props)} ${renderPersonalCard(props)} ${renderAutomationsCard(props)}
         ${renderPresetsCard(props)}
       </div>
 

--- a/ui/src/pages/config/view.ts
+++ b/ui/src/pages/config/view.ts
@@ -162,8 +162,6 @@ export type ConfigProps = {
   includeVirtualSections?: boolean;
   /** Layout mode: "tabs" (default flat scroll) or "accordion" (grouped collapsible). */
   settingsLayout?: "tabs" | "accordion";
-  /** Callback to navigate back to Quick Settings. Shown in accordion mode. */
-  onBackToQuick?: () => void;
   webPush?: WebPushUiState;
   onWebPushSubscribe?: () => void;
   onWebPushUnsubscribe?: () => void;
@@ -1390,23 +1388,6 @@ export function renderConfig(props: ConfigProps) {
   function renderAccordionNav() {
     return html`
       <div class="config-accordion-nav">
-        ${props.onBackToQuick
-          ? html`
-              <button class="config-accordion-nav__back" @click=${props.onBackToQuick}>
-                <svg
-                  viewBox="0 0 24 24"
-                  fill="none"
-                  stroke="currentColor"
-                  stroke-width="2"
-                  width="14"
-                  height="14"
-                >
-                  <polyline points="15 18 9 12 15 6"></polyline>
-                </svg>
-                Quick Settings
-              </button>
-            `
-          : nothing}
         ${allCategories.map(
           (cat) => html`
             <div class="config-accordion-group">

--- a/ui/src/styles/config-quick.css
+++ b/ui/src/styles/config-quick.css
@@ -8,7 +8,8 @@
   width: 100%;
 }
 
-.content-header + .settings-workspace {
+.content-header + .settings-workspace,
+.config-view-toggle-row + .settings-workspace {
   margin-top: 20px;
 }
 
@@ -148,37 +149,29 @@ openclaw-logs-page {
   padding: 32px 16px 56px;
 }
 
-.qs-header {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 16px;
-  margin-bottom: 24px;
+/* Persistent Simple/Advanced switch in the page header; keeps the way back
+   from advanced settings visible at all times. */
+.config-view-toggle {
+  flex: 0 0 auto;
+  align-self: center;
 }
 
-.qs-header__title {
-  display: flex;
-  align-items: center;
-  gap: 10px;
-  font-size: 1.35rem;
-  font-weight: 700;
-  letter-spacing: -0.02em;
-  margin: 0;
-  color: var(--text-strong);
+/* Mobile fallback: layout.mobile.css hides .content-header at small widths,
+   which would strand users in advanced mode with no way back. Mirror the
+   switch in an in-body row that only shows when the header is hidden. */
+.config-view-toggle-row {
+  display: none;
 }
 
-.qs-header__title svg {
-  width: 22px;
-  height: 22px;
-  opacity: 0.5;
-  color: currentColor;
-  stroke: currentColor;
-  fill: none;
-}
-
-.qs-header__title svg * {
-  stroke: currentColor;
-  fill: none;
+@media (max-width: 768px), (max-width: 932px) and (max-height: 500px) and (orientation: landscape) {
+  .config-view-toggle-row {
+    display: flex;
+    justify-content: flex-end;
+    width: 100%;
+    max-width: 1520px;
+    margin: 0 auto;
+    padding: 12px 16px 0;
+  }
 }
 
 /* ── Grid ── */
@@ -188,15 +181,6 @@ openclaw-logs-page {
   grid-template-columns: repeat(12, minmax(0, 1fr));
   align-items: stretch;
   gap: 14px;
-}
-
-.qs-side-stack {
-  display: grid;
-  grid-column: span 3;
-  grid-template-rows: auto 1fr;
-  align-self: stretch;
-  gap: 14px;
-  min-width: 0;
 }
 
 /* ── Card ── */
@@ -223,12 +207,17 @@ openclaw-logs-page {
 
 .qs-card--model,
 .qs-card--channels,
-.qs-card--security {
+.qs-card--security,
+.qs-card--automations {
   grid-column: span 4;
 }
 
+.qs-card--appearance {
+  grid-column: 1 / -1;
+}
+
 .qs-card--personal {
-  grid-column: span 9;
+  grid-column: span 8;
 }
 
 .qs-card--personal .qs-identity-grid {
@@ -355,21 +344,43 @@ openclaw-logs-page {
   color: var(--accent);
 }
 
-.qs-row--tool-profile {
+/* Stacked row: label above a full-width, equal-segment control. Used where a
+   side-by-side row would wrap unpredictably (Appearance, tool profile). */
+.qs-row--stacked {
   align-items: stretch;
   flex-direction: column;
   gap: 8px;
   padding-block: 10px;
 }
 
-.qs-row--tool-profile .qs-row__label {
+.qs-row--stacked .qs-row__label {
   flex: 0 0 auto;
   width: 100%;
 }
 
-.qs-row--tool-profile .qs-segmented {
+.qs-row--stacked .qs-segmented {
   align-self: stretch;
   justify-content: flex-start;
+}
+
+.qs-row--stacked .qs-segmented__btn {
+  flex: 1 1 0;
+  padding-inline: 6px;
+  text-align: center;
+}
+
+/* ── Appearance card ── */
+
+.qs-appearance {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(min(240px, 100%), 1fr));
+  gap: 0 24px;
+  padding: 2px 16px 8px;
+}
+
+.qs-appearance .qs-row {
+  border-top: none;
+  padding-inline: 0;
 }
 
 .qs-field {
@@ -412,12 +423,6 @@ openclaw-logs-page {
   border: 1px solid color-mix(in srgb, var(--border) 60%, transparent);
   border-radius: var(--radius-md);
   background: color-mix(in srgb, var(--bg-elevated) 42%, var(--card) 58%);
-  box-shadow: inset 3px 0 0 color-mix(in srgb, var(--accent) 42%, transparent);
-}
-
-.qs-identity-card--assistant {
-  background: color-mix(in srgb, var(--bg-elevated) 50%, var(--card) 50%);
-  box-shadow: inset 3px 0 0 color-mix(in srgb, var(--border-strong) 70%, transparent);
 }
 
 .qs-identity-card__copy {
@@ -537,7 +542,7 @@ openclaw-logs-page {
   flex: 0 0 auto;
   border-radius: calc(var(--radius-md) + 2px);
   border: 1px solid color-mix(in srgb, var(--border) 70%, transparent);
-  box-shadow: 0 8px 20px rgba(0, 0, 0, 0.16);
+  box-shadow: var(--shadow-sm);
   object-fit: cover;
   object-position: center;
 }
@@ -787,29 +792,6 @@ openclaw-logs-page {
   margin-bottom: 20px;
 }
 
-.config-accordion-nav__back {
-  display: flex;
-  align-items: center;
-  gap: 6px;
-  font-size: 0.8125rem;
-  font-weight: 600;
-  color: var(--accent);
-  background: none;
-  border: none;
-  cursor: pointer;
-  padding: 8px 12px;
-  margin-bottom: 8px;
-  border-radius: var(--radius-md);
-  transition:
-    opacity var(--duration-fast) var(--ease-out),
-    background var(--duration-fast) var(--ease-out);
-}
-
-.config-accordion-nav__back:hover {
-  opacity: 0.85;
-  background: var(--accent-subtle);
-}
-
 .config-accordion-group {
   border: 1px solid color-mix(in srgb, var(--border) 70%, transparent);
   border-radius: var(--radius-md);
@@ -914,91 +896,68 @@ openclaw-logs-page {
 
 /* ── Presets Grid ── */
 
-.qs-presets-grid {
-  display: grid;
-  grid-template-columns: repeat(2, minmax(0, 1fr));
-  gap: 10px;
-  padding: 0;
-}
-
 .qs-profiles {
   display: grid;
-  grid-template-columns: minmax(0, 1.3fr) minmax(280px, 0.9fr);
-  gap: 18px;
-  padding: 18px 16px 16px;
-  background: linear-gradient(
-    180deg,
-    color-mix(in srgb, var(--accent-subtle) 18%, transparent) 0%,
-    transparent 36%
-  );
-}
-
-.qs-profiles__copy {
-  min-width: 0;
-  display: flex;
-  flex-direction: column;
   gap: 14px;
-}
-
-.qs-profiles__eyebrow {
-  font-size: 0.6875rem;
-  font-weight: 700;
-  letter-spacing: 0.08em;
-  text-transform: uppercase;
-  color: color-mix(in srgb, var(--accent) 68%, var(--muted) 32%);
+  padding: 14px 16px 16px;
 }
 
 .qs-profiles__intro {
   margin: 0;
-  max-width: 62ch;
+  max-width: 78ch;
   font-size: 0.8125rem;
   line-height: 1.55;
   color: var(--muted);
   text-wrap: pretty;
 }
 
-.qs-profile-state {
-  display: flex;
-  align-items: flex-start;
+.qs-presets-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(min(230px, 100%), 1fr));
   gap: 10px;
-  padding: 12px 14px;
-  border: 1px solid color-mix(in srgb, var(--border) 70%, transparent);
-  border-radius: var(--radius-md);
-  background: color-mix(in srgb, var(--bg-elevated) 72%, var(--card) 28%);
 }
 
-.qs-profile-state--pending {
-  border-color: color-mix(in srgb, var(--accent) 28%, var(--border) 72%);
-  background: color-mix(in srgb, var(--accent-subtle) 42%, var(--card) 58%);
-}
-
-.qs-profile-state--pending .qs-status-dot {
-  background: var(--accent);
-  box-shadow: 0 0 10px color-mix(in srgb, var(--accent) 24%, transparent);
-}
-
-.qs-profile-state--ok {
-  border-color: color-mix(in srgb, var(--ok) 24%, var(--border) 76%);
-  background: color-mix(in srgb, var(--ok-subtle) 58%, var(--card) 42%);
-}
-
-.qs-profile-state__text {
-  min-width: 0;
+.qs-profiles__footer {
   display: flex;
-  flex-direction: column;
-  gap: 2px;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px 16px;
+  padding-top: 12px;
+  border-top: 1px solid color-mix(in srgb, var(--border) 50%, transparent);
 }
 
-.qs-profile-state__title {
+.qs-profiles__summary {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: baseline;
+  gap: 4px 10px;
+  min-width: 0;
+}
+
+.qs-profiles__summary-label {
   font-size: 0.8125rem;
   font-weight: 650;
   color: var(--text-strong);
 }
 
-.qs-profile-state__copy {
+.qs-profiles__summary-values {
   font-size: 0.75rem;
-  line-height: 1.45;
   color: var(--muted);
+}
+
+.qs-profiles__actions {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 8px;
+}
+
+.qs-profiles__hint {
+  font-size: 0.75rem;
+  line-height: 1.4;
+  max-width: 46ch;
 }
 
 .qs-preset {
@@ -1022,25 +981,18 @@ openclaw-logs-page {
 .qs-preset:hover {
   border-color: color-mix(in srgb, var(--accent) 40%, var(--border) 60%);
   background: color-mix(in srgb, var(--accent-subtle) 40%, var(--card) 60%);
-  box-shadow: 0 10px 24px rgba(0, 0, 0, 0.16);
-  transform: translateY(-1px);
 }
 
 .qs-preset:focus-visible {
   outline: none;
   border-color: color-mix(in srgb, var(--accent) 55%, var(--border) 45%);
-  box-shadow:
-    0 0 0 2px color-mix(in srgb, var(--accent) 18%, transparent),
-    0 8px 24px rgba(0, 0, 0, 0.18);
+  box-shadow: 0 0 0 2px color-mix(in srgb, var(--accent) 18%, transparent);
 }
 
 .qs-preset--active {
   border-color: color-mix(in srgb, var(--accent) 50%, var(--border) 50%);
   background: color-mix(in srgb, var(--accent-subtle) 60%, var(--card) 40%);
-  box-shadow:
-    0 0 0 1px color-mix(in srgb, var(--accent) 15%, transparent),
-    0 12px 28px rgba(0, 0, 0, 0.2);
-  transform: translateY(-1px);
+  box-shadow: 0 0 0 1px color-mix(in srgb, var(--accent) 15%, transparent);
 }
 
 .qs-preset--active:hover {
@@ -1111,180 +1063,20 @@ openclaw-logs-page {
   background: color-mix(in srgb, var(--bg-elevated) 84%, transparent);
 }
 
-.qs-profile-panel {
-  min-width: 0;
-  display: flex;
-  flex-direction: column;
-  gap: 12px;
-  padding: 16px;
-  border-radius: var(--radius-lg);
-  border: 1px solid color-mix(in srgb, var(--border) 70%, transparent);
-  background: color-mix(in srgb, var(--bg-elevated) 76%, var(--card) 24%);
-}
-
-.qs-profile-panel__eyebrow {
-  font-size: 0.6875rem;
-  font-weight: 700;
-  letter-spacing: 0.08em;
-  text-transform: uppercase;
-  color: color-mix(in srgb, var(--accent) 68%, var(--muted) 32%);
-}
-
-.qs-profile-panel__title {
-  margin: 0;
-  font-size: 1.08rem;
-  font-weight: 700;
-  letter-spacing: -0.02em;
-  color: var(--text-strong);
-  text-wrap: balance;
-}
-
-.qs-profile-panel__copy {
-  margin: 0;
-  font-size: 0.8125rem;
-  line-height: 1.55;
-  color: var(--text);
-}
-
-.qs-profile-panel__impact {
-  font-size: 0.75rem;
-  line-height: 1.5;
-  color: var(--muted);
-}
-
-.qs-profile-panel__stats {
-  display: grid;
-  gap: 10px;
-}
-
-.qs-profile-stat {
-  display: grid;
-  gap: 4px;
-  padding: 12px;
-  border: 1px solid color-mix(in srgb, var(--border) 62%, transparent);
-  border-radius: var(--radius-md);
-  background: color-mix(in srgb, var(--card) 84%, transparent);
-}
-
-.qs-profile-stat--changed {
-  border-color: color-mix(in srgb, var(--accent) 32%, var(--border) 68%);
-  background: color-mix(in srgb, var(--accent-subtle) 44%, var(--card) 56%);
-}
-
-.qs-profile-stat__header {
-  display: flex;
-  align-items: flex-start;
-  justify-content: space-between;
-  gap: 12px;
-}
-
-.qs-profile-stat__label {
-  font-size: 0.6875rem;
-  font-weight: 700;
-  letter-spacing: 0.06em;
-  text-transform: uppercase;
-  color: var(--muted);
-}
-
-.qs-profile-stat__value {
-  font-size: 0.875rem;
-  font-weight: 650;
-  color: var(--text-strong);
-  text-align: right;
-}
-
-.qs-profile-stat__sub {
-  font-size: 0.75rem;
-  font-weight: 600;
-  color: var(--muted);
-}
-
-.qs-profile-stat--changed .qs-profile-stat__sub {
-  color: var(--accent);
-}
-
-.qs-profile-stat__note {
-  font-size: 0.75rem;
-  line-height: 1.45;
-}
-
-.qs-profile-panel__actions {
-  display: grid;
-  gap: 10px;
-  padding-top: 4px;
-  border-top: 1px solid color-mix(in srgb, var(--border) 55%, transparent);
-}
-
-.qs-profile-panel__actions-copy,
-.qs-profile-panel__footer {
-  font-size: 0.75rem;
-  line-height: 1.5;
-}
-
-.qs-profile-panel__actions-row {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 8px;
-}
-
-.qs-profile-panel__footer {
-  padding-top: 4px;
-  border-top: 1px solid color-mix(in srgb, var(--border) 55%, transparent);
-}
-
 @media (max-width: 1100px) {
   .qs-grid {
     grid-template-columns: repeat(2, minmax(0, 1fr));
     align-items: stretch;
   }
 
-  .qs-side-stack {
-    display: contents;
-  }
-
-  .qs-card,
-  .qs-card--span-all,
-  .qs-card--personal,
-  .qs-card--model,
-  .qs-card--channels,
-  .qs-card--security,
-  .qs-card--appearance,
-  .qs-card--automations {
+  .qs-card {
     grid-column: span 1;
   }
 
+  .qs-card--appearance,
   .qs-card--personal,
   .qs-card--span-all {
     grid-column: 1 / -1;
-  }
-
-  .qs-card--model {
-    order: 1;
-  }
-
-  .qs-card--channels {
-    order: 2;
-  }
-
-  .qs-card--security {
-    order: 3;
-  }
-
-  .qs-card--appearance {
-    order: 5;
-  }
-
-  .qs-card--personal {
-    order: 4;
-  }
-
-  .qs-card--automations {
-    grid-column: 1 / -1;
-    order: 6;
-  }
-
-  .qs-card--span-all {
-    order: 7;
   }
 }
 
@@ -1295,6 +1087,17 @@ openclaw-logs-page {
 
   .qs-card--personal .qs-identity-grid {
     grid-template-columns: 1fr;
+  }
+
+  .qs-profiles__footer,
+  .qs-profiles__actions {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .qs-profiles__actions .btn {
+    width: 100%;
+    justify-content: center;
   }
 }
 
@@ -1314,34 +1117,5 @@ openclaw-logs-page {
 
   .qs-identity-grid {
     grid-template-columns: 1fr;
-  }
-
-  .qs-header {
-    align-items: flex-start;
-  }
-
-  .qs-header__title {
-    font-size: 1.15rem;
-  }
-}
-
-@media (max-width: 920px) {
-  .qs-profiles {
-    grid-template-columns: 1fr;
-  }
-}
-
-@media (max-width: 720px) {
-  .qs-presets-grid {
-    grid-template-columns: 1fr;
-  }
-
-  .qs-profile-panel__actions-row {
-    flex-direction: column;
-  }
-
-  .qs-profile-panel__actions-row .btn {
-    width: 100%;
-    justify-content: center;
   }
 }


### PR DESCRIPTION
Closes #100145

## What Problem This Solves

Fixes an issue where the Control UI **Settings** page (`/config`) was cluttered and had a one-way trap into Advanced mode.

- The **Appearance** card was squeezed into a narrow side column, so its four segmented controls (Theme, Mode, Roundness, Text size) wrapped onto multiple lines, the "Roundness" label was clipped by its control, and the "Import" theme option orphaned onto its own row.
- The **Context Profile** card printed every preset's numbers twice (grid + a side "stat" panel) and showed a red "selected but not saved yet" pending banner even when nothing was staged, because the quick view was never given the saved config to diff against.
- After clicking **Advanced ›**, the only way back to the simple view was a small "Quick Settings" text button buried at the top of the accordion section list — nothing where the user had just clicked. Users concluded they were stuck.

## Why This Change Was Made

The redesign turns Quick Settings into a calmer dashboard and makes the simple/advanced choice a persistent, symmetric control:

- **Persistent Simple / Advanced switch** in the page header (`config-page.ts`), replacing the one-way "Advanced ›" button and the buried in-accordion "Quick Settings" back link. A mirrored in-body toggle row shows only at the mobile breakpoint, where the page header is hidden — so mobile users are never stranded in Advanced mode.
- **Appearance card** now spans the full row and lays its four controls out in an auto-fitting grid with equal-width segments, so nothing wraps or clips at any width.
- **Context Profile card** drops the duplicate side panel for a single compact "current values" summary line, and only claims **Pending** when a change is actually staged (`savedConfigObject` is now passed so the diff is real).
- General declutter: removed the redundant in-page "Quick Settings" heading (the page already has a "Settings" title), tightened card shadows/hover, and simplified the Personal card. Net ‑655 lines across the two largest files.

No config, protocol, or storage contract changes — this is presentation only within `ui/src/pages/config` and its stylesheet.

## User Impact

- Settings reads as one clean dashboard instead of competing panels; the Appearance controls no longer wrap or overlap.
- Switching between Simple and Advanced is always one obvious click, in the same place, in both directions — on desktop and mobile.
- The Context Profile card no longer cries "Pending" when nothing changed.

## Evidence

**Before / After — Quick Settings (desktop)**

| Before | After |
| --- | --- |
| ![before](https://raw.githubusercontent.com/steipete/openclaw-pr-assets/main/config-quick-settings-redesign/before-quick-settings.png) | ![after](https://raw.githubusercontent.com/steipete/openclaw-pr-assets/main/config-quick-settings-redesign/after-quick-settings-full.png) |

**Advanced view — the way back**

| Before (only a buried "Quick Settings" link) | After (persistent Simple/Advanced switch, top-right) |
| --- | --- |
| ![before advanced](https://raw.githubusercontent.com/steipete/openclaw-pr-assets/main/config-quick-settings-redesign/before-advanced.png) | ![after advanced](https://raw.githubusercontent.com/steipete/openclaw-pr-assets/main/config-quick-settings-redesign/after-advanced.png) |

**Mobile** — the page header is hidden at ≤768px, so the switch is mirrored into an in-body row (verified in Advanced mode; the Simple button returns to the quick view):

![after mobile advanced](https://raw.githubusercontent.com/steipete/openclaw-pr-assets/main/config-quick-settings-redesign/after-mobile-advanced.png)

**Validation** (local, worktree checkout against a scratch gateway):

- `node scripts/run-vitest.mjs ui/src/pages/config/quick.test.ts ui/src/pages/config/presets.test.ts` → 19 passed
- `node scripts/run-vitest.mjs ui/src/pages/config/view.browser.test.ts` → 27 passed
- `node scripts/run-tsgo.mjs -p tsconfig.core.json` → clean (covers `ui/**`)
- `oxfmt --check` on all touched files → clean
- Codex autoreview (`autoreview --mode local`) → clean after the mobile-visibility fix (it caught the original header-only toggle stranding mobile users; addressed by the mirrored in-body row).
- Before/after screenshots captured with Playwright against the live dev Control UI.
