### PR TITLE
fix(auto-reply): deliver model directive acknowledgements

### DIFF
--- a/src/auto-reply/reply/get-reply-directives.target-session.test.ts
+++ b/src/auto-reply/reply/get-reply-directives.target-session.test.ts
@@ -2,6 +2,7 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { SessionEntry } from "../../config/sessions.js";
 import { SessionWorkStartInvalidatedError } from "../../config/sessions/lifecycle.js";
+import { getReplyPayloadMetadata } from "../reply-payload.js";
 import type { TemplateContext } from "../templating.js";
 import { resolveReplyDirectives } from "./get-reply-directives.js";
 import { buildTestCtx } from "./test-ctx.js";
@@ -367,6 +368,26 @@ describe("resolveReplyDirectives", () => {
     expect(result).toEqual({ kind: "reply", reply: { text: error.message } });
     expect(typing.cleanup).toHaveBeenCalledOnce();
     expect(mocks.applyInlineDirectiveOverrides).not.toHaveBeenCalled();
+  });
+
+  it("marks terminal directive replies for delivery under source suppression", async () => {
+    mocks.applyInlineDirectiveOverrides.mockResolvedValueOnce({
+      kind: "reply",
+      reply: { text: "Model set to fable (anthropic/claude-fable-5) for this session." },
+    });
+
+    const { result } = await resolveHelloWithModelDefaults({
+      body: "/model fable",
+      commandAuthorized: true,
+      defaultThinking: "off",
+      defaultReasoning: "on",
+    });
+
+    expect(result.kind).toBe("reply");
+    if (result.kind !== "reply" || !result.reply || Array.isArray(result.reply)) {
+      throw new Error("expected a single directive reply");
+    }
+    expect(getReplyPayloadMetadata(result.reply)?.deliverDespiteSourceReplySuppression).toBe(true);
   });
 
   it("keeps one-turn fast mode with the resolved fast mode", async () => {

--- a/src/auto-reply/reply/get-reply-directives.ts
+++ b/src/auto-reply/reply/get-reply-directives.ts
@@ -15,6 +15,7 @@ import { normalizeAgentId } from "../../routing/session-key.js";
 import { createLazyImportLoader } from "../../shared/lazy-promise.js";
 import type { SkillCommandSpec } from "../../skills/types.js";
 import { shouldHandleTextCommands } from "../commands-text-routing.js";
+import { markCommandReplyForDelivery } from "../reply-payload.js";
 import type { MsgContext, TemplateContext } from "../templating.js";
 import {
   normalizeThinkLevel,
@@ -651,7 +652,7 @@ export async function resolveReplyDirectives(params: {
     typing,
   });
   if (applyResult.kind === "reply") {
-    return { kind: "reply", reply: applyResult.reply };
+    return { kind: "reply", reply: markCommandReplyForDelivery(applyResult.reply) };
   }
   directives = applyResult.directives;
   provider = applyResult.provider;


### PR DESCRIPTION
## Summary

- deliver directive-only command acknowledgements when source reply suppression is active
- add regression coverage for model alias confirmations such as /model fable

## Test plan

- pnpm test src/auto-reply/reply/get-reply-directives.target-session.test.ts src/auto-reply/reply/get-reply-directives-apply.test.ts src/auto-reply/reply/get-reply-inline-actions.skip-when-config-empty.test.ts
- pnpm check
- pnpm build
- autoreview with Codex GPT-5.5: clean