### PR TITLE
feat: mobile operator terminal (Android) hosting the full-screen web terminal view

### DIFF
--- a/apps/android/app/src/main/java/ai/openclaw/app/MainViewModel.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/MainViewModel.kt
@@ -113,6 +113,8 @@ class MainViewModel(
   val notificationForwardingSessionKey: StateFlow<String?> = prefs.notificationForwardingSessionKey
 
   val isConnected: StateFlow<Boolean> = runtimeState(initial = false) { it.isConnected }
+  val gatewayControlPage: StateFlow<NodeRuntime.GatewayControlPage?> =
+    runtimeState(initial = null) { it.gatewayControlPage }
   val isNodeConnected: StateFlow<Boolean> = runtimeState(initial = false) { it.nodeConnected }
   val nodeCapabilityApproval: StateFlow<GatewayNodeCapabilityApproval> =
     runtimeState(initial = GatewayNodeCapabilityApproval.Loading) { it.nodeCapabilityApproval }

--- a/apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt
@@ -1,7 +1,7 @@
 package ai.openclaw.app
 
-import ai.openclaw.app.chat.ChatController
 import ai.openclaw.app.chat.ChatCommandEntry
+import ai.openclaw.app.chat.ChatController
 import ai.openclaw.app.chat.ChatMessage
 import ai.openclaw.app.chat.ChatPendingToolCall
 import ai.openclaw.app.chat.ChatSessionEntry
@@ -16,6 +16,7 @@ import ai.openclaw.app.gateway.GatewayTlsProbeFailure
 import ai.openclaw.app.gateway.GatewayTlsProbeResult
 import ai.openclaw.app.gateway.GatewayUpdateAvailableSummary
 import ai.openclaw.app.gateway.NodeEventSendOutcome
+import ai.openclaw.app.gateway.formatGatewayAuthority
 import ai.openclaw.app.gateway.normalizeGatewayApprovalRequestId
 import ai.openclaw.app.gateway.normalizeGatewayTlsFingerprint
 import ai.openclaw.app.gateway.parseChatSendAck
@@ -302,6 +303,17 @@ class NodeRuntime(
     val password: String?,
   )
 
+  /**
+   * HTTP(S) page origin of the connected gateway plus the shared credential a
+   * gateway-served page (e.g. the `?view=terminal` Control UI document) can
+   * authenticate with. Derived from the same endpoint/auth the WS sessions use.
+   */
+  data class GatewayControlPage(
+    val baseUrl: String,
+    val token: String?,
+    val password: String?,
+  )
+
   private val appContext = context.applicationContext
   private val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
   private val deviceAuthStore = DeviceAuthStore(prefs)
@@ -490,6 +502,8 @@ class NodeRuntime(
 
   private val _isConnected = MutableStateFlow(false)
   val isConnected: StateFlow<Boolean> = _isConnected.asStateFlow()
+  private val _gatewayControlPage = MutableStateFlow<GatewayControlPage?>(null)
+  val gatewayControlPage: StateFlow<GatewayControlPage?> = _gatewayControlPage.asStateFlow()
   private val _nodeConnected = MutableStateFlow(false)
   val nodeConnected: StateFlow<Boolean> = _nodeConnected.asStateFlow()
   private val _nodeCapabilityApproval = MutableStateFlow<GatewayNodeCapabilityApproval>(GatewayNodeCapabilityApproval.Loading)
@@ -1964,6 +1978,12 @@ class NodeRuntime(
   ) {
     if (!isCurrentConnectAttempt(connectAttemptId)) return
     connectedEndpoint = endpoint
+    _gatewayControlPage.value =
+      GatewayControlPage(
+        baseUrl = gatewayControlPageBaseUrl(endpoint),
+        token = auth.token?.trim()?.takeIf { it.isNotEmpty() },
+        password = auth.password?.trim()?.takeIf { it.isNotEmpty() },
+      )
     updateStatus {
       operatorConnectionProblem = null
       nodeConnectionProblem = null
@@ -1982,6 +2002,12 @@ class NodeRuntime(
     auth: GatewayConnectAuth,
   ) {
     beginConnect(endpoint = endpoint, auth = resolveGatewayConnectAuth(auth))
+  }
+
+  /** HTTP(S) origin serving the connected gateway's Control UI pages. */
+  private fun gatewayControlPageBaseUrl(endpoint: GatewayEndpoint): String {
+    val scheme = if (endpoint.tlsEnabled) "https" else "http"
+    return "$scheme://${formatGatewayAuthority(endpoint.host, endpoint.port)}"
   }
 
   internal fun resolveGatewayConnectAuth(explicitAuth: GatewayConnectAuth? = null): GatewayConnectAuth =
@@ -2075,6 +2101,7 @@ class NodeRuntime(
     connectAttemptSeq.incrementAndGet()
     stopActiveVoiceSession()
     connectedEndpoint = null
+    _gatewayControlPage.value = null
     activeGatewayAuth = null
     updateStatus {
       operatorConnectionProblem = null
@@ -3635,11 +3662,9 @@ internal fun parseGatewayNodeApprovalState(raw: String?): GatewayNodeApprovalSta
     else -> GatewayNodeApprovalState.Loading
   }
 
-internal fun gatewayEventInvalidatesNodesDevices(event: String): Boolean =
-  event == "node.pair.requested" || event == "node.pair.resolved"
+internal fun gatewayEventInvalidatesNodesDevices(event: String): Boolean = event == "node.pair.requested" || event == "node.pair.resolved"
 
-internal fun nodeConnectFailureNeedsApprovalRefresh(error: GatewaySession.ErrorShape): Boolean =
-  error.details?.code == "PAIRING_REQUIRED"
+internal fun nodeConnectFailureNeedsApprovalRefresh(error: GatewaySession.ErrorShape): Boolean = error.details?.code == "PAIRING_REQUIRED"
 
 internal fun currentNodeCapabilityApproval(
   nodes: List<GatewayNodeSummary>,

--- a/apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt
@@ -140,6 +140,7 @@ internal enum class SettingsRoute {
   Channels,
   Dreaming,
   Canvas,
+  Terminal,
   Notifications,
   PhoneCapabilities,
   Gateway,
@@ -172,6 +173,7 @@ internal fun SettingsDetailScreen(
     SettingsRoute.Channels -> ChannelsSettingsScreen(viewModel = viewModel, onBack = onBack)
     SettingsRoute.Dreaming -> DreamingSettingsScreen(viewModel = viewModel, onBack = onBack)
     SettingsRoute.Canvas -> CanvasSettingsScreen(viewModel = viewModel, onBack = onBack)
+    SettingsRoute.Terminal -> TerminalSettingsScreen(viewModel = viewModel, onBack = onBack)
     SettingsRoute.Notifications -> NotificationSettingsScreen(viewModel = viewModel, onBack = onBack)
     SettingsRoute.PhoneCapabilities -> PhoneCapabilitiesScreen(viewModel = viewModel, onBack = onBack)
     SettingsRoute.Gateway -> GatewaySettingsScreen(viewModel = viewModel, onBack = onBack)

--- a/apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt
@@ -77,6 +77,7 @@ import androidx.compose.material.icons.outlined.ChatBubbleOutline
 import androidx.compose.material.icons.outlined.Inventory2
 import androidx.compose.material.icons.outlined.MicNone
 import androidx.compose.material.icons.outlined.Settings
+import androidx.compose.material.icons.outlined.Terminal
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
@@ -1436,6 +1437,7 @@ private fun SettingsShellScreen(
           SettingsRow("Usage", usageSummaryText(usageSummary.providers.size), Icons.Default.Storage, status = if (usageSummary.providers.isNotEmpty()) true else null, route = SettingsRoute.Usage),
           SettingsRow("Skills", skillsSummaryText(skillsSummary.skills), Icons.Default.Settings, status = skillsStatus(skillsSummary.skills), route = SettingsRoute.Skills),
           SettingsRow("Dreaming", dreamingSummaryText(dreamingSummary), Icons.Default.Storage, status = dreamingStatus(dreamingSummary), route = SettingsRoute.Dreaming),
+          SettingsRow("Terminal", "Shell in the agent workspace", Icons.Outlined.Terminal, status = isConnected, route = SettingsRoute.Terminal),
           SettingsRow("Voice", if (speakerEnabled) "Speaker on" else "Speaker muted", Icons.Default.Mic, route = SettingsRoute.Voice),
           SettingsRow("Canvas", "Screen surface", Icons.AutoMirrored.Filled.ScreenShare, status = isConnected, route = SettingsRoute.Canvas),
           SettingsRow("Notifications", if (notificationForwardingEnabled) "Smart delivery" else "Off", Icons.Default.Notifications, route = SettingsRoute.Notifications),
@@ -1642,6 +1644,7 @@ internal fun settingsSectionTitleForRoute(route: SettingsRoute): String =
     SettingsRoute.Usage,
     SettingsRoute.Skills,
     SettingsRoute.Dreaming,
+    SettingsRoute.Terminal,
     -> "Agents & automation"
 
     SettingsRoute.Voice,

--- a/apps/android/app/src/main/java/ai/openclaw/app/ui/TerminalSettingsScreen.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/ui/TerminalSettingsScreen.kt
@@ -1,0 +1,173 @@
+package ai.openclaw.app.ui
+
+import ai.openclaw.app.MainViewModel
+import ai.openclaw.app.NodeRuntime
+import ai.openclaw.app.ui.design.ClawPlainIconButton
+import ai.openclaw.app.ui.design.ClawScaffold
+import ai.openclaw.app.ui.design.ClawTheme
+import android.annotation.SuppressLint
+import android.view.View
+import android.webkit.WebSettings
+import android.webkit.WebView
+import android.webkit.WebViewClient
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.imePadding
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.outlined.Terminal
+import androidx.compose.material3.Icon
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.key
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.viewinterop.AndroidView
+import androidx.webkit.WebSettingsCompat
+import androidx.webkit.WebViewCompat
+import androidx.webkit.WebViewFeature
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.put
+
+/**
+ * Full-height terminal surface: embeds the gateway-served terminal-only
+ * Control UI document (`/?view=terminal`, the same ghostty-web surface the
+ * desktop Control UI uses) for the currently connected gateway.
+ */
+@Composable
+internal fun TerminalSettingsScreen(
+  viewModel: MainViewModel,
+  onBack: () -> Unit,
+) {
+  val isConnected by viewModel.isConnected.collectAsState()
+  val controlPage by viewModel.gatewayControlPage.collectAsState()
+  ClawScaffold(
+    contentPadding = PaddingValues(start = ClawTheme.spacing.lg, top = 14.dp, end = ClawTheme.spacing.lg, bottom = 6.dp),
+  ) {
+    Column(modifier = Modifier.fillMaxSize().imePadding(), verticalArrangement = Arrangement.spacedBy(10.dp)) {
+      Row(modifier = Modifier.fillMaxWidth(), verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(9.dp)) {
+        ClawPlainIconButton(
+          icon = Icons.AutoMirrored.Filled.ArrowBack,
+          contentDescription = "Back",
+          onClick = onBack,
+        )
+        Text(text = "Terminal", style = ClawTheme.type.title, color = ClawTheme.colors.text, modifier = Modifier.weight(1f), maxLines = 1, overflow = TextOverflow.Ellipsis)
+        Icon(imageVector = Icons.Outlined.Terminal, contentDescription = null, tint = ClawTheme.colors.textMuted)
+      }
+      Box(modifier = Modifier.fillMaxWidth().weight(1f)) {
+        val page = controlPage
+        if (isConnected && page != null) {
+          // Recreate the WebView only when the gateway page or credentials
+          // change; recompositions must not restart live shell sessions.
+          key(page) {
+            TerminalWebView(page = page, modifier = Modifier.fillMaxSize())
+          }
+        } else {
+          Column(modifier = Modifier.fillMaxWidth().padding(top = 48.dp), horizontalAlignment = Alignment.CenterHorizontally, verticalArrangement = Arrangement.spacedBy(6.dp)) {
+            Text(text = "Terminal needs a connected gateway", style = ClawTheme.type.section, color = ClawTheme.colors.text)
+            Text(text = "Connect to your gateway to open a shell in the agent workspace.", style = ClawTheme.type.body, color = ClawTheme.colors.textMuted)
+          }
+        }
+      }
+    }
+  }
+}
+
+/** Minimal WebView host for the terminal page; no script bridges needed. */
+@SuppressLint("SetJavaScriptEnabled")
+// Deprecated file-URL settings are still force-disabled defensively, like the canvas host.
+@Suppress("DEPRECATION")
+@Composable
+private fun TerminalWebView(
+  page: NodeRuntime.GatewayControlPage,
+  modifier: Modifier = Modifier,
+) {
+  val context = LocalContext.current
+  val webViewRef = remember { arrayOfNulls<WebView>(1) }
+
+  DisposableEffect(Unit) {
+    onDispose {
+      val webView = webViewRef[0] ?: return@onDispose
+      webView.stopLoading()
+      webView.destroy()
+      webViewRef[0] = null
+    }
+  }
+
+  AndroidView(
+    modifier = modifier,
+    factory = {
+      val webView = WebView(context)
+      val webSettings = webView.settings
+      webSettings.setAllowContentAccess(false)
+      webSettings.setAllowFileAccess(false)
+      webSettings.setAllowFileAccessFromFileURLs(false)
+      webSettings.setAllowUniversalAccessFromFileURLs(false)
+      webSettings.setSafeBrowsingEnabled(true)
+      webSettings.javaScriptEnabled = true
+      webSettings.domStorageEnabled = true
+      webSettings.mixedContentMode = WebSettings.MIXED_CONTENT_COMPATIBILITY_MODE
+      webSettings.builtInZoomControls = false
+      webSettings.displayZoomControls = false
+      webSettings.setSupportZoom(false)
+      // targetSdk 33+ ignores Force Dark APIs; the terminal page owns its own
+      // dark palette, so opt out of algorithmic darkening like the canvas host.
+      if (WebViewFeature.isFeatureSupported(WebViewFeature.ALGORITHMIC_DARKENING)) {
+        WebSettingsCompat.setAlgorithmicDarkeningAllowed(webSettings, false)
+      }
+      webView.overScrollMode = View.OVER_SCROLL_NEVER
+      webView.webViewClient = WebViewClient()
+      installTerminalAuthScript(webView, page)
+      webView.loadUrl("${page.baseUrl}/?view=terminal")
+      webViewRef[0] = webView
+      webView
+    },
+  )
+}
+
+/**
+ * Hands the gateway credentials to the Control UI via its
+ * `__OPENCLAW_NATIVE_CONTROL_AUTH__` startup contract (the same mechanism the
+ * macOS Dashboard and iOS Terminal hub use), origin-locked by the platform's
+ * allowed-origin rules, so the token never appears in the page URL. Without
+ * document-start script support the page simply shows its own login gate.
+ */
+private fun installTerminalAuthScript(
+  webView: WebView,
+  page: NodeRuntime.GatewayControlPage,
+) {
+  if (page.token == null && page.password == null) return
+  if (!WebViewFeature.isFeatureSupported(WebViewFeature.DOCUMENT_START_SCRIPT)) return
+  val gatewayUrl = page.baseUrl.replaceFirst("http", "ws")
+  val payload =
+    buildJsonObject {
+      put("gatewayUrl", gatewayUrl)
+      page.token?.let { put("token", it) }
+      page.password?.let { put("password", it) }
+    }
+  val script =
+    """
+    (() => {
+      try {
+        Object.defineProperty(window, "__OPENCLAW_NATIVE_CONTROL_AUTH__", {
+          value: $payload,
+          configurable: true,
+        });
+      } catch (e) {}
+    })();
+    """.trimIndent()
+  WebViewCompat.addDocumentStartJavaScript(webView, script, setOf(page.baseUrl))
+}


### PR DESCRIPTION
## What Problem This Solves

Android operators have no way to reach the Gateway terminal from their phone. The web Control UI ships a terminal (PTY protocol + reattach on `main`) and iOS gained a Terminal hub, but the Android app had no terminal surface.

## Why This Change Was Made

Mirrors the iOS approach: rather than a native terminal, the Android app embeds the gateway-served full-screen terminal-only Control UI document (`/?view=terminal`) in a Compose-hosted `WebView`, reusing the active gateway connection. The native side is a thin host.

- New `TerminalSettingsScreen` (Compose + `WebView`) wired as a `SettingsRoute.Terminal` destination in the "Agents & automation" group — the same nav pattern as the existing Canvas screen. Availability follows the gateway connection.
- `NodeRuntime` exposes a new `GatewayControlPage` state (HTTP(S) page origin + shared credential) derived from the same endpoint/auth the WebSocket sessions use; `MainViewModel` re-exposes it as a `StateFlow`.
- Credentials reach the Control UI via its `__OPENCLAW_NATIVE_CONTROL_AUTH__` document-start contract (the same mechanism macOS Dashboard and the iOS Terminal hub use), injected with `WebViewCompat.addDocumentStartJavaScript` origin-locked to the gateway origin — the token never appears in the page URL or WebView history. The `WebView` is recreated only when the gateway page/credentials change so recompositions never restart live shells.

Requires the web `?view=terminal` mode, which lands with the iOS PR (#100150). No gateway protocol changes.

## User Impact

Android operators get a Terminal entry in Settings: a full-screen shell in the agent workspace hosted in a WebView, reusing the phone's gateway connection. Availability follows the existing `gateway.terminal.enabled` + `operator.admin` gate; an inline notice is shown when the gateway is not connected or lacks the terminal.

## Evidence

- Build: `pnpm android:assemble` (`:app:assemblePlayDebug`) succeeded → `openclaw-2026.6.11-play-debug.apk`.
- Tests: `:app:testPlayDebugUnitTest` passed; ktlint (`pnpm android:lint`) and ktlintFormat clean.
- Real-device: installed on a physical Pixel 10a (Android 16) via wireless ADB; app launches.
- Server-side functional proof of the shared web piece: loading `?view=terminal` against a dev gateway opened a real `/bin/zsh` PTY session (`terminal.open` RPC, `shell=/bin/zsh`) — the same document the Android WebView hosts.
- Scoped/additive: `git diff --numstat` — one new screen file plus a small `NodeRuntime`/`MainViewModel` state addition and Settings nav wiring; no protocol/config surface changes.
