### PR TITLE
fix(whatsapp): replace expired terminal QR on refresh

### DIFF
--- a/extensions/whatsapp/src/login.coverage.test.ts
+++ b/extensions/whatsapp/src/login.coverage.test.ts
@@ -155,15 +155,27 @@ describe("loginWeb coverage", () => {
     const restartOpts = createWaSocketOptions(1);
     expect(initialOpts?.onQr).toBe(restartOpts?.onQr);
 
-    initialOpts?.onQr?.("initial-qr");
-    restartOpts?.onQr?.("restart-qr");
-    await flushTasks();
+    const stdoutDescriptor = Object.getOwnPropertyDescriptor(process.stdout, "isTTY");
+    Object.defineProperty(process.stdout, "isTTY", { configurable: true, value: true });
+    try {
+      initialOpts?.onQr?.("initial-qr");
+      await flushTasks();
+      restartOpts?.onQr?.("restart-qr");
+      await flushTasks();
+    } finally {
+      if (stdoutDescriptor) {
+        Object.defineProperty(process.stdout, "isTTY", stdoutDescriptor);
+      } else {
+        Reflect.deleteProperty(process.stdout, "isTTY");
+      }
+    }
 
     expect(runtime.log).toHaveBeenCalledWith(
-      "Open the WhatsApp app, go to Linked Devices, then scan this QR:",
+      "Open the WhatsApp app, go to Linked Devices, then scan this QR:\nterminal:initial-qr",
     );
-    expect(runtime.log).toHaveBeenCalledWith("terminal:initial-qr");
-    expect(runtime.log).toHaveBeenCalledWith("terminal:restart-qr");
+    expect(runtime.log).toHaveBeenCalledWith(
+      "\x1b[2J\x1b[HOpen the WhatsApp app, go to Linked Devices, then scan this QR:\nterminal:restart-qr",
+    );
     expect(renderQrTerminalMock).toHaveBeenCalledWith("initial-qr", { small: true });
     expect(renderQrTerminalMock).toHaveBeenCalledWith("restart-qr", { small: true });
   });

--- a/extensions/whatsapp/src/login.ts
+++ b/extensions/whatsapp/src/login.ts
@@ -11,6 +11,9 @@ import { renderQrTerminal } from "./qr-terminal.js";
 import { createWaSocket, waitForWaConnection } from "./session.js";
 import { resolveWhatsAppSocketTiming } from "./socket-timing.js";
 
+const QR_LINK_INSTRUCTION = "Open the WhatsApp app, go to Linked Devices, then scan this QR:";
+const CLEAR_TERMINAL = "\x1b[2J\x1b[H";
+
 export async function loginWeb(
   verbose: boolean,
   waitForConnection?: typeof waitForWaConnection,
@@ -21,13 +24,22 @@ export async function loginWeb(
   const account = resolveWhatsAppAccount({ cfg, accountId });
   const socketTiming = resolveWhatsAppSocketTiming(cfg);
   const restoredFromBackup = await restoreCredsFromBackupIfNeeded(account.authDir);
+  let qrVersion = 0;
   const onQr = (qr: string) => {
-    runtime.log("Open the WhatsApp app, go to Linked Devices, then scan this QR:");
+    const currentQrVersion = ++qrVersion;
     void renderQrTerminal(qr, { small: true })
       .then((output) => {
-        runtime.log(output.endsWith("\n") ? output.slice(0, -1) : output);
+        if (currentQrVersion !== qrVersion) {
+          return;
+        }
+        const refreshPrefix = currentQrVersion > 1 && process.stdout.isTTY ? CLEAR_TERMINAL : "";
+        const renderedQr = output.endsWith("\n") ? output.slice(0, -1) : output;
+        runtime.log(`${refreshPrefix}${QR_LINK_INSTRUCTION}\n${renderedQr}`);
       })
       .catch((err: unknown) => {
+        if (currentQrVersion !== qrVersion) {
+          return;
+        }
         runtime.error(`failed rendering WhatsApp QR: ${String(err)}`);
       });
   };


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users linking WhatsApp in a terminal would see each refreshed QR code appended beneath the expired one, leaving multiple stacked codes that looked corrupted.

## Why This Change Was Made

Treat the instruction and rendered QR as one display frame. When Baileys supplies a replacement code, interactive terminals clear the visible display before drawing the latest frame; non-TTY output remains append-only, and superseded asynchronous renders are discarded.

The QR matrix renderer is unchanged. Baileys 7 intentionally rotates the first code after 60 seconds and later codes after 20 seconds, so refresh ownership belongs in the WhatsApp login display path.

## User Impact

WhatsApp linking now shows one current, scannable QR code instead of a stack of expired and current codes.

## Evidence

- Reproduced from a live `openclaw channels login --channel whatsapp` session: two Baileys refreshes appeared as vertically stacked QR codes; pairing itself completed successfully.
- `node scripts/run-vitest.mjs extensions/whatsapp/src/login.test.ts extensions/whatsapp/src/login.coverage.test.ts` — 2 files, 7 tests passed.
- Delegated Blacksmith Testbox `tbx_01kwr34yh8azjjdhkjnm1m146k` — `check:changed` passed extension production/test types, lint, guards, and import-cycle checks (exit 0): https://github.com/openclaw/openclaw/actions/runs/28727482353
- `.agents/skills/autoreview/scripts/autoreview --mode local` — clean; no accepted/actionable findings.

AI-assisted with Codex; implementation and evidence reviewed by the submitting maintainer.
