### PR TITLE
fix: preserve Codex transcript ownership

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,7 +33,7 @@ Docs: https://docs.openclaw.ai
 
 - **Status signal:** omit the redundant `Plugins: OK` row from compact `/status` output while retaining actionable plugin-health warnings and detailed plugin status.
 - **Control UI terminal rendering:** adopt the shared `@openclaw/libterminal` browser lifecycle and add Nerd Font fallbacks so icon-enabled shell listings render their glyphs when a compatible local font is installed.
-- **Control UI chat history:** hide redundant channel-final delivery mirrors when the preceding app-server assistant reply already shows the same text.
+- **Slack transcript history:** let Codex app-server own its persisted assistant replies so Slack does not append redundant delivery-mirror rows, while the Control UI keeps legacy duplicate mirrors hidden.
 - **Control UI chat spacing:** keep the first message comfortably clear of the topbar with a responsive minimum transcript inset.
 - **ClawRouter auth profiles:** resolve credential-scoped catalog models during agent runs when the proxy key is stored in an auth profile, and document plugin and model allowlists.
 - **Telegram durability:** recover stalled ingress claims, retry restart-dropped media, survive transient polling errors, dead-letter poison updates, preserve forwarded rich text, route plugin callbacks correctly, keep progress updates in one stable multi-line window, map self-hosted Bot API container paths through trusted host roots, and fall back safely when Telegram rejects rich final replies. (#97118, #98102, #98735, #98775, #98776, #97174, #98907, #91984, #98786) Thanks @vincentkoc, @luoyanglang, @DaveArcher18, @obviyus, @goldmar, @Marvinthebored, @Dizesales, and @shakkernerd.

--- a/extensions/codex/src/app-server/run-attempt.test.ts
+++ b/extensions/codex/src/app-server/run-attempt.test.ts
@@ -1468,6 +1468,7 @@ describe("runCodexAppServerAttempt", () => {
 
     expect(result.promptError).toBeNull();
     expect(result.assistantTexts).toEqual(["Nested done."]);
+    expect(result.assistantTranscriptOwned).toBe(true);
   });
 
   it("delivers completed assistant text when an orphan native tool call lacks a matching result", async () => {

--- a/extensions/codex/src/app-server/run-attempt.ts
+++ b/extensions/codex/src/app-server/run-attempt.ts
@@ -3294,7 +3294,7 @@ export async function runCodexAppServerAttempt(
     } else {
       codexModelCallDiagnostics.emitCompleted(result);
     }
-    await mirrorTranscriptBestEffort({
+    const assistantTranscriptOwned = await mirrorTranscriptBestEffort({
       params,
       agentId: sessionAgentId,
       notifyUserMessagePersisted,
@@ -3468,6 +3468,7 @@ export async function runCodexAppServerAttempt(
       promptErrorSource: finalPromptErrorSource,
       ...(codexAppServerFailure ? { codexAppServerFailure } : {}),
       ...(promptTimeoutOutcome ? { promptTimeoutOutcome } : {}),
+      ...(assistantTranscriptOwned ? { assistantTranscriptOwned: true } : {}),
       systemPromptReport,
     };
   } finally {

--- a/extensions/codex/src/app-server/transcript-mirror.test.ts
+++ b/extensions/codex/src/app-server/transcript-mirror.test.ts
@@ -19,6 +19,7 @@ import {
   attachCodexMirrorIdentity,
   buildCodexUserPromptMessage,
   mirrorCodexAppServerTranscript,
+  mirrorTranscriptBestEffort,
 } from "./transcript-mirror.js";
 
 const publishSessionTranscriptUpdateByIdentityMock = vi.hoisted(() => vi.fn());
@@ -204,6 +205,92 @@ describe("mirrorCodexAppServerTranscript", () => {
       content: [{ type: "text", text: "show me live" }],
       idempotencyKey: "codex-app-server:thread-1:turn-1:prompt",
     });
+  });
+
+  it("reports final assistant ownership for new and idempotent mirrors", async () => {
+    const sessionFile = await createTempSessionFile();
+    const assistantMessage = attachCodexMirrorIdentity(
+      makeAgentAssistantMessage({
+        content: [{ type: "text", text: "owned once" }],
+        timestamp: Date.now(),
+      }),
+      "turn-1:assistant",
+    );
+
+    const firstMirror = await mirrorCodexAppServerTranscript({
+      sessionFile,
+      sessionId: "session-1",
+      sessionKey: "agent:main:main",
+      messages: [assistantMessage],
+      idempotencyScope: "codex-app-server:thread-1",
+    });
+    const secondMirror = await mirrorCodexAppServerTranscript({
+      sessionFile,
+      sessionId: "session-1",
+      sessionKey: "agent:main:main",
+      messages: [assistantMessage],
+      idempotencyScope: "codex-app-server:thread-1",
+    });
+
+    expect(firstMirror.assistantMirrorIdentitiesOwned).toEqual(["turn-1:assistant"]);
+    expect(secondMirror.assistantMirrorIdentitiesOwned).toEqual(["turn-1:assistant"]);
+    const records = parseJsonLines<{ type?: string; message?: { role?: string } }>(
+      await fs.readFile(sessionFile, "utf8"),
+    );
+    expect(records.filter((record) => record.message?.role === "assistant")).toHaveLength(1);
+  });
+
+  it("keeps assistant ownership when live update publication fails", async () => {
+    publishSessionTranscriptUpdateByIdentityMock.mockRejectedValueOnce(new Error("publish failed"));
+    const sessionFile = await createTempSessionFile();
+    const assistantMessage = attachCodexMirrorIdentity(
+      makeAgentAssistantMessage({
+        content: [{ type: "text", text: "durably persisted" }],
+        timestamp: Date.now(),
+      }),
+      "turn-1:assistant",
+    );
+
+    const result = await mirrorCodexAppServerTranscript({
+      sessionFile,
+      sessionId: "session-1",
+      sessionKey: "agent:main:main",
+      messages: [assistantMessage],
+      idempotencyScope: "codex-app-server:thread-1",
+    });
+
+    expect(result.assistantMirrorIdentitiesOwned).toEqual(["turn-1:assistant"]);
+    expect(await fs.readFile(sessionFile, "utf8")).toContain('"role":"assistant"');
+  });
+
+  it("leaves the assistant unowned when transcript persistence fails", async () => {
+    const root = await makeRoot("openclaw-codex-transcript-failure-");
+    const invalidParent = path.join(root, "not-a-directory");
+    await fs.writeFile(invalidParent, "file blocks transcript directory creation", "utf8");
+    const assistantMessage = attachCodexMirrorIdentity(
+      makeAgentAssistantMessage({
+        content: [{ type: "text", text: "needs fallback persistence" }],
+        timestamp: Date.now(),
+      }),
+      "turn-1:assistant",
+    );
+
+    const assistantTranscriptOwned = await mirrorTranscriptBestEffort({
+      params: {
+        sessionFile: path.join(invalidParent, "session.jsonl"),
+        sessionId: "session-1",
+        suppressNextUserMessagePersistence: true,
+      } as Parameters<typeof mirrorTranscriptBestEffort>[0]["params"],
+      result: {
+        messagesSnapshot: [assistantMessage],
+      } as Parameters<typeof mirrorTranscriptBestEffort>[0]["result"],
+      notifyUserMessagePersisted: vi.fn(),
+      cwd: root,
+      threadId: "thread-1",
+      turnId: "turn-1",
+    });
+
+    expect(assistantTranscriptOwned).toBe(false);
   });
 
   it("emits stable sequence numbers for multi-message mirror batches", async () => {
@@ -431,19 +518,23 @@ describe("mirrorCodexAppServerTranscript", () => {
     );
     const sessionFile = await createTempSessionFile();
 
-    await mirrorCodexAppServerTranscript({
+    const result = await mirrorCodexAppServerTranscript({
       sessionFile,
       sessionId: "session-1",
       sessionKey: "session-1",
       messages: [
-        makeAgentAssistantMessage({
-          content: [{ type: "text", text: "should not persist" }],
-          timestamp: Date.now(),
-        }),
+        attachCodexMirrorIdentity(
+          makeAgentAssistantMessage({
+            content: [{ type: "text", text: "should not persist" }],
+            timestamp: Date.now(),
+          }),
+          "turn-1:assistant",
+        ),
       ],
       idempotencyScope: "scope-1",
     });
 
+    expect(result.assistantMirrorIdentitiesOwned).toEqual(["turn-1:assistant"]);
     await expect(fs.readFile(sessionFile, "utf8")).rejects.toHaveProperty("code", "ENOENT");
   });
 

--- a/extensions/codex/src/app-server/transcript-mirror.ts
+++ b/extensions/codex/src/app-server/transcript-mirror.ts
@@ -20,6 +20,7 @@ type MirroredAgentMessage = Extract<AgentMessage, { role: "user" | "assistant" |
 type MirroredUserMessage = Extract<AgentMessage, { role: "user" }>;
 
 export type CodexAppServerTranscriptMirrorResult = {
+  assistantMirrorIdentitiesOwned: string[];
   userMessagesPresent: MirroredUserMessage[];
 };
 
@@ -107,7 +108,7 @@ export async function mirrorTranscriptBestEffort(params: {
   cwd: string;
   threadId: string;
   turnId: string;
-}): Promise<void> {
+}): Promise<boolean> {
   try {
     const messages = await resolveFinalCodexMirrorMessages({
       params: params.params,
@@ -130,10 +131,18 @@ export async function mirrorTranscriptBestEffort(params: {
       config: params.params.config,
     });
     for (const message of mirrorResult.userMessagesPresent) {
-      params.notifyUserMessagePersisted(message);
+      try {
+        params.notifyUserMessagePersisted(message);
+      } catch (error) {
+        embeddedAgentLog.warn("failed to notify codex app-server user-message persistence", {
+          error: formatErrorMessage(error),
+        });
+      }
     }
+    return mirrorResult.assistantMirrorIdentitiesOwned.includes(`${params.turnId}:assistant`);
   } catch (error) {
     embeddedAgentLog.warn("failed to mirror codex app-server transcript", { error });
+    return false;
   }
 }
 
@@ -286,11 +295,11 @@ export async function mirrorCodexAppServerTranscript(params: {
       message.role === "user" || message.role === "assistant" || message.role === "toolResult",
   );
   if (messages.length === 0) {
-    return { userMessagesPresent: [] };
+    return { assistantMirrorIdentitiesOwned: [], userMessagesPresent: [] };
   }
 
   const transcriptTarget = resolveCodexMirrorTranscriptTarget(params);
-  const { appendedUpdates, userMessagesPresent } = await withSessionTranscriptWriteLock(
+  const mirrorBatch = await withSessionTranscriptWriteLock(
     { ...transcriptTarget, config: params.config },
     async (transcript) => {
       const nextAppendedUpdates: Array<{
@@ -298,6 +307,7 @@ export async function mirrorCodexAppServerTranscript(params: {
         message: AgentMessage;
         messageSeq: number;
       }> = [];
+      const nextAssistantMirrorIdentitiesOwned = new Set<string>();
       const nextUserMessagesPresent: MirroredUserMessage[] = [];
       const mirrorState = readTranscriptMirrorState(await transcript.readEvents());
       let nextMessageSeq = mirrorState.messageCount;
@@ -315,6 +325,9 @@ export async function mirrorCodexAppServerTranscript(params: {
           if (persistedUserMessage) {
             nextUserMessagesPresent.push(persistedUserMessage);
           }
+          if (message.role === "assistant") {
+            nextAssistantMirrorIdentitiesOwned.add(dedupeIdentity);
+          }
           continue;
         }
         const nextMessage = runAgentHarnessBeforeMessageWriteHook({
@@ -323,6 +336,12 @@ export async function mirrorCodexAppServerTranscript(params: {
           sessionKey: params.sessionKey,
         });
         if (!nextMessage) {
+          if (message.role === "assistant") {
+            // A transcript hook deliberately blocked this logical assistant row.
+            // Treat that as an authoritative persistence decision so delivery
+            // does not bypass the hook with a fallback mirror.
+            nextAssistantMirrorIdentitiesOwned.add(dedupeIdentity);
+          }
           continue;
         }
         const messageToAppend = (
@@ -342,6 +361,9 @@ export async function mirrorCodexAppServerTranscript(params: {
           continue;
         }
         const { messageId, message: appendedMessage } = appended;
+        if (message.role === "assistant") {
+          nextAssistantMirrorIdentitiesOwned.add(dedupeIdentity);
+        }
         if (appendedMessage.role === "user") {
           nextUserMessagesPresent.push(appendedMessage);
           if (idempotencyKey) {
@@ -358,24 +380,37 @@ export async function mirrorCodexAppServerTranscript(params: {
           mirrorState.idempotencyKeys.add(idempotencyKey);
         }
       }
-      return { appendedUpdates: nextAppendedUpdates, userMessagesPresent: nextUserMessagesPresent };
+      return {
+        appendedUpdates: nextAppendedUpdates,
+        assistantMirrorIdentitiesOwned: [...nextAssistantMirrorIdentitiesOwned],
+        userMessagesPresent: nextUserMessagesPresent,
+      };
     },
   );
+  const { appendedUpdates, assistantMirrorIdentitiesOwned, userMessagesPresent } = mirrorBatch;
 
   for (const update of appendedUpdates) {
-    await publishSessionTranscriptUpdateByIdentity({
-      ...transcriptTarget,
-      update: {
-        ...(params.sessionKey ? { sessionKey: params.sessionKey } : {}),
-        ...(params.agentId ? { agentId: params.agentId } : {}),
-        message: update.message,
-        messageId: update.messageId,
-        messageSeq: update.messageSeq,
-      },
-    });
+    try {
+      await publishSessionTranscriptUpdateByIdentity({
+        ...transcriptTarget,
+        update: {
+          ...(params.sessionKey ? { sessionKey: params.sessionKey } : {}),
+          ...(params.agentId ? { agentId: params.agentId } : {}),
+          message: update.message,
+          messageId: update.messageId,
+          messageSeq: update.messageSeq,
+        },
+      });
+    } catch (error) {
+      // The transcript append is already committed. A transient live-update
+      // failure must not make dispatch append a second assistant message.
+      embeddedAgentLog.warn("failed to publish codex app-server transcript update", {
+        error: formatErrorMessage(error),
+      });
+    }
   }
 
-  return { userMessagesPresent };
+  return { assistantMirrorIdentitiesOwned, userMessagesPresent };
 }
 
 function resolveCodexMirrorTranscriptTarget(params: {
@@ -418,5 +453,9 @@ function readTranscriptMirrorState(events: unknown[]): {
       }
     }
   }
-  return { idempotencyKeys, messageCount, userMessagesByIdempotencyKey };
+  return {
+    idempotencyKeys,
+    messageCount,
+    userMessagesByIdempotencyKey,
+  };
 }

--- a/src/agents/embedded-agent-runner/run.ts
+++ b/src/agents/embedded-agent-runner/run.ts
@@ -3620,6 +3620,7 @@ async function runEmbeddedAgentInternal(
           const payloads = buildEmbeddedRunPayloads({
             assistantTexts: attempt.assistantTexts,
             assistantMessageIndex: attempt.lastAssistantTextMessageIndex,
+            assistantTranscriptOwned: attempt.assistantTranscriptOwned,
             toolMetas: attempt.toolMetas,
             lastAssistant: attempt.lastAssistant,
             currentAssistant: currentAttemptAssistant ?? null,

--- a/src/agents/embedded-agent-runner/run/payloads.test.ts
+++ b/src/agents/embedded-agent-runner/run/payloads.test.ts
@@ -71,6 +71,18 @@ describe("buildEmbeddedRunPayloads tool-error warnings", () => {
     expectSinglePayloadText(payloads, "Done.");
   });
 
+  it("marks runtime-persisted final replies as transcript owned", () => {
+    const payloads = buildPayloads({
+      assistantTexts: ["Already persisted."],
+      assistantTranscriptOwned: true,
+    });
+
+    expect(payloads).toHaveLength(1);
+    expect(getReplyPayloadMetadata(payloads[0] as object)).toMatchObject({
+      assistantTranscriptOwned: true,
+    });
+  });
+
   it("does not revive signed unphased text when explicit final-answer text is empty", () => {
     expectNoPayloads({
       lastAssistant: {

--- a/src/agents/embedded-agent-runner/run/payloads.ts
+++ b/src/agents/embedded-agent-runner/run/payloads.ts
@@ -552,6 +552,7 @@ function resolveToolErrorWarningPolicy(params: {
 export function buildEmbeddedRunPayloads(params: {
   assistantTexts: string[];
   assistantMessageIndex?: number;
+  assistantTranscriptOwned?: boolean;
   toolMetas: ToolMetaEntry[];
   lastAssistant: AssistantMessage | undefined;
   currentAssistant?: AssistantMessage | null;
@@ -926,9 +927,16 @@ export function buildEmbeddedRunPayloads(params: {
           nonTerminalToolErrorWarning: true,
         });
       }
-      if (!item.isError && !item.isReasoning && params.assistantMessageIndex !== undefined) {
+      if (
+        !item.isError &&
+        !item.isReasoning &&
+        (params.assistantMessageIndex !== undefined || params.assistantTranscriptOwned === true)
+      ) {
         setReplyPayloadMetadata(payload, {
-          assistantMessageIndex: params.assistantMessageIndex,
+          ...(params.assistantMessageIndex !== undefined
+            ? { assistantMessageIndex: params.assistantMessageIndex }
+            : {}),
+          ...(params.assistantTranscriptOwned === true ? { assistantTranscriptOwned: true } : {}),
         });
       }
       if (item.replyToId) {

--- a/src/agents/embedded-agent-runner/run/types.ts
+++ b/src/agents/embedded-agent-runner/run/types.ts
@@ -114,6 +114,8 @@ export type EmbeddedRunAttemptParams = EmbeddedRunAttemptBase & {
 
 export type EmbeddedRunAttemptResult = {
   aborted: boolean;
+  /** True when the runtime made the authoritative final-assistant transcript decision. */
+  assistantTranscriptOwned?: boolean;
   /** True when the abort originated from the caller-provided abortSignal. */
   externalAbort: boolean;
   timedOut: boolean;

--- a/src/auto-reply/reply/dispatch-from-config.test.ts
+++ b/src/auto-reply/reply/dispatch-from-config.test.ts
@@ -1466,7 +1466,7 @@ describe("dispatchReplyFromConfig", () => {
 
   it.each([
     ["embedded", { assistantMessageIndex: 7 }],
-    ["CLI", { assistantTranscriptOwned: true }],
+    ["runtime-owned", { assistantTranscriptOwned: true }],
   ])("does not mirror %s finals with a runtime transcript owner", async (_name, metadata) => {
     setNoAbort();
     const dispatcher = createDispatcher();


### PR DESCRIPTION
## Summary

- make Codex app-server report an authoritative final-assistant transcript outcome after append, idempotent replay, or transcript-hook blocking
- propagate that ownership through the embedded attempt and reply payload so Slack skips its redundant `channel-final` persistence fallback
- preserve the fallback when transcript persistence fails, and keep the UI projection only for legacy duplicate rows

## Tests

- `pnpm tsgo:all`
- Codex transcript mirror suite: 18 passed
- Codex final-assistant ownership integration test: 1 passed
- combined transcript mirror, payload, dispatch, and app-server attempt suites: 424 passed; 3 unrelated approval-policy assertions on current main fail locally because this configured runtime resolves `on-request`
- structured Codex autoreview: clean, no actionable findings
