### PR TITLE
fix: legacy Codex model miss no longer suggests invalid config

### DIFF
--- a/src/agents/embedded-agent-runner/model.test.ts
+++ b/src/agents/embedded-agent-runner/model.test.ts
@@ -2855,6 +2855,30 @@ describe("resolveModel", () => {
     );
   });
 
+  it("points legacy openai-codex configured models at migration and auth recovery", async () => {
+    const cfg = {
+      agents: {
+        defaults: {
+          models: {
+            "openai-codex/gpt-5.4": {
+              contextWindow: 1_050_000,
+              maxOutputTokens: 128_000,
+            },
+          },
+        },
+      },
+    } as unknown as OpenClawConfig;
+
+    const result = await resolveModelAsync("openai-codex", "gpt-5.4", "/tmp/agent", cfg, {
+      runtimeHooks: createRuntimeHooks(),
+      skipAgentDiscovery: true,
+    });
+
+    expect(result.error).toBe(
+      'Unknown model: openai-codex/gpt-5.4. Found agents.defaults.models["openai-codex/gpt-5.4"], but "openai-codex" is a legacy Codex provider id. Do not add models.providers["openai-codex"] without baseUrl; current config validation rejects that legacy provider overlay. Run `openclaw doctor --fix`, then check `openclaw models status` and re-authenticate with `openclaw models auth login --provider openai` if no OpenAI/Codex OAuth profile is available. Use the repaired openai/gpt-5.4 route with Codex runtime metadata. See https://docs.openclaw.ai/concepts/model-providers.',
+    );
+  });
+
   it("repairs stale text-only Foundry fallback rows for GPT-family models", () => {
     const cfg = {
       models: {

--- a/src/agents/embedded-agent-runner/model.test.ts
+++ b/src/agents/embedded-agent-runner/model.test.ts
@@ -2860,10 +2860,7 @@ describe("resolveModel", () => {
       agents: {
         defaults: {
           models: {
-            "openai-codex/gpt-5.4": {
-              contextWindow: 1_050_000,
-              maxOutputTokens: 128_000,
-            },
+            "openai-codex/gpt-5.4": {},
           },
         },
       },

--- a/src/agents/embedded-agent-runner/model.ts
+++ b/src/agents/embedded-agent-runner/model.ts
@@ -113,6 +113,8 @@ const STATIC_PROVIDER_RUNTIME_HOOKS: ProviderRuntimeHooks = {
   normalizeProviderTransportWithPlugin: () => undefined,
 };
 
+const LEGACY_OPENAI_CODEX_PROVIDER_ID = "openai-codex";
+
 const SKIP_AGENT_DISCOVERY_PROVIDER_RUNTIME_HOOKS: ProviderRuntimeHooks = {
   // skipAgentDiscovery is the lean path used before agent discovery/models.json has run.
   ...TARGET_PROVIDER_RUNTIME_HOOKS,
@@ -1928,6 +1930,9 @@ function buildMissingProviderModelRegistrationHint(params: {
   const agentRuntimeId = configuredEntry.agentRuntime?.id;
   if (agentRuntimeId) {
     return `Found agents.defaults.models["${agentModelKey}"] bound to the "${agentRuntimeId}" agent runtime. Models served by an agent runtime come from that runtime and its linked account, not from models.providers["${params.provider}"].models[] — registering it there will not make it usable. Confirm "${params.modelId}" is still offered by the "${agentRuntimeId}" runtime and switch agents.defaults.model.primary to a currently available model (run \`openclaw models list --provider ${params.provider}\` to list them). See https://docs.openclaw.ai/concepts/model-providers.`;
+  }
+  if (normalizeProviderId(params.provider) === LEGACY_OPENAI_CODEX_PROVIDER_ID) {
+    return `Found agents.defaults.models["${agentModelKey}"], but "${params.provider}" is a legacy Codex provider id. Do not add models.providers["${params.provider}"] without baseUrl; current config validation rejects that legacy provider overlay. Run \`openclaw doctor --fix\`, then check \`openclaw models status\` and re-authenticate with \`openclaw models auth login --provider openai\` if no OpenAI/Codex OAuth profile is available. Use the repaired openai/${params.modelId} route with Codex runtime metadata. See https://docs.openclaw.ai/concepts/model-providers.`;
   }
   const providerConfig = findNormalizedProviderValue(
     params.cfg?.models?.providers,


### PR DESCRIPTION
Closes #100066

## What Problem This Solves

Fixes an issue where operators who referenced a legacy `openai-codex/*` model in `agents.defaults.models` could receive an `Unknown model` recovery hint that told them to add `models.providers["openai-codex"].models[]`. Following that hint can produce a startup validation failure because `openai-codex` is a legacy provider id and current config validation rejects that provider overlay without `baseUrl`.

## Why This Change Was Made

The recovery hint now treats `openai-codex` as a legacy Codex route instead of a custom provider registration target. It points operators at `openclaw doctor --fix`, `openclaw models status`, and OpenAI/Codex OAuth re-authentication instead of suggesting a `models.providers["openai-codex"]` edit. This intentionally does not expand the config schema or make `openai-codex` a new valid provider overlay.

## User Impact

Operators no longer get guidance that can turn an unknown-model runtime error into a gateway startup crash-loop. The suggested recovery path now matches the existing legacy migration and auth/status workflows.

## Evidence

Real OpenClaw CLI proof with isolated home/state and a valid config containing `agents.defaults.models["openai-codex/gpt-5.4"] = {}` but no `models.providers["openai-codex"]` overlay:

```text
$ HOME=[isolated] OPENCLAW_HOME=[isolated] OPENCLAW_CONFIG_PATH=[proof-config] OPENCLAW_STATE_DIR=[isolated-state] pnpm -C [worktree] openclaw infer model run --local --model openai-codex/gpt-5.4 --prompt ping
Error: Unknown model: openai-codex/gpt-5.4. Found agents.defaults.models["openai-codex/gpt-5.4"], but "openai-codex" is a legacy Codex provider id. Do not add models.providers["openai-codex"] without baseUrl; current config validation rejects that legacy provider overlay. Run `openclaw doctor --fix`, then check `openclaw models status` and re-authenticate with `openclaw models auth login --provider openai` if no OpenAI/Codex OAuth profile is available. Use the repaired openai/gpt-5.4 route with Codex runtime metadata. See https://docs.openclaw.ai/concepts/model-providers.
[ELIFECYCLE] Command failed with exit code 1.

[proof] command exit status: 1
[proof] verified real CLI emitted migration/auth recovery hint and did not emit the stale provider-registration hint.
```

Red/green source-level repro:

- Added a regression test for `agents.defaults.models["openai-codex/gpt-5.4"]` with no provider model row. Before the fix, the test failed because the error still said to add `models.providers["openai-codex"].models[]`.
- After the fix, the same path returns migration/auth recovery guidance instead.

```text
[test] starting test/vitest/vitest.agents.config.ts

 RUN  v4.1.8 [local path redacted]

[vitest] still running with no output for 30000ms (test/vitest/vitest.agents.config.ts).

 Test Files  1 passed (1)
      Tests  121 passed (121)
   Start at  10:32:43
   Duration  57.96s (transform 11.29s, setup 982ms, import 13.49s, tests 43.10s, environment 0ms)

[test] passed 1 Vitest shard in 68.87s
```

Validator contract unchanged:

```text
[test] starting test/vitest/vitest.runtime-config.config.ts

 RUN  v4.1.8 [local path redacted]

 Test Files  2 passed (2)
      Tests  18 passed (18)
   Start at  10:34:07
   Duration  5.61s (transform 7.45s, setup 281ms, import 10.19s, tests 67ms, environment 0ms)

[test] passed 1 Vitest shard in 15.62s
```
