### PR TITLE
fix(agent): hide code mode wait progress

### DIFF
--- a/src/agents/agent-tool-definition-adapter.ts
+++ b/src/agents/agent-tool-definition-adapter.ts
@@ -367,6 +367,7 @@ export function toToolDefinitions(
     return {
       name,
       label: tool.label ?? name,
+      ...(tool.hideFromChannelProgress === true ? { hideFromChannelProgress: true } : {}),
       description: tool.description ?? "",
       parameters: tool.parameters,
       prepareArguments: tool.prepareArguments,

--- a/src/agents/embedded-agent-runner.splitsdktools.test.ts
+++ b/src/agents/embedded-agent-runner.splitsdktools.test.ts
@@ -44,6 +44,23 @@ describe("splitSdkTools", () => {
     ]);
   });
 
+  it("preserves channel-progress visibility metadata", () => {
+    const hiddenWait = {
+      ...createStubTool("wait"),
+      hideFromChannelProgress: true,
+    };
+    const { customTools } = splitSdkTools({
+      tools: [hiddenWait, createStubTool("plugin_wait")],
+      sandboxEnabled: false,
+    });
+
+    expect(customTools[0]).toMatchObject({
+      name: "wait",
+      hideFromChannelProgress: true,
+    });
+    expect(customTools[1]).not.toHaveProperty("hideFromChannelProgress");
+  });
+
   it("keeps OpenClaw-managed custom tools in OpenClaw runtime's session allowlist", () => {
     // Session tools are OpenClaw-managed custom tools; dropping them from the
     // allowlist would break inter-agent routing even when sandboxing is enabled.

--- a/src/agents/sessions/extensions/types.ts
+++ b/src/agents/sessions/extensions/types.ts
@@ -500,6 +500,8 @@ export interface ToolDefinition<
   name: string;
   /** Human-readable label for UI */
   label: string;
+  /** Preserve lifecycle telemetry without rendering transient channel progress. */
+  hideFromChannelProgress?: boolean;
   /** Description for LLM */
   description: string;
   /** Optional one-line snippet for the Available tools section in the default system prompt. Custom tools are omitted from that section when this is not provided. */

--- a/src/agents/sessions/sdk.test.ts
+++ b/src/agents/sessions/sdk.test.ts
@@ -298,6 +298,37 @@ describe("createAgentSession tool defaults", () => {
     expect(session.getActiveToolNames()).toEqual(["custom_lookup"]);
   });
 
+  it("preserves channel-progress visibility for custom tools", async () => {
+    const hiddenTool: ToolDefinition = {
+      name: "internal_wait",
+      label: "Internal Wait",
+      hideFromChannelProgress: true,
+      description: "Waits for internal work.",
+      parameters: Type.Object({}),
+      execute: async () => ({
+        content: [{ type: "text", text: "ok" }],
+        details: {},
+      }),
+    };
+
+    const { session } = await createAgentSession({
+      model: testModel,
+      noTools: "builtin",
+      customTools: [hiddenTool],
+      resourceLoader: createEmptyResourceLoader(),
+      sessionManager: SessionManager.inMemory(),
+      settingsManager: SettingsManager.inMemory(),
+      modelRegistry: ModelRegistry.inMemory(AuthStorage.inMemory()),
+    });
+
+    expect(session.agent.state.tools).toEqual([
+      expect.objectContaining({
+        name: "internal_wait",
+        hideFromChannelProgress: true,
+      }),
+    ]);
+  });
+
   it("preserves an exact base system prompt when active tools change", async () => {
     const customTool: ToolDefinition = {
       name: "custom_lookup",

--- a/src/agents/sessions/tools/tool-definition-wrapper.ts
+++ b/src/agents/sessions/tools/tool-definition-wrapper.ts
@@ -19,6 +19,7 @@ export function wrapToolDefinition<
   return {
     name: definition.name,
     label: definition.label,
+    ...(definition.hideFromChannelProgress === true ? { hideFromChannelProgress: true } : {}),
     description: definition.description,
     parameters: definition.parameters,
     prepareArguments: definition.prepareArguments,
@@ -46,6 +47,7 @@ export function createToolDefinitionFromAgentTool(tool: AgentTool): ToolDefiniti
   return {
     name: tool.name,
     label: tool.label,
+    ...(tool.hideFromChannelProgress === true ? { hideFromChannelProgress: true } : {}),
     description: tool.description,
     parameters: tool.parameters,
     prepareArguments: tool.prepareArguments,


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where Discord users saw repetitive `🧩 Wait` entries while Code Mode polled background work.

## Why This Change Was Made

Preserves the existing `hideFromChannelProgress` marker across both `AgentTool` / `ToolDefinition` adapter boundaries. Normal plugin and catalog tools remain visible, including tools that happen to be named `wait`.

## User Impact

Discord work progress now shows meaningful actions without exposing internal Code Mode polling.

## Evidence

- New adapter regression failed before the fix, then passed.
- Focused lifecycle suite: 404 tests passed.
- Full `pnpm check` passed (guards, typecheck, lint, policy checks).
- Live gateway proof: 25+ post-restart internal waits produced no new Discord `Wait` rows; the remaining visible row predates the restart.
- Autoreview: clean; no accepted/actionable findings.
