### PR TITLE
fix(compaction): carry streamed total onto cached final usage when totalTokens is missing

### DIFF
--- a/packages/agent-core/src/harness/compaction/compaction.test.ts
+++ b/packages/agent-core/src/harness/compaction/compaction.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it, vi } from "vitest";
 import { createAssistantMessageEventStream } from "../../llm.js";
-import type { AssistantMessage, Model, StreamFn } from "../../llm.js";
-import { generateSummary } from "./compaction.js";
+import type { AssistantMessage, Model, StreamFn, Usage } from "../../llm.js";
+import { calculateContextTokens, generateSummary } from "./compaction.js";
 
 describe("generateSummary thinking options", () => {
   it("maps explicit Fable off to low effort for compaction", async () => {
@@ -58,5 +58,59 @@ describe("generateSummary thinking options", () => {
 
     expect(result).toEqual({ ok: true, value: "summary" });
     expect(streamFn).toHaveBeenCalledOnce();
+  });
+});
+
+function makeUsage(overrides: Partial<Usage> = {}): Usage {
+  return {
+    input: 0,
+    output: 0,
+    cacheRead: 0,
+    cacheWrite: 0,
+    totalTokens: 0,
+    cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+    ...overrides,
+  };
+}
+
+describe("calculateContextTokens", () => {
+  it("returns totalTokens when non-zero", () => {
+    const usage = makeUsage({ totalTokens: 163_978 });
+    expect(calculateContextTokens(usage)).toBe(163_978);
+  });
+
+  it("returns totalTokens even when other fields are large (prefers totalTokens)", () => {
+    const usage = makeUsage({
+      input: 1000,
+      output: 500,
+      cacheRead: 999_999,
+      cacheWrite: 500_000,
+      totalTokens: 1_500,
+    });
+    expect(calculateContextTokens(usage)).toBe(1_500);
+  });
+
+  it("falls back to input + output + cacheRead + cacheWrite when totalTokens is 0", () => {
+    const usage = makeUsage({ input: 100, output: 200, totalTokens: 0 });
+    expect(calculateContextTokens(usage)).toBe(300);
+  });
+
+  it("includes cacheRead/cacheWrite in fallback for single-call cached usage", () => {
+    // A single API call with prompt caching: totalTokens is 0 on the usage,
+    // but cacheRead/cacheWrite represent real context tokens for this call.
+    // The fallback must include them to avoid undercounting context (#99843).
+    const usage = makeUsage({
+      input: 50,
+      output: 200,
+      cacheRead: 150_000,
+      cacheWrite: 10_000,
+      totalTokens: 0,
+    });
+    expect(calculateContextTokens(usage)).toBe(160_250);
+  });
+
+  it("returns 0 when all fields are 0", () => {
+    const usage = makeUsage();
+    expect(calculateContextTokens(usage)).toBe(0);
   });
 });

--- a/packages/agent-core/src/harness/compaction/compaction.ts
+++ b/packages/agent-core/src/harness/compaction/compaction.ts
@@ -146,7 +146,15 @@ export const DEFAULT_COMPACTION_SETTINGS: CompactionSettings = {
   keepRecentTokens: 20000,
 };
 
-/** Calculate total context tokens from provider usage. */
+/**
+ * Calculate total context tokens from provider usage.
+ *
+ * Prefer `totalTokens` as the canonical per-call context size. When it is
+ * missing (0), fall back to the component sum — which is correct for a single
+ * API call. Turn-aggregated cache buckets are prevented from reaching this
+ * path by the usage normalization in the embedded runner that populates
+ * `total` before the usage is stored on the assistant message (#99843).
+ */
 export function calculateContextTokens(usage: Usage): number {
   return usage.totalTokens || usage.input + usage.output + usage.cacheRead + usage.cacheWrite;
 }

--- a/src/agents/embedded-agent-subscribe.handlers.messages.test.ts
+++ b/src/agents/embedded-agent-subscribe.handlers.messages.test.ts
@@ -1099,6 +1099,67 @@ describe("handleMessageEnd", () => {
     expect(ctx.recordAssistantUsage).toHaveBeenCalledWith(message.usage);
   });
 
+  it("carries streamed total onto cached final usage when totalTokens is missing (#99843)", () => {
+    // The exact scenario from #99843: the final assistant snapshot already has
+    // usage buckets (input/output/cacheRead/cacheWrite with aggregated cache)
+    // but totalTokens is 0. The streamed pending total is the real per-call
+    // context — preservePendingAssistantUsage must carry it onto the message
+    // while keeping the provider's billing buckets intact.
+    const ctx = createMessageEndContext({
+      state: {
+        pendingAssistantUsage: {
+          input: 12,
+          output: 15_104,
+          cacheRead: 148_862,
+          cacheWrite: 0,
+          total: 163_978,
+        },
+      },
+    });
+    const message = {
+      role: "assistant" as const,
+      api: "anthropic-messages" as const,
+      provider: "anthropic" as const,
+      model: "claude-opus-4-8" as const,
+      content: [{ type: "text" as const, text: "Done." }],
+      stopReason: "stop" as const,
+      usage: {
+        input: 12,
+        output: 15_104,
+        cacheRead: 819_661,
+        cacheWrite: 93_130,
+        totalTokens: 0,
+        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+      },
+      timestamp: 1,
+    };
+
+    void handleMessageEnd(ctx, {
+      type: "message_end",
+      message,
+    } as never);
+
+    // Billing buckets preserved, totalTokens restored from streamed total
+    expect(firstMockArg(ctx.noteLastAssistant as never, "last assistant")).toMatchObject({
+      usage: {
+        input: 12,
+        output: 15_104,
+        cacheRead: 819_661,
+        cacheWrite: 93_130,
+        totalTokens: 163_978,
+      },
+    });
+    expect(ctx.recordAssistantUsage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        input: 12,
+        output: 15_104,
+        cacheRead: 819_661,
+        cacheWrite: 93_130,
+        totalTokens: 163_978,
+      }),
+    );
+  });
+
   it("warns when assistant text only pretends to call a registered tool", () => {
     const warn = vi.fn();
     const ctx = createMessageEndContext({

--- a/src/agents/embedded-agent-subscribe.handlers.messages.ts
+++ b/src/agents/embedded-agent-subscribe.handlers.messages.ts
@@ -96,6 +96,24 @@ export function preservePendingAssistantUsage(
   }
   const messageUsage = normalizeUsage((message as { usage?: UsageLike }).usage);
   if (hasNonzeroUsage(messageUsage)) {
+    // The final assistant snapshot already carries usage buckets (input/output/
+    // cacheRead/cacheWrite) from the provider, but totalTokens may still be
+    // zero when the provider omits the aggregate total. The streamed pending
+    // total is the real per-call context snapshot — carry it onto the final
+    // usage so compaction estimation never re-sums turn-aggregated cache
+    // buckets (which can inflate the estimate ~5.7x, see #99843).
+    if (
+      typeof pendingUsage.total === "number" &&
+      Number.isFinite(pendingUsage.total) &&
+      pendingUsage.total > 0 &&
+      !(typeof messageUsage?.total === "number" && messageUsage.total > 0)
+    ) {
+      message.usage = {
+        ...makeZeroUsageSnapshot(),
+        ...(message as { usage?: UsageLike }).usage,
+        totalTokens: pendingUsage.total,
+      };
+    }
     return message;
   }
 

--- a/src/agents/embedded-agent-subscribe.ts
+++ b/src/agents/embedded-agent-subscribe.ts
@@ -631,6 +631,19 @@ export function subscribeEmbeddedAgentSession(params: SubscribeEmbeddedAgentSess
     if (!usage) {
       return;
     }
+    // Ensure `total` is populated before downstream compaction estimation reads
+    // it via preservePendingAssistantUsage. When the provider stream event omits
+    // a total, derive it from per-call component fields instead of leaving it
+    // undefined. An undefined total forces the caller's fallback to re-sum
+    // the components, which can inflate estimates when cacheRead/cacheWrite
+    // are turn-aggregated across multiple API calls in a tool-loop turn (#99843).
+    if (usage.total === undefined || usage.total <= 0) {
+      const derived =
+        (usage.input ?? 0) + (usage.output ?? 0) + (usage.cacheRead ?? 0) + (usage.cacheWrite ?? 0);
+      if (derived > 0) {
+        usage.total = derived;
+      }
+    }
     state.pendingAssistantUsage = usage;
   };
   const getUsageTotals = () => {


### PR DESCRIPTION
## What Problem This Solves

Fixes #99843 — Auto-compaction can fire far below the configured trigger (~164k actual on a 180k threshold) because `calculateContextTokens` re-sums turn-aggregated `cacheRead`/`cacheWrite` when `totalTokens` is zero.

**Root cause**: Two gaps in the usage-repair chain:

1. **`preservePendingAssistantUsage`** (primary): When the final assistant snapshot already has non-zero usage buckets (`input`/`output`/`cacheRead`/`cacheWrite`) but `totalTokens: 0`, the function returns early — skipping repair. The aggregated cache buckets then flow into `calculateContextTokens` which sums them (~931k instead of the real ~164k).

2. **`recordAssistantUsage`** (defense-in-depth): When the provider stream event omits `total`, `pendingUsage.total` stays undefined, forcing downstream callers to derive it from potentially aggregated component fields.

## Why This Change Was Made

**Primary fix** (`preservePendingAssistantUsage`): When the message already has provider usage buckets but `totalTokens` is missing, carry the streamed `pendingUsage.total` onto the message while preserving the original billing buckets. The streamed total is the real per-call context snapshot.

**Defense-in-depth** (`recordAssistantUsage`): Populate `usage.total` from per-call component fields when the provider omits it, so downstream always has a correct `total`.

**Estimator** (`calculateContextTokens`): The fallback formula `input + output + cacheRead + cacheWrite` is correct for single-call usage and properly accounts for cached prompt context.

## User Impact

- Multi-call tool-loop turns with prompt caching will no longer compact at ~55% of the configured threshold
- Cached single-call sessions with missing `totalTokens` still get accurate context estimates
- Cost-accounting cache buckets are preserved (only `totalTokens` is repaired)

## Evidence

- **Test results**: compaction tests (6 passed), agent compaction tests (17 passed), handler tests (44 passed) — **67 tests total**
- **New handler test**: proves `preservePendingAssistantUsage` repairs `totalTokens` on a non-zero-usage message with aggregated cache buckets (the exact #99843 scenario)
- **New compaction tests**: 5 tests for `calculateContextTokens` covering `totalTokens` priority, cached fallback, and edge cases
- **No existing test regression**

🤖 Generated with [Claude Code](https://claude.com/claude-code)