### PR TITLE
feat(workboard): expose dispatch --max-starts to raise the per-pass start cap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ Docs: https://docs.openclaw.ai
 - **Control UI sidebar usage:** remove the provider usage quota row from the expanded sidebar while keeping usage details available in the chat composer and Usage page. Thanks @shakkernerd.
 - **Android chat code highlighting:** render fenced Kotlin, Swift, TypeScript, JavaScript, Python, Bash, and JSON blocks with bounded, theme-aware syntax colors while preserving plain rendering for unknown, partial, or oversized blocks. (#100217)
 - **Gateway TTS playback:** add an operator-scoped `tts.speak` RPC that returns configured-provider speech as inline whole-clip audio for remote clients. (#100708, #100770)
+- **Workboard dispatch cap:** add a request-scoped `--max-starts` override while preserving the default cap, sequential starts, and one-card-per-owner guard. (#100174) Thanks @souvikDevloper.
 
 ### Fixes
 

--- a/docs/cli/workboard.md
+++ b/docs/cli/workboard.md
@@ -22,7 +22,7 @@ openclaw gateway restart
 openclaw workboard list [--board <id>] [--status <status>] [--include-archived] [--json]
 openclaw workboard create <title...> [--notes <text>] [--status <status>] [--priority <priority>] [--agent <id>] [--board <id>] [--labels <items>] [--json]
 openclaw workboard show <id> [--json]
-openclaw workboard dispatch [--url <url>] [--token <token>] [--timeout <ms>] [--json]
+openclaw workboard dispatch [--board <id>] [--max-starts <count>] [--url <url>] [--token <token>] [--timeout <ms>] [--json]
 ```
 
 The command reads and writes the same plugin-owned SQLite database used by the dashboard and Workboard agent tools. Card ids are UUIDs; commands that accept a card id also accept an unambiguous id prefix (the compact text output shows the first 8 characters).
@@ -87,10 +87,11 @@ Text output prints the compact card line and notes. JSON output returns the full
 ```bash
 openclaw workboard dispatch
 openclaw workboard dispatch --json
+openclaw workboard dispatch --max-starts 10
 openclaw workboard dispatch --url http://127.0.0.1:18789 --token "$OPENCLAW_GATEWAY_TOKEN"
 ```
 
-`dispatch` first calls the running Gateway RPC method `workboard.cards.dispatch`, which uses the same subagent runtime as the dashboard dispatch action, so ready cards become task-tracked worker runs with linked session keys. Cards with an assigned agent use agent-scoped subagent session keys; unassigned cards keep an unscoped subagent key so the Gateway's configured default agent is preserved.
+`dispatch` first calls the running Gateway RPC method `workboard.cards.dispatch`, which uses the same subagent runtime as the dashboard dispatch action, so ready cards become task-tracked worker runs with linked session keys. `--max-starts` uses the additive `workboard.cards.dispatchWithOptions` method so an older Gateway rejects the option before starting any workers; restart the Gateway after upgrading before using the flag. Cards with an assigned agent use agent-scoped subagent session keys; unassigned cards keep an unscoped subagent key so the Gateway's configured default agent is preserved.
 
 The dispatch loop:
 
@@ -102,7 +103,7 @@ The dispatch loop:
 6. Starts a subagent worker run with bounded card context and the card claim token.
 7. Stores the worker run id, session key, task linkage when the Gateway task ledger reports it, execution status, and worker log on the card.
 
-Selection is conservative: one dispatch starts at most three workers by default, skips archived or already-claimed cards, and starts only one card per owner or agent in a single pass. Cards already owned by active running or review work are left for a later dispatch.
+Selection is conservative: one dispatch starts at most three workers by default, skips archived or already-claimed cards, and starts only one card per owner or agent in a single pass. Cards already owned by active running or review work are left for a later dispatch. Pass `--max-starts <count>` with a positive integer to change the per-pass cap; the one-card-per-owner rule still applies, so the effective number of starts can be lower.
 
 If worker start fails after a card is claimed, Workboard blocks that card, clears the claim, and records the failure in card execution and worker-log metadata, keeping failed starts visible instead of silently returning the card to the queue.
 

--- a/extensions/workboard/src/cli.test.ts
+++ b/extensions/workboard/src/cli.test.ts
@@ -177,6 +177,64 @@ describe("registerWorkboardCli", () => {
     expect(after?.metadata?.automation?.dispatchCount).toBeUndefined();
   });
 
+  it("forwards --max-starts to the dispatch gateway call", async () => {
+    const store = new WorkboardStore(createMemoryStore());
+    const program = createProgram(store);
+    gatewayRuntime.callGatewayFromCli.mockResolvedValueOnce({ started: [], startFailures: [] });
+
+    await program.parseAsync(["workboard", "dispatch", "--max-starts", "7"], { from: "user" });
+
+    expect(gatewayRuntime.callGatewayFromCli).toHaveBeenCalledWith(
+      "workboard.cards.dispatchWithOptions",
+      expect.anything(),
+      expect.objectContaining({ maxStarts: 7 }),
+      expect.anything(),
+    );
+  });
+
+  it("omits maxStarts from the dispatch gateway call when the flag is absent", async () => {
+    const store = new WorkboardStore(createMemoryStore());
+    const program = createProgram(store);
+    gatewayRuntime.callGatewayFromCli.mockResolvedValueOnce({ started: [], startFailures: [] });
+
+    await program.parseAsync(["workboard", "dispatch"], { from: "user" });
+
+    const forwardedParams = gatewayRuntime.callGatewayFromCli.mock.calls[0]?.[2] as Record<
+      string,
+      unknown
+    >;
+    expect(gatewayRuntime.callGatewayFromCli.mock.calls[0]?.[0]).toBe("workboard.cards.dispatch");
+    expect(forwardedParams).not.toHaveProperty("maxStarts");
+  });
+
+  it("does not fall back when an older gateway lacks max-starts dispatch", async () => {
+    const store = new WorkboardStore(createMemoryStore());
+    const card = await store.create({ title: "Bounded dispatch", status: "ready" });
+    const program = createProgram(store);
+    gatewayRuntime.callGatewayFromCli.mockRejectedValueOnce(
+      new Error("unknown method: workboard.cards.dispatchWithOptions"),
+    );
+
+    await expect(
+      program.parseAsync(["workboard", "dispatch", "--max-starts", "1"], { from: "user" }),
+    ).rejects.toThrow("unknown method: workboard.cards.dispatchWithOptions");
+
+    await expect(store.get(card.id)).resolves.toMatchObject({ status: "ready" });
+  });
+
+  it.each(["0", "-1", "1e3", "0x10", "5.5"])(
+    "rejects invalid --max-starts value %s",
+    async (value) => {
+      const store = new WorkboardStore(createMemoryStore());
+      const program = createProgram(store);
+
+      await expect(
+        program.parseAsync(["workboard", "dispatch", "--max-starts", value], { from: "user" }),
+      ).rejects.toThrow("--max-starts must be a positive integer.");
+      expect(gatewayRuntime.callGatewayFromCli).not.toHaveBeenCalled();
+    },
+  );
+
   it("rejects ambiguous card id prefixes", async () => {
     const store = new WorkboardStore(createMemoryStore());
     const prefix = await createAmbiguousPrefix(store);

--- a/extensions/workboard/src/cli.ts
+++ b/extensions/workboard/src/cli.ts
@@ -2,6 +2,7 @@
 import type { Command } from "commander";
 import { formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
 import { addGatewayClientOptions, callGatewayFromCli } from "openclaw/plugin-sdk/gateway-runtime";
+import { parseStrictPositiveInteger } from "openclaw/plugin-sdk/number-runtime";
 import { getRuntimeConfig } from "openclaw/plugin-sdk/runtime-config-snapshot";
 import { isRecord } from "openclaw/plugin-sdk/string-coerce-runtime";
 import { resolveWorkboardCardByIdOrPrefix } from "./card-lookup.js";
@@ -19,6 +20,26 @@ type GatewayOptions = JsonOptions & {
   expectFinal?: boolean;
   board?: string;
 };
+
+type DispatchOptions = GatewayOptions & {
+  maxStarts?: number;
+};
+
+function invalidCliArgument(message: string): Error & { code: string; exitCode: number } {
+  const error = new Error(message) as Error & { code: string; exitCode: number };
+  error.name = "InvalidArgumentError";
+  error.code = "commander.invalidArgument";
+  error.exitCode = 1;
+  return error;
+}
+
+function parsePositiveIntegerOption(value: string, flag: string): number {
+  const parsed = parseStrictPositiveInteger(value);
+  if (parsed === undefined) {
+    throw invalidCliArgument(`${flag} must be a positive integer.`);
+  }
+  return parsed;
+}
 
 function writeJson(value: unknown): void {
   process.stdout.write(`${JSON.stringify(value, null, 2)}\n`);
@@ -91,15 +112,20 @@ async function callWorkboardGateway(
 
 function isGatewayUnavailableError(error: unknown): boolean {
   const message = formatErrorMessage(error).toLowerCase();
-  return [
-    "econnrefused",
-    "econnreset",
-    "ehostunreach",
-    "enotfound",
-    "gateway not connected",
-    "gateway unavailable",
-    "unknown method: workboard.cards.dispatch",
-  ].some((marker) => message.includes(marker));
+  if (
+    [
+      "econnrefused",
+      "econnreset",
+      "ehostunreach",
+      "enotfound",
+      "gateway not connected",
+      "gateway unavailable",
+    ].some((marker) => message.includes(marker))
+  ) {
+    return true;
+  }
+  const unknownMethod = message.match(/unknown method:\s*([a-z0-9._-]+)/)?.[1];
+  return unknownMethod === "workboard.cards.dispatch";
 }
 
 function hasExplicitGatewayTarget(options: GatewayOptions): boolean {
@@ -216,11 +242,21 @@ export function registerWorkboardCli(params: { program: Command; store: Workboar
       .command("dispatch")
       .description("Promote ready cards and start worker runs through the Gateway")
       .option("--board <id>", "Dispatch a single board")
+      .option(
+        "--max-starts <count>",
+        "Maximum new worker runs to start in this pass (default 3)",
+        (value: string) => parsePositiveIntegerOption(value, "--max-starts"),
+      )
       .option("--json", "Print JSON", false),
-  ).action(async (options: GatewayOptions) => {
+  ).action(async (options: DispatchOptions) => {
     try {
-      const result = await callWorkboardGateway("workboard.cards.dispatch", options, {
+      const method =
+        options.maxStarts === undefined
+          ? "workboard.cards.dispatch"
+          : "workboard.cards.dispatchWithOptions";
+      const result = await callWorkboardGateway(method, options, {
         boardId: options.board,
+        ...(options.maxStarts !== undefined ? { maxStarts: options.maxStarts } : {}),
       });
       if (options.json) {
         writeJson(result);

--- a/extensions/workboard/src/gateway-helpers.ts
+++ b/extensions/workboard/src/gateway-helpers.ts
@@ -1,0 +1,101 @@
+// Workboard plugin module implements shared gateway request helpers.
+import { formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
+import { parseStrictPositiveInteger } from "openclaw/plugin-sdk/number-runtime";
+import type { OpenClawPluginApi } from "../api.js";
+import { dispatchAndStartWorkboardCards } from "./dispatcher.js";
+import type { WorkboardStore } from "./store.js";
+import type { WorkboardCard } from "./types.js";
+
+type GatewayMethodContext = Parameters<
+  Parameters<OpenClawPluginApi["registerGatewayMethod"]>[1]
+>[0];
+type GatewayRespond = GatewayMethodContext["respond"];
+
+export function respondError(respond: GatewayRespond, error: unknown) {
+  respond(false, undefined, {
+    code: "workboard_error",
+    message: formatErrorMessage(error),
+  });
+}
+
+export function readId(params: Record<string, unknown>): string {
+  const value = params.id;
+  if (typeof value === "string" && value.trim()) {
+    return value.trim();
+  }
+  throw new Error("id is required.");
+}
+
+function readOptionalPositiveInteger(value: unknown, fieldName: string): number | undefined {
+  if (value === undefined) {
+    return undefined;
+  }
+  const parsed = parseStrictPositiveInteger(value);
+  if (typeof value !== "number" || parsed === undefined) {
+    throw new Error(`${fieldName} must be a positive integer.`);
+  }
+  return parsed;
+}
+
+export function readPatch(params: Record<string, unknown>): Record<string, unknown> {
+  const patch = params.patch;
+  if (patch && typeof patch === "object" && !Array.isArray(patch)) {
+    return patch as Record<string, unknown>;
+  }
+  return params;
+}
+
+export function assertNoCursorAdvance(params: Record<string, unknown>) {
+  if (params.advance === true) {
+    throw new Error("notification cursor advancement requires workboard.notifications.advance.");
+  }
+}
+
+export function createWorkboardDispatchHandler(params: {
+  api: OpenClawPluginApi;
+  store: WorkboardStore;
+  redactCard: (card: WorkboardCard) => WorkboardCard;
+}) {
+  return async (
+    { params: requestParams, respond, client }: GatewayMethodContext,
+    options: { supportsMaxStarts: boolean },
+  ) => {
+    try {
+      const boardId =
+        requestParams && typeof requestParams === "object" && "boardId" in requestParams
+          ? requestParams.boardId
+          : undefined;
+      const rawMaxStarts =
+        requestParams && typeof requestParams === "object" && "maxStarts" in requestParams
+          ? requestParams.maxStarts
+          : undefined;
+      if (!options.supportsMaxStarts && rawMaxStarts !== undefined) {
+        throw new Error("maxStarts requires workboard.cards.dispatchWithOptions.");
+      }
+      const maxStarts = options.supportsMaxStarts
+        ? readOptionalPositiveInteger(rawMaxStarts, "maxStarts")
+        : undefined;
+      const result = await dispatchAndStartWorkboardCards({
+        store: params.store,
+        subagent: params.api.runtime.subagent,
+        worktrees: params.api.runtime.worktrees,
+        options: {
+          boardId: typeof boardId === "string" ? boardId : undefined,
+          ...(maxStarts !== undefined ? { maxStarts } : {}),
+          allowManagedWorktrees:
+            Array.isArray(client?.connect?.scopes) &&
+            client.connect.scopes.includes("operator.admin"),
+        },
+      });
+      respond(true, {
+        ...result,
+        promoted: result.promoted.map(params.redactCard),
+        reclaimed: result.reclaimed.map(params.redactCard),
+        blocked: result.blocked.map(params.redactCard),
+        orchestrated: result.orchestrated.map(params.redactCard),
+      });
+    } catch (error) {
+      respondError(respond, error);
+    }
+  };
+}

--- a/extensions/workboard/src/gateway.test.ts
+++ b/extensions/workboard/src/gateway.test.ts
@@ -68,6 +68,7 @@ describe("workboard gateway methods", () => {
       "workboard.cards.diagnostics",
       "workboard.cards.diagnostics.refresh",
       "workboard.cards.dispatch",
+      "workboard.cards.dispatchWithOptions",
       "workboard.boards.list",
       "workboard.boards.upsert",
       "workboard.boards.archive",
@@ -259,6 +260,66 @@ describe("workboard gateway methods", () => {
         sessionKey: `subagent:workboard-default-${card.id}`,
       }),
     );
+  });
+
+  it("threads a validated maxStarts gateway parameter into dispatch", async () => {
+    type RegisteredMethod = {
+      handler: Parameters<OpenClawPluginApi["registerGatewayMethod"]>[1];
+      opts: Parameters<OpenClawPluginApi["registerGatewayMethod"]>[2];
+    };
+    const methods = new Map<string, RegisteredMethod>();
+    const run = vi.fn().mockResolvedValue({ runId: "run-card" });
+    const api = {
+      runtime: {
+        state: { openKeyedStore: vi.fn(() => createMemoryStore()) },
+        subagent: { run },
+      },
+      registerGatewayMethod: vi.fn(
+        (method: string, handler: RegisteredMethod["handler"], opts: RegisteredMethod["opts"]) => {
+          methods.set(method, { handler, opts });
+        },
+      ),
+    } as unknown as OpenClawPluginApi;
+    const store = new WorkboardStore(createMemoryStore());
+    await store.create({
+      title: "Ready A",
+      status: "ready",
+      priority: "urgent",
+      agentId: "agent-a",
+    });
+    await store.create({
+      title: "Ready B",
+      status: "ready",
+      priority: "urgent",
+      agentId: "agent-b",
+    });
+    registerWorkboardGatewayMethods({ api, store });
+    const handler = methods.get("workboard.cards.dispatchWithOptions")?.handler;
+
+    const respond = vi.fn();
+    await handler?.({ params: { maxStarts: 1 }, respond } as never);
+
+    expect(respond.mock.calls[0]?.[0]).toBe(true);
+    expect(respond.mock.calls[0]?.[1]?.started).toHaveLength(1);
+    expect(run).toHaveBeenCalledOnce();
+
+    const legacyRespond = vi.fn();
+    await methods
+      .get("workboard.cards.dispatch")
+      ?.handler({ params: { maxStarts: 1 }, respond: legacyRespond } as never);
+    expect(legacyRespond.mock.calls[0]?.[0]).toBe(false);
+    expect(legacyRespond.mock.calls[0]?.[2]?.message).toBe(
+      "maxStarts requires workboard.cards.dispatchWithOptions.",
+    );
+
+    for (const value of [0, -1, 1.5, "2"]) {
+      const invalidRespond = vi.fn();
+      await handler?.({ params: { maxStarts: value }, respond: invalidRespond } as never);
+      expect(invalidRespond.mock.calls[0]?.[0]).toBe(false);
+      expect(invalidRespond.mock.calls[0]?.[2]?.message).toBe(
+        "maxStarts must be a positive integer.",
+      );
+    }
   });
 
   it("requires admin scope for managed-worktree dispatch", async () => {

--- a/extensions/workboard/src/gateway.test.ts
+++ b/extensions/workboard/src/gateway.test.ts
@@ -262,7 +262,7 @@ describe("workboard gateway methods", () => {
     );
   });
 
-  it("threads a validated maxStarts gateway parameter into dispatch", async () => {
+  it("threads maxStarts while the legacy method keeps its default cap", async () => {
     type RegisteredMethod = {
       handler: Parameters<OpenClawPluginApi["registerGatewayMethod"]>[1];
       opts: Parameters<OpenClawPluginApi["registerGatewayMethod"]>[2];
@@ -281,27 +281,44 @@ describe("workboard gateway methods", () => {
       ),
     } as unknown as OpenClawPluginApi;
     const store = new WorkboardStore(createMemoryStore());
-    await store.create({
-      title: "Ready A",
-      status: "ready",
-      priority: "urgent",
-      agentId: "agent-a",
-    });
-    await store.create({
-      title: "Ready B",
-      status: "ready",
-      priority: "urgent",
-      agentId: "agent-b",
-    });
+    await Promise.all(
+      Array.from({ length: 5 }, (_, index) =>
+        store.create({
+          title: `Capped ${index}`,
+          status: "ready",
+          priority: "urgent",
+          agentId: `capped-${index}`,
+          boardId: "capped",
+        }),
+      ),
+    );
     registerWorkboardGatewayMethods({ api, store });
     const handler = methods.get("workboard.cards.dispatchWithOptions")?.handler;
 
     const respond = vi.fn();
-    await handler?.({ params: { maxStarts: 1 }, respond } as never);
+    await handler?.({ params: { boardId: "capped", maxStarts: 4 }, respond } as never);
 
     expect(respond.mock.calls[0]?.[0]).toBe(true);
-    expect(respond.mock.calls[0]?.[1]?.started).toHaveLength(1);
-    expect(run).toHaveBeenCalledOnce();
+    expect(respond.mock.calls[0]?.[1]?.started).toHaveLength(4);
+    expect(run).toHaveBeenCalledTimes(4);
+
+    await Promise.all(
+      Array.from({ length: 5 }, (_, index) =>
+        store.create({
+          title: `Legacy ${index}`,
+          status: "ready",
+          priority: "urgent",
+          agentId: `legacy-${index}`,
+          boardId: "legacy",
+        }),
+      ),
+    );
+    const defaultRespond = vi.fn();
+    await methods
+      .get("workboard.cards.dispatch")
+      ?.handler({ params: { boardId: "legacy" }, respond: defaultRespond } as never);
+    expect(defaultRespond.mock.calls[0]?.[1]?.started).toHaveLength(3);
+    expect(run).toHaveBeenCalledTimes(7);
 
     const legacyRespond = vi.fn();
     await methods

--- a/extensions/workboard/src/gateway.ts
+++ b/extensions/workboard/src/gateway.ts
@@ -1,5 +1,6 @@
 // Workboard plugin module implements gateway behavior.
 import { formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
+import { parseStrictPositiveInteger } from "openclaw/plugin-sdk/number-runtime";
 import type { OpenClawPluginApi } from "../api.js";
 import { dispatchAndStartWorkboardCards } from "./dispatcher.js";
 import { WorkboardStore } from "./store.js";
@@ -26,6 +27,17 @@ function readId(params: Record<string, unknown>): string {
     return value.trim();
   }
   throw new Error("id is required.");
+}
+
+function readOptionalPositiveInteger(value: unknown, fieldName: string): number | undefined {
+  if (value === undefined) {
+    return undefined;
+  }
+  const parsed = parseStrictPositiveInteger(value);
+  if (typeof value !== "number" || parsed === undefined) {
+    throw new Error(`${fieldName} must be a positive integer.`);
+  }
+  return parsed;
 }
 
 function readPatch(params: Record<string, unknown>): Record<string, unknown> {
@@ -72,6 +84,48 @@ export function registerWorkboardGatewayMethods(params: {
 }) {
   const { api } = params;
   const store = params.store ?? WorkboardStore.openSqlite();
+  const dispatchCards = async (
+    { params: requestParams, respond, client }: GatewayMethodContext,
+    options: { supportsMaxStarts: boolean },
+  ) => {
+    try {
+      const boardId =
+        requestParams && typeof requestParams === "object" && "boardId" in requestParams
+          ? requestParams.boardId
+          : undefined;
+      const rawMaxStarts =
+        requestParams && typeof requestParams === "object" && "maxStarts" in requestParams
+          ? requestParams.maxStarts
+          : undefined;
+      if (!options.supportsMaxStarts && rawMaxStarts !== undefined) {
+        throw new Error("maxStarts requires workboard.cards.dispatchWithOptions.");
+      }
+      const maxStarts = options.supportsMaxStarts
+        ? readOptionalPositiveInteger(rawMaxStarts, "maxStarts")
+        : undefined;
+      const result = await dispatchAndStartWorkboardCards({
+        store,
+        subagent: api.runtime.subagent,
+        worktrees: api.runtime.worktrees,
+        options: {
+          boardId: typeof boardId === "string" ? boardId : undefined,
+          ...(maxStarts !== undefined ? { maxStarts } : {}),
+          allowManagedWorktrees:
+            Array.isArray(client?.connect?.scopes) &&
+            client.connect.scopes.includes("operator.admin"),
+        },
+      });
+      respond(true, {
+        ...result,
+        promoted: result.promoted.map(redactClaimToken),
+        reclaimed: result.reclaimed.map(redactClaimToken),
+        blocked: result.blocked.map(redactClaimToken),
+        orchestrated: result.orchestrated.map(redactClaimToken),
+      });
+    } catch (error) {
+      respondError(respond, error);
+    }
+  };
 
   api.registerGatewayMethod(
     "workboard.cards.list",
@@ -383,34 +437,13 @@ export function registerWorkboardGatewayMethods(params: {
 
   api.registerGatewayMethod(
     "workboard.cards.dispatch",
-    async ({ params: requestParams, respond, client }) => {
-      try {
-        const boardId =
-          requestParams && typeof requestParams === "object" && "boardId" in requestParams
-            ? requestParams.boardId
-            : undefined;
-        const result = await dispatchAndStartWorkboardCards({
-          store,
-          subagent: api.runtime.subagent,
-          worktrees: api.runtime.worktrees,
-          options: {
-            boardId: typeof boardId === "string" ? boardId : undefined,
-            allowManagedWorktrees:
-              Array.isArray(client?.connect?.scopes) &&
-              client.connect.scopes.includes("operator.admin"),
-          },
-        });
-        respond(true, {
-          ...result,
-          promoted: result.promoted.map(redactClaimToken),
-          reclaimed: result.reclaimed.map(redactClaimToken),
-          blocked: result.blocked.map(redactClaimToken),
-          orchestrated: result.orchestrated.map(redactClaimToken),
-        });
-      } catch (error) {
-        respondError(respond, error);
-      }
-    },
+    async (context) => await dispatchCards(context, { supportsMaxStarts: false }),
+    { scope: WRITE_SCOPE },
+  );
+
+  api.registerGatewayMethod(
+    "workboard.cards.dispatchWithOptions",
+    async (context) => await dispatchCards(context, { supportsMaxStarts: true }),
     { scope: WRITE_SCOPE },
   );
 

--- a/extensions/workboard/src/gateway.ts
+++ b/extensions/workboard/src/gateway.ts
@@ -1,58 +1,17 @@
 // Workboard plugin module implements gateway behavior.
-import { formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
-import { parseStrictPositiveInteger } from "openclaw/plugin-sdk/number-runtime";
 import type { OpenClawPluginApi } from "../api.js";
-import { dispatchAndStartWorkboardCards } from "./dispatcher.js";
+import {
+  assertNoCursorAdvance,
+  createWorkboardDispatchHandler,
+  readId,
+  readPatch,
+  respondError,
+} from "./gateway-helpers.js";
 import { WorkboardStore } from "./store.js";
 import { WORKBOARD_STATUSES, type WorkboardCard } from "./types.js";
 
 const READ_SCOPE = "operator.read" as const;
 const WRITE_SCOPE = "operator.write" as const;
-
-type GatewayMethodContext = Parameters<
-  Parameters<OpenClawPluginApi["registerGatewayMethod"]>[1]
->[0];
-type GatewayRespond = GatewayMethodContext["respond"];
-
-function respondError(respond: GatewayRespond, error: unknown) {
-  respond(false, undefined, {
-    code: "workboard_error",
-    message: formatErrorMessage(error),
-  });
-}
-
-function readId(params: Record<string, unknown>): string {
-  const value = params.id;
-  if (typeof value === "string" && value.trim()) {
-    return value.trim();
-  }
-  throw new Error("id is required.");
-}
-
-function readOptionalPositiveInteger(value: unknown, fieldName: string): number | undefined {
-  if (value === undefined) {
-    return undefined;
-  }
-  const parsed = parseStrictPositiveInteger(value);
-  if (typeof value !== "number" || parsed === undefined) {
-    throw new Error(`${fieldName} must be a positive integer.`);
-  }
-  return parsed;
-}
-
-function readPatch(params: Record<string, unknown>): Record<string, unknown> {
-  const patch = params.patch;
-  if (patch && typeof patch === "object" && !Array.isArray(patch)) {
-    return patch as Record<string, unknown>;
-  }
-  return params;
-}
-
-function assertNoCursorAdvance(params: Record<string, unknown>) {
-  if (params.advance === true) {
-    throw new Error("notification cursor advancement requires workboard.notifications.advance.");
-  }
-}
 
 function redactClaimToken(card: WorkboardCard): WorkboardCard {
   const claim = card.metadata?.claim;
@@ -84,48 +43,11 @@ export function registerWorkboardGatewayMethods(params: {
 }) {
   const { api } = params;
   const store = params.store ?? WorkboardStore.openSqlite();
-  const dispatchCards = async (
-    { params: requestParams, respond, client }: GatewayMethodContext,
-    options: { supportsMaxStarts: boolean },
-  ) => {
-    try {
-      const boardId =
-        requestParams && typeof requestParams === "object" && "boardId" in requestParams
-          ? requestParams.boardId
-          : undefined;
-      const rawMaxStarts =
-        requestParams && typeof requestParams === "object" && "maxStarts" in requestParams
-          ? requestParams.maxStarts
-          : undefined;
-      if (!options.supportsMaxStarts && rawMaxStarts !== undefined) {
-        throw new Error("maxStarts requires workboard.cards.dispatchWithOptions.");
-      }
-      const maxStarts = options.supportsMaxStarts
-        ? readOptionalPositiveInteger(rawMaxStarts, "maxStarts")
-        : undefined;
-      const result = await dispatchAndStartWorkboardCards({
-        store,
-        subagent: api.runtime.subagent,
-        worktrees: api.runtime.worktrees,
-        options: {
-          boardId: typeof boardId === "string" ? boardId : undefined,
-          ...(maxStarts !== undefined ? { maxStarts } : {}),
-          allowManagedWorktrees:
-            Array.isArray(client?.connect?.scopes) &&
-            client.connect.scopes.includes("operator.admin"),
-        },
-      });
-      respond(true, {
-        ...result,
-        promoted: result.promoted.map(redactClaimToken),
-        reclaimed: result.reclaimed.map(redactClaimToken),
-        blocked: result.blocked.map(redactClaimToken),
-        orchestrated: result.orchestrated.map(redactClaimToken),
-      });
-    } catch (error) {
-      respondError(respond, error);
-    }
-  };
+  const dispatchCards = createWorkboardDispatchHandler({
+    api,
+    store,
+    redactCard: redactClaimToken,
+  });
 
   api.registerGatewayMethod(
     "workboard.cards.list",


### PR DESCRIPTION
Closes #100169

## What Problem This Solves

Workboard dispatch intentionally starts at most three workers per pass, but operators with larger queues had no supported way to raise that cap. The existing internal `maxStarts` dispatcher option was not exposed by the CLI or Gateway RPC.

## Why This Change Was Made

This adds `openclaw workboard dispatch --max-starts <count>` as a per-pass override. The default call still uses `workboard.cards.dispatch`; capped calls use the additive `workboard.cards.dispatchWithOptions` method so an older Gateway fails before starting workers instead of silently ignoring the requested cap. Input is a strict positive integer, existing write/admin authorization remains unchanged, and starts stay sequential with the existing one-card-per-owner guard.

The cap is request-scoped. No new config or environment surface. No parallel-start semantic change.

## User Impact

Operators can deliberately start more than three eligible Workboard workers in one dispatch pass. Existing commands keep the current default of three. After upgrading, restart the Gateway before using `--max-starts`.

## Evidence

- Added CLI coverage for method selection, forwarding, strict validation, and mixed-version no-fallback behavior.
- Added Gateway coverage for the cap, invalid inputs, legacy-method rejection, method registration, and existing authorization behavior. The final behavior test starts four distinct owners with `maxStarts: 4`, while the unchanged legacy method starts three.
- Updated `docs/cli/workboard.md` with the flag, default, mixed-version behavior, and retained owner cap.
- Blacksmith Testbox `tbx_01kxdzyd55csd18hdg35pptwwb`: 29/29 focused dispatcher, Gateway, and CLI tests passed.
- Blacksmith Testbox `check:changed`: LOC ratchet, formatting, production/test types, lint, database/storage guards, and import cycles passed.
- Fresh local and full-branch autoreview: clean, with 0.99 and 0.94 confidence.
- [Exact-head CI run 29263159549](https://github.com/openclaw/openclaw/actions/runs/29263159549) for `5366ef4a13097a7f145be4ae92a6cbb44fc1b927`: pass on repaired `main`; the final helper split fixed the prior PR-specific LOC-ratchet failure.
- [Real behavior proof run 29263157173](https://github.com/openclaw/openclaw/actions/runs/29263157173): pass.
