### PR TITLE
fix(session): add exponential backoff retry for stale-snapshot conflicts on concurrent session init

### DIFF
--- a/src/auto-reply/reply/session.ts
+++ b/src/auto-reply/reply/session.ts
@@ -60,6 +60,7 @@ import {
   normalizeMainKey,
 } from "../../routing/session-key.js";
 import { isInterSessionInputProvenance } from "../../sessions/input-provenance.js";
+import { sleep } from "../../utils.js";
 import {
   normalizeDeliveryChannelRoute,
   normalizeSessionDeliveryFields,
@@ -307,29 +308,42 @@ function resolveInitSessionStateAttemptContext(
   };
 }
 
+/** Max retries for stale-snapshot conflicts during concurrent session init. */
+const STALE_SNAPSHOT_MAX_RETRIES = 3;
+/** Base backoff delay between stale-snapshot retries (exponential: 200ms, 400ms, 800ms). */
+const STALE_SNAPSHOT_BASE_DELAY_MS = 200;
+
 /** Initializes or reuses the reply session state for one inbound turn. */
 export async function initSessionState(params: InitSessionStateParams): Promise<SessionInitResult> {
-  return await initSessionStateAttempt(params, false);
+  return await initSessionStateAttempt(params);
 }
 
-async function initSessionStateAttempt(
-  params: InitSessionStateParams,
-  staleSnapshotRetried: boolean,
-): Promise<SessionInitResult> {
+async function initSessionStateAttempt(params: InitSessionStateParams): Promise<SessionInitResult> {
   const attemptContext = resolveInitSessionStateAttemptContext(params);
   // Guarded revision checks only serialize correctly when the snapshot and
-  // commit share the same writer lane.
-  return await runExclusiveSessionStoreWrite(
-    attemptContext.storePath,
-    async () => await initSessionStateAttemptLocked(params, attemptContext, staleSnapshotRetried),
-  );
+  // commit share the same writer lane. Retry stale-snapshot conflicts outside
+  // the lock so each attempt acquires a fresh writer lane and re-reads the
+  // latest snapshot. Exponential backoff gives concurrent writers time to
+  // finish before the next attempt.
+  for (let retries = 0; retries <= STALE_SNAPSHOT_MAX_RETRIES; retries++) {
+    const result = await runExclusiveSessionStoreWrite(
+      attemptContext.storePath,
+      async () => await initSessionStateAttemptLocked(params, attemptContext),
+    );
+    if (result !== "stale-snapshot") {
+      return result;
+    }
+    if (retries < STALE_SNAPSHOT_MAX_RETRIES) {
+      await sleep(STALE_SNAPSHOT_BASE_DELAY_MS * 2 ** retries);
+    }
+  }
+  throw new Error(`reply session initialization conflicted for ${attemptContext.sessionKey}`);
 }
 
 async function initSessionStateAttemptLocked(
   params: InitSessionStateParams,
   attemptContext: InitSessionStateAttemptContext,
-  staleSnapshotRetried: boolean,
-): Promise<SessionInitResult> {
+): Promise<SessionInitResult | "stale-snapshot"> {
   const { ctx, cfg, commandAuthorized } = params;
   const { agentId, conversationBindingContext, isSystemEvent, sessionCtxForState, storePath } =
     attemptContext;
@@ -931,10 +945,7 @@ async function initSessionStateAttemptLocked(
     storePath,
   });
   if (!committed.ok) {
-    if (!staleSnapshotRetried) {
-      return await initSessionStateAttemptLocked(params, attemptContext, true);
-    }
-    throw new Error(`reply session initialization conflicted for ${sessionKey}`);
+    return "stale-snapshot";
   }
   sessionEntry = committed.sessionEntry;
   sessionId = sessionEntry.sessionId;


### PR DESCRIPTION
## What Problem This Solves

Fixes #100173 — When users send concurrent messages to the same session, `commitReplySessionInitialization` can fail with a stale-snapshot revision conflict. The old code retried **once with no delay**, and did so **inside the writer lock** (preventing the snapshot from being refreshed by other writers). The retry almost always failed again, propagating a hard error to the plugin layer and showing the user "⚠️ 服务调用失败，请稍后重试。".

## Why This Change Was Made

**Core fix**: Replace the single immediate retry (inside the lock) with **3 retries with exponential backoff** (200ms → 400ms → 800ms) **outside the writer lock**. This gives concurrent writers time to complete and commit their revisions before the next attempt re-reads the snapshot.

**Key changes in `initSessionStateAttempt`**:
- Retry loop runs **outside** `runExclusiveSessionStoreWrite` so each attempt acquires a fresh writer lane and re-reads the latest snapshot
- Exponential backoff: `200ms * 2^retry` (200ms, 400ms, 800ms)
- Uses existing `sleep()` utility from `src/utils.js`

**In `initSessionStateAttemptLocked`**:
- Removed recursive retry inside the lock, replaced with a `"stale-snapshot"` return signal
- Removed `staleSnapshotRetried` boolean parameter

## Steps to Reproduce

1. Deploy OpenClaw with NapCat QQ/Telegram plugin
2. User sends multiple rapid messages to the same session
3. Previously: `reply session initialization conflicted for <sessionKey>` error → user sees "服务调用失败"
4. Now: conflict retries with backoff, resolves transparently

## User Impact

- Concurrent messages to the same session no longer produce visible "service call failed" errors
- Stale-snapshot conflicts resolve transparently via exponential backoff
- No behavior change for normal (non-concurrent) session initialization

## Evidence

- **Source-level**: The single-retry code path at `session.ts:934-935` is the exact error propagator
- **Test results**: `session.test.ts` 126 passed, `get-reply.config-override.test.ts` 5 passed, `block-streaming.test.ts` 2 passed, `state-migrations.session-roundtrip.test.ts` 1 passed — **134 tests total, no regressions**
- **Linter**: `oxfmt` reordered imports correctly after the `sleep` import was added

🤖 Generated with [Claude Code](https://claude.com/claude-code)