### PR TITLE
fix(ui): publish mobile setup independently

### DIFF
--- a/ui/src/app/overlays.ts
+++ b/ui/src/app/overlays.ts
@@ -620,9 +620,10 @@ export function createApplicationOverlays(gateway: ApplicationGateway): Applicat
       }
       devicePairSetupState.pendingCount = 0;
       const setupOperation = openDevicePairSetupState(devicePairSetupState);
-      const pendingCountOperation = refreshDevicePairPendingCount();
+      // Pairing-list latency must not keep a ready setup code behind the loading state.
+      void refreshDevicePairPendingCount();
       publish();
-      await Promise.all([setupOperation, pendingCountOperation]);
+      await setupOperation;
       if (!disposed) {
         publish();
       }

--- a/ui/src/e2e/mobile-pairing.e2e.test.ts
+++ b/ui/src/e2e/mobile-pairing.e2e.test.ts
@@ -75,6 +75,7 @@ describeControlUiE2e("Control UI mobile pairing mocked Gateway E2E", () => {
       const sidebarPairingButton = page.locator(".sidebar-pair-mobile");
       await sidebarPairingButton.waitFor();
       await expect.poll(async () => sidebarPairingButton.isEnabled()).toBe(true);
+      await gateway.deferNext("device.pair.list");
       await sidebarPairingButton.click();
 
       const dialog = page.getByRole("dialog", { name: "OpenClaw mobile" });
@@ -88,8 +89,15 @@ describeControlUiE2e("Control UI mobile pairing mocked Gateway E2E", () => {
       );
       expect(
         await page.getByText("Official OpenClaw mobile apps connect automatically").isVisible(),
-      ).toBe(false);
+      ).toBe(true);
+      await gateway.resolveDeferred("device.pair.list", {
+        paired: [],
+        pending: [{ deviceId: "mobile-1", requestId: "request-1" }],
+      });
       expect(await page.getByText("Device requests waiting for review: 1").isVisible()).toBe(true);
+      expect(
+        await page.getByText("Official OpenClaw mobile apps connect automatically").isVisible(),
+      ).toBe(false);
 
       const firstRequest = await gateway.waitForRequest("device.pair.setupCode");
       expect(firstRequest.params).toEqual({});


### PR DESCRIPTION
## What Problem This Solves

Follow-up to #100157. A slow or stalled `device.pair.list` request could keep the mobile pairing dialog on its generating state even after `device.pair.setupCode` had already returned a usable QR code.

## Why This Change Was Made

Setup-code publication and pending-device refresh are independent operations. The overlay now publishes the setup result as soon as it resolves while the guarded pending refresh continues separately.

## User Impact

The pairing QR appears promptly even when loading pending device requests is slow. Pending-device status still updates when its request completes.

## Evidence

- `node scripts/run-vitest.mjs run --config test/vitest/vitest.ui-e2e.config.ts --configLoader runner ui/src/e2e/mobile-pairing.e2e.test.ts` — passed; the test deliberately defers `device.pair.list` and requires the QR to render first.
- `node scripts/run-vitest.mjs run ui/src/lib/device-pair-setup.test.ts ui/src/pages/config/quick.test.ts` — 19 tests passed.
- Fresh autoreview — no actionable findings.

AI-assisted: implementation and tests were produced with Codex and reviewed through the repository autoreview workflow.
