### PR TITLE
test(docs): align rewrite guards with current wording

### DIFF
--- a/src/agents/minimax-docs.test.ts
+++ b/src/agents/minimax-docs.test.ts
@@ -15,7 +15,6 @@ const minimaxDoc = fs.readFileSync(path.join(repoRoot, "docs/providers/minimax.m
 
 describe("MiniMax docs sync", () => {
   it("keeps the live-testing guide on the current MiniMax default", () => {
-    expect(testingLiveDoc).toContain("MiniMax M3");
     expect(testingLiveDoc).toContain(MINIMAX_DEFAULT_MODEL_REF);
   });
 

--- a/src/config/talk-defaults.test.ts
+++ b/src/config/talk-defaults.test.ts
@@ -33,10 +33,13 @@ function readRepoFile(relativePath: string): string {
 describe("talk silence timeout defaults", () => {
   it("keeps help text and docs aligned with the policy", () => {
     const defaultsDescription = describeTalkSilenceTimeoutDefaults();
+    const talkDocDefaults =
+      `\`${EXPECTED_TALK_SILENCE_TIMEOUT_MS_BY_PLATFORM.macos}\` ms macOS/Android, ` +
+      `\`${EXPECTED_TALK_SILENCE_TIMEOUT_MS_BY_PLATFORM.ios}\` ms iOS`;
 
     expect(FIELD_HELP["talk.silenceTimeoutMs"]).toContain(defaultsDescription);
     expect(readRepoFile("docs/gateway/config-agents.md")).toContain(defaultsDescription);
-    expect(readRepoFile("docs/nodes/talk.md")).toContain(defaultsDescription);
+    expect(readRepoFile("docs/nodes/talk.md")).toContain(talkDocDefaults);
   });
 
   it("matches the Apple and Android runtime constants", () => {

--- a/src/cron/isolated-agent/run-fallback-policy.test.ts
+++ b/src/cron/isolated-agent/run-fallback-policy.test.ts
@@ -428,6 +428,6 @@ describe("resolveCronFallbacksOverride", () => {
     const automationDocs = readFileSync("docs/automation/cron-jobs.md", "utf8");
 
     expect(cliDocs).toContain("Local-provider preflight checks walk configured fallbacks");
-    expect(automationDocs).toContain("Local-provider preflight checks walk configured fallbacks");
+    expect(automationDocs).toContain("This preflight walks the job's configured fallback chain");
   });
 });

--- a/src/docs/environment-docs.test.ts
+++ b/src/docs/environment-docs.test.ts
@@ -20,7 +20,7 @@ describe("environment docs", () => {
 
     expect(markdown).toContain("Provider credentials and workspace `.env`");
     expect(markdown).toContain(
-      "OpenClaw ignores provider credential environment variables from workspace `.env` files",
+      "OpenClaw ignores provider credentials and protected runtime controls from workspace `.env`",
     );
     expect(markdown).toContain("~/.openclaw/.env");
     expect(markdown).toContain("$OPENCLAW_STATE_DIR/.env");


### PR DESCRIPTION
## What Problem This Solves

The source-grounded docs rewrite in #100142 preserved the documented behavior
but changed four sentence/table forms. Exact-string test assertions still
expected the old prose, so current `main` failed four compact CI shards and
blocked unrelated pull requests.

## Why This Change Was Made

Each guard now checks the rewritten documentation's canonical semantic form:

- workspace `.env` provider credentials remain explicitly ignored;
- Talk defaults remain tied to the platform constants and current table form;
- the MiniMax live guide remains tied to `MINIMAX_DEFAULT_MODEL_REF`;
- cron preflight still documents fallback-chain traversal before skipping.

The behavioral coverage remains; only obsolete duplicate wording checks are
removed.

## User Impact

No runtime behavior changes. The current docs and their source-backed regression
guards agree again, restoring exact-head CI for unrelated work.

## Evidence

- `node scripts/run-vitest.mjs src/docs/environment-docs.test.ts src/config/talk-defaults.test.ts src/agents/minimax-docs.test.ts src/cron/isolated-agent/run-fallback-policy.test.ts`
  - 4 files, 23 tests passed locally.
- Crabbox delegated Blacksmith Testbox:
  - provider `blacksmith-testbox`;
  - id `tbx_01kwrbct6fqztyyxctxc8vcecs`;
  - hydration run: https://github.com/openclaw/openclaw/actions/runs/28730490516;
  - `pnpm check:changed` passed with core-test typecheck and targeted oxlint.
- Fresh autoreview:
  - accepted one finding to preserve the workspace `.env` source boundary;
  - reran focused tests;
  - final review reported no accepted/actionable findings, confidence 0.98.
- `git diff --check` passed.
