### PR TITLE
fix(shared): truncateLine respects maxLength exactly (#99979)

### DIFF
--- a/src/shared/subagents-format.test.ts
+++ b/src/shared/subagents-format.test.ts
@@ -37,14 +37,14 @@ describe("shared/subagents-format", () => {
 
   it("truncates lines only when needed", () => {
     expect(truncateLine("short", 10)).toBe("short");
-    expect(truncateLine("trim me   ", 7)).toBe("trim me...");
+    expect(truncateLine("trim me   ", 7)).toBe("trim...");
   });
 
   it("truncates without breaking surrogate pairs", () => {
     // Emoji at the cut point: the surrogate pair must not be split.
-    expect(truncateLine("AB🤖CD", 3)).toBe("AB...");
+    expect(truncateLine("AB🤖CD", 3)).toBe("...");
     // Cut point in the middle of a 3-emoji string.
-    expect(truncateLine("🤖🤖🤖", 5)).toBe("🤖🤖...");
+    expect(truncateLine("🤖🤖🤖", 5)).toBe("🤖...");
     // CJK Extension B (surrogate pair) at boundary: character stays intact.
     expect(truncateLine("AB𠮷CD", 5)).toBe("AB𠮷C...");
     // No broken surrogates in output.

--- a/src/shared/subagents-format.ts
+++ b/src/shared/subagents-format.ts
@@ -30,7 +30,9 @@ export function truncateLine(value: string, maxLength: number) {
   if (value.length <= maxLength) {
     return value;
   }
-  return `${truncateUtf16Safe(value, maxLength).trimEnd()}...`;
+  // Account for the "..." suffix so the result stays within maxLength (#99979).
+  const contentLen = Math.max(0, maxLength - 3);
+  return `${truncateUtf16Safe(value, contentLen).trimEnd()}...`;
 }
 
 type TokenUsageLike = {


### PR DESCRIPTION
Closes #99979

## Summary

`truncateLine` appended `...` AFTER slicing to `maxLength`, producing strings up to `maxLength+3` characters. This broke column alignment for callers that expect the result to fit within `maxLength`.

## Root cause

```typescript
// Before: truncates to maxLength, then adds "..." → maxLength+3 chars
return `${truncateUtf16Safe(value, maxLength).trimEnd()}...`;
```

## Fix

+3/-1: subtract 3 from `maxLength` when computing the content slice so the total (content + `...`) stays within the caller's limit:

```typescript
const contentLen = Math.max(0, maxLength - 3);
return `${truncateUtf16Safe(value, contentLen).trimEnd()}...`;
```

## Files

- `src/shared/subagents-format.ts` — `truncateLine()` +3/-1
- `src/shared/subagents-format.test.ts` — update 3 test expectations to match corrected behavior