### PR TITLE
fix(status): return current time from session_status and harden time-hint prompt

### DIFF
--- a/src/agents/system-prompt.ts
+++ b/src/agents/system-prompt.ts
@@ -1152,7 +1152,7 @@ export function buildAgentSystemPrompt(params: {
         : "",
       params.modelAliasLines && params.modelAliasLines.length > 0 && !isMinimal ? "" : "",
       userTimezone
-        ? "If you need the current date, time, or day of week, run session_status (📊 session_status)."
+        ? "Never assume or guess the current date, time, or day of week; your training data is stale. Whenever anything depends on the present moment (scheduling, deadlines, age/elapsed math, or words like today/now/tomorrow/this week), first run session_status (📊 session_status) and use its `Current time` value."
         : "",
       "## Workspace",
       `Your working directory is: ${displayWorkspaceDir}`,

--- a/src/status/status-message.test.ts
+++ b/src/status/status-message.test.ts
@@ -20,6 +20,26 @@ afterEach(() => {
   cliBackendsTesting.resetDepsForTest();
 });
 
+describe("buildStatusMessage current time", () => {
+  it("surfaces a live current-time line so session_status returns the date/time", () => {
+    // 2025-07-03T08:00:00Z; the Reference UTC line is timezone-independent.
+    const now = 1_751_529_600_000;
+    const text = buildStatusMessage({
+      now,
+      config: { agents: { defaults: { userTimezone: "UTC", timeFormat: "24" } } },
+      agent: { model: "anthropic/claude-haiku-4-5" },
+      sessionKey: "agent:main:main",
+      sessionScope: "per-sender",
+      queue: { mode: "steer", depth: 0 },
+      modelAuth: "api-key",
+    });
+
+    expect(text).toContain("Current time:");
+    expect(text).toContain("(UTC)");
+    expect(text).toContain("Reference UTC: 2025-07-03 08:00 UTC");
+  });
+});
+
 describe("buildStatusMessage context window", () => {
   it("ignores stale runtime context after a manual session model switch", () => {
     const text = buildStatusMessage({

--- a/src/status/status-message.ts
+++ b/src/status/status-message.ts
@@ -7,6 +7,7 @@ import {
   normalizeOptionalString,
 } from "@openclaw/normalization-core/string-coerce";
 import { resolveContextTokensForModel } from "../agents/context.js";
+import { resolveCronStyleNow } from "../agents/current-time.js";
 import { DEFAULT_CONTEXT_TOKENS, DEFAULT_MODEL, DEFAULT_PROVIDER } from "../agents/defaults.js";
 import { resolveExtraParams } from "../agents/embedded-agent-runner/extra-params.js";
 import { resolveFastModeState } from "../agents/fast-mode.js";
@@ -563,6 +564,12 @@ function hasUserPinnedModelSelection(entry: SessionEntry | undefined): boolean {
 
 export function buildStatusMessage(args: StatusArgs): string {
   const now = args.now ?? Date.now();
+  // Live wall-clock line for the status card. The field/render slot existed but
+  // was never populated, so the model (told to call session_status for the date/
+  // time) got none back and would guess. Derive from `now` + config timezone so
+  // every render path (/status command and session_status tool) surfaces it.
+  const timeLine =
+    args.timeLine ?? (args.config ? resolveCronStyleNow(args.config, now).timeLine : undefined);
   const entry = args.sessionEntry;
   const selectionConfig = {
     agents: {
@@ -1113,7 +1120,7 @@ export function buildStatusMessage(args: StatusArgs): string {
 
   return [
     versionLine,
-    args.timeLine,
+    timeLine,
     args.uptimeLine,
     ...modelLines,
     configuredFallbacksLine,


### PR DESCRIPTION
## What Problem This Solves

The `session_status` card exposed a "Current time" slot, and the agent system prompt told the model to run `session_status` whenever it needed the date/time. But `buildStatusMessage` never populated the time line — `args.timeLine` was always `undefined` — so the tool returned no clock value. The model, having no real time to read, would fall back to guessing from stale training data (wrong day/date), breaking anything time-dependent (scheduling, "today/now", elapsed/age math).

## Why This Change Was Made

Make the status card actually carry a live wall-clock line so the documented "call session_status for the time" contract works. The time is derived from `now` + the configured `userTimezone` via `resolveCronStyleNow`, so every render path (the `/status` command and the `session_status` tool) surfaces the same value. The prompt hint is also hardened to explicitly forbid guessing the current moment and to name the `Current time` field to read.

## User Impact

Agents now get an accurate current date/time from `session_status` instead of guessing. No config or API changes; the time line renders from existing config/timezone.

## Evidence

- New behavior test in `src/status/status-message.test.ts` asserts the rendered card contains `Current time:`, the timezone, and the fixed `Reference UTC` line for a known `now`.
- `node scripts/run-vitest.mjs src/status/status-message.test.ts` → 3 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
