### PR TITLE
fix(tui): keep local commands out of model prompts

### DIFF
--- a/src/tui/commands.test.ts
+++ b/src/tui/commands.test.ts
@@ -5,6 +5,12 @@ import { getSlashCommands, helpText, parseCommand } from "./commands.js";
 describe("parseCommand", () => {
   it("normalizes aliases and keeps command args", () => {
     expect(parseCommand("/elev full")).toEqual({ name: "elevated", args: "full" });
+    expect(parseCommand("/t high")).toEqual({ name: "think", args: "high" });
+    expect(parseCommand("/side check this")).toEqual({ name: "btw", args: "check this" });
+    expect(parseCommand("/compact: focus on decisions")).toEqual({
+      name: "compact",
+      args: "focus on decisions",
+    });
   });
 
   it("normalizes gateway-status aliases", () => {
@@ -95,6 +101,15 @@ describe("getSlashCommands", () => {
       "Enable or disable memory dreaming.",
     );
   });
+
+  it("only advertises shared commands that local mode can route", () => {
+    const names = getSlashCommands({ local: true }).map((command) => command.name);
+
+    expect(names).toEqual(
+      expect.not.arrayContaining(["commands", "status", "compact", "context", "tools"]),
+    );
+    expect(names).toEqual(expect.arrayContaining(["goal", "btw", "side", "stop", "t"]));
+  });
 });
 
 describe("helpText", () => {
@@ -106,5 +121,12 @@ describe("helpText", () => {
     expect(output).toContain("/gateway-status");
     expect(output).toContain("/gwstatus");
     expect(output).toContain("/crestodian [request]");
+  });
+
+  it("does not advertise Gateway-owned commands in local mode", () => {
+    const output = helpText({ local: true });
+
+    expect(output).not.toContain("/commands");
+    expect(output).not.toContain("/status");
   });
 });

--- a/src/tui/commands.ts
+++ b/src/tui/commands.ts
@@ -2,7 +2,11 @@
 import type { SlashCommand } from "@earendil-works/pi-tui";
 import { normalizeLowercaseStringOrEmpty } from "@openclaw/normalization-core/string-coerce";
 import type { CommandEntry } from "../../packages/gateway-protocol/src/index.js";
-import { listChatCommands, listChatCommandsForConfig } from "../auto-reply/commands-registry.js";
+import {
+  listChatCommands,
+  listChatCommandsForConfig,
+  resolveTextCommand,
+} from "../auto-reply/commands-registry.js";
 import { formatThinkingLevels, listThinkingLevelLabels } from "../auto-reply/thinking.js";
 import type { OpenClawConfig } from "../config/types.js";
 
@@ -29,9 +33,13 @@ export type SlashCommandOptions = {
 };
 
 const COMMAND_ALIASES: Record<string, string> = {
-  elev: "elevated",
   gwstatus: "gateway-status",
 };
+
+// These shared commands have explicit local TUI routing but no same-named
+// built-in autocomplete entry. Other shared commands require the Gateway and
+// must stay out of local autocomplete and model prompts.
+const LOCAL_TUI_ROUTED_SHARED_COMMANDS = new Set(["btw", "goal", "stop"]);
 
 function createLevelCompletion(
   levels: string[],
@@ -64,6 +72,13 @@ function appendSlashCommand(
 }
 
 export function parseCommand(input: string): ParsedCommand {
+  const sharedCommand = resolveTextCommand(input);
+  if (sharedCommand) {
+    return {
+      name: sharedCommand.command.key,
+      args: sharedCommand.args ?? "",
+    };
+  }
   const trimmed = input.replace(/^\//, "").trim();
   if (!trimmed) {
     return { name: "", args: "" };
@@ -74,6 +89,11 @@ export function parseCommand(input: string): ParsedCommand {
     name: COMMAND_ALIASES[normalized] ?? normalized,
     args: rest.join(" ").trim(),
   };
+}
+
+/** Whether a slash input belongs to the shared Gateway command registry. */
+export function isSharedTextCommand(input: string): boolean {
+  return resolveTextCommand(input) !== null;
 }
 
 export function getSlashCommands(options: SlashCommandOptions = {}): SlashCommand[] {
@@ -161,6 +181,13 @@ export function getSlashCommands(options: SlashCommandOptions = {}): SlashComman
   const seen = new Set(commands.map((command) => command.name));
   const gatewayCommands = options.cfg ? listChatCommandsForConfig(options.cfg) : listChatCommands();
   for (const command of gatewayCommands) {
+    if (
+      options.local &&
+      !seen.has(command.key) &&
+      !LOCAL_TUI_ROUTED_SHARED_COMMANDS.has(command.key)
+    ) {
+      continue;
+    }
     const aliases = command.textAliases.length > 0 ? command.textAliases : [`/${command.key}`];
     for (const alias of aliases) {
       appendSlashCommand(commands, seen, alias, command.description);
@@ -182,8 +209,7 @@ export function helpText(options: SlashCommandOptions = {}): string {
   return [
     "Slash commands:",
     "/help",
-    "/commands",
-    "/status",
+    ...(options.local ? [] : ["/commands", "/status"]),
     "/gateway-status",
     "/gwstatus",
     ...(options.local ? ["/auth [provider]"] : []),

--- a/src/tui/tui-command-handlers.test.ts
+++ b/src/tui/tui-command-handlers.test.ts
@@ -355,6 +355,44 @@ describe("tui command handlers", () => {
     });
   });
 
+  it.each(["/status", "/compact", "/commands", "/context", "/context detail"])(
+    "keeps unsupported shared command %s out of local model prompts",
+    async (command) => {
+      const { handleCommand, sendChat, addPendingUser, addSystem } = createHarness({
+        opts: { local: true },
+      });
+
+      await handleCommand(command);
+
+      expect(sendChat).not.toHaveBeenCalled();
+      expect(addPendingUser).not.toHaveBeenCalled();
+      expect(addSystem).toHaveBeenCalledWith(
+        expect.stringMatching(/not available in local embedded mode; message not sent$/),
+      );
+    },
+  );
+
+  it("preserves local side prompts and unknown slash text", async () => {
+    const emptySide = createHarness({ opts: { local: true } });
+    await emptySide.handleCommand("/side");
+    expect(emptySide.sendChat).not.toHaveBeenCalled();
+    expect(emptySide.addSystem).toHaveBeenCalledWith("Usage: /btw [side question]");
+
+    const side = createHarness({ opts: { local: true } });
+    await side.handleCommand("/side check this");
+    expectSendChatFields(side.sendChat, {
+      sessionKey: "agent:main:main",
+      message: "/side check this",
+    });
+
+    const unknown = createHarness({ opts: { local: true } });
+    await unknown.handleCommand("/not-a-real-command");
+    expectSendChatFields(unknown.sendChat, {
+      sessionKey: "agent:main:main",
+      message: "/not-a-real-command",
+    });
+  });
+
   it("starts local goals and sends the objective to the model", async () => {
     const runGoalCommand = vi.fn().mockResolvedValue({ text: "Goal started: ship" });
     const { handleCommand, sendChat, addSystem, refreshSessionInfo, addPendingUser } =
@@ -1090,18 +1128,18 @@ describe("tui command handlers", () => {
       activityStatus: "streaming",
     });
 
-    await handleCommand("/context detail");
+    await handleCommand("continue here");
 
     expect(sendChat).toHaveBeenCalledTimes(1);
     expectSendChatFields(sendChat, {
-      message: "/context detail",
+      message: "continue here",
       sessionKey: "agent:main:main",
     });
     expect(reserveAssistantSlot).toHaveBeenCalledWith("run-active");
     const reserveCallOrder = reserveAssistantSlot.mock.invocationCallOrder[0];
     const addPendingUserCallOrder = addPendingUser.mock.invocationCallOrder[0];
     expect(reserveCallOrder).toBeLessThan(addPendingUserCallOrder);
-    expect(addPendingUser).toHaveBeenCalledWith(expect.any(String), "/context detail");
+    expect(addPendingUser).toHaveBeenCalledWith(expect.any(String), "continue here");
     expect(addSystem).not.toHaveBeenCalledWith(
       "agent is busy — press Esc to abort before sending a new message",
     );
@@ -1186,10 +1224,10 @@ describe("tui command handlers", () => {
       activityStatus: "finishing context",
     });
 
-    await handleCommand("/context detail");
+    await handleCommand("continue after compaction");
 
     expect(sendChat).toHaveBeenCalledTimes(1);
-    expect(addPendingUser).toHaveBeenCalledWith(expect.any(String), "/context detail");
+    expect(addPendingUser).toHaveBeenCalledWith(expect.any(String), "continue after compaction");
     expect(addSystem).not.toHaveBeenCalledWith(
       "agent is busy — press Esc to abort before sending a new message",
     );

--- a/src/tui/tui-command-handlers.ts
+++ b/src/tui/tui-command-handlers.ts
@@ -18,7 +18,7 @@ import {
 import { isChatStopCommandText } from "../gateway/chat-abort.js";
 import { formatRelativeTimestamp } from "../infra/format-time/format-relative.ts";
 import { normalizeAgentId } from "../routing/session-key.js";
-import { helpText, parseCommand } from "./commands.js";
+import { helpText, isSharedTextCommand, parseCommand } from "./commands.js";
 import type { ChatLog } from "./components/chat-log.js";
 import {
   createFilterableSelectList,
@@ -146,6 +146,10 @@ export function createCommandHandlers(context: CommandHandlerContext) {
     runAuthFlow,
     requestExit,
   } = context;
+
+  const addUnsupportedLocalCommand = (name: string) => {
+    chatLog.addSystem(`/${name} is not available in local embedded mode; message not sent`);
+  };
 
   const setAgent = async (id: string) => {
     state.currentAgentId = normalizeAgentId(id);
@@ -435,7 +439,9 @@ export function createCommandHandlers(context: CommandHandlerContext) {
         await openAgentSelector();
         break;
       case "context":
-        if (!args) {
+        if (opts.local) {
+          addUnsupportedLocalCommand(name);
+        } else if (!args) {
           openContextModeSelector();
         } else {
           await sendMessage(raw);
@@ -460,6 +466,13 @@ export function createCommandHandlers(context: CommandHandlerContext) {
           }
         } else {
           await sendMessage(raw);
+        }
+        break;
+      case "btw":
+        if (args) {
+          await sendMessage(raw);
+        } else {
+          chatLog.addSystem("Usage: /btw [side question]");
         }
         break;
       case "crestodian":
@@ -746,9 +759,14 @@ export function createCommandHandlers(context: CommandHandlerContext) {
       case "quit":
         requestExit();
         break;
-      default:
+      default: {
+        if (opts.local && isSharedTextCommand(raw)) {
+          addUnsupportedLocalCommand(name);
+          break;
+        }
         await sendMessage(raw);
         break;
+      }
     }
     tui.requestRender();
   };

--- a/src/tui/tui-pty-local.e2e.test.ts
+++ b/src/tui/tui-pty-local.e2e.test.ts
@@ -386,6 +386,16 @@ describe("TUI PTY real backends", () => {
       const fixture = await startLocalModeTui();
       try {
         await fixture.run.waitForOutput("local ready", LOCAL_STARTUP_TIMEOUT_MS);
+        for (const command of ["/status", "/compact", "/commands", "/context"]) {
+          await fixture.run.write(`${command}\r`);
+          await fixture.run.waitForOutput(
+            `${command} is not available in local embedded mode; message not sent`,
+          );
+        }
+        await fixture.run.write("/side\r");
+        await fixture.run.waitForOutput("Usage: /btw [side question]");
+        expect(fixture.mockModel.requests()).toHaveLength(0);
+
         await fixture.run.write("send the local PTY smoke response\r");
         await waitFor({
           timeoutMs: LOCAL_OUTPUT_TIMEOUT_MS,


### PR DESCRIPTION
Closes #71592

## What Problem This Solves

Fixes an issue where users of `openclaw tui --local` could select or type shared slash commands such as `/status`, `/compact`, `/commands`, and `/context`, then have those control commands sent to the model as ordinary user prompts because the embedded backend does not run the Gateway command handlers.

## Why This Change Was Made

The TUI now resolves shared aliases through the canonical command registry, advertises only commands with an explicit local route, and rejects known Gateway-owned commands before model submission. Gateway-connected behavior, argument-bearing `/btw` and `/side`, and intentionally unknown slash text remain unchanged; bare `/btw` and `/side` now return the shared usage hint.

AI-assisted: yes. I reviewed the implementation and understand the affected local and Gateway command paths.

## User Impact

Local TUI users no longer spend model turns or pollute transcripts when they invoke an advertised control command that requires the Gateway. Autocomplete and `/help` now match what local embedded mode can actually execute, and unsupported commands produce a direct local explanation.

## Evidence

- Focused unit proof: `node scripts/run-vitest.mjs src/tui/commands.test.ts src/tui/tui-command-handlers.test.ts` — 96 tests passed.
- Real local PTY proof: `OPENCLAW_TUI_PTY_INCLUDE_LOCAL=1 node scripts/run-vitest.mjs run --config test/vitest/vitest.tui-pty.config.ts src/tui/tui-pty-local.e2e.test.ts --testNamePattern 'drives the real local backend'` — the TUI visibly rejected `/status`, `/compact`, `/commands`, and `/context`, returned usage for bare `/side`, made zero model requests for those inputs, then sent a normal prompt through the real embedded backend and rendered `LOCAL_PTY_RESPONSE`.
- Linux CI-parity proof: Blacksmith Testbox through Crabbox `tbx_01kwrdzcx1a87xgeb9v92yfghr` ([run 28731441776](https://github.com/openclaw/openclaw/actions/runs/28731441776)) — `pnpm check:changed` passed core production/test typechecks, lint, import cycles, and changed guards; the same real local PTY scenario passed on Linux.
- Autoreview: final `autoreview --mode local` completed with no accepted/actionable findings after two in-scope routing findings were fixed.
