### PR TITLE
fix(ui): show only Standard and Fast for OpenAI speed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ Docs: https://docs.openclaw.ai
 ### Fixes
 
 - **macOS SSH tunnels:** resolve user-installed SSH `ProxyCommand` helpers through the app's managed PATH while preserving inherited connection environment, so remote aliases work after Finder and sanitized-script launches.
+- **Control UI OpenAI speed picker:** show only Standard and Fast choices for OpenAI models.
 - **Control UI terminal rendering:** adopt the shared `@openclaw/libterminal` browser lifecycle and add Nerd Font fallbacks so icon-enabled shell listings render their glyphs when a compatible local font is installed.
 - **Slack transcript history:** let Codex app-server own its persisted assistant replies so Slack does not append redundant delivery-mirror rows, while the Control UI keeps legacy duplicate mirrors hidden.
 - **Control UI chat history:** hide redundant channel-final delivery mirrors when the preceding app-server assistant reply already shows the same text.

--- a/ui/src/lib/chat/model-select-state.test.ts
+++ b/ui/src/lib/chat/model-select-state.test.ts
@@ -7,6 +7,7 @@ import {
   DEFAULT_CHAT_MODEL_CATALOG,
 } from "../../test-helpers/chat-model.ts";
 import {
+  resolveChatFastModeSelectState,
   resolveChatModelOverrideValue,
   resolveChatModelSelectState,
 } from "./model-select-state.ts";
@@ -25,7 +26,68 @@ function createChatModelState(
   };
 }
 
+function resolveFastModeState(params: {
+  provider: string;
+  fastMode?: boolean | "auto";
+  effectiveFastMode?: boolean | "auto";
+}) {
+  const sessionsResult = createSessionsListResult({
+    model: "model",
+    modelProvider: params.provider,
+  });
+  sessionsResult.sessions[0] = {
+    ...sessionsResult.sessions[0],
+    ...(params.fastMode === undefined ? {} : { fastMode: params.fastMode }),
+    ...(params.effectiveFastMode === undefined
+      ? {}
+      : { effectiveFastMode: params.effectiveFastMode }),
+  };
+  return resolveChatFastModeSelectState({
+    activeRunId: null,
+    catalog: [],
+    connected: true,
+    currentModelOverride: `${params.provider}/model`,
+    gatewayAvailable: true,
+    loading: false,
+    sending: false,
+    sessionKey: "main",
+    sessionsResult,
+    stream: null,
+  });
+}
+
 describe("chat-model-select-state", () => {
+  it("offers only Standard and Fast for OpenAI models", () => {
+    expect(resolveFastModeState({ provider: "openai" })).toMatchObject({
+      currentOverride: "off",
+      options: [
+        { value: "off", label: "Standard" },
+        { value: "on", label: "Fast" },
+      ],
+      supported: true,
+    });
+    expect(resolveFastModeState({ provider: "openai", fastMode: true }).currentOverride).toBe("on");
+    expect(
+      resolveFastModeState({ provider: "openai", effectiveFastMode: true }).currentOverride,
+    ).toBe("on");
+    expect(resolveFastModeState({ provider: "openai", fastMode: "auto" }).currentOverride).toBe(
+      "auto",
+    );
+  });
+
+  it("keeps inherited and auto choices for other fast-mode providers", () => {
+    expect(resolveFastModeState({ provider: "anthropic", fastMode: "auto" })).toMatchObject({
+      currentOverride: "auto",
+      options: [
+        { value: "", label: "Default" },
+        { value: "on", label: "Fast" },
+        { value: "off", label: "Standard" },
+        { value: "auto", label: "Auto" },
+      ],
+      supported: true,
+    });
+  });
+
   it("uses the server-qualified value when the active session provider is present", () => {
     const state = createChatModelState({
       chatModelCatalog: createModelCatalog(DEEPSEEK_CHAT_MODEL),

--- a/ui/src/lib/chat/model-select-state.ts
+++ b/ui/src/lib/chat/model-select-state.ts
@@ -190,7 +190,7 @@ export function resolveChatFastModeSelectState(
     activeRow?.modelProvider?.trim().toLowerCase() ??
     defaultProvider?.trim().toLowerCase() ??
     null;
-  const currentOverride =
+  const configuredOverride =
     activeRow?.fastMode === "auto"
       ? "auto"
       : activeRow?.fastMode === true
@@ -198,8 +198,19 @@ export function resolveChatFastModeSelectState(
         : activeRow?.fastMode === false
           ? "off"
           : "";
+  const isOpenAI = effectiveProvider === "openai";
+  const effectiveOpenAIMode = activeRow?.effectiveFastMode ?? activeRow?.fastMode;
+  // OpenAI exposes one optional priority tier. Keep legacy auto unselected so
+  // either binary choice replaces it instead of implying the wrong tier.
+  const currentOverride = isOpenAI
+    ? effectiveOpenAIMode === true
+      ? "on"
+      : effectiveOpenAIMode === "auto"
+        ? "auto"
+        : "off"
+    : configuredOverride;
   const supported = Boolean(
-    (effectiveProvider && FAST_MODE_PROVIDER_IDS.has(effectiveProvider)) || currentOverride,
+    (effectiveProvider && FAST_MODE_PROVIDER_IDS.has(effectiveProvider)) || configuredOverride,
   );
   return {
     currentOverride,
@@ -211,12 +222,17 @@ export function resolveChatFastModeSelectState(
       Boolean(input.activeRunId) ||
       input.stream !== null ||
       !input.gatewayAvailable,
-    options: [
-      { value: "", label: "Default" },
-      { value: "on", label: "Fast" },
-      { value: "off", label: "Standard" },
-      { value: "auto", label: "Auto" },
-    ],
+    options: isOpenAI
+      ? [
+          { value: "off", label: "Standard" },
+          { value: "on", label: "Fast" },
+        ]
+      : [
+          { value: "", label: "Default" },
+          { value: "on", label: "Fast" },
+          { value: "off", label: "Standard" },
+          { value: "auto", label: "Auto" },
+        ],
     supported,
   };
 }


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where OpenAI users opening the Control UI model picker would see four speed choices—Default, Fast, Standard, and Auto—even though OpenAI exposes only the standard and priority service tiers.

## Why This Change Was Made

The OpenAI picker now presents only Standard and Fast, ordered Standard first. Selection follows the effective session state so inherited Fast remains visible; legacy Auto remains unselected until the user explicitly chooses one of the supported binary modes. Other providers retain their existing choices.

## User Impact

OpenAI users now get an unambiguous two-choice speed control matching the provider contract.

## Evidence

- Reproduced the four-choice OpenAI picker in the running Control UI.
- `OPENCLAW_HEAVY_CHECK_LOCK_SCOPE=worktree OPENCLAW_VITEST_FS_MODULE_CACHE_PATH=/tmp/openclaw-speed-picker-vitest node scripts/run-vitest.mjs ui/src/lib/chat/model-select-state.test.ts` — 11 tests passed.
- `OPENCLAW_HEAVY_CHECK_LOCK_SCOPE=worktree node scripts/run-tsgo.mjs -p tsconfig.core.json` — passed.
- `.agents/skills/autoreview/scripts/autoreview --mode local --stream-engine-output` — clean after addressing effective/inherited mode selection.
- Verified the dependency contract in sibling Codex sources: `codex-rs/protocol/src/config_types.rs`, `codex-rs/protocol/src/openai_models.rs`, `codex-rs/core/src/session/mod.rs`, and their service-tier tests. Codex maps Standard to the default tier and Fast to priority.

AI-assisted: implemented and reviewed with Codex; maintainer-directed change.
