### PR TITLE
fix(ui): make tool activity rows selectable and less repetitive

### DIFF
--- a/ui/src/pages/chat/chat-responsive.browser.test.ts
+++ b/ui/src/pages/chat/chat-responsive.browser.test.ts
@@ -82,7 +82,7 @@ function iconSvg() {
   return `<svg viewBox="0 0 24 24" aria-hidden="true"><path d="M12 5v14M5 12h14"></path></svg>`;
 }
 
-function activityErrorAlignmentHtml() {
+function activityAlignmentHtml() {
   return `
     <div class="chat-thread" role="log">
       <div class="chat-thread-inner">
@@ -94,7 +94,6 @@ function activityErrorAlignmentHtml() {
                 <span class="chat-activity-group__icon">${iconSvg()}</span>
                 <span class="chat-activity-group__label">Activity: 2 tools</span>
                 <span class="chat-activity-group__preview">Bash, Gateway</span>
-                <span class="chat-activity-group__badge">${iconSvg()}<span>Error</span></span>
               </button>
               <div class="chat-activity-group__body">
                 <div class="chat-bubble" data-activity-call-bubble>
@@ -106,7 +105,6 @@ function activityErrorAlignmentHtml() {
                       <span class="chat-tool-msg-summary__icon">${iconSvg()}</span>
                       <span class="chat-tool-msg-summary__label">Tool error</span>
                       <span class="chat-tool-msg-summary__names">Bash</span>
-                      <span class="chat-tool-msg-summary__error-badge">${iconSvg()}<span>Error</span></span>
                     </button>
                   </div>
                 </div>
@@ -496,19 +494,25 @@ describeBrowserLayout("chat responsive browser layout", () => {
   it.each([
     [430, 720],
     [1366, 900],
-  ] as const)("right-aligns activity errors with call bubbles at %sx%s", async (width, height) => {
+  ] as const)("right-aligns activity rows with call bubbles at %sx%s", async (width, height) => {
     const page = await openBrowserPage(width, height);
     try {
       await page.setContent(
-        `<!doctype html><html><head><style>${readUiCss()}</style></head><body>${activityErrorAlignmentHtml()}</body></html>`,
+        `<!doctype html><html><head><style>${readUiCss()}</style></head><body>${activityAlignmentHtml()}</body></html>`,
       );
 
       await expectNoHorizontalOverflow(page);
       const callBubble = await getRect(page, "[data-activity-call-bubble]");
       const errorSummary = await getRect(page, ".chat-tool-msg-summary--error");
-      const errorBadge = await getRect(page, ".chat-tool-msg-summary__error-badge");
       expect(Math.abs(callBubble.right - errorSummary.right)).toBeLessThanOrEqual(1);
-      expect(Math.abs(errorBadge.right - (errorSummary.right - 8))).toBeLessThanOrEqual(1);
+      const selectionStyles = await page.evaluate(() => ({
+        activity: getComputedStyle(
+          document.querySelector<HTMLElement>(".chat-activity-group__summary")!,
+        ).userSelect,
+        tool: getComputedStyle(document.querySelector<HTMLElement>(".chat-tool-msg-summary")!)
+          .userSelect,
+      }));
+      expect(selectionStyles).toEqual({ activity: "text", tool: "text" });
     } finally {
       await closeBrowserPage(page);
     }

--- a/ui/src/pages/chat/components/chat-message.test.ts
+++ b/ui/src/pages/chat/components/chat-message.test.ts
@@ -60,6 +60,18 @@ function requireFirstMockArg(
   return arg;
 }
 
+function selectText(element: Element) {
+  const range = document.createRange();
+  range.selectNodeContents(element);
+  const selection = window.getSelection();
+  selection?.removeAllRanges();
+  selection?.addRange(range);
+}
+
+function pointerClick(element: Element) {
+  element.dispatchEvent(new MouseEvent("click", { bubbles: true, detail: 1 }));
+}
+
 vi.mock("../../../lib/agents/display.ts", () => {
   const isRenderableControlUiAvatarUrl = (value: string) =>
     /^data:image\//i.test(value) || (value.startsWith("/") && !value.startsWith("//"));
@@ -130,7 +142,7 @@ vi.mock("../../../lib/chat/tool-display.ts", async (importOriginal) => {
           ? String((args as { detail: unknown }).detail)
           : args && typeof args === "object" && name === "skill_workshop" && "action" in args
             ? String((args as { action: unknown }).action)
-          : undefined,
+            : undefined,
     }),
   };
 });
@@ -1099,6 +1111,7 @@ describe("grouped chat rendering", () => {
 
   it("passes the effective default-expanded activity state to the toggle handler", () => {
     const container = document.createElement("div");
+    document.body.append(container);
     const onToggleToolMessageExpanded = vi.fn();
     const group: MessageGroup = {
       kind: "group",
@@ -1134,9 +1147,32 @@ describe("grouped chat rendering", () => {
     renderMessageGroups(container, [group], { onToggleToolMessageExpanded });
 
     expect(container.querySelector(".chat-activity-group.is-open")).toBeInstanceOf(HTMLElement);
-    expectElement(container, ".chat-activity-group__summary", HTMLButtonElement).click();
+    const activitySummary = expectElement(
+      container,
+      ".chat-activity-group__summary",
+      HTMLButtonElement,
+    );
+    expect(activitySummary.classList.contains("chat-activity-group__summary--error")).toBe(true);
+    expect(activitySummary.getAttribute("aria-label")).toContain("includes errors");
+    expect(activitySummary.querySelector(".chat-activity-group__badge")).toBeNull();
+    const errorSummary = expectElement(
+      container,
+      ".chat-tool-msg-summary--error",
+      HTMLButtonElement,
+    );
+    expect(errorSummary.querySelector(".chat-tool-msg-summary__label")?.textContent).toBe(
+      "Tool error",
+    );
+    expect(errorSummary.querySelector(".chat-tool-msg-summary__error-badge")).toBeNull();
+    selectText(expectElement(activitySummary, ".chat-activity-group__label", HTMLElement));
+    pointerClick(activitySummary);
+    expect(onToggleToolMessageExpanded).not.toHaveBeenCalled();
+
+    window.getSelection()?.removeAllRanges();
+    activitySummary.click();
 
     expect(onToggleToolMessageExpanded).toHaveBeenCalledWith("activity:tool-group", true);
+    container.remove();
   });
 
   it("keeps succeeded grouped tool activity collapsed without error styling", () => {
@@ -1281,9 +1317,7 @@ describe("grouped chat rendering", () => {
 
     expectElement(container, ".chat-bubble--tool-shell", HTMLElement);
     const summary = container.querySelector<HTMLElement>(".chat-tool-msg-summary");
-    expect(summary?.querySelector(".chat-tool-msg-summary__label")?.textContent).toBe(
-      "Sub-agent",
-    );
+    expect(summary?.querySelector(".chat-tool-msg-summary__label")?.textContent).toBe("Sub-agent");
     expect(container.querySelector(".chat-tool-msg-body")).toBeNull();
 
     renderAssistantMessage(container, message, {
@@ -1465,6 +1499,8 @@ describe("grouped chat rendering", () => {
 
   it("marks status-only standalone tool-result summaries as errors", () => {
     const container = document.createElement("div");
+    document.body.append(container);
+    const onToggleToolMessageExpanded = vi.fn();
     const groups = [
       createMessageGroup(
         {
@@ -1481,15 +1517,21 @@ describe("grouped chat rendering", () => {
 
     renderMessageGroups(container, groups, {
       isToolMessageExpanded: () => false,
+      onToggleToolMessageExpanded,
     });
 
     let summary = expectElement(container, ".chat-tool-msg-summary", HTMLButtonElement);
     expect(summary.classList.contains("chat-tool-msg-summary--error")).toBe(true);
     expect(summary.querySelector(".chat-tool-msg-summary__label")?.textContent).toBe("Tool error");
-    expect(summary.querySelector(".chat-tool-msg-summary__names")?.textContent).toBe(
-      "Sub-agent",
-    );
-    expect(summary.querySelector(".chat-tool-msg-summary__error-badge")).not.toBeNull();
+    expect(summary.querySelector(".chat-tool-msg-summary__names")?.textContent).toBe("Sub-agent");
+    expect(summary.querySelector(".chat-tool-msg-summary__error-badge")).toBeNull();
+    selectText(expectElement(summary, ".chat-tool-msg-summary__label", HTMLElement));
+    pointerClick(summary);
+    expect(onToggleToolMessageExpanded).not.toHaveBeenCalled();
+
+    window.getSelection()?.removeAllRanges();
+    summary.click();
+    expect(onToggleToolMessageExpanded).toHaveBeenCalledOnce();
 
     renderMessageGroups(container, groups, {
       isToolMessageExpanded: () => true,
@@ -1501,6 +1543,7 @@ describe("grouped chat rendering", () => {
     expect(
       JSON.parse(container.querySelector(".chat-json-content code")?.textContent ?? "{}"),
     ).toEqual({ status: "error" });
+    container.remove();
   });
 
   it("keeps succeeded standalone tool-result summaries collapsed without error styling", () => {

--- a/ui/src/pages/chat/components/chat-message.ts
+++ b/ui/src/pages/chat/components/chat-message.ts
@@ -44,6 +44,7 @@ import {
   renderToolCard,
   renderToolPreview,
   resolveCollapsedToolDetail,
+  shouldToggleSelectableDisclosure,
 } from "./chat-tool-cards.ts";
 
 function renderChatIcon(name: string) {
@@ -692,17 +693,20 @@ export function renderMessageGroup(group: MessageGroup, opts: RenderMessageGroup
                 : ""}"
               type="button"
               aria-expanded=${String(activityExpanded)}
-              @click=${() =>
-                opts.onToggleToolMessageExpanded?.(activityDisclosureId, activityExpanded)}
+              aria-label=${hasError
+                ? `Activity: ${toolCount} tool${toolCount === 1 ? "" : "s"}, includes errors. ${preview}`
+                : nothing}
+              @click=${(event: MouseEvent) => {
+                if (shouldToggleSelectableDisclosure(event)) {
+                  opts.onToggleToolMessageExpanded?.(activityDisclosureId, activityExpanded);
+                }
+              }}
             >
-              <span class="chat-activity-group__icon">${icons.activity}</span>
+              <span class="chat-activity-group__icon">${hasError ? icons.x : icons.activity}</span>
               <span class="chat-activity-group__label"
                 >Activity: ${toolCount} tool${toolCount === 1 ? "" : "s"}</span
               >
               <span class="chat-activity-group__preview">${preview}</span>
-              ${hasError
-                ? html`<span class="chat-activity-group__badge">${icons.x}<span>Error</span></span>`
-                : nothing}
               <span
                 class="collapse-chevron ${activityExpanded ? "" : "collapse-chevron--collapsed"}"
                 aria-hidden="true"
@@ -1984,7 +1988,11 @@ function renderGroupedMessage(
                   : ""}"
                 type="button"
                 aria-expanded=${String(toolMessageExpanded)}
-                @click=${() => opts.onToggleToolMessageExpanded?.(toolMessageDisclosureId)}
+                @click=${(event: MouseEvent) => {
+                  if (shouldToggleSelectableDisclosure(event)) {
+                    opts.onToggleToolMessageExpanded?.(toolMessageDisclosureId);
+                  }
+                }}
               >
                 <span class="chat-tool-msg-summary__icon">${toolMessageIcon}</span>
                 <span class="chat-tool-msg-summary__label">${toolMessageLabel}</span>
@@ -1993,13 +2001,6 @@ function renderGroupedMessage(
                   : toolPreview
                     ? html`<span class="chat-tool-msg-summary__preview">${toolPreview}</span>`
                     : nothing}
-                ${toolMessageHasError
-                  ? html`<span
-                      class="chat-tool-msg-summary__error-badge"
-                      aria-label="Tool returned an error"
-                      >${icons.x}<span>Error</span></span
-                    >`
-                  : nothing}
               </button>
               ${toolMessageExpanded
                 ? html`

--- a/ui/src/pages/chat/components/chat-tool-cards.test.ts
+++ b/ui/src/pages/chat/components/chat-tool-cards.test.ts
@@ -50,7 +50,49 @@ function requireFirstMockArg(
   return arg;
 }
 
+function selectText(element: Element) {
+  const range = document.createRange();
+  range.selectNodeContents(element);
+  const selection = window.getSelection();
+  selection?.removeAllRanges();
+  selection?.addRange(range);
+}
+
+function pointerClick(element: Element) {
+  element.dispatchEvent(new MouseEvent("click", { bubbles: true, detail: 1 }));
+}
+
 describe("tool-cards", () => {
+  it("keeps selected summary text from toggling the disclosure", () => {
+    const container = document.createElement("div");
+    document.body.append(container);
+    const toggle = vi.fn();
+    render(
+      renderToolCard(
+        {
+          id: "msg:selectable",
+          name: "web_search",
+          args: { query: "openclaw" },
+        },
+        { expanded: false, onToggleExpanded: toggle },
+      ),
+      container,
+    );
+
+    const summary = container.querySelector<HTMLButtonElement>(".chat-tool-msg-summary");
+    const label = summary?.querySelector(".chat-tool-msg-summary__label");
+    expect(summary).not.toBeNull();
+    expect(label).not.toBeNull();
+    selectText(label!);
+    pointerClick(summary!);
+    expect(toggle).not.toHaveBeenCalled();
+
+    window.getSelection()?.removeAllRanges();
+    pointerClick(summary!);
+    expect(toggle).toHaveBeenCalledWith("msg:selectable");
+    container.remove();
+  });
+
   it("renders expanded cards with inline input and output sections", () => {
     const container = document.createElement("div");
     const toggle = vi.fn();
@@ -430,7 +472,7 @@ describe("tool-cards", () => {
     });
   });
 
-  it("renders a Tool error label and Error badge when output is an error JSON", () => {
+  it("renders an error summary without a redundant Error badge", () => {
     const container = document.createElement("div");
     render(
       renderToolCard(
@@ -453,10 +495,18 @@ describe("tool-cards", () => {
     expect(container.textContent).not.toMatch(/\bTool output\b/);
     const summaryButton = container.querySelector("button.chat-tool-msg-summary");
     expect(summaryButton?.classList.contains("chat-tool-msg-summary--error")).toBe(true);
-    expect(container.querySelector(".chat-tool-msg-summary__error-badge")).not.toBeNull();
+    expect(summaryButton?.querySelector(".chat-tool-msg-summary__label")?.textContent).toBe(
+      "Tool error",
+    );
+    expect(container.querySelector(".chat-tool-msg-summary__error-badge")).toBeNull();
     const expandedCard = container.querySelector(".chat-tool-card");
     expect(expandedCard?.classList.contains("chat-tool-card--error")).toBe(true);
-    expect(container.querySelector(".chat-tool-card__status-badge")).not.toBeNull();
+    expect(container.querySelector(".chat-tool-card__status-badge")).toBeNull();
+    expect(
+      Array.from(container.querySelectorAll(".chat-tool-card__block-label")).map(
+        (label) => label.textContent,
+      ),
+    ).toContain("Tool error");
   });
 
   it("renders a Tool error label when output has a status-only error payload", () => {
@@ -497,7 +547,7 @@ describe("tool-cards", () => {
     expect(container.textContent).not.toMatch(/\bTool output\b/);
     const summaryButton = container.querySelector("button.chat-tool-msg-summary");
     expect(summaryButton?.classList.contains("chat-tool-msg-summary--error")).toBe(true);
-    expect(container.querySelector(".chat-tool-msg-summary__error-badge")).not.toBeNull();
+    expect(container.querySelector(".chat-tool-msg-summary__error-badge")).toBeNull();
   });
 
   it("renders a Tool error label when the tool card has an explicit error flag", () => {
@@ -519,6 +569,27 @@ describe("tool-cards", () => {
     expect(container.textContent).not.toMatch(/\bTool output\b/);
     expect(container.querySelector(".chat-tool-msg-summary--error")).not.toBeNull();
     expect(container.querySelector(".chat-tool-card--error")).not.toBeNull();
+  });
+
+  it("renders a plain error detail when a failed tool has no output", () => {
+    const container = document.createElement("div");
+    render(
+      renderToolCard(
+        {
+          id: "msg:err:no-output",
+          name: "lookup",
+          isError: true,
+        },
+        { expanded: true, onToggleExpanded: vi.fn() },
+      ),
+      container,
+    );
+
+    expect(container.querySelector(".chat-tool-card__status-badge")).toBeNull();
+    expect(container.querySelector(".chat-tool-card__block-label")?.textContent).toBe("Tool error");
+    expect(container.querySelector(".chat-tool-card__block-content")?.textContent).toBe(
+      "No output — tool failed.",
+    );
   });
 
   it("respects an explicit success flag even when the payload looks like an error", () => {

--- a/ui/src/pages/chat/components/chat-tool-cards.ts
+++ b/ui/src/pages/chat/components/chat-tool-cards.ts
@@ -23,6 +23,20 @@ import type { SidebarContent } from "./chat-sidebar.ts";
 
 type FullMessageRequest = NonNullable<SidebarContent["fullMessageRequest"]>;
 
+export function shouldToggleSelectableDisclosure(event: MouseEvent): boolean {
+  if (event.detail === 0) {
+    return true;
+  }
+  const target = event.currentTarget;
+  const selection = window.getSelection();
+  if (!(target instanceof Node) || !selection || selection.isCollapsed) {
+    return true;
+  }
+  return ![selection.anchorNode, selection.focusNode].some(
+    (node) => node !== null && target.contains(node),
+  );
+}
+
 function formatToolOutputForSidebar(text: string): string {
   if (isMarkdownBlockArtText(text)) {
     return "```\n" + text + "\n```";
@@ -266,17 +280,16 @@ function renderCollapsedToolSummary(params: {
       class="chat-tool-msg-summary ${isError ? "chat-tool-msg-summary--error" : ""}"
       type="button"
       aria-expanded=${String(expanded)}
-      @click=${() => onToggleExpanded()}
+      @click=${(event: MouseEvent) => {
+        if (shouldToggleSelectableDisclosure(event)) {
+          onToggleExpanded();
+        }
+      }}
     >
       <span class="chat-tool-msg-summary__icon">${icon}</span>
       <span class="chat-tool-msg-summary__label">${displayLabel}</span>
       ${displayName
         ? html`<span class="chat-tool-msg-summary__names">${displayName}</span>`
-        : nothing}
-      ${isError
-        ? html`<span class="chat-tool-msg-summary__error-badge" aria-label="Tool returned an error"
-            >${icons.x}<span>Error</span></span
-          >`
         : nothing}
     </button>
   `;
@@ -412,11 +425,6 @@ export function renderExpandedToolCardContent(
         <div class="chat-tool-card__title">
           <span class="chat-tool-card__icon">${renderToolIcon(display.icon)}</span>
           <span>${display.label}</span>
-          ${isError
-            ? html`<span class="chat-tool-card__status-badge" role="status"
-                >${icons.x}<span>Error</span></span
-              >`
-            : nothing}
         </div>
         ${canOpenSidebar
           ? html`
@@ -449,7 +457,12 @@ export function renderExpandedToolCardContent(
               label: isError ? "Tool error" : "Tool output",
               text: card.outputText!,
             })
-        : nothing}
+        : isError
+          ? renderToolDataBlock({
+              label: "Tool error",
+              text: "No output — tool failed.",
+            })
+          : nothing}
     </div>
   `;
 }

--- a/ui/src/styles/chat/tool-cards.css
+++ b/ui/src/styles/chat/tool-cards.css
@@ -26,7 +26,7 @@
   font-size: var(--control-ui-text-sm);
   line-height: 1.5;
   color: var(--muted);
-  user-select: none;
+  user-select: text;
   list-style: none;
   border: 0;
   border-radius: var(--radius-sm);
@@ -114,34 +114,6 @@
 .chat-tool-msg-summary--error .chat-tool-msg-summary__icon,
 .chat-tool-msg-summary--error .chat-tool-msg-summary__label {
   color: var(--destructive, var(--danger, #c0392b));
-}
-
-.chat-tool-msg-summary__error-badge {
-  display: inline-flex;
-  align-items: center;
-  gap: 3px;
-  box-sizing: border-box;
-  padding: 1px 6px;
-  margin-left: auto;
-  border-radius: 999px;
-  background: color-mix(in srgb, var(--destructive, var(--danger, #c0392b)) 14%, transparent);
-  color: var(--destructive, var(--danger, #c0392b));
-  font-size: 11px;
-  font-weight: 600;
-  letter-spacing: 0.04em;
-  text-transform: uppercase;
-  line-height: 1.4;
-  flex-shrink: 0;
-}
-
-.chat-tool-msg-summary__error-badge svg {
-  width: 10px;
-  height: 10px;
-  stroke: currentColor;
-  fill: none;
-  stroke-width: 2px;
-  stroke-linecap: round;
-  stroke-linejoin: round;
 }
 
 /* ── Expanded tool row body ── */
@@ -259,32 +231,6 @@
   stroke: currentColor;
   fill: none;
   stroke-width: 1.5px;
-  stroke-linecap: round;
-  stroke-linejoin: round;
-}
-
-.chat-tool-card__status-badge {
-  display: inline-flex;
-  align-items: center;
-  gap: 3px;
-  padding: 1px 6px;
-  margin-left: 6px;
-  border-radius: 999px;
-  background: color-mix(in srgb, var(--destructive, var(--danger, #c0392b)) 14%, transparent);
-  color: var(--destructive, var(--danger, #c0392b));
-  font-size: 11px;
-  font-weight: 600;
-  letter-spacing: 0.04em;
-  text-transform: uppercase;
-  line-height: 1.4;
-}
-
-.chat-tool-card__status-badge svg {
-  width: 10px;
-  height: 10px;
-  stroke: currentColor;
-  fill: none;
-  stroke-width: 2px;
   stroke-linecap: round;
   stroke-linejoin: round;
 }
@@ -581,6 +527,7 @@
   font: inherit;
   text-align: left;
   cursor: pointer;
+  user-select: text;
   transition: background 150ms ease;
 }
 
@@ -593,8 +540,7 @@
   color: var(--destructive, var(--danger, #c0392b));
 }
 
-.chat-activity-group__icon,
-.chat-activity-group__badge {
+.chat-activity-group__icon {
   display: inline-flex;
   align-items: center;
   justify-content: center;
@@ -609,8 +555,7 @@
   color: inherit;
 }
 
-.chat-activity-group__icon svg,
-.chat-activity-group__badge svg {
+.chat-activity-group__icon svg {
   width: 14px;
   height: 14px;
   fill: none;
@@ -636,19 +581,6 @@
   line-height: 1.4;
   text-overflow: ellipsis;
   white-space: nowrap;
-}
-
-.chat-activity-group__badge {
-  gap: 3px;
-  padding: 2px 6px;
-  border-radius: var(--radius-full);
-  background: color-mix(in srgb, var(--destructive, var(--danger, #c0392b)) 14%, transparent);
-  color: var(--destructive, var(--danger, #c0392b));
-  font-size: 11px;
-  font-weight: 650;
-  letter-spacing: 0.04em;
-  line-height: 1;
-  text-transform: uppercase;
 }
 
 /* Left rule groups the rows without wrapping them in another card. */


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users inspecting tool activity could not reliably select row text, and failed tools displayed repetitive `ERROR` pills even though the activity and tool-error rows already communicated failure.

## Why This Change Was Made

Tool disclosures now allow text selection and ignore pointer clicks produced by an active selection while preserving keyboard toggles. Redundant error pills are removed from aggregate, collapsed, and expanded tool surfaces; error labels, red X/icon treatment, accessible aggregate context, and an explicit empty-failure detail remain.

AI-assisted change; behavior and edge cases reviewed before submission.

## User Impact

Users can copy tool activity text without accidentally expanding or collapsing rows. Error activity is cleaner and less repetitive while still remaining clear and accessible.

## Evidence

- `node ../scripts/run-vitest.mjs run --config vitest.config.ts src/pages/chat/components/chat-tool-cards.test.ts src/pages/chat/components/chat-message.test.ts src/pages/chat/chat-responsive.browser.test.ts` — 120 tests passed.
- `node scripts/run-tsgo.mjs -p test/tsconfig/tsconfig.test.ui.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/test-ui.tsbuildinfo` — passed.
- `../node_modules/.bin/vite build` from `ui/` — passed.
- Structured Codex autoreview after fixes — clean, no accepted/actionable findings (0.94 confidence).
