### PR TITLE
chore(android): add deterministic chat streaming replay test harness

### DIFF
--- a/apps/android/app/src/test/java/ai/openclaw/app/chat/ChatControllerStreamReplayTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/chat/ChatControllerStreamReplayTest.kt
@@ -1,0 +1,318 @@
+package ai.openclaw.app.chat
+
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.advanceTimeBy
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runCurrent
+import kotlinx.coroutines.test.runTest
+import kotlinx.serialization.json.Json
+import org.junit.Assert.assertArrayEquals
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Deterministic streaming replay scenarios: a ScriptedGateway replays scripted
+ * chat.event/chat.history sequences into ChatController under virtual time.
+ */
+class ChatControllerStreamReplayTest {
+  private val json = Json { ignoreUnknownKeys = true }
+
+  private fun TestScope.newController(gateway: ScriptedGateway): ChatController =
+    ChatController(scope = this, json = json, requestGateway = gateway::request)
+
+  private fun transcript(controller: ChatController): List<Pair<String, String?>> =
+    controller.messages.value.map { message ->
+      message.role to message.content.firstOrNull { it.type == "text" }?.text
+    }
+
+  @Test
+  @OptIn(ExperimentalCoroutinesApi::class)
+  fun cleanRunStreamsThenConvergesToHistoryWithoutDuplicates() =
+    runTest {
+      val gateway = ScriptedGateway(json)
+      gateway.respondChatSend(status = "started")
+      val controller = newController(gateway)
+      controller.handleGatewayEvent("health", null)
+
+      assertTrue(controller.sendMessageAwaitAcceptance("Hello there", "off", emptyList()))
+      val runId = requireNotNull(gateway.lastRunId)
+      assertEquals(1, controller.pendingRunCount.value)
+      val optimisticUserId = controller.messages.value.single { it.role == "user" }.id
+
+      controller.handleGatewayEvent("chat", chatDeltaPayload("main", runId, "Str"))
+      assertEquals("Str", controller.streamingAssistantText.value)
+      controller.handleGatewayEvent("chat", chatDeltaPayload("main", runId, "Streamed reply."))
+      assertEquals("Streamed reply.", controller.streamingAssistantText.value)
+
+      gateway.respondWith(
+        "chat.history",
+        historyResponse(
+          sessionId = "session-1",
+          messages =
+            listOf(
+              ReplayHistoryMessage("user", "Hello there", 1_000, idempotencyKey = "$runId:user"),
+              ReplayHistoryMessage("assistant", "Streamed reply.", 2_000),
+            ),
+        ),
+      )
+      controller.handleGatewayEvent("chat", chatTerminalPayload("main", runId))
+      advanceUntilIdle()
+
+      assertEquals(
+        listOf("user" to "Hello there", "assistant" to "Streamed reply."),
+        transcript(controller),
+      )
+      // Gateway copy replaces the optimistic echo in place: same row identity, no duplicate.
+      assertEquals(optimisticUserId, controller.messages.value.single { it.role == "user" }.id)
+      assertEquals(0, controller.pendingRunCount.value)
+      assertNull(controller.streamingAssistantText.value)
+      assertNull(controller.errorText.value)
+      assertEquals("session-1", controller.sessionId.value)
+    }
+
+  @Test
+  @OptIn(ExperimentalCoroutinesApi::class)
+  fun duplicateDeltaAndTerminalDeliveryProducesNoDuplicateRows() =
+    runTest {
+      val gateway = ScriptedGateway(json)
+      gateway.respondChatSend(status = "started")
+      val controller = newController(gateway)
+      controller.handleGatewayEvent("health", null)
+
+      assertTrue(controller.sendMessageAwaitAcceptance("dedupe me", "off", emptyList()))
+      val runId = requireNotNull(gateway.lastRunId)
+
+      val delta = chatDeltaPayload("main", runId, "Only once.")
+      controller.handleGatewayEvent("chat", delta)
+      controller.handleGatewayEvent("chat", delta)
+      assertEquals("Only once.", controller.streamingAssistantText.value)
+
+      gateway.respondWith(
+        "chat.history",
+        historyResponse(
+          sessionId = "session-1",
+          messages =
+            listOf(
+              ReplayHistoryMessage("user", "dedupe me", 1_000, idempotencyKey = "$runId:user"),
+              ReplayHistoryMessage("assistant", "Only once.", 2_000),
+            ),
+        ),
+      )
+      val terminal = chatTerminalPayload("main", runId)
+      controller.handleGatewayEvent("chat", terminal)
+      advanceUntilIdle()
+      val idsAfterFirstTerminal = controller.messages.value.map { it.id }
+
+      // Redelivered terminal event triggers a second history refresh with the same payload.
+      controller.handleGatewayEvent("chat", terminal)
+      advanceUntilIdle()
+
+      assertEquals(2, gateway.callCount("chat.history"))
+      assertEquals(
+        listOf("user" to "dedupe me", "assistant" to "Only once."),
+        transcript(controller),
+      )
+      // Row identities stay stable across the duplicate refresh.
+      assertEquals(idsAfterFirstTerminal, controller.messages.value.map { it.id })
+      assertEquals(0, controller.pendingRunCount.value)
+    }
+
+  @Test
+  @OptIn(ExperimentalCoroutinesApi::class)
+  fun optimisticAckTimeoutDiscardsUserEchoUnderVirtualTime() =
+    runTest {
+      val gateway = ScriptedGateway(json)
+      gateway.respondChatSend(status = "started")
+      val controller = newController(gateway)
+      controller.handleGatewayEvent("health", null)
+
+      assertTrue(controller.sendMessageAwaitAcceptance("never answered", "off", emptyList()))
+      assertEquals(1, controller.pendingRunCount.value)
+
+      // One virtual millisecond before the 120s ack deadline nothing changes.
+      advanceTimeBy(119_999)
+      runCurrent()
+      assertEquals(1, controller.pendingRunCount.value)
+      assertTrue(transcript(controller).contains("user" to "never answered"))
+      assertNull(controller.errorText.value)
+
+      advanceTimeBy(1)
+      runCurrent()
+      assertEquals(0, controller.pendingRunCount.value)
+      assertFalse(transcript(controller).contains("user" to "never answered"))
+      assertEquals("Timed out waiting for a reply; try again or refresh.", controller.errorText.value)
+    }
+
+  @Test
+  @OptIn(ExperimentalCoroutinesApi::class)
+  fun reconnectMidRunClearsTransientStateAndHistoryConverges() =
+    runTest {
+      val gateway = ScriptedGateway(json)
+      gateway.respondChatSend(status = "started")
+      val controller = newController(gateway)
+      controller.handleGatewayEvent("health", null)
+
+      assertTrue(controller.sendMessageAwaitAcceptance("survive reconnect", "off", emptyList()))
+      val runId = requireNotNull(gateway.lastRunId)
+      val optimisticUserId = controller.messages.value.single { it.role == "user" }.id
+
+      controller.handleGatewayEvent("chat", chatDeltaPayload("main", runId, "partial ans"))
+      controller.handleGatewayEvent(
+        "agent",
+        """{"sessionKey":"main","ts":10,"stream":"tool","data":{"phase":"start","name":"exec","toolCallId":"tool-1"}}""",
+      )
+      assertEquals("partial ans", controller.streamingAssistantText.value)
+      assertEquals(1, controller.pendingToolCalls.value.size)
+
+      controller.onDisconnected("connection lost")
+      assertNull(controller.streamingAssistantText.value)
+      assertEquals(0, controller.pendingRunCount.value)
+      assertTrue(controller.pendingToolCalls.value.isEmpty())
+      assertNull(controller.sessionId.value)
+      assertFalse(controller.healthOk.value)
+      // The local echo stays rendered until the next history load resolves it.
+      assertTrue(transcript(controller).contains("user" to "survive reconnect"))
+
+      controller.handleGatewayEvent("health", null)
+      gateway.respondWith(
+        "chat.history",
+        historyResponse(
+          sessionId = "session-1",
+          messages =
+            listOf(
+              ReplayHistoryMessage("user", "survive reconnect", 1_000, idempotencyKey = "$runId:user"),
+              ReplayHistoryMessage("assistant", "Recovered reply.", 2_000),
+            ),
+        ),
+      )
+      controller.refresh()
+      advanceUntilIdle()
+
+      assertEquals(
+        listOf("user" to "survive reconnect", "assistant" to "Recovered reply."),
+        transcript(controller),
+      )
+      assertEquals(optimisticUserId, controller.messages.value.single { it.role == "user" }.id)
+      assertEquals("session-1", controller.sessionId.value)
+
+      // Disconnect cancelled the 120s ack timer: the converged transcript must not decay.
+      advanceTimeBy(120_000)
+      runCurrent()
+      assertNull(controller.errorText.value)
+      assertEquals(2, controller.messages.value.size)
+    }
+
+  @Test
+  @OptIn(ExperimentalCoroutinesApi::class)
+  fun staleHistoryResponseIsDroppedByGenerationTracking() =
+    runTest {
+      val gateway = ScriptedGateway(json)
+      val controller = newController(gateway)
+
+      gateway.respondWith(
+        "chat.history",
+        historyResponse(
+          sessionId = "session-main",
+          messages = listOf(ReplayHistoryMessage("assistant", "main transcript", 1_000)),
+        ),
+      )
+      controller.load("main")
+      advanceUntilIdle()
+      assertEquals(listOf("assistant" to "main transcript"), transcript(controller))
+
+      // Gate the next "main" history fetch so its response arrives after a session switch.
+      val staleMainGate = CompletableDeferred<Unit>()
+      gateway.respond("chat.history") { paramsJson ->
+        when (gateway.sessionKeyOf(paramsJson)) {
+          "other" ->
+            historyResponse(
+              sessionId = "session-other",
+              messages = listOf(ReplayHistoryMessage("assistant", "other transcript", 3_000)),
+            )
+          else -> {
+            staleMainGate.await()
+            historyResponse(
+              sessionId = "session-main",
+              messages = listOf(ReplayHistoryMessage("assistant", "stale main row", 9_000)),
+            )
+          }
+        }
+      }
+
+      controller.handleGatewayEvent("chat", chatTerminalPayload("main", runId = null))
+      runCurrent() // history refetch for "main" is now suspended on the gate
+
+      controller.switchSession("other")
+      advanceUntilIdle()
+      assertEquals(listOf("assistant" to "other transcript"), transcript(controller))
+      assertEquals("session-other", controller.sessionId.value)
+
+      staleMainGate.complete(Unit)
+      advanceUntilIdle()
+
+      // The stale "main" response resolved after the switch and must be dropped.
+      assertEquals(listOf("assistant" to "other transcript"), transcript(controller))
+      assertEquals("session-other", controller.sessionId.value)
+    }
+
+  @Test
+  @OptIn(ExperimentalCoroutinesApi::class)
+  fun markdownFixtureStreamsByteIdenticalAndConvergesLosslessly() =
+    runTest {
+      val fixture =
+        checkNotNull(javaClass.getResourceAsStream("/chat/markdown_stream_fixture.md")) {
+          "missing markdown stream fixture resource"
+        }.readBytes().toString(Charsets.UTF_8)
+      val fixtureBytes = fixture.toByteArray(Charsets.UTF_8)
+
+      val gateway = ScriptedGateway(json)
+      gateway.respondChatSend(status = "started")
+      val controller = newController(gateway)
+      controller.handleGatewayEvent("health", null)
+
+      assertTrue(controller.sendMessageAwaitAcceptance("render markdown shapes", "off", emptyList()))
+      val runId = requireNotNull(gateway.lastRunId)
+
+      // Odd chunk size on purpose so boundaries fall inside words, escapes, and emoji.
+      val chunks = chunkPreservingCodePoints(fixture, chunkSize = 47)
+      assertTrue("fixture should stream in many chunks", chunks.size > 10)
+      var accumulated = ""
+      for (chunk in chunks) {
+        accumulated += chunk
+        controller.handleGatewayEvent("chat", chatDeltaPayload("main", runId, accumulated))
+        assertEquals(accumulated, controller.streamingAssistantText.value)
+      }
+
+      val streamed = requireNotNull(controller.streamingAssistantText.value)
+      assertArrayEquals(fixtureBytes, streamed.toByteArray(Charsets.UTF_8))
+
+      gateway.respondWith(
+        "chat.history",
+        historyResponse(
+          sessionId = "session-md",
+          messages =
+            listOf(
+              ReplayHistoryMessage("user", "render markdown shapes", 1_000, idempotencyKey = "$runId:user"),
+              ReplayHistoryMessage("assistant", fixture, 2_000),
+            ),
+        ),
+      )
+      controller.handleGatewayEvent("chat", chatTerminalPayload("main", runId))
+      advanceUntilIdle()
+
+      val confirmed =
+        controller.messages.value
+          .single { it.role == "assistant" }
+          .content
+          .single { it.type == "text" }
+          .text
+      assertArrayEquals(fixtureBytes, requireNotNull(confirmed).toByteArray(Charsets.UTF_8))
+      assertNull(controller.streamingAssistantText.value)
+      assertEquals(0, controller.pendingRunCount.value)
+    }
+}

--- a/apps/android/app/src/test/java/ai/openclaw/app/chat/ChatControllerStreamReplayTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/chat/ChatControllerStreamReplayTest.kt
@@ -44,9 +44,12 @@ class ChatControllerStreamReplayTest {
       assertEquals(1, controller.pendingRunCount.value)
       val optimisticUserId = controller.messages.value.single { it.role == "user" }.id
 
-      controller.handleGatewayEvent("chat", chatDeltaPayload("main", runId, "Str"))
+      controller.handleGatewayEvent("chat", chatDeltaPayload("main", runId, 1, "Str", "Str"))
       assertEquals("Str", controller.streamingAssistantText.value)
-      controller.handleGatewayEvent("chat", chatDeltaPayload("main", runId, "Streamed reply."))
+      controller.handleGatewayEvent(
+        "chat",
+        chatDeltaPayload("main", runId, 2, "eamed reply.", "Streamed reply."),
+      )
       assertEquals("Streamed reply.", controller.streamingAssistantText.value)
 
       gateway.respondWith(
@@ -60,7 +63,7 @@ class ChatControllerStreamReplayTest {
             ),
         ),
       )
-      controller.handleGatewayEvent("chat", chatTerminalPayload("main", runId))
+      controller.handleGatewayEvent("chat", chatTerminalPayload("main", runId, seq = 3))
       advanceUntilIdle()
 
       assertEquals(
@@ -87,7 +90,7 @@ class ChatControllerStreamReplayTest {
       assertTrue(controller.sendMessageAwaitAcceptance("dedupe me", "off", emptyList()))
       val runId = requireNotNull(gateway.lastRunId)
 
-      val delta = chatDeltaPayload("main", runId, "Only once.")
+      val delta = chatDeltaPayload("main", runId, 1, "Only once.", "Only once.")
       controller.handleGatewayEvent("chat", delta)
       controller.handleGatewayEvent("chat", delta)
       assertEquals("Only once.", controller.streamingAssistantText.value)
@@ -103,7 +106,7 @@ class ChatControllerStreamReplayTest {
             ),
         ),
       )
-      val terminal = chatTerminalPayload("main", runId)
+      val terminal = chatTerminalPayload("main", runId, seq = 2)
       controller.handleGatewayEvent("chat", terminal)
       advanceUntilIdle()
       val idsAfterFirstTerminal = controller.messages.value.map { it.id }
@@ -161,10 +164,13 @@ class ChatControllerStreamReplayTest {
       val runId = requireNotNull(gateway.lastRunId)
       val optimisticUserId = controller.messages.value.single { it.role == "user" }.id
 
-      controller.handleGatewayEvent("chat", chatDeltaPayload("main", runId, "partial ans"))
+      controller.handleGatewayEvent(
+        "chat",
+        chatDeltaPayload("main", runId, 1, "partial ans", "partial ans"),
+      )
       controller.handleGatewayEvent(
         "agent",
-        """{"sessionKey":"main","ts":10,"stream":"tool","data":{"phase":"start","name":"exec","toolCallId":"tool-1"}}""",
+        """{"sessionKey":"main","runId":"$runId","seq":2,"ts":10,"stream":"tool","data":{"phase":"start","name":"exec","toolCallId":"tool-1"}}""",
       )
       assertEquals("partial ans", controller.streamingAssistantText.value)
       assertEquals(1, controller.pendingToolCalls.value.size)
@@ -244,7 +250,10 @@ class ChatControllerStreamReplayTest {
         }
       }
 
-      controller.handleGatewayEvent("chat", chatTerminalPayload("main", runId = null))
+      controller.handleGatewayEvent(
+        "chat",
+        chatTerminalPayload("main", runId = "external-run", seq = 1),
+      )
       runCurrent() // history refetch for "main" is now suspended on the gate
 
       controller.switchSession("other")
@@ -282,9 +291,12 @@ class ChatControllerStreamReplayTest {
       val chunks = chunkPreservingCodePoints(fixture, chunkSize = 47)
       assertTrue("fixture should stream in many chunks", chunks.size > 10)
       var accumulated = ""
-      for (chunk in chunks) {
+      for ((index, chunk) in chunks.withIndex()) {
         accumulated += chunk
-        controller.handleGatewayEvent("chat", chatDeltaPayload("main", runId, accumulated))
+        controller.handleGatewayEvent(
+          "chat",
+          chatDeltaPayload("main", runId, index + 1, chunk, accumulated),
+        )
         assertEquals(accumulated, controller.streamingAssistantText.value)
       }
 
@@ -302,7 +314,10 @@ class ChatControllerStreamReplayTest {
             ),
         ),
       )
-      controller.handleGatewayEvent("chat", chatTerminalPayload("main", runId))
+      controller.handleGatewayEvent(
+        "chat",
+        chatTerminalPayload("main", runId, seq = chunks.size + 1),
+      )
       advanceUntilIdle()
 
       val confirmed =

--- a/apps/android/app/src/test/java/ai/openclaw/app/chat/ChatReplayHarness.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/chat/ChatReplayHarness.kt
@@ -1,0 +1,172 @@
+package ai.openclaw.app.chat
+
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+
+/**
+ * Scripted gateway responder for deterministic chat replay tests.
+ *
+ * Plugs into the same internal ChatController(requestGateway) seam the other
+ * controller tests use; scenarios script per-method responses and replay
+ * chat/agent events through ChatController.handleGatewayEvent under
+ * kotlinx-coroutines-test virtual time.
+ */
+internal class ScriptedGateway(private val json: Json) {
+  data class Call(
+    val method: String,
+    val paramsJson: String?,
+  )
+
+  val calls = mutableListOf<Call>()
+  private val handlers = mutableMapOf<String, suspend (paramsJson: String?) -> String>()
+
+  /** Client-generated run id captured from the latest chat.send params. */
+  var lastRunId: String? = null
+    private set
+
+  init {
+    // Benign defaults so bootstrap/health/commands side requests never fail a scenario.
+    respondWith("health", "{}")
+    respondWith("commands.list", """{"commands":[]}""")
+    respondWith("sessions.list", """{"sessions":[]}""")
+  }
+
+  fun respond(
+    method: String,
+    handler: suspend (paramsJson: String?) -> String,
+  ) {
+    handlers[method] = handler
+  }
+
+  fun respondWith(
+    method: String,
+    responseJson: String,
+  ) {
+    respond(method) { responseJson }
+  }
+
+  /** Acks chat.send echoing the client idempotency key as run id, like the live gateway. */
+  fun respondChatSend(status: String) {
+    respond("chat.send") { paramsJson ->
+      val runId =
+        paramsJson
+          ?.let { json.parseToJsonElement(it).jsonObject["idempotencyKey"]?.jsonPrimitive?.content }
+      lastRunId = runId
+      buildJsonObject {
+        if (runId != null) put("runId", JsonPrimitive(runId))
+        put("status", JsonPrimitive(status))
+      }.toString()
+    }
+  }
+
+  suspend fun request(
+    method: String,
+    paramsJson: String?,
+  ): String {
+    calls += Call(method, paramsJson)
+    val handler = handlers[method] ?: error("ScriptedGateway: no scripted response for $method")
+    return handler(paramsJson)
+  }
+
+  fun sessionKeyOf(paramsJson: String?): String? =
+    paramsJson?.let { json.parseToJsonElement(it).jsonObject["sessionKey"]?.jsonPrimitive?.content }
+
+  fun callCount(method: String): Int = calls.count { it.method == method }
+}
+
+/** One transcript row for a scripted chat.history response. */
+internal data class ReplayHistoryMessage(
+  val role: String,
+  val text: String,
+  val timestampMs: Long,
+  val idempotencyKey: String? = null,
+)
+
+internal fun historyResponse(
+  sessionId: String,
+  messages: List<ReplayHistoryMessage>,
+): String =
+  buildJsonObject {
+    put("sessionId", JsonPrimitive(sessionId))
+    put(
+      "messages",
+      JsonArray(
+        messages.map { message ->
+          buildJsonObject {
+            put("role", JsonPrimitive(message.role))
+            put("content", JsonPrimitive(message.text))
+            put("timestamp", JsonPrimitive(message.timestampMs))
+            if (message.idempotencyKey != null) {
+              put("idempotencyKey", JsonPrimitive(message.idempotencyKey))
+            }
+          }
+        },
+      ),
+    )
+  }.toString()
+
+/** Gateway chat event carrying the accumulated assistant text snapshot so far. */
+internal fun chatDeltaPayload(
+  sessionKey: String,
+  runId: String,
+  accumulatedText: String,
+): String =
+  buildJsonObject {
+    put("sessionKey", JsonPrimitive(sessionKey))
+    put("runId", JsonPrimitive(runId))
+    put("state", JsonPrimitive("delta"))
+    put(
+      "message",
+      buildJsonObject {
+        put("role", JsonPrimitive("assistant"))
+        put(
+          "content",
+          JsonArray(
+            listOf(
+              buildJsonObject {
+                put("type", JsonPrimitive("text"))
+                put("text", JsonPrimitive(accumulatedText))
+              },
+            ),
+          ),
+        )
+      },
+    )
+  }.toString()
+
+internal fun chatTerminalPayload(
+  sessionKey: String,
+  runId: String?,
+  state: String = "final",
+): String =
+  buildJsonObject {
+    put("sessionKey", JsonPrimitive(sessionKey))
+    if (runId != null) put("runId", JsonPrimitive(runId))
+    put("state", JsonPrimitive(state))
+  }.toString()
+
+/**
+ * Splits text into fixed-size chunks without splitting surrogate pairs; encoding half
+ * a pair through the JSON event pipeline would corrupt the streamed byte sequence.
+ */
+internal fun chunkPreservingCodePoints(
+  text: String,
+  chunkSize: Int,
+): List<String> {
+  require(chunkSize > 1) { "chunkSize must leave room for surrogate pairs" }
+  val chunks = mutableListOf<String>()
+  var start = 0
+  while (start < text.length) {
+    var end = minOf(start + chunkSize, text.length)
+    if (end < text.length && Character.isHighSurrogate(text[end - 1])) {
+      end -= 1
+    }
+    chunks += text.substring(start, end)
+    start = end
+  }
+  return chunks
+}

--- a/apps/android/app/src/test/java/ai/openclaw/app/chat/ChatReplayHarness.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/chat/ChatReplayHarness.kt
@@ -109,16 +109,20 @@ internal fun historyResponse(
     )
   }.toString()
 
-/** Gateway chat event carrying the accumulated assistant text snapshot so far. */
+/** Protocol-valid gateway delta carrying both the incremental chunk and accumulated snapshot. */
 internal fun chatDeltaPayload(
   sessionKey: String,
   runId: String,
+  seq: Int,
+  deltaText: String,
   accumulatedText: String,
 ): String =
   buildJsonObject {
     put("sessionKey", JsonPrimitive(sessionKey))
     put("runId", JsonPrimitive(runId))
+    put("seq", JsonPrimitive(seq))
     put("state", JsonPrimitive("delta"))
+    put("deltaText", JsonPrimitive(deltaText))
     put(
       "message",
       buildJsonObject {
@@ -140,12 +144,14 @@ internal fun chatDeltaPayload(
 
 internal fun chatTerminalPayload(
   sessionKey: String,
-  runId: String?,
+  runId: String,
+  seq: Int,
   state: String = "final",
 ): String =
   buildJsonObject {
     put("sessionKey", JsonPrimitive(sessionKey))
-    if (runId != null) put("runId", JsonPrimitive(runId))
+    put("runId", JsonPrimitive(runId))
+    put("seq", JsonPrimitive(seq))
     put("state", JsonPrimitive(state))
   }.toString()
 

--- a/apps/android/app/src/test/resources/chat/markdown_stream_fixture.md
+++ b/apps/android/app/src/test/resources/chat/markdown_stream_fixture.md
@@ -1,0 +1,49 @@
+# Streaming Markdown Shapes
+
+## Headings and emphasis
+
+This paragraph mixes **bold**, _italic_, `inline code`, and unicode text such as
+café, naïve, Größe, 流式渲染, and emoji 🦀🌊 that force surrogate pairs through the
+JSON event pipeline.
+
+### Lists
+
+- unordered item one
+- unordered item two
+  - nested child with `code`
+  - nested child with a [link](https://docs.openclaw.ai)
+- unordered item three
+
+1. ordered first
+2. ordered second
+3. ordered third
+
+### Fenced code
+
+```kotlin
+fun greet(name: String): String {
+  val trimmed = name.trim()
+  return "Hello, $trimmed! <tags> & \"quotes\" survive"
+}
+```
+
+```json
+{ "runId": "run-1", "state": "delta", "text": "chunk — escaped" }
+```
+
+### Table
+
+| Column A | Column B | Column C |
+| -------- | -------- | -------- |
+| alpha    | 1        | true     |
+| beta     | 2        | false    |
+| gamma 🦀 | 3        | null     |
+
+> Blockquote line one
+> Blockquote line two
+
+---
+
+### Long paragraph
+
+Streaming transports must not corrupt long unbroken prose, so this single paragraph keeps going for quite a while without any line breaks to make sure chunk boundaries land in the middle of words, punctuation, and multi-byte sequences like ünïcödé and 🦀, verifying that every accumulated snapshot remains a strict prefix of the final text and that the terminal snapshot is byte-identical to this fixture file exactly as it was committed, trailing newline included.


### PR DESCRIPTION
## What Problem This Solves

The Android chat pipeline's streaming behavior (gateway `chat` event pushes, optimistic message lifecycle, history reconciliation, generation tracking) had unit coverage only for isolated helper functions and send acks. There was no deterministic way to replay a full streaming run — chunks, duplicates, timeouts, reconnects, stale responses — so regressions in transcript convergence could only be caught manually.

Part of #100196

## Why This Change Was Made

Adds a scripted replay harness (`ScriptedGateway`) on the existing internal `ChatController(requestGateway)` test seam, driving deterministic event/history sequences under kotlinx-coroutines-test virtual time. No production code changes and no new seams.

## User Impact

None directly (test-only). Protects users from streaming regressions: duplicated chat rows, lost optimistic messages, stuck pending runs after reconnect, stale transcripts after session switches, and markdown corruption during streaming.

## Evidence

- `cd apps/android && ./gradlew :app:testPlayDebugUnitTest --tests '*ChatControllerStreamReplayTest*'` — 6/6 pass.
- `./gradlew :app:testPlayDebugUnitTest --tests 'ai.openclaw.app.chat.*'` — 42/42 pass.
- Scenarios: clean run convergence with stable row identity; duplicate delta/terminal delivery dedupe; 120s optimistic ack timeout boundary-exact under virtual time; reconnect mid-run transient-state clearing + convergence; stale history dropped by generation tracking; markdown-shapes fixture (headings/lists/fenced code/tables/long paragraph/surrogate pairs) byte-identical through the JSON event pipeline.
- Codex autoreview: clean, no accepted findings.
