### PR TITLE
fix(cron): job edits no longer break CLI-backend runs by stripping the default toolsAllow marker

### DIFF
--- a/src/cron/isolated-agent/run.message-tool-policy.test.ts
+++ b/src/cron/isolated-agent/run.message-tool-policy.test.ts
@@ -2,6 +2,7 @@
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { createSourceDeliveryPlan } from "../../infra/outbound/source-delivery-plan.js";
 import type { SkillSnapshot } from "../../skills/types.js";
+import { applyJobPatch } from "../service/jobs.js";
 import type { CronDeliveryMode } from "../types.js";
 import type { MutableCronSession } from "./run-session-state.js";
 import {
@@ -850,6 +851,45 @@ describe("runCronIsolatedAgentTurn message tool policy", () => {
           toolsAllowIsDefault: true,
         },
       ),
+    });
+
+    const cliRun = expectRecordFields(
+      getMockCallArg(runCliAgentMock, 0, 0, "CLI run"),
+      {},
+      "CLI run params",
+    );
+    expect(cliRun.toolsAllow).toBeUndefined();
+  });
+
+  it("keeps a cron-tool default toolsAllow marker after a self-edit before CLI execution", async () => {
+    mockRunCronFallbackPassthrough();
+    resolveCronDeliveryPlanMock.mockReturnValue(makeAnnounceDeliveryPlan());
+    isCliProviderMock.mockReturnValue(true);
+    runCliAgentMock.mockResolvedValue({
+      payloads: [{ text: "done" }],
+      meta: { agentMeta: { usage: { input: 10, output: 20 } } },
+    });
+    const job = makeMessageToolPolicyJob(
+      { mode: "announce", channel: "messagechat", to: "123" },
+      {
+        kind: "agentTurn",
+        message: "send a message",
+        toolsAllow: ["read", "cron"],
+        toolsAllowIsDefault: true,
+      },
+    );
+
+    applyJobPatch(job, {
+      payload: {
+        kind: "agentTurn",
+        message: "send a clearer message",
+        toolsAllow: ["read", "cron"],
+      },
+    });
+
+    await runCronIsolatedAgentTurn({
+      ...makeParams(),
+      job,
     });
 
     const cliRun = expectRecordFields(

--- a/src/cron/service.jobs.test.ts
+++ b/src/cron/service.jobs.test.ts
@@ -449,6 +449,34 @@ describe("applyJobPatch", () => {
     }
   });
 
+  it("preserves the default toolsAllow flag when a self-edit echoes the default list", () => {
+    const job = createIsolatedAgentTurnJob("job-tools-default-echo", {
+      mode: "announce",
+      channel: "telegram",
+    });
+    job.payload = {
+      kind: "agentTurn",
+      message: "do it",
+      toolsAllow: ["exec", "read"],
+      toolsAllowIsDefault: true,
+    };
+
+    applyJobPatch(job, {
+      payload: {
+        kind: "agentTurn",
+        message: "do it later",
+        toolsAllow: ["exec", "read"],
+      },
+    });
+
+    expect(job.payload.kind).toBe("agentTurn");
+    if (job.payload.kind === "agentTurn") {
+      expect(job.payload.message).toBe("do it later");
+      expect(job.payload.toolsAllow).toEqual(["exec", "read"]);
+      expect(job.payload.toolsAllowIsDefault).toBe(true);
+    }
+  });
+
   it("clears agentTurn payload.toolsAllow when patch requests null", () => {
     const job = createIsolatedAgentTurnJob("job-tools-clear", {
       mode: "announce",

--- a/src/cron/service/jobs.ts
+++ b/src/cron/service/jobs.ts
@@ -963,12 +963,17 @@ function applyAgentTurnToolsAllowPatch(
 ): void {
   if (Array.isArray(patch.toolsAllow)) {
     payload.toolsAllow = patch.toolsAllow;
-    // Same-kind edits keep the marker only when the default list is unchanged;
-    // kind replacements carry the cron-tool-stamped marker into persistence.
-    if (
-      patch.toolsAllowIsDefault === true &&
-      (!existing || (existing.toolsAllowIsDefault === true && toolsAllowEqual(existing, patch)))
-    ) {
+    // Same-kind edits keep the marker whenever the default-stamped list is
+    // unchanged — even when the patch omits toolsAllowIsDefault, because the
+    // cron tool's model-facing schema never sends it. Dropping the marker on an
+    // echoed list silently reclassifies "default" as an explicit restriction,
+    // which fail-closes the next run on CLI backends that cannot enforce
+    // runtime toolsAllow. Kind replacements (no existing payload) still require
+    // the cron-tool-stamped marker on the patch itself.
+    const keepDefaultMarker = existing
+      ? existing.toolsAllowIsDefault === true && toolsAllowEqual(existing, patch)
+      : patch.toolsAllowIsDefault === true;
+    if (keepDefaultMarker) {
       payload.toolsAllowIsDefault = true;
     } else {
       delete payload.toolsAllowIsDefault;


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where a cron job on a CLI backend (e.g. claude-cli) starts failing every run with `CLI backend claude-cli cannot enforce runtime toolsAllow; use an embedded runtime for restricted tool policy` after any edit to the job — including edits that never touched tools at all (production case: an agent tweaking its own job's prompt text).

## Why This Change Was Made

Jobs created via the cron tool get the full default tool inventory auto-stamped into `payload.toolsAllow` with a `toolsAllowIsDefault: true` marker. The cron tool's model-facing schema does not expose that marker, so agent-driven edits echo the unchanged list back without it — and `applyAgentTurnToolsAllowPatch` deleted the marker, silently reclassifying "default snapshot" as "explicit restriction". `resolveCliRuntimeToolsAllow` only drops marker-stamped defaults, so the next CLI run hit the (correct, deliberate) fail-closed guard in `prepareCliRunContext`.

The fix: an unchanged list can never reclassify "default" into "explicit restriction" — the marker now survives same-kind edits whenever the patched list equals the existing default-stamped list, whether or not the patch re-asserts the flag. Genuinely changed lists still drop the marker (a new list is an explicit choice), `toolsAllow: null` still clears both, and kind replacements still require the stamped marker on the patch itself. The fail-closed CLI guard is intentionally untouched.

## User Impact

Editing any field of a scheduled job no longer breaks its future runs on CLI backends. Explicit tool restrictions still fail closed on backends that cannot enforce them.

## Evidence

- Production trace: live job "Sunday Magic Drop" — created with the default stamp, self-edited by the agent, marker stripped, every subsequent run threw at `prepare.ts` until the payload was manually repaired.
- Fail-confirmed regression (`service.jobs.test.ts`): patch with unchanged list + changed message + no marker → pre-fix 1 failed / 77 passed; post-fix 132/132 across jobs + run-executor message-tool-policy suites. Executor-level test asserts the CLI run context no longer throws.
- oxlint + `git diff --check` clean.
- Landed with manual orchestrator review per maintainer instruction.
