### PR TITLE
fix(ui): mobile-optimize gateway dashboard login gate

### DIFF
--- a/ui/src/components/login-gate.ts
+++ b/ui/src/components/login-gate.ts
@@ -313,9 +313,20 @@ function renderLoginGate(props: LoginGateProps) {
           <label class="field">
             <span>${t("overview.access.wsUrl")}</span>
             <input
+              inputmode="url"
+              autocapitalize="none"
+              autocorrect="off"
+              autocomplete="off"
+              spellcheck="false"
+              enterkeyhint="go"
               .value=${props.gatewayUrl}
               @input=${(e: Event) => {
                 props.onGatewayUrlChange((e.target as HTMLInputElement).value);
+              }}
+              @keydown=${(e: KeyboardEvent) => {
+                if (e.key === "Enter") {
+                  props.onConnect();
+                }
               }}
               placeholder="ws://127.0.0.1:18789"
             />
@@ -327,6 +338,7 @@ function renderLoginGate(props: LoginGateProps) {
                 type=${props.showGatewayToken ? "text" : "password"}
                 autocomplete="off"
                 spellcheck="false"
+                enterkeyhint="go"
                 .value=${props.token}
                 @input=${(e: Event) => {
                   props.onTokenChange((e.target as HTMLInputElement).value);
@@ -360,6 +372,7 @@ function renderLoginGate(props: LoginGateProps) {
                 type=${props.showGatewayPassword ? "text" : "password"}
                 autocomplete="off"
                 spellcheck="false"
+                enterkeyhint="go"
                 .value=${props.password}
                 @input=${(e: Event) => {
                   props.onPasswordChange((e.target as HTMLInputElement).value);
@@ -393,8 +406,8 @@ function renderLoginGate(props: LoginGateProps) {
           </button>
         </div>
         ${failure ? renderLoginFailure(failure) : ""}
-        <div class="login-gate__help">
-          <div class="login-gate__help-title">${t("overview.connection.title")}</div>
+        <details class="login-gate__help">
+          <summary class="login-gate__help-title">${t("overview.connection.title")}</summary>
           <ol class="login-gate__steps">
             <li>
               ${t("overview.connection.step1")}${renderConnectCommand("openclaw gateway run")}
@@ -411,7 +424,7 @@ function renderLoginGate(props: LoginGateProps) {
               >${t("overview.connection.docsLink")}</a
             >
           </div>
-        </div>
+        </details>
       </div>
     </div>
   `;

--- a/ui/src/e2e/login-gate.e2e.test.ts
+++ b/ui/src/e2e/login-gate.e2e.test.ts
@@ -1,0 +1,260 @@
+// Control UI tests cover the responsive disconnected login gate.
+import { chromium, type Browser, type BrowserContext, type Page } from "playwright";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import {
+  canRunPlaywrightChromium,
+  resolvePlaywrightChromiumExecutablePath,
+  startControlUiE2eServer,
+  type ControlUiE2eServer,
+} from "../test-helpers/control-ui-e2e.ts";
+
+const chromiumExecutablePath = resolvePlaywrightChromiumExecutablePath(chromium.executablePath());
+const chromiumAvailable = canRunPlaywrightChromium(chromiumExecutablePath);
+const allowMissingChromium = process.env.OPENCLAW_UI_E2E_ALLOW_MISSING_CHROMIUM === "1";
+const describeControlUiE2e = chromiumAvailable || !allowMissingChromium ? describe : describe.skip;
+
+let browser: Browser;
+let server: ControlUiE2eServer;
+
+async function renderLoginGate(page: Page): Promise<void> {
+  const response = await page.goto(server.baseUrl);
+  expect(response?.status()).toBe(200);
+
+  await mountLoginGate(page);
+}
+
+async function mountLoginGate(page: Page): Promise<void> {
+  await page.evaluate(async () => {
+    await customElements.whenDefined("openclaw-login-gate");
+    const gate = document.createElement("openclaw-login-gate") as HTMLElement & {
+      props: Record<string, unknown>;
+      updateComplete: Promise<unknown>;
+    };
+    document.body.dataset.connectCount = "0";
+    gate.props = {
+      basePath: "",
+      connected: false,
+      lastError: "unauthorized: gateway token required",
+      lastErrorCode: null,
+      hasToken: false,
+      hasPassword: false,
+      gatewayUrl: "ws://127.0.0.1:18789",
+      token: "",
+      password: "",
+      showGatewayToken: false,
+      showGatewayPassword: false,
+      onGatewayUrlChange: () => {},
+      onTokenChange: () => {},
+      onPasswordChange: () => {},
+      onToggleGatewayToken: () => {},
+      onToggleGatewayPassword: () => {},
+      onConnect: () => {
+        const current = Number.parseInt(document.body.dataset.connectCount ?? "0", 10);
+        document.body.dataset.connectCount = String(current + 1);
+      },
+    };
+    document.body.replaceChildren(gate);
+    await gate.updateComplete;
+  });
+}
+
+async function closeContext(context: BrowserContext): Promise<void> {
+  await context.close().catch(() => {});
+}
+
+describeControlUiE2e("Control UI responsive login gate E2E", () => {
+  beforeAll(async () => {
+    if (!chromiumAvailable) {
+      throw new Error(
+        `Playwright Chromium is not installed or cannot start at ${chromiumExecutablePath}. Run \`pnpm --dir ui exec playwright install --with-deps chromium\`, or set OPENCLAW_UI_E2E_ALLOW_MISSING_CHROMIUM=1 only when intentionally skipping this lane.`,
+      );
+    }
+    server = await startControlUiE2eServer();
+    browser = await chromium.launch({ executablePath: chromiumExecutablePath });
+  });
+
+  afterAll(async () => {
+    await browser?.close();
+    await server?.close();
+  });
+
+  it("keeps mobile controls compact, touchable, and keyboard-friendly", async () => {
+    const context = await browser.newContext({
+      hasTouch: true,
+      isMobile: true,
+      viewport: { height: 500, width: 375 },
+    });
+    const page = await context.newPage();
+
+    try {
+      await renderLoginGate(page);
+      const gatewayInput = page.locator(".login-gate__form .field input").first();
+      expect(await gatewayInput.getAttribute("inputmode")).toBe("url");
+      expect(await gatewayInput.getAttribute("autocapitalize")).toBe("none");
+      expect(await gatewayInput.getAttribute("autocorrect")).toBe("off");
+      expect(await gatewayInput.getAttribute("spellcheck")).toBe("false");
+      expect(await gatewayInput.getAttribute("enterkeyhint")).toBe("go");
+
+      await gatewayInput.press("Enter");
+      expect(await page.locator("body").getAttribute("data-connect-count")).toBe("1");
+
+      const metrics = await page.evaluate(() => {
+        const gate = document.querySelector<HTMLElement>(".login-gate");
+        const card = document.querySelector<HTMLElement>(".login-gate__card");
+        const inputs = Array.from(
+          document.querySelectorAll<HTMLElement>(".login-gate__form .field input"),
+        );
+        const toggles = Array.from(
+          document.querySelectorAll<HTMLElement>(".login-gate__secret-row .btn--icon"),
+        );
+        const connect = document.querySelector<HTMLElement>(".login-gate__connect");
+        if (!gate || !card || !connect) {
+          throw new Error("Missing login gate elements");
+        }
+        const gateStyle = getComputedStyle(gate);
+        const cardStyle = getComputedStyle(card);
+        return {
+          cardPadding: cardStyle.padding,
+          cardTop: card.getBoundingClientRect().top,
+          connectMinHeight: getComputedStyle(connect).minHeight,
+          gateClientHeight: gate.clientHeight,
+          gateOverflowY: gateStyle.overflowY,
+          gatePadding: gateStyle.padding,
+          gateScrollHeight: gate.scrollHeight,
+          inputMinHeights: inputs.map((input) => getComputedStyle(input).minHeight),
+          toggleSizes: toggles.map((toggle) => {
+            const style = getComputedStyle(toggle);
+            return { height: style.height, minWidth: style.minWidth, width: style.width };
+          }),
+        };
+      });
+
+      expect(metrics.gatePadding).toBe("16px 12px");
+      expect(metrics.cardPadding).toBe("24px 20px");
+      expect(metrics.cardTop).toBeGreaterThanOrEqual(0);
+      expect(metrics.connectMinHeight).toBe("44px");
+      expect(metrics.gateOverflowY).toBe("auto");
+      expect(metrics.gateScrollHeight).toBeGreaterThan(metrics.gateClientHeight);
+      expect(metrics.inputMinHeights.every((height) => height === "44px")).toBe(true);
+      expect(
+        metrics.toggleSizes.every(
+          ({ height, minWidth, width }) =>
+            height === "44px" && minWidth === "44px" && width === "44px",
+        ),
+      ).toBe(true);
+
+      const failureDocs = page.locator(".login-gate__failure-docs");
+      await failureDocs.scrollIntoViewIfNeeded();
+      const failureDocsBox = await failureDocs.boundingBox();
+      if (!failureDocsBox) {
+        throw new Error("Missing failure documentation link bounds");
+      }
+      expect(failureDocsBox.y + failureDocsBox.height).toBeLessThanOrEqual(500);
+    } finally {
+      await closeContext(context);
+    }
+  });
+
+  it("keeps failure recovery visible while generic help stays collapsed", async () => {
+    const context = await browser.newContext({ viewport: { height: 900, width: 1280 } });
+    const page = await context.newPage();
+
+    try {
+      await renderLoginGate(page);
+      const failure = page.locator(".login-gate__failure");
+      expect(await failure.evaluate((element) => element.tagName)).toBe("DIV");
+      expect(await page.locator(".login-gate__failure-summary").isVisible()).toBe(true);
+      expect(await page.locator(".login-gate__failure-steps").isVisible()).toBe(true);
+      expect(await page.locator(".login-gate__failure-docs").isVisible()).toBe(true);
+
+      const help = page.locator(".login-gate__help");
+      expect(await help.evaluate((element) => element.tagName)).toBe("DETAILS");
+      expect(await help.getAttribute("open")).toBeNull();
+      expect(await page.locator(".login-gate__steps").isVisible()).toBe(false);
+    } finally {
+      await closeContext(context);
+    }
+  });
+
+  it("applies standalone safe-area insets exactly once", async () => {
+    const context = await browser.newContext({
+      hasTouch: true,
+      isMobile: true,
+      viewport: { height: 500, width: 375 },
+    });
+    const page = await context.newPage();
+
+    try {
+      await renderLoginGate(page);
+      const metrics = await page.evaluate(() => {
+        const root = document.documentElement;
+        root.style.setProperty("--safe-area-top", "34px");
+        root.style.setProperty("--safe-area-right", "20px");
+        root.style.setProperty("--safe-area-bottom", "21px");
+        root.style.setProperty("--safe-area-left", "18px");
+
+        const mediaRules = Array.from(document.styleSheets).flatMap((sheet) =>
+          Array.from(sheet.cssRules).filter(
+            (rule): rule is CSSMediaRule =>
+              rule instanceof CSSMediaRule &&
+              rule.conditionText.includes("display-mode: standalone"),
+          ),
+        );
+        const standaloneBodyRule = mediaRules.find((mediaRule) =>
+          Array.from(mediaRule.cssRules).some(
+            (rule) => rule instanceof CSSStyleRule && rule.selectorText === "body",
+          ),
+        );
+        const standaloneGateRule = mediaRules.find((mediaRule) =>
+          Array.from(mediaRule.cssRules).some(
+            (rule) => rule instanceof CSSStyleRule && rule.selectorText === ".login-gate",
+          ),
+        );
+        if (!standaloneBodyRule || !standaloneGateRule) {
+          throw new Error("Missing standalone safe-area ownership rules");
+        }
+
+        // Headless Chromium cannot toggle installed-app display mode reliably.
+        // Apply the exact production inner rules to verify their computed layout.
+        const activeStandaloneRules = document.createElement("style");
+        activeStandaloneRules.textContent = [standaloneBodyRule, standaloneGateRule]
+          .flatMap((mediaRule) => Array.from(mediaRule.cssRules, (rule) => rule.cssText))
+          .join("\n");
+        document.head.append(activeStandaloneRules);
+
+        const gate = document.querySelector<HTMLElement>(".login-gate");
+        if (!gate) {
+          throw new Error("Missing login gate element");
+        }
+        const bodyStyle = getComputedStyle(document.body);
+        const gateStyle = getComputedStyle(gate);
+        const gateBounds = gate.getBoundingClientRect();
+        return {
+          bodyPadding: {
+            bottom: bodyStyle.paddingBottom,
+            left: bodyStyle.paddingLeft,
+            right: bodyStyle.paddingRight,
+            top: bodyStyle.paddingTop,
+          },
+          gateBottom: gateBounds.bottom,
+          gatePadding: gateStyle.padding,
+          gateRuleCondition: standaloneGateRule.conditionText,
+          gateTop: gateBounds.top,
+        };
+      });
+
+      expect(metrics.bodyPadding).toEqual({
+        bottom: "21px",
+        left: "18px",
+        right: "20px",
+        top: "34px",
+      });
+      expect(metrics.gatePadding).toBe("16px 12px");
+      expect(metrics.gateRuleCondition).toContain("display-mode: standalone");
+      expect(metrics.gateTop).toBe(34);
+      expect(metrics.gateBottom).toBe(479);
+    } finally {
+      await closeContext(context);
+    }
+  });
+});

--- a/ui/src/styles/components.css
+++ b/ui/src/styles/components.css
@@ -6,8 +6,10 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  min-height: 100vh;
-  min-height: 100dvh;
+  height: 100vh;
+  height: 100dvh;
+  max-height: 100%;
+  overflow-y: auto;
   background: var(--bg);
   padding: 24px;
 }
@@ -21,6 +23,7 @@
 
 .login-gate__card {
   width: min(520px, 100%);
+  margin-block: auto;
   background: var(--card);
   border: 1px solid var(--border);
   border-radius: var(--radius-lg);
@@ -140,12 +143,12 @@
 .login-gate__help-title {
   font-weight: 600;
   font-size: 12px;
-  margin-bottom: 10px;
   color: var(--fg);
+  cursor: pointer;
 }
 
 .login-gate__steps {
-  margin: 0;
+  margin: 10px 0 0;
   padding-left: 20px;
   font-size: 12px;
   line-height: 1.6;
@@ -206,6 +209,44 @@
 .login-gate__docs {
   margin-top: 10px;
   font-size: 12px;
+}
+
+/* Phones (matches the layout.mobile.css breakpoint). The gate renders outside
+   the shell, so it needs its own safe-area padding for notch/home-bar overlap
+   with viewport-fit=cover. */
+@media (max-width: 768px), (max-width: 932px) and (max-height: 500px) and (orientation: landscape) {
+  .login-gate {
+    padding: max(16px, var(--safe-area-top)) max(12px, var(--safe-area-right))
+      max(16px, var(--safe-area-bottom)) max(12px, var(--safe-area-left));
+  }
+
+  .login-gate__card {
+    padding: 24px 20px;
+  }
+
+  /* 44px touch targets per platform guidelines. */
+  .login-gate__form .field input {
+    min-height: 44px;
+  }
+
+  .login-gate__secret-row .btn--icon {
+    width: 44px;
+    min-width: 44px;
+    height: 44px;
+  }
+
+  .login-gate__connect {
+    min-height: 44px;
+  }
+}
+
+/* The standalone body already owns safe-area insets. Reusing them inside the
+   gate would double notch/home-bar spacing and shrink its scroll viewport. */
+@media (display-mode: standalone) and (max-width: 768px),
+  (display-mode: standalone) and (max-width: 932px) and (max-height: 500px) and (orientation: landscape) {
+  .login-gate {
+    padding: 16px 12px;
+  }
 }
 
 /* ===========================================


### PR DESCRIPTION
## What Problem This Solves

The Gateway Dashboard login gate was not mobile-optimized. Page/card padding squeezed the form on phones, touch targets were below 44px, the WebSocket URL field used text-keyboard defaults, and long recovery/help content could overflow constrained or standalone viewports.

## Why This Change Was Made

The disconnected gate is shared across desktop and mobile Control UI entry points. It should reuse the existing mobile breakpoint and safe-area ownership while keeping recovery-critical failure guidance immediately visible.

## User Impact

- Mobile and small-landscape layouts use compact card padding, 44px controls, URL-keyboard hints, and Enter-to-connect parity.
- Generic "How to connect" guidance is collapsed, while connection-failure summaries, recovery steps, and documentation remain visible.
- The gate becomes its own bounded scroll container so recovery content stays reachable in short and standalone viewports.
- Browser mode consumes safe-area insets in the gate; installed standalone mode consumes them once at the body boundary instead of doubling notch/home-bar spacing.

## Evidence

- Blacksmith Testbox `tbx_01kwrxep11m1gy1d3h1q36z2fr`: focused Chromium E2E, 3/3 passing at mobile, desktop, and simulated standalone safe-area layouts.
- Same Testbox: `pnpm check:changed` and `pnpm build` passed on the final prepared tree.
- Fresh Codex autoreview passed with no accepted/actionable findings for both the final fixup and the complete branch diff.
- Exact pushed head: `4004728da2ad2602ad51af6972335d9307216361`.
