### PR TITLE
fix(test): unit-fast tests inherit live host config

### DIFF
--- a/test/setup.env.ts
+++ b/test/setup.env.ts
@@ -4,7 +4,7 @@
 // sees the developer's real ~/.openclaw (e.g. an openclaw.json key the branch
 // schema rejects deterministically fails schema-reading tests locally while CI
 // stays green).
-import { withIsolatedTestHome } from "./test-env.js";
+import { installTestEnv } from "./test-env.js";
 
 process.env.VITEST = "true";
 
@@ -17,7 +17,9 @@ const globalState = globalThis as typeof globalThis & {
 };
 
 if (!globalState[ENV_ISOLATION_SETUP]) {
-  const testEnv = withIsolatedTestHome();
+  // unit-fast is never a live lane, even when its parent shell exports live flags.
+  // Hermetic mode prevents real or staged credentials/config from entering the worker.
+  const testEnv = installTestEnv({ mode: "hermetic" });
   const handle: EnvIsolationHandle = {
     cleanup: () => {
       testEnv.cleanup();

--- a/test/setup.env.ts
+++ b/test/setup.env.ts
@@ -1,0 +1,29 @@
+// Env-only isolation for fast shards that intentionally skip the full shared
+// setup (no module mocks, no custom runner). unit-fast runs isolate:false with
+// auto-curated membership, so without this any test that reads config/state
+// sees the developer's real ~/.openclaw (e.g. an openclaw.json key the branch
+// schema rejects deterministically fails schema-reading tests locally while CI
+// stays green).
+import { withIsolatedTestHome } from "./test-env.js";
+
+process.env.VITEST = "true";
+
+const ENV_ISOLATION_SETUP = Symbol.for("openclaw.envIsolationTestSetup");
+
+type EnvIsolationHandle = { cleanup: () => void };
+
+const globalState = globalThis as typeof globalThis & {
+  [ENV_ISOLATION_SETUP]?: EnvIsolationHandle;
+};
+
+if (!globalState[ENV_ISOLATION_SETUP]) {
+  const testEnv = withIsolatedTestHome();
+  const handle: EnvIsolationHandle = {
+    cleanup: () => {
+      testEnv.cleanup();
+      delete globalState[ENV_ISOLATION_SETUP];
+    },
+  };
+  process.once("exit", handle.cleanup);
+  globalState[ENV_ISOLATION_SETUP] = handle;
+}

--- a/test/test-env.test.ts
+++ b/test/test-env.test.ts
@@ -233,6 +233,45 @@ describe("installTestEnv", () => {
     expect(process.env.TEST_PROFILE_ONLY).toBe("from-profile");
   });
 
+  it("keeps hermetic mode isolated when live flags request the real HOME", () => {
+    const realHome = createTempHome();
+    writeFile(path.join(realHome, ".profile"), "export TEST_PROFILE_ONLY=from-profile\n");
+    writeFile(path.join(realHome, ".openclaw", "openclaw.json"), '{"live":true}\n');
+    writeFile(path.join(realHome, ".openclaw", "credentials", "token.txt"), "secret\n");
+
+    setTestEnvValue("HOME", realHome);
+    setTestEnvValue("USERPROFILE", realHome);
+    setTestEnvValue("LIVE", "1");
+    setTestEnvValue("OPENCLAW_LIVE_TEST", "1");
+    setTestEnvValue("OPENCLAW_LIVE_GATEWAY", "1");
+    setTestEnvValue("OPENCLAW_LIVE_USE_REAL_HOME", "1");
+    const callerPluginDir = path.join(realHome, "caller-plugins");
+    setTestEnvValue("OPENCLAW_BUNDLED_PLUGINS_DIR", callerPluginDir);
+    setTestEnvValue("OPENCLAW_TEST_TRUST_BUNDLED_PLUGINS_DIR", "1");
+    setTestEnvValue("OPENCLAW_DISABLE_BUNDLED_PLUGINS", "1");
+    setTestEnvValue("OPENCLAW_HOME", realHome);
+
+    const testEnv = installTestEnv({ mode: "hermetic" });
+    cleanupFns.push(testEnv.cleanup);
+
+    expect(testEnv.tempHome).not.toBe(realHome);
+    expect(process.env.HOME).toBe(testEnv.tempHome);
+    expect(process.env.TEST_PROFILE_ONLY).toBeUndefined();
+    expect(process.env.LIVE).toBeUndefined();
+    expect(process.env.OPENCLAW_LIVE_TEST).toBeUndefined();
+    expect(process.env.OPENCLAW_LIVE_GATEWAY).toBeUndefined();
+    expect(process.env.OPENCLAW_LIVE_USE_REAL_HOME).toBeUndefined();
+    expect(process.env.OPENCLAW_BUNDLED_PLUGINS_DIR).not.toBe(callerPluginDir);
+    expect(path.basename(process.env.OPENCLAW_BUNDLED_PLUGINS_DIR ?? "")).toBe("extensions");
+    expect(process.env.OPENCLAW_TEST_TRUST_BUNDLED_PLUGINS_DIR).toBe("1");
+    expect(process.env.OPENCLAW_DISABLE_BUNDLED_PLUGINS).toBeUndefined();
+    expect(process.env.OPENCLAW_HOME).toBeUndefined();
+    expect(fs.existsSync(path.join(testEnv.tempHome, ".openclaw", "openclaw.json"))).toBe(false);
+    expect(
+      fs.existsSync(path.join(testEnv.tempHome, ".openclaw", "credentials", "token.txt")),
+    ).toBe(false);
+  });
+
   it("does not load ~/.profile for normal isolated test runs", () => {
     const realHome = createTempHome();
     writeFile(path.join(realHome, ".profile"), "export TEST_PROFILE_ONLY=from-profile\n");

--- a/test/test-env.ts
+++ b/test/test-env.ts
@@ -9,7 +9,19 @@ import JSON5 from "json5";
 import { deleteTestEnvValue, setTestEnvValue } from "../src/test-utils/env.js";
 
 type RestoreEntry = { key: string; value: string | undefined };
+type InstallTestEnvOptions =
+  | { mode?: "live-aware"; loadProfileEnv?: boolean }
+  | { mode: "hermetic" };
 
+const LIVE_TEST_TRIGGER_ENV_KEYS = ["LIVE", "OPENCLAW_LIVE_TEST", "OPENCLAW_LIVE_GATEWAY"] as const;
+const HERMETIC_TEST_ENV_KEYS = [
+  ...LIVE_TEST_TRIGGER_ENV_KEYS,
+  "OPENCLAW_LIVE_USE_REAL_HOME",
+  "OPENCLAW_BUNDLED_PLUGINS_DIR",
+  "OPENCLAW_TEST_TRUST_BUNDLED_PLUGINS_DIR",
+  "OPENCLAW_DISABLE_BUNDLED_PLUGINS",
+  "OPENCLAW_HOME",
+] as const;
 const LIVE_EXTERNAL_AUTH_DIRS = [".claude/backups", ".gemini", ".minimax"] as const;
 const LIVE_EXTERNAL_AUTH_FILES = [
   ".claude.json",
@@ -149,6 +161,7 @@ function loadProfileEnv(homeDir = os.homedir()): void {
 
 function resolveRestoreEntries(): RestoreEntry[] {
   return [
+    ...HERMETIC_TEST_ENV_KEYS.map((key) => ({ key, value: process.env[key] })),
     { key: "OPENCLAW_TEST_FAST", value: process.env.OPENCLAW_TEST_FAST },
     {
       key: "OPENCLAW_STRICT_FAST_REPLY_CONFIG",
@@ -170,11 +183,6 @@ function resolveRestoreEntries(): RestoreEntry[] {
     { key: "XDG_CACHE_HOME", value: process.env.XDG_CACHE_HOME },
     { key: "OPENCLAW_STATE_DIR", value: process.env.OPENCLAW_STATE_DIR },
     { key: "OPENCLAW_CONFIG_PATH", value: process.env.OPENCLAW_CONFIG_PATH },
-    { key: "OPENCLAW_BUNDLED_PLUGINS_DIR", value: process.env.OPENCLAW_BUNDLED_PLUGINS_DIR },
-    {
-      key: "OPENCLAW_TEST_TRUST_BUNDLED_PLUGINS_DIR",
-      value: process.env.OPENCLAW_TEST_TRUST_BUNDLED_PLUGINS_DIR,
-    },
     { key: "OPENCLAW_GATEWAY_PORT", value: process.env.OPENCLAW_GATEWAY_PORT },
     { key: "OPENCLAW_BRIDGE_ENABLED", value: process.env.OPENCLAW_BRIDGE_ENABLED },
     { key: "OPENCLAW_BRIDGE_HOST", value: process.env.OPENCLAW_BRIDGE_HOST },
@@ -212,16 +220,6 @@ function createIsolatedTestHome(restore: RestoreEntry[]): {
   // Prefer deriving state dir from HOME so nested tests that change HOME also isolate correctly.
   deleteTestEnvValue("OPENCLAW_STATE_DIR");
   deleteTestEnvValue("OPENCLAW_AGENT_DIR");
-  // Deterministic bundled-plugin discovery: built checkouts prefer dist/extensions,
-  // which excludes externalized official plugins (e.g. qwen) whose manifests drive
-  // endpoint classification. Pin discovery to the source tree so tests behave like
-  // CI (no dist) regardless of local build state. Discovery tests manage this env
-  // themselves per case.
-  setTestEnvValue("OPENCLAW_TEST_TRUST_BUNDLED_PLUGINS_DIR", "1");
-  setTestEnvValue(
-    "OPENCLAW_BUNDLED_PLUGINS_DIR",
-    path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..", "extensions"),
-  );
   // Prefer test-controlled ports over developer overrides (avoid port collisions across tests/workers).
   deleteTestEnvValue("OPENCLAW_GATEWAY_PORT");
   deleteTestEnvValue("OPENCLAW_BRIDGE_ENABLED");
@@ -433,19 +431,18 @@ function stageLiveTestState(params: {
   restoreClaudeConfigFromBackupIfNeeded(params.tempHome);
 }
 
-export function installTestEnv(options?: { loadProfileEnv?: boolean }): {
+export function installTestEnv(options?: InstallTestEnvOptions): {
   cleanup: () => void;
   tempHome: string;
 } {
-  const live =
-    process.env.LIVE === "1" ||
-    process.env.OPENCLAW_LIVE_TEST === "1" ||
-    process.env.OPENCLAW_LIVE_GATEWAY === "1";
-  const allowRealHome = isTruthyEnvValue(process.env.OPENCLAW_LIVE_USE_REAL_HOME);
+  const hermetic = options?.mode === "hermetic";
+  const live = !hermetic && LIVE_TEST_TRIGGER_ENV_KEYS.some((key) => process.env[key] === "1");
+  const allowRealHome = !hermetic && isTruthyEnvValue(process.env.OPENCLAW_LIVE_USE_REAL_HOME);
   const realHome = process.env.HOME ?? os.homedir();
   const liveEnvSnapshot = { ...process.env };
 
-  const shouldLoadProfileEnv = options?.loadProfileEnv ?? (live || allowRealHome);
+  const requestedProfileLoad = options?.mode === "hermetic" ? false : options?.loadProfileEnv;
+  const shouldLoadProfileEnv = requestedProfileLoad ?? (live || allowRealHome);
   if (shouldLoadProfileEnv) {
     loadProfileEnv(realHome);
   }
@@ -457,14 +454,25 @@ export function installTestEnv(options?: { loadProfileEnv?: boolean }): {
   const restore = resolveRestoreEntries();
   const testEnv = createIsolatedTestHome(restore);
 
-  if (live) {
+  if (hermetic) {
+    for (const key of HERMETIC_TEST_ENV_KEYS) {
+      deleteTestEnvValue(key);
+    }
+    // Keep non-isolated workers on this checkout's manifests, never a caller's
+    // staged plugin tree or a sibling worktree resolved through shared node_modules.
+    setTestEnvValue("OPENCLAW_TEST_TRUST_BUNDLED_PLUGINS_DIR", "1");
+    setTestEnvValue(
+      "OPENCLAW_BUNDLED_PLUGINS_DIR",
+      path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..", "extensions"),
+    );
+  } else if (live) {
     stageLiveTestState({ env: liveEnvSnapshot, realHome, tempHome: testEnv.tempHome });
   }
 
   return testEnv;
 }
 
-export function withIsolatedTestHome(options?: { loadProfileEnv?: boolean }): {
+export function withIsolatedTestHome(options?: InstallTestEnvOptions): {
   cleanup: () => void;
   tempHome: string;
 } {

--- a/test/test-env.ts
+++ b/test/test-env.ts
@@ -4,6 +4,7 @@ import fs from "node:fs";
 import { createRequire } from "node:module";
 import os from "node:os";
 import path from "node:path";
+import { fileURLToPath } from "node:url";
 import JSON5 from "json5";
 import { deleteTestEnvValue, setTestEnvValue } from "../src/test-utils/env.js";
 
@@ -169,6 +170,11 @@ function resolveRestoreEntries(): RestoreEntry[] {
     { key: "XDG_CACHE_HOME", value: process.env.XDG_CACHE_HOME },
     { key: "OPENCLAW_STATE_DIR", value: process.env.OPENCLAW_STATE_DIR },
     { key: "OPENCLAW_CONFIG_PATH", value: process.env.OPENCLAW_CONFIG_PATH },
+    { key: "OPENCLAW_BUNDLED_PLUGINS_DIR", value: process.env.OPENCLAW_BUNDLED_PLUGINS_DIR },
+    {
+      key: "OPENCLAW_TEST_TRUST_BUNDLED_PLUGINS_DIR",
+      value: process.env.OPENCLAW_TEST_TRUST_BUNDLED_PLUGINS_DIR,
+    },
     { key: "OPENCLAW_GATEWAY_PORT", value: process.env.OPENCLAW_GATEWAY_PORT },
     { key: "OPENCLAW_BRIDGE_ENABLED", value: process.env.OPENCLAW_BRIDGE_ENABLED },
     { key: "OPENCLAW_BRIDGE_HOST", value: process.env.OPENCLAW_BRIDGE_HOST },
@@ -206,6 +212,16 @@ function createIsolatedTestHome(restore: RestoreEntry[]): {
   // Prefer deriving state dir from HOME so nested tests that change HOME also isolate correctly.
   deleteTestEnvValue("OPENCLAW_STATE_DIR");
   deleteTestEnvValue("OPENCLAW_AGENT_DIR");
+  // Deterministic bundled-plugin discovery: built checkouts prefer dist/extensions,
+  // which excludes externalized official plugins (e.g. qwen) whose manifests drive
+  // endpoint classification. Pin discovery to the source tree so tests behave like
+  // CI (no dist) regardless of local build state. Discovery tests manage this env
+  // themselves per case.
+  setTestEnvValue("OPENCLAW_TEST_TRUST_BUNDLED_PLUGINS_DIR", "1");
+  setTestEnvValue(
+    "OPENCLAW_BUNDLED_PLUGINS_DIR",
+    path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..", "extensions"),
+  );
   // Prefer test-controlled ports over developer overrides (avoid port collisions across tests/workers).
   deleteTestEnvValue("OPENCLAW_GATEWAY_PORT");
   deleteTestEnvValue("OPENCLAW_BRIDGE_ENABLED");

--- a/test/vitest-unit-fast-config.test.ts
+++ b/test/vitest-unit-fast-config.test.ts
@@ -19,6 +19,8 @@ import {
 } from "./vitest/vitest.unit-fast-paths.mjs";
 import { createUnitFastVitestConfig } from "./vitest/vitest.unit-fast.config.ts";
 
+const ENV_ISOLATION_SETUP_PATH = /[\\/]test[\\/]setup\.env\.ts$/u;
+
 function requireTestConfig<T extends { test?: unknown }>(config: T): NonNullable<T["test"]> {
   if (!config.test) {
     throw new Error("expected unit-fast vitest test config");
@@ -108,7 +110,7 @@ describe("unit-fast vitest lane", () => {
     expect(testConfig.runner).toBeUndefined();
     // Env isolation only: the fast shards install the isolated test home but
     // must not pull in the shared setup's module mocks.
-    expect(testConfig.setupFiles).toStrictEqual([expect.stringMatching(/test\/setup\.env\.ts$/u)]);
+    expect(testConfig.setupFiles).toStrictEqual([expect.stringMatching(ENV_ISOLATION_SETUP_PATH)]);
     expect(testConfig.include).toContain(
       "src/agents/agent-tools.deferred-followup-guidance.test.ts",
     );
@@ -212,9 +214,7 @@ describe("unit-fast vitest lane", () => {
     expect(timerConfig.include).toEqual(unitFastTimerTestFiles);
     expect(timerConfig.fileParallelism).toBe(false);
     expect(timerConfig.maxWorkers).toBe(1);
-    expect(timerConfig.setupFiles).toStrictEqual([
-      expect.stringMatching(/test\/setup\.env\.ts$/u),
-    ]);
+    expect(timerConfig.setupFiles).toStrictEqual([expect.stringMatching(ENV_ISOLATION_SETUP_PATH)]);
   });
 
   it("keeps broad audit candidates separate from automatically routed unit-fast tests", () => {

--- a/test/vitest-unit-fast-config.test.ts
+++ b/test/vitest-unit-fast-config.test.ts
@@ -106,7 +106,9 @@ describe("unit-fast vitest lane", () => {
 
     expect(testConfig.isolate).toBe(false);
     expect(testConfig.runner).toBeUndefined();
-    expect(testConfig.setupFiles).toStrictEqual([]);
+    // Env isolation only: the fast shards install the isolated test home but
+    // must not pull in the shared setup's module mocks.
+    expect(testConfig.setupFiles).toStrictEqual([expect.stringMatching(/test\/setup\.env\.ts$/u)]);
     expect(testConfig.include).toContain(
       "src/agents/agent-tools.deferred-followup-guidance.test.ts",
     );
@@ -210,6 +212,9 @@ describe("unit-fast vitest lane", () => {
     expect(timerConfig.include).toEqual(unitFastTimerTestFiles);
     expect(timerConfig.fileParallelism).toBe(false);
     expect(timerConfig.maxWorkers).toBe(1);
+    expect(timerConfig.setupFiles).toStrictEqual([
+      expect.stringMatching(/test\/setup\.env\.ts$/u),
+    ]);
   });
 
   it("keeps broad audit candidates separate from automatically routed unit-fast tests", () => {

--- a/test/vitest/vitest.shared.config.ts
+++ b/test/vitest/vitest.shared.config.ts
@@ -505,6 +505,7 @@ export const sharedVitestConfig = {
       "package.json",
       "pnpm-lock.yaml",
       "test/setup.ts",
+      "test/setup.env.ts",
       "test/setup.shared.ts",
       "test/setup.extensions.ts",
       "test/setup-openclaw-runtime.ts",

--- a/test/vitest/vitest.unit-fast-fake-timers.config.ts
+++ b/test/vitest/vitest.unit-fast-fake-timers.config.ts
@@ -1,7 +1,11 @@
 // Vitest unit fast fake timers config wires the unit fast fake timers test shard.
 import { defineConfig } from "vitest/config";
 import { loadPatternListFromEnv, narrowIncludePatternsForCli } from "./vitest.pattern-file.ts";
-import { nonIsolatedRunnerPath, sharedVitestConfig } from "./vitest.shared.config.ts";
+import {
+  nonIsolatedRunnerPath,
+  resolveRepoRootPath,
+  sharedVitestConfig,
+} from "./vitest.shared.config.ts";
 import { getUnitFastTimerTestFiles } from "./vitest.unit-fast-paths.mjs";
 
 export function createUnitFastFakeTimersVitestConfig(
@@ -20,7 +24,8 @@ export function createUnitFastFakeTimersVitestConfig(
       name: "unit-fast-fake-timers",
       isolate: false,
       runner: nonIsolatedRunnerPath,
-      setupFiles: [],
+      // Env isolation only (no shared-setup mocks), mirroring unit-fast.
+      setupFiles: [resolveRepoRootPath("test/setup.env.ts")],
       include: includeFromEnv ?? cliInclude ?? unitFastTimerTestFiles,
       exclude: sharedTest.exclude ?? [],
       maxWorkers: 1,

--- a/test/vitest/vitest.unit-fast.config.ts
+++ b/test/vitest/vitest.unit-fast.config.ts
@@ -1,7 +1,7 @@
 // Vitest unit fast config wires the unit fast test shard.
 import { defineConfig } from "vitest/config";
 import { loadPatternListFromEnv, narrowIncludePatternsForCli } from "./vitest.pattern-file.ts";
-import { sharedVitestConfig } from "./vitest.shared.config.ts";
+import { resolveRepoRootPath, sharedVitestConfig } from "./vitest.shared.config.ts";
 import { getUnitFastTestFiles, getUnitFastTimerTestFiles } from "./vitest.unit-fast-paths.mjs";
 
 export function createUnitFastVitestConfig(
@@ -21,7 +21,9 @@ export function createUnitFastVitestConfig(
       name: "unit-fast",
       isolate: false,
       runner: undefined,
-      setupFiles: [],
+      // Env isolation only (no shared-setup mocks): membership is auto-curated,
+      // so tests must never read the developer's real config/state.
+      setupFiles: [resolveRepoRootPath("test/setup.env.ts")],
       include: includeFromEnv ?? cliInclude ?? unitFastTestFiles,
       exclude: sharedTest.exclude ?? [],
       passWithNoTests: true,


### PR DESCRIPTION
Related: #100046
Related: #100125

## What Problem This Solves

Fixes an issue where the `unit-fast` Vitest shards could read a developer's real `~/.openclaw/openclaw.json` because those projects intentionally ran with `setupFiles: []`. A host config written by a newer local gateway could therefore fail otherwise unrelated schema/config tests while CI stayed green.

The same gap was more serious in shells exporting live-test flags: the shared env helper could stage real config/credentials into the test home, or use the real HOME outright when `OPENCLAW_LIVE_USE_REAL_HOME=1` was present.

The built-checkout provider-endpoint failure originally described by this PR is now fixed at the production ownership boundary by #100125 and is intentionally no longer part of this patch.

## Why This Change Was Made

Both unit-fast projects now load a minimal env-only setup that installs one isolated HOME per non-isolated worker without pulling in the shared setup's module mocks. `installTestEnv({ mode: "hermetic" })` centralizes the stronger contract: it ignores and clears live/real-HOME flags, replaces caller plugin-discovery overrides with this checkout's source manifest tree, and restores captured env during cleanup. Config contract assertions accept both Windows and POSIX path separators.

## User Impact

Maintainers and agents can run the fast/full test lanes without results depending on live OpenClaw config, credentials, plugin overrides, or platform path separators. No runtime/product behavior changes.

## Evidence

- Root cause verified on current main: both unit-fast projects had no setup file, while config-reading tests are auto-curated into those shards.
- Blacksmith Testbox through Crabbox (`tbx_01kwsj6n2avb863x782m5hhb75`): `pnpm test test/test-env.test.ts test/vitest-unit-fast-config.test.ts` — 14 tests passed.
- Same Testbox, actual unit-fast config under live/real-HOME plus hostile bundled-plugin overrides: `message-tool.internal-source-reply.integration.test.ts` and `status.summary.runtime.test.ts` — 19 tests passed.
- `oxfmt --check` on all seven touched files and `git diff --check` — clean.
- Structured Codex autoreview of the complete branch against `origin/main` — no accepted/actionable findings.
- Exact-head hosted CI/Testbox runs on `5b76f90231ce51997c163dba6262e6b5643c1dfb` are the final merge gate.
