### PR TITLE
fix(crestodian): repair post-merge checks

### DIFF
--- a/apps/.i18n/native-source.json
+++ b/apps/.i18n/native-source.json
@@ -17867,7 +17867,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 167,
+      "line": 168,
       "path": "apps/macos/Sources/OpenClaw/RemotePortTunnel.swift",
       "source": "ssh tunnel exited before listening",
       "surface": "apple",
@@ -17875,7 +17875,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 183,
+      "line": 184,
       "path": "apps/macos/Sources/OpenClaw/RemotePortTunnel.swift",
       "source": "ssh tunnel did not open local port \\(localPort)",
       "surface": "apple",
@@ -17883,7 +17883,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 183,
+      "line": 184,
       "path": "apps/macos/Sources/OpenClaw/RemotePortTunnel.swift",
       "source": "ssh tunnel failed: \\(stderr)",
       "surface": "apple",

--- a/docs/start/onboarding-overview.md
+++ b/docs/start/onboarding-overview.md
@@ -12,13 +12,13 @@ optional chat channels — they just differ in how you interact with the setup.
 
 ## Which path should I use?
 
-|                | CLI onboarding                         | macOS app onboarding      |
-| -------------- | -------------------------------------- | ------------------------- |
-| **Platforms**  | macOS, Linux, Windows (native or WSL2) | macOS only                |
+|                | CLI onboarding                         | macOS app onboarding        |
+| -------------- | -------------------------------------- | --------------------------- |
+| **Platforms**  | macOS, Linux, Windows (native or WSL2) | macOS only                  |
 | **Interface**  | Terminal wizard                        | Guided UI + Crestodian chat |
-| **Best for**   | Servers, headless, full control        | Desktop Mac, visual setup |
-| **Automation** | `--non-interactive` for scripts        | Manual only               |
-| **Command**    | `openclaw onboard`                     | Launch the app            |
+| **Best for**   | Servers, headless, full control        | Desktop Mac, visual setup   |
+| **Automation** | `--non-interactive` for scripts        | Manual only                 |
+| **Command**    | `openclaw onboard`                     | Launch the app              |
 
 Most users should start with **CLI onboarding** — it works everywhere and gives
 you the most control.

--- a/docs/start/onboarding.md
+++ b/docs/start/onboarding.md
@@ -74,9 +74,10 @@ Where does the **Gateway** run?
   ambiguous transport failure, restart the setup conversation instead of
   replaying the previous turn.
 
-  Remote and Configure Later flows skip this local setup conversation.
+Remote and Configure Later flows skip this local setup conversation.
 </Step>
 <Step title="Permissions">
+
 <Frame caption="Choose what permissions do you want to give OpenClaw">
 <img src="/assets/macos-onboarding/05-permissions.png" alt="" />
 </Frame>

--- a/src/crestodian/onboarding-welcome.ts
+++ b/src/crestodian/onboarding-welcome.ts
@@ -38,11 +38,10 @@ export async function buildOnboardingWelcome(params: {
     normalizeSecretInputString(auth?.token) !== undefined ||
     isSecretRef(auth?.password) ||
     normalizeSecretInputString(auth?.password) !== undefined;
-  const hasAuthoredSetup = Boolean(
+  const hasAuthoredSetup =
     (authoredConfig?.wizard && Object.keys(authoredConfig.wizard).length > 0) ||
     hasAuthMode ||
-    hasAuthSecret,
-  );
+    hasAuthSecret;
   if (hasAuthoredSetup && overview.defaultModel) {
     const welcome = formatCrestodianOnboardingWelcome(overview);
     params.engine.noteAssistantMessage(welcome);


### PR DESCRIPTION
## What Problem This Solves

The merge-head CI for #99935 exposed three generated/formatting drifts after the final rebase: native app localization inventory, two onboarding docs files, and one lint-only redundant type conversion.

## Why This Change Was Made

Regenerate the native localization inventory against the merged macOS sources, apply the repository formatter to the affected docs, and simplify the onboarding predicate without changing behavior.

## User Impact

No product behavior change. Restores green native-i18n, docs-format, and lint checks for the newly landed Crestodian onboarding flow.

## Evidence

- `node --import tsx scripts/native-app-i18n.ts check`
- canonical `oxfmt --check` on the two docs files and TypeScript file
- canonical `oxlint` on `src/crestodian/onboarding-welcome.ts`
- `node scripts/run-vitest.mjs src/crestodian/onboarding-welcome.test.ts` (4 tests)
- `git diff --check`
- fresh autoreview: clean

Follow-up to #99935.
