### PR TITLE
fix: avoid splitting surrogate pairs in node-host truncateOutput

### DIFF
--- a/src/node-host/invoke.test.ts
+++ b/src/node-host/invoke.test.ts
@@ -6,7 +6,7 @@ import { describe, expect, it, vi } from "vitest";
 import type { GatewayClient } from "../gateway/client.js";
 import { withEnvAsync } from "../test-utils/env.js";
 import type { SkillBinsProvider } from "./invoke-types.js";
-import { handleInvoke } from "./invoke.js";
+import { handleInvoke, truncateOutput } from "./invoke.js";
 
 describe("node host invoke", () => {
   it.runIf(process.platform !== "win32")(
@@ -188,5 +188,38 @@ describe("node host invoke", () => {
       execPolicy?: { security?: string; ask?: string };
     };
     expect(payload.execPolicy).toEqual({ security: "allowlist", ask: "on-miss" });
+  });
+});
+
+describe("truncateOutput", () => {
+  it("returns text unchanged when shorter than maxChars", () => {
+    const result = truncateOutput("hello", 100);
+    expect(result).toEqual({ text: "hello", truncated: false });
+  });
+
+  it("truncates ASCII text without splitting", () => {
+    const result = truncateOutput("abcdefghij", 5);
+    expect(result.truncated).toBe(true);
+    expect(result.text).toContain("... (truncated)");
+    expect(result.text.endsWith("fghij")).toBe(true);
+  });
+
+  it("preserves surrogate pairs at truncation boundary", () => {
+    // 10 emoji = 20 UTF-16 code units; keep last 5 code units
+    const raw = "😀".repeat(10);
+    const result = truncateOutput(raw, 5);
+    expect(result.truncated).toBe(true);
+    // Must be well-formed — no lone surrogate at the start
+    const tail = result.text.replace("... (truncated) ", "");
+    expect(tail.isWellFormed()).toBe(true);
+  });
+
+  it("preserves CJK extension B characters at truncation boundary", () => {
+    // 𐍈 = U+10348, a supplementary plane character (surrogate pair in UTF-16)
+    const raw = "𐍈".repeat(10);
+    const result = truncateOutput(raw, 5);
+    expect(result.truncated).toBe(true);
+    const tail = result.text.replace("... (truncated) ", "");
+    expect(tail.isWellFormed()).toBe(true);
   });
 });

--- a/src/node-host/invoke.ts
+++ b/src/node-host/invoke.ts
@@ -4,6 +4,7 @@ import fs from "node:fs";
 import path from "node:path";
 import { normalizeLowercaseStringOrEmpty } from "@openclaw/normalization-core/string-coerce";
 import { normalizeStringEntries } from "@openclaw/normalization-core/string-normalization";
+import { sliceUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
 import { GatewayClient } from "../gateway/client.js";
 import {
   analyzeArgvCommand,
@@ -226,11 +227,15 @@ export function sanitizeEnv(overrides?: Record<string, string> | null): Record<s
   return sanitizeHostExecEnv({ overrides, blockPathOverrides: true });
 }
 
-function truncateOutput(raw: string, maxChars: number): { text: string; truncated: boolean } {
+export function truncateOutput(
+  raw: string,
+  maxChars: number,
+): { text: string; truncated: boolean } {
   if (raw.length <= maxChars) {
     return { text: raw, truncated: false };
   }
-  return { text: `... (truncated) ${raw.slice(raw.length - maxChars)}`, truncated: true };
+  const tail = sliceUtf16Safe(raw, raw.length - maxChars);
+  return { text: `... (truncated) ${tail}`, truncated: true };
 }
 
 export function decodeCapturedOutputBuffer(params: {


### PR DESCRIPTION
## Summary

**Problem**: `truncateOutput` in the node-host invoke path uses raw `String.prototype.slice` for tail truncation. When the cut point falls inside a UTF-16 surrogate pair (emoji, CJK extension B+), the result string starts with a lone low surrogate and `isWellFormed()` returns `false`. Ill-formed Unicode can be rejected by strict UTF-8 encoders, JSON transports, and database drivers.

**Solution**: Replace the raw `raw.slice(raw.length - maxChars)` with the existing `sliceUtf16Safe(raw, raw.length - maxChars)` helper from `@openclaw/normalization-core/utf16-slice`. This helper is already tested and used in 30+ files across the repository.

What changed: `src/node-host/invoke.ts` — one call-site in `truncateOutput` (+ import). `src/node-host/invoke.test.ts` — four new unit tests.

What did NOT change: Public API, truncation threshold semantics, output format, any other exec-output path.

Fixes #99981

## Root Cause

`String.prototype.slice` operates on UTF-16 code units without surrogate-pair awareness. One emoji or supplementary-plane character occupies 2 code units (a surrogate pair). Slicing between them splits the pair, producing an ill-formed string.

```
$ node -e "console.log('😀'.repeat(10).slice(15).isWellFormed())"
false
```

## Real behavior proof

Behavior addressed: Tail-truncated exec output becomes ill-formed Unicode when the cut lands inside a surrogate pair.

Real environment tested: Windows 10, Node v22.20.0, openclaw main @ c64a306f90.

Exact steps or command run after this patch:
```
node --import tsx -e "
const { truncateOutput } = require('./src/node-host/invoke.ts');
const r1 = truncateOutput('hello world', 5);
console.log('ASCII:', r1.text);
const r2 = truncateOutput('😀'.repeat(10), 5);
const tail = r2.text.replace('... (truncated) ', '');
console.log('emoji wellFormed:', tail.isWellFormed());
console.log('emoji tail:', JSON.stringify(tail));
"
```

After-fix evidence:
```
ASCII: ... (truncated) world
emoji wellFormed: true
emoji tail: "😀😀"
```

Observed result after the fix: ASCII truncation unchanged. Emoji tail is well-formed Unicode (`isWellFormed() === true`). Unit tests: 6 passed, 3 skipped (platform-conditional), 0 failed.

What was not tested: Full gateway end-to-end with a real node-host sending emoji-laden exec output. The fix is a pure string-safety change — `sliceUtf16Safe` has comprehensive surrogate-pair tests in its own package.

## Risk checklist

- [x] merge-risk: low — single call-site replacement, no control-flow or API change
- [x] Diff ≤ 100 lines (+41/-3 in 2 files)
- [x] No lockfile or CHANGELOG changes
- [x] Reuses existing `sliceUtf16Safe` helper (self-tested), no new dependencies
- [x] 4 new unit tests covering surrogate pair, ASCII, short-text scenarios
- [x] No cross-module impact — `truncateOutput` only called by `buildExecEventPayload`
