### PR TITLE
fix(agents): report plugin approval request rejections

### DIFF
--- a/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
@@ -7085,6 +7085,7 @@ public struct PluginApprovalRequestParams: Codable, Sendable {
     public let alloweddecisions: [String]?
     public let agentid: String?
     public let sessionkey: String?
+    public let approvalreviewerdeviceids: [String]?
     public let turnsourcechannel: String?
     public let turnsourceto: String?
     public let turnsourceaccountid: String?
@@ -7102,6 +7103,7 @@ public struct PluginApprovalRequestParams: Codable, Sendable {
         alloweddecisions: [String]?,
         agentid: String? = nil,
         sessionkey: String?,
+        approvalreviewerdeviceids: [String]?,
         turnsourcechannel: String?,
         turnsourceto: String?,
         turnsourceaccountid: String?,
@@ -7118,6 +7120,7 @@ public struct PluginApprovalRequestParams: Codable, Sendable {
         self.alloweddecisions = alloweddecisions
         self.agentid = agentid
         self.sessionkey = sessionkey
+        self.approvalreviewerdeviceids = approvalreviewerdeviceids
         self.turnsourcechannel = turnsourcechannel
         self.turnsourceto = turnsourceto
         self.turnsourceaccountid = turnsourceaccountid
@@ -7136,6 +7139,7 @@ public struct PluginApprovalRequestParams: Codable, Sendable {
         case alloweddecisions = "allowedDecisions"
         case agentid = "agentId"
         case sessionkey = "sessionKey"
+        case approvalreviewerdeviceids = "approvalReviewerDeviceIds"
         case turnsourcechannel = "turnSourceChannel"
         case turnsourceto = "turnSourceTo"
         case turnsourceaccountid = "turnSourceAccountId"

--- a/src/agents/agent-tools.before-tool-call.e2e.test.ts
+++ b/src/agents/agent-tools.before-tool-call.e2e.test.ts
@@ -7,6 +7,7 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { GatewayClientRequestError } from "../gateway/client.js";
 import {
   onInternalDiagnosticEvent,
   onDiagnosticEvent,
@@ -1573,7 +1574,7 @@ describe("before_tool_call requireApproval handling", () => {
     }
   });
 
-  it("falls back to block on gateway error", async () => {
+  it("falls back to block on gateway transport errors", async () => {
     hookRunner.runBeforeToolCall.mockResolvedValue({
       requireApproval: {
         title: "Gateway down",
@@ -1591,6 +1592,35 @@ describe("before_tool_call requireApproval handling", () => {
 
     expect(result.blocked).toBe(true);
     expect(result).toHaveProperty("reason", "Plugin approval required (gateway unavailable)");
+  });
+
+  it("surfaces plugin approval request rejections instead of reporting gateway unavailable", async () => {
+    hookRunner.runBeforeToolCall.mockResolvedValue({
+      requireApproval: {
+        title: "Approval title that exceeds the gateway schema limit after interpolation",
+        description: "Gateway rejects the request while staying reachable",
+      },
+    });
+
+    mockCallGateway.mockRejectedValueOnce(
+      new GatewayClientRequestError({
+        code: "INVALID_REQUEST",
+        message:
+          "invalid plugin.approval.request params: at /title: must not have more than 80 characters",
+      }),
+    );
+
+    const result = await runBeforeToolCallHook({
+      toolName: "bash",
+      params: {},
+      ctx: { agentId: "main", sessionKey: "main" },
+    });
+
+    expect(result.blocked).toBe(true);
+    expect(result).toHaveProperty(
+      "reason",
+      "Plugin approval request rejected: invalid plugin.approval.request params: at /title: must not have more than 80 characters",
+    );
   });
 
   it("blocks when gateway returns no id", async () => {

--- a/src/agents/agent-tools.before-tool-call.embedded-mode.test.ts
+++ b/src/agents/agent-tools.before-tool-call.embedded-mode.test.ts
@@ -4,6 +4,7 @@
  * plugin hook decisions.
  */
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { GatewayClientRequestError } from "../gateway/client.js";
 import { setEmbeddedMode } from "../infra/embedded-mode.js";
 import {
   EmbeddedPluginApprovalBroker,
@@ -186,6 +187,7 @@ describe("runBeforeToolCallHook — embedded mode approvals", () => {
     const broker = new EmbeddedPluginApprovalBroker();
     setEmbeddedPluginApprovalBroker(broker);
     const onResolution = vi.fn();
+
     runBeforeToolCallMock.mockResolvedValue({
       requireApproval: {
         pluginId: "test-plugin",
@@ -215,6 +217,42 @@ describe("runBeforeToolCallHook — embedded mode approvals", () => {
       deniedReason: "plugin-approval",
     });
     expect(onResolution).toHaveBeenCalledWith(PluginApprovalResolutions.CANCELLED);
+  });
+
+  it("reports gateway approval request rejections distinctly in embedded mode", async () => {
+    setEmbeddedMode(true);
+
+    runBeforeToolCallMock.mockResolvedValue({
+      requireApproval: {
+        pluginId: "test-plugin",
+        title: "Needs approval",
+        description: "Test approval request",
+        severity: "info",
+      },
+      params: { adjusted: true },
+    });
+    mockCallGatewayTool.mockRejectedValueOnce(
+      new GatewayClientRequestError({
+        code: "INVALID_REQUEST",
+        message:
+          "invalid plugin.approval.request params: at /title: must not have more than 80 characters",
+      }),
+    );
+
+    const result = await runBeforeToolCallHook({
+      toolName: "exec",
+      params: { command: "ls" },
+      toolCallId: "call-rejected",
+    });
+
+    expect(result).toMatchObject({
+      blocked: true,
+      kind: "failure",
+      deniedReason: "plugin-approval",
+      reason:
+        "Plugin approval request rejected: invalid plugin.approval.request params: at /title: must not have more than 80 characters",
+      params: { command: "ls" },
+    });
   });
 
   it("reports approval-required tools without opening an approval request", async () => {

--- a/src/agents/agent-tools.before-tool-call.ts
+++ b/src/agents/agent-tools.before-tool-call.ts
@@ -8,6 +8,7 @@ import path from "node:path";
 import { addTimerTimeoutGraceMs } from "@openclaw/normalization-core/number-coercion";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import type { ToolLoopDetectionConfig } from "../config/types.tools.js";
+import { GatewayClientRequestError } from "../gateway/client.js";
 import {
   diagnosticErrorCategory,
   diagnosticHttpStatusCode,
@@ -32,6 +33,7 @@ import {
 } from "../infra/diagnostic-trace-context.js";
 import { isEmbeddedMode } from "../infra/embedded-mode.js";
 import { getEmbeddedPluginApprovalBroker } from "../infra/embedded-plugin-approval-broker.js";
+import { formatErrorMessage } from "../infra/errors.js";
 import {
   describeNativePluginApprovalClientSetup,
   resolveApprovalInitiatingSurfaceState,
@@ -932,10 +934,17 @@ async function requestPluginToolApproval(params: {
       blocked: true,
       kind: "failure",
       deniedReason: "plugin-approval",
-      reason: "Plugin approval required (gateway unavailable)",
+      reason: formatPluginApprovalGatewayFailureReason(err),
       params: params.baseParams,
     };
   }
+}
+
+function formatPluginApprovalGatewayFailureReason(err: unknown): string {
+  if (err instanceof GatewayClientRequestError && err.gatewayCode === "INVALID_REQUEST") {
+    return `Plugin approval request rejected: ${formatErrorMessage(err)}`;
+  }
+  return "Plugin approval required (gateway unavailable)";
 }
 
 /** Resolve a deferred plugin approval request at the later execution boundary. */


### PR DESCRIPTION
## Summary

- Distinguish gateway request rejections from transport/unavailable failures in the plugin approval before_tool_call path.
- Surface `INVALID_REQUEST` details to the agent as `Plugin approval request rejected: ...` instead of the misleading gateway-unavailable fallback.
- Add regression coverage for both embedded-mode and full before_tool_call approval handling while preserving the transport-error fallback.

## Issue/Motivation

Fixes #100212.

A reachable gateway can reject `plugin.approval.request` payloads, for example when an approval title exceeds the schema's 80-character cap. Before this change, the catch block reported every non-abort request failure as `Plugin approval required (gateway unavailable)`, which points operators and agents at the wrong system even when the gateway actively returned `INVALID_REQUEST`.

## Changes

- Added a small formatter for plugin approval gateway failures.
- When the caught error is `GatewayClientRequestError` with `gatewayCode === "INVALID_REQUEST"`, the returned tool-block reason now includes the sanitized request rejection message.
- Other errors still use the existing `Plugin approval required (gateway unavailable)` reason.
- Added regression tests for request rejection handling in embedded and full before_tool_call approval flows.

## Testing

- `node scripts/run-vitest.mjs run src/agents/agent-tools.before-tool-call.embedded-mode.test.ts src/agents/agent-tools.before-tool-call.e2e.test.ts`
- `node scripts/run-vitest.mjs run --config test/vitest/vitest.unit.config.ts src/mcp/plugin-tools-serve.test.ts`
- `git diff --check HEAD~1..HEAD`
- Diff secret scan over `git diff HEAD~1..HEAD`

## What Problem This Solves

Plugin approval request validation failures are no longer misreported as gateway outages. Agents and operators now see that the approval request was rejected, plus the relevant validation message, so they can fix the plugin-provided approval payload instead of debugging a healthy gateway or target app.

## Evidence

- `node scripts/run-vitest.mjs run src/agents/agent-tools.before-tool-call.embedded-mode.test.ts src/agents/agent-tools.before-tool-call.e2e.test.ts` passed: 14 embedded-mode tests and 59 before_tool_call e2e tests.
- `node scripts/run-vitest.mjs run --config test/vitest/vitest.unit.config.ts src/mcp/plugin-tools-serve.test.ts` passed: 9 tests.
- `git diff --check HEAD~1..HEAD` passed.
- Diff secret scan over `git diff HEAD~1..HEAD` passed.
- Duplicate check before publishing found no open or merged PR referencing #100212, `Plugin approval request rejected`, or the `plugin.approval.request` gateway-unavailable rejection path.
