### PR TITLE
fix: report rejected plugin approval requests accurately

### DIFF
--- a/src/agents/agent-tools.before-tool-call.e2e.test.ts
+++ b/src/agents/agent-tools.before-tool-call.e2e.test.ts
@@ -7,6 +7,7 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { GatewayClientRequestError } from "../gateway/client.js";
 import {
   onInternalDiagnosticEvent,
   onDiagnosticEvent,
@@ -1573,7 +1574,7 @@ describe("before_tool_call requireApproval handling", () => {
     }
   });
 
-  it("falls back to block on gateway error", async () => {
+  it("falls back to block on gateway transport errors", async () => {
     hookRunner.runBeforeToolCall.mockResolvedValue({
       requireApproval: {
         title: "Gateway down",
@@ -1591,6 +1592,35 @@ describe("before_tool_call requireApproval handling", () => {
 
     expect(result.blocked).toBe(true);
     expect(result).toHaveProperty("reason", "Plugin approval required (gateway unavailable)");
+  });
+
+  it("surfaces plugin approval request rejections instead of reporting gateway unavailable", async () => {
+    hookRunner.runBeforeToolCall.mockResolvedValue({
+      requireApproval: {
+        title: "Overlong approval title",
+        description: "Gateway rejects invalid approval params",
+      },
+    });
+
+    mockCallGateway.mockRejectedValueOnce(
+      new GatewayClientRequestError({
+        code: "INVALID_REQUEST",
+        message:
+          "invalid plugin.approval.request params: at /title: must not have more than 80 characters",
+      }),
+    );
+
+    const result = await runBeforeToolCallHook({
+      toolName: "bash",
+      params: {},
+      ctx: { agentId: "main", sessionKey: "main" },
+    });
+
+    expect(result.blocked).toBe(true);
+    expect(result).toHaveProperty(
+      "reason",
+      "Plugin approval request rejected: invalid plugin.approval.request params: at /title: must not have more than 80 characters",
+    );
   });
 
   it("blocks when gateway returns no id", async () => {

--- a/src/agents/agent-tools.before-tool-call.embedded-mode.test.ts
+++ b/src/agents/agent-tools.before-tool-call.embedded-mode.test.ts
@@ -4,6 +4,7 @@
  * plugin hook decisions.
  */
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { GatewayClientRequestError } from "../gateway/client.js";
 import { setEmbeddedMode } from "../infra/embedded-mode.js";
 import {
   getGlobalHookRunner,
@@ -144,6 +145,44 @@ describe("runBeforeToolCallHook — embedded mode approvals", () => {
       { expectFinal: false },
     );
     expect(onResolution).toHaveBeenCalledTimes(1);
+    expect(onResolution).toHaveBeenCalledWith(PluginApprovalResolutions.CANCELLED);
+  });
+
+  it("reports gateway approval request rejections distinctly in embedded mode", async () => {
+    setEmbeddedMode(true);
+    const onResolution = vi.fn();
+
+    runBeforeToolCallMock.mockResolvedValue({
+      requireApproval: {
+        pluginId: "test-plugin",
+        title: "Needs approval",
+        description: "Test approval request",
+        severity: "info",
+        onResolution,
+      },
+    });
+    mockCallGatewayTool.mockRejectedValueOnce(
+      new GatewayClientRequestError({
+        code: "INVALID_REQUEST",
+        message:
+          "invalid plugin.approval.request params: at /title: must not have more than 80 characters",
+      }),
+    );
+
+    const result = await runBeforeToolCallHook({
+      toolName: "exec",
+      params: { command: "ls" },
+      toolCallId: "call-1",
+    });
+
+    expect(result).toEqual({
+      blocked: true,
+      kind: "failure",
+      deniedReason: "plugin-approval",
+      reason:
+        "Plugin approval request rejected: invalid plugin.approval.request params: at /title: must not have more than 80 characters",
+      params: { command: "ls" },
+    });
     expect(onResolution).toHaveBeenCalledWith(PluginApprovalResolutions.CANCELLED);
   });
 

--- a/src/agents/agent-tools.before-tool-call.ts
+++ b/src/agents/agent-tools.before-tool-call.ts
@@ -8,6 +8,7 @@ import path from "node:path";
 import { addTimerTimeoutGraceMs } from "@openclaw/normalization-core/number-coercion";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import type { ToolLoopDetectionConfig } from "../config/types.tools.js";
+import { GatewayClientRequestError } from "../gateway/client.js";
 import {
   diagnosticErrorCategory,
   diagnosticHttpStatusCode,
@@ -30,6 +31,7 @@ import {
   freezeDiagnosticTraceContext,
   type DiagnosticTraceContext,
 } from "../infra/diagnostic-trace-context.js";
+import { formatErrorMessage } from "../infra/errors.js";
 import {
   describeNativePluginApprovalClientSetup,
   resolveApprovalInitiatingSurfaceState,
@@ -684,6 +686,13 @@ function buildPluginApprovalFailureReason(params: {
   return `${params.fallbackReason}\n\n${setupText}`;
 }
 
+function buildPluginApprovalGatewayFailureReason(err: unknown): string {
+  if (err instanceof GatewayClientRequestError && err.gatewayCode === "INVALID_REQUEST") {
+    return `Plugin approval request rejected: ${formatErrorMessage(err)}`;
+  }
+  return "Plugin approval required (gateway unavailable)";
+}
+
 async function requestPluginToolApproval(params: {
   approval: PluginApprovalRequest;
   toolName: string;
@@ -861,7 +870,7 @@ async function requestPluginToolApproval(params: {
       blocked: true,
       kind: "failure",
       deniedReason: "plugin-approval",
-      reason: "Plugin approval required (gateway unavailable)",
+      reason: buildPluginApprovalGatewayFailureReason(err),
       params: params.baseParams,
     };
   }


### PR DESCRIPTION
Closes #100212.

## What Problem This Solves

Fixes an issue where plugin approval requests rejected by the gateway, such as schema validation failures, were reported to the agent as `gateway unavailable` even though the gateway was healthy.

## Why This Change Was Made

The approval handler now distinguishes gateway `INVALID_REQUEST` rejections from transport-style gateway failures and returns the rejected request message to the agent. Generic gateway failures keep the existing unavailable wording.

## User Impact

Agents and operators now see the actual plugin approval validation problem instead of being sent toward gateway availability debugging.

## Evidence

Live gateway/plugin approval proof against a temporary loopback gateway and the production `before_tool_call` path:

```text
gateway rejected invalid request: true
gateway error code: INVALID_REQUEST
agent-facing reason: Plugin approval request rejected: invalid plugin.approval.request params: at /title: must not have more than 80 characters
contains gateway-unavailable wording: false
```

Focused approval, gateway, and MCP Vitest shards passed locally. Targeted oxfmt, oxlint, and whitespace checks passed.

AI-assisted contribution.
