### PR TITLE
fix(agents): send session_id affinity header to ChatGPT Responses backend

### DIFF
--- a/packages/ai/src/providers/openai-chatgpt-responses.ts
+++ b/packages/ai/src/providers/openai-chatgpt-responses.ts
@@ -275,6 +275,10 @@ export const streamOpenAICodexResponses: StreamFunction<
       if (nextBody !== undefined) {
         body = nextBody as RequestBody;
       }
+      // NOTE: when options.sessionId is absent, this falls back to a fresh random id
+      // per request, which forfeits session-affinity routing on the WS transport (the
+      // backend routes by session_id/x-client-request-id). Left as-is for this fix;
+      // see the SSE-path session_id addition in buildOpenAIClientHeaders (agents/openai-transport-stream.ts).
       const websocketRequestId = options?.sessionId || createCodexRequestId();
       const sseHeaders = buildSSEHeaders(
         model.headers,

--- a/src/agents/openai-transport-stream.test.ts
+++ b/src/agents/openai-transport-stream.test.ts
@@ -1061,6 +1061,31 @@ describe("openai transport stream", () => {
     expect(headers.session_id).toBe("caller-supplied-session");
   });
 
+  it("does not add a generated session_id header when the caller supplies a differently-cased one", () => {
+    const headers = testing.buildOpenAIClientHeaders(
+      {
+        id: "gpt-5.5",
+        name: "GPT-5.5",
+        api: "openai-chatgpt-responses",
+        provider: "openai",
+        baseUrl: "https://chatgpt.com/backend-api",
+        headers: {},
+        reasoning: true,
+        input: ["text"],
+        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+        contextWindow: 200000,
+        maxTokens: 8192,
+      } satisfies Model<"openai-chatgpt-responses">,
+      { systemPrompt: "", messages: [] } as never,
+      { Session_ID: "caller-supplied-session" },
+      undefined,
+      "session-abc-123",
+    );
+
+    expect(headers.Session_ID).toBe("caller-supplied-session");
+    expect(headers.session_id).toBeUndefined();
+  });
+
   it("adds SSE Accept only to native ChatGPT/Codex Responses stream requests", () => {
     const codexModel = {
       id: "gpt-5.5",

--- a/src/agents/openai-transport-stream.test.ts
+++ b/src/agents/openai-transport-stream.test.ts
@@ -968,6 +968,99 @@ describe("openai transport stream", () => {
     expect(headers.accept).toBeUndefined();
   });
 
+  it("adds session_id header for the native ChatGPT/Codex Responses transport when a session id is present", () => {
+    const headers = testing.buildOpenAIClientHeaders(
+      {
+        id: "gpt-5.5",
+        name: "GPT-5.5",
+        api: "openai-chatgpt-responses",
+        provider: "openai",
+        baseUrl: "https://chatgpt.com/backend-api",
+        headers: {},
+        reasoning: true,
+        input: ["text"],
+        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+        contextWindow: 200000,
+        maxTokens: 8192,
+      } satisfies Model<"openai-chatgpt-responses">,
+      { systemPrompt: "", messages: [] } as never,
+      undefined,
+      undefined,
+      "session-abc-123",
+    );
+
+    expect(headers.session_id).toBe("session-abc-123");
+  });
+
+  it("omits the session_id header for the native ChatGPT/Codex Responses transport when no session id is available", () => {
+    const headers = testing.buildOpenAIClientHeaders(
+      {
+        id: "gpt-5.5",
+        name: "GPT-5.5",
+        api: "openai-chatgpt-responses",
+        provider: "openai",
+        baseUrl: "https://chatgpt.com/backend-api",
+        headers: {},
+        reasoning: true,
+        input: ["text"],
+        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+        contextWindow: 200000,
+        maxTokens: 8192,
+      } satisfies Model<"openai-chatgpt-responses">,
+      { systemPrompt: "", messages: [] } as never,
+    );
+
+    expect(headers.session_id).toBeUndefined();
+  });
+
+  it("does not add a session_id header for non-native OpenAI Responses transports even when a session id is present", () => {
+    const headers = testing.buildOpenAIClientHeaders(
+      {
+        id: "gpt-5.4",
+        name: "GPT-5.4",
+        api: "openai-responses",
+        provider: "openai",
+        baseUrl: "https://api.openai.com/v1",
+        headers: {},
+        reasoning: true,
+        input: ["text"],
+        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+        contextWindow: 200000,
+        maxTokens: 8192,
+      } satisfies Model<"openai-responses">,
+      { systemPrompt: "", messages: [] } as never,
+      undefined,
+      undefined,
+      "session-abc-123",
+    );
+
+    expect(headers.session_id).toBeUndefined();
+  });
+
+  it("does not overwrite an existing session_id header on the native ChatGPT/Codex Responses transport", () => {
+    const headers = testing.buildOpenAIClientHeaders(
+      {
+        id: "gpt-5.5",
+        name: "GPT-5.5",
+        api: "openai-chatgpt-responses",
+        provider: "openai",
+        baseUrl: "https://chatgpt.com/backend-api",
+        headers: {},
+        reasoning: true,
+        input: ["text"],
+        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+        contextWindow: 200000,
+        maxTokens: 8192,
+      } satisfies Model<"openai-chatgpt-responses">,
+      { systemPrompt: "", messages: [] } as never,
+      { session_id: "caller-supplied-session" },
+      undefined,
+      "session-abc-123",
+    );
+
+    expect(headers.session_id).toBe("caller-supplied-session");
+  });
+
   it("adds SSE Accept only to native ChatGPT/Codex Responses stream requests", () => {
     const codexModel = {
       id: "gpt-5.5",

--- a/src/agents/openai-transport-stream.ts
+++ b/src/agents/openai-transport-stream.ts
@@ -1910,8 +1910,9 @@ function buildOpenAIClientHeaders(
     precedence: "caller-wins",
   }).headers;
   const resolvedHeaders = headers ?? {};
-  // The ChatGPT Responses backend routes requests by session_id; without it each
-  // request can land on an arbitrary machine and the provider prompt cache misses.
+  // This header routes ChatGPT Responses session affinity; without it requests land
+  // on arbitrary machines and prompt cache misses. codex-rs sends "session-id"
+  // (codex-rs/codex-api/src/requests/headers.rs), but backend accepts "session_id"; align with packages/ai openai-chatgpt-responses.
   if (
     sessionId &&
     !Object.keys(resolvedHeaders).some(

--- a/src/agents/openai-transport-stream.ts
+++ b/src/agents/openai-transport-stream.ts
@@ -45,6 +45,7 @@ import {
   stripSystemPromptCacheBoundary,
 } from "@openclaw/ai/internal/shared";
 import { isRecord } from "@openclaw/normalization-core/record-coerce";
+import { normalizeLowercaseStringOrEmpty } from "@openclaw/normalization-core/string-coerce";
 import { uniqueStrings } from "@openclaw/normalization-core/string-normalization";
 import OpenAI, { AzureOpenAI } from "openai";
 import type { ChatCompletionChunk } from "openai/resources/chat/completions.js";
@@ -1913,7 +1914,9 @@ function buildOpenAIClientHeaders(
   // request can land on an arbitrary machine and the provider prompt cache misses.
   if (
     sessionId &&
-    resolvedHeaders.session_id === undefined &&
+    !Object.keys(resolvedHeaders).some(
+      (key) => normalizeLowercaseStringOrEmpty(key) === "session_id",
+    ) &&
     usesNativeOpenAICodexResponsesBackend(model)
   ) {
     resolvedHeaders.session_id = sessionId;

--- a/src/agents/openai-transport-stream.ts
+++ b/src/agents/openai-transport-stream.ts
@@ -1885,6 +1885,7 @@ function buildOpenAIClientHeaders(
   context: Context,
   optionHeaders?: Record<string, string>,
   turnHeaders?: Record<string, string>,
+  sessionId?: string,
 ): Record<string, string> {
   const providerHeaders = { ...model.headers };
   if (model.provider === "github-copilot") {
@@ -1907,7 +1908,17 @@ function buildOpenAIClientHeaders(
     callerHeaders: Object.keys(callerHeaders).length > 0 ? callerHeaders : undefined,
     precedence: "caller-wins",
   }).headers;
-  return headers ?? {};
+  const resolvedHeaders = headers ?? {};
+  // The ChatGPT Responses backend routes requests by session_id; without it each
+  // request can land on an arbitrary machine and the provider prompt cache misses.
+  if (
+    sessionId &&
+    resolvedHeaders.session_id === undefined &&
+    usesNativeOpenAICodexResponsesBackend(model)
+  ) {
+    resolvedHeaders.session_id = sessionId;
+  }
+  return resolvedHeaders;
 }
 
 function resolveProviderTransportTurnState(
@@ -1975,12 +1986,13 @@ function createOpenAIResponsesClient(
   apiKey: string,
   optionHeaders?: Record<string, string>,
   turnHeaders?: Record<string, string>,
+  sessionId?: string,
 ) {
   return new OpenAI({
     apiKey,
     baseURL: model.baseUrl,
     dangerouslyAllowBrowser: true,
-    defaultHeaders: buildOpenAIClientHeaders(model, context, optionHeaders, turnHeaders),
+    defaultHeaders: buildOpenAIClientHeaders(model, context, optionHeaders, turnHeaders, sessionId),
     fetch: buildGuardedModelFetch(model),
     ...buildOpenAISdkClientOptions(model),
   });
@@ -2024,6 +2036,7 @@ export function createOpenAIResponsesTransportStreamFn(): StreamFn {
           apiKey,
           options?.headers,
           turnState?.headers,
+          options?.sessionId,
         );
         let params = buildOpenAIResponsesParams(
           model,


### PR DESCRIPTION
Fixes #100232

### Problem
The agent-runtime OpenAI Responses transport (`createOpenAIResponsesClient` →
`buildOpenAIClientHeaders`) never sends a `session_id` header. The ChatGPT backend
(chatgpt.com/backend-api) routes requests by `session_id` — codex-cli sends it on every
request (thread id), and OpenClaw's own SSE/WS provider path (`openai-chatgpt-responses.ts`)
already sets it. Without it, each HTTP request from a session can land on a different
backend machine, whose local prompt cache doesn't hold the session's prefix.

Observed on live traffic (gpt-5.5, ChatGPT OAuth): cold-write streaks and *interleaved cache
lineages* — `cached_tokens` alternating between two values (e.g. ~28k and ~57k) across
consecutive turns of one session, i.e. two machines each holding a different partial prefix.
Aggregate TRUE cache hit rate ~47-56% vs codex-cli's ~92-96% on the same account/model.

### Fix
`buildOpenAIClientHeaders()` takes an optional `sessionId`; when
`usesNativeOpenAICodexResponsesBackend(model)` and no `session_id` was set by
caller/turn headers (caller-wins preserved), it adds `session_id: <sessionId>`. Threaded
from `options?.sessionId` at the single Responses-client call site. Scoped strictly to the
native ChatGPT/Codex backend — api.openai.com and proxy endpoints are untouched.

### Measurements (12 identical prompts per leg, fresh session each, same account/hour)
| Config | TRUE hit% = cache_read/(cache_read+input) |
|---|---|
| stock | 56.0% |
| + this fix (as a dist hot-patch) | **81.8%** |
(For reference: codex-cli on the same account ~92-96%; remaining gap is its
`previous_response_id`+delta continuation, out of scope here.)

A separate controlled A/B (identical tool-call sequences, same session shape) comparing
stock vs. the combined local fix set measured **45.9% → 92.0%** TRUE hit rate — 6.5x fewer
uncached input tokens for identical work (stock session `3017333e`: 466,088 uncached input
tokens; fixed session `b97d343e`: 71,478). This isolates the session_id header's own
contribution (56.0% → 81.8%, table above) from an additional byte-stable-prefix fix tracked
separately in a follow-up PR.

Also adds a NOTE comment (no behavior change) at the WS `websocketRequestId` fallback in
`openai-chatgpt-responses.ts`, which mints a fresh random id per request when
`options.sessionId` is absent — forfeiting affinity on that transport; worth a follow-up.

### Tests
4 unit tests: header present iff native backend + sessionId; absent without sessionId;
absent for `openai-responses`/api.openai.com; caller-supplied `session_id` not overwritten.
Typecheck (`run-tsgo.mjs -p tsconfig.core.json`) clean. (Vitest currently fails to launch
on this dev box for unrelated toolchain reasons — rolldown native binding; tests were
written against the existing patterns in `openai-transport-stream.test.ts`.)

Reported-by: @Peetiegonzalez
cc: @Peetiegonzalez

## What Problem This Solves

The ChatGPT Responses backend (chatgpt.com/backend-api) routes HTTP requests by `session_id`.
`buildOpenAIClientHeaders()` never sent one, so consecutive requests from the same OpenClaw
session could land on different backend machines, each holding a different partial prompt-cache
prefix — visible as interleaved cache lineages and cold-write streaks on live traffic. codex-cli
(external reference client) and OpenClaw's own WS/SSE path already send this header; only the
HTTP Responses transport used by the `openclaw` agent runtime was missing it. See "Problem" above
for the full mechanism and code path.

## Evidence

Measured, not estimated: 12 identical prompts per leg, fresh session each, same account and same
hour, ChatGPT-OAuth gpt-5.5, `TRUE hit% = cache_read / (cache_read + input)` computed from each
call's provider `usage` fields.

- Single-variable isolation (session_id header only, all else equal): **56.0% -> 81.8%** TRUE hit
  rate (+25.8 points), cache lineage streaks disappear.
- Combined with the companion byte-stability fix (#100272), same protocol: **45.9% -> 92.0%**
  TRUE hit rate, 6.5x fewer uncached input tokens for identical 12-turn work (466,088 -> 71,478
  uncached tokens).
- Full per-call tables, regression timeline (traced to a runtime-pin config change, not a code
  regression), and cross-provider blast-radius analysis:
  https://raw.githubusercontent.com/Marvinthebored/openclaw/proof-assets-session-affinity-header/pr-proof/100233-session-affinity-header/EVIDENCE.md
