### PR TITLE
fix(ci): run Mantis Codex proof on Node 24

### DIFF
--- a/.github/workflows/mantis-telegram-desktop-proof.yml
+++ b/.github/workflows/mantis-telegram-desktop-proof.yml
@@ -445,7 +445,7 @@ jobs:
           sudo chown -R codex:codex "$GITHUB_WORKSPACE"
 
       - name: Run Codex Mantis Telegram agent
-        uses: openai/codex-action@e0fdf01220eb9a88167c4898839d273e3f2609d1
+        uses: openai/codex-action@52fe01ec70a42f454c9d2ebd47598f9fd6893d56
         env:
           BASELINE_REF: ${{ needs.resolve_request.outputs.baseline_ref }}
           BASELINE_SHA: ${{ needs.validate_refs.outputs.baseline_revision }}


### PR DESCRIPTION
﻿Fixes #100235.

## What Problem This Solves

Fixes an issue where the Mantis Telegram Desktop Proof workflow could install Node 24 for the job but then launch the Codex proof agent under Node 20 through the pinned `openai/codex-action`. Current OpenClaw requires Node `>=22.19.0 <23 || >=23.11.0`, and the observed proof run failed before OpenClaw became ready because pnpm/current repo paths require Node `22.13+` and `node:sqlite`.

This made Telegram-visible PRs look proof-failed for an infrastructure/runtime reason instead of the behavior being reviewed.

## Why This Change Was Made

The Mantis workflow already sets `NODE_VERSION: 24.x` and runs `.github/actions/setup-node-env`, but the pinned `openai/codex-action@e0fdf01220eb9a88167c4898839d273e3f2609d1` contains its own internal `actions/setup-node` step with `node-version: "20"`. This updates that action pin to the v1.11 commit `52fe01ec70a42f454c9d2ebd47598f9fd6893d56`, whose action metadata uses Node 24 internally.

The PR intentionally changes only the Mantis Telegram Desktop Proof action pin. It does not change proof prompts, Telegram credentials, Crabbox behavior, or OpenClaw runtime code.

## User Impact

Maintainers and contributors should get Mantis Telegram proof results that reflect the OpenClaw/Telegram behavior under test rather than a stale Codex action Node 20 runtime. PRs that need Telegram-visible proof are less likely to be blocked by a toolchain mismatch before any visual artifact can be captured.

## Evidence

Observed failing run: `Mantis Telegram Desktop Proof` run `28727669615`, job `85187883914`, head SHA `21b5f455dcf1681d73ffbfd593b9fbada2d0dc81`.

Before this patch, the same run showed the outer workflow on Node 24 and the Codex action falling back to Node 20:

```text
Using active Node 24.13.0 at /opt/hostedtoolcache/node/24.13.0/x64/bin/node
Found in cache @ /opt/hostedtoolcache/node/20.20.0/x64
node: v20.20.0
Running: CODEX_HOME=/tmp/mantis-codex-home-28727669615 sudo -u codex -- /opt/hostedtoolcache/node/20.20.0/x64/bin/codex exec ...
warn: This version of pnpm requires at least Node.js v22.13
warn: The current version of Node.js is v20.20.0
Mantis Telegram desktop proof failed: comparison=fail.
```

Upstream action metadata checked:

- `openai/codex-action@e0fdf01220eb9a88167c4898839d273e3f2609d1` uses internal `actions/setup-node` with `node-version: "20"`.
- `openai/codex-action@52fe01ec70a42f454c9d2ebd47598f9fd6893d56` (v1.11) uses internal `actions/setup-node` with `node-version: "24"`.

Local checks on this branch:

```shell
git diff --check HEAD~1..HEAD
```

Result: clean.

```shell
rg -n "openai/codex-action@|e0fdf01220eb9a88167c4898839d273e3f2609d1|52fe01ec70a42f454c9d2ebd47598f9fd6893d56" .github/workflows/mantis-telegram-desktop-proof.yml
```

Result: only the new `openai/codex-action@52fe01ec70a42f454c9d2ebd47598f9fd6893d56` pin remains.

```powershell
$env:PYTHONUTF8='1'; python .agents\skills\autoreview\scripts\autoreview --mode local
```

Result: `autoreview clean: no accepted/actionable findings reported`; overall patch correctness `0.9`.

Not tested: I cannot rerun the private Mantis Telegram Desktop Proof lane from this fork because it depends on repository secrets/protected proof infrastructure. The after-fix evidence here is the pinned action metadata showing the internal Node runtime moves from Node 20 to Node 24, plus the focused workflow diff and clean review.
