### PR TITLE
fix(ui): hide duplicate terminal caret

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- **Control UI terminal cursor:** hide the browser-native contenteditable caret so the integrated terminal shows only its canvas-rendered cursor.
 - **macOS SSH tunnels:** resolve user-installed SSH `ProxyCommand` helpers through the app's managed PATH while preserving inherited connection environment, so remote aliases work after Finder and sanitized-script launches.
 - **Control UI terminal rendering:** adopt the shared `@openclaw/libterminal` browser lifecycle and add Nerd Font fallbacks so icon-enabled shell listings render their glyphs when a compatible local font is installed.
 - **Slack transcript history:** let Codex app-server own its persisted assistant replies so Slack does not append redundant delivery-mirror rows, while the Control UI keeps legacy duplicate mirrors hidden.

--- a/ui/src/components/terminal/terminal-panel.test.ts
+++ b/ui/src/components/terminal/terminal-panel.test.ts
@@ -4,6 +4,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import type { TerminalGatewayClient } from "./terminal-connection.ts";
 
 type CreateOptions = {
+  parent: HTMLElement;
   terminalOptions?: { fontFamily?: string };
   onData?: (bytes: Uint8Array) => void;
   onResize?: (size: { columns: number; rows: number }) => void;
@@ -69,6 +70,7 @@ describe("OpenClawTerminalPanel", () => {
       });
     });
     expect(createOptions?.terminalOptions?.fontFamily).toContain("MesloLGLDZ Nerd Font Mono");
+    expect(getComputedStyle(createOptions!.parent).caretColor).toBe("rgba(0, 0, 0, 0)");
     await vi.waitFor(() => {
       expect(requests).toContainEqual({
         method: "terminal.resize",

--- a/ui/src/components/terminal/terminal-panel.ts
+++ b/ui/src/components/terminal/terminal-panel.ts
@@ -956,6 +956,9 @@ export class OpenClawTerminalPanel extends LitElement {
       position: absolute;
       inset: 0;
       padding: 6px 8px;
+      /* ghostty-web focuses this contenteditable host while drawing its own
+         cursor on canvas; hide the otherwise duplicated browser caret. */
+      caret-color: transparent;
     }
     .tp-empty,
     .tp-error {


### PR DESCRIPTION
## Summary

- suppress Chrome's native contenteditable caret in the integrated terminal host
- preserve Ghostty's canvas-rendered terminal cursor and input/focus behavior
- add a computed-style regression assertion and changelog entry

## Root cause

Ghostty focuses a `contenteditable` host while rendering the PTY cursor on a canvas inside it. Chrome therefore painted a second native caret at the host's top-left corner.

## Testing

- `pnpm test ui/src/components/terminal/terminal-panel.test.ts`
- `pnpm ui:build`
- local `pnpm check:changed` lanes for the touched files
- Codex autoreview: clean, no actionable findings
