### PR TITLE
fix: surface actual gateway rejection reason to agent instead of hardcoded 'unavailable' (fixes #100212)

### DIFF
--- a/src/agents/agent-tools.before-tool-call.e2e.test.ts
+++ b/src/agents/agent-tools.before-tool-call.e2e.test.ts
@@ -7,6 +7,7 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { GatewayClientRequestError } from "../gateway/client.js";
 import {
   onInternalDiagnosticEvent,
   onDiagnosticEvent,
@@ -1591,6 +1592,35 @@ describe("before_tool_call requireApproval handling", () => {
 
     expect(result.blocked).toBe(true);
     expect(result).toHaveProperty("reason", "Plugin approval required (gateway unavailable)");
+  });
+
+  it("falls back to block with actual error on gateway rejection", async () => {
+    hookRunner.runBeforeToolCall.mockResolvedValue({
+      requireApproval: {
+        title: "Gateway rejection",
+        description: "Gateway will reject",
+      },
+    });
+
+    mockCallGateway.mockRejectedValueOnce(
+      new GatewayClientRequestError({
+        code: "INVALID_REQUEST",
+        message:
+          "invalid plugin.approval.request params: at /title: must not have more than 80 characters",
+      }),
+    );
+
+    const result = await runBeforeToolCallHook({
+      toolName: "bash",
+      params: {},
+      ctx: { agentId: "main", sessionKey: "main" },
+    });
+
+    expect(result.blocked).toBe(true);
+    expect(result).toHaveProperty(
+      "reason",
+      "Plugin approval request failed: invalid plugin.approval.request params: at /title: must not have more than 80 characters",
+    );
   });
 
   it("blocks when gateway returns no id", async () => {

--- a/src/agents/agent-tools.before-tool-call.ts
+++ b/src/agents/agent-tools.before-tool-call.ts
@@ -89,6 +89,7 @@ export {
   isToolWrappedWithBeforeToolCallHook,
   setBeforeToolCallDiagnosticsEnabled,
 } from "./before-tool-call-metadata.js";
+import { GatewayClientRequestError } from "../gateway/client.js";
 import { copyChannelAgentToolMeta, getChannelAgentToolMeta } from "./channel-tools.js";
 import {
   getCodeModeExecBeforeHookMetadata,
@@ -857,11 +858,15 @@ async function requestPluginToolApproval(params: {
       };
     }
     log.warn(`plugin approval gateway request failed; blocking tool call: ${String(err)}`);
+    const reason =
+      err instanceof GatewayClientRequestError && err.gatewayCode !== "UNAVAILABLE"
+        ? `Plugin approval request failed: ${err.message}`
+        : "Plugin approval required (gateway unavailable)";
     return {
       blocked: true,
       kind: "failure",
       deniedReason: "plugin-approval",
-      reason: "Plugin approval required (gateway unavailable)",
+      reason,
       params: params.baseParams,
     };
   }


### PR DESCRIPTION
## What Problem This Solves

When the gateway **rejects** a `plugin.approval.request` (e.g. schema validation → `INVALID_REQUEST`), the `before_tool_call` approval handler catches the error and returns a **hardcoded** reason to the agent:

> `Plugin approval required (gateway unavailable)`

But the gateway is reachable and healthy — it *actively rejected* the request. The actual error is only `log.warn`'d and never surfaced, so the agent (and any operator reading the transcript) is told the gateway is **down** when it isn't. This points debugging in exactly the wrong direction.

## Why This Change Was Made

The catch block in `requestPluginToolApproval` (line 864) hardcoded `"Plugin approval required (gateway unavailable)"` for all errors, ignoring the actual `GatewayClientRequestError.gatewayCode` and `message` that distinguish rejections from connectivity failures.

This fix checks if the error is a `GatewayClientRequestError` with a non-`UNAVAILABLE` code (e.g. `INVALID_REQUEST`, `PERMISSION_DENIED`) and surfaces the actual error message to the agent. Generic errors and true `UNAVAILABLE` cases still return the original message.

## User Impact

- Agents receiving gateway rejections now see the actual error (e.g. "invalid plugin.approval.request params: at /title: must not have more than 80 characters") instead of misleading "gateway unavailable"
- Operators debugging approval failures can identify the real cause from the agent transcript without reading raw gateway logs
- No behavior change for actual gateway connectivity failures

## Evidence

## Real behavior proof

- **Behavior addressed:** Plugin approval gateway rejection reason is surfaced to agent
- **Environment tested:** OpenClaw 2026.6.11 (8b229a9), macOS, local build
- **Steps run after the patch:**
  1. Built the project with `pnpm build`
  2. Verified the fix is present in the dist bundle: `grep "Plugin approval request failed.*err.message" dist/agent-tools.before-tool-call-*.js`
  3. Ran the existing test suite plus new test: `node scripts/run-vitest.mjs run src/agents/agent-tools.before-tool-call.e2e.test.ts`
  4. Simulated the fix behavior with `node -e` to demonstrate the error message differentiation

- **Evidence after fix:**
```
=== Fix Behavior Proof ===

Test 1 - Gateway rejection (INVALID_REQUEST):
  gatewayCode: INVALID_REQUEST
  Agent reason: Plugin approval request failed: invalid plugin.approval.request params: at /title: must not have more than 80 characters

Test 2 - Gateway unavailable (UNAVAILABLE):
  gatewayCode: UNAVAILABLE
  Agent reason: Plugin approval required (gateway unavailable)

Test 3 - Generic error:
  Agent reason: Plugin approval required (gateway unavailable)

Summary:
  Before fix: All cases returned "Plugin approval required (gateway unavailable)"
  After fix: Gateway rejections (INVALID_REQUEST, etc.) return the actual error
```

- **Observed result after fix:** Gateway rejection errors now surface the actual error message (e.g. "invalid plugin.approval.request params: at /title: must not have more than 80 characters") instead of hardcoded "gateway unavailable"
- **What was not tested:** Live gateway interaction with a real plugin approval rejection (requires running gateway + plugin with approval hook)

## Changes Made

- `src/agents/agent-tools.before-tool-call.ts`: Import `GatewayClientRequestError`, differentiate gateway rejections from connectivity failures in catch block
- `src/agents/agent-tools.before-tool-call.e2e.test.ts`: Add test for `INVALID_REQUEST` rejection reason surfacing

- [x] AI-assisted (Hermes Agent)
