### PR TITLE
fix(ui): hide idle composer scrollbar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- **Control UI composer scrollbar:** show the message-field scrollbar only when the draft actually overflows its autosized height.
 - **Control UI terminal cursor:** hide the browser-native contenteditable caret so the integrated terminal shows only its canvas-rendered cursor.
 - **macOS SSH tunnels:** resolve user-installed SSH `ProxyCommand` helpers through the app's managed PATH while preserving inherited connection environment, so remote aliases work after Finder and sanitized-script launches.
 - **Control UI OpenAI speed picker:** show only Standard and Fast choices for OpenAI models.

--- a/ui/src/pages/chat/chat-view.test.ts
+++ b/ui/src/pages/chat/chat-view.test.ts
@@ -1961,6 +1961,92 @@ describe("chat composer IME composition", () => {
   });
 });
 
+describe("chat composer sizing", () => {
+  it("sizes restored drafts after the rendered value is committed", async () => {
+    const container = renderChatView({ draft: "A restored long draft" });
+    const textarea = requireElement(
+      container,
+      ".agent-chat__composer-combobox > textarea",
+      "composer textarea",
+    ) as HTMLTextAreaElement;
+    Object.defineProperties(textarea, {
+      scrollHeight: { configurable: true, value: 180 },
+      clientHeight: { configurable: true, value: 150 },
+    });
+    document.body.append(container);
+
+    await Promise.resolve();
+
+    expect(textarea.style.height).toBe("150px");
+    expect(textarea.style.overflowY).toBe("auto");
+    container.remove();
+  });
+
+  it("shows the textarea scrollbar only when the draft overflows", () => {
+    const container = renderChatView({});
+    const textarea = requireElement(
+      container,
+      ".agent-chat__composer-combobox > textarea",
+      "composer textarea",
+    ) as HTMLTextAreaElement;
+    let scrollHeight = 42;
+    let clientHeight = 42;
+    Object.defineProperties(textarea, {
+      scrollHeight: { configurable: true, get: () => scrollHeight },
+      clientHeight: { configurable: true, get: () => clientHeight },
+    });
+
+    textarea.dispatchEvent(new InputEvent("input", { bubbles: true }));
+
+    expect(textarea.style.height).toBe("42px");
+    expect(textarea.style.overflowY).toBe("hidden");
+
+    scrollHeight = 180;
+    clientHeight = 150;
+    textarea.value = "A long draft";
+    textarea.dispatchEvent(new InputEvent("input", { bubbles: true }));
+
+    expect(textarea.style.height).toBe("150px");
+    expect(textarea.style.overflowY).toBe("auto");
+  });
+
+  it("rechecks overflow when responsive layout changes the textarea height", () => {
+    let resizeCallback: ResizeObserverCallback | undefined;
+    class TestResizeObserver {
+      constructor(callback: ResizeObserverCallback) {
+        resizeCallback = callback;
+      }
+      observe() {}
+      unobserve() {}
+      disconnect() {}
+      takeRecords(): ResizeObserverEntry[] {
+        return [];
+      }
+    }
+    vi.stubGlobal("ResizeObserver", TestResizeObserver);
+    const container = renderChatView({});
+    const textarea = requireElement(
+      container,
+      ".agent-chat__composer-combobox > textarea",
+      "composer textarea",
+    ) as HTMLTextAreaElement;
+    let scrollHeight = 42;
+    let clientHeight = 42;
+    Object.defineProperties(textarea, {
+      scrollHeight: { configurable: true, get: () => scrollHeight },
+      clientHeight: { configurable: true, get: () => clientHeight },
+    });
+    textarea.dispatchEvent(new InputEvent("input", { bubbles: true }));
+    expect(textarea.style.overflowY).toBe("hidden");
+
+    scrollHeight = 120;
+    clientHeight = 56;
+    resizeCallback?.([], {} as ResizeObserver);
+
+    expect(textarea.style.overflowY).toBe("auto");
+  });
+});
+
 describe("chat slash menu accessibility", () => {
   function inputDraft(container: HTMLElement, value: string) {
     const textarea = container.querySelector<HTMLTextAreaElement>("textarea");

--- a/ui/src/pages/chat/components/chat-composer.ts
+++ b/ui/src/pages/chat/components/chat-composer.ts
@@ -219,9 +219,43 @@ export function resetChatComposerState() {
   Object.assign(composerState, createChatComposerState());
 }
 
+const composerTextareaResizeObservers = new WeakMap<HTMLTextAreaElement, ResizeObserver>();
+
+function updateTextareaOverflow(el: HTMLTextAreaElement) {
+  el.style.overflowY = el.scrollHeight > el.clientHeight ? "auto" : "hidden";
+}
+
 function adjustTextareaHeight(el: HTMLTextAreaElement) {
+  // Hide the browser's scrollbar while measuring; restore it only when the
+  // final CSS-constrained height actually clips the draft.
+  el.style.overflowY = "hidden";
   el.style.height = "auto";
   el.style.height = `${Math.min(el.scrollHeight, 150)}px`;
+  updateTextareaOverflow(el);
+}
+
+function observeTextareaOverflow(el: HTMLTextAreaElement) {
+  if (typeof ResizeObserver !== "function" || composerTextareaResizeObservers.has(el)) {
+    return;
+  }
+  const observer = new ResizeObserver(() => updateTextareaOverflow(el));
+  observer.observe(el);
+  composerTextareaResizeObservers.set(el, observer);
+}
+
+function disconnectTextareaOverflowObserver(el: HTMLTextAreaElement) {
+  composerTextareaResizeObservers.get(el)?.disconnect();
+  composerTextareaResizeObservers.delete(el);
+}
+
+function scheduleTextareaHeightAdjustment(el: HTMLTextAreaElement) {
+  // Lit invokes ref callbacks before the textarea is connected and before its
+  // controlled value is committed, so measure once the render has settled.
+  queueMicrotask(() => {
+    if (el.isConnected) {
+      adjustTextareaHeight(el);
+    }
+  });
 }
 
 function focusComposerFromChrome(event: MouseEvent, connected: boolean) {
@@ -1730,9 +1764,14 @@ export function renderChatComposer(props: ChatComposerProps) {
       <div class="agent-chat__composer-combobox">
         <textarea
           ${ref((element) => {
-            composerTextarea = element instanceof HTMLTextAreaElement ? element : null;
+            const nextTextarea = element instanceof HTMLTextAreaElement ? element : null;
+            if (composerTextarea && composerTextarea !== nextTextarea) {
+              disconnectTextareaOverflowObserver(composerTextarea);
+            }
+            composerTextarea = nextTextarea;
             if (composerTextarea) {
-              adjustTextareaHeight(composerTextarea);
+              observeTextareaOverflow(composerTextarea);
+              scheduleTextareaHeightAdjustment(composerTextarea);
             }
           })}
           .value=${visibleDraft}


### PR DESCRIPTION
## Summary

- hide the message textarea scrollbar when its draft fits without scrolling
- restore scrolling only when the autosized textarea is actually clipped
- re-evaluate overflow after controlled draft updates and responsive height changes
- add regression coverage and a changelog entry

## Root cause

The textarea kept its browser-default `overflow-y: auto`. OpenClaw's global custom scrollbar styling therefore painted and reserved a 6px scrollbar gutter even when `scrollHeight` equaled `clientHeight`.

## Testing

- `pnpm test ui/src/pages/chat/chat-view.test.ts` (95 tests)
- `pnpm ui:build`
- local `pnpm check:changed` lanes for the touched files
- Codex autoreview: clean after addressing restored-draft and responsive-layout findings
