### PR TITLE
fix(voice-call): auto-respond to webhook transcripts

### DIFF
--- a/extensions/voice-call/src/manager.closed-loop.test.ts
+++ b/extensions/voice-call/src/manager.closed-loop.test.ts
@@ -130,7 +130,7 @@ describe("CallManager closed-loop turns", () => {
 
     const expectedTurnToken = requireTurnToken(provider);
 
-    manager.processEvent({
+    const staleResult = manager.processEvent({
       id: "evt-turn-token-bad",
       type: "call.speech",
       callId: started.callId,
@@ -140,10 +140,11 @@ describe("CallManager closed-loop turns", () => {
       isFinal: true,
       turnToken: "wrong-token",
     });
+    expect(staleResult).toEqual({ kind: "ignored" });
 
     expectTranscriptWaiter(manager, started.callId);
 
-    manager.processEvent({
+    const finalResult = manager.processEvent({
       id: "evt-turn-token-good",
       type: "call.speech",
       callId: started.callId,
@@ -152,6 +153,11 @@ describe("CallManager closed-loop turns", () => {
       transcript: "final answer",
       isFinal: true,
       turnToken: expectedTurnToken,
+    });
+    expect(finalResult).toMatchObject({
+      kind: "final-speech",
+      transcript: "final answer",
+      waiterResolved: true,
     });
 
     const turnResult = await turnPromise;

--- a/extensions/voice-call/src/manager.ts
+++ b/extensions/voice-call/src/manager.ts
@@ -6,7 +6,7 @@ import { formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
 import { normalizeOptionalString } from "openclaw/plugin-sdk/string-coerce-runtime";
 import type { VoiceCallConfig, VoiceCallCoreSessionConfig } from "./config.js";
 import type { CallManagerContext, StreamSessionIssuer } from "./manager/context.js";
-import { processEvent as processManagerEvent } from "./manager/events.js";
+import { processEvent as processManagerEvent, type ProcessEventResult } from "./manager/events.js";
 import { getCallByProviderCallId as getCallByProviderCallIdFromMaps } from "./manager/lookup.js";
 import {
   continueCall as continueCallWithContext,
@@ -15,6 +15,7 @@ import {
   sendDtmf as sendDtmfWithContext,
   speak as speakWithContext,
   speakInitialMessage as speakInitialMessageWithContext,
+  type SpeakOptions,
 } from "./manager/outbound.js";
 import {
   getCallHistoryFromStore,
@@ -316,8 +317,12 @@ export class CallManager {
   /**
    * Speak to user in an active call.
    */
-  async speak(callId: CallId, text: string): Promise<{ success: boolean; error?: string }> {
-    return speakWithContext(this.getContext(), callId, text);
+  async speak(
+    callId: CallId,
+    text: string,
+    options?: SpeakOptions,
+  ): Promise<{ success: boolean; error?: string }> {
+    return speakWithContext(this.getContext(), callId, text, options);
   }
 
   /**
@@ -376,8 +381,8 @@ export class CallManager {
   /**
    * Process a webhook event.
    */
-  processEvent(event: NormalizedEvent): void {
-    processManagerEvent(this.getContext(), event);
+  processEvent(event: NormalizedEvent): ProcessEventResult {
+    return processManagerEvent(this.getContext(), event);
   }
 
   private shouldDeferConversationInitialMessageUntilStreamConnect(): boolean {

--- a/extensions/voice-call/src/manager/events.test.ts
+++ b/extensions/voice-call/src/manager/events.test.ts
@@ -687,7 +687,7 @@ describe("processEvent (functional)", () => {
     });
     ctx.providerCallIdMap.set("provider-dedupe", "call-dedupe");
 
-    processEvent(ctx, {
+    const firstResult = processEvent(ctx, {
       id: "evt-1",
       dedupeKey: "stable-key-1",
       type: "call.speech",
@@ -698,7 +698,7 @@ describe("processEvent (functional)", () => {
       isFinal: true,
     });
 
-    processEvent(ctx, {
+    const replayResult = processEvent(ctx, {
       id: "evt-2",
       dedupeKey: "stable-key-1",
       type: "call.speech",
@@ -715,6 +715,12 @@ describe("processEvent (functional)", () => {
     }
     expect(call.transcript).toHaveLength(1);
     expect(Array.from(ctx.processedEventIds)).toEqual(["stable-key-1"]);
+    expect(firstResult).toMatchObject({
+      kind: "final-speech",
+      transcript: "hello",
+      waiterResolved: false,
+    });
+    expect(replayResult).toEqual({ kind: "ignored" });
   });
 
   it("keeps retryable call.error events replayable", () => {

--- a/extensions/voice-call/src/manager/events.ts
+++ b/extensions/voice-call/src/manager/events.ts
@@ -31,6 +31,16 @@ type EventContext = Pick<
   | "streamSessionIssuer"
 >;
 
+export type ProcessEventResult =
+  | { kind: "ignored" }
+  | { kind: "processed" }
+  | {
+      kind: "final-speech";
+      call: CallRecord;
+      transcript: string;
+      waiterResolved: boolean;
+    };
+
 function shouldAcceptInbound(config: EventContext["config"], from: string | undefined): boolean {
   const { inboundPolicy: policy, allowFrom } = config;
 
@@ -138,10 +148,10 @@ function persistRejectedInboundCall(params: {
   persistCallRecord(params.ctx.storePath, rejectedCall);
 }
 
-export function processEvent(ctx: EventContext, event: NormalizedEvent): void {
+export function processEvent(ctx: EventContext, event: NormalizedEvent): ProcessEventResult {
   const dedupeKey = event.dedupeKey || event.id;
   if (ctx.processedEventIds.has(dedupeKey)) {
-    return;
+    return { kind: "ignored" };
   }
 
   let call = findCall({
@@ -166,11 +176,11 @@ export function processEvent(ctx: EventContext, event: NormalizedEvent): void {
         console.warn(
           `[voice-call] Inbound call rejected by policy but no provider to hang up (providerCallId: ${pid}, from: ${event.from}); call will time out on provider side.`,
         );
-        return;
+        return { kind: "ignored" };
       }
       ctx.processedEventIds.add(dedupeKey);
       if (ctx.rejectedProviderCallIds.has(pid)) {
-        return;
+        return { kind: "ignored" };
       }
       ctx.rejectedProviderCallIds.add(pid);
       const callId = event.callId ?? pid;
@@ -187,7 +197,7 @@ export function processEvent(ctx: EventContext, event: NormalizedEvent): void {
           const message = formatErrorMessage(err);
           console.warn(`[voice-call] Failed to reject inbound call ${pid}:`, message);
         });
-      return;
+      return { kind: "processed" };
     }
 
     call = createWebhookCall({
@@ -203,7 +213,7 @@ export function processEvent(ctx: EventContext, event: NormalizedEvent): void {
   }
 
   if (!call) {
-    return;
+    return { kind: "ignored" };
   }
 
   if (event.providerCallId && event.providerCallId !== call.providerCallId) {
@@ -224,6 +234,7 @@ export function processEvent(ctx: EventContext, event: NormalizedEvent): void {
     call.processedEventIds.push(dedupeKey);
   }
 
+  let result: ProcessEventResult = { kind: "processed" };
   switch (event.type) {
     case "call.initiated":
       transitionState(call, "initiated");
@@ -305,9 +316,16 @@ export function processEvent(ctx: EventContext, event: NormalizedEvent): void {
           console.warn(
             `[voice-call] Ignoring speech event with mismatched turn token for ${call.callId}`,
           );
+          result = { kind: "ignored" };
           break;
         }
         addTranscriptEntry(call, "user", event.transcript);
+        result = {
+          kind: "final-speech",
+          call,
+          transcript: event.transcript,
+          waiterResolved: resolved,
+        };
       }
       ensureMaxDurationTimerForLiveCall({
         ctx,
@@ -331,7 +349,7 @@ export function processEvent(ctx: EventContext, event: NormalizedEvent): void {
         endReason: event.reason,
         endedAt: event.timestamp,
       });
-      return;
+      return { kind: "processed" };
 
     case "call.error":
       if (!event.retryable) {
@@ -342,7 +360,7 @@ export function processEvent(ctx: EventContext, event: NormalizedEvent): void {
           endedAt: event.timestamp,
           transcriptRejectReason: `Call error: ${event.error}`,
         });
-        return;
+        return { kind: "processed" };
       }
       // Keep retryable provider errors replayable so a redelivery can still
       // drive later recovery or terminal handling for the same event key.
@@ -350,4 +368,5 @@ export function processEvent(ctx: EventContext, event: NormalizedEvent): void {
   }
 
   persistCallRecord(ctx.storePath, call);
+  return result;
 }

--- a/extensions/voice-call/src/manager/outbound.test.ts
+++ b/extensions/voice-call/src/manager/outbound.test.ts
@@ -321,13 +321,16 @@ describe("voice-call outbound helpers", () => {
       storePath: "/tmp/voice-call.json",
     };
 
-    await expect(speak(ctx as never, "call-1", "hello")).resolves.toEqual({ success: true });
+    await expect(
+      speak(ctx as never, "call-1", "hello", { listenAfterPlayback: true }),
+    ).resolves.toEqual({ success: true });
     expect(transitionStateMock).toHaveBeenCalledWith(call, "speaking");
     expect(playTts).toHaveBeenCalledWith({
       callId: "call-1",
       providerCallId: "provider-1",
       text: "hello",
       voice: "alloy",
+      listenAfterPlayback: true,
     });
     expect(addTranscriptEntryMock).toHaveBeenCalledWith(call, "bot", "hello");
 

--- a/extensions/voice-call/src/manager/outbound.ts
+++ b/extensions/voice-call/src/manager/outbound.ts
@@ -268,10 +268,15 @@ export async function initiateCall(
   }
 }
 
+export type SpeakOptions = {
+  listenAfterPlayback?: boolean;
+};
+
 export async function speak(
   ctx: SpeakContext,
   callId: CallId,
   text: string,
+  options?: SpeakOptions,
 ): Promise<{ success: boolean; error?: string }> {
   const connected = requireConnectedCall(ctx, callId);
   if (!connected.ok) {
@@ -295,11 +300,13 @@ export async function speak(
     const voice = resolvePreferredTtsVoice(
       resolveVoiceCallEffectiveConfig(ctx.config, numberRouteKey).config,
     );
+    const playbackOptions = options?.listenAfterPlayback ? { listenAfterPlayback: true } : {};
     await provider.playTts({
       callId,
       providerCallId,
       text,
       voice,
+      ...playbackOptions,
     });
 
     addTranscriptEntry(call, "bot", text);

--- a/extensions/voice-call/src/providers/plivo.test.ts
+++ b/extensions/voice-call/src/providers/plivo.test.ts
@@ -1,5 +1,5 @@
 // Voice Call tests cover plivo plugin behavior.
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { PlivoProvider } from "./plivo.js";
 
 function requireEvent<T>(event: T | undefined, message: string): T {
@@ -90,5 +90,55 @@ describe("PlivoProvider", () => {
       .callUuidToWebhookUrl;
 
     expect(callbackMap.get("call-uuid")).toBe("https://voice.openclaw.ai/voice/webhook");
+  });
+
+  it("renders an auto-response as the prompt for the next speech input", async () => {
+    const provider = new PlivoProvider({
+      authId: "MA000000000000000000",
+      authToken: "test-token",
+    });
+    const apiRequest = vi.fn(async (_params: unknown) => ({}));
+    (
+      provider as unknown as {
+        apiRequest: (params: unknown) => Promise<unknown>;
+      }
+    ).apiRequest = apiRequest;
+    (
+      provider as unknown as {
+        callIdToWebhookUrl: Map<string, string>;
+      }
+    ).callIdToWebhookUrl.set("internal-call-id", "https://example.com/voice/webhook");
+
+    await provider.playTts({
+      callId: "internal-call-id",
+      providerCallId: "call-uuid",
+      text: "How can I help?",
+      locale: "en-US",
+      listenAfterPlayback: true,
+    });
+
+    expect(apiRequest).toHaveBeenCalledWith(
+      expect.objectContaining({
+        method: "POST",
+        endpoint: "/Call/call-uuid/",
+        body: expect.objectContaining({
+          aleg_url: expect.stringContaining("flow=xml-speak"),
+        }),
+      }),
+    );
+
+    const result = provider.parseWebhookEvent({
+      headers: { host: "example.com" },
+      rawBody: "CallUUID=call-uuid",
+      url: "https://example.com/voice/webhook?provider=plivo&flow=xml-speak&callId=internal-call-id",
+      method: "POST",
+      query: { provider: "plivo", flow: "xml-speak", callId: "internal-call-id" },
+    });
+    const responseBody = requireResponseBody(result.providerResponseBody);
+    expect(responseBody).toContain('<GetInput inputType="speech"');
+    expect(responseBody).toContain('speechEndTimeout="2"');
+    expect(responseBody).toContain("flow=getinput");
+    expect(responseBody).toContain('<Speak language="en-US">How can I help?</Speak>');
+    expect(responseBody.indexOf("<GetInput")).toBeLessThan(responseBody.indexOf("<Speak"));
   });
 });

--- a/extensions/voice-call/src/providers/plivo.ts
+++ b/extensions/voice-call/src/providers/plivo.ts
@@ -37,7 +37,7 @@ export interface PlivoProviderOptions {
   webhookSecurity?: WebhookSecurityConfig;
 }
 
-type PendingSpeak = { text: string; locale?: string };
+type PendingSpeak = { text: string; locale?: string; listenAfterPlayback?: boolean };
 type PendingListen = { language?: string };
 
 function createPlivoRequestDedupeKey(ctx: WebhookContext): string {
@@ -158,8 +158,18 @@ export class PlivoProvider implements VoiceCallProvider {
         this.pendingSpeakByCallId.delete(callId);
       }
 
+      const actionUrl =
+        pending?.listenAfterPlayback && callId
+          ? this.buildActionUrl(ctx, { flow: "getinput", callId })
+          : null;
       const xml = pending
-        ? PlivoProvider.xmlSpeak(pending.text, pending.locale)
+        ? actionUrl
+          ? PlivoProvider.xmlSpeakAndListen({
+              text: pending.text,
+              language: pending.locale,
+              actionUrl,
+            })
+          : PlivoProvider.xmlSpeak(pending.text, pending.locale)
         : PlivoProvider.xmlKeepAlive();
       return {
         events: [],
@@ -415,6 +425,7 @@ export class PlivoProvider implements VoiceCallProvider {
     this.pendingSpeakByCallId.set(input.callId, {
       text: input.text,
       locale: input.locale,
+      listenAfterPlayback: input.listenAfterPlayback,
     });
 
     await this.transferCallLeg({
@@ -515,7 +526,22 @@ export class PlivoProvider implements VoiceCallProvider {
     const language = params.language || "en-US";
     return `<?xml version="1.0" encoding="UTF-8"?>
 <Response>
-  <GetInput inputType="speech" method="POST" action="${escapeXml(params.actionUrl)}" language="${escapeXml(language)}" executionTimeout="30" speechEndTimeout="1" redirect="false">
+  <GetInput inputType="speech" method="POST" action="${escapeXml(params.actionUrl)}" language="${escapeXml(language)}" executionTimeout="30" speechEndTimeout="2" redirect="false">
+  </GetInput>
+  <Wait length="300" />
+</Response>`;
+  }
+
+  private static xmlSpeakAndListen(params: {
+    text: string;
+    actionUrl: string;
+    language?: string;
+  }): string {
+    const language = params.language || "en-US";
+    return `<?xml version="1.0" encoding="UTF-8"?>
+<Response>
+  <GetInput inputType="speech" method="POST" action="${escapeXml(params.actionUrl)}" language="${escapeXml(language)}" executionTimeout="30" speechEndTimeout="2" redirect="false">
+    <Speak language="${escapeXml(language)}">${escapeXml(params.text)}</Speak>
   </GetInput>
   <Wait length="300" />
 </Response>`;

--- a/extensions/voice-call/src/types.ts
+++ b/extensions/voice-call/src/types.ts
@@ -258,6 +258,8 @@ export type PlayTtsInput = {
   text: string;
   voice?: string;
   locale?: string;
+  /** Keep collecting speech after playback when the provider owns the listening XML. */
+  listenAfterPlayback?: boolean;
 };
 
 export type SendDtmfInput = {

--- a/extensions/voice-call/src/webhook.test.ts
+++ b/extensions/voice-call/src/webhook.test.ts
@@ -31,7 +31,7 @@ const mocks = vi.hoisted(() => {
   };
 
   return {
-    generateVoiceResponse: vi.fn(async () => ({ text: null })),
+    generateVoiceResponse: vi.fn(async (): Promise<{ text: string | null }> => ({ text: null })),
     getRealtimeTranscriptionProvider: vi.fn<(...args: unknown[]) => unknown>(
       () => realtimeTranscriptionProvider,
     ),
@@ -121,7 +121,7 @@ const createCall = (startedAt: number): CallRecord => ({
 
 const createManager = (calls: CallRecord[]) => {
   const endCall = vi.fn(async () => ({ success: true }));
-  const processEvent = vi.fn();
+  const processEvent = vi.fn<CallManager["processEvent"]>(() => ({ kind: "processed" }));
   const manager = {
     getActiveCalls: () => calls,
     endCall,
@@ -1657,9 +1657,10 @@ describe("VoiceCallWebhookServer classic response routing", () => {
     call.direction = "outbound";
     call.to = "+15550001111";
     call.sessionKey = "agent:top:voice:15550001111";
+    const speak = vi.fn(async () => ({ success: true }));
     const manager = {
       getCall: (callId: string) => (callId === call.callId ? call : undefined),
-      speak: vi.fn(async () => ({ success: true })),
+      speak,
     } as unknown as CallManager;
     const config = createConfig({
       agentId: "top",
@@ -1675,7 +1676,7 @@ describe("VoiceCallWebhookServer classic response routing", () => {
       undefined,
       {} as never,
     );
-    mocks.generateVoiceResponse.mockReset().mockResolvedValue({ text: null });
+    mocks.generateVoiceResponse.mockReset().mockResolvedValue({ text: "Hello back" });
 
     await (
       server as unknown as {
@@ -1688,6 +1689,9 @@ describe("VoiceCallWebhookServer classic response routing", () => {
       "classic voice response",
     )[0] as { voiceConfig?: VoiceCallConfig } | undefined;
     expect(params?.voiceConfig?.agentId).toBe("top");
+    expect(speak).toHaveBeenCalledWith(call.callId, "Hello back", {
+      listenAfterPlayback: true,
+    });
   });
 });
 
@@ -1895,11 +1899,18 @@ describe("VoiceCallWebhookServer barge-in suppression during initial message", (
     };
 
     const clearTtsQueue = vi.fn<TwilioProviderTestDouble["clearTtsQueue"]>();
-    const processEvent = vi.fn((event: NormalizedEvent) => {
+    const processEvent = vi.fn<CallManager["processEvent"]>((event) => {
       if (event.type === "call.speech") {
         // Mirrors manager behavior: call.speech transitions to listening.
         call.state = "listening";
+        return {
+          kind: "final-speech",
+          call,
+          transcript: event.transcript,
+          waiterResolved: false,
+        };
       }
+      return { kind: "processed" };
     });
     const manager = {
       getActiveCalls: () => [call],
@@ -1977,7 +1988,16 @@ describe("VoiceCallWebhookServer barge-in suppression during initial message", (
     };
 
     const clearTtsQueue = vi.fn<TwilioProviderTestDouble["clearTtsQueue"]>();
-    const processEvent = vi.fn();
+    const processEvent = vi.fn<CallManager["processEvent"]>((event) =>
+      event.type === "call.speech"
+        ? {
+            kind: "final-speech",
+            call,
+            transcript: event.transcript,
+            waiterResolved: false,
+          }
+        : { kind: "processed" },
+    );
     const manager = {
       getActiveCalls: () => [call],
       getCallByProviderCallId: (providerCallId: string) =>
@@ -2027,6 +2047,95 @@ describe("VoiceCallWebhookServer barge-in suppression during initial message", (
       expect(event.transcript).toBe("hello");
       expect(event.isFinal).toBe(true);
       expect(handleInboundResponse).toHaveBeenCalledWith("call-inbound", "hello");
+    } finally {
+      await server.stop();
+    }
+  });
+});
+
+describe("VoiceCallWebhookServer webhook event path auto-response (#79118)", () => {
+  const createInboundCall = (): CallRecord => ({
+    callId: "call-inbound-79118",
+    providerCallId: "v3:provider-79118",
+    provider: "telnyx",
+    direction: "inbound",
+    state: "listening",
+    from: "+15550009999",
+    to: "+15550000111",
+    startedAt: Date.now(),
+    transcript: [],
+    processedEventIds: [],
+  });
+
+  const buildSpeechEvent = (
+    call: CallRecord,
+  ): Extract<NormalizedEvent, { type: "call.speech" }> => ({
+    id: "evt-79118",
+    type: "call.speech",
+    callId: call.providerCallId as string,
+    providerCallId: call.providerCallId,
+    timestamp: Date.now(),
+    transcript: "hallo wie geht es dir",
+    isFinal: true,
+  });
+
+  const buildTelnyxLikeProvider = (event: NormalizedEvent): VoiceCallProvider => ({
+    ...provider,
+    name: "telnyx",
+    verifyWebhook: () => ({ ok: true, verifiedRequestKey: "telnyx:req:79118" }),
+    parseWebhookEvent: () => ({ events: [event], statusCode: 200 }),
+  });
+
+  const buildManagerWith = (call: CallRecord, result?: ReturnType<CallManager["processEvent"]>) => {
+    const managerResult = createManager([call]);
+    managerResult.processEvent.mockReturnValue(
+      result ?? {
+        kind: "final-speech",
+        call,
+        transcript: "hallo wie geht es dir",
+        waiterResolved: false,
+      },
+    );
+    return managerResult;
+  };
+
+  const installHandleInboundResponseSpy = (server: VoiceCallWebhookServer) => {
+    const spy = vi.fn(async () => {});
+    (
+      server as unknown as {
+        handleInboundResponse: (callId: string, transcript: string) => Promise<void>;
+      }
+    ).handleInboundResponse = spy;
+    return spy;
+  };
+
+  it("auto-responds to a final inbound webhook transcript", async () => {
+    const inboundCall = createInboundCall();
+    const event = buildSpeechEvent(inboundCall);
+    const { manager, processEvent } = buildManagerWith(inboundCall);
+    const config = createConfig({
+      skipSignatureVerification: true,
+      serve: { port: 0, bind: "127.0.0.1", path: "/voice/webhook" },
+    });
+    const server = new VoiceCallWebhookServer(config, manager, buildTelnyxLikeProvider(event));
+    const handleInboundResponse = installHandleInboundResponseSpy(server);
+
+    try {
+      const baseUrl = await server.start();
+      const response = await postWebhookForm(server, baseUrl, "stub=1");
+      expect(response.status).toBe(200);
+      expect(processEvent).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: "call.speech",
+          transcript: "hallo wie geht es dir",
+          isFinal: true,
+        }),
+      );
+      expect(handleInboundResponse).toHaveBeenCalledTimes(1);
+      expect(handleInboundResponse).toHaveBeenCalledWith(
+        inboundCall.callId,
+        "hallo wie geht es dir",
+      );
     } finally {
       await server.stop();
     }

--- a/extensions/voice-call/src/webhook.ts
+++ b/extensions/voice-call/src/webhook.ts
@@ -405,16 +405,7 @@ export class VoiceCallWebhookServer {
           transcript,
           isFinal: true,
         };
-        this.manager.processEvent(event);
-
-        // Auto-respond in conversation mode (inbound always, outbound if mode is conversation)
-        const callMode = call.metadata?.mode as string | undefined;
-        const shouldRespond = call.direction === "inbound" || callMode === "conversation";
-        if (shouldRespond) {
-          this.handleInboundResponse(call.callId, transcript).catch((err: unknown) => {
-            console.warn(`[voice-call] Failed to auto-respond:`, err);
-          });
-        }
+        this.processEventWithAutoResponse(event);
       },
       onSpeechStart: (providerCallId) => {
         if (this.provider.name !== "twilio") {
@@ -941,11 +932,28 @@ export class VoiceCallWebhookServer {
   private processParsedEvents(events: NormalizedEvent[]): void {
     for (const event of events) {
       try {
-        this.manager.processEvent(event);
+        this.processEventWithAutoResponse(event);
       } catch (err) {
         console.error(`[voice-call] Error processing event ${event.type}:`, err);
       }
     }
+  }
+
+  private processEventWithAutoResponse(event: NormalizedEvent): void {
+    const result = this.manager.processEvent(event);
+    if (result.kind !== "final-speech" || result.waiterResolved) {
+      return;
+    }
+    const callMode = result.call.metadata?.mode as string | undefined;
+    if (result.call.direction !== "inbound" && callMode !== "conversation") {
+      return;
+    }
+
+    // Both media-stream and carrier-webhook transcripts share this handoff.
+    // The manager result excludes replays and turn-token mismatches.
+    void this.handleInboundResponse(result.call.callId, result.transcript).catch((err: unknown) => {
+      console.warn(`[voice-call] Failed to auto-respond:`, err);
+    });
   }
 
   private writeWebhookResponse(res: http.ServerResponse, payload: WebhookResponsePayload): void {
@@ -1015,7 +1023,7 @@ export class VoiceCallWebhookServer {
 
       if (result.text) {
         console.log(`[voice-call] AI response: "${result.text}"`);
-        await this.manager.speak(callId, result.text);
+        await this.manager.speak(callId, result.text, { listenAfterPlayback: true });
       }
     } catch (err) {
       console.error(`[voice-call] Auto-response error:`, err);


### PR DESCRIPTION
Closes #79118
Supersedes #79336 because the contributor fork predates the current `main` history and cannot be refreshed through GitHub's verified branch-edit path without replaying more than 21,000 unrelated files.

## What Problem This Solves

Fixes an issue where callers using carrier webhook transcription could hear the greeting and have their speech transcribed, but OpenClaw would never generate or speak a reply.

## Why This Change Was Made

Both media-stream and carrier-webhook transcripts now use one manager-owned final-speech result and one auto-response handoff. Replays, partial transcripts, turn-token mismatches, and transcripts already consumed by a closed-loop waiter stay excluded. Plivo renders an auto-response inside the next supported `GetInput` prompt so conversation continues after playback.

## User Impact

Inbound voice conversations can continue beyond the first transcribed utterance across Telnyx-style webhooks and Plivo XML flows, without producing duplicate replies.

## Evidence

- Blacksmith Testbox focused suite: 93/93 tests passed across manager, outbound, webhook, and Plivo paths.
- Post-review focused rerun: 48/48 webhook and Plivo tests passed.
- Touched-surface `check:changed`: extension typechecks, lint, database-first guard, media helper guard, and import-cycle checks passed.
- Real local TCP webhook path: HTTP 200, transcript persisted, exactly one response callback invoked.
- Plivo XML checked against the current GetInput contract; nested `Speak` is supported and `speechEndTimeout="2"` is within the documented 2-10 second range.
- Fresh Codex autoreview: clean, 0.91 confidence after fixing the one accepted Plivo contract finding.
- Original contributor proof in #79336 covered the real Telnyx call path. Co-authorship is preserved in the commit.

Known gap: no maintainer Plivo carrier credential was available for a billed PSTN call; provider-contract proof and the real XML generation path are covered directly.
