### PR TITLE
fix(ui): center terminal new-session button

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- **Control UI terminal tabs:** vertically center the new-session button in the terminal tab strip.
 - **Control UI composer scrollbar:** show the message-field scrollbar only when the draft actually overflows its autosized height.
 - **Control UI terminal cursor:** hide the browser-native contenteditable caret so the integrated terminal shows only its canvas-rendered cursor.
 - **macOS SSH tunnels:** resolve user-installed SSH `ProxyCommand` helpers through the app's managed PATH while preserving inherited connection environment, so remote aliases work after Finder and sanitized-script launches.

--- a/ui/src/components/terminal/terminal-panel.test.ts
+++ b/ui/src/components/terminal/terminal-panel.test.ts
@@ -71,6 +71,8 @@ describe("OpenClawTerminalPanel", () => {
     });
     expect(createOptions?.terminalOptions?.fontFamily).toContain("MesloLGLDZ Nerd Font Mono");
     expect(getComputedStyle(createOptions!.parent).caretColor).toBe("rgba(0, 0, 0, 0)");
+    const styles = (OpenClawTerminalPanel.styles as { cssText: string }).cssText;
+    expect(styles).toMatch(/\.tp-new\s*\{[^}]*align-self:\s*center/u);
     await vi.waitFor(() => {
       expect(requests).toContainEqual({
         method: "terminal.resize",

--- a/ui/src/components/terminal/terminal-panel.ts
+++ b/ui/src/components/terminal/terminal-panel.ts
@@ -930,6 +930,9 @@ export class OpenClawTerminalPanel extends LitElement {
       border-radius: 6px;
       padding: 0;
     }
+    .tp-new {
+      align-self: center;
+    }
     .tp-tab__close:hover,
     .tp-new:hover,
     .tp-icon:hover {


### PR DESCRIPTION
## Summary

- vertically center the terminal new-session button in the tab strip
- preserve the full-height tabs and active underline geometry
- add focused regression coverage and a changelog entry

## Root cause

The tab strip stretches its children, while the new-session button has a fixed 26px height. The button therefore stayed at the cross-start of the 38px row, placing its center 6px above the active tab's center.

## Testing

- `pnpm test ui/src/components/terminal/terminal-panel.test.ts`
- `pnpm ui:build`
- `pnpm exec oxfmt --check --threads=1 CHANGELOG.md ui/src/components/terminal/terminal-panel.ts ui/src/components/terminal/terminal-panel.test.ts`
- scoped `pnpm check:changed`
- `.agents/skills/autoreview/scripts/autoreview --mode local` (clean)
