### PR TITLE
docs: align onboarding and fix anchor validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,12 +98,10 @@ Model note: while many providers and models are supported, prefer a current flag
 ## Install (recommended)
 
 Runtime: **Node 24 (recommended) or Node 22.19+**.
+The installer script is the recommended beginner path because it handles Node setup, installs OpenClaw, and launches onboarding.
 
 ```bash
-npm install -g openclaw@latest
-# or: pnpm add -g openclaw@latest
-
-openclaw onboard --install-daemon
+curl -fsSL https://openclaw.ai/install.sh | bash
 ```
 
 OpenClaw Onboard installs the Gateway daemon (launchd/systemd user service) so it stays running.
@@ -119,6 +117,13 @@ Recommended daemon mode:
 ```bash
 openclaw onboard --install-daemon
 openclaw gateway status
+```
+
+Manual Node-managed install:
+
+```bash
+npm install -g openclaw@latest
+openclaw onboard --install-daemon
 ```
 
 Foreground/debug mode:

--- a/docs/channels/groups.md
+++ b/docs/channels/groups.md
@@ -429,6 +429,8 @@ Account-level channel configs can set the same policy under `channels.<channel>.
   </Accordion>
 </AccordionGroup>
 
+<a id="groupchannel-tool-restrictions-optional" />
+
 ## Group/channel tool restrictions (optional)
 
 Some channel configs support restricting which tools are available **inside a specific group/room/channel**.

--- a/docs/channels/matrix.md
+++ b/docs/channels/matrix.md
@@ -219,7 +219,7 @@ Full object form accepts `{ mode, preview, progress }`:
 
 | `streaming`       | Behavior                                                                                                                                                 |
 | ----------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `"off"` (default) | Wait for the full reply, send once. `true` <-> `"partial"`, `false` <-> `"off"`.                                                                         |
+| `"off"` (default) | Wait for the full reply, send once. `true` maps to `"partial"`; `false` maps to `"off"`.                                                                 |
 | `"partial"`       | Edit one normal text message in place as the model writes the current block. Stock clients may notify on the first preview, not the final edit.          |
 | `"quiet"`         | Same as `"partial"` but the message is a non-notifying notice. Recipients are notified once a per-user push rule matches the finalized edit (see below). |
 | `"progress"`      | Sends individual compact progress lines using a progress draft.                                                                                          |
@@ -880,7 +880,7 @@ Room allowlist keys (`groups`, legacy `rooms`) should be room IDs or aliases. Pl
 - `replyToMode`: `"off"` (default), `"first"`, `"all"`, or `"batched"`.
 - `threadReplies`: `"off"` (top-level default resolves to `"inbound"` unless explicitly set), `"inbound"`, or `"always"`.
 - `threadBindings`: per-channel overrides for thread-bound session routing and lifecycle.
-- `streaming`: `"off"` (default), `"partial"`, `"quiet"`, `"progress"`, or object form `{ mode, preview: { toolProgress }, progress: { label, labels, maxLines, maxLineChars, toolProgress } }`. `true` <-> `"partial"`, `false` <-> `"off"`.
+- `streaming`: `"off"` (default), `"partial"`, `"quiet"`, `"progress"`, or object form `{ mode, preview: { toolProgress }, progress: { label, labels, maxLines, maxLineChars, toolProgress } }`. `true` maps to `"partial"`; `false` maps to `"off"`.
 - `blockStreaming`: when `true`, completed assistant blocks are kept as separate progress messages. Default: `false`.
 - `markdown`: optional Markdown rendering config for outbound text.
 - `responsePrefix`: optional string prepended to outbound replies.

--- a/docs/channels/signal.md
+++ b/docs/channels/signal.md
@@ -168,6 +168,8 @@ To manage `signal-cli` yourself (slow JVM cold starts, container init, shared CP
 
 This skips auto-spawn and OpenClaw's startup wait. For slow auto-spawned starts, set `channels.signal.startupTimeoutMs`.
 
+<a id="container-mode-bbernhardsignal-cli-rest-api" />
+
 ## Container mode (bbernhard/signal-cli-rest-api)
 
 Instead of running `signal-cli` natively, use the [bbernhard/signal-cli-rest-api](https://github.com/bbernhard/signal-cli-rest-api) Docker container, which wraps `signal-cli` behind a REST + WebSocket interface.

--- a/docs/concepts/qa-e2e-automation.md
+++ b/docs/concepts/qa-e2e-automation.md
@@ -1215,10 +1215,10 @@ report maps rankings back to real refs after parsing.
 Candidate runs default to `high` thinking, with `medium` for GPT-5.5 and
 `xhigh` for older OpenAI eval refs that support it. Override a specific
 candidate inline with `--model provider/model,thinking=<level>`; inline
-options also support `fast`, `no-fast`, and `fast=<bool>`. `--thinking
-<level>` still sets a global fallback, and the older `--model-thinking
-<provider/model=level>` form is kept for compatibility. OpenAI candidate
-refs default to fast mode so priority processing is used where the provider
+options also support `fast`, `no-fast`, and `fast=<bool>`. `--thinking <level>`
+still sets a global fallback, and the older
+`--model-thinking <provider/model=level>` form is kept for compatibility. OpenAI
+candidate refs default to fast mode so priority processing is used where the provider
 supports it. Pass `--fast` only when you want to force fast mode on for
 every candidate model. Candidate and judge durations are recorded in the
 report for benchmark analysis, but judge prompts explicitly say not to rank

--- a/docs/gateway/config-agents.md
+++ b/docs/gateway/config-agents.md
@@ -37,6 +37,8 @@ Optional repository root shown in the system prompt's Runtime line. If unset, Op
 }
 ```
 
+<a id="agentsdefaultsskills" />
+
 ### `agents.defaults.skills`
 
 Optional default skill allowlist for agents that do not set
@@ -607,6 +609,8 @@ Periodic heartbeat runs.
 - `skipWhenBusy`: when true, heartbeat runs defer on that agent's extra busy lanes: its own session-keyed subagent or nested command work. Cron lanes always defer heartbeats, even without this flag.
 - Per-agent: set `agents.list[].heartbeat`. When any agent defines `heartbeat`, **only those agents** run heartbeats.
 - Heartbeats run full agent turns — shorter intervals burn more tokens.
+
+<a id="agentsdefaultscompaction" />
 
 ### `agents.defaults.compaction`
 

--- a/docs/gateway/config-tools.md
+++ b/docs/gateway/config-tools.md
@@ -213,6 +213,8 @@ Controls elevated exec access outside the sandbox:
 
 Values shown are defaults except `applyPatch.allowModels` (empty/unset by default, meaning any compatible model may use `apply_patch`). `approvalRunningNoticeMs` emits a running notice when approval-backed exec runs long; `0` disables it.
 
+<a id="toolsloopdetection" />
+
 ### `tools.loopDetection`
 
 Tool-loop safety checks are **disabled by default**. Set `enabled: true` to activate detection. Settings can be defined globally in `tools.loopDetection` and overridden per-agent at `agents.list[].tools.loopDetection`.
@@ -386,6 +388,8 @@ Configures inbound media understanding (image/audio/video):
   },
 }
 ```
+
+<a id="toolssessions" />
 
 ### `tools.sessions`
 

--- a/docs/gateway/heartbeat.md
+++ b/docs/gateway/heartbeat.md
@@ -384,6 +384,8 @@ channels:
 | Indicator-only (no messages)             | `channels.defaults.heartbeat: { showOk: false, showAlerts: false, useIndicator: true }`  |
 | OKs in one channel only                  | `channels.telegram.heartbeat: { showOk: true }`                                          |
 
+<a id="heartbeatmd-optional" />
+
 ## HEARTBEAT.md (optional)
 
 If a `HEARTBEAT.md` file exists in the workspace, the default prompt tells the agent to read it. Think of it as your "heartbeat checklist": small, stable, and safe to consider every 30 minutes.

--- a/docs/index.md
+++ b/docs/index.md
@@ -54,7 +54,7 @@ OpenClaw is a **self-hosted gateway** that connects your favorite chat apps — 
 - **Agent-native**: built for coding agents with tool use, sessions, memory, and multi-agent routing
 - **Open source**: MIT licensed, community-driven
 
-**What do you need?** Node 24 (recommended), or Node 22 LTS (`22.19+`) for compatibility, an API key from your chosen provider, and 5 minutes. For best quality and security, use the strongest latest-generation model available.
+**What do you need?** Node 24 (recommended), or Node 22 LTS (`22.19+`) for compatibility, a supported auth method for your chosen provider, and 5 minutes. Onboarding supports API keys, OAuth, and provider-specific manual auth. For best quality and security, use the strongest latest-generation model available.
 
 ## How it works
 
@@ -98,7 +98,7 @@ The Gateway is the single source of truth for sessions, routing, and channel con
 <Steps>
   <Step title="Install OpenClaw">
     ```bash
-    npm install -g openclaw@latest
+    curl -fsSL https://openclaw.ai/install.sh | bash
     ```
   </Step>
   <Step title="Onboard and install the service">
@@ -118,7 +118,7 @@ The Gateway is the single source of truth for sessions, routing, and channel con
   </Step>
 </Steps>
 
-Need the full install and dev setup? See [Getting Started](/start/getting-started).
+Need Windows, npm, pnpm, bun, Docker, or source setup? See [Getting Started](/start/getting-started) and [Install](/install).
 
 ## Dashboard
 

--- a/docs/install/docker.md
+++ b/docs/install/docker.md
@@ -289,6 +289,8 @@ docker compose -f docker-compose.yml -f docker-compose.extra.yml run --rm \
 For shared production automation or predictable Anthropic billing, prefer the Anthropic API-key path. Claude CLI reuse follows Claude Code's installed version, account login, billing, and update behavior.
 </Note>
 
+<a id="bonjour--mdns" />
+
 ### Bonjour / mDNS
 
 Docker bridge networking usually doesn't forward Bonjour/mDNS multicast (`224.0.0.251:5353`) reliably. When `OPENCLAW_DISABLE_BONJOUR` is unset, the bundled Bonjour plugin auto-disables LAN advertising once it detects it's running in a container, so it won't crash-loop retrying multicast the bridge drops. Set `OPENCLAW_DISABLE_BONJOUR=1` to force it off regardless of detection, or `0` to force it on (only on host networking, macvlan, or another network where mDNS multicast is known to work).

--- a/docs/plugins/copilot.md
+++ b/docs/plugins/copilot.md
@@ -246,6 +246,8 @@ failure never fails the attempt: an internal best-effort wrapper, plus a
 defense-in-depth `.catch(...)` at the attempt level. Failures are logged, not
 surfaced.
 
+<a id="side-questions-btw" />
+
 ## Side questions (`/btw`)
 
 `/btw` is **not** native on this harness. `createCopilotAgentHarness()`

--- a/docs/plugins/memory-lancedb.md
+++ b/docs/plugins/memory-lancedb.md
@@ -182,11 +182,11 @@ local server returns context-length errors.
 
 ## Recall and capture limits
 
-| Setting           | Default | Range                        | Applies to                                                 |
-| ----------------- | ------- | ---------------------------- | ---------------------------------------------------------- |
-| `recallMaxChars`  | `1000`  | 100-10000                    | Text sent to the embedding API for recall.                 |
-| `captureMaxChars` | `500`   | 100-10000                    | Message length eligible for auto-capture.                  |
-| `customTriggers`  | `[]`    | 0-50 items, each <=100 chars | Literal phrases that make auto-capture consider a message. |
+| Setting           | Default | Range                            | Applies to                                                 |
+| ----------------- | ------- | -------------------------------- | ---------------------------------------------------------- |
+| `recallMaxChars`  | `1000`  | 100-10000                        | Text sent to the embedding API for recall.                 |
+| `captureMaxChars` | `500`   | 100-10000                        | Message length eligible for auto-capture.                  |
+| `customTriggers`  | `[]`    | 0-50 items, up to 100 chars each | Literal phrases that make auto-capture consider a message. |
 
 `recallMaxChars` bounds the `before_prompt_build` auto-recall query, the
 `memory_recall` tool, the `memory_forget` query path, and `openclaw ltm

--- a/docs/start/getting-started.md
+++ b/docs/start/getting-started.md
@@ -13,7 +13,7 @@ working chat session.
 ## What you need
 
 - **Node.js 22.19+, 23.11+, or 24+** (24 is the recommended default)
-- **An API key** from a model provider (Anthropic, OpenAI, Google, etc.) — onboarding will prompt you
+- **A model auth method** — onboarding supports API keys, OAuth, and provider-specific manual auth
 
 <Tip>
 Check your Node version with `node --version`.
@@ -54,8 +54,8 @@ Need to install Node? See [Node setup](/install/node).
     openclaw onboard --install-daemon
     ```
 
-    The wizard walks you through choosing a model provider, setting an API key,
-    and configuring the Gateway. QuickStart is usually only a few minutes, but
+    The wizard walks you through choosing a model provider, configuring auth,
+    and setting up the Gateway. QuickStart is usually only a few minutes, but
     provider sign-in, channel pairing, daemon install, network downloads, skills,
     or optional plugins can make full onboarding take longer. Skip optional
     steps and return later with `openclaw configure`.

--- a/docs/tools/exec-approvals.md
+++ b/docs/tools/exec-approvals.md
@@ -283,18 +283,18 @@ openclaw exec-policy preset yolo
 Updates both local `tools.exec.host/security/ask` and the local approvals
 file defaults (including `askFallback: "full"`). It is intentionally
 local-only. To change gateway-host or node-host approvals remotely, use
-`openclaw approvals set --gateway` or `openclaw approvals set --node
-<id|name|ip>`.
+`openclaw approvals set --gateway` or
+`openclaw approvals set --node <id|name|ip>`.
 
 Other built-in presets: `cautious` (`host=gateway`, `security=allowlist`,
 `ask=on-miss`, `askFallback=deny`) and `deny-all` (`host=gateway`,
 `security=deny`, `ask=off`, `askFallback=deny`). Apply the same way:
 `openclaw exec-policy preset cautious`.
 
-To set individual fields instead of a full preset, use
-`openclaw exec-policy set --host <auto|sandbox|gateway|node> --security
-<deny|allowlist|full> --ask <off|on-miss|always> --ask-fallback
-<deny|allowlist|full>` with any subset of those flags.
+To set individual fields instead of a full preset, use `openclaw exec-policy set`
+with any subset of `--host <auto|sandbox|gateway|node>`,
+`--security <deny|allowlist|full>`, `--ask <off|on-miss|always>`, and
+`--ask-fallback <deny|allowlist|full>`.
 
 ### Node host
 

--- a/docs/tools/skills-config.md
+++ b/docs/tools/skills-config.md
@@ -97,6 +97,8 @@ Most skills configuration lives under `skills` in
   need this setting.
 </ParamField>
 
+<a id="operator-install-policy-securityinstallpolicy" />
+
 ## Operator Install Policy (`security.installPolicy`)
 
 Use `security.installPolicy` when operators need a trusted local command to

--- a/docs/tools/thinking.md
+++ b/docs/tools/thinking.md
@@ -58,6 +58,8 @@ title: "Thinking levels"
 - **Embedded OpenClaw**: the resolved level is passed to the in-process OpenClaw agent runtime.
 - **Claude CLI backend**: non-off levels are passed to Claude Code as `--effort` when using `claude-cli`; see [CLI backends](/gateway/cli-backends).
 
+<a id="fast-mode-fast" />
+
 ## Fast mode (/fast)
 
 - Levels: `auto|on|off|default`.

--- a/scripts/docs-link-audit.mjs
+++ b/scripts/docs-link-audit.mjs
@@ -7,12 +7,21 @@ import os from "node:os";
 import path from "node:path";
 import { pathToFileURL } from "node:url";
 import { resolveClawHubRepoPath, syncClawHubDocsTree } from "./docs-sync-publish.mjs";
-import { createPnpmRunnerSpawnSpec } from "./pnpm-runner.mjs";
+import { resolveNpmRunner } from "./npm-runner.mjs";
 
 const ROOT = process.cwd();
 const DOCS_DIR = path.join(ROOT, "docs");
 const DOCS_JSON_PATH = path.join(DOCS_DIR, "docs.json");
-const MINTLIFY_BROKEN_LINKS_ARGS = ["dlx", "mint", "broken-links", "--check-anchors"];
+const MINTLIFY_PACKAGE = "mint@4.2.600";
+const MINTLIFY_BROKEN_LINKS_ARGS = [
+  "exec",
+  "--yes",
+  `--package=${MINTLIFY_PACKAGE}`,
+  "--",
+  "mint",
+  "broken-links",
+  "--check-anchors",
+];
 const NODE_25_UNSUPPORTED_BY_MINTLIFY = 25;
 
 if (!fs.existsSync(DOCS_DIR) || !fs.statSync(DOCS_DIR).isDirectory()) {
@@ -317,6 +326,10 @@ export function prepareMirroredDocsDir(sourceDir = DOCS_DIR, options = {}) {
   }
 }
 
+function rewritePureHtmlCommentLinesForMdx(text) {
+  return text.replace(/^([ \t]*)<!--([^\n]*)-->\s*$/gm, "$1{/*$2*/}");
+}
+
 /**
  * Creates an English-only temporary docs tree for Mintlify anchor checks.
  */
@@ -340,6 +353,17 @@ export function prepareAnchorAuditDocsDir(sourceDir = DOCS_DIR) {
     const sanitized = sanitizeDocsConfigForEnglishOnly(docsConfig);
     fs.writeFileSync(docsJsonPath, `${JSON.stringify(sanitized, null, 2)}\n`, "utf8");
 
+    for (const abs of walk(tempDir)) {
+      if (!/\.(md|mdx)$/i.test(abs)) {
+        continue;
+      }
+      const text = fs.readFileSync(abs, "utf8");
+      const rewritten = rewritePureHtmlCommentLinesForMdx(text);
+      if (rewritten !== text) {
+        fs.writeFileSync(abs, rewritten, "utf8");
+      }
+    }
+
     return tempDir;
   } catch (error) {
     fs.rmSync(tempDir, { recursive: true, force: true });
@@ -353,17 +377,26 @@ function parseNodeMajor(version) {
   return Number.isFinite(major) ? major : 0;
 }
 
-function createMintlifyPnpmRunnerSpawnSpec(params, options = {}) {
-  return createPnpmRunnerSpawnSpec({
+function createMintlifyNpmRunnerSpawnSpec(params, options = {}) {
+  const env = params.env ?? process.env;
+  const runner = resolveNpmRunner({
     comSpec: params.comSpec,
-    cwd: params.cwd,
-    env: params.env ?? process.env,
-    nodeExecPath: options.nodeExecPath ?? params.nodeExecPath,
-    npmExecPath: params.npmExecPath,
+    env,
+    execPath: options.nodeExecPath ?? params.nodeExecPath,
+    npmArgs: MINTLIFY_BROKEN_LINKS_ARGS,
     platform: params.platform,
-    pnpmArgs: MINTLIFY_BROKEN_LINKS_ARGS,
-    stdio: "inherit",
   });
+  return {
+    command: runner.command,
+    args: runner.args,
+    options: {
+      cwd: params.cwd,
+      env: runner.env ?? env,
+      shell: runner.shell,
+      stdio: "inherit",
+      windowsVerbatimArguments: runner.windowsVerbatimArguments,
+    },
+  };
 }
 
 /**
@@ -385,11 +418,11 @@ function createMintlifyPnpmRunnerSpawnSpec(params, options = {}) {
 export function resolveMintlifyAnchorAuditInvocation(params) {
   const nodeVersion = params.nodeVersion ?? process.versions.node;
   if (parseNodeMajor(nodeVersion) < NODE_25_UNSUPPORTED_BY_MINTLIFY) {
-    return createMintlifyPnpmRunnerSpawnSpec(params);
+    return createMintlifyNpmRunnerSpawnSpec(params);
   }
 
   const node22Probe = "process.exit(Number(process.versions.node.split('.')[0]) === 22 ? 0 : 1)";
-  const node22Runner = createMintlifyPnpmRunnerSpawnSpec(params, { nodeExecPath: "node" });
+  const node22Runner = createMintlifyNpmRunnerSpawnSpec(params, { nodeExecPath: "node" });
   const candidates = [
     {
       command: "fnm",
@@ -413,7 +446,7 @@ export function resolveMintlifyAnchorAuditInvocation(params) {
     }
   }
 
-  return createMintlifyPnpmRunnerSpawnSpec(params);
+  return createMintlifyNpmRunnerSpawnSpec(params);
 }
 
 /**
@@ -585,9 +618,8 @@ export function runDocsLinkAuditCli(options = {}) {
 
     try {
       anchorDocsDir = prepareAnchorAuditDocsDirImpl(mirroredDocsDir.dir);
-      // Use the npm Mintlify package explicitly. Some developer machines also
-      // have the Swift Package Manager tool named `mint` on PATH, and that
-      // binary exits with "command 'broken-links' not found".
+      // Use a pinned npm Mintlify package. pnpm dlx exposes Mintlify's undeclared
+      // transitive imports as ERR_MODULE_NOT_FOUND under isolated installs.
       const invocation = resolveMintlifyAnchorAuditInvocation({
         comSpec: options.comSpec,
         cwd: anchorDocsDir,

--- a/src/scripts/docs-link-audit.test.ts
+++ b/src/scripts/docs-link-audit.test.ts
@@ -150,13 +150,20 @@ describe("docs-link-audit", () => {
       )}\n`,
       "utf8",
     );
-    fs.writeFileSync(path.join(docsRoot, "help", "testing.md"), "# testing\n", "utf8");
+    fs.writeFileSync(
+      path.join(docsRoot, "help", "testing.md"),
+      "# testing\n<!-- anchor audit marker -->\n",
+      "utf8",
+    );
     fs.writeFileSync(path.join(docsRoot, "zh-CN", "help", "testing.md"), "# 测试\n", "utf8");
 
     const anchorDocsDir = prepareAnchorAuditDocsDir(docsRoot);
     try {
       expect(fs.existsSync(path.join(anchorDocsDir, "help", "testing.md"))).toBe(true);
       expect(fs.existsSync(path.join(anchorDocsDir, "zh-CN"))).toBe(false);
+      expect(fs.readFileSync(path.join(anchorDocsDir, "help", "testing.md"), "utf8")).toContain(
+        "{/* anchor audit marker */}",
+      );
 
       const sanitizedDocsJson = JSON.parse(
         fs.readFileSync(path.join(anchorDocsDir, "docs.json"), "utf8"),
@@ -256,7 +263,7 @@ describe("docs-link-audit", () => {
     expect(mirroredCleaned).toBe(true);
   });
 
-  it("uses Mintlify through pnpm dlx for anchor validation", () => {
+  it("uses pinned Mintlify through npm exec for anchor validation", () => {
     let invocation:
       | {
           command: string;
@@ -266,16 +273,13 @@ describe("docs-link-audit", () => {
       | undefined;
     let cleanedDir: string | undefined;
     const anchorDocsDir = path.join(os.tmpdir(), "docs-link-audit-anchor");
-    const fakePnpm = path.join(anchorDocsDir, "pnpm.cjs");
     fs.mkdirSync(anchorDocsDir, { recursive: true });
-    fs.writeFileSync(fakePnpm, "#!/usr/bin/env node\n", { mode: 0o755 });
 
     const exitCode = runDocsLinkAuditCli({
       args: ["--anchors"],
       env: { ...process.env, OPENCLAW_DOCS_LINK_SENTINEL: "1" },
       nodeExecPath: "/opt/node/bin/node",
       nodeVersion: "22.21.1",
-      npmExecPath: fakePnpm,
       prepareAnchorAuditDocsDirImpl() {
         return anchorDocsDir;
       },
@@ -290,8 +294,16 @@ describe("docs-link-audit", () => {
 
     expect(exitCode).toBe(0);
     expect(invocation).toEqual({
-      command: "/opt/node/bin/node",
-      args: [fakePnpm, "dlx", "mint", "broken-links", "--check-anchors"],
+      command: "npm",
+      args: [
+        "exec",
+        "--yes",
+        "--package=mint@4.2.600",
+        "--",
+        "mint",
+        "broken-links",
+        "--check-anchors",
+      ],
       options: expect.objectContaining({
         cwd: anchorDocsDir,
         env: expect.objectContaining({ OPENCLAW_DOCS_LINK_SENTINEL: "1" }),
@@ -310,15 +322,12 @@ describe("docs-link-audit", () => {
     }> = [];
     let cleanedDir: string | undefined;
     const anchorDocsDir = path.join(os.tmpdir(), "docs-link-audit-anchor");
-    const fakePnpm = path.join(anchorDocsDir, "pnpm.cjs");
     fs.mkdirSync(anchorDocsDir, { recursive: true });
-    fs.writeFileSync(fakePnpm, "#!/usr/bin/env node\n", { mode: 0o755 });
 
     const exitCode = runDocsLinkAuditCli({
       args: ["--anchors"],
       nodeExecPath: "/opt/node/bin/node",
       nodeVersion: "25.3.0",
-      npmExecPath: fakePnpm,
       prepareAnchorAuditDocsDirImpl() {
         return anchorDocsDir;
       },
@@ -353,9 +362,11 @@ describe("docs-link-audit", () => {
       args: [
         "exec",
         "--using=22",
-        "node",
-        fakePnpm,
-        "dlx",
+        "npm",
+        "exec",
+        "--yes",
+        "--package=mint@4.2.600",
+        "--",
         "mint",
         "broken-links",
         "--check-anchors",


### PR DESCRIPTION
## Summary
- Align README/home/getting-started onboarding copy with installer-first setup and non-API-key auth options.
- Make `docs:check-links:anchors` deterministic by running a pinned Mintlify package via npm and preparing an MDX-safe temp docs tree.
- Fix Mintlify-visible anchor targets and prose/table syntax that blocked anchor validation.

## Validation
- `pnpm docs:list`
- `pnpm docs:check-links`
- `pnpm docs:check-mdx`
- `pnpm format:docs:check`
- `pnpm docs:check-i18n-glossary`
- `pnpm lint:docs`
- `pnpm docs:check-links:anchors`
- `pnpm docs:map:check`
- `node scripts/test-projects.mjs src/scripts/docs-link-audit.test.ts`
- `git diff --check`

WhatsApp/runtime source changes are intentionally out of scope.