### PR TITLE
fix(google): normalize Live function declarations

### DIFF
--- a/extensions/google/realtime-voice-provider.test.ts
+++ b/extensions/google/realtime-voice-provider.test.ts
@@ -261,7 +261,7 @@ describe("buildGoogleRealtimeVoiceProvider", () => {
           behavior?: string;
           description?: string;
           name?: string;
-          parametersJsonSchema?: unknown;
+          parameters?: unknown;
         }>;
       }>;
     };
@@ -283,7 +283,7 @@ describe("buildGoogleRealtimeVoiceProvider", () => {
     const declarations = config.tools?.[0]?.functionDeclarations ?? [];
     expect(declarations[0]?.name).toBe("lookup");
     expect(declarations[0]?.description).toBe("Look something up");
-    expect(declarations[0]?.parametersJsonSchema).toEqual({
+    expect(declarations[0]?.parameters).toEqual({
       type: "object",
       properties: {
         query: { type: "string" },
@@ -292,7 +292,7 @@ describe("buildGoogleRealtimeVoiceProvider", () => {
     });
     expect(declarations[1]?.name).toBe("openclaw_agent_consult");
     expect(declarations[1]?.description).toBe("Ask OpenClaw");
-    expect(declarations[1]?.parametersJsonSchema).toEqual({
+    expect(declarations[1]?.parameters).toEqual({
       type: "object",
       properties: {
         question: { type: "string" },
@@ -403,7 +403,14 @@ describe("buildGoogleRealtimeVoiceProvider", () => {
             speechConfig?: { voiceConfig?: { prebuiltVoiceConfig?: { voiceName?: string } } };
             systemInstruction?: string;
             temperature?: number;
-            tools?: Array<{ functionDeclarations?: Array<{ behavior?: string; name?: string }> }>;
+            tools?: Array<{
+              functionDeclarations?: Array<{
+                behavior?: string;
+                name?: string;
+                parameters?: unknown;
+                parametersJsonSchema?: unknown;
+              }>;
+            }>;
           };
           model?: string;
         };
@@ -419,12 +426,17 @@ describe("buildGoogleRealtimeVoiceProvider", () => {
     expect(liveConstraints?.config?.speechConfig?.voiceConfig?.prebuiltVoiceConfig?.voiceName).toBe(
       "Puck",
     );
-    expect(liveConstraints?.config?.tools?.[0]?.functionDeclarations?.[0]?.name).toBe(
-      "openclaw_agent_consult",
-    );
-    expect(liveConstraints?.config?.tools?.[0]?.functionDeclarations?.[0]?.behavior).toBe(
-      "NON_BLOCKING",
-    );
+    const declaration = liveConstraints?.config?.tools?.[0]?.functionDeclarations?.[0];
+    expect(declaration?.name).toBe("openclaw_agent_consult");
+    expect(declaration?.behavior).toBe("NON_BLOCKING");
+    expect(declaration?.parameters).toEqual({
+      type: "object",
+      properties: {
+        question: { type: "string" },
+      },
+      required: ["question"],
+    });
+    expect(declaration?.parametersJsonSchema).toBeUndefined();
     expect(sessionLocal?.provider).toBe("google");
     expect(sessionLocal?.transport).toBe("provider-websocket");
     const websocketSession = sessionLocal as {

--- a/extensions/google/realtime-voice-provider.ts
+++ b/extensions/google/realtime-voice-provider.ts
@@ -340,10 +340,12 @@ function buildRealtimeInputConfig(
 
 function buildFunctionDeclarations(tools: RealtimeVoiceTool[] | undefined): FunctionDeclaration[] {
   return (tools ?? []).map((tool) => {
+    // Live preview models honor the OpenAPI `parameters` field; the SDK normalizes
+    // our lowercase JSON Schema types before sending the mutually exclusive field.
     const declaration: FunctionDeclaration = {
       name: tool.name,
       description: tool.description,
-      parametersJsonSchema: tool.parameters,
+      parameters: tool.parameters as unknown as FunctionDeclaration["parameters"],
     };
     if (tool.name === REALTIME_VOICE_AGENT_CONSULT_TOOL_NAME) {
       declaration.behavior = "NON_BLOCKING" as Behavior;


### PR DESCRIPTION
Supersedes #79572 because the contributor fork predates the current `main` history and cannot be refreshed through GitHub's verified branch-edit path without replaying unrelated repository history.

## What Problem This Solves

Fixes an issue where Google Live voice sessions could reject OpenClaw tool declarations before the model could call them.

## Why This Change Was Made

Realtime tool declarations now use the Google GenAI SDK's supported `parameters` field. The SDK normalizes that shape for Gemini Live, while `parametersJsonSchema` bypasses the required normalization. Existing constrained-session and browser tool declaration consumers are covered together.

## User Impact

Google Live voice sessions can register and call OpenClaw tools instead of failing on the declaration payload.

## Evidence

- Inspected the installed `@google/genai` 2.10.0 source and types: `parameters` is normalized for FunctionDeclaration payloads; `parametersJsonSchema` is passed through without that conversion.
- Blacksmith Testbox focused suite: 26/26 tests passed.
- Regression coverage includes the constrained browser-session tool declaration path.
- Fresh Codex autoreview: clean, 0.96 confidence.
- Original contributor evidence in #79572 documents a real PSTN/Gemini Live session. Co-authorship is preserved in the commit.

Known gap: no maintainer Gemini Live credential was available for an independent billed call; direct dependency-contract inspection and the focused declaration consumers are covered.
