### PR TITLE
fix(voice-call): normalize mapped proxy addresses

### DIFF
--- a/extensions/voice-call/src/proxy-ip.ts
+++ b/extensions/voice-call/src/proxy-ip.ts
@@ -1,0 +1,18 @@
+// Voice Call plugin module normalizes proxy IP representations.
+export function normalizeProxyIp(value: string | undefined): string | undefined {
+  const trimmed = value?.trim();
+  if (!trimmed) {
+    return undefined;
+  }
+  const unwrapped =
+    trimmed.startsWith("[") && trimmed.endsWith("]") ? trimmed.slice(1, -1) : trimmed;
+  const normalized = unwrapped.toLowerCase();
+  const mappedIpv4Prefix = "::ffff:";
+  if (normalized.startsWith(mappedIpv4Prefix)) {
+    const mappedIpv4 = normalized.slice(mappedIpv4Prefix.length);
+    if (/^\d{1,3}(?:\.\d{1,3}){3}$/.test(mappedIpv4)) {
+      return mappedIpv4;
+    }
+  }
+  return normalized;
+}

--- a/extensions/voice-call/src/webhook-security.test.ts
+++ b/extensions/voice-call/src/webhook-security.test.ts
@@ -388,6 +388,42 @@ describe("verifyPlivoWebhook", () => {
     expectAcceptedWebhookVersion(result, "v3");
   });
 
+  it("matches trusted proxies for Plivo when Node reports an IPv4-mapped remote address", () => {
+    const authToken = "test-auth-token";
+    const nonce = "nonce-ipv4-mapped-plivo";
+    const postBody = "CallUUID=uuid&CallStatus=in-progress&From=%2B15550000000";
+    const webhookUrl = "https://proxy.example.com/voice/webhook?flow=answer&callId=abc";
+
+    const signature = plivoV3Signature({
+      authToken,
+      urlWithQuery: webhookUrl,
+      postBody,
+      nonce,
+    });
+
+    const result = verifyPlivoWebhook(
+      {
+        headers: {
+          host: "localhost:3000",
+          "x-forwarded-proto": "https",
+          "x-forwarded-host": "proxy.example.com",
+          "x-plivo-signature-v3": signature,
+          "x-plivo-signature-v3-nonce": nonce,
+        },
+        rawBody: postBody,
+        url: "http://localhost:3000/voice/webhook?flow=answer&callId=abc",
+        method: "POST",
+        query: { flow: "answer", callId: "abc" },
+        remoteAddress: "::ffff:127.0.0.1",
+      },
+      authToken,
+      { trustForwardingHeaders: true, trustedProxyIPs: ["127.0.0.1"] },
+    );
+
+    expectAcceptedWebhookVersion(result, "v3");
+    expect(result.verificationUrl).toBe(webhookUrl);
+  });
+
   it("rejects missing signatures", () => {
     const result = verifyPlivoWebhook(
       {
@@ -784,6 +820,34 @@ describe("verifyTwilioWebhook", () => {
       },
       authToken,
       { trustForwardingHeaders: true, trustedProxyIPs: ["203.0.113.10"] },
+    );
+
+    expect(result.ok).toBe(true);
+    expect(result.verificationUrl).toBe(webhookUrl);
+  });
+
+  it("matches trusted proxies when Node reports an IPv4-mapped remote address", () => {
+    const authToken = "test-auth-token";
+    const postBody = "CallSid=CS123&CallStatus=completed&From=%2B15550000000";
+    const webhookUrl = "https://proxy.example.com/voice/webhook";
+
+    const signature = twilioSignature({ authToken, url: webhookUrl, postBody });
+
+    const result = verifyTwilioWebhook(
+      {
+        headers: {
+          host: "localhost:3000",
+          "x-forwarded-proto": "https",
+          "x-forwarded-host": "proxy.example.com",
+          "x-twilio-signature": signature,
+        },
+        rawBody: postBody,
+        url: "http://localhost:3000/voice/webhook",
+        method: "POST",
+        remoteAddress: "::ffff:127.0.0.1",
+      },
+      authToken,
+      { trustForwardingHeaders: true, trustedProxyIPs: ["127.0.0.1"] },
     );
 
     expect(result.ok).toBe(true);

--- a/extensions/voice-call/src/webhook-security.ts
+++ b/extensions/voice-call/src/webhook-security.ts
@@ -8,6 +8,7 @@ import {
   normalizeStringEntries,
 } from "openclaw/plugin-sdk/string-coerce-runtime";
 import { getHeader } from "./http-headers.js";
+import { normalizeProxyIp } from "./proxy-ip.js";
 import type { WebhookContext } from "./types.js";
 import { createWebhookReplayCache, markWebhookReplay } from "./webhook-replay.js";
 
@@ -207,8 +208,13 @@ export function reconstructWebhookUrl(ctx: WebhookContext, options?: WebhookUrlO
   const trustedProxyIPs = options?.trustedProxyIPs?.filter(Boolean) ?? [];
   const hasTrustedProxyIPs = trustedProxyIPs.length > 0;
   const remoteIP = options?.remoteIP ?? ctx.remoteAddress;
+  const normalizedTrustedProxyIps = new Set(
+    trustedProxyIPs.map((ip) => normalizeProxyIp(ip)).filter((ip): ip is string => Boolean(ip)),
+  );
+  const normalizedRemoteIp = normalizeProxyIp(remoteIP);
   const fromTrustedProxy =
-    !hasTrustedProxyIPs || (remoteIP ? trustedProxyIPs.includes(remoteIP) : false);
+    !hasTrustedProxyIPs ||
+    (normalizedRemoteIp ? normalizedTrustedProxyIps.has(normalizedRemoteIp) : false);
 
   // Only trust forwarding headers if: (has whitelist OR explicitly trusted) AND from trusted proxy
   const shouldTrustForwardingHeaders = (hasAllowedHosts || explicitlyTrusted) && fromTrustedProxy;

--- a/extensions/voice-call/src/webhook.ts
+++ b/extensions/voice-call/src/webhook.ts
@@ -38,6 +38,7 @@ import { MediaStreamHandler } from "./media-stream.js";
 import type { VoiceCallProvider } from "./providers/base.js";
 import { isProviderStatusTerminal } from "./providers/shared/call-status.js";
 import type { TwilioProvider } from "./providers/twilio.js";
+import { normalizeProxyIp } from "./proxy-ip.js";
 import type { CallRecord, NormalizedEvent, WebhookContext } from "./types.js";
 import type { WebhookResponsePayload } from "./webhook.types.js";
 import type { RealtimeCallHandler } from "./webhook/realtime-handler.js";
@@ -105,24 +106,6 @@ function appendRecentTalkEventMetadata(call: CallRecord, event: TalkEvent): void
 
 function buildRequestUrl(requestUrl: string | undefined): URL {
   return new URL(requestUrl ?? "/", "http://localhost");
-}
-
-function normalizeProxyIp(value: string | undefined): string | undefined {
-  const trimmed = value?.trim();
-  if (!trimmed) {
-    return undefined;
-  }
-  const unwrapped =
-    trimmed.startsWith("[") && trimmed.endsWith("]") ? trimmed.slice(1, -1) : trimmed;
-  const normalized = unwrapped.toLowerCase();
-  const mappedIpv4Prefix = "::ffff:";
-  if (normalized.startsWith(mappedIpv4Prefix)) {
-    const mappedIpv4 = normalized.slice(mappedIpv4Prefix.length);
-    if (/^\d{1,3}(?:\.\d{1,3}){3}$/.test(mappedIpv4)) {
-      return mappedIpv4;
-    }
-  }
-  return normalized;
 }
 
 function resolveForwardedClientIp(


### PR DESCRIPTION
Closes #86525
Supersedes #86527 because the contributor fork predates the current `main` history and cannot be refreshed through GitHub's verified branch-edit path without replaying unrelated repository history.

## What Problem This Solves

Fixes an issue where voice webhooks arriving through an IPv4 socket could be represented by Node as an IPv4-mapped IPv6 address, preventing a configured trusted IPv4 proxy from being recognized.

## Why This Change Was Made

Webhook signature verification and the media-stream path now share one narrow proxy-address normalizer. Only IPv4-mapped IPv6 literals are converted; ordinary IPv4 and IPv6 addresses retain their existing representation and trust checks.

## User Impact

Operators using trusted IPv4 reverse proxies can validate carrier webhook URLs correctly even when Node reports the peer as `::ffff:a.b.c.d`.

## Evidence

- Focused local voice-call suites: 70/70 tests passed.
- Blacksmith Testbox focused suite: 67/67 tests passed.
- Real IPv4 TCP socket probe produced `::ffff:127.0.0.1`; the production Twilio verifier accepted the reconstructed public proxy URL and returned a verified request key.
- Twilio and Plivo webhook proxy/signature contracts were checked against their current official documentation.
- Fresh Codex autoreview: clean, 0.99 confidence.
- Original contributor credit from #86527 is preserved in the commit.

Known proof gaps: none for the bounded address-normalization path.
