### PR TITLE
fix: correct typo 'explict' to 'explicit' in agent contributing guide

### DIFF
--- a/.agents/skills/technical-documentation/references/agent-and-contributing.md
+++ b/.agents/skills/technical-documentation/references/agent-and-contributing.md
@@ -141,5 +141,5 @@ When these rules conflict:
 1. Preserve contributor and reader task success first.
 2. Preserve instruction clarity and unambiguous boundaries second.
 3. Preserve long-term maintainability and context-efficiency third.
-4. Add extra agent optimization only if it does not reduce human clarity or there is explict need.
+4. Add extra agent optimization only if it does not reduce human clarity or there is explicit need.
 5. Use your judgement as the expert.


### PR DESCRIPTION
## What Problem This Solves

Fixes a spelling mistake in the agent contributing reference document.

## Why This Change Was Made

"explict" should be "explicit" — this is a straightforward typo fix that improves documentation clarity for AI agents reading the guidance.

## User Impact

Agents reading this document will see correct spelling, reducing potential confusion.

## Evidence

Single character fix: `explict` → `explicit`