### PR TITLE
fix(agents): carry current-turn inbound metadata in a tail runtime-context message for byte-stable prompt caching

### DIFF
--- a/extensions/anthropic/stream-wrappers.ts
+++ b/extensions/anthropic/stream-wrappers.ts
@@ -209,7 +209,7 @@ export function createAnthropicServiceTierWrapper(
     }
 
     return streamWithPayloadPatch(underlying, model, context, options, (payloadObj) =>
-      applyAnthropicPayloadPolicyToParams(payloadObj, payloadPolicy),
+      applyAnthropicPayloadPolicyToParams(payloadObj, payloadPolicy, new Set()),
     );
   };
 }

--- a/extensions/qa-lab/src/providers/aimock/server.ts
+++ b/extensions/qa-lab/src/providers/aimock/server.ts
@@ -23,6 +23,11 @@ type AimockRequestSnapshot = {
   toolOutputStructuredError?: true;
 };
 
+// Runtime-context delimiters are owned by src/agents/internal-runtime-context.ts.
+// This mock mirrors the wire shape so delimiter drift fails through QA timeouts.
+const INTERNAL_RUNTIME_CONTEXT_BEGIN = "<<<BEGIN_OPENCLAW_INTERNAL_CONTEXT>>>";
+const INTERNAL_RUNTIME_CONTEXT_END = "<<<END_OPENCLAW_INTERNAL_CONTEXT>>>";
+
 function stringifyContent(content: unknown): string {
   if (typeof content === "string") {
     return content;
@@ -57,10 +62,21 @@ function extractLastUserText(body: ChatCompletionRequest | null | undefined) {
   for (let index = messages.length - 1; index >= 0; index -= 1) {
     const message = messages[index];
     if (message?.role === "user") {
-      return stringifyContent(message.content);
+      const text = stringifyContent(message.content);
+      if (!isInternalRuntimeContextCarrierText(text)) {
+        return text;
+      }
     }
   }
   return "";
+}
+
+function isInternalRuntimeContextCarrierText(text: string) {
+  const trimmed = text.trim();
+  return (
+    trimmed.includes(INTERNAL_RUNTIME_CONTEXT_BEGIN) &&
+    trimmed.endsWith(INTERNAL_RUNTIME_CONTEXT_END)
+  );
 }
 
 function extractAllInputText(body: ChatCompletionRequest | null | undefined) {

--- a/extensions/qa-lab/src/providers/mock-openai/server.test.ts
+++ b/extensions/qa-lab/src/providers/mock-openai/server.test.ts
@@ -133,6 +133,15 @@ function makeUserInput(text: string) {
   };
 }
 
+const TEST_RUNTIME_CONTEXT_CARRIER = [
+  "OpenClaw runtime context for the immediately preceding user message.",
+  "This context is runtime-generated, not user-authored. Keep internal details private.",
+  "",
+  "<<<BEGIN_OPENCLAW_INTERNAL_CONTEXT>>>",
+  "runtime metadata",
+  "<<<END_OPENCLAW_INTERNAL_CONTEXT>>>",
+].join("\n");
+
 function makeDeveloperInput(text: string) {
   return {
     role: "developer" as const,
@@ -3576,6 +3585,21 @@ describe("qa mock openai server", () => {
 
     expect(response.status).toBe(200);
     expect(outputText(await response.json())).toBe("CURRENT_REPLY");
+  });
+
+  it("uses the previous user instruction when the tail user item is runtime context", async () => {
+    const server = await startMockServer();
+
+    const response = await postResponses(server, {
+      stream: false,
+      input: [
+        makeUserInput("Reply exactly: QA_RUNTIME_CONTEXT_CARRIER_OK"),
+        makeUserInput(TEST_RUNTIME_CONTEXT_CARRIER),
+      ],
+    });
+
+    expect(response.status).toBe(200);
+    expect(outputText(await response.json())).toBe("QA_RUNTIME_CONTEXT_CARRIER_OK");
   });
 
   it("uses WhatsApp location markers only for the matching coordinate body", async () => {

--- a/extensions/qa-lab/src/providers/mock-openai/server.ts
+++ b/extensions/qa-lab/src/providers/mock-openai/server.ts
@@ -113,6 +113,11 @@ type MockOpenAiRequestSnapshot = {
   toolOutputStructuredError?: true;
 };
 
+// Runtime-context delimiters are owned by src/agents/internal-runtime-context.ts.
+// This mock mirrors the wire shape so delimiter drift fails through QA timeouts.
+const INTERNAL_RUNTIME_CONTEXT_BEGIN = "<<<BEGIN_OPENCLAW_INTERNAL_CONTEXT>>>";
+const INTERNAL_RUNTIME_CONTEXT_END = "<<<END_OPENCLAW_INTERNAL_CONTEXT>>>";
+
 // Anthropic /v1/messages request/response shapes the mock actually needs.
 // This is a subset of the real Anthropic Messages API — just enough so the
 // QA suite can run its parity pack against a "baseline" Anthropic provider
@@ -368,7 +373,7 @@ function extractLastUserText(input: ResponsesInputItem[]) {
       continue;
     }
     const text = extractInputText(item.content);
-    if (text) {
+    if (text && !isInternalRuntimeContextCarrierText(text)) {
       return text;
     }
   }
@@ -378,11 +383,22 @@ function extractLastUserText(input: ResponsesInputItem[]) {
 function findLastUserIndex(input: ResponsesInputItem[]) {
   for (let index = input.length - 1; index >= 0; index -= 1) {
     const item = input[index];
-    if (item.role === "user" && Array.isArray(item.content)) {
+    if (item.role !== "user" || !Array.isArray(item.content)) {
+      continue;
+    }
+    if (!isInternalRuntimeContextCarrierText(extractInputText(item.content))) {
       return index;
     }
   }
   return -1;
+}
+
+function isInternalRuntimeContextCarrierText(text: string) {
+  const trimmed = text.trim();
+  return (
+    trimmed.includes(INTERNAL_RUNTIME_CONTEXT_BEGIN) &&
+    trimmed.endsWith(INTERNAL_RUNTIME_CONTEXT_END)
+  );
 }
 
 function isToolOutputContinuationText(text: string) {

--- a/packages/agent-core/src/harness/messages.test.ts
+++ b/packages/agent-core/src/harness/messages.test.ts
@@ -39,3 +39,31 @@ describe("harness message timestamps", () => {
     expect(message?.timestamp).toBe(0);
   });
 });
+
+describe("convertToLlm runtime-context carrier marking", () => {
+  const timestamp = "2026-05-30T17:00:00.000Z";
+
+  it("marks a runtime-context carrier custom message so providers skip cache anchoring", () => {
+    const [message] = convertToLlm([
+      createCustomMessage(
+        "openclaw.runtime-context",
+        "current-turn metadata",
+        false,
+        { source: "openclaw-runtime-context", runtimeContextCarrier: true },
+        timestamp,
+      ),
+    ]);
+
+    expect(message?.role).toBe("user");
+    expect((message as { runtimeContextCarrier?: boolean }).runtimeContextCarrier).toBe(true);
+  });
+
+  it("does not mark ordinary custom messages", () => {
+    const [message] = convertToLlm([
+      createCustomMessage("note", "some note", false, { source: "other" }, timestamp),
+    ]);
+
+    expect(message?.role).toBe("user");
+    expect((message as { runtimeContextCarrier?: boolean }).runtimeContextCarrier).toBeUndefined();
+  });
+});

--- a/packages/agent-core/src/harness/messages.ts
+++ b/packages/agent-core/src/harness/messages.ts
@@ -139,10 +139,16 @@ export function convertToLlm(messages: AgentMessage[]): Message[] {
             typeof message.content === "string"
               ? [{ type: "text" as const, text: message.content }]
               : message.content;
+          // Transient current-turn runtime-context carriers must not anchor a
+          // provider prompt-cache breakpoint (their bytes change every turn).
+          const runtimeContextCarrier =
+            (message.details as { runtimeContextCarrier?: unknown } | undefined)
+              ?.runtimeContextCarrier === true;
           return {
             role: "user",
             content,
             timestamp: message.timestamp,
+            ...(runtimeContextCarrier ? { runtimeContextCarrier: true } : {}),
           };
         }
         case "branchSummary":

--- a/packages/ai/src/providers/anthropic.test.ts
+++ b/packages/ai/src/providers/anthropic.test.ts
@@ -1985,6 +1985,44 @@ describe("Anthropic provider", () => {
     ]);
   });
 
+  it("anchors the message cache breakpoint on the last stable user turn, skipping a trailing runtime-context carrier", async () => {
+    let capturedPayload: unknown;
+    const stream = streamSimpleAnthropic(
+      makeAnthropicModel(),
+      {
+        systemPrompt: "system",
+        messages: [
+          { role: "user", content: "stable question", timestamp: 0 },
+          {
+            role: "user",
+            content: "volatile current-turn metadata",
+            timestamp: 1,
+            runtimeContextCarrier: true,
+          },
+        ],
+      },
+      {
+        apiKey: "sk-ant-provider",
+        onPayload: (payload) => {
+          capturedPayload = payload;
+          throw new Error("stop before network");
+        },
+      },
+    );
+
+    const result = await stream.result();
+
+    expect(result.stopReason).toBe("error");
+    const messages = (capturedPayload as { messages: { content: unknown }[] }).messages;
+    // Deepest breakpoint anchors on the stable user turn (converted to a block
+    // array with cache_control) so it stays a cacheable prefix next turn...
+    expect(messages[0]?.content).toEqual([
+      { type: "text", text: "stable question", cache_control: { type: "ephemeral" } },
+    ]);
+    // ...and NOT on the trailing volatile carrier, which is left uncached.
+    expect(messages[1]?.content).toBe("volatile current-turn metadata");
+  });
+
   it("emits start event only after message_start so pre-stream SSE errors arrive before any non-error event", async () => {
     function createSseEventResponse(lines: string): Response {
       return new Response(lines, {

--- a/packages/ai/src/providers/anthropic.ts
+++ b/packages/ai/src/providers/anthropic.ts
@@ -1381,6 +1381,10 @@ function convertMessages(
   replayThinkingEnabled = true,
 ): MessageParam[] {
   const params: MessageParam[] = [];
+  // Param indexes for transient runtime-context carriers — excluded from
+  // cache_control breakpoint selection so the deepest breakpoint anchors on the
+  // last stable user turn, not the volatile carrier appended after it.
+  const cacheBreakpointOptOutParamIndexes = new Set<number>();
 
   // Transform messages for cross-provider compatibility
   const transformedMessages = transformMessages(messages, model, normalizeToolCallId);
@@ -1392,8 +1396,12 @@ function convertMessages(
     const msg = transformedMessages[i];
 
     if (msg.role === "user") {
+      const isRuntimeContextCarrier = msg.runtimeContextCarrier === true;
       if (typeof msg.content === "string") {
         if (msg.content.trim().length > 0) {
+          if (isRuntimeContextCarrier) {
+            cacheBreakpointOptOutParamIndexes.add(params.length);
+          }
           params.push({
             role: "user",
             content: sanitizeSurrogates(msg.content),
@@ -1424,6 +1432,9 @@ function convertMessages(
         });
         if (filteredBlocks.length === 0) {
           continue;
+        }
+        if (isRuntimeContextCarrier) {
+          cacheBreakpointOptOutParamIndexes.add(params.length);
         }
         params.push({
           role: "user",
@@ -1536,7 +1547,7 @@ function convertMessages(
 
     for (let i = params.length - 1; i >= 0; i--) {
       const message = params[i];
-      if (message.role !== "user") {
+      if (message.role !== "user" || cacheBreakpointOptOutParamIndexes.has(i)) {
         continue;
       }
 

--- a/packages/ai/src/providers/openai-completions.test.ts
+++ b/packages/ai/src/providers/openai-completions.test.ts
@@ -718,6 +718,49 @@ describe("OpenAI-compatible completions params", () => {
     });
   });
 
+  it("anchors the OpenRouter Anthropic cache marker on the last stable user turn, skipping a trailing runtime-context carrier", async () => {
+    let capturedMessages: unknown;
+    const stream = streamOpenAICompletions(
+      {
+        ...createModel(32_000),
+        id: "anthropic/claude-sonnet-4.6",
+        provider: "openrouter",
+        baseUrl: "https://openrouter.ai/api/v1",
+      },
+      {
+        systemPrompt: "system",
+        messages: [
+          { role: "user", content: "stable question", timestamp: 1 },
+          {
+            role: "user",
+            content: "volatile current-turn metadata",
+            timestamp: 2,
+            runtimeContextCarrier: true,
+          },
+        ],
+      },
+      {
+        apiKey: "sk-test",
+        onPayload(payload) {
+          capturedMessages = (payload as { messages?: unknown }).messages;
+          throw new Error("stop before network");
+        },
+      },
+    );
+
+    const result = await stream.result();
+
+    expect(result.stopReason).toBe("error");
+    const messages = capturedMessages as Array<{ role: string; content: unknown }>;
+    const stableMsg = messages.find((m) => JSON.stringify(m.content).includes("stable question"));
+    const carrierMsg = messages.find((m) =>
+      JSON.stringify(m.content).includes("volatile current-turn metadata"),
+    );
+    // The stable user turn carries the cache breakpoint; the trailing carrier does not.
+    expect(JSON.stringify(stableMsg)).toContain("cache_control");
+    expect(JSON.stringify(carrierMsg)).not.toContain("cache_control");
+  });
+
   it("adds reasoning_content replay fields for Xiaomi MiMo assistant tool history", async () => {
     let capturedMessages: unknown;
     const stream = streamOpenAICompletions(

--- a/packages/ai/src/providers/openai-completions.ts
+++ b/packages/ai/src/providers/openai-completions.ts
@@ -650,7 +650,11 @@ function buildParams(
   cacheRetention: CacheRetention = resolveCacheRetention(options?.cacheRetention),
 ) {
   const cacheControl = getCompatCacheControl(compat, cacheRetention);
+  // Transient runtime-context carrier indexes skip cache anchoring so the breakpoint
+  // stays on the last stable user turn; conversion-to-policy must not splice messages.
+  const cacheOptOutIndexes = new Set<number>();
   const messages = convertMessages(model, context, compat, {
+    cacheOptOutIndexes,
     preserveSystemPromptCacheBoundary: cacheControl !== undefined,
   });
 
@@ -731,7 +735,7 @@ function buildParams(
   }
 
   if (cacheControl) {
-    applyAnthropicCacheControl(messages, params.tools, cacheControl);
+    applyAnthropicCacheControl(messages, params.tools, cacheControl, cacheOptOutIndexes);
   }
 
   if (options?.toolChoice) {
@@ -838,20 +842,15 @@ function getCompatCacheControl(
   return { type: "ephemeral", ...(ttl ? { ttl } : {}) };
 }
 
-// Params built from transient runtime-context carrier user messages — excluded
-// from cache_control breakpoint selection so anchoring stays on the last stable
-// user turn, not the volatile carrier appended after it. Keyed by object
-// identity so concurrent conversions never collide, and never serialized.
-const runtimeContextCarrierParams = new WeakSet<object>();
-
 function applyAnthropicCacheControl(
   messages: ChatCompletionMessageParam[],
   tools: OpenAI.Chat.Completions.ChatCompletionTool[] | undefined,
   cacheControl: OpenAICompatCacheControl,
+  cacheOptOutIndexes: ReadonlySet<number>,
 ): void {
   addCacheControlToSystemPrompt(messages, cacheControl);
   addCacheControlToLastTool(tools, cacheControl);
-  addCacheControlToLastConversationMessage(messages, cacheControl);
+  addCacheControlToLastConversationMessage(messages, cacheControl, cacheOptOutIndexes);
 }
 
 function addCacheControlToSystemPrompt(
@@ -869,10 +868,11 @@ function addCacheControlToSystemPrompt(
 function addCacheControlToLastConversationMessage(
   messages: ChatCompletionMessageParam[],
   cacheControl: OpenAICompatCacheControl,
+  cacheOptOutIndexes: ReadonlySet<number>,
 ): void {
   for (let i = messages.length - 1; i >= 0; i--) {
     const message = messages[i];
-    if (runtimeContextCarrierParams.has(message)) {
+    if (cacheOptOutIndexes.has(i)) {
       continue;
     }
     if (message.role === "user" || message.role === "assistant") {
@@ -971,7 +971,10 @@ export function convertMessages(
   model: Model<"openai-completions">,
   context: Context,
   compat: ResolvedOpenAICompletionsCompat,
-  options: { preserveSystemPromptCacheBoundary?: boolean } = {},
+  options: {
+    cacheOptOutIndexes?: Set<number>;
+    preserveSystemPromptCacheBoundary?: boolean;
+  } = {},
 ): ChatCompletionMessageParam[] {
   const params: ChatCompletionMessageParam[] = [];
 
@@ -1033,7 +1036,7 @@ export function convertMessages(
           content: sanitizeSurrogates(msg.content),
         };
         if (isRuntimeContextCarrier) {
-          runtimeContextCarrierParams.add(userParam);
+          options.cacheOptOutIndexes?.add(params.length);
         }
         params.push(userParam);
       } else {
@@ -1061,7 +1064,7 @@ export function convertMessages(
           content,
         };
         if (isRuntimeContextCarrier) {
-          runtimeContextCarrierParams.add(userParam);
+          options.cacheOptOutIndexes?.add(params.length);
         }
         params.push(userParam);
       }

--- a/packages/ai/src/providers/openai-completions.ts
+++ b/packages/ai/src/providers/openai-completions.ts
@@ -838,6 +838,12 @@ function getCompatCacheControl(
   return { type: "ephemeral", ...(ttl ? { ttl } : {}) };
 }
 
+// Params built from transient runtime-context carrier user messages — excluded
+// from cache_control breakpoint selection so anchoring stays on the last stable
+// user turn, not the volatile carrier appended after it. Keyed by object
+// identity so concurrent conversions never collide, and never serialized.
+const runtimeContextCarrierParams = new WeakSet<object>();
+
 function applyAnthropicCacheControl(
   messages: ChatCompletionMessageParam[],
   tools: OpenAI.Chat.Completions.ChatCompletionTool[] | undefined,
@@ -866,6 +872,9 @@ function addCacheControlToLastConversationMessage(
 ): void {
   for (let i = messages.length - 1; i >= 0; i--) {
     const message = messages[i];
+    if (runtimeContextCarrierParams.has(message)) {
+      continue;
+    }
     if (message.role === "user" || message.role === "assistant") {
       if (addCacheControlToMessage(message, cacheControl)) {
         return;
@@ -1017,11 +1026,16 @@ export function convertMessages(
     }
 
     if (msg.role === "user") {
+      const isRuntimeContextCarrier = msg.runtimeContextCarrier === true;
       if (typeof msg.content === "string") {
-        params.push({
+        const userParam: ChatCompletionMessageParam = {
           role: "user",
           content: sanitizeSurrogates(msg.content),
-        });
+        };
+        if (isRuntimeContextCarrier) {
+          runtimeContextCarrierParams.add(userParam);
+        }
+        params.push(userParam);
       } else {
         const content: ChatCompletionContentPart[] = msg.content.map(
           (item): ChatCompletionContentPart => {
@@ -1042,10 +1056,14 @@ export function convertMessages(
         if (content.length === 0) {
           continue;
         }
-        params.push({
+        const userParam: ChatCompletionMessageParam = {
           role: "user",
           content,
-        });
+        };
+        if (isRuntimeContextCarrier) {
+          runtimeContextCarrierParams.add(userParam);
+        }
+        params.push(userParam);
       }
     } else if (msg.role === "assistant") {
       // Some providers don't accept null content, use empty string instead

--- a/packages/llm-core/src/types.ts
+++ b/packages/llm-core/src/types.ts
@@ -285,6 +285,15 @@ export interface UserMessage {
   role: "user";
   content: string | (TextContent | ImageContent)[];
   timestamp: number; // Unix timestamp in milliseconds
+  /**
+   * Marks a user message that carries transient current-turn runtime context
+   * (e.g. an OpenClaw runtime-context carrier appended after the active user
+   * turn). Such messages are volatile — present only on the turn they belong to
+   * and stripped on replay — so providers must NOT anchor a prompt-cache
+   * breakpoint on them, or the breakpoint would land on bytes that change every
+   * turn. Anchoring stays on the last stable (non-carrier) user message.
+   */
+  runtimeContextCarrier?: boolean;
 }
 
 /** Assistant turn, including provider identity and final stop state. */

--- a/src/agents/anthropic-payload-policy.test.ts
+++ b/src/agents/anthropic-payload-policy.test.ts
@@ -6,7 +6,6 @@ import { SYSTEM_PROMPT_CACHE_BOUNDARY } from "@openclaw/ai/internal/shared";
  */
 import { describe, expect, it } from "vitest";
 import {
-  anthropicRuntimeContextCarrierParams,
   applyAnthropicPayloadPolicyToParams,
   resolveAnthropicPayloadPolicy,
 } from "./anthropic-payload-policy.js";
@@ -83,7 +82,7 @@ describe("anthropic payload policy", () => {
       ],
     };
 
-    applyAnthropicPayloadPolicyToParams(payload, policy);
+    applyAnthropicPayloadPolicyToParams(payload, policy, new Set());
 
     expect(payload.service_tier).toBe("standard_only");
     expect(payload.system).toEqual([
@@ -118,14 +117,12 @@ describe("anthropic payload policy", () => {
     });
     const stableUser = { role: "user", content: [{ type: "text", text: "stable question" }] };
     const carrier = { role: "user", content: "volatile current-turn metadata" };
-    // The managed transport marks carrier params on conversion; emulate that.
-    anthropicRuntimeContextCarrierParams.add(carrier);
     const payload: TestPayload = {
       system: [{ type: "text", text: "system" }],
       messages: [stableUser, carrier],
     };
 
-    applyAnthropicPayloadPolicyToParams(payload, policy);
+    applyAnthropicPayloadPolicyToParams(payload, policy, new Set([1]));
 
     // Deepest breakpoint anchors on the stable user turn...
     expect(payload.messages[0]).toEqual({
@@ -175,7 +172,7 @@ describe("anthropic payload policy", () => {
       ],
     };
 
-    applyAnthropicPayloadPolicyToParams(payload, policy);
+    applyAnthropicPayloadPolicyToParams(payload, policy, new Set());
 
     expect(payload.messages[0]).toEqual({
       role: "user",
@@ -230,7 +227,7 @@ describe("anthropic payload policy", () => {
       ],
     };
 
-    applyAnthropicPayloadPolicyToParams(payload, policy);
+    applyAnthropicPayloadPolicyToParams(payload, policy, new Set());
 
     expect(payload.messages[0]).toEqual({
       role: "user",
@@ -279,7 +276,7 @@ describe("anthropic payload policy", () => {
       ],
     };
 
-    applyAnthropicPayloadPolicyToParams(payload, policy);
+    applyAnthropicPayloadPolicyToParams(payload, policy, new Set());
 
     expect(payload.messages[0]).toEqual({
       role: "user",
@@ -309,7 +306,7 @@ describe("anthropic payload policy", () => {
     });
     const payload = simpleTextPayload();
 
-    applyAnthropicPayloadPolicyToParams(payload, policy);
+    applyAnthropicPayloadPolicyToParams(payload, policy, new Set());
 
     expect(payload).not.toHaveProperty("service_tier");
     expect(payload.system).toEqual([textBlock("Follow policy.", { type: "ephemeral", ttl: "1h" })]);
@@ -331,7 +328,7 @@ describe("anthropic payload policy", () => {
       });
       const payload = simpleTextPayload();
 
-      applyAnthropicPayloadPolicyToParams(payload, policy);
+      applyAnthropicPayloadPolicyToParams(payload, policy, new Set());
 
       expectShortEphemeralTextPayload(payload);
     } finally {
@@ -353,7 +350,7 @@ describe("anthropic payload policy", () => {
     });
     const payload = simpleTextPayload();
 
-    applyAnthropicPayloadPolicyToParams(payload, policy);
+    applyAnthropicPayloadPolicyToParams(payload, policy, new Set());
 
     expectShortEphemeralTextPayload(payload);
   });
@@ -368,7 +365,7 @@ describe("anthropic payload policy", () => {
     });
     const payload = boundarySystemPayload();
 
-    applyAnthropicPayloadPolicyToParams(payload, policy);
+    applyAnthropicPayloadPolicyToParams(payload, policy, new Set());
 
     expect(payload.system).toEqual([
       textBlock("Stable prefix", { type: "ephemeral", ttl: "1h" }),
@@ -392,7 +389,7 @@ describe("anthropic payload policy", () => {
       messages: [{ role: "user", content: "Hello" }],
     };
 
-    applyAnthropicPayloadPolicyToParams(payload, policy);
+    applyAnthropicPayloadPolicyToParams(payload, policy, new Set());
 
     expect(payload.system).toEqual([
       textBlock("Follow policy.", { type: "ephemeral", ttl: "1h" }),
@@ -414,7 +411,7 @@ describe("anthropic payload policy", () => {
     });
     const payload = simpleTextPayload();
 
-    applyAnthropicPayloadPolicyToParams(payload, policy);
+    applyAnthropicPayloadPolicyToParams(payload, policy, new Set());
 
     expect(payload.system).toEqual([textBlock("Follow policy.", { type: "ephemeral" })]);
   });
@@ -429,7 +426,7 @@ describe("anthropic payload policy", () => {
     });
     const payload = boundarySystemPayload();
 
-    applyAnthropicPayloadPolicyToParams(payload, policy);
+    applyAnthropicPayloadPolicyToParams(payload, policy, new Set());
 
     expect(payload.system).toEqual([textBlock("Stable prefix\nDynamic lab suffix")]);
   });

--- a/src/agents/anthropic-payload-policy.test.ts
+++ b/src/agents/anthropic-payload-policy.test.ts
@@ -6,6 +6,7 @@ import { SYSTEM_PROMPT_CACHE_BOUNDARY } from "@openclaw/ai/internal/shared";
  */
 import { describe, expect, it } from "vitest";
 import {
+  anthropicRuntimeContextCarrierParams,
   applyAnthropicPayloadPolicyToParams,
   resolveAnthropicPayloadPolicy,
 } from "./anthropic-payload-policy.js";
@@ -104,6 +105,39 @@ describe("anthropic payload policy", () => {
           cache_control: { type: "ephemeral", ttl: "1h" },
         },
       ],
+    });
+  });
+
+  it("anchors the cache marker on the last stable user turn, skipping a trailing runtime-context carrier", () => {
+    const policy = resolveAnthropicPayloadPolicy({
+      provider: "anthropic",
+      api: "anthropic-messages",
+      baseUrl: "https://api.anthropic.com/v1",
+      cacheRetention: "long",
+      enableCacheControl: true,
+    });
+    const stableUser = { role: "user", content: [{ type: "text", text: "stable question" }] };
+    const carrier = { role: "user", content: "volatile current-turn metadata" };
+    // The managed transport marks carrier params on conversion; emulate that.
+    anthropicRuntimeContextCarrierParams.add(carrier);
+    const payload: TestPayload = {
+      system: [{ type: "text", text: "system" }],
+      messages: [stableUser, carrier],
+    };
+
+    applyAnthropicPayloadPolicyToParams(payload, policy);
+
+    // Deepest breakpoint anchors on the stable user turn...
+    expect(payload.messages[0]).toEqual({
+      role: "user",
+      content: [
+        { type: "text", text: "stable question", cache_control: { type: "ephemeral", ttl: "1h" } },
+      ],
+    });
+    // ...and NOT on the trailing volatile carrier (left uncached as a plain string).
+    expect(payload.messages[1]).toEqual({
+      role: "user",
+      content: "volatile current-turn metadata",
     });
   });
 

--- a/src/agents/anthropic-payload-policy.ts
+++ b/src/agents/anthropic-payload-policy.ts
@@ -9,16 +9,6 @@ import {
  */
 import { resolveProviderRequestCapabilities } from "./provider-attribution.js";
 
-/**
- * Anthropic-message params (built by the managed transport) that carry transient
- * current-turn runtime context and must be excluded from cache_control
- * breakpoint selection — otherwise the deepest breakpoint would anchor on the
- * volatile carrier appended after the active user turn, whose bytes change every
- * turn. Keyed by object identity so concurrent conversions never collide, and
- * never serialized to the wire.
- */
-export const anthropicRuntimeContextCarrierParams = new WeakSet<object>();
-
 /** @deprecated Anthropic-family provider payload helper; do not use from third-party plugins. */
 type AnthropicServiceTier = "auto" | "standard_only";
 
@@ -155,6 +145,7 @@ function applyAnthropicCacheControlToMessages(
   messages: unknown,
   cacheControl: AnthropicEphemeralCacheControl,
   markerLimit: number,
+  cacheBreakpointOptOutMessageIndexes: ReadonlySet<number>,
 ): void {
   if (!Array.isArray(messages) || messages.length === 0 || markerLimit <= 0) {
     return;
@@ -169,7 +160,7 @@ function applyAnthropicCacheControlToMessages(
     }
 
     const record = message as Record<string, unknown>;
-    if (record.role !== "user" || anthropicRuntimeContextCarrierParams.has(record)) {
+    if (record.role !== "user" || cacheBreakpointOptOutMessageIndexes.has(i)) {
       continue;
     }
 
@@ -265,6 +256,7 @@ export function resolveAnthropicPayloadPolicy(
 export function applyAnthropicPayloadPolicyToParams(
   payloadObj: Record<string, unknown>,
   policy: AnthropicPayloadPolicy,
+  cacheBreakpointOptOutMessageIndexes: ReadonlySet<number>,
 ): void {
   if (
     policy.allowsServiceTier &&
@@ -291,6 +283,7 @@ export function applyAnthropicPayloadPolicyToParams(
     payloadObj.messages,
     policy.cacheControl,
     ANTHROPIC_CACHE_CONTROL_LIMIT - usedMarkers,
+    cacheBreakpointOptOutMessageIndexes,
   );
 }
 

--- a/src/agents/anthropic-payload-policy.ts
+++ b/src/agents/anthropic-payload-policy.ts
@@ -9,6 +9,16 @@ import {
  */
 import { resolveProviderRequestCapabilities } from "./provider-attribution.js";
 
+/**
+ * Anthropic-message params (built by the managed transport) that carry transient
+ * current-turn runtime context and must be excluded from cache_control
+ * breakpoint selection — otherwise the deepest breakpoint would anchor on the
+ * volatile carrier appended after the active user turn, whose bytes change every
+ * turn. Keyed by object identity so concurrent conversions never collide, and
+ * never serialized to the wire.
+ */
+export const anthropicRuntimeContextCarrierParams = new WeakSet<object>();
+
 /** @deprecated Anthropic-family provider payload helper; do not use from third-party plugins. */
 type AnthropicServiceTier = "auto" | "standard_only";
 
@@ -159,7 +169,7 @@ function applyAnthropicCacheControlToMessages(
     }
 
     const record = message as Record<string, unknown>;
-    if (record.role !== "user") {
+    if (record.role !== "user" || anthropicRuntimeContextCarrierParams.has(record)) {
       continue;
     }
 

--- a/src/agents/anthropic-transport-stream.ts
+++ b/src/agents/anthropic-transport-stream.ts
@@ -64,7 +64,6 @@ import type {
 import "../llm/ai-transport-host.js";
 import { MALFORMED_STREAMING_FRAGMENT_ERROR_MESSAGE } from "../shared/assistant-error-format.js";
 import {
-  anthropicRuntimeContextCarrierParams,
   applyAnthropicPayloadPolicyToParams,
   resolveAnthropicPayloadPolicy,
 } from "./anthropic-payload-policy.js";
@@ -392,14 +391,15 @@ function convertAnthropicMessages(
   messages: Context["messages"],
   model: AnthropicTransportModel,
   isOAuthToken: boolean,
-  options?: {
+  options: {
     allowReasoningContentReplay?: boolean;
+    cacheBreakpointOptOutMessageIndexes: Set<number>;
     replayThinkingEnabled?: boolean;
   },
-) {
+): Array<Record<string, unknown>> {
   const params: Array<Record<string, unknown>> = [];
-  const allowReasoningContentReplay = options?.allowReasoningContentReplay === true;
-  const replayThinkingEnabled = options?.replayThinkingEnabled !== false;
+  const allowReasoningContentReplay = options.allowReasoningContentReplay === true;
+  const replayThinkingEnabled = options.replayThinkingEnabled !== false;
   const transformedMessages = transformTransportMessages(messages, model, normalizeToolCallId);
   const activeToolTurnAssistantIndex = replayThinkingEnabled
     ? -1
@@ -415,7 +415,7 @@ function convertAnthropicMessages(
             content: sanitizeTransportPayloadText(msg.content),
           };
           if (isRuntimeContextCarrier) {
-            anthropicRuntimeContextCarrierParams.add(userParam);
+            options.cacheBreakpointOptOutMessageIndexes.add(params.length);
           }
           params.push(userParam);
         }
@@ -456,7 +456,7 @@ function convertAnthropicMessages(
         content: filteredBlocks,
       };
       if (isRuntimeContextCarrier) {
-        anthropicRuntimeContextCarrierParams.add(userParam);
+        options.cacheBreakpointOptOutMessageIndexes.add(params.length);
       }
       params.push(userParam);
       continue;
@@ -1008,14 +1008,17 @@ function buildAnthropicParams(
     cacheRetention: options?.cacheRetention,
     enableCacheControl: true,
   });
+  // Transient runtime-context carrier indexes skip cache anchoring so the breakpoint
+  // stays on the last stable user turn; conversion-to-policy must not splice messages.
+  const cacheBreakpointOptOutMessageIndexes = new Set<number>();
+  const messages = convertAnthropicMessages(context.messages, model, isOAuthToken, {
+    allowReasoningContentReplay: supportsReasoningContentReplay(model),
+    cacheBreakpointOptOutMessageIndexes,
+    replayThinkingEnabled,
+  });
   const params: Record<string, unknown> = {
     model: resolveAnthropicRequestModelId(model),
-    messages: ensureNonEmptyAnthropicMessages(
-      convertAnthropicMessages(context.messages, model, isOAuthToken, {
-        allowReasoningContentReplay: supportsReasoningContentReplay(model),
-        replayThinkingEnabled,
-      }),
-    ),
+    messages: ensureNonEmptyAnthropicMessages(messages),
     max_tokens: maxTokens,
     stream: true,
   };
@@ -1110,7 +1113,7 @@ function buildAnthropicParams(
       params.tool_choice = projectedToolChoice;
     }
   }
-  applyAnthropicPayloadPolicyToParams(params, payloadPolicy);
+  applyAnthropicPayloadPolicyToParams(params, payloadPolicy, cacheBreakpointOptOutMessageIndexes);
   return { params, toolProjection };
 }
 

--- a/src/agents/anthropic-transport-stream.ts
+++ b/src/agents/anthropic-transport-stream.ts
@@ -64,6 +64,7 @@ import type {
 import "../llm/ai-transport-host.js";
 import { MALFORMED_STREAMING_FRAGMENT_ERROR_MESSAGE } from "../shared/assistant-error-format.js";
 import {
+  anthropicRuntimeContextCarrierParams,
   applyAnthropicPayloadPolicyToParams,
   resolveAnthropicPayloadPolicy,
 } from "./anthropic-payload-policy.js";
@@ -406,12 +407,17 @@ function convertAnthropicMessages(
   for (let i = 0; i < transformedMessages.length; i += 1) {
     const msg = transformedMessages[i];
     if (msg.role === "user") {
+      const isRuntimeContextCarrier = msg.runtimeContextCarrier === true;
       if (typeof msg.content === "string") {
         if (msg.content.trim().length > 0) {
-          params.push({
+          const userParam = {
             role: "user",
             content: sanitizeTransportPayloadText(msg.content),
-          });
+          };
+          if (isRuntimeContextCarrier) {
+            anthropicRuntimeContextCarrierParams.add(userParam);
+          }
+          params.push(userParam);
         }
         continue;
       }
@@ -445,10 +451,14 @@ function convertAnthropicMessages(
       if (filteredBlocks.length === 0) {
         continue;
       }
-      params.push({
+      const userParam = {
         role: "user",
         content: filteredBlocks,
-      });
+      };
+      if (isRuntimeContextCarrier) {
+        anthropicRuntimeContextCarrierParams.add(userParam);
+      }
+      params.push(userParam);
       continue;
     }
     if (msg.role === "assistant") {

--- a/src/agents/embedded-agent-runner/run/attempt.llm-boundary.cache-stability.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.llm-boundary.cache-stability.test.ts
@@ -22,6 +22,10 @@ import { describe, expect, it } from "vitest";
 import { stripInboundMetadata } from "../../../auto-reply/reply/strip-inbound-meta.js";
 import { buildTimestampPrefix } from "../../../gateway/server-methods/agent-timestamp.js";
 import type { Context, Model } from "../../../llm/types.js";
+import {
+  OPENCLAW_RUNTIME_CONTEXT_CUSTOM_TYPE,
+  relocateCurrentRuntimeContextCarrierToTail,
+} from "../../internal-runtime-context.js";
 import { normalizeMessagesForLlmBoundary } from "./attempt.llm-boundary.js";
 
 // ---------------------------------------------------------------------------
@@ -351,5 +355,137 @@ describe("prompt-cache byte-identity (issue #3658)", () => {
     // Metadata stripped, then stamped from the message's own timestamp.
     const expectedStrippedBare = stripInboundMetadata(stored); // "What is 2+2?"
     expect(output[0]?.content).toBe(`${EXPECTED_PREFIX_TURN1}${expectedStrippedBare}`);
+  });
+});
+
+function runtimeCarrier(content: string, timestamp: number): AgentMsg {
+  return {
+    role: "custom",
+    customType: OPENCLAW_RUNTIME_CONTEXT_CUSTOM_TYPE,
+    content,
+    display: false,
+    details: { source: "openclaw-runtime-context", runtimeContextCarrier: true },
+    timestamp,
+  } as unknown as AgentMsg;
+}
+
+function isCarrier(message: unknown): boolean {
+  return Boolean(
+    message &&
+    typeof message === "object" &&
+    (message as { customType?: unknown }).customType === OPENCLAW_RUNTIME_CONTEXT_CUSTOM_TYPE,
+  );
+}
+
+function textOf(message: unknown): string | undefined {
+  const content = (message as { content?: unknown } | undefined)?.content;
+  if (typeof content === "string") {
+    return content;
+  }
+  if (Array.isArray(content)) {
+    const block = content.find(
+      (b) => b && typeof b === "object" && (b as { type?: unknown }).type === "text",
+    );
+    return block ? (block as { text?: string }).text : undefined;
+  }
+  return undefined;
+}
+
+describe("prompt-cache tail carrier for current-turn metadata (issue #100271)", () => {
+  const wire = (messages: AgentMsg[]) =>
+    relocateCurrentRuntimeContextCarrierToTail(
+      normalizeMessagesForLlmBoundary(messages, { timezone: TZ }),
+    ) as unknown as Array<Record<string, unknown>>;
+
+  const META = "Conversation info (untrusted metadata):\nsender=Bob";
+
+  it("keeps the active user turn bare, tail-places the carrier, and drops it from replayed history", () => {
+    // The runner installs the carrier immediately BEFORE the active user turn;
+    // the user turn itself is bare.
+    const active: AgentMsg[] = [
+      storedUserMsg("earlier", TS_TURN1 - 2000),
+      ASSISTANT_MSG,
+      runtimeCarrier(META, TS_TURN2),
+      currentUserMsg("what does this mean?", TS_TURN2),
+    ];
+    const wireActive = wire(active);
+
+    // Carrier relocated to the ABSOLUTE tail (the append-only slot).
+    expect(isCarrier(wireActive[wireActive.length - 1])).toBe(true);
+    // The active user turn sits just before it, BARE and stamped — no metadata.
+    const activeUser = wireActive[wireActive.length - 2];
+    expect(textOf(activeUser)).toBe(`${requiredTimestampPrefix(TS_TURN2)}what does this mean?`);
+    expect(textOf(activeUser)).not.toContain("Conversation info");
+
+    // Next turn: that user message is now historical (bare, no carrier survives).
+    const historical: AgentMsg[] = [
+      storedUserMsg("earlier", TS_TURN1 - 2000),
+      ASSISTANT_MSG,
+      storedUserMsg("what does this mean?", TS_TURN2),
+      ASSISTANT_MSG,
+      currentUserMsg("and then?", TS_TURN2 + 60000),
+    ];
+    const wireHistorical = wire(historical);
+
+    // No runtime-context carrier remains anywhere in replayed history.
+    expect(wireHistorical.some(isCarrier)).toBe(false);
+    // The aged user turn is byte-identical to its active form.
+    const agedUser = wireHistorical.find((m) => textOf(m)?.endsWith("what does this mean?"));
+    expect(JSON.stringify(agedUser)).toBe(JSON.stringify(activeUser));
+  });
+
+  it("request N+1 is a strict prefix-extension of request N through the active user turn", () => {
+    const turnN: AgentMsg[] = [
+      storedUserMsg("q1", TS_TURN1 - 2000),
+      ASSISTANT_MSG,
+      runtimeCarrier(META, TS_TURN2),
+      currentUserMsg("q2", TS_TURN2),
+    ];
+    const turnN1: AgentMsg[] = [
+      storedUserMsg("q1", TS_TURN1 - 2000),
+      ASSISTANT_MSG,
+      storedUserMsg("q2", TS_TURN2),
+      ASSISTANT_MSG,
+      runtimeCarrier(META, TS_TURN2 + 60000),
+      currentUserMsg("q3", TS_TURN2 + 60000),
+    ];
+    const wireN = wire(turnN).map((m) => JSON.stringify(m));
+    const wireN1 = wire(turnN1).map((m) => JSON.stringify(m));
+
+    // Everything through the turn-N active user turn (q1, reply, q2) is
+    // byte-identical in request N+1 — only the trailing carrier differs.
+    const sharedPrefixLen = 3;
+    expect(wireN1.slice(0, sharedPrefixLen)).toEqual(wireN.slice(0, sharedPrefixLen));
+    // In request N the carrier occupies the append-only slot right after q2.
+    expect(isCarrier(wire(turnN)[3])).toBe(true);
+  });
+
+  it("runtime-only (room-event) inline context is not strip-eligible, so it stays byte-stable in both positions", () => {
+    // Runtime-only turns keep their inbound context inline (not in the carrier).
+    // That is safe ONLY because room-event/system context is not strip-eligible:
+    // the historical strip removes just the buildInboundUserContextPrefix blocks
+    // (Conversation info / Reply target / …), which room events never carry. So
+    // the inline form is byte-identical active vs historical.
+    const roomText = [
+      "[OpenClaw room event]",
+      "inbound_event_kind: room_event",
+      "Room context:\n#1 Alice: hi",
+    ].join("\n\n");
+    const asCurrent: AgentMsg[] = [currentUserMsg(roomText, TS_TURN2)];
+    const asHistorical: AgentMsg[] = [
+      storedUserMsg(roomText, TS_TURN2),
+      ASSISTANT_MSG,
+      currentUserMsg("next", TS_TURN2 + 60000),
+    ];
+    const cur = normalizeMessagesForLlmBoundary(asCurrent, { timezone: TZ }) as unknown as Array<{
+      content?: unknown;
+    }>;
+    const hist = normalizeMessagesForLlmBoundary(asHistorical, {
+      timezone: TZ,
+    }) as unknown as Array<{ content?: unknown }>;
+    // Byte-identical active vs historical...
+    expect(JSON.stringify(cur[0]?.content)).toBe(JSON.stringify(hist[0]?.content));
+    // ...and the room context is preserved in both (the strip does not touch it).
+    expect(JSON.stringify(hist[0]?.content)).toContain("inbound_event_kind: room_event");
   });
 });

--- a/src/agents/embedded-agent-runner/run/attempt.spawn-workspace.context-engine.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.spawn-workspace.context-engine.test.ts
@@ -1595,6 +1595,7 @@ describe("runEmbeddedAttempt context engine sessionKey forwarding", () => {
 
   it("adds current-turn context to the current model input without exposing internal runtime context", async () => {
     let seenPrompt: string | undefined;
+    let seenMessages: unknown[] | undefined;
 
     const result = await createContextEngineAttemptRunner({
       contextEngine: createContextEngineBootstrapAndAssemble(),
@@ -1628,6 +1629,7 @@ describe("runEmbeddedAttempt context engine sessionKey forwarding", () => {
       },
       sessionPrompt: async (session, prompt) => {
         seenPrompt = prompt;
+        seenMessages = [...session.messages];
         session.messages = [
           ...session.messages,
           { role: "assistant", content: "done", timestamp: 2 },
@@ -1635,16 +1637,28 @@ describe("runEmbeddedAttempt context engine sessionKey forwarding", () => {
       },
     });
 
-    expect(seenPrompt).toContain("what does this mean?");
-    expect(seenPrompt).toContain("Reply target of current user message (untrusted, for context):");
-    expect(seenPrompt).toContain('"sender_label": "Mike"');
-    expect(seenPrompt).toContain("WT daily plan - Sat May 2");
-    expect(seenPrompt).toContain("./quoted-secret.png");
-    expect(seenPrompt).toContain("media://inbound/quoted.png");
+    // The user prompt is kept BARE; current-turn inbound metadata is routed into
+    // the runtime-context carrier instead of being prepended to the user text.
+    expect(seenPrompt).toBe("what does this mean?");
+    expect(seenPrompt).not.toContain(
+      "Reply target of current user message (untrusted, for context):",
+    );
     expect(seenPrompt).not.toContain("OPENCLAW_INTERNAL_CONTEXT");
     expect(seenPrompt).not.toContain("secret runtime context");
-    expect(seenPrompt?.trim().startsWith("Reply target of current user message")).toBe(true);
     expect(result.finalPromptText).toBe(seenPrompt);
+    const runtimeContext = findRecord(
+      requireRecords(seenMessages, "seen messages"),
+      (message) => message.customType === "openclaw.runtime-context",
+      "runtime context message",
+    );
+    expect(runtimeContext.content).toContain(
+      "Reply target of current user message (untrusted, for context):",
+    );
+    expect(runtimeContext.content).toContain('"sender_label": "Mike"');
+    expect(runtimeContext.content).toContain("WT daily plan - Sat May 2");
+    expect(runtimeContext.content).toContain("./quoted-secret.png");
+    expect(runtimeContext.content).toContain("media://inbound/quoted.png");
+    expect(runtimeContext.content).toContain("secret runtime context");
     expect(hoisted.detectAndLoadPromptImagesMock).toHaveBeenCalledTimes(1);
     expect(mockParams(hoisted.detectAndLoadPromptImagesMock, 0, "prompt image params").prompt).toBe(
       "what does this mean?",
@@ -1657,7 +1671,7 @@ describe("runEmbeddedAttempt context engine sessionKey forwarding", () => {
       .map((line) => JSON.parse(line) as TrajectoryEvent);
     const promptSubmitted = trajectoryEvents.find((event) => event.type === "prompt.submitted");
     expect(promptSubmitted?.data?.prompt).toBe(seenPrompt);
-    expect(promptSubmitted?.data?.prompt).toContain("WT daily plan - Sat May 2");
+    expect(promptSubmitted?.data?.prompt).not.toContain("WT daily plan - Sat May 2");
     expect(promptSubmitted?.data?.prompt).not.toContain("secret runtime context");
   });
 
@@ -1906,6 +1920,7 @@ describe("runEmbeddedAttempt context engine sessionKey forwarding", () => {
   it("submits suppressed room event context as the model prompt", async () => {
     let seenPrompt: string | undefined;
     let seenModelMessages: unknown[] | undefined;
+    let seenMessages: unknown[] | undefined;
     const runBeforePromptBuild = vi.fn(async () => ({
       prependContext: "dynamic hook context",
       appendContext: "dynamic hook tail",
@@ -1939,6 +1954,7 @@ describe("runEmbeddedAttempt context engine sessionKey forwarding", () => {
       },
       sessionPrompt: async (session, prompt) => {
         seenPrompt = prompt;
+        seenMessages = [...session.messages];
         const transformContext = (
           session.agent as {
             transformContext?: (messages: AgentMessage[]) => Promise<AgentMessage[]>;
@@ -1954,14 +1970,23 @@ describe("runEmbeddedAttempt context engine sessionKey forwarding", () => {
       },
     });
 
-    expect(seenPrompt).toContain("[OpenClaw room event]");
-    expect(seenPrompt).toContain("inbound_event_kind: room_event");
-    expect(seenPrompt).toContain("visible_reply_contract: message_tool_only");
-    expect(seenPrompt).toContain("Current event:\n#2003 Bob: hey claw summarize the plan");
-    expect(seenPrompt?.trim().endsWith("[OpenClaw room event]")).toBe(true);
+    // The user prompt stays the bare room-event marker; the room context is
+    // routed into the runtime-context carrier instead of the user text.
+    expect(seenPrompt).toBe("[OpenClaw room event]");
+    expect(seenPrompt).not.toContain("inbound_event_kind: room_event");
     expect(seenPrompt).not.toBe("Continue the OpenClaw runtime event.");
     expect(seenPrompt).not.toContain("dynamic hook context");
     expect(seenPrompt).not.toContain("dynamic hook tail");
+    const roomRuntimeContext = findRecord(
+      requireRecords(seenMessages, "seen messages"),
+      (message) => message.customType === "openclaw.runtime-context",
+      "runtime context message",
+    );
+    expect(roomRuntimeContext.content).toContain("inbound_event_kind: room_event");
+    expect(roomRuntimeContext.content).toContain("visible_reply_contract: message_tool_only");
+    expect(roomRuntimeContext.content).toContain(
+      "Current event:\n#2003 Bob: hey claw summarize the plan",
+    );
     expect(JSON.stringify(seenModelMessages)).toContain("dynamic hook context");
     expect(JSON.stringify(seenModelMessages)).toContain("dynamic hook tail");
     expect(result.finalPromptText).toBe(seenPrompt);
@@ -1972,7 +1997,10 @@ describe("runEmbeddedAttempt context engine sessionKey forwarding", () => {
       .split("\n")
       .map((line) => JSON.parse(line) as TrajectoryEvent);
     const contextCompiled = trajectoryEvents.find((event) => event.type === "context.compiled");
-    expect(contextCompiled?.data?.prompt).toContain("visible_reply_contract: message_tool_only");
+    // Room context now rides the runtime-context carrier, not the user prompt.
+    expect(contextCompiled?.data?.prompt).not.toContain(
+      "visible_reply_contract: message_tool_only",
+    );
     expect(contextCompiled?.data?.prompt).toContain("[OpenClaw room event]");
   });
 

--- a/src/agents/embedded-agent-runner/run/attempt.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.ts
@@ -174,6 +174,7 @@ import { runAgentEndSideEffects } from "../../harness/agent-end-side-effects.js"
 import { runAgentHarnessBeforeAgentFinalizeHook } from "../../harness/lifecycle-hook-helpers.js";
 import { resolveHeartbeatPromptForSystemPrompt } from "../../heartbeat-system-prompt.js";
 import { resolveImageSanitizationLimits } from "../../image-sanitization.js";
+import { relocateCurrentRuntimeContextCarrierToTail } from "../../internal-runtime-context.js";
 import {
   applyLocalModelLeanToolSearchDefaults,
   filterLocalModelLeanTools,
@@ -2614,7 +2615,17 @@ export async function runEmbeddedAttempt(
       if (typeof activeSession.agent.convertToLlm === "function") {
         const baseConvertToLlm = activeSession.agent.convertToLlm.bind(activeSession.agent);
         activeSession.agent.convertToLlm = async (messages) =>
-          await baseConvertToLlm(normalizeMessagesForLlmBoundary(messages, buildBoundaryOptions()));
+          await baseConvertToLlm(
+            // Wire-only: move the current-turn runtime-context carrier to the
+            // absolute tail so the request is an append-only prefix-extension
+            // through the active user turn (see the function's cache rationale).
+            // Applied here, not inside normalizeMessagesForLlmBoundary, because
+            // normalizeMessagesForCurrentPromptBoundary slices off its appended
+            // prompt by position and must not see the carrier relocated past it.
+            relocateCurrentRuntimeContextCarrierToTail(
+              normalizeMessagesForLlmBoundary(messages, buildBoundaryOptions()),
+            ),
+          );
       }
       let prePromptMessageCount = activeSession.messages.length;
       const toolResultPromptProjectionState: ToolResultPromptProjectionState =
@@ -4382,14 +4393,35 @@ export async function runEmbeddedAttempt(
               ? "model-prompt"
               : "runtime-event",
           });
-          const promptForSession = buildCurrentInboundPrompt({
-            context: params.currentInboundContext,
-            prompt: promptSubmission.prompt,
-          });
-          const promptForModel = buildCurrentInboundPrompt({
-            context: params.currentInboundContext,
-            prompt: promptSubmission.modelPrompt ?? promptSubmission.prompt,
-          });
+          const isRuntimeOnlyTurn = promptSubmission.runtimeOnly === true;
+          const currentInboundContextText = isRuntimeOnlyTurn
+            ? undefined
+            : params.currentInboundContext?.text?.trim() || undefined;
+          // Normal user turns keep the user prompt BARE and route current-turn
+          // inbound metadata into the runtime-context carrier (relocated after the
+          // active user turn on the wire), so the persisted/replayed user message
+          // is byte-identical whether active or historical — the cache-stability
+          // fix. Runtime-only turns (room events, etc.) have no bare user turn to
+          // protect, so their inbound context stays inline exactly as before. That
+          // inline path stays byte-stable because a runtime-only turn only ever
+          // carries room-event/system context, which is NOT strip-eligible: the
+          // historical strip only removes the `buildInboundUserContextPrefix`
+          // blocks (Conversation info / Reply target / Sender / …), and those are
+          // produced only for non-room turns — which always have a non-empty body
+          // and so are never runtime-only. So inline-active and inline-historical
+          // serialize identically (verified in the cache-stability tests).
+          const promptForSession = isRuntimeOnlyTurn
+            ? buildCurrentInboundPrompt({
+                context: params.currentInboundContext,
+                prompt: promptSubmission.prompt,
+              })
+            : promptSubmission.prompt;
+          const promptForModel = isRuntimeOnlyTurn
+            ? buildCurrentInboundPrompt({
+                context: params.currentInboundContext,
+                prompt: promptSubmission.modelPrompt ?? promptSubmission.prompt,
+              })
+            : (promptSubmission.modelPrompt ?? promptSubmission.prompt);
           currentUserTimestampOverride =
             !isRawModelRun && typeof preparedUserTurnMessage?.timestamp === "number"
               ? {
@@ -4408,9 +4440,11 @@ export async function runEmbeddedAttempt(
               setActiveSessionSystemPrompt(runtimeSystemPrompt);
             }
           }
-          const runtimeContextForHook = promptSubmission.runtimeOnly
+          const runtimeContextForHook = isRuntimeOnlyTurn
             ? undefined
-            : promptSubmission.runtimeContext?.trim();
+            : [currentInboundContextText, promptSubmission.runtimeContext?.trim()]
+                .filter((value): value is string => Boolean(value))
+                .join("\n\n") || undefined;
           const runtimeContextMessageForCurrentTurn =
             buildRuntimeContextCustomMessage(runtimeContextForHook);
           const messagesForCurrentPrompt = runtimeContextMessageForCurrentTurn

--- a/src/agents/embedded-agent-runner/run/runtime-context-prompt.ts
+++ b/src/agents/embedded-agent-runner/run/runtime-context-prompt.ts
@@ -28,7 +28,7 @@ export type RuntimeContextCustomMessage = {
   customType: string;
   content: string;
   display: false;
-  details: { source: "openclaw-runtime-context" };
+  details: { source: "openclaw-runtime-context"; runtimeContextCarrier: true };
   timestamp: number;
 };
 
@@ -279,7 +279,7 @@ export function buildRuntimeContextCustomMessage(
       kind: "next-turn",
     }),
     display: false,
-    details: { source: "openclaw-runtime-context" },
+    details: { source: "openclaw-runtime-context", runtimeContextCarrier: true },
     timestamp: Date.now(),
   };
 }

--- a/src/agents/internal-runtime-context.test.ts
+++ b/src/agents/internal-runtime-context.test.ts
@@ -9,8 +9,25 @@ import {
   hasInternalRuntimeContext,
   INTERNAL_RUNTIME_CONTEXT_BEGIN,
   INTERNAL_RUNTIME_CONTEXT_END,
+  OPENCLAW_RUNTIME_CONTEXT_CUSTOM_TYPE,
+  relocateCurrentRuntimeContextCarrierToTail,
   stripInternalRuntimeContext,
 } from "./internal-runtime-context.js";
+
+type TestMessage = { role: string; content: string; customType?: string };
+
+function carrier(content = "runtime ctx"): TestMessage {
+  return { role: "custom", customType: OPENCLAW_RUNTIME_CONTEXT_CUSTOM_TYPE, content };
+}
+function user(content: string): TestMessage {
+  return { role: "user", content };
+}
+function assistant(content: string): TestMessage {
+  return { role: "assistant", content };
+}
+function toolResult(content: string): TestMessage {
+  return { role: "toolResult", content };
+}
 
 function createDeterministicRng(seed: number): () => number {
   let state = seed >>> 0;
@@ -123,5 +140,49 @@ describe("internal runtime context codec", () => {
       expect(stripped).not.toContain(INTERNAL_RUNTIME_CONTEXT_BEGIN);
       expect(stripped).not.toContain(INTERNAL_RUNTIME_CONTEXT_END);
     }
+  });
+});
+
+describe("relocateCurrentRuntimeContextCarrierToTail", () => {
+  it("moves a before-user carrier to the absolute tail", () => {
+    const messages = [user("older"), assistant("reply"), carrier("meta"), user("active")];
+    const out = relocateCurrentRuntimeContextCarrierToTail(messages);
+    expect(out.map((m) => m.role)).toEqual(["user", "assistant", "user", "custom"]);
+    // Non-carrier order is preserved; the active user turn is no longer preceded
+    // by the volatile carrier, so it caches as a stable prefix.
+    expect(out.filter((m) => m.role !== "custom")).toEqual([
+      user("older"),
+      assistant("reply"),
+      user("active"),
+    ]);
+    expect(out[out.length - 1]).toEqual(carrier("meta"));
+  });
+
+  it("moves the carrier past tool-call/tool-result scaffolding to the absolute tail", () => {
+    const messages = [
+      carrier("meta"),
+      user("active"),
+      assistant("tool call"),
+      toolResult("tool output"),
+    ];
+    const out = relocateCurrentRuntimeContextCarrierToTail(messages);
+    expect(out.map((m) => m.role)).toEqual(["user", "assistant", "toolResult", "custom"]);
+    expect(out[out.length - 1]).toEqual(carrier("meta"));
+  });
+
+  it("is a no-op (same reference) when the carrier is already at the tail", () => {
+    const messages = [user("active"), assistant("tool call"), toolResult("out"), carrier("meta")];
+    const out = relocateCurrentRuntimeContextCarrierToTail(messages);
+    expect(out).toBe(messages);
+  });
+
+  it("is a no-op when there is no carrier", () => {
+    const messages = [user("active"), assistant("reply")];
+    expect(relocateCurrentRuntimeContextCarrierToTail(messages)).toBe(messages);
+  });
+
+  it("leaves a carrier in place when there is no active user turn to anchor after", () => {
+    const messages = [carrier("meta"), assistant("reply")];
+    expect(relocateCurrentRuntimeContextCarrierToTail(messages)).toBe(messages);
   });
 });

--- a/src/agents/internal-runtime-context.ts
+++ b/src/agents/internal-runtime-context.ts
@@ -309,3 +309,45 @@ export function stripHistoricalRuntimeContextCustomMessages<T>(messages: T[]): T
     return currentRuntimeContextIndexes.has(index);
   });
 }
+
+/**
+ * Moves current-turn runtime-context carrier messages to the absolute tail of
+ * the request (after the active user turn and any tool-call scaffolding).
+ *
+ * Prompt-cache rationale: a per-turn carrier that is stripped on replay makes
+ * the next request diverge at the carrier's slot. Placed BEFORE the active user
+ * turn, that slot precedes everything that gets reused, so the whole tail
+ * (user turn + tool loop) re-bills every turn. Placed at the ABSOLUTE tail, the
+ * divergence lands exactly where the next turn's new bytes (the assistant reply)
+ * begin anyway, so the request is an append-only prefix-extension through the
+ * active user turn — only the trailing carrier is ever re-billed.
+ *
+ * Runs after {@link stripHistoricalRuntimeContextCustomMessages}, so only the
+ * current-turn carrier(s) remain. When there is no active user turn to anchor
+ * after, messages are returned unchanged.
+ */
+export function relocateCurrentRuntimeContextCarrierToTail<T>(messages: T[]): T[] {
+  const lastIndex = messages.length - 1;
+  if (lastIndex < 0 || !messages.some(isOpenClawRuntimeContextCustomMessage)) {
+    return messages;
+  }
+  // Already tail-placed (a contiguous carrier run ends the array): no-op so the
+  // serialized bytes stay stable across re-attempts of the same request.
+  let firstNonCarrierFromEnd = lastIndex;
+  while (
+    firstNonCarrierFromEnd >= 0 &&
+    isOpenClawRuntimeContextCustomMessage(messages[firstNonCarrierFromEnd])
+  ) {
+    firstNonCarrierFromEnd -= 1;
+  }
+  const rest = messages.filter((message) => !isOpenClawRuntimeContextCustomMessage(message));
+  // No active user turn to anchor after — leave placement to the strip pass.
+  if (!rest.some(isUserMessage)) {
+    return messages;
+  }
+  if (firstNonCarrierFromEnd === rest.length - 1) {
+    return messages;
+  }
+  const carriers = messages.filter(isOpenClawRuntimeContextCustomMessage);
+  return [...rest, ...carriers];
+}


### PR DESCRIPTION
Fixes #100271

**Reported-by:** @Peetiegonzalez
**cc:** @Peetiegonzalez

### Problem

The channel layer decorates the ACTIVE user message with an inbound-metadata block
("Conversation info (untrusted metadata)" / "Reply target of current user message" / sender /
forwarded / chat-history), composed at request-build time via `buildInboundUserContextPrefix`
(`src/auto-reply/reply/inbound-meta.ts`) → `currentInboundContext`. But the session store persists
the BARE user text, and `stripHistoricalInboundMetadataFromUserMessages`
(`src/agents/embedded-agent-runner/run/attempt.llm-boundary.ts`) strips that block from historical
user turns before replay. The active turn becomes the previous turn's history the instant a new
turn arrives, so its serialized bytes change retroactively — decorated as the active turn, bare as
history — on every single turn, invalidating any prefix/exact-match provider prompt cache from that
point onward, every turn. (#90811 fixed the *timestamp* half of this same active/historical
asymmetry; this is the metadata half.)

### Fix — tail-placed runtime-context carrier

This reworks the earlier "strip the active turn" approach (which lost model-visible context, the
blocker ClawSweeper raised) into one that keeps the context AND recovers the cache cost.

Current-turn inbound metadata is routed **out of the user prompt** and into the existing hidden
runtime-context custom message (the mechanism from #89428 — credited below), and that carrier is
relocated to the **absolute tail** of the wire request — after the active user turn and any
tool-call scaffolding:

- The user turn stays **bare and byte-identical** in both the active and historical positions (the
  cache-stability guarantee; the same property #90811 established for the timestamp).
- The volatile carrier sits at the tail, so when it vanishes next turn the first differing byte
  lands exactly where the next turn's new bytes (the assistant reply) begin anyway. The request is
  an **append-only prefix-extension through the active user turn** — only the trailing carrier is
  ever re-billed.
- Providers must not anchor a cache breakpoint on the volatile carrier, or breakpoint quantization
  forfeits the win. A durable marker (`UserMessage.runtimeContextCarrier`, set by `convertToLlm`
  from the carrier's `details`) lets the Anthropic and OpenAI-completions transports skip it when
  selecting the deepest `cache_control` breakpoint, keeping the anchor on the last stable user turn.

Storage stays BARE (the documented invariant in `src/sessions/user-turn-transcript.ts` is
preserved); runtime-only turns (room events) keep their existing inline behavior when they have no
bare user turn to protect; legacy sessions with bare-stored user messages are unchanged.

### Why tail placement, not before-user (the divergence-offset math)

The runtime-context carrier is per-turn and stripped on replay, so it necessarily vanishes at its
slot next turn. Where that slot sits decides how much re-bills on a prefix cache:

| Design | Active user turn context | First differing byte in request N+1 | Prefix-cache cost |
|---|---|---|---|
| **A. Strip active turn** (prior PR) | ❌ lost (ClawSweeper P1) | at/after userN (bare both ways) | append-only ✅ |
| **B. Before-user carrier** (#89428 as-is) | ✅ preserved | at the carrier slot, which is *before* userN | userN + tool loop re-bill every turn ❌ |
| **C. Tail carrier** (this PR) | ✅ preserved | at the carrier slot, which is *after* userN (where the assistant reply begins anyway) | append-only ✅ |

C is the only option that preserves current-turn context AND is append-only. B keeps context but
recovers almost none of the cache cost on prefix caches (and only breakpoint scraps on Anthropic),
because the carrier vanishing *before* userN re-bills the whole tail — the same magnitude as the
bug. This PR stacks on #89428's runtime-context handoff and adds the tail placement + the
transport breakpoint anchor.

### Review

Reviewed with N adversarial gpt-5.5 (codex) sweeps — correctness of the carrier/placement path,
byte-identity/cache-divergence, compatibility & transcript readers, and test adequacy. Reviewed with 5 adversarial gpt-5.5 (codex) read-only sweeps — correctness of the carrier/placement path, byte-identity/cache-divergence, compatibility & transcript readers, test adequacy, plus a final consolidated pass. **Found + fixed:** (1) a second Anthropic cache-anchor path — the managed transport (`src/agents/anthropic-transport-stream.ts` + `anthropic-payload-policy.ts`, the OAuth/managed path) was still anchoring the deepest `cache_control` breakpoint on the relocated tail carrier; it now carries the same carrier opt-out; (2) missing provider-payload breakpoint tests for the managed Anthropic transport and OpenAI-completions (added). A theoretical runtime-only inline mutation was **verified unreachable** (room-event/system context is not strip-eligible, and non-room turns always have a non-empty body so are never runtime-only) and pinned with a byte-stability test. The final consolidated sweep came back **clean**.

### Tests

- `internal-runtime-context.test.ts`: `relocateCurrentRuntimeContextCarrierToTail` unit coverage
  (before-user → tail, past tool scaffolding, idempotent no-op, no-carrier, no-active-user).
- `attempt.llm-boundary.cache-stability.test.ts`: the active user turn is bare with the carrier at
  the tail; the same message is byte-identical once aged to history (carrier gone); request N+1 is
  a strict prefix-extension of request N through the active user turn.
- `anthropic.test.ts`: the deepest cache breakpoint anchors on the last stable user turn, skipping
  a trailing runtime-context carrier.
- `messages.test.ts`: `convertToLlm` marks a runtime-context carrier so providers skip cache
  anchoring; ordinary custom messages are unmarked.
- `attempt.spawn-workspace.context-engine.test.ts`: updated to assert current-turn metadata now
  rides the runtime-context carrier (bare user prompt), for both the normal and suppressed
  room-event paths.

Typecheck (`node scripts/run-tsgo.mjs -p tsconfig.core.json`): zero new errors (47 pre-existing
`ui/` module-resolution errors present on unmodified upstream main too).

Full shard results vs pristine `upstream/main` baseline — zero NEW failures: `agents-embedded-agent`
1629/1629; `unit-fast` 11088 passed (4 pre-existing `test/scripts/{check,verify}.test.ts` failures,
identical on base); packages (`ai`/`agent-core`/`llm-core`) 390/390.

## What Problem This Solves

The active user turn's serialized text differed from how that same turn is later replayed as
history: the channel layer decorated the active turn with an untrusted-metadata block that
`stripHistoricalInboundMetadataFromUserMessages` strips for every historical turn but left in place
for the turn currently being sent. Since the active turn becomes the previous turn's history the
instant the next turn arrives, its bytes changed retroactively at that point in the conversation on
every single turn — invalidating any prefix/exact-match provider prompt cache from that point
onward. This PR keeps the metadata model-visible (now on both the active turn and — via the tail
carrier — nowhere in replayed history, so history stays clean) while making the user turn
byte-stable.

## Evidence

The byte-stability property this PR gives the user turn (bare + append-only in both positions) is
the same one measured for the active/historical asymmetry in #100271:

- OpenAI (gpt-5.5, ChatGPT-OAuth, session-affinity header from #100233 applied): **81.8% → 90.6%**
  TRUE cache-hit rate once the active user turn stops mutating.
- Anthropic (claude-sonnet-4-6), whose cache matches only at explicit `cache_control` breakpoints:
  over a 12-turn session **cacheWrite 60,208 → 10,051 tokens (-83%)**, cacheRead advancing
  monotonically instead of resetting to the same system-prompt breakpoint every turn. This PR's
  transport breakpoint anchor is what keeps that win under tail placement (the breakpoint stays on
  the stable user turn, not the volatile trailer).
- DeepSeek / Kimi (incremental multi-prefix caches) absorb the mutation already and are
  neutral-to-slightly-positive — not a regression.

Unlike the strip approach those numbers were first measured under, this design **preserves** the
current-turn sender/reply/mention context for the model (addressing ClawSweeper's P1) — it moves
the context to the runtime-context carrier rather than deleting it. The only added cost over pure
strip is the trailing carrier's own bytes once per turn (read-priced, never part of a reused
prefix).

Full per-call tables and the Anthropic breakpoint mechanism:
https://raw.githubusercontent.com/Marvinthebored/openclaw/proof-assets-metadata-byte-stability/pr-proof/100272-metadata-byte-stability/EVIDENCE.md
