### PR TITLE
fix: treat empty-string optional integer tool params as unset

### DIFF
--- a/src/agents/tools/common.params.test.ts
+++ b/src/agents/tools/common.params.test.ts
@@ -132,6 +132,37 @@ describe("readNumberParam", () => {
     ).toThrow("deleteDays must be an integer from 0 to 7");
   });
 
+  it("treats empty or whitespace-only strings as unset for optional positive integer params", () => {
+    // Tool-calling models routinely emit empty-string defaults for optional
+    // params (e.g. Telegram replyTo/threadId) they are not actually setting.
+    // An empty/whitespace string carries no value and must not throw.
+    expect(readPositiveIntegerParam({ replyTo: "" }, "replyTo")).toBeUndefined();
+    expect(readPositiveIntegerParam({ threadId: "   " }, "threadId")).toBeUndefined();
+    expect(readPositiveIntegerParam({ replyTo: "\t\n" }, "replyTo")).toBeUndefined();
+    // Genuinely invalid present values must still throw.
+    expect(() => readPositiveIntegerParam({ replyTo: "0" }, "replyTo")).toThrow(
+      "replyTo must be a positive integer",
+    );
+    expect(() => readPositiveIntegerParam({ replyTo: 0 }, "replyTo")).toThrow(
+      "replyTo must be a positive integer",
+    );
+    expect(() => readPositiveIntegerParam({ replyTo: "-3" }, "replyTo")).toThrow(
+      "replyTo must be a positive integer",
+    );
+  });
+
+  it("treats empty or whitespace-only strings as unset for optional non-negative integer params", () => {
+    expect(readNonNegativeIntegerParam({ position: "" }, "position")).toBeUndefined();
+    expect(readNonNegativeIntegerParam({ position: "  " }, "position")).toBeUndefined();
+    // A present, valid zero is still a real value.
+    expect(readNonNegativeIntegerParam({ position: "0" }, "position")).toBe(0);
+    expect(readNonNegativeIntegerParam({ position: 0 }, "position")).toBe(0);
+    // Genuinely invalid present values must still throw.
+    expect(() => readNonNegativeIntegerParam({ position: "4.5" }, "position")).toThrow(
+      "position must be a non-negative integer",
+    );
+  });
+
   it("throws for invalid present bounded finite number params", () => {
     expect(readFiniteNumberParam({ quality: "0.75" }, "quality")).toBe(0.75);
     expect(readFiniteNumberParam({ quality: null }, "quality")).toBeUndefined();

--- a/src/agents/tools/common.ts
+++ b/src/agents/tools/common.ts
@@ -112,6 +112,19 @@ function readParamRaw(params: Record<string, unknown>, key: string): unknown {
   return readSnakeCaseParamRaw(params, key);
 }
 
+/**
+ * True when a raw tool-param value should be treated as "not provided".
+ *
+ * Tool-calling models frequently populate every optional field with an empty
+ * or whitespace-only string default even when the caller did not set it. Such
+ * a value carries no information and must not be treated as an invalid present
+ * value. This mirrors how {@link readStringParam} / {@link readNumberParam}
+ * already ignore empty/whitespace strings.
+ */
+function isBlankParamValue(raw: unknown): boolean {
+  return typeof raw === "string" && raw.trim() === "";
+}
+
 export function readStringParam(
   params: Record<string, unknown>,
   key: string,
@@ -244,8 +257,11 @@ export function readPositiveIntegerParam(
     positiveInteger: true,
     strict: true,
   });
-  if (value === undefined && readParamRaw(params, key) != null) {
-    throw new ToolInputError(options.message ?? `${key} must be a positive integer`);
+  if (value === undefined) {
+    const raw = readParamRaw(params, key);
+    if (raw != null && !isBlankParamValue(raw)) {
+      throw new ToolInputError(options.message ?? `${key} must be a positive integer`);
+    }
   }
   if (value !== undefined && options.max !== undefined && value > options.max) {
     throw new ToolInputError(options.message ?? `${key} must be a positive integer`);
@@ -265,8 +281,11 @@ export function readNonNegativeIntegerParam(
     nonNegativeInteger: true,
     strict: true,
   });
-  if (value === undefined && readParamRaw(params, key) != null) {
-    throw new ToolInputError(options.message ?? `${key} must be a non-negative integer`);
+  if (value === undefined) {
+    const raw = readParamRaw(params, key);
+    if (raw != null && !isBlankParamValue(raw)) {
+      throw new ToolInputError(options.message ?? `${key} must be a non-negative integer`);
+    }
   }
   if (value !== undefined && options.max !== undefined && value > options.max) {
     throw new ToolInputError(options.message ?? `${key} must be a non-negative integer`);


### PR DESCRIPTION
Closes #100269

## What Problem This Solves

Fixes an issue where agent-initiated and scheduled (cron) Telegram messages would silently fail to deliver when the driving model filled the optional `replyTo`/`threadId` (or `replyToMessageId`/`messageThreadId`) fields with an empty-string default. The user never receives the message — most painfully, time-sensitive cron reminders that run, draft correctly, then fail only at the delivery step.

Modern tool-calling models routinely emit *every* optional schema field with an empty (`""`) or zero (`"0"`) default even when the caller isn't setting it. For those Telegram routing hints the empty default caused `ToolInputError: replyTo must be a positive integer.` (and the `threadId` variant); the agent then retried with more invalid defaults and gave up. This reproduced identically across two independent providers (an MAI Flash-family model and GitHub Copilot `gpt-5-mini`), confirming it is model-agnostic and rooted in the shared parameter reader rather than any one model.

## Why This Change Was Made

`readPositiveIntegerParam` / `readNonNegativeIntegerParam` in `src/agents/tools/common.ts` threw whenever the parsed value was `undefined` but the raw param was not `null`. An empty/whitespace-only string parses to `undefined` yet is `!= null`, so it threw — even though an empty string is semantically "not provided". These readers now treat a **blank string** as unset (return `undefined`) while still rejecting genuinely invalid *present* values (numeric `0`, `"42.5"`, `"-3"`, over-`max`). This mirrors how `readStringParam`/`readNumberParam` already ignore empty/whitespace strings, and fixes every channel that reads routing params through these helpers (Telegram, plus the same pattern in Discord/Slack/Matrix and the core message-action-runner) in a single place. The existing "`timeoutMs: 0` throws" contract is preserved.

## User Impact

Agent- and cron-initiated messages (Telegram especially) now deliver reliably regardless of which model drives the `message` tool. Empty optional routing-param defaults are ignored instead of aborting the send, so scheduled reminders and notifications stop silently disappearing. No API or behavior change for callers that pass real values; invalid present values are still rejected exactly as before.

## Evidence

Targeted unit run of the touched test file (19 pre-existing + 2 new cases), all green:

```
$ npx vitest run src/agents/tools/common.params.test.ts
 ✓  unit-fast  src/agents/tools/common.params.test.ts (21 tests) 9ms
 Test Files  1 passed (1)
      Tests  21 passed (21)
```

New tests assert both the fix and the preserved strictness:

```ts
expect(readPositiveIntegerParam({ replyTo: "" }, "replyTo")).toBeUndefined();
expect(readPositiveIntegerParam({ threadId: "   " }, "threadId")).toBeUndefined();
expect(() => readPositiveIntegerParam({ replyTo: "0" }, "replyTo")).toThrow("replyTo must be a positive integer");
expect(() => readPositiveIntegerParam({ replyTo: 0 }, "replyTo")).toThrow("replyTo must be a positive integer");
expect(() => readPositiveIntegerParam({ replyTo: "-3" }, "replyTo")).toThrow("replyTo must be a positive integer");
```

Real-world before/after (Telegram cron send via the `message` tool, model emitting `replyTo:""` / `threadId:""`):
- **Before:** `ToolInputError: replyTo must be a positive integer.` ×N, delivery fails, no message received.
- **After (with this change applied):** `{ "ok": true, "messageId": "…" }`, message delivered, zero `ToolInputError`.

Full `pnpm build && pnpm check && pnpm test` was not run locally (the monorepo-wide typecheck exhausted memory on my constrained ARM/WSL box); I relied on the scoped vitest lane above and am leaving CI to validate the wider suite. Happy to adjust if a maintainer wants a different validation lane.
