### PR TITLE
fix: classify structured invalid_request_error as format to advance model fallback chain

### DIFF
--- a/src/agents/embedded-agent-helpers/errors.ts
+++ b/src/agents/embedded-agent-helpers/errors.ts
@@ -597,7 +597,12 @@ function isSandboxBlockedErrorMessage(raw: string): boolean {
 }
 
 function isSchemaErrorMessage(raw: string): boolean {
-  if (!raw || isReplayInvalidErrorMessage(raw) || isContextOverflowError(raw)) {
+  if (
+    !raw ||
+    isReplayInvalidErrorMessage(raw) ||
+    isContextOverflowError(raw) ||
+    isStructuredInvalidRequestError(raw)
+  ) {
     return false;
   }
   return classifyFailoverReason(raw) === "format" || matchesFormatErrorPattern(raw);
@@ -1113,6 +1118,9 @@ function classifyFailoverClassificationFromMessage(
     return toReasonClassification("timeout");
   }
   if (isCloudCodeAssistFormatError(raw)) {
+    return toReasonClassification("format");
+  }
+  if (isStructuredInvalidRequestError(raw)) {
     return toReasonClassification("format");
   }
   if (isExactUnknownNoDetailsError(raw)) {
@@ -1711,6 +1719,21 @@ function isStructuredServerErrorMessage(raw: string): boolean {
     value.includes('"code":"server_error"') ||
     value.includes('"type":"upstream_error"') ||
     value.includes('"code":"upstream_error"')
+  );
+}
+
+function isStructuredInvalidRequestError(raw: string): boolean {
+  if (!raw) {
+    return false;
+  }
+  const parsedType = normalizeOptionalLowercaseString(parseApiErrorInfo(raw)?.type);
+  if (parsedType && parsedType.includes("invalid_request")) {
+    return true;
+  }
+  const value = normalizeLowercaseStringOrEmpty(raw);
+  return (
+    value.includes('"type":"invalid_request_error"') ||
+    value.includes('"code":"invalid_request_error"')
   );
 }
 

--- a/src/agents/embedded-agent-helpers/failover-matches.test.ts
+++ b/src/agents/embedded-agent-helpers/failover-matches.test.ts
@@ -210,3 +210,32 @@ describe("generic assistant error text classification (#93931)", () => {
     ).toBe(false);
   });
 });
+
+describe("structured invalid request error classification (#99174)", () => {
+  it("classifies Anthropic invalid_request_error JSON body as format", () => {
+    const raw =
+      '{"type":"error","error":{"type":"invalid_request_error","message":"messages.27.content.1: `thinking` blocks cannot be modified."}}';
+    expect(classifyFailoverReason(raw)).toBe("format");
+  });
+
+  it("classifies OpenAI flattened invalid_request_error as format", () => {
+    const raw =
+      '{"error":{"code":"invalid_request_error","message":"The parameter `model` is required."}}';
+    expect(classifyFailoverReason(raw)).toBe("format");
+  });
+
+  it("keeps existing structured server_error classification", () => {
+    // server_error should still classify as server_error, not be affected
+    // by the new invalid_request check.
+    const raw = '{"type":"error","error":{"type":"server_error","message":"internal error"}}';
+    expect(classifyFailoverReason(raw)).toBe("server_error");
+  });
+
+  it("does not affect existing auth classification", () => {
+    expect(classifyFailoverReason("invalid api key provided")).toBe("auth");
+  });
+
+  it("does not affect existing rate_limit classification", () => {
+    expect(classifyFailoverReason("rate limit exceeded")).toBe("rate_limit");
+  });
+});


### PR DESCRIPTION
## Summary

**Problem**: Anthropic-style 400 error bodies with no leading HTTP status prefix (e.g. `{"type":"error","error":{"type":"invalid_request_error",...}}`) return `null` from `classifyFailoverClassificationFromMessage`, so the model fallback chain is never consulted and the user sees a terminal error instead of failing over to a healthy model.

**Solution**: Added `isStructuredInvalidRequestError` following the existing `isStructuredServerErrorMessage` pattern. When an `invalid_request_error` type is detected in the JSON error body, classify it as `"format"` so the `FailoverError` machinery advances the fallback chain.

**What changed**: +53/-1 across 2 files in `src/agents/embedded-agent-helpers/`:
- New `isStructuredInvalidRequestError` function
- Classification check in `classifyFailoverClassificationFromMessage`
- Exclude from `isSchemaErrorMessage` to keep telemetry accurate
- Test cases

**What did NOT change**: user-facing error text, config surface, exported APIs, provider behavior for non-`invalid_request_error` bodies.

## What Problem This Solves

When an Anthropic-compatible provider returns a 400 with a JSON body like `{"type":"error","error":{"type":"invalid_request_error","message":"..."}}`, the failover classifier fails to route it through the fallback chain:
1. `extractLeadingHttpStatus` returns `undefined` (body starts with `{`, not `400 `)
2. `classifyFailoverClassificationFromHttpStatus` is skipped (no status)
3. `classifyFailoverClassificationFromMessage` finds no matching rule → returns `null`
4. Result: 3× same-model empty-error-retry (guaranteed to fail) → terminal error
5. Configured fallback models are never attempted.

Fixes #99174

## Root Cause

`classifyFailoverClassificationFromMessage` had classifiers for `server_error`, `upstream_error`, and 15+ other patterns, but no rule for the Anthropic-specific `invalid_request_error` error type. The existing `isStructuredServerErrorMessage` function provides the reference pattern.

## Real behavior proof

**Behavior addressed**: Classify Anthropic-style `invalid_request_error` JSON error bodies as `"format"` so the model fallback chain advances instead of returning null.

**Real environment tested**: Linux x64, Node v22.22.0

**Exact steps or command run after this patch**:
```terminal
pnpm test src/agents/embedded-agent-helpers/failover-matches.test.ts
```

**After-fix evidence**:
```terminal_output
Test Files  1 passed (1)
     Tests  34 passed (34)

✓ classifies Anthropic invalid_request_error JSON body as format
✓ classifies OpenAI flattened invalid_request_error as format
✓ keeps existing structured server_error classification
✓ does not affect existing auth classification
✓ does not affect existing rate_limit classification
```

**Observed result after the fix**: All 34 tests pass including 5 new tests covering `invalid_request_error` classification. The broader errors test suite (5 tests) also passes with no regression.

**What was not tested**: End-to-end gateway test with real provider returning 400. The classification is a pure function tested in isolation; the runtime integration (FailoverError → fallback chain advance) is covered by existing E2E tests for other `"format"`-classified errors.

## Risk checklist

merge-risk: Low

- [x] Low risk declaration — pure classification logic, no config/API/behavior surface changes for non-invalid-request errors
- [x] `isSchemaErrorMessage` correctly excludes invalid_request errors to keep telemetry accurate
- [x] Placement after auth/billing/rate-limit/overflow checks ensures more specific classifications take precedence
- [x] New code follows the exact same pattern as `isStructuredServerErrorMessage` (established, tested, reviewed)
- [x] No changes to user-facing error text, config, exported APIs, or provider behavior
