### PR TITLE
feat(macos): adopt the shared read-only chat transcript cache

### DIFF
--- a/apps/macos/Sources/OpenClaw/ChatTranscriptCacheSupport.swift
+++ b/apps/macos/Sources/OpenClaw/ChatTranscriptCacheSupport.swift
@@ -1,0 +1,101 @@
+import Foundation
+import OpenClawChatUI
+
+/// Builds the read-only offline chat transcript cache for the macOS app.
+///
+/// The database lives in the per-user Application Support container
+/// (`~/Library/Application Support/OpenClaw/chat-cache.sqlite`), matching the
+/// existing OpenClaw app-support layout. macOS has no per-file Data Protection
+/// classes (the iOS store applies `completeUntilFirstUserAuthentication`);
+/// at-rest protection here is the per-user container permissions plus FileVault.
+enum MacChatTranscriptCache {
+    /// Stable identity of the gateway this app talks to, derivable offline
+    /// (the cache pre-paints before any connection is up). Keys must not
+    /// collide across gateways:
+    /// - local mode keys on the gateway state dir, the store that owns local
+    ///   session data: distinct profiles (distinct `OPENCLAW_STATE_DIR`) never
+    ///   share cached transcripts even when they reuse the same port;
+    /// - remote/direct keys on the full canonical remote URL (scheme, host,
+    ///   resolved port, path, query), since one origin can route to several
+    ///   gateways by path;
+    /// - remote/ssh keys on the SSH target plus the resolved remote gateway
+    ///   port (one SSH target can front several gateways on different ports).
+    ///   The tunneled 127.0.0.1 URL is per-launch and deliberately never used
+    ///   as identity.
+    static func gatewayID(
+        mode: AppState.ConnectionMode,
+        localStateDir: URL,
+        remoteTransport: AppState.RemoteTransport,
+        directURL: URL?,
+        sshTarget: String,
+        sshRemotePort: Int) -> String?
+    {
+        switch mode {
+        case .unconfigured:
+            return nil
+        case .local:
+            // Canonicalize so /var vs /private/var style aliases of the same
+            // state dir never split one gateway's cache into two scopes.
+            return "local:\(localStateDir.resolvingSymlinksInPath().standardizedFileURL.path)"
+        case .remote:
+            switch remoteTransport {
+            case .direct:
+                guard let directURL,
+                      let scheme = directURL.scheme?.lowercased(),
+                      let host = directURL.host?.lowercased(),
+                      !host.isEmpty
+                else {
+                    return nil
+                }
+                guard let port = GatewayRemoteConfig.defaultPort(for: directURL) else { return nil }
+                // Keep path/query: one origin can front several gateways via
+                // reverse-proxy routing, and the app connects to the full URL.
+                // Percent-encoded forms, not URL.path: decoding would collapse
+                // distinct request paths like /team%2Fa and /team/a.
+                // Auth is intentionally not part of the identity: gateway
+                // transcripts are not partitioned per token/password principal,
+                // and keying on credentials would drop the cache on rotation.
+                guard let components = URLComponents(url: directURL, resolvingAgainstBaseURL: false) else {
+                    return nil
+                }
+                let query = components.percentEncodedQuery.map { "?\($0)" } ?? ""
+                return "remote:\(scheme)://\(host):\(port)\(components.percentEncodedPath)\(query)"
+            case .ssh:
+                let target = sshTarget.trimmingCharacters(in: .whitespacesAndNewlines)
+                guard !target.isEmpty else { return nil }
+                return "ssh:\(target):\(sshRemotePort)"
+            }
+        }
+    }
+
+    /// Offline transcript cache scoped to the currently configured gateway.
+    /// Nil when the app is unconfigured or the remote target cannot be
+    /// resolved, so foreign rows can never leak into another gateway's scope.
+    static func make() -> (any OpenClawChatTranscriptCache)? {
+        let root = OpenClawConfigFile.loadDict()
+        let mode = ConnectionModeResolver.resolve(root: root).mode
+        let resolution = GatewayRemoteConfig.resolveTransportResolution(root: root)
+        let sshTarget = CommandResolver.connectionSettings(configRoot: root).target
+        // Mirror the tunnel's remote-port resolution (RemotePortTunnel.create)
+        // so the identity matches the gateway the forward actually reaches.
+        let defaultRemotePort = GatewayEnvironment.gatewayPort()
+        let sshHost = CommandResolver.parseSSHTarget(sshTarget)?.host ?? ""
+        let sshRemotePort = RemotePortTunnel.resolveRemotePortOverride(
+            defaultRemotePort: defaultRemotePort,
+            for: sshHost) ?? defaultRemotePort
+        let gatewayID = self.gatewayID(
+            mode: mode,
+            localStateDir: OpenClawConfigFile.stateDirURL(),
+            remoteTransport: resolution.transport,
+            directURL: resolution.directURL,
+            sshTarget: sshTarget,
+            sshRemotePort: sshRemotePort)
+        guard let gatewayID else { return nil }
+        guard let base = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask).first
+        else {
+            return nil
+        }
+        let databaseURL = base.appendingPathComponent("OpenClaw/chat-cache.sqlite", isDirectory: false)
+        return OpenClawChatSQLiteTranscriptCache(databaseURL: databaseURL, gatewayID: gatewayID)
+    }
+}

--- a/apps/macos/Sources/OpenClaw/ChatTranscriptCacheSupport.swift
+++ b/apps/macos/Sources/OpenClaw/ChatTranscriptCacheSupport.swift
@@ -71,8 +71,8 @@ enum MacChatTranscriptCache {
     /// Offline transcript cache scoped to the currently configured gateway.
     /// Nil when the app is unconfigured or the remote target cannot be
     /// resolved, so foreign rows can never leak into another gateway's scope.
-    // Concrete return: the same SQLite store also backs the offline command
-    // outbox, and callers wire both protocol facets from one instance.
+    /// Concrete return type: the same SQLite store also backs the offline
+    /// command outbox, and callers wire both protocol facets from one instance.
     static func make() -> OpenClawChatSQLiteTranscriptCache? {
         let root = OpenClawConfigFile.loadDict()
         let mode = ConnectionModeResolver.resolve(root: root).mode

--- a/apps/macos/Sources/OpenClaw/ChatTranscriptCacheSupport.swift
+++ b/apps/macos/Sources/OpenClaw/ChatTranscriptCacheSupport.swift
@@ -71,7 +71,9 @@ enum MacChatTranscriptCache {
     /// Offline transcript cache scoped to the currently configured gateway.
     /// Nil when the app is unconfigured or the remote target cannot be
     /// resolved, so foreign rows can never leak into another gateway's scope.
-    static func make() -> (any OpenClawChatTranscriptCache)? {
+    // Concrete return: the same SQLite store also backs the offline command
+    // outbox, and callers wire both protocol facets from one instance.
+    static func make() -> OpenClawChatSQLiteTranscriptCache? {
         let root = OpenClawConfigFile.loadDict()
         let mode = ConnectionModeResolver.resolve(root: root).mode
         let resolution = GatewayRemoteConfig.resolveTransportResolution(root: root)

--- a/apps/macos/Sources/OpenClaw/RemotePortTunnel.swift
+++ b/apps/macos/Sources/OpenClaw/RemotePortTunnel.swift
@@ -189,9 +189,9 @@ final class RemotePortTunnel: @unchecked Sendable {
         throw NSError(domain: "RemotePortTunnel", code: 4, userInfo: [NSLocalizedDescriptionKey: msg])
     }
 
-    // Shared with MacChatTranscriptCache: the offline cache identity must key
-    // on the same remote gateway port this tunnel actually forwards to, or two
-    // gateways behind one SSH target would share cached transcripts.
+    /// Shared with MacChatTranscriptCache: the offline cache identity must key
+    /// on the same remote gateway port this tunnel actually forwards to, or two
+    /// gateways behind one SSH target would share cached transcripts.
     static func resolveRemotePortOverride(defaultRemotePort: Int, for sshHost: String) -> Int? {
         let root = OpenClawConfigFile.loadDict()
         if let port = GatewayRemoteConfig.resolveRemotePort(root: root) {

--- a/apps/macos/Sources/OpenClaw/RemotePortTunnel.swift
+++ b/apps/macos/Sources/OpenClaw/RemotePortTunnel.swift
@@ -189,7 +189,10 @@ final class RemotePortTunnel: @unchecked Sendable {
         throw NSError(domain: "RemotePortTunnel", code: 4, userInfo: [NSLocalizedDescriptionKey: msg])
     }
 
-    private static func resolveRemotePortOverride(defaultRemotePort: Int, for sshHost: String) -> Int? {
+    // Shared with MacChatTranscriptCache: the offline cache identity must key
+    // on the same remote gateway port this tunnel actually forwards to, or two
+    // gateways behind one SSH target would share cached transcripts.
+    static func resolveRemotePortOverride(defaultRemotePort: Int, for sshHost: String) -> Int? {
         let root = OpenClawConfigFile.loadDict()
         if let port = GatewayRemoteConfig.resolveRemotePort(root: root) {
             return port

--- a/apps/macos/Sources/OpenClaw/WebChatSwiftUI.swift
+++ b/apps/macos/Sources/OpenClaw/WebChatSwiftUI.swift
@@ -250,15 +250,27 @@ final class WebChatSwiftUIWindowController {
     var onVisibilityChanged: ((Bool) -> Void)?
 
     convenience init(sessionKey: String, presentation: WebChatPresentation) {
-        self.init(sessionKey: sessionKey, presentation: presentation, transport: MacGatewayChatTransport())
+        // Connection-mode changes tear chat windows down via resetTunnels(),
+        // so binding the cache identity at construction stays correct.
+        self.init(
+            sessionKey: sessionKey,
+            presentation: presentation,
+            transport: MacGatewayChatTransport(),
+            transcriptCache: MacChatTranscriptCache.make())
     }
 
-    init(sessionKey: String, presentation: WebChatPresentation, transport: any OpenClawChatTransport) {
+    init(
+        sessionKey: String,
+        presentation: WebChatPresentation,
+        transport: any OpenClawChatTransport,
+        transcriptCache: (any OpenClawChatTranscriptCache)? = nil)
+    {
         self.sessionKey = sessionKey
         self.presentation = presentation
         let vm = OpenClawChatViewModel(
             sessionKey: sessionKey,
             transport: transport,
+            transcriptCache: transcriptCache,
             initialThinkingLevel: Self.persistedThinkingLevel(),
             onThinkingLevelChanged: { level in
                 UserDefaults.standard.set(level, forKey: webChatThinkingLevelDefaultsKey)

--- a/apps/macos/Sources/OpenClaw/WebChatSwiftUI.swift
+++ b/apps/macos/Sources/OpenClaw/WebChatSwiftUI.swift
@@ -251,19 +251,24 @@ final class WebChatSwiftUIWindowController {
 
     convenience init(sessionKey: String, presentation: WebChatPresentation) {
         // Connection-mode changes tear chat windows down via resetTunnels(),
-        // so binding the cache identity at construction stays correct.
+        // so binding the cache identity at construction stays correct. One
+        // store instance backs both the transcript cache and the offline
+        // command outbox.
+        let store = MacChatTranscriptCache.make()
         self.init(
             sessionKey: sessionKey,
             presentation: presentation,
             transport: MacGatewayChatTransport(),
-            transcriptCache: MacChatTranscriptCache.make())
+            transcriptCache: store,
+            outbox: store)
     }
 
     init(
         sessionKey: String,
         presentation: WebChatPresentation,
         transport: any OpenClawChatTransport,
-        transcriptCache: (any OpenClawChatTranscriptCache)? = nil)
+        transcriptCache: (any OpenClawChatTranscriptCache)? = nil,
+        outbox: (any OpenClawChatCommandOutbox)? = nil)
     {
         self.sessionKey = sessionKey
         self.presentation = presentation
@@ -271,6 +276,7 @@ final class WebChatSwiftUIWindowController {
             sessionKey: sessionKey,
             transport: transport,
             transcriptCache: transcriptCache,
+            outbox: outbox,
             initialThinkingLevel: Self.persistedThinkingLevel(),
             onThinkingLevelChanged: { level in
                 UserDefaults.standard.set(level, forKey: webChatThinkingLevelDefaultsKey)

--- a/apps/macos/Tests/OpenClawIPCTests/ChatTranscriptCacheIdentityTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/ChatTranscriptCacheIdentityTests.swift
@@ -1,0 +1,163 @@
+import Foundation
+import Testing
+@testable import OpenClaw
+
+struct ChatTranscriptCacheIdentityTests {
+    private static let defaultStateDir = URL(fileURLWithPath: "/Users/tester/.openclaw", isDirectory: true)
+
+    @Test func `unconfigured mode has no cache identity`() {
+        let id = MacChatTranscriptCache.gatewayID(
+            mode: .unconfigured,
+            localStateDir: Self.defaultStateDir,
+            remoteTransport: .ssh,
+            directURL: nil,
+            sshTarget: "user@host",
+            sshRemotePort: 18789)
+        #expect(id == nil)
+    }
+
+    @Test func `local mode keys on state dir so profiles never collide`() {
+        let defaultProfile = MacChatTranscriptCache.gatewayID(
+            mode: .local,
+            localStateDir: Self.defaultStateDir,
+            remoteTransport: .ssh,
+            directURL: nil,
+            sshTarget: "",
+            sshRemotePort: 18789)
+        let devProfile = MacChatTranscriptCache.gatewayID(
+            mode: .local,
+            localStateDir: URL(fileURLWithPath: "/Users/tester/.openclaw-dev", isDirectory: true),
+            remoteTransport: .ssh,
+            directURL: nil,
+            sshTarget: "",
+            sshRemotePort: 18789)
+        #expect(defaultProfile == "local:/Users/tester/.openclaw")
+        #expect(devProfile == "local:/Users/tester/.openclaw-dev")
+        #expect(defaultProfile != devProfile)
+    }
+
+    @Test func `local state dir aliases resolve to one identity`() throws {
+        // macOS tmp lives behind a /var -> /private/var symlink; both spellings
+        // of the same state dir must map to a single cache scope.
+        let canonical = try FileManager.default.temporaryDirectory
+            .appendingPathComponent("openclaw-cache-identity-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: canonical, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: canonical) }
+        let resolved = canonical.resolvingSymlinksInPath()
+        let viaSymlink = MacChatTranscriptCache.gatewayID(
+            mode: .local,
+            localStateDir: canonical,
+            remoteTransport: .ssh,
+            directURL: nil,
+            sshTarget: "",
+            sshRemotePort: 18789)
+        let viaResolved = MacChatTranscriptCache.gatewayID(
+            mode: .local,
+            localStateDir: resolved,
+            remoteTransport: .ssh,
+            directURL: nil,
+            sshTarget: "",
+            sshRemotePort: 18789)
+        #expect(viaSymlink == viaResolved)
+    }
+
+    @Test func `remote direct keys on the full canonical url`() {
+        let explicitPort = MacChatTranscriptCache.gatewayID(
+            mode: .remote,
+            localStateDir: Self.defaultStateDir,
+            remoteTransport: .direct,
+            directURL: URL(string: "ws://Gateway.Example.com:9001"),
+            sshTarget: "",
+            sshRemotePort: 18789)
+        #expect(explicitPort == "remote:ws://gateway.example.com:9001")
+
+        let defaultWSSPort = MacChatTranscriptCache.gatewayID(
+            mode: .remote,
+            localStateDir: Self.defaultStateDir,
+            remoteTransport: .direct,
+            directURL: URL(string: "wss://gw.example.com"),
+            sshTarget: "",
+            sshRemotePort: 18789)
+        #expect(defaultWSSPort == "remote:wss://gw.example.com:443")
+
+        // One origin can route to several gateways by path; each path is its
+        // own cache scope.
+        let teamA = MacChatTranscriptCache.gatewayID(
+            mode: .remote,
+            localStateDir: Self.defaultStateDir,
+            remoteTransport: .direct,
+            directURL: URL(string: "wss://gw.example.com/team-a"),
+            sshTarget: "",
+            sshRemotePort: 18789)
+        let teamB = MacChatTranscriptCache.gatewayID(
+            mode: .remote,
+            localStateDir: Self.defaultStateDir,
+            remoteTransport: .direct,
+            directURL: URL(string: "wss://gw.example.com/team-b"),
+            sshTarget: "",
+            sshRemotePort: 18789)
+        #expect(teamA == "remote:wss://gw.example.com:443/team-a")
+        #expect(teamB == "remote:wss://gw.example.com:443/team-b")
+        #expect(teamA != teamB)
+
+        // Percent-encoded path spelling is part of the request URL and must
+        // not collapse into the decoded form's scope.
+        let encodedPath = MacChatTranscriptCache.gatewayID(
+            mode: .remote,
+            localStateDir: Self.defaultStateDir,
+            remoteTransport: .direct,
+            directURL: URL(string: "wss://gw.example.com/team%2Fa"),
+            sshTarget: "",
+            sshRemotePort: 18789)
+        let decodedPath = MacChatTranscriptCache.gatewayID(
+            mode: .remote,
+            localStateDir: Self.defaultStateDir,
+            remoteTransport: .direct,
+            directURL: URL(string: "wss://gw.example.com/team/a"),
+            sshTarget: "",
+            sshRemotePort: 18789)
+        #expect(encodedPath == "remote:wss://gw.example.com:443/team%2Fa")
+        #expect(encodedPath != decodedPath)
+
+        let missingURL = MacChatTranscriptCache.gatewayID(
+            mode: .remote,
+            localStateDir: Self.defaultStateDir,
+            remoteTransport: .direct,
+            directURL: nil,
+            sshTarget: "",
+            sshRemotePort: 18789)
+        #expect(missingURL == nil)
+    }
+
+    @Test func `remote ssh keys on the ssh target and remote gateway port`() {
+        let id = MacChatTranscriptCache.gatewayID(
+            mode: .remote,
+            localStateDir: Self.defaultStateDir,
+            remoteTransport: .ssh,
+            directURL: nil,
+            sshTarget: "  user@studio.local  ",
+            sshRemotePort: 18789)
+        #expect(id == "ssh:user@studio.local:18789")
+
+        // One SSH target can front several gateways on different remote ports;
+        // each must get its own cache scope.
+        let otherGateway = MacChatTranscriptCache.gatewayID(
+            mode: .remote,
+            localStateDir: Self.defaultStateDir,
+            remoteTransport: .ssh,
+            directURL: nil,
+            sshTarget: "user@studio.local",
+            sshRemotePort: 19001)
+        #expect(otherGateway == "ssh:user@studio.local:19001")
+        #expect(otherGateway != id)
+
+        let missingTarget = MacChatTranscriptCache.gatewayID(
+            mode: .remote,
+            localStateDir: Self.defaultStateDir,
+            remoteTransport: .ssh,
+            directURL: nil,
+            sshTarget: "   ",
+            sshRemotePort: 18789)
+        #expect(missingTarget == nil)
+    }
+}

--- a/docs/docs_map.md
+++ b/docs/docs_map.md
@@ -2354,6 +2354,18 @@ Do not edit it by hand; run `pnpm docs:map:gen`.
   - H2: Full list
   - H2: Related
 
+## concepts/managed-worktrees.md
+
+- Route: /concepts/managed-worktrees
+- Headings:
+  - H2: Layout and names
+  - H2: Provision ignored files
+  - H2: Run repository setup
+  - H2: Snapshots, cleanup, and restore
+  - H2: CLI
+  - H2: Gateway methods
+  - H2: Workboard workspaces
+
 ## concepts/mantis-slack-desktop-runbook.md
 
 - Route: /concepts/mantis-slack-desktop-runbook

--- a/docs/platforms/mac/webchat.md
+++ b/docs/platforms/mac/webchat.md
@@ -29,6 +29,7 @@ The macOS menu bar app embeds the WebChat UI as a native SwiftUI view. It connec
 - `chat.history` returns a display-normalized transcript: inline directive tags are stripped from visible text, plain-text tool-call XML payloads (`<tool_call>`, `<function_call>`, `<tool_calls>`, `<function_calls>`, including truncated blocks) and leaked model control tokens are stripped, pure silent-token assistant rows such as exact `NO_REPLY`/`no_reply` are omitted, and oversized rows can be replaced with a truncated placeholder.
 - Session: defaults to the primary session as above; the UI can switch between sessions.
 - Onboarding uses a dedicated session to keep first-run setup separate.
+- Offline cache: the app keeps a small read-only cache of recent chat sessions and transcripts per gateway (`~/Library/Application Support/OpenClaw/chat-cache.sqlite`): cold opens paint the last known transcript immediately and refresh once the Gateway responds, and recent chats stay browsable while disconnected (sending stays disabled until the connection is back).
 
 ## Security surface
 


### PR DESCRIPTION
Stacked on #100219 (`feat/ios-chat-offline-cache`) — lands after it; this PR's own diff is the macOS adoption only.

Part of #100194

## What Problem This Solves

Resolves a problem where the macOS chat window showed nothing until the gateway responded, and nothing at all while disconnected — the shared read-only transcript cache introduced for the chat pipeline was not wired up on macOS.

## Why This Change Was Made

Adopts the shared `OpenClawChatTranscriptCache` seam in the macOS app. The work is wiring plus a macOS-specific gateway identity key (`MacChatTranscriptCache.gatewayID`): unconfigured → no cache; local gateway → `local:<canonical state dir>` (the state dir owns local session data, so profiles never collide even when sharing a port); direct remote → the full canonical URL (one origin can path-route to several gateways); ssh remote → `ssh:<target>:<resolved remote gateway port>` reusing the tunnel's own port resolution so identity matches what is actually forwarded. Per-launch tunnel URLs are never used as identity. Auth is deliberately excluded from the key — gateway transcripts are not principal-scoped, and keying on credentials would drop the cache on every token rotation (documented inline). DB lives at `~/Library/Application Support/OpenClaw/chat-cache.sqlite`; at-rest protection is the per-user container plus FileVault. The shared store needed zero changes (its iOS file-protection call was already platform-gated).

## User Impact

The macOS chat window renders the last known conversation instantly on open and stays browsable read-only while the gateway is unreachable, per gateway identity, with the same disposable, bounded, text-only cache contract as the rest of the app family.

## Evidence

- `apps/shared/OpenClawKit`: `swift build` clean; `swift test --filter "ChatTranscriptCacheStoreTests|ChatViewModelTranscriptCacheTests"` — 15/15.
- `apps/macos`: `swift build` clean; `swift test --filter ChatTranscriptCacheIdentityTests` — 5/5 (per-mode identity keys, symlink canonicalization, ssh port resolution).
- Codex autoreview: 5 rounds; 3 accepted findings fixed (local key now uses the state dir rather than port; ssh key includes the resolved remote port; direct key uses the full percent-encoded URL rather than host:port); 1 finding consciously rejected with inline-documented rationale (auth-principal digest in the identity key — transcripts aren't principal-scoped and rotation would needlessly drop the cache).

Known gap: no live end-to-end offline pass on macOS yet (wiring proven by builds + the shared suite); pnpm-gated lint lanes covered by CI (diff is Swift + one docs line).

**Update:** now stacked on the iOS outbox branch (#100331) and additionally wires the offline command outbox into macOS chat windows (`feat(macos): wire the offline command outbox into chat windows`): the same gateway-scoped SQLite store instance backs both the transcript cache and the outbox, so macOS gets queued offline sends with the full shared contract (FIFO flush, retry/expiry, tombstoned deletes). Landing order: #100219 → #100331 → this PR. Codex autoreview on the wiring commit: clean (0.88). Part of #46664 as well.
