### PR TITLE
fix(protocol): regenerate plugin approval Swift model

### DIFF
--- a/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
@@ -7085,6 +7085,7 @@ public struct PluginApprovalRequestParams: Codable, Sendable {
     public let alloweddecisions: [String]?
     public let agentid: String?
     public let sessionkey: String?
+    public let approvalreviewerdeviceids: [String]?
     public let turnsourcechannel: String?
     public let turnsourceto: String?
     public let turnsourceaccountid: String?
@@ -7102,6 +7103,7 @@ public struct PluginApprovalRequestParams: Codable, Sendable {
         alloweddecisions: [String]?,
         agentid: String? = nil,
         sessionkey: String?,
+        approvalreviewerdeviceids: [String]?,
         turnsourcechannel: String?,
         turnsourceto: String?,
         turnsourceaccountid: String?,
@@ -7118,6 +7120,7 @@ public struct PluginApprovalRequestParams: Codable, Sendable {
         self.alloweddecisions = alloweddecisions
         self.agentid = agentid
         self.sessionkey = sessionkey
+        self.approvalreviewerdeviceids = approvalreviewerdeviceids
         self.turnsourcechannel = turnsourcechannel
         self.turnsourceto = turnsourceto
         self.turnsourceaccountid = turnsourceaccountid
@@ -7136,6 +7139,7 @@ public struct PluginApprovalRequestParams: Codable, Sendable {
         case alloweddecisions = "allowedDecisions"
         case agentid = "agentId"
         case sessionkey = "sessionKey"
+        case approvalreviewerdeviceids = "approvalReviewerDeviceIds"
         case turnsourcechannel = "turnSourceChannel"
         case turnsourceto = "turnSourceTo"
         case turnsourceaccountid = "turnSourceAccountId"


### PR DESCRIPTION
## What Problem This Solves

Current `main` fails the bundled protocol CI lane on every pull request. The TypeScript protocol schema includes `PluginApprovalRequestParams.approvalReviewerDeviceIds`, but the checked-in generated Swift model omits it, so `pnpm protocol:gen:swift` leaves a dirty diff.

## Why This Change Was Made

Regenerate the checked-in Swift protocol model from the canonical schema. No hand-written protocol or runtime behavior changes.

## User Impact

Restores generated protocol parity and unblocks unrelated pull requests. Apple clients regain the declared plugin-approval reviewer device field in the generated model.

## Evidence

- Blacksmith Testbox: `pnpm protocol:gen:swift` reproduced no change beyond this four-line generated delta.
- The same missing generated field failed `checks-fast-bundled-protocol` on two disjoint PR heads: [28737505727](https://github.com/openclaw/openclaw/actions/runs/28737505727) and [28737516882](https://github.com/openclaw/openclaw/actions/runs/28737516882).
- `git diff --check`
