### PR TITLE
feat(ios): add Apple Watch voice turns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ Docs: https://docs.openclaw.ai
 ### Changes
 
 - **Control UI context usage:** show context-window progress, latest-run input/output tokens, and the active model when the chat context ring is opened.
+- **Apple Watch voice turns:** dictate a message from the Watch chat and hear the new OpenClaw reply spoken on the Watch, with explicit silent-message and stop-speaking controls. (#100224)
 - **Conversational onboarding:** add a real agent-loop Crestodian setup flow across the CLI, Gateway, web install, and macOS app, with typed operations, exact approval binding, masked credential prompts, isolated session transcripts, and safe handoff to the normal agent.
 - **Generated session titles:** name new Control UI sessions from their first message, and add default/per-agent `utilityModel` routing for lower-cost session, topic, and thread title generation. Thanks @Juliangsm and @zhangguiping-xydt.
 - **ClawRouter routing and quotas:** add the bundled ClawRouter provider plugin with credential-scoped dynamic model discovery, OpenAI-compatible and native Anthropic/Gemini transports, and managed budget reporting across OpenClaw usage surfaces. (#99658)

--- a/apps/.i18n/native-source.json
+++ b/apps/.i18n/native-source.json
@@ -12741,9 +12741,9 @@
       "kind": "ui-call",
       "line": 1192,
       "path": "apps/ios/WatchApp/Sources/WatchInboxView.swift",
-      "source": "Message",
+      "source": "Message OpenClaw",
       "surface": "apple",
-      "id": "native.apple.23e5c409f5338b5e"
+      "id": "native.apple.b816e4b9e492ae6c"
     },
     {
       "kind": "ui-named-argument",

--- a/apps/.i18n/native-source.json
+++ b/apps/.i18n/native-source.json
@@ -10995,7 +10995,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 2296,
+      "line": 2319,
       "path": "apps/ios/Sources/Model/NodeAppModel.swift",
       "source": "Action required",
       "surface": "apple",
@@ -11003,7 +11003,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 2296,
+      "line": 2319,
       "path": "apps/ios/Sources/Model/NodeAppModel.swift",
       "source": "Approval needed",
       "surface": "apple",
@@ -11011,7 +11011,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 2629,
+      "line": 2652,
       "path": "apps/ios/Sources/Model/NodeAppModel.swift",
       "source": "Connecting…",
       "surface": "apple",
@@ -11019,7 +11019,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 2629,
+      "line": 2652,
       "path": "apps/ios/Sources/Model/NodeAppModel.swift",
       "source": "Reconnecting…",
       "surface": "apple",
@@ -11027,7 +11027,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 2633,
+      "line": 2656,
       "path": "apps/ios/Sources/Model/NodeAppModel.swift",
       "source": "Connecting...",
       "surface": "apple",
@@ -11035,7 +11035,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 2633,
+      "line": 2656,
       "path": "apps/ios/Sources/Model/NodeAppModel.swift",
       "source": "Reconnecting...",
       "surface": "apple",
@@ -11043,7 +11043,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 2941,
+      "line": 2964,
       "path": "apps/ios/Sources/Model/NodeAppModel.swift",
       "source": "Connected",
       "surface": "apple",
@@ -11051,7 +11051,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 2941,
+      "line": 2964,
       "path": "apps/ios/Sources/Model/NodeAppModel.swift",
       "source": "Offline",
       "surface": "apple",
@@ -12547,7 +12547,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 327,
+      "line": 329,
       "path": "apps/ios/WatchApp/Sources/WatchInboxView.swift",
       "source": "\\(self.chatCount)",
       "surface": "apple",
@@ -12555,7 +12555,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 331,
+      "line": 333,
       "path": "apps/ios/WatchApp/Sources/WatchInboxView.swift",
       "source": "\\(self.approvalCount)",
       "surface": "apple",
@@ -12563,7 +12563,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 336,
+      "line": 338,
       "path": "apps/ios/WatchApp/Sources/WatchInboxView.swift",
       "source": "AI agent online",
       "surface": "apple",
@@ -12571,7 +12571,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 336,
+      "line": 338,
       "path": "apps/ios/WatchApp/Sources/WatchInboxView.swift",
       "source": "Reconnect on iPhone",
       "surface": "apple",
@@ -12579,7 +12579,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 343,
+      "line": 345,
       "path": "apps/ios/WatchApp/Sources/WatchInboxView.swift",
       "source": "Pairing",
       "surface": "apple",
@@ -12587,7 +12587,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 343,
+      "line": 345,
       "path": "apps/ios/WatchApp/Sources/WatchInboxView.swift",
       "source": "Running",
       "surface": "apple",
@@ -12595,7 +12595,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 363,
+      "line": 365,
       "path": "apps/ios/WatchApp/Sources/WatchInboxView.swift",
       "source": "Ready for quick actions",
       "surface": "apple",
@@ -12603,7 +12603,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 363,
+      "line": 365,
       "path": "apps/ios/WatchApp/Sources/WatchInboxView.swift",
       "source": "Waiting for iPhone sync",
       "surface": "apple",
@@ -12611,7 +12611,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 367,
+      "line": 369,
       "path": "apps/ios/WatchApp/Sources/WatchInboxView.swift",
       "source": "1 approval waiting",
       "surface": "apple",
@@ -12619,7 +12619,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 367,
+      "line": 369,
       "path": "apps/ios/WatchApp/Sources/WatchInboxView.swift",
       "source": "\\(self.approvalCount) approvals",
       "surface": "apple",
@@ -12627,7 +12627,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 376,
+      "line": 378,
       "path": "apps/ios/WatchApp/Sources/WatchInboxView.swift",
       "source": "Decide from watch",
       "surface": "apple",
@@ -12635,7 +12635,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 376,
+      "line": 378,
       "path": "apps/ios/WatchApp/Sources/WatchInboxView.swift",
       "source": "No approvals",
       "surface": "apple",
@@ -12643,7 +12643,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 430,
+      "line": 432,
       "path": "apps/ios/WatchApp/Sources/WatchInboxView.swift",
       "source": "1 recent message",
       "surface": "apple",
@@ -12651,7 +12651,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 430,
+      "line": 432,
       "path": "apps/ios/WatchApp/Sources/WatchInboxView.swift",
       "source": "\\(self.chatCount) recent messages",
       "surface": "apple",
@@ -12659,7 +12659,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 432,
+      "line": 434,
       "path": "apps/ios/WatchApp/Sources/WatchInboxView.swift",
       "source": "No messages synced",
       "surface": "apple",
@@ -12667,7 +12667,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 462,
+      "line": 464,
       "path": "apps/ios/WatchApp/Sources/WatchInboxView.swift",
       "source": "Synced",
       "surface": "apple",
@@ -12675,7 +12675,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 462,
+      "line": 464,
       "path": "apps/ios/WatchApp/Sources/WatchInboxView.swift",
       "source": "Waiting for iPhone",
       "surface": "apple",
@@ -12683,7 +12683,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 728,
+      "line": 730,
       "path": "apps/ios/WatchApp/Sources/WatchInboxView.swift",
       "source": "Inbox",
       "surface": "apple",
@@ -12691,7 +12691,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 904,
+      "line": 906,
       "path": "apps/ios/WatchApp/Sources/WatchInboxView.swift",
       "source": "OpenClaw",
       "surface": "apple",
@@ -12699,7 +12699,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 993,
+      "line": 995,
       "path": "apps/ios/WatchApp/Sources/WatchInboxView.swift",
       "source": "You",
       "surface": "apple",
@@ -12707,7 +12707,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 995,
+      "line": 997,
       "path": "apps/ios/WatchApp/Sources/WatchInboxView.swift",
       "source": "System",
       "surface": "apple",
@@ -12715,7 +12715,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1031,
+      "line": 1042,
       "path": "apps/ios/WatchApp/Sources/WatchInboxView.swift",
       "source": "Refresh",
       "surface": "apple",
@@ -12723,7 +12723,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1065,
+      "line": 1137,
       "path": "apps/ios/WatchApp/Sources/WatchInboxView.swift",
       "source": "No chat synced",
       "surface": "apple",
@@ -12731,7 +12731,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1072,
+      "line": 1144,
       "path": "apps/ios/WatchApp/Sources/WatchInboxView.swift",
       "source": "Tap the message pill below to start from your watch.",
       "surface": "apple",
@@ -12739,15 +12739,15 @@
     },
     {
       "kind": "ui-call",
-      "line": 1114,
+      "line": 1192,
       "path": "apps/ios/WatchApp/Sources/WatchInboxView.swift",
-      "source": "Message OpenClaw",
+      "source": "Message",
       "surface": "apple",
-      "id": "native.apple.b816e4b9e492ae6c"
+      "id": "native.apple.23e5c409f5338b5e"
     },
     {
       "kind": "ui-named-argument",
-      "line": 1179,
+      "line": 1295,
       "path": "apps/ios/WatchApp/Sources/WatchInboxView.swift",
       "source": "Approvals",
       "surface": "apple",
@@ -12755,7 +12755,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1182,
+      "line": 1298,
       "path": "apps/ios/WatchApp/Sources/WatchInboxView.swift",
       "source": "Clear",
       "surface": "apple",
@@ -12763,7 +12763,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1183,
+      "line": 1299,
       "path": "apps/ios/WatchApp/Sources/WatchInboxView.swift",
       "source": "No approvals waiting",
       "surface": "apple",
@@ -12771,7 +12771,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1243,
+      "line": 1359,
       "path": "apps/ios/WatchApp/Sources/WatchInboxView.swift",
       "source": "Approval",
       "surface": "apple",
@@ -12779,7 +12779,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1257,
+      "line": 1373,
       "path": "apps/ios/WatchApp/Sources/WatchInboxView.swift",
       "source": "Sending decision...",
       "surface": "apple",
@@ -12787,7 +12787,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1261,
+      "line": 1377,
       "path": "apps/ios/WatchApp/Sources/WatchInboxView.swift",
       "source": "Approve",
       "surface": "apple",
@@ -12795,7 +12795,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1267,
+      "line": 1383,
       "path": "apps/ios/WatchApp/Sources/WatchInboxView.swift",
       "source": "Deny",
       "surface": "apple",

--- a/apps/ios/Sources/Chat/AppleReviewDemoChatTransport.swift
+++ b/apps/ios/Sources/Chat/AppleReviewDemoChatTransport.swift
@@ -399,7 +399,8 @@ private actor LocalFixtureChatStore {
                     content: nil),
             ],
             timestamp: timestamp,
-            idempotencyKey: idempotencyKey)
+            idempotencyKey: idempotencyKey,
+            stopReason: role == "assistant" ? "stop" : nil)
     }
 
     private static func normalizedSessionKey(_ value: String, fallback: String) -> String {

--- a/apps/ios/Sources/Model/NodeAppModel.swift
+++ b/apps/ios/Sources/Model/NodeAppModel.swift
@@ -1,4 +1,5 @@
 import CoreLocation
+import CryptoKit
 import Observation
 import OpenClawChatUI
 import OpenClawKit
@@ -22,6 +23,27 @@ private struct GatewayRelayIdentityResponse: Decodable {
 private struct WatchChatPreview {
     var items: [OpenClawWatchChatItem]
     var statusText: String?
+}
+
+private struct WatchChatMetadataEnvelope: Decodable {
+    struct Metadata: Decodable {
+        var id: String?
+    }
+
+    var metadata: Metadata?
+    var messageToolMirror: [String: String]?
+
+    enum CodingKeys: String, CodingKey {
+        case metadata = "__openclaw"
+        case messageToolMirror = "openclawMessageToolMirror"
+    }
+}
+
+private struct WatchChatMessageEntry {
+    var message: OpenClawChatMessage
+    var text: String
+    var serverId: String?
+    var isMessageToolMirror: Bool
 }
 
 private struct ExecApprovalGatewayEventPayload: Decodable {
@@ -271,7 +293,8 @@ final class NodeAppModel {
     private static let backgroundAliveLastSuccessAtMsKey = "gateway.backgroundAlive.lastSuccessAtMs"
     private static let backgroundAliveLastTriggerKey = "gateway.backgroundAlive.lastTrigger"
     private static let foregroundResumeHealthTimeoutSeconds = 1
-    private static let watchChatCompletionWaitMs = 45000
+    private static let watchChatCompletionWaitMs = 75000
+    private static let watchChatRunWaitSliceMs = 60000
 
     var cameraHUDText: String?
     var cameraHUDKind: CameraHUDKind?
@@ -3570,41 +3593,99 @@ extension NodeAppModel {
         }
     }
 
-    private nonisolated static func decodeWatchChatMessage(
-        _ raw: OpenClawKit.AnyCodable) -> OpenClawChatMessage?
+    private nonisolated static func watchChatReplyText(
+        from raw: [OpenClawKit.AnyCodable],
+        runId: String,
+        submittedText: String,
+        submittedAtMs: Int) -> String?
     {
-        guard let data = try? JSONEncoder().encode(raw) else { return nil }
-        return try? JSONDecoder().decode(OpenClawChatMessage.self, from: data)
+        let entries = raw.compactMap(self.decodeWatchChatMessage)
+        if let directReply = entries.last(where: {
+            self.isTerminalWatchAssistant($0) && $0.message.idempotencyKey == runId
+        }) {
+            return directReply.text
+        }
+
+        let userIdempotencyKey = "\(runId):user"
+        let exactUserIndex = entries.lastIndex(where: {
+            $0.message.role.lowercased() == "user" &&
+                $0.message.idempotencyKey == userIdempotencyKey
+        })
+        let queuedUserIndex = entries.lastIndex(where: { entry in
+            guard entry.message.role.lowercased() == "user",
+                  let timestampMs = self.watchTimestampMs(entry.message.timestamp),
+                  timestampMs >= submittedAtMs
+            else {
+                return false
+            }
+            return entry.text.contains(submittedText)
+        })
+        guard let userIndex = exactUserIndex ?? queuedUserIndex else { return nil }
+        return entries[(userIndex + 1)...].first(where: {
+            self.isTerminalWatchAssistant($0)
+        })?.text
+    }
+
+    private nonisolated static func isTerminalWatchAssistant(_ entry: WatchChatMessageEntry) -> Bool {
+        guard entry.message.role.lowercased() == "assistant" else { return false }
+        if entry.isMessageToolMirror {
+            return true
+        }
+        guard let stopReason = entry.message.stopReason?.lowercased() else { return false }
+        // Tool-use rows can contain visible progress text, but a later assistant row owns the final reply.
+        return stopReason != "tooluse" && stopReason != "tool_use" && stopReason != "tool_calls"
+    }
+
+    private nonisolated static func decodeWatchChatMessage(
+        _ raw: OpenClawKit.AnyCodable) -> WatchChatMessageEntry?
+    {
+        guard let data = try? JSONEncoder().encode(raw),
+              let message = try? JSONDecoder().decode(OpenClawChatMessage.self, from: data),
+              let text = self.nonEmptyWatchChatText(self.watchChatText(from: message))
+        else {
+            return nil
+        }
+        let metadata = try? JSONDecoder().decode(WatchChatMetadataEnvelope.self, from: data)
+        return WatchChatMessageEntry(
+            message: message,
+            text: text,
+            serverId: metadata?.metadata?.id,
+            isMessageToolMirror: metadata?.messageToolMirror != nil)
     }
 
     private nonisolated static func makeWatchChatItems(
         from raw: [OpenClawKit.AnyCodable]) -> [OpenClawWatchChatItem]
     {
-        var readableMessages: [(OpenClawChatMessage, String)] = []
-        for item in raw.reversed() {
-            guard let message = self.decodeWatchChatMessage(item) else { continue }
-            let text = self.watchChatText(from: message)
-            guard !text.isEmpty else { continue }
-            readableMessages.append((message, text))
-            if readableMessages.count == self.watchChatPreviewItemLimit {
-                break
-            }
+        let readableMessages = raw.compactMap(self.decodeWatchChatMessage)
+        var idOccurrences: [String: Int] = [:]
+        let identified = readableMessages.map { entry -> (WatchChatMessageEntry, String) in
+            let baseId = entry.serverId.map { "\(entry.message.role)-\($0)" }
+                ?? self.watchChatFallbackKey(entry)
+            idOccurrences[baseId, default: 0] += 1
+            let stableId = "\(baseId)-\(idOccurrences[baseId]!)"
+            return (entry, stableId)
         }
-        return Array(readableMessages.reversed()).enumerated().map { index, entry in
-            let timestampMs = self.watchTimestampMs(entry.0.timestamp)
-            let stableTime = timestampMs.map(String.init) ?? entry.0.id.uuidString
+        return identified.suffix(self.watchChatPreviewItemLimit).map { entry, stableId in
+            let timestampMs = self.watchTimestampMs(entry.message.timestamp)
             return OpenClawWatchChatItem(
-                id: "\(entry.0.role)-\(stableTime)-\(index)",
-                role: entry.0.role,
-                text: self.truncatedWatchChatText(entry.1),
+                id: stableId,
+                role: entry.message.role,
+                text: self.truncatedWatchChatText(entry.text),
                 timestampMs: timestampMs)
         }
+    }
+
+    private nonisolated static func watchChatFallbackKey(_ entry: WatchChatMessageEntry) -> String {
+        let timestamp = self.watchTimestampMs(entry.message.timestamp).map(String.init) ?? "missing"
+        let source = "\(entry.message.role)\u{0}\(timestamp)\u{0}\(entry.text)"
+        let digest = SHA256.hash(data: Data(source.utf8)).map { String(format: "%02x", $0) }.joined()
+        return "\(entry.message.role)-\(digest)"
     }
 
     private nonisolated static func watchChatText(from message: OpenClawChatMessage) -> String {
         let parts = message.content.compactMap { content -> String? in
             let kind = (content.type ?? "text").lowercased()
-            guard kind.isEmpty || kind == "text" else { return nil }
+            guard kind.isEmpty || kind == "text" || kind == "output_text" else { return nil }
             if let text = self.nonEmptyWatchChatText(content.text) {
                 return text
             }
@@ -3784,14 +3865,24 @@ extension NodeAppModel {
         self.focusChatSession(sessionKey)
 
         do {
+            let submittedAtMs = Int(Date().timeIntervalSince1970 * 1000)
             if self.isAppleReviewDemoModeEnabled {
-                _ = try await self.appleReviewDemoChatTransport.sendMessage(
+                let response = try await self.appleReviewDemoChatTransport.sendMessage(
                     sessionKey: sessionKey,
                     message: text,
                     thinking: "auto",
                     idempotencyKey: event.commandId,
                     attachments: [])
-                await self.syncWatchAppSnapshot(reason: "watch_chat_sent", includeChat: true)
+                let history = try await self.appleReviewDemoChatTransport.requestHistory(sessionKey: sessionKey)
+                if let replyText = Self.watchChatReplyText(
+                    from: history.messages ?? [],
+                    runId: response.runId,
+                    submittedText: text,
+                    submittedAtMs: submittedAtMs)
+                {
+                    await self.sendWatchChatCompletion(commandId: event.commandId, replyText: replyText)
+                }
+                await self.syncWatchAppSnapshot(reason: "watch_chat_completed", includeChat: true)
                 return true
             }
 
@@ -3806,6 +3897,8 @@ extension NodeAppModel {
             }
 
             let transport = IOSGatewayChatTransport(gateway: self.operatorSession)
+            let completionDeadline = Date().addingTimeInterval(
+                Double(Self.watchChatCompletionWaitMs) / 1000)
             let response = try await transport.sendMessage(
                 sessionKey: sessionKey,
                 message: text,
@@ -3813,10 +3906,19 @@ extension NodeAppModel {
                 idempotencyKey: event.commandId,
                 attachments: [])
             await self.syncWatchAppSnapshot(reason: "watch_chat_sent", includeChat: true)
-            let completed = await transport.waitForRunCompletion(
+            _ = await transport.waitForRunCompletion(
                 runId: response.runId,
-                timeoutMs: Self.watchChatCompletionWaitMs)
-            guard completed else { return true }
+                timeoutMs: Self.watchChatRunWaitSliceMs)
+            if let replyText = await self.waitForWatchChatReply(
+                transport: transport,
+                sessionKey: sessionKey,
+                runId: response.runId,
+                submittedText: text,
+                submittedAtMs: submittedAtMs,
+                deadline: completionDeadline)
+            {
+                await self.sendWatchChatCompletion(commandId: event.commandId, replyText: replyText)
+            }
             await self.syncWatchAppSnapshot(reason: "watch_chat_completed", includeChat: true)
             return true
         } catch {
@@ -3827,6 +3929,43 @@ extension NodeAppModel {
                     gatewayStableID: self.normalizedWatchChatGatewayStableID(event))
             }
             return false
+        }
+    }
+
+    private func waitForWatchChatReply(
+        transport: IOSGatewayChatTransport,
+        sessionKey: String,
+        runId: String,
+        submittedText: String,
+        submittedAtMs: Int,
+        deadline: Date) async -> String?
+    {
+        repeat {
+            if let payload = try? await transport.requestHistory(sessionKey: sessionKey),
+               let replyText = Self.watchChatReplyText(
+                   from: payload.messages ?? [],
+                   runId: runId,
+                   submittedText: submittedText,
+                   submittedAtMs: submittedAtMs)
+            {
+                return replyText
+            }
+            guard Date() < deadline else { return nil }
+            try? await Task.sleep(for: .seconds(1))
+        } while !Task.isCancelled
+        return nil
+    }
+
+    private func sendWatchChatCompletion(commandId: String, replyText: String) async {
+        do {
+            _ = try await self.watchMessagingService.sendChatCompletion(
+                OpenClawWatchChatCompletionMessage(
+                    commandId: commandId,
+                    replyText: replyText,
+                    sentAtMs: Int(Date().timeIntervalSince1970 * 1000)))
+        } catch {
+            GatewayDiagnostics.log(
+                "watch chat completion failed commandId=\(commandId) error=\(error.localizedDescription)")
         }
     }
 
@@ -5199,6 +5338,19 @@ extension NodeAppModel {
 
     nonisolated static func _test_makeWatchChatItems(from raw: [OpenClawKit.AnyCodable]) -> [OpenClawWatchChatItem] {
         self.makeWatchChatItems(from: raw)
+    }
+
+    nonisolated static func _test_watchChatReplyText(
+        from raw: [OpenClawKit.AnyCodable],
+        runId: String,
+        submittedText: String,
+        submittedAtMs: Int) -> String?
+    {
+        self.watchChatReplyText(
+            from: raw,
+            runId: runId,
+            submittedText: submittedText,
+            submittedAtMs: submittedAtMs)
     }
 
     func _test_isGatewayConnected() -> Bool {

--- a/apps/ios/Sources/Services/NodeServiceProtocols.swift
+++ b/apps/ios/Sources/Services/NodeServiceProtocols.swift
@@ -145,6 +145,8 @@ protocol WatchMessagingServicing: AnyObject, Sendable {
         _ message: OpenClawWatchExecApprovalSnapshotMessage) async throws -> WatchNotificationSendResult
     func syncAppSnapshot(
         _ message: OpenClawWatchAppSnapshotMessage) async throws -> WatchNotificationSendResult
+    func sendChatCompletion(
+        _ message: OpenClawWatchChatCompletionMessage) async throws -> WatchNotificationSendResult
 }
 
 extension CameraController: CameraServicing {}

--- a/apps/ios/Sources/Services/WatchMessagingPayloadCodec.swift
+++ b/apps/ios/Sources/Services/WatchMessagingPayloadCodec.swift
@@ -2,6 +2,8 @@ import Foundation
 import OpenClawKit
 
 enum WatchMessagingPayloadCodec {
+    static let completedChatReplyTextLimit = 4000
+
     static func nowMs() -> Int {
         Int(Date().timeIntervalSince1970 * 1000)
     }
@@ -198,6 +200,22 @@ enum WatchMessagingPayloadCodec {
             payload["snapshotId"] = snapshotId
         }
         return payload
+    }
+
+    static func encodeChatCompletionPayload(
+        _ message: OpenClawWatchChatCompletionMessage) -> [String: Any]
+    {
+        [
+            "type": message.type.rawValue,
+            "commandId": message.commandId,
+            "replyText": self.truncatedCompletedChatReplyText(message.replyText),
+            "sentAtMs": message.sentAtMs ?? self.nowMs(),
+        ]
+    }
+
+    private static func truncatedCompletedChatReplyText(_ text: String) -> String {
+        guard text.count > self.completedChatReplyTextLimit else { return text }
+        return "\(text.prefix(self.completedChatReplyTextLimit - 3))..."
     }
 
     static func parseQuickReplyPayload(

--- a/apps/ios/Sources/Services/WatchMessagingService.swift
+++ b/apps/ios/Sources/Services/WatchMessagingService.swift
@@ -158,6 +158,13 @@ final class WatchMessagingService: @preconcurrency WatchMessagingServicing {
             WatchMessagingPayloadCodec.encodeAppSnapshotPayload(message))
     }
 
+    func sendChatCompletion(
+        _ message: OpenClawWatchChatCompletionMessage) async throws -> WatchNotificationSendResult
+    {
+        try await self.transport.sendPayload(
+            WatchMessagingPayloadCodec.encodeChatCompletionPayload(message))
+    }
+
     private func emitStatusIfChanged(_ snapshot: WatchMessagingStatus) {
         guard snapshot != self.lastEmittedStatus else {
             return

--- a/apps/ios/Tests/Logic/WatchVoiceTurnTrackerTests.swift
+++ b/apps/ios/Tests/Logic/WatchVoiceTurnTrackerTests.swift
@@ -1,0 +1,30 @@
+import Testing
+
+struct WatchVoiceTurnTrackerTests {
+    @Test func `waits for matching completed voice command`() {
+        var tracker = WatchVoiceTurnTracker()
+        tracker.begin(commandId: "voice-command")
+
+        #expect(tracker.takeReply(completedCommandId: "other-command", text: "Other reply") == nil)
+        #expect(tracker.isAwaitingReply)
+        #expect(tracker.takeReply(completedCommandId: "voice-command", text: "New reply") == "New reply")
+        #expect(!tracker.isAwaitingReply)
+    }
+
+    @Test func `ignores empty assistant messages until readable reply arrives`() {
+        var tracker = WatchVoiceTurnTracker()
+        tracker.begin(commandId: "voice-command")
+
+        #expect(tracker.takeReply(completedCommandId: "voice-command", text: "  \n") == nil)
+        #expect(tracker.isAwaitingReply)
+        #expect(tracker.takeReply(completedCommandId: "voice-command", text: "  Ready.  ") == "Ready.")
+    }
+
+    @Test func `canceled turn does not speak later assistant message`() {
+        var tracker = WatchVoiceTurnTracker()
+        tracker.begin(commandId: "voice-command")
+        tracker.cancel()
+
+        #expect(tracker.takeReply(completedCommandId: "voice-command", text: "Later reply") == nil)
+    }
+}

--- a/apps/ios/Tests/NodeAppModelInvokeTests.swift
+++ b/apps/ios/Tests/NodeAppModelInvokeTests.swift
@@ -38,7 +38,9 @@ private func makeWatchChatRawMessage(
     role: String,
     text: String?,
     type: String = "text",
-    timestamp: Double) throws -> AnyCodable
+    timestamp: Double,
+    idempotencyKey: String? = nil,
+    stopReason: String? = nil) throws -> AnyCodable
 {
     let message = OpenClawChatMessage(
         role: role,
@@ -50,8 +52,30 @@ private func makeWatchChatRawMessage(
                 fileName: nil,
                 content: nil),
         ],
-        timestamp: timestamp)
+        timestamp: timestamp,
+        idempotencyKey: idempotencyKey,
+        stopReason: stopReason ?? (role == "assistant" ? "stop" : nil))
     let data = try JSONEncoder().encode(message)
+    return try JSONDecoder().decode(AnyCodable.self, from: data)
+}
+
+private func makeProjectedWatchChatRawMessage(
+    role: String,
+    text: String,
+    timestamp: Double,
+    serverId: String,
+    isMessageToolMirror: Bool = false) throws -> AnyCodable
+{
+    var object: [String: Any] = [
+        "role": role,
+        "content": [["type": "text", "text": text]],
+        "timestamp": timestamp,
+        "__openclaw": ["id": serverId],
+    ]
+    if isMessageToolMirror {
+        object["openclawMessageToolMirror"] = ["toolName": "message"]
+    }
+    let data = try JSONSerialization.data(withJSONObject: object)
     return try JSONDecoder().decode(AnyCodable.self, from: data)
 }
 
@@ -82,6 +106,7 @@ private final class MockWatchMessagingService: @preconcurrency WatchMessagingSer
     var lastSentExecApprovalExpired: OpenClawWatchExecApprovalExpiredMessage?
     var lastSentExecApprovalSnapshot: OpenClawWatchExecApprovalSnapshotMessage?
     var lastSentAppSnapshot: OpenClawWatchAppSnapshotMessage?
+    var lastSentChatCompletion: OpenClawWatchChatCompletionMessage?
     private var statusHandler: (@Sendable (WatchMessagingStatus) -> Void)?
     private var replyHandler: (@Sendable (WatchQuickReplyEvent) -> Void)?
     private var execApprovalResolveHandler: (@Sendable (WatchExecApprovalResolveEvent) -> Void)?
@@ -171,6 +196,16 @@ private final class MockWatchMessagingService: @preconcurrency WatchMessagingSer
         _ message: OpenClawWatchAppSnapshotMessage) async throws -> WatchNotificationSendResult
     {
         self.lastSentAppSnapshot = message
+        if let sendError {
+            throw sendError
+        }
+        return self.nextSendResult
+    }
+
+    func sendChatCompletion(
+        _ message: OpenClawWatchChatCompletionMessage) async throws -> WatchNotificationSendResult
+    {
+        self.lastSentChatCompletion = message
         if let sendError {
             throw sendError
         }
@@ -721,9 +756,11 @@ private final class MockBootstrapNotificationCenter: NotificationCentering, @unc
                 sentAtMs: 126,
                 transport: "sendMessage"))
         for _ in 0..<20 {
-            if watchService.lastSentAppSnapshot?.chatItems?.contains(where: { item in
-                item.role == "user" && item.text.contains("Watch says hello")
-            }) == true {
+            if watchService.lastSentChatCompletion?.commandId == "watch-send-chat",
+               watchService.lastSentAppSnapshot?.chatItems?.contains(where: { item in
+                   item.role == "user" && item.text.contains("Watch says hello")
+               }) == true
+            {
                 break
             }
             try? await Task.sleep(nanoseconds: 50_000_000)
@@ -732,6 +769,8 @@ private final class MockBootstrapNotificationCenter: NotificationCentering, @unc
         #expect(watchService.lastSentAppSnapshot?.chatItems?.contains { item in
             item.role == "user" && item.text.contains("Watch says hello")
         } == true)
+        #expect(watchService.lastSentChatCompletion?.commandId == "watch-send-chat")
+        #expect(watchService.lastSentChatCompletion?.replyText.contains("Watch says hello") == true)
     }
 
     @Test func watchChatPreviewKeepsOlderReadableMessagesAfterInternalEvents() throws {
@@ -753,6 +792,179 @@ private final class MockBootstrapNotificationCenter: NotificationCentering, @unc
         let items = NodeAppModel._test_makeWatchChatItems(from: rawMessages)
 
         #expect(items.map(\.text) == ["Still worth reading"])
+    }
+
+    @Test func watchChatPreviewReadsResponsesOutputText() throws {
+        let rawMessages = try [
+            makeWatchChatRawMessage(
+                role: "assistant",
+                text: "Responses reply",
+                type: "output_text",
+                timestamp: 1000),
+        ]
+
+        let items = NodeAppModel._test_makeWatchChatItems(from: rawMessages)
+
+        #expect(items.map(\.text) == ["Responses reply"])
+    }
+
+    @Test func watchVoiceReplyMatchesDirectRunInsteadOfNewestAssistant() throws {
+        let rawMessages = try [
+            makeWatchChatRawMessage(
+                role: "assistant",
+                text: "Matching reply",
+                timestamp: 2000,
+                idempotencyKey: "watch-run"),
+            makeWatchChatRawMessage(
+                role: "assistant",
+                text: "Unrelated newer reply",
+                timestamp: 3000,
+                idempotencyKey: "other-run"),
+        ]
+
+        let reply = NodeAppModel._test_watchChatReplyText(
+            from: rawMessages,
+            runId: "watch-run",
+            submittedText: "Question",
+            submittedAtMs: 1000)
+
+        #expect(reply == "Matching reply")
+    }
+
+    @Test func watchVoiceReplyAnchorsQueuedRunAfterPersistedUserTurn() throws {
+        let rawMessages = try [
+            makeWatchChatRawMessage(role: "assistant", text: "Active reply", timestamp: 2000),
+            makeWatchChatRawMessage(
+                role: "user",
+                text: "Watch question",
+                timestamp: 3000,
+                idempotencyKey: "watch-run:user"),
+            makeWatchChatRawMessage(
+                role: "assistant",
+                text: "Still working",
+                timestamp: 3500,
+                stopReason: "toolUse"),
+            makeWatchChatRawMessage(role: "assistant", text: "Queued reply", timestamp: 4000),
+        ]
+
+        let reply = NodeAppModel._test_watchChatReplyText(
+            from: rawMessages,
+            runId: "watch-run",
+            submittedText: "Watch question",
+            submittedAtMs: 2500)
+
+        #expect(reply == "Queued reply")
+    }
+
+    @Test func watchVoiceReplyFindsCollectedQueuedTurn() throws {
+        let rawMessages = try [
+            makeWatchChatRawMessage(role: "assistant", text: "Active reply", timestamp: 2000),
+            makeWatchChatRawMessage(
+                role: "user",
+                text: "[Queued messages]\nWatch question\nAnother request",
+                timestamp: 3100,
+                idempotencyKey: "followup-collect:session:hash"),
+            makeWatchChatRawMessage(role: "assistant", text: "Collected reply", timestamp: 4000),
+        ]
+
+        let reply = NodeAppModel._test_watchChatReplyText(
+            from: rawMessages,
+            runId: "watch-run",
+            submittedText: "Watch question",
+            submittedAtMs: 2500)
+
+        #expect(reply == "Collected reply")
+    }
+
+    @Test func watchVoiceReplyAcceptsTerminalMessageToolMirror() throws {
+        let rawMessages = try [
+            makeWatchChatRawMessage(
+                role: "user",
+                text: "Send the update",
+                timestamp: 3000,
+                idempotencyKey: "watch-run:user"),
+            makeProjectedWatchChatRawMessage(
+                role: "assistant",
+                text: "Update sent",
+                timestamp: 4000,
+                serverId: "tool-result-1",
+                isMessageToolMirror: true),
+        ]
+
+        let reply = NodeAppModel._test_watchChatReplyText(
+            from: rawMessages,
+            runId: "watch-run",
+            submittedText: "Send the update",
+            submittedAtMs: 2500)
+
+        #expect(reply == "Update sent")
+    }
+
+    @Test func watchChatCompletionBoundsReplyText() {
+        let message = OpenClawWatchChatCompletionMessage(
+            commandId: "watch-voice",
+            replyText: String(repeating: "x", count: 5000))
+
+        let payload = WatchMessagingPayloadCodec.encodeChatCompletionPayload(message)
+        let reply = payload["replyText"] as? String
+
+        #expect(reply?.count == WatchMessagingPayloadCodec.completedChatReplyTextLimit)
+        #expect(reply?.hasSuffix("...") == true)
+    }
+
+    @Test func watchChatPreviewDisambiguatesIdenticalFallbackMessages() throws {
+        let rawMessages = try [
+            makeWatchChatRawMessage(role: "assistant", text: "Same", timestamp: 1000),
+            makeWatchChatRawMessage(role: "assistant", text: "Same", timestamp: 1000),
+        ]
+
+        let items = NodeAppModel._test_makeWatchChatItems(from: rawMessages)
+
+        #expect(items.count == 2)
+        #expect(items[0].id != items[1].id)
+    }
+
+    @Test func watchChatPreviewDisambiguatesProjectedRowsSharingServerID() throws {
+        let rawMessages = try [
+            makeProjectedWatchChatRawMessage(
+                role: "toolResult",
+                text: "Update sent",
+                timestamp: 1000,
+                serverId: "shared-result"),
+            makeProjectedWatchChatRawMessage(
+                role: "assistant",
+                text: "Update sent",
+                timestamp: 1000,
+                serverId: "shared-result",
+                isMessageToolMirror: true),
+        ]
+
+        let items = NodeAppModel._test_makeWatchChatItems(from: rawMessages)
+
+        #expect(items.count == 2)
+        #expect(items[0].id != items[1].id)
+    }
+
+    @Test func watchChatPreviewKeepsMessageIDsStableWhenWindowRolls() throws {
+        var rawMessages: [AnyCodable] = []
+        for index in 0..<5 {
+            try rawMessages.append(
+                makeWatchChatRawMessage(
+                    role: "assistant",
+                    text: "Reply \(index)",
+                    timestamp: Double(1000 + index)))
+        }
+
+        let before = NodeAppModel._test_makeWatchChatItems(from: rawMessages)
+        try rawMessages.append(
+            makeWatchChatRawMessage(
+                role: "user",
+                text: "Next question",
+                timestamp: 2000))
+        let after = NodeAppModel._test_makeWatchChatItems(from: rawMessages)
+
+        #expect(before.last?.id == after.dropLast().last?.id)
+        #expect(after.last?.role == "user")
     }
 
     @Test @MainActor func watchAppCommandQueuesChatMessageWhenOperatorOffline() async {

--- a/apps/ios/WatchApp/Sources/OpenClawWatchApp.swift
+++ b/apps/ios/WatchApp/Sources/OpenClawWatchApp.swift
@@ -92,14 +92,14 @@ struct OpenClawWatchApp: App {
         }
     }
 
-    private func sendChatMessage(_ text: String) {
-        guard let receiver else { return }
+    private func sendChatMessage(_ text: String) -> String? {
+        guard let receiver else { return nil }
         let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard !trimmed.isEmpty else { return }
+        guard !trimmed.isEmpty else { return nil }
         guard self.inboxStore.hasGatewayTaggedAppSnapshot else {
             self.inboxStore.markAppCommandBlocked(.sendChat, reason: "refreshing iPhone state")
             self.refreshAppSnapshot()
-            return
+            return nil
         }
         let message = self.inboxStore.makeAppCommand(.sendChat, text: trimmed)
         self.inboxStore.markAppCommandSending(.sendChat)
@@ -109,6 +109,7 @@ struct OpenClawWatchApp: App {
             try? await Task.sleep(nanoseconds: 900_000_000)
             self.refreshAppSnapshot()
         }
+        return message.commandId
     }
 
     private func refreshExecApprovalReview(force: Bool = false) {

--- a/apps/ios/WatchApp/Sources/WatchConnectivityReceiver.swift
+++ b/apps/ios/WatchApp/Sources/WatchConnectivityReceiver.swift
@@ -439,6 +439,25 @@ final class WatchConnectivityReceiver: NSObject, @unchecked Sendable {
             snapshotId: snapshotId)
     }
 
+    private static func parseChatCompletionPayload(
+        _ payload: [String: Any]) -> WatchChatCompletionMessage?
+    {
+        guard (payload["type"] as? String) == WatchPayloadType.chatCompletion.rawValue else {
+            return nil
+        }
+        let commandId = (payload["commandId"] as? String)?
+            .trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        let replyText = (payload["replyText"] as? String)?
+            .trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        guard !commandId.isEmpty, !replyText.isEmpty else { return nil }
+        let sentAtMs = (payload["sentAtMs"] as? Int)
+            ?? (payload["sentAtMs"] as? NSNumber)?.intValue
+        return WatchChatCompletionMessage(
+            commandId: commandId,
+            replyText: replyText,
+            sentAtMs: sentAtMs)
+    }
+
     private static func parseChatItem(_ item: Any) -> WatchChatItem? {
         guard let dict = item as? [String: Any] else { return nil }
         guard let id = (dict["id"] as? String)?.trimmingCharacters(in: .whitespacesAndNewlines),
@@ -607,6 +626,12 @@ extension WatchConnectivityReceiver: WCSessionDelegate {
         if let snapshot = Self.parseAppSnapshotPayload(payload) {
             Task { @MainActor in
                 self.store.consume(appSnapshot: snapshot)
+            }
+            return
+        }
+        if let completion = Self.parseChatCompletionPayload(payload) {
+            Task { @MainActor in
+                self.store.consume(chatCompletion: completion)
             }
         }
     }

--- a/apps/ios/WatchApp/Sources/WatchInboxStore.swift
+++ b/apps/ios/WatchApp/Sources/WatchInboxStore.swift
@@ -9,6 +9,7 @@ enum WatchPayloadType: String, Codable, Equatable {
     case appSnapshot = "watch.app.snapshot"
     case appSnapshotRequest = "watch.app.snapshotRequest"
     case appCommand = "watch.app.command"
+    case chatCompletion = "watch.chat.completion"
     case execApprovalPrompt = "watch.execApproval.prompt"
     case execApprovalResolve = "watch.execApproval.resolve"
     case execApprovalResolved = "watch.execApproval.resolved"
@@ -103,6 +104,12 @@ struct WatchAppSnapshotMessage: Codable, Equatable {
     var chatStatusText: String?
     var sentAtMs: Int?
     var snapshotId: String?
+}
+
+struct WatchChatCompletionMessage: Codable, Equatable {
+    var commandId: String
+    var replyText: String
+    var sentAtMs: Int?
 }
 
 struct WatchChatItem: Codable, Equatable, Identifiable {
@@ -222,6 +229,7 @@ struct WatchExecApprovalRecord: Codable, Equatable, Identifiable {
     var appSnapshotUpdatedAt: Date?
     var appSnapshotStatusText: String?
     var appCommandStatusText: String?
+    var chatCompletion: WatchChatCompletionMessage?
     var greetingTextOverride: String?
     var isExecApprovalReviewLoading = false
     var execApprovalReviewStatusText: String?
@@ -443,6 +451,10 @@ struct WatchExecApprovalRecord: Codable, Equatable, Identifiable {
         self.appSnapshotUpdatedAt = Date()
         self.appSnapshotStatusText = nil
         self.persistState()
+    }
+
+    func consume(chatCompletion message: WatchChatCompletionMessage) {
+        self.chatCompletion = message
     }
 
     func markAppSnapshotRequestStarted() {

--- a/apps/ios/WatchApp/Sources/WatchInboxView.swift
+++ b/apps/ios/WatchApp/Sources/WatchInboxView.swift
@@ -8,7 +8,7 @@ struct WatchInboxView: View {
     var onRefreshExecApprovalReview: (() -> Void)?
     var onRefreshAppSnapshot: (() -> Void)?
     var onAppCommand: ((WatchAppCommand) -> Void)?
-    var onSendChatMessage: ((String) -> Void)?
+    var onSendChatMessage: ((String) -> String?)?
 
     var body: some View {
         NavigationStack {
@@ -32,7 +32,7 @@ private struct WatchControlSurfaceView: View {
     var onRefreshExecApprovalReview: (() -> Void)?
     var onRefreshAppSnapshot: (() -> Void)?
     var onAppCommand: ((WatchAppCommand) -> Void)?
-    var onSendChatMessage: ((String) -> Void)?
+    var onSendChatMessage: ((String) -> String?)?
     @State private var selectedFace = 0
 
     var body: some View {
@@ -300,6 +300,8 @@ private struct WatchControlSurfaceView: View {
             sendStatusText: self.chatSendStatusText,
             avatarImageSource: self.avatarImageSource,
             avatarText: self.avatarText,
+            completedChatCommandId: self.store.chatCompletion?.commandId,
+            completedChatReplyText: self.store.chatCompletion?.replyText,
             onRefresh: self.onRefreshAppSnapshot,
             onSendMessage: self.onSendChatMessage)
     }
@@ -1006,8 +1008,13 @@ private struct WatchChatTimelineView: View {
     let sendStatusText: String?
     var avatarImageSource: String?
     var avatarText: String?
+    var completedChatCommandId: String?
+    var completedChatReplyText: String?
     var onRefresh: (() -> Void)?
-    var onSendMessage: ((String) -> Void)?
+    var onSendMessage: ((String) -> String?)?
+    @State private var voiceTurnTracker = WatchVoiceTurnTracker()
+    @State private var speechPlayback = WatchSpeechPlayback()
+    @State private var voiceReplyTimeout: Task<Void, Never>?
 
     var body: some View {
         VStack(spacing: 7) {
@@ -1028,6 +1035,10 @@ private struct WatchChatTimelineView: View {
                         WatchTinyStatus(text: sendStatusText)
                     }
 
+                    if let voiceStatusText = self.voiceStatusText {
+                        WatchTinyStatus(text: voiceStatusText)
+                    }
+
                     WatchSecondaryButton(title: "Refresh") {
                         self.onRefresh?()
                     }
@@ -1041,19 +1052,80 @@ private struct WatchChatTimelineView: View {
 
             WatchChatComposer(
                 onSendMessage: { text in
-                    self.sendMessage(text)
+                    _ = self.sendMessage(text)
+                },
+                onStartVoiceTurn: {
+                    self.startVoiceTurn()
+                },
+                isAwaitingVoiceReply: self.voiceTurnTracker.isAwaitingReply,
+                onCancelVoiceTurn: {
+                    self.cancelVoiceTurn()
+                },
+                isSpeaking: self.speechPlayback.isSpeaking,
+                onStopSpeaking: {
+                    self.speechPlayback.stop()
                 })
                 .padding(.horizontal, 7)
                 .padding(.bottom, 5)
         }
         .background(WatchClawStyle.background.ignoresSafeArea())
         .navigationTitle("Chat")
+        .onChange(of: self.completedChatCommandId) { _, commandId in
+            self.handleCompletedVoiceTurn(commandId: commandId)
+        }
+        .onDisappear {
+            self.cancelVoiceTurn()
+            self.speechPlayback.stop()
+        }
     }
 
-    private func sendMessage(_ text: String) {
+    private func sendMessage(_ text: String) -> String? {
         let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard !trimmed.isEmpty else { return }
-        self.onSendMessage?(trimmed)
+        guard !trimmed.isEmpty else { return nil }
+        return self.onSendMessage?(trimmed)
+    }
+
+    private var voiceStatusText: String? {
+        if self.speechPlayback.isSpeaking {
+            return "Speaking reply…"
+        }
+        if self.voiceTurnTracker.isAwaitingReply {
+            return "Waiting for spoken reply…"
+        }
+        return nil
+    }
+
+    private func startVoiceTurn() {
+        WatchNativeTextInput.present(suggestions: []) { text in
+            guard let commandId = self.sendMessage(text) else { return }
+            self.voiceTurnTracker.begin(commandId: commandId)
+            self.scheduleVoiceReplyTimeout()
+        }
+    }
+
+    private func handleCompletedVoiceTurn(commandId: String?) {
+        guard let reply = voiceTurnTracker.takeReply(
+            completedCommandId: commandId,
+            text: completedChatReplyText)
+        else {
+            return
+        }
+        self.voiceReplyTimeout?.cancel()
+        self.speechPlayback.speak(reply)
+    }
+
+    private func cancelVoiceTurn() {
+        self.voiceReplyTimeout?.cancel()
+        self.voiceTurnTracker.cancel()
+    }
+
+    private func scheduleVoiceReplyTimeout() {
+        self.voiceReplyTimeout?.cancel()
+        self.voiceReplyTimeout = Task { @MainActor in
+            try? await Task.sleep(for: .seconds(90))
+            guard !Task.isCancelled else { return }
+            self.voiceTurnTracker.cancel()
+        }
     }
 }
 
@@ -1103,40 +1175,84 @@ private struct WatchMiniUserDot: View {
 
 private struct WatchChatComposer: View {
     let onSendMessage: (String) -> Void
+    let onStartVoiceTurn: () -> Void
+    let isAwaitingVoiceReply: Bool
+    let onCancelVoiceTurn: () -> Void
+    let isSpeaking: Bool
+    let onStopSpeaking: () -> Void
 
     var body: some View {
-        Button {
-            WatchNativeTextInput.present(
-                suggestions: [],
-                onSubmit: self.onSendMessage)
-        } label: {
-            HStack(spacing: 6) {
-                Text("Message OpenClaw")
-                    .font(WatchClawType.body(size: 12, weight: .semibold))
-                    .foregroundStyle(.secondary)
-                    .lineLimit(1)
-                Spacer(minLength: 0)
-                WatchVoiceGlyph()
-                    .frame(width: 18, height: 18)
-                    .padding(5)
-                    .background {
-                        Circle()
-                            .fill(WatchClawStyle.hotGradient)
-                    }
+        HStack(spacing: 6) {
+            Button {
+                WatchNativeTextInput.present(
+                    suggestions: [],
+                    onSubmit: self.onSendMessage)
+            } label: {
+                HStack(spacing: 5) {
+                    Text("Message")
+                        .font(WatchClawType.body(size: 12, weight: .semibold))
+                        .foregroundStyle(.secondary)
+                        .lineLimit(1)
+                    Spacer(minLength: 0)
+                    Image(systemName: "text.bubble")
+                        .font(WatchClawType.symbol(size: 12, weight: .semibold))
+                        .foregroundStyle(.secondary)
+                }
+                .padding(.horizontal, 11)
+                .padding(.vertical, 10)
+                .background {
+                    Capsule(style: .continuous)
+                        .fill(Color.white.opacity(0.09))
+                        .overlay {
+                            Capsule(style: .continuous)
+                                .strokeBorder(Color.white.opacity(0.16), lineWidth: 1)
+                        }
+                }
             }
-            .padding(.leading, 12)
-            .padding(.trailing, 5)
-            .padding(.vertical, 5)
-            .background {
-                Capsule(style: .continuous)
-                    .fill(Color.white.opacity(0.09))
-                    .overlay {
-                        Capsule(style: .continuous)
-                            .strokeBorder(Color.white.opacity(0.16), lineWidth: 1)
+            .buttonStyle(.plain)
+            .disabled(self.isAwaitingVoiceReply)
+
+            Button {
+                if self.isSpeaking {
+                    self.onStopSpeaking()
+                } else if self.isAwaitingVoiceReply {
+                    self.onCancelVoiceTurn()
+                } else {
+                    self.onStartVoiceTurn()
+                }
+            } label: {
+                Group {
+                    if self.isSpeaking {
+                        Image(systemName: "speaker.slash.fill")
+                            .font(WatchClawType.symbol(size: 13, weight: .bold))
+                    } else if self.isAwaitingVoiceReply {
+                        Image(systemName: "xmark")
+                            .font(WatchClawType.symbol(size: 13, weight: .bold))
+                    } else {
+                        WatchVoiceGlyph()
                     }
+                }
+                .foregroundStyle(.white)
+                .frame(width: 20, height: 20)
+                .padding(8)
+                .background {
+                    Circle()
+                        .fill(WatchClawStyle.hotGradient)
+                }
             }
+            .buttonStyle(.plain)
+            .accessibilityLabel(self.voiceButtonAccessibilityLabel)
         }
-        .buttonStyle(.plain)
+    }
+
+    private var voiceButtonAccessibilityLabel: String {
+        if self.isSpeaking {
+            return "Stop speaking"
+        }
+        if self.isAwaitingVoiceReply {
+            return "Cancel voice turn"
+        }
+        return "Start voice turn"
     }
 }
 

--- a/apps/ios/WatchApp/Sources/WatchInboxView.swift
+++ b/apps/ios/WatchApp/Sources/WatchInboxView.swift
@@ -1189,7 +1189,7 @@ private struct WatchChatComposer: View {
                     onSubmit: self.onSendMessage)
             } label: {
                 HStack(spacing: 5) {
-                    Text("Message")
+                    Text("Message OpenClaw")
                         .font(WatchClawType.body(size: 12, weight: .semibold))
                         .foregroundStyle(.secondary)
                         .lineLimit(1)

--- a/apps/ios/WatchApp/Sources/WatchSpeechPlayback.swift
+++ b/apps/ios/WatchApp/Sources/WatchSpeechPlayback.swift
@@ -1,0 +1,46 @@
+import AVFAudio
+import Observation
+
+@MainActor
+@Observable
+final class WatchSpeechPlayback: NSObject {
+    private let synthesizer = AVSpeechSynthesizer()
+    private(set) var isSpeaking = false
+
+    override init() {
+        super.init()
+        self.synthesizer.delegate = self
+    }
+
+    func speak(_ text: String) {
+        self.stop()
+        self.isSpeaking = true
+        self.synthesizer.speak(AVSpeechUtterance(string: text))
+    }
+
+    func stop() {
+        guard self.isSpeaking || self.synthesizer.isSpeaking else { return }
+        self.synthesizer.stopSpeaking(at: .immediate)
+        self.isSpeaking = false
+    }
+}
+
+extension WatchSpeechPlayback: AVSpeechSynthesizerDelegate {
+    nonisolated func speechSynthesizer(
+        _: AVSpeechSynthesizer,
+        didFinish _: AVSpeechUtterance)
+    {
+        Task { @MainActor in
+            self.isSpeaking = false
+        }
+    }
+
+    nonisolated func speechSynthesizer(
+        _: AVSpeechSynthesizer,
+        didCancel _: AVSpeechUtterance)
+    {
+        Task { @MainActor in
+            self.isSpeaking = false
+        }
+    }
+}

--- a/apps/ios/WatchApp/Sources/WatchVoiceTurnTracker.swift
+++ b/apps/ios/WatchApp/Sources/WatchVoiceTurnTracker.swift
@@ -1,0 +1,31 @@
+import Foundation
+
+struct WatchVoiceTurnTracker: Equatable {
+    private(set) var commandId: String?
+    private(set) var isAwaitingReply = false
+
+    mutating func begin(commandId: String) {
+        self.commandId = commandId
+        self.isAwaitingReply = true
+    }
+
+    mutating func takeReply(completedCommandId: String?, text: String?) -> String? {
+        guard self.isAwaitingReply,
+              let completedCommandId,
+              completedCommandId == commandId,
+              let text = text?.trimmingCharacters(in: .whitespacesAndNewlines),
+              !text.isEmpty
+        else {
+            return nil
+        }
+
+        self.commandId = nil
+        self.isAwaitingReply = false
+        return text
+    }
+
+    mutating func cancel() {
+        self.commandId = nil
+        self.isAwaitingReply = false
+    }
+}

--- a/apps/ios/project.yml
+++ b/apps/ios/project.yml
@@ -317,6 +317,7 @@ targets:
         buildPhase: resources
     dependencies:
       - sdk: AppIntents.framework
+      - sdk: AVFAudio.framework
       - sdk: WatchConnectivity.framework
       - sdk: UserNotifications.framework
     configFiles:
@@ -405,6 +406,8 @@ targets:
       Release: Signing.xcconfig
     sources:
       - path: Tests/Logic
+      - path: WatchApp/Sources/WatchVoiceTurnTracker.swift
+        group: WatchApp/Sources
     dependencies:
       - package: OpenClawKit
     settings:

--- a/apps/shared/OpenClawKit/Sources/OpenClawKit/WatchCommands.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawKit/WatchCommands.swift
@@ -11,6 +11,7 @@ public enum OpenClawWatchPayloadType: String, Codable, Sendable, Equatable {
     case appSnapshot = "watch.app.snapshot"
     case appSnapshotRequest = "watch.app.snapshotRequest"
     case appCommand = "watch.app.command"
+    case chatCompletion = "watch.chat.completion"
     case execApprovalPrompt = "watch.execApproval.prompt"
     case execApprovalResolve = "watch.execApproval.resolve"
     case execApprovalResolved = "watch.execApproval.resolved"
@@ -211,6 +212,20 @@ public struct OpenClawWatchChatItem: Codable, Sendable, Equatable, Identifiable 
         self.role = role
         self.text = text
         self.timestampMs = timestampMs
+    }
+}
+
+public struct OpenClawWatchChatCompletionMessage: Codable, Sendable, Equatable {
+    public var type: OpenClawWatchPayloadType
+    public var commandId: String
+    public var replyText: String
+    public var sentAtMs: Int?
+
+    public init(commandId: String, replyText: String, sentAtMs: Int? = nil) {
+        self.type = .chatCompletion
+        self.commandId = commandId
+        self.replyText = replyText
+        self.sentAtMs = sentAtMs
     }
 }
 


### PR DESCRIPTION
Closes #100224

## What Problem This Solves

Apple Watch chat accepts dictated text, but replies remain visual-only. Users cannot complete a hands-free voice turn from the Watch.

## Why This Change Was Made

Adds an explicit voice-turn action that uses native Watch dictation, the existing WatchConnectivity chat path, and native speech playback for the matching completed assistant reply. The existing Message action remains silent; intermediate tool progress is not spoken, and users can cancel while waiting or stop playback.

## User Impact

Users can tap the microphone on Apple Watch, dictate a message, and hear OpenClaw's final reply spoken back. Delivery survives temporary Watch reachability changes through the existing durable WatchConnectivity path.

## Evidence

- `xcodebuild test -project apps/ios/OpenClaw.xcodeproj -scheme OpenClaw -destination 'platform=iOS Simulator,id=504AD0F4-BA3E-4012-B7CB-C45A1F613984' -only-testing:OpenClawTests/NodeAppModelInvokeTests` — 87 tests passed.
- `xcodebuild test -project apps/ios/OpenClaw.xcodeproj -scheme OpenClawLogicTests -destination 'platform=macOS' -only-testing:OpenClawLogicTests/WatchVoiceTurnTrackerTests` — 3 tests passed.
- `xcodebuild build -project apps/ios/OpenClaw.xcodeproj -scheme OpenClawWatchApp -destination 'platform=watchOS Simulator,id=1173986F-82CA-463A-B461-7C3D569E01A0'` — succeeded.
- Rebased Watch app installed and launched on Apple Watch Series 11 simulator, PID 7735.
- Fresh local autoreview: no accepted/actionable findings.
