### PR TITLE
fix(session): add exponential backoff retry for stale-snapshot conflicts on concurrent session init

### DIFF
--- a/src/auto-reply/reply/session-stale-snapshot-retry.test.ts
+++ b/src/auto-reply/reply/session-stale-snapshot-retry.test.ts
@@ -1,0 +1,141 @@
+/**
+ * Tests for stale-snapshot retry with exponential backoff during concurrent
+ * reply-session initialization (#100173).
+ *
+ * Cross-process session-store conflicts cannot be reproduced in a single
+ * Vitest worker because all same-store writes serialize through the in-process
+ * writer queue. These tests mock commitReplySessionInitialization to return
+ * synthetic stale-snapshot results and verify the retry contract.
+ */
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import type { OpenClawConfig } from "../../config/config.js";
+import { writeSessionStoreForTestAsync } from "../../config/sessions/test-helpers.js";
+import { initSessionState } from "./session.js";
+
+const commitMock = vi.fn();
+
+vi.mock("../../config/sessions/session-accessor.js", async () => {
+  const actual = await vi.importActual("../../config/sessions/session-accessor.js");
+  return {
+    ...(actual as Record<string, unknown>),
+    commitReplySessionInitialization: (
+      ...args: Parameters<typeof commitMock>
+    ): ReturnType<typeof commitMock> => commitMock(...args),
+  };
+});
+
+let suiteRoot: string;
+let suiteCase = 0;
+
+beforeAll(async () => {
+  suiteRoot = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-session-retry-"));
+});
+
+afterAll(async () => {
+  await fs.rm(suiteRoot, { recursive: true, force: true });
+});
+
+async function makeStorePath(prefix: string): Promise<string> {
+  const dir = path.join(suiteRoot, `${prefix}${++suiteCase}`);
+  await fs.mkdir(dir);
+  return path.join(dir, "sessions.json");
+}
+
+async function setupSession(storePath: string, sessionKey: string) {
+  await writeSessionStoreForTestAsync(storePath, {
+    [sessionKey]: {
+      sessionId: "existing-session",
+      updatedAt: Date.now(),
+    },
+  });
+}
+
+describe("initSessionState stale-snapshot retry", () => {
+  beforeEach(() => {
+    commitMock.mockReset();
+  });
+
+  it("retries with backoff and succeeds after transient stale-snapshot conflicts", async () => {
+    const storePath = await makeStorePath("ok-");
+    const sessionKey = "agent:main:telegram:chat:retry-ok";
+    await setupSession(storePath, sessionKey);
+    const cfg = { session: { store: storePath } } as OpenClawConfig;
+
+    let callCount = 0;
+    commitMock.mockImplementation(async () => {
+      callCount += 1;
+      if (callCount <= 2) {
+        return { ok: false as const, reason: "stale-snapshot" as const, revision: "stale" };
+      }
+      return {
+        ok: true as const,
+        previousSessionTranscript: { transcriptFile: null, tokenCount: null, endedAt: null },
+        sessionEntry: {
+          sessionId: "backoff-session",
+          sessionKey,
+          updatedAt: Date.now(),
+          revision: "latest",
+        },
+        sessionStoreView: {},
+      };
+    });
+
+    const result = await initSessionState({
+      ctx: { Body: "retry me", SessionKey: sessionKey },
+      cfg,
+      commandAuthorized: true,
+    });
+
+    // 1 initial + 2 stale retries + 1 success = 4 calls
+    expect(callCount).toBeGreaterThanOrEqual(3);
+    expect(result.sessionKey).toBe(sessionKey);
+    expect(result.sessionEntry.sessionId).toBe("backoff-session");
+  });
+
+  it("throws after exhausting all 4 attempts (1 initial + 3 retries)", async () => {
+    const storePath = await makeStorePath("exhaust-");
+    const sessionKey = "agent:main:telegram:chat:exhaust";
+    await setupSession(storePath, sessionKey);
+    const cfg = { session: { store: storePath } } as OpenClawConfig;
+
+    commitMock.mockImplementation(async () => ({
+      ok: false as const,
+      reason: "stale-snapshot" as const,
+      revision: "stale",
+    }));
+
+    await expect(
+      initSessionState({
+        ctx: { Body: "keep failing", SessionKey: sessionKey },
+        cfg,
+        commandAuthorized: true,
+      }),
+    ).rejects.toThrow(`reply session initialization conflicted for ${sessionKey}`);
+
+    // 1 initial + 3 retries = 4 attempts
+    expect(commitMock).toHaveBeenCalledTimes(4);
+  });
+
+  it("does not retry non-stale-snapshot errors", async () => {
+    const storePath = await makeStorePath("nonretry-");
+    const sessionKey = "agent:main:telegram:chat:nonretry";
+    await setupSession(storePath, sessionKey);
+    const cfg = { session: { store: storePath } } as OpenClawConfig;
+
+    commitMock.mockRejectedValue(new Error("unrelated disk error"));
+
+    await expect(
+      initSessionState({
+        ctx: { Body: "boom", SessionKey: sessionKey },
+        cfg,
+        commandAuthorized: true,
+      }),
+    ).rejects.toThrow("unrelated disk error");
+
+    // Must not retry — only 1 attempt
+    expect(commitMock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/auto-reply/reply/session.ts
+++ b/src/auto-reply/reply/session.ts
@@ -66,6 +66,7 @@ import {
   interruptSessionWorkAdmissions,
   runExclusiveSessionLifecycleMutation,
 } from "../../sessions/session-lifecycle-admission.js";
+import { sleep } from "../../utils.js";
 import {
   normalizeDeliveryChannelRoute,
   normalizeSessionDeliveryFields,
@@ -221,7 +222,8 @@ type InitSessionStateAttemptContext = {
 
 type InitSessionStateAttemptOutcome =
   | { kind: "complete"; result: SessionInitResult }
-  | { kind: "lifecycle-mutation"; sessionId: string; sessionKey: string };
+  | { kind: "lifecycle-mutation"; sessionId: string; sessionKey: string }
+  | { kind: "stale-snapshot"; sessionKey: string };
 
 function resolveSessionConversationBindingContext(
   cfg: OpenClawConfig,
@@ -319,87 +321,114 @@ function resolveInitSessionStateAttemptContext(
   };
 }
 
+/** Max retries for stale-snapshot conflicts during concurrent session init. */
+const STALE_SNAPSHOT_MAX_RETRIES = 3;
+/** Base backoff delay (exponential: 200ms, 400ms, 800ms) between stale-snapshot retries. */
+const STALE_SNAPSHOT_BASE_DELAY_MS = 200;
+
 /** Initializes or reuses the reply session state for one inbound turn. */
 export async function initSessionState(params: InitSessionStateParams): Promise<SessionInitResult> {
-  return await initSessionStateAttempt(params, false);
+  return await initSessionStateAttempt(params);
 }
 
-async function initSessionStateAttempt(
-  params: InitSessionStateParams,
-  staleSnapshotRetried: boolean,
-): Promise<SessionInitResult> {
+async function initSessionStateAttempt(params: InitSessionStateParams): Promise<SessionInitResult> {
   const attemptContext = resolveInitSessionStateAttemptContext(params);
-  // Guarded revision checks only serialize correctly when the snapshot and
-  // commit share the same writer lane.
-  const attempt = await runExclusiveSessionStoreWrite(
-    attemptContext.storePath,
-    async () =>
-      await initSessionStateAttemptLocked(params, attemptContext, staleSnapshotRetried, undefined),
-  );
-  if (attempt.kind === "complete") {
-    return attempt.result;
-  }
+  let lastStaleKey: string | undefined;
 
-  let rollover = attempt;
-  while (true) {
-    const candidate = rollover;
-    const identities = [candidate.sessionKey, candidate.sessionId];
-    let preparedOutcome: InitSessionStateAttemptOutcome | undefined;
-    // Drain foreign owners before the rollover takes the writer lane. Holding
-    // that lane while waiting would deadlock owners that release after a write.
-    const outcome = await runExclusiveSessionLifecycleMutation({
-      scope: attemptContext.storePath,
-      identities,
-      signal: params.signal,
-      prepare: async () => {
-        // A queued rollover may change identity or become obsolete. Recheck
-        // before interrupting, then reacquire any refreshed identity first.
-        const revalidated = await runExclusiveSessionStoreWrite(
-          attemptContext.storePath,
-          async () => await initSessionStateAttemptLocked(params, attemptContext, false, undefined),
-        );
-        if (
-          revalidated.kind === "complete" ||
-          revalidated.sessionKey !== candidate.sessionKey ||
-          revalidated.sessionId !== candidate.sessionId
-        ) {
-          preparedOutcome = revalidated;
-          return;
-        }
-        const drained = await interruptSessionWorkAdmissions({
-          scope: attemptContext.storePath,
-          identities,
-          timeoutMs: SESSION_WORK_ADMISSION_DRAIN_TIMEOUT_MS,
-        });
-        if (!drained) {
-          throw new Error(
-            `timed out draining work before reply session rollover: ${candidate.sessionKey}`,
-          );
-        }
-      },
-      run: async () => {
-        if (preparedOutcome) {
-          return preparedOutcome;
-        }
-        // Interrupted owners can rebind while draining. The locked attempt
-        // must match this exact fenced identity before any rollover side effect.
-        return await runExclusiveSessionStoreWrite(
-          attemptContext.storePath,
-          async () => await initSessionStateAttemptLocked(params, attemptContext, false, candidate),
-        );
-      },
-    });
-    if (outcome.kind === "complete") {
-      return outcome.result;
+  // Retry stale-snapshot conflicts outside the writer lock so each attempt
+  // acquires a fresh writer lane and re-reads the latest snapshot.
+  // Exponential backoff gives concurrent cross-process writers time to finish
+  // before the next attempt re-reads and re-commits.
+  for (let retries = 0; retries <= STALE_SNAPSHOT_MAX_RETRIES; retries++) {
+    const attempt = await runExclusiveSessionStoreWrite(
+      attemptContext.storePath,
+      async () => await initSessionStateAttemptLocked(params, attemptContext, undefined),
+    );
+    if (attempt.kind === "complete") {
+      return attempt.result;
     }
-    rollover = outcome;
+    if (attempt.kind === "stale-snapshot") {
+      lastStaleKey = attempt.sessionKey;
+      if (retries < STALE_SNAPSHOT_MAX_RETRIES) {
+        await sleep(STALE_SNAPSHOT_BASE_DELAY_MS * 2 ** retries);
+        continue;
+      }
+      throw new Error(`reply session initialization conflicted for ${lastStaleKey}`);
+    }
+
+    // lifecycle-mutation handling
+    let rollover = attempt;
+    while (true) {
+      const candidate = rollover;
+      const identities = [candidate.sessionKey, candidate.sessionId];
+      let preparedOutcome: InitSessionStateAttemptOutcome | undefined;
+      // Drain foreign owners before the rollover takes the writer lane. Holding
+      // that lane while waiting would deadlock owners that release after a write.
+      const outcome = await runExclusiveSessionLifecycleMutation({
+        scope: attemptContext.storePath,
+        identities,
+        signal: params.signal,
+        prepare: async () => {
+          // A queued rollover may change identity or become obsolete. Recheck
+          // before interrupting, then reacquire any refreshed identity first.
+          const revalidated = await runExclusiveSessionStoreWrite(
+            attemptContext.storePath,
+            async () => await initSessionStateAttemptLocked(params, attemptContext, undefined),
+          );
+          if (
+            revalidated.kind === "complete" ||
+            (revalidated.kind !== "stale-snapshot" &&
+              (revalidated.sessionKey !== candidate.sessionKey ||
+                revalidated.sessionId !== candidate.sessionId))
+          ) {
+            preparedOutcome = revalidated;
+            return;
+          }
+          // Stale snapshot during lifecycle revalidation is unexpected — a
+          // writer that held the lock just committed. Treat it as terminal.
+          if (revalidated.kind === "stale-snapshot") {
+            throw new Error(
+              `reply session initialization conflicted for ${revalidated.sessionKey}`,
+            );
+          }
+          const drained = await interruptSessionWorkAdmissions({
+            scope: attemptContext.storePath,
+            identities,
+            timeoutMs: SESSION_WORK_ADMISSION_DRAIN_TIMEOUT_MS,
+          });
+          if (!drained) {
+            throw new Error(
+              `timed out draining work before reply session rollover: ${candidate.sessionKey}`,
+            );
+          }
+        },
+        run: async () => {
+          if (preparedOutcome) {
+            return preparedOutcome;
+          }
+          // Interrupted owners can rebind while draining. The locked attempt
+          // must match this exact fenced identity before any rollover side effect.
+          return await runExclusiveSessionStoreWrite(
+            attemptContext.storePath,
+            async () => await initSessionStateAttemptLocked(params, attemptContext, candidate),
+          );
+        },
+      });
+      if (outcome.kind === "complete") {
+        return outcome.result;
+      }
+      if (outcome.kind === "stale-snapshot") {
+        throw new Error(`reply session initialization conflicted for ${outcome.sessionKey}`);
+      }
+      rollover = outcome;
+    }
   }
+  throw new Error(`reply session initialization conflicted for ${lastStaleKey ?? "unknown"}`);
 }
 
 async function initSessionStateAttemptLocked(
   params: InitSessionStateParams,
   attemptContext: InitSessionStateAttemptContext,
-  staleSnapshotRetried: boolean,
   lifecycleMutationIdentity: { sessionId: string; sessionKey: string } | undefined,
 ): Promise<InitSessionStateAttemptOutcome> {
   const { ctx, cfg, commandAuthorized } = params;
@@ -1020,10 +1049,7 @@ async function initSessionStateAttemptLocked(
     storePath,
   });
   if (!committed.ok) {
-    if (!staleSnapshotRetried) {
-      return await initSessionStateAttemptLocked(params, attemptContext, true, undefined);
-    }
-    throw new Error(`reply session initialization conflicted for ${sessionKey}`);
+    return { kind: "stale-snapshot", sessionKey };
   }
   sessionEntry = committed.sessionEntry;
   sessionId = sessionEntry.sessionId;


### PR DESCRIPTION
## What Problem This Solves

Fixes #100173 — When users send concurrent cross-process messages to the same session, `commitReplySessionInitialization` can fail with a stale-snapshot revision conflict. The old code retried **once with no delay inside the writer lock**, which almost always failed again and propagated a hard error to the plugin layer (user sees "⚠️ 服务调用失败").

## Why This Change Was Made

**Move retry outside the writer lock** with exponential backoff:
- Each retry re-acquires the lock and re-reads the latest snapshot
- 3 retries with exponential backoff: 200ms → 400ms → 800ms
- Uses existing `sleep()` utility from `src/utils.js`

**Key changes in `initSessionStateAttempt`**:
- Added `{ kind: "stale-snapshot", sessionKey }` to `InitSessionStateAttemptOutcome`
- Retry loop runs **outside** `runExclusiveSessionStoreWrite` — each attempt acquires a fresh writer lane
- Removed `staleSnapshotRetried` boolean from `initSessionStateAttemptLocked`
- Final throw message uses the accurate `sessionKey` from the outcome

**Stale snapshot during lifecycle revalidation** (inside the lifecycle-mutation loop) is treated as terminal — an unexpected state since the writer held the lock just before.

## Previous Reviews Addressed

- ✅ **AmirF194**: `attemptContext.sessionKey` no longer exists — compile error fixed
- ✅ **AmirF194**: Added standalone test file `session-stale-snapshot-retry.test.ts` (3 tests) verifying retry-then-succeed, 4-attempt bound, and non-retry of unrelated errors
- ✅ Based on current main (2026-07-05)

## User Impact

- Concurrent messages to the same session no longer produce visible "service call failed" errors
- Stale-snapshot conflicts resolve transparently via exponential backoff
- No behavior change for normal (non-concurrent) session init
- Non-stale-snapshot errors still propagate immediately (not retried)

## Evidence

- **Test results**: `session.test.ts` 133 passed + `session-stale-snapshot-retry.test.ts` 3 passed — **136 tests, no regressions**
- **New tests**: mock `commitReplySessionInitialization` → stale-snapshot for N attempts → verify retry contract (cross-process conflict scenario)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
