### PR TITLE
feat(android): durable offline command outbox for chat sends

### DIFF
--- a/apps/.i18n/native-source.json
+++ b/apps/.i18n/native-source.json
@@ -123,7 +123,7 @@
     },
     {
       "kind": "ui-state-text",
-      "line": 103,
+      "line": 104,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/MainViewModel.kt",
       "source": "Searching…",
       "surface": "android",
@@ -131,7 +131,7 @@
     },
     {
       "kind": "ui-state-text",
-      "line": 192,
+      "line": 193,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/MainViewModel.kt",
       "source": "Mic off",
       "surface": "android",
@@ -139,7 +139,7 @@
     },
     {
       "kind": "ui-state-text",
-      "line": 202,
+      "line": 203,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/MainViewModel.kt",
       "source": "Off",
       "surface": "android",
@@ -179,7 +179,7 @@
     },
     {
       "kind": "ui-state-text",
-      "line": 516,
+      "line": 519,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Offline",
       "surface": "android",
@@ -187,7 +187,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 2083,
+      "line": 2100,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Failed: this host requires wss:// or Tailscale Serve. No TLS endpoint detected.",
       "surface": "android",
@@ -195,7 +195,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 2085,
+      "line": 2102,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Failed: secure endpoint reached, but TLS fingerprint verification timed out. Check Tailscale Serve or gateway TLS and retry.",
       "surface": "android",
@@ -203,7 +203,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 2087,
+      "line": 2104,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Failed: couldn't reach the secure gateway endpoint for this host.",
       "surface": "android",
@@ -5027,7 +5027,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 172,
+      "line": 181,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatComposer.kt",
       "source": "Type a message…",
       "surface": "android",
@@ -5035,15 +5035,15 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 182,
+      "line": 191,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatComposer.kt",
-      "source": "Gateway is offline. Open Settings to reconnect.",
+      "source": "Gateway is offline. Text messages are queued and sent after reconnecting.",
       "surface": "android",
-      "id": "native.android.6522139155c1eebd"
+      "id": "native.android.8e06942aa080e420"
     },
     {
       "kind": "ui-named-argument",
-      "line": 211,
+      "line": 220,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatComposer.kt",
       "source": "Select thinking level",
       "surface": "android",
@@ -5051,7 +5051,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 235,
+      "line": 244,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatComposer.kt",
       "source": "Attach",
       "surface": "android",
@@ -5059,7 +5059,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 243,
+      "line": 252,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatComposer.kt",
       "source": "Refresh",
       "surface": "android",
@@ -5067,7 +5067,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 251,
+      "line": 260,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatComposer.kt",
       "source": "Abort",
       "surface": "android",
@@ -5075,7 +5075,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 289,
+      "line": 305,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatComposer.kt",
       "source": "Send",
       "surface": "android",
@@ -5083,7 +5083,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 315,
+      "line": 331,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatComposer.kt",
       "source": "No commands found",
       "surface": "android",
@@ -5099,7 +5099,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 105,
+      "line": 116,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatMessageListCard.kt",
       "source": "Jump to latest",
       "surface": "android",
@@ -5107,7 +5107,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 126,
+      "line": 137,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatMessageListCard.kt",
       "source": "Loading session",
       "surface": "android",
@@ -5115,7 +5115,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 146,
+      "line": 157,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatMessageListCard.kt",
       "source": "No messages yet",
       "surface": "android",
@@ -5123,7 +5123,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 145,
+      "line": 148,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatMessageViews.kt",
       "source": "Thinking...",
       "surface": "android",
@@ -5131,7 +5131,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 164,
+      "line": 167,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatMessageViews.kt",
       "source": "Running tools...",
       "surface": "android",
@@ -5139,7 +5139,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 167,
+      "line": 170,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatMessageViews.kt",
       "source": "${display.emoji} ${display.label}",
       "surface": "android",
@@ -5147,15 +5147,31 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 185,
+      "line": 188,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatMessageViews.kt",
       "source": "... +${toolCalls.size - 6} more",
       "surface": "android",
       "id": "native.android.29021f925bf290c7"
     },
     {
+      "kind": "ui-named-argument",
+      "line": 233,
+      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatMessageViews.kt",
+      "source": "Retry",
+      "surface": "android",
+      "id": "native.android.9bd31c23ebdf7c7a"
+    },
+    {
+      "kind": "ui-named-argument",
+      "line": 236,
+      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatMessageViews.kt",
+      "source": "Delete",
+      "surface": "android",
+      "id": "native.android.b728b15914267f57"
+    },
+    {
       "kind": "conditional-branch",
-      "line": 235,
+      "line": 304,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatMessageViews.kt",
       "source": "You",
       "surface": "android",
@@ -5163,7 +5179,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 236,
+      "line": 305,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatMessageViews.kt",
       "source": "System",
       "surface": "android",
@@ -5171,7 +5187,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 237,
+      "line": 306,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatMessageViews.kt",
       "source": "OpenClaw",
       "surface": "android",
@@ -5179,7 +5195,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 263,
+      "line": 332,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatMessageViews.kt",
       "source": "Unsupported attachment",
       "surface": "android",
@@ -5187,7 +5203,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 223,
+      "line": 225,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Chat needs attention",
       "surface": "android",
@@ -5195,7 +5211,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 349,
+      "line": 366,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "All",
       "surface": "android",
@@ -5203,7 +5219,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 403,
+      "line": 420,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "OpenClaw",
       "surface": "android",
@@ -5211,7 +5227,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 424,
+      "line": 441,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "New chat",
       "surface": "android",
@@ -5219,7 +5235,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 425,
+      "line": 442,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Refresh chat",
       "surface": "android",
@@ -5227,7 +5243,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 428,
+      "line": 445,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Chat",
       "surface": "android",
@@ -5235,7 +5251,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 555,
+      "line": 582,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Loading session",
       "surface": "android",
@@ -5243,7 +5259,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 582,
+      "line": 609,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Jump to latest",
       "surface": "android",
@@ -5251,7 +5267,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 602,
+      "line": 629,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Ready when you are",
       "surface": "android",
@@ -5259,7 +5275,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 633,
+      "line": 660,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Fix connection",
       "surface": "android",
@@ -5267,7 +5283,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 634,
+      "line": 661,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Copy diagnostics",
       "surface": "android",
@@ -5275,7 +5291,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 771,
+      "line": 798,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Tools running",
       "surface": "android",
@@ -5283,7 +5299,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 776,
+      "line": 803,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "+${toolCalls.size - 4} more",
       "surface": "android",
@@ -5291,7 +5307,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 786,
+      "line": 813,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Thinking",
       "surface": "android",
@@ -5299,7 +5315,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 787,
+      "line": 814,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "OpenClaw is preparing a response.",
       "surface": "android",
@@ -5307,7 +5323,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 899,
+      "line": 933,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Stop",
       "surface": "android",
@@ -5315,7 +5331,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 916,
+      "line": 950,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "No commands found",
       "surface": "android",
@@ -5323,7 +5339,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 978,
+      "line": 1012,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Gateway offline",
       "surface": "android",
@@ -5331,7 +5347,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1068,
+      "line": 1102,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Attach image",
       "surface": "android",
@@ -5339,7 +5355,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1083,
+      "line": 1117,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Message OpenClaw",
       "surface": "android",
@@ -5347,7 +5363,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1098,
+      "line": 1132,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Voice",
       "surface": "android",
@@ -5355,7 +5371,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1136,
+      "line": 1170,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Remove attachment",
       "surface": "android",
@@ -5363,7 +5379,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1157,
+      "line": 1191,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Main",
       "surface": "android",
@@ -5371,7 +5387,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1213,
+      "line": 1247,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Send",
       "surface": "android",
@@ -5379,7 +5395,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1252,
+      "line": 1286,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "$contextLabel · ${contextMeterThinkingLabel(thinkingLevel)}",
       "surface": "android",
@@ -5387,7 +5403,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 272,
+      "line": 287,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatSheetContent.kt",
       "source": "CHAT ERROR",
       "surface": "android",

--- a/apps/android/app/src/main/java/ai/openclaw/app/MainViewModel.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/MainViewModel.kt
@@ -2,6 +2,7 @@ package ai.openclaw.app
 
 import ai.openclaw.app.chat.ChatCommandEntry
 import ai.openclaw.app.chat.ChatMessage
+import ai.openclaw.app.chat.ChatOutboxItem
 import ai.openclaw.app.chat.ChatPendingToolCall
 import ai.openclaw.app.chat.ChatSessionEntry
 import ai.openclaw.app.chat.OutgoingAttachment
@@ -215,6 +216,7 @@ class MainViewModel(
   val chatSessions: StateFlow<List<ChatSessionEntry>> = runtimeState(initial = emptyList()) { it.chatSessions }
   val pendingRunCount: StateFlow<Int> = runtimeState(initial = 0) { it.pendingRunCount }
   val chatCommands: StateFlow<List<ChatCommandEntry>> = runtimeState(initial = emptyList<ChatCommandEntry>()) { it.chatCommands }
+  val chatOutboxItems: StateFlow<List<ChatOutboxItem>> = runtimeState(initial = emptyList()) { it.chatOutboxItems }
   val execApprovals: StateFlow<List<GatewayExecApprovalSummary>> = runtimeState(initial = emptyList()) { it.execApprovals }
   val execApprovalsRefreshing: StateFlow<Boolean> = runtimeState(initial = false) { it.execApprovalsRefreshing }
   val execApprovalsErrorText: StateFlow<String?> = runtimeState(initial = null) { it.execApprovalsErrorText }
@@ -297,7 +299,7 @@ class MainViewModel(
   }
 
   /** Clears setup credentials without starting the runtime just to discard first-run pairing auth. */
-  private fun resetGatewaySetupAuth() {
+  private suspend fun resetGatewaySetupAuth() {
     runtimeRef.value?.resetGatewaySetupAuth() ?: resetGatewaySetupAuthWithoutRuntime()
   }
 
@@ -613,6 +615,14 @@ class MainViewModel(
 
   fun refreshChatCommands() {
     ensureRuntime().refreshChatCommands()
+  }
+
+  fun retryChatOutboxCommand(id: String) {
+    ensureRuntime().retryChatOutboxCommand(id)
+  }
+
+  fun deleteChatOutboxCommand(id: String) {
+    ensureRuntime().deleteChatOutboxCommand(id)
   }
 
   fun sendChat(

--- a/apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt
@@ -1,12 +1,15 @@
 package ai.openclaw.app
 
+import ai.openclaw.app.chat.ChatCacheDatabase
 import ai.openclaw.app.chat.ChatCacheScope
 import ai.openclaw.app.chat.ChatCommandEntry
 import ai.openclaw.app.chat.ChatController
 import ai.openclaw.app.chat.ChatMessage
+import ai.openclaw.app.chat.ChatOutboxItem
 import ai.openclaw.app.chat.ChatPendingToolCall
 import ai.openclaw.app.chat.ChatSessionEntry
 import ai.openclaw.app.chat.OutgoingAttachment
+import ai.openclaw.app.chat.RoomChatCommandOutbox
 import ai.openclaw.app.chat.RoomChatTranscriptCache
 import ai.openclaw.app.gateway.DeviceAuthEntry
 import ai.openclaw.app.gateway.DeviceAuthStore
@@ -840,8 +843,14 @@ class NodeRuntime(
     }
   }
 
+  // One Room handle owns both chat stores (disposable transcript cache + durable command outbox).
+  private val chatCacheDatabase: ChatCacheDatabase = ChatCacheDatabase.open(appContext)
+
   private val chatTranscriptCache: RoomChatTranscriptCache =
-    RoomChatTranscriptCache(context = appContext)
+    RoomChatTranscriptCache(database = chatCacheDatabase)
+
+  private val chatCommandOutbox: RoomChatCommandOutbox =
+    RoomChatCommandOutbox(database = chatCacheDatabase)
 
   private val chat: ChatController =
     ChatController(
@@ -850,6 +859,7 @@ class NodeRuntime(
       json = json,
       transcriptCache = chatTranscriptCache,
       cacheScope = ::chatCacheScope,
+      commandOutbox = chatCommandOutbox,
     ).also {
       it.applyMainSessionKey(_mainSessionKey.value)
     }
@@ -1268,14 +1278,16 @@ class NodeRuntime(
   fun setGatewayPassword(value: String) = prefs.setGatewayPassword(value)
 
   /** Clears setup credentials plus paired device tokens for both Android gateway roles. */
-  fun resetGatewaySetupAuth() {
+  suspend fun resetGatewaySetupAuth() {
     prefs.clearGatewaySetupAuth()
     val deviceId = identityStore.loadOrCreate().deviceId
     deviceAuthStore.clearToken(deviceId, "node")
     deviceAuthStore.clearToken(deviceId, "operator")
     // A pairing/auth reset can precede pairing a different gateway principal at the same
-    // endpoint id; purge offline transcripts so they cannot surface under the new pairing.
-    scope.launch { runCatching { chatTranscriptCache.clearAll() } }
+    // endpoint id. The purge must complete before pairing continues: queued commands are
+    // replayed on reconnect, so an async purge could flush stale rows to the new principal.
+    runCatching { chatTranscriptCache.clearAll() }
+    runCatching { chatCommandOutbox.clearAll() }
   }
 
   /** Persists onboarding state; callers decide whether runtime startup is needed first. */
@@ -1310,6 +1322,11 @@ class NodeRuntime(
   val chatSessions: StateFlow<List<ChatSessionEntry>> = chat.sessions
   val pendingRunCount: StateFlow<Int> = chat.pendingRunCount
   val chatCommands: StateFlow<List<ChatCommandEntry>> = chat.commands
+  val chatOutboxItems: StateFlow<List<ChatOutboxItem>> = chat.outboxItems
+
+  fun retryChatOutboxCommand(id: String) = chat.retryOutboxCommand(id)
+
+  fun deleteChatOutboxCommand(id: String) = chat.deleteOutboxCommand(id)
 
   init {
     if (prefs.voiceWakeMode.value != VoiceWakeMode.Off) {

--- a/apps/android/app/src/main/java/ai/openclaw/app/chat/ChatCommandOutbox.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/chat/ChatCommandOutbox.kt
@@ -1,0 +1,337 @@
+package ai.openclaw.app.chat
+
+import androidx.room.Dao
+import androidx.room.Entity
+import androidx.room.Insert
+import androidx.room.PrimaryKey
+import androidx.room.Query
+import androidx.room.withTransaction
+import java.util.UUID
+
+/** Upper bound of durable outbox rows per gateway; enqueue is refused beyond this. */
+internal const val OUTBOX_MAX_QUEUED = 50
+
+/** Queued commands older than this are expired instead of sending stale instructions. */
+internal const val OUTBOX_EXPIRY_MS = 48L * 60L * 60L * 1000L
+
+/** Total send attempts per item before it is parked as failed. */
+internal const val OUTBOX_MAX_SEND_ATTEMPTS = 3
+
+/** Base backoff between retry attempts for one item; multiplied by the attempt count. */
+internal const val OUTBOX_RETRY_BACKOFF_MS = 2_000L
+
+/** lastError marker for items expired by [OUTBOX_EXPIRY_MS]; also shown in the UI row. */
+internal const val OUTBOX_EXPIRED_ERROR = "expired"
+
+enum class ChatOutboxStatus(
+  internal val dbValue: String,
+) {
+  Queued("queued"),
+  Sending("sending"),
+  Failed("failed"),
+  ;
+
+  internal companion object {
+    // Destructive migration keeps the schema in lockstep, so unknown values should not occur;
+    // park anything unexpected as Failed so it stays visible instead of silently sending.
+    fun fromDb(value: String): ChatOutboxStatus = entries.firstOrNull { it.dbValue == value } ?: Failed
+  }
+}
+
+/** One durable queued chat command; [id] doubles as the chat.send idempotency key. */
+data class ChatOutboxItem(
+  val id: String,
+  val sessionKey: String,
+  val text: String,
+  // Normalized thinking level captured at enqueue time, so a later selector change cannot
+  // silently alter how an already-queued command is delivered.
+  val thinkingLevel: String,
+  val createdAtMs: Long,
+  val status: ChatOutboxStatus,
+  val retryCount: Int,
+  val lastError: String?,
+)
+
+sealed interface ChatOutboxEnqueueResult {
+  data class Queued(
+    val item: ChatOutboxItem,
+  ) : ChatOutboxEnqueueResult
+
+  data object QueueFull : ChatOutboxEnqueueResult
+
+  /** No gateway identity is available (nothing paired/configured), so nothing can be queued. */
+  data object Unavailable : ChatOutboxEnqueueResult
+}
+
+/**
+ * Durable offline outbox for text chat commands.
+ *
+ * Unlike the disposable transcript cache, queued rows are user input that must survive process
+ * restarts until they are acked by the gateway, expired, or explicitly deleted. Like the cache,
+ * callers bind every gateway-scoped operation to an explicit [ChatCacheScope] gateway id captured
+ * before their suspend point, so a connection switch cannot re-scope rows mid-operation.
+ */
+interface ChatCommandOutbox {
+  /** All rows for [gatewayId], strictly createdAt-ordered. */
+  suspend fun load(gatewayId: String): List<ChatOutboxItem>
+
+  suspend fun enqueue(
+    gatewayId: String,
+    sessionKey: String,
+    text: String,
+    thinkingLevel: String,
+    nowMs: Long,
+  ): ChatOutboxEnqueueResult
+
+  /** Returns the number of rows updated (0 when the row no longer exists), so callers can claim. */
+  suspend fun updateStatus(
+    id: String,
+    status: ChatOutboxStatus,
+    retryCount: Int,
+    lastError: String?,
+  ): Int
+
+  /**
+   * User-driven retry of a failed row: back to 'queued' with reset attempts and a fresh
+   * createdAt, so an expired row is not immediately re-expired by the flush sweep. Keeps the
+   * row id, so the original idempotency key still dedupes on the gateway.
+   */
+  suspend fun requeueForRetry(
+    gatewayId: String,
+    id: String,
+    nowMs: Long,
+  )
+
+  suspend fun delete(id: String)
+
+  /** Drops queued commands for a deleted session so they cannot send into a dead session. */
+  suspend fun deleteForSession(
+    gatewayId: String,
+    sessionKey: String,
+  )
+
+  /** Crash safety: rows stuck in 'sending' from a killed process become 'queued' again. */
+  suspend fun requeueSendingAfterRestart()
+
+  /** Expires queued rows older than [OUTBOX_EXPIRY_MS] to 'failed' instead of sending stale commands. */
+  suspend fun expireStale(
+    gatewayId: String,
+    nowMs: Long,
+  )
+
+  /** Purges every row for all gateways; used when pairing/auth state is reset. */
+  suspend fun clearAll()
+}
+
+@Entity(tableName = "outbox_commands")
+internal data class OutboxCommandEntity(
+  @PrimaryKey val id: String,
+  val gatewayId: String,
+  val sessionKey: String,
+  val text: String,
+  val thinkingLevel: String,
+  val createdAtMs: Long,
+  val status: String,
+  val retryCount: Int,
+  val lastError: String?,
+)
+
+@Dao
+internal interface ChatOutboxDao {
+  // id tiebreak keeps flush order deterministic when two rows share a createdAt millisecond.
+  @Query("SELECT * FROM outbox_commands WHERE gatewayId = :gatewayId ORDER BY createdAtMs ASC, id ASC")
+  suspend fun commands(gatewayId: String): List<OutboxCommandEntity>
+
+  @Query("SELECT COUNT(*) FROM outbox_commands WHERE gatewayId = :gatewayId")
+  suspend fun count(gatewayId: String): Int
+
+  @Query("SELECT MAX(createdAtMs) FROM outbox_commands WHERE gatewayId = :gatewayId")
+  suspend fun maxCreatedAt(gatewayId: String): Long?
+
+  @Insert
+  suspend fun insert(row: OutboxCommandEntity)
+
+  @Query("UPDATE outbox_commands SET status = :status, retryCount = :retryCount, lastError = :lastError WHERE id = :id")
+  suspend fun updateStatus(
+    id: String,
+    status: String,
+    retryCount: Int,
+    lastError: String?,
+  ): Int
+
+  @Query("UPDATE outbox_commands SET status = :toStatus WHERE status = :fromStatus")
+  suspend fun updateAllWithStatus(
+    fromStatus: String,
+    toStatus: String,
+  )
+
+  @Query(
+    "UPDATE outbox_commands SET status = :status, retryCount = 0, lastError = NULL, createdAtMs = :createdAtMs " +
+      "WHERE id = :id",
+  )
+  suspend fun requeueForRetry(
+    id: String,
+    createdAtMs: Long,
+    status: String,
+  )
+
+  @Query(
+    "UPDATE outbox_commands SET status = :failedStatus, lastError = :error " +
+      "WHERE gatewayId = :gatewayId AND status = :queuedStatus AND createdAtMs <= :cutoffMs",
+  )
+  suspend fun expireQueuedAtOrBefore(
+    gatewayId: String,
+    cutoffMs: Long,
+    queuedStatus: String,
+    failedStatus: String,
+    error: String,
+  )
+
+  @Query("DELETE FROM outbox_commands WHERE id = :id")
+  suspend fun delete(id: String)
+
+  @Query("DELETE FROM outbox_commands WHERE gatewayId = :gatewayId AND sessionKey = :sessionKey")
+  suspend fun deleteForSession(
+    gatewayId: String,
+    sessionKey: String,
+  )
+
+  @Query("DELETE FROM outbox_commands")
+  suspend fun deleteAll()
+}
+
+/**
+ * Room-backed [ChatCommandOutbox] sharing the chat cache database. Callers pass the gateway id
+ * captured before their suspend point; a blank identity disables both reads and writes.
+ */
+class RoomChatCommandOutbox internal constructor(
+  private val database: ChatCacheDatabase,
+) : ChatCommandOutbox {
+  override suspend fun load(gatewayId: String): List<ChatOutboxItem> {
+    val gateway = scopedGatewayId(gatewayId) ?: return emptyList()
+    return database.outboxDao().commands(gateway).map { row ->
+      ChatOutboxItem(
+        id = row.id,
+        sessionKey = row.sessionKey,
+        text = row.text,
+        thinkingLevel = row.thinkingLevel,
+        createdAtMs = row.createdAtMs,
+        status = ChatOutboxStatus.fromDb(row.status),
+        retryCount = row.retryCount,
+        lastError = row.lastError,
+      )
+    }
+  }
+
+  override suspend fun enqueue(
+    gatewayId: String,
+    sessionKey: String,
+    text: String,
+    thinkingLevel: String,
+    nowMs: Long,
+  ): ChatOutboxEnqueueResult {
+    val gateway = scopedGatewayId(gatewayId) ?: return ChatOutboxEnqueueResult.Unavailable
+    val key = sessionKey.trim().takeIf { it.isNotEmpty() } ?: return ChatOutboxEnqueueResult.Unavailable
+    val dao = database.outboxDao()
+    // The bound counts every row (failed included) so total storage stays capped; failed rows
+    // are user-visible and deletable, so a full queue is always recoverable from the UI.
+    val row =
+      database.withTransaction {
+        if (dao.count(gateway) >= OUTBOX_MAX_QUEUED) {
+          null
+        } else {
+          // Monotonic per-gateway createdAt keeps flush strictly FIFO even when two sends land
+          // in the same wall-clock millisecond (the id tiebreak is a random UUID otherwise).
+          val createdAt = maxOf(nowMs, (dao.maxCreatedAt(gateway) ?: Long.MIN_VALUE) + 1)
+          val entity =
+            OutboxCommandEntity(
+              id = UUID.randomUUID().toString(),
+              gatewayId = gateway,
+              sessionKey = key,
+              text = text,
+              thinkingLevel = thinkingLevel,
+              createdAtMs = createdAt,
+              status = ChatOutboxStatus.Queued.dbValue,
+              retryCount = 0,
+              lastError = null,
+            )
+          dao.insert(entity)
+          entity
+        }
+      } ?: return ChatOutboxEnqueueResult.QueueFull
+    return ChatOutboxEnqueueResult.Queued(
+      ChatOutboxItem(
+        id = row.id,
+        sessionKey = row.sessionKey,
+        text = row.text,
+        thinkingLevel = row.thinkingLevel,
+        createdAtMs = row.createdAtMs,
+        status = ChatOutboxStatus.Queued,
+        retryCount = 0,
+        lastError = null,
+      ),
+    )
+  }
+
+  override suspend fun updateStatus(
+    id: String,
+    status: ChatOutboxStatus,
+    retryCount: Int,
+    lastError: String?,
+  ): Int = database.outboxDao().updateStatus(id = id, status = status.dbValue, retryCount = retryCount, lastError = lastError)
+
+  override suspend fun requeueForRetry(
+    gatewayId: String,
+    id: String,
+    nowMs: Long,
+  ) {
+    val gateway = scopedGatewayId(gatewayId) ?: return
+    val dao = database.outboxDao()
+    database.withTransaction {
+      // Same monotonic clamp as enqueue: a retried row re-joins the end of the FIFO queue.
+      val createdAt = maxOf(nowMs, (dao.maxCreatedAt(gateway) ?: Long.MIN_VALUE) + 1)
+      dao.requeueForRetry(id = id, createdAtMs = createdAt, status = ChatOutboxStatus.Queued.dbValue)
+    }
+  }
+
+  override suspend fun delete(id: String) {
+    database.outboxDao().delete(id)
+  }
+
+  override suspend fun deleteForSession(
+    gatewayId: String,
+    sessionKey: String,
+  ) {
+    val gateway = scopedGatewayId(gatewayId) ?: return
+    val key = sessionKey.trim().takeIf { it.isNotEmpty() } ?: return
+    database.outboxDao().deleteForSession(gateway, key)
+  }
+
+  override suspend fun requeueSendingAfterRestart() {
+    // Deliberately unscoped: interrupted sends must recover even before a gateway is resolved.
+    database.outboxDao().updateAllWithStatus(
+      fromStatus = ChatOutboxStatus.Sending.dbValue,
+      toStatus = ChatOutboxStatus.Queued.dbValue,
+    )
+  }
+
+  override suspend fun expireStale(
+    gatewayId: String,
+    nowMs: Long,
+  ) {
+    val gateway = scopedGatewayId(gatewayId) ?: return
+    database.outboxDao().expireQueuedAtOrBefore(
+      gatewayId = gateway,
+      cutoffMs = nowMs - OUTBOX_EXPIRY_MS,
+      queuedStatus = ChatOutboxStatus.Queued.dbValue,
+      failedStatus = ChatOutboxStatus.Failed.dbValue,
+      error = OUTBOX_EXPIRED_ERROR,
+    )
+  }
+
+  override suspend fun clearAll() {
+    database.outboxDao().deleteAll()
+  }
+
+  private fun scopedGatewayId(gatewayId: String): String? = gatewayId.trim().takeIf { it.isNotEmpty() }
+}

--- a/apps/android/app/src/main/java/ai/openclaw/app/chat/ChatController.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/chat/ChatController.kt
@@ -3,6 +3,7 @@ package ai.openclaw.app.chat
 import ai.openclaw.app.resolveAgentIdFromMainSessionKey
 import ai.openclaw.app.gateway.GatewaySession
 import ai.openclaw.app.gateway.parseChatSendAck
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
@@ -34,6 +35,7 @@ class ChatController internal constructor(
   private val requestGateway: suspend (method: String, paramsJson: String?) -> String,
   private val transcriptCache: ChatTranscriptCache? = null,
   private val cacheScope: () -> ChatCacheScope? = { null },
+  private val commandOutbox: ChatCommandOutbox? = null,
 ) {
   internal constructor(
     scope: CoroutineScope,
@@ -41,12 +43,14 @@ class ChatController internal constructor(
     json: Json,
     transcriptCache: ChatTranscriptCache? = null,
     cacheScope: () -> ChatCacheScope? = { null },
+    commandOutbox: ChatCommandOutbox? = null,
   ) : this(
     scope = scope,
     json = json,
     requestGateway = { method, paramsJson -> session.request(method, paramsJson) },
     transcriptCache = transcriptCache,
     cacheScope = cacheScope,
+    commandOutbox = commandOutbox,
   )
 
   private var appliedMainSessionKey = "main"
@@ -110,6 +114,25 @@ class ChatController internal constructor(
   // any run the gateway still reports in flight (chat.history `inFlightRun`).
   private var restoreRunStateOnReconnect = false
 
+  private val _outboxItems = MutableStateFlow<List<ChatOutboxItem>>(emptyList())
+  val outboxItems: StateFlow<List<ChatOutboxItem>> = _outboxItems.asStateFlow()
+
+  private val outboxFlushInFlight = AtomicBoolean(false)
+
+  init {
+    if (commandOutbox != null) {
+      scope.launch {
+        // Crash safety: a process killed mid-flush leaves rows in 'sending'; requeue them so
+        // they are retried instead of being stuck invisible to the flush loop forever.
+        runCatching { commandOutbox.requeueSendingAfterRestart() }
+        currentCacheScope()?.let { outboxScope ->
+          runCatching { commandOutbox.expireStale(outboxScope.gatewayId, System.currentTimeMillis()) }
+        }
+        publishOutbox()
+      }
+    }
+  }
+
   /** Clears transient chat state when the operator gateway session disconnects. */
   fun onDisconnected(message: String) {
     restoreRunStateOnReconnect = true
@@ -134,6 +157,8 @@ class ChatController internal constructor(
         markLoading = false,
       )
       _sessions.value = emptyList()
+      // Outbox rows are gateway-scoped too; the next publish repopulates them for the new scope.
+      _outboxItems.value = emptyList()
     }
   }
 
@@ -314,8 +339,13 @@ class ChatController internal constructor(
     val trimmed = message.trim()
     if (trimmed.isEmpty() && attachments.isEmpty()) return false
     if (!_healthOk.value) {
-      _errorText.value = "Gateway health not OK; cannot send"
-      return false
+      // Offline capture: text-only commands become durable outbox rows and flush on reconnect.
+      // Attachments stay blocked (text-only v1) so large payloads never sit in the database.
+      if (commandOutbox == null || attachments.isNotEmpty()) {
+        _errorText.value = "Gateway health not OK; cannot send"
+        return false
+      }
+      return enqueueOfflineCommand(text = trimmed, thinkingLevel = normalizeThinking(thinkingLevel))
     }
 
     val runId = UUID.randomUUID().toString()
@@ -455,7 +485,7 @@ class ChatController internal constructor(
         scope.launch { pollHealthIfNeeded(force = false) }
       }
       "health" -> {
-        _healthOk.value = true
+        markHealthOk()
         refreshCommandsAfterReconnect()
         if (restoreRunStateOnReconnect) {
           restoreRunStateOnReconnect = false
@@ -687,7 +717,7 @@ class ChatController internal constructor(
     lastHealthPollAtMs = now
     try {
       requestGateway("health", null)
-      _healthOk.value = true
+      markHealthOk()
       if (_commands.value.isEmpty() || commandsAgentId != resolveAgentIdForSessionKey(_sessionKey.value)) {
         fetchCommands()
       }
@@ -696,10 +726,250 @@ class ChatController internal constructor(
     }
   }
 
+  // Gateway-health transition is the single reconnect trigger for the outbox flush; it avoids a
+  // second reachability source (ConnectivityManager) that could disagree with gateway state.
+  private fun markHealthOk() {
+    val wasOk = _healthOk.value
+    _healthOk.value = true
+    if (!wasOk && commandOutbox != null) {
+      scope.launch { flushOutbox() }
+    }
+  }
+
   private fun refreshCommandsAfterReconnect() {
     if (_commands.value.isNotEmpty() && commandsAgentId == resolveAgentIdForSessionKey(_sessionKey.value)) return
     scope.launch { fetchCommands() }
   }
+
+  private suspend fun enqueueOfflineCommand(
+    text: String,
+    thinkingLevel: String,
+  ): Boolean {
+    val outbox = commandOutbox ?: return false
+    val outboxScope =
+      currentCacheScope() ?: run {
+        _errorText.value = "Gateway health not OK; cannot send"
+        return false
+      }
+    val result =
+      try {
+        outbox.enqueue(
+          gatewayId = outboxScope.gatewayId,
+          sessionKey = _sessionKey.value,
+          text = text,
+          thinkingLevel = thinkingLevel,
+          nowMs = System.currentTimeMillis(),
+        )
+      } catch (_: Throwable) {
+        _errorText.value = "Could not queue message for later delivery."
+        return false
+      }
+    return when (result) {
+      is ChatOutboxEnqueueResult.Queued -> {
+        _errorText.value = null
+        publishOutbox()
+        true
+      }
+      ChatOutboxEnqueueResult.QueueFull -> {
+        _errorText.value = "Offline queue is full ($OUTBOX_MAX_QUEUED messages); delete queued items first."
+        false
+      }
+      ChatOutboxEnqueueResult.Unavailable -> {
+        _errorText.value = "Gateway health not OK; cannot send"
+        false
+      }
+    }
+  }
+
+  /** Re-queues a failed outbox item and flushes immediately when the gateway is healthy. */
+  fun retryOutboxCommand(id: String) {
+    val outbox = commandOutbox ?: return
+    scope.launch {
+      val outboxScope = currentCacheScope() ?: return@launch
+      // requeueForRetry (not a plain status flip) refreshes createdAt so retrying an expired
+      // row does not get re-expired by the flush sweep before it can send.
+      runCatching { outbox.requeueForRetry(gatewayId = outboxScope.gatewayId, id = id, nowMs = System.currentTimeMillis()) }
+      publishOutbox()
+      if (_healthOk.value) flushOutbox()
+    }
+  }
+
+  fun deleteOutboxCommand(id: String) {
+    val outbox = commandOutbox ?: return
+    scope.launch {
+      runCatching { outbox.delete(id) }
+      publishOutbox()
+    }
+  }
+
+  private suspend fun publishOutbox() {
+    val outbox = commandOutbox ?: return
+    val outboxScope = currentCacheScope()
+    if (outboxScope == null) {
+      _outboxItems.value = emptyList()
+      return
+    }
+    val items = runCatching { outbox.load(outboxScope.gatewayId) }.getOrDefault(emptyList())
+    // Publish under the scope lock so rows loaded for an old gateway cannot land after a switch.
+    synchronized(gatewayScopeApplyLock) {
+      if (outboxScope == currentCacheScope()) {
+        _outboxItems.value = items
+      }
+    }
+  }
+
+  /**
+   * Sends queued outbox rows strictly createdAt-ordered. Single-flight: health events can fire
+   * repeatedly while a flush is already draining the queue.
+   */
+  private suspend fun flushOutbox() {
+    val outbox = commandOutbox ?: return
+    if (!outboxFlushInFlight.compareAndSet(false, true)) return
+    var flushedAny = false
+    try {
+      // The whole flush is bound to one gateway scope; a connection switch mid-flush stops it
+      // and the next health transition flushes under the new scope.
+      val flushScope = currentCacheScope() ?: return
+      runCatching { outbox.expireStale(flushScope.gatewayId, System.currentTimeMillis()) }
+      publishOutbox()
+      while (_healthOk.value && currentCacheScope() == flushScope) {
+        val next =
+          runCatching { outbox.load(flushScope.gatewayId) }
+            .getOrDefault(emptyList())
+            .firstOrNull { it.status == ChatOutboxStatus.Queued } ?: break
+        when (sendOutboxItem(outbox, next, flushScope)) {
+          OutboxSendOutcome.Sent -> flushedAny = true
+          OutboxSendOutcome.Failed, OutboxSendOutcome.Skipped -> {}
+          OutboxSendOutcome.Stop -> break
+        }
+      }
+    } finally {
+      outboxFlushInFlight.set(false)
+      publishOutbox()
+      if (flushedAny) {
+        // Durable history replaces the queued bubbles; reconciliation matches by idempotency key.
+        refreshCurrentHistoryBestEffort()
+      }
+    }
+  }
+
+  // Sent: acked and removed. Failed: parked as failed. Skipped: row vanished (user delete).
+  // Stop: flush must halt (offline or gateway scope changed); the row stays queued.
+  private enum class OutboxSendOutcome { Sent, Failed, Skipped, Stop }
+
+  private sealed interface OutboxSendResult {
+    data object Accepted : OutboxSendResult
+
+    /** Gateway responded with a terminal failure ack; the message reached it but was rejected. */
+    data class Rejected(
+      val error: String,
+    ) : OutboxSendResult
+
+    /** Request never got an ack (socket drop, timeout); delivery state is unknown. */
+    data class TransportFailure(
+      val error: String,
+    ) : OutboxSendResult
+  }
+
+  private suspend fun sendOutboxItem(
+    outbox: ChatCommandOutbox,
+    item: ChatOutboxItem,
+    flushScope: ChatCacheScope,
+  ): OutboxSendOutcome {
+    // Claim the row before sending: 0 updated rows means it was deleted since the load, and a
+    // deleted command must never be sent. Skipped (like Failed) lets the flush continue.
+    val claimed = runCatching { outbox.updateStatus(item.id, ChatOutboxStatus.Sending, item.retryCount, item.lastError) }.getOrDefault(0)
+    publishOutbox()
+    if (claimed == 0) return OutboxSendOutcome.Skipped
+    var attempts = item.retryCount
+    while (true) {
+      val error =
+        when (val result = attemptOutboxSend(item)) {
+          OutboxSendResult.Accepted -> {
+            // Ack received: delete the row so the flushed history copy is the only bubble left.
+            runCatching { outbox.delete(item.id) }
+            publishOutbox()
+            return OutboxSendOutcome.Sent
+          }
+          is OutboxSendResult.TransportFailure -> {
+            // No ack means the gateway is effectively unreachable even if healthOk has not
+            // flipped yet. Keep the row queued without burning attempts and drop health so
+            // the next successful health poll/event re-triggers the flush.
+            runCatching { outbox.updateStatus(item.id, ChatOutboxStatus.Queued, attempts, result.error) }
+            publishOutbox()
+            _healthOk.value = false
+            return OutboxSendOutcome.Stop
+          }
+          is OutboxSendResult.Rejected -> result.error
+        }
+      attempts += 1
+      if (attempts >= OUTBOX_MAX_SEND_ATTEMPTS) {
+        runCatching { outbox.updateStatus(item.id, ChatOutboxStatus.Failed, attempts, error) }
+        publishOutbox()
+        return OutboxSendOutcome.Failed
+      }
+      // The row stays 'sending' through the backoff: Sending rows expose no Delete/Retry
+      // actions, so the user cannot delete a row this loop is about to resend.
+      runCatching { outbox.updateStatus(item.id, ChatOutboxStatus.Sending, attempts, error) }
+      publishOutbox()
+      // Losing health or the gateway scope mid-flush means this item must not retry now:
+      // requeue it for the next reconnect under the right scope. Without the scope check,
+      // a pairing switch during backoff could replay the captured text into the new gateway.
+      if (!_healthOk.value || currentCacheScope() != flushScope) {
+        return requeueAndStop(outbox, item.id, attempts, error)
+      }
+      delay(OUTBOX_RETRY_BACKOFF_MS * attempts)
+      if (!_healthOk.value || currentCacheScope() != flushScope) {
+        return requeueAndStop(outbox, item.id, attempts, error)
+      }
+      // Re-claim after the delay: a row deleted through any non-UI path must not be resent.
+      val reclaimed = runCatching { outbox.updateStatus(item.id, ChatOutboxStatus.Sending, attempts, error) }.getOrDefault(0)
+      if (reclaimed == 0) {
+        publishOutbox()
+        return OutboxSendOutcome.Skipped
+      }
+    }
+  }
+
+  private suspend fun requeueAndStop(
+    outbox: ChatCommandOutbox,
+    id: String,
+    attempts: Int,
+    error: String,
+  ): OutboxSendOutcome {
+    runCatching { outbox.updateStatus(id, ChatOutboxStatus.Queued, attempts, error) }
+    publishOutbox()
+    return OutboxSendOutcome.Stop
+  }
+
+  private suspend fun attemptOutboxSend(item: ChatOutboxItem): OutboxSendResult =
+    try {
+      val params =
+        buildJsonObject {
+          // Rows enqueued under the pre-hello "main" alias must flush to the canonical main
+          // session the gateway announced, matching how the UI attributes those rows.
+          put("sessionKey", JsonPrimitive(normalizeRequestedSessionKey(item.sessionKey)))
+          put("message", JsonPrimitive(item.text))
+          // Enqueue-time thinking level: a later selector change must not alter queued sends.
+          put("thinking", JsonPrimitive(item.thinkingLevel))
+          put("timeoutMs", JsonPrimitive(30_000))
+          // The row id is the idempotency key, so gateway-side dedupe makes redelivery of an
+          // acked-but-crashed item harmless.
+          put("idempotencyKey", JsonPrimitive(item.id))
+        }
+      val ack = parseChatSendAck(json, requestGateway("chat.send", params.toString()))
+      if (ack.isTerminalFailure) {
+        OutboxSendResult.Rejected("Chat failed before the run started")
+      } else {
+        OutboxSendResult.Accepted
+      }
+    } catch (err: CancellationException) {
+      // Teardown must not be recorded as a send failure; the row stays 'sending' and the
+      // next startup recovery requeues it.
+      throw err
+    } catch (err: Throwable) {
+      OutboxSendResult.TransportFailure(err.message ?: "send failed")
+    }
 
   private fun handleChatEvent(payloadJson: String) {
     val payload = json.parseToJsonElement(payloadJson).asObjectOrNull() ?: return
@@ -1038,11 +1308,14 @@ class ChatController internal constructor(
     val key = sessionKey?.trim()?.takeIf { it.isNotEmpty() } ?: return
     _sessions.value = _sessions.value.filterNot { it.key == key }
     // Gateway-side deletes must also purge the offline copy, or the deleted transcript would
-    // reappear on the next offline cold open.
-    val cache = transcriptCache ?: return
+    // reappear on the next offline cold open. Queued commands for the session die with it too.
     val requestCacheScope = currentCacheScope() ?: return
     scope.launch {
-      runCatching { cache.deleteSession(requestCacheScope.gatewayId, key) }
+      transcriptCache?.let { runCatching { it.deleteSession(requestCacheScope.gatewayId, key) } }
+      commandOutbox?.let {
+        runCatching { it.deleteForSession(requestCacheScope.gatewayId, key) }
+        publishOutbox()
+      }
     }
   }
 

--- a/apps/android/app/src/main/java/ai/openclaw/app/chat/ChatTranscriptCache.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/chat/ChatTranscriptCache.kt
@@ -159,18 +159,22 @@ internal interface ChatCacheDao {
 }
 
 @Database(
-  entities = [CachedSessionEntity::class, CachedMessageEntity::class],
-  version = 1,
+  entities = [CachedSessionEntity::class, CachedMessageEntity::class, OutboxCommandEntity::class],
+  version = 2,
   exportSchema = false,
 )
 internal abstract class ChatCacheDatabase : RoomDatabase() {
   abstract fun dao(): ChatCacheDao
 
+  abstract fun outboxDao(): ChatOutboxDao
+
   companion object {
     fun open(context: Context): ChatCacheDatabase =
       Room
         .databaseBuilder(context, ChatCacheDatabase::class.java, CHAT_TRANSCRIPT_CACHE_DB_NAME)
-        // The cache is disposable by contract: any schema bump drops and rebuilds instead of migrating.
+        // Established contract: any schema bump drops and rebuilds instead of migrating. Cached
+        // transcripts are disposable; the outbox loses at most a handful of unsent commands at a
+        // release boundary, which is acceptable versus carrying migrations for this store.
         .fallbackToDestructiveMigration(dropAllTables = true)
         .build()
   }
@@ -183,8 +187,6 @@ internal abstract class ChatCacheDatabase : RoomDatabase() {
 class RoomChatTranscriptCache internal constructor(
   private val database: ChatCacheDatabase,
 ) : ChatTranscriptCache {
-  constructor(context: Context) : this(database = ChatCacheDatabase.open(context))
-
   private val json = Json
   private val textPartsSerializer = ListSerializer(String.serializer())
 

--- a/apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatComposer.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatComposer.kt
@@ -51,6 +51,7 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
@@ -60,6 +61,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import kotlinx.coroutines.launch
 
 /** Result of applying a stored chat draft to the current composer input. */
 internal data class DraftApplication(
@@ -123,11 +125,13 @@ fun ChatComposer(
   onSetThinkingLevel: (level: String) -> Unit,
   onRefresh: () -> Unit,
   onAbort: () -> Unit,
-  onSend: (text: String) -> Unit,
+  /** Returns whether the send/enqueue was accepted; refusals restore the cleared draft. */
+  onSend: suspend (text: String) -> Boolean,
 ) {
   var input by rememberSaveable { mutableStateOf("") }
   var lastAppliedDraft by rememberSaveable { mutableStateOf<String?>(null) }
   var showThinkingMenu by remember { mutableStateOf(false) }
+  val sendScope = rememberCoroutineScope()
   val slashCommands =
     remember(input, commands) {
       matchingSlashCommands(input = input, commands = commands)
@@ -144,10 +148,15 @@ fun ChatComposer(
     }
   }
 
-  // One in-flight run owns the composer actions; attachments alone are enough
-  // to send when the gateway is healthy.
+  // One in-flight run owns the composer actions; attachments alone are enough to send when the
+  // gateway is healthy. Offline, only text can be sent (it is queued durably; text-only v1).
   val canSend =
-    pendingRunCount == 0 && (input.trim().isNotEmpty() || attachments.isNotEmpty()) && healthOk
+    pendingRunCount == 0 &&
+      if (healthOk) {
+        input.trim().isNotEmpty() || attachments.isNotEmpty()
+      } else {
+        input.trim().isNotEmpty() && attachments.isEmpty()
+      }
   val sendBusy = pendingRunCount > 0
 
   Column(modifier = Modifier.fillMaxWidth(), verticalArrangement = Arrangement.spacedBy(8.dp)) {
@@ -179,7 +188,7 @@ fun ChatComposer(
 
     if (!healthOk) {
       Text(
-        text = "Gateway is offline. Open Settings to reconnect.",
+        text = "Gateway is offline. Text messages are queued and sent after reconnecting.",
         style = mobileCallout,
         color = ai.openclaw.app.ui.mobileWarning,
       )
@@ -263,7 +272,14 @@ fun ChatComposer(
           val action = resolveSheetComposerSendAction(input = message)
           if (action.sendMessage || attachments.isNotEmpty()) {
             input = ""
-            onSend(message)
+            sendScope.launch {
+              val accepted = onSend(message)
+              // Refused sends (offline queue full, enqueue failure) must not eat the draft;
+              // restore it unless the user already started typing something new.
+              if (!accepted && input.isEmpty()) {
+                input = message
+              }
+            }
           }
         },
         enabled = canSend,

--- a/apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatMessageListCard.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatMessageListCard.kt
@@ -1,6 +1,7 @@
 package ai.openclaw.app.ui.chat
 
 import ai.openclaw.app.chat.ChatMessage
+import ai.openclaw.app.chat.ChatOutboxItem
 import ai.openclaw.app.chat.ChatPendingToolCall
 import ai.openclaw.app.ui.mobileBorder
 import ai.openclaw.app.ui.mobileCallout
@@ -42,14 +43,18 @@ fun ChatMessageListCard(
   streamingAssistantText: String?,
   healthOk: Boolean,
   modifier: Modifier = Modifier,
+  outboxItems: List<ChatOutboxItem> = emptyList(),
+  onRetryOutbox: (String) -> Unit = {},
+  onDeleteOutbox: (String) -> Unit = {},
 ) {
   val timeline =
-    remember(messages, pendingRunCount, pendingToolCalls, streamingAssistantText) {
+    remember(messages, pendingRunCount, pendingToolCalls, streamingAssistantText, outboxItems) {
       buildChatTimeline(
         messages = messages,
         pendingRunCount = pendingRunCount,
         pendingToolCalls = pendingToolCalls,
         streamingAssistantText = streamingAssistantText,
+        outboxItems = outboxItems,
       )
     }
   val readerScroll =
@@ -72,6 +77,12 @@ fun ChatMessageListCard(
       itemsIndexed(items = timeline.items, key = { _, item -> chatTimelineItemKey(item) }) { _, item ->
         when (item) {
           is ChatTimelineItem.Message -> ChatMessageBubble(message = item.message)
+          is ChatTimelineItem.OutboxCommand ->
+            ChatOutboxBubble(
+              item = item.item,
+              onRetry = { onRetryOutbox(item.item.id) },
+              onDelete = { onDeleteOutbox(item.item.id) },
+            )
           is ChatTimelineItem.PendingTools -> ChatPendingToolsBubble(toolCalls = item.toolCalls)
           is ChatTimelineItem.StreamingAssistant -> ChatStreamingAssistantBubble(text = item.text)
           ChatTimelineItem.Thinking -> ChatTypingIndicatorBubble()

--- a/apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatMessageViews.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatMessageViews.kt
@@ -2,6 +2,8 @@ package ai.openclaw.app.ui.chat
 
 import ai.openclaw.app.chat.ChatMessage
 import ai.openclaw.app.chat.ChatMessageContent
+import ai.openclaw.app.chat.ChatOutboxItem
+import ai.openclaw.app.chat.ChatOutboxStatus
 import ai.openclaw.app.chat.ChatPendingToolCall
 import ai.openclaw.app.tools.ToolDisplayRegistry
 import ai.openclaw.app.ui.mobileAccent
@@ -15,6 +17,7 @@ import ai.openclaw.app.ui.mobileCardSurface
 import ai.openclaw.app.ui.mobileCodeBg
 import ai.openclaw.app.ui.mobileCodeBorder
 import ai.openclaw.app.ui.mobileCodeText
+import ai.openclaw.app.ui.mobileDanger
 import ai.openclaw.app.ui.mobileText
 import ai.openclaw.app.ui.mobileTextSecondary
 import ai.openclaw.app.ui.mobileWarning
@@ -188,6 +191,72 @@ fun ChatPendingToolsBubble(toolCalls: List<ChatPendingToolCall>) {
         )
       }
     }
+  }
+}
+
+/** Queued/failed offline command with inline retry/delete controls; rendered as a user bubble. */
+@Composable
+fun ChatOutboxBubble(
+  item: ChatOutboxItem,
+  onRetry: () -> Unit,
+  onDelete: () -> Unit,
+) {
+  val failed = item.status == ChatOutboxStatus.Failed
+  val statusColor = if (failed) mobileDanger else mobileWarning
+  val statusLabel =
+    when (item.status) {
+      ChatOutboxStatus.Queued -> "Queued — sends when reconnected"
+      ChatOutboxStatus.Sending -> "Sending…"
+      ChatOutboxStatus.Failed ->
+        item.lastError
+          ?.trim()
+          ?.takeIf { it.isNotEmpty() }
+          ?.let { "Failed — $it" } ?: "Failed"
+    }
+
+  ChatBubbleContainer(
+    style = bubbleStyle("user").copy(borderColor = statusColor.copy(alpha = 0.6f)),
+    roleLabel = "You",
+  ) {
+    ChatMarkdown(text = item.text, textColor = mobileText)
+    Row(
+      verticalAlignment = Alignment.CenterVertically,
+      horizontalArrangement = Arrangement.spacedBy(10.dp),
+    ) {
+      Text(
+        text = statusLabel,
+        style = mobileCaption1,
+        color = statusColor,
+        modifier = Modifier.weight(1f),
+      )
+      if (failed) {
+        ChatOutboxAction(label = "Retry", color = mobileAccent, onClick = onRetry)
+      }
+      if (item.status != ChatOutboxStatus.Sending) {
+        ChatOutboxAction(label = "Delete", color = mobileTextSecondary, onClick = onDelete)
+      }
+    }
+  }
+}
+
+@Composable
+private fun ChatOutboxAction(
+  label: String,
+  color: Color,
+  onClick: () -> Unit,
+) {
+  Surface(
+    onClick = onClick,
+    shape = RoundedCornerShape(8.dp),
+    color = Color.Transparent,
+    contentColor = color,
+    border = BorderStroke(1.dp, color.copy(alpha = 0.5f)),
+  ) {
+    Text(
+      text = label,
+      style = mobileCaption1.copy(fontWeight = FontWeight.SemiBold),
+      modifier = Modifier.padding(horizontal = 10.dp, vertical = 5.dp),
+    )
   }
 }
 

--- a/apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt
@@ -4,6 +4,7 @@ import ai.openclaw.app.MainViewModel
 import ai.openclaw.app.chat.ChatCommandEntry
 import ai.openclaw.app.chat.ChatMessage
 import ai.openclaw.app.chat.ChatMessageContent
+import ai.openclaw.app.chat.ChatOutboxItem
 import ai.openclaw.app.chat.ChatPendingToolCall
 import ai.openclaw.app.chat.ChatSessionEntry
 import ai.openclaw.app.chat.OutgoingAttachment
@@ -110,6 +111,7 @@ fun ChatScreen(
   val chatDraft by viewModel.chatDraft.collectAsState()
   val pendingAssistantAutoSend by viewModel.pendingAssistantAutoSend.collectAsState()
   val remoteAddress by viewModel.remoteAddress.collectAsState()
+  val outboxItems by viewModel.chatOutboxItems.collectAsState()
   val manualHost by viewModel.manualHost.collectAsState()
   val manualPort by viewModel.manualPort.collectAsState()
   val manualTls by viewModel.manualTls.collectAsState()
@@ -234,6 +236,14 @@ fun ChatScreen(
       streamingAssistantText = streamingAssistantText,
       healthOk = healthOk,
       gatewayOffline = gatewayOffline,
+      outboxItems =
+        outboxItemsForSession(
+          items = outboxItems,
+          sessionKey = sessionKey,
+          mainSessionKey = mainSessionKey,
+        ),
+      onRetryOutbox = viewModel::retryChatOutboxCommand,
+      onDeleteOutbox = viewModel::deleteChatOutboxCommand,
       onStarterPrompt = { prompt -> input = prompt },
       modifier = Modifier.weight(1f),
     )
@@ -275,10 +285,17 @@ fun ChatScreen(
               base64 = attachment.base64,
             )
           }
+        val pendingAttachments = attachments.toList()
         input = ""
         attachments.clear()
         scope.launch {
-          viewModel.sendChat(message = message, thinking = thinkingLevel, attachments = outgoing)
+          val accepted = viewModel.sendChatAwaitAcceptance(message = message, thinking = thinkingLevel, attachments = outgoing)
+          if (!accepted) {
+            // Refused sends (offline queue full, enqueue failure) must not eat the draft;
+            // restore it unless the user already started typing something new.
+            if (input.isEmpty()) input = message
+            if (attachments.isEmpty()) attachments.addAll(pendingAttachments)
+          }
         }
       },
     )
@@ -501,16 +518,20 @@ private fun ChatMessageList(
   streamingAssistantText: String?,
   healthOk: Boolean,
   gatewayOffline: Boolean,
+  outboxItems: List<ChatOutboxItem>,
+  onRetryOutbox: (String) -> Unit,
+  onDeleteOutbox: (String) -> Unit,
   onStarterPrompt: (String) -> Unit,
   modifier: Modifier = Modifier,
 ) {
   val timeline =
-    remember(messages, pendingRunCount, pendingToolCalls, streamingAssistantText) {
+    remember(messages, pendingRunCount, pendingToolCalls, streamingAssistantText, outboxItems) {
       buildChatTimeline(
         messages = messages,
         pendingRunCount = pendingRunCount,
         pendingToolCalls = pendingToolCalls,
         streamingAssistantText = streamingAssistantText,
+        outboxItems = outboxItems,
       )
     }
   val readerScroll =
@@ -536,6 +557,12 @@ private fun ChatMessageList(
               live = false,
               content = item.message.content,
               timestampMs = item.message.timestampMs,
+            )
+          is ChatTimelineItem.OutboxCommand ->
+            ChatOutboxBubble(
+              item = item.item,
+              onRetry = { onRetryOutbox(item.item.id) },
+              onDelete = { onDeleteOutbox(item.item.id) },
             )
           is ChatTimelineItem.PendingTools -> ToolBubble(toolCalls = item.toolCalls)
           is ChatTimelineItem.StreamingAssistant ->
@@ -868,7 +895,14 @@ private fun ChatComposer(
         modifier = Modifier.weight(1f),
       )
       SendButton(
-        enabled = healthOk && pendingRunCount == 0 && (value.trim().isNotEmpty() || attachments.isNotEmpty()),
+        // Offline, only text sends are enabled: they queue durably (text-only v1).
+        enabled =
+          pendingRunCount == 0 &&
+            if (healthOk) {
+              value.trim().isNotEmpty() || attachments.isNotEmpty()
+            } else {
+              value.trim().isNotEmpty() && attachments.isEmpty()
+            },
         onClick = onSend,
       )
     }

--- a/apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatSheetContent.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatSheetContent.kt
@@ -101,6 +101,7 @@ fun ChatSheetContent(viewModel: MainViewModel) {
   val chatCommands by viewModel.chatCommands.collectAsState()
   val chatDraft by viewModel.chatDraft.collectAsState()
   val pendingAssistantAutoSend by viewModel.pendingAssistantAutoSend.collectAsState()
+  val outboxItems by viewModel.chatOutboxItems.collectAsState()
 
   LaunchedEffect(Unit) {
     val loadSessionKey = resolveInitialChatLoadSessionKey(sessionKey, mainSessionKey)
@@ -182,6 +183,14 @@ fun ChatSheetContent(viewModel: MainViewModel) {
       streamingAssistantText = streamingAssistantText,
       healthOk = healthOk,
       modifier = Modifier.weight(1f, fill = true),
+      outboxItems =
+        outboxItemsForSession(
+          items = outboxItems,
+          sessionKey = sessionKey,
+          mainSessionKey = mainSessionKey,
+        ),
+      onRetryOutbox = viewModel::retryChatOutboxCommand,
+      onDeleteOutbox = viewModel::deleteChatOutboxCommand,
     )
 
     Row(modifier = Modifier.fillMaxWidth().imePadding()) {
@@ -212,8 +221,14 @@ fun ChatSheetContent(viewModel: MainViewModel) {
                 base64 = att.base64,
               )
             }
-          viewModel.sendChat(message = text, thinking = thinkingLevel, attachments = outgoing)
+          val pendingAttachments = attachments.toList()
           attachments.clear()
+          val accepted = viewModel.sendChatAwaitAcceptance(message = text, thinking = thinkingLevel, attachments = outgoing)
+          if (!accepted && attachments.isEmpty()) {
+            // Refused sends must not silently drop selected attachments either.
+            attachments.addAll(pendingAttachments)
+          }
+          accepted
         },
       )
     }

--- a/apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatTimeline.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatTimeline.kt
@@ -1,11 +1,17 @@
 package ai.openclaw.app.ui.chat
 
 import ai.openclaw.app.chat.ChatMessage
+import ai.openclaw.app.chat.ChatOutboxItem
 import ai.openclaw.app.chat.ChatPendingToolCall
 
 internal sealed class ChatTimelineItem {
   data class Message(
     val message: ChatMessage,
+  ) : ChatTimelineItem()
+
+  /** Durable queued/failed offline command shown below the transcript until acked or deleted. */
+  data class OutboxCommand(
+    val item: ChatOutboxItem,
   ) : ChatTimelineItem()
 
   data class StreamingAssistant(
@@ -33,10 +39,13 @@ internal fun buildChatTimeline(
   pendingRunCount: Int,
   pendingToolCalls: List<ChatPendingToolCall>,
   streamingAssistantText: String?,
+  outboxItems: List<ChatOutboxItem> = emptyList(),
 ): ChatTimeline {
   val stream = streamingAssistantText?.trim()?.takeIf { it.isNotEmpty() }
   val items =
     buildList {
+      // reverseLayout: index 0 renders bottom-most; queued commands are the newest user input.
+      outboxItems.asReversed().forEach { item -> add(ChatTimelineItem.OutboxCommand(item)) }
       if (stream != null) add(ChatTimelineItem.StreamingAssistant(stream))
       if (pendingToolCalls.isNotEmpty()) add(ChatTimelineItem.PendingTools(pendingToolCalls))
       if (pendingRunCount > 0) add(ChatTimelineItem.Thinking)
@@ -74,8 +83,25 @@ internal fun buildChatTimeline(
     latestContentIndex = latestContentIndex,
     latestUserMessageId = latestUserMessage?.id,
     latestUserMessageVersion = latestUserMessage?.let(::stableMessageVersion),
-    latestContentVersion = latestContentVersion(messages, pendingRunCount, pendingToolCalls, stream),
+    latestContentVersion = latestContentVersion(messages, pendingRunCount, pendingToolCalls, stream, outboxItems),
   )
+}
+
+/**
+ * Outbox rows for the visible session. Rows enqueued under the "main" alias still belong to the
+ * canonical main session once the gateway hello rewrites the current key.
+ */
+internal fun outboxItemsForSession(
+  items: List<ChatOutboxItem>,
+  sessionKey: String,
+  mainSessionKey: String,
+): List<ChatOutboxItem> {
+  val mainKey = mainSessionKey.trim().ifEmpty { "main" }
+  val current = sessionKey.trim().let { if (it == "main") mainKey else it }
+  return items.filter { item ->
+    val itemKey = item.sessionKey.let { if (it == "main") mainKey else it }
+    itemKey == current
+  }
 }
 
 private fun stableMessageVersion(message: ChatMessage): String {
@@ -115,6 +141,7 @@ private fun latestContentVersion(
   pendingRunCount: Int,
   pendingToolCalls: List<ChatPendingToolCall>,
   stream: String?,
+  outboxItems: List<ChatOutboxItem> = emptyList(),
 ): String {
   val latest = messages.lastOrNull()
   return buildString {
@@ -150,12 +177,20 @@ private fun latestContentVersion(
     }
     append(":stream=")
     append(stream?.hashCode() ?: 0)
+    append(":outbox=")
+    outboxItems.forEach { item ->
+      append(item.id)
+      append(',')
+      append(item.status)
+      append(';')
+    }
   }
 }
 
 internal fun chatTimelineItemKey(item: ChatTimelineItem): String =
   when (item) {
     is ChatTimelineItem.Message -> "message:${item.message.id}"
+    is ChatTimelineItem.OutboxCommand -> "outbox:${item.item.id}"
     is ChatTimelineItem.PendingTools -> "tools"
     is ChatTimelineItem.StreamingAssistant -> "stream"
     ChatTimelineItem.Thinking -> "thinking"

--- a/apps/android/app/src/test/java/ai/openclaw/app/GatewayBootstrapAuthTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/GatewayBootstrapAuthTest.kt
@@ -604,7 +604,7 @@ class GatewayBootstrapAuthTest {
     authStore.saveToken(deviceId, "node", "stale-node-token")
     authStore.saveToken(deviceId, "operator", "stale-operator-token")
 
-    runtime.resetGatewaySetupAuth()
+    runBlocking { runtime.resetGatewaySetupAuth() }
 
     assertNull(prefs.loadGatewayToken())
     assertNull(prefs.loadGatewayBootstrapToken())

--- a/apps/android/app/src/test/java/ai/openclaw/app/chat/ChatControllerOutboxTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/chat/ChatControllerOutboxTest.kt
@@ -1,0 +1,560 @@
+package ai.openclaw.app.chat
+
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runCurrent
+import kotlinx.coroutines.test.runTest
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.util.UUID
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class ChatControllerOutboxTest {
+  private val json = Json { ignoreUnknownKeys = true }
+
+  /** In-memory stand-in for the Room outbox; Room persistence itself is covered by [RoomChatCommandOutboxTest]. */
+  private class FakeCommandOutbox(
+    private val capacity: Int = OUTBOX_MAX_QUEUED,
+  ) : ChatCommandOutbox {
+    val rows = LinkedHashMap<String, ChatOutboxItem>()
+    val deletedSessions = mutableListOf<String>()
+    private var nextCreatedAt = 0L
+
+    fun seed(item: ChatOutboxItem) {
+      rows[item.id] = item
+      nextCreatedAt = maxOf(nextCreatedAt, item.createdAtMs + 1)
+    }
+
+    override suspend fun load(gatewayId: String): List<ChatOutboxItem> = rows.values.sortedWith(compareBy({ it.createdAtMs }, { it.id }))
+
+    override suspend fun enqueue(
+      gatewayId: String,
+      sessionKey: String,
+      text: String,
+      thinkingLevel: String,
+      nowMs: Long,
+    ): ChatOutboxEnqueueResult {
+      if (rows.size >= capacity) return ChatOutboxEnqueueResult.QueueFull
+      val createdAt = maxOf(nowMs, nextCreatedAt)
+      nextCreatedAt = createdAt + 1
+      val item =
+        ChatOutboxItem(
+          id = UUID.randomUUID().toString(),
+          sessionKey = sessionKey,
+          text = text,
+          thinkingLevel = thinkingLevel,
+          createdAtMs = createdAt,
+          status = ChatOutboxStatus.Queued,
+          retryCount = 0,
+          lastError = null,
+        )
+      rows[item.id] = item
+      return ChatOutboxEnqueueResult.Queued(item)
+    }
+
+    override suspend fun updateStatus(
+      id: String,
+      status: ChatOutboxStatus,
+      retryCount: Int,
+      lastError: String?,
+    ): Int {
+      val current = rows[id] ?: return 0
+      rows[id] = current.copy(status = status, retryCount = retryCount, lastError = lastError)
+      return 1
+    }
+
+    override suspend fun requeueForRetry(
+      gatewayId: String,
+      id: String,
+      nowMs: Long,
+    ) {
+      val current = rows[id] ?: return
+      val createdAt = maxOf(nowMs, nextCreatedAt)
+      nextCreatedAt = createdAt + 1
+      rows[id] = current.copy(status = ChatOutboxStatus.Queued, retryCount = 0, lastError = null, createdAtMs = createdAt)
+    }
+
+    override suspend fun delete(id: String) {
+      rows.remove(id)
+    }
+
+    override suspend fun deleteForSession(
+      gatewayId: String,
+      sessionKey: String,
+    ) {
+      deletedSessions += sessionKey
+      rows.values.removeAll { it.sessionKey == sessionKey }
+    }
+
+    override suspend fun requeueSendingAfterRestart() {
+      for ((id, item) in rows) {
+        if (item.status == ChatOutboxStatus.Sending) {
+          rows[id] = item.copy(status = ChatOutboxStatus.Queued)
+        }
+      }
+    }
+
+    override suspend fun expireStale(
+      gatewayId: String,
+      nowMs: Long,
+    ) {
+      for ((id, item) in rows) {
+        if (item.status == ChatOutboxStatus.Queued && item.createdAtMs <= nowMs - OUTBOX_EXPIRY_MS) {
+          rows[id] = item.copy(status = ChatOutboxStatus.Failed, lastError = OUTBOX_EXPIRED_ERROR)
+        }
+      }
+    }
+
+    override suspend fun clearAll() {
+      rows.clear()
+    }
+  }
+
+  /** Toggleable gateway seam: records chat.send idempotency keys and echoes them as run ids. */
+  private inner class FakeGateway {
+    var online = false
+    var failSendsWithTransportError = false
+    var sendResponse: (idempotencyKey: String) -> String = { key -> """{"runId":"$key"}""" }
+    val sentIdempotencyKeys = mutableListOf<String>()
+    val sentMessages = mutableListOf<String>()
+    val sentSessionKeys = mutableListOf<String>()
+    val sentThinkingLevels = mutableListOf<String>()
+    var historyMessagesJson = "[]"
+
+    suspend fun request(
+      method: String,
+      paramsJson: String?,
+    ): String {
+      if (!online) throw IllegalStateException("offline")
+      return when (method) {
+        "chat.send" -> {
+          if (failSendsWithTransportError) throw IllegalStateException("socket closed")
+          val params = json.parseToJsonElement(paramsJson.orEmpty()) as JsonObject
+          val key = (params["idempotencyKey"] as JsonPrimitive).content
+          sentIdempotencyKeys += key
+          sentMessages += (params["message"] as JsonPrimitive).content
+          sentSessionKeys += (params["sessionKey"] as JsonPrimitive).content
+          sentThinkingLevels += (params["thinking"] as JsonPrimitive).content
+          sendResponse(key)
+        }
+        "chat.history" -> """{"sessionId":"session-1","messages":$historyMessagesJson}"""
+        else -> "{}"
+      }
+    }
+  }
+
+  private fun controller(
+    scope: CoroutineScope,
+    gateway: FakeGateway,
+    outbox: ChatCommandOutbox,
+  ): ChatController =
+    ChatController(
+      scope = scope,
+      json = json,
+      requestGateway = gateway::request,
+      cacheScope = { ChatCacheScope(gatewayId = "gateway-test", connectionGeneration = 1L) },
+      commandOutbox = outbox,
+    )
+
+  @Test
+  fun enqueueWhileOfflineShowsQueuedRowAndSurvivesControllerRecreation() =
+    runTest {
+      val gateway = FakeGateway()
+      val outbox = FakeCommandOutbox()
+      val first = controller(this, gateway, outbox)
+      first.load("main")
+      advanceUntilIdle()
+      assertFalse(first.healthOk.value)
+
+      val accepted = first.sendMessageAwaitAcceptance(message = "offline hello", thinkingLevel = "off", attachments = emptyList())
+
+      assertTrue(accepted)
+      val queuedRow = first.outboxItems.value.single()
+      assertEquals("offline hello", queuedRow.text)
+      assertEquals(ChatOutboxStatus.Queued, queuedRow.status)
+
+      // Recreated controller (fresh process analog) republishes the durable row.
+      val second = controller(this, gateway, outbox)
+      advanceUntilIdle()
+      assertEquals(listOf("offline hello"), second.outboxItems.value.map { it.text })
+    }
+
+  @Test
+  fun offlineAttachmentSendsAreRejectedInsteadOfQueued() =
+    runTest {
+      val gateway = FakeGateway()
+      val outbox = FakeCommandOutbox()
+      val chat = controller(this, gateway, outbox)
+      chat.load("main")
+      advanceUntilIdle()
+
+      val accepted =
+        chat.sendMessageAwaitAcceptance(
+          message = "with image",
+          thinkingLevel = "off",
+          attachments = listOf(OutgoingAttachment(type = "image", mimeType = "image/png", fileName = "a.png", base64 = "AAAA")),
+        )
+
+      assertFalse(accepted)
+      assertEquals("Gateway health not OK; cannot send", chat.errorText.value)
+      assertTrue(outbox.rows.isEmpty())
+    }
+
+  @Test
+  fun reconnectFlushesQueuedCommandsInOrderWithRowIdsAsIdempotencyKeys() =
+    runTest {
+      val gateway = FakeGateway()
+      val outbox = FakeCommandOutbox()
+      val chat = controller(this, gateway, outbox)
+      chat.load("main")
+      advanceUntilIdle()
+
+      chat.sendMessageAwaitAcceptance(message = "one", thinkingLevel = "high", attachments = emptyList())
+      chat.sendMessageAwaitAcceptance(message = "two", thinkingLevel = "off", attachments = emptyList())
+      chat.sendMessageAwaitAcceptance(message = "three", thinkingLevel = "off", attachments = emptyList())
+      val queuedIds = chat.outboxItems.value.map { it.id }
+      assertEquals(3, queuedIds.size)
+      // A later selector change must not rewrite the thinking level of already-queued sends.
+      chat.setThinkingLevel("low")
+
+      gateway.online = true
+      chat.handleGatewayEvent("health", null)
+      advanceUntilIdle()
+
+      assertEquals(listOf("one", "two", "three"), gateway.sentMessages)
+      assertEquals(queuedIds, gateway.sentIdempotencyKeys)
+      assertEquals(listOf("main", "main", "main"), gateway.sentSessionKeys)
+      assertEquals(listOf("high", "off", "off"), gateway.sentThinkingLevels)
+      assertTrue(chat.outboxItems.value.isEmpty())
+    }
+
+  @Test
+  fun mainAliasRowsFlushToCanonicalMainSessionAfterHello() =
+    runTest {
+      val gateway = FakeGateway()
+      val outbox = FakeCommandOutbox()
+      val chat = controller(this, gateway, outbox)
+      chat.load("main")
+      advanceUntilIdle()
+      chat.sendMessageAwaitAcceptance(message = "queued pre-hello", thinkingLevel = "off", attachments = emptyList())
+      val queuedRow = chat.outboxItems.value.single()
+      assertEquals("main", queuedRow.sessionKey)
+
+      // Gateway hello announces the canonical main session key, then health recovers.
+      gateway.online = true
+      chat.applyMainSessionKey("agent:work:main")
+      advanceUntilIdle()
+      chat.handleGatewayEvent("health", null)
+      advanceUntilIdle()
+
+      assertEquals(listOf("agent:work:main"), gateway.sentSessionKeys)
+      assertTrue(chat.outboxItems.value.isEmpty())
+    }
+
+  @Test
+  fun ackRemovesRowAndHistoryCopyIsTheOnlyBubble() =
+    runTest {
+      val gateway = FakeGateway()
+      val outbox = FakeCommandOutbox()
+      val chat = controller(this, gateway, outbox)
+      chat.load("main")
+      advanceUntilIdle()
+
+      chat.sendMessageAwaitAcceptance(message = "queued text", thinkingLevel = "off", attachments = emptyList())
+      val queuedRow = chat.outboxItems.value.single()
+      val queuedId = queuedRow.id
+
+      // The post-flush history refresh returns the durable copy keyed by the row id.
+      gateway.historyMessagesJson =
+        """[{ "role": "user", "content": "queued text", "timestamp": 10, "idempotencyKey": "$queuedId" }]"""
+      gateway.online = true
+      chat.handleGatewayEvent("health", null)
+      advanceUntilIdle()
+
+      assertTrue(chat.outboxItems.value.isEmpty())
+      val userCopies = chat.messages.value.filter { message -> message.content.any { it.text == "queued text" } }
+      assertEquals(1, userCopies.size)
+      assertEquals(queuedId, userCopies.single().idempotencyKey)
+    }
+
+  @Test
+  fun gatewayScopeSwitchDuringRetryBackoffStopsTheFlushWithoutReplaying() =
+    runTest {
+      val gateway = FakeGateway()
+      val outbox = FakeCommandOutbox()
+      var activeScope: ChatCacheScope? = ChatCacheScope(gatewayId = "gateway-test", connectionGeneration = 1L)
+      val chat =
+        ChatController(
+          scope = this,
+          json = json,
+          requestGateway = gateway::request,
+          cacheScope = { activeScope },
+          commandOutbox = outbox,
+        )
+      chat.load("main")
+      advanceUntilIdle()
+      chat.sendMessageAwaitAcceptance(message = "old gateway text", thinkingLevel = "off", attachments = emptyList())
+
+      gateway.online = true
+      gateway.sendResponse = { """{"status":"error"}""" }
+      chat.handleGatewayEvent("health", null)
+      // Run up to the retry backoff delay, then switch the gateway scope while it is pending.
+      runCurrent()
+      activeScope = ChatCacheScope(gatewayId = "gateway-other", connectionGeneration = 2L)
+      advanceUntilIdle()
+
+      // Only the pre-switch attempt happened; the captured row was not replayed into the new scope.
+      assertEquals(1, gateway.sentIdempotencyKeys.size)
+      val row = outbox.rows.values.single()
+      assertEquals(ChatOutboxStatus.Queued, row.status)
+      assertEquals(1, row.retryCount)
+    }
+
+  @Test
+  fun rowDeletedDuringRetryBackoffIsNeverResent() =
+    runTest {
+      val gateway = FakeGateway()
+      val outbox = FakeCommandOutbox()
+      val chat = controller(this, gateway, outbox)
+      chat.load("main")
+      advanceUntilIdle()
+      chat.sendMessageAwaitAcceptance(message = "deleted mid-retry", thinkingLevel = "off", attachments = emptyList())
+      val queuedRow = chat.outboxItems.value.single()
+      val id = queuedRow.id
+
+      gateway.online = true
+      gateway.sendResponse = { """{"status":"error"}""" }
+      chat.handleGatewayEvent("health", null)
+      // Run up to the retry backoff delay; the row stays 'sending' so the UI offers no actions.
+      runCurrent()
+      assertEquals(ChatOutboxStatus.Sending, outbox.rows.getValue(id).status)
+      // Simulate the row disappearing through a non-UI path (e.g. session purge) mid-backoff.
+      outbox.rows.remove(id)
+      advanceUntilIdle()
+
+      // The post-delay re-claim found no row, so the captured text was not sent again.
+      assertEquals(1, gateway.sentIdempotencyKeys.size)
+      assertTrue(outbox.rows.isEmpty())
+      assertTrue(chat.outboxItems.value.isEmpty())
+    }
+
+  @Test
+  fun sendFailuresBackOffThenParkAsFailedAfterMaxAttempts() =
+    runTest {
+      val gateway = FakeGateway()
+      val outbox = FakeCommandOutbox()
+      val chat = controller(this, gateway, outbox)
+      chat.load("main")
+      advanceUntilIdle()
+      chat.sendMessageAwaitAcceptance(message = "doomed", thinkingLevel = "off", attachments = emptyList())
+
+      gateway.online = true
+      gateway.sendResponse = { """{"status":"error"}""" }
+      chat.handleGatewayEvent("health", null)
+      advanceUntilIdle()
+
+      assertEquals(OUTBOX_MAX_SEND_ATTEMPTS, gateway.sentIdempotencyKeys.size)
+      val failed = chat.outboxItems.value.single()
+      assertEquals(ChatOutboxStatus.Failed, failed.status)
+      assertEquals(OUTBOX_MAX_SEND_ATTEMPTS, failed.retryCount)
+      assertNotNull(failed.lastError)
+    }
+
+  @Test
+  fun transportFailureKeepsRowQueuedForNextReconnectInsteadOfBurningAttempts() =
+    runTest {
+      val gateway = FakeGateway()
+      val outbox = FakeCommandOutbox()
+      val chat = controller(this, gateway, outbox)
+      chat.load("main")
+      advanceUntilIdle()
+      chat.sendMessageAwaitAcceptance(message = "survives drops", thinkingLevel = "off", attachments = emptyList())
+
+      gateway.online = true
+      gateway.failSendsWithTransportError = true
+      chat.handleGatewayEvent("health", null)
+      advanceUntilIdle()
+
+      // No ack means delivery state is unknown: the row must stay queued with attempts intact.
+      val row = chat.outboxItems.value.single()
+      assertEquals(ChatOutboxStatus.Queued, row.status)
+      assertEquals(0, row.retryCount)
+      assertFalse(chat.healthOk.value)
+
+      gateway.failSendsWithTransportError = false
+      chat.handleGatewayEvent("health", null)
+      advanceUntilIdle()
+
+      assertEquals(listOf("survives drops"), gateway.sentMessages)
+      assertTrue(chat.outboxItems.value.isEmpty())
+    }
+
+  @Test
+  fun retryResetsFailedRowAndFlushesImmediately() =
+    runTest {
+      val gateway = FakeGateway()
+      val outbox = FakeCommandOutbox()
+      outbox.seed(
+        ChatOutboxItem(
+          id = "failed-row",
+          sessionKey = "main",
+          text = "try me again",
+          thinkingLevel = "off",
+          // Recent timestamp: the startup/flush expiry sweep must not expire this row.
+          createdAtMs = System.currentTimeMillis(),
+          status = ChatOutboxStatus.Failed,
+          retryCount = OUTBOX_MAX_SEND_ATTEMPTS,
+          lastError = "boom",
+        ),
+      )
+      val chat = controller(this, gateway, outbox)
+      gateway.online = true
+      chat.load("main")
+      advanceUntilIdle()
+      assertTrue(chat.healthOk.value)
+      val seededRow = chat.outboxItems.value.single()
+      assertEquals(ChatOutboxStatus.Failed, seededRow.status)
+
+      chat.retryOutboxCommand("failed-row")
+      advanceUntilIdle()
+
+      assertEquals(listOf("failed-row"), gateway.sentIdempotencyKeys)
+      assertTrue(chat.outboxItems.value.isEmpty())
+    }
+
+  @Test
+  fun deleteRemovesQueuedRow() =
+    runTest {
+      val gateway = FakeGateway()
+      val outbox = FakeCommandOutbox()
+      val chat = controller(this, gateway, outbox)
+      chat.load("main")
+      advanceUntilIdle()
+      chat.sendMessageAwaitAcceptance(message = "delete me", thinkingLevel = "off", attachments = emptyList())
+      val queuedRow = chat.outboxItems.value.single()
+      val id = queuedRow.id
+
+      chat.deleteOutboxCommand(id)
+      advanceUntilIdle()
+
+      assertTrue(chat.outboxItems.value.isEmpty())
+      assertTrue(outbox.rows.isEmpty())
+    }
+
+  @Test
+  fun queueFullRefusalSurfacesErrorWithoutQueueing() =
+    runTest {
+      val gateway = FakeGateway()
+      val outbox = FakeCommandOutbox(capacity = 1)
+      val chat = controller(this, gateway, outbox)
+      chat.load("main")
+      advanceUntilIdle()
+      assertTrue(chat.sendMessageAwaitAcceptance(message = "fits", thinkingLevel = "off", attachments = emptyList()))
+
+      val accepted = chat.sendMessageAwaitAcceptance(message = "overflow", thinkingLevel = "off", attachments = emptyList())
+
+      assertFalse(accepted)
+      assertEquals(1, outbox.rows.size)
+      val errorText = chat.errorText.value.orEmpty()
+      assertTrue(errorText.contains("full"))
+    }
+
+  @Test
+  fun sendingRowsRecoverToQueuedOnControllerStartup() =
+    runTest {
+      val gateway = FakeGateway()
+      val outbox = FakeCommandOutbox()
+      outbox.seed(
+        ChatOutboxItem(
+          id = "interrupted",
+          sessionKey = "main",
+          text = "crashed mid-send",
+          thinkingLevel = "off",
+          // Recent timestamp: the startup expiry sweep must not expire the recovered row.
+          createdAtMs = System.currentTimeMillis(),
+          status = ChatOutboxStatus.Sending,
+          retryCount = 1,
+          lastError = "socket closed",
+        ),
+      )
+
+      val chat = controller(this, gateway, outbox)
+      advanceUntilIdle()
+
+      val recovered = chat.outboxItems.value.single()
+      assertEquals(ChatOutboxStatus.Queued, recovered.status)
+      assertEquals(1, recovered.retryCount)
+    }
+
+  @Test
+  fun staleQueuedRowsExpireToFailedInsteadOfSendingOnReconnect() =
+    runTest {
+      val gateway = FakeGateway()
+      val outbox = FakeCommandOutbox()
+      outbox.seed(
+        ChatOutboxItem(
+          id = "stale",
+          sessionKey = "main",
+          text = "two days old",
+          thinkingLevel = "off",
+          createdAtMs = System.currentTimeMillis() - OUTBOX_EXPIRY_MS,
+          status = ChatOutboxStatus.Queued,
+          retryCount = 0,
+          lastError = null,
+        ),
+      )
+      val chat = controller(this, gateway, outbox)
+      gateway.online = true
+      chat.handleGatewayEvent("health", null)
+      advanceUntilIdle()
+
+      assertTrue(gateway.sentIdempotencyKeys.isEmpty())
+      val expired = chat.outboxItems.value.single()
+      assertEquals(ChatOutboxStatus.Failed, expired.status)
+      assertEquals(OUTBOX_EXPIRED_ERROR, expired.lastError)
+
+      // Retrying an expired row refreshes its createdAt, so the flush sweep cannot
+      // immediately re-expire it and the send actually happens.
+      chat.retryOutboxCommand("stale")
+      advanceUntilIdle()
+      assertEquals(listOf("stale"), gateway.sentIdempotencyKeys)
+      assertTrue(chat.outboxItems.value.isEmpty())
+    }
+
+  @Test
+  fun sessionDeleteEventPurgesThatSessionsOutboxRows() =
+    runTest {
+      val gateway = FakeGateway()
+      val outbox = FakeCommandOutbox()
+      outbox.seed(
+        ChatOutboxItem(
+          id = "doomed-session-row",
+          sessionKey = "agent:old:main",
+          text = "orphaned",
+          thinkingLevel = "off",
+          createdAtMs = 5,
+          status = ChatOutboxStatus.Queued,
+          retryCount = 0,
+          lastError = null,
+        ),
+      )
+      val chat = controller(this, gateway, outbox)
+      advanceUntilIdle()
+
+      chat.handleGatewayEvent(
+        "sessions.changed",
+        """{"reason":"delete","sessionKey":"agent:old:main"}""",
+      )
+      advanceUntilIdle()
+
+      assertEquals(listOf("agent:old:main"), outbox.deletedSessions)
+      assertTrue(chat.outboxItems.value.isEmpty())
+    }
+}

--- a/apps/android/app/src/test/java/ai/openclaw/app/chat/RoomChatCommandOutboxTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/chat/RoomChatCommandOutboxTest.kt
@@ -1,0 +1,186 @@
+package ai.openclaw.app.chat
+
+import androidx.room.Room
+import kotlinx.coroutines.test.runTest
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.RuntimeEnvironment
+
+@RunWith(RobolectricTestRunner::class)
+class RoomChatCommandOutboxTest {
+  private val database: ChatCacheDatabase =
+    Room
+      .inMemoryDatabaseBuilder(RuntimeEnvironment.getApplication(), ChatCacheDatabase::class.java)
+      .build()
+
+  private val store = RoomChatCommandOutbox(database = database)
+
+  @After
+  fun tearDown() {
+    database.close()
+  }
+
+  private suspend fun ChatCommandOutbox.enqueueQueued(
+    text: String,
+    nowMs: Long,
+    gatewayId: String = "gateway-a",
+    sessionKey: String = "main",
+    thinkingLevel: String = "off",
+  ): ChatOutboxItem {
+    val result =
+      enqueue(gatewayId = gatewayId, sessionKey = sessionKey, text = text, thinkingLevel = thinkingLevel, nowMs = nowMs)
+    return (result as ChatOutboxEnqueueResult.Queued).item
+  }
+
+  @Test
+  fun enqueuePersistsAndLoadsInEnqueueOrderEvenForCollidingClocks() =
+    runTest {
+      store.enqueueQueued("first", nowMs = 20, thinkingLevel = "high")
+      // Same millisecond and a backwards clock must not scramble FIFO flush order.
+      store.enqueueQueued("second", nowMs = 20)
+      store.enqueueQueued("third", nowMs = 10)
+
+      val loaded = store.load("gateway-a")
+
+      assertEquals(listOf("first", "second", "third"), loaded.map { it.text })
+      assertTrue(loaded.all { it.status == ChatOutboxStatus.Queued && it.retryCount == 0 && it.lastError == null })
+      assertEquals(listOf("main", "main", "main"), loaded.map { it.sessionKey })
+      // Enqueue-time thinking level survives the round trip.
+      assertEquals(listOf("high", "off", "off"), loaded.map { it.thinkingLevel })
+      assertEquals(loaded.map { it.createdAtMs }.sorted(), loaded.map { it.createdAtMs })
+    }
+
+  @Test
+  fun enqueueRefusesBeyondMaxQueued() =
+    runTest {
+      repeat(OUTBOX_MAX_QUEUED) { index ->
+        store.enqueueQueued("m$index", nowMs = index.toLong())
+      }
+
+      val refused =
+        store.enqueue(gatewayId = "gateway-a", sessionKey = "main", text = "overflow", thinkingLevel = "off", nowMs = 999)
+
+      assertEquals(ChatOutboxEnqueueResult.QueueFull, refused)
+      assertEquals(OUTBOX_MAX_QUEUED, store.load("gateway-a").size)
+    }
+
+  @Test
+  fun expireStaleFailsRowsAtOrPastTheBoundaryOnly() =
+    runTest {
+      val now = 1_000_000_000L
+      val atBoundary = store.enqueueQueued("stale", nowMs = now - OUTBOX_EXPIRY_MS)
+      val justInside = store.enqueueQueued("fresh", nowMs = now - OUTBOX_EXPIRY_MS + 1)
+
+      store.expireStale("gateway-a", nowMs = now)
+
+      val byId = store.load("gateway-a").associateBy { it.id }
+      assertEquals(ChatOutboxStatus.Failed, byId.getValue(atBoundary.id).status)
+      assertEquals(OUTBOX_EXPIRED_ERROR, byId.getValue(atBoundary.id).lastError)
+      assertEquals(ChatOutboxStatus.Queued, byId.getValue(justInside.id).status)
+      assertNull(byId.getValue(justInside.id).lastError)
+    }
+
+  @Test
+  fun expireStaleLeavesFailedAndSendingRowsUntouched() =
+    runTest {
+      val now = 1_000_000_000L
+      val failed = store.enqueueQueued("already failed", nowMs = now - OUTBOX_EXPIRY_MS - 5)
+      store.updateStatus(failed.id, ChatOutboxStatus.Failed, retryCount = 3, lastError = "boom")
+      val sending = store.enqueueQueued("in flight", nowMs = now - OUTBOX_EXPIRY_MS - 5)
+      store.updateStatus(sending.id, ChatOutboxStatus.Sending, retryCount = 0, lastError = null)
+
+      store.expireStale("gateway-a", nowMs = now)
+
+      val byId = store.load("gateway-a").associateBy { it.id }
+      assertEquals("boom", byId.getValue(failed.id).lastError)
+      assertEquals(ChatOutboxStatus.Sending, byId.getValue(sending.id).status)
+    }
+
+  @Test
+  fun requeueSendingAfterRestartRecoversInterruptedRows() =
+    runTest {
+      val interrupted = store.enqueueQueued("interrupted", nowMs = 10)
+      store.updateStatus(interrupted.id, ChatOutboxStatus.Sending, retryCount = 1, lastError = "socket closed")
+      val failed = store.enqueueQueued("dead", nowMs = 20)
+      store.updateStatus(failed.id, ChatOutboxStatus.Failed, retryCount = 3, lastError = "boom")
+
+      store.requeueSendingAfterRestart()
+
+      val byId = store.load("gateway-a").associateBy { it.id }
+      assertEquals(ChatOutboxStatus.Queued, byId.getValue(interrupted.id).status)
+      // Retry bookkeeping survives the restart; only the stuck status is repaired.
+      assertEquals(1, byId.getValue(interrupted.id).retryCount)
+      assertEquals(ChatOutboxStatus.Failed, byId.getValue(failed.id).status)
+    }
+
+  @Test
+  fun requeueForRetryRefreshesCreatedAtSoExpirySweepCannotRefailIt() =
+    runTest {
+      val now = 1_000_000_000L
+      val stale = store.enqueueQueued("expired once", nowMs = now - OUTBOX_EXPIRY_MS - 10)
+      store.expireStale("gateway-a", nowMs = now)
+      assertEquals(ChatOutboxStatus.Failed, store.load("gateway-a").single().status)
+
+      store.requeueForRetry(gatewayId = "gateway-a", id = stale.id, nowMs = now)
+      store.expireStale("gateway-a", nowMs = now)
+
+      val retried = store.load("gateway-a").single()
+      assertEquals(ChatOutboxStatus.Queued, retried.status)
+      assertEquals(0, retried.retryCount)
+      assertNull(retried.lastError)
+      assertTrue(retried.createdAtMs >= now)
+    }
+
+  @Test
+  fun rowsAreScopedToGatewayIdentity() =
+    runTest {
+      store.enqueueQueued("gateway a command", nowMs = 10, gatewayId = "gateway-a")
+
+      assertEquals(emptyList<ChatOutboxItem>(), store.load("gateway-b"))
+      store.enqueueQueued("gateway b command", nowMs = 20, gatewayId = "gateway-b")
+
+      assertEquals(listOf("gateway a command"), store.load("gateway-a").map { it.text })
+      assertEquals(listOf("gateway b command"), store.load("gateway-b").map { it.text })
+    }
+
+  @Test
+  fun blankGatewayIdentityDisablesReadsAndWrites() =
+    runTest {
+      assertEquals(
+        ChatOutboxEnqueueResult.Unavailable,
+        store.enqueue(gatewayId = " ", sessionKey = "main", text = "hi", thinkingLevel = "off", nowMs = 1),
+      )
+      assertEquals(emptyList<ChatOutboxItem>(), store.load(" "))
+
+      // Nothing was written under a fallback scope either.
+      assertEquals(emptyList<ChatOutboxItem>(), store.load("gateway-a"))
+    }
+
+  @Test
+  fun deleteForSessionRemovesOnlyThatSessionsRows() =
+    runTest {
+      store.enqueueQueued("for main", nowMs = 10)
+      store.enqueueQueued("for other", nowMs = 20, sessionKey = "agent:other:main")
+
+      store.deleteForSession("gateway-a", "main")
+
+      assertEquals(listOf("for other"), store.load("gateway-a").map { it.text })
+    }
+
+  @Test
+  fun clearAllPurgesEveryGatewayScope() =
+    runTest {
+      store.enqueueQueued("a command", nowMs = 10, gatewayId = "gateway-a")
+      store.enqueueQueued("b command", nowMs = 20, gatewayId = "gateway-b")
+
+      store.clearAll()
+
+      assertEquals(emptyList<ChatOutboxItem>(), store.load("gateway-a"))
+      assertEquals(emptyList<ChatOutboxItem>(), store.load("gateway-b"))
+    }
+}


### PR DESCRIPTION
**Stacked on the Android chat offline cache branch (#100227, `feat/android-chat-offline-cache`); lands after it.**

Part of #46664

## What Problem This Solves

Text commands typed while the gateway is unreachable are currently refused with an error and lost. Users routinely open chat while disconnected (transit, flaky Wi-Fi, gateway restart) and expect what they typed to be delivered once the connection returns.

## Why This Change Was Made

A durable outbox lets users keep issuing text commands offline and have them delivered in order after reconnect, without inventing a second reachability source or a new store: it extends the existing chat cache database (schema v2, destructive migration per that DB's established contract) and the existing gateway-health transition as the flush trigger. Every row's UUID is its `chat.send` idempotency key, so delivery is at-least-once with gateway-side dedup — history replaces each queued bubble exactly once. Conservative defaults: 50 queued per gateway, 48h expiry to "failed (expired)" instead of firing stale commands, 3 send attempts with backoff, transport drops keep rows queued without burning attempts, `sending` rows revert to `queued` on startup, and pairing/auth resets purge the outbox with the cache. Text-only v1; attachments stay online-only.

## User Impact

- Sending a text message while offline queues it durably: it appears in the transcript immediately with a "Queued — sends when reconnected" state and survives app restarts.
- On reconnect, queued messages flush strictly in order; the thinking level chosen at enqueue time is preserved.
- Failures park as visibly failed after 3 attempts with Retry/Delete inline on the bubble; Retry refreshes the timestamp so an expired row can actually resend. Refused sends restore the draft instead of dropping it.

## Evidence

- `RoomChatCommandOutboxTest` (Robolectric, 10 tests): persistence, FIFO under same-millisecond clock collisions, MAX_QUEUED refusal, 48h boundary expiry, sending→queued recovery, retry-refresh, gateway scoping, purges.
- `ChatControllerOutboxTest` (12 tests): enqueue-while-offline across controller recreation, ordered flush with idempotency keys asserted, ack removes row with exactly one history bubble, rejected→failed-after-3, transport-failure requeue, main-alias rows flushed to the canonical main session, purge on session delete.
- `cd apps/android && ./gradlew :app:testPlayDebugUnitTest` — full lane green; ktlint clean on touched files; native i18n inventory synced.
- Codex autoreview: 4 runs across 3 fix cycles; 5 accepted findings fixed (enqueue-time thinking level, expired-retry dead end, main-alias misrouting, transport failures burning attempts, draft loss + purge race); final run clean ("patch is correct").

**Follow-up:** voice capture (`MicCaptureManager`) still buffers recognized turns in an in-memory FIFO while offline; its queue is coupled to per-turn reply correlation and TTS playback, so routing it into the durable outbox is deferred to a dedicated change. No on-device screenshot pass yet (unit/Robolectric proof).

**Update (rebase onto the reworked cache base):** the base branch's cache API was rebuilt upstream around explicit gateway-scope binding (`ChatCacheScope`); the outbox is now re-expressed on that model — enqueue/publish/flush bind to the captured scope, a pairing/connection switch mid-flush stops the flush and clears presented rows, per-item retries re-check health and scope around each backoff (old-gateway text can never replay into a new gateway), and `updateStatus` is a claiming write so a row deleted through any path is never resent. Squashed to a single commit on the new base; 24 outbox tests green plus the full Play unit lane. One autoreview finding consciously rejected with inline rationale: destructive migration for the outbox table is the established design contract for this database (losing at most a few unsent commands at a rare schema-bump boundary is the accepted trade-off, documented at the site).
