### PR TITLE
test(number-coercion): unit tests for resolveNonNegativeNumber

### DIFF
--- a/src/shared/number-coercion.test.ts
+++ b/src/shared/number-coercion.test.ts
@@ -24,12 +24,12 @@ describe("resolveNonNegativeNumber", () => {
   });
 
   it("returns undefined for NaN", () => {
-    expect(resolveNonNegativeNumber(NaN)).toBeUndefined();
+    expect(resolveNonNegativeNumber(Number.NaN)).toBeUndefined();
   });
 
   it("returns undefined for Infinity and -Infinity", () => {
-    expect(resolveNonNegativeNumber(Infinity)).toBeUndefined();
-    expect(resolveNonNegativeNumber(-Infinity)).toBeUndefined();
+    expect(resolveNonNegativeNumber(Number.POSITIVE_INFINITY)).toBeUndefined();
+    expect(resolveNonNegativeNumber(Number.NEGATIVE_INFINITY)).toBeUndefined();
   });
 
   it("returns undefined for null and undefined", () => {

--- a/src/shared/number-coercion.test.ts
+++ b/src/shared/number-coercion.test.ts
@@ -1,0 +1,45 @@
+// Covers resolveNonNegativeNumber boundary behavior for session cost and token helpers.
+import { describe, expect, it } from "vitest";
+import { resolveNonNegativeNumber } from "./number-coercion.js";
+
+describe("resolveNonNegativeNumber", () => {
+  it("returns non-negative finite numbers as-is", () => {
+    expect(resolveNonNegativeNumber(0)).toBe(0);
+    expect(resolveNonNegativeNumber(1)).toBe(1);
+    expect(resolveNonNegativeNumber(0.5)).toBe(0.5);
+    expect(resolveNonNegativeNumber(Number.MAX_SAFE_INTEGER)).toBe(Number.MAX_SAFE_INTEGER);
+  });
+
+  it("returns -0 as 0 (IEEE 754 -0 >= 0 is true)", () => {
+    // -0 passes Number.isFinite and -0 >= 0, so the raw value (-0) is returned.
+    // Object.is disambiguates from +0 in the assertion.
+    const result = resolveNonNegativeNumber(-0);
+    expect(Object.is(result, -0)).toBe(true);
+  });
+
+  it("returns undefined for negative numbers", () => {
+    expect(resolveNonNegativeNumber(-1)).toBeUndefined();
+    expect(resolveNonNegativeNumber(-0.5)).toBeUndefined();
+    expect(resolveNonNegativeNumber(-Number.MAX_SAFE_INTEGER)).toBeUndefined();
+  });
+
+  it("returns undefined for NaN", () => {
+    expect(resolveNonNegativeNumber(NaN)).toBeUndefined();
+  });
+
+  it("returns undefined for Infinity and -Infinity", () => {
+    expect(resolveNonNegativeNumber(Infinity)).toBeUndefined();
+    expect(resolveNonNegativeNumber(-Infinity)).toBeUndefined();
+  });
+
+  it("returns undefined for null and undefined", () => {
+    expect(resolveNonNegativeNumber(null)).toBeUndefined();
+    expect(resolveNonNegativeNumber(undefined)).toBeUndefined();
+  });
+
+  it("returns undefined for non-number primitives", () => {
+    expect(resolveNonNegativeNumber("5" as unknown as number)).toBeUndefined();
+    expect(resolveNonNegativeNumber(true as unknown as number)).toBeUndefined();
+    expect(resolveNonNegativeNumber("" as unknown as number)).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## What Problem This Solves

`resolveNonNegativeNumber` in `src/shared/number-coercion.ts` is used across 7+ call sites (session-store, session-usage, cron, gateway) to validate cost and token values. It has zero dedicated test coverage — no `number-coercion.test.ts` exists.

## Why This Change Was Made

The function has a three-part guard (`typeof`, `Number.isFinite`, `>= 0`) with subtle IEEE 754 edge cases (negative zero, NaN, Infinity). Dedicated unit tests prevent regressions when this shared helper is refactored or when `@openclaw/normalization-core` re-exports change.

## Changes

- **`src/shared/number-coercion.test.ts`** (new, 45 lines) — 7 test cases covering all boundary conditions

## Evidence

Reproducibility: yes. Source inspection confirms no existing `number-coercion.test.ts` on current main.

Test output:

```text
$ npx vitest run src/shared/number-coercion.test.ts

 RUN  v4.1.8 D:/IdeaWork/openclaw-src

 ✓ src/shared/number-coercion.test.ts (7 tests) 5ms

 Test Files  1 passed (1)
      Tests  7 passed (7)
   Start at  18:47:51
   Duration  960ms
```

### Test cases

| # | Test | Input | Expected | Covers |
|---|------|-------|----------|--------|
| 1 | returns non-negative finite numbers as-is | 0, 1, 0.5, MAX_SAFE_INTEGER | same value | normal path |
| 2 | returns -0 as 0 (IEEE 754) | -0 | -0 (via Object.is) | IEEE 754 edge |
| 3 | returns undefined for negative numbers | -1, -0.5, -MAX_SAFE_INTEGER | undefined | negative guard |
| 4 | returns undefined for NaN | NaN | undefined | Number.isFinite |
| 5 | returns undefined for Infinity and -Infinity | Infinity, -Infinity | undefined | Number.isFinite |
| 6 | returns undefined for null and undefined | null, undefined | undefined | typeof guard |
| 7 | returns undefined for non-number primitives | "5", true, "" | undefined | typeof guard |

## Related

N/A (self-contained test addition)

🤖 Generated with [Claude Code](https://claude.com/claude-code)