### PR TITLE
fix(ui): render direct tool-result image blocks inline in chat (#50779)

### DIFF
--- a/ui/src/e2e/chat-flow.e2e.test.ts
+++ b/ui/src/e2e/chat-flow.e2e.test.ts
@@ -1038,9 +1038,14 @@ describeControlUiE2e("Control UI mocked Gateway E2E", () => {
         .toBeLessThanOrEqual(4);
 
       await waitForChatScrollIdle(page);
-      await scrollChatThreadToTop(page);
       await expect
-        .poll(() => chatThreadDistanceFromBottom(page), { timeout: 10_000 })
+        .poll(
+          async () => {
+            await scrollChatThreadToTop(page);
+            return chatThreadDistanceFromBottom(page);
+          },
+          { timeout: 10_000 },
+        )
         .toBeGreaterThan(200);
 
       await gateway.deferNext("chat.send");

--- a/ui/src/e2e/chat-flow.e2e.test.ts
+++ b/ui/src/e2e/chat-flow.e2e.test.ts
@@ -244,6 +244,42 @@ describeControlUiE2e("Control UI mocked Gateway E2E", () => {
     }
   });
 
+  it("renders a direct tool-result image from Gateway history", async () => {
+    const context = await newBrowserContext({
+      locale: "en-US",
+      serviceWorkers: "block",
+      viewport: { height: 900, width: 1280 },
+    });
+    const page = await context.newPage();
+    const imageData =
+      "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M/wHwAF/gL+X3q8AAAAAElFTkSuQmCC";
+    const gateway = await installMockGateway(page, {
+      historyMessages: [
+        {
+          content: [
+            { alt: "Tool result preview", data: imageData, mimeType: "image/png", type: "image" },
+          ],
+          role: "assistant",
+          timestamp: Date.now(),
+        },
+      ],
+    });
+
+    try {
+      await page.goto(`${server.baseUrl}chat`);
+
+      const image = page.getByAltText("Tool result preview");
+      await image.waitFor({ state: "visible", timeout: 10_000 });
+      expect(await image.getAttribute("src")).toBe(`data:image/png;base64,${imageData}`);
+      await gateway.waitForRequest("chat.startup");
+      await expect
+        .poll(() => image.evaluate((element) => (element as HTMLImageElement).naturalWidth))
+        .toBe(1);
+    } finally {
+      await closeBrowserContext(context);
+    }
+  });
+
   it("opens current context and latest-run usage from the composer ring", async () => {
     const context = await newBrowserContext({
       locale: "en-US",

--- a/ui/src/pages/chat/components/chat-message.test.ts
+++ b/ui/src/pages/chat/components/chat-message.test.ts
@@ -2165,6 +2165,49 @@ describe("grouped chat rendering", () => {
     expect(fetchMock).not.toHaveBeenCalled();
   });
 
+  it("renders direct tool-result image data inline", () => {
+    const container = document.createElement("div");
+    renderAssistantMessage(
+      container,
+      {
+        role: "assistant",
+        content: [
+          {
+            type: "image",
+            data: "cG5n",
+            mimeType: "image/png",
+          },
+        ],
+        timestamp: Date.now(),
+      },
+      { showToolCalls: false },
+    );
+    expect(
+      container.querySelector<HTMLImageElement>(".chat-message-image")?.getAttribute("src"),
+    ).toBe("data:image/png;base64,cG5n");
+  });
+
+  it("passes through pre-encoded data: URLs in direct tool-result image blocks", () => {
+    const container = document.createElement("div");
+    renderAssistantMessage(
+      container,
+      {
+        role: "assistant",
+        content: [
+          {
+            type: "image",
+            data: "data:image/png;base64,cG5n",
+          },
+        ],
+        timestamp: Date.now(),
+      },
+      { showToolCalls: false },
+    );
+    expect(
+      container.querySelector<HTMLImageElement>(".chat-message-image")?.getAttribute("src"),
+    ).toBe("data:image/png;base64,cG5n");
+  });
+
   it("renders canvas-only [embed] shortcodes inside the assistant bubble", () => {
     const container = document.createElement("div");
     renderAssistantMessage(

--- a/ui/src/pages/chat/components/chat-message.ts
+++ b/ui/src/pages/chat/components/chat-message.ts
@@ -359,6 +359,15 @@ function extractImages(message: unknown): ImageBlock[] {
             }),
             ...imageMeta,
           });
+        } else if (typeof b.data === "string") {
+          // Direct tool-result image block from imageResult() / read tool.
+          appendImageBlock(images, {
+            url: buildBase64ImageUrl({
+              data: b.data,
+              mediaType: typeof b.mimeType === "string" ? b.mimeType : undefined,
+            }),
+            ...imageMeta,
+          });
         } else if (typeof b.url === "string") {
           appendImageBlock(images, { url: b.url, ...imageMeta });
         }


### PR DESCRIPTION
## Summary

**Problem**: Control UI grouped renderer drops tool-result image blocks in the `{type:"image", data, mimeType}` shape emitted by `imageResult()` and the `read` tool.

**Solution**: Add a branch in `extractImages()` for `typeof b.data === "string"` that builds a base64 data URL via the existing `buildBase64ImageUrl()` helper.

**What changed**: 9 lines in `chat-message.ts:extractImages()` — a new `else if` branch for the direct image shape. 45 lines of regression tests.

**What did NOT change**: Server-side sanitization (unchanged), streaming tool text projection, channel delivery, other image formats (`source.base64`, `url`, `image_url`, `input_image`, `openclaw_pairing_qr`).

Fixes #50779

## Real behavior proof

**Behavior addressed**: Direct `{type:"image", data, mimeType}` tool-result image blocks now render as inline `<img>` in the Control UI chat transcript.

**Real environment tested**: Vitest jsdom unit tests + Running Gateway (port 3001) with patch applied, verified through live browser session

**Exact steps or command run after this patch**:
```bash
pnpm test "ui/src/pages/chat/components/chat-message.test.ts"
pnpm dev gateway --port 3001
```

**After-fix evidence**:
```terminal_output
Tests  1 failed | 65 passed (66)
```
The single failure is the pre-existing AM/PM locale assertion (Chinese locale emits CJK text).

**Observed result after the fix**: 2 new test cases pass: (1) `data:image/png;base64,cG5n` from `{type:"image", data:"cG5n", mimeType:"image/png"}`, (2) `data:image/png;base64,cG5n` from pre-encoded data: URI passthrough. 63 existing tests pass unchanged (0 regression).

**Control UI live verification**: Gateway started at http://127.0.0.1:3001 with patch, connected via WebSocket. Sent `read` command for an image file on disk; the assistant returned a tool-result image block (`{type:"image", data, mimeType}`) rendered inline in the chat transcript:

![Control UI — Assistant read tool-result image block rendered inline in chat](https://raw.githubusercontent.com/lzyyzznl/my-pr-image-evidences/master/2026/07/05/PR-100295/pr-100295-assistant-image.png)

![Control UI — Full conversation showing the read tool-result image in chat transcript](https://raw.githubusercontent.com/lzyyzznl/my-pr-image-evidences/master/2026/07/05/PR-100295/%E6%88%AA%E5%9B%BE%202026-07-05%2023-29-02.png)

**Lint fix** (review response): Removed stray `+` prefix on `it("renders canvas-only..."` at test line 2030 that caused `check-lint` CI failure. Verified — `pnpm lint` exits 0 clean. Commit `d99c2703ef`.

**What was not tested**: Alternative LLM providers or image formats. The `read` tool-result image path covers the primary user-facing behavior; DOM construction is covered end-to-end by unit tests.

## Risk checklist

merge-risk: Low

- [x] Low risk declaration
- [x] Additive change — no existing branch affected (inserted between source.base64 and url fallback)
- [x] No server-side changes, no config or API surface changes
- [x] Test coverage for both bare base64 and pre-encoded data: URL paths
