### PR TITLE
test: update e2e tempfile routing expectation

### DIFF
--- a/src/scripts/test-projects.test.ts
+++ b/src/scripts/test-projects.test.ts
@@ -905,6 +905,7 @@ describe("test-projects args", () => {
           "test/scripts/control-ui-i18n.test.ts",
           "test/scripts/docs-list.test.ts",
           "test/scripts/doctor-install-switch-wrapper.test.ts",
+          "test/scripts/e2e-shell-tempfiles.test.ts",
           "test/scripts/e2e-text-file-utils.test.ts",
           "test/scripts/fixture-common.test.ts",
           "test/scripts/fixture-plugin-commands.test.ts",


### PR DESCRIPTION
## What Problem This Solves

Current `main` fails `checks-node-compact-small-whole-2` on every pull request. The new E2E shell tempfile test imports `test/helpers/temp-dir.ts`, so dependency-aware test routing includes it, but the routing expectation was not updated with the new importer.

## Why This Change Was Made

Keep the expected import-driven run plan aligned with the repository's actual test graph. Production routing is already correct and the newly routed test passes.

## User Impact

No runtime impact. Restores green CI for current `main` and unblocks unrelated pull requests.

## Evidence

- Blacksmith Testbox: `node scripts/run-vitest.mjs src/scripts/test-projects.test.ts` passed 83/83.
- Exact failure reproduced on two disjoint product heads: [28738304277](https://github.com/openclaw/openclaw/actions/runs/28738304277) and [28738308629](https://github.com/openclaw/openclaw/actions/runs/28738308629).
- `oxfmt --check src/scripts/test-projects.test.ts`
- `git diff --check`
