### PR TITLE
fix(protocol): refresh plugin approval Swift model

### DIFF
--- a/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
@@ -7085,6 +7085,7 @@ public struct PluginApprovalRequestParams: Codable, Sendable {
     public let alloweddecisions: [String]?
     public let agentid: String?
     public let sessionkey: String?
+    public let approvalreviewerdeviceids: [String]?
     public let turnsourcechannel: String?
     public let turnsourceto: String?
     public let turnsourceaccountid: String?
@@ -7102,6 +7103,7 @@ public struct PluginApprovalRequestParams: Codable, Sendable {
         alloweddecisions: [String]?,
         agentid: String? = nil,
         sessionkey: String?,
+        approvalreviewerdeviceids: [String]?,
         turnsourcechannel: String?,
         turnsourceto: String?,
         turnsourceaccountid: String?,
@@ -7118,6 +7120,7 @@ public struct PluginApprovalRequestParams: Codable, Sendable {
         self.alloweddecisions = alloweddecisions
         self.agentid = agentid
         self.sessionkey = sessionkey
+        self.approvalreviewerdeviceids = approvalreviewerdeviceids
         self.turnsourcechannel = turnsourcechannel
         self.turnsourceto = turnsourceto
         self.turnsourceaccountid = turnsourceaccountid
@@ -7136,6 +7139,7 @@ public struct PluginApprovalRequestParams: Codable, Sendable {
         case alloweddecisions = "allowedDecisions"
         case agentid = "agentId"
         case sessionkey = "sessionKey"
+        case approvalreviewerdeviceids = "approvalReviewerDeviceIds"
         case turnsourcechannel = "turnSourceChannel"
         case turnsourceto = "turnSourceTo"
         case turnsourceaccountid = "turnSourceAccountId"


### PR DESCRIPTION
## What Problem This Solves

The generated Swift gateway protocol model was stale after `PluginApprovalRequestParams` gained `approvalreviewerdeviceids`. The bundled protocol CI gate therefore failed on current `main`, blocking otherwise unrelated pull requests.

## Why This Change Was Made

Refresh the checked-in Swift model with the exact output produced by the repository protocol generators. The change is limited to the missing optional property, initializer parameter and assignment, and coding key.

## User Impact

No runtime behavior change. The checked-in Swift protocol model once again matches the canonical gateway schema, restoring the bundled protocol gate.

## Evidence

- `pnpm protocol:gen`
- `pnpm protocol:gen:swift`
- Verified zero generated drift on Blacksmith Testbox `tbx_01kwrx2es5ax4pwqm47c356d45`
- Fresh autoreview: no actionable findings

