### PR TITLE
fix(voice-call): tolerate missing realtime config

### DIFF
--- a/extensions/voice-call/src/manager.notify.test.ts
+++ b/extensions/voice-call/src/manager.notify.test.ts
@@ -209,6 +209,24 @@ describe("CallManager notify and mapping", () => {
     expectFirstPlayTtsText(provider, "Twilio non-stream");
   });
 
+  it("speaks initial message on answered when legacy config omits realtime", async () => {
+    const { manager, provider } = await createManagerHarness({}, new FakeProvider("plivo"));
+    const managerConfig = requireRecord(manager, "manager internals") as {
+      config?: Record<string, unknown>;
+    };
+    delete managerConfig.config?.realtime;
+
+    const callId = await initiateCallWithMessage(
+      manager,
+      "+15550000014",
+      "Legacy config hello",
+      "conversation",
+    );
+    await answerCall(manager, callId, "evt-conversation-missing-realtime");
+
+    expectFirstPlayTtsText(provider, "Legacy config hello");
+  });
+
   it("lets realtime conversations own the initial greeting instead of posting legacy TwiML", async () => {
     const { manager, provider } = await createManagerHarness(
       { realtime: { enabled: true, provider: "openai" } },

--- a/extensions/voice-call/src/manager.ts
+++ b/extensions/voice-call/src/manager.ts
@@ -407,7 +407,7 @@ export class CallManager {
     // is actually available; otherwise speak immediately on answered.
     const mode = (call.metadata?.mode as string | undefined) ?? "conversation";
     if (mode === "conversation") {
-      if (this.config.realtime.enabled) {
+      if (this.config.realtime?.enabled) {
         return;
       }
       const shouldWaitForStreamConnect =


### PR DESCRIPTION
Closes #100294

## What Problem This Solves

Fixes an issue where users running voice-call conversation mode with config objects that omit `realtime` would hit a `TypeError` when a call is answered, preventing the initial greeting from playing.

## Why This Change Was Made

The answered-call path now treats missing realtime config the same as realtime disabled, matching the optional realtime checks used by sibling voice-call manager paths. A focused regression test covers the legacy/missing-config shape and verifies the normal initial-message path still runs.

## User Impact

Conversation calls can continue in standard TTS/STT mode even when the realtime config section is absent, instead of leaving answered calls without the initial greeting.

## Evidence

- Current head: `4cfc10129acb7a51e802aa7bb163650cb8657ca1`.
- Claim proved: answered conversation calls with missing realtime config play their initial message instead of throwing on `realtime.enabled` in the manager-level answered-call path.
- Commands / artifacts:
  - `node scripts/run-vitest.mjs extensions/voice-call/src/manager.notify.test.ts`
  - `git diff --check`
  - `python .agents\skills\autoreview\scripts\autoreview --mode local`
  - Current-head GitHub checks for `4cfc10129acb7a51e802aa7bb163650cb8657ca1`
- Observed result:
  - `manager.notify.test.ts`: 1 file passed, 15 tests passed.
  - `git diff --check`: passed.
  - Autoreview: clean, no accepted/actionable findings reported.
  - Current-head CI checks are green, including `check-lint`, `check-prod-types`, `check-test-types`, `build-artifacts`, and the focused extension/channel lanes.
- Not tested / proof gaps:
  - No live telephony provider call was placed from this environment, and no real answered-call recording/runtime log is attached.
  - The remaining proof gap is a real voice-call answered-call run with an omitted `realtime` config object, using a configured telephony/provider environment, or an explicit maintainer proof override for the manager-level regression proof above.
