### PR TITLE
fix(memory): report close-time pending work failures

### DIFF
--- a/extensions/memory-core/src/memory/manager-async-state.ts
+++ b/extensions/memory-core/src/memory/manager-async-state.ts
@@ -19,15 +19,20 @@ export async function startAsyncSearchSync(params: {
 export async function awaitPendingManagerWork(params: {
   pendingSync?: Promise<void> | null;
   pendingProviderInit?: Promise<void> | null;
+  onError?: (err: unknown) => void;
 }): Promise<void> {
   if (params.pendingSync) {
     try {
       await params.pendingSync;
-    } catch {}
+    } catch (err: unknown) {
+      params.onError?.(err);
+    }
   }
   if (params.pendingProviderInit) {
     try {
       await params.pendingProviderInit;
-    } catch {}
+    } catch (err: unknown) {
+      params.onError?.(err);
+    }
   }
 }

--- a/extensions/memory-core/src/memory/manager.async-search.test.ts
+++ b/extensions/memory-core/src/memory/manager.async-search.test.ts
@@ -72,6 +72,42 @@ describe("memory search async sync", () => {
     await closePromise;
   });
 
+  it("reports pending sync failures during close", async () => {
+    const onError = vi.fn();
+    const syncError = new Error("sync failed");
+
+    await awaitPendingManagerWork({
+      pendingSync: Promise.reject(syncError),
+      onError,
+    });
+
+    expect(onError).toHaveBeenCalledWith(syncError);
+  });
+
+  it("reports pending provider initialization failures during close", async () => {
+    const onError = vi.fn();
+    const providerError = new Error("provider init failed");
+
+    await awaitPendingManagerWork({
+      pendingProviderInit: Promise.reject(providerError),
+      onError,
+    });
+
+    expect(onError).toHaveBeenCalledWith(providerError);
+  });
+
+  it("does not report errors for completed pending close work", async () => {
+    const onError = vi.fn();
+
+    await awaitPendingManagerWork({
+      pendingSync: Promise.resolve(),
+      pendingProviderInit: Promise.resolve(),
+      onError,
+    });
+
+    expect(onError).not.toHaveBeenCalled();
+  });
+
   it("skips background search sync when search-triggered sync is disabled", async () => {
     const syncMock = vi.fn(async () => {});
     await startAsyncSearchSync({

--- a/extensions/memory-core/src/memory/manager.ts
+++ b/extensions/memory-core/src/memory/manager.ts
@@ -1364,14 +1364,23 @@ export class MemoryIndexManager extends MemoryManagerEmbeddingOps implements Mem
         }
       }
     };
+    const reportPendingWorkError = (err: unknown) => {
+      log.warn(`memory close: pending manager work failed: ${formatErrorMessage(err)}`);
+    };
     const awaitCurrentSync = async () => {
       const pendingSync = this.syncing;
       if (!pendingSync) {
         return;
       }
-      await awaitPendingManagerWork({ pendingSync });
+      await awaitPendingManagerWork({
+        pendingSync,
+        onError: reportPendingWorkError,
+      });
     };
-    await awaitPendingManagerWork({ pendingProviderInit });
+    await awaitPendingManagerWork({
+      pendingProviderInit,
+      onError: reportPendingWorkError,
+    });
     rememberCurrentProvider();
     try {
       await awaitCurrentSync();


### PR DESCRIPTION
## Summary

Fixes memory manager close-time diagnostics so rejected pending sync/provider initialization work is no longer swallowed silently.

## Issue/Motivation

Fixes #96766.

`awaitPendingManagerWork` previously caught and discarded errors from both `pendingSync` and `pendingProviderInit`. If shutdown races with a failed memory sync, SQLite/filesystem failure, or provider initialization failure, the close path could hide the failure completely.

## Changes

- Adds an optional `onError` callback to `awaitPendingManagerWork` and invokes it for rejected pending sync/provider initialization promises.
- Wires `MemoryIndexManager.close()` to log close-time pending-work failures with the existing `formatErrorMessage` helper.
- Adds regression coverage for rejected sync, rejected provider initialization, and successful pending work.

## Testing

- `node scripts/run-vitest.mjs run extensions/memory-core/src/memory/manager.async-search.test.ts` — passed (6 tests)
- `pnpm exec oxlint extensions/memory-core/src/memory/manager-async-state.ts extensions/memory-core/src/memory/manager.ts extensions/memory-core/src/memory/manager.async-search.test.ts` — 0 warnings/errors
- `pnpm exec oxfmt --check --threads=1 extensions/memory-core/src/memory/manager-async-state.ts extensions/memory-core/src/memory/manager.ts extensions/memory-core/src/memory/manager.async-search.test.ts` — passed
- `git diff --check` — passed
- Diff secret scan — 0 suspicious added secrets

## What Problem This Solves

Close-time memory manager failures were invisible: `awaitPendingManagerWork` used empty `catch {}` blocks for both pending sync and provider initialization. That made shutdown-time sync/provider failures indistinguishable from clean close and could hide data-loss or provider-init failures.

## Evidence

- Source verification on current `main`: `extensions/memory-core/src/memory/manager-async-state.ts` still had empty `catch {}` blocks for `pendingSync` and `pendingProviderInit` before this patch.
- Regression tests now assert rejected pending sync and provider initialization promises call `onError`, while resolved promises do not.
- Local validation passed:
  - `node scripts/run-vitest.mjs run extensions/memory-core/src/memory/manager.async-search.test.ts` → 1 file passed, 6 tests passed
  - `pnpm exec oxlint ...` → Found 0 warnings and 0 errors
  - `pnpm exec oxfmt --check --threads=1 ...` → All matched files use the correct format
  - `git diff --check` → clean
  - Diff secret scan → 0 suspicious added secrets

No live SQLite/disk-full shutdown fault was forced; the regression exercises the deterministic promise-rejection paths described by the issue.
