### PR TITLE
fix(cron): reject sub-millisecond durations

### DIFF
--- a/src/cli/cron-cli/shared.test.ts
+++ b/src/cli/cron-cli/shared.test.ts
@@ -347,6 +347,8 @@ describe("parseDurationMs", () => {
 
   it("rejects non-positive and malformed durations", () => {
     expect(parseDurationMs("0s")).toBeNull();
+    expect(parseDurationMs("0.5ms")).toBeNull();
+    expect(parseDurationMs("0.001ms")).toBeNull();
     expect(parseDurationMs("-5s")).toBeNull();
     expect(parseDurationMs("abc")).toBeNull();
     expect(parseDurationMs("")).toBeNull();

--- a/src/cli/cron-cli/shared.ts
+++ b/src/cli/cron-cli/shared.ts
@@ -227,9 +227,9 @@ export function parseDurationMs(input: string): number | null {
             ? 3_600_000
             : 86_400_000;
   const result = Math.floor(n * factor);
-  if (!Number.isFinite(result)) {
+  if (!Number.isFinite(result) || result <= 0) {
     // A finite mantissa can still overflow to Infinity for a large unit (e.g. a long
-    // pure-digit string with "d"); reject it instead of returning Infinity ms.
+    // pure-digit string with "d"); tiny positive values can also floor to 0ms.
     return null;
   }
   return result;


### PR DESCRIPTION
Closes #100306

## What Problem This Solves

Fixes an issue where users setting cron CLI duration flags could have positive sub-millisecond values silently treated as `0ms` when the value was below one millisecond.

## Why This Change Was Made

The cron duration parser now rejects values whose millisecond result is non-finite or non-positive after unit conversion and flooring. This keeps the existing overflow guard while also rejecting tiny positive inputs that would otherwise become zero-duration metadata or cooldowns.

## User Impact

Cron schedule and failure-alert duration inputs such as `0.5ms` are rejected instead of being accepted as an unintended zero-millisecond value.

## Evidence

- Current head: `ab50fb9f03580c368b93e11f26281719c8ebecc3`.
- Claim proved: positive sub-millisecond cron CLI durations are rejected through the real cron CLI paths while the existing duration parser behavior remains covered.
- Changed files:
  - `src/cli/cron-cli/shared.ts`
  - `src/cli/cron-cli/shared.test.ts`
- Commands / artifacts:
  - `git diff --check` -> passed after merging current `upstream/main` (`6237580e3cc40d1c05a832428feee048dd3feb44`).
  - 
ode scripts/run-vitest.mjs src/cli/cron-cli/shared.test.ts -> passed, 1 test file / 30 tests.
  - `node scripts/run-vitest.mjs src/scripts/test-projects.test.ts` -> passed, 1 test file / 83 tests; this covers the stale `checks-node-compact-small-whole-2` log assertion after the branch merge.
  - Real CLI proof with isolated temporary `OPENCLAW_HOME`, `OPENCLAW_STATE_DIR`, and `OPENCLAW_CONFIG_PATH`:
    - `node --import tsx src/entry.ts cron create --name subms-proof --every 0.5ms --system-event tick --json` -> `Error: Invalid --every. Use a duration like 10m, 1h, or 1d.`, exit code 1.
    - `node --import tsx src/entry.ts cron edit proof-job --failure-alert --failure-alert-cooldown 0.5ms --failure-alert-mode announce` -> `Error: Invalid --failure-alert-cooldown.`, exit code 1.
  - `python .agents\skills\autoreview\scripts\autoreview --mode local` -> clean on the earlier local proof pass.
  - GitHub PR checks on current head: rerunning after branch update; `Real behavior proof`, workflow sanity, dependency guard, labeler, and OpenGrep have already reported success, with CI/CodeQL still in progress.
- Observed result:
  - The real CLI rejects `0.5ms` for both cron schedule creation and failure-alert cooldown before creating persistent user cron state.
  - Focused Vitest passed: cron parser coverage, 1 test file / 30 tests; tooling route coverage, 1 test file / 83 tests.
  - Autoreview clean: no accepted/actionable findings reported.
  - PR is mergeable and maintainer edits are enabled.
- Not tested / proof gaps:
  - No live cron schedule was created; rejection happens before gateway RPC and before persistent cron state creation.
  - One broad CI shard, `checks-node-compact-small-whole-2`, failed in `src/scripts/test-projects.test.ts:857` because helper routing received `test/scripts/package-git-fixture.test.ts`. That failure is outside this PR's cron parser diff; this PR only changes `src/cli/cron-cli/shared.ts` and `src/cli/cron-cli/shared.test.ts`.

