### PR TITLE
fix(gateway): log start session persistence failures

### DIFF
--- a/src/gateway/server-chat.agent-events.test.ts
+++ b/src/gateway/server-chat.agent-events.test.ts
@@ -3174,6 +3174,32 @@ describe("agent event handler", () => {
     );
   });
 
+  it("logs when start session persistence fails", async () => {
+    const { chatRunState, handler, sessionEventSubscribers } = createHarness();
+    sessionEventSubscribers.subscribe("conn-1");
+    chatRunState.registry.add("run-global-work", {
+      sessionKey: "global",
+      agentId: "work",
+      clientRunId: "client-global-work",
+    });
+    persistGatewaySessionLifecycleEventMock.mockRejectedValueOnce(new Error("start disk full"));
+
+    handler({
+      runId: "run-global-work",
+      seq: 1,
+      stream: "lifecycle",
+      ts: Date.now(),
+      data: { phase: "start" },
+    });
+
+    await vi.waitFor(() => {
+      expect(logErrorMock).toHaveBeenCalledTimes(1);
+    });
+    expect(logErrorMock).toHaveBeenCalledWith(
+      "gateway: start session persistence failed session=global run=run-global-work error=Error: start disk full",
+    );
+  });
+
   it("routes hidden selected-agent global chat events only to matching subscribers", () => {
     const { broadcastToConnIds, chatRunState, handler, sessionMessageSubscribers } =
       createHarness();

--- a/src/gateway/server-chat.ts
+++ b/src/gateway/server-chat.ts
@@ -1439,7 +1439,14 @@ export function createAgentEventHandler({
         sessionKey,
         agentId: sessionAgentId,
         event: evt,
-      }).catch(() => undefined);
+      }).catch((err: unknown) => {
+        // Surface the swallowed start-phase persistence failure: a silent write
+        // failure drops the run's start marker from restart-recovery accounting
+        // with no operator trace, matching the terminal-phase log below.
+        logError(
+          `gateway: start session persistence failed session=${formatForLog(sessionKey)} run=${formatForLog(evt.runId)} error=${formatForLog(err)}`,
+        );
+      });
       const sessionEventConnIds = sessionEventSubscribers.getAll();
       if (sessionEventConnIds.size > 0) {
         broadcastToConnIds(


### PR DESCRIPTION
## What Problem This Solves

Resolves an issue where operators lose all visibility when a gateway session's
**start** lifecycle event fails to persist. When the session-lifecycle store
rejects the write for a `"start"` event, the run's start marker is silently
dropped from restart-recovery accounting with no log line, so an operator
investigating a session that never resumed after a restart has no trace of the
failed write.

The sibling **terminal**-phase persistence failure was made observable in
#97839 (`log terminal session persistence failures`), but the start-phase path
was left swallowing its rejection.

## Why This Change Was Made

The start-phase persist was fired as
`void persistGatewaySessionLifecycleEvent({...}).catch(() => undefined)` — the
rejection was discarded with zero logging, while the terminal-phase sibling in
the same file already logs the equivalent failure. This change mirrors #97839:
the start-phase catch now emits a redacted `logError` with the same message
shape (via `formatForLog`), so both lifecycle phases surface persistence
failures consistently. The fire-and-forget semantics are unchanged — this is
limited to adding the missing log line, with no change to recovery behavior.

## User Impact

Operators and maintainers now get a logged, redacted diagnostic
(`gateway: start session persistence failed session=… run=… error=…`) when a
session's start marker fails to persist, matching the existing terminal-phase
log. This closes an asymmetric blind spot in restart-recovery diagnostics. No
user-visible runtime behavior changes.

## Evidence

### Real behavior proof (genuine read-only-filesystem rejection, no mocks)

Drove the **shipped** `createAgentEventHandler` end-to-end against a **real**
session-store persistence failure — the production analog of a read-only disk
or filesystem holding session state. A real on-disk session entry is seeded
via the prod `upsertSessionEntry` API while the fs is writable, then its
directory is remounted **read-only (EROFS)** inside a user+mount namespace.
Reads still succeed (so `loadSessionEntry` finds the entry); the real atomic
write (`@openclaw/fs-safe` `replaceFileAtomic` → `fs.writeFile` temp) then fails
with `EROFS`, `requireWriteSuccess: true` propagates the rejection, and the
handler's start-phase `.catch` fires. No `vi.mock`; the persistence function and
`logError`/`formatForLog` are the real production modules.

> EROFS (not `chmod`) is required because `@openclaw/fs-safe` chmods the target
> directory back to `0o700` immediately before every write, which defeats
> permission-based injection on a directory the process owns. A read-only mount
> cannot be chmod'd away.

```
[setup] seeded real entry: <sandbox>/.openclaw/agents/main/sessions/sessions.json
[setup] canonicalKey=agent:main:proof-session sessionId=sess-proof-1
[setup] remounted read-only (EROFS): <sandbox>/.openclaw/agents/main/sessions
[setup] direct write to dir blocked by EROFS: YES

=== A. persistGatewaySessionLifecycleEvent rejection (real EROFS write) ===
persist REJECTED: code=EROFS
  Error: EROFS: read-only file system, open '<sandbox>/.../sessions.json.<pid>.<uuid>.tmp'

=== B. Shipped createAgentEventHandler `.catch` -> logError (real stderr) ===
[gateway] start session persistence failed session=agent:main:proof-session run=run-proof-start error=Error: EROFS: read-only file system, open '<sandbox>/.../sessions.json.<pid>.<uuid>.tmp': code=EROFS

=== RESULT ===
underlying failure was a real EROFS fs write error: YES
shipped handler emitted the redacted start-persist log: YES
PROOF PASS
```

Before this change the same run produces **no** log line (the rejection is
swallowed by `.catch(() => undefined)`); after it, the redacted diagnostic above
is emitted, mirroring the terminal-phase behavior shipped in #97839.

### Focused regression test

A colocated regression test (`server-chat.agent-events.test.ts`), modeled on the
existing terminal-failure test and the existing start-persist success test,
forces the start persist to reject and asserts the redacted log fires exactly
once:

```
✓ agent event handler > logs when start session persistence fails
 Test Files  2 passed (2)
      Tests  200 passed (200)
```

### Static checks

- `oxfmt --check` — clean; `oxlint` — clean
- `tsgo:core` — exit 0

The change is confined to `src/gateway/server-chat.ts` (the start-phase catch)
plus its colocated test. No config, migration, or protocol surface touched.
