### PR TITLE
test(tooling): include package fixture importer

### DIFF
--- a/src/scripts/test-projects.test.ts
+++ b/src/scripts/test-projects.test.ts
@@ -916,6 +916,7 @@ describe("test-projects args", () => {
           "test/scripts/kitchen-sink-rpc-walk.test.ts",
           "test/scripts/native-app-i18n.test.ts",
           "test/scripts/onboard-config-fixtures.test.ts",
+          "test/scripts/package-git-fixture.test.ts",
           "test/scripts/parallels-lib-helpers.test.ts",
           "test/scripts/parallels-package-log-progress-extract.test.ts",
           "test/scripts/parallels-smoke-model.test.ts",


### PR DESCRIPTION
## What Problem This Solves

Current `main` fails `src/scripts/test-projects.test.ts` after `test/scripts/package-git-fixture.test.ts` began importing `test/helpers/temp-dir.ts` without updating the deterministic importer expectation.

## Why This Change Was Made

Add the newly observed importer to the existing tooling-project expectation. This restores the routing contract without changing production behavior.

## User Impact

No runtime impact. Restores the compact CI shard for current `main` and PRs rebased onto it.

## Evidence

- `node scripts/run-vitest.mjs src/scripts/test-projects.test.ts` — 83 passed.
- `git diff --check` — passed.
- Fresh Codex autoreview — clean, no accepted/actionable findings (0.99 confidence).
