### PR TITLE
test(zod-parse): unit tests for safeParseWithSchema and safeParseJsonWithSchema

### DIFF
--- a/src/utils/zod-parse.test.ts
+++ b/src/utils/zod-parse.test.ts
@@ -1,0 +1,86 @@
+// Covers safeParseWithSchema and safeParseJsonWithSchema boundary behavior for plugin and config boundaries.
+import { describe, expect, it } from "vitest";
+import { z } from "zod";
+import { safeParseJsonWithSchema, safeParseWithSchema } from "./zod-parse.js";
+
+const NameSchema = z.object({ name: z.string() });
+const NumbersSchema = z.array(z.number());
+const StringSchema = z.string();
+const NestedSchema = z.object({
+  user: z.object({ id: z.number(), email: z.string().email().optional() }),
+});
+
+describe("safeParseWithSchema", () => {
+  it("returns parsed data for schema-valid objects", () => {
+    expect(safeParseWithSchema(NameSchema, { name: "Ada" })).toEqual({ name: "Ada" });
+  });
+
+  it("returns null for schema-invalid values", () => {
+    expect(safeParseWithSchema(NameSchema, { name: 1 })).toBeNull();
+    expect(safeParseWithSchema(NameSchema, {})).toBeNull();
+  });
+
+  it("returns null for null and undefined input", () => {
+    expect(safeParseWithSchema(NameSchema, null)).toBeNull();
+    expect(safeParseWithSchema(NameSchema, undefined)).toBeNull();
+  });
+
+  it("works with array schemas", () => {
+    expect(safeParseWithSchema(NumbersSchema, [1, 2, 3])).toEqual([1, 2, 3]);
+    expect(safeParseWithSchema(NumbersSchema, ["a"])).toBeNull();
+  });
+
+  it("works with primitive schemas", () => {
+    expect(safeParseWithSchema(StringSchema, "hello")).toBe("hello");
+    expect(safeParseWithSchema(StringSchema, 123)).toBeNull();
+  });
+
+  it("works with nested object schemas", () => {
+    const valid = { user: { id: 1, email: "a@b.com" } };
+    expect(safeParseWithSchema(NestedSchema, valid)).toEqual(valid);
+  });
+
+  it("returns null when nested fields fail validation", () => {
+    expect(safeParseWithSchema(NestedSchema, { user: { id: "x" } })).toBeNull();
+  });
+
+  it("accepts objects with optional fields present or absent", () => {
+    expect(safeParseWithSchema(NestedSchema, { user: { id: 1 } })).toEqual({
+      user: { id: 1 },
+    });
+  });
+});
+
+describe("safeParseJsonWithSchema", () => {
+  it("returns parsed data for valid JSON strings", () => {
+    expect(safeParseJsonWithSchema(NameSchema, `{"name":"Ada"}`)).toEqual({
+      name: "Ada",
+    });
+  });
+
+  it("returns null for malformed JSON", () => {
+    expect(safeParseJsonWithSchema(NameSchema, "{")).toBeNull();
+  });
+
+  it("returns null for empty and whitespace-only strings", () => {
+    expect(safeParseJsonWithSchema(NameSchema, "")).toBeNull();
+    expect(safeParseJsonWithSchema(NameSchema, "   ")).toBeNull();
+  });
+
+  it("returns null when JSON parses but schema rejects", () => {
+    expect(safeParseJsonWithSchema(NameSchema, `{"name":1}`)).toBeNull();
+    expect(safeParseJsonWithSchema(NameSchema, `{}`)).toBeNull();
+  });
+
+  it("works with array JSON and array schemas", () => {
+    expect(safeParseJsonWithSchema(NumbersSchema, `[1,2,3]`)).toEqual([1, 2, 3]);
+    expect(safeParseJsonWithSchema(NumbersSchema, `["a"]`)).toBeNull();
+  });
+
+  it("returns null for valid JSON of the wrong type", () => {
+    // Number JSON passed to an object schema — schema rejects
+    expect(safeParseJsonWithSchema(NameSchema, `42`)).toBeNull();
+    // null JSON — schema rejects because expected object
+    expect(safeParseJsonWithSchema(NameSchema, `null`)).toBeNull();
+  });
+});


### PR DESCRIPTION
## What Problem This Solves

`safeParseWithSchema` and `safeParseJsonWithSchema` in `src/utils/zod-parse.ts` are used at plugin, config, and runtime boundaries to safely validate external payloads. Existing coverage in `utils-misc.test.ts` has only 2 shared test cases (5 assertions) with no dedicated test file.

## Why This Change Was Made

These helpers guard config parsing (`setup.ts`, `doctor-plugin-manifests.ts`) and runtime data ingestion (`tailscale-status.ts`). Missing coverage for null/undefined input, array schemas, nested objects, optional fields, malformed JSON, and type mismatches leaves validation gaps.

## Changes

- **`src/utils/zod-parse.test.ts`** (new, 86 lines) — 14 test cases (21 assertions) covering both functions exhaustively

## Evidence

Reproducibility: yes. Source inspection confirms no existing `zod-parse.test.ts` on current main.

Test output:

```text
$ npx vitest run src/utils/zod-parse.test.ts

 ✓ src/utils/zod-parse.test.ts (14 tests) 4ms

 Test Files  1 passed (1)
      Tests  14 passed (14)
```

### Test coverage

| # | Function | Test | Assertions |
|---|----------|------|:--:|
| 1 | safeParseWithSchema | returns parsed data for valid objects | 1 |
| 2 | | returns null for invalid values | 2 |
| 3 | | returns null for null and undefined | 2 |
| 4 | | works with array schemas | 2 |
| 5 | | works with primitive schemas | 2 |
| 6 | | works with nested object schemas | 1 |
| 7 | | returns null on nested field failure | 1 |
| 8 | | accepts optional fields | 1 |
| 9 | safeParseJsonWithSchema | returns parsed data for valid JSON | 1 |
| 10 | | returns null for malformed JSON | 1 |
| 11 | | returns null for empty/whitespace | 2 |
| 12 | | returns null on schema rejection | 2 |
| 13 | | works with array JSON | 2 |
| 14 | | returns null for wrong-type JSON | 2 |

## Related

N/A (self-contained test addition)

🤖 Generated with [Claude Code](https://claude.com/claude-code)