### PR TITLE
fix(ui): add workboard detail drawer actions

### DIFF
--- a/src/gateway/session-utils.perf.test.ts
+++ b/src/gateway/session-utils.perf.test.ts
@@ -50,6 +50,7 @@ describe("listSessionsFromStore resolver cache", () => {
       for (let i = 0; i < rowCount; i++) {
         const tuple = tuples[i % tuples.length];
         store[`agent:default:webchat:dm:${i}`] = {
+          sessionId: `session-${i}`,
           updatedAt: now - i,
           modelProvider: tuple.modelProvider,
           model: tuple.model,

--- a/ui/src/pages/workboard/view.test.ts
+++ b/ui/src/pages/workboard/view.test.ts
@@ -1479,6 +1479,111 @@ describe("renderWorkboard", () => {
     }
   });
 
+  it("renders compact-card actions in the detail drawer", () => {
+    const host = {};
+    const state = getWorkboardState(host);
+    const request = vi.fn(async () => ({ card: state.cards[0] }));
+    state.loaded = true;
+    state.detailCardId = "card-1";
+    state.cards = [
+      {
+        id: "card-1",
+        title: "Drawer action parity",
+        status: "running",
+        priority: "normal",
+        labels: [],
+        position: 1000,
+        createdAt: 1,
+        updatedAt: 1,
+        sessionKey: "agent:main:drawer-action",
+      },
+    ];
+    const container = document.createElement("div");
+
+    render(
+      renderWorkboard({
+        host,
+        client: { request } as unknown as GatewayBrowserClient,
+        connected: true,
+        pluginEnabled: true,
+        agentsList: null,
+        sessions: [
+          {
+            key: "agent:main:drawer-action",
+            kind: "direct",
+            updatedAt: 2,
+            status: "running",
+            hasActiveRun: true,
+          },
+        ],
+        onOpenSession: () => undefined,
+      }),
+      container,
+    );
+
+    const drawer = container.querySelector<HTMLElement>(".workboard-detail");
+    expect(drawer).toBeTruthy();
+    expect(drawer?.querySelector<HTMLSelectElement>(".workboard-card__move-select")).toBeTruthy();
+    expect(
+      drawer?.querySelector<HTMLButtonElement>('button[aria-label="Stop session"]'),
+    ).toBeTruthy();
+    expect(drawer?.querySelector<HTMLButtonElement>('button[aria-label="Edit card"]')).toBeTruthy();
+    expect(
+      drawer?.querySelector<HTMLButtonElement>('button[aria-label="Archive card"]'),
+    ).toBeTruthy();
+    expect(
+      drawer?.querySelector<HTMLButtonElement>('button[aria-label="Delete card"]'),
+    ).toBeTruthy();
+  });
+
+  it("hides unavailable detail drawer actions for archived read-only cards", () => {
+    const host = {};
+    const state = getWorkboardState(host);
+    state.loaded = true;
+    state.detailCardId = "card-1";
+    state.cards = [
+      {
+        id: "card-1",
+        title: "Read only archived drawer",
+        status: "todo",
+        priority: "normal",
+        labels: [],
+        position: 1000,
+        createdAt: 1,
+        updatedAt: 1,
+        metadata: { archivedAt: 2 },
+      },
+    ];
+    state.showArchived = true;
+    const container = document.createElement("div");
+
+    render(
+      renderWorkboard({
+        host,
+        client: null,
+        connected: true,
+        canWrite: false,
+        pluginEnabled: true,
+        agentsList: null,
+        sessions: [],
+        onOpenSession: () => undefined,
+      }),
+      container,
+    );
+
+    const drawer = container.querySelector<HTMLElement>(".workboard-detail");
+    expect(drawer).toBeTruthy();
+    expect(drawer?.querySelector<HTMLSelectElement>(".workboard-card__move-select")).toBeNull();
+    expect(
+      drawer?.querySelector<HTMLButtonElement>('button[aria-label="Stop session"]'),
+    ).toBeNull();
+    expect(drawer?.querySelector<HTMLButtonElement>('button[aria-label="Edit card"]')).toBeNull();
+    expect(
+      drawer?.querySelector<HTMLButtonElement>('button[aria-label="Unarchive card"]'),
+    ).toBeNull();
+    expect(drawer?.querySelector<HTMLButtonElement>('button[aria-label="Delete card"]')).toBeNull();
+  });
+
   it("keeps cards compact and puts model-specific execution actions in details", () => {
     const host = {};
     const state = getWorkboardState(host);

--- a/ui/src/pages/workboard/view.ts
+++ b/ui/src/pages/workboard/view.ts
@@ -1864,6 +1864,7 @@ function renderCardDetailsPanel(props: WorkboardProps) {
   const formatted = formatLifecycle(lifecycle);
   const taskIsAuthoritative = task ? taskMatchesLifecycle(task, lifecycle) : false;
   const linkedSessionKey = card.sessionKey ?? card.execution?.sessionKey;
+  const session = findWorkboardSession(card, props.sessions);
   const writable = canMutate(props);
   const comments = card.metadata?.comments ?? [];
   const attempts = card.metadata?.attempts ?? [];
@@ -1877,6 +1878,13 @@ function renderCardDetailsPanel(props: WorkboardProps) {
   const automation = card.metadata?.automation;
   const events = (card.events ?? []).slice(-6).toReversed();
   const busy = state.busyCardIds.has(card.id) || state.dispatching;
+  const activeTask = cardHasActiveOrRunningUnresolvedTask(card, task, state.missingTaskIds);
+  const live =
+    activeTask ||
+    cardHasUnresolvedStartedRun(card) ||
+    session?.hasActiveRun === true ||
+    (session?.hasActiveRun !== false && session?.status === "running");
+  const archived = Boolean(card.metadata?.archivedAt);
   const showStartControls = writable && cardCanStart(state, props.sessions, card);
   const dependencies = getWorkboardDependencyState(card, state.cards);
   return html`
@@ -2081,6 +2089,93 @@ function renderCardDetailsPanel(props: WorkboardProps) {
         </section>
 
         <div class="workboard-detail__actions">
+          ${writable ? renderCardMoveControl(props, card, busy) : nothing}
+          <div class="workboard-detail__actions-row">
+            ${writable && (linkedSessionKey ? live : activeTask)
+              ? html`
+                  <button
+                    class="btn btn--icon"
+                    type="button"
+                    title=${t("workboard.stopSession")}
+                    aria-label=${t("workboard.stopSession")}
+                    ?disabled=${busy || !props.connected}
+                    @click=${() =>
+                      stopWorkboardCard({
+                        host: props.host,
+                        client: props.client,
+                        card,
+                        requestUpdate: props.onRequestUpdate,
+                      })}
+                  >
+                    ${icons.stop}<span>${t("workboard.stopSession")}</span>
+                  </button>
+                `
+              : nothing}
+            ${writable && !archived
+              ? html`
+                  <button
+                    class="btn btn--icon"
+                    type="button"
+                    title=${t("workboard.editCard")}
+                    aria-label=${t("workboard.editCard")}
+                    aria-haspopup="dialog"
+                    ?disabled=${state.dispatching}
+                    @click=${(event: MouseEvent) => {
+                      rememberWorkboardReturnFocus(event.currentTarget);
+                      openEditModal(state, card);
+                      props.onRequestUpdate?.();
+                    }}
+                  >
+                    ${icons.edit}<span>${t("workboard.editCard")}</span>
+                  </button>
+                `
+              : nothing}
+            ${writable
+              ? html`
+                  <button
+                    class="btn btn--icon"
+                    type="button"
+                    title=${archived ? t("workboard.unarchiveCard") : t("workboard.archiveCard")}
+                    aria-label=${archived
+                      ? t("workboard.unarchiveCard")
+                      : t("workboard.archiveCard")}
+                    ?disabled=${busy}
+                    @click=${() =>
+                      archiveWorkboardCard({
+                        host: props.host,
+                        client: props.client,
+                        cardId: card.id,
+                        archived: !archived,
+                        requestUpdate: props.onRequestUpdate,
+                      })}
+                  >
+                    ${archived ? icons.archiveRestore : icons.archive}<span
+                      >${archived ? t("workboard.unarchiveCard") : t("workboard.archiveCard")}</span
+                    >
+                  </button>
+                `
+              : nothing}
+            ${writable
+              ? html`
+                  <button
+                    class="btn btn--icon workboard-card__delete"
+                    type="button"
+                    title=${t("workboard.deleteCard")}
+                    aria-label=${t("workboard.deleteCard")}
+                    ?disabled=${busy}
+                    @click=${() =>
+                      deleteWorkboardCard({
+                        host: props.host,
+                        client: props.client,
+                        cardId: card.id,
+                        requestUpdate: props.onRequestUpdate,
+                      })}
+                  >
+                    ${icons.trash}<span>${t("workboard.deleteCard")}</span>
+                  </button>
+                `
+              : nothing}
+          </div>
           ${linkedSessionKey
             ? html`
                 <button

--- a/ui/src/styles/workboard.css
+++ b/ui/src/styles/workboard.css
@@ -1503,6 +1503,18 @@
   justify-content: center;
 }
 
+.workboard-detail__actions-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+
+.workboard-detail__actions-row .btn {
+  flex: 0 0 auto;
+  justify-content: center;
+  min-width: 0;
+}
+
 @media (max-width: 860px) {
   .workboard-modal {
     padding: 0;


### PR DESCRIPTION
## Summary

- Adds the same status move, stop, edit, archive/unarchive, and delete controls from compact Workboard cards to the expanded card detail drawer.
- Keeps the actions behind the existing write/readiness/busy/archived guards so read-only and archived detail drawers do not expose unavailable mutations.
- Adds focused Control UI tests for drawer action parity and read-only archived behavior.

## Issue/Motivation

Fixes #99957.

The issue's crowded-column layout symptom was already handled by earlier work, but the card detail drawer still lacked the action parity explicitly requested in the report: users could edit, move, archive, stop, or delete from the compact card, but had to close the detail drawer to perform those same operations.

A prior closed PR (#99970) targeted this same remaining gap but did not land. This PR keeps the scope narrow and current-main based.

## Changes

- Reuses the existing Workboard mutation helpers from the detail drawer:
  - status move dropdown
  - stop session/task button
  - edit card button
  - archive/unarchive button
  - delete button
- Adds a wrapping action row style for the detail drawer footer.
- Adds regression coverage for writable running cards and read-only archived cards.

## Testing

- `node scripts/run-vitest.mjs run ui/src/pages/workboard/view.test.ts` — 70 tests passed
- `corepack pnpm exec oxlint --config .oxlintrc.json --tsconfig test/tsconfig/tsconfig.test.ui.json ui/src/pages/workboard/view.ts ui/src/pages/workboard/view.test.ts` — 0 warnings/errors
- `corepack pnpm exec oxfmt --check ui/src/pages/workboard/view.ts ui/src/pages/workboard/view.test.ts ui/src/styles/workboard.css` — passed
- `git diff --check` — passed
- Diff secret scan over added lines — clean

## What Problem This Solves

Users opening a Workboard card's expanded detail drawer could inspect a card but could not perform the same practical operations available on the compact board card: move status, stop a live run, edit, archive/unarchive, or delete. That made the expanded view a dead end for managing cards and forced users to close the drawer before acting.

## Evidence

- The new `renders compact-card actions in the detail drawer` test renders a running, writable card detail drawer and asserts the status select plus Stop, Edit, Archive, and Delete actions are present.
- The new `hides unavailable detail drawer actions for archived read-only cards` test renders an archived read-only drawer and asserts mutation controls are absent.
- Targeted UI test run passed: `node scripts/run-vitest.mjs run ui/src/pages/workboard/view.test.ts` -> 70 tests passed.
- Formatting/lint/diff checks passed as listed above.
- No live browser screenshot was captured from this hourly worker; this is covered by deterministic DOM rendering tests for the affected drawer surface.
