### PR TITLE
fix: hot-reload visible reply mode changes

### DIFF
--- a/src/cli/config-cli.test.ts
+++ b/src/cli/config-cli.test.ts
@@ -64,6 +64,8 @@ vi.mock("../gateway/config-reload-plan.js", () => ({
         (changedPath.startsWith("agents.list.") ||
           changedPath.startsWith("agents.defaults.models.") ||
           changedPath.startsWith("models.") ||
+          changedPath === "messages.visibleReplies" ||
+          changedPath === "messages.groupChat.visibleReplies" ||
           changedPath.startsWith("plugins.")),
     );
     restartReasons.push(
@@ -1191,8 +1193,7 @@ describe("config cli", () => {
           issues: [
             {
               path: "update.channel",
-              message:
-                'Invalid input (allowed: "stable", "extended-stable", "beta", "dev")',
+              message: 'Invalid input (allowed: "stable", "extended-stable", "beta", "dev")',
               allowedValues: ["stable", "extended-stable", "beta", "dev"],
               allowedValuesHiddenCount: 0,
             },
@@ -3602,6 +3603,28 @@ describe("config cli", () => {
 
       expectLogIncludes("Updated models.providers.openai.agentRuntime.id");
       expectLogIncludes("Change will apply without restarting the gateway.");
+      expectLogExcludes("Restart the gateway to apply.");
+    });
+
+    it("prints a hot-reload hint for visible reply mode changes", async () => {
+      const resolved: OpenClawConfig = {
+        messages: {
+          visibleReplies: "message_tool",
+        },
+      };
+      setSnapshot(resolved, withRuntimeDefaults(resolved));
+
+      await runConfigCommand([
+        "config",
+        "set",
+        "messages.visibleReplies",
+        '"automatic"',
+        "--strict-json",
+      ]);
+
+      expectLogIncludes("Updated messages.visibleReplies");
+      expectLogIncludes("Change will apply without restarting the gateway.");
+      expectLogExcludes("No gateway restart needed.");
       expectLogExcludes("Restart the gateway to apply.");
     });
 

--- a/src/gateway/config-reload-plan.ts
+++ b/src/gateway/config-reload-plan.ts
@@ -80,6 +80,12 @@ const BASE_RELOAD_RULES: ReloadRule[] = [
   { prefix: "diagnostics.stuckSessionWarnMs", kind: "none" },
   { prefix: "diagnostics.stuckSessionAbortMs", kind: "none" },
   { prefix: "diagnostics.memoryPressureSnapshot", kind: "hot" },
+  // Visible-reply policy is consulted for every dispatched source turn. It
+  // must refresh the runtime snapshot immediately so direct Codex/Telegram
+  // chats stop exposing the message-tool-only contract after operators switch
+  // back to automatic replies.
+  { prefix: "messages.visibleReplies", kind: "hot" },
+  { prefix: "messages.groupChat.visibleReplies", kind: "hot" },
   { prefix: "hooks.gmail", kind: "hot", actions: ["restart-gmail-watcher"] },
   { prefix: "hooks", kind: "hot", actions: ["reload-hooks"] },
   {

--- a/src/gateway/config-reload.test.ts
+++ b/src/gateway/config-reload.test.ts
@@ -476,6 +476,18 @@ describe("buildGatewayReloadPlan", () => {
     expect(plan.noopPaths).toStrictEqual([]);
   });
 
+  it("hot-reloads visible reply mode changes", () => {
+    const changedPaths = ["messages.visibleReplies", "messages.groupChat.visibleReplies"];
+    const plan = buildGatewayReloadPlan(changedPaths);
+
+    expect(plan.restartGateway).toBe(false);
+    expect(plan.restartReasons).toStrictEqual([]);
+    expect(plan.hotReasons).toStrictEqual(changedPaths);
+    expect(plan.noopPaths).toStrictEqual([]);
+    expect(resolveConfigReloadMetadata("messages.visibleReplies").kind).toBe("hot");
+    expect(resolveConfigReloadMetadata("messages.groupChat.visibleReplies").kind).toBe("hot");
+  });
+
   it("hot-reloads auth cooldown changes without a gateway restart", () => {
     const changedPaths = [
       "auth.cooldowns.billingBackoffHours",
@@ -808,6 +820,31 @@ describe("startGatewayConfigReloader", () => {
     expect(harness.onConfigChange.mock.calls[0]?.[1]).toBe(nextConfig);
     expect(harness.onConfigApplied).toHaveBeenCalledTimes(1);
     expect(harness.onHotReload).not.toHaveBeenCalled();
+    expect(harness.onRestart).not.toHaveBeenCalled();
+    await harness.reloader.stop();
+  });
+
+  it("runs hot reload when visible reply mode changes", async () => {
+    const initialConfig: OpenClawConfig = {
+      gateway: { reload: { debounceMs: 0 } },
+      messages: { visibleReplies: "message_tool" },
+    };
+    const nextConfig: OpenClawConfig = {
+      gateway: { reload: { debounceMs: 0 } },
+      messages: { visibleReplies: "automatic" },
+    };
+    const readSnapshot = vi.fn(async () =>
+      makeSnapshot({ config: nextConfig, hash: "visible-replies" }),
+    );
+    const harness = createReloaderHarness(readSnapshot, { initialConfig });
+
+    harness.watcher.emit("change");
+    await vi.runAllTimersAsync();
+
+    expect(harness.onConfigChange).toHaveBeenCalledTimes(1);
+    expect(harness.onHotReload).toHaveBeenCalledTimes(1);
+    expect(harness.onHotReload.mock.calls[0]?.[0].hotReasons).toEqual(["messages.visibleReplies"]);
+    expect(harness.onConfigApplied).toHaveBeenCalledTimes(1);
     expect(harness.onRestart).not.toHaveBeenCalled();
     await harness.reloader.stop();
   });


### PR DESCRIPTION
﻿## What Problem This Solves

Fixes an issue where users who set `messages.visibleReplies` back to `automatic` could still get the old message-tool-only contract on later direct channel turns until the Gateway was restarted.

This was especially confusing in Telegram/Codex onboarding: `openclaw config set messages.visibleReplies automatic` could report that no Gateway restart was needed, but the next Codex turn could still expose `message(action=send)` as the source-reply path and suppress automatic final delivery.

## Why This Change Was Made

Visible-reply mode is a live dispatch policy, so changes to `messages.visibleReplies` and `messages.groupChat.visibleReplies` now go through the Gateway hot-reload path instead of the dynamic-read/no-op path. That refreshes the runtime config snapshot for the next dispatched turn without restarting channels or the full Gateway.

The change is intentionally scoped to the visible-reply fields; other `messages.*` settings keep their existing reload classification.

## User Impact

Operators can switch direct/source replies back to automatic delivery and have the next turn pick up the new contract. The CLI now prints the hot-reload hint for this change instead of the misleading `No gateway restart needed.` message.

## Evidence

- `node scripts/run-vitest.mjs run --config test/vitest/vitest.gateway.config.ts src/gateway/config-reload.test.ts src/cli/config-cli.test.ts` passed: 3 files, 252 tests.
- `node scripts/test-projects.mjs --changed upstream/main` was also run. It failed in unrelated Windows/path and temp-file-lock tests outside this diff, including symlink permission, Windows path normalization, and SQLite temp unlink failures; no failure pointed at the changed files.
