### PR TITLE
fix(exec): require approval for Windows shell expansions

### DIFF
--- a/src/agents/bash-tools.exec-host-gateway.test.ts
+++ b/src/agents/bash-tools.exec-host-gateway.test.ts
@@ -581,6 +581,81 @@ describe("processGatewayAllowlist", () => {
     });
   });
 
+  it("requires explicit approval for Windows PowerShell expansion commands", async () => {
+    const command = 'powershell -NoProfile -Command "$env:USERPROFILE"';
+    requiresExecApprovalMock.mockReturnValue(false);
+    buildEnforcedShellCommandMock.mockReturnValue({
+      ok: false,
+      reason: "unenforceable windows shell token: $",
+    });
+    evaluateShellAllowlistWithAuthorizationMock.mockReturnValue({
+      allowlistMatches: [{ pattern: "powershell.exe", source: "allow-always" }],
+      analysisOk: true,
+      allowlistSatisfied: true,
+      segments: [
+        {
+          raw: command,
+          resolution: null,
+          argv: ["powershell", "-NoProfile", "-Command", "$env:USERPROFILE"],
+          requiresExplicitApproval: "windows-shell-expansion",
+        },
+      ],
+      segmentAllowlistEntries: [{ pattern: "powershell.exe", source: "allow-always" }],
+      segmentSatisfiedBy: ["allowlist"],
+    });
+    resolveExecHostApprovalContextMock.mockReturnValue({
+      approvals: { allowlist: [], file: { version: 1, agents: {} } },
+      hostSecurity: "allowlist",
+      hostAsk: "on-miss",
+      askFallback: "deny",
+    });
+
+    const result = await runGatewayAllowlist({
+      command,
+      ask: "on-miss",
+      autoReview: true,
+    });
+
+    expect(defaultExecAutoReviewerMock).not.toHaveBeenCalled();
+    expect(createAndRegisterDefaultExecApprovalRequestMock).toHaveBeenCalledTimes(1);
+    expect(result.pendingResult?.details.status).toBe("approval-pending");
+  });
+
+  it("requires explicit approval for Windows PowerShell expansion allowlist misses", async () => {
+    const command = 'node app.js "$(whoami)"';
+    requiresExecApprovalMock.mockReturnValue(true);
+    evaluateShellAllowlistWithAuthorizationMock.mockReturnValue({
+      allowlistMatches: [],
+      analysisOk: true,
+      allowlistSatisfied: false,
+      segments: [
+        {
+          raw: command,
+          resolution: null,
+          argv: ["node", "app.js", "$(whoami)"],
+          requiresExplicitApproval: "windows-shell-expansion",
+        },
+      ],
+      segmentAllowlistEntries: [],
+    });
+    resolveExecHostApprovalContextMock.mockReturnValue({
+      approvals: { allowlist: [], file: { version: 1, agents: {} } },
+      hostSecurity: "allowlist",
+      hostAsk: "on-miss",
+      askFallback: "deny",
+    });
+
+    const result = await runGatewayAllowlist({
+      command,
+      ask: "on-miss",
+      autoReview: true,
+    });
+
+    expect(defaultExecAutoReviewerMock).not.toHaveBeenCalled();
+    expect(createAndRegisterDefaultExecApprovalRequestMock).toHaveBeenCalledTimes(1);
+    expect(result.pendingResult?.details.status).toBe("approval-pending");
+  });
+
   it("auto-reviews heredoc commands instead of forcing human approval", async () => {
     const command = "python3 - <<'PY'\nprint('ok')\nPY";
     requiresExecApprovalMock.mockReturnValue(false);
@@ -722,7 +797,7 @@ describe("processGatewayAllowlist", () => {
     });
   });
 
-  it("auto-reviews allowlist plan misses instead of forcing human approval", async () => {
+  it("requires human approval for allowlist plan misses", async () => {
     const command = "echo ok";
     requiresExecApprovalMock.mockReturnValue(false);
     buildEnforcedShellCommandMock.mockReturnValue({
@@ -749,19 +824,9 @@ describe("processGatewayAllowlist", () => {
       autoReview: true,
     });
 
-    expect(defaultExecAutoReviewerMock).toHaveBeenCalledWith(
-      expect.objectContaining({
-        command,
-        argv: ["echo", "ok"],
-        host: "gateway",
-        reason: "execution-plan-miss",
-      }),
-    );
-    expect(createAndRegisterDefaultExecApprovalRequestMock).not.toHaveBeenCalled();
-    expect(result).toEqual({
-      execCommandOverride: undefined,
-      allowWithoutEnforcedCommand: true,
-    });
+    expect(defaultExecAutoReviewerMock).not.toHaveBeenCalled();
+    expect(createAndRegisterDefaultExecApprovalRequestMock).toHaveBeenCalledTimes(1);
+    expect(result.pendingResult?.details.status).toBe("approval-pending");
   });
 
   it("omits allow-always when allowlist execution cannot persist reusable patterns", async () => {

--- a/src/agents/bash-tools.exec-host-gateway.test.ts
+++ b/src/agents/bash-tools.exec-host-gateway.test.ts
@@ -52,6 +52,9 @@ const buildExecApprovalPendingToolResultMock = vi.hoisted(() => vi.fn());
 const buildExecApprovalFollowupTargetMock = vi.hoisted(() =>
   vi.fn<BuildExecApprovalFollowupTargetMock>(() => null),
 );
+const registerExecApprovalRequestForHostOrThrowMock = vi.hoisted(() =>
+  vi.fn(async () => undefined),
+);
 const createExecApprovalDecisionStateMock = vi.hoisted(() =>
   vi.fn(
     (): {
@@ -173,7 +176,7 @@ vi.mock("../infra/exec-auto-review.js", () => ({
 vi.mock("./bash-tools.exec-approval-request.js", () => ({
   buildExecApprovalRequesterContext: vi.fn(() => ({})),
   buildExecApprovalTurnSourceContext: vi.fn(() => ({})),
-  registerExecApprovalRequestForHostOrThrow: vi.fn(async () => undefined),
+  registerExecApprovalRequestForHostOrThrow: registerExecApprovalRequestForHostOrThrowMock,
 }));
 
 vi.mock("./bash-tools.exec-host-shared.js", () => ({
@@ -330,16 +333,24 @@ describe("processGatewayAllowlist", () => {
       details: { status: "approval-pending" },
       content: [],
     });
+    registerExecApprovalRequestForHostOrThrowMock.mockClear();
     createAndRegisterDefaultExecApprovalRequestMock.mockReset();
-    createAndRegisterDefaultExecApprovalRequestMock.mockResolvedValue({
-      approvalId: "req-1",
-      approvalSlug: "slug-1",
-      warningText: "",
-      expiresAtMs: Date.now() + 60_000,
-      preResolvedDecision: null,
-      initiatingSurface: "origin",
-      sentApproverDms: false,
-      unavailableReason: null,
+    createAndRegisterDefaultExecApprovalRequestMock.mockImplementation(async (args?: unknown) => {
+      const register =
+        args && typeof args === "object" && "register" in args
+          ? (args as { register?: (approvalId: string) => Promise<void> }).register
+          : undefined;
+      await register?.("req-1");
+      return {
+        approvalId: "req-1",
+        approvalSlug: "slug-1",
+        warningText: "",
+        expiresAtMs: Date.now() + 60_000,
+        preResolvedDecision: null,
+        initiatingSurface: "origin",
+        sentApproverDms: false,
+        unavailableReason: null,
+      };
     });
   });
 
@@ -618,6 +629,23 @@ describe("processGatewayAllowlist", () => {
 
     expect(defaultExecAutoReviewerMock).not.toHaveBeenCalled();
     expect(createAndRegisterDefaultExecApprovalRequestMock).toHaveBeenCalledTimes(1);
+    expect(resolveExecApprovalAllowedDecisionsMock).toHaveBeenCalledWith({
+      ask: "on-miss",
+      allowAlwaysPersistence: {
+        kind: "one-shot",
+        reasons: ["no-reusable-pattern"],
+      },
+    });
+    expect(registerExecApprovalRequestForHostOrThrowMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        unavailableDecisions: ["allow-always"],
+      }),
+    );
+    expect(buildExecApprovalPendingToolResultMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        allowedDecisions: ["allow-once", "deny"],
+      }),
+    );
     expect(result.pendingResult?.details.status).toBe("approval-pending");
   });
 
@@ -653,6 +681,23 @@ describe("processGatewayAllowlist", () => {
 
     expect(defaultExecAutoReviewerMock).not.toHaveBeenCalled();
     expect(createAndRegisterDefaultExecApprovalRequestMock).toHaveBeenCalledTimes(1);
+    expect(resolveExecApprovalAllowedDecisionsMock).toHaveBeenCalledWith({
+      ask: "on-miss",
+      allowAlwaysPersistence: {
+        kind: "one-shot",
+        reasons: ["no-reusable-pattern"],
+      },
+    });
+    expect(registerExecApprovalRequestForHostOrThrowMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        unavailableDecisions: ["allow-always"],
+      }),
+    );
+    expect(buildExecApprovalPendingToolResultMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        allowedDecisions: ["allow-once", "deny"],
+      }),
+    );
     expect(result.pendingResult?.details.status).toBe("approval-pending");
   });
 

--- a/src/agents/bash-tools.exec-host-gateway.test.ts
+++ b/src/agents/bash-tools.exec-host-gateway.test.ts
@@ -699,8 +699,8 @@ describe("processGatewayAllowlist", () => {
     );
     expect(createAndRegisterDefaultExecApprovalRequestMock).not.toHaveBeenCalled();
     expect(result).toEqual({
-      execCommandOverride: undefined,
-      allowWithoutEnforcedCommand: true,
+      execCommandOverride: command,
+      allowWithoutEnforcedCommand: false,
     });
   });
 
@@ -755,8 +755,8 @@ describe("processGatewayAllowlist", () => {
     expect(createAndRegisterDefaultExecApprovalRequestMock).not.toHaveBeenCalled();
     expect(warnings[0]).toContain("reviewer or explicit approval");
     expect(result).toEqual({
-      execCommandOverride: undefined,
-      allowWithoutEnforcedCommand: true,
+      execCommandOverride: command,
+      allowWithoutEnforcedCommand: false,
     });
   });
 
@@ -771,6 +771,10 @@ describe("processGatewayAllowlist", () => {
       throw new Error(authorizationPlan.reason);
     }
     requiresExecApprovalMock.mockReturnValue(false);
+    buildEnforcedShellCommandMock.mockReturnValue({
+      ok: true,
+      command: "/usr/bin/head -c 16",
+    });
     evaluateShellAllowlistWithAuthorizationMock.mockReturnValue({
       allowlistMatches: [],
       analysisOk: true,
@@ -797,7 +801,7 @@ describe("processGatewayAllowlist", () => {
     });
   });
 
-  it("requires human approval for allowlist plan misses", async () => {
+  it("auto-reviews allowlist plan misses before asking a human", async () => {
     const command = "echo ok";
     requiresExecApprovalMock.mockReturnValue(false);
     buildEnforcedShellCommandMock.mockReturnValue({
@@ -824,9 +828,19 @@ describe("processGatewayAllowlist", () => {
       autoReview: true,
     });
 
-    expect(defaultExecAutoReviewerMock).not.toHaveBeenCalled();
-    expect(createAndRegisterDefaultExecApprovalRequestMock).toHaveBeenCalledTimes(1);
-    expect(result.pendingResult?.details.status).toBe("approval-pending");
+    expect(defaultExecAutoReviewerMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        command,
+        argv: ["echo", "ok"],
+        host: "gateway",
+        reason: "execution-plan-miss",
+      }),
+    );
+    expect(createAndRegisterDefaultExecApprovalRequestMock).not.toHaveBeenCalled();
+    expect(result).toEqual({
+      execCommandOverride: undefined,
+      allowWithoutEnforcedCommand: true,
+    });
   });
 
   it("omits allow-always when allowlist execution cannot persist reusable patterns", async () => {

--- a/src/agents/bash-tools.exec-host-gateway.test.ts
+++ b/src/agents/bash-tools.exec-host-gateway.test.ts
@@ -1448,6 +1448,41 @@ EOF`,
     expect(result).toEqual({ execCommandOverride: undefined });
   });
 
+  it("requires explicit approval for Windows PowerShell expansion despite durable exact-command trust", async () => {
+    const command = 'powershell -NoProfile -Command "$env:USERPROFILE"';
+    evaluateShellAllowlistWithAuthorizationMock.mockReturnValue({
+      allowlistMatches: [{ pattern: "powershell.exe", source: "allow-always" }],
+      analysisOk: true,
+      allowlistSatisfied: true,
+      segments: [
+        {
+          raw: command,
+          resolution: null,
+          argv: ["powershell", "-NoProfile", "-Command", "$env:USERPROFILE"],
+          requiresExplicitApproval: "windows-shell-expansion",
+        },
+      ],
+      segmentAllowlistEntries: [{ pattern: "powershell.exe", source: "allow-always" }],
+      segmentSatisfiedBy: ["allowlist"],
+    });
+    hasDurableExecApprovalMock.mockReturnValue(true);
+    requiresExecApprovalMock.mockReturnValue(false);
+    buildEnforcedShellCommandMock.mockReturnValue({
+      ok: true,
+      command,
+    });
+
+    const result = await runGatewayAllowlist({
+      command,
+      ask: "on-miss",
+      autoReview: true,
+    });
+
+    expect(defaultExecAutoReviewerMock).not.toHaveBeenCalled();
+    expect(createAndRegisterDefaultExecApprovalRequestMock).toHaveBeenCalledTimes(1);
+    expect(result.pendingResult?.details.status).toBe("approval-pending");
+  });
+
   it("keeps denying allowlist misses when durable trust does not match", async () => {
     evaluateShellAllowlistWithAuthorizationMock.mockReturnValue({
       allowlistMatches: [],

--- a/src/agents/bash-tools.exec-host-gateway.test.ts
+++ b/src/agents/bash-tools.exec-host-gateway.test.ts
@@ -699,8 +699,8 @@ describe("processGatewayAllowlist", () => {
     );
     expect(createAndRegisterDefaultExecApprovalRequestMock).not.toHaveBeenCalled();
     expect(result).toEqual({
-      execCommandOverride: command,
-      allowWithoutEnforcedCommand: false,
+      execCommandOverride: process.platform === "win32" ? command : undefined,
+      allowWithoutEnforcedCommand: process.platform !== "win32",
     });
   });
 
@@ -755,8 +755,8 @@ describe("processGatewayAllowlist", () => {
     expect(createAndRegisterDefaultExecApprovalRequestMock).not.toHaveBeenCalled();
     expect(warnings[0]).toContain("reviewer or explicit approval");
     expect(result).toEqual({
-      execCommandOverride: command,
-      allowWithoutEnforcedCommand: false,
+      execCommandOverride: process.platform === "win32" ? command : undefined,
+      allowWithoutEnforcedCommand: process.platform !== "win32",
     });
   });
 

--- a/src/agents/bash-tools.exec-host-gateway.ts
+++ b/src/agents/bash-tools.exec-host-gateway.ts
@@ -607,6 +607,9 @@ export async function processGatewayAllowlist(
     );
   }
   if (requiresAsk) {
+    const requiresExplicitApproval = allowlistEval.segments.some(
+      (segment) => segment.requiresExplicitApproval !== undefined,
+    );
     const [autoReviewSegment] = allowlistEval.segments;
     const autoReviewArgv =
       allowlistEval.segments.length === 1 &&
@@ -619,9 +622,13 @@ export async function processGatewayAllowlist(
       params.autoReview === true &&
       hostAsk !== "always" &&
       autoReviewHasBoundCommand &&
+      !requiresAllowlistPlanApproval &&
+      !requiresExplicitApproval &&
       !requiresSecurityAuditSuppressionApproval;
     let autoReviewRequiresHumanApproval =
       (params.autoReview === true && hostAsk !== "always" && !autoReviewHasBoundCommand) ||
+      requiresAllowlistPlanApproval ||
+      requiresExplicitApproval ||
       requiresSecurityAuditSuppressionApproval;
     if (canAutoReviewApprovalMiss) {
       const reviewer = params.autoReviewer ?? defaultExecAutoReviewer;

--- a/src/agents/bash-tools.exec-host-gateway.ts
+++ b/src/agents/bash-tools.exec-host-gateway.ts
@@ -171,8 +171,12 @@ function createOneShotAllowAlwaysDecision(): AllowAlwaysPersistenceDecision {
 function resolveGatewayEffectiveAllowAlwaysPersistence(params: {
   command: string;
   allowAlwaysPersistence: AllowAlwaysPersistenceDecision;
+  requiresExplicitApproval: boolean;
   requiresAllowlistPlanApproval: boolean;
 }): AllowAlwaysPersistenceDecision {
+  if (params.requiresExplicitApproval) {
+    return createOneShotAllowAlwaysDecision();
+  }
   if (!params.requiresAllowlistPlanApproval) {
     return params.allowAlwaysPersistence;
   }
@@ -562,6 +566,9 @@ export async function processGatewayAllowlist(
       env: params.env,
       segments: allowlistEval.segments,
     }) && !(hostSecurity === "full" && hostAsk === "off");
+  const requiresExplicitApproval = allowlistEval.segments.some(
+    (segment) => segment.requiresExplicitApproval !== undefined,
+  );
   const requiresAsk =
     requiresExecApproval({
       ask: hostAsk,
@@ -587,6 +594,7 @@ export async function processGatewayAllowlist(
   const effectiveAllowAlwaysPersistence = resolveGatewayEffectiveAllowAlwaysPersistence({
     command: params.command,
     allowAlwaysPersistence,
+    requiresExplicitApproval,
     requiresAllowlistPlanApproval,
   });
   const approvalAllowedDecisions = resolveExecApprovalAllowedDecisions({
@@ -607,9 +615,6 @@ export async function processGatewayAllowlist(
     );
   }
   if (requiresAsk) {
-    const requiresExplicitApproval = allowlistEval.segments.some(
-      (segment) => segment.requiresExplicitApproval !== undefined,
-    );
     const [autoReviewSegment] = allowlistEval.segments;
     const autoReviewArgv =
       allowlistEval.segments.length === 1 &&

--- a/src/agents/bash-tools.exec-host-gateway.ts
+++ b/src/agents/bash-tools.exec-host-gateway.ts
@@ -622,12 +622,10 @@ export async function processGatewayAllowlist(
       params.autoReview === true &&
       hostAsk !== "always" &&
       autoReviewHasBoundCommand &&
-      !requiresAllowlistPlanApproval &&
       !requiresExplicitApproval &&
       !requiresSecurityAuditSuppressionApproval;
     let autoReviewRequiresHumanApproval =
       (params.autoReview === true && hostAsk !== "always" && !autoReviewHasBoundCommand) ||
-      requiresAllowlistPlanApproval ||
       requiresExplicitApproval ||
       requiresSecurityAuditSuppressionApproval;
     if (canAutoReviewApprovalMiss) {

--- a/src/agents/bash-tools.exec-host-gateway.ts
+++ b/src/agents/bash-tools.exec-host-gateway.ts
@@ -580,6 +580,7 @@ export async function processGatewayAllowlist(
     requiresAllowlistPlanApproval ||
     requiresHeredocApproval ||
     requiresInlineEvalApproval ||
+    requiresExplicitApproval ||
     requiresSecurityAuditSuppressionApproval;
   if (requiresHeredocApproval) {
     params.warnings.push(

--- a/src/agents/bash-tools.exec-host-node-phases.ts
+++ b/src/agents/bash-tools.exec-host-node-phases.ts
@@ -104,6 +104,10 @@ function resolveNodeRunTimeoutMs(runTimeoutSec: number): number {
     : 0;
 }
 
+function createOneShotAllowAlwaysDecision(): AllowAlwaysPersistenceDecision {
+  return { kind: "one-shot", reasons: ["no-reusable-pattern"] };
+}
+
 type NodePolicyCommandEval = {
   command: string;
   cwd: string | undefined;
@@ -672,6 +676,17 @@ export async function analyzeNodeApprovalRequirement(params: {
       // Fall back to requiring approval if node approvals cannot be fetched.
     }
   }
+  const allowAlwaysPersistence = resolveAllowAlwaysPersistenceDecision({
+    segments: baseAllowlistEval.segments,
+    commandText: approvalCommand,
+    cwd: approvalCwd,
+    env: analysisEnv,
+    platform: params.target.platform,
+    strictInlineEval: params.request.strictInlineEval,
+    authorizationPlan: baseAllowlistEval.authorizationPlan,
+    runtimePayload: inlineEvalHit !== null,
+    preparedCoverage: params.prepared.allowAlwaysCoverage,
+  });
   return {
     analysisOk,
     allowlistSatisfied,
@@ -682,17 +697,9 @@ export async function analyzeNodeApprovalRequirement(params: {
     inlineEvalHit,
     requiresExplicitApproval,
     requiresSecurityAuditSuppressionApproval,
-    allowAlwaysPersistence: resolveAllowAlwaysPersistenceDecision({
-      segments: baseAllowlistEval.segments,
-      commandText: approvalCommand,
-      cwd: approvalCwd,
-      env: analysisEnv,
-      platform: params.target.platform,
-      strictInlineEval: params.request.strictInlineEval,
-      authorizationPlan: baseAllowlistEval.authorizationPlan,
-      runtimePayload: inlineEvalHit !== null,
-      preparedCoverage: params.prepared.allowAlwaysCoverage,
-    }),
+    allowAlwaysPersistence: requiresExplicitApproval
+      ? createOneShotAllowAlwaysDecision()
+      : allowAlwaysPersistence,
     autoReviewArgv:
       autoReviewBindingEval.segments.length === 1 &&
       (autoReviewBindingEval.segments[0]?.raw === undefined ||

--- a/src/agents/bash-tools.exec-host-node-phases.ts
+++ b/src/agents/bash-tools.exec-host-node-phases.ts
@@ -74,6 +74,7 @@ type NodeApprovalAnalysis = {
   nodeSecurity?: ExecSecurity;
   nodeAsk?: ExecAsk;
   inlineEvalHit: InterpreterInlineEvalHit | null;
+  requiresExplicitApproval: boolean;
   requiresSecurityAuditSuppressionApproval: boolean;
   autoReviewArgv?: string[];
   allowAlwaysPersistence: AllowAlwaysPersistenceDecision;
@@ -588,6 +589,9 @@ export async function analyzeNodeApprovalRequirement(params: {
         segments: entry.allowlistEval.segments,
       }),
     ) && !(params.hostSecurity === "full" && params.hostAsk === "off");
+  const requiresExplicitApproval = policyCommandEvals.some((entry) =>
+    entry.allowlistEval.segments.some((segment) => segment.requiresExplicitApproval !== undefined),
+  );
   if (
     (params.hostAsk === "always" ||
       params.hostSecurity === "allowlist" ||
@@ -676,6 +680,7 @@ export async function analyzeNodeApprovalRequirement(params: {
     nodeSecurity: params.prepared.execPolicy?.security,
     nodeAsk: params.prepared.execPolicy?.ask,
     inlineEvalHit,
+    requiresExplicitApproval,
     requiresSecurityAuditSuppressionApproval,
     allowAlwaysPersistence: resolveAllowAlwaysPersistenceDecision({
       segments: baseAllowlistEval.segments,

--- a/src/agents/bash-tools.exec-host-node.test.ts
+++ b/src/agents/bash-tools.exec-host-node.test.ts
@@ -25,6 +25,7 @@ type MockAllowlistSegment = {
   raw?: string;
   resolution: null;
   argv: string[];
+  requiresExplicitApproval?: "windows-shell-expansion";
 };
 type MockAllowlistResult = {
   allowlistMatches: unknown[];

--- a/src/agents/bash-tools.exec-host-node.test.ts
+++ b/src/agents/bash-tools.exec-host-node.test.ts
@@ -742,6 +742,19 @@ describe("executeNodeHostCommand", () => {
     expect(result.details?.status).toBe("approval-pending");
     expect(autoReviewer).not.toHaveBeenCalled();
     expect(createAndRegisterDefaultExecApprovalRequestMock).toHaveBeenCalledTimes(1);
+    expect(resolveExecApprovalAllowedDecisionsMock).toHaveBeenCalledWith({
+      ask: "on-miss",
+      allowAlwaysPersistence: {
+        kind: "one-shot",
+        reasons: ["no-reusable-pattern"],
+      },
+    });
+    expect(requireRegisteredApprovalRequest().unavailableDecisions).toEqual(["allow-always"]);
+    expect(buildExecApprovalPendingToolResultMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        allowedDecisions: ["allow-once", "deny"],
+      }),
+    );
   });
 
   it("reviews the prepared node plan before suppressing human approval", async () => {

--- a/src/agents/bash-tools.exec-host-node.test.ts
+++ b/src/agents/bash-tools.exec-host-node.test.ts
@@ -687,6 +687,62 @@ describe("executeNodeHostCommand", () => {
     );
   });
 
+  it("requires explicit approval for Windows PowerShell expansion node commands", async () => {
+    const autoReviewer = vi.fn<ExecAutoReviewer>(async () => ({
+      decision: "allow-once",
+      risk: "low",
+      rationale: "safe read",
+    }));
+    parsePreparedSystemRunPayloadMock.mockReturnValue({
+      plan: {
+        ...preparedPlan,
+        argv: ["powershell", "-NoProfile", "-Command", "$env:USERPROFILE"],
+        commandText: 'powershell -NoProfile -Command "$env:USERPROFILE"',
+      },
+      execPolicy: { security: "full", ask: "off" },
+    });
+    evaluateShellAllowlistMock.mockReturnValue({
+      allowlistMatches: [],
+      analysisOk: true,
+      allowlistSatisfied: false,
+      segments: [
+        {
+          raw: 'powershell -NoProfile -Command "$env:USERPROFILE"',
+          resolution: null,
+          argv: ["powershell", "-NoProfile", "-Command", "$env:USERPROFILE"],
+          requiresExplicitApproval: "windows-shell-expansion",
+        },
+      ],
+      segmentAllowlistEntries: [],
+    });
+    resolveExecHostApprovalContextMock.mockReturnValue({
+      approvals: { allowlist: [], file: { version: 1, agents: {} } },
+      hostSecurity: "allowlist",
+      hostAsk: "on-miss",
+      askFallback: "deny",
+    });
+    requiresExecApprovalMock.mockReturnValue(false);
+
+    const result = await executeNodeHostCommand({
+      command: 'powershell -NoProfile -Command "$env:USERPROFILE"',
+      workdir: "/tmp/work",
+      env: {},
+      security: "allowlist",
+      ask: "on-miss",
+      autoReview: true,
+      autoReviewer,
+      defaultTimeoutSec: 30,
+      approvalRunningNoticeMs: 0,
+      warnings: [],
+      agentId: "requested-agent",
+      sessionKey: "requested-session",
+    });
+
+    expect(result.details?.status).toBe("approval-pending");
+    expect(autoReviewer).not.toHaveBeenCalled();
+    expect(createAndRegisterDefaultExecApprovalRequestMock).toHaveBeenCalledTimes(1);
+  });
+
   it("reviews the prepared node plan before suppressing human approval", async () => {
     const divergentPlan = {
       argv: ["rm", "-rf", "/tmp/work"],

--- a/src/agents/bash-tools.exec-host-node.ts
+++ b/src/agents/bash-tools.exec-host-node.ts
@@ -128,6 +128,7 @@ export async function executeNodeHostCommand(
     nodeSecurity,
     nodeAsk,
     inlineEvalHit,
+    requiresExplicitApproval,
     requiresSecurityAuditSuppressionApproval,
     autoReviewArgv,
     allowAlwaysPersistence,
@@ -153,6 +154,7 @@ export async function executeNodeHostCommand(
       durableApprovalSatisfied,
     }) ||
     inlineEvalHit !== null ||
+    requiresExplicitApproval ||
     requiresSecurityAuditSuppressionApproval;
   if (requiresSecurityAuditSuppressionApproval) {
     params.warnings.push(
@@ -207,12 +209,14 @@ export async function executeNodeHostCommand(
     let autoReviewRequiresHumanApproval =
       autoReviewBlockedByNodePolicy ||
       (params.autoReview === true && hostAsk !== "always" && !autoReviewHasBoundCommand) ||
+      requiresExplicitApproval ||
       requiresSecurityAuditSuppressionApproval;
     if (
       params.autoReview === true &&
       hostAsk !== "always" &&
       autoReviewHasBoundCommand &&
       !autoReviewBlockedByNodePolicy &&
+      !requiresExplicitApproval &&
       !requiresSecurityAuditSuppressionApproval
     ) {
       const reviewer = params.autoReviewer ?? defaultExecAutoReviewer;

--- a/src/config/io.write-config.test.ts
+++ b/src/config/io.write-config.test.ts
@@ -197,6 +197,19 @@ describe("config io write", () => {
       logger: silentLogger,
     });
 
+  it("writes openclaw.json without a UTF-8 BOM", async () => {
+    await withSuiteHome(async (home) => {
+      const configPath = path.join(home, ".openclaw", "openclaw.json");
+      const io = createFastConfigIO(home);
+
+      await io.writeConfigFile({ gateway: { mode: "local" } });
+
+      const bytes = await fs.readFile(configPath);
+      expect([...bytes.subarray(0, 3)]).not.toEqual([0xef, 0xbb, 0xbf]);
+      expect(bytes[0]).toBe("{".charCodeAt(0));
+    });
+  });
+
   it("writes health state to SQLite through public config reads", async () => {
     await withSuiteHome(async (home) => {
       const configPath = path.join(home, ".openclaw", "openclaw.json");

--- a/src/infra/exec-approvals-analysis.test.ts
+++ b/src/infra/exec-approvals-analysis.test.ts
@@ -90,20 +90,39 @@ describe("Windows shell analysis", () => {
     }
   });
 
-  it("rejects PowerShell expansion tokens", () => {
+  it("parses PowerShell expansion tokens for approval review", () => {
     const cases: string[] = [
-      'node tool.js "--user=%USERNAME%"',
       'node app.js "$env:USERPROFILE"',
       "node app.js ${var}",
-      "node app.js $(whoami)",
       'node app.js "$?"',
       'node app.js "$$"',
+      'node app.js "$_"',
     ];
 
     for (const command of cases) {
       const res = analyzeWindowsShellCommand({ command, platform: "win32" });
-      expect(res.ok).toBe(false);
+      expect(res.ok).toBe(true);
+      expect(res.segments[0]?.argv[0]).toBe("node");
+      expect(res.segments[0]?.requiresExplicitApproval).toBe("windows-shell-expansion");
     }
+  });
+
+  it("still rejects cmd-style expansion tokens during analysis", () => {
+    const res = analyzeWindowsShellCommand({
+      command: 'node tool.js "--user=%USERNAME%"',
+      platform: "win32",
+    });
+
+    expect(res.ok).toBe(false);
+  });
+
+  it("still rejects unquoted PowerShell subexpressions during analysis", () => {
+    const res = analyzeWindowsShellCommand({
+      command: "node app.js $(whoami)",
+      platform: "win32",
+    });
+
+    expect(res.ok).toBe(false);
   });
 
   it("allows bare $ not followed by identifier", () => {
@@ -219,6 +238,26 @@ describe("Windows enforced shell command rendering", () => {
 
     expect(result.ok).toBe(false);
   });
+
+  it("refuses to build enforced commands with PowerShell expansion tokens", () => {
+    const analysis = analyzeWindowsShellCommand({
+      command: 'node app.js "$env:USERPROFILE"',
+      platform: "win32",
+    });
+
+    expect(analysis.ok).toBe(true);
+
+    const result = buildEnforcedShellCommand({
+      command: 'node app.js "$env:USERPROFILE"',
+      segments: analysis.segments,
+      platform: "win32",
+    });
+
+    expect(result).toEqual({
+      ok: false,
+      reason: "unenforceable windows shell token: $",
+    });
+  });
 });
 
 describe("windowsEscapeArg", () => {
@@ -244,6 +283,7 @@ describe("windowsEscapeArg", () => {
     expect(windowsEscapeArg("$(whoami)")).toEqual({ ok: false });
     expect(windowsEscapeArg("$?")).toEqual({ ok: false });
     expect(windowsEscapeArg("$$")).toEqual({ ok: false });
+    expect(windowsEscapeArg("$_")).toEqual({ ok: false });
   });
 
   it("allows $ not followed by identifier", () => {

--- a/src/infra/exec-command-analysis-types.ts
+++ b/src/infra/exec-command-analysis-types.ts
@@ -4,6 +4,7 @@ export type ExecCommandSegment = {
   raw: string;
   argv: string[];
   sourceArgv?: string[];
+  requiresExplicitApproval?: "windows-shell-expansion";
   resolution: CommandResolution | null;
 };
 

--- a/src/infra/windows-shell-command.ts
+++ b/src/infra/windows-shell-command.ts
@@ -190,14 +190,16 @@ export function isWindowsPlatform(platform?: string | null): boolean {
 const WINDOWS_UNSAFE_CMD_META = /[%`]|\$(?=[A-Za-z_{(?$_])/;
 
 function findWindowsShellExpansionToken(command: string): string | null {
-  for (let i = 0; i < command.length; i += 1) {
-    if (command[i] !== "$") {
+  let previous = "";
+  for (const current of command) {
+    if (previous !== "$") {
+      previous = current;
       continue;
     }
-    const next = command[i + 1];
-    if (next !== undefined && /[A-Za-z_{(?$_]/.test(next)) {
+    if (/[A-Za-z_{(?$_]/.test(current)) {
       return "$";
     }
+    previous = current;
   }
   return null;
 }

--- a/src/infra/windows-shell-command.ts
+++ b/src/infra/windows-shell-command.ts
@@ -32,13 +32,6 @@ function findWindowsUnsupportedToken(command: string): string | null {
       inDouble = !inDouble;
       continue;
     }
-    if (ch === "$") {
-      const next = command[i + 1];
-      if (next !== undefined && /[A-Za-z_{(?$]/.test(next)) {
-        return "$";
-      }
-      continue;
-    }
     if (WINDOWS_UNSUPPORTED_TOKENS.has(ch)) {
       if (inDouble && !WINDOWS_ALWAYS_UNSAFE_TOKENS.has(ch)) {
         continue;
@@ -168,12 +161,16 @@ export function analyzeWindowsShellCommand(params: {
   if (!argv || argv.length === 0) {
     return { ok: false, reason: "unable to parse windows command", segments: [] };
   }
+  const shellExpansionToken = findWindowsShellExpansionToken(effective);
   return {
     ok: true,
     segments: [
       {
         raw: params.command,
         argv,
+        ...(shellExpansionToken
+          ? { requiresExplicitApproval: "windows-shell-expansion" as const }
+          : {}),
         resolution: resolveCommandResolutionFromArgv(
           argv,
           params.cwd,
@@ -190,7 +187,20 @@ export function isWindowsPlatform(platform?: string | null): boolean {
   return normalized.startsWith("win");
 }
 
-const WINDOWS_UNSAFE_CMD_META = /[%`]|\$(?=[A-Za-z_{(?$])/;
+const WINDOWS_UNSAFE_CMD_META = /[%`]|\$(?=[A-Za-z_{(?$_])/;
+
+function findWindowsShellExpansionToken(command: string): string | null {
+  for (let i = 0; i < command.length; i += 1) {
+    if (command[i] !== "$") {
+      continue;
+    }
+    const next = command[i + 1];
+    if (next !== undefined && /[A-Za-z_{(?$_]/.test(next)) {
+      return "$";
+    }
+  }
+  return null;
+}
 
 export function windowsEscapeArg(value: string): { ok: true; escaped: string } | { ok: false } {
   if (value === "") {
@@ -228,6 +238,10 @@ export function rebuildWindowsShellCommandFromSource(params: {
   const unsupported = findWindowsUnsupportedToken(source);
   if (unsupported) {
     return { ok: false, reason: `unsupported windows shell token: ${unsupported}` };
+  }
+  const unenforceable = findWindowsShellExpansionToken(source);
+  if (unenforceable) {
+    return { ok: false, reason: `unenforceable windows shell token: ${unenforceable}` };
   }
   const rendered = params.renderSegment(source, 0);
   if (!rendered.ok) {

--- a/src/infra/windows-shell-command.ts
+++ b/src/infra/windows-shell-command.ts
@@ -26,8 +26,7 @@ function findWindowsUnsupportedToken(command: string): string | null {
   let inDouble = false;
   // cmd.exe does not recognise single quotes, so they are not treated as safe
   // quoting for this cross-host safety check.
-  for (let i = 0; i < command.length; i++) {
-    const ch = command[i];
+  for (const ch of command) {
     if (ch === '"') {
       inDouble = !inDouble;
       continue;


### PR DESCRIPTION
Closes #100289

## What Problem This Solves

Fixes an issue where Windows exec approval analysis treated PowerShell `$` variables as unparseable, which could block or misroute commands such as `$env:USERPROFILE` before they could be explicitly approved. Also adds regression coverage that config writes keep `openclaw.json` BOM-free.

## Why This Change Was Made

Windows shell analysis now parses PowerShell expansion tokens for approval review, but marks those segments as requiring explicit approval. Gateway-host and node-host exec both honor that marker by blocking auto-review auto-execution only for marked expansion segments, while ordinary unmarked allowlist plan misses still use the existing auto-review path.

After the ClawSweeper review, explicit Windows expansion approvals now also force one-shot approval persistence in both gateway and node exec hosts. That keeps `allow-always` unavailable for expansion approval requests while preserving reusable approvals for ordinary, enforceable commands. Windows enforced-command rendering still refuses to rebuild commands containing PowerShell expansion tokens so reviewed argv cannot drift from executed PowerShell behavior.

The config writer already emits JSON through Node string writes without adding a BOM, so this change adds a byte-level regression test instead of inventing a separate writer path.

## User Impact

Windows users can get PowerShell variable commands into the normal exec approval flow without the command being treated as an unsupported parse failure. Commands containing PowerShell expansion require explicit one-shot approval rather than reusable/auto-review enforcement, preserving the approval boundary.

Config writes are covered by a regression test that verifies the file starts with `{` and not `EF BB BF`.

## Evidence

- Current head: `afc4a6aa7be90a44a42fe490616ceec4239f6222`.
- Claim proved by focused tests:
  - Windows PowerShell expansion tokens parse for approval review, cannot be rebuilt into enforced commands, and require explicit approval on both gateway and node exec hosts.
  - Explicit Windows expansion approval requests now force one-shot persistence, make `allow-always` unavailable, and show pending decisions `allow-once` / `deny`.
  - Unmarked gateway allowlist plan misses still go through auto-review.
- Real Windows/Gateway behavior proof on current head:
  - Worktree: `E:\code\openclaw-pr-100322-proof`, `git rev-parse HEAD` -> `afc4a6aa7be90a44a42fe490616ceec4239f6222`.
  - Gateway/Control UI: local Gateway at `http://127.0.0.1:19001/`, Control UI session `agent:dev:main`, exec approval policy set to host `gateway`, security `allowlist`, ask `always`, ask fallback `deny`.
  - Real gateway-host exec driver invoked the PR-head `createExecTool({ host: "gateway", security: "allowlist", ask: "always" })` path with command `powershell.exe -NoProfile -Command 'Write-Output $env:USERPROFILE'`.
  - Pending result: `status="approval-pending"`, host `gateway`, command text preserved with `$env:USERPROFILE`, `allowedDecisions=["allow-once","deny"]`; `allow-always` was not present.
  - Control UI approval card showed the same command, host `gateway`, agent `dev`, session `agent:dev:main`, CWD `E:\code\openclaw-pr-100322-proof`, security `allowlist`, ask policy `always`, and the message that always-allow was unavailable because the effective policy requires approval every time. The only visible decision buttons were `允许一次` / `拒绝`.
  - After clicking `允许一次`, the pending approval resolved and the same gateway-host exec continued to completion: `status="completed"`, `exitCode=0`, `timedOut=false`, output matched the Windows `USERPROFILE` value (`C:\Users\<redacted>`).
  - Gateway log corroboration: `exec.approval.request` completed, followed by `exec.approval.waitDecision` completion for the same proof window.
- Commands / artifacts:
- Current follow-up repair on `08029dc85bc0c9d0693e05be586528b2088e5e9f`:
  - Fixed the gateway-host approval predicate so `requiresExplicitApproval` forces an approval request even when exact-command durable approval is already satisfied.
  - Added a gateway-host regression covering Windows PowerShell expansion with durable exact-command trust; the command still returns `approval-pending` instead of bypassing approval.
  - `git diff --check -- src/agents/bash-tools.exec-host-gateway.ts src/agents/bash-tools.exec-host-gateway.test.ts` -> passed.
  - Current-head GitHub checks and ClawSweeper re-review are pending after this push.  - `PNPM_CONFIG_MODULES_DIR=E:\code\openclaw\node_modules OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs src/agents/bash-tools.exec-host-gateway.test.ts src/agents/bash-tools.exec-host-node.test.ts -- -t "Windows PowerShell expansion"` -> passed on current head, 2 files / 3 selected tests.
  - `PNPM_CONFIG_MODULES_DIR=E:\code\openclaw\node_modules OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs src/agents/bash-tools.exec-host-gateway.test.ts src/agents/bash-tools.exec-host-node.test.ts src/infra/exec-approvals-analysis.test.ts src/config/io.write-config.test.ts -- -t "Windows PowerShell expansion|PowerShell expansion|without a UTF-8 BOM|enforced commands with PowerShell expansion"` -> passed on current head, 3 Vitest shards / 6 selected tests.
  - `git diff --check` -> passed on the current repair diff before commit.
  - `python .agents\skills\autoreview\scripts\autoreview --mode local` -> passed on the final local patch with `autoreview clean: no accepted/actionable findings reported` and `overall: patch is correct (0.84)`.
  - Earlier base-PR evidence still applies: `node scripts/run-vitest.mjs src/infra/exec-approvals-analysis.test.ts` passed 23 tests; `node scripts/run-vitest.mjs src/config/io.write-config.test.ts -- -t "writes openclaw.json without a UTF-8 BOM"` passed 1 selected test.
- Observed result:
  - PowerShell expansion segments carry `requiresExplicitApproval: "windows-shell-expansion"`.
  - Gateway/node approval paths do not auto-review marked expansion segments.
  - Gateway/node approval requests for marked expansion segments derive allowed/unavailable decisions from one-shot persistence, so `allow-always` is unavailable and pending UI decisions are `allow-once` / `deny`.
  - Unmarked gateway allowlist plan misses still call the auto-reviewer instead of going directly to human approval.
  - Enforced Windows command rendering rejects expansion tokens including `$env:*`, `$?`, `$$`, `$_`, and `${...}`.
- Dependency contract checked:
  - Sibling `../codex` source was inspected. Codex app-server protocol defines `auto_review` as reviewer routing and command execution approval as a separate request/decision surface. This supports keeping explicit approval scoped to marked PowerShell expansion segments while preserving auto-review for ordinary plan misses.
- Not tested / proof gaps:
  - The previous real Windows/Gateway proof remains the runtime proof for the explicit one-shot expansion flow. The latest current-head repair is a narrow source/test fix for the durable exact-command bypass, with GitHub checks and ClawSweeper re-review pending.
  - Testbox/Crabbox remote proof remains unavailable from this repair lane because the earlier `node scripts/crabbox-wrapper.mjs warmup --provider blacksmith-testbox --keep --timing-json` attempt failed early with `selected binary failed basic --version/--help sanity checks`.
