### PR TITLE
fix: preserve load-path plugins with installed index

### DIFF
--- a/src/commands/channel-setup/plugin-install.test.ts
+++ b/src/commands/channel-setup/plugin-install.test.ts
@@ -89,8 +89,14 @@ vi.mock("../../plugins/loader.js", () => ({
 }));
 
 const discoverOpenClawPlugins = vi.fn((_args?: unknown) => ({ candidates: [], diagnostics: [] }));
+const discoverConfiguredPluginLoadPathCandidates = vi.fn((_args?: unknown) => ({
+  candidates: [],
+  diagnostics: [],
+}));
 vi.mock("../../plugins/discovery.js", () => ({
   discoverOpenClawPlugins: (args: unknown) => discoverOpenClawPlugins(args),
+  discoverConfiguredPluginLoadPathCandidates: (args: unknown) =>
+    discoverConfiguredPluginLoadPathCandidates(args),
 }));
 
 import fs from "node:fs";
@@ -223,6 +229,7 @@ beforeEach(() => {
   }));
   resolveBundledPluginSources.mockReturnValue(new Map());
   discoverOpenClawPlugins.mockReturnValue({ candidates: [], diagnostics: [] });
+  discoverConfiguredPluginLoadPathCandidates.mockReturnValue({ candidates: [], diagnostics: [] });
   getChannelPluginCatalogEntry.mockReturnValue(undefined);
   listChannelPluginCatalogEntries.mockReturnValue([]);
   loadPluginManifestRegistry.mockReturnValue({ plugins: [], diagnostics: [] });

--- a/src/plugins/discovery.ts
+++ b/src/plugins/discovery.ts
@@ -405,10 +405,22 @@ function mergeDiscoveryResult(
 
 function addMissingRequiredPluginDiagnostics(result: PluginDiscoveryResult): void {
   const candidateIds = new Set(result.candidates.map((candidate) => candidate.idHint));
+  addMissingRequiredPluginDiagnosticsForCandidates({
+    candidates: result.candidates,
+    knownCandidateIds: candidateIds,
+    diagnostics: result.diagnostics,
+  });
+}
+
+function addMissingRequiredPluginDiagnosticsForCandidates(params: {
+  candidates: readonly PluginCandidate[];
+  knownCandidateIds: ReadonlySet<string>;
+  diagnostics: PluginDiagnostic[];
+}): void {
   const seen = new Set<string>();
-  for (const candidate of result.candidates) {
+  for (const candidate of params.candidates) {
     for (const requiredPluginId of candidate.requiredPluginIds ?? []) {
-      if (candidateIds.has(requiredPluginId) || requiredPluginId === candidate.idHint) {
+      if (params.knownCandidateIds.has(requiredPluginId) || requiredPluginId === candidate.idHint) {
         continue;
       }
       const key = `${candidate.idHint}\0${requiredPluginId}`;
@@ -416,7 +428,7 @@ function addMissingRequiredPluginDiagnostics(result: PluginDiscoveryResult): voi
         continue;
       }
       seen.add(key);
-      result.diagnostics.push({
+      params.diagnostics.push({
         level: "warn",
         pluginId: candidate.idHint,
         source: candidate.requiredPluginSource ?? candidate.source,
@@ -1207,6 +1219,53 @@ function readChildDirectoryNames(dir: string | undefined): Set<string> {
   }
 }
 
+function discoverConfiguredLoadPaths(params: {
+  loadPaths?: readonly string[];
+  roots: ReturnType<typeof resolvePluginSourceRoots>;
+  workspaceDir?: string;
+  ownershipUid?: number | null;
+  env: NodeJS.ProcessEnv;
+  candidates: PluginCandidate[];
+  diagnostics: PluginDiagnostic[];
+  seen: Set<string>;
+  realpathCache: Map<string, string>;
+  packageManifestCache: Map<string, PackageManifest | null>;
+}): void {
+  for (const loadPath of params.loadPaths ?? []) {
+    if (typeof loadPath !== "string") {
+      continue;
+    }
+    const trimmed = loadPath.trim();
+    if (!trimmed) {
+      continue;
+    }
+    const bundledAlias = resolvePackagedBundledLoadPathAlias({
+      bundledRoot: params.roots.stock,
+      loadPath: resolveUserPath(trimmed, params.env),
+    });
+    if (bundledAlias) {
+      params.diagnostics.push({
+        level: "warn",
+        source: trimmed,
+        message: `ignored plugins.load.paths entry that points at OpenClaw's ${bundledAlias.kind} bundled plugin directory; remove this redundant path or run openclaw doctor --fix`,
+      });
+      continue;
+    }
+    discoverFromPath({
+      rawPath: trimmed,
+      origin: "config",
+      ownershipUid: params.ownershipUid,
+      workspaceDir: params.workspaceDir,
+      env: params.env,
+      candidates: params.candidates,
+      diagnostics: params.diagnostics,
+      seen: params.seen,
+      realpathCache: params.realpathCache,
+      packageManifestCache: params.packageManifestCache,
+    });
+  }
+}
+
 function discoverFromPath(params: {
   rawPath: string;
   origin: PluginOrigin;
@@ -1447,40 +1506,18 @@ export function discoverOpenClawPlugins(params: {
     () => {
       const result = createDiscoveryResult();
       const seen = new Set<string>();
-      const extra = params.extraPaths ?? [];
-      for (const extraPath of extra) {
-        if (typeof extraPath !== "string") {
-          continue;
-        }
-        const trimmed = extraPath.trim();
-        if (!trimmed) {
-          continue;
-        }
-        const bundledAlias = resolvePackagedBundledLoadPathAlias({
-          bundledRoot: roots.stock,
-          loadPath: resolveUserPath(trimmed, env),
-        });
-        if (bundledAlias) {
-          result.diagnostics.push({
-            level: "warn",
-            source: trimmed,
-            message: `ignored plugins.load.paths entry that points at OpenClaw's ${bundledAlias.kind} bundled plugin directory; remove this redundant path or run openclaw doctor --fix`,
-          });
-          continue;
-        }
-        discoverFromPath({
-          rawPath: trimmed,
-          origin: "config",
-          ownershipUid: params.ownershipUid,
-          workspaceDir,
-          env,
-          candidates: result.candidates,
-          diagnostics: result.diagnostics,
-          seen,
-          realpathCache,
-          packageManifestCache,
-        });
-      }
+      discoverConfiguredLoadPaths({
+        loadPaths: params.extraPaths,
+        roots,
+        ownershipUid: params.ownershipUid,
+        workspaceDir,
+        env,
+        candidates: result.candidates,
+        diagnostics: result.diagnostics,
+        seen,
+        realpathCache,
+        packageManifestCache,
+      });
       const workspaceMatchesBundledRoot = resolvesToSameDirectory(
         workspaceRoot,
         roots.stock,
@@ -1630,6 +1667,47 @@ export function discoverOpenClawPlugins(params: {
   const seenDiagnostics = new Set<string>();
   mergeDiscoveryResult(result, scopedResult, seenSources, seenDiagnostics);
   mergeDiscoveryResult(result, sharedResult, seenSources, seenDiagnostics);
+  addMissingRequiredPluginDiagnostics(result);
+  return result;
+}
+
+export function discoverConfiguredPluginLoadPathCandidates(params: {
+  workspaceDir?: string;
+  loadPaths?: readonly string[];
+  knownCandidates?: readonly PluginCandidate[];
+  ownershipUid?: number | null;
+  env?: NodeJS.ProcessEnv;
+}): PluginDiscoveryResult {
+  const env = params.env ?? process.env;
+  const workspaceDir = normalizeOptionalString(params.workspaceDir);
+  const workspaceRoot = workspaceDir ? resolveUserPath(workspaceDir, env) : undefined;
+  const roots = resolvePluginSourceRoots({ workspaceDir: workspaceRoot, env });
+  const result = createDiscoveryResult();
+  const seen = new Set<string>();
+  const realpathCache = new Map<string, string>();
+  const packageManifestCache = new Map<string, PackageManifest | null>();
+  discoverConfiguredLoadPaths({
+    loadPaths: params.loadPaths,
+    roots,
+    ownershipUid: params.ownershipUid,
+    workspaceDir,
+    env,
+    candidates: result.candidates,
+    diagnostics: result.diagnostics,
+    seen,
+    realpathCache,
+    packageManifestCache,
+  });
+  if (params.knownCandidates && params.knownCandidates.length > 0) {
+    addMissingRequiredPluginDiagnosticsForCandidates({
+      candidates: result.candidates,
+      knownCandidateIds: new Set(
+        [...params.knownCandidates, ...result.candidates].map((candidate) => candidate.idHint),
+      ),
+      diagnostics: result.diagnostics,
+    });
+    return result;
+  }
   addMissingRequiredPluginDiagnostics(result);
   return result;
 }

--- a/src/plugins/manifest-registry-installed.test.ts
+++ b/src/plugins/manifest-registry-installed.test.ts
@@ -449,6 +449,101 @@ describe("loadPluginManifestRegistryForInstalledIndex", () => {
     });
   });
 
+  it("includes explicit load-path plugins when reconstructing from an installed index", () => {
+    const installedRoot = makeTempDir();
+    const configuredRoot = makeTempDir();
+    writePlugin(installedRoot, "installed", "installed-");
+    writePlugin(configuredRoot, "configured", "configured-");
+
+    const registry = loadPluginManifestRegistryForInstalledIndex({
+      index: createIndex(installedRoot),
+      config: {
+        plugins: {
+          load: { paths: [configuredRoot] },
+          entries: {
+            configured: { enabled: true },
+          },
+          allow: ["installed", "configured"],
+        },
+      },
+      env: {
+        OPENCLAW_VERSION: "2026.4.25",
+        VITEST: "true",
+      },
+      includeDisabled: true,
+    });
+
+    expect(registry.diagnostics).toStrictEqual([]);
+    expect(registry.plugins.map((plugin) => plugin.id)).toEqual(["installed", "configured"]);
+    expect(registry.plugins.map((plugin) => plugin.origin)).toEqual(["global", "config"]);
+    expect(registry.plugins.map((plugin) => plugin.modelSupport)).toEqual([
+      { modelPrefixes: ["installed-"] },
+      { modelPrefixes: ["configured-"] },
+    ]);
+  });
+
+  it("does not warn when load-path plugin requirements are already in the installed index", () => {
+    const installedRoot = makeTempDir();
+    const configuredRoot = makeTempDir();
+    writePlugin(installedRoot, "installed", "installed-");
+    writePlugin(configuredRoot, "configured", "configured-");
+    fs.writeFileSync(
+      path.join(configuredRoot, "openclaw.plugin.json"),
+      JSON.stringify({
+        id: "configured",
+        requiresPlugins: ["installed"],
+        configSchema: { type: "object" },
+      }),
+      "utf8",
+    );
+
+    const registry = loadPluginManifestRegistryForInstalledIndex({
+      index: createIndex(installedRoot),
+      config: {
+        plugins: {
+          load: { paths: [configuredRoot] },
+          allow: ["installed", "configured"],
+        },
+      },
+      env: {
+        OPENCLAW_VERSION: "2026.4.25",
+        VITEST: "true",
+      },
+      includeDisabled: true,
+      pluginIds: ["configured"],
+    });
+
+    expect(registry.plugins.map((plugin) => plugin.id)).toEqual(["configured"]);
+    expect(registry.diagnostics).toStrictEqual([]);
+  });
+
+  it("hides disabled load-path plugins when reconstructing from an installed index", () => {
+    const installedRoot = makeTempDir();
+    const configuredRoot = makeTempDir();
+    writePlugin(installedRoot, "installed", "installed-");
+    writePlugin(configuredRoot, "configured", "configured-");
+
+    const registry = loadPluginManifestRegistryForInstalledIndex({
+      index: createIndex(installedRoot),
+      config: {
+        plugins: {
+          load: { paths: [configuredRoot] },
+          entries: {
+            configured: { enabled: false },
+          },
+          allow: ["installed", "configured"],
+        },
+      },
+      env: {
+        OPENCLAW_VERSION: "2026.4.25",
+        VITEST: "true",
+      },
+    });
+
+    expect(registry.plugins.map((plugin) => plugin.id)).toEqual(["installed"]);
+    expect(registry.diagnostics).toStrictEqual([]);
+  });
+
   it("reconstructs bundle candidates with their bundle manifest format", () => {
     const rootDir = makeTempDir();
     fs.mkdirSync(path.join(rootDir, ".claude-plugin"), { recursive: true });

--- a/src/plugins/manifest-registry-installed.ts
+++ b/src/plugins/manifest-registry-installed.ts
@@ -6,7 +6,8 @@ import { normalizeOptionalString } from "@openclaw/normalization-core/string-coe
 import { normalizeOptionalTrimmedStringList } from "@openclaw/normalization-core/string-normalization";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { tryReadJsonSync } from "../infra/json-files.js";
-import type { PluginCandidate } from "./discovery.js";
+import { normalizePluginsConfig, resolveEnableState } from "./config-state.js";
+import { discoverConfiguredPluginLoadPathCandidates, type PluginCandidate } from "./discovery.js";
 import { hashJson } from "./installed-plugin-index-hash.js";
 import type { InstalledPluginFileSignature } from "./installed-plugin-index-hash.js";
 import type { InstalledPluginIndex, InstalledPluginIndexRecord } from "./installed-plugin-index.js";
@@ -618,16 +619,43 @@ export function loadPluginManifestRegistryForInstalledIndex(params: {
             return !pluginId || pluginIdSet.has(pluginId);
           })
         : params.index.diagnostics;
-      const candidates = params.index.plugins
+      const normalizedConfig = normalizePluginsConfig(params.config?.plugins);
+      const installedCandidates = params.index.plugins
         .filter((plugin) => params.includeDisabled || plugin.enabled)
-        .filter((plugin) => !pluginIdSet || pluginIdSet.has(plugin.pluginId))
         .map((plugin) => toPluginCandidate(plugin, realpathCache));
+      const indexedCandidates = pluginIdSet
+        ? installedCandidates.filter((candidate) => pluginIdSet.has(candidate.idHint))
+        : installedCandidates;
+      const configuredLoadPathDiscovery = discoverConfiguredPluginLoadPathCandidates({
+        loadPaths: normalizedConfig.loadPaths,
+        knownCandidates: installedCandidates,
+        workspaceDir: params.workspaceDir,
+        env,
+      });
+      const configuredCandidates = pluginIdSet
+        ? configuredLoadPathDiscovery.candidates.filter((candidate) =>
+            pluginIdSet.has(candidate.idHint),
+          )
+        : configuredLoadPathDiscovery.candidates;
+      const enabledConfiguredCandidates =
+        params.includeDisabled === true
+          ? configuredCandidates
+          : configuredCandidates.filter(
+              (candidate) =>
+                resolveEnableState(candidate.idHint, candidate.origin, normalizedConfig).enabled,
+            );
+      const configuredDiagnostics = pluginIdSet
+        ? configuredLoadPathDiscovery.diagnostics.filter((diagnostic) => {
+            const pluginId = diagnostic.pluginId;
+            return !pluginId || pluginIdSet.has(pluginId);
+          })
+        : configuredLoadPathDiscovery.diagnostics;
       return loadPluginManifestRegistry({
         config: params.config,
         workspaceDir: params.workspaceDir,
         env,
-        candidates,
-        diagnostics: [...diagnostics],
+        candidates: [...indexedCandidates, ...enabledConfiguredCandidates],
+        diagnostics: [...diagnostics, ...configuredDiagnostics],
         installRecords: extractPluginInstallRecordsFromInstalledPluginIndex(params.index),
         ...(params.bundledChannelConfigCollector
           ? { bundledChannelConfigCollector: params.bundledChannelConfigCollector }

--- a/src/plugins/plugin-registry-contributions.current-snapshot.test.ts
+++ b/src/plugins/plugin-registry-contributions.current-snapshot.test.ts
@@ -9,7 +9,11 @@ import { resolveInstalledPluginIndexPolicyHash } from "./installed-plugin-index-
 import type { InstalledPluginIndex } from "./installed-plugin-index.js";
 import type { PluginManifestRecord } from "./manifest-registry.js";
 import type { PluginMetadataSnapshot } from "./plugin-metadata-snapshot.types.js";
-import { loadPluginManifestRegistryForPluginRegistry } from "./plugin-registry-contributions.js";
+import {
+  listPluginContributionIds,
+  loadPluginManifestRegistryForPluginRegistry,
+  resolveProviderOwners,
+} from "./plugin-registry-contributions.js";
 
 afterEach(() => {
   clearCurrentPluginMetadataSnapshot();
@@ -33,11 +37,11 @@ function createPluginRecord(id: string, enabled: boolean): InstalledPluginIndex[
   } as unknown as InstalledPluginIndex["plugins"][number];
 }
 
-function createManifest(id: string): PluginManifestRecord {
+function createManifest(id: string, origin: PluginManifestRecord["origin"] = "global"): PluginManifestRecord {
   return {
     id,
-    origin: "global",
-    providers: [],
+    origin,
+    providers: [id],
     channels: [],
     channelConfigs: {},
     cliBackends: [],
@@ -140,6 +144,61 @@ describe("loadPluginManifestRegistryForPluginRegistry current snapshot", () => {
         pluginIds: ["disabled"],
       }).plugins.map((plugin) => plugin.id),
     ).toEqual(["disabled"]);
+  });
+
+  it("keeps enabled load-path plugins when reusing scoped current metadata", () => {
+    const config: OpenClawConfig = {
+      plugins: {
+        entries: {
+          "load-path": { enabled: true },
+        },
+      },
+    };
+    const env = {
+      HOME: "/tmp/openclaw-test-home",
+      OPENCLAW_DISABLE_BUNDLED_PLUGINS: "1",
+    };
+    const workspaceDir = "/workspace";
+    const snapshot = createSnapshot({ config, workspaceDir });
+    const loadPathPlugin = createManifest("load-path", "config");
+    setCurrentPluginMetadataSnapshot(
+      {
+        ...snapshot,
+        manifestRegistry: {
+          plugins: [...snapshot.manifestRegistry.plugins, loadPathPlugin],
+          diagnostics: [],
+        },
+        plugins: [...snapshot.plugins, loadPathPlugin],
+        byPluginId: new Map([...snapshot.byPluginId, [loadPathPlugin.id, loadPathPlugin]]),
+      },
+      { config, env, workspaceDir },
+    );
+
+    const lookUpTable = {
+      index: snapshot.index,
+      manifestRegistry: {
+        plugins: [...snapshot.manifestRegistry.plugins, loadPathPlugin],
+        diagnostics: [],
+      },
+      plugins: [...snapshot.plugins, loadPathPlugin],
+      normalizePluginId: snapshot.normalizePluginId,
+      owners: {
+        ...snapshot.owners,
+        providers: new Map([...snapshot.owners.providers, ["load-path", ["load-path"]]]),
+      },
+    };
+
+    expect(
+      loadPluginManifestRegistryForPluginRegistry({ config, env, workspaceDir }).plugins.map(
+        (plugin) => plugin.id,
+      ),
+    ).toContain("load-path");
+    expect(
+      listPluginContributionIds({ lookUpTable, config, contribution: "providers" }),
+    ).toContain("load-path");
+    expect(resolveProviderOwners({ lookUpTable, config, providerId: "load-path" })).toEqual([
+      "load-path",
+    ]);
   });
 
   it("does not reuse current metadata for explicit registry inputs or diagnostics", () => {

--- a/src/plugins/plugin-registry-contributions.ts
+++ b/src/plugins/plugin-registry-contributions.ts
@@ -2,11 +2,11 @@
 import { normalizeProviderId } from "@openclaw/model-catalog-core/provider-id";
 import { normalizeSortedUniqueStringEntries } from "@openclaw/normalization-core/string-normalization";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
-import { normalizePluginsConfig, resolveEnableState } from "./config-state.js";
 import {
   normalizePluginsConfigWithResolver,
   type NormalizedPluginsConfig,
 } from "./config-normalization-shared.js";
+import { normalizePluginsConfig, resolveEnableState } from "./config-state.js";
 import { getCurrentPluginMetadataSnapshot } from "./current-plugin-metadata-snapshot.js";
 import { isInstalledPluginEnabled } from "./installed-plugin-index.js";
 import { loadPluginManifestRegistryForInstalledIndex } from "./manifest-registry-installed.js";
@@ -260,12 +260,13 @@ function listContributionManifestPlugins(
     index: PluginRegistrySnapshot;
   },
 ): readonly PluginManifestRecord[] {
-  const plugins = params.lookUpTable?.plugins;
+  const lookUpTable = params.lookUpTable;
+  const plugins = lookUpTable?.plugins;
   if (plugins) {
     const enabledPluginIds = new Set(
       resolveContributionScopePluginIds({
         index: params.index,
-        manifestRegistry: params.lookUpTable.manifestRegistry,
+        manifestRegistry: lookUpTable.manifestRegistry,
         includeDisabled: params.includeDisabled,
         config: params.config,
       }),

--- a/src/plugins/plugin-registry-contributions.ts
+++ b/src/plugins/plugin-registry-contributions.ts
@@ -2,6 +2,7 @@
 import { normalizeProviderId } from "@openclaw/model-catalog-core/provider-id";
 import { normalizeSortedUniqueStringEntries } from "@openclaw/normalization-core/string-normalization";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { normalizePluginsConfig, resolveEnableState } from "./config-state.js";
 import {
   normalizePluginsConfigWithResolver,
   type NormalizedPluginsConfig,
@@ -179,23 +180,78 @@ function resolveContributionPluginIds(params: {
     .map((plugin) => plugin.pluginId);
 }
 
+function resolveContributionScopePluginIds(params: {
+  index: PluginRegistrySnapshot;
+  manifestRegistry?: PluginManifestRegistry;
+  includeDisabled?: boolean;
+  config?: OpenClawConfig;
+}): readonly string[] {
+  const pluginIds = new Set(
+    resolveContributionPluginIds({
+      index: params.index,
+      includeDisabled: params.includeDisabled,
+      config: params.config,
+    }),
+  );
+  if (!params.manifestRegistry) {
+    return [...pluginIds];
+  }
+  const indexedPluginIds = new Set(params.index.plugins.map((plugin) => plugin.pluginId));
+  const normalizedConfig = normalizePluginsConfig(params.config?.plugins);
+  for (const plugin of params.manifestRegistry.plugins) {
+    if (indexedPluginIds.has(plugin.id)) {
+      continue;
+    }
+    if (
+      params.includeDisabled ||
+      resolveEnableState(plugin.id, plugin.origin, normalizedConfig).enabled
+    ) {
+      pluginIds.add(plugin.id);
+    }
+  }
+  return [...pluginIds];
+}
+
+function filterManifestRegistryForContributionScope(params: {
+  manifestRegistry: PluginManifestRegistry;
+  index: PluginRegistrySnapshot;
+  includeDisabled?: boolean;
+  config?: OpenClawConfig;
+}): PluginManifestRegistry {
+  const pluginIds = new Set(
+    resolveContributionScopePluginIds({
+      index: params.index,
+      manifestRegistry: params.manifestRegistry,
+      includeDisabled: params.includeDisabled,
+      config: params.config,
+    }),
+  );
+  return {
+    plugins: params.manifestRegistry.plugins.filter((plugin) => pluginIds.has(plugin.id)),
+    diagnostics: params.manifestRegistry.diagnostics.filter(
+      (diagnostic) => !diagnostic.pluginId || pluginIds.has(diagnostic.pluginId),
+    ),
+  };
+}
+
 function loadContributionManifestRegistry(
   params: LoadPluginRegistryParams & {
     index: PluginRegistrySnapshot;
     includeDisabled?: boolean;
   },
 ): PluginManifestRegistry {
-  return loadPluginManifestRegistryForInstalledIndex({
+  const manifestRegistry = loadPluginManifestRegistryForInstalledIndex({
     index: params.index,
     config: params.config,
     workspaceDir: params.workspaceDir,
     env: params.env,
-    pluginIds: resolveContributionPluginIds({
-      index: params.index,
-      includeDisabled: params.includeDisabled,
-      config: params.config,
-    }),
     includeDisabled: true,
+  });
+  return filterManifestRegistryForContributionScope({
+    manifestRegistry,
+    index: params.index,
+    includeDisabled: params.includeDisabled,
+    config: params.config,
   });
 }
 
@@ -207,8 +263,9 @@ function listContributionManifestPlugins(
   const plugins = params.lookUpTable?.plugins;
   if (plugins) {
     const enabledPluginIds = new Set(
-      resolveContributionPluginIds({
+      resolveContributionScopePluginIds({
         index: params.index,
+        manifestRegistry: params.lookUpTable.manifestRegistry,
         includeDisabled: params.includeDisabled,
         config: params.config,
       }),
@@ -249,12 +306,14 @@ function resolveContributionOwnerMap(
 function filterContributionOwnerIds(params: {
   owners: readonly string[];
   index: PluginRegistrySnapshot;
+  manifestRegistry?: PluginManifestRegistry;
   includeDisabled?: boolean;
   config?: OpenClawConfig;
 }): readonly string[] {
   const enabledPluginIds = new Set(
-    resolveContributionPluginIds({
+    resolveContributionScopePluginIds({
       index: params.index,
+      manifestRegistry: params.manifestRegistry,
       includeDisabled: params.includeDisabled,
       config: params.config,
     }),
@@ -296,9 +355,12 @@ function loadCurrentManifestRegistryForPluginRegistry(
   }
   const pluginIdSet = params.pluginIds === undefined ? undefined : new Set(params.pluginIds);
   const enabledPluginIds = new Set(
-    current.index.plugins
-      .filter((plugin) => params.includeDisabled || plugin.enabled)
-      .map((plugin) => plugin.pluginId),
+    resolveContributionScopePluginIds({
+      index: current.index,
+      manifestRegistry: current.manifestRegistry,
+      includeDisabled: params.includeDisabled,
+      config: params.config,
+    }),
   );
   return {
     plugins: current.manifestRegistry.plugins.filter(
@@ -367,6 +429,7 @@ export function resolvePluginContributionOwners(
       return filterContributionOwnerIds({
         owners,
         index,
+        manifestRegistry: params.lookUpTable.manifestRegistry,
         includeDisabled: params.includeDisabled,
         config: params.config,
       });
@@ -401,6 +464,7 @@ export function resolveProviderOwners(params: ResolveProviderOwnersParams): read
     return filterContributionOwnerIds({
       owners,
       index,
+      manifestRegistry: params.lookUpTable.manifestRegistry,
       includeDisabled: params.includeDisabled,
       config: params.config,
     });


### PR DESCRIPTION
﻿Closes #99185

## What Problem This Solves

Fixes an issue where users with managed installed plugins would lose workspace plugins configured through `plugins.load.paths` when plugin metadata rebuilt from the installed-plugin index, causing stale `plugin not found` config warnings even though the workspace plugin files still existed.

## Why This Change Was Made

The installed-index manifest registry reconstruction now also discovers the current explicit `plugins.load.paths` candidates and merges them with installed-index candidates. Scoped contribution and current-snapshot registry reuse now keep enabled load-path plugins that are present in the manifest registry even when they are not recorded in the installed index. The merge keeps the existing installed-index fast path while preserving plugin-id scoping, disabled-plugin filtering, and required-plugin diagnostics that know about already indexed plugins.

## User Impact

Operators can keep managed npm plugins and explicit workspace load-path plugins enabled together. Workspace plugins configured in `plugins.entries` or `plugins.allow` no longer disappear from config validation or contribution owner resolution solely because a managed plugin index exists.

## Evidence

Current head: `a1af1391966e0076c9328a9f4631fa1d3c6926fd`.

- Claim proved: installed-index registry reconstruction includes explicit `plugins.load.paths` plugins; scoped contribution/current-snapshot registry paths keep enabled load-path plugins outside the installed index; scoped requirements and disabled configured plugins remain covered.
- Source/path evidence:
  - `src/plugins/manifest-registry-installed.test.ts` now covers an installed managed-plugin index plus a configured load-path plugin and asserts both `installed` and `configured` are present with no diagnostics.
  - `src/plugins/plugin-registry-contributions.current-snapshot.test.ts` now covers current metadata reuse so a load-path plugin outside the installed index still contributes provider ownership.
  - `src/plugins/manifest-registry-installed.ts` merges installed-index candidates with discovered `plugins.load.paths` candidates before config validation sees the registry, which is the path that previously produced the stale `plugin not found` warning.
- Commands / artifacts:
  - `node scripts/run-tsgo.mjs -p tsconfig.core.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/core-pr100325.tsbuildinfo --pretty false` - passed on this PR head.
  - `node scripts/run-vitest.mjs src/plugins/manifest-registry-installed.test.ts src/plugins/plugin-registry-contributions.current-snapshot.test.ts src/commands/channel-setup/plugin-install.test.ts` - passed on this PR head, 3 Vitest shards, 50 passed / 1 skipped.
  - GitHub CI run `28742921375` for this head: plugin-relevant lanes passed, including `check-prod-types`, `check-lint`, `check-test-types`, `checks-fast-contracts-plugins-a`, `checks-fast-contracts-plugins-b`, `Critical Quality (plugin-boundary)`, and `build-artifacts`.
  - GitHub `Real behavior proof` run `28742991218` passed the external-PR proof/context gate for this PR.
  - `git diff --check upstream/main...HEAD` - passed locally in a clean PR worktree.
- Not tested / proof gaps:
  - I did not run a live gateway restart against a real npm-installed `@openclaw/llama-cpp-provider` plus the reporter's workspace plugin set; the source-level installed-index path and contribution paths are covered by focused tests instead.
  - Local rerun of the focused Vitest command from this linked worktree was blocked because `node_modules` is absent; per repo policy I did not run `pnpm install` locally just to reconcile a Codex worktree.
  - Current CI has one failing unrelated gateway shard: `checks-node-compact-small-5` failed in `src/gateway/server.chat.gateway-server-chat-b.test.ts` (`chat.send does not recreate a session deleted while admission waits`). The failure is outside this PR's changed plugin files and the single-job rerun was not permitted by GitHub.
  - Earlier autoreview was run on the previous patch head and found no accepted/actionable findings; no fresh autoreview was run after the final narrow follow-up commit.
