### PR TITLE
fix: make Codex direct replies automatic by default

### DIFF
--- a/docs/gateway/config-channels.md
+++ b/docs/gateway/config-channels.md
@@ -810,7 +810,7 @@ See the full channel index: [Channels](/channels).
 
 Group messages default to **require mention** (metadata mention or safe regex patterns). Applies to WhatsApp, Telegram, Discord, Google Chat, and iMessage group chats.
 
-Visible replies are controlled separately. Normal group, channel, and internal WebChat direct requests default to automatic final delivery: final assistant text posts through the legacy visible reply path. Opt into `messages.visibleReplies: "message_tool"` or `messages.groupChat.visibleReplies: "message_tool"` when visible output should only post after the agent calls `message(action=send)`. If the model returns final text without calling the message tool in an opted-in tool-only mode, that final text stays private and the gateway verbose log records suppressed payload metadata.
+Visible replies are controlled separately. Normal group, channel, Codex direct, and internal WebChat direct requests default to automatic final delivery: final assistant text posts through the legacy visible reply path. Opt into `messages.visibleReplies: "message_tool"` or `messages.groupChat.visibleReplies: "message_tool"` when visible output should only post after the agent calls `message(action=send)`. If the model returns final text without calling the message tool in an opted-in tool-only mode, that final text stays private and the gateway verbose log records suppressed payload metadata.
 
 Tool-only visible replies require a model/runtime that reliably calls tools, and are recommended for shared ambient rooms on latest-generation models such as GPT 5.5. Some weaker models can answer final text but fail to understand that source-visible output must be sent with `message(action=send)`. For those models, use `"automatic"` so the final assistant turn is the visible reply path. If the session log shows assistant text with `didSendViaMessagingTool: false`, the model produced private final text instead of calling the message tool. Switch to a stronger tool-calling model for that channel, inspect the gateway verbose log for the suppressed payload summary, or set `messages.groupChat.visibleReplies: "automatic"` to use visible final replies for every group/channel request.
 
@@ -822,7 +822,7 @@ This rule applies to normal agent final text. Plugin-owned conversation bindings
 
 Symptom: a group/channel @mention shows the typing indicator and the gateway log reports `dispatch complete (queuedFinal=false, replies=0)`, but no message lands in the room. DMs to the same agent reply normally.
 
-Cause: the group/channel visible-reply mode resolves to `"message_tool"`, so OpenClaw runs the turn but suppresses the final assistant text unless the agent calls `message(action=send)`. There is no `NO_REPLY` contract in this mode; no message-tool call means no source reply. There is no error because suppression is the configured behavior. Normal group and channel turns default to `"automatic"`, so this symptom only appears when `messages.groupChat.visibleReplies` (or global `messages.visibleReplies`) is explicitly set to `"message_tool"`. Harness `defaultVisibleReplies` does not apply here — the group/channel resolver ignores it; it only affects direct/source chats (the Codex harness suppresses direct-chat finals that way).
+Cause: the group/channel visible-reply mode resolves to `"message_tool"`, so OpenClaw runs the turn but suppresses the final assistant text unless the agent calls `message(action=send)`. There is no `NO_REPLY` contract in this mode; no message-tool call means no source reply. There is no error because suppression is the configured behavior. Normal group and channel turns default to `"automatic"`, so this symptom only appears when `messages.groupChat.visibleReplies` (or global `messages.visibleReplies`) is explicitly set to `"message_tool"`. Harness `defaultVisibleReplies` does not apply here; the group/channel resolver ignores it. Harness defaults only affect direct/source chats, and the Codex harness defaults those direct/source chats to automatic final delivery.
 
 Fix: either pick a stronger tool-calling model, remove the explicit `"message_tool"` override to fall back to the `"automatic"` default, or set `messages.groupChat.visibleReplies: "automatic"` to force visible replies for every group/channel request. The gateway hot-reloads `messages` config after the file is saved; only restart the gateway when file watching or config reload is disabled in the deployment.
 
@@ -835,7 +835,7 @@ Fix: either pick a stronger tool-calling model, remove the explicit `"message_to
 ```json5
 {
   messages: {
-    visibleReplies: "automatic", // force old automatic final replies for direct/source chats
+    visibleReplies: "automatic", // force automatic final replies for direct/source chats
     groupChat: {
       historyLimit: 50,
       unmentionedInbound: "room_event", // always-on unmentioned room chatter becomes quiet context
@@ -852,7 +852,7 @@ Fix: either pick a stronger tool-calling model, remove the explicit `"message_to
 
 `messages.groupChat.unmentionedInbound: "room_event"` submits unmentioned always-on group/channel messages as quiet room context on supported channels. Mentioned messages, commands, and direct messages remain user requests. See [Ambient room events](/channels/ambient-room-events) for complete Discord, Slack, and Telegram examples.
 
-`messages.visibleReplies` is the global source-event default; `messages.groupChat.visibleReplies` overrides it for group/channel source events. When `messages.visibleReplies` is unset, direct/source chats use the selected runtime or harness default, but internal WebChat direct turns use automatic final delivery for Pi/Codex prompt parity. Set `messages.visibleReplies: "message_tool"` to intentionally require `message(action=send)` for visible output. Channel allowlists and mention gating still decide whether an event is processed.
+`messages.visibleReplies` is the global source-event default; `messages.groupChat.visibleReplies` overrides it for group/channel source events. When `messages.visibleReplies` is unset, direct/source chats use the selected runtime or harness default. The Codex harness default is automatic final delivery, matching TUI/WebChat behavior for fresh installs. Set `messages.visibleReplies: "message_tool"` to intentionally require `message(action=send)` for visible output. Channel allowlists and mention gating still decide whether an event is processed.
 
 #### DM history limits
 

--- a/docs/plugins/codex-harness-runtime.md
+++ b/docs/plugins/codex-harness-runtime.md
@@ -47,10 +47,11 @@ continue with the newly selected model.
 ## Visible replies and heartbeats
 
 Direct/source chat turns through the Codex harness default to automatic final
-assistant delivery for internal WebChat surfaces, matching the Pi harness
-contract: the agent replies normally and OpenClaw posts the final text to the
-source conversation. Set `messages.visibleReplies: "message_tool"` to keep
-final assistant text private unless the agent calls `message(action="send")`.
+assistant delivery for source surfaces, including Telegram direct messages and
+internal WebChat. This matches the Pi harness contract: the agent replies
+normally and OpenClaw posts the final text to the source conversation. Set
+`messages.visibleReplies: "message_tool"` to keep final assistant text private
+unless the agent calls `message(action="send")`.
 
 Codex heartbeat turns get `heartbeat_respond` in the searchable OpenClaw tool
 catalog by default so the agent can record whether the wake should stay quiet

--- a/extensions/codex/harness.ts
+++ b/extensions/codex/harness.ts
@@ -54,7 +54,7 @@ export function createCodexAppServerAgentHarness(options?: {
     label: options?.label ?? "Codex agent harness",
     contextEngineHostCapabilities: CODEX_APP_SERVER_CONTEXT_ENGINE_HOST_CAPABILITIES,
     deliveryDefaults: {
-      sourceVisibleReplies: "message_tool",
+      sourceVisibleReplies: "automatic",
     },
     supports: (ctx) => {
       const provider = ctx.provider.trim().toLowerCase();

--- a/extensions/codex/index.test.ts
+++ b/extensions/codex/index.test.ts
@@ -80,7 +80,7 @@ describe("codex plugin", () => {
     expect(agentHarnessRegistration.id).toBe("codex");
     expect(agentHarnessRegistration.label).toBe("Codex agent harness");
     expect(agentHarnessRegistration.deliveryDefaults).toEqual({
-      sourceVisibleReplies: "message_tool",
+      sourceVisibleReplies: "automatic",
     });
     expect(typeof agentHarnessRegistration.dispose).toBe("function");
     expect(mediaProviderRegistration?.id).toBe("codex");
@@ -139,7 +139,7 @@ describe("codex plugin", () => {
   it("claims the Codex routing providers by default", () => {
     const harness = createCodexAppServerAgentHarness();
 
-    expect(harness.deliveryDefaults?.sourceVisibleReplies).toBe("message_tool");
+    expect(harness.deliveryDefaults?.sourceVisibleReplies).toBe("automatic");
     expect(
       harness.supports({ provider: "codex", modelId: "gpt-5.4", requestedRuntime: "auto" })
         .supported,

--- a/src/auto-reply/reply/dispatch-from-config.test.ts
+++ b/src/auto-reply/reply/dispatch-from-config.test.ts
@@ -12072,12 +12072,12 @@ describe("sendPolicy deny — suppress delivery, not processing (#53328)", () =>
     expect(firstFinalReplyPayload(dispatcher)?.text).toBe("visible direct reply");
   });
 
-  it("keeps Codex direct source delivery message-tool-only when config is unset", async () => {
+  it("keeps Codex direct source delivery automatic when config is unset", async () => {
     setNoAbort();
     registerAgentHarness({
       id: "codex",
       label: "Codex",
-      deliveryDefaults: { sourceVisibleReplies: "message_tool" },
+      deliveryDefaults: { sourceVisibleReplies: "automatic" },
       supports: () => ({ supported: true, priority: 100 }),
       runAttempt: vi.fn(async () => ({}) as never),
     });
@@ -12089,8 +12089,8 @@ describe("sendPolicy deny — suppress delivery, not processing (#53328)", () =>
     };
     const dispatcher = createDispatcher();
     const replyResolver = vi.fn(async (_ctx: MsgContext, opts?: GetReplyOptions) => {
-      expect(opts?.sourceReplyDeliveryMode).toBe("message_tool_only");
-      return { text: "private final reply" } satisfies ReplyPayload;
+      expect(opts?.sourceReplyDeliveryMode).toBe("automatic");
+      return { text: "visible final reply" } satisfies ReplyPayload;
     });
 
     const result = await dispatchReplyFromConfig({
@@ -12105,8 +12105,8 @@ describe("sendPolicy deny — suppress delivery, not processing (#53328)", () =>
     });
 
     expect(replyResolver).toHaveBeenCalledTimes(1);
-    expect(result.queuedFinal).toBe(false);
-    expect(dispatcher.sendFinalReply).not.toHaveBeenCalled();
+    expect(result.queuedFinal).toBe(true);
+    expect(firstFinalReplyPayload(dispatcher)?.text).toBe("visible final reply");
   });
 
   it("uses Codex direct source delivery defaults before a session entry exists", async () => {
@@ -12114,15 +12114,15 @@ describe("sendPolicy deny — suppress delivery, not processing (#53328)", () =>
     registerAgentHarness({
       id: "codex",
       label: "Codex",
-      deliveryDefaults: { sourceVisibleReplies: "message_tool" },
+      deliveryDefaults: { sourceVisibleReplies: "automatic" },
       supports: () => ({ supported: true, priority: 100 }),
       runAttempt: vi.fn(async () => ({}) as never),
     });
     sessionStoreMocks.currentEntry = undefined;
     const dispatcher = createDispatcher();
     const replyResolver = vi.fn(async (_ctx: MsgContext, opts?: GetReplyOptions) => {
-      expect(opts?.sourceReplyDeliveryMode).toBe("message_tool_only");
-      return { text: "private first reply" } satisfies ReplyPayload;
+      expect(opts?.sourceReplyDeliveryMode).toBe("automatic");
+      return { text: "visible first reply" } satisfies ReplyPayload;
     });
 
     const result = await dispatchReplyFromConfig({
@@ -12139,8 +12139,8 @@ describe("sendPolicy deny — suppress delivery, not processing (#53328)", () =>
     });
 
     expect(replyResolver).toHaveBeenCalledTimes(1);
-    expect(result.queuedFinal).toBe(false);
-    expect(dispatcher.sendFinalReply).not.toHaveBeenCalled();
+    expect(result.queuedFinal).toBe(true);
+    expect(firstFinalReplyPayload(dispatcher)?.text).toBe("visible first reply");
   });
 
   it("uses channel model overrides before Codex first-turn direct source delivery defaults", async () => {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users messaging a fresh Codex-backed direct source chat, including Telegram DMs, could see a short visible progress reply and then no useful work when `messages.visibleReplies` was unset.

This made Telegram onboarding feel broken compared with TUI/WebChat: the bot could say it would verify or do work, but the normal final reply path was private unless the model used `message(action=send)` correctly.

## Why This Change Was Made

The Codex harness now defaults direct/source visible replies to `automatic`, matching the TUI/WebChat expectation that final assistant text is delivered visibly by default. Operators can still opt into message-tool-only visible delivery with `messages.visibleReplies: "message_tool"` when they intentionally want that stricter contract.

The docs now describe Codex direct chats as automatic by default and keep message-tool-only delivery framed as an explicit opt-in. Companion PR #100321 handles hot reload for changing the visible-reply config after install; this PR fixes the fresh-install default itself.

## User Impact

New Telegram/Codex users should not need to run `openclaw config set messages.visibleReplies automatic` to make the bot behave like TUI. Fresh direct chats can complete work and deliver normal final replies visibly unless the operator explicitly configures message-tool-only delivery.

## Evidence

Passed:

- `node scripts/run-vitest.mjs run --config test/vitest/vitest.extension-codex.config.ts extensions/codex/index.test.ts`
- `node scripts/run-vitest.mjs run --config test/vitest/vitest.auto-reply-reply.config.ts src/auto-reply/reply/dispatch-from-config.test.ts --testNamePattern "Codex direct source delivery"`

Also ran broader auto-reply dispatch coverage, which reached 250/252 passing tests and failed in existing Windows path/media-binding assertions outside this diff.
