### PR TITLE
fix(ios): own gateway setup deep-link delivery

### DIFF
--- a/apps/.i18n/native-source.json
+++ b/apps/.i18n/native-source.json
@@ -8691,7 +8691,7 @@
     },
     {
       "kind": "ui-modifier",
-      "line": 120,
+      "line": 131,
       "path": "apps/ios/Sources/Design/SettingsProTab.swift",
       "source": "Settings",
       "surface": "apple",
@@ -8699,7 +8699,7 @@
     },
     {
       "kind": "ui-modifier",
-      "line": 213,
+      "line": 224,
       "path": "apps/ios/Sources/Design/SettingsProTab.swift",
       "source": "Scan QR Code",
       "surface": "apple",
@@ -8707,7 +8707,7 @@
     },
     {
       "kind": "ui-modifier",
-      "line": 234,
+      "line": 245,
       "path": "apps/ios/Sources/Design/SettingsProTab.swift",
       "source": "Reset Onboarding?",
       "surface": "apple",
@@ -8715,7 +8715,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 238,
+      "line": 249,
       "path": "apps/ios/Sources/Design/SettingsProTab.swift",
       "source": "Reset",
       "surface": "apple",
@@ -8723,7 +8723,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 242,
+      "line": 253,
       "path": "apps/ios/Sources/Design/SettingsProTab.swift",
       "source": "Cancel",
       "surface": "apple",
@@ -8731,7 +8731,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 246,
+      "line": 257,
       "path": "apps/ios/Sources/Design/SettingsProTab.swift",
       "source": "This disconnects, clears saved gateway credentials, and reopens onboarding.",
       "surface": "apple",
@@ -8739,7 +8739,7 @@
     },
     {
       "kind": "ui-modifier",
-      "line": 249,
+      "line": 260,
       "path": "apps/ios/Sources/Design/SettingsProTab.swift",
       "source": "QR Scanner Unavailable",
       "surface": "apple",
@@ -8747,7 +8747,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 256,
+      "line": 267,
       "path": "apps/ios/Sources/Design/SettingsProTab.swift",
       "source": "OK",
       "surface": "apple",
@@ -8755,7 +8755,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 304,
+      "line": 321,
       "path": "apps/ios/Sources/Design/SettingsProTab.swift",
       "source": "Enable OpenClaw Hosted Push Relay?",
       "surface": "apple",
@@ -8763,7 +8763,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 318,
+      "line": 335,
       "path": "apps/ios/Sources/Design/SettingsProTab.swift",
       "source": "Continue",
       "surface": "apple",
@@ -8771,7 +8771,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 326,
+      "line": 343,
       "path": "apps/ios/Sources/Design/SettingsProTab.swift",
       "source": "Not Now",
       "surface": "apple",
@@ -8859,7 +8859,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 634,
+      "line": 633,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "Configured",
       "surface": "apple",
@@ -8867,7 +8867,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 634,
+      "line": 633,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "Not configured",
       "surface": "apple",
@@ -8875,7 +8875,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 699,
+      "line": 698,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "Connect to the gateway.",
       "surface": "apple",
@@ -8883,7 +8883,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 699,
+      "line": 698,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "Gateway requests will appear here.",
       "surface": "apple",
@@ -8891,7 +8891,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 746,
+      "line": 745,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "High",
       "surface": "apple",
@@ -8899,7 +8899,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 746,
+      "line": 745,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "Resolving",
       "surface": "apple",
@@ -8907,7 +8907,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 751,
+      "line": 750,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "One-time approval",
       "surface": "apple",
@@ -8915,7 +8915,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 751,
+      "line": 750,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "Permission can be saved",
       "surface": "apple",
@@ -8923,7 +8923,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 753,
+      "line": 752,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "Medium",
       "surface": "apple",
@@ -8931,7 +8931,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 753,
+      "line": 752,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "Review",
       "surface": "apple",
@@ -8939,7 +8939,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 774,
+      "line": 773,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "\\(diagnosticsIssueCount)",
       "surface": "apple",
@@ -8947,7 +8947,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 785,
+      "line": 784,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "Location off",
       "surface": "apple",
@@ -8955,7 +8955,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 787,
+      "line": 786,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "Location While Using",
       "surface": "apple",
@@ -8963,7 +8963,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 789,
+      "line": 788,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "Location While Using, effective Off",
       "surface": "apple",
@@ -8971,7 +8971,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 791,
+      "line": 790,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "Location While Using, effective Always",
       "surface": "apple",
@@ -8979,7 +8979,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 793,
+      "line": 792,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "Location Always",
       "surface": "apple",
@@ -8987,7 +8987,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 795,
+      "line": 794,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "Location Always, effective While Using",
       "surface": "apple",
@@ -8995,7 +8995,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 797,
+      "line": 796,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "Location Always, effective Off",
       "surface": "apple",
@@ -9003,7 +9003,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 825,
+      "line": 824,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "Checking iOS notification permission.",
       "surface": "apple",
@@ -9011,7 +9011,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 827,
+      "line": 826,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "OpenClaw can show approval prompts and event alerts when the app is not active.",
       "surface": "apple",
@@ -9019,7 +9019,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 829,
+      "line": 828,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "Notifications have been denied. Enable them in iOS Settings.",
       "surface": "apple",
@@ -9027,7 +9027,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 831,
+      "line": 830,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "Enable notifications to receive approval prompts and event alerts outside the app.",
       "surface": "apple",
@@ -9035,7 +9035,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 833,
+      "line": 832,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "OpenClaw cannot determine the current notification permission state.",
       "surface": "apple",
@@ -11659,7 +11659,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 207,
+      "line": 209,
       "path": "apps/ios/Sources/RootTabs.swift",
       "source": "Settings",
       "surface": "apple",
@@ -11667,7 +11667,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 306,
+      "line": 308,
       "path": "apps/ios/Sources/RootTabs.swift",
       "source": "OpenClaw",
       "surface": "apple",
@@ -11675,7 +11675,7 @@
     },
     {
       "kind": "ui-modifier",
-      "line": 336,
+      "line": 338,
       "path": "apps/ios/Sources/RootTabs.swift",
       "source": "OpenClaw \\(self.sidebarGatewayStatusTitle)",
       "surface": "apple",
@@ -11683,7 +11683,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 341,
+      "line": 343,
       "path": "apps/ios/Sources/RootTabs.swift",
       "source": "Online",
       "surface": "apple",
@@ -11691,7 +11691,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 343,
+      "line": 345,
       "path": "apps/ios/Sources/RootTabs.swift",
       "source": "Connecting",
       "surface": "apple",
@@ -11699,7 +11699,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 345,
+      "line": 347,
       "path": "apps/ios/Sources/RootTabs.swift",
       "source": "Needs attention",
       "surface": "apple",
@@ -11707,7 +11707,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 347,
+      "line": 349,
       "path": "apps/ios/Sources/RootTabs.swift",
       "source": "Offline",
       "surface": "apple",
@@ -11715,7 +11715,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 427,
+      "line": 429,
       "path": "apps/ios/Sources/RootTabs.swift",
       "source": "Chat",
       "surface": "apple",
@@ -11723,7 +11723,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 440,
+      "line": 442,
       "path": "apps/ios/Sources/RootTabs.swift",
       "source": "Overview",
       "surface": "apple",
@@ -11731,7 +11731,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 464,
+      "line": 466,
       "path": "apps/ios/Sources/RootTabs.swift",
       "source": "Agents",
       "surface": "apple",
@@ -11739,7 +11739,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 471,
+      "line": 473,
       "path": "apps/ios/Sources/RootTabs.swift",
       "source": "Instances",
       "surface": "apple",
@@ -11747,7 +11747,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 482,
+      "line": 484,
       "path": "apps/ios/Sources/RootTabs.swift",
       "source": "Dreaming",
       "surface": "apple",
@@ -11755,7 +11755,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 489,
+      "line": 491,
       "path": "apps/ios/Sources/RootTabs.swift",
       "source": "Usage",
       "surface": "apple",
@@ -11763,7 +11763,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 496,
+      "line": 498,
       "path": "apps/ios/Sources/RootTabs.swift",
       "source": "Cron Jobs",
       "surface": "apple",
@@ -11771,7 +11771,7 @@
     },
     {
       "kind": "ui-modifier",
-      "line": 622,
+      "line": 630,
       "path": "apps/ios/Sources/RootTabs.swift",
       "source": "Hide Sidebar",
       "surface": "apple",
@@ -11779,7 +11779,7 @@
     },
     {
       "kind": "ui-modifier",
-      "line": 749,
+      "line": 757,
       "path": "apps/ios/Sources/RootTabs.swift",
       "source": "Close canvas",
       "surface": "apple",
@@ -11787,7 +11787,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 998,
+      "line": 1006,
       "path": "apps/ios/Sources/RootTabs.swift",
       "source": "Gateway needs attention",
       "surface": "apple",
@@ -11795,7 +11795,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 998,
+      "line": 1006,
       "path": "apps/ios/Sources/RootTabs.swift",
       "source": "OpenClaw iOS",
       "surface": "apple",
@@ -11803,7 +11803,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1034,
+      "line": 1042,
       "path": "apps/ios/Sources/RootTabs.swift",
       "source": "Available",
       "surface": "apple",
@@ -11811,7 +11811,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1034,
+      "line": 1042,
       "path": "apps/ios/Sources/RootTabs.swift",
       "source": "Gateway default",
       "surface": "apple",

--- a/apps/ios/Sources/Design/SettingsProTab.swift
+++ b/apps/ios/Sources/Design/SettingsProTab.swift
@@ -1,6 +1,11 @@
 import OpenClawKit
 import SwiftUI
 
+struct GatewaySetupRequest {
+    let id: Int
+    let link: GatewayConnectDeepLink
+}
+
 struct SettingsProTab: View {
     @Environment(NodeAppModel.self) var appModel
     @Environment(VoiceWakeManager.self) var voiceWake
@@ -69,6 +74,8 @@ struct SettingsProTab: View {
     let ownsNavigationStack: Bool
     let navigateToRoute: ((SettingsRoute) -> Void)?
     let onRouteChange: ((SettingsRoute?) -> Void)?
+    let gatewaySetupRequest: GatewaySetupRequest?
+    let onGatewaySetupRequestHandled: ((Int) -> Void)?
 
     init(
         initialRoute: SettingsRoute? = nil,
@@ -76,7 +83,9 @@ struct SettingsProTab: View {
         headerLeadingAction: OpenClawSidebarHeaderAction? = nil,
         ownsNavigationStack: Bool = true,
         navigateToRoute: ((SettingsRoute) -> Void)? = nil,
-        onRouteChange: ((SettingsRoute?) -> Void)? = nil)
+        onRouteChange: ((SettingsRoute?) -> Void)? = nil,
+        gatewaySetupRequest: GatewaySetupRequest? = nil,
+        onGatewaySetupRequestHandled: ((Int) -> Void)? = nil)
     {
         self.initialRoute = initialRoute
         self.directRoute = directRoute
@@ -84,6 +93,8 @@ struct SettingsProTab: View {
         self.ownsNavigationStack = ownsNavigationStack
         self.navigateToRoute = navigateToRoute
         self.onRouteChange = onRouteChange
+        self.gatewaySetupRequest = gatewaySetupRequest
+        self.onGatewaySetupRequestHandled = onGatewaySetupRequestHandled
     }
 
     var body: some View {
@@ -136,9 +147,12 @@ struct SettingsProTab: View {
                 self.previousLocationModeRaw = self.locationModeRaw
                 self.syncSettingsState()
                 self.refreshNotificationSettings()
-                self.applyPendingGatewaySetupLinkIfNeeded()
+                self.applyGatewaySetupRequestIfNeeded()
                 self.applyInitialRouteIfNeeded()
                 self.notifyRouteChange()
+            }
+            .onChange(of: self.gatewaySetupRequest?.id) { _, _ in
+                self.applyGatewaySetupRequestIfNeeded()
             }
             .onChange(of: self.scenePhase) { _, phase in
                 if phase == .active {
@@ -171,9 +185,6 @@ struct SettingsProTab: View {
             }
             .onChange(of: self.defaultShareInstruction) { _, newValue in
                 ShareToAgentSettings.saveDefaultInstruction(newValue)
-            }
-            .onChange(of: self.appModel.gatewaySetupRequestID) { _, _ in
-                self.applyPendingGatewaySetupLinkIfNeeded()
             }
             .onChange(of: self.onboardingRequestID) { _, _ in
                 // Root-owned resets leave Settings mounted behind onboarding.
@@ -260,6 +271,12 @@ struct SettingsProTab: View {
                 Text(self.scannerError ?? "")
                     .font(OpenClawType.subhead)
             }
+    }
+
+    private func applyGatewaySetupRequestIfNeeded() {
+        guard let gatewaySetupRequest else { return }
+        self.applyGatewaySetupLink(gatewaySetupRequest.link)
+        self.onGatewaySetupRequestHandled?(gatewaySetupRequest.id)
     }
 
     func openNotificationsRouteFromApprovals() {

--- a/apps/ios/Sources/Design/SettingsProTabActions.swift
+++ b/apps/ios/Sources/Design/SettingsProTabActions.swift
@@ -222,8 +222,7 @@ extension SettingsProTab {
         await self.connectManual()
     }
 
-    func applyPendingGatewaySetupLinkIfNeeded() {
-        guard let link = self.appModel.consumePendingGatewaySetupLink() else { return }
+    func applyGatewaySetupLink(_ link: GatewayConnectDeepLink) {
         self.setupCode = ""
         self.setupStatusText = nil
         self.stagedGatewaySetupLink = link

--- a/apps/ios/Sources/RootTabs.swift
+++ b/apps/ios/Sources/RootTabs.swift
@@ -51,7 +51,7 @@ struct RootTabs: View {
     @State private var didEvaluateOnboarding: Bool = false
     @State private var didAutoOpenSettings: Bool = false
     @State private var didApplyInitialChatSession: Bool = false
-    @State private var handledGatewaySetupRequestID: Int = 0
+    @State private var gatewaySetupRequest: GatewaySetupRequest?
     @State private var suppressedExecApprovalPromptIDForNotificationSettings: String?
 
     private static var initialTab: AppTab {
@@ -202,7 +202,9 @@ struct RootTabs: View {
 
             SettingsProTab(
                 initialRoute: self.selectedSettingsRoute,
-                onRouteChange: self.handleSettingsRouteChange)
+                onRouteChange: self.handleSettingsRouteChange,
+                gatewaySetupRequest: self.gatewaySetupRequest,
+                onGatewaySetupRequestHandled: self.handleGatewaySetupRequest)
                 .id(self.settingsTabViewID)
                 .tabItem { Label("Settings", systemImage: "gearshape.fill") }
                 .tag(AppTab.settings)
@@ -511,13 +513,17 @@ struct RootTabs: View {
                     headerLeadingAction: self.sidebarHeaderLeadingAction,
                     ownsNavigationStack: false,
                     navigateToRoute: self.pushSidebarSettingsRoute,
-                    onRouteChange: self.handleSettingsRouteChange)
+                    onRouteChange: self.handleSettingsRouteChange,
+                    gatewaySetupRequest: self.gatewaySetupRequest,
+                    onGatewaySetupRequestHandled: self.handleGatewaySetupRequest)
             } else {
                 SettingsProTab(
                     headerLeadingAction: self.sidebarHeaderLeadingAction,
                     ownsNavigationStack: false,
                     navigateToRoute: self.pushSidebarSettingsRoute,
-                    onRouteChange: self.handleSettingsRouteChange)
+                    onRouteChange: self.handleSettingsRouteChange,
+                    gatewaySetupRequest: self.gatewaySetupRequest,
+                    onGatewaySetupRequestHandled: self.handleGatewaySetupRequest)
             }
         case .gateway:
             SettingsProTab(
@@ -525,7 +531,9 @@ struct RootTabs: View {
                 headerLeadingAction: self.sidebarHeaderLeadingAction,
                 ownsNavigationStack: false,
                 navigateToRoute: self.pushSidebarSettingsRoute,
-                onRouteChange: self.handleSettingsRouteChange)
+                onRouteChange: self.handleSettingsRouteChange,
+                gatewaySetupRequest: self.gatewaySetupRequest,
+                onGatewaySetupRequestHandled: self.handleGatewaySetupRequest)
         }
     }
 
@@ -1291,13 +1299,20 @@ extension RootTabs {
 
     private func maybeOpenSettingsForGatewaySetup() {
         let requestID = self.appModel.gatewaySetupRequestID
-        guard requestID != 0, requestID != self.handledGatewaySetupRequestID else { return }
-        self.handledGatewaySetupRequestID = requestID
+        guard requestID != 0, requestID != self.gatewaySetupRequest?.id else { return }
+        guard let link = self.appModel.consumePendingGatewaySetupLink() else { return }
         self.showOnboarding = false
         self.presentedSheet = nil
         self.didAutoOpenSettings = true
         self.selectSidebarDestination(.gateway)
+        // Root owns delivery so embedded Settings views cannot consume the one-shot link.
+        self.gatewaySetupRequest = GatewaySetupRequest(id: requestID, link: link)
         self.requestLocalNetworkAccess(reason: "gateway_setup_deeplink")
+    }
+
+    private func handleGatewaySetupRequest(_ requestID: Int) {
+        guard self.gatewaySetupRequest?.id == requestID else { return }
+        self.gatewaySetupRequest = nil
     }
 
     private func maybeRequestLocalNetworkAccess(reason: String) {

--- a/apps/ios/Sources/Terminal/TerminalHubScreen.swift
+++ b/apps/ios/Sources/Terminal/TerminalHubScreen.swift
@@ -151,10 +151,6 @@ struct TerminalHubScreen: View {
 
     /// Identity for the embedded web view: recreate it only when the gateway
     /// endpoint or credentials actually change.
-    static func webContentIdentity(config: GatewayConnectConfig?) -> Int {
-        self.webContentIdentity(config: config, storedOperatorToken: self.storedOperatorToken())
-    }
-
     static func webContentIdentity(config: GatewayConnectConfig?, storedOperatorToken: String?) -> Int {
         var hasher = Hasher()
         hasher.combine(config?.url)

--- a/apps/shared/OpenClawKit/Sources/OpenClawKit/DeepLinks.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawKit/DeepLinks.swift
@@ -1,5 +1,9 @@
 import Foundation
 
+private func defaultGatewayPort(tls: Bool) -> Int {
+    tls ? 443 : 18789
+}
+
 public enum DeepLinkRoute: Sendable, Equatable {
     case agent(AgentDeepLink)
     case gateway(GatewayConnectDeepLink)
@@ -122,7 +126,7 @@ public struct GatewayConnectDeepLink: Codable, Sendable, Equatable {
         }
         return GatewayConnectDeepLink(
             host: host,
-            port: payload.port ?? (tls ? 443 : 18789),
+            port: payload.port ?? defaultGatewayPort(tls: tls),
             tls: tls,
             bootstrapToken: payload.bootstrapToken,
             token: payload.token,
@@ -149,7 +153,7 @@ public struct GatewayConnectDeepLink: Codable, Sendable, Equatable {
         }
         return GatewayConnectDeepLink(
             host: hostname,
-            port: parsed.port ?? (tls ? 443 : 18789),
+            port: parsed.port ?? defaultGatewayPort(tls: tls),
             tls: tls,
             bootstrapToken: bootstrapToken,
             token: token,
@@ -254,7 +258,7 @@ public enum DeepLinkParser {
                 return nil
             }
             let tls = (query["tls"] as NSString?)?.boolValue ?? false
-            let port = query["port"].flatMap { Int($0) } ?? (tls ? 443 : 18789)
+            let port = query["port"].flatMap { Int($0) } ?? defaultGatewayPort(tls: tls)
             if !tls, !LoopbackHost.isLocalNetworkHost(hostParam) {
                 return nil
             }

--- a/apps/shared/OpenClawKit/Tests/OpenClawKitTests/DeepLinksSecurityTests.swift
+++ b/apps/shared/OpenClawKit/Tests/OpenClawKitTests/DeepLinksSecurityTests.swift
@@ -10,6 +10,13 @@ private func setupCode(from payload: String) -> String {
         .replacingOccurrences(of: "=", with: "")
 }
 
+private func gatewayLink(from raw: String) -> GatewayConnectDeepLink? {
+    guard let url = URL(string: raw),
+          case let .gateway(link)? = DeepLinkParser.parse(url)
+    else { return nil }
+    return link
+}
+
 @Suite struct DeepLinksSecurityTests {
     @Test func dashboardDeepLinkParses() {
         let url = URL(string: "openclaw://dashboard")!
@@ -22,16 +29,21 @@ private func setupCode(from payload: String) -> String {
     }
 
     @Test func gatewayDeepLinkUsesTlsDefaultPortWhenPortMissing() {
-        let url = URL(string: "openclaw://gateway?host=gateway.example.com&tls=1&token=abc")!
-        #expect(
-            DeepLinkParser.parse(url) == .gateway(
-                .init(
-                    host: "gateway.example.com",
-                    port: 443,
-                    tls: true,
-                    bootstrapToken: nil,
-                    token: "abc",
-                    password: nil)))
+        let link = gatewayLink(from: "openclaw://gateway?host=gateway.example.com&tls=1")
+        #expect(link?.port == 443)
+        #expect(link?.tls == true)
+    }
+
+    @Test func gatewayDeepLinkUsesPlaintextDefaultPortWhenPortMissing() {
+        let link = gatewayLink(from: "openclaw://gateway?host=127.0.0.1&tls=0")
+        #expect(link?.port == 18789)
+        #expect(link?.tls == false)
+    }
+
+    @Test func gatewayDeepLinkPreservesExplicitTlsPort() {
+        let link = gatewayLink(from: "openclaw://gateway?host=gateway.example.com&port=18789&tls=1")
+        #expect(link?.port == 18789)
+        #expect(link?.tls == true)
     }
 
     @Test func gatewayDeepLinkRejectsInsecureNonLoopbackWs() {


### PR DESCRIPTION
## What Problem This Solves

#100258 fixed the omitted TLS-port default from #99887, but repeated live gateway setup links exposed a separate delivery race: any mounted `SettingsProTab` could consume the app-global one-shot request, including a hidden embedded settings surface. The visible canonical Settings screen could then miss the link entirely.

## Why This Change Was Made

- Make `RootTabs` the single owner of gateway setup link consumption and routing.
- Pass a typed, identity-bearing request only to the canonical phone/iPad Settings destination.
- Clear the request only after that destination acknowledges staging it, preventing both hidden-view consumption and replay.
- Centralize the TLS/plaintext default-port mapping and cover omitted/explicit ports in focused tests.
- Remove the now-unused terminal web-content identity overload so the iOS dead-code gate remains green.

## User Impact

Repeated `openclaw://gateway/setup` links now reliably populate the visible gateway settings on both phone and iPad. TLS links without an explicit port use 443, plaintext links use 18789, explicit ports remain unchanged, and an already-applied link is not replayed.

## Evidence

- `swift test --package-path apps/shared/OpenClawKit --filter DeepLinksSecurityTests` — 21/21 passed.
- `node --import tsx scripts/native-app-i18n.ts check` — 2,493 entries, no changes required.
- `xcodebuild -project apps/ios/OpenClaw.xcodeproj -scheme OpenClaw -configuration Debug -destination 'id=E617A5DF-735E-442C-98EC-31C140517359' -derivedDataPath /tmp/pr99887-final-derived build` — succeeded.
- Live exact-app simulator proof: two consecutive unique TLS links applied through the real Connect flow on iPhone and iPad; the second host replaced the first, port was 443, and TLS remained enabled.
- Fresh branch autoreview: no findings; patch correct, confidence 0.84.
- `git diff --check origin/main...HEAD` — clean.

No visual layout or styling changed, so before/after screenshots would not add useful UI evidence.

Follow-up to #99887 and #100258.
