### PR TITLE
feat(ios): durable offline command outbox for chat sends

### DIFF
--- a/apps/.i18n/native-source.json
+++ b/apps/.i18n/native-source.json
@@ -123,7 +123,7 @@
     },
     {
       "kind": "ui-state-text",
-      "line": 103,
+      "line": 101,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/MainViewModel.kt",
       "source": "Searching…",
       "surface": "android",
@@ -131,7 +131,7 @@
     },
     {
       "kind": "ui-state-text",
-      "line": 192,
+      "line": 190,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/MainViewModel.kt",
       "source": "Mic off",
       "surface": "android",
@@ -139,7 +139,7 @@
     },
     {
       "kind": "ui-state-text",
-      "line": 202,
+      "line": 200,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/MainViewModel.kt",
       "source": "Off",
       "surface": "android",
@@ -371,7 +371,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1200,
+      "line": 1185,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/gateway/GatewaySession.kt",
       "source": "Connecting…",
       "surface": "android",
@@ -379,7 +379,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1200,
+      "line": 1185,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/gateway/GatewaySession.kt",
       "source": "Reconnecting…",
       "surface": "android",
@@ -3195,7 +3195,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 980,
+      "line": 979,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Clear this phone's saved gateway access and scan a fresh setup code.",
       "surface": "android",
@@ -3203,7 +3203,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 987,
+      "line": 981,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Pair New Gateway",
       "surface": "android",
@@ -3211,7 +3211,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 988,
+      "line": 982,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Setup Code",
       "surface": "android",
@@ -3219,7 +3219,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 992,
+      "line": 986,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Android can scan or paste an existing setup code, but this gateway does not expose setup-code generation to the app yet. Generate the QR/code on the gateway host with openclaw qr, then scan it here or paste the setup code below.",
       "surface": "android",
@@ -3227,7 +3227,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1001,
+      "line": 995,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Connection Setup",
       "surface": "android",
@@ -3235,7 +3235,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1002,
+      "line": 996,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Setup code",
       "surface": "android",
@@ -3243,7 +3243,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1004,
+      "line": 998,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Host",
       "surface": "android",
@@ -3251,7 +3251,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1005,
+      "line": 999,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Port",
       "surface": "android",
@@ -3259,7 +3259,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1009,
+      "line": 1003,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Local",
       "surface": "android",
@@ -3267,7 +3267,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1013,
+      "line": 1007,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Token",
       "surface": "android",
@@ -3275,7 +3275,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1014,
+      "line": 1008,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Bootstrap",
       "surface": "android",
@@ -3283,7 +3283,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1016,
+      "line": 1010,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Password",
       "surface": "android",
@@ -3291,7 +3291,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1021,
+      "line": 1015,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Save & Connect",
       "surface": "android",
@@ -3299,7 +3299,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1061,
+      "line": 1055,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Appearance",
       "surface": "android",
@@ -3307,7 +3307,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1072,
+      "line": 1066,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Theme",
       "surface": "android",
@@ -3315,7 +3315,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1095,
+      "line": 1089,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Ready",
       "surface": "android",
@@ -3323,7 +3323,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1124,
+      "line": 1118,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "About",
       "surface": "android",
@@ -3331,7 +3331,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1136,
+      "line": 1130,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Gateway",
       "surface": "android",
@@ -3339,7 +3339,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1138,
+      "line": 1132,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Runtime",
       "surface": "android",
@@ -3347,7 +3347,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1141,
+      "line": 1135,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Update",
       "surface": "android",
@@ -3355,7 +3355,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1171,
+      "line": 1165,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Licenses",
       "surface": "android",
@@ -3363,7 +3363,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1172,
+      "line": 1166,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "OpenClaw appreciates its partners in the open-source community.",
       "surface": "android",
@@ -3371,7 +3371,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1181,
+      "line": 1175,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "No license notices are packaged in this build.",
       "surface": "android",
@@ -3379,7 +3379,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1207,
+      "line": 1201,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Open ${license.title}",
       "surface": "android",
@@ -3387,7 +3387,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1242,
+      "line": 1236,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Check",
       "surface": "android",
@@ -3395,7 +3395,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1275,
+      "line": 1269,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Back",
       "surface": "android",
@@ -3403,7 +3403,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1348,
+      "line": 1342,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Sending",
       "surface": "android",
@@ -3411,7 +3411,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1357,
+      "line": 1351,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Allow Once",
       "surface": "android",
@@ -3419,7 +3419,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1357,
+      "line": 1351,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Allowing",
       "surface": "android",
@@ -3427,7 +3427,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1365,
+      "line": 1359,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Always",
       "surface": "android",
@@ -3435,7 +3435,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1365,
+      "line": 1359,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Saving",
       "surface": "android",
@@ -3443,7 +3443,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1373,
+      "line": 1367,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Deny",
       "surface": "android",
@@ -3451,7 +3451,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1373,
+      "line": 1367,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Denying",
       "surface": "android",
@@ -3459,7 +3459,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1398,
+      "line": 1392,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Review",
       "surface": "android",
@@ -3467,7 +3467,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1423,
+      "line": 1417,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Issue",
       "surface": "android",
@@ -3475,7 +3475,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1454,
+      "line": 1448,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Default assistant",
       "surface": "android",
@@ -3483,7 +3483,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1456,
+      "line": 1450,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Default",
       "surface": "android",
@@ -3491,7 +3491,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1512,
+      "line": 1506,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Needs attention",
       "surface": "android",
@@ -3499,7 +3499,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1515,
+      "line": 1509,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Waiting ${minutes}m",
       "surface": "android",
@@ -3507,7 +3507,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1515,
+      "line": 1509,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Waiting for review",
       "surface": "android",
@@ -3515,7 +3515,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1543,
+      "line": 1537,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "${job.scheduleLabel} · ${formatCronWake(job.nextRunAtMs)} · ${job.promptPreview}",
       "surface": "android",
@@ -3523,7 +3523,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1550,
+      "line": 1544,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "No limits reported",
       "surface": "android",
@@ -3531,7 +3531,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1571,
+      "line": 1565,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Off",
       "surface": "android",
@@ -5203,7 +5203,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 226,
+      "line": 225,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Chat needs attention",
       "surface": "android",
@@ -5211,7 +5211,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 367,
+      "line": 366,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "All",
       "surface": "android",
@@ -5219,7 +5219,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 421,
+      "line": 420,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "OpenClaw",
       "surface": "android",
@@ -5227,7 +5227,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 442,
+      "line": 441,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "New chat",
       "surface": "android",
@@ -5235,7 +5235,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 443,
+      "line": 442,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Refresh chat",
       "surface": "android",
@@ -5243,7 +5243,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 446,
+      "line": 445,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Chat",
       "surface": "android",
@@ -5251,7 +5251,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 583,
+      "line": 582,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Loading session",
       "surface": "android",
@@ -5259,7 +5259,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 610,
+      "line": 609,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Jump to latest",
       "surface": "android",
@@ -5267,7 +5267,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 630,
+      "line": 629,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Ready when you are",
       "surface": "android",
@@ -5275,7 +5275,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 661,
+      "line": 660,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Fix connection",
       "surface": "android",
@@ -5283,7 +5283,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 662,
+      "line": 661,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Copy diagnostics",
       "surface": "android",
@@ -5291,7 +5291,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 800,
+      "line": 799,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Tools running",
       "surface": "android",
@@ -5299,7 +5299,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 805,
+      "line": 804,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "+${toolCalls.size - 4} more",
       "surface": "android",
@@ -5307,7 +5307,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 815,
+      "line": 814,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Thinking",
       "surface": "android",
@@ -5315,7 +5315,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 816,
+      "line": 815,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "OpenClaw is preparing a response.",
       "surface": "android",
@@ -5323,7 +5323,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 935,
+      "line": 934,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Stop",
       "surface": "android",
@@ -5331,7 +5331,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 952,
+      "line": 951,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "No commands found",
       "surface": "android",
@@ -5339,7 +5339,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1014,
+      "line": 1013,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Gateway offline",
       "surface": "android",
@@ -5347,7 +5347,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1104,
+      "line": 1103,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Attach image",
       "surface": "android",
@@ -5355,7 +5355,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1119,
+      "line": 1118,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Message OpenClaw",
       "surface": "android",
@@ -5363,7 +5363,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1134,
+      "line": 1133,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Voice",
       "surface": "android",
@@ -5371,7 +5371,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1172,
+      "line": 1171,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Remove attachment",
       "surface": "android",
@@ -5379,7 +5379,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1193,
+      "line": 1192,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Main",
       "surface": "android",
@@ -5387,7 +5387,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1249,
+      "line": 1248,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Send",
       "surface": "android",
@@ -5395,7 +5395,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1288,
+      "line": 1287,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "$contextLabel · ${contextMeterThinkingLabel(thinkingLevel)}",
       "surface": "android",
@@ -5403,7 +5403,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 269,
+      "line": 287,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatSheetContent.kt",
       "source": "CHAT ERROR",
       "surface": "android",
@@ -7259,7 +7259,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 110,
+      "line": 100,
       "path": "apps/ios/Sources/Design/ChatProTab.swift",
       "source": "Unable to Export Transcript",
       "surface": "apple",
@@ -7267,7 +7267,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 114,
+      "line": 104,
       "path": "apps/ios/Sources/Design/ChatProTab.swift",
       "source": "OK",
       "surface": "apple",
@@ -7275,7 +7275,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 118,
+      "line": 108,
       "path": "apps/ios/Sources/Design/ChatProTab.swift",
       "source": "OpenClaw could not prepare the Markdown file.",
       "surface": "apple",
@@ -7283,7 +7283,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 138,
+      "line": 128,
       "path": "apps/ios/Sources/Design/ChatProTab.swift",
       "source": "What would you like to work on?",
       "surface": "apple",
@@ -7291,7 +7291,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 149,
+      "line": 139,
       "path": "apps/ios/Sources/Design/ChatProTab.swift",
       "source": "The session attaches once the gateway is ready.",
       "surface": "apple",
@@ -7299,7 +7299,7 @@
     },
     {
       "kind": "ui-modifier",
-      "line": 240,
+      "line": 218,
       "path": "apps/ios/Sources/Design/ChatProTab.swift",
       "source": "Opens Settings / Gateway",
       "surface": "apple",
@@ -7307,7 +7307,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 265,
+      "line": 243,
       "path": "apps/ios/Sources/Design/ChatProTab.swift",
       "source": "Export Transcript",
       "surface": "apple",
@@ -7315,7 +7315,7 @@
     },
     {
       "kind": "ui-modifier",
-      "line": 275,
+      "line": 253,
       "path": "apps/ios/Sources/Design/ChatProTab.swift",
       "source": "Chat actions",
       "surface": "apple",
@@ -7323,7 +7323,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 328,
+      "line": 306,
       "path": "apps/ios/Sources/Design/ChatProTab.swift",
       "source": "Connected",
       "surface": "apple",
@@ -7331,7 +7331,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 328,
+      "line": 306,
       "path": "apps/ios/Sources/Design/ChatProTab.swift",
       "source": "Unavailable",
       "surface": "apple",
@@ -7339,7 +7339,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 339,
+      "line": 317,
       "path": "apps/ios/Sources/Design/ChatProTab.swift",
       "source": "Connect to a gateway",
       "surface": "apple",
@@ -7347,7 +7347,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 339,
+      "line": 317,
       "path": "apps/ios/Sources/Design/ChatProTab.swift",
       "source": "Message \\(self.agentDisplayName)...",
       "surface": "apple",
@@ -7355,7 +7355,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 393,
+      "line": 367,
       "path": "apps/ios/Sources/Design/ChatProTab.swift",
       "source": "Check OpenClaw status",
       "surface": "apple",
@@ -7363,7 +7363,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 394,
+      "line": 368,
       "path": "apps/ios/Sources/Design/ChatProTab.swift",
       "source": "Summarize the current OpenClaw status and tell me what needs attention.",
       "surface": "apple",
@@ -7371,7 +7371,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 397,
+      "line": 371,
       "path": "apps/ios/Sources/Design/ChatProTab.swift",
       "source": "What can I control here?",
       "surface": "apple",
@@ -7379,7 +7379,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 398,
+      "line": 372,
       "path": "apps/ios/Sources/Design/ChatProTab.swift",
       "source": "Show me which phone controls and device capabilities are available right now.",
       "surface": "apple",
@@ -7387,7 +7387,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 401,
+      "line": 375,
       "path": "apps/ios/Sources/Design/ChatProTab.swift",
       "source": "Help me start voice chat",
       "surface": "apple",
@@ -7395,7 +7395,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 402,
+      "line": 376,
       "path": "apps/ios/Sources/Design/ChatProTab.swift",
       "source": "Help me start a realtime voice session from this phone.",
       "surface": "apple",
@@ -11131,7 +11131,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 2699,
+      "line": 2702,
       "path": "apps/ios/Sources/Model/NodeAppModel.swift",
       "source": "Action required",
       "surface": "apple",
@@ -11139,7 +11139,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 2699,
+      "line": 2702,
       "path": "apps/ios/Sources/Model/NodeAppModel.swift",
       "source": "Approval needed",
       "surface": "apple",
@@ -11147,7 +11147,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 3254,
+      "line": 3257,
       "path": "apps/ios/Sources/Model/NodeAppModel.swift",
       "source": "Connecting…",
       "surface": "apple",
@@ -11155,7 +11155,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 3254,
+      "line": 3257,
       "path": "apps/ios/Sources/Model/NodeAppModel.swift",
       "source": "Reconnecting…",
       "surface": "apple",
@@ -11163,7 +11163,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 3258,
+      "line": 3261,
       "path": "apps/ios/Sources/Model/NodeAppModel.swift",
       "source": "Connecting...",
       "surface": "apple",
@@ -11171,7 +11171,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 3258,
+      "line": 3261,
       "path": "apps/ios/Sources/Model/NodeAppModel.swift",
       "source": "Reconnecting...",
       "surface": "apple",
@@ -11179,7 +11179,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 3546,
+      "line": 3549,
       "path": "apps/ios/Sources/Model/NodeAppModel.swift",
       "source": "Connected",
       "surface": "apple",
@@ -11187,7 +11187,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 3546,
+      "line": 3549,
       "path": "apps/ios/Sources/Model/NodeAppModel.swift",
       "source": "Offline",
       "surface": "apple",
@@ -20298,8 +20298,56 @@
       "id": "native.apple.e9914cfc93a514cb"
     },
     {
+      "kind": "conditional-branch",
+      "line": 640,
+      "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatMessageViews.swift",
+      "source": "Queued",
+      "surface": "apple",
+      "id": "native.apple.86695104895ebed8"
+    },
+    {
+      "kind": "conditional-branch",
+      "line": 642,
+      "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatMessageViews.swift",
+      "source": "Sending…",
+      "surface": "apple",
+      "id": "native.apple.a85f179b35d39d8f"
+    },
+    {
+      "kind": "conditional-branch",
+      "line": 644,
+      "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatMessageViews.swift",
+      "source": "Not sent",
+      "surface": "apple",
+      "id": "native.apple.2888a268bfa49e9e"
+    },
+    {
+      "kind": "conditional-branch",
+      "line": 662,
+      "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatMessageViews.swift",
+      "source": "Queued, sends when reconnected",
+      "surface": "apple",
+      "id": "native.apple.593219d4c4479c59"
+    },
+    {
+      "kind": "conditional-branch",
+      "line": 664,
+      "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatMessageViews.swift",
+      "source": "Sending",
+      "surface": "apple",
+      "id": "native.apple.00e673b9c5263c5c"
+    },
+    {
+      "kind": "conditional-branch",
+      "line": 666,
+      "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatMessageViews.swift",
+      "source": "Not sent, touch and hold to retry or delete",
+      "surface": "apple",
+      "id": "native.apple.df1a81bd7a0bca36"
+    },
+    {
       "kind": "ui-call",
-      "line": 710,
+      "line": 761,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatMessageViews.swift",
       "source": "Running tools…",
       "surface": "apple",
@@ -20307,7 +20355,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 718,
+      "line": 769,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatMessageViews.swift",
       "source": "\\(display.emoji) \\(display.label)",
       "surface": "apple",
@@ -20323,7 +20371,23 @@
     },
     {
       "kind": "ui-call",
-      "line": 425,
+      "line": 402,
+      "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatView.swift",
+      "source": "Retry Send",
+      "surface": "apple",
+      "id": "native.apple.5824df4efbf6c977"
+    },
+    {
+      "kind": "ui-call",
+      "line": 417,
+      "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatView.swift",
+      "source": "Delete",
+      "surface": "apple",
+      "id": "native.apple.cdad35e9657fa693"
+    },
+    {
+      "kind": "ui-call",
+      "line": 471,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatView.swift",
       "source": "Jump to latest",
       "surface": "apple",
@@ -20331,7 +20395,7 @@
     },
     {
       "kind": "ui-modifier",
-      "line": 436,
+      "line": 482,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatView.swift",
       "source": "Jump to latest reply",
       "surface": "apple",
@@ -20339,7 +20403,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 456,
+      "line": 502,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatView.swift",
       "source": "Refresh",
       "surface": "apple",
@@ -20347,7 +20411,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 881,
+      "line": 927,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatView.swift",
       "source": "Loading chat",
       "surface": "apple",
@@ -20355,7 +20419,7 @@
     },
     {
       "kind": "ui-modifier",
-      "line": 961,
+      "line": 1007,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatView.swift",
       "source": "Dismiss",
       "surface": "apple",

--- a/apps/.i18n/native-source.json
+++ b/apps/.i18n/native-source.json
@@ -123,7 +123,7 @@
     },
     {
       "kind": "ui-state-text",
-      "line": 101,
+      "line": 103,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/MainViewModel.kt",
       "source": "Searching…",
       "surface": "android",
@@ -131,7 +131,7 @@
     },
     {
       "kind": "ui-state-text",
-      "line": 190,
+      "line": 192,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/MainViewModel.kt",
       "source": "Mic off",
       "surface": "android",
@@ -139,7 +139,7 @@
     },
     {
       "kind": "ui-state-text",
-      "line": 200,
+      "line": 202,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/MainViewModel.kt",
       "source": "Off",
       "surface": "android",
@@ -371,7 +371,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1185,
+      "line": 1200,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/gateway/GatewaySession.kt",
       "source": "Connecting…",
       "surface": "android",
@@ -379,7 +379,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1185,
+      "line": 1200,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/gateway/GatewaySession.kt",
       "source": "Reconnecting…",
       "surface": "android",
@@ -3195,7 +3195,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 979,
+      "line": 980,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Clear this phone's saved gateway access and scan a fresh setup code.",
       "surface": "android",
@@ -3203,7 +3203,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 981,
+      "line": 987,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Pair New Gateway",
       "surface": "android",
@@ -3211,7 +3211,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 982,
+      "line": 988,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Setup Code",
       "surface": "android",
@@ -3219,7 +3219,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 986,
+      "line": 992,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Android can scan or paste an existing setup code, but this gateway does not expose setup-code generation to the app yet. Generate the QR/code on the gateway host with openclaw qr, then scan it here or paste the setup code below.",
       "surface": "android",
@@ -3227,7 +3227,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 995,
+      "line": 1001,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Connection Setup",
       "surface": "android",
@@ -3235,7 +3235,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 996,
+      "line": 1002,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Setup code",
       "surface": "android",
@@ -3243,7 +3243,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 998,
+      "line": 1004,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Host",
       "surface": "android",
@@ -3251,7 +3251,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 999,
+      "line": 1005,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Port",
       "surface": "android",
@@ -3259,7 +3259,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1003,
+      "line": 1009,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Local",
       "surface": "android",
@@ -3267,7 +3267,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1007,
+      "line": 1013,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Token",
       "surface": "android",
@@ -3275,7 +3275,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1008,
+      "line": 1014,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Bootstrap",
       "surface": "android",
@@ -3283,7 +3283,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1010,
+      "line": 1016,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Password",
       "surface": "android",
@@ -3291,7 +3291,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1015,
+      "line": 1021,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Save & Connect",
       "surface": "android",
@@ -3299,7 +3299,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1055,
+      "line": 1061,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Appearance",
       "surface": "android",
@@ -3307,7 +3307,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1066,
+      "line": 1072,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Theme",
       "surface": "android",
@@ -3315,7 +3315,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1089,
+      "line": 1095,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Ready",
       "surface": "android",
@@ -3323,7 +3323,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1118,
+      "line": 1124,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "About",
       "surface": "android",
@@ -3331,7 +3331,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1130,
+      "line": 1136,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Gateway",
       "surface": "android",
@@ -3339,7 +3339,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1132,
+      "line": 1138,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Runtime",
       "surface": "android",
@@ -3347,7 +3347,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1135,
+      "line": 1141,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Update",
       "surface": "android",
@@ -3355,7 +3355,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1165,
+      "line": 1171,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Licenses",
       "surface": "android",
@@ -3363,7 +3363,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1166,
+      "line": 1172,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "OpenClaw appreciates its partners in the open-source community.",
       "surface": "android",
@@ -3371,7 +3371,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1175,
+      "line": 1181,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "No license notices are packaged in this build.",
       "surface": "android",
@@ -3379,7 +3379,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1201,
+      "line": 1207,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Open ${license.title}",
       "surface": "android",
@@ -3387,7 +3387,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1236,
+      "line": 1242,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Check",
       "surface": "android",
@@ -3395,7 +3395,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1269,
+      "line": 1275,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Back",
       "surface": "android",
@@ -3403,7 +3403,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1342,
+      "line": 1348,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Sending",
       "surface": "android",
@@ -3411,7 +3411,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1351,
+      "line": 1357,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Allow Once",
       "surface": "android",
@@ -3419,7 +3419,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1351,
+      "line": 1357,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Allowing",
       "surface": "android",
@@ -3427,7 +3427,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1359,
+      "line": 1365,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Always",
       "surface": "android",
@@ -3435,7 +3435,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1359,
+      "line": 1365,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Saving",
       "surface": "android",
@@ -3443,7 +3443,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1367,
+      "line": 1373,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Deny",
       "surface": "android",
@@ -3451,7 +3451,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1367,
+      "line": 1373,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Denying",
       "surface": "android",
@@ -3459,7 +3459,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1392,
+      "line": 1398,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Review",
       "surface": "android",
@@ -3467,7 +3467,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1417,
+      "line": 1423,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Issue",
       "surface": "android",
@@ -3475,7 +3475,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1448,
+      "line": 1454,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Default assistant",
       "surface": "android",
@@ -3483,7 +3483,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1450,
+      "line": 1456,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Default",
       "surface": "android",
@@ -3491,7 +3491,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1506,
+      "line": 1512,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Needs attention",
       "surface": "android",
@@ -3499,7 +3499,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1509,
+      "line": 1515,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Waiting ${minutes}m",
       "surface": "android",
@@ -3507,7 +3507,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1509,
+      "line": 1515,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Waiting for review",
       "surface": "android",
@@ -3515,7 +3515,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1537,
+      "line": 1543,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "${job.scheduleLabel} · ${formatCronWake(job.nextRunAtMs)} · ${job.promptPreview}",
       "surface": "android",
@@ -3523,7 +3523,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1544,
+      "line": 1550,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "No limits reported",
       "surface": "android",
@@ -3531,7 +3531,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1565,
+      "line": 1571,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Off",
       "surface": "android",
@@ -5203,7 +5203,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 225,
+      "line": 226,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Chat needs attention",
       "surface": "android",
@@ -5211,7 +5211,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 366,
+      "line": 367,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "All",
       "surface": "android",
@@ -5219,7 +5219,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 420,
+      "line": 421,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "OpenClaw",
       "surface": "android",
@@ -5227,7 +5227,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 441,
+      "line": 442,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "New chat",
       "surface": "android",
@@ -5235,7 +5235,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 442,
+      "line": 443,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Refresh chat",
       "surface": "android",
@@ -5243,7 +5243,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 445,
+      "line": 446,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Chat",
       "surface": "android",
@@ -5251,7 +5251,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 582,
+      "line": 583,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Loading session",
       "surface": "android",
@@ -5259,7 +5259,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 609,
+      "line": 610,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Jump to latest",
       "surface": "android",
@@ -5267,7 +5267,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 629,
+      "line": 630,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Ready when you are",
       "surface": "android",
@@ -5275,7 +5275,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 660,
+      "line": 661,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Fix connection",
       "surface": "android",
@@ -5283,7 +5283,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 661,
+      "line": 662,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Copy diagnostics",
       "surface": "android",
@@ -5291,7 +5291,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 799,
+      "line": 800,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Tools running",
       "surface": "android",
@@ -5299,7 +5299,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 804,
+      "line": 805,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "+${toolCalls.size - 4} more",
       "surface": "android",
@@ -5307,7 +5307,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 814,
+      "line": 815,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Thinking",
       "surface": "android",
@@ -5315,7 +5315,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 815,
+      "line": 816,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "OpenClaw is preparing a response.",
       "surface": "android",
@@ -5323,7 +5323,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 934,
+      "line": 935,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Stop",
       "surface": "android",
@@ -5331,7 +5331,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 951,
+      "line": 952,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "No commands found",
       "surface": "android",
@@ -5339,7 +5339,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1013,
+      "line": 1014,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Gateway offline",
       "surface": "android",
@@ -5347,7 +5347,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1103,
+      "line": 1104,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Attach image",
       "surface": "android",
@@ -5355,7 +5355,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1118,
+      "line": 1119,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Message OpenClaw",
       "surface": "android",
@@ -5363,7 +5363,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1133,
+      "line": 1134,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Voice",
       "surface": "android",
@@ -5371,7 +5371,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1171,
+      "line": 1172,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Remove attachment",
       "surface": "android",
@@ -5379,7 +5379,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1192,
+      "line": 1193,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Main",
       "surface": "android",
@@ -5387,7 +5387,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1248,
+      "line": 1249,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Send",
       "surface": "android",
@@ -5395,7 +5395,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1287,
+      "line": 1288,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "$contextLabel · ${contextMeterThinkingLabel(thinkingLevel)}",
       "surface": "android",
@@ -5403,7 +5403,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 287,
+      "line": 269,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatSheetContent.kt",
       "source": "CHAT ERROR",
       "surface": "android",
@@ -7259,7 +7259,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 100,
+      "line": 110,
       "path": "apps/ios/Sources/Design/ChatProTab.swift",
       "source": "Unable to Export Transcript",
       "surface": "apple",
@@ -7267,7 +7267,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 104,
+      "line": 114,
       "path": "apps/ios/Sources/Design/ChatProTab.swift",
       "source": "OK",
       "surface": "apple",
@@ -7275,7 +7275,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 108,
+      "line": 118,
       "path": "apps/ios/Sources/Design/ChatProTab.swift",
       "source": "OpenClaw could not prepare the Markdown file.",
       "surface": "apple",
@@ -7283,7 +7283,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 128,
+      "line": 138,
       "path": "apps/ios/Sources/Design/ChatProTab.swift",
       "source": "What would you like to work on?",
       "surface": "apple",
@@ -7291,7 +7291,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 139,
+      "line": 149,
       "path": "apps/ios/Sources/Design/ChatProTab.swift",
       "source": "The session attaches once the gateway is ready.",
       "surface": "apple",
@@ -7299,7 +7299,7 @@
     },
     {
       "kind": "ui-modifier",
-      "line": 218,
+      "line": 238,
       "path": "apps/ios/Sources/Design/ChatProTab.swift",
       "source": "Opens Settings / Gateway",
       "surface": "apple",
@@ -7307,7 +7307,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 243,
+      "line": 263,
       "path": "apps/ios/Sources/Design/ChatProTab.swift",
       "source": "Export Transcript",
       "surface": "apple",
@@ -7315,7 +7315,7 @@
     },
     {
       "kind": "ui-modifier",
-      "line": 253,
+      "line": 273,
       "path": "apps/ios/Sources/Design/ChatProTab.swift",
       "source": "Chat actions",
       "surface": "apple",
@@ -7323,7 +7323,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 306,
+      "line": 326,
       "path": "apps/ios/Sources/Design/ChatProTab.swift",
       "source": "Connected",
       "surface": "apple",
@@ -7331,7 +7331,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 306,
+      "line": 326,
       "path": "apps/ios/Sources/Design/ChatProTab.swift",
       "source": "Unavailable",
       "surface": "apple",
@@ -7339,7 +7339,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 317,
+      "line": 337,
       "path": "apps/ios/Sources/Design/ChatProTab.swift",
       "source": "Connect to a gateway",
       "surface": "apple",
@@ -7347,7 +7347,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 317,
+      "line": 337,
       "path": "apps/ios/Sources/Design/ChatProTab.swift",
       "source": "Message \\(self.agentDisplayName)...",
       "surface": "apple",
@@ -7355,7 +7355,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 367,
+      "line": 391,
       "path": "apps/ios/Sources/Design/ChatProTab.swift",
       "source": "Check OpenClaw status",
       "surface": "apple",
@@ -7363,7 +7363,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 368,
+      "line": 392,
       "path": "apps/ios/Sources/Design/ChatProTab.swift",
       "source": "Summarize the current OpenClaw status and tell me what needs attention.",
       "surface": "apple",
@@ -7371,7 +7371,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 371,
+      "line": 395,
       "path": "apps/ios/Sources/Design/ChatProTab.swift",
       "source": "What can I control here?",
       "surface": "apple",
@@ -7379,7 +7379,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 372,
+      "line": 396,
       "path": "apps/ios/Sources/Design/ChatProTab.swift",
       "source": "Show me which phone controls and device capabilities are available right now.",
       "surface": "apple",
@@ -7387,7 +7387,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 375,
+      "line": 399,
       "path": "apps/ios/Sources/Design/ChatProTab.swift",
       "source": "Help me start voice chat",
       "surface": "apple",
@@ -7395,7 +7395,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 376,
+      "line": 400,
       "path": "apps/ios/Sources/Design/ChatProTab.swift",
       "source": "Help me start a realtime voice session from this phone.",
       "surface": "apple",
@@ -11131,7 +11131,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 2702,
+      "line": 2704,
       "path": "apps/ios/Sources/Model/NodeAppModel.swift",
       "source": "Action required",
       "surface": "apple",
@@ -11139,7 +11139,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 2702,
+      "line": 2704,
       "path": "apps/ios/Sources/Model/NodeAppModel.swift",
       "source": "Approval needed",
       "surface": "apple",
@@ -11147,7 +11147,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 3257,
+      "line": 3259,
       "path": "apps/ios/Sources/Model/NodeAppModel.swift",
       "source": "Connecting…",
       "surface": "apple",
@@ -11155,7 +11155,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 3257,
+      "line": 3259,
       "path": "apps/ios/Sources/Model/NodeAppModel.swift",
       "source": "Reconnecting…",
       "surface": "apple",
@@ -11163,7 +11163,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 3261,
+      "line": 3263,
       "path": "apps/ios/Sources/Model/NodeAppModel.swift",
       "source": "Connecting...",
       "surface": "apple",
@@ -11171,7 +11171,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 3261,
+      "line": 3263,
       "path": "apps/ios/Sources/Model/NodeAppModel.swift",
       "source": "Reconnecting...",
       "surface": "apple",
@@ -11179,7 +11179,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 3549,
+      "line": 3551,
       "path": "apps/ios/Sources/Model/NodeAppModel.swift",
       "source": "Connected",
       "surface": "apple",
@@ -11187,7 +11187,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 3549,
+      "line": 3551,
       "path": "apps/ios/Sources/Model/NodeAppModel.swift",
       "source": "Offline",
       "surface": "apple",

--- a/apps/ios/Sources/Design/ChatProTab.swift
+++ b/apps/ios/Sources/Design/ChatProTab.swift
@@ -173,17 +173,7 @@ struct ChatProTab: View {
             self.viewModelTransportModeID = transportModeID
             self.viewModelTransportAgentID = transportAgentID
             self.viewModelAgentID = agentID
-            self.viewModel = OpenClawChatViewModel(
-                sessionKey: sessionKey,
-                transport: self.appModel.makeChatTransport(),
-                activeAgentId: agentID,
-                transcriptCache: self.appModel.makeChatTranscriptCache(),
-                onSessionChanged: { sessionKey in
-                    self.appModel.focusChatSession(sessionKey)
-                },
-                diagnosticsLog: { message in
-                    GatewayDiagnostics.log(message)
-                })
+            self.viewModel = self.makeChatViewModel(sessionKey: sessionKey, activeAgentId: agentID)
             return
         }
         if self.viewModelTransportModeID != transportModeID ||
@@ -193,21 +183,29 @@ struct ChatProTab: View {
             self.viewModelTransportModeID = transportModeID
             self.viewModelTransportAgentID = transportAgentID
             self.viewModelAgentID = agentID
-            self.viewModel = OpenClawChatViewModel(
-                sessionKey: sessionKey,
-                transport: self.appModel.makeChatTransport(),
-                activeAgentId: agentID,
-                transcriptCache: self.appModel.makeChatTranscriptCache(),
-                onSessionChanged: { sessionKey in
-                    self.appModel.focusChatSession(sessionKey)
-                },
-                diagnosticsLog: { message in
-                    GatewayDiagnostics.log(message)
-                })
+            self.viewModel = self.makeChatViewModel(sessionKey: sessionKey, activeAgentId: agentID)
             return
         }
         guard viewModel.sessionKey != sessionKey else { return }
         viewModel.syncSession(to: sessionKey)
+    }
+
+    private func makeChatViewModel(sessionKey: String, activeAgentId: String? = nil) -> OpenClawChatViewModel {
+        // One store instance backs both seams so the transcript cache and the
+        // offline outbox share a single SQLite connection.
+        let offlineStore = self.appModel.makeChatOfflineStore()
+        return OpenClawChatViewModel(
+            sessionKey: sessionKey,
+            transport: self.appModel.makeChatTransport(),
+            activeAgentId: activeAgentId,
+            transcriptCache: offlineStore,
+            outbox: offlineStore,
+            onSessionChanged: { sessionKey in
+                self.appModel.focusChatSession(sessionKey)
+            },
+            diagnosticsLog: { message in
+                GatewayDiagnostics.log(message)
+            })
     }
 
     private var talkControl: OpenClawChatTalkControl {

--- a/apps/ios/Sources/Model/NodeAppModel.swift
+++ b/apps/ios/Sources/Model/NodeAppModel.swift
@@ -359,8 +359,11 @@ final class NodeAppModel {
 
     private var chatTranscriptCacheGeneration = 0
 
-    /// Offline transcript cache scoped to the paired gateway identity.
-    func makeChatTranscriptCache() -> (any OpenClawChatTranscriptCache)? {
+    /// Offline transcript cache plus durable command outbox, both scoped to
+    /// the paired gateway identity (one SQLite file per gateway, memoized so
+    /// retire/purge can close every open handle). Nil for fixture/unpaired
+    /// transports: no cache and no outbox.
+    func makeChatOfflineStore() -> OpenClawChatSQLiteTranscriptCache? {
         guard let gatewayID = self.chatTranscriptCacheGatewayID else { return nil }
         if let cache = self.chatTranscriptCachesByGatewayID[gatewayID] {
             return cache
@@ -372,17 +375,19 @@ final class NodeAppModel {
     }
 
     func loadCachedChatSessions() async -> [OpenClawChatSessionEntry] {
-        guard let cache = self.makeChatTranscriptCache() else { return [] }
+        guard let cache = self.makeChatOfflineStore() else { return [] }
         return await cache.loadSessions()
     }
 
     func storeCachedChatSessions(_ sessions: [OpenClawChatSessionEntry]) async {
-        guard let cache = self.makeChatTranscriptCache() else { return }
+        guard let cache = self.makeChatOfflineStore() else { return }
         await cache.storeSessions(sessions)
     }
 
     /// Delete one gateway's cache during bootstrap replacement, or the whole
-    /// disposable database during a full onboarding reset.
+    /// disposable database during a full onboarding reset. The offline command
+    /// outbox shares each gateway's database file, so purging a cache also
+    /// drops that gateway's queued commands.
     func purgeChatTranscriptCache(gatewayID: String? = nil) async {
         if let gatewayID, !gatewayID.isEmpty {
             guard let databaseURL = self.chatTranscriptCacheDatabaseURL(gatewayID: gatewayID) else { return }

--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatMessageViews.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatMessageViews.swift
@@ -618,6 +618,57 @@ struct ChatTypingIndicatorBubble: View {
     }
 }
 
+/// Status footer for a user bubble backed by the durable offline outbox.
+@MainActor
+struct ChatOutboxStatusLabel: View {
+    let state: OpenClawChatOutboxMessageState
+
+    var body: some View {
+        HStack(spacing: 4) {
+            Image(systemName: self.iconName)
+                .font(.system(size: 10, weight: .semibold))
+            Text(self.title)
+                .font(OpenClawChatTypography.caption)
+        }
+        .foregroundStyle(self.state.isFailed ? AnyShapeStyle(OpenClawChatTheme.danger) : AnyShapeStyle(.secondary))
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel(self.accessibilityText)
+    }
+
+    private var title: String {
+        switch self.state {
+        case .queued:
+            "Queued"
+        case .sending:
+            "Sending…"
+        case .failed:
+            "Not sent"
+        }
+    }
+
+    private var iconName: String {
+        switch self.state {
+        case .queued:
+            "clock"
+        case .sending:
+            "arrow.up.circle"
+        case .failed:
+            "exclamationmark.circle"
+        }
+    }
+
+    private var accessibilityText: String {
+        switch self.state {
+        case .queued:
+            "Queued, sends when reconnected"
+        case .sending:
+            "Sending"
+        case .failed:
+            "Not sent, touch and hold to retry or delete"
+        }
+    }
+}
+
 extension ChatTypingIndicatorBubble: @MainActor Equatable {
     static func == (lhs: Self, rhs: Self) -> Bool {
         lhs.style == rhs.style &&

--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatTranscriptCache.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatTranscriptCache.swift
@@ -20,19 +20,105 @@ public protocol OpenClawChatTranscriptCache: Sendable {
     func storeTranscript(sessionKey: String, messages: [OpenClawChatMessage]) async
 }
 
+/// One durable queued chat command (text only in v1). `id` is the client UUID
+/// that becomes the transport idempotency key on flush, so at-least-once
+/// delivery stays safe across retries and app restarts.
+///
+/// Naming mirrors the watch-side `QueuedCommand` shape (WatchChatCoordinator)
+/// so the two queues can merge into one owner later.
+public struct OpenClawChatOutboxCommand: Hashable, Sendable, Identifiable {
+    public enum Status: String, Sendable {
+        case queued
+        case sending
+        case failed
+    }
+
+    public let id: String
+    public let sessionKey: String
+    public let text: String
+    /// Thinking level captured when the command was queued, so a later flush
+    /// never borrows the setting of whichever session is visible then.
+    public let thinking: String
+    /// Seconds since 1970; flush order is strictly ascending `createdAt`.
+    public let createdAt: Double
+    public var status: Status
+    public var retryCount: Int
+    public var lastError: String?
+
+    public init(
+        id: String,
+        sessionKey: String,
+        text: String,
+        thinking: String,
+        createdAt: Double,
+        status: Status,
+        retryCount: Int,
+        lastError: String?)
+    {
+        self.id = id
+        self.sessionKey = sessionKey
+        self.text = text
+        self.thinking = thinking
+        self.createdAt = createdAt
+        self.status = status
+        self.retryCount = retryCount
+        self.lastError = lastError
+    }
+}
+
+/// Durable offline outbox for chat commands, scoped to one gateway identity
+/// exactly like the transcript cache. Implementations persist queued sends so
+/// they survive app restarts and flush on reconnect.
+public protocol OpenClawChatCommandOutbox: Sendable {
+    /// Returns false when the queue is full (`maxQueuedCommands`) or storage
+    /// is unavailable; callers surface that instead of dropping text silently.
+    func enqueueCommand(_ command: OpenClawChatOutboxCommand) async -> Bool
+    /// Gateway-scoped rows in `createdAt` order. Applies the staleness gate:
+    /// queued rows older than `outboxCommandMaxAge` become failed("expired")
+    /// so reconnect never sends stale commands silently.
+    func loadCommands() async -> [OpenClawChatOutboxCommand]
+    /// Crash safety: rows stuck in 'sending' from a previous process revert
+    /// to 'queued'; the idempotency key makes the re-send safe. Returns false
+    /// when the store was unreachable (for example Complete file protection
+    /// while the device is locked) so callers can retry recovery later.
+    @discardableResult
+    func recoverInterruptedSends() async -> Bool
+    /// Claims a row for sending. Returns false when the row no longer exists
+    /// (deleted mid-flush), so the flush skips it instead of sending stale text.
+    @discardableResult
+    func markCommandSending(id: String) async -> Bool
+    func markCommandQueued(id: String, retryCount: Int, lastError: String?) async
+    func markCommandFailed(id: String, retryCount: Int, lastError: String?) async
+    /// Explicit user retry: reset attempts and refresh `createdAt` so an
+    /// expired row can send again (retry is new intent, so it also moves the
+    /// command to the queue tail rather than replaying its old position).
+    func markCommandRetried(id: String) async
+    func deleteCommand(id: String) async
+}
+
 /// SQLite-backed transcript cache for one gateway identity. Owners should use
 /// one database file per gateway so reset can physically remove that gateway's
-/// cached transcript bytes without disturbing other paired gateways.
+/// cached transcript bytes without disturbing other paired gateways; queries
+/// are additionally scoped by `gatewayID` as a defensive belt.
 ///
 /// The cache is disposable: any open, schema, or decode mismatch drops the
-/// affected state and rebuilds silently. There are no migrations.
-public actor OpenClawChatSQLiteTranscriptCache: OpenClawChatTranscriptCache {
+/// affected state and rebuilds silently. There are no migrations. The command
+/// outbox shares this database; a drop also clears queued commands, which is
+/// acceptable because a queue that predates a schema change is stale anyway.
+public actor OpenClawChatSQLiteTranscriptCache: OpenClawChatTranscriptCache, OpenClawChatCommandOutbox {
     /// Bounds keep the cache small: enough for a recently-used session picker
     /// and a full first screen of transcript, not a durable archive.
     public static let maxCachedSessions = 50
     public static let maxCachedTranscripts = 50
     public static let maxCachedMessagesPerSession = 200
-    static let schemaVersion: Int32 = 1
+    /// Outbox bounds: refuse enqueue beyond this many rows per gateway, and
+    /// expire queued commands instead of sending them after two days offline.
+    public static let maxQueuedCommands = 50
+    public static let outboxCommandMaxAge: TimeInterval = 48 * 60 * 60
+    /// Machine-readable `lastError` set by the staleness gate.
+    public static let outboxExpiredError = "expired"
+    // v2 adds the outbox_commands table; older shapes drop-and-rebuild.
+    static let schemaVersion: Int32 = 2
 
     /// Owns the raw sqlite handle so it closes on release without needing an
     /// isolated actor deinit (OpaquePointer is not Sendable).
@@ -173,6 +259,148 @@ public actor OpenClawChatSQLiteTranscriptCache: OpenClawChatTranscriptCache {
         // no-op. Closing the handle lets the owner delete the whole cache file.
         self.isRetired = true
         self.db = nil
+    }
+
+    // MARK: - OpenClawChatCommandOutbox
+
+    public func enqueueCommand(_ command: OpenClawChatOutboxCommand) async -> Bool {
+        guard !self.isRetired, let db = await self.handle() else { return false }
+        let count = self.selectInt(
+            db,
+            sql: "SELECT COUNT(*) FROM outbox_commands WHERE gateway_id = ?1",
+            bindings: [self.gatewayID]) ?? 0
+        // Bound the queue per gateway across all statuses so failed rows also
+        // count: the user must clear them before queueing more.
+        guard count < Self.maxQueuedCommands else { return false }
+        return self.execute(
+            db,
+            sql: """
+            INSERT INTO outbox_commands(
+                client_uuid, gateway_id, session_key, text, thinking, created_at, status, retry_count, last_error
+            ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, '')
+            """,
+            bindings: [
+                command.id,
+                self.gatewayID,
+                command.sessionKey,
+                command.text,
+                command.thinking,
+                command.createdAt,
+                command.status.rawValue,
+                command.retryCount,
+            ])
+    }
+
+    public func loadCommands() async -> [OpenClawChatOutboxCommand] {
+        guard !self.isRetired, let db = await self.handle() else { return [] }
+        // Staleness gate: a command queued 48h ago is more likely wrong than
+        // wanted; surface it as failed("expired") instead of sending it.
+        self.execute(
+            db,
+            sql: """
+            UPDATE outbox_commands SET status = 'failed', last_error = ?3
+            WHERE gateway_id = ?1 AND status = 'queued' AND created_at < ?2
+            """,
+            bindings: [
+                self.gatewayID,
+                Date().timeIntervalSince1970 - Self.outboxCommandMaxAge,
+                Self.outboxExpiredError,
+            ])
+
+        var statement: OpaquePointer?
+        let sql = """
+        SELECT client_uuid, session_key, text, thinking, created_at, status, retry_count, last_error
+        FROM outbox_commands WHERE gateway_id = ?1
+        ORDER BY created_at ASC, id ASC
+        """
+        guard sqlite3_prepare_v2(db, sql, -1, &statement, nil) == SQLITE_OK else { return [] }
+        defer { sqlite3_finalize(statement) }
+        guard self.bind(statement, bindings: [self.gatewayID]) else { return [] }
+
+        var commands: [OpenClawChatOutboxCommand] = []
+        while sqlite3_step(statement) == SQLITE_ROW {
+            guard let id = sqlite3_column_text(statement, 0),
+                  let sessionKey = sqlite3_column_text(statement, 1),
+                  let text = sqlite3_column_text(statement, 2)
+            else { continue }
+            let thinking = sqlite3_column_text(statement, 3).map { String(cString: $0) } ?? ""
+            let statusRaw = sqlite3_column_text(statement, 5).map { String(cString: $0) } ?? ""
+            let lastError = sqlite3_column_text(statement, 7).map { String(cString: $0) } ?? ""
+            commands.append(
+                OpenClawChatOutboxCommand(
+                    id: String(cString: id),
+                    sessionKey: String(cString: sessionKey),
+                    text: String(cString: text),
+                    thinking: thinking,
+                    createdAt: sqlite3_column_double(statement, 4),
+                    // Unknown status means a foreign writer; treating it as
+                    // queued is safe because the idempotency key dedupes.
+                    status: OpenClawChatOutboxCommand.Status(rawValue: statusRaw) ?? .queued,
+                    retryCount: Int(sqlite3_column_int64(statement, 6)),
+                    lastError: lastError.isEmpty ? nil : lastError))
+        }
+        return commands
+    }
+
+    @discardableResult
+    public func recoverInterruptedSends() async -> Bool {
+        guard !self.isRetired, let db = await self.handle() else { return false }
+        return self.execute(
+            db,
+            sql: "UPDATE outbox_commands SET status = 'queued' WHERE gateway_id = ?1 AND status = 'sending'",
+            bindings: [self.gatewayID])
+    }
+
+    @discardableResult
+    public func markCommandSending(id: String) async -> Bool {
+        guard !self.isRetired, let db = await self.handle() else { return false }
+        let updated = self.execute(
+            db,
+            sql: "UPDATE outbox_commands SET status = 'sending' WHERE gateway_id = ?1 AND client_uuid = ?2",
+            bindings: [self.gatewayID, id])
+        // Zero changed rows means the command was deleted while this claim
+        // was queued; the caller must not send it.
+        return updated && sqlite3_changes(db) > 0
+    }
+
+    public func markCommandQueued(id: String, retryCount: Int, lastError: String?) async {
+        await self.updateCommandStatus(id: id, status: "queued", retryCount: retryCount, lastError: lastError)
+    }
+
+    public func markCommandFailed(id: String, retryCount: Int, lastError: String?) async {
+        await self.updateCommandStatus(id: id, status: "failed", retryCount: retryCount, lastError: lastError)
+    }
+
+    public func markCommandRetried(id: String) async {
+        guard !self.isRetired, let db = await self.handle() else { return }
+        // Fresh createdAt: without it the staleness gate would immediately
+        // re-expire a retried row that sat offline past the 48h bound.
+        self.execute(
+            db,
+            sql: """
+            UPDATE outbox_commands SET status = 'queued', retry_count = 0, last_error = '', created_at = ?3
+            WHERE gateway_id = ?1 AND client_uuid = ?2
+            """,
+            bindings: [self.gatewayID, id, Date().timeIntervalSince1970])
+    }
+
+    public func deleteCommand(id: String) async {
+        guard !self.isRetired, let db = await self.handle() else { return }
+        self.execute(
+            db,
+            sql: "DELETE FROM outbox_commands WHERE gateway_id = ?1 AND client_uuid = ?2",
+            bindings: [self.gatewayID, id])
+    }
+
+    private func updateCommandStatus(id: String, status: String, retryCount: Int, lastError: String?) async {
+        guard !self.isRetired, let db = await self.handle() else { return }
+        self.execute(
+            db,
+            sql: """
+            UPDATE outbox_commands SET status = ?3, retry_count = ?4, last_error = ?5
+            WHERE gateway_id = ?1 AND client_uuid = ?2
+            """,
+            bindings: [self.gatewayID, id, status, retryCount, lastError ?? ""])
     }
 
     // MARK: - Cached shapes
@@ -323,6 +551,22 @@ public actor OpenClawChatSQLiteTranscriptCache: OpenClawChatTranscriptCache {
                 PRIMARY KEY(gateway_id, session_key)
             )
             """,
+            // last_error uses '' for "none" so every column binds non-null.
+            // rowid `id` breaks created_at ties so flush order stays stable.
+            """
+            CREATE TABLE IF NOT EXISTS outbox_commands(
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                client_uuid TEXT NOT NULL UNIQUE,
+                gateway_id TEXT NOT NULL,
+                session_key TEXT NOT NULL,
+                text TEXT NOT NULL,
+                thinking TEXT NOT NULL DEFAULT '',
+                created_at REAL NOT NULL,
+                status TEXT NOT NULL,
+                retry_count INTEGER NOT NULL DEFAULT 0,
+                last_error TEXT NOT NULL DEFAULT ''
+            )
+            """,
             "PRAGMA user_version = \(Self.schemaVersion)",
         ]
         for sql in statements {
@@ -345,6 +589,15 @@ public actor OpenClawChatSQLiteTranscriptCache: OpenClawChatTranscriptCache {
         return sqlite3_step(statement) == SQLITE_DONE
     }
 
+    private func selectInt(_ db: OpaquePointer, sql: String, bindings: [Any]) -> Int? {
+        var statement: OpaquePointer?
+        guard sqlite3_prepare_v2(db, sql, -1, &statement, nil) == SQLITE_OK else { return nil }
+        defer { sqlite3_finalize(statement) }
+        guard self.bind(statement, bindings: bindings) else { return nil }
+        guard sqlite3_step(statement) == SQLITE_ROW else { return nil }
+        return Int(sqlite3_column_int64(statement, 0))
+    }
+
     private func selectPayload(_ db: OpaquePointer, sql: String, bindings: [Any]) -> String? {
         var statement: OpaquePointer?
         guard sqlite3_prepare_v2(db, sql, -1, &statement, nil) == SQLITE_OK else { return nil }
@@ -363,6 +616,8 @@ public actor OpenClawChatSQLiteTranscriptCache: OpenClawChatTranscriptCache {
             let result: Int32 = switch value {
             case let text as String:
                 sqlite3_bind_text(statement, index, text, -1, transient)
+            case let int as Int:
+                sqlite3_bind_int64(statement, index, Int64(int))
             case let real as Double:
                 sqlite3_bind_double(statement, index, real)
             default:

--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatTranscriptCache.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatTranscriptCache.swift
@@ -117,7 +117,7 @@ public actor OpenClawChatSQLiteTranscriptCache: OpenClawChatTranscriptCache, Ope
     public static let outboxCommandMaxAge: TimeInterval = 48 * 60 * 60
     /// Machine-readable `lastError` set by the staleness gate.
     public static let outboxExpiredError = "expired"
-    // v2 adds the outbox_commands table; older shapes drop-and-rebuild.
+    /// v2 adds the outbox_commands table; older shapes drop-and-rebuild.
     static let schemaVersion: Int32 = 2
 
     /// Owns the raw sqlite handle so it closes on release without needing an

--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatView.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatView.swift
@@ -330,20 +330,7 @@ public struct OpenClawChatView: View {
         }
 
         ForEach(self.visibleMessages) { msg in
-            ChatMessageBubble(
-                message: msg,
-                style: self.style,
-                markdownVariant: self.markdownVariant,
-                userAccent: self.userAccent,
-                showsAssistantTrace: self.showsAssistantTrace,
-                assistantName: self.assistantName,
-                assistantAvatarText: self.assistantAvatarText,
-                assistantAvatarTint: self.assistantAvatarTint,
-                showsAssistantAvatar: self.showsAssistantAvatars,
-                isClean: self.composerChrome == .clean)
-                .frame(
-                    maxWidth: .infinity,
-                    alignment: msg.role.lowercased() == "user" ? .trailing : .leading)
+            self.messageRow(for: msg)
         }
 
         if self.viewModel.pendingRunCount > 0 {
@@ -378,6 +365,65 @@ public struct OpenClawChatView: View {
                 showsAssistantAvatar: self.showsAssistantAvatars,
                 isClean: self.composerChrome == .clean)
                 .frame(maxWidth: .infinity, alignment: .leading)
+        }
+    }
+
+    @ViewBuilder
+    private func messageRow(for msg: OpenClawChatMessage) -> some View {
+        let bubble = ChatMessageBubble(
+            message: msg,
+            style: self.style,
+            markdownVariant: self.markdownVariant,
+            userAccent: self.userAccent,
+            showsAssistantTrace: self.showsAssistantTrace,
+            assistantName: self.assistantName,
+            assistantAvatarText: self.assistantAvatarText,
+            assistantAvatarTint: self.assistantAvatarTint,
+            showsAssistantAvatar: self.showsAssistantAvatars,
+            isClean: self.composerChrome == .clean)
+            .frame(
+                maxWidth: .infinity,
+                alignment: msg.role.lowercased() == "user" ? .trailing : .leading)
+        if let outboxState = self.viewModel.outboxState(for: msg.id) {
+            // Offline-queued send: show the durable state under the bubble
+            // and offer retry/delete through the row's context menu.
+            VStack(alignment: .trailing, spacing: 3) {
+                bubble
+                ChatOutboxStatusLabel(state: outboxState)
+                    .padding(.trailing, 8)
+            }
+            .frame(maxWidth: .infinity, alignment: .trailing)
+            .contextMenu {
+                if outboxState.isFailed {
+                    Button {
+                        self.viewModel.retryOutboxMessage(msg.id)
+                    } label: {
+                        Label {
+                            Text("Retry Send")
+                                .font(OpenClawChatTypography.body)
+                        } icon: {
+                            Image(systemName: "arrow.clockwise")
+                        }
+                    }
+                }
+                // No Delete while `.sending`: the transport call is already
+                // in flight and cannot be prevented, so removing the bubble
+                // would hide a message that may still reach the gateway.
+                if outboxState != .sending {
+                    Button(role: .destructive) {
+                        self.viewModel.deleteOutboxMessage(msg.id)
+                    } label: {
+                        Label {
+                            Text("Delete")
+                                .font(OpenClawChatTypography.body)
+                        } icon: {
+                            Image(systemName: "trash")
+                        }
+                    }
+                }
+            }
+        } else {
+            bubble
         }
     }
 

--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatViewModel+Outbox.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatViewModel+Outbox.swift
@@ -1,0 +1,487 @@
+import Foundation
+import OSLog
+
+private let outboxLogger = Logger(subsystem: "ai.openclaw", category: "OpenClawChatOutbox")
+
+/// Display state for a transcript row backed by a durable outbox command.
+public enum OpenClawChatOutboxMessageState: Equatable, Sendable {
+    case queued
+    case sending
+    case failed(reason: String?)
+
+    public var isFailed: Bool {
+        if case .failed = self { return true }
+        return false
+    }
+}
+
+// Durable offline command outbox. Sends made while the gateway is unhealthy
+// are persisted (per gateway, alongside the transcript cache) and flushed
+// strictly in createdAt order when health recovers. Each command's client
+// UUID rides as the transport idempotency key, so at-least-once flushing plus
+// gateway dedupe keeps the transcript exact.
+extension OpenClawChatViewModel {
+    public func outboxState(for messageID: UUID) -> OpenClawChatOutboxMessageState? {
+        self.outboxStatesByMessageID[messageID]
+    }
+
+    /// Tap-to-retry for a failed command: reset attempts, refresh createdAt
+    /// (so even an expired row can send again), and flush if healthy.
+    public func retryOutboxMessage(_ messageID: UUID) {
+        guard let outbox, let commandID = self.outboxCommandIDsByMessageID[messageID] else { return }
+        self.outboxStatesByMessageID[messageID] = .queued
+        Task { [weak self] in
+            await outbox.markCommandRetried(id: commandID)
+            self?.flushOutboxIfNeeded()
+        }
+    }
+
+    public func deleteOutboxMessage(_ messageID: UUID) {
+        guard let outbox, let commandID = self.outboxCommandIDsByMessageID[messageID] else { return }
+        // Tombstone first, synchronously: an active flush checks this set
+        // right before its transport call, so the deleted command cannot be
+        // sent even if the row deletion below races the flush's claim.
+        self.deletedOutboxCommandIDs.insert(commandID)
+        Task { [weak self] in
+            // Durable delete before the bubble disappears: if the process
+            // dies in this window, both the row and the visible bubble
+            // survive, so a user-deleted command can never silently
+            // resurrect and send on the next launch.
+            await outbox.deleteCommand(id: commandID)
+            guard let self else { return }
+            // Row is durably gone; the tombstone has done its job.
+            self.deletedOutboxCommandIDs.remove(commandID)
+            self.outboxCommandIDsByMessageID.removeValue(forKey: messageID)
+            self.outboxMessageIDsByCommandID.removeValue(forKey: commandID)
+            self.outboxStatesByMessageID.removeValue(forKey: messageID)
+            self.replaceMessages(self.messages.filter { $0.id != messageID })
+        }
+    }
+
+    // MARK: - Capture
+
+    /// Offline capture path used by performSend when the gateway is
+    /// unhealthy: persist first, then render the queued bubble. A full queue
+    /// refuses the enqueue and keeps the draft so no text is lost.
+    func enqueueOutboxCommand(text: String, session: SessionSnapshot) async {
+        guard let outbox else { return }
+        let command = OpenClawChatOutboxCommand(
+            id: UUID().uuidString,
+            sessionKey: session.key,
+            text: text,
+            thinking: self.thinkingLevel,
+            createdAt: Date().timeIntervalSince1970,
+            status: .queued,
+            retryCount: 0,
+            lastError: nil)
+        let accepted = await outbox.enqueueCommand(command)
+        guard self.isCurrentSession(session) else { return }
+        guard accepted else {
+            self.errorText = "Offline queue is full. Delete a queued message or reconnect to send."
+            return
+        }
+        self.input = ""
+        self.errorText = nil
+        self.presentOutboxCommands([command])
+        // Health can recover between the send-gate check and the enqueue;
+        // flushing here closes that gap instead of waiting for the next event.
+        if self.healthOK {
+            self.flushOutboxIfNeeded()
+        }
+    }
+
+    /// Requeue path for a live text send that failed at the transport while
+    /// `healthOK` was stale-true. Reuses the send's runId as the command ID so
+    /// the optimistic bubble's "\(runId):user" key and the gateway's dedupe
+    /// identity are preserved even if the failed send actually landed.
+    /// Returns false when the queue refuses (caller keeps the failure path).
+    func requeueFailedLiveSend(
+        runId: String,
+        text: String,
+        thinking: String,
+        messageID: UUID,
+        session: SessionSnapshot) async -> Bool
+    {
+        guard let outbox else { return false }
+        let command = OpenClawChatOutboxCommand(
+            id: runId,
+            sessionKey: session.key,
+            text: text,
+            thinking: thinking,
+            createdAt: Date().timeIntervalSince1970,
+            status: .queued,
+            retryCount: 0,
+            lastError: nil)
+        guard await outbox.enqueueCommand(command) else { return false }
+        guard self.isCurrentSession(session) else { return true }
+        self.mapOutboxCommand(command, to: messageID)
+        self.errorText = nil
+        // Auto-retry immediately while health still reads healthy; either the
+        // transport recovered or the command lands visibly in 'failed'.
+        self.flushOutboxIfNeeded()
+        return true
+    }
+
+    // MARK: - Restore
+
+    /// Session switches drop the visible bubbles, so per-message outbox
+    /// state must go with them, and the FIFO send gate must assume a backlog
+    /// again until restore adopts the new session's durable rows. Without
+    /// this reset a send issued right after a switch could go live ahead of
+    /// that session's persisted queue.
+    func resetOutboxPresentationForSessionSwitch() {
+        self.hasRestoredOutboxMessages = false
+        self.outboxCommandIDsByMessageID.removeAll()
+        self.outboxMessageIDsByCommandID.removeAll()
+        self.outboxStatesByMessageID.removeAll()
+    }
+
+    /// Re-adopts or re-appends queued bubbles for the visible session after
+    /// cold open, session switches, and wholesale history replacement.
+    func restoreOutboxMessages(session: SessionSnapshot) {
+        guard let outbox else { return }
+        Task { [weak self] in
+            guard let self else { return }
+            await self.recoverInterruptedOutboxSendsIfNeeded()
+            let commands = await outbox.loadCommands()
+            guard self.isCurrentSession(session) else { return }
+            self.presentOutboxCommands(commands.filter { $0.sessionKey == session.key })
+            // The FIFO send gate assumes a backlog until this point.
+            self.hasRestoredOutboxMessages = true
+            // Relaunching while already healthy never sees an unhealthy ->
+            // healthy transition, so kick the flush here as well.
+            if self.healthOK, commands.contains(where: { $0.status == .queued }) {
+                self.flushOutboxIfNeeded()
+            }
+        }
+    }
+
+    /// Appends bubbles for commands in the current session, adopting rows
+    /// that already carry the command's user idempotency key (cache pre-paint
+    /// or an earlier restore), and refreshes their display states.
+    private func presentOutboxCommands(_ commands: [OpenClawChatOutboxCommand]) {
+        self.pruneOutboxMappings()
+        guard !commands.isEmpty else { return }
+        var next = self.messages
+        for command in commands.sorted(by: { $0.createdAt < $1.createdAt }) {
+            // User-deleted commands awaiting durable removal must not be
+            // re-presented or re-mapped by a concurrent restore/flush pass.
+            if self.deletedOutboxCommandIDs.contains(command.id) { continue }
+            let key = Self.outboxUserIdempotencyKey(command.id)
+            if let existing = next.first(where: { $0.idempotencyKey == key }) {
+                self.mapOutboxCommand(command, to: existing.id)
+                continue
+            }
+            let message = Self.outboxUserMessage(for: command)
+            next.append(message)
+            self.mapOutboxCommand(command, to: message.id)
+        }
+        self.replaceMessages(next)
+    }
+
+    private static func outboxUserMessage(for command: OpenClawChatOutboxCommand) -> OpenClawChatMessage {
+        OpenClawChatMessage(
+            role: "user",
+            content: [
+                OpenClawChatMessageContent(
+                    type: "text",
+                    text: command.text,
+                    mimeType: nil,
+                    fileName: nil,
+                    content: nil),
+            ],
+            // Message timestamps are milliseconds; outbox rows store seconds.
+            timestamp: command.createdAt * 1000,
+            idempotencyKey: self.outboxUserIdempotencyKey(command.id))
+    }
+
+    private func mapOutboxCommand(_ command: OpenClawChatOutboxCommand, to messageID: UUID) {
+        self.outboxCommandIDsByMessageID[messageID] = command.id
+        self.outboxMessageIDsByCommandID[command.id] = messageID
+        self.outboxStatesByMessageID[messageID] = Self.outboxDisplayState(for: command)
+    }
+
+    private func pruneOutboxMappings() {
+        let visibleMessageIDs = Set(self.messages.map(\.id))
+        let staleMessageIDs = self.outboxCommandIDsByMessageID.keys.filter {
+            !visibleMessageIDs.contains($0)
+        }
+        for messageID in staleMessageIDs {
+            if let commandID = self.outboxCommandIDsByMessageID.removeValue(forKey: messageID) {
+                self.outboxMessageIDsByCommandID.removeValue(forKey: commandID)
+            }
+            self.outboxStatesByMessageID.removeValue(forKey: messageID)
+        }
+    }
+
+    // MARK: - Health
+
+    func pollHealthIfNeeded(force: Bool, sessionSnapshot: SessionSnapshot? = nil) async {
+        if !force, let last = lastHealthPollAt, Date().timeIntervalSince(last) < 10 {
+            return
+        }
+        self.lastHealthPollAt = Date()
+        do {
+            let ok = try await self.transport.requestHealth(timeoutMs: 5000)
+            if let sessionSnapshot, !self.isCurrentSession(sessionSnapshot) { return }
+            self.applyTransportHealth(ok)
+        } catch {
+            if let sessionSnapshot, !self.isCurrentSession(sessionSnapshot) { return }
+            self.applyTransportHealth(false)
+        }
+    }
+
+    /// Single choke point for health updates so the offline outbox flushes
+    /// exactly on the unhealthy -> healthy transition.
+    func applyTransportHealth(_ ok: Bool) {
+        let wasHealthy = self.healthOK
+        self.healthOK = ok
+        if ok, !wasHealthy {
+            self.flushOutboxIfNeeded()
+        }
+    }
+
+    // MARK: - Flush
+
+    func flushOutboxIfNeeded() {
+        guard self.outbox != nil, self.healthOK else { return }
+        guard !self.isFlushingOutbox else {
+            // Coalesce triggers that land mid-pass (tap-to-retry, enqueue
+            // race) so their commands are not stranded until the next
+            // health transition.
+            self.isOutboxFlushRequestedWhileActive = true
+            return
+        }
+        self.isFlushingOutbox = true
+        Task { [weak self] in
+            await self?.performOutboxFlush()
+            guard let self else { return }
+            self.isFlushingOutbox = false
+            if self.isOutboxFlushRequestedWhileActive {
+                self.isOutboxFlushRequestedWhileActive = false
+                self.flushOutboxIfNeeded()
+            }
+        }
+    }
+
+    private func performOutboxFlush() async {
+        guard let outbox else { return }
+        await self.recoverInterruptedOutboxSendsIfNeeded()
+        var flushedCurrentSession = false
+        // One attempt per command per pass: if a delete/mark write ever fails
+        // (broken store), the pass ends instead of re-sending in a hot loop.
+        var attemptedCommandIDs = Set<String>()
+        while self.healthOK {
+            let commands = await outbox.loadCommands()
+            self.presentOutboxCommands(commands.filter { $0.sessionKey == self.sessionKey })
+            guard let next = commands.first(where: {
+                $0.status == .queued && !attemptedCommandIDs.contains($0.id)
+            }) else { break }
+            attemptedCommandIDs.insert(next.id)
+            // Delete-vs-flush race: the user may have removed this bubble
+            // after the pass loaded its snapshot. The tombstone catches the
+            // synchronous UI delete; the claiming UPDATE (zero rows changed
+            // = row already gone) catches the DB-side delete. Either way the
+            // command must not be sent. The tombstone is not consumed here:
+            // it lives until the delete task confirms the row is durably
+            // gone, so retries and later passes stay covered too.
+            if self.deletedOutboxCommandIDs.contains(next.id) {
+                self.clearOutboxState(forCommandID: next.id)
+                continue
+            }
+            // Same ordering contract as the live send path: a run must not
+            // start on a stale model while a sessions.patch(model) for its
+            // session is still in flight.
+            await self.waitForPendingModelPatches(in: next.sessionKey)
+            guard await outbox.markCommandSending(id: next.id) else {
+                self.clearOutboxState(forCommandID: next.id)
+                continue
+            }
+            // The claim awaited off the main actor: a user delete may have
+            // landed during that suspension (tombstone set, row deletion in
+            // flight). Recheck before the transport call; the delete task
+            // owns the durable removal and drops the tombstone once the row
+            // is gone, even though the claim re-marked it 'sending'.
+            if self.deletedOutboxCommandIDs.contains(next.id) {
+                self.clearOutboxState(forCommandID: next.id)
+                continue
+            }
+            self.setOutboxState(.sending, forCommandID: next.id)
+            do {
+                let response = try await self.transport.sendMessage(
+                    sessionKey: next.sessionKey,
+                    message: next.text,
+                    // Thinking level captured at enqueue time, never the
+                    // visible session's current setting.
+                    thinking: next.thinking,
+                    idempotencyKey: next.id,
+                    attachments: [])
+                if response.status == "error" || response.status == "timeout" {
+                    // Gateway rejected the run: this burns a retry attempt,
+                    // unlike transport-level failures handled in catch.
+                    let handled = await self.recordOutboxRejection(
+                        of: next,
+                        outbox: outbox,
+                        reason: "Run failed to start (\(response.status)).")
+                    if handled { continue } else { break }
+                }
+                // Ack: drop the durable row. The queued bubble stays and is
+                // adopted by the durable session.message/history row via the
+                // shared idempotency key, so no duplicate turn appears.
+                //
+                // Deliberately no pendingRuns adoption for background flushes:
+                // the reply still lands via handleChatEvent's external-run
+                // final branch (session-scoped, run-id independent),
+                // handleSessionMessageEvent, and the post-drain history
+                // refresh below. Run tracking (typing indicator, streaming,
+                // timeouts) stays owned by interactive performSend.
+                // Close the crash window between ack and the next canonical
+                // history write-through: splice the sent turn into the
+                // session's cached transcript before the outbox row goes
+                // away, so a cold offline reopen still shows it. Await the
+                // chained cache writes first so an in-flight older snapshot
+                // cannot land after the splice and drop the turn.
+                await self.pendingCacheWriteTask?.value
+                await self.spliceSentCommandIntoCachedTranscript(next)
+                // From here the outbox row is the turn's last durable copy;
+                // remember its key so a lagging history snapshot cannot
+                // evict the visible row before confirming it.
+                self.recentlySentOutboxUserKeys.insert(Self.outboxUserIdempotencyKey(next.id))
+                await outbox.deleteCommand(id: next.id)
+                self.clearOutboxState(forCommandID: next.id)
+                self.outboxTransportFailureStreak = 0
+                if next.sessionKey == self.sessionKey {
+                    flushedCurrentSession = true
+                }
+            } catch {
+                // Transport-level failure (unreachable, socket drop): a
+                // connectivity blip, not a gateway verdict on the command.
+                // Keep the row queued without burning a durable retry
+                // attempt; the in-memory streak paces repeated throws up the
+                // delay ladder instead of hammering the first rung forever.
+                outboxLogger.error("outbox flush send failed \(error.localizedDescription, privacy: .public)")
+                await outbox.markCommandQueued(
+                    id: next.id,
+                    retryCount: next.retryCount,
+                    lastError: error.localizedDescription)
+                self.setOutboxState(.queued, forCommandID: next.id)
+                self.outboxTransportFailureStreak += 1
+                if self.outboxTransportFailureStreak > self.outboxRetryDelaysMs.count {
+                    // Ladder exhausted: the transport is not actually usable
+                    // despite healthOK. Drop health so the reconnect/poll
+                    // machinery owns pacing; the next genuine healthy
+                    // transition re-flushes and the row stays queued.
+                    self.healthOK = false
+                    break
+                }
+                // Strict createdAt ordering: never skip ahead of a command
+                // that is still deliverable.
+                self.scheduleOutboxRetry(afterAttempts: self.outboxTransportFailureStreak)
+                break
+            }
+        }
+        // Tombstones are NOT cleared here: each lives until its delete task
+        // confirms the row is durably gone (process death in that window
+        // leaves both row and tombstone-protected bubble intact). The set
+        // stays bounded by in-flight user deletes.
+        if flushedCurrentSession {
+            await self.refreshHistoryAfterOutboxFlush()
+        }
+    }
+
+    /// Gateway rejections ("error"/"timeout" send acks) burn a retry attempt
+    /// and become terminally 'failed' after `maxOutboxSendAttempts`. Returns
+    /// true when the flush pass may continue with younger commands.
+    private func recordOutboxRejection(
+        of command: OpenClawChatOutboxCommand,
+        outbox: any OpenClawChatCommandOutbox,
+        reason: String) async -> Bool
+    {
+        outboxLogger.error("outbox flush send rejected \(reason, privacy: .public)")
+        let attempts = command.retryCount + 1
+        if attempts >= Self.maxOutboxSendAttempts {
+            await outbox.markCommandFailed(id: command.id, retryCount: attempts, lastError: reason)
+            self.setOutboxState(.failed(reason: reason), forCommandID: command.id)
+            // Terminal failure needs user action; let younger commands
+            // flush instead of blocking behind it forever.
+            return true
+        }
+        await outbox.markCommandQueued(id: command.id, retryCount: attempts, lastError: reason)
+        self.setOutboxState(.queued, forCommandID: command.id)
+        // Strict createdAt ordering: never skip ahead of a command that
+        // still has retries left.
+        self.scheduleOutboxRetry(afterAttempts: attempts)
+        return false
+    }
+
+    private func scheduleOutboxRetry(afterAttempts attempts: Int) {
+        let delays = self.outboxRetryDelaysMs
+        guard !delays.isEmpty else {
+            self.outboxRetryTask?.cancel()
+            self.outboxRetryTask = Task { [weak self] in
+                await Task.yield()
+                self?.flushOutboxIfNeeded()
+            }
+            return
+        }
+        let delayMs = delays[min(max(attempts - 1, 0), delays.count - 1)]
+        self.outboxRetryTask?.cancel()
+        self.outboxRetryTask = Task { [weak self] in
+            try? await Task.sleep(nanoseconds: delayMs * 1_000_000)
+            guard !Task.isCancelled else { return }
+            self?.flushOutboxIfNeeded()
+        }
+    }
+
+    /// Appends a flushed background-session turn to that session's cached
+    /// transcript so a cold offline reopen shows it before live history.
+    private func spliceSentCommandIntoCachedTranscript(_ command: OpenClawChatOutboxCommand) async {
+        guard let transcriptCache else { return }
+        let key = Self.outboxUserIdempotencyKey(command.id)
+        var cached = await transcriptCache.loadTranscript(sessionKey: command.sessionKey)
+        guard !cached.contains(where: { $0.idempotencyKey == key }) else { return }
+        cached.append(Self.outboxUserMessage(for: command))
+        await transcriptCache.storeTranscript(sessionKey: command.sessionKey, messages: cached)
+    }
+
+    private func recoverInterruptedOutboxSendsIfNeeded() async {
+        guard let outbox, !self.hasRecoveredInterruptedOutboxSends else { return }
+        // Burn the once-per-launch gate only when the store was reachable:
+        // with Complete file protection the database is legitimately
+        // unavailable while the device is locked, and skipping recovery then
+        // would leave crashed 'sending' rows stuck forever after unlock.
+        if await outbox.recoverInterruptedSends() {
+            self.hasRecoveredInterruptedOutboxSends = true
+        }
+    }
+
+    private func setOutboxState(_ state: OpenClawChatOutboxMessageState, forCommandID commandID: String) {
+        guard let messageID = self.outboxMessageIDsByCommandID[commandID] else { return }
+        self.outboxStatesByMessageID[messageID] = state
+    }
+
+    private func clearOutboxState(forCommandID commandID: String) {
+        guard let messageID = self.outboxMessageIDsByCommandID.removeValue(forKey: commandID) else { return }
+        self.outboxCommandIDsByMessageID.removeValue(forKey: messageID)
+        self.outboxStatesByMessageID.removeValue(forKey: messageID)
+    }
+
+    private static func outboxDisplayState(for command: OpenClawChatOutboxCommand)
+        -> OpenClawChatOutboxMessageState
+    {
+        switch command.status {
+        case .queued:
+            .queued
+        case .sending:
+            .sending
+        case .failed:
+            .failed(reason: command.lastError)
+        }
+    }
+
+    /// Matches the optimistic-send convention (`"<runId>:user"`), which is
+    /// also the key the gateway persists on the durable user row.
+    static func outboxUserIdempotencyKey(_ commandID: String) -> String {
+        "\(commandID):user"
+    }
+}

--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatViewModel+SessionKeys.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatViewModel+SessionKeys.swift
@@ -1,6 +1,49 @@
 import Foundation
 
 extension OpenClawChatViewModel {
+    public var sessionChoices: [OpenClawChatSessionEntry] {
+        let now = Date().timeIntervalSince1970 * 1000
+        let cutoff = now - (24 * 60 * 60 * 1000)
+        let sorted = self.sessions.sorted { ($0.updatedAt ?? 0) > ($1.updatedAt ?? 0) }
+        let mainSessionKey = self.resolvedMainSessionKey
+
+        var result: [OpenClawChatSessionEntry] = []
+        var included = Set<String>()
+
+        // Always show the resolved main session first, even if it hasn't been updated recently.
+        if let main = sorted.first(where: { $0.key == mainSessionKey }) {
+            result.append(main)
+            included.insert(main.key)
+        } else {
+            result.append(self.placeholderSession(key: mainSessionKey))
+            included.insert(mainSessionKey)
+        }
+
+        for entry in sorted {
+            guard !included.contains(entry.key) else { continue }
+            guard entry.key == self.sessionKey || !Self.isHiddenInternalSession(entry.key) else { continue }
+            guard (entry.updatedAt ?? 0) >= cutoff else { continue }
+            result.append(entry)
+            included.insert(entry.key)
+        }
+
+        if !included.contains(self.sessionKey) {
+            if let current = sorted.first(where: { $0.key == self.sessionKey }) {
+                result.append(current)
+            } else {
+                result.append(self.placeholderSession(key: self.sessionKey))
+            }
+        }
+
+        return result
+    }
+
+    private static func isHiddenInternalSession(_ key: String) -> Bool {
+        let trimmed = key.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return false }
+        return trimmed == "onboarding" || trimmed.hasSuffix(":onboarding")
+    }
+
     func matchesCurrentSessionKey(incoming: String, current: String) -> Bool {
         Self.matchesCurrentSessionKey(
             incoming: incoming,

--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatViewModel+Thinking.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatViewModel+Thinking.swift
@@ -1,0 +1,133 @@
+import Foundation
+
+// Thinking-level normalization and option resolution. Session entries,
+// session defaults, and free-form user aliases all feed the picker; this
+// extension owns collapsing them into the canonical option list.
+
+extension OpenClawChatViewModel {
+    func syncThinkingLevelOptions() {
+        let currentSession = self.sessions.first(where: { $0.key == self.sessionKey })
+        var options = self.resolvedThinkingLevelOptions(for: currentSession)
+        if let current = Self.normalizedThinkingLevel(thinkingLevel) {
+            options = Self.withCurrentThinkingOption(options, current: current)
+        }
+        self.thinkingLevelOptions = options
+    }
+
+    private func resolvedThinkingLevelOptions(
+        for currentSession: OpenClawChatSessionEntry?) -> [OpenClawChatThinkingLevelOption]
+    {
+        if let levels = Self.normalizedThinkingLevelOptions(currentSession?.thinkingLevels), !levels.isEmpty {
+            return levels
+        }
+
+        let defaultsMatch = currentSession.map {
+            Self.sessionModelMatchesDefaults($0, defaults: self.sessionDefaults)
+        } ?? true
+
+        if defaultsMatch,
+           let levels = Self.normalizedThinkingLevelOptions(sessionDefaults?.thinkingLevels),
+           !levels.isEmpty
+        {
+            return levels
+        }
+
+        if let options = Self.thinkingOptions(from: currentSession?.thinkingOptions), !options.isEmpty {
+            return options
+        }
+
+        if defaultsMatch,
+           let options = Self.thinkingOptions(from: sessionDefaults?.thinkingOptions),
+           !options.isEmpty
+        {
+            return options
+        }
+
+        return Self.baseThinkingLevelOptions
+    }
+
+    private static func sessionModelMatchesDefaults(
+        _ session: OpenClawChatSessionEntry,
+        defaults: OpenClawChatSessionsDefaults?) -> Bool
+    {
+        let providerMatches = session.modelProvider == nil || session.modelProvider == defaults?.modelProvider
+        let modelMatches = session.model == nil || session.model == defaults?.model
+        return providerMatches && modelMatches
+    }
+
+    private static func normalizedThinkingLevelOptions(
+        _ levels: [OpenClawChatThinkingLevelOption]?) -> [OpenClawChatThinkingLevelOption]?
+    {
+        guard let levels else { return nil }
+        return Self.dedupedThinkingOptions(
+            levels.compactMap { level in
+                guard let id = Self.normalizedThinkingLevel(level.id) else { return nil }
+                let label = level.label.trimmingCharacters(in: .whitespacesAndNewlines)
+                return OpenClawChatThinkingLevelOption(id: id, label: label.isEmpty ? id : label)
+            })
+    }
+
+    private static func thinkingOptions(from labels: [String]?) -> [OpenClawChatThinkingLevelOption]? {
+        guard let labels else { return nil }
+        return Self.dedupedThinkingOptions(
+            labels.compactMap { label in
+                guard let id = Self.normalizedThinkingLevel(label) else { return nil }
+                let trimmed = label.trimmingCharacters(in: .whitespacesAndNewlines)
+                return OpenClawChatThinkingLevelOption(id: id, label: trimmed.isEmpty ? id : trimmed)
+            })
+    }
+
+    static func withCurrentThinkingOption(
+        _ options: [OpenClawChatThinkingLevelOption],
+        current: String) -> [OpenClawChatThinkingLevelOption]
+    {
+        guard !options.contains(where: { $0.id == current }) else { return options }
+        return options + [OpenClawChatThinkingLevelOption(id: current, label: current)]
+    }
+
+    private static func dedupedThinkingOptions(
+        _ options: [OpenClawChatThinkingLevelOption]) -> [OpenClawChatThinkingLevelOption]
+    {
+        var result: [OpenClawChatThinkingLevelOption] = []
+        var seen = Set<String>()
+        for option in options {
+            guard !option.id.isEmpty, !seen.contains(option.id) else { continue }
+            seen.insert(option.id)
+            result.append(option)
+        }
+        return result
+    }
+
+    static func normalizedThinkingLevel(_ level: String?) -> String? {
+        guard let level else { return nil }
+        let trimmed = level.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        guard !trimmed.isEmpty else { return nil }
+        let collapsed = trimmed.replacingOccurrences(
+            of: "[\\s_-]+",
+            with: "",
+            options: .regularExpression)
+
+        switch collapsed {
+        case "adaptive", "auto":
+            return "adaptive"
+        case "max":
+            return "max"
+        case "xhigh", "extrahigh":
+            return "xhigh"
+        case "off", "none":
+            return "off"
+        case "on", "enable", "enabled":
+            return "low"
+        case "min", "minimal", "think":
+            return "minimal"
+        case "low", "thinkhard":
+            return "low"
+        case "mid", "med", "medium", "thinkharder", "harder":
+            return "medium"
+        case "high", "ultra", "ultrathink", "thinkhardest", "highest":
+            return "high"
+        default:
+            return trimmed
+        }
+    }
+}

--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatViewModel.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatViewModel.swift
@@ -16,7 +16,8 @@ public final class OpenClawChatViewModel {
 
     public var input: String = ""
     public private(set) var thinkingLevel: String
-    public private(set) var thinkingLevelOptions: [OpenClawChatThinkingLevelOption]
+    /// Setter is module-internal for the thinking-level extension only.
+    public internal(set) var thinkingLevelOptions: [OpenClawChatThinkingLevelOption]
     public private(set) var modelSelectionID: String = "__default__"
     public private(set) var modelChoices: [OpenClawChatModelChoice] = []
     public private(set) var slashCommands: [OpenClawChatCommandChoice] = []
@@ -37,7 +38,8 @@ public final class OpenClawChatViewModel {
     public private(set) var isAborting = false
     public var errorText: String?
     public var attachments: [OpenClawPendingAttachment] = []
-    public private(set) var healthOK: Bool = false
+    /// Setter is module-internal for the health/outbox extension only.
+    public internal(set) var healthOK: Bool = false
     public private(set) var pendingRunCount: Int = 0
 
     public private(set) var sessionKey: String
@@ -56,13 +58,60 @@ public final class OpenClawChatViewModel {
     /// one), a slow cache read must never paint stale rows over it.
     var hasAppliedLiveHistory = false
     var hasAppliedLiveSessions = false
-    private let transport: any OpenClawChatTransport
+    /// Internal for the outbox extension's flush path only.
+    let transport: any OpenClawChatTransport
     let haptics: OpenClawChatHaptics
     let transcriptCache: (any OpenClawChatTranscriptCache)?
+    let outbox: (any OpenClawChatCommandOutbox)?
+    /// Per-message outbox display state; rows without an entry are normal
+    /// transcript rows. Observable so bubbles update when flush progresses.
+    public internal(set) var outboxStatesByMessageID: [UUID: OpenClawChatOutboxMessageState] = [:]
+    @ObservationIgnored
+    var outboxCommandIDsByMessageID: [UUID: String] = [:]
+    @ObservationIgnored
+    var outboxMessageIDsByCommandID: [String: UUID] = [:]
+    @ObservationIgnored
+    var isFlushingOutbox = false
+    @ObservationIgnored
+    var isOutboxFlushRequestedWhileActive = false
+    @ObservationIgnored
+    var hasRecoveredInterruptedOutboxSends = false
+    /// Tombstones set synchronously on user delete so an active flush pass
+    /// never sends a command whose bubble the user just removed.
+    @ObservationIgnored
+    var deletedOutboxCommandIDs: Set<String> = []
+    /// Backoff between failed flush attempts; internal so tests can shorten it.
+    @ObservationIgnored
+    var outboxRetryDelaysMs: [UInt64] = [2000, 8000]
+    /// Consecutive transport-level flush failures. Paces retries up the
+    /// delay ladder without touching the durable per-command retryCount
+    /// (reserved for gateway verdicts); past the ladder, health drops and
+    /// the reconnect machinery owns pacing.
+    @ObservationIgnored
+    var outboxTransportFailureStreak = 0
+    /// User idempotency keys of turns just flushed from the outbox whose
+    /// durable outbox row is already deleted but which no history snapshot
+    /// has confirmed yet. Reconciliation must not evict them: the gateway
+    /// history can lag the ack, and eviction here would drop the turn from
+    /// both the screen and the write-through cache. Drained when a snapshot
+    /// contains the key; bounded because every flush drains or session
+    /// switches clear it.
+    @ObservationIgnored
+    var recentlySentOutboxUserKeys: Set<String> = []
+    /// False until restoreOutboxMessages has adopted durable rows for the
+    /// visible session. Until then the in-memory outbox state is blind to
+    /// rows persisted by an earlier process, so the FIFO send gate must
+    /// assume a backlog exists.
+    @ObservationIgnored
+    var hasRestoredOutboxMessages = false
+    @ObservationIgnored
+    nonisolated(unsafe) var outboxRetryTask: Task<Void, Never>?
+    /// A command becomes terminally 'failed' after this many send attempts.
+    nonisolated static let maxOutboxSendAttempts = 3
     @ObservationIgnored
     var pendingCacheWriteTask: Task<Void, Never>?
     private(set) var activeAgentId: String?
-    private var sessionDefaults: OpenClawChatSessionsDefaults?
+    var sessionDefaults: OpenClawChatSessionsDefaults?
     private let prefersExplicitThinkingLevel: Bool
     private let onSessionChanged: (@MainActor (String) -> Void)?
     private let onThinkingLevelChanged: (@MainActor @Sendable (String) -> Void)?
@@ -180,7 +229,7 @@ public final class OpenClawChatViewModel {
         }
     }
 
-    private var lastHealthPollAt: Date?
+    var lastHealthPollAt: Date?
 
     public init(
         sessionKey: String,
@@ -188,6 +237,7 @@ public final class OpenClawChatViewModel {
         activeAgentId: String? = nil,
         haptics: OpenClawChatHaptics = OpenClawChatHaptics(),
         transcriptCache: (any OpenClawChatTranscriptCache)? = nil,
+        outbox: (any OpenClawChatCommandOutbox)? = nil,
         initialThinkingLevel: String? = nil,
         onSessionChanged: (@MainActor (String) -> Void)? = nil,
         onThinkingLevelChanged: (@MainActor @Sendable (String) -> Void)? = nil,
@@ -199,6 +249,7 @@ public final class OpenClawChatViewModel {
         self.transcriptCache = transcriptCache
         let normalizedAgentId = activeAgentId?.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
         self.activeAgentId = normalizedAgentId?.isEmpty == false ? normalizedAgentId : nil
+        self.outbox = outbox
         let normalizedThinkingLevel = Self.normalizedThinkingLevel(initialThinkingLevel)
         let initialResolvedThinkingLevel = normalizedThinkingLevel ?? "off"
         self.thinkingLevel = initialResolvedThinkingLevel
@@ -225,6 +276,7 @@ public final class OpenClawChatViewModel {
     deinit {
         self.eventTask?.cancel()
         self.bootstrapTask?.cancel()
+        self.outboxRetryTask?.cancel()
         for (_, task) in self.pendingRunTimeoutTasks {
             task.cancel()
         }
@@ -327,53 +379,10 @@ public final class OpenClawChatViewModel {
         self.errorText = nil
     }
 
-    public var sessionChoices: [OpenClawChatSessionEntry] {
-        let now = Date().timeIntervalSince1970 * 1000
-        let cutoff = now - (24 * 60 * 60 * 1000)
-        let sorted = self.sessions.sorted { ($0.updatedAt ?? 0) > ($1.updatedAt ?? 0) }
-        let mainSessionKey = self.resolvedMainSessionKey
-
-        var result: [OpenClawChatSessionEntry] = []
-        var included = Set<String>()
-
-        // Always show the resolved main session first, even if it hasn't been updated recently.
-        if let main = sorted.first(where: { $0.key == mainSessionKey }) {
-            result.append(main)
-            included.insert(main.key)
-        } else {
-            result.append(self.placeholderSession(key: mainSessionKey))
-            included.insert(mainSessionKey)
-        }
-
-        for entry in sorted {
-            guard !included.contains(entry.key) else { continue }
-            guard entry.key == self.sessionKey || !Self.isHiddenInternalSession(entry.key) else { continue }
-            guard (entry.updatedAt ?? 0) >= cutoff else { continue }
-            result.append(entry)
-            included.insert(entry.key)
-        }
-
-        if !included.contains(self.sessionKey) {
-            if let current = sorted.first(where: { $0.key == self.sessionKey }) {
-                result.append(current)
-            } else {
-                result.append(self.placeholderSession(key: self.sessionKey))
-            }
-        }
-
-        return result
-    }
-
     var resolvedMainSessionKey: String {
         let trimmed = self.sessionDefaults?.mainSessionKey?
             .trimmingCharacters(in: .whitespacesAndNewlines)
         return (trimmed?.isEmpty == false ? trimmed : nil) ?? "main"
-    }
-
-    private static func isHiddenInternalSession(_ key: String) -> Bool {
-        let trimmed = key.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard !trimmed.isEmpty else { return false }
-        return trimmed == "onboarding" || trimmed.hasSuffix(":onboarding")
     }
 
     public var showsModelPicker: Bool {
@@ -387,7 +396,7 @@ public final class OpenClawChatViewModel {
         return "Default: \(self.modelLabel(for: defaultModelID))"
     }
 
-    private static let baseThinkingLevelOptions: [OpenClawChatThinkingLevelOption] = [
+    static let baseThinkingLevelOptions: [OpenClawChatThinkingLevelOption] = [
         OpenClawChatThinkingLevelOption(id: "off", label: "off"),
         OpenClawChatThinkingLevelOption(id: "minimal", label: "minimal"),
         OpenClawChatThinkingLevelOption(id: "low", label: "low"),
@@ -526,6 +535,19 @@ public final class OpenClawChatViewModel {
         } else {
             Self.reconcileMessageIDs(previous: self.messages, incoming: incoming)
         }
+        // Ack-to-history window: turns just flushed from the outbox may not
+        // be in this snapshot yet. Their durable rows are gone, so keep the
+        // visible rows (appended: they are the newest turns) until a
+        // snapshot carries their idempotency key.
+        if !self.recentlySentOutboxUserKeys.isEmpty {
+            self.recentlySentOutboxUserKeys.subtract(incoming.compactMap(\.idempotencyKey))
+            let nextKeys = Set(nextMessages.compactMap(\.idempotencyKey))
+            let preserved = self.messages.filter { message in
+                guard let key = message.idempotencyKey else { return false }
+                return self.recentlySentOutboxUserKeys.contains(key) && !nextKeys.contains(key)
+            }
+            nextMessages.append(contentsOf: preserved)
+        }
         let reconciledMessageIDs = Set(nextMessages.map(\.id))
         nextMessages.append(contentsOf: self.messages.filter { message in
             retainedMessageIDs.contains(message.id) && !reconciledMessageIDs.contains(message.id)
@@ -564,8 +586,15 @@ public final class OpenClawChatViewModel {
         // An empty post-send refresh is incomplete by contract: reconciliation
         // preserves the visible transcript, so preserve its last canonical cache too.
         if !preservingOptimisticLocalMessages || !incoming.isEmpty {
-            self.persistTranscriptToCache(sessionKey: request.session.key, messages: incoming)
+            // Persist the RECONCILED transcript, not raw incoming: a stale
+            // snapshot missing a just-acked turn must not overwrite the
+            // cache after the durable outbox row is already gone — the cache
+            // mirrors what the user sees.
+            self.persistTranscriptToCache(sessionKey: request.session.key, messages: nextMessages)
         }
+        // Wholesale history replacement drops local-only queued bubbles;
+        // re-adopt or re-append them from the durable outbox.
+        self.restoreOutboxMessages(session: request.session)
         return true
     }
 
@@ -657,6 +686,7 @@ public final class OpenClawChatViewModel {
             id: bootstrapGeneration,
             historyRequest: historyRequest)
         self.paintFromCacheIfNeeded(session: context.session)
+        self.restoreOutboxMessages(session: context.session)
         self.bootstrapTask = Task { [weak self] in
             guard let self else { return }
             await self.bootstrap(context: context)
@@ -988,14 +1018,48 @@ public final class OpenClawChatViewModel {
         let sessionSnapshot = self.currentSessionSnapshot()
         let sessionKey = sessionSnapshot.key
 
+        // Raised before the health poll so the entry guard covers the whole
+        // async path: a second submit during `pollHealthIfNeeded` would
+        // otherwise re-capture the same draft and enqueue a duplicate
+        // outbox row.
+        self.isSending = true
+        defer { self.isSending = false }
+
         if !self.healthOK {
             await self.pollHealthIfNeeded(force: true, sessionSnapshot: sessionSnapshot)
             guard self.isCurrentSession(sessionSnapshot) else { return }
+            // Offline capture: queue text-only sends durably instead of
+            // failing. Attachments stay on the live path (text only in v1).
+            if !self.healthOK, self.outbox != nil, self.attachments.isEmpty {
+                self.logDiagnostic(
+                    "chat.ui send queued offline sessionKey=\(sessionKey) inputLen=\(trimmed.count)")
+                await self.enqueueOutboxCommand(text: trimmed, session: sessionSnapshot)
+                return
+            }
         }
 
-        self.isSending = true
+        // FIFO across the reconnect boundary: while this session still has
+        // queued/sending outbox rows — or restore has not yet adopted rows
+        // persisted by an earlier process, so we must assume a backlog — a
+        // live send would race ahead of them. Route it through the outbox so
+        // the queue stays the single ordering authority; it flushes
+        // immediately while healthy, so the turn still sends right away.
+        // Failed rows are parked user decisions and do not hold new sends
+        // hostage. Attachment sends stay live (online-only in v1) and are
+        // documented as outside the ordering guarantee. Deliberately
+        // session-scoped: other sessions' queued rows are separate
+        // conversations with no ordering contract against this send.
+        if self.outbox != nil, self.attachments.isEmpty,
+           !self.hasRestoredOutboxMessages
+           || self.outboxStatesByMessageID.values.contains(where: { !$0.isFailed })
+        {
+            self.logDiagnostic(
+                "chat.ui send routed behind outbox sessionKey=\(sessionKey) inputLen=\(trimmed.count)")
+            await self.enqueueOutboxCommand(text: trimmed, session: sessionSnapshot)
+            return
+        }
+
         self.errorText = nil
-        defer { self.isSending = false }
         let runId = UUID().uuidString
         let messageText = trimmed.isEmpty && !self.attachments.isEmpty ? "See attached." : trimmed
         let thinkingLevel = self.thinkingLevel
@@ -1133,6 +1197,32 @@ public final class OpenClawChatViewModel {
             }
         } catch {
             guard self.isCurrentSession(sessionSnapshot) else { return }
+            // Stale-healthy disconnects surface here instead of at the send
+            // gate. Requeue text-only sends durably (same runId = same
+            // idempotency identity, safe even if the send actually landed)
+            // and keep the optimistic bubble as the queued row.
+            if encodedAttachments.isEmpty {
+                self.runMessageScopesByRunID.removeValue(forKey: runId)
+                self.clearPendingRun(runId)
+                let requeued = await self.requeueFailedLiveSend(
+                    runId: runId,
+                    text: messageText,
+                    thinking: thinkingLevel,
+                    messageID: userMessageID,
+                    session: sessionSnapshot)
+                if requeued {
+                    self.logDiagnostic(
+                        "chat.ui send requeued offline sessionKey=\(sessionKey) "
+                            + "localRunId=\(runId) error=\(error.localizedDescription)")
+                    return
+                }
+                guard self.isCurrentSession(sessionSnapshot) else { return }
+                // Refused requeue (queue full / broken store): restore the
+                // draft so the text is not lost with the failed bubble.
+                if self.input.isEmpty {
+                    self.input = messageText
+                }
+            }
             self.removePendingLocalUserEcho(for: runId)
             self.runMessageScopesByRunID.removeValue(forKey: runId)
             self.errorText = error.localizedDescription
@@ -1237,6 +1327,8 @@ public final class OpenClawChatViewModel {
         self.pendingLocalUserEchoMessageIDsByRunID.removeAll()
         self.runMessageScopesByRunID.removeAll()
         self.provisionalFinalMessagesByID.removeAll()
+        self.recentlySentOutboxUserKeys.removeAll()
+        self.resetOutboxPresentationForSessionSwitch()
         self.sessionId = nil
         self.pendingToolCallsById = [:]
         self.updateStreamingAssistantText(nil)
@@ -1400,107 +1492,16 @@ public final class OpenClawChatViewModel {
         self.inFlightModelPatchCountsBySession[sessionKey] = remaining
     }
 
-    private func waitForPendingModelPatches(in sessionKey: String) async {
+    /// Internal for the outbox flush, which must honor the same ordering
+    /// behind in-flight model patches as the live send path.
+    func waitForPendingModelPatches(in sessionKey: String) async {
         guard (self.inFlightModelPatchCountsBySession[sessionKey] ?? 0) > 0 else { return }
         await withCheckedContinuation { continuation in
             self.modelPatchWaitersBySession[sessionKey, default: []].append(continuation)
         }
     }
 
-    private func syncThinkingLevelOptions() {
-        let currentSession = self.sessions.first(where: { $0.key == self.sessionKey })
-        var options = self.resolvedThinkingLevelOptions(for: currentSession)
-        if let current = Self.normalizedThinkingLevel(thinkingLevel) {
-            options = Self.withCurrentThinkingOption(options, current: current)
-        }
-        self.thinkingLevelOptions = options
-    }
-
-    private func resolvedThinkingLevelOptions(
-        for currentSession: OpenClawChatSessionEntry?) -> [OpenClawChatThinkingLevelOption]
-    {
-        if let levels = Self.normalizedThinkingLevelOptions(currentSession?.thinkingLevels), !levels.isEmpty {
-            return levels
-        }
-
-        let defaultsMatch = currentSession.map {
-            Self.sessionModelMatchesDefaults($0, defaults: self.sessionDefaults)
-        } ?? true
-
-        if defaultsMatch,
-           let levels = Self.normalizedThinkingLevelOptions(sessionDefaults?.thinkingLevels),
-           !levels.isEmpty
-        {
-            return levels
-        }
-
-        if let options = Self.thinkingOptions(from: currentSession?.thinkingOptions), !options.isEmpty {
-            return options
-        }
-
-        if defaultsMatch,
-           let options = Self.thinkingOptions(from: sessionDefaults?.thinkingOptions),
-           !options.isEmpty
-        {
-            return options
-        }
-
-        return Self.baseThinkingLevelOptions
-    }
-
-    private static func sessionModelMatchesDefaults(
-        _ session: OpenClawChatSessionEntry,
-        defaults: OpenClawChatSessionsDefaults?) -> Bool
-    {
-        let providerMatches = session.modelProvider == nil || session.modelProvider == defaults?.modelProvider
-        let modelMatches = session.model == nil || session.model == defaults?.model
-        return providerMatches && modelMatches
-    }
-
-    private static func normalizedThinkingLevelOptions(
-        _ levels: [OpenClawChatThinkingLevelOption]?) -> [OpenClawChatThinkingLevelOption]?
-    {
-        guard let levels else { return nil }
-        return Self.dedupedThinkingOptions(
-            levels.compactMap { level in
-                guard let id = Self.normalizedThinkingLevel(level.id) else { return nil }
-                let label = level.label.trimmingCharacters(in: .whitespacesAndNewlines)
-                return OpenClawChatThinkingLevelOption(id: id, label: label.isEmpty ? id : label)
-            })
-    }
-
-    private static func thinkingOptions(from labels: [String]?) -> [OpenClawChatThinkingLevelOption]? {
-        guard let labels else { return nil }
-        return Self.dedupedThinkingOptions(
-            labels.compactMap { label in
-                guard let id = Self.normalizedThinkingLevel(label) else { return nil }
-                let trimmed = label.trimmingCharacters(in: .whitespacesAndNewlines)
-                return OpenClawChatThinkingLevelOption(id: id, label: trimmed.isEmpty ? id : trimmed)
-            })
-    }
-
-    private static func withCurrentThinkingOption(
-        _ options: [OpenClawChatThinkingLevelOption],
-        current: String) -> [OpenClawChatThinkingLevelOption]
-    {
-        guard !options.contains(where: { $0.id == current }) else { return options }
-        return options + [OpenClawChatThinkingLevelOption(id: current, label: current)]
-    }
-
-    private static func dedupedThinkingOptions(
-        _ options: [OpenClawChatThinkingLevelOption]) -> [OpenClawChatThinkingLevelOption]
-    {
-        var result: [OpenClawChatThinkingLevelOption] = []
-        var seen = Set<String>()
-        for option in options {
-            guard !option.id.isEmpty, !seen.contains(option.id) else { continue }
-            seen.insert(option.id)
-            result.append(option)
-        }
-        return result
-    }
-
-    private func placeholderSession(key: String) -> OpenClawChatSessionEntry {
+    func placeholderSession(key: String) -> OpenClawChatSessionEntry {
         OpenClawChatSessionEntry(
             key: key,
             kind: nil,
@@ -1728,7 +1729,7 @@ public final class OpenClawChatViewModel {
     private func handleTransportEvent(_ evt: OpenClawChatTransportEvent) {
         switch evt {
         case let .health(ok):
-            self.healthOK = ok
+            self.applyTransportHealth(ok)
         case .tick:
             let context = self.currentSessionSnapshot()
             Task { await self.pollHealthIfNeeded(force: false, sessionSnapshot: context) }
@@ -2293,6 +2294,12 @@ public final class OpenClawChatViewModel {
         }.first
     }
 
+    /// Narrow seam for the outbox extension: pull durable history after a
+    /// flush so acked commands reconcile with their queued bubbles.
+    func refreshHistoryAfterOutboxFlush() async {
+        await self.refreshHistoryAfterRun()
+    }
+
     @discardableResult
     private func refreshHistoryAfterRun(historyRequest request: HistoryRequest? = nil) async
         -> (applied: Bool, runSnapshotApplied: Bool, supportsInFlightRunState: Bool, hasInFlightRun: Bool)
@@ -2395,51 +2402,4 @@ public final class OpenClawChatViewModel {
         }
     }
 
-    private func pollHealthIfNeeded(force: Bool, sessionSnapshot: SessionSnapshot? = nil) async {
-        if !force, let last = lastHealthPollAt, Date().timeIntervalSince(last) < 10 {
-            return
-        }
-        self.lastHealthPollAt = Date()
-        do {
-            let ok = try await transport.requestHealth(timeoutMs: 5000)
-            if let sessionSnapshot, !self.isCurrentSession(sessionSnapshot) { return }
-            self.healthOK = ok
-        } catch {
-            if let sessionSnapshot, !self.isCurrentSession(sessionSnapshot) { return }
-            self.healthOK = false
-        }
-    }
-
-    private static func normalizedThinkingLevel(_ level: String?) -> String? {
-        guard let level else { return nil }
-        let trimmed = level.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
-        guard !trimmed.isEmpty else { return nil }
-        let collapsed = trimmed.replacingOccurrences(
-            of: "[\\s_-]+",
-            with: "",
-            options: .regularExpression)
-
-        switch collapsed {
-        case "adaptive", "auto":
-            return "adaptive"
-        case "max":
-            return "max"
-        case "xhigh", "extrahigh":
-            return "xhigh"
-        case "off", "none":
-            return "off"
-        case "on", "enable", "enabled":
-            return "low"
-        case "min", "minimal", "think":
-            return "minimal"
-        case "low", "thinkhard":
-            return "low"
-        case "mid", "med", "medium", "thinkharder", "harder":
-            return "medium"
-        case "high", "ultra", "ultrathink", "thinkhardest", "highest":
-            return "high"
-        default:
-            return trimmed
-        }
-    }
 }

--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatViewModel.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatViewModel.swift
@@ -2401,5 +2401,4 @@ public final class OpenClawChatViewModel {
             }
         }
     }
-
 }

--- a/apps/shared/OpenClawKit/Tests/OpenClawKitTests/ChatTranscriptCacheStoreTests.swift
+++ b/apps/shared/OpenClawKit/Tests/OpenClawKitTests/ChatTranscriptCacheStoreTests.swift
@@ -58,6 +58,24 @@ private func messageTexts(_ messages: [OpenClawChatMessage]) -> [String] {
     messages.map { $0.content.compactMap(\.text).joined() }
 }
 
+private func outboxCommand(
+    id: String = UUID().uuidString,
+    sessionKey: String = "main",
+    text: String,
+    thinking: String = "off",
+    createdAt: Double = Date().timeIntervalSince1970) -> OpenClawChatOutboxCommand
+{
+    OpenClawChatOutboxCommand(
+        id: id,
+        sessionKey: sessionKey,
+        text: text,
+        thinking: thinking,
+        createdAt: createdAt,
+        status: .queued,
+        retryCount: 0,
+        lastError: nil)
+}
+
 struct ChatTranscriptCacheStoreTests {
     @Test func `transcript and sessions round trip`() async throws {
         let url = try makeDatabaseURL()
@@ -319,5 +337,144 @@ struct ChatTranscriptCacheStoreTests {
         #expect(await reader.loadTranscript(sessionKey: "main").isEmpty)
         // The bad row was deleted, not just skipped.
         #expect(await reader.loadTranscript(sessionKey: "main").isEmpty)
+    }
+}
+
+struct ChatCommandOutboxStoreTests {
+    @Test func `outbox commands round trip in createdAt order across store instances`() async throws {
+        let url = try makeDatabaseURL()
+        defer { try? FileManager.default.removeItem(at: url.deletingLastPathComponent()) }
+        // Recent timestamps: rows older than the staleness gate would expire.
+        let now = Date().timeIntervalSince1970
+        do {
+            let store = OpenClawChatSQLiteTranscriptCache(databaseURL: url, gatewayID: "gw-a")
+            #expect(await store.enqueueCommand(
+                outboxCommand(id: "c-2", text: "second", thinking: "high", createdAt: now - 10)))
+            #expect(await store.enqueueCommand(
+                outboxCommand(id: "c-1", text: "first", thinking: "off", createdAt: now - 20)))
+        }
+
+        // New instance = simulated app relaunch: rows are durable.
+        let reopened = OpenClawChatSQLiteTranscriptCache(databaseURL: url, gatewayID: "gw-a")
+        let loaded = await reopened.loadCommands()
+        #expect(loaded.map(\.id) == ["c-1", "c-2"])
+        #expect(loaded.map(\.text) == ["first", "second"])
+        #expect(loaded.map(\.thinking) == ["off", "high"])
+        #expect(loaded.map(\.status) == [.queued, .queued])
+        #expect(loaded.map(\.retryCount) == [0, 0])
+        #expect(loaded.map(\.lastError) == [nil, nil])
+        #expect(loaded.map(\.sessionKey) == ["main", "main"])
+    }
+
+    @Test func `claiming a deleted command returns false`() async throws {
+        let url = try makeDatabaseURL()
+        defer { try? FileManager.default.removeItem(at: url.deletingLastPathComponent()) }
+        let store = OpenClawChatSQLiteTranscriptCache(databaseURL: url, gatewayID: "gw-a")
+        #expect(await store.enqueueCommand(outboxCommand(id: "c-1", text: "kept")))
+        #expect(await store.markCommandSending(id: "c-1"))
+
+        // Deleted (or never-existing) rows must refuse the claim so a flush
+        // pass working from a stale snapshot cannot send them.
+        await store.deleteCommand(id: "c-1")
+        #expect(await store.markCommandSending(id: "c-1") == false)
+        #expect(await store.markCommandSending(id: "never-existed") == false)
+    }
+
+    @Test func `interrupted sending rows revert to queued on recovery`() async throws {
+        let url = try makeDatabaseURL()
+        defer { try? FileManager.default.removeItem(at: url.deletingLastPathComponent()) }
+        do {
+            let store = OpenClawChatSQLiteTranscriptCache(databaseURL: url, gatewayID: "gw-a")
+            #expect(await store.enqueueCommand(outboxCommand(id: "c-1", text: "in flight")))
+            await store.markCommandSending(id: "c-1")
+            #expect(await store.loadCommands().map(\.status) == [.sending])
+        }
+
+        // Simulated crash mid-send: a fresh process recovers the row to
+        // queued; the idempotency key makes the re-send safe.
+        let reopened = OpenClawChatSQLiteTranscriptCache(databaseURL: url, gatewayID: "gw-a")
+        #expect(await reopened.recoverInterruptedSends())
+        #expect(await reopened.loadCommands().map(\.status) == [.queued])
+
+        // An unreachable store must report failure so callers do not burn
+        // their once-per-launch recovery gate while the DB is locked.
+        await reopened.retire()
+        #expect(await !reopened.recoverInterruptedSends())
+    }
+
+    @Test func `queued commands expire to failed at the staleness boundary`() async throws {
+        let url = try makeDatabaseURL()
+        defer { try? FileManager.default.removeItem(at: url.deletingLastPathComponent()) }
+        let store = OpenClawChatSQLiteTranscriptCache(databaseURL: url, gatewayID: "gw-a")
+        let now = Date().timeIntervalSince1970
+        let maxAge = OpenClawChatSQLiteTranscriptCache.outboxCommandMaxAge
+        #expect(await store.enqueueCommand(
+            outboxCommand(id: "c-stale", text: "stale", createdAt: now - maxAge - 60)))
+        #expect(await store.enqueueCommand(
+            outboxCommand(id: "c-fresh", text: "fresh", createdAt: now - maxAge + 60)))
+
+        let loaded = await store.loadCommands()
+        let stale = try #require(loaded.first { $0.id == "c-stale" })
+        let fresh = try #require(loaded.first { $0.id == "c-fresh" })
+        #expect(stale.status == .failed)
+        #expect(stale.lastError == OpenClawChatSQLiteTranscriptCache.outboxExpiredError)
+        #expect(fresh.status == .queued)
+        #expect(fresh.lastError == nil)
+    }
+
+    @Test func `enqueue refuses beyond the queue bound`() async throws {
+        let url = try makeDatabaseURL()
+        defer { try? FileManager.default.removeItem(at: url.deletingLastPathComponent()) }
+        let store = OpenClawChatSQLiteTranscriptCache(databaseURL: url, gatewayID: "gw-a")
+        let bound = OpenClawChatSQLiteTranscriptCache.maxQueuedCommands
+
+        for index in 0..<bound {
+            #expect(await store.enqueueCommand(outboxCommand(id: "c-\(index)", text: "m\(index)")))
+        }
+        #expect(await !store.enqueueCommand(outboxCommand(id: "c-overflow", text: "one too many")))
+        #expect(await store.loadCommands().count == bound)
+
+        // Deleting a row frees capacity again.
+        await store.deleteCommand(id: "c-0")
+        #expect(await store.enqueueCommand(outboxCommand(id: "c-after-delete", text: "fits now")))
+    }
+
+    @Test func `outbox rows are scoped per gateway identity`() async throws {
+        let url = try makeDatabaseURL()
+        defer { try? FileManager.default.removeItem(at: url.deletingLastPathComponent()) }
+        let storeA = OpenClawChatSQLiteTranscriptCache(databaseURL: url, gatewayID: "gw-a")
+        let storeB = OpenClawChatSQLiteTranscriptCache(databaseURL: url, gatewayID: "gw-b")
+
+        #expect(await storeA.enqueueCommand(outboxCommand(id: "c-a", text: "for gateway A")))
+        #expect(await storeB.loadCommands().isEmpty)
+
+        // Cross-gateway mutations must not leak either.
+        await storeB.markCommandFailed(id: "c-a", retryCount: 3, lastError: "boom")
+        await storeB.deleteCommand(id: "c-a")
+        let survivors = await storeA.loadCommands()
+        #expect(survivors.map(\.id) == ["c-a"])
+        #expect(survivors.map(\.status) == [.queued])
+    }
+
+    @Test func `retry and failure marks persist retry count and last error`() async throws {
+        let url = try makeDatabaseURL()
+        defer { try? FileManager.default.removeItem(at: url.deletingLastPathComponent()) }
+        let store = OpenClawChatSQLiteTranscriptCache(databaseURL: url, gatewayID: "gw-a")
+        #expect(await store.enqueueCommand(outboxCommand(id: "c-1", text: "retry me")))
+
+        await store.markCommandQueued(id: "c-1", retryCount: 2, lastError: "socket closed")
+        var loaded = await store.loadCommands()
+        #expect(loaded.map(\.status) == [.queued])
+        #expect(loaded.map(\.retryCount) == [2])
+        #expect(loaded.map(\.lastError) == ["socket closed"])
+
+        await store.markCommandFailed(id: "c-1", retryCount: 3, lastError: "gave up")
+        loaded = await store.loadCommands()
+        #expect(loaded.map(\.status) == [.failed])
+        #expect(loaded.map(\.retryCount) == [3])
+        #expect(loaded.map(\.lastError) == ["gave up"])
+
+        await store.deleteCommand(id: "c-1")
+        #expect(await store.loadCommands().isEmpty)
     }
 }

--- a/apps/shared/OpenClawKit/Tests/OpenClawKitTests/ChatViewModelOutboxTests.swift
+++ b/apps/shared/OpenClawKit/Tests/OpenClawKitTests/ChatViewModelOutboxTests.swift
@@ -1,0 +1,1089 @@
+import Foundation
+import OpenClawKit
+import Testing
+@testable import OpenClawChatUI
+
+private func makeOutboxDatabaseURL() throws -> URL {
+    let dir = FileManager.default.temporaryDirectory
+        .appendingPathComponent("chat-outbox-tests-\(UUID().uuidString)", isDirectory: true)
+    try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+    return dir.appendingPathComponent("chat-cache.sqlite", isDirectory: false)
+}
+
+private func userTexts(_ vm: OpenClawChatViewModel) async -> [String] {
+    await MainActor.run {
+        vm.messages
+            .filter { $0.role == "user" }
+            .map { $0.content.compactMap(\.text).joined() }
+    }
+}
+
+private struct OutboxSendError: Error, LocalizedError {
+    var errorDescription: String? { "transport unreachable" }
+}
+
+private actor OutboxTransportState {
+    var healthy: Bool
+    var sendFails: Bool
+    var sendRejects = false
+    var historyFails = false
+    var heldSendGate: DeleteGate?
+    var staleHistoryRows: [AnyCodable]?
+
+    func setHeldSendGate(_ gate: DeleteGate?) {
+        self.heldSendGate = gate
+    }
+
+    func setStaleHistoryRows(_ rows: [AnyCodable]?) {
+        self.staleHistoryRows = rows
+    }
+    var sentIdempotencyKeys: [String] = []
+    var sentMessages: [String] = []
+    var sentSessionKeys: [String] = []
+    var sentThinkingLevels: [String] = []
+
+    init(healthy: Bool, sendFails: Bool) {
+        self.healthy = healthy
+        self.sendFails = sendFails
+    }
+
+    func setHistoryFails(_ fails: Bool) {
+        self.historyFails = fails
+    }
+
+    func setHealthy(_ healthy: Bool) {
+        self.healthy = healthy
+    }
+
+    func setSendFails(_ fails: Bool) {
+        self.sendFails = fails
+    }
+
+    func setSendRejects(_ rejects: Bool) {
+        self.sendRejects = rejects
+    }
+
+    func recordSend(sessionKey: String, message: String, idempotencyKey: String, thinking: String) {
+        self.sentSessionKeys.append(sessionKey)
+        self.sentMessages.append(message)
+        self.sentIdempotencyKeys.append(idempotencyKey)
+        self.sentThinkingLevels.append(thinking)
+    }
+}
+
+/// Scripted transport for offline-outbox flows: health is switchable, sends
+/// can be forced to fail, and history synthesizes the durable user rows for
+/// every accepted send (what the gateway would persist).
+private final class OutboxTestTransport: @unchecked Sendable, OpenClawChatTransport {
+    let state: OutboxTransportState
+    private let stream: AsyncStream<OpenClawChatTransportEvent>
+    private let continuation: AsyncStream<OpenClawChatTransportEvent>.Continuation
+
+    init(healthy: Bool, sendFails: Bool = false) {
+        self.state = OutboxTransportState(healthy: healthy, sendFails: sendFails)
+        var cont: AsyncStream<OpenClawChatTransportEvent>.Continuation!
+        self.stream = AsyncStream { c in cont = c }
+        self.continuation = cont
+    }
+
+    func goOnline() async {
+        await self.state.setHealthy(true)
+        self.continuation.yield(.health(ok: true))
+    }
+
+    func emit(_ event: OpenClawChatTransportEvent) {
+        self.continuation.yield(event)
+    }
+
+    func requestHistory(sessionKey: String) async throws -> OpenClawChatHistoryPayload {
+        guard await self.state.healthy, await !self.state.historyFails else { throw OutboxSendError() }
+        if let stale = await self.state.staleHistoryRows {
+            // Gateway lag: the snapshot predates the just-acked send.
+            return OpenClawChatHistoryPayload(
+                sessionKey: sessionKey,
+                sessionId: "sess-live",
+                messages: stale,
+                thinkingLevel: "off")
+        }
+        let keys = await self.state.sentIdempotencyKeys
+        let texts = await self.state.sentMessages
+        let durableUserRows = zip(keys.indices, keys).map { index, key in
+            AnyCodable([
+                "role": "user",
+                "content": [["type": "text", "text": index < texts.count ? texts[index] : ""]],
+                "timestamp": Double(1000 + index),
+                "__openclaw": ["idempotencyKey": "\(key):user"],
+            ] as [String: Any])
+        }
+        return OpenClawChatHistoryPayload(
+            sessionKey: sessionKey,
+            sessionId: "sess-live",
+            messages: durableUserRows,
+            thinkingLevel: "off")
+    }
+
+    func sendMessage(
+        sessionKey: String,
+        message: String,
+        thinking: String,
+        idempotencyKey: String,
+        attachments _: [OpenClawChatAttachmentPayload]) async throws -> OpenClawChatSendResponse
+    {
+        if let gate = await self.state.heldSendGate {
+            // One-shot: only the first send is held so tests can pin the
+            // window where the flush is mid-drain.
+            await self.state.setHeldSendGate(nil)
+            await gate.wait()
+        }
+        if await self.state.sendFails {
+            throw OutboxSendError()
+        }
+        if await self.state.sendRejects {
+            // Gateway responded but refused to start the run.
+            return OpenClawChatSendResponse(runId: idempotencyKey, status: "error")
+        }
+        await self.state.recordSend(
+            sessionKey: sessionKey,
+            message: message,
+            idempotencyKey: idempotencyKey,
+            thinking: thinking)
+        return OpenClawChatSendResponse(runId: idempotencyKey, status: "accepted")
+    }
+
+    /// Gated model patch: `setSessionModel` blocks until `releaseModelPatch`
+    /// so tests can hold a patch in flight while the outbox flushes.
+    private let modelPatchGate = AsyncStream<Void>.makeStream()
+
+    func releaseModelPatch() {
+        self.modelPatchGate.continuation.yield(())
+    }
+
+    func setSessionModel(sessionKey _: String, model _: String?) async throws {
+        var iterator = self.modelPatchGate.stream.makeAsyncIterator()
+        _ = await iterator.next()
+    }
+
+    func listSessions(limit _: Int?) async throws -> OpenClawChatSessionsListResponse {
+        OpenClawChatSessionsListResponse(ts: nil, path: nil, count: 0, defaults: nil, sessions: [])
+    }
+
+    func requestHealth(timeoutMs _: Int) async throws -> Bool {
+        await self.state.healthy
+    }
+
+    func events() -> AsyncStream<OpenClawChatTransportEvent> {
+        self.stream
+    }
+}
+
+private func makeOutboxViewModel(
+    transport: OutboxTestTransport,
+    outbox: any OpenClawChatCommandOutbox,
+    transcriptCache: (any OpenClawChatTranscriptCache)? = nil,
+    retryDelaysMs: [UInt64] = [1, 1]) async -> OpenClawChatViewModel
+{
+    await MainActor.run {
+        let vm = OpenClawChatViewModel(
+            sessionKey: "main",
+            transport: transport,
+            transcriptCache: transcriptCache,
+            outbox: outbox)
+        vm.outboxRetryDelaysMs = retryDelaysMs
+        return vm
+    }
+}
+
+private func sendWhileOffline(_ vm: OpenClawChatViewModel, text: String) async throws {
+    await MainActor.run {
+        vm.input = text
+        vm.send()
+    }
+    try await waitUntil("queued bubble for \(text)") {
+        await MainActor.run {
+            vm.messages.contains { message in
+                message.role == "user" && message.content.contains { $0.text == text }
+            }
+        }
+    }
+}
+
+@MainActor
+private func queuedStateCount(_ vm: OpenClawChatViewModel) -> Int {
+    vm.outboxStatesByMessageID.count
+}
+
+/// Forwarding outbox that can delay `loadCommands`, making restore-vs-send
+/// interleavings deterministic in tests.
+private actor DelayingOutbox: OpenClawChatCommandOutbox {
+    private let base: OpenClawChatSQLiteTranscriptCache
+    private var loadDelayNanoseconds: UInt64 = 0
+
+    init(base: OpenClawChatSQLiteTranscriptCache) {
+        self.base = base
+    }
+
+    func setLoadDelayNanoseconds(_ delay: UInt64) {
+        self.loadDelayNanoseconds = delay
+    }
+
+    func enqueueCommand(_ command: OpenClawChatOutboxCommand) async -> Bool {
+        await self.base.enqueueCommand(command)
+    }
+
+    func loadCommands() async -> [OpenClawChatOutboxCommand] {
+        if self.loadDelayNanoseconds > 0 {
+            try? await Task.sleep(nanoseconds: self.loadDelayNanoseconds)
+        }
+        return await self.base.loadCommands()
+    }
+
+    @discardableResult
+    func recoverInterruptedSends() async -> Bool {
+        await self.base.recoverInterruptedSends()
+    }
+
+    @discardableResult
+    func markCommandSending(id: String) async -> Bool {
+        await self.base.markCommandSending(id: id)
+    }
+
+    func markCommandQueued(id: String, retryCount: Int, lastError: String?) async {
+        await self.base.markCommandQueued(id: id, retryCount: retryCount, lastError: lastError)
+    }
+
+    func markCommandFailed(id: String, retryCount: Int, lastError: String?) async {
+        await self.base.markCommandFailed(id: id, retryCount: retryCount, lastError: lastError)
+    }
+
+    func markCommandRetried(id: String) async {
+        await self.base.markCommandRetried(id: id)
+    }
+
+    func deleteCommand(id: String) async {
+        await self.base.deleteCommand(id: id)
+    }
+}
+
+struct ChatViewModelOutboxTests {
+    @Test func `offline send queues durably and renders queued row`() async throws {
+        let url = try makeOutboxDatabaseURL()
+        defer { try? FileManager.default.removeItem(at: url.deletingLastPathComponent()) }
+        let store = OpenClawChatSQLiteTranscriptCache(databaseURL: url, gatewayID: "gw-test")
+        let transport = OutboxTestTransport(healthy: false)
+        let vm = await makeOutboxViewModel(transport: transport, outbox: store)
+
+        await MainActor.run { vm.load() }
+        try await sendWhileOffline(vm, text: "hello offline")
+
+        // Nothing hit the transport; the command is durable instead.
+        #expect(await transport.state.sentIdempotencyKeys.isEmpty)
+        let commands = await store.loadCommands()
+        #expect(commands.map(\.text) == ["hello offline"])
+        #expect(commands.map(\.status) == [.queued])
+        #expect(commands.map(\.sessionKey) == ["main"])
+
+        // The visible row carries the queued state and the draft was cleared.
+        #expect(await MainActor.run { vm.input.isEmpty })
+        let queuedStates = await MainActor.run {
+            vm.messages.compactMap { vm.outboxState(for: $0.id) }
+        }
+        #expect(queuedStates == [.queued])
+
+        // Recreating the view model (fresh cold open, still offline)
+        // restores the queued bubble from the durable store.
+        let vm2 = await makeOutboxViewModel(transport: transport, outbox: store)
+        await MainActor.run { vm2.load() }
+        try await waitUntil("queued bubble restored after recreation") {
+            await MainActor.run {
+                vm2.messages.contains { vm2.outboxState(for: $0.id) == .queued }
+            }
+        }
+        #expect(await userTexts(vm2) == ["hello offline"])
+    }
+
+    @Test func `reconnect flushes queued commands in order with their idempotency keys`() async throws {
+        let url = try makeOutboxDatabaseURL()
+        defer { try? FileManager.default.removeItem(at: url.deletingLastPathComponent()) }
+        let store = OpenClawChatSQLiteTranscriptCache(databaseURL: url, gatewayID: "gw-test")
+        let transport = OutboxTestTransport(healthy: false)
+        // Same store instance backs cache and outbox, like the app wiring.
+        let vm = await makeOutboxViewModel(transport: transport, outbox: store, transcriptCache: store)
+
+        await MainActor.run { vm.load() }
+        try await sendWhileOffline(vm, text: "first")
+        try await sendWhileOffline(vm, text: "second")
+        let queuedIDs = await store.loadCommands().map(\.id)
+        #expect(queuedIDs.count == 2)
+
+        await transport.goOnline()
+
+        try await waitUntil("outbox drained") {
+            await store.loadCommands().isEmpty
+        }
+        // At-least-once contract: the transport saw each command exactly once
+        // here, keyed by its client UUID, in strict createdAt order.
+        #expect(await transport.state.sentIdempotencyKeys == queuedIDs)
+        #expect(await transport.state.sentMessages == ["first", "second"])
+        #expect(await transport.state.sentSessionKeys == ["main", "main"])
+
+        // Durable history replaced the queued bubbles without duplicating
+        // them, and no outbox state markers remain.
+        try await waitUntil("durable history reconciled") {
+            await MainActor.run { vm.sessionId == "sess-live" }
+        }
+        #expect(await userTexts(vm) == ["first", "second"])
+        #expect(await MainActor.run { queuedStateCount(vm) } == 0)
+
+        // Crash-window durability: the sent turns were written through to the
+        // transcript cache no later than outbox-row deletion, so a cold
+        // offline reopen still shows them.
+        let cached = await store.loadTranscript(sessionKey: "main")
+        let cachedUserTexts = cached
+            .filter { $0.role == "user" }
+            .map { $0.content.compactMap(\.text).joined() }
+        #expect(cachedUserTexts == ["first", "second"])
+    }
+
+    @Test func `assistant reply for a flushed run lands via the external-run final event`() async throws {
+        let url = try makeOutboxDatabaseURL()
+        defer { try? FileManager.default.removeItem(at: url.deletingLastPathComponent()) }
+        let store = OpenClawChatSQLiteTranscriptCache(databaseURL: url, gatewayID: "gw-test")
+        let transport = OutboxTestTransport(healthy: false)
+        let vm = await makeOutboxViewModel(transport: transport, outbox: store)
+
+        await MainActor.run { vm.load() }
+        try await sendWhileOffline(vm, text: "question")
+        await transport.goOnline()
+        try await waitUntil("outbox drained") {
+            await store.loadCommands().isEmpty
+        }
+        let runId = try #require(await transport.state.sentIdempotencyKeys.first)
+
+        // Drop history availability so the assertion below can only be
+        // satisfied by the event path, not a lucky history refresh. (The
+        // scripted history never contains assistant rows, so leaving it on
+        // would wipe the appended final with an incomplete snapshot.)
+        await transport.state.setHistoryFails(true)
+
+        // Flushed runs are intentionally not in pendingRuns; the reply is
+        // delivered through the session-scoped external-run final branch.
+        transport.emit(
+            .chat(
+                OpenClawChatEventPayload(
+                    runId: runId,
+                    sessionKey: "main",
+                    state: "final",
+                    message: AnyCodable([
+                        "role": "assistant",
+                        "content": [["type": "text", "text": "answer"]],
+                        "timestamp": 5000.0,
+                    ] as [String: Any]),
+                    errorMessage: nil)))
+
+        try await waitUntil("assistant reply visible") {
+            await MainActor.run {
+                vm.messages.contains { message in
+                    message.role == "assistant" && message.content.contains { $0.text == "answer" }
+                }
+            }
+        }
+    }
+
+    @Test func `sent turn is cached before the outbox row is deleted`() async throws {
+        let url = try makeOutboxDatabaseURL()
+        defer { try? FileManager.default.removeItem(at: url.deletingLastPathComponent()) }
+        let store = OpenClawChatSQLiteTranscriptCache(databaseURL: url, gatewayID: "gw-test")
+        let transport = OutboxTestTransport(healthy: false)
+        let vm = await makeOutboxViewModel(transport: transport, outbox: store, transcriptCache: store)
+
+        await MainActor.run { vm.load() }
+        try await sendWhileOffline(vm, text: "must survive")
+
+        // Sends succeed on reconnect but history stays unreachable, so the
+        // post-flush history write-through can never populate the cache.
+        // Only the pre-delete write-through can preserve the turn.
+        await transport.state.setHistoryFails(true)
+        await transport.goOnline()
+        try await waitUntil("outbox drained") {
+            await store.loadCommands().isEmpty
+        }
+
+        let cached = await store.loadTranscript(sessionKey: "main")
+        #expect(cached.map { $0.content.compactMap(\.text).joined() } == ["must survive"])
+        _ = vm
+    }
+
+    @Test func `gateway rejections burn attempts then fail terminally and support tap retry`() async throws {
+        let url = try makeOutboxDatabaseURL()
+        defer { try? FileManager.default.removeItem(at: url.deletingLastPathComponent()) }
+        let store = OpenClawChatSQLiteTranscriptCache(databaseURL: url, gatewayID: "gw-test")
+        let transport = OutboxTestTransport(healthy: false)
+        let vm = await makeOutboxViewModel(transport: transport, outbox: store)
+
+        await MainActor.run { vm.load() }
+        try await sendWhileOffline(vm, text: "doomed")
+
+        // Gateway is reachable again but rejects the run on every attempt.
+        await transport.state.setSendRejects(true)
+        await transport.goOnline()
+
+        try await waitUntil("command failed after max attempts") {
+            await store.loadCommands().map(\.status) == [.failed]
+        }
+        let failed = try #require(await store.loadCommands().first)
+        #expect(failed.retryCount == OpenClawChatViewModel.maxOutboxSendAttempts)
+        #expect(failed.lastError != nil)
+        try await waitUntil("failed state visible") {
+            await MainActor.run {
+                vm.messages.contains { vm.outboxState(for: $0.id)?.isFailed == true }
+            }
+        }
+
+        // Tap-to-retry resets attempts; with the gateway accepting again the
+        // command now flushes and the row disappears.
+        await transport.state.setSendRejects(false)
+        let failedMessageID = try #require(await MainActor.run {
+            vm.messages.first { vm.outboxState(for: $0.id)?.isFailed == true }?.id
+        })
+        await MainActor.run { vm.retryOutboxMessage(failedMessageID) }
+        try await waitUntil("retried command drained") {
+            await store.loadCommands().isEmpty
+        }
+        #expect(await transport.state.sentIdempotencyKeys.count == 1)
+    }
+
+    @Test func `transport failures keep commands queued without burning attempts`() async throws {
+        let url = try makeOutboxDatabaseURL()
+        defer { try? FileManager.default.removeItem(at: url.deletingLastPathComponent()) }
+        let store = OpenClawChatSQLiteTranscriptCache(databaseURL: url, gatewayID: "gw-test")
+        // Health reads true, but the actual send path is down: the send gate
+        // is bypassed and the transport error must requeue instead of losing
+        // the draft.
+        let transport = OutboxTestTransport(healthy: true, sendFails: true)
+        let vm = await makeOutboxViewModel(transport: transport, outbox: store)
+
+        await MainActor.run { vm.load() }
+        try await waitUntil("bootstrap healthy") {
+            await MainActor.run { vm.healthOK }
+        }
+        await MainActor.run {
+            vm.input = "stale health send"
+            vm.send()
+        }
+
+        // The optimistic bubble survives as a durable outbox row that stays
+        // queued: connectivity blips never burn retry attempts.
+        try await waitUntil("send requeued durably") {
+            await store.loadCommands().map(\.status) == [.queued]
+        }
+        // Give the automatic retry chain a few cycles to prove the row never
+        // escalates toward failed while the transport keeps throwing. The
+        // status may read 'sending' mid-attempt; the invariants are that it
+        // never turns failed and attempts stay unburned.
+        try await Task.sleep(nanoseconds: 50_000_000)
+        let requeued = try #require(await store.loadCommands().first)
+        #expect(requeued.status != .failed)
+        #expect(requeued.retryCount == 0)
+        #expect(requeued.text == "stale health send")
+        #expect(await userTexts(vm) == ["stale health send"])
+        let bubbleKey = await MainActor.run {
+            vm.messages.first { $0.role == "user" }?.idempotencyKey
+        }
+        // Same idempotency identity as the failed live send, so a duplicate
+        // delivery on the gateway side stays deduped.
+        #expect(bubbleKey == "\(requeued.id):user")
+
+        // Once the transport recovers, the next healthy transition drains
+        // the row without any user action. (Repeated throws exhaust the
+        // retry ladder and drop health, so recovery is signaled the same way
+        // a real reconnect is.)
+        await transport.state.setSendFails(false)
+        await transport.goOnline()
+        // Generous timeout: draining rides the millisecond retry chain, which
+        // can be starved under full parallel suite load.
+        try await waitUntil("requeued command drained", timeoutSeconds: 10) {
+            await store.loadCommands().isEmpty
+        }
+        #expect(await transport.state.sentIdempotencyKeys == [requeued.id])
+    }
+
+    @Test func `tap retry refreshes createdAt so an expired command can resend`() async throws {
+        let url = try makeOutboxDatabaseURL()
+        defer { try? FileManager.default.removeItem(at: url.deletingLastPathComponent()) }
+        let store = OpenClawChatSQLiteTranscriptCache(databaseURL: url, gatewayID: "gw-test")
+        // A command that sat offline past the staleness bound.
+        let staleCreatedAt = Date().timeIntervalSince1970 -
+            OpenClawChatSQLiteTranscriptCache.outboxCommandMaxAge - 60
+        #expect(await store.enqueueCommand(
+            OpenClawChatOutboxCommand(
+                id: "c-expired",
+                sessionKey: "main",
+                text: "old message",
+                thinking: "off",
+                createdAt: staleCreatedAt,
+                status: .queued,
+                retryCount: 0,
+                lastError: nil)))
+        let transport = OutboxTestTransport(healthy: false)
+        let vm = await makeOutboxViewModel(transport: transport, outbox: store)
+
+        await MainActor.run { vm.load() }
+        // Restore surfaces the expired command as failed("expired").
+        try await waitUntil("expired command visible as failed") {
+            await MainActor.run {
+                vm.messages.contains { vm.outboxState(for: $0.id)?.isFailed == true }
+            }
+        }
+        #expect(await store.loadCommands().map(\.lastError) == [
+            OpenClawChatSQLiteTranscriptCache.outboxExpiredError,
+        ])
+
+        // Explicit retry is new intent: createdAt refreshes, so the row goes
+        // back to queued instead of immediately re-expiring, and it flushes
+        // once the gateway is reachable.
+        let messageID = try #require(await MainActor.run {
+            vm.messages.first { vm.outboxState(for: $0.id)?.isFailed == true }?.id
+        })
+        await MainActor.run { vm.retryOutboxMessage(messageID) }
+        try await waitUntil("retried command re-queued") {
+            await store.loadCommands().map(\.status) == [.queued]
+        }
+        await transport.goOnline()
+        try await waitUntil("expired-then-retried command drained") {
+            await store.loadCommands().isEmpty
+        }
+        #expect(await transport.state.sentMessages == ["old message"])
+    }
+
+    @Test func `flush sends the thinking level captured with the queued command`() async throws {
+        let url = try makeOutboxDatabaseURL()
+        defer { try? FileManager.default.removeItem(at: url.deletingLastPathComponent()) }
+        let store = OpenClawChatSQLiteTranscriptCache(databaseURL: url, gatewayID: "gw-test")
+        // Queued earlier under a session running "high"; the visible session's
+        // current level is "off" and must not leak into the flush.
+        #expect(await store.enqueueCommand(
+            OpenClawChatOutboxCommand(
+                id: "c-think",
+                sessionKey: "other-session",
+                text: "think hard",
+                thinking: "high",
+                createdAt: Date().timeIntervalSince1970,
+                status: .queued,
+                retryCount: 0,
+                lastError: nil)))
+        let transport = OutboxTestTransport(healthy: false)
+        let vm = await makeOutboxViewModel(transport: transport, outbox: store)
+        #expect(await MainActor.run { vm.thinkingLevel } == "off")
+
+        await MainActor.run { vm.load() }
+        await transport.goOnline()
+        try await waitUntil("outbox drained") {
+            await store.loadCommands().isEmpty
+        }
+        #expect(await transport.state.sentThinkingLevels == ["high"])
+        #expect(await transport.state.sentSessionKeys == ["other-session"])
+        _ = vm
+    }
+
+    @Test func `flushed background-session turn is spliced into its cached transcript`() async throws {
+        let url = try makeOutboxDatabaseURL()
+        defer { try? FileManager.default.removeItem(at: url.deletingLastPathComponent()) }
+        let store = OpenClawChatSQLiteTranscriptCache(databaseURL: url, gatewayID: "gw-test")
+        // Queued for a session the user is no longer viewing.
+        #expect(await store.enqueueCommand(
+            OpenClawChatOutboxCommand(
+                id: "c-background",
+                sessionKey: "other-session",
+                text: "sent from elsewhere",
+                thinking: "off",
+                createdAt: Date().timeIntervalSince1970,
+                status: .queued,
+                retryCount: 0,
+                lastError: nil)))
+        let transport = OutboxTestTransport(healthy: false)
+        let vm = await makeOutboxViewModel(transport: transport, outbox: store, transcriptCache: store)
+
+        await MainActor.run { vm.load() }
+        await transport.goOnline()
+        try await waitUntil("outbox drained") {
+            await store.loadCommands().isEmpty
+        }
+
+        // The turn survives in that session's cached transcript even though
+        // its messages were never loaded into the view model.
+        let cached = await store.loadTranscript(sessionKey: "other-session")
+        #expect(cached.map { $0.content.compactMap(\.text).joined() } == ["sent from elsewhere"])
+        #expect(cached.map(\.idempotencyKey) == ["c-background:user"])
+        _ = vm
+    }
+
+    @Test func `full queue refuses enqueue and keeps the draft`() async throws {
+        let url = try makeOutboxDatabaseURL()
+        defer { try? FileManager.default.removeItem(at: url.deletingLastPathComponent()) }
+        let store = OpenClawChatSQLiteTranscriptCache(databaseURL: url, gatewayID: "gw-test")
+        for index in 0..<OpenClawChatSQLiteTranscriptCache.maxQueuedCommands {
+            let accepted = await store.enqueueCommand(
+                OpenClawChatOutboxCommand(
+                    id: "prefill-\(index)",
+                    sessionKey: "other",
+                    text: "m\(index)",
+                    thinking: "off",
+                    createdAt: Date().timeIntervalSince1970,
+                    status: .queued,
+                    retryCount: 0,
+                    lastError: nil))
+            #expect(accepted)
+        }
+        let transport = OutboxTestTransport(healthy: false)
+        let vm = await makeOutboxViewModel(transport: transport, outbox: store)
+
+        await MainActor.run {
+            vm.input = "does not fit"
+            vm.send()
+        }
+        try await waitUntil("refusal surfaced") {
+            await MainActor.run { vm.errorText != nil }
+        }
+        // The draft survives so the text is not lost, and no row was added.
+        #expect(await MainActor.run { vm.input } == "does not fit")
+        #expect(await userTexts(vm).isEmpty)
+        #expect(await store.loadCommands().count == OpenClawChatSQLiteTranscriptCache.maxQueuedCommands)
+    }
+
+    @Test func `repeated transport failures climb the backoff ladder then drop health`() async throws {
+        let url = try makeOutboxDatabaseURL()
+        defer { try? FileManager.default.removeItem(at: url.deletingLastPathComponent()) }
+        let store = OpenClawChatSQLiteTranscriptCache(databaseURL: url, gatewayID: "gw-test")
+        let transport = OutboxTestTransport(healthy: false, sendFails: true)
+        let vm = await makeOutboxViewModel(transport: transport, outbox: store)
+
+        await MainActor.run { vm.load() }
+        try await sendWhileOffline(vm, text: "stuck in transit")
+
+        // Gateway reports healthy but every send throws: the flush must walk
+        // the retry ladder (streak 1, 2) and then drop health instead of
+        // retrying at the first rung forever.
+        await transport.goOnline()
+        // healthOK starts false pre-goOnline, so the exhaustion signal is
+        // the streak walking past the ladder (2 rungs in tests) WITH health
+        // down again — not the initial offline state.
+        try await waitUntil("ladder exhausted and health dropped") {
+            await MainActor.run { vm.outboxTransportFailureStreak >= 3 && !vm.healthOK }
+        }
+        // Row survives as queued: transport throws never burn durable
+        // attempts.
+        let commands = await store.loadCommands()
+        #expect(commands.map(\.status) == [.queued])
+        #expect(commands.map(\.retryCount) == [0])
+
+        // A genuine recovery flushes normally and resets the streak.
+        await transport.state.setSendFails(false)
+        await transport.goOnline()
+        try await waitUntil("command sent after recovery") {
+            await transport.state.sentIdempotencyKeys.count == 1
+        }
+        try await waitUntil("row drained") {
+            await store.loadCommands().isEmpty
+        }
+        #expect(await MainActor.run { vm.outboxTransportFailureStreak } == 0)
+    }
+
+    @Test func `deleting a queued message removes bubble and durable row`() async throws {
+        let url = try makeOutboxDatabaseURL()
+        defer { try? FileManager.default.removeItem(at: url.deletingLastPathComponent()) }
+        let store = OpenClawChatSQLiteTranscriptCache(databaseURL: url, gatewayID: "gw-test")
+        let transport = OutboxTestTransport(healthy: false)
+        let vm = await makeOutboxViewModel(transport: transport, outbox: store)
+
+        await MainActor.run { vm.load() }
+        try await sendWhileOffline(vm, text: "changed my mind")
+
+        let messageID = try #require(await MainActor.run {
+            vm.messages.first { vm.outboxState(for: $0.id) == .queued }?.id
+        })
+        await MainActor.run { vm.deleteOutboxMessage(messageID) }
+
+        // The bubble disappears only after the durable delete lands, so a
+        // process kill can never orphan a hidden-but-persisted command.
+        try await waitUntil("bubble removed after durable delete") {
+            await userTexts(vm).isEmpty
+        }
+        #expect(await MainActor.run { queuedStateCount(vm) } == 0)
+        try await waitUntil("durable row deleted") {
+            await store.loadCommands().isEmpty
+        }
+    }
+}
+
+/// Holds `deleteCommand` until released so tests can pin the exact window
+/// where a user delete races an in-flight flush pass (row still visible in
+/// the pass's snapshot).
+private final class HeldDeleteOutbox: @unchecked Sendable, OpenClawChatCommandOutbox {
+    private let base: OpenClawChatSQLiteTranscriptCache
+    private let gate = DeleteGate()
+
+    init(base: OpenClawChatSQLiteTranscriptCache) {
+        self.base = base
+    }
+
+    func releaseHeldDeletes() async {
+        await self.gate.open()
+    }
+
+    /// Fired (once) just before the claim forwards, on the flush's task:
+    /// lets tests land a user delete inside the claim's await window.
+    private var onClaim: (@Sendable () async -> Void)?
+
+    func setOnClaim(_ hook: @escaping @Sendable () async -> Void) {
+        self.onClaim = hook
+    }
+
+    func enqueueCommand(_ command: OpenClawChatOutboxCommand) async -> Bool {
+        await self.base.enqueueCommand(command)
+    }
+
+    func loadCommands() async -> [OpenClawChatOutboxCommand] {
+        await self.base.loadCommands()
+    }
+
+    @discardableResult
+    func recoverInterruptedSends() async -> Bool {
+        await self.base.recoverInterruptedSends()
+    }
+
+    @discardableResult
+    func markCommandSending(id: String) async -> Bool {
+        if let hook = self.onClaim {
+            self.onClaim = nil
+            await hook()
+        }
+        return await self.base.markCommandSending(id: id)
+    }
+
+    func markCommandQueued(id: String, retryCount: Int, lastError: String?) async {
+        await self.base.markCommandQueued(id: id, retryCount: retryCount, lastError: lastError)
+    }
+
+    func markCommandFailed(id: String, retryCount: Int, lastError: String?) async {
+        await self.base.markCommandFailed(id: id, retryCount: retryCount, lastError: lastError)
+    }
+
+    func markCommandRetried(id: String) async {
+        await self.base.markCommandRetried(id: id)
+    }
+
+    func deleteCommand(id: String) async {
+        await self.gate.wait()
+        await self.base.deleteCommand(id: id)
+    }
+}
+
+private actor DeleteGate {
+    private var isOpen = false
+    private var waiters: [CheckedContinuation<Void, Never>] = []
+
+    func open() {
+        self.isOpen = true
+        for waiter in self.waiters { waiter.resume() }
+        self.waiters.removeAll()
+    }
+
+    func wait() async {
+        if self.isOpen { return }
+        await withCheckedContinuation { self.waiters.append($0) }
+    }
+}
+
+extension ChatViewModelOutboxTests {
+    @Test func `double submit during the offline health probe enqueues once`() async throws {
+        let url = try makeOutboxDatabaseURL()
+        defer { try? FileManager.default.removeItem(at: url.deletingLastPathComponent()) }
+        let store = OpenClawChatSQLiteTranscriptCache(databaseURL: url, gatewayID: "gw-test")
+        let transport = OutboxTestTransport(healthy: false)
+        let vm = await makeOutboxViewModel(transport: transport, outbox: store)
+
+        await MainActor.run { vm.load() }
+        // Two rapid submits of the same draft: the second lands while the
+        // first is still awaiting the forced health probe. The isSending
+        // guard must swallow it instead of enqueueing a duplicate row.
+        await MainActor.run {
+            vm.input = "tap tap"
+            vm.send()
+            vm.send()
+        }
+        try await waitUntil("queued bubble for tap tap") {
+            await MainActor.run {
+                vm.messages.contains { message in
+                    message.role == "user" && message.content.contains { $0.text == "tap tap" }
+                }
+            }
+        }
+
+        let commands = await store.loadCommands()
+        #expect(commands.map(\.text) == ["tap tap"])
+        #expect(await MainActor.run { queuedStateCount(vm) } == 1)
+    }
+
+    @Test func `stale history after the flush ack cannot evict the sent turn from the cache`() async throws {
+        let url = try makeOutboxDatabaseURL()
+        defer { try? FileManager.default.removeItem(at: url.deletingLastPathComponent()) }
+        let store = OpenClawChatSQLiteTranscriptCache(databaseURL: url, gatewayID: "gw-test")
+        let transport = OutboxTestTransport(healthy: false)
+        let vm = await makeOutboxViewModel(transport: transport, outbox: store, transcriptCache: store)
+
+        await MainActor.run { vm.load() }
+        try await sendWhileOffline(vm, text: "must survive stale history")
+
+        // The gateway acks the flush but its history snapshot lags: it still
+        // returns only an older turn without the just-sent idempotency key.
+        let staleRow = AnyCodable([
+            "role": "assistant",
+            "content": [["type": "text", "text": "older turn"]],
+            "timestamp": 500.0,
+        ] as [String: Any])
+        await transport.state.setStaleHistoryRows([staleRow])
+        await transport.goOnline()
+        try await waitUntil("outbox drained") {
+            await store.loadCommands().isEmpty
+        }
+        try await waitUntil("stale refresh applied") {
+            await MainActor.run { vm.messages.contains { message in
+                message.content.contains { $0.text == "older turn" }
+            } }
+        }
+        // Wait out the chained cache writes, then cold-reopen offline: the
+        // sent turn must still pre-paint even though the outbox row is gone
+        // and the last history snapshot did not contain it.
+        if let pendingWrite = await MainActor.run(body: { vm.pendingCacheWriteTask }) {
+            await pendingWrite.value
+        }
+        let cached = await store.loadTranscript(sessionKey: "main")
+        #expect(cached.contains { message in
+            message.content.contains { $0.text == "must survive stale history" }
+        })
+    }
+
+    @Test func `send before restore adopts durable rows still queues behind them`() async throws {
+        let url = try makeOutboxDatabaseURL()
+        defer { try? FileManager.default.removeItem(at: url.deletingLastPathComponent()) }
+        let store = OpenClawChatSQLiteTranscriptCache(databaseURL: url, gatewayID: "gw-test")
+        // Persist a row as an earlier process would have.
+        #expect(await store.enqueueCommand(OpenClawChatOutboxCommand(
+            id: UUID().uuidString,
+            sessionKey: "main",
+            text: "queued by the previous launch",
+            thinking: "off",
+            createdAt: Date().timeIntervalSince1970 - 60,
+            status: .queued,
+            retryCount: 0,
+            lastError: nil)))
+
+        // Healthy cold open: fire a send synchronously after load(), before
+        // the async restore has adopted the durable row. The FIFO gate must
+        // still route it behind the backlog.
+        let transport = OutboxTestTransport(healthy: true)
+        let vm = await makeOutboxViewModel(transport: transport, outbox: store)
+        await MainActor.run {
+            vm.load()
+            vm.input = "typed instantly on open"
+            vm.send()
+        }
+
+        try await waitUntil("both turns delivered") {
+            await transport.state.sentMessages.count == 2
+        }
+        #expect(await transport.state.sentMessages == [
+            "queued by the previous launch",
+            "typed instantly on open",
+        ])
+        try await waitUntil("rows drained") {
+            await store.loadCommands().isEmpty
+        }
+    }
+
+    @Test func `send right after a session switch still queues behind that session's backlog`() async throws {
+        let url = try makeOutboxDatabaseURL()
+        defer { try? FileManager.default.removeItem(at: url.deletingLastPathComponent()) }
+        let store = OpenClawChatSQLiteTranscriptCache(databaseURL: url, gatewayID: "gw-test")
+        // Backlog persisted for a session that is not initially visible.
+        #expect(await store.enqueueCommand(OpenClawChatOutboxCommand(
+            id: UUID().uuidString,
+            sessionKey: "second",
+            text: "backlog in second session",
+            thinking: "off",
+            createdAt: Date().timeIntervalSince1970 - 60,
+            status: .queued,
+            retryCount: 0,
+            lastError: nil)))
+
+        // Start offline so the backlog cannot drain before the switch.
+        let transport = OutboxTestTransport(healthy: false)
+        let outbox = DelayingOutbox(base: store)
+        let vm = await makeOutboxViewModel(transport: transport, outbox: outbox)
+        await MainActor.run { vm.load() }
+        // Let "main" finish restoring so the FIFO gate flag is set for it.
+        try await waitUntil("initial session restored") {
+            await MainActor.run { vm.hasRestoredOutboxMessages }
+        }
+
+        // Delay outbox reads from here on so, after the switch, neither the
+        // new session's restore nor the reconnect flush can observe the
+        // backlog before the send's gate check runs. Only the reset-on-switch
+        // keeps ordering safe in that window.
+        await outbox.setLoadDelayNanoseconds(150_000_000)
+
+        // Switch, reconnect, and send immediately: the restore gate must
+        // reset with the switch, so this send routes behind the new
+        // session's backlog instead of going live ahead of it.
+        await MainActor.run { vm.switchSession(to: "second") }
+        await transport.goOnline()
+        await MainActor.run {
+            vm.input = "typed right after switching"
+            vm.send()
+        }
+
+        try await waitUntil("both turns delivered") {
+            await transport.state.sentMessages.count == 2
+        }
+        #expect(await transport.state.sentMessages == [
+            "backlog in second session",
+            "typed right after switching",
+        ])
+        try await waitUntil("rows drained") {
+            await store.loadCommands().isEmpty
+        }
+    }
+
+    @Test func `flush waits for an in-flight model patch before sending`() async throws {
+        let url = try makeOutboxDatabaseURL()
+        defer { try? FileManager.default.removeItem(at: url.deletingLastPathComponent()) }
+        let store = OpenClawChatSQLiteTranscriptCache(databaseURL: url, gatewayID: "gw-test")
+        let transport = OutboxTestTransport(healthy: false)
+        let vm = await makeOutboxViewModel(transport: transport, outbox: store)
+
+        await MainActor.run { vm.load() }
+        try await sendWhileOffline(vm, text: "after the model change")
+
+        // A model change is still patching when health recovers. The flush
+        // must honor the same ordering as live sends and hold until the
+        // patch resolves, or the run would start on the stale model.
+        await MainActor.run { vm.selectModel("anthropic/claude-test") }
+        await transport.goOnline()
+        try await Task.sleep(nanoseconds: 100_000_000)
+        #expect(await transport.state.sentMessages.isEmpty)
+
+        transport.releaseModelPatch()
+        try await waitUntil("outbox drained after patch resolved") {
+            await store.loadCommands().isEmpty
+        }
+        #expect(await transport.state.sentMessages == ["after the model change"])
+    }
+
+    @Test func `live send after reconnect queues behind draining outbox rows`() async throws {
+        let url = try makeOutboxDatabaseURL()
+        defer { try? FileManager.default.removeItem(at: url.deletingLastPathComponent()) }
+        let store = OpenClawChatSQLiteTranscriptCache(databaseURL: url, gatewayID: "gw-test")
+        let transport = OutboxTestTransport(healthy: false)
+        let vm = await makeOutboxViewModel(transport: transport, outbox: store)
+
+        await MainActor.run { vm.load() }
+        try await sendWhileOffline(vm, text: "first, written offline")
+
+        // Reconnect with the first send held mid-flight, then send live text
+        // immediately: it must fall in line behind the draining row, not
+        // race ahead of it.
+        let gate = DeleteGate()
+        await transport.state.setHeldSendGate(gate)
+        await transport.goOnline()
+        try await waitUntil("first row claimed for sending") {
+            await store.loadCommands().map(\.status) == [.sending]
+        }
+        await MainActor.run {
+            vm.input = "second, right after reconnect"
+            vm.send()
+        }
+        try await waitUntil("second row queued behind the first") {
+            await store.loadCommands().map(\.text).contains("second, right after reconnect")
+        }
+        #expect(await transport.state.sentMessages.isEmpty)
+
+        await gate.open()
+        try await waitUntil("both rows drained in order") {
+            await store.loadCommands().isEmpty
+        }
+        #expect(await transport.state.sentMessages == [
+            "first, written offline",
+            "second, right after reconnect",
+        ])
+    }
+
+    @Test func `deleting during the claim await never sends`() async throws {
+        let url = try makeOutboxDatabaseURL()
+        defer { try? FileManager.default.removeItem(at: url.deletingLastPathComponent()) }
+        let store = OpenClawChatSQLiteTranscriptCache(databaseURL: url, gatewayID: "gw-test")
+        let outbox = HeldDeleteOutbox(base: store)
+        let transport = OutboxTestTransport(healthy: false)
+        let vm = await makeOutboxViewModel(transport: transport, outbox: outbox)
+
+        await MainActor.run { vm.load() }
+        try await sendWhileOffline(vm, text: "deleted inside the claim")
+        let messageID = try #require(await MainActor.run {
+            vm.messages.first { vm.outboxState(for: $0.id) == .queued }?.id
+        })
+
+        // The delete lands inside markCommandSending's await window: after
+        // the pre-claim tombstone check, before the claim resolves. The
+        // post-claim recheck must catch it.
+        outbox.setOnClaim {
+            await MainActor.run { vm.deleteOutboxMessage(messageID) }
+        }
+        await transport.goOnline()
+        // The recheck path awaits the (held) durable delete, so give the
+        // flush a beat to reach it and prove nothing was sent meanwhile.
+        try await Task.sleep(nanoseconds: 100_000_000)
+        #expect(await transport.state.sentIdempotencyKeys.isEmpty)
+        await outbox.releaseHeldDeletes()
+        try await waitUntil("flush drains without sending") {
+            await MainActor.run { queuedStateCount(vm) == 0 }
+        }
+        #expect(await transport.state.sentIdempotencyKeys.isEmpty)
+        try await waitUntil("durable row deleted") {
+            await store.loadCommands().isEmpty
+        }
+    }
+
+    @Test func `deleting a queued bubble mid-flush never sends it`() async throws {
+        let url = try makeOutboxDatabaseURL()
+        defer { try? FileManager.default.removeItem(at: url.deletingLastPathComponent()) }
+        let store = OpenClawChatSQLiteTranscriptCache(databaseURL: url, gatewayID: "gw-test")
+        let outbox = HeldDeleteOutbox(base: store)
+        let transport = OutboxTestTransport(healthy: false)
+        let vm = await makeOutboxViewModel(transport: transport, outbox: outbox)
+
+        await MainActor.run { vm.load() }
+        try await sendWhileOffline(vm, text: "changed my mind mid-flush")
+
+        // User deletes the bubble; the durable row deletion is held, so the
+        // next flush pass still sees the row in its snapshot — the exact
+        // race window the tombstone protects.
+        let messageID = try #require(await MainActor.run {
+            vm.messages.first { vm.outboxState(for: $0.id) == .queued }?.id
+        })
+        await MainActor.run { vm.deleteOutboxMessage(messageID) }
+
+        await transport.goOnline()
+        try await waitUntil("flush pass drains without sending") {
+            await MainActor.run { queuedStateCount(vm) == 0 }
+        }
+        #expect(await transport.state.sentIdempotencyKeys.isEmpty)
+
+        // Once the held deletion completes, the row is gone for good and a
+        // later flush still sends nothing.
+        await outbox.releaseHeldDeletes()
+        try await waitUntil("durable row deleted") {
+            await store.loadCommands().isEmpty
+        }
+        await transport.emit(.health(ok: true))
+        #expect(await transport.state.sentIdempotencyKeys.isEmpty)
+    }
+}

--- a/docs/platforms/ios.md
+++ b/docs/platforms/ios.md
@@ -14,7 +14,8 @@ Availability: iPhone app builds are distributed through Apple channels when enab
 - Connects to a Gateway over WebSocket (LAN or tailnet).
 - Exposes node capabilities: Canvas, Screen snapshot, Camera capture, Location, Talk mode, Voice wake.
 - Receives `node.invoke` commands and reports node status events.
-- Keeps a small read-only offline cache of recent chat sessions and transcripts per paired gateway: cold opens paint the last known transcript immediately and refresh once the gateway responds, recent chats stay browsable while disconnected (sending stays disabled until the connection is back), and reset/forget purges the protected local cache.
+- Keeps a small read-only offline cache of recent chat sessions and transcripts per paired gateway: cold opens paint the last known transcript immediately and refresh once the gateway responds, recent chats stay browsable while disconnected, and reset/forget purges the protected local cache.
+- Queues text messages sent while disconnected in a durable per-gateway outbox (up to 50): queued bubbles show in the transcript, flush in order on reconnect with idempotency keys so nothing sends twice, retry with backoff before surfacing as "Not sent" with retry/delete in the message context menu, and expire instead of sending after 48 hours offline; reset/forget clears the queue with the cache.
 
 ## Requirements
 


### PR DESCRIPTION
**Stacked on the iOS chat offline cache branch (#100219, `feat/ios-chat-offline-cache`); lands after it.**

Part of #46664

## What Problem This Solves

Text sent while the gateway is unreachable is refused and lost. Users who think of things for their agent while offline (transit, dead zones, gateway restarts) have no way to hand them off — the thought has to survive in their head until connectivity returns.

## Why This Change Was Made

Adds a durable offline command outbox to the shared chat pipeline, wired up for iOS. It extends the existing transcript-cache SQLite database (same DB, new table) rather than adding a store, and uses the existing health transition as the flush trigger rather than a second reachability source. Each queued command's UUID rides as the `chat.send` idempotency key, so flushing is at-least-once with gateway-side dedup. Conservative contract: text-only v1, 50 queued per gateway, 48h expiry to a visible "expired" state instead of silently firing stale commands, 3 attempts for gateway rejections with visible failure + tap-to-retry, transport-level failures never burn attempts (they climb an in-memory backoff ladder, then drop health so the reconnect machinery owns pacing), `sending` rows recover to `queued` after a crash, and rows purge with the cache on gateway resets.

Ordering is a first-class guarantee: the outbox is the single ordering authority for a session's turns. New live sends route behind queued/sending rows (including immediately after a cold open, before durable rows are re-adopted), the flush is strictly createdAt-ordered and single-flight, and a just-flushed turn stays visible and cached until a history snapshot confirms its idempotency key — a lagging gateway snapshot cannot evict it. Deliberately session-scoped: other sessions' queued rows are separate conversations with no ordering contract against a new send (documented inline).

## User Impact

- Sending while offline queues the message durably: it renders immediately with a "queued" state, survives app restarts, and delivers in order on reconnect with no user action.
- Failures are visible and recoverable: expired/rejected commands park as "failed" with Retry/Delete on the bubble; Retry refreshes the timestamp so expired items can resend. Delete is hidden once a row is in flight (the send can no longer be prevented).
- Bounded and private: 50 commands per gateway, text only, stored in the same protected per-gateway database as the transcript cache.

## Evidence

- `cd apps/shared/OpenClawKit && swift test --filter "ChatViewModelOutboxTests|ChatTranscriptCacheStoreTests"` — full outbox suite green (16 VM scenarios + store round-trip/claim tests), including deterministic tests for: enqueue-offline persistence across VM recreation, ordered flush with idempotency keys, ack-removes-row without duplicate bubbles, rejection→failed-after-3 with tap retry, transport-failure backoff ladder then health drop, 48h expiry boundary, MAX_QUEUED refusal + draft preservation, crash recovery, delete-vs-flush races (snapshot window AND claim-await window via a held-delete/claim-hook harness), double-submit during the health probe, post-reconnect live sends queueing behind draining rows, cold-open sends queueing behind not-yet-adopted durable rows, and stale-history-after-ack cache preservation.
- `swift test --filter "ChatViewModelTests|ChatViewModelTranscriptCacheTests"` — 111+ existing tests green.
- Codex autoreview: 8 rounds. Seven accepted findings fixed, each with a regression test (delete-vs-flush race, claim-window delete race, Delete exposed on in-flight rows, duplicate enqueue on double submit, unbounded first-rung transport retries, live sends overtaking the queue after reconnect, stale history evicting just-acked turns from cache). One finding-half consciously rejected with inline rationale (gateway-wide send blocking across sessions — separate conversations have no ordering contract, and wedging them on another session's backlog is worse product behavior). Final round clean.

Follow-ups noted: voice-capture queue unification (`WatchReplyCoordinator` overlap documented in code), macOS wiring rides the stacked macOS cache PR, and attachment sends remain online-only v1 (outside the ordering guarantee, documented inline).

**Update (post-#100219 landing):** rebuilt as a single squashed commit on main, re-expressing the outbox on the landed cache rewrite (per-gateway SHA256-named DB files under `chat-cache/`, retired/async-handle store API, main's onboarding purge redesign). All seven review-hardened behaviors preserved with their regression tests, plus four more fixes from this pass's review rounds: session-switch FIFO-gate reset, model-patch ordering during flush, delete-durability window (bubble persists until the durable row is confirmed gone — no resurrect-after-kill), and crash-recovery gating under a locked store. Validation: `swift test` across the five affected suites — 150 tests green (three consecutive runs); final Codex autoreview clean (0.84).
