### PR TITLE
fix(ci): bound hosted gate workflow pagination

### DIFF
--- a/scripts/verify-pr-hosted-gates.mjs
+++ b/scripts/verify-pr-hosted-gates.mjs
@@ -17,6 +17,8 @@ const ARTIFACT_FALLBACK_REQUIRED_WORKFLOWS = [
   "Blacksmith ARM Testbox",
   "Workflow Sanity",
 ];
+const WORKFLOW_RUNS_PAGE_SIZE = 100;
+const MAX_WORKFLOW_RUN_SEARCH_RESULTS = 1_000;
 
 function readOptionValue(argv, index, optionName) {
   const value = argv[index + 1];
@@ -168,8 +170,19 @@ function stripAnsi(raw) {
   return raw.replace(new RegExp(`${escape}\\[[0-?]*[ -/]*[@-~]`, "gu"), "");
 }
 
-export function parseWorkflowRunPages(raw) {
-  return JSON.parse(stripAnsi(raw)).flatMap((page) => page.workflow_runs ?? []);
+export function parseWorkflowRunPage(raw) {
+  const page = JSON.parse(stripAnsi(raw));
+  return {
+    totalCount: page.total_count ?? 0,
+    workflowRuns: page.workflow_runs ?? [],
+  };
+}
+
+export function workflowRunPageCount(totalCount) {
+  return Math.min(
+    Math.ceil(totalCount / WORKFLOW_RUNS_PAGE_SIZE),
+    MAX_WORKFLOW_RUN_SEARCH_RESULTS / WORKFLOW_RUNS_PAGE_SIZE,
+  );
 }
 
 export function collectHostedGateEvidence({ sha, workflowRuns, changelogOnly = false }) {
@@ -220,11 +233,24 @@ export function collectHostedGateEvidence({ sha, workflowRuns, changelogOnly = f
 }
 
 function loadWorkflowRuns(repo, sha) {
-  const raw = execPlainGh(
-    ["api", `repos/${repo}/actions/runs?head_sha=${sha}&per_page=100`, "--paginate", "--slurp"],
-    { encoding: "utf8", stdio: ["ignore", "pipe", "pipe"] },
-  );
-  return parseWorkflowRunPages(raw);
+  const loadPage = (page) =>
+    parseWorkflowRunPage(
+      execPlainGh(
+        [
+          "api",
+          `repos/${repo}/actions/runs?head_sha=${sha}&per_page=${WORKFLOW_RUNS_PAGE_SIZE}&page=${page}`,
+        ],
+        { encoding: "utf8", stdio: ["ignore", "pipe", "pipe"] },
+      ),
+    );
+
+  // Keep every request pinned to the head SHA and bound it to GitHub's documented search window.
+  const firstPage = loadPage(1);
+  const workflowRuns = [...firstPage.workflowRuns];
+  for (let page = 2; page <= workflowRunPageCount(firstPage.totalCount); page += 1) {
+    workflowRuns.push(...loadPage(page).workflowRuns);
+  }
+  return workflowRuns;
 }
 
 export function main(argv = process.argv.slice(2)) {

--- a/test/scripts/verify-pr-hosted-gates.test.ts
+++ b/test/scripts/verify-pr-hosted-gates.test.ts
@@ -2,8 +2,9 @@ import { describe, expect, it } from "vitest";
 import {
   collectHostedGateEvidence,
   parseArgs,
-  parseWorkflowRunPages,
+  parseWorkflowRunPage,
   SCHEDULED_HOSTED_WORKFLOWS,
+  workflowRunPageCount,
 } from "../../scripts/verify-pr-hosted-gates.mjs";
 
 const sha = "773ffd87a1e1e34451ad6e38fda37380c2569a50";
@@ -394,9 +395,17 @@ describe("verify-pr-hosted-gates", () => {
     }
   });
 
-  it("accepts JSON emitted through a colorizing GitHub CLI shim", () => {
+  it("accepts one workflow-runs page emitted through a colorizing GitHub CLI shim", () => {
     expect(
-      parseWorkflowRunPages('\u001B[1;37m[{"workflow_runs":[{"id":1,"name":"CI"}]}]\u001B[0m'),
-    ).toEqual([{ id: 1, name: "CI" }]);
+      parseWorkflowRunPage(
+        '\u001B[1;37m{"total_count":101,"workflow_runs":[{"id":1,"name":"CI"}]}\u001B[0m',
+      ),
+    ).toEqual({ totalCount: 101, workflowRuns: [{ id: 1, name: "CI" }] });
+  });
+
+  it("bounds workflow-run pagination to GitHub's search result limit", () => {
+    expect(workflowRunPageCount(0)).toBe(0);
+    expect(workflowRunPageCount(101)).toBe(2);
+    expect(workflowRunPageCount(10_000)).toBe(10);
   });
 });


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where maintainers landing a pull request could exhaust the shared GitHub REST API quota when the hosted-gate verifier followed an unbounded workflow-runs pagination chain.

## Why This Change Was Made

The verifier now fetches workflow-run pages explicitly, repeating the exact head SHA on every request and stopping at GitHub's documented 1,000-result search window. This preserves complete gate evidence while bounding API use.

## User Impact

No product behavior changes. Maintainer PR preparation remains complete and no longer risks consuming an hourly API quota in one run.

## Evidence

- Blacksmith Testbox `tbx_01kws6dks482rv1pbv7erbnvkp`: `pnpm test test/scripts/verify-pr-hosted-gates.test.ts` — 18/18 passed.
- Same Testbox: `pnpm check:changed` — tooling lane passed.
- Fresh Codex autoreview: clean, confidence 0.97.
- GitHub's workflow-runs API documents `head_sha`, a maximum page size of 100, and a 1,000-result search cap: https://docs.github.com/en/rest/actions/workflow-runs#list-workflow-runs-for-a-repository