### PR TITLE
fix(telegram): duplicate assistant messages in conversation context

### DIFF
--- a/extensions/telegram/src/bot-handlers.runtime.ts
+++ b/extensions/telegram/src/bot-handlers.runtime.ts
@@ -190,10 +190,7 @@ function resolvePromptContextTextDedupeKey(
   if (typeof message.body !== "string" || !message.body.trim()) {
     return undefined;
   }
-  if (typeof message.timestamp_ms !== "number" || !Number.isFinite(message.timestamp_ms)) {
-    return undefined;
-  }
-  return `${message.timestamp_ms}:${message.body.trim()}`;
+  return message.body.trim();
 }
 
 export const registerTelegramHandlers = ({


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users sending messages via Telegram would receive duplicate assistant replies in the conversation context passed to the model, doubling token usage and potentially confusing the model with repeated entries.

Each assistant reply appears twice: once from the session transcript (with a `session:`-prefixed message ID) and once from the Telegram message cache (with the actual Telegram message ID). Both carry the same visible text but slightly different timestamps, causing the dedup key to differ and both copies to be retained.

## Why This Change Was Made

The dedup key in `resolvePromptContextTextDedupeKey` was `timestamp_ms:body`, which fails when the same assistant text appears in both sources with timestamps differing by milliseconds (session transcript gets the generation timestamp, Telegram cache gets the delivery timestamp).

This change removes the timestamp component from the dedup key, using only the message body text. The overall dedup logic (removing session-transcript entries that already exist in the Telegram cache) remains unchanged; only the matching criterion is tightened.

## User Impact

- Telegram users no longer receive duplicated assistant replies in the model conversation context
- Token usage is reduced for every turn that previously carried duplicates
- No impact on non-Telegram channels or message delivery

## Evidence

- Reproduced before fix: every assistant turn produced a `#message_id` entry and a `#session:<id>` entry with identical text in the model context
- After fix: verified with multiple message exchanges that assistant replies appear exactly once in the context, while legitimate session-only narration entries (e.g., tool progress text) are preserved correctly
- Tested on OpenClaw 2026.7.1-beta.1 with deepseek/deepseek-v4-pro