### PR TITLE
fix(chat): deduplicate streaming intermediate assistant messages in chat history

### DIFF
--- a/src/gateway/chat-display-projection.ts
+++ b/src/gateway/chat-display-projection.ts
@@ -1473,6 +1473,40 @@ function displayTextForDuplicateCheck(message: Record<string, unknown>): string 
   return text ? text : undefined;
 }
 
+function hasThinkingBlock(message: Record<string, unknown>): boolean {
+  const content = message.content;
+  if (!Array.isArray(content)) {
+    return false;
+  }
+  return content.some(
+    (block) =>
+      block && typeof block === "object" && (block as Record<string, unknown>).type === "thinking",
+  );
+}
+
+/**
+ * Detects assistant message pairs where the first is a streaming intermediate
+ * (has a thinking block) and the second is the finalized reply with identical
+ * visible text. Drops the intermediate to avoid display duplication.
+ */
+function isStreamingTransitionDuplicate(
+  current: Record<string, unknown>,
+  next: Record<string, unknown> | null | undefined,
+): boolean {
+  if (!next || !current || typeof current !== "object" || typeof next !== "object") {
+    return false;
+  }
+  if (current.role !== "assistant" || next.role !== "assistant") {
+    return false;
+  }
+  if (!hasThinkingBlock(current) || hasThinkingBlock(next)) {
+    return false;
+  }
+  const currentText = displayTextForDuplicateCheck(current);
+  const nextText = displayTextForDuplicateCheck(next);
+  return Boolean(currentText && nextText && currentText === nextText);
+}
+
 function isDuplicateAcpGatewayInjectedMessage(
   current: Record<string, unknown>,
   previousVisible: Record<string, unknown> | undefined,
@@ -1561,6 +1595,10 @@ function filterVisibleProjectedHistoryMessages(
       continue;
     }
     if (shouldHideProjectedHistoryMessage(current)) {
+      changed = true;
+      continue;
+    }
+    if (isStreamingTransitionDuplicate(current, next)) {
       changed = true;
       continue;
     }


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users viewing chat history in TUI or Control UI see duplicate assistant messages for a single turn. Each reply appears twice: once as a streaming intermediate entry (containing both thinking and text blocks) and once as the finalized entry (text only). Both produce identical visible text.

This is most noticeable when the reply originates from a channel (e.g., Telegram) where streaming creates an intermediate transcript entry before the finalized one is written, and the chat history display reads both.

## Why This Change Was Made

Added a new dedup check `isStreamingTransitionDuplicate` in the chat history display pipeline. The check detects two consecutive assistant messages where:
- Both have role "assistant"
- The first has a thinking block (streaming intermediate), the second does not (finalized)
- Both have identical visible text

When matched, only the first (intermediate) entry is dropped; the second (finalized) entry is kept. This avoids false positives when the assistant intentionally outputs identical consecutive text — those cases lack the thinking-block fingerprint.

## User Impact

- TUI and Control UI chat history no longer show duplicate assistant messages from streaming intermediate → final transitions
- Intentional repeated assistant output is preserved correctly
- No impact on the model conversation context (separate code path)

## Evidence

- Reproduced: a single-message exchange from Telegram produced two assistant entries in the session transcript (one with thinking+text blocks, one with text only), both rendered with identical visible text in TUI
- After fix: verified with multiple Telegram-sourced and TUI-sourced message exchanges that each assistant reply appears exactly once in chat history, while tool-call intermediate narration entries are preserved correctly
- Tested by toggling between channel sources and confirming no duplicate display