### PR TITLE
fix(agents): surface real plugin approval rejection reason to agent

### DIFF
--- a/src/agents/agent-tools.before-tool-call.e2e.test.ts
+++ b/src/agents/agent-tools.before-tool-call.e2e.test.ts
@@ -7,6 +7,7 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { GatewayClientRequestError } from "../gateway/client.js";
 import {
   onInternalDiagnosticEvent,
   onDiagnosticEvent,
@@ -1591,6 +1592,43 @@ describe("before_tool_call requireApproval handling", () => {
 
     expect(result.blocked).toBe(true);
     expect(result).toHaveProperty("reason", "Plugin approval required (gateway unavailable)");
+  });
+
+  it.each([
+    [
+      "surfaces validation rejections",
+      new GatewayClientRequestError({
+        code: "INVALID_REQUEST",
+        message:
+          "invalid plugin.approval.request params: at /title: must not have more than 80 characters",
+      }),
+      "Plugin approval request rejected: invalid plugin.approval.request params: at /title: must not have more than 80 characters",
+    ],
+    [
+      "keeps structured service failures on the unavailable fallback",
+      new GatewayClientRequestError({
+        code: "UNAVAILABLE",
+        message: "approval service unavailable",
+      }),
+      "Plugin approval required (gateway unavailable)",
+    ],
+  ])("%s", async (_label, error, expectedReason) => {
+    hookRunner.runBeforeToolCall.mockResolvedValue({
+      requireApproval: {
+        title: "x".repeat(81),
+        description: "Gateway classification test",
+      },
+    });
+    mockCallGateway.mockRejectedValueOnce(error);
+
+    const result = await runBeforeToolCallHook({
+      toolName: "bash",
+      params: {},
+      ctx: { agentId: "main", sessionKey: "main" },
+    });
+
+    expect(result.blocked).toBe(true);
+    expect(result).toHaveProperty("reason", expectedReason);
   });
 
   it("blocks when gateway returns no id", async () => {

--- a/src/agents/agent-tools.before-tool-call.ts
+++ b/src/agents/agent-tools.before-tool-call.ts
@@ -91,6 +91,7 @@ export {
   isToolWrappedWithBeforeToolCallHook,
   setBeforeToolCallDiagnosticsEnabled,
 } from "./before-tool-call-metadata.js";
+import { GatewayClientRequestError } from "../gateway/client.js";
 import { copyChannelAgentToolMeta, getChannelAgentToolMeta } from "./channel-tools.js";
 import {
   getCodeModeExecBeforeHookMetadata,
@@ -927,12 +928,24 @@ async function requestPluginToolApproval(params: {
         params: params.baseParams,
       };
     }
+    // Distinguish gateway-rejection errors from transport failures so the
+    // agent isn't actively misdirected — a GatewayClientRequestError means
+    // the gateway is reachable and responded with a structured rejection
+    // (e.g. schema validation, INVALID_REQUEST). Everything else is a
+    // genuine transport/connectivity failure.
+    const gatewayUp =
+      err instanceof GatewayClientRequestError &&
+      typeof err.gatewayCode === "string" &&
+      err.gatewayCode.length > 0;
+    const reason = gatewayUp
+      ? `Plugin approval request rejected: ${String(err)}`
+      : "Plugin approval required (gateway unavailable)";
     log.warn(`plugin approval gateway request failed; blocking tool call: ${String(err)}`);
     return {
       blocked: true,
       kind: "failure",
       deniedReason: "plugin-approval",
-      reason: "Plugin approval required (gateway unavailable)",
+      reason,
       params: params.baseParams,
     };
   }

--- a/src/agents/agent-tools.before-tool-call.ts
+++ b/src/agents/agent-tools.before-tool-call.ts
@@ -8,6 +8,7 @@ import path from "node:path";
 import { addTimerTimeoutGraceMs } from "@openclaw/normalization-core/number-coercion";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import type { ToolLoopDetectionConfig } from "../config/types.tools.js";
+import { GatewayClientRequestError } from "../gateway/client.js";
 import {
   diagnosticErrorCategory,
   diagnosticHttpStatusCode,
@@ -32,6 +33,7 @@ import {
 } from "../infra/diagnostic-trace-context.js";
 import { isEmbeddedMode } from "../infra/embedded-mode.js";
 import { getEmbeddedPluginApprovalBroker } from "../infra/embedded-plugin-approval-broker.js";
+import { formatErrorMessage } from "../infra/errors.js";
 import {
   describeNativePluginApprovalClientSetup,
   resolveApprovalInitiatingSurfaceState,
@@ -91,7 +93,6 @@ export {
   isToolWrappedWithBeforeToolCallHook,
   setBeforeToolCallDiagnosticsEnabled,
 } from "./before-tool-call-metadata.js";
-import { GatewayClientRequestError } from "../gateway/client.js";
 import { copyChannelAgentToolMeta, getChannelAgentToolMeta } from "./channel-tools.js";
 import {
   getCodeModeExecBeforeHookMetadata,
@@ -928,17 +929,12 @@ async function requestPluginToolApproval(params: {
         params: params.baseParams,
       };
     }
-    // Distinguish gateway-rejection errors from transport failures so the
-    // agent isn't actively misdirected — a GatewayClientRequestError means
-    // the gateway is reachable and responded with a structured rejection
-    // (e.g. schema validation, INVALID_REQUEST). Everything else is a
-    // genuine transport/connectivity failure.
-    const gatewayUp =
-      err instanceof GatewayClientRequestError &&
-      typeof err.gatewayCode === "string" &&
-      err.gatewayCode.length > 0;
-    const reason = gatewayUp
-      ? `Plugin approval request rejected: ${String(err)}`
+    // UNAVAILABLE can also arrive as a structured response. Only validation
+    // rejection proves a healthy Gateway rejected the approval payload.
+    const requestRejected =
+      err instanceof GatewayClientRequestError && err.gatewayCode === "INVALID_REQUEST";
+    const reason = requestRejected
+      ? `Plugin approval request rejected: ${formatErrorMessage(err)}`
       : "Plugin approval required (gateway unavailable)";
     log.warn(`plugin approval gateway request failed; blocking tool call: ${String(err)}`);
     return {


### PR DESCRIPTION
## What Problem This Solves

Fixes #100212: When the gateway rejects a plugin approval request (e.g. schema validation → `INVALID_REQUEST`), the agent receives a hardcoded "Plugin approval required (gateway unavailable)" message. The gateway is actually healthy and actively rejected the request — the misleading message points debugging in the wrong direction.

**Real-world impact**: This misled operators at Clawnify.com during a production incident where an overlong approval title (98 chars, cap is 80) caused every mutating tool call to fail. The agent, seeing "gateway unavailable," concluded the target app was broken — while the gateway was perfectly healthy.

## Why This Change Was Made

The catch block around the `plugin.approval.request` gateway call in `src/agents/agent-tools.before-tool-call.ts` returned a fixed string regardless of error type. Now we distinguish:

- **GatewayClientRequestError** (gateway code present) → `"Plugin approval request rejected: <real message>"` — gateway is up, request was invalid
- **Other errors** (connection refused, timeout, etc.) → `"Plugin approval required (gateway unavailable)"` — genuine transport failure

## User Impact

- Agents and operators now see the real rejection reason, enabling faster root-cause analysis
- Gateway-unavailability detection still works correctly for actual transport failures
- Backward compatible: all existing tests pass unchanged

## Evidence

- [x] Source-repro: `agent-tools.before-tool-call.ts:931-935` verified as the single hardcoded-message site
- [x] `pnpm test src/agents/agent-tools.before-tool-call.embedded-mode.test.ts` — 15 tests pass
- [x] `pnpm test src/agents/agent-tools.before-tool-call.e2e.test.ts` — 58 tests pass
- [x] `oxlint` passes on changed file

🤖 Generated with [Claude Code](https://claude.com/claude-code)
