### PR TITLE
fix(bonjour-discovery): tolerate malformed tailscale status JSON

### DIFF
--- a/scripts/proof/bonjour-tailscale-malformed-json.mts
+++ b/scripts/proof/bonjour-tailscale-malformed-json.mts
@@ -1,0 +1,41 @@
+// Real behavior proof: malformed `tailscale status --json` does not crash
+// wide-area gateway discovery.
+
+import {
+  discoverGatewayBeacons,
+  type GatewayBonjourBeacon,
+} from "../../src/infra/bonjour-discovery.js";
+import type { runCommandWithTimeout } from "../../src/process/exec.js";
+
+const WIDE_AREA_DOMAIN = "openclaw.internal.";
+
+const run = async (argv: string[]) => {
+  const cmd = argv[0];
+  if (cmd === "dns-sd" && argv[1] === "-B") {
+    return { stdout: "", stderr: "", code: 0, signal: null, killed: false };
+  }
+  if (cmd === "tailscale" && argv[1] === "status" && argv[2] === "--json") {
+    return { stdout: "not valid json {", stderr: "", code: 0, signal: null, killed: false };
+  }
+  throw new Error(`unexpected argv: ${argv.join(" ")}`);
+};
+
+console.log("=== Proof: bonjour-discovery malformed tailscale status JSON ===\n");
+console.log("Discovering gateways with tailscale returning invalid JSON...\n");
+
+const beacons: GatewayBonjourBeacon[] = await discoverGatewayBeacons({
+  platform: "darwin",
+  timeoutMs: 1200,
+  domains: [WIDE_AREA_DOMAIN],
+  wideAreaDomain: WIDE_AREA_DOMAIN,
+  run: run as unknown as typeof runCommandWithTimeout,
+});
+
+console.log(`Discovered beacons: ${JSON.stringify(beacons)}`);
+
+if (beacons.length === 0) {
+  console.log("\nPASS: malformed tailscale JSON is tolerated and discovery returns empty list.");
+} else {
+  console.log("\nFAIL: expected empty beacon list.");
+  process.exitCode = 1;
+}

--- a/src/infra/bonjour-discovery.test.ts
+++ b/src/infra/bonjour-discovery.test.ts
@@ -341,6 +341,29 @@ describe("bonjour-discovery", () => {
     expect(calls.map((c) => c.argv[0])).toContain("dig");
   });
 
+  it("tolerates malformed tailscale status JSON during wide-area fallback", async () => {
+    const run = vi.fn(async (argv: string[]) => {
+      const cmd = argv[0];
+      if (cmd === "dns-sd" && argv[1] === "-B") {
+        return { stdout: "", stderr: "", code: 0, signal: null, killed: false };
+      }
+      if (cmd === "tailscale" && argv[1] === "status" && argv[2] === "--json") {
+        return { stdout: "not valid json {", stderr: "", code: 0, signal: null, killed: false };
+      }
+      throw new Error(`unexpected argv: ${argv.join(" ")}`);
+    });
+
+    const beacons = await discoverGatewayBeacons({
+      platform: "darwin",
+      timeoutMs: 1200,
+      domains: [WIDE_AREA_DOMAIN],
+      wideAreaDomain: WIDE_AREA_DOMAIN,
+      run: run as unknown as typeof runCommandWithTimeout,
+    });
+
+    expect(beacons).toEqual([]);
+  });
+
   it("normalizes domains and respects domains override", async () => {
     const calls: string[][] = [];
     const run = vi.fn(async (argv: string[]) => {

--- a/src/infra/bonjour-discovery.ts
+++ b/src/infra/bonjour-discovery.ts
@@ -162,7 +162,14 @@ function parseDigSrv(stdout: string): { host: string; port: number } | null {
 }
 
 function parseTailscaleStatusIPv4s(stdout: string): string[] {
-  const parsed = stdout ? (JSON.parse(stdout) as Record<string, unknown>) : {};
+  let parsed: Record<string, unknown>;
+  try {
+    parsed = stdout ? (JSON.parse(stdout) as Record<string, unknown>) : {};
+  } catch {
+    // Tailscale status is an external command; malformed JSON should not crash
+    // wide-area gateway discovery.
+    return [];
+  }
   const out: string[] = [];
 
   const addIps = (value: unknown) => {


### PR DESCRIPTION
## What Problem This Solves

On macOS, `discoverGatewayBeacons` falls back to wide-area Tailnet DNS discovery when split DNS is not configured. That path runs `tailscale status --json` and feeds the stdout directly to `JSON.parse`. If Tailscale returns malformed JSON, the discovery crashes with a raw `SyntaxError`.

## Why This Change Was Made

Wrapped the `JSON.parse` in `parseTailscaleStatusIPv4s` with a `try/catch` that returns an empty IP list. The caller `discoverWideAreaViaTailnetDns` already catches and ignores failures, so malformed output now degrades gracefully to "no Tailnet IPs found" instead of crashing.

## User Impact

Gateway discovery on Tailnet no longer crashes when the local `tailscale` CLI emits unexpected output.

## Evidence

Terminal proof (after fix):

```bash
node_modules/.bin/tsx scripts/proof/bonjour-tailscale-malformed-json.mts
```

Output:

```
=== Proof: bonjour-discovery malformed tailscale status JSON ===

Discovering gateways with tailscale returning invalid JSON...

Discovered beacons: []

PASS: malformed tailscale JSON is tolerated and discovery returns empty list.
```

Regression test:

```bash
node scripts/run-vitest.mjs src/infra/bonjour-discovery.test.ts
```

All 6 tests pass.
