### PR TITLE
fix(tui): suppress unhandled rejection from editor submit handlers

### DIFF
--- a/scripts/plugin-sdk-surface-report.mjs
+++ b/scripts/plugin-sdk-surface-report.mjs
@@ -274,29 +274,31 @@ function countWildcardReexports(entrypoints) {
   return { count, matches };
 }
 
-// All three inventories overlap. Reuse one module graph so reporting subsets
-// does not triple TypeScript compiler time and heap usage.
-const exportStatsProgram = ts.createProgram(pluginSdkEntrypoints.map(entrypointPath), {
-  allowJs: false,
-  declaration: true,
-  emitDeclarationOnly: true,
-  module: ts.ModuleKind.ESNext,
-  moduleResolution: ts.ModuleResolutionKind.Bundler,
-  noEmit: true,
-  skipLibCheck: true,
-  strict: false,
-  target: ts.ScriptTarget.ES2022,
-  types: [],
-});
-const exportStatsChecker = exportStatsProgram.getTypeChecker();
+// All three inventories overlap. Lazily reuse one module graph so --help and
+// invalid options avoid compiler work without tripling report time and heap.
+let exportStatsProgram;
 
 function collectExportStats(entrypoints) {
+  exportStatsProgram ??= ts.createProgram(pluginSdkEntrypoints.map(entrypointPath), {
+    allowJs: false,
+    declaration: true,
+    emitDeclarationOnly: true,
+    module: ts.ModuleKind.ESNext,
+    moduleResolution: ts.ModuleResolutionKind.Bundler,
+    noEmit: true,
+    skipLibCheck: true,
+    strict: false,
+    target: ts.ScriptTarget.ES2022,
+    types: [],
+  });
+  const program = exportStatsProgram;
+  const checker = program.getTypeChecker();
   const byEntrypoint = new Map();
   const uniqueNames = new Set();
   const uniqueCallableNames = new Set();
 
   for (const entrypoint of entrypoints) {
-    const sourceFile = exportStatsProgram.getSourceFile(entrypointPath(entrypoint));
+    const sourceFile = program.getSourceFile(entrypointPath(entrypoint));
     if (!sourceFile) {
       byEntrypoint.set(entrypoint, {
         exports: 0,
@@ -306,8 +308,8 @@ function collectExportStats(entrypoints) {
       });
       continue;
     }
-    const moduleSymbol = exportStatsChecker.getSymbolAtLocation(sourceFile);
-    const symbols = moduleSymbol ? exportStatsChecker.getExportsOfModule(moduleSymbol) : [];
+    const moduleSymbol = checker.getSymbolAtLocation(sourceFile);
+    const symbols = moduleSymbol ? checker.getExportsOfModule(moduleSymbol) : [];
     let callableExports = 0;
     let deprecatedExports = 0;
     let deprecatedCallableExports = 0;
@@ -315,11 +317,11 @@ function collectExportStats(entrypoints) {
     for (const symbol of symbols) {
       const exportName = `${entrypoint}:${symbol.getName()}`;
       uniqueNames.add(exportName);
-      const callable = isCallableExport(exportStatsChecker, symbol, sourceFile);
+      const callable = isCallableExport(checker, symbol, sourceFile);
       const deprecated =
         deprecatedEntrypoint ||
         hasDeprecatedTag(symbol) ||
-        hasDeprecatedTag(unwrapAlias(exportStatsChecker, symbol));
+        hasDeprecatedTag(unwrapAlias(checker, symbol));
       if (callable) {
         callableExports += 1;
         uniqueCallableNames.add(exportName);

--- a/src/scripts/test-projects.test.ts
+++ b/src/scripts/test-projects.test.ts
@@ -1,4 +1,5 @@
 // Test project script tests cover fixture project discovery and validation.
+import { spawnSync } from "node:child_process";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
@@ -854,167 +855,68 @@ describe("test-projects args", () => {
   });
 
   it("routes top-level test helpers to importing repo tests", () => {
-    expect(buildVitestRunPlans(["test/helpers/temp-dir.ts"])).toEqual([
-      {
-        config: "test/vitest/vitest.unit-fast.config.ts",
-        forwardedArgs: [],
-        includePatterns: [
-          "src/agents/command/attempt-execution.shared.test.ts",
-          "src/auto-reply/reply/session-entry-persistence.test.ts",
-          "src/crestodian/operations.test.ts",
-          "src/install-sh-version.test.ts",
-          "src/proxy-capture/store.sqlite.test.ts",
-          "test/scripts/android-version.test.ts",
-          "test/scripts/resolve-openclaw-ref.test.ts",
-        ],
-        watchMode: false,
-      },
-      {
-        config: "test/vitest/vitest.unit-fast-fake-timers.config.ts",
-        forwardedArgs: [],
-        includePatterns: ["src/entry.compile-cache.test.ts"],
-        watchMode: false,
-      },
-      {
-        config: "test/vitest/vitest.unit.config.ts",
-        forwardedArgs: [
-          "src/state/openclaw-agent-db.test.ts",
-          "src/state/openclaw-state-db.test.ts",
-          "src/state/sqlite-query-plan.test.ts",
-          "src/transcripts/store.test.ts",
-        ],
-        includePatterns: null,
-        watchMode: false,
-      },
-      {
-        config: "test/vitest/vitest.tooling.config.ts",
-        forwardedArgs: [],
-        includePatterns: [
-          "src/scripts/docs-link-audit.test.ts",
-          "src/scripts/sync-plugin-versions.test.ts",
-          "test/e2e/qa-lab/runtime/gateway-mcp-real-transports.test.ts",
-          "test/helpers/temp-dir.test.ts",
-          "test/scripts/android-pin-version.test.ts",
-          "test/scripts/bench-cli-startup.test.ts",
-          "test/scripts/check-package-dist-imports.test.ts",
-          "test/scripts/check-workflows.test.ts",
-          "test/scripts/ci-hydrate-testbox-env.test.ts",
-          "test/scripts/clawhub-fixture-server.test.ts",
-          "test/scripts/codex-install-assertions.test.ts",
-          "test/scripts/config-reload-mutate-metadata.test.ts",
-          "test/scripts/control-ui-i18n.test.ts",
-          "test/scripts/docs-list.test.ts",
-          "test/scripts/doctor-install-switch-wrapper.test.ts",
-          "test/scripts/e2e-shell-tempfiles.test.ts",
-          "test/scripts/e2e-text-file-utils.test.ts",
-          "test/scripts/fixture-common.test.ts",
-          "test/scripts/fixture-plugin-commands.test.ts",
-          "test/scripts/incremental-line-reader.test.ts",
-          "test/scripts/ios-configure-signing.test.ts",
-          "test/scripts/ios-team-id.test.ts",
-          "test/scripts/ios-version.test.ts",
-          "test/scripts/kitchen-sink-rpc-walk.test.ts",
-          "test/scripts/native-app-i18n.test.ts",
-          "test/scripts/onboard-config-fixtures.test.ts",
-          "test/scripts/package-git-fixture.test.ts",
-          "test/scripts/parallels-lib-helpers.test.ts",
-          "test/scripts/parallels-package-log-progress-extract.test.ts",
-          "test/scripts/parallels-smoke-model.test.ts",
-          "test/scripts/plugin-package-dependencies.test.ts",
-          "test/scripts/plugins-assertions.test.ts",
-          "test/scripts/prepare-extension-package-boundary-artifacts.test.ts",
-          "test/scripts/proxy-install-ca.test.ts",
-          "test/scripts/release-preflight.test.ts",
-          "test/scripts/render-maturity-docs.test.ts",
-          "test/scripts/report-test-temp-creations.test.ts",
-          "test/scripts/runtime-postbuild-stamp.test.ts",
-          "test/scripts/test-install-sh-docker.test.ts",
-          "test/scripts/test-projects.test.ts",
-          "test/test-env.test.ts",
-          "test/vitest-scoped-config.test.ts",
-        ],
-        watchMode: false,
-      },
-      {
-        config: "test/vitest/vitest.gateway.config.ts",
-        forwardedArgs: [],
-        includePatterns: [
-          "src/gateway/hooks-mapping.test.ts",
-          "src/gateway/server-methods/chat.abort-persistence.test.ts",
-          "src/gateway/server.agent.gateway-server-agent-b.test.ts",
-          "src/gateway/server.chat.gateway-server-chat-b.test.ts",
-          "src/gateway/server.sessions.permissions-hooks.test.ts",
-          "src/gateway/terminal/launch.test.ts",
-        ],
-        watchMode: false,
-      },
-      {
-        config: "test/vitest/vitest.runtime-config.config.ts",
-        forwardedArgs: [],
-        includePatterns: ["src/config/sessions/entry-freshness.test.ts"],
-        watchMode: false,
-      },
-      {
-        config: "test/vitest/vitest.cron.config.ts",
-        forwardedArgs: [],
-        includePatterns: [
-          "src/cron/isolated-agent/run-session-state.test.ts",
-          "src/cron/run-log.error-reason.test.ts",
-        ],
-        watchMode: false,
-      },
-      {
-        config: "test/vitest/vitest.commands.config.ts",
-        forwardedArgs: [],
-        includePatterns: [
-          "src/commands/doctor-completion.test.ts",
-          "src/commands/status.scan.shared.test.ts",
-        ],
-        watchMode: false,
-      },
-      {
-        config: "test/vitest/vitest.auto-reply.config.ts",
-        forwardedArgs: [],
-        includePatterns: [
-          "src/auto-reply/reply/get-reply-native-slash-fast-path.test.ts",
-          "src/auto-reply/reply/get-reply.auto-fallback.test.ts",
-          "src/auto-reply/reply/reply-turn-admission.test.ts",
-          "src/auto-reply/reply/session-updates.test.ts",
-        ],
-        watchMode: false,
-      },
-      {
-        config: "test/vitest/vitest.agents.config.ts",
-        forwardedArgs: [],
-        includePatterns: [
-          "src/agents/agent-bundle-mcp-runtime.test.ts",
-          "src/agents/agent-tools-agent-config.exec.test.ts",
-          "src/agents/bash-tools.exec-foreground-failures.test.ts",
-          "src/agents/cli-runner.reliability.test.ts",
-          "src/agents/models-config.file-mode.test.ts",
-          "src/agents/sandbox/ssh.test.ts",
-          "src/agents/sessions/tools/find.fd.test.ts",
-          "src/agents/sessions/tools/read.test.ts",
-        ],
-        watchMode: false,
-      },
-      {
-        config: "test/vitest/vitest.plugins.config.ts",
-        forwardedArgs: [],
-        includePatterns: ["src/plugins/git-install.test.ts"],
-        watchMode: false,
-      },
-      {
-        config: "test/vitest/vitest.e2e.config.ts",
-        forwardedArgs: [
-          "test/e2e/qa-lab/plugins/plugin-lifecycle-probe.e2e.test.ts",
-          "test/e2e/qa-lab/runtime/openai-compatible-chat-tools.e2e.test.ts",
-          "test/openclaw-launcher.e2e.test.ts",
-        ],
-        includePatterns: null,
-        watchMode: false,
-      },
-    ]);
+    // The importer inventory of test/helpers/temp-dir.ts churns with every new
+    // test using the helper; frozen full lists broke main on unrelated test
+    // additions. Assert the routing structure instead of the inventory.
+    const plans = buildVitestRunPlans(["test/helpers/temp-dir.ts"]);
+    const planFiles = plans.map((plan) => plan.includePatterns ?? plan.forwardedArgs);
+    const expandedFiles = planFiles.flat();
+
+    // Helper targets expand to importing test files; the helper itself never
+    // reaches Vitest as a raw target.
+    expect(expandedFiles).toContain("test/helpers/temp-dir.test.ts");
+    expect(expandedFiles).not.toContain("test/helpers/temp-dir.ts");
+    expect(expandedFiles.filter((file) => !file.endsWith(".test.ts"))).toEqual([]);
+
+    // Lower bound derived from the repo itself: every tracked test file that
+    // directly imports the helper must be picked up by the expansion scan, so
+    // dropped importers still fail without freezing the full inventory.
+    const scanRoots = ["src", "test", "ui", "extensions", "packages"];
+    const grep = spawnSync(
+      "git",
+      ["grep", "-l", "--fixed-strings", "helpers/temp-dir", "--", ...scanRoots],
+      { encoding: "utf8" },
+    );
+    expect(grep.status).toBe(0);
+    const directImporterTests = grep.stdout
+      .split("\n")
+      .map((line) => line.trim())
+      .filter((file) => file.endsWith(".test.ts") && !file.endsWith(".live.test.ts"))
+      .filter((file) => {
+        const source = fs.readFileSync(file, "utf8");
+        return [...source.matchAll(/from\s+["'](\.[^"']+)["']/gu)].some((match) => {
+          const importerDir = path.posix.dirname(file);
+          const resolved = path.posix.normalize(path.posix.join(importerDir, match[1]));
+          return resolved.replace(/\.(?:js|ts)$/u, "") === "test/helpers/temp-dir";
+        });
+      });
+    expect(directImporterTests.length).toBeGreaterThan(0);
+    expect(directImporterTests.filter((file) => !expandedFiles.includes(file))).toEqual([]);
+
+    // Importers partition across configs: each file lands in exactly one plan,
+    // in deterministic sorted order.
+    expect(plans.length).toBeGreaterThan(1);
+    expect(new Set(expandedFiles).size).toBe(expandedFiles.length);
+    for (const files of planFiles) {
+      expect(files).toEqual([...files].toSorted((left, right) => left.localeCompare(right)));
+    }
+
+    // Each importer must route to the same config and include-vs-forwarded
+    // shape as targeting it directly, so this test fails on real routing
+    // regressions but not on new importers of the helper.
+    for (const plan of plans) {
+      expect(plan.watchMode).toBe(false);
+      for (const file of plan.includePatterns ?? plan.forwardedArgs) {
+        expect(buildVitestRunPlans([file])).toEqual([
+          {
+            config: plan.config,
+            forwardedArgs: plan.includePatterns ? [] : [file],
+            includePatterns: plan.includePatterns ? [file] : null,
+            watchMode: false,
+          },
+        ]);
+      }
+    }
   });
 
   it("routes e2e targets straight to the e2e config", () => {

--- a/src/tui/tui-submit-test-helpers.ts
+++ b/src/tui/tui-submit-test-helpers.ts
@@ -15,6 +15,7 @@ type SubmitHarness = {
   handleBangLine: MockFn;
   canSubmitMessage: MockFn;
   onBlockedMessageSubmit: MockFn;
+  onSubmitError: MockFn;
   onSubmit: (text: string) => void;
 };
 
@@ -31,11 +32,13 @@ export function createSubmitHarness(params?: {
   const handleBangLine = vi.fn();
   const canSubmitMessage = vi.fn(params?.canSubmitMessage ?? (() => true));
   const onBlockedMessageSubmit = vi.fn();
+  const onSubmitError = vi.fn();
   const onSubmit = createEditorSubmitHandler({
     editor,
     handleCommand,
     sendMessage,
     handleBangLine,
+    onSubmitError,
     canSubmitMessage,
     onBlockedMessageSubmit,
   });
@@ -46,6 +49,7 @@ export function createSubmitHarness(params?: {
     handleBangLine,
     canSubmitMessage,
     onBlockedMessageSubmit,
+    onSubmitError,
     onSubmit,
   };
 }

--- a/src/tui/tui-submit.ts
+++ b/src/tui/tui-submit.ts
@@ -1,6 +1,22 @@
 // Handles TUI input submission and command dispatch.
 import { normalizeLowercaseStringOrEmpty } from "@openclaw/normalization-core/string-coerce";
 
+export type TuiSubmitAction = "local shell" | "command" | "message";
+
+function runSubmitAction(
+  action: TuiSubmitAction,
+  run: () => Promise<void> | void,
+  onError: (action: TuiSubmitAction, error: unknown) => void,
+): void {
+  try {
+    void Promise.resolve(run()).catch((error: unknown) => {
+      onError(action, error);
+    });
+  } catch (error) {
+    onError(action, error);
+  }
+}
+
 export function createEditorSubmitHandler(params: {
   editor: {
     setText: (value: string) => void;
@@ -9,6 +25,7 @@ export function createEditorSubmitHandler(params: {
   handleCommand: (value: string) => Promise<void> | void;
   sendMessage: (value: string) => Promise<void> | void;
   handleBangLine: (value: string) => Promise<void> | void;
+  onSubmitError: (action: TuiSubmitAction, error: unknown) => void;
   canSubmitMessage?: (value: string) => boolean;
   onBlockedMessageSubmit?: (value: string) => void;
 }) {
@@ -28,7 +45,7 @@ export function createEditorSubmitHandler(params: {
     if (raw.startsWith("!") && raw !== "!") {
       params.editor.setText("");
       params.editor.addToHistory(raw);
-      void params.handleBangLine(raw);
+      runSubmitAction("local shell", () => params.handleBangLine(raw), params.onSubmitError);
       return;
     }
 
@@ -36,7 +53,7 @@ export function createEditorSubmitHandler(params: {
       params.editor.setText("");
       // Enable built-in editor prompt history navigation (up/down).
       params.editor.addToHistory(value);
-      void params.handleCommand(value);
+      runSubmitAction("command", () => params.handleCommand(value), params.onSubmitError);
       return;
     }
 
@@ -49,7 +66,7 @@ export function createEditorSubmitHandler(params: {
     params.editor.setText("");
     // Enable built-in editor prompt history navigation (up/down).
     params.editor.addToHistory(value);
-    void params.sendMessage(value);
+    runSubmitAction("message", () => params.sendMessage(value), params.onSubmitError);
   };
 }
 

--- a/src/tui/tui.submit-handler.test.ts
+++ b/src/tui/tui.submit-handler.test.ts
@@ -88,6 +88,7 @@ describe("createEditorSubmitHandler", () => {
       handleCommand: vi.fn(),
       sendMessage,
       handleBangLine: vi.fn(),
+      onSubmitError: vi.fn(),
       canSubmitMessage: () => false,
       onBlockedMessageSubmit,
     });
@@ -122,6 +123,30 @@ describe("createEditorSubmitHandler", () => {
     expect(editor.addToHistory).toHaveBeenCalledWith("Line 1\nLine 2\nLine 3");
     expect(handleCommand).not.toHaveBeenCalled();
     expect(handleBangLine).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ["local shell", "!false", "handleBangLine"],
+    ["command", "/broken", "handleCommand"],
+    ["message", "hello", "sendMessage"],
+  ] as const)("reports rejected %s handlers", async (action, input, handler) => {
+    const harness = createSubmitHarness();
+    harness[handler].mockRejectedValueOnce(new Error("gateway unavailable"));
+
+    harness.onSubmit(input);
+    await Promise.resolve();
+
+    expect(harness.onSubmitError).toHaveBeenCalledWith(action, expect.any(Error));
+  });
+
+  it("reports synchronous submit handler failures", () => {
+    const harness = createSubmitHarness();
+    harness.handleCommand.mockImplementationOnce(() => {
+      throw new Error("command exploded");
+    });
+
+    expect(() => harness.onSubmit("/broken")).not.toThrow();
+    expect(harness.onSubmitError).toHaveBeenCalledWith("command", expect.any(Error));
   });
 });
 

--- a/src/tui/tui.ts
+++ b/src/tui/tui.ts
@@ -18,6 +18,7 @@ import type { CommandEntry } from "../../packages/gateway-protocol/src/index.js"
 import { resolveAgentIdByWorkspacePath, resolveDefaultAgentId } from "../agents/agent-scope.js";
 import { getRuntimeConfig, type OpenClawConfig } from "../config/config.js";
 import { isChatStopCommandText } from "../gateway/chat-abort.js";
+import { formatErrorMessage } from "../infra/errors.js";
 import { registerUncaughtExceptionHandler } from "../infra/unhandled-rejections.js";
 import { getWindowsSystem32ExePath } from "../infra/windows-install-roots.js";
 import { setConsoleSubsystemFilter } from "../logging/console.js";
@@ -45,6 +46,7 @@ import { createEventHandlers } from "./tui-event-handlers.js";
 import {
   formatGoalFooter,
   formatRemoteConnectionHostFooter,
+  sanitizeRenderableText,
   formatTokens,
 } from "./tui-formatters.js";
 import {
@@ -62,6 +64,7 @@ import {
   createEditorSubmitHandler,
   createSubmitBurstCoalescer,
   shouldEnableWindowsGitBashPasteFallback,
+  type TuiSubmitAction,
 } from "./tui-submit.js";
 import type {
   AgentSummary,
@@ -1442,11 +1445,17 @@ export async function runTui(opts: RunTuiOptions): Promise<TuiResult> {
     addBlockedChatSubmitNotice(chatLog);
     tui.requestRender();
   };
+  const notifySubmitError = (action: TuiSubmitAction, error: unknown) => {
+    const message = sanitizeRenderableText(formatErrorMessage(error));
+    chatLog.addSystem(`${action} submit failed: ${message}`);
+    tui.requestRender();
+  };
   const submitHandler = createEditorSubmitHandler({
     editor,
     handleCommand,
     sendMessage,
     handleBangLine: runLocalShellLine,
+    onSubmitError: notifySubmitError,
     canSubmitMessage: canSubmitChatMessage,
     onBlockedMessageSubmit: notifyBlockedChatSubmit,
   });


### PR DESCRIPTION
## What Problem This Solves

The TUI editor dispatches local-shell, slash-command, and message handlers as fire-and-forget work. An unexpected synchronous throw or rejected promise at that boundary could become an unhandled error and terminate the interactive session without an actionable in-screen diagnostic.

## Why This Change Was Made

Centralize all three submit actions behind one error boundary. The TUI owner now receives the action and error, redacts/sanitizes the message, adds a visible system row, and requests a render. This replaces the original stderr-only implementation and extends coverage to synchronous throws without duplicating the existing submit test suite.

## User Impact

Rare submit-handler failures no longer escape the editor callback. The TUI stays open and shows which submit action failed plus a safe error message.

## Evidence

- Blacksmith Testbox `tbx_01kwshtt5wredtckz64rmczt54`: `corepack pnpm test src/tui/tui.submit-handler.test.ts` — 19/19 passed.
- Same Testbox: `OPENCLAW_TUI_PTY_INCLUDE_LOCAL=1 node scripts/run-vitest.mjs run --config test/vitest/vitest.tui-pty.config.ts` — 24/24 PTY checks passed, including real local and Gateway backend paths.
- Fresh autoreview: no accepted/actionable findings; correctness confidence 0.95.
- `git diff --check` passed.

Release note: Fixed TUI submit failures so unexpected command, message, or local-shell handler errors remain visible without ending the session.
